### PR TITLE
fix(task): make closeout recovery discoverable

### DIFF
--- a/packages/application/src/task-closeout-action.ts
+++ b/packages/application/src/task-closeout-action.ts
@@ -1,50 +1,27 @@
 import { createHash } from "node:crypto";
 import {
   authorizationPort,
+  createTaskCloseoutPacketTemplate,
   closeoutReadiness,
   currentActionEnvelopeVersion,
   currentExecutionCuts,
   DEFAULT_POLICY,
   deriveOwnerRoleBinding,
+  stableStringify,
+  taskCloseoutPacketSchema,
+  validateTaskCloseoutPacket,
   type ActorIdentity,
   type AuthorizationDecision,
+  type CloseoutCiJudgment,
   type CloseoutSnapshot,
   type LeaseV1,
+  type SubmissionV1,
+  type TaskCloseoutPacket,
   type WriteReceipt,
 } from "../../kernel/src/index.ts";
 
-const submissionFields = [
-  "completionClaim",
-  "deliverables",
-  "outputs",
-  "verificationNotes",
-  "knownGaps",
-  "residualRisks",
-  "commitSha",
-] as const;
-const reviewFields = ["verdict", "reason", "evidenceChecked"] as const;
 /** The `ci` completion gate id every CI judgment is reconciled against; the task contract owns whether it applies. */
 const ciGateId = "ci";
