### PR TITLE
fix: derive command coverage counts from the catalog

### DIFF
--- a/packages/cli/test/thin-command-contract-parity.test.ts
+++ b/packages/cli/test/thin-command-contract-parity.test.ts
@@ -48,7 +48,6 @@ const frozenMutations = Object.freeze([
 ] as const);
 
 test("all public commands expose the canonical structured input facet", () => {
-  assert.equal(daemonProtocolCommands.length, 138);
   for (const command of daemonProtocolCommands) {
     assert.equal(Object.hasOwn(command, "inputs"), true, `${command.id}: explicit inputs`);
     assert.deepEqual(deriveThinCliInputs(command), command.inputs, command.id);

--- a/packages/cli/test/thin-command.test.ts
+++ b/packages/cli/test/thin-command.test.ts
@@ -8,7 +8,10 @@ import { emit, main, resolveCliVersion } from "../src/index.ts";
 
 test("top-level help renders a derived domain directory and domain help filters commands", () => {
   const help = renderThinHelp();
-  assert.equal(thinCliCommands.length, 137);
+  assert.equal(
+    thinCliCommands.length,
+    daemonProtocolCommands.filter((command) => !("internal" in command && command.internal)).length,
+  );
   for (const domain of [...new Set(daemonProtocolCommands.map((command) => command.path[0]))]
     .filter((value): value is string => value !== undefined)
     .sort())

--- a/packages/daemon/test/command-admission.test.ts
+++ b/packages/daemon/test/command-admission.test.ts
@@ -10,8 +10,7 @@ const localSource = "local" as const;
 const assignmentSource = { kind: "assignment", nodeId: "edge-one", assignmentId: "assignment-one" } as const;
 const admissionRoutes = new Set(["direct", "via-assignment", "via-center-forward", "rejected"]);
 
-test("all 138 daemon commands close every repo-mode admission cell", () => {
-  assert.equal(daemonProtocolCommands.length, 138);
+test("all daemon commands close every repo-mode admission cell", () => {
   let cells = 0;
   for (const command of daemonProtocolCommands) {
     assert.deepEqual(Object.keys(command.admission).sort(), [...daemonRepoModeWords].sort(), command.id);
@@ -35,7 +34,7 @@ test("all 138 daemon commands close every repo-mode admission cell", () => {
       }
     }
   }
-  assert.equal(cells, 138 * 3);
+  assert.equal(cells, daemonProtocolCommands.length * daemonRepoModeWords.length);
 });
 
 test("observe.tail declares direct admission and named source residency for every tail kind", () => {


### PR DESCRIPTION
# English
## Summary
Three tests hardcoded command counts (`138`/`137`), which drift whenever the command catalog changes. They now derive counts from the authoritative `daemonProtocolCommands` projection (filtering internal commands, multiplying by repo-mode words) so the assertions track the source of truth.
## What Changed
`thin-command-contract-parity.test.ts`, `thin-command.test.ts`, `command-admission.test.ts`: replace literal counts with derived expressions.
## Machine-Readable Declarations
Production-Delta: +0/-0
## Task And Scope
Authority: task_d8bf94d711308406497d9ddabb.
## Verification
CEO verified: literals `138`/`137`/`138*3` replaced with `daemonProtocolCommands`-derived expressions; test-only change (Production-Delta +0/-0).
## Review Evidence
CEO semantic acceptance: removes the hardcoded-count drift class at the source; tests now derive from the command contract.
## Residual Risk
None; test-only, tracks the authoritative catalog.
# 中文
## 概要
三个测试硬编码命令数(`138`/`137`),命令目录一变就漂移。现改为从权威 `daemonProtocolCommands` 投影派生(过滤 internal、乘 repo-mode 词数),断言随真源走。
## 改动内容
`thin-command-contract-parity.test.ts`、`thin-command.test.ts`、`command-admission.test.ts`:字面数改为派生表达式。
## 机读声明说明
Production-Delta: +0/-0;仅测试,从命令契约派生。
