### PR TITLE
fix(daemon): backfill migration entity families (agent/schedule/runtime-session)

### DIFF
--- a/packages/daemon/src/migration-import-backfill.ts
+++ b/packages/daemon/src/migration-import-backfill.ts
@@ -1,0 +1,397 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import {
+  MIGRATION_IMPORT_SOURCE,
+  canonicalEventWritePlan,
+  compileEntityUpsert,
+  compileScheduleDefinitionEvent,
+  consumeKnownError,
+  sha256Text,
+  stableStringify,
+  validateCurrentCanonicalEvent,
+  validateScheduleV1,
+  type AgentRuntimeEventV1,
+  type CanonicalContentBlob,
+  type RuntimeSession,
+  type ScheduleV1,
+} from "../../kernel/src/index.ts";
+import type { MigrationImportContext } from "./migration-import-run.ts";
+import type { Prepared } from "./migration-import-types.ts";
+
+export function prepareEntityBackfills(
+  context: MigrationImportContext,
+  initialRevision: number,
+): { readonly prepared: readonly Prepared[]; readonly revision: number } {
+  const prepared: Prepared[] = [];
+  let revision = initialRevision;
+  const append = (bundle: Prepared): boolean => {
+    const held = context.input.store.readEvent(bundle.event.opId);
+    if (held !== null) {
+      if (
+        held.schema !== bundle.event.schema ||
+        held.type !== bundle.event.type ||
+        stableStringify(held.payload) !== stableStringify(bundle.event.payload)
+      )
+        throw context.migrationImportError(
+          "migration_source_operation_conflict",
+          `Backfill operation ${bundle.event.opId} is already bound to different canonical bytes.`,
+        );
+      return false;
+    }
+    prepared.push({ ...bundle, event: { ...bundle.event, workspaceRevision: revision + 1 } });
+    revision += 1;
+    return true;
+  };
+
+  for (const source of context.oracle.agents.values()) {
+    const existing = context.existingAgents.get(source.agentId),
+      sourceAnchor = source.sourceAnchor.source;
+    if (existing !== undefined) {
+      const same = stableStringify(existing) === stableStringify(source.value);
+      context.backfillRows.push({
+        entityType: "agent",
+        entityId: source.agentId,
+        action: same ? "unchanged" : "conflict",
+        sourceAnchor,
+      });
+      if (same) {
+        context.agentMap.set(source.agentId, source.agentId);
+        context.alreadyImported.agent += 1;
+      } else {
+        context.skips.push({
+          entityType: "agent",
+          migratedFrom: source.agentId,
+          sourcePath: sourceAnchor,
+          reason: "destination agent id contains a different declaration",
+        });
+      }
+      continue;
+    }
+    try {
+      const opId = context.migrationOperationId(context.sourceKey, "agent", source.agentId),
+        bundle = compileEntityUpsert({
+          entityKind: "agent",
+          entity: source.value,
+          eventId: `event-${sha256Text(opId)}`,
+          opId,
+          workspaceRevision: revision + 1,
+          actor: context.actorFor(`agent/${source.agentId}`),
+          source: MIGRATION_IMPORT_SOURCE,
+          occurredAt: source.sourceAnchor.occurredAt,
+        });
+      context.agentMap.set(source.agentId, source.agentId);
+      context.backfillRows.push({ entityType: "agent", entityId: source.agentId, action: "create", sourceAnchor });
+      if (!append(bundle)) {
+        context.alreadyImported.agent += 1;
+        context.backfillRows[context.backfillRows.length - 1] = {
+          entityType: "agent",
+          entityId: source.agentId,
+          action: "unchanged",
+          sourceAnchor,
+        };
+      }
+    } catch (error) {
+      consumeKnownError(error);
+      context.agentMap.delete(source.agentId);
+      markConflict(context, "agent", source.agentId, sourceAnchor);
+      context.skips.push({
+        entityType: "agent",
+        migratedFrom: source.agentId,
+        sourcePath: sourceAnchor,
+        reason: context.message(error),
+      });
+    }
+  }
+
+  for (const source of context.oracle.schedules.values()) {
+    const existing = context.existingSchedules.get(source.scheduleId),
+      sourceAnchor = source.sourceAnchor.source;
+    if (existing !== undefined) {
+      const same = stableStringify(existing) === stableStringify(source.value);
+      context.backfillRows.push({
+        entityType: "schedule",
+        entityId: source.scheduleId,
+        action: same ? "unchanged" : "conflict",
+        sourceAnchor,
+      });
+      if (same) {
+        context.scheduleMap.set(source.scheduleId, source.scheduleId);
+        context.alreadyImported.schedule += 1;
+      } else {
+        context.skips.push({
+          entityType: "schedule",
+          migratedFrom: source.scheduleId,
+          sourcePath: sourceAnchor,
+          reason: "destination schedule id contains a different projection",
+        });
+      }
+      continue;
+    }
+    try {
+      const schedule = remapScheduleAgents(context, source.value),
+        errors = validateScheduleV1(schedule);
+      if (errors.length) throw new Error(errors.join("; "));
+      const opId = context.migrationOperationId(context.sourceKey, "schedule", source.scheduleId),
+        bundle = compileScheduleDefinitionEvent({
+          type: "schedule_created",
+          schedule,
+          eventId: `event-${sha256Text(opId)}`,
+          opId,
+          workspaceRevision: revision + 1,
+          actor: context.actorFor(`schedule/${source.scheduleId}`),
+          source: MIGRATION_IMPORT_SOURCE,
+          occurredAt: source.sourceAnchor.occurredAt,
+        });
+      context.scheduleMap.set(source.scheduleId, source.scheduleId);
+      context.backfillRows.push({
+        entityType: "schedule",
+        entityId: source.scheduleId,
+        action: "create",
+        sourceAnchor,
+      });
+      if (!append(bundle)) {
+        context.alreadyImported.schedule += 1;
+        context.backfillRows[context.backfillRows.length - 1] = {
+          entityType: "schedule",
+          entityId: source.scheduleId,
+          action: "unchanged",
+          sourceAnchor,
+        };
+      }
+    } catch (error) {
+      consumeKnownError(error);
+      context.scheduleMap.delete(source.scheduleId);
+      markConflict(context, "schedule", source.scheduleId, sourceAnchor);
+      context.skips.push({
+        entityType: "schedule",
+        migratedFrom: source.scheduleId,
+        sourcePath: sourceAnchor,
+        reason: context.message(error),
+      });
+    }
+  }
+
+  for (const source of context.oracle.runtimeSessions.values()) {
+    const existing = context.existingRuntimeSessions.get(source.runtimeSessionId),
+      sourceAnchor = source.sourceAnchor.source;
+    if (existing !== undefined) {
+      const same = stableStringify(existing) === stableStringify(source.value);
+      context.backfillRows.push({
+        entityType: "runtime-session",
+        entityId: source.runtimeSessionId,
+        action: same ? "unchanged" : "conflict",
+        sourceAnchor,
+      });
+      if (same) {
+        context.runtimeSessionMap.set(source.runtimeSessionId, source.runtimeSessionId);
+        context.alreadyImported["runtime-session"] += 1;
+      } else {
+        context.skips.push({
+          entityType: "runtime-session",
+          migratedFrom: source.runtimeSessionId,
+          sourcePath: sourceAnchor,
+          reason: "destination runtime-session id contains a different projection",
+        });
+      }
+      continue;
+    }
+    try {
+      const bundles = runtimeSessionBundles(context, source.value, source.startedAt, source.outcome, revision);
+      context.runtimeSessionMap.set(source.runtimeSessionId, source.runtimeSessionId);
+      context.backfillRows.push({
+        entityType: "runtime-session",
+        entityId: source.runtimeSessionId,
+        action: "create",
+        sourceAnchor,
+      });
+      let added = false;
+      for (const bundle of bundles) added = append(bundle) || added;
+      if (!added) {
+        context.alreadyImported["runtime-session"] += 1;
+        context.backfillRows[context.backfillRows.length - 1] = {
+          entityType: "runtime-session",
+          entityId: source.runtimeSessionId,
+          action: "unchanged",
+          sourceAnchor,
+        };
+      }
+    } catch (error) {
+      consumeKnownError(error);
+      context.runtimeSessionMap.delete(source.runtimeSessionId);
+      markConflict(context, "runtime-session", source.runtimeSessionId, sourceAnchor);
+      context.skips.push({
+        entityType: "runtime-session",
+        migratedFrom: source.runtimeSessionId,
+        sourcePath: sourceAnchor,
+        reason: context.message(error),
+      });
+    }
+  }
+  return { prepared, revision };
+}
+
+function runtimeSessionBundles(
+  context: MigrationImportContext,
+  session: RuntimeSession,
+  startedAt: string,
+  outcome: {
+    readonly result: { readonly sha256: string; readonly size: number; readonly mediaType: string };
+    readonly reasonCode?: string;
+  } | null,
+  initialRevision: number,
+): readonly Prepared[] {
+  const base = context.migrationOperationId(context.sourceKey, "runtime-session", session.runtimeSessionId),
+    specs: Array<{
+      readonly suffix: string;
+      readonly type: AgentRuntimeEventV1["type"];
+      readonly payload: Readonly<Record<string, unknown>>;
+      readonly occurredAt: string;
+      readonly blobs?: readonly CanonicalContentBlob[];
+    }> = [
+      {
+        suffix: "started",
+        type: "runtime_session_started",
+        occurredAt: startedAt,
+        payload: {
+          runtimeSessionId: session.runtimeSessionId,
+          instanceId: session.instanceId,
+          installationId: session.installationId,
+          kindId: session.kindId,
+          definitionSnapshotRef: session.definitionSnapshotRef,
+          launchGeneration: session.launchGeneration,
+          attachable: session.attachable,
+        },
+      },
+    ];
+  if ((session.providerSessionId === null) !== (session.transcriptRef === null))
+    throw new Error("runtime session provider identity and transcript reference are incomplete");
+  if (session.providerSessionId !== null && session.transcriptRef !== null)
+    specs.push({
+      suffix: "provider",
+      type: "runtime_session_provider_bound",
+      occurredAt: startedAt,
+      payload: {
+        runtimeSessionId: session.runtimeSessionId,
+        providerSessionId: session.providerSessionId,
+        transcriptRef: session.transcriptRef,
+      },
+    });
+  for (const [index, binding] of session.taskBindings.entries()) {
+    const taskId =
+      context.taskMap.get(binding.taskId) ?? (context.existingTasks.has(binding.taskId) ? binding.taskId : null);
+    if (taskId === null) throw new Error(`runtime task binding ${binding.taskId} has no imported destination task`);
+    specs.push({
+      suffix: `task-${index}`,
+      type: "runtime_session_task_bound",
+      occurredAt: binding.boundAt,
+      payload: {
+        runtimeSessionId: session.runtimeSessionId,
+        taskId,
+        executionId: binding.executionId,
+        providerSessionId: binding.providerSessionId,
+        transcriptRef: binding.transcriptRef,
+      },
+    });
+  }
+  if (session.liveness === "exited")
+    specs.push({
+      suffix: "exited",
+      type: "runtime_session_exited",
+      occurredAt: session.lastObservedAt,
+      payload: { runtimeSessionId: session.runtimeSessionId },
+    });
+  else if (session.liveness !== "live")
+    specs.push({
+      suffix: "liveness",
+      type: "runtime_session_liveness_changed",
+      occurredAt: session.lastObservedAt,
+      payload: { runtimeSessionId: session.runtimeSessionId, liveness: session.liveness },
+    });
+  if (session.outcome !== null) {
+    if (outcome === null) throw new Error("runtime outcome projection has no source result claim");
+    if (
+      outcome.result.sha256 !== session.resultRef?.slice("artifact:runtime-result/sha256/".length) ||
+      outcome.result.mediaType !== "text/plain; charset=utf-8"
+    )
+      throw new Error("runtime outcome source claim does not match the projected result reference");
+    const body = readSourceResult(context, outcome.result.sha256),
+      bytes = Buffer.byteLength(body);
+    if (bytes !== outcome.result.size || sha256Text(body) !== outcome.result.sha256)
+      throw new Error(`runtime result blob ${outcome.result.sha256} is missing or corrupt`);
+    specs.push({
+      suffix: "outcome",
+      type: "runtime_session_outcome_observed",
+      occurredAt: session.lastObservedAt,
+      payload: {
+        runtimeSessionId: session.runtimeSessionId,
+        outcome: session.outcome,
+        exitCode: session.exitCode,
+        resultRef: session.resultRef,
+        result: outcome.result,
+        ...(outcome.reasonCode ? { reasonCode: outcome.reasonCode } : {}),
+      },
+      blobs: [{ ...outcome.result, body }],
+    });
+  }
+  let revision = initialRevision;
+  const actor = context.actorFor(`runtime-session/${session.runtimeSessionId}`);
+  return specs.map((spec) => {
+    const opId = `${base}-${spec.suffix}`,
+      event = {
+        schema: "agent-runtime-event/v1",
+        eventId: `event-${sha256Text(opId)}`,
+        workspaceRevision: ++revision,
+        opId,
+        type: spec.type,
+        actor,
+        source: MIGRATION_IMPORT_SOURCE,
+        occurredAt: spec.occurredAt,
+        payload: spec.payload,
+      } as AgentRuntimeEventV1,
+      errors = validateCurrentCanonicalEvent(event);
+    if (errors.length) throw new Error(errors.join("; "));
+    return {
+      event,
+      plan: canonicalEventWritePlan(event, "agent-runtime/v1", session.runtimeSessionId),
+      blobs: spec.blobs ?? [],
+    };
+  });
+}
+
+function remapScheduleAgents(context: MigrationImportContext, schedule: ScheduleV1): ScheduleV1 {
+  if (schedule.spec.target.kind !== "agent") return schedule;
+  const sourceAgentId = schedule.spec.target.agentId,
+    mapped = context.agentMap.get(sourceAgentId);
+  if (context.oracle.agents.has(sourceAgentId) && mapped === undefined)
+    throw new Error(`schedule target agent ${sourceAgentId} was not imported`);
+  const targetAgentId = mapped ?? sourceAgentId;
+  return targetAgentId === sourceAgentId
+    ? schedule
+    : { ...schedule, spec: { ...schedule.spec, target: { ...schedule.spec.target, agentId: targetAgentId } } };
+}
+
+function markConflict(
+  context: MigrationImportContext,
+  entityType: "agent" | "schedule" | "runtime-session",
+  entityId: string,
+  sourceAnchor: string,
+): void {
+  const index = context.backfillRows.findLastIndex((row) => row.entityType === entityType && row.entityId === entityId);
+  const value = { entityType, entityId, action: "conflict" as const, sourceAnchor };
+  if (index === -1) context.backfillRows.push(value);
+  else context.backfillRows[index] = value;
+}
+
+function readSourceResult(context: MigrationImportContext, sha256: string): string {
+  for (const target of [
+    path.join(context.sourceLayout.authoredRoot, "objects", "sha256", sha256.slice(0, 2), sha256.slice(2)),
+    path.join(context.sourceLayout.authoredRoot, "objects", "sha256", sha256),
+  ])
+    try {
+      return new TextDecoder("utf-8", { fatal: true }).decode(readFileSync(target));
+    } catch (error) {
+      consumeKnownError(error);
+      // Try the other supported ledger object layout before reporting one source-row failure.
+    }
+  throw new Error(`runtime result blob ${sha256} is unavailable in the source ledger`);
+}

