### PR TITLE
fix(gui): let the quick switcher escape sidebar clipping

### DIFF
--- a/packages/gui/src/renderer/components/AppSidebar.tsx
+++ b/packages/gui/src/renderer/components/AppSidebar.tsx
@@ -1,10 +1,12 @@
-import { FolderSimple, CaretUpDown, CloudSlash, WarningCircle } from "@phosphor-icons/react";
+import { useRef } from "react";
+import { FolderSimple, CaretUpDown, CloudSlash } from "@phosphor-icons/react";
 import type { SystemRepoRow } from "../api-client.ts";
 import type { Project } from "../model/types.ts";
 import type { RuntimeHealth } from "../model/runtime-health.ts";
 import type { ViewId } from "../navigation/viewHistory.ts";
 import { NAV_GROUPS, navLabel } from "../navigation/navConfig.tsx";
-import { NavButton, ProjectSummary, ThemeToggle } from "./shell-chrome.tsx";
+import { NavButton, ThemeToggle } from "./shell-chrome.tsx";
+import { QuickSwitcher } from "./sidebar/QuickSwitcher.tsx";
 import { SystemStatusPanel, type LedgerStatusBarInput } from "./sidebar/SystemStatusPanel.tsx";
 import { t } from "../i18n/index.tsx";
 
