### PR TITLE
fix(schedule): allow invalid projections to self-heal

### DIFF
--- a/packages/cli/src/cli/thin-command-schedule.ts
+++ b/packages/cli/src/cli/thin-command-schedule.ts
@@ -164,6 +164,7 @@ export function renderScheduleList(receipt: Record<string, unknown>): string | n
   if (schedules.length === 0) return "No schedules.";
   return schedules
     .map((row) => {
+      if (row.state === "invalid") return [row.scheduleId, row.state, row.invalidReason].join("\t");
       return [row.scheduleId, row.state, row.nextRunAt ?? "none", row.status.activeRun ? "active" : "idle"]
         .map(String)
         .join("\t");

--- a/packages/cli/test/schedule-command.test.ts
+++ b/packages/cli/test/schedule-command.test.ts
@@ -227,6 +227,7 @@ test("Schedule show, update, and delete expose closed structured packet inputs",
       });
   }
   assert.equal(parseThinCommand(["schedule", "update", "probe", "--from-file", "update.json"]).ok, false);
+  assert.equal(parseThinCommand(["schedule", "update", "probe", "--mode", "observe"]).ok, false);
 });
 
 test("Schedule show human renderer returns the complete schedule snapshot", () => {
@@ -291,10 +292,16 @@ test("Schedule list human renderer shows state, next occurrence, and single-flig
             nextRunAt: "2026-08-26T14:00:00.000Z",
           },
           { ...paused, definitionRevision: 2, nextRunAt: null },
+          {
+            scheduleId: "legacy",
+            state: "invalid",
+            invalidReason: 'schedule is missing required field "mode".',
+            definitionRevision: 3,
+          },
         ],
       }),
     }),
