### PR TITLE
feat(cli): add recursive task index queries

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -151,7 +151,14 @@ export function emit(receipt: Record<string, unknown>, json: boolean): void {
 }
 
 function renderTaskCreateReceipt(receipt: Record<string, unknown>): string {
-  const contract = receipt.outputShape === "repository-diff" ? [repositoryDiffContract] : [];
+  const contract = receipt.outputShape === "repository-diff" ? [repositoryDiffContract] : [],
+    guidance =
+      receipt.dryRun !== true && typeof receipt.packagePath === "string" && typeof receipt.taskId === "string"
+        ? [
+            `plan: write the concrete plan at harness/${receipt.packagePath}/task_plan.md`,
+            `agenda: use ha task pin ${receipt.taskId} to pin it to the CEO agenda`,
+          ]
+        : [];
   return [
     String(receipt.summary),
     `preset: ${String(receipt.presetId)}/${String(receipt.profileId)}`,
@@ -159,6 +166,7 @@ function renderTaskCreateReceipt(receipt: Record<string, unknown>): string {
     `completionGates: ${JSON.stringify(receipt.completionGates)}`,
     ...contract,
     `next: ${String(receipt.nextAction)}`,
+    ...guidance,
   ].join("\n");
 }
 

--- a/packages/cli/test/thin-command.test.ts
+++ b/packages/cli/test/thin-command.test.ts
@@ -285,6 +285,8 @@ test("human preset and task receipts print resolved completion contracts byte-fo
           ok: true,
           command: "task-create",
           summary: "created task task-one at tasks/task-one",
+          taskId: "task-one",
+          packagePath: "tasks/task-one",
           presetId: "standard-task",
           profileId: "baseline",
           outputShape: "repository-diff",
@@ -306,6 +308,8 @@ test("human preset and task receipts print resolved completion contracts byte-fo
       'completionGates: ["ci","code-doc-reconciliation"]',
       expectedContract,
       "next: edit tasks/task-one/task_plan.md, then run ha task start task-one --execution-id <id>",
+      "plan: write the concrete plan at harness/tasks/task-one/task_plan.md",
+      "agenda: use ha task pin task-one to pin it to the CEO agenda",
     ].join("\n");
   assert.deepEqual(Buffer.from(taskOutput), Buffer.from(expectedTask));
 
@@ -336,6 +340,7 @@ test("thin parser derives closed preset and task-create payloads from descriptor
       "milestone",
       "--dry-run",
     ]),
+    tree = parseThinCommand(["task", "list", "--parent", "task-root", "--depth", "all", "--search", "needle"]),
     inspect = parseThinCommand(["preset", "inspect", "standard-task", "--locale", "en-US"]),
     check = parseThinCommand(["preset", "check", "standard-task", "--snapshot-digest", `sha256:${"a".repeat(64)}`]),
     validate = parseThinCommand(["preset", "validate", "--source", "package"]),
@@ -345,7 +350,7 @@ test("thin parser derives closed preset and task-create payloads from descriptor
     uninstall = parseThinCommand(["preset", "uninstall", "standard-task", "--dry-run"]),
     upgrade = parseThinCommand(["preset", "upgrade", "task-1"]);
   assert.equal(
-    [create, inspect, check, validate, install, seed, audit, uninstall, upgrade].every((result) => result.ok),
+    [create, tree, inspect, check, validate, install, seed, audit, uninstall, upgrade].every((result) => result.ok),
     true,
   );
   if (create.ok) {
@@ -358,6 +363,13 @@ test("thin parser derives closed preset and task-create payloads from descriptor
       dryRun: true,
     });
   }
+  if (tree.ok)
+    assert.deepEqual(tree.command.action, {
+      kind: "task-list",
+      parentTaskId: "task-root",
+      depth: "all",
+      search: "needle",
+    });
   if (inspect.ok) {
     assert.equal(inspect.command.method, "repo.preset.inspect");
     assert.deepEqual(inspect.command.action, {

--- a/packages/daemon/src/doc-sync-adjudication.ts
+++ b/packages/daemon/src/doc-sync-adjudication.ts
@@ -174,7 +174,7 @@ export function scannerRead(input: Input): DocCandidateScan {
     ...(!taskScoped ? { selection: input.action.paths as string[] } : {}),
     ...(typeof input.action.taskId === "string" ? { taskId: input.action.taskId } : {}),
   });
-  if (!taskScoped) validateSelectedDocPaths(input.rootDir, input.action.paths as string[], scan);
+  if (!taskScoped) validateSelectedDocPaths(input.action.paths as string[], scan);
   return scan;
 }
 
@@ -205,6 +205,6 @@ export function scannerSubmit(input: Input): DocCandidateScan {
     ...(typeof input.action.taskId === "string" ? { taskId: input.action.taskId } : {}),
     ...(typeof input.action.executionId === "string" ? { executionId: input.action.executionId } : {}),
   });
-  if (!taskScoped) validateSelectedDocPaths(input.rootDir, input.action.paths as string[], scan);
+  if (!taskScoped) validateSelectedDocPaths(input.action.paths as string[], scan);
   return scan;
 }

