### PR TITLE
fix(daemon): deterministic disposition for 65 manual migration rows

### DIFF
--- a/packages/daemon/src/migration-import-task-restatement.ts
+++ b/packages/daemon/src/migration-import-task-restatement.ts
@@ -192,7 +192,7 @@ function compileContractForRestatement(
     return { contract: compileContract(sourceRoot, taskId, metadata), metadata };
   } catch (error) {
     const code = codedError(error),
-      presetId = optionalText(metadata.presetId);
+      presetId = optionalTrimmedText(metadata.presetId);
     if (code === "preset_not_found" && presetId && retiredTaskPresetIds.has(presetId)) {
       const repaired = { ...metadata, presetId: "standard-task", taskClass: "standard" as const };
       return {
@@ -247,7 +247,7 @@ function codedError(error: unknown): string | null {
     : null;
 }
 
-function optionalText(value: unknown): string | null {
+function optionalTrimmedText(value: unknown): string | null {
   return typeof value === "string" && value.trim() ? value : null;
 }
 

--- a/packages/daemon/src/migration-import-task-restatement.ts
+++ b/packages/daemon/src/migration-import-task-restatement.ts
@@ -11,7 +11,9 @@ import {
   validateTaskBootstrapEvent,
   validateTaskEvent,
   validateTaskV2,
+  taskClasses,
   type PersistedCanonicalEventV1,
+  type TaskClass,
   type TaskV2,
 } from "../../kernel/src/index.ts";
 import { compileRepoTaskPackage } from "../../preset/src/index.ts";
@@ -47,6 +49,11 @@ export interface RestatedTaskContract {
   readonly body: string;
   readonly presetSnapshotDigest: `sha256:${string}`;
   readonly source: "contract" | "compiled";
+  readonly repair?: {
+    readonly disposition: "retired-preset-to-standard-task" | "preset-task-class-aligned";
+    readonly presetId: string;
+    readonly taskClass: TaskClass;
+  };
 }
 
 export interface TaskContractCompileFallback {
@@ -58,6 +65,16 @@ export interface TaskContractCompileFallback {
   readonly locale?: unknown;
   readonly slug?: unknown;
 }
+
+const retiredTaskPresetIds = new Set([
+  "doc-canon-sync",
+  "gate-architecture-retrospective",
+  "idea-to-ship",
+  "long-running-task",
+  "milestone-dossier",
+  "progress-site",
+  "usage-acceptance",
+]);
 
 /** Restates the machine contract into its migrated package and derives the immutable preset digest when needed. */
 export function restateTaskContract(input: {
@@ -86,12 +103,13 @@ export function compileRestatedTaskContract(input: {
   readonly targetPackagePath: string;
   readonly fallback: TaskContractCompileFallback;
 }): RestatedTaskContract {
-  const compiled = compileContract(input.sourceRoot, input.targetTaskId, input.fallback),
-    document = compiled.documents.find(({ slot }) => slot === "task.contract");
+  const compiled = compileContractForRestatement(input.sourceRoot, input.targetTaskId, input.fallback),
+    document = compiled.contract.documents.find(({ slot }) => slot === "task.contract");
   if (!document) throw new Error(`${input.sourcePath}: compiled task package has no task.contract document`);
   return {
     ...restateTaskContractBody({ ...input, body: document.body }),
     source: "compiled",
+    ...(compiled.repair ? { repair: compiled.repair } : {}),
   };
 }
 
@@ -114,15 +132,20 @@ export function restateTaskContractBody(input: {
   const declaredDigest = contract.presetSnapshotDigest;
   if (declaredDigest !== undefined && declaredDigest !== null && !presetDigest(declaredDigest))
     throw new Error(`${input.sourcePath}: presetSnapshotDigest is not SHA-256`);
-  const metadata = contractCompileMetadata(contract, input.fallback),
-    settings = readSettingsFacet(
-      readFileSync(path.join(resolveHarnessLayout(input.sourceRoot).authoredRoot, "harness.yaml"), "utf8"),
-    );
+  let metadata = contractCompileMetadata(contract, input.fallback);
+  const settings = readSettingsFacet(
+    readFileSync(path.join(resolveHarnessLayout(input.sourceRoot).authoredRoot, "harness.yaml"), "utf8"),
+  );
   let digest = presetDigest(declaredDigest) ? declaredDigest : null,
-    source: RestatedTaskContract["source"] = "contract";
+    source: RestatedTaskContract["source"] = "contract",
+    repair: RestatedTaskContract["repair"];
   if (digest === null) {
     try {
-      digest = compileContract(input.sourceRoot, input.targetTaskId, metadata).snapshot.digest;
+      const compiled = compileContractForRestatement(input.sourceRoot, input.targetTaskId, metadata);
+      digest = compiled.contract.snapshot.digest;
+      metadata = compiled.metadata;
+      repair = compiled.repair;
+      if (repair) contract = compiledContractDocument(compiled.contract, input.sourcePath);
       source = "compiled";
     } catch (error) {
       throw new Error(`${input.sourcePath}: cannot derive presetSnapshotDigest from task contract metadata`, {
@@ -133,6 +156,7 @@ export function restateTaskContractBody(input: {
   return {
     presetSnapshotDigest: digest,
     source,
+    ...(repair ? { repair } : {}),
     body: `${JSON.stringify(
       {
         ...contract,
@@ -153,6 +177,78 @@ export function restateTaskContractBody(input: {
       2,
     )}\n`,
   };
+}
+
+function compileContractForRestatement(
+  sourceRoot: string,
+  taskId: string,
+  metadata: TaskContractCompileFallback,
+): {
+  readonly contract: ReturnType<typeof compileContract>;
+  readonly metadata: TaskContractCompileFallback;
+  readonly repair?: RestatedTaskContract["repair"];
+} {
+  try {
+    return { contract: compileContract(sourceRoot, taskId, metadata), metadata };
+  } catch (error) {
+    const code = codedError(error),
+      presetId = optionalText(metadata.presetId);
+    if (code === "preset_not_found" && presetId && retiredTaskPresetIds.has(presetId)) {
+      const repaired = { ...metadata, presetId: "standard-task", taskClass: "standard" as const };
+      return {
+        contract: compileContract(sourceRoot, taskId, repaired),
+        metadata: repaired,
+        repair: {
+          disposition: "retired-preset-to-standard-task",
+          presetId: "standard-task",
+          taskClass: "standard",
+        },
+      };
+    }
+    if (code === "task_class_mismatch" || code === "task_class_required") {
+      const matches = taskClasses.flatMap((taskClass) => {
+        const candidate = { ...metadata, taskClass };
+        try {
+          return [{ contract: compileContract(sourceRoot, taskId, candidate), metadata: candidate }];
+        } catch {
+          return [];
+        }
+      });
+      if (matches.length === 1 && presetId) {
+        const match = matches[0]!;
+        return {
+          ...match,
+          repair: {
+            disposition: "preset-task-class-aligned",
+            presetId,
+            taskClass: match.metadata.taskClass as TaskClass,
+          },
+        };
+      }
+    }
+    throw error;
+  }
+}
+
+function compiledContractDocument(
+  compiled: ReturnType<typeof compileContract>,
+  sourcePath: string,
+): Record<string, unknown> {
+  const document = compiled.documents.find(({ slot }) => slot === "task.contract");
+  if (!document) throw new Error(`${sourcePath}: compiled task package has no task.contract document`);
+  const value = JSON.parse(document.body) as unknown;
+  if (!migrationImportRecord(value)) throw new Error(`${sourcePath}: compiled task.contract document is invalid`);
+  return value;
+}
+
+function codedError(error: unknown): string | null {
+  return error !== null && typeof error === "object" && typeof (error as { readonly code?: unknown }).code === "string"
+    ? String((error as { readonly code: string }).code)
+    : null;
+}
+
+function optionalText(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value : null;
 }
 
 function compileContract(sourceRoot: string, taskId: string, metadata: TaskContractCompileFallback) {

--- a/packages/daemon/src/repo-cell-task-maintenance.ts
+++ b/packages/daemon/src/repo-cell-task-maintenance.ts
@@ -200,6 +200,15 @@ export function migrateTaskContracts(
             packagePathBefore,
             packagePathAfter: current.packagePath,
             digestSource: restated.source,
+            ...(restated.repair
+              ? {
+                  disposition: restated.repair.disposition,
+                  presetIdBefore: task.metadata?.presetId ?? null,
+                  presetIdAfter: restated.repair.presetId,
+                  taskClassBefore: task.taskClass,
+                  taskClassAfter: restated.repair.taskClass,
+                }
+              : {}),
           };
         }
         return { taskId, status: "current" };
@@ -233,6 +242,12 @@ export function migrateTaskContracts(
           taskId,
           ...(repairs.has(taskId) ? { repairPresetSnapshotDigest: repairs.get(taskId)!.presetSnapshotDigest } : {}),
           ...(repairs.has(taskId) ? { repairTaskContractBody: repairs.get(taskId)!.body } : {}),
+          ...(repairs.get(taskId)?.repair
+            ? {
+                repairPresetId: repairs.get(taskId)!.repair!.presetId,
+                repairTaskClass: repairs.get(taskId)!.repair!.taskClass,
+              }
+            : {}),
         },
         binding,
       ),

--- a/packages/daemon/src/repo-cell-task-mutation.ts
+++ b/packages/daemon/src/repo-cell-task-mutation.ts
@@ -265,10 +265,23 @@ export function taskMutation(
   }
   if (action.kind === "task-contract-migrate") {
     const repairedDigest =
-      typeof action.repairPresetSnapshotDigest === "string" &&
-      /^sha256:[0-9a-f]{64}$/u.test(action.repairPresetSnapshotDigest)
-        ? (action.repairPresetSnapshotDigest as `sha256:${string}`)
-        : null;
+        typeof action.repairPresetSnapshotDigest === "string" &&
+        /^sha256:[0-9a-f]{64}$/u.test(action.repairPresetSnapshotDigest)
+          ? (action.repairPresetSnapshotDigest as `sha256:${string}`)
+          : null,
+      repairedTaskClass = (taskClasses as readonly unknown[]).includes(action.repairTaskClass)
+        ? (action.repairTaskClass as TaskV2["taskClass"])
+        : null,
+      repairedPresetId =
+        typeof action.repairPresetId === "string" && action.repairPresetId.trim() ? action.repairPresetId.trim() : null,
+      repairedMetadata =
+        repairedPresetId === null || !task.metadata ? task.metadata : { ...task.metadata, presetId: repairedPresetId },
+      fields = [
+        "contractVersion",
+        ...(repairedDigest === null ? [] : ["presetSnapshotDigest"]),
+        ...(repairedTaskClass === null || repairedTaskClass === task.taskClass ? [] : ["taskClass"]),
+        ...(repairedPresetId === null || repairedPresetId === task.metadata?.presetId ? [] : ["presetId"]),
+      ];
     if ((task.contractVersion ?? 0) >= 1 && repairedDigest === null)
       throw cell.cellCodedError(
         "contract_current",
@@ -280,6 +293,8 @@ export function taskMutation(
         ...task,
         contractVersion: 1,
         ...(repairedDigest === null ? {} : { presetSnapshotDigest: repairedDigest }),
+        ...(repairedTaskClass === null ? {} : { taskClass: repairedTaskClass }),
+        ...(repairedMetadata === undefined ? {} : { metadata: repairedMetadata }),
       },
       audit: {
         command: "contract-migrate",
@@ -287,7 +302,7 @@ export function taskMutation(
           repairedDigest === null
             ? "Backfilled immutable task-contract/v1 from unambiguous L1 task truth"
             : "Repaired migrated task preset digest and canonical task-contract package path",
-        fields: repairedDigest === null ? ["contractVersion"] : ["contractVersion", "presetSnapshotDigest"],
+        fields,
       },
     };
   }

--- a/packages/daemon/test/migration-import-replay-records.integration.test.ts
+++ b/packages/daemon/test/migration-import-replay-records.integration.test.ts
@@ -855,6 +855,194 @@ test("contract migration repairs old migrated rows through one canonical event a
   }
 });
 
+test("contract migration deterministically disposes all three canonical manual families and stays idempotent", async () => {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-migrate-contract-manual-families-")),
+    repoId = workspaceId("migration-contract-manual-families"),
+    occurredAt = "2026-08-31T00:00:00.000Z",
+    samples = [
+      {
+        taskId: "task_01KWFQ0285MRXE92BYX7AGF9HD",
+        title: "M3 triadic kernel milestone main coordination task",
+        slug: "m3-triadic-kernel",
+        sourcePresetId: "long-running-task",
+        targetPresetId: "standard-task",
+        targetTaskClass: "standard" as const,
+        disposition: "retired-preset-to-standard-task",
+        hasSourceContract: false,
+      },
+      {
+        taskId: "task_01KX51Z7HJTS56CTSVCTEM1SRF",
+        title: "进展页持续维护（library.qianbaner.top）",
+        slug: "library-qianbaner-top",
+        sourcePresetId: "progress-site",
+        targetPresetId: "standard-task",
+        targetTaskClass: "standard" as const,
+        disposition: "retired-preset-to-standard-task",
+        hasSourceContract: true,
+      },
+      {
+        taskId: "task_01KXAWVMTP3GV0QD7E5570CE4B",
+        title: "PLT-Attribution:双轴归属主干统一切面(ADR-0028)",
+        slug: "plt-attribution-adr-0028",
+        sourcePresetId: "create-milestone",
+        targetPresetId: "create-milestone",
+        targetTaskClass: "milestone" as const,
+        disposition: "preset-task-class-aligned",
+        hasSourceContract: false,
+      },
+    ];
+  let cell: Awaited<ReturnType<typeof openRepoCell>> | undefined;
+  try {
+    initRepo(rootDir);
+    cell = await openRepoCell({ repoId, rootDir: canonicalRoot(rootDir), ownerId: "manual-family-bootstrap" });
+    assert.equal((await cell.run({ kind: "projection-rebuild" }, { actor, source: "local" })).outcome, "applied");
+    await cell.close();
+    cell = undefined;
+    const settings = readSettingsFacet(readFileSync(path.join(rootDir, "harness/harness.yaml"), "utf8")),
+      store = makeTaskEventStore({ repoId, rootDir });
+    let revision = store.readHead()?.revision ?? 0;
+    for (const sample of samples) {
+      const target = compileRepoTaskPackage({
+          rootDir,
+          settings,
+          taskId: sample.taskId,
+          action: {
+            kind: "task-create",
+            title: sample.title,
+            slug: sample.slug,
+            presetId: sample.targetPresetId,
+            taskClass: sample.targetTaskClass,
+            verticalId: "software/coding",
+            profileId: "baseline",
+          },
+        }),
+        packagePath = target.packagePath,
+        index = target.documents.find(({ slot }) => slot === "task.index")!,
+        task = {
+          schema: "task/v2" as const,
+          taskId: sample.taskId,
+          title: sample.title,
+          taskClass: "standard" as const,
+          status: "planned" as const,
+          graph: REPLAY_TASK_GRAPH,
+          currentNode: "implementation",
+          iteration: 0,
+          pinned: false,
+          packageDisposition: "active" as const,
+          createdBy: actor,
+          completionGateIds: [],
+          presetSnapshotDigest: null,
+          metadata: {
+            idempotencyKey: null,
+            parentTaskId: null,
+            workKind: "chore" as const,
+            riskTier: "medium" as const,
+            urgency: "medium" as const,
+            verticalId: "software/coding",
+            presetId: sample.sourcePresetId,
+            profileId: "baseline",
+            moduleKey: null,
+            slug: sample.slug,
+            surfaces: [],
+            fromLegacyId: null,
+          },
+        };
+      store.append(
+        prepare(
+          "legacy-source",
+          actor,
+          "task",
+          sample.taskId,
+          occurredAt,
+          ++revision,
+          {
+            kind: "task",
+            provenance: "imported_snapshot",
+            task,
+            originalStatus: "planned",
+            packagePath,
+            documentClaim: claim(index.path, index.body, index.mediaType),
+          },
+          [blob(index.body, index.mediaType)],
+        ),
+      );
+      for (const document of target.documents.filter(({ slot }) => slot !== "task.index")) {
+        if (document.slot === "task.contract" && !sample.hasSourceContract) continue;
+        const body =
+          document.slot === "task.contract"
+            ? `${JSON.stringify(
+                {
+                  schema: "task-contract/v1",
+                  contractVersion: 1,
+                  taskId: sample.taskId,
+                  title: sample.title,
+                  taskClass: "standard",
+                  metadata: task.metadata,
+                },
+                null,
+                2,
+              )}\n`
+            : document.body;
+        store.append(
+          prepare(
+            "legacy-source",
+            actor,
+            "task-document",
+            `harness/${packagePath}/${document.relativePath}`,
+            occurredAt,
+            ++revision,
+            {
+              kind: "task-document",
+              taskId: sample.taskId,
+              documentClaim: claim(document.path, body, document.mediaType),
+            },
+            [blob(body, document.mediaType)],
+          ),
+        );
+      }
+    }
+    await store.drain();
+    cell = await openRepoCell({ repoId, rootDir: canonicalRoot(rootDir), ownerId: "manual-family-daemon" });
+    const binding = { actor, source: "local" as const },
+      before = makeTaskEventStore({ repoId, rootDir }).read().revision,
+      dry = await cell.run({ kind: "task-contract-migrate", mode: "dry-run" }, binding),
+      evidence = JSON.parse(String(dry.evidence)) as {
+        readonly report: readonly Record<string, unknown>[];
+        readonly manual: readonly Record<string, unknown>[];
+      };
+    assert.equal(dry.outcome, "pending");
+    assert.equal(makeTaskEventStore({ repoId, rootDir }).read().revision, before);
+    assert.equal(evidence.manual.length, 0);
+    for (const sample of samples) {
+      const row = evidence.report.find(({ taskId }) => taskId === sample.taskId)!;
+      assert.equal(row.status, "repair");
+      assert.equal(row.disposition, sample.disposition);
+      assert.equal(row.presetIdAfter, sample.targetPresetId);
+      assert.equal(row.taskClassAfter, sample.targetTaskClass);
+    }
+    const applied = await cell.run({ kind: "task-contract-migrate", mode: "apply" }, binding);
+    assert.equal(applied.outcome, "applied", JSON.stringify(applied));
+    const firstLedger = makeTaskEventStore({ repoId, rootDir }).read();
+    assert.equal(firstLedger.revision, before + samples.length);
+    assert.equal(firstLedger.events.filter((event) => event.type === "task_contract_migrated").length, samples.length);
+    const rows = (await cell.read("repo.tasks.list")).rows;
+    for (const sample of samples) {
+      const repaired = rows.find(({ taskId }) => taskId === sample.taskId)!.snapshot.task!;
+      assert.equal(repaired.metadata?.presetId, sample.targetPresetId);
+      assert.equal(repaired.taskClass, sample.targetTaskClass);
+      assert.match(String(repaired.presetSnapshotDigest), /^sha256:[0-9a-f]{64}$/u);
+    }
+    const rerun = await cell.run({ kind: "task-contract-migrate", mode: "apply" }, binding),
+      secondLedger = makeTaskEventStore({ repoId, rootDir }).read();
+    assert.equal(rerun.outcome, "applied", JSON.stringify(rerun));
+    assert.equal(secondLedger.revision, firstLedger.revision);
+    assert.equal(secondLedger.events.length, firstLedger.events.length);
+  } finally {
+    await cell?.close();
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});
+
 function contractMetadata(taskId: string, packagePath: string, title = "Migrated repair fixture") {
   return {
     schema: "task-contract/v1",

--- a/packages/daemon/test/migration-import-task-restatement.test.ts
+++ b/packages/daemon/test/migration-import-task-restatement.test.ts
@@ -5,7 +5,11 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
 import { REPLAY_TASK_GRAPH } from "../../kernel/src/index.ts";
-import { restateLegacyTaskEvents, restateTaskContractBody } from "../src/migration-import-task-restatement.ts";
+import {
+  compileRestatedTaskContract,
+  restateLegacyTaskEvents,
+  restateTaskContractBody,
+} from "../src/migration-import-task-restatement.ts";
 
 const actor = { principal: { personId: "person_zeyu" }, executor: null } as const;
 
@@ -119,6 +123,159 @@ test("task contract restatement fails closed when a missing digest cannot be der
         }),
       /cannot derive presetSnapshotDigest from task contract metadata/u,
     );
+  } finally {
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});
+
+test("retired long-running-task metadata restates the real M3 sample through standard-task", () => {
+  const rootDir = fixtureRoot();
+  try {
+    const taskId = "task_01KWFQ0285MRXE92BYX7AGF9HD",
+      restated = restateTaskContractBody({
+        sourceRoot: rootDir,
+        sourcePath: `harness/tasks/${taskId}/task-contract.json`,
+        body: JSON.stringify({ schema: "task-contract/v1", taskId, taskClass: "standard" }),
+        targetTaskId: taskId,
+        targetPackagePath: `tasks/${taskId}-m3-triadic-kernel`,
+        fallback: {
+          title: "M3 triadic kernel milestone main coordination task",
+          taskClass: "standard",
+          verticalId: "software/coding",
+          presetId: "long-running-task",
+          profileId: "baseline",
+          slug: "m3-triadic-kernel",
+        },
+      }),
+      contract = JSON.parse(restated.body) as Record<string, unknown>;
+    assert.deepEqual(restated.repair, {
+      disposition: "retired-preset-to-standard-task",
+      presetId: "standard-task",
+      taskClass: "standard",
+    });
+    assert.equal(contract.presetId, "standard-task");
+    assert.equal(contract.taskClass, "standard");
+    assert.equal(contract.presetSnapshotDigest, restated.presetSnapshotDigest);
+  } finally {
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});
+
+test("another retired preset uses the same explicit standard-task disposition", () => {
+  const rootDir = fixtureRoot();
+  try {
+    const taskId = "task_01KX51Z7HJTS56CTSVCTEM1SRF",
+      restated = restateTaskContractBody({
+        sourceRoot: rootDir,
+        sourcePath: `harness/tasks/${taskId}/task-contract.json`,
+        body: JSON.stringify({ schema: "task-contract/v1", taskId, taskClass: "standard" }),
+        targetTaskId: taskId,
+        targetPackagePath: `tasks/${taskId}-library-qianbaner-top`,
+        fallback: {
+          title: "进展页持续维护（library.qianbaner.top）",
+          taskClass: "standard",
+          verticalId: "software/coding",
+          presetId: "progress-site",
+          profileId: "baseline",
+          slug: "library-qianbaner-top",
+        },
+      });
+    assert.equal(restated.repair?.disposition, "retired-preset-to-standard-task");
+    assert.equal(restated.repair?.presetId, "standard-task");
+  } finally {
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});
+
+test("preset taskClass requirement overrides the real Attribution sample declaration", () => {
+  const rootDir = fixtureRoot();
+  try {
+    const taskId = "task_01KXAWVMTP3GV0QD7E5570CE4B",
+      restated = restateTaskContractBody({
+        sourceRoot: rootDir,
+        sourcePath: `harness/tasks/${taskId}/task-contract.json`,
+        body: JSON.stringify({ schema: "task-contract/v1", taskId, taskClass: "standard" }),
+        targetTaskId: taskId,
+        targetPackagePath: `tasks/${taskId}-plt-attribution-adr-0028`,
+        fallback: {
+          title: "PLT-Attribution:双轴归属主干统一切面(ADR-0028)",
+          taskClass: "standard",
+          verticalId: "software/coding",
+          presetId: "create-milestone",
+          profileId: "baseline",
+          slug: "plt-attribution-adr-0028",
+        },
+      }),
+      contract = JSON.parse(restated.body) as Record<string, unknown>;
+    assert.deepEqual(restated.repair, {
+      disposition: "preset-task-class-aligned",
+      presetId: "create-milestone",
+      taskClass: "milestone",
+    });
+    assert.equal(contract.presetId, "create-milestone");
+    assert.equal(contract.taskClass, "milestone");
+  } finally {
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});
+
+test("unrecognized missing presets remain manual instead of receiving a guessed contract", () => {
+  const rootDir = fixtureRoot();
+  try {
+    assert.throws(
+      () =>
+        restateTaskContractBody({
+          sourceRoot: rootDir,
+          sourcePath: "harness/tasks/task-unknown/task-contract.json",
+          body: JSON.stringify({
+            ...taskContractMetadata(),
+            presetId: "unknown-retired-preset",
+            presetSnapshotDigest: null,
+          }),
+          targetTaskId: "task-unknown",
+          targetPackagePath: "tasks/task-unknown",
+        }),
+      /cannot derive presetSnapshotDigest from task contract metadata/u,
+    );
+  } finally {
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});
+
+test("missing contract synthesis uses the same deterministic retired-preset and taskClass rules", () => {
+  const rootDir = fixtureRoot();
+  try {
+    const retired = compileRestatedTaskContract({
+        sourceRoot: rootDir,
+        sourcePath: "harness/tasks/task_01KWFQ0285MRXE92BYX7AGF9HD/task-contract.json",
+        targetTaskId: "task_01KWFQ0285MRXE92BYX7AGF9HD",
+        targetPackagePath: "tasks/task_01KWFQ0285MRXE92BYX7AGF9HD-m3-triadic-kernel",
+        fallback: {
+          title: "M3 triadic kernel milestone main coordination task",
+          taskClass: "standard",
+          verticalId: "software/coding",
+          presetId: "long-running-task",
+          profileId: "baseline",
+          slug: "m3-triadic-kernel",
+        },
+      }),
+      conflict = compileRestatedTaskContract({
+        sourceRoot: rootDir,
+        sourcePath: "harness/tasks/task_01KXAWVMTP3GV0QD7E5570CE4B/task-contract.json",
+        targetTaskId: "task_01KXAWVMTP3GV0QD7E5570CE4B",
+        targetPackagePath: "tasks/task_01KXAWVMTP3GV0QD7E5570CE4B-plt-attribution-adr-0028",
+        fallback: {
+          title: "PLT-Attribution:双轴归属主干统一切面(ADR-0028)",
+          taskClass: "standard",
+          verticalId: "software/coding",
+          presetId: "create-milestone",
+          profileId: "baseline",
+          slug: "plt-attribution-adr-0028",
+        },
+      });
+    assert.equal(retired.repair?.disposition, "retired-preset-to-standard-task");
+    assert.equal(conflict.repair?.disposition, "preset-task-class-aligned");
+    assert.equal(conflict.repair?.taskClass, "milestone");
   } finally {
     rmSync(rootDir, { recursive: true, force: true });
   }


### PR DESCRIPTION
# English

## Summary

The migration channel previously produced 65 `manual` rows it could not restate deterministically: 43 tasks referenced the retired `long-running-task` preset, 6 referenced five other retired presets, and 16 carried a taskClass that conflicts with their preset snapshot. Per the owner's ruling (decision dec_2C829149F53FD81D742DE8AA11), this change makes their disposition deterministic inside the migration/repair channel only: tasks whose preset id is on the explicit retired-preset list are recompiled against the current `standard-task` preset with `taskClass=standard` (old semantics dropped, no compatibility preset restored); taskClass conflicts are resolved by enumerating task classes and taking the only class the preset snapshot compiles — the preset snapshot wins. Every repair records an audited disposition (`retired-preset-to-standard-task` or `preset-task-class-aligned`) with before/after preset id and task class in the mutation audit fields. Unmatched inputs still fall to `manual`; the normal write path vocabulary is untouched.

## Architectural Justification

- The repair logic lives in the existing migration restatement module (`migration-import-task-restatement.ts`) and flows through the existing `task-contract-migrate` mutation; no new layer, flag, or channel is introduced.

## What Changed

- `packages/daemon/src/migration-import-task-restatement.ts`: retired-preset allowlist, `compileContractForRestatement` repair fallback (retired preset → `standard-task`; taskClass mismatch → the unique class the preset snapshot accepts), repair metadata threaded into the restated contract.
- `packages/daemon/src/repo-cell-task-maintenance.ts`: dry-run/apply report rows now carry the disposition and before/after preset id and task class.
- `packages/daemon/src/repo-cell-task-mutation.ts`: `task-contract-migrate` applies the repaired task class and preset id and lists the exact mutated fields in the audit record.
- Tests: a replay-records integration test covering both dispositions plus idempotency, and extended restatement unit tests.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: use the single CI-backed `Production-Delta` declaration below; do not enter a second metric.

## Machine-Readable Declarations

Production-Delta: +139/-13

## Task And Scope

- Harness task: task_9305f3a019cc2037c50a6730ac (private ledger)
- Branch: codex/manual65
- Public scope: migration/repair channel restatement rules, migrate report fields, and their tests
- Private planning/evidence updated: yes
- Out of scope: any canonical production apply (CEO-owned, after backup tag and row-table review); normal write-path vocabulary

## Version Impact

- Version: no version change because this extends an internal migration repair channel
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope:
- Authority: not applicable
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason:
- Break-glass scope:
- Follow-up governance task:

## Verification

- Base `origin/main` SHA: 54121c27df60d6f60e5f5c18f57ca610f99d45ca
- Branch merge-base with `origin/main`: 54121c27df60d6f60e5f5c18f57ca610f99d45ca
- Last `git fetch origin` time: 2026-08-31 evening
- Sync method: rebase onto `origin/main` after #2066 merged
- Public diff command: git diff origin/main..codex/manual65
- Private evidence commit/path: private ledger task_9305f3a (fact F-B6B538BA; artifacts/manual65-dryrun.md with the full 65-row disposition table)
- Reviewer evidence path: see Review Evidence
- GitHub Actions `rewrite-ci` run URL: pending (PR checks)
- [x] Dry-run against a disposable copy of the canonical ledger: 65 repair / 0 manual, reconciled 43+6+16=65; receipt applied=false
- [x] Targeted tests: fast 13/13, isolated Docker integration 8/8, typecheck, ESLint, file-complexity
- Not run: full local check suites — worker/local stop-point policy; GitHub CI is the complete authority for this PR.

## Review Evidence

- Self-review: CEO semantic acceptance against decision dec_2C829149 CH1 — mapping direction (drop retired semantics, no compat preset) and conflict direction (snapshot wins) both match the ruling; repair is confined to the migration channel; unmatched inputs still fail to manual.
- Reviewer subagent: not used beyond the implementing agent's dry-run evidence (single-reviewer budget; the production apply gets its own row-table review)
- Human review: requested via this PR; the 65-row disposition table is in the private ledger for the apply-time review
- Blocking findings: none

## Residual Risk

- The production apply is a separate CEO-owned step (backup tag `backup/pre-contract-migrate-20260831` exists); this PR alone changes no canonical data.
- The retired-preset list is explicit; a future retired preset would fall to `manual` until added — intentional fail-closed behavior.

## References

- Task: task_9305f3a019cc2037c50a6730ac (private ledger)
- Decision: dec_2C829149F53FD81D742DE8AA11 (owner ruling on the 65-row disposition)
- Evidence: fact F-B6B538BA; artifacts/manual65-dryrun.md (private ledger)

---

# 中文

## 概要

迁移通道此前产出 65 条无法确定性改写的 `manual` 行:43 个任务引用已退役的 `long-running-task` preset,6 个引用另外五种退役 preset,16 个的 taskClass 与其 preset snapshot 冲突。按所有者裁决(decision dec_2C829149F53FD81D742DE8AA11),本变更把它们的处置在**迁移/修复通道内**变为确定性:preset id 命中显式退役清单的任务按当前 `standard-task` preset 重编译并取 `taskClass=standard`(旧语义直接丢弃,不恢复兼容 preset);taskClass 冲突按「枚举 task class、取 preset snapshot 唯一可编译的那个」解决——snapshot 赢。每次修复都在 mutation 审计字段里记录处置类型(`retired-preset-to-standard-task` 或 `preset-task-class-aligned`)与前后 preset id / task class。未命中的输入仍落 `manual`;正常写路词表不动。

## 架构辩护

- 修复逻辑放在既有迁移改写模块(`migration-import-task-restatement.ts`)并走既有 `task-contract-migrate` mutation;不新增层、开关或通道。

## 改动内容

- `packages/daemon/src/migration-import-task-restatement.ts`:退役 preset 白名单、`compileContractForRestatement` 修复回退(退役 preset → `standard-task`;taskClass 不匹配 → snapshot 唯一接受的类),修复元数据随改写契约输出。
- `packages/daemon/src/repo-cell-task-maintenance.ts`:dry-run/apply 报表行携带处置类型与前后 preset id / task class。
- `packages/daemon/src/repo-cell-task-mutation.ts`:`task-contract-migrate` 应用修复后的 task class 与 preset id,审计记录精确列出被改字段。
- 测试:覆盖两种处置与幂等性的 replay-records 集成测试,以及扩展的改写单测。

## 门收割 / Gate Harvest

- 删除的生产路径:none
- 同 commit 删除的门 / fixture:none
- 生产净行数:引用英文块中的 `Production-Delta`;该值由 production-delta job 计算,不要手填第二份数字。

## 机读声明说明

- 机读声明只在英文块出现一次,见英文块 `Production-Delta: +139/-13`。

## 任务与范围

- Harness 任务:task_9305f3a019cc2037c50a6730ac(私有台账)
- 分支:codex/manual65
- 公开范围:迁移/修复通道改写规则、migrate 报表字段及其测试
- 私有计划 / 证据是否已更新:yes
- 范围外:任何 canonical 生产 apply(归 CEO,须备份 tag 与行表审阅后执行);正常写路词表

## 版本影响

- 版本:不改版本,原因是内部迁移修复通道扩展
- 发布影响:不发布

## 治理声明

- 是否触碰 protected surface:no
- protected surface 范围:
- 依据:不适用
- 机器检查边界:本 PR 只声明该段存在;声明是否真实、充分,由 reviewer 判断。
- Break-glass:no
- Break-glass 原因:
- Break-glass 范围:
- 后续治理任务:

## 验证

- `origin/main` 基准 SHA:54121c27df60d6f60e5f5c18f57ca610f99d45ca
- 当前分支与 `origin/main` 的 merge-base:54121c27df60d6f60e5f5c18f57ca610f99d45ca
- 最近一次 `git fetch origin` 时间:2026-08-31 晚间
- 同步方式:#2066 合入后 rebase 到 `origin/main`
- 公开 diff 命令:git diff origin/main..codex/manual65
- 私有证据 commit/path:私有台账 task_9305f3a(fact F-B6B538BA;artifacts/manual65-dryrun.md 含 65 行处置全表)
- Reviewer 证据路径:见审查证据
- GitHub Actions `rewrite-ci` run URL:待 PR checks
- [x] 对 canonical 台账一次性副本 dry-run:65 repair / 0 manual,对账 43+6+16=65;回执 applied=false
- [x] 定向测试:fast 13/13、隔离 Docker 集成 8/8、typecheck、ESLint、file-complexity
- 未运行:完整本地 check 套件——按 worker/本地停止点纪律,GitHub CI 是本 PR 的完整权威。

## 审查证据

- 自查:CEO 按 decision dec_2C829149 CH1 语义验收——映射方向(丢弃退役语义、不做兼容 preset)与冲突方向(snapshot 赢)均合裁决;修复封在迁移通道;未命中仍落 manual。
- Reviewer subagent:除实现 agent 的 dry-run 证据外未另派(单评审员预算;生产 apply 另有行表审阅)
- 人工审查:经本 PR 请求;65 行处置表在私有台账供 apply 时审阅
- 阻塞发现:none

## 残余风险

- 生产 apply 是独立的 CEO 步骤(备份 tag `backup/pre-contract-migrate-20260831` 已在);本 PR 本身不改任何 canonical 数据。
- 退役 preset 清单是显式的;未来新退役的 preset 在加入清单前会落 `manual`——有意的 fail-closed 行为。

## 关联材料

- 任务:task_9305f3a019cc2037c50a6730ac(私有台账)
- 决策:dec_2C829149F53FD81D742DE8AA11(65 行处置的所有者裁决)
- 证据:fact F-B6B538BA;artifacts/manual65-dryrun.md(私有台账)

---

## PR Gate Checklist / PR 门禁清单

- [x] Branch is based on latest `origin/main`. / 分支基于最新 `origin/main`。
- [x] PR body uses this full template structure. / PR 描述使用本模板完整结构。
- [x] PR body uses two complete language blocks: `# English` first, then `# 中文`. / PR 正文使用两块完整正文:`# English` 在上,`# 中文` 在下。
- [x] PR body passes `tools/check-pr-body-bilingual.mjs`. / PR 正文通过 `tools/check-pr-body-bilingual.mjs`。
- [x] If the PR touches a manifest-derived protected surface, Governance Declaration is filled with ADR/decision/task evidence or break-glass fields. / 若 PR 触碰 manifest 派生的 protected surface,Governance Declaration 已填写 ADR/decision/task 依据或 break-glass 字段。
- [x] No private harness files are included. / 不包含私有 harness 文件。
- [x] No ignored local agent entry files are included. / 不包含被忽略的本地 agent 入口文件。
- [x] No absolute local filesystem paths are included in this public PR body. / 本公开 PR 描述不包含本机绝对路径。
- [x] Public diff is limited to the stated task scope. / 公开 diff 限于声明的任务范围。
- [x] Private planning/evidence updates are recorded when applicable. / 适用时已记录私有计划 / 证据更新。
- [x] Version and publish impact are stated. / 已说明版本与发布影响。
- [x] Local verification commands are recorded honestly. / 已如实记录本地验证命令。
- [x] CI results are linked or explained. / CI 结果已链接或说明。
- [x] Review evidence is recorded. / 已记录审查证据。
- [x] Open P0/P1/P2 findings are closed, deferred with owner, or explicitly blocked. / open P0/P1/P2 findings 已关闭、带 owner 延后,或明确阻塞。
- [x] Merge method and post-merge branch cleanup plan are clear. / 合并方式和合并后分支清理计划清楚。
- [x] No admin bypass is planned unless explicitly approved and recorded. / 除非明确批准并记录,否则不计划 admin bypass。
