### PR TITLE
fix(daemon): attribute task action failures exactly

### DIFF
--- a/packages/daemon/src/agent-entities.ts
+++ b/packages/daemon/src/agent-entities.ts
@@ -1,6 +1,12 @@
 import { existsSync, lstatSync, readFileSync } from "node:fs";
 import path from "node:path";
-import { consumeKnownError, openEntityStore, type EntityStore, type TaskProjection } from "../../kernel/src/index.ts";
+import {
+  attributeEntityActionCriterion,
+  consumeKnownError,
+  openEntityStore,
+  type EntityStore,
+  type TaskProjection,
+} from "../../kernel/src/index.ts";
 import {
   entitySlug,
   parseAgentDeclarationV1,
@@ -356,14 +362,18 @@ export function prepareAgentEntityInstall(input: {
   const decoded = declarationSource(input.action),
     source = decoded.source ?? "runtime-result";
   if ("issues" in decoded)
-    throw entityError(
+    throw agentInstallError(
+      kind,
       decoded.issues[0]?.code ?? "invalid_entity_package",
       decoded.issues[0]?.message ?? "Entity package is invalid.",
+      "agent/declaration-schema",
     );
   if (input.action.generatedOnly === true && input.action.validated !== true)
-    throw entityError(
+    throw agentInstallError(
+      kind,
       "agent_validation_required",
       "Generated Agent output must pass ha agent validate before install; rerun ha agent create so the harness can validate the structured declaration.",
+      "agent/generated-validation",
     );
   const declaration = decoded.declaration,
     current = repairableStoredDeclaration(input.entityStore ?? openEntityStore(input.rootDir), kind, declaration.id);
@@ -377,10 +387,12 @@ export function prepareAgentEntityInstall(input: {
     input.replay !== true &&
     (current.workspaceRevision ?? 0) !== Number(input.action.expectedVersion)
   )
-    throw entityError(
+    throw agentInstallError(
+      kind,
       "revision_conflict",
       `${kind} ${declaration.id} expected revision ${String(input.action.expectedVersion)}, ` +
         `current revision is ${String(current.workspaceRevision ?? 0)}.`,
+      "agent/entity-revision",
     );
   if (input.action.generatedOnly === true && current.exists && input.replay !== true)
     throw generatedAgentConflict(declaration.id);
@@ -568,9 +580,11 @@ function entityError(code: string, message: string): Error & { readonly code: st
   return Object.assign(new Error(message), { code });
 }
 function generatedAgentConflict(id: string): Error & { readonly code: string } {
-  return entityError(
+  return agentInstallError(
+    "agent",
     "agent_id_conflict",
     `Agent ${id} already exists; run ha agent inspect ${id}, choose a different id, and retry ha agent create.`,
+    "agent/generated-identity",
   );
 }
 function admitGeneratedAgent(
@@ -582,17 +596,33 @@ function admitGeneratedAgent(
   const available = (runtimeInstances ?? []).filter((instance) => instance.enabled),
     compatible = available.filter((instance) => agent.runtime_type === "any" || instance.kindId === agent.runtime_type);
   if (compatible.length === 0)
-    throw entityError(
+    throw agentInstallError(
+      "agent",
       "agent_runtime_type_unavailable",
       `Agent ${agent.id} requires runtime_type ${
         agent.runtime_type
       }, but no enabled instance provides it; run ha runtime instance list, change runtime_type to any or a listed kind, and retry ha agent create.`,
+      "agent/runtime-compatibility",
     );
   if (agent.model !== undefined && !compatible.some((instance) => instance.models.includes(agent.model!)))
-    throw entityError(
+    throw agentInstallError(
+      "agent",
       "agent_model_unavailable",
       `Agent ${agent.id} requests model ${
         agent.model
       }, but no compatible enabled instance supports it; run ha runtime instance list, remove model to use the instance default or choose a listed model, and retry ha agent create.`,
+      "agent/model-compatibility",
     );
+}
+
+function agentInstallError(
+  kind: AgentEntityKind,
+  code: string,
+  message: string,
+  criterionRef: string,
+): Error & { readonly code: string } {
+  const error = entityError(code, message);
+  return kind === "agent"
+    ? (attributeEntityActionCriterion(error, "install", criterionRef) as Error & { readonly code: string })
+    : error;
 }

--- a/packages/daemon/src/entity-action-catalog-executor.ts
+++ b/packages/daemon/src/entity-action-catalog-executor.ts
@@ -36,6 +36,7 @@ import {
 } from "../../kernel/src/index.ts";
 import { prepareDecisionAmend, validateDecisionPackages } from "./decision-surface-actions.ts";
 import { unknownFieldViolation } from "./protocol/json-rpc-types.ts";
+import { actionCriterionFailureOfReceipt } from "./repo-cell-settlement.ts";
 import type { RepoCellBinding, RepoTaskAction } from "./repo-cell-types.ts";
 import {
   commitRuntimeSessionBundle,
@@ -472,10 +473,17 @@ export function deriveActionResult(
         : targetIdField && typeof receiptFields[targetIdField] === "string"
           ? receiptFields[targetIdField]
           : null,
-    inferredCriteria = contract.criteria.filter((criterion) => criterion.failureCode === receipt.code),
-    unmetCriteria: readonly EntityActionUnmetCriterionV1[] = rejected
-      ? (receipt.unmetCriteria ?? (inferredCriteria.length === 1 ? inferredCriteria : []))
+    attributedFailure = actionCriterionFailureOfReceipt(receipt),
+    attributedRefs = attributedFailure
+      ? attributedFailure.actionId === contract.id
+        ? [attributedFailure.criterionRef]
+        : invalidCriterionAttribution(contract, attributedFailure.actionId, attributedFailure.criterionRef)
       : [],
+    criterionRefs = receipt.unmetCriteria?.map(({ ref }) => ref) ?? attributedRefs,
+    unmetCriteria: readonly EntityActionUnmetCriterionV1[] =
+      receipt.outcome === "op_rejected"
+        ? criterionRefs.map((criterionRef) => resolveActionCriterion(contract, criterionRef))
+        : [],
     explanation = rejected
       ? (unmetCriteria[0]?.explain ??
         receipt.nextAction ??
@@ -495,10 +503,37 @@ export function deriveActionResult(
             revision: receipt.revision ?? null,
           },
     rejectionExplanation: explanation,
-    nextActions: Object.freeze([
-      ...new Set([...(receipt.nextActions ?? []), ...(receipt.nextAction ? [receipt.nextAction] : [])]),
-    ]),
+    nextActions: Object.freeze(
+      unmetCriteria.length > 0
+        ? [
+            ...new Set([
+              ...(receipt.nextActions ?? []),
+              ...(!attributedFailure && receipt.nextAction ? [receipt.nextAction] : []),
+              ...(attributedFailure?.nextActions ?? []),
+            ]),
+          ]
+        : [...new Set([...(receipt.nextActions ?? []), ...(receipt.nextAction ? [receipt.nextAction] : [])])],
+    ),
   };
+}
+
+function resolveActionCriterion(contract: EntityActionContract, criterionRef: string): EntityActionUnmetCriterionV1 {
+  const criterion = contract.criteria.find(({ ref }) => ref === criterionRef);
+  if (!criterion)
+    throw Object.assign(
+      new Error(`Action ${contract.target.kind}.${contract.id} does not declare criterion ${criterionRef}.`),
+      { code: "invalid_store" },
+    );
+  return { ref: criterion.ref, failureCode: criterion.failureCode, explain: criterion.explain };
+}
+
+function invalidCriterionAttribution(contract: EntityActionContract, actionId: string, criterionRef: string): never {
+  throw Object.assign(
+    new Error(
+      `Action ${contract.target.kind}.${contract.id} received criterion ${criterionRef} attributed to ${actionId}.`,
+    ),
+    { code: "invalid_store" },
+  );
 }
 
 function reclassificationAction(

--- a/packages/daemon/src/repo-cell-errors.ts
+++ b/packages/daemon/src/repo-cell-errors.ts
@@ -1,20 +1,14 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
-import { VcsCommandError, normalizeDomainError } from "../../kernel/src/index.ts";
+import {
+  VcsCommandError,
+  attributeEntityActionCriterion,
+  entityActionCriterionFailure,
+  normalizeDomainError,
+  type EntityActionCriterionFailure,
+} from "../../kernel/src/index.ts";
 
-const ACTION_CRITERION_FAILURE = Symbol("action-criterion-failure");
-
-export interface CellActionCriterionFailure {
-  readonly actionId: string;
-  readonly criterionRef: string;
-  readonly nextActions: readonly string[];
-}
-
-type CriterionError = Error & {
-  readonly code?: string;
-  readonly opId?: string;
-  readonly [ACTION_CRITERION_FAILURE]?: CellActionCriterionFailure;
-};
+export type CellActionCriterionFailure = EntityActionCriterionFailure;
 
 export function cellCodedError(code: string, text: string): Error {
   const error = new Error(text) as Error & { code: string };
@@ -38,21 +32,12 @@ export function attributeCellCriterion(
   criterionRef: string,
   nextActions: readonly string[] = [],
 ): Error {
-  const attributed =
-    error instanceof Error
-      ? (error as CriterionError)
-      : (cellCodedError(cellErrorCode(error), cellErrorMessage(error)) as CriterionError);
-  Object.defineProperty(attributed, ACTION_CRITERION_FAILURE, {
-    configurable: false,
-    enumerable: false,
-    value: Object.freeze({ actionId, criterionRef, nextActions: Object.freeze([...nextActions]) }),
-  });
-  return attributed;
+  const attributed = error instanceof Error ? error : cellCodedError(cellErrorCode(error), cellErrorMessage(error));
+  return attributeEntityActionCriterion(attributed, actionId, criterionRef, nextActions);
 }
 
 export function actionCriterionFailure(error: unknown): CellActionCriterionFailure | null {
-  if (!(error instanceof Error)) return null;
-  return (error as CriterionError)[ACTION_CRITERION_FAILURE] ?? null;
+  return entityActionCriterionFailure(error);
 }
 
 export function unavailableRuntimeInstanceStore(): never {

--- a/packages/daemon/src/repo-cell-errors.ts
+++ b/packages/daemon/src/repo-cell-errors.ts
@@ -2,10 +2,57 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { VcsCommandError, normalizeDomainError } from "../../kernel/src/index.ts";
 
+const ACTION_CRITERION_FAILURE = Symbol("action-criterion-failure");
+
+export interface CellActionCriterionFailure {
+  readonly actionId: string;
+  readonly criterionRef: string;
+  readonly nextActions: readonly string[];
+}
+
+type CriterionError = Error & {
+  readonly code?: string;
+  readonly opId?: string;
+  readonly [ACTION_CRITERION_FAILURE]?: CellActionCriterionFailure;
+};
+
 export function cellCodedError(code: string, text: string): Error {
   const error = new Error(text) as Error & { code: string };
   error.code = code;
   return error;
+}
+
+export function cellCriterionError(
+  code: string,
+  text: string,
+  actionId: string,
+  criterionRef: string,
+  nextActions: readonly string[] = [],
+): Error {
+  return attributeCellCriterion(cellCodedError(code, text), actionId, criterionRef, nextActions);
+}
+
+export function attributeCellCriterion(
+  error: unknown,
+  actionId: string,
+  criterionRef: string,
+  nextActions: readonly string[] = [],
+): Error {
+  const attributed =
+    error instanceof Error
+      ? (error as CriterionError)
+      : (cellCodedError(cellErrorCode(error), cellErrorMessage(error)) as CriterionError);
+  Object.defineProperty(attributed, ACTION_CRITERION_FAILURE, {
+    configurable: false,
+    enumerable: false,
+    value: Object.freeze({ actionId, criterionRef, nextActions: Object.freeze([...nextActions]) }),
+  });
+  return attributed;
+}
+
+export function actionCriterionFailure(error: unknown): CellActionCriterionFailure | null {
+  if (!(error instanceof Error)) return null;
+  return (error as CriterionError)[ACTION_CRITERION_FAILURE] ?? null;
 }
 
 export function unavailableRuntimeInstanceStore(): never {

--- a/packages/daemon/src/repo-cell-execution-selection.ts
+++ b/packages/daemon/src/repo-cell-execution-selection.ts
@@ -1,13 +1,11 @@
 import {
   approvedReviewsForCut,
-  canStartExecution,
   closeoutReadiness,
-  currentExecutionCuts,
   currentSubmittedExecutions,
-  type TaskLifecycleCommand,
+  getExecutableEntityAction,
+  taskActionUsage,
 } from "../../kernel/src/index.ts";
-import { cellCodedError } from "./repo-cell-errors.ts";
-import { actorHint } from "./repo-cell-proof.ts";
+import { cellCodedError, cellCriterionError } from "./repo-cell-errors.ts";
 import { cellStringList, requiredCellText } from "./repo-cell-settlement.ts";
 import type { RepoTaskAction, Snapshot } from "./repo-cell-types.ts";
 
@@ -120,30 +118,14 @@ export function completeExecutionId(action: RepoTaskAction, snapshot: Snapshot, 
   if (supplied !== undefined) return supplied;
   const assessed = closeoutReadiness(snapshot);
   if (assessed.executionId !== undefined) return assessed.executionId;
-  const suffix = [
-    "",
-    `${action.ci === "passed" ? " --ci passed" : ""}`,
-    "",
-    `${cellStringList(action.paths)
-      .map((value) => ` --path ${value}`)
-      .join("")}`,
-    `${factHoldsFlags(action.factHolds)}`,
-    "",
-  ].join("");
-  return rejectExecutionSelection(
-    currentExecutionCuts(snapshot),
-    "Closeout execution",
-    [
-      "Run ha task show ",
-      `${taskId}`,
-      "; reach one submitted current-iteration execution before retrying ha ",
-      "task complete ",
-      `${taskId}`,
-      "",
-      `${suffix}`,
-      ".",
-    ].join(""),
-    (candidate) => `ha task complete ${taskId} --execution-id ${candidate}${suffix}`,
+  const contract = getExecutableEntityAction("task-complete");
+  if (!contract) throw cellCodedError("invalid_store", "Task complete is missing from the Action catalog.");
+  throw cellCriterionError(
+    "invalid_command",
+    "Task complete could not select one current closeout execution.",
+    "complete",
+    "closeout-readiness/closeoutReadiness",
+    [taskActionUsage(contract, taskId)],
   );
 }
 
@@ -175,77 +157,4 @@ function factHoldsFlags(value: unknown): string {
       return [` --fact-holds ${factId}:${JSON.stringify(row.rationale)}`];
     })
     .join("");
-}
-
-export function submitLeaseRequiredMessage(
-  command: Extract<TaskLifecycleCommand, { readonly type: "SubmitExecution" }>,
-  snapshot: Snapshot,
-): string {
-  const execution = snapshot.executions.find((candidate) => candidate.executionId === command.executionId);
-  if (execution?.submission)
-    return [
-      "Execution ",
-      `${command.executionId}`,
-      " is already submitted; run ha task review-execution ",
-      `${command.taskId}`,
-      " --execution-id ",
-      `${command.executionId}`,
-      " --review-id <review-id> --from-file <review.json>.",
-    ].join("");
-  const lease = snapshot.lease,
-    submit = `ha task submit ${command.taskId} --json-input '<submission-json>'`;
-  if (lease?.phase === "held")
-    return [
-      "Submit requires the active execution lease; the authenticated holder (",
-      `${actorHint(lease.actor)}`,
-      ") must run ",
-      `${submit}`,
-      ", or ha task release ",
-      `${command.taskId}`,
-      ".",
-    ].join("");
-  if (lease?.phase === "orphaned")
-    return [
-      "Submit requires the active execution lease; the lease for execution ",
-      `${lease.executionId}`,
-      " lapsed at ",
-      `${lease.expiresAt}`,
-      "; run ha task release ",
-      `${command.taskId}`,
-      ", then ha task start ",
-      `${command.taskId}`,
-      " --execution-id ",
-      `${lease.executionId}`,
-      ", then retry ",
-      `${submit}`,
-      ".",
-    ].join("");
-  if (lease?.phase === "reserving")
-    return [
-      "Submit requires the active execution lease; wait for the reservation for ",
-      "execution ",
-      `${lease.executionId}`,
-      " to publish or lapse at ",
-      `${lease.expiresAt}`,
-      ", then retry ",
-      `${submit}`,
-      ".",
-    ].join("");
-  if (canStartExecution(snapshot, command.executionId))
-    return [
-      "Submit requires the active execution lease; run ha task start ",
-      `${command.taskId}`,
-      " --execution-id ",
-      `${command.executionId}`,
-      ", then retry ",
-      `${submit}`,
-      ".",
-    ].join("");
-  return [
-    "Submit requires the active execution lease; run ha task show ",
-    `${command.taskId}`,
-    ", then follow the next lifecycle command reported for execution ",
-    `${command.executionId}`,
-    ".",
-  ].join("");
 }

--- a/packages/daemon/src/repo-cell-proof.ts
+++ b/packages/daemon/src/repo-cell-proof.ts
@@ -4,6 +4,7 @@ import {
   codeDocRecordId,
   consentedApprovedReview,
   currentCodeDocWitness,
+  evaluateTaskActionCapability,
   heldLeaseForExecutionActor,
   getTaskActionForTransition,
   isIndependentFrom,
@@ -98,13 +99,29 @@ export async function proofFor(
       execution = snapshot.executions.find(
         (candidate) => candidate.executionId === command.executionId && candidate.submission !== null,
       ),
-      authorizationDecision = requiredAuthorizationDecision(binding);
+      authorizationDecision = requiredAuthorizationDecision(binding),
+      reviewCriterion = lifecycleAction
+        ? evaluateTaskActionCapability({
+            action: lifecycleAction,
+            snapshot,
+            actor: command.actor,
+            invocation: {
+              taskId: command.taskId,
+              executionId: command.executionId,
+              reviewId: command.reviewId,
+              runtimeTaskBound: runtimeBinding !== null,
+            },
+          }).find(({ criterionRef }) => criterionRef === REVIEW_PROOF_CRITERION)
+        : undefined;
+    if (!reviewCriterion)
+      throw new Error(`Task review criterion ${REVIEW_PROOF_CRITERION} has no capability evaluation.`);
     if (runtimeBinding !== null)
       throw cellCriterionError(
         "runtime_task_self_review_forbidden",
         "Task review runtime-binding independence proof was not satisfied.",
         "review",
         REVIEW_PROOF_CRITERION,
+        reviewCriterion.nextActions,
       );
     if (execution === undefined || !isIndependentFrom(execution.actor, command.actor)) {
       throw cellCriterionError(
@@ -112,6 +129,7 @@ export async function proofFor(
         "Task review actor independence proof was not satisfied.",
         "review",
         REVIEW_PROOF_CRITERION,
+        reviewCriterion.nextActions,
       );
     }
     return {

--- a/packages/daemon/src/repo-cell-proof.ts
+++ b/packages/daemon/src/repo-cell-proof.ts
@@ -20,11 +20,15 @@ import {
   type TaskLifecycleCommand,
   type WriteReceipt,
 } from "../../kernel/src/index.ts";
-import { cellCodedError } from "./repo-cell-errors.ts";
+import { cellCodedError, cellCriterionError } from "./repo-cell-errors.ts";
 import { verifyCodeDocCommitPaths } from "./code-doc-path-verification.ts";
-import { submitLeaseRequiredMessage } from "./repo-cell-execution-selection.ts";
 import type { PublicPublication, RepoCellBinding, RepoTaskAction, Snapshot } from "./repo-cell-types.ts";
 import { leaseTtlMs } from "./repo-cell-types.ts";
+
+const START_VALIDATION_CRITERION = "task-lifecycle-command-transitions/start.validate";
+const SUBMIT_LEASE_CRITERION = "actor-domain-services/heldLeaseForExecutionActor";
+const REVIEW_PROOF_CRITERION = "repo-cell-proof/proofFor.RecordReview";
+const COMPLETE_VALIDATION_CRITERION = "task-lifecycle-review-transitions/complete.validate";
 
 export async function proofFor(
   command: TaskLifecycleCommand,
@@ -42,7 +46,12 @@ export async function proofFor(
       executionId = commandFields[lifecycleExecution.targetIdField],
       ttlMs = typeof commandFields.ttlMs === "number" ? commandFields.ttlMs : leaseTtlMs;
     if (typeof executionId !== "string")
-      throw cellCodedError("invalid_command", `${lifecycleExecution.commandType} requires a target entity id.`);
+      throw cellCriterionError(
+        "invalid_command",
+        `${lifecycleExecution.commandType} requires a target entity id.`,
+        "start",
+        START_VALIDATION_CRITERION,
+      );
     const authorizationDecision = requiredAuthorizationDecision(binding);
     return {
       actorBinding: command.actor,
@@ -61,7 +70,13 @@ export async function proofFor(
   if (command.type === "TransitionTask") return {};
   if (command.type === "SubmitExecution") {
     const lease = heldLeaseForExecutionActor(snapshot, command.executionId, command.actor);
-    if (!lease) throw cellCodedError("lease_required", submitLeaseRequiredMessage(command, snapshot));
+    if (!lease)
+      throw cellCriterionError(
+        "lease_required",
+        "Task submit lease proof was not satisfied.",
+        "submit",
+        SUBMIT_LEASE_CRITERION,
+      );
     return {
       actorBinding: command.actor,
       leaseVersion: lease.version,
@@ -85,39 +100,18 @@ export async function proofFor(
       ),
       authorizationDecision = requiredAuthorizationDecision(binding);
     if (runtimeBinding !== null)
-      throw cellCodedError(
+      throw cellCriterionError(
         "runtime_task_self_review_forbidden",
-        [
-          "This runtime is bound to task ",
-          `${command.taskId}`,
-          " and execution ",
-          `${command.executionId}`,
-          " and cannot review its own work; have an independent human or a runtime ",
-          "with no binding to this task and execution run ha task review-execution ",
-          `${command.taskId}`,
-          " --execution-id ",
-          `${command.executionId}`,
-          " --review-id ",
-          `${command.reviewId}`,
-          " --from-file <review.json>.",
-        ].join(""),
+        "Task review runtime-binding independence proof was not satisfied.",
+        "review",
+        REVIEW_PROOF_CRITERION,
       );
     if (execution === undefined || !isIndependentFrom(execution.actor, command.actor)) {
-      const undeclared = execution?.actor.executor === null && command.actor.executor === null;
-      throw cellCodedError(
+      throw cellCriterionError(
         "actor_unauthorized",
-        undeclared
-          ? [
-              "Execution Review requires a reviewer independent of the submitter: the ",
-              "submitted execution's original start declared no executor, so only a ",
-              "different person can review it. Run ha task declare-executor with that ",
-              "principal and an agent executor to record an auditable recovery before ",
-              "same-person review.",
-            ].join("")
-          : [
-              "Execution Review requires a reviewer independent of the submitting executor; ",
-              "review without declaring that executor.",
-            ].join(""),
+        "Task review actor independence proof was not satisfied.",
+        "review",
+        REVIEW_PROOF_CRITERION,
       );
     }
     return {
@@ -209,19 +203,37 @@ export function completeProof(
   binding: RepoCellBinding,
 ): ProofFor<CompleteTaskCommand> & { readonly authorizationDecision: AuthorizationDecision } {
   if (snapshot.lease !== null)
-    throw cellCodedError("active_lease", "Complete requires the execution lease to be released.");
+    throw cellCriterionError(
+      "active_lease",
+      "Task completion lease-release proof was not satisfied.",
+      "complete",
+      COMPLETE_VALIDATION_CRITERION,
+    );
   const authorizationDecision = requiredAuthorizationDecision(binding);
   if (!snapshot.task || !isSamePerson(snapshot.task.createdBy, command.actor))
-    throw cellCodedError("actor_unauthorized", "Complete requires the Execution owner principal.");
+    throw cellCriterionError(
+      "actor_unauthorized",
+      "Task completion owner proof was not satisfied.",
+      "complete",
+      COMPLETE_VALIDATION_CRITERION,
+    );
   const execution = snapshot.executions.find(
     (candidate) => candidate.executionId === command.executionId && candidate.submission !== null,
   );
-  if (!execution?.submission) throw cellCodedError("invalid_transition", "Complete requires a submitted execution.");
+  if (!execution?.submission)
+    throw cellCriterionError(
+      "invalid_transition",
+      "Task completion submitted-execution proof was not satisfied.",
+      "complete",
+      COMPLETE_VALIDATION_CRITERION,
+    );
   const supplied = canonicalGateReceipts(snapshot, execution);
   if (supplied.length !== requiredGateWitnessCount(snapshot, execution))
-    throw cellCodedError(
+    throw cellCriterionError(
       "gate_witness_missing",
-      "Every applicable completion gate requires a canonical typed witness; local receipt files are not authoritative.",
+      "Task completion canonical gate-witness proof was not satisfied.",
+      "complete",
+      COMPLETE_VALIDATION_CRITERION,
     );
   return {
     capability: "task-complete@v1",

--- a/packages/daemon/src/repo-cell-settlement.ts
+++ b/packages/daemon/src/repo-cell-settlement.ts
@@ -79,7 +79,7 @@ export function completionStopped(
 ): WriteReceipt {
   const receipt = failed(
     opId,
-    cellCriterionError(blocker.code, blocker.next.reason, "complete", "closeout-readiness/closeoutReadiness", [
+    cellCriterionError(blocker.code, blocker.next.command, "complete", "closeout-readiness/closeoutReadiness", [
       blocker.next.command,
     ]),
   );

--- a/packages/daemon/src/repo-cell-settlement.ts
+++ b/packages/daemon/src/repo-cell-settlement.ts
@@ -4,9 +4,18 @@ import {
   type TaskProgressEvidence,
   type WriteReceiptDraft as WriteReceipt,
 } from "../../kernel/src/index.ts";
-import { cellCodedError, cellErrorCode, cellErrorMessage } from "./repo-cell-errors.ts";
+import {
+  actionCriterionFailure,
+  cellCodedError,
+  cellCriterionError,
+  cellErrorCode,
+  cellErrorMessage,
+  type CellActionCriterionFailure,
+} from "./repo-cell-errors.ts";
 import { gateChecks, selectedReviewId } from "./repo-cell-proof.ts";
 import type { Snapshot } from "./repo-cell-types.ts";
+
+const criterionFailureByReceipt = new WeakMap<object, CellActionCriterionFailure>();
 
 export function completionApplied(
   receipt: WriteReceipt,
@@ -43,8 +52,9 @@ export function completionSettlement(
           ? "Wait for canonical settlement, then query this receipt."
           : "Resolve the rejected canonical step before retrying completion.",
     state = `${snapshot.task?.status ?? "missing"}/${snapshot.task?.currentNode ?? "missing"}`;
-  return {
+  const settled = {
     ...receipt,
+    ...(receipt.outcome === "pending" || receipt.outcome === "indeterminate" ? { unmetCriteria: [] } : {}),
     taskId: snapshot.task?.taskId,
     executionId,
     reviewId: selectedReviewId(snapshot, executionId),
@@ -57,6 +67,7 @@ export function completionSettlement(
     steps,
     stoppedAt,
   } as WriteReceipt;
+  return carryActionCriterionFailure(receipt, settled);
 }
 
 export function completionStopped(
@@ -66,8 +77,14 @@ export function completionStopped(
   blocker: ReturnType<typeof completionBlockers>[number],
   steps: readonly WriteReceipt[],
 ): WriteReceipt {
-  return {
-    ...rejected(opId, blocker.code, blocker.next.command),
+  const receipt = failed(
+    opId,
+    cellCriterionError(blocker.code, blocker.next.reason, "complete", "closeout-readiness/closeoutReadiness", [
+      blocker.next.command,
+    ]),
+  );
+  return carryActionCriterionFailure(receipt, {
+    ...receipt,
     taskId: snapshot.task?.taskId,
     executionId,
     reviewId: selectedReviewId(snapshot, executionId),
@@ -79,7 +96,7 @@ export function completionStopped(
     next: [blocker.next],
     steps,
     stoppedAt: blocker.code,
-  } as WriteReceipt;
+  } as WriteReceipt);
 }
 
 export function rejected(opId: string, code: string, nextAction: string): WriteReceipt {
@@ -95,19 +112,33 @@ export function rejected(opId: string, code: string, nextAction: string): WriteR
 
 export function failed(opId: string, error: unknown): WriteReceipt {
   const code = cellErrorCode(error);
-  return error instanceof VcsCommandError || code === "publication_indeterminate"
-    ? {
-        outcome: "indeterminate",
-        opId,
-        code,
-        origin: error instanceof VcsCommandError ? error.origin : "daemon",
-        evidence: error instanceof VcsCommandError ? `git-failure:${error.command}` : "publication-cut:indeterminate",
-        nextAction:
-          error instanceof VcsCommandError
-            ? `repair the Git object store and retry: ${error.message}`
-            : cellErrorMessage(error),
-      }
-    : rejected(opId, code, cellErrorMessage(error));
+  const receipt: WriteReceipt =
+    error instanceof VcsCommandError || code === "publication_indeterminate"
+      ? {
+          outcome: "indeterminate",
+          opId,
+          code,
+          origin: error instanceof VcsCommandError ? error.origin : "daemon",
+          evidence: error instanceof VcsCommandError ? `git-failure:${error.command}` : "publication-cut:indeterminate",
+          nextAction:
+            error instanceof VcsCommandError
+              ? `repair the Git object store and retry: ${error.message}`
+              : cellErrorMessage(error),
+        }
+      : rejected(opId, code, cellErrorMessage(error));
+  const criterionFailure = actionCriterionFailure(error);
+  if (criterionFailure !== null) criterionFailureByReceipt.set(receipt, criterionFailure);
+  return receipt;
+}
+
+export function actionCriterionFailureOfReceipt(receipt: WriteReceipt): CellActionCriterionFailure | null {
+  return criterionFailureByReceipt.get(receipt) ?? null;
+}
+
+function carryActionCriterionFailure(source: WriteReceipt, target: WriteReceipt): WriteReceipt {
+  const criterionFailure = criterionFailureByReceipt.get(source);
+  if (criterionFailure !== undefined) criterionFailureByReceipt.set(target, criterionFailure);
+  return target;
 }
 
 export function requiredCellText(value: unknown, name: string): string {

--- a/packages/daemon/src/settings-action-runtime.ts
+++ b/packages/daemon/src/settings-action-runtime.ts
@@ -1,5 +1,6 @@
 import {
   SETTINGS_ID,
+  attributeEntityActionCriterion,
   isSettingsEvent,
   settingsActionLocale,
   type EntityActionCompileInput,
@@ -215,9 +216,13 @@ async function assertCatalogSelection(rootDir: string, settings: SettingsV1): Pr
     preset = presets.find((row) => row.id === settings.defaultPreset && row.verticalId === settings.defaultVertical),
     selection = [settings.defaultVertical, settings.defaultPreset, settings.defaultProfile].join("/");
   if (preset?.validity !== "valid" || !preset.profiles?.some((profile) => profile.id === settings.defaultProfile))
-    throw Object.assign(new Error(`Settings selection ${selection} is not a valid catalog preset profile.`), {
-      code: "invalid_settings_catalog_selection",
-    });
+    throw attributeEntityActionCriterion(
+      Object.assign(new Error(`Settings selection ${selection} is not a valid catalog preset profile.`), {
+        code: "invalid_settings_catalog_selection",
+      }),
+      "update",
+      "settings/catalog-selection",
+    );
 }
 
 interface SettingsCatalogPreset {

--- a/packages/daemon/src/task-action-catalog-runtime.ts
+++ b/packages/daemon/src/task-action-catalog-runtime.ts
@@ -3,16 +3,19 @@ import {
   evaluateTaskActionCapability,
   getExecutableEntityAction,
   heldLeaseForExecutionActor,
-  isTerminalStatus,
   revisionIssues,
   type EntityActionContract,
   type EntityActionUnmetCriterionV1,
   type TaskLifecycleCommand,
   type WriteReceiptDraft as WriteReceipt,
 } from "../../kernel/src/index.ts";
-import { actorHint } from "./repo-cell-proof.ts";
+import { actionCriterionFailure, attributeCellCriterion } from "./repo-cell-errors.ts";
 import { leaseTtlMs, type RepoCellBinding, type RepoTaskAction } from "./repo-cell-types.ts";
 import type { RepoCellOperationalContext } from "./repo-cell-action-context.ts";
+
+const REVISION_CRITERION = "task-lifecycle-contract-support/revisionIssues";
+const START_CRITERION = "task-lifecycle-command-transitions/canStartExecution";
+const SUBMIT_LEASE_CRITERION = "actor-domain-services/heldLeaseForExecutionActor";
 
 export async function runTaskActionCatalogRuntime(
   cell: RepoCellOperationalContext,
@@ -27,6 +30,10 @@ export async function runTaskActionCatalogRuntime(
     contract = getExecutableEntityAction(action.kind),
     lifecycle = contract?.execution?.lifecycle,
     preview = lifecycle?.coordination === "reserve" && action.dryRun === true,
+    evaluations =
+      contract?.target.kind === "task"
+        ? evaluateTaskActionCapability({ action: contract, snapshot: current.snapshot, actor: binding.actor })
+        : [],
     activeLease = cell.projection.currentLease(taskId, cell.now());
   if (
     lifecycle?.coordination === "reserve" &&
@@ -56,37 +63,14 @@ export async function runTaskActionCatalogRuntime(
         summary: `reused active execution ${activeLease.executionId}`,
       } as WriteReceipt;
     }
-    throw cell.cellCodedError(
-      "lease_conflict",
-      activeLease.phase === "reserving"
-        ? `Task ${taskId} is being reserved by ${actorHint(activeLease.actor)}; ` +
-            "wait for that reservation to publish " +
-            `or lapse at ${activeLease.expiresAt}, then retry ha task start ${taskId}.`
-        : `Task ${taskId} is held by ${actorHint(activeLease.actor)}; ` +
-            `that holder must run ha task release ${taskId}. ` +
-            `This caller must wait for release, then retry ha task start ${taskId}.`,
-    );
+    if (!contract) throw new Error(`Task Action ${action.kind} is not declared.`);
+    return taskActionRejection(cell, action, binding, current.snapshot.revision, contract, [
+      criterionEvaluation(evaluations, START_CRITERION),
+    ]);
   }
-  if (preview && !current.snapshot.task)
-    throw cell.cellCodedError("task_not_found", "Run ha task list, choose an existing task id, then retry task start.");
-  if (preview && current.snapshot.lease)
-    throw cell.cellCodedError(
-      "lease_conflict",
-      `Run ha task release ${taskId} as the current holder before starting another execution.`,
-    );
-  if (preview && current.snapshot.task && isTerminalStatus(current.snapshot.task.status))
-    throw cell.cellCodedError(
-      "terminal_task",
-      `Run ha task supersede ${taskId} --title <follow-up-title> for new work.`,
-    );
-  const unmet =
-    contract?.target.kind === "task"
-      ? evaluateTaskActionCapability({
-          action: contract,
-          snapshot: current.snapshot,
-          actor: binding.actor,
-        }).filter(({ status }) => status === "unmet")
-      : [];
+  const submitLeaseEvaluation = evaluations.find(({ criterionRef }) => criterionRef === SUBMIT_LEASE_CRITERION);
+  if (action.kind === "task-submit" && submitLeaseEvaluation?.status === "unmet" && contract)
+    return taskActionRejection(cell, action, binding, current.snapshot.revision, contract, [submitLeaseEvaluation]);
   if (lifecycle?.coordination === "reserve" && !preview)
     cell.assertTaskTransitionDocumentReady({
       rootDir: cell.rootDir,
@@ -107,7 +91,15 @@ export async function runTaskActionCatalogRuntime(
       current.snapshot,
     );
   } catch (error) {
-    const rejection = taskActionFailure(cell, action, binding, current.snapshot.revision, contract, unmet, error);
+    const rejection = taskActionFailure(
+      cell,
+      action,
+      binding,
+      current.snapshot.revision,
+      contract,
+      evaluations,
+      contract ? attributeCellCriterion(error, contract.id, invocationCriterionRef(contract)) : error,
+    );
     if (rejection) return rejection;
     throw error;
   }
@@ -118,7 +110,7 @@ export async function runTaskActionCatalogRuntime(
       workspaceRevision: current.snapshot.revision + 1,
     } as TaskLifecycleCommand).length > 0
   ) {
-    const criterion = contract.criteria.find(({ ref }) => ref === "task-lifecycle-contract-support/revisionIssues");
+    const criterion = contract.criteria.find(({ ref }) => ref === REVISION_CRITERION);
     if (!criterion)
       throw new Error(`Task Action ${contract.id} does not declare its existing revisionIssues predicate.`);
     return taskActionRejection(cell, action, binding, current.snapshot.revision, contract, [
@@ -127,6 +119,16 @@ export async function runTaskActionCatalogRuntime(
         nextActions: [`${criterion.explain} Then retry with --expected-version ${String(current.snapshot.revision)}.`],
       },
     ]);
+  }
+  if (lifecycle?.coordination === "reserve") {
+    const commandFields = normalized as unknown as Readonly<Record<string, unknown>>,
+      executionId = commandFields[lifecycle.targetIdField];
+    if (typeof executionId !== "string")
+      throw cell.cellCodedError("invalid_command", `${lifecycle.commandType} requires a target entity id.`);
+    if (!canStartExecution(current.snapshot, executionId) && contract)
+      return taskActionRejection(cell, action, binding, current.snapshot.revision, contract, [
+        criterionEvaluation(evaluations, START_CRITERION),
+      ]);
   }
   if (preview && lifecycle) {
     const commandFields = normalized as unknown as Readonly<Record<string, unknown>>,
@@ -155,13 +157,27 @@ export async function runTaskActionCatalogRuntime(
   try {
     authorityProof = await cell.proofFor(command, current.snapshot, binding, cell.projection);
   } catch (error) {
-    const rejection = taskActionFailure(cell, action, binding, current.snapshot.revision, contract, unmet, error);
+    const rejection = taskActionFailure(cell, action, binding, current.snapshot.revision, contract, evaluations, error);
     if (rejection) return rejection;
     throw error;
   }
-  if (unmet.length > 0 && contract)
-    return taskActionRejection(cell, action, binding, current.snapshot.revision, contract, unmet);
-  const result = await cell.service.execute(command, authorityProof);
+  let result: Awaited<ReturnType<RepoCellOperationalContext["service"]["execute"]>>;
+  try {
+    result = await cell.service.execute(command, authorityProof);
+  } catch (error) {
+    if (!isTaskLifecycleContractError(error) || !contract) throw error;
+    const rejection = taskActionFailure(
+      cell,
+      action,
+      binding,
+      current.snapshot.revision,
+      contract,
+      evaluations,
+      attributeCellCriterion(error, contract.id, invocationCriterionRef(contract)),
+    );
+    if (rejection) return rejection;
+    throw error;
+  }
   if (result.outcome === "applied" && result.event && result.proof)
     return cell.lifecycleReceipt(
       result.event,
@@ -193,19 +209,34 @@ function taskActionFailure(
   binding: RepoCellBinding,
   revision: number,
   contract: EntityActionContract | undefined,
-  unmet: readonly {
+  evaluations: readonly {
     readonly criterionRef: string;
+    readonly status: string;
     readonly nextActions: readonly string[];
   }[],
   error: unknown,
 ): WriteReceipt | null {
-  if (!contract) return null;
-  const rejected = cell.failed(
+  const failure = actionCriterionFailure(error);
+  if (!contract || failure?.actionId !== contract.id) return null;
+  const evaluation = evaluations.find(({ criterionRef }) => criterionRef === failure.criterionRef),
+    rejected = cell.failed(
       cell.errorOperationId(error) ?? cell.operationId(action, binding, cell.input.repoId, revision),
       error,
-    ),
-    withCriteria = attachTaskActionCriteria(cell, action, binding, revision, contract, unmet, rejected);
-  return withCriteria.unmetCriteria?.length ? withCriteria : null;
+    );
+  return taskActionRejection(
+    cell,
+    action,
+    binding,
+    revision,
+    contract,
+    [
+      {
+        criterionRef: failure.criterionRef,
+        nextActions: failure.nextActions.length ? failure.nextActions : (evaluation?.nextActions ?? []),
+      },
+    ],
+    rejected,
+  );
 }
 
 function taskActionRejection(
@@ -225,13 +256,7 @@ function taskActionRejection(
       if (!criterion) throw new Error(`Task Action ${contract.id} criterion ${criterionRef} is not declared.`);
       return criterion;
     }),
-    nextActions = Object.freeze([
-      ...new Set([
-        ...(rejected?.nextActions ?? []),
-        ...(rejected?.nextAction ? [rejected.nextAction] : []),
-        ...unmet.flatMap(({ nextActions: next }) => next),
-      ]),
-    ]),
+    nextActions = Object.freeze([...new Set([...unmet.flatMap(({ nextActions: next }) => next)])]),
     first = unmetCriteria[0]!;
   return {
     ...(rejected ??
@@ -240,28 +265,34 @@ function taskActionRejection(
         first.failureCode,
         nextActions[0] ?? first.explain,
       )),
+    nextAction: nextActions[0] ?? first.explain,
+    evidence: `criterion:${first.ref}`,
     unmetCriteria,
     rejectionExplanation: first.explain,
     nextActions,
   };
 }
 
-function attachTaskActionCriteria(
-  cell: RepoCellOperationalContext,
-  action: RepoTaskAction,
-  binding: RepoCellBinding,
-  revision: number,
-  contract: EntityActionContract,
-  unmet: readonly {
+function criterionEvaluation(
+  evaluations: readonly {
     readonly criterionRef: string;
     readonly nextActions: readonly string[];
   }[],
-  rejected: WriteReceipt,
-): WriteReceipt {
-  const matching = unmet.filter(({ criterionRef }) =>
-    contract.criteria.some(({ ref, failureCode }) => ref === criterionRef && failureCode === rejected.code),
-  );
-  return matching.length > 0
-    ? taskActionRejection(cell, action, binding, revision, contract, matching, rejected)
-    : rejected;
+  criterionRef: string,
+): { readonly criterionRef: string; readonly nextActions: readonly string[] } {
+  const evaluation = evaluations.find((candidate) => candidate.criterionRef === criterionRef);
+  if (!evaluation) throw new Error(`Task Action criterion ${criterionRef} has no capability evaluation.`);
+  return evaluation;
+}
+
+function invocationCriterionRef(contract: EntityActionContract): string {
+  const suffix = `/${contract.id}.validate`,
+    criterion = contract.criteria.find(({ ref }) => ref.endsWith(suffix));
+  if (!criterion) throw new Error(`Task Action ${contract.id} does not declare its invocation validator criterion.`);
+  return criterion.ref;
+}
+
+function isTaskLifecycleContractError(error: unknown): error is Error & { readonly issues: readonly unknown[] } {
+  if (!(error instanceof Error) || error.name !== "TaskLifecycleContractError") return false;
+  return Array.isArray((error as Error & { readonly issues?: unknown }).issues);
 }

--- a/packages/daemon/src/task-action-catalog-runtime.ts
+++ b/packages/daemon/src/task-action-catalog-runtime.ts
@@ -74,19 +74,29 @@ export async function runTaskActionCatalogRuntime(
       } as WriteReceipt;
     }
     if (!contract) throw new Error(`Task Action ${action.kind} is not declared.`);
-    return taskActionRejection(cell, action, binding, current.snapshot.revision, contract, [
-      criterionEvaluation(evaluations, START_CRITERION),
-    ]);
+    const leaseEvaluation = criterionEvaluation(evaluations, START_CRITERION);
+    return taskActionRejection(
+      cell,
+      action,
+      binding,
+      current.snapshot.revision,
+      contract,
+      [leaseEvaluation],
+      undefined,
+      "lease_conflict",
+    );
   }
   const submitValidationEvaluation = evaluations.find(
       ({ criterionRef }) => criterionRef === SUBMIT_VALIDATION_CRITERION,
     ),
-    submitLeaseEvaluation = evaluations.find(({ criterionRef }) => criterionRef === SUBMIT_LEASE_CRITERION);
-  if (action.kind === "task-submit" && submitValidationEvaluation?.status === "unmet" && contract)
+    submitLeaseEvaluation = evaluations.find(({ criterionRef }) => criterionRef === SUBMIT_LEASE_CRITERION),
+    submitValidationUnmet = submitValidationEvaluation?.status === "unmet",
+    submitLeaseUnmet = submitLeaseEvaluation?.status === "unmet";
+  if (action.kind === "task-submit" && submitValidationUnmet && contract)
     return taskActionRejection(cell, action, binding, current.snapshot.revision, contract, [
       submitValidationEvaluation,
     ]);
-  if (action.kind === "task-submit" && submitLeaseEvaluation?.status === "unmet" && contract)
+  if (action.kind === "task-submit" && submitLeaseUnmet && contract)
     return taskActionRejection(cell, action, binding, current.snapshot.revision, contract, [submitLeaseEvaluation]);
   if (lifecycle?.coordination === "reserve" && !preview)
     cell.assertTaskTransitionDocumentReady({
@@ -267,6 +277,7 @@ function taskActionRejection(
     readonly nextActions: readonly string[];
   }[],
   rejected?: WriteReceipt,
+  rejectionCode?: string,
 ): WriteReceipt {
   const unmetCriteria: readonly EntityActionUnmetCriterionV1[] = unmet.map(({ criterionRef }) => {
       const criterion = contract.criteria.find(({ ref }) => ref === criterionRef);
@@ -279,7 +290,7 @@ function taskActionRejection(
     ...(rejected ??
       cell.rejected(
         cell.operationId(action, binding, cell.input.repoId, revision),
-        first.failureCode,
+        rejectionCode ?? first.failureCode,
         nextActions[0] ?? first.explain,
       )),
     nextAction: nextActions[0] ?? first.explain,

--- a/packages/daemon/src/task-action-catalog-runtime.ts
+++ b/packages/daemon/src/task-action-catalog-runtime.ts
@@ -15,6 +15,7 @@ import type { RepoCellOperationalContext } from "./repo-cell-action-context.ts";
 
 const REVISION_CRITERION = "task-lifecycle-contract-support/revisionIssues";
 const START_CRITERION = "task-lifecycle-command-transitions/canStartExecution";
+const SUBMIT_VALIDATION_CRITERION = "task-lifecycle-command-transitions/submit.validate";
 const SUBMIT_LEASE_CRITERION = "actor-domain-services/heldLeaseForExecutionActor";
 
 export async function runTaskActionCatalogRuntime(
@@ -32,7 +33,16 @@ export async function runTaskActionCatalogRuntime(
     preview = lifecycle?.coordination === "reserve" && action.dryRun === true,
     evaluations =
       contract?.target.kind === "task"
-        ? evaluateTaskActionCapability({ action: contract, snapshot: current.snapshot, actor: binding.actor })
+        ? evaluateTaskActionCapability({
+            action: contract,
+            snapshot: current.snapshot,
+            actor: binding.actor,
+            invocation: {
+              taskId,
+              ...(typeof action.executionId === "string" ? { executionId: action.executionId } : {}),
+              ...(typeof action.reviewId === "string" ? { reviewId: action.reviewId } : {}),
+            },
+          })
         : [],
     activeLease = cell.projection.currentLease(taskId, cell.now());
   if (
@@ -68,7 +78,14 @@ export async function runTaskActionCatalogRuntime(
       criterionEvaluation(evaluations, START_CRITERION),
     ]);
   }
-  const submitLeaseEvaluation = evaluations.find(({ criterionRef }) => criterionRef === SUBMIT_LEASE_CRITERION);
+  const submitValidationEvaluation = evaluations.find(
+      ({ criterionRef }) => criterionRef === SUBMIT_VALIDATION_CRITERION,
+    ),
+    submitLeaseEvaluation = evaluations.find(({ criterionRef }) => criterionRef === SUBMIT_LEASE_CRITERION);
+  if (action.kind === "task-submit" && submitValidationEvaluation?.status === "unmet" && contract)
+    return taskActionRejection(cell, action, binding, current.snapshot.revision, contract, [
+      submitValidationEvaluation,
+    ]);
   if (action.kind === "task-submit" && submitLeaseEvaluation?.status === "unmet" && contract)
     return taskActionRejection(cell, action, binding, current.snapshot.revision, contract, [submitLeaseEvaluation]);
   if (lifecycle?.coordination === "reserve" && !preview)

--- a/packages/daemon/test/action-failure-explanation.integration.test.ts
+++ b/packages/daemon/test/action-failure-explanation.integration.test.ts
@@ -1,0 +1,222 @@
+// harness-test-tier: integration
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { makeTaskEventStore } from "../../kernel/src/index.ts";
+import { canonicalRoot, workspaceId } from "../src/protocol/daemon-protocol.contract.ts";
+import { withRoleBinding } from "./role-binding.fixtures.ts";
+import { openBootstrappedRepoCell as openRepoCell } from "./repo-settings.fixture.ts";
+import { initRepo } from "./task-surface.fixtures.ts";
+import { realizeTaskPlanFixture } from "../../../tools/fixtures/task-plan.mjs";
+
+const owner = {
+    actor: {
+      principal: { personId: "person-failure-owner" },
+      executor: { kind: "agent" as const, id: "failure-owner" },
+    },
+    source: "local" as const,
+  },
+  otherWriter = {
+    actor: {
+      principal: { personId: "person-failure-other" },
+      executor: { kind: "agent" as const, id: "failure-other" },
+    },
+    source: "local" as const,
+  },
+  reviewer = withRoleBinding(
+    {
+      actor: { principal: { personId: "person-failure-reviewer" }, executor: null },
+      source: "local" as const,
+    },
+    "arbiter",
+  ),
+  selfReviewer = withRoleBinding(owner, "arbiter");
+
+test("Task execution rejects with the exact Action criterion and performs no rejected mutation", async () => {
+  const rootDir = workspace("criteria"),
+    repoId = workspaceId("action-failure-criteria"),
+    taskId = "task-action-failure",
+    executionId = "execution-action-failure";
+  let cell: Awaited<ReturnType<typeof openRepoCell>> | undefined;
+  try {
+    cell = await openRepoCell({ repoId, rootDir: canonicalRoot(rootDir), ownerId: "action-failure-criteria" });
+    const created = await cell.run({ kind: "task-create", taskId, title: "Action failure criteria" }, owner);
+    assert.equal(created.outcome, "applied");
+    await realizeTaskPlanFixture(rootDir, String((created as Record<string, unknown>).packagePath), (planPath) =>
+      cell!.run({ kind: "doc-submit", paths: [planPath] }, owner),
+    );
+    assert.equal((await cell.run({ kind: "task-start", taskId, executionId }, owner)).outcome, "applied");
+
+    await assertRejectedWithoutMutation(
+      rootDir,
+      repoId,
+      () => cell!.run({ kind: "task-submit", taskId, executionId }, otherWriter),
+      ["actor-domain-services/heldLeaseForExecutionActor"],
+    );
+    await assertRejectedWithoutMutation(
+      rootDir,
+      repoId,
+      () => cell!.run({ kind: "task-start", taskId, executionId: "execution-foreign" }, otherWriter),
+      ["task-lifecycle-command-transitions/canStartExecution"],
+    );
+
+    assert.equal((await cell.run({ kind: "task-release", taskId }, owner)).outcome, "applied");
+    await assertRejectedWithoutMutation(
+      rootDir,
+      repoId,
+      () => cell!.run({ kind: "task-start", taskId, executionId, expectedVersion: 0 }, owner),
+      ["task-lifecycle-contract-support/revisionIssues"],
+    );
+    assert.equal((await cell.run({ kind: "task-start", taskId, executionId }, owner)).outcome, "applied");
+
+    await assertRejectedWithoutMutation(
+      rootDir,
+      repoId,
+      () => cell!.run({ kind: "task-submit", taskId, executionId }, owner),
+      ["task-lifecycle-command-transitions/submit.validate"],
+    );
+    assert.equal(
+      (
+        await cell.run(
+          {
+            kind: "task-submit",
+            taskId,
+            executionId,
+            submission: {
+              completionClaim: "Ready for exact failure attribution.",
+              deliverables: ["receipt"],
+              outputs: ["ActionResult"],
+              verificationNotes: ["integration"],
+              knownGaps: [],
+              residualRisks: [],
+              commitSha: "a".repeat(40),
+            },
+          },
+          owner,
+        )
+      ).outcome,
+      "applied",
+    );
+
+    await assertRejectedWithoutMutation(
+      rootDir,
+      repoId,
+      () => cell!.run({ kind: "task-review-execution", taskId, executionId }, reviewer),
+      ["task-lifecycle-review-transitions/review.validate"],
+    );
+    writeFileSync(
+      path.join(rootDir, "review.json"),
+      JSON.stringify({
+        verdict: "approved",
+        reason: "Self review must be rejected.",
+        evidenceChecked: ["integration"],
+      }),
+    );
+    await assertRejectedWithoutMutation(
+      rootDir,
+      repoId,
+      () =>
+        cell!.run(
+          {
+            kind: "task-review-execution",
+            taskId,
+            executionId,
+            reviewId: "review-self",
+            fromFile: "review.json",
+          },
+          selfReviewer,
+        ),
+      ["repo-cell-proof/proofFor.RecordReview"],
+    );
+    await assertRejectedWithoutMutation(
+      rootDir,
+      repoId,
+      () => cell!.run({ kind: "task-complete", taskId, executionId }, owner),
+      ["closeout-readiness/closeoutReadiness"],
+    );
+
+    const deniedBinding = {
+      ...owner,
+      roleBindings: [],
+      authorizationBindingMode: "declared" as const,
+    };
+    const denied = await assertRejectedWithoutMutation(
+      rootDir,
+      repoId,
+      () => cell!.run({ kind: "task-review-execution", taskId, executionId }, deniedBinding),
+      [],
+    );
+    assert.equal(denied.code, "authorization_denied");
+    assert.equal(denied.authorizationDecision.outcome, "denied");
+    assert.ok(denied.authorizationDecision.reasonCodes.length > 0);
+    assert.ok(denied.authorizationDecision.nextActions.length > 0);
+  } finally {
+    await cell?.close();
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});
+
+test("publication indeterminate remains operational and never invents an Action criterion", async () => {
+  const rootDir = workspace("operational"),
+    repoId = workspaceId("action-failure-operational"),
+    taskId = "task-action-operational";
+  let armed = false,
+    cell: Awaited<ReturnType<typeof openRepoCell>> | undefined;
+  try {
+    cell = await openRepoCell({
+      repoId,
+      rootDir: canonicalRoot(rootDir),
+      ownerId: "action-failure-operational",
+      killpoint: (point) => {
+        if (armed && point === "after_sqlite_commit")
+          throw Object.assign(new Error("Query the stable receipt before retrying."), {
+            code: "publication_indeterminate",
+          });
+      },
+    });
+    const created = await cell.run({ kind: "task-create", taskId, title: "Operational failure" }, owner);
+    assert.equal(created.outcome, "applied");
+    await realizeTaskPlanFixture(rootDir, String((created as Record<string, unknown>).packagePath), (planPath) =>
+      cell!.run({ kind: "doc-submit", paths: [planPath] }, owner),
+    );
+    armed = true;
+    const receipt = await cell.run({ kind: "task-start", taskId, executionId: "execution-operational" }, owner);
+    assert.equal(receipt.outcome, "indeterminate", JSON.stringify(receipt));
+    assert.equal(receipt.code, "publication_indeterminate");
+    assert.deepEqual(receipt.unmetCriteria, []);
+    assert.ok(receipt.nextAction);
+    assert.ok(receipt.nextActions?.length);
+    assert.doesNotMatch(JSON.stringify(receipt), /criteria\/publication_indeterminate/u);
+  } finally {
+    await cell?.close();
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});
+
+async function assertRejectedWithoutMutation(
+  rootDir: string,
+  repoId: ReturnType<typeof workspaceId>,
+  run: () => ReturnType<Awaited<ReturnType<typeof openRepoCell>>["run"]>,
+  expectedRefs: readonly string[],
+) {
+  const before = makeTaskEventStore({ repoId, rootDir }).read().events.length,
+    receipt = await run(),
+    after = makeTaskEventStore({ repoId, rootDir }).read().events.length;
+  assert.notEqual(receipt.outcome, "applied", JSON.stringify(receipt));
+  assert.equal(after, before, JSON.stringify(receipt));
+  assert.deepEqual(receipt.unmetCriteria?.map(({ ref }) => ref) ?? [], expectedRefs, JSON.stringify(receipt));
+  for (const criterion of receipt.unmetCriteria ?? []) {
+    assert.deepEqual(Object.keys(criterion).sort(), ["explain", "failureCode", "ref"]);
+    assert.ok(criterion.failureCode);
+    assert.ok(criterion.explain);
+  }
+  return receipt;
+}
+
+function workspace(name: string): string {
+  const rootDir = mkdtempSync(path.join(tmpdir(), `ha-action-failure-${name}-`));
+  initRepo(rootDir);
+  return rootDir;
+}

--- a/packages/daemon/test/rejection-next-actions.integration.test.ts
+++ b/packages/daemon/test/rejection-next-actions.integration.test.ts
@@ -51,8 +51,9 @@ test("submit lease refusals name the state-specific command that advances the ex
     );
     assert.equal(
       withoutLease.nextAction,
-      `Submit requires the active execution lease; run ha task start ${taskId} --execution-id ${executionId}, then retry ha task submit ${taskId} --json-input '<submission-json>'.`,
+      `The authenticated actor owns the active execution lease at its current version. Then retry ha task submit ${taskId} [--execution-id <execution-id>] [--from-file <from-file>] [--json-input <json-input>].`,
     );
+    assert.deepEqual(withoutLease.nextActions, [withoutLease.nextAction]);
     assert.equal((await cell.run({ kind: "task-start", taskId, executionId }, holder)).outcome, "applied");
     assert.equal(
       (await cell.run({ kind: "task-submit", taskId, executionId, fromFile: "submission.json" }, holder)).outcome,
@@ -63,11 +64,16 @@ test("submit lease refusals name the state-specific command that advances the ex
       { kind: "task-submit", taskId, executionId, fromFile: "submission.json" },
       holder,
     );
-    assert.equal(alreadySubmitted.code, "lease_required", JSON.stringify(alreadySubmitted));
+    assert.equal(alreadySubmitted.code, "invalid_transition", JSON.stringify(alreadySubmitted));
+    assert.deepEqual(
+      alreadySubmitted.unmetCriteria?.map(({ ref }) => ref),
+      ["task-lifecycle-command-transitions/submit.validate"],
+    );
     assert.equal(
       alreadySubmitted.nextAction,
       `Execution ${executionId} is already submitted; run ha task review-execution ${taskId} --execution-id ${executionId} --review-id <review-id> --from-file <review.json>.`,
     );
+    assert.deepEqual(alreadySubmitted.nextActions, [alreadySubmitted.nextAction]);
     writeFileSync(
       path.join(rootDir, "review.json"),
       JSON.stringify({ verdict: "approved", reason: "Independent review.", evidenceChecked: ["integration"] }),

--- a/packages/daemon/test/review-independence-diagnostics.integration.test.ts
+++ b/packages/daemon/test/review-independence-diagnostics.integration.test.ts
@@ -66,6 +66,7 @@ test("#1541: each Execution Review refusal names its own cause and its own repai
       ["task-lifecycle-review-transitions/review.validate"],
     );
     assert.match(String(beforeSubmission.nextAction), /requires a submitted execution/u);
+    assert.deepEqual(beforeSubmission.nextActions, [beforeSubmission.nextAction]);
 
     assert.equal((await cell.run({ kind: "task-start", taskId, executionId }, agent)).outcome, "applied");
     const commitSha = git(rootDir, "rev-parse", "HEAD");
@@ -106,6 +107,7 @@ test("#1541: each Execution Review refusal names its own cause and its own repai
     assert.equal(selfReview.code, "actor_unauthorized");
     assert.match(String(selfReview.nextAction), /independent of the submitting executor/u);
     assert.doesNotMatch(String(selfReview.nextAction), /declared no executor/u);
+    assert.deepEqual(selfReview.nextActions, [selfReview.nextAction]);
 
     // The repair the issue could not find: a bare human invocation reviews an agent-declared submission
     // on the very same principal. This is the assertion that falsifies "unreachable on Windows".
@@ -304,6 +306,7 @@ test("a child bare-invocation execution can recover from its parent Task dispatc
     );
     assert.match(String(refused.nextAction), /declared no executor/u);
     assert.match(String(refused.nextAction), /original start/u);
+    assert.deepEqual(refused.nextActions, [refused.nextAction]);
 
     const wrongPrincipal = withRoleBinding(
       {
@@ -368,6 +371,7 @@ test("a child bare-invocation execution can recover from its parent Task dispatc
     );
     assert.equal(selfReview.code, "actor_unauthorized");
     assert.match(String(selfReview.nextAction), /independent of the submitting executor/u);
+    assert.deepEqual(selfReview.nextActions, [selfReview.nextAction]);
 
     const reviewed = await cell.run(
       { kind: "task-review-execution", taskId, executionId, reviewId: "r3", fromFile: "review.json" },
@@ -695,6 +699,7 @@ test("task-bound runtime sessions cannot review their own execution across exit 
         denied.nextAction,
         `This runtime is bound to task ${taskId} and execution ${executionId} and cannot review its own work; have an independent human or a runtime with no binding to this task and execution run ha task review-execution ${taskId} --execution-id ${executionId} --review-id ${reviewId} --from-file <review.json>.`,
       );
+      assert.deepEqual(denied.nextActions, [denied.nextAction]);
       assert.equal(
         (
           await cell.run(

--- a/packages/daemon/test/task-action-catalog-executor.test.ts
+++ b/packages/daemon/test/task-action-catalog-executor.test.ts
@@ -1,7 +1,10 @@
 // harness-test-tier: contract
 import assert from "node:assert/strict";
 import test from "node:test";
-import { makeEntityActionCatalogExecutor } from "../src/entity-action-catalog-executor.ts";
+import { getExecutableEntityAction } from "../../kernel/src/index.ts";
+import { makeEntityActionCatalogExecutor, deriveActionResult } from "../src/entity-action-catalog-executor.ts";
+import { cellCriterionError } from "../src/repo-cell-errors.ts";
+import { failed } from "../src/repo-cell-settlement.ts";
 
 test("the catalog executor directly invokes Task execution metadata and derives ActionResult", async () => {
   const executor = makeEntityActionCatalogExecutor({
@@ -72,7 +75,7 @@ test("rejected Task ActionResult preserves the exact structured criterion", asyn
     {
       ref: "task-lifecycle-contract-support/revisionIssues",
       failureCode: "invalid_transition",
-      explain: "The command expectedVersion matches the current Task aggregate revision.",
+      explain: "The command expectedVersion equals the canonical Task projection revision at commit time.",
     },
   ]);
   assert.deepEqual(receipt.effects, []);
@@ -100,4 +103,27 @@ test("ambiguous failure codes do not invent a criterion", async () => {
     });
   assert.deepEqual(receipt.unmetCriteria, []);
   assert.doesNotMatch(JSON.stringify(receipt), /criteria\/invalid_transition/u);
+});
+
+test("criterion-bearing failures resolve descriptors by action plus ref even when failure codes collide", () => {
+  const contract = getExecutableEntityAction("task-start");
+  assert.ok(contract);
+  for (const criterionRef of [
+    "task-lifecycle-contract-support/revisionIssues",
+    "task-lifecycle-command-transitions/canStartExecution",
+  ]) {
+    const descriptor = contract.criteria.find(({ ref }) => ref === criterionRef);
+    assert.ok(descriptor);
+    const receipt = deriveActionResult(
+      contract,
+      { kind: "task-start", taskId: "task_contract" },
+      failed(
+        `op-${criterionRef}`,
+        cellCriterionError("invalid_transition", "Retry from the validator result.", "start", criterionRef, [
+          "Retry from the validator result.",
+        ]),
+      ),
+    );
+    assert.deepEqual(receipt.unmetCriteria, [descriptor]);
+  }
 });

--- a/packages/kernel/src/domain/agent-action-contract.ts
+++ b/packages/kernel/src/domain/agent-action-contract.ts
@@ -4,7 +4,7 @@ import type {
   EntityActionInputContract,
   EntityActionInputField,
 } from "./entity-kind-registry.ts";
-import type { EntityActionCompileHook } from "./entity-action-execution.ts";
+import { attributeEntityActionCriterion, type EntityActionCompileHook } from "./entity-action-execution.ts";
 import { assertTransitionDocumentReady, requireTransitionDocumentKind } from "./transition-document-readiness.ts";
 
 export interface AgentActionDraft {
@@ -122,7 +122,22 @@ export function createAgentActionCatalog(
 }
 
 export const compileAgentInstallAction: EntityActionCompileHook = (input): AgentActionDraft => {
-  const entity = parseAgentDeclarationV1(input.action.declaration);
-  assertTransitionDocumentReady(requireTransitionDocumentKind("agent.install"), entity.instructions);
+  let entity: AgentDeclarationV1;
+  try {
+    entity = parseAgentDeclarationV1(input.action.declaration);
+  } catch (error) {
+    throw agentCriterionError(error, "agent/declaration-schema", "invalid_manifest");
+  }
+  try {
+    assertTransitionDocumentReady(requireTransitionDocumentKind("agent.install"), entity.instructions);
+  } catch (error) {
+    throw agentCriterionError(error, "agent/instructions-ready", "instructions_placeholder");
+  }
   return { kind: "entity", entityKind: "agent", entity };
 };
+
+function agentCriterionError(error: unknown, criterionRef: string, fallbackCode: string): Error {
+  const attributed = error instanceof Error ? error : Object.assign(new Error(String(error)), { code: fallbackCode });
+  if (!("code" in attributed)) Object.assign(attributed, { code: fallbackCode });
+  return attributeEntityActionCriterion(attributed, "install", criterionRef);
+}

--- a/packages/kernel/src/domain/entity-action-execution.ts
+++ b/packages/kernel/src/domain/entity-action-execution.ts
@@ -42,6 +42,37 @@ export interface EntityActionExecutionContract {
   };
 }
 
+const ENTITY_ACTION_CRITERION_FAILURE = Symbol("entity-action-criterion-failure");
+
+export interface EntityActionCriterionFailure {
+  readonly actionId: string;
+  readonly criterionRef: string;
+  readonly nextActions: readonly string[];
+}
+
+type CriterionError = Error & {
+  readonly [ENTITY_ACTION_CRITERION_FAILURE]?: EntityActionCriterionFailure;
+};
+
+export function attributeEntityActionCriterion(
+  error: Error,
+  actionId: string,
+  criterionRef: string,
+  nextActions: readonly string[] = [],
+): Error {
+  Object.defineProperty(error as CriterionError, ENTITY_ACTION_CRITERION_FAILURE, {
+    configurable: false,
+    enumerable: false,
+    value: Object.freeze({ actionId, criterionRef, nextActions: Object.freeze([...nextActions]) }),
+  });
+  return error;
+}
+
+export function entityActionCriterionFailure(error: unknown): EntityActionCriterionFailure | null {
+  if (!(error instanceof Error)) return null;
+  return (error as CriterionError)[ENTITY_ACTION_CRITERION_FAILURE] ?? null;
+}
+
 export interface EntityActionCompileInput {
   readonly action: Readonly<Record<string, unknown>>;
   readonly actor: ActorIdentity;

--- a/packages/kernel/src/domain/index.ts
+++ b/packages/kernel/src/domain/index.ts
@@ -164,10 +164,12 @@ export type {
 export { projectBaseEntityAtCut, requireEntityTypeContract } from "./base-entity.ts";
 export type { BaseEntity } from "./base-entity.ts";
 export type {
+  EntityActionCriterionFailure,
   EntityActionCompileInput,
   EntityActionDraft,
   EntityActionExecutionContract,
 } from "./entity-action-execution.ts";
+export { attributeEntityActionCriterion, entityActionCriterionFailure } from "./entity-action-execution.ts";
 export { runtimeSessionActionIds, runtimeSessionActionPayload } from "./runtime-session-action-contract.ts";
 export type { RuntimeSessionActionDraft } from "./runtime-session-action-contract.ts";
 

--- a/packages/kernel/src/domain/schedule-action-contract.ts
+++ b/packages/kernel/src/domain/schedule-action-contract.ts
@@ -4,7 +4,11 @@ import type {
   EntityActionInputContract,
   EntityActionInputField,
 } from "./entity-kind-registry.ts";
-import type { EntityActionCompileHook, EntityActionCompileInput } from "./entity-action-execution.ts";
+import {
+  attributeEntityActionCriterion,
+  type EntityActionCompileHook,
+  type EntityActionCompileInput,
+} from "./entity-action-execution.ts";
 import {
   compileScheduleDeletedEvent,
   compileScheduleDefinitionEvent,
@@ -381,7 +385,12 @@ function compileScheduleAction(
     };
   if (id === "create") {
     if (current !== undefined && current !== null)
-      reject("entity_exists", `Schedule ${text(action.scheduleId, "scheduleId")} already exists.`);
+      rejectCriterion(
+        "create",
+        "schedule/create-identity",
+        "entity_exists",
+        `Schedule ${text(action.scheduleId, "scheduleId")} already exists.`,
+      );
     const created = createScheduleV1({
       scheduleId: text(action.scheduleId, "scheduleId"),
       name: text(action.name, "name"),
@@ -408,7 +417,12 @@ function compileScheduleAction(
   if (id === "update") {
     const fields = definitionFields.map(({ field }) => field);
     if (!fields.some((field) => Object.hasOwn(action, field)))
-      reject("invalid_command", "Schedule update requires at least one definition field.");
+      rejectCriterion(
+        "update",
+        "schedule/update-definition",
+        "invalid_command",
+        "Schedule update requires at least one definition field.",
+      );
     if (!record(current))
       reject("entity_not_found", `Schedule ${text(action.scheduleId, "scheduleId")} does not exist.`);
     const merged = mergeScheduleUpdate(current, action, input.occurredAt);
@@ -428,7 +442,9 @@ function compileScheduleAction(
   if (!schedule) reject("entity_not_found", `Schedule ${text(action.scheduleId, "scheduleId")} does not exist.`);
   if (id === "delete") {
     if (schedule.status.activeRun)
-      reject(
+      rejectCriterion(
+        "delete",
+        "schedule/delete-single-flight",
         "schedule_single_flight_active",
         `Schedule ${schedule.scheduleId} has an active occurrence; settle it before deletion.`,
       );
@@ -456,9 +472,9 @@ function compileScheduleAction(
       }),
     );
   }
-  if (id === "run-now" || id === "claim") return claimOccurrence(schedule, revision, input, common);
+  if (id === "run-now" || id === "claim") return claimOccurrence(id, schedule, revision, input, common);
   if (id === "link") {
-    const active = matchingClaim(schedule, action.claimFence);
+    const active = matchingClaim("link", schedule, action.claimFence);
     return event(
       compileScheduleRunEvent({
         ...common,
@@ -478,7 +494,7 @@ function compileScheduleAction(
     );
   }
   if (id === "record-missed") return missedOccurrences(schedule, revision, input, common);
-  const active = matchingClaim(schedule, action.claimFence),
+  const active = matchingClaim("settle", schedule, action.claimFence),
     outcome = action.outcome as ScheduleRunOutcome;
   if (!scheduleRunOutcomes.includes(outcome) || !timestamp(action.endedAt))
     reject("invalid_command", "Schedule settlement requires one canonical outcome and UTC end time.");
@@ -506,6 +522,7 @@ function compileScheduleAction(
 }
 
 function claimOccurrence(
+  actionId: "run-now" | "claim",
   schedule: ScheduleV1,
   revision: number,
   input: EntityActionCompileInput,
@@ -515,12 +532,16 @@ function claimOccurrence(
   if (schedule.state !== "armed")
     reject("schedule_paused", `Schedule ${schedule.scheduleId} is paused; enable it before claiming.`);
   if (typeof action.observedDefinitionRevision === "number" && action.observedDefinitionRevision !== revision)
-    reject(
+    rejectCriterion(
+      actionId,
+      "schedule/definition-revision-fence",
       "schedule_definition_stale",
       `Schedule ${schedule.scheduleId} changed at revision ${revision}; refresh its definition before claiming.`,
     );
   if (schedule.status.activeRun)
-    reject(
+    rejectCriterion(
+      actionId,
+      "schedule/occurrence-single-flight",
       "schedule_single_flight_active",
       `Schedule ${schedule.scheduleId} already has active occurrence ${schedule.status.activeRun.occurrenceId}.`,
     );
@@ -568,7 +589,9 @@ function missedOccurrences(
   if (schedule.state !== "armed")
     reject("schedule_paused", `Schedule ${schedule.scheduleId} is paused; it cannot record a timer miss.`);
   if (action.observedDefinitionRevision !== revision)
-    reject(
+    rejectCriterion(
+      "record-missed",
+      "schedule/missed-definition-fence",
       "schedule_definition_stale",
       `Schedule ${schedule.scheduleId} changed at revision ${revision}; refresh it before recording a timer miss.`,
     );
@@ -612,11 +635,20 @@ function currentSchedule(input: EntityActionCompileInput): ScheduleV1 | null {
   return validateScheduleV1(input.currentEntity).length === 0 ? (input.currentEntity as ScheduleV1) : null;
 }
 
-function matchingClaim(schedule: ScheduleV1, fence: unknown): NonNullable<ScheduleV1["status"]["activeRun"]> {
+function matchingClaim(
+  actionId: "link" | "settle",
+  schedule: ScheduleV1,
+  fence: unknown,
+): NonNullable<ScheduleV1["status"]["activeRun"]> {
   const claimFence = text(fence, "claimFence"),
     active = schedule.status.activeRun;
   if (!active || active.claimFence !== claimFence)
-    reject("schedule_claim_stale", `Schedule ${schedule.scheduleId} no longer owns claim ${claimFence}.`);
+    rejectCriterion(
+      actionId,
+      "schedule/active-claim-fence",
+      "schedule_claim_stale",
+      `Schedule ${schedule.scheduleId} no longer owns claim ${claimFence}.`,
+    );
   return active;
 }
 
@@ -745,4 +777,8 @@ function text(value: unknown, name: string): string {
 
 function reject(code: string, message: string): never {
   throw Object.assign(new Error(message), { code });
+}
+
+function rejectCriterion(actionId: string, criterionRef: string, code: string, message: string): never {
+  throw attributeEntityActionCriterion(Object.assign(new Error(message), { code }), actionId, criterionRef);
 }

--- a/packages/kernel/src/domain/settings-action-contract.ts
+++ b/packages/kernel/src/domain/settings-action-contract.ts
@@ -4,7 +4,11 @@ import type {
   EntityActionInputContract,
   EntityActionInputField,
 } from "./entity-kind-registry.ts";
-import type { EntityActionCompileHook, EntityActionCompileInput } from "./entity-action-execution.ts";
+import {
+  attributeEntityActionCriterion,
+  type EntityActionCompileHook,
+  type EntityActionCompileInput,
+} from "./entity-action-execution.ts";
 import { compileSettingsChangedEvent, type SettingsEventBundle } from "./settings-event.ts";
 import {
   SETTINGS_ID,
@@ -176,9 +180,13 @@ export function compileSettingsUpdate(input: EntityActionCompileInput): Settings
     rejectSettings("invalid_command", "expectedVersion must be a non-negative integer when supplied.");
   if (!repositoryChangeRequested) return { kind: "no-changes", settings: current, revision };
   if (expectedVersion !== undefined && Number(expectedVersion) !== revision)
-    rejectSettings(
-      "revision_conflict",
-      `Settings expected revision ${String(expectedVersion)}, current revision is ${revision}.`,
+    throw attributeEntityActionCriterion(
+      new SettingsActionError(
+        "revision_conflict",
+        `Settings expected revision ${String(expectedVersion)}, current revision is ${revision}.`,
+      ),
+      "update",
+      "settings/singleton-revision",
     );
   const candidate: RepositorySettingsV1 = {
       schema: "settings/v1",

--- a/packages/kernel/src/domain/task-action-capability.ts
+++ b/packages/kernel/src/domain/task-action-capability.ts
@@ -49,15 +49,7 @@ const revisionCurrent: Evaluation = ({ snapshot }) =>
 const taskCapabilityEvaluators = Object.freeze(
   new Map<string, Evaluation>([
     [key("start", "task-lifecycle-contract-support/revisionIssues"), revisionCurrent],
-    [
-      key("start", "task-lifecycle-command-transitions/canStartExecution"),
-      ({ snapshot }) =>
-        ["entity-action-explanation", ...snapshot.executions.map(({ executionId }) => executionId)].some(
-          (executionId) => canStartExecution(snapshot, executionId),
-        )
-          ? "met"
-          : "unmet",
-    ],
+    [key("start", "task-lifecycle-command-transitions/canStartExecution"), startAvailability],
     [
       key("start", "task-lifecycle-command-transitions/start.validate"),
       ({ snapshot }) =>
@@ -129,7 +121,36 @@ function submitValidation(input: TaskActionCapabilityInput): PredicateEvaluation
   };
 }
 
+function startAvailability(input: TaskActionCapabilityInput): PredicateEvaluation | "met" | "unmet" {
+  const executionIds = [
+      "entity-action-explanation",
+      ...input.snapshot.executions.map(({ executionId }) => executionId),
+    ],
+    startable = executionIds.some((executionId) => canStartExecution(input.snapshot, executionId));
+  if (startable) return "met";
+  const lease = input.snapshot.lease;
+  if (!lease || heldLeaseForExecutionActor(input.snapshot, lease.executionId, input.actor)) return "unmet";
+  const taskId = invocationTaskId(input),
+    executor = lease.actor.executor ? `${lease.actor.executor.kind}:${lease.actor.executor.id}` : "none",
+    holder = `personId=${lease.actor.principal.personId}, executor=${executor}`;
+  return {
+    status: "unmet",
+    nextActions: [
+      lease.phase === "reserving"
+        ? `Task ${taskId} is being reserved by ${holder}; wait for that reservation to publish ` +
+          `or lapse at ${lease.expiresAt}, then retry ha task start ${taskId}.`
+        : `Task ${taskId} is held by ${holder}; that holder must run ha task release ${taskId}. ` +
+          `This caller must wait for release, then retry ha task start ${taskId}.`,
+    ],
+  };
+}
+
 function reviewValidation(input: TaskActionCapabilityInput): PredicateEvaluation | "invocation-required" {
+  if (
+    input.invocation?.reviewId !== undefined &&
+    input.snapshot.reviews.some(({ reviewId }) => reviewId === input.invocation?.reviewId)
+  )
+    return { status: "unmet" };
   if (currentSubmittedExecutions(input.snapshot).length > 0) return "invocation-required";
   const taskId = invocationTaskId(input),
     executionId = input.invocation?.executionId ?? "<execution-id>",

--- a/packages/kernel/src/domain/task-action-capability.ts
+++ b/packages/kernel/src/domain/task-action-capability.ts
@@ -19,11 +19,25 @@ export interface TaskActionCapabilityInput {
   readonly action: EntityActionContract;
   readonly snapshot: TaskLifecycleSnapshot;
   readonly actor: ActorIdentity;
+  readonly invocation?: TaskActionCapabilityInvocation;
 }
 
-type Evaluation = (input: TaskActionCapabilityInput) => Exclude<EntityActionCriterionStatus, "not-evaluated">;
+export interface TaskActionCapabilityInvocation {
+  readonly taskId: string;
+  readonly executionId?: string;
+  readonly reviewId?: string;
+  readonly runtimeTaskBound?: boolean;
+}
 
-const invocationRequired: Evaluation = () => "invocation-required";
+interface PredicateEvaluation {
+  readonly status: Exclude<EntityActionCriterionStatus, "not-evaluated">;
+  readonly nextActions?: readonly string[];
+}
+
+type Evaluation = (
+  input: TaskActionCapabilityInput,
+) => Exclude<EntityActionCriterionStatus, "not-evaluated"> | PredicateEvaluation;
+
 const revisionCurrent: Evaluation = ({ snapshot }) =>
   revisionIssues(snapshot, {
     expectedRevision: snapshot.revision,
@@ -54,23 +68,14 @@ const taskCapabilityEvaluators = Object.freeze(
           : "unmet",
     ],
     [key("submit", "task-lifecycle-contract-support/revisionIssues"), revisionCurrent],
-    [key("submit", "task-lifecycle-command-transitions/submit.validate"), invocationRequired],
+    [key("submit", "task-lifecycle-command-transitions/submit.validate"), submitValidation],
     [
       key("submit", "actor-domain-services/heldLeaseForExecutionActor"),
       ({ snapshot, actor }) => (heldLeaseForExecutionActor(snapshot, undefined, actor) ? "met" : "unmet"),
     ],
     [key("review", "task-lifecycle-contract-support/revisionIssues"), revisionCurrent],
-    [
-      key("review", "task-lifecycle-review-transitions/review.validate"),
-      ({ snapshot }) => (currentSubmittedExecutions(snapshot).length > 0 ? "invocation-required" : "unmet"),
-    ],
-    [
-      key("review", "repo-cell-proof/proofFor.RecordReview"),
-      ({ snapshot, actor }) =>
-        currentSubmittedExecutions(snapshot).some((execution) => isIndependentFrom(execution.actor, actor))
-          ? "met"
-          : "unmet",
-    ],
+    [key("review", "task-lifecycle-review-transitions/review.validate"), reviewValidation],
+    [key("review", "repo-cell-proof/proofFor.RecordReview"), reviewIndependence],
     [key("complete", "task-lifecycle-contract-support/revisionIssues"), revisionCurrent],
     [
       key("complete", "closeout-readiness/closeoutReadiness"),
@@ -93,19 +98,112 @@ export function evaluateTaskActionCapability(
     const evaluate = taskCapabilityEvaluators.get(key(input.action.id, criterion.ref));
     if (evaluate === undefined)
       throw new Error(`Task Action ${input.action.id} criterion ${criterion.ref} has no capability classification.`);
-    const status = evaluate(input);
+    const evaluated = evaluate(input),
+      status = typeof evaluated === "string" ? evaluated : evaluated.status;
     return Object.freeze({
       criterionRef: criterion.ref,
       status,
       nextActions: Object.freeze(
-        status === "met"
-          ? []
-          : status === "invocation-required"
-            ? invocationNextActions(input.action)
-            : [`${criterion.explain} ${retryUsage(input.action, input.snapshot.task?.taskId)}`],
+        typeof evaluated !== "string" && evaluated.nextActions
+          ? [...evaluated.nextActions]
+          : status === "met"
+            ? []
+            : status === "invocation-required"
+              ? invocationNextActions(input.action)
+              : [`${criterion.explain} ${retryUsage(input.action, input.snapshot.task?.taskId)}`],
       ),
     });
   });
+}
+
+function submitValidation(input: TaskActionCapabilityInput): PredicateEvaluation | "invocation-required" {
+  const submitted = submittedExecution(input);
+  if (!submitted) return "invocation-required";
+  const taskId = invocationTaskId(input),
+    executionId = submitted.executionId;
+  return {
+    status: "unmet",
+    nextActions: [
+      `Execution ${executionId} is already submitted; run ${reviewCommand(taskId, executionId, "<review-id>")}.`,
+    ],
+  };
+}
+
+function reviewValidation(input: TaskActionCapabilityInput): PredicateEvaluation | "invocation-required" {
+  if (currentSubmittedExecutions(input.snapshot).length > 0) return "invocation-required";
+  const taskId = invocationTaskId(input),
+    executionId = input.invocation?.executionId ?? "<execution-id>",
+    reviewId = input.invocation?.reviewId ?? "<review-id>";
+  return {
+    status: "unmet",
+    nextActions: [
+      [
+        "Execution Review requires a submitted execution; run ha task start ",
+        `${taskId}`,
+        " --execution-id ",
+        `${executionId}`,
+        ", then ha task submit ",
+        `${taskId}`,
+        " --execution-id ",
+        `${executionId}`,
+        " --json-input '<submission-json>', then retry ",
+        `${reviewCommand(taskId, executionId, reviewId)}`,
+        ".",
+      ].join(""),
+    ],
+  };
+}
+
+function reviewIndependence(input: TaskActionCapabilityInput): PredicateEvaluation | "met" {
+  const submitted = submittedExecutions(input),
+    dependent = !submitted.some((execution) => isIndependentFrom(execution.actor, input.actor));
+  if (!input.invocation?.runtimeTaskBound && !dependent) return "met";
+  const taskId = invocationTaskId(input),
+    executionId = submitted[0]?.executionId ?? input.invocation?.executionId ?? "<execution-id>",
+    reviewId = input.invocation?.reviewId ?? "<review-id>",
+    command = reviewCommand(taskId, executionId, reviewId);
+  if (input.invocation?.runtimeTaskBound)
+    return {
+      status: "unmet",
+      nextActions: [
+        `This runtime is bound to task ${taskId} and execution ${executionId} and cannot review its own work; ` +
+          `have an independent human or a runtime with no binding to this task and execution run ${command}.`,
+      ],
+    };
+  if (submitted[0]?.actor.executor === null && input.actor.executor === null)
+    return {
+      status: "unmet",
+      nextActions: [
+        `The submitted execution's original start declared no executor, so only a different person can review it. ` +
+          `Run ha task declare-executor ${taskId} --execution-id ${executionId} --agent <dispatch-agent> ` +
+          `--reason <reason> before same-person review, or have a different person run ${command}.`,
+      ],
+    };
+  return {
+    status: "unmet",
+    nextActions: [`Have a reviewer independent of the submitting executor run ${command}.`],
+  };
+}
+
+function submittedExecution(input: TaskActionCapabilityInput) {
+  return submittedExecutions(input)[0];
+}
+
+function submittedExecutions(input: TaskActionCapabilityInput) {
+  const submitted = currentSubmittedExecutions(input.snapshot),
+    executionId = input.invocation?.executionId;
+  return executionId === undefined ? submitted : submitted.filter((execution) => execution.executionId === executionId);
+}
+
+function invocationTaskId(input: TaskActionCapabilityInput): string {
+  return input.invocation?.taskId ?? input.snapshot.task?.taskId ?? "<task-id>";
+}
+
+function reviewCommand(taskId: string, executionId: string, reviewId: string): string {
+  return (
+    `ha task review-execution ${taskId} --execution-id ${executionId} ` +
+    `--review-id ${reviewId} --from-file <review.json>`
+  );
 }
 
 export function taskActionUsage(action: EntityActionContract, taskId = "<task-id>"): string {

--- a/packages/kernel/src/domain/task-action-contract.ts
+++ b/packages/kernel/src/domain/task-action-contract.ts
@@ -222,7 +222,9 @@ const taskActionDeclarations = Object.freeze([
       {
         ref: "task-lifecycle-review-transitions/review.validate",
         failureCode: "invalid_transition",
-        explain: "The review targets the current submitted execution and its pinned content cut.",
+        explain:
+          "The review targets the current submitted execution and its pinned content cut; " +
+          "append-only Review history requires a new review id.",
       },
       {
         ref: "repo-cell-proof/proofFor.RecordReview",

--- a/packages/kernel/src/domain/write-chain.contract.ts
+++ b/packages/kernel/src/domain/write-chain.contract.ts
@@ -10,6 +10,7 @@ export { receiptDetailRegistry, validateWriteReceipt, WRITE_RECEIPT_SCHEMA } fro
 export type {
   AuthorizationDecision,
   DocSyncReceiptDetail,
+  EntityActionUnmetCriterionV1,
   LedgerCutIdentity,
   ReceiptProof,
   ReceiptJsonValue,

--- a/packages/kernel/test/contracts/structured-unmet-criteria.test.ts
+++ b/packages/kernel/test/contracts/structured-unmet-criteria.test.ts
@@ -1,0 +1,61 @@
+// harness-test-tier: contract
+import assert from "node:assert/strict";
+import test from "node:test";
+import { authorizationPort, type ActionEnvelope, type AuthorizationContext } from "../../src/index.ts";
+import { createWriteReceipt, validateWriteReceipt, type WriteReceipt } from "../../src/domain/write-chain.contract.ts";
+
+const actor = { principal: { personId: "person-criteria" }, executor: null } as const;
+const authorizationDecision = authorizationPort.authorize(
+  {
+    actionId: "action-criteria",
+    kind: "task-start",
+    target: "task/task-criteria",
+    actor,
+    idempotencyKey: "criteria",
+  } satisfies ActionEnvelope,
+  {
+    defaultBinding: { principalPersonId: actor.principal.personId, source: "local" },
+    roleBindingTargets: ["settings/repository"],
+    evaluatedAt: "2026-09-01T00:00:00.000Z",
+    evaluatedAtCut: "canonical:7",
+    writeSource: "local",
+    target: {},
+  } satisfies AuthorizationContext,
+);
+
+const criterion = {
+  ref: "task-lifecycle-command-transitions/canStartExecution",
+  failureCode: "invalid_transition",
+  explain: "The requested execution is admissible at the current Task cut.",
+} as const;
+
+function receipt(unmetCriteria: unknown): WriteReceipt {
+  return {
+    outcome: "op_rejected",
+    opId: "op-criteria",
+    code: criterion.failureCode,
+    origin: "daemon",
+    evidence: `criterion:${criterion.ref}`,
+    nextAction: "Retry after the Task becomes startable.",
+    authorizationDecision,
+    unmetCriteria,
+  } as WriteReceipt;
+}
+
+test("WriteReceipt accepts the closed structured unmet-criterion value", () => {
+  const value = receipt([criterion]);
+  assert.deepEqual(validateWriteReceipt(value), []);
+  assert.deepEqual(createWriteReceipt(value).unmetCriteria, [criterion]);
+});
+
+test("WriteReceipt rejects the retired string form and unknown criterion fields", () => {
+  assert.match(validateWriteReceipt(receipt([criterion.ref])).join("\n"), /structured criterion explanations/u);
+  assert.match(
+    validateWriteReceipt(receipt([{ ...criterion, guessed: true }])).join("\n"),
+    /structured criterion explanations/u,
+  );
+  assert.match(
+    validateWriteReceipt(receipt([{ ...criterion, explain: "" }])).join("\n"),
+    /structured criterion explanations/u,
+  );
+});


### PR DESCRIPTION
# English

## Summary

Ontology explain slice C: Task action failures now cross the execution boundary carrying the exact `(actionId, criterionRef)` that failed, and the public `WriteReceipt`/ActionResult projects that identity to the canonical descriptor's closed `{ ref, failureCode, explain }` value. No production path reverse-maps a failure code to a criterion any more: the old `contract.criteria.filter(criterion.failureCode === receipt.code)` inference and every handwritten business-hint branch (submit lease sentences, review-independence remediation assembly, complete execution-selection prose) are deleted. `failureCode` remains an error classification only — never an identity key; an action-id mismatch or undeclared ref fails closed with `invalid_store`, with no default ref, dual-read fallback, or `criteria/<code>` synthesis. Authority separation holds: criterion rejections carry `unmetCriteria` with `authorizationDecision: allowed`; authorization denials carry only the Policy decision's `reasonCodes`/`nextActions` with empty criteria; operational/transport/settlement failures never receive criterion metadata. Internal attribution rides a private `WeakMap` across settlement, so the closed public receipt schema gains no field.

The continuation adjudicated four legacy-suite assertion failures instead of blanking them: one was a **real regression** — a successful submit releases the lease, so a repeated submit was preempted by the lease criterion and lost the precise "already submitted → run review-execution" attribution; `submit.validate` now evaluates before the lease result and owns that remediation. Two more were information loss fixed at the predicate: `review.validate` and `proofFor.RecordReview` now return context-specific, terminating `nextActions` (start→submit→review route; independent-human-or-unbound-runtime review command) as evaluator output. All business remediation text lives in `task-action-capability.ts`, keyed by exact Action + criterion identity — settlement and proof contain no message branches.

## Architectural Justification

- Mechanism sentence: failure identity must be carried from the failing predicate, not reconstructed from the failure classification — code collision (two `invalid_transition` criteria on one action) makes reverse-mapping structurally wrong.
- Deletion with the feature: the code-based criteria filter, Task failure attachment by code, and five families of handwritten hint sentences are removed; production grep for all retired sentences and inference patterns is empty.
- Authorities stay separate: criteria are Action authority, `AuthorizationDecision` is Policy authority, operational codes are transport/repository authority; none may impersonate another (G2 discipline).
- Concurrency: rejected cases leave the Task event count unchanged (asserted per case); successful contenders still pass expected-version and lease fencing at the center queue.

## What Changed

- daemon: `repo-cell-errors.ts` (+47, typed `CellActionCriterionFailure`), `task-action-catalog-runtime.ts` (exact-criterion runtime), `repo-cell-proof.ts` / `repo-cell-settlement.ts` (typed handoff, no wire-schema field), `repo-cell-execution-selection.ts` (−113 net, remediation assembly deleted), `task-action-capability.ts` (predicate-owned remediation).
- kernel: `write-chain.contract.ts` re-exports A's structured `EntityActionUnmetCriterionV1` (single schema authority; no second receipt type).
- Tests: new `action-failure-explanation.integration.test.ts` (222) covering start/submit/review/complete, authorization, operational, and zero-mutation assertions; new `structured-unmet-criteria.test.ts` (61) closing the receipt schema; the two legacy diagnostic suites updated to the adjudicated contract with `nextActions === [nextAction]` parity.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none

## Machine-Readable Declarations

Production-Delta: +635/-290
Dependency-Change: none

### Optional Evidence Claims

None.

## Task And Scope

- Harness task: `task_54924a2d9e50aab5c4a25ca6cc` (Ontology explain C; design authority §1.3, 2.2, 3, 5.3, 6, 7C, 9)
- Branch: `codex/explain-c`
- Public scope: daemon failure attribution + kernel contract re-export + tests; no CLI/protocol surface, Action descriptor, tool, gate, baseline, or workflow change.
- Private planning/evidence: `artifacts/error-attribution-report.md` (four-action failure matrix, old/new collision output, continuation adjudication).

## Version Impact

- Version: no change. Publish impact: none.

## Governance Declaration

- Protected surface touched: no.
- Authority: task_54924a2d9e50aab5c4a25ca6cc.
- Break-glass: no

## Verification

- Isolated Ubuntu: rejection-next-actions 3/3; review-independence-diagnostics 4/4; action-failure-explanation 2/2; task-action-explanation service/read 1/1 + 2/2; schedule-runtime-settlement 1/1; daemon-receipt-cli 1/1; structured-unmet-criteria 2/2 (Node 24); catalog-executor 4/4.
- typecheck, ESLint, Prettier, import-boundaries (3→3), `git diff --check` clean; CEO re-ran both legacy suites locally — 0 fail; line-density pass; production grep for retired sentences/inference empty.
- [ ] Full suites: GitHub CI is the authority.

## Review Evidence

- CEO semantic review: exact-identity attribution with fail-closed unknown refs; the already-submitted preemption was correctly adjudicated as a real regression and fixed by evaluation order, not test-blanking; all new remediation is predicate output keyed by action+criterion — no hint-branch regression; authority三分 verified against the report's three sample receipts.

## Residual Risk

- D slice consumes the structured fields for parity and must not key on the lower-level `code` (handoff contract in the report); no runtime risk beyond daemon failure paths.

---

# 中文

## 概要

Ontology explain C:Task 四动作的执行失败现在携带**精确的 `(actionId, criterionRef)`** 跨越执行边界,公开 `WriteReceipt`/ActionResult 投影为 canonical descriptor 的封闭 `{ ref, failureCode, explain }`。生产路径不再按失败码反猜准则:旧的 `criteria.filter(failureCode === code)` 推断与全部手写业务 hint 分支(submit 租约句、review 独立性补救拼装、complete 执行选择文案)删除。`failureCode` 只作错误分类,永不作身份键;action 不匹配或未声明 ref 一律 fail-closed `invalid_store`,无默认 ref、无双读回退、无 `criteria/<code>` 合成。权威三分:criterion 拒绝带 `unmetCriteria` 且 authorization=allowed;授权拒绝只带 Policy 的 reasonCodes/nextActions 且 criteria 为空;operational/transport/settlement 失败不携带任何 criterion 元数据。内部归因经私有 `WeakMap` 穿越 settlement,公开回执 schema 零新增字段。

续跑对四处遗留断言逐处裁决而非改绿:其一为**真回归**——submit 成功即释放租约,重复 submit 被 lease criterion 抢答,丢失「already submitted → 去 review」的精准归因;现 `submit.validate` 先于 lease 结果评估并持有该补救。另两处为信息损失,修在谓词:`review.validate` 与 `proofFor.RecordReview` 现返回场景化、可终止的 `nextActions`(start→submit→review 路线;独立人类或未绑定 runtime 的完整 review 命令),全部是 evaluator 输出。所有业务补救文案住 `task-action-capability.ts`,按 Action+criterion 身份键入——settlement 与 proof 零 message 分支。

## 架构辩护

- 机制句:失败身份必须由失败谓词携带,不得从失败分类反构——同一 action 上两个同码 criterion 的碰撞使反查在结构上就是错的。
- 随功能删除:按码过滤、按码挂接、五族手写 hint 全删;生产 grep 全部退休句与推断模式为空。
- 权威不冒名:criteria=Action 权威,AuthorizationDecision=Policy 权威,operational=传输/仓储权威(G2 纪律)。
- 并发:每个拒绝用例断言 Task 事件数不变;成功竞争者仍过 expected-version 与 lease fence。

## 改动内容

- daemon:typed `CellActionCriterionFailure`、exact-criterion runtime、typed 交接(无 wire 字段)、执行选择补救拼装删除(净 −113)、谓词化补救(`task-action-capability.ts`)。
- kernel:write-chain 契约再导出 A 的结构化 schema(单一权威,无第二回执类型)。
- 测试:action-failure-explanation 222 行(四动作/授权/运维/零变更断言)+ structured-unmet-criteria 61 行(封闭 schema);两套遗留诊断套件按裁决契约更新并断言 `nextActions === [nextAction]`。

## 门收割 / Gate Harvest

- 无删除(生产删除面是推断分支与 hint 句,非整路径退役)。

## 机读声明说明

`Production-Delta` 由 gate 实测(+635/-290)。

## 任务与范围

- Task `task_54924a2d9e50aab5c4a25ca6cc`;分支 `codex/explain-c`;设计权威 §1.3/2.2/3/5.3/6/7C/9。

## 版本影响

- 不改版本、不发布。

## 治理声明

- 未触碰受保护面;授权=task_54924a2d9e50aab5c4a25ca6cc;非 break-glass。

## 验证

- 隔离 Ubuntu 八套件全绿(含两套遗留套件 3/3 与 4/4);typecheck/ESLint/Prettier/import-boundaries(3→3)/diff-check 干净;CEO 本地复跑两套件 0 fail;line-density pass;退休句生产 grep 为空。
- 完整权威=GitHub CI。

## 审查证据

- CEO 语义验收:already-submitted 抢答裁定为真回归并按评估顺序修复(非改测试);新补救全部为谓词输出,无 hint 分支回潮;权威三分对照报告三样例回执核实。

## 残余风险

- D 片消费结构化字段做 parity,不得按低层 `code` 键入(交接契约在报告);daemon 失败路径之外无运行时风险。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VTzQAqvuFy6ikGjBKxA9xj
