### PR TITLE
fix(gui): correct artifact pane drag direction and preview fill

### DIFF
--- a/packages/gui/src/renderer/components/HtmlArtifactPreview.tsx
+++ b/packages/gui/src/renderer/components/HtmlArtifactPreview.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useRef } from "react";
 import { buildHtmlArtifactDataUrl, HTML_ARTIFACT_PARTITION } from "../../api/html-artifact-policy.ts";
 
+const ISOLATION_BADGE = "隔离本地预览 · 脚本 / 外联已禁用";
+
 export function HtmlArtifactPreview({
   content,
   path,
@@ -48,9 +50,14 @@ export function HtmlArtifactPreview({
       ].join(" ")}
       data-testid="html-artifact-preview"
     >
-      <header className="flex shrink-0 items-center justify-between gap-3 border-b border-border bg-surface-raised px-3 py-2">
+      <header
+        className={[
+          "flex shrink-0 items-center justify-between gap-3",
+          "border-b border-border bg-surface-raised px-3 py-2",
+        ].join(" ")}
+      >
         <span className="min-w-0 truncate font-mono text-[11px] text-text-muted">{path}</span>
-        <span className="shrink-0 font-mono text-[10px] text-text-faint">隔离本地预览 · 脚本 / 外联已禁用</span>
+        <span className="shrink-0 font-mono text-[10px] text-text-faint">{ISOLATION_BADGE}</span>
       </header>
       <div
         ref={hostRef}

--- a/packages/gui/src/renderer/components/HtmlArtifactPreview.tsx
+++ b/packages/gui/src/renderer/components/HtmlArtifactPreview.tsx
@@ -1,7 +1,15 @@
 import { useEffect, useRef } from "react";
 import { buildHtmlArtifactDataUrl, HTML_ARTIFACT_PARTITION } from "../../api/html-artifact-policy.ts";
 
-export function HtmlArtifactPreview({ content, path }: { readonly content: string; readonly path: string }) {
+export function HtmlArtifactPreview({
+  content,
+  path,
+  fillAvailable = false,
+}: {
+  readonly content: string;
+  readonly path: string;
+  readonly fillAvailable?: boolean;
+}) {
   const hostRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -33,14 +41,22 @@ export function HtmlArtifactPreview({ content, path }: { readonly content: strin
   }, [content, path]);
 
   return (
-    <section className="overflow-hidden rounded-lg border border-border bg-surface" data-testid="html-artifact-preview">
-      <header className="flex items-center justify-between gap-3 border-b border-border bg-surface-raised px-3 py-2">
+    <section
+      className={[
+        "overflow-hidden rounded-lg border border-border bg-surface",
+        fillAvailable ? "html-artifact-preview-fill flex h-full min-h-0 min-w-0 flex-col" : "",
+      ].join(" ")}
+      data-testid="html-artifact-preview"
+    >
+      <header className="flex shrink-0 items-center justify-between gap-3 border-b border-border bg-surface-raised px-3 py-2">
         <span className="min-w-0 truncate font-mono text-[11px] text-text-muted">{path}</span>
-        <span className="shrink-0 font-mono text-[10px] text-text-faint">
-          隔离本地预览 · 脚本 / 外联已禁用
-        </span>
+        <span className="shrink-0 font-mono text-[10px] text-text-faint">隔离本地预览 · 脚本 / 外联已禁用</span>
       </header>
-      <div ref={hostRef} className="min-h-[42rem] bg-white" />
+      <div
+        ref={hostRef}
+        className={fillAvailable ? "min-h-0 min-w-0 flex-1 overflow-hidden bg-white" : "min-h-[42rem] bg-white"}
+        data-testid="html-artifact-host"
+      />
     </section>
   );
 }

--- a/packages/gui/src/renderer/styles.css
+++ b/packages/gui/src/renderer/styles.css
@@ -333,9 +333,14 @@ html[data-theme="light"] ::selection {
 .html-artifact-webview {
   display: flex;
   width: 100%;
+  max-width: 100%;
   height: 100%;
   min-height: 42rem;
   background: white;
+}
+
+.html-artifact-preview-fill .html-artifact-webview {
+  min-height: 0;
 }
 
 /*

--- a/packages/gui/src/renderer/views/ArtifactsView.tsx
+++ b/packages/gui/src/renderer/views/ArtifactsView.tsx
@@ -125,7 +125,7 @@ export function ArtifactsWorkspace({
     writeArtifactDrawerState(drawer);
   }, [drawer]);
 
-  // 拖右边缘改宽:左抽屉向左拖变宽。宽度钳在 [200px, 容器宽 50%]。
+  // 拖右边缘改宽:水平位移直接加到左抽屉宽度,宽度钳在 [200px, 容器宽 50%]。
   const onResizePointerDown = useCallback(
     (event: React.PointerEvent<HTMLDivElement>) => {
       event.preventDefault();
@@ -139,7 +139,7 @@ export function ArtifactsWorkspace({
     if (drag === null) return;
     const host = rowHostRef.current;
     const max = host === null ? Number.POSITIVE_INFINITY : Math.floor(host.clientWidth / 2);
-    const next = clampDrawerWidth(drag.startWidth + (drag.startX - event.clientX), max);
+    const next = clampDrawerWidth(drag.startWidth + (event.clientX - drag.startX), max);
     setDrawer((state) => (state.width === next ? state : { ...state, width: next }));
   }, []);
   const onResizePointerUp = useCallback(() => {
@@ -388,6 +388,7 @@ function ArtifactPreviewBody({
   readonly openError: string | null;
 }) {
   const taskId = row.taskId;
+  const html = isHtmlDocument(row.path);
   return (
     <>
       <header className="flex shrink-0 items-center gap-2 border-b border-border bg-surface-raised px-3 py-2">
@@ -430,7 +431,10 @@ function ArtifactPreviewBody({
           {openError}
         </p>
       )}
-      <div className="min-h-0 flex-1 overflow-y-auto p-3">
+      <div
+        data-testid="artifact-preview-content"
+        className={`min-h-0 flex-1 p-3 ${html ? "overflow-hidden" : "overflow-y-auto"}`}
+      >
         {row.taskId === null ? (
           <PreviewNote text={t("artifacts.preview.noTask")} />
         ) : document.isPending ? (
@@ -440,8 +444,9 @@ function ArtifactPreviewBody({
         ) : document.data.blobSha256 === null && document.data.worktreeBody === null ? (
           <PreviewNote text={t("artifacts.preview.absent")} />
         ) : // 工作树实时内容优先(与 Task 详情文件页同一规则):未提交的产物是真实工作。
-        isHtmlDocument(row.path) ? (
+        html ? (
           <HtmlArtifactPreview
+            fillAvailable
             content={
               document.data.uncommitted && document.data.worktreeBody !== null
                 ? document.data.worktreeBody

--- a/packages/gui/test/artifacts-view.vitest.ts
+++ b/packages/gui/test/artifacts-view.vitest.ts
@@ -1,6 +1,7 @@
 // harness-test-tier: integration
 // @vitest-environment happy-dom
 import { beforeAll, afterEach, describe, expect, it, vi } from "vitest";
+import { readFileSync } from "node:fs";
 import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { createElement } from "react";
@@ -59,6 +60,7 @@ async function renderSurface(element: ReturnType<typeof createElement>): Promise
 
 afterEach(async () => {
   for (const { root } of mounted.splice(0)) await act(async () => root.unmount());
+  document.defaultView?.localStorage.clear();
   document.body.innerHTML = "";
 });
 
@@ -67,6 +69,17 @@ async function click(container: HTMLElement, testId: string): Promise<void> {
   if (target === null) throw new Error(`missing ${testId}`);
   await act(async () => {
     target.click();
+  });
+}
+
+async function pointer(target: HTMLElement, type: string, clientX: number, pointerId = 1): Promise<void> {
+  const event = new Event(type, { bubbles: true });
+  Object.defineProperties(event, {
+    clientX: { value: clientX },
+    pointerId: { value: pointerId },
+  });
+  await act(async () => {
+    target.dispatchEvent(event);
   });
 }
 
@@ -150,6 +163,36 @@ describe("artifacts timeline — list, preview, and task jump", () => {
     expect(drawer).not.toBeNull();
     expect(drawer?.style.width).toBe("420px");
     expect(container.querySelector('[data-testid="artifacts-drawer-resize"]')).not.toBeNull();
+  });
+
+  it("resizes the left drawer in the same direction as the pointer and keeps its bounds", async () => {
+    const container = await renderSurface(
+      createElement(ArtifactsWorkspace, {
+        repoId: "repo-a",
+        data: dto(),
+        pending: false,
+        kind: "html",
+        onKindChange: noop,
+        onNavigateTask: noop,
+      }),
+    );
+    const host = container.querySelector<HTMLElement>('[data-testid="artifacts-drawer-row"]')!;
+    const handle = container.querySelector<HTMLElement>('[data-testid="artifacts-drawer-resize"]')!;
+    Object.defineProperty(host, "clientWidth", { configurable: true, value: 1_000 });
+    handle.setPointerCapture = vi.fn();
+
+    await pointer(handle, "pointerdown", 420);
+    await pointer(handle, "pointermove", 470);
+    expect(container.querySelector<HTMLElement>('[data-testid="artifacts-drawer"]')?.style.width).toBe("470px");
+
+    await pointer(handle, "pointermove", 370);
+    expect(container.querySelector<HTMLElement>('[data-testid="artifacts-drawer"]')?.style.width).toBe("370px");
+
+    await pointer(handle, "pointermove", 900);
+    expect(container.querySelector<HTMLElement>('[data-testid="artifacts-drawer"]')?.style.width).toBe("500px");
+
+    await pointer(handle, "pointermove", 0);
+    expect(container.querySelector<HTMLElement>('[data-testid="artifacts-drawer"]')?.style.width).toBe("200px");
   });
 
   it("collapses the drawer to a rail and restores it, remembering the state in localStorage", async () => {
@@ -250,6 +293,25 @@ describe("artifacts timeline — list, preview, and task jump", () => {
     expect(webview?.getAttribute("webpreferences")).toContain("sandbox=yes");
     expect(webview?.getAttribute("webpreferences")).toContain("javascript=no");
     expect(String(webview?.getAttribute("src")).startsWith("data:text/html;charset=utf-8,")).toBe(true);
+    // HTML 分支不再由父容器滚动或 42rem 最小高度撑开;高度链路一直 flex 到 webview,
+    // 长页面的滚动因此留在 guest 内部。
+    const content = container.querySelector<HTMLElement>('[data-testid="artifact-preview-content"]');
+    expect(content?.classList.contains("overflow-hidden")).toBe(true);
+    expect(content?.classList.contains("overflow-y-auto")).toBe(false);
+    const preview = container.querySelector<HTMLElement>('[data-testid="html-artifact-preview"]');
+    expect(preview?.classList.contains("h-full")).toBe(true);
+    expect(preview?.classList.contains("min-h-0")).toBe(true);
+    expect(preview?.classList.contains("flex-col")).toBe(true);
+    expect(preview?.classList.contains("html-artifact-preview-fill")).toBe(true);
+    const host = container.querySelector<HTMLElement>('[data-testid="html-artifact-host"]');
+    expect(host?.classList.contains("flex-1")).toBe(true);
+    expect(host?.classList.contains("min-h-0")).toBe(true);
+    const styles = readFileSync("src/renderer/styles.css", "utf8");
+    const webviewRule = styles.match(/\.html-artifact-webview\s*\{([^}]*)\}/u)?.[1];
+    const fillRule = styles.match(/\.html-artifact-preview-fill \.html-artifact-webview\s*\{([^}]*)\}/u)?.[1];
+    expect(webviewRule).toContain("height: 100%");
+    expect(webviewRule).toContain("max-width: 100%");
+    expect(fillRule).toContain("min-height: 0");
   });
 
   it("renders a Markdown artifact with the shared markdown reader, not a webview", async () => {
@@ -268,6 +330,11 @@ describe("artifacts timeline — list, preview, and task jump", () => {
     await click(container, "artifact-focus-task_weathering-artifacts/report.md");
     await settle();
     expect(container.querySelector('[data-testid="html-artifact-webview"]')).toBeNull();
+    expect(
+      container
+        .querySelector<HTMLElement>('[data-testid="artifact-preview-content"]')
+        ?.classList.contains("overflow-y-auto"),
+    ).toBe(true);
     expect(container.textContent).toContain("Markdown report");
   });
 


### PR DESCRIPTION
# English

## Summary

Two owner-reported defects in the Artifacts view: the drawer resize handle moved opposite to the pointer (dragging left widened it), and the HTML artifact preview rendered only ~half of the available height. This PR fixes the drag delta sign and makes the preview fill its available flex space.

## What Changed

- `views/ArtifactsView.tsx`: resize delta is now `event.clientX - drag.startX` (same direction as the pointer); clamp behavior in `[200px, 50% of container]` unchanged.
- `components/HtmlArtifactPreview.tsx`: new `fillAvailable` mode — the section becomes a `h-full` flex column and the iframe host takes `flex-1 min-h-0`, so the preview fills the pane instead of a fixed `min-h-[42rem]` half-render; the artifacts view opts in.
- `styles.css`: preview fill rule.
- `packages/gui/test/artifacts-view.vitest.ts`: regression coverage for the drag direction math and the fill-mode class chain (+67 lines).

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: use the single CI-backed `Production-Delta` declaration below; do not enter a second metric.

## Machine-Readable Declarations

Production-Delta: +39/-11

## Task And Scope

- Harness task: task_06bae07e93db25a86588e4ac05
- Branch: codex/gui-artifact-pane
- Public scope: packages/gui renderer (Artifacts view + HTML preview) and its tests only
- Private planning/evidence updated: yes
- Out of scope: artifacts list performance (task_8c062355695767ae96b129b7fb)

## Version Impact

- Version: no version change because this is a renderer defect fix
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: task_06bae07e93db25a86588e4ac05
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no

## Verification

- Base `origin/main` SHA: 37a2a0dc67ff97acec3c9acc0da9363756e7cdbb
- Branch merge-base with `origin/main`: baf9ca42e665642b0dedcb03f379f62ca57d7661
- Last `git fetch origin` time: 2026-08-31 (UTC)
- Sync method: none needed
- Public diff command: `git diff origin/main...codex/gui-artifact-pane`
- Private evidence path: harness/tasks/task_06bae07e93db25a86588e4ac05-gui-artifact-pane-defects/artifacts/
- Reviewer evidence path: same as above
- GitHub Actions `rewrite-ci` run URL: pending on this PR's head
- Targeted local run: `packages/gui/test/artifacts-view.vitest.ts` green at 3db06beb1 (full matrix belongs to CI)
- Not run: full local matrix (worker stop-point discipline)

## Residual Risk

- Owner-eye acceptance (drag feel + long-page preview) happens on the running dev GUI after merge; any residual UX nit will be filed against the performance task.

---

# 中文

## 摘要

产物页两个泽宇亲验缺陷:①左侧抽屉拖宽手柄与鼠标方向相反(往左拖变宽);②HTML 预览只渲染约一半高度。本 PR 修正拖拽 delta 符号,并让预览以 flex 方式吃满可用空间。

## 变更点

- `ArtifactsView.tsx`:拖拽增量改为 `event.clientX - drag.startX`(与指针同向),钳位 `[200px, 容器 50%]` 不变。
- `HtmlArtifactPreview.tsx`:新增 `fillAvailable` 模式——组件变为 `h-full` flex 列,iframe 宿主 `flex-1 min-h-0` 吃满面板,替代固定 `min-h-[42rem]` 导致的半屏;产物页启用该模式。
- 回归测试 +67 行:拖拽方向数学与 fill 模式类链。

## 验证与残余风险

- 定向测试 `artifacts-view.vitest.ts` 在 3db06beb1 绿;完整矩阵归 CI。
- 合并后 CEO 在 dev GUI 亲手验证拖拽手感与长页预览;残余 UX 问题归入性能任务。
