### PR TITLE
docs: add harness-contributing skill as the single contribution workflow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,29 +1,23 @@
 # Contributing
 
-Harness Anything is a repo-native harness. Public code and docs live in this repository; private planning, reviews, ledgers, and generated local state must not be committed to the public package surface.
+Public contributions may change this repository's source, tests, tools, CI,
+examples, and release documentation. Keep private planning, local agent state,
+generated caches, credentials, private URLs, absolute machine paths, and
+unrelated local changes out of public commits and pull requests.
 
-## Public / Private Boundary
+## Standard workflow
 
-- Do not commit `.harness-private/**`, local agent entry files, or generated runtime/cache state.
-- Public changes belong in source, tests, examples, `docs-release/**`, or tool scripts.
-- Keep authored task evidence separate from generated projections and local worktree state.
+Install or load [`harness-contributing`](skills/harness-contributing/SKILL.md)
+in the coding agent helping with the change, and follow it from issue scope
+through worktree, tests, manifest-selected gates, the complete bilingual PR
+template, review triage, and maintainer merge. That skill is the sole executable
+contribution workflow; this page does not maintain a second copy.
 
-## Change Flow
+For explanatory background and the public issue-filing guide, start at
+[`docs-release/contributing/en/00-overview.md`](docs-release/contributing/en/00-overview.md)
+or
+[`docs-release/contributing/zh/00-overview.md`](docs-release/contributing/zh/00-overview.md).
 
-1. Branch from latest `origin/main`.
-2. Keep implementation changes scoped to the task or issue.
-3. Add or update tests for behavior changes.
-4. Run `npm run check` before requesting review.
-5. In the PR, list the verification commands and any deferred work.
-6. If you changed CLI code and use the built bin (`npx ha`), rebuild the
-   workspace dist (`npm run build -w @harness-anything/cli`); running from
-   source (`node packages/cli/src/index.ts`) is always fresh. Refresh a global
-   install only when cutting a version. Local distribution and release steps
-   live in the private harness `ci-cd-standard.md`; there is no public npm
-   publish yet.
-
-## Review Expectations
-
-- Do not mark human Dashboard confirmation from an agent.
-- Do not claim formal package release or publish readiness unless the release milestone explicitly owns it.
-- For lifecycle, projection, schema, package surface, or cutover changes, include evidence from the relevant contract tests and checker gates.
+External contributors and their agents may prepare and update a contribution
+branch and PR. They may not push to `main`, waive required CI, or merge; final
+merge authority remains with maintainers.

--- a/docs-release/contributing/en/00-overview.md
+++ b/docs-release/contributing/en/00-overview.md
@@ -1,63 +1,43 @@
 # Contributing overview
 
-Harness Anything is built for agent-shaped work, but contributions still move
-through ordinary git review, CI, and maintainer authority. A good contribution is
-not just a patch that works locally. It is a patch with a clear scope, recorded
-evidence, a reviewable PR, and no private context leaking into the public repo.
+Harness Anything accepts public contributions through ordinary git review,
+required GitHub CI, and maintainer-controlled merge. A useful contribution has
+a narrow public scope, reproducible evidence, a complete bilingual PR, and no
+private or machine-local context in its diff.
 
-This path is the contribution contract for this repository. Read it before
-opening a PR, and give it to any coding agent that helps you.
+## The workflow authority
 
-## The contribution path
+Install or load
+[`harness-contributing`](../../../skills/harness-contributing/SKILL.md) in the
+coding agent helping with the change. That skill is the repository's sole
+executable path from issue scope through worktree, tests, manifest-selected
+gates, PR-body validation, review triage, and merge handoff.
 
-1. Prepare a source checkout and use a branch or worktree.
-2. Keep the change inside one reviewable scope.
-3. Run the checks that match the scope.
-4. Open a PR with the full bilingual template.
-5. Triage review comments and CI failures.
-6. Wait for maintainer-controlled merge.
+These pages explain the reasons and boundaries around that workflow. They do
+not repeat its commands or maintain a second checklist. When wording here and a
+current machine-readable repository surface differ, follow the skill's routing
+to the live PR template, gate manifest, and package scripts.
 
-The last step matters: external contributors and their agents may propose
-changes, but they do not merge them into `main`. Merge authority stays with the
-maintainers, the repository owner, or a maintainer-authorized admin agent after
-the required gates pass.
+## Where to start
 
-## What this path covers
+- To implement an accepted issue or maintainer-approved change, start with the
+  [contribution skill](../../../skills/harness-contributing/SKILL.md).
+- To report a new public bug or documentation gap, use
+  [Filing GitHub issues](06-github-issues.md) first.
+- Before changing release or packaging claims, read
+  [Release Posture](../../release-posture.md).
 
-- [Local setup](01-local-setup.md): runtime, install posture, branch discipline,
-  and public/private file boundaries.
-- [Change flow](02-change-flow.md): how to shape a contribution so it can be
-  reviewed and tested.
-- [CI and evidence](03-ci-and-evidence.md): local commands, CI lanes, test
-  tiers, and what must be recorded in the PR.
-- [PR, review, and merge](04-pr-review-and-merge.md): the PR template, review
-  evidence, bot comment triage, and merge authority.
-- [Agent contributors](05-agent-contributors.md): rules for coding agents that
-  work on this repository.
-- [Filing GitHub issues](06-github-issues.md): how to write public issues that
-  maintainers and agents can reproduce and repair.
+## Background pages
 
-## Public scope only
+- [Local setup](01-local-setup.md) explains why the worktree and public/private
+  boundaries exist.
+- [Change flow](02-change-flow.md) records scope and architecture expectations.
+- [CI and evidence](03-ci-and-evidence.md) explains the gate authority model.
+- [PR, review, and merge](04-pr-review-and-merge.md) explains reviewer and
+  maintainer responsibilities.
+- [Agent contributors](05-agent-contributors.md) defines the agent evidence and
+  authority boundary.
 
-Public contributions belong in the public monorepo: `packages/`, `tools/`,
-`.github/`, root configuration, root README files, package README files, and
-`docs-release/`.
-
-Do not include local planning records, private evidence folders, generated
-caches, local agent entry files, credentials, absolute filesystem paths, or
-machine-specific state. If a private note helped you make a change, summarize
-the public reasoning in the PR instead of copying the private note.
-
-## Release posture
-
-The current public release posture is source checkout and package smoke, not a
-published npm package or signed desktop artifact. Before changing install,
-packaging, or release wording, read [Release Posture](../../release-posture.md)
-and keep the docs honest about what is shipped, foundation-only, and planned.
-
-## The short version
-
-Make the smallest coherent change, prove it with the right checks, fill the PR
-template honestly, and leave merge control to maintainers. If your agent cannot
-explain the scope, the verification, and the merge boundary, it is not ready to
-open the PR.
+External contributors and their agents have proposal authority. They may
+prepare and update a branch and PR, but final merge authority stays with
+maintainers.

--- a/docs-release/contributing/en/01-local-setup.md
+++ b/docs-release/contributing/en/01-local-setup.md
@@ -1,98 +1,26 @@
 # Local setup
 
