### PR TITLE
fix(gui): open project-external local doc links in-app; unify graph entry on detail pages

### DIFF
--- a/packages/gui/src/api/local-doc-contract.ts
+++ b/packages/gui/src/api/local-doc-contract.ts
@@ -1,0 +1,49 @@
+export const LOCAL_DOC_READ_CHANNEL = "harness:localDoc:read";
+
+/**
+ * 「GUI 内读本机文档」(task_89d324b5)的 renderer→main 契约。
+ *
+ * 详情页 Markdown 里的本机文件链接(项目外绝对路径 / `~/…`)在 GUI 内打开阅读:
+ * 这是节点本地只读查询 —— 主进程用 node:fs 读一个文件返回文本,不落台账、无并发
+ * 主体、没有任何写路。操作者是本机合作者,因此不做 allowlist 配置层、不对敏感目录
+ * 特判:本机当前用户可读的文件即可读。
+ *
+ * 伪装防线只有一条且是诚实展示:路径在主进程解析符号链接后返回**真实绝对路径**
+ * (realpath),界面按它展示 —— 链接写 `/tmp/link.md` 而真身在 `~/Notes/x.md` 时,
+ * 读者看到的是真身路径。不可读(不存在/无权限/目录/二进制/超大)以 typed code
+ * 返回,渲染进程按 code 出页内错误态,绝不抛成白屏。
+ */
+export type LocalDocReadErrorCode =
+  | "not_found"
+  | "not_a_regular_file"
+  | "not_readable"
+  | "binary_file"
+  | "too_large"
+  | "request_rejected"
+  | "bridge_unavailable";
+
+export interface LocalDocReadInput {
+  /** Markdown href 原样路径:绝对路径(`/Users/…`)或家目录相对(`~/…`)。 */
+  readonly path: string;
+}
+
+export interface LocalDocReadSuccess {
+  readonly ok: true;
+  /** realpath 解析后的真实绝对路径(符号链接已展开),界面按它展示。 */
+  readonly path: string;
+  readonly content: string;
+  readonly sizeBytes: number;
+}
+
+export interface LocalDocReadFailure {
+  readonly ok: false;
+  readonly code: LocalDocReadErrorCode;
+  readonly path: string;
+  readonly message: string;
+}
+
+export type LocalDocReadResult = LocalDocReadSuccess | LocalDocReadFailure;
+
+export interface LocalDocApi {
+  readonly read: (input: LocalDocReadInput) => Promise<LocalDocReadResult>;
+}

--- a/packages/gui/src/main/electron-main.ts
+++ b/packages/gui/src/main/electron-main.ts
@@ -1,9 +1,11 @@
 import { app, BrowserWindow, dialog, ipcMain, session, shell } from "electron";
+import { homedir } from "node:os";
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import type { HarnessLayoutOverrides } from "../../../kernel/src/index.ts";
 import { registerHarnessIpcHandlers } from "./ipc-handlers.ts";
 import { registerArtifactOpenIpc } from "./artifact-open-ipc.ts";
+import { registerLocalDocIpc } from "./local-doc-ipc.ts";
 import { bootstrapLocalRepository, createLocalGuiServiceBridge } from "./local-composition-root.ts";
 import { addLocalMainControls } from "./local-main-controls.ts";
 import { resolveLocalDaemonTarget } from "../../../daemon/src/client/local-daemon-target.ts";
@@ -11,13 +13,12 @@ import { daemonBuildStamp } from "../../../daemon/src/build-identity.ts";
 import {
   evaluateHtmlArtifactAttachment,
   evaluateHtmlArtifactRequest,
-  evaluateNavigationRequest,
   evaluatePermissionRequest,
   evaluateWindowOpenRequest,
   HTML_ARTIFACT_PARTITION,
   type IpcWebContentsTrustPolicy,
 } from "./security-policy.ts";
-import { assertDevRendererUrl, createGuiContentSecurityPolicy } from "./window-config.ts";
+import { assertDevRendererUrl, createGuiContentSecurityPolicy, isNavigableAppDocumentUrl } from "./window-config.ts";
 import { registerFirstRunIpcHandlers } from "./first-run-ipc.ts";
 
 const dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -25,7 +26,6 @@ const dirname = path.dirname(fileURLToPath(import.meta.url));
 export function createMainWindow(): BrowserWindow {
   const preloadPath = path.join(guiPackageRoot(), "dist-electron/electron-preload.cjs");
   const rendererUrl = process.env.ELECTRON_RENDERER_URL;
-  const allowDevRenderer = Boolean(rendererUrl);
   const packagedRendererUrl = createLocalPackagedRendererUrl();
   const mainWindow = new BrowserWindow({
     title: "Harness Anything",
@@ -46,8 +46,11 @@ export function createMainWindow(): BrowserWindow {
 
   mainWindow.once("ready-to-show", () => mainWindow.show());
   mainWindow.webContents.setWindowOpenHandler(() => ({ action: evaluateWindowOpenRequest().action }));
+  // 单文档应用:窗口只可停在入口文档上。dev 态同源任意路径(Markdown 外链的绝对
+  // 路径会解析到 dev origin 之下)同样拒绝 —— 那会把窗口带离应用,落在 dev server
+  // 的 404 白屏上(task_89d324b5 详情面外链白屏的壳侧成因;渲染层拦截是根修)。
   mainWindow.webContents.on("will-navigate", (event, url) => {
-    if (evaluateNavigationRequest(url, { packagedRendererUrl, allowDevRenderer }).action === "deny") {
+    if (!isNavigableAppDocumentUrl(url, { packagedRendererUrl, devRendererUrl: rendererUrl })) {
       event.preventDefault();
     }
   });
@@ -164,6 +167,8 @@ export async function startGuiApp(): Promise<void> {
     },
     trustPolicy,
   );
+  // GUI 内读本机文档(task_89d324b5):节点本地只读查询,主进程收窄见 local-doc-ipc.ts。
+  registerLocalDocIpc(ipcMain, { homeDir: () => homedir() }, trustPolicy);
   createTrustedMainWindow(trustedWebContentsIds);
   app.on("activate", () => {
     if (BrowserWindow.getAllWindows().length === 0) createTrustedMainWindow(trustedWebContentsIds);

--- a/packages/gui/src/main/local-doc-ipc.ts
+++ b/packages/gui/src/main/local-doc-ipc.ts
@@ -1,0 +1,177 @@
+import { readFile, realpath, stat } from "node:fs/promises";
+import { homedir } from "node:os";
+import path from "node:path";
+import { LOCAL_DOC_READ_CHANNEL, type LocalDocReadInput, type LocalDocReadResult } from "../api/local-doc-contract.ts";
+import { assertTrustedIpcSender } from "./ipc-handlers.ts";
+import type { IpcWebContentsTrustPolicy } from "./security-policy.ts";
+
+/**
+ * 「GUI 内读本机文档」的唯一 IPC 通道(task_89d324b5)。
+ *
+ * 详情页 Markdown 链接指向项目外本机文件时,渲染进程把链接里的路径原样交给本通道,
+ * 主进程只做只读解析与读取,返回文本或 typed 失败:
+ *
+ *   1. 请求形状收紧:`{path}` 且恰为该字段;路径必须是非空、无控制字符的字符串,
+ *      `~` 展开后必须是绝对路径 —— 相对路径与 `~user` 形态在入口即拒。
+ *   2. 符号链接在读取前用 realpath 展开,返回真实绝对路径:界面展示真身路径,
+ *      目录逃逸伪装(链接写 A、真身在 B)在展示层不成立。
+ *   3. 只读边界:本模块不引入任何写路(fs 写函数一个都不出现),不落台账;
+ *      操作者是本机合作者,本机当前用户可读的文件即可读,无 allowlist、无敏感目录特判。
+ *   4. 失败 typed:fs errno(`error.code`)键控映射到契约 code,渲染进程按 code
+ *      出页内错误态;二进制(NUL/高替换率)与超过上限的文件同样 typed 拒绝。
+ *
+ * electron 不在本模块引入(node 单测要能加载),home 目录由默认服务提供、可注入。
+ */
+
+/** 单文件读取上限:Markdown 阅读面按「一篇文档」设定,超限给页内错误而非卡死渲染。 */
+export const LOCAL_DOC_MAX_BYTES = 2 * 1024 * 1024;
+
+/** 二进制嗅探窗口:UTF-8 解码后前 4 KiB 内替换字符占比超过该阈值判定为二进制。 */
+const BINARY_SNIFF_WINDOW = 4096;
+const BINARY_REPLACEMENT_RATIO = 0.1;
+
+export interface LocalDocServices {
+  /** `~` 展开的根;缺省 node:os homedir()。 */
+  readonly homeDir: () => string;
+  /** 读取上限(字节);缺省 LOCAL_DOC_MAX_BYTES。 */
+  readonly maxBytes?: number;
+}
+
+export interface LocalDocRegistrar {
+  readonly handle: (
+    channel: string,
+    listener: (event: { readonly sender: { readonly id: number } }, payload: unknown) => Promise<unknown>,
+  ) => void;
+}
+
+export function registerLocalDocIpc(
+  registrar: LocalDocRegistrar,
+  services: LocalDocServices = { homeDir: homedir },
+  trustPolicy: IpcWebContentsTrustPolicy,
+): void {
+  registrar.handle(LOCAL_DOC_READ_CHANNEL, async (event, payload) => {
+    assertTrustedIpcSender(event, trustPolicy);
+    const input = validateLocalDocReadInput(payload);
+    return readLocalDocument(input.path, services);
+  });
+}
+
+export function validateLocalDocReadInput(value: unknown): LocalDocReadInput {
+  if (typeof value !== "object" || value === null || Array.isArray(value))
+    throw new Error("Local document read requires an object payload.");
+  const record: Record<string, unknown> = value as Record<string, unknown>;
+  for (const key of Object.keys(record))
+    if (key !== "path") throw new Error(`Local document read does not accept field ${key}.`);
+  const candidate = record.path;
+  if (typeof candidate !== "string" || candidate.length === 0)
+    throw new Error("Local document read requires a path string.");
+  if (candidate.length > 4096 || CONTROL_CHARACTERS.test(candidate))
+    throw new Error("Local document path contains unsupported characters.");
+  // 非 Windows 平台不接受反斜杠与 Windows 盘符形态(与 api/local-api 的
+  // isForeignAbsolutePath 同一口径);Windows 上反斜杠是合法分隔符。注意不能用
+  // path.win32.isAbsolute 判盘符 —— 它对 `/posix/abs` 也返回 true。
+  if (process.platform !== "win32" && (candidate.includes(BACKSLASH) || WINDOWS_DRIVE.test(candidate)))
+    throw new Error("Local document path uses an unsupported separator.");
+  return { path: candidate };
+}
+
+const CONTROL_CHARACTERS = /[\u0000-\u001f\u007f]/u;
+
+/** `~/…` → `<home>/…`;`~user` 不展开(交给后续绝对路径判定拒绝)。 */
+export function expandHomePath(inputPath: string, homeDir: string): string {
+  if (inputPath === "~") return homeDir;
+  if (inputPath.startsWith("~/")) return path.join(homeDir, inputPath.slice(2));
+  return inputPath;
+}
+
+/** fs errno → 契约 code(code 键控,不做消息子串判定)。 */
+export function classifyLocalDocFsError(cause: unknown): "not_found" | "not_a_regular_file" | "not_readable" {
+  const code = (cause as { readonly code?: unknown } | null)?.code;
+  if (code === "ENOENT" || code === "ENOTDIR") return "not_found";
+  if (code === "EISDIR") return "not_a_regular_file";
+  return "not_readable";
+}
+
+/** UTF-8 安全解码后的二进制嗅探:NUL 字节,或嗅探窗口内替换字符占比过高。 */
+export function looksBinary(content: string): boolean {
+  if (content.includes(NUL)) return true;
+  const head = content.slice(0, BINARY_SNIFF_WINDOW);
+  if (head.length === 0) return false;
+  let replacements = 0;
+  for (const character of head) if (character === REPLACEMENT_CHARACTER) replacements += 1;
+  return replacements / head.length > BINARY_REPLACEMENT_RATIO;
+}
+
+const NUL = String.fromCharCode(0);
+const BACKSLASH = String.fromCharCode(0x5c);
+const WINDOWS_DRIVE = /^[a-zA-Z]:[\\/]/u;
+const REPLACEMENT_CHARACTER = String.fromCharCode(0xfffd);
+
+export async function readLocalDocument(
+  rawPath: string,
+  services: LocalDocServices = { homeDir: homedir },
+): Promise<LocalDocReadResult> {
+  const maxBytes = services.maxBytes ?? LOCAL_DOC_MAX_BYTES;
+  const expanded = expandHomePath(rawPath, services.homeDir());
+  if (!path.isAbsolute(expanded))
+    return {
+      ok: false,
+      code: "request_rejected",
+      path: expanded,
+      message: "Local document path must be absolute after home-directory expansion.",
+    };
+
+  let realPath: string;
+  try {
+    realPath = await realpath(expanded);
+  } catch (cause) {
+    return fsFailure(classifyLocalDocFsError(cause), expanded, cause);
+  }
+
+  let size: number, isFile: boolean;
+  try {
+    const info = await stat(realPath);
+    size = info.size;
+    isFile = info.isFile();
+  } catch (cause) {
+    return fsFailure(classifyLocalDocFsError(cause), realPath, cause);
+  }
+  if (!isFile)
+    return {
+      ok: false,
+      code: "not_a_regular_file",
+      path: realPath,
+      message: "Local document path points at a directory or a special file.",
+    };
+  if (size > maxBytes)
+    return {
+      ok: false,
+      code: "too_large",
+      path: realPath,
+      message: `Local document is ${size} bytes; the in-app reader accepts at most ${maxBytes}.`,
+    };
+
+  let content: string;
+  try {
+    content = await readFile(realPath, "utf8");
+  } catch (cause) {
+    return fsFailure(classifyLocalDocFsError(cause), realPath, cause);
+  }
+  if (looksBinary(content))
+    return {
+      ok: false,
+      code: "binary_file",
+      path: realPath,
+      message: "Local document does not decode as text.",
+    };
+  return { ok: true, path: realPath, content, sizeBytes: size };
+}
+
+function fsFailure(
+  code: "not_found" | "not_a_regular_file" | "not_readable",
+  pathValue: string,
+  cause: unknown,
+): LocalDocReadResult {
+  const detail = cause instanceof Error ? cause.message : String(cause);
+  return { ok: false, code, path: pathValue, message: detail };
+}

--- a/packages/gui/src/main/window-config.ts
+++ b/packages/gui/src/main/window-config.ts
@@ -43,28 +43,25 @@ export function createGuiContentSecurityPolicy(options: GuiContentSecurityPolicy
     connectSrc,
     "object-src 'none'",
     "base-uri 'none'",
-    "frame-ancestors 'none'"
+    "frame-ancestors 'none'",
   ].join("; ");
 }
 
 export const guiContentSecurityPolicy = createGuiContentSecurityPolicy();
 
-export const allowedRendererOrigins = Object.freeze([
-  "file://",
-  "http://127.0.0.1:5173"
-] as const);
+export const allowedRendererOrigins = Object.freeze(["file://", "http://127.0.0.1:5173"] as const);
 
 export function createGuiIndexContentSecurityPolicy(): string {
   return [
-  "default-src 'self'",
-  "script-src 'self'",
-  "style-src 'self'",
-  "img-src 'self' data:",
-  "font-src 'self'",
-  "connect-src 'self'",
-  "object-src 'none'",
-  "base-uri 'none'",
-  "frame-ancestors 'none'"
+    "default-src 'self'",
+    "script-src 'self'",
+    "style-src 'self'",
+    "img-src 'self' data:",
+    "font-src 'self'",
+    "connect-src 'self'",
+    "object-src 'none'",
+    "base-uri 'none'",
+    "frame-ancestors 'none'",
   ].join("; ");
 }
 
@@ -82,8 +79,8 @@ export function createGuiWindowOptions(preloadPath: string): GuiWindowOptions {
       sandbox: true,
       webSecurity: true,
       webviewTag: true,
-      preload: preloadPath
-    }
+      preload: preloadPath,
+    },
   };
 }
 
@@ -106,6 +103,34 @@ export function isTrustedRendererUrl(url: string, options: TrustedRendererUrlOpt
     if (parsed.protocol !== "file:") return false;
     const packagedRendererUrl = options.packagedRendererUrl ?? createPackagedRendererUrl();
     return parsed.href === new URL(packagedRendererUrl).href;
+  } catch {
+    return false;
+  }
+}
+
+export interface AppDocumentUrlOptions {
+  readonly packagedRendererUrl?: string;
+  /** dev 启动时加载的 renderer 入口(ELECTRON_RENDERER_URL);打包态缺省。 */
+  readonly devRendererUrl?: string | undefined;
+}
+
+/**
+ * 渲染层是单文档应用:窗口可导航的 URL 只有入口文档本身 —— 打包态的 index file URL,
+ * 或 dev server 的根路径。dev 态此前允许同源任意路径(如 Markdown 里 `/Users/…`
+ * 绝对路径链接解析到 `http://127.0.0.1:5173/Users/…`),点击后窗口离开应用文档、
+ * 落在 dev server 的 404 上 —— 这就是详情面外链白屏的壳侧成因(task_89d324b5)。
+ * 渲染层的链接拦截是根修;本判定把同一类逃逸在壳边界也关掉(纵深防御)。
+ */
+export function isNavigableAppDocumentUrl(url: string, options: AppDocumentUrlOptions = {}): boolean {
+  try {
+    const parsed = new URL(url);
+    if (options.devRendererUrl !== undefined && options.devRendererUrl !== "") {
+      const devUrl = new URL(options.devRendererUrl);
+      if (parsed.origin === devUrl.origin) return parsed.pathname === devUrl.pathname;
+    }
+    if (parsed.protocol !== "file:") return false;
+    const packagedRendererUrl = new URL(options.packagedRendererUrl ?? createPackagedRendererUrl());
+    return parsed.href === packagedRendererUrl.href;
   } catch {
     return false;
   }

--- a/packages/gui/src/preload/electron-preload.ts
+++ b/packages/gui/src/preload/electron-preload.ts
@@ -10,6 +10,7 @@ import { agentRuntimePreloadApi } from "./agent-runtime-preload.ts";
 import { daemonGuiStreamFacets } from "../../../daemon/src/protocol/daemon-protocol.contract.ts";
 import { FIRST_RUN_BOOTSTRAP_CHANNEL, FIRST_RUN_CHOOSE_CHANNEL, type FirstRunApi } from "../api/first-run-contract.ts";
 import { ARTIFACT_OPEN_EXTERNAL_CHANNEL, type ArtifactOpenApi } from "../api/artifact-open-contract.ts";
+import { LOCAL_DOC_READ_CHANNEL, type LocalDocApi } from "../api/local-doc-contract.ts";
 const streamMethods: ReadonlySet<string> = new Set(daemonGuiStreamFacets.map(({ guiBridgeMethod }) => guiBridgeMethod));
 const exposedApi = Object.fromEntries(
   preloadAllowlist
@@ -32,6 +33,10 @@ const exposedHarnessApi = {
   artifacts: {
     openExternal: (input) => ipcRenderer.invoke(ARTIFACT_OPEN_EXTERNAL_CHANNEL, input),
   } satisfies ArtifactOpenApi,
+  // GUI 内读本机文档(task_89d324b5):只读通道,主进程收窄见 main/local-doc-ipc.ts。
+  localDoc: {
+    read: (input) => ipcRenderer.invoke(LOCAL_DOC_READ_CHANNEL, input),
+  } satisfies LocalDocApi,
   capabilities: preloadApiCapabilities,
 };
 

--- a/packages/gui/src/renderer/App.tsx
+++ b/packages/gui/src/renderer/App.tsx
@@ -59,6 +59,7 @@ import { useWorkspaceSummaryQuery } from "./workspace-summary-data.ts";
 import { WorkspaceSummaryPending } from "./components/WorkspaceSummaryPending.tsx";
 import { prewarmRuntimeInstanceCatalog } from "./runtime-instance-data.ts";
 import { FirstRunGuide, FirstRunWizard } from "./components/FirstRunWizard.tsx";
+import { LocalDocLayer } from "./local-doc/LocalDocLayer.tsx";
 
 /**
  * 渲染全量决策行的视图。总览不在决策抽屉关闭时预读完整图;
@@ -402,6 +403,7 @@ function AppShell() {
                 onSetPin={(task, pinned) => {
                   void taskActions.setTaskPin(task, pinned);
                 }}
+                onFocusGraph={focusEntityInGraph}
               />
             ) : view === "home" ? (
               <HomeView
@@ -590,6 +592,7 @@ function AppShell() {
                 focusedEntityRef={focusedEntityRef}
                 onSelectEntity={selectRuntimeEntity}
                 onFocusSchedule={(ref) => updateLocation({ focusedEntityRef: ref })}
+                onFocusGraph={focusEntityInGraph}
               />
             ) : view === "artifacts" ? (
               <ArtifactsView repoId={projectId} onNavigateTask={navigateToTask} />
@@ -603,6 +606,7 @@ function AppShell() {
                 }))}
                 focusedEntityRef={focusedEntityRef}
                 onSelectEntity={selectRuntimeEntity}
+                onFocusGraph={focusEntityInGraph}
               />
             ) : view === "providers" ? (
               <ProvidersView
@@ -674,7 +678,11 @@ function AppShell() {
 export function App() {
   return (
     <ThemeProvider>
-      <AppShell />
+      {/* 本机文档浮层(task_89d324b5):详情页 Markdown 的项目外本机文件链接在 GUI 内
+          打开阅读;context 让所有 Markdown 锚点共享同一个打开入口。 */}
+      <LocalDocLayer>
+        <AppShell />
+      </LocalDocLayer>
     </ThemeProvider>
   );
 }

