### PR TITLE
perf(gui): real-ledger read baseline with shrink-only ratchet; drop duplicate cold-view reads

### DIFF
--- a/packages/gui/src/renderer/App.tsx
+++ b/packages/gui/src/renderer/App.tsx
@@ -171,6 +171,12 @@ function AppShell() {
   useEffect(() => {
     if (!activeRepoId || !tasksQuery.data) return;
     const cut = `${activeRepoId}:${tasksQuery.data.watermark}:${tasksQuery.data.sourceRevision}`;
+    // 首次水合只是建立比较基准,不是「台账变化」。把它当变化会让刚完成的
+    // workspace summary / 三元切面立刻再读一遍;后续 cut 才失效挂载中的读面。
+    if (lastLedgerCut.current === null) {
+      lastLedgerCut.current = cut;
+      return;
+    }
     if (lastLedgerCut.current === cut) return;
     lastLedgerCut.current = cut;
     void invalidateLedgerDependents(queryClient, activeRepoId);

--- a/packages/gui/test/triadic-read-scoping.vitest.ts
+++ b/packages/gui/test/triadic-read-scoping.vitest.ts
@@ -291,10 +291,9 @@ const decisionCalls = (calls: readonly RecordedCall[]) => calls.filter(({ method
 describe("三元读取按挂载域分层", () => {
   it("任务看板会话只读 derives 边切面与决策摘要,没有完整投影", async () => {
     const { calls } = await mountApp({ view: "board" });
-    // 挂载水合时首批 tasks 数据到达会触发一次初始 cut 失效,常驻窄面因此各被读两遍
-    // (读形不变,这是与 main 相同的既有行为);断言的是读面集合,不是次数。
-    expect([...new Set(relationGraphCalls(calls()).map(({ payload }) => payload?.facet))]).toEqual(["edges"]);
-    expect([...new Set(decisionCalls(calls()).map(({ payload }) => payload?.projection))]).toEqual(["summary"]);
+    // 首批 tasks 水合只建立 cut 基准,不能把刚完成的常驻读面再次失效。
+    expect(relationGraphCalls(calls()).map(({ payload }) => payload?.facet)).toEqual(["edges"]);
+    expect(decisionCalls(calls()).map(({ payload }) => payload?.projection)).toEqual(["summary"]);
   });
 
   it("台账 cut 前进时,看板上只重取挂载中的窄面,完整投影不被重取", async () => {

--- a/tools/gate-manifest.json
+++ b/tools/gate-manifest.json
@@ -4649,6 +4649,55 @@
       }
     },
     {
+      "id": "gui-read-baseline",
+      "command": "node tools/gates/gui-read-baseline.mjs --base origin/main --mode ratchet",
+      "category": "local-consistency",
+      "tier": "pr-advisory",
+      "tierReason": "Real-ledger GUI latency is host-sensitive, so the PR job enforces only the committed shrink-only request/payload/latency ratchet; G-slice reports supply fresh measurements.",
+      "authoritySource": [
+        "task_c03713017573032b7b7149b9b5",
+        "tools/measure-gui-read-baseline.mjs"
+      ],
+      "consumerScope": [
+        "cold-load daemon reads for overview, board, graph, sessions, schedules, Agent/Squad, and Artifacts views",
+        "per-view request count, response payload, IPC elapsed time, and daemon handler elapsed time"
+      ],
+      "githubContext": {
+        "requiredContexts": [],
+        "workflowJobs": ["ontology-advisory"],
+        "nodeVersions": [24]
+      },
+      "allowlistPolicy": {
+        "allowed": false,
+        "location": null,
+        "adrOrDecisionRequired": false,
+        "notes": "There is no upward-budget receipt or exception path; a new real-ledger measurement may only lower committed limits."
+      },
+      "changeControl": {
+        "ordinaryImplementationMayModify": false,
+        "requiresGovernanceEvidence": true,
+        "protectedSurfaces": [
+          "tools/gates/gui-read-baseline.mjs",
+          "tools/gates/gui-read-baseline.json",
+          "tools/gates/test/gui-read-baseline.test.mjs",
+          "tools/measure-gui-read-baseline.mjs",
+          "tools/gate-manifest.json"
+        ]
+      },
+      "bypassFixtureRequired": false,
+      "executionSurfaces": {
+        "packageJson": { "check": false, "checkPr": false, "script": null },
+        "rewriteCi": { "pullRequestJobs": ["ontology-advisory"], "nonPullRequestJobs": [] },
+        "branchProtection": { "required": false, "contexts": [] },
+        "classes": ["pr"]
+      },
+      "deterministic": true,
+      "positiveControl": {
+        "status": "covered",
+        "evidence": ["tools/gates/test/gui-read-baseline.test.mjs"]
+      }
+    },
+    {
       "id": "ontology-kind-authority",
       "command": "node tools/gates/ontology-kind-authority.mjs",
       "category": "boundary",

--- a/tools/gates/gui-read-baseline.json
+++ b/tools/gates/gui-read-baseline.json
@@ -1,0 +1,49 @@
+{
+  "schema": "gui-read-ratchet/v1",
+  "basisRevision": "7dacdf10737fd9408f65b932de606f06ddee5cd3",
+  "measuredAt": "2026-08-30T09:48:59.194Z",
+  "views": {
+    "overview": {
+      "requestCount": 7,
+      "payloadBytes": 13034611,
+      "maxE2eDurationMs": 3219.973,
+      "maxHandlerDurationMs": 1307
+    },
+    "board": {
+      "requestCount": 5,
+      "payloadBytes": 2656879,
+      "maxE2eDurationMs": 880.904,
+      "maxHandlerDurationMs": 673
+    },
+    "graph": {
+      "requestCount": 10,
+      "payloadBytes": 13066918,
+      "maxE2eDurationMs": 3215.647,
+      "maxHandlerDurationMs": 1260
+    },
+    "sessions": {
+      "requestCount": 10,
+      "payloadBytes": 5833831,
+      "maxE2eDurationMs": 1154.308,
+      "maxHandlerDurationMs": 662
+    },
+    "schedules": {
+      "requestCount": 6,
+      "payloadBytes": 2679143,
+      "maxE2eDurationMs": 901.726,
+      "maxHandlerDurationMs": 673
+    },
+    "agentSquad": {
+      "requestCount": 10,
+      "payloadBytes": 3845816,
+      "maxE2eDurationMs": 1275.082,
+      "maxHandlerDurationMs": 729
+    },
+    "artifacts": {
+      "requestCount": 6,
+      "payloadBytes": 2683679,
+      "maxE2eDurationMs": 1078.688,
+      "maxHandlerDurationMs": 699
+    }
+  }
+}

--- a/tools/gates/gui-read-baseline.mjs
+++ b/tools/gates/gui-read-baseline.mjs
@@ -1,0 +1,120 @@
+#!/usr/bin/env node
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { git, pathExistsAt } from "./git.mjs";
+import { exitCodeFor, parseCommonArgs } from "./ontology-gate-lib.mjs";
+
+const baselineFile = "tools/gates/gui-read-baseline.json";
+const viewIds = Object.freeze(["overview", "board", "graph", "sessions", "schedules", "agentSquad", "artifacts"]);
+const metricNames = Object.freeze(["requestCount", "payloadBytes", "maxE2eDurationMs", "maxHandlerDurationMs"]);
+
+export function parseGuiReadBaseline(body, source = baselineFile) {
+  let parsed;
+  try {
+    parsed = JSON.parse(body);
+  } catch (error) {
+    throw new Error(`${source} is not valid JSON: ${error.message}`);
+  }
+  if (parsed?.schema !== "gui-read-ratchet/v1" || typeof parsed.basisRevision !== "string" || !plain(parsed.views))
+    throw new Error(`${source} must use gui-read-ratchet/v1 with basisRevision and views`);
+  const views = normalizeViews(parsed.views, source);
+  return { basisRevision: parsed.basisRevision, measuredAt: parsed.measuredAt ?? null, views };
+}
+
+export function parseGuiReadMeasurement(body, source = "measurement") {
+  let parsed;
+  try {
+    parsed = JSON.parse(body);
+  } catch (error) {
+    throw new Error(`${source} is not valid JSON: ${error.message}`);
+  }
+  if (parsed?.schema !== "gui-read-baseline/v1" || !plain(parsed.views))
+    throw new Error(`${source} must use gui-read-baseline/v1 with views`);
+  return normalizeViews(parsed.views, source);
+}
+
+export function evaluateGuiReadBaseline({ rootDir, base = null, measurementPath = null }) {
+  const absoluteBaseline = path.join(rootDir, baselineFile);
+  const current = parseGuiReadBaseline(readFileSync(absoluteBaseline, "utf8"), baselineFile);
+  const historical =
+    base && pathExistsAt(rootDir, base, baselineFile)
+      ? parseGuiReadBaseline(git(rootDir, ["show", `${base}:${baselineFile}`]), `${base}:${baselineFile}`)
+      : null;
+  const findings = [];
+  if (historical) compareLimits(current.views, historical.views, "shrink-only baseline", findings);
+  if (measurementPath) {
+    const observed = parseGuiReadMeasurement(readFileSync(measurementPath, "utf8"), measurementPath);
+    compareLimits(observed, current.views, "measurement", findings);
+  }
+  return { current, historical, findings };
+}
+
+function compareLimits(actual, limits, label, findings) {
+  for (const viewId of viewIds) {
+    for (const metric of metricNames) {
+      if (actual[viewId][metric] > limits[viewId][metric])
+        findings.push(`${viewId}.${metric}: ${label} rose from ${limits[viewId][metric]} to ${actual[viewId][metric]}`);
+    }
+  }
+}
+
+function normalizeViews(value, source) {
+  const keys = Object.keys(value).sort();
+  const expected = [...viewIds].sort();
+  if (JSON.stringify(keys) !== JSON.stringify(expected))
+    throw new Error(`${source} views must be exactly ${viewIds.join(", ")}`);
+  return Object.fromEntries(
+    viewIds.map((viewId) => {
+      const row = value[viewId];
+      if (!plain(row)) throw new Error(`${source} ${viewId} must be an object`);
+      for (const metric of metricNames) {
+        const number = row[metric];
+        if (!Number.isFinite(number) || number < 0 || (metric === "requestCount" && !Number.isInteger(number)))
+          throw new Error(`${source} ${viewId}.${metric} must be a non-negative number`);
+      }
+      return [viewId, Object.fromEntries(metricNames.map((metric) => [metric, row[metric]]))];
+    }),
+  );
+}
+
+function plain(value) {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function parseArgs(argv) {
+  const common = [];
+  let measurementPath = null;
+  for (let index = 0; index < argv.length; index += 1) {
+    if (argv[index] === "--measurement") {
+      measurementPath = argv[index + 1];
+      if (!measurementPath) throw new Error("--measurement requires a path");
+      index += 1;
+    } else common.push(argv[index]);
+  }
+  return { ...parseCommonArgs(common, { allowBase: true }), measurementPath };
+}
+
+export function main(argv = process.argv.slice(2)) {
+  try {
+    const { rootDir, base, mode, measurementPath } = parseArgs(argv);
+    const result = evaluateGuiReadBaseline({
+      rootDir,
+      base,
+      measurementPath: measurementPath ? path.resolve(rootDir, measurementPath) : null,
+    });
+    console.log(`GUI read baseline ratchet: ${mode}`);
+    for (const [viewId, row] of Object.entries(result.current.views))
+      console.log(
+        `${viewId}: requests=${row.requestCount} payload=${row.payloadBytes}B ` +
+          `e2e<=${row.maxE2eDurationMs}ms handler<=${row.maxHandlerDurationMs}ms`,
+      );
+    for (const finding of result.findings) console.error(`- ${finding}`);
+    return exitCodeFor(mode, result.findings.length);
+  } catch (error) {
+    console.error(`GUI read baseline ratchet: ${error instanceof Error ? error.message : String(error)}`);
+    return 1;
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href) process.exitCode = main();

--- a/tools/gates/test/gui-read-baseline.test.mjs
+++ b/tools/gates/test/gui-read-baseline.test.mjs
@@ -1,0 +1,54 @@
+// harness-test-tier: fast
+import assert from "node:assert/strict";
+import path from "node:path";
+import test from "node:test";
+import { evaluateGuiReadBaseline, main } from "../gui-read-baseline.mjs";
+import { captureGate, makeRepo, writeRepoFile } from "./helpers.mjs";
+
+const repoRoot = path.resolve(import.meta.dirname, "../../..");
+const baselinePath = "tools/gates/gui-read-baseline.json";
+const ids = ["overview", "board", "graph", "sessions", "schedules", "agentSquad", "artifacts"];
+
+function baseline(value) {
+  return `${JSON.stringify({
+    schema: "gui-read-ratchet/v1",
+    basisRevision: "a".repeat(40),
+    views: Object.fromEntries(
+      ids.map((id) => [
+        id,
+        { requestCount: value, payloadBytes: value, maxE2eDurationMs: value, maxHandlerDurationMs: value },
+      ]),
+    ),
+  })}\n`;
+}
+
+function measurement(value) {
+  return `${JSON.stringify({
+    schema: "gui-read-baseline/v1",
+    views: Object.fromEntries(
+      ids.map((id) => [
+        id,
+        { requestCount: value, payloadBytes: value, maxE2eDurationMs: value, maxHandlerDurationMs: value },
+      ]),
+    ),
+  })}\n`;
+}
+
+test("GUI read gate rejects an upward ratchet and an observation over baseline", () => {
+  assert.equal(captureGate(() => main(["--root", repoRoot, "--base", "origin/main", "--mode", "ratchet"])).code, 0);
+  const { rootDir, base } = makeRepo({ [baselinePath]: baseline(5) });
+
+  writeRepoFile(rootDir, baselinePath, baseline(6));
+  const raised = evaluateGuiReadBaseline({ rootDir, base });
+  assert.match(raised.findings.join("\n"), /overview\.requestCount: shrink-only baseline rose from 5 to 6/u);
+
+  writeRepoFile(rootDir, baselinePath, baseline(5));
+  const measurementPath = path.join(rootDir, "measurement.json");
+  writeRepoFile(rootDir, "measurement.json", measurement(7));
+  const observed = evaluateGuiReadBaseline({ rootDir, base, measurementPath });
+  assert.match(observed.findings.join("\n"), /overview\.payloadBytes: measurement rose from 5 to 7/u);
+  const positive = captureGate(() =>
+    main(["--root", rootDir, "--base", base, "--measurement", measurementPath, "--mode", "ratchet"]),
+  );
+  assert.equal(positive.code, 1);
+});

--- a/tools/measure-gui-read-baseline.mjs
+++ b/tools/measure-gui-read-baseline.mjs
@@ -1,0 +1,587 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+import { mkdir, readFile, readdir, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import process from "node:process";
+
+const BRIDGE_READ_METHODS = Object.freeze({
+  getSystemStatus: "daemon.gui.system.read",
+  getTasks: "repo.tasks.list",
+  getWorkspaceSummary: "repo.workspace.summary.read",
+  getAgenda: "repo.agenda.read",
+  getRelationGraph: "repo.triadic.relationGraph",
+  getDecisions: "repo.decisions.list",
+  getTaskDocument: "repo.tasks.document.read",
+  getTaskDocuments: "repo.tasks.documents.list",
+  getAgentRuntimeOverview: "repo.agentRuntime.overview",
+  getAgentRuntimeSessionGroups: "repo.agentRuntime.sessionGroups",
+  getAgentRuntimeSession: "repo.agentRuntime.sessions.read",
+  getAgentRuntimeEvents: "repo.agentRuntime.events.read",
+  getTaskDispatches: "repo.task.dispatches",
+  listAgents: "repo.agent.entities.list",
+  showAgent: "repo.agent.entity.read",
+  listAgentSkills: "repo.agent.skills.list",
+  listSquads: "repo.squad.entities.list",
+  showSquad: "repo.squad.entity.read",
+  listSquadRuns: "repo.squad.runs.list",
+  readSquadRun: "repo.squad.run.read",
+  listSchedules: "repo.schedules.list",
+  listArtifacts: "repo.artifacts.list",
+});
+
+const VIEWS = Object.freeze([
+  { id: "overview", label: "总览" },
+  { id: "board", label: "看板" },
+  { id: "graph", label: "关系图" },
+  { id: "sessions", label: "会话" },
+  { id: "schedules", label: "定时计划" },
+  { id: "agentSquad", label: "Agent · 含 Squad" },
+  { id: "artifacts", label: "产物" },
+]);
+
+class InspectorClient {
+  constructor(socket) {
+    this.socket = socket;
+    this.nextId = 1;
+    this.pending = new Map();
+    socket.onmessage = (event) => {
+      const message = JSON.parse(String(event.data));
+      if (!message.id) return;
+      const pending = this.pending.get(message.id);
+      if (!pending) return;
+      this.pending.delete(message.id);
+      if (message.error) pending.reject(new Error(message.error.message));
+      else pending.resolve(message.result);
+    };
+  }
+
+  static async connect(url) {
+    const socket = new globalThis.WebSocket(url);
+    await new Promise((resolve, reject) => {
+      socket.onopen = resolve;
+      socket.onerror = reject;
+    });
+    return new InspectorClient(socket);
+  }
+
+  request(method, params = {}) {
+    const id = this.nextId++;
+    return new Promise((resolve, reject) => {
+      this.pending.set(id, { resolve, reject });
+      this.socket.send(JSON.stringify({ id, method, params }));
+    });
+  }
+
+  close() {
+    this.socket.close();
+  }
+}
+
+const options = parseArgs(process.argv.slice(2));
+const sourceRoot = path.resolve(options.sourceRoot ?? path.resolve(import.meta.dirname, ".."));
+const ledgerRoot = path.resolve(options.ledgerRoot ?? process.env.HARNESS_CANONICAL_ROOT ?? sourceRoot);
+const userRoot = path.resolve(
+  options.userRoot ?? process.env.HARNESS_DAEMON_USER_ROOT ?? path.join(os.homedir(), ".harness"),
+);
+const outputPath = path.resolve(
+  options.output ?? path.join(sourceRoot, "tmp", `gui-read-baseline-${new Date().toISOString().slice(0, 10)}.json`),
+);
+
+const processes = processSnapshot();
+const daemon = findDaemon(processes, userRoot);
+const gui = findGui(processes, sourceRoot);
+const basisRevision = git(sourceRoot, ["rev-parse", "HEAD"]).trim();
+const sourceStatus = git(sourceRoot, ["status", "--short"]).split("\n").filter(Boolean);
+const projection = projectionStatus(path.join(ledgerRoot, ".harness", "cache", "task.sqlite"));
+if (!projection.ready) throw new Error(`projection is not ready: ${JSON.stringify(projection)}`);
+
+const inspector = await openElectronInspector(gui.pid);
+let probeInstalled = false;
+try {
+  await focusGui(inspector.client);
+  await installProbe(inspector.client);
+  probeInstalled = true;
+  await selectRepository(inspector.client);
+  await waitForQuiet(inspector.client, 800, 120_000);
+
+  const runs = [];
+  for (const view of VIEWS) {
+    await selectView(inspector.client, view.label);
+    await waitForQuiet(inspector.client, 800, 120_000);
+    await resetProbe(inspector.client);
+    const startedAtMs = Date.now();
+    await reloadRenderer(inspector.client);
+    await waitForView(inspector.client, view.label, 120_000);
+    await waitForQuiet(inspector.client, 800, 120_000);
+    const endedAtMs = Date.now();
+    const records = await readProbe(inspector.client);
+    const wrongRepo = records.find((record) => record.payload?.repoId && record.payload.repoId !== "canonical");
+    if (wrongRepo) throw new Error(`view ${view.id} read unexpected repository ${wrongRepo.payload.repoId}`);
+    runs.push({ view, startedAtMs, endedAtMs, records });
+    process.stdout.write(`[measure] ${view.id} requests=${records.length} elapsedMs=${endedAtMs - startedAtMs}\n`);
+  }
+
+  await sleep(1_000);
+  const start = Math.min(...runs.map((run) => run.startedAtMs));
+  const end = Math.max(...runs.map((run) => run.endedAtMs));
+  const daemonRequests = await readDaemonRequests(userRoot, daemon.pid, start, end);
+  const views = Object.fromEntries(
+    runs.map((run) => {
+      const requests = pairDaemonRequests(run.records, daemonRequests);
+      return [run.view.id, summarizeView(run, requests)];
+    }),
+  );
+  const baseline = {
+    schema: "gui-read-baseline/v1",
+    measuredAt: new Date().toISOString(),
+    basisRevision,
+    sourceState: { dirty: sourceStatus.length > 0, status: sourceStatus },
+    repository: { id: "canonical", ledgerRoot, sourceRoot },
+    daemon: { pid: daemon.pid, elapsed: daemon.elapsed },
+    projection,
+    measurement: {
+      shape:
+        "cold renderer reload with canonical ordered first and the target view persisted; includes common chrome reads",
+      payloadBytes: "Buffer.byteLength(JSON.stringify(bridgeResult))",
+      e2eDurationMs: "Electron IPC handler elapsed time",
+      handlerDurationMs: "paired daemon-default connection-log request durationMs",
+      viewOrder: VIEWS.map((view) => view.id),
+    },
+    views,
+  };
+  await mkdir(path.dirname(outputPath), { recursive: true });
+  await writeFile(outputPath, `${JSON.stringify(baseline, null, 2)}\n`, "utf8");
+  const markdownPath = outputPath.replace(/\.json$/u, ".md");
+  await writeFile(markdownPath, renderMarkdown(baseline), "utf8");
+  process.stdout.write(`baseline=${outputPath}\nreport=${markdownPath}\n`);
+} finally {
+  if (probeInstalled) await uninstallProbe(inspector.client).catch(() => undefined);
+  inspector.client.close();
+  if (inspector.openedByScript) await closeElectronInspector();
+}
+
+function summarizeView(run, requests) {
+  const successful = requests.filter((request) => request.handlerOk && request.responseBytes !== null);
+  const methodGroups = groupBy(successful, (request) => request.daemonMethod);
+  const methods = Object.fromEntries(
+    [...methodGroups.entries()].map(([method, rows]) => [
+      method,
+      {
+        requestCount: rows.length,
+        payloadBytes: rows.reduce((sum, row) => sum + row.responseBytes, 0),
+        e2eDurationMs: rows.map((row) => round(row.e2eMs)),
+        handlerDurationMs: rows.map((row) => row.daemonDurationMs),
+      },
+    ]),
+  );
+  const repeatedProjection = [...methodGroups.entries()].flatMap(([method, rows]) => {
+    const payloads = groupBy(rows, (row) => JSON.stringify(row.payload));
+    return [...payloads.values()].some((samePayload) => samePayload.length > 1) ? [method] : [];
+  });
+  const nPlusOne = [...methodGroups.entries()].flatMap(([method, rows]) => {
+    if (rows.length < 2) return [];
+    const entityKeys = new Set(rows.map((row) => entitySelector(row.payload)).filter(Boolean));
+    return entityKeys.size > 1 ? [method] : [];
+  });
+  const fullProjection = successful
+    .filter(
+      (row) =>
+        (row.daemonMethod === "repo.triadic.relationGraph" && !row.payload?.facet) ||
+        (row.daemonMethod === "repo.decisions.list" && !row.payload?.projection),
+    )
+    .map((row) => row.daemonMethod);
+  return {
+    label: run.view.label,
+    coldLoadDurationMs: run.endedAtMs - run.startedAtMs,
+    requestCount: successful.length,
+    payloadBytes: successful.reduce((sum, row) => sum + row.responseBytes, 0),
+    maxE2eDurationMs: round(Math.max(0, ...successful.map((row) => row.e2eMs))),
+    maxHandlerDurationMs: Math.max(0, ...successful.map((row) => row.daemonDurationMs ?? 0)),
+    amplification: {
+      nPlusOneMethods: [...new Set(nPlusOne)],
+      fullProjectionMethods: [...new Set(fullProjection)],
+      repeatedProjectionMethods: [...new Set(repeatedProjection)],
+    },
+    methods,
+    requests,
+  };
+}
+
+function renderMarkdown(baseline) {
+  const rows = Object.entries(baseline.views)
+    .map(([id, view]) => {
+      const flags = [
+        view.amplification.nPlusOneMethods.length ? `N+1: ${view.amplification.nPlusOneMethods.join(", ")}` : null,
+        view.amplification.fullProjectionMethods.length
+          ? `full: ${view.amplification.fullProjectionMethods.join(", ")}`
+          : null,
+        view.amplification.repeatedProjectionMethods.length
+          ? `repeat: ${view.amplification.repeatedProjectionMethods.join(", ")}`
+          : null,
+      ].filter(Boolean);
+      return `| ${view.label} (\`${id}\`) | ${view.requestCount} | ${view.payloadBytes} | ${view.maxE2eDurationMs} | ${view.maxHandlerDurationMs} | ${flags.join("; ") || "none"} |`;
+    })
+    .join("\n");
+  const detail = Object.entries(baseline.views)
+    .map(([id, view]) => {
+      const methodRows = Object.entries(view.methods)
+        .map(
+          ([method, metrics]) =>
+            `| \`${method}\` | ${metrics.requestCount} | ${metrics.payloadBytes} | ${metrics.e2eDurationMs.join(", ")} | ${metrics.handlerDurationMs.map((value) => value ?? "unmatched").join(", ")} |`,
+        )
+        .join("\n");
+      return `## ${view.label} (\`${id}\`)\n\n| method | count | payload bytes | e2e duration ms | daemon duration ms |\n|---|---:|---:|---|---|\n${methodRows}\n`;
+    })
+    .join("\n");
+  return `# GUI read baseline\n\n- Measured: ${baseline.measuredAt}\n- Basis revision: \`${baseline.basisRevision}\`\n- Source state: ${baseline.sourceState.dirty ? `dirty (${baseline.sourceState.status.join(", ")})` : "clean"}\n- Projection: schema ${baseline.projection.schemaVersion}, watermark ${baseline.projection.watermark}, source revision ${baseline.projection.scannedRevision}\n- Basis: ${baseline.measurement.shape}. Payload and latency definitions are embedded in the JSON sibling.\n\n| view | requests | payload bytes | max e2e ms | max daemon ms | amplification |\n|---|---:|---:|---:|---:|---|\n${rows}\n\n${detail}`;
+}
+
+function pairDaemonRequests(guiRecords, daemonRequests) {
+  const available = new Set(daemonRequests.map((_, index) => index));
+  return guiRecords.map((record) => {
+    let best = null;
+    for (const index of available) {
+      const candidate = daemonRequests[index];
+      if (candidate.method !== record.daemonMethod) continue;
+      const distance = Math.abs(Date.parse(candidate.atEnd) - record.endedAtMs);
+      if (distance > 5_000 || (best && best.distance <= distance)) continue;
+      best = { index, distance, candidate };
+    }
+    if (best) available.delete(best.index);
+    return {
+      ...record,
+      e2eMs: round(record.e2eMs),
+      daemonDurationMs: best?.candidate.durationMs ?? null,
+      daemonAtEnd: best?.candidate.atEnd ?? null,
+    };
+  });
+}
+
+async function readDaemonRequests(root, pid, startMs, endMs) {
+  const logDir = path.join(root, "logs");
+  const names = (await readdir(logDir)).filter(
+    (name) => name.startsWith("daemon-default-conn-") && name.includes(".jsonl"),
+  );
+  const rows = [];
+  for (const name of names) {
+    const body = await readFile(path.join(logDir, name), "utf8");
+    for (const line of body.split("\n")) {
+      if (!line) continue;
+      const row = JSON.parse(line);
+      const at = Date.parse(row.atEnd ?? row.at);
+      if (row.event === "request" && row.pid === pid && at >= startMs - 5_000 && at <= endMs + 5_000) rows.push(row);
+    }
+  }
+  return rows;
+}
+
+async function installProbe(client) {
+  return evaluateMain(
+    client,
+    `(() => {
+      const { ipcMain } = process.mainModule.require("electron");
+      const mapping = ${JSON.stringify(BRIDGE_READ_METHODS)};
+      if (globalThis.__guiReadBaselineProbe?.uninstall) globalThis.__guiReadBaselineProbe.uninstall();
+      const probe = { records: [], inflight: 0, originals: new Map() };
+      for (const [bridgeMethod, daemonMethod] of Object.entries(mapping)) {
+        const channel = "harness:" + bridgeMethod;
+        const original = ipcMain._invokeHandlers.get(channel);
+        if (!original) continue;
+        probe.originals.set(channel, original);
+        ipcMain._invokeHandlers.set(channel, async function (...args) {
+          const startedAtMs = Date.now(), started = performance.now();
+          probe.inflight += 1;
+          try {
+            const rawResult = await original.apply(this, args);
+            const result = bridgeMethod === "getSystemStatus" && Array.isArray(rawResult?.repos)
+              ? { ...rawResult, repos: [...rawResult.repos].sort((left, right) =>
+                  left?.repoId === "canonical" ? -1 : right?.repoId === "canonical" ? 1 : 0) }
+              : rawResult;
+            probe.records.push({ bridgeMethod, daemonMethod, payload: args[1] ?? null, startedAtMs,
+              endedAtMs: Date.now(), e2eMs: performance.now() - started,
+              responseBytes: Buffer.byteLength(JSON.stringify(result) ?? "null"), handlerOk: true });
+            return result;
+          } catch (error) {
+            probe.records.push({ bridgeMethod, daemonMethod, payload: args[1] ?? null, startedAtMs,
+              endedAtMs: Date.now(), e2eMs: performance.now() - started, responseBytes: null,
+              handlerOk: false, error: error instanceof Error ? error.message : String(error) });
+            throw error;
+          } finally { probe.inflight -= 1; }
+        });
+      }
+      probe.uninstall = () => { for (const [channel, original] of probe.originals) ipcMain._invokeHandlers.set(channel, original); };
+      globalThis.__guiReadBaselineProbe = probe;
+      return { handlers: probe.originals.size };
+    })()`,
+  );
+}
+
+function readProbe(client) {
+  return evaluateMain(client, "globalThis.__guiReadBaselineProbe?.records ?? []");
+}
+function resetProbe(client) {
+  return evaluateMain(client, "globalThis.__guiReadBaselineProbe.records = []; true");
+}
+function uninstallProbe(client) {
+  return evaluateMain(
+    client,
+    "globalThis.__guiReadBaselineProbe?.uninstall(); delete globalThis.__guiReadBaselineProbe; true",
+  );
+}
+
+async function waitForQuiet(client, quietMs, timeoutMs) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const state = await evaluateMain(
+      client,
+      `(() => { const p = globalThis.__guiReadBaselineProbe; const last = p?.records.at(-1)?.endedAtMs ?? Date.now();
+        return { inflight: p?.inflight ?? 0, quietFor: Date.now() - last }; })()`,
+    );
+    if (state.inflight === 0 && state.quietFor >= quietMs) return;
+    await sleep(100);
+  }
+  throw new Error(`GUI reads did not become quiet within ${timeoutMs}ms`);
+}
+
+async function selectView(client, label) {
+  const result = await executeRenderer(
+    client,
+    `(() => { const button = [...document.querySelectorAll("button")].find((row) => row.title === ${JSON.stringify(label)});
+      if (!button) return false; button.click(); return true; })()`,
+  );
+  if (!result) throw new Error(`navigation button ${label} is missing`);
+  await waitForView(client, label, 30_000);
+}
+
+async function waitForView(client, label, timeoutMs) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const ready = await executeRenderer(
+      client,
+      `(() => { const button = [...document.querySelectorAll("button")].find((row) => row.title === ${JSON.stringify(label)});
+        return Boolean(button && button.className.includes("font-medium") && document.querySelector('[data-testid="real-task-summary"]')); })()`,
+    ).catch(() => false);
+    if (ready) return;
+    await sleep(150);
+  }
+  throw new Error(`view ${label} did not become active within ${timeoutMs}ms`);
+}
+
+async function selectRepository(client) {
+  const current = await executeRenderer(
+    client,
+    `(() => [...document.querySelectorAll("button")].find((element) =>
+      element.title === "快速切换项目")?.innerText ?? "")()`,
+  );
+  if (current.startsWith("harness-anything\n")) return;
+  let selected = await executeRenderer(
+    client,
+    `(() => { const repository = [...document.querySelectorAll("button")].find((element) =>
+      element.innerText.startsWith("harness-anything\\n") && element.innerText.includes("canonical · enabled / attached"));
+      if (!repository) return false; repository.click(); return true; })()`,
+  );
+  const opened =
+    selected ||
+    (await executeRenderer(
+      client,
+      `(() => { const switcher = [...document.querySelectorAll("button")].find((element) =>
+      element.title === "快速切换项目"); if (!switcher) return false; switcher.click(); return true; })()`,
+    ));
+  if (!opened) throw new Error("repository switcher is missing");
+  if (!selected) {
+    await sleep(350);
+    selected = await executeRenderer(
+      client,
+      `(() => { const repository = [...document.querySelectorAll("button")].find((element) =>
+        element.innerText.startsWith("harness-anything\\n") && element.innerText.includes("canonical · enabled / attached"));
+        if (!repository) return false; repository.click(); return true; })()`,
+    );
+  }
+  if (!selected) throw new Error("attached canonical repository entry is missing");
+  const deadline = Date.now() + 60_000;
+  while (Date.now() < deadline) {
+    const ready = await executeRenderer(
+      client,
+      `(() => {
+        const current = [...document.querySelectorAll("button")].find((element) =>
+          element.title === "快速切换项目")?.innerText ?? "";
+        const summary = document.querySelector('[data-testid="real-task-summary"]')?.innerText ?? "";
+        return { ready: current.startsWith("harness-anything\\n") && /\\d+/u.test(summary), summary };
+      })()`,
+    ).catch(() => ({ ready: false }));
+    if (ready.ready) return;
+    await sleep(250);
+  }
+  throw new Error("canonical repository did not become ready in the GUI");
+}
+
+async function reloadRenderer(client) {
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    try {
+      await evaluateMain(
+        client,
+        `(() => { const { BrowserWindow } = process.mainModule.require("electron");
+        BrowserWindow.getAllWindows()[0].webContents.reloadIgnoringCache(); return true; })()`,
+      );
+      await sleep(100);
+      return;
+    } catch (error) {
+      if (!String(error).includes("Promise was collected") || attempt === 19) throw error;
+      await sleep(100);
+    }
+  }
+}
+
+async function focusGui(client) {
+  await evaluateMain(
+    client,
+    `(() => { const { BrowserWindow, app } = process.mainModule.require("electron");
+    const window = BrowserWindow.getAllWindows()[0]; window.show(); window.focus(); app.focus({ steal: true }); return true; })()`,
+  );
+}
+
+async function openElectronInspector(pid) {
+  let target = await inspectorTarget(),
+    openedByScript = false;
+  if (!target) {
+    process.kill(pid, "SIGUSR1");
+    openedByScript = true;
+    for (let attempt = 0; attempt < 50 && !target; attempt += 1) {
+      await sleep(100);
+      target = await inspectorTarget();
+    }
+  }
+  if (!target) throw new Error("Electron inspector did not open on 127.0.0.1:9229");
+  const client = await InspectorClient.connect(target.webSocketDebuggerUrl);
+  const inspectedPid = await evaluateMain(client, "process.pid");
+  if (inspectedPid !== pid) throw new Error(`inspector pid ${inspectedPid} does not match GUI pid ${pid}`);
+  return { client, openedByScript };
+}
+
+async function inspectorTarget() {
+  try {
+    const response = await fetch("http://127.0.0.1:9229/json/list", { signal: AbortSignal.timeout(400) });
+    const targets = response.ok ? await response.json() : [];
+    return targets.find((entry) => entry.type === "node" && entry.webSocketDebuggerUrl) ?? null;
+  } catch {
+    return null;
+  }
+}
+
+async function closeElectronInspector() {
+  const target = await inspectorTarget();
+  if (!target) return;
+  const client = await InspectorClient.connect(target.webSocketDebuggerUrl);
+  await evaluateMain(client, 'setTimeout(() => process.mainModule.require("node:inspector").close(), 50); true');
+  client.close();
+}
+
+async function evaluateMain(client, expression) {
+  const response = await client.request("Runtime.evaluate", { expression, awaitPromise: true, returnByValue: true });
+  if (response.exceptionDetails)
+    throw new Error(response.exceptionDetails.exception?.description ?? response.exceptionDetails.text);
+  return response.result.value;
+}
+
+async function executeRenderer(client, expression) {
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    try {
+      return await evaluateMain(
+        client,
+        `(async () => { const { BrowserWindow } = process.mainModule.require("electron");
+        return BrowserWindow.getAllWindows()[0].webContents.executeJavaScript(${JSON.stringify(expression)}, true); })()`,
+      );
+    } catch (error) {
+      if (!String(error).includes("Promise was collected") || attempt === 19) throw error;
+      await sleep(100);
+    }
+  }
+  throw new Error("renderer evaluation retry budget exhausted");
+}
+
+function processSnapshot() {
+  return execFileSync("ps", ["-axo", "pid=,etime=,rss=,%cpu=,command="], { encoding: "utf8" })
+    .split("\n")
+    .flatMap((line) => {
+      const match = /^\s*(\d+)\s+(\S+)\s+(\d+)\s+([\d.]+)\s+(.*)$/u.exec(line);
+      return match ? [{ pid: Number(match[1]), elapsed: match[2], command: match[5] }] : [];
+    });
+}
+
+function findDaemon(processes, root) {
+  const suffix = `daemon serve --user-root ${root} --daemon-id default`;
+  const matches = processes.filter((entry) => entry.command.includes(suffix));
+  if (matches.length !== 1) throw new Error(`expected one default daemon for ${root}; found ${matches.length}`);
+  return matches[0];
+}
+
+function findGui(processes, root) {
+  const entrypoint = path.join(root, "packages", "gui", "src", "main", "electron-main.ts");
+  const matches = processes.filter((entry) => entry.command.includes(entrypoint) && !entry.command.includes("--type="));
+  if (matches.length !== 1) throw new Error(`expected one Electron GUI for ${root}; found ${matches.length}`);
+  return matches[0];
+}
+
+function projectionStatus(databasePath) {
+  const query =
+    "SELECT schema_version, watermark, scanned_revision, squad_run_ready, coalesce(scan_cursor, '') FROM projection_meta";
+  const [schemaVersion, watermark, scannedRevision, squadRunReady, scanCursor] = execFileSync(
+    "/usr/bin/sqlite3",
+    ["-readonly", "-separator", "\t", databasePath, query],
+    { encoding: "utf8" },
+  )
+    .trim()
+    .split("\t");
+  return {
+    schemaVersion: Number(schemaVersion),
+    watermark: Number(watermark),
+    scannedRevision: Number(scannedRevision),
+    squadRunReady: Number(squadRunReady),
+    scanCursor: scanCursor || null,
+    ready: Number(watermark) === Number(scannedRevision) && Number(squadRunReady) === 1 && !scanCursor,
+  };
+}
+
+function parseArgs(args) {
+  const result = {};
+  for (let index = 0; index < args.length; index += 2) {
+    const flag = args[index],
+      value = args[index + 1];
+    if (!value) throw new Error(`${flag} requires a value`);
+    const key = {
+      "--source-root": "sourceRoot",
+      "--ledger-root": "ledgerRoot",
+      "--user-root": "userRoot",
+      "--output": "output",
+    }[flag];
+    if (!key) throw new Error(`unknown option ${flag}`);
+    result[key] = value;
+  }
+  return result;
+}
+
+function entitySelector(payload) {
+  if (!payload || typeof payload !== "object") return null;
+  for (const key of ["taskId", "runtimeSessionId", "agentId", "squadId", "scheduleId"]) {
+    if (payload[key]) return `${key}:${payload[key]}`;
+  }
+  return null;
+}
+
+function groupBy(rows, keyOf) {
+  const groups = new Map();
+  for (const row of rows) groups.set(keyOf(row), [...(groups.get(keyOf(row)) ?? []), row]);
+  return groups;
+}
+
+function git(root, args) {
+  return execFileSync("git", args, { cwd: root, encoding: "utf8" });
+}
+function round(value) {
+  return Math.round(value * 1000) / 1000;
+}
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}


### PR DESCRIPTION
# English

## Summary

This PR establishes a reproducible real-ledger cold-read baseline for the seven GUI views (Overview, Board, Graph, Sessions, Schedules, Agent/Squad, Artifacts) and wires it into a shrink-only advisory ratchet over per-view request count, payload bytes, IPC latency, and daemon-handler latency. It also removes three duplicate mounted reads from every cold view by no longer treating the first task-projection hydration as a ledger change.

## Architectural Justification

- GUI latency has been degrading release over release without a number attached to it. The baseline measures the real canonical ledger (projection schema 14, basis revision `7dacdf10`) and records request count, payload, and handler latency per view so each later Phase G slice can report a before/after instead of an impression.
- The ratchet is shrink-only and advisory: it cannot be satisfied by adding caches or a second read path, only by reducing what a view asks for. No compatibility or fallback path is introduced.
- The renderer fix deletes behavior (a spurious refetch on first hydration) rather than adding a memo layer; it is the smallest change that removes the duplicate `repo.workspace.summary.read` / `repo.decisions.list` / `repo.triadic.relationGraph` reads.
- Wide read cost that remains (`repo.tasks.list` 2.2 MB / 650–750 ms handler, full `decisions.list` and `relationGraph` on Overview/Graph) is a daemon read-shape problem owned by G3b and is deliberately not patched here.

## What Changed

- `tools/measure-gui-read-baseline.mjs`: cold renderer reload against the real ledger, per view, emitting a JSON + Markdown baseline.
- `tools/gates/gui-read-baseline.mjs` + `gui-read-baseline.json` + gate-manifest entry: advisory shrink-only ratchet over the recorded baseline.
- `packages/gui/src/renderer/App.tsx`: first task-projection hydration no longer triggers the ledger-change refetch (−3 requests on every cold view, −23.1% to −37.5%; payload −3.3% to −14.5%).
- Tests: `tools/gates/test/gui-read-baseline.test.mjs` (gate contract), `packages/gui/test/triadic-read-scoping.vitest.ts` updated for the first-cut branch.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: see the single `Production-Delta` declaration below.

## Machine-Readable Declarations

Production-Delta: +713/-0
Dependency-Change: none

### Optional Evidence Claims

No external CI or performance evidence claim is made; the before/after numbers are from the committed baseline JSON measured on the maintainer's machine and are advisory.

## Task And Scope

- Harness task: `task_c03713017573032b7b7149b9b5`
- Branch: `codex/gui-read-latency`
- Public scope: GUI read baseline tool, advisory ratchet gate, renderer duplicate-read removal.
- Private planning/evidence updated: yes — `artifacts/gui-read-baseline-2026-08-30.md`, `artifacts/gui-read-analysis-2026-08-30.md` (not part of the public diff).
- Out of scope: daemon read-shape changes for wide projections (G3b), any caching layer, new GUI pages.

## Version Impact

- Version: no version change; internal tooling and a renderer behavior fix.
- Publish impact: no publish.

## Governance Declaration

- Protected surface touched: yes
- Protected surface scope: `tools/gate-manifest.json` (adds one advisory gate entry; no existing gate weakened).
- Authority: `task_c03713017573032b7b7149b9b5`; Phase G north star §5 ("GUI 性能是实体散乱的症状,每片报读延迟前后对照").
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable

## Verification

- Base `origin/main` SHA: `7dacdf10737fd9408f65b932de606f06ddee5cd3`
- Sync method: branch created from `origin/main`; rebased before merge if needed.
- Public diff command: `git diff --stat origin/main...HEAD`
- Commands run locally (worker report, task artifacts `reports/`): `npm -w @harness-anything/gui run test:gui -- test/triadic-read-scoping.vitest.ts test/ledger-invalidation-scope.vitest.ts`; `node tools/run-node-tests.mjs --tier fast --file tools/gates/test/gui-read-baseline.test.mjs`; `node tools/gates/gui-read-baseline.mjs --base origin/main --mode ratchet`; `node tools/check-gate-manifest-invariants.mjs`; `npm run typecheck`; 38 boundary checks passed (GitHub-token-only check excluded).
- [ ] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [x] `npm run typecheck`
- [ ] `npm test`
- [x] `npm run harness:check-import-boundaries`
- [x] `npm run harness:scan-forbidden-symbols`
- [x] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed

## Review Evidence

- CEO semantic review: matches the north-star ruling "measure first, then ratchet"; no new page, no cache, no second read path. Full GitHub CI is the authority for the rest.

## Residual Risk

- IPC latency in the baseline is affected by shared-daemon queue load; the ratchet stores daemon-handler latency separately and is advisory only.
- Wide reads on Overview/Graph remain 13 MB per cold load until G3b changes the daemon read shape.

## References

- Task: `task_c03713017573032b7b7149b9b5`
- Phase G north star: `harness/tasks/task_5a71a25b…/artifacts/entity-model-north-star-20260830.md` §5

# 中文

## 概要

为七个 GUI 视图(总览 / 看板 / 关系图 / 会话 / 定时计划 / Agent·Squad / 产物)建立可复跑的真台账冷读基线,并接入只降不升的 advisory 棘轮(每视图请求数、payload 字节、IPC 延迟、daemon handler 延迟)。同时让首次 task 投影水合不再被当作台账变更,删掉每个冷视图的三条重复读。

## 架构辩护

- GUI 一直在变慢但从来没有数字。基线在真 canonical 台账(projection schema 14,基准 revision `7dacdf10`)上按视图记录请求数、payload 与 handler 延迟,之后每个 Phase G 切片都能报前后对照,而不是凭感觉。
- 棘轮只降不升且 advisory:加缓存、加第二条读路都过不了它,只有让视图少要东西才能过;没有引入任何兼容或兜底路径。
- 渲染层修复是删行为(首次水合触发的多余 refetch),不是加 memo 层;这是去掉重复 `repo.workspace.summary.read` / `repo.decisions.list` / `repo.triadic.relationGraph` 的最小改动。
- 剩余的宽读成本(`repo.tasks.list` 2.2 MB / handler 650–750 ms,总览与关系图的整份 `decisions.list` 与 `relationGraph`)是 daemon 读形状问题,归 G3b,本 PR 刻意不补。

## 改动内容

- `tools/measure-gui-read-baseline.mjs`:对真台账做冷 reload,逐视图输出 JSON + Markdown 基线。
- `tools/gates/gui-read-baseline.mjs` + `gui-read-baseline.json` + gate-manifest 条目:基于已记录基线的 advisory shrink-only 棘轮。
- `packages/gui/src/renderer/App.tsx`:首次 task 投影水合不再触发台账变更 refetch(每个冷视图 −3 请求,−23.1%~−37.5%;payload −3.3%~−14.5%)。
- 测试:`tools/gates/test/gui-read-baseline.test.mjs`(门契约)、`packages/gui/test/triadic-read-scoping.vitest.ts` 按 first-cut 分支更新。

## 门收割 / Gate Harvest

- 删除的生产路径:无。
- 删除的门 / fixture:无。
- 生产净行数:以英文块中唯一的 `Production-Delta` 为准。

## 机读声明说明

`Production-Delta: +713/-0` 由 `tools/gates/production-delta.mjs --base origin/main` 实测;绝大部分是测量工具与门(`tools/`),GUI 生产代码 +6/-0。

## 任务与范围

- Harness task:`task_c03713017573032b7b7149b9b5`
- 分支:`codex/gui-read-latency`
- 公开范围:GUI 读基线工具、advisory 棘轮门、渲染层重复读删除。
- 私有规划/证据:任务包 `artifacts/gui-read-baseline-2026-08-30.md`、`gui-read-analysis-2026-08-30.md`(不在公开 diff 内)。
- 范围外:daemon 宽投影读形状(G3b)、任何缓存层、新 GUI 页面。

## 版本影响

- 版本:不变;内部工具与一处渲染行为修复。
- 发布影响:不发布。

## 治理声明

- 触碰受保护面:是
- 范围:`tools/gate-manifest.json`(新增一条 advisory 门;未削弱任何既有门)。
- 授权:`task_c03713017573032b7b7149b9b5`;Phase G 北极星 §5(GUI 性能按片报前后对照)。
- 机器检查边界:本 PR 只断言声明存在,是否属实由评审判断。
- Break-glass:否;理由/范围:不适用。

## 验证

- 基准 `origin/main`:`7dacdf10737fd9408f65b932de606f06ddee5cd3`;同步方式:自 `origin/main` 建分支,合并前按需 rebase。
- 本地已跑(见任务包 `reports/`):GUI 两个 vitest、门契约测试、棘轮 ratchet 模式、gate-manifest 不变量、typecheck、38 项边界检查(仅缺 GitHub token 的一项未跑)。
- [ ] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [x] `npm run typecheck`
- [ ] `npm test`
- [x] `npm run harness:check-import-boundaries`
- [x] `npm run harness:scan-forbidden-symbols`
- [x] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed

## 审查证据

- CEO 语义验收:符合「先量再收」裁决;无新页面、无缓存、无第二读路。其余以 GitHub CI 为权威。

## 残余风险

- 基线中的 IPC 延迟受共享 daemon 队列负载影响;棘轮单独保存 handler 延迟且仅 advisory。
- 总览/关系图冷加载仍是 13 MB 宽读,等 G3b 改 daemon 读形状。

## 关联材料

- Task:`task_c03713017573032b7b7149b9b5`
- Phase G 北极星 §5。