-## Prerequisites
+The canonical prerequisites, clone command, and worktree sequence live in
+[Environment and worktree](../../../skills/harness-contributing/SKILL.md#environment-and-worktree).
+Use that sequence for every contribution rather than translating this page into
+a second setup recipe.
 
-Use the same baseline as the public docs:
+## Why the isolated worktree is required
 
-- Node.js 24 or newer. CI covers Node 24 and Node 26.
-- git.
-- A clean source checkout of this repository.
+The primary checkout is a coordination point, not an implementation surface.
+One contribution per worktree makes branch ownership visible, keeps concurrent
+human or agent edits separate, and makes the final public diff attributable to
+one scope. A dirty or shared worktree destroys that evidence even when the code
+itself is correct.
 
-From the repository root:
+## Public checkout boundary
 
-```bash
-npm ci
-```
+The contribution checkout may contain public source, tests, tools, CI,
+fixtures, examples, and release documentation. Local planning, agent runtime
+state, caches, credentials, private URLs, absolute machine paths, and unrelated
+changes are not contribution material. The skill's boundary and staged-diff
+checks are the operational authority for enforcing this distinction.
 
-There is no public npm package release yet. For product usage and local
-development from source, follow the install path in
-[start/install](../../start/en/01-install.md). For repository contribution, work
-from the checkout and use the workspace scripts.
-
-## Use a branch or worktree
-
-Do not edit shared `main` directly. Start from the latest upstream state:
-
-```bash
-git fetch origin
-git switch -c <branch-name> origin/main
-```
-
-Agent-authored implementation branches should use the repository convention:
-
-```bash
-git switch -c codex/<short-scope> origin/main
-```
-
-When running multiple agents or keeping local coordination separate from public
-implementation, prefer a git worktree:
-
-```bash
-git worktree add .worktrees/<short-scope> -b codex/<short-scope> origin/main
-```
-
-Each concurrent agent gets its own branch or worktree. Two agents editing the
-same working tree is treated as a coordination failure, not as a merge strategy.
-
-## Keep public and local files separate
-
-Public PRs may include repository code, tools, CI files, public docs, and
-fixtures. They must not include:
-
-- local agent entry files such as root `AGENTS.md` or `CLAUDE.md`;
-- local harness or planning records that were not intentionally made public;
-- generated cache directories;
-- editor, Finder, OS, or machine-local files;
-- secrets, tokens, private URLs, or absolute local paths.
-
-Run `git status --short` before staging. Stage only the paths that belong to the
-contribution.
-
-## Command names
-
-Use the current CLI command names:
-
-```bash
-ha <command>
-```
-
-After the 0.1 package publication to npm, the public npm command surface will also be:
-
-```bash
-npx harness-anything <command>
-```
-
-Until that release exists, treat `npx harness-anything` as forward-looking and
-use the source checkout / local `ha` path. Do not use the stale `harness` /
-`npx harness` command surface for this checkout.
-
-If you edit `packages/cli/src`, rebuild the workspace CLI before relying on the
-workspace bin:
-
-```bash
-npm run build -w @harness-anything/cli
-```
-
-While iterating on CLI behavior, running the source entrypoint directly is also
-valid:
-
-```bash
-node packages/cli/src/index.ts --json doctor
-```
-
-## Before you start coding
-
-Write down the scope in one sentence. If you cannot state what files or behavior
-the PR is allowed to change, narrow the work before editing. Contributions that
-mix implementation, release posture, unrelated cleanup, and docs rewrites are
-hard to review and likely to be sent back.
+Product installation and repository contribution are different jobs. For using
+the product from source, follow [Start / Install](../../start/en/01-install.md).
+For changing this repository, follow the contribution skill.

--- a/docs-release/contributing/en/02-change-flow.md
+++ b/docs-release/contributing/en/02-change-flow.md
@@ -1,75 +1,27 @@
 # Change flow
 
-## Start with one reviewable scope
+The executable edit, test-tier, targeted-test, and commit sequence lives in
+[Make the change and test its surface](../../../skills/harness-contributing/SKILL.md#make-the-change-and-test-its-surface)
+and
+[Commit with the contributor identity](../../../skills/harness-contributing/SKILL.md#commit-with-the-contributor-identity).
 
-A contribution should answer:
+## Reviewable scope
 
-- What problem does this solve?
-- What files or surfaces may change?
-- What is explicitly out of scope?
-- What evidence will prove the change?
+A contribution should solve one public problem and name its allowed surface,
+excluded surface, and proof. Unrelated cleanup belongs in another issue or PR
+unless it blocks the accepted change. Dependency, package, and release-adjacent
+changes need an explicit impact statement because a small textual diff may
+still change the shipped boundary.
 
-Keep unrelated cleanup out of the PR. If you find a neighboring bug, either fix
-it only when it blocks the current change or open a separate issue/PR.
+## Architecture expectations
 
-## Respect the architecture boundary
+Markdown in git is authored source; derived stores are rebuildable
+projections. Contributions must not introduce a second authored truth or bypass
+an existing load-bearing write path. Changes should stay behind current package
+boundaries and public surfaces unless the PR explains why those surfaces cannot
+carry the behavior.
 
-Harness Anything treats Markdown in git as authored source of truth and derived
-stores as rebuildable projections. Do not introduce a second source of truth for
-tasks, decisions, facts, or relations. Do not bypass the write path for
-load-bearing authored records.
-
-When changing application behavior, prefer existing package boundaries and
-public surfaces. Avoid deep imports across packages unless the current public
-surface cannot express the change and the PR explicitly explains why.
-
-## Use the existing command surface
-
-CLI changes should go through registered commands, descriptors, help text,
-receipt shapes, error codes, and tests together. A command that works but cannot
-be discovered by `--help`, cannot emit structured output, or returns an
-unregistered error shape is not finished.
-
-Every Node test added under `packages/**` or `tools/**` must declare its tier on
-the first line, for example `// harness-test-tier: integration`. Missing,
-repeated, or invalid declarations fail closed; no central file list is updated.
-
-## Docs changes
-
-Public user-facing docs live in `docs-release/`, root README files, and package
-README files. The root `docs/` directory is not the public release channel for
-this repository.
-
-Docs should describe the current release posture honestly. Do not claim a
-published npm package, signed installer, notarized build, hosted service, or
-finished GUI product unless the release posture and gates have changed first.
-
-For docs-only PRs, still treat private-boundary and path leakage checks as real
-gates. Public docs must not reveal private planning paths, local filesystem
-paths, or unpublished operating state.
-
-## Dependency and package changes
-
-Dependency, package, and release-adjacent changes have a higher review burden.
-They must preserve the current package policy unless the PR is explicitly a
-release-boundary task:
-
-- non-CLI workspace packages remain private before an explicit publish task;
-- version and publish impact must be stated in the PR;
-- package smoke and supply-chain checks may be required even when the code diff
-  looks small.
-
-## Commit discipline
-
-Commit messages stay concise and English by convention. The PR body carries the
-full bilingual explanation.
-
-Before committing:
-
-```bash
-git status --short
-git diff --check
-```
-
-Only stage files that belong to the stated scope. Do not reset, reformat, or
-stage someone else's unrelated local changes.
+CLI behavior is complete only when its registered command, descriptor, help,
+structured receipt, error contract, and relevant tests agree. Public docs live
+in `docs-release/`, root README files, and package README files, and they must
+describe the current release posture without promising an unshipped product.

--- a/docs-release/contributing/en/03-ci-and-evidence.md
+++ b/docs-release/contributing/en/03-ci-and-evidence.md
@@ -1,102 +1,30 @@
 # CI and evidence
 
-Every contribution needs evidence. Evidence is not confidence language; it is a
-command, test result, CI run, diff, review note, or reasoned "not run" entry that
-a reviewer can inspect.
+The current commands for targeted tests, manifest-selected workflow jobs, the
+narrow local GitHub-credential exception, and typecheck live in
+[Run local gates](../../../skills/harness-contributing/SKILL.md#run-local-gates).
+That section is the executable authority; this page explains what the results
+mean.
 
-## Local checks
+## Gate authority
 
-The smallest useful pre-PR loop is:
+`tools/gate-manifest.json` classifies gates by tier and maps them to GitHub
+workflow jobs. Contributors select the job that owns their changed surface and
+run it through the manifest runner. A remembered list of package scripts is not
+equivalent, because the manifest and workflow can evolve.
 
-```bash
-git diff --check
-```
+GitHub's required PR contexts remain authoritative. A local pass is evidence
+for review, not permission to waive CI. Likewise, the aggregate full-check lane
+used on `main`, schedules, or manual dispatch is not the standard pre-PR loop.
 
-For public docs changes, also run:
+## Evidence standard
 
-```bash
-npm run harness:check-private-boundary
-npm run harness:check-docs-release-map
-```
+Useful evidence names the exact command, result, scope, and any reason it was
+not run. Confidence language and a bare “not needed” are not evidence. The PR
+should make it possible for a reviewer to distinguish a passing relevant check,
+an unrelated check intentionally omitted, and a check still pending in GitHub.
 
-For package, CLI, kernel, tool, GUI, or contract changes, run the PR-sized gate:
-
-```bash
-npm run check:pr
-```
-
-Before claiming implementation readiness for broad public changes, run:
-
-```bash
-npm run check
-```
-
-If a command is not run, the PR must say exactly which command was skipped and
-why. "Not needed" is not enough; name the scope reason.
-
-## Test tiers
-
-The repository uses tiered test lanes:
-
-| Command | Use |
-| --- | --- |
-| `npm run test:fast` | Pure or near-pure behavior tests. |
-| `npm run test:contract` | Public API, schema, and cross-package contracts. |
-| `npm run test:integration` | CLI, filesystem, store, migration, and slower behavior. |
-| `npm test` | Full Node test suite. |
-| `npm run test:gui` | GUI test lane. |
-
-New Node tests under `packages/**` or `tools/**` must put exactly one valid
-`// harness-test-tier: fast|contract|integration` declaration on their first
-line. The runner rejects missing, repeated, or invalid declarations.
-
-## CI lanes
-
-Pull requests run the `rewrite-ci` workflow. Required PR signals include the
-typecheck, fast/contract, integration, boundary, package-policy, GUI build,
-Node 26 compatibility, supply-chain, and PR body lint lanes as configured by the
-repository.
-
-The full aggregate `npm run check` lane is reserved for `main`, scheduled runs,
-and manual dispatch. Do not treat a pull-request skip of the full-check job as a
-failure when the PR lanes passed by design.
-
-## Merge discipline
-
-`main` advances through GitHub's protected merge path. Do not merge a pull request into
-`main` before the required checks and reviews pass.
-
-If an emergency direct merge is explicitly approved, the person performing it is
-responsible for immediately rebasing every pull request already in the queue and
-rerunning the required gates. The emergency merge is not complete until queued
-work has a fresh base.
-
-After approval and passing required checks, enable GitHub auto-merge. GitHub
-will merge the pull request when the protected branch rules are satisfied.
-
-## Evidence in the PR
-
-The PR template asks for:
-
-- base `origin/main` SHA and merge-base;
-- last fetch time and sync method;
-- public diff command;
-- local verification commands;
-- GitHub Actions `rewrite-ci` run URL;
-- reviewer evidence and blocking findings;
-- residual risk.
-
-Fill these fields honestly. Empty verification sections slow review down because
-maintainers must reconstruct the evidence from scratch.
-
-## Failing checks
-
-When a check fails:
-
-1. Read the failure, not just the job name.
-2. Fix the PR branch.
-3. Re-run the smallest local command that proves the fix.
-4. Push normally and wait for CI again.
-
-Do not force-push or direct-push to `main` to escape a failure. A failing gate is
-part of the contribution, and resolving it is part of the work.
+When a check fails, read its output, repair the contribution branch, rerun the
+smallest proving test and affected manifest job, and let GitHub evaluate the new
+commit. A failed gate remains part of the review record; it is not a reason to
+rewrite history or bypass protection.

--- a/docs-release/contributing/en/04-pr-review-and-merge.md
+++ b/docs-release/contributing/en/04-pr-review-and-merge.md
@@ -1,83 +1,27 @@
 # PR, review, and merge
 
-## PR body format
+The canonical body-building, production-delta, bilingual-lint, PR creation,
+review-triage, and merge-handoff steps live in
+[Prepare the bilingual PR body](../../../skills/harness-contributing/SKILL.md#prepare-the-bilingual-pr-body),
+[Push and open the PR](../../../skills/harness-contributing/SKILL.md#push-and-open-the-pr),
+and [Review and merge](../../../skills/harness-contributing/SKILL.md#review-and-merge).
 
-Every public PR uses the repository template at `.github/pull_request_template.md`.
-The body must contain two complete language blocks:
+## PR contract
 
-1. `# English`
-2. `# 中文`
+The live [pull request template](../../../.github/pull_request_template.md) is
+the body authority. Its English and Chinese blocks are independently complete;
+machine-readable declarations stay in the location and format the template
+specifies. Empty or deleted sections make a contribution harder to audit even
+when a lightweight lint happens to accept them.
 
-Do not write alternating paragraph-by-paragraph translations. The English block
-is complete on its own; the Chinese block is complete on its own. The gate also
-checks the PR gate checklist.
+## Review responsibility
 
-## Required PR content
+Self-review, human review, and concrete bot comments are evidence to triage.
+They do not replace required CI, and a bot is not merge authority. Every open
+P0/P1/P2 finding must be fixed, rejected with rationale, deferred with an owner
+and reason, or left explicitly blocking before merge.
 
-Fill in:
-
-- Summary.
-- What Changed.
-- Task And Scope.
-- Version Impact.
-- Verification.
-- Review Evidence.
-- Residual Risk.
-- References.
-- PR Gate Checklist.
-
-If a section does not apply, say why. Do not delete template sections to make the
-PR look shorter.
-
-## Review evidence
-
-Review evidence includes self-review, maintainer review, human review, reviewer
-subagent output, and concrete bot comments on the PR. Treat review comments as
-inputs that must be triaged, not as automatic truth and not as noise.
-
-Any open P0/P1/P2 finding must be in one of these states before merge:
-
-- fixed;
-- explicitly false-positive with rationale;
-- deferred with owner and reason;
-- blocking.
-
-Do not merge with an untriaged release-blocking finding.
-
-## Bot comments
-
-If Codex Connect Bot, ChatGPT Codex Connector, or another review bot leaves a
-specific comment, include it in review triage. The bot is not the merge
-authority, and the bot is not a substitute for CI. It is evidence to evaluate.
-
-## Merge authority
-
-External contributors and their agents do not merge PRs into `main`.
-
-A PR may be merged only by a maintainer, the repository owner, or a
-maintainer-authorized admin agent after:
-
-- the branch is based on current `origin/main` or has been synchronized;
-- required `rewrite-ci` PR lanes are green;
-- the PR has no merge conflict;
-- the PR body and checklist are complete;
-- review evidence has been triaged;
-- no open release-blocking P0/P1/P2 finding remains.
-
-Maintainer-authorized admin merge is not a way to skip CI or review triage. It
-is a controlled merge path after the gates are satisfied.
-
-## Conflict handling
-
-If the PR has a merge conflict, fix the PR branch by merging or rebasing from
-`origin/main`, resolve the conflict, run the relevant checks again, and let CI
-rerun.
-
-Do not solve conflicts by force-pushing over `main`, direct-pushing to `main`, or
-asking an agent to bypass branch protection.
-
-## After merge
-
-Branch cleanup is maintainer-owned unless a maintainer explicitly asks the
-contributor to help. Public contribution is complete when the PR is merged or
-closed with a clear reason, not when local code happens to work.
+External contributors and their agents stop after the branch is current,
+conflict-free, green, and reviewed. A maintainer owns the normal merge-commit
+path and post-merge branch cleanup. Squash, rebase merge, direct pushes, and
+admin bypass are not the standard contribution path.

--- a/docs-release/contributing/en/05-agent-contributors.md
+++ b/docs-release/contributing/en/05-agent-contributors.md
@@ -1,81 +1,24 @@
 # Agent contributors
 
-Coding agents are welcome as implementation assistants, but they must follow the
-same public contribution contract as humans. An agent that can edit files but
-cannot respect scope, evidence, and merge authority is not ready to work on this
-repository.
+Coding agents follow the same public contribution contract as humans. Load
+[`harness-contributing`](../../../skills/harness-contributing/SKILL.md) and use
+its complete sequence; do not derive an agent-specific shortcut from this page.
 
-## Give the agent this read set
+## Agent evidence boundary
 
-At minimum, point the agent to:
+An agent should inspect current public source before editing, keep the declared
+scope visible, preserve unrelated work, and report exact commands and results.
+Its handoff must distinguish what changed, what did not, which checks passed,
+which checks were not run and why, open findings, and residual risk.
 
-- this contributing path;
-- the root README and `docs-release/`;
-- `.github/pull_request_template.md`;
-- the specific files named by the task or issue;
-- package scripts in `package.json`;
-- relevant tests next to the changed code.
+An agent may use only authority actually granted for the contribution. It must
+not expose local context, bypass generated gates, remove a failing test to make
+CI green, or claim a human review, Dashboard confirmation, release decision, or
+merge approval on someone else's behalf.
 
-For code involving a library, framework, SDK, CLI, or cloud service, the agent
-should consult current official docs rather than relying on memory.
+## Proposal authority
 
-## Agent ground rules
-
-The agent must:
-
-- state the task scope before editing;
-- work on a branch or worktree, not shared `main`;
-- inspect current code before proposing abstractions;
-- keep edits inside the stated scope;
-- use existing package boundaries and helpers;
-- run relevant checks and report exact results;
-- preserve unrelated local changes;
-- stage only files it changed for the task;
-- keep private notes, local paths, and credentials out of public diffs.
-
-The agent must not:
-
-- add compatibility shims for hypothetical users before the release boundary
-  asks for them;
-- rewrite unrelated files for style;
-- bypass generated gates or remove failing tests to make CI green;
-- open a PR with an empty verification section;
-- merge, force-push, or direct-push to `main` unless a maintainer explicitly
-  grants that authority for that exact operation.
-
-## Agent-created tasks and evidence
-
-If a maintainer asks the agent to use Harness Anything task records, the agent
-should use the current CLI:
-
-```bash
-ha task create --title "<title>" --vertical software/coding --preset standard-task
-ha task progress append <task-id> --text "<progress>"
-ha fact record --statement "<observed fact>" --source "<source>" --confidence high [--task <task-id>]
-```
-
-Do not hand-scaffold task directories. If the CLI cannot create or update the
-task package, stop and report the blocker.
-
-## Agent PR handoff
-
-Before asking for review, the agent should leave a compact handoff:
-
-- what changed;
-- what did not change;
-- commands run;
-- commands not run and why;
-- known residual risk;
-- files that need human attention.
-
-This handoff belongs in the PR body or review comment, not in private local
-notes that reviewers cannot see.
-
-## Merge boundary for agents
-
-An external contributor's agent has proposal authority only. It can create a
-branch, make commits, run checks, and open or update a PR. It cannot decide that
-the PR is allowed into `main`.
-
-Only maintainers, the owner, or a maintainer-authorized admin agent may merge,
-and only after the CI and review gates described in this path are satisfied.
+An authorized agent may prepare commits, push the contribution branch, and open
+or update its PR. It may not push to `main`, force-push to evade a failed check,
+or decide that the PR may merge. The final handoff must say plainly that merge
+remains maintainer-owned.

--- a/docs-release/contributing/en/06-github-issues.md
+++ b/docs-release/contributing/en/06-github-issues.md
@@ -104,7 +104,7 @@ template.
 
 ## After a fix
 
-The PR should reference the issue, explain the scope, include verification
-evidence, and leave merge authority with maintainers. If the fix changes the
-issue's assumptions, say that in the PR body rather than silently broadening the
-scope.
+Once an issue is accepted for implementation, continue with the repository's
+[`harness-contributing`](../../../skills/harness-contributing/SKILL.md) skill.
+If the fix changes the issue's assumptions, call that out during scope review
+instead of silently broadening the contribution.

--- a/docs-release/contributing/zh/00-overview.md
+++ b/docs-release/contributing/zh/00-overview.md
@@ -1,51 +1,35 @@
 # 贡献概览
 
-Harness Anything 是为 agent 形态的工作流设计的，但贡献仍然必须经过普通的 git
-review、CI 和 maintainer 权限。一份好的贡献不只是“本地能跑”的补丁，而是范围清楚、有
-证据、PR 可审查、并且没有把私有上下文泄漏进公开仓库的补丁。
+Harness Anything 的公开贡献经过普通 git review、GitHub required CI 和
+maintainer 控制的合入路径。合格贡献需要范围清楚、证据可复现、PR 双语正文完整，且
+公开 diff 不包含私有或机器本地上下文。
 
-这条路径是本仓库的贡献合同。开 PR 前先读它；让任何帮你开发的 coding agent 也先读它。
+## 流程权威
 
-## 贡献路径
+请在协助开发的 coding agent 中安装或加载
+[`harness-contributing`](../../../skills/harness-contributing/SKILL.md)。这份 skill
+是从 issue scope、独立 worktree、测试与 manifest gate、PR body 预检、review
+triage 到合入 handoff 的唯一可执行路径。
 
-1. 准备源码 checkout，并使用 branch 或 worktree。
-2. 把改动控制在一个可审查的范围内。
-3. 运行与范围匹配的检查。
-4. 用完整双语模板开 PR。
-5. 处理 review comment 和 CI 失败。
-6. 等 maintainer 控制的合入路径。
+本目录只解释流程背后的原因和边界，不复制命令，也不维护第二份 checklist。如果本文与
+当前机读 surface 不一致，应按 skill 的指引读取实时 PR template、gate manifest 和
+package scripts。
 
-最后一步很重要：外部贡献者和他们的 agent 可以提出改动，但不能把改动合入 `main`。
-合入权属于 maintainer、仓库 owner，或 maintainer 授权的 admin agent，并且必须在
-required gates 通过之后执行。
+## 从哪里开始
 
-## 这条路径覆盖什么
+- 实现已接受的 issue 或 maintainer 批准的改动：从
+  [贡献 skill](../../../skills/harness-contributing/SKILL.md) 开始。
+- 报告新的公开 bug 或文档缺口：先看 [提 GitHub issue](06-github-issues.md)。
+- 修改 release 或 packaging 说法前：先看
+  [Release Posture](../../release-posture.md)。
 
-- [本地准备](01-local-setup.md)：运行时、安装姿态、branch 纪律、公开/私有文件边界。
-- [改动流程](02-change-flow.md)：如何把贡献做成可审查、可测试的形状。
-- [CI 与证据](03-ci-and-evidence.md)：本地命令、CI lane、测试分层、PR 证据。
-- [PR、审查与合入](04-pr-review-and-merge.md)：PR 模板、review evidence、bot
-  comment triage、合入权限。
-- [Agent 贡献者](05-agent-contributors.md)：参与本仓开发的 coding agent 必须遵守的规则。
-- [提 GitHub issue](06-github-issues.md)：如何写出 maintainer 和 agent 都能复现、
-  修复的公开 issue。
+## 背景页面
 
-## 只进入公开范围
+- [本地准备](01-local-setup.md)：说明 worktree 和公开边界为何存在。
+- [改动流程](02-change-flow.md)：说明 scope 与架构预期。
+- [CI 与证据](03-ci-and-evidence.md)：说明 gate 权威模型。
+- [PR、审查与合入](04-pr-review-and-merge.md)：说明 reviewer 与 maintainer 责任。
+- [Agent 贡献者](05-agent-contributors.md)：说明 agent 的证据和权限边界。
 
-公开贡献应该落在公开 monorepo：`packages/`、`tools/`、`.github/`、根配置、根
-README、package README，以及 `docs-release/`。
-
-不要提交本地计划记录、私有证据目录、生成缓存、本地 agent 入口文件、凭证、绝对文件系统路径，
-或机器特有状态。如果某条私有笔记帮你做了判断，请把可公开的推理摘要写进 PR，而不是复制私有笔记。
-
-## Release 姿态
-
-当前公开 release 姿态是源码 checkout 和 package smoke，不是已发布 npm 包，也不是已签名的
-桌面产物。修改安装、打包、发布措辞前，先读
-[Release Posture](../../release-posture.md)，确保文档诚实区分 shipped、
-foundation-only 和 planned。
-
-## 简短版
-
-做一个最小且完整的改动，用正确检查证明它，如实填 PR 模板，把合入控制权留给 maintainer。
-如果你的 agent 讲不清范围、验证和合入边界，它还没准备好开 PR。
+外部贡献者及其 agent 只有 proposal authority：可以准备和更新 branch/PR，最终合入权
+属于 maintainer。

--- a/docs-release/contributing/zh/01-local-setup.md
+++ b/docs-release/contributing/zh/01-local-setup.md
@@ -1,90 +1,20 @@
 # 本地准备
 
-## 前置条件
+标准前置条件、clone 命令和 worktree 序列统一放在
+[Environment and worktree](../../../skills/harness-contributing/SKILL.md#environment-and-worktree)。
+每份贡献都直接按该序列执行，不要从本页另写一套 setup recipe。
 
-使用公开文档里的同一条基线：
+## 为什么必须使用独立 worktree
 
-- Node.js 24 或更新版本。CI 覆盖 Node 24 和 Node 26。
-- git。
-- 本仓库的干净源码 checkout。
+primary checkout 是协调点，不是实现 surface。每份贡献只占一个 worktree，可以明确
+branch ownership、隔离并发的人或 agent，并让最终公开 diff 对应单一 scope。即使代码
+本身正确，共用或已有脏改动的 worktree 也会破坏这条证据链。
 
-从仓库根目录运行：
+## 公开 checkout 边界
 
-```bash
-npm ci
-```
+贡献 checkout 可以包含公开源码、测试、工具、CI、fixture、example 和 release 文档。
+本地规划、agent runtime 状态、cache、凭证、私有 URL、本机绝对路径和无关改动都不是
+公开贡献材料。具体执行以 skill 的边界说明和 staged-diff 检查为准。
 
-目前还没有公开 npm package release。产品使用和本地源码运行见
-[start/install](../../start/zh/01-install.md)。贡献本仓代码时，从 checkout 工作并使用
-workspace scripts。
-
-## 使用 branch 或 worktree
-
-不要直接编辑共享 `main`。先基于最新 upstream：
-
-```bash
-git fetch origin
-git switch -c <branch-name> origin/main
-```
-
-Agent 写的实现分支应使用本仓约定：
-
-```bash
-git switch -c codex/<short-scope> origin/main
-```
-
-如果有多个 agent 并行，或需要把本地协调和公开实现隔离开，优先使用 git worktree：
-
-```bash
-git worktree add .worktrees/<short-scope> -b codex/<short-scope> origin/main
-```
-
-每个并发 agent 使用自己的 branch 或 worktree。两个 agent 编辑同一个 working tree 是协调
-失败，不是 merge 策略。
-
-## 分开公开文件和本地文件
-
-公开 PR 可以包含仓库代码、工具、CI 文件、公开文档和 fixture。不得包含：
-
-- 根目录本地 agent 入口文件，例如 `AGENTS.md` 或 `CLAUDE.md`；
-- 未刻意公开的本地 harness 或计划记录；
-- 生成缓存目录；
-- 编辑器、Finder、操作系统或机器本地文件；
-- secret、token、私有 URL 或本机绝对路径。
-
-stage 前先运行 `git status --short`。只 stage 属于本次贡献的路径。
-
-## 命令名
-
-使用当前 CLI 命令面：
-
-```bash
-ha <command>
-```
-
-等 0.1 package 发布到 npm 之后，公开 npm 命令面也会是：
-
-```bash
-npx harness-anything <command>
-```
-
-在发布真正存在之前，把 `npx harness-anything` 视为前瞻说明，并使用源码
-checkout / 本地 `ha` 路径。不要在这个 checkout 里使用 stale 的 `harness` /
-`npx harness` 命令面。
-
-如果改了 `packages/cli/src`，在依赖 workspace bin 前先重建 CLI：
-
-```bash
-npm run build -w @harness-anything/cli
-```
-
-迭代 CLI 行为时，也可以直接跑源码入口：
-
-```bash
-node packages/cli/src/index.ts --json doctor
-```
-
-## 开始编码前
-
-用一句话写清 scope。如果你说不清 PR 允许改哪些文件或行为，先收窄再动手。把实现、release
-姿态、无关清理和 docs 重写混在一起的贡献很难 review，也更容易被退回。
+使用产品和修改本仓库是两件事。源码使用路径见
+[Start / Install](../../start/zh/01-install.md)；修改本仓库时使用贡献 skill。

--- a/docs-release/contributing/zh/02-change-flow.md
+++ b/docs-release/contributing/zh/02-change-flow.md
@@ -1,62 +1,22 @@
 # 改动流程
 
-## 从一个可审查范围开始
+可执行的编辑、test tier、定向测试和 commit 序列统一放在
+[Make the change and test its surface](../../../skills/harness-contributing/SKILL.md#make-the-change-and-test-its-surface)
+与
+[Commit with the contributor identity](../../../skills/harness-contributing/SKILL.md#commit-with-the-contributor-identity)。
 
-一份贡献应该能回答：
+## 可审查范围
 
-- 它解决什么问题？
-- 哪些文件或 surface 可以改变？
-- 哪些明确不在范围内？
-- 什么证据能证明它成立？
+一份贡献只解决一个公开问题，并明确允许改动面、排除面和证明方式。无关清理应进入另一
+issue/PR，除非它阻塞已接受的改动。dependency、package 和 release-adjacent 改动必须
+明确说明影响，因为很小的文本 diff 也可能改变交付边界。
 
-把无关清理留在 PR 外。如果你发现旁边还有一个 bug，只有当它阻塞当前改动时才一起修；否则开独立
-issue/PR。
+## 架构预期
 
-## 尊重架构边界
+git 中的 Markdown 是 authored source，派生 store 是可重建 projection。贡献不得引入
+第二份 authored truth，也不得绕过现有承重写入路径。优先保持当前 package boundary
+和 public surface；若它们无法承载行为，PR 必须解释原因。
 
-Harness Anything 把 git 里的 Markdown 当成 authored source of truth，把派生存储当成可重建投影。
-不要为 task、decision、fact 或 relation 引入第二个 source of truth。不要绕过承重 authored
-record 的写入路径。
-
-改应用行为时，优先使用现有 package boundary 和 public surface。除非现有 public surface 无法表达本次改动，
-且 PR 明确解释原因，否则避免跨 package deep import。
-
-## 使用现有命令面
-
-CLI 改动要同时经过已注册 command、descriptor、help 文本、receipt shape、error code 和测试。
-一个命令即使能跑，如果不能通过 `--help` 被发现、不能输出结构化结果，或返回未注册错误形态，都还没完成。
-
-在 `packages/**` 或 `tools/**` 下新增 Node 测试时，必须在首行声明 tier，例如
-`// harness-test-tier: integration`。缺失、重复或非法声明一律 fail closed，不再更新中央文件清单。
-
-## 文档改动
-
-公开用户文档放在 `docs-release/`、根 README 和 package README。根 `docs/` 不是这个仓库的公开 release
-渠道。
-
-文档必须诚实描述当前 release 姿态。除非 release posture 和 gates 已先改变，否则不要声称已经有公开 npm 包、签名
-installer、notarized build、hosted service 或完整 GUI 产品。
-
-docs-only PR 也必须把 private-boundary 和路径泄漏检查当成真实 gate。公开文档不得暴露私有计划路径、本机文件系统路径或未发布的运行状态。
-
-## 依赖和 package 改动
-
-依赖、package 和 release-adjacent 改动的 review 负担更高。除非 PR 明确是 release-boundary 任务，
-否则必须保持当前 package policy：
-
-- 在明确 publish task 前，workspace packages 保持 private；
-- PR 必须说明 version 与 publish impact；
-- 即使代码 diff 很小，也可能需要 package smoke 和 supply-chain 检查。
-
-## Commit 纪律
-
-commit message 按约定保持简洁英文。完整双语解释放在 PR body。
-
-commit 前：
-
-```bash
-git status --short
-git diff --check
-```
-
-只 stage 属于本次 scope 的文件。不要 reset、重排格式或 stage 别人的无关本地改动。
+CLI 行为只有在 registered command、descriptor、help、structured receipt、error
+contract 和相关测试一致时才算完整。公开文档位于 `docs-release/`、根 README 和 package
+README，并且必须如实描述当前 release posture，不能承诺尚未交付的产品。

--- a/docs-release/contributing/zh/03-ci-and-evidence.md
+++ b/docs-release/contributing/zh/03-ci-and-evidence.md
@@ -1,90 +1,26 @@
 # CI 与证据
 
-每份贡献都需要证据。证据不是“我觉得可以”，而是 reviewer 能检查的命令、测试结果、CI run、diff、review
-note，或有理由的 “not run” 记录。
+定向测试、manifest-selected workflow job、本地 GitHub 凭证窄例外和 typecheck 的当前
+命令统一放在
+[Run local gates](../../../skills/harness-contributing/SKILL.md#run-local-gates)。
+该节是执行权威；本页只解释结果代表什么。
 
-## 本地检查
+## Gate 权威
 
-最小有用的 pre-PR loop 是：
+`tools/gate-manifest.json` 按 tier 分类 gate，并映射到 GitHub workflow job。贡献者选择
+拥有本次改动面的 job，并通过 manifest runner 执行。记忆中的 package script 列表不能
+替代 manifest，因为 manifest 和 workflow 都会演进。
 
-```bash
-git diff --check
-```
+GitHub required PR contexts 始终是权威。本地通过是 review evidence，不是跳过 CI 的
+许可。同样，给 `main`、schedule 或 manual dispatch 使用的 aggregate full-check lane
+不是标准 pre-PR loop。
 
-公开 docs 改动还要运行：
+## 证据标准
 
-```bash
-npm run harness:check-private-boundary
-npm run harness:check-docs-release-map
-```
+有效证据要写明精确命令、结果、scope，以及未运行时的原因。“有信心”和单独一句“不需要”
+都不是证据。PR 应让 reviewer 能区分：相关检查已通过、无关检查按 scope 未运行、或检查
+仍在 GitHub 等待。
 
-package、CLI、kernel、tool、GUI 或 contract 改动，运行 PR-sized gate：
-
-```bash
-npm run check:pr
-```
-
-对范围较大的公开改动声明 implementation readiness 前，运行：
-
-```bash
-npm run check
-```
-
-如果某条命令没跑，PR 必须写清哪条命令跳过、为什么跳过。“不需要”不够；要写明 scope 原因。
-
-## 测试分层
-
-仓库使用分层测试 lane：
-
-| 命令 | 用途 |
-| --- | --- |
-| `npm run test:fast` | 纯或近纯行为测试。 |
-| `npm run test:contract` | public API、schema、跨 package contract。 |
-| `npm run test:integration` | CLI、filesystem、store、migration 和较慢行为。 |
-| `npm test` | 全量 Node test suite。 |
-| `npm run test:gui` | GUI 测试 lane。 |
-
-新增 `packages/**` 或 `tools/**` Node 测试必须在首行放置恰好一个有效的
-`// harness-test-tier: fast|contract|integration` 声明。Runner 会拒绝缺失、重复或非法声明。
-
-## CI lanes
-
-Pull request 运行 `rewrite-ci` workflow。Required PR signals 包括仓库配置里的 typecheck、fast/contract、
-integration、boundary、package-policy、GUI build、Node 26 compatibility、supply-chain 和 PR body lint lanes。
-
-完整聚合 `npm run check` lane 保留给 `main`、scheduled run 和 manual dispatch。pull request 上 full-check
-job 按设计 skipped 时，不要把它当失败。
-
-## 合并纪律
-
-`main` 通过 GitHub 保护的合并路径前进。required checks 和 review 通过前不要把 pull request 合进 `main`。
-
-如果紧急情况被明确批准为直接合并，执行者负责立即 rebase 队列里已有的所有 pull request，并重新运行 required
-gates。队内工作重新基于最新 `main` 之前，这次紧急合并不算收尾完成。
-
-review 和 required checks 通过后启用 GitHub auto-merge。保护分支规则满足时，GitHub 会自动合并 pull request。
-
-## PR 里的证据
-
-PR 模板要求填写：
-
-- base `origin/main` SHA 和 merge-base；
-- 最近一次 fetch 时间和同步方式；
-- public diff command；
-- 本地验证命令；
-- GitHub Actions `rewrite-ci` run URL；
-- reviewer evidence 和 blocking findings；
-- residual risk。
-
-如实填写这些字段。空 verification section 会拖慢 review，因为 maintainer 必须从零重建证据。
-
-## 检查失败时
-
-检查失败时：
-
-1. 读失败内容，不只看 job 名字。
-2. 修 PR branch。
-3. 重跑能证明修复成立的最小本地命令。
-4. 正常 push，等待 CI 重跑。
-
-不要 force-push 或 direct-push 到 `main` 来逃避失败。失败的 gate 是贡献的一部分，解决它也是工作的一部分。
+检查失败时，阅读实际输出，修 contribution branch，重跑能证明修复的最小测试和受影响
+manifest job，再让 GitHub 检查新 commit。失败 gate 是 review record 的一部分，不能靠
+改写历史或绕过保护来消失。

--- a/docs-release/contributing/zh/04-pr-review-and-merge.md
+++ b/docs-release/contributing/zh/04-pr-review-and-merge.md
@@ -1,72 +1,23 @@
 # PR、审查与合入
 
-## PR body 格式
+标准 PR body、production delta、双语 lint、创建 PR、review triage 与 merge handoff
+步骤统一放在
+[Prepare the bilingual PR body](../../../skills/harness-contributing/SKILL.md#prepare-the-bilingual-pr-body)、
+[Push and open the PR](../../../skills/harness-contributing/SKILL.md#push-and-open-the-pr)
+和 [Review and merge](../../../skills/harness-contributing/SKILL.md#review-and-merge)。
 
-每个公开 PR 都使用 `.github/pull_request_template.md`。正文必须包含两个完整语言块：
+## PR 合同
 
-1. `# English`
-2. `# 中文`
+实时 [pull request template](../../../.github/pull_request_template.md) 是正文权威。英文块和
+中文块各自完整；机读声明必须保留在 template 指定的位置和格式。即使轻量 lint 偶然接受，
+空白或删掉的 section 仍会破坏可审计性。
 
-不要逐段交错翻译。英文块本身完整；中文块本身完整。gate 也会检查 PR gate checklist。
+## Review 责任
 
-## PR 必填内容
+self-review、human review 和具体 bot comment 都是需要 triage 的证据，不能代替 required
+CI，bot 也没有合入权。合入前，每个 open P0/P1/P2 finding 都必须已修复、带理由判为
+false positive、带 owner/理由延期，或明确保持 blocking。
 
-填写：
-
-- Summary。
-- What Changed。
-- Task And Scope。
-- Version Impact。
-- Verification。
-- Review Evidence。
-- Residual Risk。
-- References。
-- PR Gate Checklist。
-
-如果某段不适用，说明原因。不要为了让 PR 看起来更短而删除模板 section。
-
-## Review evidence
-
-Review evidence 包括自查、maintainer review、human review、reviewer subagent 输出，以及 PR 上具体的
-bot comments。把 review comments 当成必须 triage 的输入；它们既不是自动真理，也不是噪音。
-
-任何 open P0/P1/P2 finding 在合入前必须处于以下状态之一：
-
-- 已修复；
-- 明确是 false-positive，并说明理由；
-- 带 owner 和理由延后；
-- 阻塞。
-
-不要在未 triage release-blocking finding 的情况下合入。
-
-## Bot comments
-
-如果 Codex Connect Bot、ChatGPT Codex Connector 或其他 review bot 留下具体 comment，要纳入 review
-triage。bot 不是合入权威，也不能替代 CI。它是需要评估的证据。
-
-## 合入权限
-
-外部贡献者和他们的 agent 不得把 PR 合入 `main`。
-
-只有 maintainer、仓库 owner 或 maintainer 授权的 admin agent 可以合入，并且必须满足：
-
-- 分支基于当前 `origin/main`，或已经同步；
-- required `rewrite-ci` PR lanes 全绿；
-- PR 没有 merge conflict；
-- PR body 和 checklist 完整；
-- review evidence 已 triage；
-- 没有 open release-blocking P0/P1/P2 finding。
-
-maintainer 授权的 admin merge 不是跳过 CI 或 review triage 的方式。它是在 gates 满足后的受控合入路径。
-
-## 冲突处理
-
-如果 PR 有 merge conflict，在 PR branch 上 merge 或 rebase `origin/main`，解决冲突，重新运行相关检查，
-再等 CI 重跑。
-
-不要通过 force-push 覆盖 `main`、direct-push 到 `main`，或要求 agent 绕过 branch protection 来解决冲突。
-
-## 合入之后
-
-branch cleanup 归 maintainer 负责，除非 maintainer 明确要求贡献者协助。公开贡献在 PR 被合入或被清楚说明原因关闭时完成，
-不是在本地代码能跑时完成。
+外部贡献者及其 agent 在 branch 已同步、无冲突、全绿、review 完成后停下。普通 merge
+commit 和合入后 branch cleanup 由 maintainer 负责。Squash、rebase merge、直推和 admin
+bypass 都不是标准贡献路径。

--- a/docs-release/contributing/zh/05-agent-contributors.md
+++ b/docs-release/contributing/zh/05-agent-contributors.md
@@ -1,71 +1,21 @@
 # Agent 贡献者
 
-欢迎把 coding agent 当成实现助手，但 agent 必须遵守和人类一样的公开贡献合同。一个能改文件却不能遵守 scope、
-evidence 和合入权限的 agent，还没准备好在这个仓库工作。
+Coding agent 与人类遵守同一份公开贡献合同。加载
+[`harness-contributing`](../../../skills/harness-contributing/SKILL.md) 并执行完整序列；
+不要从本页推导一条 agent 专用捷径。
 
-## 给 agent 的最小读集
+## Agent 证据边界
 
-至少把这些材料交给 agent：
+agent 应在编辑前检查当前公开源码，持续显示声明 scope，保留无关改动，并报告精确命令与
+结果。handoff 必须区分改了什么、没改什么、哪些检查通过、哪些未运行及原因、open
+finding 和 residual risk。
 
-- 这套 contributing 文档；
-- root README 和 `docs-release/`；
-- `.github/pull_request_template.md`；
-- task 或 issue 点名的具体文件；
-- `package.json` 里的 package scripts；
-- changed code 旁边的相关测试。
+agent 只能使用贡献任务实际授予的权限。它不得暴露本地上下文、绕过 generated gate、
+删除失败测试来让 CI 变绿，也不得替别人声称 human review、Dashboard confirmation、
+release decision 或 merge approval。
 
-如果代码涉及 library、framework、SDK、CLI 或 cloud service，agent 应查阅当前官方文档，而不是只依赖记忆。
+## Proposal authority
 
-## Agent 基本规则
-
-agent 必须：
-
-- 编辑前说明 task scope；
-- 在 branch 或 worktree 上工作，不在共享 `main` 上工作；
-- 提抽象前先读当前代码；
-- 把编辑控制在声明范围内；
-- 使用现有 package boundary 和 helper；
-- 运行相关检查并报告精确结果；
-- 保留无关本地改动；
-- 只 stage 本任务修改的文件；
-- 不把私有笔记、本地路径或凭证放进公开 diff。
-
-agent 不得：
-
-- 在 release boundary 要求前，为假想用户加兼容 shim；
-- 为了风格重写无关文件；
-- 绕过 generated gates，或删除失败测试来让 CI 变绿；
-- 用空 verification section 开 PR；
-- merge、force-push 或 direct-push 到 `main`，除非 maintainer 对该具体操作明确授权。
-
-## Agent 创建 task 与证据
-
-如果 maintainer 要求 agent 使用 Harness Anything task records，agent 应使用当前 CLI：
-
-```bash
-ha task create --title "<title>" --vertical software/coding --preset standard-task
-ha task progress append <task-id> --text "<progress>"
-ha fact record --statement "<observed fact>" --source "<source>" --confidence high [--task <task-id>]
-```
-
-不要手工 scaffold task 目录。如果 CLI 不能创建或更新 task package，停下来报告 blocker。
-
-## Agent PR handoff
-
-请求 review 前，agent 应留下紧凑 handoff：
-
-- 改了什么；
-- 没改什么；
-- 跑了哪些命令；
-- 哪些命令没跑，为什么；
-- 已知 residual risk；
-- 需要人重点看的文件。
-
-这份 handoff 应放进 PR body 或 review comment，而不是放在 reviewer 看不到的私有本地笔记里。
-
-## Agent 的合入边界
-
-外部贡献者的 agent 只有 proposal authority。它可以建 branch、commit、跑检查、开或更新 PR。它不能决定
-PR 是否允许进入 `main`。
-
-只有 maintainer、owner 或 maintainer 授权的 admin agent 可以合入，并且必须满足这套文档里的 CI 与 review gates。
+获得授权的 agent 可以准备 commit、push contribution branch、创建或更新 PR；不能直推
+`main`、用 force-push 逃避失败检查，或自行决定 PR 可以合入。最终 handoff 必须明确说明
+merge 仍由 maintainer 控制。

--- a/docs-release/contributing/zh/06-github-issues.md
+++ b/docs-release/contributing/zh/06-github-issues.md
@@ -84,5 +84,6 @@ ha preset action github-issue-repair plan \
 
 ## 修复之后
 
-PR 应引用对应 issue，说明范围，包含验证证据，并把合入权限留给 maintainer。如果修复改变了 issue
-原来的假设，请在 PR body 里说明，不要静默扩大范围。
+issue 被接受实现后，继续执行本仓
+[`harness-contributing`](../../../skills/harness-contributing/SKILL.md) skill。如果修复改变了
+issue 原来的假设，应在 scope review 时明确说明，不要静默扩大贡献范围。

--- a/skills/harness-contributing/SKILL.md
+++ b/skills/harness-contributing/SKILL.md
@@ -1,0 +1,322 @@
+---
+name: harness-contributing
+description: Contribute a public change to Harness Anything from a GitHub issue through an isolated worktree, scoped tests, manifest-selected gates, a complete bilingual PR body, review triage, and maintainer merge. Use when a human or coding agent is preparing or updating a contribution to this repository.
+---
+
+# Harness Contributing
+
+This is the executable contribution path for this repository. Start with a
+public issue or a maintainer-approved scope, work in one isolated worktree, and
+finish with a reviewable pull request. The current
+[`tools/gate-manifest.json`](../../tools/gate-manifest.json),
+[`package.json`](../../package.json), and
+[`pull_request_template.md`](../../.github/pull_request_template.md) remain the
+machine-readable authorities they describe; inspect them instead of relying on
+remembered job names or template fields.
+
+## Boundary
+
+Use only public repository source, public issue/PR discussion, and evidence a
+reviewer may see. Never copy local planning records, generated runtime state,
+local agent instructions, credentials, private URLs, or absolute machine paths
+into the branch or PR body. Before every commit, inspect the complete staged
+diff and confirm every path belongs to the stated public scope.
+
+The contribution scope grants authority to change the stated files and run
+local checks. Push the branch or open/update its PR only when the user or
+maintainer asked for that external action. No contribution grants authority to
+push to `main`, bypass a gate, force-push, or merge. A maintainer owns the final
+merge.
+
+> 中文：只使用公开仓库、公开 issue/PR 和 reviewer 可见的证据。不要把本地规划、
+> 运行状态、凭证、私有链接或本机绝对路径放进公开 diff 或 PR。贡献者只能提交提案，
+> 不能直推或自行合入 `main`。
+
+## Environment and worktree
+
+Node.js 24 or newer and git are required. For a new checkout, run:
+
+```bash
+git clone https://github.com/FairladyZ625/harness-anything.git
+cd harness-anything
+git fetch origin
+node --version
+git status --short --branch
+```
+
+Stop if Node is older than 24 or the checkout already has changes you do not
+own. Do not implement on the primary checkout or shared `main`. From the primary
+checkout, create exactly one task worktree from current `origin/main`:
+
+```bash
+git worktree add .worktrees/<slug> -b <branch> origin/main
+cd .worktrees/<slug>
+npm ci
+git merge-base --is-ancestor origin/main HEAD
+git status --short --branch
+```
+
+Replace `<slug>` with a short filesystem-safe scope and `<branch>` with the
+public contribution branch, such as `fix/<slug>` or `docs/<slug>`. If either
+name already belongs to another worktree, choose a new name; never share that
+worktree. `git merge-base --is-ancestor` must exit zero before editing.
+
+Read the issue and relevant source in this worktree. State, in one sentence,
+the problem, allowed change surface, excluded surface, and proof required. Ask
+for a maintainer decision rather than guessing when the public issue does not
+settle a load-bearing choice.
+
+> 中文：从最新 `origin/main` 创建独立 worktree；每个贡献者或 agent 使用自己的
+> branch/worktree。先确认 Node 24+、安装依赖、写清范围，再开始编辑。
+
+## Make the change and test its surface
+
+Keep the patch to the smallest coherent solution. Inspect nearby code and tests
+before adding a new abstraction. Preserve unrelated changes and generated
+files.
+
+Every new Node test under `packages/` or `tools/` must:
+
+- have a filename ending in `.test.mjs`, `.test.js`, `.test.ts`, `.spec.mjs`,
+  `.spec.js`, or `.spec.ts`; and
+- put exactly one of these declarations on line 1:
+
+```js
+// harness-test-tier: fast
+// harness-test-tier: contract
+// harness-test-tier: integration
+```
+
+Choose `fast` for pure or near-pure behavior, `contract` for public API/schema
+or cross-package contracts, and `integration` for CLI, filesystem, store,
+migration, or other slower behavior. The rules are enforced by
+[`tools/test-tier-manifest.mjs`](../../tools/test-tier-manifest.mjs); there is no
+central file list to edit.
+
+Run each changed or newly added Node test through the repository runner:
+
+```bash
+node tools/run-node-tests.mjs --file <repo-relative-test-file>
+```
+
+Repeat `--file` for multiple exact files when they form one test surface. For a
+docs-only change, run the closest docs checker or checker test if one exists;
+do not invent a meaningless test. Always inspect the patch:
+
+```bash
+git status --short
+git diff --check
+git diff --stat
+git diff -- <changed-paths>
+```
+
+> 中文：测试文件名必须匹配 `.test`/`.spec` 约定，首行必须且只能声明一个
+> `fast|contract|integration` tier。先跑改动面的精确测试；docs-only 改动若没有
+> 对应行为测试，不要为了凑数新增无意义测试。
+
+## Run local gates
+
+Do not use `npm run check:local` as the contribution loop, and do not run the
+full aggregate merely to approximate GitHub. GitHub CI is authoritative. Run
+the exact local job surface selected from the current gate manifest, plus
+typecheck.
+
+First list the current pull-request job names and tiers:
+
+```bash
+node -e 'const m=require("./tools/gate-manifest.json"); console.log([...new Set(m.gates.filter(g=>!g.aggregate).flatMap(g=>(g.executionSurfaces?.rewriteCi?.pullRequestJobs??[]).map(job=>`${g.tier}\t${job}`)))].sort().join("\n"))'
+```
+
+Then run every job that matches the changed surface:
+
+```bash
+node tools/run-manifest-gates.mjs --workflow-job <job>
+npm run typecheck
+```
+
+`boundaries` is the usual job for public source, tool, and documentation
+boundaries. Use the manifest's other current PR jobs when the patch touches
+their surface—for example tests, package policy, dependencies/supply chain, or
+the GUI. Record every command and result in the PR body, including a scoped
+reason for anything not run.
+
+One gate has a local credential exception. If `boundaries` reaches
+`check-github-required-contexts` and fails only because no GitHub repository or
+token is available, preserve that output and rerun the same job with only that
+gate excluded:
+
+```bash
+node tools/run-manifest-gates.mjs --workflow-job boundaries --exclude check-github-required-contexts
+```
+
+Do not use that exclusion for any other failure, and never treat it as a CI
+waiver. The required GitHub context must still pass on the PR.
+
+> 中文：从 `tools/gate-manifest.json` 读取当前 job/tier，用
+> `run-manifest-gates` 跑改动面对应的 job，并始终运行 `npm run typecheck`。
+> 本地只有 `check-github-required-contexts` 可在确认确实缺 GitHub 凭证后单独排除；
+> 该排除不适用于 CI，也不能掩盖其他失败。
+
+## Commit with the contributor identity
+
+Confirm the author identity before committing:
+
+```bash
+git config --get user.name
+git config --get user.email
+```
+
+If either is empty or wrong, the contributor must set their own identity before
+continuing:
+
+```bash
+git config user.name "<your name>"
+git config user.email "<your email>"
+```
+
+Stage only named contribution paths, recheck the staged patch, and commit:
+
+```bash
+git add <changed-paths>
+git diff --cached --check
+git diff --cached --stat
+git diff --cached -- <changed-paths>
+git commit -m "<feat|fix|refactor|docs|test|ci>: <concise English summary>"
+```
+
+Do not mention an AI author in the commit message. Use the actual human or
+agent operator's configured git identity.
+
+## Prepare the bilingual PR body
+
+Do this after all contribution commits, because the production-delta gate
+measures committed `HEAD` from its merge-base. Refresh and synchronize first,
+then rerun affected tests and gates if the rebase changes the branch:
+
+```bash
+git fetch origin
+git rebase origin/main
+git rev-parse origin/main
+git merge-base origin/main HEAD
+git status --short --branch
+```
+
+Copy the current template; never reconstruct its sections from memory:
+
+```bash
+cp .github/pull_request_template.md /tmp/harness-anything-pr-body.md
+${EDITOR:-vi} /tmp/harness-anything-pr-body.md
+```
+
+Fill every uncommented section in the complete `# English` block and the
+complete `# 中文` block. Preserve their order and the shared checklist. Use
+`not applicable` plus a reason where appropriate instead of deleting a section.
+Keep machine-readable declarations exactly once and only in the English block,
+flush left as the template instructs. Do not claim CI, human review, or a test
+that has not happened.
+
+To obtain `Production-Delta`, replace the template's `N` and `M` with zero as a
+provisional declaration, run the authoritative calculator, replace it with the
+printed `+N/-M`, and run again until it passes:
+
+```bash
+node tools/gates/production-delta.mjs --base origin/main --pr-body-file /tmp/harness-anything-pr-body.md
+${EDITOR:-vi} /tmp/harness-anything-pr-body.md
+node tools/gates/production-delta.mjs --base origin/main --pr-body-file /tmp/harness-anything-pr-body.md
+```
+
+For a docs-only branch this is normally `Production-Delta: +0/-0`; never assume
+that value for a source change. If production churn exceeds 200 lines or net
+growth exceeds +300, fill both architectural-justification sections.
+
+Preflight the two complete language blocks through the requested environment
+interface, then run the manifest's full PR-body job:
+
+```bash
+export PR_BODY="$(cat /tmp/harness-anything-pr-body.md)"
+node tools/check-pr-body-bilingual.mjs --env PR_BODY
+export PR_BASE_SHA="$(git merge-base origin/main HEAD)"
+export PR_HEAD_SHA="$(git rev-parse HEAD)"
+node tools/run-manifest-gates.mjs --workflow-job pr-body-lint
+unset PR_BODY PR_BASE_SHA PR_HEAD_SHA
+```
+
+[`references/example-pr-body.md`](references/example-pr-body.md) is a completed
+docs-only example that exercises every section. It is a fixture, not a template:
+always copy the live repository template for a real PR.
+
+> 中文：所有 commit 完成后再计算 `Production-Delta`。PR body 必须保留模板的完整
+> 英文块、完整中文块和共享 checklist；机读声明只在英文块顶格出现一次。不得把未发生
+> 的 CI、人工 review 或测试写成已完成。
+
+## Push and open the PR
+
+Push only the contribution branch to a remote where the contributor has write
+access:
+
+```bash
+git push -u <write-remote> HEAD
+```
+
+With an authenticated GitHub CLI, open the PR against the canonical `main`:
+
+```bash
+gh auth status
+gh pr create --repo FairladyZ625/harness-anything --base main --head <github-user>:<branch> --title "<PR title>" --body-file /tmp/harness-anything-pr-body.md
+```
+
+If the branch is in the canonical repository rather than a fork, use
+`--head <branch>`. Save the PR URL. Update the body rather than replacing it
+with a shorter hand-written summary when later commits change scope or delta.
+
+## Review and merge
+
+Watch the protected checks and read the actual failure output:
+
+```bash
+gh pr checks <pr-number> --repo FairladyZ625/harness-anything --watch
+gh pr view <pr-number> --repo FairladyZ625/harness-anything --comments
+```
+
+Triage every concrete reviewer or bot finding. Before merge, each P0/P1/P2
+finding must be fixed, explained as a false positive, deferred with an owner and
+reason, or left explicitly blocking. For a fix, edit the same worktree, rerun
+the smallest proving test and affected manifest jobs, make another prefixed
+commit, push normally, and update the PR body and `Production-Delta`. Never
+force-push to escape a failed check.
+
+External contributors and their agents stop after the PR is green, current,
+conflict-free, and fully reviewed. A maintainer performs the repository's normal
+merge-commit path; only that maintainer may run:
+
+```bash
+gh pr merge <pr-number> --repo FairladyZ625/harness-anything --merge --delete-branch
+```
+
+Do not squash, rebase-merge, direct-push, or use an admin bypass. The
+contribution is complete when GitHub reports the PR merged or closed with a
+clear reason.
+
+> 中文：逐条处理 CI、human review 和 bot comment；P0/P1/P2 必须完成 triage。
+> 外部贡献者或 agent 在 PR 全绿、无冲突、review 完成后停下，由 maintainer 用普通
+> merge commit 合入。不得 squash、rebase merge、直推或 admin bypass。
+
+## Agent contributor notes
+
+An agent follows the same path and evidence standard as a human. It must keep
+the declared scope visible, preserve unrelated work, show exact commands and
+results, and leave external actions such as pushing or opening a PR within the
+user's granted authority. It must not report human review, Dashboard
+confirmation, release readiness, or merge approval on anyone else's behalf.
+
+Before handoff, report:
+
+- what changed and what stayed out of scope;
+- exact tests and manifest jobs run, with pass/fail results;
+- commands not run and the scoped reason;
+- the production delta and PR-body preflight result;
+- open findings, residual risk, and the files needing human attention; and
+- that merge remains maintainer-owned.
+
+> 中文：agent 必须保留无关改动、如实报告命令结果，且不能替人声称人工确认、发布
+> 就绪或合入批准。handoff 要写清改动、验证、未跑项、风险和 maintainer 合入边界。

--- a/skills/harness-contributing/SKILL.md
+++ b/skills/harness-contributing/SKILL.md
@@ -40,34 +40,52 @@ Node.js 24 or newer and git are required. For a new checkout, run:
 git clone https://github.com/FairladyZ625/harness-anything.git
 cd harness-anything
 git fetch origin
-node --version
 git status --short --branch
 ```
 
-Stop if Node is older than 24 or the checkout already has changes you do not
-own. Do not implement on the primary checkout or shared `main`. From the primary
+Run this version gate as one standalone command before `npm ci`; it exits
+nonzero and prints three common activation choices when the active Node is too
+old:
+
+```bash
+node -e 'const major=Number(process.versions.node.split(".")[0]); if (major < 24) { console.error([`Node.js 24+ required; found ${process.version}.`, "nvm: nvm install 24 && nvm use 24", `Homebrew node@24: brew install node@24 && export PATH="$(brew --prefix node@24)/bin:$PATH"`, "Volta: volta install node@24"].join("\n")); process.exit(1); } console.log(`Node.js ${process.version} satisfies >=24`);'
+```
+
+If it fails, use one printed line to activate Node 24, then rerun the same gate
+until it exits zero. Stop if the checkout already has changes you do not own.
+Do not implement on the primary checkout or shared `main`. From the primary
 checkout, create exactly one task worktree from current `origin/main`:
 
 ```bash
 git worktree add .worktrees/<slug> -b <branch> origin/main
 cd .worktrees/<slug>
-npm ci
 git merge-base --is-ancestor origin/main HEAD
+git rev-list --count origin/main..HEAD
+git log --oneline origin/main..HEAD
 git status --short --branch
+npm ci
 ```
 
 Replace `<slug>` with a short filesystem-safe scope and `<branch>` with the
 public contribution branch, such as `fix/<slug>` or `docs/<slug>`. If either
 name already belongs to another worktree, choose a new name; never share that
-worktree. `git merge-base --is-ancestor` must exit zero before editing.
+worktree. `git merge-base --is-ancestor` must exit zero before editing. A newly
+created branch should print `0` from `git rev-list` and no commit lines from
+`git log`. Any listed commit is already part of the prospective
+`origin/main...HEAD` PR delta: continue only when it belongs to the approved
+public contribution, and later describe the whole branch delta while clearly
+distinguishing those pre-existing commits from the edits made in this run.
+Otherwise stop and create a clean worktree or ask the maintainer which branch
+scope is intended.
 
 Read the issue and relevant source in this worktree. State, in one sentence,
 the problem, allowed change surface, excluded surface, and proof required. Ask
 for a maintainer decision rather than guessing when the public issue does not
 settle a load-bearing choice.
 
-> 中文：从最新 `origin/main` 创建独立 worktree；每个贡献者或 agent 使用自己的
-> branch/worktree。先确认 Node 24+、安装依赖、写清范围，再开始编辑。
+> 中文：先用单独的一条可执行命令确认 Node 24+，再从最新 `origin/main` 创建独立
+> worktree；每个贡献者或 agent 使用自己的 branch/worktree。编辑前列出 ahead
+> commit；它们会进入整个 PR diff，不能当作不存在。安装依赖并写清范围后再编辑。
 
 ## Make the change and test its surface
 
@@ -127,6 +145,13 @@ First list the current pull-request job names and tiers:
 node -e 'const m=require("./tools/gate-manifest.json"); console.log([...new Set(m.gates.filter(g=>!g.aggregate).flatMap(g=>(g.executionSurfaces?.rewriteCi?.pullRequestJobs??[]).map(job=>`${g.tier}\t${job}`)))].sort().join("\n"))'
 ```
 
+Then print the gate IDs, commands, and declared consumer scope behind those
+jobs; use this output rather than inferring a job from its name:
+
+```bash
+node -e 'const m=require("./tools/gate-manifest.json"); for (const g of m.gates.filter(g=>!g.aggregate)) for (const job of g.executionSurfaces?.rewriteCi?.pullRequestJobs??[]) console.log(`${job}\t${g.id}\t${g.command}\t${(g.consumerScope??[]).join("; ")}`)'
+```
+
 Then run every job that matches the changed surface:
 
 ```bash
@@ -141,21 +166,27 @@ the GUI. Record every command and result in the PR body, including a scoped
 reason for anything not run.
 
 One gate has a local credential exception. If `boundaries` reaches
-`check-github-required-contexts` and fails only because no GitHub repository or
-token is available, preserve that output and rerun the same job with only that
-gate excluded:
+`check-github-required-contexts`, the only failure that may be excluded locally
+is the exact error `repository must be provided as owner/name` when no GitHub
+repository/token context is available. Preserve that output and rerun the same
+job with only that gate excluded:
 
 ```bash
 node tools/run-manifest-gates.mjs --workflow-job boundaries --exclude check-github-required-contexts
 ```
 
-Do not use that exclusion for any other failure, and never treat it as a CI
-waiver. The required GitHub context must still pass on the PR.
+If that exact message is not the sole failure, do not exclude the gate. Never
+treat the exclusion as a CI waiver; the required GitHub context must still pass
+on the PR. A `boundaries` run currently takes about 45 seconds locally. The
+runner stops at the first failure and cannot resume, so the permitted exclusion
+rerun starts the selected job again from its first command.
 
 > 中文：从 `tools/gate-manifest.json` 读取当前 job/tier，用
 > `run-manifest-gates` 跑改动面对应的 job，并始终运行 `npm run typecheck`。
-> 本地只有 `check-github-required-contexts` 可在确认确实缺 GitHub 凭证后单独排除；
-> 该排除不适用于 CI，也不能掩盖其他失败。
+> 本地只有 `check-github-required-contexts` 的精确报错
+> `repository must be provided as owner/name` 可在确认缺 GitHub 上下文后单独排除；
+> 该排除不适用于 CI，也不能掩盖其他失败。`boundaries` 当前约需 45 秒，失败后不能
+> 从断点续跑。
 
 ## Commit with the contributor identity
 
@@ -195,11 +226,17 @@ then rerun affected tests and gates if the rebase changes the branch:
 
 ```bash
 git fetch origin
+date -u '+%Y-%m-%d %H:%M:%S UTC'
 git rebase origin/main
 git rev-parse origin/main
 git merge-base origin/main HEAD
 git status --short --branch
 ```
+
+Put the `date -u` output in `Last git fetch origin time`. If the initial
+worktree check found approved pre-existing commits, describe the complete
+`origin/main...HEAD` delta in the PR body and explicitly separate those commits
+from the changes authored in the current run.
 
 Copy the current template; never reconstruct its sections from memory:
 
@@ -214,6 +251,34 @@ complete `# 中文` block. Preserve their order and the shared checklist. Use
 Keep machine-readable declarations exactly once and only in the English block,
 flush left as the template instructs. Do not claim CI, human review, or a test
 that has not happened.
+
+For an external contributor, fill `Harness task` in both language blocks with
+the public issue number, for example `#1234`; if there is no public issue, write
+`not applicable`. Never put a private task ID, local planning ID, or private
+evidence path in the public PR body. If neither `package.json` nor
+`package-lock.json` changed, delete the entire `Dependency-Change:` line; do not
+leave `Dependency-Change: none`. Keep and fully describe that line only when one
+of those dependency files changed.
+
+In the Verification checklist, check an item only when its exact command exited
+zero, either because you ran it directly or because the manifest runner printed
+that command and reported it passed. A passing current `boundaries` job
+indirectly runs these checklist items:
+
+- `npm run harness:check-import-boundaries`
+- `npm run harness:scan-forbidden-symbols`
+- `npm run harness:check-private-boundary`
+- `npm run harness:check-implementation-contracts`
+- `npm run harness:check-schema-contracts`
+- `npm run harness:check-legacy-intake-readiness`
+
+Check those items only when all appear as passed in the runner output. Do not
+infer that `npm run check`, `npm test`,
+`npm run harness:check-package-policy`, or
+`npm run harness:smoke-cli-package` ran as part of `boundaries`; leave each
+unchecked unless that exact command actually passed. Record the top-level
+manifest command and any allowed exclusion in the surrounding Verification
+text.
 
 To obtain `Production-Delta`, replace the template's `N` and `M` with zero as a
 provisional declaration, run the authoritative calculator, replace it with the
@@ -246,8 +311,10 @@ docs-only example that exercises every section. It is a fixture, not a template:
 always copy the live repository template for a real PR.
 
 > 中文：所有 commit 完成后再计算 `Production-Delta`。PR body 必须保留模板的完整
-> 英文块、完整中文块和共享 checklist；机读声明只在英文块顶格出现一次。不得把未发生
-> 的 CI、人工 review 或测试写成已完成。
+> 英文块、完整中文块和共享 checklist；机读声明只在英文块顶格出现一次。外部贡献者的
+> `Harness task` 只填公开 issue 号，没有就填 `not applicable`，不要放私有 ID；无依赖
+> 文件变化时删除整条 `Dependency-Change:`。checklist 只勾选直接通过、或由 runner
+> 明确打印并通过的命令。不得把未发生的 CI、人工 review 或测试写成已完成。
 
 ## Push and open the PR
 

--- a/skills/harness-contributing/references/example-pr-body.md
+++ b/skills/harness-contributing/references/example-pr-body.md
@@ -1,0 +1,218 @@
+# English
+
+## Summary
+
+Document the repository's contribution workflow through one public skill and
+make the public entry pages point to that authority.
+
+## Architectural Justification
+
+- Not required: this example has no production-source churn.
+
+## What Changed
+
+- Added a public contribution skill and replaced duplicated procedural prose
+  with links to that skill.
+
+## Gate Harvest / 门收割
+
+Deleted-Production-Paths: none
+Deleted-Gates-Fixtures: none
+- Production net lines: the declaration below is calculator-backed.
+
+## Machine-Readable Declarations
+
+Production-Delta: +0/-0
+
+### Optional Evidence Claims
+
+- None. This example makes no CI-attribution or performance claim.
+
+## Task And Scope
+
+- Harness task: not applicable to this external public example
+- Branch: `docs/contributing-smoke`
+- Public scope: contribution skill and public contributing pages
+- Private planning/evidence updated: not applicable
+- Out of scope: source behavior, gate policy, and CI configuration
+
+## Version Impact
+
+- Version: no version change because this is documentation only
+- Publish impact: no publish
+
+## Governance Declaration
+
+- Protected surface touched: no
+- Protected surface scope: not applicable
+- Authority: not applicable
+- Machine-check boundary: the declaration exists; reviewers decide whether it is sufficient.
+- Break-glass: no
+- Break-glass reason: not applicable
+- Break-glass scope: not applicable
+- Follow-up governance task: not applicable
+
+## Verification
+
+- Base `origin/main` SHA: `b0a9b74fd921ada93f6854d10bf1ff116725f482`
+- Branch merge-base with `origin/main`: `b0a9b74fd921ada93f6854d10bf1ff116725f482`
+- Last `git fetch origin` time: 2026-08-30 UTC
+- Sync method: none needed
+- Public diff command: `git diff --stat origin/main...HEAD`
+- Private evidence commit/path: not applicable
+- Reviewer evidence path: this PR's review thread
+- GitHub Actions `rewrite-ci` run URL: pending until the PR is opened
+- [x] `npm ci`
+- [x] `git diff --check`
+- [ ] `npm run check`
+- [x] `npm run typecheck`
+- [ ] `npm test`
+- [ ] `npm run harness:check-import-boundaries`
+- [ ] `npm run harness:scan-forbidden-symbols`
+- [ ] `npm run harness:check-private-boundary`
+- [ ] `npm run harness:check-package-policy`
+- [ ] `npm run harness:check-implementation-contracts`
+- [ ] `npm run harness:check-schema-contracts`
+- [ ] `npm run harness:check-legacy-intake-readiness`
+- [ ] `npm run harness:smoke-cli-package`
+- [ ] GitHub Actions `rewrite-ci` passed
+- Not run: the full aggregate and unrelated package/source commands; the
+  manifest-selected `boundaries` job and typecheck cover this docs example,
+  while GitHub CI remains authoritative.
+
+## Review Evidence
+
+- Self-review: checked scope, links, commands, bilingual structure, and public-only wording
+- Reviewer subagent: not used
+- Human review: pending on the PR
+- Blocking findings: none at handoff
+
+## Residual Risk
+
+- The live PR template or gate manifest may change; contributors must read both
+  from their current branch instead of copying this example.
+
+## References
+
+- Task: public contribution workflow documentation
+- Evidence: local command results recorded in Verification
+- Review: PR review thread when opened
+
+---
+
+# 中文
+
+## 概要
+
+用一份公开 skill 记录本仓唯一贡献流程，并让公开入口页引用这份权威说明。
+
+## 架构辩护
+
+- 不需要：这个示例没有生产源码增删。
+
+## 改动内容
+
+- 新增公开贡献 skill，并把重复的流程文字替换为指向该 skill 的链接。
+
+## 门收割 / Gate Harvest
+
+- 删除的生产路径：无。
+- 同 commit 删除的门 / fixture：无。
+- 生产净行数：引用英文块中由工具计算的唯一声明。
+
+## 机读声明说明
+
+- 英文块中的 `Production-Delta` 是唯一机读生产增删声明。
+- 本示例没有依赖变化，也没有保留旧生产路径。
+- 无；本示例不声明 CI 归因或性能证据。
+
+## 任务与范围
+
+- Harness 任务：外部公开示例不适用
+- 分支：`docs/contributing-smoke`
+- 公开范围：贡献 skill 与公开贡献入口页
+- 私有计划 / 证据是否已更新：不适用
+- 范围外：源码行为、gate policy 与 CI 配置
+
+## 版本影响
+
+- 版本：纯文档改动，不修改版本
+- 发布影响：不发布
+
+## 治理声明
+
+- 是否触碰 protected surface：否
+- protected surface 范围：不适用
+- 依据：不适用
+- 机器检查边界：本段声明存在，是否充分由 reviewer 判断。
+- Break-glass：否
+- Break-glass 原因：不适用
+- Break-glass 范围：不适用
+- 后续治理任务：不适用
+
+## 验证
+
+- `origin/main` 基准 SHA：`b0a9b74fd921ada93f6854d10bf1ff116725f482`
+- 当前分支与 `origin/main` 的 merge-base：`b0a9b74fd921ada93f6854d10bf1ff116725f482`
+- 最近一次 `git fetch origin` 时间：2026-08-30 UTC
+- 同步方式：不需要
+- 公开 diff 命令：`git diff --stat origin/main...HEAD`
+- 私有证据 commit/path：不适用
+- Reviewer 证据路径：本 PR 的 review thread
+- GitHub Actions `rewrite-ci` run URL：PR 创建后补充
+- [x] `npm ci`
+- [x] `git diff --check`
+- [ ] `npm run check`
+- [x] `npm run typecheck`
+- [ ] `npm test`
+- [ ] `npm run harness:check-import-boundaries`
+- [ ] `npm run harness:scan-forbidden-symbols`
+- [ ] `npm run harness:check-private-boundary`
+- [ ] `npm run harness:check-package-policy`
+- [ ] `npm run harness:check-implementation-contracts`
+- [ ] `npm run harness:check-schema-contracts`
+- [ ] `npm run harness:check-legacy-intake-readiness`
+- [ ] `npm run harness:smoke-cli-package`
+- [ ] GitHub Actions `rewrite-ci` passed
+- 未运行：未跑完整聚合及无关 package/source 命令；本 docs 示例运行 manifest
+  选择的 `boundaries` job 与 typecheck，最终以 GitHub CI 为准。
+
+## 审查证据
+
+- 自查：已检查 scope、链接、命令、双语结构和公开边界
+- Reviewer subagent：未使用
+- 人工审查：等待 PR review
+- 阻塞发现：handoff 时无
+
+## 残余风险
+
+- 实际 PR template 或 gate manifest 可能变化；贡献者必须读取当前 branch 的文件，
+  不能直接复制本示例。
+
+## 关联材料
+
+- 任务：公开贡献流程文档
+- 证据：Verification 中记录的本地命令结果
+- 审查：PR 创建后的 review thread
+
+---
+
+## PR Gate Checklist / PR 门禁清单
+
+- [x] Branch is based on latest `origin/main`. / 分支基于最新 `origin/main`。
+- [x] PR body uses this full template structure. / PR 描述使用本模板完整结构。
+- [x] PR body uses two complete language blocks: `# English` first, then `# 中文`. / PR 正文使用两块完整正文：`# English` 在上，`# 中文` 在下。
+- [x] PR body passes `tools/check-pr-body-bilingual.mjs`. / PR 正文通过 `tools/check-pr-body-bilingual.mjs`。
+- [x] If the PR touches a manifest-derived protected surface, Governance Declaration is filled with authority evidence or break-glass fields. / 若 PR 触碰 manifest 派生的 protected surface，Governance Declaration 已填写依据或 break-glass 字段。
+- [x] No private files are included. / 不包含私有文件。
+- [x] No ignored local agent entry files are included. / 不包含被忽略的本地 agent 入口文件。
+- [x] No absolute local filesystem paths are included in this public PR body. / 本公开 PR 描述不包含本机绝对路径。
+- [x] Public diff is limited to the stated task scope. / 公开 diff 限于声明的任务范围。
+- [x] Private planning/evidence updates are recorded when applicable. / 适用时已记录私有计划 / 证据更新。
+- [x] Version and publish impact are stated. / 已说明版本与发布影响。
+- [x] Local verification commands are recorded honestly. / 已如实记录本地验证命令。
+- [x] CI results are linked or explained. / CI 结果已链接或说明。
+- [x] Review evidence is recorded. / 已记录审查证据。
+- [x] Open P0/P1/P2 findings are closed, deferred with owner, or explicitly blocked. / open P0/P1/P2 findings 已关闭、带 owner 延后，或明确阻塞。
+- [x] Merge method and post-merge branch cleanup plan are clear. / 合并方式和合并后分支清理计划清楚。
+- [x] No admin bypass is planned unless explicitly approved and recorded. / 除非明确批准并记录，否则不计划 admin bypass。

--- a/skills/harness-contributing/references/example-pr-body.md
+++ b/skills/harness-contributing/references/example-pr-body.md
@@ -30,7 +30,7 @@ Production-Delta: +0/-0
 
 ## Task And Scope
 
-- Harness task: not applicable to this external public example
+- Harness task: not applicable; this external example has no public issue
 - Branch: `docs/contributing-smoke`
 - Public scope: contribution skill and public contributing pages
 - Private planning/evidence updated: not applicable
@@ -67,18 +67,19 @@ Production-Delta: +0/-0
 - [ ] `npm run check`
 - [x] `npm run typecheck`
 - [ ] `npm test`
-- [ ] `npm run harness:check-import-boundaries`
-- [ ] `npm run harness:scan-forbidden-symbols`
-- [ ] `npm run harness:check-private-boundary`
+- [x] `npm run harness:check-import-boundaries`
+- [x] `npm run harness:scan-forbidden-symbols`
+- [x] `npm run harness:check-private-boundary`
 - [ ] `npm run harness:check-package-policy`
-- [ ] `npm run harness:check-implementation-contracts`
-- [ ] `npm run harness:check-schema-contracts`
-- [ ] `npm run harness:check-legacy-intake-readiness`
+- [x] `npm run harness:check-implementation-contracts`
+- [x] `npm run harness:check-schema-contracts`
+- [x] `npm run harness:check-legacy-intake-readiness`
 - [ ] `npm run harness:smoke-cli-package`
 - [ ] GitHub Actions `rewrite-ci` passed
-- Not run: the full aggregate and unrelated package/source commands; the
-  manifest-selected `boundaries` job and typecheck cover this docs example,
-  while GitHub CI remains authoritative.
+- Not run: the full aggregate, `npm test`, package-policy, smoke CLI, and other
+  unrelated jobs. The manifest-selected `boundaries` job ran and passed the six
+  checked `harness:*` commands indirectly; typecheck passed directly, while
+  GitHub CI remains authoritative.
 
 ## Review Evidence
 
@@ -128,7 +129,7 @@ Production-Delta: +0/-0
 
 ## 任务与范围
 
-- Harness 任务：外部公开示例不适用
+- Harness 任务：不适用；此外部示例没有公开 issue
 - 分支：`docs/contributing-smoke`
 - 公开范围：贡献 skill 与公开贡献入口页
 - 私有计划 / 证据是否已更新：不适用
@@ -165,17 +166,18 @@ Production-Delta: +0/-0
 - [ ] `npm run check`
 - [x] `npm run typecheck`
 - [ ] `npm test`
-- [ ] `npm run harness:check-import-boundaries`
-- [ ] `npm run harness:scan-forbidden-symbols`
-- [ ] `npm run harness:check-private-boundary`
+- [x] `npm run harness:check-import-boundaries`
+- [x] `npm run harness:scan-forbidden-symbols`
+- [x] `npm run harness:check-private-boundary`
 - [ ] `npm run harness:check-package-policy`
-- [ ] `npm run harness:check-implementation-contracts`
-- [ ] `npm run harness:check-schema-contracts`
-- [ ] `npm run harness:check-legacy-intake-readiness`
+- [x] `npm run harness:check-implementation-contracts`
+- [x] `npm run harness:check-schema-contracts`
+- [x] `npm run harness:check-legacy-intake-readiness`
 - [ ] `npm run harness:smoke-cli-package`
 - [ ] GitHub Actions `rewrite-ci` passed
-- 未运行：未跑完整聚合及无关 package/source 命令；本 docs 示例运行 manifest
-  选择的 `boundaries` job 与 typecheck，最终以 GitHub CI 为准。
+- 未运行：未跑完整聚合、`npm test`、package-policy、smoke CLI 及其他无关 job。
+  manifest 选择的 `boundaries` job 间接运行并通过了上面勾选的六条 `harness:*`
+  命令；typecheck 是直接运行并通过，最终以 GitHub CI 为准。
 
 ## 审查证据
 

--- a/tools/skill-contracts.test.mjs
+++ b/tools/skill-contracts.test.mjs
@@ -15,7 +15,7 @@ test("repository skills are discoverable with agent metadata", () => {
     .map((entry) => entry.name)
     .sort();
 
-  assert.deepEqual(skillNames, ["harness-install", "harness-migration", "preset-creator", "preset-trigger", "vertical-creator"]);
+  assert.deepEqual(skillNames, ["harness-contributing", "harness-install", "harness-migration", "preset-creator", "preset-trigger", "vertical-creator"]);
   for (const skillName of ["harness-install", "harness-migration", "preset-trigger"]) {
     assert.equal(existsSync(path.join(skillsRoot, skillName, "SKILL.md")), true, skillName);
     assert.equal(existsSync(path.join(skillsRoot, skillName, "agents", "openai.yaml")), true, skillName);


### PR DESCRIPTION
# English

## Summary

Adds `skills/harness-contributing/SKILL.md`, the single executable contribution path for external contributors and their coding agents: public/private boundary, Node 24 gate, isolated worktree, scoped tests with tier markers, manifest-selected local gates, the bilingual PR template with a computed `Production-Delta`, review triage, and maintainer merge. `CONTRIBUTING.md` becomes an entry page that points to the skill; `docs-release/contributing/{en,zh}` keep background and issue-filing guidance and drop their duplicated step lists. A validated example PR body ships under `references/`.

## Architectural Justification

- The July `CONTRIBUTING.md` (29 lines) no longer matched the actual flow (26-section bilingual template, gate manifest, production-delta declaration, test tier markers, worktree discipline). One process, one authority: the skill is executable, the docs reference it, nothing is maintained twice.
- Every command in the skill was run in a fresh worktree before being written down; a zero-context agent then completed a minimal contribution (one docs sentence → gates → commit → lint-passing PR body) in 8m24s using only the skill, and its 12 friction points were folded back in (machine-executable Node gate, pre-existing-commit detection, the exact GitHub-context error text that may be excluded, `Dependency-Change` rule, direct-vs-runner checklist semantics, public-issue-only task line, fetch timestamp).
- Boundary is enforced by content, not by trust: the skill references only public repository sources; a leak scan for private paths/ids over the changed files is 0.

## What Changed

- New: `skills/harness-contributing/SKILL.md` (+ `references/example-pr-body.md`), synced by `tools/sync-runtime-skills.mjs`.
- `CONTRIBUTING.md`: entry page → skill + docs-release.
- `docs-release/contributing/en/*`, `zh/*`: reference the skill; duplicated step-by-step removed; documented conflicts with current tooling corrected.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none

## Machine-Readable Declarations

Production-Delta: +0/-0

### Optional Evidence Claims

None.

## Task And Scope

- Harness task: `task_8733f02fedc779bfea0fbfa406`
- Branch: `codex/contributing-skill`
- Public scope: contributor skill and contribution docs only.
- Private planning/evidence updated: yes — `artifacts/report-2026-08-30.md`, `artifacts/usability-report-20260830.md`, Fact `F-6B490D21`.
- Out of scope: the two framework frictions the exercise surfaced (docs checker not recursive; docs-only changes still run all 41 boundary commands with no resume) — tracked separately.

## Version Impact

- Version: no change. Publish impact: none.

## Governance Declaration

- Protected surface touched: no
- Authority: `task_8733f02fedc779bfea0fbfa406` (泽宇 2026-08-30 request).
- Break-glass: no

## Verification

- Base `origin/main`: `f2f70d23b5048e4b4fe3273437d4ccf47650e83c`.
- Worker: skill sync, leak scan 0, link check, pr-body-lint on the example, typecheck, targeted tests, 40 local boundary gates (GitHub-context check excluded).
- Fresh-agent usability run: full path completed; report in the task package.
- [x] `git diff --check`
- [x] `npm run typecheck`
- [x] `npm run harness:check-import-boundaries`
- [x] `npm run harness:scan-forbidden-symbols`
- [x] `npm run harness:check-private-boundary`
- [ ] `npm run check` / `npm test` / others: GitHub CI is the authority.

## Review Evidence

- CEO semantic review: single path, boundary content, public-only references; usability run accepted.

## Residual Risk

- docs-only contributions still pay the full `boundaries` job locally (~45s) until per-surface gate selection lands.

## References

- `task_8733f02fedc779bfea0fbfa406`; Fact `F-6B490D21`.

# 中文

## 概要

新增 `skills/harness-contributing/SKILL.md`,作为外部贡献者及其 coding agent 的唯一可执行贡献路径:公开/私有边界、Node 24 门、独立 worktree、带 tier 标记的定向测试、manifest 选择的本地门、双语 PR 模板与实测 `Production-Delta`、评审分流、maintainer 合并。`CONTRIBUTING.md` 改为入口页指向该 skill;`docs-release/contributing/{en,zh}` 只保留背景与 issue 指南,删掉重复的步骤清单。`references/` 附一份已过 lint 的 PR body 范例。

## 架构辩护

- 7 月的 `CONTRIBUTING.md`(29 行)早已跟不上真实流程(26 节双语模板、gate manifest、production-delta 声明、测试 tier 标记、worktree 纪律)。一个流程只留一份权威:skill 可执行,文档引用它,不再维护两份。
- skill 里每条命令都先在 fresh worktree 真跑过;随后一个零前情 agent 只凭 skill 在 8m24s 内完成最小贡献(改一句 docs → 门 → commit → 过 lint 的 PR body),它交回的 12 条摩擦已回填(机器可执行的 Node 门、预存 commit 检测、允许排除的 GitHub-context 报错原文、`Dependency-Change` 规则、直接/间接 checklist 语义、只填公开 issue 的 task 行、fetch 时间戳)。
- 边界靠内容而非信任:skill 只引用公开仓源;对改动文件做私有路径/id 泄漏扫描为 0。

## 改动内容

- 新增 `skills/harness-contributing/SKILL.md`(+ `references/example-pr-body.md`),由 `tools/sync-runtime-skills.mjs` 同步。
- `CONTRIBUTING.md`:入口页 → skill + docs-release。
- `docs-release/contributing/en/*`、`zh/*`:引用 skill,删重复步骤,修正与当前工具不一致处。

## 门收割 / Gate Harvest

- 删除的生产路径:无;删除的门/fixture:无。

## 机读声明说明

`Production-Delta` 由 gate 实测(纯文档,预期 +0/-0)。

## 任务与范围

- Task `task_8733f02fedc779bfea0fbfa406`;分支 `codex/contributing-skill`;范围:贡献者 skill 与贡献文档;范围外:演练暴露的两条框架摩擦(docs checker 不递归;docs-only 改动仍跑全部 41 条 boundaries 且不可续跑),另行跟踪。

## 版本影响

- 不改版本、不发布。

## 治理声明

- 未触碰受保护面;授权 task(泽宇 2026-08-30 提出);非 break-glass。

## 验证

- 基准 `origin/main` `f2f70d23…`;worker:skill 同步、泄漏扫描 0、链接检查、范例过 pr-body-lint、typecheck、定向测试、40 条本地边界门;零前情 agent 走通全路径(报告在任务包);GitHub CI 为完整权威。

## 审查证据

- CEO 语义验收:唯一路径、边界内容、只引公开源;使用性演练通过。

## 残余风险

- 在按改动面选门落地前,docs-only 贡献本地仍要跑完整 `boundaries`(约 45s)。

## 关联材料

- `task_8733f02fedc779bfea0fbfa406`;Fact `F-6B490D21`。
