### PR TITLE
docs: legacy ledger recovery guide (bilingual)

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ The result is a repository that remembers more than its code:
 - [Architecture](./docs-release/architecture/en/00-overview.md) — explore the kernel, storage model, write path, and projections. ([中文](./docs-release/architecture/zh/00-overview.md))
 - [Release posture](./docs-release/release-posture.md) — see what is shipped, foundational, or planned.
 - [Migration](./docs-release/migration-genesis-replay.md) — replay an older-generation ledger into the current format. ([agent skill](./skills/harness-migration/SKILL.md))
+- [Ledger recovery](./docs-release/migration-legacy-ledger-recovery.md) — repair a repository whose legacy ledger the current daemon refuses to attach. ([中文](./docs-release/migration-legacy-ledger-recovery.zh-CN.md))
 - [Minimal example](./examples/minimal-project/) — inspect the smallest working project.
 
 ## Contributing

--- a/docs-release/README.md
+++ b/docs-release/README.md
@@ -128,6 +128,14 @@ mirrors, and the remote boundary.
 
 → **[operations-server-daemon.md](operations-server-daemon.md)**
 
+## Recover a repository that refuses every command
+
+An upgraded daemon can refuse a repository whose ledger still carries legacy migration events.
+That refusal has a defined in-place recovery: read the symptom, preview the fact rekey, reconcile
+the counts, apply, prove idempotency, and confirm the repository re-attaches.
+
+→ **[migration-legacy-ledger-recovery.md](migration-legacy-ledger-recovery.md)**
+
 ## Attribute every write correctly
 
 Human, agent, system, local CLI, and authenticated daemon writes do not use the

--- a/docs-release/README.zh-CN.md
+++ b/docs-release/README.zh-CN.md
@@ -115,6 +115,13 @@ daemon 文档说明当前运维形态和限制：本地 daemon 服务管理、�
 
 → **[operations-server-daemon.zh-CN.md](operations-server-daemon.zh-CN.md)**
 
+## 恢复一个拒绝一切命令的仓库
+
+升级后的 daemon 可能拒收台账里仍带 legacy migration 事件的仓库。这种拒收有明确的原地恢复
+路径：读症状、预演 fact rekey、对账计数、执行、验证幂等，并确认仓库 re-attach。
+
+→ **[migration-legacy-ledger-recovery.zh-CN.md](migration-legacy-ledger-recovery.zh-CN.md)**
+
 ## 正确标注每一次写入的归属
 
 human、agent、system、本地 CLI 与已认证 daemon 并不走同一条身份通道。配置 shell 或团队

