### PR TITLE
fix(daemon): coalesce squad callback drain

### DIFF
--- a/packages/daemon/src/squad-coordinator.ts
+++ b/packages/daemon/src/squad-coordinator.ts
@@ -490,11 +490,12 @@ export function makeSquadCoordinator(input: {
     if (state.leaderTurns.length >= state.leaderTurnBudget)
       throw new Error(`leader turn budget ${state.leaderTurnBudget} exhausted`);
     if (trigger.kind !== "initial") await input.reacquireTaskLease(state.taskId, state.binding);
-    const turnId = `leader-${state.leaderTurns.length + 1}`,
+    const drainedTriggers = trigger.kind === "initial" ? [] : state.pendingLeaderTriggers,
+      turnId = `leader-${state.leaderTurns.length + 1}`,
       prompt =
         trigger.kind === "initial"
           ? initialLeaderPrompt(state)
-          : callbackLeaderPrompt(state, trigger, dispatchRows(state)),
+          : callbackLeaderPrompt(state, drainedTriggers, dispatchRows(state)),
       receipt = await input.runtimeSpawner().spawn(
         {
           runtimeInstanceId: state.runtimeInstanceId,
@@ -531,8 +532,7 @@ export function makeSquadCoordinator(input: {
           },
         ],
         currentLeaderRuntimeSessionId: runtimeSessionId,
-        pendingLeaderTriggers:
-          trigger.kind === "initial" ? state.pendingLeaderTriggers : state.pendingLeaderTriggers.slice(1),
+        pendingLeaderTriggers: trigger.kind === "initial" ? state.pendingLeaderTriggers : [],
         phase: "leader_running",
         error: null,
       });

--- a/packages/daemon/src/squad-leader-decision.ts
+++ b/packages/daemon/src/squad-leader-decision.ts
@@ -107,18 +107,22 @@ export function initialLeaderPrompt(state: LeaderPromptState): string {
 
 export function callbackLeaderPrompt(
   state: LeaderPromptState,
-  trigger: LeaderTrigger,
+  triggers: readonly LeaderTrigger[],
   rows: readonly TaskDispatchRow[],
 ): string {
-  const statusRows = statusRowsForPrompt(state, rows);
+  const statusRows = statusRowsForPrompt(state, rows),
+    retries = triggers.filter((trigger) => trigger.kind === "leader_retry"),
+    waits = triggers.filter((trigger) => trigger.kind === "worker_wait"),
+    sourceCounts = new Map<string, number>();
+  for (const trigger of triggers) sourceCounts.set(trigger.kind, (sourceCounts.get(trigger.kind) ?? 0) + 1);
   return [
-    trigger.kind === "leader_retry" ? "# Squad leader retry" : "# Squad worker callback",
-    `Trigger: ${JSON.stringify(trigger)}`,
-    ...(trigger.kind === "leader_retry"
-      ? [`Previous turn could not advance: ${trigger.reason}`]
-      : trigger.kind === "worker_wait"
-        ? [`Wait completed: ${trigger.reason}`]
-        : []),
+    retries.length > 0 ? "# Squad leader retry" : "# Squad worker callback",
+    `Merged callback batch: total=${String(triggers.length)}; sources=${[...sourceCounts]
+      .map(([kind, count]) => `${kind}:${String(count)}`)
+      .join(",")}`,
+    `Triggers: ${JSON.stringify(triggers)}`,
+    ...retries.map((trigger) => `Previous turn could not advance: ${trigger.reason}`),
+    ...waits.map((trigger) => `Wait completed: ${trigger.reason}`),
     "Review the durable TaskDispatchRow receipts below. " +
       "Return runtime-batch/v1 to reassign or add work. " +
       "Every runtime-batch/v1 must contain at least one dispatch. " +

--- a/packages/daemon/test/squad-coordinator-recovery.test.ts
+++ b/packages/daemon/test/squad-coordinator-recovery.test.ts
@@ -620,6 +620,110 @@ test("malformed leader results exhaust the declared budget after exactly that ma
   });
 });
 
+test("one callback turn drains more worker outcomes than the leader turn budget", async () => {
+  await withRootDir(async (rootDir) => {
+    const workers = Array.from({ length: 6 }, (_, index) => ({
+        workerId: index % 2 === 0 ? "sol" : "terra",
+        dispatchId: `dispatch_${(index + 2).toString(16).padStart(24, "0")}`,
+        runtimeSessionId: `runtime-worker-${index + 1}`,
+        outcome: null,
+      })),
+      fixture = makeRecoveryFixture(rootDir, {
+        leaderOutcome: null,
+        leaderTurnBudget: 3,
+        workers,
+        leaderReport: true,
+      });
+
+    for (const worker of workers) {
+      fixture.completeWorker(worker.runtimeSessionId);
+      await fixture.coordinator.observeOutcome(outcomeEvent(worker.runtimeSessionId));
+    }
+    let status = fixture.coordinator.status(SQUAD_RUN_ID);
+    assert.equal(status.status, "leader_running");
+    assert.equal(status.pendingLeaderCallbackCount, workers.length);
+    assert.equal(fixture.spawns.length, 0, "callbacks queue while the leader is running");
+
+    fixture.completeLeader(LEADER_SESSION_ID, JSON.stringify({ schema: "squad-decision/v1", action: "waiting" }));
+    await fixture.coordinator.observeOutcome(outcomeEvent(LEADER_SESSION_ID));
+
+    status = fixture.coordinator.status(SQUAD_RUN_ID);
+    assert.equal(status.status, "leader_running", String(status.error));
+    assert.equal(status.pendingLeaderCallbackCount, 0);
+    assert.equal((status.leaders as unknown[]).length, 2);
+    assert.equal(fixture.spawns.length, 1);
+    assert.match(String(fixture.spawns[0]?.prompt), /Merged callback batch: total=6; sources=worker_outcome:6/u);
+    for (const [index, worker] of workers.entries())
+      assert.match(
+        String(fixture.spawns[0]?.prompt),
+        new RegExp(`attempt=worker-${index + 1} .*session=${worker.runtimeSessionId} status=succeeded`, "u"),
+      );
+
+    const callbackSessionId = String(status.currentLeaderRuntimeSessionId);
+    fixture.completeLeader(callbackSessionId, JSON.stringify({ schema: "squad-decision/v1", action: "converged" }));
+    await fixture.coordinator.observeOutcome(outcomeEvent(callbackSessionId));
+
+    status = fixture.coordinator.status(SQUAD_RUN_ID);
+    assert.equal(status.status, "converged", String(status.error));
+    assert.equal((status.leaders as unknown[]).length, 2);
+    assert.equal(status.error, null);
+  });
+});
+
+test("a leader retry remains primary while coalescing queued worker outcomes", async () => {
+  await withRootDir(async (rootDir) => {
+    const workers = [
+        {
+          workerId: "sol",
+          dispatchId: "dispatch_000000000000000000000002",
+          runtimeSessionId: "runtime-worker-sol",
+          outcome: null,
+        },
+        {
+          workerId: "terra",
+          dispatchId: "dispatch_000000000000000000000003",
+          runtimeSessionId: "runtime-worker-terra",
+          outcome: null,
+        },
+      ] as const,
+      fixture = makeRecoveryFixture(rootDir, {
+        leaderOutcome: "succeeded",
+        leaderResult: "not json",
+        leaderTurnBudget: 3,
+        workers,
+        leaderReport: true,
+      });
+    for (const worker of workers) {
+      fixture.completeWorker(worker.runtimeSessionId);
+      await fixture.coordinator.observeOutcome(outcomeEvent(worker.runtimeSessionId));
+    }
+
+    await fixture.coordinator.observeOutcome(outcomeEvent(LEADER_SESSION_ID));
+
+    let status = fixture.coordinator.status(SQUAD_RUN_ID);
+    assert.equal(status.status, "leader_running", String(status.error));
+    assert.equal(status.pendingLeaderCallbackCount, 0);
+    assert.deepEqual((status.leaders as { readonly trigger: unknown }[])[1]?.trigger, {
+      kind: "leader_retry",
+      turnId: "leader-1",
+      reason: "Leader result was not JSON.",
+    });
+    assert.equal(fixture.spawns[0]?.providerSessionId, "provider-leader");
+    assert.equal(fixture.spawns[0]?.idempotencyKey, `${SQUAD_RUN_ID}:leader:retry:leader-1`);
+    assert.match(
+      String(fixture.spawns[0]?.prompt),
+      /Merged callback batch: total=3; sources=leader_retry:1,worker_outcome:2/u,
+    );
+    assert.match(String(fixture.spawns[0]?.prompt), /Previous turn could not advance: Leader result was not JSON\./u);
+
+    const retrySessionId = String(status.currentLeaderRuntimeSessionId);
+    fixture.completeLeader(retrySessionId, JSON.stringify({ schema: "squad-decision/v1", action: "converged" }));
+    await fixture.coordinator.observeOutcome(outcomeEvent(retrySessionId));
+    status = fixture.coordinator.status(SQUAD_RUN_ID);
+    assert.equal(status.status, "converged", String(status.error));
+  });
+});
+
 test("a rejected worker attempt does not block a later dispatch to the same worker", async () => {
   await withRootDir(async (rootDir) => {
     const plan = JSON.stringify({


### PR DESCRIPTION
# English

## Summary

The squad callback coordinator drained its leader-trigger queue one entry per leader turn (`pendingLeaderTriggers.slice(1)`), so N workers that call back while a leader turn is running were split into N separate leader turns. With a finite `leaderTurnBudget`, a burst of callbacks exhausts the budget before the queue empties and the whole squad run fails. This was observed live: squad run `squad_e577568d9ebc49a4b3a2adda` (ontology-squad, leaderTurnBudget=8) ran exactly 8 leader turns with 1 callback still pending and failed with `leader turn budget 8 exhausted`. This PR coalesces the drain: a non-initial leader turn consumes the entire pending queue at once, so a same-batch burst converges in one or two turns instead of one-per-callback. The leader already receives the full `dispatchRows` snapshot, so it sees every worker outcome regardless; nothing is lost by draining together.

## Architectural Justification

Not applicable — Production-Delta is +17/-13, far under the 200-line threshold. The fix is a narrowing (drain-all instead of drain-one), not new machinery; the alternative considered (mid-flight prompt injection into a running leader) was rejected because it requires rebuilding the worker-host reverse stdin channel and is supported by only one provider today.

## What Changed

- `packages/daemon/src/squad-coordinator.ts`: `spawnLeader` now captures the whole pending queue as `drainedTriggers` for a non-initial turn and clears `pendingLeaderTriggers` to `[]` instead of `slice(1)`. The per-turn `idempotencyKey` still keys off the head trigger, so it stays stable per turn and unique across turns.
- `packages/daemon/src/squad-leader-decision.ts`: `callbackLeaderPrompt` now takes the batched `triggers[]`. It marks the turn as a retry when any `leader_retry` is present, emits every retry and wait reason (not just the first), and summarizes the merged batch (`total`, `sources=kind:count`). Worker outcomes remain authoritative via `dispatchRows`.
- `packages/daemon/test/squad-coordinator-recovery.test.ts`: added a fan-out coalescing test (budget 3, workers > 3 → one callback turn drains all, converges) and a retry-coalescing test (a `leader_retry` batched with two `worker_outcome` triggers keeps the retry idempotency key and the retry-flavored prompt, then converges).

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: use the single CI-backed `Production-Delta` declaration below; do not enter a second metric.

## Machine-Readable Declarations

Production-Delta: +17/-13

## Task And Scope

- Harness task: task_726084d3e5c135bf2ffc918d35
- Branch: codex/squad-coalesce-drain
- Public scope: squad callback coordinator drain semantics (daemon) + directed tests
- Private planning/evidence updated: yes
- Out of scope: `leaderTurnBudget` default/value (a per-squad declaration field, handled separately), mid-flight injection, live squad rerun

## Version Impact

- Version: no version change because this is an internal daemon coordinator fix with no package surface change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none
- Authority: task_726084d3e5c135bf2ffc918d35 (flow-defect surfaced during the PLT-Ontology milestone: budget-exhaustion squad failure)
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no

## Verification

- Base `origin/main` SHA: a573a1d392c8dea3a5293adea3de16f5500eed23
- Branch merge-base with `origin/main`: a573a1d392c8dea3a5293adea3de16f5500eed23
- Last `git fetch origin` time: 2026-08-29T12:27:11Z
- Sync method: none needed
- Public diff command: `git diff a573a1d392c8dea3a5293adea3de16f5500eed23..14cc2515309fff70895839e065852e44881c9681`
- Private evidence commit/path: harness/tasks/task_726084d3e5c135bf2ffc918d35-squad-coalesce-drain/ (plan, fact F-AEC48FAC)
- Reviewer evidence path: this PR body + CEO semantic acceptance (diff ground-truthed, not receipt-trusted)
- GitHub Actions `rewrite-ci` run URL: pending (linked after first run)
- [x] focused daemon suite: `squad-coordinator-recovery` 13 passed / 0 failed (368.788 ms)
- [x] `npm run typecheck`
- [x] `npm run lint`
- [ ] `npm run check` / full gate matrix
- Not run: full local gate matrix — worker stop condition is targeted-test green + local commit; the complete gate matrix is GitHub CI's authority (running full `check:local` on a shared machine starves fork slots).

## Review Evidence

- Self-review: CEO ground-truthed the diff (drain-all correct; workers still dispatched in parallel; retry semantics preserved via batched prompt + stable retry idempotency key; positive control present — reverting to `slice(1)` fails the fan-out test).
- Reviewer subagent: none (single-file daemon fix; semantic acceptance by CEO)
- Human review: pending
- Blocking findings: none

## Residual Risk

- Validation used the coordinator test fixture, not a live squad rerun (per the task's directed-test stop condition). The live rerun is the 259 weathering closure, which will exercise this path with `leaderTurnBudget=20` after merge.

## References

- Task: task_726084d3e5c135bf2ffc918d35
- Evidence: fact F-AEC48FAC; squad run squad_e577568d9ebc49a4b3a2adda (failure evidence)
- Review: CEO semantic acceptance

---

# 中文

## 概要

Squad 回调协调器过去每个 leader turn 只从触发器队列消费一个(`pendingLeaderTriggers.slice(1)`),于是 leader 运行期间 N 个 worker 回调被拆成 N 个独立 leader turn。`leaderTurnBudget` 有限时,一批回调会在队列清空前烧光 budget、整个 squad run 失败。实测:squad run `squad_e577568d9ebc49a4b3a2adda`(ontology-squad,budget=8)正好跑满 8 个 leader turn、还剩 1 个回调 pending,以 `leader turn budget 8 exhausted` 失败。本 PR 把 drain 合并:非 initial 的 leader turn 一次性消费整个 pending 队列,同批回调收敛到 1~2 个 turn 而非一回调一 turn。leader 本来就拿全量 `dispatchRows` 快照、能看到所有 worker 结局,合并 drain 不丢任何东西。

## 架构辩护

不适用——Production-Delta 为 +17/-13,远低于 200 行阈值。本修复是收窄(drain 全部而非 drain 一个),不是新增机制;曾考虑的替代方案(向运行中 leader 中途注入 prompt)因需重建 worker-host 反向 stdin 管道、且今天只一个 provider 支持而否决。

## 改动内容

- `packages/daemon/src/squad-coordinator.ts`:`spawnLeader` 非 initial turn 时把整个 pending 队列捕获为 `drainedTriggers`,并把 `pendingLeaderTriggers` 清空为 `[]`(不再 `slice(1)`)。每 turn 的 `idempotencyKey` 仍以队首触发器为键,保持同 turn 稳定、跨 turn 唯一。
- `packages/daemon/src/squad-leader-decision.ts`:`callbackLeaderPrompt` 改收批量 `triggers[]`。批次含任一 `leader_retry` 时标记为 retry,逐条输出所有 retry 与 wait 原因(不止第一个),并汇总合并批次(`total`、`sources=kind:count`)。worker 结局权威仍来自 `dispatchRows`。
- `packages/daemon/test/squad-coordinator-recovery.test.ts`:新增扇出合并测试(budget 3、worker >3 → 一个回调 turn drain 全部并收敛)与 retry 合并测试(一个 `leader_retry` 与两个 `worker_outcome` 同批 → 保留 retry idempotency key 与 retry 型 prompt,再收敛)。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 同 commit 删除的门 / fixture：none
- 生产净行数：引用英文块中的 `Production-Delta`。

## 机读声明说明

- 机读声明只在英文块出现一次并顶格。
- 无 `package.json` / `package-lock.json` 变化,故删除 `Dependency-Change` 行。

## 任务与范围

- Harness 任务：task_726084d3e5c135bf2ffc918d35
- 分支：codex/squad-coalesce-drain
- 公开范围：squad 回调协调器 drain 语义(daemon)+ 定向测试
- 私有计划 / 证据是否已更新：yes
- 范围外：`leaderTurnBudget` 默认值/取值(每 squad 声明字段,另行处置)、中途注入、真机 squad 重跑

## 版本影响

- 版本：不改版本,因为这是 daemon 内部协调器修复,无 package 面变化
- 发布影响：不发布

## 治理声明

- 是否触碰 protected surface：no
- protected surface 范围：none
- 依据：task_726084d3e5c135bf2ffc918d35（PLT-Ontology 里程碑中暴露的流转缺陷：budget 耗尽导致 squad 失败）
- 机器检查边界：本 PR 只声明该段存在；声明是否真实、充分，由 reviewer 判断。
- Break-glass：no

## 验证

- `origin/main` 基准 SHA：a573a1d392c8dea3a5293adea3de16f5500eed23
- 当前分支与 `origin/main` 的 merge-base：a573a1d392c8dea3a5293adea3de16f5500eed23
- 最近一次 `git fetch origin` 时间：2026-08-29T12:27:11Z
- 同步方式：不需要
- 公开 diff 命令：`git diff a573a1d392c8dea3a5293adea3de16f5500eed23..14cc2515309fff70895839e065852e44881c9681`
- 私有证据 commit/path：harness/tasks/task_726084d3e5c135bf2ffc918d35-squad-coalesce-drain/（plan、fact F-AEC48FAC）
- Reviewer 证据路径：本 PR body + CEO 语义验收（亲自 ground-truth diff，不信回执）
- GitHub Actions `rewrite-ci` run URL：pending（首跑后补链）
- [x] 定向 daemon 套件：`squad-coordinator-recovery` 13 passed / 0 failed（368.788 ms）
- [x] `npm run typecheck`
- [x] `npm run lint`
- [ ] `npm run check` / 完整门矩阵
- 未运行：完整本地门矩阵——worker 停止点是定向测试绿 + 本地 commit；完整门矩阵是 GitHub CI 的权威（共享机跑全量 `check:local` 会枯竭 fork 槽）。

## 审查证据

- 自查：CEO 亲自 ground-truth diff（drain 全部正确；workers 仍并行派工；retry 语义经批量 prompt + 稳定 retry idempotency key 保留；阳性对照存在——退回 `slice(1)` 会让扇出测试失败）。
- Reviewer subagent：无（单文件 daemon 修复；语义验收由 CEO 做）
- 人工审查：pending
- 阻塞发现：无

## 残余风险

- 验证用协调器测试 fixture,非真机 squad 重跑(遵任务的定向测试停止点)。真机重跑就是 259 风化闭环,合并后将以 `leaderTurnBudget=20` 走这条路径。

## 关联材料

- 任务：task_726084d3e5c135bf2ffc918d35
- 证据：fact F-AEC48FAC；squad run squad_e577568d9ebc49a4b3a2adda（失败证据）
- 审查：CEO 语义验收
