### PR TITLE
feat(gui): auto fast-forward to origin/main before launching dev shell

### DIFF
--- a/packages/gui/scripts/dev-electron.mjs
+++ b/packages/gui/scripts/dev-electron.mjs
@@ -13,6 +13,37 @@ const require = createRequire(import.meta.url);
 const guiRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const repoRoot = path.resolve(guiRoot, "../..");
 const rendererUrl = "http://127.0.0.1:5173";
+
+// Auto fast-forward the local checkout to origin/main before building, so the
+// launcher always ships the latest merged GUI. Main is never developed on
+// directly — all work lands through worktree PRs — so a clean fast-forward is
+// always safe. Skip loudly (never fail the launch) when the checkout is not on
+// main or the working tree is dirty; the daemon reads its canonical ledger from
+// ~/.harness, not this source tree, so a source fast-forward does not disturb it.
+function fastForwardToOriginMain() {
+  const branch = spawnSync("git", ["rev-parse", "--abbrev-ref", "HEAD"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+  }).stdout?.trim();
+  if (branch !== "main") {
+    log(`on '${branch}', not main — skipping auto fast-forward`);
+    return;
+  }
+  if (spawnSync("git", ["status", "--porcelain"], { cwd: repoRoot, encoding: "utf8" }).stdout?.trim()) {
+    log("working tree dirty — skipping auto fast-forward");
+    return;
+  }
+  log("fetching origin/main...");
+  if (spawnSync("git", ["fetch", "origin", "main"], { cwd: repoRoot, stdio: "inherit" }).status !== 0) {
+    log("git fetch failed — building current checkout");
+    return;
+  }
+  const ff = spawnSync("git", ["merge", "--ff-only", "origin/main"], { cwd: repoRoot, encoding: "utf8" });
+  if (ff.status === 0) log("fast-forwarded to origin/main");
+  else log(`not fast-forwardable (local diverged?) — building current checkout: ${(ff.stderr || "").trim()}`);
+}
+fastForwardToOriginMain();
+
 const electronPath = require("electron");
 // Resolve vite's own bin script through Node's module resolution rather than shelling
 // out to npx: npx.cmd resolves its own npm-cli.js relative to the invoking npm script's
@@ -28,7 +59,7 @@ function log(message) {
 log("building preload bundle...");
 const preloadBuild = spawnSync(process.execPath, [viteBin, "build", "--config", "vite.preload.config.ts"], {
   cwd: guiRoot,
-  stdio: "inherit"
+  stdio: "inherit",
 });
 if (preloadBuild.status !== 0) {
   console.error("[dev-electron] preload build failed");
@@ -39,7 +70,7 @@ log(`starting renderer dev server at ${rendererUrl} ...`);
 const vite = spawn(process.execPath, [viteBin, "--host", "127.0.0.1", "--port", "5173", "--strictPort"], {
   cwd: guiRoot,
   env: { ...process.env, BROWSER: "none" },
-  stdio: ["ignore", "pipe", "pipe"]
+  stdio: ["ignore", "pipe", "pipe"],
 });
 // Forwarding stdout (previously discarded) surfaces Vite's own diagnostics, including its
 // "ready in" banner, in the launcher log instead of the poll loop being the only witness.
@@ -73,7 +104,7 @@ async function stopVite() {
   vite.kill("SIGTERM");
   const closed = once(vite, "close");
   const timedOut = new Promise((resolveSleep) => setTimeout(() => resolveSleep("timeout"), 5_000));
-  if (await Promise.race([closed, timedOut]) === "timeout") {
+  if ((await Promise.race([closed, timedOut])) === "timeout") {
     vite.kill("SIGKILL");
     await once(vite, "close").catch(() => undefined);
   }
@@ -93,9 +124,9 @@ const electron = spawn(electronPath, [path.join(guiRoot, "src/main/electron-main
   env: {
     ...process.env,
     ELECTRON_RENDERER_URL: rendererUrl,
-    HARNESS_GUI_ROOT: process.env.HARNESS_GUI_ROOT ?? repoRoot
+    HARNESS_GUI_ROOT: process.env.HARNESS_GUI_ROOT ?? repoRoot,
   },
-  stdio: "inherit"
+  stdio: "inherit",
 });
 
 const shutdown = async (code) => {


### PR DESCRIPTION
# English

## Summary
The GUI dev launcher (`dev-electron.mjs`) now fast-forwards the local checkout to `origin/main` before building, so launching always ships the latest merged GUI instead of a stale local build.

## What Changed
- Added `fastForwardToOriginMain()` to `packages/gui/scripts/dev-electron.mjs`, invoked before the preload/renderer build.
- Guards: runs only when on `main` and the working tree is clean; otherwise logs and skips. Never fails the launch (fetch/merge errors fall back to building the current checkout).

## Gate Harvest / 门收割
- No gate changes.

## Machine-Readable Declarations
Production-Delta: +0/-0

## Task And Scope
Addresses recurring friction: the human kept launching a stale GUI because local `main` lagged `origin/main` while all real work happens in worktree PRs. Rationale recorded under milestone `task_5fc5080044fcfdbf548008f2f5`.

## Version Impact
None (dev launcher tooling only; not shipped runtime).

## Governance Declaration
No protected surface, CI, or gate touched.

## Verification
- `node --check` passes.
- On a non-`main` branch the hook logs `not main — skipping` and does not mutate the tree (verified in the worktree).
- The daemon reads its canonical ledger from `~/.harness`, not this source tree, so a source fast-forward does not disturb running agents (fact-backed: worker-hosts are detached + re-adopted on daemon restart).

## Review Evidence
CEO direct change (known, bounded diff). Single-file dev launcher tweak.

## Residual Risk
Low. If `origin/main` is unreachable or the tree is dirty, the launcher silently builds the current checkout (fail-open by design).

## References
Milestone task_5fc5080044fcfdbf548008f2f5.

# 中文

## 概要
GUI 开发启动器(`dev-electron.mjs`)现在在构建前把本地 checkout 快进到 `origin/main`,启动即最新合并版 GUI,不再起旧的本地构建。

## 改动内容
- 在 `packages/gui/scripts/dev-electron.mjs` 加 `fastForwardToOriginMain()`,构建前调用。
- 守卫:仅当在 `main` 且工作树干净时执行;否则记日志跳过;永不使启动失败(fetch/merge 出错则退回构建当前 checkout)。

## 门收割 / Gate Harvest
- 无门改动。

## 机读声明说明
见英文块 Production-Delta。

## 任务与范围
解决反复摩擦:本地 main 落后 origin/main、而所有开发都在 worktree PR,导致人老是起旧 GUI。理由记于里程碑 task_5fc5080044fcfdbf548008f2f5。

## 版本影响
无(仅开发启动器工具,非发布运行时)。

## 治理声明
未触碰 protected surface / CI / gate。

## 验证
- `node --check` 通过。
- 非 main 分支下钩子记录 skip 且不改动工作树(worktree 内已验)。
- daemon 从 ~/.harness 读 canonical 台账、不读本源码树,源码快进不扰在飞 agent(有 fact 支撑:worker-host detached + daemon 重启重新收养)。

## 残留风险
低。origin/main 不可达或工作树脏时,启动器静默构建当前 checkout(设计为 fail-open)。