--- a/docs-release/migration-legacy-ledger-recovery.md
+++ b/docs-release/migration-legacy-ledger-recovery.md
@@ -1,0 +1,238 @@
+# Legacy Ledger Recovery: When a Repository Refuses Every Command
+
+Status: recovery path for a registered repository whose ledger still carries legacy migration
+events that the current generation rejects on read. This page repairs that repository in place. For
+moving an older-generation repository into a freshly initialized one, read
+[migration-genesis-replay.md](migration-genesis-replay.md) instead.
+
+## The symptom
+
+You upgraded, and now the repository answers every command the same way:
+
+```console
+$ ha task list
+error code=repo_unavailable hint=this workspace stays latched until its ledger data verifies: repair the data-shape cause below, then rerun the command; the next attempt re-probes the ledger and re-attaches automatically once the data verifies. Cause: migration task entity is invalid
+```
+
+Three things are true in that one line:
+
+- The daemon did not lose your data, and it did not lock you out by accident. It refuses to attach
+  the repository because the ledger does not verify against the current canonical-event contract.
+- The cause is a data-shape defect, not an infrastructure fault. The example above names
+  `migration task entity is invalid`; another repository in the same situation names a different
+  field. The recovery path is the same either way.
+- The latch is self-healing by design. Once the data verifies, the next command re-probes the
+  ledger and re-attaches automatically. You do not restart anything to finish that step.
+
+Read the `Cause:` text before anything else. This page covers the data-shape class, where the cause
+points at an event or entity inside your ledger. If the hint instead says the workspace stays
+latched until its *Git or lock infrastructure* recovers, or until its *projection* verifies, this is
+not your page: follow that hint's own instruction (`ha daemon projection rebuild` for the projection
+class, the named infrastructure repair otherwise).
+
+## What is actually wrong
+
+The current daemon reads the ledger through a strict canonical-event parser. A repository migrated
+by an earlier generation can still contain migration events that do not satisfy today's contract —
+for example a `migration-import-event/v1` whose task entity is missing the `provenance` field that
+is now required. The parser refuses the whole ledger, the repository's cell stays unattached
+("latched"), and every command that needs the repository returns `repo_unavailable`.
+
+The repair is not a manual data edit. Three pieces already exist in the daemon, and together they
+make one recovery command sufficient:
+
+- **Recovery admission.** `ha migrate import` and `ha migrate rekey-facts` enter a latched
+  repository through the repository's single-writer recovery ingress. Ordinary commands stay
+  rejected while the data does not verify.
+- **Oracle rebuild.** The migration oracle no longer trusts a stale derived cache. When the cached
+  projection does not match the canonical event head, it rebuilds a disposable view by replaying the
+  inspected, normalized canonical stream, and accepts that view only at the exact event head. You do
+  not touch `.harness/cache/task.sqlite` by hand.
+- **Provenance restatement.** `ha migrate rekey-facts` plans an in-place restatement for the exact
+  legacy shape whose `payload.entity.provenance` key is absent: it adds
+  `provenance: "imported_snapshot"` and normalizes an embedded legacy task body at the same time.
+  Every other invalid shape keeps its typed rejection.
+
+Nothing here relaxes validation. The restated bytes must still pass the same strict canonical-event
+serialization as any other write; the recovery only supplies the field today's contract requires and
+yesterday's writer omitted.
+
+## How recovery admission behaves
+
+One recovery at a time, per repository, through one queue:
+
+- The first recovery command claims the repository's recovery ingress and then joins the existing
+  single-writer queue. A second recovery command arriving while the first is still settling is
+  rejected with `recovery_conflict` and names the command to wait for.
+- A dry-run publishes nothing and does not clear the latch. Only an apply does.
+- Recovery is the only way in. An edge node or a direct file write cannot open an unavailable
+  ledger; there is no second admission mechanism to find or invent.
+
+## Before you start
+
+1. **Run every command from the repository's registered root**, so the daemon resolves the right
+   repository. For multi-repository routing see
+   [operations-server-daemon.md](operations-server-daemon.md).
+2. **Freeze the repository's other writers** — other agents, GUI sessions, scheduled jobs. The
+   recovery command runs through the daemon's single-writer queue, so it does not need the daemon
+   stopped; it does need nothing else writing to that ledger.
+3. **Commit the cut.** The ledger must be a completely committed snapshot. The recovery and the
+   importer both refuse an uncommitted source, and that refusal is correct: an uncommitted cut
+   cannot be verified or replayed.
+4. **Back up the ledger.** Tag the ledger's own nested git repository, not the outer project
+   repository:
+
+   ```bash
+   git -C <project-root>/harness tag backup/pre-migrate-<name>-<yyyymmdd>
+   git -C <project-root>/harness rev-parse backup/pre-migrate-<name>-<yyyymmdd>
+   ```
+
+   The tag must resolve to the ledger repository's own `HEAD`. A tag attempted from an outer
+   project-repository commit is rejected by git, because those objects do not exist in the nested
+   ledger repository.
+
+## The recovery, step by step
+
+| Step | You run | Expected shape | Then |
+| --- | --- | --- | --- |
+| 1. Confirm the symptom | `ha task list` | `error code=repo_unavailable … Cause: <data-shape cause>`, exit 1 | If the cause is a data-shape defect, continue. |
+| 2. Freeze writers, commit the cut | `git -C <project-root>/harness status --porcelain` | empty | Commit outstanding ledger edits first. |
+| 3. Back up | `git -C <project-root>/harness tag …` | tag resolves to ledger `HEAD` | Keep the tag; do not delete it after success. |
+| 4. Preview | `ha migrate rekey-facts --dry-run` | counts line, one row per restated event, marker line | Reconcile the counts (below). |
+| 5. Apply | `ha migrate rekey-facts` | same counts and rows, marker line without the preview op | — |
+| 6. Prove idempotency | `ha migrate rekey-facts --dry-run` | every count `0`, no rows | Done; nothing was left half-applied. |
+| 7. Confirm re-attach | `ha task list` | task rows, no error | The repository is usable again. |
+
+### 4. Preview the recovery plan
+
+```bash
+ha migrate rekey-facts --dry-run
+```
+
+```text
+maps:
+counts: rekeyedFacts=0  factEvents=0  producesEdges=0  retargetedRelations=0  rewrittenRelationEvents=0  rewrittenEmbeddedRelationEvents=0  rewrittenMigrationTaskEvents=<N>  rewrittenDecisionEvents=0  rewrittenTaskEvents=0  rewrittenAgentEvents=0  rewrittenSettingsEvents=0
+migrationTaskProvenanceRestatements:
+migration-<op-id>	events/<shard>/migration-<op-id>.json
+… one row per restated event …
+schema=fact-rekey-id-map/v1  markerOpId=op_<sha256>
+```
+
+Add `--json` for the same receipt as one machine-readable object.
+
+### 5. Reconcile, then apply
+
+Reconcile before you apply. Two checks, both mechanical:
+
+- `rewrittenMigrationTaskEvents` is the number of legacy migration task events the recovery will
+  restate. It must equal the number of `migrationTaskProvenanceRestatements` rows, and you should
+  be able to account for it against your own history — how many tasks did that older migration
+  import?
+- Every other count is `0`. A non-zero count on another rewrite surface means the recovery is
+  planning work this page does not describe. Stop and read that report before applying.
+
+Then apply:
+
+```bash
+ha migrate rekey-facts
+```
+
+The apply prints the same counts and the same rows, and ends with the marker line
+`schema=fact-rekey-id-map/v1` without the preview `markerOpId`. The restated events keep their
+identity — same `eventId`, same `opId`, same revision — and change only the missing provenance key,
+plus the normalization of an embedded legacy task body where one is present. The command then
+rebuilds the projection from the repaired ledger.
+
+If the ledger still uses the legacy `flat/v1` object layout, the apply receipt ends with an advisory
+line naming `ha migrate ledger`. That is an observation about layout, not an error, and it does not
+affect this recovery.
+
+### 6. Prove idempotency
+
+```bash
+ha migrate rekey-facts --dry-run
+```
+
+```text
+maps:
+counts: rekeyedFacts=0  factEvents=0  producesEdges=0  retargetedRelations=0  rewrittenRelationEvents=0  rewrittenEmbeddedRelationEvents=0  rewrittenMigrationTaskEvents=0  rewrittenDecisionEvents=0  rewrittenTaskEvents=0  rewrittenAgentEvents=0  rewrittenSettingsEvents=0
+schema=fact-rekey-id-map/v1
+```
+
+Every count is `0`, there are no restatement rows, and no preview marker. A second apply with the
+same result is also safe: repeat apply is a no-op.
+
+### 7. Confirm the repository re-attached
+
+```bash
+ha task list
+```
+
+Task rows come back and no error is printed. You did not run a re-attach command, and none exists:
+the latch re-probes on the next command after the data verifies.
+
+### If you also need to merge an external snapshot
+
+The recovery above repairs the repository you are standing in. It does not merge anything in. If you
+also have a second, external Harness repository to merge into this one, that is the genesis-replay
+import path, and it now enters through the same recovery admission:
+
+```bash
+ha migrate import --source <path-to-other-repo>/harness --dry-run
+ha migrate import --source <path-to-other-repo>/harness
+```
+
+The dry-run writes nothing and reconciles five active entity kinds — task / decision / fact /
+relation / execution — against a same-cut or disposable rebuilt oracle. Read
+[migration-genesis-replay.md](migration-genesis-replay.md) for the full procedure, the
+`--resolve` conflict syntax, and the acceptance equality. Run the import dry-run first, every time.
+
+## If something fails
+
+| Report | What it means | Action |
+| --- | --- | --- |
+| `recovery_conflict` | Another recovery command already holds this repository's single-writer recovery ingress. | Wait for the command named in the hint to settle, then rerun. Do not open a second path in. |
+| `publication_indeterminate` with a `git … update-ref …` hint | A commit was made outside the daemon, so the ledger branch no longer points at the last published event commit. | Run the `git -C … update-ref …` command exactly as printed — it moves only the branch pointer and leaves every file in place — then `ha daemon stop`, then retry the recovery. |
+| Source rejected as not completely committed | The ledger work tree has uncommitted changes. | Commit them (or park them), then rerun the dry-run. Do not migrate a dirty cut. |
+| `migration_projection_oracle_cut_mismatch` | A stale derived projection does not match the canonical event head. | The oracle falls back to a disposable rebuild on its own. If the error persists, stop the source's writers and read the nested cause. Do not delete or move `.harness/cache/task.sqlite` by hand — a stale cache is rebuilt in place, and moving it away returns the same verdict. |
+| A typed rejection other than the missing-provenance shape | The ledger contains an invalid event this recovery does not restate. | Keep the ledger, capture the named event and schema, and report it. Guessing a restatement for an undescribed shape is not a recovery. |
+| Dry-run reports every count `0` before any apply, and `ha task list` still fails | The daemon predates the provenance-restatement branch, which skipped invalid events instead of planning their repair. | Upgrade the daemon to a build that carries the restatement, then rerun the dry-run. The count must be non-zero before the latch can clear. |
+| `repo_unavailable` persisting after a clean idempotent dry-run | The latch cause was not the data-shape class this recovery settles. | Read the `Cause:` text again and follow the class-specific hint; see also [operations-server-daemon.md](operations-server-daemon.md). |
+
+Two mistakes worth naming, because both look productive and neither is:
+
+- Deleting or renaming the derived cache by hand does not help. A stale cache is rebuilt in place
+  from the committed events; moving it away gets you a rebuilt cache and the same verdict.
+- Editing the legacy event JSON by hand to add the missing field is not the same operation. The
+  recovery restates events inside the single-writer queue, preserves identity, and re-validates the
+  result. A hand edit outside that queue is exactly the outside-the-daemon commit that produces
+  `publication_indeterminate`.
+
+## FAQ
+
+**Is my data at risk during this recovery?**
+The recovery rewrites event files inside the daemon's single-writer queue, re-validates every
+restated byte against the strict canonical-event contract, and rebuilds the projection from the
+result. You tagged the ledger before starting, so the pre-recovery state is recoverable regardless.
+
+**Why does the dry-run not fix anything?**
+A dry-run publishes nothing and does not clear the latch. It exists so you can reconcile the plan —
+which events, how many, and nothing else — before any byte changes.
+
+**Do I need to stop the daemon?**
+No. The recovery command runs through the daemon's single-writer queue; that queue is what makes the
+rewrite safe. Stop the repository's *other* writers instead. The one place `ha daemon stop` appears
+is the `publication_indeterminate` recovery above, and there it follows the ref repair.
+
+**My counts are not zero on the other surfaces. What do I do?**
+Stop and read the report before applying. This page describes a recovery whose only planned work is
+the provenance restatement; another non-zero count means a different plan, and it needs its own
+understanding rather than a broader approval.
+
+**Will the restated events look migrated?**
+They already did. The restatement adds the `provenance` marker that says this task came in as an
+imported snapshot; it does not change what happened, when it happened, or who did it.
+
+**A command or flag I need isn't on this page.**
+This page covers the recovery surface described above. Run `ha migrate --help` for the authoritative
+command description.

