### PR TITLE
fix(migration): restate embedded runtime relations through the rekey recovery channel

### DIFF
--- a/packages/daemon/src/embedded-relation-restatement.ts
+++ b/packages/daemon/src/embedded-relation-restatement.ts
@@ -1,0 +1,141 @@
+import {
+  isMigrationImportEvent,
+  runtimeTaskExecutionRelation,
+  stableStringify,
+  type AgentRuntimeEventV1,
+  type EntityRelationRecord,
+  type MigrationImportEventV1,
+  type PersistedCanonicalEventV1,
+} from "../../kernel/src/index.ts";
+
+export interface EmbeddedRelationRestatementDifference {
+  readonly relationId: string;
+  readonly migrationOpId: string;
+  readonly migrationRevision: number;
+  readonly derivedOpId: string;
+  readonly derivedRevision: number | null;
+  readonly derivedSource: "event" | "runtime-session-task-binding-contract";
+  readonly changedFields: readonly string[];
+  readonly before: EntityRelationRecord;
+  readonly after: EntityRelationRecord;
+}
+
+export interface EmbeddedRelationRestatementPlan {
+  readonly rewrites: ReadonlyMap<string, MigrationImportEventV1>;
+  readonly differences: readonly EmbeddedRelationRestatementDifference[];
+}
+
+interface DerivedRelationSource {
+  readonly event: AgentRuntimeEventV1 | null;
+  readonly record: EntityRelationRecord;
+}
+
+const relationRecordFields = [
+  "relation_id",
+  "source",
+  "target",
+  "type",
+  "direction",
+  "strength",
+  "origin",
+  "state",
+  "rationale",
+] as const;
+
+export function planEmbeddedRelationRestatements(
+  events: readonly PersistedCanonicalEventV1[],
+): EmbeddedRelationRestatementPlan {
+  const derivedById = new Map<string, DerivedRelationSource[]>();
+  for (const event of events) {
+    if (event.schema !== "agent-runtime-event/v1" || event.type !== "runtime_session_task_bound") continue;
+    const record = runtimeTaskExecutionRelation(event.payload.runtimeSessionId, event.payload.taskId),
+      sources = derivedById.get(record.relation_id) ?? [];
+    sources.push({ event, record });
+    derivedById.set(record.relation_id, sources);
+  }
+
+  const derivedTruth = new Map<string, DerivedRelationSource>();
+  for (const [relationId, sources] of derivedById) {
+    const variants = new Map(sources.map((source) => [stableStringify(source.record), source]));
+    if (variants.size > 1)
+      throw new Error(
+        `Embedded relation ${relationId} has conflicting derived identities from ${sources
+          .map(({ event }) => event?.opId ?? "runtime-session-task-binding-contract")
+          .sort()
+          .join(", ")}`,
+      );
+    const selected = [...sources].sort(
+      (left, right) =>
+        left.event!.workspaceRevision - right.event!.workspaceRevision ||
+        left.event!.opId.localeCompare(right.event!.opId),
+    )[0];
+    if (selected) derivedTruth.set(relationId, selected);
+  }
+
+  const rewrites = new Map<string, MigrationImportEventV1>(),
+    differences: EmbeddedRelationRestatementDifference[] = [];
+  for (const event of events) {
+    if (!isMigrationImportEvent(event) || event.payload.entity.kind !== "relation") continue;
+    const before = event.payload.entity.relation,
+      eventDerived = derivedTruth.get(before.relation_id),
+      contractDerived = runtimeTaskExecutionContract(before);
+    if (
+      eventDerived &&
+      contractDerived &&
+      stableStringify(eventDerived.record) !== stableStringify(contractDerived.record)
+    )
+      throw new Error(`Embedded relation ${before.relation_id} disagrees with its runtime task-binding contract`);
+    const derived = eventDerived ?? contractDerived;
+    if (!derived || stableStringify(before) === stableStringify(derived.record)) continue;
+    assertSameRelationIdentity(before, derived.record);
+    const after = derived.record,
+      rewrite: MigrationImportEventV1 = {
+        ...event,
+        payload: {
+          ...event.payload,
+          entity: {
+            ...event.payload.entity,
+            relation: after,
+            ownerRef: after.source,
+          },
+        },
+      };
+    rewrites.set(event.opId, rewrite);
+    differences.push({
+      relationId: before.relation_id,
+      migrationOpId: event.opId,
+      migrationRevision: event.workspaceRevision,
+      derivedOpId: derived.event?.opId ?? "contract:runtime-session-task-binding",
+      derivedRevision: derived.event?.workspaceRevision ?? null,
+      derivedSource: derived.event === null ? "runtime-session-task-binding-contract" : "event",
+      changedFields: relationRecordFields.filter((field) => before[field] !== after[field]),
+      before,
+      after,
+    });
+  }
+  differences.sort(
+    (left, right) =>
+      left.relationId.localeCompare(right.relationId) || left.migrationOpId.localeCompare(right.migrationOpId),
+  );
+  return { rewrites, differences };
+}
+
+function runtimeTaskExecutionContract(record: EntityRelationRecord): DerivedRelationSource | null {
+  if (record.type !== "executes" || record.direction !== "directed" || record.state !== "active") return null;
+  const runtimeSessionId = /^runtime-session\/([^/]+)$/u.exec(record.source)?.[1],
+    taskId = /^task\/([^/]+)$/u.exec(record.target)?.[1];
+  return runtimeSessionId && taskId
+    ? { event: null, record: runtimeTaskExecutionRelation(runtimeSessionId, taskId) }
+    : null;
+}
+
+function assertSameRelationIdentity(before: EntityRelationRecord, after: EntityRelationRecord): void {
+  if (
+    before.relation_id !== after.relation_id ||
+    before.source !== after.source ||
+    before.target !== after.target ||
+    before.type !== after.type ||
+    before.direction !== after.direction
+  )
+    throw new Error(`Embedded relation ${before.relation_id} cannot be restated across relation identity fields`);
+}

