### PR TITLE
feat(migration): any-historical-version rebuild — automatic oracle rebuild, legacy-shape normalization, eight-variant fixture proof

### DIFF
--- a/docs-release/migration-genesis-replay.md
+++ b/docs-release/migration-genesis-replay.md
@@ -27,7 +27,7 @@ There are two migration inputs and exactly one command for each:
 
 | Input                                                                  | Command                               | Preconditions                                                                                          | Acceptance                                                                                                                                                |
 | ---------------------------------------------------------------------- | ------------------------------------- | ------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Legacy repository whose ledger predates the current generation         | `ha migrate import --source <source>` | Freeze writers, stop the source daemon, and use a committed source whose active projection and canonical event head are at the same cut. Run `--dry-run` first. | Active IDs satisfy source ⊆ target; each kind's difference equals derived + archived/retired; 12-kind conformance and claim coverage pass. |
+| Legacy repository whose ledger predates the current generation         | `ha migrate import --source <source>` | Freeze writers, stop the source daemon, and use a committed source. A same-cut projection is used when present; otherwise the importer rebuilds a disposable oracle from committed events and authored packages. Run `--dry-run` first. | Active IDs satisfy source ⊆ target; each kind's difference equals derived + archived/retired; current-event pre-validation and claim coverage pass. |
 | Already-canonical repository with task-local `fact/<task>/F-*` records | `ha migrate rekey-facts`              | Stop the repository daemon/writers and run against the committed canonical cut. Run `--dry-run` first. | Re-keyed facts and `produces` edges match the dry-run id-map; SQLite fact/relation counts are stable; `ha fact search` and `ha fact show <F-id>` succeed. |
 
 Run the fact-only path once at the fleet center. The marker carries a ledger
@@ -56,7 +56,7 @@ data.
 
 The order matters. Do not run the real import before the dry-run proves set
 inclusion and the explained-difference equality for all five entity kinds, plus
-12-kind conformance and claim-coverage preservation. Skip and authored-directory
+current-event pre-validation and claim-coverage preservation. Skip and authored-directory
 counts are not subtracted from the entity oracle. Destination-preimage conflicts
 remain an independent write-safety condition and require explicit resolution.
 
@@ -87,8 +87,12 @@ the daemon automatically.
 ha migrate import --source <path-to-old-repo> --dry-run
 ```
 
-The dry-run writes nothing. It reads `.harness/cache/task.sqlite` at the same
-revision as `harness/events/head.json` and reconciles five active entity kinds —
+The dry-run writes nothing. When `.harness/cache/task.sqlite` exists, it reads
+that projection at the same revision as `harness/events/head.json`. When it is
+absent, the same command automatically builds a disposable projection from the
+committed flat or sharded event ledger and overlays older authored packages.
+It never writes the source or its Git refs. The report identifies this path as
+`Oracle: rebuilt-source` and reconciles five active entity kinds —
 task / decision / fact / relation / execution. Each row reports source active,
 target included, difference, derived, archived, and retired. Passing means
 source ⊆ target and difference = derived + archived/retired. Load-bearing
@@ -141,6 +145,14 @@ disposition is recorded in the receipt, with up to 20 samples per kind in the
 report. A non-zero class with no usable witness follows this archival rule; it
 does not disappear or pause for another decision.
 
+One known historical schedule writer stored a declaration claim whose blob
+contains the full schedule while the event contract claims the definition
+facet. The importer accepts that exact claim/definition mismatch only for its
+disposable oracle, reports `ACCEPT schedule_definition_facet_mismatch` with
+`treatment=accepted_truth_gap`, and keeps the archived source bytes unchanged.
+Other unsupported event shapes fail with `unsupported_legacy_event`; preserve
+the source and report the named event before retrying.
+
 ### 5. Run the real import
 
 ```bash
@@ -149,7 +161,7 @@ ha migrate import --source <path-to-old-repo>
 
 Acceptance: source active IDs are a subset of target IDs for all five kinds;
 each difference equals its derived plus archived/retired count; coverage and
-12-kind conformance pass. The command exits 1 if any of those checks fails and
+current-event pre-validation pass. The command exits 1 if any of those checks fails and
 0 when all pass. Skip and authored-audit rows neither change the expected count
 nor produce exit code 3.
 
@@ -191,6 +203,17 @@ The failure model is simple because the old repository is read-only throughout:
 This is the main advantage of genesis replay over an in-place upgrade: there is
 no half-migrated state that can corrupt source data.
 
+Use the report code and row as the repair instruction:
+
+| Report | Action |
+| --- | --- |
+| `required` authored row | Supply the exact printed `--resolve path=destination|source` choice, then dry-run again. |
+| `migration_projection_oracle_cut_mismatch` | Stop source writers and regenerate or remove the stale local projection; do not alter committed events. |
+| `unsupported_legacy_event` | Preserve the source, capture the named event and schema, and report it as a missing compatibility fixture. |
+| `migration_projection_rebuild_failed` | Preserve the source and use the nested cause to repair a missing/corrupt committed blob or report an unsupported invariant. |
+| `ACCEPT schedule_definition_facet_mismatch` | No source repair is required. Confirm the warning is the known schedule facet variant and retain the forensic archive. |
+| reconciliation `FAIL` or `invalid_write_plan` | Do not apply. Keep the full dry-run receipt and report the failing kind/event; a successful dry-run must not defer a write-plan failure to apply. |
+
 ## Fact-only rekey procedure
 
 For an already-canonical repository, do not use genesis import. Stop its daemon
@@ -223,7 +246,7 @@ The old repository is the reference copy. Day-to-day work moves to the new
 repository; the old one no longer participates in reads or writes.
 
 **Can I skip the dry-run?**
-No. The dry-run fixes a same-cut projection/event-head oracle and proves set
+No. The dry-run fixes a same-cut or disposable rebuilt oracle and proves set
 inclusion plus the per-kind explained-difference equality. Review the derived,
 archived, and retired samples before applying the import.
 