--- a/docs-release/migration-legacy-ledger-recovery.zh-CN.md
+++ b/docs-release/migration-legacy-ledger-recovery.zh-CN.md
@@ -1,0 +1,216 @@
+# Legacy 台账恢复：当仓库拒绝一切命令时
+
+状态：面向「已注册、但台账里仍留着当前代际读取时拒收的 legacy migration 事件」的仓库的恢复
+路径。本页做的是原地修复。若要把上一代际的仓库迁进一个全新初始化的仓库，请改读
+[migration-genesis-replay.zh-CN.md](migration-genesis-replay.zh-CN.md)。
+
+## 症状
+
+你升级之后，这个仓库对所有命令给出同一个回答：
+
+```console
+$ ha task list
+error code=repo_unavailable hint=this workspace stays latched until its ledger data verifies: repair the data-shape cause below, then rerun the command; the next attempt re-probes the ledger and re-attaches automatically once the data verifies. Cause: migration task entity is invalid
+```
+
+这一行里同时有三件事成立：
+
+- daemon 没有弄丢你的数据，也不是误把你锁在门外。它拒绝 attach 这个仓库，是因为台账
+  过不了当前 canonical-event 契约的校验。
+- 成因是数据形状缺陷，不是基础设施故障。上面的例子点名
+  `migration task entity is invalid`；处于同样局面的另一个仓库可能点名别的字段。无论
+  点名哪个，恢复路径都相同。
+- 这个闩是按自愈设计的。数据一旦通过校验，下一条命令会重新探测台账并自动 re-attach。
+  这一步不需要你手工重启任何东西。
+
+动手前先读 `Cause:` 文本。本页覆盖的是 data-shape 这一类——成因指向你台账内部的某个
+事件或实体。如果 hint 说的是工作区要等 *Git 或锁基础设施* 恢复、或等 *projection*
+校验通过，那不是本页的问题：按那条 hint 自己的指示走（projection 类用
+`ha daemon projection rebuild`，infrastructure 类按点名的基础设施修复处理）。
+
+## 到底哪里坏了
+
+当前 daemon 经由严格的 canonical-event 解析器读台账。由更早代际迁移过来的仓库，里面可能
+还留着不满足今天契约的 migration 事件——例如一个 `migration-import-event/v1`，其 task
+实体缺少如今必填的 `provenance` 字段。解析器拒收整个台账，该仓库的 cell 保持未 attach
+（「上闩」），于是每一条需要这个仓库的命令都返回 `repo_unavailable`。
+
+修复不是手工改数据。以下三件已经存在于 daemon 中，合起来让一条恢复命令就足够：
+
+- **恢复准入。** `ha migrate import` 与 `ha migrate rekey-facts` 经由该仓库的单写者恢复
+  通道进入一个上闩的仓库。数据未通过校验期间，普通命令维持拒收。
+- **oracle 重建。** migration oracle 不再信任过期的派生缓存。缓存投影与 canonical 事件头
+  不一致时，它重放检视过的、已规范化的 canonical 流来重建一个一次性视图，并且只有在该
+  视图恰好等于事件头时才接受。你不需要手工处理 `.harness/cache/task.sqlite`。
+- **provenance 重述。** `ha migrate rekey-facts` 会为「`payload.entity.provenance` 键缺失」
+  这一精确的 legacy 形态规划一次原地重述：补上 `provenance: "imported_snapshot"`，并同
+  步规范化内嵌的 legacy task 体。其余无效形态保持原有的 typed 拒绝。
+
+这里没有任何一处放松校验。重述后的字节仍须通过与任何其他写入相同的严格 canonical-event
+序列化；恢复只是补上今天契约要求、而昨天的写入者漏掉的那个字段。
+
+## 恢复准入的行为
+
+每个仓库同一时刻只有一条恢复，走同一条队列：
+
+- 第一条恢复命令先认领该仓库的恢复准入，再加入既有的单写队列。第一条尚未 settle 时
+  到达的第二条恢复命令会以 `recovery_conflict` 拒收，并点名该等待的命令。
+- dry-run 不发布任何东西，也不清闩。只有 apply 会。
+- 恢复是唯一的入口。边缘节点或直接写文件都打不开一个 unavailable 的台账；不存在第二套
+  准入机制可供寻找或发明。
+
+## 开始之前
+
+1. **每条命令都在该仓库的注册根目录下执行**，让 daemon 解析到正确的仓库。多仓库路由见
+   [operations-server-daemon.zh-CN.md](operations-server-daemon.zh-CN.md)。
+2. **冻结该仓库的其他写入者**——其他 agent、GUI 会话、定时任务。恢复命令走 daemon 的
+   单写队列，因此不需要停 daemon；需要的是没有别的东西在写这份台账。
+3. **提交切面。** 台账必须是完全 committed 的快照。恢复与导入器都会拒收未提交的源，这个
+   拒收是对的：未提交的切面既无法校验也无法重放。
+4. **备份台账。** 给台账自己的嵌套 git 仓库打 tag，不是外层项目仓库：
+
+   ```bash
+   git -C <项目根>/harness tag backup/pre-migrate-<名称>-<yyyymmdd>
+   git -C <项目根>/harness rev-parse backup/pre-migrate-<名称>-<yyyymmdd>
+   ```
+
+   tag 必须解析到台账仓库自己的 `HEAD`。用外层项目仓库的 commit 去打 tag 会被 git 拒绝，
+   因为那些对象在嵌套台账仓库里不存在。
+
+## 恢复的逐步流程
+
+| 步骤 | 执行 | 预期形态 | 下一步 |
+| --- | --- | --- | --- |
+| 1. 确认症状 | `ha task list` | `error code=repo_unavailable … Cause: <data-shape 成因>`，退出码 1 | 成因是数据形状缺陷则继续。 |
+| 2. 冻结写入者、提交切面 | `git -C <项目根>/harness status --porcelain` | 为空 | 先把台账的遗留编辑提交掉。 |
+| 3. 备份 | `git -C <项目根>/harness tag …` | tag 解析到台账 `HEAD` | 保留 tag；成功之后也不要删。 |
+| 4. 预演 | `ha migrate rekey-facts --dry-run` | counts 行、每个被重述事件一行、marker 行 | 对账（见下）。 |
+| 5. 执行 | `ha migrate rekey-facts` | 相同的 counts 与行，marker 行不带预演 op | — |
+| 6. 验证幂等 | `ha migrate rekey-facts --dry-run` | 所有计数为 `0`，没有任何行 | 完成；不存在半应用状态。 |
+| 7. 确认 re-attach | `ha task list` | 出任务行，无报错 | 仓库恢复可用。 |
+
+### 4. 预演恢复计划
+
+```bash
+ha migrate rekey-facts --dry-run
+```
+
+```text
+maps:
+counts: rekeyedFacts=0  factEvents=0  producesEdges=0  retargetedRelations=0  rewrittenRelationEvents=0  rewrittenEmbeddedRelationEvents=0  rewrittenMigrationTaskEvents=<N>  rewrittenDecisionEvents=0  rewrittenTaskEvents=0  rewrittenAgentEvents=0  rewrittenSettingsEvents=0
+migrationTaskProvenanceRestatements:
+migration-<op-id>	events/<shard>/migration-<op-id>.json
+… 每个被重述事件一行 …
+schema=fact-rekey-id-map/v1  markerOpId=op_<sha256>
+```
+
+加 `--json` 可得到同一份回执的单对象机器可读形态。
+
+### 5. 对账，然后执行
+
+执行前先对账。两项检查，都是机械的：
+
+- `rewrittenMigrationTaskEvents` 是本次恢复将重述的 legacy migration task 事件数。它必须
+  等于 `migrationTaskProvenanceRestatements` 的行数，而且你应该能用自己的历史把它对上——
+  当年那次旧迁移到底导入了多少个 task？
+- 其余所有计数都是 `0`。若另一个重述面出现非零计数，说明恢复计划里有本页没有描述的
+  工作量。停下来先读那份报告，再决定是否执行。
+
+然后执行：
+
+```bash
+ha migrate rekey-facts
+```
+
+执行输出打印同样的 counts 与同样的行，结尾的 marker 行是
+`schema=fact-rekey-id-map/v1`，不带预演的 `markerOpId`。被重述的事件保持身份——
+`eventId`、`opId`、revision 都不变——只改缺失的 provenance 键，外加在内嵌 legacy task 体
+存在时对它做规范化。命令随后从修复后的台账重建投影。
+
+如果台账仍在使用 legacy `flat/v1` 对象布局，执行回执的结尾会多一行提示
+`ha migrate ledger` 的 advisory。那是对布局的观察，不是错误，也不影响本次恢复。
+
+### 6. 验证幂等
+
+```bash
+ha migrate rekey-facts --dry-run
+```
+
+```text
+maps:
+counts: rekeyedFacts=0  factEvents=0  producesEdges=0  retargetedRelations=0  rewrittenRelationEvents=0  rewrittenEmbeddedRelationEvents=0  rewrittenMigrationTaskEvents=0  rewrittenDecisionEvents=0  rewrittenTaskEvents=0  rewrittenAgentEvents=0  rewrittenSettingsEvents=0
+schema=fact-rekey-id-map/v1
+```
+
+所有计数为 `0`，没有重述行，也没有预演 marker。再执行一次 apply 得到同样结果也是安全的：
+重复 apply 是 no-op。
+
+### 7. 确认仓库已 re-attach
+
+```bash
+ha task list
+```
+
+任务行回来了，不再报错。你没有运行过任何 re-attach 命令，它也不存在：数据通过校验后，
+闩会在下一条命令上自动重探。
+
+### 如果你还需合并外部快照
+
+上面的恢复修复的是你所在的这个仓库，它不合并任何东西进来。若你还有第二个外部的 Harness
+仓库要并入本仓，那是创世重放的 import 路径，而且它现在也走同一条恢复准入：
+
+```bash
+ha migrate import --source <另一仓库路径>/harness --dry-run
+ha migrate import --source <另一仓库路径>/harness
+```
+
+dry-run 不写任何东西，并以同 cut 或一次性重建的 oracle 对五类现役实体——task / decision /
+fact / relation / execution——做对账。完整流程、`--resolve` 冲突语法与验收等式见
+[migration-genesis-replay.zh-CN.md](migration-genesis-replay.zh-CN.md)。每次都先跑 import
+dry-run。
+
+## 出错怎么办
+
+| 报告 | 含义 | 动作 |
+| --- | --- | --- |
+| `recovery_conflict` | 另一条恢复命令已持有该仓库的单写者恢复准入。 | 等 hint 点名的那条命令 settle，再重跑。不要另开第二条路。 |
+| `publication_indeterminate`（带 `git … update-ref …` 提示） | daemon 之外有人 commit 过，台账分支不再指向最后一个已发布事件 commit。 | 原样执行报错里打印的那条 `git -C … update-ref …`——它只移动分支指针，不动任何文件——然后 `ha daemon stop`，再重试恢复。 |
+| 源因未完全提交被拒收 | 台账工作树有未提交改动。 | 提交（或移开）后重跑 dry-run。不要迁移脏切面。 |
+| `migration_projection_oracle_cut_mismatch` | 过期的派生投影与 canonical 事件头不一致。 | oracle 会自行回落到一次性重建。若报错持续，停掉源的写入者并读内层原因。不要手工删除或移动 `.harness/cache/task.sqlite`——过期缓存会被就地重建，把它移开只会得到同样的判定。 |
+| 缺 provenance 形态之外的 typed 拒绝 | 台账里有本恢复不重述的无效事件。 | 保留台账，收集点名的事件与 schema，然后报告。为未描述的形状猜一个重述不是恢复。 |
+| 尚未 apply 时 dry-run 全部计数为 `0`，且 `ha task list` 仍然失败 | daemon 早于 provenance 重述分支，那个版本会跳过无效事件，而不是为它们的修复出计划。 | 把 daemon 升级到带重述分支的构建，再重跑 dry-run。计数非零，闩才有可能被清掉。 |
+| 幂等 dry-run 干净之后仍持续 `repo_unavailable` | 闩的成因不属于本恢复所 settle 的 data-shape 类。 | 重读 `Cause:` 文本并按该类的 hint 处理；另见 [operations-server-daemon.zh-CN.md](operations-server-daemon.zh-CN.md)。 |
+
+有两个错误值得点名，因为它们看起来都很有产出，其实都不是：
+
+- 手工删除或改名派生缓存没有用。过期缓存会被从已提交事件就地重建；把它移开，你会得到
+  一个重建出来的缓存和同一个判定。
+- 手工编辑 legacy 事件 JSON 去补那个缺失字段，不是同一个操作。恢复在单写队列内重述事件、
+  保持身份、并对结果重新校验。在该队列之外的手工编辑，恰恰就是制造
+  `publication_indeterminate` 的那种 daemon 之外的 commit。
+
+## FAQ
+
+**恢复过程中我的数据有风险吗？**
+恢复在 daemon 的单写队列内重写事件文件，把每个被重述的字节重新过一遍严格 canonical-event
+契约校验，并从结果重建投影。你在开始前打了 tag，所以无论如何，恢复前的状态都可回退。
+
+**为什么 dry-run 不修任何东西？**
+dry-run 不发布任何东西，也不清闩。它存在的意义是让你在任何字节改变之前对账这份计划——
+哪些事件、多少条、以及没有别的。
+
+**我需要停 daemon 吗？**
+不需要。恢复命令走 daemon 的单写队列；正是这条队列让重写变得安全。要停的是这个仓库的
+*其他* 写入者。`ha daemon stop` 只出现在上面 `publication_indeterminate` 的恢复里，而且
+那是跟在 ref 修复之后的动作。
+
+**其他面上的计数不是零，怎么办？**
+停下来，先读报告再决定。本页描述的恢复，其唯一计划的工作量就是 provenance 重述；另一个
+计数非零意味着那是另一份计划，需要单独弄清楚，而不是放宽批准范围。
+
+**重述后的事件会看起来像被迁移过吗？**
+它们本来就像。重述补上的 `provenance` 标记说的是这个 task 是作为导入快照进来的；它不改
+变发生了什么、何时发生、以及是谁做的。
+
+**本页没写到的命令或 flag？**
+本页只覆盖上述恢复面。运行 `ha migrate --help` 查看权威的命令描述。


