### PR TITLE
fix(daemon): restate legacy migration task provenance through fact-rekey

### DIFF
--- a/packages/daemon/src/fact-rekey-event-read.ts
+++ b/packages/daemon/src/fact-rekey-event-read.ts
@@ -1,0 +1,109 @@
+import path from "node:path";
+import {
+  consumeKnownError,
+  isFactEvent,
+  ledgerGitPath,
+  localGitObjectRefStore,
+  parseCanonicalEvent,
+  resolveLedgerGitLayout,
+  validateFactEvent,
+  type CanonicalEventStore,
+  type FactEventV1,
+  type PersistedCanonicalEventV1,
+} from "../../kernel/src/index.ts";
+import {
+  restateLegacyMigrationTaskProvenance,
+  type MigrationEventRead,
+  type MigrationTaskProvenanceRestatement,
+} from "./migration-task-provenance-restatement.ts";
+import { isJsonObject } from "./protocol/json-rpc-types.ts";
+
+export function readFactRekeyEvents(rootDir: string, store: CanonicalEventStore): MigrationEventRead {
+  const ledger = resolveLedgerGitLayout(rootDir),
+    commit = store.currentCommit().sha,
+    prefix = ledgerGitPath(ledger, "events/");
+  const entries = localGitObjectRefStore
+    .listTree(ledger.rootDir, commit, ledger.authoredPrefix || undefined)
+    .filter(({ target }) => target.startsWith(prefix) && !target.endsWith("/head.json") && target.endsWith(".json"));
+  if (entries.length === 0) return { events: [], migrationTaskProvenanceRestatements: [] };
+  const output = localGitObjectRefStore.batch(ledger.rootDir, `${entries.map(({ oid }) => oid).join("\n")}\n`),
+    events: PersistedCanonicalEventV1[] = [],
+    migrationTaskProvenanceRestatements: MigrationTaskProvenanceRestatement[] = [];
+  let cursor = 0;
+  for (const entry of entries) {
+    const headerEnd = output.indexOf(10, cursor);
+    if (headerEnd < 0) break;
+    const size = Number(output.subarray(cursor, headerEnd).toString("utf8").split(" ").at(-1)),
+      start = headerEnd + 1,
+      body = output.subarray(start, start + size).toString("utf8");
+    cursor = start + size + 1;
+    let value: unknown;
+    try {
+      value = JSON.parse(body);
+    } catch (error) {
+      consumeKnownError(error);
+      events.push(parseCanonicalEvent(body));
+      continue;
+    }
+    try {
+      events.push(normalizeLegacyFactEvent(value) ?? parseCanonicalEvent(body));
+    } catch (error) {
+      const sourcePath = entry.target.split(path.sep).join("/"),
+        restated = restateLegacyMigrationTaskProvenance(value, body);
+      if (restated === null) throw error;
+      consumeKnownError(error);
+      events.push(restated);
+      migrationTaskProvenanceRestatements.push({ opId: restated.opId, sourcePath });
+    }
+  }
+  return {
+    events: events.sort((left, right) => left.workspaceRevision - right.workspaceRevision),
+    migrationTaskProvenanceRestatements: migrationTaskProvenanceRestatements.sort(
+      (left, right) => left.sourcePath.localeCompare(right.sourcePath) || left.opId.localeCompare(right.opId),
+    ),
+  };
+}
+
+function normalizeLegacyFactEvent(value: unknown): FactEventV1 | null {
+  if (!isJsonObject(value) || value.schema !== "fact-event/v1" || !isJsonObject(value.payload)) return null;
+  const payload = value.payload;
+  if (!Array.isArray(payload.provenance) || !isJsonObject(payload.factsDocumentClaim)) return null;
+  const provenance = payload.provenance.map((entry) => {
+    if (
+      !isJsonObject(entry) ||
+      typeof entry.runtime !== "string" ||
+      (typeof entry.sessionId !== "string" && entry.sessionId !== null) ||
+      typeof entry.boundAt !== "string"
+    )
+      return null;
+    return {
+      ...entry,
+      runtime: entry.runtime,
+      sessionId: entry.sessionId,
+      boundAt: entry.boundAt,
+      transcriptReachability:
+        entry.transcriptReachability === "dispatch_stream_only" || entry.transcriptReachability === "unavailable"
+          ? entry.transcriptReachability
+          : ("by_session_id" as const),
+    };
+  });
+  if (provenance.some((entry) => entry === null) || typeof value.factId !== "string") return null;
+  const normalized = { ...value, schema: "fact-event/v1" as const, payload: { ...payload, provenance } };
+  const legacySupersedes = isJsonObject(payload.supersedes) ? payload.supersedes : null,
+    legacySupersededFactId =
+      typeof legacySupersedes?.factRef === "string"
+        ? /^fact\/[^/]+\/(F-[0-9A-HJKMNP-TV-Z]{8})$/u.exec(legacySupersedes.factRef)?.[1]
+        : undefined;
+  const validationCandidate = {
+    ...normalized,
+    payload: {
+      ...normalized.payload,
+      factsDocumentClaim: { ...payload.factsDocumentClaim, path: `facts/${value.factId}.md` },
+      ...(legacySupersededFactId && legacySupersedes
+        ? { supersedes: { ...legacySupersedes, factRef: `fact/${legacySupersededFactId}` } }
+        : {}),
+    },
+  };
+  if (validateFactEvent(validationCandidate).length > 0 || !isFactEvent(normalized)) return null;
+  return normalized;
+}

