### PR TITLE
fix(daemon): confirm runtime liveness after launch

### DIFF
--- a/packages/daemon/src/runtime-spawner.ts
+++ b/packages/daemon/src/runtime-spawner.ts
@@ -655,6 +655,17 @@ export function makeRuntimeSpawner(input: RuntimeSpawnerInput) {
       dispatchId: newDispatchId,
       pid: runtimeProcess.pid,
     });
+    // `runtime_session_started` is published before launch so immediate provider
+    // callbacks can resolve the session. Confirm liveness after the process is
+    // actually registered, ahead of any output or exit work those callbacks queue.
+    input.schedule(async () => {
+      await publishRuntimeEvent(
+        "runtime_session_liveness_changed",
+        { runtimeSessionId, liveness: "live" },
+        `${dispatchOpId}-live`,
+        binding,
+      );
+    });
     attachActiveRuntime(extracted, active, resumeObservation);
     return requested.receipt
       ? {

--- a/packages/daemon/test/runtime-spawn-lifecycle.integration.test.ts
+++ b/packages/daemon/test/runtime-spawn-lifecycle.integration.test.ts
@@ -47,7 +47,10 @@ test("runtime spawn publishes a canonical session and makes it visible in overvi
     git(root, "config", "user.email", "spawn@example.invalid");
     git(root, "commit", "--allow-empty", "-qm", "base");
     let launched: unknown,
-      intentWasDurable = false;
+      intentWasDurable = false,
+      observerSawUnknown = false,
+      firstExit: ((code: number | null) => void) | null = null,
+      launchCount = 0;
     const cell = await openRepoCell({
       repoId: workspaceId("runtime-spawn"),
       rootDir: canonicalRoot(root),
@@ -102,7 +105,7 @@ test("runtime spawn publishes a canonical session and makes it visible in overvi
         cwd: request.cwd,
         prompt: request.prompt,
       }),
-      runtimeLaunch: (input) => {
+      runtimeLaunch: (input, persistence) => {
         intentWasDurable = makeTaskEventStore({
           repoId: "runtime-spawn",
           rootDir: root,
@@ -110,11 +113,24 @@ test("runtime spawn publishes a canonical session and makes it visible in overvi
           .read()
           .events.some((candidate) => candidate.type === "runtime_dispatch_requested");
         launched = input;
+        const observer = makeTaskProjection({
+            rootDir: root,
+            eventStore: makeTaskEventStore({ repoId: "runtime-spawn", rootDir: root }),
+          }),
+          thisLaunch = launchCount++;
+        observerSawUnknown ||= observer.readRuntimeSessions().some((candidate) => candidate.liveness === "unknown");
+        appendRuntimeWorkerRecord(root, persistence.dispatchId, {
+          kind: "process_started",
+          occurredAt: "2026-08-30T05:42:44.000Z",
+          pid: 123,
+        });
         return {
           pid: 123,
           onOutput: () => undefined,
           onErrorOutput: () => undefined,
-          onExit: () => undefined,
+          onExit: (listener) => {
+            if (thisLaunch === 0) firstExit = listener;
+          },
           terminate: () => undefined,
         };
       },
@@ -170,6 +186,7 @@ test("runtime spawn publishes a canonical session and makes it visible in overvi
       );
       assert.equal(receipt.outcome, "applied");
       assert.equal(intentWasDurable, true);
+      assert.equal(observerSawUnknown, true);
       assert.deepEqual(launched, {
         definition,
         installation,
@@ -182,13 +199,25 @@ test("runtime spawn publishes a canonical session and makes it visible in overvi
         cwd: canonicalRoot(root),
         prompt: "Inspect the repository",
       });
-      const events = makeTaskEventStore({
-          repoId: "runtime-spawn",
-          rootDir: root,
-        }).read().events,
+      await eventually(() =>
+        makeTaskEventStore({ repoId: "runtime-spawn", rootDir: root })
+          .read()
+          .events.some(
+            (candidate) =>
+              candidate.type === "runtime_session_liveness_changed" &&
+              candidate.payload.runtimeSessionId === receipt.runtimeSessionId &&
+              candidate.payload.liveness === "live",
+          ),
+      );
+      const events = makeTaskEventStore({ repoId: "runtime-spawn", rootDir: root }).read().events,
         observed = events.find((candidate) => candidate.type === "runtime_installation_observed"),
         dispatch = events.find((candidate) => candidate.type === "runtime_dispatch_requested"),
-        started = events.find((candidate) => candidate.type === "runtime_session_started");
+        started = events.find((candidate) => candidate.type === "runtime_session_started"),
+        live = events.find(
+          (candidate) =>
+            candidate.type === "runtime_session_liveness_changed" &&
+            candidate.payload.runtimeSessionId === receipt.runtimeSessionId,
+        );
       assert.equal(
         observed?.type === "runtime_installation_observed" && observed.payload.installationId,
         definition.installationId,
@@ -199,6 +228,7 @@ test("runtime spawn publishes a canonical session and makes it visible in overvi
       );
       assert.ok(events.indexOf(observed!) < events.indexOf(dispatch!));
       assert.ok(events.indexOf(dispatch!) < events.indexOf(started!));
+      assert.ok(events.indexOf(started!) < events.indexOf(live!));
       assert.equal(
         dispatch?.type === "runtime_dispatch_requested" && dispatch.payload.instanceId,
         definition.instanceId,
@@ -224,6 +254,47 @@ test("runtime spawn publishes a canonical session and makes it visible in overvi
       const session = overview.sessions.find((candidate) => candidate.runtimeSessionId === receipt.runtimeSessionId);
       assert.equal(session?.instanceId, definition.instanceId);
       assert.deepEqual(session?.definitionSnapshot, definition);
+      assert.equal(session?.liveness, "live");
+      assert.equal(session?.semanticState, "running");
+
+      // Sanitized copies of the Codex JSONL frame shapes captured from a real
+      // provider stream on 2026-08-30, followed by its native process exit.
+      for (const event of [
+        { type: "thread.started", thread_id: "provider-live-after-launch" },
+        { type: "turn.started" },
+        {
+          type: "item.completed",
+          item: { id: "message", type: "agent_message", text: "runtime stayed live" },
+        },
+        { type: "turn.completed", usage: { input_tokens: 1, cached_input_tokens: 0, output_tokens: 1 } },
+      ])
+        appendRuntimeWorkerRecord(root, String(receipt.dispatchId), {
+          kind: "provider_event",
+          occurredAt: "2026-08-30T05:42:45.000Z",
+          event,
+        });
+      appendRuntimeWorkerRecord(root, String(receipt.dispatchId), {
+        kind: "process_exit",
+        occurredAt: "2026-08-30T05:42:46.000Z",
+        exitCode: 0,
+        signal: null,
+      });
+      assert.ok(firstExit, "runtime exit listener must be attached before the provider exits");
+      firstExit(0);
+      await eventually(() =>
+        makeTaskEventStore({ repoId: "runtime-spawn", rootDir: root })
+          .read()
+          .events.some(
+            (candidate) =>
+              candidate.type === "runtime_session_exited" &&
+              candidate.payload.runtimeSessionId === receipt.runtimeSessionId,
+          ),
+      );
+      const settled = (await cell.read("repo.agentRuntime.overview", {})).sessions.find(
+        (candidate) => candidate.runtimeSessionId === receipt.runtimeSessionId,
+      );
+      assert.equal(settled?.liveness, "exited");
+      assert.notEqual(settled?.semanticState, "running");
       const alternate = await cell.spawnRuntime(
         {
           runtimeInstanceId: "codex-review",


### PR DESCRIPTION
# English

## Summary

Runtime sessions stayed `liveness: unknown` in `ha runtime status` and in the GUI (session badge `unknown`, header "0 running") while the child process was alive and its dispatch stream was still growing. Root cause: the ordinary spawn path publishes `runtime_session_started` before launch (so immediate provider callbacks can resolve the session) but never publishes a canonical `runtime_session_liveness_changed(live)` once the process is actually registered; a projection opened or rebuilt in that window demotes the not-yet-exited session to `unknown` and nothing ever promotes it. Restart adoption already published the live witness; ordinary spawn did not. Fix: after the process is registered, publish the canonical live witness through the RepoCell single-writer queue, ahead of any output/exit work the provider callbacks may enqueue. No `ps` polling, no read-side inference, no GUI special-casing. Reproduced against real Codex and Claude (`glm-work`) dispatch streams from 2026-08-30; one integration test now reproduces the race and replays sanitized real Codex frames to assert `live/running` then `exited`.

## Architectural Justification

- Not required (churn 90 lines, production +11/-0). The defect is a missing canonical witness on one path; the existing adoption (restart) and settlement (exit) writers remain the sole owners of their respective transitions.

## What Changed

- `packages/daemon/src/runtime-spawner.ts`: after `attach`/process registration, schedule one canonical `runtime_session_liveness_changed { liveness: "live" }` event (op id `${dispatchOpId}-live`) on the RepoCell queue.
- `packages/daemon/test/runtime-spawn-lifecycle.integration.test.ts`: opens a second projection between `runtime_session_started` and launch to assert the `unknown` race is observable, waits for the live event, asserts `started` precedes `live`, asserts overview shows `live/running`, then replays real Codex frame shapes plus `process_exit(0)` and asserts `exited` / not running.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: use the single CI-backed `Production-Delta` declaration below; do not enter a second metric.

## Machine-Readable Declarations

Production-Delta: +11/-0

## Task And Scope

- Harness task: task_7246bbc34fe3b46f42d0b342e2
- Branch: codex/runtime-liveness
- Public scope: daemon runtime spawner + one integration test
- Private planning/evidence updated: yes (task plan, progress, fact F-A8E3783E, fix report in task artifacts)
- Out of scope: U19c outcome classification after exit (task_90b811eab3114d06f262f76e0f) — different axis, different root cause; sessions already reach `liveness: exited` while `outcome` may still be `unknown`.

## Version Impact

- Version: no version change because this is a daemon behavior fix inside the current milestone; no publish.
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none
- Authority: task_7246bbc34fe3b46f42d0b342e2
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: ea1046f946454a87e39f0baf40b6029b250e0b72
- Branch merge-base with `origin/main`: ea1046f946454a87e39f0baf40b6029b250e0b72
- Last `git fetch origin` time: 2026-08-30 (before branch creation)
- Sync method: none needed
- Public diff command: `git diff origin/main...codex/runtime-liveness`
- Private evidence commit/path: harness task package `task_7246bbc34fe3b46f42d0b342e2` → `artifacts/runtime-liveness-fix-report.md`, `progress.md`
- Reviewer evidence path: same fix report; CEO review re-ran the integration test on the worktree: 6 pass / 0 fail (19.2 s)
- GitHub Actions `rewrite-ci` run URL: pending (filled after PR opens)
- [x] `git diff --check`
- [x] Targeted: `node --test packages/daemon/test/runtime-spawn-lifecycle.integration.test.ts` — 6/6 pass (worker: Docker-isolated 6/6; before fix 5/6 with the new case failing on the live-event wait)
- [ ] `npm ci` / `npm run check` / `npm run typecheck` / `npm test` / harness:* gates / smoke-cli-package — delegated to GitHub `rewrite-ci` (local full check is not the stop point per repo policy)
- [ ] GitHub Actions `rewrite-ci` passed
- Not run: `npm run check:local` — repo policy forbids full local matrix on worker/CEO machines; CI is authoritative.

## Review Evidence

- Self-review: worker report with real-provider stream evidence (three 2026-08-30 sessions, frame counts, no live event before exit).
- Reviewer subagent: Claude fork re-read diff, confirmed event-driven fix (no polling), confirmed test replays real Codex frame shapes and asserts exited after `process_exit`, re-ran integration test 6/6.
- Human review: CEO semantic acceptance against task plan (event chain break located; no fallback layer added).
- Blocking findings: none. Post-merge ground truth still required: dispatch one worker and confirm `ha runtime status` reports `live` within seconds and GUI header count follows.

## Residual Risk

- The fix is verified in isolated repo cells; the default daemon has not run it yet. Post-merge acceptance dispatch closes that gap.
- U19c (post-exit outcome `unknown`) is untouched and remains open.

## References

- Task: task_7246bbc34fe3b46f42d0b342e2
- Evidence: fact F-A8E3783E; artifacts/runtime-liveness-fix-report.md
- Review: this PR body, Review Evidence section

---

# 中文

## 概要

子进程活着、dispatch 流持续增长时,`ha runtime status` 与 GUI(会话徽章 `unknown`、顶栏「0 个在跑」)仍报 `liveness: unknown`。根因:普通 spawn 路径为了让 provider 即时回调能查到 session,在 launch 前先发 `runtime_session_started`,但进程真正登记后从未发布 canonical 的 `runtime_session_liveness_changed(live)`;这个窗口内新开或重建的投影会把未退出 session 降为 `unknown`,之后没人再升回来。restart adoption 早就发了这条 live witness,普通 spawn 没有。修法:进程登记后,经 RepoCell 单写队列发布 canonical live witness,并排在 provider output/exit 回调可能排入的工作之前。没有 `ps` 轮询、读层推断或 GUI 特判。用 2026-08-30 真实 Codex 与 Claude(`glm-work`)流复现;新增集成用例稳定复现竞态并回放脱敏的真实 Codex 帧,断言先 `live/running` 再 `exited`。

## 架构辩护

- 不需要(churn 90 行,生产 +11/-0)。缺陷是一条路径缺少 canonical witness;adoption(重启)与 settlement(退出)仍各自唯一拥有其转换。

## 改动内容

- `packages/daemon/src/runtime-spawner.ts`:进程登记后在 RepoCell 队列上调度一条 canonical `runtime_session_liveness_changed { liveness: "live" }`(op id `${dispatchOpId}-live`)。
- `packages/daemon/test/runtime-spawn-lifecycle.integration.test.ts`:在 `runtime_session_started` 与 launch 之间打开第二投影断言 `unknown` 竞态可观测;等待 live 事件;断言 `started` 先于 `live`;overview 为 `live/running`;回放真实 Codex 帧形状 + `process_exit(0)` 后断言 `exited` 且不再 running。

## 门收割 / Gate Harvest

- 删除的生产路径:none
- 同 commit 删除的门 / fixture:none
- 生产净行数:引用英文块 `Production-Delta`。

## 机读声明说明

- 见英文块的 `Production-Delta` 声明;无依赖变化;无保留旧路径。

## 任务与范围

- Harness 任务:task_7246bbc34fe3b46f42d0b342e2
- 分支:codex/runtime-liveness
- 公开范围:daemon runtime spawner + 一个集成测试
- 私有计划 / 证据是否已更新:yes(plan、progress、fact F-A8E3783E、任务包内修复报告)
- 范围外:U19c 退出后 outcome 分类(task_90b811eab3114d06f262f76e0f)——不同状态轴、不同根因;现场 session 已能到 `exited` 而 `outcome` 仍可为 `unknown`。

## 版本影响

- 版本:不改版本,原因是里程碑内 daemon 行为修复,不发布
- 发布影响:不发布

## 治理声明

- 是否触碰 protected surface:no
- protected surface 范围:无
- 依据:task_7246bbc34fe3b46f42d0b342e2
- 机器检查边界:本 PR 只声明该段存在;是否真实充分由 reviewer 判断。
- Break-glass:no
- Break-glass 原因:不适用
- Break-glass 范围:不适用
- 后续治理任务:不适用

## 验证

- `origin/main` 基准 SHA:ea1046f946454a87e39f0baf40b6029b250e0b72
- 当前分支与 `origin/main` 的 merge-base:ea1046f946454a87e39f0baf40b6029b250e0b72
- 最近一次 `git fetch origin` 时间:2026-08-30(建分支前)
- 同步方式:不需要
- 公开 diff 命令:`git diff origin/main...codex/runtime-liveness`
- 私有证据 commit/path:任务包 `artifacts/runtime-liveness-fix-report.md`、`progress.md`
- Reviewer 证据路径:同上;CEO 复核在 worktree 重跑集成测试 6/6(19.2 s)
- GitHub Actions `rewrite-ci` run URL:开 PR 后补
- [x] `git diff --check`
- [x] 定向:`node --test packages/daemon/test/runtime-spawn-lifecycle.integration.test.ts` 6/6(worker Docker 隔离 6/6;修复前 5/6,新增用例等待 live 事件失败)
- [ ] `npm ci` / `npm run check` / `npm run typecheck` / `npm test` / harness:* 门 / smoke-cli-package——交 GitHub `rewrite-ci`
- [ ] GitHub Actions `rewrite-ci` passed
- 未运行:`npm run check:local`——仓库纪律禁止在 worker/CEO 机器跑全量矩阵,CI 为权威。

## 审查证据

- 自查:worker 报告含真 provider 流证据(三条 2026-08-30 session、帧计数、退出前无 live 事件)。
- Reviewer subagent:Claude fork 通读 diff,确认事件驱动无轮询,确认测试回放真实 Codex 帧并在 `process_exit` 后断言 exited,重跑集成测试 6/6。
- 人工审查:CEO 按 task plan 语义验收(定位到事件链断点;未加兜底层)。
- 阻塞发现:无。合并后仍需 ground-truth:派一个 worker,数秒内 `ha runtime status` 应为 `live`,GUI 顶栏计数同步。

## 残余风险

- 修复只在隔离 repo cell 验证,default daemon 尚未运行它;合并后的验收派工补上。
- U19c(退出后 outcome `unknown`)未动,仍开放。

## 关联材料

- 任务:task_7246bbc34fe3b46f42d0b342e2
- 证据:fact F-A8E3783E;artifacts/runtime-liveness-fix-report.md
- 审查:本 PR 正文「审查证据」节
