### PR TITLE
fix(daemon): rebuild stale migration oracle in place

### DIFF
--- a/packages/daemon/src/migration-import-oracle-rebuild.ts
+++ b/packages/daemon/src/migration-import-oracle-rebuild.ts
@@ -58,7 +58,8 @@ export function rebuildMigrationProjectionOracle(
     if (inspection.eventHeadRevision !== null && oracle.watermark !== inspection.eventHeadRevision)
       throw migrationImportError(
         "migration_projection_oracle_cut_mismatch",
-        `Rebuilt projection watermark ${oracle.watermark} does not match canonical event head ${inspection.eventHeadRevision}.`,
+        `Rebuilt projection watermark ${oracle.watermark} ` +
+          `does not match canonical event head ${inspection.eventHeadRevision}.`,
       );
     return oracle;
   } catch (error) {

--- a/packages/daemon/src/migration-import-oracle-rebuild.ts
+++ b/packages/daemon/src/migration-import-oracle-rebuild.ts
@@ -48,11 +48,28 @@ export function rebuildMigrationProjectionOracle(
   sourceRoot: string,
   inspection = inspectMigrationSourceEvents(sourceRoot),
 ): MigrationProjectionOracle {
-  const rebuilt = inspection.events.length === 0 ? emptyOracle(inspection) : rebuildEventOracle(sourceRoot, inspection);
-  return {
-    ...overlayAuthoredOracle(sourceRoot, rebuilt, inspection),
-    normalizedRelationMigrationEntities: inspection.normalizedRelationMigrationEntities,
-  };
+  try {
+    const rebuilt =
+        inspection.events.length === 0 ? emptyOracle(inspection) : rebuildEventOracle(sourceRoot, inspection),
+      oracle = {
+        ...overlayAuthoredOracle(sourceRoot, rebuilt, inspection),
+        normalizedRelationMigrationEntities: inspection.normalizedRelationMigrationEntities,
+      };
+    if (inspection.eventHeadRevision !== null && oracle.watermark !== inspection.eventHeadRevision)
+      throw migrationImportError(
+        "migration_projection_oracle_cut_mismatch",
+        `Rebuilt projection watermark ${oracle.watermark} does not match canonical event head ${inspection.eventHeadRevision}.`,
+      );
+    return oracle;
+  } catch (error) {
+    if (migrationErrorCode(error) !== null) throw error;
+    consumeKnownError(error);
+    throw migrationImportError(
+      "migration_projection_rebuild_failed",
+      `Could not rebuild the source oracle without modifying the source: ` +
+        `${error instanceof Error ? error.message : String(error)}.`,
+    );
+  }
 }
 
 export function inspectMigrationSourceEvents(sourceRoot: string): MigrationEventInspection {
@@ -75,7 +92,8 @@ export function inspectMigrationSourceEvents(sourceRoot: string): MigrationEvent
       consumeKnownError(error);
       throw migrationImportError("invalid_migration_source", `${sourcePath}: canonical event is not JSON.`);
     }
-    const legacyTask = containsSchema(raw, "task/v1");
+    const legacyTask = containsSchema(raw, "task/v1"),
+      legacyMigrationTaskWithoutProvenance = isLegacyMigrationTaskWithoutProvenance(raw);
     let event: CanonicalEventV1;
     try {
       event = normalizePersistedCanonicalEvent(parseCanonicalEvent(`${stableStringify(raw)}\n`));
@@ -93,7 +111,9 @@ export function inspectMigrationSourceEvents(sourceRoot: string): MigrationEvent
       observations.push({
         code: "legacy_event_normalized",
         sourcePath,
-        detail: `normalized ${event.schema} to the current read contract for oracle replay`,
+        detail: legacyMigrationTaskWithoutProvenance
+          ? "restated legacy migration task entity with provenance=imported_snapshot for oracle replay"
+          : `normalized ${event.schema} to the current read contract for oracle replay`,
         treatment: "mechanically_normalized",
       });
     }
@@ -627,6 +647,19 @@ function containsSchema(value: unknown, schema: string): boolean {
   return isMigrationImportRecord(value)
     ? value.schema === schema || Object.values(value).some((entry) => containsSchema(entry, schema))
     : false;
+}
+
+function isLegacyMigrationTaskWithoutProvenance(value: unknown): boolean {
+  if (!isMigrationImportRecord(value) || value.schema !== "migration-import-event/v1") return false;
+  const payload = isMigrationImportRecord(value.payload) ? value.payload : null,
+    entity = payload !== null && isMigrationImportRecord(payload.entity) ? payload.entity : null;
+  return entity?.kind === "task" && !Object.hasOwn(entity, "provenance");
+}
+
+function migrationErrorCode(error: unknown): string | null {
+  return typeof error === "object" && error !== null && "code" in error && typeof error.code === "string"
+    ? error.code
+    : null;
 }
 
 function cleanScalar(value: string): string {

--- a/packages/daemon/src/migration-import-oracle.ts
+++ b/packages/daemon/src/migration-import-oracle.ts
@@ -124,9 +124,11 @@ export function readMigrationProjectionOracle(sourceRoot: string): MigrationProj
   const layout = resolveHarnessLayout(sourceRoot),
     databasePath = path.join(layout.localRoot, "cache", "task.sqlite"),
     inspection = inspectMigrationSourceEvents(sourceRoot);
-  const oracle = !existsSync(databasePath)
-    ? rebuildMigrationProjectionOracle(sourceRoot, inspection)
-    : {
+  let oracle: MigrationProjectionOracle;
+  if (!existsSync(databasePath)) oracle = rebuildMigrationProjectionOracle(sourceRoot, inspection);
+  else
+    try {
+      oracle = {
         ...readMigrationProjectionOracleAtPath(
           sourceRoot,
           databasePath,
@@ -135,6 +137,11 @@ export function readMigrationProjectionOracle(sourceRoot: string): MigrationProj
         ),
         normalizedRelationMigrationEntities: inspection.normalizedRelationMigrationEntities,
       };
+    } catch (error) {
+      if (!hasErrorCode(error, "migration_projection_oracle_cut_mismatch")) throw error;
+      consumeKnownError(error);
+      oracle = rebuildMigrationProjectionOracle(sourceRoot, inspection);
+    }
   return overlayAgentDeclarations(sourceRoot, oracle);
 }
 
@@ -574,4 +581,8 @@ function number(value: unknown, label: string): number {
   if (typeof result !== "number" || !Number.isSafeInteger(result) || result < 0)
     throw migrationImportError("invalid_migration_projection_oracle", `${label} is invalid.`);
   return result;
+}
+
+function hasErrorCode(error: unknown, code: string): boolean {
+  return typeof error === "object" && error !== null && "code" in error && error.code === code;
 }

--- a/packages/daemon/src/migration-import-task-restatement.ts
+++ b/packages/daemon/src/migration-import-task-restatement.ts
@@ -129,9 +129,16 @@ export function restateTaskContractBody(input: {
   } catch (error) {
     throw new Error(`${input.sourcePath}: invalid task-contract.json`, { cause: error });
   }
-  const declaredDigest = contract.presetSnapshotDigest;
+  const legacyPreset =
+      contract.schema === "task-contract-snapshot/v1" && migrationImportRecord(contract.preset)
+        ? contract.preset
+        : null,
+    usesLegacyPresetDigest = contract.presetSnapshotDigest === undefined && legacyPreset?.digest !== undefined,
+    declaredDigest = usesLegacyPresetDigest ? legacyPreset?.digest : contract.presetSnapshotDigest;
   if (declaredDigest !== undefined && declaredDigest !== null && !presetDigest(declaredDigest))
-    throw new Error(`${input.sourcePath}: presetSnapshotDigest is not SHA-256`);
+    throw new Error(
+      `${input.sourcePath}: ${usesLegacyPresetDigest ? "preset.digest" : "presetSnapshotDigest"} is not SHA-256`,
+    );
   let metadata = contractCompileMetadata(contract, input.fallback);
   const settings = readSettingsFacet(
     readFileSync(path.join(resolveHarnessLayout(input.sourceRoot).authoredRoot, "harness.yaml"), "utf8"),

--- a/packages/daemon/test/migration-import-legacy-variants.integration.test.ts
+++ b/packages/daemon/test/migration-import-legacy-variants.integration.test.ts
@@ -11,6 +11,7 @@ import {
   compileScheduleDefinitionEvent,
   createScheduleV1,
   eventObjectRelativePath,
+  makeTaskProjection,
   serializeEventHead,
   serializePersistedCanonicalEvent,
   sha256Text,
@@ -27,6 +28,11 @@ const variants: readonly { readonly name: string; readonly build: VariantBuilder
   { name: "flat-task-v1-events", build: (root) => taskV1Fixture(root, "flat/v1") },
   { name: "sharded-task-v1-events", build: (root) => taskV1Fixture(root, "sharded-sha256-2/v1") },
   { name: "migration-import-task-v1", build: migrationTaskV1Fixture },
+  {
+    name: "in-place-migration-import-task-v1",
+    build: inPlaceMigrationTaskV1Fixture,
+    observation: /ACCEPT legacy_event_normalized .*provenance=imported_snapshot/u,
+  },
   { name: "legacy-doc-commit-cut", build: legacyDocCutFixture },
   { name: "task-local-fact-event", build: legacyFactEventFixture },
   { name: "taskless-fact-current-provenance", build: tasklessFactFixture },
@@ -110,6 +116,21 @@ function migrationTaskV1Fixture(root: string): void {
   writeBlob(root, claim.sha256, body);
   writeEvent(root, event.opId, eventBody, "flat/v1");
   writeHead(root, 1, event.opId, eventBody);
+}
+
+function inPlaceMigrationTaskV1Fixture(root: string): void {
+  migrationTaskV1Fixture(root);
+  writeFileSync(path.join(root, ".gitignore"), "/.harness/\n");
+  const projection = makeTaskProjection({
+    rootDir: root,
+    eventStore: {
+      readHead: () => null,
+      readBatch: () => ({ sourceRevision: 0, events: [], cursor: null, done: true, accessedItems: 0 }),
+      readContentBlob: () => null,
+    },
+  });
+  projection.rebuild();
+  projection.close();
 }
 
 function legacyFactEventFixture(root: string): void {

--- a/packages/daemon/test/migration-import-oracle.test.ts
+++ b/packages/daemon/test/migration-import-oracle.test.ts
@@ -5,9 +5,21 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
 import test from "node:test";
+import {
+  REPLAY_TASK_GRAPH,
+  canonicalizeContractValue,
+  makeTaskProjection,
+  serializeEventHead,
+  sha256Text,
+} from "../../kernel/src/index.ts";
 import { readMigrationProjectionOracle } from "../src/migration-import-oracle.ts";
 
-test("same-cut oracle rejects a projection watermark that differs from canonical event head", () => {
+const actor = {
+  principal: { personId: "migration-oracle-fixture" },
+  executor: { kind: "agent", id: "migration-import" },
+} as const;
+
+test("mismatched same-cut oracle rejects when disposable replay cannot reach the canonical event head", () => {
   const root = mkdtempSync(path.join(tmpdir(), "migration-oracle-cut-")),
     authored = path.join(root, "harness"),
     local = path.join(root, ".harness/cache");
@@ -28,9 +40,163 @@ test("same-cut oracle rejects a projection watermark that differs from canonical
       (error: unknown) =>
         error instanceof Error &&
         (error as Error & { readonly code?: string }).code === "migration_projection_oracle_cut_mismatch" &&
-        /watermark 6.*head 7/u.test(error.message),
+        /Rebuilt projection watermark 0.*head 7/u.test(error.message),
     );
   } finally {
     rmSync(root, { recursive: true, force: true });
   }
 });
+
+test("stale same-cut oracle rebuilds a legacy migration task through the normalized event stream", () => {
+  const root = mkdtempSync(path.join(tmpdir(), "migration-oracle-in-place-"));
+  try {
+    const taskId = "task_legacy_in_place",
+      packagePath = `tasks/${taskId}-legacy-in-place`,
+      documentBody = taskDocument(taskId),
+      documentSha = sha256Text(documentBody),
+      event = {
+        schema: "migration-import-event/v1",
+        eventId: "event-legacy-in-place",
+        workspaceRevision: 1,
+        opId: "op-legacy-in-place",
+        type: "entity_migrated",
+        actor,
+        source: "migration-import/v1",
+        occurredAt: "2026-08-15T00:00:00.000Z",
+        payload: {
+          migratedFrom: taskId,
+          generation: "v0",
+          entity: {
+            kind: "task",
+            task: {
+              schema: "task/v1",
+              taskId,
+              title: "Legacy in-place task",
+              taskClass: "standard",
+              status: "planned",
+              graph: REPLAY_TASK_GRAPH,
+              currentNode: "implementation",
+              iteration: 0,
+              createdBy: actor,
+              completionGateIds: [],
+              presetSnapshotDigest: null,
+            },
+            originalStatus: "planned",
+            packagePath,
+            documentClaim: {
+              path: `${packagePath}/INDEX.md`,
+              sha256: documentSha,
+              size: Buffer.byteLength(documentBody),
+              mediaType: "text/markdown",
+              policyId: "typed-migration-import/v1",
+            },
+          },
+        },
+      },
+      eventBody = `${JSON.stringify(canonicalizeContractValue(event))}\n`;
+    writeHarnessRoot(root);
+    mkdirSync(path.join(root, "harness/events"), { recursive: true });
+    mkdirSync(path.join(root, "harness/objects/sha256", documentSha.slice(0, 2)), { recursive: true });
+    mkdirSync(path.join(root, "harness", packagePath), { recursive: true });
+    writeFileSync(path.join(root, "harness/events/op-legacy-in-place.json"), eventBody);
+    writeFileSync(
+      path.join(root, "harness/events/head.json"),
+      serializeEventHead({
+        revision: 1,
+        opId: event.opId,
+        eventDigest: `sha256:${sha256Text(eventBody)}`,
+      }),
+    );
+    writeFileSync(
+      path.join(root, "harness/objects/sha256", documentSha.slice(0, 2), documentSha.slice(2)),
+      documentBody,
+    );
+    writeFileSync(path.join(root, "harness", packagePath, "INDEX.md"), documentBody);
+    createEmptyProjection(root);
+
+    const oracle = readMigrationProjectionOracle(root);
+
+    assert.equal(oracle.basis, "rebuilt-source");
+    assert.equal(oracle.watermark, 1);
+    assert.equal(oracle.eventHeadRevision, 1);
+    assert.equal(oracle.tasks.get(taskId)?.snapshot.task?.schema, "task/v2");
+    assert.ok(
+      oracle.formatObservations.some(
+        ({ code, detail }) =>
+          code === "legacy_event_normalized" && /migration task entity.*provenance=imported_snapshot/u.test(detail),
+      ),
+    );
+    assert.ok(oracle.formatObservations.some(({ code }) => code === "source_projection_rebuilt"));
+    const sourceDatabase = new DatabaseSync(path.join(root, ".harness/cache/task.sqlite"), { readOnly: true });
+    try {
+      assert.equal(
+        (
+          sourceDatabase.prepare("SELECT watermark FROM projection_meta WHERE singleton=1").get() as {
+            readonly watermark: number;
+          }
+        ).watermark,
+        0,
+      );
+    } finally {
+      sourceDatabase.close();
+    }
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("matching source projection remains the same-cut oracle", () => {
+  const root = mkdtempSync(path.join(tmpdir(), "migration-oracle-same-cut-"));
+  try {
+    writeHarnessRoot(root);
+    createEmptyProjection(root);
+    const oracle = readMigrationProjectionOracle(root);
+    assert.equal(oracle.basis, "same-cut-projection");
+    assert.equal(oracle.watermark, 0);
+    assert.equal(oracle.eventHeadRevision, null);
+    assert.equal(oracle.formatObservations.length, 0);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+function writeHarnessRoot(root: string): void {
+  mkdirSync(path.join(root, "harness"), { recursive: true });
+  writeFileSync(
+    path.join(root, "harness/harness.yaml"),
+    "schema: harness-anything/v1\nlayout:\n  authoredRoot: harness\n  localRoot: .harness\n",
+  );
+}
+
+function createEmptyProjection(root: string): void {
+  const projection = makeTaskProjection({
+    rootDir: root,
+    eventStore: {
+      readHead: () => null,
+      readBatch: () => ({ sourceRevision: 0, events: [], cursor: null, done: true, accessedItems: 0 }),
+      readContentBlob: () => null,
+    },
+  });
+  projection.rebuild();
+  projection.close();
+}
+
+function taskDocument(taskId: string): string {
+  return [
+    "---",
+    "schema: task-package/v2",
+    `task_id: ${taskId}`,
+    'title: "Legacy in-place task"',
+    "lifecycle:",
+    "  status: planned",
+    "  engine: migration-import/v1",
+    "bindingCreatedAt: 2026-08-15T00:00:00.000Z",
+    "vertical: software/coding",
+    "preset: standard-task",
+    "profile: baseline",
+    "---",
+    "",
+    "# Legacy in-place task",
+    "",
+  ].join("\n");
+}

--- a/packages/daemon/test/migration-import-task-restatement.test.ts
+++ b/packages/daemon/test/migration-import-task-restatement.test.ts
@@ -88,6 +88,33 @@ test("task contract restatement preserves a declared digest and rewrites migrate
   }
 });
 
+test("legacy snapshot contract preserves its nested preset digest without resolving the retired preset", () => {
+  const rootDir = fixtureRoot();
+  try {
+    const digest = `sha256:${"b".repeat(64)}` as const,
+      restated = restateTaskContractBody({
+        sourceRoot: rootDir,
+        sourcePath: "harness/tasks/task-old/task-contract.json",
+        body: JSON.stringify({
+          schema: "task-contract-snapshot/v1",
+          vertical: "software/coding",
+          preset: { id: "retired-local-preset", version: "0.1.0", digest },
+          profile: { id: "baseline" },
+          documents: [],
+        }),
+        targetTaskId: "task-new",
+        targetPackagePath: "tasks/task-new-migrated-task",
+        fallback: { title: "Migrated task", taskClass: "standard" },
+      }),
+      contract = JSON.parse(restated.body) as Record<string, unknown>;
+    assert.equal(restated.source, "contract");
+    assert.equal(restated.presetSnapshotDigest, digest);
+    assert.equal(contract.presetSnapshotDigest, digest);
+  } finally {
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});
+
 test("task contract restatement recomputes a missing digest from contract metadata", () => {
   const rootDir = fixtureRoot();
   try {


### PR DESCRIPTION
# English

## Summary

Unblocks the tri-repository migrations by fixing an in-place recovery deadlock in the migration oracle. A repository latched for an invalid legacy migration task event legitimately holds its derived projection at watermark 0, yet `readMigrationProjectionOracle` read that stale source SQLite first and threw `migration_projection_oracle_cut_mismatch` — permanently blocking the very `migrate-import` that repairs the ledger. Now, only that exact typed mismatch falls back to a disposable scratch replay of the already-inspected and mechanically normalized event stream, and the rebuilt oracle is accepted only when its watermark exactly reaches the canonical event head; any other error keeps its typed path. The failing legacy shape is pinned: `migration-import-event/v1` task entities missing `payload.entity.provenance` (318 events across the three sources, all identical) — restated as `provenance: "imported_snapshot"` (an imported snapshot by definition) with an explicit `legacy_event_normalized` observation. A second mechanical legacy variant surfaced behind it: historical `task-contract-snapshot/v1` documents keep the preset digest at nested `preset.digest` (218/218, 33/33, 54/54 usable — none missing); the restater now copies that exact SHA-256 for that schema only, never synthesizing a digest.

## Architectural Justification

- Mechanism sentence: a derived-cache freshness rejection must not block a repair operation when the same immutable source can be normalized and fully replayed into a disposable verified view.
- Narrow trigger, strict acceptance: fallback fires only on the one typed code; a rebuilt oracle short of the head re-throws the same typed mismatch — no watermark is faked, no validation is loosened.
- Read-only by construction: scratch replay uses a `mkdtemp` SQLite removed in `finally`; the source database is opened read-only (verified on the three production sources: mtime and size identical before/after).
- Multi-node: recovery admission stays serialized by the RepoCell single-flight ingress from #2080; the oracle is pure read derivation — no new writer, queue, claim, or shared artifact.

## What Changed

- `migration-import-oracle.ts`: existing-DB branch catches only `migration_projection_oracle_cut_mismatch` and falls back to the rebuild path.
- `migration-import-oracle-rebuild.ts`: rebuilt oracle must reach the canonical head; provenance restatement named in dry-run observations.
- `migration-import-task-restatement.ts`: `task-contract-snapshot/v1` nested `preset.digest` accepted as the declared digest (that schema only).
- Tests +216/−2: red→green oracle rebuild case, provenance restatement, nested-digest preservation, and an isolated in-place full dry-run fixture (Ubuntu, 10/10).

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none

## Machine-Readable Declarations

Production-Delta: +64/-12
Dependency-Change: none

### Optional Evidence Claims

None.

## Task And Scope

- Harness task: `task_4e43f05b319bc0108014b727d7` (unblocks `task_b85c1c56` tri-repo migration; diagnosis Fact `F-DE1428F9`)
- Branch: `codex/migrate-oracle-inplace`
- Public scope: migration oracle in-place recovery.
- Private planning/evidence: worker report `artifacts/implementation-report.md`; Facts `F-E8213E60`, `F-DE1428F9`.

## Version Impact

- Version: no change. Publish impact: none.

## Governance Declaration

- Protected surface touched: no (packages-only diff).
- Authority: task_4e43f05b319bc0108014b727d7.
- Break-glass: no

## Verification

- Base: rebased onto `2c0fd5094` cleanly; CEO re-ran typecheck + duplicate-definitions green.
- Worker: focused fast suites 17/17 (two new cases red before the change, green after); isolated Ubuntu integration 10/10 including an in-place full dry-run fixture; prettier/eslint/tsc/`git diff --check` pass.
- Read-only oracle execution against the three real source cuts converged: watermark 718/718, 999/999, 4047/4047 (Fact `F-E8213E60`); source SQLite untouched.
- [ ] Full suites: GitHub CI is the authority.

## Review Evidence

- CEO semantic review: fallback trigger is the single typed code with strict head-parity acceptance; restatement semantics unambiguous (imported snapshot by definition, 318/318 same shape); nested-digest handling bounded to the legacy schema with 100% usable-digest counts; no retained duplicate path.

## Residual Risk

- Production dry-run/apply/re-attach/idempotency on the three repositories remains CEO-owned follow-up after deployment; GitHub CI on this PR is the complete authority.

---

# 中文

## 概要

修复迁移 oracle 的原地恢复死锁,解锁三仓迁移。因无效 legacy migration task 事件上闩的仓,其派生投影**合法地**停在水位 0,而 `readMigrationProjectionOracle` 先读这份过期源 SQLite 并抛 `migration_projection_oracle_cut_mismatch`——恰好永久挡住修复台账用的 `migrate-import`。现在仅该 typed 码回落到一次性 scratch 重放(重放已检视并机械规范化的事件流),且重建 oracle 的水位必须精确到达 canonical 事件头才被接受;其余错误保持原 typed 路径。病灶钉死:`migration-import-event/v1` 的 task 实体缺 `payload.entity.provenance`(三仓共 318 个事件,形状全同)——重述为 `provenance: "imported_snapshot"`(迁移导入事件内的 task 按定义就是导入快照),并在 dry-run 观察里显式记名。其后露出第二种机械 legacy 形态:历史 `task-contract-snapshot/v1` 把 preset digest 存在嵌套 `preset.digest`(218/218、33/33、54/54 全部可用、零缺失);restater 仅对该 schema 原样复制该 SHA-256,绝不合成 digest。

## 架构辩护

- 机制句:派生缓存的新鲜度拒绝,不得阻塞能从同一不可变源规范化重放出可验证一次性视图的修复操作。
- 窄触发、严接受:仅那一个 typed 码回落;重建不到头就原码重抛——不伪造水位、不放松校验。
- 只读成立:scratch 用 `mkdtemp` SQLite 且 `finally` 删除;源库只读打开(三个生产源实测 mtime/size 前后一致)。
- 多节点:恢复准入仍由 #2080 的 RepoCell 单占串行;oracle 纯读推导,无新写者/队列/claim/共享 artifact。

## 改动内容

- `migration-import-oracle.ts`:DB 存在分支仅捕获该 typed 码回落重建路。
- `migration-import-oracle-rebuild.ts`:重建 oracle 必须到头;provenance 重述记名进 dry-run 观察。
- `migration-import-task-restatement.ts`:仅对 `task-contract-snapshot/v1` 接受嵌套 `preset.digest`。
- 测试 +216/−2:红→绿重建用例、provenance 重述、嵌套 digest 保留、隔离原地全量 dry-run fixture(Ubuntu 10/10)。

## 门收割 / Gate Harvest

- 删除的生产路径:无;same-cut 正常路保持唯一正路,typed 失配成为受控触发器,无双路残留。

## 机读声明说明

`Production-Delta` 由 gate 实测(+64/−12)。

## 任务与范围

- Task `task_4e43f05b319bc0108014b727d7`(解锁 task_b85c1c56;诊断 F-DE1428F9);分支 `codex/migrate-oracle-inplace`。

## 版本影响

- 不改版本、不发布。

## 治理声明

- 未触碰受保护面(纯 packages diff);授权=task_4e43f05b319bc0108014b727d7;非 break-glass。

## 验证

- worker:聚焦 fast 17/17(新两例改前红改后绿)、隔离 Ubuntu 集成 10/10(含原地全量 dry-run fixture)、prettier/eslint/tsc/diff-check 过;三真实源只读跑 oracle 收敛 718/718、999/999、4047/4047(F-E8213E60),源 SQLite 未动。
- CEO:rebase 到 2c0fd5094;typecheck+duplicate-definitions 重跑绿;完整权威=GitHub CI。

## 审查证据

- CEO 语义验收:触发器单 typed 码+严格到头接受;重述语义无歧义(318/318 同形);嵌套 digest 处理限定 legacy schema 且全量可用计数;无保留双路。

## 残余风险

- 三仓生产 dry-run/apply/re-attach/幂等验证为合并部署后 CEO 自留后续;本 PR 的 GitHub CI 为完整权威。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VTzQAqvuFy6ikGjBKxA9xj
