### PR TITLE
fix(gui): artifacts list card has one click semantic — open the preview

### DIFF
--- a/packages/gui/src/renderer/i18n/locales/en-US/views.json
+++ b/packages/gui/src/renderer/i18n/locales/en-US/views.json
@@ -681,7 +681,6 @@
   "artifacts.timeSource.ledger": "ledger",
   "artifacts.timeSource.mtime": "file mtime",
   "artifacts.list.count": "{count} items",
-  "artifacts.list.open": "Preview here",
   "artifacts.list.col.file": "File",
   "artifacts.list.col.task": "Task",
   "artifacts.list.col.path": "Repo path",

--- a/packages/gui/src/renderer/i18n/locales/zh-CN/views.json
+++ b/packages/gui/src/renderer/i18n/locales/zh-CN/views.json
@@ -681,7 +681,6 @@
   "artifacts.timeSource.ledger": "台账",
   "artifacts.timeSource.mtime": "文件",
   "artifacts.list.count": "{count} 个",
-  "artifacts.list.open": "就地预览",
   "artifacts.list.col.file": "文件",
   "artifacts.list.col.task": "所属 task",
   "artifacts.list.col.path": "仓内路径",

--- a/packages/gui/src/renderer/views/ArtifactsView.tsx
+++ b/packages/gui/src/renderer/views/ArtifactsView.tsx
@@ -201,7 +201,6 @@ export function ArtifactsWorkspace({
                       row={row}
                       active={current !== null && sameArtifact(row, current)}
                       onSelect={() => setSelected(row)}
-                      onNavigateTask={onNavigateTask}
                     />
                   ))}
                 </ul>