### PR DESCRIPTION
# English

## Summary

User-facing bilingual recovery guide for repositories whose legacy ledger the current daemon refuses to attach (`repo_unavailable` with a data-shape cause). Other users upgrading across the migration generation hit exactly the situation this repository's own three production recoveries exercised; until now the only public coverage was the genesis-replay page, which addresses a different scenario (replaying into a freshly initialized repository) — in-place recovery had no user-facing path. The guide documents the full journey against observed output shapes, not invented ones: confirm the symptom and classify the cause → freeze writers and commit the cut → back up the nested ledger repository (not the outer project repo) → `ha migrate rekey-facts --dry-run` and reconcile the counts → apply → prove idempotency with a second all-zero dry-run → automatic re-attach → optional external-snapshot import via the existing genesis page. Troubleshooting covers every failure actually met in production: `recovery_conflict` single-flight, `publication_indeterminate` with the printed `update-ref` recovery, uncommitted-source rejection, the oracle cut-mismatch (with an explicit "do not touch the cache by hand"), typed rejection of non-restatable shapes, and the pre-restatement daemon's silent-skip trap. Every documented claim is mapped to a source (code path, PR closeout, or production log) in the task's evidence report.

## Architectural Justification

- Docs-only: no code, CI, or gate definition changed; the internal orchestration skill was deliberately not the carrier — public user guidance lives in `docs-release/`.
- Placeholder discipline: all repository names, paths, ids are placeholders (`<project-root>`, `<name>`, `<op-id>`); leak sweep over private repo names, machine paths, emails, task/op ids returned zero (worker self-check and an independent CEO grep).

