### PR TITLE
feat(gates): scope local manifest gates by changed surface, add --resume, recursive docs checker

### DIFF
--- a/skills/harness-contributing/SKILL.md
+++ b/skills/harness-contributing/SKILL.md
@@ -185,9 +185,9 @@ If that exact message is not the sole failure, do not exclude the gate. Never
 treat the exclusion as a CI waiver; the required GitHub context must still pass
 on the PR. `--resume` uses only the checkpoint from the latest failed run in the
 same worktree, skips commands that already passed, and removes the checkpoint
-after success. If the selected surface or tracked repository content changed,
-the runner rejects the checkpoint; rerun without `--resume` so affected checks
-are not skipped. Results are never cached across successful runs.
+after success. If the selected gates or their commands changed, the runner
+rejects the checkpoint; rerun without `--resume` so affected checks are not
+skipped. Results are never cached across successful runs.
 
 > 中文：从 `tools/gate-manifest.json` 读取当前 job/tier，用
 > `run-manifest-gates --changed origin/main` 跑改动面对应的 job，并始终运行
@@ -196,7 +196,7 @@ are not skipped. Results are never cached across successful runs.
 > 本地只有 `check-github-required-contexts` 的精确报错
 > `repository must be provided as owner/name` 可在确认缺 GitHub 上下文后单独排除；
 > 该排除不适用于 CI，也不能掩盖其他失败。`--resume` 只复用同一 worktree 最近一次
-> 失败运行的已绿命令；成功后删除断点，代码或选择面变化后必须重新完整执行。
+> 失败运行的已绿命令；成功后删除断点，所选 gate 或命令变化后必须重新完整执行。
 
 ## Commit with the contributor identity
 

--- a/skills/harness-contributing/SKILL.md
+++ b/skills/harness-contributing/SKILL.md
@@ -152,18 +152,24 @@ jobs; use this output rather than inferring a job from its name:
 node -e 'const m=require("./tools/gate-manifest.json"); for (const g of m.gates.filter(g=>!g.aggregate)) for (const job of g.executionSurfaces?.rewriteCi?.pullRequestJobs??[]) console.log(`${job}\t${g.id}\t${g.command}\t${(g.consumerScope??[]).join("; ")}`)'
 ```
 
-Then run every job that matches the changed surface:
+Then run every job that matches the changed surface. Pass the merge base to the
+runner so its optional manifest path declarations can narrow local commands; a
+working-tree comparison includes committed, uncommitted, and untracked edits:
 
 ```bash