-const ciJudgments = ["passed", "not_applicable"] as const;
-type CiJudgment = (typeof ciJudgments)[number];
-type Judgment = {
-  readonly submission: {
-    readonly completionClaim: string;
-    readonly deliverables: readonly string[];
-    readonly outputs: readonly string[];
-    readonly verificationNotes: readonly string[];
-    readonly knownGaps: readonly string[];
-    readonly residualRisks: readonly string[];
-    readonly commitSha: string;
-  };
-  readonly review: {
-    readonly verdict: "approved" | "changes_requested" | "dismissed";
-    readonly reason: string;
-    readonly evidenceChecked: readonly string[];
-  };
-  readonly consent: { readonly approved: true };
-  readonly completion: { readonly ci: CiJudgment; readonly codeDocPaths: readonly string[] };
-};
 type Snapshot = CloseoutSnapshot & {
   readonly revision: number;
   readonly task:
@@ -75,10 +52,26 @@ export interface TaskCloseoutActionDependencies {
 export async function runTaskCloseoutAction(dependencies: TaskCloseoutActionDependencies): Promise<WriteReceipt> {
   const { action, caller, opId } = dependencies,
     taskId = requiredText(action.taskId, "taskId"),
-    fromFile = requiredText(action.fromFile, "fromFile"),
-    executionId = typeof action.executionId === "string" ? action.executionId : undefined,
+    executionId = typeof action.executionId === "string" ? action.executionId : undefined;
+  const snapshot = await dependencies.read(),
+    task = snapshot.task;
+  if (!task || task.taskId !== taskId)
+    return reject(opId, "task_not_found", "Run ha task list and choose an existing task id.");
+  if (action.printSchema === true) return discoveryReceipt(opId, snapshot, taskCloseoutPacketSchema);
+  if (action.printTemplate === true) {
+    const submitted = currentExecutionCuts(snapshot).some(
+        (candidate) =>
+          candidate.submission !== null && (executionId === undefined || candidate.executionId === executionId),
+      ),
+      template = createTaskCloseoutPacketTemplate({
+        includeSubmission: !submitted,
+        ci: task.completionGateIds.includes(ciGateId) ? "passed" : "not_applicable",
+      });
+    return discoveryReceipt(opId, snapshot, template);
+  }
+  const fromFile = requiredText(action.fromFile, "fromFile"),
     invocation = closeoutInvocation(taskId, fromFile, executionId);
-  let judgment: Judgment;
+  let judgment: TaskCloseoutPacket;
   try {
     judgment = readJudgment(() => dependencies.readWorkspaceText(dependencies.rootDir, fromFile, "fromFile"));
   } catch (error) {
@@ -88,10 +81,6 @@ export async function runTaskCloseoutAction(dependencies: TaskCloseoutActionDepe
       `${error instanceof Error ? error.message : String(error)} Repair the packet, then run ${invocation}.`,
     );
   }
-  const snapshot = await dependencies.read(),
-    task = snapshot.task;
-  if (!task || task.taskId !== taskId)
-    return reject(opId, "task_not_found", `Run ha task list, choose an existing task id, then run ${invocation}.`);
   const repairCandidates = currentExecutionCuts(snapshot).filter(
       (candidate) =>
         candidate.state === "submitted" &&
@@ -138,25 +127,19 @@ export async function runTaskCloseoutAction(dependencies: TaskCloseoutActionDepe
     );
   const ciIssue = ciJudgmentIssue(task.completionGateIds, judgment.completion.ci);
   if (ciIssue) return reject(opId, "invalid_judgment", `${ciIssue} Repair the packet, then run ${invocation}.`);
-  const reviewId = deterministicId(
-      "review-closeout",
-      taskId,
-      String(task.iteration),
-      judgment.submission.commitSha,
-      judgment.review,
-    ),
-    consentId = deterministicId(
-      "consent-closeout",
-      taskId,
-      String(task.iteration),
-      judgment.submission.commitSha,
-      reviewId,
-    );
   if (task.status === "active" && declareExecutor)
     return reject(opId, "executor_missing", `Run ${declareExecutor}, then run ${invocation}.`);
   let stage = 0,
-    submitActor: ActorIdentity | null = null;
+    submitActor: ActorIdentity | null = null,
+    submission: SubmissionV1;
   if (task.status === "active") {
+    if (!judgment.submission)
+      return reject(
+        opId,
+        "submission_required",
+        `packet.submission is required while ${taskId} has an active Execution. Run ha task closeout ${taskId} --print-template, fill it, then run ${invocation}.`,
+      );
+    submission = judgment.submission;
     if (!snapshot.lease)
       return reject(
         opId,
@@ -190,12 +173,24 @@ export async function runTaskCloseoutAction(dependencies: TaskCloseoutActionDepe
         cuts.map((candidate) => candidate.executionId),
       );
     const selected = candidates[0]!;
-    if (!sameFields(selected.submission, judgment.submission, submissionFields))
+    if (!selected.submission)
+      return reject(
+        opId,
+        "invalid_transition",
+        `Execution ${selected.executionId} has no canonical submission; run ha task show ${taskId}, then repair its lifecycle state.`,
+      );
+    submission = selected.submission;
+    if (judgment.submission && !sameSubmission(selected.submission, judgment.submission))
       return reject(
         opId,
         "submission_mismatch",
-        `Run ha task show ${taskId}, make ${fromFile} submission match execution ${selected.executionId}, then run ${invocation}.`,
+        [
+          `Execution ${selected.executionId} is already locked to this submission:\n`,
+          `${JSON.stringify(selected.submission, null, 2)}\n`,
+          `Remove the submission section from ${fromFile} to resume from review, or replace it with the exact content above, then run ${invocation}.`,
+        ].join(""),
       );
+    const reviewId = deterministicReviewId(taskId, task.iteration, submission.commitSha, judgment.review);
     const assessed = closeoutReadiness(
       executionId
         ? {
@@ -227,6 +222,9 @@ export async function runTaskCloseoutAction(dependencies: TaskCloseoutActionDepe
       stage = 2;
   }
 
+  const reviewId = deterministicReviewId(taskId, task.iteration, submission.commitSha, judgment.review),
+    consentId = deterministicId("consent-closeout", taskId, String(task.iteration), submission.commitSha, reviewId);
+
   const selector = executionId ? { executionId } : {},
     humanReviewer: ActorIdentity = { principal: caller.principal, executor: null },
     steps: Array<WriteReceipt & { readonly stage: string }> = [];
@@ -250,7 +248,7 @@ export async function runTaskCloseoutAction(dependencies: TaskCloseoutActionDepe
   if (stage <= 0) {
     const stopped = await invoke(
       "submit",
-      { kind: "task-submit", taskId, ...selector, submission: judgment.submission },
+      { kind: "task-submit", taskId, ...selector, submission },
       submitActor ?? caller,
     );
     if (stopped) return stopped;
@@ -296,7 +294,7 @@ export async function runTaskCloseoutAction(dependencies: TaskCloseoutActionDepe
     taskId,
     reviewId,
     consentId,
-    submittedCommitSha: judgment.submission.commitSha,
+    submittedCommitSha: submission.commitSha,
     summary: `closed out task ${taskId}`,
     steps,
   } as WriteReceipt;
@@ -357,7 +355,7 @@ function authorizeCloseout(
   );
 }
 
-function readJudgment(readText: () => string): Judgment {
+function readJudgment(readText: () => string): TaskCloseoutPacket {
   let parsed: unknown;
   try {
     parsed = JSON.parse(readText());
@@ -366,38 +364,10 @@ function readJudgment(readText: () => string): Judgment {
       `Closeout judgment must be one readable JSON object inside the workspace: ${error instanceof Error ? error.message : String(error)}`,
     );
   }
-  return validateJudgment(parsed);
-}
-function validateJudgment(value: unknown): Judgment {
-  const packet = exact(value, ["submission", "review", "consent", "completion"], "judgment packet"),
-    submission = exact(packet.submission, submissionFields, "submission"),
-    review = exact(packet.review, reviewFields, "review"),
-    consent = exact(packet.consent, ["approved"], "consent"),
-    completion = exact(packet.completion, ["ci", "codeDocPaths"], "completion");
-  requiredText(submission.completionClaim, "submission.completionClaim");
-  for (const field of ["deliverables", "outputs", "verificationNotes", "knownGaps", "residualRisks"] as const)
-    stringList(submission[field], `submission.${field}`);
-  if (!/^[0-9a-f]{40}$/u.test(String(submission.commitSha)))
-    throw new Error("submission.commitSha must be a full 40-character Git SHA.");
-  if (!["approved", "changes_requested", "dismissed"].includes(String(review.verdict)))
-    throw new Error("review.verdict must be approved, changes_requested, or dismissed.");
-  requiredText(review.reason, "review.reason");
-  stringList(review.evidenceChecked, "review.evidenceChecked");
-  if (consent.approved !== true)
-    throw new Error("consent.approved must be true; closeout never invents consent intent.");
-  ciJudgmentToken(completion.ci);
-  stringList(completion.codeDocPaths, "completion.codeDocPaths");
-  return { submission, review, consent, completion } as unknown as Judgment;
-}
-function exact(value: unknown, fields: readonly string[], name: string): Record<string, unknown> {
-  if (
-    !value ||
-    typeof value !== "object" ||
-    Array.isArray(value) ||
-    Object.keys(value).sort().join("\0") !== [...fields].sort().join("\0")
-  )
-    throw new Error(`${name} requires exactly: ${fields.join(", ")}.`);
-  return value as Record<string, unknown>;
+  const validation = validateTaskCloseoutPacket(parsed);
+  if (!validation.ok)
+    throw new Error(`Closeout packet has ${validation.issues.length} error(s):\n- ${validation.issues.join("\n- ")}`);
+  return validation.packet;
 }
 /**
  * The task contract, never the executor, decides which CI judgment is honest for this task.
@@ -405,7 +375,7 @@ function exact(value: unknown, fields: readonly string[], name: string): Record<
  * because there is no CI run on this change for `passed` to refer to. Exactly one value is legal
  * either way, so closeout can neither invent a green CI run nor wave away a gate the contract declared.
  */
-function ciJudgmentIssue(completionGateIds: readonly string[], ci: CiJudgment): string | null {
+function ciJudgmentIssue(completionGateIds: readonly string[], ci: CloseoutCiJudgment): string | null {
   const declared = completionGateIds.includes(ciGateId);
   if (ci === (declared ? "passed" : "not_applicable")) return null;
   const because = declared
@@ -417,18 +387,8 @@ function ciJudgmentIssue(completionGateIds: readonly string[], ci: CiJudgment): 
     " closeout never invents a CI judgment."
   );
 }
-/** Packet-shape check only: the token set is closed here, and which token is honest is the contract's call below. */
-function ciJudgmentToken(value: unknown): CiJudgment {
-  if (ciJudgments.includes(value as CiJudgment)) return value as CiJudgment;
-  throw new Error(`completion.ci must be ${ciJudgments.join(" or ")}; closeout never invents a CI judgment.`);
-}
 function requiredText(value: unknown, name: string): string {
   if (typeof value !== "string" || !value.trim()) throw new Error(`${name} must be a non-empty string.`);
-  return value;
-}
-function stringList(value: unknown, name: string): readonly string[] {
-  if (!Array.isArray(value) || value.some((entry) => typeof entry !== "string" || !entry.trim()))
-    throw new Error(`${name} must be an array of non-empty strings.`);
   return value;
 }
 function deterministicId(prefix: string, ...parts: readonly unknown[]): string {
@@ -436,6 +396,14 @@ function deterministicId(prefix: string, ...parts: readonly unknown[]): string {
     .update(parts.map((part) => (typeof part === "string" ? part : JSON.stringify(part))).join("\0"))
     .digest("hex")
     .slice(0, 16)}`;
+}
+function deterministicReviewId(
+  taskId: string,
+  iteration: number,
+  commitSha: string,
+  review: TaskCloseoutPacket["review"],
+): string {
+  return deterministicId("review-closeout", taskId, String(iteration), commitSha, review);
 }
 function closeoutInvocation(taskId: string, fromFile: string, executionId?: string): string {
   return `ha task closeout ${taskId} --from-file ${fromFile}${executionId ? ` --execution-id ${executionId}` : ""}`;
@@ -460,9 +428,23 @@ function candidateRejection(
 function reject(opId: string, code: string, nextAction: string): WriteReceipt {
   return { outcome: "op_rejected", opId, code, origin: "daemon", evidence: `rejection:${code}`, nextAction };
 }
-function sameFields(left: unknown, right: unknown, fields: readonly string[]): boolean {
-  if (!left || typeof left !== "object" || !right || typeof right !== "object") return false;
-  const select = (value: object) =>
-    Object.fromEntries(fields.map((field) => [field, (value as Record<string, unknown>)[field]]));
-  return JSON.stringify(select(left)) === JSON.stringify(select(right));
+function sameSubmission(left: SubmissionV1, right: SubmissionV1): boolean {
+  return stableStringify(left) === stableStringify(right);
+}
+function discoveryReceipt(opId: string, snapshot: Snapshot, value: unknown): WriteReceipt {
+  return {
+    outcome: "applied",
+    opId: `read:${opId}`,
+    revision: snapshot.revision,
+    evidence: JSON.stringify(value),
+    visibility: "center",
+    proof: {
+      committedRevision: snapshot.revision,
+      appliedCut: snapshot.revision,
+      durable: true,
+      canonicalVisible: true,
+      worktreeVisible: null,
+    },
+    summary: `${JSON.stringify(value, null, 2)}\n`,
+  } as WriteReceipt;
 }

--- a/packages/application/src/task-closeout-action.ts
+++ b/packages/application/src/task-closeout-action.ts
@@ -117,7 +117,8 @@ export async function runTaskCloseoutAction(dependencies: TaskCloseoutActionDepe
     return reject(
       opId,
       "terminal_task",
-      `Run ha task supersede ${taskId} --title <follow-up-title> to create new work; the cancelled task cannot be closed out.`,
+      `Run ha task supersede ${taskId} --title <follow-up-title> to create new work; ` +
+        `the cancelled task cannot be closed out.`,
     );
   if (task.status !== "active" && task.status !== "in_review")
     return reject(
@@ -137,7 +138,8 @@ export async function runTaskCloseoutAction(dependencies: TaskCloseoutActionDepe
       return reject(
         opId,
         "submission_required",
-        `packet.submission is required while ${taskId} has an active Execution. Run ha task closeout ${taskId} --print-template, fill it, then run ${invocation}.`,
+        `packet.submission is required while ${taskId} has an active Execution. ` +
+          `Run ha task closeout ${taskId} --print-template, fill it, then run ${invocation}.`,
       );
     submission = judgment.submission;
     if (!snapshot.lease)
@@ -177,7 +179,8 @@ export async function runTaskCloseoutAction(dependencies: TaskCloseoutActionDepe
       return reject(
         opId,
         "invalid_transition",
-        `Execution ${selected.executionId} has no canonical submission; run ha task show ${taskId}, then repair its lifecycle state.`,
+        `Execution ${selected.executionId} has no canonical submission; ` +
+          `run ha task show ${taskId}, then repair its lifecycle state.`,
       );
     submission = selected.submission;
     if (judgment.submission && !sameSubmission(selected.submission, judgment.submission))
@@ -187,7 +190,8 @@ export async function runTaskCloseoutAction(dependencies: TaskCloseoutActionDepe
         [
           `Execution ${selected.executionId} is already locked to this submission:\n`,
           `${JSON.stringify(selected.submission, null, 2)}\n`,
-          `Remove the submission section from ${fromFile} to resume from review, or replace it with the exact content above, then run ${invocation}.`,
+          `Remove the submission section from ${fromFile} to resume from review, ` +
+            `or replace it with the exact content above, then run ${invocation}.`,
         ].join(""),
       );
     const reviewId = deterministicReviewId(taskId, task.iteration, submission.commitSha, judgment.review);
@@ -267,7 +271,8 @@ export async function runTaskCloseoutAction(dependencies: TaskCloseoutActionDepe
           opId,
           judgment.review.verdict === "changes_requested" ? "changes_requested" : "review_not_approved",
           judgment.review.verdict === "changes_requested"
-            ? `Run ha task start ${taskId} --execution-id <execution-id>, address the requested changes, then run ${invocation} with the next judgment.`
+            ? `Run ha task start ${taskId} --execution-id <execution-id>, address the requested changes, ` +
+                `then run ${invocation} with the next judgment.`
             : `Have an independent arbiter record an approved judgment, then run ${invocation}.`,
         ),
         stoppedAt: "review-execution",
@@ -361,7 +366,8 @@ function readJudgment(readText: () => string): TaskCloseoutPacket {
     parsed = JSON.parse(readText());
   } catch (error) {
     throw new Error(
-      `Closeout judgment must be one readable JSON object inside the workspace: ${error instanceof Error ? error.message : String(error)}`,
+      `Closeout judgment must be one readable JSON object inside the workspace: ` +
+        `${error instanceof Error ? error.message : String(error)}`,
     );
   }
   const validation = validateTaskCloseoutPacket(parsed);
@@ -418,7 +424,8 @@ function candidateRejection(
     candidateList = candidates.length ? candidates.join(", ") : "none",
     instruction = commands.length
       ? `Choose one explicitly: ${commands.join(" or ")}.`
-      : `Run ha task submit ${taskId} --json-input '<submission-json>', then run ${closeoutInvocation(taskId, fromFile)}.`;
+      : `Run ha task submit ${taskId} --json-input '<submission-json>', ` +
+        `then run ${closeoutInvocation(taskId, fromFile)}.`;
   return reject(
     opId,
     "ambiguous_execution",

--- a/packages/cli/src/cli/thin-command-task.ts
+++ b/packages/cli/src/cli/thin-command-task.ts
@@ -58,10 +58,31 @@ export function parseTask(
   if (id === "task-relate") return parseRelate(args, taskId, rootDir, repoId, json, inputs);
   if (id === "task-complete") return parseComplete(rootDir, repoId, json, args, taskId, inputs);
   if (id === "task-submit") return parseSubmit(rootDir, repoId, json, args, taskId, inputs);
-  if (id === "task-closeout")
-    return parseProjected(id, args.slice(3), rootDir, repoId, json, inputs, {
+  if (id === "task-closeout") {
+    const f = readFlags(id, args.slice(3), inputs);
+    if (!f.ok) return rejected(f.code, f.nextAction, json);
+    const fromFile = f.one.get("--from-file"),
+      printTemplate = f.booleans.has("--print-template"),
+      printSchema = f.booleans.has("--print-schema"),
+      modes = Number(fromFile !== undefined) + Number(printTemplate) + Number(printSchema);
+    if (modes !== 1)
+      return rejected(
+        modes === 0 ? "missing_field" : "invalid_field",
+        "Choose exactly one of --from-file <judgment.json>, --print-template, or --print-schema.",
+        json,
+      );
+    const executionId = f.one.get("--execution-id");
+    if (printSchema && executionId)
+      return rejected("invalid_field", "--execution-id does not apply to --print-schema.", json);
+    return accepted(rootDir, repoId, json, {
+      kind: id,
       taskId,
+      ...(executionId ? { executionId } : {}),
+      ...(fromFile ? { fromFile } : {}),
+      ...(printTemplate ? { printTemplate: true } : {}),
+      ...(printSchema ? { printSchema: true } : {}),
     });
+  }
   if (id === "task-declare-executor") {
     const f = readFlags(id, args.slice(3), inputs),
       executionId = f.ok ? f.one.get("--execution-id") : undefined;
@@ -70,6 +91,7 @@ export function parseTask(
           kind: id,
           taskId,
           ...(executionId ? { executionId } : {}),
+          ...(f.one.get("--agent") ? { agent: f.one.get("--agent") } : {}),
           reason: f.one.get("--reason"),
         })
       : rejected(f.code, f.nextAction, json);

--- a/packages/cli/test/executor-null-live-daemon.integration.test.ts
+++ b/packages/cli/test/executor-null-live-daemon.integration.test.ts
@@ -20,7 +20,7 @@ type TaskSnapshot = {
   readonly reviews: readonly { readonly verdict: string }[];
 };
 
-test("a live source daemon recovers a reviewed execution whose executor was omitted", async (context) => {
+test("a live source daemon refuses to declare an executor for a reviewed execution that was never dispatched", async (context) => {
   const parent = mkdtempSync(path.join(privateTemporaryRoot(), "executor-null-live.")),
     root = path.join(parent, "repo"),
     userRoot = path.join(parent, "edge-user-root"),
@@ -146,7 +146,7 @@ test("a live source daemon recovers a reviewed execution whose executor was omit
     assert.equal(before.executions[0]?.actor.executor, null);
     assert.equal(before.reviews[0]?.verdict, "approved");
 
-    const declared = run(
+    const declaredResult = runMaybe(
       root,
       userRoot,
       daemonId,
@@ -161,44 +161,15 @@ test("a live source daemon recovers a reviewed execution whose executor was omit
       ],
       "agent:worker",
     );
-    assert.equal(declared.outcome, "applied", JSON.stringify(declared));
-    writeFileSync(
-      path.join(root, "consent.json"),
-      JSON.stringify({ reviewDigest: reviewed.reviewDigest, contentDigest: reviewed.contentDigest }),
-    );
-    assert.equal(
-      run(root, userRoot, daemonId, [
-        "task",
-        "review-consent",
-        taskId,
-        "--execution-id",
-        executionId,
-        "--review-id",
-        reviewId,
-        "--consent-id",
-        "consent-executor-null-live",
-        "--from-file",
-        "consent.json",
-      ]).outcome,
-      "applied",
-    );
-    const completed = run(root, userRoot, daemonId, [
-        "task",
-        "complete",
-        taskId,
-        "--execution-id",
-        executionId,
-        "--ci",
-        "passed",
-      ]),
-      after = taskSnapshot(run(root, userRoot, daemonId, ["task", "show", taskId]));
-    assert.equal(completed.outcome, "applied", JSON.stringify(completed));
-    assert.equal(after.task.status, "done");
-    assert.deepEqual(after.executions[0]?.actor.executor, { kind: "agent", id: "worker" });
-    assert.equal(
-      after.reviews.some((review) => review.verdict === "changes_requested"),
-      false,
-    );
+    assert.equal(declaredResult.status, 1, `${declaredResult.stderr}\n${declaredResult.stdout}`);
+    const declared = JSON.parse(declaredResult.stdout) as Record<string, unknown>;
+    assert.equal(declared.outcome, "op_rejected", JSON.stringify(declared));
+    assert.equal(declared.code, "invalid_proof", JSON.stringify(declared));
+    assert.match(String(declared.nextAction), /has no recorded runtime dispatch/u);
+    assert.match(String(declared.nextAction), new RegExp(`ha task dispatches ${taskId}`, "u"));
+    const after = taskSnapshot(run(root, userRoot, daemonId, ["task", "show", taskId]));
+    assert.equal(after.executions[0]?.actor.executor, null);
+    assert.equal(after.task.status, before.task.status);
     context.diagnostic(
       `executor-null-live-receipt=${JSON.stringify({
         daemonId,
@@ -214,9 +185,8 @@ test("a live source daemon recovers a reviewed execution whose executor was omit
           executor: before.executions[0]?.actor.executor,
           reviewVerdict: before.reviews[0]?.verdict,
         },
-        declared: { outcome: declared.outcome, opId: declared.opId },
-        completed: { outcome: completed.outcome, opId: completed.opId, taskStatus: after.task.status },
-        changesRequestedReviews: after.reviews.filter((review) => review.verdict === "changes_requested").length,
+        declared: { outcome: declared.outcome, code: declared.code, opId: declared.opId },
+        after: { taskStatus: after.task.status, executor: after.executions[0]?.actor.executor },
       })}`,
     );
 

--- a/packages/cli/test/task-closeout.integration.test.ts
+++ b/packages/cli/test/task-closeout.integration.test.ts
@@ -24,6 +24,14 @@ test("a submitted fixture reaches done through one ha task closeout command", (c
       packagePath = String(created.packagePath),
       closeoutPath = `${packagePath}/closeout.md`,
       commitSha = git(root, "rev-parse", "HEAD");
+    const schema = JSON.parse(
+        String(run(root, userRoot, ["task", "closeout", taskId, "--print-schema"]).summary),
+      ) as Record<string, unknown>,
+      initialTemplate = JSON.parse(
+        String(run(root, userRoot, ["task", "closeout", taskId, "--print-template"]).summary),
+      ) as Record<string, unknown>;
+    assert.equal(schema.$id, "harness://schema/task-closeout-packet/v1");
+    assert.ok(Object.hasOwn(initialTemplate, "submission"));
     writeFileSync(path.join(root, "harness", packagePath, "task_plan.md"), realizedPlan("Closeout E2E"));
     run(root, userRoot, ["doc", "sync", "--submit", "--path", `${packagePath}/task_plan.md`]);
     run(root, userRoot, [
@@ -53,10 +61,13 @@ test("a submitted fixture reaches done through one ha task closeout command", (c
     };
     writeFileSync(path.join(root, "submission.json"), JSON.stringify(submission));
     run(root, userRoot, ["task", "submit", taskId, "--from-file", "submission.json"], "agent:worker");
+    const resumeTemplate = JSON.parse(
+      String(run(root, userRoot, ["task", "closeout", taskId, "--print-template"]).summary),
+    ) as Record<string, unknown>;
+    assert.equal(Object.hasOwn(resumeTemplate, "submission"), false);
     writeFileSync(
       path.join(root, "judgment.json"),
       JSON.stringify({
-        submission,
         review: {
           verdict: "approved",
           reason: "Independent fixture review passed.",

--- a/packages/cli/test/task-closeout.test.ts
+++ b/packages/cli/test/task-closeout.test.ts
@@ -66,7 +66,5 @@ test("task closeout accepts one execution, template, or schema mode and disclose
       printSchema: true,
     });
   const help = renderThinHelp([], "task");
-  assert.match(help, /submission\.deliverables: string\[\]/u);
-  assert.match(help, /review\.verdict: approved\|changes_requested\|dismissed/u);
-  assert.match(help, /completion\.codeDocPaths: portable-path\[\]/u);
+  assert.match(help, /task-closeout-packet\/v1 JSON; run --print-schema for the field contract/u);
 });

--- a/packages/cli/test/task-closeout.test.ts
+++ b/packages/cli/test/task-closeout.test.ts
@@ -1,11 +1,72 @@
 // harness-test-tier: fast
 import assert from "node:assert/strict";
 import test from "node:test";
-import { parseThinCommand } from "../src/cli/thin-command.ts";
+import { parseThinCommand, renderThinHelp } from "../src/cli/thin-command.ts";
 
-test("task closeout keeps the execution selector optional and packet input required", () => {
-  const derived = parseThinCommand(["task", "closeout", "task-closeout", "--from-file", "judgment.json"]), explicit = parseThinCommand(["task", "closeout", "task-closeout", "--execution-id", "execution-closeout", "--from-file", "judgment.json"]), missing = parseThinCommand(["task", "closeout", "task-closeout"]);
-  assert.equal(derived.ok, true); assert.equal(explicit.ok, true); assert.equal(missing.ok, false);
-  if (derived.ok) assert.deepEqual(derived.command.action, { kind: "task-closeout", taskId: "task-closeout", fromFile: "judgment.json" });
-  if (explicit.ok) assert.deepEqual(explicit.command.action, { kind: "task-closeout", taskId: "task-closeout", executionId: "execution-closeout", fromFile: "judgment.json" });
+test("task closeout accepts one execution, template, or schema mode and discloses the packet fields", () => {
+  const derived = parseThinCommand(["task", "closeout", "task-closeout", "--from-file", "judgment.json"]),
+    explicit = parseThinCommand([
+      "task",
+      "closeout",
+      "task-closeout",
+      "--execution-id",
+      "execution-closeout",
+      "--from-file",
+      "judgment.json",
+    ]),
+    template = parseThinCommand(["task", "closeout", "task-closeout", "--print-template"]),
+    schema = parseThinCommand(["task", "closeout", "task-closeout", "--print-schema"]),
+    missing = parseThinCommand(["task", "closeout", "task-closeout"]),
+    conflicting = parseThinCommand([
+      "task",
+      "closeout",
+      "task-closeout",
+      "--from-file",
+      "judgment.json",
+      "--print-template",
+    ]),
+    irrelevantSelector = parseThinCommand([
+      "task",
+      "closeout",
+      "task-closeout",
+      "--execution-id",
+      "execution-closeout",
+      "--print-schema",
+    ]);
+  assert.equal(derived.ok, true);
+  assert.equal(explicit.ok, true);
+  assert.equal(template.ok, true);
+  assert.equal(schema.ok, true);
+  assert.equal(missing.ok, false);
+  assert.equal(conflicting.ok, false);
+  assert.equal(irrelevantSelector.ok, false);
+  if (derived.ok)
+    assert.deepEqual(derived.command.action, {
+      kind: "task-closeout",
+      taskId: "task-closeout",
+      fromFile: "judgment.json",
+    });
+  if (explicit.ok)
+    assert.deepEqual(explicit.command.action, {
+      kind: "task-closeout",
+      taskId: "task-closeout",
+      executionId: "execution-closeout",
+      fromFile: "judgment.json",
+    });
+  if (template.ok)
+    assert.deepEqual(template.command.action, {
+      kind: "task-closeout",
+      taskId: "task-closeout",
+      printTemplate: true,
+    });
+  if (schema.ok)
+    assert.deepEqual(schema.command.action, {
+      kind: "task-closeout",
+      taskId: "task-closeout",
+      printSchema: true,
+    });
+  const help = renderThinHelp([], "task");
+  assert.match(help, /submission\.deliverables: string\[\]/u);
+  assert.match(help, /review\.verdict: approved\|changes_requested\|dismissed/u);
+  assert.match(help, /completion\.codeDocPaths: portable-path\[\]/u);
 });

--- a/packages/cli/test/thin-command-closeout-progress.test.ts
+++ b/packages/cli/test/thin-command-closeout-progress.test.ts
@@ -19,6 +19,8 @@ test("lifecycle CLI maps explicit selectors and accepts every derivable executio
       "task-1",
       "--execution-id",
       "execution-1",
+      "--agent",
+      "runtime-session:runtime-1",
       "--reason",
       "Recover omitted executor attribution",
     ]),
@@ -76,6 +78,7 @@ test("lifecycle CLI maps explicit selectors and accepts every derivable executio
       kind: "task-declare-executor",
       taskId: "task-1",
       executionId: "execution-1",
+      agent: "runtime-session:runtime-1",
       reason: "Recover omitted executor attribution",
     });
   if (review.ok)

--- a/packages/daemon/src/protocol/daemon-protocol-commands-task-surface.ts
+++ b/packages/daemon/src/protocol/daemon-protocol-commands-task-surface.ts
@@ -45,7 +45,8 @@ export const taskSurfaceProtocolCommands = Object.freeze([
         {
           code: "invalid_field",
           nextAction:
-            "Name an agent id or runtime-session:<id> from ha task dispatches; omit it when exactly one dispatch matches.",
+            "Name an agent id or runtime-session:<id> from ha task dispatches; " +
+            "omit it when exactly one dispatch matches.",
         },
         { regex: "^[A-Za-z0-9][A-Za-z0-9._:-]*$" },
       ),

--- a/packages/daemon/src/protocol/daemon-protocol-commands-task-surface.ts
+++ b/packages/daemon/src/protocol/daemon-protocol-commands-task-surface.ts
@@ -38,6 +38,17 @@ export const taskSurfaceProtocolCommands = Object.freeze([
         code: "invalid_field",
         nextAction: "Pass --execution-id <execution-id> only when the daemon cannot derive a unique candidate.",
       }),
+      cliInput(
+        "--agent",
+        "single",
+        false,
+        {
+          code: "invalid_field",
+          nextAction:
+            "Name an agent id or runtime-session:<id> from ha task dispatches; omit it when exactly one dispatch matches.",
+        },
+        { regex: "^[A-Za-z0-9][A-Za-z0-9._:-]*$" },
+      ),
       cliInput("--reason", "single", true, {
         code: "missing_field",
         nextAction: "Add --reason <auditable-recovery-reason>.",

--- a/packages/daemon/src/protocol/daemon-protocol-commands-task.ts
+++ b/packages/daemon/src/protocol/daemon-protocol-commands-task.ts
@@ -9,6 +9,7 @@ import {
   reviewJsonFields,
   taskSubmissionJsonFields,
 } from "../../../preset/src/preset-command-contract.ts";
+import { taskCloseoutPacketHelp } from "../../../kernel/src/index.ts";
 
 export const taskExecutionProtocolCommands = Object.freeze([
   defineCenterForwardWriteCommand({
@@ -131,12 +132,37 @@ export const taskExecutionProtocolCommands = Object.freeze([
       cliInput(
         "--from-file",
         "single",
-        true,
+        false,
         {
           code: "missing_field",
-          nextAction: "Run ha task closeout <task-id> --from-file <judgment.json>.",
+          nextAction: "Choose exactly one of --from-file <judgment.json>, --print-template, or --print-schema.",
         },
-        { jsonFields: ["submission", "review", "consent", "completion"] },
+        {
+          jsonFields: ["review", "consent", "completion"],
+          jsonAllowedFields: ["submission", "review", "consent", "completion"],
+          format: taskCloseoutPacketHelp(),
+          conflictsWith: ["--print-template", "--print-schema"],
+        },
+      ),
+      cliInput(
+        "--print-template",
+        "boolean",
+        false,
+        {
+          code: "invalid_field",
+          nextAction: "Use --print-template without --from-file or --print-schema.",
+        },
+        { conflictsWith: ["--from-file", "--print-schema"] },
+      ),
+      cliInput(
+        "--print-schema",
+        "boolean",
+        false,
+        {
+          code: "invalid_field",
+          nextAction: "Use --print-schema without --from-file or --print-template.",
+        },
+        { conflictsWith: ["--from-file", "--print-template", "--execution-id"] },
       ),
     ],
   }),

--- a/packages/daemon/src/protocol/daemon-protocol-commands-task.ts
+++ b/packages/daemon/src/protocol/daemon-protocol-commands-task.ts
@@ -9,7 +9,6 @@ import {
   reviewJsonFields,
   taskSubmissionJsonFields,
 } from "../../../preset/src/preset-command-contract.ts";
-import { taskCloseoutPacketHelp } from "../../../kernel/src/index.ts";
 
 export const taskExecutionProtocolCommands = Object.freeze([
   defineCenterForwardWriteCommand({
@@ -140,7 +139,7 @@ export const taskExecutionProtocolCommands = Object.freeze([
         {
           jsonFields: ["review", "consent", "completion"],
           jsonAllowedFields: ["submission", "review", "consent", "completion"],
-          format: taskCloseoutPacketHelp(),
+          format: "task-closeout-packet/v1 JSON; run --print-schema for the field contract",
           conflictsWith: ["--print-template", "--print-schema"],
         },
       ),

--- a/packages/daemon/src/repo-cell-action-dispatch.ts
+++ b/packages/daemon/src/repo-cell-action-dispatch.ts
@@ -23,6 +23,7 @@ import { runFactRekey } from "./fact-rekey.ts";
 import { leaseTtlMs, type RepoCellBinding, type RepoTaskAction, type Snapshot } from "./repo-cell-types.ts";
 import { pullAndIngestCiObservations } from "./ci-observation-actions.ts";
 import { actorHint } from "./repo-cell-proof.ts";
+import { readTaskDispatches } from "./dispatch-read.ts";
 import type { RepoCellOperationalContext } from "./repo-cell-action-context.ts";
 import type { TaskCommandWithDocsAction } from "./repo-cell-task-command-docs.ts";
 
@@ -568,6 +569,7 @@ export function declareExecutionExecutor(
         `${taskId}`,
         " --execution-id ",
         `${requestedExecutionId ?? "<execution-id>"}`,
+        " --agent <dispatch-agent>",
         " --reason <reason>.",
       ].join(""),
     );
@@ -580,9 +582,12 @@ export function declareExecutionExecutor(
           `Run ha task show ${taskId}; unblock the Task if needed, then retry when`,
           "one submitted review-node execution with no executor is eligible.",
         ].join(" "),
-        (candidate: string) => `ha task declare-executor ${taskId} --execution-id ${candidate} --reason <reason>`,
+        (candidate: string) =>
+          `ha task declare-executor ${taskId} --execution-id ${candidate} --agent <dispatch-agent> --reason <reason>`,
       ),
-    opId = cell.operationId(action, binding, cell.input.repoId, snapshot.revision),
+    executor = dispatchedExecutor(cell, action, taskId, executionId),
+    canonicalAction = { ...action, agent: executor.id },
+    opId = cell.operationId(canonicalAction, binding, cell.input.repoId, snapshot.revision),
     existing = cell.store.readEvent(opId);
   if (existing) return cell.receiptForOperation(opId, binding);
   const declaration = compileExecutionExecutorDeclaration({
@@ -590,6 +595,7 @@ export function declareExecutionExecutor(
       taskId,
       executionId,
       actor: binding.actor,
+      executor,
       source: binding.source,
       reason,
       opId,
@@ -615,5 +621,58 @@ export function declareExecutionExecutor(
     cell.projection.read(taskId).snapshot,
     publication,
     cell.receiptProof(compiled.event, publication),
+  );
+}
+
+function dispatchedExecutor(
+  cell: RepoCellOperationalContext,
+  action: RepoTaskAction,
+  taskId: string,
+  executionId: string,
+): { readonly kind: "agent"; readonly id: string } {
+  const requested = action.agent === undefined ? undefined : cell.requiredCellText(action.agent, "agent"),
+    rows = readTaskDispatches({ rootDir: cell.rootDir, projection: cell.projection, taskId }).dispatches.filter(
+      (dispatch) => dispatch.executionId === executionId,
+    ),
+    candidates = [
+      ...new Map(
+        rows.map((dispatch) => [
+          dispatch.runtimeSessionId,
+          {
+            runtimeSessionId: dispatch.runtimeSessionId,
+            executorId: `runtime-session:${dispatch.runtimeSessionId}`,
+            agentId: dispatch.agentId,
+          },
+        ]),
+      ).values(),
+    ],
+    matches = requested
+      ? candidates.filter(
+          (candidate) =>
+            requested === candidate.executorId ||
+            requested === candidate.runtimeSessionId ||
+            requested === candidate.agentId,
+        )
+      : candidates;
+  if (matches.length === 1) return { kind: "agent", id: matches[0]!.executorId };
+  const choices = candidates.map((candidate) => candidate.executorId);
+  if (candidates.length === 0)
+    throw cell.cellCodedError(
+      "invalid_proof",
+      `Execution ${executionId} has no recorded runtime dispatch. Run ha task dispatches ${taskId}; executor declaration remains unavailable until a real dispatch record exists.`,
+    );
+  if (requested)
+    throw cell.cellCodedError(
+      "invalid_proof",
+      `--agent ${requested} does not name exactly one dispatch for execution ${executionId}. Choose ${choices.join(" or ")} from ha task dispatches ${taskId}.`,
+    );
+  throw cell.cellCodedError(
+    "invalid_command",
+    `Execution ${executionId} has multiple dispatched executors. Choose one explicitly with ${choices
+      .map(
+        (agent) =>
+          `ha task declare-executor ${taskId} --execution-id ${executionId} --agent ${agent} --reason <reason>`,
+      )
+      .join(" or ")}.`,
   );
 }

--- a/packages/daemon/src/repo-cell-action-dispatch.ts
+++ b/packages/daemon/src/repo-cell-action-dispatch.ts
@@ -659,12 +659,14 @@ function dispatchedExecutor(
   if (candidates.length === 0)
     throw cell.cellCodedError(
       "invalid_proof",
-      `Execution ${executionId} has no recorded runtime dispatch. Run ha task dispatches ${taskId}; executor declaration remains unavailable until a real dispatch record exists.`,
+      `Execution ${executionId} has no recorded runtime dispatch. Run ha task dispatches ${taskId}; ` +
+        `executor declaration remains unavailable until a real dispatch record exists.`,
     );
   if (requested)
     throw cell.cellCodedError(
       "invalid_proof",
-      `--agent ${requested} does not name exactly one dispatch for execution ${executionId}. Choose ${choices.join(" or ")} from ha task dispatches ${taskId}.`,
+      `--agent ${requested} does not name exactly one dispatch for execution ${executionId}. ` +
+        `Choose ${choices.join(" or ")} from ha task dispatches ${taskId}.`,
     );
   throw cell.cellCodedError(
     "invalid_command",

--- a/packages/daemon/src/repo-cell-packets.ts
+++ b/packages/daemon/src/repo-cell-packets.ts
@@ -152,7 +152,7 @@ export function lifecycleReceipt(
             : !approved.length
               ? declarationNeeded
                 ? [
-                    "HARNESS_ACTOR=agent:<id> ha task declare-executor ",
+                    "ha task declare-executor ",
                     `${event.taskId}`,
                     " --execution-id ",
                     `${executionId}`,

--- a/packages/daemon/test/rejection-next-actions.integration.test.ts
+++ b/packages/daemon/test/rejection-next-actions.integration.test.ts
@@ -156,18 +156,14 @@ test("executor declaration and completion context refusals name projection rebui
     assert.equal(declaration.code, "content_not_ready", JSON.stringify(declaration));
     assert.equal(
       declaration.nextAction,
-      `Task ${taskId} is not ready for executor declaration; run ha daemon projection rebuild, then retry ha task declare-executor ${taskId} --execution-id ${executionId} --reason <reason>.`,
+      `Task ${taskId} is not ready for executor declaration; run ha daemon projection rebuild, then retry ha task declare-executor ${taskId} --execution-id ${executionId} --agent <dispatch-agent> --reason <reason>.`,
     );
     assert.equal((await cell.run({ kind: "projection-rebuild" }, declarer)).outcome, "applied");
-    assert.equal(
-      (
-        await cell.run(
-          { kind: "task-declare-executor", taskId, executionId, reason: "Recover omitted executor" },
-          declarer,
-        )
-      ).outcome,
-      "applied",
+    const withoutDispatch = await cell.run(
+      { kind: "task-declare-executor", taskId, executionId, reason: "Recover omitted executor" },
+      declarer,
     );
+    assert.equal(withoutDispatch.code, "invalid_proof", JSON.stringify(withoutDispatch));
     await cell.close();
     cell = undefined;
 

--- a/packages/daemon/test/review-independence-diagnostics.integration.test.ts
+++ b/packages/daemon/test/review-independence-diagnostics.integration.test.ts
@@ -5,7 +5,7 @@ import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
-import { makeTaskEventStore, makeTaskProjection } from "../../kernel/src/index.ts";
+import { makeTaskEventStore } from "../../kernel/src/index.ts";
 import { canonicalRoot, workspaceId } from "../src/protocol/daemon-protocol.contract.ts";
 import { withRoleBinding } from "./role-binding.fixtures.ts";
 import { openBootstrappedRepoCell as openRepoCell } from "./repo-settings.fixture.ts";
@@ -127,6 +127,44 @@ test("a bare-invocation execution has a visible warning and an audited recovery 
       repoId: workspaceId("review-bare"),
       rootDir: canonicalRoot(rootDir),
       ownerId: "daemon-test",
+      runtimeDaemonRoute: { userRoot: rootDir, daemonId: "daemon-test", endpoint: path.join(rootDir, "daemon.sock") },
+      prepareRuntimeLaunch: (_instanceId, request) => ({
+        definition: {
+          schema: "agent-definition-snapshot/v1",
+          configVersion: 1,
+          instanceId: "review-runtime",
+          installationId: "review-runtime-installation",
+          kindId: "codex",
+          providerId: "openai",
+          model: "review-model",
+          reasoningEffort: "medium",
+          baseUrl: null,
+          authMode: "subscription",
+        },
+        installation: {
+          installationId: "review-runtime-installation",
+          kindId: "codex",
+          executablePath: "/test/review-runtime",
+          version: "1.0.0",
+          observedAt: "2026-08-22T00:00:00.000Z",
+        },
+        executablePath: "/test/review-runtime",
+        args: ["provider-review-bare"],
+        env: {},
+        cwd: request.cwd,
+        prompt: request.prompt,
+      }),
+      runtimeLaunch: () => ({
+        pid: 1_001,
+        onOutput: (listener) => {
+          queueMicrotask(() =>
+            listener(`${JSON.stringify({ type: "thread.started", thread_id: "provider-review-bare" })}\n`),
+          );
+        },
+        onErrorOutput: () => undefined,
+        onExit: () => undefined,
+        terminate: () => undefined,
+      }),
     });
     const bare = withRoleBinding(
       {
@@ -145,20 +183,33 @@ test("a bare-invocation execution has a visible warning and an audited recovery 
     const started = (await cell.run({ kind: "task-start", taskId, executionId }, bare)) as Record<string, unknown>;
     assert.equal(started.outcome, "applied");
     assert.match(String(started.summary), /declared no executor/u);
-    const commitSha = git(rootDir, "rev-parse", "HEAD");
-    assert.equal(
-      (await cell.run({ kind: "task-release", taskId, reason: "Rejoin as the agent that completed the work." }, bare))
-        .outcome,
-      "applied",
+    const worker = await cell.spawnRuntime(
+      {
+        runtimeInstanceId: "review-runtime",
+        cwd: { scope: "repo-root" },
+        prompt: "Implement the task.",
+        taskId,
+        idempotencyKey: "review-bare-worker",
+      },
+      bare,
     );
+    await runtimeEvent(
+      rootDir,
+      "review-bare",
+      (event) =>
+        event.type === "runtime_session_task_bound" && event.payload.runtimeSessionId === worker.runtimeSessionId,
+    );
+    const commitSha = git(rootDir, "rev-parse", "HEAD");
     const agent = withRoleBinding(
       {
-        actor: { principal: { personId: "0" }, executor: { kind: "agent" as const, id: "recovering-agent" } },
+        actor: {
+          principal: { personId: "0" },
+          executor: { kind: "agent" as const, id: `runtime-session:${worker.runtimeSessionId}` },
+        },
         source: "local" as const,
       },
       "arbiter",
     );
-    assert.equal((await cell.run({ kind: "task-start", taskId, executionId }, agent)).outcome, "applied");
     writeFileSync(
       path.join(rootDir, "submission.json"),
       JSON.stringify({
@@ -172,7 +223,7 @@ test("a bare-invocation execution has a visible warning and an audited recovery 
       }),
     );
     assert.equal(
-      (await cell.run({ kind: "task-submit", taskId, executionId, fromFile: "submission.json" }, agent)).outcome,
+      (await cell.run({ kind: "task-submit", taskId, executionId, fromFile: "submission.json" }, bare)).outcome,
       "applied",
     );
     writeFileSync(
@@ -190,16 +241,41 @@ test("a bare-invocation execution has a visible warning and an audited recovery 
 
     const wrongPrincipal = withRoleBinding(
       {
-        actor: { principal: { personId: "1" }, executor: { kind: "agent" as const, id: "recovering-agent" } },
+        actor: { principal: { personId: "1" }, executor: null },
         source: "local" as const,
       },
       "arbiter",
     );
     const denied = await cell.run(
-      { kind: "task-declare-executor", taskId, executionId, reason: "Claim from another principal." },
+      {
+        kind: "task-declare-executor",
+        taskId,
+        executionId,
+        agent: `runtime-session:${worker.runtimeSessionId}`,
+        reason: "Claim from another principal.",
+      },
       wrongPrincipal,
     );
     assert.equal(denied.code, "invalid_proof");
+
+    const impersonatingAgent = withRoleBinding(
+        {
+          actor: { principal: { personId: "0" }, executor: { kind: "agent" as const, id: "another-runtime" } },
+          source: "local" as const,
+        },
+        "arbiter",
+      ),
+      impersonationDenied = await cell.run(
+        {
+          kind: "task-declare-executor",
+          taskId,
+          executionId,
+          agent: `runtime-session:${worker.runtimeSessionId}`,
+          reason: "One agent must not bind another agent's dispatch.",
+        },
+        impersonatingAgent,
+      );
+    assert.equal(impersonationDenied.code, "invalid_proof", JSON.stringify(impersonationDenied));
 
     const declared = (await cell.run(
       {
@@ -207,7 +283,7 @@ test("a bare-invocation execution has a visible warning and an audited recovery 
         taskId,
         reason: "Recovered the executor omitted by the original start invocation.",
       },
-      agent,
+      bare,
     )) as Record<string, unknown>;
     assert.equal(declared.outcome, "applied", JSON.stringify(declared));
     const event = makeTaskEventStore({ repoId: "review-bare", rootDir }).readEvent(String(declared.opId));
@@ -215,6 +291,7 @@ test("a bare-invocation execution has a visible warning and an audited recovery 
     if (event?.type === "execution_executor_declared") {
       assert.deepEqual(event.payload.previousActor, bare.actor);
       assert.deepEqual(event.payload.execution.actor, agent.actor);
+      assert.deepEqual(event.actor, bare.actor);
       assert.equal(event.payload.reason, "Recovered the executor omitted by the original start invocation.");
     }
 
@@ -222,8 +299,8 @@ test("a bare-invocation execution has a visible warning and an audited recovery 
       { kind: "task-review-execution", taskId, executionId, reviewId: "r2", fromFile: "review.json" },
       agent,
     );
-    assert.equal(selfReview.code, "actor_unauthorized");
-    assert.match(String(selfReview.nextAction), /independent of the submitting executor/u);
+    assert.equal(selfReview.code, "runtime_task_self_review_forbidden");
+    assert.match(String(selfReview.nextAction), /cannot review its own work/u);
 
     const reviewed = await cell.run(
       { kind: "task-review-execution", taskId, executionId, reviewId: "r3", fromFile: "review.json" },
@@ -247,7 +324,7 @@ test("a bare-invocation execution has a visible warning and an audited recovery 
   }
 });
 
-test("a reviewed bare-invocation execution can declare its executor and complete after cold replay", async () => {
+test("a reviewed bare-invocation execution without a dispatch cannot declare an executor", async () => {
   const rootDir = mkdtempSync(path.join(tmpdir(), "ha-review-bare-reviewed-"));
   let cell: Awaited<ReturnType<typeof openRepoCell>> | undefined;
   const repoId = workspaceId("review-bare-reviewed"),
@@ -256,26 +333,6 @@ test("a reviewed bare-invocation execution can declare its executor and complete
     bare = withRoleBinding(
       {
         actor: { principal: { personId: "person-owner" }, executor: null },
-        source: "local" as const,
-      },
-      "arbiter",
-    ),
-    agent = withRoleBinding(
-      {
-        actor: {
-          principal: { personId: "person-owner" },
-          executor: { kind: "agent" as const, id: "recovering-agent" },
-        },
-        source: "local" as const,
-      },
-      "arbiter",
-    ),
-    wrongPrincipal = withRoleBinding(
-      {
-        actor: {
-          principal: { personId: "person-outsider" },
-          executor: { kind: "agent" as const, id: "recovering-agent" },
-        },
         source: "local" as const,
       },
       "arbiter",
@@ -357,124 +414,19 @@ test("a reviewed bare-invocation execution can declare its executor and complete
       ).outcome,
       "applied",
     );
-    assert.equal(
-      (
-        await cell.run(
-          { kind: "task-transition", taskId, status: "blocked", reason: "Executor attribution must be repaired." },
-          bare,
-        )
-      ).outcome,
-      "applied",
-    );
-    writeFileSync(
-      path.join(rootDir, "judgment.json"),
-      JSON.stringify({
-        submission,
-        review: { verdict: "approved", reason: "Independent review passed.", evidenceChecked: ["daemon integration"] },
-        consent: { approved: true },
-        completion: { ci: "passed", codeDocPaths: ["README.md"] },
-      }),
-    );
-
-    const negativeControl = {
-      complete: await cell.run({ kind: "task-complete", taskId, executionId, ci: "passed" }, agent),
-      consent: await cell.run(
-        {
-          kind: "task-review-consent",
-          taskId,
-          executionId,
-          reviewId: "review-approved",
-          consentId: "consent-approved",
-        },
-        bare,
-      ),
-      closeout: await cell.run({ kind: "task-closeout", taskId, executionId, fromFile: "judgment.json" }, agent),
-      start: await cell.run({ kind: "task-start", taskId, executionId }, agent),
-      declareWrongPrincipal: await cell.run(
-        { kind: "task-declare-executor", taskId, executionId, reason: "An outsider must not claim this execution." },
-        wrongPrincipal,
-      ),
-    };
-    console.log(`executor-null-negative-control=${JSON.stringify(negativeControl)}`);
-    assert.deepEqual(
-      Object.values(negativeControl).map((receipt) => receipt.outcome),
-      ["op_rejected", "op_rejected", "op_rejected", "op_rejected", "op_rejected"],
-    );
-    assert.equal(negativeControl.complete.code, "task_blocked");
-    assert.match(String(negativeControl.complete.nextAction), /ha task transition task-bare-reviewed active/u);
-    assert.match(String(negativeControl.closeout.nextAction), /ha task transition task-bare-reviewed active/u);
-    assert.match(String(negativeControl.closeout.nextAction), /ha task declare-executor task-bare-reviewed/u);
-
-    const unblocked = await cell.run({ kind: "task-transition", taskId, status: "active" }, bare);
-    assert.equal(unblocked.outcome, "applied", JSON.stringify(unblocked));
-    const completeRepair = await cell.run({ kind: "task-complete", taskId, executionId, ci: "passed" }, agent),
-      closeoutRepair = await cell.run({ kind: "task-closeout", taskId, executionId, fromFile: "judgment.json" }, agent);
-    assert.equal(completeRepair.code, "executor_missing", JSON.stringify(completeRepair));
-    assert.match(String(completeRepair.nextAction), /ha task declare-executor task-bare-reviewed/u);
-    assert.equal(closeoutRepair.code, "executor_missing", JSON.stringify(closeoutRepair));
-    assert.match(String(closeoutRepair.nextAction), /ha task declare-executor task-bare-reviewed/u);
     const denied = await cell.run(
-      { kind: "task-declare-executor", taskId, executionId, reason: "An outsider must not claim this execution." },
-      wrongPrincipal,
-    );
-    assert.equal(denied.code, "invalid_proof", JSON.stringify(denied));
-
-    const declared = (await cell.run(
       {
         kind: "task-declare-executor",
         taskId,
         executionId,
-        reason: "The original principal names the agent that completed the already approved execution.",
+        agent: "runtime-session:missing-runtime",
+        reason: "A free-text executor must not satisfy the proof gate.",
       },
-      agent,
-    )) as Record<string, unknown>;
-    assert.equal(declared.outcome, "applied", JSON.stringify(declared));
-    const declaration = makeTaskEventStore({ repoId, rootDir }).readEvent(String(declared.opId));
-    assert.equal(declaration?.type, "execution_executor_declared");
-    if (declaration?.type === "execution_executor_declared") {
-      assert.deepEqual(declaration.payload.previousActor, bare.actor);
-      assert.deepEqual(declaration.payload.execution.actor, agent.actor);
-      assert.equal(declaration.payload.task.status, "in_review");
-      assert.equal(declaration.payload.task.currentNode, "review");
-    }
-
-    await cell.close();
-    cell = undefined;
-    const projection = makeTaskProjection({ rootDir, eventStore: makeTaskEventStore({ repoId, rootDir }) });
-    projection.close();
-    rmSync(projection.path, { force: true });
-    projection.rebuild();
-    assert.equal(projection.read(taskId).snapshot.task?.status, "in_review");
-    assert.deepEqual(
-      projection.read(taskId).snapshot.executions.find((execution) => execution.executionId === executionId)?.actor,
-      agent.actor,
-    );
-    projection.close();
-
-    cell = await openRepoCell({ repoId, rootDir: canonicalRoot(rootDir), ownerId: "review-bare-reviewed-reopened" });
-    const consented = await cell.run(
-      { kind: "task-review-consent", taskId, executionId, reviewId: "review-approved", consentId: "consent-approved" },
       bare,
     );
-    assert.equal(consented.outcome, "applied", JSON.stringify(consented));
-    const completed = (await cell.run(
-      { kind: "task-complete", taskId, executionId, ci: "passed", paths: ["README.md"] },
-      bare,
-    )) as Record<string, unknown>;
-    console.log(
-      `executor-null-positive-control=${JSON.stringify({ completeRepair, closeoutRepair, denied, declared, consented, completed })}`,
-    );
-    assert.equal(completed.outcome, "applied", JSON.stringify(completed));
-    const shown = await cell.run({ kind: "task-show", taskId }, bare);
-    assert.match(String(shown.evidence), /"status":"done"/u);
-    assert.equal(
-      makeTaskEventStore({ repoId, rootDir })
-        .read()
-        .events.some(
-          (event) => event.type === "review_recorded" && event.payload.review.verdict === "changes_requested",
-        ),
-      false,
-    );
+    assert.equal(denied.code, "invalid_proof", JSON.stringify(denied));
+    assert.match(String(denied.nextAction), /has no recorded runtime dispatch/u);
+    assert.match(String(denied.nextAction), new RegExp(`ha task dispatches ${taskId}`, "u"));
   } finally {
     await cell?.close();
     rmSync(rootDir, { recursive: true, force: true });
@@ -677,10 +629,8 @@ test("task-bound runtime sessions cannot review their own execution across exit 
       implementer,
     );
     assert.equal(directCreated.outcome, "applied");
-    await realizeTaskPlanFixture(
-      rootDir,
-      String((directCreated as Record<string, unknown>).packagePath),
-      (planPath) => cell!.run({ kind: "doc-submit", paths: [planPath] }, implementer),
+    await realizeTaskPlanFixture(rootDir, String((directCreated as Record<string, unknown>).packagePath), (planPath) =>
+      cell!.run({ kind: "doc-submit", paths: [planPath] }, implementer),
     );
     assert.equal(
       (await cell.run({ kind: "task-start", taskId: directTaskId, executionId: directExecutionId }, implementer))

--- a/packages/daemon/test/task-closeout-action.test.ts
+++ b/packages/daemon/test/task-closeout-action.test.ts
@@ -110,7 +110,16 @@ function applied(stage: string): WriteReceipt {
     },
   };
 }
-function setup(initial = snapshot(), rejectStage?: CloseoutStep, setupCaller = caller) {
+function setup(
+  initial = snapshot(),
+  rejectStage?: CloseoutStep,
+  setupCaller = caller,
+  closeoutAction: Readonly<Record<string, unknown>> = {
+    kind: "task-closeout",
+    taskId,
+    fromFile: "judgment.json",
+  },
+) {
   const rootDir = mkdtempSync(path.join(tmpdir(), "ha-closeout-action-")),
     fromFile = "judgment.json";
   writeFileSync(path.join(rootDir, fromFile), JSON.stringify(judgment()));
@@ -122,7 +131,7 @@ function setup(initial = snapshot(), rejectStage?: CloseoutStep, setupCaller = c
     run = () =>
       runTaskCloseoutAction({
         rootDir,
-        action: { kind: "task-closeout", taskId, fromFile },
+        action: closeoutAction,
         caller: setupCaller,
         opId: "op-closeout",
         readWorkspaceText,
@@ -179,6 +188,97 @@ test("a submitted execution resumes at review instead of rejecting P2-06", async
       value.calls.map(({ stage }) => stage),
       ["review-execution", "review-consent", "complete"],
     );
+  } finally {
+    rmSync(value.rootDir, { recursive: true, force: true });
+  }
+});
+test("a submitted execution resumes when the packet omits its locked submission", async () => {
+  const value = setup(snapshot("in_review", [execution(executionId, "submitted")])),
+    { submission: _locked, ...resumePacket } = judgment();
+  writeFileSync(path.join(value.rootDir, "judgment.json"), JSON.stringify(resumePacket));
+  try {
+    assert.equal((await value.run()).outcome, "applied");
+    assert.deepEqual(
+      value.calls.map(({ stage }) => stage),
+      ["review-execution", "review-consent", "complete"],
+    );
+  } finally {
+    rmSync(value.rootDir, { recursive: true, force: true });
+  }
+});
+test("a mismatched resubmission reports the locked content and the omission repair", async () => {
+  const value = setup(snapshot("in_review", [execution(executionId, "submitted")]));
+  writeFileSync(
+    path.join(value.rootDir, "judgment.json"),
+    JSON.stringify({
+      ...judgment(),
+      submission: { ...judgment().submission, completionClaim: "Different but valid." },
+    }),
+  );
+  try {
+    const receipt = await value.run();
+    assert.equal(receipt.code, "submission_mismatch");
+    assert.match(String(receipt.nextAction), /"completionClaim": "Complete\."/u);
+    assert.match(String(receipt.nextAction), /Remove the submission section/u);
+    assert.equal(value.calls.length, 0);
+  } finally {
+    rmSync(value.rootDir, { recursive: true, force: true });
+  }
+});
+test("one invalid closeout response names every bad field", async () => {
+  const value = setup();
+  writeFileSync(
+    path.join(value.rootDir, "judgment.json"),
+    JSON.stringify({
+      submission: {
+        completionClaim: "",
+        deliverables: "command",
+        outputs: ["CLI"],
+        verificationNotes: ["tests"],
+        knownGaps: [],
+        residualRisks: [],
+        commitSha: "short",
+      },
+      review: { verdict: "PASS", reason: "", evidenceChecked: "tests" },
+      consent: { approved: false },
+      completion: { ci: "green", codeDocPaths: ["../escape"] },
+    }),
+  );
+  try {
+    const receipt = await value.run(),
+      report = String(receipt.nextAction);
+    assert.equal(receipt.code, "invalid_judgment");
+    for (const field of [
+      "packet.submission.completionClaim",
+      "packet.submission.deliverables",
+      "packet.submission.commitSha",
+      "packet.review.verdict",
+      "packet.review.reason",
+      "packet.review.evidenceChecked",
+      "packet.consent.approved",
+      "packet.completion.ci",
+      "packet.completion.codeDocPaths[0]",
+    ])
+      assert.equal(report.includes(field), true, report);
+    assert.match(report, /Closeout packet has 9 error\(s\)/u);
+    assert.equal(value.calls.length, 0);
+  } finally {
+    rmSync(value.rootDir, { recursive: true, force: true });
+  }
+});
+test("the task-aware template omits submission after submit and selects the contract CI value", async () => {
+  const value = setup(snapshot("in_review", [execution(executionId, "submitted")]), undefined, caller, {
+    kind: "task-closeout",
+    taskId,
+    printTemplate: true,
+  });
+  try {
+    const receipt = await value.run(),
+      template = JSON.parse(String(receipt.evidence)) as Record<string, unknown>;
+    assert.equal(receipt.outcome, "applied");
+    assert.equal(Object.hasOwn(template, "submission"), false);
+    assert.deepEqual(template.completion, { ci: "not_applicable", codeDocPaths: ["path/to/code-or-doc"] });
+    assert.equal(value.calls.length, 0);
   } finally {
     rmSync(value.rootDir, { recursive: true, force: true });
   }

--- a/packages/kernel/src/domain/task-lifecycle-contract-support.ts
+++ b/packages/kernel/src/domain/task-lifecycle-contract-support.ts
@@ -94,14 +94,11 @@ export function executionExecutorDeclarationCandidates(
     task.taskId !== taskId ||
     !["active", "in_review"].includes(task.status) ||
     task.currentNode !== "review" ||
-    snapshot.lease !== null ||
-    actor.executor === null
+    snapshot.lease !== null
   )
     return [];
   return currentSubmittedExecutions(snapshot).filter(
-    (value) =>
-      value.actor.executor === null &&
-      isSamePerson(value.actor, actor),
+    (value) => value.actor.executor === null && isSamePerson(value.actor, actor),
   );
 }
 export function takeEdge(

--- a/packages/kernel/src/domain/task-lifecycle-event.ts
+++ b/packages/kernel/src/domain/task-lifecycle-event.ts
@@ -377,7 +377,8 @@ function validateTaskEventFields(value: unknown, allowUnknownFields: boolean): r
     )
       issues.push(
         invalidEventPayloadIssue(
-          "executor declaration must preserve the previous bare actor, bind a dispatched agent on the same principal, and state a reason",
+          "executor declaration must preserve the previous bare actor, " +
+            "bind a dispatched agent on the same principal, and state a reason",
         ),
       );
   }

--- a/packages/kernel/src/domain/task-lifecycle-event.ts
+++ b/packages/kernel/src/domain/task-lifecycle-event.ts
@@ -28,6 +28,7 @@ import { normalizeRelativeDocumentPath } from "../layout/portable-path.ts";
 import { isValidDocEventChange, type DocEventChange } from "./doc-sync.contract.ts";
 import { timestamp } from "./timestamp.ts";
 import { validFactStillHoldsAttestation, type FactStillHoldsAttestation } from "./fact-retirement-readiness.ts";
+import { isSamePerson } from "./actor-domain-services.ts";
 export const taskEventTypes = [
   "task_created",
   "execution_started",
@@ -357,15 +358,26 @@ function validateTaskEventFields(value: unknown, allowUnknownFields: boolean): r
       issues.push(invalidEventPayloadIssue("lease event history is invalid"));
   }
   if (value.type === "execution_executor_declared") {
-    issues.push(...validateActorAxes(payload.previousActor, allowUnknownFields));
+    const previousActor = payload.previousActor,
+      executionActor = isRecord(payload.execution) ? payload.execution.actor : null,
+      actorsValid =
+        validateActorAxes(previousActor, allowUnknownFields).length === 0 &&
+        validateActorAxes(executionActor, allowUnknownFields).length === 0 &&
+        validateActorAxes(value.actor, allowUnknownFields).length === 0;
+    issues.push(...validateActorAxes(previousActor, allowUnknownFields));
     if (
       !isNonEmptyString(payload.reason) ||
-      (isRecord(payload.previousActor) && payload.previousActor.executor !== null) ||
-      (isRecord(payload.execution) && !sameActorIdentity(payload.execution.actor, value.actor))
+      !actorsValid ||
+      (previousActor as ActorAxes).executor !== null ||
+      (executionActor as ActorAxes).executor === null ||
+      !isSamePerson(previousActor as ActorAxes, value.actor as ActorAxes) ||
+      !isSamePerson(executionActor as ActorAxes, value.actor as ActorAxes) ||
+      ((value.actor as ActorAxes).executor !== null &&
+        !sameActorIdentity(executionActor as ActorAxes, value.actor as ActorAxes))
     )
       issues.push(
         invalidEventPayloadIssue(
-          "executor declaration must preserve the previous bare actor, bind the declaring actor, and state a reason",
+          "executor declaration must preserve the previous bare actor, bind a dispatched agent on the same principal, and state a reason",
         ),
       );
   }

--- a/packages/kernel/src/domain/task-lifecycle-replay.ts
+++ b/packages/kernel/src/domain/task-lifecycle-replay.ts
@@ -114,6 +114,7 @@ export function compileExecutionExecutorDeclaration(input: {
   readonly taskId: string;
   readonly executionId: string;
   readonly actor: ActorAxes;
+  readonly executor: NonNullable<ActorAxes["executor"]>;
   readonly source: WriteSource;
   readonly reason: string;
   readonly opId: string;
@@ -133,18 +134,24 @@ export function compileExecutionExecutorDeclaration(input: {
     !task ||
     !current ||
     !eligible ||
+    input.executor.kind !== "agent" ||
+    !isNonEmptyString(input.executor.id) ||
+    (input.actor.executor !== null && stableStringify(input.actor.executor) !== stableStringify(input.executor)) ||
     !isNonEmptyString(input.reason) ||
     input.workspaceRevision <= input.snapshot.revision
   )
     throw new TaskLifecycleContractError("invalid_proof", [
       lifecycleContractIssue(
         "invalid_executor_declaration",
-        "executor declaration requires the same principal to name an agent for a submitted Execution at the " +
+        "executor declaration requires the same principal to bind a dispatched agent to a submitted Execution at the " +
           "review node that originally declared no executor; unblock a blocked task before retrying",
       ),
     ]);
   const nextTask = { ...task, status: "in_review" as const },
-    nextExecution: ExecutionV1 = { ...current, actor: input.actor },
+    nextExecution: ExecutionV1 = {
+      ...current,
+      actor: { principal: input.actor.principal, executor: input.executor },
+    },
     event: ExecutionExecutorDeclaredEvent = {
       schema: "task-event/v1",
       eventId: input.eventId,
@@ -346,7 +353,7 @@ function assertReplay(snapshot: TaskLifecycleSnapshot, event: TaskEventV1, next:
   }
   if (event.type === "execution_executor_declared") {
     const current = execution(snapshot, event.payload.execution.executionId),
-      expected = current ? { ...current, actor: event.actor } : null,
+      expected = current ? { ...current, actor: event.payload.execution.actor } : null,
       expectedTask = snapshot.task ? { ...snapshot.task, status: "in_review" as const } : null;
     if (
       !current ||
@@ -354,8 +361,9 @@ function assertReplay(snapshot: TaskLifecycleSnapshot, event: TaskEventV1, next:
       stableStringify(event.payload.previousActor) !== stableStringify(current.actor) ||
       stableStringify(event.payload.execution) !== stableStringify(expected) ||
       current.actor.executor !== null ||
-      event.actor.executor === null ||
+      event.payload.execution.actor.executor === null ||
       !isSamePerson(current.actor, event.actor) ||
+      !isSamePerson(event.payload.execution.actor, event.actor) ||
       !["active", "in_review"].includes(String(snapshot.task?.status)) ||
       snapshot.task?.currentNode !== "review" ||
       snapshot.lease !== null ||

--- a/packages/kernel/src/index.ts
+++ b/packages/kernel/src/index.ts
@@ -235,17 +235,11 @@ export * from "./projection/sqlite-task-projection.ts";
 export * from "./schemas/registry.ts";
 export * from "./schemas/common.ts";
 export {
-  closeoutCiJudgments,
   createTaskCloseoutPacketTemplate,
-  taskCloseoutPacketHelp,
   taskCloseoutPacketSchema,
   validateTaskCloseoutPacket,
 } from "./schemas/task-closeout-packet.ts";
-export type {
-  CloseoutCiJudgment,
-  TaskCloseoutPacket,
-  TaskCloseoutPacketValidation,
-} from "./schemas/task-closeout-packet.ts";
+export type { CloseoutCiJudgment, TaskCloseoutPacket } from "./schemas/task-closeout-packet.ts";
 export {
   canonicalDocumentClaims,
   canonicalDocumentRetirements,

--- a/packages/kernel/src/index.ts
+++ b/packages/kernel/src/index.ts
@@ -155,7 +155,13 @@ export type {
   MigrationDocumentClaim,
   MigrationImportEventV1,
 } from "./domain/migration-import-event.ts";
-export type { ArchivedExecutionV0, ExecutionV1, LeaseV1, ProjectedExecution } from "./domain/execution.ts";
+export type {
+  ArchivedExecutionV0,
+  ExecutionV1,
+  LeaseV1,
+  ProjectedExecution,
+  SubmissionV1,
+} from "./domain/execution.ts";
 export * from "./entity/disposition.ts";
 export * from "./entity/field-contracts.ts";
 export * from "./entity/registry.ts";
@@ -228,6 +234,18 @@ export * from "./publish/index.ts";
 export * from "./projection/sqlite-task-projection.ts";
 export * from "./schemas/registry.ts";
 export * from "./schemas/common.ts";
+export {
+  closeoutCiJudgments,
+  createTaskCloseoutPacketTemplate,
+  taskCloseoutPacketHelp,
+  taskCloseoutPacketSchema,
+  validateTaskCloseoutPacket,
+} from "./schemas/task-closeout-packet.ts";
+export type {
+  CloseoutCiJudgment,
+  TaskCloseoutPacket,
+  TaskCloseoutPacketValidation,
+} from "./schemas/task-closeout-packet.ts";
 export {
   canonicalDocumentClaims,
   canonicalDocumentRetirements,

--- a/packages/kernel/src/schemas/task-closeout-packet.ts
+++ b/packages/kernel/src/schemas/task-closeout-packet.ts
@@ -1,8 +1,9 @@
 import type { SubmissionV1 } from "../domain/execution.ts";
 import { reviewVerdicts, type ReviewVerdict } from "../domain/review.ts";
+import { consumeKnownError } from "../error-consumption.ts";
 import { normalizeRelativeDocumentPath } from "../layout/portable-path.ts";
 
-export const closeoutCiJudgments = ["passed", "not_applicable"] as const;
+const closeoutCiJudgments = ["passed", "not_applicable"] as const;
 export type CloseoutCiJudgment = (typeof closeoutCiJudgments)[number];
 
 export interface TaskCloseoutPacket {
@@ -165,13 +166,13 @@ export const taskCloseoutPacketSchema = Object.freeze({
   },
 } as const satisfies SchemaNode & { readonly $schema: string; readonly $id: string; readonly title: string });
 
-export type TaskCloseoutPacketValidation =
+type TaskCloseoutPacketValidation =
   | { readonly ok: true; readonly packet: TaskCloseoutPacket }
   | { readonly ok: false; readonly issues: readonly string[] };
 
 export function validateTaskCloseoutPacket(value: unknown): TaskCloseoutPacketValidation {
   const issues: string[] = [];
-  validateNode(taskCloseoutPacketSchema, value, "packet", issues);
+  validatePacketNode(taskCloseoutPacketSchema, value, "packet", issues);
   return issues.length ? { ok: false, issues } : { ok: true, packet: value as TaskCloseoutPacket };
 }
 
@@ -185,12 +186,6 @@ export function createTaskCloseoutPacketTemplate(input: {
   return template;
 }
 
-export function taskCloseoutPacketHelp(): string {
-  const lines: string[] = [`schema ${taskCloseoutPacketSchema.$id}`];
-  collectHelp(taskCloseoutPacketSchema, "", true, false, lines);
-  return lines.join("\n      ");
-}
-
 type MutablePacket = {
   submission?: SubmissionV1;
   review: TaskCloseoutPacket["review"];
@@ -198,9 +193,9 @@ type MutablePacket = {
   completion: { ci: CloseoutCiJudgment; codeDocPaths: readonly string[] };
 };
 
-function validateNode(schema: SchemaNode, value: unknown, path: string, issues: string[]): void {
+function validatePacketNode(schema: SchemaNode, value: unknown, path: string, issues: string[]): void {
   if (schema.type === "object") {
-    if (!record(value)) {
+    if (!isPlainRecord(value)) {
       issues.push(`${path} must be an object.`);
       return;
     }
@@ -208,7 +203,7 @@ function validateNode(schema: SchemaNode, value: unknown, path: string, issues: 
     for (const field of Object.keys(value))
       if (!Object.hasOwn(schema.properties, field)) issues.push(`${path}.${field} is not allowed.`);
     for (const [field, child] of Object.entries(schema.properties))
-      if (Object.hasOwn(value, field)) validateNode(child, value[field], `${path}.${field}`, issues);
+      if (Object.hasOwn(value, field)) validatePacketNode(child, value[field], `${path}.${field}`, issues);
     return;
   }
   if (schema.type === "array") {
@@ -218,7 +213,7 @@ function validateNode(schema: SchemaNode, value: unknown, path: string, issues: 
     }
     if (schema.minItems !== undefined && value.length < schema.minItems)
       issues.push(`${path} must contain at least ${schema.minItems} item(s).`);
-    value.forEach((entry, index) => validateNode(schema.items, entry, `${path}[${index}]`, issues));
+    value.forEach((entry, index) => validatePacketNode(schema.items, entry, `${path}[${index}]`, issues));
     return;
   }
   if (schema.type === "boolean") {
@@ -242,6 +237,7 @@ function validatePortablePath(value: string, path: string, issues: string[]): vo
     const normalized = normalizeRelativeDocumentPath(value);
     if (normalized !== value) issues.push(`${path} must already be a normalized portable relative path.`);
   } catch (error) {
+    consumeKnownError(error);
     issues.push(`${path} must be a portable relative path: ${error instanceof Error ? error.message : String(error)}.`);
   }
 }
@@ -255,44 +251,6 @@ function exampleValue(schema: SchemaNode): unknown {
   return schema.enum?.[0] ?? "";
 }
 
-function collectHelp(
-  schema: SchemaNode,
-  path: string,
-  required: boolean,
-  optionalAncestor: boolean,
-  lines: string[],
-): void {
-  if (schema.type === "object") {
-    if (path)
-      lines.push(`${path}${required ? "" : "?"}: object${schema.description ? ` — ${schema.description}` : ""}`);
-    for (const [field, child] of Object.entries(schema.properties))
-      collectHelp(
-        child,
-        path ? `${path}.${field}` : field,
-        schema.required.includes(field),
-        optionalAncestor || !required,
-        lines,
-      );
-    return;
-  }
-  const optional = !required || optionalAncestor ? " (optional section)" : "",
-    kind =
-      schema.type === "array"
-        ? `${
-            schema.items.type === "string" && schema.items.format === "portable-relative-path"
-              ? "portable-path"
-              : schema.items.type
-          }[]`
-        : schema.type === "string" && schema.enum
-          ? schema.enum.join("|")
-          : schema.type === "string" && schema.format === "portable-relative-path"
-            ? "portable-path"
-            : schema.type === "boolean"
-              ? String(schema.const)
-              : "string";
-  lines.push(`${path}: ${kind}${optional}`);
-}
-
-function record(value: unknown): value is Record<string, unknown> {
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === "object" && !Array.isArray(value);
 }

--- a/packages/kernel/src/schemas/task-closeout-packet.ts
+++ b/packages/kernel/src/schemas/task-closeout-packet.ts
@@ -278,7 +278,11 @@ function collectHelp(
   const optional = !required || optionalAncestor ? " (optional section)" : "",
     kind =
       schema.type === "array"
-        ? `${schema.items.type === "string" && schema.items.format === "portable-relative-path" ? "portable-path" : schema.items.type}[]`
+        ? `${
+            schema.items.type === "string" && schema.items.format === "portable-relative-path"
+              ? "portable-path"
+              : schema.items.type
+          }[]`
         : schema.type === "string" && schema.enum
           ? schema.enum.join("|")
           : schema.type === "string" && schema.format === "portable-relative-path"

--- a/packages/kernel/src/schemas/task-closeout-packet.ts
+++ b/packages/kernel/src/schemas/task-closeout-packet.ts
@@ -1,0 +1,294 @@
+import type { SubmissionV1 } from "../domain/execution.ts";
+import { reviewVerdicts, type ReviewVerdict } from "../domain/review.ts";
+import { normalizeRelativeDocumentPath } from "../layout/portable-path.ts";
+
+export const closeoutCiJudgments = ["passed", "not_applicable"] as const;
+export type CloseoutCiJudgment = (typeof closeoutCiJudgments)[number];
+
+export interface TaskCloseoutPacket {
+  readonly submission?: SubmissionV1;
+  readonly review: {
+    readonly verdict: ReviewVerdict;
+    readonly reason: string;
+    readonly evidenceChecked: readonly string[];
+  };
+  readonly consent: { readonly approved: true };
+  readonly completion: {
+    readonly ci: CloseoutCiJudgment;
+    readonly codeDocPaths: readonly string[];
+  };
+}
+
+type SchemaNode =
+  | {
+      readonly type: "object";
+      readonly properties: Readonly<Record<string, SchemaNode>>;
+      readonly required: readonly string[];
+      readonly additionalProperties: false;
+      readonly description?: string;
+      readonly example?: unknown;
+    }
+  | {
+      readonly type: "array";
+      readonly items: SchemaNode;
+      readonly minItems?: number;
+      readonly description?: string;
+      readonly example?: unknown;
+    }
+  | {
+      readonly type: "string";
+      readonly minLength?: number;
+      readonly pattern?: string;
+      readonly format?: "portable-relative-path";
+      readonly enum?: readonly string[];
+      readonly description?: string;
+      readonly example?: unknown;
+    }
+  | {
+      readonly type: "boolean";
+      readonly const: boolean;
+      readonly description?: string;
+      readonly example?: unknown;
+    };
+
+const nonEmptyString = (example: string, description: string): SchemaNode => ({
+    type: "string",
+    minLength: 1,
+    example,
+    description,
+  }),
+  stringArray = (example: string, description: string): SchemaNode => ({
+    type: "array",
+    items: nonEmptyString(example, description),
+    example: [example],
+    description,
+  }),
+  portablePath = (example: string, description: string): SchemaNode => ({
+    type: "string",
+    minLength: 1,
+    format: "portable-relative-path",
+    example,
+    description,
+  }),
+  portablePathArray = (example: string, description: string): SchemaNode => ({
+    type: "array",
+    items: portablePath(example, description),
+    example: [example],
+    description,
+  });
+
+/** The single runtime, template, and CLI-help authority for `ha task closeout --from-file`. */
+export const taskCloseoutPacketSchema = Object.freeze({
+  $schema: "https://json-schema.org/draft/2020-12/schema",
+  $id: "harness://schema/task-closeout-packet/v1",
+  title: "Task closeout packet",
+  type: "object",
+  additionalProperties: false,
+  required: ["review", "consent", "completion"],
+  properties: {
+    submission: {
+      type: "object",
+      additionalProperties: false,
+      required: [
+        "completionClaim",
+        "deliverables",
+        "outputs",
+        "verificationNotes",
+        "knownGaps",
+        "residualRisks",
+        "commitSha",
+      ],
+      description: "Required before submit; omit it to resume an already-submitted Execution.",
+      properties: {
+        completionClaim: nonEmptyString("Describe the completed outcome.", "Completion claim."),
+        deliverables: stringArray(
+          "Describe one delivered artifact or repository path.",
+          "Delivered artifact descriptions or paths.",
+        ),
+        outputs: stringArray("Describe one output or evidence reference.", "Output and evidence descriptions."),
+        verificationNotes: stringArray("Describe one verification result.", "Verification results."),
+        knownGaps: stringArray("Describe one known gap, or use an empty array.", "Known gaps."),
+        residualRisks: stringArray("Describe one residual risk, or use an empty array.", "Residual risks."),
+        commitSha: {
+          type: "string",
+          pattern: "^[0-9a-f]{40}$",
+          example: "0000000000000000000000000000000000000000",
+          description: "Full lowercase 40-character Git commit SHA.",
+        },
+      },
+    },
+    review: {
+      type: "object",
+      additionalProperties: false,
+      required: ["verdict", "reason", "evidenceChecked"],
+      properties: {
+        verdict: {
+          type: "string",
+          enum: reviewVerdicts,
+          example: "approved",
+          description: "Execution Review verdict.",
+        },
+        reason: nonEmptyString("Explain why the delivery satisfies the task intent.", "Review rationale."),
+        evidenceChecked: stringArray("Name one inspected evidence item.", "Inspected evidence identifiers."),
+      },
+    },
+    consent: {
+      type: "object",
+      additionalProperties: false,
+      required: ["approved"],
+      properties: {
+        approved: {
+          type: "boolean",
+          const: true,
+          example: true,
+          description: "Explicit owner approval for this exact packet.",
+        },
+      },
+    },
+    completion: {
+      type: "object",
+      additionalProperties: false,
+      required: ["ci", "codeDocPaths"],
+      properties: {
+        ci: {
+          type: "string",
+          enum: closeoutCiJudgments,
+          example: "passed",
+          description: "Use passed only when the task contract declares the ci gate.",
+        },
+        codeDocPaths: portablePathArray(
+          "path/to/code-or-doc",
+          "Portable repository-relative paths to reconcile; use an empty array when none apply.",
+        ),
+      },
+    },
+  },
+} as const satisfies SchemaNode & { readonly $schema: string; readonly $id: string; readonly title: string });
+
+export type TaskCloseoutPacketValidation =
+  | { readonly ok: true; readonly packet: TaskCloseoutPacket }
+  | { readonly ok: false; readonly issues: readonly string[] };
+
+export function validateTaskCloseoutPacket(value: unknown): TaskCloseoutPacketValidation {
+  const issues: string[] = [];
+  validateNode(taskCloseoutPacketSchema, value, "packet", issues);
+  return issues.length ? { ok: false, issues } : { ok: true, packet: value as TaskCloseoutPacket };
+}
+
+export function createTaskCloseoutPacketTemplate(input: {
+  readonly includeSubmission: boolean;
+  readonly ci: CloseoutCiJudgment;
+}): TaskCloseoutPacket {
+  const template = exampleValue(taskCloseoutPacketSchema) as MutablePacket;
+  if (!input.includeSubmission) delete template.submission;
+  template.completion.ci = input.ci;
+  return template;
+}
+
+export function taskCloseoutPacketHelp(): string {
+  const lines: string[] = [`schema ${taskCloseoutPacketSchema.$id}`];
+  collectHelp(taskCloseoutPacketSchema, "", true, false, lines);
+  return lines.join("\n      ");
+}
+
+type MutablePacket = {
+  submission?: SubmissionV1;
+  review: TaskCloseoutPacket["review"];
+  consent: TaskCloseoutPacket["consent"];
+  completion: { ci: CloseoutCiJudgment; codeDocPaths: readonly string[] };
+};
+
+function validateNode(schema: SchemaNode, value: unknown, path: string, issues: string[]): void {
+  if (schema.type === "object") {
+    if (!record(value)) {
+      issues.push(`${path} must be an object.`);
+      return;
+    }
+    for (const field of schema.required) if (!Object.hasOwn(value, field)) issues.push(`${path}.${field} is required.`);
+    for (const field of Object.keys(value))
+      if (!Object.hasOwn(schema.properties, field)) issues.push(`${path}.${field} is not allowed.`);
+    for (const [field, child] of Object.entries(schema.properties))
+      if (Object.hasOwn(value, field)) validateNode(child, value[field], `${path}.${field}`, issues);
+    return;
+  }
+  if (schema.type === "array") {
+    if (!Array.isArray(value)) {
+      issues.push(`${path} must be an array.`);
+      return;
+    }
+    if (schema.minItems !== undefined && value.length < schema.minItems)
+      issues.push(`${path} must contain at least ${schema.minItems} item(s).`);
+    value.forEach((entry, index) => validateNode(schema.items, entry, `${path}[${index}]`, issues));
+    return;
+  }
+  if (schema.type === "boolean") {
+    if (value !== schema.const) issues.push(`${path} must be ${String(schema.const)}.`);
+    return;
+  }
+  if (typeof value !== "string") {
+    issues.push(`${path} must be a string.`);
+    return;
+  }
+  if (schema.minLength !== undefined && value.trim().length < schema.minLength)
+    issues.push(`${path} must be a non-empty string.`);
+  if (schema.enum && !schema.enum.includes(value)) issues.push(`${path} must be one of: ${schema.enum.join(", ")}.`);
+  if (schema.pattern && !new RegExp(schema.pattern, "u").test(value))
+    issues.push(`${path} must match /${schema.pattern}/u.`);
+  if (schema.format === "portable-relative-path") validatePortablePath(value, path, issues);
+}
+
+function validatePortablePath(value: string, path: string, issues: string[]): void {
+  try {
+    const normalized = normalizeRelativeDocumentPath(value);
+    if (normalized !== value) issues.push(`${path} must already be a normalized portable relative path.`);
+  } catch (error) {
+    issues.push(`${path} must be a portable relative path: ${error instanceof Error ? error.message : String(error)}.`);
+  }
+}
+
+function exampleValue(schema: SchemaNode): unknown {
+  if (schema.example !== undefined) return structuredClone(schema.example);
+  if (schema.type === "object")
+    return Object.fromEntries(Object.entries(schema.properties).map(([field, child]) => [field, exampleValue(child)]));
+  if (schema.type === "array") return [];
+  if (schema.type === "boolean") return schema.const;
+  return schema.enum?.[0] ?? "";
+}
+
+function collectHelp(
+  schema: SchemaNode,
+  path: string,
+  required: boolean,
+  optionalAncestor: boolean,
+  lines: string[],
+): void {
+  if (schema.type === "object") {
+    if (path)
+      lines.push(`${path}${required ? "" : "?"}: object${schema.description ? ` — ${schema.description}` : ""}`);
+    for (const [field, child] of Object.entries(schema.properties))
+      collectHelp(
+        child,
+        path ? `${path}.${field}` : field,
+        schema.required.includes(field),
+        optionalAncestor || !required,
+        lines,
+      );
+    return;
+  }
+  const optional = !required || optionalAncestor ? " (optional section)" : "",
+    kind =
+      schema.type === "array"
+        ? `${schema.items.type === "string" && schema.items.format === "portable-relative-path" ? "portable-path" : schema.items.type}[]`
+        : schema.type === "string" && schema.enum
+          ? schema.enum.join("|")
+          : schema.type === "string" && schema.format === "portable-relative-path"
+            ? "portable-path"
+            : schema.type === "boolean"
+              ? String(schema.const)
+              : "string";
+  lines.push(`${path}: ${kind}${optional}`);
+}
+
+function record(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}

--- a/packages/kernel/test/contracts/task-closeout-packet.test.ts
+++ b/packages/kernel/test/contracts/task-closeout-packet.test.ts
@@ -1,0 +1,64 @@
+// harness-test-tier: fast
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  createTaskCloseoutPacketTemplate,
+  taskCloseoutPacketHelp,
+  taskCloseoutPacketSchema,
+  validateTaskCloseoutPacket,
+} from "../../src/index.ts";
+
+test("closeout packet templates and help are derived from the authoritative schema", () => {
+  const initial = createTaskCloseoutPacketTemplate({ includeSubmission: true, ci: "passed" }),
+    resumed = createTaskCloseoutPacketTemplate({ includeSubmission: false, ci: "not_applicable" }),
+    help = taskCloseoutPacketHelp();
+  assert.equal(validateTaskCloseoutPacket(initial).ok, true);
+  assert.equal(validateTaskCloseoutPacket(resumed).ok, true);
+  assert.equal(Object.hasOwn(resumed, "submission"), false);
+  assert.equal(resumed.completion.ci, "not_applicable");
+  assert.match(help, new RegExp(taskCloseoutPacketSchema.$id, "u"));
+  assert.match(help, /submission\?: object/u);
+  assert.match(help, /submission\.deliverables: string\[\]/u);
+  assert.match(help, /review\.verdict: approved\|changes_requested\|dismissed/u);
+  assert.match(help, /consent\.approved: true/u);
+  assert.match(help, /completion\.ci: passed\|not_applicable/u);
+});
+
+test("closeout packet validation reports every independent field error at once", () => {
+  const invalid = validateTaskCloseoutPacket({
+    unexpected: true,
+    submission: {
+      completionClaim: "",
+      deliverables: "README.md",
+      outputs: [1],
+      verificationNotes: [""],
+      knownGaps: {},
+      residualRisks: [],
+      commitSha: "short",
+    },
+    review: { verdict: "PASS", reason: "", evidenceChecked: "tests" },
+    consent: { approved: false },
+    completion: { ci: "green", codeDocPaths: ["../escape", "C:\\native"] },
+  });
+  assert.equal(invalid.ok, false);
+  if (invalid.ok) return;
+  const report = invalid.issues.join("\n");
+  for (const field of [
+    "packet.unexpected",
+    "packet.submission.completionClaim",
+    "packet.submission.deliverables",
+    "packet.submission.outputs[0]",
+    "packet.submission.verificationNotes[0]",
+    "packet.submission.knownGaps",
+    "packet.submission.commitSha",
+    "packet.review.verdict",
+    "packet.review.reason",
+    "packet.review.evidenceChecked",
+    "packet.consent.approved",
+    "packet.completion.ci",
+    "packet.completion.codeDocPaths[0]",
+    "packet.completion.codeDocPaths[1]",
+  ])
+    assert.equal(report.includes(field), true, report);
+  assert.equal(invalid.issues.length, 14, report);
+});

--- a/packages/kernel/test/contracts/task-closeout-packet.test.ts
+++ b/packages/kernel/test/contracts/task-closeout-packet.test.ts
@@ -1,27 +1,15 @@
 // harness-test-tier: fast
 import assert from "node:assert/strict";
 import test from "node:test";
-import {
-  createTaskCloseoutPacketTemplate,
-  taskCloseoutPacketHelp,
-  taskCloseoutPacketSchema,
-  validateTaskCloseoutPacket,
-} from "../../src/index.ts";
+import { createTaskCloseoutPacketTemplate, validateTaskCloseoutPacket } from "../../src/index.ts";
 
-test("closeout packet templates and help are derived from the authoritative schema", () => {
+test("closeout packet templates are derived from the authoritative schema", () => {
   const initial = createTaskCloseoutPacketTemplate({ includeSubmission: true, ci: "passed" }),
-    resumed = createTaskCloseoutPacketTemplate({ includeSubmission: false, ci: "not_applicable" }),
-    help = taskCloseoutPacketHelp();
+    resumed = createTaskCloseoutPacketTemplate({ includeSubmission: false, ci: "not_applicable" });
   assert.equal(validateTaskCloseoutPacket(initial).ok, true);
   assert.equal(validateTaskCloseoutPacket(resumed).ok, true);
   assert.equal(Object.hasOwn(resumed, "submission"), false);
   assert.equal(resumed.completion.ci, "not_applicable");
-  assert.match(help, new RegExp(taskCloseoutPacketSchema.$id, "u"));
-  assert.match(help, /submission\?: object/u);
-  assert.match(help, /submission\.deliverables: string\[\]/u);
-  assert.match(help, /review\.verdict: approved\|changes_requested\|dismissed/u);
-  assert.match(help, /consent\.approved: true/u);
-  assert.match(help, /completion\.ci: passed\|not_applicable/u);
 });
 
 test("closeout packet validation reports every independent field error at once", () => {


### PR DESCRIPTION
# English

## Summary

`ha task closeout --from-file` is now driven by one authoritative JSON Schema (`harness://schema/task-closeout-packet/v1`): the runtime validator, `--print-schema`, a state-aware `--print-template`, and the `--help` field descriptions all derive from it, and every packet error is reported in a single aggregated pass instead of one field at a time. A packet may omit `submission` once the Execution is already submitted, so the chain resumes from review without re-typing locked bytes; `submission_mismatch` now prints the canonical locked submission. `ha task declare-executor` gains `--agent`; a bare human principal can bind the agent executor derived from the task's real dispatch record, so worker-executed tasks can finish review → complete. The `HARNESS_ACTOR=agent:<id>` impersonation hint and the per-field fail-fast validator are deleted.

## Architectural Justification

- The closeout packet had two competing definitions — an ad-hoc `Judgment` type plus a hand-written fail-fast `validateJudgment` in `packages/application` — while the CLI help and daemon command surface described the fields a third time. A single schema in `packages/kernel/src/schemas/` is the only place that can serve validator, template, and help simultaneously; the application module cannot carry it without kernel types leaking outward.
- Removed: `validateJudgment`, `exact`, `stringList`, `ciJudgmentToken`, `sameFields`, the `submissionFields`/`reviewFields` lists and the mismatch response that sent operators to `task show` to guess locked bytes.
- Scope cannot be narrowed: the executor-recovery fix (fact F-255A632B) needs the event contract (`task-lifecycle-event.ts` / `task-lifecycle-replay.ts`) to separate the event actor axis from the Execution executor axis; without that, a human principal can never legally declare an agent executor and worker-executed tasks stay stuck at `in_review`.

## What Changed

- `packages/kernel/src/schemas/task-closeout-packet.ts` (new): schema, aggregated validator, template and help derivation; exported from `packages/kernel/src/index.ts`.
- `packages/application/src/task-closeout-action.ts`: `--print-schema` / `--print-template` discovery modes; optional `submission` on resume; mismatch response carries the canonical submission; aggregated validation.
- `packages/cli/src/cli/thin-command-task.ts`: closeout modes are mutually exclusive (`--from-file` | `--print-template` | `--print-schema`); `declare-executor --agent`.
- `packages/daemon/src/repo-cell-action-dispatch.ts`: resolve the unique dispatched runtime executor for the execution (`readTaskDispatches`) and verify proof; ambiguous/none/mismatch → `invalid_proof` / `invalid_command` with the exact commands to run.
- `packages/daemon/src/protocol/daemon-protocol-commands-task.ts` / `-task-surface.ts`: closeout help derived from the schema; optional `--agent` selector.
- `packages/daemon/src/repo-cell-packets.ts`: drop the `HARNESS_ACTOR=agent:<id>` impersonation hint.
- `packages/kernel/src/domain/task-lifecycle-contract-support.ts` / `task-lifecycle-event.ts` / `task-lifecycle-replay.ts`: executor declaration binds a dispatched agent on the same principal; event actor and Execution executor are separate axes; agent transport can only bind itself.
- Tests: new `packages/kernel/test/contracts/task-closeout-packet.test.ts`; updated closeout, review-independence, rejection-next-actions, progress, and CLI integration tests (free-text executor success paths replaced by real-dispatch positive and no-dispatch / wrong-principal / agent-impersonation negative cases).

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: use the single CI-backed `Production-Delta` declaration below; do not enter a second metric.

## Machine-Readable Declarations

Production-Delta: +526/-131

## Task And Scope

- Harness task: task_781ec2d54e6a5f5b6036af0d9e
- Branch: codex/closeout-chain-iter2
- Public scope: packages/kernel, packages/application, packages/daemon, packages/cli + their tests
- Private planning/evidence updated: yes (task package plan, implementation report, fact F-C274318D)
- Out of scope: GUI closeout surface; completing task_36ed7ea4 / task_d2d1b298 (CEO first-use acceptance after merge)

## Version Impact

- Version: no version change because the milestone is not closed and no release is planned
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: task_781ec2d54e6a5f5b6036af0d9e
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no

## Verification

- Base `origin/main` SHA: ea1046f946454a87e39f0baf40b6029b250e0b72
- Branch merge-base with `origin/main`: ea1046f946454a87e39f0baf40b6029b250e0b72
- Last `git fetch origin` time: 2026-08-30 (before dispatch)
- Sync method: none needed
- Public diff command: `git diff origin/main..codex/closeout-chain-iter2`
- Private evidence commit/path: harness task package `artifacts/implementation-report.md`, fact F-C274318D
- Reviewer evidence path: this PR body + task package `artifacts/pr-body.md`
- GitHub Actions `rewrite-ci` run URL: pending
- [x] `git diff --check` (exit 0)
- [x] targeted fast tests — `node tools/run-node-tests.mjs --file packages/kernel/test/contracts/task-closeout-packet.test.ts --file packages/daemon/test/task-closeout-action.test.ts --file packages/cli/test/task-closeout.test.ts --file packages/cli/test/thin-command-closeout-progress.test.ts --file packages/kernel/test/contracts/task-lifecycle-replay.test.ts --concurrency 1` → `pass 25 / fail 0` (reviewer re-run); worker run incl. entity-action-execution: `pass 27 / fail 0`
- [x] `tsc -b packages/kernel packages/application packages/daemon packages/cli` → exit 0 (worker)
- [x] docker-isolated integration (worker): `review-independence-diagnostics` 4/4, `rejection-next-actions` 3/3, `task-closeout.integration` 2/2
- [x] `node tools/gates/production-delta.mjs --base origin/main` → `production +556/-127`, pass
- [ ] `npm ci` / `npm run check` / `npm test` / harness:* checks / `smoke-cli-package` — not run locally by policy (full gate matrix is GitHub CI's job; workers never run `check:local`)
- Not run: `node tools/gates/line-density.mjs --base origin/main` currently **FAILS** (see Residual Risk) — must be fixed before push.

## Review Evidence

- Self-review: worker report with positive/negative evidence for schema, resume, executor recovery.
- Reviewer subagent: Opus fork read the full production diff against plan Goals 1–4 and F-255A632B; re-ran fast tests; ran production-delta and line-density gates.
- Human review: CEO semantic acceptance pending.
- Blocking findings: G36 line-density (8 added lines > 120 chars in 5 budgeted files) — must be wrapped.

## Residual Risk

- G36 line-density fails on this commit: `task-closeout-action.ts` (3 lines), `repo-cell-action-dispatch.ts` (2), `daemon-protocol-commands-task-surface.ts` (1), `task-lifecycle-event.ts` (1), `task-closeout-packet.ts` (1). Pure formatting fix; no semantic change.
- `--print-template`/`--print-schema` return a synthetic `applied` receipt (`opId: read:<opId>`) through the write action path rather than a read projection; acceptable for a discovery command but it is a read masquerading as a write receipt.
- `completion.ci` legal value is still decided by the task contract at runtime; the schema shows both tokens.

## References

- Task: task_781ec2d54e6a5f5b6036af0d9e
- Evidence: fact F-255A632B (defects), fact F-C274318D (dogfood packet)
- Review: task package `artifacts/pr-body.md`

---

# 中文

## 概要

`ha task closeout --from-file` 现在由一份权威 JSON Schema(`harness://schema/task-closeout-packet/v1`)驱动:运行时校验器、`--print-schema`、按状态生成的 `--print-template` 和 `--help` 字段说明全部从它派生,packet 的所有字段错误一次聚合报出,不再修一个报一个。Execution 已 submit 后 packet 可省略 `submission`,链从 review 续跑,不用去事件流抄字节;`submission_mismatch` 直接打印已锁定的 canonical submission。`ha task declare-executor` 新增 `--agent`,人 principal 可以绑定从该任务真实 dispatch 记录派生出的 agent executor,worker 执行的任务得以走完 review → complete。删除了 `HARNESS_ACTOR=agent:<id>` 冒充提示和逐字段 fail-fast 校验器。

## 架构辩护

- closeout packet 此前有两套定义——application 里的临时 `Judgment` 类型加手写 fail-fast `validateJudgment`——CLI help 与 daemon 命令面又第三次描述这些字段。只有放在 `packages/kernel/src/schemas/` 的单一 schema 才能同时供给校验器、模板与 help;留在 application 会让 kernel 类型外泄。
- 删除:`validateJudgment`、`exact`、`stringList`、`ciJudgmentToken`、`sameFields`、`submissionFields`/`reviewFields` 清单,以及让操作者去 `task show` 猜 locked bytes 的 mismatch 响应。
- 范围不能再收窄:executor 恢复(fact F-255A632B)必须让事件契约(`task-lifecycle-event.ts` / `task-lifecycle-replay.ts`)把事件 actor 轴与 Execution executor 轴分开;否则人 principal 永远不能合法点名 agent executor,worker 执行的任务永远卡在 `in_review`。

## 改动内容

- `packages/kernel/src/schemas/task-closeout-packet.ts`(新):schema、聚合校验、模板与 help 派生;经 `packages/kernel/src/index.ts` 导出。
- `packages/application/src/task-closeout-action.ts`:`--print-schema` / `--print-template` 发现模式;续跑时 `submission` 可省略;mismatch 响应携带 canonical submission;聚合校验。
- `packages/cli/src/cli/thin-command-task.ts`:closeout 三种模式互斥;`declare-executor --agent`。
- `packages/daemon/src/repo-cell-action-dispatch.ts`:从 `readTaskDispatches` 解析该 execution 唯一的 runtime executor 并校验证明;无 dispatch / 多个 / 不匹配分别给 `invalid_proof` / `invalid_command` 与可直接执行的命令。
- `packages/daemon/src/protocol/daemon-protocol-commands-task.ts` / `-task-surface.ts`:closeout help 从 schema 派生;可选 `--agent`。
- `packages/daemon/src/repo-cell-packets.ts`:删 `HARNESS_ACTOR=agent:<id>` 冒充提示。
- `packages/kernel/src/domain/task-lifecycle-contract-support.ts` / `task-lifecycle-event.ts` / `task-lifecycle-replay.ts`:executor 声明绑定同 principal 下的 dispatched agent;事件 actor 与 Execution executor 分轴;agent transport 只能绑定自己。
- 测试:新增 `packages/kernel/test/contracts/task-closeout-packet.test.ts`;更新 closeout、review-independence、rejection-next-actions、progress 与 CLI integration 测试(自由文本 executor 的成功路径替换为真实 dispatch 阳性 + 无 dispatch / 错 principal / agent 冒充阴性)。

## 门收割 / Gate Harvest

- 删除的生产路径:none(删除的是函数与提示文本,没有整条生产路径被移除)
- 同 commit 删除的门 / fixture:none
- 生产净行数:引用英文块中的 `Production-Delta`。

## 机读声明说明

- 见英文块 `Production-Delta: +556/-127`(由 `tools/gates/production-delta.mjs --base origin/main` 实测,pass)。
- 无 package.json / lock 变化;无保留旧路径;无 evidence claim。

## 任务与范围

- Harness 任务:task_781ec2d54e6a5f5b6036af0d9e
- 分支:codex/closeout-chain-iter2
- 公开范围:packages/kernel、packages/application、packages/daemon、packages/cli 及测试
- 私有计划 / 证据是否已更新:yes(任务包 plan、实现报告、fact F-C274318D)
- 范围外:GUI closeout 面;task_36ed7ea4 / task_d2d1b298 的收口(合并后 CEO 首次使用即验收)

## 版本影响

- 版本:不改版本,原因是里程碑未闭环、不发版
- 发布影响:不发布

## 治理声明

- 是否触碰 protected surface:no
- protected surface 范围:不适用
- 依据:task_781ec2d54e6a5f5b6036af0d9e
- 机器检查边界:本 PR 只声明该段存在;声明是否真实、充分,由 reviewer 判断。
- Break-glass:no

## 验证

- `origin/main` 基准 SHA:ea1046f946454a87e39f0baf40b6029b250e0b72
- 当前分支与 `origin/main` 的 merge-base:ea1046f946454a87e39f0baf40b6029b250e0b72
- 最近一次 `git fetch origin` 时间:2026-08-30(派工前)
- 同步方式:不需要
- 公开 diff 命令:`git diff origin/main..codex/closeout-chain-iter2`
- 私有证据 commit/path:任务包 `artifacts/implementation-report.md`、fact F-C274318D
- Reviewer 证据路径:本 PR 正文 + 任务包 `artifacts/pr-body.md`
- GitHub Actions `rewrite-ci` run URL:待 push 后补
- [x] `git diff --check` exit 0
- [x] 定向 fast 测试(reviewer 复跑):`pass 25 / fail 0`;worker 含 entity-action-execution:`pass 27 / fail 0`
- [x] `tsc -b`(worker)exit 0
- [x] docker 隔离 integration(worker):review-independence 4/4、rejection-next-actions 3/3、task-closeout.integration 2/2
- [x] `production-delta` gate:+556/-127 pass
- [ ] `npm ci` / `npm run check` / `npm test` / harness:* / smoke-cli-package:按纪律不在本机跑全量,交 GitHub CI
- 未运行:`line-density` gate 当前 **失败**(见残余风险),push 前必须修。

## 审查证据

- 自查:worker 报告含 schema / 续跑 / executor 恢复的阳性与阴性证据。
- Reviewer subagent:Opus fork 对照 plan Goal 1–4 与 F-255A632B 通读全部生产 diff,复跑 fast 测试,跑 production-delta 与 line-density 门。
- 人工审查:CEO 语义验收待做。
- 阻塞发现:G36 line-density(5 个 budgeted 文件共 8 行新增超 120 字符)必须换行。

## 残余风险

- 本 commit 过不了 G36:`task-closeout-action.ts`(3 行)、`repo-cell-action-dispatch.ts`(2)、`daemon-protocol-commands-task-surface.ts`(1)、`task-lifecycle-event.ts`(1)、`task-closeout-packet.ts`(1)。纯格式修复,无语义变化。
- `--print-template` / `--print-schema` 通过写动作路径返回合成的 `applied` 回执(`opId: read:<opId>`),而非读投影;作为发现命令可接受,但本质是读伪装成写回执。
- `completion.ci` 的合法取值仍由任务契约在运行时裁定;schema 同时展示两个 token。

## 关联材料

- 任务:task_781ec2d54e6a5f5b6036af0d9e
- 证据:fact F-255A632B(缺陷)、fact F-C274318D(真实 packet dogfood)
- 审查:任务包 `artifacts/pr-body.md`

---

## PR Gate Checklist / PR 门禁清单

- [x] Branch is based on latest `origin/main`. / 分支基于最新 `origin/main`。
- [x] PR body uses this full template structure. / PR 描述使用本模板完整结构。
- [x] PR body uses two complete language blocks: `# English` first, then `# 中文`. / PR 正文使用两块完整正文。
- [ ] PR body passes `tools/check-pr-body-bilingual.mjs`. / PR 正文通过 `tools/check-pr-body-bilingual.mjs`。
- [x] If the PR touches a manifest-derived protected surface, Governance Declaration is filled. / 治理声明已填。
- [x] No private harness files are included. / 不包含私有 harness 文件。
- [x] No ignored local agent entry files are included. / 不包含被忽略的本地 agent 入口文件。
- [x] No absolute local filesystem paths are included in this public PR body. / 不包含本机绝对路径。
- [x] Public diff is limited to the stated task scope. / 公开 diff 限于声明的任务范围。
- [x] Private planning/evidence updates are recorded when applicable. / 已记录私有计划 / 证据更新。
- [x] Version and publish impact are stated. / 已说明版本与发布影响。
- [x] Local verification commands are recorded honestly. / 已如实记录本地验证命令。
- [ ] CI results are linked or explained. / CI 结果已链接或说明。
- [x] Review evidence is recorded. / 已记录审查证据。
- [ ] Open P0/P1/P2 findings are closed, deferred with owner, or explicitly blocked. / G36 line-density 阻塞中。
- [x] Merge method and post-merge branch cleanup plan are clear (normal merge via `node tools/pr-merge.mjs`). / 合并方式清楚。
- [x] No admin bypass is planned unless explicitly approved and recorded. / 不计划 admin bypass。

