### PR TITLE
fix(daemon): fence runtime adoption by node so forced restart keeps owned sessions live

### DIFF
--- a/packages/cli/test/runtime-cli.integration.test.ts
+++ b/packages/cli/test/runtime-cli.integration.test.ts
@@ -639,6 +639,40 @@ test("real CLI runs, archives task-bound dispatches, resumes, waits through stat
     context.diagnostic(
       `detach cross-process retrieval: ${JSON.stringify({ launcherPid: detachedProcess.pid, retrievalPid: retrievalProcess.pid, runtimeSessionId: detachedRuntimeSessionId, outcome: retrievalProcess.receipt.outcome, resultText: retrievedText, readerReuse })}`,
     );
+    const restartDetached = run(root, env, ["runtime", "run", "cli-worker", "--prompt", "hold", "--detach"]),
+      restartSessionId = String(restartDetached.runtimeSessionId),
+      restartDispatchId = String(restartDetached.dispatchId),
+      liveBeforeRestart = await eventuallyRuntimeStatus(root, env, restartSessionId, "live"),
+      workerPid = Number(
+        readDispatchRecords(root, restartDispatchId).find((record) => record.kind === "process_started")?.pid,
+      ),
+      daemonBeforeRestart = run(root, env, ["daemon", "status"]),
+      stoppedForRestart = run(root, env, ["daemon", "stop", "--force"]);
+    assert.equal(liveBeforeRestart.session.liveness, "live");
+    assert.equal(
+      processAlive(workerPid),
+      true,
+      `runtime worker ${String(workerPid)} must be live before daemon restart`,
+    );
+    assert.equal(stoppedForRestart.forced, true, JSON.stringify(stoppedForRestart));
+    assert.equal(processAlive(workerPid), true, `runtime worker ${String(workerPid)} must survive daemon stop --force`);
+    const liveAfterRestart = await eventuallyRuntimeStatus(root, env, restartSessionId, "live"),
+      daemonAfterRestart = run(root, env, ["daemon", "status"]);
+    assert.notEqual(daemonAfterRestart.pid, daemonBeforeRestart.pid, "runtime status must use a restarted daemon");
+    assert.equal(liveAfterRestart.session.liveness, "live");
+    assert.equal(liveAfterRestart.session.activity.outcome, null);
+    assert.equal(processAlive(workerPid), true, `runtime worker ${String(workerPid)} must agree with runtime status`);
+    assert.equal(run(root, env, ["runtime", "cancel", restartSessionId]).detail, "cancelled");
+    context.diagnostic(
+      `daemon restart liveness: ${JSON.stringify({
+        runtimeSessionId: restartSessionId,
+        workerPid,
+        daemonBefore: daemonBeforeRestart.pid,
+        daemonAfter: daemonAfterRestart.pid,
+        before: liveBeforeRestart.session.liveness,
+        after: liveAfterRestart.session.liveness,
+      })}`,
+    );
     const invalidOnExit = runMaybe(root, env, [
       "runtime",
       "run",
@@ -1300,6 +1334,30 @@ async function eventually<T>(read: () => T): Promise<T> {
     await new Promise((resolve) => setTimeout(resolve, 20));
   }
   throw new Error(`dispatch did not settle: ${JSON.stringify(last)}`);
+}
+async function eventuallyRuntimeStatus(
+  root: string,
+  env: NodeJS.ProcessEnv,
+  runtimeSessionId: string,
+  liveness: string,
+): Promise<{ readonly session: Record<string, unknown> & { readonly activity: Record<string, unknown> } }> {
+  let last: Record<string, unknown> = {};
+  for (let attempt = 0; attempt < 500; attempt += 1) {
+    last = run(root, env, ["runtime", "status", runtimeSessionId]);
+    const session = last.session as Record<string, unknown> & { readonly activity: Record<string, unknown> };
+    if (session.liveness === liveness) return { session };
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+  throw new Error(`runtime status did not reach ${liveness}: ${JSON.stringify(last)}`);
+}
+function processAlive(pid: number): boolean {
+  if (!Number.isInteger(pid) || pid < 1) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
 }
 function run(root: string, env: NodeJS.ProcessEnv, args: readonly string[]): Record<string, unknown> {
   const result = runMaybe(root, env, args);

--- a/packages/daemon/src/fleet-edge-runtime.ts
+++ b/packages/daemon/src/fleet-edge-runtime.ts
@@ -160,6 +160,7 @@ export function openFleetEdgeRuntime(input: {
     repoId: request.repoId,
     rootDir: request.workspaceRoot,
     daemonGeneration: input.daemonGeneration,
+    runtimeNodeId: request.nodeId,
     runtimeDaemonRoute: input.daemonRoute,
     remote: {
       existing: async (opId) => {
@@ -352,9 +353,9 @@ export function openFleetEdgeRuntime(input: {
       await ready;
       if (method === "repo.schedule.run") return runSchedule(action);
       return method === "repo.agentRuntime.spawn"
-        ? spawner.spawn(action, edgeBinding())
+        ? spawner.spawn(action, edgeBinding(request))
         : method === "repo.agentRuntime.cancel"
-          ? spawner.cancel(action, edgeBinding())
+          ? spawner.cancel(action, edgeBinding(request))
           : ((await runFleetRuntimeReadClient({
               ...runtimeReadPeer,
               repoId: request.repoId,
@@ -448,7 +449,7 @@ export function openFleetEdgeRuntime(input: {
       idempotencyKey: operationKey,
       now,
       spawn: async (scheduled) => {
-        const spawned = await spawner.spawnScheduled(scheduled, edgeBinding());
+        const spawned = await spawner.spawnScheduled(scheduled, edgeBinding(request));
         return {
           outcome: String(spawned.outcome),
           ...(typeof spawned.dispatchId === "string" ? { dispatchId: spawned.dispatchId } : {}),
@@ -525,8 +526,11 @@ function scheduleResult(
   };
 }
 
-function edgeBinding() {
-  return { actor: { principal: { personId: "fleet-edge" }, executor: null }, source: "local" as const };
+function edgeBinding(request: Pick<FleetEdgeRuntimeRequest["payload"], "nodeId" | "assignmentId">) {
+  return {
+    actor: { principal: { personId: "fleet-edge" }, executor: null },
+    source: { kind: "assignment" as const, nodeId: request.nodeId, assignmentId: request.assignmentId },
+  };
 }
 function edgeRuntimeError(code: string, message: string): Error {
   return Object.assign(new Error(message), { code });

--- a/packages/daemon/src/runtime-spawn-adoption.ts
+++ b/packages/daemon/src/runtime-spawn-adoption.ts
@@ -25,7 +25,14 @@ export async function adoptRuntimes(context: RuntimeSpawnerContext): Promise<voi
     if (fallbackSummary) context.reconcileFallback(fallbackSummary);
     const session = byId.get(header.runtimeSessionId);
     const metadata = adoptableMetadata(header);
-    if (!session || session.liveness === "exited" || session.outcome !== null || !metadata) continue;
+    if (
+      !session ||
+      session.liveness === "exited" ||
+      session.outcome !== null ||
+      !metadata ||
+      !ownedByRuntimeNode(metadata.binding, context.input.runtimeNodeId)
+    )
+      continue;
     const fullStream = readDispatchStream(context.input.rootDir, header.dispatchId),
       stream = fullStream ?? readDispatchStreamSummary(context.input.rootDir, header.dispatchId);
     if (!stream?.process) continue;
@@ -113,6 +120,14 @@ export async function adoptRuntimes(context: RuntimeSpawnerContext): Promise<voi
       timer.unref();
     }
   }
+}
+
+function ownedByRuntimeNode(binding: RuntimeBinding, runtimeNodeId: string | undefined): boolean {
+  if (runtimeNodeId === undefined) return true;
+  const source: unknown = binding.source;
+  if (source === null || typeof source !== "object" || Array.isArray(source)) return false;
+  const assignment = source as Record<string, unknown>;
+  return assignment.kind === "assignment" && assignment.nodeId === runtimeNodeId;
 }
 
 function adoptableMetadata(header: DispatchStreamHeader): {

--- a/packages/daemon/src/runtime-spawner.ts
+++ b/packages/daemon/src/runtime-spawner.ts
@@ -101,6 +101,7 @@ export interface RuntimeSpawnerInput {
   readonly repoId: string;
   readonly rootDir: string;
   readonly daemonGeneration: number;
+  readonly runtimeNodeId?: string;
   readonly runtimeDaemonRoute?: RuntimeDaemonRoute;
   readonly store?: () => CanonicalEventStore;
   readonly projection?: () => TaskProjection;

--- a/packages/daemon/test/dispatch-stream.test.ts
+++ b/packages/daemon/test/dispatch-stream.test.ts
@@ -187,6 +187,54 @@ test("adoption skips a stream above Node's string limit while runtime cancel sti
   }
 });
 
+test("fleet adoption does not probe a dispatch owned by another node", async () => {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-dispatch-node-owner-"));
+  try {
+    const dispatchId = "dispatch_999999999999999999999999",
+      runtimeSessionId = "runtime_999999999999999999999999";
+    openDispatchStream(rootDir, {
+      dispatchId,
+      taskId: "task-node-owner",
+      executionId: "execution-node-owner",
+      runtimeSessionId,
+      instanceId: "instance-1",
+      startedAt: "2026-08-30T00:00:00.000Z",
+      dispatchOpId: "dispatch-op-node-owner",
+      kindId: "codex",
+      permissionMode: null,
+      binding: {
+        actor: { principal: { personId: "edge-worker" }, executor: null },
+        source: { kind: "assignment", nodeId: "node-a", assignmentId: "assignment-a" },
+      },
+      cwd: rootDir,
+      prompt: "node-owned adoption",
+      model: "gpt-5.6-sol",
+      reasoningEffort: null,
+      fast: false,
+    });
+    appendRuntimeWorkerRecord(rootDir, dispatchId, { kind: "process_started", pid: process.pid });
+    const adopted = new Map(),
+      context = {
+        input: {
+          rootDir,
+          repoId: "node-owner",
+          runtimeNodeId: "node-b",
+          remote: {
+            readRuntimeSessions: async () => [
+              { runtimeSessionId, instanceId: "instance-1", providerSessionId: null, liveness: "live", outcome: null },
+            ],
+          },
+        },
+        processes: adopted,
+        reconcileFallback: () => undefined,
+      };
+    await adoptRuntimes(context);
+    assert.equal(adopted.size, 0, "only the dispatching node may probe or settle its recorded pid");
+  } finally {
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});
+
 test("the dispatch fuse drops unbounded output but preserves terminal records", () => {
   const rootDir = mkdtempSync(path.join(tmpdir(), "ha-dispatch-write-fuse-"));
   const warning = console.warn,

--- a/packages/daemon/test/fleet-transport.integration.test.ts
+++ b/packages/daemon/test/fleet-transport.integration.test.ts
@@ -15,6 +15,7 @@ import {
 } from "../../kernel/src/index.ts";
 import type { AgentRuntimeSessionDto } from "../src/agent-runtime-contract.ts";
 import { openDaemonHost } from "../src/daemon-host.ts";
+import { readDispatchStream } from "../src/dispatch-stream.ts";
 import { openFleetEdgeRuntime } from "../src/fleet-edge-runtime.ts";
 import { runFleetEdgeTask } from "../src/fleet-edge-task.ts";
 import { applyFleetMirrorCut, locateFleetMirrorView } from "../src/fleet-edge-mirror.ts";
@@ -748,6 +749,11 @@ test(
     assert.equal(launchedEnv?.HARNESS_DAEMON_USER_ROOT, edgeUserRoot);
     assert.equal(launchedEnv?.HARNESS_DAEMON_ID, "fleet-runtime-edge");
     assert.equal(launchedEnv?.HARNESS_DAEMON_REPO_ID, fixture.assignment.repoId);
+    assert.deepEqual(readDispatchStream(edgeRoot, String(receipt.dispatchId))?.header.binding?.source, {
+      kind: "assignment",
+      nodeId: fixture.assignment.nodeId,
+      assignmentId: fixture.assignment.assignmentId,
+    });
     await taskReleaseBarrier.started;
     await delay(5_100);
     const settlingEvents = makeTaskEventStore({ repoId: fixture.assignment.repoId, rootDir: fixture.repo })

--- a/packages/daemon/test/runtime-spawn-lifecycle.integration.test.ts
+++ b/packages/daemon/test/runtime-spawn-lifecycle.integration.test.ts
@@ -955,11 +955,32 @@ test("repo-cell restart re-adopts a live native runtime and settles an exit reco
         "utf8",
       ).includes("provider-re-adopt-session"),
     );
+    const reAdoptHostPid = await eventuallyValue(() => {
+      const started = readFileSync(
+        path.join(root, ".harness", "runtime", "dispatches", `${String(receipt.dispatchId)}.jsonl`),
+        "utf8",
+      )
+        .trim()
+        .split(/\r?\n/u)
+        .map((line) => JSON.parse(line) as Record<string, unknown>)
+        .find((record) => record.kind === "process_started");
+      return Number.isInteger(started?.pid) && Number(started?.pid) > 0 ? Number(started?.pid) : null;
+    });
     await cell.close();
     cell = undefined;
     await new Promise((resolve) => setTimeout(resolve, 100));
     assert.doesNotThrow(() => process.kill(providerPid, 0), "repo-cell close must not terminate its runtime worker");
     cell = await open("re-adopt-after");
+    const liveProjection = makeTaskProjection({
+      rootDir: root,
+      projectionPath: path.join(parent, "runtime-re-adopt-live-before-exit.sqlite"),
+      eventStore: makeTaskEventStore({ repoId, rootDir: root }),
+    });
+    liveProjection.list();
+    const adopted = liveProjection.readRuntimeSession(String(receipt.runtimeSessionId))!;
+    liveProjection.close();
+    assert.deepEqual({ liveness: adopted.liveness, outcome: adopted.outcome }, { liveness: "live", outcome: null });
+    assert.doesNotThrow(() => process.kill(reAdoptHostPid, 0), "adopted runtime worker must still be alive");
     writeFileSync(release, "release");
     await eventually(() =>
       makeTaskEventStore({ repoId, rootDir: root })
@@ -986,6 +1007,14 @@ test("repo-cell restart re-adopts a live native runtime and settles an exit reco
       },
       { liveness: "exited", outcome: "succeeded", exitCode: 0 },
     );
+    await eventually(() => {
+      try {
+        process.kill(reAdoptHostPid, 0);
+        return false;
+      } catch {
+        return true;
+      }
+    });
     assert.match(
       readFileSync(path.join(root, ".harness", "runtime", "dispatches", `${String(receipt.dispatchId)}.jsonl`), "utf8"),
       /survived daemon restart/u,


### PR DESCRIPTION
# English

## Summary

A forced daemon restart used to settle every previously running runtime session as `exited / outcome unknown`, even when the worker process was still alive and its worktree kept growing. This PR makes startup adoption probe only the PIDs this node owns: fleet dispatch bindings now persist the existing assignment `{ nodeId, assignmentId }`, the spawner knows its current node, and restart adoption skips dispatches owned by another node. Same-host runtimes stay `live` across `ha daemon stop --force` and settle with their real exit code.

## Architectural Justification

- The defect was a classification error at startup (one-shot settlement of everything that was running), not a missing heartbeat. The fix narrows adoption to durable node ownership instead of adding a liveness layer.
- Multi-node: only the node that spawned a runtime can probe its PID; another node's restart must not settle it. Ownership was already in the dispatch stream and write-source contract; nothing new is invented and no kernel entity or runtime-session shape changes (Phase G entity freeze respected).
- No retry, no fallback, no compatibility path.

## What Changed

- `packages/daemon/src/fleet-edge-runtime.ts`: persist assignment ownership on the dispatch binding; pass the active fleet node into the spawner.
- `packages/daemon/src/runtime-spawn-adoption.ts`: gate PID adoption/probing on durable node ownership.
- `packages/daemon/src/runtime-spawner.ts`: carry `nodeId`.
- Tests: dispatch-stream, fleet-transport integration (dispatch header durably records ownership), runtime-spawn-lifecycle integration (live across forced restart, real exit code), runtime CLI integration.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none

## Machine-Readable Declarations

Production-Delta: +26/-6
Dependency-Change: none

### Optional Evidence Claims

None.

## Task And Scope

- Harness task: `task_5450bf02bd30d0e44ef0f6ecf5`
- Branch: `codex/daemon-restart-liveness`
- Public scope: daemon runtime adoption on restart.
- Private planning/evidence updated: yes — `artifacts/report-2026-08-30.md`, Fact `F-8A19EF46` (not in the public diff).
- Out of scope: runtime-session entity shape (G3a), any heartbeat mechanism.

## Version Impact

- Version: no change. Publish impact: none.

## Governance Declaration

- Protected surface touched: no
- Authority: `task_5450bf02bd30d0e44ef0f6ecf5`
- Break-glass: no

## Verification

- Base `origin/main`: `24bebf4c7e48c008853d4a7bd90cae06c3980b05`; sync method: branch from `origin/main`, rebase before merge if needed.
- Local (worker report): typecheck, lint, boundaries (GitHub-token check excluded), focused tests, isolated Docker CLI/lifecycle/fleet suites.
- [x] `git diff --check`
- [x] `npm run typecheck`
- [x] `npm run harness:check-import-boundaries`
- [x] `npm run harness:scan-forbidden-symbols`
- [x] `npm run harness:check-private-boundary`
- [x] `npm run harness:check-implementation-contracts`
- [ ] `npm run check` / `npm test` / others: GitHub CI is the authority.

## Review Evidence

- CEO semantic review: matches the plan's mechanism ruling (ownership-fenced adoption, no new fields, no heartbeat).

## Residual Risk

- Runtimes spawned before this change without a persisted owner are treated as not owned by any node and are not adopted; they settle on their own exit. One-time, documented in the task report.

## References

- `task_5450bf02bd30d0e44ef0f6ecf5`; Fact `F-67DA1F98` (原始观察), `F-8A19EF46` (修复后实测)。

# 中文

## 概要

`ha daemon stop --force` 重启后,所有重启前在飞的 runtime session 会被一刀切结算成 `exited / outcome unknown`,哪怕 worker 进程还活着、worktree 还在增长。本 PR 让启动时的接管只探活**本节点拥有的** PID:fleet 派工绑定持久化已有的 `{ nodeId, assignmentId }`,spawner 知道自己的节点,重启接管跳过别的节点拥有的派工。同机 runtime 跨强制重启保持 `live`,退出后按真实退出码结算。

## 架构辩护

- 缺陷是启动时的分类错误(把「上次 running」全部结算),不是缺心跳;修法是把接管收窄到持久化的节点归属,不加探活层。
- 多节点:只有派出该 runtime 的节点能探它的 PID,别的节点重启不得替它结算。归属信息本来就在 dispatch stream 与 write-source 契约里,没有发明新东西;kernel 实体与 runtime-session 形状未变(遵守 Phase G 冻结)。
- 无重试、无兜底、无兼容路径。

## 改动内容

- `fleet-edge-runtime.ts`:派工绑定持久化归属;把当前 fleet 节点传给 spawner。
- `runtime-spawn-adoption.ts`:PID 接管/探活按持久化节点归属把门。
- `runtime-spawner.ts`:携带 `nodeId`。
- 测试:dispatch-stream、fleet-transport 集成(派工头持久记录归属)、runtime-spawn-lifecycle 集成(跨强制重启保持 live、真实退出码)、runtime CLI 集成。

## 门收割 / Gate Harvest

- 删除的生产路径:无;删除的门/fixture:无。

## 机读声明说明

`Production-Delta` 由 `tools/gates/production-delta.mjs --base origin/main` 实测。

## 任务与范围

- Task:`task_5450bf02bd30d0e44ef0f6ecf5`;分支 `codex/daemon-restart-liveness`;范围:daemon 重启时 runtime 接管。范围外:runtime-session 实体形状(G3a)、任何心跳机制。

## 版本影响

- 不改版本、不发布。

## 治理声明

- 未触碰受保护面;授权 `task_5450bf02bd30d0e44ef0f6ecf5`;非 break-glass。

## 验证

- 基准 `origin/main` `24bebf4c…`;本地(worker 报告):typecheck、lint、boundaries(除 GitHub token 项)、定向测试、Docker 隔离 CLI/lifecycle/fleet 套件;GitHub CI 为完整权威。

## 审查证据

- CEO 语义验收:符合 plan 的机制裁定(按归属把门接管、不加字段、不加心跳)。

## 残余风险

- 本改动前派出、没有持久化归属的 runtime 不会被任何节点接管,自行退出后结算;一次性,报告已记。

## 关联材料

- Fact `F-67DA1F98`(原始观察)、`F-8A19EF46`(修复后实测)。
