### PR TITLE
feat(ontology): task action explain surface — one engine, three doors

### DIFF
--- a/packages/application/test/task-action-explanation-service.test.ts
+++ b/packages/application/test/task-action-explanation-service.test.ts
@@ -2,7 +2,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import {
-  explainEntityKind,
+  getEntityKindContract,
   projectBaseEntityAtCut,
   requireEntityTypeContract,
   type ActorIdentity,
@@ -18,7 +18,7 @@ test("Task explanations distinguish lifecycle state, actor capability, invocatio
   try {
     await harness.create();
     const planned = await snapshot(harness),
-      oldPlanned = explainEntityKind("task").transitions.available,
+      oldPlanned = taskCatalogActionIds(),
       plannedOwner = explain(harness, planned, owner),
       plannedStart = row(plannedOwner, "start");
     assert.deepEqual(
@@ -36,7 +36,7 @@ test("Task explanations distinguish lifecycle state, actor capability, invocatio
 
     await harness.start("execution-1");
     const active = await snapshot(harness),
-      oldActive = explainEntityKind("task").transitions.available,
+      oldActive = taskCatalogActionIds(),
       activeOwner = explain(harness, active, owner),
       activeOther = explain(harness, active, reviewer);
     assert.deepEqual(oldActive, oldPlanned, "the old catalog-only explain cannot distinguish lifecycle state");
@@ -119,6 +119,10 @@ test("Task explanations distinguish lifecycle state, actor capability, invocatio
 
 async function snapshot(harness: ReturnType<typeof lifecycleHarness>): Promise<TaskLifecycleSnapshot> {
   return (await harness.service.read("task-1")).snapshot;
+}
+
+function taskCatalogActionIds(): readonly string[] {
+  return getEntityKindContract("task")?.actionCatalog?.actions.map(({ id }) => id) ?? [];
 }
 
 function explain(

--- a/packages/cli/src/cli-render.ts
+++ b/packages/cli/src/cli-render.ts
@@ -21,7 +21,7 @@ export function humanError(receipt: Record<string, unknown>): {
 } {
   const outer = receipt.error && typeof receipt.error === "object" ? (receipt.error as Record<string, unknown>) : {},
     code = typeof outer.code === "string" ? outer.code : typeof receipt.code === "string" ? receipt.code : "unknown",
-    hint =
+    baseHint =
       typeof outer.hint === "string"
         ? outer.hint
         : typeof receipt.nextAction === "string"
@@ -29,6 +29,21 @@ export function humanError(receipt: Record<string, unknown>): {
           : typeof receipt.next === "string"
             ? receipt.next
             : "Command failed.",
+    criteria = Array.isArray(receipt.unmetCriteria)
+      ? receipt.unmetCriteria.flatMap((entry) =>
+          entry &&
+          typeof entry === "object" &&
+          typeof (entry as Record<string, unknown>).ref === "string" &&
+          typeof (entry as Record<string, unknown>).explain === "string"
+            ? [
+                `${String((entry as Record<string, unknown>).ref)} — ${String(
+                  (entry as Record<string, unknown>).explain,
+                )}`,
+              ]
+            : [],
+        )
+      : [],
+    hint = criteria.length > 0 ? `${baseHint} Unmet criteria: ${criteria.join("; ")}` : baseHint,
     leader = receipt.leader && typeof receipt.leader === "object" ? (receipt.leader as Record<string, unknown>) : null,
     nested = leader ? humanError(leader) : null,
     failure: ReceiptFailure =

--- a/packages/cli/src/cli/entity-action-explain-render.ts
+++ b/packages/cli/src/cli/entity-action-explain-render.ts
@@ -1,0 +1,58 @@
+export interface EntityActionExplanationRenderInput {
+  readonly mode: "catalog" | "object" | "failure";
+  readonly evaluatedAtCut: string | null;
+  readonly subjects: readonly {
+    readonly ref: string | null;
+    readonly revision: number | null;
+    readonly failure: null | {
+      readonly code: string;
+      readonly message: string;
+      readonly nextActions: readonly string[];
+    };
+    readonly actions: readonly {
+      readonly action: { readonly id: string; readonly explain: string; readonly syntax: { readonly usage: string } };
+      readonly available: boolean | null;
+      readonly unmetCriteria: readonly {
+        readonly ref: string;
+        readonly failureCode: string;
+        readonly explain: string;
+      }[];
+      readonly authorizationDecision: null | {
+        readonly outcome: "allowed" | "denied";
+        readonly reasonCodes: readonly string[];
+      };
+      readonly nextActions: readonly string[];
+    }[];
+  }[];
+}
+
+export function renderEntityActionExplanation(value: EntityActionExplanationRenderInput): string {
+  const heading =
+      value.mode === "catalog"
+        ? "Task actions (catalog; availability is not evaluated without an object):"
+        : `Task action explanation at ${String(value.evaluatedAtCut)}:`,
+    subjects = value.subjects.flatMap((subject) => {
+      if (subject.failure)
+        return [
+          `${subject.ref ?? "invalid ref"}: ${subject.failure.code} — ${subject.failure.message}`,
+          ...subject.failure.nextActions.map((next) => `  next: ${next}`),
+        ];
+      const subjectHeading = subject.ref ? `${subject.ref} @ revision ${String(subject.revision)}` : "task catalog",
+        actions = subject.actions.flatMap((row) => {
+          const state = row.available === null ? "not evaluated" : row.available ? "available" : "unavailable";
+          return [
+            `  ${row.action.id}: ${state} — ${row.action.explain}`,
+            `    usage: ${row.action.syntax.usage}`,
+            ...row.unmetCriteria.map(
+              (criterion) => `    unmet: ${criterion.ref} [${criterion.failureCode}] — ${criterion.explain}`,
+            ),
+            ...(row.authorizationDecision?.outcome === "denied"
+              ? [`    authorization: denied (${row.authorizationDecision.reasonCodes.join(", ")})`]
+              : []),
+            ...row.nextActions.map((next) => `    next: ${next}`),
+          ];
+        });
+      return [subjectHeading, ...actions];
+    });
+  return [heading, ...subjects].join("\n");
+}

--- a/packages/cli/src/cli/task-action-help.ts
+++ b/packages/cli/src/cli/task-action-help.ts
@@ -1,0 +1,21 @@
+import { taskActionHelpRows } from "../../../daemon/src/protocol/daemon-protocol.contract.ts";
+
+export interface TaskActionHelpRow {
+  readonly usage: string;
+  readonly summary: string;
+  readonly help: string;
+}
+
+const byCommand = new Map(taskActionHelpRows.map((row) => [commandKey(row.usage), row]));
+
+export function preferTaskActionHelp(row: TaskActionHelpRow): TaskActionHelpRow {
+  return byCommand.get(commandKey(row.usage)) ?? row;
+}
+
+export function projectedTaskActionHelpRows(): readonly TaskActionHelpRow[] {
+  return taskActionHelpRows;
+}
+
+function commandKey(usage: string): string {
+  return usage.split(" ").slice(0, 3).join(" ");
+}

--- a/packages/cli/src/cli/thin-command-explain.ts
+++ b/packages/cli/src/cli/thin-command-explain.ts
@@ -1,0 +1,34 @@
+import type { SafePath } from "../../../daemon/src/protocol/daemon-protocol.contract.ts";
+import { accepted, rejected } from "./thin-command-flags.ts";
+import type { ThinParseResult } from "./thin-command-types.ts";
+
+export function parseExplain(
+  args: readonly string[],
+  rootDir: SafePath,
+  repoId: string | undefined,
+  json: boolean,
+  method: string,
+): ThinParseResult {
+  const targets = args.slice(1);
+  if (targets.length === 1 && targets[0] === "task")
+    return accepted(
+      rootDir,
+      repoId,
+      json,
+      { kind: "entity-action-explain", schema: "entity-action-explain-request/v1", mode: "catalog", refs: [] },
+      method,
+    );
+  if (targets.length < 1 || targets.length > 500 || targets.some((target) => !/^task\/.+/u.test(target)))
+    return rejected(
+      "invalid_field",
+      "Use ha explain task for the catalog, or ha explain task/<task-id> [task/<task-id>...] for 1..500 objects.",
+      json,
+    );
+  return accepted(
+    rootDir,
+    repoId,
+    json,
+    { kind: "entity-action-explain", schema: "entity-action-explain-request/v1", mode: "object", refs: targets },
+    method,
+  );
+}

--- a/packages/cli/src/cli/thin-command-router.ts
+++ b/packages/cli/src/cli/thin-command-router.ts
@@ -2,6 +2,7 @@ import type { SafePath } from "../../../daemon/src/protocol/daemon-protocol.cont
 import { parseDecision } from "./thin-command-decision.ts";
 import { parseDoc } from "./thin-command-doc.ts";
 import { parseFact } from "./thin-command-fact.ts";
+import { parseExplain } from "./thin-command-explain.ts";
 import { accepted, nonEmpty, readFlags, rejected, rejectInput } from "./thin-command-flags.ts";
 import { parsePreset } from "./thin-command-preset.ts";
 import { parseProjected, projectFlags } from "./thin-command-projection.ts";
@@ -63,6 +64,7 @@ export function parseRouted(
     return args.length === 2
       ? accepted(rootDir, repoId, json, { kind: "ledger-migrate" })
       : rejected("unknown_field", "ha ledger migrate takes no options.", json);
+  if (route.id === "explain") return parseExplain(args, rootDir, repoId, json, route.method);
   if (route.id.startsWith("runtime-instance-")) return parseRuntimeInstance(route, args, rootDir, repoId, json, inputs);
   if (route.id.startsWith("runtime-")) return parseRuntime(route, args, rootDir, repoId, json, inputs);
   if (route.id.startsWith("schedule-")) return parseSchedule(route, args, rootDir, repoId, json, inputs);

--- a/packages/cli/src/cli/thin-command.ts
+++ b/packages/cli/src/cli/thin-command.ts
@@ -41,6 +41,7 @@ import { deriveInputDirectory } from "./thin-command-inputs.ts";
 import { parseRouted } from "./thin-command-router.ts";
 import { parseResumeDispatch } from "./thin-command-runtime.ts";
 import { parseTask } from "./thin-command-task.ts";
+import { preferTaskActionHelp } from "./task-action-help.ts";
 import type { ProtocolCommand, ThinCliInputDirectory, ThinParseResult } from "./thin-command-types.ts";
 
 type LifecyclePublicationAction =
@@ -87,11 +88,13 @@ function parseTaskRoute(
 
 export function renderThinHelp(catalog: readonly ThinHelpCatalogEntry[] = [], domain?: string): string {
   const rows = [
-      ...thinCliCommands.map(({ usage, summary, help }) => ({
-        usage,
-        summary,
-        help,
-      })),
+      ...thinCliCommands.map(({ usage, summary, help }) =>
+        preferTaskActionHelp({
+          usage,
+          summary,
+          help,
+        }),
+      ),
     ],
     visible = domain ? rows.filter(({ usage }) => usage.split(" ")[1] === domain) : rows,
     groups = commandDomains(),

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -20,6 +20,10 @@ import {
 } from "./cli/thin-command.ts";
 import { renderScheduleList, renderScheduleRuns, renderScheduleShow } from "./cli/thin-command-schedule.ts";
 import {
+  renderEntityActionExplanation,
+  type EntityActionExplanationRenderInput,
+} from "./cli/entity-action-explain-render.ts";
+import {
   daemonAutostartFailureCode,
   daemonBuildStaleCode,
   daemonResponseTimeoutCode,
@@ -79,7 +83,11 @@ export async function main(argv: readonly string[] = process.argv.slice(2)): Pro
       ? await runRuntimeFacadeCommand(typedCommand)
       : await runCommandThroughDaemon(typedCommand, (phase) => emit(phase, typedCommand.json));
     emit(receipt, typedCommand.json);
-    return Number.isInteger(receipt.exitCode) ? Number(receipt.exitCode) : receipt.ok === true ? 0 : 1;
+    return Number.isInteger(receipt.exitCode)
+      ? Number(receipt.exitCode)
+      : receipt.ok === true || receipt.schema === "entity-action-explanation/v1"
+        ? 0
+        : 1;
   } catch (error) {
     const autostartCode = daemonAutostartFailureCode(error),
       timeoutCode = daemonResponseTimeoutCode(error),
@@ -105,6 +113,8 @@ export function materializeDecisionStdin(
 
 export function emit(receipt: Record<string, unknown>, json: boolean): void {
   if (json) console.log(JSON.stringify(receipt));
+  else if (receipt.schema === "entity-action-explanation/v1")
+    console.log(renderEntityActionExplanation(receipt as unknown as EntityActionExplanationRenderInput));
   else if (receipt.command === "runtime-batch" && Array.isArray(receipt.dispatches))
     console.log(
       receipt.dispatches.length ? receipt.dispatches.map(renderRuntimeBatchRow).join("\n") : "No batch dispatches.",

--- a/packages/cli/test/agent-create.integration.test.ts
+++ b/packages/cli/test/agent-create.integration.test.ts
@@ -116,22 +116,13 @@ test("agent create runs and ontology-squad reinstall stays on the canonical Enti
       },
       ontologyGet = JSON.parse(
         String(run(root, env, ["entity", "get", "squad", "--id", ontologySquad.id]).evidence),
-      ) as { entity: { value: unknown } },
-      agentExplanation = JSON.parse(String(run(root, env, ["entity", "explain", "agent"]).evidence)) as Record<
-        string,
-        unknown
-      >,
-      squadExplanation = JSON.parse(String(run(root, env, ["entity", "explain", "squad"]).evidence)) as Record<
-        string,
-        unknown
-      >;
+      ) as { entity: { value: unknown } };
     assert.equal(
       entityList.entities.some(({ id }) => id === "meta-designer"),
       true,
     );
     assert.equal(entityGet.entity.value.id, "meta-designer");
     assert.deepEqual(ontologyGet.entity.value, ontologySquad);
-    assert.deepEqual(Object.keys(agentExplanation).sort(), Object.keys(squadExplanation).sort());
     const inventory = run(root, env, ["runtime", "instance", "list"]),
       installation = (inventory.installations as Array<Record<string, unknown>>).find(
         (row) => row.version === "codex agent-create-fixture",

--- a/packages/cli/test/explain-command.integration.test.ts
+++ b/packages/cli/test/explain-command.integration.test.ts
@@ -7,38 +7,62 @@ import path from "node:path";
 import test from "node:test";
 
 const cli = path.resolve("packages/cli/src/index.ts");
-const kinds = ["task", "fact", "decision", "agent", "squad", "policy", "execution", "review", "runtime-session"];
 
-test("ha entity explain returns the uniform contract for all nine kinds", (context) => {
-  const parent = mkdtempSync(path.join(tmpdir(), "ha-kind-authority-")),
+test("ha explain exposes the Task catalog and typed object failures through the read-only RPC", () => {
+  const parent = mkdtempSync(path.join(tmpdir(), "ha-action-explain-")),
     root = path.join(parent, "repo"),
     userRoot = path.join(parent, "user");
   try {
     setupRepository(root);
     assert.equal(run(root, userRoot, ["daemon", "start", "--service"]).ok, true);
     assert.equal(
-      run(root, userRoot, ["daemon", "repo", "register", "--repo-id", "kind-authority", "--root", root, "--no-link"])
+      run(root, userRoot, ["daemon", "repo", "register", "--repo-id", "action-explain", "--root", root, "--no-link"])
         .ok,
       true,
     );
-    for (const kind of kinds) {
-      const receipt = run(root, userRoot, ["entity", "explain", kind]);
-      assert.equal(receipt.outcome, "applied", kind);
-      const explanation = JSON.parse(String(receipt.evidence)) as { schema: string; kind: string };
-      assert.deepEqual(
-        { schema: explanation.schema, kind: explanation.kind },
-        {
-          schema: "entity-kind-explanation/v1",
-          kind,
-        },
-      );
-      context.diagnostic(`ha entity explain ${kind}: ${JSON.stringify(explanation)}`);
-    }
+    const catalog = run(root, userRoot, ["explain", "task"]),
+      object = run(root, userRoot, ["explain", "task/task_missing"]);
+    assert.deepEqual(
+      {
+        schema: catalog.schema,
+        mode: catalog.mode,
+        ids: actionIds(catalog),
+      },
+      {
+        schema: "entity-action-explanation/v1",
+        mode: "catalog",
+        ids: ["start", "submit", "review", "complete"],
+      },
+    );
+    assert.deepEqual(
+      {
+        schema: object.schema,
+        mode: object.mode,
+        failure: failureCode(object),
+      },
+      {
+        schema: "entity-action-explanation/v1",
+        mode: "failure",
+        failure: "entity_not_found",
+      },
+    );
   } finally {
     runBestEffort(root, userRoot, ["daemon", "stop"]);
     rmSync(parent, { recursive: true, force: true });
   }
 });
+
+function actionIds(value: Record<string, unknown>): unknown {
+  const subjects = value.subjects as readonly {
+    readonly actions: readonly { readonly action: { readonly id: string } }[];
+  }[];
+  return subjects[0]?.actions.map(({ action }) => action.id);
+}
+
+function failureCode(value: Record<string, unknown>): unknown {
+  const subjects = value.subjects as readonly { readonly failure: { readonly code: string } | null }[];
+  return subjects[0]?.failure?.code;
+}
 
 function setupRepository(root: string): void {
   mkdirSync(path.join(root, "harness"), { recursive: true });
@@ -63,8 +87,8 @@ roles:
     "utf8",
   );
   git(root, "init", "--quiet");
-  git(root, "config", "user.name", "Kind Authority Test");
-  git(root, "config", "user.email", "kind-authority@example.test");
+  git(root, "config", "user.name", "Explain Test");
+  git(root, "config", "user.email", "explain@example.test");
   git(root, "add", "README.md", "harness/harness.yaml", "harness/people.yaml");
   git(root, "commit", "--quiet", "-m", "fixture");
 }

--- a/packages/cli/test/explain-three-door-consistency.test.ts
+++ b/packages/cli/test/explain-three-door-consistency.test.ts
@@ -1,0 +1,82 @@
+// harness-test-tier: contract
+import assert from "node:assert/strict";
+import test from "node:test";
+import { makeTaskActionExplanationService } from "../../application/src/task-action-explanation-service.ts";
+import { lifecycleHarness, owner } from "../../application/test/task-lifecycle-test-harness.ts";
+import { deriveActionResult } from "../../daemon/src/entity-action-catalog-executor.ts";
+import {
+  getExecutableEntityAction,
+  projectBaseEntityAtCut,
+  requireEntityTypeContract,
+  type BaseEntity,
+} from "../../kernel/src/index.ts";
+import { projectedTaskActionHelpRows } from "../src/cli/task-action-help.ts";
+
+test("help, object explain, and rejected ActionResult preserve one Task Action row", async () => {
+  const harness = lifecycleHarness();
+  try {
+    await harness.create();
+    await harness.start("execution-1");
+    const snapshot = (await harness.service.read("task-1")).snapshot,
+      event = harness.eventStore.read().events.find(({ workspaceRevision }) => workspaceRevision === snapshot.revision);
+    assert.ok(snapshot.task);
+    assert.ok(event);
+    const cut = `canonical:${snapshot.revision}`,
+      entity = projectBaseEntityAtCut<BaseEntity<"task">>(requireEntityTypeContract("task"), {
+        kind: "task",
+        id: snapshot.task.taskId,
+        workspaceRevision: snapshot.revision,
+        occurredAt: event.occurredAt,
+        actor: event.actor,
+        source: event.source,
+        pinned: snapshot.task.pinned,
+        disposition: snapshot.task.packageDisposition ?? "active",
+      }),
+      explanation = makeTaskActionExplanationService({
+        actor: owner,
+        authorize: ({ target, evaluatedAtCut }) => ({
+          policyRef: "default@5",
+          actor: owner,
+          subject: target,
+          bindingsUsed: [],
+          outcome: "allowed",
+          reasonCodes: [],
+          nextActions: [],
+          evaluatedAtCut,
+        }),
+      }).object({ entity, snapshot, evaluatedAtCut: cut }),
+      row = explanation.subjects[0]?.actions.find(({ action }) => action.id === "start"),
+      contract = getExecutableEntityAction("task-start"),
+      help = projectedTaskActionHelpRows().find(({ usage }) => usage.startsWith("ha task start "));
+    assert.ok(row);
+    assert.ok(contract);
+    assert.ok(help);
+    const firstUnmet = row.unmetCriteria[0];
+    assert.ok(firstUnmet);
+    assert.equal(row.available, false);
+    assert.equal(help.summary, row.action.explain);
+    assert.equal(help.usage, row.action.syntax.usage);
+
+    const failure = deriveActionResult(
+      contract,
+      { kind: "task-start", taskId: "task-1" },
+      {
+        outcome: "op_rejected",
+        opId: "op-three-door",
+        code: firstUnmet.failureCode,
+        origin: "daemon",
+        evidence: "rejection:capability",
+        authorizationDecision: row.authorizationDecision!,
+        unmetCriteria: row.unmetCriteria,
+        rejectionExplanation: firstUnmet.explain,
+        nextActions: row.nextActions,
+      },
+    );
+    assert.deepEqual(failure.unmetCriteria, row.unmetCriteria);
+    assert.deepEqual(failure.authorizationDecision, row.authorizationDecision);
+    assert.deepEqual(failure.nextActions, row.nextActions);
+    assert.equal(failure.rejectionExplanation, firstUnmet.explain);
+  } finally {
+    harness.cleanup();
+  }
+});

--- a/packages/cli/test/provider-fallback-render.test.ts
+++ b/packages/cli/test/provider-fallback-render.test.ts
@@ -56,6 +56,23 @@ test("CLI dispatch and nested receipt errors are handled by closed tagged branch
   assert.deepEqual(humanError({ code: "top", nextAction: "repair" }), { code: "top", hint: "repair" });
   assert.deepEqual(
     humanError({
+      code: "invalid_transition",
+      nextAction: "refresh and retry",
+      unmetCriteria: [
+        {
+          ref: "task-lifecycle-contract-support/revisionIssues",
+          failureCode: "invalid_transition",
+          explain: "Expected revision must match.",
+        },
+      ],
+    }),
+    {
+      code: "invalid_transition",
+      hint: "refresh and retry Unmet criteria: task-lifecycle-contract-support/revisionIssues — Expected revision must match.",
+    },
+  );
+  assert.deepEqual(
+    humanError({
       code: "squad_leader_failed",
       leader: { error: { code: "lease_conflict", hint: "release the holder" } },
     }),

--- a/packages/cli/test/task-action-help.test.ts
+++ b/packages/cli/test/task-action-help.test.ts
@@ -1,0 +1,54 @@
+// harness-test-tier: fast
+import assert from "node:assert/strict";
+import test from "node:test";
+import { makeTaskActionExplanationService } from "../../application/src/task-action-explanation-service.ts";
+import { generatedTaskActionProtocolDeclarations } from "../../daemon/src/protocol/daemon-protocol-commands-task.ts";
+import { renderEntityActionExplanation } from "../src/cli/entity-action-explain-render.ts";
+import { projectedTaskActionHelpRows } from "../src/cli/task-action-help.ts";
+import { renderThinHelp } from "../src/cli/thin-command.ts";
+
+test("Task lifecycle help is projected from the generated Action declarations", () => {
+  const rows = projectedTaskActionHelpRows();
+  assert.deepEqual(
+    rows.map(({ summary }) => summary),
+    generatedTaskActionProtocolDeclarations.map(({ explain }) => explain),
+  );
+  assert.deepEqual(
+    rows.map(({ usage }) => usage.split(" ").slice(0, 3).join(" ")),
+    generatedTaskActionProtocolDeclarations.map(({ execution }) =>
+      ["ha", "task", execution.ingress.slice("task-".length)].join(" "),
+    ),
+  );
+  const submit = rows.find(({ usage }) => usage.startsWith("ha task submit "));
+  assert.match(submit?.usage ?? "", /--from-file.*--json-input/u);
+  assert.match(submit?.help ?? "", /mutually exclusive with: --json-input/u);
+  assert.equal(
+    rows.some((row) => "available" in row),
+    false,
+  );
+});
+
+test("Task help replaces only the four lifecycle rows", () => {
+  const help = renderThinHelp([], "task");
+  for (const row of projectedTaskActionHelpRows()) {
+    assert.match(help, new RegExp(row.summary.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&"), "u"));
+    assert.match(help, new RegExp(row.usage.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&"), "u"));
+  }
+  assert.match(help, /ha task create/u);
+  assert.match(help, /ha task progress append/u);
+  assert.doesNotMatch(help, /availability: (?:true|false)|available: (?:true|false)/u);
+});
+
+test("human explain output labels catalog availability as not evaluated", () => {
+  const catalog = makeTaskActionExplanationService({
+      actor: { principal: { personId: "person-help" }, executor: null },
+      authorize: () => {
+        throw new Error("catalog rendering must not evaluate authorization");
+      },
+    }).catalog(),
+    rendered = renderEntityActionExplanation(catalog);
+  assert.match(rendered, /Task actions \(catalog; availability is not evaluated without an object\)/u);
+  assert.match(rendered, /start: not evaluated/u);
+  assert.match(rendered, /usage: ha task start <task-id>/u);
+  assert.doesNotMatch(rendered, /start: available/u);
+});

--- a/packages/cli/test/thin-command.test.ts
+++ b/packages/cli/test/thin-command.test.ts
@@ -113,7 +113,8 @@ test("capabilities is an exact-set projection of the command contract", () => {
       "doc-sync-dry-run",
       "doc-sync-submit",
     ],
-    entity: ["entity-explain", "entity-get", "entity-list"],
+    entity: ["entity-get", "entity-list"],
+    explain: ["explain"],
     fact: ["fact-record", "fact-search", "fact-show"],
     init: ["repo-bootstrap"],
     migrate: ["fact-rekey", "ledger-migrate", "migrate-import"],
@@ -206,6 +207,30 @@ test("capabilities is an exact-set projection of the command contract", () => {
     template: ["template-list", "template-render"],
     vertical: ["vertical-validate"],
   });
+});
+
+test("explain routes catalog and object requests to the typed read method", () => {
+  const catalog = parseThinCommand(["explain", "task"]),
+    objects = parseThinCommand(["explain", "task/task-one", "task/task-two"]),
+    invalid = parseThinCommand(["explain", "decision/dec-one"]);
+  assert.equal(catalog.ok, true);
+  assert.equal(objects.ok, true);
+  assert.equal(invalid.ok, false);
+  if (!catalog.ok || !objects.ok || invalid.ok) return;
+  assert.equal(catalog.command.method, "repo.entity.actions.explain");
+  assert.deepEqual(catalog.command.action, {
+    kind: "entity-action-explain",
+    schema: "entity-action-explain-request/v1",
+    mode: "catalog",
+    refs: [],
+  });
+  assert.deepEqual(objects.command.action, {
+    kind: "entity-action-explain",
+    schema: "entity-action-explain-request/v1",
+    mode: "object",
+    refs: ["task/task-one", "task/task-two"],
+  });
+  assert.match(invalid.nextAction, /ha explain task\/.*1\.\.500 objects/u);
 });
 
 test("task transition conditional inputs preserve audited cancellation and reinstatement", () => {

--- a/packages/daemon/src/entity-action-catalog-executor.ts
+++ b/packages/daemon/src/entity-action-catalog-executor.ts
@@ -20,6 +20,7 @@ import {
   type EntityActionContract,
   type EntityActionDraft,
   type EntityActionExecutionContract,
+  type EntityActionUnmetCriterionV1,
   type EntityEventV1,
   type EntityUpsertBundle,
   type EventPublicationKillpoint,
@@ -437,13 +438,12 @@ export function deriveActionResult(
         : targetIdField && typeof receiptFields[targetIdField] === "string"
           ? receiptFields[targetIdField]
           : null,
-    unmetCriteria = rejected
-      ? contract.criteria
-          .filter((criterion) => criterion.failureCode === receipt.code)
-          .map((criterion) => criterion.ref)
+    inferredCriteria = contract.criteria.filter((criterion) => criterion.failureCode === receipt.code),
+    unmetCriteria: readonly EntityActionUnmetCriterionV1[] = rejected
+      ? (receipt.unmetCriteria ?? (inferredCriteria.length === 1 ? inferredCriteria : []))
       : [],
     explanation = rejected
-      ? (contract.criteria.find((criterion) => criterion.failureCode === receipt.code)?.explain ??
+      ? (unmetCriteria[0]?.explain ??
         receipt.nextAction ??
         `Action ${contract.target.kind}.${contract.id} was rejected.`)
       : null;
@@ -460,7 +460,9 @@ export function deriveActionResult(
             revision: receipt.revision ?? null,
           },
     rejectionExplanation: explanation,
-    nextActions: receipt.nextAction ? [receipt.nextAction] : [],
+    nextActions: Object.freeze([
+      ...new Set([...(receipt.nextActions ?? []), ...(receipt.nextAction ? [receipt.nextAction] : [])]),
+    ]),
   };
 }
 

--- a/packages/daemon/src/protocol/daemon-protocol-commands-agent.ts
+++ b/packages/daemon/src/protocol/daemon-protocol-commands-agent.ts
@@ -191,12 +191,12 @@ export const agentProtocolCommands = Object.freeze([
     inputs: [],
   }),
   defineRepoReadCommand({
-    id: "entity-explain",
-    phase: "Runtime-B",
-    path: ["entity", "explain", "<kind>"],
-    summary: "Explain one registered Entity kind contract.",
-    method: "repo.task.run",
-    positional: "entityKind",
+    id: "explain",
+    actionKind: "entity-action-explain",
+    phase: "Ontology-Explain-A",
+    path: ["explain", "<task|task/ref>..."],
+    summary: "Explain the Task Action catalog or evaluate one or more Task refs at the current canonical cut.",
+    method: "repo.entity.actions.explain",
     inputs: [],
   }),
   defineRepoReadCommand({

--- a/packages/daemon/src/protocol/daemon-protocol-commands-task.ts
+++ b/packages/daemon/src/protocol/daemon-protocol-commands-task.ts
@@ -481,6 +481,13 @@ export const derivedTaskActionProtocolCommands = Object.freeze(
   generatedTaskActionProtocolDeclarations.map(taskActionProtocolCommand),
 );
 
+export const taskActionHelpRows = Object.freeze(
+  generatedTaskActionProtocolDeclarations.map((action) => {
+    const { usage, summary, help } = taskActionProtocolCommand(action);
+    return Object.freeze({ usage, summary, help });
+  }),
+);
+
 export const taskExecutionProtocolCommands = Object.freeze([
   ...derivedTaskActionProtocolCommands,
   defineCenterForwardWriteCommand({

--- a/packages/daemon/src/protocol/daemon-protocol.contract.ts
+++ b/packages/daemon/src/protocol/daemon-protocol.contract.ts
@@ -638,6 +638,7 @@ export {
   resolveThinCliCommand,
   thinCliCommands,
 } from "./daemon-protocol-commands.ts";
+export { taskActionHelpRows } from "./daemon-protocol-commands-task.ts";
 export { daemonGuiActionMethods, daemonGuiStreamFacets, daemonStreamFacets } from "./daemon-protocol-gui-actions.ts";
 export { daemonGuiReadMethods } from "./daemon-protocol-gui-reads.ts";
 export { validateObserveTailResult } from "./daemon-protocol-gui-types.ts";

--- a/packages/daemon/src/repo-cell-action-dispatch.ts
+++ b/packages/daemon/src/repo-cell-action-dispatch.ts
@@ -3,7 +3,6 @@ import {
   compileExecutionExecutorDeclaration,
   compileTaskLifecycleWrite,
   createEntityStore,
-  explainEntityKind,
   executionExecutorDeclarationCandidates,
   getExecutableEntityAction,
   isLedgerLayoutMigrationEvent,
@@ -235,17 +234,10 @@ export async function executeAction(
       cell.entityActionRuntimes,
     );
   if (action.kind === "preset-upgrade") return cell.upgradePresetSnapshot(action, binding);
-  if (/^entity-(?:explain|get|list)$/u.test(action.kind)) {
+  if (/^entity-(?:get|list)$/u.test(action.kind)) {
     const revision = cell.store.readHead()?.revision ?? 0,
       kind = cell.requiredCellText(action.entityKind, "entityKind"),
       entities = createEntityStore(cell.store);
-    if (action.kind === "entity-explain")
-      return cell.readResult(
-        cell.operationId(action, binding, cell.input.repoId, revision),
-        explainEntityKind(kind),
-        revision,
-        null,
-      );
     if (action.kind === "entity-list")
       return cell.readResult(
         cell.operationId(action, binding, cell.input.repoId, revision),

--- a/packages/daemon/src/repo-cell-api.ts
+++ b/packages/daemon/src/repo-cell-api.ts
@@ -13,6 +13,7 @@ import {
   type DaemonRepoMode,
   type DecisionProjectionRow,
   type EventPublicationKillpoint,
+  type EntityActionUnmetCriterionV1,
   type TaskProjection,
   type TaskProjectionListQuery,
   type WriteReceipt,
@@ -141,7 +142,7 @@ export function createRepoCellApi(context: RepoCellApiContext): RepoCell {
         withAuthorizationDecision(
           context.failed(actionId, error),
           decision,
-          ["runtime-session/executor-binding"],
+          [],
           error instanceof Error ? error.message : String(error),
         ),
       );
@@ -155,7 +156,7 @@ export function createRepoCellApi(context: RepoCellApiContext): RepoCell {
       durable = (durablePolicyActions as readonly string[]).includes(action.kind),
       frameCurrent = (
         receipt: WriteReceiptDraft,
-        criteria: readonly string[] = [],
+        criteria: readonly EntityActionUnmetCriterionV1[] = [],
         explanation?: string,
       ): WriteReceipt =>
         durable
@@ -174,7 +175,7 @@ export function createRepoCellApi(context: RepoCellApiContext): RepoCell {
             "repo_unavailable",
             context.latched(),
           ),
-          ["repo-cell/availability"],
+          [],
           context.latched(),
         ),
       );
@@ -190,7 +191,7 @@ export function createRepoCellApi(context: RepoCellApiContext): RepoCell {
         ? withAuthorizationDecision(
             result,
             authorizationDecision,
-            result.unmetCriteria?.length ? result.unmetCriteria : [criterionForError(error)],
+            result.unmetCriteria ?? [],
             result.rejectionExplanation ?? (error instanceof Error ? error.message : String(error)),
           )
         : (result as WriteReceipt);
@@ -258,7 +259,7 @@ export function createRepoCellApi(context: RepoCellApiContext): RepoCell {
               "invalid_command",
               "Squad input must contain only JSON values.",
             ),
-            ["action-envelope/json-input"],
+            [],
             "Squad input must contain only JSON values.",
           ),
         );
@@ -956,7 +957,7 @@ export function createRepoCellApi(context: RepoCellApiContext): RepoCell {
 function withAuthorizationDecision(
   receipt: WriteReceiptDraft,
   authorizationDecision: AuthorizationDecision,
-  unmetCriteria: readonly string[] = receipt.unmetCriteria ?? [],
+  unmetCriteria: readonly EntityActionUnmetCriterionV1[] = receipt.unmetCriteria ?? [],
   rejectionExplanation: string | undefined = receipt.rejectionExplanation ?? undefined,
 ): WriteReceipt {
   return {
@@ -968,15 +969,11 @@ function withAuthorizationDecision(
         ? (rejectionExplanation ?? `Action rejected after ${authorizationDecision.policyRef} qualification.`)
         : null,
     nextActions: Object.freeze([
-      ...(receipt.nextActions ?? []),
-      ...(receipt.nextAction ? [receipt.nextAction] : []),
-      ...authorizationDecision.nextActions,
+      ...new Set([
+        ...(receipt.nextActions ?? []),
+        ...(receipt.nextAction ? [receipt.nextAction] : []),
+        ...authorizationDecision.nextActions,
+      ]),
     ]),
   };
-}
-
-function criterionForError(error: unknown): string {
-  return typeof error === "object" && error !== null && "code" in error && typeof error.code === "string"
-    ? `criteria/${error.code}`
-    : "criteria/action-execution";
 }

--- a/packages/daemon/src/task-action-catalog-runtime.ts
+++ b/packages/daemon/src/task-action-catalog-runtime.ts
@@ -1,8 +1,13 @@
 import {
   canStartExecution,
+  evaluateTaskActionCapability,
   getExecutableEntityAction,
   heldLeaseForExecutionActor,
   isTerminalStatus,
+  revisionIssues,
+  type EntityActionContract,
+  type EntityActionUnmetCriterionV1,
+  type TaskLifecycleCommand,
   type WriteReceiptDraft as WriteReceipt,
 } from "../../kernel/src/index.ts";
 import { actorHint } from "./repo-cell-proof.ts";
@@ -19,7 +24,8 @@ export async function runTaskActionCatalogRuntime(
     expectedRevision = Number.isSafeInteger(action.expectedVersion)
       ? Number(action.expectedVersion)
       : current.snapshot.revision,
-    lifecycle = getExecutableEntityAction(action.kind)?.execution?.lifecycle,
+    contract = getExecutableEntityAction(action.kind),
+    lifecycle = contract?.execution?.lifecycle,
     preview = lifecycle?.coordination === "reserve" && action.dryRun === true,
     activeLease = cell.projection.currentLease(taskId, cell.now());
   if (
@@ -73,6 +79,15 @@ export async function runTaskActionCatalogRuntime(
       "terminal_task",
       `Run ha task supersede ${taskId} --title <follow-up-title> for new work.`,
     );
+  if (contract?.target.kind === "task") {
+    const capability = evaluateTaskActionCapability({
+        action: contract,
+        snapshot: current.snapshot,
+        actor: binding.actor,
+      }),
+      unmet = capability.filter(({ status }) => status === "unmet");
+    if (unmet.length > 0) return taskActionRejection(cell, action, binding, current.snapshot.revision, contract, unmet);
+  }
   if (lifecycle?.coordination === "reserve" && !preview)
     cell.assertTaskTransitionDocumentReady({
       rootDir: cell.rootDir,
@@ -90,6 +105,23 @@ export async function runTaskActionCatalogRuntime(
     cell.rootDir,
     current.snapshot,
   );
+  if (
+    contract?.target.kind === "task" &&
+    revisionIssues(current.snapshot, {
+      ...normalized,
+      workspaceRevision: current.snapshot.revision + 1,
+    } as TaskLifecycleCommand).length > 0
+  ) {
+    const criterion = contract.criteria.find(({ ref }) => ref === "task-lifecycle-contract-support/revisionIssues");
+    if (!criterion)
+      throw new Error(`Task Action ${contract.id} does not declare its existing revisionIssues predicate.`);
+    return taskActionRejection(cell, action, binding, current.snapshot.revision, contract, [
+      {
+        criterionRef: criterion.ref,
+        nextActions: [`${criterion.explain} Then retry with --expected-version ${String(current.snapshot.revision)}.`],
+      },
+    ]);
+  }
   if (preview && lifecycle) {
     const commandFields = normalized as unknown as Readonly<Record<string, unknown>>,
       executionId = commandFields[lifecycle.targetIdField];
@@ -138,4 +170,34 @@ export async function runTaskActionCatalogRuntime(
     result.code ?? "publication_unknown",
     result.nextAction ?? "Retry receipt show before resubmitting.",
   );
+}
+
+function taskActionRejection(
+  cell: RepoCellOperationalContext,
+  action: RepoTaskAction,
+  binding: RepoCellBinding,
+  revision: number,
+  contract: EntityActionContract,
+  unmet: readonly {
+    readonly criterionRef: string;
+    readonly nextActions: readonly string[];
+  }[],
+): WriteReceipt {
+  const unmetCriteria: readonly EntityActionUnmetCriterionV1[] = unmet.map(({ criterionRef }) => {
+      const criterion = contract.criteria.find(({ ref }) => ref === criterionRef);
+      if (!criterion) throw new Error(`Task Action ${contract.id} criterion ${criterionRef} is not declared.`);
+      return criterion;
+    }),
+    nextActions = Object.freeze([...new Set(unmet.flatMap(({ nextActions: next }) => next))]),
+    first = unmetCriteria[0]!;
+  return {
+    ...cell.rejected(
+      cell.operationId(action, binding, cell.input.repoId, revision),
+      first.failureCode,
+      nextActions[0] ?? first.explain,
+    ),
+    unmetCriteria,
+    rejectionExplanation: first.explain,
+    nextActions,
+  };
 }

--- a/packages/daemon/src/task-action-catalog-runtime.ts
+++ b/packages/daemon/src/task-action-catalog-runtime.ts
@@ -79,15 +79,14 @@ export async function runTaskActionCatalogRuntime(
       "terminal_task",
       `Run ha task supersede ${taskId} --title <follow-up-title> for new work.`,
     );
-  if (contract?.target.kind === "task") {
-    const capability = evaluateTaskActionCapability({
-        action: contract,
-        snapshot: current.snapshot,
-        actor: binding.actor,
-      }),
-      unmet = capability.filter(({ status }) => status === "unmet");
-    if (unmet.length > 0) return taskActionRejection(cell, action, binding, current.snapshot.revision, contract, unmet);
-  }
+  const unmet =
+    contract?.target.kind === "task"
+      ? evaluateTaskActionCapability({
+          action: contract,
+          snapshot: current.snapshot,
+          actor: binding.actor,
+        }).filter(({ status }) => status === "unmet")
+      : [];
   if (lifecycle?.coordination === "reserve" && !preview)
     cell.assertTaskTransitionDocumentReady({
       rootDir: cell.rootDir,
@@ -96,15 +95,22 @@ export async function runTaskActionCatalogRuntime(
       slot: "task.plan",
       transition: "task.start",
     });
-  const normalized = cell.buildCommand(
-    preview ? cell.withoutDryRun(action) : action,
-    taskId,
-    binding,
-    cell.input.repoId,
-    expectedRevision,
-    cell.rootDir,
-    current.snapshot,
-  );
+  let normalized: ReturnType<RepoCellOperationalContext["buildCommand"]>;
+  try {
+    normalized = cell.buildCommand(
+      preview ? cell.withoutDryRun(action) : action,
+      taskId,
+      binding,
+      cell.input.repoId,
+      expectedRevision,
+      cell.rootDir,
+      current.snapshot,
+    );
+  } catch (error) {
+    const rejection = taskActionFailure(cell, action, binding, current.snapshot.revision, contract, unmet, error);
+    if (rejection) return rejection;
+    throw error;
+  }
   if (
     contract?.target.kind === "task" &&
     revisionIssues(current.snapshot, {
@@ -140,13 +146,22 @@ export async function runTaskActionCatalogRuntime(
     );
   }
   const command = cell.withServerMeta(
-      normalized,
-      cell.store.readTaskEvent(normalized.opId),
-      cell.store.readHead()?.revision ?? 0,
-      cell.now(),
-    ),
-    authorityProof = await cell.proofFor(command, current.snapshot, binding, cell.projection),
-    result = await cell.service.execute(command, authorityProof);
+    normalized,
+    cell.store.readTaskEvent(normalized.opId),
+    cell.store.readHead()?.revision ?? 0,
+    cell.now(),
+  );
+  let authorityProof: Awaited<ReturnType<RepoCellOperationalContext["proofFor"]>>;
+  try {
+    authorityProof = await cell.proofFor(command, current.snapshot, binding, cell.projection);
+  } catch (error) {
+    const rejection = taskActionFailure(cell, action, binding, current.snapshot.revision, contract, unmet, error);
+    if (rejection) return rejection;
+    throw error;
+  }
+  if (unmet.length > 0 && contract)
+    return taskActionRejection(cell, action, binding, current.snapshot.revision, contract, unmet);
+  const result = await cell.service.execute(command, authorityProof);
   if (result.outcome === "applied" && result.event && result.proof)
     return cell.lifecycleReceipt(
       result.event,
@@ -172,6 +187,27 @@ export async function runTaskActionCatalogRuntime(
   );
 }
 
+function taskActionFailure(
+  cell: RepoCellOperationalContext,
+  action: RepoTaskAction,
+  binding: RepoCellBinding,
+  revision: number,
+  contract: EntityActionContract | undefined,
+  unmet: readonly {
+    readonly criterionRef: string;
+    readonly nextActions: readonly string[];
+  }[],
+  error: unknown,
+): WriteReceipt | null {
+  if (!contract) return null;
+  const rejected = cell.failed(
+      cell.errorOperationId(error) ?? cell.operationId(action, binding, cell.input.repoId, revision),
+      error,
+    ),
+    withCriteria = attachTaskActionCriteria(cell, action, binding, revision, contract, unmet, rejected);
+  return withCriteria.unmetCriteria?.length ? withCriteria : null;
+}
+
 function taskActionRejection(
   cell: RepoCellOperationalContext,
   action: RepoTaskAction,
@@ -182,22 +218,50 @@ function taskActionRejection(
     readonly criterionRef: string;
     readonly nextActions: readonly string[];
   }[],
+  rejected?: WriteReceipt,
 ): WriteReceipt {
   const unmetCriteria: readonly EntityActionUnmetCriterionV1[] = unmet.map(({ criterionRef }) => {
       const criterion = contract.criteria.find(({ ref }) => ref === criterionRef);
       if (!criterion) throw new Error(`Task Action ${contract.id} criterion ${criterionRef} is not declared.`);
       return criterion;
     }),
-    nextActions = Object.freeze([...new Set(unmet.flatMap(({ nextActions: next }) => next))]),
+    nextActions = Object.freeze([
+      ...new Set([
+        ...(rejected?.nextActions ?? []),
+        ...(rejected?.nextAction ? [rejected.nextAction] : []),
+        ...unmet.flatMap(({ nextActions: next }) => next),
+      ]),
+    ]),
     first = unmetCriteria[0]!;
   return {
-    ...cell.rejected(
-      cell.operationId(action, binding, cell.input.repoId, revision),
-      first.failureCode,
-      nextActions[0] ?? first.explain,
-    ),
+    ...(rejected ??
+      cell.rejected(
+        cell.operationId(action, binding, cell.input.repoId, revision),
+        first.failureCode,
+        nextActions[0] ?? first.explain,
+      )),
     unmetCriteria,
     rejectionExplanation: first.explain,
     nextActions,
   };
+}
+
+function attachTaskActionCriteria(
+  cell: RepoCellOperationalContext,
+  action: RepoTaskAction,
+  binding: RepoCellBinding,
+  revision: number,
+  contract: EntityActionContract,
+  unmet: readonly {
+    readonly criterionRef: string;
+    readonly nextActions: readonly string[];
+  }[],
+  rejected: WriteReceipt,
+): WriteReceipt {
+  const matching = unmet.filter(({ criterionRef }) =>
+    contract.criteria.some(({ ref, failureCode }) => ref === criterionRef && failureCode === rejected.code),
+  );
+  return matching.length > 0
+    ? taskActionRejection(cell, action, binding, revision, contract, matching, rejected)
+    : rejected;
 }

--- a/packages/daemon/test/agent-action.integration.test.ts
+++ b/packages/daemon/test/agent-action.integration.test.ts
@@ -80,7 +80,13 @@ test("Agent install uses the executable catalog with CAS, replay, readiness, and
     );
     assert.equal(stale.outcome, "op_rejected");
     assert.equal(stale.code, "revision_conflict");
-    assert.deepEqual(stale.unmetCriteria, ["agent/entity-revision"]);
+    assert.deepEqual(stale.unmetCriteria, [
+      {
+        ref: "agent/entity-revision",
+        failureCode: "revision_conflict",
+        explain: "When supplied, expectedVersion must match the latest Agent entity revision.",
+      },
+    ]);
 
     const placeholder = await cell.run(
       {
@@ -97,7 +103,13 @@ test("Agent install uses the executable catalog with CAS, replay, readiness, and
     );
     assert.equal(placeholder.outcome, "op_rejected");
     assert.equal(placeholder.code, "instructions_placeholder");
-    assert.deepEqual(placeholder.unmetCriteria, ["agent/instructions-ready"]);
+    assert.deepEqual(placeholder.unmetCriteria, [
+      {
+        ref: "agent/instructions-ready",
+        failureCode: "instructions_placeholder",
+        explain: "Agent instructions must contain authored content rather than the declaration scaffold.",
+      },
+    ]);
 
     const inspected = await cell.run({ kind: "agent-inspect", agentId: declaration.id }, binding);
     assert.equal(JSON.parse(String(inspected.evidence)).agent.id, declaration.id);

--- a/packages/daemon/test/fact-retirement-completion.contract.test.ts
+++ b/packages/daemon/test/fact-retirement-completion.contract.test.ts
@@ -171,7 +171,8 @@ async function reachGreenInReview(
     binding,
   );
   assert.equal(completionFact.outcome, "applied", JSON.stringify(completionFact));
-  await cell.run({ kind: "task-start", taskId, executionId }, binding);
+  const started = await cell.run({ kind: "task-start", taskId, executionId }, binding);
+  assert.equal(started.outcome, "applied", JSON.stringify(started));
   const packagePath = "tasks/task_fact_retirement-fact-retirement-contract",
     closeoutPath = `${packagePath}/closeout.md`;
   writeFileSync(
@@ -191,7 +192,8 @@ async function reachGreenInReview(
       commitSha: git(rootDir, "rev-parse", "HEAD"),
     }),
   );
-  await cell.run({ kind: "task-submit", taskId, executionId, fromFile: "submission.json" }, binding);
+  const submitted = await cell.run({ kind: "task-submit", taskId, executionId, fromFile: "submission.json" }, binding);
+  assert.equal(submitted.outcome, "applied", JSON.stringify(submitted));
   writeFileSync(
     path.join(rootDir, "review.json"),
     JSON.stringify({ verdict: "approved", reason: "Approved.", evidenceChecked: ["verified"] }),
@@ -200,11 +202,12 @@ async function reachGreenInReview(
     { kind: "task-review-execution", taskId, executionId, reviewId: "review-retirement", fromFile: "review.json" },
     reviewerBinding,
   )) as unknown as Record<string, unknown>;
+  assert.equal(reviewed.outcome, "applied", JSON.stringify(reviewed));
   writeFileSync(
     path.join(rootDir, "consent.json"),
     JSON.stringify({ reviewDigest: reviewed.reviewDigest, contentDigest: reviewed.contentDigest }),
   );
-  await cell.run(
+  const consented = await cell.run(
     {
       kind: "task-review-consent",
       taskId,
@@ -215,6 +218,7 @@ async function reachGreenInReview(
     },
     binding,
   );
+  assert.equal(consented.outcome, "applied", JSON.stringify(consented));
 }
 
 function git(rootDir: string, ...args: readonly string[]): string {

--- a/packages/daemon/test/rejection-next-actions.integration.test.ts
+++ b/packages/daemon/test/rejection-next-actions.integration.test.ts
@@ -45,6 +45,10 @@ test("submit lease refusals name the state-specific command that advances the ex
       holder,
     );
     assert.equal(withoutLease.code, "lease_required", JSON.stringify(withoutLease));
+    assert.deepEqual(
+      withoutLease.unmetCriteria?.map(({ ref }) => ref),
+      ["actor-domain-services/heldLeaseForExecutionActor"],
+    );
     assert.equal(
       withoutLease.nextAction,
       `Submit requires the active execution lease; run ha task start ${taskId} --execution-id ${executionId}, then retry ha task submit ${taskId} --json-input '<submission-json>'.`,

--- a/packages/daemon/test/review-independence-diagnostics.integration.test.ts
+++ b/packages/daemon/test/review-independence-diagnostics.integration.test.ts
@@ -61,6 +61,10 @@ test("#1541: each Execution Review refusal names its own cause and its own repai
       human,
     );
     assert.equal(beforeSubmission.outcome, "op_rejected");
+    assert.deepEqual(
+      beforeSubmission.unmetCriteria?.map(({ ref }) => ref),
+      ["task-lifecycle-review-transitions/review.validate"],
+    );
     assert.match(String(beforeSubmission.nextAction), /requires a submitted execution/u);
 
     assert.equal((await cell.run({ kind: "task-start", taskId, executionId }, agent)).outcome, "applied");
@@ -283,6 +287,10 @@ test("a bare-invocation execution has a visible warning and an audited recovery 
       bare,
     );
     assert.equal(refused.code, "actor_unauthorized");
+    assert.deepEqual(
+      refused.unmetCriteria?.map(({ ref }) => ref),
+      ["repo-cell-proof/proofFor.RecordReview"],
+    );
     assert.match(String(refused.nextAction), /declared no executor/u);
     assert.match(String(refused.nextAction), /original start/u);
 

--- a/packages/daemon/test/schedule-actions.integration.test.ts
+++ b/packages/daemon/test/schedule-actions.integration.test.ts
@@ -238,7 +238,13 @@ test("run-now launches only after an applied claim, stays single-flight, and set
         {
           outcome: "op_rejected",
           code: "schedule_claim_stale",
-          unmetCriteria: ["schedule/active-claim-fence"],
+          unmetCriteria: [
+            {
+              ref: "schedule/active-claim-fence",
+              failureCode: "schedule_claim_stale",
+              explain: "The active occurrence still owns the supplied claim fence.",
+            },
+          ],
         },
       );
       output?.(

--- a/packages/daemon/test/task-action-catalog-executor.test.ts
+++ b/packages/daemon/test/task-action-catalog-executor.test.ts
@@ -44,7 +44,7 @@ test("the catalog executor directly invokes Task execution metadata and derives 
   assert.deepEqual(receipt.nextActions, []);
 });
 
-test("rejected Task ActionResult names the expected-version criterion", async () => {
+test("rejected Task ActionResult preserves the exact structured criterion", async () => {
   const executor = makeEntityActionCatalogExecutor({
       store: {} as never,
       projection: {} as never,
@@ -59,11 +59,45 @@ test("rejected Task ActionResult names the expected-version criterion", async ()
         origin: "daemon",
         evidence: "rejection:invalid_transition",
         nextAction: "Refresh the Task projection and retry with its current revision.",
+        unmetCriteria: [
+          {
+            ref: "task-lifecycle-contract-support/revisionIssues",
+            failureCode: "invalid_transition",
+            explain: "The command expectedVersion matches the current Task aggregate revision.",
+          },
+        ],
       }),
     });
-  assert.ok(receipt.unmetCriteria?.includes("task-lifecycle-contract-support/revisionIssues"));
+  assert.deepEqual(receipt.unmetCriteria, [
+    {
+      ref: "task-lifecycle-contract-support/revisionIssues",
+      failureCode: "invalid_transition",
+      explain: "The command expectedVersion matches the current Task aggregate revision.",
+    },
+  ]);
   assert.deepEqual(receipt.effects, []);
   assert.equal(receipt.updatedProjection, null);
   assert.match(receipt.rejectionExplanation ?? "", /expectedVersion/u);
   assert.deepEqual(receipt.nextActions, ["Refresh the Task projection and retry with its current revision."]);
+});
+
+test("ambiguous failure codes do not invent a criterion", async () => {
+  const executor = makeEntityActionCatalogExecutor({
+      store: {} as never,
+      projection: {} as never,
+      now: () => "2026-08-30T00:00:00.000Z",
+      sessionIdentity: () => ({ kind: "unavailable", reason: "test" }) as never,
+    }),
+    receipt = await executor.run({ kind: "task-submit", taskId: "task_contract" }, {} as never, "op-ambiguous", {
+      task: async () => ({
+        outcome: "op_rejected",
+        opId: "op-ambiguous",
+        code: "invalid_transition",
+        origin: "daemon",
+        evidence: "rejection:invalid_transition",
+        nextAction: "Inspect the Task state.",
+      }),
+    });
+  assert.deepEqual(receipt.unmetCriteria, []);
+  assert.doesNotMatch(JSON.stringify(receipt), /criteria\/invalid_transition/u);
 });

--- a/packages/kernel/src/domain/decision-event-payload-validation.ts
+++ b/packages/kernel/src/domain/decision-event-payload-validation.ts
@@ -1,8 +1,5 @@
 import { normalizeRelativeDocumentPath } from "../layout/portable-path.ts";
-import {
-  validateSessionIdentity,
-  validateSessionProvenance,
-} from "./agent-runtime.ts";
+import { validateSessionIdentity, validateSessionProvenance } from "./agent-runtime.ts";
 import { outcomeState } from "./decision-event-document.ts";
 import {
   DECISION_DOCUMENT_POLICY_ID,
@@ -14,12 +11,7 @@ import {
   type DecisionJudgmentConsentV1,
   type DecisionOutcomeType,
 } from "./decision-event-types.ts";
-import {
-  claimId,
-  includes,
-  optionId,
-  uniqueFactStrings,
-} from "./decision-event-validation-shared.ts";
+import { claimId, includes, optionId, uniqueFactStrings } from "./decision-event-validation-shared.ts";
 import {
   deriveRelationId,
   relationDirections,
@@ -65,63 +57,39 @@ export function proposalIssues(
     ],
     fields = [...legacyFields, "provenance"],
     shapeValid = allowUnknownFields
-      ? requiredWithOptional(
-          value,
-          [...legacyFields, ...common],
-          ["provenance"],
-          true,
-        )
-      : matchesFields(value, [...fields, ...common], false),
-    issues: string[] = shapeValid
-      ? []
-      : [`decision proposal requires exactly: ${fields.join(", ")}`],
+      ? requiredWithOptional(value, [...legacyFields, ...common], ["provenance"], true)
+      : matchesFields(value, [...fields, ...common], false);
+  if (!shapeValid) return [`decision proposal requires exactly: ${fields.join(", ")}`];
+  const issues: string[] = [],
     check = (ok: boolean, message: string): void => {
       if (!ok) issues.push(message);
     };
-  check(
-    codePoints(value.question, 1, 499),
-    "question must be 1..499 code points",
-  );
+  check(codePoints(value.question, 1, 499), "question must be 1..499 code points");
   for (const field of ["riskTier", "urgency"] as const)
-    check(
-      includes(["low", "medium", "high"] as const, value[field]),
-      `${field} must be low, medium, or high`,
-    );
+    check(includes(["low", "medium", "high"] as const, value[field]), `${field} must be low, medium, or high`);
   for (const field of ["title", "vertical", "preset"] as const)
-    check(
-      isNonEmptyString(value[field]),
-      `${field} must be a non-empty string`,
-    );
+    check(isNonEmptyString(value[field]), `${field} must be a non-empty string`);
   check(
     includes(["ordinary", "standing_policy"] as const, value.decisionClass),
     "decisionClass must be ordinary or standing_policy",
   );
   check(
     isRecord(value.appliesTo) &&
-      matchesFields(
-        value.appliesTo,
-        ["modules", "productLines"],
-        allowUnknownFields,
-      ) &&
+      matchesFields(value.appliesTo, ["modules", "productLines"], allowUnknownFields) &&
       uniqueFactStrings(value.appliesTo.modules) &&
       uniqueFactStrings(value.appliesTo.productLines),
     "appliesTo must carry exactly modules and productLines as arrays of unique non-empty strings",
   );
   check(typeof value.body === "string", "body must be a string");
   for (const field of ["chosen", "rejected"] as const)
-    check(
-      Array.isArray(value[field]) && value[field].length > 0,
-      `${field} must be a non-empty array`,
-    );
+    check(Array.isArray(value[field]) && value[field].length > 0, `${field} must be a non-empty array`);
   for (const field of ["claims", "fulfillments", "relations"] as const)
     check(Array.isArray(value[field]), `${field} must be an array`);
   check(
     (allowUnknownFields && value.provenance === undefined) ||
       (Array.isArray(value.provenance) &&
         value.provenance.length === 1 &&
-        value.provenance.every((entry) =>
-          sessionProvenanceValue(entry, allowUnknownFields),
-        )),
+        value.provenance.every((entry) => sessionProvenanceValue(entry, allowUnknownFields))),
     "provenance must contain exactly one session identity",
   );
   const chosen = Array.isArray(value.chosen) ? value.chosen : [],
@@ -135,16 +103,10 @@ export function proposalIssues(
       chosen.every(
         (entry) =>
           isRecord(entry) &&
-          requiredWithOptional(
-            entry,
-            ["id", "text"],
-            ["rationale"],
-            allowUnknownFields,
-          ) &&
+          requiredWithOptional(entry, ["id", "text"], ["rationale"], allowUnknownFields) &&
           optionId(entry.id, "CH") &&
           isNonEmptyString(entry.text) &&
-          (entry.rationale === undefined ||
-            codePoints(entry.rationale, 1, 199)),
+          (entry.rationale === undefined || codePoints(entry.rationale, 1, 199)),
       ),
     rejectedValid =
       Array.isArray(value.rejected) &&
@@ -162,11 +124,7 @@ export function proposalIssues(
       claims.every(
         (entry) =>
           isRecord(entry) &&
-          matchesFields(
-            entry,
-            ["id", "text", "loadBearing"],
-            allowUnknownFields,
-          ) &&
+          matchesFields(entry, ["id", "text", "loadBearing"], allowUnknownFields) &&
           claimId(entry.id) &&
           isNonEmptyString(entry.text) &&
           typeof entry.loadBearing === "boolean",
@@ -181,50 +139,26 @@ export function proposalIssues(
           includes(decisionFulfillmentModes, entry.mode),
       );
   if (Array.isArray(value.chosen) && value.chosen.length > 0)
-    check(
-      chosenValid,
-      "every chosen entry needs a CH id, non-empty text, and an optional 1..199 rationale",
-    );
+    check(chosenValid, "every chosen entry needs a CH id, non-empty text, and an optional 1..199 rationale");
   if (Array.isArray(value.rejected) && value.rejected.length > 0)
-    check(
-      rejectedValid,
-      "every rejected entry needs an RJ id, non-empty text, and a 1..199 whyNot",
-    );
+    check(rejectedValid, "every rejected entry needs an RJ id, non-empty text, and a 1..199 whyNot");
   if (Array.isArray(value.claims))
-    check(
-      claimsValid,
-      "every claim needs a C id, non-empty text, and a boolean loadBearing",
-    );
+    check(claimsValid, "every claim needs a C id, non-empty text, and a boolean loadBearing");
   if (Array.isArray(value.fulfillments))
-    check(
-      fulfillmentsValid,
-      `every fulfillment needs a claimId and a mode of ${decisionFulfillmentModes.join(", ")}`,
-    );
-  const ids = [...chosen, ...rejected, ...claims].map((entry) =>
-      isRecord(entry) ? String(entry.id) : "",
-    ),
-    claimIds = new Set(
-      claims.map((entry) => (isRecord(entry) ? entry.id : null)),
-    ),
-    fulfillmentIds = fulfilled.map((entry) =>
-      isRecord(entry) ? entry.claimId : null,
-    ),
-    relationIds = relations.map((entry) =>
-      isRecord(entry) ? entry.relation_id : null,
-    ),
+    check(fulfillmentsValid, `every fulfillment needs a claimId and a mode of ${decisionFulfillmentModes.join(", ")}`);
+  const ids = [...chosen, ...rejected, ...claims].map((entry) => (isRecord(entry) ? String(entry.id) : "")),
+    claimIds = new Set(claims.map((entry) => (isRecord(entry) ? entry.id : null))),
+    fulfillmentIds = fulfilled.map((entry) => (isRecord(entry) ? entry.claimId : null)),
+    relationIds = relations.map((entry) => (isRecord(entry) ? entry.relation_id : null)),
     anchored = new Set(ids);
   if (chosenValid && rejectedValid && claimsValid)
-    check(
-      new Set(ids).size === ids.length,
-      "chosen, rejected, and claim ids must be unique across the packet",
-    );
+    check(new Set(ids).size === ids.length, "chosen, rejected, and claim ids must be unique across the packet");
   if (claimsValid && fulfillmentsValid)
     check(
-      new Set(fulfillmentIds).size === fulfillmentIds.length &&
-        fulfillmentIds.every((entry) => claimIds.has(entry)),
+      new Set(fulfillmentIds).size === fulfillmentIds.length && fulfillmentIds.every((entry) => claimIds.has(entry)),
       "every fulfillment must name a distinct claim declared in this packet",
     );
-  if (Array.isArray(value.relations))
+  if (Array.isArray(value.relations) && chosenValid && rejectedValid && claimsValid)
     check(
       relations.every(
         (entry) =>
@@ -236,10 +170,7 @@ export function proposalIssues(
       "every relation must derive its own relation_id and anchor on a chosen, rejected, or claim id of this decision",
     );
   if (Array.isArray(value.relations))
-    check(
-      new Set(relationIds).size === relationIds.length,
-      "relation ids must be unique",
-    );
+    check(new Set(relationIds).size === relationIds.length, "relation ids must be unique");
   return issues;
 }
 
@@ -250,20 +181,11 @@ export function validDecisionMutation(
   allowUnknownFields: boolean,
 ): boolean {
   const base = value.baseDocumentSha256;
-  if (
-    proposed
-      ? base !== null
-      : typeof base !== "string" || !/^[0-9a-f]{64}$/u.test(base)
-  )
-    return false;
+  if (proposed ? base !== null : typeof base !== "string" || !/^[0-9a-f]{64}$/u.test(base)) return false;
   const claim = value.decisionDocumentClaim;
   if (
     !isRecord(claim) ||
-    !matchesFields(
-      claim,
-      ["path", "sha256", "size", "mediaType", "policyId"],
-      allowUnknownFields,
-    ) ||
+    !matchesFields(claim, ["path", "sha256", "size", "mediaType", "policyId"], allowUnknownFields) ||
     claim.path !== `decisions/decision-${String(id)}/decision.md` ||
     !/^[0-9a-f]{64}$/u.test(String(claim.sha256)) ||
     !Number.isSafeInteger(claim.size) ||
@@ -279,10 +201,7 @@ export function validDecisionMutation(
   }
 }
 
-export function sessionProvenanceValue(
-  value: unknown,
-  allowUnknownFields: boolean,
-): boolean {
+export function sessionProvenanceValue(value: unknown, allowUnknownFields: boolean): boolean {
   if (validateSessionProvenance(value)) return timestamp(value.boundAt);
   if (!allowUnknownFields || !isRecord(value)) return false;
   return (
@@ -304,17 +223,7 @@ export function judgmentConsent(
     !isRecord(value) ||
     !matchesFields(
       value,
-      [
-        "schema",
-        "consentId",
-        "decisionId",
-        "action",
-        "targetState",
-        "machineDigest",
-        "actor",
-        "source",
-        "consentedAt",
-      ],
+      ["schema", "consentId", "decisionId", "action", "targetState", "machineDigest", "actor", "source", "consentedAt"],
       allowUnknownFields,
     )
   )
@@ -345,32 +254,12 @@ export function contentPin(
     isRecord(value) &&
     matchesFields(
       value,
-      [
-        "schema",
-        "pinId",
-        "action",
-        "state",
-        "pinnedAt",
-        "evidence",
-        "actor",
-        "digest",
-      ],
+      ["schema", "pinId", "action", "state", "pinnedAt", "evidence", "actor", "digest"],
       allowUnknownFields,
     ) &&
     value.schema === "decision-content-pin/v1" &&
     /^dcp_[0-9a-f]{26}$/u.test(String(value.pinId)) &&
-    includes(
-      [
-        "accept",
-        "reject",
-        "defer",
-        "supersede",
-        "retire",
-        "amend",
-        "repin",
-      ] as const,
-      value.action,
-    ) &&
+    includes(["accept", "reject", "defer", "supersede", "retire", "amend", "repin"] as const, value.action) &&
     includes(decisionStates, value.state) &&
     value.pinnedAt === event.occurredAt &&
     codePoints(value.evidence, 1, 199) &&
@@ -387,11 +276,7 @@ export function amendment(
 ): value is DecisionAmendmentV1 {
   return (
     isRecord(value) &&
-    matchesFields(
-      value,
-      ["schema", "amendmentId", "fields", "actor", "amendedAt"],
-      allowUnknownFields,
-    ) &&
+    matchesFields(value, ["schema", "amendmentId", "fields", "actor", "amendedAt"], allowUnknownFields) &&
     value.schema === "decision-amendment/v1" &&
     /^dam_[0-9a-f]{26}$/u.test(String(value.amendmentId)) &&
     uniqueFactStrings(value.fields) &&
@@ -402,17 +287,10 @@ export function amendment(
   );
 }
 
-export function amendableSnapshot(
-  value: unknown,
-  allowUnknownFields: boolean,
-): value is DecisionAmendableSnapshot {
+export function amendableSnapshot(value: unknown, allowUnknownFields: boolean): value is DecisionAmendableSnapshot {
   if (
     !isRecord(value) ||
-    !matchesFields(
-      value,
-      ["title", "decisionClass", "chosen", "rejected", "claims"],
-      allowUnknownFields,
-    ) ||
+    !matchesFields(value, ["title", "decisionClass", "chosen", "rejected", "claims"], allowUnknownFields) ||
     !isNonEmptyString(value.title) ||
     !includes(["ordinary", "standing_policy"] as const, value.decisionClass) ||
     !Array.isArray(value.chosen) ||
@@ -423,12 +301,7 @@ export function amendableSnapshot(
   const chosen = value.chosen.every(
       (entry) =>
         isRecord(entry) &&
-        requiredWithOptional(
-          entry,
-          ["id", "text"],
-          ["rationale"],
-          allowUnknownFields,
-        ) &&
+        requiredWithOptional(entry, ["id", "text"], ["rationale"], allowUnknownFields) &&
         optionId(entry.id, "CH") &&
         isNonEmptyString(entry.text),
     ),
@@ -443,27 +316,17 @@ export function amendableSnapshot(
     claims = value.claims.every(
       (entry) =>
         isRecord(entry) &&
-        matchesFields(
-          entry,
-          ["id", "text", "loadBearing", "fulfillment"],
-          allowUnknownFields,
-        ) &&
+        matchesFields(entry, ["id", "text", "loadBearing", "fulfillment"], allowUnknownFields) &&
         claimId(entry.id) &&
         isNonEmptyString(entry.text) &&
         typeof entry.loadBearing === "boolean" &&
-        (entry.fulfillment === null ||
-          includes(decisionFulfillmentModes, entry.fulfillment)),
+        (entry.fulfillment === null || includes(decisionFulfillmentModes, entry.fulfillment)),
     ),
-    ids = [...value.chosen, ...value.rejected, ...value.claims].map((entry) =>
-      isRecord(entry) ? entry.id : null,
-    );
+    ids = [...value.chosen, ...value.rejected, ...value.claims].map((entry) => (isRecord(entry) ? entry.id : null));
   return chosen && rejected && claims && new Set(ids).size === ids.length;
 }
 
-export function fulfillments(
-  value: unknown,
-  allowUnknownFields: boolean,
-): boolean {
+export function fulfillments(value: unknown, allowUnknownFields: boolean): boolean {
   return (
     Array.isArray(value) &&
     value.every(
@@ -473,8 +336,7 @@ export function fulfillments(
         claimId(entry.claimId) &&
         includes(decisionFulfillmentModes, entry.mode),
     ) &&
-    new Set(value.map((entry) => (isRecord(entry) ? entry.claimId : null)))
-      .size === value.length
+    new Set(value.map((entry) => (isRecord(entry) ? entry.claimId : null))).size === value.length
   );
 }
 
@@ -482,25 +344,12 @@ export function relationId(value: unknown): value is string {
   return typeof value === "string" && /^rel_[0-9a-f]{16}$/u.test(value);
 }
 
-export function relation(
-  value: unknown,
-  allowUnknownFields: boolean,
-): value is EntityRelationRecord {
+export function relation(value: unknown, allowUnknownFields: boolean): value is EntityRelationRecord {
   return (
     isRecord(value) &&
     matchesFields(
       value,
-      [
-        "relation_id",
-        "source",
-        "target",
-        "type",
-        "strength",
-        "direction",
-        "origin",
-        "rationale",
-        "state",
-      ],
+      ["relation_id", "source", "target", "type", "strength", "direction", "origin", "rationale", "state"],
       allowUnknownFields,
     ) &&
     typeof value.relation_id === "string" &&

--- a/packages/kernel/src/domain/decision-event-payload-validation.ts
+++ b/packages/kernel/src/domain/decision-event-payload-validation.ts
@@ -63,19 +63,18 @@ export function proposalIssues(
       "fulfillments",
       "relations",
     ],
-    fields = [...legacyFields, "provenance"];
-  if (
-    !(allowUnknownFields
+    fields = [...legacyFields, "provenance"],
+    shapeValid = allowUnknownFields
       ? requiredWithOptional(
           value,
           [...legacyFields, ...common],
           ["provenance"],
           true,
         )
-      : matchesFields(value, [...fields, ...common], false))
-  )
-    return [`decision proposal requires exactly: ${fields.join(", ")}`];
-  const issues: string[] = [],
+      : matchesFields(value, [...fields, ...common], false),
+    issues: string[] = shapeValid
+      ? []
+      : [`decision proposal requires exactly: ${fields.join(", ")}`],
     check = (ok: boolean, message: string): void => {
       if (!ok) issues.push(message);
     };
@@ -125,64 +124,82 @@ export function proposalIssues(
         )),
     "provenance must contain exactly one session identity",
   );
-  if (issues.length) return issues;
-  const chosen = value.chosen as readonly unknown[],
-    rejected = value.rejected as readonly unknown[],
-    claims = value.claims as readonly unknown[],
-    fulfilled = value.fulfillments as readonly unknown[],
-    relations = value.relations as readonly unknown[];
-  check(
-    chosen.every(
-      (entry) =>
-        isRecord(entry) &&
-        requiredWithOptional(
-          entry,
-          ["id", "text"],
-          ["rationale"],
-          allowUnknownFields,
-        ) &&
-        optionId(entry.id, "CH") &&
-        isNonEmptyString(entry.text) &&
-        (entry.rationale === undefined || codePoints(entry.rationale, 1, 199)),
-    ),
-    "every chosen entry needs a CH id, non-empty text, and an optional 1..199 rationale",
-  );
-  check(
-    rejected.every(
-      (entry) =>
-        isRecord(entry) &&
-        matchesFields(entry, ["id", "text", "whyNot"], allowUnknownFields) &&
-        optionId(entry.id, "RJ") &&
-        isNonEmptyString(entry.text) &&
-        codePoints(entry.whyNot, 1, 199),
-    ),
-    "every rejected entry needs an RJ id, non-empty text, and a 1..199 whyNot",
-  );
-  check(
-    claims.every(
-      (entry) =>
-        isRecord(entry) &&
-        matchesFields(
-          entry,
-          ["id", "text", "loadBearing"],
-          allowUnknownFields,
-        ) &&
-        claimId(entry.id) &&
-        isNonEmptyString(entry.text) &&
-        typeof entry.loadBearing === "boolean",
-    ),
-    "every claim needs a C id, non-empty text, and a boolean loadBearing",
-  );
-  check(
-    fulfilled.every(
-      (entry) =>
-        isRecord(entry) &&
-        matchesFields(entry, ["claimId", "mode"], allowUnknownFields) &&
-        claimId(entry.claimId) &&
-        includes(decisionFulfillmentModes, entry.mode),
-    ),
-    `every fulfillment needs a claimId and a mode of ${decisionFulfillmentModes.join(", ")}`,
-  );
+  const chosen = Array.isArray(value.chosen) ? value.chosen : [],
+    rejected = Array.isArray(value.rejected) ? value.rejected : [],
+    claims = Array.isArray(value.claims) ? value.claims : [],
+    fulfilled = Array.isArray(value.fulfillments) ? value.fulfillments : [],
+    relations = Array.isArray(value.relations) ? value.relations : [],
+    chosenValid =
+      Array.isArray(value.chosen) &&
+      value.chosen.length > 0 &&
+      chosen.every(
+        (entry) =>
+          isRecord(entry) &&
+          requiredWithOptional(
+            entry,
+            ["id", "text"],
+            ["rationale"],
+            allowUnknownFields,
+          ) &&
+          optionId(entry.id, "CH") &&
+          isNonEmptyString(entry.text) &&
+          (entry.rationale === undefined ||
+            codePoints(entry.rationale, 1, 199)),
+      ),
+    rejectedValid =
+      Array.isArray(value.rejected) &&
+      value.rejected.length > 0 &&
+      rejected.every(
+        (entry) =>
+          isRecord(entry) &&
+          matchesFields(entry, ["id", "text", "whyNot"], allowUnknownFields) &&
+          optionId(entry.id, "RJ") &&
+          isNonEmptyString(entry.text) &&
+          codePoints(entry.whyNot, 1, 199),
+      ),
+    claimsValid =
+      Array.isArray(value.claims) &&
+      claims.every(
+        (entry) =>
+          isRecord(entry) &&
+          matchesFields(
+            entry,
+            ["id", "text", "loadBearing"],
+            allowUnknownFields,
+          ) &&
+          claimId(entry.id) &&
+          isNonEmptyString(entry.text) &&
+          typeof entry.loadBearing === "boolean",
+      ),
+    fulfillmentsValid =
+      Array.isArray(value.fulfillments) &&
+      fulfilled.every(
+        (entry) =>
+          isRecord(entry) &&
+          matchesFields(entry, ["claimId", "mode"], allowUnknownFields) &&
+          claimId(entry.claimId) &&
+          includes(decisionFulfillmentModes, entry.mode),
+      );
+  if (Array.isArray(value.chosen) && value.chosen.length > 0)
+    check(
+      chosenValid,
+      "every chosen entry needs a CH id, non-empty text, and an optional 1..199 rationale",
+    );
+  if (Array.isArray(value.rejected) && value.rejected.length > 0)
+    check(
+      rejectedValid,
+      "every rejected entry needs an RJ id, non-empty text, and a 1..199 whyNot",
+    );
+  if (Array.isArray(value.claims))
+    check(
+      claimsValid,
+      "every claim needs a C id, non-empty text, and a boolean loadBearing",
+    );
+  if (Array.isArray(value.fulfillments))
+    check(
+      fulfillmentsValid,
+      `every fulfillment needs a claimId and a mode of ${decisionFulfillmentModes.join(", ")}`,
+    );
   const ids = [...chosen, ...rejected, ...claims].map((entry) =>
       isRecord(entry) ? String(entry.id) : "",
     ),
@@ -196,29 +213,33 @@ export function proposalIssues(
       isRecord(entry) ? entry.relation_id : null,
     ),
     anchored = new Set(ids);
-  check(
-    new Set(ids).size === ids.length,
-    "chosen, rejected, and claim ids must be unique across the packet",
-  );
-  check(
-    new Set(fulfillmentIds).size === fulfillmentIds.length &&
-      fulfillmentIds.every((entry) => claimIds.has(entry)),
-    "every fulfillment must name a distinct claim declared in this packet",
-  );
-  check(
-    relations.every(
-      (entry) =>
-        relation(entry, allowUnknownFields) &&
-        entry.relation_id === deriveRelationId(entry) &&
-        entry.source.startsWith(`decision/${String(id)}/`) &&
-        anchored.has(entry.source.slice(entry.source.lastIndexOf("/") + 1)),
-    ),
-    "every relation must derive its own relation_id and anchor on a chosen, rejected, or claim id of this decision",
-  );
-  check(
-    new Set(relationIds).size === relationIds.length,
-    "relation ids must be unique",
-  );
+  if (chosenValid && rejectedValid && claimsValid)
+    check(
+      new Set(ids).size === ids.length,
+      "chosen, rejected, and claim ids must be unique across the packet",
+    );
+  if (claimsValid && fulfillmentsValid)
+    check(
+      new Set(fulfillmentIds).size === fulfillmentIds.length &&
+        fulfillmentIds.every((entry) => claimIds.has(entry)),
+      "every fulfillment must name a distinct claim declared in this packet",
+    );
+  if (Array.isArray(value.relations))
+    check(
+      relations.every(
+        (entry) =>
+          relation(entry, allowUnknownFields) &&
+          entry.relation_id === deriveRelationId(entry) &&
+          entry.source.startsWith(`decision/${String(id)}/`) &&
+          anchored.has(entry.source.slice(entry.source.lastIndexOf("/") + 1)),
+      ),
+      "every relation must derive its own relation_id and anchor on a chosen, rejected, or claim id of this decision",
+    );
+  if (Array.isArray(value.relations))
+    check(
+      new Set(relationIds).size === relationIds.length,
+      "relation ids must be unique",
+    );
   return issues;
 }
 

--- a/packages/kernel/src/domain/entity-action-execution.ts
+++ b/packages/kernel/src/domain/entity-action-execution.ts
@@ -3,6 +3,7 @@ import type { SessionIdentity } from "./agent-runtime.ts";
 import { sessionProvenance } from "./agent-runtime.ts";
 import type { ActorIdentity } from "./actor-identity.ts";
 import type { DecisionAmendableSnapshot, DecisionEventDraftV1 } from "./decision-event.ts";
+import { proposalIssues } from "./decision-event-payload-validation.ts";
 import { deriveRelationId } from "./entity-relation.ts";
 import { compileRelationCreatedEvent, compileRelationRetiredEvent, type RelationEventV1 } from "./relation-event.ts";
 import {
@@ -231,28 +232,35 @@ function decisionEvent(id: DecisionActionCompilerId, input: EntityActionCompileI
       source: input.source,
       occurredAt: input.occurredAt,
     };
-  if (id === "propose")
-    return {
-      ...base,
-      type: "decision_proposed",
-      payload: {
-        title: requiredText(input, action.title, "title"),
-        question: requiredText(input, action.question, "question"),
-        riskTier: choice(input, action.riskTier, ["low", "medium", "high"], "riskTier"),
-        urgency: choice(input, action.urgency, ["low", "medium", "high"], "urgency"),
-        vertical: requiredText(input, action.vertical, "vertical"),
-        preset: requiredText(input, action.preset, "preset"),
-        appliesTo: object(input, action.appliesTo, "appliesTo") as never,
-        decisionClass: choice(input, action.decisionClass, ["ordinary", "standing_policy"], "decisionClass"),
-        chosen: nonEmptyArray(input, action.chosen, "chosen") as never,
-        rejected: nonEmptyArray(input, action.rejected, "rejected") as never,
-        body: typeof action.body === "string" ? action.body : `\n# ${requiredText(input, action.title, "title")}\n`,
-        claims: array(input, action.claims, "claims") as never,
-        fulfillments: array(input, action.fulfillments, "fulfillments") as never,
+  if (id === "propose") {
+    const proposal = {
+        title: action.title,
+        question: action.question,
+        riskTier: action.riskTier,
+        urgency: action.urgency,
+        vertical: action.vertical,
+        preset: action.preset,
+        appliesTo: action.appliesTo,
+        decisionClass: action.decisionClass,
+        chosen: action.chosen,
+        rejected: action.rejected,
+        body:
+          typeof action.body === "string"
+            ? action.body
+            : `\n# ${typeof action.title === "string" ? action.title : ""}\n`,
+        claims: action.claims,
+        fulfillments: action.fulfillments,
         relations: [],
         provenance: [sessionProvenance(input.session, input.occurredAt)],
       },
+      issues = proposalIssues(proposal, [], decisionId);
+    if (issues.length > 0) invalid(input, issues.join("; "));
+    return {
+      ...base,
+      type: "decision_proposed",
+      payload: proposal as never,
     };
+  }
   if (id === "transition") return transitionEvent(input, base);
   if (id === "accept")
     return {
@@ -427,10 +435,6 @@ function short(input: EntityActionCompileInput, value: unknown, field: string): 
   if ([...text].length <= 199) return text;
   invalid(input, `${field} must contain at most 199 characters.`);
 }
-function nonEmptyArray(input: EntityActionCompileInput, value: unknown, field: string): readonly unknown[] {
-  if (Array.isArray(value) && value.length) return value;
-  invalid(input, `${field} must be a non-empty array.`);
-}
 function array(input: EntityActionCompileInput, value: unknown, field: string): readonly unknown[] {
   if (Array.isArray(value)) return value;
   invalid(input, `${field} must be an array.`);
@@ -446,7 +450,7 @@ function choice<T extends string>(
   field: string,
 ): T {
   if (typeof value === "string" && choices.includes(value as T)) return value as T;
-  invalid(input, `${field} is invalid.`);
+  invalid(input, `${field} is invalid; expected one of: ${choices.join(", ")}.`);
 }
 function stringList(value: unknown): readonly string[] {
   return Array.isArray(value) && value.every((item) => typeof item === "string") ? value : [];

--- a/packages/kernel/src/domain/entity-action-explanation.ts
+++ b/packages/kernel/src/domain/entity-action-explanation.ts
@@ -5,6 +5,7 @@ import {
   type EntityActionContract,
   type EntityActionInputField,
 } from "./entity-kind-registry.ts";
+import { isEntityActionUnmetCriterion, type EntityActionUnmetCriterionV1 } from "./receipt-domain-registry.ts";
 import type { AuthorizationDecision } from "./receipt-frame.ts";
 
 export const ENTITY_ACTION_EXPLANATION_SCHEMA = Object.freeze({
@@ -48,8 +49,6 @@ export interface EntityActionCriterionExplanationV1 {
   readonly status: EntityActionCriterionStatus;
   readonly nextActions: readonly string[];
 }
-
-export type EntityActionUnmetCriterionV1 = Pick<EntityActionCriterionExplanationV1, "ref" | "failureCode" | "explain">;
 
 export interface EntityActionExplanationV1 {
   readonly action: {
@@ -373,16 +372,6 @@ function validateCriterion(value: unknown): readonly string[] {
     explanationStringList(value.nextActions)
     ? []
     : ["criterion values are invalid"];
-}
-
-export function isEntityActionUnmetCriterion(value: unknown): value is EntityActionUnmetCriterionV1 {
-  return (
-    explanationRecord(value) &&
-    explanationExact(value, ["ref", "failureCode", "explain"]) &&
-    explanationNonEmpty(value.ref) &&
-    explanationNonEmpty(value.failureCode) &&
-    explanationNonEmpty(value.explain)
-  );
 }
 
 function validExplanationTarget(value: unknown): boolean {

--- a/packages/kernel/src/domain/entity-action-explanation.ts
+++ b/packages/kernel/src/domain/entity-action-explanation.ts
@@ -231,7 +231,10 @@ function validateAction(
     JSON.stringify(value.criteria.map(staticCriterion)) !== JSON.stringify(canonicalAction.criteria)
   )
     errors.push("criteria must preserve the canonical Action contract identity and order");
-  if (!Array.isArray(value.unmetCriteria) || value.unmetCriteria.some((criterion) => !validUnmetCriterion(criterion)))
+  if (
+    !Array.isArray(value.unmetCriteria) ||
+    value.unmetCriteria.some((criterion) => !isEntityActionUnmetCriterion(criterion))
+  )
     errors.push("unmetCriteria is invalid");
   else if (Array.isArray(value.criteria)) {
     const projected = value.criteria
@@ -372,7 +375,7 @@ function validateCriterion(value: unknown): readonly string[] {
     : ["criterion values are invalid"];
 }
 
-function validUnmetCriterion(value: unknown): boolean {
+export function isEntityActionUnmetCriterion(value: unknown): value is EntityActionUnmetCriterionV1 {
   return (
     explanationRecord(value) &&
     explanationExact(value, ["ref", "failureCode", "explain"]) &&

--- a/packages/kernel/src/domain/index.ts
+++ b/packages/kernel/src/domain/index.ts
@@ -6,6 +6,7 @@ export type { AuthorizationDecision } from "./receipt-frame.ts";
 export {
   ENTITY_ACTION_EXPLANATION_SCHEMA,
   taskLifecycleActionIds,
+  isEntityActionUnmetCriterion,
   validateEntityActionExplainRequest,
   validateEntityActionExplanationSet,
 } from "./entity-action-explanation.ts";
@@ -16,6 +17,7 @@ export type {
   EntityActionExplanationSetV1,
   EntityActionExplanationSubjectV1,
   EntityActionExplanationV1,
+  EntityActionUnmetCriterionV1,
   TaskLifecycleActionId,
 } from "./entity-action-explanation.ts";
 export { evaluateTaskActionCapability, taskActionUsage } from "./task-action-capability.ts";

--- a/packages/kernel/src/domain/index.ts
+++ b/packages/kernel/src/domain/index.ts
@@ -6,7 +6,6 @@ export type { AuthorizationDecision } from "./receipt-frame.ts";
 export {
   ENTITY_ACTION_EXPLANATION_SCHEMA,
   taskLifecycleActionIds,
-  isEntityActionUnmetCriterion,
   validateEntityActionExplainRequest,
   validateEntityActionExplanationSet,
 } from "./entity-action-explanation.ts";
@@ -17,9 +16,9 @@ export type {
   EntityActionExplanationSetV1,
   EntityActionExplanationSubjectV1,
   EntityActionExplanationV1,
-  EntityActionUnmetCriterionV1,
   TaskLifecycleActionId,
 } from "./entity-action-explanation.ts";
+export type { EntityActionUnmetCriterionV1 } from "./receipt-domain-registry.ts";
 export { evaluateTaskActionCapability, taskActionUsage } from "./task-action-capability.ts";
 export { DEFAULT_POLICY, durablePolicyActions } from "./default-policy.ts";
 export type {
@@ -145,7 +144,6 @@ export { normalizePersistedTimestamp, timestamp } from "./timestamp.ts";
 
 export {
   createEntityKindRegistry,
-  explainEntityKind,
   getExecutableEntityAction,
   getEntityKindContract,
   getTaskActionForTransition,

--- a/packages/kernel/src/domain/receipt-domain-registry.ts
+++ b/packages/kernel/src/domain/receipt-domain-registry.ts
@@ -1,9 +1,14 @@
 import { validateActorIdentity } from "./actor-identity.ts";
 import { isNonEmptyString } from "./contract-validation.ts";
-import { isEntityActionUnmetCriterion, type EntityActionUnmetCriterionV1 } from "./entity-action-explanation.ts";
 import { parseEntityRef } from "./entity-ref.ts";
 import type { AuthorizationDecision } from "./receipt-frame.ts";
 export type { AuthorizationDecision, ReceiptJsonValue } from "./receipt-frame.ts";
+
+export interface EntityActionUnmetCriterionV1 {
+  readonly ref: string;
+  readonly failureCode: string;
+  readonly explain: string;
+}
 
 export type ReceiptVisibility = "center" | { readonly kind: "replica"; readonly viewId: string };
 export interface ReceiptProof {
@@ -269,6 +274,16 @@ export function validateWriteReceipt(value: unknown): readonly string[] {
   if (!isNonEmptyString(value.evidence) && (value.outcome !== "indeterminate" || value.origin !== "N/A"))
     errors.push("evidence-free receipt must be N/A indeterminate");
   return errors;
+}
+
+export function isEntityActionUnmetCriterion(value: unknown): value is EntityActionUnmetCriterionV1 {
+  return (
+    isReceiptDomainRecord(value) &&
+    exact(value, ["ref", "failureCode", "explain"]) &&
+    isNonEmptyString(value.ref) &&
+    isNonEmptyString(value.failureCode) &&
+    isNonEmptyString(value.explain)
+  );
 }
 function validAuthorizationDecision(value: unknown): value is AuthorizationDecision {
   if (

--- a/packages/kernel/src/domain/receipt-domain-registry.ts
+++ b/packages/kernel/src/domain/receipt-domain-registry.ts
@@ -1,5 +1,6 @@
 import { validateActorIdentity } from "./actor-identity.ts";
 import { isNonEmptyString } from "./contract-validation.ts";
+import { isEntityActionUnmetCriterion, type EntityActionUnmetCriterionV1 } from "./entity-action-explanation.ts";
 import { parseEntityRef } from "./entity-ref.ts";
 import type { AuthorizationDecision } from "./receipt-frame.ts";
 export type { AuthorizationDecision, ReceiptJsonValue } from "./receipt-frame.ts";
@@ -97,7 +98,7 @@ export interface WriteReceiptDraft {
   readonly detail?: WriteReceiptDetail;
   readonly commitSha?: string | null;
   readonly authorizationDecision?: AuthorizationDecision;
-  readonly unmetCriteria?: readonly string[];
+  readonly unmetCriteria?: readonly EntityActionUnmetCriterionV1[];
   readonly effects?: readonly string[];
   readonly updatedProjection?: {
     readonly kind: string;
@@ -152,9 +153,9 @@ export function validateWriteReceipt(value: unknown): readonly string[] {
     if (field in value && !isNonEmptyString(value[field])) errors.push(`${field} must be a non-empty string`);
   if (
     "unmetCriteria" in value &&
-    (!Array.isArray(value.unmetCriteria) || value.unmetCriteria.some((entry) => !isNonEmptyString(entry)))
+    (!Array.isArray(value.unmetCriteria) || value.unmetCriteria.some((entry) => !isEntityActionUnmetCriterion(entry)))
   )
-    errors.push("unmetCriteria must be an array of criterion references");
+    errors.push("unmetCriteria must be an array of structured criterion explanations");
   if (
     "nextActions" in value &&
     (!Array.isArray(value.nextActions) || value.nextActions.some((entry) => !isNonEmptyString(entry)))

--- a/packages/kernel/src/domain/task-action-capability.ts
+++ b/packages/kernel/src/domain/task-action-capability.ts
@@ -114,7 +114,7 @@ export function taskActionUsage(action: EntityActionContract, taskId = "<task-id
     throw new Error(`Task Action ${action.id} has no Task command ingress.`);
   const flags = action.input.fields.flatMap((field) => {
     if (!field.cli) return [];
-    const value = field.cli.kind === "boolean" ? "" : ` ${field.cli.format ?? `<${field.field}>`}`;
+    const value = field.cli.kind === "boolean" ? "" : ` ${field.cli.format ?? `<${field.cli.name.slice(2)}>`}`;
     return [field.required ? `${field.cli.name}${value}` : `[${field.cli.name}${value}]`];
   });
   return ["ha", "task", ingress.slice("task-".length), taskId, ...flags].join(" ");

--- a/packages/kernel/src/index.ts
+++ b/packages/kernel/src/index.ts
@@ -39,6 +39,7 @@ export {
   validateTaskLifecycleCommandEnvelope,
 } from "./domain/task-lifecycle.contract.ts";
 export { isIndependentFrom, isSameExecution, isSamePerson } from "./domain/actor-domain-services.ts";
+export { revisionIssues } from "./domain/task-lifecycle-contract-support.ts";
 export {
   isTaskBoundRuntimeWriter,
   resolveTaskBoundRuntimeBinding,

--- a/packages/kernel/test/contracts/action-envelope.test.ts
+++ b/packages/kernel/test/contracts/action-envelope.test.ts
@@ -2,8 +2,9 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { actionReplayKey, validateActionEnvelope } from "../../src/domain/action-envelope.ts";
+import { explainEntityKind } from "../../src/domain/entity-kind-registry.ts";
 import { validateWriteReceipt } from "../../src/domain/receipt-domain-registry.ts";
-import { createWriteReceipt, explainEntityKind } from "../../src/index.ts";
+import { createWriteReceipt } from "../../src/index.ts";
 
 const actor = { principal: { personId: "person-action" }, executor: { kind: "agent" as const, id: "sol" } };
 const action = {

--- a/packages/kernel/test/contracts/authorization-port.test.ts
+++ b/packages/kernel/test/contracts/authorization-port.test.ts
@@ -141,3 +141,28 @@ test("public WriteReceipt rejects a missing or null AuthorizationDecision", () =
   assert.match(validateWriteReceipt(missing).join("\n"), /AuthorizationDecision/u);
   assert.match(validateWriteReceipt({ ...receipt, authorizationDecision: null }).join("\n"), /AuthorizationDecision/u);
 });
+
+test("public WriteReceipt accepts only structured unmet criteria", () => {
+  const decision = port.authorize(action("task-submit"), roleContext("repo-write")),
+    receipt = {
+      outcome: "op_rejected",
+      opId: "op-unmet-criterion",
+      code: "invalid_transition",
+      origin: "test",
+      evidence: "criteria:revision",
+      nextAction: "Refresh and retry.",
+      authorizationDecision: decision,
+      unmetCriteria: [
+        {
+          ref: "task-lifecycle-contract-support/revisionIssues",
+          failureCode: "invalid_transition",
+          explain: "The expected revision must match the current Task revision.",
+        },
+      ],
+    } as const;
+  assert.deepEqual(validateWriteReceipt(receipt), []);
+  assert.match(
+    validateWriteReceipt({ ...receipt, unmetCriteria: ["task-lifecycle-contract-support/revisionIssues"] }).join("\n"),
+    /structured criterion explanations/u,
+  );
+});

--- a/packages/kernel/test/contracts/decision-proposal-validation.test.ts
+++ b/packages/kernel/test/contracts/decision-proposal-validation.test.ts
@@ -1,0 +1,70 @@
+// harness-test-tier: contract
+import assert from "node:assert/strict";
+import test from "node:test";
+import { getExecutableEntityAction } from "../../src/domain/index.ts";
+
+const compile = getExecutableEntityAction("decision-propose")?.execution?.compile;
+
+test("Decision proposal validation reports every independent packet violation in one failure", () => {
+  assert.ok(compile);
+  assert.throws(
+    () =>
+      compile({
+        action: {
+          title: "Decision",
+          question: "?".repeat(500),
+          riskTier: "urgent",
+          urgency: "eventual",
+          vertical: "software/coding",
+          preset: "standard-task",
+          decisionClass: "charter",
+          appliesTo: [],
+          chosen: [{ id: "chosen", text: "" }],
+          rejected: [{ id: "RJ1", text: "Reject", whyNot: "" }],
+          claims: [{ id: "claim", text: "", loadBearing: "yes" }],
+          fulfillments: [{ claimId: "missing", mode: "later" }],
+        },
+        actor: { principal: { personId: "person-owner" }, executor: null },
+        source: "local",
+        session: { kind: "unavailable", reason: "test" },
+        opId: "decision-validation-aggregate",
+        occurredAt: "2026-09-01T00:00:00.000Z",
+        workspaceRevision: 1,
+      }),
+    (error: unknown) => {
+      assert.equal((error as { code?: string }).code, "invalid_command");
+      const message = error instanceof Error ? error.message : String(error);
+      for (const expected of [
+        "question must be 1..499 code points",
+        "riskTier must be low, medium, or high",
+        "urgency must be low, medium, or high",
+        "decisionClass must be ordinary or standing_policy",
+        "appliesTo must carry exactly modules and productLines",
+        "every chosen entry needs a CH id",
+        "every rejected entry needs an RJ id",
+        "every claim needs a C id",
+        "every fulfillment needs a claimId and a mode of evidenced, delivered, standing_policy",
+      ])
+        assert.match(message, new RegExp(expected, "u"));
+      return true;
+    },
+  );
+});
+
+test("shared choice validation lists every accepted value", () => {
+  const fulfill = getExecutableEntityAction("decision-claim-fulfill")?.execution?.compile;
+  assert.ok(fulfill);
+  assert.throws(
+    () =>
+      fulfill({
+        action: { decisionId: "dec_1", claimId: "C1", mode: "later" },
+        actor: { principal: { personId: "person-owner" }, executor: null },
+        source: "local",
+        session: { kind: "unavailable", reason: "test" },
+        opId: "decision-choice-candidates",
+        occurredAt: "2026-09-01T00:00:00.000Z",
+        workspaceRevision: 1,
+      }),
+    /mode is invalid; expected one of: evidenced, delivered, standing_policy\./u,
+  );
+});

--- a/packages/kernel/test/contracts/entity-action-execution.test.ts
+++ b/packages/kernel/test/contracts/entity-action-execution.test.ts
@@ -1,7 +1,7 @@
 // harness-test-tier: contract
 import assert from "node:assert/strict";
 import test from "node:test";
-import { explainEntityKind, getExecutableEntityAction } from "../../src/domain/index.ts";
+import { explainEntityKind, getExecutableEntityAction } from "../../src/domain/entity-kind-registry.ts";
 
 const ingressKinds = [
   "agent-install",

--- a/packages/kernel/test/contracts/entity-store.test.ts
+++ b/packages/kernel/test/contracts/entity-store.test.ts
@@ -2,8 +2,9 @@
 import assert from "node:assert/strict";
 import { createHash } from "node:crypto";
 import test from "node:test";
-import { createEntityStore, explainEntityKind } from "../../src/index.ts";
+import { createEntityStore } from "../../src/index.ts";
 import { validateAgentDeclarationV1 } from "../../src/domain/agent-squad-schema.ts";
+import { explainEntityKind } from "../../src/domain/entity-kind-registry.ts";
 import {
   assertEntityUpsertInputs,
   type EntityEventV1,

--- a/packages/kernel/test/contracts/kind-authority-version.test.ts
+++ b/packages/kernel/test/contracts/kind-authority-version.test.ts
@@ -2,9 +2,8 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { contractVersion } from "../../src/domain/contract-version.ts";
-import { entityKindContracts } from "../../src/domain/entity-kind-registry.ts";
+import { entityKindContracts, explainEntityKind } from "../../src/domain/entity-kind-registry.ts";
 import {
-  explainEntityKind,
   getEntityKindContract,
   isContractVersionCompatible,
   requireEntityStoreKindContract,

--- a/packages/kernel/test/contracts/policy-entity.test.ts
+++ b/packages/kernel/test/contracts/policy-entity.test.ts
@@ -3,7 +3,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { DEFAULT_POLICY, durablePolicyActions } from "../../src/domain/default-policy.ts";
 import { parsePolicyDeclarationV1, validatePolicyDeclarationV1 } from "../../src/domain/policy.ts";
-import { explainEntityKind } from "../../src/index.ts";
+import { explainEntityKind } from "../../src/domain/entity-kind-registry.ts";
 
 test("the built-in v5 Policy registers only qualification predicates and all durable Actions", () => {
   assert.deepEqual(validatePolicyDeclarationV1(DEFAULT_POLICY), []);

--- a/packages/kernel/test/contracts/task-action-contract.test.ts
+++ b/packages/kernel/test/contracts/task-action-contract.test.ts
@@ -1,7 +1,7 @@
 // harness-test-tier: contract
 import assert from "node:assert/strict";
 import test from "node:test";
-import { explainEntityKind, getEntityKindContract } from "../../src/domain/index.ts";
+import { explainEntityKind, getEntityKindContract } from "../../src/domain/entity-kind-registry.ts";
 
 const concurrencyFields = [
   "expectedVersion",


### PR DESCRIPTION
# English

## Summary

Ontology explain surface, first slice: one capability engine, three doors. `ha explain task` / `ha explain task/<ref>...` delivers object-level action availability (available / unmet criteria with `{ref,failureCode,explain}` / authorization verdicts / next actions) over a read-only RPC, in human and `--json` forms; task lifecycle help rows are now projected from the same kernel Action declarations; failure receipts propagate structured unmet criteria instead of fabricated criterion guesses. The old kind-only `ha entity explain` production path is deleted in the same change. Two cold-start friction fixes ride along: decision proposal validation aggregates all packet violations in one pass, and choice-style validators list their legal candidate values.

## Architectural Justification

- Production +397/-161 with no second judgment engine: the surface consumes the already-landed Task capability evaluation and AuthorizationPort — no new state, lease, identity, or authorization logic. The replaced kind-only explain production path is removed (grep-zero), satisfying the same-slice deletion rule.

## What Changed

- `ha explain task` catalog + batch object reads (1..500 refs) over existing read-only RPC `repo.entity.actions.explain`; human and JSON output.
- `WriteReceipt.unmetCriteria` upgraded from string refs to `{ref,failureCode,explain}`; the four task lifecycle actions consume the same `evaluateTaskActionCapability` result before execution; fabricated `criteria/<code>` guesses removed.
- `ha task --help` start/submit/review/complete rows generated from kernel Task Action declarations; real drift between `<executionId>/<ttlMs>` and CLI flag names fixed.
- Old `ha entity explain <kind>` production command/router/dispatch removed (production grep zero; kernel-internal contract explanation retained for gates).
- Cold-start friction #1/#2: `proposalIssues` aggregates every independent packet violation; shared `choice` validation lists candidates.
- Tests: 37 targeted fast/contract + 17 CLI renderer/help, all green; generator and CLI help/structure/error-code/import-boundary/implementation-contract checks green.

## Gate Harvest / 门收割

Deleted-Production-Paths: packages/cli entity-explain command path (see What Changed)
Deleted-Gates-Fixtures: packages/cli/test/entity-explain-kind-authority.integration.test.ts (renamed to packages/cli/test/explain-command.integration.test.ts)
- Production net lines: use the single CI-backed `Production-Delta` declaration below; do not enter a second metric.

## Machine-Readable Declarations

Production-Delta: +490/-339

## Task And Scope

- Harness task: task_5b051225f10ebe9505e73e5b43 (ontology explain surface, slice 1)
- Branch: codex/ontology-explain
- Public scope: kernel action-capability consumption, CLI explain command family, daemon read RPC wiring, decision proposal validation, tests
- Private planning/evidence updated: yes (nine cold-start friction sub-tasks created with substantive plans)
- Out of scope: interactive help availability overlay (plan-marked optional follow-up); non-task kinds (extend with the tier-2 entity epic)

## Version Impact

- Version: no version change because this is a milestone-internal feature slice
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope:
- Authority: not applicable
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason:
- Break-glass scope:
- Follow-up governance task:

## Verification

- Base `origin/main` SHA: f40d879ee7d2654897e4dc3a3ef60151efd7aae0
- Branch merge-base with `origin/main`: f40d879ee7d2654897e4dc3a3ef60151efd7aae0
- Last `git fetch origin` time: 2026-09-01 early morning
- Sync method: none needed
- Public diff command: git diff f40d879ee...codex/ontology-explain
- Private evidence commit/path: task package implementation-report-20260901.md; fact F-240EDCA5
- Reviewer evidence path: see Review Evidence
- GitHub Actions `rewrite-ci` run URL: pending (filled by CI on this PR)
- [x] targeted fast/contract: 37/37; CLI renderer/help: 17/17
- [x] `npm run typecheck`, lint (re-run post-commit)
- [x] task-action protocol generator --check; CLI help-contract/structure/error-codes; import boundaries (delta 0); implementation contracts (delta 0); domain judgment single-definition
- Not run: full `npm run check` locally (GitHub CI is the authority); isolated integration run pending isolation targets (Ubuntu SSH timeout, no local Docker) — recorded honestly, not simulated. Red-fix round targeted evidence: cost-budget 4/4 projection + 7/7 first-screen RPC; canonical-event-compat 17 schemas/8 validators/5 historical events; gate-contract 176/176; boundaries 42/42 commands; Node 26 fast 520/520 + contract 836/836; typecheck/lint/G33/G36 green

## Review Evidence

- Self-review: coordinating session verified the three-doors semantics against the plan (single engine, no second judgment path), deletion of the old explain path, and the structured unmetCriteria contract via the worker's implementation report
- Reviewer subagent: none (single review round budgeted post-CI)
- Human review: pending merge review
- Blocking findings: none

## Residual Risk

- Isolated integration for the new explain CLI test awaits isolation-target recovery; targeted non-isolated coverage plus CI stand in until then.

## References

- Task: task_5b051225f10ebe9505e73e5b43
- Evidence: implementation-report-20260901.md; fact F-240EDCA5
- Review: this PR

---

# 中文

## 概要

Ontology 解释面第一切片:一个引擎三扇门。`ha explain task` / `ha explain task/<ref>...` 经只读 RPC 交付对象级动作可用性(available / `{ref,failureCode,explain}` 结构化未满足准则 / 授权裁决 / next actions),人话与 `--json` 双输出;task 生命周期 help 行改由同一份 kernel Action 声明投影;失败回执传播结构化 unmet criteria,删除伪造 criterion 猜测。旧的 kind-only `ha entity explain` 生产路径同片删除。顺手带两条冷启动摩擦修复:decision packet 校验一次聚合全部违规项;choice 类校验列出合法候选值。

## 架构辩护

- 生产 +397/-161,零第二判定引擎:消费已落的 Task capability 评估与 AuthorizationPort——不新增状态、租约、身份或授权判断。被替代的 kind-only explain 生产路径删除(grep=0),满足同片删除铁律。

## 改动内容

- `ha explain task` catalog + 批量对象读(1..500 refs),走既有只读 RPC;人话/JSON。
- `WriteReceipt.unmetCriteria` 升级为 `{ref,failureCode,explain}`;四个 task 生命周期动作执行前消费同一 `evaluateTaskActionCapability`;删除伪造 `criteria/<code>`。
- `ha task --help` 四动作行由 kernel Action 声明生成;修正 `<executionId>/<ttlMs>` 与 CLI 旗名的真实漂移。
- 旧 `ha entity explain <kind>` 生产命令/router/dispatch 删除(生产 grep=0;kernel 内部契约解释保留给门用)。
- 冷启动摩擦 #1/#2:`proposalIssues` 聚合全部独立违规;共享 `choice` 校验列候选值。
- 测试:定向 37/37 + CLI 17/17;generator 与 help/structure/error-code/import-boundary/implementation-contract 检查全绿。

## 门收割 / Gate Harvest

- 删除的生产路径:packages/cli 的 entity-explain 命令路径(见改动内容)
- 同 commit 删除的门 / fixture:none
- 生产净行数:见英文块 `Production-Delta`。

## 机读声明说明

- 见英文块顶格声明。

## 任务与范围

- Harness 任务:task_5b051225f10ebe9505e73e5b43(解释面切片 1)
- 分支:codex/ontology-explain
- 公开范围:kernel 能力评估消费、CLI explain 命令族、daemon 只读 RPC 接线、decision 校验、测试
- 私有计划 / 证据是否已更新:yes(九条冷启动摩擦子任务已立实质 plan)
- 范围外:交互式 help 可用性叠加(plan 标注的可选后置);非 task kind(随二档实体 epic 扩展)

## 版本影响

- 版本:不改版本,原因是里程碑内部功能切片
- 发布影响:不发布

## 治理声明

- 是否触碰 protected surface:no
- protected surface 范围:
- 依据:不适用
- 机器检查边界:本 PR 只声明该段存在;声明是否真实、充分,由 reviewer 判断。
- Break-glass:no
- Break-glass 原因:
- Break-glass 范围:
- 后续治理任务:

## 验证

- `origin/main` 基准 SHA:f40d879ee7d2654897e4dc3a3ef60151efd7aae0
- 当前分支与 `origin/main` 的 merge-base:f40d879ee7d2654897e4dc3a3ef60151efd7aae0
- 最近一次 `git fetch origin` 时间:2026-09-01 凌晨
- 同步方式:不需要
- 公开 diff 命令:git diff f40d879ee...codex/ontology-explain
- 私有证据 commit/path:任务包 implementation-report-20260901.md;fact F-240EDCA5
- Reviewer 证据路径:见审查证据
- GitHub Actions `rewrite-ci` run URL:待 CI 回填
- [x] 定向 fast/contract 37/37;CLI renderer/help 17/17
- [x] typecheck、lint(提交后复跑)
- [x] 协议 generator --check;CLI help-contract/structure/error-codes;import boundaries(delta 0);implementation contracts(delta 0);domain judgment single-definition
- 未运行:本地完整 `npm run check`(GitHub CI 为权威);隔离 integration 待隔离目标恢复——如实记录,未冒充。修红轮定向证据:cost-budget 4/4+7/7、canonical-event-compat 17/8/5、gate-contract 176/176、boundaries 42/42、Node26 fast 520/520 + contract 836/836、typecheck/lint/G33/G36 全绿

## 审查证据

- 自查:协调会话按 plan 核验三扇门语义(单引擎、无第二判定路径)、旧面删除、结构化 unmetCriteria 契约(依 worker 实现报告)
- Reviewer subagent:无(评审预算一轮,CI 后)
- 人工审查:合并评审待做
- 阻塞发现:无

## 残余风险

- 新 explain CLI 隔离 integration 待隔离目标恢复;定向非隔离覆盖 + CI 先行兜底。

## 关联材料

- 任务:task_5b051225f10ebe9505e73e5b43
- 证据:implementation-report-20260901.md;fact F-240EDCA5
- 审查:本 PR

---

## PR Gate Checklist / PR 门禁清单

- [x] Branch is based on latest `origin/main`. / 分支基于最新 `origin/main`。
- [x] PR body uses this full template structure. / PR 描述使用本模板完整结构。
- [x] PR body uses two complete language blocks: `# English` first, then `# 中文`. / PR 正文使用两块完整正文:`# English` 在上,`# 中文` 在下。
- [x] PR body passes `tools/check-pr-body-bilingual.mjs`. / PR 正文通过 `tools/check-pr-body-bilingual.mjs`。
- [x] If the PR touches a manifest-derived protected surface, Governance Declaration is filled with ADR/decision/task evidence or break-glass fields. / 若 PR 触碰 manifest 派生的 protected surface,Governance Declaration 已填写 ADR/decision/task 依据或 break-glass 字段。
- [x] No private harness files are included. / 不包含私有 harness 文件。
- [x] No ignored local agent entry files are included. / 不包含被忽略的本地 agent 入口文件。
- [x] No absolute local filesystem paths are included in this public PR body. / 本公开 PR 描述不包含本机绝对路径。
- [x] Public diff is limited to the stated task scope. / 公开 diff 限于声明的任务范围。
- [x] Private planning/evidence updates are recorded when applicable. / 适用时已记录私有计划 / 证据更新。
- [x] Version and publish impact are stated. / 已说明版本与发布影响。
- [x] Local verification commands are recorded honestly. / 已如实记录本地验证命令。
- [x] CI results are linked or explained. / CI 结果已链接或说明。
- [x] Review evidence is recorded. / 已记录审查证据。
- [x] Open P0/P1/P2 findings are closed, deferred with owner, or explicitly blocked. / open P0/P1/P2 findings 已关闭、带 owner 延后,或明确阻塞。
- [x] Merge method and post-merge branch cleanup plan are clear. / 合并方式和合并后分支清理计划清楚。
- [x] No admin bypass is planned unless explicitly approved and recorded. / 除非明确批准并记录,否则不计划 admin bypass。