--- a/packages/daemon/src/fact-rekey-evidence.ts
+++ b/packages/daemon/src/fact-rekey-evidence.ts
@@ -13,6 +13,10 @@ export interface FactRekeyEvidencePlan {
   readonly eventRewrites: readonly { readonly event: PersistedCanonicalEventV1 }[];
   readonly docsOnly: readonly unknown[];
   readonly embeddedRelationRestatements: readonly EmbeddedRelationRestatementDifference[];
+  readonly migrationTaskProvenanceRestatements: readonly {
+    readonly opId: string;
+    readonly sourcePath: string;
+  }[];
   readonly rewrittenAgentEvents: number;
   readonly rewrittenSettingsEvents: number;
 }
@@ -30,6 +34,7 @@ export function factRekeyEvidence(plan: FactRekeyEvidencePlan) {
     },
     counts: factRekeyCounts(plan),
     embeddedRelationRestatements: plan.embeddedRelationRestatements,
+    migrationTaskProvenanceRestatements: plan.migrationTaskProvenanceRestatements,
   };
 }
 
@@ -43,6 +48,7 @@ function factRekeyCounts(plan: FactRekeyEvidencePlan): Record<string, number> {
       ({ event }) => isMigrationImportEvent(event) && event.payload.entity.kind === "relation",
     ).length,
     rewrittenEmbeddedRelationEvents: plan.embeddedRelationRestatements.length,
+    rewrittenMigrationTaskEvents: plan.migrationTaskProvenanceRestatements.length,
     rewrittenDecisionEvents: plan.eventRewrites.filter(({ event }) => event.schema === "decision-event/v1").length,
     rewrittenTaskEvents: plan.eventRewrites.filter(({ event }) => event.schema === "task-event/v1").length,
     rewrittenAgentEvents: plan.rewrittenAgentEvents,