## What Changed

- `docs-release/migration-legacy-ledger-recovery.md` (new, English) + `.zh-CN.md` (new, Chinese) — full bilingual pair.
- `docs-release/README.md` + `README.zh-CN.md` — index entry added.
- Root `README.md` — one Documentation line linking the recovery guide (CEO addition).

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none

## Machine-Readable Declarations

Production-Delta: +0/-0
Dependency-Change: none

### Optional Evidence Claims

None.

## Task And Scope

- Harness task: `task_99b43b2c6910a417ad1d898bc8`
- Branch: `codex/migration-user-guide`
- Public scope: docs-release recovery guide + index links.
- Private planning/evidence: fact-to-source mapping in the task's report artifact.

## Version Impact

- Version: no change. Publish impact: none.

## Governance Declaration

- Protected surface touched: no (docs-only diff).
- Authority: task_99b43b2c6910a417ad1d898bc8.
- Break-glass: no

## Verification

- `npm run harness:check-docs-release-map`: passed. `git diff --check`: clean.
- Leak sweep (private repo names, `/Users/` paths, emails, task/op ids): zero matches — worker self-check table plus independent CEO grep.
- Command output shapes transcribed from real production recovery logs and negative controls, not invented.
- [ ] Full suites: GitHub CI is the authority.

