### PR TITLE
fix: route hand-written missions through doc sync; revision-aware readiness hints

### DIFF
--- a/packages/cli/test/runtime-cli.integration.test.ts
+++ b/packages/cli/test/runtime-cli.integration.test.ts
@@ -215,6 +215,13 @@ test("real CLI runs, archives task-bound dispatches, resumes, waits through stat
       "--title",
       "Automatic lease",
     ]);
+    const automaticPackagePath = String(automaticTask.packagePath),
+      automaticPlanPath = `${automaticPackagePath}/task_plan.md`,
+      oneSectionMissing = realizedPlan("Automatic lease").replace(
+        /\n\n## CI\/Gate Authority Stop Condition\n\n[^\n]+/u,
+        "",
+      );
+    writeFileSync(path.join(root, "harness", automaticPlanPath), oneSectionMissing);
     const automaticArgs = [
         "runtime",
         "run",
@@ -228,13 +235,39 @@ test("real CLI runs, archives task-bound dispatches, resumes, waits through stat
       placeholderLease = runMaybe(root, env, automaticArgs);
     assert.equal(placeholderLease.status, 1);
     assert.equal(placeholderLease.receipt.code, "plan_placeholder");
-    const automaticPackagePath = String(automaticTask.packagePath);
+    assert.match(
+      String(placeholderLease.receipt.nextAction),
+      /task\.plan readiness judged the canonical projection document at workspace revision \d+/u,
+    );
+    assert.match(
+      String(placeholderLease.receipt.nextAction),
+      /missing required section is: CI\/Gate Authority Stop Condition/u,
+    );
+    assert.doesNotMatch(String(placeholderLease.receipt.nextAction), /missing required sections are: Brief/u);
+    assert.match(
+      String(placeholderLease.receipt.nextAction),
+      new RegExp(`ha doc sync --submit --path ${automaticPlanPath}`, "u"),
+    );
     writeFileSync(path.join(root, "harness", automaticPackagePath, "task_plan.md"), realizedPlan("Automatic lease"));
-    run(root, env, ["doc", "sync", "--submit", "--path", `${automaticPackagePath}/task_plan.md`]);
+    const automaticPlanSync = run(root, env, ["doc", "sync", "--submit", "--path", automaticPlanPath]);
     const automaticLease = runMaybe(root, env, automaticArgs);
     assert.equal(automaticLease.status, 0, JSON.stringify(automaticLease));
     assert.equal(automaticLease.receipt.outcome, "running");
     assert.equal(typeof automaticLease.receipt.dispatchId, "string");
+    context.diagnostic(
+      `revision-aware plan hint: ${JSON.stringify({
+        before: {
+          outcome: placeholderLease.receipt.outcome,
+          code: placeholderLease.receipt.code,
+          nextAction: placeholderLease.receipt.nextAction,
+        },
+        sync: { outcome: automaticPlanSync.outcome, summary: automaticPlanSync.summary },
+        after: {
+          outcome: automaticLease.receipt.outcome,
+          dispatchId: automaticLease.receipt.dispatchId,
+        },
+      })}`,
+    );
     const resumed = run(root, env, [
       "runtime",
       "run",
@@ -448,18 +481,28 @@ test("real CLI runs, archives task-bound dispatches, resumes, waits through stat
     ]);
     assert.equal(mismatch.status, 1);
     assert.equal(mismatch.receipt.code, "agent_runtime_type_mismatch");
-    const existingSource = path.join(root, "existing-mission.txt");
-    writeFileSync(existingSource, "existing mission");
-    run(root, env, [
-      "task",
-      "artifact",
-      "add",
+    const existingMissionPath = `${packagePath}/artifacts/missions/existing-mission.md`;
+    mkdirSync(path.join(artifactRoot, "missions"), { recursive: true });
+    writeFileSync(path.join(root, "harness", existingMissionPath), "existing mission");
+    const unsyncedMission = runMaybe(root, env, [
+      "runtime",
+      "run",
+      "cli-worker",
+      "--mission",
+      "existing-mission",
+      "--task",
       taskId,
-      "--source",
-      "existing-mission.txt",
-      "--destination",
-      "missions/existing-mission.md",
+      "--no-stream",
     ]);
+    assert.equal(unsyncedMission.status, 1);
+    assert.equal(unsyncedMission.receipt.code, "runtime_mission_unavailable");
+    assert.match(
+      String(unsyncedMission.receipt.nextAction),
+      new RegExp(`ha doc sync --submit --path ${existingMissionPath}`, "u"),
+    );
+    const missionStatus = run(root, env, ["doc", "status", "--path", existingMissionPath]);
+    assert.match(String(missionStatus.evidence), /"state":"eligible"/u);
+    const missionSync = run(root, env, ["doc", "sync", "--submit", "--path", existingMissionPath]);
     const retiredPromptFile = runMaybe(root, env, [
       "runtime",
       "run",
@@ -487,6 +530,18 @@ test("real CLI runs, archives task-bound dispatches, resumes, waits through stat
       ) as Record<string, unknown>;
     const reusedMission = readFileSync(path.join(artifactRoot, "missions", `${reusedDispatchId}.md`), "utf8"),
       reusedReport = readFileSync(path.join(artifactRoot, "reports", `${reusedDispatchId}.md`), "utf8");
+    context.diagnostic(
+      `hand-written mission route: ${JSON.stringify({
+        before: {
+          outcome: unsyncedMission.receipt.outcome,
+          code: unsyncedMission.receipt.code,
+          nextAction: unsyncedMission.receipt.nextAction,
+        },
+        status: { outcome: missionStatus.outcome, evidence: missionStatus.evidence },
+        sync: { outcome: missionSync.outcome, summary: missionSync.summary },
+        after: { outcome: reused.outcome, dispatchId: reusedDispatchId },
+      })}`,
+    );
     assert.equal(reusedDispatch.missionRef, `${packagePath}/artifacts/missions/${reusedDispatchId}.md`);
     assert.deepEqual(
       readdirSync(path.join(artifactRoot, "missions")).sort(),

--- a/packages/daemon/src/repo-cell-action-dispatch.ts
+++ b/packages/daemon/src/repo-cell-action-dispatch.ts
@@ -475,6 +475,7 @@ export async function lifecycleAction(
     );
   if (resolvedLifecycle?.coordination === "reserve" && !preview)
     cell.assertTaskTransitionDocumentReady({
+      rootDir: cell.rootDir,
       projection: cell.projection,
       taskId,
       slot: "task.plan",

--- a/packages/daemon/src/repo-cell-task-command-docs.ts
+++ b/packages/daemon/src/repo-cell-task-command-docs.ts
@@ -156,6 +156,7 @@ export async function runTaskCommandWithDocs(
   if (resolvedLifecycle?.coordination === "reserve")
     try {
       assertTaskTransitionDocumentReady({
+        rootDir: cell.rootDir,
         projection: cell.projection,
         taskId,
         slot: "task.plan",

--- a/packages/daemon/src/runtime-spawn-mission.ts
+++ b/packages/daemon/src/runtime-spawn-mission.ts
@@ -132,6 +132,7 @@ export function deriveTaskMission(
   readonly missionBody: string | null;
 } {
   const planDocument = assertTaskTransitionDocumentReady({
+      rootDir,
       projection,
       taskId,
       slot: "task.plan",
@@ -178,7 +179,10 @@ function readMissionDocument(
   if (read.watermark < read.sourceRevision || !read.document || !read.document.body.trim())
     throw runtimeSpawnError(
       "runtime_mission_unavailable",
-      `Task ${taskId} has no ready non-empty mission at harness/${logicalPath}.`,
+      [
+        `Task ${taskId} has no ready non-empty mission in the canonical projection at harness/${logicalPath}. `,
+        `If the file exists on disk, run ha doc sync --submit --path ${logicalPath}, then retry.`,
+      ].join(""),
     );
   return { path: path.join(packageRoot, "artifacts", "missions", `${name}.md`), body: read.document.body };
 }

--- a/packages/daemon/src/transition-document-access.ts
+++ b/packages/daemon/src/transition-document-access.ts
@@ -1,7 +1,12 @@
+import { existsSync, lstatSync, readFileSync } from "node:fs";
+import path from "node:path";
 import {
+  assessTransitionDocument,
   assertTransitionDocumentReady,
   normalizeRelativeDocumentPath,
   requireTransitionDocumentKind,
+  resolveHarnessLayout,
+  sha256Text,
   type TaskProjection,
 } from "../../kernel/src/index.ts";
 
@@ -11,6 +16,9 @@ export interface TaskTransitionDocument {
   readonly packagePath: string;
   readonly path: string;
   readonly body: string;
+  readonly blobSha256: string;
+  readonly workspaceRevision: number;
+  readonly source: "canonical projection" | "submitted candidate";
 }
 
 export function readTaskTransitionDocument(input: {
@@ -64,18 +72,25 @@ export function readTaskTransitionDocument(input: {
   }
   if (!documentPath.startsWith(`${task.packagePath}/`))
     throw transitionDocumentAccessError("content_not_ready", `Task ${input.taskId} ${input.slot} leaves its package.`);
-  const overridden = input.bodyOverrides?.get(documentPath);
-  if (overridden !== undefined) return { packagePath: task.packagePath, path: documentPath, body: overridden };
   const documentRead = input.projection.readDocument(documentPath);
   if (documentRead.watermark < documentRead.sourceRevision || !documentRead.document)
     throw transitionDocumentAccessError(
       "content_not_ready",
       `Task ${input.taskId} ${input.slot} projection is not ready at ${documentPath}.`,
     );
-  return { packagePath: task.packagePath, path: documentPath, body: documentRead.document.body };
+  const overridden = input.bodyOverrides?.get(documentPath);
+  return {
+    packagePath: task.packagePath,
+    path: documentPath,
+    body: overridden ?? documentRead.document.body,
+    blobSha256: overridden === undefined ? documentRead.document.blobSha256 : sha256Text(overridden),
+    workspaceRevision: documentRead.document.workspaceRevision,
+    source: overridden === undefined ? "canonical projection" : "submitted candidate",
+  };
 }
 
 export function assertTaskTransitionDocumentReady(input: {
+  readonly rootDir: string;
   readonly projection: TaskProjection;
   readonly taskId: string;
   readonly slot: TaskTransitionDocumentSlot;
@@ -92,14 +107,53 @@ export function assertTaskTransitionDocumentReady(input: {
   try {
     assertTransitionDocumentReady(kind, document.body);
   } catch (error) {
-    if (error && typeof error === "object")
+    if (error && typeof error === "object") {
+      const projectedMissing = transitionMissingSections(error),
+        diskBody = document.source === "canonical projection" ? readOnDiskBody(input.rootDir, document.path) : null,
+        diskDiffers = diskBody !== null && diskBody !== document.body,
+        actionableMissing = diskDiffers ? assessTransitionDocument(kind, diskBody).missingSections : projectedMissing,
+        revision =
+          document.source === "canonical projection"
+            ? `canonical projection document at workspace revision ${document.workspaceRevision}`
+            : `submitted candidate against canonical projection workspace revision ${document.workspaceRevision}`,
+        missing = missingSectionsHint(actionableMissing),
+        recovery = diskDiffers
+          ? `The on-disk harness/${document.path} differs; ${missing} ${
+              actionableMissing.length ? "Complete that content, then run" : "Run"
+            } ha doc sync --submit --path ${document.path}, then retry.`
+          : [
+              `${missing}`,
+              ` Edit harness/${document.path}, then run ha doc sync --submit --path ${document.path} and retry.`,
+            ].join("");
       Object.assign(error, {
         documentPath: document.path,
-        message: `${(error as Error).message} Edit harness/${document.path}, then retry.`,
+        missingSections: actionableMissing,
+        projectedMissingSections: projectedMissing,
+        message: `${String((error as { readonly code?: unknown }).code ?? "content_not_ready")}: ${kind} readiness judged the ${revision} (blob sha256 ${document.blobSha256}). ${recovery}`,
       });
+    }
     throw error;
   }
   return document;
+}
+
+function readOnDiskBody(rootDir: string, documentPath: string): string | null {
+  const target = path.join(resolveHarnessLayout(rootDir).authoredRoot, ...documentPath.split("/"));
+  return existsSync(target) && !lstatSync(target).isSymbolicLink() && lstatSync(target).isFile()
+    ? readFileSync(target, "utf8")
+    : null;
+}
+
+function transitionMissingSections(error: object): readonly string[] {
+  return "missingSections" in error && Array.isArray(error.missingSections)
+    ? error.missingSections.filter((value): value is string => typeof value === "string")
+    : [];
+}
+
+function missingSectionsHint(sections: readonly string[]): string {
+  return sections.length === 0
+    ? "it has no missing required sections."
+    : `its missing required ${sections.length === 1 ? "section is" : "sections are"}: ${sections.join(", ")}.`;
 }
 
 function transitionDocumentAccessError(code: string, message: string): Error {

--- a/packages/daemon/src/transition-document-access.ts
+++ b/packages/daemon/src/transition-document-access.ts
@@ -129,7 +129,11 @@ export function assertTaskTransitionDocumentReady(input: {
         documentPath: document.path,
         missingSections: actionableMissing,
         projectedMissingSections: projectedMissing,
-        message: `${String((error as { readonly code?: unknown }).code ?? "content_not_ready")}: ${kind} readiness judged the ${revision} (blob sha256 ${document.blobSha256}). ${recovery}`,
+        message: [
+          `${String((error as { readonly code?: unknown }).code ?? "content_not_ready")}:`,
+          `${kind} readiness judged the ${revision} (blob sha256 ${document.blobSha256}).`,
+          recovery,
+        ].join(" "),
       });
     }
     throw error;

--- a/packages/daemon/test/hitrate-task-lifecycle.integration.test.ts
+++ b/packages/daemon/test/hitrate-task-lifecycle.integration.test.ts
@@ -9,7 +9,7 @@ import { canonicalRoot, workspaceId } from "../src/protocol/daemon-protocol.cont
 import { openBootstrappedRepoCell as openRepoCell } from "./repo-settings.fixture.ts";
 import { withRoleBinding } from "./role-binding.fixtures.ts";
 import { git, initRepo } from "./task-surface.fixtures.ts";
-import { realizeTaskPlanFixture } from "../../../tools/fixtures/task-plan.mjs";
+import { realizedTaskPlan, realizeTaskPlanFixture } from "../../../tools/fixtures/task-plan.mjs";
 
 test("task start, inline submit, and code-doc reconcile reuse daemon-known lifecycle state", async () => {
   const parent = mkdtempSync(path.join(tmpdir(), "ha-hitrate-lifecycle-")),
@@ -57,12 +57,25 @@ test("task start, inline submit, and code-doc reconcile reuse daemon-known lifec
       holder,
     );
     assert.equal(fact.outcome, "applied", JSON.stringify(fact));
+    const packagePath = String((created as { readonly packagePath?: unknown }).packagePath),
+      planPath = `${packagePath}/task_plan.md`,
+      oneSectionMissing = realizedTaskPlan("Lifecycle hit rate").replace(
+        /\n\n## CI\/Gate Authority Stop Condition\n\n[^\n]+/u,
+        "",
+      );
+    writeFileSync(path.join(rootDir, "harness", planPath), oneSectionMissing);
     const placeholder = await cell.run({ kind: "task-start", taskId, executionId }, holder);
     assert.equal(placeholder.outcome, "op_rejected", JSON.stringify(placeholder));
     assert.equal(placeholder.code, "plan_placeholder");
-    assert.match(placeholder.nextAction ?? "", /task_plan\.md/u);
-    const packagePath = String((created as { readonly packagePath?: unknown }).packagePath),
-      closeoutPath = `${packagePath}/closeout.md`;
+    assert.match(
+      placeholder.nextAction ?? "",
+      /task\.plan readiness judged the canonical projection document at workspace revision \d+/u,
+    );
+    assert.match(placeholder.nextAction ?? "", /The on-disk harness\/tasks\/.*\/task_plan\.md differs/u);
+    assert.match(placeholder.nextAction ?? "", /missing required section is: CI\/Gate Authority Stop Condition/u);
+    assert.match(placeholder.nextAction ?? "", new RegExp(`ha doc sync --submit --path ${planPath}`, "u"));
+    assert.doesNotMatch(placeholder.nextAction ?? "", /missing required sections are: Brief/u);
+    const closeoutPath = `${packagePath}/closeout.md`;
     await realizeTaskPlanFixture(
       rootDir,
       packagePath,


### PR DESCRIPTION
# English

## Summary

`ha runtime run --task <id> --mission <name>` rejected a hand-written `artifacts/missions/<name>.md` as `runtime_mission_unavailable` while `ha doc sync` offered no route for it (fact F-67BCC803), and the `plan_placeholder` hint named all 14 sections when the on-disk plan lacked one because it judged an older ledger projection (F-C81C7166). Missions and plans are now consumed from the canonical projection through one route: `artifacts/missions/*.md` is a doc-sync candidate, so a hand-written mission is submitted like any other task document. Readiness failures name the judged source, workspace revision and blob SHA-256, and when the authored file differs from the projection the hint assesses the on-disk body and says to sync it.

## Architectural Justification

- Production-Delta as computed: one candidate rule plus hint fields; no disk-read bypass added (the center projection stays the single source).

## What Changed

- doc-sync candidate policy: `artifacts/missions/*.md`.
- runtime-spawn-mission / transition-document-access: revision-aware hints.
- tests for the two facts' scenarios.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: targeted daemon tests on the isolated target (report r1.md before/after CLI transcripts)
- Production net lines: use the single CI-backed `Production-Delta` declaration below; do not enter a second metric.

## Machine-Readable Declarations

Production-Delta: +70/-6
Dependency-Change: none

### Optional Evidence Claims

## Task And Scope

- Harness task: task_d0884a58b5c4511cb6f38e0972
- Branch: codex/mission-route
- Public scope: daemon mission resolution, doc-sync candidates, readiness hints
- Private planning/evidence updated: yes
- Out of scope: none

## Version Impact

- Version: no version change because pre-release internal change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none
- Authority: task_d0884a58b5c4511cb6f38e0972
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: origin/main
- Branch merge-base with `origin/main`: origin/main
- Last `git fetch origin` time: 2026-08-29T00:47Z
- Sync method: none needed
- Public diff command: `git diff origin/main...HEAD`
- Private evidence commit/path: harness task package task_d0884a58b5c4511cb6f38e0972 (artifacts/reports)
- Reviewer evidence path: same task package
- GitHub Actions `rewrite-ci` run URL: pending
- [x] Worker (Sol): before/after CLI transcripts for --mission and the hint; targeted tests green
- [x] CEO: both facts reproduced by hand on 2026-08-29 07:48–07:50 before filing
- [ ] CI on this PR
- [ ] `npm ci`
- [ ] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Not run: full local matrix by design; CI is the authority.

## Review Evidence

- Self-review: CEO chose the projection-as-source option over reading disk to keep one path.
- Reviewer subagent: Sol implemented; CEO acceptance.
- Human review: pending
- Blocking findings: none

## Residual Risk

- A mission edited on disk but not synced is still rejected — by design; the hint now says exactly that.

## References

- Task: task_d0884a58b5c4511cb6f38e0972
- Evidence: task package artifacts/reports
- Review: this PR

---

# 中文

## 概要

`ha runtime run --task <id> --mission <name>` 对手写的 `artifacts/missions/<name>.md` 报 `runtime_mission_unavailable`,而 `ha doc sync` 没有它的路由(fact F-67BCC803);`plan_placeholder` 提示在磁盘 plan 只缺一节时列出全部 14 节,因为它判的是旧的台账投影(F-C81C7166)。现在 mission 与 plan 都经唯一路由从 canonical 投影消费:`artifacts/missions/*.md` 成为 doc-sync 候选,手写 mission 像其它任务文档一样提交。就绪失败会写明所判来源、workspace revision 与 blob SHA-256;磁盘文件与投影不同时,提示改判磁盘正文并指示同步。

## 架构辩护

- Production-Delta 实算:一条候选规则加提示字段;不加读磁盘旁路(中心投影仍是唯一来源)。

## 改动内容

- doc-sync 候选策略:`artifacts/missions/*.md`。
- runtime-spawn-mission / transition-document-access:带 revision 的提示。
- 两个 fact 场景的测试。

## 门收割 / Gate Harvest

- 删除的生产路径:无
- 同 commit 删除的门 / fixture:隔离目标定向 daemon 测试(报告 r1.md 含前后 CLI 记录)
- 生产净行数:引用英文块中的 `Production-Delta`。

## 机读声明说明

- 见英文块。

## 任务与范围

- Harness 任务:task_d0884a58b5c4511cb6f38e0972
- 分支:codex/mission-route
- 公开范围:daemon mission 解析、doc-sync 候选、就绪提示
- 私有计划 / 证据是否已更新:yes
- 范围外:无

## 版本影响

- 版本:不改版本,原因是预发布内部改动
- 发布影响:不发布

## 治理声明

- 是否触碰 protected surface:no
- protected surface 范围:none
- 依据:task_d0884a58b5c4511cb6f38e0972
- 机器检查边界:本 PR 只声明该段存在;是否真实、充分由 reviewer 判断。
- Break-glass:no
- Break-glass 原因:不适用
- Break-glass 范围:不适用
- 后续治理任务:不适用

## 验证

- `origin/main` 基准 SHA:origin/main
- 当前分支与 `origin/main` 的 merge-base:origin/main
- 最近一次 `git fetch origin` 时间:2026-08-29T00:47Z
- 同步方式:不需要
- 公开 diff 命令:`git diff origin/main...HEAD`
- 私有证据 commit/path:harness 任务包 task_d0884a58b5c4511cb6f38e0972
- Reviewer 证据路径:同上
- GitHub Actions `rewrite-ci` run URL:待定
- [x] worker(Sol):--mission 与提示的前后 CLI 记录;定向测试绿
- [x] CEO:立件前于 07:48–07:50 手动复现两个 fact
- [ ] 本 PR 的 CI
- [ ] `npm ci`
- [ ] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- 未运行:按设计不跑本地全量;以 CI 为权威。

## 审查证据

- 自查:CEO 选「投影为唯一来源」而非读磁盘,保持单路径。
- Reviewer subagent:Sol 实现;CEO 验收。
- 人工审查:待定
- 阻塞发现:无

## 残余风险

- 磁盘改了没同步的 mission 仍被拒——这是设计;提示现在明说。

## 关联材料

- 任务:task_d0884a58b5c4511cb6f38e0972
- 证据:任务包 artifacts/reports
- 审查:本 PR
