### PR TITLE
feat(kernel): raise default WAL idle flush interval to one hour

### DIFF
--- a/packages/daemon/test/authored-wal-doc-sync.integration.test.ts
+++ b/packages/daemon/test/authored-wal-doc-sync.integration.test.ts
@@ -11,6 +11,10 @@ import { realizeTaskPlanFixture } from "../../../tools/fixtures/task-plan.mjs";
 import { openBootstrappedRepoCell as openRepoCell } from "./repo-settings.fixture.ts";
 import { git, initRepo, ownerBinding, write } from "./doc-sync-slice-a.fixtures.ts";
 
+// Idle WAL→Git materialization defaults to one hour (owner ruling 2026-08-31). These suites
+// wait for materialized commits, so pin the test-local idle timer to a fast interval.
+process.env.HARNESS_WAL_FLUSH_MS = "250";
+
 test("WAL flush settles an eligible authored edit and status highlights blocked candidates", async () => {
   const rootDir = mkdtempSync(path.join(tmpdir(), "ha-authored-wal-doc-sync-"));
   initRepo(rootDir);

--- a/packages/daemon/test/fleet-dual-sync.integration.test.ts
+++ b/packages/daemon/test/fleet-dual-sync.integration.test.ts
@@ -23,232 +23,608 @@ import { runFleetWriteClient } from "../src/fleet/edge.ts";
 import { registerBootstrappedDaemonRepo as registerDaemonRepo } from "./repo-settings.fixture.ts";
 import { realizedTaskPlan } from "../../../tools/fixtures/task-plan.mjs";
 
-const replicaQuota = 64 * 1024 * 1024, nodes = ["node-one", "node-two"] as const;
-type NodeId = typeof nodes[number];
-const submissionPacket = { completionClaim: "complete", deliverables: [], outputs: [], verificationNotes: ["dual-sync integration"], knownGaps: [], residualRisks: [], commitSha: "a".repeat(40) };
+// Idle WAL→Git materialization defaults to one hour (owner ruling 2026-08-31). These suites
+// wait for materialized commits, so pin the test-local idle timer to a fast interval.
+process.env.HARNESS_WAL_FLUSH_MS = "250";
+
+const replicaQuota = 64 * 1024 * 1024,
+  nodes = ["node-one", "node-two"] as const;
+type NodeId = (typeof nodes)[number];
+const submissionPacket = {
+  completionClaim: "complete",
+  deliverables: [],
+  outputs: [],
+  verificationNotes: ["dual-sync integration"],
+  knownGaps: [],
+  residualRisks: [],
+  commitSha: "a".repeat(40),
+};
 
 async function dualSyncFixture() {
-  const root = mkdtempSync(path.join(tmpdir(), "ha-fleet-dual-")), repo = path.join(root, "repo"), userRoot = path.join(root, "user"), stateRoot = path.join(root, "state"), keyFile = path.join(root, "tls.key"), certFile = path.join(root, "tls.crt");
+  const root = mkdtempSync(path.join(tmpdir(), "ha-fleet-dual-")),
+    repo = path.join(root, "repo"),
+    userRoot = path.join(root, "user"),
+    stateRoot = path.join(root, "state"),
+    keyFile = path.join(root, "tls.key"),
+    certFile = path.join(root, "tls.crt");
   mkdirSync(path.join(repo, "harness"), { recursive: true });
-  const git = (...args: readonly string[]): string => execFileSync("git", ["-C", repo, ...args], { encoding: "utf8" }).trim();
-  git("init", "-q"); git("config", "user.name", "Dual Sync Test"); git("config", "user.email", "dual@example.invalid"); git("commit", "--allow-empty", "-qm", "base");
-  writeFileSync(path.join(repo, "harness/harness.yaml"), "schema: harness-anything/v1\nname: dual\nlayout:\n  authoredRoot: harness\n  localRoot: .harness\n");
+  const git = (...args: readonly string[]): string =>
+    execFileSync("git", ["-C", repo, ...args], { encoding: "utf8" }).trim();
+  git("init", "-q");
+  git("config", "user.name", "Dual Sync Test");
+  git("config", "user.email", "dual@example.invalid");
+  git("commit", "--allow-empty", "-qm", "base");
+  writeFileSync(
+    path.join(repo, "harness/harness.yaml"),
+    "schema: harness-anything/v1\nname: dual\nlayout:\n  authoredRoot: harness\n  localRoot: .harness\n",
+  );
   const ownerUid = process.getuid?.() ?? 0;
-  writeFileSync(path.join(repo, "harness/people.yaml"), `${JSON.stringify({ schema: "harness-people/v1", people: [{ personId: "person-fixture", displayName: "Fixture Owner", roles: ["owner"], credentials: [{ kind: "unix-socket-owner-boundary", issuer: `host:${hostname()}`, subject: String(ownerUid) }] }], roles: [{ roleId: "owner", commandClasses: ["admin", "repo-write", "repo-read", "arbiter"] }] }, null, 2)}\n`);
-  git("add", "harness"); git("commit", "-qm", "harness");
+  writeFileSync(
+    path.join(repo, "harness/people.yaml"),
+    `${JSON.stringify({ schema: "harness-people/v1", people: [{ personId: "person-fixture", displayName: "Fixture Owner", roles: ["owner"], credentials: [{ kind: "unix-socket-owner-boundary", issuer: `host:${hostname()}`, subject: String(ownerUid) }] }], roles: [{ roleId: "owner", commandClasses: ["admin", "repo-write", "repo-read", "arbiter"] }] }, null, 2)}\n`,
+  );
+  git("add", "harness");
+  git("commit", "-qm", "harness");
   registerDaemonRepo({ canonicalRoot: repo, repoId: "dual-repo", userRoot, createConvenienceLinks: false });
-  execFileSync("openssl", ["req", "-x509", "-newkey", "rsa:2048", "-nodes", "-keyout", keyFile, "-out", certFile, "-subj", "/CN=localhost", "-days", "1", "-addext", "subjectAltName=DNS:localhost"], { stdio: "ignore" });
-  const key = readFileSync(keyFile), cert = readFileSync(certFile), host = await openDaemonHost({ daemonId: "dual-center", userRoot });
+  execFileSync(
+    "openssl",
+    [
+      "req",
+      "-x509",
+      "-newkey",
+      "rsa:2048",
+      "-nodes",
+      "-keyout",
+      keyFile,
+      "-out",
+      certFile,
+      "-subj",
+      "/CN=localhost",
+      "-days",
+      "1",
+      "-addext",
+      "subjectAltName=DNS:localhost",
+    ],
+    { stdio: "ignore" },
+  );
+  const key = readFileSync(keyFile),
+    cert = readFileSync(certFile),
+    host = await openDaemonHost({ daemonId: "dual-center", userRoot });
   await host.attachmentsSettled();
   // Scope covers every task package plus one shared-surface document: tasks/
   // paths are lease-arbitrated (class A), context/ is the class-B surface.
-  const assignment = (nodeId: NodeId): FleetAssignmentRecord => ({ nodeId, assignmentId: `assignment-${nodeId}`, repoId: "dual-repo", taskId: "task-seeded", executionId: "exe-seeded", paths: ["tasks", "context/shared-notes.md", "context/other-notes.md"], viewId: `${nodeId}-view`, expiresAt: "2099-01-01T00:00:00.000Z", actor: { principal: { personId: `person-${nodeId}` }, executor: { kind: "agent", id: `agent-${nodeId}` } } });
+  const assignment = (nodeId: NodeId): FleetAssignmentRecord => ({
+    nodeId,
+    assignmentId: `assignment-${nodeId}`,
+    repoId: "dual-repo",
+    taskId: "task-seeded",
+    executionId: "exe-seeded",
+    paths: ["tasks", "context/shared-notes.md", "context/other-notes.md"],
+    viewId: `${nodeId}-view`,
+    expiresAt: "2099-01-01T00:00:00.000Z",
+    actor: { principal: { personId: `person-${nodeId}` }, executor: { kind: "agent", id: `agent-${nodeId}` } },
+  });
   const byId = new Map(nodes.map((nodeId) => [assignment(nodeId).assignmentId, assignment(nodeId)]));
-  const center: FleetTlsCenter = await listenFleetTls({ host, stateRoot, key, cert, replicaDiskQuotaBytes: replicaQuota, authenticate: (nodeId, credential) => credential === `secret-${nodeId}`, resolveAssignment: (assignmentId) => byId.get(assignmentId) ?? null });
-  const edgeRoot = (nodeId: NodeId): string => path.join(root, `${nodeId}-edge`), workspace = (nodeId: NodeId): string => path.join(root, `${nodeId}-workspace`);
+  const center: FleetTlsCenter = await listenFleetTls({
+    host,
+    stateRoot,
+    key,
+    cert,
+    replicaDiskQuotaBytes: replicaQuota,
+    authenticate: (nodeId, credential) => credential === `secret-${nodeId}`,
+    resolveAssignment: (assignmentId) => byId.get(assignmentId) ?? null,
+  });
+  const edgeRoot = (nodeId: NodeId): string => path.join(root, `${nodeId}-edge`),
+    workspace = (nodeId: NodeId): string => path.join(root, `${nodeId}-workspace`);
   for (const nodeId of nodes) mkdirSync(workspace(nodeId), { recursive: true });
-  const channel = (nodeId: NodeId) => ({ host: "127.0.0.1", port: center.port, caPath: certFile, servername: "localhost", nodeId, credential: `secret-${nodeId}`, assignmentId: `assignment-${nodeId}`, repoId: "dual-repo", viewRoot: edgeRoot(nodeId), quotaBytes: replicaQuota, workspaceRoot: workspace(nodeId) });
-  const edgeTask = (nodeId: NodeId, action: Record<string, unknown>): Promise<Record<string, unknown>> => runFleetEdgeTask({ payload: { ...channel(nodeId), action: action as never } });
-  const edgeDocSync = (nodeId: NodeId, options: { readonly dryRun?: boolean; readonly paths?: readonly string[] } = {}): Promise<Record<string, unknown>> => runFleetEdgeDocSync({ payload: { ...channel(nodeId), ...options } as never });
-  const conflictExit = (nodeId: NodeId, action: "resolve" | "discard-local" | "overwrite-center", conflictId: string): Promise<Record<string, unknown>> => runFleetEdgeConflictExit({ payload: { ...channel(nodeId), action, conflictId } as never });
-  const rawWrite = (nodeId: NodeId, changes: readonly { readonly path: string; readonly body: string; readonly baseBlobSha256?: string | null }[], executionId: string | null = null) => runFleetWriteClient({ hostname: "127.0.0.1", port: center.port, ca: cert, servername: "localhost", nodeId, credential: `secret-${nodeId}`, assignmentId: `assignment-${nodeId}`, timeoutMs: 30_000, channel: "collaborator", executionId, changes });
+  const channel = (nodeId: NodeId) => ({
+    host: "127.0.0.1",
+    port: center.port,
+    caPath: certFile,
+    servername: "localhost",
+    nodeId,
+    credential: `secret-${nodeId}`,
+    assignmentId: `assignment-${nodeId}`,
+    repoId: "dual-repo",
+    viewRoot: edgeRoot(nodeId),
+    quotaBytes: replicaQuota,
+    workspaceRoot: workspace(nodeId),
+  });
+  const edgeTask = (nodeId: NodeId, action: Record<string, unknown>): Promise<Record<string, unknown>> =>
+    runFleetEdgeTask({ payload: { ...channel(nodeId), action: action as never } });
+  const edgeDocSync = (
+    nodeId: NodeId,
+    options: { readonly dryRun?: boolean; readonly paths?: readonly string[] } = {},
+  ): Promise<Record<string, unknown>> => runFleetEdgeDocSync({ payload: { ...channel(nodeId), ...options } as never });
+  const conflictExit = (
+    nodeId: NodeId,
+    action: "resolve" | "discard-local" | "overwrite-center",
+    conflictId: string,
+  ): Promise<Record<string, unknown>> =>
+    runFleetEdgeConflictExit({ payload: { ...channel(nodeId), action, conflictId } as never });
+  const rawWrite = (
+    nodeId: NodeId,
+    changes: readonly { readonly path: string; readonly body: string; readonly baseBlobSha256?: string | null }[],
+    executionId: string | null = null,
+  ) =>
+    runFleetWriteClient({
+      hostname: "127.0.0.1",
+      port: center.port,
+      ca: cert,
+      servername: "localhost",
+      nodeId,
+      credential: `secret-${nodeId}`,
+      assignmentId: `assignment-${nodeId}`,
+      timeoutMs: 30_000,
+      channel: "collaborator",
+      executionId,
+      changes,
+    });
   const view = (nodeId: NodeId) => locateFleetMirrorView(edgeRoot(nodeId), "dual-repo");
-  const worktree = (nodeId: NodeId, logical: string): string => path.join(workspace(nodeId), "harness", ...logical.split("/"));
-  const writeWorktree = (nodeId: NodeId, logical: string, body: string): void => { const target = worktree(nodeId, logical); mkdirSync(path.dirname(target), { recursive: true }); writeFileSync(target, body); };
+  const worktree = (nodeId: NodeId, logical: string): string =>
+    path.join(workspace(nodeId), "harness", ...logical.split("/"));
+  const writeWorktree = (nodeId: NodeId, logical: string, body: string): void => {
+    const target = worktree(nodeId, logical);
+    mkdirSync(path.dirname(target), { recursive: true });
+    writeFileSync(target, body);
+  };
   const conflictsRoot = (nodeId: NodeId): string => path.join(workspace(nodeId), ".harness", "conflicts");
-  const localAuth = { transportKind: "unix-socket" as const, unixSocketOwnerBoundary: { ownerUid, source: "unix-socket-filesystem-owner-boundary" as const } };
-  const createTask = async (nodeId: NodeId, taskId: string, title: string): Promise<{ readonly taskId: string; readonly packagePath: string }> => { const receipt = await edgeTask(nodeId, { kind: "task-create", taskId, title }); assert.equal(receipt.ok, true, `task create failed: ${JSON.stringify(receipt).slice(0, 400)}`); const packagePath = String(receipt.packagePath), planPath = `${packagePath}/task_plan.md`; writeFileSync(path.join(repo, "harness", planPath), realizedTaskPlan(title)); const submitted = await host.run("dual-repo", { kind: "doc-submit", paths: [planPath] }, localAuth); assert.equal(submitted.outcome, "applied", JSON.stringify(submitted)); const deadline = performance.now() + 15_000; for (;;) { const shown = await host.run("dual-repo", { kind: "receipt-show", opId: submitted.opId }, localAuth); if (typeof shown.commitSha === "string") break; if (performance.now() >= deadline) throw new Error(`Git materialization did not publish ${submitted.opId}`); await new Promise((resolve) => setTimeout(resolve, 25)); } for (const target of nodes) { const synced = await edgeDocSync(target); assert.equal(synced.ok, true, JSON.stringify(synced).slice(0, 500)); } return { taskId: String(receipt.taskId), packagePath }; };
-  return { root, repo, host, center, channel, edgeTask, edgeDocSync, conflictExit, rawWrite, view, worktree, writeWorktree, conflictsRoot, createTask, git, close: async () => { await center.close(); await host.close(); rmSync(root, { recursive: true, force: true }); } };
+  const localAuth = {
+    transportKind: "unix-socket" as const,
+    unixSocketOwnerBoundary: { ownerUid, source: "unix-socket-filesystem-owner-boundary" as const },
+  };
+  const createTask = async (
+    nodeId: NodeId,
+    taskId: string,
+    title: string,
+  ): Promise<{ readonly taskId: string; readonly packagePath: string }> => {
+    const receipt = await edgeTask(nodeId, { kind: "task-create", taskId, title });
+    assert.equal(receipt.ok, true, `task create failed: ${JSON.stringify(receipt).slice(0, 400)}`);
+    const packagePath = String(receipt.packagePath),
+      planPath = `${packagePath}/task_plan.md`;
+    writeFileSync(path.join(repo, "harness", planPath), realizedTaskPlan(title));
+    const submitted = await host.run("dual-repo", { kind: "doc-submit", paths: [planPath] }, localAuth);
+    assert.equal(submitted.outcome, "applied", JSON.stringify(submitted));
+    const deadline = performance.now() + 15_000;
+    for (;;) {
+      const shown = await host.run("dual-repo", { kind: "receipt-show", opId: submitted.opId }, localAuth);
+      if (typeof shown.commitSha === "string") break;
+      if (performance.now() >= deadline) throw new Error(`Git materialization did not publish ${submitted.opId}`);
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    }
+    for (const target of nodes) {
+      const synced = await edgeDocSync(target);
+      assert.equal(synced.ok, true, JSON.stringify(synced).slice(0, 500));
+    }
+    return { taskId: String(receipt.taskId), packagePath };
+  };
+  return {
+    root,
+    repo,
+    host,
+    center,
+    channel,
+    edgeTask,
+    edgeDocSync,
+    conflictExit,
+    rawWrite,
+    view,
+    worktree,
+    writeWorktree,
+    conflictsRoot,
+    createTask,
+    git,
+    close: async () => {
+      await center.close();
+      await host.close();
+      rmSync(root, { recursive: true, force: true });
+    },
+  };
 }
 type Fixture = Awaited<ReturnType<typeof dualSyncFixture>>;
 
-test("remote-edge task and document reads use the authoritative cut after materialization", { timeout: 60_000 }, async (t) => {
-  const fixture: Fixture = await dualSyncFixture(); t.after(() => fixture.close());
-  const created = await fixture.createTask("node-one", "task-seeded", "Authoritative edge read");
-  const shown = await fixture.edgeTask("node-one", { kind: "task-show", taskId: created.taskId });
-  assert.equal(shown.ok, true, JSON.stringify(shown)); assert.ok(Number(shown.revision) > 0); assert.doesNotMatch(String(shown.summary), /task=null/u);
-  const logical = "context/shared-notes.md"; fixture.writeWorktree("node-one", logical, "# Submitted once\n");
-  const submitted = await fixture.edgeDocSync("node-one", { paths: [logical] });
-  assert.equal(submitted.ok, true, JSON.stringify(submitted));
-  const status = await fixture.edgeDocSync("node-one", { dryRun: true, paths: [logical] });
-  assert.equal(status.cut && (status.cut as { revision: number }).revision, submitted.cut && (submitted.cut as { revision: number }).revision);
-  assert.deepEqual(status.rows, [], `already-submitted document was re-eligible: ${JSON.stringify(status.rows)}`);
-});
+test(
+  "remote-edge task and document reads use the authoritative cut after materialization",
+  { timeout: 60_000 },
+  async (t) => {
+    const fixture: Fixture = await dualSyncFixture();
+    t.after(() => fixture.close());
+    const created = await fixture.createTask("node-one", "task-seeded", "Authoritative edge read");
+    const shown = await fixture.edgeTask("node-one", { kind: "task-show", taskId: created.taskId });
+    assert.equal(shown.ok, true, JSON.stringify(shown));
+    assert.ok(Number(shown.revision) > 0);
+    assert.doesNotMatch(String(shown.summary), /task=null/u);
+    const logical = "context/shared-notes.md";
+    fixture.writeWorktree("node-one", logical, "# Submitted once\n");
+    const submitted = await fixture.edgeDocSync("node-one", { paths: [logical] });
+    assert.equal(submitted.ok, true, JSON.stringify(submitted));
+    const status = await fixture.edgeDocSync("node-one", { dryRun: true, paths: [logical] });
+    assert.equal(
+      status.cut && (status.cut as { revision: number }).revision,
+      submitted.cut && (submitted.cut as { revision: number }).revision,
+    );
+    assert.deepEqual(status.rows, [], `already-submitted document was re-eligible: ${JSON.stringify(status.rows)}`);
+  },
+);
 
-test("class A: a task command carries local task documents, and the effect lands in both mirrors", { timeout: 60_000 }, async (t) => {
-  const fixture: Fixture = await dualSyncFixture(); t.after(() => fixture.close());
-  const created = await fixture.createTask("node-one", "task_AAAA000000000000000000000A", "Class A carry");
-  const planPath = `${created.packagePath}/task_plan.md`;
-  const original = readFileSync(fixture.worktree("node-one", planPath), "utf8");
-  fixture.writeWorktree("node-one", planPath, `${original}\n## Edge owner notes\n\nEdited on the edge before starting the task.\n`);
-  const started = await fixture.edgeTask("node-one", { kind: "task-start", taskId: created.taskId, executionId: "exe-a-carry" });
-  assert.equal(started.ok, true, JSON.stringify(started).slice(0, 500));
-  assert.equal((started as { readonly docSync?: { readonly outcome?: string } }).docSync?.outcome, "applied", "the carried documents must land with the transition");
-  assert.equal((started as { readonly mirrorOutcome?: string }).mirrorOutcome, "applied");
-  // The pushed bytes are now the mirror content on both nodes.
-  assert.match(readFileSync(fixture.worktree("node-one", planPath), "utf8"), /Edge owner notes/u);
-  await fixture.edgeTask("node-two", { kind: "task-create", taskId: "task_BBBB000000000000000000000B", title: "Peer view" }); // node-two pulls its own create
-  const peerPlan = readFileSync(fixture.worktree("node-two", planPath), "utf8");
-  assert.match(peerPlan, /Edge owner notes/u, "the second edge must see the carried document through its mirror");
-});
+test(
+  "class A: a task command carries local task documents, and the effect lands in both mirrors",
+  { timeout: 60_000 },
+  async (t) => {
+    const fixture: Fixture = await dualSyncFixture();
+    t.after(() => fixture.close());
+    const created = await fixture.createTask("node-one", "task_AAAA000000000000000000000A", "Class A carry");
+    const planPath = `${created.packagePath}/task_plan.md`;
+    const original = readFileSync(fixture.worktree("node-one", planPath), "utf8");
+    fixture.writeWorktree(
+      "node-one",
+      planPath,
+      `${original}\n## Edge owner notes\n\nEdited on the edge before starting the task.\n`,
+    );
+    const started = await fixture.edgeTask("node-one", {
+      kind: "task-start",
+      taskId: created.taskId,
+      executionId: "exe-a-carry",
+    });
+    assert.equal(started.ok, true, JSON.stringify(started).slice(0, 500));
+    assert.equal(
+      (started as { readonly docSync?: { readonly outcome?: string } }).docSync?.outcome,
+      "applied",
+      "the carried documents must land with the transition",
+    );
+    assert.equal((started as { readonly mirrorOutcome?: string }).mirrorOutcome, "applied");
+    // The pushed bytes are now the mirror content on both nodes.
+    assert.match(readFileSync(fixture.worktree("node-one", planPath), "utf8"), /Edge owner notes/u);
+    await fixture.edgeTask("node-two", {
+      kind: "task-create",
+      taskId: "task_BBBB000000000000000000000B",
+      title: "Peer view",
+    }); // node-two pulls its own create
+    const peerPlan = readFileSync(fixture.worktree("node-two", planPath), "utf8");
+    assert.match(peerPlan, /Edge owner notes/u, "the second edge must see the carried document through its mirror");
+  },
+);
 
-test("F10: a hyphen-prefix sibling package never rides another task's class-A command", { timeout: 60_000 }, async (t) => {
-  const fixture: Fixture = await dualSyncFixture(); t.after(() => fixture.close());
-  const target = await fixture.createTask("node-one", "task-direct", "Direct");
-  const sibling = await fixture.createTask("node-one", "task-direct-other", "Sibling");
-  const siblingPlan = `${sibling.packagePath}/task_plan.md`, original = readFileSync(fixture.worktree("node-one", siblingPlan), "utf8");
-  fixture.writeWorktree("node-one", siblingPlan, `${original}\nSibling-only local note.\n`);
-  const started = await fixture.edgeTask("node-one", { kind: "task-start", taskId: target.taskId, executionId: "exe-prefix-target" });
-  assert.equal(started.ok, true, JSON.stringify(started).slice(0, 500));
-  assert.equal((started as { readonly docSync?: unknown }).docSync, undefined, "the target command must not attach the sibling's dirty document");
-  assert.match(readFileSync(fixture.worktree("node-one", siblingPlan), "utf8"), /Sibling-only local note/u);
-  // Refresh the peer through a real task command: it must not observe the
-  // sibling note because it was not carried under the target's lease.
-  assert.equal((await fixture.edgeTask("node-two", { kind: "task-create", taskId: "task-prefix-observer", title: "Observer" })).ok, true);
-  assert.doesNotMatch(readFileSync(fixture.worktree("node-two", siblingPlan), "utf8"), /Sibling-only local note/u);
-});
+test(
+  "F10: a hyphen-prefix sibling package never rides another task's class-A command",
+  { timeout: 60_000 },
+  async (t) => {
+    const fixture: Fixture = await dualSyncFixture();
+    t.after(() => fixture.close());
+    const target = await fixture.createTask("node-one", "task-direct", "Direct");
+    const sibling = await fixture.createTask("node-one", "task-direct-other", "Sibling");
+    const siblingPlan = `${sibling.packagePath}/task_plan.md`,
+      original = readFileSync(fixture.worktree("node-one", siblingPlan), "utf8");
+    fixture.writeWorktree("node-one", siblingPlan, `${original}\nSibling-only local note.\n`);
+    const started = await fixture.edgeTask("node-one", {
+      kind: "task-start",
+      taskId: target.taskId,
+      executionId: "exe-prefix-target",
+    });
+    assert.equal(started.ok, true, JSON.stringify(started).slice(0, 500));
+    assert.equal(
+      (started as { readonly docSync?: unknown }).docSync,
+      undefined,
+      "the target command must not attach the sibling's dirty document",
+    );
+    assert.match(readFileSync(fixture.worktree("node-one", siblingPlan), "utf8"), /Sibling-only local note/u);
+    // Refresh the peer through a real task command: it must not observe the
+    // sibling note because it was not carried under the target's lease.
+    assert.equal(
+      (await fixture.edgeTask("node-two", { kind: "task-create", taskId: "task-prefix-observer", title: "Observer" }))
+        .ok,
+      true,
+    );
+    assert.doesNotMatch(readFileSync(fixture.worktree("node-two", siblingPlan), "utf8"), /Sibling-only local note/u);
+  },
+);
 
-test("class A: a base conflict voids the whole transition and stages base/local/center", { timeout: 60_000 }, async (t) => {
-  const fixture: Fixture = await dualSyncFixture(); t.after(() => fixture.close());
-  const created = await fixture.createTask("node-one", "task_CCCC000000000000000000000C", "Base conflict");
-  const planPath = `${created.packagePath}/task_plan.md`, original = readFileSync(fixture.worktree("node-one", planPath), "utf8");
-  // Another collaborator rewrites the plan at the center while this edge is
-  // still based on the original cut. F1: the channel-less doc submit is
-  // refused outright; the collaborator must hold the lease and name it.
-  const centerVersion = `${original}\n## Rewritten at the center\n\nThe center moved this document first.\n`;
-  const refused = await fixture.rawWrite("node-two", [{ path: planPath, body: centerVersion, baseBlobSha256: sha256Bytes(Buffer.from(original)) }]);
-  assert.equal(refused.center.outcome, "op_rejected");
-  assert.equal(refused.center.code, "task_docs_require_task_command");
-  assert.equal((await fixture.edgeTask("node-two", { kind: "task-start", taskId: created.taskId, executionId: "exe-center-writer" })).ok, true);
-  const pushed = await fixture.rawWrite("node-two", [{ path: planPath, body: centerVersion, baseBlobSha256: sha256Bytes(Buffer.from(original)) }], "exe-center-writer");
-  assert.equal(pushed.center.outcome, "applied");
-  assert.equal((await fixture.edgeTask("node-two", { kind: "task-release", taskId: created.taskId, reason: "center-side rewrite done" })).ok, true);
-  const localVersion = `${original}\n## Edge owner notes\n\nLocal edit based on the stale cut.\n`;
-  fixture.writeWorktree("node-one", planPath, localVersion);
-  const started = await fixture.edgeTask("node-one", { kind: "task-start", taskId: created.taskId, executionId: "exe-a-conflict" });
-  assert.equal(started.ok, false, "a base conflict must void the whole command");
-  assert.ok(["mirror_behind_center", "base_blob_changed"].includes(String((started as { readonly code?: string }).code)), `a conflict code was expected, saw ${String((started as { readonly code?: string }).code)}`);
-  // The transition did NOT happen: the task still has no lease at the center.
-  const leases = fixture.center.status().leases.leases.filter((row) => row.taskId === created.taskId);
-  assert.equal(leases.length, 0, "the center state must not transition on a conflicted bundle");
-  // The divergence is staged with all three sides.
-  const conflicts = readdirSync(fixture.conflictsRoot("node-one")).filter((entry) => entry.startsWith("cflt-"));
-  assert.equal(conflicts.length, 1, `exactly one staged conflict expected, saw ${conflicts.join(",")}`);
-  const dir = path.join(fixture.conflictsRoot("node-one"), conflicts[0]!);
-  const manifest = JSON.parse(readFileSync(path.join(dir, "manifest.json"), "utf8")) as { readonly code: string; readonly paths: readonly { readonly path: string }[]; readonly exits: readonly string[]; readonly state: string };
-  assert.deepEqual(manifest.paths.map((row) => row.path), [planPath]);
-  assert.deepEqual(manifest.exits, ["resolve", "discard-local", "overwrite-center"]);
-  assert.match(readFileSync(path.join(dir, "local", planPath), "utf8"), /Edge owner notes/u);
-  assert.match(readFileSync(path.join(dir, "center", planPath), "utf8"), /Rewritten at the center/u);
-  assert.ok(readFileSync(path.join(dir, "base", planPath), "utf8").startsWith(original.slice(0, 40).trim()), "the staged base side must hold the original cut bytes");
-  // The center document is untouched by the failed push and the local edit survives.
-  assert.match(readFileSync(fixture.worktree("node-one", planPath), "utf8"), /Edge owner notes/u);
-  // The per-path base guard itself: a bundle whose mirror cut is current but
-  // whose declared per-path base no longer matches the projection is refused
-  // with base_blob_changed and the transition never runs.
-  const auth = { transportKind: "fleet-tls" as const, assignmentBinding: { nodeId: "node-one", assignmentId: "assignment-node-one", repoId: "dual-repo", taskId: created.taskId, executionId: "exe-seeded", paths: ["tasks"], actor: { principal: { personId: "person-node-one" }, executor: { kind: "agent" as const, id: "agent-node-one" } } } };
-  const status = await fixture.host.run("dual-repo", { kind: "doc-status", paths: [planPath] }, auth);
-  if (status.detail?.kind !== "doc_sync") throw new Error("doc status lacks a canonical cut");
-  const current = status.detail.currentLedgerSha;
-  const probe = await fixture.host.run("dual-repo", { kind: "task-start", taskId: created.taskId, executionId: "exe-a-probe", mirrorBaseCut: { revision: current.revision, headDigest: current.headDigest }, docChanges: [{ path: planPath, baseBlobSha256: sha256Bytes(Buffer.from(localVersion)), policyId: "markdown-body-replaceable/v1", candidate: { ref: `doc-sync-claims/${sha256Bytes(Buffer.from(centerVersion))}`, sha256: sha256Bytes(Buffer.from(centerVersion)), size: Buffer.byteLength(centerVersion), mediaType: "text/markdown" } }] }, auth);
-  assert.equal(probe.outcome, "op_rejected");
-  assert.equal(probe.code, "base_blob_changed");
-  assert.equal(fixture.center.status().leases.leases.filter((row) => row.taskId === created.taskId).length, 0, "the probe transition must not apply either");
-});
+test(
+  "class A: a base conflict voids the whole transition and stages base/local/center",
+  { timeout: 60_000 },
+  async (t) => {
+    const fixture: Fixture = await dualSyncFixture();
+    t.after(() => fixture.close());
+    const created = await fixture.createTask("node-one", "task_CCCC000000000000000000000C", "Base conflict");
+    const planPath = `${created.packagePath}/task_plan.md`,
+      original = readFileSync(fixture.worktree("node-one", planPath), "utf8");
+    // Another collaborator rewrites the plan at the center while this edge is
+    // still based on the original cut. F1: the channel-less doc submit is
+    // refused outright; the collaborator must hold the lease and name it.
+    const centerVersion = `${original}\n## Rewritten at the center\n\nThe center moved this document first.\n`;
+    const refused = await fixture.rawWrite("node-two", [
+      { path: planPath, body: centerVersion, baseBlobSha256: sha256Bytes(Buffer.from(original)) },
+    ]);
+    assert.equal(refused.center.outcome, "op_rejected");
+    assert.equal(refused.center.code, "task_docs_require_task_command");
+    assert.equal(
+      (
+        await fixture.edgeTask("node-two", {
+          kind: "task-start",
+          taskId: created.taskId,
+          executionId: "exe-center-writer",
+        })
+      ).ok,
+      true,
+    );
+    const pushed = await fixture.rawWrite(
+      "node-two",
+      [{ path: planPath, body: centerVersion, baseBlobSha256: sha256Bytes(Buffer.from(original)) }],
+      "exe-center-writer",
+    );
+    assert.equal(pushed.center.outcome, "applied");
+    assert.equal(
+      (
+        await fixture.edgeTask("node-two", {
+          kind: "task-release",
+          taskId: created.taskId,
+          reason: "center-side rewrite done",
+        })
+      ).ok,
+      true,
+    );
+    const localVersion = `${original}\n## Edge owner notes\n\nLocal edit based on the stale cut.\n`;
+    fixture.writeWorktree("node-one", planPath, localVersion);
+    const started = await fixture.edgeTask("node-one", {
+      kind: "task-start",
+      taskId: created.taskId,
+      executionId: "exe-a-conflict",
+    });
+    assert.equal(started.ok, false, "a base conflict must void the whole command");
+    assert.ok(
+      ["mirror_behind_center", "base_blob_changed"].includes(String((started as { readonly code?: string }).code)),
+      `a conflict code was expected, saw ${String((started as { readonly code?: string }).code)}`,
+    );
+    // The transition did NOT happen: the task still has no lease at the center.
+    const leases = fixture.center.status().leases.leases.filter((row) => row.taskId === created.taskId);
+    assert.equal(leases.length, 0, "the center state must not transition on a conflicted bundle");
+    // The divergence is staged with all three sides.
+    const conflicts = readdirSync(fixture.conflictsRoot("node-one")).filter((entry) => entry.startsWith("cflt-"));
+    assert.equal(conflicts.length, 1, `exactly one staged conflict expected, saw ${conflicts.join(",")}`);
+    const dir = path.join(fixture.conflictsRoot("node-one"), conflicts[0]!);
+    const manifest = JSON.parse(readFileSync(path.join(dir, "manifest.json"), "utf8")) as {
+      readonly code: string;
+      readonly paths: readonly { readonly path: string }[];
+      readonly exits: readonly string[];
+      readonly state: string;
+    };
+    assert.deepEqual(
+      manifest.paths.map((row) => row.path),
+      [planPath],
+    );
+    assert.deepEqual(manifest.exits, ["resolve", "discard-local", "overwrite-center"]);
+    assert.match(readFileSync(path.join(dir, "local", planPath), "utf8"), /Edge owner notes/u);
+    assert.match(readFileSync(path.join(dir, "center", planPath), "utf8"), /Rewritten at the center/u);
+    assert.ok(
+      readFileSync(path.join(dir, "base", planPath), "utf8").startsWith(original.slice(0, 40).trim()),
+      "the staged base side must hold the original cut bytes",
+    );
+    // The center document is untouched by the failed push and the local edit survives.
+    assert.match(readFileSync(fixture.worktree("node-one", planPath), "utf8"), /Edge owner notes/u);
+    // The per-path base guard itself: a bundle whose mirror cut is current but
+    // whose declared per-path base no longer matches the projection is refused
+    // with base_blob_changed and the transition never runs.
+    const auth = {
+      transportKind: "fleet-tls" as const,
+      assignmentBinding: {
+        nodeId: "node-one",
+        assignmentId: "assignment-node-one",
+        repoId: "dual-repo",
+        taskId: created.taskId,
+        executionId: "exe-seeded",
+        paths: ["tasks"],
+        actor: {
+          principal: { personId: "person-node-one" },
+          executor: { kind: "agent" as const, id: "agent-node-one" },
+        },
+      },
+    };
+    const status = await fixture.host.run("dual-repo", { kind: "doc-status", paths: [planPath] }, auth);
+    if (status.detail?.kind !== "doc_sync") throw new Error("doc status lacks a canonical cut");
+    const current = status.detail.currentLedgerSha;
+    const probe = await fixture.host.run(
+      "dual-repo",
+      {
+        kind: "task-start",
+        taskId: created.taskId,
+        executionId: "exe-a-probe",
+        mirrorBaseCut: { revision: current.revision, headDigest: current.headDigest },
+        docChanges: [
+          {
+            path: planPath,
+            baseBlobSha256: sha256Bytes(Buffer.from(localVersion)),
+            policyId: "markdown-body-replaceable/v1",
+            candidate: {
+              ref: `doc-sync-claims/${sha256Bytes(Buffer.from(centerVersion))}`,
+              sha256: sha256Bytes(Buffer.from(centerVersion)),
+              size: Buffer.byteLength(centerVersion),
+              mediaType: "text/markdown",
+            },
+          },
+        ],
+      },
+      auth,
+    );
+    assert.equal(probe.outcome, "op_rejected");
+    assert.equal(probe.code, "base_blob_changed");
+    assert.equal(
+      fixture.center.status().leases.leases.filter((row) => row.taskId === created.taskId).length,
+      0,
+      "the probe transition must not apply either",
+    );
+  },
+);
 
-test("class A: a stale mirror cut is refused, then the same command applies after a sync", { timeout: 60_000 }, async (t) => {
-  const fixture: Fixture = await dualSyncFixture(); t.after(() => fixture.close());
-  const created = await fixture.createTask("node-one", "task_DDDD000000000000000000000D", "Mirror gate");
-  const planPath = `${created.packagePath}/task_plan.md`, original = readFileSync(fixture.worktree("node-one", planPath), "utf8");
-  // The center advances on a path this edge does not touch, so only the mirror
-  // base cut is stale — the gate must still refuse to carry documents on it.
-  await fixture.rawWrite("node-two", [{ path: "context/shared-notes.md", body: "# Shared\n\nFirst center version.\n" }]);
-  fixture.writeWorktree("node-one", planPath, `${original}\n## Local plan edit\n\nBased on the previous cut.\n`);
-  const refused = await fixture.edgeTask("node-one", { kind: "task-start", taskId: created.taskId, executionId: "exe-a-gate" });
-  assert.equal(refused.ok, false);
-  assert.equal((refused as { readonly code?: string }).code, "mirror_behind_center");
-  assert.equal(fixture.center.status().leases.leases.filter((row) => row.taskId === created.taskId).length, 0, "the transition must not apply behind the gate");
-  // The explicit sync round refreshes the mirror; the retried command applies.
-  const synced = await fixture.edgeDocSync("node-one");
-  assert.equal(synced.ok, true, JSON.stringify(synced).slice(0, 400));
-  const retried = await fixture.edgeTask("node-one", { kind: "task-start", taskId: created.taskId, executionId: "exe-a-gate" });
-  assert.equal(retried.ok, true, JSON.stringify(retried).slice(0, 500));
-  assert.equal((retried as { readonly docSync?: { readonly outcome?: string } }).docSync?.outcome, "applied");
-  assert.match(readFileSync(fixture.worktree("node-one", planPath), "utf8"), /Local plan edit/u);
-});
+test(
+  "class A: a stale mirror cut is refused, then the same command applies after a sync",
+  { timeout: 60_000 },
+  async (t) => {
+    const fixture: Fixture = await dualSyncFixture();
+    t.after(() => fixture.close());
+    const created = await fixture.createTask("node-one", "task_DDDD000000000000000000000D", "Mirror gate");
+    const planPath = `${created.packagePath}/task_plan.md`,
+      original = readFileSync(fixture.worktree("node-one", planPath), "utf8");
+    // The center advances on a path this edge does not touch, so only the mirror
+    // base cut is stale — the gate must still refuse to carry documents on it.
+    await fixture.rawWrite("node-two", [
+      { path: "context/shared-notes.md", body: "# Shared\n\nFirst center version.\n" },
+    ]);
+    fixture.writeWorktree("node-one", planPath, `${original}\n## Local plan edit\n\nBased on the previous cut.\n`);
+    const refused = await fixture.edgeTask("node-one", {
+      kind: "task-start",
+      taskId: created.taskId,
+      executionId: "exe-a-gate",
+    });
+    assert.equal(refused.ok, false);
+    assert.equal((refused as { readonly code?: string }).code, "mirror_behind_center");
+    assert.equal(
+      fixture.center.status().leases.leases.filter((row) => row.taskId === created.taskId).length,
+      0,
+      "the transition must not apply behind the gate",
+    );
+    // The explicit sync round refreshes the mirror; the retried command applies.
+    const synced = await fixture.edgeDocSync("node-one");
+    assert.equal(synced.ok, true, JSON.stringify(synced).slice(0, 400));
+    const retried = await fixture.edgeTask("node-one", {
+      kind: "task-start",
+      taskId: created.taskId,
+      executionId: "exe-a-gate",
+    });
+    assert.equal(retried.ok, true, JSON.stringify(retried).slice(0, 500));
+    assert.equal((retried as { readonly docSync?: { readonly outcome?: string } }).docSync?.outcome, "applied");
+    assert.match(readFileSync(fixture.worktree("node-one", planPath), "utf8"), /Local plan edit/u);
+  },
+);
 
-test("non-holder task-document pushes are rejected outright (no staging, no ledger effect)", { timeout: 60_000 }, async (t) => {
-  const fixture: Fixture = await dualSyncFixture(); t.after(() => fixture.close());
-  const created = await fixture.createTask("node-one", "task_EEEE000000000000000000000E", "Holder only");
-  const started = await fixture.edgeTask("node-one", { kind: "task-start", taskId: created.taskId, executionId: "exe-a-holder" });
-  assert.equal(started.ok, true);
-  const planPath = `${created.packagePath}/task_plan.md`, original = readFileSync(fixture.worktree("node-one", planPath), "utf8");
-  const before = Number(fixture.git("rev-list", "--count", "refs/ha/canonical"));
-  // node-two names the holder's execution but is a different principal: the
-  // domain lease rejects the push, bypassing the automatic entry changes
-  // nothing.
-  const attempt = await fixture.rawWrite("node-two", [{ path: planPath, body: `${original}\n## Non-holder edit\n\nMust not land.\n`, baseBlobSha256: sha256Bytes(Buffer.from(original)) }], "exe-a-holder");
-  assert.equal(attempt.center.outcome, "op_rejected");
-  assert.equal(attempt.center.code, "lease_conflict");
-  assert.equal(Number(fixture.git("rev-list", "--count", "refs/ha/canonical")), before, "the ledger must not move for a non-holder push");
-});
+test(
+  "non-holder task-document pushes are rejected outright (no staging, no ledger effect)",
+  { timeout: 60_000 },
+  async (t) => {
+    const fixture: Fixture = await dualSyncFixture();
+    t.after(() => fixture.close());
+    const created = await fixture.createTask("node-one", "task_EEEE000000000000000000000E", "Holder only");
+    const started = await fixture.edgeTask("node-one", {
+      kind: "task-start",
+      taskId: created.taskId,
+      executionId: "exe-a-holder",
+    });
+    assert.equal(started.ok, true);
+    const planPath = `${created.packagePath}/task_plan.md`,
+      original = readFileSync(fixture.worktree("node-one", planPath), "utf8");
+    const before = Number(fixture.git("rev-list", "--count", "refs/ha/canonical"));
+    // node-two names the holder's execution but is a different principal: the
+    // domain lease rejects the push, bypassing the automatic entry changes
+    // nothing.
+    const attempt = await fixture.rawWrite(
+      "node-two",
+      [
+        {
+          path: planPath,
+          body: `${original}\n## Non-holder edit\n\nMust not land.\n`,
+          baseBlobSha256: sha256Bytes(Buffer.from(original)),
+        },
+      ],
+      "exe-a-holder",
+    );
+    assert.equal(attempt.center.outcome, "op_rejected");
+    assert.equal(attempt.center.code, "lease_conflict");
+    assert.equal(
+      Number(fixture.git("rev-list", "--count", "refs/ha/canonical")),
+      before,
+      "the ledger must not move for a non-holder push",
+    );
+  },
+);
 
-test("class B: doc sync compares, pushes, and CENTER_REJECTED stages instead of overwriting; all three exits work", { timeout: 60_000 }, async (t) => {
-  const fixture: Fixture = await dualSyncFixture(); t.after(() => fixture.close());
-  const shared = "context/shared-notes.md";
-  await fixture.rawWrite("node-one", [{ path: shared, body: "# Shared\n\nv1 baseline.\n" }]);
-  const first = await fixture.edgeDocSync("node-one", { paths: [shared] });
-  assert.equal(first.ok, true, JSON.stringify(first).slice(0, 400));
-  assert.equal(readFileSync(fixture.worktree("node-one", shared), "utf8"), "# Shared\n\nv1 baseline.\n");
-  // Local edit on the edge; the center version moves underneath it.
-  const localBody = "# Shared\n\nv1 baseline.\n\n## Edge one addition\n\nOnly on the edge.\n";
-  fixture.writeWorktree("node-one", shared, localBody);
-  await fixture.rawWrite("node-two", [{ path: shared, body: "# Shared\n\nv1 baseline.\n\n## Center version two\n\nWritten by the peer edge.\n", baseBlobSha256: sha256Bytes(Buffer.from("# Shared\n\nv1 baseline.\n")) }]);
-  const conflicted = await fixture.edgeDocSync("node-one", { paths: [shared] });
-  assert.equal(conflicted.ok, false, "the round must not report success over divergence");
-  assert.equal((conflicted as { readonly syncState?: string }).syncState, "CONFLICT_STAGED");
-  assert.equal((conflicted as { readonly code?: string }).code, "pull_blocked");
-  const conflicts = readdirSync(fixture.conflictsRoot("node-one")).filter((entry) => entry.startsWith("cflt-"));
-  assert.equal(conflicts.length, 1);
-  const conflictId = conflicts[0]!, dir = path.join(fixture.conflictsRoot("node-one"), conflictId);
-  assert.match(readFileSync(path.join(dir, "center", shared), "utf8"), /Center version two/u);
-  assert.match(readFileSync(path.join(dir, "local", shared), "utf8"), /Edge one addition/u);
-  // Nothing was merged or overwritten: the worktree keeps the local bytes and
-  // the center keeps its own.
-  assert.match(readFileSync(fixture.worktree("node-one", shared), "utf8"), /Edge one addition/u);
-  // Exit 2 — discard-local: the worktree adopts the recorded center bytes.
-  const discarded = await fixture.conflictExit("node-one", "discard-local", conflictId);
-  assert.equal(discarded.ok, true, JSON.stringify(discarded).slice(0, 400));
-  assert.match(readFileSync(fixture.worktree("node-one", shared), "utf8"), /Center version two/u);
-  const settled = JSON.parse(readFileSync(path.join(dir, "manifest.json"), "utf8")) as { readonly state: string; readonly resolvedVia: string };
-  assert.equal(settled.state, "resolved"); assert.equal(settled.resolvedVia, "discard-local");
-  // Stage a second divergence and take exit 3 — overwrite-center.
-  fixture.writeWorktree("node-one", shared, "# Shared\n\nv1 baseline.\n\n## Center version two\n\nWritten by the peer edge.\n\n## Edge one wins\n\nExplicit overwrite.\n");
-  // The center revision stays inside the existing region (no new heading):
-  // the additive-region policy forbids wholesale rewrites, so the overwrite
-  // exit must also operate within it.
-  const v3 = await fixture.rawWrite("node-two", [{ path: shared, body: "# Shared\n\nv1 baseline.\n\n## Center version two\n\nWritten by the peer edge, revised at the center.\n", baseBlobSha256: sha256Bytes(Buffer.from("# Shared\n\nv1 baseline.\n\n## Center version two\n\nWritten by the peer edge.\n")) }]);
-  assert.equal(v3.center.outcome, "applied", JSON.stringify(v3.center));
-  const second = await fixture.edgeDocSync("node-one", { paths: [shared] });
-  assert.equal(second.ok, false, JSON.stringify(second).slice(0, 600));
-  const secondConflicts = readdirSync(fixture.conflictsRoot("node-one")).filter((entry) => entry.startsWith("cflt-"));
-  assert.equal(secondConflicts.length, 2, `expected the second divergence to stage separately, saw ${secondConflicts.join(",")}`);
-  const secondId = secondConflicts.find((entry) => entry !== conflictId)!;
-  const overwritten = await fixture.conflictExit("node-one", "overwrite-center", secondId);
-  assert.equal(overwritten.ok, true, JSON.stringify(overwritten).slice(0, 500));
-  const afterOverwrite = readFileSync(fixture.worktree("node-one", shared), "utf8");
-  assert.match(afterOverwrite, /Edge one wins/u, "the mirror must hold the explicit overwrite result");
-  // Exit 1 — resolve closes a record by hand.
-  fixture.writeWorktree("node-one", shared, `${afterOverwrite}\n## Merged by hand\n\nresolve exit.\n`);
-  const resolved = await fixture.conflictExit("node-one", "resolve", conflictId);
-  assert.equal(resolved.ok, true);
-  const final = await fixture.edgeDocSync("node-one", { paths: [shared] });
-  assert.equal(final.ok, true, `after resolving, the round must converge: ${JSON.stringify(final).slice(0, 400)}`);
-  assert.equal((final as { readonly syncState?: string }).syncState, "SYNCED");
-});
+test(
+  "class B: doc sync compares, pushes, and CENTER_REJECTED stages instead of overwriting; all three exits work",
+  { timeout: 60_000 },
+  async (t) => {
+    const fixture: Fixture = await dualSyncFixture();
+    t.after(() => fixture.close());
+    const shared = "context/shared-notes.md";
+    await fixture.rawWrite("node-one", [{ path: shared, body: "# Shared\n\nv1 baseline.\n" }]);
+    const first = await fixture.edgeDocSync("node-one", { paths: [shared] });
+    assert.equal(first.ok, true, JSON.stringify(first).slice(0, 400));
+    assert.equal(readFileSync(fixture.worktree("node-one", shared), "utf8"), "# Shared\n\nv1 baseline.\n");
+    // Local edit on the edge; the center version moves underneath it.
+    const localBody = "# Shared\n\nv1 baseline.\n\n## Edge one addition\n\nOnly on the edge.\n";
+    fixture.writeWorktree("node-one", shared, localBody);
+    await fixture.rawWrite("node-two", [
+      {
+        path: shared,
+        body: "# Shared\n\nv1 baseline.\n\n## Center version two\n\nWritten by the peer edge.\n",
+        baseBlobSha256: sha256Bytes(Buffer.from("# Shared\n\nv1 baseline.\n")),
+      },
+    ]);
+    const conflicted = await fixture.edgeDocSync("node-one", { paths: [shared] });
+    assert.equal(conflicted.ok, false, "the round must not report success over divergence");
+    assert.equal((conflicted as { readonly syncState?: string }).syncState, "CONFLICT_STAGED");
+    assert.equal((conflicted as { readonly code?: string }).code, "pull_blocked");
+    const conflicts = readdirSync(fixture.conflictsRoot("node-one")).filter((entry) => entry.startsWith("cflt-"));
+    assert.equal(conflicts.length, 1);
+    const conflictId = conflicts[0]!,
+      dir = path.join(fixture.conflictsRoot("node-one"), conflictId);
+    assert.match(readFileSync(path.join(dir, "center", shared), "utf8"), /Center version two/u);
+    assert.match(readFileSync(path.join(dir, "local", shared), "utf8"), /Edge one addition/u);
+    // Nothing was merged or overwritten: the worktree keeps the local bytes and
+    // the center keeps its own.
+    assert.match(readFileSync(fixture.worktree("node-one", shared), "utf8"), /Edge one addition/u);
+    // Exit 2 — discard-local: the worktree adopts the recorded center bytes.
+    const discarded = await fixture.conflictExit("node-one", "discard-local", conflictId);
+    assert.equal(discarded.ok, true, JSON.stringify(discarded).slice(0, 400));
+    assert.match(readFileSync(fixture.worktree("node-one", shared), "utf8"), /Center version two/u);
+    const settled = JSON.parse(readFileSync(path.join(dir, "manifest.json"), "utf8")) as {
+      readonly state: string;
+      readonly resolvedVia: string;
+    };
+    assert.equal(settled.state, "resolved");
+    assert.equal(settled.resolvedVia, "discard-local");
+    // Stage a second divergence and take exit 3 — overwrite-center.
+    fixture.writeWorktree(
+      "node-one",
+      shared,
+      "# Shared\n\nv1 baseline.\n\n## Center version two\n\nWritten by the peer edge.\n\n## Edge one wins\n\nExplicit overwrite.\n",
+    );
+    // The center revision stays inside the existing region (no new heading):
+    // the additive-region policy forbids wholesale rewrites, so the overwrite
+    // exit must also operate within it.
+    const v3 = await fixture.rawWrite("node-two", [
+      {
+        path: shared,
+        body: "# Shared\n\nv1 baseline.\n\n## Center version two\n\nWritten by the peer edge, revised at the center.\n",
+        baseBlobSha256: sha256Bytes(
+          Buffer.from("# Shared\n\nv1 baseline.\n\n## Center version two\n\nWritten by the peer edge.\n"),
+        ),
+      },
+    ]);
+    assert.equal(v3.center.outcome, "applied", JSON.stringify(v3.center));
+    const second = await fixture.edgeDocSync("node-one", { paths: [shared] });
+    assert.equal(second.ok, false, JSON.stringify(second).slice(0, 600));
+    const secondConflicts = readdirSync(fixture.conflictsRoot("node-one")).filter((entry) => entry.startsWith("cflt-"));
+    assert.equal(
+      secondConflicts.length,
+      2,
+      `expected the second divergence to stage separately, saw ${secondConflicts.join(",")}`,
+    );
+    const secondId = secondConflicts.find((entry) => entry !== conflictId)!;
+    const overwritten = await fixture.conflictExit("node-one", "overwrite-center", secondId);
+    assert.equal(overwritten.ok, true, JSON.stringify(overwritten).slice(0, 500));
+    const afterOverwrite = readFileSync(fixture.worktree("node-one", shared), "utf8");
+    assert.match(afterOverwrite, /Edge one wins/u, "the mirror must hold the explicit overwrite result");
+    // Exit 1 — resolve closes a record by hand.
+    fixture.writeWorktree("node-one", shared, `${afterOverwrite}\n## Merged by hand\n\nresolve exit.\n`);
+    const resolved = await fixture.conflictExit("node-one", "resolve", conflictId);
+    assert.equal(resolved.ok, true);
+    const final = await fixture.edgeDocSync("node-one", { paths: [shared] });
+    assert.equal(final.ok, true, `after resolving, the round must converge: ${JSON.stringify(final).slice(0, 400)}`);
+    assert.equal((final as { readonly syncState?: string }).syncState, "SYNCED");
+  },
+);
 
 test("class B: a clean push round applies at the center and reports SYNCED", { timeout: 60_000 }, async (t) => {
-  const fixture: Fixture = await dualSyncFixture(); t.after(() => fixture.close());
+  const fixture: Fixture = await dualSyncFixture();
+  t.after(() => fixture.close());
   const shared = "context/shared-notes.md";
   await fixture.rawWrite("node-one", [{ path: shared, body: "# Shared\n\nbaseline.\n" }]);
   const baseline = await fixture.edgeDocSync("node-one", { paths: [shared] });
@@ -260,171 +636,376 @@ test("class B: a clean push round applies at the center and reports SYNCED", { t
   const submitted = await fixture.edgeDocSync("node-one", { paths: [shared] });
   assert.equal(submitted.ok, true, JSON.stringify(submitted).slice(0, 400));
   assert.equal((submitted as { readonly syncState?: string }).syncState, "SYNCED");
-  assert.equal(readFileSync(fixture.worktree("node-one", shared), "utf8"), "# Shared\n\nbaseline.\n\n## Push me\n\nClean local change.\n");
+  assert.equal(
+    readFileSync(fixture.worktree("node-one", shared), "utf8"),
+    "# Shared\n\nbaseline.\n\n## Push me\n\nClean local change.\n",
+  );
   const peer = await fixture.edgeDocSync("node-two", { paths: [shared] });
   assert.equal(peer.ok, true);
   assert.match(readFileSync(fixture.worktree("node-two", shared), "utf8"), /Push me/u);
 });
 
 test("pull-blocked is reported on the dual axis instead of masquerading as synced", { timeout: 60_000 }, async (t) => {
-  const fixture: Fixture = await dualSyncFixture(); t.after(() => fixture.close());
+  const fixture: Fixture = await dualSyncFixture();
+  t.after(() => fixture.close());
   const taskA = await fixture.createTask("node-one", "task_FFFF000000000000000000000F", "Dual axis A");
   const taskB = await fixture.createTask("node-one", "task_GGGG000000000000000000000G", "Dual axis B");
-  assert.equal((await fixture.edgeTask("node-one", { kind: "task-start", taskId: taskA.taskId, executionId: "exe-dual-a" })).ok, true);
+  assert.equal(
+    (await fixture.edgeTask("node-one", { kind: "task-start", taskId: taskA.taskId, executionId: "exe-dual-a" })).ok,
+    true,
+  );
   const planB = `${taskB.packagePath}/task_plan.md`;
   // node-one keeps a local edit on task B's plan while node-two takes B and
   // pushes a different version through its own task command.
   const original = readFileSync(fixture.worktree("node-one", planB), "utf8");
   fixture.writeWorktree("node-one", planB, `${original}\n## Node one local notes\n\nUnsynced.\n`);
-  assert.equal((await fixture.edgeTask("node-two", { kind: "task-start", taskId: taskB.taskId, executionId: "exe-dual-b" })).ok, true);
+  assert.equal(
+    (await fixture.edgeTask("node-two", { kind: "task-start", taskId: taskB.taskId, executionId: "exe-dual-b" })).ok,
+    true,
+  );
   const peerOriginal = readFileSync(fixture.worktree("node-two", planB), "utf8");
-  fixture.writeWorktree("node-two", planB, `${peerOriginal}\n## Node two landed version\n\nPushed while node-one was dirty.\n`);
-  const peerPush = await fixture.edgeTask("node-two", { kind: "task-progress-append", taskId: taskB.taskId, text: "peer pushed the plan with this transition" });
+  fixture.writeWorktree(
+    "node-two",
+    planB,
+    `${peerOriginal}\n## Node two landed version\n\nPushed while node-one was dirty.\n`,
+  );
+  const peerPush = await fixture.edgeTask("node-two", {
+    kind: "task-progress-append",
+    taskId: taskB.taskId,
+    text: "peer pushed the plan with this transition",
+  });
   assert.equal(peerPush.ok, true, JSON.stringify(peerPush).slice(0, 500));
   // node-one's own command on task A applies at the center; the auto pull then
   // finds the diverged task B plan and must say pull_blocked, not synced.
-  const progress = await fixture.edgeTask("node-one", { kind: "task-progress-append", taskId: taskA.taskId, text: "applied at the center while the mirror diverged" });
+  const progress = await fixture.edgeTask("node-one", {
+    kind: "task-progress-append",
+    taskId: taskA.taskId,
+    text: "applied at the center while the mirror diverged",
+  });
   assert.equal(progress.ok, false, "a pull-blocked outcome must not report ok");
   assert.equal((progress as { readonly canonicalOutcome?: string }).canonicalOutcome, "applied");
   assert.equal((progress as { readonly mirrorOutcome?: string }).mirrorOutcome, "pull_blocked");
   const conflicts = readdirSync(fixture.conflictsRoot("node-one")).filter((entry) => entry.startsWith("cflt-"));
   assert.equal(conflicts.length, 1);
-  const manifest = JSON.parse(readFileSync(path.join(fixture.conflictsRoot("node-one"), conflicts[0]!, "manifest.json"), "utf8")) as { readonly paths: readonly { readonly path: string }[] };
-  assert.deepEqual(manifest.paths.map((row) => row.path), [planB]);
-  assert.match(readFileSync(fixture.worktree("node-one", planB), "utf8"), /Node one local notes/u, "the local bytes must survive untouched");
+  const manifest = JSON.parse(
+    readFileSync(path.join(fixture.conflictsRoot("node-one"), conflicts[0]!, "manifest.json"), "utf8"),
+  ) as { readonly paths: readonly { readonly path: string }[] };
+  assert.deepEqual(
+    manifest.paths.map((row) => row.path),
+    [planB],
+  );
+  assert.match(
+    readFileSync(fixture.worktree("node-one", planB), "utf8"),
+    /Node one local notes/u,
+    "the local bytes must survive untouched",
+  );
 });
 
 test("F4: an unresolved conflict gates this task's later commands at the edge", { timeout: 60_000 }, async (t) => {
-  const fixture: Fixture = await dualSyncFixture(); t.after(() => fixture.close());
+  const fixture: Fixture = await dualSyncFixture();
+  t.after(() => fixture.close());
   const created = await fixture.createTask("node-one", "task_IIII000000000000000000000I", "Gate task");
-  const planPath = `${created.packagePath}/task_plan.md`, original = readFileSync(fixture.worktree("node-one", planPath), "utf8");
+  const planPath = `${created.packagePath}/task_plan.md`,
+    original = readFileSync(fixture.worktree("node-one", planPath), "utf8");
   // Diverge the plan: center rewrite (holder channel) vs local edit.
-  assert.equal((await fixture.edgeTask("node-one", { kind: "task-start", taskId: created.taskId, executionId: "exe-gate-a" })).ok, true);
-  await fixture.rawWrite("node-one", [{ path: planPath, body: `${original}\n## Center version\n`, baseBlobSha256: sha256Bytes(Buffer.from(original)) }], "exe-gate-a");
-  assert.equal((await fixture.edgeTask("node-one", { kind: "task-release", taskId: created.taskId, reason: "handing over" })).ok, true);
+  assert.equal(
+    (await fixture.edgeTask("node-one", { kind: "task-start", taskId: created.taskId, executionId: "exe-gate-a" })).ok,
+    true,
+  );
+  await fixture.rawWrite(
+    "node-one",
+    [{ path: planPath, body: `${original}\n## Center version\n`, baseBlobSha256: sha256Bytes(Buffer.from(original)) }],
+    "exe-gate-a",
+  );
+  assert.equal(
+    (await fixture.edgeTask("node-one", { kind: "task-release", taskId: created.taskId, reason: "handing over" })).ok,
+    true,
+  );
   fixture.writeWorktree("node-one", planPath, `${original}\n## Local version\n`);
   // A second node takes the lease and moves the plan; edge-one's local edit diverges.
   assert.equal((await fixture.edgeDocSync("node-two")).ok, true);
   const takeover = await fixture.edgeTask("node-two", { kind: "task-start", taskId: created.taskId });
   assert.equal(takeover.ok, true, JSON.stringify(takeover).slice(0, 500));
   const centerNow = `${original}\n## Center version\n`;
-  const moved = await fixture.rawWrite("node-two", [{ path: planPath, body: `${centerNow}\n## Center moved again\n`, baseBlobSha256: sha256Bytes(Buffer.from(centerNow)) }], "exe-gate-a");
+  const moved = await fixture.rawWrite(
+    "node-two",
+    [
+      {
+        path: planPath,
+        body: `${centerNow}\n## Center moved again\n`,
+        baseBlobSha256: sha256Bytes(Buffer.from(centerNow)),
+      },
+    ],
+    "exe-gate-a",
+  );
   assert.equal(moved.center.outcome, "applied", JSON.stringify(moved.center));
-  assert.equal((await fixture.edgeTask("node-two", { kind: "task-release", taskId: created.taskId, reason: "gate scenario" })).ok, true);
+  assert.equal(
+    (await fixture.edgeTask("node-two", { kind: "task-release", taskId: created.taskId, reason: "gate scenario" })).ok,
+    true,
+  );
   const diverged = await fixture.edgeDocSync("node-one", { paths: [planPath] });
   assert.equal(diverged.ok, false, JSON.stringify(diverged).slice(0, 400));
   assert.equal((diverged as { readonly syncState?: string }).syncState, "CONFLICT_STAGED");
   // The unresolved record gates this task's commands BEFORE any upload: no
   // center round-trip, no ledger movement.
   const beforeGate = Number(fixture.git("rev-list", "--count", "refs/ha/canonical"));
-  const gated = await fixture.edgeTask("node-one", { kind: "task-start", taskId: created.taskId, executionId: "exe-gate-c" });
+  const gated = await fixture.edgeTask("node-one", {
+    kind: "task-start",
+    taskId: created.taskId,
+    executionId: "exe-gate-c",
+  });
   assert.equal(gated.ok, false);
   assert.equal((gated as { readonly code?: string }).code, "conflict_open");
-  assert.equal(Number(fixture.git("rev-list", "--count", "refs/ha/canonical")), beforeGate, "the gate must refuse without touching the center");
+  assert.equal(
+    Number(fixture.git("rev-list", "--count", "refs/ha/canonical")),
+    beforeGate,
+    "the gate must refuse without touching the center",
+  );
   // Another task is unaffected: its commands stay canonically admissible even
   // while this task's conflict is open (the mirror may still report the other
   // task's divergence on the dual axis — that is the honest outcome).
-  const other = await fixture.edgeTask("node-one", { kind: "task-create", taskId: "task_JJJJ000000000000000000000J", title: "Unaffected task" });
-  assert.equal((other as { readonly canonicalOutcome?: string }).canonicalOutcome, "applied", JSON.stringify(other).slice(0, 400));
+  const other = await fixture.edgeTask("node-one", {
+    kind: "task-create",
+    taskId: "task_JJJJ000000000000000000000J",
+    title: "Unaffected task",
+  });
+  assert.equal(
+    (other as { readonly canonicalOutcome?: string }).canonicalOutcome,
+    "applied",
+    JSON.stringify(other).slice(0, 400),
+  );
   fixture.writeWorktree("node-one", `${String(other.packagePath)}/task_plan.md`, realizedTaskPlan("Unaffected task"));
-  const otherStart = await fixture.edgeTask("node-one", { kind: "task-start", taskId: "task_JJJJ000000000000000000000J", executionId: "exe-gate-other" });
-  assert.equal((otherStart as { readonly canonicalOutcome?: string }).canonicalOutcome, "applied", JSON.stringify(otherStart).slice(0, 400));
+  const otherStart = await fixture.edgeTask("node-one", {
+    kind: "task-start",
+    taskId: "task_JJJJ000000000000000000000J",
+    executionId: "exe-gate-other",
+  });
+  assert.equal(
+    (otherStart as { readonly canonicalOutcome?: string }).canonicalOutcome,
+    "applied",
+    JSON.stringify(otherStart).slice(0, 400),
+  );
   // discard-local lifts the gate.
   const record = readFleetUnresolvedConflicts(path.join(fixture.root, "node-one-workspace"), "dual-repo")[0]!;
   const discarded = await fixture.conflictExit("node-one", "discard-local", record.conflictId);
   assert.equal(discarded.ok, true, JSON.stringify(discarded).slice(0, 400));
   const ungated = await fixture.edgeTask("node-one", { kind: "task-start", taskId: created.taskId });
-  assert.equal((ungated as { readonly canonicalOutcome?: string }).canonicalOutcome, "applied", JSON.stringify(ungated).slice(0, 400));
+  assert.equal(
+    (ungated as { readonly canonicalOutcome?: string }).canonicalOutcome,
+    "applied",
+    JSON.stringify(ungated).slice(0, 400),
+  );
 });
 
-test("F5/F6: a rejected push settles honestly and overwrite-center is idempotent across a crash after the append", { timeout: 60_000 }, async (t) => {
-  const fixture: Fixture = await dualSyncFixture(); t.after(() => fixture.close());
-  const shared = "context/shared-notes.md";
-  await fixture.rawWrite("node-one", [{ path: shared, body: "# Shared\n\nbaseline.\n" }]);
-  assert.equal((await fixture.edgeDocSync("node-one", { paths: [shared] })).ok, true);
-  const baseline = "# Shared\n\nbaseline.\n";
-  // Keep both edits within the existing # Shared region. That creates a
-  // legitimate shared-prose divergence and also lets the fixture emulate the
-  // already-appended overwrite bytes without violating the heading policy.
-  fixture.writeWorktree("node-one", shared, `${baseline}\nEdge one wins.\n`);
-  await fixture.rawWrite("node-two", [{ path: shared, body: `${baseline}\nCenter moved.\n`, baseBlobSha256: sha256Bytes(Buffer.from(baseline)) }]);
-  // settlePushRejection with a diverged mirror stages base/local/center and reports blocked.
-  const peer = { hostname: "127.0.0.1", port: fixture.center.port, ca: readFileSync(path.join(fixture.root, "tls.crt")), servername: "localhost", nodeId: "node-one", credential: "secret-node-one", assignmentId: "assignment-node-one" };
-  const diverged = await settlePushRejection({ ...fixture.channel("node-one") }, peer, 30_000, "base_blob_changed");
-  assert.equal(diverged.blocked, true);
-  assert.equal(diverged.conflicts.length, 1, "a same-path move must stage its record, not strand the operator");
-  const record = diverged.conflicts[0]!;
-  const manifest = JSON.parse(readFileSync(path.join(record.dir, "manifest.json"), "utf8")) as { readonly paths: readonly { readonly path: string }[] };
-  assert.deepEqual(manifest.paths.map((row) => row.path), [shared]);
-  // settlePushRejection with a NON-diverged mirror reports an honest
-  // CENTER_REJECTED (blocked=false, nothing staged) instead of claiming
-  // CONFLICT_STAGED with no record (F5).
-  // Use the peer's clean mirror for the ledger-only rejection branch. The
-  // node-one view intentionally still carries the unresolved same-path
-  // conflict above; reusing it would test the persistent gate, not the
-  // CENTER_REJECTED-without-staging outcome.
-  assert.equal((await fixture.edgeDocSync("node-two", { paths: [shared] })).ok, true);
-  const peerTwo = { hostname: "127.0.0.1", port: fixture.center.port, ca: readFileSync(path.join(fixture.root, "tls.crt")), servername: "localhost", nodeId: "node-two", credential: "secret-node-two", assignmentId: "assignment-node-two" };
-  const clean = await settlePushRejection({ ...fixture.channel("node-two"), paths: [] }, peerTwo, 30_000, "base_ledger_changed");
-  assert.equal(clean.blocked, false);
-  assert.deepEqual(clean.conflicts, []);
-  // F6 idempotency: simulate a crash after the center append by pushing the
-  // staged local bytes directly (holder-less shared channel), then retrying
-  // the exit — it must settle without a second push.
-  const settledRecord = readFleetUnresolvedConflicts(path.join(fixture.root, "node-one-workspace"), "dual-repo").find((entry) => entry.paths.some((row) => row.path === shared))!;
-  // The simulated crash happens after the center append has committed the
-  // staged local bytes verbatim. A retry must recognize that digest and close
-  // the record without appending a second event.
-  const stagedLocal = `${baseline}\nEdge one wins.\n`;
-  const manual = await fixture.rawWrite("node-one", [{ path: shared, body: stagedLocal, baseBlobSha256: sha256Bytes(Buffer.from(`${baseline}\nCenter moved.\n`)) }]);
-  assert.equal(manual.center.outcome, "applied", JSON.stringify(manual.center));
-  const commitsAfterAppend = Number(fixture.git("rev-list", "--count", "refs/ha/canonical"));
-  const idempotent = await fixture.conflictExit("node-one", "overwrite-center", settledRecord.conflictId);
-  assert.equal(idempotent.ok, true, JSON.stringify(idempotent).slice(0, 400));
-  assert.equal((idempotent as { readonly idempotent?: boolean }).idempotent, true);
-  const after = JSON.parse(readFileSync(path.join(fixture.root, "node-one-workspace", ".harness", "conflicts", settledRecord.conflictId, "manifest.json"), "utf8")) as { readonly state: string };
-  assert.equal(after.state, "resolved");
-  assert.equal(Number(fixture.git("rev-list", "--count", "refs/ha/canonical")), commitsAfterAppend, "the idempotent retry must not append a second doc event");
-});
+test(
+  "F5/F6: a rejected push settles honestly and overwrite-center is idempotent across a crash after the append",
+  { timeout: 60_000 },
+  async (t) => {
+    const fixture: Fixture = await dualSyncFixture();
+    t.after(() => fixture.close());
+    const shared = "context/shared-notes.md";
+    await fixture.rawWrite("node-one", [{ path: shared, body: "# Shared\n\nbaseline.\n" }]);
+    assert.equal((await fixture.edgeDocSync("node-one", { paths: [shared] })).ok, true);
+    const baseline = "# Shared\n\nbaseline.\n";
+    // Keep both edits within the existing # Shared region. That creates a
+    // legitimate shared-prose divergence and also lets the fixture emulate the
+    // already-appended overwrite bytes without violating the heading policy.
+    fixture.writeWorktree("node-one", shared, `${baseline}\nEdge one wins.\n`);
+    await fixture.rawWrite("node-two", [
+      { path: shared, body: `${baseline}\nCenter moved.\n`, baseBlobSha256: sha256Bytes(Buffer.from(baseline)) },
+    ]);
+    // settlePushRejection with a diverged mirror stages base/local/center and reports blocked.
+    const peer = {
+      hostname: "127.0.0.1",
+      port: fixture.center.port,
+      ca: readFileSync(path.join(fixture.root, "tls.crt")),
+      servername: "localhost",
+      nodeId: "node-one",
+      credential: "secret-node-one",
+      assignmentId: "assignment-node-one",
+    };
+    const diverged = await settlePushRejection({ ...fixture.channel("node-one") }, peer, 30_000, "base_blob_changed");
+    assert.equal(diverged.blocked, true);
+    assert.equal(diverged.conflicts.length, 1, "a same-path move must stage its record, not strand the operator");
+    const record = diverged.conflicts[0]!;
+    const manifest = JSON.parse(readFileSync(path.join(record.dir, "manifest.json"), "utf8")) as {
+      readonly paths: readonly { readonly path: string }[];
+    };
+    assert.deepEqual(
+      manifest.paths.map((row) => row.path),
+      [shared],
+    );
+    // settlePushRejection with a NON-diverged mirror reports an honest
+    // CENTER_REJECTED (blocked=false, nothing staged) instead of claiming
+    // CONFLICT_STAGED with no record (F5).
+    // Use the peer's clean mirror for the ledger-only rejection branch. The
+    // node-one view intentionally still carries the unresolved same-path
+    // conflict above; reusing it would test the persistent gate, not the
+    // CENTER_REJECTED-without-staging outcome.
+    assert.equal((await fixture.edgeDocSync("node-two", { paths: [shared] })).ok, true);
+    const peerTwo = {
+      hostname: "127.0.0.1",
+      port: fixture.center.port,
+      ca: readFileSync(path.join(fixture.root, "tls.crt")),
+      servername: "localhost",
+      nodeId: "node-two",
+      credential: "secret-node-two",
+      assignmentId: "assignment-node-two",
+    };
+    const clean = await settlePushRejection(
+      { ...fixture.channel("node-two"), paths: [] },
+      peerTwo,
+      30_000,
+      "base_ledger_changed",
+    );
+    assert.equal(clean.blocked, false);
+    assert.deepEqual(clean.conflicts, []);
+    // F6 idempotency: simulate a crash after the center append by pushing the
+    // staged local bytes directly (holder-less shared channel), then retrying
+    // the exit — it must settle without a second push.
+    const settledRecord = readFleetUnresolvedConflicts(path.join(fixture.root, "node-one-workspace"), "dual-repo").find(
+      (entry) => entry.paths.some((row) => row.path === shared),
+    )!;
+    // The simulated crash happens after the center append has committed the
+    // staged local bytes verbatim. A retry must recognize that digest and close
+    // the record without appending a second event.
+    const stagedLocal = `${baseline}\nEdge one wins.\n`;
+    const manual = await fixture.rawWrite("node-one", [
+      { path: shared, body: stagedLocal, baseBlobSha256: sha256Bytes(Buffer.from(`${baseline}\nCenter moved.\n`)) },
+    ]);
+    assert.equal(manual.center.outcome, "applied", JSON.stringify(manual.center));
+    const commitsAfterAppend = Number(fixture.git("rev-list", "--count", "refs/ha/canonical"));
+    const idempotent = await fixture.conflictExit("node-one", "overwrite-center", settledRecord.conflictId);
+    assert.equal(idempotent.ok, true, JSON.stringify(idempotent).slice(0, 400));
+    assert.equal((idempotent as { readonly idempotent?: boolean }).idempotent, true);
+    const after = JSON.parse(
+      readFileSync(
+        path.join(
+          fixture.root,
+          "node-one-workspace",
+          ".harness",
+          "conflicts",
+          settledRecord.conflictId,
+          "manifest.json",
+        ),
+        "utf8",
+      ),
+    ) as { readonly state: string };
+    assert.equal(after.state, "resolved");
+    assert.equal(
+      Number(fixture.git("rev-list", "--count", "refs/ha/canonical")),
+      commitsAfterAppend,
+      "the idempotent retry must not append a second doc event",
+    );
+  },
+);
 
-test("F6: an idempotent overwrite reports a newly pull-blocked mirror instead of masking it", { timeout: 60_000 }, async (t) => {
-  const fixture: Fixture = await dualSyncFixture(); t.after(() => fixture.close());
-  const shared = "context/shared-notes.md", other = "context/other-notes.md";
-  const sharedBase = "# Shared\n\nbaseline.\n", otherBase = "# Other\n\nbaseline.\n";
-  assert.equal((await fixture.rawWrite("node-one", [{ path: shared, body: sharedBase }])).center.outcome, "applied");
-  assert.equal((await fixture.rawWrite("node-one", [{ path: other, body: otherBase }])).center.outcome, "applied");
-  assert.equal((await fixture.edgeDocSync("node-one")).ok, true);
-  const sharedLocal = `${sharedBase}\nedge wins.\n`;
-  fixture.writeWorktree("node-one", shared, sharedLocal);
-  assert.equal((await fixture.rawWrite("node-two", [{ path: shared, body: `${sharedBase}\ncenter moved.\n`, baseBlobSha256: sha256Bytes(Buffer.from(sharedBase)) }])).center.outcome, "applied");
-  const peer = { hostname: "127.0.0.1", port: fixture.center.port, ca: readFileSync(path.join(fixture.root, "tls.crt")), servername: "localhost", nodeId: "node-one", credential: "secret-node-one", assignmentId: "assignment-node-one" };
-  const staged = await settlePushRejection({ ...fixture.channel("node-one") }, peer, 30_000, "base_blob_changed");
-  assert.equal(staged.blocked, true);
-  const original = staged.conflicts[0]!;
-  // A different path diverges after the original record exists. The simulated
-  // crashed overwrite then makes only the original path canonical.
-  fixture.writeWorktree("node-one", other, `${otherBase}\nedge-local.\n`);
-  assert.equal((await fixture.rawWrite("node-two", [{ path: other, body: `${otherBase}\ncenter-new.\n`, baseBlobSha256: sha256Bytes(Buffer.from(otherBase)) }])).center.outcome, "applied");
-  assert.equal((await fixture.rawWrite("node-one", [{ path: shared, body: sharedLocal, baseBlobSha256: sha256Bytes(Buffer.from(`${sharedBase}\ncenter moved.\n`)) }])).center.outcome, "applied");
-  const retried = await fixture.conflictExit("node-one", "overwrite-center", original.conflictId);
-  assert.equal(retried.ok, false, JSON.stringify(retried).slice(0, 600));
-  assert.equal((retried as { readonly idempotent?: boolean }).idempotent, true);
-  assert.equal((retried as { readonly canonicalOutcome?: string }).canonicalOutcome, "applied");
-  assert.equal((retried as { readonly mirrorOutcome?: string }).mirrorOutcome, "pull_blocked");
-  const originalState = JSON.parse(readFileSync(path.join(original.dir, "manifest.json"), "utf8")) as { readonly state: string };
-  assert.equal(originalState.state, "resolved", "the already-canonical overwrite itself is settled");
-  assert.ok(readFleetUnresolvedConflicts(path.join(fixture.root, "node-one-workspace"), "dual-repo").some((record) => record.paths.some((row) => row.path === other)), "the unrelated divergence must remain staged and visible");
-});
+test(
+  "F6: an idempotent overwrite reports a newly pull-blocked mirror instead of masking it",
+  { timeout: 60_000 },
+  async (t) => {
+    const fixture: Fixture = await dualSyncFixture();
+    t.after(() => fixture.close());
+    const shared = "context/shared-notes.md",
+      other = "context/other-notes.md";
+    const sharedBase = "# Shared\n\nbaseline.\n",
+      otherBase = "# Other\n\nbaseline.\n";
+    assert.equal((await fixture.rawWrite("node-one", [{ path: shared, body: sharedBase }])).center.outcome, "applied");
+    assert.equal((await fixture.rawWrite("node-one", [{ path: other, body: otherBase }])).center.outcome, "applied");
+    assert.equal((await fixture.edgeDocSync("node-one")).ok, true);
+    const sharedLocal = `${sharedBase}\nedge wins.\n`;
+    fixture.writeWorktree("node-one", shared, sharedLocal);
+    assert.equal(
+      (
+        await fixture.rawWrite("node-two", [
+          {
+            path: shared,
+            body: `${sharedBase}\ncenter moved.\n`,
+            baseBlobSha256: sha256Bytes(Buffer.from(sharedBase)),
+          },
+        ])
+      ).center.outcome,
+      "applied",
+    );
+    const peer = {
+      hostname: "127.0.0.1",
+      port: fixture.center.port,
+      ca: readFileSync(path.join(fixture.root, "tls.crt")),
+      servername: "localhost",
+      nodeId: "node-one",
+      credential: "secret-node-one",
+      assignmentId: "assignment-node-one",
+    };
+    const staged = await settlePushRejection({ ...fixture.channel("node-one") }, peer, 30_000, "base_blob_changed");
+    assert.equal(staged.blocked, true);
+    const original = staged.conflicts[0]!;
+    // A different path diverges after the original record exists. The simulated
+    // crashed overwrite then makes only the original path canonical.
+    fixture.writeWorktree("node-one", other, `${otherBase}\nedge-local.\n`);
+    assert.equal(
+      (
+        await fixture.rawWrite("node-two", [
+          { path: other, body: `${otherBase}\ncenter-new.\n`, baseBlobSha256: sha256Bytes(Buffer.from(otherBase)) },
+        ])
+      ).center.outcome,
+      "applied",
+    );
+    assert.equal(
+      (
+        await fixture.rawWrite("node-one", [
+          {
+            path: shared,
+            body: sharedLocal,
+            baseBlobSha256: sha256Bytes(Buffer.from(`${sharedBase}\ncenter moved.\n`)),
+          },
+        ])
+      ).center.outcome,
+      "applied",
+    );
+    const retried = await fixture.conflictExit("node-one", "overwrite-center", original.conflictId);
+    assert.equal(retried.ok, false, JSON.stringify(retried).slice(0, 600));
+    assert.equal((retried as { readonly idempotent?: boolean }).idempotent, true);
+    assert.equal((retried as { readonly canonicalOutcome?: string }).canonicalOutcome, "applied");
+    assert.equal((retried as { readonly mirrorOutcome?: string }).mirrorOutcome, "pull_blocked");
+    const originalState = JSON.parse(readFileSync(path.join(original.dir, "manifest.json"), "utf8")) as {
+      readonly state: string;
+    };
+    assert.equal(originalState.state, "resolved", "the already-canonical overwrite itself is settled");
+    assert.ok(
+      readFleetUnresolvedConflicts(path.join(fixture.root, "node-one-workspace"), "dual-repo").some((record) =>
+        record.paths.some((row) => row.path === other),
+      ),
+      "the unrelated divergence must remain staged and visible",
+    );
+  },
+);
 
 test("class A submit carries the closing documents in the same serial command", { timeout: 60_000 }, async (t) => {
-  const fixture: Fixture = await dualSyncFixture(); t.after(() => fixture.close());
+  const fixture: Fixture = await dualSyncFixture();
+  t.after(() => fixture.close());
   const created = await fixture.createTask("node-one", "task_HHHH000000000000000000000H", "Closing docs ride submit");
-  assert.equal((await fixture.edgeTask("node-one", { kind: "task-start", taskId: created.taskId, executionId: "exe-a-submit" })).ok, true);
-  const planPath = `${created.packagePath}/task_plan.md`, original = readFileSync(fixture.worktree("node-one", planPath), "utf8");
+  assert.equal(
+    (await fixture.edgeTask("node-one", { kind: "task-start", taskId: created.taskId, executionId: "exe-a-submit" }))
+      .ok,
+    true,
+  );
+  const planPath = `${created.packagePath}/task_plan.md`,
+    original = readFileSync(fixture.worktree("node-one", planPath), "utf8");
   fixture.writeWorktree("node-one", planPath, `${original}\n## Closing note\n\nRides the submit.\n`);
-  const submitted = await fixture.edgeTask("node-one", { kind: "task-submit", taskId: created.taskId, executionId: "exe-a-submit", submission: submissionPacket });
+  const submitted = await fixture.edgeTask("node-one", {
+    kind: "task-submit",
+    taskId: created.taskId,
+    executionId: "exe-a-submit",
+    submission: submissionPacket,
+  });
   assert.equal(submitted.ok, true, JSON.stringify(submitted).slice(0, 500));
-  assert.equal((submitted as { readonly docSync?: { readonly outcome?: string; readonly paths?: readonly string[] } }).docSync?.outcome, "applied");
-  assert.deepEqual((submitted as { readonly docSync?: { readonly paths?: readonly string[] } }).docSync?.paths, [planPath]);
+  assert.equal(
+    (submitted as { readonly docSync?: { readonly outcome?: string; readonly paths?: readonly string[] } }).docSync
+      ?.outcome,
+    "applied",
+  );
+  assert.deepEqual((submitted as { readonly docSync?: { readonly paths?: readonly string[] } }).docSync?.paths, [
+    planPath,
+  ]);
   assert.match(readFileSync(fixture.worktree("node-one", planPath), "utf8"), /Closing note/u);
 });

--- a/packages/daemon/test/fleet-transport-scale.integration.test.ts
+++ b/packages/daemon/test/fleet-transport-scale.integration.test.ts
@@ -10,6 +10,10 @@ import { listenFleetTls, type FleetAssignmentRecord, type FleetTlsCenter } from 
 import { registerBootstrappedDaemonRepo as registerDaemonRepo } from "./repo-settings.fixture.ts";
 import { realizeTaskPlanFixture } from "../../../tools/fixtures/task-plan.mjs";
 
+// Idle WAL→Git materialization defaults to one hour (owner ruling 2026-08-31). These suites
+// wait for materialized commits, so pin the test-local idle timer to a fast interval.
+process.env.HARNESS_WAL_FLUSH_MS = "250";
+
 const replicaQuota = 64 * 1024 * 1024;
 function reclaimer() {
   const closers: Array<() => void> = [],

--- a/packages/daemon/test/fleet-transport.integration.test.ts
+++ b/packages/daemon/test/fleet-transport.integration.test.ts
@@ -37,6 +37,10 @@ import {
 import type { RuntimeInstallationWitness } from "../src/agent-runtime-instances.ts";
 import { realizeTaskPlanFixture } from "../../../tools/fixtures/task-plan.mjs";
 
+// Idle WAL→Git materialization defaults to one hour (owner ruling 2026-08-31). These suites
+// wait for materialized commits, so pin the test-local idle timer to a fast interval.
+process.env.HARNESS_WAL_FLUSH_MS = "250";
+
 const replicaQuota = 64 * 1024 * 1024;
 // A `node --test` timeout suspends the test body at its current await and never resumes it, so `try…finally`
 // teardown does not run on the timeout path. Every fixture therefore owns its OS resources and every test hands

--- a/packages/daemon/test/gui-s3-contract.test.ts
+++ b/packages/daemon/test/gui-s3-contract.test.ts
@@ -30,7 +30,7 @@ test("daemon Settings reads use the exact canonical Settings shape", () => {
       task: "governance/task-scaffold.json",
       repository: "governance/repository-scaffold.json",
     },
-    walFlush: { adaptive: true, events: 256, bytes: 8_388_608, milliseconds: 2_000 },
+    walFlush: { adaptive: true, events: 256, bytes: 8_388_608, milliseconds: 3_600_000 },
   };
   const valid = { schema: "daemon.settings-read/v1", ok: true, settings };
   assert.equal(parseDaemonGuiReadResult("repo.settings.read", valid), valid);

--- a/packages/gui/test/service-bridge.test.ts
+++ b/packages/gui/test/service-bridge.test.ts
@@ -176,7 +176,7 @@ test("GUI client reaches every shipped read through a real resident daemon", asy
         task: "governance/task-scaffold.json",
         repository: "governance/repository-scaffold.json",
       },
-      walFlush: { adaptive: true, events: 256, bytes: 8_388_608, milliseconds: 2_000 },
+      walFlush: { adaptive: true, events: 256, bytes: 8_388_608, milliseconds: 3_600_000 },
     });
     const settingsUpdated = parseDaemonGuiActionResponse(
       "repo.settings.update",

--- a/packages/gui/test/service-bridge.test.ts
+++ b/packages/gui/test/service-bridge.test.ts
@@ -24,6 +24,10 @@ import {
 } from "../../daemon/src/protocol/gui-result-validation.ts";
 import { createLocalGuiServiceBridge } from "../src/index.ts";
 import { startGuiResidentDaemonFixture } from "../test-support/resident-daemon.mjs";
+
+// Idle WAL→Git materialization defaults to one hour (owner ruling 2026-08-31). This suite
+// waits for materialized commits, so pin the test-local idle timer to a fast interval.
+process.env.HARNESS_WAL_FLUSH_MS = "250";
 import { writeTriadicLedger } from "../test-support/triadic-ledger.mjs";
 import type { Failure } from "./service-bridge.fixtures.ts";
 import { restoreEnv } from "./service-bridge.fixtures.ts";

--- a/packages/gui/test/settings-repository-selectors.vitest.ts
+++ b/packages/gui/test/settings-repository-selectors.vitest.ts
@@ -23,7 +23,7 @@ const SETTINGS = {
   defaultProfile: "baseline",
   locale: "zh-CN" as const,
   scaffolds: { task: "governance/task-scaffold.json", repository: "governance/repository-scaffold.json" },
-  walFlush: { adaptive: true, events: 256, bytes: 8_388_608, milliseconds: 2_000 },
+  walFlush: { adaptive: true, events: 256, bytes: 8_388_608, milliseconds: 3_600_000 },
 };
 const SNAPSHOT = {
   schema: "gui-catalog-snapshot/v1" as const,
@@ -280,7 +280,7 @@ describe("Settings 仓库字段是目录喂的选择器", () => {
       walFlushAdaptive: true,
       walFlushEvents: 256,
       walFlushBytes: 8_388_608,
-      walFlushMilliseconds: 2_000,
+      walFlushMilliseconds: 3_600_000,
     });
   });
 

--- a/packages/gui/test/system-group-widescreen.vitest.ts
+++ b/packages/gui/test/system-group-widescreen.vitest.ts
@@ -47,7 +47,7 @@ function seedQueries(client: QueryClient): void {
       defaultProfile: "baseline",
       locale: "zh-CN",
       scaffolds: { task: "governance/task-scaffold.json", repository: "governance/repository-scaffold.json" },
-      walFlush: { adaptive: true, events: 256, bytes: 8_388_608, milliseconds: 2_000 },
+      walFlush: { adaptive: true, events: 256, bytes: 8_388_608, milliseconds: 3_600_000 },
     },
   });
   client.setQueryData(catalogQueryKeys.snapshot(REPO_ID), {
@@ -268,7 +268,7 @@ describe("Settings kind renderer consumes and updates the daemon-owned facet", (
         defaultProfile: "baseline",
         locale: "zh-CN" as const,
         scaffolds: { task: "governance/task-scaffold.json", repository: "governance/repository-scaffold.json" },
-        walFlush: { adaptive: true, events: 256, bytes: 8_388_608, milliseconds: 2_000 },
+        walFlush: { adaptive: true, events: 256, bytes: 8_388_608, milliseconds: 3_600_000 },
       },
       updateSettings = vi.fn(async (payload: Record<string, unknown>) => ({
         schema: "command-receipt/v2",

--- a/packages/kernel/src/domain/settings.ts
+++ b/packages/kernel/src/domain/settings.ts
@@ -14,11 +14,15 @@ export interface WalFlushSettingsV1 {
   readonly milliseconds: number;
 }
 
+// Owner ruling (Zeyu, 2026-08-31): the idle timer is a floor, not the flush
+// driver — 256 events / 8 MiB remain the load-bounded triggers, and one commit
+// per hour of idle activity replaces the ~2s cadence that produced 100+
+// ledger commits per day.
 export const DEFAULT_WAL_FLUSH_SETTINGS: WalFlushSettingsV1 = Object.freeze({
   adaptive: true,
   events: 256,
   bytes: 8 * 1024 * 1024,
-  milliseconds: 2_000,
+  milliseconds: 3_600_000,
 });
 
 export const SETTINGS_FIELD_OWNERSHIP = Object.freeze({


### PR DESCRIPTION
# English

## Summary

The default WAL idle flush interval was 2 seconds, so an active day produced well over a hundred `harness WAL flush` ledger commits. Per the owner's ruling (Zeyu, 2026-08-31), the two load-bounded triggers stay exactly as they are — 256 events and 8 MiB still force a flush under load — and only the idle timer is raised from 2 seconds to one hour. The loss window stays bounded by the event/byte caps; the timer is a floor for quiet periods, not the flush driver. Test fixtures that mirror the default settings object are updated to the new value; the repo-cell settings integration fixture keeps its explicit 2000ms value because it tests explicit configuration, not the default.

## Architectural Justification

- Not required: one frozen default constant changes value; no mechanism, flag, or layer is added. Per-repository override through settings remains the existing path.

## What Changed

- `packages/kernel/src/domain/settings.ts`: `DEFAULT_WAL_FLUSH_SETTINGS.milliseconds` 2_000 → 3_600_000, with a comment recording the ruling.
- Default-mirroring test fixtures updated: `gui-s3-contract.test.ts`, `settings-repository-selectors.vitest.ts` (two sites), `service-bridge.test.ts`, `system-group-widescreen.vitest.ts` (two sites).

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: use the single CI-backed `Production-Delta` declaration below; do not enter a second metric.

## Machine-Readable Declarations

Production-Delta: +5/-1

## Task And Scope

- Harness task: task_5fc5080044fcfdbf548008f2f5 milestone lane (owner-ruled operational default change)
- Branch: codex/wal-flush-interval
- Public scope: one kernel default constant and the test fixtures that mirror it
- Private planning/evidence updated: yes (fact F-B16F8586 records the flush-cadence ground truth)
- Out of scope: adaptive flush algorithm, event/byte caps, per-repository settings channel

## Version Impact

- Version: no version change because only a default value moves within the existing settings contract
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope:
- Authority: not applicable
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason:
- Break-glass scope:
- Follow-up governance task:

## Verification

- Base `origin/main` SHA: e4bdcce67359c7130fafc65dd421f42e4eee6530
- Branch merge-base with `origin/main`: e4bdcce67359c7130fafc65dd421f42e4eee6530
- Last `git fetch origin` time: 2026-08-31 evening
- Sync method: branched from current `origin/main`
- Public diff command: git diff origin/main..codex/wal-flush-interval
- Private evidence commit/path: private ledger fact F-B16F8586
- Reviewer evidence path: see Review Evidence
- GitHub Actions `rewrite-ci` run URL: pending (PR checks)
- [x] Targeted node tests: `gui-s3-contract.test.ts`, `repo-cell-settings.integration.test.ts` pass; `wal-shadow-event-store.test.ts` passes except one pre-existing local-only failure (`/var` vs `/private/var` symlink prefix in a repair-hint regex — macOS path canonicalization, untouched by this diff; Linux CI unaffected)
- [x] Targeted GUI vitests: the three touched files pass 15/15 after fixture alignment
- Not run: full local check suites — worker/local stop-point policy; GitHub CI is the complete authority for this PR.

## Review Evidence

- Self-review: CEO verified the consumer (`wal-shadow-event-store.ts`) treats `milliseconds` as the idle timer and `amortizationWindow = max(ms, lastFlushDuration*4)` stays well-defined with the larger floor; event/byte triggers are independent code paths.
- Reviewer subagent: not used (single-constant change, single-reviewer budget)
- Human review: requested via this PR
- Blocking findings: none

## Residual Risk

- Quiet repositories commit up to one hour later than before; a crash in that window loses at most the WAL tail already bounded by 256 events / 8 MiB (unchanged semantics, larger time bound — explicitly accepted by the owner).

## References

- Owner ruling: Zeyu, 2026-08-31 (keep event/byte caps, raise idle timer to ≥10 minutes, one hour acceptable)
- Fact: F-B16F8586 (private ledger)

---

# 中文

## 概要

WAL 空闲刷盘默认间隔原为 2 秒,活跃的一天会产出一百多个 `harness WAL flush` 台账提交。按所有者裁决(泽宇,2026-08-31),两个负载触发条件原样保留——256 事件与 8 MiB 仍在负载下强制刷盘——只把空闲计时器从 2 秒提到 1 小时。丢失窗口仍由事件/字节上限兜底;计时器是安静期的下限,不是刷盘的主驱动。镜像默认值的测试夹具同步更新;repo-cell settings 集成夹具保留其显式 2000ms,因为它测的是显式配置而非默认值。

## 架构辩护

- 不需要:只改一个冻结默认常量的值,不加机制、开关或层;按仓覆盖仍走既有 settings 通道。

## 改动内容

- `packages/kernel/src/domain/settings.ts`:`DEFAULT_WAL_FLUSH_SETTINGS.milliseconds` 2_000 → 3_600_000,并以注释记录裁决。
- 镜像默认值的测试夹具:`gui-s3-contract.test.ts`、`settings-repository-selectors.vitest.ts`(两处)、`service-bridge.test.ts`、`system-group-widescreen.vitest.ts`(两处)。

## 门收割 / Gate Harvest

- 删除的生产路径:none
- 同 commit 删除的门 / fixture:none
- 生产净行数:引用英文块中的 `Production-Delta`;该值由 production-delta job 计算,不要手填第二份数字。

## 机读声明说明

- 机读声明只在英文块出现一次,见英文块 `Production-Delta: +5/-1`。

## 任务与范围

- Harness 任务:task_5fc5080044fcfdbf548008f2f5 里程碑线(所有者裁决的运行默认值调整)
- 分支:codex/wal-flush-interval
- 公开范围:一个 kernel 默认常量与镜像它的测试夹具
- 私有计划 / 证据是否已更新:yes(fact F-B16F8586 记录刷盘节奏 ground truth)
- 范围外:自适应刷盘算法、事件/字节上限、按仓 settings 通道

## 版本影响

- 版本:不改版本,原因是仅默认值在既有 settings 契约内变动
- 发布影响:不发布

## 治理声明

- 是否触碰 protected surface:no
- protected surface 范围:
- 依据:不适用
- 机器检查边界:本 PR 只声明该段存在;声明是否真实、充分,由 reviewer 判断。
- Break-glass:no
- Break-glass 原因:
- Break-glass 范围:
- 后续治理任务:

## 验证

- `origin/main` 基准 SHA:e4bdcce67359c7130fafc65dd421f42e4eee6530
- 当前分支与 `origin/main` 的 merge-base:e4bdcce67359c7130fafc65dd421f42e4eee6530
- 最近一次 `git fetch origin` 时间:2026-08-31 晚间
- 同步方式:自当前 `origin/main` 开分支
- 公开 diff 命令:git diff origin/main..codex/wal-flush-interval
- 私有证据 commit/path:私有台账 fact F-B16F8586
- Reviewer 证据路径:见审查证据
- GitHub Actions `rewrite-ci` run URL:待 PR checks
- [x] 定向 node 测试:`gui-s3-contract.test.ts`、`repo-cell-settings.integration.test.ts` 通过;`wal-shadow-event-store.test.ts` 除一个先存的本机限定失败外通过(修复提示正则里 `/var` 与 `/private/var` 的 macOS symlink 前缀差,与本 diff 无接触;Linux CI 不受影响)
- [x] 定向 GUI vitest:三个触碰文件夹具对齐后 15/15 通过
- 未运行:完整本地 check 套件——按 worker/本地停止点纪律,GitHub CI 是本 PR 的完整权威。

## 审查证据

- 自查:CEO 核实消费方(`wal-shadow-event-store.ts`)把 `milliseconds` 当空闲计时器,`amortizationWindow = max(ms, lastFlushDuration*4)` 在更大下限下仍良定义;事件/字节触发是独立代码路径。
- Reviewer subagent:未派(单常量改动,单评审员预算)
- 人工审查:经本 PR 请求
- 阻塞发现:none

## 残余风险

- 安静仓库最迟比原来晚 1 小时落提交;该窗口内崩溃最多丢已被 256 事件/8 MiB 兜底的 WAL 尾(语义不变,时间上限放大——所有者明示接受)。

## 关联材料

- 所有者裁决:泽宇,2026-08-31(保留事件/字节兜底,空闲计时器 ≥10 分钟,1 小时可接受)
- Fact:F-B16F8586(私有台账)

---

## PR Gate Checklist / PR 门禁清单

- [x] Branch is based on latest `origin/main`. / 分支基于最新 `origin/main`。
- [x] PR body uses this full template structure. / PR 描述使用本模板完整结构。
- [x] PR body uses two complete language blocks: `# English` first, then `# 中文`. / PR 正文使用两块完整正文:`# English` 在上,`# 中文` 在下。
- [x] PR body passes `tools/check-pr-body-bilingual.mjs`. / PR 正文通过 `tools/check-pr-body-bilingual.mjs`。
- [x] If the PR touches a manifest-derived protected surface, Governance Declaration is filled with ADR/decision/task evidence or break-glass fields. / 若 PR 触碰 manifest 派生的 protected surface,Governance Declaration 已填写 ADR/decision/task 依据或 break-glass 字段。
- [x] No private harness files are included. / 不包含私有 harness 文件。
- [x] No ignored local agent entry files are included. / 不包含被忽略的本地 agent 入口文件。
- [x] No absolute local filesystem paths are included in this public PR body. / 本公开 PR 描述不包含本机绝对路径。
- [x] Public diff is limited to the stated task scope. / 公开 diff 限于声明的任务范围。
- [x] Private planning/evidence updates are recorded when applicable. / 适用时已记录私有计划 / 证据更新。
- [x] Version and publish impact are stated. / 已说明版本与发布影响。
- [x] Local verification commands are recorded honestly. / 已如实记录本地验证命令。
- [x] CI results are linked or explained. / CI 结果已链接或说明。
- [x] Review evidence is recorded. / 已记录审查证据。
- [x] Open P0/P1/P2 findings are closed, deferred with owner, or explicitly blocked. / open P0/P1/P2 findings 已关闭、带 owner 延后,或明确阻塞。
- [x] Merge method and post-merge branch cleanup plan are clear. / 合并方式和合并后分支清理计划清楚。
- [x] No admin bypass is planned unless explicitly approved and recorded. / 除非明确批准并记录,否则不计划 admin bypass。