--- a/docs-release/migration-genesis-replay.zh-CN.md
+++ b/docs-release/migration-genesis-replay.zh-CN.md
@@ -23,7 +23,7 @@ ha migrate import --source <source> [--resolve <仓库相对路径>=destination|
 
 | 输入                                | 命令                                  | 前置                                                                     | 验收                                                                                                                   |
 | ----------------------------------- | ------------------------------------- | ------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------- |
-| 早于当前代际的老仓                  | `ha migrate import --source <source>` | 冻结写入、停止源 daemon，源必须是 committed snapshot，且现役 projection 与 canonical event head 在同一 cut；先跑 `--dry-run`。 | 五类现役 ID 集合满足 source ⊆ target；每类差异恰等于 derived + archived/retired；12-kind conformance 与 coverage 保全均通过。 |
+| 早于当前代际的老仓                  | `ha migrate import --source <source>` | 冻结写入、停止源 daemon，源必须是 committed snapshot。有同 cut projection 时直接使用；没有时导入器从已提交事件和 authored package 自动重建一个临时 oracle。先跑 `--dry-run`。 | 五类现役 ID 集合满足 source ⊆ target；每类差异恰等于 derived + archived/retired；当前事件预校验与 coverage 保全均通过。 |
 | 已 canonical 但有 `fact/<task>/F-*` | `ha migrate rekey-facts`              | 停止该仓 daemon/写入者，在 committed canonical cut 上先跑 `--dry-run`。  | id-map 中 fact 与 `produces` 数量一致；SQLite fact/relation 计数稳定；`ha fact search` 与 `ha fact show <F-id>` 成功。 |
 
 fact-only 路径只在 fleet center 执行一次。marker 携带 ledger epoch；边缘节点
@@ -42,7 +42,7 @@ fact-only 路径只在 fleet center 执行一次。marker 携带 ledger epoch；
 ## 五步流程
 
 顺序承重。在 dry-run 对全部五类实体报出集合包含、差异解释等式成立，且
-12-kind conformance 与 coverage 保全通过之前，不要跑正式导入。`skipped` 与
+当前事件预校验与 coverage 保全通过之前，不要跑正式导入。`skipped` 与
 authored 目录数量不参与实体集合的通过计算；目标 preimage 冲突仍是独立的写入
 安全条件，必须显式 resolve。
 
@@ -69,8 +69,10 @@ ha init --repo-id <id> --person-id <id> --display-name <name>
 ha migrate import --source <老仓路径> --dry-run
 ```
 
-dry-run 不写任何东西。它从源仓 `.harness/cache/task.sqlite` 读取与
-`harness/events/head.json` 同 revision 的现役 projection，输出五类实体——
+dry-run 不写任何东西。源仓有 `.harness/cache/task.sqlite` 时，它读取与
+`harness/events/head.json` 同 revision 的 projection；没有时，同一条命令从已提交的
+flat 或 sharded 事件台账重建一个临时 projection，并叠加更早的 authored package。
+它不修改源仓或其 Git ref，报告会标记 `Oracle: rebuilt-source`。随后输出五类实体——
 task / decision / fact / relation / execution——的 ID 集合对账。每类给出
 source active、target included、difference、derived、archived、retired；通过条件是
 source ⊆ target 且 difference = derived + archived/retired。decision 的承重 claim
@@ -120,6 +122,12 @@ ha migrate import --source <老仓副本路径> \
 回执，报告每类最多展示 20 条样本；没有任何见证但数量非零时也走这条规则，
 不会静默丢失或停下来等待额外裁决。
 
+某个已知历史 schedule writer 曾让 declaration claim 的 blob 包含整个
+schedule，而 event contract 声明的是 definition facet。导入器只在临时 oracle 中容忍这一
+claim/definition 不一致，报告 `ACCEPT schedule_definition_facet_mismatch` 和
+`treatment=accepted_truth_gap`，且不修改归档源字节。其他不支持的事件形态会以
+`unsupported_legacy_event` 失败；保留源仓，记录报错事件后再报告。
+
 ### 5. 正式导入
 
 ```bash
@@ -127,7 +135,7 @@ ha migrate import --source <老仓路径>
 ```
 
 验收条件：五类现役 ID 集合 source ⊆ target；每类 difference 恰等于
-derived + archived/retired；coverage 保全；12-kind conformance 通过。任一项不满足
+derived + archived/retired；coverage 保全；当前事件预校验通过。任一项不满足
 命令退出 1；全部满足退出 0。`skipped` 和 authored audit 不再改变预期总数，
 也不再产生退出码 3。
 
@@ -158,6 +166,17 @@ derived + archived/retired；coverage 保全；12-kind conformance 通过。任�
 
 这是创世重放相对原地升级的主要优势：不存在能把源数据改坏的半迁移状态。
 
+按报告 code 或行处置：
+
+| 报告 | 动作 |
+| --- | --- |
+| authored 行为 `required` | 按报告原样传入 `--resolve path=destination|source`，再跑 dry-run。 |
+| `migration_projection_oracle_cut_mismatch` | 停止源写入者，重建或删除过期的本地 projection；不改已提交事件。 |
+| `unsupported_legacy_event` | 保留源仓，收集命名的 event 和 schema，作为缺失的兼容 fixture 报告。 |
+| `migration_projection_rebuild_failed` | 保留源仓，根据内层原因修复缺失/损坏的已提交 blob，或报告不支持的 invariant。 |
+| `ACCEPT schedule_definition_facet_mismatch` | 无需修复源。确认这是已知 schedule facet 变体，保留法证归档。 |
+| reconciliation `FAIL` 或 `invalid_write_plan` | 不要 apply。保留完整 dry-run 回执并报告失败 kind/event；成功 dry-run 不应把 write-plan 错误拖到 apply。 |
+
 ## 仅 fact 原地 rekey
 
 已 canonical 的仓库不要使用 genesis import。停止 daemon 和所有写入者，确认
@@ -187,7 +206,7 @@ no-op。无法确定 owner 的 fact 不伪造归属，会无 task 边 rekey 并�
 老仓是参考副本。日常工作转移到新仓；老仓不再参与读写。
 
 **可以跳过 dry-run 吗？**
-不行。dry-run 固定 source projection 与 canonical event head 的同一 cut，并证明
+不行。dry-run 固定同 cut projection 或临时重建 oracle，并证明
 集合包含和逐类差异解释。先审阅所有 derived/archived/retired 样本，再决定是否
 正式导入。
 

--- a/packages/daemon/src/migration-import-oracle-rebuild.ts
+++ b/packages/daemon/src/migration-import-oracle-rebuild.ts
@@ -1,0 +1,559 @@
+import { mkdtempSync, readFileSync, readdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import {
+  REPLAY_TASK_GRAPH,
+  canonicalMigrationProvenance,
+  compileFactWrite,
+  consumeKnownError,
+  makeTaskProjection,
+  normalizePersistedCanonicalEvent,
+  parseCanonicalEvent,
+  readLegacyMigrationSource,
+  readMarkdownSource,
+  readScalar,
+  resolveHarnessLayout,
+  serializePersistedCanonicalEvent,
+  sha256Text,
+  stableStringify,
+  taskEntryToRow,
+  type CanonicalEventV1,
+  type PersistedCanonicalEventV1,
+} from "../../kernel/src/index.ts";
+import { readMigrationProjectionOracleAtPath, type MigrationProjectionOracle } from "./migration-import-oracle.ts";
+import { isMigrationImportRecord, migrationImportError, timestamp } from "./migration-import-report.ts";
+import type { MigrationFormatObservation } from "./migration-import-types.ts";
+
+export interface MigrationEventInspection {
+  readonly events: readonly CanonicalEventV1[];
+  readonly eventHeadRevision: number | null;
+  readonly observations: readonly MigrationFormatObservation[];
+  readonly syntheticBlobs: ReadonlyMap<string, Uint8Array>;
+}
+
+const migrationOracleActor = {
+  principal: { personId: "migration-oracle" },
+  executor: { kind: "agent", id: "migration-import" },
+} as const;
+
+/** Rebuilds only a disposable migration oracle. The source repository and its Git refs remain untouched. */
+export function rebuildMigrationProjectionOracle(sourceRoot: string): MigrationProjectionOracle {
+  const inspection = inspectMigrationSourceEvents(sourceRoot),
+    rebuilt = inspection.events.length === 0 ? emptyOracle(inspection) : rebuildEventOracle(sourceRoot, inspection);
+  return overlayAuthoredOracle(sourceRoot, rebuilt, inspection);
+}
+
+export function inspectMigrationSourceEvents(sourceRoot: string): MigrationEventInspection {
+  const layout = resolveHarnessLayout(sourceRoot),
+    eventsRoot = path.join(layout.authoredRoot, "events"),
+    observations: MigrationFormatObservation[] = [],
+    syntheticBlobs = new Map<string, Uint8Array>(),
+    events: CanonicalEventV1[] = [];
+  for (const file of jsonFiles(eventsRoot).filter((candidate) => path.basename(candidate) !== "head.json")) {
+    const sourcePath = portable(path.relative(sourceRoot, file));
+    let raw: unknown;
+    try {
+      raw = JSON.parse(readFileSync(file, "utf8")) as unknown;
+    } catch (error) {
+      consumeKnownError(error);
+      throw migrationImportError("invalid_migration_source", `${sourcePath}: canonical event is not JSON.`);
+    }
+    const legacyTask = containsSchema(raw, "task/v1");
+    let event: CanonicalEventV1;
+    try {
+      event = normalizePersistedCanonicalEvent(parseCanonicalEvent(`${stableStringify(raw)}\n`));
+    } catch (error) {
+      const normalized = normalizeKnownLegacyEvent(raw, syntheticBlobs);
+      if (normalized === null) {
+        consumeKnownError(error);
+        throw migrationImportError(
+          "unsupported_legacy_event",
+          `${sourcePath}: ${error instanceof Error ? error.message : String(error)}. Preserve the source and report this event schema before retrying.`,
+        );
+      }
+      event = normalized;
+      observations.push({
+        code: "legacy_event_normalized",
+        sourcePath,
+        detail: `normalized ${event.schema} to the current read contract for oracle replay`,
+        treatment: "mechanically_normalized",
+      });
+    }
+    if (legacyTask)
+      observations.push({
+        code: "legacy_event_normalized",
+        sourcePath,
+        detail: "restated embedded Task/v1 as Task/v2 with pinned=false and packageDisposition=active defaults",
+        treatment: "mechanically_normalized",
+      });
+    event = normalizeScheduleFacet(sourceRoot, event, sourcePath, observations, syntheticBlobs);
+    events.push(event);
+  }
+  events.sort((left, right) => left.workspaceRevision - right.workspaceRevision || left.opId.localeCompare(right.opId));
+  const eventHeadRevision = readHeadRevision(eventsRoot) ?? events.at(-1)?.workspaceRevision ?? null;
+  if (eventHeadRevision !== null && events.some((event) => event.workspaceRevision > eventHeadRevision))
+    throw migrationImportError(
+      "migration_projection_oracle_cut_mismatch",
+      `Canonical event revision exceeds source head ${eventHeadRevision}.`,
+    );
+  return { events, eventHeadRevision, observations, syntheticBlobs };
+}
+
+function rebuildEventOracle(sourceRoot: string, inspection: MigrationEventInspection): MigrationProjectionOracle {
+  const scratch = mkdtempSync(path.join(tmpdir(), "ha-migration-oracle-")),
+    databasePath = path.join(scratch, "task.sqlite"),
+    sourceRevision = inspection.eventHeadRevision ?? inspection.events.at(-1)?.workspaceRevision ?? 0,
+    readSourceBlob = sourceBlobReader(sourceRoot, inspection.syntheticBlobs),
+    eventDigest = inspection.events.length
+      ? (`sha256:${sha256Text(serializePersistedCanonicalEvent(inspection.events.at(-1)!))}` as const)
+      : null;
+  let projection: ReturnType<typeof makeTaskProjection> | undefined;
+  try {
+    const eventStore = {
+      readHead: () => (sourceRevision === 0 || eventDigest === null ? null : { revision: sourceRevision, eventDigest }),
+      readBatch: (cursor: string | null, maxItems: number) => {
+        const start = cursor === null ? 0 : Number(cursor),
+          batch = inspection.events.slice(start, start + maxItems),
+          next = start + batch.length,
+          done = next >= inspection.events.length;
+        return {
+          sourceRevision,
+          events: batch,
+          cursor: done ? null : String(next),
+          done,
+          accessedItems: batch.length,
+          prefetchContent: (requested: readonly CanonicalEventV1[]) => {
+            const hashes = new Set(requested.flatMap(contentHashes));
+            return new Map([...hashes].map((hash) => [hash, readSourceBlob(hash)]));
+          },
+        };
+      },
+      readContentBlob: readSourceBlob,
+    };
+    projection = makeTaskProjection({ rootDir: scratch, projectionPath: databasePath, eventStore });
+    projection.rebuild();
+    projection.close();
+    projection = undefined;
+    return readMigrationProjectionOracleAtPath(sourceRoot, databasePath, "rebuilt-source", [
+      ...inspection.observations,
+      {
+        code: "source_projection_rebuilt",
+        sourcePath: ".harness/cache/task.sqlite",
+        detail: `rebuilt a disposable oracle from ${inspection.events.length} committed canonical events`,
+        treatment: "rebuilt_read_only",
+      },
+    ]);
+  } catch (error) {
+    consumeKnownError(error);
+    throw migrationImportError(
+      "migration_projection_rebuild_failed",
+      `Could not rebuild the source oracle without modifying the source: ${error instanceof Error ? error.message : String(error)}.`,
+    );
+  } finally {
+    projection?.close();
+    rmSync(scratch, { recursive: true, force: true });
+  }
+}
+
+function overlayAuthoredOracle(
+  sourceRoot: string,
+  base: MigrationProjectionOracle,
+  inspection: MigrationEventInspection,
+): MigrationProjectionOracle {
+  const layout = resolveHarnessLayout(sourceRoot),
+    taskRead = readMarkdownSource(sourceRoot),
+    cold = readLegacyMigrationSource(sourceRoot),
+    tasks = new Map(base.tasks),
+    decisions = new Map(base.decisions),
+    facts = new Map(base.facts),
+    relations = new Map(base.relations),
+    executions = new Map(base.executions),
+    entityKeys = new Set(base.entityKeys),
+    firstTaskEvents = earliestTaskEvents(inspection.events);
+  for (const entry of taskRead.entries) {
+    const row = taskEntryToRow(sourceRoot, entry),
+      occurredAt =
+        timestamp(readScalar(entry.frontmatter, "  bindingCreatedAt")) ??
+        timestamp(readScalar(entry.frontmatter, "bindingCreatedAt")) ??
+        timestamp(readScalar(entry.frontmatter, "createdAt")),
+      firstEvent =
+        firstTaskEvents.get(row.taskId) ??
+        (occurredAt ? { eventId: `authored:${row.taskId}`, occurredAt, workspaceRevision: 0 } : null),
+      title = cleanScalar(readScalar(entry.frontmatter, "title")) || markdownH1(entry.body) || row.taskId,
+      task = {
+        schema: "task/v2",
+        taskId: row.taskId,
+        title,
+        taskClass: "standard",
+        status: row.canonicalStatus,
+        graph: REPLAY_TASK_GRAPH,
+        currentNode: row.canonicalStatus === "in_review" ? "review" : "implementation",
+        iteration: 0,
+        pinned: false,
+        packageDisposition: row.packageDisposition,
+        createdBy: migrationOracleActor,
+        completionGateIds: [],
+        presetSnapshotDigest: null,
+      };
+    if (!tasks.has(row.taskId))
+      tasks.set(row.taskId, {
+        taskId: row.taskId,
+        workspaceRevision: firstEvent?.workspaceRevision ?? 0,
+        packagePath: portable(path.relative(layout.authoredRoot, path.dirname(entry.indexPath))),
+        snapshot: { task },
+        firstEvent,
+      });
+    entityKeys.add(`task\0${row.taskId}`);
+  }
+  for (const decision of cold.decisions) {
+    if (!decisions.has(decision.decisionId))
+      decisions.set(decision.decisionId, {
+        decisionId: decision.decisionId,
+        workspaceRevision: 0,
+        fields: {
+          decision_id: decision.decisionId,
+          state: decision.state,
+          title: decision.title,
+          question: decision.question,
+          risk_tier: decision.riskTier ?? "medium",
+          urgency: decision.urgency ?? "medium",
+          vertical: decision.vertical ?? "software/coding",
+          preset: decision.preset ?? "standard-task",
+          decision_class: decision.decisionClass ?? "ordinary",
+          applies_json: JSON.stringify({ modules: decision.moduleKeys, productLines: decision.productLineKeys }),
+          proposer_json: JSON.stringify(migrationOracleActor.principal),
+          arbiter_json: null,
+          proposed_at: decision.proposedAt ?? null,
+          decided_at: decision.decidedAt ?? null,
+          provenance_json: JSON.stringify(decision.provenance ?? []),
+        },
+        chosen: decision.chosenRecords,
+        rejected: decision.rejectedRecords,
+        claims: decision.claimRecords,
+      });
+    entityKeys.add(`decision\0${decision.decisionId}`);
+  }
+  for (const fact of cold.facts) {
+    if (!facts.has(fact.factId))
+      facts.set(fact.factId, {
+        factId: fact.factId,
+        workspaceRevision: 0,
+        fields: {
+          ...(fact.taskId ? { taskId: fact.taskId } : {}),
+          factId: fact.factId,
+          statement: fact.statement,
+          evidenceSource: fact.source,
+          observedAt: fact.observedAt,
+          confidence: fact.confidence,
+          memoryClass: fact.memoryClass,
+          memoryTags: fact.memoryTags,
+          provenance: fact.provenance,
+        },
+      });
+    entityKeys.add(`fact\0${fact.factId}`);
+  }
+  for (const edge of cold.truth.edges) {
+    if (!relations.has(edge.relationId))
+      relations.set(edge.relationId, {
+        relationId: edge.relationId,
+        workspaceRevision: 0,
+        row: edge,
+        originalFields: { ...edge },
+      });
+  }
+  for (const execution of legacyExecutions(layout.authoredRoot)) {
+    if (!executions.has(execution.id))
+      executions.set(execution.id, { executionId: execution.id, workspaceRevision: 0, fields: execution.fields });
+    entityKeys.add(`execution\0${execution.id}`);
+  }
+  return {
+    ...base,
+    basis: "rebuilt-source",
+    databasePath: "<rebuilt-from-committed-source>",
+    tasks,
+    decisions,
+    facts,
+    relations,
+    executions,
+    entityKeys,
+    coverageCount: Math.max(
+      base.coverageCount,
+      cold.decisions.flatMap(({ claimRecords }) => claimRecords).filter(({ loadBearing }) => loadBearing).length,
+    ),
+  };
+}
+
+function emptyOracle(inspection: MigrationEventInspection): MigrationProjectionOracle {
+  return {
+    basis: "rebuilt-source",
+    formatObservations: [
+      ...inspection.observations,
+      {
+        code: "source_projection_rebuilt",
+        sourcePath: ".harness/cache/task.sqlite",
+        detail: "rebuilt a disposable oracle from committed authored packages (the source predates canonical events)",
+        treatment: "rebuilt_read_only",
+      },
+    ],
+    databasePath: "<rebuilt-from-committed-source>",
+    watermark: 0,
+    eventHeadRevision: inspection.eventHeadRevision,
+    tasks: new Map(),
+    decisions: new Map(),
+    facts: new Map(),
+    relations: new Map(),
+    executions: new Map(),
+    entityKeys: new Set(),
+    coverageCount: 0,
+  };
+}
+
+function normalizeKnownLegacyEvent(raw: unknown, syntheticBlobs: Map<string, Uint8Array>): CanonicalEventV1 | null {
+  if (!isMigrationImportRecord(raw) || !isMigrationImportRecord(raw.payload)) return null;
+  if (raw.schema === "fact-event/v1") {
+    const payload = raw.payload;
+    if (
+      typeof raw.eventId !== "string" ||
+      typeof raw.opId !== "string" ||
+      !Number.isSafeInteger(raw.workspaceRevision) ||
+      typeof raw.factId !== "string" ||
+      typeof raw.occurredAt !== "string" ||
+      !isMigrationImportRecord(raw.actor) ||
+      !Array.isArray(payload.provenance)
+    )
+      return null;
+    const legacySupersedes = isMigrationImportRecord(payload.supersedes) ? payload.supersedes : null,
+      legacyFactId =
+        typeof legacySupersedes?.factRef === "string"
+          ? /(?:^|\/)(F-[0-9A-HJKMNP-TV-Z]{8})$/u.exec(legacySupersedes.factRef)?.[1]
+          : undefined;
+    try {
+      const compiled = compileFactWrite({
+        event: {
+          schema: "fact-event/v1",
+          eventId: raw.eventId,
+          workspaceRevision: raw.workspaceRevision as number,
+          opId: raw.opId,
+          ...(typeof raw.taskId === "string" ? { taskId: raw.taskId } : {}),
+          factId: raw.factId,
+          type: "fact_recorded",
+          actor: raw.actor as never,
+          source: raw.source as never,
+          occurredAt: raw.occurredAt,
+          payload: {
+            statement: String(payload.statement),
+            evidenceSource: String(payload.evidenceSource),
+            observedAt: String(payload.observedAt),
+            confidence: payload.confidence as never,
+            memoryClass: payload.memoryClass as never,
+            memoryTags: Array.isArray(payload.memoryTags) ? (payload.memoryTags as never) : [],
+            provenance: canonicalMigrationProvenance(payload.provenance) as never,
+            ...(legacyFactId && legacySupersedes
+              ? {
+                  supersedes: {
+                    factRef: `fact/${legacyFactId}`,
+                    rationale: String(legacySupersedes.rationale),
+                  },
+                }
+              : {}),
+          },
+        },
+      });
+      syntheticBlobs.set(compiled.blobs[0].sha256, Buffer.from(compiled.blobs[0].body));
+      return compiled.event;
+    } catch (error) {
+      consumeKnownError(error);
+      return null;
+    }
+  }
+  if (raw.schema === "migration-import-event/v1" && isMigrationImportRecord(raw.payload.entity)) {
+    const normalized = normalizePersistedCanonicalEvent(
+      raw as unknown as PersistedCanonicalEventV1,
+    ) as unknown as Record<string, unknown>;
+    if (!isMigrationImportRecord(normalized.payload) || !isMigrationImportRecord(normalized.payload.entity))
+      return null;
+    const entity = normalized.payload.entity,
+      currentEntity =
+        entity.kind === "task"
+          ? { ...entity, provenance: "imported_snapshot" }
+          : entity.kind === "fact" && isMigrationImportRecord(entity.fact) && Array.isArray(entity.fact.provenance)
+            ? { ...entity, fact: { ...entity.fact, provenance: canonicalMigrationProvenance(entity.fact.provenance) } }
+            : entity,
+      candidate = { ...normalized, payload: { ...normalized.payload, entity: currentEntity } };
+    try {
+      return normalizePersistedCanonicalEvent(
+        parseCanonicalEvent(serializePersistedCanonicalEvent(candidate as unknown as PersistedCanonicalEventV1)),
+      );
+    } catch (error) {
+      consumeKnownError(error);
+      return null;
+    }
+  }
+  return null;
+}
+
+function normalizeScheduleFacet(
+  sourceRoot: string,
+  event: CanonicalEventV1,
+  sourcePath: string,
+  observations: MigrationFormatObservation[],
+  syntheticBlobs: Map<string, Uint8Array>,
+): CanonicalEventV1 {
+  if (event.schema !== "schedule-event/v1" || !("declarationDocumentClaim" in event.payload)) return event;
+  const claim = event.payload.declarationDocumentClaim,
+    readBlob = sourceBlobReader(sourceRoot, syntheticBlobs),
+    bytes = readBlob(claim.sha256);
+  if (bytes === null) return event;
+  let actual: unknown;
+  try {
+    actual = JSON.parse(new TextDecoder("utf-8", { fatal: true }).decode(bytes)) as unknown;
+  } catch (error) {
+    consumeKnownError(error);
+    return event;
+  }
+  const { status: _status, ...definition } = event.payload.schedule,
+    expected = definition;
+  if (stableStringify(actual) === stableStringify(expected)) return event;
+  if (stableStringify(actual) !== stableStringify(event.payload.schedule)) return event;
+  const body = `${JSON.stringify(expected, null, 2)}\n`,
+    sha256 = sha256Text(body),
+    next = {
+      ...event,
+      payload: {
+        ...event.payload,
+        declarationDocumentClaim: { ...claim, sha256, size: Buffer.byteLength(body) },
+      },
+    } as CanonicalEventV1;
+  syntheticBlobs.set(sha256, Buffer.from(body));
+  observations.push({
+    code: "schedule_definition_facet_mismatch",
+    sourcePath,
+    detail: `accepted historical schedule ${event.entity.id}: declaration blob ${claim.sha256} contains the full schedule instead of only the definition facet`,
+    treatment: "accepted_truth_gap",
+  });
+  return next;
+}
+
+function sourceBlobReader(sourceRoot: string, synthetic: ReadonlyMap<string, Uint8Array>) {
+  const authoredRoot = resolveHarnessLayout(sourceRoot).authoredRoot;
+  return (sha256: string): Uint8Array | null => {
+    const held = synthetic.get(sha256);
+    if (held !== undefined) return held;
+    for (const candidate of [
+      path.join(authoredRoot, "objects", "sha256", sha256),
+      path.join(authoredRoot, "objects", "sha256", sha256.slice(0, 2), sha256.slice(2)),
+    ])
+      try {
+        return readFileSync(candidate);
+      } catch (error) {
+        consumeKnownError(error);
+      }
+    return null;
+  };
+}
+
+function contentHashes(event: CanonicalEventV1): readonly string[] {
+  const values: string[] = [];
+  const visit = (value: unknown): void => {
+    if (Array.isArray(value)) return value.forEach(visit);
+    if (!isMigrationImportRecord(value)) return;
+    if (typeof value.sha256 === "string" && /^[0-9a-f]{64}$/u.test(value.sha256)) values.push(value.sha256);
+    Object.values(value).forEach(visit);
+  };
+  visit(event);
+  return [...new Set(values)];
+}
+
+function earliestTaskEvents(events: readonly CanonicalEventV1[]) {
+  const rows = new Map<
+    string,
+    { readonly eventId: string; readonly occurredAt: string; readonly workspaceRevision: number }
+  >();
+  for (const event of events) {
+    const taskId =
+      "taskId" in event && typeof event.taskId === "string"
+        ? event.taskId
+        : event.schema === "migration-import-event/v1" && event.payload.entity.kind === "task"
+          ? event.payload.entity.task.taskId
+          : null;
+    if (taskId !== null && !rows.has(taskId))
+      rows.set(taskId, {
+        eventId: event.eventId,
+        occurredAt: event.occurredAt,
+        workspaceRevision: event.workspaceRevision,
+      });
+  }
+  return rows;
+}
+
+function legacyExecutions(authoredRoot: string): readonly {
+  readonly id: string;
+  readonly fields: Readonly<Record<string, unknown>>;
+}[] {
+  return files(path.join(authoredRoot, "tasks"))
+    .filter((file) => /\/executions\/[^/]+\.md$/u.test(portable(file)))
+    .flatMap((file) => {
+      const body = readFileSync(file, "utf8");
+      try {
+        const fields = JSON.parse(body) as unknown;
+        if (!isMigrationImportRecord(fields)) return [];
+        const id = typeof fields.execution_id === "string" ? fields.execution_id : path.basename(file, ".md");
+        return [{ id, fields }];
+      } catch (error) {
+        consumeKnownError(error);
+        return [{ id: path.basename(file, ".md"), fields: { rawBody: body } }];
+      }
+    });
+}
+
+function jsonFiles(root: string): readonly string[] {
+  return files(root).filter((file) => file.endsWith(".json"));
+}
+
+function files(root: string): readonly string[] {
+  try {
+    return readdirSync(root, { withFileTypes: true })
+      .flatMap((entry) => {
+        const target = path.join(root, entry.name);
+        return entry.isDirectory() ? files(target) : entry.isFile() ? [target] : [];
+      })
+      .sort();
+  } catch (error) {
+    consumeKnownError(error);
+    return [];
+  }
+}
+
+function readHeadRevision(eventsRoot: string): number | null {
+  try {
+    const value = JSON.parse(readFileSync(path.join(eventsRoot, "head.json"), "utf8")) as unknown;
+    return isMigrationImportRecord(value) && Number.isSafeInteger(value.revision) ? (value.revision as number) : null;
+  } catch (error) {
+    consumeKnownError(error);
+    return null;
+  }
+}
+
+function containsSchema(value: unknown, schema: string): boolean {
+  if (Array.isArray(value)) return value.some((entry) => containsSchema(entry, schema));
+  return isMigrationImportRecord(value)
+    ? value.schema === schema || Object.values(value).some((entry) => containsSchema(entry, schema))
+    : false;
+}
+
+function markdownH1(body: string): string | null {
+  return /^#\s+(.+?)\s*$/mu.exec(body)?.[1]?.trim() || null;
+}
+
+function cleanScalar(value: string): string {
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    return typeof parsed === "string" ? parsed : value;
+  } catch {
+    return value;
+  }
+}
+
+function portable(value: string): string {
+  return value.split(path.sep).join("/");
+}

--- a/packages/daemon/src/migration-import-oracle-rebuild.ts
+++ b/packages/daemon/src/migration-import-oracle-rebuild.ts
@@ -1,4 +1,5 @@
 import { mkdtempSync, readFileSync, readdirSync, rmSync } from "node:fs";
+import { markdownH1 } from "./migration-import-tasks.ts";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import {
@@ -68,7 +69,8 @@ export function inspectMigrationSourceEvents(sourceRoot: string): MigrationEvent
         consumeKnownError(error);
         throw migrationImportError(
           "unsupported_legacy_event",
-          `${sourcePath}: ${error instanceof Error ? error.message : String(error)}. Preserve the source and report this event schema before retrying.`,
+          `${sourcePath}: ${error instanceof Error ? error.message : String(error)}. ` +
+            `Preserve the source and report this event schema before retrying.`,
         );
       }
       event = normalized;
@@ -147,7 +149,8 @@ function rebuildEventOracle(sourceRoot: string, inspection: MigrationEventInspec
     consumeKnownError(error);
     throw migrationImportError(
       "migration_projection_rebuild_failed",
-      `Could not rebuild the source oracle without modifying the source: ${error instanceof Error ? error.message : String(error)}.`,
+      `Could not rebuild the source oracle without modifying the source: ` +
+        `${error instanceof Error ? error.message : String(error)}.`,
     );
   } finally {
     projection?.close();
@@ -428,7 +431,9 @@ function normalizeScheduleFacet(
   observations.push({
     code: "schedule_definition_facet_mismatch",
     sourcePath,
-    detail: `accepted historical schedule ${event.entity.id}: declaration blob ${claim.sha256} contains the full schedule instead of only the definition facet`,
+    detail:
+      `accepted historical schedule ${event.entity.id}: ` +
+      `declaration blob ${claim.sha256} contains the full schedule instead of only the definition facet`,
     treatment: "accepted_truth_gap",
   });
   return next;
@@ -539,10 +544,6 @@ function containsSchema(value: unknown, schema: string): boolean {
   return isMigrationImportRecord(value)
     ? value.schema === schema || Object.values(value).some((entry) => containsSchema(entry, schema))
     : false;
-}
-
-function markdownH1(body: string): string | null {
-  return /^#\s+(.+?)\s*$/mu.exec(body)?.[1]?.trim() || null;
 }
 
 function cleanScalar(value: string): string {

--- a/packages/daemon/src/migration-import-oracle.ts
+++ b/packages/daemon/src/migration-import-oracle.ts
@@ -3,6 +3,8 @@ import { DatabaseSync } from "node:sqlite";
 import path from "node:path";
 import { resolveHarnessLayout, type RelationGraphEdgeRow } from "../../kernel/src/index.ts";
 import { isMigrationImportRecord, migrationImportError, nonEmpty } from "./migration-import-report.ts";
+import { inspectMigrationSourceEvents, rebuildMigrationProjectionOracle } from "./migration-import-oracle-rebuild.ts";
+import type { MigrationFormatObservation } from "./migration-import-types.ts";
 
 export const migrationOracleKinds = ["task", "decision", "fact", "relation", "execution"] as const;
 export type MigrationOracleKind = (typeof migrationOracleKinds)[number];
@@ -48,6 +50,8 @@ export interface ProjectionOracleExecution {
 }
 
 export interface MigrationProjectionOracle {
+  readonly basis: "same-cut-projection" | "rebuilt-source";
+  readonly formatObservations: readonly MigrationFormatObservation[];
   readonly databasePath: string;
   readonly watermark: number;
   readonly eventHeadRevision: number | null;
@@ -67,11 +71,22 @@ interface SqlRow {
 export function readMigrationProjectionOracle(sourceRoot: string): MigrationProjectionOracle {
   const layout = resolveHarnessLayout(sourceRoot),
     databasePath = path.join(layout.localRoot, "cache", "task.sqlite");
-  if (!existsSync(databasePath))
-    throw migrationImportError(
-      "migration_projection_oracle_missing",
-      `Same-cut migration oracle is missing: ${path.relative(sourceRoot, databasePath)}.`,
-    );
+  if (!existsSync(databasePath)) return rebuildMigrationProjectionOracle(sourceRoot);
+  return readMigrationProjectionOracleAtPath(
+    sourceRoot,
+    databasePath,
+    "same-cut-projection",
+    inspectMigrationSourceEvents(sourceRoot).observations,
+  );
+}
+
+export function readMigrationProjectionOracleAtPath(
+  sourceRoot: string,
+  databasePath: string,
+  basis: MigrationProjectionOracle["basis"],
+  formatObservations: readonly MigrationFormatObservation[],
+): MigrationProjectionOracle {
+  const layout = resolveHarnessLayout(sourceRoot);
   const database = new DatabaseSync(databasePath, { readOnly: true });
   try {
     const meta = rows(database, "SELECT watermark FROM projection_meta WHERE singleton=1")[0],
@@ -183,6 +198,8 @@ export function readMigrationProjectionOracle(sourceRoot: string): MigrationProj
       ),
       coverage = rows(database, "SELECT COUNT(*) AS count FROM decision_claim WHERE load_bearing=1")[0];
     return {
+      basis,
+      formatObservations,
       databasePath,
       watermark,
       eventHeadRevision,

--- a/packages/daemon/src/migration-import-report.ts
+++ b/packages/daemon/src/migration-import-report.ts
@@ -9,6 +9,7 @@ import type {
   ImportCounts,
   MigrationDisposition,
   MigrationFieldDerivation,
+  MigrationFormatObservation,
   MigrationKindReconciliation,
   MigrationOracleBasis,
   Skip,
@@ -62,6 +63,7 @@ export function reportTable(
   setReconciliation: Readonly<Record<MigrationOracleKind, MigrationKindReconciliation>>,
   fieldDerivations: readonly MigrationFieldDerivation[],
   dispositions: readonly MigrationDisposition[],
+  formatObservations: readonly MigrationFormatObservation[],
 ): string {
   const rows = (Object.keys(old) as EntityKind[]).map((kind) =>
       [
@@ -161,7 +163,10 @@ export function reportTable(
     `Already imported from this Git lineage: ${already || "none"}`,
     `ID remappings: ${remappings.length ? remappings.length : "none"}`,
     ...remappings.map((item) => `- REMAP ${item.entityType} ${item.sourceId} -> ${item.targetId}: ${item.reason}`),
-    `Format observations: ${skips.length ? `${skips.length} legacy parser observations` : "none"}`,
+    `Format observations: ${skips.length ? `${skips.length} legacy parser observations` : "none"}; ${formatObservations.length ? `${formatObservations.length} accepted historical variants` : "no accepted historical variants"}`,
+    ...formatObservations.map(
+      (item) => `- ACCEPT ${item.code} (${item.sourcePath}): ${item.detail}; treatment=${item.treatment}`,
+    ),
     [
       "Attribution: principal restored from source records for ",
       `${attribution.restored}`,

--- a/packages/daemon/src/migration-import-report.ts
+++ b/packages/daemon/src/migration-import-report.ts
@@ -163,7 +163,10 @@ export function reportTable(
     `Already imported from this Git lineage: ${already || "none"}`,
     `ID remappings: ${remappings.length ? remappings.length : "none"}`,
     ...remappings.map((item) => `- REMAP ${item.entityType} ${item.sourceId} -> ${item.targetId}: ${item.reason}`),
-    `Format observations: ${skips.length ? `${skips.length} legacy parser observations` : "none"}; ${formatObservations.length ? `${formatObservations.length} accepted historical variants` : "no accepted historical variants"}`,
+    `Format observations: ${skips.length ? `${skips.length} legacy parser observations` : "none"}; ` +
+      (formatObservations.length
+        ? `${formatObservations.length} accepted historical variants`
+        : "no accepted historical variants"),
     ...formatObservations.map(
       (item) => `- ACCEPT ${item.code} (${item.sourcePath}): ${item.detail}; treatment=${item.treatment}`,
     ),

--- a/packages/daemon/src/migration-import-run.ts
+++ b/packages/daemon/src/migration-import-run.ts
@@ -508,8 +508,11 @@ export async function runSingleMigrationImport(
   }
   const reconciliation = reconcileProjectionOracle(extracted),
     oracleBasis = {
-      kind: "same-cut-projection" as const,
-      databasePath: portableMigrationPath(path.relative(sourceRoot, oracle.databasePath)),
+      kind: oracle.basis,
+      databasePath:
+        oracle.basis === "same-cut-projection"
+          ? portableMigrationPath(path.relative(sourceRoot, oracle.databasePath))
+          : oracle.databasePath,
       watermark: oracle.watermark,
       eventHeadRevision: oracle.eventHeadRevision,
     },
@@ -556,6 +559,7 @@ export async function runSingleMigrationImport(
       reconciliation,
       fieldDerivations,
       dispositions,
+      formatObservations: oracle.formatObservations,
     },
     mapBody = `${stableStringify(idMap)}\n`,
     mapPrepared = prepare(
@@ -622,6 +626,7 @@ export async function runSingleMigrationImport(
       reconciliation,
       fieldDerivations,
       dispositions,
+      oracle.formatObservations,
     ),
     publishedMap = dryRun ? null : input.store.readEvent(mapPrepared.event.opId),
     publication = publishedMap ? input.store.publication(publishedMap) : null,
@@ -645,6 +650,7 @@ export async function runSingleMigrationImport(
       reconciliation,
       fieldDerivations,
       dispositions,
+      formatObservations: oracle.formatObservations,
     }),
     visibility: "center",
     proof: {
@@ -663,6 +669,7 @@ export async function runSingleMigrationImport(
     reconciliation,
     fieldDerivations: [...fieldDerivations],
     dispositions: [...dispositions],
+    formatObservations: [...oracle.formatObservations],
     authoredCoverage,
     skippedEntities: [...skips].sort(bySkip),
     idMapPath: writesAllowed ? idMapPath : null,

--- a/packages/daemon/src/migration-import-source.ts
+++ b/packages/daemon/src/migration-import-source.ts
@@ -220,6 +220,7 @@ export function combineMigrationReceipts(
     reconciliation,
     fieldDerivations: receipts.flatMap(({ fieldDerivations }) => fieldDerivations),
     dispositions: receipts.flatMap(({ dispositions }) => dispositions),
+    formatObservations: receipts.flatMap(({ formatObservations }) => formatObservations),
     authoredCoverage,
     skippedEntities: receipts.flatMap(({ skippedEntities }) => skippedEntities),
     idMapPath: last.idMapPath,

--- a/packages/daemon/src/migration-import-tasks.ts
+++ b/packages/daemon/src/migration-import-tasks.ts
@@ -511,7 +511,7 @@ export function taskTitleFromPackage(
   return indexTitle ? { value: indexTitle, source: path.relative(authoredRoot, indexPath) } : null;
 }
 
-function markdownH1(body: string | null): string | null {
+export function markdownH1(body: string | null): string | null {
   const value = body?.match(/^#\s+(.+?)\s*$/mu)?.[1]?.trim() ?? "";
   return value || null;
 }

--- a/packages/daemon/src/migration-import-types.ts
+++ b/packages/daemon/src/migration-import-types.ts
@@ -44,10 +44,17 @@ export interface MigrationKindReconciliation {
 }
 
 export interface MigrationOracleBasis {
-  readonly kind: "same-cut-projection";
+  readonly kind: "same-cut-projection" | "rebuilt-source";
   readonly databasePath: string;
   readonly watermark: number;
   readonly eventHeadRevision: number | null;
+}
+
+export interface MigrationFormatObservation {
+  readonly code: "legacy_event_normalized" | "schedule_definition_facet_mismatch" | "source_projection_rebuilt";
+  readonly sourcePath: string;
+  readonly detail: string;
+  readonly treatment: "mechanically_normalized" | "accepted_truth_gap" | "rebuilt_read_only";
 }
 
 export interface Draft {
@@ -136,6 +143,7 @@ export type MigrationImportReceipt = WriteReceipt & {
   readonly reconciliation: Readonly<Record<MigrationOracleKind, MigrationKindReconciliation>>;
   readonly fieldDerivations: readonly MigrationFieldDerivation[];
   readonly dispositions: readonly MigrationDisposition[];
+  readonly formatObservations: readonly MigrationFormatObservation[];
   readonly authoredCoverage: AuthoredCoverage;
   readonly skippedEntities: readonly Skip[];
   readonly idMapPath: string | null;

--- a/packages/daemon/test/migration-import-legacy-variants.integration.test.ts
+++ b/packages/daemon/test/migration-import-legacy-variants.integration.test.ts
@@ -1,0 +1,359 @@
+// harness-test-tier: integration
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import {
+  REPLAY_TASK_GRAPH,
+  canonicalizeContractValue,
+  compileFactWrite,
+  compileScheduleDefinitionEvent,
+  createScheduleV1,
+  eventObjectRelativePath,
+  serializeEventHead,
+  serializePersistedCanonicalEvent,
+  sha256Text,
+  type PersistedCanonicalEventV1,
+} from "../../kernel/src/index.ts";
+import { canonicalRoot, workspaceId } from "../src/protocol/daemon-protocol.contract.ts";
+import { openRepoCell } from "../src/repo-cell.ts";
+import { actor, git, initRepo, legacyFixture } from "./migration-import.fixtures.ts";
+
+type VariantBuilder = (root: string) => void;
+
+const variants: readonly { readonly name: string; readonly build: VariantBuilder; readonly observation?: RegExp }[] = [
+  { name: "markdown-only-v0", build: legacyFixture },
+  { name: "flat-task-v1-events", build: (root) => taskV1Fixture(root, "flat/v1") },
+  { name: "sharded-task-v1-events", build: (root) => taskV1Fixture(root, "sharded-sha256-2/v1") },
+  { name: "migration-import-task-v1", build: migrationTaskV1Fixture },
+  { name: "legacy-doc-commit-cut", build: legacyDocCutFixture },
+  { name: "task-local-fact-event", build: legacyFactEventFixture },
+  { name: "taskless-fact-current-provenance", build: tasklessFactFixture },
+  {
+    name: "schedule-definition-facet-drift",
+    build: scheduleFacetDriftFixture,
+    observation: /ACCEPT schedule_definition_facet_mismatch/u,
+  },
+];
+
+test("every historical canonical format fixture dry-runs through one-command oracle rebuild", async (t) => {
+  for (const variant of variants)
+    await t.test(variant.name, async () => {
+      const scratch = mkdtempSync(path.join(tmpdir(), `ha-migration-variant-${variant.name}-`)),
+        source = path.join(scratch, "source"),
+        destination = path.join(scratch, "destination");
+      let cell: Awaited<ReturnType<typeof openRepoCell>> | undefined;
+      try {
+        variant.build(source);
+        commitSource(source);
+        initRepo(destination);
+        cell = await openRepoCell({
+          repoId: workspaceId(`migration-${variant.name}`),
+          rootDir: canonicalRoot(destination),
+          ownerId: "migration-daemon",
+          now: () => "2026-08-31T00:00:00.000Z",
+        });
+        const result = (await cell.run(
+          { kind: "migrate-import", sourceRoots: [source], dryRun: true },
+          { actor, source: "local" },
+        )) as Record<string, unknown>;
+        assert.equal(result.exitCode, 0, JSON.stringify(result));
+        assert.match(String(result.summary), /Oracle: rebuilt-source/u);
+        assert.match(String(result.summary), /Reconciliation: PASS/u);
+        assert.doesNotMatch(String(result.summary), /invalid_write_plan/u);
+        if (variant.observation) assert.match(String(result.summary), variant.observation);
+      } finally {
+        await cell?.close();
+        rmSync(scratch, { recursive: true, force: true, maxRetries: 5, retryDelay: 20 });
+      }
+    });
+});
+
+function taskV1Fixture(root: string, layout: "flat/v1" | "sharded-sha256-2/v1"): void {
+  const taskId = `task_${layout === "flat/v1" ? "flat" : "sharded"}`,
+    body = taskDocument(taskId, `Legacy ${layout}`),
+    event = taskV1Event(taskId, 1),
+    eventBody = serializePersistedCanonicalEvent(event as unknown as PersistedCanonicalEventV1);
+  baseFixture(root, taskId, body);
+  writeEvent(root, event.opId, eventBody, layout);
+  writeHead(root, 1, event.opId, eventBody);
+}
+
+function migrationTaskV1Fixture(root: string): void {
+  const taskId = "task_imported_v1",
+    body = taskDocument(taskId, "Imported Task/v1"),
+    claim = migrationClaim(`tasks/${taskId}-imported-task-v1/INDEX.md`, body, "text/markdown"),
+    event = {
+      schema: "migration-import-event/v1",
+      eventId: "event-imported-v1",
+      workspaceRevision: 1,
+      opId: "op-imported-v1",
+      type: "entity_migrated",
+      actor,
+      source: "migration-import/v1",
+      occurredAt: "2026-08-15T00:00:00.000Z",
+      payload: {
+        migratedFrom: taskId,
+        generation: "v0",
+        entity: {
+          kind: "task",
+          task: legacyTask(taskId, "Imported Task/v1"),
+          originalStatus: "planned",
+          packagePath: `tasks/${taskId}-imported-task-v1`,
+          documentClaim: claim,
+        },
+      },
+    },
+    eventBody = `${JSON.stringify(canonicalizeContractValue(event))}\n`;
+  baseFixture(root, taskId, body, `tasks/${taskId}-imported-task-v1`);
+  writeBlob(root, claim.sha256, body);
+  writeEvent(root, event.opId, eventBody, "flat/v1");
+  writeHead(root, 1, event.opId, eventBody);
+}
+
+function legacyFactEventFixture(root: string): void {
+  const taskId = "task_fact_local",
+    factId = "F-ABCDEF12",
+    taskRoot = baseFixture(root, taskId, taskDocument(taskId, "Task-local fact")),
+    factsBody = `# Facts\n\n- {fact_id: ${factId}, statement: Legacy event fact, source: fixture, observedAt: 2026-08-15T00:00:00.000Z, confidence: high, memoryClass: semantic, memoryTags: [pattern], provenance: [{runtime: codex, sessionId: legacy-session, boundAt: 2026-08-15T00:00:00.000Z}]}\n`,
+    claim = {
+      path: `${path.relative(path.join(root, "harness"), taskRoot).split(path.sep).join("/")}/facts.md`,
+      sha256: sha256Text(factsBody),
+      size: Buffer.byteLength(factsBody),
+      mediaType: "text/markdown",
+      policyId: "typed-machine-writer/v1",
+    },
+    event = {
+      schema: "fact-event/v1",
+      eventId: "event-legacy-fact",
+      workspaceRevision: 1,
+      opId: "op-legacy-fact",
+      taskId,
+      factId,
+      type: "fact_recorded",
+      actor,
+      source: "local",
+      occurredAt: "2026-08-15T00:00:00.000Z",
+      payload: {
+        statement: "Legacy event fact",
+        evidenceSource: "fixture",
+        observedAt: "2026-08-15T00:00:00.000Z",
+        confidence: "high",
+        memoryClass: "semantic",
+        memoryTags: ["pattern"],
+        provenance: [{ runtime: "codex", sessionId: "legacy-session", boundAt: "2026-08-15T00:00:00.000Z" }],
+        factsDocumentClaim: claim,
+      },
+    },
+    eventBody = `${JSON.stringify(event)}\n`;
+  writeFileSync(path.join(taskRoot, "facts.md"), factsBody);
+  writeBlob(root, claim.sha256, factsBody);
+  writeEvent(root, event.opId, eventBody, "flat/v1");
+  writeHead(root, 1, event.opId, eventBody);
+}
+
+function legacyDocCutFixture(root: string): void {
+  const taskId = "task_doc_cut",
+    body = "historical opaque note\n",
+    sha256 = sha256Text(body),
+    event = {
+      schema: "doc-event/v1",
+      eventId: "event-doc-commit-cut",
+      workspaceRevision: 1,
+      opId: "op-doc-commit-cut",
+      type: "documents_written",
+      actor,
+      source: "local",
+      occurredAt: "2026-08-20T00:00:00.000Z",
+      payload: {
+        executionId: null,
+        baseLedgerSha: { repoId: "legacy-repo", sha: "a".repeat(40) },
+        changes: [
+          {
+            path: `tasks/${taskId}-doc-cut/artifacts/note.txt`,
+            baseBlobSha256: null,
+            candidate: { sha256, size: Buffer.byteLength(body), mediaType: "text/plain" },
+            policyId: "opaque-textual-whole-file/v1",
+            regionProofs: [],
+          },
+        ],
+      },
+    },
+    eventBody = `${JSON.stringify(canonicalizeContractValue(event))}\n`;
+  baseFixture(root, taskId, taskDocument(taskId, "Legacy document cut"), `tasks/${taskId}-doc-cut`);
+  writeBlob(root, sha256, body);
+  writeEvent(root, event.opId, eventBody, "flat/v1");
+  writeHead(root, 1, event.opId, eventBody);
+}
+
+function tasklessFactFixture(root: string): void {
+  const factId = "F-FACEB00C",
+    compiled = compileFactWrite({
+      event: {
+        schema: "fact-event/v1",
+        eventId: "event-taskless-current",
+        workspaceRevision: 1,
+        opId: "op-taskless-current",
+        factId,
+        type: "fact_recorded",
+        actor,
+        source: "local",
+        occurredAt: "2026-08-27T00:00:00.000Z",
+        payload: {
+          statement: "Taskless historical fact",
+          evidenceSource: "fixture",
+          observedAt: "2026-08-27T00:00:00.000Z",
+          confidence: "high",
+          memoryClass: "semantic",
+          memoryTags: [],
+          provenance: [
+            {
+              runtime: "codex",
+              sessionId: null,
+              transcriptReachability: "unavailable",
+              boundAt: "2026-08-27T00:00:00.000Z",
+            },
+          ],
+        },
+      },
+    }),
+    eventBody = serializePersistedCanonicalEvent(compiled.event);
+  harnessRoot(root);
+  mkdirSync(path.join(root, "harness/facts"), { recursive: true });
+  writeFileSync(path.join(root, `harness/facts/${factId}.md`), compiled.body);
+  writeBlob(root, compiled.blobs[0].sha256, compiled.blobs[0].body);
+  writeEvent(root, compiled.event.opId, eventBody, "sharded-sha256-2/v1");
+  writeHead(root, 1, compiled.event.opId, eventBody);
+}
+
+function scheduleFacetDriftFixture(root: string): void {
+  baseFixture(root, "task_schedule_witness", taskDocument("task_schedule_witness", "Schedule witness"));
+  const schedule = createScheduleV1({
+      scheduleId: "schedule-fixture",
+      name: "Historical schedule",
+      mode: "detect",
+      spec: {
+        trigger: { kind: "interval", everyMs: 60_000, anchorAt: "2026-08-26T00:00:00.000Z" },
+        target: { kind: "agent", agentId: "agent-fixture", runtimeInstanceId: "runtime-fixture" },
+        mission: "Preserve the historical schedule.",
+      },
+      actor,
+      occurredAt: "2026-08-26T00:00:00.000Z",
+    }),
+    compiled = compileScheduleDefinitionEvent({
+      type: "schedule_created",
+      schedule,
+      eventId: "event-schedule-drift",
+      opId: "op-schedule-drift",
+      workspaceRevision: 1,
+      actor,
+      source: "local",
+      occurredAt: "2026-08-26T00:00:00.000Z",
+    }),
+    historicalBody = `${JSON.stringify(schedule, null, 2)}\n`,
+    historicalClaim = {
+      ...compiled.event.payload.declarationDocumentClaim,
+      sha256: sha256Text(historicalBody),
+      size: Buffer.byteLength(historicalBody),
+    },
+    event = {
+      ...compiled.event,
+      payload: { ...compiled.event.payload, declarationDocumentClaim: historicalClaim },
+    },
+    eventBody = serializePersistedCanonicalEvent(event);
+  writeBlob(root, historicalClaim.sha256, historicalBody);
+  writeEvent(root, event.opId, eventBody, "sharded-sha256-2/v1");
+  writeHead(root, 1, event.opId, eventBody);
+}
+
+function baseFixture(root: string, taskId: string, body: string, packagePath?: string): string {
+  harnessRoot(root);
+  const taskRoot = path.join(root, "harness", packagePath ?? `tasks/${taskId}-${slug(taskId)}`);
+  mkdirSync(taskRoot, { recursive: true });
+  writeFileSync(path.join(taskRoot, "INDEX.md"), body);
+  return taskRoot;
+}
+
+function harnessRoot(root: string): void {
+  mkdirSync(path.join(root, "harness"), { recursive: true });
+  writeFileSync(
+    path.join(root, "harness/harness.yaml"),
+    "schema: harness-anything/v1\nlayout:\n  authoredRoot: harness\n  localRoot: .harness\n",
+  );
+}
+
+function taskDocument(taskId: string, title: string): string {
+  return `---\nschema: task-package/v2\ntask_id: ${taskId}\ntitle: ${JSON.stringify(title)}\nlifecycle:\n  status: planned\n  engine: local\n  bindingCreatedAt: 2026-08-15T00:00:00.000Z\nvertical: software/coding\npreset: standard-task\nprofile: baseline\n---\n\n# ${title}\n`;
+}
+
+function taskV1Event(taskId: string, workspaceRevision: number) {
+  return {
+    schema: "task-event/v1",
+    eventId: `event-${taskId}`,
+    workspaceRevision,
+    opId: `op-${taskId}`,
+    taskId,
+    type: "task_created",
+    actor,
+    source: "local",
+    occurredAt: "2026-08-15T00:00:00.000Z",
+    payload: { task: legacyTask(taskId, `Legacy ${taskId}`) },
+  };
+}
+
+function legacyTask(taskId: string, title: string) {
+  return {
+    schema: "task/v1",
+    taskId,
+    title,
+    taskClass: "standard",
+    status: "planned",
+    graph: REPLAY_TASK_GRAPH,
+    currentNode: "implementation",
+    iteration: 0,
+    createdBy: actor,
+    completionGateIds: [],
+    presetSnapshotDigest: null,
+  };
+}
+
+function migrationClaim(target: string, body: string, mediaType: string) {
+  return {
+    path: target,
+    sha256: sha256Text(body),
+    size: Buffer.byteLength(body),
+    mediaType,
+    policyId: "typed-migration-import/v1",
+  };
+}
+
+function writeEvent(root: string, opId: string, body: string, layout: "flat/v1" | "sharded-sha256-2/v1"): void {
+  const target = path.join(root, "harness", eventObjectRelativePath(opId, layout));
+  mkdirSync(path.dirname(target), { recursive: true });
+  writeFileSync(target, body);
+}
+
+function writeBlob(root: string, sha256: string, body: string): void {
+  const target = path.join(root, "harness/objects/sha256", sha256.slice(0, 2), sha256.slice(2));
+  mkdirSync(path.dirname(target), { recursive: true });
+  writeFileSync(target, body);
+}
+
+function writeHead(root: string, revision: number, opId: string, eventBody: string): void {
+  const target = path.join(root, "harness/events/head.json");
+  mkdirSync(path.dirname(target), { recursive: true });
+  writeFileSync(target, serializeEventHead({ revision, opId, eventDigest: `sha256:${sha256Text(eventBody)}` }));
+}
+
+function commitSource(root: string): void {
+  git(root, "init", "-q");
+  git(root, "config", "user.name", "Historical Fixture");
+  git(root, "config", "user.email", "historical-fixture@example.invalid");
+  git(root, "add", ".");
+  git(root, "commit", "-qm", "historical fixture");
+}
+
+function slug(taskId: string): string {
+  return taskId.replace(/^task_/u, "").replaceAll("_", "-");
+}

