### PR TITLE
fix(kernel): normalize projected snapshot.task through currentTaskForWrite

### DIFF
--- a/packages/kernel/src/projection/projection-schema.ts
+++ b/packages/kernel/src/projection/projection-schema.ts
@@ -1,4 +1,5 @@
-// Version 16 adds the rebuildable archived_entity witness table used by genesis
-// migration truth-gap restatements. A version mismatch takes the discard-and-replay
-// path so an older cache cannot silently omit archived source identities.
-export const taskProjectionSchemaVersion = 16;
+// Version 17 normalizes every stored snapshot.task through currentTaskForWrite so
+// legacy hosted fields (relations, metadata.longRunning) embedded in event payloads
+// never reach GUI-facing task rows. A version mismatch takes the discard-and-replay
+// path so caches written by older appliers are rebuilt with normalized rows.
+export const taskProjectionSchemaVersion = 17;

--- a/packages/kernel/src/projection/rebuildable-task-projection-event-application.ts
+++ b/packages/kernel/src/projection/rebuildable-task-projection-event-application.ts
@@ -420,12 +420,8 @@ export function applyEvent(
         completionGateIds: event.payload.task.completionGateIds,
         presetSnapshotDigest: event.payload.task.presetSnapshotDigest,
       },
-      historical = { ...current.task, ...changed },
       currentShape = { ...currentTaskForWrite(current.task), ...changed };
-    if (
-      canonicalJson(historical) !== canonicalJson(event.payload.task) &&
-      canonicalJson(currentShape) !== canonicalJson(event.payload.task)
-    )
+    if (canonicalJson(currentShape) !== canonicalJson(currentTaskForWrite(event.payload.task)))
       throw new Error(`preset snapshot upgrade changed immutable task fields for ${event.taskId}`);
     const snapshot = JSON.parse(new TextDecoder("utf-8", { fatal: true }).decode(snapshotBytes)),
       contractBody = new TextDecoder("utf-8", { fatal: true }).decode(contractBytes),
