### PR TITLE
fix(e2e-probe): warm daemon projection to ready before launching the GUI

### DIFF
--- a/packages/gui/test/e2e-probe-warm-daemon.test.mjs
+++ b/packages/gui/test/e2e-probe-warm-daemon.test.mjs
@@ -1,0 +1,67 @@
+// harness-test-tier: fast
+import assert from "node:assert/strict";
+import test from "node:test";
+import { warmDaemonProjection } from "../../../tools/e2e-probe.mjs";
+
+const ready = { evidence: JSON.stringify({ status: "ready" }) };
+const pending = { evidence: JSON.stringify({ status: "pending" }) };
+const noSleep = async () => undefined;
+
+test("warmDaemonProjection returns once the projection reports ready", async () => {
+  const seen = [pending, pending, ready];
+  let call = 0;
+  const outcome = await warmDaemonProjection({
+    readProjection: () => Promise.resolve(seen[call++]),
+    sleep: noSleep,
+  });
+  assert.deepEqual(outcome, { attempts: 3, status: "ready" });
+  assert.equal(call, 3, "the warm-up kept polling until the projection caught up");
+});
+
+test("warmDaemonProjection tolerates transient read failures before ready", async () => {
+  let call = 0;
+  const outcome = await warmDaemonProjection({
+    readProjection: () => {
+      call += 1;
+      if (call === 1) throw new Error("daemon starting");
+      return Promise.resolve(ready);
+    },
+    sleep: noSleep,
+  });
+  assert.deepEqual(outcome, { attempts: 2, status: "ready" });
+});
+
+test("warmDaemonProjection fails closed with a diagnosable code when never ready", async () => {
+  let call = 0;
+  await assert.rejects(
+    warmDaemonProjection({
+      attempts: 4,
+      readProjection: () => {
+        call += 1;
+        return Promise.resolve(pending);
+      },
+      sleep: noSleep,
+    }),
+    (error) => {
+      assert.equal(error.code, "daemon_projection_unready");
+      assert.match(error.message, /projection status pending/u);
+      return true;
+    },
+  );
+  assert.equal(call, 4, "the warm-up exhausted exactly its attempt budget");
+});
+
+test("warmDaemonProjection never sleeps after its final attempt", async () => {
+  let sleeps = 0;
+  await assert.rejects(
+    warmDaemonProjection({
+      attempts: 3,
+      readProjection: () => Promise.resolve(pending),
+      sleep: async () => {
+        sleeps += 1;
+      },
+    }),
+    { code: "daemon_projection_unready" },
+  );
+  assert.equal(sleeps, 2, "N attempts wait at most N-1 times between reads");
+});

