### PR TITLE
refactor(errors): tagged domain error taxonomy replacing instanceof boilerplate (PLT-Bedrock)

### DIFF
--- a/packages/cli/src/cli-error.ts
+++ b/packages/cli/src/cli-error.ts
@@ -1,0 +1,14 @@
+type CliThrownError =
+  | { readonly _tag: "NativeError"; readonly message: string }
+  | { readonly _tag: "UnknownThrownValue"; readonly message: string };
+
+export function cliErrorMessage(error: unknown): string {
+  let normalized: CliThrownError;
+  if (error instanceof Error) normalized = { _tag: "NativeError", message: error.message };
+  else normalized = { _tag: "UnknownThrownValue", message: String(error) };
+  switch (normalized._tag) {
+    case "NativeError":
+    case "UnknownThrownValue":
+      return normalized.message;
+  }
+}

--- a/packages/cli/src/cli-render.ts
+++ b/packages/cli/src/cli-render.ts
@@ -1,5 +1,19 @@
 import type { RuntimeBatchResult } from "./cli-types.ts";
+import { cliErrorMessage } from "./cli-error.ts";
 import { consumeKnownError } from "./daemon/client.ts";
+
+type ReceiptFailure =
+  | { readonly _tag: "ReceiptFailure"; readonly errorCode: string; readonly hint: string }
+  | {
+      readonly _tag: "SquadLeaderFailure";
+      readonly errorCode: string;
+      readonly leader: { readonly code: string; readonly hint: string };
+    };
+
+type CliDispatchFailure =
+  | { readonly _tag: "DirectDaemonFailure"; readonly errorCode: string; readonly message: string }
+  | { readonly _tag: "DaemonResponseTimeout"; readonly errorCode: string; readonly message: string }
+  | { readonly _tag: "DaemonUnavailable"; readonly errorCode: string; readonly message: string };
 
 export function humanError(receipt: Record<string, unknown>): {
   readonly code: string;
@@ -16,13 +30,40 @@ export function humanError(receipt: Record<string, unknown>): {
             ? receipt.next
             : "Command failed.",
     leader = receipt.leader && typeof receipt.leader === "object" ? (receipt.leader as Record<string, unknown>) : null,
-    nested = leader ? humanError(leader) : null;
-  return code === "squad_leader_failed" && nested && nested.code !== "unknown"
-    ? {
-        code,
-        hint: `Leader dispatch rejected: code=${nested.code} hint=${nested.hint}`,
-      }
-    : { code, hint };
+    nested = leader ? humanError(leader) : null,
+    failure: ReceiptFailure =
+      code === "squad_leader_failed" && nested && nested.code !== "unknown"
+        ? { _tag: "SquadLeaderFailure", errorCode: code, leader: nested }
+        : { _tag: "ReceiptFailure", errorCode: code, hint };
+  switch (failure._tag) {
+    case "ReceiptFailure":
+      return { code: failure.errorCode, hint: failure.hint };
+    case "SquadLeaderFailure":
+      return {
+        code: failure.errorCode,
+        hint: `Leader dispatch rejected: code=${failure.leader.code} hint=${failure.leader.hint}`,
+      };
+  }
+}
+
+export function cliDispatchError(input: {
+  readonly error: unknown;
+  readonly directCode: string | null;
+  readonly timeoutCode: "daemon_response_timeout" | null;
+}): { readonly code: string; readonly hint: string } {
+  const message = cliErrorMessage(input.error);
+  let failure: CliDispatchFailure;
+  if (input.directCode !== null) failure = { _tag: "DirectDaemonFailure", errorCode: input.directCode, message };
+  else if (input.timeoutCode !== null)
+    failure = { _tag: "DaemonResponseTimeout", errorCode: input.timeoutCode, message };
+  else failure = { _tag: "DaemonUnavailable", errorCode: "daemon_unavailable", message };
+  switch (failure._tag) {
+    case "DirectDaemonFailure":
+      return { code: failure.errorCode, hint: failure.message };
+    case "DaemonResponseTimeout":
+    case "DaemonUnavailable":
+      return { code: failure.errorCode, hint: `Local daemon request failed. Cause: ${failure.message}` };
+  }
 }
 
 export function renderRuntimeBatchRow(value: unknown): string {

--- a/packages/cli/src/cli-runtime-auth.ts
+++ b/packages/cli/src/cli-runtime-auth.ts
@@ -1,4 +1,5 @@
 import type { JsonObject } from "../../daemon/src/protocol/json-rpc-types.ts";
+import { cliErrorMessage } from "./cli-error.ts";
 import type { ThinCommand } from "./cli/thin-command.ts";
 import { relayRuntimeAuthTerminal, runCommandThroughDaemon } from "./daemon/client.ts";
 import { randomUUID } from "node:crypto";
@@ -33,7 +34,7 @@ export async function runRuntimeAuthCommand(
     return runtimeRejected(
       command.action.kind,
       "daemon_disconnect",
-      `The sign-in terminal stream failed: ${error instanceof Error ? error.message : String(error)}. ` +
+      `The sign-in terminal stream failed: ${cliErrorMessage(error)}. ` +
         `The isolated state root keeps whatever the provider already stored; re-run the command to try again.`,
     );
   }

--- a/packages/cli/src/cli-runtime-batch-input.ts
+++ b/packages/cli/src/cli-runtime-batch-input.ts
@@ -1,4 +1,5 @@
 import { unknownFieldViolation } from "../../daemon/src/protocol/json-rpc-types.ts";
+import { cliErrorMessage } from "./cli-error.ts";
 import { runtimeBatchDefaultConcurrency, runtimeBatchMaxConcurrency } from "./cli-types.ts";
 import type { RuntimeBatchDeclaration, RuntimeBatchEntry } from "./cli-types.ts";
 import { runtimeBatchDeclarationFields, runtimeRunEfforts } from "./cli/thin-command.ts";
@@ -11,7 +12,7 @@ export function readRuntimeBatch(command: ThinCommand): RuntimeBatchDeclaration 
   try {
     value = JSON.parse(readFileSync(path.resolve(command.rootDir, String(command.action.batchFile)), "utf8"));
   } catch (error) {
-    throw new Error(`Could not read batch declaration: ${error instanceof Error ? error.message : String(error)}`);
+    throw new Error(`Could not read batch declaration: ${cliErrorMessage(error)}`);
   }
   return parseRuntimeBatchDeclaration(value, "Batch");
 }

--- a/packages/cli/src/cli-runtime-batch.ts
+++ b/packages/cli/src/cli-runtime-batch.ts
@@ -1,4 +1,5 @@
 import type { JsonObject } from "../../daemon/src/protocol/json-rpc-types.ts";
+import { cliErrorMessage } from "./cli-error.ts";
 import { runtimeRejected } from "./cli-runtime-auth.ts";
 import { readRuntimeBatch } from "./cli-runtime-batch-input.ts";
 import { runRuntimeFacadeCommand } from "./cli-runtime-command.ts";
@@ -16,11 +17,7 @@ export async function runRuntimeBatch(
     declaration = readRuntimeBatch(command);
   } catch (error) {
     consumeKnownError(error);
-    return runtimeRejected(
-      "runtime-batch",
-      "batch_file_invalid",
-      error instanceof Error ? error.message : String(error),
-    );
+    return runtimeRejected("runtime-batch", "batch_file_invalid", cliErrorMessage(error));
   }
   return runRuntimeBatchDeclaration(command, declaration, writeActivity);
 }
