### PR TITLE
fix(daemon): admit migrate-import through recovery ingress

### DIFF
--- a/packages/daemon/src/recovery-state.ts
+++ b/packages/daemon/src/recovery-state.ts
@@ -7,6 +7,7 @@ export interface RecoveryCommandPolicy {
 const recoveryCommands: Readonly<Record<string, RecoveryCommandPolicy>> = Object.freeze({
   "fact-rekey": Object.freeze({ causes: Object.freeze(["data-shape"] as const), settlesLatch: true }),
   "ledger-migrate": Object.freeze({ causes: Object.freeze(["data-shape"] as const), settlesLatch: true }),
+  "migrate-import": Object.freeze({ causes: Object.freeze(["data-shape"] as const), settlesLatch: true }),
   "projection-rebuild": Object.freeze({ causes: Object.freeze(["projection"] as const), settlesLatch: true }),
   "receipt-show": Object.freeze({
     causes: Object.freeze(["data-shape", "infrastructure"] as const),

--- a/packages/daemon/src/repo-cell-api.ts
+++ b/packages/daemon/src/repo-cell-api.ts
@@ -127,6 +127,7 @@ export interface RepoCellApiContext {
 }
 
 export function createRepoCellApi(context: RepoCellApiContext): RepoCell {
+  let settlingRecovery: string | null = null;
   const run = (action: RepoTaskAction, binding: RepoCellBinding, signal?: AbortSignal): Promise<WriteReceipt> => {
     try {
       ({ action, binding } = bindVerifiedExecutorClaim({
@@ -180,6 +181,28 @@ export function createRepoCellApi(context: RepoCellApiContext): RepoCell {
           context.latched(),
         ),
       );
+    const claimsRecovery = context.state !== "attached" && recoveryCommand?.settlesLatch === true;
+    if (claimsRecovery && settlingRecovery !== null) {
+      const nextAction = [
+        "Recovery command ",
+        `${settlingRecovery}`,
+        " already holds this repository's single-writer recovery ingress; retry ",
+        `${action.kind}`,
+        " after it settles.",
+      ].join("");
+      return Promise.resolve(
+        frameCurrent(
+          context.rejected(
+            context.operationId(action, binding, context.input.repoId, 0),
+            "recovery_conflict",
+            nextAction,
+          ),
+          [],
+          nextAction,
+        ),
+      );
+    }
+    if (claimsRecovery) settlingRecovery = action.kind;
     const failAction = (error: unknown, authorizationDecision?: AuthorizationDecision): WriteReceipt => {
       if (context.fatalCellError(error)) context.latchWith(error);
       const receipt = context.failed(
@@ -232,11 +255,23 @@ export function createRepoCellApi(context: RepoCellApiContext): RepoCell {
           const executed = context.withLayoutAdvisory(context.withHumanSummary(await execute(queuedDecision))),
             receipt = queuedDecision ? withAuthorizationDecision(executed, queuedDecision) : (executed as WriteReceipt);
           if (recoveryCommand?.settlesLatch && receipt.outcome === "applied") {
-            context.state = "attached";
-            context.lastError = null;
-            context.causeClass = null;
-            context.recoveryUncertain = false;
-            context.recoveryProbe.clear();
+            if (action.kind === "migrate-import") {
+              context.recoveryProbe.clear();
+              context.attemptRecovery();
+              if (context.state !== "attached")
+                return {
+                  ...receipt,
+                  outcome: "pending",
+                  code: "repo_unavailable",
+                  nextAction: context.latched(),
+                } as WriteReceipt;
+            } else {
+              context.state = "attached";
+              context.lastError = null;
+              context.causeClass = null;
+              context.recoveryUncertain = false;
+              context.recoveryProbe.clear();
+            }
           }
           context.replica.kick();
           return receipt;
@@ -249,7 +284,11 @@ export function createRepoCellApi(context: RepoCellApiContext): RepoCell {
         () => undefined,
         () => undefined,
       );
-      return pending.catch((error) => failAction(error, queuedDecision));
+      return pending
+        .catch((error) => failAction(error, queuedDecision))
+        .finally(() => {
+          if (claimsRecovery) settlingRecovery = null;
+        });
     };
     if (action.kind === "squad-run") {
       if (!isJsonObject(action))

--- a/packages/daemon/test/repo-cell-latch-recovery.test.ts
+++ b/packages/daemon/test/repo-cell-latch-recovery.test.ts
@@ -18,6 +18,7 @@ import { openBootstrappedRepoCell as openRepoCell } from "./repo-settings.fixtur
 import { projectedTaskIds } from "../src/repo-cell-receipts.ts";
 import { cellCodedError } from "../src/repo-cell-errors.ts";
 import { recoveryCommandPolicy } from "../src/recovery-state.ts";
+import { initRepo as initMigrationRepo, legacyFixture, sources } from "./migration-import.fixtures.ts";
 
 const actor = { principal: { personId: "person-latch" }, executor: null } as const;
 
@@ -57,10 +58,97 @@ test("projection recovery names and carries the reachable rebuild command", () =
     causes: ["data-shape"],
     settlesLatch: true,
   });
+  assert.deepEqual(recoveryCommandPolicy("migrate-import", "data-shape"), {
+    causes: ["data-shape"],
+    settlesLatch: true,
+  });
+  assert.equal(recoveryCommandPolicy("migrate-import", "projection"), null);
+  assert.equal(recoveryCommandPolicy("migrate-import", "infrastructure"), null);
   assert.deepEqual(recoveryCommandPolicy("receipt-show", "infrastructure"), {
     causes: ["data-shape", "infrastructure"],
     settlesLatch: false,
   });
+});
+
+test("migration import enters a data-shape latch, stays single-flight, and re-probes after apply", async () => {
+  const scratch = mkdtempSync(path.join(tmpdir(), "ha-latch-migrate-import-")),
+    source = path.join(scratch, "legacy"),
+    destination = path.join(scratch, "destination"),
+    binding = { actor, source: "local" as const },
+    clock = "2026-09-01T00:00:00.000Z";
+  let injectLatch = false,
+    cell: RepoCell | undefined;
+  try {
+    legacyFixture(source);
+    initMigrationRepo(destination);
+    const sourceRoots = sources(source);
+    cell = await openRepoCell({
+      repoId: workspaceId("latch-migrate-import"),
+      rootDir: canonicalRoot(destination),
+      ownerId: "latch-migrate-import-bootstrap",
+      now: () => clock,
+    });
+    await cell.close();
+    cell = undefined;
+    git(destination, "read-tree", "refs/ha/canonical");
+    git(destination, "checkout-index", "-a", "-f");
+    git(destination, "update-ref", "HEAD", "refs/ha/canonical");
+
+    cell = await openRepoCell({
+      repoId: workspaceId("latch-migrate-import"),
+      rootDir: canonicalRoot(destination),
+      ownerId: "latch-migrate-import-recovery",
+      now: () => clock,
+      killpoint: (point) => {
+        if (injectLatch && point === "before_event_write") {
+          injectLatch = false;
+          throw new Error("migration task entity is invalid");
+        }
+      },
+    });
+    injectLatch = true;
+    const latched = await cell.run(
+      { kind: "task-create", taskId: "task_injected_latch", title: "Injected latch" },
+      binding,
+    );
+    assert.equal(latched.outcome, "op_rejected", JSON.stringify(latched));
+    assert.match(String(latched.nextAction), /migration task entity is invalid/u);
+    assert.equal(cell.status().state, "unavailable");
+    assert.equal(cell.status().causeClass, "data-shape");
+    const cache = path.join(destination, ".harness/cache/task.sqlite"),
+      db = new DatabaseSync(cache),
+      row = db.prepare("SELECT schema_version FROM projection_meta WHERE singleton = 1").get() as {
+        readonly schema_version: number;
+      };
+    db.exec("UPDATE projection_meta SET schema_version = 999 WHERE singleton = 1;");
+    db.close();
+    const failedProbe = await cell.run({ kind: "task-list" }, binding);
+    assert.equal(failedProbe.code, "repo_unavailable");
+    assert.match(String(failedProbe.nextAction), /kernel projection schema 999/u);
+
+    const repaired = new DatabaseSync(cache);
+    repaired.prepare("UPDATE projection_meta SET schema_version = ? WHERE singleton = 1").run(row.schema_version);
+    repaired.close();
+    const dryRun = await cell.run({ kind: "migrate-import", sourceRoots, dryRun: true }, binding);
+    assert.equal(dryRun.outcome, "pending", JSON.stringify(dryRun));
+    assert.equal((dryRun as Record<string, unknown>).mode, "dry-run");
+    assert.equal((dryRun as Record<string, unknown>).exitCode, 0);
+    assert.equal(cell.status().state, "unavailable", "a dry-run cannot claim to have repaired the latch");
+    assert.equal((await cell.run({ kind: "task-list" }, binding)).code, "repo_unavailable");
+
+    const first = cell.run({ kind: "migrate-import", sourceRoots }, binding),
+      second = await cell.run({ kind: "migrate-import", sourceRoots }, binding),
+      applied = await first;
+    assert.equal(second.outcome, "op_rejected", JSON.stringify(second));
+    assert.equal(second.code, "recovery_conflict");
+    assert.match(String(second.nextAction), /single-writer recovery ingress/u);
+    assert.equal(applied.outcome, "applied", JSON.stringify(applied));
+    assert.equal(cell.status().state, "attached");
+    assert.equal((await cell.run({ kind: "task-list" }, binding)).outcome, "applied");
+  } finally {
+    await cell?.close();
+    rmSync(scratch, { recursive: true, force: true });
+  }
 });
 
 test("projection rebuild is executable from a projection latch and settles it", async () => {


### PR DESCRIPTION
# English

## Summary

Fixes a recovery-path contradiction found while preflighting the tri-repository migrations (harness task `task_b85c1c56`): a repository latched for a `data-shape` cause (e.g. `migration task entity is invalid`) rejected every `repo.task.run` action with `repo_unavailable` — including `migrate-import`, the very tool that repairs such a ledger. `migrate-import` is now admitted through the existing RepoCell recovery channel (same allowlist family as `fact-rekey`/`ledger-migrate`): dry-runs reach the importer without clearing the latch; a successful apply clears the recovery-probe throttle and re-probes initialization/projection, attaching the cell only if that probe succeeds (otherwise the receipt returns `pending`/`repo_unavailable` and the latch stays). Ordinary actions remain rejected while latched. A concurrent second recovery request receives a typed `recovery_conflict` with an explicit retry action — the repository's recovery ingress is single-claim in front of the existing single-writer queue.

## Architectural Justification

- No second ledger-opening or write path: the host API needed no bypass (a latched-after-attach cell is still in the host map and forwarded); admission is a one-line extension of the existing recovery allowlist plus a single-claim fence inside the cell.
- Narrowing, not adding: the fix narrows «unavailable rejects everything» to «unavailable rejects non-recovery actions»; no data-shape validation is loosened.
- Checkpoint discharged: fact-rekey cannot repair this incident shape (invalid migration task events are skipped before plan inspection and no rewrite branch reconstructs them), so this channel is necessary, not redundant.
- Multi-node: the concurrency owner is the per-repository recovery-ingress claim serialized in front of the center RepoCell single-writer queue; the loser gets typed `recovery_conflict`.

## What Changed

- `packages/daemon/src/recovery-state.ts`: `migrate-import` added to the recovery command policy (`data-shape`, settlesLatch).
- `packages/daemon/src/repo-cell-api.ts`: single-claim recovery fence; apply-path re-probe before attach; typed `recovery_conflict`.
- `packages/daemon/test/repo-cell-latch-recovery.test.ts`: new isolated suite (11 cases) — injected incident message, persistent data-shape probe, importer dry-run reach, ordinary-action rejection, concurrent conflict, apply, re-attachment.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none

## Machine-Readable Declarations

Production-Delta: +46/-6
Dependency-Change: none

### Optional Evidence Claims

None.

## Task And Scope

- Harness task: `task_b42be62d0bcb805843ec71bb8f` (unblocks `task_b85c1c56` tri-repo migration, relation rel_3b369744)
- Branch: `codex/migrate-recovery-ingress`
- Public scope: recovery-channel admission for migrate-import.
- Private planning/evidence: worker report `artifacts/implementation-report.md`; Fact `F-1F9694DC`, preflight Fact `F-62E5C29B`.

## Version Impact

- Version: no change. Publish impact: none.

## Governance Declaration

- Protected surface touched: no (packages-only diff).
- Break-glass: no

## Verification

- Base `origin/main`: rebased onto `8abfad17a` cleanly; CEO re-ran typecheck + duplicate-definitions green.
- Worker: isolated Ubuntu integration 11/11 (`tools/dispatch-isolated-test.mjs`, scratch repositories only); tsc -b, targeted ESLint/Prettier, file-complexity, implementation-contracts (allowlist unchanged at 129), `git diff --check` — all pass.
- No command touched the three production migration repositories; their dry-runs/applies are the CEO-owned follow-up after deploy.
- [ ] Full suites: GitHub CI is the authority.

## Review Evidence

- CEO semantic review: allowlist extension follows the fact-rekey family exactly (no second admission mechanism); latch-cause validation untouched; dry-run/apply semantics match the task plan; typed error (no message.includes).

## Residual Risk

- The recovery fence is in-memory per RepoCell — correct for the center single-daemon topology; if cells ever become multi-process, the claim must move into the queue itself (documented in the task package).

---

# 中文

## 概要

修复 tri-repo 迁移预检(task `task_b85c1c56`)发现的恢复路自相矛盾:因 `data-shape` 原因上闩的仓(如 `migration task entity is invalid`)对所有 `repo.task.run` 动作一律回 `repo_unavailable`——连修复这种台账用的 `migrate-import` 也进不去。现在 `migrate-import` 经**既有** RepoCell 恢复通道准入(与 `fact-rekey`/`ledger-migrate` 同一 allowlist 族):dry-run 可达 importer 且不清闩;apply 成功后清恢复探针节流并重新探测初始化/投影,探测通过才 attach(否则回执 `pending`/`repo_unavailable`,闩保持)。上闩期间普通动作仍被拒。并发的第二个恢复请求收到 typed `recovery_conflict` 与明确重试指引——恢复准入在既有单写队列之前单占。

## 架构辩护

- 不开第二条开台账/写路:host API 无需旁路(attach 后上闩的 cell 仍在 host map 中被转发);准入=恢复 allowlist 一行扩展+cell 内单占 fence。
- 是收窄不是加层:把「unavailable 拒绝一切」收窄为「unavailable 拒绝非恢复动作」;数据形状校验一条不放松。
- Checkpoint 已答:fact-rekey 修不了本事故形状(无效 migration task 事件在计划检视前即被跳过,且无重建分支),本通道必要、非冗余。
- 多节点:并发主体=仓级恢复准入单占,串行于中心 RepoCell 单写队列之前;后到者收 typed `recovery_conflict`。

## 改动内容

- `recovery-state.ts`:`migrate-import` 加入恢复命令策略(`data-shape`,settlesLatch)。
- `repo-cell-api.ts`:恢复单占 fence;apply 路重探针再 attach;typed `recovery_conflict`。
- 新增隔离测试套件 `repo-cell-latch-recovery.test.ts`(11 例):注入实测事故消息、持久 data-shape 探针、dry-run 可达、普通动作拒绝、并发冲突、apply、重新 attach。

## 门收割 / Gate Harvest

- 删除的生产路径:无。

## 机读声明说明

`Production-Delta` 由 gate 实测(+46/−6)。

## 任务与范围

- Task `task_b42be62d0bcb805843ec71bb8f`(解锁 `task_b85c1c56` 三仓迁移);分支 `codex/migrate-recovery-ingress`。

## 版本影响

- 不改版本、不发布。

## 治理声明

- 未触碰受保护面(纯 packages diff);非 break-glass。

## 验证

- worker:隔离 Ubuntu 集成 11/11(只用 scratch 仓)、tsc、定向 ESLint/Prettier、file-complexity、implementation-contracts(allowlist 持平 129)全绿;三个生产迁移仓零触碰,部署后 dry-run/apply 归 CEO;完整权威=GitHub CI。
- CEO:rebase 到 8abfad17a 干净;typecheck+duplicate-definitions 重跑绿。

## 审查证据

- CEO 语义验收:严格沿 fact-rekey 族扩展、无第二套准入机制;闩因校验未动;typed 错误无 message.includes。

## 残余风险

- 恢复 fence 为 cell 内存级——对中心单 daemon 拓扑正确;若未来 cell 多进程化,占用须下沉到队列本身(已记入任务包)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VTzQAqvuFy6ikGjBKxA9xj
