### PR TITLE
fix(kernel,daemon): dispatch closeout continuation on in_review tasks; add active→planned edge; hide archived packages from task list

### DIFF
--- a/packages/application/src/task-closeout-action.ts
+++ b/packages/application/src/task-closeout-action.ts
@@ -31,7 +31,13 @@ type Snapshot = CloseoutSnapshot & {
     | null;
   readonly lease: LeaseV1 | null;
 };
-export type CloseoutStep = "submit" | "review-execution" | "review-consent" | "complete" | "task-show";
+export type CloseoutStep =
+  | "preset-upgrade"
+  | "submit"
+  | "review-execution"
+  | "review-consent"
+  | "complete"
+  | "task-show";
 export interface TaskCloseoutActionDependencies {
   readonly rootDir: string;
   readonly action: Readonly<Record<string, unknown>>;
@@ -40,6 +46,7 @@ export interface TaskCloseoutActionDependencies {
   readonly opId: string;
   readonly readWorkspaceText: (rootDir: string, requested: string, field: string) => string;
   readonly read: () => Promise<Snapshot>;
+  readonly presetSnapshotCurrent: () => boolean;
   readonly invoke: (
     stage: CloseoutStep,
     action: Readonly<Record<string, unknown>>,
@@ -246,6 +253,10 @@ export async function runTaskCloseoutAction(dependencies: TaskCloseoutActionDepe
       ...reject(opId, "actor_unauthorized", `The active lease holder must run ${invocation}.`),
       authorizationDecision: closeoutAuthorization,
     };
+  if (!dependencies.presetSnapshotCurrent()) {
+    const stopped = await invoke("preset-upgrade", { kind: "preset-upgrade", taskId }, caller);
+    if (stopped) return stopped;
+  }
   if (stage <= 0) {
     const stopped = await invoke(
       "submit",
@@ -312,13 +323,15 @@ export async function runTaskCloseoutAction(dependencies: TaskCloseoutActionDepe
     const row = receipt as WriteReceipt & { readonly next?: readonly { readonly command?: string }[] },
       candidate = receipt.nextAction ?? row.next?.[0]?.command ?? "",
       fallback =
-        name === "submit"
-          ? `The active lease holder must run ${invocation}.`
-          : name === "review-execution"
-            ? `Have an independent arbiter run ${invocation}.`
-            : name === "review-consent"
-              ? `The Task owner must run ${invocation}.`
-              : `Run ha task complete ${taskId} to inspect the blocking gate, then retry ${invocation}.`,
+        name === "preset-upgrade"
+          ? `Retry ${invocation} after the preset upgrade reaches the canonical projection.`
+          : name === "submit"
+            ? `The active lease holder must run ${invocation}.`
+            : name === "review-execution"
+              ? `Have an independent arbiter run ${invocation}.`
+              : name === "review-consent"
+                ? `The Task owner must run ${invocation}.`
+                : `Run ha task complete ${taskId} to inspect the blocking gate, then retry ${invocation}.`,
       nextAction = /\bha\s/u.test(candidate) ? candidate : fallback;
     return {
       ...receipt,

--- a/packages/daemon/src/repo-cell-api.ts
+++ b/packages/daemon/src/repo-cell-api.ts
@@ -1,6 +1,7 @@
 import { createHash } from "node:crypto";
 import {
   assertCurrentWriter,
+  currentSubmittedExecutions,
   durablePolicyActions,
   getExecutableEntityAction,
   projectDecisionReadiness,
@@ -726,9 +727,16 @@ export function createRepoCellApi(context: RepoCellApiContext): RepoCell {
               .digest("hex")
               .slice(0, 32)}`
           : null,
-        taskLease = taskId ? context.projection.currentLease(taskId) : null;
+        taskLease = taskId ? context.projection.currentLease(taskId) : null,
+        taskSnapshot = taskId ? context.projection.read(taskId).snapshot : null,
+        reviewContinuation =
+          taskSnapshot?.task?.status === "in_review" &&
+          taskSnapshot.task.currentNode === "review" &&
+          taskSnapshot.lease === null &&
+          currentSubmittedExecutions(taskSnapshot).length === 1;
       if (
         taskId &&
+        !reviewContinuation &&
         (taskLease === null || taskLease.phase === "released") &&
         (!dispatchOpId || context.store.readEvent(dispatchOpId) === null)
       ) {

--- a/packages/daemon/src/repo-cell-closeout.ts
+++ b/packages/daemon/src/repo-cell-closeout.ts
@@ -1,6 +1,7 @@
 import { runTaskCloseoutAction } from "../../application/src/task-closeout-action.ts";
 import { closeoutReadiness, type WriteReceiptDraft } from "../../kernel/src/index.ts";
 import { authorizeRepoCellAction } from "./repo-cell-authorization.ts";
+import { isPresetSnapshotCurrent } from "./repo-cell-task-progress.ts";
 import type { RepoCellOperationalContext } from "./repo-cell-action-context.ts";
 import type { RepoCellBinding, RepoTaskAction, Snapshot } from "./repo-cell-types.ts";
 
@@ -32,6 +33,16 @@ export async function closeoutTask(
         readonly task: NonNullable<Snapshot["task"]>;
         readonly lease: Snapshot["lease"];
       },
+    presetSnapshotCurrent: () => {
+      const projected = cell.projection.read(taskId);
+      return isPresetSnapshotCurrent(
+        cell,
+        taskId,
+        projected.snapshot,
+        projected.packagePath,
+        `ha task closeout ${taskId} --from-file ${String(action.fromFile)}`,
+      );
+    },
     invoke: async (stage, leaf, actor) => {
       const leafAction = leaf as RepoTaskAction,
         revision = cell.store.readHead()?.revision ?? 0,
@@ -55,6 +66,7 @@ export async function closeoutTask(
           authorizationDecision,
         };
       if (stage === "task-show") return cell.showTask(taskId);
+      if (stage === "preset-upgrade") return cell.upgradePresetSnapshot(leafAction, leafBinding);
       if (stage === "complete") return cell.completeTask(leafAction, leafBinding);
       return cell.lifecycleAction(leafAction, leafBinding);
     },

--- a/packages/daemon/src/repo-cell-packets.ts
+++ b/packages/daemon/src/repo-cell-packets.ts
@@ -143,43 +143,45 @@ export function lifecycleReceipt(
     checks = gateChecks(snapshot, executionId ?? ""),
     missingGate = checks.find((value) => value.status === "blocked")?.gate,
     nextCommand =
-      snapshot.task?.status === "active" && executionId
-        ? `ha task submit ${event.taskId} --json-input '<submission-json>'`
-        : snapshot.task?.status === "active"
-          ? `ha task start ${event.taskId} --execution-id <id>`
-          : snapshot.task?.status !== "in_review"
-            ? null
-            : !approved.length
-              ? declarationNeeded
-                ? [
-                    "ha task declare-executor ",
-                    `${event.taskId}`,
-                    " --execution-id ",
-                    `${executionId}`,
-                    " --reason <auditable-recovery-reason>",
-                  ].join("")
-                : [
-                    "ha task review-execution ",
-                    `${event.taskId}`,
-                    " --execution-id ",
-                    `${executionId}`,
-                    " --review-id <id> --from-file <review.json>",
-                  ].join("")
-              : !selected
-                ? [
-                    "ha task review-consent ",
-                    `${event.taskId}`,
-                    " --execution-id ",
-                    `${executionId}`,
-                    " --review-id ",
-                    `${consentReviewId}`,
-                    " --consent-id <id>",
-                  ].join("")
-                : missingGate === "ci"
-                  ? `ha task complete ${event.taskId} --execution-id ${executionId} --ci passed`
-                  : missingGate === "code-doc-reconciliation"
-                    ? `ha task code-doc reconcile ${event.taskId}`
-                    : `ha task complete ${event.taskId} --execution-id ${executionId}`,
+      event.type === "lease_released" && snapshot.task?.status === "active"
+        ? `ha task transition ${event.taskId} planned --reason <why-work-is-returning-to-planning>`
+        : snapshot.task?.status === "active" && executionId
+          ? `ha task submit ${event.taskId} --json-input '<submission-json>'`
+          : snapshot.task?.status === "active"
+            ? `ha task start ${event.taskId} --execution-id <id>`
+            : snapshot.task?.status !== "in_review"
+              ? null
+              : !approved.length
+                ? declarationNeeded
+                  ? [
+                      "ha task declare-executor ",
+                      `${event.taskId}`,
+                      " --execution-id ",
+                      `${executionId}`,
+                      " --reason <auditable-recovery-reason>",
+                    ].join("")
+                  : [
+                      "ha task review-execution ",
+                      `${event.taskId}`,
+                      " --execution-id ",
+                      `${executionId}`,
+                      " --review-id <id> --from-file <review.json>",
+                    ].join("")
+                : !selected
+                  ? [
+                      "ha task review-consent ",
+                      `${event.taskId}`,
+                      " --execution-id ",
+                      `${executionId}`,
+                      " --review-id ",
+                      `${consentReviewId}`,
+                      " --consent-id <id>",
+                    ].join("")
+                  : missingGate === "ci"
+                    ? `ha task complete ${event.taskId} --execution-id ${executionId} --ci passed`
+                    : missingGate === "code-doc-reconciliation"
+                      ? `ha task code-doc reconcile ${event.taskId}`
+                      : `ha task complete ${event.taskId} --execution-id ${executionId}`,
     next = nextCommand
       ? [
           {

--- a/packages/daemon/src/repo-cell-task-progress.ts
+++ b/packages/daemon/src/repo-cell-task-progress.ts
@@ -362,14 +362,13 @@ function factRetirementBlocker(taskId: string, executionId: string, assessment: 
   } as const;
 }
 
-export function completionContext(
+function currentPresetSnapshotDigest(
   cell: RepoCellOperationalContext,
   taskId: string,
   snapshot: Snapshot,
   packagePath: string | null,
-  binding: RepoCellBinding,
   retryCommand: string,
-): CompletionReadinessContext {
+): string {
   if (!packagePath || !snapshot.task?.presetSnapshotDigest)
     throw cell.cellCodedError(
       "content_not_ready",
@@ -396,7 +395,34 @@ export function completionContext(
         taskClass: contract.taskClass,
       },
     });
-  if (current.snapshot.digest !== snapshot.task.presetSnapshotDigest)
+  return current.snapshot.digest;
+}
+
+export function isPresetSnapshotCurrent(
+  cell: RepoCellOperationalContext,
+  taskId: string,
+  snapshot: Snapshot,
+  packagePath: string | null,
+  retryCommand: string,
+): boolean {
+  return (
+    currentPresetSnapshotDigest(cell, taskId, snapshot, packagePath, retryCommand) ===
+    snapshot.task?.presetSnapshotDigest
+  );
+}
+
+export function completionContext(
+  cell: RepoCellOperationalContext,
+  taskId: string,
+  snapshot: Snapshot,
+  packagePath: string | null,
+  binding: RepoCellBinding,
+  retryCommand: string,
+): CompletionReadinessContext {
+  if (
+    currentPresetSnapshotDigest(cell, taskId, snapshot, packagePath, retryCommand) !==
+    snapshot.task?.presetSnapshotDigest
+  )
     throw cell.cellCodedError("preset_snapshot_mismatch", `Run ha preset upgrade ${taskId} before completion.`);
   const closeoutDocument = readTaskTransitionDocument({
       projection: cell.projection,

--- a/packages/daemon/src/repo-cell-task-query.ts
+++ b/packages/daemon/src/repo-cell-task-query.ts
@@ -66,22 +66,25 @@ export function listTasks(cell: TaskQueryCell, action: RepoTaskAction, binding: 
   const read = cell.projection.readTaskIndex();
   let selected: ReturnType<typeof selectTaskIndex>;
   try {
-    selected = selectTaskIndex(read.rows, {
-      ...(typeof action.parentTaskId === "string" ? { parentTaskId: action.parentTaskId } : {}),
-      ...(depth === undefined ? {} : { depth }),
-      filters: {
-        ...(query.status ? { status: query.status } : {}),
-        ...(typeof action.module === "string" ? { module: action.module } : {}),
-        ...(typeof action.workKind === "string" ? { workKind: action.workKind } : {}),
-        ...(typeof action.riskTier === "string" ? { riskTier: action.riskTier } : {}),
-        ...(typeof action.urgency === "string" ? { urgency: action.urgency } : {}),
-        ...(typeof action.search === "string" ? { search: action.search } : {}),
-        ...(query.updatedAfter ? { updatedAfter: query.updatedAfter } : {}),
-        ...(query.updatedBefore ? { updatedBefore: query.updatedBefore } : {}),
+    selected = selectTaskIndex(
+      read.rows.filter((row) => row.packageDisposition === "active"),
+      {
+        ...(typeof action.parentTaskId === "string" ? { parentTaskId: action.parentTaskId } : {}),
+        ...(depth === undefined ? {} : { depth }),
+        filters: {
+          ...(query.status ? { status: query.status } : {}),
+          ...(typeof action.module === "string" ? { module: action.module } : {}),
+          ...(typeof action.workKind === "string" ? { workKind: action.workKind } : {}),
+          ...(typeof action.riskTier === "string" ? { riskTier: action.riskTier } : {}),
+          ...(typeof action.urgency === "string" ? { urgency: action.urgency } : {}),
+          ...(typeof action.search === "string" ? { search: action.search } : {}),
+          ...(query.updatedAfter ? { updatedAfter: query.updatedAfter } : {}),
+          ...(query.updatedBefore ? { updatedBefore: query.updatedBefore } : {}),
+        },
+        ...(query.limit === undefined ? {} : { limit: query.limit }),
+        ...(query.cursor === undefined ? {} : { cursor: query.cursor }),
       },
-      ...(query.limit === undefined ? {} : { limit: query.limit }),
-      ...(query.cursor === undefined ? {} : { cursor: query.cursor }),
-    });
+    );
   } catch (error) {
     if (error instanceof Error && error.message === "task list cursor is invalid")
       throw cell.cellCodedError("invalid_command", "Task list cursor is invalid; restart the filtered query.");

--- a/packages/daemon/src/runtime-spawner.ts
+++ b/packages/daemon/src/runtime-spawner.ts
@@ -9,6 +9,7 @@ import type {
 } from "../../kernel/src/index.ts";
 import {
   consumeKnownError,
+  currentSubmittedExecutions,
   isSameExecution,
   isSamePerson,
   resolveTaskBoundRuntimeBinding,
@@ -273,6 +274,14 @@ export function makeRuntimeSpawner(input: RuntimeSpawnerInput) {
       projection = input.remote ? null : requiredRuntimeProjection(input),
       remoteTask = taskId && input.remote ? await input.remote.taskContext(taskId, missionName) : null,
       lease = taskId && !input.remote ? projection!.currentLease(taskId) : null,
+      taskSnapshot = taskId && !input.remote ? projection!.read(taskId).snapshot : null,
+      reviewExecutions =
+        taskSnapshot?.task?.status === "in_review" &&
+        taskSnapshot.task.currentNode === "review" &&
+        taskSnapshot.lease === null
+          ? currentSubmittedExecutions(taskSnapshot)
+          : [],
+      reviewExecution = reviewExecutions.length === 1 ? reviewExecutions[0]! : null,
       hash = createHash("sha256").update(`${input.repoId}\0${idempotencyKey}`).digest("hex"),
       newDispatchId = `dispatch_${hash.slice(0, 24)}`,
       runtimeSessionId = `runtime_${hash.slice(24, 48)}`,
@@ -297,7 +306,7 @@ export function makeRuntimeSpawner(input: RuntimeSpawnerInput) {
           "authorization_missing",
           "Runtime dispatch requires the center AuthorizationPort decision.",
         );
-      if (!leaseQualifies)
+      if (!leaseQualifies && reviewExecution === null)
         throw runtimeSpawnError("runtime_task_lease_required", runtimeTaskLeaseRequiredMessage(taskId, lease));
     }
     const daemonRoute = taskId || trustedSchedule ? input.runtimeDaemonRoute : undefined;
@@ -506,7 +515,7 @@ export function makeRuntimeSpawner(input: RuntimeSpawnerInput) {
     const taskBinding = taskId
         ? {
             taskId,
-            executionId: remoteTask?.executionId ?? lease!.executionId,
+            executionId: remoteTask?.executionId ?? lease?.executionId ?? reviewExecution!.executionId,
             leaseVersion: lease?.version ?? null,
           }
         : null,

--- a/packages/daemon/test/closeout-ci-judgment-contract.test.ts
+++ b/packages/daemon/test/closeout-ci-judgment-contract.test.ts
@@ -20,27 +20,110 @@ import type { ActorIdentity, WriteReceipt } from "../../kernel/src/index.ts";
 import { runTaskCloseoutAction } from "../../application/src/task-closeout-action.ts";
 import { readWorkspaceText } from "../src/workspace-text-port.ts";
 
-const taskId = "task-ci-judgment", executionId = "execution-ci-judgment", commitSha = "b".repeat(40);
+const taskId = "task-ci-judgment",
+  executionId = "execution-ci-judgment",
+  commitSha = "b".repeat(40);
 const person: ActorIdentity = { principal: { personId: "owner" }, executor: { kind: "agent", id: "owner-agent" } };
-const submission = { completionClaim: "Docs only.", deliverables: ["report"], outputs: ["artifact"], verificationNotes: ["read"], knownGaps: [], residualRisks: [], commitSha };
+const submission = {
+  completionClaim: "Docs only.",
+  deliverables: ["report"],
+  outputs: ["artifact"],
+  verificationNotes: ["read"],
+  knownGaps: [],
+  residualRisks: [],
+  commitSha,
+};
 
 /** A docs-shaped judgment packet whose CI posture the caller chooses, so both postures meet both contracts. */
-function packet(ci: string) { return { submission, review: { verdict: "approved", reason: "Reviewed.", evidenceChecked: ["report"] }, consent: { approved: true }, completion: { ci, codeDocPaths: [] } }; }
+function packet(ci: string) {
+  return {
+    submission,
+    review: { verdict: "approved", reason: "Reviewed.", evidenceChecked: ["report"] },
+    consent: { approved: true },
+    completion: { ci, codeDocPaths: [] },
+  };
+}
 /** completionGateIds is the whole point of the fixture: it is preset-owned and fixed at task creation. */
 function fixture(completionGateIds: readonly string[], status = "active") {
-  return { revision: 2, task: { schema: "task/v1", taskId, title: "CI judgment", taskClass: "standard", status, graph: { maxIterations: 1, nodes: [], edges: [] }, currentNode: "implementation", iteration: 0, createdBy: person, completionGateIds, presetSnapshotDigest: null },
-    executions: [{ schema: "execution/v1", executionId, taskId, nodeId: "implementation", iteration: 0, state: "active", actor: person, claimedAt: "2026-08-24T00:00:00.000Z", submittedAt: null, closedAt: null, submission: null }],
-    reviews: [], consents: [], codeDocWitnesses: [], gateWitnesses: [], edgesTaken: [], lease: { schema: "lease/v1", taskId, executionId, actor: person, source: "local", phase: "held", expiresAt: "2026-08-24T01:00:00.000Z", ttlMs: 1, version: 0 }, decisionRelations: [] };
+  return {
+    revision: 2,
+    task: {
+      schema: "task/v1",
+      taskId,
+      title: "CI judgment",
+      taskClass: "standard",
+      status,
+      graph: { maxIterations: 1, nodes: [], edges: [] },
+      currentNode: "implementation",
+      iteration: 0,
+      createdBy: person,
+      completionGateIds,
+      presetSnapshotDigest: null,
+    },
+    executions: [
+      {
+        schema: "execution/v1",
+        executionId,
+        taskId,
+        nodeId: "implementation",
+        iteration: 0,
+        state: "active",
+        actor: person,
+        claimedAt: "2026-08-24T00:00:00.000Z",
+        submittedAt: null,
+        closedAt: null,
+        submission: null,
+      },
+    ],
+    reviews: [],
+    consents: [],
+    codeDocWitnesses: [],
+    gateWitnesses: [],
+    edgesTaken: [],
+    lease: {
+      schema: "lease/v1",
+      taskId,
+      executionId,
+      actor: person,
+      source: "local",
+      phase: "held",
+      expiresAt: "2026-08-24T01:00:00.000Z",
+      ttlMs: 1,
+      version: 0,
+    },
+    decisionRelations: [],
+  };
 }
 async function closeout(completionGateIds: readonly string[], ci: string, status = "active") {
-  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-closeout-ci-")), fromFile = "judgment.json", completeCalls: Array<Readonly<Record<string, unknown>>> = [];
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-closeout-ci-")),
+    fromFile = "judgment.json",
+    completeCalls: Array<Readonly<Record<string, unknown>>> = [];
   writeFileSync(path.join(rootDir, fromFile), JSON.stringify(packet(ci)));
   try {
-    const receipt = await runTaskCloseoutAction({ rootDir, action: { kind: "task-closeout", taskId, fromFile }, caller: person, opId: "op-ci-judgment", readWorkspaceText,
+    const receipt = await runTaskCloseoutAction({
+      rootDir,
+      action: { kind: "task-closeout", taskId, fromFile },
+      caller: person,
+      opId: "op-ci-judgment",
+      readWorkspaceText,
       read: async () => fixture(completionGateIds, status) as never,
-      invoke: async (stage, action) => { if (stage === "complete") completeCalls.push(action); return { outcome: "applied", opId: `op-${stage}`, revision: 3, evidence: `event:${stage}`, visibility: "center", proof: { committedRevision: 3, appliedCut: 3, durable: true, canonicalVisible: true, worktreeVisible: true } } as WriteReceipt; } });
+      presetSnapshotCurrent: () => true,
+      invoke: async (stage, action) => {
+        if (stage === "complete") completeCalls.push(action);
+        return {
+          outcome: "applied",
+          opId: `op-${stage}`,
+          revision: 3,
+          evidence: `event:${stage}`,
+          visibility: "center",
+          proof: { committedRevision: 3, appliedCut: 3, durable: true, canonicalVisible: true, worktreeVisible: true },
+        } as WriteReceipt;
+      },
+    });
     return { receipt, completeCalls };
-  } finally { rmSync(rootDir, { recursive: true, force: true }); }
+  } finally {
+    rmSync(rootDir, { recursive: true, force: true });
+  }
 }
 
 test("a task whose contract declares no ci gate closes out on the honest not_applicable", async () => {
@@ -70,17 +153,24 @@ test("a declared ci gate cannot be waved away as not_applicable", async () => {
 });
 
 test("the ci value domain stays closed, so no third token slips through either contract", async () => {
-  for (const gates of [[], ["ci"]] as const) for (const ci of ["failed", "skipped", "PASSED", "", "true"]) {
-    const { receipt } = await closeout(gates, ci);
-    assert.equal(receipt.code, "invalid_judgment", `${ci} was accepted for gates ${JSON.stringify(gates)}`);
-  }
+  for (const gates of [[], ["ci"]] as const)
+    for (const ci of ["failed", "skipped", "PASSED", "", "true"]) {
+      const { receipt } = await closeout(gates, ci);
+      assert.equal(receipt.code, "invalid_judgment", `${ci} was accepted for gates ${JSON.stringify(gates)}`);
+    }
 });
 
 test("not_applicable reaches the leaf as an omitted --ci flag rather than a value it would reject", async () => {
   const absent = await closeout([], "not_applicable");
-  assert.deepEqual(absent.completeCalls.map((action) => Object.hasOwn(action, "ci")), [false]);
+  assert.deepEqual(
+    absent.completeCalls.map((action) => Object.hasOwn(action, "ci")),
+    [false],
+  );
   const present = await closeout(["ci"], "passed");
-  assert.deepEqual(present.completeCalls.map((action) => action.ci), ["passed"]);
+  assert.deepEqual(
+    present.completeCalls.map((action) => action.ci),
+    ["passed"],
+  );
 });
 
 test("a lifecycle state that blocks closeout is reported before the CI judgment, so the first error is the one actually blocking", async () => {

--- a/packages/daemon/test/runtime-spawn-ingress.integration.test.ts
+++ b/packages/daemon/test/runtime-spawn-ingress.integration.test.ts
@@ -349,6 +349,67 @@ test("daemon ingress preserves executor-scoped task-bound runtime spawn", async 
       assert.equal(start?.type, "execution_started");
       if (start?.type === "execution_started") assert.equal(start.payload.lease.actor.executor, null);
     });
+    await t.test("an in-review task dispatches a closeout continuation without reopening execution", async () => {
+      const taskId = "task-runtime-review-continuation",
+        executionId = "exec-runtime-review-continuation";
+      await createReadyTask(taskId, "Runtime review continuation");
+      assert.equal((await host.run(repoId, { kind: "task-start", taskId, executionId }, auth)).outcome, "applied");
+      assert.equal(
+        (
+          await host.run(
+            repoId,
+            {
+              kind: "task-submit",
+              taskId,
+              executionId,
+              submission: {
+                completionClaim: "Continue the closeout round.",
+                deliverables: ["review continuation"],
+                outputs: ["runtime dispatch"],
+                verificationNotes: ["integration"],
+                knownGaps: [],
+                residualRisks: [],
+                commitSha: "a".repeat(40),
+              },
+            },
+            auth,
+          )
+        ).outcome,
+        "applied",
+      );
+      const before = makeTaskEventStore({ repoId, rootDir: root })
+        .read()
+        .events.filter((event) => event.type === "execution_started" && event.taskId === taskId).length;
+      const receipt = await rpc(host, auth, "repo.agentRuntime.spawn", {
+        repo: { repoId },
+        payload: {
+          runtimeInstanceId: ingressDefinition.instanceId,
+          cwd: { scope: "repo-root" },
+          prompt: "Continue review and closeout.",
+          taskId,
+          idempotencyKey: "runtime-review-continuation",
+        },
+      });
+      assert.equal(receipt.outcome, "applied", JSON.stringify(receipt));
+      const events = makeTaskEventStore({ repoId, rootDir: root }).read().events;
+      assert.equal(
+        events.filter((event) => event.type === "execution_started" && event.taskId === taskId).length,
+        before,
+        "review continuation must not reopen or replace the submitted execution",
+      );
+      const bound = await eventuallyValue(
+        async () =>
+          makeTaskEventStore({ repoId, rootDir: root })
+            .read()
+            .events.find(
+              (event) =>
+                event.type === "runtime_session_task_bound" &&
+                event.payload.runtimeSessionId === receipt.runtimeSessionId,
+            ) ?? null,
+      );
+      assert.equal(bound?.type, "runtime_session_task_bound");
+      if (bound?.type === "runtime_session_task_bound") assert.equal(bound.payload.executionId, executionId);
+    });
     await t.test("human lease remains task-bindable without an executor", async () => {
       const taskId = "task-runtime-human",
         executionId = "exec-runtime-human";

--- a/packages/daemon/test/task-closeout-action.test.ts
+++ b/packages/daemon/test/task-closeout-action.test.ts
@@ -130,6 +130,7 @@ function setup(
     taskId,
     fromFile: "judgment.json",
   },
+  presetSnapshotCurrent = true,
 ) {
   const rootDir = mkdtempSync(path.join(tmpdir(), "ha-closeout-action-")),
     fromFile = "judgment.json";
@@ -148,6 +149,7 @@ function setup(
         opId: "op-closeout",
         readWorkspaceText,
         read: async () => initial as never,
+        presetSnapshotCurrent: () => presetSnapshotCurrent,
         invoke: async (stage, action, stepActor) => {
           calls.push({ stage, action, actor: stepActor });
           return stage === rejectStage
@@ -188,6 +190,20 @@ test("closeout runs four canonical leaf commands without impersonating the creat
       ["worker-agent", null, "worker-agent", "worker-agent"],
     );
     assert.deepEqual(value.calls.at(-1)?.action.paths, ["packages/application/src/task-closeout-action.ts"]);
+  } finally {
+    rmSync(value.rootDir, { recursive: true, force: true });
+  }
+});
+test("closeout upgrades a stale preset snapshot before the first lifecycle mutation", async () => {
+  const value = setup(snapshot(), undefined, caller, undefined, false);
+  try {
+    const receipt = await value.run();
+    assert.equal(receipt.outcome, "applied");
+    assert.deepEqual(
+      value.calls.map(({ stage }) => stage),
+      ["preset-upgrade", "submit", "review-execution", "review-consent", "complete"],
+    );
+    assert.deepEqual(value.calls[0]?.action, { kind: "preset-upgrade", taskId });
   } finally {
     rmSync(value.rootDir, { recursive: true, force: true });
   }

--- a/packages/daemon/test/task-wip.integration.test.ts
+++ b/packages/daemon/test/task-wip.integration.test.ts
@@ -297,7 +297,7 @@ test("a standard task becomes a visible structure-derived root without rewriting
   }
 });
 
-test("task list rows expose packageDisposition and taskClass so the occupancy count is independently recomputable", async () => {
+test("task list exposes active package metadata and excludes archived packages from the worktable", async () => {
   const rootDir = mkdtempSync(path.join(tmpdir(), "ha-task-wip-projection-"));
   let cell: Cell | undefined;
   try {
@@ -345,8 +345,8 @@ test("task list rows expose packageDisposition and taskClass so the occupancy co
     assert.equal(byTask.get("task_STD")?.taskClass, "standard");
     assert.equal(byTask.get("task_STD")?.packageDisposition, "active");
     assert.equal(byTask.get("task_MILESTONE")?.taskClass, "milestone");
-    assert.equal(byTask.get("task_ARCHIVED")?.packageDisposition, "archived");
-    // The gate's counting criteria, recomputed only from list rows: 3 active-status rows, 1 occupying slot.
+    assert.equal(byTask.has("task_ARCHIVED"), false);
+    // The gate's counting criteria, recomputed only from visible worktable rows: 1 occupying slot.
     const occupying = rows.filter(
       (row) =>
         ["active", "blocked", "in_review"].includes(row.status) &&
@@ -356,6 +356,84 @@ test("task list rows expose packageDisposition and taskClass so the occupancy co
     assert.deepEqual(
       occupying.map((row) => row.taskId),
       ["task_STD"],
+    );
+  } finally {
+    await cell?.close();
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});
+
+test("a released active task returns to planned while held leases and stale writers reject", async () => {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-task-return-planned-"));
+  let cell: Cell | undefined;
+  try {
+    initRepo(rootDir);
+    cell = await openRepoCell({
+      repoId: workspaceId("task-return-planned"),
+      rootDir: canonicalRoot(rootDir),
+      ownerId: "task-return-planned",
+      now: () => "2026-08-30T00:00:00.000Z",
+    });
+    const binding = { actor, source: "local" as const },
+      taskId = "task_RETURN_PLANNED";
+    await createReadyTask(cell, rootDir, taskId, "Return released work to planning");
+    assert.equal(
+      (await cell.run({ kind: "task-start", taskId, executionId: "exe_return_planned" }, binding)).outcome,
+      "applied",
+    );
+    const held = await cell.run(
+      { kind: "task-transition", taskId, status: "planned", reason: "Scope needs replanning" },
+      binding,
+    );
+    assert.equal(held.outcome, "op_rejected");
+    assert.equal(held.code, "invalid_transition");
+    assert.match(String(held.nextAction), /unleased active task/u);
+
+    const released = await cell.run(
+      { kind: "task-release", taskId, reason: "No worker remains; return scope to planning" },
+      binding,
+    );
+    assert.equal(released.outcome, "applied");
+    assert.match(
+      String((released.next as readonly { readonly command?: string }[] | undefined)?.[0]?.command),
+      new RegExp(`ha task transition ${taskId} planned --reason`, "u"),
+    );
+
+    const expectedVersion = released.revision,
+      attempts = await Promise.all([
+        cell.run(
+          {
+            kind: "task-transition",
+            taskId,
+            status: "planned",
+            reason: "Owner returned orphaned work to planning",
+            expectedVersion,
+          },
+          binding,
+        ),
+        cell.run(
+          {
+            kind: "task-transition",
+            taskId,
+            status: "planned",
+            reason: "Concurrent return to planning",
+            expectedVersion,
+          },
+          binding,
+        ),
+      ]),
+      applied = attempts.filter((receipt) => receipt.outcome === "applied"),
+      rejected = attempts.filter((receipt) => receipt.outcome === "op_rejected");
+    assert.equal(applied.length, 1, JSON.stringify(attempts));
+    assert.equal(rejected.length, 1, JSON.stringify(attempts));
+    assert.equal(rejected[0]?.code, "invalid_transition");
+    assert.equal(
+      (
+        JSON.parse(String((await cell.run({ kind: "task-show", taskId }, binding)).evidence)) as {
+          readonly task: { readonly status: string };
+        }
+      ).task.status,
+      "planned",
     );
   } finally {
     await cell?.close();

--- a/packages/kernel/src/domain/lifecycle-status.ts
+++ b/packages/kernel/src/domain/lifecycle-status.ts
@@ -1,13 +1,6 @@
-export const domainStatuses = [
-  "planned",
-  "active",
-  "blocked",
-  "in_review",
-  "done",
-  "cancelled"
-] as const;
+export const domainStatuses = ["planned", "active", "blocked", "in_review", "done", "cancelled"] as const;
 
-export type DomainStatus = typeof domainStatuses[number];
+export type DomainStatus = (typeof domainStatuses)[number];
 export type CanonicalStatus = DomainStatus;
 export type StatusCoarseClass = "open" | "terminal";
 export type StatusTransitionRejectionReason = "terminal_status" | "unsupported_transition";
@@ -19,18 +12,12 @@ export const openDomainStatuses = [
   "planned",
   "active",
   "blocked",
-  "in_review"
-] as const satisfies ReadonlyArray<DomainStatus>;
-
-export const terminalDomainStatuses = [
-  "done",
-  "cancelled"
-] as const satisfies ReadonlyArray<DomainStatus>;
-
-export const reviewArtifactStatuses = [
   "in_review",
-  "done"
 ] as const satisfies ReadonlyArray<DomainStatus>;
+
+export const terminalDomainStatuses = ["done", "cancelled"] as const satisfies ReadonlyArray<DomainStatus>;
+
+export const reviewArtifactStatuses = ["in_review", "done"] as const satisfies ReadonlyArray<DomainStatus>;
 
 export function isDomainStatus(value: string): value is DomainStatus {
   return (domainStatuses as ReadonlyArray<string>).includes(value);
@@ -55,11 +42,11 @@ export const reinstateTaskTargets = ["planned", "active", "in_review"] as const 
 
 const allowedStatusTransitions = {
   planned: ["active", "blocked", "cancelled"],
-  active: ["blocked", "in_review", "done", "cancelled"],
+  active: ["planned", "blocked", "in_review", "done", "cancelled"],
   blocked: ["active", "cancelled"],
   in_review: ["active", "blocked", "done", "cancelled"],
   done: [],
-  cancelled: reinstateTaskTargets
+  cancelled: reinstateTaskTargets,
 } as const satisfies Record<DomainStatus, ReadonlyArray<DomainStatus>>;
 
 export function explainStatusTransition(from: DomainStatus, to: DomainStatus): StatusTransitionExplanation {

--- a/packages/kernel/src/domain/task-lifecycle-command-transitions.ts
+++ b/packages/kernel/src/domain/task-lifecycle-command-transitions.ts
@@ -284,6 +284,34 @@ export const reinstate: Transition = {
       (raw as TransitionTaskCommand).status as "planned" | "active" | "in_review",
     ),
 };
+export const returnToPlanned: Transition = {
+  id: "return_to_planned",
+  commandType: "TransitionTask",
+  from: "active",
+  proof: ["auditedReason"],
+  eventType: "task_transitioned",
+  matches: (command, snapshot) =>
+    command.type === "TransitionTask" && command.status === "planned" && snapshot.task?.status === "active",
+  validate: (snapshot, raw) => {
+    const command = raw as TransitionTaskCommand,
+      issues = revisionIssues(snapshot, command);
+    if (
+      snapshot.task?.status !== "active" ||
+      snapshot.lease !== null ||
+      !explainStatusTransition("active", "planned").allowed
+    )
+      issues.push(
+        lifecycleContractIssue(
+          "invalid_transition",
+          "ReturnToPlanned requires an unleased active task after its execution lease is released",
+        ),
+      );
+    if (!isNonEmptyString(command.reason))
+      issues.push(lifecycleContractIssue("invalid_schema", "ReturnToPlanned requires an auditable reason"));
+    return issues;
+  },
+  reduce: (snapshot, raw) => transitionTask(snapshot, raw as TransitionTaskCommand, "planned"),
+};
 export const unblock: Transition = {
   id: "unblock_task",
   commandType: "TransitionTask",

--- a/packages/kernel/src/domain/task-lifecycle-transitions.ts
+++ b/packages/kernel/src/domain/task-lifecycle-transitions.ts
@@ -1,5 +1,14 @@
 import type { Transition } from "./task-lifecycle-contract-internal-types.ts";
-import { block, cancel, create, reinstate, start, submit, unblock } from "./task-lifecycle-command-transitions.ts";
+import {
+  block,
+  cancel,
+  create,
+  reinstate,
+  returnToPlanned,
+  start,
+  submit,
+  unblock,
+} from "./task-lifecycle-command-transitions.ts";
 import { complete, consent, reconcile, review } from "./task-lifecycle-review-transitions.ts";
 import { repoint } from "./task-lifecycle-code-doc-repoint.ts";
 
@@ -9,6 +18,7 @@ export const TASK_LIFECYCLE_TRANSITIONS: readonly Transition[] = Object.freeze([
   start,
   block,
   reinstate,
+  returnToPlanned,
   unblock,
   cancel,
   submit,

--- a/packages/kernel/test/contracts/kernel-index.test.ts
+++ b/packages/kernel/test/contracts/kernel-index.test.ts
@@ -5,28 +5,28 @@ import * as kernel from "../../src/index.ts";
 
 test("kernel public source index is importable by the explicit TS test runner", () => {
   assert.equal(kernel.REPLAY_TASK_GRAPH.template, "replay/v1");
-  assert.deepEqual(kernel.TASK_LIFECYCLE_COMMAND_CATALOG.map((entry) => entry.commandType), [
-    "CreateReplayTask",
-    "StartExecution",
-    "TransitionTask",
-    "TransitionTask",
-    "TransitionTask",
-    "TransitionTask",
-    "SubmitExecution",
-    "RecordReview",
-    "RecordReviewConsent",
-    "ReconcileCodeDoc",
-    "RepointCodeDoc",
-    "CompleteTask"
-  ]);
-  assert.deepEqual([...kernel.decisionStates], [
-    "proposed",
-    "in_effect",
-    "rejected",
-    "deferred",
-    "superseded",
-    "outcome_retired"
-  ]);
+  assert.deepEqual(
+    kernel.TASK_LIFECYCLE_COMMAND_CATALOG.map((entry) => entry.commandType),
+    [
+      "CreateReplayTask",
+      "StartExecution",
+      "TransitionTask",
+      "TransitionTask",
+      "TransitionTask",
+      "TransitionTask",
+      "TransitionTask",
+      "SubmitExecution",
+      "RecordReview",
+      "RecordReviewConsent",
+      "ReconcileCodeDoc",
+      "RepointCodeDoc",
+      "CompleteTask",
+    ],
+  );
+  assert.deepEqual(
+    [...kernel.decisionStates],
+    ["proposed", "in_effect", "rejected", "deferred", "superseded", "outcome_retired"],
+  );
   assert.equal("LifecycleEngine" in kernel, false);
   assert.equal("LockRegistry" in kernel, false);
   assert.equal(typeof kernel.VersionControlSystem, "object");

--- a/packages/kernel/test/domain/domain-status.test.ts
+++ b/packages/kernel/test/domain/domain-status.test.ts
@@ -6,22 +6,13 @@ import {
   domainStatuses,
   explainStatusTransition,
   needsReviewArtifacts,
-  statusCoarseClass
+  statusCoarseClass,
 } from "../../src/domain/lifecycle-status.ts";
-import {
-  decisionStates
-} from "../../src/domain/decision-event.ts";
+import { decisionStates } from "../../src/domain/decision-event.ts";
 import { DomainStatusSchema } from "../../src/schemas/registry.ts";
 
 test("domain status vocabulary is exactly the six canonical coordination states", () => {
-  assert.deepEqual([...domainStatuses], [
-    "planned",
-    "active",
-    "blocked",
-    "in_review",
-    "done",
-    "cancelled"
-  ]);
+  assert.deepEqual([...domainStatuses], ["planned", "active", "blocked", "in_review", "done", "cancelled"]);
   assert.equal(domainStatuses.includes("unknown" as never), false);
 });
 
@@ -52,6 +43,7 @@ test("domain owns canonical lifecycle status transition semantics", () => {
     "planned->blocked",
     "planned->cancelled",
     "active->active",
+    "active->planned",
     "active->blocked",
     "active->in_review",
     "active->done",
@@ -68,7 +60,7 @@ test("domain owns canonical lifecycle status transition semantics", () => {
     "cancelled->cancelled",
     "cancelled->planned",
     "cancelled->active",
-    "cancelled->in_review"
+    "cancelled->in_review",
   ]);
 
   for (const from of domainStatuses) {
@@ -83,12 +75,8 @@ test("domain owns canonical lifecycle status transition semantics", () => {
 });
 
 test("Decision event vocabulary exposes only canonical projection states", () => {
-  assert.deepEqual([...decisionStates], [
-    "proposed",
-    "in_effect",
-    "rejected",
-    "deferred",
-    "superseded",
-    "outcome_retired"
-  ]);
+  assert.deepEqual(
+    [...decisionStates],
+    ["proposed", "in_effect", "rejected", "deferred", "superseded", "outcome_retired"],
+  );
 });


### PR DESCRIPTION
# English

## Summary

Two task-lifecycle flow defects surfaced by this week's closeout runs, fixed by narrowing rejections rather than adding bypasses:

1. **Closeout continuation could not be dispatched** — `ha runtime run --task` on a task already `in_review` unconditionally wrote `StartExecution` first and was rejected with `invalid_transition`; a stale preset snapshot was only detected at `complete`, after the review round had already advanced. Now, for the exact case `in_review + review + no lease + exactly one current submitted Execution`, the runtime binds to that Execution instead of starting a new one; the closeout action checks the preset snapshot before its first lifecycle write and runs the existing canonical `preset-upgrade` leaf when stale. The `complete` guard stays.
2. **Orphan `active` tasks had no way back to `planned`** — after `release` cleared the lease, no transition accepted `planned`, so the only options were `cancel` or leaving the task hanging; `ha task list` also surfaced archived packages. Now the status matrix has the single edge `active → planned` (`return_to_planned`, criteria: status active, `lease === null`, auditable reason, CAS on `expectedVersion`); the release receipt names that next command; `repo.tasks.list` filters `packageDisposition !== active` before the flat/tree selector.

## Architectural Justification

- Framework must not create friction for agents (2026-08-20 principle): both defects were the framework rejecting a legitimate path and forcing manual recovery. The fix deletes the wrong precondition and adds the one missing lifecycle edge — no `--force`, no compatibility branch, no second validator (`generate-task-action-protocol.mjs --check` green with no generated diff).
- Multi-node: `return_to_planned` reuses `expectedVersion` CAS and requires `lease === null`, so two nodes cannot both return the same task; runtime binding to an existing Execution reads the canonical projection only.
- Execution audit rows are kept on release; "no active work" is expressed by the lease, not by deleting history.

## What Changed

- Daemon: `repo-cell-api.ts`, `runtime-spawner.ts` (exact-case binding), `task-closeout-action.ts` + `repo-cell-task-progress.ts` (snapshot check before first write), `repo.tasks.list` disposition filter, release receipt hint.
- Kernel: status matrix `active → planned`; `return_to_planned` TransitionTask in the Task lifecycle catalog; action/kernel-index parity now five TransitionTask definitions.
- Tests: negative controls for both (red before, green after), stale-snapshot ordering, lease-held rejection, archived rows excluded.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none

## Machine-Readable Declarations

Production-Delta: +186/-88
Dependency-Change: none

### Optional Evidence Claims

None.

## Task And Scope

- Harness tasks: `task_33f3b7133cea65a51408bbcb26` (closeout continuation), `task_f5596f643b0f5f694bc3da2643` (orphan active → planned)
- Branch: `codex/flow-defects`
- Public scope: task lifecycle catalog, runtime task ingress, closeout action, task list projection filter.
- Private planning/evidence updated: yes — each task's `artifacts/report-20260830.md`; Facts `F-D621AB7B`, `F-D205EB2B`; `execution-workflow-standard.md` synced (closeout order, code-doc reconcile flag-less form).
- Out of scope: projection-lag wait on `runtime run --task` (task_6b37fa8d, blocked on this PR because it touches the same `runtime-spawner.ts` region).

## Version Impact

- Version: no change. Publish impact: none.

## Governance Declaration

- Protected surface touched: no
- Authority: `task_33f3b7133cea65a51408bbcb26`, `task_f5596f643b0f5f694bc3da2643`; Facts `F-7E341B32`, `F-CF41341A` (defect observations).
- Break-glass: no

## Verification

- Base `origin/main`: `5c8b5b0168a1284584404d42784d14ac55de5158` (post #2045, rebased).
- Worker: focused tests + negative controls green; typecheck; `run-manifest-gates --changed` green (GitHub-context check excluded); real RepoCell/daemon chain receipts recorded in the reports; `generate-task-action-protocol.mjs --check` green.
- [x] `git diff --check`
- [x] `npm run typecheck`
- [x] `npm run harness:check-import-boundaries`
- [x] `npm run harness:scan-forbidden-symbols`
- [x] `npm run harness:check-private-boundary`
- [x] `npm run harness:check-implementation-contracts`
- [ ] `npm run check` / `npm test` / others: GitHub CI is the authority.

## Review Evidence

- CEO semantic review: rejection narrowed, not bypassed; snapshot check moved earlier without removing the final guard; single new edge with CAS + lease criteria; list filter uses existing disposition field.

## Residual Risk

- Tasks whose review round has more than one submitted Execution still take the original rejection path (ambiguous binding is not guessed).

## References

- Tasks and facts above; `harness/governance/standards/execution-workflow-standard.md`.

# 中文

## 概要

本周销账跑出的两个 task 生命周期流转缺陷,修法是收窄拒绝而不是加旁路:

1. **销账续跑无法派工**:task 已 `in_review` 时 `ha runtime run --task` 无条件先写 `StartExecution`,被 `invalid_transition` 拒;陈旧 preset 快照要到 `complete` 才暴露,而 review 轮已推进。现在对精确情形 `in_review + review + 无 lease + 恰好一个当前 submitted Execution`,runtime 直接绑定该 Execution 不再新起;closeout action 在首笔生命周期写之前检查快照,陈旧则先走既有 canonical `preset-upgrade` leaf。`complete` 的最终 guard 保留。
2. **孤儿 `active` 任务回不到 `planned`**:`release` 清掉 lease 后没有任何转换接受 `planned`,只能 `cancel` 或挂着;`ha task list` 还把已归档包列出来。现在状态矩阵加唯一边 `active → planned`(`return_to_planned`,criteria:status active、`lease === null`、可审计 reason、`expectedVersion` CAS);release 回执直接指出下一条命令;`repo.tasks.list` 在 flat/tree selector 前过滤 `packageDisposition !== active`。

## 架构辩护

- 框架不给 Agent 造麻烦(2026-08-20 要义):两处都是框架拒绝合法路径、逼人手工补救。修复删掉错误前置、补上缺的那条边——无 `--force`、无兼容分支、无第二套 validator(`generate-task-action-protocol.mjs --check` 绿且无生成 diff)。
- 多节点:`return_to_planned` 复用 `expectedVersion` CAS 且要求 `lease === null`,两个节点不可能同时把同一 task 退回;绑定既有 Execution 只读 canonical 投影。
- release 保留 Execution 审计行,「无在役工作」由 lease 表达,不删历史。

## 改动内容

- Daemon:`repo-cell-api.ts`、`runtime-spawner.ts`(精确情形绑定)、`task-closeout-action.ts` + `repo-cell-task-progress.ts`(首笔写前检查快照)、`repo.tasks.list` disposition 过滤、release 回执提示。
- Kernel:状态矩阵 `active → planned`;Task lifecycle catalog 登记 `return_to_planned`;action/kernel-index parity 为五条 TransitionTask。
- 测试:两处阴性对照(改前红改后绿)、陈旧快照顺序、持租约拒绝、archived 行排除。

## 门收割 / Gate Harvest

- 删除的生产路径:无;删除的门/fixture:无。

## 机读声明说明

`Production-Delta` 由 gate 实测。

## 任务与范围

- Task `task_33f3b7133cea65a51408bbcb26`、`task_f5596f643b0f5f694bc3da2643`;分支 `codex/flow-defects`;范围:task lifecycle catalog、runtime task ingress、closeout action、task list 投影过滤;范围外:`runtime run --task` 的投影追赶等待(task_6b37fa8d,因同改 `runtime-spawner.ts` 同一段而等本 PR)。

## 版本影响

- 不改版本、不发布。

## 治理声明

- 未触碰受保护面;授权上述两个 task + F-7E341B32 / F-CF41341A;非 break-glass。

## 验证

- 基准 `origin/main` `5c8b5b01…`(已 rebase);worker:定向测试 + 阴性对照绿、typecheck、`run-manifest-gates --changed` 绿(除 GitHub-context 项)、真实 RepoCell/daemon 链回执见报告、协议生成器 `--check` 绿;GitHub CI 为完整权威。

## 审查证据

- CEO 语义验收:收窄而非绕过;快照检查前移且保留终 guard;唯一新边带 CAS + lease 准则;list 过滤用既有 disposition 字段。

## 残余风险

- review 轮有多于一个 submitted Execution 的任务仍走原拒绝路径(不猜歧义绑定)。

## 关联材料

- 上述 task 与 fact;`harness/governance/standards/execution-workflow-standard.md`。
