### PR TITLE
fix(kernel): identify write targets by path, fold content-addressed targets by SHA

### DIFF
--- a/packages/daemon/test/doc-sync-slice-a-implicit-lease.test.ts
+++ b/packages/daemon/test/doc-sync-slice-a-implicit-lease.test.ts
@@ -11,6 +11,38 @@ import { openBootstrappedRepoCell as openRepoCell } from "./repo-settings.fixtur
 import { realizeTaskPlanFixture } from "../../../tools/fixtures/task-plan.mjs";
 
 import { actor, git, initRepo, rows, write } from "./doc-sync-slice-a.fixtures.ts";
+test("implicit submit accepts two authored paths with identical content", async () => {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-doc-a-identical-content-"));
+  initRepo(rootDir);
+  const repoId = workspaceId("identical-content"),
+    cell = await openRepoCell({
+      repoId,
+      rootDir: canonicalRoot(rootDir),
+      ownerId: "identical-content-daemon",
+    }),
+    binding = { actor, source: "local" as const },
+    body = "# Same\n\nshared body\n";
+  try {
+    write(rootDir, "context/one.md", body);
+    write(rootDir, "context/two.md", body);
+    const submitted = (await cell.run({ kind: "doc-submit", paths: [] }, binding)) as Record<string, unknown>;
+    assert.equal(submitted.outcome, "applied", JSON.stringify(submitted));
+    assert.doesNotMatch(JSON.stringify(submitted), /duplicate write target/u);
+    const event = makeTaskEventStore({ repoId, rootDir }).readEvent(String(submitted.opId));
+    assert.equal(event?.schema, "doc-event/v1");
+    if (event?.schema === "doc-event/v1")
+      assert.deepEqual(
+        event.payload.changes.map((change) => change.path),
+        ["context/one.md", "context/two.md"],
+      );
+    assert.equal(readFileSync(path.join(rootDir, "harness/context/one.md"), "utf8"), body);
+    assert.equal(readFileSync(path.join(rootDir, "harness/context/two.md"), "utf8"), body);
+  } finally {
+    await cell.close();
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});
+
 test("implicit submit applies eligible prose and reports an unrelated blocked row as skipped", async () => {
   const rootDir = mkdtempSync(path.join(tmpdir(), "ha-doc-a-partial-blocked-"));
   initRepo(rootDir);

--- a/packages/kernel/src/domain/doc-sync-writer.ts
+++ b/packages/kernel/src/domain/doc-sync-writer.ts
@@ -23,6 +23,7 @@ import {
   freezeDeclaredWritePlan,
   isFrozenWritePlan,
   isRecord,
+  normalizeContentAddressedInputs,
   type FrozenWritePlan,
   type WriteTarget,
 } from "./write-chain.contract.ts";
@@ -251,7 +252,13 @@ export function decideDocWrite(input: DocWriteDecisionInput): DocWriteDecision {
       ...(retirementReason === undefined ? {} : { retirementReason }),
     },
   };
-  return { accepted: true, event, blobs, plan: docSyncWritePlan(event), authorizationDecision };
+  return {
+    accepted: true,
+    event,
+    blobs: normalizeContentAddressedInputs(blobs),
+    plan: docSyncWritePlan(event),
+    authorizationDecision,
+  };
 }
 
 export function docSyncWritePlan(event: DocEventV1): FrozenWritePlan<"DocSyncSubmit"> {

--- a/packages/kernel/src/domain/write-chain.contract.ts
+++ b/packages/kernel/src/domain/write-chain.contract.ts
@@ -153,6 +153,12 @@ export type WriteTarget =
     }
   | { readonly kind: "content_blob"; readonly sha256: string; readonly size: number; readonly mediaType: string }
   | { readonly kind: "local_wal_file"; readonly path: string; readonly operation: "append" | "replace" };
+export interface ContentAddressedInput {
+  readonly sha256: string;
+  readonly size: number;
+  readonly mediaType: string;
+  readonly body?: string;
+}
 export interface WritePlan<C extends string = string> {
   readonly commandType: C;
   readonly targets: readonly WriteTarget[];
@@ -361,7 +367,7 @@ function safeIdentity(value: unknown): value is string {
 }
 
 function targetKey(target: WriteTarget): string {
-  return target.kind === "event_file" || target.kind === "event_head"
+  return target.kind === "event_file" || target.kind === "event_head" || target.kind === "authored_file"
     ? `${target.kind}:${target.path}`
     : target.kind === "local_wal_file" || target.kind === "authored_file_delete"
       ? `${target.kind}:${target.path}`
@@ -370,6 +376,49 @@ function targetKey(target: WriteTarget): string {
         : target.kind === "lease_sqlite"
           ? `${target.kind}:${target.table}:${target.taskId}:${target.operation}`
           : `${target.kind}:${target.sha256}`;
+}
+
+function isContentAddressedTarget(target: WriteTarget): boolean {
+  return (
+    target.kind === "content_blob" ||
+    (target.kind === "local_wal_file" && /^\.harness\/wal\/objects\/[0-9a-f]{64}$/u.test(target.path))
+  );
+}
+
+function contentAddressedTargetConflicts(left: WriteTarget, right: WriteTarget): boolean {
+  return (
+    left.kind === "content_blob" &&
+    right.kind === "content_blob" &&
+    (left.size !== right.size || left.mediaType !== right.mediaType)
+  );
+}
+
+function normalizeWriteTargets(targets: readonly WriteTarget[]): readonly WriteTarget[] {
+  const seen = new Set<string>();
+  return targets.filter((target) => {
+    if (!isContentAddressedTarget(target)) return true;
+    const key = targetKey(target);
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
+export function normalizeContentAddressedInputs<T extends ContentAddressedInput>(inputs: readonly T[]): readonly T[] {
+  const bySha256 = new Map<string, T>();
+  for (const input of inputs) {
+    const prior = bySha256.get(input.sha256);
+    if (
+      prior !== undefined &&
+      (prior.size !== input.size || prior.mediaType !== input.mediaType || prior.body !== input.body)
+    )
+      throw new WriteChainContractError(
+        "invalid_write_plan",
+        `content address ${input.sha256} has conflicting size, media type, or body`,
+      );
+    if (prior === undefined) bySha256.set(input.sha256, input);
+  }
+  return [...bySha256.values()];
 }
 
 const WAL_SEGMENT_PATH = ".harness/wal/seg-000000.log";
@@ -412,11 +461,15 @@ export function validateDeclaredWritePlan(plan: WritePlan, commandTypes: readonl
     !plan.targets.some((target) => target.kind === "projection_invalidation")
   )
     errors.push("write plan must declare event and projection targets");
-  const keys = new Set<string>();
+  const targetsByKey = new Map<string, WriteTarget>();
   for (const target of plan.targets) {
     const key = targetKey(target);
-    if (keys.has(key)) errors.push(`duplicate write target: ${key}`);
-    keys.add(key);
+    const prior = targetsByKey.get(key);
+    if (prior !== undefined) {
+      if (!isContentAddressedTarget(target)) errors.push(`duplicate write target: ${key}`);
+      else if (contentAddressedTargetConflicts(prior, target))
+        errors.push(`conflicting content-addressed write target: ${key}`);
+    } else targetsByKey.set(key, target);
     if (
       target.kind === "event_file" &&
       (!safeWorkspacePath(target.path) ||
@@ -457,10 +510,12 @@ export function freezeDeclaredWritePlan<C extends string>(
   plan: WritePlan<C>,
   commandTypes: readonly string[],
 ): FrozenWritePlan<C> {
-  const suppliedWalTargets = plan.targets.filter(
-    (target): target is Extract<WriteTarget, { readonly kind: "local_wal_file" }> => target.kind === "local_wal_file",
+  const suppliedWalTargets = normalizeWriteTargets(
+    plan.targets.filter(
+      (target): target is Extract<WriteTarget, { readonly kind: "local_wal_file" }> => target.kind === "local_wal_file",
+    ),
   );
-  const nonWalTargets = plan.targets.filter((target) => target.kind !== "local_wal_file");
+  const nonWalTargets = normalizeWriteTargets(plan.targets.filter((target) => target.kind !== "local_wal_file"));
   const derivedWalTargets = localWalWriteTargets(nonWalTargets);
   const resolvedPlan = { commandType: plan.commandType, targets: [...nonWalTargets, ...derivedWalTargets] };
   const errors = [

--- a/packages/kernel/src/store/task-event-store-publication.ts
+++ b/packages/kernel/src/store/task-event-store-publication.ts
@@ -9,7 +9,11 @@ import {
   ledgerLayoutMigrationWritePlan,
   type LedgerLayoutMigrationEventV1,
 } from "../domain/ledger-layout-migration-event.ts";
-import { serializeEventHead } from "../domain/write-chain.contract.ts";
+import {
+  normalizeContentAddressedInputs,
+  serializeEventHead,
+  WriteChainContractError,
+} from "../domain/write-chain.contract.ts";
 import { isSettingsEvent } from "../domain/settings-event.ts";
 import { isPeopleEvent } from "../domain/people-event.ts";
 import { sha256Text, stableStringify } from "../integrity/stable-hash.ts";
@@ -167,15 +171,14 @@ export function createPublicationApi(runtime: StoreRuntime) {
       },
       ...additionalFiles,
     ];
-    const contentBySha256 = new Map<string, CanonicalEventWriteBundle["blobs"][number]>();
-    for (const member of members)
-      for (const blob of member.blobs) {
-        const prior = contentBySha256.get(blob.sha256);
-        if (prior !== undefined && prior.body !== blob.body)
-          throw new TaskEventStoreError("invalid_write_plan", `content blob ${blob.sha256} has conflicting bytes`);
-        contentBySha256.set(blob.sha256, blob);
-      }
-    const blobs = [...contentBySha256.values()],
+    let blobs: readonly CanonicalEventWriteBundle["blobs"][number][];
+    try {
+      blobs = normalizeContentAddressedInputs(members.flatMap((member) => member.blobs));
+    } catch (error) {
+      if (!(error instanceof WriteChainContractError)) throw error;
+      throw new TaskEventStoreError("invalid_write_plan", error.message);
+    }
+    const contentBySha256 = new Map(blobs.map((blob) => [blob.sha256, blob])),
       uncached = blobs.filter((blob) => !runtime.recentContent.has(blob.sha256)).map((blob) => blob.sha256);
     const existingBlobs = readBlobsAt(runtime.ledger, parent.sha, uncached);
     for (const claim of blobs) {

--- a/packages/kernel/src/store/task-event-store-validation.ts
+++ b/packages/kernel/src/store/task-event-store-validation.ts
@@ -33,6 +33,8 @@ import { assertPeopleEventInputs, isPeopleEvent } from "../domain/people-event.t
 import { assertSnapshotUpgradeInputs, isSnapshotUpgradeEvent } from "../domain/task-snapshot-upgrade-store-seam.ts";
 import {
   isFrozenWritePlan,
+  normalizeContentAddressedInputs,
+  WriteChainContractError,
   type EventHead,
   type FrozenWritePlan,
   type WriteTarget,
@@ -178,7 +180,8 @@ export function assertBundle(bundle: CanonicalEventWriteBundle): void {
   )
     throw new TaskEventStoreError("invalid_write_plan", "canonical write bundle must declare its event and head");
   assertContentInputs(claims, blobs, "canonical bundle");
-  const declaredAuthored = plan.targets.filter((target) => target.kind === "authored_file"),
+  const normalizedClaims = normalizeContentAddressedInputs(claims),
+    declaredAuthored = plan.targets.filter((target) => target.kind === "authored_file"),
     expectedAuthored: WriteTarget[] = canonicalDocumentClaims(event).map((claim) => ({
       kind: "authored_file",
       path: claim.path,
@@ -191,7 +194,7 @@ export function assertBundle(bundle: CanonicalEventWriteBundle): void {
     targetShape(declaredAuthored) !== targetShape(expectedAuthored) ||
     targetShape(plan.targets.filter((target) => target.kind === "content_blob")) !==
       targetShape(
-        claims.map((claim) => ({
+        normalizedClaims.map((claim) => ({
           kind: "content_blob",
           sha256: claim.sha256,
           size: claim.size,
@@ -266,6 +269,15 @@ export function assertContentInputs(
   }[],
   label: string,
 ): void {
+  let normalizedClaims: readonly (typeof claims)[number][];
+  let normalizedBlobs: readonly (typeof blobs)[number][];
+  try {
+    normalizedClaims = normalizeContentAddressedInputs(claims);
+    normalizedBlobs = normalizeContentAddressedInputs(blobs);
+  } catch (error) {
+    if (!(error instanceof WriteChainContractError)) throw error;
+    throw new TaskEventStoreError("invalid_write_plan", `${label} content inputs conflict for one SHA`);
+  }
   const shape = (
     items: readonly {
       readonly sha256: string;
@@ -279,8 +291,8 @@ export function assertContentInputs(
         .sort((a, b) => a.sha256.localeCompare(b.sha256)),
     );
   if (
-    shape(blobs) !== shape(claims) ||
-    blobs.some((blob) => Buffer.byteLength(blob.body) !== blob.size || sha256Text(blob.body) !== blob.sha256)
+    shape(normalizedBlobs) !== shape(normalizedClaims) ||
+    normalizedBlobs.some((blob) => Buffer.byteLength(blob.body) !== blob.size || sha256Text(blob.body) !== blob.sha256)
   )
     throw new TaskEventStoreError(
       "invalid_write_plan",

--- a/packages/kernel/src/store/wal-shadow-event-store.ts
+++ b/packages/kernel/src/store/wal-shadow-event-store.ts
@@ -1,5 +1,5 @@
 import { serializePersistedCanonicalEvent } from "../domain/doc-sync.contract.ts";
-import type { ActorIdentity, EventHead } from "../domain/write-chain.contract.ts";
+import { normalizeContentAddressedInputs, type ActorIdentity, type EventHead } from "../domain/write-chain.contract.ts";
 import { consumeKnownError } from "../error-consumption.ts";
 import { sha256Text } from "../integrity/stable-hash.ts";
 import { resolveHarnessLayout } from "../layout/index.ts";
@@ -323,7 +323,7 @@ export function makeWalShadowEventStore(options: StoreOptions): CanonicalEventSt
       // The killpoint models the gap in which a successor writer epoch can be
       // allocated. Recheck immediately before the WAL becomes authoritative.
       options.beforeAppend?.();
-      wal.append({ event: bundle.event, blobs: bundle.blobs });
+      wal.append({ event: bundle.event, blobs: normalizeContentAddressedInputs(bundle.blobs) });
       options.killpoint?.("after_event_write");
       options.killpoint?.("after_head_write");
       makeVisible(ledger, wal, pendingEvents, gitBaseline.files, bundle, options);

--- a/tools/gates/test/write-chain-contract.test.mjs
+++ b/tools/gates/test/write-chain-contract.test.mjs
@@ -8,6 +8,7 @@ import {
   issueWriterGenerationToken,
   nextRecoveryBatch,
   normalizeCommandEnvelope,
+  normalizeContentAddressedInputs,
   serializeEventEnvelope,
   serializeEventHead,
   validateNormalizedCommandEnvelope,
@@ -113,6 +114,121 @@ test("G03 derives exact local WAL declarations from canonical targets", () => {
         ["CreateReplayTask"],
       ),
     /local WAL targets must exactly derive/u,
+  );
+});
+
+test("G03 keys authored targets by path even when their content is identical", () => {
+  const sha256 = "a".repeat(64);
+  const plan = freezeDeclaredWritePlan(
+    {
+      commandType: "DocSyncSubmit",
+      targets: [
+        { kind: "event_file", path: "harness/events/op-1.json", operation: "create" },
+        { kind: "event_head", path: "harness/events/head.json", operation: "replace" },
+        { kind: "projection_invalidation", projection: "document/v1", key: "context/one.md" },
+        {
+          kind: "authored_file",
+          path: "context/one.md",
+          operation: "replace",
+          sha256,
+          size: 4,
+          mediaType: "text/plain",
+        },
+        {
+          kind: "authored_file",
+          path: "context/two.md",
+          operation: "replace",
+          sha256,
+          size: 4,
+          mediaType: "text/plain",
+        },
+      ],
+    },
+    ["DocSyncSubmit"],
+  );
+
+  assert.deepEqual(
+    plan.targets.filter((target) => target.kind === "authored_file").map((target) => target.path),
+    ["context/one.md", "context/two.md"],
+  );
+});
+
+test("G03 still rejects two authored writes to the same path", () => {
+  const authored = {
+    kind: "authored_file",
+    path: "context/one.md",
+    operation: "replace",
+    sha256: "a".repeat(64),
+    size: 4,
+    mediaType: "text/plain",
+  };
+  assert.throws(
+    () =>
+      freezeDeclaredWritePlan(
+        {
+          commandType: "DocSyncSubmit",
+          targets: [
+            { kind: "event_file", path: "harness/events/op-1.json", operation: "create" },
+            { kind: "event_head", path: "harness/events/head.json", operation: "replace" },
+            { kind: "projection_invalidation", projection: "document/v1", key: "context/one.md" },
+            authored,
+            authored,
+          ],
+        },
+        ["DocSyncSubmit"],
+      ),
+    /duplicate write target: authored_file:context\/one\.md/u,
+  );
+});
+
+test("G03 folds identical content targets and their derived WAL object target by SHA", () => {
+  const content = { kind: "content_blob", sha256: "a".repeat(64), size: 4, mediaType: "text/plain" };
+  const plan = freezeDeclaredWritePlan(
+    {
+      commandType: "DocSyncSubmit",
+      targets: [
+        { kind: "event_file", path: "harness/events/op-1.json", operation: "create" },
+        { kind: "event_head", path: "harness/events/head.json", operation: "replace" },
+        { kind: "projection_invalidation", projection: "document/v1", key: "context/one.md" },
+        content,
+        { ...content },
+      ],
+    },
+    ["DocSyncSubmit"],
+  );
+
+  assert.equal(plan.targets.filter((target) => target.kind === "content_blob").length, 1);
+  assert.equal(
+    plan.targets.filter((target) => target.kind === "local_wal_file" && target.path.includes("/objects/")).length,
+    1,
+  );
+  assert.throws(
+    () =>
+      freezeDeclaredWritePlan(
+        {
+          commandType: "DocSyncSubmit",
+          targets: [
+            ...plan.targets.filter((target) => target.kind !== "local_wal_file"),
+            { ...content, mediaType: "application/octet-stream" },
+          ],
+        },
+        ["DocSyncSubmit"],
+      ),
+    /conflicting content-addressed write target/u,
+  );
+});
+
+test("G03 folds identical blob inputs and rejects conflicting bodies for one SHA", () => {
+  const blob = {
+    sha256: "a".repeat(64),
+    size: 4,
+    mediaType: "text/plain",
+    body: "left",
+  };
+  assert.deepEqual(normalizeContentAddressedInputs([blob, { ...blob }]), [blob]);
+  assert.throws(
+    () => normalizeContentAddressedInputs([blob, { ...blob, body: "rght" }]),
+    /conflicting size, media type, or body/u,
   );
 });
 


### PR DESCRIPTION
# English

## Summary

`validateDeclaredWritePlan` keyed `authored_file` targets by content SHA, so two different paths with identical content in one write plan were rejected as `duplicate write target`; the daemon's background full `doc-submit` then failed every cycle (38 identical walls reports once drove the daemon to 90% CPU). Per decision `dec_65A68C12C7D46ECF62DF93AB77`, mutable targets are now identified by path, content-addressed targets (`content_blob`, WAL objects, blob inputs) are normalized by SHA and folded idempotently, and a same-SHA entry whose size, media type, or body conflicts rejects the whole plan.

## Architectural Justification

- The defect was a target-identity classification error. The fix corrects identity instead of adding a skip-bad-candidate layer or a retry (rejected in the decision).
- Content-addressed objects are idempotent by construction; duplicates in one plan are one write. Real conflict is exactly one shape: same content name, different content — and that still fails closed.
- The old SHA-keyed `authored_file` branch is removed in the same change; no compatibility path remains.
- Multi-node: two nodes submitting the same-SHA blob converge on one object through the center single-writer queue; the fold happens at plan validation before append.

## What Changed

- `packages/kernel/src/domain/write-chain.contract.ts`: `targetKey` by path for mutable targets, by SHA for content-addressed ones; SHA-conflict rejection.
- `packages/kernel/src/domain/doc-sync-writer.ts`, `store/task-event-store-{publication,validation}.ts`, `store/wal-shadow-event-store.ts`: blob-input / claim normalization aligned with the same identity rule.
- Tests: `tools/gates/test/write-chain-contract.test.mjs` (two paths same content OK; same path twice rejected; same-SHA blob folded; same-SHA conflicting body rejected), doc-sync implicit-lease test.
- Real-ledger check: isolated daemon `doc-submit paths:[]` with two identical authored files → 7/7 submitted, no `duplicate write target`.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none

## Machine-Readable Declarations

Production-Delta: +101/-24
Dependency-Change: none

### Optional Evidence Claims

None.

## Task And Scope

- Harness task: `task_a656383e4df7e142df29687280`; decision `dec_65A68C12C7D46ECF62DF93AB77`
- Branch: `codex/wal-dup`
- Public scope: kernel write-plan target identity and blob normalization.
- Private planning/evidence updated: yes — `artifacts/continue-report-20260830.md`, Facts `F-90C1ED93`, `F-9B047AC9`.
- Out of scope: doc-submit batch semantics, daemon scan cadence.

## Version Impact

- Version: no change. Publish impact: none.

## Governance Declaration

- Protected surface touched: no
- Authority: `task_a656383e4df7e142df29687280`, `dec_65A68C12C7D46ECF62DF93AB77`
- Break-glass: no

## Verification

- Base `origin/main`: `24bebf4c7e48c008853d4a7bd90cae06c3980b05`; branch from `origin/main`, rebase before merge if needed.
- Local (worker report): contract tests 14/14, real `doc-submit` 7/7 in Docker-isolated daemon, typecheck, lint, line-density, boundaries 38/38 (GitHub-token check excluded).
- [x] `git diff --check`
- [x] `npm run typecheck`
- [x] `npm run harness:check-import-boundaries`
- [x] `npm run harness:scan-forbidden-symbols`
- [x] `npm run harness:check-private-boundary`
- [x] `npm run harness:check-implementation-contracts`
- [ ] `npm run check` / `npm test` / others: GitHub CI is the authority.

## Review Evidence

- CEO semantic review against `dec_65A68C12` CH1–CH4: path identity, SHA fold, conflict rejection, old branch removed — all present.

## Residual Risk

- The Ubuntu isolated host was unreachable; real-ledger verification ran on the Docker isolated target of the same official entrypoint.

## References

- `dec_65A68C12C7D46ECF62DF93AB77`, Facts `F-90C1ED93` / `F-9B047AC9`.

# 中文

## 概要

`validateDeclaredWritePlan` 把 `authored_file` 按内容 SHA keying,两份不同路径、相同内容的文件在同一 write plan 里被判 `duplicate write target`;daemon 后台全量 `doc-submit` 因此每个周期都失败(38 份同内容 walls 报告曾把 daemon 顶到 90% CPU)。按 `dec_65A68C12C7D46ECF62DF93AB77`:可变目标按路径识别,内容寻址目标(`content_blob`、WAL object、blob input)按 SHA 归一化并幂等折叠,同 SHA 但 size / media type / body 冲突则拒绝整条 plan。

## 架构辩护

- 缺陷是目标身份的分类错误;修法是把身份定对,而不是加「跳过坏候选」层或重试(决策里已否决)。
- 内容寻址对象天然幂等,同 plan 内重复就是一次写;真冲突只有一种形状——同一内容名下塞了不同内容——仍 fail-closed。
- 旧的按 SHA keying `authored_file` 分支同变更删除,不留兼容路径。
- 多节点:两个节点提交同 SHA blob,经中心单写队列收敛为一个对象;折叠发生在 append 前的 plan 校验。

## 改动内容

- `write-chain.contract.ts`:`targetKey` 可变目标按路径、内容寻址按 SHA;SHA 冲突拒绝。
- `doc-sync-writer.ts`、`task-event-store-{publication,validation}.ts`、`wal-shadow-event-store.ts`:blob-input / claim 归一化对齐同一身份规则。
- 测试:`tools/gates/test/write-chain-contract.test.mjs`(两路径同内容通过;同路径两次拒绝;同 SHA blob 折叠;同 SHA 冲突正文拒绝)、doc-sync 隐式租约测试。
- 真台账:隔离 daemon 放两份同内容 authored 文件跑 `doc-submit paths:[]` → 7/7 提交成功,无 `duplicate write target`。

## 门收割 / Gate Harvest

- 删除的生产路径:无(按 SHA keying 的 `authored_file` 分支在 `write-chain.contract.ts` 内删除);删除的门/fixture:无。

## 机读声明说明

`Production-Delta` 由 `tools/gates/production-delta.mjs --base origin/main` 实测。

## 任务与范围

- Task `task_a656383e4df7e142df29687280`;decision `dec_65A68C12`;分支 `codex/wal-dup`;范围:kernel write plan 目标身份与 blob 归一化。范围外:doc-submit 批处理语义、daemon 扫描节奏。

## 版本影响

- 不改版本、不发布。

## 治理声明

- 未触碰受保护面;授权 task + decision;非 break-glass。

## 验证

- 基准 `origin/main` `24bebf4c…`;本地(worker 报告):契约测试 14/14、Docker 隔离 daemon 真 doc-submit 7/7、typecheck、lint、line-density、boundaries 38/38;GitHub CI 为完整权威。

## 审查证据

- CEO 按 dec_65A68C12 CH1–CH4 逐条核:路径身份、SHA 折叠、冲突拒绝、旧分支删除均在。

## 残余风险

- Ubuntu 隔离主机不可达,真台账验证在同一官方入口的 Docker 隔离目标完成。

## 关联材料

- `dec_65A68C12C7D46ECF62DF93AB77`;Fact `F-90C1ED93` / `F-9B047AC9`。
