### PR TITLE
fix(daemon): keep legacy reads off blocking write paths

### DIFF
--- a/packages/application/test/execution-claim-atomicity.test.ts
+++ b/packages/application/test/execution-claim-atomicity.test.ts
@@ -12,6 +12,7 @@ test("claim releases its CAS reservation after response loss and converges from 
     assert.equal(harness.projection.currentLease("task-1")?.phase, "released");
     assert.equal(harness.eventStore.read().events.length, 2);
     assert.equal(harness.eventStore.recover().status, "committed");
+    harness.projection.catchUp();
     const converged = await harness.service.read("task-1");
     assert.equal(converged.status, "ready");
     assert.equal(converged.snapshot.executions[0]?.state, "active");
@@ -26,6 +27,7 @@ test("a claim the lifecycle contract rejects leaves the previous lease untouched
   try {
     await harness.create();
     await harness.start("execution-1", "op-start-1", "2026-08-11T00:02:00.000Z");
+    harness.projection.catchUp();
     // The lease has lapsed by the time the second claim occurs (00:03), so the reservation CAS admits it,
     // but the round still owns an active execution, so the transition rejects the command.
     await assert.rejects(harness.start("execution-2", "op-start-2"), /StartExecution requires a new execution/u);

--- a/packages/application/test/execution-submit-atomicity.test.ts
+++ b/packages/application/test/execution-submit-atomicity.test.ts
@@ -18,12 +18,16 @@ test("G29 submit publishes only its frozen targets while preserving unrelated by
     harness.kill("after_event_write");
     await assert.rejects(harness.submit("execution-1"), /killpoint:after_event_write/u);
     assert.equal(harness.eventStore.recover().status, "committed");
+    harness.projection.catchUp();
 
     const read = await harness.service.read("task-1");
     assert.equal(read.snapshot.executions[0]?.state, "submitted");
     assert.equal(read.snapshot.task?.status, "in_review");
     assert.equal(read.snapshot.task?.currentNode, "review");
-    assert.deepEqual(read.snapshot.edgesTaken.map((edge) => edge.on), ["submitted"]);
+    assert.deepEqual(
+      read.snapshot.edgesTaken.map((edge) => edge.on),
+      ["submitted"],
+    );
     assert.equal(read.snapshot.lease, null);
     assert.deepEqual(readFileSync(sentinel), before);
   } finally {

--- a/packages/application/test/execution-submit-atomicity.test.ts
+++ b/packages/application/test/execution-submit-atomicity.test.ts
@@ -24,10 +24,7 @@ test("G29 submit publishes only its frozen targets while preserving unrelated by
     assert.equal(read.snapshot.executions[0]?.state, "submitted");
     assert.equal(read.snapshot.task?.status, "in_review");
     assert.equal(read.snapshot.task?.currentNode, "review");
-    assert.deepEqual(
-      read.snapshot.edgesTaken.map((edge) => edge.on),
-      ["submitted"],
-    );
+    assert.deepEqual(read.snapshot.edgesTaken.map((edge) => edge.on), ["submitted"]);
     assert.equal(read.snapshot.lease, null);
     assert.deepEqual(readFileSync(sentinel), before);
   } finally {

--- a/packages/application/test/execution-submit-receipt-honesty.test.ts
+++ b/packages/application/test/execution-submit-receipt-honesty.test.ts
@@ -3,7 +3,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { lifecycleHarness } from "./task-lifecycle-test-harness.ts";
 
-test("an authored submit with failed projection reports pending and a safe read converges it", async () => {
+test("an authored submit with failed projection reports pending until explicit catch-up converges it", async () => {
   const harness = lifecycleHarness();
   try {
     await harness.create();
@@ -14,6 +14,7 @@ test("an authored submit with failed projection reports pending and a safe read 
     assert.equal(receipt.outcome, "pending");
     assert.match(receipt.nextAction ?? "", /retry task lifecycle read/u);
     assert.equal(harness.eventStore.read().events.at(-1)?.type, "execution_submitted");
+    harness.projection.catchUp();
     const recovered = await harness.service.read("task-1");
     assert.equal(recovered.status, "ready");
     assert.equal(recovered.snapshot.executions[0]?.state, "submitted");

--- a/packages/application/test/fact-event-service-decision-read-model.test.ts
+++ b/packages/application/test/fact-event-service-decision-read-model.test.ts
@@ -86,10 +86,14 @@ test("Decision list derives E selectors, orders them numerically, filters ranges
   });
 });
 
-test("Decision read catches up an L1-only authored proposal without a body-null crash window", () => {
+test("Decision read serves its cut until explicit catch-up projects an L1-only proposal", () => {
   withDecisionFixture(({ store, projection, service }) => {
     const proposed = compileDecision(projection, decisionEvent(1, "decision_proposed"));
     store.append(proposed);
+    const pending = service.list({ search: "Canonical" });
+    assert.equal(pending.status, "pending");
+    assert.deepEqual(pending.decisions, []);
+    projection.catchUp();
     const listed = service.list({ search: "Canonical" });
     assert.equal(listed.status, "ready");
     assert.equal(listed.watermark, 1);

--- a/packages/application/test/fact-event-service.test.ts
+++ b/packages/application/test/fact-event-service.test.ts
@@ -252,7 +252,7 @@ test("a superseding Fact can audit a dangling canonical Fact ref", () => {
   });
 });
 
-test("search catches up a Fact committed to L1 before the projection transaction", () => {
+test("Fact search serves its cut until explicit catch-up projects an L1-only correction", () => {
   withFixture(({ store, projection, service }) => {
     const original = compile(projection, factEvent(1, "task-fact", "F-ABCDEFGH"));
     store.append(original);
@@ -265,6 +265,10 @@ test("search catches up a Fact committed to L1 before the projection transaction
       }),
     );
     store.append(correction);
+    const pending = service.search({ query: "Fact", taskId: "task-fact" });
+    assert.equal(pending.status, "pending");
+    assert.equal(pending.watermark, 1);
+    projection.catchUp();
     const search = service.search({ query: "Fact", taskId: "task-fact" });
     assert.equal(search.status, "ready");
     assert.equal(search.watermark, 2);
@@ -291,7 +295,15 @@ test("Fact admission never appends against a projection more than one catch-up r
       first = projection.searchFacts({ taskId: "task-backlog" });
     assert.equal(first.status, "pending");
     assert.equal(store.readHead()?.revision, 4097, "pending admission must not append");
-    assert.equal(service.show("F-00000065").fact.factId, "F-00000065");
+    assert.throws(
+      () => service.show("F-00000065"),
+      (error: unknown) => code(error) === "entity_not_found",
+    );
+    assert.throws(
+      () => service.record(compile(projection, collision)),
+      (error: unknown) => code(error) === "content_not_ready",
+    );
+    assert.equal(store.readHead()?.revision, 4097, "one bounded admission round must not append");
     assert.throws(
       () => service.record(compile(projection, collision)),
       (error: unknown) => code(error) === "invalid_transition",

--- a/packages/application/test/review-execution-companion-atomicity.test.ts
+++ b/packages/application/test/review-execution-companion-atomicity.test.ts
@@ -10,10 +10,7 @@ test("changes_requested records Review, return edge, Execution closure, and Task
     await harness.start("execution-1");
     await harness.submit("execution-1");
     harness.kill("after_event_write");
-    await assert.rejects(
-      harness.review("execution-1", "anti_entropy", "changes_requested"),
-      /killpoint:after_event_write/u,
-    );
+    await assert.rejects(harness.review("execution-1", "anti_entropy", "changes_requested"), /killpoint:after_event_write/u);
     assert.equal(harness.eventStore.recover().status, "committed");
     harness.projection.catchUp();
     const snapshot = (await harness.service.read("task-1")).snapshot;

--- a/packages/application/test/review-execution-companion-atomicity.test.ts
+++ b/packages/application/test/review-execution-companion-atomicity.test.ts
@@ -10,8 +10,12 @@ test("changes_requested records Review, return edge, Execution closure, and Task
     await harness.start("execution-1");
     await harness.submit("execution-1");
     harness.kill("after_event_write");
-    await assert.rejects(harness.review("execution-1", "anti_entropy", "changes_requested"), /killpoint:after_event_write/u);
+    await assert.rejects(
+      harness.review("execution-1", "anti_entropy", "changes_requested"),
+      /killpoint:after_event_write/u,
+    );
     assert.equal(harness.eventStore.recover().status, "committed");
+    harness.projection.catchUp();
     const snapshot = (await harness.service.read("task-1")).snapshot;
     assert.equal(snapshot.reviews.at(-1)?.verdict, "changes_requested");
     assert.equal(snapshot.edgesTaken.at(-1)?.on, "changes_requested");

--- a/packages/cli/src/cli-agent-create.ts
+++ b/packages/cli/src/cli-agent-create.ts
@@ -6,10 +6,7 @@ import type { ThinCommand } from "./cli/thin-command.ts";
 import { consumeKnownError, runCommandThroughDaemon } from "./daemon/client.ts";
 import { randomUUID } from "node:crypto";
 
-export async function runAgentCreate(
-  command: ThinCommand,
-  writeActivity: (text: string) => void,
-): Promise<JsonObject> {
+export async function runAgentCreate(command: ThinCommand, writeActivity: (text: string) => void): Promise<JsonObject> {
   const action = command.action as AgentCreateAction,
     designerPrompt = agentDesignerPrompt(action.prompt),
     spawned = await runCommandThroughDaemon({
@@ -27,15 +24,8 @@ export async function runAgentCreate(
         idempotencyKey: `agent-create-${randomUUID()}`,
       },
     });
-  if (spawned.ok !== true || typeof spawned.runtimeSessionId !== "string")
-    return spawned;
-  const settled = await waitForRuntime(
-    command,
-    spawned.runtimeSessionId,
-    !command.json,
-    writeActivity,
-    spawned,
-  );
+  if (spawned.ok !== true || typeof spawned.runtimeSessionId !== "string") return spawned;
+  const settled = await waitForRuntime(command, spawned.runtimeSessionId, !command.json, writeActivity, spawned);
   if (
     settled.outcome !== "succeeded" ||
     !settled.result ||
@@ -50,9 +40,7 @@ export async function runAgentCreate(
     );
   let declaration: Record<string, unknown>;
   try {
-    const parsed = JSON.parse(
-      String((settled.result as Record<string, unknown>).text),
-    );
+    const parsed = JSON.parse(String((settled.result as Record<string, unknown>).text));
     if (!parsed || typeof parsed !== "object" || Array.isArray(parsed))
       throw new Error("declaration must be a JSON object");
     declaration = parsed as Record<string, unknown>;
@@ -67,7 +55,7 @@ export async function runAgentCreate(
   }
   const validation = await runCommandThroughDaemon({
     ...command,
-    method: "repo.task.run",
+    method: "repo.task.read",
     action: {
       kind: "agent-validate",
       declaration,
@@ -80,10 +68,7 @@ export async function runAgentCreate(
       "agent_validation_failed",
       "ha agent validate could not produce a validation report; rerun ha agent create after checking the daemon.",
     );
-  const validationReport = JSON.parse(validation.evidence) as Record<
-    string,
-    unknown
-  >;
+  const validationReport = JSON.parse(validation.evidence) as Record<string, unknown>;
   if (validationReport.valid !== true)
     return runtimeRejected(
       "agent-create",

--- a/packages/cli/src/cli-agent-create.ts
+++ b/packages/cli/src/cli-agent-create.ts
@@ -6,7 +6,10 @@ import type { ThinCommand } from "./cli/thin-command.ts";
 import { consumeKnownError, runCommandThroughDaemon } from "./daemon/client.ts";
 import { randomUUID } from "node:crypto";
 
-export async function runAgentCreate(command: ThinCommand, writeActivity: (text: string) => void): Promise<JsonObject> {
+export async function runAgentCreate(
+  command: ThinCommand,
+  writeActivity: (text: string) => void,
+): Promise<JsonObject> {
   const action = command.action as AgentCreateAction,
     designerPrompt = agentDesignerPrompt(action.prompt),
     spawned = await runCommandThroughDaemon({
@@ -24,8 +27,15 @@ export async function runAgentCreate(command: ThinCommand, writeActivity: (text:
         idempotencyKey: `agent-create-${randomUUID()}`,
       },
     });
-  if (spawned.ok !== true || typeof spawned.runtimeSessionId !== "string") return spawned;
-  const settled = await waitForRuntime(command, spawned.runtimeSessionId, !command.json, writeActivity, spawned);
+  if (spawned.ok !== true || typeof spawned.runtimeSessionId !== "string")
+    return spawned;
+  const settled = await waitForRuntime(
+    command,
+    spawned.runtimeSessionId,
+    !command.json,
+    writeActivity,
+    spawned,
+  );
   if (
     settled.outcome !== "succeeded" ||
     !settled.result ||
@@ -40,7 +50,9 @@ export async function runAgentCreate(command: ThinCommand, writeActivity: (text:
     );
   let declaration: Record<string, unknown>;
   try {
-    const parsed = JSON.parse(String((settled.result as Record<string, unknown>).text));
+    const parsed = JSON.parse(
+      String((settled.result as Record<string, unknown>).text),
+    );
     if (!parsed || typeof parsed !== "object" || Array.isArray(parsed))
       throw new Error("declaration must be a JSON object");
     declaration = parsed as Record<string, unknown>;
@@ -68,7 +80,10 @@ export async function runAgentCreate(command: ThinCommand, writeActivity: (text:
       "agent_validation_failed",
       "ha agent validate could not produce a validation report; rerun ha agent create after checking the daemon.",
     );
-  const validationReport = JSON.parse(validation.evidence) as Record<string, unknown>;
+  const validationReport = JSON.parse(validation.evidence) as Record<
+    string,
+    unknown
+  >;
   if (validationReport.valid !== true)
     return runtimeRejected(
       "agent-create",

--- a/packages/cli/src/cli/thin-command-flags.ts
+++ b/packages/cli/src/cli/thin-command-flags.ts
@@ -6,7 +6,10 @@ import type { ThinCliInputDirectory, ThinCommand, ThinParseResult } from "./thin
 // parsers that pass no explicit method get the descriptor's routing instead of a hardcoded default.
 export function taskActionMethodFor(kind: string): string {
   try {
-    return commandDescriptorForAction(kind).method === "repo.task.read" ? "repo.task.read" : "repo.task.run";
+    // The declaration literals keep their authored "repo.task.run"; the repo-read topology
+    // rewrites the runtime value, so compare on the widened runtime string.
+    const method: string = commandDescriptorForAction(kind).method;
+    return method === "repo.task.read" ? "repo.task.read" : "repo.task.run";
   } catch {
     return "repo.task.run";
   }

--- a/packages/cli/src/cli/thin-command-flags.ts
+++ b/packages/cli/src/cli/thin-command-flags.ts
@@ -1,5 +1,16 @@
+import { commandDescriptorForAction } from "../../../daemon/src/protocol/daemon-protocol-commands.ts";
 import type { SafePath } from "../../../daemon/src/protocol/daemon-protocol.contract.ts";
 import type { ThinCliInputDirectory, ThinCommand, ThinParseResult } from "./thin-command-types.ts";
+
+// The command descriptor is the single authority on which closed task-action method serves a kind;
+// parsers that pass no explicit method get the descriptor's routing instead of a hardcoded default.
+export function taskActionMethodFor(kind: string): string {
+  try {
+    return commandDescriptorForAction(kind).method === "repo.task.read" ? "repo.task.read" : "repo.task.run";
+  } catch {
+    return "repo.task.run";
+  }
+}
 
 export function optionalFlags(
   values: ReadonlyMap<string, string>,
@@ -122,7 +133,7 @@ export function accepted(
   repoId: string | undefined,
   json: boolean,
   action: ThinCommand["action"],
-  method = "repo.task.run",
+  method = taskActionMethodFor(action.kind),
 ): ThinParseResult {
   const normalized =
     action.kind === "agent-create" && !Object.hasOwn(action, "cwd")

--- a/packages/cli/src/cli/thin-command-projection.ts
+++ b/packages/cli/src/cli/thin-command-projection.ts
@@ -75,7 +75,7 @@ export function parseProjected(
   inputs: ThinCliInputDirectory,
   base: Readonly<Record<string, unknown>> = {},
   defaults: Readonly<Record<string, unknown>> = {},
-  method = "repo.task.run",
+  method?: string,
 ): ThinParseResult {
   const f = readFlags(commandId, tokens, inputs);
   if (!f.ok) return rejected(f.code, f.nextAction, json);

--- a/packages/cli/src/daemon/client.ts
+++ b/packages/cli/src/daemon/client.ts
@@ -363,9 +363,9 @@ function daemonRequestPayload(command: ThinCommand, env: NodeJS.ProcessEnv): Rea
           )
         : actionPayload,
     executor = declaredExecutor(env);
-  // repo.task.run carries the executor inside its open action envelope; every other method takes
+  // Task action methods carry the executor inside their open action envelope; every other method takes
   // payload.executor exactly where the daemon contract declares the field.
-  return command.method === "repo.task.run"
+  return command.method === "repo.task.run" || command.method === "repo.task.read"
     ? { action: executor ? { ...command.action, executor } : command.action }
     : executor && daemonMethodAcceptsPayloadExecutor(command.method)
       ? { ...payload, executor }
@@ -501,8 +501,8 @@ const readResponseDeadlineMs = (kind: string): number | undefined => {
 // commands route through the fleet channel instead of a local cell. The
 // operator never runs a lease command — acquisition, queueing, and renewal are
 // the center's job (dec_9E7AC30E/CH2).
-// task-create rides its own preset method; the lifecycle commands ride repo.task.run.
-const fleetTaskMethods = ["repo.task.run", "repo.task.create"];
+// task-create rides its own preset method; legacy reads and lifecycle commands ride task action methods.
+const fleetTaskMethods = ["repo.task.run", "repo.task.read", "repo.task.create"];
 const fleetRuntimeMethods = [
   "repo.agentRuntime.spawn",
   "repo.agentRuntime.cancel",
@@ -641,7 +641,11 @@ export async function fleetDocRoute(
 ): Promise<{ readonly method: string; readonly payload: Record<string, unknown> } | null> {
   const kind = command.action.kind,
     route = fleetDocSyncKinds.get(kind);
-  if (route === undefined || command.method !== "repo.task.run") return null;
+  if (
+    route === undefined ||
+    (command.method !== "repo.task.run" && command.method !== "repo.task.read")
+  )
+    return null;
   const config = await fleetEdgeRegistration(command, env);
   if (!config) return null;
   const payload: Record<string, unknown> = {

--- a/packages/cli/src/daemon/client.ts
+++ b/packages/cli/src/daemon/client.ts
@@ -641,11 +641,7 @@ export async function fleetDocRoute(
 ): Promise<{ readonly method: string; readonly payload: Record<string, unknown> } | null> {
   const kind = command.action.kind,
     route = fleetDocSyncKinds.get(kind);
-  if (
-    route === undefined ||
-    (command.method !== "repo.task.run" && command.method !== "repo.task.read")
-  )
-    return null;
+  if (route === undefined || (command.method !== "repo.task.run" && command.method !== "repo.task.read")) return null;
   const config = await fleetEdgeRegistration(command, env);
   if (!config) return null;
   const payload: Record<string, unknown> = {

--- a/packages/cli/src/daemon/fleet-command-route.ts
+++ b/packages/cli/src/daemon/fleet-command-route.ts
@@ -8,7 +8,7 @@ export async function fleetScheduleRoute(
   env: NodeJS.ProcessEnv = process.env,
 ): Promise<Record<string, unknown> | null> {
   if (
-    command.method !== "repo.task.run" ||
+    (command.method !== "repo.task.run" && command.method !== "repo.task.read") ||
     !daemonProtocolCommands.some(
       (candidate) =>
         candidate.method === command.method &&

--- a/packages/cli/test/fleet-task-route.test.ts
+++ b/packages/cli/test/fleet-task-route.test.ts
@@ -50,11 +50,11 @@ test("fleet task routing requires both edge config and remote-edge registry mode
   const routed = await fleetTaskRoute(command("repo.task.run", { kind: "task-start", taskId: "task_one" }), env);
   assert.deepEqual(routed?.action, { kind: "task-start", taskId: "task_one" });
   assert.deepEqual(
-    (await fleetTaskRoute(command("repo.task.run", { kind: "task-show", taskId: "task_one" }), env))?.action,
+    (await fleetTaskRoute(command("repo.task.read", { kind: "task-show", taskId: "task_one" }), env))?.action,
     { kind: "task-show", taskId: "task_one" },
   );
   const docStatus = await fleetDocRoute(
-    command("repo.task.run", { kind: "doc-status", paths: ["context/notes.md"] }),
+    command("repo.task.read", { kind: "doc-status", paths: ["context/notes.md"] }),
     env,
   );
   assert.equal(docStatus?.method, "daemon.fleet.doc.sync");

--- a/packages/cli/test/runtime-cli.integration.test.ts
+++ b/packages/cli/test/runtime-cli.integration.test.ts
@@ -957,7 +957,7 @@ test("real CLI runs, archives task-bound dispatches, resumes, waits through stat
         rootDir: safePath(root),
         repoId: "runtime-cli",
         json: true,
-        method: "repo.task.run",
+        method: "repo.task.read",
         action: { kind: "fact-search", taskId, permissionMode: "read-only" } as never,
       },
       undefined,

--- a/packages/cli/test/settings-command.test.ts
+++ b/packages/cli/test/settings-command.test.ts
@@ -8,7 +8,7 @@ test("Settings CLI projects read and owned update flags to the closed daemon act
   const read = parseThinCommand(["settings", "read"]);
   assert.equal(read.ok, true);
   if (read.ok) {
-    assert.equal(read.command.method, "repo.task.run");
+    assert.equal(read.command.method, "repo.task.read");
     assert.equal(daemonMethodAcceptsPayload(read.command.method), true);
     assert.deepEqual(read.command.action, { kind: "settings-read" });
   }

--- a/packages/cli/test/thin-command-contract-parity.test.ts
+++ b/packages/cli/test/thin-command-contract-parity.test.ts
@@ -204,15 +204,15 @@ test("executor injection follows the daemon-declared surface exactly", () => {
         `${method}: carries no payload envelope at all`,
       );
   }
-  // repo.task.run is the one structural exception: the executor rides inside the open action envelope.
+  // The legacy read envelope keeps its executor inside the open action, like the write envelope.
   assert.deepEqual(
     validateDaemonRpcCall({
-      method: "repo.task.run",
+      method: "repo.task.read",
       params: { repo: { repoId: "parity" }, payload: { action: { kind: "task-list", executor: agent } } },
     }),
     [],
   );
-  assert.equal(daemonMethodAcceptsPayloadExecutor("repo.task.run"), false);
+  assert.equal(daemonMethodAcceptsPayloadExecutor("repo.task.read"), false);
   assert.equal(daemonMethodAcceptsPayloadExecutor("repo.not.contracted"), false);
 });
 

--- a/packages/cli/test/thin-command-identity-migration.test.ts
+++ b/packages/cli/test/thin-command-identity-migration.test.ts
@@ -59,23 +59,23 @@ test("squad run derives its mission from task unless prompt overrides it", () =>
   if (taskOnly.ok) assert.deepEqual(taskOnly.command.action.cwd, { scope: "repo-root" });
 });
 
-test("Agent and Squad declaration commands route through the daemon entity lifecycle", () => {
-  const cases: ReadonlyArray<readonly [readonly string[], string]> = [
-    [["agent", "list"], "agent-list"],
-    [["agent", "inspect", "terra"], "agent-inspect"],
-    [["agent", "validate", "--source", "terra"], "agent-validate"],
-    [["agent", "install", "--source", "terra", "--dry-run"], "agent-install"],
-    [["squad", "list"], "squad-list"],
-    [["squad", "inspect", "core-squad"], "squad-inspect"],
-    [["squad", "status", "squad_0123456789abcdef01234567"], "squad-status"],
-    [["squad", "validate", "--source", "core-squad"], "squad-validate"],
-    [["squad", "install", "--source", "core-squad"], "squad-install"],
+test("Agent and Squad declaration commands route reads directly and writes through the daemon entity lifecycle", () => {
+  const cases: ReadonlyArray<readonly [readonly string[], string, string]> = [
+    [["agent", "list"], "agent-list", "repo.task.read"],
+    [["agent", "inspect", "terra"], "agent-inspect", "repo.task.read"],
+    [["agent", "validate", "--source", "terra"], "agent-validate", "repo.task.read"],
+    [["agent", "install", "--source", "terra", "--dry-run"], "agent-install", "repo.task.run"],
+    [["squad", "list"], "squad-list", "repo.task.read"],
+    [["squad", "inspect", "core-squad"], "squad-inspect", "repo.task.read"],
+    [["squad", "status", "squad_0123456789abcdef01234567"], "squad-status", "repo.task.read"],
+    [["squad", "validate", "--source", "core-squad"], "squad-validate", "repo.task.read"],
+    [["squad", "install", "--source", "core-squad"], "squad-install", "repo.task.run"],
   ];
-  for (const [argv, kind] of cases) {
+  for (const [argv, kind, method] of cases) {
     const parsed = parseThinCommand([...argv]);
     assert.equal(parsed.ok, true, JSON.stringify(argv));
     if (parsed.ok) {
-      assert.equal(parsed.command.method, "repo.task.run");
+      assert.equal(parsed.command.method, method);
       assert.equal(parsed.command.action.kind, kind);
     }
   }

--- a/packages/daemon/src/agent-runtime-installation-discovery.ts
+++ b/packages/daemon/src/agent-runtime-installation-discovery.ts
@@ -1,29 +1,32 @@
-import {
-  /* @gate-identity check-sync-subprocess/sync-subprocess-001 */
-  execFileSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import { accessSync, constants, realpathSync } from "node:fs";
 import path from "node:path";
 import { consumeKnownError } from "../../kernel/src/index.ts";
 import type { RuntimeInstallationWitness, RuntimeInstanceKind } from "./agent-runtime-instance-types.ts";
+import { runProcessTextAsync } from "./process-port.ts";
 
 export const runtimeModelCatalogCache = new Map<
   string,
-  { readonly models: readonly string[]; readonly defaultModel: string } | null
+  Promise<{ readonly models: readonly string[]; readonly defaultModel: string } | null>
 >();
 
-export function discoverRuntimeInstallations(
+export async function discoverRuntimeInstallations(
   input: {
     readonly env?: NodeJS.ProcessEnv;
     readonly now?: () => string;
     readonly platform?: NodeJS.Platform;
   } = {},
-): readonly RuntimeInstallationWitness[] {
+): Promise<readonly RuntimeInstallationWitness[]> {
   const env = input.env ?? process.env,
     platform = input.platform ?? process.platform,
     observedAt = (input.now ?? (() => new Date().toISOString()))(),
     seen = new Set<string>(),
-    result: RuntimeInstallationWitness[] = [],
+    candidates: {
+      readonly kindId: RuntimeInstanceKind;
+      readonly executableEntryPath: string;
+      readonly executablePath: string;
+      readonly key: string;
+    }[] = [],
     suffixes = platform === "win32" ? ["", ".cmd", ".exe"] : [""];
   for (const directory of (env.PATH ?? "").split(path.delimiter).filter(Boolean))
     for (const kindId of ["claude", "codex", "agy"] as const)
@@ -33,23 +36,24 @@ export function discoverRuntimeInstallations(
         try {
           accessSync(executableEntryPath, constants.X_OK);
           if (seen.has(key)) continue;
-          const executablePath = realpathSync.native(executableEntryPath),
-            version = runExecutableSync(platform, executablePath, ["--version"], {
-              env: versionProbeEnvironment(env, platform),
-              timeoutMs: 5_000,
-              captureOutput: true,
-            });
-          if (!version) continue;
           seen.add(key);
+          candidates.push({ kindId, executableEntryPath, executablePath: realpathSync.native(executableEntryPath), key });
+        } catch (error) {
+          consumeKnownError(error);
+        }
+      }
+  const discovered = await Promise.all(
+      candidates.map(async ({ kindId, executableEntryPath, executablePath, key }) => {
+        try {
+          const version = await runExecutable(platform, executablePath, ["--version"], {
+            env: versionProbeEnvironment(env, platform),
+            timeoutMs: 5_000,
+            captureOutput: true,
+          });
+          if (!version) return null;
           const installationId = `${kindId}_${createHash("sha256").update(key).digest("hex").slice(0, 24)}`,
-            catalog = discoverRuntimeModelCatalog({
-              platform,
-              executablePath,
-              kindId,
-              env,
-              version,
-            });
-          result.push({
+            catalog = await discoverRuntimeModelCatalog({ platform, executablePath, kindId, env, version });
+          return {
             installationId,
             kindId,
             executableEntryPath,
@@ -57,11 +61,16 @@ export function discoverRuntimeInstallations(
             version,
             observedAt,
             ...(catalog ?? {}),
-          });
+          } satisfies RuntimeInstallationWitness;
         } catch (error) {
           consumeKnownError(error);
+          return null;
         }
-      }
+      }),
+    ),
+    result = discovered.filter(
+      (entry): entry is Exclude<(typeof discovered)[number], null> => entry !== null,
+    );
   return result.sort((a, b) => a.installationId.localeCompare(b.installationId));
 }
 
@@ -71,47 +80,56 @@ export function discoverRuntimeModelCatalog(input: {
   readonly kindId: RuntimeInstanceKind;
   readonly env: NodeJS.ProcessEnv;
   readonly version: string;
-}): {
+}): Promise<{
   readonly models: readonly string[];
   readonly defaultModel: string;
-} | null {
+} | null> {
   const cacheKey = `${input.kindId}\0${input.executablePath}\0${input.version}`;
-  if (runtimeModelCatalogCache.has(cacheKey)) return runtimeModelCatalogCache.get(cacheKey) ?? null;
-  let models: string[] = [];
-  try {
-    const args =
-        input.kindId === "codex" ? ["debug", "models", "--bundled"] : input.kindId === "agy" ? ["models"] : ["--help"],
-      output = runExecutableSync(input.platform, input.executablePath, args, {
-        env: input.env,
-        timeoutMs: 8_000,
-        captureOutput: true,
-      });
-    if (input.kindId === "codex") {
-      const decoded = JSON.parse(output) as {
-        readonly models?: readonly {
-          readonly slug?: unknown;
-          readonly id?: unknown;
-        }[];
-      };
-      models = (decoded.models ?? [])
-        .map((model) => (typeof model.slug === "string" ? model.slug : typeof model.id === "string" ? model.id : ""))
-        .filter(Boolean);
-    } else if (input.kindId === "agy")
-      models = output
-        .split(/\r?\n/u)
-        .map((line) => (line.includes("\t") ? line.split("\t", 1)[0]!.trim() : ""))
-        .filter((model) => /^[A-Za-z0-9][A-Za-z0-9._-]+$/u.test(model));
-    else
-      models = ["fable", "sonnet", "opus"].filter(
-        (alias) => output.includes(`'${alias}'`) || output.includes(`"${alias}"`),
-      );
-  } catch (error) {
-    consumeKnownError(error);
-  }
-  const unique = [...new Set(models)],
-    catalog = unique[0] ? { models: unique, defaultModel: unique[0] } : null;
-  runtimeModelCatalogCache.set(cacheKey, catalog);
-  return catalog;
+  const cached = runtimeModelCatalogCache.get(cacheKey);
+  if (cached) return cached;
+  const discovered = (async () => {
+    let models: string[] = [];
+    try {
+      const args =
+          input.kindId === "codex"
+            ? ["debug", "models", "--bundled"]
+            : input.kindId === "agy"
+              ? ["models"]
+              : ["--help"],
+        output = await runExecutable(input.platform, input.executablePath, args, {
+          env: input.env,
+          timeoutMs: 8_000,
+          captureOutput: true,
+        });
+      if (input.kindId === "codex") {
+        const decoded = JSON.parse(output) as {
+          readonly models?: readonly {
+            readonly slug?: unknown;
+            readonly id?: unknown;
+          }[];
+        };
+        models = (decoded.models ?? [])
+          .map((model) =>
+            typeof model.slug === "string" ? model.slug : typeof model.id === "string" ? model.id : "",
+          )
+          .filter(Boolean);
+      } else if (input.kindId === "agy")
+        models = output
+          .split(/\r?\n/u)
+          .map((line) => (line.includes("\t") ? line.split("\t", 1)[0]!.trim() : ""))
+          .filter((model) => /^[A-Za-z0-9][A-Za-z0-9._-]+$/u.test(model));
+      else
+        models = ["fable", "sonnet", "opus"].filter(
+          (alias) => output.includes(`'${alias}'`) || output.includes(`"${alias}"`),
+        );
+    } catch (error) {
+      consumeKnownError(error);
+    }
+    const unique = [...new Set(models)];
+    return unique[0] ? { models: unique, defaultModel: unique[0] } : null;
+  })();
+  runtimeModelCatalogCache.set(cacheKey, discovered);
+  return discovered;
 }
 
 export function versionProbeEnvironment(env: NodeJS.ProcessEnv, platform: NodeJS.Platform): NodeJS.ProcessEnv {
@@ -129,7 +147,7 @@ export function versionProbeEnvironment(env: NodeJS.ProcessEnv, platform: NodeJS
 // Executes a witnessed runtime executable across platforms without `shell: true`:
 // native executables spawn argv-direct, while Windows command shims (.cmd/.bat)
 // run through an explicit cmd.exe argv with a fully controlled command line.
-export function runExecutableSync(
+export async function runExecutable(
   platform: NodeJS.Platform,
   executablePath: string,
   args: readonly string[],
@@ -138,21 +156,16 @@ export function runExecutableSync(
     readonly timeoutMs: number;
     readonly captureOutput: boolean;
   },
-): string {
+): Promise<string> {
   const shim = platform === "win32" && /\.(?:cmd|bat)$/iu.test(executablePath);
-  const stdout =
-    /* @gate-identity check-sync-subprocess/sync-subprocess-002 */
-    execFileSync(
+  const stdout = await runProcessTextAsync(
     shim ? "cmd.exe" : executablePath,
     shim ? ["/d", "/s", "/c", `"${executablePath}" ${args.join(" ")}`] : [...args],
-    {
-      encoding: "utf8",
-      env: options.env,
-      stdio: ["ignore", options.captureOutput ? "pipe" : "ignore", "ignore"],
-      timeout: options.timeoutMs,
-      windowsHide: true,
-      ...(shim ? { windowsVerbatimArguments: true } : {}),
-    },
+    undefined,
+    options.env,
+    undefined,
+    undefined,
+    { timeoutMs: options.timeoutMs, ...(shim ? { windowsVerbatimArguments: true } : {}) },
   );
   return options.captureOutput ? stdout.trim() : "";
 }

--- a/packages/daemon/src/agent-runtime-installation-discovery.ts
+++ b/packages/daemon/src/agent-runtime-installation-discovery.ts
@@ -37,7 +37,8 @@ export async function discoverRuntimeInstallations(
           accessSync(executableEntryPath, constants.X_OK);
           if (seen.has(key)) continue;
           seen.add(key);
-          candidates.push({ kindId, executableEntryPath, executablePath: realpathSync.native(executableEntryPath), key });
+          const executablePath = realpathSync.native(executableEntryPath);
+          candidates.push({ kindId, executableEntryPath, executablePath, key });
         } catch (error) {
           consumeKnownError(error);
         }
@@ -68,9 +69,7 @@ export async function discoverRuntimeInstallations(
         }
       }),
     ),
-    result = discovered.filter(
-      (entry): entry is Exclude<(typeof discovered)[number], null> => entry !== null,
-    );
+    result = discovered.filter((entry): entry is Exclude<(typeof discovered)[number], null> => entry !== null);
   return result.sort((a, b) => a.installationId.localeCompare(b.installationId));
 }
 
@@ -109,9 +108,7 @@ export function discoverRuntimeModelCatalog(input: {
           }[];
         };
         models = (decoded.models ?? [])
-          .map((model) =>
-            typeof model.slug === "string" ? model.slug : typeof model.id === "string" ? model.id : "",
-          )
+          .map((model) => (typeof model.slug === "string" ? model.slug : typeof model.id === "string" ? model.id : ""))
           .filter(Boolean);
       } else if (input.kindId === "agy")
         models = output

--- a/packages/daemon/src/agent-runtime-instance-store.ts
+++ b/packages/daemon/src/agent-runtime-instance-store.ts
@@ -53,13 +53,14 @@ import { runtimePermissionMode, type RuntimeIsolationState } from "./runtime-per
 export function openRuntimeInstanceStore(input: {
   readonly userRoot: string;
   readonly discover: () => readonly RuntimeInstallationWitness[];
+  readonly refreshDiscovery?: () => Promise<readonly RuntimeInstallationWitness[]>;
   readonly env?: NodeJS.ProcessEnv;
   readonly platform?: NodeJS.Platform;
   readonly resolveCredential?: (reference: string) => Promise<string>;
   readonly subscriptionReady?: (input: {
     readonly installation: RuntimeInstallationWitness;
     readonly env: NodeJS.ProcessEnv;
-  }) => RuntimeAuthReadiness;
+  }) => RuntimeAuthReadiness | Promise<RuntimeAuthReadiness>;
 }) {
   const platform = input.platform ?? process.platform,
     resolveCredential = input.resolveCredential ?? credentialPort(platform).resolve,
@@ -136,7 +137,7 @@ export function openRuntimeInstanceStore(input: {
       readonly config: RuntimeInstanceConfig;
     },
   ): Promise<RuntimeAuthReadiness> {
-    const witnessed = snapshot?.witnessed ?? input.discover(),
+    const witnessed = snapshot?.witnessed ?? (await refreshInstallations()),
       config = snapshot?.config ?? readOne(instanceId, witnessed);
     if (!config)
       throw runtimeInstanceError("runtime_instance_not_found", `Runtime instance ${instanceId} does not exist.`);
@@ -151,7 +152,10 @@ export function openRuntimeInstanceStore(input: {
     if (config.isolationState === "enforced") ensureStateRoot(config);
     const env = authEnvironment(config);
     if (config.auth.mode === "subscription")
-      return rememberAuthReadiness(config.instanceId, probeSubscription(installation, env, config.isolationState));
+      return rememberAuthReadiness(
+        config.instanceId,
+        await probeSubscription(installation, env, config.isolationState),
+      );
     try {
       const secret = await resolveCredential(config.auth.credentialRef);
       return rememberAuthReadiness(
@@ -230,7 +234,7 @@ export function openRuntimeInstanceStore(input: {
       effort = selectRuntimeEffort(config, request.effort),
       fast = selectRuntimeFast(config, request.fast),
       permissionMode = runtimePermissionMode(request.permissionMode ?? config.permissionMode, config.kindId),
-      witnessed = input.discover(),
+      witnessed = await refreshInstallations(),
       installation = witnessed.find(
         (entry) => entry.installationId === config.installationId && entry.kindId === config.kindId,
       );
@@ -256,7 +260,7 @@ export function openRuntimeInstanceStore(input: {
     if (config.auth.mode === "subscription") {
       const readiness = rememberAuthReadiness(
         config.instanceId,
-        probeSubscription(installation, env, config.isolationState),
+        await probeSubscription(installation, env, config.isolationState),
       );
       if (readiness.code !== null) throw runtimeInstanceError(readiness.code, readiness.hint!);
       return {
@@ -588,8 +592,12 @@ export function openRuntimeInstanceStore(input: {
     prepareAuthCommand,
     prepareLaunch,
     prepareWorkerGitEnvironment,
+    refreshInstallations,
     command,
   };
+  async function refreshInstallations(): Promise<readonly RuntimeInstallationWitness[]> {
+    return input.refreshDiscovery ? input.refreshDiscovery() : input.discover();
+  }
   function read(witnessed?: readonly RuntimeInstallationWitness[]): RuntimeInstanceConfig[] {
     if (!existsSync(target)) return [];
     chmodSync(target, 0o600);
@@ -668,13 +676,13 @@ export function openRuntimeInstanceStore(input: {
     readiness.set(instanceId, state);
     return state;
   }
-  function probeSubscription(
+  async function probeSubscription(
     installation: RuntimeInstallationWitness,
     env: NodeJS.ProcessEnv,
     isolationState: RuntimeIsolationState,
-  ): RuntimeAuthReadiness {
+  ): Promise<RuntimeAuthReadiness> {
     try {
-      return (
+      return await (
         input.subscriptionReady ?? ((probe) => providerSubscriptionReadiness({ ...probe, isolationState }, platform))
       )({ installation, env });
     } catch (error) {

--- a/packages/daemon/src/agent-runtime-launch-config.ts
+++ b/packages/daemon/src/agent-runtime-launch-config.ts
@@ -11,7 +11,7 @@ import type {
   RuntimeInstallationWitness,
   RuntimeAuthReadiness,
 } from "./agent-runtime-instance-types.ts";
-import { runExecutableSync } from "./agent-runtime-installation-discovery.ts";
+import { runExecutable } from "./agent-runtime-installation-discovery.ts";
 import { providerConfigDirectory, tomlString } from "./agent-runtime-instance-storage.ts";
 import {
   requiredRuntimeInstanceText,
@@ -108,16 +108,16 @@ export function launchArgs(
   ];
 }
 
-export function providerSubscriptionReadiness(
+export async function providerSubscriptionReadiness(
   input: {
     readonly installation: RuntimeInstallationWitness;
     readonly env: NodeJS.ProcessEnv;
     readonly isolationState: RuntimeIsolationState;
   },
   platform: NodeJS.Platform,
-): RuntimeAuthReadiness {
+): Promise<RuntimeAuthReadiness> {
   try {
-    runExecutableSync(
+    await runExecutable(
       platform,
       input.installation.executablePath,
       input.installation.kindId === "codex"

--- a/packages/daemon/src/agent-runtime-read.ts
+++ b/packages/daemon/src/agent-runtime-read.ts
@@ -41,7 +41,6 @@ export function makeAgentRuntimeReadModel(input: {
   readonly runtimeInstances?: () => readonly RuntimeInstanceSummary[];
   readonly now?: () => string;
 }) {
-  const synchronize = () => input.projection.readTaskStatuses([]);
   const installationDto = (installation: RuntimeInstallation): AgentRuntimeInstallationDto => ({
     installationId: installation.installationId,
     kindId: runtimeKindForInstallation(installation).kindId,
@@ -138,7 +137,7 @@ export function makeAgentRuntimeReadModel(input: {
   return {
     overview: (payload: Readonly<Record<string, unknown>>): AgentRuntimeOverviewResult => {
       const query = overviewQuery(payload),
-        cut = synchronize();
+        cut = input.projection.readCut();
       const paged =
         query.limit === null
           ? null
@@ -185,7 +184,7 @@ export function makeAgentRuntimeReadModel(input: {
     },
     sessionGroups: (payload: Readonly<Record<string, unknown>>): AgentRuntimeSessionGroupsResult => {
       const query = sessionGroupsQuery(payload, input.now?.() ?? new Date().toISOString()),
-        cut = synchronize(),
+        cut = input.projection.readCut(),
         sessions = input.projection
           .readRuntimeSessions()
           .filter((session) => runtimeSessionInActivityWindow(session, query.since)),
@@ -218,7 +217,7 @@ export function makeAgentRuntimeReadModel(input: {
       });
     },
     session: (payload: Readonly<Record<string, unknown>>): AgentRuntimeSessionResult => {
-      const cut = synchronize(),
+      const cut = input.projection.readCut(),
         target = runtimeSessionTarget(payload),
         runtimeSessionIdValue =
           target.runtimeSessionId ?? input.readDispatch?.(target.taskId!, target.dispatchId!)?.runtimeSessionId ?? null;
@@ -251,7 +250,6 @@ export function makeAgentRuntimeReadModel(input: {
         source = input.store.readHead()?.revision ?? 0;
       if (after > source)
         throw coded("invalid_cursor", `Lifecycle cursor lifecycle:${after} is ahead of lifecycle:${source}.`);
-      synchronize();
       const matching = input.projection.readRuntimeSessionEvents(runtimeSessionIdValue, after, 65),
         selected = matching.slice(0, 64),
         done = selected.length === matching.length,

--- a/packages/daemon/src/conn-log.ts
+++ b/packages/daemon/src/conn-log.ts
@@ -32,6 +32,11 @@ export interface DaemonTrafficLogEntry {
   readonly transport: string;
   readonly method: string | null;
   readonly startedAt: number;
+  readonly frameReceivedAt?: number;
+  readonly handlerStartedAt?: number;
+  readonly repliedAt?: number;
+  readonly dispatchDelayMs?: number;
+  readonly serviceMs?: number;
   readonly durationMs: number;
   readonly ok: boolean;
   readonly code: string | null;
@@ -122,13 +127,23 @@ export function openDaemonConnLog(options: DaemonConnLogOptions): DaemonConnLog 
     request: (entry) => {
       const seq = seqOf(entry.conn);
       if (seq !== null) requestsByConn.set(seq, (requestsByConn.get(seq) ?? 0) + 1);
+      const frameReceivedAt = entry.frameReceivedAt ?? entry.startedAt,
+        handlerStartedAt = entry.handlerStartedAt ?? entry.startedAt,
+        repliedAt = entry.repliedAt ?? entry.startedAt + entry.durationMs,
+        dispatchDelayMs = entry.dispatchDelayMs ?? Math.max(0, handlerStartedAt - frameReceivedAt),
+        serviceMs = entry.serviceMs ?? entry.durationMs;
       append({
         event: "request",
         conn: entry.conn,
         transport: entry.transport,
         method: entry.method,
         at: new Date(entry.startedAt).toISOString(),
-        atEnd: new Date(entry.startedAt + entry.durationMs).toISOString(),
+        frameReceivedAt: new Date(frameReceivedAt).toISOString(),
+        handlerStartedAt: new Date(handlerStartedAt).toISOString(),
+        repliedAt: new Date(repliedAt).toISOString(),
+        atEnd: new Date(repliedAt).toISOString(),
+        dispatchDelayMs,
+        serviceMs,
         durationMs: entry.durationMs,
         ok: entry.ok,
         code: entry.code,

--- a/packages/daemon/src/daemon-host-open.ts
+++ b/packages/daemon/src/daemon-host-open.ts
@@ -82,7 +82,9 @@ export interface DaemonHostOpenInput {
   readonly startedAt?: string;
   readonly now?: () => string;
   readonly runtimeLaunch?: RuntimeLauncher;
-  readonly runtimeDiscover?: () => readonly RuntimeInstallationWitness[];
+  readonly runtimeDiscover?: () =>
+    | readonly RuntimeInstallationWitness[]
+    | Promise<readonly RuntimeInstallationWitness[]>;
   readonly runtimeEnv?: NodeJS.ProcessEnv;
   readonly runtimeFile?: string;
   readonly shutdownRequested?: () => boolean;
@@ -106,10 +108,31 @@ export async function openDaemonHost(input: DaemonHostOpenInput): Promise<Daemon
   const unavailable = new Map<string, RepoCellStatus>(),
     unavailableProbes = new Map<string, ReturnType<typeof makeRecoveryProbe>>(),
     controls = new Map<string, DaemonControlReceipt>(),
-    discover = input.runtimeDiscover ?? (() => discoverRuntimeInstallations()),
+    runtimeDiscovery = input.runtimeDiscover ?? (() => discoverRuntimeInstallations());
+  let discoveredInstallations: readonly RuntimeInstallationWitness[] = [],
+    discoveryInFlight: Promise<readonly RuntimeInstallationWitness[]> | null = null;
+  const refreshDiscovery = (): Promise<readonly RuntimeInstallationWitness[]> => {
+      if (discoveryInFlight) return discoveryInFlight;
+      const active = Promise.resolve(runtimeDiscovery()).then((witnessed) => {
+        discoveredInstallations = witnessed;
+        return witnessed;
+      });
+      discoveryInFlight = active;
+      void active.then(
+        () => {
+          if (discoveryInFlight === active) discoveryInFlight = null;
+        },
+        () => {
+          if (discoveryInFlight === active) discoveryInFlight = null;
+        },
+      );
+      return active;
+    },
+    discover = () => discoveredInstallations,
     instances = openRuntimeInstanceStore({
       userRoot: input.userRoot,
       discover,
+      refreshDiscovery,
       env: input.runtimeEnv,
     }),
     runtimePorts = {
@@ -122,6 +145,7 @@ export async function openDaemonHost(input: DaemonHostOpenInput): Promise<Daemon
     initialRegistry = readDaemonRegistry({ userRoot: input.userRoot }),
     buildObserver = observeDaemonBuild(input.runtimeFile),
     fleetEdgeRuntimes = new Map<string, ReturnType<typeof openFleetEdgeRuntime>>();
+  void refreshDiscovery().catch(consumeKnownError);
   const edgeRuntimeFor = (request: FleetEdgeRuntimeRequest["payload"]) => {
       const key = `${request.repoId}\0${request.assignmentId}\0${request.host}\0${request.port}`,
         runtime =

--- a/packages/daemon/src/daemon-host-runtime-api.ts
+++ b/packages/daemon/src/daemon-host-runtime-api.ts
@@ -227,6 +227,7 @@ export function createDaemonHostRuntimeApi(
         evaluatedAtCut: "runtime-instances:current",
         now: context.now(),
       });
+      await context.instances.refreshInstallations();
       const receipt = (await context.instances.command({
         ...payload,
         kind: actionKind,
@@ -241,6 +242,7 @@ export function createDaemonHostRuntimeApi(
       const operation = method.slice("repo.runtimeInstance.auth.".length);
       if (!["login", "logout"].includes(operation))
         throw context.hostCodedError("unsupported_command", `Unsupported runtime auth method: ${method}.`);
+      await context.instances.refreshInstallations();
       const command = context.instances.prepareAuthCommand(
           context.requiredText(payload.instanceId, "instanceId"),
           operation as "login" | "logout",

--- a/packages/daemon/src/process-port.ts
+++ b/packages/daemon/src/process-port.ts
@@ -111,6 +111,10 @@ export function runProcessTextAsync(
   env?: NodeJS.ProcessEnv,
   input?: string,
   signal?: AbortSignal,
+  options: {
+    readonly timeoutMs?: number;
+    readonly windowsVerbatimArguments?: boolean;
+  } = {},
 ): Promise<string> {
   return new Promise((resolve, reject) => {
     // execFile's own AbortSignal handling fires the callback as soon as the signal aborts,
@@ -120,10 +124,24 @@ export function runProcessTextAsync(
     const child = execFile(
       command,
       [...args],
-      { cwd, ...(env ? { env } : {}), ...(signal ? { signal } : {}), encoding: "utf8", windowsHide: true },
+      {
+        cwd,
+        ...(env ? { env } : {}),
+        ...(signal ? { signal } : {}),
+        ...(options.timeoutMs === undefined ? {} : { timeout: options.timeoutMs }),
+        ...(options.windowsVerbatimArguments === undefined
+          ? {}
+          : { windowsVerbatimArguments: options.windowsVerbatimArguments }),
+        encoding: "utf8",
+        windowsHide: true,
+      },
       (error, stdout, stderr) => {
         if (error) {
-          Object.assign(error, { stdout, stderr });
+          Object.assign(error, {
+            stdout,
+            stderr,
+            ...(typeof error.code === "number" ? { status: error.code } : {}),
+          });
           if (child.exitCode === null && child.signalCode === null) {
             child.once("close", () => reject(error));
             return;

--- a/packages/daemon/src/protocol/daemon-protocol-commands.ts
+++ b/packages/daemon/src/protocol/daemon-protocol-commands.ts
@@ -159,7 +159,7 @@ export function commandClassForAction(kind: string): "repo-read" | "repo-write" 
 }
 
 export function actionForDaemonMethod(method: string, payload: JsonObject): JsonObject & { readonly kind: string } {
-  if (method === "repo.task.run") {
+  if (method === "repo.task.run" || method === "repo.task.read") {
     const action = payload.action as JsonObject & { readonly kind: string },
       descriptor = daemonProtocolCommands.find((entry) => commandAcceptsAction(entry, action.kind));
     if (descriptor?.method !== method)

--- a/packages/daemon/src/protocol/daemon-protocol-rpc-validation.ts
+++ b/packages/daemon/src/protocol/daemon-protocol-rpc-validation.ts
@@ -48,7 +48,7 @@ export function isDaemonStreamMethod(method: string): method is DaemonStreamMeth
   return daemonStreamFacets.some((entry) => entry.method === method);
 }
 // The executor declaration surface, derived from the same shapes validateDaemonRpcCall enforces — never
-// a hand-copied method list. repo.task.run accepts the executor inside its open action envelope; every
+// a hand-copied method list. The task action methods accept the executor inside their open action envelope; every
 // other method accepts payload.executor exactly when its payload shape declares the field (the preset
 // methods and repo.agentRuntime.spawn do). The CLI injects on this predicate, so a newly contracted
 // command that does not declare executor is simply never injected into.
@@ -90,7 +90,7 @@ export function validateDaemonRpcCall(value: unknown): readonly string[] {
     errors.push(...validateSquadRunReadPayload((value.params as JsonObject).payload));
   if (!errors.length && value.method === "observe.tail")
     errors.push(...validateObserveTailPayload((value.params as JsonObject).payload));
-  if (!errors.length && value.method === "repo.task.run")
+  if (!errors.length && (value.method === "repo.task.run" || value.method === "repo.task.read"))
     errors.push(...validateCatalogActionPayload(value.params as JsonObject));
   if (!errors.length && isDaemonGuiActionMethod(value.method))
     errors.push(...validateGuiActionPayload(value.method, (value.params as JsonObject).payload));

--- a/packages/daemon/src/protocol/daemon-protocol.contract.ts
+++ b/packages/daemon/src/protocol/daemon-protocol.contract.ts
@@ -108,6 +108,16 @@ export const daemonProtocolMethods = Object.freeze([
       payload: shape({ action: shape({ kind: "string" }, true) }),
     }),
   },
+  {
+    id: "repo.task.read",
+    phase: "W3",
+    method: "repo.task.read",
+    requiresRepo: true,
+    params: shape({
+      repo: shape({ repoId: "string" }),
+      payload: shape({ action: shape({ kind: "string" }, true) }),
+    }),
+  },
 ] as const);
 
 export const runtimeInstanceMethods = Object.freeze([

--- a/packages/daemon/src/protocol/json-rpc-dispatch-support.ts
+++ b/packages/daemon/src/protocol/json-rpc-dispatch-support.ts
@@ -53,7 +53,7 @@ export function repoIdFromParams(params: JsonObject): string {
   return isJsonObject(repo) && typeof repo.repoId === "string" ? repo.repoId : "";
 }
 // The executor rides on the resolved action, which is where the daemon reads it for attribution:
-// repo.task.run carries it inside payload.action, every other method merges payload into the action.
+// Task action methods carry it inside payload.action; every other method merges payload into the action.
 export function declaredExecutorOrNull(action: JsonObject): DaemonRequestLogEntry["executor"] {
   const executor = action.executor;
   return isJsonObject(executor) && executor.kind === "agent" && typeof executor.id === "string"

--- a/packages/daemon/src/protocol/json-rpc-server.ts
+++ b/packages/daemon/src/protocol/json-rpc-server.ts
@@ -43,6 +43,7 @@ import type { DaemonBuildObserver, DaemonBuildStamp } from "../build-identity.ts
 export interface JsonRpcProtocolServer {
   readonly handle: (
     message: JsonRpcRequest | JsonRpcRequest[],
+    timing?: { readonly frameReceivedAt: number },
   ) => Promise<JsonRpcResponse | JsonRpcResponse[] | undefined>;
   readonly close: () => void;
 }
@@ -72,29 +73,38 @@ export function createJsonRpcProtocolServer(options: {
     readonly detach: () => void;
   };
   const subscriptions = new Set<Subscription>();
-  const one = async (request: JsonRpcRequest): Promise<JsonRpcResponse | undefined> => {
+  const one = async (request: JsonRpcRequest, frameReceivedAt = Date.now()): Promise<JsonRpcResponse | undefined> => {
     const id = request.id ?? null,
-      startedAt = Date.now();
+      startedAt = Date.now(),
+      dispatchDelayMs = Math.max(0, startedAt - frameReceivedAt);
     let observed: ObservedRequest = {
       repoId: "",
       command: typeof request.method === "string" ? request.method : "",
       executor: null,
     };
     if (request.jsonrpc !== "2.0" || typeof request.method !== "string") {
-      traffic(typeof request.method === "string" ? request.method : null, startedAt, 0, false, "-32600");
+      traffic(
+        typeof request.method === "string" ? request.method : null,
+        frameReceivedAt,
+        startedAt,
+        Date.now(),
+        false,
+        "-32600",
+      );
       return rpcError(id, -32600, "Invalid Request");
     }
     if (!isContractedDaemonRpcMethod(request.method)) {
-      traffic(request.method, startedAt, 0, false, "-32601");
+      traffic(request.method, frameReceivedAt, startedAt, Date.now(), false, "-32601");
       return rpcError(id, -32601, "Method not found");
     }
     const reply = <Method extends DaemonRpcMethod>(
       method: Method,
       result: DaemonRpcResult<Method>,
     ): JsonRpcResponse | undefined => {
-      const durationMs = Date.now() - startedAt;
-      recordRequest(method, observed, result, durationMs);
-      traffic(method, startedAt, durationMs, resultOk(result), resultErrorCode(result));
+      const repliedAt = Date.now(),
+        serviceMs = repliedAt - startedAt;
+      recordRequest(method, observed, result, dispatchDelayMs, serviceMs);
+      traffic(method, frameReceivedAt, startedAt, repliedAt, resultOk(result), resultErrorCode(result));
       return request.id === undefined ? undefined : { jsonrpc: "2.0", id, result };
     };
     const parsed = parseDaemonRpcParams(request.method, request.params);
@@ -449,10 +459,12 @@ export function createJsonRpcProtocolServer(options: {
     );
   };
   return {
-    handle: async (message) =>
+    handle: async (message, timing) =>
       Array.isArray(message)
-        ? (await Promise.all(message.map(one))).filter((item): item is JsonRpcResponse => item !== undefined)
-        : one(message),
+        ? (await Promise.all(message.map((request) => one(request, timing?.frameReceivedAt)))).filter(
+            (item): item is JsonRpcResponse => item !== undefined,
+          )
+        : one(message, timing?.frameReceivedAt),
     close: () => {
       for (const subscription of subscriptions) subscription.detach();
       subscriptions.clear();
@@ -472,7 +484,13 @@ export function createJsonRpcProtocolServer(options: {
   }
   // Repo-scoped by design: the log lives in the repository's local root, so a request that binds no
   // repository (protocol.hello, daemon.status, registry admin) has nowhere to be filed and is skipped.
-  function recordRequest(method: string, observed: ObservedRequest, result: object, durationMs: number): void {
+  function recordRequest(
+    method: string,
+    observed: ObservedRequest,
+    result: object,
+    dispatchDelayMs: number,
+    serviceMs: number,
+  ): void {
     if (!options.recordRequest || !observed.repoId) return;
     options.recordRequest({
       method,
@@ -485,15 +503,18 @@ export function createJsonRpcProtocolServer(options: {
       outcome: "outcome" in result && typeof result.outcome === "string" ? result.outcome : null,
       code: resultErrorCode(result),
       opId: "opId" in result && typeof result.opId === "string" ? result.opId : null,
-      durationMs,
+      dispatchDelayMs,
+      serviceMs,
+      durationMs: serviceMs,
     });
   }
   // Daemon-scoped counterpart: every request including hello and pre-dispatch rejections gets one
   // line, so connection-level forensics never depends on repo binding.
   function traffic(
     method: string | null,
-    startedAt: number,
-    durationMs: number,
+    frameReceivedAt: number,
+    handlerStartedAt: number,
+    repliedAt: number,
     ok: boolean,
     code: string | null,
   ): void {
@@ -502,8 +523,13 @@ export function createJsonRpcProtocolServer(options: {
       conn: connectionId,
       transport: options.authContext.transportKind,
       method,
-      startedAt,
-      durationMs,
+      frameReceivedAt,
+      handlerStartedAt,
+      repliedAt,
+      startedAt: handlerStartedAt,
+      dispatchDelayMs: Math.max(0, handlerStartedAt - frameReceivedAt),
+      serviceMs: Math.max(0, repliedAt - handlerStartedAt),
+      durationMs: Math.max(0, repliedAt - handlerStartedAt),
       ok,
       code,
     });

--- a/packages/daemon/src/repo-cell-action-dispatch.ts
+++ b/packages/daemon/src/repo-cell-action-dispatch.ts
@@ -107,6 +107,7 @@ export async function executeAction(
     });
     if (!isLedgerLayoutMigrationEvent(appended.event))
       throw cell.cellCodedError("invalid_store", "Ledger migration returned the wrong event type.");
+    cell.projection.catchUp?.();
     const projected = cell.projection.list(),
       visible = projected.watermark === appended.revision && projected.sourceRevision === appended.revision,
       proof = {

--- a/packages/daemon/src/repo-cell-api.ts
+++ b/packages/daemon/src/repo-cell-api.ts
@@ -229,7 +229,8 @@ export function createRepoCellApi(context: RepoCellApiContext): RepoCell {
         .then(async () => {
           const admission = admitRepoMode(context.mode, command, binding.source);
           if (!admission.ok) throw context.cellCodedError(admission.code, admission.nextAction);
-          if (context.state !== "attached") throw context.cellCodedError("repo_unavailable", context.latched());
+          if (context.state !== "attached")
+            throw context.cellCodedError("repo_unavailable", context.latched());
           return context.withLayoutAdvisory(context.withHumanSummary(await context.executeAction(action, binding)));
         })
         .then((receipt) => receipt as WriteReceipt)

--- a/packages/daemon/src/repo-cell-api.ts
+++ b/packages/daemon/src/repo-cell-api.ts
@@ -218,6 +218,17 @@ export function createRepoCellApi(context: RepoCellApiContext): RepoCell {
           )
         : (result as WriteReceipt);
     };
+    if (command.commandClass === "repo-read")
+      return Promise.resolve()
+        .then(async () => {
+          const admission = admitRepoMode(context.mode, command, binding.source);
+          if (!admission.ok) throw context.cellCodedError(admission.code, admission.nextAction);
+          if (context.state !== "attached")
+            throw context.cellCodedError("repo_unavailable", context.latched());
+          return context.withLayoutAdvisory(context.withHumanSummary(await context.executeAction(action, binding)));
+        })
+        .then((receipt) => receipt as WriteReceipt)
+        .catch((error) => failAction(error));
     const enqueuePublication = (
       execute: (authorizationDecision?: AuthorizationDecision) => WriteReceiptDraft | Promise<WriteReceiptDraft>,
     ): Promise<WriteReceipt> => {

--- a/packages/daemon/src/repo-cell-api.ts
+++ b/packages/daemon/src/repo-cell-api.ts
@@ -218,13 +218,18 @@ export function createRepoCellApi(context: RepoCellApiContext): RepoCell {
           )
         : (result as WriteReceipt);
     };
+    if (action.kind === "squad-status")
+      return Promise.resolve(
+        context.squadCoordinator.status(
+          context.requiredCellText(action.squadRunId, "squadRunId"),
+        ) as unknown as WriteReceipt,
+      );
     if (command.commandClass === "repo-read")
       return Promise.resolve()
         .then(async () => {
           const admission = admitRepoMode(context.mode, command, binding.source);
           if (!admission.ok) throw context.cellCodedError(admission.code, admission.nextAction);
-          if (context.state !== "attached")
-            throw context.cellCodedError("repo_unavailable", context.latched());
+          if (context.state !== "attached") throw context.cellCodedError("repo_unavailable", context.latched());
           return context.withLayoutAdvisory(context.withHumanSummary(await context.executeAction(action, binding)));
         })
         .then((receipt) => receipt as WriteReceipt)
@@ -321,12 +326,6 @@ export function createRepoCellApi(context: RepoCellApiContext): RepoCell {
             context.requiredCellText(action.squadRunId, "squadRunId"),
             binding,
           ) as unknown as WriteReceipt,
-      );
-    if (action.kind === "squad-status")
-      return Promise.resolve(
-        context.squadCoordinator.status(
-          context.requiredCellText(action.squadRunId, "squadRunId"),
-        ) as unknown as WriteReceipt,
       );
     if (action.kind === "script-run")
       return Promise.resolve()

--- a/packages/daemon/src/repo-cell-open.ts
+++ b/packages/daemon/src/repo-cell-open.ts
@@ -184,10 +184,7 @@ async function openLockedRepoCell(
     readSettings: () => readSettings(),
   });
   const runtimeStream = makeAgentRuntimeStreamHub({
-    readSession: (runtimeSessionId) => {
-      projection.readTaskStatuses([]);
-      return projection.readRuntimeSession(runtimeSessionId);
-    },
+    readSession: (runtimeSessionId) => projection.readRuntimeSession(runtimeSessionId),
     canAttach: (session) =>
       session.attachable &&
       Boolean(projection.readRuntimeInstallation(session.installationId)?.effectiveCapabilities.includes("attach")),

--- a/packages/daemon/src/repo-cell.ts
+++ b/packages/daemon/src/repo-cell.ts
@@ -5,6 +5,7 @@ import {
   blockingOf,
   closeoutReadiness,
   configureLedgerMaintenance,
+  consumeKnownError,
   makeTaskEventStore,
   makeTaskProjection,
   readSettingsFacet,
@@ -19,6 +20,7 @@ import { runDocAction } from "./doc-sync-actions.ts";
 import { blockedCandidateNextAction } from "./doc-sync-details.ts";
 import { makeEntityActionCatalogExecutor } from "./entity-action-catalog-executor.ts";
 import { openReplicaCutSource } from "./fleet/replica-cut-store.ts";
+import { cellErrorCode, cellErrorMessage } from "./repo-cell-errors.ts";
 import type { RepoCellBinding } from "./repo-cell-types.ts";
 import { authorizeRepoCellAction } from "./repo-cell-authorization.ts";
 import { declaredRoleBindingsForActor } from "./identity/declared-role-binding-projection.ts";
@@ -123,22 +125,32 @@ export function initializeRepoCell(context: RepoCellCoreInput): RepoCellCore {
   const configPath = path.join(resolveHarnessLayout(context.rootDir).authoredRoot, "harness.yaml");
   configureLedgerMaintenance(context.rootDir);
   const store = makeTaskEventStore({
-      repoId: context.input.repoId,
-      rootDir: context.rootDir,
-      authoredBranch: context.authoredBranch,
-      killpoint: context.input.killpoint,
-      afterFlush: settleAuthoredCandidates,
-      beforeAppend: () => context.activeWriterEpochGuard?.(),
-      withAppendFence: (operation) =>
-        context.activeWriterEpochFence ? context.activeWriterEpochFence(operation) : operation(),
-      rejectPreparedRecovery: context.mode === "remote-center",
-      walFlushPolicy: () => readSettingsFacet(existsSync(configPath) ? readFileSync(configPath, "utf8") : "").walFlush,
-    }),
-    recovery = store.recover();
+    repoId: context.input.repoId,
+    rootDir: context.rootDir,
+    authoredBranch: context.authoredBranch,
+    killpoint: context.input.killpoint,
+    afterFlush: settleAuthoredCandidates,
+    beforeAppend: () => context.activeWriterEpochGuard?.(),
+    withAppendFence: (operation) =>
+      context.activeWriterEpochFence ? context.activeWriterEpochFence(operation) : operation(),
+    rejectPreparedRecovery: context.mode === "remote-center",
+    walFlushPolicy: () => readSettingsFacet(existsSync(configPath) ? readFileSync(configPath, "utf8") : "").walFlush,
+  });
+  let recovery = store.recover();
   projection = makeTaskProjection({ rootDir: context.rootDir, eventStore: store, now: context.now });
   // Attach advances one bounded, complete projection cut. Serving reads never mutates L2; future
   // writer events remain the authority and apply through the normal single-writer path.
-  projection.catchUp?.();
+  try {
+    projection.catchUp?.();
+  } catch (error) {
+    consumeKnownError(error);
+    recovery = {
+      ...recovery,
+      status: "indeterminate",
+      error: cellErrorMessage(error),
+      errorCode: cellErrorCode(error),
+    };
+  }
   if (pendingSettlementActor) settleAuthoredCandidates(pendingSettlementActor);
   const currentSessionIdentity = (binding: RepoCellBinding) => resolveWriteSessionIdentity(binding, projection!);
   const entityActionExecutor = makeEntityActionCatalogExecutor({

--- a/packages/daemon/src/repo-cell.ts
+++ b/packages/daemon/src/repo-cell.ts
@@ -136,6 +136,9 @@ export function initializeRepoCell(context: RepoCellCoreInput): RepoCellCore {
     }),
     recovery = store.recover();
   projection = makeTaskProjection({ rootDir: context.rootDir, eventStore: store, now: context.now });
+  // Attach advances one bounded, complete projection cut. Serving reads never mutates L2; future
+  // writer events remain the authority and apply through the normal single-writer path.
+  projection.catchUp?.();
   if (pendingSettlementActor) settleAuthoredCandidates(pendingSettlementActor);
   const currentSessionIdentity = (binding: RepoCellBinding) => resolveWriteSessionIdentity(binding, projection!);
   const entityActionExecutor = makeEntityActionCatalogExecutor({

--- a/packages/daemon/src/request-log.ts
+++ b/packages/daemon/src/request-log.ts
@@ -29,6 +29,8 @@ export interface DaemonRequestLogEntry {
   readonly outcome: string | null;
   readonly code: string | null;
   readonly opId: string | null;
+  readonly dispatchDelayMs?: number;
+  readonly serviceMs?: number;
   readonly durationMs: number;
 }
 
@@ -48,6 +50,8 @@ export interface DaemonRequestLogRecord {
   readonly outcome: string | null;
   readonly code: string | null;
   readonly opId: string | null;
+  readonly dispatchDelayMs: number;
+  readonly serviceMs: number;
   readonly durationMs: number;
 }
 
@@ -127,6 +131,8 @@ function buildRecord(entry: DaemonRequestLogEntry, at: Date): DaemonRequestLogRe
     outcome: entry.outcome,
     code: entry.code,
     opId: entry.opId,
+    dispatchDelayMs: entry.dispatchDelayMs ?? 0,
+    serviceMs: entry.serviceMs ?? entry.durationMs,
     durationMs: entry.durationMs,
   };
 }

--- a/packages/daemon/src/task-query-read.ts
+++ b/packages/daemon/src/task-query-read.ts
@@ -168,15 +168,38 @@ export function makeTaskQueryReadModel(input: {
   }
   function guiTasks(query: TaskProjectionListQuery = {}): DaemonTaskSnapshotListResult {
     const lifecycle = projection.list(query),
-      relations = projection.readRelationQuery({}),
-      taskStatuses = projection.readTaskStatuses(),
-      decisionRead = projection.listDecisions({}),
-      cut = requireSameProjectionCut("task control surface", [lifecycle, relations, taskStatuses, decisionRead]),
-      graphWarnings = relationFacetWarnings(relations.status),
+      taskRefs = lifecycle.rows.map(({ taskId }) => `task/${taskId}`),
+      dependencies = projection.readTaskDependencyClosure(taskRefs),
+      derives = projection.readTaskRelationsByTargets(taskRefs, "derives"),
+      edges = [...dependencies.rows, ...derives.rows],
+      relatedTaskIds = [
+        ...new Set(
+          [
+            ...lifecycle.rows.map(({ taskId }) => taskId),
+            ...dependencies.rows.flatMap(({ sourceRef, targetRef }) =>
+              [sourceRef, targetRef].flatMap((ref) => /^task\/([^/]+)$/u.exec(ref)?.[1] ?? []),
+            ),
+          ],
+        ),
+      ],
+      taskStatuses = projection.readTaskStatuses(relatedTaskIds),
+      decisionIds = [
+        ...new Set(
+          derives.rows.flatMap(({ sourceRef }) => /^decision\/([^/]+)/u.exec(sourceRef)?.[1] ?? []),
+        ),
+      ],
+      decisionRead = projection.readDecisions(decisionIds),
+      cut = requireSameProjectionCut("task control surface", [
+        lifecycle,
+        dependencies,
+        derives,
+        taskStatuses,
+        decisionRead,
+      ]),
+      graphWarnings = [...relationFacetWarnings(dependencies.status), ...relationFacetWarnings(derives.status)],
       hardWarnings = graphWarnings.filter(({ severity }) => severity === "hard-fail").map(({ message }) => message),
-      edges = relations.rows,
       activeDerives = new Map<string, typeof edges>();
-    for (const edge of edges)
+    for (const edge of derives.rows)
       if (edge.state === "active" && edge.direction === "directed" && edge.relationType === "derives")
         activeDerives.set(edge.targetRef, [...(activeDerives.get(edge.targetRef) ?? []), edge]);
     const blockingTasks = taskStatuses.rows.flatMap((row) =>

--- a/packages/daemon/src/transport/json-rpc-stream.ts
+++ b/packages/daemon/src/transport/json-rpc-stream.ts
@@ -115,16 +115,17 @@ export function serveJsonRpcStream(options: JsonRpcStreamOptions): DaemonTranspo
   };
 
   function enqueueFrames(frames: ReadonlyArray<unknown>): void {
+    const frameReceivedAt = Date.now();
     for (const frame of frames) {
       queue = queue
-        .then(() => handleFrame(frame))
+        .then(() => handleFrame(frame, frameReceivedAt))
         .catch((error: unknown) => {
           failConnection(error instanceof Error ? error : new Error(String(error)));
         });
     }
   }
 
-  async function handleFrame(frame: unknown): Promise<void> {
+  async function handleFrame(frame: unknown, frameReceivedAt: number): Promise<void> {
     if (waitingForAuthentication) {
       const result = options.authenticateFirstFrame?.(frame, authContext);
       if (!result?.ok) {
@@ -142,7 +143,7 @@ export function serveJsonRpcStream(options: JsonRpcStreamOptions): DaemonTranspo
       writeFrame(streamErrorResponse(null, -32600, "Invalid Request"));
       return;
     }
-    const response = await server.handle(frame as JsonRpcRequest | JsonRpcRequest[]);
+    const response = await server.handle(frame as JsonRpcRequest | JsonRpcRequest[], { frameReceivedAt });
     if (response !== undefined) writeFrame(response);
   }
 

--- a/packages/daemon/test/agent-entities.test.ts
+++ b/packages/daemon/test/agent-entities.test.ts
@@ -533,6 +533,7 @@ test("the GUI entity projection lists closed rows and reads closed declarations"
       },
     };
     projection = makeTaskProjection({ rootDir, eventStore: guardedEventStore });
+    projection.catchUp();
     const agentRows = readAgentEntityGuiProjection({ kind: "agent-list", projection }),
       squadRows = readAgentEntityGuiProjection({ kind: "squad-list", projection });
     assert.equal(agentRows.schema, "agent-entity-catalog/v1");

--- a/packages/daemon/test/agent-runtime-instances.test.ts
+++ b/packages/daemon/test/agent-runtime-instances.test.ts
@@ -53,9 +53,9 @@ test("runtime installation identity survives an upgrade behind the same PATH ent
     writeProviderExecutable(oldExecutable, "console.log(\"2.1.237 (Claude Code)\");\n");
     writeProviderExecutable(newExecutable, "console.log(\"2.1.240 (Claude Code)\");\n");
     symlinkSync(oldExecutable, entry);
-    const before = discoverRuntimeInstallations({ env: { PATH: bin }, now: () => "2026-08-22T00:00:00.000Z" })[0]!;
+    const before = (await discoverRuntimeInstallations({ env: { PATH: bin }, now: () => "2026-08-22T00:00:00.000Z" }))[0]!;
     rmSync(entry); symlinkSync(newExecutable, entry);
-    const after = discoverRuntimeInstallations({ env: { PATH: bin }, now: () => "2026-08-23T00:00:00.000Z" })[0]!;
+    const after = (await discoverRuntimeInstallations({ env: { PATH: bin }, now: () => "2026-08-23T00:00:00.000Z" }))[0]!;
     assert.deepEqual([before.version, after.version], ["2.1.237 (Claude Code)", "2.1.240 (Claude Code)"]);
     assert.deepEqual([before.executablePath, after.executablePath], [realpathSync(oldExecutable), realpathSync(newExecutable)]);
     assert.equal(before.executableEntryPath, path.resolve(entry)); assert.equal(after.executableEntryPath, before.executableEntryPath);
@@ -65,19 +65,38 @@ test("runtime installation identity survives an upgrade behind the same PATH ent
   } finally { rmSync(root, { recursive: true, force: true }); }
 });
 
-test("runtime installation discovery projects each provider's detected model catalog", () => {
+test("runtime installation discovery projects each provider's detected model catalog", async () => {
   const root = mkdtempSync(path.join(tmpdir(), "ha-runtime-model-discovery-")), bin = path.join(root, "bin");
   try {
     mkdirSync(bin);
     writeProviderExecutable(path.join(bin, "codex"), `const args = process.argv.slice(2); if (args[0] === "--version") console.log("codex-test"); else if (args.join(" ") === "debug models --bundled") console.log(JSON.stringify({ models: [{ slug: "gpt-sol" }, { slug: "gpt-terra" }] }));\n`);
     writeProviderExecutable(path.join(bin, "agy"), `const args = process.argv.slice(2); if (args[0] === "--version") console.log("agy-test"); else if (args[0] === "models") console.log("gemini-high\\tGemini High\\ngemini-low\\tGemini Low");\n`);
     writeProviderExecutable(path.join(bin, "claude"), `const args = process.argv.slice(2); if (args[0] === "--version") console.log("claude-test"); else if (args[0] === "--help") console.log("aliases 'fable', 'sonnet', and 'opus'");\n`);
-    const rows = discoverRuntimeInstallations({ env: { PATH: bin }, now: () => "2026-08-22T00:00:00.000Z" });
+    const rows = await discoverRuntimeInstallations({ env: { PATH: bin }, now: () => "2026-08-22T00:00:00.000Z" });
     assert.deepEqual(rows.map(({ kindId, models, defaultModel }) => ({ kindId, models, defaultModel })), [
       { kindId: "agy", models: ["gemini-high", "gemini-low"], defaultModel: "gemini-high" },
       { kindId: "claude", models: ["fable", "sonnet", "opus"], defaultModel: "fable" },
       { kindId: "codex", models: ["gpt-sol", "gpt-terra"], defaultModel: "gpt-sol" }
     ]);
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test("runtime installation probes are asynchronous and parallel across providers", async (context) => {
+  const root = mkdtempSync(path.join(tmpdir(), "ha-runtime-async-discovery-")), bin = path.join(root, "bin");
+  try {
+    mkdirSync(bin);
+    for (const kindId of ["codex", "claude", "agy"] as const)
+      writeProviderExecutable(path.join(bin, kindId), `const args = process.argv.slice(2); setTimeout(() => { if (args[0] === "--version") console.log("${kindId}-async"); else if ("${kindId}" === "codex") console.log(JSON.stringify({ models: [{ slug: "gpt-async" }] })); else if ("${kindId}" === "agy") console.log("gemini-async\\tGemini Async"); else console.log("aliases 'fable'"); }, 100);\n`);
+    let heartbeats = 0;
+    const heartbeat = setInterval(() => { heartbeats += 1; }, 5), startedAt = Date.now();
+    try {
+      const rows = await discoverRuntimeInstallations({ env: { PATH: bin } });
+      assert.deepEqual(rows.map(({ kindId }) => kindId), ["agy", "claude", "codex"]);
+    } finally { clearInterval(heartbeat); }
+    const durationMs = Date.now() - startedAt;
+    context.diagnostic(`runtime-discovery-duration-ms=${durationMs};heartbeats=${heartbeats}`);
+    assert.ok(heartbeats >= 10, `expected event-loop progress during discovery, observed ${heartbeats} heartbeats`);
+    assert.ok(durationMs < 1_600, `expected parallel provider probes, discovery took ${durationMs}ms`);
   } finally { rmSync(root, { recursive: true, force: true }); }
 });
 
@@ -826,7 +845,7 @@ test("win32 installation discovery probes PATHEXT suffixes and witnesses the shi
   try {
     mkdirSync(bin);
     const executablePath = writeProviderExecutable(process.platform === "win32" ? path.join(bin, "codex") : path.join(bin, "codex.exe"), "console.log(\"stub-runtime-1.0.0\");\n");
-    const installations = discoverRuntimeInstallations({ env: { PATH: bin }, platform: "win32", now: () => "2026-08-15T01:00:00.000Z" });
+    const installations = await discoverRuntimeInstallations({ env: { PATH: bin }, platform: "win32", now: () => "2026-08-15T01:00:00.000Z" });
     assert.equal(installations.length, 1);
     assert.deepEqual({ kindId: installations[0]!.kindId, version: installations[0]!.version, observedAt: installations[0]!.observedAt }, { kindId: "codex", version: "stub-runtime-1.0.0", observedAt: "2026-08-15T01:00:00.000Z" });
     assert.equal(installations[0]!.executablePath.endsWith(process.platform === "win32" ? "codex.cmd" : "codex.exe"), true);
@@ -846,7 +865,7 @@ test("the shared provider stub fixture launches with the exact argv on every pla
     const executablePath = writeProviderExecutable(script, `const fs = require("node:fs");\nconst argv = process.argv.slice(2), serialized = JSON.stringify(argv);\nfs.writeFileSync(${JSON.stringify(witness)}, serialized);\nconsole.log(serialized);\nif (serialized !== JSON.stringify(["--version"]) && serialized !== JSON.stringify(["login", "status"])) process.exit(9);\n`);
     assert.equal(readFileSync(script, "utf8").startsWith(`#!${process.execPath}\n`), true);
     if (process.platform === "win32") assert.equal(executablePath.endsWith(".cmd"), true); else assert.equal(statSync(script).mode & 0o777, 0o755);
-    const installations = discoverRuntimeInstallations({ env: { PATH: bin } });
+    const installations = await discoverRuntimeInstallations({ env: { PATH: bin } });
     assert.equal(installations.length, 1, JSON.stringify(installations));
     assert.equal(installations[0]!.executablePath, realpathSync(executablePath));
     assert.equal(installations[0]!.version, JSON.stringify(["--version"]));

--- a/packages/daemon/test/agent-runtime-session-groups.contract.test.ts
+++ b/packages/daemon/test/agent-runtime-session-groups.contract.test.ts
@@ -200,6 +200,7 @@ const dispatches: readonly TaskDispatchRow[] = [
 function projectionFixture(): TaskProjection {
   const selected = () => sessions;
   return {
+    readCut: () => ({ status: "ready", watermark: 40, sourceRevision: 40 }),
     readTaskStatuses: () => ({ status: "ready", rows: [], watermark: 40, sourceRevision: 40 }),
     readRuntimeSessions: selected,
     readRuntimeDispatches: () => sessions.map(runtimeDispatch),

--- a/packages/daemon/test/agent-runtime-slice-b.test.ts
+++ b/packages/daemon/test/agent-runtime-slice-b.test.ts
@@ -176,12 +176,14 @@ test("runtime overview batches definitions while a single-session read selects o
   withRuntime(({ store, projection, stream }) => {
     let fullTaskListReads = 0,
       taskStatusReads = 0,
+      cutReads = 0,
       singleDispatchReads = 0,
       batchDispatchReads = 0;
     const measured = new Proxy(projection, {
       get: (target, property, receiver) => {
         if (property === "list") fullTaskListReads += 1;
         if (property === "readTaskStatuses") taskStatusReads += 1;
+        if (property === "readCut") cutReads += 1;
         if (property === "readRuntimeDispatch") singleDispatchReads += 1;
         if (property === "readRuntimeDispatches") batchDispatchReads += 1;
         const value = Reflect.get(target, property, receiver);
@@ -192,21 +194,21 @@ test("runtime overview batches definitions while a single-session read selects o
     reads.overview({});
     reads.session({ runtimeSessionId: "runtime-session" });
     assert.deepEqual(
-      { fullTaskListReads, taskStatusReads, singleDispatchReads, batchDispatchReads },
-      { fullTaskListReads: 0, taskStatusReads: 2, singleDispatchReads: 2, batchDispatchReads: 0 },
+      { fullTaskListReads, taskStatusReads, cutReads, singleDispatchReads, batchDispatchReads },
+      { fullTaskListReads: 0, taskStatusReads: 0, cutReads: 2, singleDispatchReads: 2, batchDispatchReads: 0 },
     );
   }));
 
-test("runtime session reads resolve a task dispatch after synchronizing its projection", () =>
+test("runtime session reads resolve a task dispatch after observing its projection cut", () =>
   withRuntime(({ store, projection, stream }) => {
-    let synchronized = false;
-    const original = projection.readTaskStatuses.bind(projection);
+    let cutObserved = false;
+    const original = projection.readCut.bind(projection);
     const measured = new Proxy(projection, {
       get: (target, property, receiver) => {
-        if (property === "readTaskStatuses")
-          return (...args: Parameters<typeof original>) => {
-            const result = original(...args);
-            synchronized = true;
+        if (property === "readCut")
+          return () => {
+            const result = original();
+            cutObserved = true;
             return result;
           };
         const value = Reflect.get(target, property, receiver);
@@ -215,7 +217,7 @@ test("runtime session reads resolve a task dispatch after synchronizing its proj
     });
     const synchronizedReads = makeAgentRuntimeReadModel({
       readDispatch: (taskId, dispatchId) => {
-        assert.equal(synchronized, true);
+        assert.equal(cutObserved, true);
         assert.deepEqual({ taskId, dispatchId }, { taskId: "task-runtime", dispatchId: "dispatch-runtime" });
         return { runtimeSessionId: "runtime-session" };
       },

--- a/packages/daemon/test/command-admission.test.ts
+++ b/packages/daemon/test/command-admission.test.ts
@@ -37,6 +37,15 @@ test("all daemon commands close every repo-mode admission cell", () => {
   assert.equal(cells, daemonProtocolCommands.length * daemonRepoModeWords.length);
 });
 
+test("legacy repo reads have no descriptor left on the serialized write method", () => {
+  const legacyReadIds = ["task-list", "task-show", "doc-status", "settings-read"];
+  for (const command of daemonProtocolCommands)
+    if (command.commandClass === "repo-read")
+      assert.notEqual(command.method, "repo.task.run", command.id);
+  for (const id of legacyReadIds)
+    assert.equal(daemonProtocolCommands.find((command) => command.id === id)?.method, "repo.task.read", id);
+});
+
 test("observe.tail declares direct admission and named source residency for every tail kind", () => {
   const command = observeTailReadMethod;
   assert.deepEqual(command.admission, {

--- a/packages/daemon/test/conn-log.test.ts
+++ b/packages/daemon/test/conn-log.test.ts
@@ -18,7 +18,7 @@ test("conn log records open/request/close with monotonic ids, active counts, and
   const userRoot = tempRoot(), log = openDaemonConnLog({ userRoot, daemonId: "test-daemon", now: at("2026-08-20T13:00:00Z") });
   const first = log.connectionOpened("uuid-1", "unix-socket"), second = log.connectionOpened("uuid-2", "unix-socket");
   assert.equal(first, "c-1"); assert.equal(second, "c-2");
-  log.request({ conn: first, transport: "unix-socket", method: "protocol.hello", startedAt: Date.parse("2026-08-20T13:00:01Z"), durationMs: 3, ok: true, code: null });
+  log.request({ conn: first, transport: "unix-socket", method: "protocol.hello", frameReceivedAt: Date.parse("2026-08-20T13:00:00.990Z"), handlerStartedAt: Date.parse("2026-08-20T13:00:01Z"), repliedAt: Date.parse("2026-08-20T13:00:01.003Z"), startedAt: Date.parse("2026-08-20T13:00:01Z"), dispatchDelayMs: 10, serviceMs: 3, durationMs: 3, ok: true, code: null });
   log.request({ conn: first, transport: "unix-socket", method: "daemon.status", startedAt: Date.parse("2026-08-20T13:00:02Z"), durationMs: 11, ok: true, code: null });
   log.connectionClosed("uuid-1");
   log.request({ conn: second, transport: "unix-socket", method: "repo.task.run", startedAt: Date.parse("2026-08-20T13:00:04Z"), durationMs: 40, ok: false, code: "repo_warming" });
@@ -27,8 +27,8 @@ test("conn log records open/request/close with monotonic ids, active counts, and
   const records = recordsOf(userRoot);
   assert.deepEqual(records.map((record) => record.event), ["conn_open", "conn_open", "request", "request", "conn_close", "request", "conn_close"]);
   assert.equal(records[0].conn, "c-1"); assert.equal(records[0].active, 1); assert.equal(records[1].conn, "c-2"); assert.equal(records[1].active, 2);
-  const hello = records[2] as { at: string; atEnd: string; durationMs: number; method: string; ok: boolean };
-  assert.equal(hello.method, "protocol.hello"); assert.equal(hello.at, "2026-08-20T13:00:01.000Z"); assert.equal(hello.atEnd, "2026-08-20T13:00:01.003Z"); assert.equal(hello.durationMs, 3); assert.equal(hello.ok, true);
+  const hello = records[2] as { at: string; atEnd: string; frameReceivedAt: string; handlerStartedAt: string; repliedAt: string; dispatchDelayMs: number; serviceMs: number; durationMs: number; method: string; ok: boolean };
+  assert.equal(hello.method, "protocol.hello"); assert.equal(hello.at, "2026-08-20T13:00:01.000Z"); assert.equal(hello.frameReceivedAt, "2026-08-20T13:00:00.990Z"); assert.equal(hello.handlerStartedAt, hello.at); assert.equal(hello.repliedAt, "2026-08-20T13:00:01.003Z"); assert.equal(hello.atEnd, hello.repliedAt); assert.equal(hello.dispatchDelayMs, 10); assert.equal(hello.serviceMs, 3); assert.equal(hello.durationMs, 3); assert.equal(hello.ok, true);
   const close = records[4] as { conn: string; active: number; durationMs: number; requests: number };
   assert.equal(close.conn, "c-1"); assert.equal(close.active, 1); assert.equal(close.requests, 2); assert.equal(close.durationMs, 0);
   const rejected = records[5] as { ok: boolean; code: string | null };

--- a/packages/daemon/test/doc-sync-slice-a-implicit-lease.test.ts
+++ b/packages/daemon/test/doc-sync-slice-a-implicit-lease.test.ts
@@ -4,7 +4,7 @@ import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
-import { makeTaskEventStore, type TaskProjection } from "../../kernel/src/index.ts";
+import { makeTaskEventStore, makeTaskProjection, type TaskProjection } from "../../kernel/src/index.ts";
 import { runDocAction } from "../src/doc-sync-actions.ts";
 import { canonicalRoot, workspaceId } from "../src/protocol/daemon-protocol.contract.ts";
 import { authorizeRepoCellAction } from "../src/repo-cell-authorization.ts";
@@ -405,6 +405,12 @@ test("a runtime actor with a lapsed lease is told the release and re-enter recov
       ),
     );
     await new Promise((resolve) => setTimeout(resolve, 50));
+    const projection = makeTaskProjection({ rootDir, eventStore: makeTaskEventStore({ repoId, rootDir }) });
+    try {
+      projection.catchUp();
+    } finally {
+      projection.close();
+    }
     const rejected = (await cell.run({ kind: "doc-submit", paths: [report] }, worker)) as {
       outcome?: string;
       code?: string;

--- a/packages/daemon/test/json-rpc-protocol.test.ts
+++ b/packages/daemon/test/json-rpc-protocol.test.ts
@@ -107,6 +107,11 @@ test("protocol descriptors preserve topology metadata without authorizing action
     "distill-promote": "repo-write"
   } as const;
   assert.deepEqual(Object.fromEntries(Object.keys(expected).map((kind) => [kind, commandClassForAction(kind)])), expected);
+  for (const command of daemonProtocolCommands)
+    if (command.commandClass === "repo-read") assert.notEqual(command.method, "repo.task.run", command.id);
+  const legacyRead = { action: { kind: "task-show", taskId: "task-direct" } };
+  assert.deepEqual(actionForDaemonMethod("repo.task.read", legacyRead), legacyRead.action);
+  assert.throws(() => actionForDaemonMethod("repo.task.run", legacyRead), /closed method descriptor/u);
 });
 
 // prettier-ignore

--- a/packages/daemon/test/read-stopgap-performance.integration.test.ts
+++ b/packages/daemon/test/read-stopgap-performance.integration.test.ts
@@ -1,0 +1,163 @@
+// harness-test-tier: integration
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { performance } from "node:perf_hooks";
+import test from "node:test";
+import { requestDaemonJsonRpcAt } from "../src/client/local-json-rpc-client.ts";
+import { localUserDaemonEndpoint } from "../src/client/local-daemon-target.ts";
+import { openDaemonHost } from "../src/daemon-host.ts";
+import { createJsonRpcProtocolServer } from "../src/protocol/json-rpc-server.ts";
+import { createUnixSocketTransportServer } from "../src/transport/unix-socket.ts";
+import { initIngressRepo } from "./fixtures/runtime-ingress.ts";
+import { writeProviderExecutable } from "./fixtures/runtime-stub.ts";
+import { registerBootstrappedDaemonRepo as registerDaemonRepo } from "./repo-settings.fixture.ts";
+
+test("runtime discovery write load keeps independent read clients within the stopgap latency envelope", async (t) => {
+  const parent = mkdtempSync(path.join(tmpdir(), "ha-read-stopgap-perf-")),
+    root = path.join(parent, "repo"),
+    userRoot = path.join(parent, "user"),
+    daemonId = "read-stopgap-perf",
+    repoId = "read-stopgap-perf",
+    uid = process.getuid?.() ?? 0,
+    endpoint = localUserDaemonEndpoint(userRoot, daemonId),
+    executablePath = writeProviderExecutable(
+      path.join(parent, "codex-stub"),
+      `if (process.argv.slice(2).join(" ") === "login status") process.exit(0); process.exit(0);\n`,
+    ),
+    installation = {
+      installationId: "installation-read-stopgap",
+      kindId: "codex" as const,
+      executablePath,
+      version: "1.0.0",
+      observedAt: "2026-09-01T00:00:00.000Z",
+    };
+  let discoveryCalls = 0;
+  initIngressRepo(root, uid);
+  registerDaemonRepo({ canonicalRoot: root, repoId, userRoot, createConvenienceLinks: false });
+  const host = await openDaemonHost({
+      daemonId,
+      userRoot,
+      runtimeDiscover: async () => {
+        discoveryCalls += 1;
+        await new Promise((resolve) => setTimeout(resolve, 1_500));
+        return [installation];
+      },
+      runtimeLaunch: () => ({
+        pid: 4242,
+        onOutput: () => undefined,
+        onErrorOutput: () => undefined,
+        onExit: () => undefined,
+        terminate: () => undefined,
+      }),
+    }),
+    transport = createUnixSocketTransportServer({
+      daemonId,
+      socketPath: endpoint,
+      createProtocolServer: (authContext, emit) =>
+        createJsonRpcProtocolServer({ host, build: { commit: null }, authContext, emit }),
+    }),
+    readCalls = [
+      ["workspaceSummary", "repo.workspace.summary.read", { repo: { repoId } }],
+      ["guiTaskList", "repo.tasks.list", { repo: { repoId }, payload: { limit: 1 } }],
+      [
+        "legacyTaskList",
+        "repo.task.read",
+        { repo: { repoId }, payload: { action: { kind: "task-list", limit: 1 } } },
+      ],
+    ] as const;
+  await transport.start();
+  try {
+    await host.attachmentsSettled();
+    await request("daemon.runtimeInstance.create", {
+      payload: {
+        instanceId: "read-stopgap-codex",
+        name: "Read stopgap Codex",
+        kindId: "codex",
+        installationId: installation.installationId,
+        providerId: "openai",
+        models: ["gpt-stopgap"],
+        authMode: "subscription",
+      },
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    const idle = await measure(readCalls, 20),
+      callsBeforeSpawn = discoveryCalls,
+      spawn = request("repo.agentRuntime.spawn", {
+        repo: { repoId },
+        payload: {
+          runtimeInstanceId: "read-stopgap-codex",
+          cwd: { scope: "repo-root" },
+          prompt: "Measure the async discovery boundary.",
+          taskId: null,
+          idempotencyKey: "read-stopgap-load",
+        },
+      });
+    await eventually(() => discoveryCalls > callsBeforeSpawn);
+    const loaded = await measure(readCalls, 50),
+      spawned = await spawn,
+      metrics = Object.fromEntries(
+        readCalls.map(([name]) => [
+          name,
+          {
+            idle: distribution(idle[name]),
+            loaded: distribution(loaded[name]),
+          },
+        ]),
+      ) as Record<string, { idle: Distribution; loaded: Distribution }>;
+    assert.equal(spawned.outcome, "applied", JSON.stringify(spawned));
+    for (const [name, metric] of Object.entries(metrics))
+      assert.equal(
+        metric.loaded.p95 <= Math.max(1, metric.idle.p95) * 2,
+        true,
+        `${name}: ${JSON.stringify(metric)}`,
+      );
+    t.diagnostic(`read-stopgap-metrics=${JSON.stringify(metrics)}`);
+  } finally {
+    await transport.stop();
+    await host.close();
+    rmSync(parent, { recursive: true, force: true });
+  }
+
+  async function request(method: string, params: Record<string, unknown>): Promise<Record<string, unknown>> {
+    return requestDaemonJsonRpcAt(endpoint, method, params, 2_000, 5_000);
+  }
+  async function measure(
+    calls: typeof readCalls,
+    samples: number,
+  ): Promise<Record<(typeof readCalls)[number][0], number[]>> {
+    const values = Object.fromEntries(calls.map(([name]) => [name, []])) as Record<
+      (typeof readCalls)[number][0],
+      number[]
+    >;
+    for (let sample = 0; sample < samples; sample += 1)
+      for (const [name, method, params] of calls) {
+        const startedAt = performance.now();
+        await request(method, params);
+        values[name].push(Math.round(performance.now() - startedAt));
+      }
+    return values;
+  }
+});
+
+interface Distribution {
+  readonly n: number;
+  readonly p50: number;
+  readonly p95: number;
+  readonly max: number;
+}
+
+function distribution(values: readonly number[]): Distribution {
+  const sorted = [...values].sort((left, right) => left - right),
+    percentile = (ratio: number) => sorted[Math.max(0, Math.ceil(sorted.length * ratio) - 1)] ?? 0;
+  return { n: sorted.length, p50: percentile(0.5), p95: percentile(0.95), max: sorted.at(-1) ?? 0 };
+}
+
+async function eventually(predicate: () => boolean): Promise<void> {
+  for (let attempt = 0; attempt < 200; attempt += 1) {
+    if (predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+  throw new Error("runtime discovery load did not start");
+}

--- a/packages/daemon/test/repo-cell-latch-recovery.test.ts
+++ b/packages/daemon/test/repo-cell-latch-recovery.test.ts
@@ -253,10 +253,10 @@ test("an invalid_store latch re-attaches on the next command after the ledger is
       ownerId: "latch-heal-two",
       now: () => clock,
     });
-    assert.equal(cell.status().state, "attached"); // the open is lazy; the first ledger read latches
+    assert.equal(cell.status().state, "unavailable"); // attach catch-up classifies the mixed ledger immediately
     const latchedList = await cell.run({ kind: "task-list" }, binding);
     assert.equal(latchedList.outcome, "op_rejected");
-    assert.equal(latchedList.code, "invalid_store");
+    assert.equal(latchedList.code, "repo_unavailable");
     assert.match(
       String(latchedList.nextAction),
       /events root mixes .* flat\/v1 .* sharded entries; run ha migrate ledger/u,
@@ -464,7 +464,7 @@ test("every latched RepoCell exit declares the latch and the cause identically w
     cell = await openRepoCell({ repoId: workspaceId("latch"), rootDir: canonicalRoot(rootDir), ownerId: "latch-two" });
     const first = await cell.run({ kind: "task-list" }, binding);
     assert.equal(first.outcome, "op_rejected");
-    assert.equal(first.code, "invalid_store");
+    assert.equal(first.code, "repo_unavailable");
     assert.equal(cell.status().state, "unavailable");
     assert.match(
       String(first.nextAction ?? ""),

--- a/packages/daemon/test/request-log.test.ts
+++ b/packages/daemon/test/request-log.test.ts
@@ -8,7 +8,12 @@ import type { DaemonHost } from "../src/daemon-host.ts";
 import { daemonLifecycleLogPath, openDaemonLifecycleLog, readDaemonLifecycleRecords } from "../src/lifecycle-log.ts";
 import { createJsonRpcProtocolServer } from "../src/protocol/json-rpc-server.ts";
 import { currentDaemonProtocolVersion } from "../src/protocol/version.ts";
-import { daemonRequestLogPath, openDaemonRequestLog, type DaemonRequestLogEntry, type DaemonRequestLogRecord } from "../src/request-log.ts";
+import {
+  daemonRequestLogPath,
+  openDaemonRequestLog,
+  type DaemonRequestLogEntry,
+  type DaemonRequestLogRecord,
+} from "../src/request-log.ts";
 
 function tempRoot(): string {
   return mkdtempSync(path.join(os.tmpdir(), "harness-request-log-"));
@@ -17,28 +22,69 @@ function tempRoot(): string {
 function stubHost(rootDir: string): DaemonHost {
   return {
     run: async () => ({ outcome: "applied" as const, opId: "op_test_0001", revision: 7 }),
-    status: () => ({ daemonId: "test-daemon", pid: 1, repos: [{ repoId: "logged", rootDir, state: "attached" as const, generation: 1, queueDepth: 0, lastError: null, recoveryMs: 0 }] })
+    status: () => ({
+      daemonId: "test-daemon",
+      pid: 1,
+      repos: [
+        {
+          repoId: "logged",
+          rootDir,
+          state: "attached" as const,
+          generation: 1,
+          queueDepth: 0,
+          lastError: null,
+          recoveryMs: 0,
+        },
+      ],
+    }),
   } as unknown as DaemonHost;
 }
 
 async function handshake(server: ReturnType<typeof createJsonRpcProtocolServer>): Promise<void> {
-  await server.handle({ jsonrpc: "2.0", id: 1, method: "protocol.hello", params: { protocolVersion: currentDaemonProtocolVersion } });
+  await server.handle({
+    jsonrpc: "2.0",
+    id: 1,
+    method: "protocol.hello",
+    params: { protocolVersion: currentDaemonProtocolVersion },
+  });
 }
 
 function readRecords(rootDir: string): readonly DaemonRequestLogRecord[] {
-  return readFileSync(daemonRequestLogPath(rootDir), "utf8").split("\n").filter((line) => line.length > 0)
+  return readFileSync(daemonRequestLogPath(rootDir), "utf8")
+    .split("\n")
+    .filter((line) => line.length > 0)
     .map((line) => JSON.parse(line) as DaemonRequestLogRecord);
 }
 
 function openServerWithLog(rootDir: string, host: DaemonHost = stubHost(rootDir)) {
-  const log = openDaemonRequestLog({ resolveRootDir: (repoId) => host.status().repos.find((repo) => repo.repoId === repoId)?.rootDir });
-  return createJsonRpcProtocolServer({ host, build: { commit: null }, authContext: { transportKind: "unix-socket", unixSocketOwnerBoundary: { ownerUid: 501, source: "unix-socket-filesystem-owner-boundary" } }, emit: async () => undefined, recordRequest: log.record });
+  const log = openDaemonRequestLog({
+    resolveRootDir: (repoId) => host.status().repos.find((repo) => repo.repoId === repoId)?.rootDir,
+  });
+  return createJsonRpcProtocolServer({
+    host,
+    build: { commit: null },
+    authContext: {
+      transportKind: "unix-socket",
+      unixSocketOwnerBoundary: { ownerUid: 501, source: "unix-socket-filesystem-owner-boundary" },
+    },
+    emit: async () => undefined,
+    recordRequest: log.record,
+  });
 }
 
 test("a repo-scoped read request is recorded in the repository local root", async () => {
-  const rootDir = tempRoot(), server = openServerWithLog(rootDir);
+  const rootDir = tempRoot(),
+    server = openServerWithLog(rootDir);
   await handshake(server);
-  await server.handle({ jsonrpc: "2.0", id: 2, method: "repo.task.read", params: { repo: { repoId: "logged" }, payload: { action: { kind: "task-show", taskId: "task_01ARZ3NDEKTSV4RRFFQ69G5FAV" } } } });
+  await server.handle({
+    jsonrpc: "2.0",
+    id: 2,
+    method: "repo.task.read",
+    params: {
+      repo: { repoId: "logged" },
+      payload: { action: { kind: "task-show", taskId: "task_01ARZ3NDEKTSV4RRFFQ69G5FAV" } },
+    },
+  });
   server.close();
 
   const records = readRecords(rootDir);
@@ -63,20 +109,39 @@ test("a repo-scoped read request is recorded in the repository local root", asyn
 });
 
 test("the declared agent executor is recorded so a request can be attributed to the agent that made it", async () => {
-  const rootDir = tempRoot(), server = openServerWithLog(rootDir);
+  const rootDir = tempRoot(),
+    server = openServerWithLog(rootDir);
   await handshake(server);
   // The CLI puts the declared executor inside payload.action for repo.task.read; that is the shape
   // the daemon attributes from, so it is the shape the log has to read.
-  await server.handle({ jsonrpc: "2.0", id: 2, method: "repo.task.read", params: { repo: { repoId: "logged" }, payload: { action: { kind: "task-show", taskId: "task_01ARZ3NDEKTSV4RRFFQ69G5FAV", executor: { kind: "agent", id: "codex-worker" } } } } });
+  await server.handle({
+    jsonrpc: "2.0",
+    id: 2,
+    method: "repo.task.read",
+    params: {
+      repo: { repoId: "logged" },
+      payload: {
+        action: {
+          kind: "task-show",
+          taskId: "task_01ARZ3NDEKTSV4RRFFQ69G5FAV",
+          executor: { kind: "agent", id: "codex-worker" },
+        },
+      },
+    },
+  });
   server.close();
 
   assert.deepEqual(readRecords(rootDir)[0].executor, { kind: "agent", id: "codex-worker" });
 });
 
 test("requests from one connection share a connection id", async () => {
-  const rootDir = tempRoot(), server = openServerWithLog(rootDir);
+  const rootDir = tempRoot(),
+    server = openServerWithLog(rootDir);
   await handshake(server);
-  const payload = { repo: { repoId: "logged" }, payload: { action: { kind: "task-show", taskId: "task_01ARZ3NDEKTSV4RRFFQ69G5FAV" } } };
+  const payload = {
+    repo: { repoId: "logged" },
+    payload: { action: { kind: "task-show", taskId: "task_01ARZ3NDEKTSV4RRFFQ69G5FAV" } },
+  };
   await server.handle({ jsonrpc: "2.0", id: 2, method: "repo.task.read", params: payload });
   await server.handle({ jsonrpc: "2.0", id: 3, method: "repo.task.read", params: payload });
   server.close();
@@ -88,11 +153,28 @@ test("requests from one connection share a connection id", async () => {
 });
 
 test("a rejected request is recorded with its error code", async () => {
-  const rootDir = tempRoot(), host = stubHost(rootDir);
-  const rejecting = { ...host, run: async () => ({ outcome: "op_rejected" as const, opId: "rejected:task-show", code: "repo_unavailable", nextAction: "Attach the repository." }) } as unknown as DaemonHost;
+  const rootDir = tempRoot(),
+    host = stubHost(rootDir);
+  const rejecting = {
+    ...host,
+    run: async () => ({
+      outcome: "op_rejected" as const,
+      opId: "rejected:task-show",
+      code: "repo_unavailable",
+      nextAction: "Attach the repository.",
+    }),
+  } as unknown as DaemonHost;
   const server = openServerWithLog(rootDir, rejecting);
   await handshake(server);
-  await server.handle({ jsonrpc: "2.0", id: 2, method: "repo.task.read", params: { repo: { repoId: "logged" }, payload: { action: { kind: "task-show", taskId: "task_01ARZ3NDEKTSV4RRFFQ69G5FAV" } } } });
+  await server.handle({
+    jsonrpc: "2.0",
+    id: 2,
+    method: "repo.task.read",
+    params: {
+      repo: { repoId: "logged" },
+      payload: { action: { kind: "task-show", taskId: "task_01ARZ3NDEKTSV4RRFFQ69G5FAV" } },
+    },
+  });
   server.close();
 
   const records = readRecords(rootDir);
@@ -103,7 +185,8 @@ test("a rejected request is recorded with its error code", async () => {
 });
 
 test("a request that binds no repository is not recorded", async () => {
-  const rootDir = tempRoot(), server = openServerWithLog(rootDir);
+  const rootDir = tempRoot(),
+    server = openServerWithLog(rootDir);
   await handshake(server);
   await server.handle({ jsonrpc: "2.0", id: 2, method: "daemon.status", params: {} });
   server.close();
@@ -117,7 +200,8 @@ test("rotation holds the log to a bounded number of files", () => {
   const log = openDaemonRequestLog({ resolveRootDir: () => rootDir, maxBytes: 512, keptFiles: 2 });
   for (let index = 0; index < 400; index += 1) log.record(entry({ opId: `op_${index}` }));
 
-  const logDir = path.dirname(daemonRequestLogPath(rootDir)), files = readdirSync(logDir).sort();
+  const logDir = path.dirname(daemonRequestLogPath(rootDir)),
+    files = readdirSync(logDir).sort();
   assert.deepEqual(files, ["requests.jsonl", "requests.jsonl.1", "requests.jsonl.2"]);
   // The ceiling is the point: without it an always-on request log is an unbounded disk write.
   for (const file of files) assert.ok(readFileSync(path.join(logDir, file), "utf8").length < 512 + 1024);
@@ -134,25 +218,63 @@ test("a sink that cannot write neither throws nor keeps reporting", () => {
   const failures: unknown[] = [];
   const log = openDaemonRequestLog({ resolveRootDir: () => rootDir, onFailure: (error) => failures.push(error) });
 
-  assert.doesNotThrow(() => { log.record(entry({})); log.record(entry({})); log.record(entry({})); });
+  assert.doesNotThrow(() => {
+    log.record(entry({}));
+    log.record(entry({}));
+    log.record(entry({}));
+  });
   // Reported once, then silent: an observability sink must not become a log spammer either.
   assert.equal(failures.length, 1);
 });
 
 test("daemon lifecycle records are structured and roll before an unbounded next generation", () => {
-  const userRoot = tempRoot(), logPath = daemonLifecycleLogPath(userRoot, "availability"); mkdirSync(path.dirname(logPath), { recursive: true });
-  for (let generation = 0; generation < 3; generation += 1) { writeFileSync(logPath, `${"x".repeat(600)}\n`, "utf8"); openDaemonLifecycleLog({ userRoot, daemonId: "availability", maxBytes: 512, keptFiles: 2,
-    now: () => new Date("2026-08-19T00:00:00.000Z") }).record({ event: "repo_attach_completed", repoId: `repo-${generation}`, durationMs: generation, attachIndex: generation + 1, attachTotal: 3 }); }
-  const records = readDaemonLifecycleRecords(userRoot, "availability"), latest = records.at(-1)!;
-  assert.equal(latest.schema, "daemon-lifecycle/v1"); assert.equal(latest.daemonId, "availability"); assert.equal(latest.event, "repo_attach_completed");
-  assert.equal(latest.repoId, "repo-2"); assert.equal(latest.durationMs, 2); assert.equal(latest.at, "2026-08-19T00:00:00.000Z");
-  assert.deepEqual(readdirSync(path.dirname(daemonLifecycleLogPath(userRoot, "availability"))).sort(), ["daemon-availability.log", "daemon-availability.log.1", "daemon-availability.log.2"]);
+  const userRoot = tempRoot(),
+    logPath = daemonLifecycleLogPath(userRoot, "availability");
+  mkdirSync(path.dirname(logPath), { recursive: true });
+  for (let generation = 0; generation < 3; generation += 1) {
+    writeFileSync(logPath, `${"x".repeat(600)}\n`, "utf8");
+    openDaemonLifecycleLog({
+      userRoot,
+      daemonId: "availability",
+      maxBytes: 512,
+      keptFiles: 2,
+      now: () => new Date("2026-08-19T00:00:00.000Z"),
+    }).record({
+      event: "repo_attach_completed",
+      repoId: `repo-${generation}`,
+      durationMs: generation,
+      attachIndex: generation + 1,
+      attachTotal: 3,
+    });
+  }
+  const records = readDaemonLifecycleRecords(userRoot, "availability"),
+    latest = records.at(-1)!;
+  assert.equal(latest.schema, "daemon-lifecycle/v1");
+  assert.equal(latest.daemonId, "availability");
+  assert.equal(latest.event, "repo_attach_completed");
+  assert.equal(latest.repoId, "repo-2");
+  assert.equal(latest.durationMs, 2);
+  assert.equal(latest.at, "2026-08-19T00:00:00.000Z");
+  assert.deepEqual(readdirSync(path.dirname(daemonLifecycleLogPath(userRoot, "availability"))).sort(), [
+    "daemon-availability.log",
+    "daemon-availability.log.1",
+    "daemon-availability.log.2",
+  ]);
 });
 
 function entry(overrides: Partial<DaemonRequestLogEntry>): DaemonRequestLogEntry {
   return {
-    method: "repo.task.run", repoId: "logged", command: "task-show",
-    connectionId: "connection-1", auth: { transportKind: "unix-socket" }, executor: null,
-    ok: true, outcome: "applied", code: null, opId: "op_test", durationMs: 1, ...overrides
+    method: "repo.task.read",
+    repoId: "logged",
+    command: "task-show",
+    connectionId: "connection-1",
+    auth: { transportKind: "unix-socket" },
+    executor: null,
+    ok: true,
+    outcome: "applied",
+    code: null,
+    opId: "op_test",
+    durationMs: 1,
+    ...overrides,
   };
 }

--- a/packages/daemon/test/request-log.test.ts
+++ b/packages/daemon/test/request-log.test.ts
@@ -38,14 +38,14 @@ function openServerWithLog(rootDir: string, host: DaemonHost = stubHost(rootDir)
 test("a repo-scoped read request is recorded in the repository local root", async () => {
   const rootDir = tempRoot(), server = openServerWithLog(rootDir);
   await handshake(server);
-  await server.handle({ jsonrpc: "2.0", id: 2, method: "repo.task.run", params: { repo: { repoId: "logged" }, payload: { action: { kind: "task-show", taskId: "task_01ARZ3NDEKTSV4RRFFQ69G5FAV" } } } });
+  await server.handle({ jsonrpc: "2.0", id: 2, method: "repo.task.read", params: { repo: { repoId: "logged" }, payload: { action: { kind: "task-show", taskId: "task_01ARZ3NDEKTSV4RRFFQ69G5FAV" } } } });
   server.close();
 
   const records = readRecords(rootDir);
   assert.equal(records.length, 1);
   const [record] = records;
   assert.equal(record.schema, "daemon-request-log/v1");
-  assert.equal(record.method, "repo.task.run");
+  assert.equal(record.method, "repo.task.read");
   // The user-facing command, not just the transport method: this is what "which commands did I run" asks for.
   assert.equal(record.command, "task-show");
   assert.equal(record.commandClass, "repo-read");
@@ -54,6 +54,8 @@ test("a repo-scoped read request is recorded in the repository local root", asyn
   assert.equal(record.ownerUid, 501);
   assert.equal(record.opId, "op_test_0001");
   assert.equal(record.outcome, "applied");
+  assert.equal(typeof record.dispatchDelayMs, "number");
+  assert.equal(typeof record.serviceMs, "number");
   assert.equal(typeof record.durationMs, "number");
   assert.ok(Date.parse(record.at) > 0);
   // The log is local-only state, never the authored ledger.
@@ -63,9 +65,9 @@ test("a repo-scoped read request is recorded in the repository local root", asyn
 test("the declared agent executor is recorded so a request can be attributed to the agent that made it", async () => {
   const rootDir = tempRoot(), server = openServerWithLog(rootDir);
   await handshake(server);
-  // The CLI puts the declared executor inside payload.action for repo.task.run; that is the shape
+  // The CLI puts the declared executor inside payload.action for repo.task.read; that is the shape
   // the daemon attributes from, so it is the shape the log has to read.
-  await server.handle({ jsonrpc: "2.0", id: 2, method: "repo.task.run", params: { repo: { repoId: "logged" }, payload: { action: { kind: "task-show", taskId: "task_01ARZ3NDEKTSV4RRFFQ69G5FAV", executor: { kind: "agent", id: "codex-worker" } } } } });
+  await server.handle({ jsonrpc: "2.0", id: 2, method: "repo.task.read", params: { repo: { repoId: "logged" }, payload: { action: { kind: "task-show", taskId: "task_01ARZ3NDEKTSV4RRFFQ69G5FAV", executor: { kind: "agent", id: "codex-worker" } } } } });
   server.close();
 
   assert.deepEqual(readRecords(rootDir)[0].executor, { kind: "agent", id: "codex-worker" });
@@ -75,8 +77,8 @@ test("requests from one connection share a connection id", async () => {
   const rootDir = tempRoot(), server = openServerWithLog(rootDir);
   await handshake(server);
   const payload = { repo: { repoId: "logged" }, payload: { action: { kind: "task-show", taskId: "task_01ARZ3NDEKTSV4RRFFQ69G5FAV" } } };
-  await server.handle({ jsonrpc: "2.0", id: 2, method: "repo.task.run", params: payload });
-  await server.handle({ jsonrpc: "2.0", id: 3, method: "repo.task.run", params: payload });
+  await server.handle({ jsonrpc: "2.0", id: 2, method: "repo.task.read", params: payload });
+  await server.handle({ jsonrpc: "2.0", id: 3, method: "repo.task.read", params: payload });
   server.close();
 
   const records = readRecords(rootDir);
@@ -90,7 +92,7 @@ test("a rejected request is recorded with its error code", async () => {
   const rejecting = { ...host, run: async () => ({ outcome: "op_rejected" as const, opId: "rejected:task-show", code: "repo_unavailable", nextAction: "Attach the repository." }) } as unknown as DaemonHost;
   const server = openServerWithLog(rootDir, rejecting);
   await handshake(server);
-  await server.handle({ jsonrpc: "2.0", id: 2, method: "repo.task.run", params: { repo: { repoId: "logged" }, payload: { action: { kind: "task-show", taskId: "task_01ARZ3NDEKTSV4RRFFQ69G5FAV" } } } });
+  await server.handle({ jsonrpc: "2.0", id: 2, method: "repo.task.read", params: { repo: { repoId: "logged" }, payload: { action: { kind: "task-show", taskId: "task_01ARZ3NDEKTSV4RRFFQ69G5FAV" } } } });
   server.close();
 
   const records = readRecords(rootDir);

--- a/packages/daemon/test/request-log.test.ts
+++ b/packages/daemon/test/request-log.test.ts
@@ -8,12 +8,7 @@ import type { DaemonHost } from "../src/daemon-host.ts";
 import { daemonLifecycleLogPath, openDaemonLifecycleLog, readDaemonLifecycleRecords } from "../src/lifecycle-log.ts";
 import { createJsonRpcProtocolServer } from "../src/protocol/json-rpc-server.ts";
 import { currentDaemonProtocolVersion } from "../src/protocol/version.ts";
-import {
-  daemonRequestLogPath,
-  openDaemonRequestLog,
-  type DaemonRequestLogEntry,
-  type DaemonRequestLogRecord,
-} from "../src/request-log.ts";
+import { daemonRequestLogPath, openDaemonRequestLog, type DaemonRequestLogEntry, type DaemonRequestLogRecord } from "../src/request-log.ts";
 
 function tempRoot(): string {
   return mkdtempSync(path.join(os.tmpdir(), "harness-request-log-"));
@@ -22,69 +17,28 @@ function tempRoot(): string {
 function stubHost(rootDir: string): DaemonHost {
   return {
     run: async () => ({ outcome: "applied" as const, opId: "op_test_0001", revision: 7 }),
-    status: () => ({
-      daemonId: "test-daemon",
-      pid: 1,
-      repos: [
-        {
-          repoId: "logged",
-          rootDir,
-          state: "attached" as const,
-          generation: 1,
-          queueDepth: 0,
-          lastError: null,
-          recoveryMs: 0,
-        },
-      ],
-    }),
+    status: () => ({ daemonId: "test-daemon", pid: 1, repos: [{ repoId: "logged", rootDir, state: "attached" as const, generation: 1, queueDepth: 0, lastError: null, recoveryMs: 0 }] })
   } as unknown as DaemonHost;
 }
 
 async function handshake(server: ReturnType<typeof createJsonRpcProtocolServer>): Promise<void> {
-  await server.handle({
-    jsonrpc: "2.0",
-    id: 1,
-    method: "protocol.hello",
-    params: { protocolVersion: currentDaemonProtocolVersion },
-  });
+  await server.handle({ jsonrpc: "2.0", id: 1, method: "protocol.hello", params: { protocolVersion: currentDaemonProtocolVersion } });
 }
 
 function readRecords(rootDir: string): readonly DaemonRequestLogRecord[] {
-  return readFileSync(daemonRequestLogPath(rootDir), "utf8")
-    .split("\n")
-    .filter((line) => line.length > 0)
+  return readFileSync(daemonRequestLogPath(rootDir), "utf8").split("\n").filter((line) => line.length > 0)
     .map((line) => JSON.parse(line) as DaemonRequestLogRecord);
 }
 
 function openServerWithLog(rootDir: string, host: DaemonHost = stubHost(rootDir)) {
-  const log = openDaemonRequestLog({
-    resolveRootDir: (repoId) => host.status().repos.find((repo) => repo.repoId === repoId)?.rootDir,
-  });
-  return createJsonRpcProtocolServer({
-    host,
-    build: { commit: null },
-    authContext: {
-      transportKind: "unix-socket",
-      unixSocketOwnerBoundary: { ownerUid: 501, source: "unix-socket-filesystem-owner-boundary" },
-    },
-    emit: async () => undefined,
-    recordRequest: log.record,
-  });
+  const log = openDaemonRequestLog({ resolveRootDir: (repoId) => host.status().repos.find((repo) => repo.repoId === repoId)?.rootDir });
+  return createJsonRpcProtocolServer({ host, build: { commit: null }, authContext: { transportKind: "unix-socket", unixSocketOwnerBoundary: { ownerUid: 501, source: "unix-socket-filesystem-owner-boundary" } }, emit: async () => undefined, recordRequest: log.record });
 }
 
 test("a repo-scoped read request is recorded in the repository local root", async () => {
-  const rootDir = tempRoot(),
-    server = openServerWithLog(rootDir);
+  const rootDir = tempRoot(), server = openServerWithLog(rootDir);
   await handshake(server);
-  await server.handle({
-    jsonrpc: "2.0",
-    id: 2,
-    method: "repo.task.read",
-    params: {
-      repo: { repoId: "logged" },
-      payload: { action: { kind: "task-show", taskId: "task_01ARZ3NDEKTSV4RRFFQ69G5FAV" } },
-    },
-  });
+  await server.handle({ jsonrpc: "2.0", id: 2, method: "repo.task.read", params: { repo: { repoId: "logged" }, payload: { action: { kind: "task-show", taskId: "task_01ARZ3NDEKTSV4RRFFQ69G5FAV" } } } });
   server.close();
 
   const records = readRecords(rootDir);
@@ -109,39 +63,20 @@ test("a repo-scoped read request is recorded in the repository local root", asyn
 });
 
 test("the declared agent executor is recorded so a request can be attributed to the agent that made it", async () => {
-  const rootDir = tempRoot(),
-    server = openServerWithLog(rootDir);
+  const rootDir = tempRoot(), server = openServerWithLog(rootDir);
   await handshake(server);
   // The CLI puts the declared executor inside payload.action for repo.task.read; that is the shape
   // the daemon attributes from, so it is the shape the log has to read.
-  await server.handle({
-    jsonrpc: "2.0",
-    id: 2,
-    method: "repo.task.read",
-    params: {
-      repo: { repoId: "logged" },
-      payload: {
-        action: {
-          kind: "task-show",
-          taskId: "task_01ARZ3NDEKTSV4RRFFQ69G5FAV",
-          executor: { kind: "agent", id: "codex-worker" },
-        },
-      },
-    },
-  });
+  await server.handle({ jsonrpc: "2.0", id: 2, method: "repo.task.read", params: { repo: { repoId: "logged" }, payload: { action: { kind: "task-show", taskId: "task_01ARZ3NDEKTSV4RRFFQ69G5FAV", executor: { kind: "agent", id: "codex-worker" } } } } });
   server.close();
 
   assert.deepEqual(readRecords(rootDir)[0].executor, { kind: "agent", id: "codex-worker" });
 });
 
 test("requests from one connection share a connection id", async () => {
-  const rootDir = tempRoot(),
-    server = openServerWithLog(rootDir);
+  const rootDir = tempRoot(), server = openServerWithLog(rootDir);
   await handshake(server);
-  const payload = {
-    repo: { repoId: "logged" },
-    payload: { action: { kind: "task-show", taskId: "task_01ARZ3NDEKTSV4RRFFQ69G5FAV" } },
-  };
+  const payload = { repo: { repoId: "logged" }, payload: { action: { kind: "task-show", taskId: "task_01ARZ3NDEKTSV4RRFFQ69G5FAV" } } };
   await server.handle({ jsonrpc: "2.0", id: 2, method: "repo.task.read", params: payload });
   await server.handle({ jsonrpc: "2.0", id: 3, method: "repo.task.read", params: payload });
   server.close();
@@ -153,28 +88,11 @@ test("requests from one connection share a connection id", async () => {
 });
 
 test("a rejected request is recorded with its error code", async () => {
-  const rootDir = tempRoot(),
-    host = stubHost(rootDir);
-  const rejecting = {
-    ...host,
-    run: async () => ({
-      outcome: "op_rejected" as const,
-      opId: "rejected:task-show",
-      code: "repo_unavailable",
-      nextAction: "Attach the repository.",
-    }),
-  } as unknown as DaemonHost;
+  const rootDir = tempRoot(), host = stubHost(rootDir);
+  const rejecting = { ...host, run: async () => ({ outcome: "op_rejected" as const, opId: "rejected:task-show", code: "repo_unavailable", nextAction: "Attach the repository." }) } as unknown as DaemonHost;
   const server = openServerWithLog(rootDir, rejecting);
   await handshake(server);
-  await server.handle({
-    jsonrpc: "2.0",
-    id: 2,
-    method: "repo.task.read",
-    params: {
-      repo: { repoId: "logged" },
-      payload: { action: { kind: "task-show", taskId: "task_01ARZ3NDEKTSV4RRFFQ69G5FAV" } },
-    },
-  });
+  await server.handle({ jsonrpc: "2.0", id: 2, method: "repo.task.read", params: { repo: { repoId: "logged" }, payload: { action: { kind: "task-show", taskId: "task_01ARZ3NDEKTSV4RRFFQ69G5FAV" } } } });
   server.close();
 
   const records = readRecords(rootDir);
@@ -185,8 +103,7 @@ test("a rejected request is recorded with its error code", async () => {
 });
 
 test("a request that binds no repository is not recorded", async () => {
-  const rootDir = tempRoot(),
-    server = openServerWithLog(rootDir);
+  const rootDir = tempRoot(), server = openServerWithLog(rootDir);
   await handshake(server);
   await server.handle({ jsonrpc: "2.0", id: 2, method: "daemon.status", params: {} });
   server.close();
@@ -200,8 +117,7 @@ test("rotation holds the log to a bounded number of files", () => {
   const log = openDaemonRequestLog({ resolveRootDir: () => rootDir, maxBytes: 512, keptFiles: 2 });
   for (let index = 0; index < 400; index += 1) log.record(entry({ opId: `op_${index}` }));
 
-  const logDir = path.dirname(daemonRequestLogPath(rootDir)),
-    files = readdirSync(logDir).sort();
+  const logDir = path.dirname(daemonRequestLogPath(rootDir)), files = readdirSync(logDir).sort();
   assert.deepEqual(files, ["requests.jsonl", "requests.jsonl.1", "requests.jsonl.2"]);
   // The ceiling is the point: without it an always-on request log is an unbounded disk write.
   for (const file of files) assert.ok(readFileSync(path.join(logDir, file), "utf8").length < 512 + 1024);
@@ -218,63 +134,25 @@ test("a sink that cannot write neither throws nor keeps reporting", () => {
   const failures: unknown[] = [];
   const log = openDaemonRequestLog({ resolveRootDir: () => rootDir, onFailure: (error) => failures.push(error) });
 
-  assert.doesNotThrow(() => {
-    log.record(entry({}));
-    log.record(entry({}));
-    log.record(entry({}));
-  });
+  assert.doesNotThrow(() => { log.record(entry({})); log.record(entry({})); log.record(entry({})); });
   // Reported once, then silent: an observability sink must not become a log spammer either.
   assert.equal(failures.length, 1);
 });
 
 test("daemon lifecycle records are structured and roll before an unbounded next generation", () => {
-  const userRoot = tempRoot(),
-    logPath = daemonLifecycleLogPath(userRoot, "availability");
-  mkdirSync(path.dirname(logPath), { recursive: true });
-  for (let generation = 0; generation < 3; generation += 1) {
-    writeFileSync(logPath, `${"x".repeat(600)}\n`, "utf8");
-    openDaemonLifecycleLog({
-      userRoot,
-      daemonId: "availability",
-      maxBytes: 512,
-      keptFiles: 2,
-      now: () => new Date("2026-08-19T00:00:00.000Z"),
-    }).record({
-      event: "repo_attach_completed",
-      repoId: `repo-${generation}`,
-      durationMs: generation,
-      attachIndex: generation + 1,
-      attachTotal: 3,
-    });
-  }
-  const records = readDaemonLifecycleRecords(userRoot, "availability"),
-    latest = records.at(-1)!;
-  assert.equal(latest.schema, "daemon-lifecycle/v1");
-  assert.equal(latest.daemonId, "availability");
-  assert.equal(latest.event, "repo_attach_completed");
-  assert.equal(latest.repoId, "repo-2");
-  assert.equal(latest.durationMs, 2);
-  assert.equal(latest.at, "2026-08-19T00:00:00.000Z");
-  assert.deepEqual(readdirSync(path.dirname(daemonLifecycleLogPath(userRoot, "availability"))).sort(), [
-    "daemon-availability.log",
-    "daemon-availability.log.1",
-    "daemon-availability.log.2",
-  ]);
+  const userRoot = tempRoot(), logPath = daemonLifecycleLogPath(userRoot, "availability"); mkdirSync(path.dirname(logPath), { recursive: true });
+  for (let generation = 0; generation < 3; generation += 1) { writeFileSync(logPath, `${"x".repeat(600)}\n`, "utf8"); openDaemonLifecycleLog({ userRoot, daemonId: "availability", maxBytes: 512, keptFiles: 2,
+    now: () => new Date("2026-08-19T00:00:00.000Z") }).record({ event: "repo_attach_completed", repoId: `repo-${generation}`, durationMs: generation, attachIndex: generation + 1, attachTotal: 3 }); }
+  const records = readDaemonLifecycleRecords(userRoot, "availability"), latest = records.at(-1)!;
+  assert.equal(latest.schema, "daemon-lifecycle/v1"); assert.equal(latest.daemonId, "availability"); assert.equal(latest.event, "repo_attach_completed");
+  assert.equal(latest.repoId, "repo-2"); assert.equal(latest.durationMs, 2); assert.equal(latest.at, "2026-08-19T00:00:00.000Z");
+  assert.deepEqual(readdirSync(path.dirname(daemonLifecycleLogPath(userRoot, "availability"))).sort(), ["daemon-availability.log", "daemon-availability.log.1", "daemon-availability.log.2"]);
 });
 
 function entry(overrides: Partial<DaemonRequestLogEntry>): DaemonRequestLogEntry {
   return {
-    method: "repo.task.read",
-    repoId: "logged",
-    command: "task-show",
-    connectionId: "connection-1",
-    auth: { transportKind: "unix-socket" },
-    executor: null,
-    ok: true,
-    outcome: "applied",
-    code: null,
-    opId: "op_test",
-    durationMs: 1,
-    ...overrides,
+    method: "repo.task.read", repoId: "logged", command: "task-show",
+    connectionId: "connection-1", auth: { transportKind: "unix-socket" }, executor: null,
+    ok: true, outcome: "applied", code: null, opId: "op_test", durationMs: 1, ...overrides
   };
 }

--- a/packages/daemon/test/runtime-spawn-lifecycle.integration.test.ts
+++ b/packages/daemon/test/runtime-spawn-lifecycle.integration.test.ts
@@ -616,7 +616,7 @@ test("attached task runtime settlement releases its execution lease before publi
           projectionPath: path.join(root, ".harness/cache/runtime-attached-tail-observer.sqlite"),
           eventStore: makeTaskEventStore({ repoId: "runtime-attached-tail", rootDir: root }),
         });
-      projection.list();
+      projection.catchUp();
       const settled = projection.readRuntimeSession(String(receipt.runtimeSessionId))!,
         taskSnapshot = projection.read(taskId).snapshot;
       projection.close();
@@ -1026,7 +1026,7 @@ test("repo-cell restart re-adopts a live native runtime and settles an exit reco
       projectionPath: path.join(parent, "runtime-re-adopt-live-before-exit.sqlite"),
       eventStore: makeTaskEventStore({ repoId, rootDir: root }),
     });
-    liveProjection.list();
+    liveProjection.catchUp();
     const adopted = liveProjection.readRuntimeSession(String(receipt.runtimeSessionId))!;
     liveProjection.close();
     assert.deepEqual({ liveness: adopted.liveness, outcome: adopted.outcome }, { liveness: "live", outcome: null });
@@ -1046,7 +1046,7 @@ test("repo-cell restart re-adopts a live native runtime and settles an exit reco
       projectionPath: path.join(parent, "runtime-re-adopt-live-observer.sqlite"),
       eventStore: makeTaskEventStore({ repoId, rootDir: root }),
     });
-    projection.list();
+    projection.catchUp();
     const settled = projection.readRuntimeSession(String(receipt.runtimeSessionId))!;
     projection.close();
     assert.deepEqual(
@@ -1121,7 +1121,7 @@ test("repo-cell restart re-adopts a live native runtime and settles an exit reco
       projectionPath: path.join(parent, "runtime-re-adopt-dead-observer.sqlite"),
       eventStore: makeTaskEventStore({ repoId, rootDir: root }),
     });
-    reopenedProjection.list();
+    reopenedProjection.catchUp();
     const daemonlessSettlement = reopenedProjection.readRuntimeSession(String(absentReceipt.runtimeSessionId))!;
     reopenedProjection.close();
     assert.deepEqual(
@@ -1211,8 +1211,9 @@ test("repo-cell restart re-adopts a live native runtime and settles an exit reco
       lostProjection = makeTaskProjection({
         rootDir: root,
         eventStore: makeTaskEventStore({ repoId, rootDir: root }),
-      }),
-      lostSession = lostProjection.readRuntimeSession(String(lostReceipt.runtimeSessionId))!;
+      });
+    lostProjection.catchUp();
+    const lostSession = lostProjection.readRuntimeSession(String(lostReceipt.runtimeSessionId))!;
     lostProjection.close();
     assert.ok(lostRow, "lost dispatch row missing after daemon restart");
     assert.equal(

--- a/packages/daemon/test/task-query-read.test.ts
+++ b/packages/daemon/test/task-query-read.test.ts
@@ -116,6 +116,31 @@ test("task control, review queue, and decision detail expose one real cut", () =
   assert.deepEqual(projectionCut(detail), readyCut);
 });
 
+test("task control narrows graph, status, and decision reads to the selected lifecycle page", () => {
+  const dependencyCalls: string[][] = [],
+    targetCalls: { targetRefs: readonly string[]; relationType: string }[] = [],
+    statusCalls: string[][] = [],
+    decisionCalls: string[][] = [],
+    dependency = { ...secondEventEdge, sourceRef: "task/task_event", targetRef: "task/task_blocker" },
+    derives = { ...eventEdge, sourceRef: "decision/dec_event", targetRef: "task/task_event" },
+    projection = projectionStub({
+      taskRows: [activeTaskRow("task_event")],
+      edges: [dependency, derives],
+      dependencyCalls,
+      targetCalls,
+      statusCalls,
+      decisionCalls,
+    });
+
+  const result = queryRead(process.cwd(), projection).guiTasks({ limit: 1 });
+
+  assert.equal(result.rows.length, 1);
+  assert.deepEqual(dependencyCalls, [["task/task_event"]]);
+  assert.deepEqual(targetCalls, [{ targetRefs: ["task/task_event"], relationType: "derives" }]);
+  assert.deepEqual(statusCalls, [["task_event", "task_blocker"]]);
+  assert.deepEqual(decisionCalls, [["dec_event"]]);
+});
+
 test("a surface fails closed instead of stitching mismatched projection cuts", () => {
   const projection = projectionStub({ decisionCut: { ...readyCut, watermark: 8, sourceRevision: 8 } }),
     read = queryRead(process.cwd(), projection);
@@ -186,6 +211,10 @@ function projectionStub(
     readonly edges?: TaskRelationProjectionRead["rows"];
     readonly calls?: TaskRelationQuery[];
     readonly taskRows?: readonly unknown[];
+    readonly dependencyCalls?: string[][];
+    readonly targetCalls?: { targetRefs: readonly string[]; relationType: string }[];
+    readonly statusCalls?: string[][];
+    readonly decisionCalls?: string[][];
   } = {},
 ): TaskProjection {
   const cut = options.cut ?? readyCut,
@@ -202,6 +231,20 @@ function projectionStub(
         : { page: { limit: query.limit, cursor: query.cursor ?? null, nextCursor: null } }),
     }),
     readTaskRelations: () => ({ ...cut, rows: edges }),
+    readTaskDependencyClosure: (sourceRefs: readonly string[]) => {
+      options.dependencyCalls?.push([...sourceRefs]);
+      return {
+        ...cut,
+        rows: edges.filter((edge) => edge.relationType === "depends-on" && sourceRefs.includes(edge.sourceRef)),
+      };
+    },
+    readTaskRelationsByTargets: (targetRefs: readonly string[], relationType: string) => {
+      options.targetCalls?.push({ targetRefs: [...targetRefs], relationType });
+      return {
+        ...cut,
+        rows: edges.filter((edge) => edge.relationType === relationType && targetRefs.includes(edge.targetRef)),
+      };
+    },
     readRelationQuery: (query: TaskRelationQuery = {}) => {
       options.calls?.push(query);
       let rows = edges.filter(
@@ -229,7 +272,19 @@ function projectionStub(
     readFactGraph: () => ({ ...cut, facts: [], edges: [], factAnchors: [] }),
     searchFacts: () => ({ ...cut, facts: [] }),
     readFactAnchors: () => ({ ...cut, rows: [] }),
-    readTaskStatuses: () => ({ ...cut, rows: [] }),
+    readTaskStatuses: (taskIds: readonly string[]) => {
+      options.statusCalls?.push([...taskIds]);
+      return { ...cut, rows: [] };
+    },
+    readDecisions: (decisionIds: readonly string[]) => {
+      options.decisionCalls?.push([...decisionIds]);
+      return {
+        ...decisionCut,
+        decisions: decisionIds.includes("dec_event")
+          ? [{ decisionId: "dec_event", appliesTo: { modules: [], productLines: [] } }]
+          : [],
+      };
+    },
     listDecisions: () => ({ ...decisionCut, decisions: [] }),
     listDecisionAgendaPage: (query) => ({
       ...decisionCut,
@@ -237,6 +292,26 @@ function projectionStub(
       page: { limit: query.limit, cursor: query.cursor ?? null, nextCursor: null },
     }),
   } as unknown as TaskProjection;
+}
+
+function activeTaskRow(taskId: string) {
+  return {
+    taskId,
+    packagePath: null,
+    generation: "v1",
+    workspaceRevision: 7,
+    createdAt: null,
+    updatedAt: "2026-08-30T00:00:00.000Z",
+    snapshot: {
+      revision: 7,
+      task: { taskId, status: "planned", packageDisposition: "active", metadata: {} },
+      executions: [],
+      reviews: [],
+      edgesTaken: [],
+      lease: null,
+      decisionRelations: [],
+    },
+  };
 }
 
 function taskRowWithoutDisposition() {

--- a/packages/gui/e2e/electron-smoke.e2e.mjs
+++ b/packages/gui/e2e/electron-smoke.e2e.mjs
@@ -206,7 +206,7 @@ test(
         rmSync(fakeProviderRoot, { recursive: true, force: true });
       }
     });
-    const codexInstallation = discoverRuntimeInstallations().find(
+    const codexInstallation = (await discoverRuntimeInstallations()).find(
       (installation) =>
         installation.kindId === "codex" && installation.executablePath === realpathSync.native(fakeProviderPath),
     );

--- a/packages/gui/src/main/local-composition-root.ts
+++ b/packages/gui/src/main/local-composition-root.ts
@@ -36,6 +36,7 @@ interface DaemonClient {
     method: string,
     params: JsonObject,
     timeoutMs?: number,
+    responseTimeoutMs?: number,
   ) => Promise<JsonObject>;
 }
 let client: Promise<DaemonClient> | undefined;
@@ -141,6 +142,7 @@ async function request(
         target,
         route.rpcMethod,
         params,
+        undefined,
         requestTimeoutMs(route, daemonPayload),
       );
     try {

--- a/packages/gui/test/service-bridge.test.ts
+++ b/packages/gui/test/service-bridge.test.ts
@@ -74,7 +74,7 @@ test("GUI client reaches every shipped read through a real resident daemon", asy
     writeFileSync(authored, documentBody);
     const status = await requestDaemonJsonRpcAt(
       fixture.endpoint,
-      "repo.task.run",
+      "repo.task.read",
       {
         repo: { repoId: fixture.repoId },
         payload: { action: { kind: "doc-status", paths: [documentPath] } },

--- a/packages/kernel/src/projection/rebuildable-task-projection-catch-up.ts
+++ b/packages/kernel/src/projection/rebuildable-task-projection-catch-up.ts
@@ -29,7 +29,7 @@ export function reduceBatch(
   events: readonly CanonicalEventV1[],
   limit: number,
   readBlob: EventStreamPort["readContentBlob"],
-  _sourceRevision: number,
+  sourceRevision: number,
 ): ProjectionApplyReceipt {
   return transaction(db, () => {
     for (const event of events) stageEvent(db, event);
@@ -55,6 +55,9 @@ export function reduceBatch(
       );
     }
     runSql(db, "UPDATE projection_meta SET state_digest = NULL WHERE singleton = 1");
+    // A successful writer apply owns this complete cut. Persist its digest in the same SQLite
+    // transaction so a subsequent serving read never has to perform a catch-up write.
+    if (isAtSourceCut(db, sourceRevision)) refreshStateDigestAtSourceCut(db, sourceRevision);
     return { metrics: { sqliteTransactions: 1, reducedItems } };
   });
 }

--- a/packages/kernel/src/projection/rebuildable-task-projection-entity-api.ts
+++ b/packages/kernel/src/projection/rebuildable-task-projection-entity-api.ts
@@ -1,26 +1,23 @@
 // @write-boundary-exemption rebuildable-projection
 import type { TaskProjection } from "./task-projection-port.ts";
 import type { ProjectionContext } from "./rebuildable-task-projection-types.ts";
-import { catchUpRound } from "./rebuildable-task-projection-catch-up.ts";
 import { withDatabase } from "./rebuildable-task-projection-database.ts";
 import { getEntityProjectionRow, listEntityProjectionRows } from "./rebuildable-task-projection-entities.ts";
-import { watermark } from "./rebuildable-task-projection-sql.ts";
+import { readProjectionCut } from "./rebuildable-task-projection-sql.ts";
 
 export function entityQueryApi(context: ProjectionContext): Pick<TaskProjection, "listEntities" | "getEntity"> {
-  const { eventStore, limit, projectionPath, readHead } = context;
+  const { projectionPath, readHead } = context;
   return {
     listEntities: (entityKind) =>
       withDatabase(projectionPath, readHead, (db) => {
-        const round = catchUpRound(db, eventStore, limit),
-          current = watermark(db);
-        requireReadyEntityCut(current, round.sourceRevision);
+        const cut = readProjectionCut(db, readHead);
+        requireReadyEntityCut(cut.watermark, cut.sourceRevision);
         return listEntityProjectionRows(db, entityKind);
       }),
     getEntity: (entityKind, entityId) =>
       withDatabase(projectionPath, readHead, (db) => {
-        const round = catchUpRound(db, eventStore, limit),
-          current = watermark(db);
-        requireReadyEntityCut(current, round.sourceRevision);
+        const cut = readProjectionCut(db, readHead);
+        requireReadyEntityCut(cut.watermark, cut.sourceRevision);
         return getEntityProjectionRow(db, entityKind, entityId);
       }),
   };

--- a/packages/kernel/src/projection/rebuildable-task-projection-factory.ts
+++ b/packages/kernel/src/projection/rebuildable-task-projection-factory.ts
@@ -48,6 +48,7 @@ import { taskQueryApi } from "./rebuildable-task-projection-task-queries.ts";
 import { markRuntimeSessionsUnknown } from "./rebuildable-task-projection-runtime.ts";
 import {
   readStateDigest,
+  readProjectionCut,
   refreshStateDigestAtSourceCut,
   transaction,
   watermark,
@@ -171,6 +172,7 @@ export function makeTaskProjection(options: {
       }
     },
     readStateDigest: () => withDatabase(projectionPath, readHead, readStateDigest),
+    readCut: () => withDatabase(projectionPath, readHead, (db) => readProjectionCut(db, readHead)),
     read: (taskId) => readProjection(projectionPath, readHead, options.eventStore, taskId, limit, now),
     list: (query) => listProjection(projectionPath, readHead, options.eventStore, limit, now, query),
     ...entityQueryApi(context),

--- a/packages/kernel/src/projection/rebuildable-task-projection-knowledge-queries.ts
+++ b/packages/kernel/src/projection/rebuildable-task-projection-knowledge-queries.ts
@@ -79,13 +79,12 @@ export function knowledgeQueryApi(
       }),
     listFactDomainTypes: () =>
       withDatabase(projectionPath, readHead, (db) => {
-        const round = catchUpRound(db, eventStore, limit),
-          current = watermark(db);
+        const cut = readProjectionCut(db, readHead);
         return {
-          status: current === round.sourceRevision ? "ready" : "pending",
+          status: cut.status,
           domainTypes: listFactDomainTypeRows(db),
-          watermark: current,
-          sourceRevision: round.sourceRevision,
+          watermark: cut.watermark,
+          sourceRevision: cut.sourceRevision,
         };
       }),
     readFactAnchors: (refs) =>

--- a/packages/kernel/src/projection/rebuildable-task-projection-knowledge-queries.ts
+++ b/packages/kernel/src/projection/rebuildable-task-projection-knowledge-queries.ts
@@ -20,7 +20,7 @@ import type { TaskProjection } from "./task-projection-port.ts";
 import type { ProjectionContext } from "./rebuildable-task-projection-types.ts";
 import { withDatabase } from "./rebuildable-task-projection-database.ts";
 import { catchUpRound } from "./rebuildable-task-projection-catch-up.ts";
-import { watermark } from "./rebuildable-task-projection-sql.ts";
+import { readProjectionCut } from "./rebuildable-task-projection-sql.ts";
 export type { ProjectionPage, TaskProjectionListQuery, TaskRelationQuery } from "./task-query-projection.ts";
 export type { TaskProjection } from "./task-projection-port.ts";
 
@@ -57,25 +57,23 @@ export function knowledgeQueryApi(
       }),
     readFact: (factId) =>
       withDatabase(projectionPath, readHead, (db) => {
-        const round = catchUpRound(db, eventStore, limit),
-          current = watermark(db);
+        const cut = readProjectionCut(db, readHead);
         return {
-          status: current === round.sourceRevision ? "ready" : "pending",
+          status: cut.status,
           fact: readFactRow(db, factId),
-          watermark: current,
-          sourceRevision: round.sourceRevision,
+          watermark: cut.watermark,
+          sourceRevision: cut.sourceRevision,
         };
       }),
     searchFacts: (filters) =>
       withDatabase(projectionPath, readHead, (db) => {
-        const round = catchUpRound(db, eventStore, limit),
-          current = watermark(db),
+        const cut = readProjectionCut(db, readHead),
           page = searchFactRowsPage(db, filters);
         return {
-          status: current === round.sourceRevision ? "ready" : "pending",
+          status: cut.status,
           facts: page.rows,
-          watermark: current,
-          sourceRevision: round.sourceRevision,
+          watermark: cut.watermark,
+          sourceRevision: cut.sourceRevision,
           ...(page.page ? { page: page.page } : {}),
         };
       }),
@@ -92,24 +90,22 @@ export function knowledgeQueryApi(
       }),
     readFactAnchors: (refs) =>
       withDatabase(projectionPath, readHead, (db) => {
-        const round = catchUpRound(db, eventStore, limit),
-          current = watermark(db);
+        const cut = readProjectionCut(db, readHead);
         return {
-          status: current === round.sourceRevision ? "ready" : "pending",
+          status: cut.status,
           rows: readFactAnchorRows(db, refs),
-          watermark: current,
-          sourceRevision: round.sourceRevision,
+          watermark: cut.watermark,
+          sourceRevision: cut.sourceRevision,
         };
       }),
     readFactGraph: () =>
       withDatabase(projectionPath, readHead, (db) => {
-        const round = catchUpRound(db, eventStore, limit),
-          current = watermark(db);
+        const cut = readProjectionCut(db, readHead);
         return {
-          status: current === round.sourceRevision ? "ready" : "pending",
+          status: cut.status,
           ...readFactGraphRows(db),
-          watermark: current,
-          sourceRevision: round.sourceRevision,
+          watermark: cut.watermark,
+          sourceRevision: cut.sourceRevision,
         };
       }),
     admitDecision: (event) =>
@@ -125,59 +121,54 @@ export function knowledgeQueryApi(
       }),
     readDecision: (decisionId) =>
       withDatabase(projectionPath, readHead, (db) => {
-        const round = catchUpRound(db, eventStore, limit),
-          current = watermark(db);
+        const cut = readProjectionCut(db, readHead);
         return {
-          status: current === round.sourceRevision ? "ready" : "pending",
+          status: cut.status,
           decision: readDecisionRow(db, decisionId),
-          watermark: current,
-          sourceRevision: round.sourceRevision,
+          watermark: cut.watermark,
+          sourceRevision: cut.sourceRevision,
         };
       }),
     readDecisions: (decisionIds) =>
       withDatabase(projectionPath, readHead, (db) => {
-        const round = catchUpRound(db, eventStore, limit),
-          current = watermark(db);
+        const cut = readProjectionCut(db, readHead);
         return {
-          status: current === round.sourceRevision ? "ready" : "pending",
+          status: cut.status,
           decisions: readDecisionRows(db, decisionIds),
-          watermark: current,
-          sourceRevision: round.sourceRevision,
+          watermark: cut.watermark,
+          sourceRevision: cut.sourceRevision,
         };
       }),
     listDecisions: (filters) =>
       withDatabase(projectionPath, readHead, (db) => {
-        const round = catchUpRound(db, eventStore, limit),
-          current = watermark(db);
+        const cut = readProjectionCut(db, readHead);
         return {
-          status: current === round.sourceRevision ? "ready" : "pending",
+          status: cut.status,
           decisions: listDecisionRows(db, filters),
-          watermark: current,
-          sourceRevision: round.sourceRevision,
+          watermark: cut.watermark,
+          sourceRevision: cut.sourceRevision,
         };
       }),
     listDecisionAgendaPage: (query) =>
       withDatabase(projectionPath, readHead, (db) => {
-        const round = catchUpRound(db, eventStore, limit),
-          current = watermark(db),
+        const cut = readProjectionCut(db, readHead),
           page = listDecisionAgendaRowsPage(db, query);
         return {
-          status: current === round.sourceRevision ? "ready" : "pending",
+          status: cut.status,
           decisions: page.rows,
           page: page.page,
-          watermark: current,
-          sourceRevision: round.sourceRevision,
+          watermark: cut.watermark,
+          sourceRevision: cut.sourceRevision,
         };
       }),
     readDecisionGraph: () =>
       withDatabase(projectionPath, readHead, (db) => {
-        const round = catchUpRound(db, eventStore, limit),
-          current = watermark(db);
+        const cut = readProjectionCut(db, readHead);
         return {
-          status: current === round.sourceRevision ? "ready" : "pending",
+          status: cut.status,
           ...readDecisionGraphRows(db),
-          watermark: current,
-          sourceRevision: round.sourceRevision,
+          watermark: cut.watermark,
+          sourceRevision: cut.sourceRevision,
         };
       }),
   };

--- a/packages/kernel/src/projection/rebuildable-task-projection-reads.ts
+++ b/packages/kernel/src/projection/rebuildable-task-projection-reads.ts
@@ -112,7 +112,7 @@ export function readDocument(
   readHead: EventStreamPort["readHead"],
   eventStore: EventStreamPort,
   documentPath: string,
-  limit: number,
+  _limit: number,
 ): DocumentProjectionRead {
   return withDatabase(projectionPath, readHead, (db) => {
     const cut = readProjectionCut(db, readHead),
@@ -134,7 +134,7 @@ export function readPresetSnapshot(
   readHead: EventStreamPort["readHead"],
   eventStore: EventStreamPort,
   digest: string,
-  limit: number,
+  _limit: number,
 ): PresetSnapshotProjectionRead {
   return withDatabase(projectionPath, readHead, (db) => {
     const cut = readProjectionCut(db, readHead),

--- a/packages/kernel/src/projection/rebuildable-task-projection-reads.ts
+++ b/packages/kernel/src/projection/rebuildable-task-projection-reads.ts
@@ -17,6 +17,7 @@ import { markRuntimeSessionsUnknown, readSnapshot } from "./rebuildable-task-pro
 import {
   parseEventJson,
   queryPreparedRows,
+  readProjectionCut,
   refreshStateDigestAtSourceCut,
   transaction,
   watermark,
@@ -35,8 +36,7 @@ export function listProjection(
 ): TaskProjectionListRead {
   const existed = localRuntimeStateFileSystem.exists(projectionPath);
   return withDatabase(projectionPath, readHead, (db: DatabaseSync) => {
-    const round = catchUpRound(db, eventStore, limit),
-      current = watermark(db),
+    const cut = readProjectionCut(db, readHead),
       at = now();
     // The unparameterized read keeps its original single statement so its result
     // stays byte-identical; only explicit query parameters take the indexed path.
@@ -72,7 +72,7 @@ export function listProjection(
         ),
       );
       return {
-        status: current === round.sourceRevision ? "ready" : "pending",
+        status: cut.status,
         rows: rows.map((row) => ({
           taskId: row.task_id,
           packagePath: row.package_path,
@@ -82,14 +82,14 @@ export function listProjection(
           updatedAt: parseEventJson(row.event_json).occurredAt,
           snapshot: readSnapshot(db, row.task_id, at),
         })),
-        watermark: current,
-        sourceRevision: round.sourceRevision,
-        warnings: !existed && round.sourceRevision > 0 ? ["projection_missing"] : [],
+        watermark: cut.watermark,
+        sourceRevision: cut.sourceRevision,
+        warnings: !existed && cut.sourceRevision > 0 ? ["projection_missing"] : [],
       };
     }
     const page = listTaskRowsNarrow(db, query);
     return {
-      status: current === round.sourceRevision ? "ready" : "pending",
+      status: cut.status,
       rows: page.rows.map((row) => ({
         taskId: row.task_id,
         packagePath: row.package_path,
@@ -99,9 +99,9 @@ export function listProjection(
         updatedAt: row.updated_at,
         snapshot: readSnapshot(db, row.task_id, at),
       })),
-      watermark: current,
-      sourceRevision: round.sourceRevision,
-      warnings: !existed && round.sourceRevision > 0 ? ["projection_missing"] : [],
+      watermark: cut.watermark,
+      sourceRevision: cut.sourceRevision,
+      warnings: !existed && cut.sourceRevision > 0 ? ["projection_missing"] : [],
       ...(page.page ? { page: page.page } : {}),
     };
   });
@@ -115,18 +115,17 @@ export function readDocument(
   limit: number,
 ): DocumentProjectionRead {
   return withDatabase(projectionPath, readHead, (db) => {
-    const round = catchUpRound(db, eventStore, limit),
-      current = watermark(db),
+    const cut = readProjectionCut(db, readHead),
       row =
         /* @gate-identity check-bypass-write-boundary/bypass-write-013 */
         db.prepare("SELECT value_json FROM document WHERE path = ?").get(documentPath) as
           | { readonly value_json: string }
           | undefined;
     return {
-      status: current === round.sourceRevision ? "ready" : "pending",
+      status: cut.status,
       document: row ? (JSON.parse(row.value_json) as DocumentState) : null,
-      watermark: current,
-      sourceRevision: round.sourceRevision,
+      watermark: cut.watermark,
+      sourceRevision: cut.sourceRevision,
     };
   });
 }
@@ -138,18 +137,17 @@ export function readPresetSnapshot(
   limit: number,
 ): PresetSnapshotProjectionRead {
   return withDatabase(projectionPath, readHead, (db) => {
-    const round = catchUpRound(db, eventStore, limit),
-      current = watermark(db),
+    const cut = readProjectionCut(db, readHead),
       row =
         /* @gate-identity check-bypass-write-boundary/bypass-write-014 */
         db.prepare("SELECT value_json FROM preset_snapshot WHERE digest = ?").get(digest) as
           | { readonly value_json: string }
           | undefined;
     return {
-      status: current === round.sourceRevision ? "ready" : "pending",
+      status: cut.status,
       snapshot: row ? JSON.parse(row.value_json) : null,
-      watermark: current,
-      sourceRevision: round.sourceRevision,
+      watermark: cut.watermark,
+      sourceRevision: cut.sourceRevision,
     };
   });
 }
@@ -164,10 +162,9 @@ export function readProjection(
 ): TaskProjectionRead {
   const existed = localRuntimeStateFileSystem.exists(projectionPath);
   return withDatabase(projectionPath, readHead, (db) => {
-    const round = catchUpRound(db, eventStore, limit);
-    const current = watermark(db);
+    const cut = readProjectionCut(db, readHead);
     return {
-      status: current === round.sourceRevision ? "ready" : "pending",
+      status: cut.status,
       snapshot: readSnapshot(db, taskId, now()),
       packagePath:
         /* @gate-identity check-bypass-write-boundary/bypass-write-015 */
@@ -176,13 +173,13 @@ export function readProjection(
             | { readonly package_path: string }
             | undefined
         )?.package_path ?? null,
-      watermark: current,
-      sourceRevision: round.sourceRevision,
-      warnings: !existed && round.sourceRevision > 0 ? ["projection_missing"] : [],
+      watermark: cut.watermark,
+      sourceRevision: cut.sourceRevision,
+      warnings: !existed && cut.sourceRevision > 0 ? ["projection_missing"] : [],
       catchUp: {
         maxItems: limit,
-        reducedItems: round.reducedItems,
-        sqliteTransactions: round.sqliteTransactions,
+        reducedItems: 0,
+        sqliteTransactions: 0,
       },
     };
   });

--- a/packages/kernel/src/projection/rebuildable-task-projection-sql.ts
+++ b/packages/kernel/src/projection/rebuildable-task-projection-sql.ts
@@ -9,6 +9,7 @@ import {
   type CanonicalEventV1,
 } from "../domain/doc-sync.contract.ts";
 import { canonicalizeContractValue } from "../domain/task.ts";
+import type { EventStreamPort } from "./rebuildable-task-projection-types.ts";
 
 // SQL execution, projection watermark, canonical serialization, and state digest primitives.
 const stateDigestTables = [
@@ -44,6 +45,20 @@ export function watermark(db: DatabaseSync): number {
       readonly watermark: number;
     };
   return Number(row.watermark);
+}
+
+export function readProjectionCut(db: DatabaseSync, readHead: EventStreamPort["readHead"]): {
+  readonly status: "ready" | "pending";
+  readonly watermark: number;
+  readonly sourceRevision: number;
+} {
+  const current = watermark(db),
+    sourceRevision = readHead()?.revision ?? 0;
+  return {
+    status: current === sourceRevision ? "ready" : "pending",
+    watermark: current,
+    sourceRevision,
+  };
 }
 
 export function readStateDigest(db: DatabaseSync): `sha256:${string}` | null {

--- a/packages/kernel/src/projection/rebuildable-task-projection-task-queries.ts
+++ b/packages/kernel/src/projection/rebuildable-task-projection-task-queries.ts
@@ -20,7 +20,14 @@ import type { ProjectionContext } from "./rebuildable-task-projection-types.ts";
 import { withDatabase } from "./rebuildable-task-projection-database.ts";
 import { catchUpRound } from "./rebuildable-task-projection-catch-up.ts";
 import { readDocument, readPresetSnapshot } from "./rebuildable-task-projection-reads.ts";
-import { watermark, parseEventJson, queryRow, queryRows, transaction } from "./rebuildable-task-projection-sql.ts";
+import {
+  readProjectionCut,
+  watermark,
+  parseEventJson,
+  queryRow,
+  queryRows,
+  transaction,
+} from "./rebuildable-task-projection-sql.ts";
 import { readWorkspaceSummaryRows } from "./workspace-summary-projection.ts";
 import { readRelationProjectionRows } from "./relation-entity-projection.ts";
 export type { ProjectionPage, TaskProjectionListQuery, TaskRelationQuery } from "./task-query-projection.ts";
@@ -112,95 +119,87 @@ export function taskQueryApi(
     readTaskIndex: () => {
       const existed = localRuntimeStateFileSystem.exists(projectionPath);
       return withDatabase(projectionPath, readHead, (db) => {
-        const round = catchUpRound(db, eventStore, limit),
-          current = watermark(db);
+        const cut = readProjectionCut(db, readHead);
         return {
           schema: "task-index-projection/v1" as const,
-          status: current === round.sourceRevision ? ("ready" as const) : ("pending" as const),
+          status: cut.status,
           rows: readTaskIndexRows(db),
-          watermark: current,
-          sourceRevision: round.sourceRevision,
-          warnings: !existed && round.sourceRevision > 0 ? (["projection_missing"] as const) : [],
+          watermark: cut.watermark,
+          sourceRevision: cut.sourceRevision,
+          warnings: !existed && cut.sourceRevision > 0 ? (["projection_missing"] as const) : [],
         };
       });
     },
     readWorkspaceSummary: () =>
       withDatabase(projectionPath, readHead, (db) => {
-        const round = catchUpRound(db, eventStore, limit),
-          current = watermark(db);
+        const cut = readProjectionCut(db, readHead);
         return {
-          status: current === round.sourceRevision ? "ready" : "pending",
+          status: cut.status,
           summary: readWorkspaceSummaryRows(db),
-          watermark: current,
-          sourceRevision: round.sourceRevision,
+          watermark: cut.watermark,
+          sourceRevision: cut.sourceRevision,
         };
       }),
     readTaskRelations: () =>
       withDatabase(projectionPath, readHead, (db: DatabaseSync) => {
-        const round = catchUpRound(db, eventStore, limit),
-          current = watermark(db);
+        const cut = readProjectionCut(db, readHead);
         return {
-          status: current === round.sourceRevision ? "ready" : "pending",
+          status: cut.status,
           rows: readTaskRelationRows(db),
-          watermark: current,
-          sourceRevision: round.sourceRevision,
+          watermark: cut.watermark,
+          sourceRevision: cut.sourceRevision,
         };
       }),
     readTaskDependencyClosure: (sourceRefs, maxDepth) =>
       withDatabase(projectionPath, readHead, (db) => {
-        const round = catchUpRound(db, eventStore, limit),
-          current = watermark(db);
+        const cut = readProjectionCut(db, readHead);
         return {
-          status: current === round.sourceRevision ? "ready" : "pending",
+          status: cut.status,
           rows: readTaskDependencyClosureRows(db, sourceRefs, maxDepth),
-          watermark: current,
-          sourceRevision: round.sourceRevision,
+          watermark: cut.watermark,
+          sourceRevision: cut.sourceRevision,
         };
       }),
     readTaskRelationsByTargets: (targetRefs, relationType) =>
       withDatabase(projectionPath, readHead, (db) => {
-        const round = catchUpRound(db, eventStore, limit),
-          current = watermark(db);
+        const cut = readProjectionCut(db, readHead);
         return {
-          status: current === round.sourceRevision ? "ready" : "pending",
+          status: cut.status,
           rows: readTaskRelationsByTargets(db, targetRefs, relationType),
-          watermark: current,
-          sourceRevision: round.sourceRevision,
+          watermark: cut.watermark,
+          sourceRevision: cut.sourceRevision,
         };
       }),
     readTaskStatuses: (taskIds) =>
       withDatabase(projectionPath, readHead, (db) => {
-        const round = catchUpRound(db, eventStore, limit),
-          current = watermark(db);
+        const cut = readProjectionCut(db, readHead);
         return {
-          status: current === round.sourceRevision ? "ready" : "pending",
+          status: cut.status,
           rows: readTaskStatusRows(db, taskIds),
-          watermark: current,
-          sourceRevision: round.sourceRevision,
+          watermark: cut.watermark,
+          sourceRevision: cut.sourceRevision,
         };
       }),
     readTaskRuntimeBatch: (query) =>
       withDatabase(projectionPath, readHead, (db) => {
-        const round = catchUpRound(db, eventStore, limit),
-          current = watermark(db),
+        const cut = readProjectionCut(db, readHead),
           page = readTaskRuntimeBatchPage(db, query);
         return {
-          status: current === round.sourceRevision ? "ready" : "pending",
+          status: cut.status,
           ...page,
-          watermark: current,
-          sourceRevision: round.sourceRevision,
+          watermark: cut.watermark,
+          sourceRevision: cut.sourceRevision,
         };
       }),
     readRelationQuery: (query) =>
       withDatabase(projectionPath, readHead, (db) => {
-        const round = catchUpRound(db, eventStore, limit),
-          current = watermark(db),
+        const cut = readProjectionCut(db, readHead),
           page = readTaskRelationPage(db, query ?? {});
         return {
-          status: current === round.sourceRevision ? "ready" : "pending",
+          status: cut.status,
           rows: page.rows,
-          watermark: current,
-          sourceRevision: round.sourceRevision,
+          watermark: cut.watermark,
+          sourceRevision: cut.sourceRevision,
           ...(page.page ? { page: page.page } : {}),
         };
       }),
@@ -241,6 +240,8 @@ export function taskQueryApi(
       }),
     readTaskCompletion: (taskId, executionId) =>
       withDatabase(projectionPath, readHead, (db) => {
+        // Completion lookup is write-recovery admission, not a serving read: it must observe a
+        // published completion before a retry can append a duplicate.
         catchUpRound(db, eventStore, limit);
         const row = queryRows(db, TASK_COMPLETION_SQL, taskId, executionId)[0];
         if (!row) return null;
@@ -281,30 +282,28 @@ export function taskQueryApi(
           pageLimit > 500
         )
           throw new Error("canonical event page requires a non-negative revision and a limit from 1 to 500");
-        const round = catchUpRound(db, eventStore, limit),
-          current = watermark(db);
+        const cut = readProjectionCut(db, readHead);
         return {
-          status: current === round.sourceRevision ? "ready" : "pending",
+          status: cut.status,
           events: queryRows(db, CANONICAL_EVENTS_SQL, afterRevision, pageLimit).map((row) =>
             parseEventJson(String(row.event_json)),
           ),
-          watermark: current,
-          sourceRevision: round.sourceRevision,
+          watermark: cut.watermark,
+          sourceRevision: cut.sourceRevision,
         };
       }),
     readCiRunObservations: (pageLimit) =>
       withDatabase(projectionPath, readHead, (db) => {
         if (!Number.isSafeInteger(pageLimit) || pageLimit < 1 || pageLimit > 2_000)
           throw new Error("ci run observation page requires a limit from 1 to 2000");
-        const round = catchUpRound(db, eventStore, limit),
-          current = watermark(db);
+        const cut = readProjectionCut(db, readHead);
         return {
-          status: current === round.sourceRevision ? "ready" : "pending",
+          status: cut.status,
           events: queryRows(db, CI_RUN_OBSERVATIONS_SQL, pageLimit)
             .map((row) => parseEventJson(String(row.event_json)))
             .filter((event) => event.schema === "ci-run-observation/v1"),
-          watermark: current,
-          sourceRevision: round.sourceRevision,
+          watermark: cut.watermark,
+          sourceRevision: cut.sourceRevision,
         };
       }),
     readDocument: (documentPath) => readDocument(projectionPath, readHead, eventStore, documentPath, limit),
@@ -351,18 +350,17 @@ export function taskQueryApi(
     readPresetSnapshot: (digest) => readPresetSnapshot(projectionPath, readHead, eventStore, digest, limit),
     readProgress: (taskId) =>
       withDatabase(projectionPath, readHead, (db) => {
-        const round = catchUpRound(db, eventStore, limit),
-          current = watermark(db),
+        const cut = readProjectionCut(db, readHead),
           rows = queryRows(
             db,
             "SELECT event_json FROM task_progress WHERE task_id = ? ORDER BY workspace_revision",
             taskId,
           );
         return {
-          status: current === round.sourceRevision ? "ready" : "pending",
+          status: cut.status,
           rows: rows.map((row) => parseEventJson(String(row.event_json)) as TaskProgressEventV1),
-          watermark: current,
-          sourceRevision: round.sourceRevision,
+          watermark: cut.watermark,
+          sourceRevision: cut.sourceRevision,
         };
       }),
   };

--- a/packages/kernel/src/projection/task-projection-port.ts
+++ b/packages/kernel/src/projection/task-projection-port.ts
@@ -65,6 +65,11 @@ export interface TaskProjection {
   readonly rebuild: () => ProjectionRebuildReceipt;
   readonly catchUp?: () => ProjectionRebuildReceipt;
   readonly readStateDigest: () => `sha256:${string}` | null;
+  readonly readCut: () => {
+    readonly status: "ready" | "pending";
+    readonly watermark: number;
+    readonly sourceRevision: number;
+  };
   readonly listEntities: (entityKind: string) => readonly EntityProjectionRow[];
   readonly getEntity: (entityKind: string, entityId: string) => EntityProjectionRow | null;
   readonly read: (taskId: string) => TaskProjectionRead;

--- a/packages/kernel/test/store/projection-ddl-rebuild.test.ts
+++ b/packages/kernel/test/store/projection-ddl-rebuild.test.ts
@@ -19,6 +19,7 @@ test("a projection schema bump discards pre-first-class Fact DDL before replay",
     writeLegacyFactProjection(projectionPath, previousProjectionSchemaVersion);
 
     const projection = makeTaskProjection({ rootDir, eventStore });
+    projection.catchUp();
     assert.equal(projection.searchFacts({ query: "standalone" }).facts[0]?.factId, "F-ABE050B5");
     projection.close();
     assertCurrentFactSchema(projectionPath);

--- a/packages/kernel/test/store/projection-identity-binding.test.ts
+++ b/packages/kernel/test/store/projection-identity-binding.test.ts
@@ -24,6 +24,9 @@ test("projection cache identity mismatch is explicit and rebuild remains availab
       const storeA = seedLedger(rootA, "ledger-a", bodyA),
         storeB = seedLedger(rootB, "ledger-b", bodyB);
       const projectionA = makeTaskProjection({ rootDir: rootA, eventStore: storeA });
+      // Serving reads answer at the persisted cut and never write; the owner warms explicitly
+      // (production does this at repo-cell open) before the first read is expected ready.
+      projectionA.rebuild();
       const warmed = projectionA.readDocument("context/notes.md");
       assert.equal(warmed.status, "ready");
       assert.equal(warmed.document?.body, bodyA);
@@ -72,6 +75,7 @@ test("event relation truth cannot cross a same-revision ledger identity", async 
       const storeA = seedFactLedger(rootA),
         storeB = seedLedger(rootB, "relation-empty", "# Notes\n\nEmpty ledger.\n"),
         projectionA = makeTaskProjection({ rootDir: rootA, eventStore: storeA });
+      projectionA.rebuild();
       projectionA.readFactGraph();
       assert.deepEqual(
         projectionA.readRelationTruth().factAnchors.map(({ factRef }) => factRef),
@@ -97,6 +101,7 @@ test("a cache ahead of a replacement source history is discarded before staged e
       const storeA = seedTaskLedger(rootA, "history-a", 6),
         storeB = seedTaskLedger(rootB, "history-b", 2),
         projectionA = makeTaskProjection({ rootDir: rootA, eventStore: storeA });
+      projectionA.rebuild();
       assert.equal(projectionA.read("task-1").watermark, 6);
 
       const projectionB = makeTaskProjection({ rootDir: rootB, eventStore: storeB, projectionPath: projectionA.path });

--- a/packages/kernel/test/store/task-projection.test.ts
+++ b/packages/kernel/test/store/task-projection.test.ts
@@ -107,6 +107,7 @@ test("task/doc reducers share one SQLite transaction and L2 rebuild restores exa
     assert.equal(projection.readOperation(event.opId)?.event.schema, "doc-event/v1");
     projection.close();
     rmSync(projection.path, { force: true });
+    projection.rebuild();
     const reopened = projection.readDocument("context/notes.md");
     assert.equal(reopened.status, "ready");
     assert.deepEqual(reopened.document, first.document);
@@ -201,7 +202,7 @@ test("headless direct apply is instance-local and never preserves an ahead cache
     const hot = live.read(event.taskId);
     assert.deepEqual(
       { status: hot.status, watermark: hot.watermark, sourceRevision: hot.sourceRevision },
-      { status: "pending", watermark: 1, sourceRevision: 0 },
+      { status: "ready", watermark: 1, sourceRevision: 1 },
     );
     assert.equal(hot.snapshot.task?.taskId, event.taskId);
     assert.equal(live.rebuild().watermark, 0);
@@ -252,8 +253,10 @@ test("cold projection reuses one batch tree scan and its verified blob prefetch"
       projection = makeTaskProjection({ rootDir, eventStore: reader, catchUpLimit: 64 }),
       before = localGitObjectRefStore.processCount();
     let read = projection.readDocument(batchDocumentPath(count));
-    for (let round = 1; read.status === "pending" && round < 4; round += 1)
+    for (let round = 0; read.status === "pending" && round < 4; round += 1) {
+      projection.catchUp?.();
       read = projection.readDocument(batchDocumentPath(count));
+    }
     assert.equal(read.status, "ready");
     assert.equal(read.document?.body, batchDocumentBody(count));
     const processes = localGitObjectRefStore.processCount() - before;
@@ -413,7 +416,7 @@ test("WAL-shadow cold projection preserves Git batch content prefetch", async (t
   });
 });
 
-test("a fresh projection prefetches deferred staged content in one batch before replay", async () => {
+test("a fresh projection stays query-only until explicit catch-up prefetches staged content", async () => {
   await withTempStoreAsync(async (rootDir) => {
     initRepo(rootDir);
     const writer = makeTaskEventStore({ repoId: "deferred-prefetch", rootDir });
@@ -425,26 +428,16 @@ test("a fresh projection prefetches deferred staged content in one batch before 
       eventStore: makeTaskEventStore({ repoId: "deferred-prefetch", rootDir }),
       catchUpLimit: 1,
     });
-    assert.equal(first.readDocument(batchDocumentPath(1)).status, "pending");
-    first.close();
-
-    const second = makeTaskProjection({
-      rootDir,
-      eventStore: makeTaskEventStore({ repoId: "deferred-prefetch", rootDir }),
-      catchUpLimit: 1,
-    });
-    assert.equal(second.readDocument(batchDocumentPath(1)).watermark, 2);
-    second.close();
-
-    const third = makeTaskProjection({
-      rootDir,
-      eventStore: makeTaskEventStore({ repoId: "deferred-prefetch", rootDir }),
-      catchUpLimit: 1,
-    });
-    const resumed = third.readDocument(batchDocumentPath(2));
+    const before = first.readDocument(batchDocumentPath(1));
+    assert.deepEqual(
+      { status: before.status, watermark: before.watermark, sourceRevision: before.sourceRevision },
+      { status: "pending", watermark: 0, sourceRevision: 2 },
+    );
+    first.catchUp?.();
+    const resumed = first.readDocument(batchDocumentPath(2));
     assert.equal(resumed.status, "ready");
     assert.equal(resumed.document?.body, batchDocumentBody(2));
-    third.close();
+    first.close();
   });
 });
 
@@ -555,6 +548,7 @@ test("a migration policy upgrade replays identically in cold rebuild", async () 
       blobs: [{ sha256: legacyHash, size: Buffer.byteLength(legacy), mediaType: "text/markdown", body: legacy }],
     });
     const projection = makeTaskProjection({ rootDir, eventStore });
+    projection.catchUp?.();
     const imported = projection.readDocument(standard);
     assert.equal(imported.status, "ready");
     assert.equal(imported.document?.policyId, MIGRATION_DOCUMENT_POLICY_ID);
@@ -603,6 +597,7 @@ test("a migration policy upgrade replays identically in cold rebuild", async () 
     });
     eventStore.append({ event: decision.event, plan: decision.plan, blobs: decision.blobs });
 
+    projection.catchUp?.();
     const warm = projection.readDocument(standard);
     assert.equal(warm.status, "ready");
     assert.equal(warm.document?.policyId, DOC_POLICY_ID);
@@ -844,6 +839,7 @@ test("historical agent entity envelopes replay into the generic entity projectio
       },
       projection = makeTaskProjection({ rootDir, eventStore });
     try {
+      projection.catchUp?.();
       const read = projection.getEntity("agent", "historical-agent");
       assert.deepEqual(
         read === null
@@ -883,7 +879,9 @@ test("stale persistent event projection schema is discarded and replayed from th
     );
     stale.close();
 
-    const read = makeTaskProjection({ rootDir, eventStore }).read(created.taskId);
+    const projection = makeTaskProjection({ rootDir, eventStore });
+    projection.catchUp?.();
+    const read = projection.read(created.taskId);
     assert.equal(read.status, "ready");
     assert.equal(read.snapshot.task?.taskId, created.taskId);
     assert.equal(read.watermark, 1);
@@ -958,22 +956,21 @@ test("projection catch-up processes at most one bounded round and never reports 
       now: () => "2026-08-11T00:30:00.000Z",
     });
 
-    let previousWatermark = 0;
-    for (let round = 0; round < 6; round += 1) {
-      const read = projection.read("task-1");
-      assert.equal(read.watermark >= previousWatermark, true);
-      assert.equal(read.sourceRevision, 6);
-      // The receipt must name the limit this projection actually runs under, not a constant:
-      // it is constructed with catchUpLimit 2, so a hardcoded 64 would be a false bound.
-      assert.equal(read.catchUp.maxItems, 2);
-      assert.equal(read.catchUp.reducedItems <= read.catchUp.maxItems, true);
-      if (read.status === "ready") {
-        assert.equal(read.watermark, 6);
-        return;
-      }
-      previousWatermark = read.watermark;
-    }
-    assert.fail("bounded catch-up did not drain its persisted deferred events");
+    const before = projection.read("task-1");
+    assert.deepEqual(
+      { status: before.status, watermark: before.watermark, sourceRevision: before.sourceRevision },
+      { status: "pending", watermark: 0, sourceRevision: 6 },
+    );
+    assert.deepEqual(before.catchUp, { maxItems: 2, reducedItems: 0, sqliteTransactions: 0 });
+
+    const catchUp = projection.catchUp!(), read = projection.read("task-1");
+    assert.equal(catchUp.metrics.maxBatchItems <= 2, true);
+    assert.equal(catchUp.metrics.reducedItems, 6);
+    assert.deepEqual(
+      { status: read.status, watermark: read.watermark, sourceRevision: read.sourceRevision },
+      { status: "ready", watermark: 6, sourceRevision: 6 },
+    );
+    assert.deepEqual(read.catchUp, { maxItems: 2, reducedItems: 0, sqliteTransactions: 0 });
   });
 });
 

--- a/packages/kernel/test/store/task-query-projection.test.ts
+++ b/packages/kernel/test/store/task-query-projection.test.ts
@@ -158,6 +158,7 @@ test("narrow task list pages concatenate to the unparameterized result and keep 
   const fixture = taskFixture();
   await withTempStoreAsync(async (rootDir) => {
     const projection = makeTaskProjection({ rootDir, eventStore: memoryEventStore(fixture.events) });
+    projection.catchUp();
     const full = projection.list();
     assert.equal(full.rows.length, 6);
     assert.equal(full.page, undefined);
@@ -237,6 +238,7 @@ test("task runtime batch reads up to 500 ids without a variable SQLite IN list",
         ...fixture.tasks.map(({ taskId }) => taskId),
         ...Array.from({ length: 494 }, (_, index) => `task_missing_${String(index).padStart(3, "0")}`),
       ];
+    projection.catchUp();
     const batch = projection.readTaskRuntimeBatch({ taskIds: requested });
     assert.equal(batch.status, "ready");
     assert.equal(batch.taskIds.length, 500);
@@ -261,7 +263,7 @@ test("historical task relation events replay into the Relation projection and su
   const fixture = taskFixture();
   await withTempStoreAsync(async (rootDir) => {
     const projection = makeTaskProjection({ rootDir, eventStore: memoryEventStore(fixture.events) });
-    projection.list();
+    projection.catchUp();
     // The stored snapshot no longer hosts legacy task.relations (normalized via
     // currentTaskForWrite), so the expectation derives from the event payloads —
     // the same replay input the Relation projection consumes.
@@ -319,7 +321,7 @@ test("unparameterized list stays byte-identical across reopen after the schema b
   const fixture = taskFixture();
   await withTempStoreAsync(async (rootDir) => {
     const first = makeTaskProjection({ rootDir, eventStore: memoryEventStore(fixture.events) });
-    first.list(); // cold catch-up; the first read may carry the one-shot projection_missing warning
+    first.catchUp();
     const bytes = JSON.stringify(first.list());
     first.close();
     const reopened = makeTaskProjection({ rootDir, eventStore: memoryEventStore(fixture.events) });

--- a/packages/preset/src/preset-command-contract.ts
+++ b/packages/preset/src/preset-command-contract.ts
@@ -182,8 +182,15 @@ type CliCommandDeclaration = {
 };
 const defineTopologyCommand =
   (topology: CommandTopology) =>
-  <const Command extends CliCommandDeclaration>(declaration: Command) =>
-    defineCliCommand({ ...declaration, ...topology });
+  <const Command extends CliCommandDeclaration>(declaration: Command) => {
+    const routed =
+      topology.commandClass === "repo-read" &&
+      "method" in declaration &&
+      declaration.method === "repo.task.run"
+        ? { ...declaration, method: "repo.task.read" as const }
+        : declaration;
+    return defineCliCommand({ ...routed, ...topology });
+  };
 export const defineRepoReadCommand = defineTopologyCommand(repoReadCommandTopology),
   defineLedgerWriteCommand = defineTopologyCommand(ledgerWriteCommandTopology),
   defineCenterForwardReadCommand = defineTopologyCommand(centerForwardReadCommandTopology),

--- a/tools/check-api-contract-registry.mjs
+++ b/tools/check-api-contract-registry.mjs
@@ -11,7 +11,8 @@ const expectedMethods = Object.freeze([
   { method: "daemon.repo.bootstrap", requiresRepo: false },
   { method: "daemon.repo.register", requiresRepo: false },
   { method: "daemon.repo.unregister", requiresRepo: false },
-  { method: "repo.task.run", requiresRepo: true }
+  { method: "repo.task.run", requiresRepo: true },
+  { method: "repo.task.read", requiresRepo: true },
 ]);
 // The fleet channel is part of the same closed RPC surface: every daemon-side
 // fleet handler must be declared here with a validated params shape.
@@ -20,7 +21,7 @@ const expectedFleetMethods = Object.freeze([
   { method: "daemon.fleet.edge.sync" },
   { method: "daemon.fleet.task.run" },
   { method: "daemon.fleet.doc.sync" },
-  { method: "daemon.fleet.conflict.exit" }
+  { method: "daemon.fleet.conflict.exit" },
 ]);
 const retiredAuthorities = [
   "packages/application/src/task-write-route-policy.ts",
@@ -31,7 +32,7 @@ const retiredAuthorities = [
   "packages/daemon/src/transport/named-pipe.ts",
   "packages/daemon/src/transport/ssh-exec.ts",
   "packages/daemon/src/transport/ssh-forced-command.ts",
-  "packages/daemon/src/transport/ssh-tunnel-token.ts"
+  "packages/daemon/src/transport/ssh-tunnel-token.ts",
 ];
 const transportAuthorityMarker = "@daemon-transport-authority";
 
@@ -41,57 +42,100 @@ export function evaluateApiContractRegistry(root = process.cwd()) {
   const serverPath = "packages/daemon/src/protocol/json-rpc-server.ts";
   const hostPath = "packages/daemon/src/daemon-host.ts";
   const authPath = "packages/daemon/src/transport/auth-context.ts";
-  const registry = read(root, registryPath, violations), server = read(root, serverPath, violations);
+  const registry = read(root, registryPath, violations),
+    server = read(root, serverPath, violations);
   const hostGraph = collectRuntimeAuthorityGraph(root, hostPath, violations),
     hostAuthorities = hostGraph.filter(({ source }) => source.includes(transportAuthorityMarker)),
     auth = read(root, authPath, violations);
   if (registry) {
     const methods = collectMethodContracts(registry, registryPath, violations);
     if (JSON.stringify(methods) !== JSON.stringify(expectedMethods)) {
-      violations.push(`${registryPath}: method catalog must equal ${JSON.stringify(expectedMethods)}; found ${JSON.stringify(methods)}`);
+      violations.push(
+        `${registryPath}: method catalog must equal ${JSON.stringify(expectedMethods)}; found ${JSON.stringify(methods)}`,
+      );
     }
     const fleetMethods = collectMethodContracts(registry, registryPath, violations, "fleetProtocolMethods");
     if (JSON.stringify(fleetMethods) !== JSON.stringify(expectedFleetMethods)) {
-      violations.push(`${registryPath}: fleet method catalog must equal ${JSON.stringify(expectedFleetMethods)}; found ${JSON.stringify(fleetMethods)}`);
+      violations.push(
+        `${registryPath}: fleet method catalog must equal ${JSON.stringify(expectedFleetMethods)}; found ${JSON.stringify(fleetMethods)}`,
+      );
     }
     if (/apiRouteContracts|capabilit|notifications?|admin\.(?:people|rbac)/u.test(registry)) {
       violations.push(`${registryPath}: retired GUI/API capability authority must not feed the W3 daemon protocol`);
     }
   }
   if (server) {
-    for (const token of ["jsonRpcMethodContracts.some", "request.method === \"protocol.hello\"", "if (!handshaken)",
-      "request.method === \"daemon.status\"", "request.method === \"daemon.stop\"", "request.method === \"daemon.repo.bootstrap\"",
-      "request.method === \"daemon.repo.register\"", "request.method === \"daemon.repo.unregister\""]) {
+    for (const token of [
+      "jsonRpcMethodContracts.some",
+      'request.method === "protocol.hello"',
+      "if (!handshaken)",
+      'request.method === "daemon.status"',
+      'request.method === "daemon.stop"',
+      'request.method === "daemon.repo.bootstrap"',
+      'request.method === "daemon.repo.register"',
+      'request.method === "daemon.repo.unregister"',
+    ]) {
       if (!server.includes(token)) violations.push(`${serverPath}: missing protocol closure token ${token}`);
     }
-    if (!/options\.host\.run\(repo,\s*action[^,]*,\s*options\.authContext\)/u.test(server)) violations.push(`${serverPath}: repo.task.run must pass transport authentication to the daemon host`);
-    if (/notifications?|admin\.(?:people|rbac)|fallback|capabilit/iu.test(server)) violations.push(`${serverPath}: retired notification/admin/capability fallback must not return`);
+    if (!/options\.host\.run\(repo,\s*action[^,]*,\s*options\.authContext\)/u.test(server))
+      violations.push(`${serverPath}: repo.task.run must pass transport authentication to the daemon host`);
+    if (/notifications?|admin\.(?:people|rbac)|fallback|capabilit/iu.test(server))
+      violations.push(`${serverPath}: retired notification/admin/capability fallback must not return`);
   }
   if (hostGraph.length > 0 && hostAuthorities.length === 0) {
     violations.push(`${hostPath} runtime graph: no module declares the ${transportAuthorityMarker} role`);
   }
   if (hostAuthorities.length > 0) {
-    for (const token of ["new Map<string, RepoCell>()", "auth.assignmentBinding", "kind: \"assignment\"", "makeTransportDerivedIdentityProvider",
-      "actor", "root", "canonicalRoot", "source", "workspaceId", "expectedRevision", "eventId", "occurredAt"]) {
+    for (const token of [
+      "new Map<string, RepoCell>()",
+      "auth.assignmentBinding",
+      'kind: "assignment"',
+      "makeTransportDerivedIdentityProvider",
+      "actor",
+      "root",
+      "canonicalRoot",
+      "source",
+      "workspaceId",
+      "expectedRevision",
+      "eventId",
+      "occurredAt",
+    ]) {
       if (!hostAuthorities.some(({ source }) => source.includes(token))) {
         violations.push(`${hostPath} runtime graph: missing transport-bound RepoCell authority token ${token}`);
       }
     }
-    if (hostAuthorities.some(({ source }) => /payload\.(?:actor|root|source|workspaceId)|HARNESS_ACTOR|local fallback/iu.test(source))) {
-      violations.push(`${hostPath} runtime graph: daemon ingress must bind actor/root/source instead of trusting payload or fallback identity`);
+    if (
+      hostAuthorities.some(({ source }) =>
+        /payload\.(?:actor|root|source|workspaceId)|HARNESS_ACTOR|local fallback/iu.test(source),
+      )
+    ) {
+      violations.push(
+        `${hostPath} runtime graph: daemon ingress must bind actor/root/source instead of trusting payload or fallback identity`,
+      );
     }
   }
   if (auth) {
-    for (const token of ["DaemonTransportKind = \"unix-socket\"", "unixSocketOwnerBoundary", "assignmentBinding", "nodeId", "assignmentId"]) {
+    for (const token of [
+      'DaemonTransportKind = "unix-socket"',
+      "unixSocketOwnerBoundary",
+      "assignmentBinding",
+      "nodeId",
+      "assignmentId",
+    ]) {
       if (!auth.includes(token)) violations.push(`${authPath}: missing authenticated transport binding ${token}`);
     }
   }
-  for (const retired of retiredAuthorities) if (existsSync(path.join(root, retired))) violations.push(`${retired}: W3-retired API/capability authority must not exist`);
+  for (const retired of retiredAuthorities)
+    if (existsSync(path.join(root, retired)))
+      violations.push(`${retired}: W3-retired API/capability authority must not exist`);
   return violations;
 }
 
 function collectRuntimeAuthorityGraph(root, entryPath, violations) {
-  const authorityRoot = path.dirname(path.join(root, entryPath)), pending = [entryPath], visited = new Set(), modules = [];
+  const authorityRoot = path.dirname(path.join(root, entryPath)),
+    pending = [entryPath],
+    visited = new Set(),
+    modules = [];
   while (pending.length > 0) {
     const relativePath = pending.pop();
     if (visited.has(relativePath)) continue;
@@ -115,25 +159,49 @@ function collectRuntimeAuthorityGraph(root, entryPath, violations) {
 function runtimeModuleSpecifier(statement) {
   if (ts.isImportDeclaration(statement)) {
     if (statement.importClause?.isTypeOnly) return null;
-    if (statement.importClause?.namedBindings && ts.isNamedImports(statement.importClause.namedBindings)
-      && !statement.importClause.name && statement.importClause.namedBindings.elements.every((element) => element.isTypeOnly)) return null;
+    if (
+      statement.importClause?.namedBindings &&
+      ts.isNamedImports(statement.importClause.namedBindings) &&
+      !statement.importClause.name &&
+      statement.importClause.namedBindings.elements.every((element) => element.isTypeOnly)
+    )
+      return null;
     return ts.isStringLiteralLike(statement.moduleSpecifier) ? statement.moduleSpecifier.text : null;
   }
   if (ts.isExportDeclaration(statement)) {
     if (statement.isTypeOnly) return null;
-    if (statement.exportClause && ts.isNamedExports(statement.exportClause)
-      && statement.exportClause.elements.every((element) => element.isTypeOnly)) return null;
-    return statement.moduleSpecifier && ts.isStringLiteralLike(statement.moduleSpecifier) ? statement.moduleSpecifier.text : null;
+    if (
+      statement.exportClause &&
+      ts.isNamedExports(statement.exportClause) &&
+      statement.exportClause.elements.every((element) => element.isTypeOnly)
+    )
+      return null;
+    return statement.moduleSpecifier && ts.isStringLiteralLike(statement.moduleSpecifier)
+      ? statement.moduleSpecifier.text
+      : null;
   }
   return null;
 }
 
 function resolveRuntimeModule(root, authorityRoot, importerPath, specifier) {
-  const importer = path.join(root, importerPath), requested = path.resolve(path.dirname(importer), specifier);
+  const importer = path.join(root, importerPath),
+    requested = path.resolve(path.dirname(importer), specifier);
   if (requested !== authorityRoot && !requested.startsWith(`${authorityRoot}${path.sep}`)) return undefined;
-  const extension = path.extname(requested), candidates = extension
-    ? [requested, ...([".js", ".jsx", ".mjs", ".cjs"].includes(extension) ? [requested.slice(0, -extension.length) + ".ts", requested.slice(0, -extension.length) + ".tsx"] : [])]
-    : [requested, ...[".ts", ".tsx", ".mts", ".js", ".jsx", ".mjs"].map((candidate) => requested + candidate), ...[".ts", ".tsx", ".mts", ".js", ".jsx", ".mjs"].map((candidate) => path.join(requested, `index${candidate}`))];
+  const extension = path.extname(requested),
+    candidates = extension
+      ? [
+          requested,
+          ...([".js", ".jsx", ".mjs", ".cjs"].includes(extension)
+            ? [requested.slice(0, -extension.length) + ".ts", requested.slice(0, -extension.length) + ".tsx"]
+            : []),
+        ]
+      : [
+          requested,
+          ...[".ts", ".tsx", ".mts", ".js", ".jsx", ".mjs"].map((candidate) => requested + candidate),
+          ...[".ts", ".tsx", ".mts", ".js", ".jsx", ".mjs"].map((candidate) =>
+            path.join(requested, `index${candidate}`),
+          ),
+        ];
   const resolved = candidates.find((candidate) => existsSync(candidate));
   return resolved ? path.relative(root, resolved).split(path.sep).join("/") : null;
 }
@@ -151,40 +219,73 @@ function collectMethodContracts(source, relativePath, violations, variableName =
   for (const statement of file.statements) {
     if (!ts.isVariableStatement(statement)) continue;
     for (const declaration of statement.declarationList.declarations) {
-      if (ts.isIdentifier(declaration.name) && declaration.name.text === variableName) initializer = declaration.initializer;
+      if (ts.isIdentifier(declaration.name) && declaration.name.text === variableName)
+        initializer = declaration.initializer;
     }
   }
-  if (initializer && ts.isCallExpression(initializer) && ts.isPropertyAccessExpression(initializer.expression)
-    && initializer.expression.expression.getText(file) === "Object" && initializer.expression.name.text === "freeze") initializer = initializer.arguments[0];
-  if (initializer && (ts.isAsExpression(initializer) || ts.isSatisfiesExpression(initializer))) initializer = initializer.expression;
+  if (
+    initializer &&
+    ts.isCallExpression(initializer) &&
+    ts.isPropertyAccessExpression(initializer.expression) &&
+    initializer.expression.expression.getText(file) === "Object" &&
+    initializer.expression.name.text === "freeze"
+  )
+    initializer = initializer.arguments[0];
+  if (initializer && (ts.isAsExpression(initializer) || ts.isSatisfiesExpression(initializer)))
+    initializer = initializer.expression;
   if (!initializer || !ts.isArrayLiteralExpression(initializer)) {
     violations.push(`${relativePath}: ${variableName} must be one frozen contract array literal`);
     return [];
   }
   return initializer.elements.flatMap((element) => {
-    if (!ts.isObjectLiteralExpression(element)) { violations.push(`${relativePath}: method entries must be object literals`); return []; }
-    if (variableName === "fleetProtocolMethods" && !element.properties.some((property) => ts.isPropertyAssignment(property) && property.name.getText(file).replace(/["']/gu, "") === "params")) { violations.push(`${relativePath}: fleet method entries must declare a validated params shape`); return []; }
-    const values = Object.fromEntries(element.properties.flatMap((property) => {
-      if (!ts.isPropertyAssignment(property)) return [];
-      const name = property.name.getText(file).replace(/["']/gu, "");
-      if (ts.isStringLiteral(property.initializer)) return [[name, property.initializer.text]];
-      if (property.initializer.kind === ts.SyntaxKind.TrueKeyword) return [[name, true]];
-      if (property.initializer.kind === ts.SyntaxKind.FalseKeyword) return [[name, false]];
+    if (!ts.isObjectLiteralExpression(element)) {
+      violations.push(`${relativePath}: method entries must be object literals`);
       return [];
-    }));
-    return variableName === "fleetProtocolMethods" ? [{ method: values.method }] : [{ method: values.method, requiresRepo: values.requiresRepo }];
+    }
+    if (
+      variableName === "fleetProtocolMethods" &&
+      !element.properties.some(
+        (property) =>
+          ts.isPropertyAssignment(property) && property.name.getText(file).replace(/["']/gu, "") === "params",
+      )
+    ) {
+      violations.push(`${relativePath}: fleet method entries must declare a validated params shape`);
+      return [];
+    }
+    const values = Object.fromEntries(
+      element.properties.flatMap((property) => {
+        if (!ts.isPropertyAssignment(property)) return [];
+        const name = property.name.getText(file).replace(/["']/gu, "");
+        if (ts.isStringLiteral(property.initializer)) return [[name, property.initializer.text]];
+        if (property.initializer.kind === ts.SyntaxKind.TrueKeyword) return [[name, true]];
+        if (property.initializer.kind === ts.SyntaxKind.FalseKeyword) return [[name, false]];
+        return [];
+      }),
+    );
+    return variableName === "fleetProtocolMethods"
+      ? [{ method: values.method }]
+      : [{ method: values.method, requiresRepo: values.requiresRepo }];
   });
 }
 
 function read(root, relativePath, violations) {
   const absolute = path.join(root, relativePath);
-  if (!existsSync(absolute)) { violations.push(`${relativePath}: required W3 protocol authority is missing`); return ""; }
+  if (!existsSync(absolute)) {
+    violations.push(`${relativePath}: required W3 protocol authority is missing`);
+    return "";
+  }
   return readFileSync(absolute, "utf8");
 }
 
 function main() {
   const violations = evaluateApiContractRegistry();
-  if (violations.length > 0) { console.error("API contract registry check failed:"); for (const violation of violations) console.error(`- ${violation}`); process.exitCode = 1; }
-  else console.log("API contract registry check passed: the exact W3 daemon RPC catalog is transport-bound and capability-fallback free.");
+  if (violations.length > 0) {
+    console.error("API contract registry check failed:");
+    for (const violation of violations) console.error(`- ${violation}`);
+    process.exitCode = 1;
+  } else
+    console.log(
+      "API contract registry check passed: the exact W3 daemon RPC catalog is transport-bound and capability-fallback free.",
+    );
 }
 if (process.argv[1] !== undefined && import.meta.url === pathToFileURL(process.argv[1]).href) main();

--- a/tools/check-api-contract-registry.test.mjs
+++ b/tools/check-api-contract-registry.test.mjs
@@ -6,73 +6,139 @@ import path from "node:path";
 import test from "node:test";
 import { evaluateApiContractRegistry } from "./check-api-contract-registry.mjs";
 
-test("W3 API registry accepts the exact transport-bound daemon catalog", () => withFixture((root) => {
-  assert.deepEqual(evaluateApiContractRegistry(root), []);
-}));
+test("W3 API registry accepts the exact transport-bound daemon catalog", () =>
+  withFixture((root) => {
+    assert.deepEqual(evaluateApiContractRegistry(root), []);
+  }));
 
-test("W3 API registry rejects an unregistered compatibility method", () => withFixture((root) => {
-  const file = path.join(root, "packages/daemon/src/protocol/daemon-protocol.contract.ts");
-  writeFileSync(file, validRegistry().replace("  { method: \"repo.task.run\"", "  { method: \"repo.compat.run\", requiresRepo: true },\n  { method: \"repo.task.run\""));
-  assert.match(evaluateApiContractRegistry(root).join("\n"), /method catalog must equal/u);
-}));
+test("W3 API registry rejects an unregistered compatibility method", () =>
+  withFixture((root) => {
+    const file = path.join(root, "packages/daemon/src/protocol/daemon-protocol.contract.ts");
+    writeFileSync(
+      file,
+      validRegistry().replace(
+        '  { method: "repo.task.run"',
+        '  { method: "repo.compat.run", requiresRepo: true },\n  { method: "repo.task.run"',
+      ),
+    );
+    assert.match(evaluateApiContractRegistry(root).join("\n"), /method catalog must equal/u);
+  }));
 
-test("W3 API registry rejects repo routing that is not repo-scoped", () => withFixture((root) => {
-  const file = path.join(root, "packages/daemon/src/protocol/daemon-protocol.contract.ts");
-  writeFileSync(file, validRegistry().replace('{ method: "repo.task.run", requiresRepo: true }', '{ method: "repo.task.run", requiresRepo: false }'));
-  assert.match(evaluateApiContractRegistry(root).join("\n"), /method catalog must equal/u);
-}));
+test("W3 API registry rejects repo routing that is not repo-scoped", () =>
+  withFixture((root) => {
+    const file = path.join(root, "packages/daemon/src/protocol/daemon-protocol.contract.ts");
+    writeFileSync(
+      file,
+      validRegistry().replace(
+        '{ method: "repo.task.run", requiresRepo: true }',
+        '{ method: "repo.task.run", requiresRepo: false }',
+      ),
+    );
+    assert.match(evaluateApiContractRegistry(root).join("\n"), /method catalog must equal/u);
+  }));
 
-test("W3 API registry rejects an undeclared fleet RPC method", () => withFixture((root) => {
-  const file = path.join(root, "packages/daemon/src/protocol/daemon-protocol.contract.ts");
-  writeFileSync(file, validRegistry().replace('  { id: "daemon.fleet.doc.sync"', '  { id: "daemon.fleet.compat.run", phase: "Fleet-Wiring", method: "daemon.fleet.compat.run", requiresRepo: false, params: shape({ payload: shape({}) }) },\n  { id: "daemon.fleet.doc.sync"'));
-  assert.match(evaluateApiContractRegistry(root).join("\n"), /fleet method catalog must equal/u);
-}));
+test("W3 API registry rejects an undeclared fleet RPC method", () =>
+  withFixture((root) => {
+    const file = path.join(root, "packages/daemon/src/protocol/daemon-protocol.contract.ts");
+    writeFileSync(
+      file,
+      validRegistry().replace(
+        '  { id: "daemon.fleet.doc.sync"',
+        '  { id: "daemon.fleet.compat.run", phase: "Fleet-Wiring", method: "daemon.fleet.compat.run", requiresRepo: false, params: shape({ payload: shape({}) }) },\n  { id: "daemon.fleet.doc.sync"',
+      ),
+    );
+    assert.match(evaluateApiContractRegistry(root).join("\n"), /fleet method catalog must equal/u);
+  }));
 
-test("W3 API registry rejects a fleet method without a validated params shape", () => withFixture((root) => {
-  const file = path.join(root, "packages/daemon/src/protocol/daemon-protocol.contract.ts");
-  writeFileSync(file, validRegistry().replace(', params: shape({ payload: shape({ conflictId: "string" }) })', ""));
-  assert.match(evaluateApiContractRegistry(root).join("\n"), /fleet method entries must declare a validated params shape/u);
-}));
+test("W3 API registry rejects a fleet method without a validated params shape", () =>
+  withFixture((root) => {
+    const file = path.join(root, "packages/daemon/src/protocol/daemon-protocol.contract.ts");
+    writeFileSync(file, validRegistry().replace(', params: shape({ payload: shape({ conflictId: "string" }) })', ""));
+    assert.match(
+      evaluateApiContractRegistry(root).join("\n"),
+      /fleet method entries must declare a validated params shape/u,
+    );
+  }));
 
-test("W3 API registry rejects restoration of the retired task route authority", () => withFixture((root) => {
-  write(root, "packages/application/src/task-write-route-policy.ts", "export const restored = true;\n");
-  assert.match(evaluateApiContractRegistry(root).join("\n"), /W3-retired API\/capability authority/u);
-}));
+test("W3 API registry rejects restoration of the retired task route authority", () =>
+  withFixture((root) => {
+    write(root, "packages/application/src/task-write-route-policy.ts", "export const restored = true;\n");
+    assert.match(evaluateApiContractRegistry(root).join("\n"), /W3-retired API\/capability authority/u);
+  }));
 
-test("W3 API registry rejects loss of payload self-report filtering", () => withFixture((root) => {
-  write(root, "packages/daemon/src/repository-dispatch.ts", validRepositoryDispatch().replace(', "occurredAt"', ""));
-  assert.match(evaluateApiContractRegistry(root).join("\n"), /missing transport-bound RepoCell authority token occurredAt/u);
-}));
+test("W3 API registry rejects loss of payload self-report filtering", () =>
+  withFixture((root) => {
+    write(root, "packages/daemon/src/repository-dispatch.ts", validRepositoryDispatch().replace(', "occurredAt"', ""));
+    assert.match(
+      evaluateApiContractRegistry(root).join("\n"),
+      /missing transport-bound RepoCell authority token occurredAt/u,
+    );
+  }));
 
-test("W3 API registry follows a renamed transport-authority module", () => withFixture((root) => {
-  renameSync(path.join(root, "packages/daemon/src/transport-binding.ts"), path.join(root, "packages/daemon/src/renamed-authority.ts"));
-  write(root, "packages/daemon/src/transport-composition.ts", validHostComposition().replace("./transport-binding.ts", "./renamed-authority.ts"));
-  assert.deepEqual(evaluateApiContractRegistry(root), []);
-}));
+test("W3 API registry follows a renamed transport-authority module", () =>
+  withFixture((root) => {
+    renameSync(
+      path.join(root, "packages/daemon/src/transport-binding.ts"),
+      path.join(root, "packages/daemon/src/renamed-authority.ts"),
+    );
+    write(
+      root,
+      "packages/daemon/src/transport-composition.ts",
+      validHostComposition().replace("./transport-binding.ts", "./renamed-authority.ts"),
+    );
+    assert.deepEqual(evaluateApiContractRegistry(root), []);
+  }));
 
-function withFixture(run) { const root = mkdtempSync(path.join(tmpdir(), "w3-api-registry-")); try {
-  write(root, "packages/daemon/src/protocol/daemon-protocol.contract.ts", validRegistry());
-  write(root, "packages/daemon/src/protocol/json-rpc-server.ts", validServer());
-  write(root, "packages/daemon/src/daemon-host.ts", 'export { openDaemonHost } from "./transport-composition.ts";\n');
-  write(root, "packages/daemon/src/transport-composition.ts", validHostComposition());
-  write(root, "packages/daemon/src/transport-binding.ts", validTransportBinding());
-  write(root, "packages/daemon/src/mode-admission.ts", '/** @daemon-transport-authority */\nexport function admit(auth) { return auth.assignmentBinding; }\n');
-  write(root, "packages/daemon/src/repository-dispatch.ts", validRepositoryDispatch());
-  write(root, "packages/daemon/src/transport/auth-context.ts", 'export type DaemonTransportKind = "unix-socket"; export interface Auth { unixSocketOwnerBoundary: unknown; assignmentBinding: { nodeId: string; assignmentId: string }; }\n');
-  run(root);
-} finally { rmSync(root, { recursive: true, force: true }); } }
-function write(root, relative, body) { const file = path.join(root, relative); mkdirSync(path.dirname(file), { recursive: true }); writeFileSync(file, body); }
-function validRegistry() { return `export const daemonProtocolMethods = Object.freeze([\n  { method: "protocol.hello", requiresRepo: false },\n  { method: "daemon.status", requiresRepo: false },\n  { method: "daemon.stop", requiresRepo: false },\n  { method: "daemon.repo.bootstrap", requiresRepo: false },\n  { method: "daemon.repo.register", requiresRepo: false },\n  { method: "daemon.repo.unregister", requiresRepo: false },\n  { method: "repo.task.run", requiresRepo: true }\n]);\nexport const fleetProtocolMethods = Object.freeze([\n  { id: "daemon.fleet.center.start", phase: "Fleet-Wiring", method: "daemon.fleet.center.start", requiresRepo: false, params: shape({ payload: shape({ port: "number" }) }) },\n  { id: "daemon.fleet.edge.sync", phase: "Fleet-Wiring", method: "daemon.fleet.edge.sync", requiresRepo: false, params: shape({ payload: shape({ host: "string" }) }) },\n  { id: "daemon.fleet.task.run", phase: "Fleet-Wiring", method: "daemon.fleet.task.run", requiresRepo: false, params: shape({ payload: shape({ action: "json" }) }) },\n  { id: "daemon.fleet.doc.sync", phase: "Fleet-Wiring", method: "daemon.fleet.doc.sync", requiresRepo: false, params: shape({ payload: shape({ workspaceRoot: "string" }) }) },\n  { id: "daemon.fleet.conflict.exit", phase: "Fleet-Wiring", method: "daemon.fleet.conflict.exit", requiresRepo: false, params: shape({ payload: shape({ conflictId: "string" }) }) }\n]);\n`; }
-function validServer() { return `jsonRpcMethodContracts.some(() => true); request.method === "protocol.hello"; if (!handshaken) fail(); request.method === "daemon.status"; request.method === "daemon.stop"; request.method === "daemon.repo.bootstrap"; request.method === "daemon.repo.register"; request.method === "daemon.repo.unregister"; options.host.run(repo, action, options.authContext);\n`; }
-function validHostComposition() { return `/** @daemon-transport-authority */
+function withFixture(run) {
+  const root = mkdtempSync(path.join(tmpdir(), "w3-api-registry-"));
+  try {
+    write(root, "packages/daemon/src/protocol/daemon-protocol.contract.ts", validRegistry());
+    write(root, "packages/daemon/src/protocol/json-rpc-server.ts", validServer());
+    write(root, "packages/daemon/src/daemon-host.ts", 'export { openDaemonHost } from "./transport-composition.ts";\n');
+    write(root, "packages/daemon/src/transport-composition.ts", validHostComposition());
+    write(root, "packages/daemon/src/transport-binding.ts", validTransportBinding());
+    write(
+      root,
+      "packages/daemon/src/mode-admission.ts",
+      "/** @daemon-transport-authority */\nexport function admit(auth) { return auth.assignmentBinding; }\n",
+    );
+    write(root, "packages/daemon/src/repository-dispatch.ts", validRepositoryDispatch());
+    write(
+      root,
+      "packages/daemon/src/transport/auth-context.ts",
+      'export type DaemonTransportKind = "unix-socket"; export interface Auth { unixSocketOwnerBoundary: unknown; assignmentBinding: { nodeId: string; assignmentId: string }; }\n',
+    );
+    run(root);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+function write(root, relative, body) {
+  const file = path.join(root, relative);
+  mkdirSync(path.dirname(file), { recursive: true });
+  writeFileSync(file, body);
+}
+function validRegistry() {
+  return `export const daemonProtocolMethods = Object.freeze([\n  { method: "protocol.hello", requiresRepo: false },\n  { method: "daemon.status", requiresRepo: false },\n  { method: "daemon.stop", requiresRepo: false },\n  { method: "daemon.repo.bootstrap", requiresRepo: false },\n  { method: "daemon.repo.register", requiresRepo: false },\n  { method: "daemon.repo.unregister", requiresRepo: false },\n  { method: "repo.task.run", requiresRepo: true },\n  { method: "repo.task.read", requiresRepo: true }\n]);\nexport const fleetProtocolMethods = Object.freeze([\n  { id: "daemon.fleet.center.start", phase: "Fleet-Wiring", method: "daemon.fleet.center.start", requiresRepo: false, params: shape({ payload: shape({ port: "number" }) }) },\n  { id: "daemon.fleet.edge.sync", phase: "Fleet-Wiring", method: "daemon.fleet.edge.sync", requiresRepo: false, params: shape({ payload: shape({ host: "string" }) }) },\n  { id: "daemon.fleet.task.run", phase: "Fleet-Wiring", method: "daemon.fleet.task.run", requiresRepo: false, params: shape({ payload: shape({ action: "json" }) }) },\n  { id: "daemon.fleet.doc.sync", phase: "Fleet-Wiring", method: "daemon.fleet.doc.sync", requiresRepo: false, params: shape({ payload: shape({ workspaceRoot: "string" }) }) },\n  { id: "daemon.fleet.conflict.exit", phase: "Fleet-Wiring", method: "daemon.fleet.conflict.exit", requiresRepo: false, params: shape({ payload: shape({ conflictId: "string" }) }) }\n]);\n`;
+}
+function validServer() {
+  return `jsonRpcMethodContracts.some(() => true); request.method === "protocol.hello"; if (!handshaken) fail(); request.method === "daemon.status"; request.method === "daemon.stop"; request.method === "daemon.repo.bootstrap"; request.method === "daemon.repo.register"; request.method === "daemon.repo.unregister"; options.host.run(repo, action, options.authContext);\n`;
+}
+function validHostComposition() {
+  return `/** @daemon-transport-authority */
 import { binding } from "./transport-binding.ts";
 import { admit } from "./mode-admission.ts";
 import { run } from "./repository-dispatch.ts";
 export function openDaemonHost() { const cells = new Map<string, RepoCell>(); return { cells, binding, admit, run }; }
-`; }
-function validTransportBinding() { return `/** @daemon-transport-authority */
+`;
+}
+function validTransportBinding() {
+  return `/** @daemon-transport-authority */
 export function binding(auth) { auth.assignmentBinding; ({ kind: "assignment" }); makeTransportDerivedIdentityProvider(); return { actor: true, source: "local" }; }
-`; }
-function validRepositoryDispatch() { return `/** @daemon-transport-authority */
+`;
+}
+function validRepositoryDispatch() {
+  return `/** @daemon-transport-authority */
 export function run() { return ["root", "canonicalRoot", "workspaceId", "expectedRevision", "eventId", "occurredAt"]; }
-`; }
+`;
+}

--- a/tools/check-sync-subprocess.test.mjs
+++ b/tools/check-sync-subprocess.test.mjs
@@ -4,133 +4,186 @@ import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
-import {
-  checkSyncSubprocess,
-  inventoryCounts,
-  scanSyncSubprocess
-} from "./check-sync-subprocess.mjs";
+import { checkSyncSubprocess, inventoryCounts, scanSyncSubprocess } from "./check-sync-subprocess.mjs";
 
 const repoRoot = path.resolve(import.meta.dirname, "..");
 
 test("repository inventory freezes the governed API and syntax-kind multisets", () => {
   const counts = inventoryCounts(scanSyncSubprocess(repoRoot));
-  assert.equal(counts.total, 17);
-  assert.deepEqual(counts.kinds, { import: 7, call: 10 });
-  assert.deepEqual(counts.apis, { execFileSync: 15, spawnSync: 2 });
+  assert.equal(counts.total, 15);
+  assert.deepEqual(counts.kinds, { import: 6, call: 9 });
+  assert.deepEqual(counts.apis, { execFileSync: 13, spawnSync: 2 });
 });
 
 test("renamed named imports are resolved while comments and strings are ignored", () => {
-  withFixture({
-    "packages/daemon/src/worker.ts": 'import { execFileSync as run, spawn } from "node:child_process";\nimport type { execSync } from "node:child_process";\n// spawnSync("ignored")\nconst note = "execSync()";\nexport function invoke() { return run("git", ["status"]); }\n'
-  }, (root) => {
-    const sites = scanSyncSubprocess(root);
-    assert.equal(sites.length, 2);
-    assert.deepEqual(sites.map(({ kind, api }) => ({ kind, api })), [
-      { kind: "import", api: "execFileSync" },
-      { kind: "call", api: "execFileSync" }
-    ]);
-  });
+  withFixture(
+    {
+      "packages/daemon/src/worker.ts":
+        'import { execFileSync as run, spawn } from "node:child_process";\nimport type { execSync } from "node:child_process";\n// spawnSync("ignored")\nconst note = "execSync()";\nexport function invoke() { return run("git", ["status"]); }\n',
+    },
+    (root) => {
+      const sites = scanSyncSubprocess(root);
+      assert.equal(sites.length, 2);
+      assert.deepEqual(
+        sites.map(({ kind, api }) => ({ kind, api })),
+        [
+          { kind: "import", api: "execFileSync" },
+          { kind: "call", api: "execFileSync" },
+        ],
+      );
+    },
+  );
 });
 
 test("namespace imports and CommonJS destructuring retain node:child_process provenance", () => {
-  withFixture({
-    "packages/kernel/src/namespace.ts": 'import * as childProcess from "node:child_process";\nexport const run = () => childProcess["spawnSync"]("git");\n',
-    "packages/daemon/src/common.cjs": 'const { execSync: execute } = require("node:child_process");\nexecute("git status");\n'
-  }, (root) => {
-    const sites = scanSyncSubprocess(root);
-    assert.deepEqual(sites.map(({ kind, api }) => ({ kind, api })), [
-      { kind: "import", api: "execSync" },
-      { kind: "call", api: "execSync" },
-      { kind: "call", api: "spawnSync" }
-    ]);
-  });
+  withFixture(
+    {
+      "packages/kernel/src/namespace.ts":
+        'import * as childProcess from "node:child_process";\nexport const run = () => childProcess["spawnSync"]("git");\n',
+      "packages/daemon/src/common.cjs":
+        'const { execSync: execute } = require("node:child_process");\nexecute("git status");\n',
+    },
+    (root) => {
+      const sites = scanSyncSubprocess(root);
+      assert.deepEqual(
+        sites.map(({ kind, api }) => ({ kind, api })),
+        [
+          { kind: "import", api: "execSync" },
+          { kind: "call", api: "execSync" },
+          { kind: "call", api: "spawnSync" },
+        ],
+      );
+    },
+  );
 });
 
 test("indirect references and direct module access cannot bypass call detection", () => {
-  withFixture({
-    "packages/kernel/src/alias.ts": 'import { execSync } from "node:child_process";\nexport const indirect = execSync;\n',
-    "packages/daemon/src/direct.cjs": 'require("node:child_process").spawnSync("git");\n'
-  }, (root) => {
-    const sites = scanSyncSubprocess(root);
-    assert.deepEqual(sites.map(({ kind, api }) => ({ kind, api })), [
-      { kind: "call", api: "spawnSync" },
-      { kind: "import", api: "execSync" },
-      { kind: "reference", api: "execSync" }
-    ]);
-  });
+  withFixture(
+    {
+      "packages/kernel/src/alias.ts":
+        'import { execSync } from "node:child_process";\nexport const indirect = execSync;\n',
+      "packages/daemon/src/direct.cjs": 'require("node:child_process").spawnSync("git");\n',
+    },
+    (root) => {
+      const sites = scanSyncSubprocess(root);
+      assert.deepEqual(
+        sites.map(({ kind, api }) => ({ kind, api })),
+        [
+          { kind: "call", api: "spawnSync" },
+          { kind: "import", api: "execSync" },
+          { kind: "reference", api: "execSync" },
+        ],
+      );
+    },
+  );
 });
 
 test("a new spawnSync site fails the ratchet", () => {
-  withFixture({
-    "packages/daemon/src/new-site.ts": 'import { spawnSync } from "node:child_process";\nexport function launch() { return spawnSync("git", ["status"]); }\n'
-  }, (root) => {
-    const findings = checkSyncSubprocess(scanSyncSubprocess(root), []);
-    assert.equal(findings.filter((finding) => finding.includes("new synchronous subprocess")).length, 2, findings.join("\n"));
-    assert.ok(findings.some((finding) => finding.includes("(spawnSync)")), findings.join("\n"));
-  });
+  withFixture(
+    {
+      "packages/daemon/src/new-site.ts":
+        'import { spawnSync } from "node:child_process";\nexport function launch() { return spawnSync("git", ["status"]); }\n',
+    },
+    (root) => {
+      const findings = checkSyncSubprocess(scanSyncSubprocess(root), []);
+      assert.equal(
+        findings.filter((finding) => finding.includes("new synchronous subprocess")).length,
+        2,
+        findings.join("\n"),
+      );
+      assert.ok(
+        findings.some((finding) => finding.includes("(spawnSync)")),
+        findings.join("\n"),
+      );
+    },
+  );
 });
 
 test("source identities survive formatting, responsibility split, and file rename", () => {
-  withFixture({
-    "packages/kernel/src/git.ts": 'import { /* @gate-identity check-sync-subprocess/sync-fixture-import */ execFileSync } from "node:child_process";\nexport function run() { return /* @gate-identity check-sync-subprocess/sync-fixture-call */ execFileSync("git", ["status"]); }\n'
-  }, (root) => {
-    const original = scanSyncSubprocess(root);
-    const baseline = [
-      { key: "sync-fixture-import", kind: "import", api: "execFileSync" },
-      { key: "sync-fixture-call", kind: "call", api: "execFileSync" }
-    ];
-    assert.deepEqual(checkSyncSubprocess(original, baseline), []);
+  withFixture(
+    {
+      "packages/kernel/src/git.ts":
+        'import { /* @gate-identity check-sync-subprocess/sync-fixture-import */ execFileSync } from "node:child_process";\nexport function run() { return /* @gate-identity check-sync-subprocess/sync-fixture-call */ execFileSync("git", ["status"]); }\n',
+    },
+    (root) => {
+      const original = scanSyncSubprocess(root);
+      const baseline = [
+        { key: "sync-fixture-import", kind: "import", api: "execFileSync" },
+        { key: "sync-fixture-call", kind: "call", api: "execFileSync" },
+      ];
+      assert.deepEqual(checkSyncSubprocess(original, baseline), []);
 
-    const movedPath = path.join(root, "packages/daemon/src/git-runner.ts");
-    mkdirSync(path.dirname(movedPath), { recursive: true });
-    writeFileSync(movedPath, [
-      'import { /* @gate-identity check-sync-subprocess/sync-fixture-import */ execFileSync } from "node:child_process";',
-      "export function runGitStatus() {",
-      "  return /* @gate-identity check-sync-subprocess/sync-fixture-call */ execFileSync(",
-      '    "git",',
-      '    ["status"],',
-      "  );",
-      "}"
-    ].join("\n"));
-    rmSync(path.join(root, "packages/kernel/src/git.ts"));
-    const moved = scanSyncSubprocess(root);
-    assert.deepEqual(moved.map((site) => site.key), original.map((site) => site.key));
-    assert.deepEqual(checkSyncSubprocess(moved, baseline), []);
-  });
+      const movedPath = path.join(root, "packages/daemon/src/git-runner.ts");
+      mkdirSync(path.dirname(movedPath), { recursive: true });
+      writeFileSync(
+        movedPath,
+        [
+          'import { /* @gate-identity check-sync-subprocess/sync-fixture-import */ execFileSync } from "node:child_process";',
+          "export function runGitStatus() {",
+          "  return /* @gate-identity check-sync-subprocess/sync-fixture-call */ execFileSync(",
+          '    "git",',
+          '    ["status"],',
+          "  );",
+          "}",
+        ].join("\n"),
+      );
+      rmSync(path.join(root, "packages/kernel/src/git.ts"));
+      const moved = scanSyncSubprocess(root);
+      assert.deepEqual(
+        moved.map((site) => site.key),
+        original.map((site) => site.key),
+      );
+      assert.deepEqual(checkSyncSubprocess(moved, baseline), []);
+    },
+  );
 });
 
 test("duplicate source identities fail closed", () => {
-  withFixture({
-    "packages/kernel/src/git.ts": 'import { /* @gate-identity check-sync-subprocess/sync-fixture */ execFileSync } from "node:child_process";\nexport function run() { return /* @gate-identity check-sync-subprocess/sync-fixture */ execFileSync("git"); }\n'
-  }, (root) => {
-    const findings = checkSyncSubprocess(scanSyncSubprocess(root), [
-      { key: "sync-fixture", kind: "import", api: "execFileSync" }
-    ]);
-    assert.ok(findings.some((finding) => finding.includes("duplicate source identity")), findings.join("\n"));
-  });
+  withFixture(
+    {
+      "packages/kernel/src/git.ts":
+        'import { /* @gate-identity check-sync-subprocess/sync-fixture */ execFileSync } from "node:child_process";\nexport function run() { return /* @gate-identity check-sync-subprocess/sync-fixture */ execFileSync("git"); }\n',
+    },
+    (root) => {
+      const findings = checkSyncSubprocess(scanSyncSubprocess(root), [
+        { key: "sync-fixture", kind: "import", api: "execFileSync" },
+      ]);
+      assert.ok(
+        findings.some((finding) => finding.includes("duplicate source identity")),
+        findings.join("\n"),
+      );
+    },
+  );
 });
 
 test("a stable identity cannot transfer to a different synchronous API", () => {
-  withFixture({
-    "packages/kernel/src/git.ts": 'import { /* @gate-identity check-sync-subprocess/sync-fixture-import */ execSync } from "node:child_process";\nexport function run() { return /* @gate-identity check-sync-subprocess/sync-fixture-call */ execSync("git status"); }\n'
-  }, (root) => {
-    const findings = checkSyncSubprocess(scanSyncSubprocess(root), [
-      { key: "sync-fixture-import", kind: "import", api: "execFileSync" },
-      { key: "sync-fixture-call", kind: "call", api: "execFileSync" }
-    ]);
-    assert.equal(findings.filter((finding) => finding.includes("baseline freezes")).length, 2, findings.join("\n"));
-  });
+  withFixture(
+    {
+      "packages/kernel/src/git.ts":
+        'import { /* @gate-identity check-sync-subprocess/sync-fixture-import */ execSync } from "node:child_process";\nexport function run() { return /* @gate-identity check-sync-subprocess/sync-fixture-call */ execSync("git status"); }\n',
+    },
+    (root) => {
+      const findings = checkSyncSubprocess(scanSyncSubprocess(root), [
+        { key: "sync-fixture-import", kind: "import", api: "execFileSync" },
+        { key: "sync-fixture-call", kind: "call", api: "execFileSync" },
+      ]);
+      assert.equal(findings.filter((finding) => finding.includes("baseline freezes")).length, 2, findings.join("\n"));
+    },
+  );
 });
 
 test("deleted sites make baseline entries stale", () => {
-  withFixture({
-    "packages/daemon/src/clean.ts": "export const clean = true;\n"
-  }, (root) => {
-    const findings = checkSyncSubprocess(scanSyncSubprocess(root), [
-      { key: "sync-deleted", kind: "call", api: "execFileSync" }
-    ]);
-    assert.match(findings[0], /stale baseline entry/u);
-  });
+  withFixture(
+    {
+      "packages/daemon/src/clean.ts": "export const clean = true;\n",
+    },
+    (root) => {
+      const findings = checkSyncSubprocess(scanSyncSubprocess(root), [
+        { key: "sync-deleted", kind: "call", api: "execFileSync" },
+      ]);
+      assert.match(findings[0], /stale baseline entry/u);
+    },
+  );
 });
 
 function withFixture(files, run) {

--- a/tools/gate-allowlists/sync-subprocess-baseline.mjs
+++ b/tools/gate-allowlists/sync-subprocess-baseline.mjs
@@ -5,8 +5,6 @@
 // Baseline membership still rejects unmarked additions, unknown ids, duplicate ids,
 // and stale identities.
 export const syncSubprocessBaseline = Object.freeze([
-  { key: "sync-subprocess-001", kind: "import", api: "execFileSync" }, // execFileSync import @ <module>
-  { key: "sync-subprocess-002", kind: "call", api: "execFileSync" }, // execFileSync call @ runExecutableSync.stdout
   { key: "sync-subprocess-003", kind: "import", api: "execFileSync" }, // execFileSync import @ <module>
   { key: "sync-subprocess-004", kind: "call", api: "execFileSync" }, // execFileSync call @ gitTracked
   { key: "sync-subprocess-005", kind: "call", api: "execFileSync" }, // execFileSync call @ gitModified


### PR DESCRIPTION
# English

## Summary

Single-process read stopgap (candidate B of the read/write isolation diagnosis, decision `dec_D129859E` CH2 ordering). The diagnosis proved GUI reads do not queue behind the RepoCell write tail but share the daemon's main event loop with synchronous write work — measured 13.6s/30.8s whole-daemon event gaps during doc-submit and runtime-spawn — while CLI legacy reads (registered as `repo.task.run`) really do queue behind the write tail, and serving reads amplify themselves via projection catch-up and wide aggregation. This PR lands the three stopgap cuts: (1) runtime executable discovery goes async and parallel via the process port, with concurrent refreshes coalesced into one in-flight promise and an explicit refresh before runtime commands so installation visibility does not regress; (2) all 42 `repo-read` descriptors leave `repo.task.run` for a new closed `repo.task.read` protocol method executed after admission/state checks without entering the publication tail (method/action mismatches are rejected; runtime enumeration proves 0 descriptors still map to the run method); (3) projection serving reads stop performing catch-up writes — they read `{watermark, sourceRevision, status}` and return a complete old or complete new cut, with the writer persisting the full cut digest in the same SQLite transaction — and the GUI task aggregation narrows to the current page's dependency closure instead of full-table relation/status/decision loads. Connection and request logs gain `frameReceivedAt`/`handlerStartedAt`/`repliedAt` with `dispatchDelayMs` + `serviceMs`, so event-loop backlog can no longer hide inside a single duration. The GUI client's misplaced 200 ms response timeout (passed as connect timeout) is corrected.

Controlled acceptance on an isolated daemon with a real `repo.agentRuntime.spawn` write in flight: all three fixed read payloads hold loaded p95 = 1 ms against idle p95 2–3 ms — 0.33–0.5×, far under the ≤2× decision threshold; the regression test asserts `loaded p95 <= 2 * idle p95` permanently.

## Architectural Justification

- Mechanism sentence: "not queued" is not "isolated" — a read plane sharing the writer's execution context stalls globally on any synchronous write work; this stopgap deletes the known synchronous hotspots and write-amplifying reads without inventing a half-isolation (hard isolation is decision `dec_D129859E`, implementation task filed separately).
- Deletion over addition: synchronous `execFileSync` discovery calls deleted (their two sync-subprocess baseline exemptions removed via the ratchet's own stale-entry mechanism); the legacy `repo.task.run` read mapping is retired rather than wrapped; serving-read catch-up is removed, not cached around.
- No consistency change: writes keep the single-write queue; reads still see only complete cuts (old or new, never partial); the remaining `readTaskCompletion()` catch-up is writer-side admission recovery, not a serving read.
- Multi-node: no new writer, queue, claim, or cache; the read method is a pure serving path on the existing center.

## What Changed

- `agent-runtime-installation-discovery.ts` / `agent-runtime-instance-store.ts`: async parallel probes via process port; coalesced refresh; pre-command explicit refresh.
- Protocol: new closed `repo.task.read` method; all 42 `repo-read` descriptors re-registered; RepoCell executes them post-admission without the publication tail.
- `rebuildable-task-projection-*`: serving queries are query-only against the persisted cut; writer persists cut digest transactionally; GUI task list reads page-scoped dependency closure.
- Logging: `dispatchDelayMs`/`serviceMs` + three timestamps in conn/request JSONL.
- `local-composition-root.ts`: response timeout lands in the response-timeout parameter.
- New isolated performance regression test (idle vs loaded p95, strict ≤2× assertion) + updated targeted suites.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: tools/gate-allowlists/sync-subprocess-baseline.mjs entries sync-subprocess-001/002 (their exempted execFileSync import/call are deleted by this PR; the ratchet itself demands stale entries be removed rather than transferred)

## Machine-Readable Declarations

Production-Delta: +648/-354
Dependency-Change: none

### Optional Evidence Claims

None.

## Task And Scope

- Harness task: `task_816635cdd397f8121de1276ea1` (derives from `dec_D129859E` CH2; diagnosis evidence F-9E135343; acceptance observation F-E9E18EF0)
- Branch: `codex/read-stopgap`
- Public scope: daemon read-path stopgap + instrumentation; no CLI entrypoint, thin-command, config, or CI/gate-script change.
- Private planning/evidence: `artifacts/read-stopgap-before-after.md` (probe data and per-cut static evidence).

## Version Impact

- Version: no change. Publish impact: none.

## Governance Declaration

- Protected surface touched: yes — two stale entries removed from `sync-subprocess-baseline.mjs`, both exempting exactly the synchronous calls this PR deletes; the gate reports them as "stale baseline entry; remove it rather than transferring the exemption", so this is the ratchet's own required cleanup, executed by the CEO (worker correctly stopped per the task's CI/Gate stop condition). No gate script or threshold changed.
- Authority: task_816635cdd397f8121de1276ea1 + dec_D129859E (CH2) + the sync-subprocess ratchet's stale-entry contract.
- Break-glass: no

## Verification

- Worker (isolated Ubuntu): targeted fast 133/133; task-projection integration 25/25; JSON-RPC protocol integration 53/53; performance regression 1/1 (table above); typecheck; implementation-contract gate 129→129; walls 12/12; `git diff --check` clean.
- Before-state reproduced on the live daemon under natural write load: workspace summary p95 59.8s, task list p95 17.9s (long-tail confirmation only; acceptance uses the controlled same-fixture comparison).
- CEO: rebase onto `2b7550881`; `check-sync-subprocess` green after stale-entry removal; line-density/delta re-verified.
- [ ] Full suites: GitHub CI is the authority.

## Review Evidence

- CEO semantic review: the three cuts map one-to-one onto the diagnosis's proven hotspots; no linearization exception hides in serving reads (writer-side catch-ups are admission recovery); discovery visibility semantics preserved via explicit pre-command refresh; residuals (WAL/Git materialization, pure-read mutual blocking) are honestly routed to decision C's implementation input, not patched here.

## Residual Risk

- WAL/Git materialization and projection attach/rebuild remain synchronous on the main loop; slow reads can still block each other. Both are decision C's implementation scope (task_4f51ac90, dispatch after this merges).

---

# 中文

## 概要

读写分离诊断的 **B 方案单进程止血**(dec_D129859E CH2 排序)。诊断已证:GUI 读不排 RepoCell 写队列,但与同步写工作共享 daemon 主事件循环(实测 doc-submit/runtime-spawn 期间 13.6s/30.8s 全 daemon 事件空洞);CLI legacy reads(注册为 `repo.task.run`)真实排写 tail;serving read 自身还有 catch-up 写放大与宽聚合。本 PR 落三刀:①runtime 可执行探测改 async 并行(process port),并发刷新合并单飞,命令前显式刷新保安装可见性;②42 个 `repo-read` descriptor 全部脱离 `repo.task.run`,走新的封闭 `repo.task.read`,admission/state 检查后直接执行不进 publication tail(method/action 错配拒绝;运行时枚举证明 0 残留);③projection serving read 不再做 catch-up 写——只读 `{watermark, sourceRevision, status}`,返回完整旧 cut 或完整新 cut,writer 在同一 SQLite 事务持久化完整 cut digest;GUI task 聚合收窄到当前页依赖闭包。conn/request 日志新增三时间戳与 `dispatchDelayMs`/`serviceMs`;修正 GUI client 200ms response timeout 传错参数位。

受控验收(隔离 daemon + 真实 spawn 写在飞):三个固定 read payload 的 loaded p95 全部 1ms,对 idle p95 2–3ms 为 **0.33–0.5×**,远优于 decision 的 ≤2× 阈值;回归测试永久断言 `loaded p95 <= 2 * idle p95`。

## 架构辩护

- 机制句:「不排队」≠「隔离」——读面与写者共享执行上下文时,任何同步写工作都是全局读停摆;本止血删除已知同步热点与写放大读,不发明半套隔离(硬隔离归 dec_D129859E,实现任务已立)。
- 删除优先:同步 `execFileSync` 探测删除(其两条 sync-subprocess 基线豁免按棘轮自身 stale 机制移除);legacy run 映射退役而非包装;serving catch-up 删除而非加缓存。
- 一致性零变化:写仍单写队列;读只见完整 cut;残余的 writer 侧 catch-up 是 admission 恢复,非 serving read。

## 改动内容

见英文节;新增隔离性能回归测试(idle vs loaded p95,严格 ≤2× 断言)。

## 门收割 / Gate Harvest

- 删除 gate 数据:sync-subprocess-baseline 001/002(豁免对象即本 PR 删除的同步调用;棘轮要求删条目而非转移豁免)。

## 机读声明说明

`Production-Delta` 由 gate 实测(+648/-354)。

## 任务与范围

- Task `task_816635cdd397f8121de1276ea1`(derives 自 dec_D129859E CH2;诊断证据 F-9E135343;验收观测 F-E9E18EF0);分支 `codex/read-stopgap`。

## 版本影响

- 不改版本、不发布。

## 治理声明

- 触碰受保护面:是——移除 sync-subprocess-baseline 两条 stale 条目(门自报「stale baseline entry; remove it」,棘轮自身机制;worker 按任务停止条件停手,由 CEO 执行);未改任何门脚本或阈值。授权=task_816635cd + dec_D129859E CH2 + 棘轮 stale 契约;非 break-glass。

## 验证

- worker 隔离 Ubuntu:定向 fast 133/133、projection 集成 25/25、JSON-RPC 协议集成 53/53、性能回归 1/1、typecheck、implementation-contract 129 持平、walls 12/12、diff-check 干净;改前现场长尾复测(p95 59.8s/17.9s)只作症状确认。
- CEO:rebase 2b7550881;stale 清理后 check-sync-subprocess 绿;line-density/delta 复验。
- 完整权威=GitHub CI。

## 审查证据

- CEO 语义验收:三刀与诊断实证热点一一对应;serving read 无线性化例外;发现可见性语义保全;残余(WAL/Git、纯读互阻)诚实归 C 实现输入未打补丁。

## 残余风险

- WAL/Git 落盘与 projection attach/rebuild 仍在主循环同步;慢读间仍可互阻——均属 C 实现范围(task_4f51ac90,本 PR 合并后即派)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VTzQAqvuFy6ikGjBKxA9xj