@@ -455,7 +451,7 @@ export function applyEvent(
       canonicalJson({
         ...current,
         revision: event.workspaceRevision,
-        task: event.payload.task,
+        task: currentTaskForWrite(event.payload.task),
       }),
       event.payload.task.status,
       event.occurredAt,
@@ -492,7 +488,7 @@ export function applyEvent(
       event.workspaceRevision,
       canonicalJson({
         ...emptyTaskLifecycleSnapshot(event.workspaceRevision),
-        task: event.payload.task,
+        task: currentTaskForWrite(event.payload.task),
       }),
       event.payload.task.status,
       event.occurredAt,

--- a/packages/kernel/src/projection/rebuildable-task-projection-migration.ts
+++ b/packages/kernel/src/projection/rebuildable-task-projection-migration.ts
@@ -1,6 +1,7 @@
 // @write-boundary-exemption rebuildable-projection
 import { DatabaseSync } from "node:sqlite";
 import { emptyTaskLifecycleSnapshot } from "../domain/task-lifecycle.contract.ts";
+import { currentTaskForWrite } from "../domain/task.ts";
 import { docByteLength, type DocumentState } from "../domain/doc-sync.contract.ts";
 import { requireEntityKindContract } from "../domain/entity-kind-registry.ts";
 import { type MigrationDocumentClaim, type MigrationImportEventV1 } from "../domain/migration-import-event.ts";
@@ -69,7 +70,7 @@ export function projectMigration(
       event.workspaceRevision,
       canonicalJson({
         ...emptyTaskLifecycleSnapshot(event.workspaceRevision),
-        task: entity.task,
+        task: currentTaskForWrite(entity.task),
       }),
       entity.task.status,
       event.occurredAt,

--- a/packages/kernel/src/projection/rebuildable-task-projection-task-events.ts
+++ b/packages/kernel/src/projection/rebuildable-task-projection-task-events.ts
@@ -1,6 +1,7 @@
 // @write-boundary-exemption rebuildable-projection
 import { DatabaseSync } from "node:sqlite";
 import { reduceTaskEvent, type TaskEventV1 } from "../domain/task-lifecycle.contract.ts";
+import { currentTaskForWrite } from "../domain/task.ts";
 import { docByteLength, verifyDocEventChange, type DocumentState } from "../domain/doc-sync.contract.ts";
 import { lifecycleDocumentPaths } from "../domain/task-lifecycle-publication.ts";
 import { slugifyTaskTitle } from "../layout/index.ts";
@@ -46,7 +47,12 @@ export function applyTaskEvent(
     UPSERT_TASK_SNAPSHOT_SQL,
     event.taskId,
     event.workspaceRevision,
-    canonicalJson({ ...snapshot, executions: [], reviews: [] }),
+    canonicalJson({
+      ...snapshot,
+      task: snapshot.task === null ? null : currentTaskForWrite(snapshot.task),
+      executions: [],
+      reviews: [],
+    }),
     snapshot.task?.status ?? null,
     event.occurredAt,
   );

--- a/packages/kernel/test/store/schedule-projection.test.ts
+++ b/packages/kernel/test/store/schedule-projection.test.ts
@@ -18,7 +18,7 @@ const actor = { principal: { personId: "person-schedule" }, executor: null } as 
 test("Schedule definition and run view share one canonical stream and rebuild exactly", async () => {
   await withTempStoreAsync(async (rootDir) => {
     initRepo(rootDir);
-    assert.equal(taskProjectionSchemaVersion, 16);
+    assert.equal(taskProjectionSchemaVersion, 17);
     const eventStore = makeTaskEventStore({ repoId: "schedule-projection", rootDir }),
       projection = makeTaskProjection({ rootDir, eventStore }),
       schedule = baseSchedule(),

--- a/packages/kernel/test/store/task-query-projection.test.ts
+++ b/packages/kernel/test/store/task-query-projection.test.ts
@@ -261,9 +261,17 @@ test("historical task relation events replay into the Relation projection and su
   const fixture = taskFixture();
   await withTempStoreAsync(async (rootDir) => {
     const projection = makeTaskProjection({ rootDir, eventStore: memoryEventStore(fixture.events) });
-    const list = projection.list(),
-      expected = list.rows.flatMap((row) =>
-        (row.snapshot.task?.relations ?? []).map((relation, recordIndex) => ({
+    projection.list();
+    // The stored snapshot no longer hosts legacy task.relations (normalized via
+    // currentTaskForWrite), so the expectation derives from the event payloads —
+    // the same replay input the Relation projection consumes.
+    const expected = fixture.events
+      .filter((event) => event.type === "task_relation_added")
+      .flatMap((event) => {
+        const task = event.payload.task as (typeof fixture.tasks)[number] & {
+          readonly relations?: readonly EntityRelationRecord[];
+        };
+        return (task.relations ?? []).map((relation, recordIndex) => ({
           relationId: relation.relation_id,
           sourceRef: relation.source,
           targetRef: relation.target,
@@ -273,11 +281,11 @@ test("historical task relation events replay into the Relation projection and su
           origin: relation.origin,
           state: relation.state,
           rationale: relation.rationale,
-          ownerRef: `task/${row.taskId}`,
-          sourcePath: `event:op-task_relation_added-${row.snapshot.revision}`,
+          ownerRef: `task/${task.taskId}`,
+          sourcePath: `event:${event.opId}`,
           recordIndex,
-        })),
-      );
+        }));
+      });
     const projected = projection.readTaskRelations();
     assert.equal(projected.status, "ready");
     assert.deepEqual(

--- a/packages/kernel/test/store/task-snapshot-normalization.test.ts
+++ b/packages/kernel/test/store/task-snapshot-normalization.test.ts
@@ -1,0 +1,85 @@
+// harness-test-tier: integration
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import test from "node:test";
+import { makeTaskProjection } from "../../src/projection/task-projection.ts";
+import { makeTaskEventStore } from "../../src/store/task-event-store.ts";
+import { taskLifecycleWritePlan } from "../../src/domain/task-lifecycle-publication.ts";
+import type { TaskEventV1 } from "../../src/domain/task-lifecycle.contract.ts";
+import { deriveRelationId } from "../../src/domain/entity-relation.ts";
+import { lifecycleFixture } from "./task-lifecycle-fixture.ts";
+import { withTempStoreAsync } from "./helpers.ts";
+
+function initRepo(rootDir: string): void {
+  for (const args of [
+    ["init", "--quiet"],
+    ["config", "user.email", "test@example.com"],
+    ["config", "user.name", "Test"],
+    ["commit", "--quiet", "--allow-empty", "-m", "seed"],
+    ["update-ref", "refs/ha/canonical", "HEAD"],
+  ])
+    execFileSync("git", args, { cwd: rootDir });
+}
+
+// Regression for the 2026-08-31 GUI outage: lifecycle event payloads may embed
+// legacy hosted fields on payload.task (relations as replay input for the
+// Relation aggregate, metadata.longRunning from older generations). The stored
+// snapshot must be normalized through currentTaskForWrite, or every GUI task
+// read is rejected by the protocol validator (`snapshot.task is invalid`).
+test("projected snapshot.task never hosts legacy relations or longRunning fields", async () => {
+  await withTempStoreAsync(async (rootDir) => {
+    initRepo(rootDir);
+    const eventStore = makeTaskEventStore({ repoId: "normalize-repo", rootDir }),
+      projection = makeTaskProjection({ rootDir, eventStore }),
+      created = lifecycleFixture().events[0]!,
+      relationIdentity = {
+        source: "task/task-1",
+        target: "task/task-2",
+        type: "depends-on",
+        direction: "directed",
+      } as const,
+      legacyRelation = {
+        relation_id: deriveRelationId(relationIdentity),
+        ...relationIdentity,
+        strength: "strong",
+        origin: "declared",
+        state: "active",
+        rationale: "legacy hosted relation embedded in the event payload",
+      };
+    const event = {
+      ...created,
+      payload: {
+        ...created.payload,
+        task: {
+          ...(created as { payload: { task: object } }).payload.task,
+          relations: [legacyRelation],
+          metadata: {
+            idempotencyKey: null,
+            parentTaskId: null,
+            workKind: null,
+            riskTier: null,
+            urgency: null,
+            verticalId: "software/coding",
+            presetId: "standard-task",
+            profileId: "baseline",
+            moduleKey: null,
+            slug: "fixture",
+            surfaces: [],
+            fromLegacyId: null,
+            longRunning: true,
+          },
+        },
+      },
+    } as unknown as TaskEventV1;
+    projection.apply(event, taskLifecycleWritePlan(event));
+    const rows = projection.list().rows;
+    assert.equal(rows.length, 1);
+    const task = rows[0]!.snapshot.task as Record<string, unknown> | null;
+    assert.ok(task, "snapshot.task must be materialized");
+    assert.ok(!Object.hasOwn(task, "relations"), "snapshot.task must not host a relations field");
+    const metadata = task.metadata as Record<string, unknown>;
+    assert.ok(!Object.hasOwn(metadata, "longRunning"), "snapshot.task.metadata must not host longRunning");
+    assert.equal(task.taskId, "task-1");
+    projection.close();
+  });
+});


### PR DESCRIPTION
# English

## Summary

Every GUI task read against the canonical repository failed with `invalid_result: daemon task snapshot ... snapshot.task is invalid` — seven task rows carried a legacy `relations` field inside `snapshot.task`, and since relation became a first-class entity (#2057) the GUI protocol validator rejects task records hosting relations, which rejects the whole `repo.tasks.list` result. Root cause: task lifecycle event payloads legitimately embed the full task record — including legacy hosted fields such as `relations` (kept as replay input for the Relation aggregate) and `metadata.longRunning` — and all four projection write sites copied `payload.task` verbatim into `task_snapshot` instead of normalizing through `currentTaskForWrite`, the kernel function that exists precisely to strip those hosted fields. The fix normalizes at all four write sites, simplifies the preset-upgrade immutable-field comparison to compare normalized shapes (deleting its now-redundant historical branch), and bumps `taskProjectionSchemaVersion` 16→17 so existing caches take the discard-and-replay path and self-heal on the next daemon start.

## Architectural Justification

- No new mechanism: the fix routes the projection writers through the already-existing `currentTaskForWrite` normalizer and deletes one redundant comparison branch. Relation replay is untouched — it reads event payloads, never the stored snapshot (verified: `refreshTaskRelationProjection` ignores its task argument).

## What Changed

- `packages/kernel/src/projection/rebuildable-task-projection-task-events.ts`: lifecycle event snapshots store a normalized `snapshot.task`.
- `packages/kernel/src/projection/rebuildable-task-projection-event-application.ts`: bootstrap and preset-upgrade writers normalize `payload.task`; the preset-upgrade immutable-field check compares normalized shapes on both sides and drops the redundant raw-historical branch.
- `packages/kernel/src/projection/rebuildable-task-projection-migration.ts`: migration entity writer normalizes `entity.task`.
- `packages/kernel/src/projection/projection-schema.ts`: schema version 16→17 (forced rebuild).
- Tests: new `task-snapshot-normalization.test.ts` regression (event with hosted relations + `longRunning` → stored snapshot hosts neither); the relation-replay test now derives its expectation from event payloads instead of the (no-longer-hosting) stored snapshot.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: use the single CI-backed `Production-Delta` declaration below; do not enter a second metric.

## Machine-Readable Declarations

Production-Delta: +17/-13

## Task And Scope

- Harness task: task_5fc5080044fcfdbf548008f2f5 milestone lane; diagnosis fact F-2028DD55 (private ledger)
- Branch: codex/gui-snapshot-relations
- Public scope: kernel projection write sites, projection schema version, and their tests
- Private planning/evidence updated: yes
- Out of scope: event compile/write-side shapes (events legitimately embed relations as replay input); GUI code

## Version Impact

- Version: no version change because the projection cache is derived state with its own schema version
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope:
- Authority: not applicable
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason:
- Break-glass scope:
- Follow-up governance task:

## Verification

- Base `origin/main` SHA: 54121c27df60d6f60e5f5c18f57ca610f99d45ca
- Branch merge-base with `origin/main`: 54121c27df60d6f60e5f5c18f57ca610f99d45ca
- Last `git fetch origin` time: 2026-08-31 evening
- Sync method: branched from current `origin/main`
- Public diff command: git diff origin/main..codex/gui-snapshot-relations
- Private evidence commit/path: private ledger fact F-2028DD55 (sqlite event/snapshot queries pinning the seven failing rows and the writer sites)
- Reviewer evidence path: see Review Evidence
- GitHub Actions `rewrite-ci` run URL: pending (PR checks)
- [x] Live reproduction: `repo.tasks.list` against the production daemon returned `invalid_result` naming seven `snapshot.task` rows before the fix
- [x] New regression test fails on the old applier and passes on the new one; all three projection test files pass 31/31 locally
- Not run: full local check suites — worker/local stop-point policy; GitHub CI is the complete authority for this PR.

## Review Evidence

- Self-review: CEO verified relation replay reads event payloads only; the stored-snapshot consumers (GUI reads, lifecycle compile bases) want the normalized shape; the deleted historical comparison branch is subsumed because both sides are normalized before comparing.
- Reviewer subagent: not used (small single-mechanism kernel fix, single-reviewer budget)
- Human review: requested via this PR
- Blocking findings: none

## Residual Risk

- The schema bump forces a one-time full projection rebuild on the next daemon start per repository (bounded, same path as any version mismatch).
- Events keep embedding hosted relations by contract; any future writer that bypasses the four sites would reintroduce the field — the regression test guards the lifecycle path.

## References

- Diagnosis fact: F-2028DD55 (private ledger)
- Related: #2057 (relation as first-class entity), `currentTaskForWrite` in `packages/kernel/src/domain/task.ts`

---

# 中文

## 概要

GUI 对 canonical 仓库的任务读全量失败:`invalid_result: daemon task snapshot ... snapshot.task is invalid`——七个 task 行的 `snapshot.task` 携带 legacy `relations` 字段,而自 relation 实体化(#2057)后,GUI 协议校验器不允许 task 记录宿主 relations,于是整个 `repo.tasks.list` 结果被拒。根因:task 生命周期事件的 payload 按契约内嵌整份 task 记录——包括 legacy 宿主字段 `relations`(作为 Relation 聚合的 replay 输入保留)与 `metadata.longRunning`——而投影层四个写点把 `payload.task` 原样拷进 `task_snapshot`,没有走 `currentTaskForWrite`(kernel 里专为剥离这些宿主字段而存在的规范化函数)。修复在四个写点统一规范化;preset-upgrade 的不可变字段比对改为两侧规范化后比较(删掉冗余的 raw-historical 分支);`taskProjectionSchemaVersion` 16→17,存量缓存在 daemon 下次启动时走 discard-and-replay 自愈。

## 架构辩护

- 零新机制:走既有的 `currentTaskForWrite` 规范化函数,并删除一个冗余比较分支。Relation replay 不受影响——它只读事件 payload,从不读存储的 snapshot(已核实:`refreshTaskRelationProjection` 忽略其 task 参数)。

## 改动内容

- `packages/kernel/src/projection/rebuildable-task-projection-task-events.ts`:生命周期事件落 snapshot 时规范化 `snapshot.task`。
- `packages/kernel/src/projection/rebuildable-task-projection-event-application.ts`:bootstrap 与 preset-upgrade 写点规范化 `payload.task`;preset-upgrade 不可变字段检查两侧规范化比较,删冗余分支。
- `packages/kernel/src/projection/rebuildable-task-projection-migration.ts`:迁移实体写点规范化 `entity.task`。
- `packages/kernel/src/projection/projection-schema.ts`:schema 版本 16→17(强制重建)。
- 测试:新增 `task-snapshot-normalization.test.ts` 回归(带宿主 relations 与 `longRunning` 的事件 → 落库 snapshot 两者皆无);relation-replay 测试的期望值改从事件 payload 派生(存量 snapshot 不再宿主该字段)。

## 门收割 / Gate Harvest

- 删除的生产路径:none
- 同 commit 删除的门 / fixture:none
- 生产净行数:引用英文块中的 `Production-Delta`;该值由 production-delta job 计算,不要手填第二份数字。

## 机读声明说明

- 机读声明只在英文块出现一次,见英文块 `Production-Delta: +17/-13`。

## 任务与范围

- Harness 任务:task_5fc5080044fcfdbf548008f2f5 里程碑线;诊断 fact F-2028DD55(私有台账)
- 分支:codex/gui-snapshot-relations
- 公开范围:kernel 投影写点、投影 schema 版本及其测试
- 私有计划 / 证据是否已更新:yes
- 范围外:事件编译/写侧形状(事件内嵌 relations 是合法的 replay 输入);GUI 代码

## 版本影响

- 版本:不改版本,原因是投影缓存属派生态,自带 schema 版本
- 发布影响:不发布

## 治理声明

- 是否触碰 protected surface:no
- protected surface 范围:
- 依据:不适用
- 机器检查边界:本 PR 只声明该段存在;声明是否真实、充分,由 reviewer 判断。
- Break-glass:no
- Break-glass 原因:
- Break-glass 范围:
- 后续治理任务:

## 验证

- `origin/main` 基准 SHA:54121c27df60d6f60e5f5c18f57ca610f99d45ca
- 当前分支与 `origin/main` 的 merge-base:54121c27df60d6f60e5f5c18f57ca610f99d45ca
- 最近一次 `git fetch origin` 时间:2026-08-31 晚间
- 同步方式:自当前 `origin/main` 开分支
- 公开 diff 命令:git diff origin/main..codex/gui-snapshot-relations
- 私有证据 commit/path:私有台账 fact F-2028DD55(sqlite 事件/快照实查钉住七个坏行与写点)
- Reviewer 证据路径:见审查证据
- GitHub Actions `rewrite-ci` run URL:待 PR checks
- [x] 现场复现:修复前对生产 daemon 调 `repo.tasks.list` 返回 invalid_result 并点名七个 `snapshot.task` 行
- [x] 新回归测试在旧应用器上失败、新应用器上通过;三个投影测试文件本地 31/31 全绿
- 未运行:完整本地 check 套件——按 worker/本地停止点纪律,GitHub CI 是本 PR 的完整权威。

## 审查证据

- 自查:CEO 核实 relation replay 只消费事件 payload;存量 snapshot 的消费方(GUI 读、生命周期编译基底)需要的正是规范化形状;被删的 historical 比较分支因两侧先规范化而被完全覆盖。
- Reviewer subagent:未派(单机制小型 kernel 修复,单评审员预算)
- 人工审查:经本 PR 请求
- 阻塞发现:none

## 残余风险

- schema bump 使每个仓库在 daemon 下次启动时做一次全量投影重建(有界,与任何版本不匹配同路径)。
- 事件按契约继续内嵌宿主 relations;未来绕过这四个写点的新写者会重新引入该字段——回归测试守住生命周期主路径。

## 关联材料

- 诊断 fact:F-2028DD55(私有台账)
- 相关:#2057(relation 一等实体化)、`packages/kernel/src/domain/task.ts` 的 `currentTaskForWrite`

---

## PR Gate Checklist / PR 门禁清单

- [x] Branch is based on latest `origin/main`. / 分支基于最新 `origin/main`。
- [x] PR body uses this full template structure. / PR 描述使用本模板完整结构。
- [x] PR body uses two complete language blocks: `# English` first, then `# 中文`. / PR 正文使用两块完整正文:`# English` 在上,`# 中文` 在下。
- [x] PR body passes `tools/check-pr-body-bilingual.mjs`. / PR 正文通过 `tools/check-pr-body-bilingual.mjs`。
- [x] If the PR touches a manifest-derived protected surface, Governance Declaration is filled with ADR/decision/task evidence or break-glass fields. / 若 PR 触碰 manifest 派生的 protected surface,Governance Declaration 已填写 ADR/decision/task 依据或 break-glass 字段。
- [x] No private harness files are included. / 不包含私有 harness 文件。
- [x] No ignored local agent entry files are included. / 不包含被忽略的本地 agent 入口文件。
- [x] No absolute local filesystem paths are included in this public PR body. / 本公开 PR 描述不包含本机绝对路径。
- [x] Public diff is limited to the stated task scope. / 公开 diff 限于声明的任务范围。
- [x] Private planning/evidence updates are recorded when applicable. / 适用时已记录私有计划 / 证据更新。
- [x] Version and publish impact are stated. / 已说明版本与发布影响。
- [x] Local verification commands are recorded honestly. / 已如实记录本地验证命令。
- [x] CI results are linked or explained. / CI 结果已链接或说明。
- [x] Review evidence is recorded. / 已记录审查证据。
- [x] Open P0/P1/P2 findings are closed, deferred with owner, or explicitly blocked. / open P0/P1/P2 findings 已关闭、带 owner 延后,或明确阻塞。
- [x] Merge method and post-merge branch cleanup plan are clear. / 合并方式和合并后分支清理计划清楚。
- [x] No admin bypass is planned unless explicitly approved and recorded. / 除非明确批准并记录,否则不计划 admin bypass。
