### PR TITLE
fix(migration): current-contract fact provenance, strict pre-validation, and O(n) hot-path removal

### DIFF
--- a/packages/daemon/src/migration-import-projection-restatement.ts
+++ b/packages/daemon/src/migration-import-projection-restatement.ts
@@ -1,4 +1,5 @@
 import {
+  canonicalMigrationProvenance,
   renderDecisionDocument,
   renderFactsDocument,
   sha256Text,
@@ -146,7 +147,7 @@ export function addOracleFact(context: MigrationImportContext, source: Projectio
           confidence: fields.confidence as "low" | "medium" | "high",
           memoryClass: fields.memoryClass as "semantic" | "episodic" | "procedural",
           memoryTags: fields.memoryTags as never,
-          provenance: provenance as never,
+          provenance: canonicalMigrationProvenance(provenance) as never,
         },
         record = {
           factId: targetFactId,

--- a/packages/daemon/src/migration-import-run.ts
+++ b/packages/daemon/src/migration-import-run.ts
@@ -7,7 +7,7 @@ import {
   resolveHarnessLayout,
   stableStringify,
   taskEntryToRow,
-  validateMigrationImportEvent,
+  validateCurrentMigrationImportEvent,
   validateCurrentCanonicalEvent,
   compilePeopleRosterActionEvent,
   MIGRATION_IMPORT_SOURCE,
@@ -459,7 +459,7 @@ export async function runSingleMigrationImport(
       continue;
     }
     const next = prepareRelation(rebound, revision + 1);
-    const errors = validateMigrationImportEvent(next.event);
+    const errors = validateCurrentMigrationImportEvent(next.event);
     if (existingRelations.has(rebound.record.relation_id)) {
       relationMap.set(row.relationId, rebound.record.relation_id);
       derivedIds.relation.add(row.relationId);
@@ -573,7 +573,7 @@ export async function runSingleMigrationImport(
       [blob(mapBody, "application/json")],
     );
   if (
-    !validateMigrationImportEvent(mapPrepared.event).length &&
+    !validateCurrentMigrationImportEvent(mapPrepared.event).length &&
     input.store.readEvent(mapPrepared.event.opId) === null
   ) {
     prepared.push(mapPrepared);
@@ -755,7 +755,7 @@ export async function runSingleMigrationImport(
       );
     for (const draft of pending) {
       const next = draft.build(revision + 1),
-        errors = validateMigrationImportEvent(next.event);
+        errors = validateCurrentMigrationImportEvent(next.event);
       if (errors.length) {
         skips.push({
           entityType: draft.kind,

--- a/packages/daemon/src/migration-import.ts
+++ b/packages/daemon/src/migration-import.ts
@@ -1,4 +1,9 @@
-import { renderFactsDocument, sha256Text, type RelationFactRow } from "../../kernel/src/index.ts";
+import {
+  canonicalMigrationProvenance,
+  renderFactsDocument,
+  sha256Text,
+  type RelationFactRow,
+} from "../../kernel/src/index.ts";
 import {
   runSingleMigrationImport,
   type MigrationImportContext,
@@ -105,7 +110,7 @@ function addFact(context: MigrationImportContext, row: RelationFactRow): void {
           confidence: row.confidence,
           memoryClass: row.memoryClass,
           memoryTags: row.memoryTags as never,
-          provenance: row.provenance as never,
+          provenance: canonicalMigrationProvenance(row.provenance) as never,
         },
         record = {
           factId: targetFactId,

--- a/packages/kernel/src/domain/migration-import-event.ts
+++ b/packages/kernel/src/domain/migration-import-event.ts
@@ -18,6 +18,7 @@ import {
   type FactMemoryTag,
   type FactProvenanceRuntime,
 } from "./fact-event.ts";
+import { validateSessionProvenance } from "./agent-runtime.ts";
 import { validateTaskV2, type TaskV2 } from "./task.ts";
 import {
   freezeDeclaredWritePlan,
@@ -268,6 +269,28 @@ function validDecisionEntity(value: Readonly<Record<string, unknown>>, allowUnkn
     Array.isArray(decision.judgmentConsents)
   );
 }
+export function canonicalMigrationProvenance(entries: readonly unknown[]): readonly {
+  readonly runtime: string;
+  readonly sessionId: string | null;
+  readonly transcriptReachability: "by_session_id" | "dispatch_stream_only" | "unavailable";
+  readonly boundAt: string;
+}[] {
+  return entries.map((entry) => {
+    if (!isRecord(entry)) return entry as never;
+    const sessionId = isNonEmptyString(entry.sessionId) ? entry.sessionId : null;
+    return {
+      runtime: String(entry.runtime),
+      sessionId,
+      transcriptReachability:
+        sessionId === null
+          ? ("unavailable" as const)
+          : entry.transcriptReachability === "dispatch_stream_only"
+            ? ("dispatch_stream_only" as const)
+            : ("by_session_id" as const),
+      boundAt: String(entry.boundAt),
+    };
+  });
+}
 function validFactEntity(value: Readonly<Record<string, unknown>>, allowUnknownFields: boolean): boolean {
   if (
     !matchesMigrationFields(value, ["kind", "fact", "documentClaim"], allowUnknownFields) ||
@@ -290,11 +313,12 @@ function validFactEntity(value: Readonly<Record<string, unknown>>, allowUnknownF
     fact.provenance.length > 0 &&
     fact.provenance.every(
       (entry) =>
-        isRecord(entry) &&
-        matchesMigrationFields(entry, ["runtime", "sessionId", "boundAt"], allowUnknownFields) &&
-        (factProvenanceRuntimes as readonly unknown[]).includes(entry.runtime) &&
-        isNonEmptyString(entry.sessionId) &&
-        timestamp(entry.boundAt),
+        validateSessionProvenance(entry) ||
+        (allowUnknownFields &&
+          isRecord(entry) &&
+          (factProvenanceRuntimes as readonly unknown[]).includes(entry.runtime) &&
+          isNonEmptyString(entry.sessionId) &&
+          timestamp(entry.boundAt)),
     )
   );
 }

--- a/packages/kernel/src/index.ts
+++ b/packages/kernel/src/index.ts
@@ -156,7 +156,9 @@ export type {
 export {
   MIGRATION_DOCUMENT_POLICY_ID,
   MIGRATION_IMPORT_SOURCE,
+  canonicalMigrationProvenance,
   migrationImportWritePlan,
+  validateCurrentMigrationImportEvent,
   validateMigrationImportEvent,
 } from "./domain/migration-import-event.ts";
 export type {

--- a/packages/kernel/src/projection/rebuildable-task-projection-catch-up.ts
+++ b/packages/kernel/src/projection/rebuildable-task-projection-catch-up.ts
@@ -54,7 +54,7 @@ export function reduceBatch(
         `sha256:${sha256Text(serializePersistedCanonicalEvent(last))}`,
       );
     }
-    refreshStateDigestAtSourceCut(db, sourceRevision);
+    runSql(db, "UPDATE projection_meta SET state_digest = NULL WHERE singleton = 1");
     return { metrics: { sqliteTransactions: 1, reducedItems } };
   });
 }
@@ -130,7 +130,7 @@ export function catchUpRound(
       else runSql(db, "UPDATE projection_meta SET scan_cursor = ? WHERE singleton = 1", batch.cursor);
     }
     const reduced = drainDeferred(db, limit, (sha256) => prefetchedContent.get(sha256) ?? null, allowRevisionGaps);
-    refreshStateDigestAtSourceCut(db, sourceRevision);
+    runSql(db, "UPDATE projection_meta SET state_digest = NULL WHERE singleton = 1");
     return reduced;
   });
   return {

--- a/packages/kernel/src/projection/rebuildable-task-projection-catch-up.ts
+++ b/packages/kernel/src/projection/rebuildable-task-projection-catch-up.ts
@@ -29,7 +29,7 @@ export function reduceBatch(
   events: readonly CanonicalEventV1[],
   limit: number,
   readBlob: EventStreamPort["readContentBlob"],
-  sourceRevision: number,
+  _sourceRevision: number,
 ): ProjectionApplyReceipt {
   return transaction(db, () => {
     for (const event of events) stageEvent(db, event);

--- a/packages/kernel/src/store/wal-event-log.ts
+++ b/packages/kernel/src/store/wal-event-log.ts
@@ -160,14 +160,14 @@ export function openWalEventLog(rootDir: string): WalEventLog {
       previousDigest: previous?.eventDigest ?? null,
     };
     const body = `${stableStringify(record)}\n`;
-    const current = fileSystem.exists(segmentPath) ? fileSystem.readText(segmentPath) : "";
+    const priorOffset = readHead().lastOffset;
     fileSystem.append(segmentPath, body);
     cached = [...readRecords(), record];
     writeHead({
       schema: "harness-wal-head/v1",
       revision,
       lastSegment: WAL_SEGMENT,
-      lastOffset: Buffer.byteLength(current + body),
+      lastOffset: priorOffset + Buffer.byteLength(body),
       headDigest: record.eventDigest,
     });
     return record;


### PR DESCRIPTION
# English

## Summary

Executing the real-ledger genesis replay (46,540-event source cut) surfaced one correctness defect and three O(n)-per-write hot paths. All four are fixed here; the full migration was re-run end to end on this code and completed with Reconciliation PASS (id-map `import_08d5e112fed0_295b2535dd25`).

1. **Migration fact validation drifted from the current provenance contract.** `validFactEntity` kept an inline copy that only accepted `{runtime, sessionId, boundAt}` with a non-empty sessionId, while the authoritative contract is `SessionProvenanceV1` (adds `transcriptReachability`; `sessionId: null` ⇔ `"unavailable"`). 5,204 source events carry the new field and 69 carry a null sessionId, so the apply failed mid-write after 17 minutes while the dry-run passed. Strict mode now delegates to `validateSessionProvenance`; lenient mode still replays legacy three-field entries. A new `canonicalMigrationProvenance` helper mechanically backfills provenance in both fact builders (import and projection restatement).
2. **Dry-run validated with the lenient validator while the write chain validates strictly**, so shape drift only surfaced during apply. The three pre-validation sites in `migration-import-run.ts` now use `validateCurrentMigrationImportEvent`; dry-run and write chain are the same predicate. (`migration-import-task-restatement.ts` keeps the lenient form on purpose — it re-validates persisted events.)
3. **`wal-event-log.ts append()` re-read the entire segment file per event** just to compute `lastOffset`. With materialization deferred the segment grows unbounded, making appends O(WAL bytes) each — measured decay from 170 to 52 events/min. The offset is now computed incrementally from the cached head.
4. **Projection catch-up recomputed the full state digest on every write** — `refreshStateDigestAtSourceCut` canonical-JSONs and hashes every row of every digest table per reduce (85% of daemon CPU in a 12s inspector profile at a 353 MB projection). Write paths now invalidate the digest (`state_digest = NULL`); the existing idle-round branch already recomputes lazily when the digest is NULL and the projection is at the source cut, so readers still converge. Measured effect: 3–27 events/min → 370–800 events/min at the same repo size.

## Architectural Justification

- One contract, one predicate: fact provenance validation now delegates to the same `validateSessionProvenance` used by `fact-event.ts` instead of maintaining a drifting inline copy; dry-run and the write chain share one validator, so any future entity-shape drift surfaces in dry-run, not mid-apply.
- The digest change deletes work rather than adding mechanism: the lazy-refresh branch already existed in `catchUpRound`; write paths simply stop doing eager O(all-rows) work that the idle branch redoes anyway.
- No compatibility layers, flags, or second paths added; net production delta is +49/−17.

## What Changed

- Kernel: `domain/migration-import-event.ts` (strict provenance via `validateSessionProvenance`; `canonicalMigrationProvenance` export), `index.ts` (exports), `store/wal-event-log.ts` (incremental offset), `projection/rebuildable-task-projection-catch-up.ts` (invalidate instead of eager digest ×2).
- Daemon: `migration-import.ts` and `migration-import-projection-restatement.ts` (provenance backfill at the builders), `migration-import-run.ts` (strict pre-validation ×3).

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none

## Machine-Readable Declarations

Production-Delta: +49/-17
Dependency-Change: none

### Optional Evidence Claims

None.

## Task And Scope

- Harness task: `task_474f84a894ab2d1c58df1e44d5` (G3 real-ledger migration execution; the full step-by-step ledger lives in its `artifacts/migrate-apply-ledger-20260831.md`).
- Branch: `codex/migration-perf-fixes`
- Public scope: migration import validation + WAL append + projection digest refresh policy.
- Out of scope (defect tasks queued in the private ledger): migration-mode single-commit materialization; adaptive flush batching; `makeVisible` O(pending) claims map; shutdown `awaitDurableSettlement` O(files); fail-closed latch clearing projection caches.

## Version Impact

- Version: no change. Publish impact: none.

## Governance Declaration

- Protected surface touched: no
- Authority: `task_474f84a894ab2d1c58df1e44d5`; migration execution ledger steps 13–24.
- Break-glass: no

## Verification

- `npm run typecheck` green (twice, before each migration re-run).
- Strongest evidence is the real workload: the full 46,540-event source migration re-ran end to end on this code — dry-run Reconciliation PASS, apply exit=0, Reconciliation PASS, projection rebuild watermark 39,958 = sourceRevision with a computed state digest, entity counts matching the same-cut oracle (task 1,916 / decision 763 / fact 2,043).
- [x] `git diff --check`
- [ ] `npm run check` / `npm test` / others: GitHub CI is the authority.

## Review Evidence

- CEO review: strict/lenient split verified against both fresh-draft and persisted-replay call sites; digest laziness relies on the pre-existing idle branch (no new mechanism); WAL offset change keeps the cold-start full read.

## Residual Risk

- Between a write burst and the next idle catch-up round, `readStateDigest` returns NULL instead of a stale digest — consumers already handle NULL (it is the pre-first-computation state).

# 中文

## 概要

真台账创世重放(源截面 46,540 事件)执行中暴露 1 个正确性缺陷与 3 处每写 O(n) 热点,本 PR 一并修复;完整迁移已在本代码上端到端重跑,Reconciliation PASS。

1. **迁移 fact 校验偏离当前 provenance 契约**:`validFactEntity` 维护了只认三键、sessionId 必须非空的内联副本,而权威契约是 `SessionProvenanceV1`(含 `transcriptReachability`,`sessionId:null` ⇔ `"unavailable"`)。源里 5,204 个事件带新字段、69 个 sessionId 为 null,apply 写到 17 分钟中途失败而 dry-run 全绿。严格模式改为委托 `validateSessionProvenance`;宽松模式保留旧三键以重放历史;新增 `canonicalMigrationProvenance` 在两条 fact builder 机械补全。
2. **dry-run 用宽松校验、写链用严格校验**:三处预校验改用 `validateCurrentMigrationImportEvent`,dry-run 与写链同谓词,未来实体形态漂移在 dry-run 现形。(task-restatement 保留宽松——它校验的是既有持久化事件。)
3. **WAL append 每事件整读段文件**只为算 lastOffset,物化推迟时段文件无界增长 → O(WAL 字节)/写(实测 170→52 事件/分钟衰减);改为从缓存 head 增量计算。
4. **投影 catch-up 每写全量重算 state digest**(全表逐行 canonicalJson+sha256;353MB 投影下占 daemon CPU 85%);写路径改为置 NULL 作废,既有空闲轮惰性重算分支原样收敛。实测同规模下 3–27 → 370–800 事件/分钟。

## 架构辩护

- 一个契约一个谓词:provenance 校验复用 fact-event 的 `validateSessionProvenance`,消灭漂移副本;dry-run 与写链共用校验器。
- digest 改动是删工作不是加机制:惰性分支本就存在,写路径只是停止做空闲轮反正会重做的 O(全表) 工作。
- 无兼容层、无开关、无第二路径;净 delta +49/−17。

## 验证

- typecheck 绿;最强证据是真负载:46,540 事件源的完整迁移在本代码上端到端重跑——dry-run PASS、apply exit=0、Reconciliation PASS、投影重建 watermark=39,958=sourceRevision、实体计数与同截面 oracle 对齐(1,916/763/2,043)。GitHub CI 为完整权威。

## 残余风险

- 写入突发与下一空闲轮之间 `readStateDigest` 返回 NULL 而非陈旧摘要——消费方本就处理 NULL(等同首算前状态)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VTzQAqvuFy6ikGjBKxA9xj
