### PR TITLE
fix(daemon): settle converged squad leader dispatch to terminal state

### DIFF
--- a/packages/daemon/src/runtime-provider-fault.ts
+++ b/packages/daemon/src/runtime-provider-fault.ts
@@ -1,6 +1,7 @@
 import type { RuntimeInstanceKind } from "./agent-runtime-instances.ts";
 import type { ActiveRuntime, ProviderFrame } from "./runtime-spawn-types.ts";
 import type { RuntimeAttemptOutcome, RuntimeProviderFault } from "./runtime-fallback-contract.ts";
+import { isSquadDecisionResult } from "./squad-leader-decision.ts";
 
 const quota =
     /\b(?:quota|usage limit|credit balance|insufficient[_ -]?quota|resource[_ -]?exhausted)\b|使用上限|配额/iu,
@@ -97,10 +98,16 @@ function runtimeExitOutcome(active: ActiveRuntime, exitCode: number | null): Run
   if (active.cancelRequested) return "cancelled";
   if (exitCode === null || active.protocolError) return "unknown";
   if (exitCode !== 0) return "failed";
-  const writeEvidenceRequired = active.kindId !== "agy" && active.permissionMode !== "read-only";
+  const writeEvidenceRequired = active.kindId !== "agy" && active.permissionMode !== "read-only",
+    squadControlEvidence =
+      active.squadId !== null &&
+      active.delegatedBy === null &&
+      active.finalText !== null &&
+      isSquadDecisionResult(active.finalText);
   if (
     active.providerOutcome === "succeeded" &&
-    (active.planIncomplete || (writeEvidenceRequired && !active.writeItemObserved && !active.planObserved))
+    (active.planIncomplete ||
+      (writeEvidenceRequired && !active.writeItemObserved && !active.planObserved && !squadControlEvidence))
   )
     return "unknown";
   return active.providerOutcome ?? "unknown";

--- a/packages/daemon/src/squad-coordinator.ts
+++ b/packages/daemon/src/squad-coordinator.ts
@@ -499,6 +499,7 @@ export function makeSquadCoordinator(input: {
         {
           runtimeInstanceId: state.runtimeInstanceId,
           agentId: state.leaderAgentId,
+          squadId: state.squadId,
           permissionMode: state.permissionMode ?? "read-only",
           prompt,
           cwd: cwdPayload(input.rootDir, state.cwd),

--- a/packages/daemon/src/squad-leader-decision.ts
+++ b/packages/daemon/src/squad-leader-decision.ts
@@ -8,6 +8,25 @@ export type LeaderDecision =
       readonly dispatches: readonly WorkerPlan[];
     };
 
+type SquadDecision = Extract<LeaderDecision, { readonly kind: "converged" | "waiting" }>;
+
+export function squadDecisionFromValue(value: unknown): SquadDecision | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const row = value as Record<string, unknown>;
+  if (row.schema !== "squad-decision/v1") return null;
+  if (row.action === "converged") return { kind: "converged" };
+  if (row.action === "waiting") return { kind: "waiting" };
+  return null;
+}
+
+export function isSquadDecisionResult(text: string): boolean {
+  try {
+    return squadDecisionFromValue(JSON.parse(text.trim())) !== null;
+  } catch {
+    return false;
+  }
+}
+
 export type WorkerWaitTrigger = {
   readonly kind: "worker_wait";
   readonly runtimeSessionId: string;
@@ -142,9 +161,9 @@ export function parseLeaderDecision(
     throw new Error("Leader result was not JSON.");
   }
   if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error("Leader result was not an object.");
+  const squadDecision = squadDecisionFromValue(value);
+  if (squadDecision !== null) return squadDecision;
   const row = value as Record<string, unknown>;
-  if (row.schema === "squad-decision/v1" && row.action === "converged") return { kind: "converged" };
-  if (row.schema === "squad-decision/v1" && row.action === "waiting") return { kind: "waiting" };
   if (row.schema !== "runtime-batch/v1" || !Array.isArray(row.dispatches))
     throw new Error("Leader result must be runtime-batch/v1 or a waiting/converged squad-decision/v1.");
   if (row.dispatches.length === 0) throw new Error("Leader runtime-batch/v1 dispatches must be a non-empty array.");

--- a/packages/daemon/test/dispatch-parent-session.integration.test.ts
+++ b/packages/daemon/test/dispatch-parent-session.integration.test.ts
@@ -5,7 +5,11 @@ import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
-import type { AgentDefinitionSnapshot, RuntimeInstallationWitness } from "../../kernel/src/index.ts";
+import {
+  makeTaskEventStore,
+  type AgentDefinitionSnapshot,
+  type RuntimeInstallationWitness,
+} from "../../kernel/src/index.ts";
 import type { RuntimeInstanceSummary } from "../src/agent-runtime-instances.ts";
 import { readDispatchStream } from "../src/dispatch-stream.ts";
 import type { RuntimeProcess } from "../src/runtime-spawn-types.ts";
@@ -81,12 +85,13 @@ test("a local binding executor names the parent runtime session when the caller 
   }
 });
 