--- a/packages/daemon/src/fact-rekey-evidence.ts
+++ b/packages/daemon/src/fact-rekey-evidence.ts
@@ -1,0 +1,51 @@
+import {
+  isFactEvent,
+  isMigrationImportEvent,
+  stableStringify,
+  type PersistedCanonicalEventV1,
+} from "../../kernel/src/index.ts";
+import type { EmbeddedRelationRestatementDifference } from "./embedded-relation-restatement.ts";
+
+export interface FactRekeyEvidencePlan {
+  readonly facts: readonly { readonly row: { readonly taskId?: string } }[];
+  readonly map: ReadonlyMap<string, string>;
+  readonly relationMap: ReadonlyMap<string, string>;
+  readonly eventRewrites: readonly { readonly event: PersistedCanonicalEventV1 }[];
+  readonly docsOnly: readonly unknown[];
+  readonly embeddedRelationRestatements: readonly EmbeddedRelationRestatementDifference[];
+  readonly rewrittenAgentEvents: number;
+  readonly rewrittenSettingsEvents: number;
+}
+
+export function factRekeyIdMapBody(plan: FactRekeyEvidencePlan): string {
+  return `${stableStringify(factRekeyEvidence(plan))}\n`;
+}
+
+export function factRekeyEvidence(plan: FactRekeyEvidencePlan) {
+  return {
+    schema: "fact-rekey-id-map/v1",
+    maps: {
+      fact: Object.fromEntries(plan.map),
+      relation: Object.fromEntries(plan.relationMap),
+    },
+    counts: factRekeyCounts(plan),
+    embeddedRelationRestatements: plan.embeddedRelationRestatements,
+  };
+}
+
+function factRekeyCounts(plan: FactRekeyEvidencePlan): Record<string, number> {
+  return {
+    rekeyedFacts: plan.facts.length,
+    factEvents: plan.eventRewrites.filter(({ event }) => isFactEvent(event)).length + plan.docsOnly.length,
+    producesEdges: plan.facts.filter((fact) => fact.row.taskId).length,
+    retargetedRelations: [...plan.relationMap].filter(([from, to]) => from !== to).length,
+    rewrittenRelationEvents: plan.eventRewrites.filter(
+      ({ event }) => isMigrationImportEvent(event) && event.payload.entity.kind === "relation",
+    ).length,
+    rewrittenEmbeddedRelationEvents: plan.embeddedRelationRestatements.length,
+    rewrittenDecisionEvents: plan.eventRewrites.filter(({ event }) => event.schema === "decision-event/v1").length,
+    rewrittenTaskEvents: plan.eventRewrites.filter(({ event }) => event.schema === "task-event/v1").length,
+    rewrittenAgentEvents: plan.rewrittenAgentEvents,
+    rewrittenSettingsEvents: plan.rewrittenSettingsEvents,
+  };
+}

--- a/packages/daemon/src/fact-rekey.ts
+++ b/packages/daemon/src/fact-rekey.ts
@@ -52,6 +52,11 @@ import {
   type WriteReceiptDraft as WriteReceipt,
 } from "../../kernel/src/index.ts";
 import type { DocEventChange } from "../../kernel/src/index.ts";
+import {
+  planEmbeddedRelationRestatements,
+  type EmbeddedRelationRestatementDifference,
+} from "./embedded-relation-restatement.ts";
+import { factRekeyEvidence, factRekeyIdMapBody } from "./fact-rekey-evidence.ts";
 import { isJsonObject, type JsonValue } from "./protocol/json-rpc-types.ts";
 import type { RepoCellBinding, RepoTaskAction } from "./repo-cell-types.ts";
 