--- a/tools/e2e-probe.mjs
+++ b/tools/e2e-probe.mjs
@@ -17,6 +17,7 @@ export async function runE2EProbeJourney({
   now = () => new Date().toISOString(),
   injectFault,
   prepareGui = true,
+  warmDaemon = true,
 } = {}) {
   const runId = `probe-${now().replaceAll(/[^0-9A-Za-z]/gu, "-")}-${randomUUID().slice(0, 8)}`,
     runRoot = path.join(outputRoot, runId),
@@ -29,6 +30,15 @@ export async function runE2EProbeJourney({
   mkdirSync(runRoot, { recursive: true, mode: 0o700 });
   try {
     if (prepareGui) prepareE2EProbeGui(workspaceRoot, env);
+    // The GUI answers projection reads with a 200 ms transport deadline. A scheduled run launches
+    // the app while its own daemon is still cold or catching up, so that first read overruns the
+    // deadline and the task sidebar stalls in its loading state until the probe's 20 s wait expires.
+    // Manual runs pass only because an earlier command already warmed the daemon. Pay that cost here,
+    // outside the GUI's budget, so both paths reach a ready projection before the window opens.
+    if (warmDaemon) {
+      currentStep = "warm_daemon";
+      await warmDaemonProjection({ rootDir, workspaceRoot, env });
+    }
     currentStep = "launch_gui";
     const [{ default: electronPath }, { _electron: electron }] = await Promise.all([
       import("electron"),
@@ -251,6 +261,37 @@ export async function recordE2EProbeFailure({
     taskId,
     deduplicated: false,
   };
+}
+
+export async function warmDaemonProjection({
+  rootDir = repositoryRoot,
+  workspaceRoot = repositoryRoot,
+  env = process.env,
+  attempts = 30,
+  delayMs = 1_000,
+  readProjection = () => runCliJson(workspaceRoot, rootDir, ["task", "list"], env),
+  sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
+} = {}) {
+  let lastDetail = "the daemon answered no projection read";
+  for (let attempt = 0; attempt < attempts; attempt += 1) {
+    try {
+      const status = projectionStatus(await readProjection());
+      if (status === "ready") return { attempts: attempt + 1, status };
+      lastDetail = `projection status ${status ?? "unknown"} after ${attempt + 1} read(s)`;
+    } catch (error) {
+      lastDetail = error instanceof Error ? error.message : String(error);
+    }
+    if (attempt + 1 < attempts) await sleep(delayMs);
+  }
+  throw probeError("daemon_projection_unready", `Daemon projection never reached ready: ${lastDetail}.`);
+}
+
+function projectionStatus(receipt) {
+  try {
+    return JSON.parse(receipt.evidence).status ?? null;
+  } catch {
+    return null;
+  }
 }
 
 async function agentRun() {


### PR DESCRIPTION
# English

## Summary

The E2E health probe failed every scheduled run at the `task_projection` step (signature `fb882b2fd07e58665b5e`): a 20s timeout waiting for the task testids. Root cause is a cold-start race, not a renderer bug — the GUI main process caps workspace-summary reads at a 200ms transport timeout, and on a scheduled run the GUI faces its own just-cold-started / catching-up daemon, so the first read exceeds 200ms and the sidebar stays in a testid-less loading state until the journey times out. Manual `--canonical-read-only` runs pass 8/8 because prior commands already warmed the daemon. This adds a `warmDaemonProjection()` step that polls `task list` until the projection reports `ready` before launching Electron, paying the cold/catch-up cost outside the 200ms budget.

## Architectural Justification

Not applicable — Production-Delta is +41/-0, far under the 200-line threshold. The change adds one warm-up helper to the existing probe entry path; no new module and no scheduler change.

## What Changed

- `tools/e2e-probe.mjs`: added `warmDaemonProjection()`, invoked before Electron launch for both `--agent-run` and `--canonical-read-only`; it polls `task list` until `status === "ready"`. If the daemon never reaches ready, the probe fail-closes in a named `warm_daemon` step reporting `daemon_projection_unready` with a diagnostic bundle — strictly more diagnosable than the previous opaque `task_projection` timeout.
- Added `packages/gui/test/e2e-probe-warm-daemon.test.mjs`: ready-gating, transient-failure tolerance, fail-closed code, backoff attempt count (4/4 green).
- Scheduler left unchanged: `recordMissed` already persists `missedCount`/`lastMissedReason` and a `schedule_occurrences_missed` event surfaced in the GUI, so missed runs are already non-silent; re-running a 4-hours-stale health probe would be meaningless, so no alerting layer is added (delete-first, no additive scaffolding).

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: see the single CI-backed `Production-Delta` declaration below.

## Machine-Readable Declarations

Production-Delta: +41/-0

## Task And Scope

- Harness task: task_f9a0ab78
- Branch: codex/e2e-probe-fix
- Public scope: e2e-probe daemon warm-up before GUI launch
- Private planning/evidence updated: not applicable
- Out of scope: raising the GUI main-process 200ms read timeout (GUI protected surface; recorded as follow-up), scheduler miss semantics

## Version Impact

- Version: no version change because this is a test-tooling fix with no package surface change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none
- Authority: task_f9a0ab78 (implementation task; no protected surface touched)
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no

---

# 中文

## 摘要

E2E 健康探针每次定时运行都在 `task_projection` 步失败(签名 `fb882b2fd07e58665b5e`):20 秒超时等 task testid。根因是**冷启动竞态,不是 renderer bug**——GUI 主进程对 workspace-summary 读设了 200ms 传输超时,而定时运行时 GUI 面对的是自身刚冷启动/追赶中的 daemon,首读超 200ms,侧栏卡在无 testid 的 loading 态直到 journey 超时。手动 `--canonical-read-only` 全绿 8/8,因为前序命令已把 daemon 热身。本 PR 新增 `warmDaemonProjection()`,启动 Electron 前轮询 `task list` 到投影 `ready` 再进 GUI,把冷/追赶成本付在 200ms 预算之外。

## 架构辩护

不适用——Production-Delta 为 +41/-0,远低于 200 行阈值。改动在既有探针入口路径加一个 warm-up helper,无新增模块、不改 scheduler。

## 变更内容

- `tools/e2e-probe.mjs`:新增 `warmDaemonProjection()`,`--agent-run` 与 `--canonical-read-only` 启动 Electron 前都调用,轮询 `task list` 到 `status === "ready"`。daemon 永不 ready 时在具名 `warm_daemon` 步 fail-close,报 `daemon_projection_unready` 并留诊断 bundle——比原来不透明的 `task_projection` 超时可诊断得多。
- 新增 `packages/gui/test/e2e-probe-warm-daemon.test.mjs`:ready 门控/瞬时失败容忍/fail-closed 码/退避次数(4/4 绿)。
- **scheduler 未改**:`recordMissed` 已把 `missedCount`/`lastMissedReason` 与 `schedule_occurrences_missed` 事件落账并在 GUI 展示,漏跑本就不静默;重跑 4 小时前的陈旧健康探针无意义,故不新增告警层(删除优先,不加脚手架)。

## 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- 生产净行数:见下方唯一 CI 背书的 `Production-Delta` 声明。

## 任务与范围

- Harness task:task_f9a0ab78
- 分支:codex/e2e-probe-fix
- 公开范围:e2e-probe 启动 GUI 前的 daemon warm-up
- 私有规划/证据更新:不适用
- 范围外:抬高 GUI 主进程 200ms 读超时(GUI 受保护面,记为后续)、scheduler 漏跑语义

## 版本影响

- 版本:无版本变更,因为这是测试工具修复,无 package 面变化
- 发布影响:不发布

## 治理声明

- 触碰受保护面:否
- 受保护面范围:无
- 授权依据:task_f9a0ab78(实现任务;未触碰受保护面)
- 机器检查边界:本 PR 仅断言声明存在;评审者判断其是否为真且充分。
- Break-glass:否