-test("a leader-only squad dispatch keeps its squad attribution after settlement archiving", async () => {
+test("a leader-only squad decision keeps attribution and settles success or failure from its process exit", async () => {
   const parent = mkdtempSync(path.join(tmpdir(), "ha-parent-session-archive-")),
     root = path.join(parent, "repo"),
     userRoot = path.join(parent, "user"),
     taskId = "task_parent_session_archive",
     executionId = "execution-parent-session-archive";
+  let launches = 0;
   mkdirSync(root);
   git(root, "init", "-q");
   git(root, "config", "user.name", "Parent Session Test");
@@ -101,7 +106,7 @@ test("a leader-only squad dispatch keeps its squad attribution after settlement 
       daemonId: "parent-session-archive",
       endpoint: path.join(userRoot, "parent-session-archive.sock"),
     },
-    runtimeInstances: () => [runtimeInstance("codex-parent")],
+    runtimeInstances: () => [{ ...runtimeInstance("codex-parent"), permissionMode: "workspace-write" }],
     prepareRuntimeLaunch: async (instanceId, request) => ({
       definition: definition(instanceId, request.model ?? "codex-parent-model"),
       installation,
@@ -111,7 +116,11 @@ test("a leader-only squad dispatch keeps its squad attribution after settlement 
       cwd: request.cwd,
       prompt: request.prompt,
     }),
-    runtimeLaunch: () => fakeProcess(7103, "success"),
+    runtimeLaunch: () => {
+      const attempt = launches;
+      launches += 1;
+      return fakeProcess(7103 + attempt, attempt === 0 ? "converged" : "failed-converged");
+    },
   });
   try {
     await installSquad(cell);
@@ -139,6 +148,8 @@ test("a leader-only squad dispatch keeps its squad attribution after settlement 
           readonly squadId?: string;
           readonly parentRuntimeSessionId?: string;
           readonly endedAt: string | null;
+          readonly outcome: string | null;
+          readonly status: string;
           readonly dispatchPath?: string | null;
         }[];
       };
@@ -149,19 +160,77 @@ test("a leader-only squad dispatch keeps its squad attribution after settlement 
     assert.ok(leaderRow, "settled leader row keeps its squad attribution");
     assert.equal(Object.hasOwn(leaderRow, "parentRuntimeSessionId"), false);
     assert.equal(leaderRow.squadId, "parent-squad");
+    assert.equal(leaderRow.outcome, "succeeded");
+    assert.equal(leaderRow.status, "succeeded");
     const document = (await cell.read("repo.tasks.document.read", {
         taskId,
         path: `artifacts/dispatches/${String(receipt.dispatchId)}.json`,
       })) as { readonly body: string },
       archived = JSON.parse(document.body) as Record<string, unknown>;
     assert.equal(archived.squadId, "parent-squad");
+    assert.equal(archived.outcome, "succeeded");
     assert.equal(Object.hasOwn(archived, "parentRuntimeSessionId"), false);
     assert.equal(Object.hasOwn(archived, "delegatedByAgentId"), false);
+    assertLeaseReleasedBeforeOutcome(root, taskId, executionId, String(receipt.runtimeSessionId));
+
+    const failedTaskId = "task_parent_session_archive_failed",
+      failedExecutionId = "execution-parent-session-archive-failed";
+    await startTask(cell, root, failedTaskId, failedExecutionId);
+    const failedReceipt = await cell.spawnRuntime(
+      {
+        runtimeInstanceId: "codex-parent",
+        agentId: "parent-leader",
+        squadId: "parent-squad",
+        cwd: { scope: "repo-root" },
+        prompt: "Exit non-zero after declaring convergence.",
+        taskId: failedTaskId,
+        idempotencyKey: "parent-session-archive-failed",
+      },
+      personBinding,
+    );
+    const failedRows = await eventually(async () => {
+        const result = (await cell.read("repo.task.dispatches", { taskId: failedTaskId })) as {
+          readonly dispatches: readonly {
+            readonly runtimeSessionId: string;
+            readonly endedAt: string | null;
+            readonly outcome: string | null;
+            readonly status: string;
+          }[];
+        };
+        return result.dispatches.some((row) => row.endedAt !== null) ? result.dispatches : null;
+      }),
+      failedRow = failedRows.find((row) => row.runtimeSessionId === failedReceipt.runtimeSessionId);
+    assert.ok(failedRow, "failed leader dispatch settles");
+    assert.equal(failedRow.outcome, "failed");
+    assert.equal(failedRow.status, "failed");
+    assertLeaseReleasedBeforeOutcome(root, failedTaskId, failedExecutionId, String(failedReceipt.runtimeSessionId));
   } finally {
     await cell.close();
     rmSync(parent, { recursive: true, force: true });
   }
 });
+
+function assertLeaseReleasedBeforeOutcome(
+  rootDir: string,
+  taskId: string,
+  executionId: string,
+  runtimeSessionId: string,
+): void {
+  const events = makeTaskEventStore({ repoId: "parent-session-archive", rootDir }).read().events,
+    releaseIndex = events.findIndex(
+      (event) =>
+        event.type === "lease_released" &&
+        event.taskId === taskId &&
+        event.payload.execution.executionId === executionId,
+    ),
+    outcomeIndex = events.findIndex(
+      (event) =>
+        event.type === "runtime_session_outcome_observed" && event.payload.runtimeSessionId === runtimeSessionId,
+    );
+  assert.ok(releaseIndex >= 0, `execution lease ${executionId} was released`);
+  assert.ok(outcomeIndex >= 0, `runtime session ${runtimeSessionId} has a terminal outcome`);
+  assert.ok(releaseIndex < outcomeIndex, "lease release precedes the terminal runtime outcome");
+}
 
 async function installSquad(cell: Awaited<ReturnType<typeof openRepoCell>>): Promise<void> {
   for (const declaration of [
@@ -256,7 +325,7 @@ function definition(instanceId: string, model: string): AgentDefinitionSnapshot 
   };
 }
 
-function fakeProcess(pid: number, behavior: "success" | "429"): RuntimeProcess {
+function fakeProcess(pid: number, behavior: "success" | "converged" | "failed-converged" | "429"): RuntimeProcess {
   let output: ((chunk: string) => void) | null = null,
     exit: ((code: number | null) => void) | null = null,
     terminated = false;
@@ -275,11 +344,20 @@ function fakeProcess(pid: number, behavior: "success" | "429"): RuntimeProcess {
           ...(behavior === "success"
             ? [{ type: "item.completed", item: { id: "write", type: "file_change", status: "completed" } }]
             : []),
-          { type: "item.completed", item: { id: "message", type: "agent_message", text: "done" } },
+          {
+            type: "item.completed",
+            item: {
+              id: "message",
+              type: "agent_message",
+              text: behavior.includes("converged")
+                ? JSON.stringify({ schema: "squad-decision/v1", action: "converged" })
+                : "done",
+            },
+          },
           { type: "turn.completed" },
         ];
         output?.(`${frames.map((frame) => JSON.stringify(frame)).join("\n")}\n`);
-        exit?.(behavior === "429" ? 1 : 0);
+        exit?.(behavior === "429" || behavior === "failed-converged" ? 1 : 0);
       });
     },
     terminate: () => {

--- a/packages/daemon/test/runtime-spawn-settlement.test.ts
+++ b/packages/daemon/test/runtime-spawn-settlement.test.ts
@@ -23,6 +23,34 @@ test("an exit-zero attempt with an incomplete plan settles as unknown", () => {
   );
 });
 
+test("a write-capable squad leader converged decision settles as succeeded without per-turn write evidence", () => {
+  const result = classifyRuntimeExit(
+    active({
+      squadId: "core-squad",
+      delegatedBy: null,
+      finalText: JSON.stringify({ schema: "squad-decision/v1", action: "converged" }),
+      writeItemObserved: false,
+      planObserved: false,
+    }),
+    0,
+  );
+  assert.equal(result.outcome, "succeeded");
+});
+
+test("a non-zero squad leader exit is failed even when its final text declares convergence", () => {
+  const result = classifyRuntimeExit(
+    active({
+      squadId: "core-squad",
+      delegatedBy: null,
+      finalText: JSON.stringify({ schema: "squad-decision/v1", action: "converged" }),
+      writeItemObserved: false,
+      planObserved: false,
+    }),
+    1,
+  );
+  assert.equal(result.outcome, "failed");
+});
+
 function active(overrides: Partial<ActiveRuntime>): ActiveRuntime {
   return {
     dispatchId: "dispatch_0123456789abcdef01234567",

--- a/packages/daemon/test/squad-coordinator-recovery.test.ts
+++ b/packages/daemon/test/squad-coordinator-recovery.test.ts
@@ -377,6 +377,7 @@ test("a malformed leader result re-asks the same leader session instead of faili
 
     assert.equal(fixture.spawns.length, 1);
     assert.equal(fixture.reacquired(), 1);
+    assert.equal(fixture.spawns[0]?.squadId, "core-squad");
     assert.equal(fixture.spawns[0]?.providerSessionId, "provider-leader");
     assert.equal(fixture.spawns[0]?.idempotencyKey, `${SQUAD_RUN_ID}:leader:retry:leader-1`);
     assert.match(String(fixture.spawns[0]?.prompt), /Leader result was not JSON\./u);


### PR DESCRIPTION
# English

## Summary

A squad leader runtime that converges (emits a `squad-decision/v1` `converged`/`waiting` result) was being settled as `unknown` by `runtimeExitOutcome`, because a leader's final text is neither a write item nor a plan, so the write-evidence guard forced `unknown`. That left the dispatch/session projection with no terminal state: the GUI Sessions view showed 未知, and the squad coordinator kept re-asking the leader (the observed "复读" retry loop). This PR completes the terminal-status transition for converged squad leaders.

## Architectural Justification

Not applicable — Production-Delta churn is +31/-4, well under the 200-line threshold. The fix extends the existing `runtimeExitOutcome` classifier and reuses the existing `squad-decision/v1` parser rather than adding a new module; a helper (`squadDecisionFromValue`) is extracted and shared to remove a duplicated inline check.

## What Changed

- `runtime-provider-fault.ts`: `runtimeExitOutcome` now recognizes squad-control evidence — a runtime that is a squad leader (`squadId !== null`, `delegatedBy === null`) whose `finalText` is a valid `squad-decision/v1` converged/waiting result no longer requires per-turn write/plan evidence, so an exit-zero converged leader settles as `succeeded` instead of `unknown`. A non-zero exit still settles as `failed`.
- `squad-coordinator.ts`: the leader spawn payload now carries `squadId`, so the active runtime can be recognized as a squad leader by the classifier.
- `squad-leader-decision.ts`: extracted `squadDecisionFromValue()` and exported `isSquadDecisionResult()`, and rewrote `parseLeaderDecision()` to reuse them, removing the duplicated `schema === "squad-decision/v1"` inline branches.
- Tests: added positive (converged leader → succeeded) and negative (non-zero leader → failed) settlement cases, plus dispatch parent-session integration coverage.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: see the single CI-backed `Production-Delta` declaration below.

## Machine-Readable Declarations

Production-Delta: +31/-4

## Task And Scope

- Harness task: task_245d7d48513d9e52571a7fd5d0
- Branch: codex/t1-dispatch-v2
- Public scope: daemon squad leader terminal-status settlement (dispatch/session projection)
- Private planning/evidence updated: not applicable
- Out of scope: GUI Sessions read-side rendering, squad coordinator retry-budget policy

## Version Impact

- Version: no version change because this is an internal daemon behavior fix with no package surface change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none
- Authority: not applicable
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no

---

# 中文

## 摘要

squad leader 运行时收敛后(输出 `squad-decision/v1` 的 `converged`/`waiting` 结果)被 `runtimeExitOutcome` 判成 `unknown`——因为 leader 的 finalText 既不是 write item 也不是 plan,写证据守卫把它强制判为 `unknown`。这让 dispatch/session 投影停在无终态:GUI Sessions 面显示"未知",squad coordinator 不断重新询问 leader(即观察到的"复读"重试循环)。本 PR 补齐 converged squad leader 的终态跳转。

## 架构辩护

不适用——Production-Delta 为 +31/-4,远低于 200 行阈值。修复扩展既有 `runtimeExitOutcome` 分类器、复用既有 `squad-decision/v1` 解析器,未新增模块;抽出共享 helper(`squadDecisionFromValue`)消除重复的 inline 判断。

## 变更内容

- `runtime-provider-fault.ts`:`runtimeExitOutcome` 新增识别 squad-control 证据——当运行时是 squad leader(`squadId !== null`、`delegatedBy === null`)且 `finalText` 是合法的 `squad-decision/v1` converged/waiting 结果时,不再要求 per-turn 写/plan 证据,于是 exit-zero 的收敛 leader 落 `succeeded` 而非 `unknown`;非零退出仍落 `failed`。
- `squad-coordinator.ts`:leader spawn payload 补 `squadId`,让分类器能识别该运行时为 squad leader。
- `squad-leader-decision.ts`:抽出 `squadDecisionFromValue()`、导出 `isSquadDecisionResult()`,重写 `parseLeaderDecision()` 复用它们,删除重复的 `schema === "squad-decision/v1"` inline 分支。
- 测试:新增正例(收敛 leader → succeeded)与负例(非零 leader → failed)settlement 用例,及 dispatch parent-session 集成覆盖。

## 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- 生产净行数:见下方唯一 CI 背书的 `Production-Delta` 声明。

## 任务与范围

- Harness task:task_245d7d48513d9e52571a7fd5d0
- 分支:codex/t1-dispatch-v2
- 公开范围:daemon squad leader 终态回写(dispatch/session 投影)
- 私有规划/证据更新:不适用
- 范围外:GUI Sessions 读面渲染、squad coordinator 重试预算策略

## 版本影响

- 版本:无版本变更,因为这是内部 daemon 行为修复,无 package 面变化
- 发布影响:不发布

## 治理声明

- 触碰受保护面:否
- 受保护面范围:无
- 授权依据:不适用
- 机器检查边界:本 PR 仅断言声明存在;评审者判断其是否为真且充分。
- Break-glass:否
