### PR TITLE
refactor(ontology): route agent install through the unified action catalog

### DIFF
--- a/packages/daemon/src/agent-entities.ts
+++ b/packages/daemon/src/agent-entities.ts
@@ -355,10 +355,15 @@ export function prepareAgentEntityInstall(input: {
     readonly models: readonly string[];
     readonly enabled: boolean;
   }[];
+  readonly replay?: boolean;
 }): PreparedAgentEntityInstall {
   const kind = entityKind(input.action.kind);
   if (!input.action.kind.endsWith("-install"))
     throw entityError("invalid_command", "Only an entity install action can prepare a declaration write.");
+  const hasDeclaration = Object.hasOwn(input.action, "declaration"),
+    hasPackageSource = Object.hasOwn(input.action, "packageSource");
+  if (hasDeclaration === hasPackageSource)
+    throw entityError("invalid_command", `${kind} install requires exactly one declaration or packageSource.`);
   const decoded = declarationSource(input.action),
     source = decoded.source ?? "runtime-result";
   if ("issues" in decoded)
@@ -373,7 +378,23 @@ export function prepareAgentEntityInstall(input: {
     );
   const declaration = decoded.declaration,
     current = repairableStoredDeclaration(input.entityStore ?? openEntityStore(input.rootDir), kind, declaration.id);
-  if (input.action.generatedOnly === true && current.exists) throw generatedAgentConflict(declaration.id);
+  if (
+    input.action.expectedVersion !== undefined &&
+    (!Number.isSafeInteger(input.action.expectedVersion) || Number(input.action.expectedVersion) < 0)
+  )
+    throw entityError("invalid_command", "expectedVersion must be a non-negative integer when supplied.");
+  if (
+    input.action.expectedVersion !== undefined &&
+    input.replay !== true &&
+    (current.workspaceRevision ?? 0) !== Number(input.action.expectedVersion)
+  )
+    throw entityError(
+      "revision_conflict",
+      `${kind} ${declaration.id} expected revision ${String(input.action.expectedVersion)}, ` +
+        `current revision is ${String(current.workspaceRevision ?? 0)}.`,
+    );
+  if (input.action.generatedOnly === true && current.exists && input.replay !== true)
+    throw generatedAgentConflict(declaration.id);
   if (input.action.generatedOnly === true && kind === "agent")
     admitGeneratedAgent(declaration as AgentDeclarationV1, input.runtimeInstances);
   const body = `${JSON.stringify(declaration, null, 2)}\n`,
@@ -397,13 +418,19 @@ function repairableStoredDeclaration(
   entityStore: EntityStore,
   kind: AgentEntityKind,
   id: string,
-): { readonly exists: boolean; readonly value: Readonly<Record<string, unknown>> | null } {
+): {
+  readonly exists: boolean;
+  readonly value: Readonly<Record<string, unknown>> | null;
+  readonly workspaceRevision: number | null;
+} {
   try {
     const current = entityStore.get<Readonly<Record<string, unknown>>>(kind, id);
-    return current === null ? { exists: false, value: null } : { exists: true, value: current.value };
+    return current === null
+      ? { exists: false, value: null, workspaceRevision: null }
+      : { exists: true, value: current.value, workspaceRevision: current.workspaceRevision };
   } catch (error) {
     if ((error as { readonly code?: unknown }).code !== "invalid_entity_contract") throw error;
-    return { exists: true, value: null };
+    return { exists: true, value: null, workspaceRevision: null };
   }
 }
 function declarationSource(

--- a/packages/daemon/src/entity-action-catalog-executor.ts
+++ b/packages/daemon/src/entity-action-catalog-executor.ts
@@ -1,14 +1,17 @@
 import { createHash } from "node:crypto";
 import { makeDecisionService, makeFactService } from "../../application/src/index.ts";
 import {
+  compileEntityUpsert,
   compileDecisionWrite,
   compileFactWrite,
   decisionWritePlan,
+  entityUpsertWritePlan,
   factWritePlan,
   getExecutableEntityAction,
   isRelationEvent,
   isSameExecution,
   relationEventWritePlan,
+  requireEntityStoreKindContract,
   timestamp,
   type AuthorizationDecision,
   type CanonicalEventCut,
@@ -17,6 +20,8 @@ import {
   type EntityActionContract,
   type EntityActionDraft,
   type EntityActionExecutionContract,
+  type EntityEventV1,
+  type EntityUpsertBundle,
   type EventPublicationKillpoint,
   type FactConfidence,
   type FactEventV1,
@@ -33,15 +38,22 @@ import type { RepoCellBinding, RepoTaskAction } from "./repo-cell-types.ts";
 type ExecutableAction = EntityActionContract & { readonly execution: EntityActionExecutionContract };
 type FactBundle = ReturnType<typeof compileFactWrite>;
 type DecisionBundle = ReturnType<typeof compileDecisionWrite>;
-type CatalogBundle = FactBundle | DecisionBundle;
+type CatalogBundle = FactBundle | DecisionBundle | EntityUpsertBundle;
 export type EntityActionCatalogRunner = (
   contract: ExecutableAction,
   action: RepoTaskAction,
   binding: RepoCellBinding,
 ) => Promise<WriteReceipt>;
+export type EntityActionCatalogPreparer = (
+  contract: ExecutableAction,
+  action: RepoTaskAction,
+  binding: RepoCellBinding,
+  opId: string,
+) => RepoTaskAction;
 export interface EntityActionCatalogRuntimes {
   readonly schedule?: EntityActionCatalogRunner;
   readonly task?: EntityActionCatalogRunner;
+  readonly prepare?: Readonly<Record<string, EntityActionCatalogPreparer>>;
 }
 
 export function makeEntityActionCatalogExecutor(input: {
@@ -87,7 +99,9 @@ export function makeEntityActionCatalogExecutor(input: {
     opId: string,
     runtimes: EntityActionCatalogRuntimes = {},
   ): WriteReceipt | Promise<WriteReceipt> => {
-    const contract = executableAction(action.kind);
+    const contract = executableAction(action.kind),
+      prepare = runtimes.prepare?.[contract.target.kind],
+      preparedAction = prepare?.(contract, action, binding, opId) ?? action;
     if (contract.execution.implementation === "schedule-event") {
       if (!runtimes.schedule)
         throw Object.assign(new Error(`Action ${action.kind} requires the Schedule Action runtime.`), {
@@ -101,7 +115,7 @@ export function makeEntityActionCatalogExecutor(input: {
       contract.execution.implementation !== "task-lifecycle" &&
       contract.execution.implementation !== "task-completion"
     )
-      return runCompiled(action, binding, opId);
+      return runCompiled(preparedAction, binding, opId);
     if (!runtimes.task)
       throw Object.assign(new Error(`Action ${action.kind} requires the Task Action runtime.`), {
         code: "unsupported_command",
@@ -158,13 +172,14 @@ export function makeEntityActionCatalogExecutor(input: {
     opId: string,
   ): WriteReceipt => {
     const authorizationDecision = decisionAuthorization(rawAction, binding, opId, input),
-      action =
+      action = (
         contract.id === "amend"
           ? prepareDecisionAmend(
               rawAction,
               decisions.show(requiredCommandText(rawAction.decisionId, "decisionId")).decision,
             )
-          : rawAction,
+          : rawAction
+      ) as RepoTaskAction,
       dryRun = action.dryRun === true,
       existing = dryRun ? null : input.store.readEvent(opId),
       requestedTime = typeof action.decidedAt === "string" ? action.decidedAt : undefined,
@@ -182,6 +197,15 @@ export function makeEntityActionCatalogExecutor(input: {
     const bundle =
       matchingReplayBundle(input.store, contract, existing) ??
       compileAction(contract, action, binding, opId, occurredAt);
+    if (isEntityBundle(bundle)) {
+      if (dryRun)
+        return entityPreview(contract, action, bundle, input.store.readHead()?.revision ?? 0, authorizationDecision);
+      return deriveActionResult(
+        contract,
+        action,
+        runEntityWrite(bundle, action, existing !== null, authorizationDecision),
+      );
+    }
     if (dryRun) {
       if (bundle.event.schema !== "decision-event/v1")
         reject("invalid_command", `${contract.execution.ingress} does not support --dry-run.`);
@@ -195,6 +219,61 @@ export function makeEntityActionCatalogExecutor(input: {
     const result = decisions.record(bundle);
     publicationKillpoints(input.killpoint);
     return decisionReceipt(result, bundle.event, authorizationDecision);
+  };
+
+  const runEntityWrite = (
+    bundle: EntityUpsertBundle,
+    action: RepoTaskAction,
+    replay: boolean,
+    authorizationDecision: AuthorizationDecision,
+  ): WriteReceipt => {
+    const appended = input.store.append(bundle);
+    if (!replay) input.projection.apply(bundle.event, bundle.plan);
+    publicationKillpoints(input.killpoint);
+    const applied = input.projection.readOperation(bundle.event.opId),
+      visible = !!applied && applied.watermark >= bundle.event.workspaceRevision,
+      claim = bundle.event.payload.declarationDocumentClaim,
+      receipt = {
+        opId: bundle.event.opId,
+        revision: appended.revision,
+        evidence: JSON.stringify({
+          report: preparedEntityReport(action),
+          event: {
+            schema: bundle.event.schema,
+            eventId: bundle.event.eventId,
+            opId: bundle.event.opId,
+            path: claim.path,
+          },
+          commitSha: appended.commitSha?.sha ?? null,
+          cut: appended.cut,
+        }),
+        visibility: "center" as const,
+        proof: {
+          committedRevision: appended.revision,
+          appliedCut: applied?.watermark ?? 0,
+          durable: true,
+          canonicalVisible: visible,
+          worktreeVisible: true,
+        },
+        detail: {
+          kind: "entity_upsert" as const,
+          entityKind: bundle.event.payload.entityKind,
+          entityId: bundle.event.payload.entityId,
+          schemaId: requireEntityStoreKindContract(bundle.event.payload.entityKind).schema.$id,
+          path: claim.path,
+        },
+        commitSha: appended.commitSha?.sha ?? null,
+        cut: appended.cut,
+        authorizationDecision,
+        entityId: bundle.event.payload.entityId,
+      };
+    return visible
+      ? { outcome: "applied", ...receipt }
+      : {
+          outcome: "pending",
+          ...receipt,
+          nextAction: `Retry after the projection records declaration event ${bundle.event.opId}.`,
+        };
   };
 
   const runRelationWrite = (
@@ -213,14 +292,14 @@ export function makeEntityActionCatalogExecutor(input: {
       draft = replay
         ? null
         : contract.execution.compile?.({
-          action,
-          actor: binding.actor,
-          source: binding.source,
-          session: input.sessionIdentity(binding),
-          opId,
-          occurredAt,
-          workspaceRevision: headRevision + 1,
-        }),
+            action,
+            actor: binding.actor,
+            source: binding.source,
+            session: input.sessionIdentity(binding),
+            opId,
+            occurredAt,
+            workspaceRevision: headRevision + 1,
+          }),
       compiled = replay ?? (draft?.kind === "relation" ? draft.event : null);
     if (!compiled || !isRelationEvent(compiled))
       reject("invalid_command", `${action.kind} did not compile a Relation event.`);
@@ -332,7 +411,14 @@ export function makeEntityActionCatalogExecutor(input: {
         workspaceRevision: headRevision + 1,
         ...(coverage ? { coverage } : {}),
       });
-    return compileDraft(input.projection, draft);
+    return compileDraft(input.projection, draft, {
+      eventId: `event-${createHash("sha256").update(opId).digest("hex")}`,
+      opId,
+      workspaceRevision: headRevision + 1,
+      actor: binding.actor,
+      source: binding.source,
+      occurredAt,
+    });
   };
 
   return Object.freeze({ run });
@@ -392,8 +478,18 @@ function isFactBundle(bundle: CatalogBundle): bundle is FactBundle {
   return bundle.event.schema === "fact-event/v1";
 }
 
-function compileDraft(projection: TaskProjection, draft: EntityActionDraft): CatalogBundle {
+function isEntityBundle(bundle: CatalogBundle): bundle is EntityUpsertBundle {
+  return bundle.event.schema === "entity-event/v1";
+}
+
+function compileDraft(
+  projection: TaskProjection,
+  draft: EntityActionDraft,
+  event: Omit<Parameters<typeof compileEntityUpsert>[0], "entityKind" | "entity">,
+): CatalogBundle {
   if (draft.kind === "fact") return compileFactWrite({ event: draft.event });
+  if (draft.kind === "entity")
+    return compileEntityUpsert({ ...event, entityKind: draft.entityKind, entity: draft.entity });
   if (draft.kind === "schedule") reject("invalid_command", "Schedule drafts require the Schedule Action runtime.");
   if (draft.kind === "relation")
     reject("invalid_command", "Relation drafts are committed directly through the Relation aggregate executor.");
@@ -432,6 +528,23 @@ function matchingReplayBundle(
   existing: ReturnType<CanonicalEventStore["readEvent"]>,
 ): CatalogBundle | null {
   const writesFact = contract.target.kind === "fact" || contract.id === "reckon";
+  if (existing?.schema === "entity-event/v1" && existing.payload.entityKind === contract.target.kind) {
+    const claim = existing.payload.declarationDocumentClaim,
+      bytes = store.readContentBlob(claim.sha256);
+    if (!bytes) reject("content_not_ready", `Entity content for ${claim.path} is unavailable.`);
+    return {
+      event: existing,
+      plan: entityUpsertWritePlan(existing as EntityEventV1),
+      blobs: [
+        {
+          sha256: claim.sha256,
+          size: claim.size,
+          mediaType: claim.mediaType,
+          body: new TextDecoder("utf-8", { fatal: true }).decode(bytes),
+        },
+      ],
+    };
+  }
   if (existing?.schema === "fact-event/v1" && writesFact) {
     const claim = existing.payload.factsDocumentClaim,
       bytes = store.readContentBlob(claim.sha256);
@@ -641,6 +754,53 @@ function decisionPreview(event: DecisionEventV1, revision: number): WriteReceipt
     },
     nextAction: "Remove --dry-run to publish this validated Decision write plan.",
   };
+}
+
+function entityPreview(
+  contract: ExecutableAction,
+  action: RepoTaskAction,
+  bundle: EntityUpsertBundle,
+  revision: number,
+  authorizationDecision: AuthorizationDecision,
+): WriteReceipt {
+  const claim = bundle.event.payload.declarationDocumentClaim;
+  return {
+    outcome: "pending",
+    opId: `preview:${createHash("sha256").update(bundle.event.opId).digest("hex")}`,
+    revision,
+    evidence: JSON.stringify({
+      report: preparedEntityReport(action),
+      eventType: bundle.event.type,
+      targetRevision: bundle.event.workspaceRevision,
+      declaration: claim,
+      writePlan: bundle.plan,
+      dryRun: true,
+    }),
+    visibility: "center",
+    proof: {
+      committedRevision: revision,
+      appliedCut: revision,
+      durable: false,
+      canonicalVisible: false,
+      worktreeVisible: false,
+    },
+    authorizationDecision,
+    unmetCriteria: [],
+    effects: [],
+    updatedProjection: null,
+    rejectionExplanation: null,
+    nextActions: ["Remove --dry-run to publish this Agent declaration through the canonical event stream."],
+    nextAction: `Remove --dry-run to run ${contract.execution.ingress}.`,
+  };
+}
+
+function preparedEntityReport(action: RepoTaskAction): Readonly<Record<string, unknown>> {
+  const prepared = action.preparedEntityAction;
+  if (!prepared || typeof prepared !== "object" || Array.isArray(prepared)) return {};
+  const report = (prepared as Readonly<Record<string, unknown>>).report;
+  return report && typeof report === "object" && !Array.isArray(report)
+    ? (report as Readonly<Record<string, unknown>>)
+    : {};
 }
 
 function missingProposalFactEvidenceHint(event: DecisionEventV1): string | null {

--- a/packages/daemon/src/entity-action-catalog-executor.ts
+++ b/packages/daemon/src/entity-action-catalog-executor.ts
@@ -265,7 +265,6 @@ export function makeEntityActionCatalogExecutor(input: {
         commitSha: appended.commitSha?.sha ?? null,
         cut: appended.cut,
         authorizationDecision,
-        entityId: bundle.event.payload.entityId,
       };
     return visible
       ? { outcome: "applied", ...receipt }

--- a/packages/daemon/src/repo-cell-action-dispatch.ts
+++ b/packages/daemon/src/repo-cell-action-dispatch.ts
@@ -182,10 +182,10 @@ export async function executeAction(
       ),
     );
   }
-  const taskActionContract = getExecutableEntityAction(action.kind);
-  if (taskActionContract?.target.kind === "task" && taskActionContract.execution) {
+  const actionContract = getExecutableEntityAction(action.kind);
+  if (actionContract?.target.kind === "task" && actionContract.execution) {
     const taskId = cell.requiredCellText(action.taskId, "taskId"),
-      lifecycle = taskActionContract.execution.lifecycle,
+      lifecycle = actionContract.execution.lifecycle,
       leasedStart =
         lifecycle?.coordination === "reserve" &&
         ["held", "reserving"].includes(cell.projection.currentLease(taskId, cell.now())?.phase ?? "");
@@ -206,7 +206,7 @@ export async function executeAction(
       },
     );
   }
-  if (taskActionContract?.target.kind === "relation" && taskActionContract.execution)
+  if (actionContract?.target.kind === "relation" && actionContract.execution)
     return cell.entityActionExecutor.run(
       action,
       binding,
@@ -226,12 +226,12 @@ export async function executeAction(
       ),
     );
   }
-  const entityActionContract = getExecutableEntityAction(action.kind);
-  if (entityActionContract?.execution)
+  const actionVersion = Number(action.expectedVersion ?? cell.store.readHead()?.revision ?? 0);
+  if (actionContract?.execution)
     return cell.entityActionExecutor.run(
       action,
       binding,
-      cell.operationId(action, binding, cell.input.repoId, Number(action.expectedVersion ?? 0)),
+      cell.operationId(action, binding, cell.input.repoId, actionVersion),
       cell.entityActionRuntimes,
     );
   if (action.kind === "preset-upgrade") return cell.upgradePresetSnapshot(action, binding);

--- a/packages/daemon/src/repo-cell-action-dispatch.ts
+++ b/packages/daemon/src/repo-cell-action-dispatch.ts
@@ -231,7 +231,7 @@ export async function executeAction(
     return cell.entityActionExecutor.run(
       action,
       binding,
-      cell.operationId(action, binding, cell.input.repoId, cell.store.readHead()?.revision ?? 0),
+      cell.operationId(action, binding, cell.input.repoId, Number(action.expectedVersion ?? 0)),
       cell.entityActionRuntimes,
     );
   if (action.kind === "preset-upgrade") return cell.upgradePresetSnapshot(action, binding);
@@ -259,7 +259,7 @@ export async function executeAction(
     const result = { schema: "entity-get/v1", kind, entity };
     return cell.readResult(cell.operationId(action, binding, cell.input.repoId, revision), result, revision, null);
   }
-  if (/^(?:agent|squad)-install$/u.test(action.kind)) {
+  if (action.kind === "squad-install") {
     const prepared = prepareAgentEntityInstall({
       rootDir: cell.rootDir,
       action,

--- a/packages/daemon/src/repo-cell-open.ts
+++ b/packages/daemon/src/repo-cell-open.ts
@@ -11,7 +11,7 @@ import {
 } from "../../kernel/src/index.ts";
 import { createPresetProcessService, presetUserRoot } from "../../preset/src/index.ts";
 import { ledgerWriteCommandTopology } from "../../preset/src/preset-command-contract.ts";
-import { readAgentDeclaration, resolveSquadDispatch } from "./agent-entities.ts";
+import { prepareAgentEntityInstall, readAgentDeclaration, resolveSquadDispatch } from "./agent-entities.ts";
 import type { PreparedRuntimeLaunch, RuntimeInstanceSummary } from "./agent-runtime-instances.ts";
 import { makeAgentRuntimeStreamHub } from "./agent-runtime-stream.ts";
 import { openGuiCatalog } from "./gui-catalog.ts";
@@ -52,7 +52,7 @@ import type {
   RepoTaskAction,
   Snapshot,
 } from "./repo-cell-types.ts";
-import type { EntityActionCatalogRuntimes } from "./entity-action-catalog-executor.ts";
+import type { EntityActionCatalogPreparer, EntityActionCatalogRuntimes } from "./entity-action-catalog-executor.ts";
 import { admitRepoMode } from "./repo-mode.ts";
 import {
   makeRuntimeSpawner,
@@ -538,8 +538,27 @@ async function openLockedRepoCell(
   });
   const runtimeContext = Object.assign(extracted, { mode, runtimeSpawner });
   runtimeContext satisfies RepoCellRuntimeContext;
-  const scheduleActionRuntime = makeScheduleActionRuntime(runtimeContext);
-  entityActionRuntimes = Object.freeze({ schedule: scheduleActionRuntime });
+  const scheduleActionRuntime = makeScheduleActionRuntime(runtimeContext),
+    prepareAgentAction: EntityActionCatalogPreparer = (_contract, action, _binding, opId) => {
+      const existing = store.readEvent(opId),
+        prepared = prepareAgentEntityInstall({
+          rootDir,
+          action,
+          entityStore: createEntityStore(store),
+          runtimeInstances: input.runtimeInstances?.(),
+          replay: existing?.schema === "entity-event/v1" && existing.payload.entityKind === "agent",
+        });
+      return {
+        ...action,
+        declaration: prepared.declaration,
+        entityId: prepared.declaration.id,
+        preparedEntityAction: { report: prepared.report },
+      };
+    };
+  entityActionRuntimes = Object.freeze({
+    schedule: scheduleActionRuntime,
+    prepare: Object.freeze({ agent: prepareAgentAction }),
+  });
   const settingsActions = makeRepoCellSettingsActions(extracted);
   const peopleActions = makeRepoCellPeopleActions(extracted);
   const operationalContext = Object.assign(runtimeContext, { settingsActions, peopleActions });

--- a/packages/daemon/test/agent-action.integration.test.ts
+++ b/packages/daemon/test/agent-action.integration.test.ts
@@ -1,0 +1,108 @@
+// harness-test-tier: integration
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { canonicalRoot, workspaceId } from "../src/protocol/daemon-protocol.contract.ts";
+import { openBootstrappedRepoCell as openRepoCell } from "./repo-settings.fixture.ts";
+import { initRepo } from "./task-surface.fixtures.ts";
+
+const binding = {
+  actor: { principal: { personId: "person-agent-action" }, executor: null },
+  source: "local" as const,
+};
+const declaration = {
+  schema: "agent-declaration/v1",
+  id: "unified-agent",
+  name: "Unified Agent",
+  instructions: "Execute the assigned mission through the canonical action route.",
+  runtime_type: "codex",
+};
+
+test("Agent install uses the executable catalog with CAS, replay, readiness, and ActionResult", async () => {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-agent-action-"));
+  initRepo(rootDir);
+  const cell = await openRepoCell({
+    repoId: workspaceId("agent-action"),
+    rootDir: canonicalRoot(rootDir),
+    ownerId: "agent-action-test",
+  });
+  try {
+    const packageSource = path.join(rootDir, "source", declaration.id);
+    mkdirSync(packageSource, { recursive: true });
+    writeFileSync(path.join(packageSource, "agent.json"), `${JSON.stringify(declaration, null, 2)}\n`);
+    const preview = await cell.run(
+      {
+        kind: "agent-install",
+        packageSource,
+        dryRun: true,
+        expectedVersion: 0,
+        idempotencyKey: "agent-action-preview",
+      },
+      binding,
+    );
+    assert.equal(preview.outcome, "pending");
+    assert.equal(preview.proof?.durable, false);
+    assert.deepEqual(preview.effects, []);
+    assert.equal(preview.updatedProjection, null);
+
+    const install = {
+        kind: "agent-install",
+        packageSource,
+        expectedVersion: 0,
+        idempotencyKey: "agent-action-install",
+      },
+      created = await cell.run(install, binding);
+    assert.equal(created.outcome, "applied", JSON.stringify(created));
+    assert.deepEqual(created.effects, ["entity-event/entity_upserted"]);
+    assert.deepEqual(created.updatedProjection, {
+      kind: "agent",
+      ref: "agent/unified-agent",
+      revision: created.revision,
+    });
+    assert.equal(created.detail?.kind, "entity_upsert");
+    assert.equal(created.detail?.entityKind, "agent");
+
+    const replayed = await cell.run(install, binding);
+    assert.equal(replayed.outcome, "applied", JSON.stringify(replayed));
+    assert.equal(replayed.opId, created.opId);
+    assert.equal(replayed.revision, created.revision);
+
+    const stale = await cell.run(
+      {
+        kind: "agent-install",
+        declaration: { ...declaration, name: "Stale Agent" },
+        expectedVersion: 0,
+        idempotencyKey: "agent-action-stale",
+      },
+      binding,
+    );
+    assert.equal(stale.outcome, "op_rejected");
+    assert.equal(stale.code, "revision_conflict");
+    assert.deepEqual(stale.unmetCriteria, ["agent/entity-revision"]);
+
+    const placeholder = await cell.run(
+      {
+        kind: "agent-install",
+        declaration: {
+          ...declaration,
+          id: "placeholder-agent",
+          instructions: "(To be written: this text becomes the agent's system prompt verbatim.)",
+        },
+        expectedVersion: 0,
+        idempotencyKey: "agent-action-placeholder",
+      },
+      binding,
+    );
+    assert.equal(placeholder.outcome, "op_rejected");
+    assert.equal(placeholder.code, "instructions_placeholder");
+    assert.deepEqual(placeholder.unmetCriteria, ["agent/instructions-ready"]);
+
+    const inspected = await cell.run({ kind: "agent-inspect", agentId: declaration.id }, binding);
+    assert.equal(JSON.parse(String(inspected.evidence)).agent.id, declaration.id);
+  } finally {
+    await cell.close();
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});

--- a/packages/daemon/test/agent-entities.test.ts
+++ b/packages/daemon/test/agent-entities.test.ts
@@ -103,21 +103,9 @@ test("Agent and Squad entities prepare, list, inspect, and replace declarations 
   }
 });
 
-test("Agent and Squad install reject the canonical blank declaration scaffolds", async () => {
+test("Squad install rejects the canonical blank roster scaffold", async () => {
   const rootDir = mkdtempSync(path.join(tmpdir(), "ha-agent-placeholder-"));
   try {
-    await assert.rejects(
-      () =>
-        install({
-          rootDir,
-          kind: "agent-install",
-          declaration: {
-            ...agent,
-            instructions: "(To be written: this text becomes the agent's system prompt verbatim.)",
-          },
-        }),
-      (error: unknown) => (error as { readonly code?: unknown }).code === "instructions_placeholder",
-    );
     await assert.rejects(
       () =>
         install({ rootDir, kind: "squad-install", declaration: { ...squad, roster: "## Squad Roster\n（待补写）" } }),

--- a/packages/kernel/src/domain/agent-action-contract.ts
+++ b/packages/kernel/src/domain/agent-action-contract.ts
@@ -1,0 +1,128 @@
+import { parseAgentDeclarationV1, type AgentDeclarationV1 } from "./agent-squad-schema.ts";
+import type {
+  EntityActionContract,
+  EntityActionInputContract,
+  EntityActionInputField,
+} from "./entity-kind-registry.ts";
+import type { EntityActionCompileHook } from "./entity-action-execution.ts";
+import { assertTransitionDocumentReady, requireTransitionDocumentKind } from "./transition-document-readiness.ts";
+
+export interface AgentActionDraft {
+  readonly kind: "entity";
+  readonly entityKind: "agent";
+  readonly entity: AgentDeclarationV1;
+}
+
+const input = (
+  fields: readonly EntityActionInputField[],
+  exactlyOneOf: readonly (readonly string[])[] = [],
+): EntityActionInputContract =>
+  Object.freeze({
+    schema: "entity-action-input/v1",
+    fields: Object.freeze(fields.map((field) => Object.freeze(field))),
+    exactlyOneOf: Object.freeze(exactlyOneOf.map((group) => Object.freeze(group))),
+  });
+
+export function createAgentActionCatalog(
+  baseAction: (id: "install") => EntityActionContract,
+  actionResultContract: EntityActionContract["returns"],
+) {
+  const declared = baseAction("install");
+  return Object.freeze({
+    ref: "kernel/agent-action/v1",
+    actions: Object.freeze([
+      Object.freeze({
+        ...declared,
+        input: input(
+          [
+            { field: "packageSource", type: "string", required: false },
+            { field: "declaration", type: "json-object", required: false },
+            { field: "declarationSource", type: "string", required: false },
+            { field: "generatedOnly", type: "boolean", required: false },
+            { field: "validated", type: "boolean", required: false },
+            { field: "dryRun", type: "boolean", required: false },
+            { field: "expectedVersion", type: "number", required: false },
+            { field: "idempotencyKey", type: "string", required: false },
+          ],
+          [["packageSource", "declaration"]],
+        ),
+        policy: Object.freeze({ ref: "default@5", action: "agent-install" }),
+        criteria: Object.freeze([
+          {
+            ref: "agent/declaration-schema",
+            failureCode: "invalid_manifest",
+            explain: "The Agent declaration must satisfy agent-declaration/v1 before publication.",
+          },
+          {
+            ref: "agent/instructions-ready",
+            failureCode: "instructions_placeholder",
+            explain: "Agent instructions must contain authored content rather than the declaration scaffold.",
+          },
+          {
+            ref: "agent/generated-validation",
+            failureCode: "agent_validation_required",
+            explain: "Generated Agent output must complete the validate step before installation.",
+          },
+          {
+            ref: "agent/generated-identity",
+            failureCode: "agent_id_conflict",
+            explain: "Generated Agent installation never replaces an existing Agent identity.",
+          },
+          {
+            ref: "agent/runtime-compatibility",
+            failureCode: "agent_runtime_type_unavailable",
+            explain: "Generated Agent runtime_type must resolve to an enabled runtime instance.",
+          },
+          {
+            ref: "agent/model-compatibility",
+            failureCode: "agent_model_unavailable",
+            explain: "Generated Agent model must be supported by a compatible runtime instance.",
+          },
+          {
+            ref: "agent/entity-revision",
+            failureCode: "revision_conflict",
+            explain: "When supplied, expectedVersion must match the latest Agent entity revision.",
+          },
+        ]),
+        concurrency: Object.freeze({
+          expectedVersion: Object.freeze({
+            authority: "entity-event/v1 Agent projection revision",
+            required: false,
+            default: "center-bound-current-revision",
+            conflict: "revision_conflict",
+          }),
+          leasePolicy: Object.freeze({ authority: "not-applicable" }),
+          occurrenceClaim: Object.freeze({ authority: "not-applicable" }),
+          idempotency: Object.freeze({
+            authority: "operation-id",
+            input: "idempotencyKey",
+            scope: "agent/{id}/install",
+            retry: "canonical-event-replay",
+          }),
+          artifactOwnership: Object.freeze({
+            owner: "agent/{id}",
+            declaration: "agents/{id}.json",
+            policy: "typed-entity/v1",
+          }),
+        }),
+        effects: Object.freeze([{ ref: "entity-event/entity_upserted", projection: "AgentProjection" }]),
+        returns: actionResultContract,
+        explain: "Install one validated Agent declaration through the canonical entity event stream.",
+        execution: Object.freeze({
+          ingress: "agent-install",
+          compile: compileAgentInstallAction,
+          read: false,
+          implementation: "compiled-event" as const,
+          topology: "center-forward-write" as const,
+          targetIdField: "entityId",
+        }),
+      }),
+    ]),
+  });
+}
+
+export const compileAgentInstallAction: EntityActionCompileHook = (input): AgentActionDraft => {
+  const entity = parseAgentDeclarationV1(input.action.declaration);
+  assertTransitionDocumentReady(requireTransitionDocumentKind("agent.install"), entity.instructions);
+  return { kind: "entity", entityKind: "agent", entity };
+};

--- a/packages/kernel/src/domain/entity-action-execution.ts
+++ b/packages/kernel/src/domain/entity-action-execution.ts
@@ -15,6 +15,7 @@ import {
 import { timestamp } from "./timestamp.ts";
 import type { WriteSource } from "./write-chain.contract.ts";
 import type { ScheduleActionDraft } from "./schedule-action-contract.ts";
+import type { AgentActionDraft } from "./agent-action-contract.ts";
 
 export interface EntityActionExecutionContract {
   readonly ingress: string;
@@ -55,6 +56,7 @@ export interface EntityActionCompileInput {
 }
 
 export type EntityActionDraft =
+  | AgentActionDraft
   | { readonly kind: "decision"; readonly event: DecisionEventDraftV1 }
   | { readonly kind: "fact"; readonly event: FactEventDraftV1 }
   | { readonly kind: "relation"; readonly event: RelationEventV1 }

--- a/packages/kernel/src/domain/entity-event.ts
+++ b/packages/kernel/src/domain/entity-event.ts
@@ -81,8 +81,6 @@ export function compileEntityUpsert(input: {
   const contractErrors = contract.entityStore.validate?.(entity) ?? [];
   if (contractErrors.length) throw new Error(contractErrors.join("; "));
   if (typeof entityId !== "string") throw new Error(`${input.entityKind} declaration has no string identity`);
-  if (input.entityKind === "agent" && isRecord(entity))
-    assertTransitionDocumentReady(requireTransitionDocumentKind("agent.install"), String(entity.instructions ?? ""));
   if (input.entityKind === "squad" && isRecord(entity))
     assertTransitionDocumentReady(requireTransitionDocumentKind("squad.install"), String(entity.roster ?? ""));
   const body = serializeEntityJsonSchema(contract.schema, entity, `${input.entityKind} declaration`),

--- a/packages/kernel/src/domain/entity-kind-registry.ts
+++ b/packages/kernel/src/domain/entity-kind-registry.ts
@@ -3,6 +3,7 @@ import taskFrontmatterJsonSchema from "../../schemas/json/task-frontmatter.schem
 import decisionPackageJsonSchema from "../../schemas/json/decision-package.schema.json" with { type: "json" };
 import factEventJsonSchema from "../../schemas/json/fact-event.schema.json" with { type: "json" };
 import { AGENT_DECLARATION_V1_SCHEMA, SQUAD_DECLARATION_V1_SCHEMA } from "./agent-squad-schema.ts";
+import { createAgentActionCatalog } from "./agent-action-contract.ts";
 import { agentRuntimeEventTypes, runtimeSessionEntityV1Schema } from "./agent-runtime.ts";
 import { decisionEventTypes, decisionStates } from "./decision-event-types.ts";
 import {
@@ -184,7 +185,7 @@ export interface EntityActionContract {
 
 export interface EntityActionInputField {
   readonly field: string;
-  readonly type: "string" | "number" | "boolean" | "string-array" | "fact-hold-array";
+  readonly type: "string" | "number" | "boolean" | "string-array" | "fact-hold-array" | "json-object";
   readonly required: boolean;
   readonly enum?: readonly string[];
   readonly regex?: string;
@@ -543,6 +544,11 @@ const scheduleActionCatalog = createScheduleActionCatalog(
   actionResultContract,
 );
 
+const agentActionCatalog = createAgentActionCatalog(
+  (id) => entityAction("agent", agentIdentity, id),
+  actionResultContract,
+);
+
 const factActionCatalog = Object.freeze({
   ref: "kernel/fact-event/v1",
   actions: Object.freeze([
@@ -719,11 +725,7 @@ export const entityKindContracts = Object.freeze([
     schema: AGENT_DECLARATION_V1_SCHEMA,
     relations: { directions: [], edges: [] },
     canonicalProjection: { embeddedEvents: [], row: { idField: "id", ownerField: null } },
-    actionCatalog: actionCatalog("kernel/agent-declaration/v1", "agent", agentIdentity, [
-      "configure",
-      "activate",
-      "retire",
-    ]),
+    actionCatalog: agentActionCatalog,
     entityStore: genericEntityStore("agents/{id}.json"),
     authoring: genericAuthoring,
     sdkExposure: noSdkExposure,

--- a/packages/kernel/src/domain/index.ts
+++ b/packages/kernel/src/domain/index.ts
@@ -259,7 +259,8 @@ export type {
 } from "./agent-squad-schema.ts";
 export { EntitySchemaContractError } from "./entity-json-schema.ts";
 
-export { compileEntityUpsert, isEntityEvent } from "./entity-event.ts";
+export { compileEntityUpsert, entityUpsertWritePlan, isEntityEvent } from "./entity-event.ts";
+export type { EntityEventV1, EntityUpsertBundle } from "./entity-event.ts";
 export type { CiRunObservationEventV1 } from "./ci-run-observation-event.ts";
 export { ciRunObservationWritePlan, validateCurrentCiRunObservationEvent } from "./ci-run-observation-event.ts";
 

--- a/packages/kernel/test/contracts/action-envelope.test.ts
+++ b/packages/kernel/test/contracts/action-envelope.test.ts
@@ -24,7 +24,7 @@ test("Action envelope is one closed kernel contract with a stable replay identit
   assert.match(validateActionEnvelope({ ...action, idempotencyKey: "" }).join("\n"), /idempotencyKey is required/u);
 });
 
-test("the five promoted Entity explanations declare metadata-only transitions without advertising availability", () => {
+test("the remaining promoted Entities stay metadata-only while Agent advertises executable install", () => {
   const catalogs = Object.fromEntries(
     ["execution", "review", "agent", "runtime-session", "policy"].map((kind) => [kind, explainEntityKind(kind)]),
   );
@@ -40,8 +40,9 @@ test("the five promoted Entity explanations declare metadata-only transitions wi
   assert.deepEqual(catalogs.review?.transitions.available, []);
   assert.deepEqual(declared("review"), ["record"]);
   assert.deepEqual(catalogs.agent?.statusVocabulary, []);
-  assert.deepEqual(catalogs.agent?.transitions.available, []);
-  assert.deepEqual(declared("agent"), ["configure", "activate", "retire"]);
+  assert.equal(catalogs.agent?.transitions.catalogRef, "kernel/agent-action/v1");
+  assert.deepEqual(catalogs.agent?.transitions.available, ["install"]);
+  assert.deepEqual(declared("agent"), ["install"]);
   assert.deepEqual(catalogs.policy?.statusVocabulary, []);
   assert.deepEqual(catalogs.policy?.transitions.available, []);
   assert.deepEqual(declared("policy"), ["draft", "activate", "retire"]);

--- a/packages/kernel/test/contracts/entity-action-execution.test.ts
+++ b/packages/kernel/test/contracts/entity-action-execution.test.ts
@@ -4,6 +4,7 @@ import test from "node:test";
 import { explainEntityKind, getExecutableEntityAction } from "../../src/domain/index.ts";
 
 const ingressKinds = [
+  "agent-install",
   "decision-accept",
   "decision-amend",
   "decision-claim-add",
@@ -49,7 +50,7 @@ const readIngressKinds = new Set([
   "schedule-show",
 ]);
 
-test("Decision, Fact, Relation, and Schedule ingress resolves to executable per-action catalog declarations", () => {
+test("Agent, Decision, Fact, Relation, and Schedule ingress resolves to executable per-action catalog declarations", () => {
   for (const ingress of ingressKinds) {
     const action = getExecutableEntityAction(ingress);
     assert.ok(action?.execution, ingress);
@@ -62,11 +63,74 @@ test("Decision, Fact, Relation, and Schedule ingress resolves to executable per-
 });
 
 test("entity explanations expose action identity but keep runtime compile hooks private", () => {
-  for (const kind of ["decision", "fact", "schedule"] as const) {
+  for (const kind of ["agent", "decision", "fact", "schedule"] as const) {
     const explanation = explainEntityKind(kind);
     assert.ok(explanation.transitions.actions.length > 0);
     for (const action of explanation.transitions.actions) assert.equal(Object.hasOwn(action, "execution"), false);
   }
+});
+
+test("Agent install owns declaration readiness, revision, idempotency, and artifact contracts", () => {
+  const explanation = explainEntityKind("agent"),
+    action = getExecutableEntityAction("agent-install");
+  assert.deepEqual(explanation.transitions.available, ["install"]);
+  assert.deepEqual(
+    explanation.transitions.actions.map(({ id }) => id),
+    ["install"],
+  );
+  assert.ok(action?.execution?.compile);
+  assert.equal(action.execution.implementation, "compiled-event");
+  assert.deepEqual(action.input.exactlyOneOf, [["packageSource", "declaration"]]);
+  assert.equal(action.concurrency.expectedVersion.conflict, "revision_conflict");
+  assert.equal(action.concurrency.idempotency.retry, "canonical-event-replay");
+  assert.equal(action.concurrency.leasePolicy.authority, "not-applicable");
+  assert.equal(action.concurrency.occurrenceClaim.authority, "not-applicable");
+  assert.deepEqual(action.concurrency.artifactOwnership, {
+    owner: "agent/{id}",
+    declaration: "agents/{id}.json",
+    policy: "typed-entity/v1",
+  });
+  const compile = (declaration: Readonly<Record<string, unknown>>) =>
+    action.execution!.compile!({
+      action: { kind: "agent-install", declaration },
+      actor: { principal: { personId: "person-agent-action" }, executor: null },
+      source: "local",
+      session: { kind: "unavailable", reason: "contract-test" },
+      opId: "agent-action-contract",
+      occurredAt: "2026-09-01T00:00:00.000Z",
+      workspaceRevision: 1,
+    });
+  assert.deepEqual(
+    compile({
+      schema: "agent-declaration/v1",
+      id: "contract-agent",
+      name: "Contract Agent",
+      instructions: "Execute the assigned contract.",
+      runtime_type: "codex",
+    }),
+    {
+      kind: "entity",
+      entityKind: "agent",
+      entity: {
+        schema: "agent-declaration/v1",
+        id: "contract-agent",
+        name: "Contract Agent",
+        instructions: "Execute the assigned contract.",
+        runtime_type: "codex",
+      },
+    },
+  );
+  assert.throws(
+    () =>
+      compile({
+        schema: "agent-declaration/v1",
+        id: "placeholder-agent",
+        name: "Placeholder Agent",
+        instructions: "(To be written: this text becomes the agent's system prompt verbatim.)",
+        runtime_type: "codex",
+      }),
+    (error: unknown) => (error as { readonly code?: unknown }).code === "instructions_placeholder",
+  );
 });
 
 test("Schedule explanations expose revision, single-flight, assignment, claim-fence, and replay contracts", () => {

--- a/packages/kernel/test/contracts/entity-store.test.ts
+++ b/packages/kernel/test/contracts/entity-store.test.ts
@@ -63,9 +63,9 @@ test("registered declaration Entity kinds explain the same contract shape from t
       declared: explanations[0]!.transitions.actions.map(({ id }) => id),
     },
     {
-      catalogRef: "kernel/agent-declaration/v1",
-      available: [],
-      declared: ["configure", "activate", "retire"],
+      catalogRef: "kernel/agent-action/v1",
+      available: ["install"],
+      declared: ["install"],
     },
   );
   assert.deepEqual(

--- a/packages/kernel/test/contracts/task-action-contract.test.ts
+++ b/packages/kernel/test/contracts/task-action-contract.test.ts
@@ -34,7 +34,7 @@ test("Task start submit review complete are complete executable Action contracts
     assert.ok(action.explain.length > 0);
   }
   assert.deepEqual(explainEntityKind("task").transitions.available, ["start", "submit", "review", "complete"]);
-  assert.deepEqual(explainEntityKind("agent").transitions.available, []);
+  assert.deepEqual(explainEntityKind("agent").transitions.available, ["install"]);
 });
 
 test("Agent-readable input and CLI facets share the same field declarations", () => {


### PR DESCRIPTION
# English

## Summary

Tier-2 entity epic, agent slice: the agent entity's only real action (`install`) moves from daemon specialization into the unified action catalog as an executable action with a compiled-event hook, CAS concurrency (`expectedVersion` → `revision_conflict`), idempotency-key operation identity, and ownership of its declaration artifact. The dispatcher's agent install specialization, the generic compiler's agent readiness special-case, and the unproven `configure/activate/retire` declared-only actions are deleted in the same change.

## Architectural Justification

- Production delta +376/-40 with no new module: the executable contract lives in the existing kernel action-contract family (`agent-action-contract.ts` mirrors the schedule slice's compiled-event pattern), and the daemon executor extends the existing `entity-action-catalog-executor`. Specialized branches are removed with grep-zero evidence; the G0-5 specialization ratchet passes and the five specialization files stay flat relative to baseline.

## What Changed

- `packages/kernel/src/domain/agent-action-contract.ts` (new): executable `install` — input schema, criteria (including instructions readiness, previously hardcoded in the generic compiler), CAS, idempotency, artifact ownership (`agents/{id}.json` belongs to `agent/{id}` only), compiled-event hook emitting the existing `entity-event/v1` `entity_upserted`.
- `packages/daemon/src/entity-action-catalog-executor.ts`: unified executor gains entity-draft preparation, dry-run preview, append/projection, canonical replay, ActionResult.
- `packages/daemon/src/repo-cell-open.ts` / `agent-entities.ts` / `repo-cell-action-dispatch.ts`: package/generated validation becomes catalog input preparation; install specialization branch removed.
- Catalog cleanup: declared-only `configure/activate/retire` deleted (no real caller evidence).
- Tests: `agent-action.integration.test.ts` (new, source/preview/CAS/replay/readiness/ActionResult), entity-action-execution contract coverage extended; obsolete specialization tests deleted.
- `explainEntityKind("agent")` now reports exactly one executable action, ready for the in-flight generalized `ha explain` engine.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: use the single CI-backed `Production-Delta` declaration below; do not enter a second metric.

## Machine-Readable Declarations

Production-Delta: +376/-40

## Task And Scope

- Harness task: task_3985f9c9c31c570af45059cf07 (agent slice under epic task_acd06bb4b0d21e4c4c95923c5f)
- Branch: codex/entity-agent
- Public scope: kernel agent action contract, daemon catalog executor, agent entity wiring, tests
- Private planning/evidence updated: yes
- Out of scope: squad path (independent future slice); the generalized explain engine itself

## Version Impact

- Version: no version change because this is an internal refactor ahead of the milestone release
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope:
- Authority: not applicable
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason:
- Break-glass scope:
- Follow-up governance task:

## Verification

- Base `origin/main` SHA: f40d879ee7d2654897e4dc3a3ef60151efd7aae0
- Branch merge-base with `origin/main`: f40d879ee7d2654897e4dc3a3ef60151efd7aae0
- Last `git fetch origin` time: 2026-09-01 early morning
- Sync method: none needed
- Public diff command: git diff f40d879ee...codex/entity-agent
- Private evidence commit/path: epic task package (inventory agent section updated; sub-task plan rewritten; fact F-AA244A9A)
- Reviewer evidence path: see Review Evidence
- GitHub Actions `rewrite-ci` run URL: pending (filled by CI on this PR)
- [x] targeted Node 24 regression: 44/44
- [x] `npm run typecheck`, lint
- [x] canonical-event compatibility, file complexity, line density, kernel dead exports, write-road, import boundaries, duplicate definitions, production-delta, G0-5 specialization ratchet
- Not run: full `npm run check` locally (GitHub CI is the authority)

## Review Evidence

- Self-review: coordinating session verified falsification-first workflow (agent unmigrated on main), sub-task reuse, multi-edge concurrency answer, specialization grep-zero, and five-file line table against the epic plan's acceptance criteria
- Reviewer subagent: none (single review round budgeted post-CI; pattern mirrors the already-merged schedule slice)
- Human review: pending merge review
- Blocking findings: none

## Residual Risk

- Sub-task ledger closeout is pending an executor bound to the sub-task (worker session was bound to the parent epic); the coordinating session will run the closeout chain after merge.

## References

- Task: task_3985f9c9c31c570af45059cf07
- Evidence: fact F-AA244A9A; epic inventory agent section
- Review: this PR

---

# 中文

## 概要

二档实体 epic 的 agent 切片:agent 唯一真实动作 `install` 从 daemon 特化迁入统一动作 catalog,成为 executable 动作——带 compiled-event hook、CAS 并发(`expectedVersion` → `revision_conflict`)、幂等键参与 operation 身份、声明 artifact 归属(`agents/{id}.json` 仅属 `agent/{id}`)。同一变更删除 dispatcher 的 install 特化分支、generic compiler 的 agent readiness 特判,以及无调用证据的 declared-only `configure/activate/retire`。

## 架构辩护

- 生产 +376/-40,零新模块:executable 契约落在既有 kernel action-contract 家族(`agent-action-contract.ts` 循 schedule 切片的 compiled-event 样板),daemon 侧扩展既有 `entity-action-catalog-executor`。特化分支删除有 grep=0 证据;G0-5 特化棘轮通过,五特化文件相对基线持平。

## 改动内容

- `agent-action-contract.ts`(新增):executable `install` 的输入、criteria(含原先硬编码在 generic compiler 的 instructions readiness)、CAS、幂等、artifact 归属、compiled-event hook(复用既有 `entity-event/v1` `entity_upserted`)。
- `entity-action-catalog-executor.ts`:统一 executor 增 entity draft、dry-run 预览、append/projection、canonical replay、ActionResult。
- `repo-cell-open.ts` / `agent-entities.ts` / `repo-cell-action-dispatch.ts`:package/generated 校验变为 catalog 输入准备;install 特化分支删除。
- catalog 清理:declared-only `configure/activate/retire` 删除(无真实调用方)。
- 测试:新增 agent-action 集成测试(源/预览/CAS/重放/readiness/ActionResult),契约测试扩展;旧特化测试删除。
- `explainEntityKind("agent")` 只暴露一个 executable,供在飞的统一 `ha explain` 引擎直接消费。

## 门收割 / Gate Harvest

- 删除的生产路径:none
- 同 commit 删除的门 / fixture:none
- 生产净行数:见英文块 `Production-Delta`。

## 机读声明说明

- 见英文块顶格声明。

## 任务与范围

- Harness 任务:task_3985f9c9c31c570af45059cf07(epic task_acd06bb4 下 agent 切片)
- 分支:codex/entity-agent
- 公开范围:kernel agent 动作契约、daemon catalog executor、agent 实体接线、测试
- 私有计划 / 证据是否已更新:yes
- 范围外:squad 路径(独立后续切片);统一 explain 引擎本身

## 版本影响

- 版本:不改版本,原因是里程碑发布前的内部重构
- 发布影响:不发布

## 治理声明

- 是否触碰 protected surface:no
- protected surface 范围:
- 依据:不适用
- 机器检查边界:本 PR 只声明该段存在;声明是否真实、充分,由 reviewer 判断。
- Break-glass:no
- Break-glass 原因:
- Break-glass 范围:
- 后续治理任务:

## 验证

- `origin/main` 基准 SHA:f40d879ee7d2654897e4dc3a3ef60151efd7aae0
- 当前分支与 `origin/main` 的 merge-base:f40d879ee7d2654897e4dc3a3ef60151efd7aae0
- 最近一次 `git fetch origin` 时间:2026-09-01 凌晨
- 同步方式:不需要
- 公开 diff 命令:git diff f40d879ee...codex/entity-agent
- 私有证据 commit/path:epic 任务包(inventory agent 段更新;子任务 plan 重写;fact F-AA244A9A)
- Reviewer 证据路径:见审查证据
- GitHub Actions `rewrite-ci` run URL:待 CI 回填
- [x] Node 24 定向回归 44/44
- [x] typecheck、lint
- [x] canonical-event compatibility、file complexity、line density、kernel dead exports、write-road、import boundaries、duplicate definitions、production-delta、G0-5 特化棘轮
- 未运行:本地完整 `npm run check`(GitHub CI 为权威)

## 审查证据

- 自查:协调会话对照 epic plan 验收判据核验:证伪先行(main 上 agent 未迁移)、子任务复用、多边缘并发答案、特化 grep=0、五文件行数表
- Reviewer subagent:无(评审预算一轮,CI 后;样式与已合并 schedule 切片同构)
- 人工审查:合并评审待做
- 阻塞发现:无

## 残余风险

- 子任务台账 closeout 待绑定子任务的执行者补交(worker 会话绑定在父 epic);合并后由协调会话走闭链。

## 关联材料

- 任务:task_3985f9c9c31c570af45059cf07
- 证据:fact F-AA244A9A;epic inventory agent 段
- 审查:本 PR

---

## PR Gate Checklist / PR 门禁清单

- [x] Branch is based on latest `origin/main`. / 分支基于最新 `origin/main`。
- [x] PR body uses this full template structure. / PR 描述使用本模板完整结构。
- [x] PR body uses two complete language blocks: `# English` first, then `# 中文`. / PR 正文使用两块完整正文:`# English` 在上,`# 中文` 在下。
- [x] PR body passes `tools/check-pr-body-bilingual.mjs`. / PR 正文通过 `tools/check-pr-body-bilingual.mjs`。
- [x] If the PR touches a manifest-derived protected surface, Governance Declaration is filled with ADR/decision/task evidence or break-glass fields. / 若 PR 触碰 manifest 派生的 protected surface,Governance Declaration 已填写 ADR/decision/task 依据或 break-glass 字段。
- [x] No private harness files are included. / 不包含私有 harness 文件。
- [x] No ignored local agent entry files are included. / 不包含被忽略的本地 agent 入口文件。
- [x] No absolute local filesystem paths are included in this public PR body. / 本公开 PR 描述不包含本机绝对路径。
- [x] Public diff is limited to the stated task scope. / 公开 diff 限于声明的任务范围。
- [x] Private planning/evidence updates are recorded when applicable. / 适用时已记录私有计划 / 证据更新。
- [x] Version and publish impact are stated. / 已说明版本与发布影响。
- [x] Local verification commands are recorded honestly. / 已如实记录本地验证命令。
- [x] CI results are linked or explained. / CI 结果已链接或说明。
- [x] Review evidence is recorded. / 已记录审查证据。
- [x] Open P0/P1/P2 findings are closed, deferred with owner, or explicitly blocked. / open P0/P1/P2 findings 已关闭、带 owner 延后,或明确阻塞。
- [x] Merge method and post-merge branch cleanup plan are clear. / 合并方式和合并后分支清理计划清楚。
- [x] No admin bypass is planned unless explicitly approved and recorded. / 除非明确批准并记录,否则不计划 admin bypass。
