### PR TITLE
fix: preserve owner admin command class

### DIFF
--- a/packages/daemon/test/people-actions.integration.test.ts
+++ b/packages/daemon/test/people-actions.integration.test.ts
@@ -5,7 +5,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
 import { makeTaskEventStore, parsePeopleRosterDocument } from "../../kernel/src/index.ts";
-import { initRepo, actor } from "./migration-import.fixtures.ts";
+import { initRepo, actor, bootstrapPerson } from "./migration-import.fixtures.ts";
 import { canonicalRoot, workspaceId } from "../src/protocol/daemon-protocol.contract.ts";
 import { openRepoCell } from "../src/repo-cell.ts";
 
@@ -109,7 +109,7 @@ test("People Action commands are the canonical write surface for people.yaml", a
   }
 });
 
-test("People Action commands cannot remove the last admin or downgrade the bootstrap owner", async () => {
+test("People Action commands cannot rewrite or downgrade the bootstrap owner role", async () => {
   const root = mkdtempSync(path.join(tmpdir(), "ha-people-invariants-"));
   let cell: Awaited<ReturnType<typeof openRepoCell>> | undefined;
   try {
@@ -144,12 +144,9 @@ test("People Action commands cannot remove the last admin or downgrade the boots
       },
       binding,
     );
-    assert.equal(ownerPolicyChanged.outcome, "applied");
-
-    const lastAdminRemoval = await cell.run({ kind: "people-remove", personId: "person_alice" }, binding);
-    assert.equal(lastAdminRemoval.outcome, "op_rejected");
-    assert.equal(lastAdminRemoval.code, "invalid_people_action");
-    assert.match(lastAdminRemoval.nextAction ?? "", /at least one enabled person with admin authority/u);
+    assert.equal(ownerPolicyChanged.outcome, "op_rejected");
+    assert.equal(ownerPolicyChanged.code, "invalid_people_action");
+    assert.match(ownerPolicyChanged.nextAction ?? "", /owner role must retain the admin command class/u);
 
     const ownerRemoval = await cell.run({ kind: "people-remove", personId: "person_zeyu" }, binding);
     assert.equal(ownerRemoval.outcome, "op_rejected");
@@ -172,7 +169,58 @@ test("People Action commands cannot remove the last admin or downgrade the boots
       makeTaskEventStore({ repoId: "people-invariants", rootDir: root })
         .read()
         .events.filter(({ schema }) => schema === "people-event/v1").length,
-      2,
+      1,
+    );
+  } finally {
+    await cell?.close();
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("People Action commands cannot remove the last enabled admin", async () => {
+  const root = mkdtempSync(path.join(tmpdir(), "ha-people-last-admin-"));
+  let cell: Awaited<ReturnType<typeof openRepoCell>> | undefined;
+  try {
+    const alice = {
+      ...bootstrapPerson,
+      personId: "person_alice",
+      displayName: "Alice",
+      roles: ["administrator"],
+      credentials: [],
+    };
+    initRepo(
+      root,
+      `${JSON.stringify(
+        {
+          schema: "harness-people/v1",
+          people: [bootstrapPerson, alice],
+          roles: [
+            { roleId: "owner", commandClasses: ["repo-read"] },
+            { roleId: "administrator", commandClasses: ["admin"] },
+          ],
+        },
+        null,
+        2,
+      )}\n`,
+    );
+    cell = await openRepoCell({
+      repoId: workspaceId("people-last-admin"),
+      rootDir: canonicalRoot(root),
+      ownerId: "people-daemon",
+      now: () => "2026-08-27T02:15:00.000Z",
+    });
+    const removed = await cell.run(
+      { kind: "people-remove", personId: "person_alice" },
+      { actor, source: "local" as const },
+    );
+    assert.equal(removed.outcome, "op_rejected");
+    assert.equal(removed.code, "invalid_people_action");
+    assert.match(removed.nextAction ?? "", /at least one enabled person with admin authority/u);
+    assert.equal(
+      makeTaskEventStore({ repoId: "people-last-admin", rootDir: root })
+        .read()
+        .events.filter(({ schema }) => schema === "people-event/v1").length,
+      0,
     );
   } finally {
     await cell?.close();

--- a/packages/kernel/src/domain/people-roster.ts
+++ b/packages/kernel/src/domain/people-roster.ts
@@ -247,6 +247,8 @@ function setPersonRole(
     throw new PeopleRosterContractError("the owner role is reserved for the bootstrap creator");
   if (held.roles.includes("owner") && rolePolicy.roleId !== "owner")
     throw new PeopleRosterContractError(`bootstrap creator ${personId} must retain the owner role`);
+  if (held.roles.includes("owner") && !rolePolicy.commandClasses.includes("admin"))
+    throw new PeopleRosterContractError("the owner role must retain the admin command class");
   const roles = withRolePolicy(roster.roles, rolePolicy),
     people = roster.people.map((person) =>
       person.personId === personId ? { ...person, roles: [rolePolicy.roleId] } : person,

--- a/packages/kernel/test/contracts/people-roster-action.test.ts
+++ b/packages/kernel/test/contracts/people-roster-action.test.ts
@@ -110,10 +110,12 @@ test("roster transitions preserve the bootstrap owner and an enabled admin", () 
       person: { ...owner, personId: "person_alice", displayName: "Alice", roles: ["admin"], credentials: [] },
       rolePolicy: { roleId: "admin", commandClasses: ["admin"] },
     }),
-    ownerWithoutAdmin = applyPeopleRosterAction(alice.body, {
-      kind: "people-set-role",
-      personId: owner.personId,
-      rolePolicy: { roleId: "owner", commandClasses: ["repo-read"] },
+    aliceRoster = parsePeopleRosterDocument(alice.body),
+    ownerWithoutAdmin = serializePeopleRosterDocument({
+      ...aliceRoster,
+      roles: aliceRoster.roles.map((role) =>
+        role.roleId === "owner" ? { ...role, commandClasses: ["repo-read"] } : role,
+      ),
     });
 
   const rejected = [
@@ -129,8 +131,14 @@ test("roster transitions preserve the bootstrap owner and an enabled admin", () 
         personId: "person_alice",
         rolePolicy: { roleId: "owner", commandClasses: ["admin"] },
       }),
+    () =>
+      applyPeopleRosterAction(alice.body, {
+        kind: "people-set-role",
+        personId: owner.personId,
+        rolePolicy: { roleId: "owner", commandClasses: ["repo-read"] },
+      }),
     () => applyPeopleRosterAction(bootstrapped.body, { kind: "people-remove", personId: owner.personId }),
-    () => applyPeopleRosterAction(ownerWithoutAdmin.body, { kind: "people-remove", personId: "person_alice" }),
+    () => applyPeopleRosterAction(ownerWithoutAdmin, { kind: "people-remove", personId: "person_alice" }),
   ];
   for (const transition of rejected)
     assert.throws(transition, (error) => {


### PR DESCRIPTION
# English
## Summary
The People roster let owner-role admin command-class policy be rewritten/downgraded through People Action commands. Per the owner-integrity invariant, the bootstrap owner's admin command class must be preserved: any attempt to rewrite or downgrade it is now rejected (`invalid_people_action`).
## What Changed
`packages/kernel/src/domain/people-roster.ts` preserves the owner admin command class; integration and contract tests updated to assert rewrite/downgrade of the bootstrap owner is `op_rejected`.
## Machine-Readable Declarations
Production-Delta: +2/-0
## Task And Scope
Authority: task_1972feb4cf7ea86dc321cf1a73.
## Verification
CEO verified: the test now asserts owner-policy change → `op_rejected` / `invalid_people_action`; kernel change preserves the owner's command class. Targeted people-roster tests are the touched surface.
## Review Evidence
CEO semantic acceptance: matches the owner-integrity invariant; scope limited to people-roster + its tests.
## Residual Risk
None material; the change tightens a privilege-preservation invariant.
# 中文
## 概要
People roster 允许经 People Action 命令改写/降级 owner 角色的 admin command class。按 owner 完整性不变量,bootstrap owner 的 admin command class 必须保留:任何改写/降级尝试现在被拒(`invalid_people_action`)。
## 改动内容
`people-roster.ts` 保留 owner admin command class;集成/契约测试改为断言改写/降级 bootstrap owner 返回 `op_rejected`。
## 机读声明说明
Production-Delta: +2/-0;收紧权限保护不变量,不削弱任何门。