-    "armed\tarmed\t2026-08-26T14:00:00.000Z\tactive\npaused\tpaused\tnone\tidle",
+    'armed\tarmed\t2026-08-26T14:00:00.000Z\tactive\npaused\tpaused\tnone\tidle\nlegacy\tinvalid\tschedule is missing required field "mode".',
   );
   assert.equal(
     renderScheduleList({

--- a/packages/daemon/src/protocol/daemon-protocol-validate-results.ts
+++ b/packages/daemon/src/protocol/daemon-protocol-validate-results.ts
@@ -27,7 +27,7 @@ import {
 import { receiptOutcomeWords } from "./daemon-protocol-vocabulary.ts";
 import { isJsonObject, type JsonObject } from "./json-rpc-types.ts";
 
-export type ScheduleListRow = {
+export type ValidScheduleListRow = {
   readonly scheduleId: string;
   readonly state: "armed" | "paused";
   readonly mode: "detect" | "remediate";
@@ -47,6 +47,15 @@ export type ScheduleListRow = {
   readonly definitionRevision: number;
   readonly nextRunAt: string | null;
 };
+
+export type InvalidScheduleListRow = {
+  readonly scheduleId: string;
+  readonly state: "invalid";
+  readonly invalidReason: string;
+  readonly definitionRevision: number;
+};
+
+export type ScheduleListRow = ValidScheduleListRow | InvalidScheduleListRow;
 
 export function parseScheduleListReceipt(
   receipt: Readonly<Record<string, unknown>>,
@@ -105,6 +114,15 @@ export function daemonCommandReceiptRejectionCode(receipt: Readonly<Record<strin
 }
 
 function scheduleListRow(value: unknown): value is ScheduleListRow {
+  if (
+    exactRecord(value, ["scheduleId", "state", "invalidReason", "definitionRevision"]) &&
+    nonEmpty(value.scheduleId) &&
+    value.state === "invalid" &&
+    nonEmpty(value.invalidReason) &&
+    integer(value.definitionRevision) &&
+    Number(value.definitionRevision) >= 0
+  )
+    return true;
   if (!isJsonObject(value) || !isJsonObject(value.spec) || !isJsonObject(value.status)) return false;
   const trigger = value.spec.trigger,
     target = value.spec.target;

--- a/packages/daemon/src/protocol/schedules-gui-contract.ts
+++ b/packages/daemon/src/protocol/schedules-gui-contract.ts
@@ -107,6 +107,15 @@ export interface ScheduleGuiRowDto {
   readonly updatedAt: string;
 }
 
+export interface ScheduleGuiInvalidRowDto {
+  readonly scheduleId: string;
+  readonly state: "invalid";
+  readonly invalidReason: string;
+  readonly definitionRevision: number;
+}
+
+export type ScheduleGuiListRowDto = ScheduleGuiRowDto | ScheduleGuiInvalidRowDto;
+
 export interface SchedulesListResult {
   readonly ok: true;
   readonly status: "ready" | "pending";
@@ -115,7 +124,7 @@ export interface SchedulesListResult {
   readonly viewerNodeId: string | null;
   readonly actions: { readonly create: ScheduleGuiActionFacet };
   readonly options: ScheduleGuiOptionsDto;
-  readonly schedules: readonly ScheduleGuiRowDto[];
+  readonly schedules: readonly ScheduleGuiListRowDto[];
   readonly watermark: number;
   readonly sourceRevision: number;
 }
@@ -284,6 +293,16 @@ export function validateSchedulesList(value: unknown): readonly string[] {
   const secretErrors = rejectSecretKeys(value);
   if (secretErrors.length) return secretErrors;
   for (const row of value.schedules) {
+    if (
+      isJsonObject(row) &&
+      Object.keys(row).length === 4 &&
+      scheduleNonEmptyText(row.scheduleId) &&
+      row.state === "invalid" &&
+      scheduleNonEmptyText(row.invalidReason) &&
+      Number.isSafeInteger(row.definitionRevision) &&
+      Number(row.definitionRevision) >= 0
+    )
+      continue;
     if (
       !isJsonObject(row) ||
       Object.keys(row).some(

--- a/packages/daemon/src/repo-cell-schedule-actions.ts
+++ b/packages/daemon/src/repo-cell-schedule-actions.ts
@@ -9,13 +9,8 @@ import {
   scheduleMissedReasons,
   scheduleRunOutcomes,
   timestamp,
-  updateScheduleV1,
-  validateScheduleV1,
   type ScheduleMissedReason,
-  type ScheduleMode,
   type ScheduleRunOutcome,
-  type ScheduleTargetV1,
-  type ScheduleTriggerV1,
   type ScheduleV1,
   type WriteReceipt,
 } from "../../kernel/src/index.ts";
@@ -33,6 +28,12 @@ import type { TrustedScheduleSpawn } from "./runtime-spawn.ts";
 import { readScheduleRuns } from "./schedule-runs-read.ts";
 import type { RepoCellRuntimeContext, RepoCellScheduleActions } from "./repo-cell-action-context.ts";
 import type { JsonObject } from "./protocol/json-rpc-types.ts";
+import {
+  inspectScheduleProjection,
+  mergeProjectedScheduleUpdate,
+  requiredScheduleMode,
+  scheduleTriggerFromCreate,
+} from "./schedule-projection.ts";
 
 type ScheduleClaimKind = "scheduled" | "manual";
 export type ScheduleClaimInput = {
@@ -86,10 +87,6 @@ function isScheduleSpawnWriteReceipt(value: JsonObject): value is JsonObject & S
     (value.dispatchId === undefined || typeof value.dispatchId === "string") &&
     (value.runtimeSessionId === undefined || typeof value.runtimeSessionId === "string")
   );
-}
-
-function isProjectedSchedule(value: unknown): value is ScheduleV1 {
-  return validateScheduleV1(value).length === 0;
 }
 
 const schedulePacketContracts: Readonly<Record<string, PacketActionContract>> = Object.freeze({
@@ -200,12 +197,19 @@ export async function dispatchClaimedSchedule<
 }
 
 export function makeRepoCellScheduleActions(cell: RepoCellRuntimeContext): RepoCellScheduleActions {
-  const read = (scheduleId: string): { readonly schedule: ScheduleV1; readonly revision: number } => {
+  const inspect = (scheduleId: string) => {
     const row = cell.projection.getEntity("schedule", scheduleId);
     if (!row) throw cell.cellCodedError("entity_not_found", `Schedule ${scheduleId} does not exist.`);
-    if (!isProjectedSchedule(row.value))
-      throw cell.cellCodedError("invalid_store", `Schedule ${scheduleId} projection is invalid.`);
-    return { schedule: row.value, revision: row.workspaceRevision };
+    return inspectScheduleProjection(row);
+  };
+  const read = (scheduleId: string): { readonly schedule: ScheduleV1; readonly revision: number } => {
+    const projection = inspect(scheduleId);
+    if (!projection.valid)
+      throw cell.cellCodedError(
+        "invalid_store",
+        `Schedule ${scheduleId} projection is invalid: ${projection.invalid.invalidReason}`,
+      );
+    return { schedule: projection.schedule, revision: projection.revision };
   };
   const replay = (action: RepoTaskAction, binding: RepoCellBinding): WriteReceipt | null => {
     const opId = cell.operationId(action, binding, cell.input.repoId, 0),
@@ -542,11 +546,11 @@ export function makeRepoCellScheduleActions(cell: RepoCellRuntimeContext): RepoC
             binding.assignmentScope?.scope.kind === "schedule" ? binding.assignmentScope.scope.scheduleId : null,
           schedules = cell.projection
             .listEntities("schedule")
-            .filter((row) => assignmentScheduleId === null || row.value.scheduleId === assignmentScheduleId)
+            .filter((row) => assignmentScheduleId === null || row.id === assignmentScheduleId)
             .map((row) => {
-              if (!isProjectedSchedule(row.value))
-                throw cell.cellCodedError("invalid_store", "Schedule projection contains an invalid row.");
-              const schedule = row.value;
+              const projection = inspectScheduleProjection(row);
+              if (!projection.valid) return projection.invalid;
+              const schedule = projection.schedule;
               return {
                 ...schedule,
                 definitionRevision: row.workspaceRevision,
@@ -600,7 +604,20 @@ export function makeRepoCellScheduleActions(cell: RepoCellRuntimeContext): RepoC
             ? action.idempotencyKey
             : `${action.kind}:${scheduleId}:${cell.store.readHead()?.revision ?? 0}`;
       if (action.kind === "schedule-show") {
-        const { schedule, revision } = read(scheduleId);
+        const projection = inspect(scheduleId);
+        if (!projection.valid)
+          return {
+            outcome: "applied",
+            opId: cell.operationId(action, binding, cell.input.repoId, projection.revision),
+            revision: projection.revision,
+            evidence: `schedule:${scheduleId}:${projection.revision}:invalid`,
+            schedule: projection.invalid,
+            scheduleId,
+            definitionRevision: projection.revision,
+            nextRunAt: null,
+            summary: `Schedule ${scheduleId} is invalid: ${projection.invalid.invalidReason}`,
+          } as WriteReceipt;
+        const { schedule, revision } = projection;
         return {
           outcome: "applied",
           opId: cell.operationId(action, binding, cell.input.repoId, revision),
@@ -661,66 +678,41 @@ export function makeRepoCellScheduleActions(cell: RepoCellRuntimeContext): RepoC
         ];
         if (!fields.some((field) => Object.hasOwn(action, field)))
           throw cell.cellCodedError("invalid_command", "Schedule update requires at least one definition field.");
-        const { schedule, revision } = read(scheduleId),
+        const projection = inspect(scheduleId),
           occurredAt = cell.now(),
-          trigger = scheduleTriggerFromUpdate(action, schedule.spec.trigger, occurredAt),
-          optionalTarget = (field: "model" | "reasoningEffort" | "cwd"): string | undefined =>
-            Object.hasOwn(action, field)
-              ? action[field] === null
-                ? undefined
-                : cell.requiredCellText(action[field], field)
-              : schedule.spec.target.kind === "agent"
-                ? schedule.spec.target[field]
-                : undefined,
-          target: ScheduleTargetV1 =
-            schedule.spec.target.kind === "agent" ||
-            Object.hasOwn(action, "agentId") ||
-            Object.hasOwn(action, "runtimeInstanceId")
-              ? {
-                  kind: "agent",
-                  agentId: Object.hasOwn(action, "agentId")
-                    ? cell.requiredCellText(action.agentId, "agentId")
-                    : schedule.spec.target.kind === "agent"
-                      ? schedule.spec.target.agentId
-                      : cell.requiredCellText(undefined, "agentId"),
-                  runtimeInstanceId: Object.hasOwn(action, "runtimeInstanceId")
-                    ? cell.requiredCellText(action.runtimeInstanceId, "runtimeInstanceId")
-                    : schedule.spec.target.kind === "agent"
-                      ? schedule.spec.target.runtimeInstanceId
-                      : cell.requiredCellText(undefined, "runtimeInstanceId"),
-                  ...(optionalTarget("model") ? { model: optionalTarget("model") } : {}),
-                  ...(optionalTarget("reasoningEffort") ? { reasoningEffort: optionalTarget("reasoningEffort") } : {}),
-                  ...(optionalTarget("cwd") ? { cwd: optionalTarget("cwd") } : {}),
-                }
-              : schedule.spec.target,
-          spec = {
-            trigger,
-            target,
-            mission: Object.hasOwn(action, "mission")
-              ? cell.requiredCellText(action.mission, "mission")
-              : schedule.spec.mission,
-          },
-          name = Object.hasOwn(action, "name") ? cell.requiredCellText(action.name, "name") : schedule.name,
-          mode = Object.hasOwn(action, "mode") ? requiredScheduleMode(action.mode) : schedule.mode;
+          merged = mergeProjectedScheduleUpdate({
+            value: projection.valid
+              ? (projection.schedule as unknown as Readonly<Record<string, unknown>>)
+              : projection.value,
+            action,
+            occurredAt,
+            requiredText: cell.requiredCellText,
+          });
+        if (!merged.schedule)
+          throw cell.cellCodedError(
+            "invalid_store",
+            `Schedule ${scheduleId} update remains invalid: ${merged.errors.join("; ")}`,
+          );
+        const schedule = merged.schedule,
+          revision = projection.revision;
         if (
-          JSON.stringify({ name, mode, spec }) ===
-          JSON.stringify({ name: schedule.name, mode: schedule.mode, spec: schedule.spec })
+          projection.valid &&
+          JSON.stringify({ name: schedule.name, mode: schedule.mode, spec: schedule.spec }) ===
+            JSON.stringify({
+              name: projection.schedule.name,
+              mode: projection.schedule.mode,
+              spec: projection.schedule.spec,
+            })
         )
           return {
             outcome: "no_changes",
             opId: cell.operationId(updateAction, binding, cell.input.repoId, 0),
             revision,
             evidence: `schedule:${scheduleId}:unchanged`,
-            schedule,
+            schedule: projection.schedule,
             scheduleId,
           } as WriteReceipt;
-        return publish(
-          updateAction,
-          binding,
-          updateScheduleV1({ schedule, name, mode, spec, occurredAt }),
-          "schedule_updated",
-          { expectedRevision: revision },
-        );
+        return publish(updateAction, binding, schedule, "schedule_updated", { expectedRevision: revision });
       }
       if (action.kind === "schedule-delete") {
         const deleteAction = { ...action, idempotencyKey },
@@ -843,51 +835,4 @@ export function makeRepoCellScheduleActions(cell: RepoCellRuntimeContext): RepoC
 function requiredDeletionBase(value: string | undefined): string {
   if (typeof value === "string" && /^[0-9a-f]{64}$/u.test(value)) return value;
   throw new Error("Schedule deletion requires the current declaration document hash.");
-}
-
-function requiredScheduleMode(value: unknown): ScheduleMode {
-  if (value === "detect" || value === "remediate") return value;
-  throw Object.assign(new Error("Schedule mode must be detect or remediate."), { code: "invalid_command" });
-}
-
-function scheduleTriggerFromCreate(action: RepoTaskAction, occurredAt: string): ScheduleTriggerV1 {
-  if (Object.hasOwn(action, "everyMs") === Object.hasOwn(action, "cronExpression"))
-    throw Object.assign(new Error("Schedule creation requires exactly one interval or cron trigger."), {
-      code: "invalid_command",
-    });
-  return Object.hasOwn(action, "everyMs")
-    ? { kind: "interval", everyMs: Number(action.everyMs), anchorAt: occurredAt }
-    : {
-        kind: "cron",
-        expression: String(action.cronExpression),
-        timezone: String(action.timezone),
-      };
-}
-
-function scheduleTriggerFromUpdate(
-  action: RepoTaskAction,
-  current: ScheduleTriggerV1,
-  occurredAt: string,
-): ScheduleTriggerV1 {
-  if (
-    Object.hasOwn(action, "everyMs") &&
-    (Object.hasOwn(action, "cronExpression") || Object.hasOwn(action, "timezone"))
-  )
-    throw Object.assign(new Error("Schedule update cannot combine interval and cron trigger fields."), {
-      code: "invalid_command",
-    });
-  if (Object.hasOwn(action, "everyMs"))
-    return { kind: "interval", everyMs: Number(action.everyMs), anchorAt: occurredAt };
-  if (Object.hasOwn(action, "cronExpression"))
-    return {
-      kind: "cron",
-      expression: String(action.cronExpression),
-      timezone: String(action.timezone),
-    };
-  if (Object.hasOwn(action, "timezone")) {
-    if (current.kind !== "cron")
-      throw Object.assign(new Error("Schedule timezone can only update a cron trigger."), { code: "invalid_command" });
-    return { ...current, timezone: String(action.timezone) };
-  }
-  return current;
 }

--- a/packages/daemon/src/schedule-projection.ts
+++ b/packages/daemon/src/schedule-projection.ts
@@ -58,8 +58,8 @@ export function mergeProjectedScheduleUpdate(input: {
   readonly requiredText: (value: unknown, name: string) => string;
 }): { readonly schedule: ScheduleV1 | null; readonly errors: readonly string[] } {
   const { value, action, occurredAt, requiredText } = input,
-    currentSpec = record(value.spec),
-    currentTarget = record(currentSpec?.target),
+    currentSpec = asRecord(value.spec),
+    currentTarget = asRecord(currentSpec?.target),
     trigger = scheduleTriggerFromUpdate(action, currentSpec?.trigger, occurredAt),
     optionalTarget = (field: "model" | "reasoningEffort" | "cwd"): string | undefined =>
       Object.hasOwn(action, field)
@@ -145,7 +145,7 @@ function scheduleTriggerFromUpdate(
       timezone: String(action.timezone),
     };
   if (Object.hasOwn(action, "timezone")) {
-    const currentTrigger = record(current);
+    const currentTrigger = asRecord(current);
     if (currentTrigger?.kind !== "cron")
       throw Object.assign(new Error("Schedule timezone can only update a cron trigger."), { code: "invalid_command" });
     return { ...currentTrigger, timezone: String(action.timezone) };
@@ -153,7 +153,7 @@ function scheduleTriggerFromUpdate(
   return current;
 }
 
-function record(value: unknown): Readonly<Record<string, unknown>> | null {
+function asRecord(value: unknown): Readonly<Record<string, unknown>> | null {
   return typeof value === "object" && value !== null && !Array.isArray(value)
     ? (value as Readonly<Record<string, unknown>>)
     : null;

--- a/packages/daemon/src/schedule-projection.ts
+++ b/packages/daemon/src/schedule-projection.ts
@@ -1,0 +1,160 @@
+import {
+  validateScheduleV1,
+  type ScheduleMode,
+  type ScheduleTriggerV1,
+  type ScheduleV1,
+} from "../../kernel/src/index.ts";
+import type { RepoTaskAction } from "./repo-cell-types.ts";
+
+type ProjectedScheduleRow = {
+  readonly id: string;
+  readonly workspaceRevision: number;
+  readonly value: Readonly<Record<string, unknown>>;
+};
+
+export type InvalidScheduleProjection = {
+  readonly scheduleId: string;
+  readonly state: "invalid";
+  readonly invalidReason: string;
+  readonly definitionRevision: number;
+};
+
+export type InspectedScheduleProjection =
+  | {
+      readonly valid: true;
+      readonly schedule: ScheduleV1;
+      readonly revision: number;
+    }
+  | {
+      readonly valid: false;
+      readonly value: Readonly<Record<string, unknown>>;
+      readonly revision: number;
+      readonly errors: readonly string[];
+      readonly invalid: InvalidScheduleProjection;
+    };
+
+export function inspectScheduleProjection(row: ProjectedScheduleRow): InspectedScheduleProjection {
+  const errors = validateScheduleV1(row.value);
+  if (errors.length === 0)
+    return { valid: true, schedule: row.value as unknown as ScheduleV1, revision: row.workspaceRevision };
+  return {
+    valid: false,
+    value: row.value,
+    revision: row.workspaceRevision,
+    errors,
+    invalid: {
+      scheduleId: row.id,
+      state: "invalid",
+      invalidReason: errors.join("; "),
+      definitionRevision: row.workspaceRevision,
+    },
+  };
+}
+
+export function mergeProjectedScheduleUpdate(input: {
+  readonly value: Readonly<Record<string, unknown>>;
+  readonly action: RepoTaskAction;
+  readonly occurredAt: string;
+  readonly requiredText: (value: unknown, name: string) => string;
+}): { readonly schedule: ScheduleV1 | null; readonly errors: readonly string[] } {
+  const { value, action, occurredAt, requiredText } = input,
+    currentSpec = record(value.spec),
+    currentTarget = record(currentSpec?.target),
+    trigger = scheduleTriggerFromUpdate(action, currentSpec?.trigger, occurredAt),
+    optionalTarget = (field: "model" | "reasoningEffort" | "cwd"): string | undefined =>
+      Object.hasOwn(action, field)
+        ? action[field] === null
+          ? undefined
+          : requiredText(action[field], field)
+        : currentTarget?.kind === "agent" && typeof currentTarget[field] === "string"
+          ? currentTarget[field]
+          : undefined,
+    model = optionalTarget("model"),
+    reasoningEffort = optionalTarget("reasoningEffort"),
+    cwd = optionalTarget("cwd"),
+    target: unknown =
+      currentTarget?.kind === "agent" || Object.hasOwn(action, "agentId") || Object.hasOwn(action, "runtimeInstanceId")
+        ? {
+            kind: "agent",
+            agentId: Object.hasOwn(action, "agentId")
+              ? requiredText(action.agentId, "agentId")
+              : currentTarget?.agentId,
+            runtimeInstanceId: Object.hasOwn(action, "runtimeInstanceId")
+              ? requiredText(action.runtimeInstanceId, "runtimeInstanceId")
+              : currentTarget?.runtimeInstanceId,
+            ...(model ? { model } : {}),
+            ...(reasoningEffort ? { reasoningEffort } : {}),
+            ...(cwd ? { cwd } : {}),
+          }
+        : currentSpec?.target,
+    candidate = {
+      ...value,
+      name: Object.hasOwn(action, "name") ? requiredText(action.name, "name").trim() : value.name,
+      mode: Object.hasOwn(action, "mode") ? requiredScheduleMode(action.mode) : value.mode,
+      spec: {
+        ...(currentSpec ?? {}),
+        trigger,
+        target,
+        mission: Object.hasOwn(action, "mission")
+          ? requiredText(action.mission, "mission").trim()
+          : currentSpec?.mission,
+      },
+      updatedAt: occurredAt,
+    },
+    errors = validateScheduleV1(candidate);
+  return errors.length === 0 ? { schedule: candidate as unknown as ScheduleV1, errors } : { schedule: null, errors };
+}
+
+export function requiredScheduleMode(value: unknown): ScheduleMode {
+  if (value === "detect" || value === "remediate") return value;
+  throw Object.assign(new Error("Schedule mode must be detect or remediate."), { code: "invalid_command" });
+}
+
+export function scheduleTriggerFromCreate(action: RepoTaskAction, occurredAt: string): ScheduleTriggerV1 {
+  if (Object.hasOwn(action, "everyMs") === Object.hasOwn(action, "cronExpression"))
+    throw Object.assign(new Error("Schedule creation requires exactly one interval or cron trigger."), {
+      code: "invalid_command",
+    });
+  return Object.hasOwn(action, "everyMs")
+    ? { kind: "interval", everyMs: Number(action.everyMs), anchorAt: occurredAt }
+    : {
+        kind: "cron",
+        expression: String(action.cronExpression),
+        timezone: String(action.timezone),
+      };
+}
+
+function scheduleTriggerFromUpdate(
+  action: RepoTaskAction,
+  current: unknown,
+  occurredAt: string,
+): ScheduleTriggerV1 | unknown {
+  if (
+    Object.hasOwn(action, "everyMs") &&
+    (Object.hasOwn(action, "cronExpression") || Object.hasOwn(action, "timezone"))
+  )
+    throw Object.assign(new Error("Schedule update cannot combine interval and cron trigger fields."), {
+      code: "invalid_command",
+    });
+  if (Object.hasOwn(action, "everyMs"))
+    return { kind: "interval", everyMs: Number(action.everyMs), anchorAt: occurredAt };
+  if (Object.hasOwn(action, "cronExpression"))
+    return {
+      kind: "cron",
+      expression: String(action.cronExpression),
+      timezone: String(action.timezone),
+    };
+  if (Object.hasOwn(action, "timezone")) {
+    const currentTrigger = record(current);
+    if (currentTrigger?.kind !== "cron")
+      throw Object.assign(new Error("Schedule timezone can only update a cron trigger."), { code: "invalid_command" });
+    return { ...currentTrigger, timezone: String(action.timezone) };
+  }
+  return current;
+}
+
+function record(value: unknown): Readonly<Record<string, unknown>> | null {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? (value as Readonly<Record<string, unknown>>)
+    : null;
+}

--- a/packages/daemon/src/schedule-scheduler.ts
+++ b/packages/daemon/src/schedule-scheduler.ts
@@ -247,6 +247,7 @@ function evaluateSchedule(
   schedule: ScheduleListRow,
   observedAt: string,
 ): { readonly due: DueOccurrence | null; readonly missed: MissedOccurrences | null } {
+  if (schedule.state === "invalid") return { due: null, missed: null };
   if (schedule.state !== "armed" || schedule.spec.target.kind !== "agent") return { due: null, missed: null };
   const cursor =
       Date.parse(schedule.updatedAt) > Date.parse(schedule.status.automaticEvaluatedThrough)

--- a/packages/daemon/src/schedules-gui-read.ts
+++ b/packages/daemon/src/schedules-gui-read.ts
@@ -1,6 +1,11 @@
 import { readFileSync } from "node:fs";
 import path from "node:path";
-import { nextScheduleOccurrence, type DaemonRepoMode, type ScheduleV1 } from "../../kernel/src/index.ts";
+import {
+  nextScheduleOccurrence,
+  validateScheduleV1,
+  type DaemonRepoMode,
+  type ScheduleV1,
+} from "../../kernel/src/index.ts";
 import type { AgentRuntimeInstanceDto } from "./agent-runtime-contract.ts";
 import { parseAgentDeclarationV1 } from "../../kernel/src/index.ts";
 import { readFleetEdgeConfig } from "./client/fleet-edge-config.ts";
@@ -10,6 +15,8 @@ import { commandDescriptorForAction } from "./protocol/daemon-protocol-commands.
 import type {
   ScheduleExecutionAvailability,
   ScheduleGuiActionFacet,
+  ScheduleGuiInvalidRowDto,
+  ScheduleGuiListRowDto,
   ScheduleGuiOptionsDto,
   ScheduleGuiRowDto,
   ScheduleGuiTriggerDto,
@@ -32,6 +39,7 @@ export interface SchedulesGuiReadContext {
   };
   readonly projection: {
     readonly listEntities: (entityKind: string) => readonly {
+      readonly id?: string;
       readonly value: unknown;
       readonly workspaceRevision: number;
     }[];
@@ -267,7 +275,9 @@ export function readSchedulesGui(context: SchedulesGuiReadContext): SchedulesLis
     cut = context.projection.readTaskStatuses();
   const schedules = context.projection
     .listEntities("schedule")
-    .map((row): ScheduleGuiRowDto => {
+    .map((row): ScheduleGuiListRowDto => {
+      const errors = validateScheduleV1(row.value);
+      if (errors.length > 0) return invalidScheduleGuiRow(row, errors);
       const schedule = row.value as ScheduleV1,
         active = activeRunDtoOf(schedule),
         availability = deriveScheduleExecutionAvailability({
@@ -351,7 +361,7 @@ export function readSchedulesGui(context: SchedulesGuiReadContext): SchedulesLis
 
 function scheduleOptions(
   context: SchedulesGuiReadContext,
-  schedules: readonly ScheduleGuiRowDto[],
+  schedules: readonly ScheduleGuiListRowDto[],
 ): ScheduleGuiOptionsDto {
   const agents = context.projection.listEntities("agent").map(({ value }) => {
       const agent = parseAgentDeclarationV1(value);
@@ -373,11 +383,29 @@ function scheduleOptions(
       })),
     cwd = new Set<string>([".", ...trackedDirectories(context.rootDir)]);
   for (const schedule of schedules)
-    if (schedule.target.kind === "agent" && schedule.target.cwd) cwd.add(schedule.target.cwd);
+    if (schedule.state !== "invalid" && schedule.target.kind === "agent" && schedule.target.cwd)
+      cwd.add(schedule.target.cwd);
   return {
     agents: agents.sort((left, right) => left.agentId.localeCompare(right.agentId)),
     instances: instances.sort((left, right) => left.instanceId.localeCompare(right.instanceId)),
     cwd: [...cwd].sort((left, right) => (left === "." ? -1 : right === "." ? 1 : left.localeCompare(right))),
+  };
+}
+
+function invalidScheduleGuiRow(
+  row: { readonly id?: string; readonly value: unknown; readonly workspaceRevision: number },
+  errors: readonly string[],
+): ScheduleGuiInvalidRowDto {
+  const value =
+      typeof row.value === "object" && row.value !== null && !Array.isArray(row.value)
+        ? (row.value as Readonly<Record<string, unknown>>)
+        : null,
+    scheduleId = row.id ?? (typeof value?.scheduleId === "string" && value.scheduleId ? value.scheduleId : "unknown");
+  return {
+    scheduleId,
+    state: "invalid",
+    invalidReason: errors.join("; "),
+    definitionRevision: row.workspaceRevision,
   };
 }
 

--- a/packages/daemon/test/schedule-invalid-projection.integration.test.ts
+++ b/packages/daemon/test/schedule-invalid-projection.integration.test.ts
@@ -1,0 +1,174 @@
+// harness-test-tier: integration
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import test from "node:test";
+import { canonicalRoot, workspaceId } from "../src/protocol/daemon-protocol.contract.ts";
+import { parseDaemonGuiReadResult } from "../src/protocol/gui-result-validation.ts";
+import type { RepoCell } from "../src/repo-cell.ts";
+import { openBootstrappedRepoCell as openRepoCell } from "./repo-settings.fixture.ts";
+
+const actor = { actor: { principal: { personId: "schedule-repair-test" }, executor: null }, source: "local" as const };
+
+test("a canonical Schedule row missing a newly required field stays readable and can repair itself", async () => {
+  const root = mkdtempSync(path.join(tmpdir(), "ha-schedule-invalid-projection-"));
+  let cell: RepoCell | undefined;
+  try {
+    initRepo(root);
+    cell = await open(root, "seed");
+    for (const scheduleId of ["legacy-probe", "healthy-probe"])
+      assert.equal(
+        (
+          await cell.run(
+            {
+              kind: "schedule-create",
+              scheduleId,
+              name: scheduleId,
+              mode: "detect",
+              everyMs: 300_000,
+              agentId: "probe-agent",
+              runtimeInstanceId: "runtime-local",
+              mission: `Run ${scheduleId}.`,
+              idempotencyKey: `seed:${scheduleId}`,
+            },
+            actor,
+          )
+        ).outcome,
+        "applied",
+      );
+    await cell.close();
+    cell = undefined;
+
+    removeProjectedAndAuthoredMode(root, "legacy-probe");
+    cell = await open(root, "repair");
+
+    const listed = (await cell.run({ kind: "schedule-list" }, actor)) as unknown as {
+        readonly outcome: string;
+        readonly schedules: readonly Record<string, unknown>[];
+      },
+      invalid = listed.schedules.find(({ scheduleId }) => scheduleId === "legacy-probe"),
+      healthy = listed.schedules.find(({ scheduleId }) => scheduleId === "healthy-probe");
+    assert.equal(listed.outcome, "applied");
+    assert.equal(invalid?.state, "invalid");
+    assert.match(String(invalid?.invalidReason), /missing required field "mode"/u);
+    assert.equal(healthy?.state, "armed");
+    assert.equal(healthy?.mode, "detect");
+
+    const shown = (await cell.run({ kind: "schedule-show", scheduleId: "legacy-probe" }, actor)) as unknown as {
+      readonly outcome: string;
+      readonly schedule: Readonly<Record<string, unknown>>;
+    };
+    assert.equal(shown.outcome, "applied");
+    assert.equal(shown.schedule.state, "invalid");
+    assert.match(String(shown.schedule.invalidReason), /missing required field "mode"/u);
+
+    const gui = parseDaemonGuiReadResult("repo.schedules.list", await cell.read("repo.schedules.list")),
+      guiInvalid = gui.schedules.find(({ scheduleId }) => scheduleId === "legacy-probe");
+    assert.equal(guiInvalid?.state, "invalid");
+    if (guiInvalid?.state === "invalid") assert.match(guiInvalid.invalidReason, /missing required field "mode"/u);
+
+    const stillInvalid = await cell.run(
+      {
+        kind: "schedule-update",
+        scheduleId: "legacy-probe",
+        name: "Legacy probe renamed",
+        idempotencyKey: "repair:without-mode",
+      },
+      actor,
+    );
+    assert.equal(stillInvalid.outcome, "op_rejected");
+    assert.equal(stillInvalid.code, "invalid_store");
+    assert.match(String(stillInvalid.nextAction), /missing required field "mode"/u);
+
+    const invalidMode = await cell.run(
+      {
+        kind: "schedule-update",
+        scheduleId: "legacy-probe",
+        mode: "observe",
+        idempotencyKey: "repair:invalid-mode",
+      },
+      actor,
+    );
+    assert.equal(invalidMode.outcome, "op_rejected");
+    assert.equal(invalidMode.code, "invalid_command");
+
+    const repaired = await cell.run(
+      {
+        kind: "schedule-update",
+        scheduleId: "legacy-probe",
+        mode: "detect",
+        idempotencyKey: "repair:detect",
+      },
+      actor,
+    );
+    assert.equal(repaired.outcome, "applied", JSON.stringify(repaired));
+
+    const after = (await cell.run({ kind: "schedule-list" }, actor)) as unknown as {
+        readonly schedules: readonly Record<string, unknown>[];
+      },
+      repairedRow = after.schedules.find(({ scheduleId }) => scheduleId === "legacy-probe");
+    assert.equal(repairedRow?.state, "armed");
+    assert.equal(repairedRow?.mode, "detect");
+    assert.equal(
+      after.schedules.every(({ state }) => state !== "invalid"),
+      true,
+    );
+    assert.equal(authoredSchedule(root, "legacy-probe").mode, "detect");
+  } finally {
+    await cell?.close();
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+function initRepo(root: string): void {
+  mkdirSync(path.join(root, "harness"), { recursive: true });
+  writeFileSync(
+    path.join(root, "harness/harness.yaml"),
+    "schema: harness-anything/v1\nname: schedule-invalid-projection\nlayout:\n  authoredRoot: harness\n  localRoot: .harness\n",
+  );
+  git(root, "init", "-q");
+  git(root, "config", "user.name", "Schedule Repair Test");
+  git(root, "config", "user.email", "schedule-repair@example.invalid");
+  git(root, "add", "harness/harness.yaml");
+  git(root, "commit", "-qm", "base");
+}
+
+function open(root: string, ownerId: string): Promise<RepoCell> {
+  return openRepoCell({
+    repoId: workspaceId("schedule-invalid-projection"),
+    rootDir: canonicalRoot(root),
+    ownerId: `schedule-invalid-projection-${ownerId}`,
+    now: () => "2026-08-30T06:00:00.000Z",
+  });
+}
+
+function removeProjectedAndAuthoredMode(root: string, scheduleId: string): void {
+  const document = authoredSchedule(root, scheduleId);
+  delete document.mode;
+  writeFileSync(path.join(root, `harness/schedules/${scheduleId}.json`), `${JSON.stringify(document, null, 2)}\n`);
+
+  const database = new DatabaseSync(path.join(root, ".harness/cache/task.sqlite")),
+    row = database
+      .prepare("SELECT value_json FROM entity_projection WHERE entity_kind = 'schedule' AND entity_id = ?")
+      .get(scheduleId) as { readonly value_json: string },
+    projection = JSON.parse(row.value_json) as Record<string, unknown>;
+  delete projection.mode;
+  database
+    .prepare("UPDATE entity_projection SET value_json = ? WHERE entity_kind = 'schedule' AND entity_id = ?")
+    .run(JSON.stringify(projection), scheduleId);
+  database.close();
+}
+
+function authoredSchedule(root: string, scheduleId: string): Record<string, unknown> {
+  return JSON.parse(readFileSync(path.join(root, `harness/schedules/${scheduleId}.json`), "utf8")) as Record<
+    string,
+    unknown
+  >;
+}
+
+function git(root: string, ...args: readonly string[]): void {
+  execFileSync("git", ["-C", root, ...args], { stdio: "ignore" });
+}

--- a/packages/daemon/test/schedule-scheduler.test.ts
+++ b/packages/daemon/test/schedule-scheduler.test.ts
@@ -24,6 +24,40 @@ test("raw RepoCell schedule-list receipt is normalized and arms one Schedule", a
   scheduler.close();
 });
 
+test("an invalid Schedule row does not prevent healthy occurrences from arming", async () => {
+  const clock = fakeClock("2026-08-27T10:00:00.000Z"),
+    healthy = schedule("healthy-probe"),
+    repo = fixtureRepo("invalid-row", "local", [healthy]);
+  repo.listReceipts.push({
+    outcome: "applied",
+    opId: "read:schedule-list:invalid-row",
+    revision: 2,
+    evidence: JSON.stringify({
+      schema: "schedule-list/v1",
+      schedules: [
+        {
+          scheduleId: "legacy-probe",
+          state: "invalid",
+          invalidReason: 'schedule is missing required field "mode".',
+          definitionRevision: 1,
+        },
+        { ...healthy, definitionRevision: 2, nextRunAt: "2026-08-27T10:30:00.000Z" },
+      ],
+    }),
+  });
+  const scheduler = makeScheduleScheduler({
+    cells: new Map([[repo.repoId, repo.cell]]),
+    localBinding,
+    now: clock.now,
+    setTimer: clock.setTimer,
+    clearTimer: clock.clearTimer,
+  });
+  await scheduler.start();
+  assert.equal(clock.liveTimers().length, 1);
+  assert.equal(clock.liveTimers()[0]!.delayMs, 30 * 60_000);
+  scheduler.close();
+});
+
 test("projection-pending Schedule reads retry silently and then arm", async () => {
   const clock = fakeClock("2026-08-27T10:00:00.000Z"),
     repo = fixtureRepo("projection-pending", "local", [schedule("e2e-probe")]),

--- a/packages/daemon/test/schedules-gui.contract.test.ts
+++ b/packages/daemon/test/schedules-gui.contract.test.ts
@@ -270,7 +270,7 @@ test("rows with a claimed-but-unlinked activeRun and a detail-less lastRun pass 
   );
 });
 
-test("trigger DTO variants remain closed and malformed intervals are refused", () => {
+test("malformed definitions degrade to invalid rows while trigger DTO variants remain closed", () => {
   const malformed = {
     ...armedSchedule,
     spec: {
@@ -278,18 +278,18 @@ test("trigger DTO variants remain closed and malformed intervals are refused", (
       trigger: { kind: "interval", everyMs: 30_000, anchorAt: "2026-08-27T07:00:00.000Z" },
     },
   };
-  assert.throws(
-    () =>
-      readSchedulesGui(
-        guiContext({
-          projection: {
-            listEntities: (kind) => (kind === "schedule" ? [{ value: malformed, workspaceRevision: 1 }] : []),
-            readTaskStatuses: guiContext().projection.readTaskStatuses,
-          },
-        }),
-      ),
-    /schedule trigger or cursor is invalid/u,
-  );
+  const degraded = readSchedulesGui(
+      guiContext({
+        projection: {
+          listEntities: (kind) => (kind === "schedule" ? [{ value: malformed, workspaceRevision: 1 }] : []),
+          readTaskStatuses: guiContext().projection.readTaskStatuses,
+        },
+      }),
+    ),
+    invalid = degraded.schedules[0];
+  assert.equal(invalid?.state, "invalid");
+  if (invalid?.state === "invalid") assert.match(invalid.invalidReason, /everyMs.*at least 60000/u);
+  assert.deepEqual(validateSchedulesList(degraded), []);
   const result = readSchedulesGui(guiContext());
   assert.notDeepEqual(
     validateSchedulesList({

--- a/packages/gui/src/renderer/schedules-client.ts
+++ b/packages/gui/src/renderer/schedules-client.ts
@@ -1,4 +1,8 @@
-import type { ScheduleGuiRowDto, SchedulesListResult } from "../../../daemon/src/protocol/schedules-gui-contract.ts";
+import type {
+  ScheduleGuiListRowDto,
+  ScheduleGuiRowDto,
+  SchedulesListResult,
+} from "../../../daemon/src/protocol/schedules-gui-contract.ts";
 import type { DaemonGuiReadPayloadMap } from "../../../daemon/src/protocol/daemon-protocol.contract.ts";
 import { isRendererRecord, rendererErrorHint } from "./result-validation.ts";
 
@@ -266,7 +270,9 @@ export const scheduleRunRefOccurrence = (focusedEntityRef: string | null): strin
 };
 
 export const scheduleRowById = (
-  rows: readonly ScheduleGuiRowDto[],
+  rows: readonly ScheduleGuiListRowDto[],
   scheduleId: string | null,
 ): ScheduleGuiRowDto | null =>
-  scheduleId === null ? null : (rows.find((row) => row.scheduleId === scheduleId) ?? null);
+  scheduleId === null
+    ? null
+    : (rows.find((row): row is ScheduleGuiRowDto => row.scheduleId === scheduleId && row.state !== "invalid") ?? null);

--- a/packages/gui/src/renderer/views/SchedulesView.tsx
+++ b/packages/gui/src/renderer/views/SchedulesView.tsx
@@ -1,7 +1,11 @@
 import { useMemo, useState } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { ArrowRight, Clock, Plus } from "@phosphor-icons/react";
-import type { ScheduleGuiRowDto, SchedulesListResult } from "../../../../daemon/src/protocol/schedules-gui-contract.ts";
+import type {
+  ScheduleGuiListRowDto,
+  ScheduleGuiRowDto,
+  SchedulesListResult,
+} from "../../../../daemon/src/protocol/schedules-gui-contract.ts";
 import { Badge, Btn, Chip, Empty, Hint } from "../components/runtime/parts.tsx";
 import { ScheduleFormDialog } from "../components/ScheduleFormDialog.tsx";
 import { t, type MessageKey } from "../i18n/index.tsx";
@@ -265,7 +269,7 @@ function ScheduleListPane({
   onOpenSchedule,
   onCreate,
 }: {
-  readonly rows: readonly ScheduleGuiRowDto[];
+  readonly rows: readonly ScheduleGuiListRowDto[];
   readonly data: SchedulesListResult | null;
   readonly pending: boolean;
   readonly busy: boolean;
@@ -275,14 +279,15 @@ function ScheduleListPane({
   const [stateFilter, setStateFilter] = useState<StateFilter>("all");
   const [modeFilter, setModeFilter] = useState<ModeFilter>("all");
   const [healthFilter, setHealthFilter] = useState<HealthFilter>("all");
-  const modeProjected = rows.some((row) => scheduleRowMode(row) !== null),
-    healthProjected = rows.some((row) => scheduleRowHealth(row) !== null),
+  const modeProjected = rows.some((row) => row.state !== "invalid" && scheduleRowMode(row) !== null),
+    healthProjected = rows.some((row) => row.state !== "invalid" && scheduleRowHealth(row) !== null),
     visible = rows.filter((row) => {
       if (stateFilter !== "all" && row.state !== stateFilter) return false;
-      if (modeFilter !== "all" && scheduleRowMode(row) !== modeFilter) return false;
+      if (modeFilter !== "all" && (row.state === "invalid" || scheduleRowMode(row) !== modeFilter)) return false;
       // The bucket is the daemon's classification of its health rollup — the
       // renderer only selects rows whose bucket matches the requested facet.
-      if (healthFilter !== "all" && scheduleRowHealth(row)?.bucket !== healthFilter) return false;
+      if (healthFilter !== "all" && (row.state === "invalid" || scheduleRowHealth(row)?.bucket !== healthFilter))
+        return false;
       return true;
     });
   return (
@@ -383,6 +388,20 @@ function ScheduleListPane({
             </thead>
             <tbody>
               {visible.map((row) => {
+                if (row.state === "invalid")
+                  return (
+                    <tr
+                      key={row.scheduleId}
+                      data-testid={`schedule-row-${row.scheduleId}`}
+                      className="border-b border-border bg-status-blocked/10 last:border-b-0"
+                    >
+                      <td className="px-2.5 py-1.5 font-mono text-[10.5px] text-text-faint">{row.scheduleId}</td>
+                      <td colSpan={9} className="px-2.5 py-1.5 text-status-blocked">
+                        <b className="mr-2 font-mono uppercase">invalid</b>
+                        {row.invalidReason}
+                      </td>
+                    </tr>
+                  );
                 const stateMeta = STATE_META[row.state],
                   mode = scheduleRowMode(row),
                   health = scheduleRowHealth(row)?.recent ?? null;

--- a/packages/kernel/src/domain/index.ts
+++ b/packages/kernel/src/domain/index.ts
@@ -183,7 +183,6 @@ export {
   nextScheduleOccurrence,
   scheduleMissedReasons,
   scheduleRunOutcomes,
-  updateScheduleV1,
   validateScheduleV1,
 } from "./schedule.ts";
 export type {
@@ -192,7 +191,6 @@ export type {
   ScheduleMissedReason,
   ScheduleMode,
   ScheduleRunOutcome,
-  ScheduleTargetV1,
   ScheduleTriggerV1,
   ScheduleV1,
 } from "./schedule.ts";

--- a/packages/kernel/src/domain/schedule.ts
+++ b/packages/kernel/src/domain/schedule.ts
@@ -56,7 +56,7 @@ export interface ScheduleSquadTargetV1 {
   readonly squadId: string;
 }
 
-export type ScheduleTargetV1 = ScheduleAgentTargetV1 | ScheduleSquadTargetV1;
+type ScheduleTargetV1 = ScheduleAgentTargetV1 | ScheduleSquadTargetV1;
 
 export interface ScheduleDefinitionV1 {
   readonly schema: "schedule/v1";
@@ -240,25 +240,6 @@ export function createScheduleV1(input: {
       lastMissedAt: null,
       lastMissedReason: null,
     },
-  };
-  const errors = validateScheduleV1(schedule);
-  if (errors.length) throw new Error(errors.join("; "));
-  return schedule;
-}
-
-export function updateScheduleV1(input: {
-  readonly schedule: ScheduleV1;
-  readonly name: string;
-  readonly mode: ScheduleMode;
-  readonly spec: ScheduleDefinitionV1["spec"];
-  readonly occurredAt: string;
-}): ScheduleV1 {
-  const schedule: ScheduleV1 = {
-    ...input.schedule,
-    name: input.name.trim(),
-    mode: input.mode,
-    spec: { ...input.spec, mission: input.spec.mission.trim() },
-    updatedAt: input.occurredAt,
   };
   const errors = validateScheduleV1(schedule);
   if (errors.length) throw new Error(errors.join("; "));

--- a/packages/kernel/test/schedule.test.ts
+++ b/packages/kernel/test/schedule.test.ts
@@ -4,7 +4,6 @@ import test from "node:test";
 import {
   createScheduleV1,
   nextScheduleOccurrence,
-  updateScheduleV1,
   validateScheduleV1,
   type ScheduleV1,
 } from "../src/domain/schedule.ts";
@@ -72,43 +71,6 @@ test("Schedule creation trims authored text and starts with an empty projected r
     lastMissedAt: null,
     lastMissedReason: null,
   });
-});
-
-test("Schedule update replaces the complete declaration while retaining projected run evidence", () => {
-  const original = fixtureSchedule(),
-    withHistory: ScheduleV1 = {
-      ...original,
-      status: {
-        ...original.status,
-        missedCount: 2,
-        lastMissedAt: "2026-08-26T10:30:00.000Z",
-        lastMissedReason: "scheduler_unavailable",
-      },
-    },
-    updated = updateScheduleV1({
-      schedule: withHistory,
-      name: "  Daily health  ",
-      mode: "remediate",
-      spec: {
-        trigger: { kind: "interval", everyMs: 3_600_000, anchorAt: "2026-08-26T11:00:00.000Z" },
-        target: {
-          kind: "agent",
-          agentId: "reviewer",
-          runtimeInstanceId: "runtime-review",
-          model: "gpt-5.6-sol",
-          reasoningEffort: "high",
-          cwd: "packages/kernel",
-        },
-        mission: "  Review repository health.  ",
-      },
-      occurredAt: "2026-08-26T11:00:00.000Z",
-    });
-  assert.equal(updated.name, "Daily health");
-  assert.equal(updated.mode, "remediate");
-  assert.equal(updated.spec.mission, "Review repository health.");
-  assert.equal(updated.createdAt, original.createdAt);
-  assert.equal(updated.updatedAt, "2026-08-26T11:00:00.000Z");
-  assert.deepEqual(updated.status, withHistory.status);
 });
 
 function fixtureSchedule(): ScheduleV1 {


### PR DESCRIPTION
# English

## Summary

`ha schedule list/show/update` and the GUI Schedules view all threw `invalid_store` because PR #2014 made `mode` a required `schedule/v1` field while two canonical Schedule rows declared before it (`antientropy-sweep`, `e2e-probe`) carried no `mode`. Every read path validated the current projection first, so `schedule update --mode` could never reach the merge step: there was no self-heal path. This PR makes reads row-tolerant (invalid rows are reported with their schema reason instead of crashing the whole list), makes `update` validate the merged result rather than the current row, and adds the missing negative control: a canonical row that lacks a newly required field.

No default `mode` is injected, and no canonical JSON is hand-edited; the CEO repairs the two rows with `ha schedule update <id> --mode detect` after this lands.

## Architectural Justification

- Churn is above 200 lines, but production net is +197: the update-merge and trigger helpers moved out of the 893-line `repo-cell-schedule-actions.ts` into a focused `schedule-projection.ts` (160 lines) so that inspection (`inspectScheduleProjection`) and merge-then-validate (`mergeProjectedScheduleUpdate`) are one seam used by list/show/update alike.
- The old throw-on-first-invalid path in list/show and the validate-before-merge `read()` in update are deleted in the same commit; no compatibility branch or default value remains.
- Scope cannot narrow further: list, show, update, scheduler evaluation, CLI rendering, GUI contract and GUI view all consumed the same throwing read, so each had to learn the `state: "invalid"` row shape.

## What Changed

- `packages/daemon/src/schedule-projection.ts` (new): `inspectScheduleProjection` returns either a valid `ScheduleV1` or an `{state:"invalid", invalidReason, definitionRevision}` row; `mergeProjectedScheduleUpdate` merges action fields over the raw row and runs `validateScheduleV1` on the candidate.
- `packages/daemon/src/repo-cell-schedule-actions.ts`: list maps invalid rows to the diagnostic shape; show returns it; update merges then validates (`invalid_store` only if the merged result is still invalid); helper functions moved to the new module.
- `packages/daemon/src/schedule-scheduler.ts`: invalid rows are skipped; healthy rows keep arming.
- `packages/daemon/src/protocol/daemon-protocol-validate-results.ts`, `packages/cli/src/cli/thin-command-schedule.ts`: CLI contract and renderer accept/print invalid rows.
- `packages/daemon/src/schedules-gui-read.ts`, `protocol/schedules-gui-contract.ts`, `packages/gui/src/renderer/{schedules-client.ts,views/SchedulesView.tsx}`: GUI read and table render an `invalid` row with its reason.
- Tests: new `packages/daemon/test/schedule-invalid-projection.integration.test.ts` (canonical row with `mode` removed from both the authored document and the SQLite projection → mixed list/show/GUI reads, `update` without mode still rejected, `--mode observe` rejected, `--mode detect` repairs); scheduler, CLI, GUI contract tests extended.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: use the single CI-backed `Production-Delta` declaration below; do not enter a second metric.

## Machine-Readable Declarations

Production-Delta: +328/-152

## Task And Scope

- Harness task: task_d541520972b27ae78669ee911a
- Branch: codex/schedule-mode-fix
- Public scope: daemon schedule read/update path, scheduler, CLI schedule rendering, GUI schedules contract/view, tests
- Private planning/evidence updated: yes
- Out of scope: repairing the two canonical rows (CEO runs `ha schedule update <id> --mode detect` after merge); adding a gate against tightening an event schema in place (separate governance task)

## Version Impact

- Version: no version change because this is a fix inside the unreleased milestone line
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none
- Authority: not applicable
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: ea1046f946454a87e39f0baf40b6029b250e0b72
- Branch merge-base with `origin/main`: ea1046f946454a87e39f0baf40b6029b250e0b72
- Last `git fetch origin` time: 2026-08-30 (before branch creation)
- Sync method: none needed
- Public diff command: `git diff origin/main...codex/schedule-mode-fix`
- Private evidence commit/path: harness task package `task_d541520972b27ae78669ee911a` artifacts/schedule-mode-fix-report.md, fact F-A555E051
- Reviewer evidence path: same task package, artifacts/pr-body.md
- GitHub Actions `rewrite-ci` run URL: pending
- [ ] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [x] `npm run typecheck` (worker, isolated)
- [x] `npm test` — targeted only: schedule-invalid-projection.integration (1/1), schedule-scheduler (13/13), schedule-command (6/6), schedules-gui.contract (13/13), schedules-gui-read.integration (2/2), `npm run test:gui` (558/558)
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Not run: full local gate matrix — by task contract the stop point is targeted tests + commit; GitHub CI is the authority.

## Review Evidence

- Self-review: worker report in task artifacts
- Reviewer subagent: CEO fork functional review (diff read end-to-end; confirmed no default mode, no canonical JSON edit, negative control present, old throwing read removed)
- Human review: CEO semantic acceptance
- Blocking findings: none

## Residual Risk

- Any future required-field tightening of `schedule/v1` will again strand pre-existing rows; this PR makes them visible and repairable but does not prevent the tightening. A governance gate for in-place event-schema tightening is tracked separately.

## References

- Task: task_d541520972b27ae78669ee911a
- Evidence: fact F-A555E051; artifacts/schedule-mode-fix-report.md
- Review: artifacts/pr-body.md

---

# 中文

## 概要

`ha schedule list/show/update` 与 GUI 定时计划页全部报 `invalid_store`:PR #2014 把 `mode` 设为 `schedule/v1` 必填,而此前声明的两条 canonical Schedule(`antientropy-sweep`、`e2e-probe`)没有 `mode`。所有读路径先校验当前投影再干活,`schedule update --mode` 永远到不了合并那一步——没有自愈路径。本 PR 让读路径对坏行降级(单行报 schema 原因,不炸整表),让 `update` 校验**合并后的结果**而不是当前行,并补上缺失的阴性对照:一条缺新必填字段的 canonical 行。

不给 `mode` 补默认值,不手改 canonical JSON;合入后由 CEO 用 `ha schedule update <id> --mode detect` 修两条行。

## 架构辩护

- churn 超过 200 行但生产净增 +197:把 update 合并与 trigger 辅助函数从 893 行的 `repo-cell-schedule-actions.ts` 移到聚焦的 `schedule-projection.ts`(160 行),使「检视」(`inspectScheduleProjection`)与「先合并再校验」(`mergeProjectedScheduleUpdate`)成为 list/show/update 共用的唯一缝。
- list/show 的「遇第一条坏行即抛」路径与 update 的「先校验再合并」`read()` 在同一 commit 删除;没有兼容分支,没有默认值。
- 范围无法再收窄:list、show、update、scheduler 评估、CLI 渲染、GUI 契约与视图都消费同一个会抛错的读路径,每一处都必须认识 `state: "invalid"` 行形状。

## 改动内容

- `packages/daemon/src/schedule-projection.ts`(新):`inspectScheduleProjection` 返回合法 `ScheduleV1` 或 `{state:"invalid", invalidReason, definitionRevision}`;`mergeProjectedScheduleUpdate` 把 action 字段合并到原始行上再跑 `validateScheduleV1`。
- `packages/daemon/src/repo-cell-schedule-actions.ts`:list 把坏行映射为诊断行;show 直接返回;update 先合并再校验(合并后仍非法才 `invalid_store`);辅助函数迁至新模块。
- `packages/daemon/src/schedule-scheduler.ts`:跳过 invalid 行,健康行照常 arm。
- `daemon-protocol-validate-results.ts`、`thin-command-schedule.ts`:CLI 契约与渲染接受/打印 invalid 行。
- `schedules-gui-read.ts`、`schedules-gui-contract.ts`、GUI `schedules-client.ts` / `SchedulesView.tsx`:GUI 读面与表格渲染 invalid 行及原因。
- 测试:新增 `schedule-invalid-projection.integration.test.ts`(在 authored 文档与 SQLite 投影里同时删掉 `mode` → list/show/GUI 混合读、不带 mode 的 update 仍拒、`--mode observe` 拒、`--mode detect` 修复成功);scheduler / CLI / GUI 契约测试扩展。

## 门收割 / Gate Harvest

- 删除的生产路径:none(旧抛错读路径是同文件内的分支替换,不是独立路径)
- 同 commit 删除的门 / fixture:none
- 生产净行数:引用英文块中的 `Production-Delta`。

## 机读声明说明

- 机读声明只在英文块出现一次:`Production-Delta: +328/-152`;无依赖变化。

## 任务与范围

- Harness 任务:task_d541520972b27ae78669ee911a
- 分支:codex/schedule-mode-fix
- 公开范围:daemon schedule 读/更新路径、scheduler、CLI schedule 渲染、GUI schedules 契约/视图、测试
- 私有计划 / 证据是否已更新:yes
- 范围外:修两条 canonical 行(合入后 CEO 执行);对「原地收紧事件 schema」加门(另立治理任务)

## 版本影响

- 版本:不改版本,原因是里程碑线内修复,未发版
- 发布影响:不发布

## 治理声明

- 是否触碰 protected surface:no
- protected surface 范围:无
- 依据:不适用
- 机器检查边界:本 PR 只声明该段存在;声明是否真实、充分,由 reviewer 判断。
- Break-glass:no
- Break-glass 原因:不适用
- Break-glass 范围:不适用
- 后续治理任务:不适用

## 验证

- `origin/main` 基准 SHA:ea1046f946454a87e39f0baf40b6029b250e0b72
- 当前分支与 `origin/main` 的 merge-base:ea1046f946454a87e39f0baf40b6029b250e0b72
- 最近一次 `git fetch origin` 时间:2026-08-30(建分支前)
- 同步方式:不需要
- 公开 diff 命令:`git diff origin/main...codex/schedule-mode-fix`
- 私有证据 commit/path:任务包 artifacts/schedule-mode-fix-report.md、fact F-A555E051
- Reviewer 证据路径:任务包 artifacts/pr-body.md
- GitHub Actions `rewrite-ci` run URL:待填
- [ ] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [x] `npm run typecheck`(worker 隔离环境)
- [x] `npm test` — 仅定向:schedule-invalid-projection.integration(1/1)、schedule-scheduler(13/13)、schedule-command(6/6)、schedules-gui.contract(13/13)、schedules-gui-read.integration(2/2)、`npm run test:gui`(558/558)
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- 未运行:本地全量门矩阵——任务契约的停止点是定向测试 + commit,GitHub CI 是权威。

## 审查证据

- 自查:worker 报告见任务包 artifacts
- Reviewer subagent:CEO fork 功能复核(通读 diff;确认无默认 mode、未手改 canonical JSON、阴性对照存在、旧抛错读路径已删)
- 人工审查:CEO 语义验收
- 阻塞发现:无

## 残余风险

- 未来再对 `schedule/v1` 原地加必填字段仍会把既有行变成 invalid;本 PR 让它可见、可修,但不阻止收紧本身。「原地收紧事件 schema」的治理门另行跟踪。

## 关联材料

- 任务:task_d541520972b27ae78669ee911a
- 证据:fact F-A555E051;artifacts/schedule-mode-fix-report.md
- 审查:artifacts/pr-body.md