--- a/packages/daemon/src/migration-import-oracle-rebuild.ts
+++ b/packages/daemon/src/migration-import-oracle-rebuild.ts
@@ -322,6 +322,9 @@ function emptyOracle(inspection: MigrationEventInspection): MigrationProjectionO
     facts: new Map(),
     relations: new Map(),
     executions: new Map(),
+    agents: new Map(),
+    schedules: new Map(),
+    runtimeSessions: new Map(),
     entityKeys: new Set(),
     coverageCount: 0,
   };

--- a/packages/daemon/src/migration-import-oracle.ts
+++ b/packages/daemon/src/migration-import-oracle.ts
@@ -1,12 +1,28 @@
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
 import { DatabaseSync } from "node:sqlite";
 import path from "node:path";
-import { resolveHarnessLayout, type RelationGraphEdgeRow } from "../../kernel/src/index.ts";
+import {
+  consumeKnownError,
+  resolveHarnessLayout,
+  type RelationGraphEdgeRow,
+  type RuntimeResultClaim,
+  type RuntimeSession,
+  type ScheduleV1,
+} from "../../kernel/src/index.ts";
 import { isMigrationImportRecord, migrationImportError, nonEmpty } from "./migration-import-report.ts";
 import { inspectMigrationSourceEvents, rebuildMigrationProjectionOracle } from "./migration-import-oracle-rebuild.ts";
 import type { MigrationFormatObservation } from "./migration-import-types.ts";
 
