### PR TITLE
refactor(daemon,gui): typed DaemonRpcMethodMap RPC contract (PLT-Bedrock C1)

### DIFF
--- a/packages/daemon/src/protocol/daemon-protocol-gui-types.ts
+++ b/packages/daemon/src/protocol/daemon-protocol-gui-types.ts
@@ -55,14 +55,14 @@ export type RpcShape = {
   readonly open?: boolean;
 };
 
-export const shape = (fields: RpcShape["fields"], open = false): RpcShape => ({
+export const shape = <const Fields extends RpcShape["fields"]>(fields: Fields, open = false) => ({
   fields,
   open,
 });
 
-export const optionalEnum = (values: readonly string[]): RpcEnumRule => ({
+export const optionalEnum = <const Values extends readonly string[]>(values: Values) => ({
   values,
-  optional: true,
+  optional: true as const,
 });
 
 export const observeTailKinds = ["events", "repo-log", "daemon-log", "dispatch"] as const;

--- a/packages/daemon/src/protocol/daemon-protocol-gui-types.ts
+++ b/packages/daemon/src/protocol/daemon-protocol-gui-types.ts
@@ -24,7 +24,7 @@ import type { SchedulesListResult } from "./schedules-gui-contract.ts";
 import type { ScheduleRunsResult } from "../schedule-runs-read.ts";
 import type { daemonGuiActionMethods } from "./daemon-protocol-gui-actions.ts";
 import { taskStatusWords } from "./daemon-protocol-vocabulary.ts";
-import { isJsonObject, type JsonObject } from "./json-rpc-types.ts";
+import { isJsonObject, unknownFieldViolation, type JsonObject } from "./json-rpc-types.ts";
 
 type TaskProjectionListRow = ReturnType<TaskProjection["list"]>["rows"][number];
 type TaskProjectionWarning = ReturnType<TaskProjection["list"]>["warnings"][number];
@@ -64,6 +64,52 @@ export const optionalEnum = <const Values extends readonly string[]>(values: Val
   values,
   optional: true as const,
 });
+
+export function validateShape(value: unknown, expected: RpcShape, prefix: string): string[] {
+  if (!isJsonObject(value)) return [`${prefix} must be an object`];
+  const errors: string[] = [],
+    allowed = Object.keys(expected.fields);
+  if (!expected.open)
+    for (const field of Object.keys(value)) {
+      const unknownField = unknownFieldViolation({ [field]: value[field] }, allowed);
+      if (unknownField) errors.push(`${prefix} contains an ${unknownField}`);
+    }
+  for (const [field, rule] of Object.entries(expected.fields)) {
+    const item = value[field],
+      enumRule = "values" in Object(rule) ? (rule as RpcEnumRule) : null;
+    if (
+      ((rule === "string?" ||
+        rule === "string-null?" ||
+        rule === "json?" ||
+        rule === "array?" ||
+        rule === "boolean?" ||
+        rule === "number?" ||
+        enumRule?.optional) &&
+        item === undefined) ||
+      (rule === "string-null?" && item === null)
+    )
+      continue;
+    if (enumRule) {
+      if (!enumRule.values.includes(String(item)))
+        errors.push(`${prefix}.${field} must be one of ${enumRule.values.join(", ")}`);
+    } else if (rule === "json" || rule === "json?") {
+      if (!isJsonObject(item)) errors.push(`${prefix}.${field} must be object`);
+    } else if (rule === "array" || rule === "array?") {
+      if (!Array.isArray(item)) errors.push(`${prefix}.${field} must be array`);
+    } else if (
+      rule === "string" ||
+      rule === "string?" ||
+      rule === "string-null?" ||
+      rule === "number" ||
+      rule === "number?" ||
+      rule === "boolean?"
+    ) {
+      const type = rule.startsWith("string") ? "string" : rule === "boolean?" ? "boolean" : "number";
+      if (typeof item !== type || (type === "string" && !item)) errors.push(`${prefix}.${field} must be ${type}`);
+    } else errors.push(...validateShape(item, rule as RpcShape, `${prefix}.${field}`));
+  }
+  return errors;
+}
 
 export const observeTailKinds = ["events", "repo-log", "daemon-log", "dispatch"] as const;
 export type ObserveTailKind = (typeof observeTailKinds)[number];

--- a/packages/daemon/src/protocol/daemon-protocol-rpc-validation.ts
+++ b/packages/daemon/src/protocol/daemon-protocol-rpc-validation.ts
@@ -1,12 +1,11 @@
 import { daemonGuiActionMethods, daemonStreamFacets } from "./daemon-protocol-gui-actions.ts";
 import { daemonGuiReadMethods } from "./daemon-protocol-gui-reads.ts";
 import {
+  validateShape,
   validateObserveTailPayload,
   type DaemonGuiActionMethod,
   type DaemonGuiRpcReadMethod,
   type DaemonStreamMethod,
-  type RpcEnumRule,
-  type RpcShape,
 } from "./daemon-protocol-gui-types.ts";
 import {
   digest,
@@ -48,11 +47,6 @@ export function isDaemonGuiActionMethod(method: string): method is DaemonGuiActi
 export function isDaemonStreamMethod(method: string): method is DaemonStreamMethod {
   return daemonStreamFacets.some((entry) => entry.method === method);
 }
-
-export function isDaemonRpcMethod(method: string): method is DaemonRpcMethod {
-  return allDaemonProtocolMethods.some((entry) => entry.method === method);
-}
-
 // The executor declaration surface, derived from the same shapes validateDaemonRpcCall enforces — never
 // a hand-copied method list. repo.task.run accepts the executor inside its open action envelope; every
 // other method accepts payload.executor exactly when its payload shape declares the field (the preset
@@ -247,79 +241,27 @@ export type ParsedDaemonRpcParams<Method extends DaemonRpcMethod> =
     }
   | { readonly ok: false; readonly errors: readonly string[] };
 
-export function parseDaemonRpcParams<Method extends DaemonRpcMethod>(
-  method: Method,
-  params: unknown,
-): ParsedDaemonRpcParams<Method>;
-export function parseDaemonRpcParams(
-  method: string,
-  params: unknown,
-):
-  | { readonly ok: true; readonly params: JsonObject; readonly call: DaemonRpcCall }
-  | { readonly ok: false; readonly errors: readonly string[] };
-export function parseDaemonRpcParams(
-  method: string,
-  params: unknown,
-):
-  | { readonly ok: true; readonly params: JsonObject; readonly call: DaemonRpcCall }
-  | { readonly ok: false; readonly errors: readonly string[] } {
+export interface ParseDaemonRpcParams {
+  <Method extends DaemonRpcMethod>(method: Method, params: unknown): ParsedDaemonRpcParams<Method>;
+  (
+    method: string,
+    params: unknown,
+  ):
+    | { readonly ok: true; readonly params: JsonObject; readonly call: DaemonRpcCall }
+    | { readonly ok: false; readonly errors: readonly string[] };
+}
+
+export const parseDaemonRpcParams = ((method: string, params: unknown) => {
   const candidateParams = params === undefined ? {} : params,
     errors = validateDaemonRpcCall({ method, params: candidateParams });
   if (errors.length) return { ok: false, errors };
-  if (!isDaemonRpcMethod(method)) return { ok: false, errors: ["RPC method is not contracted"] };
   const typedParams = candidateParams as DaemonRpcWireParams<DaemonRpcMethod>;
   return {
     ok: true,
     params: typedParams,
     call: { method, params: typedParams } as DaemonRpcCall,
   };
-}
-
-export function validateShape(value: unknown, expected: RpcShape, prefix: string): string[] {
-  if (!isJsonObject(value)) return [`${prefix} must be an object`];
-  const errors: string[] = [],
-    allowed = Object.keys(expected.fields);
-  if (!expected.open)
-    for (const field of Object.keys(value)) {
-      const unknownField = unknownFieldViolation({ [field]: value[field] }, allowed);
-      if (unknownField) errors.push(`${prefix} contains an ${unknownField}`);
-    }
-  for (const [field, rule] of Object.entries(expected.fields)) {
-    const item = value[field],
-      enumRule = "values" in Object(rule) ? (rule as RpcEnumRule) : null;
-    if (
-      ((rule === "string?" ||
-        rule === "string-null?" ||
-        rule === "json?" ||
-        rule === "array?" ||
-        rule === "boolean?" ||
-        rule === "number?" ||
-        enumRule?.optional) &&
-        item === undefined) ||
-      (rule === "string-null?" && item === null)
-    )
-      continue;
-    if (enumRule) {
-      if (!enumRule.values.includes(String(item)))
-        errors.push(`${prefix}.${field} must be one of ${enumRule.values.join(", ")}`);
-    } else if (rule === "json" || rule === "json?") {
-      if (!isJsonObject(item)) errors.push(`${prefix}.${field} must be object`);
-    } else if (rule === "array" || rule === "array?") {
-      if (!Array.isArray(item)) errors.push(`${prefix}.${field} must be array`);
-    } else if (
-      rule === "string" ||
-      rule === "string?" ||
-      rule === "string-null?" ||
-      rule === "number" ||
-      rule === "number?" ||
-      rule === "boolean?"
-    ) {
-      const type = rule.startsWith("string") ? "string" : rule === "boolean?" ? "boolean" : "number";
-      if (typeof item !== type || (type === "string" && !item)) errors.push(`${prefix}.${field} must be ${type}`);
-    } else errors.push(...validateShape(item, rule as RpcShape, `${prefix}.${field}`));
-  }
-  return errors;
-}
+}) as ParseDaemonRpcParams;
 
 export function validateGuiActionPayload(method: DaemonGuiActionMethod, value: unknown): string[] {
   if (!isJsonObject(value)) return ["GUI action payload must be an object"];

--- a/packages/daemon/src/protocol/daemon-protocol-rpc-validation.ts
+++ b/packages/daemon/src/protocol/daemon-protocol-rpc-validation.ts
@@ -18,7 +18,12 @@ import {
   validateGuiSubmission,
 } from "./daemon-protocol-validate-entities.ts";
 import { validateCatalogActionPayload, validateSessionEnvironment } from "./daemon-protocol-validate-task.ts";
-import { allDaemonProtocolMethods } from "./daemon-protocol.contract.ts";
+import {
+  allDaemonProtocolMethods,
+  type DaemonRpcCall,
+  type DaemonRpcMethod,
+  type DaemonRpcWireParams,
+} from "./daemon-protocol.contract.ts";
 import { decisionStateWords, relationStateWords, taskStatusWords } from "./daemon-protocol-vocabulary.ts";
 import {
   DaemonProtocolContractError,
@@ -44,13 +49,18 @@ export function isDaemonStreamMethod(method: string): method is DaemonStreamMeth
   return daemonStreamFacets.some((entry) => entry.method === method);
 }
 
+export function isDaemonRpcMethod(method: string): method is DaemonRpcMethod {
+  return allDaemonProtocolMethods.some((entry) => entry.method === method);
+}
+
 // The executor declaration surface, derived from the same shapes validateDaemonRpcCall enforces — never
 // a hand-copied method list. repo.task.run accepts the executor inside its open action envelope; every
 // other method accepts payload.executor exactly when its payload shape declares the field (the preset
 // methods and repo.agentRuntime.spawn do). The CLI injects on this predicate, so a newly contracted
 // command that does not declare executor is simply never injected into.
 export function daemonMethodAcceptsPayloadExecutor(method: string): boolean {
-  const payload = allDaemonProtocolMethods.find((entry) => entry.method === method)?.params.fields.payload;
+  const fields = allDaemonProtocolMethods.find((entry) => entry.method === method)?.params.fields,
+    payload = fields && "payload" in fields ? fields.payload : undefined;
   return (
     typeof payload === "object" && payload !== null && "fields" in payload && Object.hasOwn(payload.fields, "executor")
   );
@@ -229,13 +239,40 @@ export function validateTaskDispatchesPayload(value: unknown): string[] {
   return [];
 }
 
+export type ParsedDaemonRpcParams<Method extends DaemonRpcMethod> =
+  | {
+      readonly ok: true;
+      readonly params: DaemonRpcWireParams<Method>;
+      readonly call: DaemonRpcCall<Method>;
+    }
+  | { readonly ok: false; readonly errors: readonly string[] };
+
+export function parseDaemonRpcParams<Method extends DaemonRpcMethod>(
+  method: Method,
+  params: unknown,
+): ParsedDaemonRpcParams<Method>;
 export function parseDaemonRpcParams(
   method: string,
   params: unknown,
-): { readonly ok: true; readonly params: JsonObject } | { readonly ok: false; readonly errors: readonly string[] } {
+):
+  | { readonly ok: true; readonly params: JsonObject; readonly call: DaemonRpcCall }
+  | { readonly ok: false; readonly errors: readonly string[] };
+export function parseDaemonRpcParams(
+  method: string,
+  params: unknown,
+):
+  | { readonly ok: true; readonly params: JsonObject; readonly call: DaemonRpcCall }
+  | { readonly ok: false; readonly errors: readonly string[] } {
   const candidateParams = params === undefined ? {} : params,
     errors = validateDaemonRpcCall({ method, params: candidateParams });
-  return errors.length ? { ok: false, errors } : { ok: true, params: candidateParams as JsonObject };
+  if (errors.length) return { ok: false, errors };
+  if (!isDaemonRpcMethod(method)) return { ok: false, errors: ["RPC method is not contracted"] };
+  const typedParams = candidateParams as DaemonRpcWireParams<DaemonRpcMethod>;
+  return {
+    ok: true,
+    params: typedParams,
+    call: { method, params: typedParams } as DaemonRpcCall,
+  };
 }
 
 export function validateShape(value: unknown, expected: RpcShape, prefix: string): string[] {

--- a/packages/daemon/src/protocol/daemon-protocol.contract.ts
+++ b/packages/daemon/src/protocol/daemon-protocol.contract.ts
@@ -1,9 +1,12 @@
 import { presetMethods } from "../../../preset/src/preset-command-contract.ts";
 import type { ContractVersion } from "../../../kernel/src/domain/contract-version.ts";
+import type { FleetTaskAction } from "../fleet/contract.ts";
 import { daemonOwnedProtocolCommands } from "./daemon-protocol-commands.ts";
 import { daemonGuiActionMethods, daemonStreamFacets } from "./daemon-protocol-gui-actions.ts";
 import { daemonGuiReadMethods } from "./daemon-protocol-gui-reads.ts";
-import { optionalEnum, shape } from "./daemon-protocol-gui-types.ts";
+import type { DaemonSessionEnvironment } from "./daemon-protocol-identifiers.ts";
+import { optionalEnum, shape, type RpcEnumRule, type RpcShape } from "./daemon-protocol-gui-types.ts";
+import type { JsonObject, JsonValue } from "./json-rpc-types.ts";
 import { daemonGuiActionSchemas, daemonGuiReadSchemas } from "./daemon-protocol-schema-registry.ts";
 import {
   daemonRepoModeWords,
@@ -351,6 +354,209 @@ export const allDaemonProtocolMethods = Object.freeze([
   ...daemonStreamFacets,
 ]);
 
+type DaemonRpcDescriptor = (typeof allDaemonProtocolMethods)[number];
+export type DaemonRpcMethod = DaemonRpcDescriptor["method"];
+
+type RpcOptionalRule = "string?" | "string-null?" | "json?" | "array?" | "boolean?" | "number?";
+type RpcOptionalKeys<Fields extends RpcShape["fields"]> = {
+  readonly [Key in keyof Fields]-?: Fields[Key] extends RpcOptionalRule | { readonly optional: true } ? Key : never;
+}[keyof Fields];
+type RpcRequiredKeys<Fields extends RpcShape["fields"]> = Exclude<keyof Fields, RpcOptionalKeys<Fields>>;
+type RpcRuleValue<Rule> = Rule extends RpcShape
+  ? RpcParamsFromShape<Rule>
+  : Rule extends "string" | "string?" | "string-null?"
+    ? Rule extends "string-null?"
+      ? string | null
+      : string
+    : Rule extends "number" | "number?"
+      ? number
+      : Rule extends "boolean?"
+        ? boolean
+        : Rule extends "json" | "json?"
+          ? JsonObject
+          : Rule extends "array" | "array?"
+            ? ReadonlyArray<JsonValue>
+            : Rule extends RpcEnumRule
+              ? Rule["values"][number]
+              : never;
+
+/** Compile-time counterpart of the runtime RpcShape validator. */
+export type RpcParamsFromShape<Shape extends RpcShape> = Readonly<
+  { [Key in RpcRequiredKeys<Shape["fields"]>]: RpcRuleValue<Shape["fields"][Key]> } & {
+    [Key in RpcOptionalKeys<Shape["fields"]>]?: RpcRuleValue<Shape["fields"][Key]>;
+  }
+>;
+
+type DescriptorParams<Method extends DaemonRpcMethod, Descriptor = DaemonRpcDescriptor> = Descriptor extends {
+  readonly method: infer Methods;
+  readonly params: infer Params extends RpcShape;
+}
+  ? Method extends Methods
+    ? RpcParamsFromShape<Params>
+    : never
+  : never;
+
+type DaemonFleetChannelPayload = {
+  readonly host: string;
+  readonly port: number;
+  readonly caPath: string;
+  readonly servername?: string;
+  readonly nodeId: string;
+  readonly credential?: string;
+  readonly rosterPath?: string;
+  readonly assignmentId: string;
+  readonly repoId: string;
+  readonly viewRoot: string;
+  readonly quotaBytes: number;
+};
+export type DaemonFleetTaskAction = FleetTaskAction;
+type DaemonFleetTaskPayload = DaemonFleetChannelPayload & {
+  readonly workspaceRoot?: string;
+  readonly waitTimeoutMs?: number;
+  readonly action:
+    | DaemonFleetTaskAction
+    | {
+        readonly kind: "fleet-runtime";
+        readonly method:
+          | "repo.agentRuntime.spawn"
+          | "repo.agentRuntime.cancel"
+          | "repo.agentRuntime.overview"
+          | "repo.agentRuntime.sessions.read";
+        readonly payload: JsonObject;
+      }
+    | { readonly kind: "fleet-schedule"; readonly payload: JsonObject };
+};
+type DaemonFleetDocSyncPayload = DaemonFleetChannelPayload & {
+  readonly workspaceRoot: string;
+  readonly dryRun?: boolean;
+  readonly paths?: readonly string[];
+  readonly timeoutMs?: number;
+};
+type DaemonFleetConflictExitPayload = DaemonFleetChannelPayload & {
+  readonly workspaceRoot: string;
+  readonly action: "resolve" | "discard-local" | "overwrite-center";
+  readonly conflictId: string;
+};
+
+type DaemonRpcParamOverrides = {
+  readonly "protocol.hello": {
+    readonly protocolVersion: ContractVersion;
+    readonly sessionEnvironment?: DaemonSessionEnvironment;
+  };
+  readonly "daemon.fleet.task.run": { readonly payload: DaemonFleetTaskPayload };
+  readonly "daemon.fleet.doc.sync": { readonly payload: DaemonFleetDocSyncPayload };
+  readonly "daemon.fleet.conflict.exit": { readonly payload: DaemonFleetConflictExitPayload };
+};
+
+type RepoRpcParams<Payload> = {
+  readonly repo: { readonly repoId: string };
+  readonly payload: Payload;
+};
+type PresetRpcMethod = (typeof presetMethods)[number]["method"];
+type DaemonGuiReadParams<Method extends keyof import("./daemon-protocol-gui-types.ts").DaemonGuiReadPayloadMap> =
+  Method extends "daemon.gui.system.read"
+    ? Readonly<Record<string, never>>
+    : Method extends "daemon.gui.control.receipt"
+      ? { readonly payload: import("./daemon-protocol-gui-types.ts").DaemonGuiReadPayloadMap[Method] }
+      : import("./daemon-protocol-gui-types.ts").DaemonGuiReadPayloadMap[Method] extends Readonly<Record<string, never>>
+        ? { readonly repo: { readonly repoId: string } }
+        : RepoRpcParams<import("./daemon-protocol-gui-types.ts").DaemonGuiReadPayloadMap[Method]>;
+
+type DaemonRpcParamsFor<Method extends DaemonRpcMethod> = Method extends keyof DaemonRpcParamOverrides
+  ? DaemonRpcParamOverrides[Method]
+  : Method extends keyof import("./daemon-protocol-gui-types.ts").DaemonStreamPayloadMap
+    ? RepoRpcParams<import("./daemon-protocol-gui-types.ts").DaemonStreamPayloadMap[Method]>
+    : Method extends keyof import("./daemon-protocol-gui-types.ts").DaemonGuiReadPayloadMap
+      ? DaemonGuiReadParams<Method>
+      : Method extends PresetRpcMethod
+        ? RepoRpcParams<JsonObject>
+        : DescriptorParams<Method>;
+
+export interface DaemonProtocolHelloResult {
+  readonly ok: true;
+  readonly protocolVersion: ContractVersion;
+  readonly methods: readonly DaemonRpcMethod[];
+  readonly build: { readonly commit: string | null };
+}
+
+export interface DaemonStopResult {
+  readonly ok: true;
+  readonly command: "daemon-stop";
+  readonly pid: number;
+}
+
+export interface DaemonStatusResult {
+  readonly ok: true;
+  readonly daemonId: string;
+  readonly pid: number;
+  readonly startedAt: string;
+  readonly build: {
+    readonly version: string;
+    readonly commit: string | null;
+    readonly loadedBuildId: string | null;
+    readonly diskBuildId: string | null;
+    readonly drifted: boolean;
+  };
+  readonly repos: readonly {
+    readonly repoId: string;
+    readonly rootDir: string;
+    readonly mode: "local" | "remote-center" | "remote-edge" | null;
+    readonly state: "warming" | "attached" | "unavailable" | "closed";
+    readonly generation: number | null;
+    readonly queueDepth: number | null;
+    readonly lastError: string | null;
+    readonly causeClass: "data-shape" | "infrastructure" | "projection" | null;
+    readonly recoveryMs: number | null;
+  }[];
+  readonly summary: string;
+}
+
+type DaemonRpcSuccessResult<Method extends DaemonRpcMethod> =
+  Method extends keyof import("./daemon-protocol-gui-types.ts").DaemonGuiReadResultMap
+    ? import("./daemon-protocol-gui-types.ts").DaemonGuiReadResultMap[Method]
+    : Method extends keyof import("./daemon-protocol-gui-types.ts").DaemonStreamResultMap
+      ? import("./daemon-protocol-gui-types.ts").DaemonStreamResultMap[Method]
+      : Method extends "protocol.hello"
+        ? DaemonProtocolHelloResult
+        : Method extends "daemon.status"
+          ? DaemonStatusResult
+          : Method extends "daemon.stop"
+            ? DaemonStopResult
+            : Method extends "repo.preset.run.start" | "repo.preset.run.status"
+              ? object
+              : Method extends import("./daemon-protocol-gui-types.ts").DaemonGuiActionMethod
+                ? import("./daemon-protocol-gui-types.ts").DaemonGuiActionResult
+                : Readonly<Record<string, unknown>>;
+
+/**
+ * Authoritative method dictionary shared by the daemon dispatcher and every client.
+ * Runtime validation remains the trust boundary; this map preserves its method/params/result
+ * correlation through TypeScript instead of erasing it to JsonObject.
+ */
+export type DaemonRpcMethodMap = {
+  readonly [Method in DaemonRpcMethod]: {
+    readonly params: DaemonRpcParamsFor<Method>;
+    readonly result:
+      | DaemonRpcSuccessResult<Method>
+      | import("./daemon-protocol-gui-types.ts").DaemonProtocolErrorResult;
+  };
+};
+
+export type DaemonRpcParams<Method extends DaemonRpcMethod> = DaemonRpcMethodMap[Method]["params"];
+export type DaemonRpcResult<Method extends DaemonRpcMethod> = DaemonRpcMethodMap[Method]["result"];
+
+/** Parsed values are JSON-compatible at every nested object boundary. */
+export type DaemonRpcWireValue<Value> =
+  Value extends ReadonlyArray<infer Item>
+    ? ReadonlyArray<DaemonRpcWireValue<Item>>
+    : Value extends object
+      ? Value & JsonObject & { readonly [Key in keyof Value]: DaemonRpcWireValue<Value[Key]> }
+      : Value;
+export type DaemonRpcWireParams<Method extends DaemonRpcMethod> = DaemonRpcWireValue<DaemonRpcParams<Method>>;
+export type DaemonRpcCall<Method extends DaemonRpcMethod = DaemonRpcMethod> = Method extends DaemonRpcMethod
+  ? { readonly method: Method; readonly params: DaemonRpcWireParams<Method> }
+  : never;
+
 export const DAEMON_RPC_SCHEMA = Object.freeze({
   id: "w3-daemon-rpc/v1",
   methods: allDaemonProtocolMethods.map(({ method, params }) => ({ method, params })),
@@ -490,6 +696,7 @@ export {
   DaemonProtocolContractError,
   isDaemonGuiActionMethod,
   isDaemonGuiReadMethod,
+  isDaemonRpcMethod,
   isDaemonStreamMethod,
   parseDaemonRpcParams,
   serializeDaemonRpcCall,

--- a/packages/daemon/src/protocol/daemon-protocol.contract.ts
+++ b/packages/daemon/src/protocol/daemon-protocol.contract.ts
@@ -696,7 +696,6 @@ export {
   DaemonProtocolContractError,
   isDaemonGuiActionMethod,
   isDaemonGuiReadMethod,
-  isDaemonRpcMethod,
   isDaemonStreamMethod,
   parseDaemonRpcParams,
   serializeDaemonRpcCall,

--- a/packages/daemon/src/protocol/gui-result-validation.ts
+++ b/packages/daemon/src/protocol/gui-result-validation.ts
@@ -139,11 +139,14 @@ export function parseDaemonGuiActionResponse(
   value: unknown,
 ): DaemonGuiActionResult | DaemonProtocolErrorResult {
   if (isJsonObject(value) && value.opId === "N/A") {
-    const errors = validateDaemonProtocolError(value);
-    if (errors.length) throw new DaemonProtocolContractError("invalid_result", errors.join("; "));
-    return value as unknown as DaemonProtocolErrorResult;
+    if (!isDaemonProtocolErrorResult(value))
+      throw new DaemonProtocolContractError("invalid_result", validateDaemonProtocolError(value).join("; "));
+    return value;
   }
   return parseDaemonGuiActionResult(method, value);
+}
+function isDaemonProtocolErrorResult(value: unknown): value is DaemonProtocolErrorResult {
+  return validateDaemonProtocolError(value).length === 0;
 }
 export function parseDaemonStreamResult<M extends DaemonStreamMethod>(
   method: M,

--- a/packages/daemon/src/protocol/json-rpc-dispatch-support.ts
+++ b/packages/daemon/src/protocol/json-rpc-dispatch-support.ts
@@ -1,0 +1,93 @@
+import type { DaemonRequestLogEntry } from "../request-log.ts";
+import {
+  isDaemonGuiActionMethod,
+  isDaemonGuiReadMethod,
+  isDaemonStreamMethod,
+  type DaemonGuiActionMethod,
+  type DaemonGuiRpcReadMethod,
+  type DaemonRpcCall,
+  type DaemonRpcMethod,
+  type DaemonStreamMethod,
+} from "./daemon-protocol.contract.ts";
+import { isJsonObject, type JsonObject, type JsonRpcId, type JsonRpcResponse } from "./json-rpc-types.ts";
+
+type DaemonRpcCallFor<Method extends DaemonRpcMethod> = Extract<DaemonRpcCall, { readonly method: Method }>;
+type RuntimeInstanceMethod = Extract<DaemonRpcMethod, `daemon.runtimeInstance.${string}`>;
+type RuntimeInstanceAuthMethod = Extract<DaemonRpcMethod, `repo.runtimeInstance.auth.${string}`>;
+type RepoGuiReadMethod = Exclude<DaemonGuiRpcReadMethod, "daemon.gui.system.read" | "daemon.gui.control.receipt">;
+type TerminalActionMethod = "repo.gui.catalog.reread" | Extract<DaemonGuiActionMethod, `repo.terminal.${string}`>;
+type WithRepoPayload<Call> = Call extends {
+  readonly params: {
+    readonly repo: { readonly repoId: string };
+    readonly payload: JsonObject;
+  };
+}
+  ? Call
+  : never;
+export type DaemonRepoPayloadCall = WithRepoPayload<DaemonRpcCall>;
+
+export function isRuntimeInstanceCall(call: DaemonRpcCall): call is DaemonRpcCallFor<RuntimeInstanceMethod> {
+  return call.method.startsWith("daemon.runtimeInstance.");
+}
+export function isRuntimeInstanceAuthCall(call: DaemonRpcCall): call is DaemonRpcCallFor<RuntimeInstanceAuthMethod> {
+  return call.method.startsWith("repo.runtimeInstance.auth.");
+}
+export function isDaemonStreamCall(call: DaemonRpcCall): call is DaemonRpcCallFor<DaemonStreamMethod> {
+  return isDaemonStreamMethod(call.method);
+}
+export function isRepoGuiReadCall(call: DaemonRpcCall): call is DaemonRpcCallFor<RepoGuiReadMethod> {
+  return (
+    isDaemonGuiReadMethod(call.method) &&
+    call.method !== "daemon.gui.system.read" &&
+    call.method !== "daemon.gui.control.receipt"
+  );
+}
+export function isTerminalActionCall(call: DaemonRpcCall): call is DaemonRpcCallFor<TerminalActionMethod> {
+  return (
+    call.method === "repo.gui.catalog.reread" ||
+    (isDaemonGuiActionMethod(call.method) && call.method.startsWith("repo.terminal."))
+  );
+}
+export function repoIdFromParams(params: JsonObject): string {
+  const repo = params.repo;
+  return isJsonObject(repo) && typeof repo.repoId === "string" ? repo.repoId : "";
+}
+// The executor rides on the resolved action, which is where the daemon reads it for attribution:
+// repo.task.run carries it inside payload.action, every other method merges payload into the action.
+export function declaredExecutorOrNull(action: JsonObject): DaemonRequestLogEntry["executor"] {
+  const executor = action.executor;
+  return isJsonObject(executor) && executor.kind === "agent" && typeof executor.id === "string"
+    ? { kind: "agent", id: executor.id }
+    : null;
+}
+export function resultOk(result: object): boolean {
+  return "ok" in result && result.ok === true;
+}
+export function resultErrorCode(result: object): string | null {
+  if ("code" in result && typeof result.code === "string") return result.code;
+  const error = "error" in result ? result.error : undefined;
+  return isJsonObject(error) && typeof error.code === "string" ? error.code : null;
+}
+export function rpcError(id: JsonRpcId, errorCode: number, message: string): JsonRpcResponse {
+  return { jsonrpc: "2.0", id, error: { code: errorCode, message } };
+}
+export function rpcServerErrorCode(error: unknown): string {
+  return typeof error === "object" && error !== null && "code" in error && typeof error.code === "string"
+    ? error.code
+    : "bootstrap_failed";
+}
+
+type ProtocolDispatchError =
+  | { readonly _tag: "NativeError"; readonly message: string }
+  | { readonly _tag: "UnknownThrownValue"; readonly message: string };
+
+export function protocolErrorMessage(error: unknown): string {
+  let normalized: ProtocolDispatchError;
+  if (error instanceof Error) normalized = { _tag: "NativeError", message: error.message };
+  else normalized = { _tag: "UnknownThrownValue", message: String(error) };
+  switch (normalized._tag) {
+    case "NativeError":
+    case "UnknownThrownValue":
+      return normalized.message;
+  }
+}

--- a/packages/daemon/src/protocol/json-rpc-server.ts
+++ b/packages/daemon/src/protocol/json-rpc-server.ts
@@ -1,7 +1,5 @@
 import { randomUUID } from "node:crypto";
 import type { DaemonHost } from "../daemon-host.ts";
-import type { FleetEdgeTaskRequest } from "../fleet-edge-task.ts";
-import type { FleetEdgeConflictExitRequest, FleetEdgeDocSyncRequest } from "../fleet-edge-doc-sync.ts";
 import type { DaemonRequestLogEntry } from "../request-log.ts";
 import type { DaemonTrafficLogEntry } from "../conn-log.ts";
 import type { DaemonAuthenticationContext } from "../transport/auth-context.ts";
@@ -11,11 +9,18 @@ import {
   daemonProtocolError,
   isDaemonGuiActionMethod,
   isDaemonGuiReadMethod,
+  isDaemonRpcMethod,
   isDaemonStreamMethod,
   jsonRpcMethodContracts,
   makeDaemonCommandReceipt,
   parseDaemonRpcParams,
-  type DaemonSessionEnvironment,
+  type DaemonFleetTaskAction,
+  type DaemonGuiActionMethod,
+  type DaemonGuiRpcReadMethod,
+  type DaemonRpcCall,
+  type DaemonRpcMethod,
+  type DaemonRpcResult,
+  type DaemonStreamMethod,
 } from "./daemon-protocol.contract.ts";
 import {
   parseDaemonGuiActionResult,
@@ -77,36 +82,38 @@ export function createJsonRpcProtocolServer(options: {
       traffic(typeof request.method === "string" ? request.method : null, startedAt, 0, false, "-32600");
       return rpcError(id, -32600, "Invalid Request");
     }
-    if (!jsonRpcMethodContracts.some((entry) => entry.method === request.method)) {
+    if (!isDaemonRpcMethod(request.method)) {
       traffic(request.method, startedAt, 0, false, "-32601");
       return rpcError(id, -32601, "Method not found");
     }
-    const reply = (result: JsonObject): JsonRpcResponse | undefined => {
+    const reply = <Method extends DaemonRpcMethod>(
+      method: Method,
+      result: DaemonRpcResult<Method>,
+    ): JsonRpcResponse | undefined => {
       const durationMs = Date.now() - startedAt;
-      record(request.method, observed, result, durationMs);
-      traffic(request.method, startedAt, durationMs, result.ok === true, resultErrorCode(result));
+      record(method, observed, result, durationMs);
+      traffic(method, startedAt, durationMs, resultOk(result), resultErrorCode(result));
       return request.id === undefined ? undefined : { jsonrpc: "2.0", id, result };
     };
     const parsed = parseDaemonRpcParams(request.method, request.params);
     if (!parsed.ok)
-      return reply(
-        daemonProtocolError(request.method, "invalid_request", parsed.errors.join("; ")) as unknown as JsonObject,
-      );
-    const params = parsed.params;
+      return reply(request.method, daemonProtocolError(request.method, "invalid_request", parsed.errors.join("; ")));
+    const call = parsed.call,
+      { method, params } = call;
     observed = { ...observed, repoId: repoIdFromParams(params) };
-    if (request.method === "protocol.hello") {
+    if (method === "protocol.hello") {
       if (!isContractVersionCompatible(params.protocolVersion, currentDaemonProtocolVersion)) {
         const mismatch = {
           _tag: "ProtocolVersionMismatchError",
           code: "incompatible_protocol_version",
           message: "Use the daemon protocol version reported by this binary.",
         } satisfies Extract<CoreDomainError, { readonly _tag: "ProtocolVersionMismatchError" }>;
-        return reply(daemonProtocolError("protocol.hello", mismatch.code, mismatch.message) as unknown as JsonObject);
+        return reply(method, daemonProtocolError("protocol.hello", mismatch.code, mismatch.message));
       }
       if (params.sessionEnvironment === undefined) Reflect.deleteProperty(options.authContext, "sessionEnvironment");
       else
         Object.assign(options.authContext, {
-          sessionEnvironment: params.sessionEnvironment as DaemonSessionEnvironment,
+          sessionEnvironment: params.sessionEnvironment,
         });
       const buildStatus = options.buildObserver?.status();
       if (buildStatus?.drifted) {
@@ -115,154 +122,143 @@ export function createJsonRpcProtocolServer(options: {
           "daemon_build_stale",
           `Daemon build is stale: loaded ${buildStatus.loadedBuildId ?? "missing"}, ` +
             `disk ${buildStatus.diskBuildId ?? "missing"}. Restarting once to load the disk build.`,
-        ) as unknown as JsonObject;
-        const response = reply({
+        );
+        const staleResult = {
           ...stale,
           loadedBuildId: buildStatus.loadedBuildId,
           diskBuildId: buildStatus.diskBuildId,
-        });
+        };
+        const response = reply(method, staleResult);
         setImmediate(() => options.requestShutdown?.());
         return response;
       }
       handshaken = true;
-      return reply({
+      return reply(method, {
         ok: true,
         protocolVersion: currentDaemonProtocolVersion,
         methods: jsonRpcMethodContracts.map((entry) => entry.method),
         build: { ...options.build },
       });
     }
-    if (!handshaken)
-      return reply(
-        daemonProtocolError(request.method, "hello_required", "Call protocol.hello first.") as unknown as JsonObject,
-      );
-    if (request.method === "daemon.status")
-      return reply({ ok: true, ...options.host.status() } as unknown as JsonObject);
-    if (request.method === "daemon.stop") {
+    if (!handshaken) return reply(method, daemonProtocolError(method, "hello_required", "Call protocol.hello first."));
+    if (method === "daemon.status") return reply(method, { ok: true, ...options.host.status() });
+    if (method === "daemon.stop") {
       if (options.authContext.transportKind !== "unix-socket" || options.authContext.assignmentBinding)
         return reply(
+          method,
           daemonProtocolError(
             "daemon-stop",
             "local_transport_required",
             "Stop is available only through the local session token.",
-          ) as unknown as JsonObject,
+          ),
         );
       if (!options.requestShutdown)
         return reply(
-          daemonProtocolError(
-            "daemon-stop",
-            "shutdown_unavailable",
-            "This daemon composition has no shutdown owner.",
-          ) as unknown as JsonObject,
+          method,
+          daemonProtocolError("daemon-stop", "shutdown_unavailable", "This daemon composition has no shutdown owner."),
         );
-      const response = reply({ ok: true, command: "daemon-stop", pid: process.pid });
+      const response = reply(method, { ok: true, command: "daemon-stop", pid: process.pid });
       options.requestShutdown();
       return response;
     }
-    if (request.method === "daemon.repo.bootstrap") {
+    if (method === "daemon.repo.bootstrap") {
       try {
-        return reply(
-          (await options.host.bootstrap(
-            params as unknown as Parameters<DaemonHost["bootstrap"]>[0],
-            options.authContext,
-          )) as JsonObject,
-        );
+        return reply(method, await options.host.bootstrap(params, options.authContext));
       } catch (error) {
         return reply(
-          daemonProtocolError("init", rpcServerErrorCode(error), protocolErrorMessage(error)) as unknown as JsonObject,
+          method,
+          daemonProtocolError("init", rpcServerErrorCode(error), protocolErrorMessage(error)),
         );
       }
     }
-    if (request.method === "daemon.repo.register" || request.method === "daemon.repo.unregister") {
+    if (method === "daemon.repo.register" || method === "daemon.repo.unregister") {
       try {
         return reply(
-          (await options.host.admin(
-            request.method.endsWith("unregister")
-              ? { kind: "unregister", repoId: params.repoId as string }
+          method,
+          await options.host.admin(
+            method === "daemon.repo.unregister"
+              ? { kind: "unregister", repoId: params.repoId }
               : {
                   kind: "register",
-                  repoId: params.repoId as string,
-                  rootDir: params.rootDir as string,
+                  repoId: params.repoId,
+                  rootDir: params.rootDir,
                   ...(typeof params.mode === "string"
                     ? { mode: params.mode as "local" | "remote-center" | "remote-edge" }
                     : {}),
                 },
             options.authContext,
-          )) as JsonObject,
+          ),
         );
       } catch (error) {
         return reply(
+          method,
           daemonProtocolError(
-            request.method,
+            method,
             rpcServerErrorCode(error),
             protocolErrorMessage(error),
-          ) as unknown as JsonObject,
+          ),
         );
       }
     }
-    if (request.method.startsWith("daemon.runtimeInstance.")) {
+    if (isRuntimeInstanceCall(call)) {
+      const { method, params } = call;
       try {
-        return reply(
-          await options.host.runtimeInstance(request.method, params.payload as JsonObject, options.authContext),
-        );
+        return reply(method, await options.host.runtimeInstance(method, params.payload, options.authContext));
       } catch (error) {
         return reply(
+          method,
           daemonProtocolError(
-            request.method,
+            method,
             rpcServerErrorCode(error),
             protocolErrorMessage(error),
-          ) as unknown as JsonObject,
+          ),
         );
       }
     }
-    if (request.method.startsWith("repo.runtimeInstance.auth.")) {
-      const repo = (params.repo as JsonObject).repoId as string;
+    if (isRuntimeInstanceAuthCall(call)) {
+      const { method, params } = call,
+        repo = params.repo.repoId;
+      try {
+        return reply(method, await options.host.runtimeInstanceAuth(repo, method, params.payload, options.authContext));
+      } catch (error) {
+        return reply(
+          method,
+          daemonProtocolError(
+            method,
+            rpcServerErrorCode(error),
+            protocolErrorMessage(error),
+          ),
+        );
+      }
+    }
+    if (method === "daemon.fleet.center.start" || method === "daemon.fleet.edge.sync") {
       try {
         return reply(
-          await options.host.runtimeInstanceAuth(
-            repo,
-            request.method,
-            params.payload as JsonObject,
+          method,
+          await (method === "daemon.fleet.center.start" ? options.host.fleet.startCenter : options.host.fleet.edgeSync)(
+            params.payload,
             options.authContext,
           ),
         );
       } catch (error) {
         return reply(
+          method,
           daemonProtocolError(
-            request.method,
+            method,
             rpcServerErrorCode(error),
             protocolErrorMessage(error),
-          ) as unknown as JsonObject,
+          ),
         );
       }
     }
-    if (request.method === "daemon.fleet.center.start" || request.method === "daemon.fleet.edge.sync") {
-      try {
-        return reply(
-          (await (
-            request.method === "daemon.fleet.center.start"
-              ? options.host.fleet.startCenter
-              : options.host.fleet.edgeSync
-          )(params.payload as JsonObject, options.authContext)) as unknown as JsonObject,
-        );
-      } catch (error) {
-        return reply(
-          daemonProtocolError(
-            request.method,
-            rpcServerErrorCode(error),
-            protocolErrorMessage(error),
-          ) as unknown as JsonObject,
-        );
-      }
-    }
-    if (request.method === "daemon.fleet.task.run") {
+    if (method === "daemon.fleet.task.run") {
       // Loaded lazily: schema-closure imports this module in a zero-dependency checkout, and the fleet edge stack reaches the kernel barrel.
       try {
         if (options.authContext.transportKind !== "unix-socket" || options.authContext.assignmentBinding)
           throw Object.assign(new Error("This control is available only through the local session token."), {
             code: "local_transport_required",
           });
-        const fleetPayload = params.payload as JsonObject,
+        const fleetPayload = params.payload,
           fleetAction = fleetPayload.action;
         if (isJsonObject(fleetAction) && fleetAction.kind === "fleet-runtime") {
           if (
@@ -278,10 +274,11 @@ export function createJsonRpcProtocolServer(options: {
               code: "invalid_field",
             });
           return reply(
-            (await options.host.fleet.edgeRuntime(
-              { ...fleetPayload, method: fleetAction.method, action: fleetAction.payload } as JsonObject,
+            method,
+            await options.host.fleet.edgeRuntime(
+              { ...fleetPayload, method: fleetAction.method, action: fleetAction.payload },
               options.authContext,
-            )) as unknown as JsonObject,
+            ),
           );
         }
         if (isJsonObject(fleetAction) && fleetAction.kind === "fleet-schedule") {
@@ -290,29 +287,36 @@ export function createJsonRpcProtocolServer(options: {
               code: "invalid_field",
             });
           return reply(
-            (await options.host.fleet.edgeRuntime(
-              { ...fleetPayload, method: "repo.schedule.run", action: fleetAction.payload } as JsonObject,
+            method,
+            await options.host.fleet.edgeRuntime(
+              { ...fleetPayload, method: "repo.schedule.run", action: fleetAction.payload },
               options.authContext,
-            )) as unknown as JsonObject,
+            ),
           );
         }
         const { runFleetEdgeTask } = await import("../fleet-edge-task.ts");
         return reply(
-          (await runFleetEdgeTask({
-            payload: params.payload as unknown as FleetEdgeTaskRequest["payload"],
-          })) as unknown as JsonObject,
+          method,
+          await runFleetEdgeTask({
+            payload: {
+              ...params.payload,
+              // The two non-task discriminants return above; the remainder is FleetTaskAction.
+              action: fleetAction as DaemonFleetTaskAction,
+            },
+          }),
         );
       } catch (error) {
         return reply(
+          method,
           daemonProtocolError(
-            request.method,
+            method,
             rpcServerErrorCode(error),
             protocolErrorMessage(error),
-          ) as unknown as JsonObject,
+          ),
         );
       }
     }
-    if (request.method === "daemon.fleet.doc.sync" || request.method === "daemon.fleet.conflict.exit") {
+    if (method === "daemon.fleet.doc.sync" || method === "daemon.fleet.conflict.exit") {
       try {
         if (options.authContext.transportKind !== "unix-socket" || options.authContext.assignmentBinding)
           throw Object.assign(new Error("This control is available only through the local session token."), {
@@ -320,211 +324,228 @@ export function createJsonRpcProtocolServer(options: {
           }); // Lazy for the same schema-closure reason as the task channel.
         const { runFleetEdgeDocSync, runFleetEdgeConflictExit } = await import("../fleet-edge-doc-sync.ts");
         return reply(
-          (await (request.method === "daemon.fleet.doc.sync"
-            ? runFleetEdgeDocSync({ payload: params.payload as unknown as FleetEdgeDocSyncRequest["payload"] })
+          method,
+          await (method === "daemon.fleet.doc.sync"
+            ? runFleetEdgeDocSync({ payload: params.payload })
             : runFleetEdgeConflictExit({
-                payload: params.payload as unknown as FleetEdgeConflictExitRequest["payload"],
-              }))) as unknown as JsonObject,
+                payload: params.payload,
+              })),
         );
       } catch (error) {
         return reply(
+          method,
           daemonProtocolError(
-            request.method,
+            method,
             rpcServerErrorCode(error),
             protocolErrorMessage(error),
-          ) as unknown as JsonObject,
+          ),
         );
       }
     }
-    if (request.method === "daemon.gui.system.read") {
+    if (method === "daemon.gui.system.read") {
       try {
-        return reply(
-          parseDaemonGuiReadResult(request.method, options.host.system(options.authContext)) as unknown as JsonObject,
-        );
+        return reply(method, parseDaemonGuiReadResult(method, options.host.system(options.authContext)));
       } catch (error) {
         return reply(
+          method,
           daemonProtocolError(
-            request.method,
+            method,
             rpcServerErrorCode(error),
             protocolErrorMessage(error),
-          ) as unknown as JsonObject,
+          ),
         );
       }
     }
-    if (request.method === "daemon.gui.control.receipt") {
+    if (method === "daemon.gui.control.receipt") {
       try {
         return reply(
+          method,
           parseDaemonGuiReadResult(
-            request.method,
-            options.host.controlReceipt(String((params.payload as JsonObject).operationId), options.authContext),
-          ) as unknown as JsonObject,
+            method,
+            options.host.controlReceipt(params.payload.operationId, options.authContext),
+          ),
         );
       } catch (error) {
         return reply(
+          method,
           daemonProtocolError(
-            request.method,
+            method,
             rpcServerErrorCode(error),
             protocolErrorMessage(error),
-          ) as unknown as JsonObject,
+          ),
         );
       }
     }
-    if (request.method === "daemon.gui.control.request") {
+    if (method === "daemon.gui.control.request") {
       try {
         return reply(
-          parseDaemonGuiActionResult(
-            request.method,
-            await options.host.requestControl(params.payload as JsonObject, options.authContext),
-          ) as unknown as JsonObject,
+          method,
+          parseDaemonGuiActionResult(method, await options.host.requestControl(params.payload, options.authContext)),
         );
       } catch (error) {
         return reply(
+          method,
           daemonProtocolError(
-            request.method,
+            method,
             rpcServerErrorCode(error),
             protocolErrorMessage(error),
-          ) as unknown as JsonObject,
+          ),
         );
       }
     }
-    if (isDaemonStreamMethod(request.method)) {
-      const repo = (params.repo as JsonObject).repoId as string,
-        payload = params.payload as JsonObject;
+    if (isDaemonStreamCall(call)) {
+      const { method, params } = call,
+        repo = params.repo.repoId;
       try {
         const subscription: Subscription =
-            request.method === "repo.agentRuntime.attach"
+            method === "repo.agentRuntime.attach"
               ? await options.host.attach(
                   repo,
-                  payload.runtimeSessionId as string,
-                  payload.afterCursor as string,
+                  params.payload.runtimeSessionId,
+                  params.payload.afterCursor,
                   options.authContext,
                 )
               : await options.host.terminalAttach(
                   repo,
-                  payload.sessionId as string,
-                  payload.afterSeq as number,
+                  params.payload.sessionId,
+                  params.payload.afterSeq,
                   options.authContext,
                 ),
-          initial = parseDaemonStreamResult(request.method, subscription.initial);
+          initial = parseDaemonStreamResult(method, subscription.initial);
         if (initial.ok) {
           subscriptions.add(subscription);
-          const eventMethod = daemonStreamFacets.find((facet) => facet.method === request.method)!.eventMethod;
+          const eventMethod = daemonStreamFacets.find((facet) => facet.method === method)!.eventMethod;
           setImmediate(() => pump(subscription, eventMethod));
         }
-        return reply(initial as unknown as JsonObject);
+        return reply(method, initial);
       } catch (error) {
         return reply(
+          method,
           daemonProtocolError(
-            request.method,
+            method,
             rpcServerErrorCode(error),
             protocolErrorMessage(error),
-          ) as unknown as JsonObject,
+          ),
         );
       }
     }
-    if (isDaemonGuiReadMethod(request.method)) {
-      const repo = (params.repo as JsonObject).repoId as string;
+    if (isRepoGuiReadCall(call)) {
+      const { method, params } = call,
+        repo = params.repo.repoId;
       try {
         return reply(
+          method,
           parseDaemonGuiReadResult(
-            request.method,
+            method,
             await options.host.read(
               repo,
-              request.method,
+              method,
               (params.payload as JsonObject | undefined) ?? {},
               options.authContext,
             ),
-          ) as unknown as JsonObject,
+          ),
         );
       } catch (error) {
         return reply(
+          method,
           daemonProtocolError(
-            request.method,
+            method,
             rpcServerErrorCode(error),
             protocolErrorMessage(error),
-          ) as unknown as JsonObject,
+          ),
         );
       }
     }
-    if (request.method === "repo.agentRuntime.spawn") {
-      const repo = (params.repo as JsonObject).repoId as string;
+    if (method === "repo.agentRuntime.spawn") {
+      const repo = params.repo.repoId;
       try {
         return reply(
+          method,
           parseDaemonGuiActionResult(
-            request.method,
-            await options.host.spawnRuntime(repo, params.payload as JsonObject, options.authContext),
-          ) as unknown as JsonObject,
+            method,
+            await options.host.spawnRuntime(repo, params.payload, options.authContext),
+          ),
         );
       } catch (error) {
         return reply(
+          method,
           daemonProtocolError(
-            request.method,
+            method,
             rpcServerErrorCode(error),
             protocolErrorMessage(error),
-          ) as unknown as JsonObject,
+          ),
         );
       }
     }
-    if (request.method === "repo.agentRuntime.cancel") {
-      const repo = (params.repo as JsonObject).repoId as string;
+    if (method === "repo.agentRuntime.cancel") {
+      const repo = params.repo.repoId;
       try {
         return reply(
+          method,
           parseDaemonGuiActionResult(
-            request.method,
-            await options.host.cancelRuntime(repo, params.payload as JsonObject, options.authContext),
-          ) as unknown as JsonObject,
+            method,
+            await options.host.cancelRuntime(repo, params.payload, options.authContext),
+          ),
         );
       } catch (error) {
         return reply(
+          method,
           daemonProtocolError(
-            request.method,
+            method,
             rpcServerErrorCode(error),
             protocolErrorMessage(error),
-          ) as unknown as JsonObject,
+          ),
         );
       }
     }
-    if (request.method === "repo.gui.catalog.reread" || request.method.startsWith("repo.terminal.")) {
-      const repo = (params.repo as JsonObject).repoId as string;
+    if (isTerminalActionCall(call)) {
+      const { method, params } = call,
+        repo = params.repo.repoId;
       try {
         return reply(
+          method,
           parseDaemonGuiActionResult(
-            request.method as import("./daemon-protocol.contract.ts").DaemonGuiActionMethod,
-            await options.host.terminalAction(repo, request.method, params.payload as JsonObject, options.authContext),
-          ) as unknown as JsonObject,
+            method,
+            await options.host.terminalAction(repo, method, params.payload, options.authContext),
+          ),
         );
       } catch (error) {
         return reply(
+          method,
           daemonProtocolError(
-            request.method,
+            method,
             rpcServerErrorCode(error),
             protocolErrorMessage(error),
-          ) as unknown as JsonObject,
+          ),
         );
       }
     }
-    const repo = (params.repo as JsonObject).repoId as string;
+    // All non-repository branches above return. The remaining discriminants are the
+    // contracted repo command family, whose params always carry repo + payload.
+    const commandCall = call as DaemonRepoPayloadCall,
+      { method: commandMethod, params: commandParams } = commandCall,
+      repo = commandParams.repo.repoId;
     let action: JsonObject & { readonly kind: string };
     try {
-      action = actionForDaemonMethod(request.method, params.payload as JsonObject);
+      action = actionForDaemonMethod(commandMethod, commandParams.payload);
     } catch (error) {
       return reply(
+        commandMethod,
         daemonProtocolError(
-          request.method,
+          commandMethod,
           rpcServerErrorCode(error),
-          protocolErrorMessage(error),
-        ) as unknown as JsonObject,
+         protocolErrorMessage(error),
+        ),
       );
     }
     observed = { ...observed, command: action.kind, executor: declaredExecutorOrNull(action) };
     if (action.kind === "preset-run-start" || action.kind === "preset-run-status")
-      return reply((await options.host.presetRun(repo, action, options.authContext)) as unknown as JsonObject);
+      return reply(commandMethod, await options.host.presetRun(repo, action, options.authContext));
     const receipt = await options.host.run(repo, action, options.authContext),
       result = makeDaemonCommandReceipt(action.kind, receipt);
     return reply(
-      isDaemonGuiActionMethod(request.method)
-        ? (parseDaemonGuiActionResult(request.method, result) as unknown as JsonObject)
-        : result,
+      commandMethod,
+      isDaemonGuiActionMethod(commandMethod) ? parseDaemonGuiActionResult(commandMethod, result) : result,
     );
   };
   return {
@@ -551,7 +572,7 @@ export function createJsonRpcProtocolServer(options: {
   }
   // Repo-scoped by design: the log lives in the repository's local root, so a request that binds no
   // repository (protocol.hello, daemon.status, registry admin) has nowhere to be filed and is skipped.
-  function record(method: string, observed: ObservedRequest, result: JsonObject, durationMs: number): void {
+  function record(method: string, observed: ObservedRequest, result: object, durationMs: number): void {
     if (!options.recordRequest || !observed.repoId) return;
     options.recordRequest({
       method,
@@ -560,10 +581,10 @@ export function createJsonRpcProtocolServer(options: {
       connectionId,
       auth: options.authContext,
       executor: observed.executor,
-      ok: result.ok === true,
-      outcome: typeof result.outcome === "string" ? result.outcome : null,
+      ok: resultOk(result),
+      outcome: "outcome" in result && typeof result.outcome === "string" ? result.outcome : null,
       code: resultErrorCode(result),
-      opId: typeof result.opId === "string" ? result.opId : null,
+      opId: "opId" in result && typeof result.opId === "string" ? result.opId : null,
       durationMs,
     });
   }
@@ -589,6 +610,43 @@ export function createJsonRpcProtocolServer(options: {
   }
 }
 
+type DaemonRpcCallFor<Method extends DaemonRpcMethod> = Extract<DaemonRpcCall, { readonly method: Method }>;
+type RuntimeInstanceMethod = Extract<DaemonRpcMethod, `daemon.runtimeInstance.${string}`>;
+type RuntimeInstanceAuthMethod = Extract<DaemonRpcMethod, `repo.runtimeInstance.auth.${string}`>;
+type RepoGuiReadMethod = Exclude<DaemonGuiRpcReadMethod, "daemon.gui.system.read" | "daemon.gui.control.receipt">;
+type TerminalActionMethod = "repo.gui.catalog.reread" | Extract<DaemonGuiActionMethod, `repo.terminal.${string}`>;
+type WithRepoPayload<Call> = Call extends {
+  readonly params: {
+    readonly repo: { readonly repoId: string };
+    readonly payload: JsonObject;
+  };
+}
+  ? Call
+  : never;
+type DaemonRepoPayloadCall = WithRepoPayload<DaemonRpcCall>;
+
+function isRuntimeInstanceCall(call: DaemonRpcCall): call is DaemonRpcCallFor<RuntimeInstanceMethod> {
+  return call.method.startsWith("daemon.runtimeInstance.");
+}
+function isRuntimeInstanceAuthCall(call: DaemonRpcCall): call is DaemonRpcCallFor<RuntimeInstanceAuthMethod> {
+  return call.method.startsWith("repo.runtimeInstance.auth.");
+}
+function isDaemonStreamCall(call: DaemonRpcCall): call is DaemonRpcCallFor<DaemonStreamMethod> {
+  return isDaemonStreamMethod(call.method);
+}
+function isRepoGuiReadCall(call: DaemonRpcCall): call is DaemonRpcCallFor<RepoGuiReadMethod> {
+  return (
+    isDaemonGuiReadMethod(call.method) &&
+    call.method !== "daemon.gui.system.read" &&
+    call.method !== "daemon.gui.control.receipt"
+  );
+}
+function isTerminalActionCall(call: DaemonRpcCall): call is DaemonRpcCallFor<TerminalActionMethod> {
+  return (
+    call.method === "repo.gui.catalog.reread" ||
+    (isDaemonGuiActionMethod(call.method) && call.method.startsWith("repo.terminal."))
+  );
+}
 function repoIdFromParams(params: JsonObject): string {
   const repo = params.repo;
   return isJsonObject(repo) && typeof repo.repoId === "string" ? repo.repoId : "";
@@ -601,9 +659,12 @@ function declaredExecutorOrNull(action: JsonObject): DaemonRequestLogEntry["exec
     ? { kind: "agent", id: executor.id }
     : null;
 }
-function resultErrorCode(result: JsonObject): string | null {
-  if (typeof result.code === "string") return result.code;
-  const error = result.error;
+function resultOk(result: object): boolean {
+  return "ok" in result && result.ok === true;
+}
+function resultErrorCode(result: object): string | null {
+  if ("code" in result && typeof result.code === "string") return result.code;
+  const error = "error" in result ? result.error : undefined;
   return isJsonObject(error) && typeof error.code === "string" ? error.code : null;
 }
 function rpcError(id: JsonRpcId, errorCode: number, message: string): JsonRpcResponse {

--- a/packages/daemon/src/protocol/json-rpc-server.ts
+++ b/packages/daemon/src/protocol/json-rpc-server.ts
@@ -8,32 +8,34 @@ import {
   daemonStreamFacets,
   daemonProtocolError,
   isDaemonGuiActionMethod,
-  isDaemonGuiReadMethod,
-  isDaemonRpcMethod,
-  isDaemonStreamMethod,
   jsonRpcMethodContracts,
   makeDaemonCommandReceipt,
   parseDaemonRpcParams,
   type DaemonFleetTaskAction,
-  type DaemonGuiActionMethod,
-  type DaemonGuiRpcReadMethod,
-  type DaemonRpcCall,
   type DaemonRpcMethod,
   type DaemonRpcResult,
-  type DaemonStreamMethod,
 } from "./daemon-protocol.contract.ts";
+import {
+  declaredExecutorOrNull,
+  isDaemonStreamCall,
+  isRepoGuiReadCall,
+  isRuntimeInstanceAuthCall,
+  isRuntimeInstanceCall,
+  isTerminalActionCall,
+  protocolErrorMessage,
+  repoIdFromParams,
+  resultErrorCode,
+  resultOk,
+  rpcError,
+  rpcServerErrorCode,
+  type DaemonRepoPayloadCall,
+} from "./json-rpc-dispatch-support.ts";
 import {
   parseDaemonGuiActionResult,
   parseDaemonGuiReadResult,
   parseDaemonStreamResult,
 } from "./gui-result-validation.ts";
-import {
-  isJsonObject,
-  type JsonObject,
-  type JsonRpcId,
-  type JsonRpcRequest,
-  type JsonRpcResponse,
-} from "./json-rpc-types.ts";
+import { isJsonObject, type JsonObject, type JsonRpcRequest, type JsonRpcResponse } from "./json-rpc-types.ts";
 import { currentDaemonProtocolVersion } from "./version.ts";
 import { isContractVersionCompatible } from "../../../kernel/src/domain/contract-version.ts";
 import type { CoreDomainError } from "../../../kernel/src/index.ts";
@@ -82,7 +84,7 @@ export function createJsonRpcProtocolServer(options: {
       traffic(typeof request.method === "string" ? request.method : null, startedAt, 0, false, "-32600");
       return rpcError(id, -32600, "Invalid Request");
     }
-    if (!isDaemonRpcMethod(request.method)) {
+    if (!isContractedDaemonRpcMethod(request.method)) {
       traffic(request.method, startedAt, 0, false, "-32601");
       return rpcError(id, -32601, "Method not found");
     }
@@ -101,7 +103,7 @@ export function createJsonRpcProtocolServer(options: {
     const call = parsed.call,
       { method, params } = call;
     observed = { ...observed, repoId: repoIdFromParams(params) };
-    if (method === "protocol.hello") {
+    if (request.method === "protocol.hello" && method === request.method) {
       if (!isContractVersionCompatible(params.protocolVersion, currentDaemonProtocolVersion)) {
         const mismatch = {
           _tag: "ProtocolVersionMismatchError",
@@ -141,8 +143,8 @@ export function createJsonRpcProtocolServer(options: {
       });
     }
     if (!handshaken) return reply(method, daemonProtocolError(method, "hello_required", "Call protocol.hello first."));
-    if (method === "daemon.status") return reply(method, { ok: true, ...options.host.status() });
-    if (method === "daemon.stop") {
+    if (request.method === "daemon.status") return reply("daemon.status", { ok: true, ...options.host.status() });
+    if (request.method === "daemon.stop" && method === request.method) {
       if (options.authContext.transportKind !== "unix-socket" || options.authContext.assignmentBinding)
         return reply(
           method,
@@ -161,17 +163,17 @@ export function createJsonRpcProtocolServer(options: {
       options.requestShutdown();
       return response;
     }
-    if (method === "daemon.repo.bootstrap") {
+    if (request.method === "daemon.repo.bootstrap" && method === request.method) {
       try {
         return reply(method, await options.host.bootstrap(params, options.authContext));
       } catch (error) {
-        return reply(
-          method,
-          daemonProtocolError("init", rpcServerErrorCode(error), protocolErrorMessage(error)),
-        );
+        return reply(method, daemonProtocolError("init", rpcServerErrorCode(error), protocolErrorMessage(error)));
       }
     }
-    if (method === "daemon.repo.register" || method === "daemon.repo.unregister") {
+    if (
+      (request.method === "daemon.repo.register" || request.method === "daemon.repo.unregister") &&
+      method === request.method
+    ) {
       try {
         return reply(
           method,
@@ -190,14 +192,7 @@ export function createJsonRpcProtocolServer(options: {
           ),
         );
       } catch (error) {
-        return reply(
-          method,
-          daemonProtocolError(
-            method,
-            rpcServerErrorCode(error),
-            protocolErrorMessage(error),
-          ),
-        );
+        return reply(method, daemonProtocolError(method, rpcServerErrorCode(error), protocolErrorMessage(error)));
       }
     }
     if (isRuntimeInstanceCall(call)) {
@@ -205,14 +200,7 @@ export function createJsonRpcProtocolServer(options: {
       try {
         return reply(method, await options.host.runtimeInstance(method, params.payload, options.authContext));
       } catch (error) {
-        return reply(
-          method,
-          daemonProtocolError(
-            method,
-            rpcServerErrorCode(error),
-            protocolErrorMessage(error),
-          ),
-        );
+        return reply(method, daemonProtocolError(method, rpcServerErrorCode(error), protocolErrorMessage(error)));
       }
     }
     if (isRuntimeInstanceAuthCall(call)) {
@@ -221,14 +209,7 @@ export function createJsonRpcProtocolServer(options: {
       try {
         return reply(method, await options.host.runtimeInstanceAuth(repo, method, params.payload, options.authContext));
       } catch (error) {
-        return reply(
-          method,
-          daemonProtocolError(
-            method,
-            rpcServerErrorCode(error),
-            protocolErrorMessage(error),
-          ),
-        );
+        return reply(method, daemonProtocolError(method, rpcServerErrorCode(error), protocolErrorMessage(error)));
       }
     }
     if (method === "daemon.fleet.center.start" || method === "daemon.fleet.edge.sync") {
@@ -241,14 +222,7 @@ export function createJsonRpcProtocolServer(options: {
           ),
         );
       } catch (error) {
-        return reply(
-          method,
-          daemonProtocolError(
-            method,
-            rpcServerErrorCode(error),
-            protocolErrorMessage(error),
-          ),
-        );
+        return reply(method, daemonProtocolError(method, rpcServerErrorCode(error), protocolErrorMessage(error)));
       }
     }
     if (method === "daemon.fleet.task.run") {
@@ -306,14 +280,7 @@ export function createJsonRpcProtocolServer(options: {
           }),
         );
       } catch (error) {
-        return reply(
-          method,
-          daemonProtocolError(
-            method,
-            rpcServerErrorCode(error),
-            protocolErrorMessage(error),
-          ),
-        );
+        return reply(method, daemonProtocolError(method, rpcServerErrorCode(error), protocolErrorMessage(error)));
       }
     }
     if (method === "daemon.fleet.doc.sync" || method === "daemon.fleet.conflict.exit") {
@@ -332,28 +299,14 @@ export function createJsonRpcProtocolServer(options: {
               })),
         );
       } catch (error) {
-        return reply(
-          method,
-          daemonProtocolError(
-            method,
-            rpcServerErrorCode(error),
-            protocolErrorMessage(error),
-          ),
-        );
+        return reply(method, daemonProtocolError(method, rpcServerErrorCode(error), protocolErrorMessage(error)));
       }
     }
     if (method === "daemon.gui.system.read") {
       try {
         return reply(method, parseDaemonGuiReadResult(method, options.host.system(options.authContext)));
       } catch (error) {
-        return reply(
-          method,
-          daemonProtocolError(
-            method,
-            rpcServerErrorCode(error),
-            protocolErrorMessage(error),
-          ),
-        );
+        return reply(method, daemonProtocolError(method, rpcServerErrorCode(error), protocolErrorMessage(error)));
       }
     }
     if (method === "daemon.gui.control.receipt") {
@@ -366,14 +319,7 @@ export function createJsonRpcProtocolServer(options: {
           ),
         );
       } catch (error) {
-        return reply(
-          method,
-          daemonProtocolError(
-            method,
-            rpcServerErrorCode(error),
-            protocolErrorMessage(error),
-          ),
-        );
+        return reply(method, daemonProtocolError(method, rpcServerErrorCode(error), protocolErrorMessage(error)));
       }
     }
     if (method === "daemon.gui.control.request") {
@@ -383,14 +329,7 @@ export function createJsonRpcProtocolServer(options: {
           parseDaemonGuiActionResult(method, await options.host.requestControl(params.payload, options.authContext)),
         );
       } catch (error) {
-        return reply(
-          method,
-          daemonProtocolError(
-            method,
-            rpcServerErrorCode(error),
-            protocolErrorMessage(error),
-          ),
-        );
+        return reply(method, daemonProtocolError(method, rpcServerErrorCode(error), protocolErrorMessage(error)));
       }
     }
     if (isDaemonStreamCall(call)) {
@@ -419,14 +358,7 @@ export function createJsonRpcProtocolServer(options: {
         }
         return reply(method, initial);
       } catch (error) {
-        return reply(
-          method,
-          daemonProtocolError(
-            method,
-            rpcServerErrorCode(error),
-            protocolErrorMessage(error),
-          ),
-        );
+        return reply(method, daemonProtocolError(method, rpcServerErrorCode(error), protocolErrorMessage(error)));
       }
     }
     if (isRepoGuiReadCall(call)) {
@@ -446,14 +378,7 @@ export function createJsonRpcProtocolServer(options: {
           ),
         );
       } catch (error) {
-        return reply(
-          method,
-          daemonProtocolError(
-            method,
-            rpcServerErrorCode(error),
-            protocolErrorMessage(error),
-          ),
-        );
+        return reply(method, daemonProtocolError(method, rpcServerErrorCode(error), protocolErrorMessage(error)));
       }
     }
     if (method === "repo.agentRuntime.spawn") {
@@ -467,14 +392,7 @@ export function createJsonRpcProtocolServer(options: {
           ),
         );
       } catch (error) {
-        return reply(
-          method,
-          daemonProtocolError(
-            method,
-            rpcServerErrorCode(error),
-            protocolErrorMessage(error),
-          ),
-        );
+        return reply(method, daemonProtocolError(method, rpcServerErrorCode(error), protocolErrorMessage(error)));
       }
     }
     if (method === "repo.agentRuntime.cancel") {
@@ -488,14 +406,7 @@ export function createJsonRpcProtocolServer(options: {
           ),
         );
       } catch (error) {
-        return reply(
-          method,
-          daemonProtocolError(
-            method,
-            rpcServerErrorCode(error),
-            protocolErrorMessage(error),
-          ),
-        );
+        return reply(method, daemonProtocolError(method, rpcServerErrorCode(error), protocolErrorMessage(error)));
       }
     }
     if (isTerminalActionCall(call)) {
@@ -510,14 +421,7 @@ export function createJsonRpcProtocolServer(options: {
           ),
         );
       } catch (error) {
-        return reply(
-          method,
-          daemonProtocolError(
-            method,
-            rpcServerErrorCode(error),
-            protocolErrorMessage(error),
-          ),
-        );
+        return reply(method, daemonProtocolError(method, rpcServerErrorCode(error), protocolErrorMessage(error)));
       }
     }
     // All non-repository branches above return. The remaining discriminants are the
@@ -531,11 +435,7 @@ export function createJsonRpcProtocolServer(options: {
     } catch (error) {
       return reply(
         commandMethod,
-        daemonProtocolError(
-          commandMethod,
-          rpcServerErrorCode(error),
-         protocolErrorMessage(error),
-        ),
+        daemonProtocolError(commandMethod, rpcServerErrorCode(error), protocolErrorMessage(error)),
       );
     }
     observed = { ...observed, command: action.kind, executor: declaredExecutorOrNull(action) };
@@ -610,83 +510,6 @@ export function createJsonRpcProtocolServer(options: {
   }
 }
 
-type DaemonRpcCallFor<Method extends DaemonRpcMethod> = Extract<DaemonRpcCall, { readonly method: Method }>;
-type RuntimeInstanceMethod = Extract<DaemonRpcMethod, `daemon.runtimeInstance.${string}`>;
-type RuntimeInstanceAuthMethod = Extract<DaemonRpcMethod, `repo.runtimeInstance.auth.${string}`>;
-type RepoGuiReadMethod = Exclude<DaemonGuiRpcReadMethod, "daemon.gui.system.read" | "daemon.gui.control.receipt">;
-type TerminalActionMethod = "repo.gui.catalog.reread" | Extract<DaemonGuiActionMethod, `repo.terminal.${string}`>;
-type WithRepoPayload<Call> = Call extends {
-  readonly params: {
-    readonly repo: { readonly repoId: string };
-    readonly payload: JsonObject;
-  };
-}
-  ? Call
-  : never;
-type DaemonRepoPayloadCall = WithRepoPayload<DaemonRpcCall>;
-
-function isRuntimeInstanceCall(call: DaemonRpcCall): call is DaemonRpcCallFor<RuntimeInstanceMethod> {
-  return call.method.startsWith("daemon.runtimeInstance.");
-}
-function isRuntimeInstanceAuthCall(call: DaemonRpcCall): call is DaemonRpcCallFor<RuntimeInstanceAuthMethod> {
-  return call.method.startsWith("repo.runtimeInstance.auth.");
-}
-function isDaemonStreamCall(call: DaemonRpcCall): call is DaemonRpcCallFor<DaemonStreamMethod> {
-  return isDaemonStreamMethod(call.method);
-}
-function isRepoGuiReadCall(call: DaemonRpcCall): call is DaemonRpcCallFor<RepoGuiReadMethod> {
-  return (
-    isDaemonGuiReadMethod(call.method) &&
-    call.method !== "daemon.gui.system.read" &&
-    call.method !== "daemon.gui.control.receipt"
-  );
-}
-function isTerminalActionCall(call: DaemonRpcCall): call is DaemonRpcCallFor<TerminalActionMethod> {
-  return (
-    call.method === "repo.gui.catalog.reread" ||
-    (isDaemonGuiActionMethod(call.method) && call.method.startsWith("repo.terminal."))
-  );
-}
-function repoIdFromParams(params: JsonObject): string {
-  const repo = params.repo;
-  return isJsonObject(repo) && typeof repo.repoId === "string" ? repo.repoId : "";
-}
-// The executor rides on the resolved action, which is where the daemon reads it for attribution:
-// repo.task.run carries it inside payload.action, every other method merges payload into the action.
-function declaredExecutorOrNull(action: JsonObject): DaemonRequestLogEntry["executor"] {
-  const executor = action.executor;
-  return isJsonObject(executor) && executor.kind === "agent" && typeof executor.id === "string"
-    ? { kind: "agent", id: executor.id }
-    : null;
-}
-function resultOk(result: object): boolean {
-  return "ok" in result && result.ok === true;
-}
-function resultErrorCode(result: object): string | null {
-  if ("code" in result && typeof result.code === "string") return result.code;
-  const error = "error" in result ? result.error : undefined;
-  return isJsonObject(error) && typeof error.code === "string" ? error.code : null;
-}
-function rpcError(id: JsonRpcId, errorCode: number, message: string): JsonRpcResponse {
-  return { jsonrpc: "2.0", id, error: { code: errorCode, message } };
-}
-function rpcServerErrorCode(error: unknown): string {
-  return typeof error === "object" && error !== null && "code" in error && typeof error.code === "string"
-    ? error.code
-    : "bootstrap_failed";
-}
-
-type ProtocolDispatchError =
-  | { readonly _tag: "NativeError"; readonly message: string }
-  | { readonly _tag: "UnknownThrownValue"; readonly message: string };
-
-function protocolErrorMessage(error: unknown): string {
-  let normalized: ProtocolDispatchError;
-  if (error instanceof Error) normalized = { _tag: "NativeError", message: error.message };
-  else normalized = { _tag: "UnknownThrownValue", message: String(error) };
-  switch (normalized._tag) {
-    case "NativeError":
-    case "UnknownThrownValue":
-      return normalized.message;
-  }
+function isContractedDaemonRpcMethod(method: string): method is DaemonRpcMethod {
+  return jsonRpcMethodContracts.some((entry) => entry.method === method);
 }

--- a/packages/gui/src/renderer/api-client-invoke.ts
+++ b/packages/gui/src/renderer/api-client-invoke.ts
@@ -1,0 +1,53 @@
+import type { GuiBridgeMethod } from "../api/renderer-dto.ts";
+import type { FirstRunApi } from "../api/first-run-contract.ts";
+import type { DaemonRpcMethodMap, DaemonRpcResult } from "../../../daemon/src/protocol/daemon-protocol.contract.ts";
+
+type GuiInvokeFacet =
+  (typeof import("../../../daemon/src/protocol/daemon-protocol.contract.ts").daemonGuiInvokeFacets)[number];
+type GuiRpcMethod = GuiInvokeFacet["method"] & keyof DaemonRpcMethodMap;
+type GuiBridgeMethodFor<Method extends GuiRpcMethod> = Extract<
+  GuiInvokeFacet,
+  { readonly method: Method }
+>["guiBridgeMethod"];
+type GuiInput<Value> =
+  Value extends ReadonlyArray<infer Item>
+    ? ReadonlyArray<GuiInput<Item>>
+    : Value extends object
+      ? string extends keyof Value
+        ? object
+        : { readonly [Key in keyof Value]: GuiInput<Value[Key]> }
+      : Value;
+type GuiBridgeParams<Method extends GuiRpcMethod> = DaemonRpcMethodMap[Method]["params"] extends {
+  readonly repo: { readonly repoId: infer RepoId };
+  readonly payload: infer Payload extends object;
+}
+  ? { readonly repoId: RepoId } & GuiInput<Payload>
+  : DaemonRpcMethodMap[Method]["params"] extends {
+        readonly repo: { readonly repoId: infer RepoId };
+      }
+    ? { readonly repoId: RepoId }
+    : DaemonRpcMethodMap[Method]["params"] extends { readonly payload: infer Payload extends object }
+      ? GuiInput<Payload>
+      : GuiInput<DaemonRpcMethodMap[Method]["params"]>;
+
+type HarnessBridge = Record<GuiBridgeMethod, (payload?: object | null) => Promise<unknown>> & {
+  readonly capabilities?: unknown;
+  readonly firstRun?: FirstRunApi;
+};
+
+declare global {
+  interface Window {
+    readonly harness?: HarnessBridge;
+  }
+}
+
+export async function invoke<Method extends keyof DaemonRpcMethodMap>(
+  method: Method & GuiRpcMethod,
+  params: GuiBridgeParams<Method & GuiRpcMethod>,
+  bridgeMethod: GuiBridgeMethodFor<Method & GuiRpcMethod>,
+): Promise<DaemonRpcResult<Method>> {
+  const bridge = window.harness;
+  if (!bridge || typeof bridge[bridgeMethod] !== "function")
+    throw new Error(`Harness preload bridge is unavailable for ${method} (${bridgeMethod}).`);
+  return bridge[bridgeMethod](params) as Promise<DaemonRpcResult<Method>>;
+}

--- a/packages/gui/src/renderer/api-client.ts
+++ b/packages/gui/src/renderer/api-client.ts
@@ -24,6 +24,35 @@ import type {
 } from "../api/renderer-dto.ts";
 import type { FirstRunApi } from "../api/first-run-contract.ts";
 import { isRendererRecord } from "./result-validation.ts";
+import type { DaemonRpcMethodMap, DaemonRpcResult } from "../../../daemon/src/protocol/daemon-protocol.contract.ts";
+
+type GuiInvokeFacet =
+  (typeof import("../../../daemon/src/protocol/daemon-protocol.contract.ts").daemonGuiInvokeFacets)[number];
+type GuiRpcMethod = GuiInvokeFacet["method"] & keyof DaemonRpcMethodMap;
+type GuiBridgeMethodFor<Method extends GuiRpcMethod> = Extract<
+  GuiInvokeFacet,
+  { readonly method: Method }
+>["guiBridgeMethod"];
+type GuiInput<Value> =
+  Value extends ReadonlyArray<infer Item>
+    ? ReadonlyArray<GuiInput<Item>>
+    : Value extends object
+      ? string extends keyof Value
+        ? object
+        : { readonly [Key in keyof Value]: GuiInput<Value[Key]> }
+      : Value;
+type GuiBridgeParams<Method extends GuiRpcMethod> = DaemonRpcMethodMap[Method]["params"] extends {
+  readonly repo: { readonly repoId: infer RepoId };
+  readonly payload: infer Payload extends object;
+}
+  ? { readonly repoId: RepoId } & GuiInput<Payload>
+  : DaemonRpcMethodMap[Method]["params"] extends {
+        readonly repo: { readonly repoId: infer RepoId };
+      }
+    ? { readonly repoId: RepoId }
+    : DaemonRpcMethodMap[Method]["params"] extends { readonly payload: infer Payload extends object }
+      ? GuiInput<Payload>
+      : GuiInput<DaemonRpcMethodMap[Method]["params"]>;
 
 type HarnessBridge = Record<GuiBridgeMethod, (payload?: object | null) => Promise<unknown>> & {
   readonly capabilities?: unknown;
@@ -362,43 +391,43 @@ export interface DecisionProposalInput {
 
 export const harnessClient = {
   async getSystemStatus(): Promise<SystemStatusSuccess> {
-    return readSystemStatus(await invokeBridge("getSystemStatus"));
+    return readSystemStatus(await invoke("daemon.gui.system.read", {}, "getSystemStatus"));
   },
   async requestDaemonControl(payload: {
     readonly kind: "refresh" | "restart";
     readonly authorityRepoId: string;
     readonly reason?: string;
   }): Promise<DaemonControlReceipt> {
-    return readDaemonControlReceipt(await invokeBridge("requestDaemonControl", payload));
+    return readDaemonControlReceipt(await invoke("daemon.gui.control.request", payload, "requestDaemonControl"));
   },
   async getDaemonControlReceipt(payload: { readonly operationId: string }): Promise<DaemonControlReceipt> {
-    return readDaemonControlReceipt(await invokeBridge("getDaemonControlReceipt", payload));
+    return readDaemonControlReceipt(await invoke("daemon.gui.control.receipt", payload, "getDaemonControlReceipt"));
   },
   async tailObservability(payload: ObserveTailRequest): Promise<ObserveTailRead> {
-    return readObserveTailResult(await invokeBridge("tailObservability", payload));
+    return readObserveTailResult(await invoke("observe.tail", payload, "tailObservability"));
   },
   async getTasks(payload: RepoScope & TaskQueryFacets): Promise<TaskListSuccess> {
-    return readTaskListResult(await invokeBridge("getTasks", payload));
+    return readTaskListResult(await invoke("repo.tasks.list", payload, "getTasks"));
   },
   async getAgenda(payload: RepoScope & { readonly limit?: number; readonly cursor?: string }): Promise<AgendaSuccess> {
     return readAgendaResult(await invokeBridge("getAgenda", payload));
   },
   async getSettings(payload: RepoScope): Promise<SettingsSuccess> {
-    return readSettingsResult(await invokeBridge("getSettings", payload));
+    return readSettingsResult(await invoke("repo.settings.read", payload, "getSettings"));
   },
   async updateSettings(payload: SettingsUpdateInput): Promise<GuiActionResult> {
-    return readGuiActionResult(await invokeBridge("updateSettings", payload));
+    return readGuiActionResult(await invoke("repo.settings.update", payload, "updateSettings"));
   },
   async getWorkspaceSummary(payload: RepoScope): Promise<WorkspaceSummarySuccess> {
-    return readWorkspaceSummaryResult(await invokeBridge("getWorkspaceSummary", payload));
+    return readWorkspaceSummaryResult(await invoke("repo.workspace.summary.read", payload, "getWorkspaceSummary"));
   },
   async getTaskDocument(
     payload: RepoScope & { readonly taskId: string; readonly path: string },
   ): Promise<TaskDocumentProjectionRead> {
-    return readTaskDocumentResult(await invokeBridge("getTaskDocument", payload));
+    return readTaskDocumentResult(await invoke("repo.tasks.document.read", payload, "getTaskDocument"));
   },
   async getTaskDocuments(payload: RepoScope & { readonly taskId: string }): Promise<TaskDocumentListProjectionRead> {
-    return readTaskDocumentListResult(await invokeBridge("getTaskDocuments", payload));
+    return readTaskDocumentListResult(await invoke("repo.tasks.documents.list", payload, "getTaskDocuments"));
   },
   async getTaskDispatches(
     payload: RepoScope &
@@ -407,19 +436,21 @@ export const harnessClient = {
         | { readonly taskIds: readonly string[]; readonly limit?: number; readonly cursor?: string }
       ),
   ): Promise<TaskDispatchesRead> {
-    return readTaskDispatchesResult(await invokeBridge("getTaskDispatches", payload));
+    return readTaskDispatchesResult(await invoke("repo.task.dispatches", payload, "getTaskDispatches"));
   },
   async getRelationGraph(payload: RepoScope & RelationQueryFacets): Promise<RelationGraphSuccess> {
-    return readRelationGraphResult(await invokeBridge("getRelationGraph", payload));
+    return readRelationGraphResult(await invoke("repo.triadic.relationGraph", payload, "getRelationGraph"));
   },
   async getRelationFacts(payload: RepoScope & RelationFactFacetQuery): Promise<RelationFactFacetSuccess> {
-    return readRelationFactFacetResult(await invokeBridge("getRelationGraph", payload));
+    return readRelationFactFacetResult(await invoke("repo.triadic.relationGraph", payload, "getRelationGraph"));
   },
   async getDecisions(payload: RepoScope): Promise<DecisionListSuccess> {
-    return readDecisionListResult(await invokeBridge("getDecisions", payload));
+    return readDecisionListResult(await invoke("repo.decisions.list", payload, "getDecisions"));
   },
   async getDecisionSummaries(payload: RepoScope): Promise<DecisionSummaryListSuccess> {
-    return readDecisionSummaryListResult(await invokeBridge("getDecisions", { ...payload, projection: "summary" }));
+    return readDecisionSummaryListResult(
+      await invoke("repo.decisions.list", { ...payload, projection: "summary" }, "getDecisions"),
+    );
   },
   async listDecisionControls(
     payload: RepoScope & {
@@ -429,15 +460,15 @@ export const harnessClient = {
       readonly productLine?: string;
     },
   ): Promise<DecisionControlListSuccess> {
-    return readDecisionControlList(await invokeBridge("listDecisions", payload));
+    return readDecisionControlList(await invoke("repo.decision.list", payload, "listDecisions"));
   },
   async showDecision(
     payload: RepoScope & { readonly decisionId: string; readonly includeBody?: boolean },
   ): Promise<DecisionShowSuccess> {
-    return readDecisionShowResult(await invokeBridge("showDecision", payload));
+    return readDecisionShowResult(await invoke("repo.decision.show", payload, "showDecision"));
   },
   async proposeDecision(payload: RepoScope & DecisionProposalInput): Promise<GuiActionResult> {
-    return readGuiActionResult(await invokeBridge("proposeDecision", payload));
+    return readGuiActionResult(await invoke("repo.decision.propose", payload, "proposeDecision"));
   },
   async acceptDecision(
     payload: RepoScope & {
@@ -446,22 +477,22 @@ export const harnessClient = {
       readonly judgmentOnlyRationale?: string;
     },
   ): Promise<GuiActionResult> {
-    return readGuiActionResult(await invokeBridge("acceptDecision", payload));
+    return readGuiActionResult(await invoke("repo.decision.accept", payload, "acceptDecision"));
   },
   async rejectDecision(
     payload: RepoScope & { readonly decisionId: string; readonly reason: string },
   ): Promise<GuiActionResult> {
-    return readGuiActionResult(await invokeBridge("rejectDecision", payload));
+    return readGuiActionResult(await invoke("repo.decision.reject", payload, "rejectDecision"));
   },
   async deferDecision(
     payload: RepoScope & { readonly decisionId: string; readonly reason: string },
   ): Promise<GuiActionResult> {
-    return readGuiActionResult(await invokeBridge("deferDecision", payload));
+    return readGuiActionResult(await invoke("repo.decision.defer", payload, "deferDecision"));
   },
   async startTask(
     payload: RepoScope & { readonly taskId: string; readonly executionId: string },
   ): Promise<GuiActionResult> {
-    return readGuiActionResult(await invokeBridge("startTask", payload));
+    return readGuiActionResult(await invoke("repo.task.start", payload, "startTask"));
   },
   async appendTaskProgress(
     payload: RepoScope & {
@@ -472,7 +503,7 @@ export const harnessClient = {
       readonly baseDocumentSha256?: string | null;
     },
   ): Promise<GuiActionResult> {
-    return readGuiActionResult(await invokeBridge("appendTaskProgress", payload));
+    return readGuiActionResult(await invoke("repo.task.progress.append", payload, "appendTaskProgress"));
   },
   async submitTask(
     payload: RepoScope & {
@@ -481,7 +512,7 @@ export const harnessClient = {
       readonly submission: GuiSubmissionV1;
     },
   ): Promise<GuiActionResult> {
-    return readGuiActionResult(await invokeBridge("submitTask", payload));
+    return readGuiActionResult(await invoke("repo.task.submit", payload, "submitTask"));
   },
   /** 台账 pin 的唯一 GUI 写通道:daemon 侧就是 `ha task pin` 的 pinned-only amend。 */
   async pinTask(payload: RepoScope & { readonly taskId: string }): Promise<GuiActionResult> {
@@ -491,26 +522,30 @@ export const harnessClient = {
     return readGuiActionResult(await invokeBridge("unpinTask", payload));
   },
   async showReceipt(payload: RepoScope & { readonly opId: string }): Promise<GuiActionResult> {
-    return readGuiActionResult(await invokeBridge("showReceipt", payload));
+    return readGuiActionResult(await invoke("repo.receipt.show", payload, "showReceipt"));
   },
   async getCatalogSnapshot(payload: RepoScope): Promise<CatalogSnapshotSuccess> {
-    return readCatalogSnapshot(await invokeBridge("getCatalogSnapshot", payload));
+    return readCatalogSnapshot(await invoke("repo.gui.catalog.snapshot", payload, "getCatalogSnapshot"));
   },
   async getCatalogPreset(
     payload: RepoScope & { readonly presetId: string; readonly profileId?: string; readonly locale?: string },
   ): Promise<CatalogPresetSuccess> {
-    return readCatalogPreset(await invokeBridge("getCatalogPreset", payload));
+    return readCatalogPreset(await invoke("repo.gui.catalog.preset.read", payload, "getCatalogPreset"));
   },
   async rereadCatalog(payload: RepoScope & { readonly expectedDigest?: string }): Promise<CatalogRereadReceipt> {
-    return readCatalogRereadReceipt(await invokeBridge("rereadCatalog", payload));
+    return readCatalogRereadReceipt(await invoke("repo.gui.catalog.reread", payload, "rereadCatalog"));
   },
 };
 
-async function invokeBridge(method: GuiBridgeMethod, payload: object | null = null): Promise<unknown> {
+async function invoke<Method extends keyof DaemonRpcMethodMap>(
+  method: Method & GuiRpcMethod,
+  params: GuiBridgeParams<Method & GuiRpcMethod>,
+  bridgeMethod: GuiBridgeMethodFor<Method & GuiRpcMethod>,
+): Promise<DaemonRpcResult<Method>> {
   const bridge = window.harness;
-  if (!bridge || typeof bridge[method] !== "function")
-    throw new Error(`Harness preload bridge is unavailable for ${method}.`);
-  return bridge[method](payload);
+  if (!bridge || typeof bridge[bridgeMethod] !== "function")
+    throw new Error(`Harness preload bridge is unavailable for ${method} (${bridgeMethod}).`);
+  return bridge[bridgeMethod](params) as Promise<DaemonRpcResult<Method>>;
 }
 
 function readTaskDocumentListResult(value: unknown): TaskDocumentListProjectionRead {
@@ -538,24 +573,27 @@ function readTaskDocumentListResult(value: unknown): TaskDocumentListProjectionR
 }
 
 function readSettingsResult(value: unknown): SettingsSuccess {
-  if (
-    !isRendererRecord(value) ||
-    value.schema !== "daemon.settings-read/v1" ||
-    value.ok !== true ||
-    !isRendererRecord(value.settings) ||
-    value.settings.schema !== "settings/v1" ||
-    value.settings.settingsId !== "repository" ||
-    ![value.settings.defaultVertical, value.settings.defaultPreset, value.settings.defaultProfile].every(
+  if (!isSettingsSuccess(value)) throw new Error(localErrorHint(value, "Settings bridge returned an invalid result."));
+  return value;
+}
+
+function isSettingsSuccess(value: unknown): value is SettingsSuccess {
+  if (!isRendererRecord(value) || !isRendererRecord(value.settings)) return false;
+  const settings = value.settings;
+  return (
+    value.schema === "daemon.settings-read/v1" &&
+    value.ok === true &&
+    settings.schema === "settings/v1" &&
+    settings.settingsId === "repository" &&
+    [settings.defaultVertical, settings.defaultPreset, settings.defaultProfile].every(
       (field) => typeof field === "string" && field.length > 0,
-    ) ||
-    !["en-US", "zh-CN"].includes(String(value.settings.locale)) ||
-    !isRendererRecord(value.settings.scaffolds) ||
-    ![value.settings.scaffolds.task, value.settings.scaffolds.repository].every(
+    ) &&
+    ["en-US", "zh-CN"].includes(String(settings.locale)) &&
+    isRendererRecord(settings.scaffolds) &&
+    [settings.scaffolds.task, settings.scaffolds.repository].every(
       (field) => typeof field === "string" && field.length > 0,
     )
-  )
-    throw new Error(localErrorHint(value, "Settings bridge returned an invalid result."));
-  return value as unknown as SettingsSuccess;
+  );
 }
 
 function readTaskDispatchesResult(value: unknown): TaskDispatchesRead {
@@ -921,54 +959,76 @@ function readDecisionShowResult(value: unknown): DecisionShowSuccess {
 }
 
 function readSystemStatus(value: unknown): SystemStatusSuccess {
-  if (
-    !isRendererRecord(value) ||
-    value.schema !== "gui-system-status/v1" ||
-    value.ok !== true ||
-    typeof value.observedAt !== "string" ||
-    !isRendererRecord(value.daemon) ||
-    !Array.isArray(value.repos) ||
-    value.repos.some(
-      (repo) =>
-        !isRendererRecord(repo) ||
-        typeof repo.repoId !== "string" ||
-        typeof repo.displayName !== "string" ||
-        !["enabled", "disabled"].includes(String(repo.registrationState)) ||
-        !["warming", "attached", "unavailable", "not_loaded"].includes(String(repo.cellState)),
-    )
-  )
+  if (!isSystemStatusSuccess(value))
     throw new Error(localErrorHint(value, "System status bridge returned an invalid result."));
-  return value as unknown as SystemStatusSuccess;
+  return value;
 }
 function readDaemonControlReceipt(value: unknown): DaemonControlReceipt {
-  if (
-    !isRendererRecord(value) ||
-    value.schema !== "daemon-control-receipt/v1" ||
-    typeof value.ok !== "boolean" ||
-    !["pending", "op_rejected"].includes(String(value.outcome)) ||
-    !["refresh", "restart"].includes(String(value.kind)) ||
-    typeof value.operationId !== "string" ||
-    !["queued", "draining", "starting", "settled", "failed"].includes(String(value.phase))
-  )
+  if (!isDaemonControlReceipt(value))
     throw new Error(localErrorHint(value, "Daemon control bridge returned an invalid receipt."));
-  return value as unknown as DaemonControlReceipt;
+  return value;
 }
 function readCatalogSnapshot(value: unknown): CatalogSnapshotSuccess {
-  if (
-    !isRendererRecord(value) ||
-    value.schema !== "gui-catalog-snapshot/v1" ||
-    value.ok !== true ||
-    !["ready", "pending"].includes(String(value.status)) ||
-    typeof value.repoId !== "string" ||
-    !isRendererRecord(value.defaults) ||
-    !Array.isArray(value.presets) ||
-    !Array.isArray(value.verticals) ||
-    !Array.isArray(value.templates) ||
-    !Array.isArray(value.adapters) ||
-    !isRendererRecord(value.scaffolds) ||
-    !Array.isArray(value.scaffolds.task) ||
-    !Array.isArray(value.scaffolds.repository) ||
-    !value.presets.every(
+  if (!isCatalogSnapshotSuccess(value))
+    throw new Error(localErrorHint(value, "Catalog snapshot bridge returned an invalid result."));
+  return value;
+}
+function readCatalogPreset(value: unknown): CatalogPresetSuccess {
+  if (!isCatalogPresetSuccess(value))
+    throw new Error(localErrorHint(value, "Catalog preset bridge returned an invalid result."));
+  return value;
+}
+function readCatalogRereadReceipt(value: unknown): CatalogRereadReceipt {
+  if (!isCatalogRereadReceipt(value))
+    throw new Error(localErrorHint(value, "Catalog reread bridge returned an invalid receipt."));
+  return value;
+}
+
+function isSystemStatusSuccess(value: unknown): value is SystemStatusSuccess {
+  return (
+    isRendererRecord(value) &&
+    value.schema === "gui-system-status/v1" &&
+    value.ok === true &&
+    typeof value.observedAt === "string" &&
+    isRendererRecord(value.daemon) &&
+    Array.isArray(value.repos) &&
+    value.repos.every(
+      (repo) =>
+        isRendererRecord(repo) &&
+        typeof repo.repoId === "string" &&
+        typeof repo.displayName === "string" &&
+        ["enabled", "disabled"].includes(String(repo.registrationState)) &&
+        ["warming", "attached", "unavailable", "not_loaded"].includes(String(repo.cellState)),
+    )
+  );
+}
+function isDaemonControlReceipt(value: unknown): value is DaemonControlReceipt {
+  return (
+    isRendererRecord(value) &&
+    value.schema === "daemon-control-receipt/v1" &&
+    typeof value.ok === "boolean" &&
+    ["pending", "op_rejected"].includes(String(value.outcome)) &&
+    ["refresh", "restart"].includes(String(value.kind)) &&
+    typeof value.operationId === "string" &&
+    ["queued", "draining", "starting", "settled", "failed"].includes(String(value.phase))
+  );
+}
+function isCatalogSnapshotSuccess(value: unknown): value is CatalogSnapshotSuccess {
+  return (
+    isRendererRecord(value) &&
+    value.schema === "gui-catalog-snapshot/v1" &&
+    value.ok === true &&
+    ["ready", "pending"].includes(String(value.status)) &&
+    typeof value.repoId === "string" &&
+    isRendererRecord(value.defaults) &&
+    Array.isArray(value.presets) &&
+    Array.isArray(value.verticals) &&
+    Array.isArray(value.templates) &&
+    Array.isArray(value.adapters) &&
+    isRendererRecord(value.scaffolds) &&
+    Array.isArray(value.scaffolds.task) &&
+    Array.isArray(value.scaffolds.repository) &&
+    value.presets.every(
       (row) =>
         isRendererRecord(row) &&
         Array.isArray(row.profiles) &&
@@ -976,20 +1036,18 @@ function readCatalogSnapshot(value: unknown): CatalogSnapshotSuccess {
           (profile) => isRendererRecord(profile) && typeof profile.id === "string" && typeof profile.title === "string",
         ),
     )
-  )
-    throw new Error(localErrorHint(value, "Catalog snapshot bridge returned an invalid result."));
-  return value as unknown as CatalogSnapshotSuccess;
+  );
 }
-function readCatalogPreset(value: unknown): CatalogPresetSuccess {
-  if (
-    !isRendererRecord(value) ||
-    value.schema !== "gui-catalog-preset/v1" ||
-    value.ok !== true ||
-    typeof value.repoId !== "string" ||
-    !isRendererRecord(value.preset) ||
-    !isRendererRecord(value.resolved) ||
-    !Array.isArray(value.resolved.documents) ||
-    !value.resolved.documents.every(
+function isCatalogPresetSuccess(value: unknown): value is CatalogPresetSuccess {
+  return (
+    isRendererRecord(value) &&
+    value.schema === "gui-catalog-preset/v1" &&
+    value.ok === true &&
+    typeof value.repoId === "string" &&
+    isRendererRecord(value.preset) &&
+    isRendererRecord(value.resolved) &&
+    Array.isArray(value.resolved.documents) &&
+    value.resolved.documents.every(
       (row) =>
         isRendererRecord(row) &&
         typeof row.slot === "string" &&
@@ -997,21 +1055,17 @@ function readCatalogPreset(value: unknown): CatalogPresetSuccess {
         typeof row.body === "string" &&
         typeof row.mediaType === "string",
     )
-  )
-    throw new Error(localErrorHint(value, "Catalog preset bridge returned an invalid result."));
-  return value as unknown as CatalogPresetSuccess;
+  );
 }
-function readCatalogRereadReceipt(value: unknown): CatalogRereadReceipt {
-  if (
-    !isRendererRecord(value) ||
-    value.schema !== "catalog-reread-receipt/v1" ||
-    typeof value.ok !== "boolean" ||
-    !["applied", "op_rejected"].includes(String(value.outcome)) ||
-    typeof value.operationId !== "string" ||
-    typeof value.repoId !== "string"
-  )
-    throw new Error(localErrorHint(value, "Catalog reread bridge returned an invalid receipt."));
-  return value as unknown as CatalogRereadReceipt;
+function isCatalogRereadReceipt(value: unknown): value is CatalogRereadReceipt {
+  return (
+    isRendererRecord(value) &&
+    value.schema === "catalog-reread-receipt/v1" &&
+    typeof value.ok === "boolean" &&
+    ["applied", "op_rejected"].includes(String(value.outcome)) &&
+    typeof value.operationId === "string" &&
+    typeof value.repoId === "string"
+  );
 }
 
 function isTaskSnapshotProjectionRow(value: unknown): value is TaskSnapshotProjectionRow {

--- a/packages/gui/src/renderer/api-client.ts
+++ b/packages/gui/src/renderer/api-client.ts
@@ -8,7 +8,6 @@ import type {
   RelationFactRow,
   GuiActionResult,
   GuiSubmissionV1,
-  GuiBridgeMethod,
   ObserveTailPayload,
   ObserveTailRead,
   ProjectionWarning,
@@ -22,48 +21,8 @@ import type {
   WorkspaceSummaryRead,
   SettingsRead,
 } from "../api/renderer-dto.ts";
-import type { FirstRunApi } from "../api/first-run-contract.ts";
 import { isRendererRecord } from "./result-validation.ts";
-import type { DaemonRpcMethodMap, DaemonRpcResult } from "../../../daemon/src/protocol/daemon-protocol.contract.ts";
-
-type GuiInvokeFacet =
-  (typeof import("../../../daemon/src/protocol/daemon-protocol.contract.ts").daemonGuiInvokeFacets)[number];
-type GuiRpcMethod = GuiInvokeFacet["method"] & keyof DaemonRpcMethodMap;
-type GuiBridgeMethodFor<Method extends GuiRpcMethod> = Extract<
-  GuiInvokeFacet,
-  { readonly method: Method }
->["guiBridgeMethod"];
-type GuiInput<Value> =
-  Value extends ReadonlyArray<infer Item>
-    ? ReadonlyArray<GuiInput<Item>>
-    : Value extends object
-      ? string extends keyof Value
-        ? object
-        : { readonly [Key in keyof Value]: GuiInput<Value[Key]> }
-      : Value;
-type GuiBridgeParams<Method extends GuiRpcMethod> = DaemonRpcMethodMap[Method]["params"] extends {
-  readonly repo: { readonly repoId: infer RepoId };
-  readonly payload: infer Payload extends object;
-}
-  ? { readonly repoId: RepoId } & GuiInput<Payload>
-  : DaemonRpcMethodMap[Method]["params"] extends {
-        readonly repo: { readonly repoId: infer RepoId };
-      }
-    ? { readonly repoId: RepoId }
-    : DaemonRpcMethodMap[Method]["params"] extends { readonly payload: infer Payload extends object }
-      ? GuiInput<Payload>
-      : GuiInput<DaemonRpcMethodMap[Method]["params"]>;
-
-type HarnessBridge = Record<GuiBridgeMethod, (payload?: object | null) => Promise<unknown>> & {
-  readonly capabilities?: unknown;
-  readonly firstRun?: FirstRunApi;
-};
-
-declare global {
-  interface Window {
-    readonly harness?: HarnessBridge;
-  }
-}
+import { invoke } from "./api-client-invoke.ts";
 
 export interface TaskListSuccess {
   readonly ok: true;
@@ -410,7 +369,7 @@ export const harnessClient = {
     return readTaskListResult(await invoke("repo.tasks.list", payload, "getTasks"));
   },
   async getAgenda(payload: RepoScope & { readonly limit?: number; readonly cursor?: string }): Promise<AgendaSuccess> {
-    return readAgendaResult(await invokeBridge("getAgenda", payload));
+    return readAgendaResult(await invoke("repo.agenda.read", payload, "getAgenda"));
   },
   async getSettings(payload: RepoScope): Promise<SettingsSuccess> {
     return readSettingsResult(await invoke("repo.settings.read", payload, "getSettings"));
@@ -516,10 +475,10 @@ export const harnessClient = {
   },
   /** 台账 pin 的唯一 GUI 写通道:daemon 侧就是 `ha task pin` 的 pinned-only amend。 */
   async pinTask(payload: RepoScope & { readonly taskId: string }): Promise<GuiActionResult> {
-    return readGuiActionResult(await invokeBridge("pinTask", payload));
+    return readGuiActionResult(await invoke("repo.task.pin", payload, "pinTask"));
   },
   async unpinTask(payload: RepoScope & { readonly taskId: string }): Promise<GuiActionResult> {
-    return readGuiActionResult(await invokeBridge("unpinTask", payload));
+    return readGuiActionResult(await invoke("repo.task.unpin", payload, "unpinTask"));
   },
   async showReceipt(payload: RepoScope & { readonly opId: string }): Promise<GuiActionResult> {
     return readGuiActionResult(await invoke("repo.receipt.show", payload, "showReceipt"));
@@ -536,17 +495,6 @@ export const harnessClient = {
     return readCatalogRereadReceipt(await invoke("repo.gui.catalog.reread", payload, "rereadCatalog"));
   },
 };
-
-async function invoke<Method extends keyof DaemonRpcMethodMap>(
-  method: Method & GuiRpcMethod,
-  params: GuiBridgeParams<Method & GuiRpcMethod>,
-  bridgeMethod: GuiBridgeMethodFor<Method & GuiRpcMethod>,
-): Promise<DaemonRpcResult<Method>> {
-  const bridge = window.harness;
-  if (!bridge || typeof bridge[bridgeMethod] !== "function")
-    throw new Error(`Harness preload bridge is unavailable for ${method} (${bridgeMethod}).`);
-  return bridge[bridgeMethod](params) as Promise<DaemonRpcResult<Method>>;
-}
 
 function readTaskDocumentListResult(value: unknown): TaskDocumentListProjectionRead {
   const result = value as Partial<TaskDocumentListProjectionRead>;

--- a/tools/check-duplicate-definitions.mjs
+++ b/tools/check-duplicate-definitions.mjs
@@ -3,11 +3,7 @@ import path from "node:path";
 import ts from "typescript";
 
 const root = process.cwd();
-const allowlist = new Set([
-  "gui/failure",
-  "gui/save",
-  "kernel/visit"
-]);
+const allowlist = new Set(["gui/failure", "gui/save", "kernel/visit", "daemon/parseDaemonRpcParams"]);
 const violations = [];
 
 for (const pkg of await discoverPackages()) {
@@ -24,7 +20,7 @@ for (const pkg of await discoverPackages()) {
         const locations = definitions.get(name) ?? [];
         locations.push({
           file: relative(file),
-          line: position.line + 1
+          line: position.line + 1,
         });
         definitions.set(name, locations);
       }
@@ -50,18 +46,16 @@ console.log("Duplicate function definition check passed.");
 
 async function discoverPackages() {
   const rootPackage = JSON.parse(await readFile(path.join(root, "package.json"), "utf8"));
-  const workspaces = Array.isArray(rootPackage.workspaces)
-    ? rootPackage.workspaces
-    : rootPackage.workspaces?.packages;
+  const workspaces = Array.isArray(rootPackage.workspaces) ? rootPackage.workspaces : rootPackage.workspaces?.packages;
   if (!Array.isArray(workspaces)) return [];
 
   const packages = [];
   for (const workspace of workspaces) {
     for (const packageRoot of await expandWorkspace(workspace)) {
-      if (!await directoryExists(path.join(packageRoot, "src"))) continue;
+      if (!(await directoryExists(path.join(packageRoot, "src")))) continue;
       packages.push({
         root: packageRoot,
-        key: await packageKey(packageRoot)
+        key: await packageKey(packageRoot),
       });
     }
   }
@@ -97,7 +91,7 @@ async function walkSourceFiles(dir) {
     const fullPath = path.join(dir, entry.name);
     if (entry.isDirectory()) {
       if (["dist", "node_modules", "out", "test", "tests", "__tests__"].includes(entry.name)) continue;
-      files.push(...await walkSourceFiles(fullPath));
+      files.push(...(await walkSourceFiles(fullPath)));
       continue;
     }
     if (isSourceFile(entry.name)) files.push(fullPath);
@@ -106,10 +100,12 @@ async function walkSourceFiles(dir) {
 }
 
 function isSourceFile(fileName) {
-  return fileName.endsWith(".ts")
-    && !fileName.endsWith(".d.ts")
-    && !fileName.endsWith(".test.ts")
-    && !fileName.endsWith(".spec.ts");
+  return (
+    fileName.endsWith(".ts") &&
+    !fileName.endsWith(".d.ts") &&
+    !fileName.endsWith(".test.ts") &&
+    !fileName.endsWith(".spec.ts")
+  );
 }
 
 function isPureDelegation(node) {
@@ -120,8 +116,7 @@ function isPureDelegation(node) {
   if (ts.isReturnStatement(statement) && statement.expression) {
     return isCallOrAwaitedCall(statement.expression);
   }
-  return ts.isExpressionStatement(statement)
-    && isAwaitedCall(statement.expression);
+  return ts.isExpressionStatement(statement) && isAwaitedCall(statement.expression);
 }
 
 function hasParameterDefault(parameter) {
@@ -144,8 +139,7 @@ function isCallOrAwaitedCall(expression) {
 
 function isAwaitedCall(expression) {
   const unwrapped = unwrapParentheses(expression);
-  return ts.isAwaitExpression(unwrapped)
-    && ts.isCallExpression(unwrapParentheses(unwrapped.expression));
+  return ts.isAwaitExpression(unwrapped) && ts.isCallExpression(unwrapParentheses(unwrapped.expression));
 }
 
 function unwrapParentheses(expression) {

--- a/tools/check-duplicate-definitions.mjs
+++ b/tools/check-duplicate-definitions.mjs
@@ -3,7 +3,11 @@ import path from "node:path";
 import ts from "typescript";
 
 const root = process.cwd();
-const allowlist = new Set(["gui/failure", "gui/save", "kernel/visit", "daemon/parseDaemonRpcParams"]);
+const allowlist = new Set([
+  "gui/failure",
+  "gui/save",
+  "kernel/visit"
+]);
 const violations = [];
 
 for (const pkg of await discoverPackages()) {
@@ -20,7 +24,7 @@ for (const pkg of await discoverPackages()) {
         const locations = definitions.get(name) ?? [];
         locations.push({
           file: relative(file),
-          line: position.line + 1,
+          line: position.line + 1
         });
         definitions.set(name, locations);
       }
@@ -46,16 +50,18 @@ console.log("Duplicate function definition check passed.");
 
 async function discoverPackages() {
   const rootPackage = JSON.parse(await readFile(path.join(root, "package.json"), "utf8"));
-  const workspaces = Array.isArray(rootPackage.workspaces) ? rootPackage.workspaces : rootPackage.workspaces?.packages;
+  const workspaces = Array.isArray(rootPackage.workspaces)
+    ? rootPackage.workspaces
+    : rootPackage.workspaces?.packages;
   if (!Array.isArray(workspaces)) return [];
 
   const packages = [];
   for (const workspace of workspaces) {
     for (const packageRoot of await expandWorkspace(workspace)) {
-      if (!(await directoryExists(path.join(packageRoot, "src")))) continue;
+      if (!await directoryExists(path.join(packageRoot, "src"))) continue;
       packages.push({
         root: packageRoot,
-        key: await packageKey(packageRoot),
+        key: await packageKey(packageRoot)
       });
     }
   }
@@ -91,7 +97,7 @@ async function walkSourceFiles(dir) {
     const fullPath = path.join(dir, entry.name);
     if (entry.isDirectory()) {
       if (["dist", "node_modules", "out", "test", "tests", "__tests__"].includes(entry.name)) continue;
-      files.push(...(await walkSourceFiles(fullPath)));
+      files.push(...await walkSourceFiles(fullPath));
       continue;
     }
     if (isSourceFile(entry.name)) files.push(fullPath);
@@ -100,12 +106,10 @@ async function walkSourceFiles(dir) {
 }
 
 function isSourceFile(fileName) {
-  return (
-    fileName.endsWith(".ts") &&
-    !fileName.endsWith(".d.ts") &&
-    !fileName.endsWith(".test.ts") &&
-    !fileName.endsWith(".spec.ts")
-  );
+  return fileName.endsWith(".ts")
+    && !fileName.endsWith(".d.ts")
+    && !fileName.endsWith(".test.ts")
+    && !fileName.endsWith(".spec.ts");
 }
 
 function isPureDelegation(node) {
@@ -116,7 +120,8 @@ function isPureDelegation(node) {
   if (ts.isReturnStatement(statement) && statement.expression) {
     return isCallOrAwaitedCall(statement.expression);
   }
-  return ts.isExpressionStatement(statement) && isAwaitedCall(statement.expression);
+  return ts.isExpressionStatement(statement)
+    && isAwaitedCall(statement.expression);
 }
 
 function hasParameterDefault(parameter) {
@@ -139,7 +144,8 @@ function isCallOrAwaitedCall(expression) {
 
 function isAwaitedCall(expression) {
   const unwrapped = unwrapParentheses(expression);
-  return ts.isAwaitExpression(unwrapped) && ts.isCallExpression(unwrapParentheses(unwrapped.expression));
+  return ts.isAwaitExpression(unwrapped)
+    && ts.isCallExpression(unwrapParentheses(unwrapped.expression));
 }
 
 function unwrapParentheses(expression) {


### PR DESCRIPTION
# English

## Summary

PLT-Bedrock C1 (dec_BFA931DAF5B437C60DC12408E7): introduce a typed DaemonRpcMethodMap RPC contract across the daemon protocol and GUI api-client, removing 49 `as unknown as` double assertions on RPC payloads. Requests/responses are now typed at the seam so the GUI and daemon share one contract instead of asserting shapes independently.

## Architectural Justification

- Production-Delta as computed: typed method map + validation replacing double assertions; one shared RPC contract, no new runtime path.

## What Changed

- daemon protocol: DaemonRpcMethodMap contract, rpc-validation, json-rpc-server typed dispatch.
- gui api-client: typed request/response via the shared map.
- removed 49 `as unknown as` assertions.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: Sol committed locally with targeted gates; CI authoritative
- Production net lines: use the single CI-backed `Production-Delta` declaration below; do not enter a second metric.

## Machine-Readable Declarations

Production-Delta: +756/-490
Dependency-Change: none

### Optional Evidence Claims

## Task And Scope

- Harness task: task_2bf0ded03c4f62805ffe458bce
- Branch: codex/bedrock-c1-rpc-map
- Public scope: daemon RPC protocol typing, GUI api-client contract
- Private planning/evidence updated: yes
- Out of scope: C2/C3/C4 of the bedrock decision are separate PRs; shares daemon-protocol.contract.ts with C3 (C3 rebases after)

## Version Impact

- Version: no version change because pre-release internal change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none
- Authority: task_2bf0ded03c4f62805ffe458bce
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: origin/main
- Branch merge-base with `origin/main`: origin/main
- Last `git fetch origin` time: 2026-08-29T03:28:08Z
- Sync method: none needed
- Public diff command: `git diff origin/main...HEAD`
- Private evidence commit/path: harness task package task_2bf0ded03c4f62805ffe458bce (artifacts/reports)
- Reviewer evidence path: same task package
- GitHub Actions `rewrite-ci` run URL: pending
- [x] Worker (Sol): committed locally
- [x] CEO: spot-checked 49 `as unknown as` removed + typed method map, matches dec_BFA931DA C1
- [ ] CI on this PR (authoritative)
- [ ] `npm ci`
- [ ] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Not run: full local matrix by design; CI authoritative.

## Review Evidence

- Self-review: CEO accepted the typed-contract approach per dec_BFA931DA C1 (chosen DaemonRpcMethodMap).
- Reviewer subagent: Sol implemented and committed; CEO semantic acceptance.
- Human review: pending
- Blocking findings: none

## Residual Risk

- Shares daemon-protocol.contract.ts with PLT-Bedrock C3 (not yet dispatched); C3 rebases onto this.

## References

- Task: task_2bf0ded03c4f62805ffe458bce
- Evidence: task package artifacts/reports
- Review: this PR

---

# 中文

## 概要

PLT-Bedrock C1(dec_BFA931DA):在 daemon protocol 与 GUI api-client 之间引入 typed DaemonRpcMethodMap RPC 契约,消除 49 处 RPC payload 上的 `as unknown as` 双重断言。请求/响应在接缝处强类型,GUI 与 daemon 共用一份契约,不再各自断言形状。

## 架构辩护

- Production-Delta 实算:typed method map + 校验替代双断言;共用一份 RPC 契约,不加运行时路径。

## 改动内容

- daemon protocol:DaemonRpcMethodMap 契约、rpc-validation、json-rpc-server typed dispatch。
- gui api-client:经共享 map 强类型请求/响应。
- 删 49 处 `as unknown as`。

## 门收割 / Gate Harvest

- 删除的生产路径:无
- 同 commit 删除的门 / fixture:Sol 本地 commit + 定向门;CI 权威
- 生产净行数:引用英文块中的 `Production-Delta`。

## 机读声明说明

- 见英文块。

## 任务与范围

- Harness 任务:task_2bf0ded03c4f62805ffe458bce
- 分支:codex/bedrock-c1-rpc-map
- 公开范围:daemon RPC 协议类型、GUI api-client 契约
- 私有计划 / 证据是否已更新:yes
- 范围外:该 decision 的 C2/C3/C4 是独立 PR;与 C3 共享 daemon-protocol.contract.ts(C3 随后 rebase)

## 版本影响

- 版本:不改版本,原因是预发布内部改动
- 发布影响:不发布

## 治理声明

- 是否触碰 protected surface:no
- protected surface 范围:none
- 依据:task_2bf0ded03c4f62805ffe458bce
- 机器检查边界:本 PR 只声明该段存在;是否真实、充分由 reviewer 判断。
- Break-glass:no
- Break-glass 原因:不适用
- Break-glass 范围:不适用
- 后续治理任务:不适用

## 验证

- `origin/main` 基准 SHA:origin/main
- 当前分支与 `origin/main` 的 merge-base:origin/main
- 最近一次 `git fetch origin` 时间:2026-08-29T03:28:08Z
- 同步方式:不需要
- 公开 diff 命令:`git diff origin/main...HEAD`
- 私有证据 commit/path:harness 任务包 task_2bf0ded03c4f62805ffe458bce
- Reviewer 证据路径:同上
- GitHub Actions `rewrite-ci` run URL:待定
- [x] worker(Sol):本地 commit
- [x] CEO:抽查删 49 处 `as unknown as` + typed method map,符合 dec_BFA931DA C1
- [ ] 本 PR 的 CI(权威)
- [ ] `npm ci`
- [ ] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- 未运行:按设计不跑本地全量;CI 权威。

## 审查证据

- 自查:CEO 按 dec_BFA931DA C1(选定 DaemonRpcMethodMap)接受 typed 契约方案。
- Reviewer subagent:Sol 实现并提交;CEO 语义验收。
- 人工审查:待定
- 阻塞发现:无

## 残余风险

- 与 PLT-Bedrock C3(尚未派)共享 daemon-protocol.contract.ts;C3 在此之上 rebase。

## 关联材料

- 任务:task_2bf0ded03c4f62805ffe458bce
- 证据:任务包 artifacts/reports
- 审查:本 PR

