### PR TITLE
fix(daemon): restrict daemon autostart to the canonical checkout

### DIFF
--- a/packages/cli/src/daemon/client.ts
+++ b/packages/cli/src/daemon/client.ts
@@ -107,7 +107,7 @@ async function withAutostart(
   request: () => Promise<JsonObject>,
   launch: () => DaemonLaunchSpec,
   socketPath: string,
-  options: { readonly autostart: boolean; readonly env: NodeJS.ProcessEnv },
+  options: { readonly autostart: boolean; readonly env: NodeJS.ProcessEnv; readonly invokingRoot: string },
 ): Promise<JsonObject> {
   try {
     return await request();
@@ -124,6 +124,7 @@ async function withAutostart(
     if (refusal) throw new DaemonAutostartError({ ok: false, ...refusal, attempts: 0 });
     const started = await ensureLocalDaemonRunning({
       socketPath,
+      invokingRoot: options.invokingRoot,
       launch,
       onProgress: (progress) => process.stderr.write(`${progress.message}\n`),
     });
@@ -175,7 +176,7 @@ export async function runCommandThroughDaemon(
         ),
       () => cliDaemonServeLaunch(userRoot, daemonId),
       socketPath,
-      { autostart, env },
+      { autostart, env, invokingRoot: command.rootDir },
     );
   }
   if (command.method.startsWith("daemon.runtimeInstance.")) {
@@ -199,7 +200,7 @@ export async function runCommandThroughDaemon(
         ),
       () => cliDaemonServeLaunch(userRoot, daemonId),
       socketPath,
-      { autostart, env },
+      { autostart, env, invokingRoot: command.rootDir },
     );
   }
   const fleetSchedule = await fleetScheduleRoute(command, env);
@@ -217,7 +218,7 @@ export async function runCommandThroughDaemon(
         ),
       () => cliDaemonServeLaunch(userRoot, daemonId),
       socketPath,
-      { autostart, env },
+      { autostart, env, invokingRoot: command.rootDir },
     );
   }
   const fleetRuntime = await fleetRuntimeRoute(command, env);
@@ -235,7 +236,7 @@ export async function runCommandThroughDaemon(
         ),
       () => cliDaemonServeLaunch(userRoot, daemonId),
       socketPath,
-      { autostart, env },
+      { autostart, env, invokingRoot: command.rootDir },
     );
   }
   const fleetTask = await fleetTaskRoute(command, env);
@@ -253,7 +254,7 @@ export async function runCommandThroughDaemon(
         ),
       () => cliDaemonServeLaunch(userRoot, daemonId),
       socketPath,
-      { autostart, env },
+      { autostart, env, invokingRoot: command.rootDir },
     );
   }
   const fleetDoc = await fleetDocRoute(command, env);
@@ -271,7 +272,7 @@ export async function runCommandThroughDaemon(
         ),
       () => cliDaemonServeLaunch(userRoot, daemonId),
       socketPath,