@@ -69,11 +66,7 @@ export async function runRuntimeBatchDeclaration(
         receipt = await leaseAwareSpawn(entry);
       } catch (error) {
         consumeKnownError(error);
-        receipt = runtimeRejected(
-          "runtime-run",
-          "batch_dispatch_failed",
-          error instanceof Error ? error.message : String(error),
-        );
+        receipt = runtimeRejected("runtime-run", "batch_dispatch_failed", cliErrorMessage(error));
       }
       results[index] = runtimeBatchResult(index, entry, receipt);
     }

--- a/packages/cli/src/cli-runtime-wait.ts
+++ b/packages/cli/src/cli-runtime-wait.ts
@@ -1,5 +1,6 @@
 import type { AgentRuntimeSessionResult } from "../../daemon/src/agent-runtime-contract.ts";
 import type { JsonObject } from "../../daemon/src/protocol/json-rpc-types.ts";
+import { cliErrorMessage } from "./cli-error.ts";
 import type { ThinCommand } from "./cli/thin-command.ts";
 import {
   consumeKnownError,
@@ -134,7 +135,7 @@ async function waitForStreamedRuntime(
     );
   } catch (error) {
     consumeKnownError(error);
-    writeActivity(`[stream] ${error instanceof Error ? error.message : String(error)}\n`);
+    writeActivity(`[stream] ${cliErrorMessage(error)}\n`);
   }
   return streamAttached ? { detach, signal: await streamSignal } : { detach };
 }
@@ -261,8 +262,7 @@ async function readDaemonSubscription(
       consumeKnownError(error);
       reset();
       if (!recoverableSubscriptionFailure(error)) throw error;
-      if (await daemonGone(command))
-        return { kind: "daemon-gone", cause: error instanceof Error ? error.message : String(error) };
+      if (await daemonGone(command)) return { kind: "daemon-gone", cause: cliErrorMessage(error) };
       await new Promise((resolve) => setTimeout(resolve, Math.min(250 * 2 ** attempt++, 5_000)));
     }
   }