--- a/packages/gui/src/renderer/components/DocReader.tsx
+++ b/packages/gui/src/renderer/components/DocReader.tsx
@@ -4,29 +4,13 @@ import Markdown from "react-markdown";
 import type { Components } from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { MagnifyingGlass } from "@phosphor-icons/react";
+import { MarkdownAnchor } from "../local-doc/MarkdownAnchor.tsx";
+import { markdownUrlTransform } from "../local-doc/markdown-links.ts";
 
 // mermaid diagram rendering is intentionally omitted in the Electron shell:
 // its runtime injects inline <style>/<script>, which the production CSP
 // (style-src 'self'; script-src 'self') blocks, and the bundle is heavy.
 // mermaid code fences fall back to a readable source block.
-const components: Components = {
-  pre({ node: _node, children }) {
-    if (isValidElement(children)) {
-      const childProps = children.props as {
-        className?: string;
-        children?: ReactNode;
-      };
-      if (childProps.className?.includes("language-mermaid")) {
-        return (
-          <pre className="my-4 overflow-x-auto rounded-md border border-border bg-surface p-3 font-mono text-[12px] text-text-muted">
-            <code>{String(childProps.children ?? "").trim()}</code>
-          </pre>
-        );
-      }
-    }
-    return <pre>{children}</pre>;
-  },
-};
 
 type ReaderLayout = "auto" | "single" | "double";
 type ReaderFont = "sans" | "serif" | "mono";
@@ -43,11 +27,52 @@ const readerFonts: Record<ReaderFont, string> = {
   mono: "var(--font-mono)",
 };
 