-node tools/run-manifest-gates.mjs --workflow-job <job>
+node tools/run-manifest-gates.mjs --workflow-job <job> --changed origin/main
 npm run typecheck
 ```
 
 `boundaries` is the usual job for public source, tool, and documentation
 boundaries. Use the manifest's other current PR jobs when the patch touches
 their surface—for example tests, package policy, dependencies/supply chain, or
-the GUI. Record every command and result in the PR body, including a scoped
-reason for anything not run.
+the GUI. Path selection is conservative: it narrows a job only when every
+changed path matches explicit `localPathGlobs`; an unclassified or mixed surface
+runs the complete job. A docs-only change under `docs-release/**` selects the
+three docs/release checks declared by the manifest. CI omits `--changed` and
+still runs every command in every job. Record every command and result in the PR
+body, including a scoped reason for anything not run.
 
 One gate has a local credential exception. If `boundaries` reaches
 `check-github-required-contexts`, the only failure that may be excluded locally
@@ -172,21 +178,25 @@ repository/token context is available. Preserve that output and rerun the same
 job with only that gate excluded:
 
 ```bash
-node tools/run-manifest-gates.mjs --workflow-job boundaries --exclude check-github-required-contexts
+node tools/run-manifest-gates.mjs --workflow-job boundaries --changed origin/main --exclude check-github-required-contexts --resume
 ```
 
 If that exact message is not the sole failure, do not exclude the gate. Never
 treat the exclusion as a CI waiver; the required GitHub context must still pass
-on the PR. A `boundaries` run currently takes about 45 seconds locally. The
-runner stops at the first failure and cannot resume, so the permitted exclusion
-rerun starts the selected job again from its first command.
+on the PR. `--resume` uses only the checkpoint from the latest failed run in the
+same worktree, skips commands that already passed, and removes the checkpoint
+after success. If the selected surface or tracked repository content changed,
+the runner rejects the checkpoint; rerun without `--resume` so affected checks
+are not skipped. Results are never cached across successful runs.
 
 > 中文：从 `tools/gate-manifest.json` 读取当前 job/tier，用
-> `run-manifest-gates` 跑改动面对应的 job，并始终运行 `npm run typecheck`。
+> `run-manifest-gates --changed origin/main` 跑改动面对应的 job，并始终运行
+> `npm run typecheck`。只有所有改动路径都被 manifest 的 `localPathGlobs` 覆盖时才
+> 缩小本地命令；遇到未分类或混合改动就保守地跑完整 job，CI 始终全跑。
 > 本地只有 `check-github-required-contexts` 的精确报错
 > `repository must be provided as owner/name` 可在确认缺 GitHub 上下文后单独排除；
-> 该排除不适用于 CI，也不能掩盖其他失败。`boundaries` 当前约需 45 秒，失败后不能
-> 从断点续跑。
+> 该排除不适用于 CI，也不能掩盖其他失败。`--resume` 只复用同一 worktree 最近一次
+> 失败运行的已绿命令；成功后删除断点，代码或选择面变化后必须重新完整执行。
 
 ## Commit with the contributor identity
 

--- a/tools/check-docs-release-map.mjs
+++ b/tools/check-docs-release-map.mjs
@@ -1,9 +1,7 @@
 import { existsSync, readdirSync, readFileSync } from "node:fs";
-import { join } from "node:path";
+import { dirname, join, resolve } from "node:path";
 
-const expectedDocs = [
-  "docs-release/release-posture.md"
-];
+const expectedDocs = ["docs-release/release-posture.md"];
 
 const requiredProductLinePhrases = [
   "Status taxonomy",
@@ -11,7 +9,7 @@ const requiredProductLinePhrases = [
   "Foundation",
   "Planned",
   "M2.5 GUI/daemon foundation",
-  "M3-M7"
+  "M3-M7",
 ];
 
 const riskyClaims = [
@@ -21,17 +19,23 @@ const riskyClaims = [
   { name: "cloud relay", subject: /\bcloud relay\b/i },
   { name: "GitHub Issues adapter", subject: /\bgithub issues\b[^.!?\n;|]*\badapter\b/i },
   { name: "Linear adapter", subject: /\blinear\b[^.!?\n;|]*\badapter\b/i },
-  { name: "M4 external adapter", subject: /\b(m4\b[^.!?\n;|]*\bexternal adapters?|external adapters?\b[^.!?\n;|]*\bm4)\b/i },
+  {
+    name: "M4 external adapter",
+    subject: /\b(m4\b[^.!?\n;|]*\bexternal adapters?|external adapters?\b[^.!?\n;|]*\bm4)\b/i,
+  },
   { name: "M3 task hierarchy", subject: /\bm3\b[^.!?\n;|]*\b(task hierarchy|relation semantics)\b/i },
   { name: "M6 GUI product", subject: /\bm6\b[^.!?\n;|]*\b(gui product|full gui)\b/i },
-  { name: "M7 release hardening", subject: /\bm7\b[^.!?\n;|]*\brelease hardening\b/i }
+  { name: "M7 release hardening", subject: /\bm7\b[^.!?\n;|]*\brelease hardening\b/i },
 ];
 
 const errors = [];
 const read = (path) => readFileSync(path, "utf8");
 const readme = read("README.md");
-const shippedClaim = /\b(shipped|available|implemented|complete|completed|ready|production-ready|supported|released)\b/i;
-const negativeOrFuture = /\b(no|not|never|without|unshipped|planned|future|later|requires|remain|remains|before|deferred|placeholder)\b/i;
+const releaseDocs = listMarkdown("docs-release");
+const shippedClaim =
+  /\b(shipped|available|implemented|complete|completed|ready|production-ready|supported|released)\b/i;
+const negativeOrFuture =
+  /\b(no|not|never|without|unshipped|planned|future|later|requires|remain|remains|before|deferred|placeholder)\b/i;
 
 for (const docPath of expectedDocs) {
   if (!existsSync(docPath)) errors.push(`Missing expected docs-release page: ${docPath}`);
@@ -45,13 +49,14 @@ if (existsSync(productLinePath)) {
   }
 }
 
-for (const docPath of ["README.md", ...listMarkdown("docs-release")]) {
+for (const docPath of ["README.md", ...releaseDocs]) {
   const content = read(docPath);
   if (/\/Users\/[^\s)`]+/.test(content)) errors.push(`${docPath} exposes an absolute local path`);
   collectOverclaims(docPath, content, errors);
+  validateLocalLinks(docPath, content, errors);
 }
 
-for (const docPath of listMarkdown("docs-release")) {
+for (const docPath of releaseDocs) {
   const content = read(docPath);
   if (content.includes(".harness-private/")) errors.push(`${docPath} exposes private harness path`);
 }
@@ -66,10 +71,13 @@ if (errors.length > 0) {
 console.log("Docs release map check passed.");
 
 function listMarkdown(root) {
-  return readdirSync(root)
-    .filter((entry) => entry.endsWith(".md"))
-    .map((entry) => join(root, entry))
-    .sort();
+  const markdown = [];
+  for (const entry of readdirSync(root, { withFileTypes: true })) {
+    const entryPath = join(root, entry.name);
+    if (entry.isDirectory()) markdown.push(...listMarkdown(entryPath));
+    else if (entry.isFile() && entry.name.endsWith(".md")) markdown.push(entryPath);
+  }
+  return markdown.sort();
 }
 
 function collectOverclaims(docPath, content, targetErrors) {
@@ -91,5 +99,25 @@ function validateReadmePrivateBoundary(content, targetErrors) {
   }
   if (/\.harness-private\/[\w.-]+/.test(content)) {
     targetErrors.push("README.md exposes a browsable private harness subpath");
+  }
+}
+
+function validateLocalLinks(docPath, content, targetErrors) {
+  const linkPattern = /(?<!!)\[[^\]]*\]\(([^)\s]+)(?:\s+["'][^)]*["'])?\)/gu;
+  for (const match of content.matchAll(linkPattern)) {
+    const rawTarget = match[1].replace(/^<|>$/gu, "");
+    if (!rawTarget || rawTarget.startsWith("#") || /^[a-z][a-z\d+.-]*:/iu.test(rawTarget)) continue;
+
+    let targetPath;
+    try {
+      targetPath = decodeURIComponent(rawTarget.split(/[?#]/u, 1)[0]);
+    } catch {
+      targetErrors.push(`${docPath} has an invalid local link: ${rawTarget}`);
+      continue;
+    }
+    if (!targetPath) continue;
+
+    const resolvedTarget = resolve(dirname(docPath), targetPath.startsWith("/") ? `.${targetPath}` : targetPath);
+    if (!existsSync(resolvedTarget)) targetErrors.push(`${docPath} links to missing path: ${rawTarget}`);
   }
 }

--- a/tools/check-docs-release-map.test.mjs
+++ b/tools/check-docs-release-map.test.mjs
@@ -23,7 +23,7 @@ test("docs release map check accepts the expected public documentation map", asy
 test("docs release map check rejects README private planning subpaths", async () => {
   await withFixtureRepo((root) => {
     writeValidDocsMap(root, {
-      readmeSuffix: "Read `.harness-private/coding-agent-harness/task`.\n"
+      readmeSuffix: "Read `.harness-private/coding-agent-harness/task`.\n",
     });
 
     const result = runDocsMapCheck(root);
@@ -38,7 +38,7 @@ test("docs release map check rejects shipped capability overclaim variants", asy
     "Signed desktop installers are shipped.",
     "The auto-update capability is available.",
     "M4 external adapters are implemented.",
-    "M3 task hierarchy is complete."
+    "M3 task hierarchy is complete.",
   ];
 
   for (const claim of claims) {
@@ -53,10 +53,25 @@ test("docs release map check rejects shipped capability overclaim variants", asy
   }
 });
 
+test("docs release map check rejects broken links in nested release docs", async () => {
+  await withFixtureRepo((root) => {
+    writeValidDocsMap(root);
+    writeFile(root, "docs-release/contributing/en/guide.md", "Read the [missing page](missing.md).");
+
+    const result = runDocsMapCheck(root);
+
+    assert.notEqual(result.status, 0);
+    assert.match(
+      result.stderr,
+      /docs-release[/\\]contributing[/\\]en[/\\]guide\.md links to missing path: missing\.md/u,
+    );
+  });
+});
+
 function runDocsMapCheck(root) {
   return spawnSync(process.execPath, [scriptPath], {
     cwd: root,
-    encoding: "utf8"
+    encoding: "utf8",
   });
 }
 
@@ -71,25 +86,33 @@ async function withFixtureRepo(fn) {
 }
 
 function writeValidDocsMap(root, options = {}) {
-  writeFile(root, "README.md", [
-    "# Harness Anything",
-    "The accountability layer for AI agents.",
-    "Private planning lives in `.harness-private/`.",
-    "Do not add `.harness-private/` to public commits.",
-    options.readmeSuffix ?? ""
-  ].join("\n"));
+  writeFile(
+    root,
+    "README.md",
+    [
+      "# Harness Anything",
+      "The accountability layer for AI agents.",
+      "Private planning lives in `.harness-private/`.",
+      "Do not add `.harness-private/` to public commits.",
+      options.readmeSuffix ?? "",
+    ].join("\n"),
+  );
 
-  writeFile(root, "docs-release/release-posture.md", [
-    "# Release Posture",
-    "## Status taxonomy",
-    "- Shipped: usable from this repository.",
-    "- Foundation: contract exists, but end-user product capability is not shipped yet.",
-    "- Planned: owned by a later milestone.",
-    "## Product line status",
-    "M2.5 GUI/daemon foundation",
-    "M3-M7",
-    options.docsSuffix ?? ""
-  ].join("\n"));
+  writeFile(
+    root,
+    "docs-release/release-posture.md",
+    [
+      "# Release Posture",
+      "## Status taxonomy",
+      "- Shipped: usable from this repository.",
+      "- Foundation: contract exists, but end-user product capability is not shipped yet.",
+      "- Planned: owned by a later milestone.",
+      "## Product line status",
+      "M2.5 GUI/daemon foundation",
+      "M3-M7",
+      options.docsSuffix ?? "",
+    ].join("\n"),
+  );
 }
 
 function writeFile(root, relativePath, body) {

--- a/tools/gate-manifest.json
+++ b/tools/gate-manifest.json
@@ -2882,6 +2882,10 @@
       "consumerScope": [
         "public docs-release map"
       ],
+      "localPathGlobs": [
+        "README.md",
+        "docs-release/**"
+      ],
       "githubContext": {
         "requiredContexts": [
           "boundaries"
@@ -3350,6 +3354,10 @@
       ],
       "consumerScope": [
         "runtime release readiness declarations"
+      ],
+      "localPathGlobs": [
+        "README.md",
+        "docs-release/**"
       ],
       "githubContext": {
         "requiredContexts": [
@@ -3885,6 +3893,10 @@
       ],
       "consumerScope": [
         "Legacy Intake readiness and retired full-cutover surface"
+      ],
+      "localPathGlobs": [
+        "README.md",
+        "docs-release/**"
       ],
       "githubContext": {
         "requiredContexts": [

--- a/tools/gate-manifest.schema.md
+++ b/tools/gate-manifest.schema.md
@@ -44,6 +44,11 @@ Each gate entry must declare:
 - `authoritySource`: non-empty array of authority files or declarations.
   Boundary gates must not use only their checker file as authority.
 - `consumerScope`: non-empty array describing the real checked consumer surface.
+- `localPathGlobs`: optional repository-relative glob array used only by local
+  `run-manifest-gates --changed` selection. A changed-path set is narrowed only
+  when every path matches at least one selected gate's declaration; otherwise
+  the runner conservatively executes the complete selected job. CI invocations
+  omit `--changed` and therefore always retain the full manifest job.
 - `githubContext`: required-context and workflow-job mapping.
 - `allowlistPolicy`: whether allowlists/exceptions exist, where they live, and
   whether ADR/decision evidence is required.

--- a/tools/run-manifest-gates.mjs
+++ b/tools/run-manifest-gates.mjs
@@ -8,7 +8,8 @@
  * first failure to preserve the old `&&` chain behavior.
  */
 import { spawnSync } from "node:child_process";