-export const migrationOracleKinds = ["task", "decision", "fact", "relation", "execution"] as const;
+export const migrationOracleKinds = [
+  "task",
+  "decision",
+  "fact",
+  "relation",
+  "execution",
+  "agent",
+  "schedule",
+  "runtime-session",
+] as const;
 export type MigrationOracleKind = (typeof migrationOracleKinds)[number];
 
 export interface ProjectionOracleTask {
@@ -49,6 +65,37 @@ export interface ProjectionOracleExecution {
   readonly fields: Readonly<Record<string, unknown>>;
 }
 
+export interface MigrationSourceAnchor {
+  readonly source: string;
+  readonly occurredAt: string;
+}
+
+export interface ProjectionOracleAgent {
+  readonly agentId: string;
+  readonly workspaceRevision: number;
+  readonly value: Readonly<Record<string, unknown>>;
+  readonly sourceAnchor: MigrationSourceAnchor;
+}
+
+export interface ProjectionOracleSchedule {
+  readonly scheduleId: string;
+  readonly workspaceRevision: number;
+  readonly value: ScheduleV1;
+  readonly sourceAnchor: MigrationSourceAnchor;
+}
+
+export interface ProjectionOracleRuntimeSession {
+  readonly runtimeSessionId: string;
+  readonly workspaceRevision: number;
+  readonly value: RuntimeSession;
+  readonly startedAt: string;
+  readonly sourceAnchor: MigrationSourceAnchor;
+  readonly outcome: {
+    readonly result: RuntimeResultClaim;
+    readonly reasonCode?: string;
+  } | null;
+}
+
 export interface MigrationProjectionOracle {
   readonly basis: "same-cut-projection" | "rebuilt-source";
   readonly formatObservations: readonly MigrationFormatObservation[];
@@ -60,6 +107,9 @@ export interface MigrationProjectionOracle {
   readonly facts: ReadonlyMap<string, ProjectionOracleFact>;
   readonly relations: ReadonlyMap<string, ProjectionOracleRelation>;
   readonly executions: ReadonlyMap<string, ProjectionOracleExecution>;
+  readonly agents: ReadonlyMap<string, ProjectionOracleAgent>;
+  readonly schedules: ReadonlyMap<string, ProjectionOracleSchedule>;
+  readonly runtimeSessions: ReadonlyMap<string, ProjectionOracleRuntimeSession>;
   readonly entityKeys: ReadonlySet<string>;
   readonly coverageCount: number;
 }
@@ -71,13 +121,15 @@ interface SqlRow {
 export function readMigrationProjectionOracle(sourceRoot: string): MigrationProjectionOracle {
   const layout = resolveHarnessLayout(sourceRoot),
     databasePath = path.join(layout.localRoot, "cache", "task.sqlite");
-  if (!existsSync(databasePath)) return rebuildMigrationProjectionOracle(sourceRoot);
-  return readMigrationProjectionOracleAtPath(
-    sourceRoot,
-    databasePath,
-    "same-cut-projection",
-    inspectMigrationSourceEvents(sourceRoot).observations,
-  );
+  const oracle = !existsSync(databasePath)
+    ? rebuildMigrationProjectionOracle(sourceRoot)
+    : readMigrationProjectionOracleAtPath(
+        sourceRoot,
+        databasePath,
+        "same-cut-projection",
+        inspectMigrationSourceEvents(sourceRoot).observations,
+      );
+  return overlayAgentDeclarations(sourceRoot, oracle);
 }
 
 export function readMigrationProjectionOracleAtPath(
@@ -187,6 +239,52 @@ export function readMigrationProjectionOracleAtPath(
           ] as const;
         }),
       ),
+      sourceEvents = readEntitySourceEvents(database),
+      agents = readEntityRows(database, "agent", (entityId, workspaceRevision, value) => ({
+        agentId: entityId,
+        workspaceRevision,
+        value,
+        sourceAnchor: sourceEvents.agents.get(entityId) ?? {
+          source: `agents/${entityId}.json`,
+          occurredAt: "1970-01-01T00:00:00.000Z",
+        },
+      })),
+      schedules = readEntityRows(database, "schedule", (entityId, workspaceRevision, value) => ({
+        scheduleId: entityId,
+        workspaceRevision,
+        value: value as unknown as ScheduleV1,
+        sourceAnchor: sourceEvents.schedules.get(entityId) ?? {
+          source: `projection:entity_projection/schedule/${entityId}`,
+          occurredAt: String(value.updatedAt ?? value.createdAt ?? "1970-01-01T00:00:00.000Z"),
+        },
+      })),
+      runtimeSessions = new Map(
+        rows(
+          database,
+          "SELECT runtime_session_id, workspace_revision, value_json FROM runtime_session ORDER BY runtime_session_id",
+        ).map((row) => {
+          const runtimeSessionId = text(row.runtime_session_id, "runtime session id"),
+            value = record(row.value_json, `runtime session ${runtimeSessionId}`) as unknown as RuntimeSession,
+            events = sourceEvents.runtimeSessions.get(runtimeSessionId);
+          return [
+            runtimeSessionId,
+            {
+              runtimeSessionId,
+              workspaceRevision: number(
+                row.workspace_revision,
+                `runtime session ${runtimeSessionId} workspace revision`,
+              ),
+              value,
+              startedAt: events?.startedAt ?? value.lastObservedAt,
+              sourceAnchor: events?.latest ?? {
+                source: `projection:runtime_session/${runtimeSessionId}`,
+                occurredAt: value.lastObservedAt,
+              },
+              outcome: events?.outcome ?? null,
+            },
+          ] as const;
+        }),
+      ),
       entityKeys = new Set(
         rows(
           database,
@@ -208,12 +306,139 @@ export function readMigrationProjectionOracleAtPath(
       facts,
       relations,
       executions,
+      agents,
+      schedules,
+      runtimeSessions,
       entityKeys,
       coverageCount: number(coverage?.count, "coverage count"),
     };
   } finally {
     database.close();
   }
+}
+
+function readEntityRows<T>(
+  database: DatabaseSync,
+  kind: string,
+  project: (entityId: string, workspaceRevision: number, value: Readonly<Record<string, unknown>>) => T,
+): ReadonlyMap<string, T> {
+  return new Map(
+    rows(
+      database,
+      "SELECT entity_id, workspace_revision, value_json FROM entity_projection WHERE entity_kind=? ORDER BY entity_id",
+      kind,
+    ).map((row) => {
+      const entityId = text(row.entity_id, `${kind} id`);
+      return [
+        entityId,
+        project(
+          entityId,
+          number(row.workspace_revision, `${kind} ${entityId} workspace revision`),
+          record(row.value_json, `${kind} ${entityId}`),
+        ),
+      ] as const;
+    }),
+  );
+}
+
+function overlayAgentDeclarations(sourceRoot: string, oracle: MigrationProjectionOracle): MigrationProjectionOracle {
+  const layout = resolveHarnessLayout(sourceRoot),
+    agentsRoot = path.join(layout.authoredRoot, "agents"),
+    agents = new Map(oracle.agents),
+    entityKeys = new Set(oracle.entityKeys);
+  let names: readonly string[];
+  try {
+    names = readdirSync(agentsRoot)
+      .filter((name) => name.endsWith(".json"))
+      .sort();
+  } catch (error) {
+    consumeKnownError(error);
+    return oracle;
+  }
+  for (const name of names) {
+    const target = path.join(agentsRoot, name),
+      source = `agents/${name}`;
+    let value: unknown;
+    try {
+      value = JSON.parse(readFileSync(target, "utf8")) as unknown;
+    } catch (error) {
+      consumeKnownError(error);
+      continue;
+    }
+    if (!isMigrationImportRecord(value) || typeof value.id !== "string") continue;
+    const held = agents.get(value.id);
+    agents.set(value.id, {
+      agentId: value.id,
+      workspaceRevision: held?.workspaceRevision ?? 0,
+      value,
+      sourceAnchor: {
+        source,
+        occurredAt: held?.sourceAnchor.occurredAt ?? statSync(target).mtime.toISOString(),
+      },
+    });
+    entityKeys.add(`agent\0${value.id}`);
+  }
+  return { ...oracle, agents, entityKeys };
+}
+
+function readEntitySourceEvents(database: DatabaseSync): {
+  readonly agents: ReadonlyMap<string, MigrationSourceAnchor>;
+  readonly schedules: ReadonlyMap<string, MigrationSourceAnchor>;
+  readonly runtimeSessions: ReadonlyMap<
+    string,
+    {
+      readonly startedAt: string;
+      readonly latest: MigrationSourceAnchor;
+      readonly outcome: ProjectionOracleRuntimeSession["outcome"];
+    }
+  >;
+} {
+  const agents = new Map<string, MigrationSourceAnchor>(),
+    schedules = new Map<string, MigrationSourceAnchor>(),
+    runtime = new Map<
+      string,
+      {
+        startedAt: string;
+        latest: MigrationSourceAnchor;
+        outcome: ProjectionOracleRuntimeSession["outcome"];
+      }
+    >();
+  for (const row of rows(
+    database,
+    "SELECT workspace_revision, event_json FROM event_index ORDER BY workspace_revision",
+  )) {
+    const event = record(row.event_json, "source event"),
+      eventId = typeof event.eventId === "string" ? event.eventId : null,
+      occurredAt = typeof event.occurredAt === "string" ? event.occurredAt : null,
+      payload = isMigrationImportRecord(event.payload) ? event.payload : null;
+    if (eventId === null || occurredAt === null || payload === null) continue;
+    const anchor = { source: `event:${eventId}`, occurredAt };
+    if (
+      (event.schema === "entity-event/v1" || event.schema === "agent-entity-event/v1") &&
+      payload.entityKind === "agent" &&
+      typeof payload.entityId === "string"
+    )
+      agents.set(payload.entityId, anchor);
+    if (
+      event.schema === "schedule-event/v1" &&
+      isMigrationImportRecord(event.entity) &&
+      event.entity.kind === "schedule" &&
+      typeof event.entity.id === "string"
+    )
+      schedules.set(event.entity.id, anchor);
+    if (event.schema !== "agent-runtime-event/v1" || typeof payload.runtimeSessionId !== "string") continue;
+    const sessionId = payload.runtimeSessionId,
+      held = runtime.get(sessionId) ?? { startedAt: occurredAt, latest: anchor, outcome: null };
+    held.latest = anchor;
+    if (event.type === "runtime_session_started") held.startedAt = occurredAt;
+    if (event.type === "runtime_session_outcome_observed" && isMigrationImportRecord(payload.result))
+      held.outcome = {
+        result: payload.result as unknown as RuntimeResultClaim,
+        ...(typeof payload.reasonCode === "string" ? { reasonCode: payload.reasonCode } : {}),
+      };
+    runtime.set(sessionId, held);
+  }
+  return { agents, schedules, runtimeSessions: runtime };
 }
 
 function readDecisions(database: DatabaseSync): ReadonlyMap<string, ProjectionOracleDecision> {
@@ -294,8 +519,12 @@ function relationRow(row: SqlRow, original: Readonly<Record<string, unknown>>): 
   };
 }
 