--- a/packages/daemon/src/doc-sync-candidate-scanner.ts
+++ b/packages/daemon/src/doc-sync-candidate-scanner.ts
@@ -78,7 +78,7 @@ export function scanDocCandidates(input: {
           : (() => {
               throw docSyncError("task_not_found", `Task ${input.taskId} has no projected package path.`);
             })(),
-    selected = input.selection?.map((value) => documentPath(value)),
+    selected = input.selection?.map((value) => documentPath(normalizeSelectedPath(ledger.authoredPrefix, value))),
     events = input.store.read().events,
     pendingPaths = events
       .filter((event) => input.store.publication(event).commitSha === null)
@@ -319,22 +319,8 @@ export function scanDocCandidates(input: {
   }
 }
 
-export function validateSelectedDocPaths(rootDir: string, selected: readonly string[], scan: DocCandidateScan): void {
+export function validateSelectedDocPaths(selected: readonly string[], scan: DocCandidateScan): void {
   if (selected.length === 0) return;
-  const authoredPrefix = resolveLedgerGitLayout(rootDir).authoredPrefix,
-    prefixed = authoredPrefix
-      ? selected.filter((value) => value === authoredPrefix || value.startsWith(`${authoredPrefix}/`))
-      : [];
-  if (prefixed.length > 0) {
-    const rewritten = prefixed.map((value) => value.slice(`${authoredPrefix}/`.length));
-    throw docSyncError(
-      "invalid_command",
-      [
-        `doc --path requires authored-root-relative paths; drop the '${authoredPrefix}/' prefix and retry with `,
-        `${rewritten.map((value) => `'${value}'`).join(", ")}`,
-      ].join(""),
-    );
-  }
   const missing = scan.rows
     .filter((row) => row.state === "clean" && row.baseBlobSha256 === null && row.candidateBlobSha256 === null)
     .map((row) => ({
@@ -342,6 +328,10 @@ export function validateSelectedDocPaths(rootDir: string, selected: readonly str
       reason: "selected doc-sync path does not match an authored candidate",
     }));
   if (missing[0]) throw docSyncError("document_not_found", blockedCandidateNextAction(missing[0]));
+}
+
+function normalizeSelectedPath(authoredPrefix: string, value: string): string {
+  return authoredPrefix && value.startsWith(`${authoredPrefix}/`) ? value.slice(authoredPrefix.length + 1) : value;
 }
 
 export function intentFromScan(

--- a/packages/daemon/src/protocol/daemon-protocol-commands-task-surface.ts
+++ b/packages/daemon/src/protocol/daemon-protocol-commands-task-surface.ts
@@ -258,7 +258,7 @@ export const taskSurfaceProtocolCommands = Object.freeze([
     id: "task-list",
     phase: "W3",
     path: ["task", "list"],
-    summary: "List Task projection rows with canonical lifecycle and metadata filters.",
+    summary: "List Task projection rows or a recursive parent subtree with canonical filters.",
     method: "repo.task.run",
     inputs: [
       cliInput(
@@ -309,6 +309,16 @@ export const taskSurfaceProtocolCommands = Object.freeze([
         code: "invalid_field",
         nextAction: "Use one parent task id.",
       }),
+      cliInput(
+        "--depth",
+        "single",
+        false,
+        {
+          code: "invalid_field",
+          nextAction: "Use --depth <positive-integer|all> together with --parent <task-id>.",
+        },
+        { regex: "^(?:[1-9][0-9]*|all)$" },
+      ),
       cliInput(
         "--updated-after",
         "single",

--- a/packages/daemon/src/repo-cell-evidence.ts
+++ b/packages/daemon/src/repo-cell-evidence.ts
@@ -1,4 +1,5 @@
 import { consumeKnownError } from "../../kernel/src/index.ts";
+import { renderTaskIndexPayload } from "./task-index-query.ts";
 
 export function decodeEvidencePayload(evidence: string): unknown {
   const tag = evidence.indexOf(":");
@@ -14,6 +15,8 @@ export function decodeEvidencePayload(evidence: string): unknown {
 }
 
 export function renderEvidencePayload(payload: unknown): string {
+  const taskIndex = renderTaskIndexPayload(payload);
+  if (taskIndex !== null) return taskIndex;
   if (Array.isArray(payload)) return renderEvidenceRows(payload);
   if (payload === null || typeof payload !== "object") return String(payload);
   const entries = Object.entries(payload),

--- a/packages/daemon/src/repo-cell-task-create.ts
+++ b/packages/daemon/src/repo-cell-task-create.ts
@@ -11,8 +11,9 @@ export function readResult(
   value: object,
   revision: number,
   worktreeVisible: boolean | null,
+  projectedCut?: { readonly status: "ready" | "pending"; readonly watermark: number; readonly sourceRevision: number },
 ): WriteReceipt {
-  const cut = cell.projection.list(),
+  const cut = projectedCut ?? cell.projection.list(),
     ready = cut.status === "ready",
     base = {
       opId,

--- a/packages/daemon/src/repo-cell-task-query.ts
+++ b/packages/daemon/src/repo-cell-task-query.ts
@@ -18,6 +18,7 @@ import {
 import type { RepoCellBinding, RepoTaskAction } from "./repo-cell-types.ts";
 import type { TaskQueryReadModel } from "./task-query-read.ts";
 import { resolveTaskRootThreshold, resolveTaskWipLimit } from "./task-wip-settings.ts";
+import { selectTaskIndex } from "./task-index-query.ts";
 
 export interface TaskQueryCell {
   readonly input: { readonly repoId: string };
@@ -34,7 +35,13 @@ export interface TaskQueryCell {
     workspaceId: string,
     expectedRevision: number,
   ) => string;
-  readonly readResult: (opId: string, value: object, revision: number, worktreeVisible: boolean | null) => WriteReceipt;
+  readonly readResult: (
+    opId: string,
+    value: object,
+    revision: number,
+    worktreeVisible: boolean | null,
+    cut?: { readonly status: "ready" | "pending"; readonly watermark: number; readonly sourceRevision: number },
+  ) => WriteReceipt;
   readonly cellCodedError: (code: string, message: string) => Error;
   readonly requiredCellText: (value: unknown, name: string) => string;
   readonly wipSnapshotEntries: () => readonly TaskWipSnapshotEntryV1[];
@@ -45,78 +52,109 @@ export interface TaskQueryCell {
 
 export function listTasks(cell: TaskQueryCell, action: RepoTaskAction, binding: RepoCellBinding): WriteReceipt {
   const query = cell.taskListQueryFromAction(action),
-    hasPostFilter = ["module", "workKind", "riskTier", "urgency", "parentTaskId", "search"].some(
-      (field) => action[field] !== undefined,
-    );
-  if (hasPostFilter && (query.limit !== undefined || query.cursor !== undefined))
+    depth = taskListDepth(action.depth);
+  if (depth === null)
     throw cell.cellCodedError(
       "invalid_command",
-      [
-        "Task list pagination cannot be combined with module, kind, risk, ",
-        "urgency, parent, or search filters; narrow those filters first, then ",
-        "page the result.",
-      ].join(""),
+      "Task list depth must be a positive integer or all; use it with --parent <task-id>.",
     );
-  const read = cell.queryRead().guiTasks(query),
-    rootSetting = resolveTaskRootThreshold(cell.rootDir),
-    childCounts = cell.directChildCounts(),
-    search = typeof action.search === "string" ? action.search.toLocaleLowerCase() : null;
-  const rows = read.rows.filter((row) => {
-    const task = row.snapshot.task,
-      metadata = task?.metadata;
-    return (
-      (!action.status || task?.status === action.status) &&
-      (!action.module ||
-        metadata?.moduleKey === action.module ||
-        row.placement.moduleKeys.includes(String(action.module))) &&
-      (!action.workKind || metadata?.workKind === action.workKind) &&
-      (!action.riskTier || metadata?.riskTier === action.riskTier) &&
-      (!action.urgency || metadata?.urgency === action.urgency) &&
-      (!action.parentTaskId ||
-        metadata?.parentTaskId === action.parentTaskId ||
-        row.placement.parentTaskId === action.parentTaskId) &&
-      (!search || `${row.taskId}\n${task?.title ?? ""}`.toLocaleLowerCase().includes(search))
+  if (depth !== undefined && typeof action.parentTaskId !== "string")
+    throw cell.cellCodedError(
+      "invalid_command",
+      "Task list --depth requires --parent <task-id> so the recursive subtree has one root.",
     );
-  });
-  return cell.readResult(
-    cell.operationId(action, binding, cell.input.repoId, read.sourceRevision),
-    {
-      rows: rows.map((row) => {
-        const task = row.snapshot.task,
-          directChildCount = childCounts.get(row.taskId) ?? 0,
-          rootAssessment = task
-            ? deriveTaskRoot(
-                {
-                  taskId: row.taskId,
-                  title: task.title,
-                  status: task.status,
-                  taskClass: task.taskClass,
-                  packageDisposition: task.packageDisposition ?? "active",
-                  hasCloseoutEvidence: hasCloseoutEvidence(row.snapshot.executions),
-                  directChildCount,
-                },
-                rootSetting.threshold,
-              )
-            : null;
-        return {
-          taskId: row.taskId,
-          status: task?.status ?? "unknown",
-          title: task?.title ?? "",
-          module: task?.metadata?.moduleKey ?? "",
-          updatedAt: row.updatedAt,
-          packagePath: row.packagePath,
-          packageDisposition: row.placement.packageDisposition,
-          taskClass: task?.taskClass ?? "unknown",
-          rootAssessment,
-        };
-      }),
-      count: rows.length,
-      warnings: read.warnings,
-      ...(read.page ? { page: read.page } : {}),
+  const read = cell.projection.readTaskIndex();
+  let selected: ReturnType<typeof selectTaskIndex>;
+  try {
+    selected = selectTaskIndex(read.rows, {
+      ...(typeof action.parentTaskId === "string" ? { parentTaskId: action.parentTaskId } : {}),
+      ...(depth === undefined ? {} : { depth }),
+      filters: {
+        ...(query.status ? { status: query.status } : {}),
+        ...(typeof action.module === "string" ? { module: action.module } : {}),
+        ...(typeof action.workKind === "string" ? { workKind: action.workKind } : {}),
+        ...(typeof action.riskTier === "string" ? { riskTier: action.riskTier } : {}),
+        ...(typeof action.urgency === "string" ? { urgency: action.urgency } : {}),
+        ...(typeof action.search === "string" ? { search: action.search } : {}),
+        ...(query.updatedAfter ? { updatedAfter: query.updatedAfter } : {}),
+        ...(query.updatedBefore ? { updatedBefore: query.updatedBefore } : {}),
+      },
+      ...(query.limit === undefined ? {} : { limit: query.limit }),
+      ...(query.cursor === undefined ? {} : { cursor: query.cursor }),
+    });
+  } catch (error) {
+    if (error instanceof Error && error.message === "task list cursor is invalid")
+      throw cell.cellCodedError("invalid_command", "Task list cursor is invalid; restart the filtered query.");
+    throw error;
+  }
+  const rootSetting = resolveTaskRootThreshold(cell.rootDir),
+    value =
+      selected.mode === "tree"
+        ? {
+            schema: "task-list/v2" as const,
+            mode: "tree" as const,
+            parentTaskId: action.parentTaskId,
+            depth,
+            rows: selected.rows,
+            count: selected.count,
+            warnings: read.warnings,
+            ...(selected.page ? { page: selected.page } : {}),
+          }
+        : {
+            schema: "task-list/v2" as const,
+            mode: "flat" as const,
+            rows: selected.rows.map((row) => {
+              const directChildCount = selected.childCounts.get(row.taskId) ?? 0;
+              return {
+                taskId: row.taskId,
+                status: row.status,
+                title: row.title,
+                pinned: row.pinned,
+                module: row.moduleKey ?? "",
+                updatedAt: row.updatedAt,
+                packagePath: row.packagePath,
+                packageDisposition: row.packageDisposition,
+                taskClass: row.taskClass,
+                rootAssessment: deriveTaskRoot(
+                  {
+                    taskId: row.taskId,
+                    title: row.title,
+                    status: row.status,
+                    taskClass: row.taskClass,
+                    packageDisposition: row.packageDisposition,
+                    hasCloseoutEvidence: false,
+                    directChildCount,
+                  },
+                  rootSetting.threshold,
+                ),
+              };
+            }),
+            count: selected.rows.length,
+            warnings: read.warnings,
+            ...(selected.page ? { page: selected.page } : {}),
+          };
+  const payload = {
+      ...value,
+      status: read.status,
+      watermark: read.watermark,
+      sourceRevision: read.sourceRevision,
     },
-    read.sourceRevision,
-    null,
-  );
+    receipt = cell.readResult(
+      cell.operationId(action, binding, cell.input.repoId, read.sourceRevision),
+      payload,
+      read.sourceRevision,
+      null,
+      read,
+    );
+  return { ...receipt, ...payload } as WriteReceipt;
+}
+
+function taskListDepth(value: unknown): number | "all" | undefined | null {
+  if (value === undefined) return undefined;
+  if (value === "all") return value;
+  const depth = typeof value === "number" ? value : typeof value === "string" ? Number(value) : Number.NaN;
+  if (!Number.isSafeInteger(depth) || depth < 1) return null;
+  return depth;
 }
 
 export function taskWipEnteringAction(

--- a/packages/daemon/src/task-index-query.ts
+++ b/packages/daemon/src/task-index-query.ts
@@ -1,0 +1,244 @@
+import { consumeKnownError, type TaskIndexProjectionRow } from "../../kernel/src/index.ts";
+
+export interface TaskIndexFilters {
+  readonly status?: string;
+  readonly module?: string;
+  readonly workKind?: string;
+  readonly riskTier?: string;
+  readonly urgency?: string;
+  readonly search?: string;
+  readonly updatedAfter?: string;
+  readonly updatedBefore?: string;
+}
+
+export interface TaskTreeNode {
+  readonly taskId: string;
+  readonly title: string;
+  readonly status: string;
+  readonly pinned: boolean;
+  readonly children: readonly TaskTreeNode[];
+}
+
+export type TaskIndexSelection =
+  | {
+      readonly mode: "flat";
+      readonly rows: readonly TaskIndexProjectionRow[];
+      readonly childCounts: ReadonlyMap<string, number>;
+      readonly page?: TaskIndexPage;
+    }
+  | {
+      readonly mode: "tree";
+      readonly rows: readonly TaskTreeNode[];
+      readonly count: number;
+      readonly page?: TaskIndexPage;
+    };
+
+interface TaskIndexPage {
+  readonly limit: number;
+  readonly cursor: string | null;
+  readonly nextCursor: string | null;
+}
+
+interface MutableTreeNode {
+  readonly taskId: string;
+  readonly title: string;
+  readonly status: string;
+  readonly pinned: boolean;
+  children: MutableTreeNode[];
+}
+
+export function selectTaskIndex(
+  source: Iterable<TaskIndexProjectionRow>,
+  input: {
+    readonly parentTaskId?: string;
+    readonly depth?: number | "all";
+    readonly filters?: TaskIndexFilters;
+    readonly limit?: number;
+    readonly cursor?: string;
+  },
+): TaskIndexSelection {
+  const rows: TaskIndexProjectionRow[] = [],
+    children = new Map<string, TaskIndexProjectionRow[]>(),
+    childCounts = new Map<string, number>();
+  for (const row of source) {
+    rows.push(row);
+    if (row.parentTaskId !== null) {
+      const siblings = children.get(row.parentTaskId);
+      if (siblings) siblings.push(row);
+      else children.set(row.parentTaskId, [row]);
+      childCounts.set(row.parentTaskId, (childCounts.get(row.parentTaskId) ?? 0) + 1);
+    }
+  }
+  for (const siblings of children.values()) siblings.sort(compareTaskRows);
+  const filters = input.filters ?? {};
+  if (input.depth === undefined) {
+    const candidates = input.parentTaskId === undefined ? rows : (children.get(input.parentTaskId) ?? []),
+      filtered = candidates.filter((row) => matchesFilters(row, filters)).sort(compareTaskRows),
+      page = paginate(filtered, input.limit, input.cursor);
+    return {
+      mode: "flat",
+      rows: page.rows,
+      childCounts,
+      ...(page.page ? { page: page.page } : {}),
+    };
+  }
+  const roots = children.get(input.parentTaskId!) ?? [],
+    tree = buildTree(roots, children, input.depth, filters),
+    page = paginate(tree, input.limit, input.cursor);
+  return {
+    mode: "tree",
+    rows: page.rows,
+    count: countNodes(page.rows),
+    ...(page.page ? { page: page.page } : {}),
+  };
+}
+
+export function renderTaskIndexPayload(payload: unknown): string | null {
+  if (payload === null || typeof payload !== "object") return null;
+  const record = payload as Record<string, unknown>;
+  if (record.schema !== "task-list/v2" || !Array.isArray(record.rows)) return null;
+  const rows = record.rows as readonly Record<string, unknown>[],
+    body =
+      record.mode === "tree"
+        ? renderTreeRows(rows)
+        : rows
+            .map(
+              (row) =>
+                `${row.pinned === true ? "📌 " : ""}${String(row.taskId)}\t${String(row.status)}\t${String(row.title)}\t${String(row.module ?? "")}\t${String(row.updatedAt ?? "")}\t${String(row.packagePath ?? "")}\t${String(row.packageDisposition ?? "")}\t${String(row.taskClass ?? "")}`,
+            )
+            .join("\n"),
+    page = record.page && typeof record.page === "object" ? `  page=${JSON.stringify(record.page)}` : "";
+  return [
+    `${record.mode === "tree" ? "tree" : "rows"}:`,
+    body || "(none)",
+    `count=${String(record.count ?? rows.length)}  status=${String(record.status ?? "unknown")}  watermark=${String(record.watermark ?? "unknown")}  sourceRevision=${String(record.sourceRevision ?? "unknown")}${page}`,
+  ].join("\n");
+}
+
+function matchesFilters(row: TaskIndexProjectionRow, filters: TaskIndexFilters): boolean {
+  const search = filters.search?.toLocaleLowerCase();
+  return (
+    (!filters.status || row.status === filters.status) &&
+    (!filters.module || row.moduleKey === filters.module) &&
+    (!filters.workKind || row.workKind === filters.workKind) &&
+    (!filters.riskTier || row.riskTier === filters.riskTier) &&
+    (!filters.urgency || row.urgency === filters.urgency) &&
+    (!filters.updatedAfter || row.updatedAt >= filters.updatedAfter) &&
+    (!filters.updatedBefore || row.updatedAt <= filters.updatedBefore) &&
+    (!search || row.taskId.toLocaleLowerCase().startsWith(search) || row.title.toLocaleLowerCase().includes(search))
+  );
+}
+
+function buildTree(
+  roots: readonly TaskIndexProjectionRow[],
+  children: ReadonlyMap<string, readonly TaskIndexProjectionRow[]>,
+  depth: number | "all",
+  filters: TaskIndexFilters,
+): MutableTreeNode[] {
+  const limit = depth === "all" ? Number.POSITIVE_INFINITY : depth,
+    seen = new Set<string>(),
+    matches = new Set<string>(),
+    createNode = (row: TaskIndexProjectionRow) => {
+      if (matchesFilters(row, filters)) matches.add(row.taskId);
+      return treeNode(row);
+    },
+    tree = roots.map(createNode),
+    stack = tree.map((node) => ({ node, level: 1 })).reverse();
+  while (stack.length) {
+    const { node, level } = stack.pop()!;
+    if (seen.has(node.taskId)) continue;
+    seen.add(node.taskId);
+    if (level >= limit) continue;
+    node.children = (children.get(node.taskId) ?? []).filter((row) => !seen.has(row.taskId)).map(createNode);
+    for (let index = node.children.length - 1; index >= 0; index -= 1)
+      stack.push({ node: node.children[index]!, level: level + 1 });
+  }
+  const postorder = tree.map((node) => ({ node, visited: false }));
+  while (postorder.length) {
+    const frame = postorder.pop()!;
+    if (!frame.visited) {
+      postorder.push({ node: frame.node, visited: true });
+      for (const child of frame.node.children) postorder.push({ node: child, visited: false });
+    } else
+      frame.node.children = frame.node.children.filter(
+        (child) => matches.has(child.taskId) || child.children.length > 0,
+      );
+  }
+  return tree.filter((node) => matches.has(node.taskId) || node.children.length > 0);
+}
+
+function treeNode(row: TaskIndexProjectionRow): MutableTreeNode {
+  return {
+    taskId: row.taskId,
+    title: row.title,
+    status: row.status,
+    pinned: row.pinned,
+    children: [],
+  };
+}
+
+function paginate<T extends { readonly taskId: string }>(
+  rows: readonly T[],
+  limit: number | undefined,
+  cursor: string | undefined,
+): { readonly rows: readonly T[]; readonly page?: TaskIndexPage } {
+  if (limit === undefined && cursor === undefined) return { rows };
+  const pageLimit = limit ?? 100,
+    after = cursor === undefined ? null : decodeCursor(cursor),
+    remaining = after === null ? rows : rows.filter((row) => row.taskId > after),
+    visible = remaining.slice(0, pageLimit),
+    last = visible.at(-1);
+  return {
+    rows: visible,
+    page: {
+      limit: pageLimit,
+      cursor: cursor ?? null,
+      nextCursor: remaining.length > pageLimit && last ? encodeCursor(last.taskId) : null,
+    },
+  };
+}
+
+function decodeCursor(value: string): string {
+  try {
+    const parsed = JSON.parse(Buffer.from(value, "base64url").toString("utf8"));
+    if (Array.isArray(parsed) && parsed.length === 1 && typeof parsed[0] === "string" && parsed[0]) return parsed[0];
+  } catch (error) {
+    // The caller translates this stable error to the command receipt.
+    consumeKnownError(error);
+  }
+  throw new Error("task list cursor is invalid");
+}
+
+function encodeCursor(taskId: string): string {
+  return Buffer.from(JSON.stringify([taskId]), "utf8").toString("base64url");
+}
+
+function compareTaskRows(left: { readonly taskId: string }, right: { readonly taskId: string }): number {
+  return left.taskId.localeCompare(right.taskId);
+}
+
+function countNodes(rows: readonly TaskTreeNode[]): number {
+  let count = 0;
+  const stack = [...rows];
+  while (stack.length) {
+    const node = stack.pop()!;
+    count += 1;
+    stack.push(...node.children);
+  }
+  return count;
+}
+
+function renderTreeRows(rows: readonly Record<string, unknown>[]): string {
+  const lines: string[] = [],
+    stack = rows.map((row) => ({ row, depth: 0 })).reverse();
+  while (stack.length) {
+    const { row, depth } = stack.pop()!;
+    lines.push(
+      `${"  ".repeat(depth)}${row.pinned === true ? "📌 " : ""}${String(row.taskId)} [${String(row.status)}] ${String(row.title)}`,
+    );
+    const children = Array.isArray(row.children) ? (row.children as Record<string, unknown>[]) : [];
+    for (let index = children.length - 1; index >= 0; index -= 1)
+      stack.push({ row: children[index]!, depth: depth + 1 });
+  }
+  return lines.join("\n");
+}

--- a/packages/daemon/src/task-index-query.ts
+++ b/packages/daemon/src/task-index-query.ts
@@ -102,16 +102,26 @@ export function renderTaskIndexPayload(payload: unknown): string | null {
       record.mode === "tree"
         ? renderTreeRows(rows)
         : rows
-            .map(
-              (row) =>
-                `${row.pinned === true ? "📌 " : ""}${String(row.taskId)}\t${String(row.status)}\t${String(row.title)}\t${String(row.module ?? "")}\t${String(row.updatedAt ?? "")}\t${String(row.packagePath ?? "")}\t${String(row.packageDisposition ?? "")}\t${String(row.taskClass ?? "")}`,
+            .map((row) =>
+              [
+                `${row.pinned === true ? "📌 " : ""}${String(row.taskId)}`,
+                String(row.status),
+                String(row.title),
+                String(row.module ?? ""),
+                String(row.updatedAt ?? ""),
+                String(row.packagePath ?? ""),
+                String(row.packageDisposition ?? ""),
+                String(row.taskClass ?? ""),
+              ].join("\t"),
             )
             .join("\n"),
     page = record.page && typeof record.page === "object" ? `  page=${JSON.stringify(record.page)}` : "";
   return [
     `${record.mode === "tree" ? "tree" : "rows"}:`,
     body || "(none)",
-    `count=${String(record.count ?? rows.length)}  status=${String(record.status ?? "unknown")}  watermark=${String(record.watermark ?? "unknown")}  sourceRevision=${String(record.sourceRevision ?? "unknown")}${page}`,
+    `count=${String(record.count ?? rows.length)}  status=${String(record.status ?? "unknown")}  ` +
+      `watermark=${String(record.watermark ?? "unknown")}  ` +
+      `sourceRevision=${String(record.sourceRevision ?? "unknown")}${page}`,
   ].join("\n");
 }
 
@@ -234,7 +244,8 @@ function renderTreeRows(rows: readonly Record<string, unknown>[]): string {
   while (stack.length) {
     const { row, depth } = stack.pop()!;
     lines.push(
-      `${"  ".repeat(depth)}${row.pinned === true ? "📌 " : ""}${String(row.taskId)} [${String(row.status)}] ${String(row.title)}`,
+      `${"  ".repeat(depth)}${row.pinned === true ? "📌 " : ""}${String(row.taskId)} ` +
+        `[${String(row.status)}] ${String(row.title)}`,
     );
     const children = Array.isArray(row.children) ? (row.children as Record<string, unknown>[]) : [];
     for (let index = children.length - 1; index >= 0; index -= 1)

--- a/packages/daemon/test/doc-sync-slice-a-implicit-lease.test.ts
+++ b/packages/daemon/test/doc-sync-slice-a-implicit-lease.test.ts
@@ -238,10 +238,18 @@ test("path and implicit submits ride the repository prose channel when the task 
       [[`${packagePath}/artifacts/reports/leased.md`, "eligible"]],
       JSON.stringify(status.evidence),
     );
+    const prefixedStatus = await cell.run(
+      {
+        kind: "doc-status",
+        paths: [`harness/${packagePath}/artifacts/reports/leased.md`],
+      },
+      person,
+    );
+    assert.deepEqual(rows(prefixedStatus.evidence), rows(status.evidence));
     const scoped = await cell.run(
       {
         kind: "doc-submit",
-        paths: [`${packagePath}/artifacts/reports/leased.md`],
+        paths: [`harness/${packagePath}/artifacts/reports/leased.md`],
       },
       person,
     );

--- a/packages/daemon/test/doc-sync-slice-a.test.ts
+++ b/packages/daemon/test/doc-sync-slice-a.test.ts
@@ -152,9 +152,7 @@ test("selected doc-sync paths are authored-relative candidates and zero-write su
     assert.match(String((authored as Record<string, unknown>).summary), /applied count: 1/u);
 
     const repoRelative = await cell.run({ kind: "doc-submit", paths: ["harness/context/selected.md"] }, binding);
-    assert.equal(repoRelative.outcome, "op_rejected", JSON.stringify(repoRelative));
-    assert.equal(repoRelative.code, "invalid_command");
-    assert.match(repoRelative.nextAction ?? "", /authored-root-relative/u);
+    assert.equal(repoRelative.outcome, "no_changes", JSON.stringify(repoRelative));
 
     const missing = await cell.run({ kind: "doc-submit", paths: ["context/missing.md"] }, binding);
     assert.equal(missing.outcome, "op_rejected", JSON.stringify(missing));

--- a/packages/daemon/test/task-index-query.test.ts
+++ b/packages/daemon/test/task-index-query.test.ts
@@ -1,0 +1,125 @@
+// harness-test-tier: fast
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { TaskIndexProjectionRow } from "../../kernel/src/index.ts";
+import { renderTaskIndexPayload, selectTaskIndex } from "../src/task-index-query.ts";
+
+test("task index expands bounded and full-depth subtrees with search context and pins", () => {
+  const rows = [
+      row("task_alpha", "Alpha", "root"),
+      row("task_beta", "Beta needle", "root", true),
+      row("task_match", "Deep match", "task_alpha"),
+      row("task_hidden", "Hidden", "task_match"),
+    ],
+    shallow = selectTaskIndex(rows, { parentTaskId: "root", depth: 1 }),
+    deepSearch = selectTaskIndex(rows, {
+      parentTaskId: "root",
+      depth: "all",
+      filters: { search: "task_ma" },
+    });
+  assert.equal(shallow.mode, "tree");
+  assert.deepEqual(
+    shallow.rows.map(({ taskId, pinned, children }) => ({ taskId, pinned, children: children.length })),
+    [
+      { taskId: "task_alpha", pinned: false, children: 0 },
+      { taskId: "task_beta", pinned: true, children: 0 },
+    ],
+  );
+  assert.equal(deepSearch.mode, "tree");
+  assert.deepEqual(deepSearch.rows, [
+    {
+      taskId: "task_alpha",
+      title: "Alpha",
+      status: "planned",
+      pinned: false,
+      children: [
+        {
+          taskId: "task_match",
+          title: "Deep match",
+          status: "planned",
+          pinned: false,
+          children: [],
+        },
+      ],
+    },
+  ]);
+  assert.match(
+    renderTaskIndexPayload({
+      schema: "task-list/v2",
+      mode: "tree",
+      rows: shallow.rows,
+      count: shallow.count,
+      status: "ready",
+      watermark: 4,
+      sourceRevision: 4,
+    })!,
+    /📌 task_beta \[planned\] Beta needle/u,
+  );
+});
+
+test("filtered task index pagination is keyset-equivalent", () => {
+  const rows = [row("task_alpha", "Needle one", "root"), row("task_beta", "Needle two", "root")],
+    first = selectTaskIndex(rows, {
+      parentTaskId: "root",
+      filters: { search: "needle" },
+      limit: 1,
+    });
+  assert.equal(first.mode, "flat");
+  assert.deepEqual(
+    first.rows.map(({ taskId }) => taskId),
+    ["task_alpha"],
+  );
+  assert.ok(first.page?.nextCursor);
+  const second = selectTaskIndex(rows, {
+    parentTaskId: "root",
+    filters: { search: "needle" },
+    limit: 1,
+    cursor: first.page!.nextCursor!,
+  });
+  assert.deepEqual(
+    second.rows.map(({ taskId }) => taskId),
+    ["task_beta"],
+  );
+  assert.equal(second.page?.nextCursor, null);
+});
+
+test("a 200-node projection iterable is consumed once and all-depth expansion stays iterative", () => {
+  const rows = Array.from({ length: 200 }, (_, index) =>
+    row(
+      `task_${String(index).padStart(3, "0")}`,
+      `Node ${index}`,
+      index === 0 ? "root" : `task_${String(index - 1).padStart(3, "0")}`,
+    ),
+  );
+  let reads = 0;
+  const source: Iterable<TaskIndexProjectionRow> = {
+      *[Symbol.iterator]() {
+        for (const value of rows) {
+          reads += 1;
+          yield value;
+        }
+      },
+    },
+    selected = selectTaskIndex(source, { parentTaskId: "root", depth: "all" });
+  assert.equal(reads, 200);
+  assert.equal(selected.mode, "tree");
+  assert.equal(selected.count, 200);
+});
+
+function row(taskId: string, title: string, parentTaskId: string | null, pinned = false): TaskIndexProjectionRow {
+  return {
+    taskId,
+    title,
+    status: "planned",
+    pinned,
+    parentTaskId,
+    moduleKey: null,
+    workKind: "feat",
+    riskTier: "medium",
+    urgency: null,
+    taskClass: "standard",
+    packageDisposition: "active",
+    packagePath: `tasks/${taskId}`,
+    updatedAt: "2026-08-30T00:00:00.000Z",
+  };
+}

--- a/packages/daemon/test/task-surface-reads-leases.integration.test.ts
+++ b/packages/daemon/test/task-surface-reads-leases.integration.test.ts
@@ -10,10 +10,7 @@ import {
   readTaskProjection,
   rebuildTaskProjection,
 } from "../../kernel/src/index.ts";
-import {
-  canonicalRoot,
-  workspaceId,
-} from "../src/protocol/daemon-protocol.contract.ts";
+import { canonicalRoot, workspaceId } from "../src/protocol/daemon-protocol.contract.ts";
 import { openBootstrappedRepoCell as openRepoCell } from "./repo-settings.fixture.ts";
 import { realizeTaskPlanFixture } from "../../../tools/fixtures/task-plan.mjs";
 
@@ -63,11 +60,32 @@ test("task read surfaces, dry-runs, idempotency, structured input, and supersede
     await realizeTaskPlanFixture(rootDir, String(created.packagePath), (planPath) =>
       cell!.run({ kind: "doc-submit", paths: [planPath] }, binding),
     );
-    mkdirSync(path.join(rootDir, "harness/legacy/source"), { recursive: true });
-    writeFileSync(
-      path.join(rootDir, "harness/legacy/source/old.md"),
-      "# Legacy\n",
+    for (const action of [
+      { kind: "task-create", taskId: "task_child_alpha", title: "Child Alpha", parentTaskId: "task_source" },
+      { kind: "task-create", taskId: "task_child_beta", title: "Child Beta", parentTaskId: "task_source" },
+      {
+        kind: "task-create",
+        taskId: "task_grandchild",
+        title: "Grandchild Needle",
+        parentTaskId: "task_child_alpha",
+      },
+    ] as const)
+      assert.equal((await cell.run(action, binding)).outcome, "applied");
+    assert.equal(
+      (
+        await cell.run(
+          {
+            kind: "task-amend",
+            taskId: "task_child_beta",
+            patches: [{ field: "pinned", value: "true" }],
+          },
+          binding,
+        )
+      ).outcome,
+      "applied",
     );
+    mkdirSync(path.join(rootDir, "harness/legacy/source"), { recursive: true });
+    writeFileSync(path.join(rootDir, "harness/legacy/source/old.md"), "# Legacy\n");
     writeFileSync(
       path.join(rootDir, "harness/legacy/index.json"),
       JSON.stringify({
@@ -80,10 +98,10 @@ test("task read surfaces, dry-runs, idempotency, structured input, and supersede
         ],
       }),
     );
-    const legacy = (await cell.run(
-      { kind: "task-create", fromLegacyId: "legacy-1" },
-      binding,
-    )) as Record<string, unknown>;
+    const legacy = (await cell.run({ kind: "task-create", fromLegacyId: "legacy-1" }, binding)) as Record<
+      string,
+      unknown
+    >;
     assert.equal(legacy.outcome, "applied", JSON.stringify(legacy));
     const eventCount = makeTaskEventStore({
       repoId: "task-read-surface",
@@ -123,11 +141,7 @@ test("task read surfaces, dry-runs, idempotency, structured input, and supersede
     assert.equal(startPreview.proof?.canonicalVisible, false);
     assert.equal(relationPreview.outcome, "pending");
     assert.equal(relationPreview.proof?.canonicalVisible, false);
-    assert.equal(
-      makeTaskEventStore({ repoId: "task-read-surface", rootDir }).read().events
-        .length,
-      eventCount,
-    );
+    assert.equal(makeTaskEventStore({ repoId: "task-read-surface", rootDir }).read().events.length, eventCount);
     await cell.run(
       {
         kind: "task-relate",
@@ -160,6 +174,27 @@ test("task read surfaces, dry-runs, idempotency, structured input, and supersede
             status: "planned",
             module: "daemon",
             search: "searchable",
+          },
+          binding,
+        ),
+      ),
+      treeReceipt = await cell.run(
+        {
+          kind: "task-list",
+          parentTaskId: "task_source",
+          depth: "all",
+          search: "needle",
+        },
+        binding,
+      ),
+      tree = evidence(treeReceipt),
+      filteredPage = evidence(
+        await cell.run(
+          {
+            kind: "task-list",
+            parentTaskId: "task_source",
+            search: "child",
+            limit: 1,
           },
           binding,
         ),
@@ -199,6 +234,31 @@ test("task read surfaces, dry-runs, idempotency, structured input, and supersede
       (listed.rows as { taskId: string }[]).map((row) => row.taskId),
       ["task_source"],
     );
+    assert.equal(tree.schema, "task-list/v2");
+    assert.equal((treeReceipt as Record<string, unknown>).schema, "task-list/v2");
+    assert.deepEqual((treeReceipt as Record<string, unknown>).rows, tree.rows);
+    assert.deepEqual(tree.rows, [
+      {
+        taskId: "task_child_alpha",
+        title: "Child Alpha",
+        status: "planned",
+        pinned: false,
+        children: [
+          {
+            taskId: "task_grandchild",
+            title: "Grandchild Needle",
+            status: "planned",
+            pinned: false,
+            children: [],
+          },
+        ],
+      },
+    ]);
+    assert.deepEqual(
+      (filteredPage.rows as { taskId: string }[]).map(({ taskId }) => taskId),
+      ["task_child_alpha"],
+    );
+    assert.equal(typeof (filteredPage.page as { nextCursor: unknown }).nextCursor, "string");
     assert.equal((relations.rows as unknown[]).length, 1);
     // #1542: event-backed truth already answers this read; an unmaterialized generated-cache
     // must not stand as a permanent hard-fail warning on an otherwise healthy workspace.
@@ -219,9 +279,7 @@ test("task read surfaces, dry-runs, idempotency, structured input, and supersede
     assert.equal(typeof superseded.replacementTaskId, "string");
     rebuildTaskProjection({ rootDir });
     assert.equal(
-      readTaskProjection({ rootDir }).rows.find(
-        (row) => row.taskId === "task_source",
-      )?.packageDisposition,
+      readTaskProjection({ rootDir }).rows.find((row) => row.taskId === "task_source")?.packageDisposition,
       "archived",
     );
   } finally {
@@ -276,19 +334,10 @@ test("a lapsed lease stays readable through task show and releasable through tas
       "applied",
     );
     const held = String(
-      (
-        (await cell.run(
-          { kind: "task-show", taskId: "task_lease" },
-          reclaimer,
-        )) as Record<string, unknown>
-      ).summary,
+      ((await cell.run({ kind: "task-show", taskId: "task_lease" }, reclaimer)) as Record<string, unknown>).summary,
     );
     assert.match(held, /\nlease: [^\n]*phase=held/u, held);
-    assert.match(
-      held,
-      /\nlease: [^\n]*expiresAt=2026-08-15T02:01:00\.000Z/u,
-      held,
-    );
+    assert.match(held, /\nlease: [^\n]*expiresAt=2026-08-15T02:01:00\.000Z/u, held);
     const earlyReclaim = await cell.run(
       {
         kind: "task-release",
@@ -297,35 +346,14 @@ test("a lapsed lease stays readable through task show and releasable through tas
       },
       reclaimer,
     );
-    assert.equal(
-      earlyReclaim.outcome,
-      "op_rejected",
-      JSON.stringify(earlyReclaim),
-    );
-    assert.equal(
-      (earlyReclaim as Record<string, unknown>).code,
-      "lease_conflict",
-      JSON.stringify(earlyReclaim),
-    );
+    assert.equal(earlyReclaim.outcome, "op_rejected", JSON.stringify(earlyReclaim));
+    assert.equal((earlyReclaim as Record<string, unknown>).code, "lease_conflict", JSON.stringify(earlyReclaim));
     clock = "2026-08-15T03:00:00.000Z";
     const summary = String(
-      (
-        (await cell.run(
-          { kind: "task-show", taskId: "task_lease" },
-          reclaimer,
-        )) as Record<string, unknown>
-      ).summary,
+      ((await cell.run({ kind: "task-show", taskId: "task_lease" }, reclaimer)) as Record<string, unknown>).summary,
     );
-    assert.match(
-      summary,
-      /\nlease: [^\n]*executionId=exe_lapse[^\n]*phase=orphaned/u,
-      summary,
-    );
-    assert.match(
-      summary,
-      /\nlease: [^\n]*expiresAt=2026-08-15T02:01:00\.000Z/u,
-      summary,
-    );
+    assert.match(summary, /\nlease: [^\n]*executionId=exe_lapse[^\n]*phase=orphaned/u, summary);
+    assert.match(summary, /\nlease: [^\n]*expiresAt=2026-08-15T02:01:00\.000Z/u, summary);
     assert.match(summary, /\ntask: [^\n]*status=active[^\n]*/u, summary);
     assert.match(summary, /executions:\n[^\n]*\texe_lapse\t/u, summary);
     // The reporter's bite: the failed append must say when the lease lapsed and name the round to re-enter.
@@ -340,11 +368,7 @@ test("a lapsed lease stays readable through task show and releasable through tas
     )) as Record<string, unknown>;
     assert.equal(bite.outcome, "op_rejected", JSON.stringify(bite));
     assert.equal(bite.code, "progress_lease_required", JSON.stringify(bite));
-    assert.match(
-      String(bite.nextAction),
-      /lapsed at 2026-08-15T02:01:00\.000Z/u,
-      JSON.stringify(bite),
-    );
+    assert.match(String(bite.nextAction), /lapsed at 2026-08-15T02:01:00\.000Z/u, JSON.stringify(bite));
     assert.match(
       String(bite.nextAction),
       /ha task release task_lease, then re-enter the round with ha task start task_lease --execution-id exe_lapse/u,
@@ -365,16 +389,8 @@ test("a lapsed lease stays readable through task show and releasable through tas
       },
       outsider,
     );
-    assert.equal(
-      crossPrincipal.outcome,
-      "op_rejected",
-      JSON.stringify(crossPrincipal),
-    );
-    assert.equal(
-      (crossPrincipal as Record<string, unknown>).code,
-      "lease_conflict",
-      JSON.stringify(crossPrincipal),
-    );
+    assert.equal(crossPrincipal.outcome, "op_rejected", JSON.stringify(crossPrincipal));
+    assert.equal((crossPrincipal as Record<string, unknown>).code, "lease_conflict", JSON.stringify(crossPrincipal));
     const released = await cell.run(
       {
         kind: "task-release",
@@ -384,12 +400,7 @@ test("a lapsed lease stays readable through task show and releasable through tas
       reclaimer,
     );
     assert.equal(released.outcome, "applied", JSON.stringify(released));
-    assert.equal(
-      evidence(
-        await cell.run({ kind: "task-show", taskId: "task_lease" }, reclaimer),
-      ).lease,
-      null,
-    );
+    assert.equal(evidence(await cell.run({ kind: "task-show", taskId: "task_lease" }, reclaimer)).lease, null);
     // The recovery the error prescribes must actually work: same execution re-leases the round, then the append lands.
     assert.equal(
       (
@@ -476,21 +487,13 @@ test("a released round is re-enterable by its own execution and still refuses a 
       "applied",
     );
     // Release ends the lease but not the round: the execution is still active, so a *second* execution stays refused.
-    const second = await cell.run(
-      { kind: "task-start", taskId: "task_round", executionId: "exe_second" },
-      binding,
-    );
+    const second = await cell.run({ kind: "task-start", taskId: "task_round", executionId: "exe_second" }, binding);
     assert.equal(second.outcome, "op_rejected", JSON.stringify(second));
     assert.equal(second.code, "invalid_transition");
     // The adjudicated exit: the same execution re-leases the round it never finished.
-    const rejoined = await cell.run(
-      { kind: "task-start", taskId: "task_round", executionId: "exe_round" },
-      binding,
-    );
+    const rejoined = await cell.run({ kind: "task-start", taskId: "task_round", executionId: "exe_round" }, binding);
     assert.equal(rejoined.outcome, "applied", JSON.stringify(rejoined));
-    const shown = evidence(
-      await cell.run({ kind: "task-show", taskId: "task_round" }, binding),
-    );
+    const shown = evidence(await cell.run({ kind: "task-show", taskId: "task_round" }, binding));
     assert.deepEqual(
       (
         shown.executions as readonly {
@@ -500,10 +503,7 @@ test("a released round is re-enterable by its own execution and still refuses a 
       ).map((row) => `${row.executionId}/${row.state}`),
       ["exe_round/active"],
     );
-    assert.equal(
-      (shown.lease as { readonly executionId: string } | null)?.executionId,
-      "exe_round",
-    );
+    assert.equal((shown.lease as { readonly executionId: string } | null)?.executionId, "exe_round");
     // Re-entry must not require the caller to remember the id. Omitting it used to derive a fresh one,
     // which the round then refused — the reported dead end, reachable with no execution id at all.
     assert.equal(
@@ -519,16 +519,13 @@ test("a released round is re-enterable by its own execution and still refuses a 
       ).outcome,
       "applied",
     );
-    const blind = await cell.run(
-      { kind: "task-start", taskId: "task_round" },
-      binding,
-    );
+    const blind = await cell.run({ kind: "task-start", taskId: "task_round" }, binding);
     assert.equal(blind.outcome, "applied", JSON.stringify(blind));
     assert.equal(
       (
-        evidence(
-          await cell.run({ kind: "task-show", taskId: "task_round" }, binding),
-        ).lease as { readonly executionId: string } | null
+        evidence(await cell.run({ kind: "task-show", taskId: "task_round" }, binding)).lease as {
+          readonly executionId: string;
+        } | null
       )?.executionId,
       "exe_round",
     );
@@ -541,9 +538,7 @@ test("a released round is re-enterable by its own execution and still refuses a 
     rmSync(replay.path, { force: true });
     replay.rebuild();
     assert.deepEqual(
-      replay
-        .read("task_round")
-        .snapshot.executions.map((row) => `${row.executionId}/${row.state}`),
+      replay.read("task_round").snapshot.executions.map((row) => `${row.executionId}/${row.state}`),
       ["exe_round/active"],
     );
     replay.close();
@@ -566,12 +561,7 @@ test("read commands report projection readiness instead of asserting canonical v
     });
     const binding = { actor, source: "local" as const };
     assert.equal(
-      (
-        await cell.run(
-          { kind: "task-create", taskId: "task_ready", title: "Readiness" },
-          binding,
-        )
-      ).outcome,
+      (await cell.run({ kind: "task-create", taskId: "task_ready", title: "Readiness" }, binding)).outcome,
       "applied",
     );
     const listed = await cell.run({ kind: "task-list" }, binding),
@@ -582,10 +572,7 @@ test("read commands report projection readiness instead of asserting canonical v
     assert.equal(payload.watermark, payload.sourceRevision);
     assert.equal(listed.proof?.canonicalVisible, true);
     assert.equal(listed.proof?.appliedCut, payload.watermark);
-    assert.match(
-      String((listed as Record<string, unknown>).summary),
-      /status=ready/u,
-    );
+    assert.match(String((listed as Record<string, unknown>).summary), /status=ready/u);
   } finally {
     await cell?.close();
     rmSync(rootDir, { recursive: true, force: true });

--- a/packages/kernel/src/composition/index.ts
+++ b/packages/kernel/src/composition/index.ts
@@ -21,7 +21,6 @@ export { makeTaskProjection } from "../projection/rebuildable-task-projection.ts
 export type {
   ProjectionPage,
   ReplicaProjectionBasis,
-  TaskIndexProjectionRead,
   TaskIndexProjectionRow,
   TaskProjection,
   TaskProjectionListQuery,

--- a/packages/kernel/src/composition/index.ts
+++ b/packages/kernel/src/composition/index.ts
@@ -21,6 +21,8 @@ export { makeTaskProjection } from "../projection/rebuildable-task-projection.ts
 export type {
   ProjectionPage,
   ReplicaProjectionBasis,
+  TaskIndexProjectionRead,
+  TaskIndexProjectionRow,
   TaskProjection,
   TaskProjectionListQuery,
   TaskRelationProjectionRead,

--- a/packages/kernel/src/domain/transition-document-readiness.ts
+++ b/packages/kernel/src/domain/transition-document-readiness.ts
@@ -165,12 +165,26 @@ export function assertTransitionDocumentReady(kind: TransitionDocumentKind, body
 }
 
 function missingMarkdownSections(body: string, contract: MarkdownDocumentContract): string[] {
-  const sections = markdownSections(body);
+  const sections = markdownSections(body),
+    untouchedScaffold = contract.requiredSections.every((heading) => {
+      const content = sections.get(normalizeHeading(heading));
+      return (
+        !!content?.trim() &&
+        (contract.scaffoldBySection[heading] ?? []).some((scaffold) =>
+          normalizeText(content).includes(normalizeText(scaffold)),
+        )
+      );
+    });
   return contract.requiredSections.filter((heading) => {
     const content = sections.get(normalizeHeading(heading));
     if (!content?.trim()) return true;
-    const normalized = normalizeText(content);
-    return (contract.scaffoldBySection[heading] ?? []).some((scaffold) => normalized.includes(normalizeText(scaffold)));
+    const scaffolds = contract.scaffoldBySection[heading] ?? [],
+      normalized = normalizeText(content),
+      retained = scaffolds.filter((scaffold) => normalized.includes(normalizeText(scaffold)));
+    if (retained.length === 0) return false;
+    if (untouchedScaffold) return true;
+    const remainder = retained.reduce((value, scaffold) => value.replaceAll(normalizeText(scaffold), " "), normalized);
+    return !/[\p{L}\p{N}]/u.test(remainder);
   });
 }
 

--- a/packages/kernel/src/index.ts
+++ b/packages/kernel/src/index.ts
@@ -254,6 +254,8 @@ export type {
   EventPublicationKillpoint,
   ProjectionPage,
   ReplicaProjectionBasis,
+  TaskIndexProjectionRead,
+  TaskIndexProjectionRow,
   TaskProjection,
   TaskProjectionListQuery,
   TaskRelationProjectionRead,

--- a/packages/kernel/src/index.ts
+++ b/packages/kernel/src/index.ts
@@ -254,7 +254,6 @@ export type {
   EventPublicationKillpoint,
   ProjectionPage,
   ReplicaProjectionBasis,
-  TaskIndexProjectionRead,
   TaskIndexProjectionRow,
   TaskProjection,
   TaskProjectionListQuery,

--- a/packages/kernel/src/projection/projection-reads.ts
+++ b/packages/kernel/src/projection/projection-reads.ts
@@ -44,6 +44,29 @@ export interface TaskProjectionListRead {
   readonly warnings: readonly TaskProjectionWarning[];
   readonly page?: ProjectionPage;
 }
+export interface TaskIndexProjectionRow {
+  readonly taskId: string;
+  readonly title: string;
+  readonly status: import("../domain/task.ts").TaskV1["status"];
+  readonly pinned: boolean;
+  readonly parentTaskId: string | null;
+  readonly moduleKey: string | null;
+  readonly workKind: import("../domain/task.ts").TaskMetadataV1["workKind"];
+  readonly riskTier: import("../domain/task.ts").TaskMetadataV1["riskTier"];
+  readonly urgency: import("../domain/task.ts").TaskMetadataV1["urgency"];
+  readonly taskClass: import("../domain/task.ts").TaskV1["taskClass"];
+  readonly packageDisposition: import("../domain/task.ts").TaskPackageDisposition;
+  readonly packagePath: string | null;
+  readonly updatedAt: string;
+}
+export interface TaskIndexProjectionRead {
+  readonly schema: "task-index-projection/v1";
+  readonly status: "ready" | "pending";
+  readonly rows: readonly TaskIndexProjectionRow[];
+  readonly watermark: number;
+  readonly sourceRevision: number;
+  readonly warnings: readonly TaskProjectionWarning[];
+}
 export interface TaskRuntimeBatchQuery {
   readonly taskIds: readonly string[];
   readonly limit?: number;

--- a/packages/kernel/src/projection/rebuildable-task-projection-task-queries.ts
+++ b/packages/kernel/src/projection/rebuildable-task-projection-task-queries.ts
@@ -3,10 +3,12 @@ import type { DatabaseSync } from "node:sqlite";
 import { isTaskEvent } from "../domain/doc-sync.contract.ts";
 import { isAgentRuntimeEvent, type AgentRuntimeEventV1 } from "../domain/agent-runtime.ts";
 import { type TaskProgressEventV1 } from "../domain/task-progress-event.ts";
+import { localRuntimeStateFileSystem } from "../local/local-layout-file-system.ts";
 import { readDecisionGraphRows } from "./decision-event-projection.ts";
 import { readFactGraphRows } from "./fact-event-projection.ts";
 import {
   readTaskDependencyClosureRows,
+  readTaskIndexRows,
   readTaskRelationPage,
   readTaskRelationRows,
   readTaskRelationsByTargets,
@@ -82,6 +84,7 @@ export function taskQueryApi(
 ): Pick<
   TaskProjection,
   | "readTaskRelations"
+  | "readTaskIndex"
   | "readWorkspaceSummary"
   | "readTaskDependencyClosure"
   | "readTaskRelationsByTargets"
@@ -105,6 +108,21 @@ export function taskQueryApi(
 > {
   const { eventStore, limit, projectionPath, readHead } = context;
   return {
+    readTaskIndex: () => {
+      const existed = localRuntimeStateFileSystem.exists(projectionPath);
+      return withDatabase(projectionPath, readHead, (db) => {
+        const round = catchUpRound(db, eventStore, limit),
+          current = watermark(db);
+        return {
+          schema: "task-index-projection/v1" as const,
+          status: current === round.sourceRevision ? ("ready" as const) : ("pending" as const),
+          rows: readTaskIndexRows(db),
+          watermark: current,
+          sourceRevision: round.sourceRevision,
+          warnings: !existed && round.sourceRevision > 0 ? (["projection_missing"] as const) : [],
+        };
+      });
+    },
     readWorkspaceSummary: () =>
       withDatabase(projectionPath, readHead, (db) => {
         const round = catchUpRound(db, eventStore, limit),

--- a/packages/kernel/src/projection/task-projection-port.ts
+++ b/packages/kernel/src/projection/task-projection-port.ts
@@ -67,6 +67,7 @@ export interface TaskProjection {
   readonly getEntity: (entityKind: string, entityId: string) => EntityProjectionRow | null;
   readonly read: (taskId: string) => TaskProjectionRead;
   readonly list: (query?: TaskProjectionListQuery) => TaskProjectionListRead;
+  readonly readTaskIndex: () => import("./projection-reads.ts").TaskIndexProjectionRead;
   readonly readWorkspaceSummary: () => WorkspaceSummaryProjectionRead;
   readonly readTaskRelations: () => TaskRelationProjectionRead;
   readonly readTaskDependencyClosure: (sourceRefs: readonly string[], maxDepth?: number) => TaskRelationProjectionRead;

--- a/packages/kernel/src/projection/task-query-projection.ts
+++ b/packages/kernel/src/projection/task-query-projection.ts
@@ -5,6 +5,7 @@ import type { DatabaseSync } from "node:sqlite";
 import type { RuntimeSession } from "../domain/agent-runtime.ts";
 import type { EntityRelationRecord } from "../domain/entity-relation.ts";
 import type { ReplayTaskStatus, TaskV1 } from "../domain/task.ts";
+import type { TaskIndexProjectionRow } from "./projection-reads.ts";
 import { queryRows, type ProjectionSqlRow } from "./rebuildable-task-projection-sql.ts";
 
 /**
@@ -60,6 +61,51 @@ export interface NarrowTaskRow {
   readonly created_at: string | null;
   readonly updated_at: string;
   readonly pinned: number;
+}
+
+/** One projection scan for the CLI task index. The row is intentionally limited
+ * to list/tree fields, so callers do not hydrate executions, reviews, leases, or
+ * relation graphs only to discard them after a metadata filter. */
+export function readTaskIndexRows(db: DatabaseSync): readonly TaskIndexProjectionRow[] {
+  const rows = queryRows<{
+    readonly task_id: string;
+    readonly package_path: string | null;
+    readonly updated_at: string;
+    readonly snapshot_json: string;
+  }>(
+    db,
+    [
+      "SELECT task_snapshot.task_id, task_package.package_path, task_snapshot.updated_at,",
+      "task_snapshot.snapshot_json FROM task_snapshot",
+      "LEFT JOIN task_package USING(task_id) ORDER BY task_snapshot.task_id",
+    ].join(" "),
+  );
+  return rows.flatMap((row) => {
+    let task: TaskV1 | null;
+    try {
+      task = (JSON.parse(row.snapshot_json) as { readonly task?: TaskV1 | null }).task ?? null;
+    } catch {
+      throw new Error(`projection snapshot mismatch for task ${row.task_id}`);
+    }
+    if (task === null) return [];
+    return [
+      {
+        taskId: row.task_id,
+        title: task.title,
+        status: task.status,
+        pinned: task.pinned ?? false,
+        parentTaskId: task.metadata?.parentTaskId ?? null,
+        moduleKey: task.metadata?.moduleKey ?? null,
+        workKind: task.metadata?.workKind ?? null,
+        riskTier: task.metadata?.riskTier ?? null,
+        urgency: task.metadata?.urgency ?? null,
+        taskClass: task.taskClass,
+        packageDisposition: task.packageDisposition ?? "active",
+        packagePath: row.package_path,
+        updatedAt: row.updated_at,
+      },
+    ];
+  });
 }
 
 /** Derive display-only creation time from the first canonical event for a task.

--- a/packages/kernel/test/store/task-query-projection.test.ts
+++ b/packages/kernel/test/store/task-query-projection.test.ts
@@ -160,6 +160,24 @@ test("narrow task list pages concatenate to the unparameterized result and keep 
     const full = projection.list();
     assert.equal(full.rows.length, 6);
     assert.equal(full.page, undefined);
+    const index = projection.readTaskIndex();
+    assert.equal(index.schema, "task-index-projection/v1");
+    assert.deepEqual(
+      index.rows.map(({ taskId, title, status, parentTaskId, pinned }) => ({
+        taskId,
+        title,
+        status,
+        parentTaskId,
+        pinned,
+      })),
+      full.rows.map(({ taskId, snapshot }) => ({
+        taskId,
+        title: snapshot.task!.title,
+        status: snapshot.task!.status,
+        parentTaskId: snapshot.task!.metadata?.parentTaskId ?? null,
+        pinned: snapshot.task!.pinned ?? false,
+      })),
+    );
     // First page of 2, then follow cursors to exhaustion.
     let page = projection.list({ limit: 2 }),
       rows = [...page.rows];

--- a/packages/kernel/test/transition-document-readiness.test.ts
+++ b/packages/kernel/test/transition-document-readiness.test.ts
@@ -49,7 +49,7 @@ test("transition document bindings enumerate canonical consumers and omit milest
   assert.throws(() => requireTransitionDocumentKind("milestone.closeout"), /no canonical document binding/u);
 });
 
-test("task plan rejects the preset scaffold, empty sections, and retained scaffold sentences", () => {
+test("task plan rejects pure scaffolds but accepts a retained scaffold sentence plus concrete content", () => {
   const template = readFileSync(
     new URL("../../preset/assets/software-coding/templates/task.plan/en-US.md", import.meta.url),
     "utf8",
@@ -64,9 +64,14 @@ test("task plan rejects the preset scaffold, empty sections, and retained scaffo
 
   const retainedScaffold = realizedPlan().replace(
     "## Brief\n\nImplemented Brief.",
-    "## Brief\n\nOne-line statement of the task objective and scope. Additional words do not realize it.",
+    "## Brief\n\nOne-line statement of the task objective and scope. Implement task-index/v1 for CLI consumers.",
   );
-  assert.deepEqual(assessTransitionDocument("task.plan", retainedScaffold).missingSections, ["Brief"]);
+  assert.equal(assessTransitionDocument("task.plan", retainedScaffold).ready, true);
+  const pureScaffoldSection = realizedPlan().replace(
+    "## Verification\n\nImplemented Verification.",
+    "## Verification\n\nStop point = targeted tests for the surface you touched, green, plus a local commit.",
+  );
+  assert.deepEqual(assessTransitionDocument("task.plan", pureScaffoldSection).missingSections, ["Verification"]);
   assert.equal(assessTransitionDocument("task.plan", realizedPlan()).ready, true);
 });
 


### PR DESCRIPTION
# English

## Summary

`ha task list --parent <task-id> --depth <n|all>` now returns a recursive subtree from a single narrow projection read instead of hydrating the full GUI task read model, cutting the canonical `--parent <ontology-root>` query from 10.1 s wall to a 41 ms daemon handler (0.71 s including cold Node start). Search composes with parent/depth/filters/pagination; the "pagination cannot be combined with filters" rejection is deleted. `ha task create` receipts now end with the plan path and a `ha task pin` hint. Two operator frictions from fact F-26909523 are fixed: plan readiness no longer marks a section as placeholder merely because it retains the template's stop-point sentence alongside real content, and `ha doc sync --path` accepts both `harness/tasks/...` and `tasks/...`.

## Architectural Justification

- The old list path went through `queryRead().guiTasks(query)`, which built relation graphs, decisions, blocking judgments and full lifecycle snapshots for every task before applying metadata filters, then ran a second projection-wide `projection.list()` for the receipt. No existing module exposed a metadata-only task index, so a narrow `readTaskIndex` port was added to the existing rebuildable SQLite task projection (one `task_snapshot ⋈ task_package` statement) — no second store, cache, or index owner.
- Removed: the filtered-pagination rejection in `repo-cell-task-query.ts`, the `guiTasks` hydration on the list path, the duplicate `projection.list()` in receipt construction, and the `harness/` prefix rejection in `doc-sync-candidate-scanner.ts` (replaced by normalization at the scanner, the single doc-sync write path).
- Scope cannot be narrowed further: subtree traversal, search-with-ancestors, and pagination must share one row shape or the CLI regains two truths for the same query.

## What Changed

- `packages/daemon/src/task-index-query.ts` (new): iterative subtree/search/pagination selector over `TaskIndexProjectionRow` plus human tree/flat renderer for `task-list/v2`.
- `packages/daemon/src/repo-cell-task-query.ts`: list path rewritten onto `projection.readTaskIndex()`; `--depth` validation; nested tree payload; flat rows keep `rootAssessment` (unchanged semantics — `deriveTaskRoot` ignores closeout evidence).
- `packages/kernel/src/projection/*`: `readTaskIndex` port, `TaskIndexProjectionRow/Read` DTOs, one narrow SQL reader.
- `packages/daemon/src/protocol/daemon-protocol-commands-task-surface.ts`: `--depth` input (regex `^(?:[1-9][0-9]*|all)$`).
- `packages/cli/src/index.ts`: create receipt guidance lines (non-dry-run only).
- `packages/kernel/src/domain/transition-document-readiness.ts`: a section is placeholder only when it is scaffold-only (or the whole document is the untouched template).
- `packages/daemon/src/doc-sync-candidate-scanner.ts` / `doc-sync-adjudication.ts`: authored-prefix normalization; `validateSelectedDocPaths` drops the unused `rootDir` argument.
- Tests: fast `task-index-query.test.ts` (200-node iterable, exactly 200 source reads), readiness positive/negative controls, thin-command receipt test; integration `task-surface-reads-leases`, `doc-sync-slice-a-implicit-lease` (both path forms), kernel `task-query-projection` (index row agrees with canonical snapshot).

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: use the single CI-backed `Production-Delta` declaration below; do not enter a second metric.

## Machine-Readable Declarations

Production-Delta: +501/-92

## Task And Scope

- Harness task: task_d41f1f9dc76ef66241825013ff
- Branch: `codex/cli-task-index-dx`
- Public scope: packages/cli, packages/daemon, packages/kernel (task list/index read path, create receipt, plan readiness, doc-sync path normalization) + tests
- Private planning/evidence updated: yes (task plan, delivery report, fact F-14EBAF5B benchmark)
- Out of scope: task pin write path, closeout lifecycle commands, schedule code, GUI, CI/gate authority

## Version Impact

- Version: no version change because this is an internal CLI/daemon behaviour change ahead of the milestone release
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: task_d41f1f9dc76ef66241825013ff
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no

## Verification

- Base `origin/main` SHA: ea1046f946454a87e39f0baf40b6029b250e0b72
- Branch merge-base with `origin/main`: ea1046f946454a87e39f0baf40b6029b250e0b72
- Last `git fetch origin` time: 2026-08-30T07:05Z
- Sync method: none needed
- Public diff command: `git diff origin/main...codex/cli-task-index-dx`
- Private evidence commit/path: harness task package artifacts/delivery-report.md
- Reviewer evidence path: harness task package artifacts/pr-body.md (this document) + CEO review notes
- GitHub Actions `rewrite-ci` run URL: pending
- [x] `git diff --check`
- [x] `npm run typecheck` (tsc --noEmit, worker)
- [x] targeted `npm test` files: task-index-query / transition-document-readiness / thin-command — 17/17 pass (reviewer re-run); integration 4/4, 6/6, 5/5, 2/2 in isolated executor (worker)
- [x] `npm run harness:check-file-complexity` (worker)
- [ ] `npm ci` — not run locally; CI authority
- [ ] `npm run check` — not run locally per worker stop-point policy; CI authority
- [ ] remaining harness checks — CI authority
- [ ] GitHub Actions `rewrite-ci` passed
- Not run: full local gate matrix by policy (worker stop-point = targeted tests + local commit).

## Review Evidence

- Self-review: worker delivery report with before/after timing, deleted paths, static checks.
- Reviewer subagent: Claude fork re-ran the fast suite (17/17), recomputed Production-Delta (+492/-92), verified test tier markers, confirmed `deriveTaskRoot` does not consume `hasCloseoutEvidence`, and ran `tools/gates/line-density.mjs`.
- Human review: CEO semantic acceptance pending.
- Blocking findings: G36 line-density FAILS on `packages/daemon/src/task-index-query.ts` (3 template-literal lines up to 271 chars, overlong characters 0 → 608). Must wrap before merge.

## Residual Risk

- Post-deploy canonical timing of `ha task list --parent <root> --depth all` not yet captured against the running daemon (measured on the production handler against the canonical SQLite instead); to be attached after merge.
- `task-list/v2` changes the receipt shape (`rows` nested in tree mode); GUI does not consume this CLI receipt.

## References

- Task: task_d41f1f9dc76ef66241825013ff
- Evidence: fact F-14EBAF5B (benchmark), fact F-26909523 (frictions)
- Review: this PR body, Review Evidence section

---

# 中文

## 概要

`ha task list --parent <task-id> --depth <n|all>` 现在从一次窄投影读直接返回递归子树,不再水合整套 GUI task 读模型:canonical `--parent <ontology 根>` 从 10.1 s 墙钟降到 daemon handler 41 ms(含冷启 Node 为 0.71 s)。搜索可与 parent/depth/过滤/分页组合,「分页不能与过滤组合」的拒绝已删除。`ha task create` 回执末尾给出 plan 路径与 `ha task pin` 提示。修掉 fact F-26909523 的两处摩擦:plan 就绪判定不再因保留模板「停止点」原句而判 placeholder(只有纯模板才判);`ha doc sync --path` 同时接受 `harness/tasks/...` 与 `tasks/...`。

## 架构辩护

- 旧 list 路径走 `queryRead().guiTasks(query)`,对每个 task 先构造关系图、decision、blocking 判断和完整生命周期快照再做元数据过滤,回执又跑第二次全投影 `projection.list()`。没有既有模块提供「只含元数据的任务索引」,因此在既有可重建 SQLite task 投影上加一个窄 `readTaskIndex` 端口(一条 `task_snapshot ⋈ task_package` 语句)——没有第二个 store、cache 或索引 owner。
- 删除:`repo-cell-task-query.ts` 的过滤+分页拒绝、list 路径上的 `guiTasks` 水合、回执里的重复 `projection.list()`、`doc-sync-candidate-scanner.ts` 里对 `harness/` 前缀的拒绝(改为在唯一 doc-sync 写路上归一化)。
- 无法再收窄:子树遍历、带祖先的搜索、分页必须共享同一行形状,否则 CLI 又会出现同一查询两套真相。

## 改动内容

- 新增 `packages/daemon/src/task-index-query.ts`:迭代式子树/搜索/分页选择器 + `task-list/v2` 树/平铺人读渲染。
- `repo-cell-task-query.ts`:list 路径改到 `projection.readTaskIndex()`;`--depth` 校验;嵌套树 payload;平铺行保留 `rootAssessment`(语义不变,`deriveTaskRoot` 不消费 closeout 证据)。
- kernel projection:`readTaskIndex` 端口、DTO、窄 SQL 读。
- 命令目录加 `--depth`;`packages/cli/src/index.ts` create 回执加两行指引。
- `transition-document-readiness.ts`:仅纯模板段判 placeholder。
- doc-sync scanner/adjudication:authored 前缀归一化,`validateSelectedDocPaths` 去掉未用的 `rootDir` 参数。
- 测试:fast 3 文件(17/17)、integration 4 文件(4/4、6/6、5/5、2/2),均有 tier 标记。

## 门收割 / Gate Harvest

- 删除的生产路径:none(删的是路径内的分支与拒绝,不是整条生产路径)
- 同 commit 删除的门 / fixture:none
- 生产净行数:引用英文块中的 `Production-Delta`。

## 机读声明说明

- 见英文块 `Production-Delta: +492/-92`;无依赖变化;无保留旧路径。

## 任务与范围

- Harness 任务:task_d41f1f9dc76ef66241825013ff
- 分支:`codex/cli-task-index-dx`
- 公开范围:packages/cli、packages/daemon、packages/kernel 的 task list/index 读路、create 回执、plan 就绪判定、doc-sync 路径归一化 + 测试
- 私有计划 / 证据是否已更新:yes
- 范围外:pin 写路、closeout 生命周期命令、schedule、GUI、CI/gate 权威面

## 版本影响

- 版本:不改版本,原因是里程碑闭环前不发版
- 发布影响:不发布

## 治理声明

- 是否触碰 protected surface:no
- protected surface 范围:不适用
- 依据:task_d41f1f9dc76ef66241825013ff
- 机器检查边界:本 PR 只声明该段存在;是否真实、充分由 reviewer 判断。
- Break-glass:no

## 验证

- `origin/main` 基准 SHA:ea1046f946454a87e39f0baf40b6029b250e0b72
- merge-base:ea1046f946454a87e39f0baf40b6029b250e0b72
- 最近一次 `git fetch origin`:2026-08-30T07:05Z
- 同步方式:不需要
- 公开 diff 命令:`git diff origin/main...codex/cli-task-index-dx`
- 私有证据:任务包 artifacts/delivery-report.md
- Reviewer 证据路径:任务包 artifacts/pr-body.md
- `rewrite-ci` run URL:待补
- [x] `git diff --check`
- [x] typecheck(worker)
- [x] 定向测试 17/17(reviewer 复跑)+ 隔离 integration(worker)
- [x] check-file-complexity(worker)
- [ ] `npm ci` / `npm run check` / 其余 harness 检查——按 worker 停止点政策不在本机跑,CI 为权威
- [ ] `rewrite-ci` passed
- 未运行:本地全量门矩阵(政策)。

## 审查证据

- 自查:worker 交付报告(前后计时、删除路径、静态检查)。
- Reviewer subagent:Claude fork 复跑 fast 17/17、重算 Production-Delta +492/-92、核 tier 标记、确认 `deriveTaskRoot` 不消费 closeout 证据、跑 line-density 门。
- 人工审查:CEO 语义验收待做。
- 阻塞发现:**G36 line-density 对 `packages/daemon/src/task-index-query.ts` 报红**(3 条模板字符串行最长 271 字符,overlong 0→608),合并前必须换行。

## 残余风险

- 合并部署后对 running daemon 的 `--depth all` 实测计时尚未采集(已按 canonical SQLite 上的生产 handler 计时),合并后补。
- `task-list/v2` 树模式回执形状变化;GUI 不消费该 CLI 回执。

## 关联材料

- 任务:task_d41f1f9dc76ef66241825013ff
- 证据:fact F-14EBAF5B、F-26909523
- 审查:本 PR body 审查证据节

---

## PR Gate Checklist / PR 门禁清单

- [x] Branch is based on latest `origin/main`. / 分支基于最新 `origin/main`。
- [x] PR body uses this full template structure. / PR 描述使用本模板完整结构。
- [x] PR body uses two complete language blocks. / 两块完整正文。
- [ ] PR body passes `tools/check-pr-body-bilingual.mjs`(CEO 开 PR 前跑)。
- [x] No protected surface touched. / 未触碰 protected surface。
- [x] No private harness files are included. / 不包含私有 harness 文件。
- [x] No ignored local agent entry files are included.
- [x] No absolute local filesystem paths are included in this public PR body.
- [x] Public diff is limited to the stated task scope.
- [x] Private planning/evidence updates are recorded.
- [x] Version and publish impact are stated.
- [x] Local verification commands are recorded honestly.
- [ ] CI results are linked or explained.(待 run)
- [x] Review evidence is recorded.
- [ ] Open findings closed: line-density blocking finding open, owner = worker/CEO.
- [x] Merge method: normal merge via `node tools/pr-merge.mjs <PR>`; post-merge cleanup by that helper.
- [x] No admin bypass is planned unless explicitly approved and recorded.


