### PR TITLE
ci(gates): promote G0-② durable action authorization gate to required

### DIFF
--- a/tools/gate-manifest.json
+++ b/tools/gate-manifest.json
@@ -4759,10 +4759,10 @@
     },
     {
       "id": "ontology-durable-action-authorization",
-      "command": "node tools/gates/ontology-durable-action-authorization.mjs",
+      "command": "node tools/gates/ontology-durable-action-authorization.mjs --mode ratchet",
       "category": "boundary",
-      "tier": "pr-advisory",
-      "tierReason": "Phase G0 baseline observation only; G2 may promote this gate after every durable action reaches AuthorizationPort and receipts carry a non-null decision.",
+      "tier": "pr-required",
+      "tierReason": null,
       "authoritySource": [
         "task_6afb9b18781322b945d268d8f2",
         "harness/context/research/2026-08-23-ontology-architecture/ontology-adversarial-audit-report.md#f3-actor-role-policy-是真实切片但不是单一授权模型"
@@ -4773,8 +4773,8 @@
         "WriteReceipt authorizationDecision contract"
       ],
       "githubContext": {
-        "requiredContexts": [],
-        "workflowJobs": ["ontology-advisory"],
+        "requiredContexts": ["boundaries"],
+        "workflowJobs": ["boundaries"],
         "nodeVersions": [24]
       },
       "allowlistPolicy": {
@@ -4795,8 +4795,8 @@
       "bypassFixtureRequired": true,
       "executionSurfaces": {
         "packageJson": { "check": false, "checkPr": false, "script": null },
-        "rewriteCi": { "pullRequestJobs": ["ontology-advisory"], "nonPullRequestJobs": [] },
-        "branchProtection": { "required": false, "contexts": [] },
+        "rewriteCi": { "pullRequestJobs": ["boundaries"], "nonPullRequestJobs": [] },
+        "branchProtection": { "required": true, "contexts": ["boundaries"] },
         "classes": ["pr"]
       },
       "deterministic": true,


### PR DESCRIPTION
# English

## Summary

Promote Phase G advisory gate G0-② `ontology-durable-action-authorization` (every durable Action is authorized through the single Kernel `AuthorizationPort` and every receipt carries a non-null decision) to required, now that G2 (#2041) is on `main` and the gate reports `0/102` in ratchet mode. Only `tools/gate-manifest.json` changes (+7/-7): tier, ratchet mode, and the required-lane declarations. Gate script, baseline, allowlist, and workflows are untouched.

## Architectural Justification

- Ruling `dec_25B7694B` as refined by `dec_EB08E6F5` CH1: a gate becomes required exactly when the slice that deletes its old paths merges. G2 deleted the transport `commandClass` second authorization, synthetic derived roles, and direct authorization branches; on `main` the gate passes in ratchet mode and the positive control fired (`exit 1`) before being reverted — see the task report.
- G0-⑤/⑥ were promoted in #2039. G0-① (kind authority), ③ (event read truth), ④ stay advisory until G3a/G3b/G4 merge.
- No gate is weakened, no baseline moved upward, no exemption added.

## What Changed

- `tools/gate-manifest.json`: `ontology-durable-action-authorization` moves from `pr-advisory` (`ontology-advisory` job) to `pr-required` in the `boundaries` lane with `--mode ratchet`; `rewriteCi` / `branchProtection` declarations follow the manifest's existing required-gate shape. Manifest invariants pass.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none

## Machine-Readable Declarations

Production-Delta: +0/-0
Dependency-Change: none

### Optional Evidence Claims

None.

## Task And Scope

- Harness task: `task_5a71a25b9fff31f7d61b79d667` (Phase G governance)
- Branch: `codex/g0-promote-2`
- Public scope: gate manifest tier change for one gate.
- Private planning/evidence updated: yes — `artifacts/g0-promote-2-report.md`, Fact `F-35A49728` (0/102 ratchet + boundaries green on `main`).
- Out of scope: gates ①③④, gate script logic, GitHub branch protection itself (the `boundaries` context is already required in ruleset 18576233, so no remote change is needed).

## Version Impact

- Version: no change. Publish impact: none.

## Governance Declaration

- Protected surface touched: yes
- Protected surface scope: `tools/gate-manifest.json` (tier promotion of one existing gate).
- Authority: `dec_25B7694B4B33D2934726D13932` CH1 + `dec_EB08E6F5AFD9E5990CC9DF4F5F` CH1; task `task_5a71a25b9fff31f7d61b79d667`.
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no

## Verification

- Base `origin/main`: `1d2a97c9e974195081cddbb6b62b411bb4aa829f` (post #2041).
- Worker report: gate ratchet `0/102` on `main`; positive control exit 1 then reverted; `node tools/check-gate-manifest-invariants.mjs` green; boundaries 41 commands green (GitHub-token check excluded); typecheck green.
- [x] `git diff --check`
- [x] `npm run typecheck`
- [x] `npm run harness:check-import-boundaries`
- [x] `npm run harness:scan-forbidden-symbols`
- [x] `npm run harness:check-private-boundary`
- [x] `npm run harness:check-implementation-contracts`
- [ ] `npm run check` / `npm test` / others: GitHub CI is the authority.

## Review Evidence

- CEO semantic review: diff is exactly the tier/lane/mode change for one gate, same shape as #2039; nothing else touched.

## Residual Risk

- Any future Action added without a port trace now blocks its PR in `boundaries` — that is the intent.

## References

- `dec_25B7694B`, `dec_EB08E6F5`, `dec_B284A85A` CH6; PR #2041; Fact `F-35A49728`.

# 中文

## 概要

G2(#2041)已合入 main,G0-② 门 `ontology-durable-action-authorization`(每个 durable Action 经唯一 Kernel `AuthorizationPort` 授权、回执决策非空)在 ratchet 模式下报 `0/102`,本 PR 把它从 advisory 升为 required。只改 `tools/gate-manifest.json`(+7/-7):tier、ratchet 模式与 required lane 声明;门脚本、基线、allowlist、workflow 不动。

## 架构辩护

- dec_25B7694B 经 dec_EB08E6F5 CH1 细化:删旧路径的切片合入之时即是该门升 required 之时。G2 删除了 transport `commandClass` 第二授权、补造派生角色与直判分支;main 上该门 ratchet 绿,阳性对照 exit 1 后还原(见任务报告)。
- ⑤⑥ 已在 #2039 升;①③④ 等 G3a/G3b/G4 合入。
- 未削门、未上调基线、未加豁免。

## 改动内容

- `tools/gate-manifest.json`:该门从 `pr-advisory`(`ontology-advisory` job)升到 `boundaries` lane 的 `pr-required`,命令加 `--mode ratchet`;`rewriteCi`/`branchProtection` 按 manifest 既有 required 门写法。invariants 通过。

## 门收割 / Gate Harvest

- 删除的生产路径:无;删除的门/fixture:无。

## 机读声明说明

`Production-Delta` 由 gate 实测(只改 manifest,+0/-0)。

## 任务与范围

- Task `task_5a71a25b9fff31f7d61b79d667`;分支 `codex/g0-promote-2`;范围:一条门的 tier 变更;范围外:①③④、门脚本逻辑、GitHub 分支保护本体(`boundaries` context 已在 ruleset 18576233 里 required,无需远端改动)。

## 版本影响

- 不改版本、不发布。

## 治理声明

- 触碰受保护面:是——`tools/gate-manifest.json` 一条既有门升 tier;授权 dec_25B7694B CH1 + dec_EB08E6F5 CH1 + task;非 break-glass。

## 验证

- 基准 `origin/main` `1d2a97c9…`;worker:ratchet `0/102`、阳性对照 exit 1 后还原、manifest invariants 绿、boundaries 41 条绿(除 GitHub-token 项)、typecheck 绿;GitHub CI 为完整权威。

## 审查证据

- CEO 语义验收:diff 恰为一条门的 tier/lane/mode 变更,与 #2039 同形,别无他动。

## 残余风险

- 今后新增 Action 若无 port 追踪会在 `boundaries` 阻塞其 PR——这正是目的。

## 关联材料

- dec_25B7694B、dec_EB08E6F5、dec_B284A85A CH6;PR #2041;Fact `F-35A49728`。
