### PR TITLE
feat(tools): pr-merge helper — 合并后自动同步本地 main(治理第8条自动化)

### DIFF
--- a/tools/pr-merge.mjs
+++ b/tools/pr-merge.mjs
@@ -1,0 +1,211 @@
+#!/usr/bin/env node
+import { spawnSync } from "node:child_process";
+import process from "node:process";
+
+const MAIN_BRANCH = "main";
+const REMOTE = "origin";
+
+function run(command, args, { cwd, allowFailure = false } = {}) {
+  const result = spawnSync(command, args, {
+    cwd,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  if (result.error) {
+    throw new Error(`${command} failed to launch: ${result.error.message}`);
+  }
+  if (!allowFailure && result.status !== 0) {
+    const detail = (result.stderr || result.stdout).trim();
+    throw new Error(`${command} ${args.join(" ")} failed${detail ? `: ${detail}` : ""}`);
+  }
+  return result;
+}
+
+function output(command, args, options) {
+  return run(command, args, options).stdout.trim();
+}
+
+function parseWorktrees(root) {
+  return output("git", ["worktree", "list", "--porcelain"], { cwd: root })
+    .split(/\n\n+/u)
+    .filter(Boolean)
+    .map((block) => {
+      const entry = {};
+      for (const line of block.split(/\n/u)) {
+        const [key, ...rest] = line.split(" ");
+        if (key === "worktree") entry.path = rest.join(" ");
+        if (key === "branch") entry.branch = rest.join(" ").replace(/^refs\/heads\//u, "");
+      }
+      return entry;
+    });
+}
+
+function readPr(selector, root) {
+  const fields = [
+    "number",
+    "state",
+    "isDraft",
+    "baseRefName",
+    "headRefName",
+    "headRefOid",
+    "isCrossRepository",
+    "mergeable",
+    "url",
+  ].join(",");
+  return JSON.parse(output("gh", ["pr", "view", selector, "--json", fields], { cwd: root }));
+}
+
+function requireCleanWorktree(worktree, label) {
+  const status = output("git", ["status", "--porcelain=v1", "--untracked-files=normal"], {
+    cwd: worktree.path,
+  });
+  if (status) {
+    throw new Error(`${label} worktree is dirty at ${worktree.path}; refusing to merge, delete, or pull.\n${status}`);
+  }
+}
+
+function preflight(selector) {
+  const invocationRoot = output("git", ["rev-parse", "--show-toplevel"], { cwd: process.cwd() });
+  const worktrees = parseWorktrees(invocationRoot);
+  const mainWorktree = worktrees.find((entry) => entry.branch === MAIN_BRANCH);
+  if (!mainWorktree) {
+    throw new Error(`No worktree has ${MAIN_BRANCH} checked out; create or restore the local main worktree first.`);
+  }
+  if (invocationRoot !== mainWorktree.path) {
+    throw new Error(`Run this helper from the main worktree: ${mainWorktree.path}`);
+  }
+
+  const pr = readPr(selector, mainWorktree.path);
+  if (!Number.isInteger(pr.number) || !pr.headRefName || !pr.headRefOid) {
+    throw new Error("GitHub returned incomplete PR identity data.");
+  }
+  if (pr.baseRefName !== MAIN_BRANCH) {
+    throw new Error(`PR #${pr.number} targets ${pr.baseRefName}, not ${MAIN_BRANCH}.`);
+  }
+  if (pr.headRefName === MAIN_BRANCH) {
+    throw new Error(`Refusing to clean protected branch ${MAIN_BRANCH}.`);
+  }
+  if (pr.isCrossRepository) {
+    throw new Error(`PR #${pr.number} comes from a fork; this helper only deletes branches from ${REMOTE}.`);
+  }
+  if (!/^[0-9a-f]{40}$/u.test(pr.headRefOid)) {
+    throw new Error(`PR #${pr.number} has an invalid head commit: ${pr.headRefOid}`);
+  }
+  if (pr.state !== "OPEN" && pr.state !== "MERGED") {
+    throw new Error(`PR #${pr.number} is ${pr.state}; only open or merged PRs can be finalized.`);
+  }
+  if (pr.state === "OPEN" && pr.isDraft) {
+    throw new Error(`PR #${pr.number} is still a draft.`);
+  }
+  if (pr.state === "OPEN" && pr.mergeable !== "MERGEABLE") {
+    throw new Error(`PR #${pr.number} is not mergeable (mergeable=${pr.mergeable}).`);
+  }
+
+  const prWorktree = worktrees.find((entry) => entry.branch === pr.headRefName);
+  requireCleanWorktree(mainWorktree, "main");
+  if (prWorktree) requireCleanWorktree(prWorktree, `PR branch ${pr.headRefName}`);
+
+  return { mainWorktree, pr, prWorktree };
+}
+
+function mergeOpenPr(pr, root) {
+  const checks = run("gh", ["pr", "checks", String(pr.number), "--required"], {
+    cwd: root,
+    allowFailure: true,
+  });
+  if (checks.status !== 0) {
+    const detail = (checks.stderr || checks.stdout).trim();
+    throw new Error(`Required checks for PR #${pr.number} are not all successful${detail ? `:\n${detail}` : "."}`);
+  }
+  if (checks.stdout.trim()) process.stdout.write(checks.stdout);
+
+  const merge = run(
+    "gh",
+    ["pr", "merge", String(pr.number), "--merge", "--admin", "--match-head-commit", pr.headRefOid],
+    { cwd: root },
+  );
+  if (merge.stdout) process.stdout.write(merge.stdout);
+
+  const merged = readPr(String(pr.number), root);
+  if (merged.state !== "MERGED") {
+    throw new Error(`PR #${pr.number} did not reach MERGED state (state=${merged.state}).`);
+  }
+}
+
+function deleteRemoteBranch(branch, root) {
+  const remoteRef = `refs/heads/${branch}`;
+  const probe = run("git", ["ls-remote", "--exit-code", "--heads", REMOTE, remoteRef], {
+    cwd: root,
+    allowFailure: true,
+  });
+  if (probe.status === 2) {
+    console.log(`Remote branch ${REMOTE}/${branch} is already absent.`);
+    return;
+  }
+  if (probe.status !== 0) {
+    throw new Error(`Unable to inspect ${REMOTE}/${branch}: ${(probe.stderr || probe.stdout).trim()}`);
+  }
+  run("git", ["push", REMOTE, "--delete", branch], { cwd: root });
+  console.log(`Deleted remote branch ${REMOTE}/${branch}.`);
+}
+
+function removeLocalBranch(pr, prWorktree, root) {
+  if (prWorktree) {
+    run("git", ["worktree", "remove", prWorktree.path], { cwd: root });
+    console.log(`Removed worktree ${prWorktree.path}.`);
+  }
+
+  const localRef = run("git", ["show-ref", "--quiet", "--verify", `refs/heads/${pr.headRefName}`], {
+    cwd: root,
+    allowFailure: true,
+  });
+  if (localRef.status === 0) {
+    run("git", ["branch", "-D", pr.headRefName], { cwd: root });
+    console.log(`Deleted local branch ${pr.headRefName}.`);
+  } else if (localRef.status !== 1) {
+    throw new Error(`Unable to inspect local branch ${pr.headRefName}: ${localRef.stderr.trim()}`);
+  }
+}
+
+function printHelp() {
+  process.stdout.write(
+    [
+      "Usage: node tools/pr-merge.mjs <PR-number-or-url>",
+      "",
+      "From the local main worktree: merge the PR after required checks pass, delete its",
+      "origin branch, remove its clean local worktree/branch, and fast-forward local main.",
+      "This helper never pulls the private harness ledger repository.",
+    ].join("\n"),
+  );
+  process.stdout.write("\n");
+}
+
+function main(argv) {
+  if (argv.includes("--help") || argv.includes("-h")) {
+    printHelp();
+    return;
+  }
+  if (argv.length !== 1 || argv[0].startsWith("-")) {
+    throw new Error("Provide exactly one PR number or URL. Run with --help for usage.");
+  }
+
+  const { mainWorktree, pr, prWorktree } = preflight(argv[0]);
+  console.log(`Finalizing PR #${pr.number} (${pr.headRefName} -> ${MAIN_BRANCH}).`);
+  if (pr.state === "OPEN") mergeOpenPr(pr, mainWorktree.path);
+  else console.log(`PR #${pr.number} is already merged; continuing with cleanup.`);
+
+  deleteRemoteBranch(pr.headRefName, mainWorktree.path);
+  removeLocalBranch(pr, prWorktree, mainWorktree.path);
+  run("git", ["checkout", MAIN_BRANCH], { cwd: mainWorktree.path });
+  run("git", ["pull", "--ff-only", REMOTE, MAIN_BRANCH], { cwd: mainWorktree.path });
+  const head = output("git", ["rev-parse", "HEAD"], { cwd: mainWorktree.path });
+  console.log(`Local ${MAIN_BRANCH} synchronized to ${head}.`);
+  console.log("Private harness ledger was not pulled; use the daemon-stop procedure if it needs separate maintenance.");
+}
+
+try {
+  main(process.argv.slice(2));
+} catch (error) {
+  process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+  process.exitCode = 1;
+}

--- a/tools/pr-merge.test.mjs
+++ b/tools/pr-merge.test.mjs
@@ -1,0 +1,153 @@
+// harness-test-tier: fast
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const helper = fileURLToPath(new URL("./pr-merge.mjs", import.meta.url));
+
+function run(command, args, { cwd, env, allowFailure = false } = {}) {
+  const result = spawnSync(command, args, { cwd, env, encoding: "utf8" });
+  if (!allowFailure && result.status !== 0) {
+    assert.fail(`${command} ${args.join(" ")} failed:\n${result.stderr || result.stdout}`);
+  }
+  return result;
+}
+
+function git(cwd, ...args) {
+  return run("git", args, { cwd }).stdout.trim();
+}
+
+function makeFakeGh(root) {
+  const bin = path.join(root, "bin");
+  const gh = path.join(bin, "gh");
+  mkdirSync(bin);
+  writeFileSync(
+    gh,
+    `#!/usr/bin/env node
+import { readFileSync, writeFileSync } from "node:fs";
+const args = process.argv.slice(2);
+const statePath = process.env.PR_STATE_PATH;
+const data = JSON.parse(readFileSync(statePath, "utf8"));
+if (args[0] === "pr" && args[1] === "view") {
+  process.stdout.write(JSON.stringify(data));
+} else if (args[0] === "pr" && args[1] === "checks") {
+  if (!args.includes("--required")) process.exit(3);
+  process.stdout.write("required-checks pass\\n");
+} else if (args[0] === "pr" && args[1] === "merge") {
+  const expected = ["--merge", "--admin", "--match-head-commit", data.headRefOid];
+  if (!expected.every((token) => args.includes(token))) process.exit(4);
+  data.state = "MERGED";
+  writeFileSync(statePath, JSON.stringify(data));
+  process.stdout.write("merged by fake gh\\n");
+} else {
+  process.stderr.write(\`unexpected gh args: \${args.join(" ")}\\n\`);
+  process.exit(2);
+}
+`,
+  );
+  chmodSync(gh, 0o755);
+  return bin;
+}
+
+function fixture(t) {
+  const root = mkdtempSync(path.join(tmpdir(), "pr-merge-test-"));
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  const remote = path.join(root, "origin.git");
+  const seed = path.join(root, "seed");
+  const main = path.join(root, "main");
+  const prWorktree = path.join(root, "pr-worktree");
+  const statePath = path.join(root, "pr-state.json");
+
+  git(root, "init", "--bare", "--initial-branch=main", remote);
+  git(root, "init", "--initial-branch=main", seed);
+  git(seed, "config", "user.name", "PR Merge Test");
+  git(seed, "config", "user.email", "pr-merge@example.test");
+  writeFileSync(path.join(seed, "base.txt"), "base\n");
+  git(seed, "add", "base.txt");
+  git(seed, "commit", "-m", "base");
+  git(seed, "remote", "add", "origin", remote);
+  git(seed, "push", "-u", "origin", "main");
+  git(root, "clone", remote, main);
+
+  git(seed, "checkout", "-b", "codex/pr-123");
+  writeFileSync(path.join(seed, "feature.txt"), "feature\n");
+  git(seed, "add", "feature.txt");
+  git(seed, "commit", "-m", "feature");
+  const headRefOid = git(seed, "rev-parse", "HEAD");
+  git(seed, "push", "-u", "origin", "codex/pr-123");
+  git(seed, "checkout", "main");
+  writeFileSync(path.join(seed, "base.txt"), "base\nupstream\n");
+  git(seed, "add", "base.txt");
+  git(seed, "commit", "-m", "upstream");
+  const upstreamHead = git(seed, "rev-parse", "HEAD");
+  git(seed, "push", "origin", "main");
+
+  git(main, "fetch", "origin", "codex/pr-123");
+  git(main, "branch", "codex/pr-123", "origin/codex/pr-123");
+  git(main, "worktree", "add", prWorktree, "codex/pr-123");
+  writeFileSync(
+    statePath,
+    JSON.stringify({
+      number: 123,
+      state: "OPEN",
+      isDraft: false,
+      baseRefName: "main",
+      headRefName: "codex/pr-123",
+      headRefOid,
+      isCrossRepository: false,
+      mergeable: "MERGEABLE",
+      url: "https://example.test/pull/123",
+    }),
+  );
+
+  const fakeBin = makeFakeGh(root);
+  const env = {
+    ...process.env,
+    PATH: `${fakeBin}${path.delimiter}${process.env.PATH}`,
+    PR_STATE_PATH: statePath,
+    HARNESS_TASK_BOUND: "",
+    HARNESS_ACTOR: "",
+    HARNESS_CANONICAL_ROOT: "",
+  };
+  return { env, headRefOid, main, prWorktree, remote, statePath, upstreamHead };
+}
+
+test("merges, cleans the PR branch and worktree, and fast-forwards local main", (t) => {
+  const setup = fixture(t);
+  const initialHead = git(setup.main, "rev-parse", "HEAD");
+  assert.notEqual(initialHead, setup.upstreamHead);
+
+  const result = run(process.execPath, [helper, "123"], { cwd: setup.main, env: setup.env });
+
+  assert.match(result.stdout, /required-checks pass/u);
+  assert.match(result.stdout, /Local main synchronized/u);
+  assert.equal(git(setup.main, "rev-parse", "HEAD"), setup.upstreamHead);
+  assert.equal(git(setup.main, "branch", "--show-current"), "main");
+  assert.equal(existsSync(setup.prWorktree), false);
+  assert.equal(git(setup.main, "branch", "--list", "codex/pr-123"), "");
+  assert.equal(git(setup.main, "ls-remote", "--heads", "origin", "refs/heads/codex/pr-123"), "");
+  assert.equal(JSON.parse(readFileSync(setup.statePath, "utf8")).state, "MERGED");
+});
+
+test("refuses a dirty main before merge or cleanup", (t) => {
+  const setup = fixture(t);
+  writeFileSync(path.join(setup.main, "dirty.txt"), "do not discard\n");
+  const initialHead = git(setup.main, "rev-parse", "HEAD");
+
+  const result = run(process.execPath, [helper, "123"], {
+    cwd: setup.main,
+    env: setup.env,
+    allowFailure: true,
+  });
+
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /main worktree is dirty/u);
+  assert.equal(git(setup.main, "rev-parse", "HEAD"), initialHead);
+  assert.equal(existsSync(setup.prWorktree), true);
+  assert.notEqual(git(setup.main, "ls-remote", "--heads", "origin", "refs/heads/codex/pr-123"), "");
+  assert.equal(JSON.parse(readFileSync(setup.statePath, "utf8")).state, "OPEN");
+});


### PR DESCRIPTION
# English

## Summary

Automates repo-governance rule 8 ("after merge: delete the remote PR branch, clean the local worktree/branch, and sync local main") into a single CEO command, `node tools/pr-merge.mjs <PR#-or-URL>`. Rule 8 was a manual step with no signal when skipped; on 2026-08-30 a skipped sync left the local `main` worktree 49 commits behind `origin/main`, which caused a wrong architecture diagnosis (a schedule schema was read from stale local source).

## Architectural Justification

- No existing tool carried the post-merge sequence; `tools/pr-doctor.mjs` diagnoses PR readiness but does not merge/cleanup/sync. A new single-entry helper is the smallest thing that makes rule 8 unskippable.
- Nothing obsolete is removed because the prior state was "a manual prose step", not code.
- Scope cannot be narrowed further: the helper deliberately bundles merge + branch-delete + worktree-clean + ff-only local-main pull, because splitting them is what allowed the step to be forgotten.

## What Changed

- `tools/pr-merge.mjs`: from the local `main` worktree, validates target=main, non-draft, mergeable, required checks green, head SHA unchanged, then admin-merges an open PR (skips if already merged); deletes `origin/<branch>`, removes the clean matching worktree + local branch, `git checkout main`, `git pull --ff-only origin main`, prints synced HEAD.
- Safety: refuses on a dirty main/PR worktree, on forks, non-main targets, non-mergeable PRs, or non-green required checks; the pull is ff-only (never local merge/rebase, never force-update main); **never pulls the private `harness/` ledger repo** (that stays behind the daemon-stop procedure).
- `tools/pr-merge.test.mjs`: stale-main synchronization + dirty-tree rejection (2/2).
- repo-governance rule 8 updated to point at the helper (private harness ledger, committed via the prose channel).

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
Production-Delta: +211/-0

## Task And Scope

- Harness task: task_36ed7ea43313259fbe324fe52a (PLT-Ontology milestone child)
- Branch: codex/post-merge-local-main-autosync
- Public scope: tools/pr-merge.mjs + tools/pr-merge.test.mjs
- Private planning/evidence updated: yes (repo-governance-standard.md rule 8)
- Out of scope: harness/ ledger auto-sync (explicitly excluded by red line)

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: not applicable
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no

## Verification

- Base `origin/main` SHA: 6ec510ea539d2abd8b075c5b5a994c45ff91bb85
- Branch merge-base with `origin/main`: 6ec510ea539d2abd8b075c5b5a994c45ff91bb85
- Last `git fetch origin` time: 2026-08-30 (this session)
- Sync method: none needed (branch based directly on current origin/main)
- Public diff command: `git show c23630199ae8a05cd314433f1db3063c9048a6af`
- Worker-run targeted tests: `tools/pr-merge.test.mjs` 2/2 (stale-main sync, dirty-tree rejection); ESLint, Prettier, `git show --check` passed.
- Not run: full `npm run check:local` — per task constraint (concurrent workers exhaust the fork pool on one machine); GitHub Actions `rewrite-ci` is the authority.

## Review Evidence

- Self-review: CEO read the full diff; confirmed the ff-only pull, the dirty-tree refusal, the protected-main guard, and the explicit "never pull the harness/ ledger" boundary (the reviewer reject condition in the task plan).
- Reviewer subagent: pending (CI + optional Codex connector review)
- Human review: CEO semantic acceptance passed (matches rule 8 exactly, red line honored)
- Blocking findings: none

## Residual Risk

- The helper references `main`-worktree topology; if a repo uses a non-standard worktree layout the operator runs the documented manual steps instead. Low risk for this repo's fixed CEO workflow.

## References

- Task: task_36ed7ea43313259fbe324fe52a
- Evidence: fact F-B0642CEA (worker), CEO diff review this session
- Review: CEO semantic acceptance (this session)

---

# 中文

## 摘要

把 repo-governance 第 8 条("合并后:删除远端 PR 分支、清理本地 worktree/branch、同步本地 main")自动化为一条 CEO 命令 `node tools/pr-merge.mjs <PR号或URL>`。第 8 条原是手动步骤,漏做没有任何信号;2026-08-30 一次漏同步致本地 `main` 工作树落后 `origin/main` 49 提交,进而读到 stale 的本地 schedule schema 源码、做出错误的架构判断。

## 架构辩护

- 现有工具没有承载合并后序列:`tools/pr-doctor.mjs` 只诊断 PR 就绪度,不做合并/清理/同步。新建单一入口 helper 是让第 8 条不可漏做的最小改动。
- 无过时代码删除,因为原状态是"一条手动散文步骤"而非代码。
- 范围无法再收窄:helper 刻意把 合并+删分支+清 worktree+ff-only pull 本地 main 打包,因为拆开正是它被遗忘的原因。

## 改了什么

- `tools/pr-merge.mjs`:从本地 `main` 工作树,校验 target=main、非 draft、可合并、必需 checks 全绿、head SHA 未变,然后 admin-merge 仍 open 的 PR(已合并则跳过);删 `origin/<分支>`、移除干净的匹配 worktree + 本地分支、`git checkout main`、`git pull --ff-only origin main`、打印同步 HEAD。
- 安全:main/PR worktree 脏、fork、非 main target、不可合并、必需 checks 非绿时拒绝;pull 为 ff-only(绝不本地 merge/rebase、绝不 force-update main);**绝不 pull 私有 `harness/` 台账仓**(仍走 daemon-stop 流程)。
- `tools/pr-merge.test.mjs`:stale-main 同步 + 脏树拒绝(2/2)。
- repo-governance 第 8 条更新指向该 helper(私有 harness 台账,经 prose channel 提交)。

## 任务与范围

- Harness 任务:task_36ed7ea43313259fbe324fe52a(PLT-Ontology 里程碑子任务)
- 分支:codex/post-merge-local-main-autosync
- 公开范围:tools/pr-merge.mjs + tools/pr-merge.test.mjs
- 私有规划/证据已更新:是(repo-governance-standard.md 第 8 条)
- 范围外:harness/ 台账自动同步(红线明确排除)

## 治理声明

- 触碰 protected surface:否
- 范围:不适用
- 授权:不适用
- Break-glass:否

## 验证

- Base `origin/main` SHA:6ec510ea539d2abd8b075c5b5a994c45ff91bb85
- 与 `origin/main` 的 merge-base:6ec510ea539d2abd8b075c5b5a994c45ff91bb85
- 最近 `git fetch origin`:2026-08-30(本会话)
- Sync 方式:无需(分支直接基于当前 origin/main)
- 公开 diff:`git show c23630199ae8a05cd314433f1db3063c9048a6af`
- Worker 定向测试:`tools/pr-merge.test.mjs` 2/2(stale-main 同步、脏树拒绝);ESLint、Prettier、`git show --check` 过。
- 未跑:完整 `npm run check:local`——按任务约束(同机并发 worker 耗尽 fork 池);以 GitHub Actions `rewrite-ci` 为权威。

## 复核证据

- 自审:CEO 通读全 diff;确认 ff-only pull、脏树拒绝、protected-main 守卫、以及明确的"绝不 pull harness/ 台账"边界(任务 plan 里的 reviewer 拒收条件)。
- Reviewer subagent:待定(CI + 可选 Codex connector 复核)
- 人工复核:CEO 语义验收通过(与第 8 条完全一致、红线守住)
- 阻塞发现:无

## 残余风险

- helper 依赖 `main` 工作树拓扑;若某仓用非标准 worktree 布局,操作者改走文档化的手动步骤。对本仓固定的 CEO 工作流风险低。

## 引用

- 任务:task_36ed7ea43313259fbe324fe52a
- 证据:fact F-B0642CEA(worker)、CEO 本会话 diff 复核
- 复核:CEO 语义验收(本会话)
