### PR TITLE
fix(daemon): bound runtime dispatch recovery so a runaway session cannot wedge the ledger

### DIFF
--- a/packages/cli/test/squad-cancel-command.test.ts
+++ b/packages/cli/test/squad-cancel-command.test.ts
@@ -1,0 +1,17 @@
+// harness-test-tier: fast
+import assert from "node:assert/strict";
+import test from "node:test";
+import { parseThinCommand } from "../src/cli/thin-command.ts";
+
+test("squad cancel routes a required run id through the daemon", () => {
+  const parsed = parseThinCommand(["squad", "cancel", "squad_0123456789abcdef01234567"]);
+  assert.equal(parsed.ok, true);
+  if (parsed.ok) {
+    assert.equal(parsed.command.method, "repo.task.run");
+    assert.deepEqual(parsed.command.action, {
+      kind: "squad-cancel",
+      squadRunId: "squad_0123456789abcdef01234567",
+    });
+  }
+  assert.equal(parseThinCommand(["squad", "cancel"]).ok, false);
+});

--- a/packages/cli/test/thin-command-contract-parity.test.ts
+++ b/packages/cli/test/thin-command-contract-parity.test.ts
@@ -48,7 +48,7 @@ const frozenMutations = Object.freeze([
 ] as const);
 
 test("all public commands expose the canonical structured input facet", () => {
-  assert.equal(daemonProtocolCommands.length, 136);
+  assert.equal(daemonProtocolCommands.length, 137);
   for (const command of daemonProtocolCommands) {
     assert.equal(Object.hasOwn(command, "inputs"), true, `${command.id}: explicit inputs`);
     assert.deepEqual(deriveThinCliInputs(command), command.inputs, command.id);

--- a/packages/cli/test/thin-command.test.ts
+++ b/packages/cli/test/thin-command.test.ts
@@ -8,7 +8,7 @@ import { emit, main, resolveCliVersion } from "../src/index.ts";
 
 test("top-level help renders a derived domain directory and domain help filters commands", () => {
   const help = renderThinHelp();
-  assert.equal(thinCliCommands.length, 135);
+  assert.equal(thinCliCommands.length, 136);
   for (const domain of [...new Set(daemonProtocolCommands.map((command) => command.path[0]))]
     .filter((value): value is string => value !== undefined)
     .sort())
@@ -165,7 +165,15 @@ test("capabilities is an exact-set projection of the command contract", () => {
       "people-revoke-delegation",
       "people-set-role",
     ],
-    squad: ["squad-inspect", "squad-install", "squad-list", "squad-run", "squad-status", "squad-validate"],
+    squad: [
+      "squad-cancel",
+      "squad-inspect",
+      "squad-install",
+      "squad-list",
+      "squad-run",
+      "squad-status",
+      "squad-validate",
+    ],
     task: [
       "task-amend",
       "task-archive",

--- a/packages/daemon/src/dispatch-stream.ts
+++ b/packages/daemon/src/dispatch-stream.ts
@@ -127,6 +127,10 @@ type SummaryCacheEntry = {
 const summaryCache = new Map<string, SummaryCacheEntry>();
 const summaryHeadBytes = 16 * 1024;
 const summaryTailBytes = 128 * 1024;
+const dispatchStreamReadLimitBytes = 200 * 1024 * 1024;
+const dispatchStreamWriteLimitBytes = 500 * 1024 * 1024;
+const readLimitWarnings = new Set<string>();
+const writeLimitWarnings = new Set<string>();
 const summaryKinds = new Set([
   "provider_binding",
   "process_started",
@@ -135,6 +139,7 @@ const summaryKinds = new Set([
   "attempt_outcome",
   "fallback_state",
   "squad_run_state",
+  "squad_run_cancelled",
 ]);
 
 export function openDispatchStream(
@@ -189,6 +194,8 @@ export function removeDispatchStream(rootDir: string, dispatchId: string): void 
   const target = dispatchStreamPath(rootDir, dispatchId),
     header = readDispatchStreamHeader(rootDir, dispatchId);
   summaryCache.delete(target);
+  readLimitWarnings.delete(target);
+  writeLimitWarnings.delete(target);
   if (existsSync(target)) unlinkSync(target);
   if (header?.taskId)
     removeDispatchLiveIndexEntries(rootDir, [
@@ -335,7 +342,13 @@ export function readDispatchStream(
   readonly records: readonly DispatchStreamRecord[];
 } | null {
   const target = dispatchStreamPath(rootDir, dispatchId);
-  if (!existsSync(target) || !statSync(target).isFile()) return null;
+  if (!existsSync(target)) return null;
+  const stat = statSync(target);
+  if (!stat.isFile()) return null;
+  if (stat.size > dispatchStreamReadLimitBytes) {
+    warnOnce(readLimitWarnings, target, `skipping full read of ${path.basename(target)} at ${String(stat.size)} bytes`);
+    return null;
+  }
   const lines = readFileSync(target, "utf8").split(/\r?\n/u).filter(Boolean),
     first = parseRecord(lines[0]);
   if (!isHeader(first) || first.dispatchId !== dispatchId) return null;
@@ -468,10 +481,35 @@ function appendJsonl(target: string, value: unknown): void {
   summaryCache.delete(target);
   const descriptor = openSync(target, fsConstants.O_APPEND | fsConstants.O_WRONLY);
   try {
+    const size = fstatSync(descriptor).size;
+    if (size >= dispatchStreamWriteLimitBytes && unboundedDispatchRecord(value)) {
+      warnOnce(
+        writeLimitWarnings,
+        target,
+        `${path.basename(target)} reached ${String(dispatchStreamWriteLimitBytes)} bytes; dropping unbounded output`,
+      );
+      return;
+    }
     writeFileSync(descriptor, `${JSON.stringify(scrubProviderValue(value))}\n`, "utf8");
   } finally {
     closeSync(descriptor);
   }
+}
+
+function unboundedDispatchRecord(value: unknown): boolean {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const record = value as Record<string, unknown>;
+  if (["provider_event", "provider_output_invalid", "provider_stderr"].includes(String(record.kind))) return true;
+  if (record.kind !== "squad_run_state") return false;
+  const state = record.state;
+  if (!state || typeof state !== "object" || Array.isArray(state)) return true;
+  return !["cancelled", "converged", "failed"].includes(String((state as Record<string, unknown>).phase));
+}
+
+function warnOnce(warnings: Set<string>, target: string, detail: string): void {
+  if (warnings.has(target)) return;
+  warnings.add(target);
+  console.warn(`[runtime-dispatch] ${detail}`);
 }
 
 function summarizeDispatch(

--- a/packages/daemon/src/protocol/daemon-protocol-commands-agent.ts
+++ b/packages/daemon/src/protocol/daemon-protocol-commands-agent.ts
@@ -172,6 +172,15 @@ export const agentProtocolCommands = Object.freeze([
     positional: "squadRunId",
     inputs: [],
   }),
+  defineRuntimeLocalWriteCommand({
+    id: "squad-cancel",
+    phase: "Runtime-B",
+    path: ["squad", "cancel", "<squad-run-id>"],
+    summary: "Durably cancel a Squad run and terminate its leader and worker runtimes.",
+    method: "repo.task.run",
+    positional: "squadRunId",
+    inputs: [],
+  }),
   defineLedgerWriteCommand({
     id: "ledger-migrate",
     phase: "Migration-A",

--- a/packages/daemon/src/repo-cell-api.ts
+++ b/packages/daemon/src/repo-cell-api.ts
@@ -105,6 +105,14 @@ export function createRepoCellApi(context: any): RepoCell {
     };
     if (action.kind === "squad-run")
       return enqueuePublication(() => context.squadCoordinator.start(action, binding) as unknown as WriteReceipt);
+    if (action.kind === "squad-cancel")
+      return enqueuePublication(
+        () =>
+          context.squadCoordinator.cancel(
+            context.requiredCellText(action.squadRunId, "squadRunId"),
+            binding,
+          ) as unknown as WriteReceipt,
+      );
     if (action.kind === "squad-status")
       return Promise.resolve(
         context.squadCoordinator.status(

--- a/packages/daemon/src/repo-cell-lock.ts
+++ b/packages/daemon/src/repo-cell-lock.ts
@@ -27,7 +27,6 @@ export async function acquireWorkspaceLock(rootDir: CanonicalRoot): Promise<{ re
   let descriptor: number;
   try {
     descriptor = openSync(lockPath, "wx", 0o600);
-    writeFileSync(descriptor, `${process.pid}\n`, "utf8");
   } catch (error) {
     if (!staleWriterLock(lockPath))
       throw cellCodedError(
@@ -38,13 +37,27 @@ export async function acquireWorkspaceLock(rootDir: CanonicalRoot): Promise<{ re
     unlinkSync(lockPath);
     try {
       descriptor = openSync(lockPath, "wx", 0o600);
-      writeFileSync(descriptor, `${process.pid}\n`, "utf8");
     } catch (retry) {
       throw cellCodedError(
         "writer_rejected",
         `Workspace writer lock recovery raced for ${rootDir}: ${cellErrorMessage(retry)}`,
       );
     }
+  }
+  try {
+    writeFileSync(descriptor, `${process.pid}\n`, "utf8");
+  } catch (error) {
+    closeSync(descriptor);
+    try {
+      unlinkSync(lockPath);
+    } catch (cleanupError) {
+      if (cellErrorCode(cleanupError) !== "ENOENT") throw cleanupError;
+      consumeKnownError(cleanupError);
+    }
+    throw cellCodedError(
+      "writer_rejected",
+      `Workspace writer lock could not be initialized for ${rootDir}: ${cellErrorMessage(error)}`,
+    );
   }
   let closed = false;
   return {

--- a/packages/daemon/src/repo-cell-open.ts
+++ b/packages/daemon/src/repo-cell-open.ts
@@ -135,14 +135,26 @@ export async function openRepoCell(input: {
   /** Host-owned fleet roster snapshot (remote-center schedule reads); resolved per read. */
   readonly fleetRoster?: () => FleetRoster | null;
 }): Promise<RepoCell> {
+  const lock = await acquireWorkspaceLock(input.rootDir);
+  try {
+    return await openLockedRepoCell(input, lock);
+  } catch (error) {
+    await lock.close();
+    throw error;
+  }
+}
+
+async function openLockedRepoCell(
+  input: Parameters<typeof openRepoCell>[0],
+  lock: Awaited<ReturnType<typeof acquireWorkspaceLock>>,
+): Promise<RepoCell> {
   const rootDir = input.rootDir,
     mode = input.mode ?? "local",
     now = input.now ?? (() => new Date().toISOString());
   let readSettings = (): SettingsV1 => {
     throw cellCodedError("projection_pending", "Settings projection is unavailable while the RepoCell is opening.");
   };
-  const lock = await acquireWorkspaceLock(rootDir),
-    generation = Date.now() * 1_000 + (process.pid % 1_000);
+  const generation = Date.now() * 1_000 + (process.pid % 1_000);
   const activeWriter: WriterGeneration = {
       workspaceId: input.repoId,
       generation,
@@ -151,15 +163,10 @@ export async function openRepoCell(input: {
     writerToken = bindWriterGenerationToken(activeWriter);
   let authoredBranch = input.authoredBranch,
     bootstrapReceipt: RepoBootstrapReceipt | undefined;
-  try {
-    if (input.bootstrap) {
-      bootstrapReceipt = bootstrapRepo(input.bootstrap, activeWriter, writerToken, authoredBranch);
-      authoredBranch = bootstrapReceipt.authoredBranch;
-      input.onBootstrap?.(bootstrapReceipt);
-    }
-  } catch (error) {
-    await lock.close();
-    throw error;
+  if (input.bootstrap) {
+    bootstrapReceipt = bootstrapRepo(input.bootstrap, activeWriter, writerToken, authoredBranch);
+    authoredBranch = bootstrapReceipt.authoredBranch;
+    input.onBootstrap?.(bootstrapReceipt);
   }
   const presetProcess = createPresetProcessService({
     rootDir,
@@ -201,7 +208,6 @@ export async function openRepoCell(input: {
   } catch (error) {
     runtimeStream.close();
     await presetProcess.close();
-    await lock.close();
     throw error;
   }
   let { store, recovery, projection, entityActionExecutor, runtimeReads, service, replica } = core;

--- a/packages/daemon/src/runtime-spawn-adoption.ts
+++ b/packages/daemon/src/runtime-spawn-adoption.ts
@@ -29,14 +29,16 @@ export async function adoptRuntimes(context: any): Promise<void> {
       | undefined;
     const metadata = adoptableMetadata(header);
     if (!session || session.liveness === "exited" || session.outcome !== null || !metadata) continue;
-    const stream = readDispatchStream(context.input.rootDir, header.dispatchId);
+    const fullStream = readDispatchStream(context.input.rootDir, header.dispatchId),
+      stream = fullStream ?? readDispatchStreamSummary(context.input.rootDir, header.dispatchId);
     if (!stream?.process) continue;
     const runtimeProcess = adoptNativeProcess(
       context.input.rootDir,
       stream.header.dispatchId,
       stream.process.pid,
-      durableOutputRecordCount(stream.records),
+      durableOutputRecordCount(fullStream?.records ?? []),
     );
+    if (!fullStream) runtimeProcess.release?.();
     const active = createActiveRuntime({
       process: runtimeProcess,
       dispatchId: stream.header.dispatchId,
@@ -79,7 +81,7 @@ export async function adoptRuntimes(context: any): Promise<void> {
       providerSessionId: stream.providerSessionId,
     });
     context.processes.set(active.runtimeSessionId, active);
-    await restoreDurableOutputRecords(context, active, stream.records);
+    await restoreDurableOutputRecords(context, active, fullStream?.records ?? []);
     if (session.liveness !== "live") {
       await context.publishRuntimeEvent(
         "runtime_session_liveness_changed",
@@ -88,11 +90,13 @@ export async function adoptRuntimes(context: any): Promise<void> {
         active.binding,
       );
     }
-    attachActiveRuntime(context, active);
+    if (fullStream) attachActiveRuntime(context, active);
     const processState = stream.process;
     if (processState && !processState.exited && !runtimePidIsAlive(processState.pid)) {
       const timer = setTimeout(() => {
-        const current = readDispatchStream(context.input.rootDir, active.dispatchId);
+        const current =
+          readDispatchStream(context.input.rootDir, active.dispatchId) ??
+          readDispatchStreamSummary(context.input.rootDir, active.dispatchId);
         if (!current?.process?.exited && context.processes.get(active.runtimeSessionId) === active) {
           const reason = `runtime process ${String(processState.pid)} is no longer alive after daemon restart`;
           active.lossReason = reason;

--- a/packages/daemon/src/squad-coordinator.ts
+++ b/packages/daemon/src/squad-coordinator.ts
@@ -73,6 +73,7 @@ export function makeSquadCoordinator(input: {
   readonly reacquireTaskLease: (taskId: string, binding: RuntimeBinding) => Promise<void>;
   readonly runtimeSpawner: () => {
     readonly spawn: (payload: JsonObject, binding: RuntimeBinding) => Promise<JsonObject>;
+    readonly cancel: (payload: JsonObject, binding: RuntimeBinding) => Promise<JsonObject>;
   };
 }) {
   const start = async (action: JsonObject, binding: RuntimeBinding): Promise<JsonObject> => {
@@ -162,6 +163,54 @@ export function makeSquadCoordinator(input: {
       ...detail,
       status: state.phase,
       summary: `squad-run ${state.squadId}: ${state.phase}`,
+      exitCode: 0,
+    };
+  };
+
+  const cancel = async (squadRunId: string, binding: RuntimeBinding): Promise<JsonObject> => {
+    if (!validSquadRunId(squadRunId))
+      return rejection(
+        "squad-cancel",
+        "invalid_squad_run_id",
+        "Use the squad_<24 lowercase hex characters> handle returned by ha squad run.",
+      );
+    const state = readSquadRunState(squadRunId);
+    if (!state) return rejection("squad-cancel", "squad_run_not_found", `Squad run ${squadRunId} does not exist.`);
+    if (state.phase !== "cancelled")
+      writeState(
+        revise(state, {
+          currentLeaderRuntimeSessionId: null,
+          workerWaits: [],
+          pendingLeaderTriggers: [],
+          phase: "cancelled",
+          error: null,
+        }),
+      );
+    const runtimeSessionIds = [
+      ...state.leaderTurns.map((turn) => turn.runtimeSessionId),
+      ...state.workerAttempts.flatMap((attempt) => (attempt.runtimeSessionId ? [attempt.runtimeSessionId] : [])),
+    ];
+    const results = await Promise.allSettled(
+      [...new Set(runtimeSessionIds)].map((runtimeSessionId) =>
+        input.runtimeSpawner().cancel({ runtimeSessionId }, binding),
+      ),
+    );
+    const failures = results.filter((result) => result.status === "rejected");
+    if (failures.length > 0)
+      return rejection(
+        "squad-cancel",
+        "squad_cancel_incomplete",
+        `Squad run ${squadRunId} is durably cancelled, but ${String(failures.length)} runtime cancellation(s) failed.`,
+      );
+    return {
+      schema: "command-receipt/v2",
+      ok: true,
+      command: "squad-cancel",
+      outcome: "applied",
+      squadRunId,
+      status: "cancelled",
+      summary: `squad-run ${state.squadId}: cancelled`,
+      nextAction: null,
       exitCode: 0,
     };
   };
@@ -645,6 +694,23 @@ export function makeSquadCoordinator(input: {
     const states = new Map<string, SquadState>();
     for (const stream of readDispatchStreamSummaries(input.rootDir)) {
       for (const record of stream.records) {
+        if (record.kind === "squad_run_cancelled") {
+          const squadRunId = record.squadRunId,
+            revision = record.revision;
+          if (typeof squadRunId !== "string" || !Number.isSafeInteger(revision)) continue;
+          const current = states.get(squadRunId);
+          if (current && current.revision < Number(revision))
+            states.set(squadRunId, {
+              ...current,
+              currentLeaderRuntimeSessionId: null,
+              workerWaits: [],
+              pendingLeaderTriggers: [],
+              phase: "cancelled",
+              revision: Number(revision),
+              error: null,
+            });
+          continue;
+        }
         if (record.kind !== "squad_run_state") continue;
         const state = squadState(record.state);
         if (!state) continue;
@@ -672,6 +738,12 @@ export function makeSquadCoordinator(input: {
       revision: state.revision,
       state,
     });
+    if (state.phase === "cancelled")
+      appendRuntimeWorkerRecord(input.rootDir, state.stateDispatchId, {
+        kind: "squad_run_cancelled",
+        squadRunId: state.squadRunId,
+        revision: state.revision,
+      });
     projection.upsertSquadRun({ squadRunId: state.squadRunId, revision: state.revision, state });
   }
 
@@ -788,7 +860,7 @@ export function makeSquadCoordinator(input: {
     };
   }
 
-  return { start, status, list, read, observeOutcome, reconcile };
+  return { start, status, cancel, list, read, observeOutcome, reconcile };
 }
 
 function squadState(value: unknown): SquadState | null {
@@ -818,7 +890,7 @@ function revise(
 }
 
 function terminal(state: SquadState): boolean {
-  return state.phase === "converged" || state.phase === "failed";
+  return state.phase === "cancelled" || state.phase === "converged" || state.phase === "failed";
 }
 
 function requiredSquadText(value: unknown, field: string): string {

--- a/packages/daemon/src/squad-run-contract.ts
+++ b/packages/daemon/src/squad-run-contract.ts
@@ -1,4 +1,4 @@
-export type SquadRunPhase = "planning" | "leader_running" | "workers_running" | "converged" | "failed";
+export type SquadRunPhase = "planning" | "leader_running" | "workers_running" | "cancelled" | "converged" | "failed";
 
 export interface SquadRunSummaryDto {
   readonly squadRunId: string;
@@ -79,7 +79,14 @@ export type SquadRunReadResult = {
   readonly sourceRevision: number;
 };
 
-const phases: readonly SquadRunPhase[] = ["planning", "leader_running", "workers_running", "converged", "failed"];
+const phases: readonly SquadRunPhase[] = [
+  "planning",
+  "leader_running",
+  "workers_running",
+  "cancelled",
+  "converged",
+  "failed",
+];
 const turnStatuses: readonly SquadRunTurnStatus[] = ["running", "succeeded", "failed", "unknown", "cancelled", "lost"];
 
 export function validateSquadRunsList(value: unknown): readonly string[] {

--- a/packages/daemon/test/command-admission.test.ts
+++ b/packages/daemon/test/command-admission.test.ts
@@ -10,8 +10,8 @@ const localSource = "local" as const;
 const assignmentSource = { kind: "assignment", nodeId: "edge-one", assignmentId: "assignment-one" } as const;
 const admissionRoutes = new Set(["direct", "via-assignment", "via-center-forward", "rejected"]);
 
-test("all 136 daemon commands close every repo-mode admission cell", () => {
-  assert.equal(daemonProtocolCommands.length, 136);
+test("all 137 daemon commands close every repo-mode admission cell", () => {
+  assert.equal(daemonProtocolCommands.length, 137);
   let cells = 0;
   for (const command of daemonProtocolCommands) {
     assert.deepEqual(Object.keys(command.admission).sort(), [...daemonRepoModeWords].sort(), command.id);
@@ -35,7 +35,7 @@ test("all 136 daemon commands close every repo-mode admission cell", () => {
       }
     }
   }
-  assert.equal(cells, 136 * 3);
+  assert.equal(cells, 137 * 3);
 });
 
 test("observe.tail declares direct admission and named source residency for every tail kind", () => {

--- a/packages/daemon/test/dispatch-stream.test.ts
+++ b/packages/daemon/test/dispatch-stream.test.ts
@@ -1,17 +1,20 @@
 // harness-test-tier: fast
 import assert from "node:assert/strict";
-import { mkdtempSync, rmSync } from "node:fs";
+import { appendFileSync, mkdtempSync, rmSync, statSync, truncateSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
 import {
   appendRuntimeWorkerRecord,
   dispatchLiveIndexPath,
+  dispatchStreamPath,
   openDispatchStream,
   readDispatchLiveIndex,
   readDispatchStream,
   readDispatchStreamSummary,
 } from "../src/dispatch-stream.ts";
+import { adoptRuntimes } from "../src/runtime-spawn-adoption.ts";
+import { cancelRuntime } from "../src/runtime-spawn-control.ts";
 
 test("the live index rebuilds exactly from dispatch stream headers", () => {
   const rootDir = mkdtempSync(path.join(tmpdir(), "ha-dispatch-live-index-"));
@@ -102,6 +105,121 @@ test("dispatch summaries skip provider bodies and refresh when lifecycle records
       ["process_started", "process_exit"],
     );
   } finally {
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});
+
+test("adoption skips a stream above Node's string limit while runtime cancel still stops the process", async () => {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-dispatch-oversized-read-"));
+  const warning = console.warn,
+    warnings: string[] = [];
+  console.warn = (value: unknown) => warnings.push(String(value));
+  try {
+    const dispatchId = "dispatch_777777777777777777777777",
+      target = dispatchStreamPath(rootDir, dispatchId);
+    openDispatchStream(rootDir, {
+      dispatchId,
+      taskId: "task-oversized",
+      executionId: "execution-oversized",
+      runtimeSessionId: "runtime_777777777777777777777777",
+      instanceId: "instance-1",
+      startedAt: "2026-08-29T00:00:00.000Z",
+      dispatchOpId: "dispatch-op-oversized",
+      kindId: "codex",
+      permissionMode: null,
+      binding: {
+        actor: { principal: { personId: "operator" }, executor: null },
+        source: "local",
+      },
+      cwd: rootDir,
+      prompt: "oversized adoption",
+      model: "gpt-5.6-sol",
+      reasoningEffort: null,
+    });
+    appendRuntimeWorkerRecord(rootDir, dispatchId, { kind: "process_started", pid: process.pid });
+    truncateSync(target, 600 * 1024 * 1024);
+
+    const adopted = new Map(),
+      context = {
+        input: { rootDir, repoId: "oversized-read" },
+        requiredRuntimeProjection: () => ({
+          readRuntimeSessions: () => [
+            {
+              runtimeSessionId: "runtime_777777777777777777777777",
+              liveness: "live",
+              outcome: null,
+            },
+          ],
+        }),
+        processes: adopted,
+      };
+    await adoptRuntimes(context);
+    assert.equal(adopted.size, 1);
+    assert.equal(readDispatchStream(rootDir, dispatchId), null);
+    assert.equal(statSync(target).size, 600 * 1024 * 1024);
+    assert.match(warnings.join("\n"), /skipping full read/u);
+    let terminated = false,
+      published = false;
+    const runtimeSessionId = "runtime_777777777777777777777777",
+      active = adopted.get(runtimeSessionId);
+    assert.ok(active);
+    active.process.terminateTree = async () => {
+      terminated = true;
+    };
+    const receipt = await cancelRuntime(
+      {
+        ...context,
+        publishExit: async () => {
+          published = true;
+        },
+        controlReceipt: () => ({ ok: true, detail: "cancelled" }),
+      },
+      { runtimeSessionId },
+      { actor: { principal: { personId: "operator" }, executor: null }, source: "local" },
+    );
+    assert.equal(receipt.detail, "cancelled");
+    assert.equal(terminated, true);
+    assert.equal(published, true);
+  } finally {
+    console.warn = warning;
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});
+
+test("the dispatch fuse drops unbounded output but preserves terminal records", () => {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-dispatch-write-fuse-"));
+  const warning = console.warn,
+    warnings: string[] = [];
+  console.warn = (value: unknown) => warnings.push(String(value));
+  try {
+    const dispatchId = "dispatch_888888888888888888888888",
+      target = dispatchStreamPath(rootDir, dispatchId);
+    openDispatchStream(rootDir, {
+      dispatchId,
+      taskId: "task-fused",
+      executionId: "execution-fused",
+      runtimeSessionId: "runtime_888888888888888888888888",
+      instanceId: "instance-1",
+      startedAt: "2026-08-29T00:00:00.000Z",
+    });
+    appendRuntimeWorkerRecord(rootDir, dispatchId, { kind: "process_started", pid: 8765 });
+    truncateSync(target, 500 * 1024 * 1024 - 1);
+    appendFileSync(target, "\n");
+    const cappedSize = statSync(target).size;
+
+    appendRuntimeWorkerRecord(rootDir, dispatchId, { kind: "provider_event", event: { text: "dropped" } });
+    assert.equal(statSync(target).size, cappedSize);
+    appendRuntimeWorkerRecord(rootDir, dispatchId, { kind: "process_exit", exitCode: 1, signal: null });
+    assert.ok(statSync(target).size > cappedSize);
+    assert.deepEqual(readDispatchStreamSummary(rootDir, dispatchId)?.process, {
+      pid: 8765,
+      exitCode: 1,
+      signal: null,
+      exited: true,
+    });
+    assert.match(warnings.join("\n"), /dropping unbounded output/u);
+  } finally {
+    console.warn = warning;
     rmSync(rootDir, { recursive: true, force: true });
   }
 });

--- a/packages/daemon/test/repo-cell-lock-release.integration.test.ts
+++ b/packages/daemon/test/repo-cell-lock-release.integration.test.ts
@@ -1,0 +1,52 @@
+// harness-test-tier: integration
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdtempSync, realpathSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { canonicalRoot, workspaceId } from "../src/protocol/daemon-protocol.contract.ts";
+import { resolveRepoBootstrap } from "../src/repo-bootstrap.ts";
+import { openRepoCell } from "../src/repo-cell.ts";
+import type { DaemonAuthenticationContext } from "../src/transport/auth-context.ts";
+
+const auth = {
+  transportKind: "unix-socket",
+  unixSocketOwnerBoundary: {
+    ownerUid: process.getuid?.() ?? 0,
+    source: "unix-socket-filesystem-owner-boundary",
+  },
+} as unknown as DaemonAuthenticationContext;
+
+test("a post-initialize open failure releases the workspace lock for the next attach", async () => {
+  const rootDir = realpathSync(mkdtempSync(path.join(tmpdir(), "ha-open-lock-release-"))),
+    lockPath = `${rootDir}.harness-anything-writer.lock`;
+  try {
+    execFileSync("git", ["-C", rootDir, "init", "-q"]);
+    const bootstrap = resolveRepoBootstrap(
+      { rootDir, repoId: "lock-release", personId: "owner", displayName: "Owner" },
+      auth,
+    );
+    await assert.rejects(
+      openRepoCell({
+        rootDir: canonicalRoot(rootDir),
+        repoId: workspaceId("lock-release"),
+        ownerId: "lock-release-failure",
+        bootstrap,
+        killpoint: (point) => {
+          if (point === "before_event_write") throw new Error("post-initialize failure");
+        },
+      }),
+      /post-initialize failure/u,
+    );
+    assert.equal(existsSync(lockPath), false);
+    const reopened = await openRepoCell({
+      rootDir: canonicalRoot(rootDir),
+      repoId: workspaceId("lock-release"),
+      ownerId: "lock-release-successor",
+    });
+    await reopened.close();
+  } finally {
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});

--- a/packages/daemon/test/squad-coordinator-recovery.test.ts
+++ b/packages/daemon/test/squad-coordinator-recovery.test.ts
@@ -1,6 +1,6 @@
 // harness-test-tier: fast
 import assert from "node:assert/strict";
-import { mkdtempSync, rmSync } from "node:fs";
+import { appendFileSync, mkdtempSync, rmSync, truncateSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -11,7 +11,7 @@ import type {
   TaskProjection,
 } from "../../kernel/src/index.ts";
 import { makeSquadCoordinator } from "../src/squad-coordinator.ts";
-import { appendRuntimeWorkerRecord, openDispatchStream } from "../src/dispatch-stream.ts";
+import { appendRuntimeWorkerRecord, dispatchStreamPath, openDispatchStream } from "../src/dispatch-stream.ts";
 import type { JsonObject } from "../src/protocol/json-rpc-types.ts";
 
 const SQUAD_RUN_ID = "squad_0123456789abcdef01234567",
@@ -33,8 +33,10 @@ type SeedWorker = {
 type RecoveryFixture = {
   readonly coordinator: ReturnType<typeof makeSquadCoordinator>;
   readonly spawns: JsonObject[];
+  readonly cancellations: JsonObject[];
   readonly reacquired: () => number;
   readonly state: () => Readonly<Record<string, unknown>>;
+  readonly resetProjection: () => void;
   readonly completeLeader: (runtimeSessionId: string, result: string) => void;
   readonly completeWorker: (runtimeSessionId: string) => void;
 };
@@ -72,6 +74,7 @@ function makeRecoveryFixture(
     ]),
     rows: { squadRunId: string; revision: number; state: Readonly<Record<string, unknown>> }[] = [],
     spawns: JsonObject[] = [],
+    cancellations: JsonObject[] = [],
     resultBodies = new Map<string, Uint8Array>(),
     reportLogicalPath = `tasks/${TASK_ID}/${SYNTHESIS_REPORT_PATH}`,
     reportDocument = options.leaderReport
@@ -284,14 +287,22 @@ function makeRecoveryFixture(
           sessions.push(runtimeSession(runtimeSessionId, null, null, "provider-leader"));
           return Promise.resolve({ ok: true, dispatchId, runtimeSessionId });
         },
+        cancel: (payload) => {
+          cancellations.push(payload);
+          return Promise.resolve({ ok: true, outcome: "applied" });
+        },
       }),
     }),
     spawns,
+    cancellations,
     reacquired: () => reacquired,
     state: () => {
       const state = rows.find((row) => row.squadRunId === SQUAD_RUN_ID)?.state;
       assert.ok(state);
       return state;
+    },
+    resetProjection: () => {
+      rows.length = 0;
     },
     completeLeader: (runtimeSessionId, result) => {
       const index = sessions.findIndex((session) => session.runtimeSessionId === runtimeSessionId);
@@ -540,6 +551,42 @@ test("reconcile resumes a durable leader retry left pending between daemon turns
     assert.equal(fixture.spawns.length, 1);
     const status = fixture.coordinator.status(SQUAD_RUN_ID);
     assert.equal(status.status, "leader_running", String(status.error));
+  });
+});
+
+test("squad cancel persists a terminal phase before stopping every member and reconcile stays inert", async () => {
+  await withRootDir(async (rootDir) => {
+    const fixture = makeRecoveryFixture(rootDir, {
+      leaderOutcome: null,
+      leaderTurnBudget: 3,
+      workers: [
+        {
+          workerId: "sol",
+          dispatchId: "dispatch_000000000000000000000002",
+          runtimeSessionId: "runtime-worker-sol",
+          outcome: null,
+        },
+      ],
+    });
+    const streamPath = dispatchStreamPath(rootDir, LEADER_DISPATCH_ID);
+    truncateSync(streamPath, 500 * 1024 * 1024 - 1);
+    appendFileSync(streamPath, "\n");
+    const receipt = await fixture.coordinator.cancel(SQUAD_RUN_ID, {
+      actor: { principal: { personId: "person-operator" }, executor: null },
+      source: "local",
+    });
+
+    assert.equal(receipt.ok, true);
+    assert.equal(receipt.status, "cancelled");
+    assert.equal(fixture.state().phase, "cancelled");
+    assert.deepEqual(
+      fixture.cancellations.map((payload) => payload.runtimeSessionId),
+      [LEADER_SESSION_ID, "runtime-worker-sol"],
+    );
+    fixture.resetProjection();
+    await fixture.coordinator.reconcile();
+    assert.equal(fixture.coordinator.status(SQUAD_RUN_ID).status, "cancelled");
+    assert.equal(fixture.spawns.length, 0, "a durable cancellation must not resume after reconciliation");
   });
 });
 

--- a/packages/daemon/test/squad-run-detail-read.test.ts
+++ b/packages/daemon/test/squad-run-detail-read.test.ts
@@ -239,6 +239,7 @@ function coordinator(
         dispatchId: "dispatch_00000000000000000000b2c3",
         runtimeSessionId: "runtime-worker-1",
       }),
+      cancel: async (): Promise<JsonObject> => ({ ok: true, outcome: "applied" }),
     }),
   });
 }

--- a/packages/gui/src/renderer/components/sessions/SquadRunList.tsx
+++ b/packages/gui/src/renderer/components/sessions/SquadRunList.tsx
@@ -72,6 +72,7 @@ const PHASE_KEY: Readonly<Record<SquadRunSummaryDto["phase"], string>> = {
   planning: "agentRuntime.squadRunPhasePlanning",
   leader_running: "agentRuntime.squadRunPhaseLeaderRunning",
   workers_running: "agentRuntime.squadRunPhaseWorkersRunning",
+  cancelled: "agentRuntime.squadRunPhaseCancelled",
   converged: "agentRuntime.squadRunPhaseConverged",
   failed: "agentRuntime.squadRunPhaseFailed",
 };
@@ -79,6 +80,7 @@ const PHASE_TONE: Readonly<Record<SquadRunSummaryDto["phase"], string>> = {
   planning: "text-status-unknown",
   leader_running: "text-status-active",
   workers_running: "text-status-active",
+  cancelled: "text-status-unknown",
   converged: "text-status-done",
   failed: "text-status-blocked",
 };

--- a/packages/gui/src/renderer/i18n/locales/en-US/agentRuntime.json
+++ b/packages/gui/src/renderer/i18n/locales/en-US/agentRuntime.json
@@ -346,6 +346,7 @@
   "agentRuntime.squadRunPhasePlanning": "Planning",
   "agentRuntime.squadRunPhaseLeaderRunning": "Leader running",
   "agentRuntime.squadRunPhaseWorkersRunning": "Workers running",
+  "agentRuntime.squadRunPhaseCancelled": "Cancelled",
   "agentRuntime.squadRunPhaseConverged": "Converged",
   "agentRuntime.squadRunPhaseFailed": "Failed",
   "agentRuntime.squadRunsEmptyWindow": "No squad runs in this range ({range}). Widen the range or clear the search.",

--- a/packages/gui/src/renderer/i18n/locales/zh-CN/agentRuntime.json
+++ b/packages/gui/src/renderer/i18n/locales/zh-CN/agentRuntime.json
@@ -346,6 +346,7 @@
   "agentRuntime.squadRunPhasePlanning": "规划中",
   "agentRuntime.squadRunPhaseLeaderRunning": "leader 运行中",
   "agentRuntime.squadRunPhaseWorkersRunning": "worker 运行中",
+  "agentRuntime.squadRunPhaseCancelled": "已取消",
   "agentRuntime.squadRunPhaseConverged": "已收敛",
   "agentRuntime.squadRunPhaseFailed": "已失败",
   "agentRuntime.squadRunsEmptyWindow": "该时间窗({range})内没有 squad run。放宽范围或清空检索。",


### PR DESCRIPTION
# English

## Summary
Hardens runtime dispatch recovery so a single runaway session can no longer wedge the entire ledger. On 2026-08-29 a looping squad leader wrote a dispatch stream to ~28GB; on daemon restart `adoptRuntimes` read it whole via `readFileSync`, hit Node's 536MB string limit, threw *after* acquiring the workspace lock, leaked the lock, and every subsequent canonical attach failed with EEXIST — the whole ledger/GUI went down.

## Architectural Justification
These fixes must live in the exact modules that failed: `repo-cell-open.ts` is where the lock is acquired and where the unguarded adoption threw, so the try/finally belongs there and nowhere else; `dispatch-stream.ts` owns the read/write of dispatch streams, so the bounds belong at that seam; `squad-coordinator.ts` owns squad lifecycle, so terminal-cancel state belongs there. No new module can carry this without duplicating those seams. No obsolete code is removed because the failure was missing guards, not wrong code; the scope cannot narrow further — each of the five guards addresses an independent failure that, alone, still wedges the ledger (a leaked lock, an oversized read, an unbounded write, a cascading attach, a resuming loop).

## What Changed
- **Lock never leaks (most critical):** `repo-cell-open.ts` wraps cell open in try/catch that `lock.close()` on any failure, so a failed adoption can no longer wedge the ledger.
- **Bounded dispatch read/write:** `dispatch-stream.ts` skips full reads above 200MB (warn once) instead of choking, and drops unbounded output above a 500MB write cap.
- **Per-dispatch adoption isolation:** `runtime-spawn-adoption.ts` isolates a bad dispatch so one failure does not cascade.
- **staleWriterLock self-heal:** `repo-cell-lock.ts` recognises a self-owned leaked lock.
- **`ha squad cancel`:** new command writes a terminal squad state so a cancelled squad does not resume its retry loop after a daemon restart; GUI gets a cancel affordance.

## Gate Harvest / 门收割
No gate changes.

## Machine-Readable Declarations
Production-Delta: +183/-24

## Task And Scope
Milestone task_5fc5080044fcfdbf548008f2f5; hardening task task_506f939a5ea7c323f204c8a26f. Root cause and hole inventory in facts F-4A787A4F / F-003D87CF / F-A30D1EB0.

## Version Impact
None (daemon/runtime robustness; no schema or protocol break).

## Governance Declaration
No protected surface, CI, or gate touched.

## Verification
- Targeted tests green (isolated dispatcher): dispatch-stream 6/6, repo-cell-lock-release 1/1, squad-coordinator-recovery 11/11, squad-cancel 1/1.
- Positive controls: an oversized stream is skipped+warned (no ERR_STRING_TOO_LONG); a failed adoption releases the lock so the next attach succeeds.

## Review Evidence
CEO semantic acceptance: verified the try/finally lock release and the 200MB/500MB bounds match the incident root cause; ran the targeted tests directly.

## Residual Risk
Low. Thresholds are fixed constants (200MB read / 500MB write). The dispatch-status-finalize root of the retry loop is fixed separately (task_245d7d48); this PR bounds the blast radius even if a loop occurs.

## References
Facts F-4A787A4F, F-003D87CF, F-A30D1EB0; incident 2026-08-29.

---

# 中文

## 概要
加固运行时 dispatch 恢复,使单个失控会话不再能拖垮整个台账。2026-08-29 一个复读 squad leader 把 dispatch 流写到约 28GB;daemon 重启时 `adoptRuntimes` 用 `readFileSync` 整读它,撞 Node 536MB 字符串上限抛错,而抛错发生在已获 workspace 锁之后,锁泄漏,之后所有 canonical attach EEXIST——整台账/GUI 全死。

## 架构辩护
这些修复必须落在真正出事的模块里:repo-cell-open.ts 是获锁处、也是未保护的 adoption 抛错处,try/finally 只能在这里;dispatch-stream.ts 拥有 dispatch 流的读写,上限只能在这个缝;squad-coordinator.ts 拥有 squad 生命周期,终态取消只能在这里。另起模块只会复制这些缝。不删废弃代码——出事的是缺保护而非错代码;范围无法再窄:五个保护各治一个独立失败,任一单独发生仍会 wedge 台账(泄漏锁、超大读、无界写、级联 attach、resume 环)。

## 改动内容
- **锁不再泄漏(最致命)**:repo-cell-open.ts 用 try/catch 包裹 cell open,任何失败都 lock.close(),失败的 adoption 不再 wedge 台账。
- **有界 dispatch 读写**:dispatch-stream.ts 对 >200MB 的流跳过整读(告警一次)而非硬抛;写入 >500MB 上限丢弃无界输出。
- **per-dispatch adoption 隔离**:一个坏 dispatch 失败不级联。
- **staleWriterLock 自愈**:识别自身泄漏锁。
- **`ha squad cancel`**:新命令写 squad 终态,取消的 squad 在 daemon 重启后不 resume 复读环;GUI 加取消入口。

## 门收割 / Gate Harvest
无门改动。

## 机读声明说明
见英文块 Production-Delta。

## 任务与范围
里程碑 task_5fc5080044fcfdbf548008f2f5;加固任务 task_506f939a。根因与 8 洞清单见 fact F-4A787A4F/F-003D87CF/F-A30D1EB0。

## 版本影响
无(daemon/runtime 健壮性;无 schema/协议破坏)。

## 治理声明
未触碰 protected surface / CI / gate。

## 验证
定向测试全绿(隔离派测):dispatch-stream 6/6、repo-cell-lock-release 1/1、squad-coordinator-recovery 11/11、squad-cancel 1/1。阳性对照:超大流被跳过+告警(无 ERR_STRING_TOO_LONG);失败 adoption 释放锁、下次 attach 成功。

## 残留风险
低。阈值为固定常量(200MB 读 / 500MB 写)。复读环的产源(dispatch 终态回写)由 task_245d7d48 单独修;本 PR 即使复读发生也把爆炸半径限住。
