### PR TITLE
fix(migration): restore task contract closeout path with digest restatement and idempotent repair

### DIFF
--- a/packages/daemon/src/migration-import-oracle-rebuild.ts
+++ b/packages/daemon/src/migration-import-oracle-rebuild.ts
@@ -23,6 +23,7 @@ import {
 } from "../../kernel/src/index.ts";
 import { readMigrationProjectionOracleAtPath, type MigrationProjectionOracle } from "./migration-import-oracle.ts";
 import { isMigrationImportRecord, migrationImportError, timestamp } from "./migration-import-report.ts";
+import { restateTaskContract } from "./migration-import-task-restatement.ts";
 import type { MigrationFormatObservation } from "./migration-import-types.ts";
 
 export interface MigrationEventInspection {
@@ -183,6 +184,20 @@ function overlayAuthoredOracle(
         firstTaskEvents.get(row.taskId) ??
         (occurredAt ? { eventId: `authored:${row.taskId}`, occurredAt, workspaceRevision: 0 } : null),
       title = cleanScalar(readScalar(entry.frontmatter, "title")) || markdownH1(entry.body) || row.taskId,
+      packagePath = portable(path.relative(layout.authoredRoot, path.dirname(entry.indexPath))),
+      contract = restateTaskContract({
+        sourceRoot,
+        sourcePackageRoot: path.dirname(entry.indexPath),
+        targetTaskId: row.taskId,
+        targetPackagePath: packagePath,
+        fallback: {
+          title,
+          taskClass: "standard",
+          verticalId: row.vertical,
+          presetId: row.preset,
+          profileId: row.profile,
+        },
+      }),
       task = {
         schema: "task/v2",
         taskId: row.taskId,
@@ -196,13 +211,14 @@ function overlayAuthoredOracle(
         packageDisposition: row.packageDisposition,
         createdBy: migrationOracleActor,
         completionGateIds: [],
-        presetSnapshotDigest: null,
+        presetSnapshotDigest: contract?.presetSnapshotDigest ?? null,
+        ...(contract === null ? {} : { contractVersion: 1 as const }),
       };
     if (!tasks.has(row.taskId))
       tasks.set(row.taskId, {
         taskId: row.taskId,
         workspaceRevision: firstEvent?.workspaceRevision ?? 0,
-        packagePath: portable(path.relative(layout.authoredRoot, path.dirname(entry.indexPath))),
+        packagePath,
         snapshot: { task },
         firstEvent,
       });

--- a/packages/daemon/src/migration-import-run.ts
+++ b/packages/daemon/src/migration-import-run.ts
@@ -91,6 +91,7 @@ import {
 } from "./migration-import-tasks.ts";
 import {
   readLegacyTaskRestatements,
+  type RestatedTaskContract,
   taskContractRestatementCounts,
   type LegacyTaskRestatement,
 } from "./migration-import-task-restatement.ts";
@@ -191,6 +192,7 @@ export interface MigrationImportContext extends MigrationRelationsContext {
   readonly alreadyImported: Record<EntityKind, number>;
   readonly taskRead: ReturnType<typeof readMarkdownSource>;
   readonly legacyTaskRestatements: ReadonlyMap<string, LegacyTaskRestatement>;
+  readonly taskContracts: Map<string, RestatedTaskContract>;
   readonly oracle: MigrationProjectionOracle;
   readonly fieldDerivations: MigrationFieldDerivation[];
   readonly dispositions: MigrationDisposition[];
@@ -307,6 +309,7 @@ export async function runSingleMigrationImport(
     >,
     retiredIds = new Set<string>(),
     nativeExecutionIds = new Set<string>();
+  const taskContracts = new Map<string, RestatedTaskContract>();
   const extracted: MigrationImportContext = {
     sourceRoot,
     message,
@@ -372,6 +375,7 @@ export async function runSingleMigrationImport(
     migrationImportError,
     taskRead,
     legacyTaskRestatements: legacyTaskRead.tasks,
+    taskContracts,
     oracle,
     fieldDerivations,
     dispositions,

--- a/packages/daemon/src/migration-import-task-restatement.ts
+++ b/packages/daemon/src/migration-import-task-restatement.ts
@@ -1,9 +1,11 @@
-import { readFileSync, readdirSync } from "node:fs";
+import { existsSync, readFileSync, readdirSync } from "node:fs";
 import path from "node:path";
 import {
   canonicalizeContractValue,
   consumeKnownError,
   normalizePersistedCanonicalEvent,
+  readSettingsFacet,
+  resolveHarnessLayout,
   validateMigrationImportEvent,
   validatePresetSnapshotUpgradeEvent,
   validateTaskBootstrapEvent,
@@ -12,6 +14,7 @@ import {
   type PersistedCanonicalEventV1,
   type TaskV2,
 } from "../../kernel/src/index.ts";
+import { compileRepoTaskPackage } from "../../preset/src/index.ts";
 
 export interface LegacyTaskRestatement {
   readonly taskId: string;
@@ -38,6 +41,168 @@ export interface LegacyTaskEventInput {
   readonly sourcePath: string;
   readonly value: unknown;
   readonly body?: string;
+}
+
+export interface RestatedTaskContract {
+  readonly body: string;
+  readonly presetSnapshotDigest: `sha256:${string}`;
+  readonly source: "contract" | "compiled";
+}
+
+export interface TaskContractCompileFallback {
+  readonly title?: unknown;
+  readonly taskClass?: unknown;
+  readonly verticalId?: unknown;
+  readonly presetId?: unknown;
+  readonly profileId?: unknown;
+  readonly locale?: unknown;
+  readonly slug?: unknown;
+}
+
+/** Restates the machine contract into its migrated package and derives the immutable preset digest when needed. */
+export function restateTaskContract(input: {
+  readonly sourceRoot: string;
+  readonly sourcePackageRoot: string;
+  readonly targetTaskId: string;
+  readonly targetPackagePath: string;
+  readonly fallback?: TaskContractCompileFallback;
+}): RestatedTaskContract | null {
+  const contractPath = path.join(input.sourcePackageRoot, "task-contract.json");
+  if (!existsSync(contractPath)) return null;
+  return restateTaskContractBody({
+    sourceRoot: input.sourceRoot,
+    sourcePath: portablePath(path.relative(input.sourceRoot, contractPath)),
+    body: readFileSync(contractPath, "utf8"),
+    targetTaskId: input.targetTaskId,
+    targetPackagePath: input.targetPackagePath,
+    fallback: input.fallback,
+  });
+}
+
+export function compileRestatedTaskContract(input: {
+  readonly sourceRoot: string;
+  readonly sourcePath: string;
+  readonly targetTaskId: string;
+  readonly targetPackagePath: string;
+  readonly fallback: TaskContractCompileFallback;
+}): RestatedTaskContract {
+  const compiled = compileContract(input.sourceRoot, input.targetTaskId, input.fallback),
+    document = compiled.documents.find(({ slot }) => slot === "task.contract");
+  if (!document) throw new Error(`${input.sourcePath}: compiled task package has no task.contract document`);
+  return {
+    ...restateTaskContractBody({ ...input, body: document.body }),
+    source: "compiled",
+  };
+}
+
+export function restateTaskContractBody(input: {
+  readonly sourceRoot: string;
+  readonly sourcePath: string;
+  readonly body: string;
+  readonly targetTaskId: string;
+  readonly targetPackagePath: string;
+  readonly fallback?: TaskContractCompileFallback;
+}): RestatedTaskContract {
+  let contract: Record<string, unknown>;
+  try {
+    const value = JSON.parse(input.body) as unknown;
+    if (!migrationImportRecord(value)) throw new Error("root must be an object");
+    contract = value;
+  } catch (error) {
+    throw new Error(`${input.sourcePath}: invalid task-contract.json`, { cause: error });
+  }
+  const declaredDigest = contract.presetSnapshotDigest;
+  if (declaredDigest !== undefined && declaredDigest !== null && !presetDigest(declaredDigest))
+    throw new Error(`${input.sourcePath}: presetSnapshotDigest is not SHA-256`);
+  const metadata = contractCompileMetadata(contract, input.fallback),
+    settings = readSettingsFacet(
+      readFileSync(path.join(resolveHarnessLayout(input.sourceRoot).authoredRoot, "harness.yaml"), "utf8"),
+    );
+  let digest = presetDigest(declaredDigest) ? declaredDigest : null,
+    source: RestatedTaskContract["source"] = "contract";
+  if (digest === null) {
+    try {
+      digest = compileContract(input.sourceRoot, input.targetTaskId, metadata).snapshot.digest;
+      source = "compiled";
+    } catch (error) {
+      throw new Error(`${input.sourcePath}: cannot derive presetSnapshotDigest from task contract metadata`, {
+        cause: error,
+      });
+    }
+  }
+  return {
+    presetSnapshotDigest: digest,
+    source,
+    body: `${JSON.stringify(
+      {
+        ...contract,
+        schema: "task-contract/v1",
+        contractVersion: 1,
+        taskId: input.targetTaskId,
+        packagePath: input.targetPackagePath,
+        title: metadata.title,
+        taskClass: metadata.taskClass ?? "standard",
+        verticalId: metadata.verticalId ?? settings.defaultVertical,
+        presetId: metadata.presetId ?? settings.defaultPreset,
+        profileId: metadata.profileId ?? settings.defaultProfile,
+        locale: metadata.locale ?? settings.locale,
+        ...(Array.isArray(contract.documents) ? { documents: normalizeContractDocuments(contract.documents) } : {}),
+        presetSnapshotDigest: digest,
+      },
+      null,
+      2,
+    )}\n`,
+  };
+}
+
+function compileContract(sourceRoot: string, taskId: string, metadata: TaskContractCompileFallback) {
+  const authoredRoot = resolveHarnessLayout(sourceRoot).authoredRoot,
+    settings = readSettingsFacet(readFileSync(path.join(authoredRoot, "harness.yaml"), "utf8"));
+  return compileRepoTaskPackage({
+    rootDir: sourceRoot,
+    settings,
+    taskId,
+    action: {
+      kind: "task-create",
+      title: metadata.title,
+      taskClass: metadata.taskClass,
+      verticalId: metadata.verticalId,
+      presetId: metadata.presetId,
+      profileId: metadata.profileId,
+      locale: metadata.locale,
+      slug: metadata.slug,
+    },
+  });
+}
+
+function contractCompileMetadata(
+  contract: Readonly<Record<string, unknown>>,
+  fallback: TaskContractCompileFallback | undefined,
+): TaskContractCompileFallback {
+  const preset = migrationImportRecord(contract.preset) ? contract.preset : {},
+    profile = migrationImportRecord(contract.profile) ? contract.profile : {},
+    documentLocale = Array.isArray(contract.documents)
+      ? contract.documents
+          .filter(migrationImportRecord)
+          .map(({ locale }) => locale)
+          .find((locale) => typeof locale === "string")
+      : undefined;
+  return {
+    title: contract.title ?? fallback?.title,
+    taskClass: contract.taskClass ?? fallback?.taskClass,
+    verticalId: contract.verticalId ?? contract.vertical ?? fallback?.verticalId,
+    presetId: contract.presetId ?? preset.id ?? fallback?.presetId,
+    profileId: contract.profileId ?? profile.id ?? fallback?.profileId,
+    locale: contract.locale ?? documentLocale ?? fallback?.locale,
+    slug: contract.slug ?? fallback?.slug,
+  };
+}
+
+function normalizeContractDocuments(documents: readonly unknown[]): readonly unknown[] {
+  return documents.map((document) => {
+    if (!migrationImportRecord(document) || typeof document.path === "string") return document;
+    return typeof document.materializeAs === "string" ? { ...document, path: document.materializeAs } : document;
+  });
 }
 
 interface LegacyTaskSnapshot {
@@ -219,6 +384,10 @@ function listJsonFiles(root: string): readonly string[] {
 
 function portablePath(value: string): string {
   return value.split(path.sep).join("/");
+}
+
+function presetDigest(value: unknown): value is `sha256:${string}` {
+  return typeof value === "string" && /^sha256:[0-9a-f]{64}$/u.test(value);
 }
 
 function migrationImportRecord(value: unknown): value is Readonly<Record<string, unknown>> {

--- a/packages/daemon/src/migration-import-tasks.ts
+++ b/packages/daemon/src/migration-import-tasks.ts
@@ -15,6 +15,7 @@ import {
 import type { ProjectionOracleTask } from "./migration-import-oracle.ts";
 import { scheduleArchivedEntity } from "./migration-import-dispositions.ts";
 import { isMigrationImportRecord } from "./migration-import-report.ts";
+import { restateTaskContract } from "./migration-import-task-restatement.ts";
 import type { ImportedTask } from "./migration-import-types.ts";
 import type { MigrationImportContext } from "./migration-import-run.ts";
 
@@ -108,6 +109,19 @@ export function addTask(context: MigrationImportContext, entry: TaskSourceEntry)
     status = context.taskStatus(row.rawStatus),
     packagePath = `tasks/${targetTaskId}-${slugifyTaskTitle(row.title)}`,
     sourceTask = context.legacyTaskRestatements.get(taskId),
+    contract = restateTaskContract({
+      sourceRoot: context.sourceRoot,
+      sourcePackageRoot: path.dirname(entry.indexPath),
+      targetTaskId,
+      targetPackagePath: packagePath,
+      fallback: {
+        title: row.title,
+        taskClass: "standard",
+        verticalId: row.vertical,
+        presetId: row.preset,
+        profileId: row.profile,
+      },
+    }),
     task: ImportedTask = {
       schema: "task/v2",
       taskId: targetTaskId,
@@ -121,8 +135,10 @@ export function addTask(context: MigrationImportContext, entry: TaskSourceEntry)
       packageDisposition: row.packageDisposition,
       createdBy: context.actor,
       completionGateIds: [],
-      presetSnapshotDigest: null,
+      presetSnapshotDigest: contract?.presetSnapshotDigest ?? null,
+      ...(contract === null ? {} : { contractVersion: 1 as const }),
     };
+  if (contract !== null) context.taskContracts.set(taskId, contract);
   context.taskMap.set(taskId, targetTaskId);
   context.taskPackages.set(taskId, packagePath);
   context.taskOccurredAt.set(taskId, occurredAt);
@@ -175,7 +191,7 @@ export function addOracleTask(context: MigrationImportContext, source: Projectio
       new Set(context.taskMap.values()),
     ),
     status = context.taskStatus(String(projected.status ?? "unknown")),
-    task = {
+    projectedTask = {
       ...projected,
       schema: "task/v2",
       taskId: targetTaskId,
@@ -186,12 +202,33 @@ export function addOracleTask(context: MigrationImportContext, source: Projectio
         ? projected.packageDisposition
         : "active",
     } as unknown as ImportedTask;
-  if (validateTaskV2(task, true).length) return false;
+  if (validateTaskV2(projectedTask, true).length) return false;
   const targetPackage =
       packagePath !== null && targetTaskId === source.taskId && packagePath.startsWith(`tasks/${targetTaskId}-`)
         ? packagePath
-        : `tasks/${targetTaskId}-${slugifyTaskTitle(task.title)}`,
-    syntheticEntry: TaskSourceEntry = {
+        : `tasks/${targetTaskId}-${slugifyTaskTitle(projectedTask.title)}`,
+    contract = restateTaskContract({
+      sourceRoot: context.sourceRoot,
+      sourcePackageRoot: packageRoot!,
+      targetTaskId,
+      targetPackagePath: targetPackage,
+      fallback: {
+        title: projectedTask.title,
+        taskClass: projectedTask.taskClass,
+        verticalId: projectedTask.metadata?.verticalId,
+        presetId: projectedTask.metadata?.presetId,
+        profileId: projectedTask.metadata?.profileId,
+        slug: projectedTask.metadata?.slug,
+      },
+    }),
+    task = {
+      ...projectedTask,
+      presetSnapshotDigest: contract?.presetSnapshotDigest ?? projectedTask.presetSnapshotDigest,
+      ...(contract === null ? {} : { contractVersion: 1 as const }),
+    } as ImportedTask;
+  if (validateTaskV2(task, true).length) return false;
+  if (contract !== null) context.taskContracts.set(source.taskId, contract);
+  const syntheticEntry: TaskSourceEntry = {
       taskId: source.taskId,
       indexPath: indexPath ?? path.join(context.sourceLayout.tasksRoot, source.taskId, "INDEX.md"),
       body: sourceBody ?? `# ${task.title}\n`,
@@ -314,7 +351,9 @@ export function addTaskPackage(context: MigrationImportContext, entry: TaskSourc
   for (const source of context.authoredEntries) {
     if (source.symlink || !source.path.startsWith(prefix) || source.path === `${sourcePackage}/INDEX.md`) continue;
     const relative = source.path.slice(prefix.length),
-      body = context.utf8File(context.sourceLayout.authoredRoot, source.path);
+      originalBody = context.utf8File(context.sourceLayout.authoredRoot, source.path),
+      body =
+        relative === "task-contract.json" ? (context.taskContracts.get(taskId)?.body ?? originalBody) : originalBody;
     if (body === null) continue;
     const legacy = /^executions\/[^/]+\.md$/u.test(relative) ? context.decodeLegacyExecution(body, taskId) : null;
     if (relative.startsWith("executions/")) {

--- a/packages/daemon/src/repo-cell-task-command-docs.ts
+++ b/packages/daemon/src/repo-cell-task-command-docs.ts
@@ -367,15 +367,27 @@ export function taskSurfaceWrite(
           "content_not_ready",
           `Retry ${action.kind} after document projection ${target} catches up.`,
         );
-      return read.document
+      const repairBody =
+        target === `${current.packagePath}/task-contract.json` && typeof action.repairTaskContractBody === "string"
+          ? action.repairTaskContractBody
+          : null;
+      return repairBody !== null
         ? [
             {
               path: target,
-              body: read.document.body,
-              blobSha256: read.document.blobSha256,
+              body: repairBody,
+              blobSha256: sha256Text(repairBody),
             },
           ]
-        : [];
+        : read.document
+          ? [
+              {
+                path: target,
+                body: read.document.body,
+                blobSha256: read.document.blobSha256,
+              },
+            ]
+          : [];
     }),
     compiled = compileTaskLifecycleWrite({
       event,

--- a/packages/daemon/src/repo-cell-task-maintenance.ts
+++ b/packages/daemon/src/repo-cell-task-maintenance.ts
@@ -1,9 +1,15 @@
 import { createHash } from "node:crypto";
 import {
   createEntityStore,
+  isMigrationImportEvent,
   requireEntityStoreKindContract,
   type WriteReceiptDraft as WriteReceipt,
 } from "../../kernel/src/index.ts";
+import {
+  compileRestatedTaskContract,
+  restateTaskContractBody,
+  type RestatedTaskContract,
+} from "./migration-import-task-restatement.ts";
 import type { RepoCellBinding, RepoTaskAction, TaskCreateReceipt } from "./repo-cell-types.ts";
 import type { RepoCellOperationalContext } from "./repo-cell-action-context.ts";
 
@@ -121,21 +127,92 @@ export function migrateTaskContracts(
   action: RepoTaskAction,
   binding: RepoCellBinding,
 ): WriteReceipt {
-  const candidates = typeof action.taskId === "string" ? [action.taskId] : [...cell.projectedTaskIds()],
+  const migratedTaskIds = new Set(
+      cell.store
+        .read()
+        .events.filter(isMigrationImportEvent)
+        .flatMap((event) => (event.payload.entity.kind === "task" ? [event.payload.entity.task.taskId] : [])),
+    ),
+    candidates = typeof action.taskId === "string" ? [action.taskId] : [...cell.projectedTaskIds()],
+    repairs = new Map<string, RestatedTaskContract>(),
     report = candidates.map((taskId) => {
       const current = cell.projection.read(taskId),
         task = current.snapshot.task;
-      return !task
-        ? { taskId, status: "manual", reason: "task_not_found" }
-        : (task.contractVersion ?? 0) >= 1
-          ? { taskId, status: "current" }
-          : !task.metadata || !task.presetSnapshotDigest || !current.packagePath
-            ? {
-                taskId,
-                status: "manual",
-                reason: "contract_metadata_incomplete",
-              }
-            : { taskId, status: "backfill" };
+      if (!task) return { taskId, status: "manual", reason: "task_not_found" };
+      if (migratedTaskIds.has(taskId) && current.packagePath) {
+        const projected = cell.projection.readDocument(`${current.packagePath}/task-contract.json`);
+        if (!cell.projectionReady(projected))
+          return { taskId, status: "manual", reason: "contract_projection_pending" };
+        let restated: RestatedTaskContract,
+          packagePathBefore: string | null = null;
+        try {
+          const fallback = {
+            title: task.title,
+            taskClass: task.taskClass,
+            verticalId: task.metadata?.verticalId,
+            presetId: task.metadata?.presetId,
+            profileId: task.metadata?.profileId,
+            slug: task.metadata?.slug,
+          };
+          if (projected.document) {
+            restated = restateTaskContractBody({
+              sourceRoot: cell.rootDir,
+              sourcePath: `${current.packagePath}/task-contract.json`,
+              body: projected.document.body,
+              targetTaskId: taskId,
+              targetPackagePath: current.packagePath,
+              fallback,
+            });
+            const contract = JSON.parse(projected.document.body) as Record<string, unknown>;
+            packagePathBefore = typeof contract.packagePath === "string" ? contract.packagePath : null;
+          } else
+            restated = compileRestatedTaskContract({
+              sourceRoot: cell.rootDir,
+              sourcePath: `${current.packagePath}/task-contract.json`,
+              targetTaskId: taskId,
+              targetPackagePath: current.packagePath,
+              fallback,
+            });
+        } catch (error) {
+          return {
+            taskId,
+            status: "manual",
+            reason: "contract_digest_not_derivable",
+            detail: error instanceof Error ? error.message : String(error),
+          };
+        }
+        const digestBefore = task.presetSnapshotDigest;
+        if (digestBefore !== null && digestBefore !== restated.presetSnapshotDigest)
+          return {
+            taskId,
+            status: "manual",
+            reason: "contract_digest_conflict",
+            presetSnapshotDigest: digestBefore,
+            contractPresetSnapshotDigest: restated.presetSnapshotDigest,
+          };
+        if (digestBefore === null || packagePathBefore !== current.packagePath || (task.contractVersion ?? 0) < 1) {
+          repairs.set(taskId, restated);
+          return {
+            taskId,
+            status: "repair",
+            presetSnapshotDigestBefore: digestBefore,
+            presetSnapshotDigestAfter: restated.presetSnapshotDigest,
+            packagePathBefore,
+            packagePathAfter: current.packagePath,
+            digestSource: restated.source,
+          };
+        }
+        return { taskId, status: "current" };
+      }
+      return (task.contractVersion ?? 0) >= 1
+        ? { taskId, status: "current" }
+        : !task.metadata || !task.presetSnapshotDigest || !current.packagePath
+          ? {
+              taskId,
+              status: "manual",
+              reason: "contract_metadata_incomplete",
+            }
+          : { taskId, status: "backfill" };
     });
   if (action.mode === "dry-run")
     return cell.previewResult(
@@ -148,8 +225,18 @@ export function migrateTaskContracts(
       cell.store.readHead()?.revision ?? 0,
       "Run task contract migrate --apply to publish the eligible backfill events.",
     );
-  const backfills = report.filter((row) => row.status === "backfill"),
-    steps = backfills.map(({ taskId }) => cell.taskSurfaceWrite({ kind: "task-contract-migrate", taskId }, binding));
+  const backfills = report.filter((row) => row.status === "backfill" || row.status === "repair"),
+    steps = backfills.map(({ taskId }) =>
+      cell.taskSurfaceWrite(
+        {
+          kind: "task-contract-migrate",
+          taskId,
+          ...(repairs.has(taskId) ? { repairPresetSnapshotDigest: repairs.get(taskId)!.presetSnapshotDigest } : {}),
+          ...(repairs.has(taskId) ? { repairTaskContractBody: repairs.get(taskId)!.body } : {}),
+        },
+        binding,
+      ),
+    );
   return cell.readResult(
     cell.operationId(action, binding, cell.input.repoId, cell.store.readHead()?.revision ?? 0),
     {

--- a/packages/daemon/src/repo-cell-task-mutation.ts
+++ b/packages/daemon/src/repo-cell-task-mutation.ts
@@ -113,7 +113,7 @@ export function taskMutation(
       },
     };
   }
-  if (activeLease && !pinOnlyAmend)
+  if (activeLease && !pinOnlyAmend && action.kind !== "task-contract-migrate")
     throw cell.cellCodedError("active_lease", `Run ha task release ${task.taskId} before ${action.kind}.`);
   if (action.kind === "task-amend") {
     const patches = amendPatches,
@@ -340,18 +340,30 @@ export function taskMutation(
     };
   }
   if (action.kind === "task-contract-migrate") {
-    if ((task.contractVersion ?? 0) >= 1)
+    const repairedDigest =
+      typeof action.repairPresetSnapshotDigest === "string" &&
+      /^sha256:[0-9a-f]{64}$/u.test(action.repairPresetSnapshotDigest)
+        ? (action.repairPresetSnapshotDigest as `sha256:${string}`)
+        : null;
+    if ((task.contractVersion ?? 0) >= 1 && repairedDigest === null)
       throw cell.cellCodedError(
         "contract_current",
         `Task ${task.taskId} already has task-contract/v1; run ha task show ${task.taskId} to inspect it.`,
       );
     return {
       type: "task_contract_migrated",
-      task: { ...task, contractVersion: 1 },
+      task: {
+        ...task,
+        contractVersion: 1,
+        ...(repairedDigest === null ? {} : { presetSnapshotDigest: repairedDigest }),
+      },
       audit: {
         command: "contract-migrate",
-        reason: "Backfilled immutable task-contract/v1 from unambiguous L1 task truth",
-        fields: ["contractVersion"],
+        reason:
+          repairedDigest === null
+            ? "Backfilled immutable task-contract/v1 from unambiguous L1 task truth"
+            : "Repaired migrated task preset digest and canonical task-contract package path",
+        fields: repairedDigest === null ? ["contractVersion"] : ["contractVersion", "presetSnapshotDigest"],
       },
     };
   }

--- a/packages/daemon/test/migration-import-replay-records.integration.test.ts
+++ b/packages/daemon/test/migration-import-replay-records.integration.test.ts
@@ -8,9 +8,12 @@ import {
   REPLAY_TASK_GRAPH,
   canonicalizeContractValue,
   makeTaskEventStore,
+  readSettingsFacet,
   sha256Text,
 } from "../../kernel/src/index.ts";
+import { compileRepoTaskPackage } from "../../preset/src/index.ts";
 import { canonicalRoot, workspaceId } from "../src/protocol/daemon-protocol.contract.ts";
+import { blob, claim, prepare } from "../src/migration-import-events.ts";
 import { openRepoCell } from "../src/repo-cell.ts";
 import { realizedTaskPlan, realizeTaskPlanFixture } from "../../../tools/fixtures/task-plan.mjs";
 
@@ -216,7 +219,8 @@ test("migration replays archived executions and keeps v0 tasks explicit about co
       { actor, source: "local" },
     );
     assert.equal(migratedContract.outcome, "applied", JSON.stringify(migratedContract));
-    assert.match(String(migratedContract.evidence), /"reason":"contract_metadata_incomplete"/u);
+    assert.match(String(migratedContract.evidence), /"status":"repair"/u);
+    assert.match(String(migratedContract.evidence), /"digestSource":"compiled"/u);
     await realizeTaskPlanFixture(
       destination,
       "tasks/task_coverage-coverage-fixture",
@@ -232,17 +236,15 @@ test("migration replays archived executions and keeps v0 tasks explicit about co
       },
       { actor, source: "local" },
     );
-    assert.equal(started.outcome, "op_rejected", JSON.stringify(started));
-    assert.equal(started.code, "content_not_ready");
-    assert.match(started.nextAction ?? "", /contract projection is not ready for task\.plan/u);
+    assert.equal(started.outcome, "applied", JSON.stringify(started));
     const afterStart = (await cell.read("repo.tasks.list")).rows.find(({ taskId }) => taskId === "task_coverage")!;
     assert.deepEqual(
       afterStart.snapshot.executions.map(({ schema }) => schema),
-      ["archived-execution/v1"],
+      ["archived-execution/v1", "execution/v1"],
     );
     assert.deepEqual(
       afterStart.executionEvidence.map(({ origin }) => origin),
-      ["archival"],
+      ["archival", "native"],
     );
   } finally {
     await cell?.close();
@@ -323,6 +325,300 @@ test("re-importing a source is an incremental no-op instead of a hard rejection"
     rmSync(scratch, { recursive: true, force: true });
   }
 });
+
+test("migration adopts the source contract digest and rewrites the contract package path", async () => {
+  const scratch = mkdtempSync(path.join(tmpdir(), "ha-migrate-contract-")),
+    source = path.join(scratch, "legacy"),
+    destination = path.join(scratch, "new"),
+    digest = `sha256:${"a".repeat(64)}`;
+  let cell: Awaited<ReturnType<typeof openRepoCell>> | undefined;
+  try {
+    coverageCompleteFixture(source);
+    writeFileSync(
+      path.join(source, "harness/tasks/task_coverage-old/task-contract.json"),
+      `${JSON.stringify(
+        {
+          ...contractMetadata("task_coverage", "tasks/task_coverage-old", "Coverage fixture"),
+          presetSnapshotDigest: digest,
+        },
+        null,
+        2,
+      )}\n`,
+    );
+    initRepo(destination);
+    cell = await openRepoCell({
+      repoId: workspaceId("migration-contract-target"),
+      rootDir: canonicalRoot(destination),
+      ownerId: "migration-daemon",
+      now: () => "2026-06-01T00:00:00.000Z",
+    });
+    const result = (await cell.run(
+      { kind: "migrate-import", sourceRoots: sources(source) },
+      { actor, source: "local" },
+    )) as Record<string, unknown>;
+    assert.equal(result.exitCode, 0, JSON.stringify(result));
+    const row = (await cell.read("repo.tasks.list")).rows.find(({ taskId }) => taskId === "task_coverage")!;
+    assert.equal(row.snapshot.task?.presetSnapshotDigest, digest);
+    assert.equal(row.snapshot.task?.contractVersion, 1);
+    const targetPackage = "tasks/task_coverage-coverage-fixture",
+      contract = JSON.parse(
+        readFileSync(path.join(destination, "harness", targetPackage, "task-contract.json"), "utf8"),
+      ) as Record<string, unknown>;
+    assert.equal(contract.taskId, "task_coverage");
+    assert.equal(contract.packagePath, targetPackage);
+    assert.equal(contract.presetSnapshotDigest, digest);
+  } finally {
+    await cell?.close();
+    rmSync(scratch, { recursive: true, force: true });
+  }
+});
+
+test("contract migration repairs old migrated rows through one canonical event and reruns as a no-op", async () => {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-migrate-contract-repair-")),
+    repoId = workspaceId("migration-contract-repair"),
+    taskId = "task_migrated_repair",
+    packagePath = `tasks/${taskId}-repair-fixture`,
+    stalePackagePath = `tasks/${taskId}-old-name`,
+    missingTaskId = "task_migrated_missing_contract",
+    missingPackagePath = `tasks/${missingTaskId}-missing-contract`,
+    occurredAt = "2026-01-01T00:00:00.000Z";
+  let cell: Awaited<ReturnType<typeof openRepoCell>> | undefined;
+  try {
+    initRepo(rootDir);
+    cell = await openRepoCell({ repoId, rootDir: canonicalRoot(rootDir), ownerId: "migration-repair-bootstrap" });
+    const bootstrap = await cell.run({ kind: "projection-rebuild" }, { actor, source: "local" });
+    assert.equal(bootstrap.outcome, "applied", JSON.stringify(bootstrap));
+    await cell.close();
+    cell = undefined;
+    const settings = readSettingsFacet(readFileSync(path.join(rootDir, "harness/harness.yaml"), "utf8")),
+      contractBase = contractMetadata(taskId, stalePackagePath),
+      digest = compileRepoTaskPackage({
+        rootDir,
+        settings,
+        taskId,
+        action: { kind: "task-create", ...contractBase },
+      }).snapshot.digest,
+      missingDigest = compileRepoTaskPackage({
+        rootDir,
+        settings,
+        taskId: missingTaskId,
+        action: { kind: "task-create", ...contractMetadata(missingTaskId, missingPackagePath) },
+      }).snapshot.digest,
+      indexBody = `---\nschema: task-package/v2\ntask_id: ${taskId}\ntitle: Migrated repair fixture\nlifecycle:\n  status: planned\n  engine: migration-import/v1\n---\n\n# Migrated repair fixture\n`,
+      contractBody = `${JSON.stringify(
+        {
+          ...contractBase,
+          presetSnapshotDigest: digest,
+          documents: [{ slot: "task.closeout", path: "closeout.md" }],
+        },
+        null,
+        2,
+      )}\n`,
+      closeoutBody =
+        "# Closeout\n\n## Summary\n\nPending.\n\n## Verification\n\nPending.\n\n## Residual Risk\n\nPending.\n",
+      store = makeTaskEventStore({ repoId, rootDir }),
+      initialRevision = store.readHead()?.revision ?? 0,
+      ledger = () => makeTaskEventStore({ repoId, rootDir }).read(),
+      task = {
+        schema: "task/v2" as const,
+        taskId,
+        title: "Migrated repair fixture",
+        taskClass: "standard" as const,
+        status: "planned" as const,
+        graph: REPLAY_TASK_GRAPH,
+        currentNode: "implementation",
+        iteration: 0,
+        pinned: false,
+        packageDisposition: "active" as const,
+        createdBy: actor,
+        completionGateIds: [],
+        presetSnapshotDigest: null,
+      };
+    store.append(
+      prepare(
+        "legacy-source",
+        actor,
+        "task",
+        taskId,
+        occurredAt,
+        initialRevision + 1,
+        {
+          kind: "task",
+          provenance: "imported_snapshot",
+          task,
+          originalStatus: "planned",
+          packagePath,
+          documentClaim: claim(`${packagePath}/INDEX.md`, indexBody, "text/markdown"),
+        },
+        [blob(indexBody, "text/markdown")],
+      ),
+    );
+    for (const [revision, name, body, mediaType] of [
+      [initialRevision + 2, "task-contract.json", contractBody, "application/json"],
+      [initialRevision + 3, "closeout.md", closeoutBody, "text/markdown"],
+    ] as const)
+      store.append(
+        prepare(
+          "legacy-source",
+          actor,
+          "task-document",
+          `harness/tasks/${taskId}-old-name/${name}`,
+          occurredAt,
+          revision,
+          {
+            kind: "task-document",
+            taskId,
+            documentClaim: claim(`${packagePath}/${name}`, body, mediaType),
+          },
+          [blob(body, mediaType)],
+        ),
+      );
+    const missingIndexBody = `---\nschema: task-package/v2\ntask_id: ${missingTaskId}\ntitle: Migrated repair fixture\nlifecycle:\n  status: planned\n  engine: migration-import/v1\n---\n\n# Migrated repair fixture\n`,
+      missingTask = {
+        ...task,
+        taskId: missingTaskId,
+        metadata: {
+          idempotencyKey: null,
+          parentTaskId: null,
+          workKind: "chore" as const,
+          riskTier: "medium" as const,
+          urgency: "medium" as const,
+          verticalId: "software/coding",
+          presetId: "standard-task",
+          profileId: "baseline",
+          moduleKey: null,
+          slug: "missing-contract",
+          surfaces: [],
+          fromLegacyId: null,
+        },
+      };
+    store.append(
+      prepare(
+        "legacy-source",
+        actor,
+        "task",
+        missingTaskId,
+        occurredAt,
+        initialRevision + 4,
+        {
+          kind: "task",
+          provenance: "imported_snapshot",
+          task: missingTask,
+          originalStatus: "planned",
+          packagePath: missingPackagePath,
+          documentClaim: claim(`${missingPackagePath}/INDEX.md`, missingIndexBody, "text/markdown"),
+        },
+        [blob(missingIndexBody, "text/markdown")],
+      ),
+    );
+    store.append(
+      prepare(
+        "legacy-source",
+        actor,
+        "task-document",
+        `harness/tasks/${missingTaskId}-old-name/closeout.md`,
+        occurredAt,
+        initialRevision + 5,
+        {
+          kind: "task-document",
+          taskId: missingTaskId,
+          documentClaim: claim(`${missingPackagePath}/closeout.md`, closeoutBody, "text/markdown"),
+        },
+        [blob(closeoutBody, "text/markdown")],
+      ),
+    );
+    await store.drain();
+    cell = await openRepoCell({ repoId, rootDir: canonicalRoot(rootDir), ownerId: "migration-repair-daemon" });
+    const binding = { actor, source: "local" as const },
+      blocked = await cell.run({ kind: "task-complete", taskId, executionId: "execution-missing" }, binding);
+    assert.equal(blocked.code, "content_not_ready");
+    const revisionBeforeDryRun = ledger().revision,
+      dryRun = await cell.run({ kind: "task-contract-migrate", mode: "dry-run", taskId }, binding),
+      dryEvidence = JSON.parse(String(dryRun.evidence)) as {
+        readonly report: readonly Record<string, unknown>[];
+      };
+    assert.equal(dryRun.outcome, "pending");
+    assert.equal(ledger().revision, revisionBeforeDryRun);
+    assert.deepEqual(dryEvidence.report[0], {
+      taskId,
+      status: "repair",
+      presetSnapshotDigestBefore: null,
+      presetSnapshotDigestAfter: digest,
+      packagePathBefore: stalePackagePath,
+      packagePathAfter: packagePath,
+      digestSource: "contract",
+    });
+    const applied = await cell.run({ kind: "task-contract-migrate", mode: "apply", taskId }, binding);
+    assert.equal(applied.outcome, "applied", JSON.stringify(applied));
+    assert.equal(ledger().revision, revisionBeforeDryRun + 1);
+    assert.equal(ledger().events.filter((event) => event.type === "task_contract_migrated").length, 1);
+    const repaired = (await cell.read("repo.tasks.list")).rows.find((row) => row.taskId === taskId)!;
+    assert.equal(repaired.snapshot.task?.presetSnapshotDigest, digest);
+    assert.equal(repaired.snapshot.task?.contractVersion, 1);
+    const repairedContract = JSON.parse(
+      readFileSync(path.join(rootDir, "harness", packagePath, "task-contract.json"), "utf8"),
+    ) as Record<string, unknown>;
+    assert.equal(repairedContract.packagePath, packagePath);
+    assert.equal(repairedContract.presetSnapshotDigest, digest);
+    const nextGate = await cell.run({ kind: "task-complete", taskId, executionId: "execution-missing" }, binding);
+    assert.notEqual(nextGate.code, "content_not_ready", JSON.stringify(nextGate));
+    assert.equal(nextGate.code, "not_in_review", JSON.stringify(nextGate));
+    const revisionBeforeRerun = ledger().revision,
+      rerun = await cell.run({ kind: "task-contract-migrate", mode: "apply", taskId }, binding);
+    assert.equal(rerun.outcome, "applied", JSON.stringify(rerun));
+    assert.equal(ledger().revision, revisionBeforeRerun);
+    assert.equal(ledger().events.filter((event) => event.type === "task_contract_migrated").length, 1);
+    const missingDryRun = await cell.run(
+        { kind: "task-contract-migrate", mode: "dry-run", taskId: missingTaskId },
+        binding,
+      ),
+      missingEvidence = JSON.parse(String(missingDryRun.evidence)) as {
+        readonly report: readonly Record<string, unknown>[];
+      };
+    assert.deepEqual(missingEvidence.report[0], {
+      taskId: missingTaskId,
+      status: "repair",
+      presetSnapshotDigestBefore: null,
+      presetSnapshotDigestAfter: missingDigest,
+      packagePathBefore: null,
+      packagePathAfter: missingPackagePath,
+      digestSource: "compiled",
+    });
+    assert.equal(
+      (await cell.run({ kind: "task-contract-migrate", mode: "apply", taskId: missingTaskId }, binding)).outcome,
+      "applied",
+    );
+    const synthesizedContract = JSON.parse(
+      readFileSync(path.join(rootDir, "harness", missingPackagePath, "task-contract.json"), "utf8"),
+    ) as Record<string, unknown>;
+    assert.equal(synthesizedContract.packagePath, missingPackagePath);
+    assert.equal(synthesizedContract.presetSnapshotDigest, missingDigest);
+    assert.equal(Array.isArray(synthesizedContract.documents), true);
+    const missingNextGate = await cell.run(
+      { kind: "task-complete", taskId: missingTaskId, executionId: "execution-missing" },
+      binding,
+    );
+    assert.equal(missingNextGate.code, "not_in_review", JSON.stringify(missingNextGate));
+  } finally {
+    await cell?.close();
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});
+
+function contractMetadata(taskId: string, packagePath: string, title = "Migrated repair fixture") {
+  return {
+    schema: "task-contract/v1",
+    contractVersion: 1,
+    taskId,
+    packagePath,
+    title,
+    taskClass: "standard",
+    verticalId: "software/coding",
+    presetId: "standard-task",
+    profileId: "baseline",
+    locale: "en-US",
+  } as const;
+}
 
 test("decision replay keeps source prose and legacy frontmatter readable beside the native projection", async () => {
   const scratch = mkdtempSync(path.join(tmpdir(), "ha-migrate-decision-content-")),

--- a/packages/daemon/test/migration-import-task-restatement.test.ts
+++ b/packages/daemon/test/migration-import-task-restatement.test.ts
@@ -1,8 +1,11 @@
 // harness-test-tier: fast
 import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
 import test from "node:test";
 import { REPLAY_TASK_GRAPH } from "../../kernel/src/index.ts";
-import { restateLegacyTaskEvents } from "../src/migration-import-task-restatement.ts";
+import { restateLegacyTaskEvents, restateTaskContractBody } from "../src/migration-import-task-restatement.ts";
 
 const actor = { principal: { personId: "person_zeyu" }, executor: null } as const;
 
@@ -51,6 +54,133 @@ test("Task/v1 restatement rejects reverse source revisions", () => {
     /revisions must increase/u,
   );
 });
+
+test("task contract restatement preserves a declared digest and rewrites migrated identity", () => {
+  const rootDir = fixtureRoot();
+  try {
+    const digest = `sha256:${"a".repeat(64)}` as const,
+      restated = restateTaskContractBody({
+        sourceRoot: rootDir,
+        sourcePath: "harness/tasks/task-old/task-contract.json",
+        body: JSON.stringify({
+          schema: "task-contract/v1",
+          contractVersion: 1,
+          taskId: "task-old",
+          packagePath: "tasks/task-old-before",
+          presetSnapshotDigest: digest,
+          title: "Migrated task",
+        }),
+        targetTaskId: "task-new",
+        targetPackagePath: "tasks/task-new-migrated-task",
+      }),
+      contract = JSON.parse(restated.body) as Record<string, unknown>;
+    assert.equal(restated.presetSnapshotDigest, digest);
+    assert.equal(restated.source, "contract");
+    assert.equal(contract.taskId, "task-new");
+    assert.equal(contract.packagePath, "tasks/task-new-migrated-task");
+    assert.equal(contract.presetSnapshotDigest, digest);
+  } finally {
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});
+
+test("task contract restatement recomputes a missing digest from contract metadata", () => {
+  const rootDir = fixtureRoot();
+  try {
+    const restated = restateTaskContractBody({
+      sourceRoot: rootDir,
+      sourcePath: "harness/tasks/task-old/task-contract.json",
+      body: JSON.stringify(taskContractMetadata()),
+      targetTaskId: "task-new",
+      targetPackagePath: "tasks/task-new-migrated-task",
+    });
+    assert.equal(restated.source, "compiled");
+    assert.match(restated.presetSnapshotDigest, /^sha256:[0-9a-f]{64}$/u);
+    assert.equal(
+      (JSON.parse(restated.body) as Record<string, unknown>).presetSnapshotDigest,
+      restated.presetSnapshotDigest,
+    );
+  } finally {
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});
+
+test("task contract restatement fails closed when a missing digest cannot be derived", () => {
+  const rootDir = fixtureRoot();
+  try {
+    assert.throws(
+      () =>
+        restateTaskContractBody({
+          sourceRoot: rootDir,
+          sourcePath: "harness/tasks/task-old/task-contract.json",
+          body: JSON.stringify({ ...taskContractMetadata(), title: null }),
+          targetTaskId: "task-new",
+          targetPackagePath: "tasks/task-new-migrated-task",
+        }),
+      /cannot derive presetSnapshotDigest from task contract metadata/u,
+    );
+  } finally {
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});
+
+test("legacy snapshot contracts use canonical task fallback metadata and normalize document paths", () => {
+  const rootDir = fixtureRoot();
+  try {
+    const restated = restateTaskContractBody({
+        sourceRoot: rootDir,
+        sourcePath: "harness/tasks/task-old/task-contract.json",
+        body: JSON.stringify({
+          schema: "task-contract-snapshot/v1",
+          vertical: "software/coding",
+          preset: { id: "standard-task" },
+          profile: { id: "baseline" },
+          documents: [{ slot: "task.closeout", materializeAs: "closeout.md", locale: "en-US" }],
+        }),
+        targetTaskId: "task-new",
+        targetPackagePath: "tasks/task-new-migrated-task",
+        fallback: { title: "Migrated task", taskClass: "standard" },
+      }),
+      contract = JSON.parse(restated.body) as {
+        readonly schema: string;
+        readonly title: string;
+        readonly presetId: string;
+        readonly documents: readonly { readonly path?: string }[];
+      };
+    assert.equal(restated.source, "compiled");
+    assert.equal(contract.schema, "task-contract/v1");
+    assert.equal(contract.title, "Migrated task");
+    assert.equal(contract.presetId, "standard-task");
+    assert.equal(contract.documents[0]?.path, "closeout.md");
+  } finally {
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});
+
+function fixtureRoot(): string {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-contract-restatement-"));
+  mkdirSync(path.join(rootDir, "harness"), { recursive: true });
+  writeFileSync(
+    path.join(rootDir, "harness/harness.yaml"),
+    "schema: harness-anything/v1\nlayout:\n  authoredRoot: harness\n  localRoot: .harness\n",
+  );
+  return rootDir;
+}
+
+function taskContractMetadata() {
+  return {
+    schema: "task-contract/v1",
+    contractVersion: 1,
+    taskId: "task-old",
+    packagePath: "tasks/task-old-before",
+    title: "Migrated task",
+    taskClass: "standard",
+    verticalId: "software/coding",
+    presetId: "standard-task",
+    profileId: "baseline",
+    locale: "en-US",
+  } as const;
+}
 
 function input(
   workspaceRevision: number,

--- a/packages/kernel/src/domain/task-lifecycle-publication.ts
+++ b/packages/kernel/src/domain/task-lifecycle-publication.ts
@@ -216,7 +216,8 @@ export function renderLifecycleDocument(
   base: string | null,
 ): string {
   if (path.endsWith("/INDEX.md")) return renderIndex(event, snapshot, path, base);
-  if (path.endsWith("/task-contract.json")) return renderContract(snapshot, base);
+  if (path.endsWith("/task-contract.json"))
+    return renderContract(snapshot, base, path.slice(0, -"/task-contract.json".length));
   if (path.endsWith("/module.md")) return renderModule(snapshot);
   if (path.endsWith("/task_plan.md") && retitledTaskPlanPath(event, path.slice(0, -"/task_plan.md".length)) !== null)
     return renderTaskPlan(snapshot, path, base);
@@ -337,7 +338,7 @@ function renderIndex(event: TaskEventV1, snapshot: TaskLifecycleSnapshot, path: 
     .replace(/^  status:.*$/mu, `  status: ${task.status}`)
     .replace(/## Next\n[\s\S]*$/u, `## Next\n\n${next}\n\n## Gate Checks\n\n${gates}\n`);
 }
-function renderContract(snapshot: TaskLifecycleSnapshot, base: string | null): string {
+function renderContract(snapshot: TaskLifecycleSnapshot, base: string | null, packagePath: string): string {
   const task = snapshot.task!,
     current = base ? (JSON.parse(base) as Record<string, unknown>) : {},
     metadata = JSON.parse(stableStringify(task.metadata ?? null)) as unknown,
@@ -348,9 +349,11 @@ function renderContract(snapshot: TaskLifecycleSnapshot, base: string | null): s
       schema: "task-contract/v1",
       contractVersion: task.contractVersion ?? 1,
       taskId: task.taskId,
+      packagePath,
       title: task.title,
       taskClass: task.taskClass,
       pinned: task.pinned,
+      presetSnapshotDigest: task.presetSnapshotDigest,
       metadata,
       relations,
     },


### PR DESCRIPTION
# English

## Summary

Migrated tasks were imported with `presetSnapshotDigest: null` and stale `task-contract.json` package paths, which blocks every migrated task's closeout (`content_not_ready`) and preset upgrade (`invalid_task_contract`). This PR makes the migrator restate the task contract at import time (adopting or recomputing the digest and normalizing `taskId`/`packagePath`), and reuses `ha task contract migrate --dry-run/--apply` as an idempotent repair channel for the already-migrated ledger. Completion gates are not loosened; tasks that cannot be mechanically repaired stay fail-closed.

## Architectural Justification

Production net is +342 driven by the contract restatement module in the migration import path plus repair-channel publication; no existing module carried "derive a valid contract from a legacy package". No compatibility layer is added: the repair rewrites rows to the canonical shape instead of teaching readers to accept the broken shape.

## What Changed

- `migration-import-task-restatement.ts`: restate the legacy task contract against the target package path; adopt the contract digest or recompute it via package compilation; fall back to canonical task metadata when the legacy contract file is missing.
- `migration-import-tasks.ts` / `migration-import-oracle-rebuild.ts` / `migration-import-run.ts`: both import paths now populate `presetSnapshotDigest` and register the restated contract instead of hardcoding `null`.
- `repo-cell-task-mutation.ts` / `repo-cell-task-maintenance.ts` / `repo-cell-task-command-docs.ts` / `task-lifecycle-publication.ts`: `ha task contract migrate` publishes per-task `task_contract_migrated` through the daemon single-writer queue with a revision fence; re-apply publishes nothing (idempotent).
- Integration tests: replay-records and restatement coverage (+440 test lines), including the acceptance sample `task_8c0e974b7c612ace414f92ab56` (digest null → `sha256:1bc6aa24…`, packagePath → `tasks/task_8c0e974b7c612ace414f92ab56-schedule`).

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: use the single CI-backed `Production-Delta` declaration below; do not enter a second metric.

## Machine-Readable Declarations

Production-Delta: +376/-34

## Task And Scope

- Harness task: task_053af663301df54d9a92692b64
- Branch: codex/migration-closeout
- Public scope: daemon migration-import family, task contract repair channel, kernel task-lifecycle publication, integration tests
- Private planning/evidence updated: yes
- Out of scope: backfilling agent/schedule/runtime-session entities (task_44d5009838e66ef1dcb7c6c3b3); running the production repair against the real ledger (CEO-gated: backup tag + dry-run + owner approval)

## Version Impact

- Version: no version change because this is a defect fix inside existing surfaces
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: task_053af663301df54d9a92692b64
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no

## Verification

- Base `origin/main` SHA: 37a2a0dc67ff97acec3c9acc0da9363756e7cdbb
- Branch merge-base with `origin/main`: baf9ca42e665642b0dedcb03f379f62ca57d7661
- Last `git fetch origin` time: 2026-08-31 (UTC, see PR checks)
- Sync method: none needed
- Public diff command: `git diff origin/main...codex/migration-closeout`
- Private evidence path: harness/tasks/task_053af663301df54d9a92692b64-migration-closeout-path/artifacts/reports/dispatch_d0b6aa3e191c3a9d547d71e7.md; Fact F-471E229F
- Reviewer evidence path: same as above
- GitHub Actions `rewrite-ci` run URL: pending on this PR's head
- Targeted local runs (worker stop-point discipline; full matrix belongs to CI): typecheck, lint, file-complexity, implementation-contract, write-road, aggregate-entry, plus migration / oracle-rebuild / fact-rekey / contract-repair / closeout integration tests — all green at 7437e34d7
- Not run: full `npm run check:local` (forbidden for workers on this machine; GitHub CI is the authority)

Read-only audit of the current ledger: 1,916 candidates; 1,851 auto-repairable; 65 manual (43 missing `long-running-task` preset, 16 post-migration `taskClass` conflicts, 6 referencing missing presets) — these stay fail-closed pending explicit governance. No production repair was executed.

## Residual Risk

- The 65 manual-disposition tasks remain blocked until a preset-restore or explicit exemption decision; tracked in the task ledger.
- Production repair of the real ledger is deliberately deferred to a CEO-gated run (backup tag + dry-run diff + owner approval).

---

# 中文

## 摘要

迁移进新 canonical 的任务被写成 `presetSnapshotDigest: null`,且 `task-contract.json` 里是旧 packagePath——所有迁移任务的销账(`content_not_ready`)和 preset 升级(`invalid_task_contract`)全被卡死。本 PR 让迁移器在导入时就重述 task contract(采用或重算 digest,归一 `taskId`/`packagePath`),并复用 `ha task contract migrate --dry-run/--apply` 作为对既有台账的幂等修复通道。完成门没有放宽:无法机械修复的任务保持 fail-closed。

## 架构辩护

净增 +342 集中在迁移导入路径新增的 contract 重述模块与修复通道发布:既有模块中不存在「从 legacy 包推导有效 contract」的能力,只能新建;没有加任何兼容层——修复把行改写成 canonical 形状,而不是教读端接受坏形状。范围无法再收窄:两条导入路径(tasks/oracle-rebuild)都产出坏行,漏一条缺陷仍在;幂等修复通道复用既有 `task contract migrate` 命令面而非另起写路。

## 变更点

- `migration-import-task-restatement.ts`:按目标包路径重述 legacy contract;采用或经包编译重算 digest;缺 contract 文件时由 canonical task metadata 重建。
- 两条导入路径(tasks / oracle-rebuild)不再硬编码 `null`,改为落重述后的 contract 与 digest。
- 修复通道逐任务发布 `task_contract_migrated`,走 daemon 单写队列 + revision fence,重复 apply 不产生新事件(幂等)。
- 集成测试 +440 行,含验收样本 task_8c0e974b(digest null→`sha256:1bc6aa24…`,packagePath 归一到 `-schedule`)。

## 验证与残余风险

- 定向测试与六项结构检查在 7437e34d7 全绿(完整矩阵归 GitHub CI)。
- 只读审计:候选 1,916,可自动修复 1,851,manual 65(43 缺 `long-running-task` preset / 16 taskClass 冲突 / 6 引用已不存在 preset)——保持 fail-closed 待治理裁决。
- 生产台账真修复刻意不在本 PR 内执行:按红线走备份 tag + dry-run 差异表 + 泽宇批准。