--- a/skills/harness-migration/SKILL.md
+++ b/skills/harness-migration/SKILL.md
@@ -358,11 +358,18 @@ cat "$DRY_RUN"
 **Use the importer as the classifier.** Do not inventory the old repository or
 invent categories of your own. Act only on what the report prints:
 
-- five entity rows (task / decision / fact / relation / coverage)
-- `Format validation` and each `- SKIP` line
+- `Oracle: same-cut-projection` or `Oracle: rebuilt-source`
+- five reconciliation rows (task / decision / fact / relation / execution)
+- `Format observations` and each `ACCEPT` or `SKIP` line
 - `Attribution`
 - the authored coverage table and each `required` row
 - `Authored reconciliation`
+
+Do not manufacture `.harness/cache/task.sqlite` in the working source. If it is
+absent, the importer rebuilds a disposable read-only oracle from committed flat
+or sharded events and older authored packages. `Oracle: rebuilt-source` is the
+expected receipt for that path; the source tree and Git refs must remain byte-for-byte
+unchanged.
 
 Branch on those rows:
 
@@ -370,9 +377,11 @@ Branch on those rows:
 | --- | --- |
 | a `required` row saying `destination content differs` | section 5 |
 | `required` on `presets/**` | section 6 |
-| any `- SKIP` line | section 7 |
+| `ACCEPT schedule_definition_facet_mismatch` | review it in section 7; no source edit |
+| `unsupported_legacy_event` or `migration_projection_rebuild_failed` | section 7 |
+| any `- SKIP` line | review it in section 7; it is diagnostic, not a count subtraction |
 | any other `required` row | show the exact row to the user and stop — this workflow does not cover it |