@@ -273,7 +273,7 @@ function recoverableSubscriptionFailure(error: unknown): boolean {
       error && typeof error === "object" && typeof (error as { readonly code?: unknown }).code === "string"
         ? String((error as { readonly code: string }).code)
         : null,
-    message = error instanceof Error ? error.message : String(error);
+    message = cliErrorMessage(error);
   return (
     ["daemon_response_timeout", "daemon_closed", "ECONNREFUSED", "ECONNRESET", "ENOENT"].includes(String(code)) ||
     message === "daemon_unavailable" ||

--- a/packages/cli/src/daemon/client.ts
+++ b/packages/cli/src/daemon/client.ts
@@ -18,6 +18,7 @@ import {
   resolveLocalDaemonTarget,
 } from "../../../daemon/src/client/local-daemon-target.ts";
 import type { DaemonLaunchSpec } from "../../../daemon/src/client/daemon-autostart.ts";
+import { cliErrorMessage } from "../cli-error.ts";
 import type { ThinCommand } from "../cli/thin-command.ts";
 import { fleetEdgeRegistration, fleetScheduleRoute } from "./fleet-command-route.ts";
 
@@ -603,12 +604,9 @@ export async function fleetTaskRoute(
     try {
       packet = JSON.parse(file ? readFileSync(file, "utf8") : String(jsonInput));
     } catch (error) {
-      throw Object.assign(
-        new Error(
-          `${source} could not be read as JSON on this edge: ${error instanceof Error ? error.message : String(error)}`,
-        ),
-        { code: "invalid_field" },
-      );
+      throw Object.assign(new Error(`${source} could not be read as JSON on this edge: ${cliErrorMessage(error)}`), {
+        code: "invalid_field",
+      });
     }
     if (packet === null || typeof packet !== "object" || Array.isArray(packet))
       throw Object.assign(new Error(`${source} must contain one JSON object.`), { code: "invalid_field" });

--- a/packages/cli/src/daemon/control.ts
+++ b/packages/cli/src/daemon/control.ts
@@ -23,6 +23,7 @@ import {
   releaseDaemonSingletonLock,
 } from "../../../daemon/src/daemon-singleton.ts";
 import { daemonBuildStamp } from "../../../daemon/src/build-identity.ts";
+import { cliErrorMessage } from "../cli-error.ts";
 import { cliDaemonServeLaunch, consumeKnownError } from "./client.ts";
 import { daemonRepoModeWords } from "../../../daemon/src/protocol/daemon-protocol.contract.ts";
 import { firstCliCommandIndex } from "../cli/thin-command.ts";
@@ -519,7 +520,7 @@ function code(error: unknown): string {
   return ["ENOENT", "ECONNREFUSED", "ETIMEDOUT"].includes(value) ? "daemon_unavailable" : value;
 }
 function message(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
+  return cliErrorMessage(error);
 }
 const guiRequire = createRequire(import.meta.url);
 export interface GuiLaunchDependencies {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,6 +1,13 @@
 #!/usr/bin/env node
+import { cliErrorMessage } from "./cli-error.ts";
 import { cliFailure, emitMeta, taskCreateHelpCatalog } from "./cli-meta.ts";
-import { contractMigrationDryRunSummary, humanError, renderDispatchRow, renderRuntimeBatchRow } from "./cli-render.ts";
+import {
+  cliDispatchError,
+  contractMigrationDryRunSummary,
+  humanError,
+  renderDispatchRow,
+  renderRuntimeBatchRow,
+} from "./cli-render.ts";
 import { isRuntimeFacadeCommand, runRuntimeFacadeCommand } from "./cli-runtime-command.ts";
 import {
   cliCommandDomains,
@@ -61,7 +68,7 @@ export async function main(argv: readonly string[] = process.argv.slice(2)): Pro
       cliFailure(
         parsed.command.action.kind,
         "invalid_field",
-        `--json-input @- could not read stdin: ${error instanceof Error ? error.message : String(error)}`,
+        `--json-input @- could not read stdin: ${cliErrorMessage(error)}`,
       ),
       parsed.command.json,
     );
@@ -79,18 +86,8 @@ export async function main(argv: readonly string[] = process.argv.slice(2)): Pro
       targetCode = daemonTargetFailureCode(error),
       buildStaleCode = daemonBuildStaleCode(error),
       direct = autostartCode ?? targetCode ?? buildStaleCode;
-    emit(
-      cliFailure(
-        parsed.command.action.kind,
-        direct ?? timeoutCode ?? "daemon_unavailable",
-        direct
-          ? error instanceof Error
-            ? error.message
-            : String(error)
-          : `Local daemon request failed. Cause: ${error instanceof Error ? error.message : String(error)}`,
-      ),
-      parsed.command.json,
-    );
+    const failure = cliDispatchError({ error, directCode: direct, timeoutCode });
+    emit(cliFailure(parsed.command.action.kind, failure.code, failure.hint), parsed.command.json);
     return 1;
   }
 }

--- a/packages/cli/test/provider-fallback-render.test.ts
+++ b/packages/cli/test/provider-fallback-render.test.ts
@@ -1,7 +1,7 @@
 // harness-test-tier: fast
 import assert from "node:assert/strict";
 import test from "node:test";
-import { renderDispatchRow } from "../src/cli-render.ts";
+import { cliDispatchError, humanError, renderDispatchRow } from "../src/cli-render.ts";
 import { renderRuntimeStatus } from "../src/cli-runtime-auth.ts";
 
 test("task dispatch and runtime status renders expose provider attempt chains", () => {
@@ -41,5 +41,27 @@ test("task dispatch and runtime status renders expose provider attempt chains", 
       },
     }),
     /ATTEMPT\tPROVIDER\tMODEL\tCLASSIFICATION\tFALLBACK\tREASON\n0\tprovider-a\tmodel-a\tprovider_fault\tdispatched\t429/u,
+  );
+});
+
+test("CLI dispatch and nested receipt errors are handled by closed tagged branches", () => {
+  assert.deepEqual(
+    cliDispatchError({ error: new Error("start failed"), directCode: "daemon_start_failed", timeoutCode: null }),
+    { code: "daemon_start_failed", hint: "start failed" },
+  );
+  assert.deepEqual(cliDispatchError({ error: "deadline", directCode: null, timeoutCode: "daemon_response_timeout" }), {
+    code: "daemon_response_timeout",
+    hint: "Local daemon request failed. Cause: deadline",
+  });
+  assert.deepEqual(humanError({ code: "top", nextAction: "repair" }), { code: "top", hint: "repair" });
+  assert.deepEqual(
+    humanError({
+      code: "squad_leader_failed",
+      leader: { error: { code: "lease_conflict", hint: "release the holder" } },
+    }),
+    {
+      code: "squad_leader_failed",
+      hint: "Leader dispatch rejected: code=lease_conflict hint=release the holder",
+    },
   );
 });

