### PR TITLE
fix(runtime): claude kind 接受 --effort,三 kind 命令面统一

### DIFF
--- a/packages/cli/src/cli/thin-command-flags.ts
+++ b/packages/cli/src/cli/thin-command-flags.ts
@@ -146,8 +146,7 @@ export function rejected(code: string, nextAction: string, json: boolean): ThinP
     code,
     nextAction:
       nextAction === "This runtime kind does not accept options for another adapter."
-        ? "Claude runtime instances cannot accept Codex options: --effort, --wire-api, " +
-          "--requires-openai-auth, or --http-header."
+        ? "Claude runtime instances cannot accept Codex options: --wire-api, --requires-openai-auth, or --http-header."
         : nextAction,
     json,
   };

--- a/packages/cli/src/cli/thin-command-runtime-instance-create.ts
+++ b/packages/cli/src/cli/thin-command-runtime-instance-create.ts
@@ -55,8 +55,7 @@ function hasForeignAdapterOptions(
 ): boolean {
   return (
     (kindId === "claude" &&
-      (flags.one.has("--effort") ||
-        flags.one.has("--wire-api") ||
+      (flags.one.has("--wire-api") ||
         flags.booleans.has("--requires-openai-auth") ||
         headers !== undefined)) ||
     (kindId === "agy" &&
@@ -91,7 +90,12 @@ function runtimeInstanceKindConfig(
             ...(one.get("--effort") ? { effort: one.get("--effort") } : {}),
           },
         }
-      : { claude: { ...(baseUrl ? { baseUrl } : {}) } };
+      : {
+          claude: {
+            ...(one.get("--effort") ? { effort: one.get("--effort") } : {}),
+            ...(baseUrl ? { baseUrl } : {}),
+          },
+        };
 }
 
 function runtimeHttpHeaderFlags(

--- a/packages/daemon/src/agent-runtime-contract.ts
+++ b/packages/daemon/src/agent-runtime-contract.ts
@@ -35,7 +35,11 @@ export type AgentRuntimeInstanceDto = AgentRuntimeInstanceCommonDto &
   (
     | {
         readonly kindId: "claude";
-        readonly claude: { readonly baseUrl: string | null; readonly baseUrlConfigured: boolean };
+        readonly claude: {
+          readonly effort?: string | null;
+          readonly baseUrl: string | null;
+          readonly baseUrlConfigured: boolean;
+        };
       }
     | {
         readonly kindId: "codex";
@@ -335,7 +339,8 @@ function validInstance(value: unknown): value is AgentRuntimeInstanceDto {
 function validClaudeInstanceConfig(value: unknown): boolean {
   return (
     isAgentRuntimeContractRecord(value) &&
-    hasExactAgentRuntimeContractFields(value, ["baseUrl", "baseUrlConfigured"]) &&
+    hasAgentRuntimeContractFields(value, ["baseUrl", "baseUrlConfigured"], ["effort"]) &&
+    (value.effort === undefined || value.effort === null || typeof value.effort === "string") &&
     (value.baseUrl === null || typeof value.baseUrl === "string") &&
     typeof value.baseUrlConfigured === "boolean"
   );

--- a/packages/daemon/src/agent-runtime-instance-config.ts
+++ b/packages/daemon/src/agent-runtime-instance-config.ts
@@ -160,7 +160,9 @@ export function runtimeInstanceConfig(value: unknown): RuntimeInstanceConfig {
     return {
       ...common,
       kindId: "claude",
-      claude: claudeRuntimeConfig(flat ? { baseUrl: value.baseUrl } : value.claude),
+      claude: claudeRuntimeConfig(
+        flat ? { effort: value.reasoningEffort, baseUrl: value.baseUrl } : value.claude,
+      ),
     };
   if (value.kindId === "agy")
     return {
@@ -187,9 +189,14 @@ export function runtimeInstanceConfig(value: unknown): RuntimeInstanceConfig {
 
 export function claudeRuntimeConfig(value: unknown): ClaudeRuntimeInstanceConfig {
   if (value === undefined) return {};
-  if (!isRuntimeInstanceRecord(value) || Object.keys(value).some((key) => key !== "baseUrl"))
-    throw runtimeInstanceError("invalid_runtime_kind_config", "claude configuration accepts only baseUrl.");
-  return value.baseUrl === undefined ? {} : { baseUrl: secureRuntimeBaseUrl(value.baseUrl) };
+  if (!isRuntimeInstanceRecord(value) || Object.keys(value).some((key) => !["effort", "baseUrl"].includes(key)))
+    throw runtimeInstanceError("invalid_runtime_kind_config", "claude configuration accepts only effort and baseUrl.");
+  const effort = value.effort === undefined ? undefined : runtimeEffort(value.effort),
+    baseUrl = value.baseUrl === undefined ? undefined : secureRuntimeBaseUrl(value.baseUrl);
+  return {
+    ...(effort ? { effort } : {}),
+    ...(baseUrl ? { baseUrl } : {}),
+  };
 }
 
 export function codexRuntimeConfig(value: unknown): CodexRuntimeInstanceConfig {
@@ -306,14 +313,9 @@ export function selectRuntimeEffort(config: RuntimeInstanceConfig, requested?: s
       ? config.codex.reasoningEffort
       : config.kindId === "agy"
         ? config.agy.effort
-        : undefined);
+        : config.claude.effort);
   if (effort === undefined) return null;
   if (config.kindId === "agy") return agyEffort(effort);
-  if (config.kindId !== "codex")
-    throw runtimeInstanceError(
-      "invalid_runtime_effort",
-      "Reasoning effort overrides are supported only by Codex or agy instances.",
-    );
   return runtimeEffort(effort);
 }
 

--- a/packages/daemon/src/agent-runtime-instance-storage.ts
+++ b/packages/daemon/src/agent-runtime-instance-storage.ts
@@ -148,6 +148,7 @@ export function publicConfig(
       ...common,
       kindId: "claude",
       claude: {
+        effort: config.claude.effort ?? null,
         baseUrl: config.claude.baseUrl ?? null,
         baseUrlConfigured: config.claude.baseUrl !== undefined,
       },

--- a/packages/daemon/src/agent-runtime-instance-store.ts
+++ b/packages/daemon/src/agent-runtime-instance-store.ts
@@ -245,7 +245,7 @@ export function openRuntimeInstanceStore(input: {
         model,
         request.prompt,
         request.providerSessionId,
-        request.effort === undefined ? null : effort,
+        config.kindId === "claude" ? effort : request.effort === undefined ? null : effort,
         permissionMode,
       ),
       definition = definitionSnapshot(config, model, effort);
@@ -689,8 +689,9 @@ function runtimeInstanceBaseUrlConfig(
     return { codex: { ...rest, ...(next ? { baseUrl: next } : {}) } };
   }
   if (current.kindId === "claude") {
-    const next = baseUrl === undefined ? current.claude.baseUrl : baseUrl || undefined;
-    return { claude: next ? { baseUrl: next } : {} };
+    const { baseUrl: _dropped, ...rest } = current.claude,
+      next = baseUrl === undefined ? current.claude.baseUrl : baseUrl || undefined;
+    return { claude: { ...rest, ...(next ? { baseUrl: next } : {}) } };
   }
   return {};
 }

--- a/packages/daemon/src/agent-runtime-instance-types.ts
+++ b/packages/daemon/src/agent-runtime-instance-types.ts
@@ -25,6 +25,7 @@ export interface RuntimeInstanceCommon {
 }
 
 export interface ClaudeRuntimeInstanceConfig {
+  readonly effort?: string;
   readonly baseUrl?: string;
 }
 

--- a/packages/daemon/src/agent-runtime-launch-config.ts
+++ b/packages/daemon/src/agent-runtime-launch-config.ts
@@ -76,6 +76,8 @@ export function launchArgs(
       ...(permissionMode ? permissionLaunchArgs("claude", permissionMode) : []),
       "--model",
       model,
+      // Claude Code's lowest accepted value is `low`; it silently ignores `minimal`.
+      ...(effort ? ["--effort", effort === "minimal" ? "low" : effort] : []),
       ...(config.auth.mode === "api-key" ? ["--bare"] : []),
       ...(providerSessionId ? ["--resume", providerSessionId] : []),
     ];

--- a/packages/daemon/src/protocol/daemon-protocol-commands-agent.ts
+++ b/packages/daemon/src/protocol/daemon-protocol-commands-agent.ts
@@ -124,7 +124,8 @@ export const agentProtocolCommands = Object.freeze([
         false,
         {
           code: "invalid_runtime_effort",
-          nextAction: "Use minimal, low, medium, high, or xhigh with a Codex instance.",
+          nextAction:
+            "Use minimal, low, medium, high, or xhigh with Claude or Codex; agy supports low, medium, or high.",
         },
         {
           enum: ["minimal", "low", "medium", "high", "xhigh"],
@@ -312,7 +313,8 @@ export const agentProtocolCommands = Object.freeze([
         false,
         {
           code: "invalid_runtime_effort",
-          nextAction: "Use minimal, low, medium, high, or xhigh with a Codex instance.",
+          nextAction:
+            "Use minimal, low, medium, high, or xhigh with Claude or Codex; agy supports low, medium, or high.",
         },
         { enum: ["minimal", "low", "medium", "high", "xhigh"] },
       ),

--- a/packages/daemon/src/protocol/daemon-protocol-commands-runtime-config.ts
+++ b/packages/daemon/src/protocol/daemon-protocol-commands-runtime-config.ts
@@ -156,7 +156,7 @@ export const runtimeConfigProtocolCommands = Object.freeze([
       cliInput("--effort", "single", false, {
         code: "invalid_field",
         nextAction:
-          "Use a kind-supported reasoning effort: agy low, medium, high; Codex minimal, low, medium, high, xhigh.",
+          "Use a kind-supported reasoning effort: agy low, medium, high; Claude or Codex minimal, low, medium, high, xhigh.",
       }),
       cliInput("--base-url", "single", false, {
         code: "invalid_field",

--- a/packages/daemon/src/protocol/daemon-protocol-commands-runtime-config.ts
+++ b/packages/daemon/src/protocol/daemon-protocol-commands-runtime-config.ts
@@ -156,7 +156,8 @@ export const runtimeConfigProtocolCommands = Object.freeze([
       cliInput("--effort", "single", false, {
         code: "invalid_field",
         nextAction:
-          "Use a kind-supported reasoning effort: agy low, medium, high; Claude or Codex minimal, low, medium, high, xhigh.",
+          "Use a kind-supported reasoning effort: agy low, medium, high; " +
+          "Claude or Codex minimal, low, medium, high, xhigh.",
       }),
       cliInput("--base-url", "single", false, {
         code: "invalid_field",

--- a/packages/daemon/src/protocol/daemon-protocol-commands-runtime-fleet.ts
+++ b/packages/daemon/src/protocol/daemon-protocol-commands-runtime-fleet.ts
@@ -43,7 +43,8 @@ export const runtimeFleetProtocolCommands = Object.freeze([
         false,
         {
           code: "invalid_runtime_effort",
-          nextAction: "Use minimal, low, medium, high, or xhigh with a Codex instance.",
+          nextAction:
+            "Use minimal, low, medium, high, or xhigh with Claude or Codex; agy supports low, medium, or high.",
         },
         { enum: ["minimal", "low", "medium", "high", "xhigh"] },
       ),
@@ -415,7 +416,8 @@ export const scheduleProtocolCommands = Object.freeze([
         false,
         {
           code: "invalid_runtime_effort",
-          nextAction: "Use minimal, low, medium, high, or xhigh with a Codex instance.",
+          nextAction:
+            "Use minimal, low, medium, high, or xhigh with Claude or Codex; agy supports low, medium, or high.",
         },
         { enum: scheduleReasoningEfforts },
       ),
@@ -525,7 +527,8 @@ export const scheduleProtocolCommands = Object.freeze([
         false,
         {
           code: "invalid_runtime_effort",
-          nextAction: "Use minimal, low, medium, high, or xhigh with a Codex instance.",
+          nextAction:
+            "Use minimal, low, medium, high, or xhigh with Claude or Codex; agy supports low, medium, or high.",
         },
         { enum: scheduleReasoningEfforts },
       ),

--- a/packages/daemon/test/agent-runtime-instances.test.ts
+++ b/packages/daemon/test/agent-runtime-instances.test.ts
@@ -229,15 +229,16 @@ test("runtime instance CRUD is a closed defineCliCommand surface", async () => {
   assert.equal(daemonProtocolCommands.find((entry) => entry.id === "runtime-instance-update")?.inputs.some(({ name }) => name === "--installation"), true);
   const created = parseThinCommand(["runtime", "instance", "create", "--id", "codex-review", "--name", "Codex Review", "--kind", "codex", "--installation", observed.installationId, "--provider", "codex_local_access", "--model", "gpt-5.6-sol", "--model", "gpt-5.6-terra", "--default-model", "gpt-5.6-terra", "--permission-mode", "workspace-write", "--effort", "xhigh", "--base-url", "http://127.0.0.1:1/v1", "--wire-api", "responses", "--requires-openai-auth", "--http-header", "X-Harness-Probe=present", "--auth", "api-key", "--credential-ref", "keychain:harness/codex-review"]);
   assert.equal(created.ok, true); if (created.ok) assert.deepEqual({ method: created.command.method, action: created.command.action }, { method: "daemon.runtimeInstance.create", action: { kind: "runtime-instance-create", instanceId: "codex-review", name: "Codex Review", kindId: "codex", installationId: observed.installationId, providerId: "codex_local_access", models: ["gpt-5.6-sol", "gpt-5.6-terra"], defaultModel: "gpt-5.6-terra", permissionMode: "workspace-write", codex: { reasoningEffort: "xhigh", baseUrl: "http://127.0.0.1:1/v1", wireApi: "responses", requiresOpenAiAuth: true, httpHeaders: { "X-Harness-Probe": "present" } }, authMode: "api-key", credentialRef: "keychain:harness/codex-review" } });
+  const claudeCreated = parseThinCommand(["runtime", "instance", "create", "--id", "claude-review", "--name", "Claude Review", "--kind", "claude", "--installation", "claude-installation", "--provider", "anthropic", "--model", "claude-fable-5", "--effort", "high", "--auth", "subscription"]); assert.equal(claudeCreated.ok, true); if (claudeCreated.ok) assert.deepEqual(claudeCreated.command.action.claude, { effort: "high" });
   for (const [argv, method, instanceId] of [["list", "daemon.runtimeInstance.list", undefined], ["show", "daemon.runtimeInstance.show", "codex-review"], ["update", "daemon.runtimeInstance.update", "codex-review"], ["delete", "daemon.runtimeInstance.delete", "codex-review"]] as const) { const parsed = parseThinCommand(["runtime", "instance", argv, ...(instanceId ? [instanceId] : [])]); assert.equal(parsed.ok, argv === "update" ? false : true, JSON.stringify(parsed)); if (parsed.ok) assert.deepEqual({ method: parsed.command.method, action: parsed.command.action }, { method, action: { kind: `runtime-instance-${argv}`, ...(instanceId ? { instanceId } : {}) } }); }
   const update = parseThinCommand(["runtime", "instance", "update", "codex-review", "--name", "Updated", "--installation", "codex-new", "--model", "gpt-5.6-sol", "--model", "gpt-5.6-terra", "--default-model", "gpt-5.6-terra", "--permission-mode", "read-only", "--disable"]); assert.equal(update.ok, true); if (update.ok) assert.deepEqual(update.command.action, { kind: "runtime-instance-update", instanceId: "codex-review", name: "Updated", installationId: "codex-new", models: ["gpt-5.6-sol", "gpt-5.6-terra"], defaultModel: "gpt-5.6-terra", permissionMode: "read-only", enabled: false });
   assert.deepEqual(validateDaemonRpcCall({ method: "daemon.runtimeInstance.update", params: { payload: { instanceId: "codex-review", installationId: "codex-new" } } }), []);
   const run = parseThinCommand(["runtime", "run", "codex-review", "--model", "gpt-5.6-terra", "--effort", "xhigh", "--permission-mode", "workspace-write", "--prompt", "Inspect"]); assert.equal(run.ok, true); if (run.ok) { assert.equal(run.command.action.model, "gpt-5.6-terra"); assert.equal(run.command.action.effort, "xhigh"); assert.equal(run.command.action.permissionMode, "workspace-write"); }
-  assert.deepEqual(parseThinCommand(["runtime", "run", "codex-review", "--effort", "turbo", "--prompt", "Inspect"]), { ok: false, code: "invalid_runtime_effort", nextAction: "Use minimal, low, medium, high, or xhigh with a Codex instance.", json: false });
+  assert.deepEqual(parseThinCommand(["runtime", "run", "codex-review", "--effort", "turbo", "--prompt", "Inspect"]), { ok: false, code: "invalid_runtime_effort", nextAction: "Use minimal, low, medium, high, or xhigh with Claude or Codex; agy supports low, medium, or high.", json: false });
   const probed = parseThinCommand(["runtime", "instance", "show", "codex-review", "--probe"]); assert.equal(probed.ok, true); if (probed.ok) assert.deepEqual({ method: probed.command.method, action: probed.command.action }, { method: "daemon.runtimeInstance.show", action: { kind: "runtime-instance-show", instanceId: "codex-review", probe: true } });
   assert.deepEqual(parseThinCommand(["runtime", "instance", "create", "--id", "bad", "--name", "Bad", "--kind", "codex", "--installation", observed.installationId, "--provider", "openai", "--model", "gpt", "--auth", "api-key"]), { ok: false, code: "missing_field", nextAction: "API-key instances require --credential-ref <opaque-ref>.", json: false });
   assert.deepEqual(parseThinCommand(["runtime", "instance", "create", "--id", "bad", "--name", "Bad", "--kind", "codex", "--installation", observed.installationId, "--provider", "openai", "--model", "gpt", "--auth", "subscription", "--credential-ref", "keychain:harness/bad"]), { ok: false, code: "invalid_field", nextAction: "Subscription instances cannot accept a credential reference.", json: false });
-  assert.deepEqual(parseThinCommand(["runtime", "instance", "create", "--id", "bad", "--name", "Bad", "--kind", "claude", "--installation", observed.installationId, "--provider", "anthropic", "--model", "claude", "--wire-api", "responses", "--auth", "subscription"]), { ok: false, code: "invalid_field", nextAction: "Claude runtime instances cannot accept Codex options: --effort, --wire-api, --requires-openai-auth, or --http-header.", json: false });
+  assert.deepEqual(parseThinCommand(["runtime", "instance", "create", "--id", "bad", "--name", "Bad", "--kind", "claude", "--installation", observed.installationId, "--provider", "anthropic", "--model", "claude", "--wire-api", "responses", "--auth", "subscription"]), { ok: false, code: "invalid_field", nextAction: "Claude runtime instances cannot accept Codex options: --wire-api, --requires-openai-auth, or --http-header.", json: false });
   for (const flag of ["--env", "--argv", "--isolation-profile"]) { const parsed = parseThinCommand(["runtime", "instance", "create", "--id", "bad", "--name", "Bad", "--kind", "codex", "--installation", observed.installationId, "--provider", "openai", "--model", "gpt", "--auth", "subscription", flag, "open"]); assert.equal(parsed.ok ? "ok" : parsed.code, "unknown_field", flag); }
 });
 
@@ -314,9 +315,9 @@ test("public instance projections keep provider options in the matching kind sec
   const userRoot = mkdtempSync(path.join(tmpdir(), "ha-runtime-public-projection-")), claude = { ...observed, installationId: "claude-projection", kindId: "claude" as const, executablePath: "/opt/runtime-test/claude" }, store = openRuntimeInstanceStore({ userRoot, discover: () => [observed, claude] });
   try {
     store.create({ schemaVersion: 2, instanceId: "codex-projection", name: "Codex Projection", kindId: "codex", installationId: observed.installationId, providerId: "sidecar", models: ["gpt-5.6-sol"], defaultModel: "gpt-5.6-sol", enabled: true, codex: { reasoningEffort: "high", baseUrl: "http://127.0.0.1:1/v1", wireApi: "responses", requiresOpenAiAuth: true, httpHeaders: { "X-Probe": "present" } }, auth: { mode: "subscription" } });
-    store.create({ schemaVersion: 2, instanceId: "claude-projection", name: "Claude Projection", kindId: "claude", installationId: claude.installationId, providerId: "anthropic", models: ["claude"], defaultModel: "claude", enabled: true, claude: { baseUrl: "https://gateway.example.test/v1" }, auth: { mode: "subscription" } });
+    store.create({ schemaVersion: 2, instanceId: "claude-projection", name: "Claude Projection", kindId: "claude", installationId: claude.installationId, providerId: "anthropic", models: ["claude"], defaultModel: "claude", enabled: true, claude: { effort: "medium", baseUrl: "https://gateway.example.test/v1" }, auth: { mode: "subscription" } });
     const codex = store.command({ kind: "runtime-instance-show", instanceId: "codex-projection" }).instance as Record<string, unknown>, claudeDto = store.command({ kind: "runtime-instance-show", instanceId: "claude-projection" }).instance as Record<string, unknown>, listed = store.command({ kind: "runtime-instance-list" }).instances as Array<Record<string, unknown>>;
-    assert.deepEqual(codex.codex, { reasoningEffort: "high", baseUrl: "http://127.0.0.1:1/v1", baseUrlConfigured: true, wire_api: "responses", requires_openai_auth: true, http_headers: { "X-Probe": "present" } }); assert.equal("reasoningEffort" in codex, false); assert.equal("baseUrl" in codex, false); assert.equal("codex" in claudeDto, false); assert.deepEqual(claudeDto.claude, { baseUrl: "https://gateway.example.test/v1", baseUrlConfigured: true }); assert.equal(listed.every((item) => item.kindId === "codex" ? "codex" in item : "claude" in item), true);
+    assert.deepEqual(codex.codex, { reasoningEffort: "high", baseUrl: "http://127.0.0.1:1/v1", baseUrlConfigured: true, wire_api: "responses", requires_openai_auth: true, http_headers: { "X-Probe": "present" } }); assert.equal("reasoningEffort" in codex, false); assert.equal("baseUrl" in codex, false); assert.equal("codex" in claudeDto, false); assert.deepEqual(claudeDto.claude, { effort: "medium", baseUrl: "https://gateway.example.test/v1", baseUrlConfigured: true }); assert.equal(listed.every((item) => item.kindId === "codex" ? "codex" in item : "claude" in item), true);
   } finally { rmSync(userRoot, { recursive: true, force: true }); }
 });
 
@@ -397,11 +398,11 @@ test("flat schema v2 runtime config normalizes into its kind section on read", a
   } finally { rmSync(userRoot, { recursive: true, force: true }); }
 });
 
-test("flat Claude effort from schema v2 migrates away without granting Claude Codex configuration", async () => {
+test("flat Claude effort from schema v2 migrates into Claude configuration", async () => {
   const userRoot = mkdtempSync(path.join(tmpdir(), "ha-runtime-claude-v2-migration-")), claude = { ...observed, installationId: "claude-installation-test", kindId: "claude" as const, executablePath: "/opt/runtime-test/claude" };
   try {
     writeFileSync(path.join(userRoot, "runtime-instances.json"), `${JSON.stringify({ schema: "runtime-instances/v1", instances: [{ schemaVersion: 2, instanceId: "claude-flat", name: "Claude Flat", kindId: "claude", installationId: claude.installationId, providerId: "anthropic", models: ["claude-fable-5"], defaultModel: "claude-fable-5", enabled: true, reasoningEffort: "high", baseUrl: "https://gateway.example.test/v1", auth: { mode: "subscription" } }] })}\n`);
-    const store = openRuntimeInstanceStore({ userRoot, discover: () => [claude] }); assert.deepEqual(store.read("claude-flat")?.claude, { baseUrl: "https://gateway.example.test/v1" }); const persisted = JSON.parse(readFileSync(path.join(userRoot, "runtime-instances.json"), "utf8")).instances[0]; assert.deepEqual(persisted.claude, { baseUrl: "https://gateway.example.test/v1" }); assert.equal("reasoningEffort" in persisted, false); assert.equal("codex" in persisted, false);
+    const store = openRuntimeInstanceStore({ userRoot, discover: () => [claude] }); assert.deepEqual(store.read("claude-flat")?.claude, { effort: "high", baseUrl: "https://gateway.example.test/v1" }); const persisted = JSON.parse(readFileSync(path.join(userRoot, "runtime-instances.json"), "utf8")).instances[0]; assert.deepEqual(persisted.claude, { effort: "high", baseUrl: "https://gateway.example.test/v1" }); assert.equal("reasoningEffort" in persisted, false); assert.equal("codex" in persisted, false);
   } finally { rmSync(userRoot, { recursive: true, force: true }); }
 });
 
@@ -424,6 +425,25 @@ test("Codex effort is a per-launch override and never mutates the instance", asy
     assert.notEqual(low.args.join("\0"), xhigh.args.join("\0")); assert.match(low.args.join(" "), /model_reasoning_effort="low"/u); assert.match(xhigh.args.join(" "), /model_reasoning_effort="xhigh"/u); assert.equal(store.read("codex-effort")?.kindId, "codex"); assert.equal(store.read("codex-effort")?.codex.reasoningEffort, "medium");
     await assert.rejects(store.prepareLaunch("codex-effort", { cwd: "/workspace/repo", prompt: "Bad", effort: "turbo" }), (error: unknown) => codedAs(error, "invalid_runtime_effort") && error instanceof Error && error.message.includes("turbo"));
     await assert.rejects(store.prepareLaunch("codex-effort", { cwd: "/workspace/repo", prompt: "Bad", effort: "" }), (error: unknown) => codedAs(error, "invalid_runtime_effort"));
+  } finally { rmSync(userRoot, { recursive: true, force: true }); }
+});
+
+test("Claude effort defaults and per-launch overrides reach the Claude Code CLI", async () => {
+  const userRoot = mkdtempSync(path.join(tmpdir(), "ha-runtime-claude-effort-")),
+    claude = { ...observed, installationId: "claude-effort-installation", kindId: "claude" as const, executablePath: "/opt/runtime-test/claude" };
+  try {
+    const store = openRuntimeInstanceStore({ userRoot, discover: () => [claude], resolveCredential: () => "instance-secret" });
+    store.create({ schemaVersion: 2, instanceId: "claude-effort", name: "Claude Effort", kindId: "claude", installationId: claude.installationId, providerId: "anthropic", models: ["claude-fable-5"], defaultModel: "claude-fable-5", enabled: true, isolationState: "enforced", claude: { effort: "medium" }, auth: { mode: "api-key", credentialRef: "credential:v1:claude-effort" } });
+    const configured = await store.prepareLaunch("claude-effort", { cwd: "/workspace/repo", prompt: "Configured" }),
+      overridden = await store.prepareLaunch("claude-effort", { cwd: "/workspace/repo", prompt: "Override", effort: "xhigh", providerSessionId: "session-1" }),
+      minimal = await store.prepareLaunch("claude-effort", { cwd: "/workspace/repo", prompt: "Minimal", effort: "minimal" });
+    assert.deepEqual(configured.args, ["-p", "--verbose", "--output-format", "stream-json", "--permission-mode", "bypassPermissions", "--model", "claude-fable-5", "--effort", "medium", "--bare"]);
+    assert.deepEqual(overridden.args.slice(-5), ["--effort", "xhigh", "--bare", "--resume", "session-1"]);
+    assert.equal(minimal.args[minimal.args.indexOf("--effort") + 1], "low");
+    assert.equal(configured.definition.reasoningEffort, "medium");
+    assert.equal(overridden.definition.reasoningEffort, "xhigh");
+    assert.equal(store.read("claude-effort")?.claude.effort, "medium");
+    await assert.rejects(store.prepareLaunch("claude-effort", { cwd: "/workspace/repo", prompt: "Bad", effort: "turbo" }), (error: unknown) => codedAs(error, "invalid_runtime_effort") && error instanceof Error && error.message.includes("turbo"));
   } finally { rmSync(userRoot, { recursive: true, force: true }); }
 });
 
@@ -880,7 +900,7 @@ test("runtime instance update edits the base URL of an existing instance", async
       installationId: claudeInstallation.installationId,
       providerId: "anthropic",
       models: ["claude-fable-5"],
-      claude: { baseUrl: "https://old-gateway.example/v1" },
+      claude: { effort: "high", baseUrl: "https://old-gateway.example/v1" },
       authMode: "api-key",
       credentialRef: "keychain:harness/claude-edit",
     });
@@ -892,6 +912,10 @@ test("runtime instance update edits the base URL of an existing instance", async
     assert.equal(
       (claudeReplaced.instance as { readonly claude: { readonly baseUrl: string | null } }).claude.baseUrl,
       "https://new-gateway.example/v1",
+    );
+    assert.equal(
+      (claudeReplaced.instance as { readonly claude: { readonly effort: string | null } }).claude.effort,
+      "high",
     );
     // Insecure endpoints are rejected by the same validation create uses.
     assert.throws(

--- a/packages/daemon/test/runtime-spawn-ingress.integration.test.ts
+++ b/packages/daemon/test/runtime-spawn-ingress.integration.test.ts
@@ -1391,6 +1391,129 @@ test("daemon ingress cancellation is explicit and idempotent for an active runti
   }
 });
 
+test("daemon ingress passes Claude effort through to the witnessed Claude Code CLI", async () => {
+  const parent = mkdtempSync(path.join(tmpdir(), "ha-runtime-claude-effort-ingress-")),
+    root = path.join(parent, "repo"),
+    userRoot = path.join(parent, "user"),
+    repoId = "runtime-claude-effort-ingress",
+    uid = process.getuid?.() ?? 0,
+    argsPath = path.join(parent, "claude-args.json"),
+    executablePath = writeProviderStub(path.join(parent, "claude-stub"), "claude", argsPath),
+    installation = {
+      installationId: "installation-claude-effort",
+      kindId: "claude" as const,
+      executablePath,
+      version: "2.1.251",
+      observedAt: "2026-08-30T00:00:00.000Z",
+    },
+    auth = {
+      transportKind: "unix-socket",
+      unixSocketOwnerBoundary: {
+        ownerUid: uid,
+        source: "unix-socket-filesystem-owner-boundary",
+      },
+    } as const;
+  initIngressRepo(root, uid);
+  registerDaemonRepo({ canonicalRoot: root, repoId, userRoot, createConvenienceLinks: false });
+  const host = await openDaemonHost({
+    daemonId: "runtime-claude-effort-ingress",
+    userRoot,
+    runtimeDiscover: () => [installation],
+  }),
+    endpoint = localUserDaemonEndpoint(userRoot, "runtime-claude-effort-ingress"),
+    transport = createUnixSocketTransportServer({
+      daemonId: "runtime-claude-effort-ingress",
+      socketPath: endpoint,
+      createProtocolServer: (authContext, emit) =>
+        createJsonRpcProtocolServer({ host, build: { commit: null }, authContext, emit }),
+    });
+  await transport.start();
+  try {
+    await host.attachmentsSettled();
+    host.runtimeInstance(
+      "daemon.runtimeInstance.create",
+      {
+        instanceId: "claude-effort-provider",
+        name: "Claude effort provider",
+        kindId: "claude",
+        installationId: installation.installationId,
+        providerId: "anthropic",
+        models: ["claude-fable-5"],
+        claude: {},
+        authMode: "subscription",
+      },
+      auth,
+    );
+    const childEnv = {
+        ...process.env,
+        HARNESS_DAEMON_USER_ROOT: userRoot,
+        HARNESS_DAEMON_ID: "runtime-claude-effort-ingress",
+        HARNESS_DAEMON_REPO_ID: repoId,
+        HARNESS_DAEMON_ENDPOINT: endpoint,
+      },
+      expectedArgs = [
+        "-p",
+        "--verbose",
+        "--output-format",
+        "stream-json",
+        "--permission-mode",
+        "bypassPermissions",
+        "--model",
+        "claude-fable-5",
+        "--effort",
+        "high",
+      ],
+      spawned = await spawnCli([
+        "--root",
+        root,
+        "--json",
+        "runtime",
+        "run",
+        "claude-effort-provider",
+        "--effort",
+        "high",
+        "--prompt",
+        "probe",
+        "--no-stream",
+      ], childEnv);
+    assert.equal(spawned.status, 0, `${spawned.stderr}\n${spawned.stdout}`);
+    assert.deepEqual(JSON.parse(readFileSync(argsPath, "utf8")), expectedArgs);
+    const rejected = await spawnCli([
+      "--root",
+      root,
+      "--json",
+      "runtime",
+      "run",
+      "claude-effort-provider",
+      "--effort",
+      "turbo",
+      "--prompt",
+      "reject",
+      "--no-stream",
+    ], childEnv);
+    assert.equal(rejected.status, 2, `${rejected.stderr}\n${rejected.stdout}`);
+    assert.equal((JSON.parse(rejected.stdout) as Record<string, unknown>).code, "invalid_runtime_effort");
+    const rejectedIngress = await rpc(host, auth, "repo.agentRuntime.spawn", {
+      repo: { repoId },
+      payload: {
+        runtimeInstanceId: "claude-effort-provider",
+        cwd: { scope: "repo-root" },
+        prompt: "reject",
+        effort: "turbo",
+        taskId: null,
+        idempotencyKey: "claude-effort-turbo",
+      },
+    });
+    assert.equal(rejectedIngress.outcome, "op_rejected", JSON.stringify(rejectedIngress));
+    assert.equal(rejectedIngress.code, "invalid_runtime_effort");
+    assert.deepEqual(JSON.parse(readFileSync(argsPath, "utf8")), expectedArgs);
+  } finally {
+    await transport.stop();
+    await host.close();
+    rmSync(parent, { recursive: true, force: true });
+  }
+});
+
 test("agy consumes only its closed stream-json event protocol", async () => {
   const parent = mkdtempSync(path.join(tmpdir(), "ha-runtime-agy-events-")),
     root = path.join(parent, "repo"),
@@ -1630,7 +1753,7 @@ async function eventuallyValue<T>(read: () => T | null | Promise<T | null>): Pro
   }
   throw new Error("runtime provider event did not arrive");
 }
-function writeProviderStub(target: string, kindId: "claude" | "codex"): string {
+function writeProviderStub(target: string, kindId: "claude" | "codex", argsTarget?: string): string {
   const lines =
     kindId === "claude"
       ? [
@@ -1716,9 +1839,12 @@ function writeProviderStub(target: string, kindId: "claude" | "codex"): string {
     kindId === "claude"
       ? `process.argv.includes("--output-format") && process.argv.includes("stream-json") && process.argv.includes("--verbose")`
       : `process.argv[2] === "exec" && process.argv.includes("--json")`;
+  const recordArgs = argsTarget
+    ? `fs.writeFileSync(${JSON.stringify(argsTarget)}, JSON.stringify(process.argv.slice(2)));\n`
+    : "";
   return writeProviderExecutable(
     target,
-    `import fs from "node:fs";\nconst auth = process.argv[2] === "auth" || process.argv[2] === "login";\nif (auth) process.exit(0);\nif (!(${structuredFlag})) process.exit(9);\nconst prompt = fs.readFileSync(0, "utf8"), secret = "sk-runtime-secret-1234567890";\nif (prompt === "failure:empty") process.exit(1);\nelse if (prompt === "failure:secret") process.stderr.write("OPENAI_API_KEY=" + secret + "\\n", () => process.exit(1));\nelse if (prompt === "failure:structured") process.stdout.write([JSON.stringify({ type: "thread.started", thread_id: "codex-provider-session" }), JSON.stringify({ type: "turn.failed", error: { message: "structured provider failure", apiToken: secret } })].join("\\n") + "\\n", () => process.exit(1));\nelse if (prompt === "permission-denied") process.stdout.write([JSON.stringify({ type: "system", subtype: "init", session_id: "claude-provider-session" }), JSON.stringify({ type: "assistant", session_id: "claude-provider-session", message: { content: [{ type: "tool_use", id: "denied-write", name: "Write", input: { file_path: "/tmp/outside", content: "denied" } }] } }), JSON.stringify({ type: "result", subtype: "success", is_error: false, session_id: "claude-provider-session", result: "write denied", permission_denials: [{ tool_name: "Write", tool_use_id: "denied-write" }] })].join("\\n") + "\\n");\nelse { let emitted = ${JSON.stringify(lines)}; if (prompt === "read-only") emitted = [{ type: "thread.started", thread_id: "codex-provider-session" }, { type: "item.completed", item: { id: "inspect", type: "command_execution", command: "git status --short", aggregated_output: "", exit_code: 0, status: "completed" } }, { type: "item.completed", item: { id: "message", type: "agent_message", text: "read-only final result" } }, { type: "turn.completed", usage: { input_tokens: 1, output_tokens: 1 } }]; else if (prompt === "no-action") emitted = [{ type: "thread.started", thread_id: "codex-provider-session" }, { type: "item.completed", item: { id: "message", type: "agent_message", text: "no-action final result" } }, { type: "turn.completed", usage: { input_tokens: 1, output_tokens: 1 } }]; else if (prompt === "no-write") emitted.splice(1, 0, { type: "item.completed", item: { id: "inspect", type: "command_execution", command: "git status --short", aggregated_output: "", exit_code: 0, status: "completed" } }, { type: "item.updated", item: { id: "plan", type: "todo_list", items: [{ text: "locate cause", status: "completed" }, { text: "write fix", status: "in_progress" }] } }); emitted.forEach((line, index) => setTimeout(() => console.log(JSON.stringify(line)), index * 40)); }\n`,
+    `import fs from "node:fs";\nconst auth = process.argv[2] === "auth" || process.argv[2] === "login";\nif (auth) process.exit(0);\n${recordArgs}if (!(${structuredFlag})) process.exit(9);\nconst prompt = fs.readFileSync(0, "utf8"), secret = "sk-runtime-secret-1234567890";\nif (prompt === "failure:empty") process.exit(1);\nelse if (prompt === "failure:secret") process.stderr.write("OPENAI_API_KEY=" + secret + "\\n", () => process.exit(1));\nelse if (prompt === "failure:structured") process.stdout.write([JSON.stringify({ type: "thread.started", thread_id: "codex-provider-session" }), JSON.stringify({ type: "turn.failed", error: { message: "structured provider failure", apiToken: secret } })].join("\\n") + "\\n", () => process.exit(1));\nelse if (prompt === "permission-denied") process.stdout.write([JSON.stringify({ type: "system", subtype: "init", session_id: "claude-provider-session" }), JSON.stringify({ type: "assistant", session_id: "claude-provider-session", message: { content: [{ type: "tool_use", id: "denied-write", name: "Write", input: { file_path: "/tmp/outside", content: "denied" } }] } }), JSON.stringify({ type: "result", subtype: "success", is_error: false, session_id: "claude-provider-session", result: "write denied", permission_denials: [{ tool_name: "Write", tool_use_id: "denied-write" }] })].join("\\n") + "\\n");\nelse { let emitted = ${JSON.stringify(lines)}; if (prompt === "read-only") emitted = [{ type: "thread.started", thread_id: "codex-provider-session" }, { type: "item.completed", item: { id: "inspect", type: "command_execution", command: "git status --short", aggregated_output: "", exit_code: 0, status: "completed" } }, { type: "item.completed", item: { id: "message", type: "agent_message", text: "read-only final result" } }, { type: "turn.completed", usage: { input_tokens: 1, output_tokens: 1 } }]; else if (prompt === "no-action") emitted = [{ type: "thread.started", thread_id: "codex-provider-session" }, { type: "item.completed", item: { id: "message", type: "agent_message", text: "no-action final result" } }, { type: "turn.completed", usage: { input_tokens: 1, output_tokens: 1 } }]; else if (prompt === "no-write") emitted.splice(1, 0, { type: "item.completed", item: { id: "inspect", type: "command_execution", command: "git status --short", aggregated_output: "", exit_code: 0, status: "completed" } }, { type: "item.updated", item: { id: "plan", type: "todo_list", items: [{ text: "locate cause", status: "completed" }, { text: "write fix", status: "in_progress" }] } }); emitted.forEach((line, index) => setTimeout(() => console.log(JSON.stringify(line)), index * 40)); }\n`,
   );
 }
 function installationFixture(kindId: "claude" | "codex", executablePath: string): RuntimeInstallationWitness {


### PR DESCRIPTION
# English

## Summary

Claude-kind runtimes (`glm-work`, `claude-grok`, native `claude`) now accept `--effort`, unifying the reasoning-effort command surface across the `codex` / `agy` / `claude` kinds. Previously `selectRuntimeEffort` threw `invalid_runtime_effort` for any non-codex/non-agy kind, even though Claude Code supports reasoning effort — so `ha runtime run <claude-instance> --effort high` was rejected outright.

## What Changed

- `selectRuntimeEffort` now reads `config.claude.effort` for the `claude` kind and validates it through the shared `minimal|low|medium|high|xhigh` vocabulary; the "throw for non-codex" branch is removed.
- `ClaudeRuntimeInstanceConfig` gains an optional `effort` field; contract validation, storage, store, and the runtime protocol commands are threaded through.
- `launchArgs` passes `--effort <value>` to the Claude Code CLI at spawn time. Shared `minimal` maps to Claude-native `low` (Claude Code's floor; it ignores `minimal`).
- CLI `runtime instance create` accepts `effort` for `claude` instances.
- Tests: 50 daemon unit assertions + 20 runtime-spawn integration assertions covering claude-kind effort acceptance, the minimal→low mapping, and invalid-value rejection.

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
Production-Delta: +47/-26

## Task And Scope

- Harness task: task_d2d1b29897c3b3111a122875c0 (PLT-Ontology milestone child)
- Branch: codex/claude-runtime-effort-passthrough
- Public scope: packages/daemon runtime adapter + packages/cli runtime-instance-create + protocol commands + tests
- Private planning/evidence updated: yes
- Out of scope: codex/agy effort semantics (unchanged); daemon rebuild/restart to pick up the fix (separate hygiene step)

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: not applicable
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no

## Verification

- Base `origin/main` SHA: 6ec510ea539d2abd8b075c5b5a994c45ff91bb85
- Branch merge-base with `origin/main`: 6ec510ea539d2abd8b075c5b5a994c45ff91bb85
- Last `git fetch origin` time: 2026-08-30 (this session)
- Sync method: none needed (branch is based directly on current origin/main)
- Public diff command: `git show 2802e2b82744891956f57c1b5c6c9d9fef37c77e`
- Worker-run targeted tests: daemon effort unit suite (50 passed), runtime-spawn integration (20 passed), typecheck, ESLint, `git diff --check`, governance walls, architecture advisory — all passed.
- Not run: full `npm run check:local` — per task constraint (concurrent workers on one machine exhaust the fork pool); GitHub Actions `rewrite-ci` is the authority.

## Review Evidence

- Self-review: CEO read the full diff; confirmed effort is not merely paper-accepted at `selectRuntimeEffort` but actually reaches the Claude Code CLI via `--effort` in `launchArgs` (the reviewer reject condition in the task plan).
- Reviewer subagent: pending (CI + optional Codex connector review)
- Human review: CEO semantic acceptance passed (implementation matches the three-kind unified command-surface intent)
- Blocking findings: none

## Residual Risk

- The running daemon still executes an older build; it will pick up this fix only after a rebuild/restart (tracked separately as daemon-build hygiene). The merge itself is correct.

## References

- Task: task_d2d1b29897c3b3111a122875c0
- Evidence: fact F-BC82309C (worker), CEO diff review this session
- Review: CEO semantic acceptance (this session)

---

# 中文

## 摘要

`claude` kind 的 runtime(`glm-work`、`claude-grok`、原生 `claude`)现在接受 `--effort`,把 reasoning-effort 命令面在 `codex` / `agy` / `claude` 三种 kind 上统一。此前 `selectRuntimeEffort` 对任何非 codex/agy 的 kind 直接抛 `invalid_runtime_effort`,而 Claude Code 本身支持 reasoning effort——导致 `ha runtime run <claude 实例> --effort high` 被直接拒绝。

## 改了什么

- `selectRuntimeEffort` 对 `claude` kind 改读 `config.claude.effort`,复用 `minimal|low|medium|high|xhigh` 共享词表校验;删除"非 codex 抛错"分支。
- `ClaudeRuntimeInstanceConfig` 新增可选 `effort` 字段;contract 校验、storage、store、runtime 协议命令一并接通。
- `launchArgs` 在 spawn 时把 `--effort <值>` 传给 Claude Code CLI;共享 `minimal` 映射为 Claude 原生 `low`(Claude Code 的下限,忽略 `minimal`)。
- CLI `runtime instance create` 对 `claude` 实例接受 `effort`。
- 测试:50 条 daemon 单测断言 + 20 条 runtime-spawn 集成断言,覆盖 claude effort 接受、minimal→low 映射、非法值拒绝。

## 任务与范围

- Harness 任务:task_d2d1b29897c3b3111a122875c0(PLT-Ontology 里程碑子任务)
- 分支:codex/claude-runtime-effort-passthrough
- 公开范围:packages/daemon runtime 适配器 + packages/cli runtime-instance-create + 协议命令 + 测试
- 私有规划/证据已更新:是
- 范围外:codex/agy effort 语义(不变);daemon 重建/重启以生效(单独的卫生步骤)

## 治理声明

- 触碰 protected surface:否
- 范围:不适用
- 授权:不适用
- Break-glass:否

## 验证

- Base `origin/main` SHA:6ec510ea539d2abd8b075c5b5a994c45ff91bb85
- 与 `origin/main` 的 merge-base:6ec510ea539d2abd8b075c5b5a994c45ff91bb85
- 最近 `git fetch origin`:2026-08-30(本会话)
- Sync 方式:无需(分支直接基于当前 origin/main)
- 公开 diff 命令:`git show 2802e2b82744891956f57c1b5c6c9d9fef37c77e`
- Worker 定向测试:daemon effort 单测(50 过)、runtime-spawn 集成(20 过)、typecheck、ESLint、`git diff --check`、治理 walls、架构 advisory——全过。
- 未跑:完整 `npm run check:local`——按任务约束(同机并发 worker 会耗尽 fork 池);以 GitHub Actions `rewrite-ci` 为权威。

## 复核证据

- 自审:CEO 通读全 diff;确认 effort 不是只在 `selectRuntimeEffort` 纸面放行,而是经 `launchArgs` 的 `--effort` 真正传到 Claude Code CLI(任务 plan 里的 reviewer 拒收条件)。
- Reviewer subagent:待定(CI + 可选 Codex connector 复核)
- 人工复核:CEO 语义验收通过(实现符合三 kind 命令面统一意图)
- 阻塞发现:无

## 残余风险

- 运行中的 daemon 仍跑旧 build,需重建/重启才生效(作为 daemon build 卫生单独跟踪)。合并本身是正确的。

## 引用

- 任务:task_d2d1b29897c3b3111a122875c0
- 证据:fact F-BC82309C(worker)、CEO 本会话 diff 复核
- 复核:CEO 语义验收(本会话)