-| no `required`, no `SKIP` | section 8 |
+| no `required` and all five reconciliation rows pass | section 8 |
 
 ## 5. Resolve destination conflicts — one batch, one decision
 
@@ -505,23 +514,34 @@ mv "$WORK_SOURCE/harness/presets" "$HARNESS_MIGRATION_WORK/legacy-presets-rebuil
 Re-run the dry-run from section 4 with `"${RESOLVE_ARGS[@]}"`. The `presets/**`
 row must be gone.
 
-## 7. Repair strict format failures on the working copy
+## 7. Handle historical-format observations
 
 ```bash
-grep '^- SKIP ' "$DRY_RUN"
+grep -E '^- (ACCEPT|SKIP) ' "$DRY_RUN"
 ```
 
-Each line names one rejected entity, its source path, and why strict validation
-refused it — for example a decision whose `occurredAt` is invalid. Show every
-line to the user.
+Show every observation to the user. `SKIP` rows are legacy-parser diagnostics;
+they are not subtracted from the projection oracle and do not independently
+block a reconciled import.
 
-Fix only the named record, **under `$WORK_SOURCE`**. If a value cannot be
-recovered from the record itself, ask the user for it. **Never add a
-compatibility rule to the importer** — a one-time historical artifact does not
-belong in product logic.
+`ACCEPT schedule_definition_facet_mismatch` with
+`treatment=accepted_truth_gap` is the one known schedule declaration-claim
+variant. The disposable oracle uses the definition facet from the event while
+the original claim blob stays untouched in the forensic archive. Confirm the
+warning has that exact code and treatment, then continue; do not rewrite it.
 