## Review Evidence

- CEO semantic review: journey matches the production-proven recovery chain step for step (symptom classification → backup-tag discipline → dry-run reconcile → apply → idempotency proof → re-attach); self-healing latch semantics stated accurately; genesis-replay boundary (in-place vs fresh-repo) drawn correctly.

## Residual Risk

- Guide describes the current daemon generation; future recovery-surface changes must update this page (docs-release map gate anchors it).

---

# 中文

## 概要

面向用户的双语恢复指引:当前 daemon 拒绝 attach 其 legacy 台账的仓库(`repo_unavailable`,data-shape 成因)。跨迁移代际升级的其他用户会撞上与本仓三次生产恢复完全相同的处境;此前公开文档只有 genesis-replay 页(面向「迁入全新初始化仓库」的另一场景),原地恢复没有用户路径。指引按**实测输出形状**(非杜撰)写全旅程:确认症状并分类成因 → 冻结写入者、提交切面 → 给嵌套台账仓库(不是外层项目仓库)打备份 tag → `ha migrate rekey-facts --dry-run` 对账计数 → apply → 二次 dry-run 全零证幂等 → 自动 re-attach → 可选经 genesis 页做外部快照导入。Troubleshooting 覆盖生产中实际撞过的每个失败:`recovery_conflict` 单占、`publication_indeterminate` 与打印的 `update-ref` 恢复、未提交源拒收、oracle cut-mismatch(明示「勿手动碰缓存」)、不可重述形态的 typed 拒绝、旧 daemon dry-run 静默跳过陷阱。每条断言在任务证据报告里有溯源(代码路径/PR closeout/生产日志)。

