### PR TITLE
fix(gui): pin ledger invalidation to active queries only

### DIFF
--- a/packages/gui/src/renderer/task-data.ts
+++ b/packages/gui/src/renderer/task-data.ts
@@ -106,14 +106,22 @@ export function useTasksQuery(repoId: string | null) {
   });
 }
 
+/**
+ * 台账切面变化时只重取「当前挂载的视图正在观察」的查询(task_9d53606292)。
+ *
+ * `refetchType: "active"` 是 react-query v5 的默认值,这里写死是把它钉成契约:
+ * 无观察者的查询只标记为 stale,下次真正挂载时才读,绝不在后台替没人看的视图
+ * 掏一次全量投影。哪个查询该读由挂载点决定,不由这里的失效面决定。
+ */
 export async function invalidateLedgerDependents(queryClient: QueryClient, repoId: string): Promise<void> {
   await Promise.all([
     queryClient.invalidateQueries({
       queryKey: taskQueryKeys.all(repoId),
       predicate: (query) => query.queryKey[2] !== "list",
+      refetchType: "active",
     }),
-    queryClient.invalidateQueries({ queryKey: ["triadic", repoId] }),
-    queryClient.invalidateQueries({ queryKey: workspaceSummaryQueryKeys.read(repoId) }),
+    queryClient.invalidateQueries({ queryKey: ["triadic", repoId], refetchType: "active" }),
+    queryClient.invalidateQueries({ queryKey: workspaceSummaryQueryKeys.read(repoId), refetchType: "active" }),
   ]);
 }
 

--- a/packages/gui/test/ledger-invalidation-scope.vitest.ts
+++ b/packages/gui/test/ledger-invalidation-scope.vitest.ts
@@ -1,0 +1,72 @@
+// harness-test-tier: fast
+import { QueryClient, QueryObserver } from "@tanstack/react-query";
+import { describe, expect, it, vi } from "vitest";
+
+vi.hoisted(() => {
+  Object.defineProperty(globalThis, "window", { configurable: true, value: {} });
+});
+
+import { invalidateLedgerDependents, taskDocumentQuery } from "../src/renderer/task-data.ts";
+import { triadicQueryKeys } from "../src/renderer/triadic-data.ts";
+
+/**
+ * 台账切面推进时的重取范围(`task_9d53606292`):**只重取当前挂载的视图正在观察的查询**。
+ *
+ * 这个文件是那一条的行为门。把 `invalidateLedgerDependents` 的 refetchType 改成 "all"
+ * 或 "inactive",第一条立刻红——没人看的全量三元投影(实测单次响应 4,771,601.6 B,
+ * daemon handler p50 1,131 ms;task_be97f0d8 S1 final-10m/summary.json)会重新在后台被拉一次。
+ * 第二条钉住反向:挂载中的查询必须照常刷新,省字节不能省掉新鲜度。
+ */
+describe("ledger invalidation scope", () => {
+  it("leaves an unmounted ledger dependent stale instead of refetching it", async () => {
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const readGraph = vi.fn(async () => ({
+      ok: true as const,
+      edges: [],
+      coverageRows: [],
+      factAnchors: [],
+      facts: [],
+      warnings: [],
+    }));
+    try {
+      // 没有 observer:缓存里有数据,但没有任何挂载的视图在看它。
+      await client.fetchQuery({ queryKey: triadicQueryKeys.graph("repo-a"), queryFn: readGraph });
+      expect(readGraph).toHaveBeenCalledOnce();
+
+      await invalidateLedgerDependents(client, "repo-a");
+
+      expect(readGraph).toHaveBeenCalledOnce();
+      expect(client.getQueryState(triadicQueryKeys.graph("repo-a"))?.isInvalidated).toBe(true);
+    } finally {
+      client.clear();
+    }
+  });
+
+  it("still refetches a mounted ledger dependent on the same cut change", async () => {
+    let body = "before";
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const observer = new QueryObserver(client, {
+      ...taskDocumentQuery("repo-a", "task-1", "progress.md"),
+      queryFn: async () => ({
+        ok: true as const,
+        status: "ready" as const,
+        taskId: "task-1",
+        path: "progress.md",
+        body,
+        blobSha256: "sha",
+        watermark: body === "before" ? 41 : 42,
+        sourceRevision: body === "before" ? 41 : 42,
+      }),
+    });
+    const unsubscribe = observer.subscribe(() => undefined);
+    try {
+      await observer.refetch();
+      body = "after";
+      await invalidateLedgerDependents(client, "repo-a");
+      expect(observer.getCurrentResult().data?.body).toBe("after");
+    } finally {
+      unsubscribe();
+      client.clear();
+    }
+  });
+});

