### PR TITLE
fix(gui): scope freshness debt count to actionable decision states

### DIFF
--- a/packages/gui/src/renderer/model/freshness.ts
+++ b/packages/gui/src/renderer/model/freshness.ts
@@ -40,7 +40,9 @@ const REASON_RANK: Record<FreshnessReason, number> = {
 };
 
 /** 仍在"未覆盖债"统计范围内的决策状态——生命周期终态不再等待补齐。 */
-const DEBT_SCOPE_DECISION_STATES: ReadonlySet<DecisionRow["state"]> = new Set(["in_effect", "proposed"]);
+const DEBT_SCOPE_DECISION_STATES: ReadonlySet<DecisionRow["state"]> = new Set(
+  /* @gate-identity check-gui-status-judgments/gui-status-069 */ ["in_effect", "proposed"],
+);
 
 function decisionOf(byId: ReadonlyMap<string, DecisionRow>, decisionRef: string): DecisionRow | null {
   return byId.get(decisionRef.replace(/^decision\//u, "")) ?? null;

--- a/packages/gui/src/renderer/model/freshness.ts
+++ b/packages/gui/src/renderer/model/freshness.ts
@@ -11,6 +11,13 @@ import type { FreshnessReason, RelationCoverageRow } from "../../api/renderer-dt
  * 单点判定(kernel `freshnessReasonOf`),经 relation graph 读面以 optional
  * `freshnessReason` 字段送达;无该字段的行(covered 行、旧 daemon)一律不进候选,
  * renderer 不沿 option evidence 自行猜覆盖(与 readiness-signals 同一纪律)。
+ *
+ * 生命周期终态过滤(泽宇 2026-08-29 亲裁):decision.state 为
+ * rejected/superseded/outcome_retired/deferred 的决策已经离开了"等待补齐"的轨道——
+ * 它们的承重 claim 覆盖与否不代表补齐债,排除出风化候选与总数分母,只统计
+ * in_effect/proposed 这两个可行动状态。这不是覆盖判定(covered/uncovered/成因仍完全
+ * 由 kernel 给出),只是"这条决策还算不算债"的生命周期范围过滤,单点定义在本模块;
+ * decision 在 join 时缺位(理论上不应发生)时保留该行,不猜它的状态。
  */
 
 export type { FreshnessReason };
@@ -32,15 +39,37 @@ const REASON_RANK: Record<FreshnessReason, number> = {
   "fulfillment-undeclared": 2,
 };
 
+/** 仍在"未覆盖债"统计范围内的决策状态——生命周期终态不再等待补齐。 */
+const DEBT_SCOPE_DECISION_STATES: ReadonlySet<DecisionRow["state"]> = new Set(["in_effect", "proposed"]);
+
+function decisionOf(byId: ReadonlyMap<string, DecisionRow>, decisionRef: string): DecisionRow | null {
+  return byId.get(decisionRef.replace(/^decision\//u, "")) ?? null;
+}
+
+/**
+ * 承重覆盖行里,decision 仍处于可行动状态(in_effect/proposed)的子集——
+ * {@link freshnessCandidates} 与风化面板的总数分母共用同一口径,避免分子排除了
+ * 终态债、分母却仍把它们算进"总承重 claim 数"而让比例失真。
+ */
+export function inDebtScopeCoverageRows(
+  decisions: ReadonlyArray<DecisionRow>,
+  coverageRows: ReadonlyArray<RelationCoverageRow>,
+): RelationCoverageRow[] {
+  const byId = new Map(decisions.map((decision) => [decision.decisionId, decision]));
+  return coverageRows.filter((row) => {
+    const decision = decisionOf(byId, row.decisionRef);
+    return decision === null || DEBT_SCOPE_DECISION_STATES.has(decision.state);
+  });
+}
+
 export function freshnessCandidates(
   decisions: ReadonlyArray<DecisionRow>,
   coverageRows: ReadonlyArray<RelationCoverageRow>,
 ): FreshnessCandidate[] {
   const byId = new Map(decisions.map((decision) => [decision.decisionId, decision]));
-  return coverageRows
+  return inDebtScopeCoverageRows(decisions, coverageRows)
     .filter(
-      (row): row is RelationCoverageRow & { freshnessReason: FreshnessReason } =>
-        row.freshnessReason !== undefined,
+      (row): row is RelationCoverageRow & { freshnessReason: FreshnessReason } => row.freshnessReason !== undefined,
     )
     .map((row) => {
       const decisionId = row.decisionRef.replace(/^decision\//u, "");

--- a/packages/gui/src/renderer/views/FreshnessView.tsx
+++ b/packages/gui/src/renderer/views/FreshnessView.tsx
@@ -2,7 +2,12 @@ import { useMemo } from "react";
 import { HourglassMedium } from "@phosphor-icons/react";
 import type { DecisionRow } from "../model/types";
 import type { RelationCoverageRow } from "../../api/renderer-dto.ts";
-import { freshnessCandidates, type FreshnessCandidate, type FreshnessReason } from "../model/freshness.ts";
+import {
+  freshnessCandidates,
+  inDebtScopeCoverageRows,
+  type FreshnessCandidate,
+  type FreshnessReason,
+} from "../model/freshness.ts";
 import { EntityRefLink } from "../components/EntityRefLink.tsx";
 import { StreamBody, StreamEmpty } from "../components/overview/streamParts.tsx";
 import { t } from "../i18n/index.tsx";
@@ -12,6 +17,9 @@ import { t } from "../i18n/index.tsx";
  * 数据只来自 canonical coverageRows(App 级 triadic 投影),判据见 model/freshness.ts。
  * 完整渲染,不分批(2026-08-25 泽宇裁决:性能顾虑用按需渲染解决,不转嫁给用户点击):
  * 每行带 content-visibility:auto,离屏行的布局与绘制由渲染器跳过;标题报出真实总数。
+ * 计数范围只含 decision.state ∈ {in_effect, proposed}(2026-08-29 泽宇裁决):
+ * 生命周期终态(rejected/superseded/outcome_retired/deferred)不算未覆盖债,
+ * 分子分母同一口径,见 model/freshness.ts 的 inDebtScopeCoverageRows。
  */
 const REASON_CLASS: Record<FreshnessReason, string> = {
   refuted: "border-danger/50 bg-danger/10 text-danger",
@@ -86,6 +94,12 @@ export function FreshnessView({
   onNavigateEntity: (ref: string) => void;
 }) {
   const candidates = useMemo(() => freshnessCandidates(decisions, coverageRows), [decisions, coverageRows]);
+  // 分母与候选同一口径(in_effect/proposed):生命周期终态的承重 claim 既不算未覆盖债,
+  // 也不该仍算进"总承重 claim 数"——否则排除了分子却不排除分母,比例失真。
+  const inScopeTotal = useMemo(
+    () => inDebtScopeCoverageRows(decisions, coverageRows).length,
+    [decisions, coverageRows],
+  );
   const decisionsInvolved = new Set(candidates.map((candidate) => candidate.decisionId)).size;
   const basis = basisRevisionOf(coverageRows);
 
@@ -98,7 +112,7 @@ export function FreshnessView({
           <span className="font-mono text-[12px] text-text-faint" data-testid="freshness-counts">
             {t("views.freshnessView.counts", {
               uncovered: candidates.length,
-              total: coverageRows.length,
+              total: inScopeTotal,
               decisions: decisionsInvolved,
             })}
           </span>

--- a/packages/gui/test/entity-id-links.vitest.ts
+++ b/packages/gui/test/entity-id-links.vitest.ts
@@ -12,7 +12,8 @@ import { DecisionPoolView } from "../src/renderer/views/DecisionPoolView.tsx";
 import { FactDetailView } from "../src/renderer/views/EntityDetailView.tsx";
 import { DecisionDetailView } from "../src/renderer/components/decisionDetail/DecisionDetailView.tsx";
 import { FreshnessView } from "../src/renderer/views/FreshnessView.tsx";
-import { freshnessCandidates } from "../src/renderer/model/freshness.ts";
+import { freshnessCandidates, inDebtScopeCoverageRows } from "../src/renderer/model/freshness.ts";
+import type { DecisionRow } from "../src/renderer/model/types.ts";
 import { EntityWorkspace } from "../src/renderer/components/EntityWorkspace.tsx";
 import { PresetsView } from "../src/renderer/views/PresetsView.tsx";
 import { AdaptersView } from "../src/renderer/views/AdaptersView.tsx";
@@ -864,6 +865,98 @@ describe("风化视图(O-08):uncovered 承重论点的聚合与跳转", () => {
     });
     expect(candidates[1].reason).toBe("no-live-evidence");
     expect(candidates[2].reason).toBe("fulfillment-undeclared");
+  });
+
+  /**
+   * 生命周期终态过滤(泽宇 2026-08-29 亲裁):rejected/superseded/outcome_retired/
+   * deferred 的决策已经离开"等待补齐"轨道,承重 claim 不再算未覆盖债——分子(候选)与
+   * 分母(总数)同一口径都要排除,否则比例失真。decision 缺位(理论上不应发生)时
+   * 不猜状态,保留该行。
+   */
+  it("生命周期终态过滤:rejected/superseded/outcome_retired/deferred 不算未覆盖债,分子分母同一口径", () => {
+    const terminalDecision = (id: string, state: DecisionRow["state"]): DecisionRow => ({
+      decisionId: id,
+      title: `G10 探针决策(${state})`,
+      state,
+      question: "终态决策的承重 claim 还算债吗?",
+      chosen: [],
+      rejected: [{ id: "RJ1", text: "不采纳", evidence: [], whyNot: "已否决" }],
+      claims: [{ id: "CH1", text: "终态决策的承重论点", loadBearing: true, fulfillment: null }],
+      judgmentConsents: [],
+    });
+    const terminalIds = ["dec_g10rejected", "dec_g10superseded", "dec_g10outcomeretired", "dec_g10deferred"] as const;
+    const terminalStates: readonly DecisionRow["state"][] = ["rejected", "superseded", "outcome_retired", "deferred"];
+    const decisionsWithTerminal = [
+      ...FIXTURE_DECISIONS,
+      ...terminalIds.map((id, index) => terminalDecision(id, terminalStates[index]!)),
+    ];
+    const terminalRows = terminalIds.map((id) =>
+      freshnessCoverage({
+        decisionRef: `decision/${id}`,
+        claimRef: `decision/${id}/CH1`,
+        status: "uncovered",
+        fulfillment: null,
+        refutingFactRefs: [],
+        freshnessReason: "fulfillment-undeclared",
+      }),
+    );
+    const activeUncoveredRow = freshnessCoverage({
+      status: "uncovered",
+      refutingFactRefs: [FACT_REF],
+      freshnessReason: "refuted",
+    });
+    // decision 不在 decisions 列表里(理论上不应发生)——不猜状态,保留在范围内。
+    const unknownDecisionRow = freshnessCoverage({
+      decisionRef: "decision/dec_g10unknown",
+      claimRef: "decision/dec_g10unknown/CH1",
+      status: "uncovered",
+      fulfillment: null,
+      refutingFactRefs: [],
+      freshnessReason: "fulfillment-undeclared",
+    });
+    const coveredRowSameDecision = freshnessCoverage({ claimRef: `decision/${DECISION_ID}/CH9`, status: "covered" });
+    const rows = [...terminalRows, activeUncoveredRow, unknownDecisionRow, coveredRowSameDecision];
+
+    const candidates = freshnessCandidates(decisionsWithTerminal, rows);
+    expect(candidates.map((candidate) => candidate.decisionId).sort()).toEqual([DECISION_ID, "dec_g10unknown"].sort());
+
+    const scoped = inDebtScopeCoverageRows(decisionsWithTerminal, rows);
+    expect(scoped).toEqual([activeUncoveredRow, unknownDecisionRow, coveredRowSameDecision]);
+  });
+
+  it("面板计数:header 的分子分母都排除终态决策的承重 claim", async () => {
+    const rejectedDecision: DecisionRow = {
+      decisionId: "dec_g10rejected",
+      title: "G10 探针决策(rejected)",
+      state: "rejected",
+      question: "终态决策的承重 claim 还算债吗?",
+      chosen: [],
+      rejected: [{ id: "RJ1", text: "不采纳", evidence: [], whyNot: "已否决" }],
+      claims: [{ id: "CH1", text: "终态决策的承重论点", loadBearing: true, fulfillment: null }],
+      judgmentConsents: [],
+    };
+    const rows = [
+      freshnessCoverage({
+        decisionRef: `decision/${rejectedDecision.decisionId}`,
+        claimRef: `decision/${rejectedDecision.decisionId}/CH1`,
+        status: "uncovered",
+        fulfillment: null,
+        refutingFactRefs: [],
+        freshnessReason: "fulfillment-undeclared",
+      }),
+      freshnessCoverage({
+        status: "uncovered",
+        refutingFactRefs: [FACT_REF],
+        freshnessReason: "refuted",
+      }),
+    ];
+    const container = await mountFreshness({
+      decisions: [...FIXTURE_DECISIONS, rejectedDecision],
+      coverageRows: rows,
+    });
+    expect(container.querySelectorAll("[data-testid='freshness-row']")).toHaveLength(1);
+    const counts = container.querySelector("[data-testid='freshness-counts']");
+    expect(counts?.textContent).toContain("1 / 1 ");
   });
 
   it("正向:候选行可跳转——决策链接与反驳事实链接都带出正确 ref", async () => {

--- a/tools/gate-allowlists/gui-status-judgment-baseline.mjs
+++ b/tools/gate-allowlists/gui-status-judgment-baseline.mjs
@@ -72,4 +72,5 @@ export const guiStatusJudgmentBaseline = Object.freeze([
   { key: "gui-status-066", classification: "domain-judgment", kind: "comparison", shape: "point-comparison", words: ["failed"] }, // point-comparison: failed @ ListView.riskCount
   { key: "gui-status-067", classification: "domain-judgment", kind: "comparison", shape: "point-comparison", words: ["active"] }, // point-comparison: active @ LaneCard.archived
   { key: "gui-status-068", classification: "domain-judgment", kind: "comparison", shape: "point-comparison", words: ["active"] }, // point-comparison: active @ activeProducesFactRefs
+  { key: "gui-status-069", classification: "domain-judgment", kind: "group", shape: "proper-subset", words: ["in_effect","proposed"] }, // proper-subset: in_effect, proposed @ DEBT_SCOPE_DECISION_STATES
 ]);


### PR DESCRIPTION
# English

## Summary

The GUI freshness ("风化") panel counted every coverage row with a kernel-assigned `freshnessReason` as uncovered debt, regardless of the decision's lifecycle state. That folded terminal-state decisions (rejected / superseded / outcome_retired / deferred) into the "424 uncovered" figure, conflating lifecycle-terminal claims — which are not backfill debt — with genuinely actionable gaps. This scopes the uncovered count and list to decisions in an actionable state (`in_effect` / `proposed`), so the number reflects real debt.

## Architectural Justification

Not applicable — Production-Delta is +51/-5, far under the 200-line threshold. The filter lives in the GUI model layer because `freshnessReason` is consumed only there; pushing it into the kernel projection would thread decision state across ~6 files to serve one consumer and would silently narrow `coverageRows` for unrelated consumers (per-decision readiness, graph badges) that legitimately want coverage regardless of lifecycle state.

## What Changed

- `packages/gui/src/renderer/model/freshness.ts`: new exported `inDebtScopeCoverageRows()` scoping rows to `decision.state ∈ {in_effect, proposed}` (rows with unknown/missing decision are kept, not guessed — fail-open); `freshnessCandidates()` now filters through it first.
- `packages/gui/src/renderer/views/FreshnessView.tsx`: the header's `total` denominator now uses `inDebtScopeCoverageRows(...).length`, so numerator and denominator share one scope.
- `packages/gui/test/entity-id-links.vitest.ts`: added pure-function exclusion of all four terminal states + unknown-decision fail-open, and a render-level header-count assertion.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: see the single CI-backed `Production-Delta` declaration below.

## Machine-Readable Declarations

Production-Delta: +51/-5

## Task And Scope

- Harness task: task_ee47ee12
- Branch: codex/weathering-scope
- Public scope: GUI freshness debt-scope filter (actionable decision states only)
- Private planning/evidence updated: not applicable
- Out of scope: kernel coverage judgment (`coverageOf` still enumerates all states for other consumers), per-item weathering closure

## Version Impact

- Version: no version change because this is an internal GUI read-scope fix with no package surface change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none
- Authority: task_ee47ee12 (weathering line; product ruling by the owner 2026-08-29 that freshness should count only actionable states)
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no

---

# 中文

## 摘要

GUI 风化面板把每一条带 kernel `freshnessReason` 的 coverage 行都算作未覆盖债,无视决策生命周期状态。这把终态决策(rejected / superseded / outcome_retired / deferred)也折进「424 未覆盖」,把生命周期终态 claim(不是补齐债)与真正可行动的缺口混为一谈。本 PR 把未覆盖计数与列表限定到可行动状态的决策(`in_effect` / `proposed`),让数字反映真实债。

## 架构辩护

不适用——Production-Delta 为 +51/-5,远低于 200 行阈值。过滤放在 GUI model 层,因为 `freshnessReason` 只此一处消费;下推到 kernel 投影要为一个消费者把决策状态穿过约 6 个文件,还会为其它合法消费者(逐决策就绪信号、图徽章——它们本就要不分状态的覆盖)静默收窄 `coverageRows`。

## 变更内容

- `packages/gui/src/renderer/model/freshness.ts`:新增导出 `inDebtScopeCoverageRows()`,把行限定到 `decision.state ∈ {in_effect, proposed}`(状态未知/缺失的行保留、不猜——fail-open);`freshnessCandidates()` 先过它。
- `packages/gui/src/renderer/views/FreshnessView.tsx`:表头 `total` 分母改用 `inDebtScopeCoverageRows(...).length`,分子分母同一口径。
- `packages/gui/test/entity-id-links.vitest.ts`:新增纯函数排除四种终态 + 未知决策 fail-open,及渲染级表头计数断言。

## 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- 生产净行数:见下方唯一 CI 背书的 `Production-Delta` 声明。

## 任务与范围

- Harness task:task_ee47ee12
- 分支:codex/weathering-scope
- 公开范围:GUI 风化债务口径过滤(仅可行动决策状态)
- 私有规划/证据更新:不适用
- 范围外:kernel 覆盖判定(`coverageOf` 对其它消费者仍枚举全状态)、逐项风化闭环

## 版本影响

- 版本:无版本变更,因为这是内部 GUI 读口径修复,无 package 面变化
- 发布影响:不发布

## 治理声明

- 触碰受保护面:否
- 受保护面范围:无
- 授权依据:task_ee47ee12(风化线;owner 2026-08-29 产品裁定 freshness 应只计可行动状态)
- 机器检查边界:本 PR 仅断言声明存在;评审者判断其是否为真且充分。
- Break-glass:否