## 架构辩护

- 纯文档:零代码/CI/门改动;公开用户指引的载体是 `docs-release/`,不是内部编排 skill。
- 占位符纪律:仓名/路径/id 全部占位;私有仓名、机器路径、邮箱、task/op id 泄漏扫描零命中(worker 自查 + CEO 独立 grep 互证)。

## 改动内容

- 新增 `docs-release/migration-legacy-ledger-recovery.md` + `.zh-CN.md` 双语对;docs-release 两 README 索引行;root README 一行文档链接(CEO 补)。

## 门收割 / Gate Harvest

- 无删除。

## 机读声明说明

`Production-Delta` 由 gate 实测(+0/−0,纯文档)。

## 任务与范围

- Task `task_99b43b2c6910a417ad1d898bc8`;分支 `codex/migration-user-guide`。

## 版本影响

- 不改版本、不发布。

## 治理声明

- 未触碰受保护面(纯 docs diff);授权=task_99b43b2c6910a417ad1d898bc8;非 break-glass。

## 验证

- `npm run harness:check-docs-release-map` 过;`git diff --check` 干净;泄漏扫描零命中;命令输出形状取自真实生产恢复日志与负例。
- 完整权威=GitHub CI。

## 审查证据

- CEO 语义验收:旅程与生产验证过的恢复链逐步一致;自愈闩语义准确;与 genesis-replay 的边界(原地 vs 新仓)划分正确。

## 残余风险

- 指引描述当前 daemon 代际;恢复面未来变更须同步本页(docs-release map 门锚定)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VTzQAqvuFy6ikGjBKxA9xj