-export function DocReader({ content }: { content: string }) {
+export function DocReader({
+  content,
+  packageBasePath = null,
+  onOpenPackageDoc,
+}: {
+  content: string;
+  /** 当前文档在任务包内的 repo 相对路径(如 `tasks/<pkg>/task_plan.md`);相对链接据此归一化。 */
+  packageBasePath?: string | null;
+  /** 包内文档导航出口:收到归一化后的 repo 相对路径。缺省时相对链接保持 inert。 */
+  onOpenPackageDoc?: (repoRelativePath: string) => void;
+}) {
   const [query, setQuery] = useState("");
   const [layout, setLayout] = useState<ReaderLayout>("auto");
   const [font, setFont] = useState<ReaderFont>("sans");
   const [fontSize, setFontSize] = useState(15);
+
+  // 链接拦截(task_89d324b5):锚点永远不做文档导航。本机文件链接转本机文档浮层,
+  // 包内相对链接走宿主提供的导航出口;components 随 props 重建以捕获最新闭包。
+  const components = useMemo<Components>(() => {
+    const base: Components = {
+      pre({ node: _node, children }) {
+        if (isValidElement(children)) {
+          const childProps = children.props as {
+            className?: string;
+            children?: ReactNode;
+          };
+          if (childProps.className?.includes("language-mermaid")) {
+            return (
+              <pre className="my-4 overflow-x-auto rounded-md border border-border bg-surface p-3 font-mono text-[12px] text-text-muted">
+                <code>{String(childProps.children ?? "").trim()}</code>
+              </pre>
+            );
+          }
+        }
+        return <pre>{children}</pre>;
+      },
+    };
+    if (packageBasePath !== null || onOpenPackageDoc !== undefined) {
+      base.a = (props) => (
+        <MarkdownAnchor {...props} packageBasePath={packageBasePath} onOpenPackageDoc={onOpenPackageDoc} />
+      );
+    } else {
+      base.a = MarkdownAnchor;
+    }
+    return base;
+  }, [packageBasePath, onOpenPackageDoc]);
 
   const matchCount = useMemo(() => {
     const q = query.trim().toLowerCase();
@@ -148,7 +173,7 @@ export function DocReader({ content }: { content: string }) {
       </div>
       <div className="doc-flow px-5 pb-6 pt-16 sm:px-6">
         <div className="prose-harness" data-layout={layout} data-font={font}>
-          <Markdown remarkPlugins={[remarkGfm]} components={components}>
+          <Markdown remarkPlugins={[remarkGfm]} components={components} urlTransform={markdownUrlTransform}>
             {content}
           </Markdown>
         </div>

--- a/packages/gui/src/renderer/components/DocReader.tsx
+++ b/packages/gui/src/renderer/components/DocReader.tsx
@@ -55,7 +55,12 @@ export function DocReader({
           };
           if (childProps.className?.includes("language-mermaid")) {
             return (
-              <pre className="my-4 overflow-x-auto rounded-md border border-border bg-surface p-3 font-mono text-[12px] text-text-muted">
+              <pre
+                className={
+                  "my-4 overflow-x-auto rounded-md border border-border bg-surface p-3 " +
+                  "font-mono text-[12px] text-text-muted"
+                }
+              >
                 <code>{String(childProps.children ?? "").trim()}</code>
               </pre>
             );

--- a/packages/gui/src/renderer/components/FactInspector.tsx
+++ b/packages/gui/src/renderer/components/FactInspector.tsx
@@ -1,4 +1,4 @@
-import { ArrowSquareOut, Graph, GitBranch, WarningCircle, X } from "@phosphor-icons/react";
+import { ArrowSquareOut, GitBranch, WarningCircle, X } from "@phosphor-icons/react";
 import type { DecisionRow, FactRef, RelationEdge, TaskRow } from "../model/types";
 import { normalizeDecisionId } from "../model/triadic";
 import { activeIncomingRelations, incomingRelations } from "../model/relation-direction.ts";
@@ -7,6 +7,7 @@ import { buildEntityJumpContext } from "../model/copy-context";
 import type { RelationCoverageRow } from "../../api/renderer-dto";
 import { t } from "../i18n/index.tsx";
 import { EntityRefLink } from "./EntityRefLink.tsx";
+import { ViewInGraphButton } from "./ViewInGraphButton.tsx";
 import { formatTime } from "../model/time.ts";
 
 function shortEndpoint(raw: string): string {
@@ -141,20 +142,19 @@ export function FactInspector({
             }
           />
         )}
-        {onFocusGraph && (
-          <button
-            onClick={() => onFocusGraph(fullRef)}
-            title={t("components.factInspector.focusFactDiagram")}
-            className="grid size-6 place-items-center rounded text-text-faint hover:bg-surface-raised hover:text-accent"
-          >
-            <Graph weight="bold" />
-          </button>
-        )}
+        {/* 统一「在关系图中查看」入口(task_89d324b5):fact 是图节点 kind,详情栏
+            头部右侧带标签按钮(替换原纯图标跳转,语义同一条路)。 */}
+        <ViewInGraphButton
+          entityRef={fullRef}
+          onFocusGraph={onFocusGraph}
+          testId="fact-view-in-graph"
+          className="flex shrink-0 items-center gap-1 rounded-md border border-border px-1.5 py-1 font-mono text-[10px] text-text-faint hover:border-border-strong hover:bg-surface-raised hover:text-text"
+        />
         {onClose && (
           <button
             onClick={onClose}
             title={t("components.factInspector.closeFactInspector")}
-            className="ml-auto grid size-6 place-items-center rounded text-text-faint hover:bg-surface-raised hover:text-text"
+            className="ml-auto grid size-6 shrink-0 place-items-center rounded text-text-faint hover:bg-surface-raised hover:text-text"
           >
             <X weight="bold" />
           </button>

--- a/packages/gui/src/renderer/components/FactInspector.tsx
+++ b/packages/gui/src/renderer/components/FactInspector.tsx
@@ -148,13 +148,19 @@ export function FactInspector({
           entityRef={fullRef}
           onFocusGraph={onFocusGraph}
           testId="fact-view-in-graph"
-          className="flex shrink-0 items-center gap-1 rounded-md border border-border px-1.5 py-1 font-mono text-[10px] text-text-faint hover:border-border-strong hover:bg-surface-raised hover:text-text"
+          className={
+            "flex shrink-0 items-center gap-1 rounded-md border border-border px-1.5 py-1 font-mono text-[10px] " +
+            "text-text-faint hover:border-border-strong hover:bg-surface-raised hover:text-text"
+          }
         />
         {onClose && (
           <button
             onClick={onClose}
             title={t("components.factInspector.closeFactInspector")}
-            className="ml-auto grid size-6 shrink-0 place-items-center rounded text-text-faint hover:bg-surface-raised hover:text-text"
+            className={
+              "ml-auto grid size-6 shrink-0 place-items-center rounded text-text-faint " +
+              "hover:bg-surface-raised hover:text-text"
+            }
           >
             <X weight="bold" />
           </button>

--- a/packages/gui/src/renderer/components/ViewInGraphButton.tsx
+++ b/packages/gui/src/renderer/components/ViewInGraphButton.tsx
@@ -1,0 +1,45 @@
+import { Graph } from "@phosphor-icons/react";
+import { t } from "../i18n/index.tsx";
+
+/**
+ * 「在关系图中查看」统一入口(task_89d324b5)。
+ *
+ * 关系图的节点空间是五种实体 kind(task/decision/fact/agent/schedule),每种的详情页
+ * 右上角都从这里取按钮 —— 一个实现按实体 ref 参数化,不在各详情页复制按钮代码。
+ * 跳转走 App 的 focusEntityInGraph(ref)(与 Decision 详情页原有按钮同一条路:
+ * 落 graph 视图 + focusedEntityRef,EntityWorkspace 收到焦点即切聚光灯)。
+ * 回调缺省时按钮不渲染(与 Decision 原有按钮的缺省语义一致)。
+ */
+export function ViewInGraphButton({
+  entityRef,
+  onFocusGraph,
+  className,
+  testId = "view-in-graph-button",
+}: {
+  /** 图键空间实体引用:`task/<id>`、`decision/<id>`、`fact/<anchor>`、`agent/<id>`、`schedule/<id>`。 */
+  readonly entityRef: string;
+  /** 跳转并聚焦该实体;缺省不渲染。 */
+  readonly onFocusGraph?: (ref: string) => void;
+  readonly className?: string;
+  readonly testId?: string;
+}) {
+  if (!onFocusGraph) return null;
+  return (
+    <button
+      type="button"
+      data-testid={testId}
+      title={entityRef}
+      onClick={() => onFocusGraph(entityRef)}
+      className={
+        className ??
+        [
+          "flex shrink-0 items-center gap-1 rounded-md border border-border px-2 py-1.5 font-mono text-[10px]",
+          "text-text-muted hover:border-border-strong hover:bg-surface-raised hover:text-text",
+        ].join(" ")
+      }
+    >
+      <Graph weight="bold" className="text-[11px]" />
+      {t("components.viewInGraph.view")}
+    </button>
+  );
+}

--- a/packages/gui/src/renderer/components/decisionDetail/DecisionBodyPanel.tsx
+++ b/packages/gui/src/renderer/components/decisionDetail/DecisionBodyPanel.tsx
@@ -1,16 +1,23 @@
 import { useMemo } from "react";
 import { useQuery } from "@tanstack/react-query";
 import Markdown from "react-markdown";
+import type { Components } from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { harnessClient } from "../../api-client.ts";
 import { t } from "../../i18n/index.tsx";
+import { MarkdownAnchor } from "../../local-doc/MarkdownAnchor.tsx";
+import { markdownUrlTransform } from "../../local-doc/markdown-links.ts";
 
 /**
  * 正文块渲染:完整渲染、永不截断(2026-08-25 泽宇裁决——性能顾虑不许转嫁成用户点击)。
  * 每块带 content-visibility:auto:离屏块的布局与绘制由渲染器跳过,DOM 仍是全量,
  * 长正文的滚动成本只与视口内块数相关。
+ *
+ * 链接拦截(task_89d324b5)与 DocReader 同一份 MarkdownAnchor:锚点永远不做文档
+ * 导航,本机文件链接转本机文档浮层 —— 决策正文里的项目外链接不再把窗口带离应用。
  */
 const BLOCK_CLASS = "[contain-intrinsic-size:auto_5rem] [content-visibility:auto]";
+const components: Components = { a: MarkdownAnchor };
 
 export function DecisionBodyPanel({ repoId, decisionId }: { repoId: string; decisionId: string }) {
   const query = useQuery({
@@ -70,7 +77,9 @@ function DecisionBodyDocument({ source }: { source: string }) {
       <div className="prose-harness">
         {blocks.map((block, index) => (
           <div key={index} data-testid="decision-body-block" className={BLOCK_CLASS}>
-            <Markdown remarkPlugins={[remarkGfm]}>{block}</Markdown>
+            <Markdown remarkPlugins={[remarkGfm]} components={components} urlTransform={markdownUrlTransform}>
+              {block}
+            </Markdown>
           </div>
         ))}
       </div>

--- a/packages/gui/src/renderer/components/decisionDetail/DecisionDetailView.tsx
+++ b/packages/gui/src/renderer/components/decisionDetail/DecisionDetailView.tsx
@@ -10,6 +10,7 @@ import {
 } from "@phosphor-icons/react";
 import { DecisionStateBadge, RiskTierBadge, UrgencyBadge } from "../badges.tsx";
 import { EntityRefLink } from "../EntityRefLink.tsx";
+import { ViewInGraphButton } from "../ViewInGraphButton.tsx";
 import { formatTime } from "../../model/time.ts";
 import type { DecisionRow, RelationEdge, TaskRow } from "../../model/types.ts";
 import { t } from "../../i18n/index.tsx";
@@ -162,18 +163,8 @@ export function DecisionDetailView({
                 {t("views.decisionDetailView.openInPool")}
               </button>
             )}
-            {onFocusGraph && (
-              <button
-                type="button"
-                onClick={() => onFocusGraph(`decision/${decision.decisionId}`)}
-                className={[
-                  "rounded-md border border-border px-2 py-1.5 font-mono text-[10px] text-text-muted",
-                  "hover:border-border-strong hover:bg-surface-raised hover:text-text",
-                ].join(" ")}
-              >
-                {t("views.decisionDetailView.focusGraph")}
-              </button>
-            )}
+            {/* 统一「在关系图中查看」入口(task_89d324b5):原特化按钮换成共享件,行为同路。 */}
+            <ViewInGraphButton entityRef={`decision/${decision.decisionId}`} onFocusGraph={onFocusGraph} />
           </div>
         </div>
         <details className="group relative z-30">

--- a/packages/gui/src/renderer/components/runtime/AgentCard.tsx
+++ b/packages/gui/src/renderer/components/runtime/AgentCard.tsx
@@ -5,6 +5,7 @@ import { runtimeTypeMatchesKind } from "../../../../../daemon/src/agent-runtime-
 import type { AgentEntityDetail, AgentEntityRow, AgentSkillRow, SquadEntityRow } from "../../agent-entity-client.ts";
 import { t } from "../../i18n/index.tsx";
 import { EntityRefLink } from "../EntityRefLink.tsx";
+import { ViewInGraphButton } from "../ViewInGraphButton.tsx";
 import {
   AddChip,
   Avatar,
@@ -77,6 +78,8 @@ type Props = {
   readonly onSelectSquad: (squadId: string) => void;
   readonly onSelectRuntime: (instanceId: string) => void;
   readonly onSelectAgent: (agentId: string) => void;
+  /** 统一「在关系图中查看」入口(task_89d324b5);缺省不渲染。 */
+  readonly onFocusGraph?: (ref: string) => void;
 };
 export function AgentCard({
   detail,
@@ -91,6 +94,7 @@ export function AgentCard({
   onSelectSquad,
   onSelectRuntime,
   onSelectAgent,
+  onFocusGraph,
 }: Props) {
   const [draft, setDraft] = useState<AgentDraft>(() => agentDraftFrom(detail)),
     [runtimeListOpen, setRuntimeListOpen] = useState(false),
@@ -127,6 +131,13 @@ export function AgentCard({
           onNavigate={() => onSelectAgent(detail.id)}
           title={detail.id}
           className="font-mono text-text-muted hover:text-accent hover:underline"
+        />
+        {/* 统一「在关系图中查看」入口(task_89d324b5):agent 是图节点 kind。 */}
+        <ViewInGraphButton
+          entityRef={`agent/${detail.id}`}
+          onFocusGraph={onFocusGraph}
+          testId="agent-view-in-graph"
+          className="ml-auto flex shrink-0 items-center gap-1 rounded border border-border px-2 py-1 text-[11px] text-text-muted hover:border-border-strong hover:text-text"
         />
       </Crumbs>
       <Card>

--- a/packages/gui/src/renderer/components/runtime/AgentCard.tsx
+++ b/packages/gui/src/renderer/components/runtime/AgentCard.tsx
@@ -137,7 +137,10 @@ export function AgentCard({
           entityRef={`agent/${detail.id}`}
           onFocusGraph={onFocusGraph}
           testId="agent-view-in-graph"
-          className="ml-auto flex shrink-0 items-center gap-1 rounded border border-border px-2 py-1 text-[11px] text-text-muted hover:border-border-strong hover:text-text"
+          className={
+            "ml-auto flex shrink-0 items-center gap-1 rounded border border-border px-2 py-1 text-[11px] " +
+            "text-text-muted hover:border-border-strong hover:text-text"
+          }
         />
       </Crumbs>
       <Card>

--- a/packages/gui/src/renderer/components/taskDetail/TaskFilesTab.tsx
+++ b/packages/gui/src/renderer/components/taskDetail/TaskFilesTab.tsx
@@ -67,7 +67,16 @@ export function TaskDocumentSidebar(props: TaskDocumentSidebarProps) {
   );
 }
 
-export function TaskFilesTab({ task, activeDoc }: { readonly task: TaskRow; readonly activeDoc: string }) {
+export function TaskFilesTab({
+  task,
+  activeDoc,
+  onOpenDoc,
+}: {
+  readonly task: TaskRow;
+  readonly activeDoc: string;
+  /** 包内相对链接的导航出口(task_89d324b5):正文里点 `artifacts/x.md` 直接切到该文件。 */
+  readonly onOpenDoc?: (path: string) => void;
+}) {
   return (
     <section className="min-w-0" data-testid="task-files-tab">
       <div className="mb-4 flex flex-wrap items-center gap-1.5 border-b border-border pb-3">
@@ -75,7 +84,13 @@ export function TaskFilesTab({ task, activeDoc }: { readonly task: TaskRow; read
         <CaretRight weight="bold" className="text-[10px] text-text-faint" />
         <span className="font-mono text-[11px] text-text-muted">{activeDoc || "未选择文件"}</span>
       </div>
-      <TaskFileBody repoId={task.projectId} taskId={task.taskId} path={activeDoc || null} />
+      <TaskFileBody
+        repoId={task.projectId}
+        taskId={task.taskId}
+        path={activeDoc || null}
+        packagePath={task.packagePath ?? null}
+        onOpenDoc={onOpenDoc}
+      />
     </section>
   );
 }
@@ -84,9 +99,12 @@ interface TaskFileBodyProps {
   readonly repoId: string;
   readonly taskId: string;
   readonly path: string | null;
+  /** 台账上的任务包路径(`tasks/<pkg>`);相对链接据此落回包内。 */
+  readonly packagePath: string | null;
+  readonly onOpenDoc?: (path: string) => void;
 }
 
-function TaskFileBody({ repoId, taskId, path }: TaskFileBodyProps) {
+function TaskFileBody({ repoId, taskId, path, packagePath, onOpenDoc }: TaskFileBodyProps) {
   const document = useTaskDocumentQuery(repoId, taskId, path);
   if (!path) return <FileEmpty text="先从左侧选择一个任务包文件。" />;
   if (document.isPending) return <FileEmpty text="正在读取文档投影…" />;
@@ -101,7 +119,11 @@ function TaskFileBody({ repoId, taskId, path }: TaskFileBodyProps) {
   const content = isHtmlDocument(path) ? (
     <HtmlArtifactPreview content={body} path={path} />
   ) : (
-    <DocReader content={body} />
+    <DocReader
+      content={body}
+      packageBasePath={packagePath !== null && path !== null ? `${packagePath}/${path}` : null}
+      onOpenPackageDoc={onOpenDoc}
+    />
   );
   return (
     <>

--- a/packages/gui/src/renderer/i18n/locales/en-US/components.json
+++ b/packages/gui/src/renderer/i18n/locales/en-US/components.json
@@ -59,7 +59,6 @@
   "components.factInspector.confidenceValue": "confidence {confidence}",
   "components.factInspector.dangerousLiaisons": "Hazardous relations",
   "components.factInspector.danglingFactReference": "dangling fact reference",
-  "components.factInspector.focusFactDiagram": "Focus this fact in the graph",
   "components.factInspector.hostTaskNotProjectedByCurrentTask": "The host task is not projected by the current task",
   "components.factInspector.inv6WillDetectAnchorNotPresent": "INV-6 will detect that this anchor is not present in the real projection. The GUI only renders alerts and does not create or repair facts.",
   "components.factInspector.jumpDecision": "Jump to this decision",
@@ -217,5 +216,19 @@
   "components.appSidebar.healthLedgerChange": "last ledger change",
   "components.appSidebar.healthNever": "no ledger change observed this session",
   "components.appSidebar.goSystem": "System",
-  "components.appSidebar.goSystemTitle": "Open the system panel (daemon status and repo table); hover for the four runtime-health signals"
+  "components.appSidebar.goSystemTitle": "Open the system panel (daemon status and repo table); hover for the four runtime-health signals",
+  "components.viewInGraph.view": "View in relation graph",
+  "components.localDoc.title": "Local document",
+  "components.localDoc.loading": "Reading the local document…",
+  "components.localDoc.close": "Close",
+  "components.localDoc.sizeBytes": "{count} bytes",
+  "components.localDoc.webLinkTitle": "External web links do not open inside the GUI",
+  "components.localDoc.inertLinkTitle": "This link form cannot be opened in the GUI",
+  "components.localDoc.errorNotFound": "File not found: {path}",
+  "components.localDoc.errorNotARegularFile": "Not a regular file (directory or special file): {path}",
+  "components.localDoc.errorNotReadable": "Not readable (permission denied or read failed): {path}",
+  "components.localDoc.errorBinaryFile": "The file is not text and cannot be read in the GUI: {path}",
+  "components.localDoc.errorTooLarge": "The file exceeds the in-app reader limit (2 MiB): {path}",
+  "components.localDoc.errorRequestRejected": "Request rejected: {message}",
+  "components.localDoc.errorBridgeUnavailable": "The local document bridge is unavailable (requires the Electron shell)."
 }

--- a/packages/gui/src/renderer/i18n/locales/en-US/views.json
+++ b/packages/gui/src/renderer/i18n/locales/en-US/views.json
@@ -10,7 +10,6 @@
   "views.decisionDetailView.consents": "Judgment consents",
   "views.decisionDetailView.consentsEmpty": "No judgment consent yet (proposed decisions have none).",
   "views.decisionDetailView.derivedTasks": "Derived tasks",
-  "views.decisionDetailView.focusGraph": "Focus in relation graph",
   "views.decisionDetailView.fulfillment": "fulfillment",
   "views.decisionDetailView.identity": "Identity",
   "views.decisionDetailView.identityActors": "PROPOSED / ARBITER",

--- a/packages/gui/src/renderer/i18n/locales/zh-CN/components.json
+++ b/packages/gui/src/renderer/i18n/locales/zh-CN/components.json
@@ -59,7 +59,6 @@
   "components.factInspector.confidenceValue": "置信度 {confidence}",
   "components.factInspector.dangerousLiaisons": "危险关系",
   "components.factInspector.danglingFactReference": "悬空 fact 引用",
-  "components.factInspector.focusFactDiagram": "在关系图中聚焦此 fact",
   "components.factInspector.hostTaskNotProjectedByCurrentTask": "宿主 task 不在当前 task 投影",
   "components.factInspector.inv6WillDetectAnchorNotPresent": "INV-6 会在真实投影中检出该锚不存在。GUI 只渲染告警，不创建或修复 fact。",
   "components.factInspector.jumpDecision": "跳转到该 decision",
@@ -217,5 +216,19 @@
   "components.appSidebar.healthLedgerChange": "最新台账变化",
   "components.appSidebar.healthNever": "本会话未观察到台账变化",
   "components.appSidebar.goSystem": "系统页",
-  "components.appSidebar.goSystemTitle": "打开系统面板（守护进程状态与仓库表）；悬浮可见运行健康四路信号"
+  "components.appSidebar.goSystemTitle": "打开系统面板（守护进程状态与仓库表）；悬浮可见运行健康四路信号",
+  "components.viewInGraph.view": "在关系图中查看",
+  "components.localDoc.title": "本机文档",
+  "components.localDoc.loading": "正在读取本机文档…",
+  "components.localDoc.close": "关闭",
+  "components.localDoc.sizeBytes": "{count} 字节",
+  "components.localDoc.webLinkTitle": "外部网页链接在 GUI 内不打开",
+  "components.localDoc.inertLinkTitle": "此链接形式在 GUI 内不支持打开",
+  "components.localDoc.errorNotFound": "文件不存在:{path}",
+  "components.localDoc.errorNotARegularFile": "不是常规文件(目录或特殊文件):{path}",
+  "components.localDoc.errorNotReadable": "没有读取权限或读取失败:{path}",
+  "components.localDoc.errorBinaryFile": "文件不是文本,无法在 GUI 内阅读:{path}",
+  "components.localDoc.errorTooLarge": "文件超过 GUI 内阅读上限(2 MiB):{path}",
+  "components.localDoc.errorRequestRejected": "请求被拒绝:{message}",
+  "components.localDoc.errorBridgeUnavailable": "本机文档读取通道不可用(需要 Electron 壳)。"
 }

--- a/packages/gui/src/renderer/i18n/locales/zh-CN/views.json
+++ b/packages/gui/src/renderer/i18n/locales/zh-CN/views.json
@@ -10,7 +10,6 @@
   "views.decisionDetailView.consents": "裁决 consent",
   "views.decisionDetailView.consentsEmpty": "尚无裁决 consent(proposed 状态没有)。",
   "views.decisionDetailView.derivedTasks": "派生 task",
-  "views.decisionDetailView.focusGraph": "在关系图聚焦",
   "views.decisionDetailView.fulfillment": "履约",
   "views.decisionDetailView.identity": "身份信息",
   "views.decisionDetailView.identityActors": "提议 / 裁决",

--- a/packages/gui/src/renderer/local-doc/LocalDocLayer.tsx
+++ b/packages/gui/src/renderer/local-doc/LocalDocLayer.tsx
@@ -1,0 +1,145 @@
+import { useCallback, useEffect, useMemo, useState, type ReactNode } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { FileText, X } from "@phosphor-icons/react";
+import { DocReader } from "../components/DocReader.tsx";
+import { t } from "../i18n/index.tsx";
+import { readLocalDocument } from "./local-doc-client.ts";
+import { LocalDocContext, type LocalDocOpener } from "./local-doc-context.ts";
+
+/**
+ * 本机文档浮层(task_89d324b5):详情页 Markdown 里的项目外本机文件链接在 GUI 内
+ * 打开阅读的唯一宿主。挂在 App 根部(LocalDocContext.Provider + 一次浮层),Markdown
+ * 锚点经 context 交路径过来;读取走只读桥,失败按 typed code 出页内错误态 —— 不白屏、
+ * 不弹系统对话框。Markdown 文件复用 DocReader(同一渲染面、同一阅读工具条),其它
+ * 文本按纯文本呈现。
+ */
+export function LocalDocLayer({ children }: { readonly children: ReactNode }) {
+  const [activePath, setActivePath] = useState<string | null>(null);
+  const openLocalDocument = useCallback((path: string) => setActivePath(path), []);
+  const value = useMemo<LocalDocOpener>(() => ({ openLocalDocument }), [openLocalDocument]);
+  return (
+    <LocalDocContext.Provider value={value}>
+      {children}
+      {activePath !== null && <LocalDocOverlay path={activePath} onClose={() => setActivePath(null)} />}
+    </LocalDocContext.Provider>
+  );
+}
+
+function LocalDocOverlay({ path, onClose }: { readonly path: string; readonly onClose: () => void }) {
+  useEffect(() => {
+    const handler = (event: globalThis.KeyboardEvent) => {
+      if (event.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [onClose]);
+  const query = useQuery({
+    queryKey: ["local-doc", path],
+    queryFn: () => readLocalDocument(path),
+    retry: false,
+    staleTime: 5_000,
+  });
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-bg/70 p-4 sm:p-8"
+      data-testid="local-doc-overlay"
+      onClick={onClose}
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label={t("components.localDoc.title")}
+        className="flex h-full w-full max-w-4xl flex-col overflow-hidden rounded-lg border border-border-strong bg-bg shadow-2xl"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <header className="flex shrink-0 items-center gap-2 border-b border-border bg-surface px-3 py-2">
+          <FileText weight="duotone" className="shrink-0 text-text-muted" />
+          <span className="shrink-0 font-mono text-[11px] font-semibold uppercase tracking-[0.16em] text-text-faint">
+            {t("components.localDoc.title")}
+          </span>
+          <span
+            className="min-w-0 flex-1 truncate font-mono text-[11px] text-text-muted"
+            data-testid="local-doc-path"
+            title={path}
+          >
+            {query.data?.ok === true ? query.data.path : path}
+          </span>
+          {query.data?.ok === true && (
+            <span className="shrink-0 font-mono text-[10px] text-text-faint">
+              {t("components.localDoc.sizeBytes", { count: query.data.sizeBytes })}
+            </span>
+          )}
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label={t("components.localDoc.close")}
+            data-testid="local-doc-close"
+            className="grid size-6 shrink-0 place-items-center rounded text-text-faint hover:bg-surface-raised hover:text-text"
+          >
+            <X weight="bold" />
+          </button>
+        </header>
+        <div className="min-h-0 flex-1 overflow-y-auto p-3 sm:p-4">
+          {query.isPending ? (
+            <p data-testid="local-doc-loading" className="font-mono text-[12px] text-text-faint">
+              {t("components.localDoc.loading")}
+            </p>
+          ) : query.data === undefined || !query.data.ok ? (
+            // 读取永不抛错(客户端把一切失败折叠成 typed 结果),这里只剩 typed 错误态;
+            // data 意外缺席时同样按错误面兜住,不把空白/异常留给用户。
+            query.data === undefined ? (
+              <LocalDocError
+                result={{ ok: false, code: "bridge_unavailable", path, message: "Local document read did not settle." }}
+              />
+            ) : (
+              <LocalDocError result={query.data} />
+            )
+          ) : isMarkdownPath(path) ? (
+            <DocReader content={query.data.content} />
+          ) : (
+            <pre
+              data-testid="local-doc-plain"
+              className="whitespace-pre-wrap break-words rounded-md border border-border bg-surface p-4 font-mono text-[12px] leading-5 text-text"
+            >
+              {query.data.content}
+            </pre>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function LocalDocError({
+  result,
+}: {
+  readonly result: { readonly ok: false; readonly code: string; readonly path: string; readonly message: string };
+}) {
+  const message =
+    result.code === "not_found"
+      ? t("components.localDoc.errorNotFound", { path: result.path })
+      : result.code === "not_a_regular_file"
+        ? t("components.localDoc.errorNotARegularFile", { path: result.path })
+        : result.code === "not_readable"
+          ? t("components.localDoc.errorNotReadable", { path: result.path })
+          : result.code === "binary_file"
+            ? t("components.localDoc.errorBinaryFile", { path: result.path })
+            : result.code === "too_large"
+              ? t("components.localDoc.errorTooLarge", { path: result.path })
+              : result.code === "bridge_unavailable"
+                ? t("components.localDoc.errorBridgeUnavailable")
+                : t("components.localDoc.errorRequestRejected", { message: result.message });
+  return (
+    <div
+      data-testid={`local-doc-error-${result.code}`}
+      className="rounded-md border border-danger/40 bg-danger/5 px-4 py-3"
+    >
+      <p className="text-[12px] font-medium text-danger">{message}</p>
+      <p className="mt-1 break-all font-mono text-[10px] text-text-faint">{result.path}</p>
+    </div>
+  );
+}
+
+function isMarkdownPath(path: string): boolean {
+  return /\.(?:md|markdown)$/iu.test(path);
+}

--- a/packages/gui/src/renderer/local-doc/LocalDocLayer.tsx
+++ b/packages/gui/src/renderer/local-doc/LocalDocLayer.tsx
@@ -3,7 +3,7 @@ import { useQuery } from "@tanstack/react-query";
 import { FileText, X } from "@phosphor-icons/react";
 import { DocReader } from "../components/DocReader.tsx";
 import { t } from "../i18n/index.tsx";
-import { readLocalDocument } from "./local-doc-client.ts";
+import { requestLocalDocument } from "./local-doc-client.ts";
 import { LocalDocContext, type LocalDocOpener } from "./local-doc-context.ts";
 
 /**
@@ -35,7 +35,7 @@ function LocalDocOverlay({ path, onClose }: { readonly path: string; readonly on
   }, [onClose]);
   const query = useQuery({
     queryKey: ["local-doc", path],
-    queryFn: () => readLocalDocument(path),
+    queryFn: () => requestLocalDocument(path),
     retry: false,
     staleTime: 5_000,
   });
@@ -49,7 +49,10 @@ function LocalDocOverlay({ path, onClose }: { readonly path: string; readonly on
         role="dialog"
         aria-modal="true"
         aria-label={t("components.localDoc.title")}
-        className="flex h-full w-full max-w-4xl flex-col overflow-hidden rounded-lg border border-border-strong bg-bg shadow-2xl"
+        className={
+          "flex h-full w-full max-w-4xl flex-col overflow-hidden rounded-lg border border-border-strong " +
+          "bg-bg shadow-2xl"
+        }
         onClick={(event) => event.stopPropagation()}
       >
         <header className="flex shrink-0 items-center gap-2 border-b border-border bg-surface px-3 py-2">
@@ -74,7 +77,10 @@ function LocalDocOverlay({ path, onClose }: { readonly path: string; readonly on
             onClick={onClose}
             aria-label={t("components.localDoc.close")}
             data-testid="local-doc-close"
-            className="grid size-6 shrink-0 place-items-center rounded text-text-faint hover:bg-surface-raised hover:text-text"
+            className={
+              "grid size-6 shrink-0 place-items-center rounded text-text-faint " +
+              "hover:bg-surface-raised hover:text-text"
+            }
           >
             <X weight="bold" />
           </button>
@@ -99,7 +105,10 @@ function LocalDocOverlay({ path, onClose }: { readonly path: string; readonly on
           ) : (
             <pre
               data-testid="local-doc-plain"
-              className="whitespace-pre-wrap break-words rounded-md border border-border bg-surface p-4 font-mono text-[12px] leading-5 text-text"
+              className={
+                "whitespace-pre-wrap break-words rounded-md border border-border bg-surface p-4 " +
+                "font-mono text-[12px] leading-5 text-text"
+              }
             >
               {query.data.content}
             </pre>

--- a/packages/gui/src/renderer/local-doc/MarkdownAnchor.tsx
+++ b/packages/gui/src/renderer/local-doc/MarkdownAnchor.tsx
@@ -1,0 +1,52 @@
+import type { AnchorHTMLAttributes, MouseEvent, ReactNode } from "react";
+import { classifyMarkdownHref } from "./markdown-links.ts";
+import { useLocalDocOpener } from "./local-doc-context.ts";
+import { t } from "../i18n/index.tsx";
+
+/**
+ * Markdown 渲染的统一锚点(task_89d324b5):react-markdown 的 `a` 组件覆盖,
+ * DocReader 与 Decision 正文共用一份。
+ *
+ * 根修就在这一行 `event.preventDefault()`:渲染层的 Markdown 锚点永远不做文档导航。
+ * 此前绝对路径链接(`/Users/…`)在 dev 壳里解析到 dev origin 之下,点击把窗口带离
+ * 应用、落在 dev server 404 上(整页白屏);打包态则被壳拒成死链接。现在点击按
+ * classifyMarkdownHref 归类:本机文件 → 本机文档浮层;包内相对路径 → 宿主提供的
+ * 包内文档导航;网页/其它 → 不打开,给出可读的 tooltip 说明。
+ */
+export interface MarkdownAnchorProps extends AnchorHTMLAttributes<HTMLAnchorElement> {
+  readonly children?: ReactNode;
+  /** react-markdown 传入的 AST 节点;显式摘掉,不泄漏到 DOM。 */
+  readonly node?: unknown;
+  /** 当前文档在任务包内的 repo 相对路径;提供时相对链接才有包内落点。 */
+  readonly packageBasePath?: string | null;
+  /** 包内文档导航出口(收到归一化后的 repo 相对路径)。 */
+  readonly onOpenPackageDoc?: (repoRelativePath: string) => void;
+}
+
+export function MarkdownAnchor({
+  href,
+  children,
+  node: _node,
+  packageBasePath,
+  onOpenPackageDoc,
+  ...rest
+}: MarkdownAnchorProps) {
+  const opener = useLocalDocOpener();
+  const target = classifyMarkdownHref(href ?? "", { packageBasePath: packageBasePath ?? null });
+  const title =
+    target.kind === "web"
+      ? t("components.localDoc.webLinkTitle")
+      : target.kind === "inert"
+        ? t("components.localDoc.inertLinkTitle")
+        : target.path;
+  const handleClick = (event: MouseEvent<HTMLAnchorElement>) => {
+    event.preventDefault();
+    if (target.kind === "local-file") opener.openLocalDocument(target.path);
+    else if (target.kind === "package-doc") onOpenPackageDoc?.(target.path);
+  };
+  return (
+    <a {...rest} href={href} title={title} onClick={handleClick} data-markdown-link={target.kind}>
+      {children}
+    </a>
+  );
+}

--- a/packages/gui/src/renderer/local-doc/local-doc-client.ts
+++ b/packages/gui/src/renderer/local-doc/local-doc-client.ts
@@ -16,7 +16,7 @@ const bridge = (): LocalDocBridge | null => {
   return value?.localDoc ?? null;
 };
 
-export async function readLocalDocument(path: string): Promise<LocalDocReadResult> {
+export async function requestLocalDocument(path: string): Promise<LocalDocReadResult> {
   const channel = bridge();
   if (channel === null)
     return {

--- a/packages/gui/src/renderer/local-doc/local-doc-client.ts
+++ b/packages/gui/src/renderer/local-doc/local-doc-client.ts
@@ -1,0 +1,60 @@
+import type { LocalDocReadErrorCode, LocalDocReadResult } from "../../api/local-doc-contract.ts";
+import { isRendererRecord } from "../result-validation.ts";
+
+/**
+ * renderer 侧「GUI 内读本机文档」客户端:把链接里的路径交给 preload 通道
+ * (`harness:localDoc:read`),主进程只读解析与读取(main/local-doc-ipc.ts)。
+ * 读取失败以 typed `{ok:false, code}` 回来,视图按 code 出页内错误态;
+ * 桥不可用 / 主进程拒单同样折叠成 typed 失败,绝不把异常抛进渲染层。
+ */
+type LocalDocBridge = {
+  readonly read: (input: { readonly path: string }) => Promise<unknown>;
+};
+
+const bridge = (): LocalDocBridge | null => {
+  const value = window.harness as unknown as { readonly localDoc?: LocalDocBridge } | undefined;
+  return value?.localDoc ?? null;
+};
+
+export async function readLocalDocument(path: string): Promise<LocalDocReadResult> {
+  const channel = bridge();
+  if (channel === null)
+    return {
+      ok: false,
+      code: "bridge_unavailable",
+      path,
+      message: "Local document bridge is unavailable.",
+    };
+  try {
+    const value = await channel.read({ path });
+    if (isRendererRecord(value)) {
+      if (
+        value.ok === true &&
+        typeof value.path === "string" &&
+        typeof value.content === "string" &&
+        typeof value.sizeBytes === "number"
+      )
+        return { ok: true, path: value.path, content: value.content, sizeBytes: value.sizeBytes };
+      if (
+        value.ok === false &&
+        typeof value.code === "string" &&
+        typeof value.path === "string" &&
+        typeof value.message === "string"
+      )
+        return { ok: false, code: value.code as LocalDocReadErrorCode, path: value.path, message: value.message };
+    }
+    return {
+      ok: false,
+      code: "request_rejected",
+      path,
+      message: "Local document read returned an unexpected shape.",
+    };
+  } catch (cause) {
+    return {
+      ok: false,
+      code: "request_rejected",
+      path,
+      message: cause instanceof Error ? cause.message : String(cause),
+    };
+  }
+}

--- a/packages/gui/src/renderer/local-doc/local-doc-context.ts
+++ b/packages/gui/src/renderer/local-doc/local-doc-context.ts
@@ -1,0 +1,19 @@
+import { createContext, useContext } from "react";
+
+/**
+ * 「GUI 内读本机文档」的打开入口上下文(task_89d324b5)。
+ *
+ * Markdown 锚点组件(MarkdownAnchor)与本机文档浮层(LocalDocLayer)之间唯一的耦合面:
+ * 锚点把 local-file 路径交给 openLocalDocument,浮层负责读取与展示。context 单独成
+ * 模块是为了不引入 DocReader → 浮层 → DocReader 的模块环(浮层复用 DocReader 渲染)。
+ * 缺省值是 no-op:宿主没挂 LocalDocLayer 时链接不炸,只是不开浮层(单测可不包 provider)。
+ */
+export interface LocalDocOpener {
+  readonly openLocalDocument: (path: string) => void;
+}
+
+export const LocalDocContext = createContext<LocalDocOpener>({ openLocalDocument: () => {} });
+
+export function useLocalDocOpener(): LocalDocOpener {
+  return useContext(LocalDocContext);
+}

--- a/packages/gui/src/renderer/local-doc/markdown-links.ts
+++ b/packages/gui/src/renderer/local-doc/markdown-links.ts
@@ -1,0 +1,93 @@
+import { consumeKnownError } from "../../api/error-consumption.ts";
+
+/**
+ * 详情页 Markdown 链接的纯函数判定(task_89d324b5)。
+ *
+ * 根修的前提:渲染层的 Markdown 锚点永远不做文档导航。此前没有任何拦截:绝对路径链接(`/Users/…`)在 dev 壳里解析到 dev origin
+ * 之下后直接把窗口带离应用(落在 dev server 404 上 = 白屏),打包态则被壳拒绝成死链接。这里把每个 href 归到四类去处:
+ *   local-file   → 本机文件读取通道(项目外绝对路径/`~`/`file://`)；
+ *   package-doc  → 任务包内相对路径(宿主提供当前文档路径时归一化后走包内文档导航)；
+ *   web/inert    → 不打开(GUI 不内嵌浏览器，也不新开外部窗口)。
+ */
+
+export type MarkdownLinkTarget =
+  | { readonly kind: "local-file"; readonly path: string }
+  | { readonly kind: "package-doc"; readonly path: string }
+  | { readonly kind: "web"; readonly href: string }
+  | { readonly kind: "inert"; readonly href: string };
+
+export interface MarkdownLinkContext {
+  /** 当前 Markdown 文档在任务包内的 repo 相对路径;提供时相对链接才有包内落点。 */
+  readonly packageBasePath?: string | null;
+}
+
+const WEB_SCHEMES = /^(?:https?|irc|ircs|mailto|xmpp|tel):/iu;
+const SCHEME = /^[a-zA-Z][a-zA-Z0-9+.-]*:/u;
+const WINDOWS_ABSOLUTE = /^[a-zA-Z]:[\\/]/u;
+
+/** href → 目标归类;空 href、锥子、未知 scheme 一律 inert(不导航、不报错)。 */
+export function classifyMarkdownHref(href: string, context: MarkdownLinkContext = {}): MarkdownLinkTarget {
+  const trimmed = href.trim();
+  if (trimmed.length === 0 || trimmed.startsWith("#")) return { kind: "inert", href: trimmed };
+  if (WEB_SCHEMES.test(trimmed)) return { kind: "web", href: trimmed };
+  if (/^file:\/\//iu.test(trimmed)) {
+    const path = fileUrlToPathString(trimmed);
+    return path === null ? { kind: "inert", href: trimmed } : { kind: "local-file", path };
+  }
+  if (SCHEME.test(trimmed)) return { kind: "inert", href: trimmed };
+  if (trimmed.startsWith("/") || trimmed.startsWith("~/") || trimmed === "~" || WINDOWS_ABSOLUTE.test(trimmed))
+    return { kind: "local-file", path: trimmed };
+  const resolved = resolveRepoDocPath(context.packageBasePath ?? null, trimmed);
+  return resolved === null ? { kind: "inert", href: trimmed } : { kind: "package-doc", path: resolved };
+}
+
+/** `file:///a/b%20c` → `/a/b c`;带非 localhost 主机的 file URL 不接受。 */
+export function fileUrlToPathString(url: string): string | null {
+  try {
+    const parsed = new URL(url);
+    if (parsed.protocol !== "file:") return null;
+    if (parsed.host !== "" && parsed.host !== "localhost") return null;
+    return decodeURIComponent(parsed.pathname);
+  } catch (cause) {
+    // URL 解析失败 = 非法 file 链接,按 inert 处理;异常本身是已知形态,消费掉。
+    consumeKnownError(cause);
+    return null;
+  }
+}
+
+/**
+ * 包内相对路径归一化:`tasks/pkg/task_plan.md` 基座 + `artifacts/x.md` → `tasks/pkg/artifacts/x.md`。
+ * `..` 越出包根、或没有基座时返回 null(链接保持 inert,不发起注定要失败的读取)。
+ */
+export function resolveRepoDocPath(packageBasePath: string | null, href: string): string | null {
+  if (packageBasePath === null || packageBasePath.length === 0) return null;
+  const segments = packageBasePath.split("/").slice(0, -1);
+  // 包根 = `tasks/<pkg>`(daemon 台账的 packagePath 口径)。`..` 只能在包内消化:
+  // 越出包根的链接指向包外文件,归一化若继续走会把「包外的 ../../x.md」静默改写成
+  // 「包内的 x.md」——打开另一个文件。宁可 null(链接 inert)。
+  const floor = segments[0] === "tasks" && segments.length >= 2 ? 2 : 0;
+  for (const segment of href.split("/")) {
+    if (segment.length === 0 || segment === ".") continue;
+    if (segment === "..") {
+      if (segments.length <= floor) return null;
+      segments.pop();
+      continue;
+    }
+    segments.push(segment);
+  }
+  const resolved = segments.join("/");
+  return resolved.length === 0 ? null : resolved;
+}
+
+/**
+ * react-markdown 的 urlTransform:默认白名单(http/https/irc/ircs/mailto/xmpp + 相对引用)
+ * 之外额外放行 `file://`。锚点不会真的导航(MarkdownAnchor 拦截后转本机读取),
+ * `javascript:`/`data:` 等仍被清空。
+ */
+export function markdownUrlTransform(url: string): string {
+  const trimmed = url.trim();
+  if (trimmed.length === 0) return "";
+  if (WEB_SCHEMES.test(trimmed) || /^file:\/\//iu.test(trimmed)) return trimmed;
+  if (!SCHEME.test(trimmed)) return trimmed;
+  return "";
+}

--- a/packages/gui/src/renderer/views/AgentSquadView.tsx
+++ b/packages/gui/src/renderer/views/AgentSquadView.tsx
@@ -40,11 +40,14 @@ export function AgentSquadView({
   tasks,
   focusedEntityRef,
   onSelectEntity,
+  onFocusGraph,
 }: {
   readonly repoId: string;
   readonly tasks: readonly DispatchDialogTaskOption[];
   readonly focusedEntityRef: string | null;
   readonly onSelectEntity: (ref: string) => void;
+  /** 统一「在关系图中查看」入口(task_89d324b5);透传给 Agent 详情卡。 */
+  readonly onFocusGraph?: (ref: string) => void;
 }) {
   const refSelection = runtimeSelectionFromRef(focusedEntityRef);
   // inspector 相关会话的检索面:深链选中谁就查谁(agent/squad id 进 daemon 精确
@@ -224,6 +227,7 @@ export function AgentSquadView({
                 onSelectSquad={(squadId) => onSelectEntity(`squad/${squadId}`)}
                 onSelectRuntime={(instanceId) => onSelectEntity(`provider/${instanceId}`)}
                 onSelectAgent={(agentId) => onSelectEntity(`agent/${agentId}`)}
+                onFocusGraph={onFocusGraph}
               />
             ) : (
               <Empty>{t("agentRuntime.loading")}</Empty>

--- a/packages/gui/src/renderer/views/ScheduleDetailView.tsx
+++ b/packages/gui/src/renderer/views/ScheduleDetailView.tsx
@@ -27,6 +27,7 @@ import {
 } from "../components/runtime/parts.tsx";
 import { ScheduleForm } from "../components/ScheduleFormDialog.tsx";
 import { SessionTranscript } from "../components/sessions/SessionTranscript.tsx";
+import { ViewInGraphButton } from "../components/ViewInGraphButton.tsx";
 import { t, type MessageKey } from "../i18n/index.tsx";
 import { formatTime } from "../model/time.ts";
 import {
@@ -200,6 +201,7 @@ export function ScheduleDetailView({
   onSave,
   onDelete,
   onSelectEntity,
+  onFocusGraph,
   onExitRun,
   onExit,
 }: {
@@ -216,6 +218,8 @@ export function ScheduleDetailView({
   readonly onDelete: () => void;
   /** Entity routing for non-session refs (agent/provider). Run sessions stay embedded. */
   readonly onSelectEntity: (ref: string) => void;
+  /** 统一「在关系图中查看」入口(task_89d324b5);缺省不渲染。 */
+  readonly onFocusGraph?: (ref: string) => void;
   /** Leave the embedded run detail back to the hub's Runs tab (location patch, no push). */
   readonly onExitRun: () => void;
   /** Back to the schedules list. */
@@ -311,6 +315,8 @@ export function ScheduleDetailView({
               <PencilSimple weight="bold" />
               {t("schedules.action.edit")}
             </Btn>
+            {/* 统一「在关系图中查看」入口(task_89d324b5):schedule 是图节点 kind。 */}
+            <ViewInGraphButton entityRef={`schedule/${row.scheduleId}`} onFocusGraph={onFocusGraph} />
           </div>
         )}
       </div>

--- a/packages/gui/src/renderer/views/SchedulesView.tsx
+++ b/packages/gui/src/renderer/views/SchedulesView.tsx
@@ -65,6 +65,7 @@ export function SchedulesView({
   focusedEntityRef,
   onSelectEntity,
   onFocusSchedule,
+  onFocusGraph,
 }: {
   readonly repoId: string;
   readonly focusedEntityRef: string | null;
@@ -72,6 +73,8 @@ export function SchedulesView({
   readonly onSelectEntity: (ref: string) => void;
   /** In-page schedule location (schedule/<id> and back to null), patched in place. */
   readonly onFocusSchedule: (ref: string | null) => void;
+  /** 统一「在关系图中查看」入口(task_89d324b5);缺省不渲染。 */
+  readonly onFocusGraph?: (ref: string) => void;
 }) {
   const query = useQuery({
     queryKey: ["schedules", repoId],
@@ -108,6 +111,7 @@ export function SchedulesView({
         focusedEntityRef={focusedEntityRef}
         onSelectEntity={onSelectEntity}
         onFocusSchedule={onFocusSchedule}
+        onFocusGraph={onFocusGraph}
       />
     </section>
   );
@@ -120,6 +124,7 @@ export function ScheduleWorkspace({
   focusedEntityRef,
   onSelectEntity,
   onFocusSchedule,
+  onFocusGraph,
   onMutated,
 }: {
   readonly repoId: string;
@@ -128,6 +133,8 @@ export function ScheduleWorkspace({
   readonly focusedEntityRef: string | null;
   readonly onSelectEntity: (ref: string) => void;
   readonly onFocusSchedule: (ref: string | null) => void;
+  /** 统一「在关系图中查看」入口(task_89d324b5);透传给详情 hub。 */
+  readonly onFocusGraph?: (ref: string) => void;
   readonly onMutated?: () => void;
 }) {
   const queryClient = useQueryClient();
@@ -225,6 +232,7 @@ export function ScheduleWorkspace({
           onSave={(input) => void saveDefinition(input)}
           onDelete={() => void deleteSchedule(selected)}
           onSelectEntity={onSelectEntity}
+          onFocusGraph={onFocusGraph}
           onExitRun={() => onFocusSchedule(scheduleRef(selected.scheduleId))}
           onExit={() => onFocusSchedule(null)}
         />

--- a/packages/gui/src/renderer/views/TaskDetailView.tsx
+++ b/packages/gui/src/renderer/views/TaskDetailView.tsx
@@ -13,6 +13,7 @@ import {
 import type { GuiSubmissionV1 } from "../../api/renderer-dto.ts";
 import { EngineBadge, FreshnessTag, StatusBadge } from "../components/badges.tsx";
 import { EntityRefLink } from "../components/EntityRefLink.tsx";
+import { ViewInGraphButton } from "../components/ViewInGraphButton.tsx";
 import {
   TaskCloseoutTab,
   TaskDispatchTab,
@@ -56,6 +57,7 @@ export function TaskDetailView({
   onProgress,
   onSubmit,
   onSetPin,
+  onFocusGraph,
 }: {
   task: TaskRow;
   onBack: () => void;
@@ -77,6 +79,8 @@ export function TaskDetailView({
   onSubmit?: (submission: GuiSubmissionV1) => Promise<unknown>;
   /** 台账 pin 写通道(`ha task pin` 同一动作);缺省时只显示 📌 状态。 */
   onSetPin?: (task: TaskRow, pinned: boolean) => void;
+  /** 统一「在关系图中查看」入口(task_89d324b5);缺省不渲染。 */
+  onFocusGraph?: (ref: string) => void;
 }) {
   const [activeTab, setActiveTab] = useState<TaskDetailTab>("overview");
   const [activeDoc, setActiveDoc] = useState("task_plan.md");
@@ -242,6 +246,8 @@ export function TaskDetailView({
             >
               {t("views.taskDetailView.openSessions")} ↗
             </button>
+            {/* 统一「在关系图中查看」入口(task_89d324b5):task 是图节点 kind。 */}
+            <ViewInGraphButton entityRef={`task/${task.taskId}`} onFocusGraph={onFocusGraph} />
           </div>
         </div>
         <div className="flex min-h-0 items-center gap-3 px-3 pb-1.5 lg:px-4">
@@ -342,7 +348,7 @@ export function TaskDetailView({
                 onSubmit={onSubmit}
               />
             ) : (
-              <TaskFilesTab task={task} activeDoc={activeDoc} />
+              <TaskFilesTab task={task} activeDoc={activeDoc} onOpenDoc={openDocument} />
             )}
           </section>
         </div>

--- a/packages/gui/src/renderer/views/genealogy/DecisionDetailPanel.tsx
+++ b/packages/gui/src/renderer/views/genealogy/DecisionDetailPanel.tsx
@@ -1,6 +1,7 @@
-import { X, ArrowsOutSimple, Graph } from "@phosphor-icons/react";
+import { X, ArrowsOutSimple } from "@phosphor-icons/react";
 import type { DecisionRow } from "../../model/types";
 import { DecisionStateBadge, RiskTierBadge, UrgencyBadge } from "../../components/badges";
+import { ViewInGraphButton } from "../../components/ViewInGraphButton.tsx";
 
 /**
  * 决策详情面板(REQ-GUI-05):状态、问题、已选/否决/why-not,
@@ -91,15 +92,12 @@ export function DecisionDetailPanel({
               在决策池查看
             </button>
           )}
-          {onFocusGraph && (
-            <button
-              onClick={() => onFocusGraph(`decision/${decision.decisionId}`)}
-              className="inline-flex items-center gap-1 rounded border border-border px-2 py-1.5 text-[11px] text-text-muted hover:border-border-strong hover:text-text"
-            >
-              <Graph weight="bold" className="text-[11px]" />
-              在关系图聚焦
-            </button>
-          )}
+          <ViewInGraphButton
+            entityRef={`decision/${decision.decisionId}`}
+            onFocusGraph={onFocusGraph}
+            testId="decision-panel-view-in-graph"
+            className="inline-flex items-center gap-1 rounded border border-border px-2 py-1.5 text-[11px] text-text-muted hover:border-border-strong hover:text-text"
+          />
         </div>
       </div>
     </aside>

--- a/packages/gui/test/entity-detail-view.vitest.ts
+++ b/packages/gui/test/entity-detail-view.vitest.ts
@@ -442,7 +442,7 @@ describe("DecisionDetailView", () => {
       poolBtn.click();
     });
     expect(onOpenPool).toHaveBeenCalledWith("dec_1");
-    const graphBtn = [...div.querySelectorAll("button")].find((b) => b.textContent === "在关系图聚焦")!;
+    const graphBtn = [...div.querySelectorAll("button")].find((b) => b.textContent === "在关系图中查看")!;
     await act(async () => {
       graphBtn.click();
     });

--- a/packages/gui/test/local-doc-ipc.test.ts
+++ b/packages/gui/test/local-doc-ipc.test.ts
@@ -1,0 +1,173 @@
+// harness-test-tier: fast
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, realpathSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { LOCAL_DOC_READ_CHANNEL } from "../src/api/local-doc-contract.ts";
+import {
+  classifyLocalDocFsError,
+  expandHomePath,
+  LOCAL_DOC_MAX_BYTES,
+  looksBinary,
+  readLocalDocument,
+  registerLocalDocIpc,
+  validateLocalDocReadInput,
+} from "../src/main/local-doc-ipc.ts";
+
+/**
+ * 「GUI 内读本机文档」的信任边界与只读语义(task_89d324b5):渲染进程只能送
+ * `{path}` 形状;主进程只读解析(realpath → 常规文件 → utf-8),失败 typed 返回。
+ * 负向面(不存在/目录/二进制/超大/符号链接真身展示/请求形状)是主防面。
+ */
+
+const trustedEvent = {
+  sender: { id: 7 },
+  senderFrame: { url: "file:///Applications/Harness/renderer/index.html" },
+};
+const trustedPolicy = {
+  isTrustedWebContentsId: (id: number) => id === 7,
+  rendererUrl: { packagedRendererUrl: trustedEvent.senderFrame.url },
+};
+
+let root: string;
+
+test.before(() => {
+  root = mkdtempSync(path.join(tmpdir(), "local-doc-ipc-"));
+});
+
+test.after(() => {
+  rmSync(root, { recursive: true, force: true });
+});
+
+test("only the local-doc channel is registered, once", () => {
+  const channels: string[] = [];
+  registerLocalDocIpc({ handle: (channel) => channels.push(channel) }, { homeDir: () => "/home" }, trustedPolicy);
+  assert.deepEqual(channels, [LOCAL_DOC_READ_CHANNEL]);
+});
+
+test("an untrusted renderer cannot reach the channel", async () => {
+  let handled: unknown = null;
+  registerLocalDocIpc(
+    { handle: (_channel, listener) => (handled = listener) },
+    { homeDir: () => "/home" },
+    { isTrustedWebContentsId: () => false },
+  );
+  await assert.rejects(
+    () => (handled as (event: unknown, payload: unknown) => Promise<unknown>)(trustedEvent, { path: "/etc/hosts" }),
+    /Rejected IPC message/u,
+  );
+});
+
+test("request shape is closed to {path} with a usable path string", () => {
+  assert.deepEqual(validateLocalDocReadInput({ path: "/Users/ce/notes.md" }), { path: "/Users/ce/notes.md" });
+  assert.deepEqual(validateLocalDocReadInput({ path: "~/notes.md" }), { path: "~/notes.md" });
+  assert.throws(() => validateLocalDocReadInput({ path: "/a", extra: 1 }), /does not accept field extra/u);
+  assert.throws(() => validateLocalDocReadInput({}), /requires a path string/u);
+  assert.throws(() => validateLocalDocReadInput({ path: 7 }), /requires a path string/u);
+  assert.throws(
+    () => validateLocalDocReadInput({ path: "/a" + String.fromCharCode(0) + "b" }),
+    /unsupported characters/u,
+  );
+  if (process.platform !== "win32")
+    assert.throws(
+      () => validateLocalDocReadInput({ path: String.raw`C:\Users\ce\notes.md` }),
+      /unsupported separator/u,
+    );
+});
+
+test("expandHomePath expands only the owner home tilde", () => {
+  assert.equal(expandHomePath("~", "/home/ce"), "/home/ce");
+  assert.equal(expandHomePath("~/notes/a.md", "/home/ce"), path.join("/home/ce", "notes/a.md"));
+  assert.equal(expandHomePath("~colleague/notes.md", "/home/ce"), "~colleague/notes.md");
+  assert.equal(expandHomePath("/etc/hosts", "/home/ce"), "/etc/hosts");
+});
+
+test("fs error codes map to contract codes without message sniffing", () => {
+  assert.equal(classifyLocalDocFsError({ code: "ENOENT" }), "not_found");
+  assert.equal(classifyLocalDocFsError({ code: "ENOTDIR" }), "not_found");
+  assert.equal(classifyLocalDocFsError({ code: "EISDIR" }), "not_a_regular_file");
+  assert.equal(classifyLocalDocFsError({ code: "EACCES" }), "not_readable");
+  assert.equal(classifyLocalDocFsError({ code: "EPERM" }), "not_readable");
+  assert.equal(classifyLocalDocFsError({ code: "EMFILE" }), "not_readable");
+  assert.equal(classifyLocalDocFsError(new Error("no code at all")), "not_readable");
+});
+
+test("binary sniff rejects NUL bytes and replacement-character noise", () => {
+  assert.equal(looksBinary("plain text with words"), false);
+  assert.equal(looksBinary("a" + String.fromCharCode(0) + "b"), true);
+  assert.equal(looksBinary("汉".repeat(100)), false);
+  assert.equal(looksBinary(String.fromCharCode(0xfffd).repeat(600) + "x"), true);
+});
+
+test("reads a readable text file and reports the real absolute path", async () => {
+  writeFileSync(path.join(root, "notes.md"), "# 标题\n\n正文一行。\n", "utf8");
+  // tmpdir 在 macOS 上是 /var → realpath 归到 /private/var;断言也按 realpath 对齐。
+  const file = realpathSync(path.join(root, "notes.md"));
+  const result = await readLocalDocument(file, { homeDir: () => "/home/ce" });
+  assert.deepEqual(result, {
+    ok: true,
+    path: file,
+    content: "# 标题\n\n正文一行。\n",
+    sizeBytes: Buffer.byteLength("# 标题\n\n正文一行。\n", "utf8"),
+  });
+});
+
+test("~ links read through the owner home directory", async () => {
+  const home = path.join(root, "home");
+  mkdirSync(home, { recursive: true });
+  writeFileSync(path.join(home, "todo.txt"), "hello", "utf8");
+  const result = await readLocalDocument("~/todo.txt", { homeDir: () => home });
+  assert.equal(result.ok, true);
+  if (result.ok) assert.equal(result.content, "hello");
+});
+
+test("a symlinked path reports the real target path (no disguised display)", async () => {
+  const realDir = path.join(root, "real-dir");
+  const linkDir = path.join(root, "link-dir");
+  mkdirSync(realDir, { recursive: true });
+  writeFileSync(path.join(realDir, "doc.md"), "real body", "utf8");
+  symlinkSync(realDir, linkDir);
+  const expectedRealDoc = realpathSync(path.join(realDir, "doc.md"));
+  const result = await readLocalDocument(path.join(linkDir, "doc.md"), { homeDir: () => "/home/ce" });
+  assert.equal(result.ok, true);
+  if (result.ok) {
+    assert.equal(result.path, expectedRealDoc);
+    assert.equal(result.content, "real body");
+  }
+});
+
+test("missing files, directories, binary files and oversize files fail typed", async () => {
+  const missing = await readLocalDocument(path.join(root, "nope.md"), { homeDir: () => "/home/ce" });
+  assert.deepEqual({ ok: missing.ok, code: missing.ok ? null : missing.code }, { ok: false, code: "not_found" });
+
+  const directory = await readLocalDocument(root, { homeDir: () => "/home/ce" });
+  assert.deepEqual(
+    { ok: directory.ok, code: directory.ok ? null : directory.code },
+    { ok: false, code: "not_a_regular_file" },
+  );
+
+  const binaryFile = path.join(root, "blob.bin");
+  writeFileSync(binaryFile, Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x00, 0x0d, 0x0a]));
+  const binary = await readLocalDocument(binaryFile, { homeDir: () => "/home/ce" });
+  assert.deepEqual({ ok: binary.ok, code: binary.ok ? null : binary.code }, { ok: false, code: "binary_file" });
+
+  const oversize = path.join(root, "big.txt");
+  writeFileSync(oversize, "x".repeat(65));
+  const tooLarge = await readLocalDocument(oversize, { homeDir: () => "/home/ce", maxBytes: 64 });
+  assert.deepEqual({ ok: tooLarge.ok, code: tooLarge.ok ? null : tooLarge.code }, { ok: false, code: "too_large" });
+  assert.equal(LOCAL_DOC_MAX_BYTES, 2 * 1024 * 1024);
+});
+
+test("relative and non-owner-tilde paths are rejected typed at read time", async () => {
+  const relative = await readLocalDocument("notes.md", { homeDir: () => "/home/ce" });
+  assert.deepEqual(
+    { ok: relative.ok, code: relative.ok ? null : relative.code },
+    { ok: false, code: "request_rejected" },
+  );
+  const foreignTilde = await readLocalDocument("~colleague/notes.md", { homeDir: () => "/home/ce" });
+  assert.deepEqual(
+    { ok: foreignTilde.ok, code: foreignTilde.ok ? null : foreignTilde.code },
+    { ok: false, code: "request_rejected" },
+  );
+});

--- a/packages/gui/test/local-doc-reader.vitest.tsx
+++ b/packages/gui/test/local-doc-reader.vitest.tsx
@@ -1,0 +1,157 @@
+// harness-test-tier: integration
+// @vitest-environment happy-dom
+import { beforeAll, afterEach, describe, expect, it, vi } from "vitest";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { createElement } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { LocalDocLayer } from "../src/renderer/local-doc/LocalDocLayer.tsx";
+import { DocReader } from "../src/renderer/components/DocReader.tsx";
+import { setActiveLocale } from "../src/renderer/i18n/core.ts";
+
+/**
+ * 本机文档浮面(task_89d324b5):详情页 Markdown 的项目外本机文件链接点击后,
+ * 在 GUI 内打开阅读;不可读时按 typed code 出页内错误态 —— 全程不触发文档导航
+ * (锚点 click 被 preventDefault,这是白屏根因的根修验证)。
+ */
+beforeAll(() => {
+  globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+  setActiveLocale("zh-CN");
+});
+afterEach(() => vi.restoreAllMocks());
+
+const mounted: { root: Root; container: HTMLElement }[] = [];
+
+async function renderLocalDocLayer(children: () => React.ReactNode): Promise<HTMLElement> {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  await act(async () => {
+    root.render(createElement(QueryClientProvider, { client }, createElement(LocalDocLayer, null, children())));
+  });
+  mounted.push({ root, container });
+  return container;
+}
+
+async function flush() {
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+}
+
+async function unmountAll() {
+  await act(async () => {
+    for (const { root } of mounted.splice(0)) root.unmount();
+  });
+}
+
+/**
+ * 点击锚点并观察「是否发生了未被拦截的导航式点击」:见证监听挂在 document 的冒泡
+ * 段 —— React 根容器的处理器先跑,preventDefault 之后见证者看到的才是最终状态。
+ */
+async function clickAnchor(anchor: HTMLAnchorElement): Promise<boolean> {
+  let navigated = false;
+  const witness = (event: MouseEvent) => {
+    if (!event.defaultPrevented) navigated = true;
+  };
+  document.addEventListener("click", witness);
+  try {
+    await act(async () => {
+      anchor.click();
+    });
+  } finally {
+    document.removeEventListener("click", witness);
+  }
+  return navigated;
+}
+
+function stubLocalDocBridge(read: (input: { readonly path: string }) => Promise<unknown>) {
+  vi.stubGlobal("window", Object.assign(window, { harness: { localDoc: { read } } }));
+}
+
+const EXTERNAL_DOC = "/Users/ce/Notes/outside-spec.md";
+
+describe("markdown local-file links open in the GUI reader overlay", () => {
+  it("clicks a project-external absolute path link and renders the document body", async () => {
+    const read = vi.fn(async () => ({
+      ok: true,
+      path: EXTERNAL_DOC,
+      content: "# 外部文档\n\n在 GUI 内读到了。",
+      sizeBytes: 24,
+    }));
+    stubLocalDocBridge(read);
+    const div = await renderLocalDocLayer(() =>
+      createElement(DocReader, { content: `详情见 [外部规范](${EXTERNAL_DOC})。` }),
+    );
+    const anchor = div.querySelector<HTMLAnchorElement>(`a[href="${EXTERNAL_DOC}"]`);
+    expect(anchor).not.toBeNull();
+    expect(await clickAnchor(anchor!)).toBe(false);
+    expect(read).toHaveBeenCalledWith({ path: EXTERNAL_DOC });
+    await flush();
+    const overlay = div.querySelector("[data-testid='local-doc-overlay']");
+    expect(overlay).not.toBeNull();
+    expect(overlay!.textContent).toContain("外部文档");
+    await unmountAll();
+  });
+
+  it("renders the real resolved path returned by the main process", async () => {
+    stubLocalDocBridge(async () => ({ ok: true, path: "/private/etc/real.md", content: "body", sizeBytes: 4 }));
+    const div = await renderLocalDocLayer(() => createElement(DocReader, { content: `[x](/tmp/link.md)` }));
+    await act(async () => {
+      div.querySelector<HTMLAnchorElement>("a[href='/tmp/link.md']")!.click();
+    });
+    await flush();
+    expect(div.querySelector("[data-testid='local-doc-path']")!.textContent).toContain("/private/etc/real.md");
+    await unmountAll();
+  });
+
+  it("shows a typed in-page error for a missing file instead of crashing", async () => {
+    stubLocalDocBridge(async () => ({
+      ok: false,
+      code: "not_found",
+      path: EXTERNAL_DOC,
+      message: "ENOENT",
+    }));
+    const div = await renderLocalDocLayer(() => createElement(DocReader, { content: `[missing](${EXTERNAL_DOC})` }));
+    await act(async () => {
+      div.querySelector<HTMLAnchorElement>(`a[href="${EXTERNAL_DOC}"]`)!.click();
+    });
+    await flush();
+    const error = div.querySelector("[data-testid='local-doc-error-not_found']");
+    expect(error).not.toBeNull();
+    expect(error!.textContent).toContain("文件不存在");
+    expect(div.querySelector("[data-testid='local-doc-overlay']")).not.toBeNull();
+    await unmountAll();
+  });
+
+  it("never navigates and never reads for web links", async () => {
+    const read = vi.fn();
+    stubLocalDocBridge(read);
+    const div = await renderLocalDocLayer(() =>
+      createElement(DocReader, { content: "[site](https://example.invalid/a.md)" }),
+    );
+    const anchor = div.querySelector<HTMLAnchorElement>("a[href='https://example.invalid/a.md']");
+    expect(anchor).not.toBeNull();
+    expect(await clickAnchor(anchor!)).toBe(false);
+    expect(read).not.toHaveBeenCalled();
+    await unmountAll();
+  });
+
+  it("routes package-relative links through the host navigation callback", async () => {
+    const read = vi.fn();
+    stubLocalDocBridge(read);
+    const onOpenPackageDoc = vi.fn();
+    const div = await renderLocalDocLayer(() =>
+      createElement(DocReader, {
+        content: "[报告](artifacts/report.md)",
+        packageBasePath: "tasks/pkg_1/task_plan.md",
+        onOpenPackageDoc,
+      }),
+    );
+    await clickAnchor(div.querySelector<HTMLAnchorElement>("a[href='artifacts/report.md']")!);
+    expect(onOpenPackageDoc).toHaveBeenCalledWith("tasks/pkg_1/artifacts/report.md");
+    expect(read).not.toHaveBeenCalled();
+    await unmountAll();
+  });
+});

--- a/packages/gui/test/markdown-links.vitest.ts
+++ b/packages/gui/test/markdown-links.vitest.ts
@@ -1,0 +1,86 @@
+// harness-test-tier: integration
+import { describe, expect, it } from "vitest";
+import {
+  classifyMarkdownHref,
+  fileUrlToPathString,
+  markdownUrlTransform,
+  resolveRepoDocPath,
+} from "../src/renderer/local-doc/markdown-links.ts";
+
+/**
+ * 详情页 Markdown 链接归类(task_89d324b5):锚点永不导航,本机文件走 GUI 内读取,
+ * 包内相对链接归一化到任务包内,网页与其余形态 inert。
+ */
+describe("classifyMarkdownHref", () => {
+  it("treats absolute, home-tilde and file:// hrefs as local files", () => {
+    expect(classifyMarkdownHref("/Users/ce/Notes/spec.md")).toEqual({
+      kind: "local-file",
+      path: "/Users/ce/Notes/spec.md",
+    });
+    expect(classifyMarkdownHref("~/Notes/spec.md")).toEqual({ kind: "local-file", path: "~/Notes/spec.md" });
+    expect(classifyMarkdownHref("file:///Users/ce/a%20b.md")).toEqual({
+      kind: "local-file",
+      path: "/Users/ce/a b.md",
+    });
+  });
+
+  it("keeps web links web and never classifies scripts as openable", () => {
+    expect(classifyMarkdownHref("https://example.invalid/doc")).toEqual({
+      kind: "web",
+      href: "https://example.invalid/doc",
+    });
+    expect(classifyMarkdownHref("mailto:ce@example.invalid")).toEqual({
+      kind: "web",
+      href: "mailto:ce@example.invalid",
+    });
+    expect(classifyMarkdownHref("javascript:alert(1)").kind).toBe("inert");
+    expect(classifyMarkdownHref("data:text/html,boom").kind).toBe("inert");
+    expect(classifyMarkdownHref("blob:https://x/y").kind).toBe("inert");
+  });
+
+  it("resolves package-relative links only when a package base path is provided", () => {
+    expect(classifyMarkdownHref("artifacts/report.md")).toEqual({ kind: "inert", href: "artifacts/report.md" });
+    expect(classifyMarkdownHref("artifacts/report.md", { packageBasePath: "tasks/pkg/task_plan.md" })).toEqual({
+      kind: "package-doc",
+      path: "tasks/pkg/artifacts/report.md",
+    });
+    expect(classifyMarkdownHref("sub/../closeout.md", { packageBasePath: "tasks/pkg/task_plan.md" })).toEqual({
+      kind: "package-doc",
+      path: "tasks/pkg/closeout.md",
+    });
+    // `..` 越出包根不落点:归一化若继续会把包外路径静默改写成包内同名文件,拒绝。
+    expect(classifyMarkdownHref("../../outside.md", { packageBasePath: "tasks/pkg/a.md" }).kind).toBe("inert");
+    expect(classifyMarkdownHref("#anchor", { packageBasePath: "tasks/pkg/a.md" }).kind).toBe("inert");
+  });
+});
+
+describe("fileUrlToPathString", () => {
+  it("accepts empty and localhost hosts only, decoding percent escapes", () => {
+    expect(fileUrlToPathString("file:///Users/ce/x.md")).toBe("/Users/ce/x.md");
+    expect(fileUrlToPathString("file://localhost/Users/ce/x.md")).toBe("/Users/ce/x.md");
+    expect(fileUrlToPathString("file://nas/share/x.md")).toBeNull();
+    expect(fileUrlToPathString("https://example.invalid/x")).toBeNull();
+  });
+});
+
+describe("resolveRepoDocPath", () => {
+  it("normalizes dot segments inside the package and refuses escapes", () => {
+    expect(resolveRepoDocPath("tasks/pkg/a.md", "b/c.md")).toBe("tasks/pkg/b/c.md");
+    expect(resolveRepoDocPath("tasks/pkg/sub/a.md", "../b.md")).toBe("tasks/pkg/b.md");
+    expect(resolveRepoDocPath("tasks/pkg/a.md", "./x.md")).toBe("tasks/pkg/x.md");
+    expect(resolveRepoDocPath("tasks/pkg/a.md", "../../x.md")).toBeNull();
+    expect(resolveRepoDocPath(null, "x.md")).toBeNull();
+  });
+});
+
+describe("markdownUrlTransform", () => {
+  it("keeps the react-markdown allowlist and additionally admits file://", () => {
+    expect(markdownUrlTransform("https://example.invalid/a")).toBe("https://example.invalid/a");
+    expect(markdownUrlTransform("file:///Users/ce/a.md")).toBe("file:///Users/ce/a.md");
+    expect(markdownUrlTransform("artifacts/a.md")).toBe("artifacts/a.md");
+    expect(markdownUrlTransform("/Users/ce/a.md")).toBe("/Users/ce/a.md");
+    expect(markdownUrlTransform("javascript:alert(1)")).toBe("");
+    expect(markdownUrlTransform("data:text/html,x")).toBe("");
+    expect(markdownUrlTransform("vbscript:evil")).toBe("");
+  });
+});

--- a/packages/gui/test/view-in-graph-button.vitest.tsx
+++ b/packages/gui/test/view-in-graph-button.vitest.tsx
@@ -1,0 +1,305 @@
+// harness-test-tier: integration
+// @vitest-environment happy-dom
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { renderToStaticMarkup } from "react-dom/server";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { ViewInGraphButton } from "../src/renderer/components/ViewInGraphButton.tsx";
+import { TaskDetailView } from "../src/renderer/views/TaskDetailView.tsx";
+import { ScheduleDetailView } from "../src/renderer/views/ScheduleDetailView.tsx";
+import { FactInspector } from "../src/renderer/components/FactInspector.tsx";
+import { AgentCard } from "../src/renderer/components/runtime/AgentCard.tsx";
+import { schedulesClient } from "../src/renderer/schedules-client.ts";
+import type { ScheduleGuiRowDto } from "../../../daemon/src/protocol/schedules-gui-contract.ts";
+import type { DecisionRow, FactRef, RelationEdge, TaskRow } from "../src/renderer/model/types.ts";
+import { setActiveLocale } from "../src/renderer/i18n/core.ts";
+
+/**
+ * 统一「在关系图中查看」入口(task_89d324b5):关系图节点空间的五种实体 kind
+ * (task/decision/fact/agent/schedule)各自的详情面都从同一个共享组件取按钮,
+ * 点击经 onFocusGraph(ref) 跳关系图并聚焦该实体 —— 与 Decision 详情页既有按钮同路。
+ */
+beforeAll(() => {
+  globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+  setActiveLocale("zh-CN");
+});
+afterEach(async () => {
+  await act(async () => {
+    for (const { root, client } of mounted.splice(0)) {
+      root.unmount();
+      client.clear();
+    }
+  });
+  document.body.replaceChildren();
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+const mounted: { readonly root: Root; readonly client: QueryClient }[] = [];
+
+async function mount(node: React.ReactNode) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const container = document.createElement("div");
+  const root = createRoot(container);
+  document.body.append(container);
+  mounted.push({ root, client });
+  await act(async () => {
+    root.render(createElement(QueryClientProvider, { client }, node));
+  });
+  return container;
+}
+
+describe("shared ViewInGraphButton", () => {
+  it("renders one labeled entry that focuses the given entity ref", async () => {
+    const onFocusGraph = vi.fn();
+    const container = await mount(createElement(ViewInGraphButton, { entityRef: "task/task_1", onFocusGraph }));
+    const button = container.querySelector<HTMLButtonElement>("[data-testid='view-in-graph-button']");
+    expect(button?.textContent).toContain("在关系图中查看");
+    expect(button?.title).toBe("task/task_1");
+    await act(async () => {
+      button!.click();
+    });
+    expect(onFocusGraph).toHaveBeenCalledWith("task/task_1");
+  });
+
+  it("renders nothing without a focus callback (host decides the exit exists)", () => {
+    const markup = renderToStaticMarkup(createElement(ViewInGraphButton, { entityRef: "task/task_1" }));
+    expect(markup).toBe("");
+  });
+});
+
+const task: TaskRow = {
+  taskId: "task-gui",
+  title: "详情面双修",
+  projectId: "repo-a",
+  coordinationStatus: "in_review",
+  rawStatus: "in_review/review",
+  freshness: "fresh",
+  packageDisposition: "active",
+  closeoutReadiness: "not_required",
+  engine: "kernel/task-lifecycle/v1",
+  source: "local-document",
+  module: "gui",
+  packagePath: "tasks/task-gui-detail",
+  gates: [],
+  docs: [],
+};
+
+describe("graph entry on each graph-focusable detail surface", () => {
+  it("Task detail header carries the button with the task ref", async () => {
+    vi.stubGlobal("window", {
+      harness: {
+        getTaskDocuments: vi.fn(async () => ({ ok: true, status: "ready", taskId: "task-gui", documents: [] })),
+        getTaskDocument: vi.fn(),
+      },
+    });
+    const onFocusGraph = vi.fn();
+    const container = await mount(
+      createElement(TaskDetailView, {
+        task,
+        onBack: () => undefined,
+        projectName: "Harness",
+        onNavigateDecision: () => undefined,
+        onNavigateEntity: () => undefined,
+        onFocusGraph,
+      }),
+    );
+    const button = container.querySelector<HTMLButtonElement>("[data-testid='view-in-graph-button']");
+    expect(button?.title).toBe("task/task-gui");
+    await act(async () => {
+      button!.click();
+    });
+    expect(onFocusGraph).toHaveBeenCalledWith("task/task-gui");
+  });
+
+  it("Task detail omits the button when the host provides no graph exit", async () => {
+    vi.stubGlobal("window", {
+      harness: {
+        getTaskDocuments: vi.fn(async () => ({ ok: true, status: "ready", taskId: "task-gui", documents: [] })),
+        getTaskDocument: vi.fn(),
+      },
+    });
+    const container = await mount(
+      createElement(TaskDetailView, {
+        task,
+        onBack: () => undefined,
+        projectName: "Harness",
+        onNavigateDecision: () => undefined,
+        onNavigateEntity: () => undefined,
+      }),
+    );
+    expect(container.querySelector("[data-testid='view-in-graph-button']")).toBeNull();
+  });
+
+  it("Schedule detail header carries the button with the schedule ref", async () => {
+    vi.spyOn(schedulesClient, "runs").mockResolvedValue({
+      ok: true,
+      status: "ready",
+      repoId: "repo-a",
+      scheduleId: "sched-probe",
+      runs: [],
+      activeRuns: [],
+      watermark: 3,
+      sourceRevision: 3,
+    } as never);
+    const onFocusGraph = vi.fn();
+    const container = await mount(
+      createElement(ScheduleDetailView, {
+        repoId: "repo-a",
+        row: scheduleRow(),
+        options: scheduleOptions(),
+        scheduleIds: ["sched-probe"],
+        focusedEntityRef: null,
+        busy: false,
+        receipt: null,
+        actionError: null,
+        onAction: () => undefined,
+        onSave: () => undefined,
+        onDelete: () => undefined,
+        onSelectEntity: () => undefined,
+        onFocusGraph,
+        onExitRun: () => undefined,
+        onExit: () => undefined,
+      }),
+    );
+    const button = container.querySelector<HTMLButtonElement>("[data-testid='view-in-graph-button']");
+    expect(button?.title).toBe("schedule/sched-probe");
+    await act(async () => {
+      button!.click();
+    });
+    expect(onFocusGraph).toHaveBeenCalledWith("schedule/sched-probe");
+  });
+
+  it("Agent detail card carries the button with the agent ref", () => {
+    const markup = renderToStaticMarkup(
+      createElement(AgentCard, {
+        detail: {
+          id: "terra",
+          name: "terra",
+          runtimeType: "codex",
+          role: "worker",
+          instructions: "Work the mission.",
+          model: null,
+          skills: [],
+          prompts: [],
+          preset: null,
+        },
+        row: null,
+        squads: [],
+        instances: [],
+        busy: false,
+        onSave: () => undefined,
+        onDispatch: () => undefined,
+        onSelectSquad: () => undefined,
+        onSelectRuntime: () => undefined,
+        onSelectAgent: () => undefined,
+        onFocusGraph: () => undefined,
+      }),
+    );
+    expect(markup).toContain('data-testid="agent-view-in-graph"');
+    expect(markup).toContain("在关系图中查看");
+    const withoutExit = renderToStaticMarkup(
+      createElement(AgentCard, {
+        detail: {
+          id: "terra",
+          name: "terra",
+          runtimeType: "codex",
+          role: "worker",
+          instructions: "Work the mission.",
+          model: null,
+          skills: [],
+          prompts: [],
+          preset: null,
+        },
+        row: null,
+        squads: [],
+        instances: [],
+        busy: false,
+        onSave: () => undefined,
+        onDispatch: () => undefined,
+        onSelectSquad: () => undefined,
+        onSelectRuntime: () => undefined,
+        onSelectAgent: () => undefined,
+      }),
+    );
+    expect(withoutExit).not.toContain('data-testid="agent-view-in-graph"');
+  });
+
+  it("Fact inspector header carries the labeled button with the fact ref", () => {
+    const fact: FactRef = {
+      anchor: "fact/F-001",
+      taskId: "task_a",
+      category: "finding",
+      text: "观察",
+      at: "2026-07-01T00:00:00.000Z",
+      confidence: "high",
+    };
+    const decisions: DecisionRow[] = [];
+    const relations: RelationEdge[] = [];
+    const markup = renderToStaticMarkup(
+      createElement(FactInspector, {
+        factRef: fact.anchor,
+        facts: [fact],
+        tasks: [],
+        decisions,
+        relations,
+        coverageRows: [],
+        onFocusGraph: () => undefined,
+      }),
+    );
+    expect(markup).toContain('data-testid="fact-view-in-graph"');
+    expect(markup).toContain("在关系图中查看");
+  });
+});
+
+function scheduleRow(overrides: Partial<ScheduleGuiRowDto> = {}): ScheduleGuiRowDto {
+  return {
+    scheduleId: "sched-probe",
+    name: "Heartbeat probe",
+    state: "armed",
+    definitionResidency: "ledger",
+    definitionRevision: 7,
+    trigger: { kind: "interval", everyMs: 7_200_000, timezone: null, summary: "every 2h" },
+    target: {
+      kind: "agent",
+      agentId: "probe-agent",
+      runtimeInstanceId: "codex-schedule",
+      model: null,
+      reasoningEffort: null,
+      cwd: null,
+    },
+    mission: "Keep the line green.",
+    executionAvailability: "claimed-elsewhere",
+    claim: { nodeId: "edge-two", assignmentId: "assignment-edge-two" },
+    nextRunAt: null,
+    actions: {
+      edit: { available: true, code: null, nextAction: null },
+      delete: { available: true, code: null, nextAction: null },
+      enable: { available: false, code: "no_changes", nextAction: "already armed" },
+      disable: { available: true, code: null, nextAction: null },
+      runNow: { available: true, code: null, nextAction: null },
+    },
+    activeRun: null,
+    lastRun: null,
+    missed: { count: 0, lastMissedAt: null, lastMissedReason: null },
+    automaticEvaluatedThrough: null,
+    ...overrides,
+  };
+}
+
+function scheduleOptions() {
+  return {
+    agents: [{ agentId: "probe-agent", name: "Probe Agent", runtimeType: "codex" }],
+    instances: [
+      {
+        instanceId: "codex-schedule",
+        name: "Schedule Codex",
+        kindId: "codex",
+        models: ["gpt-5.6"],
+        efforts: ["low", "medium", "high"],
+      },
+    ],
+    cwd: ["."],
+  };
+}

--- a/packages/gui/test/window-config.test.ts
+++ b/packages/gui/test/window-config.test.ts
@@ -1,7 +1,14 @@
 // harness-test-tier: contract
 import assert from "node:assert/strict";
 import test from "node:test";
-import { assertDevRendererUrl, createGuiContentSecurityPolicy, createGuiWindowOptions, guiContentSecurityPolicy, isTrustedRendererUrl } from "../src/index.ts";
+import {
+  assertDevRendererUrl,
+  createGuiContentSecurityPolicy,
+  createGuiWindowOptions,
+  guiContentSecurityPolicy,
+  isNavigableAppDocumentUrl,
+  isTrustedRendererUrl,
+} from "../src/index.ts";
 
 test("dev renderer override accepts only the local Vite server", () => {
   assert.equal(assertDevRendererUrl("http://127.0.0.1:5173"), true);
@@ -34,6 +41,47 @@ test("trusted renderer URL accepts only explicit dev server or packaged renderer
   assert.equal(isTrustedRendererUrl("file:///tmp/renderer/index.html", { packagedRendererUrl }), false);
   assert.equal(isTrustedRendererUrl("file:///app/.harness-private/task.md", { packagedRendererUrl }), false);
   assert.equal(isTrustedRendererUrl("https://example.invalid", { packagedRendererUrl }), false);
+});
+
+// task_89d324b5:窗口是单文档应用 —— dev 态此前放行同源任意路径,Markdown 里
+// `/Users/…` 绝对路径链接解析到 dev origin 之下,点击把窗口带离应用落在 404 白屏。
+test("document navigation stays pinned to the app entry document", () => {
+  const packagedRendererUrl = "file:///app/renderer/index.html";
+
+  // dev:入口根可停留,同源任意路径(含外链解析出的 /Users/…)一律拒绝。
+  assert.equal(
+    isNavigableAppDocumentUrl("http://127.0.0.1:5173/", {
+      packagedRendererUrl,
+      devRendererUrl: "http://127.0.0.1:5173",
+    }),
+    true,
+  );
+  assert.equal(
+    isNavigableAppDocumentUrl("http://127.0.0.1:5173", {
+      packagedRendererUrl,
+      devRendererUrl: "http://127.0.0.1:5173/",
+    }),
+    true,
+  );
+  assert.equal(
+    isNavigableAppDocumentUrl("http://127.0.0.1:5173/Users/ce/Notes/spec.md", {
+      packagedRendererUrl,
+      devRendererUrl: "http://127.0.0.1:5173",
+    }),
+    false,
+  );
+  assert.equal(
+    isNavigableAppDocumentUrl("http://localhost:5173/", {
+      packagedRendererUrl,
+      devRendererUrl: "http://127.0.0.1:5173",
+    }),
+    false,
+  );
+  // 打包态:只有入口 index 文档;其余 file:// 与远程 URL 全拒。
+  assert.equal(isNavigableAppDocumentUrl(packagedRendererUrl, { packagedRendererUrl }), true);
+  assert.equal(isNavigableAppDocumentUrl("file:///Users/ce/Notes/spec.md", { packagedRendererUrl }), false);
+  assert.equal(isNavigableAppDocumentUrl("https://example.invalid/", { packagedRendererUrl }), false);
+  assert.equal(isNavigableAppDocumentUrl("not a url", { packagedRendererUrl }), false);
 });
 
 test("the main window enables only the policy-guarded HTML artifact webview surface", () => {

--- a/packages/gui/tsconfig.renderer.json
+++ b/packages/gui/tsconfig.renderer.json
@@ -29,6 +29,7 @@
     "src/api/artifact-open-contract.ts",
     "src/api/first-run-contract.ts",
     "src/api/html-artifact-policy.ts",
+    "src/api/local-doc-contract.ts",
     "src/api/renderer-dto.ts"
   ],
   "exclude": [

--- a/tools/gui-test-manifest.mjs
+++ b/tools/gui-test-manifest.mjs
@@ -64,4 +64,7 @@ export const guiVitestManifest = [
   "packages/gui/test/gui-w6-truncation-visibility.vitest.ts",
   "packages/gui/test/system-group-widescreen.vitest.ts",
   "packages/gui/test/ledger-invalidation-scope.vitest.ts",
+  "packages/gui/test/view-in-graph-button.vitest.tsx",
+  "packages/gui/test/local-doc-reader.vitest.tsx",
+  "packages/gui/test/markdown-links.vitest.ts",
 ];


### PR DESCRIPTION
# English

## Summary

Two GUI detail-surface fixes reported by the user on 2026-09-01. ① Clicking a Markdown link that points to a local document outside the workspace (e.g. `/Users/…/notes.md`) blanked the whole app: DocReader/Decision bodies rendered bare `<a>` anchors with no click interception, and the dev shell's `will-navigate` trusted the entire dev origin, so the absolute path resolved under it and actually navigated the window away (reproduced red→green in a real Electron shell: before — the URL leaves the app document; after — the window stays put). Fixed on both sides: a shared `MarkdownAnchor` component (preventDefault always first; pure-function href classification: local file / in-package relative / web / inert) plus a read-only `harness:localDoc:read` IPC bridge (main-process realpath → regular-file check → utf8 read; zero write paths; errno-keyed typed failure codes — `not_found`/`not_a_regular_file`/`binary_file`/`too_large` 2 MiB/…) rendering external docs in an in-app overlay, with per-code in-page error states instead of a crash; the shell gains defense-in-depth `isNavigableAppDocumentUrl` (single-document app: only the entry root can navigate). ② «View in relation graph» is now one shared `ViewInGraphButton` (parameterized by entity ref, using the existing `focusEntityInGraph`) wired into all five graph-space kinds — decision (detail page + evolution panel, deleting the two specialized implementations), task, fact, schedule, agent.

## Architectural Justification

- Root cause fixed, not swallowed: the anchor layer never performs document navigation; the shell rule is a second wall, not the fix.
- Read-only capability, no allowlist scaffolding: the operator is a collaborator on their own machine — realpath is displayed honestly (a symlink shows its target), write functions are absent from the bridge, and requests are shape-closed `{path}` with a trusted-sender check shared with the existing openExternal IPC.
- One button, one implementation: the Decision-specific graph entries are deleted in the same change that lands the shared component.
- Multi-node: local-file reading is a node-local read-only query (no ledger write, no concurrency owner); the graph button is pure read navigation.

## What Changed

- New: `local-doc-contract.ts`, `local-doc-ipc.ts` (main), `MarkdownAnchor.tsx`, `markdown-links.ts`, `LocalDocLayer` overlay, `ViewInGraphButton.tsx`.
- Modified: DocReader/DecisionBodyPanel consume the shared anchor; window-config single-document navigation rule; task files tab in-package link navigation; detail pages of task/fact/schedule/agent/decision adopt the shared graph button; en/zh locales.
- Tests: local-doc-ipc (11), markdown-links (6), local-doc-reader (5, incl. navigation-interception witness), view-in-graph-button (7), window-config additions; GUI vitest suite 645 cases green.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none

## Machine-Readable Declarations

Production-Delta: +869/-80
Dependency-Change: none

### Optional Evidence Claims

None.

## Task And Scope

- Harness task: `task_89d324b540f5dde7827b65db61` (GUI detail-face double fix)
- Branch: `codex/gui-detail-face`
- Public scope: GUI package + gui-test-manifest registration; no daemon protocol/kernel/CLI changes.
- Private planning/evidence: worker report `artifacts/implementation-report.md` (GLM worker, dispatch_91a152e2).

## Version Impact

- Version: no change. Publish impact: none.

## Governance Declaration

- Protected surface touched: no (gui package + test manifest registration only).
- Authority: task_89d324b540f5dde7827b65db61 (GUI detail-face double fix).
- Break-glass: no

## Verification

- Base: rebased onto `401e739f8` cleanly; CEO re-ran typecheck green.
- Worker: tsc, eslint, GUI vitest 68 files / 645 cases green; red→green navigation evidence from a real Electron shell recorded in the implementation report.
- CEO manual GUI verification of both scenarios follows on the deployed build (dogfooding is part of acceptance).
- [ ] Full suites: GitHub CI is the authority.

## Review Evidence

- CEO semantic review: preventDefault-first anchor design; typed errno-keyed failure codes (no message sniffing); two Decision-specialized graph entries deleted in the same change; shell rule is defense-in-depth, not the primary fix.

## Residual Risk

- Web links inside Markdown are inert with a tooltip (no external-browser channel is shipped in the GUI); if the user wants browser opening, that is a follow-up capability, not a regression.

---

# 中文

## 概要

修复用户 2026-09-01 报告的两个 GUI 详情面问题。①Markdown 中指向工作区外本机文档的链接(如 `/Users/…/notes.md`)点击后整页白屏:DocReader/Decision 正文把链接渲染成裸 `<a>` 且渲染层零拦截,dev 壳 `will-navigate` 又信任整个 dev origin,绝对路径被解析到其下并真的执行了窗口导航(真实 Electron 壳红→绿实测:修复前 URL 离开应用文档,修复后原位不动)。两侧修复:共享 `MarkdownAnchor` 组件(preventDefault 永远先行;href 纯函数归类:本机文件/包内相对/网页/inert)+ 只读 IPC 桥 `harness:localDoc:read`(主进程 realpath→常规文件校验→utf8 读取;零写路;errno 键控 typed 失败码——`not_found`/`not_a_regular_file`/`binary_file`/`too_large` 2MiB 上限等),外部文档在应用内浮层阅读,按 code 出页内错误态而非崩溃;壳侧纵深防御 `isNavigableAppDocumentUrl`(单文档应用只允许入口根导航)。②「在关系图中查看」统一为共享 `ViewInGraphButton`(按实体 ref 参数化,走既有 `focusEntityInGraph`),接入关系图节点空间全部五种 kind——decision(详情页+演化史面板,同变更删除两份特化实现)、task、fact、schedule、agent。

## 架构辩护

- 修根因不吞崩溃:锚点层永不执行文档导航;壳规则是第二道墙不是修复本体。
- 只读能力、不造 allowlist 脚手架:操作者是自己机器上的合作者——realpath 诚实展示(符号链接显示真身)、桥内零写函数、请求形状闭包 `{path}` 并复用既有可信发送者校验。
- 一个按钮一份实现:Decision 两处特化入口与共享件同变更删除。
- 多节点:本机文件读取是节点本地只读查询(不落台账、无并发主体);图按钮是纯读导航。

## 改动内容

- 新增:`local-doc-contract.ts`、`local-doc-ipc.ts`、`MarkdownAnchor.tsx`、`markdown-links.ts`、`LocalDocLayer` 浮层、`ViewInGraphButton.tsx`。
- 修改:DocReader/DecisionBodyPanel 换用共享锚点;window-config 单文档导航规则;Task files 页包内链接导航;task/fact/schedule/agent/decision 详情页接入共享图按钮;中英文案。
- 测试:local-doc-ipc(11)、markdown-links(6)、local-doc-reader(5,含导航拦截见证)、view-in-graph-button(7)、window-config 增补;GUI vitest 68 文件 645 例全绿。

## 门收割 / Gate Harvest

- 删除的生产路径:无独立文件;Decision 两处图入口特化在组件内就地删除。

## 机读声明说明

`Production-Delta` 由 gate 实测(+869/−80)。

## 任务与范围

- Task `task_89d324b540f5dde7827b65db61`;分支 `codex/gui-detail-face`;范围:GUI 包 + gui-test-manifest 登记,不动 daemon 协议/kernel/CLI。

## 版本影响

- 不改版本、不发布。

## 治理声明

- 未触碰受保护面;授权=task_89d324b540f5dde7827b65db61;非 break-glass。

## 验证

- worker(GLM):tsc、eslint、GUI vitest 645 例全绿;真实 Electron 壳导航红→绿证据见实现报告;CEO rebase 到 401e739f8 后重跑 typecheck 绿;合并部署后 CEO 亲手复验两场景;完整权威=GitHub CI。

## 审查证据

- CEO 语义验收:preventDefault 先行设计;typed errno 键控失败码无子串嗅探;两处 Decision 特化删除与共享件同变更;壳规则定位为纵深不是主修。

## 残余风险

- Markdown 网页链接为 inert+tooltip(GUI 未开通外部浏览器通路);如需浏览器打开属后续能力,非回归。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VTzQAqvuFy6ikGjBKxA9xj