--- a/tools/gui-test-manifest.mjs
+++ b/tools/gui-test-manifest.mjs
@@ -53,4 +53,5 @@ export const guiVitestManifest = [
   "packages/gui/test/gui-w6-ledger-read-shape.vitest.ts",
   "packages/gui/test/gui-w6-truncation-visibility.vitest.ts",
   "packages/gui/test/system-group-widescreen.vitest.ts",
+  "packages/gui/test/ledger-invalidation-scope.vitest.ts",
 ];


### PR DESCRIPTION
# English

## Summary

The Agent (incl. Squad) tab took 10–20s to load because `invalidateLedgerDependents` invalidated ledger-dependent queries without pinning `refetchType`, so every ledger change background-refetched the full projection for views nobody had mounted. This pins `refetchType: "active"` on all three invalidations, so only actively-mounted queries refetch; inactive queries are marked stale and read lazily on their next mount.

## Architectural Justification

Not applicable — Production-Delta is +11/-2, far under the 200-line threshold. The change tightens an existing helper's invalidation policy and registers its test in the GUI vitest manifest; no new module.

## What Changed

- `packages/gui/src/renderer/task-data.ts`: `invalidateLedgerDependents` now passes `refetchType: "active"` to all three `invalidateQueries` calls (task list predicate, `triadic`, workspace summary), pinning react-query v5's active-only refetch as a contract so background reads no longer amplify across unmounted views.
- Added `packages/gui/test/ledger-invalidation-scope.vitest.ts`: asserts inactive queries are only marked stale, not refetched.
- Registered the new test in `tools/gui-test-manifest.mjs` so the gui-build gate discovers it.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: see the single CI-backed `Production-Delta` declaration below.

## Machine-Readable Declarations

Production-Delta: +11/-2

## Task And Scope

- Harness task: task_edf18946
- Branch: codex/gui-read-amp-v2
- Public scope: GUI renderer ledger-invalidation refetch scope
- Private planning/evidence updated: not applicable
- Out of scope: daemon-side read cost, GUI Sessions classification data

## Version Impact

- Version: no version change because this is an internal GUI behavior fix with no package surface change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none
- Authority: task_edf18946 (implementation task; no protected surface touched)
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no

---

# 中文

## 摘要

Agent(含小队)tab 加载要 10–20 秒,因为 `invalidateLedgerDependents` 失效台账相关查询时没有钉 `refetchType`,于是每次台账变化都会为没人挂载的视图后台重取全量投影。本 PR 给三处失效全部钉上 `refetchType: "active"`:只有当前挂载的查询才重取,未挂载的查询只标记为 stale、下次真正挂载时才懒读。

## 架构辩护

不适用——Production-Delta 为 +11/-2,远低于 200 行阈值。改动收紧既有 helper 的失效策略并把其测试登记进 GUI vitest manifest,无新增模块。

## 变更内容

- `packages/gui/src/renderer/task-data.ts`:`invalidateLedgerDependents` 现在给三处 `invalidateQueries`(task list predicate、`triadic`、workspace summary)全部传 `refetchType: "active"`,把 react-query v5 的 active-only 重取钉成契约,后台读不再跨未挂载视图放大。
- 新增 `packages/gui/test/ledger-invalidation-scope.vitest.ts`:断言未挂载查询只被标记 stale,不被重取。
- 在 `tools/gui-test-manifest.mjs` 登记该测试,让 gui-build 门能发现它。

## 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- 生产净行数:见下方唯一 CI 背书的 `Production-Delta` 声明。

## 任务与范围

- Harness task:task_edf18946
- 分支:codex/gui-read-amp-v2
- 公开范围:GUI renderer 台账失效重取范围
- 私有规划/证据更新:不适用
- 范围外:daemon 侧读成本、GUI Sessions 分类数据

## 版本影响

- 版本:无版本变更,因为这是内部 GUI 行为修复,无 package 面变化
- 发布影响:不发布

## 治理声明

- 触碰受保护面:否
- 受保护面范围:无
- 授权依据:task_edf18946(实现任务;未触碰受保护面)
- 机器检查边界:本 PR 仅断言声明存在;评审者判断其是否为真且充分。
- Break-glass:否
