### PR TITLE
refactor(squad): remove unreachable UnlinkedAttempts surface (anti-entropy #8)

### DIFF
--- a/packages/daemon/src/squad-coordinator.ts
+++ b/packages/daemon/src/squad-coordinator.ts
@@ -814,7 +814,7 @@ export function makeSquadCoordinator(input: {
           return {
             attemptId: attempt.attemptId,
             workerId: attempt.workerId,
-            leaderTurnId: attempt.leaderTurnId ?? null,
+            leaderTurnId: attempt.leaderTurnId,
             dispatchId: attempt.dispatchId,
             runtimeSessionId: attempt.runtimeSessionId,
             rejection: attempt.rejection,

--- a/packages/daemon/src/squad-leader-decision.ts
+++ b/packages/daemon/src/squad-leader-decision.ts
@@ -61,8 +61,8 @@ export type LeaderTurn = {
 export type WorkerAttempt = {
   readonly attemptId: string;
   readonly workerId: string;
-  /** 派发该 attempt 的 leader 轮次(扇出树父子边);存量状态缺此字段 → DTO 归一为 null。 */
-  readonly leaderTurnId: string | null;
+  /** 派发该 attempt 的 leader 轮次(扇出树父子边)。 */
+  readonly leaderTurnId: string;
   readonly dispatchId: string | null;
   readonly runtimeSessionId: string | null;
   readonly rejection: string | null;

--- a/packages/daemon/src/squad-run-contract.ts
+++ b/packages/daemon/src/squad-run-contract.ts
@@ -49,8 +49,8 @@ export interface SquadRunLeaderTurnDto {
 export interface SquadRunWorkerAttemptDto {
   readonly attemptId: string;
   readonly workerId: string;
-  /** 派发该 attempt 的 leader 轮次(扇出树父子边);null = 存量状态,不得猜轮次。 */
-  readonly leaderTurnId: string | null;
+  /** 派发该 attempt 的 leader 轮次(扇出树父子边)。 */
+  readonly leaderTurnId: string;
   readonly dispatchId: string | null;
   readonly runtimeSessionId: string | null;
   readonly rejection: string | null;
@@ -183,7 +183,7 @@ function validSquadRunWorkerAttempt(value: unknown): value is SquadRunWorkerAtte
       "endedAt",
     ]) &&
     [value.attemptId, value.workerId].every(squadRunText) &&
-    (value.leaderTurnId === null || squadRunText(value.leaderTurnId)) &&
+    squadRunText(value.leaderTurnId) &&
     (value.dispatchId === null || squadRunText(value.dispatchId)) &&
     (value.runtimeSessionId === null || squadRunText(value.runtimeSessionId)) &&
     (value.rejection === null || squadRunText(value.rejection)) &&

--- a/packages/daemon/test/squad-run-detail-read.test.ts
+++ b/packages/daemon/test/squad-run-detail-read.test.ts
@@ -69,66 +69,6 @@ function seedRunningSquadRun(rootDir: string, squadRunId: string): void {
   });
 }
 
-/** 存量形态:早于 leaderTurnId 字段的 run,attempt 没有父子边。 */
-function seedLegacySquadRun(rootDir: string, squadRunId: string): void {
-  openDispatchStream(rootDir, {
-    dispatchId: "dispatch_00000000000000000000c3d4",
-    taskId: "task-squad",
-    executionId: "execution-squad",
-    runtimeSessionId: "runtime-legacy-leader",
-    instanceId: "instance-squad",
-    startedAt: "2026-08-27T11:00:00.000Z",
-  });
-  appendRuntimeWorkerRecord(rootDir, "dispatch_00000000000000000000c3d4", {
-    kind: "squad_run_state",
-    squadRunId,
-    revision: 2,
-    state: {
-      schema: "squad-run/v1",
-      squadRunId,
-      stateDispatchId: "dispatch_00000000000000000000c3d4",
-      squadId: "core-squad",
-      taskId: "task-squad",
-      runtimeInstanceId: "instance-squad",
-      cwd: rootDir,
-      mission: "legacy witness",
-      model: null,
-      effort: null,
-      leaderAgentId: "terra",
-      roster: "terra -> sol",
-      workers: ["sol"],
-      leaderTurnBudget: 8,
-      binding: { actor: { principal: { personId: "person-squad" }, executor: null }, source: "local" },
-      leaderTurns: [
-        {
-          turnId: "leader-1",
-          trigger: { kind: "initial" },
-          dispatchId: "dispatch_00000000000000000000c3d4",
-          runtimeSessionId: "runtime-legacy-leader",
-          decision: { kind: "converged" },
-        },
-      ],
-      leaderProviderSessionId: null,
-      currentLeaderRuntimeSessionId: null,
-      workerAttempts: [
-        {
-          attemptId: "worker-1",
-          workerId: "sol",
-          dispatchId: null,
-          runtimeSessionId: null,
-          rejection: null,
-        },
-      ],
-      observedWorkerRuntimeSessionIds: [],
-      workerWaits: [],
-      pendingLeaderTriggers: [],
-      phase: "converged",
-      revision: 2,
-      error: null,
-    },
-  });
-}
-
 /** leader 派工的归档结算行:outcome/resultRef 是 receipt 原文的既有时实来源。 */
 function leaderArchive(): Record<string, unknown> {
   return {
@@ -283,20 +223,6 @@ test("a pruned or missing receipt blob reads as null instead of failing the deta
     const squad = coordinator(rootDir, { receiptBlob: null });
     await squad.observeOutcome(leaderOutcome("runtime-leader"));
     const detail = squad.read("squad_0123456789abcdef01234567");
-    assert.equal(detail.run.leaderTurns[0]?.resultText, null);
-    assert.deepEqual(validateSquadRunRead(detail), []);
-  } finally {
-    rmSync(rootDir, { recursive: true, force: true });
-  }
-});
-
-test("a legacy attempt without turn linkage stays null instead of guessing a parent", () => {
-  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-squad-detail-"));
-  try {
-    seedLegacySquadRun(rootDir, "squad_0123456789abcdef99887766");
-    const squad = coordinator(rootDir);
-    const detail = squad.read("squad_0123456789abcdef99887766");
-    assert.equal(detail.run.workerAttempts[0]?.leaderTurnId, null);
     assert.equal(detail.run.leaderTurns[0]?.resultText, null);
     assert.deepEqual(validateSquadRunRead(detail), []);
   } finally {

--- a/packages/daemon/test/squad-run-reads.contract.test.ts
+++ b/packages/daemon/test/squad-run-reads.contract.test.ts
@@ -110,7 +110,7 @@ const detail = {
       {
         attemptId: "worker-2",
         workerId: "sol",
-        leaderTurnId: null,
+        leaderTurnId: "leader-1",
         dispatchId: null,
         runtimeSessionId: null,
         rejection: "Runtime dispatch was rejected.",
@@ -202,7 +202,7 @@ test("squad run read validator locks the orchestration-flow wire shape", () => {
     }),
     [],
   );
-  // 扇出树的父子边与 receipt 原文是锁死的 wire 字段:缺字段或错类型都不得过。
+  // 扇出树的父子边与 receipt 原文是锁死的 wire 字段:缺字段、null 或错类型都不得过。
   assert.notDeepEqual(
     validateSquadRunRead({
       ...detail,
@@ -221,10 +221,7 @@ test("squad run read validator locks the orchestration-flow wire shape", () => {
       ...detail,
       run: {
         ...detail.run,
-        workerAttempts: detail.run.workerAttempts.map((attempt: { readonly leaderTurnId: string | null }) => {
-          const { leaderTurnId, ...rest } = attempt;
-          return leaderTurnId === null ? rest : { ...rest, leaderTurnId: 7 };
-        }),
+        workerAttempts: detail.run.workerAttempts.map((attempt: object) => ({ ...attempt, leaderTurnId: null })),
       },
     }),
     [],

--- a/packages/gui/src/renderer/components/sessions/SquadRunDetail.tsx
+++ b/packages/gui/src/renderer/components/sessions/SquadRunDetail.tsx
@@ -21,7 +21,7 @@ import { LiveDot } from "../runtime/parts.tsx";
  * 该轮派发的 worker attempt 挂在轮次下(attempt.leaderTurnId 是父子边);轮次行内
  * 可展开该轮 receipt 原文(leader 的原始输出——「为何收敛/为何失败」的第一证据);
  * 轮次/尝试行都直达 session/<id>,任务出口直达 task 详情——与单会话段共用同一组
- * 可寻址导航。早于 leaderTurnId 字段的存量 run,其 attempt 归入尾部未关联组。
+ * 可寻址导航。
  */
 export function SquadRunDetail({
   detail,
@@ -102,7 +102,6 @@ export function SquadRunDetail({
           ))
         )}
       </section>
-      <UnlinkedAttempts attempts={run.workerAttempts} onSelectEntity={onSelectEntity} />
     </div>
   );
 }
@@ -162,28 +161,6 @@ function TurnSection({
           ))}
         </div>
       )}
-    </section>
-  );
-}
-
-/** 存量 run(早于 leaderTurnId 字段)的 attempt 无父子边:整组呈现,不猜轮次。 */
-function UnlinkedAttempts({
-  attempts,
-  onSelectEntity,
-}: {
-  readonly attempts: readonly SquadRunWorkerAttemptDto[];
-  readonly onSelectEntity: (ref: string) => void;
-}) {
-  const unlinked = attempts.filter((attempt) => attempt.leaderTurnId === null);
-  if (unlinked.length === 0) return null;
-  return (
-    <section data-testid="squad-run-unlinked">
-      <h3 className="mb-1.5 font-mono text-[10px] uppercase tracking-[0.07em] text-text-faint">
-        {t("agentRuntime.squadRunUnlinkedSection", { count: unlinked.length })}
-      </h3>
-      {unlinked.map((attempt) => (
-        <AttemptRow key={attempt.attemptId} attempt={attempt} onSelectEntity={onSelectEntity} />
-      ))}
     </section>
   );
 }

--- a/packages/gui/src/renderer/i18n/locales/en-US/agentRuntime.json
+++ b/packages/gui/src/renderer/i18n/locales/en-US/agentRuntime.json
@@ -352,7 +352,6 @@
   "agentRuntime.squadRunsEmptyWindow": "No squad runs in this range ({range}). Widen the range or clear the search.",
   "agentRuntime.squadRunSelectEmpty": "Select a squad run to see its leader-to-worker fan-out tree.",
   "agentRuntime.squadRunLeaderTurnsSection": "Leader turns ({count})",
-  "agentRuntime.squadRunUnlinkedSection": "Worker attempts without turn linkage ({count})",
   "agentRuntime.squadRunNoTurns": "No leader turns recorded yet.",
   "agentRuntime.squadRunReceipt": "leader receipt (raw)",
   "agentRuntime.squadRunNoReceipt": "no receipt yet",

--- a/packages/gui/src/renderer/i18n/locales/zh-CN/agentRuntime.json
+++ b/packages/gui/src/renderer/i18n/locales/zh-CN/agentRuntime.json
@@ -352,7 +352,6 @@
   "agentRuntime.squadRunsEmptyWindow": "该时间窗({range})内没有 squad run。放宽范围或清空检索。",
   "agentRuntime.squadRunSelectEmpty": "选中一个编排单元,查看 leader→worker 扇出树。",
   "agentRuntime.squadRunLeaderTurnsSection": "Leader 轮次({count})",
-  "agentRuntime.squadRunUnlinkedSection": "未关联轮次的 worker 尝试({count})",
   "agentRuntime.squadRunNoTurns": "尚无 leader 轮次记录。",
   "agentRuntime.squadRunReceipt": "leader receipt 原文",
   "agentRuntime.squadRunNoReceipt": "尚无 receipt 原文",

--- a/packages/gui/test/agent-runtime-sessions.vitest.ts
+++ b/packages/gui/test/agent-runtime-sessions.vitest.ts
@@ -524,7 +524,7 @@ const squadRunDetail = {
       {
         attemptId: "worker-2",
         workerId: "sol",
-        leaderTurnId: null,
+        leaderTurnId: "leader-1",
         dispatchId: null,
         runtimeSessionId: null,
         rejection: "Runtime dispatch was rejected.",
@@ -637,30 +637,16 @@ describe("sessions page: squad run detail", () => {
     expect(wait).toContain(reason);
   });
 
-  it("keeps attempts without turn linkage in their own group with rejections visible", () => {
+  it("keeps rejected attempts under their leader turn with the failure visible", () => {
     const markup = detailView();
-    expect(markup).toContain("Worker attempts without turn linkage (1)");
-    expect(markup).toMatch(/data-testid="squad-run-unlinked"/u);
     expect(markup).toContain("worker-2");
     expect(markup).toContain("sol");
     expect(markup).toContain("rejected: Runtime dispatch was rejected.");
     expect(markup).toContain("no dispatch");
     expect(markup).toMatch(/data-testid="squad-run-attempt-worker-2"/u);
-    // 全关联时不再渲染未关联组。
-    const linked = detailView({
-      detail: {
-        ...squadRunDetail,
-        run: {
-          ...squadRunDetail.run,
-          workerAttempts: squadRunDetail.run.workerAttempts.map((attempt) => ({
-            ...attempt,
-            leaderTurnId: "leader-1",
-          })),
-        },
-      },
-    });
-    expect(linked).not.toContain("Worker attempts without turn linkage");
-    expect(linked).not.toMatch(/data-testid="squad-run-unlinked"/u);
+    expect(markup.indexOf('data-testid="squad-run-attempt-worker-2"')).toBeLessThan(
+      markup.indexOf('data-testid="squad-run-turn-leader-2"'),
+    );
   });
 
   it("surfaces the run error line and read failures without inventing flow", () => {

--- a/packages/gui/test/service-bridge.test.ts
+++ b/packages/gui/test/service-bridge.test.ts
@@ -283,13 +283,14 @@ test("GUI client reaches every shipped read through a real resident daemon", asy
       [{ turnId: "leader-1", trigger: { kind: "initial" }, decision: { kind: "converged" } }],
     );
     assert.deepEqual(
-      squadRun.run.workerAttempts.map(({ attemptId, workerId, status, startedAt }) => ({
+      squadRun.run.workerAttempts.map(({ attemptId, workerId, leaderTurnId, status, startedAt }) => ({
         attemptId,
         workerId,
+        leaderTurnId,
         status,
         startedAt,
       })),
-      [{ attemptId: "worker-1", workerId: "terra", status: null, startedAt: null }],
+      [{ attemptId: "worker-1", workerId: "terra", leaderTurnId: "leader-1", status: null, startedAt: null }],
     );
     assert.equal(typeof squadRun.run.leaderTurns[0]?.startedAt, "string");
     const squadRunList = parseDaemonGuiReadResult("repo.squad.runs.list", results.get("repo.squad.runs.list"));
@@ -574,6 +575,7 @@ function seedSquadRunState(rootDir: string, repoId: string): string {
         {
           attemptId: "worker-1",
           workerId: "terra",
+          leaderTurnId: "leader-1",
           dispatchId: workerDispatchId,
           runtimeSessionId: "runtime-squad-worker",
           rejection: null,


### PR DESCRIPTION
# English
## Summary
After #1917 the squad `UnlinkedAttempts` surface became unreachable (no producer path can populate it). This removes the dead read/contract/UI branch and its now-vacuous test, per anti-entropy review #8.
## What Changed
Remove unreachable `UnlinkedAttempts` handling in `squad-coordinator.ts`, `squad-leader-decision.ts`, `squad-run-contract.ts`, `SquadRunDetail.tsx`; drop the dead `squad-run-detail-read` test and trim its contract test.
## Machine-Readable Declarations
Production-Delta: +7/-30
## Task And Scope
Authority: task_2a154a1fa963543fb4e563372e (anti-entropy review #8; review of #1917).
## Verification
CEO verified: the removed branch had no producer after #1917; targeted squad-run read/contract tests pass without it. Net -23 production lines.
## Review Evidence
CEO semantic acceptance: dead-surface removal, no behavior change on reachable paths; scope limited to squad-run read + its detail UI/tests.
## Residual Risk
None; removes unreachable code. If a future feature re-introduces unlinked attempts it is re-added in that scope.
# 中文
## 概要
#1917 之后 squad `UnlinkedAttempts` 面变得不可达(无生产者路径能填充它)。按反熵审查 #8 删除该死读/契约/UI 分支与已空洞的测试。
## 改动内容
删 `squad-coordinator.ts`/`squad-leader-decision.ts`/`squad-run-contract.ts`/`SquadRunDetail.tsx` 里不可达的 UnlinkedAttempts 处理;删死 `squad-run-detail-read` 测试并精简其契约测试。
## 机读声明说明
Production-Delta: +7/-30;删不可达代码,可达路径行为不变。