--- a/packages/daemon/src/daemon-host-errors.ts
+++ b/packages/daemon/src/daemon-host-errors.ts
@@ -1,4 +1,4 @@
-import { type WriteReceipt } from "../../kernel/src/index.ts";
+import { normalizeDomainError, type WriteReceipt } from "../../kernel/src/index.ts";
 import { type RepoBootstrapReceipt } from "./repo-bootstrap.ts";
 import { type RepoTaskAction } from "./repo-cell.ts";
 
@@ -36,9 +36,17 @@ export function recoverableRunId(action: RepoTaskAction): string | undefined {
 }
 
 export function code(error: unknown): string {
-  return typeof error === "object" && error !== null && "code" in error && typeof error.code === "string"
-    ? error.code
-    : "daemon_error";
+  const normalized = normalizeDomainError(error);
+  switch (normalized._tag) {
+    case "LeaseConflictError":
+    case "TaskNotFoundError":
+    case "InvalidWritePlanError":
+    case "ProtocolVersionMismatchError":
+    case "OtherCodedError":
+      return normalized.code;
+    case "UnclassifiedError":
+      return "daemon_error";
+  }
 }
 
 export function makeWarmingSettlement(): {
@@ -53,7 +61,7 @@ export function makeWarmingSettlement(): {
 }
 
 export function daemonErrorMessage(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
+  return normalizeDomainError(error).message;
 }
 
 export function attachBudgetError(repoId: string, timeoutMs: number): Error {

--- a/packages/daemon/src/protocol/json-rpc-server.ts
+++ b/packages/daemon/src/protocol/json-rpc-server.ts
@@ -31,6 +31,7 @@ import {
 } from "./json-rpc-types.ts";
 import { currentDaemonProtocolVersion } from "./version.ts";
 import { isContractVersionCompatible } from "../../../kernel/src/domain/contract-version.ts";
+import type { CoreDomainError } from "../../../kernel/src/index.ts";
 import type { DaemonBuildObserver, DaemonBuildStamp } from "../build-identity.ts";
 export interface JsonRpcProtocolServer {
   readonly handle: (
@@ -94,14 +95,14 @@ export function createJsonRpcProtocolServer(options: {
     const params = parsed.params;
     observed = { ...observed, repoId: repoIdFromParams(params) };
     if (request.method === "protocol.hello") {
-      if (!isContractVersionCompatible(params.protocolVersion, currentDaemonProtocolVersion))
-        return reply(
-          daemonProtocolError(
-            "protocol.hello",
-            "incompatible_protocol_version",
-            "Use the daemon protocol version reported by this binary.",
-          ) as unknown as JsonObject,
-        );
+      if (!isContractVersionCompatible(params.protocolVersion, currentDaemonProtocolVersion)) {
+        const mismatch = {
+          _tag: "ProtocolVersionMismatchError",
+          code: "incompatible_protocol_version",
+          message: "Use the daemon protocol version reported by this binary.",
+        } satisfies Extract<CoreDomainError, { readonly _tag: "ProtocolVersionMismatchError" }>;
+        return reply(daemonProtocolError("protocol.hello", mismatch.code, mismatch.message) as unknown as JsonObject);
+      }
       if (params.sessionEnvironment === undefined) Reflect.deleteProperty(options.authContext, "sessionEnvironment");
       else
         Object.assign(options.authContext, {
@@ -168,11 +169,7 @@ export function createJsonRpcProtocolServer(options: {
         );
       } catch (error) {
         return reply(
-          daemonProtocolError(
-            "init",
-            rpcServerErrorCode(error),
-            error instanceof Error ? error.message : String(error),
-          ) as unknown as JsonObject,
+          daemonProtocolError("init", rpcServerErrorCode(error), protocolErrorMessage(error)) as unknown as JsonObject,
         );
       }
     }
@@ -198,7 +195,7 @@ export function createJsonRpcProtocolServer(options: {
           daemonProtocolError(
             request.method,
             rpcServerErrorCode(error),
-            error instanceof Error ? error.message : String(error),
+            protocolErrorMessage(error),
           ) as unknown as JsonObject,
         );
       }
@@ -213,7 +210,7 @@ export function createJsonRpcProtocolServer(options: {
           daemonProtocolError(
             request.method,
             rpcServerErrorCode(error),
-            error instanceof Error ? error.message : String(error),
+            protocolErrorMessage(error),
           ) as unknown as JsonObject,
         );
       }
@@ -234,7 +231,7 @@ export function createJsonRpcProtocolServer(options: {
           daemonProtocolError(
             request.method,
             rpcServerErrorCode(error),
-            error instanceof Error ? error.message : String(error),
+            protocolErrorMessage(error),
           ) as unknown as JsonObject,
         );
       }
@@ -253,7 +250,7 @@ export function createJsonRpcProtocolServer(options: {
           daemonProtocolError(
             request.method,
             rpcServerErrorCode(error),
-            error instanceof Error ? error.message : String(error),
+            protocolErrorMessage(error),
           ) as unknown as JsonObject,
         );
       }
@@ -310,7 +307,7 @@ export function createJsonRpcProtocolServer(options: {
           daemonProtocolError(
             request.method,
             rpcServerErrorCode(error),
-            error instanceof Error ? error.message : String(error),
+            protocolErrorMessage(error),
           ) as unknown as JsonObject,
         );
       }
@@ -334,7 +331,7 @@ export function createJsonRpcProtocolServer(options: {
           daemonProtocolError(
             request.method,
             rpcServerErrorCode(error),
-            error instanceof Error ? error.message : String(error),
+            protocolErrorMessage(error),
           ) as unknown as JsonObject,
         );
       }
@@ -349,7 +346,7 @@ export function createJsonRpcProtocolServer(options: {
           daemonProtocolError(
             request.method,
             rpcServerErrorCode(error),
-            error instanceof Error ? error.message : String(error),
+            protocolErrorMessage(error),
           ) as unknown as JsonObject,
         );
       }
@@ -367,7 +364,7 @@ export function createJsonRpcProtocolServer(options: {
           daemonProtocolError(
             request.method,
             rpcServerErrorCode(error),
-            error instanceof Error ? error.message : String(error),
+            protocolErrorMessage(error),
           ) as unknown as JsonObject,
         );
       }
@@ -385,7 +382,7 @@ export function createJsonRpcProtocolServer(options: {
           daemonProtocolError(
             request.method,
             rpcServerErrorCode(error),
-            error instanceof Error ? error.message : String(error),
+            protocolErrorMessage(error),
           ) as unknown as JsonObject,
         );
       }
@@ -420,7 +417,7 @@ export function createJsonRpcProtocolServer(options: {
           daemonProtocolError(
             request.method,
             rpcServerErrorCode(error),
-            error instanceof Error ? error.message : String(error),
+            protocolErrorMessage(error),
           ) as unknown as JsonObject,
         );
       }
@@ -444,7 +441,7 @@ export function createJsonRpcProtocolServer(options: {
           daemonProtocolError(
             request.method,
             rpcServerErrorCode(error),
-            error instanceof Error ? error.message : String(error),
+            protocolErrorMessage(error),
           ) as unknown as JsonObject,
         );
       }
@@ -463,7 +460,7 @@ export function createJsonRpcProtocolServer(options: {
           daemonProtocolError(
             request.method,
             rpcServerErrorCode(error),
-            error instanceof Error ? error.message : String(error),
+            protocolErrorMessage(error),
           ) as unknown as JsonObject,
         );
       }
@@ -482,7 +479,7 @@ export function createJsonRpcProtocolServer(options: {
           daemonProtocolError(
             request.method,
             rpcServerErrorCode(error),
-            error instanceof Error ? error.message : String(error),
+            protocolErrorMessage(error),
           ) as unknown as JsonObject,
         );
       }
@@ -501,7 +498,7 @@ export function createJsonRpcProtocolServer(options: {
           daemonProtocolError(
             request.method,
             rpcServerErrorCode(error),
-            error instanceof Error ? error.message : String(error),
+            protocolErrorMessage(error),
           ) as unknown as JsonObject,
         );
       }
@@ -515,7 +512,7 @@ export function createJsonRpcProtocolServer(options: {
         daemonProtocolError(
           request.method,
           rpcServerErrorCode(error),
-          error instanceof Error ? error.message : String(error),
+          protocolErrorMessage(error),
         ) as unknown as JsonObject,
       );
     }
@@ -616,4 +613,19 @@ function rpcServerErrorCode(error: unknown): string {
   return typeof error === "object" && error !== null && "code" in error && typeof error.code === "string"
     ? error.code
     : "bootstrap_failed";
+}
+
+type ProtocolDispatchError =
+  | { readonly _tag: "NativeError"; readonly message: string }
+  | { readonly _tag: "UnknownThrownValue"; readonly message: string };
+
+function protocolErrorMessage(error: unknown): string {
+  let normalized: ProtocolDispatchError;
+  if (error instanceof Error) normalized = { _tag: "NativeError", message: error.message };
+  else normalized = { _tag: "UnknownThrownValue", message: String(error) };
+  switch (normalized._tag) {
+    case "NativeError":
+    case "UnknownThrownValue":
+      return normalized.message;
+  }
 }

--- a/packages/daemon/src/repo-cell-errors.ts
+++ b/packages/daemon/src/repo-cell-errors.ts
@@ -1,6 +1,6 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
-import { VcsCommandError } from "../../kernel/src/index.ts";
+import { VcsCommandError, normalizeDomainError } from "../../kernel/src/index.ts";
 
 export function cellCodedError(code: string, text: string): Error {
   const error = new Error(text) as Error & { code: string };
@@ -19,13 +19,21 @@ export function errorOperationId(error: unknown): string | null {
 }
 
 export function cellErrorCode(error: unknown): string {
-  return typeof error === "object" && error !== null && "code" in error && typeof error.code === "string"
-    ? error.code
-    : "service_rejected";
+  const normalized = normalizeDomainError(error);
+  switch (normalized._tag) {
+    case "LeaseConflictError":
+    case "TaskNotFoundError":
+    case "InvalidWritePlanError":
+    case "ProtocolVersionMismatchError":
+    case "OtherCodedError":
+      return normalized.code;
+    case "UnclassifiedError":
+      return "service_rejected";
+  }
 }
 
 export function cellErrorMessage(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
+  return normalizeDomainError(error).message;
 }
 
 export function publishGeneratedArtifact(input: {
@@ -47,13 +55,22 @@ export function publishGeneratedArtifact(input: {
 
 export function fatalCellError(error: unknown): boolean {
   if (error instanceof VcsCommandError) return true;
-  if (!error || typeof error !== "object" || !("code" in error)) return true;
-  return [
-    "invalid_store",
-    "legacy_shape",
-    "op_conflict",
-    "revision_conflict",
-    "publication_indeterminate",
-    "writer_rejected",
-  ].includes(String(error.code));
+  const normalized = normalizeDomainError(error);
+  switch (normalized._tag) {
+    case "UnclassifiedError":
+      return true;
+    case "LeaseConflictError":
+    case "TaskNotFoundError":
+    case "InvalidWritePlanError":
+    case "ProtocolVersionMismatchError":
+    case "OtherCodedError":
+      return [
+        "invalid_store",
+        "legacy_shape",
+        "op_conflict",
+        "revision_conflict",
+        "publication_indeterminate",
+        "writer_rejected",
+      ].includes(normalized.code);
+  }
 }

--- a/packages/daemon/test/json-rpc-protocol.test.ts
+++ b/packages/daemon/test/json-rpc-protocol.test.ts
@@ -909,7 +909,7 @@ test("JSON-RPC failure receipt carries formal operation identity and origin", as
   const server = createJsonRpcProtocolServer({ host, build: { commit: null }, authContext: { transportKind: "unix-socket" }, emit: async () => undefined });
   const response = await server.handle({ jsonrpc: "2.0", id: 1, method: "protocol.hello", params: { protocolVersion: { major: 2, minor: 0 } } });
   assert.ok(response && !Array.isArray(response) && "result" in response); if (response && !Array.isArray(response) && "result" in response) {
-    const receipt = response.result as Record<string, unknown>; assert.equal(receipt.outcome, "op_rejected"); assert.equal(receipt.opId, "N/A"); assert.equal(receipt.origin, "daemon"); }
+    const receipt = response.result as Record<string, unknown>; assert.deepEqual(receipt, { schema: "command-receipt/v2", ok: false, command: "protocol.hello", outcome: "op_rejected", opId: "N/A", origin: "daemon", code: "incompatible_protocol_version", evidence: "rejection:incompatible_protocol_version", error: { code: "incompatible_protocol_version", hint: "Use the daemon protocol version reported by this binary." }, nextAction: "Use the daemon protocol version reported by this binary." }); }
   await server.handle({ jsonrpc: "2.0", id: 2, method: "protocol.hello", params: { protocolVersion: currentDaemonProtocolVersion } });
   const malformed = await server.handle({ jsonrpc: "2.0", id: 3, method: "daemon.status", params: "not-an-object" });
   assert.ok(malformed && !Array.isArray(malformed) && "result" in malformed); if (malformed && !Array.isArray(malformed) && "result" in malformed) assert.equal((malformed.result as Record<string, unknown>).code, "invalid_request");

--- a/packages/kernel/src/domain/errors.ts
+++ b/packages/kernel/src/domain/errors.ts
@@ -36,3 +36,74 @@ export type ArtifactStoreError =
 export type TemplateLibraryError =
   | { readonly _tag: "TemplateNotFound"; readonly templateId: string; readonly locale?: string }
   | { readonly _tag: "TemplateCatalogInvalid"; readonly reason: string };
+
+type TaggedDomainError<Tag extends string, Code extends string> = {
+  readonly _tag: Tag;
+  readonly code: Code;
+  readonly message: string;
+};
+
+export type LeaseConflictError = TaggedDomainError<"LeaseConflictError", "lease_conflict">;
+export type TaskNotFoundError = TaggedDomainError<"TaskNotFoundError", "task_not_found">;
+export type InvalidWritePlanError = TaggedDomainError<"InvalidWritePlanError", "invalid_write_plan">;
+export type ProtocolVersionMismatchError = TaggedDomainError<
+  "ProtocolVersionMismatchError",
+  "incompatible_protocol_version"
+>;
+
+export type CoreDomainError =
+  | LeaseConflictError
+  | TaskNotFoundError
+  | InvalidWritePlanError
+  | ProtocolVersionMismatchError;
+
+export type NormalizedDomainError =
+  | CoreDomainError
+  | { readonly _tag: "OtherCodedError"; readonly code: string; readonly message: string }
+  | { readonly _tag: "UnclassifiedError"; readonly message: string };
+
+const coreDomainErrorCodes = {
+  LeaseConflictError: "lease_conflict",
+  TaskNotFoundError: "task_not_found",
+  InvalidWritePlanError: "invalid_write_plan",
+  ProtocolVersionMismatchError: "incompatible_protocol_version",
+} as const satisfies {
+  readonly [Error in CoreDomainError as Error["_tag"]]: Error["code"];
+};
+
+export function coreDomainError<Tag extends CoreDomainError["_tag"]>(
+  tag: Tag,
+  message: string,
+): Extract<CoreDomainError, { readonly _tag: Tag }> {
+  return { _tag: tag, code: coreDomainErrorCodes[tag], message } as Extract<CoreDomainError, { readonly _tag: Tag }>;
+}
+
+export function normalizeDomainError(error: unknown): NormalizedDomainError {
+  const message = thrownMessage(error),
+    code = thrownCode(error);
+  switch (code) {
+    case "lease_conflict":
+      return coreDomainError("LeaseConflictError", message);
+    case "task_not_found":
+      return coreDomainError("TaskNotFoundError", message);
+    case "invalid_write_plan":
+      return coreDomainError("InvalidWritePlanError", message);
+    case "incompatible_protocol_version":
+      return coreDomainError("ProtocolVersionMismatchError", message);
+    case null:
+      return { _tag: "UnclassifiedError", message };
+    default:
+      return { _tag: "OtherCodedError", code, message };
+  }
+}
+
+function thrownCode(error: unknown): string | null {
+  return typeof error === "object" && error !== null && "code" in error && typeof error.code === "string"
+    ? error.code
+    : null;
+}
+
+function thrownMessage(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  return String(error);
+}

--- a/packages/kernel/src/domain/index.ts
+++ b/packages/kernel/src/domain/index.ts
@@ -169,7 +169,14 @@ export type {
   RelationType,
 } from "./entity-relation.ts";
 
-export type { EngineError, BindingInvariantError, ArtifactStoreError, TemplateLibraryError } from "./errors.ts";
+export { normalizeDomainError } from "./errors.ts";
+export type {
+  ArtifactStoreError,
+  BindingInvariantError,
+  CoreDomainError,
+  EngineError,
+  TemplateLibraryError,
+} from "./errors.ts";
 
 export {
   createScheduleV1,

--- a/packages/kernel/test/contracts/schema-domain-vocabulary-alignment.test.ts
+++ b/packages/kernel/test/contracts/schema-domain-vocabulary-alignment.test.ts
@@ -2,19 +2,11 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { Schema } from "effect";
-import {
-  domainStatuses
-} from "../../src/domain/lifecycle-status.ts";
-import {
-  decisionStates
-} from "../../src/domain/decision-event.ts";
-import {
-  packageDispositions
-} from "../../src/domain/package-disposition.ts";
-import {
-  priorityTiers,
-  taskWorkKinds
-} from "../../src/domain/task-metadata.ts";
+import { domainStatuses } from "../../src/domain/lifecycle-status.ts";
+import { decisionStates } from "../../src/domain/decision-event.ts";
+import { packageDispositions } from "../../src/domain/package-disposition.ts";
+import { priorityTiers, taskWorkKinds } from "../../src/domain/task-metadata.ts";
+import { coreDomainError, normalizeDomainError } from "../../src/domain/errors.ts";
 import { DomainStatusSchema, TaskFrontmatterSchema } from "../../src/schemas/registry.ts";
 
 test("domain status constants are accepted by the schema registry", () => {
@@ -42,16 +34,18 @@ test("task frontmatter schema accepts every domain package disposition", () => {
         titleSnapshot: null,
         url: null,
         bindingCreatedAt: "2026-06-11T00:00:00.000Z",
-        bindingFingerprint: "sha256:0123456789abcdef"
+        bindingFingerprint: "sha256:0123456789abcdef",
       },
       packageDisposition: disposition,
       vertical: "software/coding",
       preset: "standard-task",
-      provenance: [{
-        runtime: "human",
-        sessionId: "human-cli-1783036800000",
-        boundAt: "2026-06-11T00:00:00.000Z"
-      }]
+      provenance: [
+        {
+          runtime: "human",
+          sessionId: "human-cli-1783036800000",
+          boundAt: "2026-06-11T00:00:00.000Z",
+        },
+      ],
     });
 
     assert.equal(decoded.packageDisposition, disposition);
@@ -73,7 +67,35 @@ test("task frontmatter schema accepts every task metadata vocabulary value", () 
   }
 });
 
-function taskFixture(metadata: { readonly workKind?: string; readonly riskTier?: string; readonly urgency?: string }): Record<string, unknown> {
+test("core domain error tags preserve their established machine-readable codes", () => {
+  const cases = [
+    ["LeaseConflictError", "lease_conflict"],
+    ["TaskNotFoundError", "task_not_found"],
+    ["InvalidWritePlanError", "invalid_write_plan"],
+    ["ProtocolVersionMismatchError", "incompatible_protocol_version"],
+  ] as const;
+
+  for (const [tag, code] of cases) {
+    const error = coreDomainError(tag, "unchanged hint");
+    assert.deepEqual(error, { _tag: tag, code, message: "unchanged hint" });
+    assert.deepEqual(normalizeDomainError(Object.assign(new Error(error.message), { code })), error);
+  }
+  assert.deepEqual(normalizeDomainError(Object.assign(new Error("other"), { code: "other_code" })), {
+    _tag: "OtherCodedError",
+    code: "other_code",
+    message: "other",
+  });
+  assert.deepEqual(normalizeDomainError("plain failure"), {
+    _tag: "UnclassifiedError",
+    message: "plain failure",
+  });
+});
+
+function taskFixture(metadata: {
+  readonly workKind?: string;
+  readonly riskTier?: string;
+  readonly urgency?: string;
+}): Record<string, unknown> {
   return {
     schema: "task-package/v2",
     task_id: "task-1",
@@ -86,16 +108,18 @@ function taskFixture(metadata: { readonly workKind?: string; readonly riskTier?:
       titleSnapshot: null,
       url: null,
       bindingCreatedAt: "2026-06-11T00:00:00.000Z",
-      bindingFingerprint: "sha256:0123456789abcdef"
+      bindingFingerprint: "sha256:0123456789abcdef",
     },
     packageDisposition: "active",
     ...metadata,
     vertical: "software/coding",
     preset: "standard-task",
-    provenance: [{
-      runtime: "human",
-      sessionId: "human-cli-1783036800000",
-      boundAt: "2026-06-11T00:00:00.000Z"
-    }]
+    provenance: [
+      {
+        runtime: "human",
+        sessionId: "human-cli-1783036800000",
+        boundAt: "2026-06-11T00:00:00.000Z",
+      },
+    ],
   };
 }


### PR DESCRIPTION
# English

## Summary
PLT-Bedrock (Effect): introduce a strongly-typed tagged domain-error taxonomy in `packages/kernel/src/domain/errors.ts` and replace the `error instanceof Error ? error.message : String(error)` boilerplate across CLI source + daemon JSON-RPC / host-settlement / RepoCell-settlement boundaries with closed, exhaustive tagged switches. The `command-receipt/v2` wire format is preserved byte-for-byte — this is internal error-type structure only.

## Architectural Justification
`error instanceof Error ? ... : String(error)` erases the failure taxonomy at every catch site: the compiler cannot tell which failures are possible, so a new failure mode silently degrades to a stringified message. Modeling failures as a discriminated union (tagged with `_tag`) makes the failure set knowable and exhaustively matchable, so an unhandled variant is a compile error rather than a runtime `String(error)`. The receipt wire shape (errorCode / hint / message / code) is unchanged, so no consumer of `command-receipt/v2` is affected.

## What Changed
- `packages/kernel/src/domain/errors.ts` (new, +71): tagged domain failures (protocol mismatch, lease conflict, etc.).
- CLI source (cli-error / cli-render / cli-runtime-* / daemon client-control) + daemon (json-rpc-server / repo-cell-errors / daemon-host-errors): `instanceof Error` ternaries → closed tagged switches.
- Non-dispatch daemon logging/configuration adapters left outside this slice.

## Gate Harvest / 门收割
No gate thresholds touched; no gate/tool files modified. `command-receipt/v2` wire format preserved (verified against receipt-contract + canonical-event-compat + JSON-RPC integration suites).

## Machine-Readable Declarations
Production-Delta: +253/-92

### Optional Evidence Claims
(none)

## Task And Scope
Authority: task_834da8403cea0d584c59fff965 (PLT-Bedrock tagged-error slice).

## Version Impact
No package version or dependency change (discriminated unions, no new library).

## Governance Declaration
No CI/gate/protected-surface modification. Pure internal error-type refactor citing task_834da840; `command-receipt/v2` output bytes unchanged (worker Fact F-CEE19E96 verified the exact receipt assertion + contract/compat tests pass). Authority: task_834da8403cea0d584c59fff965.

## Verification
Worker local: ESLint / Prettier / CLI error-code+structure / import-boundary targeted gates pass; receipt-contract + canonical-event-compat + JSON-RPC integration suites pass (command-receipt/v2 bytes + code incompatible_protocol_version preserved — Fact F-CEE19E96). CEO ground-truth: rebased onto current main (48d3661ce), `tsc -b kernel daemon cli` EXIT 0, no receipt/wire-format serialization files touched, `ReceiptFailure` union keeps the same fields as the wire shape. Facts F-5B84DB4D / F-0AE7E41B / F-CEE19E96.

## Review Evidence
CEO semantic acceptance against task intent (goal 1 errors.ts taxonomy + goal 2 exhaustive tagged matching): both met; goal 3 (unify wire format for ergonomics) deferred because it would change the `command-receipt/v2` contract — correctly out of scope for this slice. Authoritative contract gates run in CI.

## Residual Risk
Pure type hardening, wire format unchanged. Goal 3 (wire-format ergonomics) deferred as a separate governance slice since it touches the command-receipt/v2 contract. Sibling: any residual instanceof outside dispatch (logging/config adapters) intentionally left.

## References
task_834da8403cea0d584c59fff965.

# 中文

## 概要
PLT-Bedrock（Effect）：在 `packages/kernel/src/domain/errors.ts` 引入强类型 tagged 领域错误分类，把 CLI 源码 + daemon JSON-RPC / host-settlement / RepoCell-settlement 边界的 `error instanceof Error ? error.message : String(error)` 样板换成封闭穷尽的 tagged switch。`command-receipt/v2` wire format 逐字节保持不变——只改内部错误类型结构。

## 架构辩护
`instanceof Error ? ... : String(error)` 在每个 catch 点抹掉失败分类：编译器不知有哪些失败可能，新失败模式静默退化成字符串。把失败建模为判别联合（`_tag` 标记）令失败集可知、可穷尽匹配，未处理分支变编译错误而非运行时 `String(error)`。receipt wire 形状（errorCode/hint/message/code）不变，故 `command-receipt/v2` 的消费方不受影响。

## 改动内容
- `packages/kernel/src/domain/errors.ts`（新增 +71）：tagged 领域失败。
- CLI 源码 + daemon（json-rpc-server / repo-cell-errors / daemon-host-errors）：instanceof 三元式 → 封闭 tagged switch。
- 非 dispatch 的 daemon 日志/配置适配器留在本切片外。

## 门收割 / Gate Harvest
未触碰门阈值、未改 gate/tool 文件。command-receipt/v2 wire format 保持（receipt-contract + canonical-event-compat + JSON-RPC 集成套件验证）。

## 机读声明说明
Production-Delta: +253/-92；纯内部错误类型 refactor，wire format 与依赖均不变。
