### PR TITLE
fix: trim dead module-policy surface (review of #1908)

### DIFF
--- a/tools/gates/module-policy.mjs
+++ b/tools/gates/module-policy.mjs
@@ -1,5 +1,5 @@
 const SOURCE_EXTENSION = /\.(?:c|m)?js$|\.(?:d\.)?tsx?$/u;
-const TEST_SEGMENT = /(?:^|\/)(?:__snapshots__|__tests__|e2e|fixtures?|snapshots?|test|tests)(?:\/|$)/u;
+const TEST_SEGMENT = /(?:^|\/)(?:__tests__|e2e|fixtures?|test|tests)(?:\/|$)/u;
 const TEST_FILE = /\.(?:integration\.)?(?:spec|test)\.[^.]+$/u;
 const CANONICAL_MODULE =
   /^(?:packages|src)\/(kernel|task-lifecycle|doc-sync|preset|cli|gui|daemon|authority-write-path|identity-rbac)(?:\/|$)/u;
@@ -28,7 +28,6 @@ const EXEMPT_PRODUCTION = Object.freeze({ production: true, budgetExempt: true }
 export const MODULE_POLICY = Object.freeze(
   Object.fromEntries([...BUDGETED_MODULES.map((name) => [name, BUDGETED_PRODUCTION]), ["tooling", EXEMPT_PRODUCTION]]),
 );
-export const MODULES = Object.freeze(Object.keys(MODULE_POLICY));
 
 export function normalizeRepoPath(filePath) {
   if (typeof filePath !== "string") return null;

--- a/tools/gates/test/module-policy.test.mjs
+++ b/tools/gates/test/module-policy.test.mjs
@@ -10,11 +10,10 @@ import {
   isProductionPath,
   isTestPath,
   MODULE_POLICY,
-  MODULES,
 } from "../module-policy.mjs";
 
-test("module-policy is the single ordered module catalog", () => {
-  assert.deepEqual(MODULES, [
+test("module-policy keeps its ordered budget catalog and tooling policy", () => {
+  assert.deepEqual(BUDGETED_MODULES, [
     "kernel",
     "task-lifecycle",
     "write-contract",
@@ -29,12 +28,7 @@ test("module-policy is the single ordered module catalog", () => {
     "agent-runtime",
     "decision",
     "fact",
-    "tooling",
   ]);
-  assert.deepEqual(
-    BUDGETED_MODULES,
-    MODULES.filter((moduleName) => !MODULE_POLICY[moduleName].budgetExempt),
-  );
   assert.deepEqual(MODULE_POLICY.tooling, { production: true, budgetExempt: true });
   assert.equal(classifyModule("packages/kernel/src/domain/task.ts"), "kernel");
   assert.equal(classifyModule("packages/application/src/task-lifecycle-gates.ts"), "task-lifecycle");
@@ -68,14 +62,8 @@ test("tool source is production but explicitly outside the line-budget scope", (
   assert.equal(isBudgetedProductionPath("packages/kernel/src/domain/task.ts"), true);
 });
 
-test("tool tests, fixtures, and snapshots stay outside production classification", () => {
-  for (const filePath of [
-    "tools/gates/rule.test.mjs",
-    "tools/gates/test/rule.mjs",
-    "tools/gates/fixtures/rule.mjs",
-    "tools/gates/snapshots/rule.mjs",
-    "tools/gates/__snapshots__/rule.mjs",
-  ]) {
+test("tool tests and fixtures stay outside production classification", () => {
+  for (const filePath of ["tools/gates/rule.test.mjs", "tools/gates/test/rule.mjs", "tools/gates/fixtures/rule.mjs"]) {
     assert.deepEqual(classifyPath(filePath), { module: null, kind: "test" }, filePath);
   }
 });

--- a/tools/gates/test/production-delta.test.mjs
+++ b/tools/gates/test/production-delta.test.mjs
@@ -35,13 +35,11 @@ test("G33 measures additions and deletions in tool source", () => {
   ]);
 });
 
-test("G33 ignores tool tests, fixtures, and snapshots in both delta directions", () => {
+test("G33 ignores tool tests and fixtures in both delta directions", () => {
   const files = {
     "tools/gates/example.test.mjs": "old test\n",
     "tools/gates/test/example.mjs": "old helper\n",
     "tools/gates/fixtures/example.mjs": "old fixture\n",
-    "tools/gates/snapshots/example.mjs": "old snapshot\n",
-    "tools/gates/__snapshots__/example.mjs": "old snapshot\n",
   };
   const { rootDir, base } = makeRepo(files);
   for (const filePath of Object.keys(files)) writeRepoFile(rootDir, filePath, "new first\nnew second\n");


### PR DESCRIPTION
# English
## Summary
`tools/gates/module-policy.mjs` exported a dead `MODULES` array (no production caller) and carried an unmandated `__snapshots__`/`snapshots` exclusion in its test-segment regex (review of #1908). Both are removed; consumers use `BUDGETED_MODULES` directly.
## What Changed
Delete dead `MODULES` export; drop the snapshots exclusion from `TEST_SEGMENT`; tests updated to `BUDGETED_MODULES`.
## Machine-Readable Declarations
Production-Delta: +1/-2
## Task And Scope
Authority: task_ad1b684ba5caec9eb71fe61bf0 (review of #1908).
## Verification
CEO verified: `export const MODULES` removed with no remaining production caller; `TEST_SEGMENT` no longer excludes snapshot dirs; module-policy tests updated. tools/ counted as production (Production-Delta +1/-2).
## Review Evidence
CEO semantic acceptance: deletion of dead surface + unmandated exclusion; scope limited to module-policy gate + tests.
## Residual Risk
None; removes dead code and an unmandated exclusion, gate judgment on real boundaries unchanged.
# 中文
## 概要
`tools/gates/module-policy.mjs` 导出了一个 dead 的 `MODULES` 数组(无生产调用方),且 test-segment 正则里带一个未授权的 `__snapshots__`/`snapshots` 排除(#1908 review 发现)。两者删除,消费方直接用 `BUDGETED_MODULES`。
## 改动内容
删 dead `MODULES` export;从 `TEST_SEGMENT` 去掉 snapshots 排除;测试改用 `BUDGETED_MODULES`。
## 机读声明说明
Production-Delta: +1/-2;删死代码与未授权排除,门对真实边界判定不变。