@@ -230,26 +229,25 @@ function ArtifactRow({
   row,
   active,
   onSelect,
-  onNavigateTask,
 }: {
   readonly row: ArtifactGuiRowDto;
   readonly active: boolean;
   readonly onSelect: () => void;
-  readonly onNavigateTask: (taskId: string) => void;
 }) {
   return (
     <li>
-      <div
+      {/* 整卡只有一种点击:打开预览(泽宇 2026-08-31 亲裁,一个组件不承载两种点击)。
+          跳所属 task 的唯一出口在预览头按钮;所属 task 标题在卡内只作信息展示。 */}
+      <button
+        type="button"
         data-testid={`artifact-row-${row.taskId ?? "taskless"}-${row.path}`}
+        onClick={onSelect}
         className={`${ROW_CLASS} ${active ? "border-accent/60 bg-surface" : ""}`}
         title={repoPathOf(row)}
       >
-        <button
-          type="button"
+        <span
           data-testid={`artifact-focus-${row.taskId ?? "taskless"}-${row.path}`}
-          onClick={onSelect}
-          title={t("artifacts.list.open")}
-          className="flex w-full items-center gap-1.5 text-left text-[12px] font-medium hover:text-accent"
+          className="flex w-full items-center gap-1.5 text-[12px] font-medium"
         >
           {row.kind === "html" ? (
             <FileHtml weight="duotone" className="size-3.5 shrink-0 text-text-faint" />
@@ -267,13 +265,13 @@ function ArtifactRow({
             {row.timeSource === "mtime" ? ` · ${t("artifacts.timeSource.mtime")}` : ""}
           </span>
           <Badge tip={t(TIME_SOURCE_LABEL[row.timeSource])}>{t(KIND_LABEL[row.kind])}</Badge>
-        </button>
+        </span>
         {row.taskId === null ? (
           <Hint>{t("artifacts.taskUnknown")}</Hint>
         ) : (
-          <TaskLinkCell taskId={row.taskId} title={row.taskTitle} onNavigateTask={onNavigateTask} />
+          <span className="block max-w-full truncate text-[11px] text-text-muted">{row.taskTitle ?? row.taskId}</span>
         )}
-      </div>
+      </button>
     </li>
   );
 }
@@ -303,29 +301,6 @@ function KindToggle({
     >
       {t(KIND_LABEL[kind])}
       {count === undefined ? "" : ` · ${count}`}
-    </button>
-  );
-}
-
-function TaskLinkCell({
-  taskId,
-  title,
-  onNavigateTask,
-}: {
-  readonly taskId: string;
-  readonly title: string | null;
-  readonly onNavigateTask: (taskId: string) => void;
-}) {
-  return (
-    <button
-      type="button"
-      data-testid={`artifact-task-${taskId}`}
-      onClick={() => onNavigateTask(taskId)}
-      title={t("artifacts.openTask")}
-      className="flex max-w-full items-center gap-1 truncate text-left text-[11px] text-text-muted hover:text-accent"
-    >
-      <span className="min-w-0 truncate">{title ?? taskId}</span>
-      <ArrowRight className="size-3 shrink-0 text-text-faint" />
     </button>
   );
 }

--- a/packages/gui/test/artifacts-view.vitest.ts
+++ b/packages/gui/test/artifacts-view.vitest.ts
@@ -338,7 +338,7 @@ describe("artifacts timeline — list, preview, and task jump", () => {
     expect(container.textContent).toContain("Markdown report");
   });
 
-  it("jumps to the owning task from the task, path, and preview header links", async () => {
+  it("the whole card opens the preview; the task jump lives only in the preview header", async () => {
     stubDocumentBridge("<h1>Weathering</h1>");
     const onNavigateTask = vi.fn();
     const container = await renderSurface(
@@ -351,14 +351,15 @@ describe("artifacts timeline — list, preview, and task jump", () => {
         onNavigateTask,
       }),
     );
-    // 左抽屉的行不再带独立的路径链接(路径进 title,预览头仍显示全路径):
-    // 跳任务的两条出口是抽屉行与预览头。
-    await click(container, "artifact-task-task_weathering");
+    // 整卡单一点击语义:点卡任意处(含所属 task 标题行)只打开预览,不跳 task。
     await click(container, "artifact-focus-task_weathering-artifacts/reports/weathering.html");
+    await click(container, "artifact-row-task_weathering-artifacts/reports/weathering.html");
     await settle();
+    expect(onNavigateTask).not.toHaveBeenCalled();
+    // 跳所属 task 的唯一出口:预览头按钮。
     await click(container, "artifact-open-task");
     expect(onNavigateTask).toHaveBeenCalledWith("task_weathering");
-    expect(onNavigateTask).toHaveBeenCalledTimes(2);
+    expect(onNavigateTask).toHaveBeenCalledTimes(1);
   });
 
   it("switches the kind facet through the filter, and an unmapped row keeps no task link", async () => {


### PR DESCRIPTION
# English

## Summary

The artifacts drawer card previously carried two different click semantics: the title row opened the in-app preview while the task-title row navigated to the owning task. Per owner feedback, the whole card now has exactly one click semantic — open the HTML/Markdown preview. The owning-task jump keeps its single dedicated exit: the button in the preview header.

## Architectural Justification

- Not required: churn is far below 200 lines and production net is negative.

## What Changed

- `ArtifactsView.tsx`: `ArtifactRow` is now a single `<button>` covering the whole card with `onClick=onSelect`; the owning-task title is rendered as plain text (no nested click target). The `TaskLinkCell` component and the `onNavigateTask` prop of `ArtifactRow` are deleted.
- The now-unused `artifacts.list.open` i18n key is removed from both `en-US` and `zh-CN` locales.
- `artifacts-view.vitest.ts`: the navigation test now asserts the card click (including its task-title area) never triggers task navigation, and that the preview-header button remains the only task jump (1 call, not 2).

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: use the single CI-backed `Production-Delta` declaration below; do not enter a second metric.

## Machine-Readable Declarations

Production-Delta: +10/-35

## Task And Scope

- Harness task: task_06bae07e (private ledger)
- Branch: codex/gui-artifact-click
- Public scope: packages/gui artifacts view click semantics only
- Private planning/evidence updated: yes
- Out of scope: sidebar system-status area and sidebar scrolling (separate in-flight task), artifact preview rendering

## Version Impact

- Version: no version change because this is a GUI interaction fix within the unreleased milestone line
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope:
- Authority: not applicable
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason:
- Break-glass scope:
- Follow-up governance task:

## Verification

- Base `origin/main` SHA: 718a22b55b048eb93a6809be0a05ef036c0c973a
- Branch merge-base with `origin/main`: 718a22b55b048eb93a6809be0a05ef036c0c973a
- Last `git fetch origin` time: 2026-08-31 (before branching)
- Sync method: none needed
- Public diff command: git diff origin/main..codex/gui-artifact-click
- Private evidence commit/path: private ledger task_06bae07e (fact F-867D2B41)
- Reviewer evidence path: see Review Evidence
- GitHub Actions `rewrite-ci` run URL: pending (PR checks)
- [x] targeted vitest: packages/gui/test/artifacts-view.vitest.ts — 10 passed / 0 failed
- Not run: full local check suites — worker/local stop-point policy; GitHub CI is the complete authority for this PR.

## Review Evidence

- Self-review: CEO reviewed the full diff; net deletion (-27 production lines), no behavior added beyond the single click semantic.
- Reviewer subagent: not used (small UI interaction fix; single-reviewer budget per review policy)
- Human review: owner requested this exact behavior with screenshot feedback
- Blocking findings: none

## Residual Risk

- Keyboard users lose the separate in-card tab stop for task navigation; the preview-header button remains reachable and is the intended single exit.

## References

- Task: task_06bae07e (private ledger)
- Evidence: fact F-867D2B41 (private ledger)
- Review: this PR body

---

# 中文

## 概要

产物抽屉卡片此前承载两种点击语义:标题行打开应用内预览,task 标题行跳转所属 task。按泽宇反馈,整卡现在只有一种点击语义——打开 HTML/Markdown 预览;跳所属 task 只保留预览头的专用按钮这一个出口。

## 架构辩护

- 不需要:churn 远低于 200 行,生产净行数为负。

## 改动内容

- `ArtifactsView.tsx`:`ArtifactRow` 改为覆盖整卡的单一 `<button>`,`onClick=onSelect`;所属 task 标题降为纯文本(无嵌套点击目标);删除 `TaskLinkCell` 组件与 `ArtifactRow` 的 `onNavigateTask` prop。
- 删除双语 locale 中已无使用方的 `artifacts.list.open` i18n key。
- `artifacts-view.vitest.ts`:导航测试改为断言点击卡片(含 task 标题区域)不触发 task 跳转,预览头按钮是唯一跳转出口(调用 1 次而非 2 次)。

## 门收割 / Gate Harvest

- 删除的生产路径:none
- 同 commit 删除的门 / fixture:none
- 生产净行数:引用英文块中的 `Production-Delta`;该值由 production-delta job 计算,不要手填第二份数字。

## 机读声明说明

- 机读声明只在英文块出现一次,见英文块 `Production-Delta: +10/-35`。

## 任务与范围

- Harness 任务:task_06bae07e(私有台账)
- 分支:codex/gui-artifact-click
- 公开范围:仅 packages/gui 产物视图点击语义
- 私有计划 / 证据是否已更新:yes
- 范围外:侧栏系统状态区与侧栏滚动(独立在飞任务)、产物预览渲染

## 版本影响

- 版本:不改版本,原因是本 PR 是未发布里程碑线内的 GUI 交互修复
- 发布影响:不发布

## 治理声明

- 是否触碰 protected surface:no
- protected surface 范围:
- 依据:不适用
- 机器检查边界:本 PR 只声明该段存在;声明是否真实、充分,由 reviewer 判断。
- Break-glass:no
- Break-glass 原因:
- Break-glass 范围:
- 后续治理任务:

## 验证

- `origin/main` 基准 SHA:718a22b55b048eb93a6809be0a05ef036c0c973a
- 当前分支与 `origin/main` 的 merge-base:718a22b55b048eb93a6809be0a05ef036c0c973a
- 最近一次 `git fetch origin` 时间:2026-08-31(建分支前)
- 同步方式:不需要
- 公开 diff 命令:git diff origin/main..codex/gui-artifact-click
- 私有证据 commit/path:私有台账 task_06bae07e(fact F-867D2B41)
- Reviewer 证据路径:见审查证据
- GitHub Actions `rewrite-ci` run URL:待 PR checks
- [x] 定向 vitest:packages/gui/test/artifacts-view.vitest.ts — 10 通过 / 0 失败
- 未运行:完整本地 check 套件——按 worker/本地停止点纪律,GitHub CI 是本 PR 的完整权威。

## 审查证据

- 自查:CEO 全量 diff 复核;净删除(生产 -27 行),除单一点击语义外无新增行为。
- Reviewer subagent:未使用(小型 UI 交互修复,按评审预算单评审员)
- 人工审查:泽宇以截图反馈明确要求此行为
- 阻塞发现:none

## 残余风险

- 键盘用户失去卡内独立的 task 跳转 tab stop;预览头按钮仍可达,且是设计上的唯一出口。

## 关联材料

- 任务:task_06bae07e(私有台账)
- 证据:fact F-867D2B41(私有台账)
- 审查:本 PR 正文

---

## PR Gate Checklist / PR 门禁清单

- [x] Branch is based on latest `origin/main`. / 分支基于最新 `origin/main`。
- [x] PR body uses this full template structure. / PR 描述使用本模板完整结构。
- [x] PR body uses two complete language blocks: `# English` first, then `# 中文`. / PR 正文使用两块完整正文:`# English` 在上,`# 中文` 在下。
- [x] PR body passes `tools/check-pr-body-bilingual.mjs`. / PR 正文通过 `tools/check-pr-body-bilingual.mjs`。
- [x] If the PR touches a manifest-derived protected surface, Governance Declaration is filled with ADR/decision/task evidence or break-glass fields. / 若 PR 触碰 manifest 派生的 protected surface,Governance Declaration 已填写 ADR/decision/task 依据或 break-glass 字段。
- [x] No private harness files are included. / 不包含私有 harness 文件。
- [x] No ignored local agent entry files are included. / 不包含被忽略的本地 agent 入口文件。
- [x] No absolute local filesystem paths are included in this public PR body. / 本公开 PR 描述不包含本机绝对路径。
- [x] Public diff is limited to the stated task scope. / 公开 diff 限于声明的任务范围。
- [x] Private planning/evidence updates are recorded when applicable. / 适用时已记录私有计划 / 证据更新。
- [x] Version and publish impact are stated. / 已说明版本与发布影响。
- [x] Local verification commands are recorded honestly. / 已如实记录本地验证命令。
- [x] CI results are linked or explained. / CI 结果已链接或说明。
- [x] Review evidence is recorded. / 已记录审查证据。
- [x] Open P0/P1/P2 findings are closed, deferred with owner, or explicitly blocked. / open P0/P1/P2 findings 已关闭、带 owner 延后,或明确阻塞。
- [x] Merge method and post-merge branch cleanup plan are clear. / 合并方式和合并后分支清理计划清楚。
- [x] No admin bypass is planned unless explicitly approved and recorded. / 除非明确批准并记录,否则不计划 admin bypass。