-function rows(database: DatabaseSync, sql: string): readonly SqlRow[] {
-  return database.prepare(sql).all() as SqlRow[];
+function rows(
+  database: DatabaseSync,
+  sql: string,
+  ...params: readonly (string | number | bigint | null)[]
+): readonly SqlRow[] {
+  return database.prepare(sql).all(...params) as SqlRow[];
 }
 
 function group(values: readonly SqlRow[], field: string): ReadonlyMap<string, readonly SqlRow[]> {

--- a/packages/daemon/src/migration-import-reconciliation.ts
+++ b/packages/daemon/src/migration-import-reconciliation.ts
@@ -38,7 +38,10 @@ function oracleIds(context: MigrationImportContext, kind: MigrationOracleKind): 
   if (kind === "decision") return new Set(context.oracle.decisions.keys());
   if (kind === "fact") return new Set(context.oracle.facts.keys());
   if (kind === "relation") return new Set(context.oracle.relations.keys());
-  return new Set(context.oracle.executions.keys());
+  if (kind === "execution") return new Set(context.oracle.executions.keys());
+  if (kind === "agent") return new Set(context.oracle.agents.keys());
+  if (kind === "schedule") return new Set(context.oracle.schedules.keys());
+  return new Set(context.oracle.runtimeSessions.keys());
 }
 
 function isIncluded(context: MigrationImportContext, kind: MigrationOracleKind, id: string): boolean {
@@ -50,7 +53,10 @@ function isIncluded(context: MigrationImportContext, kind: MigrationOracleKind, 
       ([source, target]) => source.endsWith(`/${id}`) || target.endsWith(`/${id}`),
     );
   if (kind === "relation") return context.relationMap.has(id) || context.retiredIds.has(id);
-  return context.nativeExecutionIds.has(id);
+  if (kind === "execution") return context.nativeExecutionIds.has(id);
+  if (kind === "agent") return context.agentMap.has(id);
+  if (kind === "schedule") return context.scheduleMap.has(id);
+  return context.runtimeSessionMap.has(id);
 }
 
 function intersection(left: ReadonlySet<string>, right: ReadonlySet<string>): Set<string> {

--- a/packages/daemon/src/migration-import-report.ts
+++ b/packages/daemon/src/migration-import-report.ts
@@ -8,6 +8,7 @@ import type {
   IdRemapping,
   ImportCounts,
   MigrationDisposition,
+  MigrationBackfillRow,
   MigrationFieldDerivation,
   MigrationFormatObservation,
   MigrationKindReconciliation,
@@ -40,6 +41,9 @@ export function skippedCounts(skips: readonly Skip[]): ImportCounts {
     decision: count(skips, "decision"),
     fact: count(skips, "fact"),
     relation: count(skips, "relation"),
+    agent: count(skips, "agent"),
+    schedule: count(skips, "schedule"),
+    "runtime-session": count(skips, "runtime-session"),
     coverage: skips.reduce((sum, item) => sum + (item.coverage ?? 0), 0),
   };
 }
@@ -64,6 +68,8 @@ export function reportTable(
   fieldDerivations: readonly MigrationFieldDerivation[],
   dispositions: readonly MigrationDisposition[],
   formatObservations: readonly MigrationFormatObservation[],
+  backfillRows: readonly MigrationBackfillRow[],
+  backfillMapPath: string,
 ): string {
   const rows = (Object.keys(old) as EntityKind[]).map((kind) =>
       [
@@ -125,7 +131,11 @@ export function reportTable(
           ({ entityId, disposition, sourcePath, reason }) =>
             `- SAMPLE ${disposition} ${kind} ${entityId} (${sourcePath}): ${reason}`,
         ),
-    ]);
+    ]),
+    backfillDifferenceRows = backfillRows.map(
+      ({ entityType, entityId, action, sourceAnchor }) =>
+        `| ${entityType} | ${entityId} | ${action} | ${sourceAnchor} |`,
+    );
   return [
     `Migration import ${dryRun ? "dry-run" : "apply"}`,
     `Source Git: root=${sourceGit.rootCommit}, head=${sourceGit.head}, tree=${sourceGit.tree}, clean=true`,
@@ -170,6 +180,11 @@ export function reportTable(
     ...formatObservations.map(
       (item) => `- ACCEPT ${item.code} (${item.sourcePath}): ${item.detail}; treatment=${item.treatment}`,
     ),
+    "",
+    "| Backfill family | Entity ID | Difference | Source anchor |",
+    "| --- | --- | --- | --- |",
+    ...backfillDifferenceRows,
+    `Backfill map: ${dryRun || !authored.passed ? `would write ${backfillMapPath}` : backfillMapPath}`,
     [
       "Attribution: principal restored from source records for ",
       `${attribution.restored}`,

--- a/packages/daemon/src/migration-import-run.ts
+++ b/packages/daemon/src/migration-import-run.ts
@@ -18,6 +18,7 @@ import {
   type MigrationImportEventV1,
   type RelationFactRow,
   type RelationGraphEdgeRow,
+  type RuntimeSession,
   type TaskProjection,
   type TaskSourceEntry,
 } from "../../kernel/src/index.ts";
@@ -43,6 +44,7 @@ import {
   validFact,
 } from "./migration-import-events.ts";
 import { archivedExecution, decodeLegacyExecution, symlinkTarget, utf8File } from "./migration-import-legacy.ts";
+import { prepareEntityBackfills } from "./migration-import-backfill.ts";
 import {
   actorFor as actorForImpl,
   dropMap as dropMapImpl,
@@ -102,6 +104,7 @@ import type {
   ImportCounts,
   ImportedRelation,
   ImportedTask,
+  MigrationBackfillRow,
   MigrationDisposition,
   MigrationFieldDerivation,
   MigrationImportReceipt,
@@ -200,6 +203,13 @@ export interface MigrationImportContext extends MigrationRelationsContext {
   readonly archivedIds: Readonly<Record<MigrationOracleKind, Set<string>>>;
   readonly retiredIds: Set<string>;
   readonly nativeExecutionIds: Set<string>;
+  readonly agentMap: Map<string, string>;
+  readonly scheduleMap: Map<string, string>;
+  readonly runtimeSessionMap: Map<string, string>;
+  readonly existingAgents: ReadonlyMap<string, Readonly<Record<string, unknown>>>;
+  readonly existingSchedules: ReadonlyMap<string, Readonly<Record<string, unknown>>>;
+  readonly existingRuntimeSessions: ReadonlyMap<string, RuntimeSession>;
+  readonly backfillRows: MigrationBackfillRow[];
 }
 
 export async function runSingleMigrationImport(
@@ -266,6 +276,11 @@ export async function runSingleMigrationImport(
     existingTasks = new Set(input.projection.list().rows.map(({ taskId }) => taskId)),
     existingDecisions = new Set(decisionGraph.decisionAnchors.map(({ decisionId }) => decisionId)),
     existingFacts = new Set(input.projection.readFactGraph().facts.map(({ ref }) => ref)),
+    existingAgents = new Map(input.projection.listEntities("agent").map(({ id, value }) => [id, value])),
+    existingSchedules = new Map(input.projection.listEntities("schedule").map(({ id, value }) => [id, value])),
+    existingRuntimeSessions = new Map(
+      input.projection.readRuntimeSessions().map((value) => [value.runtimeSessionId, value]),
+    ),
     existingRelations = new Set(
       [...decisionGraph.edges, ...input.projection.readFactGraph().edges].map(({ relationId }) => relationId),
     );
@@ -273,6 +288,9 @@ export async function runSingleMigrationImport(
     decisionMap = new Map<string, string>(),
     factMap = new Map<string, string>(),
     relationMap = new Map<string, string>(),
+    agentMap = new Map<string, string>(),
+    scheduleMap = new Map<string, string>(),
+    runtimeSessionMap = new Map<string, string>(),
     taskPackages = new Map<string, string>(),
     taskOccurredAt = new Map<string, string>(),
     factDocuments = new Map<
@@ -295,8 +313,12 @@ export async function runSingleMigrationImport(
       decision: 0,
       fact: 0,
       relation: 0,
+      agent: 0,
+      schedule: 0,
+      "runtime-session": 0,
       coverage: 0,
     },
+    backfillRows: MigrationBackfillRow[] = [],
     fieldDerivations: MigrationFieldDerivation[] = [],
     dispositions: MigrationDisposition[] = [],
     derivedIds = Object.fromEntries(migrationOracleKinds.map((kind) => [kind, new Set<string>()])) as Record<
@@ -383,6 +405,13 @@ export async function runSingleMigrationImport(
     archivedIds,
     retiredIds,
     nativeExecutionIds,
+    agentMap,
+    scheduleMap,
+    runtimeSessionMap,
+    existingAgents,
+    existingSchedules,
+    existingRuntimeSessions,
+    backfillRows,
     relationMap,
   };
 
@@ -398,6 +427,9 @@ export async function runSingleMigrationImport(
   for (const row of oracle.decisions.values()) addOracleDecision(extracted, row);
   for (const row of oracle.facts.values()) addOracleFact(extracted, row);
   prepareEntityDrafts();
+  const backfill = prepareEntityBackfills(extracted, revision);
+  prepared.push(...backfill.prepared);
+  revision = backfill.revision;
   for (const source of oracle.tasks.values())
     if (!taskMap.has(source.taskId))
       scheduleArchivedEntity(extracted, {
@@ -526,6 +558,9 @@ export async function runSingleMigrationImport(
       decision: oracle.decisions.size,
       fact: oracle.facts.size,
       relation: oracle.relations.size,
+      agent: oracle.agents.size,
+      schedule: oracle.schedules.size,
+      "runtime-session": oracle.runtimeSessions.size,
       coverage: oracle.coverageCount,
     },
     skipped = skippedCounts(skips),
@@ -539,6 +574,9 @@ export async function runSingleMigrationImport(
       decision: reconciliation.decision.target,
       fact: reconciliation.fact.target,
       relation: reconciliation.relation.target,
+      agent: reconciliation.agent.target,
+      schedule: reconciliation.schedule.target,
+      "runtime-session": reconciliation["runtime-session"].target,
       coverage: preservedCoverage,
     },
     contractRestatements = {
@@ -556,6 +594,9 @@ export async function runSingleMigrationImport(
         decision: Object.fromEntries(decisionMap),
         fact: Object.fromEntries(factMap),
         relation: Object.fromEntries(relationMap),
+        agent: Object.fromEntries(agentMap),
+        schedule: Object.fromEntries(scheduleMap),
+        "runtime-session": Object.fromEntries(runtimeSessionMap),
       },
       remappings,
       skipped: [...skips].sort(bySkip),
@@ -585,6 +626,39 @@ export async function runSingleMigrationImport(
     input.store.readEvent(mapPrepared.event.opId) === null
   ) {
     prepared.push(mapPrepared);
+    revision += 1;
+  }
+  const backfillMapPath = `migrations/${importId}/entity-backfill.json`,
+    backfillMapBody = `${stableStringify({
+      schema: "migration-entity-backfill-map/v1",
+      importId,
+      source: sourceRoot,
+      sourceGit,
+      generatedAt: input.now(),
+      rows: backfillRows,
+      maps: {
+        agent: Object.fromEntries(agentMap),
+        schedule: Object.fromEntries(scheduleMap),
+        "runtime-session": Object.fromEntries(runtimeSessionMap),
+      },
+    })}\n`,
+    backfillMapPrepared = prepare(
+      sourceKey,
+      actor,
+      "entity-backfill-map",
+      importId,
+      input.now(),
+      revision + 1,
+      {
+        kind: "repo-document",
+        nodeKind: "file",
+        documentClaim: claim(backfillMapPath, backfillMapBody, "application/json"),
+        referencedContentClaims: [],
+      },
+      [blob(backfillMapBody, "application/json")],
+    );
+  if (input.store.readEvent(backfillMapPrepared.event.opId) === null) {
+    prepared.push(backfillMapPrepared);
     revision += 1;
   }
   // The WAL is authoritative for each append. Migration defers worktree/Git
@@ -642,16 +716,20 @@ export async function runSingleMigrationImport(
       fieldDerivations,
       dispositions,
       oracle.formatObservations,
+      backfillRows,
+      backfillMapPath,
     ),
-    publishedMap = dryRun ? null : input.store.readEvent(mapPrepared.event.opId),
+    publicationMarker = backfillMapPrepared,
+    publishedMap = dryRun ? null : input.store.readEvent(publicationMarker.event.opId),
     publication = publishedMap ? input.store.publication(publishedMap) : null,
     canonicalVisible =
-      publication?.cut.opId === mapPrepared.event.opId && publication.cut.revision === publishedMap?.workspaceRevision,
+      publication?.cut.opId === publicationMarker.event.opId &&
+      publication.cut.revision === publishedMap?.workspaceRevision,
     outcome =
       exitCode === 1 ? ("op_rejected" as const) : canonicalVisible ? ("applied" as const) : ("pending" as const);
   return {
     outcome,
-    opId: mapPrepared.event.opId,
+    opId: publicationMarker.event.opId,
     revision: writesAllowed ? revision : initialRevision,
     evidence: JSON.stringify({
       importId,
@@ -665,6 +743,8 @@ export async function runSingleMigrationImport(
       reconciliation,
       fieldDerivations,
       dispositions,
+      backfillRows,
+      backfillMapPath,
       formatObservations: oracle.formatObservations,
     }),
     visibility: "center",
@@ -688,6 +768,8 @@ export async function runSingleMigrationImport(
     authoredCoverage,
     skippedEntities: [...skips].sort(bySkip),
     idMapPath: writesAllowed ? idMapPath : null,
+    backfillMapPath: writesAllowed ? backfillMapPath : null,
+    backfillRows: [...backfillRows],
     ...(exitCode === 1
       ? {
           code: "migration_reconciliation_failed",
@@ -699,7 +781,7 @@ export async function runSingleMigrationImport(
         ? {
             nextAction: dryRun
               ? "Remove --dry-run to publish this reconciled migration plan."
-              : `Query receipt ${mapPrepared.event.opId}; the canonical import-map publication is missing.`,
+              : `Query receipt ${publicationMarker.event.opId}; the canonical import-map publication is missing.`,
           }
         : {
             nextAction: "Migration reconciliation passed; rerunning or appending another --source is safe.",

--- a/packages/daemon/src/migration-import-source.ts
+++ b/packages/daemon/src/migration-import-source.ts
@@ -138,10 +138,9 @@ export function combineMigrationReceipts(
   if (!last) throw migrationImportError("invalid_command", "migrate import requires at least one --source.");
   const sum = (select: (receipt: MigrationImportReceipt) => ImportCounts): ImportCounts =>
       Object.fromEntries(
-        (["task", "decision", "fact", "relation", "coverage"] as const).map((kind) => [
-          kind,
-          receipts.reduce((total, receipt) => total + select(receipt)[kind], 0),
-        ]),
+        (["task", "decision", "fact", "relation", "agent", "schedule", "runtime-session", "coverage"] as const).map(
+          (kind) => [kind, receipts.reduce((total, receipt) => total + select(receipt)[kind], 0)],
+        ),
       ) as unknown as ImportCounts,
     counts = {
       old: sum((receipt) => receipt.counts.old),
@@ -224,6 +223,8 @@ export function combineMigrationReceipts(
     authoredCoverage,
     skippedEntities: receipts.flatMap(({ skippedEntities }) => skippedEntities),
     idMapPath: last.idMapPath,
+    backfillMapPath: last.backfillMapPath,
+    backfillRows: receipts.flatMap(({ backfillRows }) => backfillRows),
     ...(exitCode === 1
       ? {
           code: "migration_reconciliation_failed",

--- a/packages/daemon/src/migration-import-tasks.ts
+++ b/packages/daemon/src/migration-import-tasks.ts
@@ -429,6 +429,15 @@ export function addTaskPackage(context: MigrationImportContext, entry: TaskSourc
 
 export function addRepoDocuments(context: MigrationImportContext): void {
   for (const source of context.authoredEntries) {
+    const agent = /^agents\/([^/]+)\.json$/u.exec(source.path),
+      schedule = /^schedules\/([^/]+)\.json$/u.exec(source.path);
+    // Native entity events below own these paths. A generic repo-document
+    // event would make a fresh import depend on event ordering for final bytes.
+    if (
+      (agent?.[1] !== undefined && context.oracle.agents.has(agent[1])) ||
+      (schedule?.[1] !== undefined && context.oracle.schedules.has(schedule[1]))
+    )
+      continue;
     const classification = context.resolveAuthoredConflict(
       context.classifyAuthored(
         context.sourceLayout.authoredRoot,

--- a/packages/daemon/src/migration-import-types.ts
+++ b/packages/daemon/src/migration-import-types.ts
@@ -7,7 +7,15 @@ import {
 import type { TaskContractRestatementCounts } from "./migration-import-task-restatement.ts";
 import type { MigrationOracleKind } from "./migration-import-oracle.ts";
 
-export type EntityKind = "task" | "decision" | "fact" | "relation" | "coverage";
+export type EntityKind =
+  | "task"
+  | "decision"
+  | "fact"
+  | "relation"
+  | "agent"
+  | "schedule"
+  | "runtime-session"
+  | "coverage";
 
 export interface Skip {
   readonly entityType: EntityKind;
@@ -77,7 +85,17 @@ export interface ImportCounts {
   readonly decision: number;
   readonly fact: number;
   readonly relation: number;
+  readonly agent: number;
+  readonly schedule: number;
+  readonly "runtime-session": number;
   readonly coverage: number;
+}
+
+export interface MigrationBackfillRow {
+  readonly entityType: "agent" | "schedule" | "runtime-session";
+  readonly entityId: string;
+  readonly action: "create" | "unchanged" | "conflict";
+  readonly sourceAnchor: string;
 }
 
 export type AuthoredDisposition = "migrated" | "excluded" | "required";
@@ -147,6 +165,8 @@ export type MigrationImportReceipt = WriteReceipt & {
   readonly authoredCoverage: AuthoredCoverage;
   readonly skippedEntities: readonly Skip[];
   readonly idMapPath: string | null;
+  readonly backfillMapPath: string | null;
+  readonly backfillRows: readonly MigrationBackfillRow[];
 };
 
 export type ImportedTask = Extract<MigrationImportEventV1["payload"]["entity"], { readonly kind: "task" }>["task"];

--- a/packages/daemon/test/migration-import-replay-records.integration.test.ts
+++ b/packages/daemon/test/migration-import-replay-records.integration.test.ts
@@ -2,6 +2,7 @@
 import assert from "node:assert/strict";
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
+import { DatabaseSync } from "node:sqlite";
 import path from "node:path";
 import test from "node:test";
 import {
@@ -325,6 +326,255 @@ test("re-importing a source is an incremental no-op instead of a hard rejection"
     rmSync(scratch, { recursive: true, force: true });
   }
 });
+
+test("migration backfills agents, schedules, and runtime sessions with a source-anchored idempotent diff", async () => {
+  const scratch = mkdtempSync(path.join(tmpdir(), "ha-migrate-entity-backfill-")),
+    source = path.join(scratch, "legacy"),
+    destination = path.join(scratch, "new"),
+    fixture = entityBackfillSource(source),
+    sourceRoots = sources(source);
+  seedEntityBackfillProjection(source, fixture);
+  let cell: Awaited<ReturnType<typeof openRepoCell>> | undefined;
+  try {
+    initRepo(destination);
+    cell = await openRepoCell({
+      repoId: workspaceId("migration-entity-backfill-target"),
+      rootDir: canonicalRoot(destination),
+      ownerId: "migration-daemon",
+      now: () => "2026-08-30T00:00:00.000Z",
+    });
+    const store = makeTaskEventStore({ repoId: "migration-entity-backfill-target", rootDir: destination }),
+      revisionBefore = store.read().revision,
+      dry = (await cell.run(
+        { kind: "migrate-import", sourceRoots, dryRun: true },
+        { actor, source: "local" },
+      )) as Record<string, unknown>;
+    assert.equal(dry.exitCode, 0, JSON.stringify(dry));
+    assert.equal(store.read().revision, revisionBefore, "dry-run must not mutate the destination ledger");
+    assert.match(String(dry.summary), /\| agent \| backfill-agent \| create \| agents\/backfill-agent\.json \|/u);
+    assert.match(String(dry.summary), /\| schedule \| backfill-schedule \| create \| event:fixture-schedule \|/u);
+    assert.match(
+      String(dry.summary),
+      /\| runtime-session \| runtime_backfill \| create \| event:fixture-runtime-outcome \|/u,
+    );
+
+    const first = (await cell.run({ kind: "migrate-import", sourceRoots }, { actor, source: "local" })) as Record<
+      string,
+      unknown
+    >;
+    assert.equal(first.exitCode, 0, JSON.stringify(first));
+    assert.match(String(first.backfillMapPath), /^migrations\/import_[0-9a-f_]+\/entity-backfill\.json$/u);
+    const projection = new DatabaseSync(path.join(destination, ".harness/cache/task.sqlite"), { readOnly: true });
+    try {
+      const entity = projection
+          .prepare(
+            "SELECT entity_kind, entity_id, value_json FROM entity_projection WHERE entity_kind IN ('agent', 'schedule') ORDER BY entity_kind",
+          )
+          .all() as readonly {
+          readonly entity_kind: string;
+          readonly entity_id: string;
+          readonly value_json: string;
+        }[],
+        runtime = projection
+          .prepare("SELECT value_json FROM runtime_session WHERE runtime_session_id='runtime_backfill'")
+          .get() as { readonly value_json: string };
+      assert.deepEqual(
+        entity.map(({ entity_kind, entity_id }) => [entity_kind, entity_id]),
+        [
+          ["agent", "backfill-agent"],
+          ["schedule", "backfill-schedule"],
+        ],
+      );
+      assert.deepEqual(JSON.parse(entity[0]!.value_json), fixture.agent);
+      assert.deepEqual(JSON.parse(entity[1]!.value_json), fixture.schedule);
+      assert.deepEqual(JSON.parse(runtime.value_json), fixture.runtimeSession);
+    } finally {
+      projection.close();
+    }
+    assert.equal(readFileSync(path.join(destination, "harness/agents/backfill-agent.json"), "utf8"), fixture.agentBody);
+    assert.equal(
+      readFileSync(path.join(destination, "harness/schedules/backfill-schedule.json"), "utf8"),
+      fixture.scheduleBody,
+    );
+    const appliedStore = makeTaskEventStore({ repoId: "migration-entity-backfill-target", rootDir: destination });
+    assert.equal(
+      Buffer.from(appliedStore.readContentBlob(fixture.resultHash) ?? []).toString("utf8"),
+      fixture.resultBody,
+    );
+    const firstRevision = appliedStore.read().revision,
+      firstEventCount = appliedStore.read().events.length,
+      second = (await cell.run({ kind: "migrate-import", sourceRoots }, { actor, source: "local" })) as Record<
+        string,
+        unknown
+      >;
+    assert.equal(second.exitCode, 0, JSON.stringify(second));
+    const rerunStore = makeTaskEventStore({ repoId: "migration-entity-backfill-target", rootDir: destination });
+    assert.equal(rerunStore.read().revision, firstRevision);
+    assert.equal(rerunStore.read().events.length, firstEventCount);
+    assert.match(String(second.summary), /agent=1, schedule=1, runtime-session=1/u);
+  } finally {
+    await cell?.close();
+    rmSync(scratch, { recursive: true, force: true });
+  }
+});
+
+function entityBackfillSource(root: string) {
+  coverageCompleteFixture(root);
+  const resultBody = "migration entity backfill result",
+    resultHash = sha256Text(resultBody),
+    agent = {
+      schema: "agent-declaration/v1",
+      id: "backfill-agent",
+      name: "Backfill Agent",
+      instructions: "Preserve the source projection and report migration evidence precisely.",
+      runtime_type: "codex",
+      role: "worker",
+      model: "gpt-5.6-terra",
+      skills: [],
+    },
+    schedule = {
+      schema: "schedule/v1",
+      scheduleId: "backfill-schedule",
+      name: "Backfill schedule",
+      state: "armed",
+      mode: "detect",
+      spec: {
+        trigger: {
+          kind: "interval",
+          everyMs: 300_000,
+          anchorAt: "2026-08-29T00:00:00.000Z",
+        },
+        target: {
+          kind: "agent",
+          agentId: "backfill-agent",
+          runtimeInstanceId: "codex-default",
+        },
+        mission: "Inspect the migration projection without changing source history.",
+      },
+      createdAt: "2026-08-29T00:00:00.000Z",
+      createdBy: actor,
+      updatedAt: "2026-08-29T00:00:00.000Z",
+      status: {
+        automaticEvaluatedThrough: "2026-08-29T00:00:00.000Z",
+        activeRun: null,
+        lastRun: null,
+        missedCount: 0,
+        lastMissedAt: null,
+        lastMissedReason: null,
+      },
+    },
+    runtimeSession = {
+      runtimeSessionId: "runtime_backfill",
+      instanceId: "codex-default",
+      installationId: "installation-codex",
+      kindId: "codex",
+      definitionSnapshotRef: "artifact:runtime-definition/backfill",
+      providerSessionId: "provider-backfill",
+      transcriptRef: "file:runtime-transcripts/backfill.jsonl",
+      launchGeneration: 1,
+      liveness: "exited",
+      attachable: false,
+      taskBindings: [
+        {
+          taskId: "task_coverage",
+          executionId: "exe_history",
+          providerSessionId: "provider-backfill",
+          transcriptRef: "file:runtime-transcripts/backfill.jsonl",
+          boundAt: "2026-08-29T00:00:01.000Z",
+        },
+      ],
+      outcome: "succeeded",
+      exitCode: 0,
+      resultRef: `artifact:runtime-result/sha256/${resultHash}`,
+      lastObservedAt: "2026-08-29T00:00:02.000Z",
+    },
+    agentBody = `${JSON.stringify(agent, null, 2)}\n`,
+    scheduleBody = `${JSON.stringify({ ...schedule, status: undefined }, null, 2)}\n`,
+    objectRoot = path.join(root, `harness/objects/sha256/${resultHash.slice(0, 2)}`);
+  mkdirSync(path.join(root, "harness/agents"), { recursive: true });
+  mkdirSync(path.join(root, "harness/schedules"), { recursive: true });
+  mkdirSync(objectRoot, { recursive: true });
+  writeFileSync(path.join(root, "harness/agents/backfill-agent.json"), agentBody);
+  writeFileSync(path.join(root, "harness/schedules/backfill-schedule.json"), scheduleBody);
+  writeFileSync(path.join(objectRoot, resultHash.slice(2)), resultBody);
+  return { agent, schedule, runtimeSession, resultBody, resultHash, agentBody, scheduleBody } as const;
+}
+
+function seedEntityBackfillProjection(root: string, fixture: ReturnType<typeof entityBackfillSource>): void {
+  const database = new DatabaseSync(path.join(root, ".harness/cache/task.sqlite"));
+  try {
+    const current = database.prepare("SELECT MAX(workspace_revision) AS revision FROM event_index").get() as {
+        readonly revision: number;
+      },
+      agentRevision = current.revision + 1,
+      scheduleRevision = agentRevision + 1,
+      startedRevision = scheduleRevision + 1,
+      outcomeRevision = startedRevision + 1,
+      insertEvent = database.prepare("INSERT INTO event_index VALUES (?, ?, NULL, ?)");
+    database
+      .prepare("INSERT INTO entity_projection VALUES ('agent', 'backfill-agent', ?, ?)")
+      .run(agentRevision, JSON.stringify(fixture.agent));
+    database
+      .prepare("INSERT INTO entity_projection VALUES ('schedule', 'backfill-schedule', ?, ?)")
+      .run(scheduleRevision, JSON.stringify(fixture.schedule));
+    database
+      .prepare("INSERT INTO runtime_session VALUES ('runtime_backfill', ?, ?)")
+      .run(outcomeRevision, JSON.stringify(fixture.runtimeSession));
+    insertEvent.run(
+      "fixture-agent",
+      agentRevision,
+      JSON.stringify({
+        schema: "entity-event/v1",
+        eventId: "fixture-agent",
+        occurredAt: "2026-08-29T00:00:00.000Z",
+        payload: { entityKind: "agent", entityId: "backfill-agent" },
+      }),
+    );
+    insertEvent.run(
+      "fixture-schedule",
+      scheduleRevision,
+      JSON.stringify({
+        schema: "schedule-event/v1",
+        eventId: "fixture-schedule",
+        occurredAt: "2026-08-29T00:00:00.000Z",
+        entity: { kind: "schedule", id: "backfill-schedule" },
+        payload: {},
+      }),
+    );
+    insertEvent.run(
+      "fixture-runtime-started",
+      startedRevision,
+      JSON.stringify({
+        schema: "agent-runtime-event/v1",
+        eventId: "fixture-runtime-started",
+        type: "runtime_session_started",
+        occurredAt: "2026-08-29T00:00:00.000Z",
+        payload: { runtimeSessionId: "runtime_backfill" },
+      }),
+    );
+    insertEvent.run(
+      "fixture-runtime-outcome",
+      outcomeRevision,
+      JSON.stringify({
+        schema: "agent-runtime-event/v1",
+        eventId: "fixture-runtime-outcome",
+        type: "runtime_session_outcome_observed",
+        occurredAt: fixture.runtimeSession.lastObservedAt,
+        payload: {
+          runtimeSessionId: "runtime_backfill",
+          result: {
+            sha256: fixture.resultHash,
+            size: Buffer.byteLength(fixture.resultBody),
+            mediaType: "text/plain; charset=utf-8",
+          },
+        },
+      }),
+    );
+    database.prepare("UPDATE projection_meta SET watermark=? WHERE singleton=1").run(outcomeRevision);
+  } finally {
+    database.close();
+  }
+}
 
 test("migration adopts the source contract digest and rewrites the contract package path", async () => {
   const scratch = mkdtempSync(path.join(tmpdir(), "ha-migrate-contract-")),

--- a/tools/gate-allowlists/check-kernel-dead-exports.json
+++ b/tools/gate-allowlists/check-kernel-dead-exports.json
@@ -100,12 +100,6 @@
         "until": "2026-09-30"
       },
       {
-        "value": "compileScheduleDefinitionEvent",
-        "ref": "task_8c0e974b7c612ace414f92ab56",
-        "reason": "Schedule tier-2 entity-ization: GUI service-bridge integration test seeds canonical schedule definitions; production schedule ingress derives these events from entity actions.",
-        "until": "2026-09-30"
-      },
-      {
         "value": "compileScheduleRunEvent",
         "ref": "task_8c0e974b7c612ace414f92ab56",
         "reason": "Schedule tier-2 entity-ization: daemon schedule-runs read test seeds canonical run events; production schedule ingress derives these events from entity actions.",


### PR DESCRIPTION
# English

## Summary

The legacy-to-canonical migration importer only carried task/decision-centric families; agent declarations, schedules, and runtime sessions were dropped, which surfaced in the GUI as "sessions, schedules, and agents are gone after migration". This PR teaches migration import to backfill the three missing entity families — 33 agents, 2 schedules, and 1,085 runtime sessions in the pinned source — through the native write routes, with row-level dry-run difference tables, deterministic operation IDs, fail-closed conflict detection, and idempotent re-apply. No production ledger write happens in this PR; the actual canonical apply is a separately gated operator procedure (backup tag → dry-run table → explicit approval).

## Architectural Justification

- The importer's oracle/reconciliation/report pipeline enumerated only the families it knew; the three missing families require family-specific compilation (agent declarations from authored JSON, schedules from the same-cut `schedule/v1` projection, runtime sessions as a minimal native event sequence preserving identity, bindings, liveness, and terminal outcome with byte-exact CAS result claims). That logic cannot be carried by the existing generic repo-document pass — that pass is exactly what dropped them, and agents/schedules are now excluded from it to avoid two writers for one authored path.
- The new `migration-import-backfill.ts` module holds the family compilation in one place; the remaining churn is the oracle/report/reconciliation surfaces learning the three families. Old behavior (silently omitting the families) is the deleted path; no compatibility shim or second import channel is added, and re-running the importer is a no-op by deterministic operation IDs.
- Scope cannot be narrowed: recovering fewer families leaves the reported data loss in place, and inventing rows instead of anchoring each to a source event/CAS object would trade correctness for size.

## What Changed

- New `packages/daemon/src/migration-import-backfill.ts`: family compilation for agent/schedule/runtime-session, row-level differences, and `migrations/<import-id>/entity-backfill.json` planning.
- Oracle, counts, reconciliation, ID maps, reports, and run wiring now include the three families; native agent/schedule paths are excluded from the generic repo-document pass.
- Runtime result claims must match a source CAS object byte-for-byte; missing or corrupt results fail that row instead of inventing content. Equal destination values are `unchanged`; unequal occupied IDs are `conflict` and fail reconciliation without writes.
- Integration test `migration-import-replay-records.integration.test.ts` covers one old-form source row per family, dry-run differences, native projection visibility, exact CAS preservation, and no-op rerun.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: use the single CI-backed `Production-Delta` declaration below; do not enter a second metric.

## Machine-Readable Declarations

Production-Delta: +786/-24

## Task And Scope

- Harness task: task_44d5009 (private ledger)
- Branch: codex/migration-backfill
- Public scope: daemon migration-import pipeline and its integration test
- Private planning/evidence updated: yes
- Out of scope: the production canonical apply itself (operator runbook, separately gated), manual-65 task contract disposition (dependent follow-up task)

## Version Impact

- Version: no version change because this is a migration-repair capability within the unreleased milestone line
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: yes
- Protected surface scope: tools/gate-allowlists/check-kernel-dead-exports.json (one stale entry removed: `compileScheduleDefinitionEvent` now has a production consumer in the backfill module, so the zero-consumption allowlist entry is obsolete; allowlist count 243 → 242)
- Authority: task_44d5009838e66ef1dcb7c6c3b3
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason:
- Break-glass scope:
- Follow-up governance task:

## Verification

- Base `origin/main` SHA: c0a35e2c9d8b52893badaf0b99340637eebae1b1
- Branch merge-base with `origin/main`: 718a22b55b048eb93a6809be0a05ef036c0c973a
- Last `git fetch origin` time: 2026-08-31 evening
- Sync method: none needed (no overlapping files with commits after the merge-base)
- Public diff command: git diff origin/main..codex/migration-backfill
- Private evidence commit/path: private ledger task_44d5009 (fact F-288E344C, backfill-report, source-inventory)
- Reviewer evidence path: see Review Evidence
- GitHub Actions `rewrite-ci` run URL: pending (PR checks)
- [x] `npm run typecheck`
- [x] lint
- [x] Targeted integration: migration-import-replay-records 7/7 pass (Node 24)
- [x] `npm run harness:check-write-road-registry`, `check-integration-test-shards`, `check-import-boundaries`, `check-file-complexity`
- Not run: full local check suites — worker/local stop-point policy; GitHub CI is the complete authority for this PR.

## Review Evidence

- Self-review: CEO semantic acceptance against the reported data loss (three families recoverable, source-anchored, fail-closed conflicts, idempotent; no canonical write in this PR).
- Reviewer subagent: implementing agent's regression evidence plus CEO review (single-reviewer budget)
- Human review: requested via this PR
- Blocking findings: none

## Residual Risk

- The production apply is a separate operator step: backup tag → fresh dry-run row table → explicit approval → single apply → idempotency re-check. The inventory-cut destination counts must be refreshed at approval time because the destination is live.
- An isolated empty-destination probe surfaced an unrelated legacy `supports` relation admission error; the repair target (existing migrated canonical cut) is unaffected, and that probe wrote nothing.

## References

- Task: task_44d5009 (private ledger)
- Evidence: fact F-288E344C (private ledger)
- Review: this PR body

---

# 中文

## 概要

legacy→canonical 迁移导入器此前只搬 task/decision 系实体;agent 声明、schedule、runtime session 三族被整体丢弃——GUI 上表现为「迁移后会话/定时计划/Agent 全没了」。本 PR 让迁移导入具备三族回填能力:钉住的源里可恢复 33 个 agent、2 个 schedule、1,085 个 runtime session,全部走原生写路,带行级 dry-run 差异表、确定性操作 ID、fail-closed 冲突检测与幂等重放。本 PR 不写生产台账;真实 canonical 回填是独立门控的操作流程(备份 tag → dry-run 差异表 → 明确批准)。

## 架构辩护

- 导入器的 oracle/对账/报告流水线只枚举它认识的实体族;缺失三族各需族专属编译(agent 以 authored JSON 声明为权威、schedule 取同 cut `schedule/v1` 投影、runtime session 重建为保身份/绑定/liveness/终态的最小原生事件序列,结果 blob 按 CAS 逐字节校验)。这无法由既有通用 repo-document 通道承载——当初正是该通道把它们丢掉的;本 PR 反而把 agent/schedule 原生路径从该通道排除,避免同一 authored 路径两个写者。
- 新增 `migration-import-backfill.ts` 把族编译收拢一处;其余增量是 oracle/报告/对账面认识三族。被删除的旧行为就是「静默丢弃三族」;不加兼容层、不开第二条导入通道,重放靠确定性操作 ID 天然 no-op。
- 范围无法收窄:少恢复任何一族=数据丢失原样保留;不锚定源事件/CAS 而凭空造行=用正确性换体积。

## 改动内容

- 新增 `packages/daemon/src/migration-import-backfill.ts`:三族编译、行级差异、`migrations/<import-id>/entity-backfill.json` 规划。
- oracle、计数、对账、ID map、报告与 run 接线纳入三族;agent/schedule 原生路径从通用 repo-document 通道排除。
- runtime 结果声明须与源 CAS 对象逐字节一致,缺失/损坏即该行失败而非造内容;目的地等值为 `unchanged`,占用不等为 `conflict` 且对账失败零写入。
- 集成测试覆盖每族一条旧形态源行、dry-run 差异、原生投影可见性、CAS 精确保真与重放 no-op。

## 门收割 / Gate Harvest

- 删除的生产路径:none
- 同 commit 删除的门 / fixture:none
- 生产净行数:引用英文块中的 `Production-Delta`;该值由 production-delta job 计算,不要手填第二份数字。

## 机读声明说明

- 机读声明只在英文块出现一次,见英文块 `Production-Delta: +786/-24`。

## 任务与范围

- Harness 任务:task_44d5009(私有台账)
- 分支:codex/migration-backfill
- 公开范围:daemon 迁移导入流水线及其集成测试
- 私有计划 / 证据是否已更新:yes
- 范围外:生产 canonical 真实回填(操作 runbook,独立门控)、manual-65 契约处置(依赖本 PR 的后续任务)

## 版本影响

- 版本:不改版本,原因是本 PR 是未发布里程碑线内的迁移修复能力
- 发布影响:不发布

## 治理声明

- 是否触碰 protected surface:yes
- protected surface 范围:tools/gate-allowlists/check-kernel-dead-exports.json(删除一条 stale 条目:`compileScheduleDefinitionEvent` 已被 backfill 模块生产消费,零消费白名单条目失效;白名单计数 243 → 242)
- 依据:task_44d5009838e66ef1dcb7c6c3b3
- 机器检查边界:本 PR 只声明该段存在;声明是否真实、充分,由 reviewer 判断。
- Break-glass:no
- Break-glass 原因:
- Break-glass 范围:
- 后续治理任务:

## 验证

- `origin/main` 基准 SHA:c0a35e2c9d8b52893badaf0b99340637eebae1b1
- 当前分支与 `origin/main` 的 merge-base:718a22b55b048eb93a6809be0a05ef036c0c973a
- 最近一次 `git fetch origin` 时间:2026-08-31 晚间
- 同步方式:不需要(与 merge-base 之后的提交无文件重叠)
- 公开 diff 命令:git diff origin/main..codex/migration-backfill
- 私有证据 commit/path:私有台账 task_44d5009(fact F-288E344C、backfill-report、source-inventory)
- Reviewer 证据路径:见审查证据
- GitHub Actions `rewrite-ci` run URL:待 PR checks
- [x] `npm run typecheck`
- [x] lint
- [x] 定向集成:migration-import-replay-records 7/7 通过(Node 24)
- [x] `npm run harness:check-write-road-registry`、`check-integration-test-shards`、`check-import-boundaries`、`check-file-complexity`
- 未运行:完整本地 check 套件——按 worker/本地停止点纪律,GitHub CI 是本 PR 的完整权威。

## 审查证据

- 自查:CEO 对照数据丢失报告做语义验收(三族可恢复、源锚定、冲突 fail-closed、幂等;本 PR 零 canonical 写入)。
- Reviewer subagent:实现 agent 自带回归证据 + CEO 复核(单评审员预算)
- 人工审查:经本 PR 请求
- 阻塞发现:none

## 残余风险

- 生产回填是独立操作步骤:备份 tag → 新鲜 dry-run 行表 → 明确批准 → 单次 apply → 幂等复核;目的地在线,批准时必须刷新目的地计数。
- 空目的地隔离探测撞到一个无关的 legacy `supports` 关系准入错误;修复目标(既有已迁移 canonical cut)不受影响,该探测零写入。

## 关联材料

- 任务:task_44d5009(私有台账)
- 证据:fact F-288E344C(私有台账)
- 审查:本 PR 正文

---

## PR Gate Checklist / PR 门禁清单

- [x] Branch is based on latest `origin/main`. / 分支基于最新 `origin/main`。
- [x] PR body uses this full template structure. / PR 描述使用本模板完整结构。
- [x] PR body uses two complete language blocks: `# English` first, then `# 中文`. / PR 正文使用两块完整正文:`# English` 在上,`# 中文` 在下。
- [x] PR body passes `tools/check-pr-body-bilingual.mjs`. / PR 正文通过 `tools/check-pr-body-bilingual.mjs`。
- [x] If the PR touches a manifest-derived protected surface, Governance Declaration is filled with ADR/decision/task evidence or break-glass fields. / 若 PR 触碰 manifest 派生的 protected surface,Governance Declaration 已填写 ADR/decision/task 依据或 break-glass 字段。
- [x] No private harness files are included. / 不包含私有 harness 文件。
- [x] No ignored local agent entry files are included. / 不包含被忽略的本地 agent 入口文件。
- [x] No absolute local filesystem paths are included in this public PR body. / 本公开 PR 描述不包含本机绝对路径。
- [x] Public diff is limited to the stated task scope. / 公开 diff 限于声明的任务范围。
- [x] Private planning/evidence updates are recorded when applicable. / 适用时已记录私有计划 / 证据更新。
- [x] Version and publish impact are stated. / 已说明版本与发布影响。
- [x] Local verification commands are recorded honestly. / 已如实记录本地验证命令。
- [x] CI results are linked or explained. / CI 结果已链接或说明。
- [x] Review evidence is recorded. / 已记录审查证据。
- [x] Open P0/P1/P2 findings are closed, deferred with owner, or explicitly blocked. / open P0/P1/P2 findings 已关闭、带 owner 延后,或明确阻塞。
- [x] Merge method and post-merge branch cleanup plan are clear. / 合并方式和合并后分支清理计划清楚。
- [x] No admin bypass is planned unless explicitly approved and recorded. / 除非明确批准并记录,否则不计划 admin bypass。