-Exit code `3` means strict failures remain. Repeat until `Format validation`
-reports none and every entity row has `Skipped = 0`.
+For `unsupported_legacy_event`, preserve the source and collect the exact event
+path, schema, and nested parser error. For `migration_projection_rebuild_failed`,
+collect the nested cause and identify any missing or corrupt committed blob.
+Stop and report either case as a missing compatibility fixture. Do not hand-edit
+canonical event bytes to get past it. A `migration_projection_oracle_cut_mismatch`
+means source writers were not frozen or a local projection is stale: stop the
+writers, remove or regenerate that local cache, and dry-run again.
+
+If a dry-run reports reconciliation `FAIL` or `invalid_write_plan`, do not apply.
+Keep the full receipt and report the named kind/event. Apply is allowed only
+after dry-run exits zero and proves every planned event against the current
+write contract.
 
 ## 8. Recreate the destination, then apply once
 
@@ -537,8 +557,9 @@ for NEW_PRESET in "$HARNESS_MIGRATION_WORK/rebuilt-presets"/*; do ha preset inst
 ha migrate import --source "$WORK_SOURCE" "${RESOLVE_ARGS[@]}" --dry-run; echo "exit=$?"
 ```
 
-Apply only when that exits zero, all five rows show `Old = Expected = New` with
-`Skipped = 0`, authored coverage has no `required`, and reconciliation passes.
+Apply only when that exits zero, all five reconciliation rows pass, authored
+coverage has no `required`, and every accepted historical observation has been
+reviewed. A source rebuilt without `task.sqlite` must say `Oracle: rebuilt-source`.
 
 **Run apply detached, and poll it.** It prints **nothing at all** until it
 finishes, so a foreground run is indistinguishable from a hang and any caller
@@ -1006,7 +1027,9 @@ success and failure paths.
 ## Done when
 
 - Apply exited zero and the final dry-run had `Reconciliation: PASS`.
-- All five entity classes show `Old = Expected = New`, `Skipped = 0`.
+- All five entity reconciliation rows pass and satisfy the reported
+  source/target explained-difference equality.
+- `Oracle` basis is recorded; every `ACCEPT` observation has been reviewed.
 - Authored coverage has no `required` row.
 - Every conflict appears as an explicit `resolved:` row.
 - Every merge recorded in the step 5 table has been applied to the destination.

--- a/tools/write-road-registry.json
+++ b/tools/write-road-registry.json
@@ -3,30 +3,57 @@
   "rows": [
     {
       "id": "lifecycle.event-publication",
-      "actions": ["task-create", "task-submit", "task-review-execution", "task-complete"],
+      "actions": [
+        "task-create",
+        "task-submit",
+        "task-review-execution",
+        "task-complete"
+      ],
       "authority": "packages/daemon/src/repo-cell.ts",
       "store": "packages/kernel/src/store/task-event-store.ts",
       "leasePolicy": "domain-contract",
-      "evidence": ["packages/daemon/src/repo-cell.ts", "packages/application/src/task-lifecycle-service.ts", "packages/kernel/src/store/task-event-store.ts", "packages/kernel/src/store/wal-event-log.ts"]
+      "evidence": [
+        "packages/daemon/src/repo-cell.ts",
+        "packages/application/src/task-lifecycle-service.ts",
+        "packages/kernel/src/store/task-event-store.ts",
+        "packages/kernel/src/store/wal-event-log.ts"
+      ]
     },
     {
       "id": "workspace.bootstrap",
-      "actions": ["repo-bootstrap", "daemon-repo-register", "daemon-repo-unregister"],
+      "actions": [
+        "repo-bootstrap",
+        "daemon-repo-register",
+        "daemon-repo-unregister"
+      ],
       "authority": "packages/daemon/src/daemon-host.ts",
-      "evidence": ["packages/daemon/src/daemon-host.ts", "packages/daemon/src/repo-bootstrap.ts", "packages/kernel/src/daemon/registry.ts"]
+      "evidence": [
+        "packages/daemon/src/daemon-host.ts",
+        "packages/daemon/src/repo-bootstrap.ts",
+        "packages/kernel/src/daemon/registry.ts"
+      ]
     },
     {
       "id": "daemon.runtime-control",
-      "actions": ["daemon-start", "daemon-stop"],
+      "actions": [
+        "daemon-start",
+        "daemon-stop"
+      ],
       "authority": "packages/daemon/src/runtime.ts",
-      "evidence": ["packages/cli/src/daemon/control.ts", "packages/daemon/src/runtime.ts", "packages/daemon/src/transport/unix-socket.ts"]
+      "evidence": [
+        "packages/cli/src/daemon/control.ts",
+        "packages/daemon/src/runtime.ts",
+        "packages/daemon/src/transport/unix-socket.ts"
+      ]
     },
     {
       "id": "projection.sqlite",
       "actions": [],
       "source": "task-event-store",
       "authority": "packages/kernel/src/projection/rebuildable-task-projection.ts",
-      "evidence": ["packages/kernel/src/projection/rebuildable-task-projection.ts"]
+      "evidence": [
+        "packages/kernel/src/projection/rebuildable-task-projection.ts"
+      ]
     }
   ],
   "physicalWriteFiles": [
@@ -35,30 +62,31 @@
     "packages/daemon/src/ci-observation-actions.ts",
     "packages/daemon/src/daemon-singleton.ts",
     "packages/daemon/src/dispatch-stream.ts",
+    "packages/daemon/src/doc-sync-candidate-scanner.ts",
     "packages/daemon/src/doc-sync-details.ts",
     "packages/daemon/src/doc-sync-files.ts",
-    "packages/daemon/src/doc-sync-candidate-scanner.ts",
+    "packages/daemon/src/durable-file.ts",
+    "packages/daemon/src/fleet-edge-mirror.ts",
     "packages/daemon/src/fleet/center-lease-claims.ts",
     "packages/daemon/src/fleet/center-listener.ts",
     "packages/daemon/src/fleet/edge.ts",
-    "packages/daemon/src/durable-file.ts",
-    "packages/daemon/src/writer-epoch.ts",
     "packages/daemon/src/fleet/replica-ack-store.ts",
     "packages/daemon/src/fleet/replica-cut-store.ts",
-    "packages/daemon/src/fleet-edge-mirror.ts",
     "packages/daemon/src/lifecycle-log.ts",
+    "packages/daemon/src/migration-import-oracle-rebuild.ts",
     "packages/daemon/src/repo-bootstrap.ts",
     "packages/daemon/src/repo-cell-errors.ts",
     "packages/daemon/src/repo-cell-lock.ts",
     "packages/daemon/src/request-log.ts",
     "packages/daemon/src/runtime.ts",
     "packages/daemon/src/transport/unix-socket.ts",
+    "packages/daemon/src/writer-epoch.ts",
     "packages/kernel/src/daemon/registry.ts",
     "packages/kernel/src/local/local-layout-file-system.ts",
     "packages/kernel/src/projection/rebuildable-task-projection-database.ts",
     "packages/kernel/src/projection/sqlite-projection-store.ts",
     "packages/kernel/src/store/local-version-control-system.ts",
-    "packages/preset/src/preset-process-service.ts",
-    "packages/preset/src/preset-installation.ts"
+    "packages/preset/src/preset-installation.ts",
+    "packages/preset/src/preset-process-service.ts"
   ]
 }


### PR DESCRIPTION
# English

## Summary

Any-historical-version migration hardening. Users can sit on any past harness format and must be able to rebuild-migrate into the current one with a single `ha migrate import`. This PR closes the two gaps the real-ledger migration exposed and proves coverage with eight historical-format fixture repositories, all reaching `Reconciliation: PASS` in isolated dry-runs:

1. **Missing source projection no longer blocks migration.** The same-cut oracle (`.harness/cache/task.sqlite`) is often absent or destroyed on old checkouts (tonight's real migration hit exactly this and needed a hand-built instrument). `migration-import-oracle-rebuild.ts` (new, 559) rebuilds a disposable SQLite oracle from committed events and authored packages automatically; corrupted events fail closed as `migration_projection_rebuild_failed` with a nested cause.
2. **Legacy shapes normalize mechanically.** Task/v1 (flat and sharded event layouts), early `migration-import-event/v1` task entities without provenance, legacy `doc-event/v1` ledger identity, three-field fact provenance, and taskless facts are normalized by a migration-only reader (backfilled fields: `pinned=false`, `packageDisposition=active`, `provenance=imported_snapshot`, `transcriptReachability` via `canonicalMigrationProvenance`). Unknown shapes fail closed as `unsupported_legacy_event` naming the exact path/schema. The known revision-35469 schedule facet drift is handled by synthesizing a consistent blob for the disposable oracle only — the source blob is untouched and an explicit truth-gap warning is emitted.

User-facing docs (`docs-release/migration-genesis-replay.md` + zh-CN) and the `harness-migration` skill are aligned with measured behavior.

## Architectural Justification

- Forward-only compatibility: all normalization lives in the migration-only read path; no compatibility layer, fallback, or second truth enters the current contracts. Mechanical backfills follow the owner ruling that missing new-structure fields may be derived; underivable data fails closed and is reported, never silently dropped.
- Deletes toil, not adds mechanism: the oracle rebuild replaces the manual "checkout old code, patch an instrument, cold-rebuild" procedure the CEO had to perform during the real migration.

## What Changed

- Daemon: `migration-import-oracle-rebuild.ts` (new, +559); `migration-import-oracle.ts` / `-run.ts` / `-source.ts` / `-report.ts` / `-types.ts` wiring (+56/−41 across).
- Tests: `migration-import-legacy-variants.integration.test.ts` (new, +359) — eight fixture variants, each an isolated init + dry-run asserting `Reconciliation: PASS`.
- Docs/skill: `docs-release/migration-genesis-replay.md` (+ zh-CN), `skills/harness-migration/SKILL.md`.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none

## Machine-Readable Declarations

Production-Delta: +611/-10
Dependency-Change: none

### Optional Evidence Claims

None.

## Task And Scope

- Harness task: `task_0c55440e0b5055975657742c57`
- Branch: `codex/migration-compat`
- Public scope: migration legacy-format compatibility + oracle rebuild + user docs/skill.
- Private evidence: variant matrix in `artifacts/report-2026-08-31.md`; Facts `F-562715EB` (coverage matrix), `F-B66FE5E5` (real migration), `F-9AB96751` (owner ruling).

## Version Impact

- Version: no change. Publish impact: none.

## Governance Declaration

- Protected surface touched: no
- Authority: `task_0c55440e0b5055975657742c57`; Facts above.
- Break-glass: no

## Verification

- Base `origin/main`: post-#2054 merge (`7ed0e15ff` line).
- Worker: eight isolated fixture dry-runs all `Reconciliation: PASS`; typecheck, ESLint, canonical-event-compat, skill validation, existing migration test family green locally.
- [x] `git diff --check`
- [x] `npm run typecheck`
- [ ] `npm run check` / full suites: GitHub CI is the authority.

## Review Evidence

- CEO semantic review: normalization confined to migration-only readers; unknown shapes fail closed with path/schema; schedule-facet synthesis touches the disposable oracle only with an explicit truth-gap warning; docs/skill claims match the fixture receipts.

## Residual Risk

- The variant set covers every format found in this repository's history; formats from third-party forks outside that history would surface as `unsupported_legacy_event` with an actionable report rather than silent misimport — by design.

## References

- Task and facts above; real-migration ledger `task_474f84a894ab2d1c58df1e44d5.../artifacts/migrate-apply-ledger-20260831.md`.

# 中文

## 概要

任意历史版本迁移加固:用户停在任何历史格式,都能一条 `ha migrate import` Rebuild 到当前格式。补齐真迁移暴露的两个缺口,并用 8 个历史格式 fixture 仓证明覆盖(隔离 dry-run 全部 `Reconciliation: PASS`):

1. **缺 source 投影不再挡路**:同截面 oracle 在老 checkout 上常缺失/被毁(今晚真迁移正中此坑,只能手工造仪器)。新增 `migration-import-oracle-rebuild.ts`(559 行)从 committed events/authored packages 自动重建一次性 SQLite oracle;事件损坏则 fail-closed 报 `migration_projection_rebuild_failed` 带嵌套原因。
2. **历史形态机械归一**:Task/v1(flat 与 sharded 两种事件布局)、早期 migration 事件缺 provenance、旧 doc-event ledger identity、三键 fact provenance、无主 fact——由 migration 专用读路机械补全(pinned=false、packageDisposition=active、provenance=imported_snapshot、transcriptReachability);不认识的形态 fail-closed 报 `unsupported_legacy_event` 并点名 path/schema。已知 revision-35469 型 schedule facet 漂移只在一次性 oracle 内合成一致 blob,源 blob 不动,显式 truth-gap 告警。

用户文档(migration-genesis-replay 中英)与 harness-migration skill 已与实测行为对齐。

## 架构辩护

- 只向前兼容:归一化全部在 migration 专用读路,当前契约零兼容层零回退;机械补全遵循「缺新结构字段可机械补,补不上 fail-closed 报告」的裁定,零静默丢弃。
- 删苦工不加机制:oracle 自动重建取代真迁移中「checkout 旧代码+打仪器补丁+冷重建」的手工流程。

## 门收割 / Gate Harvest

- 删除的生产路径:无;删除的门/fixture:无。

## 机读声明说明

`Production-Delta` 由 gate 实测。

## 任务与范围

- Task `task_0c55440e0b5055975657742c57`;分支 `codex/migration-compat`;范围:迁移历史兼容+oracle 重建+用户文档/skill。

## 版本影响

- 不改版本、不发布。

## 治理声明

- 未触碰受保护面;授权=task + F-562715EB/F-B66FE5E5/F-9AB96751;非 break-glass。

## 验证

- worker 本地:8 个隔离 fixture dry-run 全 PASS、typecheck、ESLint、canonical-event-compat、skill 校验、既有迁移测试族绿;完整权威=GitHub CI。

## 审查证据

- CEO 语义验收:归一化只在迁移读路;未知形态 fail-closed 带 path/schema;facet 合成只碰一次性 oracle 且显式告警;文档断言与 fixture 回执一致。

## 残余风险

- 变体集覆盖本仓历史全部格式;仓外第三方分叉的格式会以 `unsupported_legacy_event` 显式报告而非静默误迁——设计如此。

## 关联材料

- 上述 task 与 fact;真迁移 ledger `migrate-apply-ledger-20260831.md`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VTzQAqvuFy6ikGjBKxA9xj