@@ -56,6 +58,7 @@ export function AppSidebar({
   health,
   onOpenSystem,
 }: AppSidebarProps) {
+  const projectSwitcherAnchor = useRef<HTMLButtonElement>(null);
   return (
     <aside
       data-testid="app-sidebar"
@@ -82,6 +85,7 @@ export function AppSidebar({
         <div className="px-3 pt-2 pb-2">
           <div className="relative">
             <button
+              ref={projectSwitcherAnchor}
               onClick={onProjectSwitcherToggle}
               title={t("components.appSidebar.quicklySwitchProjects")}
               className={`flex w-full items-center gap-2 rounded-md border px-2 py-2 text-left text-sm
@@ -99,48 +103,14 @@ export function AppSidebar({
               <CaretUpDown weight="bold" className="shrink-0 text-text-faint" />
             </button>
 
-            {projectSwitcherOpen && (
-              <div
-                className={`absolute left-0 right-0 z-30 mt-2 rounded-lg border border-border-strong
-                  bg-surface-raised p-2 shadow-2xl shadow-black/35 md:right-auto md:w-[320px]`}
-              >
-                <div className="flex items-center justify-between px-1 pb-2">
-                  <span className="font-mono text-[11px] uppercase tracking-wide text-text-faint">
-                    {t("components.appSidebar.quickSwitch")}
-                  </span>
-                  <span className="font-mono text-[11px] text-text-faint">
-                    {t("components.appSidebar.projectCount", { count: repos.length })}
-                  </span>
-                </div>
-                <div className="flex max-h-[330px] flex-col gap-1.5 overflow-y-auto">
-                  {repos.map((repo) => (
-                    <ProjectSummary
-                      key={repo.repoId}
-                      repo={repo}
-                      active={repo.repoId === activeRepoId}
-                      onOpen={() => onOpenProject(repo.repoId)}
-                    />
-                  ))}
-                </div>
-                <div className="mt-2 grid grid-cols-2 gap-1.5 border-t border-border pt-2">
-                  <button
-                    onClick={onOpenProjectManager}
-                    className={`rounded-md border border-border px-2 py-1.5 text-left text-[12px] font-medium
-                      text-text-muted hover:border-border-strong hover:text-text`}
-                  >
-                    {t("components.appSidebar.manageAll")}
-                  </button>
-                  <button
-                    disabled
-                    className={`inline-flex items-center justify-center gap-1 rounded-md border border-border
-                      px-2 py-1.5 text-[12px] text-text-faint opacity-70`}
-                  >
-                    <WarningCircle weight="bold" />
-                    {t("components.appSidebar.localMode")}
-                  </button>
-                </div>
-              </div>
-            )}
+            <QuickSwitcher
+              open={projectSwitcherOpen}
+              anchorRef={projectSwitcherAnchor}
+              repos={repos}
+              activeRepoId={activeRepoId}
+              onOpenProject={onOpenProject}
+              onOpenProjectManager={onOpenProjectManager}
+            />
           </div>
         </div>
 

--- a/packages/gui/src/renderer/components/shell-chrome.tsx
+++ b/packages/gui/src/renderer/components/shell-chrome.tsx
@@ -82,8 +82,8 @@ export function ProjectSummary({ repo, active, onOpen }: { repo: SystemRepoRow; 
         <FolderSimple weight="duotone" />
       </span>
       <span className="min-w-0 flex-1">
-        <span className="block truncate text-[15px] font-semibold text-text">{repo.displayName}</span>
-        <span className="block truncate font-mono text-[13px] text-text-faint">
+        <span className="block break-words text-[15px] font-semibold text-text">{repo.displayName}</span>
+        <span className="block font-mono text-[13px] text-text-faint [overflow-wrap:anywhere]">
           {repo.repoId} · {repo.registrationState} / {repo.cellState}
         </span>
         <span className="mt-1 flex flex-wrap gap-1.5 font-mono text-[12px] tabular-nums">
@@ -94,7 +94,7 @@ export function ProjectSummary({ repo, active, onOpen }: { repo: SystemRepoRow; 
           <span className="text-text-faint">lock {repo.lockState}</span>
         </span>
         {repo.cellState !== "attached" && (
-          <span className="mt-1 block text-[11px] text-status-blocked">
+          <span className="mt-1 block break-words text-[11px] text-status-blocked">
             {repo.unavailableReason ?? repo.lastError ?? "unknown / 未投影"}
           </span>
         )}

--- a/packages/gui/src/renderer/components/sidebar/QuickSwitcher.tsx
+++ b/packages/gui/src/renderer/components/sidebar/QuickSwitcher.tsx
@@ -1,0 +1,114 @@
+import { useLayoutEffect, useState, type RefObject } from "react";
+import { createPortal } from "react-dom";
+import { WarningCircle } from "@phosphor-icons/react";
+import type { SystemRepoRow } from "../../api-client.ts";
+import { t } from "../../i18n/index.tsx";
+import { ProjectSummary } from "../shell-chrome.tsx";
+
+const VIEWPORT_GUTTER = 8;
+
+export interface QuickSwitcherPosition {
+  readonly left: number;
+  readonly top: number;
+  readonly maxHeight: number;
+}
+
+export function quickSwitcherPosition(
+  anchor: Pick<DOMRect, "bottom" | "left">,
+  viewport: { readonly width: number; readonly height: number },
+): QuickSwitcherPosition {
+  const left = Math.max(VIEWPORT_GUTTER, Math.min(anchor.left, viewport.width - VIEWPORT_GUTTER));
+  const top = Math.max(VIEWPORT_GUTTER, Math.min(anchor.bottom + VIEWPORT_GUTTER, viewport.height - VIEWPORT_GUTTER));
+  return {
+    left,
+    top,
+    maxHeight: Math.max(0, viewport.height - top - VIEWPORT_GUTTER),
+  };
+}
+
+export function QuickSwitcher({
+  open,
+  anchorRef,
+  repos,
+  activeRepoId,
+  onOpenProject,
+  onOpenProjectManager,
+}: {
+  readonly open: boolean;
+  readonly anchorRef: RefObject<HTMLElement | null>;
+  readonly repos: readonly SystemRepoRow[];
+  readonly activeRepoId: string | null;
+  readonly onOpenProject: (repoId: string) => void;
+  readonly onOpenProjectManager: () => void;
+}) {
+  const [position, setPosition] = useState<QuickSwitcherPosition | null>(null);
+
+  useLayoutEffect(() => {
+    if (!open) return;
+    const updatePosition = () => {
+      const anchor = anchorRef.current;
+      if (!anchor) return;
+      setPosition(
+        quickSwitcherPosition(anchor.getBoundingClientRect(), {
+          width: window.innerWidth,
+          height: window.innerHeight,
+        }),
+      );
+    };
+    updatePosition();
+    window.addEventListener("resize", updatePosition);
+    window.addEventListener("scroll", updatePosition, true);
+    return () => {
+      window.removeEventListener("resize", updatePosition);
+      window.removeEventListener("scroll", updatePosition, true);
+    };
+  }, [anchorRef, open]);
+
+  if (!open || position === null || typeof document === "undefined") return null;
+
+  return createPortal(
+    <div
+      data-testid="quick-switcher-panel"
+      className={`fixed z-40 flex w-max min-w-[min(320px,90vw)] max-w-[min(480px,90vw)] flex-col
+        overflow-hidden rounded-lg border border-border-strong bg-surface-raised p-2 shadow-2xl shadow-black/35`}
+      style={position}
+    >
+      <div className="flex shrink-0 items-center justify-between px-1 pb-2">
+        <span className="font-mono text-[11px] uppercase tracking-wide text-text-faint">
+          {t("components.appSidebar.quickSwitch")}
+        </span>
+        <span className="font-mono text-[11px] text-text-faint">
+          {t("components.appSidebar.projectCount", { count: repos.length })}
+        </span>
+      </div>
+      <div className="flex min-h-0 max-h-[330px] flex-col gap-1.5 overflow-y-auto">
+        {repos.map((repo) => (
+          <ProjectSummary
+            key={repo.repoId}
+            repo={repo}
+            active={repo.repoId === activeRepoId}
+            onOpen={() => onOpenProject(repo.repoId)}
+          />
+        ))}
+      </div>
+      <div className="mt-2 grid shrink-0 grid-cols-2 gap-1.5 border-t border-border pt-2">
+        <button
+          onClick={onOpenProjectManager}
+          className={`rounded-md border border-border px-2 py-1.5 text-left text-[12px] font-medium
+            text-text-muted hover:border-border-strong hover:text-text`}
+        >
+          {t("components.appSidebar.manageAll")}
+        </button>
+        <button
+          disabled
+          className={`inline-flex items-center justify-center gap-1 rounded-md border border-border
+            px-2 py-1.5 text-[12px] text-text-faint opacity-70`}
+        >
+          <WarningCircle weight="bold" />
+          {t("components.appSidebar.localMode")}
+        </button>
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/packages/gui/test/sidebar-system-status.vitest.ts
+++ b/packages/gui/test/sidebar-system-status.vitest.ts
@@ -5,6 +5,7 @@ import { act, createElement } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { renderToStaticMarkup } from "react-dom/server";
 import { AppSidebar } from "../src/renderer/components/AppSidebar.tsx";
+import { quickSwitcherPosition } from "../src/renderer/components/sidebar/QuickSwitcher.tsx";
 import {
   LedgerStatusBar,
   SystemStatusPanel,
@@ -62,6 +63,37 @@ const project = {
   engines: [],
   watermarkAt: NOW,
 };
+
+const switcherRepos = [
+  {
+    repoId: "repo",
+    displayName: "harness-anything canonical workspace",
+    canonicalRoot: "/repo",
+    authoredBranch: "main",
+    registrationState: "enabled",
+    cellState: "attached",
+    generation: 1,
+    queueDepth: 0,
+    lockState: "held",
+    recoveryMs: 0,
+    lastError: null,
+    unavailableReason: null,
+  },
+  {
+    repoId: "migration-rehearsal-with-long-identifier",
+    displayName: "Migration rehearsal / legacy workspace import",
+    canonicalRoot: "/migration",
+    authoredBranch: "migration/rehearsal",
+    registrationState: "enabled",
+    cellState: "unavailable",
+    generation: 2,
+    queueDepth: 0,
+    lockState: "unknown",
+    recoveryMs: null,
+    lastError: "migration task entity is invalid: missing canonical source relation",
+    unavailableReason: "migration task entity is invalid: missing canonical source relation",
+  },
+] as const;
 
 function sidebarMarkup() {
   return renderToStaticMarkup(
@@ -143,6 +175,114 @@ async function mount(element: ReturnType<typeof createElement>) {
   });
   return { div, root: root as Root };
 }
+
+function anchorRect(left: number, bottom: number): DOMRect {
+  return {
+    bottom,
+    height: 40,
+    left,
+    right: left + 172,
+    top: bottom - 40,
+    width: 172,
+    x: left,
+    y: bottom - 40,
+    toJSON: () => ({}),
+  };
+}
+
+describe("quick switcher overflow regression", () => {
+  it("portals the open panel outside both clipping ancestors and preserves the existing actions", async () => {
+    const rect = vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockReturnValue(anchorRect(12, 84));
+    const onOpenProject = vi.fn();
+    const onOpenProjectManager = vi.fn();
+    const { div, root } = await mount(
+      createElement(AppSidebar, {
+        project,
+        repos: switcherRepos,
+        activeRepoId: "repo",
+        view: "overview",
+        hasSelection: false,
+        inboxCount: 0,
+        projectSwitcherOpen: true,
+        onProjectSwitcherToggle: () => undefined,
+        onOpenProject,
+        onOpenProjectManager,
+        onNavigate: () => undefined,
+        ledgerStatus,
+        onRefreshLedger: () => undefined,
+        health: healthy,
+        onOpenSystem: () => undefined,
+      }),
+    );
+
+    const aside = div.querySelector('[data-testid="app-sidebar"]') as HTMLElement;
+    const panel = document.body.querySelector('[data-testid="quick-switcher-panel"]') as HTMLElement;
+    expect(panel).not.toBeNull();
+    expect(aside.contains(panel)).toBe(false);
+    expect(panel.parentElement).toBe(document.body);
+    expect(panel.className).toContain("fixed");
+    expect(panel.className).toContain("w-max");
+    expect(panel.className).toContain("min-w-[min(320px,90vw)]");
+    expect(panel.className).toContain("max-w-[min(480px,90vw)]");
+    expect(panel.innerHTML).not.toContain("truncate");
+    expect(panel.textContent).toContain("Migration rehearsal / legacy workspace import");
+    expect(panel.textContent).toContain("unavailable");
+    expect(panel.textContent).toContain("queue 0");
+    expect(panel.textContent).toContain("migration task entity is invalid: missing canonical source relation");
+
+    await act(async () => {
+      (panel.querySelector("button") as HTMLButtonElement).click();
+    });
+    expect(onOpenProject).toHaveBeenCalledWith("repo");
+    await act(async () => {
+      (panel.querySelectorAll("button")[2] as HTMLButtonElement).click();
+    });
+    expect(onOpenProjectManager).toHaveBeenCalledTimes(1);
+
+    await act(async () => root.unmount());
+    rect.mockRestore();
+  });
+
+  it("tracks the trigger after layout changes and bounds its height inside the viewport", async () => {
+    let currentRect = anchorRect(12, 84);
+    const rect = vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockImplementation(() => currentRect);
+    const { root } = await mount(
+      createElement(AppSidebar, {
+        project,
+        repos: switcherRepos,
+        activeRepoId: "repo",
+        view: "overview",
+        hasSelection: false,
+        inboxCount: 0,
+        projectSwitcherOpen: true,
+        onProjectSwitcherToggle: () => undefined,
+        onOpenProject: () => undefined,
+        onOpenProjectManager: () => undefined,
+        onNavigate: () => undefined,
+        ledgerStatus,
+        onRefreshLedger: () => undefined,
+        health: healthy,
+        onOpenSystem: () => undefined,
+      }),
+    );
+    const panel = document.body.querySelector('[data-testid="quick-switcher-panel"]') as HTMLElement;
+    expect(panel.style.left).toBe("12px");
+    expect(panel.style.top).toBe("92px");
+
+    currentRect = anchorRect(20, 104);
+    await act(async () => window.dispatchEvent(new Event("resize")));
+    expect(panel.style.left).toBe("20px");
+    expect(panel.style.top).toBe("112px");
+
+    expect(quickSwitcherPosition(anchorRect(-20, 84), { width: 320, height: 600 })).toEqual({
+      left: 8,
+      top: 92,
+      maxHeight: 500,
+    });
+    await act(async () => root.unmount());
+    rect.mockRestore();
+  });
+});
 
 describe("SystemStatusPanel(侧栏左下角紧凑系统运行区)", () => {
   it("keeps every migrated fact visible: events, refresh time, health lamp, revisions, system exit", async () => {


### PR DESCRIPTION
# English

## Summary

The sidebar quick-switcher dropdown was hard-clipped at the sidebar's right edge (196px), truncating project names, status lines, and unavailability reasons. The panel now renders through a React portal to `document.body` with fixed positioning anchored to the trigger button, so it floats above the main content, sizes to its content up to `min(480px, 90vw)`, and wraps long status text in full. Requested by the operator from a live screenshot.

## Architectural Justification

- Not applicable: +131/-47 production lines, no new module. The sidebar's `overflow-hidden`/`overflow-y-auto` layers are structural invariants from the short-viewport scrolling fix; the panel escapes the clipping ancestor chain instead of weakening shared layout containment.

## What Changed

- `AppSidebar.tsx`: keeps the trigger button ref and mounts the extracted `QuickSwitcher` component; drops the in-tree absolute-positioned panel.
- `sidebar/QuickSwitcher.tsx` (new): portal rendering, viewport-clamped fixed positioning with resize/scroll re-anchoring, `w-max min-w-[min(320px,90vw)] max-w-[min(480px,90vw)]`, internal scroll capped to viewport height.
- `shell-chrome.tsx`: project name, repo id, and error reason wrap instead of truncating.
- `sidebar-system-status.vitest.ts`: regression coverage for portal positioning geometry and clamping.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: use the single CI-backed `Production-Delta` declaration below; do not enter a second metric.

## Machine-Readable Declarations

Production-Delta: +131/-47

## Task And Scope

- Harness task: task_ae9862598bf0b81506a4181905 (gui quick-switcher overflow)
- Branch: codex/gui-quick-switcher
- Public scope: GUI renderer sidebar components and GUI tests only
- Private planning/evidence updated: yes
- Out of scope: any other sidebar layout behavior

## Version Impact

- Version: no version change because this is a GUI fix ahead of the milestone release
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope:
- Authority: not applicable
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason:
- Break-glass scope:
- Follow-up governance task:

## Verification

- Base `origin/main` SHA: e4bdcce67359c7130fafc65dd421f42e4eee6530
- Branch merge-base with `origin/main`: e4bdcce67359c7130fafc65dd421f42e4eee6530
- Last `git fetch origin` time: 2026-08-31 late evening
- Sync method: none needed
- Public diff command: git diff e4bdcce67...codex/gui-quick-switcher
- Private evidence commit/path: harness task package artifacts (report.md with before/after screenshots and browser geometry table)
- Reviewer evidence path: see Review Evidence
- GitHub Actions `rewrite-ci` run URL: pending (filled by CI on this PR)
- [x] full GUI test suite: 65 files, 627 tests passed (worker run)
- [x] `npm run typecheck`, lint, GUI build, G36 gate (worker run)
- [x] real-browser geometry verification at 1440x900 / 1440x600 / 640x600 / 320x600: no page horizontal scroll, panel fully inside viewport
- [x] operator-facing screenshot review (before/after) by the coordinating session
- Not run: full `npm run check` locally (GitHub CI is the authority)

## Review Evidence

- Self-review: coordinating session reviewed the portal component line-by-line and the before/after screenshots against the operator's report
- Reviewer subagent: none (single review round budgeted; GUI-only change with full-suite green and geometry evidence)
- Human review: pending merge review
- Blocking findings: none

## Residual Risk

- Portal panel re-anchors on scroll/resize listeners; exotic nested-scroll containers could lag one frame on reposition — cosmetic only.

## References

- Task: task_ae9862598bf0b81506a4181905
- Evidence: task artifacts report.md (screenshots, geometry table)
- Review: this PR

---

# 中文

## 概要

侧栏快速切换下拉此前在侧栏右缘(196px)被硬裁,项目名、状态行与不可用原因均被截断。现改为 React portal 渲染到 `document.body`,以触发按钮为锚做 fixed 定位,浮于主内容区之上,宽度内容自适应并限制在 `min(480px, 90vw)`,长状态文本完整换行。来源:泽宇截图指出的问题。

## 架构辩护

- 不适用:生产 +131/-47,无新模块。侧栏的 `overflow-hidden`/`overflow-y-auto` 是矮窗口滚动修复的结构不变量;方案让面板逃逸裁剪祖先链,而不是削弱共享布局约束。

## 改动内容

- `AppSidebar.tsx`:保留触发按钮 ref,挂载抽出的 `QuickSwitcher` 组件;移除树内 absolute 面板。
- `sidebar/QuickSwitcher.tsx`(新增):portal 渲染、视口收敛的 fixed 定位(resize/scroll 重锚)、`w-max min-w-[min(320px,90vw)] max-w-[min(480px,90vw)]`、内部滚动按视口高度封顶。
- `shell-chrome.tsx`:项目名、仓标识、错误原因换行不截断。
- `sidebar-system-status.vitest.ts`:portal 定位几何与收敛的回归覆盖。

## 门收割 / Gate Harvest

- 删除的生产路径:none
- 同 commit 删除的门 / fixture:none
- 生产净行数:见英文块 `Production-Delta`。

## 机读声明说明

- 见英文块顶格声明。

## 任务与范围

- Harness 任务:task_ae9862598bf0b81506a4181905(GUI 快速切换溢出)
- 分支:codex/gui-quick-switcher
- 公开范围:仅 GUI renderer 侧栏组件与 GUI 测试
- 私有计划 / 证据是否已更新:yes
- 范围外:其他侧栏布局行为

## 版本影响

- 版本:不改版本,原因是里程碑发布前的 GUI 修复
- 发布影响:不发布

## 治理声明

- 是否触碰 protected surface:no
- protected surface 范围:
- 依据:不适用
- 机器检查边界:本 PR 只声明该段存在;声明是否真实、充分,由 reviewer 判断。
- Break-glass:no
- Break-glass 原因:
- Break-glass 范围:
- 后续治理任务:

## 验证

- `origin/main` 基准 SHA:e4bdcce67359c7130fafc65dd421f42e4eee6530
- 当前分支与 `origin/main` 的 merge-base:e4bdcce67359c7130fafc65dd421f42e4eee6530
- 最近一次 `git fetch origin` 时间:2026-08-31 深夜
- 同步方式:不需要
- 公开 diff 命令:git diff e4bdcce67...codex/gui-quick-switcher
- 私有证据 commit/path:harness 任务包 artifacts(report.md,含 before/after 截图与浏览器几何表)
- Reviewer 证据路径:见审查证据
- GitHub Actions `rewrite-ci` run URL:待 CI 回填
- [x] GUI 全量测试:65 文件、627 测试通过(worker 执行)
- [x] typecheck、lint、GUI build、G36 门(worker 执行)
- [x] 真实浏览器几何验证 1440x900 / 1440x600 / 640x600 / 320x600:无页面横滚,面板完整在视口内
- [x] 协调会话完成 before/after 截图眼验
- 未运行:本地完整 `npm run check`(GitHub CI 为权威)

## 审查证据

- 自查:协调会话逐行审阅 portal 组件,并对照泽宇报告核验 before/after 截图
- Reviewer subagent:无(评审预算一轮;GUI 单面改动,全量测试绿 + 几何证据)
- 人工审查:合并评审待做
- 阻塞发现:无

## 残余风险

- portal 面板靠 scroll/resize 监听重锚;极端嵌套滚动容器下重定位可能滞后一帧——仅外观影响。

## 关联材料

- 任务:task_ae9862598bf0b81506a4181905
- 证据:任务包 artifacts report.md(截图、几何表)
- 审查:本 PR

---

## PR Gate Checklist / PR 门禁清单

- [x] Branch is based on latest `origin/main`. / 分支基于最新 `origin/main`。
- [x] PR body uses this full template structure. / PR 描述使用本模板完整结构。
- [x] PR body uses two complete language blocks: `# English` first, then `# 中文`. / PR 正文使用两块完整正文:`# English` 在上,`# 中文` 在下。
- [x] PR body passes `tools/check-pr-body-bilingual.mjs`. / PR 正文通过 `tools/check-pr-body-bilingual.mjs`。
- [x] If the PR touches a manifest-derived protected surface, Governance Declaration is filled with ADR/decision/task evidence or break-glass fields. / 若 PR 触碰 manifest 派生的 protected surface,Governance Declaration 已填写 ADR/decision/task 依据或 break-glass 字段。
- [x] No private harness files are included. / 不包含私有 harness 文件。
- [x] No ignored local agent entry files are included. / 不包含被忽略的本地 agent 入口文件。
- [x] No absolute local filesystem paths are included in this public PR body. / 本公开 PR 描述不包含本机绝对路径。
- [x] Public diff is limited to the stated task scope. / 公开 diff 限于声明的任务范围。
- [x] Private planning/evidence updates are recorded when applicable. / 适用时已记录私有计划 / 证据更新。
- [x] Version and publish impact are stated. / 已说明版本与发布影响。
- [x] Local verification commands are recorded honestly. / 已如实记录本地验证命令。
- [x] CI results are linked or explained. / CI 结果已链接或说明。
- [x] Review evidence is recorded. / 已记录审查证据。
- [x] Open P0/P1/P2 findings are closed, deferred with owner, or explicitly blocked. / open P0/P1/P2 findings 已关闭、带 owner 延后,或明确阻塞。
- [x] Merge method and post-merge branch cleanup plan are clear. / 合并方式和合并后分支清理计划清楚。
- [x] No admin bypass is planned unless explicitly approved and recorded. / 除非明确批准并记录,否则不计划 admin bypass。