@@ -106,6 +111,7 @@ interface FactRekeyPlan {
   readonly rewrittenEntityDocuments: readonly { readonly path: string; readonly body: string }[];
   readonly rewrittenAgentEvents: number;
   readonly rewrittenSettingsEvents: number;
+  readonly embeddedRelationRestatements: readonly EmbeddedRelationRestatementDifference[];
   readonly docsOnly: readonly MappedLegacyFact[];
 }
 
@@ -118,7 +124,7 @@ export function runFactRekey(input: {
   readonly now: () => string;
 }): WriteReceipt {
   const plan = buildPlan(input.rootDir, input.store);
-  const mapBody = idMapBody(plan);
+  const mapBody = factRekeyIdMapBody(plan);
   const digest = sha256Text(mapBody);
   const markerOpId = `op_${sha256Text(`fact-rekey\0${digest}`)}`;
   const existingMarker = migrationEvents(input.rootDir, input.store).find(
@@ -134,7 +140,7 @@ export function runFactRekey(input: {
       revision: input.store.readHead()?.revision ?? 0,
       code: "no_changes",
       origin: "fact-rekey",
-      evidence: JSON.stringify({ schema: "fact-rekey-id-map/v1", maps: Object.fromEntries(plan.map) }),
+      evidence: JSON.stringify(factRekeyEvidence(plan)),
       visibility: "center",
       proof: {
         committedRevision: input.store.readHead()?.revision ?? 0,
@@ -151,9 +157,7 @@ export function runFactRekey(input: {
       opId: `preview:${markerOpId}`,
       revision: input.store.readHead()?.revision ?? 0,
       evidence: JSON.stringify({
-        schema: "fact-rekey-id-map/v1",
-        maps: Object.fromEntries(plan.map),
-        counts: counts(plan),
+        ...factRekeyEvidence(plan),
         markerOpId,
       }),
       visibility: "center",
@@ -247,11 +251,7 @@ export function runFactRekey(input: {
       outcome: "applied",
       opId: marker.opId,
       revision: appended.revision,
-      evidence: JSON.stringify({
-        schema: "fact-rekey-id-map/v1",
-        maps: Object.fromEntries(plan.map),
-        counts: counts(plan),
-      }),
+      evidence: JSON.stringify(factRekeyEvidence(plan)),
       visibility: "center",
       proof: {
         committedRevision: appended.revision,
@@ -332,6 +332,14 @@ function buildPlan(rootDir: string, store: CanonicalEventStore): FactRekeyPlan {
     const normalized = normalizeLegacyRelationMigrationEvent(event, cold.legacyFactRefs, relationMap);
     if (normalized !== event) normalizedRelationEvents.set(event.opId, normalized as PersistedCanonicalEventV1);
   }
+  const normalizedEvents = events.map((event) => normalizedRelationEvents.get(event.opId) ?? event),
+    embeddedRelationPlan = planEmbeddedRelationRestatements(normalizedEvents);
+  for (const difference of embeddedRelationPlan.differences) {
+    const current = relationMap.get(difference.relationId);
+    if (current !== undefined && current !== difference.relationId)
+      throw new Error(`Embedded relation ${difference.relationId} conflicts with an existing relation rekey`);
+    relationMap.set(difference.relationId, difference.relationId);
+  }
   const currentSquadClaims = new Map<string, EntityDeclarationClaimSnapshot>();
   for (const event of events)
     if (event.schema === "entity-event/v1" && event.payload.entityKind === "squad")
@@ -341,6 +349,7 @@ function buildPlan(rootDir: string, store: CanonicalEventStore): FactRekeyPlan {
     rewrittenEntityPaths = new Set<string>(),
     decisionStates = new Map<string, DecisionDocumentState>(),
     decisionRelations = new Map<string, DecisionDocumentState["relations"]>(),
+    identityRefsChanged = map.size > 0 || [...relationMap].some(([from, to]) => from !== to),
     rewriteCounts = { agent: 0, settings: 0 },
     legacyEvents = new Set(
       events
@@ -352,6 +361,8 @@ function buildPlan(rootDir: string, store: CanonicalEventStore): FactRekeyPlan {
     );
   for (const event of events) {
     const agentRewrite = rewriteRetiredAgentEntity(event, store);
+    const restatedEvent =
+      embeddedRelationPlan.rewrites.get(event.opId) ?? normalizedRelationEvents.get(event.opId) ?? event;
     let next: PersistedCanonicalEventV1;
     if (agentRewrite !== null) {
       next = transformCanonicalEvent(agentRewrite.event, mapRef, relationMap);
@@ -404,8 +415,8 @@ function buildPlan(rootDir: string, store: CanonicalEventStore): FactRekeyPlan {
           mapRef,
           relationMap,
         );
-      } else next = transformCanonicalEvent(normalizedRelationEvents.get(event.opId) ?? event, mapRef, relationMap);
-    } else next = transformCanonicalEvent(normalizedRelationEvents.get(event.opId) ?? event, mapRef, relationMap);
+      } else next = transformCanonicalEvent(restatedEvent, mapRef, relationMap);
+    } else next = transformCanonicalEvent(restatedEvent, mapRef, relationMap);
     if (next.schema === "settings-event/v1" && isJsonObject(next.payload.settings)) {
       const settings = repositorySettings(next.payload.settings);
       if (stableStringify(settings) !== stableStringify(next.payload.settings)) {
@@ -442,14 +453,14 @@ function buildPlan(rootDir: string, store: CanonicalEventStore): FactRekeyPlan {
     }
     if (next.schema === "decision-event/v1") {
       const current = decisionStates.get(next.decisionId) ?? null;
-      next = rekeyDecisionProofs(next, current);
+      if (identityRefsChanged) next = rekeyDecisionProofs(next, current);
       try {
         decisionStates.set(next.decisionId, reduceDecisionDocument(current, next));
       } catch (error) {
         consumeKnownError(error);
       }
     }
-    if (next.schema === "task-event/v1" && next.type === "review_consent_recorded")
+    if (identityRefsChanged && next.schema === "task-event/v1" && next.type === "review_consent_recorded")
       next = rekeyReviewConsentProof(next);
     if (stableStringify(next) !== stableStringify(event))
       eventRewrites.push({ event: next, body: serializePersistedCanonicalEvent(next) });
@@ -521,6 +532,7 @@ function buildPlan(rootDir: string, store: CanonicalEventStore): FactRekeyPlan {
     rewrittenEntityDocuments,
     rewrittenAgentEvents: rewriteCounts.agent,
     rewrittenSettingsEvents: rewriteCounts.settings,
+    embeddedRelationRestatements: embeddedRelationPlan.differences,
     docsOnly,
   };
 }
@@ -1060,29 +1072,4 @@ function authoredFiles(root: string): readonly { readonly relativePath: string; 
   };
   visit(root);
   return output;
-}
-
-function idMapBody(plan: FactRekeyPlan): string {
-  return `${stableStringify({
-    schema: "fact-rekey-id-map/v1",
-    maps: {
-      fact: Object.fromEntries(plan.map),
-      relation: Object.fromEntries(plan.relationMap),
-    },
-    counts: counts(plan),
-  })}\n`;
-}
-
-function counts(plan: FactRekeyPlan): Record<string, number> {
-  return {
-    rekeyedFacts: plan.facts.length,
-    factEvents: plan.eventRewrites.filter(({ event }) => isFactEvent(event)).length + plan.docsOnly.length,
-    producesEdges: plan.facts.filter((fact) => fact.row.taskId).length,
-    retargetedRelations: [...plan.relationMap].filter(([from, to]) => from !== to).length,
-    rewrittenRelationEvents: plan.eventRewrites.filter(
-      ({ event }) => isMigrationImportEvent(event) && event.payload.entity.kind === "relation",
-    ).length,
-    rewrittenAgentEvents: plan.rewrittenAgentEvents,
-    rewrittenSettingsEvents: plan.rewrittenSettingsEvents,
-  };
 }

--- a/packages/daemon/test/embedded-relation-restatement.test.ts
+++ b/packages/daemon/test/embedded-relation-restatement.test.ts
@@ -1,0 +1,91 @@
+// harness-test-tier: fast
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  deriveRelationId,
+  runtimeTaskExecutionRelation,
+  type AgentRuntimeEventV1,
+  type MigrationImportEventV1,
+} from "../../kernel/src/index.ts";
+import { planEmbeddedRelationRestatements } from "../src/embedded-relation-restatement.ts";
+
+const actor = { principal: { personId: "person_zeyu" }, executor: null } as const;
+const identity = {
+  source: "runtime-session/runtime_fixture",
+  target: "task/task_fixture",
+  type: "executes" as const,
+  direction: "directed" as const,
+};
+const relationId = deriveRelationId(identity);
+const migrationEvent: MigrationImportEventV1 = {
+  schema: "migration-import-event/v1",
+  eventId: "event-migration-relation",
+  workspaceRevision: 1,
+  opId: "migration-runtime-relation",
+  type: "entity_migrated",
+  actor,
+  source: "migration-import/v1",
+  occurredAt: "2026-08-31T00:00:00.000Z",
+  payload: {
+    migratedFrom: relationId,
+    generation: "v0",
+    entity: {
+      kind: "relation",
+      ownerRef: identity.source,
+      relation: {
+        relation_id: relationId,
+        ...identity,
+        strength: "strong",
+        origin: "imported_snapshot",
+        state: "active",
+        rationale: "Authenticated runtime handoff.",
+      },
+    },
+  },
+};
+const taskBindingEvent: AgentRuntimeEventV1 = {
+  schema: "agent-runtime-event/v1",
+  eventId: "event-runtime-task-binding",
+  workspaceRevision: 2,
+  opId: "migration-runtime-task-binding",
+  type: "runtime_session_task_bound",
+  actor,
+  source: "migration-import/v1",
+  occurredAt: "2026-08-30T15:51:46.589Z",
+  payload: {
+    runtimeSessionId: "runtime_fixture",
+    taskId: "task_fixture",
+    executionId: "exe_fixture",
+    providerSessionId: "provider_fixture",
+    transcriptRef: "file:.harness/runtime/fixture.jsonl",
+  },
+};
+
+test("embedded relation restatement aligns runtime execution identity and is idempotent", () => {
+  const derived = runtimeTaskExecutionRelation("runtime_fixture", "task_fixture");
+  assert.notDeepEqual(migrationEvent.payload.entity.relation, derived);
+
+  const plan = planEmbeddedRelationRestatements([migrationEvent]);
+  assert.equal(plan.differences.length, 1);
+  assert.deepEqual(plan.differences[0]?.changedFields, ["origin", "rationale"]);
+  assert.equal(plan.differences[0]?.migrationOpId, migrationEvent.opId);
+  assert.equal(plan.differences[0]?.derivedOpId, "contract:runtime-session-task-binding");
+  assert.equal(plan.differences[0]?.derivedRevision, null);
+  assert.equal(plan.differences[0]?.derivedSource, "runtime-session-task-binding-contract");
+  const rewritten = plan.rewrites.get(migrationEvent.opId);
+  assert.ok(rewritten);
+  assert.equal(rewritten.eventId, migrationEvent.eventId);
+  assert.equal(rewritten.workspaceRevision, migrationEvent.workspaceRevision);
+  assert.equal(rewritten.payload.migratedFrom, migrationEvent.payload.migratedFrom);
+  assert.equal(rewritten.payload.entity.kind, "relation");
+  if (rewritten.payload.entity.kind === "relation") {
+    assert.equal(rewritten.payload.entity.relation.origin, "generated");
+    assert.equal(rewritten.payload.entity.relation.rationale, "Runtime session is bound to the task execution.");
+  }
+
+  assert.deepEqual(rewritten.payload.entity.relation, derived);
+
+  const repeat = planEmbeddedRelationRestatements([rewritten, taskBindingEvent]);
+  assert.equal(repeat.differences.length, 0);
+  assert.equal(repeat.rewrites.size, 0);
+});

--- a/packages/kernel/src/domain/agent-runtime.ts
+++ b/packages/kernel/src/domain/agent-runtime.ts
@@ -8,6 +8,7 @@ import {
   type EventEnvelope,
 } from "./write-chain.contract.ts";
 import type { EntityDocumentJsonSchema } from "./entity-json-schema.ts";
+import { deriveRelationId, type EntityRelationRecord } from "./entity-relation.ts";
 import { timestamp } from "./timestamp.ts";
 
 export const runtimeProtocolFamilies = ["claude-compatible", "codex", "agy"] as const;
@@ -26,6 +27,23 @@ export const agentRuntimeEventTypes = [
   "runtime_session_outcome_observed",
   "runtime_dispatch_outcome_unknown",
 ] as const;
+
+export function runtimeTaskExecutionRelation(runtimeSessionId: string, taskId: string): EntityRelationRecord {
+  const identity = {
+    source: `runtime-session/${runtimeSessionId}`,
+    target: `task/${taskId}`,
+    type: "executes" as const,
+    direction: "directed" as const,
+  };
+  return {
+    relation_id: deriveRelationId(identity),
+    ...identity,
+    strength: "strong",
+    origin: "generated",
+    state: "active",
+    rationale: "Runtime session is bound to the task execution.",
+  };
+}
 export type RuntimeProtocolFamily = (typeof runtimeProtocolFamilies)[number];
 export type RuntimeCapability = (typeof runtimeCapabilities)[number];
 export type RuntimeLiveness = (typeof runtimeLivenessStates)[number];

--- a/packages/kernel/src/domain/index.ts
+++ b/packages/kernel/src/domain/index.ts
@@ -180,6 +180,7 @@ export {
 } from "./entity-relation.ts";
 export { isRelationEvent, relationEventWritePlan, relationRecord } from "./relation-event.ts";
 export type {
+  EntityRelationRecord,
   EntityRelationValidationIssue,
   EntityRelationValidationIssueCode,
   RelationDirection,

--- a/packages/kernel/src/index.ts
+++ b/packages/kernel/src/index.ts
@@ -5,6 +5,7 @@ export {
   runtimeSessionInActivityWindow,
   runtimeSessionIsRunning,
   runtimeSessionSemanticState,
+  runtimeTaskExecutionRelation,
   sessionProvenance,
   unavailableSessionIdentity,
 } from "./domain/agent-runtime.ts";

--- a/packages/kernel/src/projection/relation-entity-projection.ts
+++ b/packages/kernel/src/projection/relation-entity-projection.ts
@@ -1,11 +1,11 @@
 // @write-boundary-exemption rebuildable-projection
 import type { DatabaseSync } from "node:sqlite";
-import type { AgentRuntimeEventV1 } from "../domain/agent-runtime.ts";
+import { runtimeTaskExecutionRelation, type AgentRuntimeEventV1 } from "../domain/agent-runtime.ts";
 import type { DecisionEventV1 } from "../domain/decision-event.ts";
 import type { FactEventV1 } from "../domain/fact-event.ts";
 import { entityKindContracts } from "../domain/entity-kind-registry.ts";
 import { interpretEmbeddedEntityProjections } from "../domain/entity-kind-projection.ts";
-import { deriveRelationId, relationOwnerRef, type EntityRelationRecord } from "../domain/entity-relation.ts";
+import { relationOwnerRef, type EntityRelationRecord } from "../domain/entity-relation.ts";
 import type { TaskEventV1 } from "../domain/task-lifecycle-event.ts";
 import {
   assertRelationRecord,
@@ -75,22 +75,15 @@ export function applyEmbeddedRelationProjectionEvents(
 ): void {
   if (event.schema !== "agent-runtime-event/v1")
     for (const relationEvent of embeddedRelationEventsForReplay(event)) applyRelationProjectionEvent(db, relationEvent);
-  if (event.schema === "agent-runtime-event/v1" && event.type === "runtime_session_task_bound") {
-    const identity = {
-      source: `runtime-session/${event.payload.runtimeSessionId}`,
-      target: `task/${event.payload.taskId}`,
-      type: "executes" as const,
-      direction: "directed" as const,
-    };
-    projectDerivedRelation(db, event, {
-      relation_id: deriveRelationId(identity),
-      ...identity,
-      strength: "strong",
-      origin: "generated",
-      state: "active",
-      rationale: "Runtime session is bound to the task execution.",
-    });
-  }
+  for (const record of derivedRelationRecordsForReplay(event)) projectDerivedRelation(db, event, record);
+}
+
+function derivedRelationRecordsForReplay(
+  event: AgentRuntimeEventV1 | DecisionEventV1 | FactEventV1 | TaskEventV1,
+): readonly EntityRelationRecord[] {
+  const records: EntityRelationRecord[] = [];
+  if (event.schema === "agent-runtime-event/v1" && event.type === "runtime_session_task_bound")
+    records.push(runtimeTaskExecutionRelation(event.payload.runtimeSessionId, event.payload.taskId));
   for (const contract of entityKindContracts)
     for (const projection of interpretEmbeddedEntityProjections(contract, event))
       for (const relation of projection.relations) {
@@ -105,8 +98,9 @@ export function applyEmbeddedRelationProjectionEvents(
           state: relation.state,
           rationale: relation.rationale,
         } as EntityRelationRecord;
-        projectDerivedRelation(db, event, record);
+        records.push(record);
       }
+  return records;
 }
 
 function projectDerivedRelation(


### PR DESCRIPTION
# English

## Summary

Fix the canonical bootstrap latch `Embedded relation rel_… changed identity`. Two mint paths wrote the same relation id with different non-identity facets: legacy migration snapshots minted `runtime-session --executes--> task` edges with `origin=imported_snapshot` / rationale "Authenticated runtime handoff.", while the current runtime task-binding projection derives the same ids with `origin=generated` / rationale "Runtime session is bound to the task execution." (endpoints/type/direction/strength/state identical). The strict same-id canonicalJson comparison (introduced 2026-08-31 by af8569b07/d5aaa11f1) is correct and is NOT weakened; the migration gap — old migration bytes never restated to the current contract — is closed instead. Full census on the failed production cut: 941/941 conflicting pairs differ only in those two fields; 34 bindings without an old relation are not conflicts.

## Architectural Justification

- Deletes the assumption that migration snapshots and runtime-derived records may independently decide non-identity facets: kernel now defines the runtime-task execution relation ONCE (`runtimeTaskExecutionRelation`), shared by projection and migration restatement.
- No reader fallback, no tolerance, no feature flag, no gate exemption. Restatement extends the existing `ha migrate rekey-facts` latch-recovery channel (already on the recovery allowlist).
- Production -58: removes the projection's inline second copy of the runtime relation construction; removes fact-rekey inline evidence/counts; narrows decision/review proof recomputation when identity is unchanged.

## What Changed

- `packages/kernel/src/domain/agent-runtime.ts`: single pure constructor `runtimeTaskExecutionRelation`.
- `packages/kernel/src/projection/relation-entity-projection.ts`: derives via the shared constructor; strict comparison untouched.
- `packages/daemon/src/embedded-relation-restatement.ts` (new): full census, event/contract truth reconciliation, identity fail-closed, deterministic rewrite, per-row diff.
- `packages/daemon/src/fact-rekey.ts` + `fact-rekey-evidence.ts`: restatement wired into the existing reachable latch recovery; id-map records 941 relation self-maps with before/after and provenance; evidence/counts extracted to their own module.
- `packages/daemon/test/embedded-relation-restatement.test.ts` (new): old snapshot → current contract, envelope preservation, before/after fields, idempotency.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: use the single CI-backed `Production-Delta` declaration below; do not enter a second metric.

## Machine-Readable Declarations

Production-Delta: +251/-58

## Task And Scope

- Harness task: task_44d5009838e66ef1dcb7c6c3b3 (round 5, production latch recovery)
- Branch: codex/backfill-r5
- Public scope: embedded-relation restatement channel + shared runtime relation constructor
- Private planning/evidence updated: yes (round5-report.md with the full 941-row diff table)
- Out of scope: production apply / ref moves / shared daemon restart (CEO-run, after merge); tri-repo migration

## Version Impact

- Version: no version change because this is a recovery-channel bug fix with no published package behavior change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: task_44d5009838e66ef1dcb7c6c3b3
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no

## Verification

- Base `origin/main` SHA: fdb0d61ad54f83b6a45f5894cb316d95edb3a031
- Branch merge-base with `origin/main`: fdb0d61ad54f83b6a45f5894cb316d95edb3a031
- Last `git fetch origin` time: 2026-08-31T19:44:00Z
- Sync method: none needed
- Public diff command: `git diff origin/main...codex/backfill-r5`
- Private evidence commit/path: task artifacts round5-report.md (941-row diff table; isolated-copy rehearsals)
- Reviewer evidence path: same as above
- GitHub Actions `rewrite-ci` run URL: pending (queued on this PR)
- [x] `npm run typecheck`
- [x] `npm run harness:check-import-boundaries`
- Not run: full `npm run check` / `npm test` locally — worker stop-point discipline; GitHub CI is the complete authority. Targeted: new restatement tests, relation graph projection 10/10, fact-rekey integration, migration-import replay 9/9, gates 176/176, canonical-event-compat 17/8, lint, complexity, line-density, dead-exports, production-delta.
- Isolated-copy rehearsals (read-only production, own daemons, stopped after): failed cut restate→rebuild→idempotent PASS; backup cut restate→rebuild→entity-backfill apply (33/2/1085, Reconciliation PASS)→rebuild→idempotent PASS.

## Review Evidence

- Self-review: worker report pins both mint paths byte-for-byte and the introducing commits; census proves 941/941 differ only in origin/rationale
- Reviewer subagent: CEO semantic review — strict check retained, constructor unified, fail-closed negatives (retired not revived, non-migration untouched, identity mismatch rejected)
- Human review: CEO (session)
- Blocking findings: none

## Residual Risk

- Production restate + apply still pending (CEO-run after merge, both paths rehearsed); canonical stays latched until then.
- `refs/ha/canonical` has been aligned by the CEO to the backup cut `429d877e7` (failed cut preserved under `evidence/failed-entity-backfill-20260901`).

## References

- Task: task_44d5009838e66ef1dcb7c6c3b3
- Evidence: round5-report.md (941-row table; rehearsal digests); evidence/failed-entity-backfill-20260901
- Review: closeout after production apply

---

# 中文

## 概要

修复 canonical bootstrap 卡死 `Embedded relation … changed identity`。同一 relation id 有两条铸造路径写出不同非 identity 字段:旧迁移快照铸 `origin=imported_snapshot`/rationale "Authenticated runtime handoff.",当前 runtime task-binding 投影派生同 id 但 `origin=generated`/rationale "Runtime session is bound to the task execution."(端点/type/direction/strength/state 全同)。昨日引入的同 id 严格比较(af8569b07/d5aaa11f1)是正确的,**不削弱**;补上的是迁移缺口——旧迁移 bytes 未重述到 current contract。失败 cut 全量清点:941/941 冲突对仅差这两个字段;34 条无旧 relation 的 binding 不构成冲突。

## 架构辩护

- 删除「迁移快照与运行时派生可各自决定非 identity 字段」这一假设:kernel 只定义一次 `runtimeTaskExecutionRelation`,投影与迁移重述共用。
- 无 reader 兜底、无容忍、无 flag、无门豁免;重述并入既有 `ha migrate rekey-facts` latch 恢复通道(已在恢复 allowlist)。
- 生产 -58:删投影内联的第二份构造、删 fact-rekey 内联 evidence/counts、收窄 identity 未变时的 proof 重算。

## 改动内容

见英文块;新增 `embedded-relation-restatement.ts`(census/对账/fail-closed/确定性重写/逐行差异)与其测试;fact-rekey 接入重述并拆出 evidence 模块。

## 门收割 / Gate Harvest

- 删除的生产路径:none
- 同 commit 删除的门 / fixture:none
- 生产净行数:引用英文块 `Production-Delta`。

## 机读声明说明

- 见英文块;无依赖变化。

## 任务与范围

- Harness 任务:task_44d5009838e66ef1dcb7c6c3b3(round 5,生产 latch 恢复)
- 分支:codex/backfill-r5
- 公开范围:嵌入关系重述通道 + 共享 runtime relation constructor
- 私有计划 / 证据是否已更新:yes(round5-report.md 含 941 行全量差异表)
- 范围外:生产 apply/ref 移动/共享 daemon 重启(合并后 CEO 执行);tri-repo 迁移

## 版本影响

- 版本:不改版本,原因是恢复通道 bug fix,无已发布包行为变化
- 发布影响:不发布

## 治理声明

- 是否触碰 protected surface:no
- protected surface 范围:不适用
- 依据:task_44d5009838e66ef1dcb7c6c3b3
- 机器检查边界:本 PR 只声明该段存在;是否真实、充分由 reviewer 判断。
- Break-glass:no

## 验证

- `origin/main` 基准 SHA:fdb0d61ad54f83b6a45f5894cb316d95edb3a031
- merge-base:fdb0d61ad54f83b6a45f5894cb316d95edb3a031
- 最近 fetch:2026-08-31T19:44:00Z
- 同步方式:不需要
- 公开 diff 命令:`git diff origin/main...codex/backfill-r5`
- 私有证据 commit/path:任务包 round5-report.md
- Reviewer 证据路径:同上
- GitHub Actions `rewrite-ci` run URL:排队中
- [x] `npm run typecheck`
- [x] `npm run harness:check-import-boundaries`
- 未运行:本地完整 `npm run check`/`npm test`——worker 停止点纪律,GitHub CI 为完整权威;定向清单与隔离副本双 cut 排演见英文块。

## 审查证据

- 自查:worker 报告逐字节钉死两条铸造路径与引入提交;census 证明 941/941 仅差 origin/rationale
- Reviewer subagent:CEO 语义复核——严格校验保留、constructor 统一、负例 fail-closed(retired 不复活、非迁移事件不改、identity 不一致拒绝)
- 人工审查:CEO(本 session)
- 阻塞发现:无

## 残余风险

- 生产重述 + apply 待合并后 CEO 执行(双路径已排演);此前 canonical 保持 latch。
- `refs/ha/canonical` 已由 CEO 对齐到 backup cut `429d877e7`(failed cut 保全于 evidence tag)。

## 关联材料

- 任务:task_44d5009838e66ef1dcb7c6c3b3
- 证据:round5-report.md;evidence/failed-entity-backfill-20260901
- 审查:生产 apply 后随 closeout 收口

---

## PR Gate Checklist / PR 门禁清单

- [x] Branch is based on latest `origin/main`. / 分支基于最新 `origin/main`。
- [x] PR body uses this full template structure. / PR 描述使用本模板完整结构。
- [x] PR body uses two complete language blocks. / 双语两块完整。
- [x] PR body passes `tools/check-pr-body-bilingual.mjs`. / 通过双语检查。
- [x] Governance Declaration filled where applicable. / 治理声明已填。
- [x] No private harness files are included. / 不含私有 harness 文件。
- [x] No ignored local agent entry files are included. / 不含本地 agent 入口文件。
- [x] No absolute local filesystem paths in this public PR body. / 不含本机绝对路径。
- [x] Public diff is limited to the stated task scope. / diff 限于声明范围。
- [x] Private planning/evidence updates recorded. / 私有证据已记录。
- [x] Version and publish impact stated. / 版本与发布影响已说明。
- [x] Local verification commands recorded honestly. / 验证如实记录。
- [x] CI results linked or explained. / CI 结果已说明。
- [x] Review evidence recorded. / 审查证据已记录。
- [x] Open P0/P1/P2 findings closed, deferred with owner, or blocked. / findings 已处置。
- [x] Merge method (normal merge) and cleanup plan are clear. / 合并方式与清理计划清楚。
- [x] No admin bypass planned. / 不计划 admin bypass。