--- a/packages/daemon/src/fact-rekey.ts
+++ b/packages/daemon/src/fact-rekey.ts
@@ -34,13 +34,11 @@ import {
   serializePersistedCanonicalEvent,
   sha256Text,
   stableStringify,
-  validateFactEvent,
   type CanonicalEventV1,
   type CanonicalEventStore,
   type DecisionDocumentState,
   type DecisionEventV1,
   type DocEventV1,
-  type FactEventV1,
   type MigrationImportEventV1,
   type FactMemoryTag,
   type PersistedCanonicalEventV1,
@@ -57,6 +55,8 @@ import {
   type EmbeddedRelationRestatementDifference,
 } from "./embedded-relation-restatement.ts";
 import { factRekeyEvidence, factRekeyIdMapBody } from "./fact-rekey-evidence.ts";
+import { type MigrationTaskProvenanceRestatement } from "./migration-task-provenance-restatement.ts";
+import { readFactRekeyEvents } from "./fact-rekey-event-read.ts";
 import { isJsonObject, type JsonValue } from "./protocol/json-rpc-types.ts";
 import type { RepoCellBinding, RepoTaskAction } from "./repo-cell-types.ts";
 
@@ -90,7 +90,6 @@ interface RewrittenEntityBlob {
   readonly sha256: string;
   readonly body: string;
 }
-
 interface FactRekeyPlan {
   readonly facts: readonly LegacyFact[];
   readonly map: ReadonlyMap<string, string>;
@@ -112,6 +111,7 @@ interface FactRekeyPlan {
   readonly rewrittenAgentEvents: number;
   readonly rewrittenSettingsEvents: number;
   readonly embeddedRelationRestatements: readonly EmbeddedRelationRestatementDifference[];
+  readonly migrationTaskProvenanceRestatements: readonly MigrationTaskProvenanceRestatement[];
   readonly docsOnly: readonly MappedLegacyFact[];
 }
 
@@ -127,7 +127,7 @@ export function runFactRekey(input: {
   const mapBody = factRekeyIdMapBody(plan);
   const digest = sha256Text(mapBody);
   const markerOpId = `op_${sha256Text(`fact-rekey\0${digest}`)}`;
-  const existingMarker = migrationEvents(input.rootDir, input.store).find(
+  const existingMarker = readFactRekeyEvents(input.rootDir, input.store).events.find(
     (event: PersistedCanonicalEventV1) =>
       isMigrationImportEvent(event) &&
       event.payload.entity.kind === "id-map" &&
@@ -268,7 +268,8 @@ export function runFactRekey(input: {
 }
 
 function buildPlan(rootDir: string, store: CanonicalEventStore): FactRekeyPlan {
-  const events = migrationEvents(rootDir, store),
+  const eventRead = readFactRekeyEvents(rootDir, store),
+    events = eventRead.events,
     cold = readLegacyMigrationSource(rootDir),
     legacyEventRevisions = new Map<string, number>(),
     rows = new Map(cold.facts.map((row) => [`fact/${row.taskId}/${row.factId}`, row]));
@@ -351,6 +352,7 @@ function buildPlan(rootDir: string, store: CanonicalEventStore): FactRekeyPlan {
     decisionRelations = new Map<string, DecisionDocumentState["relations"]>(),
     identityRefsChanged = map.size > 0 || [...relationMap].some(([from, to]) => from !== to),
     rewriteCounts = { agent: 0, settings: 0 },
+    forcedEventRewrites = new Set(eventRead.migrationTaskProvenanceRestatements.map(({ opId }) => opId)),
     legacyEvents = new Set(
       events
         .filter(
@@ -462,7 +464,7 @@ function buildPlan(rootDir: string, store: CanonicalEventStore): FactRekeyPlan {
     }
     if (identityRefsChanged && next.schema === "task-event/v1" && next.type === "review_consent_recorded")
       next = rekeyReviewConsentProof(next);
-    if (stableStringify(next) !== stableStringify(event))
+    if (forcedEventRewrites.has(next.opId) || stableStringify(next) !== stableStringify(event))
       eventRewrites.push({ event: next, body: serializePersistedCanonicalEvent(next) });
   }
   const docsOnly: readonly MappedLegacyFact[] = facts
@@ -533,6 +535,7 @@ function buildPlan(rootDir: string, store: CanonicalEventStore): FactRekeyPlan {
     rewrittenAgentEvents: rewriteCounts.agent,
     rewrittenSettingsEvents: rewriteCounts.settings,
     embeddedRelationRestatements: embeddedRelationPlan.differences,
+    migrationTaskProvenanceRestatements: eventRead.migrationTaskProvenanceRestatements,
     docsOnly,
   };
 }
@@ -635,79 +638,6 @@ function mergeDecisionRelations(
 
 function legacyFactsDocumentName(): string {
   return ["facts", "md"].join(".");
-}
-
-function migrationEvents(rootDir: string, store: CanonicalEventStore): PersistedCanonicalEventV1[] {
-  const ledger = resolveLedgerGitLayout(rootDir),
-    commit = store.currentCommit().sha,
-    prefix = ledgerGitPath(ledger, "events/");
-  const entries = localGitObjectRefStore
-    .listTree(ledger.rootDir, commit, ledger.authoredPrefix || undefined)
-    .filter(({ target }) => target.startsWith(prefix) && !target.endsWith("/head.json") && target.endsWith(".json"));
-  if (entries.length === 0) return [];
-  const output = localGitObjectRefStore.batch(ledger.rootDir, `${entries.map(({ oid }) => oid).join("\n")}\n`);
-  const events: PersistedCanonicalEventV1[] = [];
-  let cursor = 0;
-  for (const _entry of entries) {
-    const headerEnd = output.indexOf(10, cursor);
-    if (headerEnd < 0) break;
-    const size = Number(output.subarray(cursor, headerEnd).toString("utf8").split(" ").at(-1)),
-      start = headerEnd + 1,
-      body = output.subarray(start, start + size).toString("utf8");
-    cursor = start + size + 1;
-    try {
-      const value: unknown = JSON.parse(body);
-      events.push(normalizeLegacyFactEvent(value) ?? parseCanonicalEvent(body));
-    } catch (error) {
-      consumeKnownError(error);
-      continue;
-    }
-  }
-  return events.sort((left, right) => left.workspaceRevision - right.workspaceRevision);
-}
-
-function normalizeLegacyFactEvent(value: unknown): FactEventV1 | null {
-  if (!isJsonObject(value) || value.schema !== "fact-event/v1" || !isJsonObject(value.payload)) return null;
-  const payload = value.payload;
-  if (!Array.isArray(payload.provenance) || !isJsonObject(payload.factsDocumentClaim)) return null;
-  const provenance = payload.provenance.map((entry) => {
-    if (
-      !isJsonObject(entry) ||
-      typeof entry.runtime !== "string" ||
-      (typeof entry.sessionId !== "string" && entry.sessionId !== null) ||
-      typeof entry.boundAt !== "string"
-    )
-      return null;
-    return {
-      ...entry,
-      runtime: entry.runtime,
-      sessionId: entry.sessionId,
-      boundAt: entry.boundAt,
-      transcriptReachability:
-        entry.transcriptReachability === "dispatch_stream_only" || entry.transcriptReachability === "unavailable"
-          ? entry.transcriptReachability
-          : ("by_session_id" as const),
-    };
-  });
-  if (provenance.some((entry) => entry === null) || typeof value.factId !== "string") return null;
-  const normalized = { ...value, schema: "fact-event/v1" as const, payload: { ...payload, provenance } };
-  const legacySupersedes = isJsonObject(payload.supersedes) ? payload.supersedes : null,
-    legacySupersededFactId =
-      typeof legacySupersedes?.factRef === "string"
-        ? /^fact\/[^/]+\/(F-[0-9A-HJKMNP-TV-Z]{8})$/u.exec(legacySupersedes.factRef)?.[1]
-        : undefined;
-  const validationCandidate = {
-    ...normalized,
-    payload: {
-      ...normalized.payload,
-      factsDocumentClaim: { ...payload.factsDocumentClaim, path: `facts/${value.factId}.md` },
-      ...(legacySupersededFactId && legacySupersedes
-        ? { supersedes: { ...legacySupersedes, factRef: `fact/${legacySupersededFactId}` } }
-        : {}),
-    },
-  };
-  if (validateFactEvent(validationCandidate).length > 0 || !isFactEvent(normalized)) return null;
-  return normalized;
 }
 
 function buildAuthoredRekeyEvents(

--- a/packages/daemon/src/migration-task-provenance-restatement.ts
+++ b/packages/daemon/src/migration-task-provenance-restatement.ts
@@ -1,0 +1,53 @@
+import {
+  consumeKnownError,
+  isMigrationImportEvent,
+  normalizePersistedCanonicalEvent,
+  parseCanonicalEvent,
+  serializePersistedCanonicalEvent,
+  stableStringify,
+  type PersistedCanonicalEventV1,
+} from "../../kernel/src/index.ts";
+import { isJsonObject } from "./protocol/json-rpc-types.ts";
+
+export interface MigrationTaskProvenanceRestatement {
+  readonly opId: string;
+  readonly sourcePath: string;
+}
+export interface MigrationEventRead {
+  readonly events: readonly PersistedCanonicalEventV1[];
+  readonly migrationTaskProvenanceRestatements: readonly MigrationTaskProvenanceRestatement[];
+}
+
+export function restateLegacyMigrationTaskProvenance(value: unknown, body: string): PersistedCanonicalEventV1 | null {
+  if (
+    !isJsonObject(value) ||
+    value.schema !== "migration-import-event/v1" ||
+    !isJsonObject(value.payload) ||
+    !isJsonObject(value.payload.entity) ||
+    value.payload.entity.kind !== "task" ||
+    Object.hasOwn(value.payload.entity, "provenance") ||
+    `${stableStringify(value)}\n` !== body
+  )
+    return null;
+  const normalized = normalizePersistedCanonicalEvent(
+      value as unknown as PersistedCanonicalEventV1,
+    ) as unknown as Record<string, unknown>,
+    payload = normalized.payload;
+  if (!isJsonObject(payload) || !isJsonObject(payload.entity)) return null;
+  const candidate = {
+    ...normalized,
+    payload: {
+      ...payload,
+      entity: { ...payload.entity, provenance: "imported_snapshot" },
+    },
+  };
+  try {
+    const event = parseCanonicalEvent(
+      serializePersistedCanonicalEvent(candidate as unknown as PersistedCanonicalEventV1),
+    );
+    return isMigrationImportEvent(event) && event.payload.entity.kind === "task" ? event : null;
+  } catch (error) {
+    consumeKnownError(error);
+    return null;
+  }
+}

--- a/packages/daemon/test/fact-rekey-migration-task-provenance.integration.test.ts
+++ b/packages/daemon/test/fact-rekey-migration-task-provenance.integration.test.ts
@@ -1,0 +1,216 @@
+// harness-test-tier: integration
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import {
+  REPLAY_TASK_GRAPH,
+  eventObjectRelativePath,
+  makeTaskEventStore,
+  migrationImportWritePlan,
+  serializeEventHead,
+  serializePersistedCanonicalEvent,
+  sha256Text,
+  stableStringify,
+  type MigrationImportEventV1,
+} from "../../kernel/src/index.ts";
+import { canonicalRoot, workspaceId } from "../src/protocol/daemon-protocol.contract.ts";
+import { openRepoCell, type RepoCell } from "../src/repo-cell.ts";
+import { actor, initRepo } from "./migration-import.fixtures.ts";
+import { openBootstrappedRepoCell } from "./repo-settings.fixture.ts";
+
+test("fact rekey restates legacy migration task provenance and is idempotent", async () => {
+  const fixture = await legacyMigrationTaskFixture("missing-provenance");
+  let cell: RepoCell | undefined;
+  try {
+    const unreadable = makeTaskEventStore({ repoId: fixture.repoId, rootDir: fixture.rootDir });
+    assert.throws(() => unreadable.read(), /migration task entity is invalid/u);
+
+    cell = await openRepoCell({
+      repoId: workspaceId(fixture.repoId),
+      rootDir: canonicalRoot(fixture.rootDir),
+      ownerId: "migration-task-provenance-recovery",
+      now: () => "2026-09-01T02:00:00.000Z",
+    });
+    const preview = await cell.run({ kind: "fact-rekey", dryRun: true }, fixture.binding),
+      previewEvidence = JSON.parse(String(preview.evidence)) as {
+        readonly counts: { readonly rewrittenMigrationTaskEvents: number };
+        readonly migrationTaskProvenanceRestatements: readonly {
+          readonly opId: string;
+          readonly sourcePath: string;
+        }[];
+      };
+    assert.equal(preview.outcome, "pending", JSON.stringify(preview));
+    assert.equal(previewEvidence.counts.rewrittenMigrationTaskEvents, 1);
+    assert.deepEqual(previewEvidence.migrationTaskProvenanceRestatements, [
+      { opId: fixture.event.opId, sourcePath: fixture.sourcePath },
+    ]);
+
+    const applied = await cell.run({ kind: "fact-rekey" }, fixture.binding);
+    assert.equal(applied.outcome, "applied", JSON.stringify(applied));
+    assert.equal(cell.status().state, "attached");
+    assert.equal((await cell.run({ kind: "task-list" }, fixture.binding)).outcome, "applied");
+
+    const repairedStore = makeTaskEventStore({ repoId: fixture.repoId, rootDir: fixture.rootDir }),
+      repaired = repairedStore.readEvent(fixture.event.opId);
+    assert.equal(repaired?.schema, "migration-import-event/v1");
+    if (repaired?.schema === "migration-import-event/v1" && repaired.payload.entity.kind === "task") {
+      assert.equal(repaired.eventId, fixture.event.eventId);
+      assert.equal(repaired.opId, fixture.event.opId);
+      assert.equal(repaired.workspaceRevision, fixture.event.workspaceRevision);
+      assert.equal(repaired.payload.entity.provenance, "imported_snapshot");
+      assert.equal(repaired.payload.entity.task.schema, "task/v2");
+      assert.equal(repaired.payload.entity.task.pinned, false);
+      assert.equal(repaired.payload.entity.task.packageDisposition, "active");
+    }
+
+    const repeated = await cell.run({ kind: "fact-rekey" }, fixture.binding),
+      repeatedEvidence = JSON.parse(String(repeated.evidence)) as {
+        readonly counts: { readonly rewrittenMigrationTaskEvents: number };
+      };
+    assert.equal(repeated.outcome, "no_changes", JSON.stringify(repeated));
+    assert.equal(repeatedEvidence.counts.rewrittenMigrationTaskEvents, 0);
+
+    await cell.close();
+    cell = undefined;
+    cell = await openRepoCell({
+      repoId: workspaceId(fixture.repoId),
+      rootDir: canonicalRoot(fixture.rootDir),
+      ownerId: "migration-task-provenance-reattach",
+    });
+    assert.equal(cell.status().state, "attached");
+    assert.equal((await cell.run({ kind: "task-list" }, fixture.binding)).outcome, "applied");
+  } finally {
+    await cell?.close();
+    rmSync(fixture.rootDir, { recursive: true, force: true });
+  }
+});
+
+test("fact rekey preserves the typed rejection for a non-target invalid migration task", async () => {
+  const fixture = await legacyMigrationTaskFixture("missing-original-status");
+  let cell: RepoCell | undefined;
+  try {
+    cell = await openRepoCell({
+      repoId: workspaceId(fixture.repoId),
+      rootDir: canonicalRoot(fixture.rootDir),
+      ownerId: "migration-task-non-target-recovery",
+    });
+    const rejected = await cell.run({ kind: "fact-rekey", dryRun: true }, fixture.binding);
+    assert.equal(rejected.outcome, "op_rejected", JSON.stringify(rejected));
+    assert.equal(rejected.code, "service_rejected");
+    assert.match(String(rejected.nextAction), /migration task entity is invalid/u);
+  } finally {
+    await cell?.close();
+    rmSync(fixture.rootDir, { recursive: true, force: true });
+  }
+});
+
+async function legacyMigrationTaskFixture(defect: "missing-provenance" | "missing-original-status") {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-rekey-migration-task-")),
+    repoId = `rekey-migration-task-${defect}`,
+    taskId = `task_rekey_${defect.replaceAll("-", "_")}`,
+    packagePath = `tasks/${taskId}-legacy`,
+    documentBody = `# Legacy migration task\n`,
+    documentSha = sha256Text(documentBody),
+    binding = { actor, source: "local" as const };
+  initRepo(rootDir);
+  const bootstrap = await openBootstrappedRepoCell({
+    repoId: workspaceId(repoId),
+    rootDir: canonicalRoot(rootDir),
+    ownerId: `bootstrap-${defect}`,
+  });
+  await bootstrap.close();
+
+  const store = makeTaskEventStore({ repoId, rootDir }),
+    event: MigrationImportEventV1 = {
+      schema: "migration-import-event/v1",
+      eventId: `event-${defect}`,
+      workspaceRevision: (store.readHead()?.revision ?? 0) + 1,
+      opId: `op-${defect}`,
+      type: "entity_migrated",
+      actor,
+      source: "migration-import/v1",
+      occurredAt: "2026-08-15T00:00:00.000Z",
+      payload: {
+        migratedFrom: taskId,
+        generation: "v0",
+        entity: {
+          kind: "task",
+          provenance: "imported_snapshot",
+          task: {
+            schema: "task/v2",
+            taskId,
+            title: "Legacy migration task",
+            taskClass: "standard",
+            status: "planned",
+            graph: REPLAY_TASK_GRAPH,
+            currentNode: "implementation",
+            iteration: 0,
+            pinned: false,
+            packageDisposition: "active",
+            createdBy: actor,
+            completionGateIds: [],
+            presetSnapshotDigest: null,
+          },
+          originalStatus: "planned",
+          packagePath,
+          documentClaim: {
+            path: `${packagePath}/INDEX.md`,
+            sha256: documentSha,
+            size: Buffer.byteLength(documentBody),
+            mediaType: "text/markdown",
+            policyId: "typed-migration-import/v1",
+          },
+        },
+      },
+    };
+  store.append({
+    event,
+    plan: migrationImportWritePlan(event),
+    blobs: [
+      {
+        body: documentBody,
+        sha256: documentSha,
+        size: Buffer.byteLength(documentBody),
+        mediaType: "text/markdown",
+      },
+    ],
+  });
+  await store.drain();
+
+  const legacy = JSON.parse(serializePersistedCanonicalEvent(event)) as Record<string, unknown>,
+    payload = legacy.payload as { entity: Record<string, unknown> },
+    entity = payload.entity;
+  if (defect === "missing-provenance") {
+    delete entity.provenance;
+    const task = entity.task as Record<string, unknown>;
+    task.schema = "task/v1";
+    delete task.pinned;
+    delete task.packageDisposition;
+  } else delete entity.originalStatus;
+  const body = `${stableStringify(legacy)}\n`,
+    relativeEventPath = eventObjectRelativePath(event.opId, store.layout()),
+    sourcePath = `harness/${relativeEventPath}`;
+  writeFileSync(path.join(rootDir, sourcePath), body);
+  writeFileSync(
+    path.join(rootDir, "harness/events/head.json"),
+    serializeEventHead({
+      revision: event.workspaceRevision,
+      opId: event.opId,
+      eventDigest: `sha256:${sha256Text(body)}`,
+    }),
+  );
+  git(rootDir, "add", "harness/events");
+  git(rootDir, "commit", "-qm", `seed ${defect} migration event`);
+  git(rootDir, "update-ref", "refs/ha/canonical", "HEAD");
+  for (const suffix of ["", "-shm", "-wal"])
+    rmSync(path.join(rootDir, `.harness/cache/task.sqlite${suffix}`), { force: true });
+  assert.equal(readFileSync(path.join(rootDir, sourcePath), "utf8"), body);
+  return { binding, event, repoId, rootDir, sourcePath };
+}
+
+function git(rootDir: string, ...args: readonly string[]): string {
+  return execFileSync("git", ["-C", rootDir, ...args], { encoding: "utf8" }).trim();
+}


### PR DESCRIPTION
# English

## Summary

Third and final unblocking layer for the tri-repository migrations (after recovery ingress #2080 and the in-place oracle rebuild #2082). The three target ledgers themselves contain 318 legacy `migration-import-event/v1` task events missing `payload.entity.provenance`; the canonical parse layer rightly rejects them, so any read of the target store fails with `service_rejected: migration task entity is invalid`. The existing `fact-rekey` recovery plan now reads canonical event objects as raw JSON only at its established ledger-read boundary and restates exactly one legacy shape: schema `migration-import-event/v1`, entity kind `task`, `provenance` key absent (not merely different), raw bytes canonical, and — after adding `provenance: "imported_snapshot"` plus the existing Task/v1→v2 defaults — strict canonical serialization must succeed. Every other parse failure is rethrown unchanged (a fixture proves a task missing `originalStatus` still returns the original typed rejection). Event identity is preserved (same `eventId`/`opId`/revision/actor/claims; bytes replaced in place, id-map marker appended, head updated through the existing event-store append); a second apply reports `rewrittenMigrationTaskEvents=0`. Dry-run evidence lists one named row per rewrite, so the CEO-owned production acceptance is a direct count check: 218 / 46 / 54 = 318.

## Architectural Justification

- Mechanism sentence: a recovery planner that discards contract-rejected source records before shape-specific restatement cannot repair those records in place — same family as the r5 embedded-relation restatement that repaired this repository (941 rewrites).
- No validation loosened: kernel strict validators untouched; the restated body must pass strict serialization; non-matching failures keep their typed path.
- No second repair mechanism: the logic lives inside the existing fact-rekey plan; the ledger reader was split by responsibility (`fact-rekey-event-read.ts`) to stay under the complexity ceiling.
- Multi-node: still the repository's single `fact-rekey` recovery action on the RepoCell single-write queue behind the #2080 data-shape recovery fence; no new writer, queue, claim, or cache.

## What Changed

- `fact-rekey-event-read.ts` (new, 109): raw-JSON ledger read boundary + exact-shape restatement gate.
- `migration-task-provenance-restatement.ts` (new, 53): the provenance restatement body.
- `fact-rekey.ts` (−79 net here): consumes the split reader; plan counts `rewrittenMigrationTaskEvents`; `fact-rekey-evidence.ts` records one row (unchanged `opId`, Git-tree `sourcePath`) per rewrite.
- New isolated integration suite (216 lines): store rejects legacy bytes → dry-run names one rewrite → apply → parseable + `task list` green + identity preserved → second apply zero → fresh RepoCell attaches; plus the non-target negative.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none

## Machine-Readable Declarations

Production-Delta: +177/-79
Dependency-Change: none

### Optional Evidence Claims

None.

## Task And Scope

- Harness task: `task_b74a4902f247d59e729289d4cd` (final unblock for `task_b85c1c56`; diagnosis Fact `F-4F69541F`)
- Branch: `codex/rekey-migration-provenance`
- Public scope: fact-rekey provenance restatement branch.
- Private planning/evidence: worker report `artifacts/implementation-report.md`.

## Version Impact

- Version: no change. Publish impact: none.

## Governance Declaration

- Protected surface touched: no (packages-only diff).
- Authority: task_b74a4902f247d59e729289d4cd.
- Break-glass: no

## Verification

- Base `origin/main`: `d4c2062a9` (no rebase needed); CEO re-ran typecheck + duplicate-definitions + line-density green.
- Worker: isolated Ubuntu integration 2/2 (red before the change on both behaviors) + fact-rekey regression 1/1; tsc/ESLint/Prettier/file-complexity/implementation-contracts (allowlist unchanged 129)/`git diff --check` pass.
- No production repository was read, dry-run, or mutated by the worker.
- [ ] Full suites: GitHub CI is the authority.

## Review Evidence

- CEO semantic review: restatement gated on the exact absent-key shape with strict re-serialization as the correctness guard; identity preservation matches r5 discipline; idempotency and non-target negative proven; counts field gives the 218/46/54 production accounting anchor.

## Residual Risk

- Production rekey dry-run count check (218/46/54), apply, migrate-import dry-run/apply, re-attach, and idempotency remain CEO-owned after deployment; GitHub CI on this PR is the complete authority.

---

# 中文

## 概要

三仓迁移的第三层(也是最后一层)解锁:前两层为恢复准入 #2080 与 oracle 原地重建 #2082。三个目标台账本体含 318 个缺 `payload.entity.provenance` 的 legacy `migration-import-event/v1` task 事件;canonical parse 层正当地拒收,导致读目标 store 即 `service_rejected: migration task entity is invalid`。现在既有 `fact-rekey` 恢复计划仅在其既定台账读取边界以 raw JSON 读事件对象,且只重述**一种精确形状**:schema 为 `migration-import-event/v1`、entity kind 为 task、`provenance` 键**缺失**(非取值不同)、原始字节 canonical、补 `provenance:"imported_snapshot"` 与既有 Task/v1→v2 默认后必须通过严格序列化。其余 parse 失败一律原样重抛(负例钉死:缺 `originalStatus` 的仍收原 typed 拒绝)。事件身份不变(同 `eventId`/`opId`/revision/actor/claims;字节原位替换、追加 id-map 标记、head 经既有 append 更新);二次 apply 报 `rewrittenMigrationTaskEvents=0`。dry-run 证据逐条记名,生产验收即直接对账:218/46/54=318。

## 架构辩护

- 机制句:在形状化重述之前就丢弃被契约拒收记录的恢复规划器,无法原位修复这些记录——与修复本仓的 r5 嵌入关系重述(941 条)同族。
- 零放松:kernel 严格校验一字未动;重述产物必须过严格序列化;不匹配失败保持 typed 原路。
- 无第二套修复机制:逻辑住在既有 fact-rekey 计划内;台账读取按职责拆出 `fact-rekey-event-read.ts` 以守复杂度门。
- 多节点:仍是该仓唯一 `fact-rekey` 恢复动作,走 RepoCell 单写队列 + #2080 data-shape 恢复单占;无新写者/队列/claim/缓存。

## 改动内容

- 新增 `fact-rekey-event-read.ts`(109,raw 读取边界+精确形状门)与 `migration-task-provenance-restatement.ts`(53,重述本体)。
- `fact-rekey.ts` 消费拆分读者;计划计数 `rewrittenMigrationTaskEvents`;evidence 逐条记录(opId 不变+Git 树 sourcePath)。
- 新隔离集成套件(216 行):拒收→dry-run 记名→apply→可 parse+task list 绿+身份不变→二次 apply 零→新开 RepoCell attach;外加非目标负例。

## 门收割 / Gate Harvest

- 删除的生产路径:无;fact-rekey.ts 净 −79 来自读者拆分。

## 机读声明说明

`Production-Delta` 由 gate 实测(+177/−79)。

## 任务与范围

- Task `task_b74a4902f247d59e729289d4cd`(task_b85c1c56 最终解锁;诊断 F-4F69541F);分支 `codex/rekey-migration-provenance`。

## 版本影响

- 不改版本、不发布。

## 治理声明

- 未触碰受保护面(纯 packages diff);授权=task_b74a4902f247d59e729289d4cd;非 break-glass。

## 验证

- worker:隔离 Ubuntu 集成 2/2(改前两行为均红)+fact-rekey 回归 1/1;tsc/ESLint/Prettier/复杂度/implementation-contracts(129 持平)/diff-check 过;三生产仓零触碰。
- CEO:基 d4c2062a9 无需 rebase;typecheck+duplicate-definitions+line-density 重跑绿;完整权威=GitHub CI。

## 审查证据

- CEO 语义验收:精确缺键形状门+严格再序列化护栏;身份保持照 r5 纪律;幂等与非目标负例齐;counts 字段即 218/46/54 生产对账锚。

## 残余风险

- 生产 rekey dry-run 对账、apply、migrate-import dry-run/apply、re-attach 与幂等验证为部署后 CEO 自留;本 PR 的 GitHub CI 为完整权威。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VTzQAqvuFy6ikGjBKxA9xj
