### PR TITLE
fix(daemon): make doc sync recovery actionable

### DIFF
--- a/packages/daemon/src/doc-sync-candidate-scanner.ts
+++ b/packages/daemon/src/doc-sync-candidate-scanner.ts
@@ -26,6 +26,7 @@ import {
   type WriteSource,
 } from "../../kernel/src/index.ts";
 import { authorizeAction } from "./authorization.ts";
+import { blockedCandidateNextAction } from "./doc-sync-details.ts";
 import { docSyncError } from "./doc-sync-files.ts";
 
 export type DocCandidateState = "clean" | "eligible" | "inapplicable" | "blocked" | "deletion" | "conflict";
@@ -201,6 +202,7 @@ export function scanDocCandidates(input: {
         null,
         null,
         retirementBase ? "deletion_forbidden" : null,
+        retirementBase ? "deletion_forbidden" : null,
       );
     const { mediaType, policyId } = classification;
     if (candidate === base)
@@ -335,12 +337,11 @@ export function validateSelectedDocPaths(rootDir: string, selected: readonly str
   }
   const missing = scan.rows
     .filter((row) => row.state === "clean" && row.baseBlobSha256 === null && row.candidateBlobSha256 === null)
-    .map((row) => row.path);
-  if (missing.length > 0)
-    throw docSyncError(
-      "document_not_found",
-      `selected doc-sync path does not match an authored candidate: ${missing.join(", ")}; run ha doc status`,
-    );
+    .map((row) => ({
+      ...row,
+      reason: "selected doc-sync path does not match an authored candidate",
+    }));
+  if (missing[0]) throw docSyncError("document_not_found", blockedCandidateNextAction(missing[0]));
 }
 
 export function intentFromScan(

--- a/packages/daemon/src/doc-sync-details.ts
+++ b/packages/daemon/src/doc-sync-details.ts
@@ -3,6 +3,8 @@ import path from "node:path";
 import type { TaskProjection } from "../../kernel/src/index.ts";
 import {
   DOC_POLICY_ID,
+  documentPath,
+  resolveDocRoute,
   resolveHarnessLayout,
   sha256Bytes,
   stableStringify,
@@ -16,6 +18,20 @@ import {
 } from "../../kernel/src/index.ts";
 import type { Input } from "./doc-sync-command-actions.ts";
 import { localProseSource } from "./doc-sync-files.ts";
+
+interface BlockedCandidate {
+  readonly path: string;
+  readonly reason: string | null;
+  readonly requiredRoute: string | null;
+}
+
+export function blockedCandidateNextAction(
+  candidate: BlockedCandidate,
+  nextStep = "rerun ha doc sync --submit",
+): string {
+  const route = candidate.requiredRoute ?? resolveDocRoute(documentPath(candidate.path)).requiredRoute;
+  return `resolve ${candidate.path} through ${route}: ${candidate.reason ?? "candidate is blocked"}; then ${nextStep}`;
+}
 
 export function readDetail(
   input: Input,
@@ -68,7 +84,9 @@ export function detail(
     differences: [],
     unresolvedTouches,
     deletions: [],
-    nextAction: "run ha doc status, then ha doc sync --dry-run --path <path> and resubmit with a new opId",
+    nextAction: unresolvedTouches[0]
+      ? blockedCandidateNextAction(unresolvedTouches[0])
+      : "run ha doc sync --dry-run --path <path> and resubmit with a new opId",
   };
 }
 

--- a/packages/daemon/src/doc-sync-settlement.ts
+++ b/packages/daemon/src/doc-sync-settlement.ts
@@ -12,7 +12,7 @@ import {
 import type { DocIntentChannel } from "./doc-sync-adjudication.ts";
 import { publicScan, type DocCandidateScan } from "./doc-sync-candidate-scanner.ts";
 import type { DocSettlementReceipt, Input } from "./doc-sync-command-actions.ts";
-import { detail, holder, isTaskPackagePath, touch } from "./doc-sync-details.ts";
+import { blockedCandidateNextAction, detail, holder, isTaskPackagePath, touch } from "./doc-sync-details.ts";
 import { localProseSource, proof } from "./doc-sync-files.ts";
 
 export function scanReceipt(input: Input, scan: DocCandidateScan): DocSettlementReceipt {
@@ -126,25 +126,20 @@ export function scanDetail(input: Input, scan: DocCandidateScan, code: string): 
           "opId",
         ].join("")
       : deletion
-        ? [
-            "run ha doc retire --path ",
-            `${deletion.path}`,
-            ' --reason "<reason>" for intentional retirement, or restore the ',
-            "document, then run ha doc status",
-          ].join("")
+        ? blockedCandidateNextAction(
+            deletion,
+            [
+              "run ha doc retire --path ",
+              deletion.path,
+              ' --reason "<reason>" for intentional retirement, or restore the ',
+              "document and rerun ha doc sync --submit",
+            ].join(""),
+          )
         : (executionChoice ??
           leaseConflict ??
           headingRestore ??
           (blocked
-            ? [
-                "resolve ",
-                `${blocked.path}`,
-                " through ",
-                `${blocked.requiredRoute ?? resolveDocRoute(documentPath(blocked.path)).requiredRoute}`,
-                ": ",
-                `${blocked.reason ?? "candidate is blocked"}`,
-                "; then rerun ha doc sync --submit",
-              ].join("")
+            ? blockedCandidateNextAction(blocked)
             : scan.rows.some((row) => row.state === "eligible")
               ? "submit this selection against the reported automatic base"
               : scan.rows.some((row) => row.state === "inapplicable")

--- a/packages/daemon/src/repo-cell.ts
+++ b/packages/daemon/src/repo-cell.ts
@@ -6,10 +6,12 @@ import {
   makeTaskEventStore,
   makeTaskProjection,
   type ActorIdentity,
+  type DocSyncReceiptDetail,
 } from "../../kernel/src/index.ts";
 import { makeAgentRuntimeReadModel } from "./agent-runtime-read.ts";
 import { readRuntimeAttemptChain, readSessionGroupDispatches, readTaskDispatches } from "./dispatch-read.ts";
 import { runDocAction } from "./doc-sync-actions.ts";
+import { blockedCandidateNextAction } from "./doc-sync-details.ts";
 import { makeEntityActionCatalogExecutor } from "./entity-action-catalog-executor.ts";
 import { openReplicaCutSource } from "./fleet/replica-cut-store.ts";
 import type { RepoCellBinding } from "./repo-cell-types.ts";
@@ -55,12 +57,8 @@ export function initializeRepoCell(context: any): any {
     })
       .then((receipt) => {
         const detail = receipt.detail?.kind === "doc_sync" ? receipt.detail : undefined,
-          blocked = [
-            ...(detail?.unresolvedTouches ?? []).map((touch) => `${touch.path} (${touch.requiredRoute})`),
-            ...(detail?.deletions ?? []).map((deletion) => `${deletion.path} (deletion)`),
-          ];
-        if (blocked.length)
-          console.warn(`[wal-materializer] authored doc candidates blocked; run ha doc status: ${blocked.join(", ")}`);
+          warning = blockedAuthoredCandidateWarning(detail);
+        if (warning) console.warn(warning);
       })
       .catch((error) => {
         console.warn(
@@ -127,6 +125,13 @@ export function initializeRepoCell(context: any): any {
     service,
     replica,
   };
+}
+
+export function blockedAuthoredCandidateWarning(detail: DocSyncReceiptDetail | undefined): string | null {
+  const unresolved = detail?.unresolvedTouches[0],
+    deletion = detail?.deletions[0],
+    nextAction = unresolved ? blockedCandidateNextAction(unresolved) : deletion ? detail.nextAction : null;
+  return nextAction === null ? null : `[wal-materializer] authored doc candidate blocked; ${nextAction}`;
 }
 
 export function chainRepoCellWrite<T>(tail: Promise<void>, work: () => T | PromiseLike<T>): Promise<T> {

--- a/packages/daemon/test/doc-sync-slice-a.test.ts
+++ b/packages/daemon/test/doc-sync-slice-a.test.ts
@@ -4,8 +4,10 @@ import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "nod
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
-import { makeTaskEventStore, sha256Text } from "../../kernel/src/index.ts";
+import { DOC_POLICY_ID, makeTaskEventStore, parseDocWriteIntent, sha256Text } from "../../kernel/src/index.ts";
+import { detail, touch } from "../src/doc-sync-details.ts";
 import { canonicalRoot, workspaceId } from "../src/protocol/daemon-protocol.contract.ts";
+import { blockedAuthoredCandidateWarning } from "../src/repo-cell.ts";
 import { openBootstrappedRepoCell as openRepoCell } from "./repo-settings.fixture.ts";
 
 import { actor, git, initRepo, opaqueTextualMediaType, rows, write } from "./doc-sync-slice-a.fixtures.ts";
@@ -157,6 +159,14 @@ test("selected doc-sync paths are authored-relative candidates and zero-write su
     const missing = await cell.run({ kind: "doc-submit", paths: ["context/missing.md"] }, binding);
     assert.equal(missing.outcome, "op_rejected", JSON.stringify(missing));
     assert.equal(missing.code, "document_not_found");
+    assert.equal(
+      missing.nextAction,
+      [
+        "resolve context/missing.md through doc-sync: selected doc-sync path does not match an authored candidate; ",
+        "then rerun ha doc sync --submit",
+      ].join(""),
+    );
+    assert.doesNotMatch(missing.nextAction ?? "", /ha doc status/u);
 
     const clean = await cell.run({ kind: "doc-submit", paths: ["context/selected.md"] }, binding);
     assert.equal(clean.outcome, "no_changes", JSON.stringify(clean));
@@ -166,6 +176,38 @@ test("selected doc-sync paths are authored-relative candidates and zero-write su
     await cell.close();
     rmSync(rootDir, { recursive: true, force: true });
   }
+});
+
+test("doc-sync details name only the first unresolved touch already in hand", () => {
+  const first = touch("context/first.md", "refresh-region-policy", 'base region is missing: "# First"'),
+    second = touch("context/second.md", "workspace-config", "path is owned by workspace-config"),
+    blocked = unresolvedDetail(first, second),
+    withoutRows = unresolvedDetail();
+  assert.equal(
+    blocked.nextAction,
+    [
+      'resolve context/first.md through refresh-region-policy: base region is missing: "# First"; ',
+      "then rerun ha doc sync --submit",
+    ].join(""),
+  );
+  assert.equal(blocked.nextAction.includes(second.path), false);
+  assert.doesNotMatch(blocked.nextAction, /ha doc status/u);
+  assert.doesNotMatch(withoutRows.nextAction, /ha doc status/u);
+});
+
+test("repo-cell warning names only the first blocked receipt row", () => {
+  const first = touch("context/first.md", "refresh-region-policy", 'base region is missing: "# First"'),
+    second = touch("context/second.md", "workspace-config", "path is owned by workspace-config"),
+    warning = blockedAuthoredCandidateWarning(unresolvedDetail(first, second));
+  assert.equal(
+    warning,
+    [
+      "[wal-materializer] authored doc candidate blocked; resolve context/first.md through ",
+      'refresh-region-policy: base region is missing: "# First"; then rerun ha doc sync --submit',
+    ].join(""),
+  );
+  assert.equal(warning?.includes(second.path), false);
+  assert.doesNotMatch(warning ?? "", /ha doc status/u);
 });
 
 test("task-scoped doc sync derives every dirty candidate from the task id", async () => {
@@ -229,7 +271,12 @@ test("doc retire deletes one projected document and returns an auditable retirem
     rmSync(path.join(rootDir, "harness", logical));
     const mutation = await cell.run({ kind: "doc-status", paths: [logical] }, binding);
     assert.equal(rows(mutation.evidence)[0]?.state, "deletion");
+    assert.match(
+      mutation.detail?.nextAction ?? "",
+      /resolve context\/temporary\.md through deletion_forbidden: canonical document is missing from the worktree/u,
+    );
     assert.match(mutation.detail?.nextAction ?? "", new RegExp(`ha doc retire --path ${logical}`, "u"));
+    assert.doesNotMatch(mutation.detail?.nextAction ?? "", /ha doc status/u);
     assert.doesNotMatch(mutation.detail?.nextAction ?? "", /resolve blocked/iu);
     const retired = await cell.run({ kind: "doc-retire", path: logical, reason }, binding);
     assert.equal(retired.outcome, "applied", JSON.stringify(retired));
@@ -267,6 +314,31 @@ test("doc retire deletes one projected document and returns an auditable retirem
     rmSync(rootDir, { recursive: true, force: true });
   }
 });
+
+function unresolvedDetail(...unresolvedTouches: ReturnType<typeof touch>[]) {
+  const current = {
+      repoId: "next-action-detail",
+      revision: 0,
+      headDigest: `sha256:${"0".repeat(64)}`,
+    },
+    intent = parseDocWriteIntent(
+      {
+        schema: "doc-write-intent/v1",
+        executionId: null,
+        baseLedgerSha: current,
+        changes: [
+          {
+            path: "context/first.md",
+            baseBlobSha256: null,
+            policyId: DOC_POLICY_ID,
+            candidate: null,
+          },
+        ],
+      },
+      current.repoId,
+    );
+  return detail(intent, current, "unresolved_touch", null, unresolvedTouches);
+}
 
 test("doc retire follows status for a Git-tracked document that was never projected", async () => {
   const rootDir = mkdtempSync(path.join(tmpdir(), "ha-doc-a-retire-tracked-"));


### PR DESCRIPTION
# English

## Summary

Four daemon rejection hints told the operator to `run ha doc status` and work it out — the daemon already knew the blocked candidate and its required route. The four sites (candidate scanner, doc-sync-details, and the two doc-sync settlement paths) now render the blocked row inline through the single #1984 blocked-row renderer and name the concrete recovery (`resolve <path> through doc-sync … then rerun ha doc sync --submit`). No second renderer; the four bespoke strings are deleted.

## Architectural Justification

- Production-Delta as computed: four hint strings replaced by one shared renderer call each; nothing else.

## What Changed

- `packages/daemon/src` doc-sync candidate scanner, doc-sync-details and settlement sites: inline blocked rows + concrete next action.
- tests updated for the new receipts.

## Gate Harvest / 门收割

Deleted-Production-Paths: the four `run ha doc status` hint strings in packages/daemon/src
Deleted-Gates-Fixtures: the changed daemon doc-sync tests (report r1.md receipts before/after)
- Production net lines: use the single CI-backed `Production-Delta` declaration below; do not enter a second metric.

## Machine-Readable Declarations

Production-Delta: +48/-29
Dependency-Change: none

### Optional Evidence Claims

## Task And Scope

- Harness task: task_becae58dd830900355171dea95
- Branch: codex/doc-status-sites
- Public scope: daemon doc-sync rejection receipts
- Private planning/evidence updated: yes
- Out of scope: CLI-side wording of the same receipts (already passes through unchanged).

## Version Impact

- Version: no version change because pre-release internal change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none
- Authority: task_becae58dd830900355171dea95
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: origin/main
- Branch merge-base with `origin/main`: origin/main
- Last `git fetch origin` time: 2026-08-29T00:47Z
- Sync method: none needed
- Public diff command: `git diff origin/main...HEAD`
- Private evidence commit/path: harness task package task_becae58dd830900355171dea95 (artifacts/reports)
- Reviewer evidence path: same task package
- GitHub Actions `rewrite-ci` run URL: pending
- [x] Worker (Sol): before/after receipts quoted in r1.md; targeted daemon tests green on the isolated target
- [x] CEO read the report: one renderer, four call sites, four deletions
- [ ] CI on this PR
- [ ] `npm ci`
- [ ] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Not run: full local matrix by design; CI is the authority.

## Review Evidence

- Self-review: CEO filed this from the F-42D28979 lease_conflict loop where the operator was told to consult doc status the daemon had already computed.
- Reviewer subagent: Sol implemented; CEO acceptance.
- Human review: pending
- Blocking findings: none

## Residual Risk

- Longer receipts when many candidates are blocked.

## References

- Task: task_becae58dd830900355171dea95
- Evidence: task package artifacts/reports
- Review: this PR

---

# 中文

## 概要

daemon 有四处拒绝提示让操作者「去跑 ha doc status 自己看」——而 daemon 当时已经知道被阻塞的候选和它的 requiredRoute。四处站点(候选扫描、doc-sync-details、两条 doc-sync 结算路径)现在经 #1984 那个唯一的 blocked-row 渲染器内联输出阻塞行,并写明具体恢复动作(`resolve <path> through doc-sync … then rerun ha doc sync --submit`)。没有第二个渲染器;四条各写各的字符串被删除。

## 架构辩护

- Production-Delta 实算:四条提示字符串各换成一次共享渲染器调用;别无其它。

## 改动内容

- `packages/daemon/src` 的 doc-sync 候选扫描、doc-sync-details 与结算站点:内联阻塞行 + 具体下一步。
- 相应测试更新。

## 门收割 / Gate Harvest

- 删除的生产路径:packages/daemon/src 中四条 `run ha doc status` 提示字符串
- 同 commit 删除的门 / fixture:改动的 daemon doc-sync 测试(报告 r1.md 含前后回执)
- 生产净行数:引用英文块中的 `Production-Delta`。

## 机读声明说明

- 见英文块。

## 任务与范围

- Harness 任务:task_becae58dd830900355171dea95
- 分支:codex/doc-status-sites
- 公开范围:daemon doc-sync 拒绝回执
- 私有计划 / 证据是否已更新:yes
- 范围外:CLI 侧同一回执的措辞(原样透传,不改)。

## 版本影响

- 版本:不改版本,原因是预发布内部改动
- 发布影响:不发布

## 治理声明

- 是否触碰 protected surface:no
- protected surface 范围:none
- 依据:task_becae58dd830900355171dea95
- 机器检查边界:本 PR 只声明该段存在;是否真实、充分由 reviewer 判断。
- Break-glass:no
- Break-glass 原因:不适用
- Break-glass 范围:不适用
- 后续治理任务:不适用

## 验证

- `origin/main` 基准 SHA:origin/main
- 当前分支与 `origin/main` 的 merge-base:origin/main
- 最近一次 `git fetch origin` 时间:2026-08-29T00:47Z
- 同步方式:不需要
- 公开 diff 命令:`git diff origin/main...HEAD`
- 私有证据 commit/path:harness 任务包 task_becae58dd830900355171dea95
- Reviewer 证据路径:同上
- GitHub Actions `rewrite-ci` run URL:待定
- [x] worker(Sol):r1.md 引用前后回执;隔离目标定向 daemon 测试绿
- [x] CEO 读报告:一个渲染器、四个调用点、四处删除
- [ ] 本 PR 的 CI
- [ ] `npm ci`
- [ ] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- 未运行:按设计不跑本地全量;以 CI 为权威。

## 审查证据

- 自查:CEO 从 F-42D28979 的 lease_conflict 闭环立件:daemon 早已算出的东西却让操作者去查。
- Reviewer subagent:Sol 实现;CEO 验收。
- 人工审查:待定
- 阻塞发现:无

## 残余风险

- 候选大量阻塞时回执变长。

## 关联材料

- 任务:task_becae58dd830900355171dea95
- 证据:任务包 artifacts/reports
- 审查:本 PR
