### PR TITLE
fix: gate gui release on macOS build only (dec_B86CD725 / dec_630DB4EB)

### DIFF
--- a/.github/workflows/gui-release.yml
+++ b/.github/workflows/gui-release.yml
@@ -49,26 +49,10 @@ jobs:
           echo "release_tag=${release_tag}" >> "${GITHUB_OUTPUT}"
           echo "release_version=${release_tag#gui-v}" >> "${GITHUB_OUTPUT}"
 
-  build:
+  build-macos:
     needs: release-context
-    name: build ${{ matrix.name }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - name: macos-arm64
-            os: macos-14
-            artifact_dir: macos-arm64
-            builder_args: --mac --arm64
-          - name: windows-x64
-            os: windows-latest
-            artifact_dir: windows-x64
-            builder_args: --win --x64
-          - name: linux-x64
-            os: ubuntu-latest
-            artifact_dir: linux-x64
-            builder_args: --linux AppImage deb --x64
+    name: build macos-arm64
+    runs-on: macos-14
     steps:
       - uses: actions/checkout@v4
         with:
@@ -79,10 +63,6 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           cache: npm
 
-      - name: Install Linux packaging tools
-        if: runner.os == 'Linux'
-        run: sudo apt-get update && sudo apt-get install -y fakeroot dpkg
-
       - run: npm ci
 
       - name: Prepare GUI desktop runtime
@@ -92,14 +72,14 @@ jobs:
       - name: Build GUI package
         working-directory: packages/gui
         env:
-          HARNESS_GUI_BUILDER_OUTPUT: ../../dist/gui-release/${{ matrix.artifact_dir }}
+          HARNESS_GUI_BUILDER_OUTPUT: ../../dist/gui-release/macos-arm64
           WIN_CSC_LINK: ""
           CSC_LINK: ""
-        run: npx electron-builder --config electron-builder.config.mjs ${{ matrix.builder_args }}
+        run: npx electron-builder --config electron-builder.config.mjs --mac --arm64
 
       - name: Write SHA256SUMS
         env:
-          ARTIFACT_DIR: ${{ matrix.artifact_dir }}
+          ARTIFACT_DIR: macos-arm64
         shell: bash
         run: |
           set -euo pipefail
@@ -110,7 +90,7 @@ jobs:
 
           const root = path.resolve("dist/gui-release", process.env.ARTIFACT_DIR);
           const files = [];
-          const releaseAssetPattern = /\.(?:AppImage|blockmap|deb|dmg|exe|zip)$/u;
+          const releaseAssetPattern = /\.(?:blockmap|dmg|zip)$/u;
           function walk(dir) {
             for (const entry of readdirSync(dir, { withFileTypes: true })) {
               const fullPath = path.join(dir, entry.name);
@@ -134,20 +114,20 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: gui-${{ matrix.artifact_dir }}
-          path: dist/gui-release/${{ matrix.artifact_dir }}/
+          name: gui-macos-arm64
+          path: dist/gui-release/macos-arm64/
           if-no-files-found: error
           retention-days: 14
 
   release:
     needs:
       - release-context
-      - build
+      - build-macos
     runs-on: ubuntu-latest
     steps:
       - uses: actions/download-artifact@v4
         with:
-          pattern: gui-*
+          name: gui-macos-arm64
           path: dist/gui-release-artifacts
 
       - name: Write release notes
@@ -164,18 +144,12 @@ jobs:
 
           ## Signing status
 
-          These artifacts are unsigned and unnotarized by design. No Apple Developer ID, Apple notarization, or Windows code-signing certificate is used for this pre-release.
+          These artifacts are unsigned and unnotarized by design. No Apple Developer ID or Apple notarization is used for this pre-release.
 
           ## Artifacts
 
           - macOS arm64: unsigned dmg and zip.
-          - Windows x64: unsigned NSIS installer. Build produced by CI; Windows runtime/install flow not manually tested.
-          - Linux x64: unsigned AppImage and deb. Build produced by CI; Linux runtime/install flow not manually tested.
-          - SHA256SUMS files are included per platform.
-
-          ## Notes
-
-          The Windows and Linux packages are first-pass CI artifacts for inspection and smoke distribution. Treat them as unverified until platform-specific install and runtime testing is completed.
+          - SHA256SUMS-macos-arm64.txt is included.
           EOF
 
       - name: Create or update draft GitHub Release
@@ -194,7 +168,14 @@ jobs:
             gh release create "${RELEASE_TAG}" --draft --prerelease --title "${title}" --notes-file release-notes.md --target "${GITHUB_SHA}"
           fi
 
-          mapfile -d '' assets < <(find dist/gui-release-artifacts -type f \( -name '*.AppImage' -o -name '*.blockmap' -o -name '*.deb' -o -name '*.dmg' -o -name '*.exe' -o -name '*.zip' -o -name 'SHA256SUMS-*.txt' \) -print0)
+          mapfile -d '' assets < <(
+            find dist/gui-release-artifacts -type f \( \
+              -name '*.blockmap' -o \
+              -name '*.dmg' -o \
+              -name '*.zip' -o \
+              -name 'SHA256SUMS-*.txt' \
+            \) -print0
+          )
           if [ "${#assets[@]}" -eq 0 ]; then
             echo "No release assets found." >&2
             exit 1


### PR DESCRIPTION
# English

## Summary
The `gui-release.yml` release job depended on the whole `build` matrix (macos-arm64 + windows-x64 + linux-x64). Windows (`spawnSync npm.cmd EINVAL`) and Linux builds fail, so a green macOS build never reached the release job (it was skipped). Per dec_B86CD725 (0.0.1 ships macOS-only) and dec_630DB4EB (Windows demoted, never on the release critical path), this reduces the workflow to a single `build-macos` job and points the release job at it, so a green macOS build releases.

## Architectural Justification
The release critical path must depend only on surfaces the milestone commits to shipping. Windows/Linux GUI packaging is demoted governance, so gating the macOS release on them inverts the dependency: a demoted, known-red surface blocks a committed one. Narrowing the matrix removes that inversion at the source rather than adding conditional skips.

## What Changed
- `build` matrix → single `build-macos` job (runs-on macos-14, `--mac --arm64`).
- Removed the windows-x64 / linux-x64 matrix legs and the Linux packaging-tools step.
- Release asset pattern narrowed to macOS artifacts (`blockmap|dmg|zip`).
- `release` job `needs: build` → `needs: build-macos`.

## Gate Harvest / 门收割
CI-only workflow change; no gate thresholds touched.

## Machine-Readable Declarations
Production-Delta: +0/-0

### Optional Evidence Claims
(none)

## Task And Scope
Authority: task_359872dd9801480283ea437129 (governance task; CI protected surface, explicitly authorized). Decisions: dec_B86CD725 (macOS-only 0.0.1), dec_630DB4EB (Windows demoted).

## Version Impact
No package version or dependency change.

## Governance Declaration
Authorized CI/gate modification: this task is an explicitly-authorized governance task for the release workflow; the change narrows scope (removes red demoted legs), does not weaken any gate. Authority: task_359872dd9801480283ea437129; dec_B86CD725; dec_630DB4EB.

## Verification
CEO ground-truthed the diff: the `release` job now `needs: build-macos`; the matrix is a single macOS leg; the asset pattern emits only macOS artifacts; no other workflow or code touched. `production-delta` computes +0/-0 (workflow path excluded from production counting).

## Review Evidence
CEO semantic acceptance against dec_B86CD725 / dec_630DB4EB: release now depends only on the macOS surface the milestone commits to. Scope limited to `.github/workflows/gui-release.yml`.

## Residual Risk
Windows/Linux GUI artifacts are no longer produced for 0.0.1 — intended per the cited decisions. If a later milestone re-commits to those platforms, the matrix legs are restored in that milestone's scope.

## References
task_359872dd; dec_B86CD725; dec_630DB4EB; failing run 33166963207.

# 中文

## 概要
`gui-release.yml` 的 release job 依赖整个 `build` 矩阵(macos-arm64 + windows-x64 + linux-x64)。Windows(`spawnSync npm.cmd EINVAL`)与 Linux 构建失败,导致 macOS 构建绿了 release job 仍被跳过。依据 dec_B86CD725(0.0.1 只发 macOS)与 dec_630DB4EB(Windows 降级,永不在发布关键路径),本 PR 把 workflow 收窄为单个 `build-macos` job 并让 release job 依赖它。

## 架构辩护
发布关键路径只应依赖里程碑承诺交付的表面。Windows/Linux GUI 打包是降级治理面,用它们门控 macOS 发布是依赖倒置:降级且已知红的面阻塞了被承诺的面。收窄矩阵从源头消除倒置,而非加条件跳过。

## 改动内容
- `build` 矩阵 → 单个 `build-macos`(macos-14,`--mac --arm64`)。
- 删除 windows-x64/linux-x64 矩阵腿与 Linux 打包工具步骤。
- release 资产模式收窄到 macOS(`blockmap|dmg|zip`)。
- release job `needs: build` → `needs: build-macos`。

## 门收割 / Gate Harvest
仅 CI workflow 改动,未触碰任何门阈值。

## 机读声明说明
Production-Delta: +0/-0;这是明确授权的 governance CI 任务,改动收窄范围(删红色降级腿),不削弱任何门。