-      { autostart, env },
+      { autostart, env, invokingRoot: command.rootDir },
     );
   }
   const target = {
@@ -294,7 +295,7 @@ export async function runCommandThroughDaemon(
     request,
     () => cliDaemonServeLaunch(target.userRoot, target.daemonId),
     target.socketPath,
-    { autostart, env },
+    { autostart, env, invokingRoot: command.rootDir },
   );
   result = await settleRepoWarming(result, request, target.userRoot, target.daemonId);
   if (command.action.kind !== "preset-run-start") return result;

--- a/packages/cli/src/daemon/control.ts
+++ b/packages/cli/src/daemon/control.ts
@@ -13,7 +13,12 @@ import { requestDaemonJsonRpcAt } from "../../../daemon/src/client/local-json-rp
 import type { DaemonShutdownExchange } from "../../../daemon/src/client/local-json-rpc-shutdown.ts";
 import { detachedProcessOptions, terminateProcess } from "../../../daemon/src/process-port.ts";
 import type { JsonObject } from "../../../daemon/src/protocol/json-rpc-types.ts";
-import { ensureLocalDaemonRunning, runtimeDaemonStartRefusal } from "../../../daemon/src/client/daemon-autostart.ts";
+import {
+  DaemonAutostartError,
+  ensureLocalDaemonRunning,
+  isDaemonUnreachable,
+  runtimeDaemonStartRefusal,
+} from "../../../daemon/src/client/daemon-autostart.ts";
 import { readDaemonPid, startDaemon } from "../../../daemon/src/runtime.ts";
 import {
   daemonProcessAlive,
@@ -35,7 +40,8 @@ export async function runDaemonControl(argv: readonly string[], renderReceipt: R
   const command = argv[at + 1],
     subcommand = argv[at + 2];
   const json = argv.includes("--json"),
-    userRoot = path.resolve(daemonOption(argv, "--user-root") ?? daemonUserRoot());
+    userRoot = path.resolve(daemonOption(argv, "--user-root") ?? daemonUserRoot()),
+    invokingRoot = path.resolve(daemonOption(argv, "--root") ?? process.cwd());
   const daemonId = daemonOption(argv, "--daemon-id") ?? daemonIdFromEnv(),
     finish: ControlFinisher = (receipt, exitCode) => finishControlReceipt(renderReceipt, receipt, json, exitCode);
   try {
@@ -108,23 +114,25 @@ export async function runDaemonControl(argv: readonly string[], renderReceipt: R
         );
       let running: Record<string, unknown> | null = null;
       try {
-        running = await status(userRoot, daemonId);
+        running = await status(userRoot, daemonId, argv);
       } catch (error) {
         consumeKnownError(error);
       }
       if (running?.ok === true) return finish(running, 0);
-      const refusal = runtimeDaemonStartRefusal();
-      if (refusal) return finish(daemonFailure("daemon-start", "daemon_start_runtime_forbidden", refusal.hint), 1);
+      const runtimeRefusal = runtimeDaemonStartRefusal();
+      if (runtimeRefusal)
+        return finish(daemonFailure("daemon-start", "daemon_start_runtime_forbidden", runtimeRefusal.hint), 1);
       const started = await ensureLocalDaemonRunning({
         socketPath: localUserDaemonEndpoint(userRoot, daemonId),
+        invokingRoot,
         launch: () => cliDaemonServeLaunch(userRoot, daemonId),
         onProgress: (progress) => process.stderr.write(`${progress.message}\n`),
       });
       return started.ok
-        ? finish(await status(userRoot, daemonId), 0)
+        ? finish(await status(userRoot, daemonId, argv), 0)
         : finish(daemonFailure("daemon-start", started.code ?? "daemon_start_failed", started.hint), 1);
     }
-    if (command === "status") return finish(await status(userRoot, daemonId, argv), 0);
+    if (command === "status") return finish(await status(userRoot, daemonId, argv, true), 0);
     if (command === "stop") {
       const pid = readDaemonPid(userRoot, daemonId);
       if (pid === null) return finish(daemonFailure("daemon-stop", "daemon_unavailable", "No daemon is running."), 1);
@@ -299,6 +307,7 @@ async function status(
   userRoot: string,
   daemonId: string,
   argv: readonly string[] = [],
+  autostart = false,
 ): Promise<Record<string, unknown>> {
   const root = path.resolve(daemonOption(argv, "--root") ?? process.cwd()),
     repoIdOverride = daemonOption(argv, "--repo") ?? process.env.HARNESS_DAEMON_REPO_ID;
@@ -313,7 +322,24 @@ async function status(
     }
   })();
   const endpoint = resolved?.socketPath ?? localUserDaemonEndpoint(userRoot, daemonId),
-    result = await requestDaemonJsonRpcAt(endpoint, "daemon.status", {}, 75);
+    request = () => requestDaemonJsonRpcAt(endpoint, "daemon.status", {}, 75);
+  let result: Record<string, unknown>;
+  try {
+    result = await request();
+  } catch (error) {
+    if (!autostart || !isDaemonUnreachable(error)) throw error;
+    consumeKnownError(error);
+    const refusal = runtimeDaemonStartRefusal();
+    if (refusal) throw new DaemonAutostartError({ ok: false, ...refusal, attempts: 0 });
+    const started = await ensureLocalDaemonRunning({
+      socketPath: endpoint,
+      invokingRoot: root,
+      launch: () => cliDaemonServeLaunch(userRoot, daemonId),
+      onProgress: (progress) => process.stderr.write(`${progress.message}\n`),
+    });
+    if (!started.ok) throw new DaemonAutostartError(started);
+    result = await request();
+  }
   const target = {
       endpoint,
       daemonId,

--- a/packages/cli/src/daemon/control.ts
+++ b/packages/cli/src/daemon/control.ts
@@ -13,12 +13,7 @@ import { requestDaemonJsonRpcAt } from "../../../daemon/src/client/local-json-rp
 import type { DaemonShutdownExchange } from "../../../daemon/src/client/local-json-rpc-shutdown.ts";
 import { detachedProcessOptions, terminateProcess } from "../../../daemon/src/process-port.ts";
 import type { JsonObject } from "../../../daemon/src/protocol/json-rpc-types.ts";
-import {
-  DaemonAutostartError,
-  ensureLocalDaemonRunning,
-  isDaemonUnreachable,
-  runtimeDaemonStartRefusal,
-} from "../../../daemon/src/client/daemon-autostart.ts";
+import { ensureLocalDaemonRunning, runtimeDaemonStartRefusal } from "../../../daemon/src/client/daemon-autostart.ts";
 import { readDaemonPid, startDaemon } from "../../../daemon/src/runtime.ts";
 import {
   daemonProcessAlive,
@@ -102,37 +97,8 @@ export async function runDaemonControl(argv: readonly string[], renderReceipt: R
       if (refusal) return finish(daemonFailure("daemon-serve", "daemon_start_runtime_forbidden", refusal.hint), 1);
       return serve(userRoot, daemonId, finish);
     }
-    if (command === "start") {
-      if (!argv.includes("--service"))
-        return finish(
-          daemonFailure(
-            "daemon-start",
-            "service_required",
-            "Use `ha daemon start --service` to start the resident daemon; other CLI commands start it on demand.",
-          ),
-          2,
-        );
-      let running: Record<string, unknown> | null = null;
-      try {
-        running = await status(userRoot, daemonId, argv);
-      } catch (error) {
-        consumeKnownError(error);
-      }
-      if (running?.ok === true) return finish(running, 0);
-      const runtimeRefusal = runtimeDaemonStartRefusal();
-      if (runtimeRefusal)
-        return finish(daemonFailure("daemon-start", "daemon_start_runtime_forbidden", runtimeRefusal.hint), 1);
-      const started = await ensureLocalDaemonRunning({
-        socketPath: localUserDaemonEndpoint(userRoot, daemonId),
-        invokingRoot,
-        launch: () => cliDaemonServeLaunch(userRoot, daemonId),
-        onProgress: (progress) => process.stderr.write(`${progress.message}\n`),
-      });
-      return started.ok
-        ? finish(await status(userRoot, daemonId, argv), 0)
-        : finish(daemonFailure("daemon-start", started.code ?? "daemon_start_failed", started.hint), 1);
-    }
-    if (command === "status") return finish(await status(userRoot, daemonId, argv, true), 0);
+    if (command === "start") return startDaemonService(argv, userRoot, daemonId, invokingRoot, finish);
+    if (command === "status") return finish(await status(userRoot, daemonId, argv), 0);
     if (command === "stop") {
       const pid = readDaemonPid(userRoot, daemonId);
       if (pid === null) return finish(daemonFailure("daemon-stop", "daemon_unavailable", "No daemon is running."), 1);
@@ -164,6 +130,42 @@ export async function runDaemonControl(argv: readonly string[], renderReceipt: R
   } catch (error) {
     return finish(daemonFailure(`daemon-${command ?? "unknown"}`, code(error), message(error)), 1);
   }
+}
+async function startDaemonService(
+  argv: readonly string[],
+  userRoot: string,
+  daemonId: string,
+  invokingRoot: string,
+  finish: ControlFinisher,
+): Promise<number> {
+  if (!argv.includes("--service"))
+    return finish(
+      daemonFailure(
+        "daemon-start",
+        "service_required",
+        "Use `ha daemon start --service` to start the resident daemon; other CLI commands start it on demand.",
+      ),
+      2,
+    );
+  let running: Record<string, unknown> | null = null;
+  try {
+    running = await status(userRoot, daemonId, argv);
+  } catch (error) {
+    consumeKnownError(error);
+  }
+  if (running?.ok === true) return finish(running, 0);
+  const runtimeRefusal = runtimeDaemonStartRefusal();
+  if (runtimeRefusal)
+    return finish(daemonFailure("daemon-start", "daemon_start_runtime_forbidden", runtimeRefusal.hint), 1);
+  const started = await ensureLocalDaemonRunning({
+    socketPath: localUserDaemonEndpoint(userRoot, daemonId),
+    invokingRoot,
+    launch: () => cliDaemonServeLaunch(userRoot, daemonId),
+    onProgress: (progress) => process.stderr.write(`${progress.message}\n`),
+  });
+  return started.ok
+    ? finish(await status(userRoot, daemonId, argv), 0)
+    : finish(daemonFailure("daemon-start", started.code ?? "daemon_start_failed", started.hint), 1);
 }
 async function fleetControl(
   argv: readonly string[],
@@ -307,7 +309,6 @@ async function status(
   userRoot: string,
   daemonId: string,
   argv: readonly string[] = [],
-  autostart = false,
 ): Promise<Record<string, unknown>> {
   const root = path.resolve(daemonOption(argv, "--root") ?? process.cwd()),
     repoIdOverride = daemonOption(argv, "--repo") ?? process.env.HARNESS_DAEMON_REPO_ID;
@@ -322,24 +323,7 @@ async function status(
     }
   })();
   const endpoint = resolved?.socketPath ?? localUserDaemonEndpoint(userRoot, daemonId),
-    request = () => requestDaemonJsonRpcAt(endpoint, "daemon.status", {}, 75);
-  let result: Record<string, unknown>;
-  try {
-    result = await request();
-  } catch (error) {
-    if (!autostart || !isDaemonUnreachable(error)) throw error;
-    consumeKnownError(error);
-    const refusal = runtimeDaemonStartRefusal();
-    if (refusal) throw new DaemonAutostartError({ ok: false, ...refusal, attempts: 0 });
-    const started = await ensureLocalDaemonRunning({
-      socketPath: endpoint,
-      invokingRoot: root,
-      launch: () => cliDaemonServeLaunch(userRoot, daemonId),
-      onProgress: (progress) => process.stderr.write(`${progress.message}\n`),
-    });
-    if (!started.ok) throw new DaemonAutostartError(started);
-    result = await request();
-  }
+    result = await requestDaemonJsonRpcAt(endpoint, "daemon.status", {}, 75);
   const target = {
       endpoint,
       daemonId,

--- a/packages/cli/test/daemon-autostart-cli.test.ts
+++ b/packages/cli/test/daemon-autostart-cli.test.ts
@@ -40,7 +40,7 @@ import { realizedTaskPlan } from "../../../tools/fixtures/task-plan.mjs";
 
 const cli = path.resolve("packages/cli/src/index.ts");
 
-test("registered canonical checkout autostarts the daemon while its worktree only connects", (context) => {
+test("registered checkout autostarts the daemon while its worktree only connects", (context) => {
   const fixture = setup();
   try {
     assert.equal(run(fixture.root, fixture.userRoot, ["daemon", "start", "--service"]).ok, true);
@@ -89,9 +89,9 @@ test("registered canonical checkout autostarts the daemon while its worktree onl
       lifecycle.some((record) => record.event === "process_exit" && record.outcome === "stop_requested"),
       true,
     );
-    const worktree = path.join(fixture.root, ".worktrees", "status-feature");
+    const worktree = path.join(fixture.root, ".worktrees", "task-list-feature");
     git(fixture.root, "worktree", "add", "--quiet", "--detach", worktree);
-    const refused = spawnSync(process.execPath, [cli, "--root", worktree, "--json", "daemon", "status"], {
+    const refused = spawnSync(process.execPath, [cli, "--root", worktree, "--json", "task", "list"], {
       encoding: "utf8",
       env: cliEnv(worktree, fixture.userRoot),
     });
@@ -102,18 +102,19 @@ test("registered canonical checkout autostarts the daemon while its worktree onl
     assert.match(refusal.error?.hint ?? "", new RegExp(escapeRegExp(fixture.root), "u"));
     assert.equal(readDaemonPid(fixture.userRoot, "default"), null, "the refused worktree must not claim the daemon");
 
-    // The daemon is gone; status from the registered canonical checkout must bring it back and answer.
-    const result = spawnSync(process.execPath, [cli, "--root", fixture.root, "--json", "daemon", "status"], {
+    // The daemon is gone; a repository command from the registered checkout must bring it back and answer.
+    const result = spawnSync(process.execPath, [cli, "--root", fixture.root, "--json", "task", "list"], {
       encoding: "utf8",
       env: cliEnv(fixture.root, fixture.userRoot),
     });
     assert.equal(result.status, 0, `${result.stderr}\n${result.stdout}`);
-    const receipt = JSON.parse(result.stdout) as { ok: boolean; error?: { code: string } };
+    const receipt = JSON.parse(result.stdout) as { ok: boolean; outcome?: string; error?: { code: string } };
     assert.equal(receipt.ok, true, JSON.stringify(receipt));
+    assert.equal(receipt.outcome, "applied");
     const restartedPid = readDaemonPid(fixture.userRoot, "default");
     assert.ok(restartedPid, "autostart must leave a resident daemon pid file");
     assert.notEqual(restartedPid, previousPid);
-    const connected = spawnSync(process.execPath, [cli, "--root", worktree, "--json", "daemon", "status"], {
+    const connected = spawnSync(process.execPath, [cli, "--root", worktree, "--json", "task", "list"], {
       encoding: "utf8",
       env: cliEnv(worktree, fixture.userRoot),
     });
@@ -124,7 +125,7 @@ test("registered canonical checkout autostarts the daemon while its worktree onl
       "the worktree must reuse the resident daemon",
     );
     context.diagnostic(
-      `worktree refusal=${refusal.error?.code}; canonical status pid=${restartedPid}; worktree existing-daemon status=ok`,
+      `worktree refusal=${refusal.error?.code}; registered checkout pid=${restartedPid}; worktree existing-daemon task-list=ok`,
     );
     const restartedLifecycle = readDaemonLifecycleRecords(fixture.userRoot, "default"),
       generationStart = restartedLifecycle.findLastIndex((record) => record.event === "process_start"),

--- a/packages/cli/test/daemon-autostart-cli.test.ts
+++ b/packages/cli/test/daemon-autostart-cli.test.ts
@@ -40,7 +40,7 @@ import { realizedTaskPlan } from "../../../tools/fixtures/task-plan.mjs";
 
 const cli = path.resolve("packages/cli/src/index.ts");
 
-test("registered workspace CLI command auto-starts the daemon, retries, and succeeds", () => {
+test("registered canonical checkout autostarts the daemon while its worktree only connects", (context) => {
   const fixture = setup();
   try {
     assert.equal(run(fixture.root, fixture.userRoot, ["daemon", "start", "--service"]).ok, true);
@@ -89,18 +89,43 @@ test("registered workspace CLI command auto-starts the daemon, retries, and succ
       lifecycle.some((record) => record.event === "process_exit" && record.outcome === "stop_requested"),
       true,
     );
-    // The daemon is gone; a plain CLI command must bring it back and still answer.
-    const result = spawnSync(process.execPath, [cli, "--root", fixture.root, "--json", "task", "list"], {
+    const worktree = path.join(fixture.root, ".worktrees", "status-feature");
+    git(fixture.root, "worktree", "add", "--quiet", "--detach", worktree);
+    const refused = spawnSync(process.execPath, [cli, "--root", worktree, "--json", "daemon", "status"], {
+      encoding: "utf8",
+      env: cliEnv(worktree, fixture.userRoot),
+    });
+    assert.notEqual(refused.status, 0, `${refused.stderr}\n${refused.stdout}`);
+    const refusal = JSON.parse(refused.stdout) as { error?: { code?: string; hint?: string } };
+    assert.equal(refusal.error?.code, "daemon_start_noncanonical_checkout");
+    assert.match(refusal.error?.hint ?? "", /A worktree may connect to an existing daemon but cannot host it/u);
+    assert.match(refusal.error?.hint ?? "", new RegExp(escapeRegExp(fixture.root), "u"));
+    assert.equal(readDaemonPid(fixture.userRoot, "default"), null, "the refused worktree must not claim the daemon");
+
+    // The daemon is gone; status from the registered canonical checkout must bring it back and answer.
+    const result = spawnSync(process.execPath, [cli, "--root", fixture.root, "--json", "daemon", "status"], {
       encoding: "utf8",
       env: cliEnv(fixture.root, fixture.userRoot),
     });
     assert.equal(result.status, 0, `${result.stderr}\n${result.stdout}`);
-    const receipt = JSON.parse(result.stdout) as { ok: boolean; outcome: string; error?: { code: string } };
+    const receipt = JSON.parse(result.stdout) as { ok: boolean; error?: { code: string } };
     assert.equal(receipt.ok, true, JSON.stringify(receipt));
-    assert.equal(receipt.outcome, "applied");
     const restartedPid = readDaemonPid(fixture.userRoot, "default");
     assert.ok(restartedPid, "autostart must leave a resident daemon pid file");
     assert.notEqual(restartedPid, previousPid);
+    const connected = spawnSync(process.execPath, [cli, "--root", worktree, "--json", "daemon", "status"], {
+      encoding: "utf8",
+      env: cliEnv(worktree, fixture.userRoot),
+    });
+    assert.equal(connected.status, 0, `${connected.stderr}\n${connected.stdout}`);
+    assert.equal(
+      readDaemonPid(fixture.userRoot, "default"),
+      restartedPid,
+      "the worktree must reuse the resident daemon",
+    );
+    context.diagnostic(
+      `worktree refusal=${refusal.error?.code}; canonical status pid=${restartedPid}; worktree existing-daemon status=ok`,
+    );
     const restartedLifecycle = readDaemonLifecycleRecords(fixture.userRoot, "default"),
       generationStart = restartedLifecycle.findLastIndex((record) => record.event === "process_start"),
       bound = restartedLifecycle.findIndex(

--- a/packages/daemon/src/client/daemon-autostart.ts
+++ b/packages/daemon/src/client/daemon-autostart.ts
@@ -1,4 +1,4 @@
-import { existsSync, realpathSync } from "node:fs";
+import { existsSync, readFileSync, realpathSync, statSync } from "node:fs";
 import path from "node:path";
 import {
   acquireDaemonAutostartFlight,
@@ -68,20 +68,20 @@ export function daemonHostStartRefusal(input: {
   readonly userRoot: string;
 }): { readonly code: "daemon_start_noncanonical_checkout"; readonly hint: string } | null {
   const invokingCheckout = daemonCheckoutRoot(input.invokingRoot),
-    enabled = readRegisteredRepos(input.userRoot).filter((repo) => repo.state === "enabled"),
-    canonical = enabled
-      .filter((repo) => pathContains(repo.canonicalRoot, invokingCheckout))
-      .sort(
-        (left, right) => path.resolve(right.canonicalRoot).length - path.resolve(left.canonicalRoot).length,
-      )[0]?.canonicalRoot;
-  if (enabled.length === 0 || (canonical && canonicalPath(canonical) === invokingCheckout)) return null;
-  const registeredRoot = canonicalPath(canonical ?? enabled[0]!.canonicalRoot);
+    registered = readRegisteredRepos(input.userRoot)
+      .filter((repo) => repo.state === "enabled")
+      .map((repo) => daemonCheckoutRoot(repo.canonicalRoot))
+      .find(
+        (registeredRoot) => registeredRoot === invokingCheckout || sameGitRepository(registeredRoot, invokingCheckout),
+      );
+  if (!registered || registered === invokingCheckout) return null;
   return {
     code: "daemon_start_noncanonical_checkout",
     hint: [
       `Refusing daemon start from non-canonical checkout ${JSON.stringify(invokingCheckout)}.`,
-      `The shared daemon must be hosted from the registered canonical checkout ${JSON.stringify(registeredRoot)}.`,
-      `A worktree may connect to an existing daemon but cannot host it; run \`ha daemon status --root ${JSON.stringify(registeredRoot)}\`, then retry this command.`,
+      `This repository is already registered from ${JSON.stringify(registered)}.`,
+      "A worktree may connect to an existing daemon but cannot host it.",
+      `Run \`ha daemon status --root ${JSON.stringify(registered)}\`, then retry this command.`,
     ].join(" "),
   };
 }
@@ -304,7 +304,20 @@ function canonicalPath(value: string): string {
   const resolved = path.resolve(value);
   return existsSync(resolved) ? realpathSync.native(resolved) : resolved;
 }
-function pathContains(parent: string, child: string): boolean {
-  const relative = path.relative(canonicalPath(parent), child);
-  return relative === "" || (relative !== ".." && !relative.startsWith(`..${path.sep}`) && !path.isAbsolute(relative));
+function sameGitRepository(left: string, right: string): boolean {
+  const leftCommon = gitCommonDirectory(left),
+    rightCommon = gitCommonDirectory(right);
+  return leftCommon !== null && rightCommon !== null && leftCommon === rightCommon;
+}
+function gitCommonDirectory(checkoutRoot: string): string | null {
+  const marker = path.join(checkoutRoot, ".git");
+  if (!existsSync(marker)) return null;
+  if (statSync(marker).isDirectory()) return canonicalPath(marker);
+  const gitdir = /^gitdir:\s*(.+)$/u.exec(readFileSync(marker, "utf8").trim())?.[1];
+  if (!gitdir) return null;
+  const administrativeRoot = canonicalPath(path.resolve(checkoutRoot, gitdir)),
+    commonPath = path.join(administrativeRoot, "commondir");
+  if (!existsSync(commonPath)) return administrativeRoot;
+  const relativeCommon = readFileSync(commonPath, "utf8").trim();
+  return relativeCommon ? canonicalPath(path.resolve(administrativeRoot, relativeCommon)) : administrativeRoot;
 }

--- a/packages/daemon/src/client/daemon-autostart.ts
+++ b/packages/daemon/src/client/daemon-autostart.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync, realpathSync, statSync } from "node:fs";
+import { existsSync, readFileSync, statSync } from "node:fs";
 import path from "node:path";
 import {
   acquireDaemonAutostartFlight,
@@ -8,6 +8,7 @@ import {
 } from "../daemon-singleton.ts";
 import { daemonLifecycleLogPath, readDaemonLifecycleRecords } from "../lifecycle-log.ts";
 import { startDetachedProcessChecked } from "../process-port.ts";
+import { canonicalPath } from "../runtime-worker-push.ts";
 import { readRegisteredRepos } from "./local-daemon-target.ts";
 export interface DaemonLaunchSpec {
   readonly command: string;
@@ -292,17 +293,13 @@ function delay(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 export function daemonCheckoutRoot(rootDir: string): string {
-  let current = canonicalPath(rootDir);
+  let current = canonicalPath(path.resolve(rootDir));
   for (;;) {
     if (existsSync(path.join(current, ".git"))) return current;
     const parent = path.dirname(current);
     if (parent === current) return canonicalPath(rootDir);
     current = parent;
   }
-}
-function canonicalPath(value: string): string {
-  const resolved = path.resolve(value);
-  return existsSync(resolved) ? realpathSync.native(resolved) : resolved;
 }
 function sameGitRepository(left: string, right: string): boolean {
   const leftCommon = gitCommonDirectory(left),

--- a/packages/daemon/src/client/daemon-autostart.ts
+++ b/packages/daemon/src/client/daemon-autostart.ts
@@ -1,3 +1,4 @@
+import { existsSync, realpathSync } from "node:fs";
 import path from "node:path";
 import {
   acquireDaemonAutostartFlight,
@@ -7,12 +8,14 @@ import {
 } from "../daemon-singleton.ts";
 import { daemonLifecycleLogPath, readDaemonLifecycleRecords } from "../lifecycle-log.ts";
 import { startDetachedProcessChecked } from "../process-port.ts";
+import { readRegisteredRepos } from "./local-daemon-target.ts";
 export interface DaemonLaunchSpec {
   readonly command: string;
   readonly args: readonly string[];
   readonly env: NodeJS.ProcessEnv;
 }
 export const autostartFailureCodes = [
+  "daemon_start_noncanonical_checkout",
   "daemon_start_runtime_forbidden",
   "daemon_spawn_not_found",
   "daemon_spawn_permission",
@@ -60,8 +63,31 @@ export function runtimeDaemonStartRefusal(
     ].join(" "),
   };
 }
+export function daemonHostStartRefusal(input: {
+  readonly invokingRoot: string;
+  readonly userRoot: string;
+}): { readonly code: "daemon_start_noncanonical_checkout"; readonly hint: string } | null {
+  const invokingCheckout = daemonCheckoutRoot(input.invokingRoot),
+    enabled = readRegisteredRepos(input.userRoot).filter((repo) => repo.state === "enabled"),
+    canonical = enabled
+      .filter((repo) => pathContains(repo.canonicalRoot, invokingCheckout))
+      .sort(
+        (left, right) => path.resolve(right.canonicalRoot).length - path.resolve(left.canonicalRoot).length,
+      )[0]?.canonicalRoot;
+  if (enabled.length === 0 || (canonical && canonicalPath(canonical) === invokingCheckout)) return null;
+  const registeredRoot = canonicalPath(canonical ?? enabled[0]!.canonicalRoot);
+  return {
+    code: "daemon_start_noncanonical_checkout",
+    hint: [
+      `Refusing daemon start from non-canonical checkout ${JSON.stringify(invokingCheckout)}.`,
+      `The shared daemon must be hosted from the registered canonical checkout ${JSON.stringify(registeredRoot)}.`,
+      `A worktree may connect to an existing daemon but cannot host it; run \`ha daemon status --root ${JSON.stringify(registeredRoot)}\`, then retry this command.`,
+    ].join(" "),
+  };
+}
 export async function ensureLocalDaemonRunning(input: {
   readonly socketPath: string;
+  readonly invokingRoot: string;
   readonly launch: () => DaemonLaunchSpec;
   readonly readyTimeoutMs?: number;
   readonly probeIntervalMs?: number;
@@ -75,7 +101,13 @@ export async function ensureLocalDaemonRunning(input: {
     spawnDetached =
       input.spawnDetached ??
       ((launch: DaemonLaunchSpec) =>
-        startDetachedProcessChecked(launch.command, launch.args, launch.env, daemonLaunchOutputPath(launch)));
+        startDetachedProcessChecked(
+          launch.command,
+          launch.args,
+          launch.env,
+          daemonLaunchOutputPath(launch),
+          daemonCheckoutRoot(input.invokingRoot),
+        ));
   // A freshly started daemon can die between binding its socket and finishing
   // startup; confirm readiness with a second probe before declaring success.
   const ready = async () => {
@@ -93,6 +125,8 @@ export async function ensureLocalDaemonRunning(input: {
     launched = input.launch();
     const target = daemonLaunchTarget(launched);
     if (!target) throw new Error("daemon launch spec does not declare its --user-root and --daemon-id");
+    const refusal = daemonHostStartRefusal({ invokingRoot: input.invokingRoot, userRoot: target.userRoot });
+    if (refusal) return { ok: false, ...refusal, attempts: 0 };
     flight = await acquireDaemonAutostartFlight(target);
     // The probe belongs inside the claim: another caller may have bound the
     // socket between this process's initial probe and atomic lock creation.
@@ -256,4 +290,21 @@ function liveDaemonSingleton(launch: DaemonLaunchSpec): boolean {
 }
 function delay(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+export function daemonCheckoutRoot(rootDir: string): string {
+  let current = canonicalPath(rootDir);
+  for (;;) {
+    if (existsSync(path.join(current, ".git"))) return current;
+    const parent = path.dirname(current);
+    if (parent === current) return canonicalPath(rootDir);
+    current = parent;
+  }
+}
+function canonicalPath(value: string): string {
+  const resolved = path.resolve(value);
+  return existsSync(resolved) ? realpathSync.native(resolved) : resolved;
+}
+function pathContains(parent: string, child: string): boolean {
+  const relative = path.relative(canonicalPath(parent), child);
+  return relative === "" || (relative !== ".." && !relative.startsWith(`..${path.sep}`) && !path.isAbsolute(relative));
 }

--- a/packages/daemon/src/process-port.ts
+++ b/packages/daemon/src/process-port.ts
@@ -11,12 +11,14 @@ export function startDetachedProcess(
   args: readonly string[],
   env: NodeJS.ProcessEnv,
   outputPath?: string,
+  cwd?: string,
 ): void {
   const outputFd = outputPath ? openDaemonOutputFd(outputPath) : null;
   try {
     const child = spawn(command, [...args], {
       ...detachedProcessOptions,
       ...(outputFd === null ? {} : { stdio: ["ignore", outputFd, outputFd] }),
+      ...(cwd ? { cwd } : {}),
       env,
     });
     child.once("spawn", () => {
@@ -39,6 +41,7 @@ export function startDetachedProcessChecked(
   args: readonly string[],
   env: NodeJS.ProcessEnv,
   outputPath?: string,
+  cwd?: string,
 ): Promise<void> {
   return new Promise((resolve, reject) => {
     const outputFd = outputPath ? openDaemonOutputFd(outputPath) : null;
@@ -47,6 +50,7 @@ export function startDetachedProcessChecked(
       child = spawn(command, [...args], {
         ...detachedProcessOptions,
         ...(outputFd === null ? {} : { stdio: ["ignore", outputFd, outputFd] }),
+        ...(cwd ? { cwd } : {}),
         env,
       });
     } catch (error) {

--- a/packages/daemon/src/runtime-worker-push.ts
+++ b/packages/daemon/src/runtime-worker-push.ts
@@ -47,7 +47,7 @@ function samePath(left: string, right: string): boolean {
   return canonicalPath(left) === canonicalPath(right);
 }
 
-function canonicalPath(value: string): string {
+export function canonicalPath(value: string): string {
   try {
     return realpathSync.native(value).replaceAll("\\", "/").replace(/\/+$/u, "");
   } catch {

--- a/packages/daemon/test/daemon-autostart.test.ts
+++ b/packages/daemon/test/daemon-autostart.test.ts
@@ -1,12 +1,13 @@
 // harness-test-tier: fast
 import assert from "node:assert/strict";
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
 import {
   DaemonAutostartError,
   daemonLaunchOutputPath,
+  daemonHostStartRefusal,
   ensureLocalDaemonRunning,
   isDaemonUnreachable,
   readDaemonStartProgress,
@@ -36,10 +37,54 @@ test("runtime start refusal requires a runtime actor", () => {
   assert.equal(absent?.code, "daemon_start_runtime_forbidden");
 });
 
+test("a worktree is refused before spawn while the registered canonical checkout is allowed", async () => {
+  const parent = mkdtempSync(path.join(tmpdir(), "ha-daemon-host-root-")),
+    canonical = path.join(parent, "repo"),
+    worktree = path.join(canonical, ".worktrees", "feature"),
+    userRoot = path.join(parent, "user");
+  try {
+    mkdirSync(path.join(canonical, ".git"), { recursive: true });
+    mkdirSync(worktree, { recursive: true });
+    mkdirSync(userRoot);
+    writeFileSync(path.join(worktree, ".git"), "gitdir: ../../.git/worktrees/feature\n", "utf8");
+    writeFileSync(
+      path.join(userRoot, "registry.json"),
+      `${JSON.stringify({ schema: "harness-daemon-registry/v1", repos: [{ repoId: "canonical", canonicalRoot: canonical, state: "enabled" }] })}\n`,
+      "utf8",
+    );
+    assert.equal(daemonHostStartRefusal({ invokingRoot: path.join(canonical, "packages"), userRoot }), null);
+    const refusal = daemonHostStartRefusal({ invokingRoot: worktree, userRoot });
+    assert.equal(refusal?.code, "daemon_start_noncanonical_checkout");
+    assert.match(refusal?.hint ?? "", /A worktree may connect to an existing daemon but cannot host it/u);
+    assert.match(refusal?.hint ?? "", new RegExp(escapeRegExp(canonical), "u"));
+
+    let spawns = 0;
+    const result = await ensureLocalDaemonRunning({
+      socketPath: path.join(parent, "daemon.sock"),
+      invokingRoot: worktree,
+      launch: () => ({
+        command: "node",
+        args: ["index.ts", "daemon", "serve", "--user-root", userRoot, "--daemon-id", "default"],
+        env: {},
+      }),
+      probe: async () => false,
+      spawnDetached: async () => {
+        spawns += 1;
+      },
+    });
+    assert.equal(result.code, "daemon_start_noncanonical_checkout");
+    assert.equal(result.attempts, 0);
+    assert.equal(spawns, 0);
+  } finally {
+    rmSync(parent, { recursive: true, force: true });
+  }
+});
+
 test("unreachable daemon is started once and the ready socket is used without a second attempt", async () => {
   let spawns = 0;
   const result = await ensureLocalDaemonRunning({
     socketPath: "/tmp/ha-autostart.sock",
+    invokingRoot: process.cwd(),
     launch,
     probe: async () => spawns > 0,
     spawnDetached: async () => {
@@ -67,6 +112,7 @@ test("concurrent callers share one autostart flight and wait for the same socket
       Array.from({ length: 12 }, () =>
         ensureLocalDaemonRunning({
           socketPath: path.join(userRoot, "daemon.sock"),
+          invokingRoot: process.cwd(),
           launch: sharedLaunch,
           probe: async () => reachable,
           spawnDetached: async () => {
@@ -101,6 +147,7 @@ test("a GUI/CLI peer that already owns the daemon singleton is awaited, not resp
     writeFileSync(daemonSingletonLockPath(userRoot, "default"), `${process.pid}\n`, "utf8");
     const result = await ensureLocalDaemonRunning({
       socketPath: path.join(userRoot, "daemon.sock"),
+      invokingRoot: process.cwd(),
       launch: sharedLaunch,
       probe: async () => false,
       spawnDetached: async () => {
@@ -122,6 +169,7 @@ test("one failed start attempt stops without spawning a second daemon", async ()
   let spawns = 0;
   const result = await ensureLocalDaemonRunning({
     socketPath: "/tmp/ha-autostart-timeout.sock",
+    invokingRoot: process.cwd(),
     launch,
     probe: async () => false,
     spawnDetached: async () => {
@@ -150,6 +198,7 @@ test("a live process with lifecycle attach progress reports starting instead of 
   try {
     const result = await ensureLocalDaemonRunning({
       socketPath: path.join(userRoot, "daemon.sock"),
+      invokingRoot: process.cwd(),
       launch: spec,
       probe: async () => false,
       probeIntervalMs: 1,
@@ -178,6 +227,7 @@ test("a launcher that is missing fails fast as daemon_spawn_not_found without a 
   let spawns = 0;
   const result = await ensureLocalDaemonRunning({
     socketPath: "/tmp/ha-autostart-enoent.sock",
+    invokingRoot: process.cwd(),
     launch,
     probe: async () => false,
     spawnDetached: async () => {
@@ -198,6 +248,7 @@ test("a launcher that is missing fails fast as daemon_spawn_not_found without a 
 test("a permission-denied launcher is classified as daemon_spawn_permission", async () => {
   const result = await ensureLocalDaemonRunning({
     socketPath: "/tmp/ha-autostart-eacces.sock",
+    invokingRoot: process.cwd(),
     launch,
     probe: async () => false,
     spawnDetached: async () => {
@@ -215,6 +266,7 @@ test("a permission-denied launcher is classified as daemon_spawn_permission", as
 test("a non-OS launcher failure is classified as daemon_start_failed", async () => {
   const result = await ensureLocalDaemonRunning({
     socketPath: "/tmp/ha-autostart-other.sock",
+    invokingRoot: process.cwd(),
     launch,
     probe: async () => false,
     spawnDetached: async () => {
@@ -312,9 +364,13 @@ test("detached stdout, stderr, and a fatal stack land in the daemon output log",
   try {
     await startDetachedProcessChecked(
       process.execPath,
-      ["-e", "console.log('stdout witness'); console.error('stderr witness'); throw new Error('fatal witness')"],
+      [
+        "-e",
+        "console.log('stdout witness'); console.log('cwd witness ' + process.cwd()); console.error('stderr witness'); throw new Error('fatal witness')",
+      ],
       process.env,
       outputPath,
+      root,
     );
     for (let attempt = 0; attempt < 100 && !readFileSync(outputPath, "utf8").includes("fatal witness"); attempt += 1)
       await new Promise((resolve) => setTimeout(resolve, 10));
@@ -322,7 +378,12 @@ test("detached stdout, stderr, and a fatal stack land in the daemon output log",
     assert.match(output, /stdout witness/u);
     assert.match(output, /stderr witness/u);
     assert.match(output, /Error: fatal witness/u);
+    assert.match(output, new RegExp(`cwd witness ${escapeRegExp(realpathSync.native(root))}`, "u"));
   } finally {
     rmSync(root, { recursive: true, force: true });
   }
 });
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
+}

--- a/packages/daemon/test/daemon-autostart.test.ts
+++ b/packages/daemon/test/daemon-autostart.test.ts
@@ -41,18 +41,27 @@ test("a worktree is refused before spawn while the registered canonical checkout
   const parent = mkdtempSync(path.join(tmpdir(), "ha-daemon-host-root-")),
     canonical = path.join(parent, "repo"),
     worktree = path.join(canonical, ".worktrees", "feature"),
+    independent = path.join(parent, "independent"),
     userRoot = path.join(parent, "user");
   try {
     mkdirSync(path.join(canonical, ".git"), { recursive: true });
+    mkdirSync(path.join(canonical, ".git", "worktrees", "feature"), { recursive: true });
     mkdirSync(worktree, { recursive: true });
+    mkdirSync(path.join(independent, ".git"), { recursive: true });
     mkdirSync(userRoot);
     writeFileSync(path.join(worktree, ".git"), "gitdir: ../../.git/worktrees/feature\n", "utf8");
+    writeFileSync(path.join(canonical, ".git", "worktrees", "feature", "commondir"), "../..\n", "utf8");
     writeFileSync(
       path.join(userRoot, "registry.json"),
       `${JSON.stringify({ schema: "harness-daemon-registry/v1", repos: [{ repoId: "canonical", canonicalRoot: canonical, state: "enabled" }] })}\n`,
       "utf8",
     );
     assert.equal(daemonHostStartRefusal({ invokingRoot: path.join(canonical, "packages"), userRoot }), null);
+    assert.equal(
+      daemonHostStartRefusal({ invokingRoot: independent, userRoot }),
+      null,
+      "a different, not-yet-registered repository owns its own checkout identity",
+    );
     const refusal = daemonHostStartRefusal({ invokingRoot: worktree, userRoot });
     assert.equal(refusal?.code, "daemon_start_noncanonical_checkout");
     assert.match(refusal?.hint ?? "", /A worktree may connect to an existing daemon but cannot host it/u);

--- a/packages/gui/src/main/electron-main.ts
+++ b/packages/gui/src/main/electron-main.ts
@@ -123,6 +123,7 @@ export async function startGuiApp(): Promise<void> {
     bridge = createLocalGuiServiceBridge(rootDir, resolveGuiLayoutOverrides(), packaged ? { packaged } : {}),
     controlled = addLocalMainControls({
       bridge,
+      invokingRoot: rootDir,
       target: async (repoId) => resolveLocalDaemonTarget({ rootDir, ...(repoId ? { repoIdOverride: repoId } : {}) }),
       clientBuildCommit: daemonBuildStamp().commit,
       ...(packaged ? { packaged } : {}),

--- a/packages/gui/src/main/local-composition-root.ts
+++ b/packages/gui/src/main/local-composition-root.ts
@@ -90,6 +90,7 @@ export async function bootstrapLocalRepository(
       if (!isDaemonUnreachable(connectError)) throw connectError;
       const started = await ensureLocalDaemonRunning({
         socketPath: target.socketPath,
+        invokingRoot: input.rootDir,
         launch: () => daemonServeLaunch(target, packaged),
       });
       if (!started.ok)
@@ -148,6 +149,7 @@ async function request(
       if (!isDaemonUnreachable(connectError)) throw connectError;
       const started = await ensureLocalDaemonRunning({
         socketPath: target.socketPath,
+        invokingRoot: rootDir,
         launch: () => daemonServeLaunch(target, packaged),
       });
       if (!started.ok)

--- a/packages/gui/src/main/local-main-controls.ts
+++ b/packages/gui/src/main/local-main-controls.ts
@@ -6,6 +6,7 @@ import type { GuiServiceBridge } from "../api/service-bridge.ts";
 import { consumeKnownError } from "../api/error-consumption.ts";
 import { createDaemonSupervisor } from "./daemon-supervisor.ts";
 import { daemonServeLaunch, type PackagedRuntime } from "./daemon-serve-launch.ts";
+import { daemonCheckoutRoot, daemonHostStartRefusal } from "../../../daemon/src/client/daemon-autostart.ts";
 import { createRuntimeInstanceCredentialController } from "./secure-credential-broker.ts";
 import type { CredentialPort } from "../../../daemon/src/agent-runtime-credential-port.ts";
 
@@ -17,6 +18,7 @@ type Target = {
 };
 export function addLocalMainControls(input: {
   readonly bridge: GuiServiceBridge;
+  readonly invokingRoot?: string;
   readonly target: (repoId?: string) => Promise<Target>;
   readonly clientBuildCommit: string | null;
   readonly packaged?: PackagedRuntime;
@@ -24,7 +26,8 @@ export function addLocalMainControls(input: {
 }): GuiServiceBridge {
   const supervisor = createDaemonSupervisor({
     authorize: async (payload) => asRecord(await input.bridge.invoke("requestDaemonControl", payload)),
-    restart: async (repoId) => restartResidentDaemon(await input.target(repoId), input.packaged),
+    restart: async (repoId) =>
+      restartResidentDaemon(await input.target(repoId), input.invokingRoot ?? process.cwd(), input.packaged),
   });
   // API-key creation remains main-process-bound so the daemon receives only an opaque
   // credential reference; the resulting create call returns to the registry-derived bridge.
@@ -76,7 +79,9 @@ export function addLocalMainControls(input: {
     return { ...value, daemon: { buildStale: stale, ...daemon } };
   }
 }
-async function restartResidentDaemon(target: Target, packaged?: PackagedRuntime) {
+async function restartResidentDaemon(target: Target, invokingRoot: string, packaged?: PackagedRuntime) {
+  const refusal = daemonHostStartRefusal({ invokingRoot, userRoot: target.userRoot });
+  if (refusal) throw Object.assign(new Error(refusal.hint), { code: refusal.code });
   const before = point(await requestDaemonJsonRpcAt(target.socketPath, "daemon.gui.system.read", {}, 500)),
     pid = readDaemonPid(target.userRoot, target.daemonId);
   if (pid === null || pid !== before.pid)
@@ -84,7 +89,13 @@ async function restartResidentDaemon(target: Target, packaged?: PackagedRuntime)
   terminateProcess(pid);
   await waitForExit(pid);
   const { command, args, env } = daemonServeLaunch(target, packaged);
-  startDetachedProcess(command, args, env, daemonLifecycleLogPath(target.userRoot, target.daemonId));
+  startDetachedProcess(
+    command,
+    args,
+    env,
+    daemonLifecycleLogPath(target.userRoot, target.daemonId),
+    daemonCheckoutRoot(invokingRoot),
+  );
   for (let attempt = 0; attempt < 100; attempt += 1) {
     try {
       const after = point(await requestDaemonJsonRpcAt(target.socketPath, "daemon.gui.system.read", {}, 100));

--- a/packages/gui/test/daemon-host-root-guard.test.ts
+++ b/packages/gui/test/daemon-host-root-guard.test.ts
@@ -1,0 +1,87 @@
+// harness-test-tier: integration
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { requestDaemonJsonRpcAt } from "../../daemon/src/client/local-json-rpc-client.ts";
+import { terminateProcess } from "../../daemon/src/process-port.ts";
+import { readDaemonPid, startDaemon, type RunningDaemon } from "../../daemon/src/runtime.ts";
+import { createLocalGuiServiceBridge } from "../src/index.ts";
+
+test("GUI worktree refuses an absent daemon then reuses the canonical resident", async (context) => {
+  const parent = mkdtempSync(path.join(tmpdir(), "ha-gui-host-root-")),
+    rootDir = path.join(parent, "repo"),
+    worktree = path.join(rootDir, ".worktrees", "feature"),
+    userRoot = path.join(parent, "user"),
+    daemonId = "gui-host-root",
+    previousRoot = process.env.HARNESS_DAEMON_USER_ROOT,
+    previousId = process.env.HARNESS_DAEMON_ID;
+  process.env.HARNESS_DAEMON_USER_ROOT = userRoot;
+  process.env.HARNESS_DAEMON_ID = daemonId;
+  const daemon = resident(await startDaemon({ daemonId, userRoot }));
+  try {
+    const bootstrapped = await requestDaemonJsonRpcAt(
+      daemon.endpoint,
+      "daemon.repo.bootstrap",
+      { rootDir, repoId: "gui-host-root", personId: "person-gui", displayName: "GUI Host Root" },
+      1_000,
+    );
+    assert.equal(bootstrapped.ok, true, JSON.stringify(bootstrapped));
+    await daemon.stop();
+    mkdirSync(worktree, { recursive: true });
+    writeFileSync(path.join(worktree, ".git"), "gitdir: ../../.git/worktrees/feature\n", "utf8");
+
+    const refusal = (await createLocalGuiServiceBridge(worktree).invoke("getTasks", {
+      repoId: "gui-host-root",
+    })) as Failure;
+    assert.equal(refusal.error?.code, "daemon_start_noncanonical_checkout", JSON.stringify(refusal));
+    assert.match(refusal.error?.hint ?? "", /A worktree may connect to an existing daemon but cannot host it/u);
+    assert.equal(readDaemonPid(userRoot, daemonId), null, "the worktree must not claim the daemon slot");
+
+    const canonical = await createLocalGuiServiceBridge(rootDir).invoke("getTasks", { repoId: "gui-host-root" });
+    assert.equal(canonical.ok, true, JSON.stringify(canonical));
+    const canonicalPid = readDaemonPid(userRoot, daemonId);
+    assert.ok(canonicalPid, "canonical GUI request must autostart the resident daemon");
+    const reused = await createLocalGuiServiceBridge(worktree).invoke("getTasks", { repoId: "gui-host-root" });
+    assert.equal(reused.ok, true, JSON.stringify(reused));
+    assert.equal(readDaemonPid(userRoot, daemonId), canonicalPid, "the worktree must reuse the canonical resident");
+    context.diagnostic(
+      `GUI worktree refusal=${refusal.error?.code}; canonical autostart pid=${canonicalPid}; existing daemon reused`,
+    );
+    await stopResident(userRoot, daemonId);
+  } finally {
+    restoreEnv("HARNESS_DAEMON_USER_ROOT", previousRoot);
+    restoreEnv("HARNESS_DAEMON_ID", previousId);
+    await daemon.stop().catch(() => undefined);
+    rmSync(parent, { recursive: true, force: true });
+  }
+});
+
+interface Failure {
+  readonly error?: { readonly code: string; readonly hint: string };
+}
+
+function resident(daemon: Awaited<ReturnType<typeof startDaemon>>): RunningDaemon {
+  if (!Reflect.has(daemon, "stop")) throw new Error(`fixture unexpectedly deferred to pid ${String(daemon.pid)}`);
+  return daemon as RunningDaemon;
+}
+
+async function stopResident(userRoot: string, daemonId: string): Promise<void> {
+  const pid = readDaemonPid(userRoot, daemonId);
+  if (pid === null) return;
+  terminateProcess(pid);
+  for (let attempt = 0; attempt < 200; attempt += 1) {
+    try {
+      process.kill(pid, 0);
+    } catch {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+}
+
+function restoreEnv(name: string, value: string | undefined): void {
+  if (value === undefined) delete process.env[name];
+  else process.env[name] = value;
+}

--- a/packages/gui/test/daemon-host-root-guard.test.ts
+++ b/packages/gui/test/daemon-host-root-guard.test.ts
@@ -29,8 +29,10 @@ test("GUI worktree refuses an absent daemon then reuses the canonical resident",
     );
     assert.equal(bootstrapped.ok, true, JSON.stringify(bootstrapped));
     await daemon.stop();
+    mkdirSync(path.join(rootDir, ".git", "worktrees", "feature"), { recursive: true });
     mkdirSync(worktree, { recursive: true });
     writeFileSync(path.join(worktree, ".git"), "gitdir: ../../.git/worktrees/feature\n", "utf8");
+    writeFileSync(path.join(rootDir, ".git", "worktrees", "feature", "commondir"), "../..\n", "utf8");
 
     const refusal = (await createLocalGuiServiceBridge(worktree).invoke("getTasks", {
       repoId: "gui-host-root",


### PR DESCRIPTION
# English

## Summary

The canonical default daemon was found hosted by an Electron process the GLM worker's screenshot script launched from `.worktrees/gui-settings-i18n` (fact F-057EC02E); when that worktree was deleted the daemon's codex probe failed and every runtime instance read as unauthenticated. Daemon startup now probes the shared socket first: a worktree reuses an existing daemon but, when none is running, it cannot claim the slot — only the registered canonical checkout may host it, and an allowed detached daemon is spawned with the canonical checkout as cwd. Refusal code `daemon_start_noncanonical_checkout`. CLI autostart, `daemon start --service`, `daemon status`, GUI autostart and GUI restart all converge on the same `ensureLocalDaemonRunning` guard; no second autostart path exists.

## Architectural Justification

- Production-Delta as computed: one guard at the single autostart site plus the cwd fix; the GUI restart path is guarded, not duplicated.

## What Changed

- daemon bootstrap (`ensureLocalDaemonRunning`): socket probe → canonical-checkout eligibility → spawn with canonical cwd.
- CLI `daemon start/status`, GUI main autostart/restart: use the guard.
- tests: daemon unit 15/15, CLI integration 11/11, GUI integration 1/1.

## Gate Harvest / 门收割

Deleted-Production-Paths: the worktree-cwd daemon spawn (daemon inherited the invoking checkout's cwd)
Deleted-Gates-Fixtures: daemon unit 15/15, CLI integration 11/11, GUI integration 1/1 on the isolated target; check-cli-error-codes, check-import-boundaries (delta 0), check-error-classification, check-file-complexity green
- Production net lines: use the single CI-backed `Production-Delta` declaration below; do not enter a second metric.

## Machine-Readable Declarations

Production-Delta: +132/-42
Dependency-Change: none

### Optional Evidence Claims

## Task And Scope

- Harness task: task_e2a58aaec3fdf9719b7c8433b8
- Branch: codex/daemon-host-guard
- Public scope: daemon autostart eligibility across CLI and GUI
- Private planning/evidence updated: yes
- Out of scope: Reaping the 24k leaked durable-file-* entries in the runtime instance tmp root (F-288E2CAC).

## Version Impact

- Version: no version change because pre-release internal change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none
- Authority: task_e2a58aaec3fdf9719b7c8433b8
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: origin/main
- Branch merge-base with `origin/main`: origin/main
- Last `git fetch origin` time: 2026-08-29T00:15Z
- Sync method: none needed
- Public diff command: `git diff origin/main...HEAD`
- Private evidence commit/path: harness task package task_e2a58aaec3fdf9719b7c8433b8 (artifacts/reports)
- Reviewer evidence path: same task package
- GitHub Actions `rewrite-ci` run URL: pending
- [x] Worker (Sol): isolated tests as listed; `npx tsc -b` exit 0; targeted ESLint exit 0
- [x] CEO read the report and diff stat; refusal text names both the worktree and the canonical path
- [ ] CI on this PR
- [ ] `npm ci`
- [ ] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Not run: full local matrix by design; CI is the authority.

## Review Evidence

- Self-review: CEO reproduced the original defect (Electron pid 91930 with a deleted cwd hosting the daemon) before filing the task.
- Reviewer subagent: Sol implemented; CEO acceptance.
- Human review: pending
- Blocking findings: none

## Residual Risk

- A machine whose registered canonical checkout was moved cannot autostart until the registration is updated; the refusal names the expected path.

## References

- Task: task_e2a58aaec3fdf9719b7c8433b8
- Evidence: task package artifacts/reports
- Review: this PR

---

# 中文

## 概要

canonical default daemon 曾被 GLM worker 截图脚本从 `.worktrees/gui-settings-i18n` 拉起的 Electron 进程托管(fact F-057EC02E);该 worktree 删除后 daemon 的 codex 探测失败,所有 runtime 实例显示未认证。daemon 启动现在先探测共享 socket:worktree 可复用已有 daemon,但没有 daemon 在跑时不能抢占——只有登记的 canonical checkout 能托管,允许的 detached daemon 以 canonical checkout 为 cwd 启动。拒绝码 `daemon_start_noncanonical_checkout`。CLI 自启、`daemon start --service`、`daemon status`、GUI 自启与 GUI 重启都收敛到同一个 `ensureLocalDaemonRunning` 守卫;没有第二条自启路径。

## 架构辩护

- Production-Delta 实算:唯一自启点上一个守卫加 cwd 修正;GUI 重启路径被守卫而非复制。

## 改动内容

- daemon bootstrap(`ensureLocalDaemonRunning`):socket 探测 → canonical checkout 资格 → 以 canonical cwd 启动。
- CLI `daemon start/status`、GUI main 自启/重启:走该守卫。
- 测试:daemon 单测 15/15、CLI 集成 11/11、GUI 集成 1/1。

## 门收割 / Gate Harvest

- 删除的生产路径:以调用方 checkout 为 cwd 启动 daemon 的旧路径
- 同 commit 删除的门 / fixture:隔离目标 daemon 单测 15/15、CLI 集成 11/11、GUI 集成 1/1;check-cli-error-codes、check-import-boundaries(delta 0)、check-error-classification、check-file-complexity 绿
- 生产净行数:引用英文块中的 `Production-Delta`。

## 机读声明说明

- 见英文块。

## 任务与范围

- Harness 任务:task_e2a58aaec3fdf9719b7c8433b8
- 分支:codex/daemon-host-guard
- 公开范围:CLI 与 GUI 的 daemon 自启资格
- 私有计划 / 证据是否已更新:yes
- 范围外:runtime instance tmp 根下 2.4 万条 durable-file-* 泄漏的回收(F-288E2CAC)。

## 版本影响

- 版本:不改版本,原因是预发布内部改动
- 发布影响:不发布

## 治理声明

- 是否触碰 protected surface:no
- protected surface 范围:none
- 依据:task_e2a58aaec3fdf9719b7c8433b8
- 机器检查边界:本 PR 只声明该段存在;是否真实、充分由 reviewer 判断。
- Break-glass:no
- Break-glass 原因:不适用
- Break-glass 范围:不适用
- 后续治理任务:不适用

## 验证

- `origin/main` 基准 SHA:origin/main
- 当前分支与 `origin/main` 的 merge-base:origin/main
- 最近一次 `git fetch origin` 时间:2026-08-29T00:15Z
- 同步方式:不需要
- 公开 diff 命令:`git diff origin/main...HEAD`
- 私有证据 commit/path:harness 任务包 task_e2a58aaec3fdf9719b7c8433b8
- Reviewer 证据路径:同上
- GitHub Actions `rewrite-ci` run URL:待定
- [x] worker(Sol):上述隔离测试;`npx tsc -b` 退出 0;定向 ESLint 退出 0
- [x] CEO 读报告与 diff stat;拒绝文案同时写明 worktree 与 canonical 路径
- [ ] 本 PR 的 CI
- [ ] `npm ci`
- [ ] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- 未运行:按设计不跑本地全量;以 CI 为权威。

## 审查证据

- 自查:CEO 立件前复现了原缺陷(cwd 已删的 Electron pid 91930 托管 daemon)。
- Reviewer subagent:Sol 实现;CEO 验收。
- 人工审查:待定
- 阻塞发现:无

## 残余风险

- 登记的 canonical checkout 被挪走的机器在更新登记前无法自启;拒绝文案给出期望路径。

## 关联材料

- 任务:task_e2a58aaec3fdf9719b7c8433b8
- 证据:任务包 artifacts/reports
- 审查:本 PR