-import { readFileSync } from "node:fs";
+import { createHash } from "node:crypto";
+import { existsSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { readTestQuarantine } from "./test-quarantine.mjs";
@@ -22,6 +23,9 @@ export function parseManifestGateArgs(args) {
     workflowJob: null,
     shard: null,
     exclude: new Set(),
+    changed: null,
+    changedPaths: null,
+    resume: false,
   };
 
   for (let index = 0; index < args.length; index += 1) {
@@ -51,6 +55,15 @@ export function parseManifestGateArgs(args) {
       index += 1;
       continue;
     }
+    if (arg === "--changed") {
+      options.changed = requireValue(args, index, arg);
+      index += 1;
+      continue;
+    }
+    if (arg === "--resume") {
+      options.resume = true;
+      continue;
+    }
     throw new Error(`unknown run-manifest-gates option: ${arg}`);
   }
 
@@ -67,24 +80,78 @@ export function parseManifestGateArgs(args) {
 }
 
 export function selectManifestGateIds(manifest, options) {
+  let gates;
   if (options.packageSurface) {
     const ids = manifest.surfaces?.packageJson?.[options.packageSurface];
     if (!Array.isArray(ids)) {
       throw new Error(`manifest has no packageJson surface ${options.packageSurface}`);
     }
-    return ids.filter((id) => !options.exclude.has(id));
+    const gatesById = new Map(manifest.gates.map((gate) => [gate.id, gate]));
+    gates = ids.map((id) => gatesById.get(id) ?? { id });
+  } else {
+    gates = manifest.gates
+      .filter((gate) => !gate.aggregate)
+      .filter((gate) =>
+        [
+          ...(gate.executionSurfaces?.rewriteCi?.pullRequestJobs ?? []),
+          ...(gate.executionSurfaces?.rewriteCi?.nonPullRequestJobs ?? []),
+        ].includes(options.workflowJob),
+      );
   }
 
-  return manifest.gates
-    .filter((gate) => !gate.aggregate)
-    .filter((gate) =>
-      [
-        ...(gate.executionSurfaces?.rewriteCi?.pullRequestJobs ?? []),
-        ...(gate.executionSurfaces?.rewriteCi?.nonPullRequestJobs ?? []),
-      ].includes(options.workflowJob),
-    )
+  const exclude = options.exclude ?? new Set();
+  return selectGatesForChangedPaths(gates, options.changedPaths)
     .map((gate) => gate.id)
-    .filter((id) => !options.exclude.has(id));
+    .filter((id) => !exclude.has(id));
+}
+
+export function selectGatesForChangedPaths(gates, changedPaths) {
+  if (!Array.isArray(changedPaths)) return gates;
+  if (changedPaths.length === 0) return [];
+
+  const scopedGates = gates.filter((gate) => gate.localPathGlobs !== undefined);
+  for (const gate of scopedGates) validateLocalPathGlobs(gate);
+  if (scopedGates.length === 0) return gates;
+
+  const selectedIds = new Set();
+  for (const changedPath of changedPaths) {
+    const normalizedPath = changedPath.replaceAll("\\", "/");
+    const matches = scopedGates.filter((gate) =>
+      gate.localPathGlobs.some((glob) => pathMatchesGlob(normalizedPath, glob)),
+    );
+    if (matches.length === 0) return gates;
+    for (const gate of matches) selectedIds.add(gate.id);
+  }
+  return gates.filter((gate) => selectedIds.has(gate.id));
+}
+
+function validateLocalPathGlobs(gate) {
+  if (
+    !Array.isArray(gate.localPathGlobs) ||
+    gate.localPathGlobs.length === 0 ||
+    gate.localPathGlobs.some((glob) => typeof glob !== "string" || glob.length === 0 || glob.startsWith("/"))
+  ) {
+    throw new Error(`manifest gate ${gate.id} localPathGlobs must be a non-empty array of relative globs`);
+  }
+}
+
+function pathMatchesGlob(filePath, glob) {
+  let expression = "^";
+  for (let index = 0; index < glob.length; index += 1) {
+    const char = glob[index];
+    if (char === "*" && glob[index + 1] === "*") {
+      if (glob[index + 2] === "/") {
+        expression += "(?:.*/)?";
+        index += 2;
+      } else {
+        expression += ".*";
+        index += 1;
+      }
+    } else if (char === "*") expression += "[^/]*";
+    else if (char === "?") expression += "[^/]";
+    else expression += char.replace(/[|\\{}()[\]^$+?.]/gu, "\\$&");
+  }
+  return new RegExp(`${expression}$`, "u").test(filePath);
 }
 
 export function buildManifestGatePlan(manifest, options) {
@@ -174,6 +241,16 @@ function readManifest() {
   return JSON.parse(readFileSync(manifestPath, "utf8"));
 }
 
+function readChangedPaths(revision) {
+  const changed = [
+    readGitOutput(["diff", "--name-only", "-z", revision, "--"]),
+    readGitOutput(["diff", "--name-only", "-z", "--"]),
+    readGitOutput(["diff", "--cached", "--name-only", "-z", "--"]),
+  ].join("");
+  const untracked = readGitOutput(["ls-files", "--others", "--exclude-standard", "-z"]);
+  return [...new Set(`${changed}${untracked}`.split("\0").filter(Boolean))].sort();
+}
+
 function runCommand(label, command) {
   console.log(`\n▶ ${label}  (${command})`);
   const started = Date.now();
@@ -200,6 +277,7 @@ function runCommand(label, command) {
 
 function main(argv) {
   const options = parseManifestGateArgs(argv);
+  if (options.changed !== null) options.changedPaths = readChangedPaths(options.changed);
   readTestQuarantine(repoRoot);
   if (shouldSkipTestQuarantine(options.workflowJob, process.env)) process.env.HARNESS_TEST_QUARANTINE = "skip";
   if (options.workflowJob)
@@ -223,20 +301,116 @@ function main(argv) {
   const manifest = readManifest();
   const plan = buildManifestGatePlan(manifest, options);
   const selector = options.packageSurface ? `package:${options.packageSurface}` : `workflow:${options.workflowJob}`;
+  const resume = prepareResume(manifest, options);
 
+  if (options.changed !== null) {
+    console.log(`Changed path selection (${options.changed}): ${options.changedPaths.length} path(s).`);
+  }
   console.log(`Manifest gate runner (${selector}): ${plan.length} command(s).`);
   const gateResults = [];
   for (const entry of plan) {
+    if (resume.passedCommands.has(entry.command)) {
+      console.log(`↷ ${entry.id} (already passed; resumed)`);
+      continue;
+    }
     const result = runCommand(entry.id, entry.command);
     gateResults.push({ gate: canonicalGateId(entry.id), pass: result.ok, metrics: { durationMs: result.durationMs } });
     if (!result.ok) {
+      writeResumeCheckpoint(resume);
       writeObservation(gateResults);
       process.exitCode = 1;
       return;
     }
+    resume.passedCommands.add(entry.command);
   }
+  rmSync(resume.path, { force: true });
   writeObservation(gateResults);
   console.log(`\nManifest gate runner passed (${selector}).`);
+}
+
+function prepareResume(manifest, options) {
+  const checkpointPath = resolveResumeCheckpointPath();
+  const signature = createResumeSignature(manifest, options);
+  if (!options.resume) {
+    rmSync(checkpointPath, { force: true });
+    return { path: checkpointPath, signature, passedCommands: new Set() };
+  }
+  if (!existsSync(checkpointPath)) {
+    throw new Error("--resume requires a failed manifest gate run in this worktree");
+  }
+
+  let checkpoint;
+  try {
+    checkpoint = JSON.parse(readFileSync(checkpointPath, "utf8"));
+  } catch (error) {
+    throw new Error(`cannot read resume checkpoint: ${error instanceof Error ? error.message : String(error)}`);
+  }
+  if (checkpoint.schema !== "manifest-gate-resume/v1" || checkpoint.signature !== signature) {
+    throw new Error(
+      "resume checkpoint does not match the selected gates or current repository state; rerun without --resume",
+    );
+  }
+  return { path: checkpointPath, signature, passedCommands: new Set(checkpoint.passedCommands ?? []) };
+}
+
+function createResumeSignature(manifest, options) {
+  const baseOptions = { ...options, exclude: new Set(), resume: false };
+  const basePlan = buildManifestGatePlan(manifest, baseOptions);
+  const repositoryState = createRepositoryStateDigest();
+  return createHash("sha256")
+    .update(
+      JSON.stringify({
+        packageSurface: options.packageSurface,
+        workflowJob: options.workflowJob,
+        shard: options.shard,
+        changed: options.changed,
+        changedPaths: options.changedPaths,
+        basePlan,
+        repositoryState,
+      }),
+    )
+    .digest("hex");
+}
+
+function createRepositoryStateDigest() {
+  const digest = createHash("sha256")
+    .update(readGitOutput(["rev-parse", "HEAD"]))
+    .update("\0")
+    .update(readGitOutput(["diff", "--binary", "HEAD", "--"]));
+  const untracked = readGitOutput(["ls-files", "--others", "--exclude-standard", "-z"]).split("\0").filter(Boolean);
+  for (const file of untracked)
+    digest
+      .update("\0")
+      .update(file)
+      .update("\0")
+      .update(readFileSync(path.join(repoRoot, file)));
+  return digest.digest("hex");
+}
+
+function readGitOutput(args) {
+  const result = spawnSync("git", args, { cwd: repoRoot, encoding: "utf8", maxBuffer: 50 * 1024 * 1024 });
+  if (result.status !== 0) throw new Error(`git ${args.join(" ")} failed: ${(result.stderr || result.stdout).trim()}`);
+  return result.stdout;
+}
+
+function resolveResumeCheckpointPath() {
+  return path.resolve(repoRoot, readGitOutput(["rev-parse", "--git-path", "manifest-gate-resume.json"]).trim());
+}
+
+function writeResumeCheckpoint(resume) {
+  writeFileSync(
+    resume.path,
+    `${JSON.stringify(
+      {
+        schema: "manifest-gate-resume/v1",
+        signature: resume.signature,
+        passedCommands: [...resume.passedCommands],
+      },
+      null,
+      2,
+    )}\n`,
+    "utf8",
+  );
 }
 
 function canonicalGateId(id) {

--- a/tools/run-manifest-gates.mjs
+++ b/tools/run-manifest-gates.mjs
@@ -346,9 +346,7 @@ function prepareResume(manifest, options) {
     throw new Error(`cannot read resume checkpoint: ${error instanceof Error ? error.message : String(error)}`);
   }
   if (checkpoint.schema !== "manifest-gate-resume/v1" || checkpoint.signature !== signature) {
-    throw new Error(
-      "resume checkpoint does not match the selected gates or current repository state; rerun without --resume",
-    );
+    throw new Error("resume checkpoint does not match the selected gates or commands; rerun without --resume");
   }
   return { path: checkpointPath, signature, passedCommands: new Set(checkpoint.passedCommands ?? []) };
 }
@@ -356,35 +354,7 @@ function prepareResume(manifest, options) {
 function createResumeSignature(manifest, options) {
   const baseOptions = { ...options, exclude: new Set(), resume: false };
   const basePlan = buildManifestGatePlan(manifest, baseOptions);
-  const repositoryState = createRepositoryStateDigest();
-  return createHash("sha256")
-    .update(
-      JSON.stringify({
-        packageSurface: options.packageSurface,
-        workflowJob: options.workflowJob,
-        shard: options.shard,
-        changed: options.changed,
-        changedPaths: options.changedPaths,
-        basePlan,
-        repositoryState,
-      }),
-    )
-    .digest("hex");
-}
-
-function createRepositoryStateDigest() {
-  const digest = createHash("sha256")
-    .update(readGitOutput(["rev-parse", "HEAD"]))
-    .update("\0")
-    .update(readGitOutput(["diff", "--binary", "HEAD", "--"]));
-  const untracked = readGitOutput(["ls-files", "--others", "--exclude-standard", "-z"]).split("\0").filter(Boolean);
-  for (const file of untracked)
-    digest
-      .update("\0")
-      .update(file)
-      .update("\0")
-      .update(readFileSync(path.join(repoRoot, file)));
-  return digest.digest("hex");
+  return createHash("sha256").update(JSON.stringify(basePlan)).digest("hex");
 }
 
 function readGitOutput(args) {

--- a/tools/run-manifest-gates.test.mjs
+++ b/tools/run-manifest-gates.test.mjs
@@ -1,7 +1,15 @@
 // harness-test-tier: fast
 import assert from "node:assert/strict";
+import { copyFileSync, mkdirSync, writeFileSync } from "node:fs";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
 import test from "node:test";
 import { buildManifestGatePlan, parseManifestGateArgs, shouldSkipTestQuarantine } from "./run-manifest-gates.mjs";
+
+const runnerPath = path.resolve(import.meta.dirname, "run-manifest-gates.mjs");
+const quarantineModulePath = path.resolve(import.meta.dirname, "test-quarantine.mjs");
 
 test("manifest gate runner appends shard args only to shardable gates", () => {
   const manifest = {
@@ -57,6 +65,65 @@ test("manifest gate runner rejects --shard for non-shardable gates", () => {
   );
 });
 
+test("manifest gate runner selects locally scoped gates for fully covered changed paths", () => {
+  const manifest = selectionManifest();
+  const options = parseManifestGateArgs(["--workflow-job", "boundaries", "--changed", "origin/main"]);
+  options.changedPaths = ["docs-release/contributing/en/guide.md"];
+
+  assert.deepEqual(buildManifestGatePlan(manifest, options), [
+    { id: "check-docs", command: "node check-docs.mjs" },
+    { id: "check-release", command: "node check-release.mjs" },
+  ]);
+  assert.equal(options.changed, "origin/main");
+});
+
+test("manifest gate runner falls back to the full job when any changed path is unclassified", () => {
+  const manifest = selectionManifest();
+  const options = parseManifestGateArgs(["--workflow-job", "boundaries", "--changed", "origin/main"]);
+  options.changedPaths = ["docs-release/guide.md", "packages/kernel/src/index.ts"];
+
+  assert.deepEqual(buildManifestGatePlan(manifest, options), [
+    { id: "check-docs", command: "node check-docs.mjs" },
+    { id: "check-release", command: "node check-release.mjs" },
+    { id: "check-everything", command: "node check-everything.mjs" },
+  ]);
+});
+
+test("manifest gate runner preserves the full CI plan when --changed is absent", () => {
+  const options = parseManifestGateArgs(["--workflow-job", "boundaries"]);
+
+  assert.deepEqual(buildManifestGatePlan(selectionManifest(), options), [
+    { id: "check-docs", command: "node check-docs.mjs" },
+    { id: "check-release", command: "node check-release.mjs" },
+    { id: "check-everything", command: "node check-everything.mjs" },
+  ]);
+});
+
+test("manifest gate runner resumes only the failed run and removes its checkpoint after success", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "ha-manifest-resume-"));
+  try {
+    writeRunnerFixture(root);
+    git(root, ["init"]);
+    git(root, ["add", "."]);
+    git(root, ["-c", "user.name=Harness Test", "-c", "user.email=test@example.com", "commit", "-m", "fixture"]);
+
+    const first = runFixture(root, {});
+    assert.equal(first.status, 1, first.stderr);
+    assert.equal(readRuns(root), "one\n");
+
+    const resumed = runFixture(root, { ALLOW_SECOND_GATE: "1" }, ["--resume"]);
+    assert.equal(resumed.status, 0, resumed.stderr);
+    assert.match(resumed.stdout, /check-one \(already passed; resumed\)/u);
+    assert.equal(readRuns(root), "one\nthree\n");
+
+    const staleResume = runFixture(root, { ALLOW_SECOND_GATE: "1" }, ["--resume"]);
+    assert.equal(staleResume.status, 2);
+    assert.match(staleResume.stderr, /--resume requires a failed manifest gate run/u);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
 test("test quarantine skips pull-request L0 jobs", () => {
   assert.equal(
     shouldSkipTestQuarantine("integration-shard", { GITHUB_EVENT_NAME: "pull_request", GITHUB_HEAD_REF: "feature/x" }),
@@ -72,3 +139,82 @@ test("test quarantine skips pull-request L0 jobs", () => {
     false,
   );
 });
+
+function selectionManifest() {
+  const executionSurfaces = { rewriteCi: { pullRequestJobs: ["boundaries"] } };
+  return {
+    gates: [
+      {
+        id: "check-docs",
+        command: "node check-docs.mjs",
+        localPathGlobs: ["README.md", "docs-release/**"],
+        executionSurfaces,
+      },
+      {
+        id: "check-release",
+        command: "node check-release.mjs",
+        localPathGlobs: ["docs-release/**"],
+        executionSurfaces,
+      },
+      { id: "check-everything", command: "node check-everything.mjs", executionSurfaces },
+    ],
+  };
+}
+
+function writeRunnerFixture(root) {
+  mkdirSync(path.join(root, "tools"), { recursive: true });
+  copyFileSync(runnerPath, path.join(root, "tools/run-manifest-gates.mjs"));
+  copyFileSync(quarantineModulePath, path.join(root, "tools/test-quarantine.mjs"));
+  writeFileSync(
+    path.join(root, "tools/gate-manifest.json"),
+    `${JSON.stringify(
+      {
+        gates: [
+          gate("check-one", "node gate-one.mjs"),
+          gate("check-two", "node gate-two.mjs"),
+          gate("check-three", "node gate-three.mjs"),
+        ],
+      },
+      null,
+      2,
+    )}\n`,
+  );
+  writeFileSync(path.join(root, "tools/test-quarantine.json"), '{"schema":"harness-test-quarantine/v1","tests":[]}\n');
+  writeFileSync(
+    path.join(root, "gate-one.mjs"),
+    'import { appendFileSync } from "node:fs";\nappendFileSync(".git/runs.log", "one\\n");\n',
+  );
+  writeFileSync(path.join(root, "gate-two.mjs"), "if (!process.env.ALLOW_SECOND_GATE) process.exit(1);\n");
+  writeFileSync(
+    path.join(root, "gate-three.mjs"),
+    'import { appendFileSync } from "node:fs";\nappendFileSync(".git/runs.log", "three\\n");\n',
+  );
+}
+
+function gate(id, command) {
+  return { id, command, executionSurfaces: { rewriteCi: { pullRequestJobs: ["boundaries"] } } };
+}
+
+function git(root, args) {
+  const result = spawnSync("git", args, { cwd: root, encoding: "utf8" });
+  assert.equal(result.status, 0, result.stderr);
+}
+
+function runFixture(root, env, extraArgs = []) {
+  return spawnSync(process.execPath, ["tools/run-manifest-gates.mjs", "--workflow-job", "boundaries", ...extraArgs], {
+    cwd: root,
+    env: { ...process.env, ...env },
+    encoding: "utf8",
+  });
+}
+
+function readRuns(root) {
+  return spawnSync(
+    process.execPath,
+    ["-e", 'process.stdout.write(require("node:fs").readFileSync(".git/runs.log","utf8"))'],
+    {
+      cwd: root,
+      encoding: "utf8",
+    },
+  ).stdout;
+}

--- a/tools/run-manifest-gates.test.mjs
+++ b/tools/run-manifest-gates.test.mjs
@@ -1,6 +1,6 @@
 // harness-test-tier: fast
 import assert from "node:assert/strict";
-import { copyFileSync, mkdirSync, writeFileSync } from "node:fs";
+import { copyFileSync, existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
@@ -102,21 +102,24 @@ test("manifest gate runner preserves the full CI plan when --changed is absent",
 test("manifest gate runner resumes only the failed run and removes its checkpoint after success", async () => {
   const root = await mkdtemp(path.join(tmpdir(), "ha-manifest-resume-"));
   try {
-    writeRunnerFixture(root);
     git(root, ["init"]);
+    git(root, ["config", "core.autocrlf", "true"]);
+    writeRunnerFixture(root);
     git(root, ["add", "."]);
     git(root, ["-c", "user.name=Harness Test", "-c", "user.email=test@example.com", "commit", "-m", "fixture"]);
 
-    const first = runFixture(root, {});
+    const ciEnv = fixtureCiEnv(root);
+    const first = runFixture(root, ciEnv);
     assert.equal(first.status, 1, first.stderr);
     assert.equal(readRuns(root), "one\n");
+    assert.equal(existsSync(ciEnv.HARNESS_CI_GATE_RESULTS), true);
 
-    const resumed = runFixture(root, { ALLOW_SECOND_GATE: "1" }, ["--resume"]);
+    const resumed = runFixture(root, { ...ciEnv, ALLOW_SECOND_GATE: "1" }, ["--resume"]);
     assert.equal(resumed.status, 0, resumed.stderr);
     assert.match(resumed.stdout, /check-one \(already passed; resumed\)/u);
     assert.equal(readRuns(root), "one\nthree\n");
 
-    const staleResume = runFixture(root, { ALLOW_SECOND_GATE: "1" }, ["--resume"]);
+    const staleResume = runFixture(root, { ...ciEnv, ALLOW_SECOND_GATE: "1" }, ["--resume"]);
     assert.equal(staleResume.status, 2);
     assert.match(staleResume.stderr, /--resume requires a failed manifest gate run/u);
   } finally {
@@ -193,6 +196,18 @@ function writeRunnerFixture(root) {
 
 function gate(id, command) {
   return { id, command, executionSurfaces: { rewriteCi: { pullRequestJobs: ["boundaries"] } } };
+}
+
+function fixtureCiEnv(root) {
+  const observationRoot = path.join(root, "tmp/ci-observation");
+  return {
+    GITHUB_ACTIONS: "true",
+    GITHUB_JOB: "fast-contract",
+    HARNESS_CI_NODE_TEST_RESULTS: path.join(observationRoot, "node-tests.json"),
+    HARNESS_CI_VITEST_RESULTS: path.join(observationRoot, "vitest.json"),
+    HARNESS_CI_GATE_RESULTS: path.join(observationRoot, "gates.json"),
+    HARNESS_CI_OBSERVATION_OUTPUT: path.join(observationRoot, "observation.json"),
+  };
 }
 
 function git(root, args) {


### PR DESCRIPTION
# English

## Summary

Local gates for docs-only changes were heavy and blind: `check-docs-release-map.mjs` only read the top level of `docs-release/`, so a broken link in a subdirectory passed; and any one-line docs change ran the full 41-command `boundaries` job (~45s, twice when the GitHub-context check fails first, no resume). This PR makes the docs checker recursive with exact source/target reporting, adds `--changed <range>` to `tools/run-manifest-gates.mjs` (selects only the manifest gates whose declared surfaces match the changed paths; docs-only → three docs/release gates), and adds `--resume` (skips commands that already passed in the previous local run; checkpoint removed on success). Docs-only local feedback drops from ~88s to 2.37s including typecheck. **CI is unchanged and still runs every job in full.**

## Architectural Justification

- Surfaced by the fresh-agent contribution exercise (task `task_8733f02f`, F-6B490D21 #4/#5): a green docs checker that cannot see the file it was asked about is a false instrument; a 45s loop for one sentence is friction the framework, not the contributor, should absorb.
- Selection narrows only what runs locally; no gate logic, threshold, or CI job set changes. The manifest gains one optional per-gate field declaring its applicable surfaces (`tools/gate-manifest.schema.md` documents it) — the minimal structural addition, defaulting to "always applicable" so unknown gates still run.
- `--resume` is a local checkpoint of the current run only; nothing is cached across runs, so it cannot hide a regression.

## What Changed

- `tools/check-docs-release-map.mjs`: recursive over `docs-release/**`; failures name source and target paths.
- `tools/run-manifest-gates.mjs`: `--changed <git range>` surface selection; `--resume` checkpoint; tests in `tools/run-manifest-gates.test.mjs` (12).
- `tools/gate-manifest.json` (+12): applicable-surface declarations for the docs/release gates; `tools/gate-manifest.schema.md` (+5).

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none

## Machine-Readable Declarations

Production-Delta: +198/-26

### Optional Evidence Claims

None; timings are from the maintainer's machine and recorded in the task report.

## Task And Scope

- Harness task: `task_a60a466bb27766af82cbc2a283`
- Branch: `codex/docs-gate-selection`
- Public scope: local gate runner, docs checker, manifest surface metadata.
- Private planning/evidence updated: yes — `artifacts/report-2026-08-30.md`, Fact `F-CE3129B9`.
- Out of scope: CI workflow job selection (unchanged by design); updating `skills/harness-contributing` wording (follow-up after merge).

## Version Impact

- Version: no change. Publish impact: none.

## Governance Declaration

- Protected surface touched: yes
- Protected surface scope: `tools/gate-manifest.json` — adds optional applicable-surface metadata to existing gate entries; no gate removed, weakened, retiered, or re-thresholded; CI job set unchanged.
- Authority: `task_a60a466bb27766af82cbc2a283`; evidence `F-6B490D21` (usability exercise), `F-CE3129B9` (before/after).
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no

## Verification

- Base `origin/main`: `56bc3dbf401a7a7502e2e58814ae7aada7bae036`.
- Worker: focused tests 12/12; typecheck; lint; recursive docs checker positive control (nested broken link fails with paths); `--changed` docs-only selection = 3 gates in 2.37s; `--resume` skipped 20 passed commands; full local boundaries green (GitHub-context check excluded).
- [x] `git diff --check`
- [x] `npm run typecheck`
- [x] `npm run harness:check-import-boundaries`
- [x] `npm run harness:scan-forbidden-symbols`
- [x] `npm run harness:check-private-boundary`
- [ ] `npm run check` / `npm test` / others: GitHub CI is the authority.

## Review Evidence

- CEO semantic review: local-only narrowing, CI untouched, positive control present, minimal manifest field.

## Residual Risk

- A gate whose surface declaration is too narrow would be skipped locally for a relevant change; CI still runs it, so the failure surfaces there rather than locally.

## References

- `task_a60a466bb27766af82cbc2a283`; Facts `F-6B490D21`, `F-CE3129B9`; skill `skills/harness-contributing`.

# 中文

## 概要

docs-only 改动的本地门又重又盲:`check-docs-release-map.mjs` 只读 `docs-release/` 顶层,子目录里的坏链接照样绿;改一句文档也要跑完整 41 条 `boundaries`(约 45s,GitHub-context 先红时要跑两遍,不能续跑)。本 PR 让 docs checker 递归并精确报告 source/target,给 `tools/run-manifest-gates.mjs` 加 `--changed <range>`(只选 manifest 里声明面命中改动路径的门;docs-only → 三条 docs/release 门)和 `--resume`(跳过上次本地已过的命令,成功后删 checkpoint)。docs-only 本地反馈从约 88s 降到 2.37s(含 typecheck)。**CI 不变,仍全量跑每个 job。**

## 架构辩护

- 来源是零前情贡献者演练(task_8733f02f,F-6B490D21 #4/#5):看不见目标文件却报绿的 checker 是假仪器;为一句话等 45s 是框架该吸收的摩擦,不该让贡献者扛。
- 选门只收窄本地跑什么;不改任何门逻辑、阈值或 CI job 集合。manifest 只加一个可选的「适用面」字段(`tools/gate-manifest.schema.md` 有说明),默认「总是适用」,未声明的门照跑。
- `--resume` 只是本次运行的本地 checkpoint,不跨次缓存,藏不住回归。

## 改动内容

- `tools/check-docs-release-map.mjs`:递归 `docs-release/**`;失败报 source 与 target 路径。
- `tools/run-manifest-gates.mjs`:`--changed` 按面选门;`--resume` checkpoint;测试 `tools/run-manifest-gates.test.mjs`(12 个)。
- `tools/gate-manifest.json`(+12):docs/release 门的适用面声明;`tools/gate-manifest.schema.md`(+5)。

## 门收割 / Gate Harvest

- 删除的生产路径:无;删除的门/fixture:无。

## 机读声明说明

`Production-Delta` 由 gate 实测。

## 任务与范围

- Task `task_a60a466bb27766af82cbc2a283`;分支 `codex/docs-gate-selection`;范围:本地门 runner、docs checker、manifest 适用面元数据;范围外:CI workflow 的 job 选择(刻意不动)、`skills/harness-contributing` 措辞更新(合入后跟进)。

## 版本影响

- 不改版本、不发布。

## 治理声明

- 触碰受保护面:是——`tools/gate-manifest.json` 给既有门加可选适用面元数据;未删、未削、未改 tier 或阈值;CI job 集合不变。授权 task + F-6B490D21 / F-CE3129B9;非 break-glass。

## 验证

- 基准 `origin/main` `56bc3dbf…`;worker:定向测试 12/12、typecheck、lint、递归 checker 阳性对照(嵌套坏链接带路径报红)、`--changed` docs-only 选 3 门 2.37s、`--resume` 跳过 20 条已过命令、本地 boundaries 全绿(除 GitHub-context 项);GitHub CI 为完整权威。

## 审查证据

- CEO 语义验收:只收窄本地、CI 不动、有阳性对照、manifest 字段最小。

## 残余风险

- 若某门的适用面声明过窄,相关改动在本地会被跳过;CI 仍全跑,失败会在 CI 而非本地暴露。

## 关联材料

- Fact `F-6B490D21`、`F-CE3129B9`;skill `skills/harness-contributing`。
