### PR TITLE
feat(gui): split terminal tabs into resizable pane trees with restorable layout (PLT-TerminalWorkspace W1)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3390,6 +3390,34 @@
         "js-yaml": "^4.1.0"
       }
     },
+    "node_modules/dockview": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/dockview/-/dockview-8.2.0.tgz",
+      "integrity": "sha512-Jj+fnFWSrdEhF+1DmpGNYjEvyqf7J0FHkDqsD98wL4WOYB2CSKavDCL49B3LHIGYvWNN7Q1O1j4p7Pts38CM5A==",
+      "license": "MIT",
+      "dependencies": {
+        "dockview-core": "^8.2.0"
+      }
+    },
+    "node_modules/dockview-core": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/dockview-core/-/dockview-core-8.2.0.tgz",
+      "integrity": "sha512-+L+xdvmO1b4in8rVkFtQM13IkPDKqDLoHJvq5HtAIsMxsPptSVveKeViYBqquaoHF+t0xb9f6692gTeKnjCKGw==",
+      "license": "MIT"
+    },
+    "node_modules/dockview-react": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/dockview-react/-/dockview-react-8.2.0.tgz",
+      "integrity": "sha512-OHa/4uuaw3VpHVkGophdYh2U1f5tOvp/ANf5CAE3QQVh2oSMKNimaWaFXEg/R1wGBdZogQyYOKQSU+wLrE0taw==",
+      "license": "MIT",
+      "dependencies": {
+        "dockview": "^8.2.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/dotenv": {
       "version": "16.6.1",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
@@ -9548,6 +9576,8 @@
         "@xterm/addon-fit": "^0.11.0",
         "@xterm/xterm": "^6.0.0",
         "@xyflow/react": "^12.11.2",
+        "dockview": "8.2.0",
+        "dockview-react": "8.2.0",
         "react": "19.2.7",
         "react-dom": "19.2.7",
         "react-markdown": "^10.1.0",

--- a/packages/gui/package.json
+++ b/packages/gui/package.json
@@ -30,6 +30,8 @@
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/xterm": "^6.0.0",
     "@xyflow/react": "^12.11.2",
+    "dockview": "8.2.0",
+    "dockview-react": "8.2.0",
     "react": "19.2.7",
     "react-dom": "19.2.7",
     "react-markdown": "^10.1.0",

--- a/packages/gui/src/renderer/components/terminal/TerminalChrome.tsx
+++ b/packages/gui/src/renderer/components/terminal/TerminalChrome.tsx
@@ -1,0 +1,239 @@
+import type { FormEvent, ReactNode } from "react";
+import type { TerminalSessionRow } from "../../../../../daemon/src/gui-s3-control.ts";
+import type { TerminalPreferences } from "../../terminal-preferences.ts";
+import { t } from "../../i18n/index.tsx";
+
+const shellOptions = ["default", "zsh", "bash", "sh", "fish"] as const;
+
+/** 一个终端 tab(= pane group)在 tab 条上的投影。 */
+export interface TerminalTabChip {
+  readonly groupId: string;
+  readonly title: string;
+  readonly backend: string;
+  readonly paneCount: number;
+}
+export interface TerminalSpawnDraft {
+  readonly name: string;
+  readonly cwdScope: "repo-root" | "repo-relative";
+  readonly path: string;
+  readonly shellProfileId: string;
+  readonly taskId: string;
+}
+
+/**
+ * 终端页的固定 chrome:标题栏、tab 条、高级启动表单(PLT-TerminalWorkspace,W1 从
+ * TerminalView 抽出以隔离状态机与展示)。纯展示组件,不持状态、不直接调 terminal-client。
+ *
+ * tab 条的语义是 W1 的二级模型:一个 chip = 一个 group,chip 上的关闭键关的是整个 group
+ * (含其中全部 pane);group 内部的 split/关闭 pane 由 pane 自己的 header 承担。
+ */
+export function TerminalChrome({
+  repoId,
+  generation,
+  preferences,
+  onPreferenceChange,
+  chips,
+  activeGroupId,
+  onSelectGroup,
+  onCloseGroup,
+  onNewTab,
+  sessions,
+  openSessionIds,
+  onAttachSession,
+  spawn,
+  onSpawnChange,
+  onCreate,
+  tasks,
+}: {
+  readonly repoId: string;
+  readonly generation: number | null | undefined;
+  readonly preferences: TerminalPreferences;
+  readonly onPreferenceChange: (update: Partial<TerminalPreferences>) => void;
+  readonly chips: readonly TerminalTabChip[];
+  readonly activeGroupId: string | null;
+  readonly onSelectGroup: (groupId: string) => void;
+  readonly onCloseGroup: (groupId: string) => void;
+  readonly onNewTab: () => void;
+  readonly sessions: readonly TerminalSessionRow[];
+  readonly openSessionIds: readonly string[];
+  readonly onAttachSession: (sessionId: string) => void;
+  readonly spawn: TerminalSpawnDraft;
+  readonly onSpawnChange: (update: Partial<TerminalSpawnDraft>) => void;
+  readonly onCreate: (event: FormEvent) => void;
+  readonly tasks: readonly { readonly taskId: string; readonly title: string }[];
+}) {
+  return (
+    <>
+      <header className="flex items-center gap-2 border-b border-border px-3 py-1.5">
+        <strong className="text-[13px]">{t("terminal.view.localTerminal")}</strong>
+        <span className="font-mono text-[11px] text-text-faint">
+          {t("terminal.view.repoGeneration", {
+            repoId,
+            generation: generation ?? t("views.settingsView.systemUnknownDash"),
+          })}
+        </span>
+        <span
+          className="inline-flex overflow-hidden rounded border border-border-strong"
+          aria-label={t("terminal.view.backendForNew")}
+        >
+          <button
+            aria-pressed={preferences.backend === "direct-pty"}
+            onClick={() => onPreferenceChange({ backend: "direct-pty" })}
+            className={toggleClassName(preferences.backend === "direct-pty")}
+          >
+            {t("terminal.view.backendDirect")}
+          </button>
+          <button
+            aria-pressed={preferences.backend === "tmux"}
+            onClick={() => onPreferenceChange({ backend: "tmux" })}
+            className={toggleClassName(preferences.backend === "tmux")}
+          >
+            {t("terminal.view.backendTmux")}
+          </button>
+        </span>
+        <span className="ml-auto font-mono text-[11px] text-text-faint" title={t("terminal.view.splitShortcut")}>
+          {t("terminal.view.shortcut")} · {t("terminal.view.splitShortcut")}
+        </span>
+      </header>
+      <div className="flex min-w-0 items-center gap-1 overflow-x-auto border-b border-border px-2 py-1">
+        {chips.map((chip) => (
+          <span key={chip.groupId} className={tabClassName(activeGroupId === chip.groupId)}>
+            <button
+              onClick={() => onSelectGroup(chip.groupId)}
+              className="max-w-44 truncate px-2 py-1 text-[11px] text-text"
+            >
+              {chip.title} <span className="font-mono text-text-faint">· {chip.backend}</span>
+              {chip.paneCount > 1 && (
+                <span className="font-mono text-text-faint">
+                  {" "}
+                  · {t("terminal.view.groupPaneCount", { count: chip.paneCount })}
+                </span>
+              )}
+            </button>
+            <button
+              onClick={() => onCloseGroup(chip.groupId)}
+              aria-label={t("terminal.view.closeTabAria", { name: chip.title })}
+              title={t("terminal.view.closeDetachTitle")}
+              className="border-l border-border px-1.5 text-text-faint hover:bg-surface-overlay"
+            >
+              ×
+            </button>
+          </span>
+        ))}
+        <button
+          onClick={onNewTab}
+          title={t("terminal.view.quickStartTitle")}
+          aria-label={t("terminal.view.newTab")}
+          className="shrink-0 rounded border border-accent/60 bg-accent/10 px-2 py-1 text-[13px] text-text"
+        >
+          +
+        </button>
+        <select
+          aria-label={t("terminal.view.attachExisting")}
+          defaultValue=""
+          onChange={(event) => {
+            if (event.target.value) onAttachSession(event.target.value);
+            event.target.value = "";
+          }}
+          className="control ml-auto shrink-0"
+        >
+          <option value="">{t("terminal.view.attachSession")}</option>
+          {sessions.map((row) => (
+            // 同一会话被两个 pane 同时 attach 的语义本波不支持:已在某个 pane 里的会话直接禁选。
+            <option
+              key={row.sessionId}
+              value={row.sessionId}
+              disabled={!row.attachable || openSessionIds.includes(row.sessionId)}
+            >
+              {row.name} · {row.backend} · {row.status}
+            </option>
+          ))}
+        </select>
+      </div>
+      <details className="border-b border-border px-3 py-1 text-[11px]">
+        <summary className="cursor-pointer text-text-muted">{t("terminal.view.advanced")}</summary>
+        <form onSubmit={onCreate} className="flex flex-wrap items-end gap-2 py-2">
+          <Field label={t("terminal.view.name")}>
+            <input
+              value={spawn.name}
+              onChange={(event) => onSpawnChange({ name: event.target.value })}
+              className="control w-28"
+            />
+          </Field>
+          <Field label={t("terminal.view.cwd")}>
+            <select
+              value={spawn.cwdScope}
+              onChange={(event) => onSpawnChange({ cwdScope: event.target.value as TerminalSpawnDraft["cwdScope"] })}
+              className="control"
+            >
+              <option value="repo-root">repo-root</option>
+              <option value="repo-relative">repo-relative</option>
+            </select>
+          </Field>
+          {spawn.cwdScope === "repo-relative" && (
+            <Field label={t("terminal.view.path")}>
+              <input
+                required
+                value={spawn.path}
+                onChange={(event) => onSpawnChange({ path: event.target.value })}
+                className="control w-36"
+              />
+            </Field>
+          )}
+          <Field label={t("terminal.view.shell")}>
+            <select
+              value={spawn.shellProfileId}
+              onChange={(event) => onSpawnChange({ shellProfileId: event.target.value })}
+              className="control"
+            >
+              {shellOptions.map((option) => (
+                <option key={option} value={option}>
+                  {option}
+                </option>
+              ))}
+            </select>
+          </Field>
+          <Field label={t("terminal.view.task")}>
+            <select
+              value={spawn.taskId}
+              onChange={(event) => onSpawnChange({ taskId: event.target.value })}
+              className="control max-w-44"
+            >
+              <option value="">{t("terminal.view.unbound")}</option>
+              {tasks.map((task) => (
+                // G10:实体 ID 不落在不可激活文本里;taskId 走机器值/tooltip,文本用标题。
+                <option key={task.taskId} value={task.taskId} title={task.taskId}>
+                  {task.title}
+                </option>
+              ))}
+            </select>
+          </Field>
+          <button className="rounded border border-accent/60 bg-accent/10 px-3 py-1 text-[12px] text-text">
+            {t("terminal.view.startCustom")}
+          </button>
+        </form>
+      </details>
+    </>
+  );
+}
+
+function toggleClassName(selected: boolean): string {
+  return [
+    "px-2 py-1 text-[11px]",
+    selected ? "bg-accent text-accent-fg" : "text-text-muted hover:bg-surface-raised",
+  ].join(" ");
+}
+function tabClassName(selected: boolean): string {
+  return [
+    "inline-flex shrink-0 overflow-hidden rounded border",
+    selected ? "border-accent/60 bg-surface-raised" : "border-border",
+  ].join(" ");
+}
+function Field({ label, children }: { readonly label: string; readonly children: ReactNode }) {
+  return (
+    <label className="grid gap-0.5 font-mono text-[10px] uppercase tracking-wide text-text-faint">
+      {label}
+      {children}
+    </label>
+  );
+}

--- a/packages/gui/src/renderer/components/terminal/TerminalPaneCard.tsx
+++ b/packages/gui/src/renderer/components/terminal/TerminalPaneCard.tsx
@@ -1,0 +1,157 @@
+import type { IDockviewPanelProps } from "dockview-react";
+import { TerminalPane } from "./TerminalPane.tsx";
+import { useTerminalPaneActions, type TerminalSplitDirection } from "./terminal-pane-context.ts";
+import type { TerminalTab } from "../../terminal-model.ts";
+import { t } from "../../i18n/index.tsx";
+
+const warningClassName = [
+  "border-b border-status-blocked/30 bg-status-blocked/10",
+  "px-2 py-1 text-[11px] text-status-blocked",
+].join(" ");
+
+/**
+ * 一个 split pane 的完整外观:自带 header(会话元信息 + 分割/关闭/终止)与 xterm 面板。
+ *
+ * dockview 的 group header 被隐藏(每个 group 恒定一个 panel,tab=group 的二级模型不允许
+ * pane 再叠成第二层 tab),所以 pane 的标题栏由本组件自己画。载荷只认 params.sessionId:
+ * 布局恢复后会话已消失时渲染可关闭占位,不阻塞其它 pane。
+ */
+export function TerminalPaneCard(props: IDockviewPanelProps<{ readonly sessionId: string }>) {
+  const actions = useTerminalPaneActions();
+  const panelId = props.api.id,
+    sessionId = props.params.sessionId,
+    tab = actions.session(sessionId),
+    focused = actions.focusedPanelId === panelId;
+  return (
+    <div
+      data-testid="terminal-pane-card"
+      data-pane-id={panelId}
+      data-session-id={sessionId}
+      data-focused={focused ? "true" : "false"}
+      onFocusCapture={() => actions.onFocusPane(panelId)}
+      onMouseDownCapture={() => actions.onFocusPane(panelId)}
+      className={[
+        "flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden",
+        focused ? "outline outline-1 -outline-offset-1 outline-accent/50" : "",
+      ].join(" ")}
+    >
+      <div className="flex flex-wrap items-center gap-2 border-b border-border px-2 py-1 text-[11px]">
+        <span className="truncate font-mono text-text-faint">
+          {tab ? `${tab.name} · ${tab.cwd} · ${tab.backend} · ${tab.durability} · ${tab.state}` : sessionId}
+        </span>
+        <span className="ml-auto inline-flex items-center gap-1">
+          <SplitButton panelId={panelId} direction="right" />
+          <SplitButton panelId={panelId} direction="below" />
+          <button
+            onClick={() => actions.onClosePane(panelId, sessionId)}
+            aria-label={t("terminal.view.closePaneAria", { name: tab?.name ?? sessionId })}
+            title={t("terminal.view.closeDetachTitle")}
+            className="rounded px-2 py-1 text-text-muted hover:bg-surface-raised"
+          >
+            {t("terminal.view.closePane")}
+          </button>
+        </span>
+        {tab && <TerminateControls tab={tab} />}
+      </div>
+      {tab ? <LivePane tab={tab} /> : <DeadPane panelId={panelId} sessionId={sessionId} />}
+    </div>
+  );
+}
+
+function LivePane({ tab }: { readonly tab: TerminalTab }) {
+  const actions = useTerminalPaneActions();
+  const interactive = tab.state === "running" && tab.attachable;
+  return (
+    <>
+      {tab.warning && (
+        <p role="status" className={warningClassName}>
+          {tab.backend === "direct-pty"
+            ? t("terminal.view.tmuxFallbackWarning")
+            : t("terminal.view.tmuxUnavailableWarning")}
+        </p>
+      )}
+      {tab.notice && (
+        <p role="status" className={warningClassName}>
+          {tab.notice}
+        </p>
+      )}
+      {tab.state === "running" || tab.output ? (
+        <TerminalPane
+          output={tab.output}
+          interactive={interactive}
+          onInput={(utf8) => actions.onInput(tab.sessionId, utf8)}
+          onFit={(cols, rows) => actions.onFit(tab.sessionId, cols, rows)}
+        />
+      ) : (
+        <div className="grid flex-1 place-items-center px-4 text-center text-[12px] text-text-faint">
+          {tab.notice ?? t("terminal.view.sessionNotInteractive")}
+        </div>
+      )}
+    </>
+  );
+}
+
+/** 布局恢复后 daemon 侧已无对应会话:占位保留位置与关闭入口,不静默吞掉这个 pane。 */
+function DeadPane({ panelId, sessionId }: { readonly panelId: string; readonly sessionId: string }) {
+  const actions = useTerminalPaneActions();
+  return (
+    <div
+      role="status"
+      data-testid="terminal-pane-dead"
+      className="grid flex-1 place-items-center gap-2 px-4 text-center text-[12px] text-text-faint"
+    >
+      <span>{t("terminal.view.paneSessionGone")}</span>
+      <button
+        onClick={() => actions.onClosePane(panelId, sessionId)}
+        className="rounded border border-border px-2 py-1 text-text-muted hover:bg-surface-raised"
+      >
+        {t("terminal.view.closePane")}
+      </button>
+    </div>
+  );
+}
+
+function SplitButton({ panelId, direction }: { readonly panelId: string; readonly direction: TerminalSplitDirection }) {
+  const actions = useTerminalPaneActions();
+  const label = direction === "right" ? t("terminal.view.splitRight") : t("terminal.view.splitDown");
+  return (
+    <button
+      onClick={() => actions.onSplitPane(panelId, direction)}
+      aria-label={label}
+      title={label}
+      className="rounded px-2 py-1 text-text-muted hover:bg-surface-raised"
+    >
+      {direction === "right" ? "⇹" : "⇳"}
+    </button>
+  );
+}
+
+function TerminateControls({ tab }: { readonly tab: TerminalTab }) {
+  const actions = useTerminalPaneActions();
+  if (actions.confirmSessionId !== tab.sessionId)
+    return (
+      <button
+        onClick={() => actions.setConfirmSessionId(tab.sessionId)}
+        className="rounded px-2 py-1 text-status-blocked hover:bg-surface-raised"
+      >
+        {t("terminal.view.terminate")}
+      </button>
+    );
+  return (
+    <>
+      <span className="text-status-blocked">{t("terminal.view.confirmTerminatePrompt")}</span>
+      <button
+        onClick={() => actions.setConfirmSessionId(null)}
+        className="rounded px-2 py-1 text-text-muted hover:bg-surface-raised"
+      >
+        {t("terminal.view.cancel")}
+      </button>
+      <button
+        onClick={() => actions.onTerminate(tab.sessionId)}
+        className="rounded px-2 py-1 text-status-blocked hover:bg-surface-raised"
+      >
+        {t("terminal.view.confirmTerminate")}
+      </button>
+    </>
+  );
+}

--- a/packages/gui/src/renderer/components/terminal/TerminalSplitGrid.tsx
+++ b/packages/gui/src/renderer/components/terminal/TerminalSplitGrid.tsx
@@ -1,0 +1,113 @@
+import { useCallback, useEffect, useRef } from "react";
+import {
+  DockviewReact,
+  themeAbyss,
+  type DockviewApi,
+  type DockviewReadyEvent,
+  type SerializedDockview,
+} from "dockview-react";
+import "dockview-react/dist/styles/dockview.css";
+import { consumeKnownError } from "../../../api/error-consumption.ts";
+import type { TerminalGridSnapshot, TerminalPaneRef } from "../../terminal-layout.ts";
+import { TerminalPaneCard } from "./TerminalPaneCard.tsx";
+
+/** 组件注册表必须是稳定引用,否则 dockview 每次渲染都会重建 panel 渲染器。 */
+const components = { terminalPane: TerminalPaneCard };
+export const terminalPaneComponent = "terminalPane";
+
+/**
+ * 一个终端 tab(= group)内部的 pane 树宿主(PLT-TerminalWorkspace W1)。
+ *
+ * dockview 的能力在此裁剪到「split + 拖拽调比例」:关掉 tab 拖拽(disableDnd)、浮动组与
+ * popout,并隐藏每个 dockview group 的 header——本页的 tab 语义由外层 tab 条承担,pane 不
+ * 允许再叠成第二层 tab,所以恒定「一个 dockview group = 一个 pane」。留下的交互只有 sash
+ * 拖拽调比例,与 xterm 自身的鼠标选区不重叠(选区在 pane 内部,sash 在 pane 边界之外)。
+ *
+ * 布局是 dockview 的 `toJSON()` 快照,只在挂载时用 `fromJSON` 恢复一次;之后 dockview 是
+ * 布局权威,任何变更经 onLayoutChange 回流给调用方持久化。父组件按 groupId 作 key 重挂。
+ */
+export function TerminalSplitGrid({
+  seeds,
+  grid,
+  onApiReady,
+  onLayoutChange,
+  onActivePaneChange,
+}: {
+  readonly seeds: readonly TerminalPaneRef[];
+  readonly grid: TerminalGridSnapshot | null;
+  readonly onApiReady: (api: DockviewApi | null) => void;
+  readonly onLayoutChange: (grid: TerminalGridSnapshot) => void;
+  readonly onActivePaneChange: (panelId: string | null) => void;
+}) {
+  const seedsRef = useRef(seeds),
+    gridRef = useRef(grid),
+    onApiReadyRef = useRef(onApiReady),
+    onLayoutChangeRef = useRef(onLayoutChange),
+    onActivePaneChangeRef = useRef(onActivePaneChange),
+    apiRef = useRef<DockviewApi | null>(null);
+  onApiReadyRef.current = onApiReady;
+  onLayoutChangeRef.current = onLayoutChange;
+  onActivePaneChangeRef.current = onActivePaneChange;
+
+  const ready = useCallback((event: DockviewReadyEvent) => {
+    const api = event.api;
+    apiRef.current = api;
+    restore(api, gridRef.current, seedsRef.current);
+    for (const group of api.groups) group.header.hidden = true;
+    api.onDidAddGroup((group) => {
+      group.header.hidden = true;
+    });
+    const snapshot = () => api.toJSON() as unknown as TerminalGridSnapshot;
+    api.onDidLayoutChange(() => onLayoutChangeRef.current(snapshot()));
+    api.onDidActivePanelChange((change) => onActivePaneChangeRef.current(change.panel?.id ?? null));
+    // 恢复/播种发生在订阅之前(避免损坏快照的 clear 被当成「组已空」),补一帧初始快照,
+    // 让「只开了一个 pane、从未再动过布局」的 group 也有可恢复的 grid。
+    if (api.panels.length > 0) onLayoutChangeRef.current(snapshot());
+    onActivePaneChangeRef.current(api.activePanel?.id ?? null);
+    onApiReadyRef.current(api);
+  }, []);
+
+  useEffect(
+    () => () => {
+      apiRef.current = null;
+      onApiReadyRef.current(null);
+    },
+    [],
+  );
+
+  return (
+    <DockviewReact
+      components={components}
+      onReady={ready}
+      theme={themeAbyss}
+      className="min-h-0 flex-1"
+      disableDnd
+      disableFloatingGroups
+      disableTabsOverflowList
+      hideBorders
+      singleTabMode="fullwidth"
+      noPanelsOverlay="emptyGroup"
+    />
+  );
+}
+
+/** 优先按快照恢复;快照损坏或为空时退回按 seeds 依次向右展开。 */
+function restore(api: DockviewApi, grid: TerminalGridSnapshot | null, seeds: readonly TerminalPaneRef[]): void {
+  if (grid) {
+    try {
+      api.fromJSON(grid as unknown as SerializedDockview);
+      if (api.panels.length > 0) return;
+    } catch (cause) {
+      consumeKnownError(cause);
+      api.clear();
+    }
+  }
+  seeds.forEach((seed, index) => {
+    api.addPanel({
+      id: seed.panelId,
+      component: terminalPaneComponent,
+      params: { sessionId: seed.sessionId },
+      ...(index === 0 ? {} : { position: { referencePanel: seeds[index - 1].panelId, direction: "right" as const } }),
+    });
+  });
+}

--- a/packages/gui/src/renderer/components/terminal/terminal-pane-context.ts
+++ b/packages/gui/src/renderer/components/terminal/terminal-pane-context.ts
@@ -1,0 +1,33 @@
+import { createContext, useContext } from "react";
+import type { TerminalTab } from "../../terminal-model.ts";
+
+/** 分割方向:right = 竖直分隔条(左右并排),below = 水平分隔条(上下叠放)。 */
+export type TerminalSplitDirection = "right" | "below";
+
+/**
+ * pane 载荷与动作的注入面(PLT-TerminalWorkspace W1)。
+ *
+ * dockview 的 panel 由 dockview 自己的 DOM 宿主渲染,但 dockview-react 用 portal 把
+ * React 元素挂回调用方的树,因此 context 照常穿透:pane 组件只拿 sessionId,会话状态
+ * 与全部副作用都从这里取,W0 的会话状态机(terminal-model / terminal-client)不下沉。
+ */
+export interface TerminalPaneActions {
+  readonly session: (sessionId: string) => TerminalTab | null;
+  readonly focusedPanelId: string | null;
+  readonly confirmSessionId: string | null;
+  readonly setConfirmSessionId: (sessionId: string | null) => void;
+  readonly onInput: (sessionId: string, utf8: string) => void;
+  readonly onFit: (sessionId: string, cols: number, rows: number) => void;
+  readonly onFocusPane: (panelId: string) => void;
+  readonly onClosePane: (panelId: string, sessionId: string) => void;
+  readonly onSplitPane: (panelId: string, direction: TerminalSplitDirection) => void;
+  readonly onTerminate: (sessionId: string) => void;
+}
+
+export const TerminalPaneContext = createContext<TerminalPaneActions | null>(null);
+
+export function useTerminalPaneActions(): TerminalPaneActions {
+  const value = useContext(TerminalPaneContext);
+  if (!value) throw new Error("TerminalPaneContext is missing; render panes inside TerminalSplitGrid.");
+  return value;
+}

--- a/packages/gui/src/renderer/i18n/locales/en-US/terminal.json
+++ b/packages/gui/src/renderer/i18n/locales/en-US/terminal.json
@@ -33,5 +33,12 @@
   "terminal.view.confirmTerminatePrompt": "Terminate the background session?",
   "terminal.view.cancel": "Cancel",
   "terminal.view.confirmTerminate": "Confirm terminate",
-  "terminal.view.terminate": "Terminate…"
+  "terminal.view.terminate": "Terminate…",
+  "terminal.view.splitShortcut": "Ctrl+Shift+5/6 split · Ctrl+Shift+W close pane · Ctrl+Alt+Arrows focus",
+  "terminal.view.splitRight": "Split right",
+  "terminal.view.splitDown": "Split down",
+  "terminal.view.closePane": "Close pane",
+  "terminal.view.closePaneAria": "Close pane {name}",
+  "terminal.view.paneSessionGone": "This pane's session is gone from the daemon; the layout was restored, close the pane to drop it.",
+  "terminal.view.groupPaneCount": "{count} panes"
 }

--- a/packages/gui/src/renderer/i18n/locales/zh-CN/terminal.json
+++ b/packages/gui/src/renderer/i18n/locales/zh-CN/terminal.json
@@ -33,5 +33,12 @@
   "terminal.view.confirmTerminatePrompt": "终止后台会话？",
   "terminal.view.cancel": "取消",
   "terminal.view.confirmTerminate": "确认终止",
-  "terminal.view.terminate": "终止…"
+  "terminal.view.terminate": "终止…",
+  "terminal.view.splitShortcut": "Ctrl+Shift+5/6 分屏 · Ctrl+Shift+W 关 pane · Ctrl+Alt+方向键 切焦点",
+  "terminal.view.splitRight": "向右分屏",
+  "terminal.view.splitDown": "向下分屏",
+  "terminal.view.closePane": "关闭 pane",
+  "terminal.view.closePaneAria": "关闭 pane {name}",
+  "terminal.view.paneSessionGone": "这个 pane 的会话已不在 daemon 侧;布局已恢复，关闭它即可。",
+  "terminal.view.groupPaneCount": "{count} pane"
 }

--- a/packages/gui/src/renderer/terminal-layout.ts
+++ b/packages/gui/src/renderer/terminal-layout.ts
@@ -1,0 +1,116 @@
+import { consumeKnownError } from "../api/error-consumption.ts";
+import { isRendererRecord } from "./result-validation.ts";
+
+const schema = "terminal-layout/v1",
+  storageKey = "harness:gui:terminal-layout",
+  maxRepositories = 8;
+
+/**
+ * 终端页分屏布局的本地持久化(PLT-TerminalWorkspace W1)。
+ *
+ * 二级模型抄 VS Code:外层 tab = group,group 内才是 split pane 树。group 的 pane 树
+ * 直接存 dockview 的 `toJSON()` 快照——它对渲染层是不透明载荷,唯一被本模块解释的是
+ * `panels[<panelId>].params.sessionId`:恢复时按 sessionId 找回 daemon 侧会话并重新
+ * attach,找不到的 pane 渲染为可关闭占位(会话与布局各自持久,不互相绑架)。
+ *
+ * 只落 renderer 侧 localStorage,不进 daemon 协议;键名沿用 terminal-preferences 的
+ * `harness:gui:` 前缀惯例,按 repoId 分槽(每个仓一套布局),超出上限时丢最旧的槽。
+ */
+export type TerminalGridSnapshot = Record<string, unknown>;
+
+export interface TerminalPaneRef {
+  readonly panelId: string;
+  readonly sessionId: string;
+}
+export interface TerminalGroupLayout {
+  readonly groupId: string;
+  /** 新建 group 尚未挂载 dockview 时的初始 pane;grid 落盘后只作兜底。 */
+  readonly seeds: readonly TerminalPaneRef[];
+  readonly grid: TerminalGridSnapshot | null;
+}
+export interface TerminalRepoLayout {
+  readonly activeGroupId: string | null;
+  readonly groups: readonly TerminalGroupLayout[];
+}
+
+export const emptyTerminalRepoLayout: TerminalRepoLayout = { activeGroupId: null, groups: [] };
+
+export interface TerminalLayoutStorage {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+}
+
+/** group 当前的 pane 列表:一旦有 dockview 快照,快照就是唯一权威(空快照 = 空 group)。 */
+export function groupPaneRefs(group: TerminalGroupLayout): readonly TerminalPaneRef[] {
+  return group.grid ? gridPaneRefs(group.grid) : group.seeds;
+}
+
+/** 从 dockview 快照里抽出 pane→session 映射(插入序即 panels 键序)。 */
+export function gridPaneRefs(grid: TerminalGridSnapshot): readonly TerminalPaneRef[] {
+  const panels = grid.panels;
+  if (!isRendererRecord(panels)) return [];
+  return Object.entries(panels).flatMap(([panelId, panel]) => {
+    if (!isRendererRecord(panel)) return [];
+    const params = panel.params;
+    if (!isRendererRecord(params) || typeof params.sessionId !== "string" || params.sessionId === "") return [];
+    return [{ panelId, sessionId: params.sessionId }];
+  });
+}
+
+/** 布局里出现过的全部 session id(去重,保持首次出现顺序)。 */
+export function layoutSessionIds(layout: TerminalRepoLayout): readonly string[] {
+  return [...new Set(layout.groups.flatMap((group) => groupPaneRefs(group).map((pane) => pane.sessionId)))];
+}
+
+export function readTerminalLayout(
+  storage: Pick<TerminalLayoutStorage, "getItem">,
+  repoId: string,
+): TerminalRepoLayout {
+  try {
+    const parsed: unknown = JSON.parse(storage.getItem(storageKey) ?? "null");
+    if (!isRendererRecord(parsed) || parsed.schema !== schema || !isRendererRecord(parsed.repos))
+      return emptyTerminalRepoLayout;
+    return repoLayout(parsed.repos[repoId]);
+  } catch (cause) {
+    consumeKnownError(cause);
+    return emptyTerminalRepoLayout;
+  }
+}
+
+export function writeTerminalLayout(storage: TerminalLayoutStorage, repoId: string, layout: TerminalRepoLayout): void {
+  try {
+    const parsed: unknown = JSON.parse(storage.getItem(storageKey) ?? "null");
+    const existing = isRendererRecord(parsed) && isRendererRecord(parsed.repos) ? parsed.repos : {};
+    const kept = Object.entries(existing).filter(([key]) => key !== repoId);
+    const repos = Object.fromEntries([...kept.slice(-(maxRepositories - 1)), [repoId, layout]]);
+    storage.setItem(storageKey, JSON.stringify({ schema, repos }));
+  } catch (cause) {
+    consumeKnownError(cause);
+  }
+}
+
+function repoLayout(value: unknown): TerminalRepoLayout {
+  if (!isRendererRecord(value) || !Array.isArray(value.groups)) return emptyTerminalRepoLayout;
+  const groups = value.groups.flatMap(groupLayout);
+  const activeGroupId = typeof value.activeGroupId === "string" ? value.activeGroupId : null;
+  return {
+    groups,
+    activeGroupId: groups.some((group) => group.groupId === activeGroupId)
+      ? activeGroupId
+      : (groups[0]?.groupId ?? null),
+  };
+}
+
+function groupLayout(value: unknown): readonly TerminalGroupLayout[] {
+  if (!isRendererRecord(value) || typeof value.groupId !== "string" || value.groupId === "") return [];
+  const grid = isRendererRecord(value.grid) ? (value.grid as TerminalGridSnapshot) : null;
+  const seeds = Array.isArray(value.seeds) ? value.seeds.flatMap(paneRef) : [];
+  const group: TerminalGroupLayout = { groupId: value.groupId, seeds, grid };
+  return groupPaneRefs(group).length > 0 ? [group] : [];
+}
+
+function paneRef(value: unknown): readonly TerminalPaneRef[] {
+  if (!isRendererRecord(value) || typeof value.panelId !== "string" || typeof value.sessionId !== "string") return [];
+  if (value.panelId === "" || value.sessionId === "") return [];
+  return [{ panelId: value.panelId, sessionId: value.sessionId }];
+}

--- a/packages/gui/src/renderer/terminal-pane-focus.ts
+++ b/packages/gui/src/renderer/terminal-pane-focus.ts
@@ -1,0 +1,71 @@
+/**
+ * pane 方向焦点导航(PLT-TerminalWorkspace W1,Tabby 的方向导航语义)。
+ *
+ * 输入是各 pane 在页面上的矩形(渲染层用 `getBoundingClientRect()` 采集),
+ * 输出是该方向上应接管焦点的 pane。选取顺序:先要求候选整体位于该方向之外侧,
+ * 再优先与当前 pane 在正交轴上有重叠的(同一行/同一列),然后取该方向距离最近的,
+ * 最后用正交轴中心距离拆平局。纯函数:不碰 DOM,便于对几何布局直接断言。
+ */
+export type PaneDirection = "left" | "right" | "up" | "down";
+
+export interface PaneBox {
+  readonly panelId: string;
+  readonly left: number;
+  readonly top: number;
+  readonly right: number;
+  readonly bottom: number;
+}
+
+/** 相邻判定容差(px):sash 借位与亚像素布局不应让相邻 pane 落选。 */
+const tolerance = 1;
+
+export function directionalPane(
+  boxes: readonly PaneBox[],
+  activePanelId: string | null,
+  direction: PaneDirection,
+): string | null {
+  const active = boxes.find((box) => box.panelId === activePanelId);
+  if (!active) return null;
+  const ranked = boxes
+    .filter((box) => box.panelId !== active.panelId && isBeyond(active, box, direction))
+    .map((box) => ({ panelId: box.panelId, score: score(active, box, direction) }))
+    .sort((left, right) => compare(left.score, right.score));
+  return ranked[0]?.panelId ?? null;
+}
+
+function isBeyond(active: PaneBox, box: PaneBox, direction: PaneDirection): boolean {
+  if (direction === "left") return box.right <= active.left + tolerance;
+  if (direction === "right") return box.left >= active.right - tolerance;
+  if (direction === "up") return box.bottom <= active.top + tolerance;
+  return box.top >= active.bottom - tolerance;
+}
+
+/** [正交轴无重叠?, 该方向的间距, 正交轴中心距离] —— 依次比较,越小越优先。 */
+function score(active: PaneBox, box: PaneBox, direction: PaneDirection): readonly [number, number, number] {
+  const horizontal = direction === "left" || direction === "right";
+  const gap =
+    direction === "left"
+      ? active.left - box.right
+      : direction === "right"
+        ? box.left - active.right
+        : direction === "up"
+          ? active.top - box.bottom
+          : box.top - active.bottom;
+  const overlap = horizontal
+    ? Math.min(active.bottom, box.bottom) - Math.max(active.top, box.top)
+    : Math.min(active.right, box.right) - Math.max(active.left, box.left);
+  const crossDistance = horizontal
+    ? Math.abs(center(active.top, active.bottom) - center(box.top, box.bottom))
+    : Math.abs(center(active.left, active.right) - center(box.left, box.right));
+  return [overlap > 0 ? 0 : 1, Math.abs(gap), crossDistance];
+}
+
+function compare(left: readonly [number, number, number], right: readonly [number, number, number]): number {
+  for (let index = 0; index < left.length; index += 1)
+    if (left[index] !== right[index]) return left[index] - right[index];
+  return 0;
+}
+
+function center(low: number, high: number): number {
+  return (low + high) / 2;
+}

--- a/packages/gui/src/renderer/views/TerminalView.tsx
+++ b/packages/gui/src/renderer/views/TerminalView.tsx
@@ -1,5 +1,6 @@
-import { useCallback, useEffect, useRef, useState, type FormEvent } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, type FormEvent } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
+import type { DockviewApi } from "dockview-react";
 import type { TerminalSessionRow } from "../../../../daemon/src/gui-s3-control.ts";
 import {
   closeTerminalTab,
@@ -20,15 +21,40 @@ import {
   writeTerminalPreferences,
   type TerminalPreferences,
 } from "../terminal-preferences.ts";
-import { TerminalPane } from "../components/terminal/TerminalPane.tsx";
+import {
+  groupPaneRefs,
+  gridPaneRefs,
+  layoutSessionIds,
+  readTerminalLayout,
+  writeTerminalLayout,
+  type TerminalGridSnapshot,
+  type TerminalGroupLayout,
+} from "../terminal-layout.ts";
+import { directionalPane, type PaneBox, type PaneDirection } from "../terminal-pane-focus.ts";
+import {
+  TerminalChrome,
+  type TerminalSpawnDraft,
+  type TerminalTabChip,
+} from "../components/terminal/TerminalChrome.tsx";
+import { TerminalSplitGrid, terminalPaneComponent } from "../components/terminal/TerminalSplitGrid.tsx";
+import {
+  TerminalPaneContext,
+  type TerminalPaneActions,
+  type TerminalSplitDirection,
+} from "../components/terminal/terminal-pane-context.ts";
 import { t } from "../i18n/index.tsx";
 
 /**
- * 终端一等页面(PLT-TerminalWorkspace W0):承接原底部终端 dock 的全部能力——
- * 多 tab、快速新建、attach 已有会话、断线重连(generation 对账)、gap 提示、
- * exit 只读、tmux/direct-pty 双后端。状态机复用 terminal-model,渲染复用 TerminalPane,
- * 本组件只搬 UI 壳。页面语义:进入页面 = 打开终端面;离开页面(或切仓)= 停止全部
- * 流并 detach 全部附件(与 dock 关闭路径同一条 closeTerminalTab/terminalClient.detach 通路)。
+ * 终端一等页面(PLT-TerminalWorkspace W0 + W1)。
+ *
+ * W0 语义不变:多 tab、快速新建、attach 已有会话、断线重连(generation 对账)、gap 提示、
+ * exit 只读、tmux/direct-pty 双后端;进入页面 = 打开终端面,离开页面(或切仓)= 停止全部流
+ * 并 detach 全部附件。会话状态机仍是 terminal-model,传输仍是 terminal-client。
+ *
+ * W1 在其上加二级模型(抄 VS Code):**tab = group**,group 内才是 split pane 树。
+ * pane 树由 dockview 承载(见 TerminalSplitGrid),布局快照按仓存 localStorage,重启后
+ * 按 pane 载荷里的 sessionId 逐个 re-attach,会话已消失的 pane 渲染可关闭占位。每个 pane
+ * 自带 ResizeObserver + fit,cols/rows 各自走既有 resize 通道上报,互不干扰。
  */
 interface Props {
   readonly repoId: string;
@@ -48,31 +74,36 @@ type AttachRow = Pick<
   | "warning"
   | "attachable"
 >;
-const shellOptions = ["default", "zsh", "bash", "sh", "fish"] as const;
-const warningClassName = [
-  "border-b border-status-blocked/30 bg-status-blocked/10",
-  "px-2 py-1 text-[11px] text-status-blocked",
-].join(" ");
+/** 新会话的落位:开新 tab(group),还是在当前 group 里从某个 pane 分割出来。 */
+type Placement =
+  | { readonly kind: "group" }
+  | { readonly kind: "split"; readonly referencePanelId: string; readonly direction: TerminalSplitDirection };
 
 export function TerminalView({ repoId, daemonGeneration, tasks }: Props) {
   const queryClient = useQueryClient(),
-    [tabs, setTabs] = useState<readonly TerminalTab[]>([]);
+    [tabs, setTabs] = useState<readonly TerminalTab[]>([]),
+    [groups, setGroups] = useState<readonly TerminalGroupLayout[]>([]),
+    [activeGroupId, setActiveGroupId] = useState<string | null>(null),
+    [focusedPanelId, setFocusedPanelId] = useState<string | null>(null);
   const tabsRef = useRef(tabs),
+    groupsRef = useRef(groups),
+    focusedPanelIdRef = useRef(focusedPanelId),
+    gridApi = useRef<DockviewApi | null>(null),
+    regionRef = useRef<HTMLDivElement>(null),
     stops = useRef(new Map<string, () => void>()),
     repoIdRef = useRef(repoId),
     mountedRef = useRef(true);
   const ackSeq = useRef(new Map<string, number>()),
     inflight = useRef(new Map<string, Promise<void>>());
-  const autoStarted = useRef(new Set<string>());
-  const [activeId, setActiveId] = useState<string | null>(null);
+  const initialised = useRef(new Set<string>());
   const [error, setError] = useState<string | null>(null),
     [confirmId, setConfirmId] = useState<string | null>(null);
   const [preferences, setPreferences] = useState<TerminalPreferences>(() =>
     readTerminalPreferences(window.localStorage),
   );
-  const [spawn, setSpawn] = useState({
+  const [spawn, setSpawn] = useState<TerminalSpawnDraft>({
     name: t("terminal.view.title"),
-    cwdScope: "repo-root" as "repo-root" | "repo-relative",
+    cwdScope: "repo-root",
     path: "",
     shellProfileId: "default",
     taskId: "",
@@ -85,17 +116,26 @@ export function TerminalView({ repoId, daemonGeneration, tasks }: Props) {
   });
   const generation = daemonGeneration ?? sessions.data?.daemonGeneration;
   tabsRef.current = tabs;
+  groupsRef.current = groups;
+  focusedPanelIdRef.current = focusedPanelId;
   useEffect(() => {
     writeTerminalPreferences(window.localStorage, preferences);
   }, [preferences]);
+  // 布局只在该仓已完成一次恢复之后才回写,否则切仓瞬间的空布局会覆盖新仓的存档。
+  useEffect(() => {
+    if (repoId === "unselected" || !initialised.current.has(repoId)) return;
+    writeTerminalLayout(window.localStorage, repoId, { activeGroupId, groups });
+  }, [activeGroupId, groups, repoId]);
 
-  /** 离开页面/切仓:停止全部流并 detach 全部附件;tab 列表随页面状态一并清空。 */
+  /** 离开页面/切仓:停止全部流并 detach 全部附件;tab/pane 布局随页面状态一并清空。 */
   const releaseTabs = useCallback(async (detachRepoId: string): Promise<void> => {
     const current = [...tabsRef.current];
     for (const stop of stops.current.values()) stop();
     stops.current.clear();
     setTabs([]);
-    setActiveId(null);
+    setGroups([]);
+    setActiveGroupId(null);
+    setFocusedPanelId(null);
     await Promise.all(
       current.flatMap((tab) =>
         tab.attachmentId
@@ -117,23 +157,19 @@ export function TerminalView({ repoId, daemonGeneration, tasks }: Props) {
     if (repoIdRef.current === repoId) return;
     const previous = repoIdRef.current;
     repoIdRef.current = repoId;
-    autoStarted.current.delete(previous);
+    initialised.current.delete(previous);
     void releaseTabs(previous);
   }, [repoId, releaseTabs]);
 
-  const attach = useCallback(
-    (row: AttachRow, afterSeq = 0) => {
-      if (!row.attachable || row.status !== "running") {
-        setError(t("terminal.view.sessionNotAttachable"));
-        return;
-      }
+  /** 只接会话流,不管落位;布局恢复走这条,不会给已有 pane 再造一个。 */
+  const attachStream = useCallback(
+    (row: AttachRow, afterSeq: number) => {
       stops.current.get(row.sessionId)?.();
       setTabs((current) => {
         const found = current.find((tab) => tab.sessionId === row.sessionId);
         const next = tabFromRow(row, generation ?? 0, found, afterSeq);
         return found ? current.map((tab) => (tab.sessionId === row.sessionId ? next : tab)) : [...current, next];
       });
-      setActiveId(row.sessionId);
       setError(null);
       try {
         const stop = terminalClient.attach(repoId, row.sessionId, afterSeq, (value) =>
@@ -159,8 +195,48 @@ export function TerminalView({ repoId, daemonGeneration, tasks }: Props) {
     [generation, repoId],
   );
 
+  /** 把会话放进布局:开新 group,或在当前 group 内从 referencePanel 分割。 */
+  const placeSession = useCallback((sessionId: string, placement: Placement) => {
+    const existing = paneOfSession(groupsRef.current, sessionId);
+    if (existing) {
+      setActiveGroupId(existing.groupId);
+      setFocusedPanelId(existing.panelId);
+      return;
+    }
+    const panelId = `pane-${crypto.randomUUID()}`;
+    const api = gridApi.current;
+    if (placement.kind === "split" && api?.getPanel(placement.referencePanelId)) {
+      api.addPanel({
+        id: panelId,
+        component: terminalPaneComponent,
+        params: { sessionId },
+        position: { referencePanel: placement.referencePanelId, direction: placement.direction },
+      });
+      setFocusedPanelId(panelId);
+      return;
+    }
+    const groupId = `group-${crypto.randomUUID()}`;
+    const next = [...groupsRef.current, { groupId, seeds: [{ panelId, sessionId }], grid: null }];
+    groupsRef.current = next;
+    setGroups(next);
+    setActiveGroupId(groupId);
+    setFocusedPanelId(panelId);
+  }, []);
+
+  const attach = useCallback(
+    (row: AttachRow, afterSeq = 0, placement: Placement = { kind: "group" }) => {
+      if (!row.attachable || row.status !== "running") {
+        setError(t("terminal.view.sessionNotAttachable"));
+        return;
+      }
+      attachStream(row, afterSeq);
+      placeSession(row.sessionId, placement);
+    },
+    [attachStream, placeSession],
+  );
+
   const start = useCallback(
-    async (custom: boolean) => {
+    async (custom: boolean, placement: Placement = { kind: "group" }) => {
       setError(null);
       const cwd: TerminalSpawnInput["cwd"] =
         custom && spawn.cwdScope === "repo-relative"
@@ -189,7 +265,7 @@ export function TerminalView({ repoId, daemonGeneration, tasks }: Props) {
         queryClient.setQueryData(terminalQueryKeys.sessions(repoId), listed);
         const row = listed.sessions.find((item) => item.sessionId === receipt.sessionId);
         if (!row) throw new Error(t("terminal.view.spawnMissing"));
-        attach(row, 0);
+        attach(row, 0, placement);
       } catch (cause) {
         consumeKnownError(cause);
         setError(message(cause));
@@ -202,72 +278,200 @@ export function TerminalView({ repoId, daemonGeneration, tasks }: Props) {
     if (generation !== null && generation !== undefined)
       setTabs((current) => reconcileTerminalGeneration(current, generation));
   }, [generation]);
+  // 进页(或换仓后首次拿到会话表)的恢复入口:优先按存档的 pane 树恢复,
+  // 存档里的会话逐个 re-attach;没有存档时退回 W0 的「附加最近会话 / 新建」。
   useEffect(() => {
     const shouldSkip =
-      repoId === "unselected" || !sessions.isSuccess || tabsRef.current.length > 0 || autoStarted.current.has(repoId);
+      repoId === "unselected" || !sessions.isSuccess || groupsRef.current.length > 0 || initialised.current.has(repoId);
     if (shouldSkip) return;
-    autoStarted.current.add(repoId);
+    initialised.current.add(repoId);
+    const stored = readTerminalLayout(window.localStorage, repoId);
+    if (stored.groups.length > 0) {
+      setGroups(stored.groups);
+      groupsRef.current = stored.groups;
+      setActiveGroupId(stored.activeGroupId);
+      for (const sessionId of layoutSessionIds(stored)) {
+        const row = sessions.data.sessions.find((item) => item.sessionId === sessionId);
+        if (row?.attachable && row.status === "running") attachStream(row, 0);
+      }
+      return;
+    }
     const restored = mostRecentAttachableTerminal(sessions.data.sessions);
     if (restored) attach(restored, 0);
     else void start(false);
-  }, [attach, repoId, sessions.data, sessions.isSuccess, start]);
+  }, [attach, attachStream, repoId, sessions.data, sessions.isSuccess, start]);
 
   const create = (event: FormEvent) => {
     event.preventDefault();
     void start(true);
   };
-  const close = async (tab: TerminalTab) => {
-    try {
-      await closeTerminalTab(repoId, tab, {
-        stopStream: stops.current.get(tab.sessionId) ?? (() => undefined),
-        detach: terminalClient.detach,
-      });
-    } catch (cause) {
-      consumeKnownError(cause);
-      setError(message(cause));
-    }
-    stops.current.delete(tab.sessionId);
-    setTabs((current) => current.filter((item) => item.sessionId !== tab.sessionId));
-    setActiveId((current) => (current === tab.sessionId ? null : current));
-  };
-  const send = (sessionId: string, utf8: string) => {
-    const tail = inflight.current.get(sessionId) ?? Promise.resolve();
-    const next = tail
-      .then(async () => {
-        const seq = (ackSeq.current.get(sessionId) ?? 0) + 1;
-        ackSeq.current.set(sessionId, await terminalClient.input(repoId, sessionId, seq, utf8));
-      })
-      .catch((cause: unknown) => {
+  /** 只关会话(停流 + detach + 移出 tab 表),不动布局。 */
+  const closeSession = useCallback(
+    async (tab: TerminalTab) => {
+      try {
+        await closeTerminalTab(repoId, tab, {
+          stopStream: stops.current.get(tab.sessionId) ?? (() => undefined),
+          detach: terminalClient.detach,
+        });
+      } catch (cause) {
+        consumeKnownError(cause);
+        setError(message(cause));
+      }
+      stops.current.delete(tab.sessionId);
+      setTabs((current) => current.filter((item) => item.sessionId !== tab.sessionId));
+    },
+    [repoId],
+  );
+  const dropGroup = useCallback((groupId: string) => {
+    const remaining = groupsRef.current.filter((group) => group.groupId !== groupId);
+    groupsRef.current = remaining;
+    setGroups(remaining);
+    setActiveGroupId((current) => (current === groupId ? (remaining[remaining.length - 1]?.groupId ?? null) : current));
+  }, []);
+  const closeGroup = useCallback(
+    async (groupId: string) => {
+      const group = groupsRef.current.find(({ groupId: id }) => id === groupId);
+      const refs = group ? groupPaneRefs(group) : [];
+      dropGroup(groupId);
+      for (const ref of refs) {
+        const tab = tabsRef.current.find((item) => item.sessionId === ref.sessionId);
+        if (tab) await closeSession(tab);
+      }
+    },
+    [closeSession, dropGroup],
+  );
+  const closePane = useCallback(
+    async (panelId: string, sessionId: string) => {
+      // 最后一个 pane 关掉后 dockview 会给出空布局,group 由 onLayoutChange 一并回收。
+      // 只有当前 group 是挂载着的,所以拿不到 panel 时不动布局,只把会话收掉。
+      gridApi.current?.getPanel(panelId)?.api.close();
+      const tab = tabsRef.current.find((item) => item.sessionId === sessionId);
+      if (tab) await closeSession(tab);
+    },
+    [closeSession],
+  );
+  const send = useCallback(
+    (sessionId: string, utf8: string) => {
+      const tail = inflight.current.get(sessionId) ?? Promise.resolve();
+      const next = tail
+        .then(async () => {
+          const seq = (ackSeq.current.get(sessionId) ?? 0) + 1;
+          ackSeq.current.set(sessionId, await terminalClient.input(repoId, sessionId, seq, utf8));
+        })
+        .catch((cause: unknown) => {
+          consumeKnownError(cause);
+          setError(message(cause));
+        });
+      inflight.current.set(sessionId, next);
+    },
+    [repoId],
+  );
+  const refit = useCallback(
+    (sessionId: string, cols: number, rows: number) => {
+      void terminalClient.resize(repoId, sessionId, cols, rows).catch((cause: unknown) => {
         consumeKnownError(cause);
         setError(message(cause));
       });
-    inflight.current.set(sessionId, next);
-  };
-  const refit = (sessionId: string, cols: number, rows: number) => {
-    void terminalClient.resize(repoId, sessionId, cols, rows).catch((cause: unknown) => {
-      consumeKnownError(cause);
-      setError(message(cause));
-    });
-  };
-  const terminate = async (tab: TerminalTab) => {
-    try {
-      await requestTerminalTermination(repoId, tab, true, { terminate: terminalClient.terminate });
-      setTabs((current) =>
-        current.map((item) =>
-          item.sessionId === tab.sessionId
-            ? { ...item, state: "exited", attachable: false, notice: t("terminal.view.terminationConfirmed") }
-            : item,
-        ),
-      );
-      setConfirmId(null);
-    } catch (cause) {
-      consumeKnownError(cause);
-      setError(message(cause));
-    }
-  };
-  const active = tabs.find((tab) => tab.sessionId === activeId) ?? null;
-  const setPreference = (update: Partial<TerminalPreferences>) =>
-    setPreferences((current) => ({ ...current, ...update }));
+    },
+    [repoId],
+  );
+  const terminate = useCallback(
+    async (sessionId: string) => {
+      const tab = tabsRef.current.find((item) => item.sessionId === sessionId);
+      if (!tab) return;
+      try {
+        await requestTerminalTermination(repoId, tab, true, { terminate: terminalClient.terminate });
+        setTabs((current) =>
+          current.map((item) =>
+            item.sessionId === sessionId
+              ? { ...item, state: "exited", attachable: false, notice: t("terminal.view.terminationConfirmed") }
+              : item,
+          ),
+        );
+        setConfirmId(null);
+      } catch (cause) {
+        consumeKnownError(cause);
+        setError(message(cause));
+      }
+    },
+    [repoId],
+  );
+
+  /** dockview 报告布局变化:快照回流到 group;空 group 直接回收。 */
+  const applyGrid = useCallback(
+    (groupId: string, grid: TerminalGridSnapshot) => {
+      if (gridPaneRefs(grid).length === 0) {
+        dropGroup(groupId);
+        return;
+      }
+      const next = groupsRef.current.map((group) => (group.groupId === groupId ? { ...group, grid } : group));
+      groupsRef.current = next;
+      setGroups(next);
+    },
+    [dropGroup],
+  );
+  const splitPane = useCallback(
+    (panelId: string, direction: TerminalSplitDirection) => {
+      void start(false, { kind: "split", referencePanelId: panelId, direction });
+    },
+    [start],
+  );
+  const focusPane = useCallback((panelId: string) => {
+    setFocusedPanelId((current) => (current === panelId ? current : panelId));
+  }, []);
+  const moveFocus = useCallback((direction: PaneDirection) => {
+    const target = directionalPane(paneBoxes(regionRef.current), focusedPanelIdRef.current, direction);
+    if (!target) return;
+    gridApi.current?.getPanel(target)?.api.setActive();
+    setFocusedPanelId(target);
+    focusPaneInput(regionRef.current, target);
+  }, []);
+
+  // 分屏快捷键(与 useAppShortcuts 同一惯例:window keydown + preventDefault)。
+  // Ctrl+Shift+5/6 分割,Ctrl+Shift+W 关 pane,Ctrl+Alt+方向键 移动焦点。
+  useEffect(() => {
+    const onKey = (event: KeyboardEvent) => {
+      if (!event.ctrlKey) return;
+      const arrow = arrowDirection(event.key);
+      if (event.shiftKey && ["5", "%"].includes(event.key)) run(event, () => splitFocused("right"));
+      else if (event.shiftKey && ["6", "^"].includes(event.key)) run(event, () => splitFocused("below"));
+      else if (event.shiftKey && event.key.toLowerCase() === "w") run(event, closeFocused);
+      else if (event.altKey && arrow) run(event, () => moveFocus(arrow));
+    };
+    const run = (event: KeyboardEvent, action: () => void) => {
+      event.preventDefault();
+      action();
+    };
+    const splitFocused = (direction: TerminalSplitDirection) => {
+      const panelId = focusedPanelIdRef.current;
+      if (panelId) splitPane(panelId, direction);
+      else void start(false);
+    };
+    const closeFocused = () => {
+      const panelId = focusedPanelIdRef.current;
+      const sessionId = panelId ? sessionOfPane(groupsRef.current, panelId) : null;
+      if (panelId && sessionId) void closePane(panelId, sessionId);
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [closePane, moveFocus, splitPane, start]);
+
+  const activeGroup = groups.find((group) => group.groupId === activeGroupId) ?? null;
+  const paneActions = useMemo<TerminalPaneActions>(
+    () => ({
+      session: (sessionId) => tabs.find((tab) => tab.sessionId === sessionId) ?? null,
+      focusedPanelId,
+      confirmSessionId: confirmId,
+      setConfirmSessionId: setConfirmId,
+      onInput: send,
+      onFit: refit,
+      onFocusPane: focusPane,
+      onClosePane: (panelId, sessionId) => void closePane(panelId, sessionId),
+      onSplitPane: splitPane,
+      onTerminate: (sessionId) => void terminate(sessionId),
+    }),
+    [closePane, confirmId, focusPane, focusedPanelId, refit, send, splitPane, tabs, terminate],
+  );
 
   return (
     <section
@@ -275,224 +479,44 @@ export function TerminalView({ repoId, daemonGeneration, tasks }: Props) {
       data-testid="terminal-view"
       className="flex min-h-0 flex-1 flex-col overflow-hidden"
     >
-      <header className="flex items-center gap-2 border-b border-border px-3 py-1.5">
-        <strong className="text-[13px]">{t("terminal.view.localTerminal")}</strong>
-        <span className="font-mono text-[11px] text-text-faint">
-          {t("terminal.view.repoGeneration", {
-            repoId,
-            generation: generation ?? t("views.settingsView.systemUnknownDash"),
-          })}
-        </span>
-        <span
-          className="inline-flex overflow-hidden rounded border border-border-strong"
-          aria-label={t("terminal.view.backendForNew")}
-        >
-          <button
-            aria-pressed={preferences.backend === "direct-pty"}
-            onClick={() => setPreference({ backend: "direct-pty" })}
-            className={toggleClassName(preferences.backend === "direct-pty")}
-          >
-            {t("terminal.view.backendDirect")}
-          </button>
-          <button
-            aria-pressed={preferences.backend === "tmux"}
-            onClick={() => setPreference({ backend: "tmux" })}
-            className={toggleClassName(preferences.backend === "tmux")}
-          >
-            {t("terminal.view.backendTmux")}
-          </button>
-        </span>
-        <span className="ml-auto font-mono text-[11px] text-text-faint" title={t("terminal.view.shortcut")}>
-          {t("terminal.view.shortcut")}
-        </span>
-      </header>
-      <div className="flex min-w-0 items-center gap-1 overflow-x-auto border-b border-border px-2 py-1">
-        {tabs.map((tab) => (
-          <span key={tab.sessionId} className={tabClassName(activeId === tab.sessionId)}>
-            <button
-              onClick={() => setActiveId(tab.sessionId)}
-              className="max-w-44 truncate px-2 py-1 text-[11px] text-text"
-            >
-              {tab.name} <span className="font-mono text-text-faint">· {tab.backend}</span>
-            </button>
-            <button
-              onClick={() => {
-                void close(tab);
+      <TerminalChrome
+        repoId={repoId}
+        generation={generation}
+        preferences={preferences}
+        onPreferenceChange={(update) => setPreferences((current) => ({ ...current, ...update }))}
+        chips={tabChips(groups, tabs)}
+        activeGroupId={activeGroupId}
+        onSelectGroup={setActiveGroupId}
+        onCloseGroup={(groupId) => void closeGroup(groupId)}
+        onNewTab={() => void start(false)}
+        sessions={sessions.data?.sessions ?? []}
+        openSessionIds={groups.flatMap((group) => groupPaneRefs(group).map((pane) => pane.sessionId))}
+        onAttachSession={(sessionId) => {
+          const row = sessions.data?.sessions.find((item) => item.sessionId === sessionId);
+          if (row) attach(row, 0);
+        }}
+        spawn={spawn}
+        onSpawnChange={(update) => setSpawn((current) => ({ ...current, ...update }))}
+        onCreate={create}
+        tasks={tasks}
+      />
+      {/* pane 区:一个 tab(group)一棵 pane 树,切 tab 即换 dockview 实例。 */}
+      <div ref={regionRef} data-testid="terminal-pane-region" className="flex min-h-0 flex-1 flex-col overflow-hidden">
+        {activeGroup ? (
+          <TerminalPaneContext.Provider value={paneActions}>
+            <TerminalSplitGrid
+              key={activeGroup.groupId}
+              seeds={activeGroup.seeds}
+              grid={activeGroup.grid}
+              onApiReady={(api) => {
+                gridApi.current = api;
               }}
-              aria-label={t("terminal.view.closeTabAria", { name: tab.name })}
-              title={t("terminal.view.closeDetachTitle")}
-              className="border-l border-border px-1.5 text-text-faint hover:bg-surface-overlay"
-            >
-              ×
-            </button>
-          </span>
-        ))}
-        <button
-          onClick={() => {
-            void start(false);
-          }}
-          title={t("terminal.view.quickStartTitle")}
-          aria-label={t("terminal.view.newTab")}
-          className="shrink-0 rounded border border-accent/60 bg-accent/10 px-2 py-1 text-[13px] text-text"
-        >
-          +
-        </button>
-        <select
-          aria-label={t("terminal.view.attachExisting")}
-          defaultValue=""
-          onChange={(event) => {
-            const row = sessions.data?.sessions.find((item) => item.sessionId === event.target.value);
-            if (row) attach(row, 0);
-            event.target.value = "";
-          }}
-          className="control ml-auto shrink-0"
-        >
-          <option value="">{t("terminal.view.attachSession")}</option>
-          {sessions.data?.sessions.map((row) => (
-            <option key={row.sessionId} value={row.sessionId} disabled={!row.attachable}>
-              {row.name} · {row.backend} · {row.status}
-            </option>
-          ))}
-        </select>
-      </div>
-      <details className="border-b border-border px-3 py-1 text-[11px]">
-        <summary className="cursor-pointer text-text-muted">{t("terminal.view.advanced")}</summary>
-        <form onSubmit={create} className="flex flex-wrap items-end gap-2 py-2">
-          <Field label={t("terminal.view.name")}>
-            <input
-              value={spawn.name}
-              onChange={(event) => setSpawn({ ...spawn, name: event.target.value })}
-              className="control w-28"
+              onLayoutChange={(grid) => applyGrid(activeGroup.groupId, grid)}
+              onActivePaneChange={(panelId) => {
+                if (panelId) focusPane(panelId);
+              }}
             />
-          </Field>
-          <Field label={t("terminal.view.cwd")}>
-            <select
-              value={spawn.cwdScope}
-              onChange={(event) =>
-                setSpawn({
-                  ...spawn,
-                  cwdScope: event.target.value as typeof spawn.cwdScope,
-                })
-              }
-              className="control"
-            >
-              <option value="repo-root">repo-root</option>
-              <option value="repo-relative">repo-relative</option>
-            </select>
-          </Field>
-          {spawn.cwdScope === "repo-relative" && (
-            <Field label={t("terminal.view.path")}>
-              <input
-                required
-                value={spawn.path}
-                onChange={(event) => setSpawn({ ...spawn, path: event.target.value })}
-                className="control w-36"
-              />
-            </Field>
-          )}
-          <Field label={t("terminal.view.shell")}>
-            <select
-              value={spawn.shellProfileId}
-              onChange={(event) => setSpawn({ ...spawn, shellProfileId: event.target.value })}
-              className="control"
-            >
-              {shellOptions.map((option) => (
-                <option key={option} value={option}>
-                  {option}
-                </option>
-              ))}
-            </select>
-          </Field>
-          <Field label={t("terminal.view.task")}>
-            <select
-              value={spawn.taskId}
-              onChange={(event) => setSpawn({ ...spawn, taskId: event.target.value })}
-              className="control max-w-44"
-            >
-              <option value="">{t("terminal.view.unbound")}</option>
-              {tasks.map((task) => (
-                // G10:实体 ID 不落在不可激活文本里;taskId 走机器值/tooltip,文本用标题。
-                <option key={task.taskId} value={task.taskId} title={task.taskId}>
-                  {task.title}
-                </option>
-              ))}
-            </select>
-          </Field>
-          <button className="rounded border border-accent/60 bg-accent/10 px-3 py-1 text-[12px] text-text">
-            {t("terminal.view.startCustom")}
-          </button>
-        </form>
-      </details>
-      {/* pane 区:中性容器,占满剩余高度;W1 分屏(pane 树)在此容器内落地。 */}
-      <div data-testid="terminal-pane-region" className="flex min-h-0 flex-1 flex-col overflow-hidden">
-        {active ? (
-          <>
-            <div className="flex flex-wrap items-center gap-2 border-b border-border px-2 py-1 text-[11px]">
-              <span className="font-mono text-text-faint">
-                {active.cwd} · {active.backend} · {active.durability} · {active.state}
-              </span>
-              <span className="font-mono text-[10px] text-text-faint">{active.sessionId}</span>
-              <button
-                onClick={() => {
-                  void close(active);
-                }}
-                className="ml-auto rounded px-2 py-1 text-text-muted hover:bg-surface-raised"
-                title={t("terminal.view.closeDetachTitle")}
-              >
-                {t("terminal.view.closeDetach")}
-              </button>
-              {confirmId === active.sessionId ? (
-                <>
-                  <span className="text-status-blocked">{t("terminal.view.confirmTerminatePrompt")}</span>
-                  <button
-                    onClick={() => setConfirmId(null)}
-                    className="rounded px-2 py-1 text-text-muted hover:bg-surface-raised"
-                  >
-                    {t("terminal.view.cancel")}
-                  </button>
-                  <button
-                    onClick={() => {
-                      void terminate(active);
-                    }}
-                    className="rounded px-2 py-1 text-status-blocked hover:bg-surface-raised"
-                  >
-                    {t("terminal.view.confirmTerminate")}
-                  </button>
-                </>
-              ) : (
-                <button
-                  onClick={() => setConfirmId(active.sessionId)}
-                  className="rounded px-2 py-1 text-status-blocked hover:bg-surface-raised"
-                >
-                  {t("terminal.view.terminate")}
-                </button>
-              )}
-            </div>
-            {active.warning && (
-              <p role="status" className={warningClassName}>
-                {active.backend === "direct-pty"
-                  ? t("terminal.view.tmuxFallbackWarning")
-                  : t("terminal.view.tmuxUnavailableWarning")}
-              </p>
-            )}
-            {active.notice && (
-              <p role="status" className={warningClassName}>
-                {active.notice}
-              </p>
-            )}
-            {active.state === "running" || active.output ? (
-              <TerminalPane
-                output={active.output}
-                interactive={active.state === "running" && active.attachable}
-                onInput={(utf8) => send(active.sessionId, utf8)}
-                onFit={(cols, rows) => refit(active.sessionId, cols, rows)}
-              />
-            ) : (
-              <div className="grid flex-1 place-items-center px-4 text-center text-[12px] text-text-faint">
-                {active.notice ?? t("terminal.view.sessionNotInteractive")}
-              </div>
-            )}
-          </>
+          </TerminalPaneContext.Provider>
         ) : (
           <div className="grid h-full place-items-center px-4 text-center text-[12px] text-text-faint">
             {t("terminal.view.startHint")}
@@ -508,6 +532,53 @@ export function TerminalView({ repoId, daemonGeneration, tasks }: Props) {
   );
 }
 
+function tabChips(groups: readonly TerminalGroupLayout[], tabs: readonly TerminalTab[]): readonly TerminalTabChip[] {
+  return groups.map((group) => {
+    const refs = groupPaneRefs(group);
+    const live = refs.flatMap((ref) => tabs.filter((tab) => tab.sessionId === ref.sessionId));
+    return {
+      groupId: group.groupId,
+      title: live[0]?.name ?? t("terminal.view.title"),
+      backend: live[0]?.backend ?? t("views.settingsView.systemUnknownDash"),
+      paneCount: refs.length,
+    };
+  });
+}
+function paneOfSession(
+  groups: readonly TerminalGroupLayout[],
+  sessionId: string,
+): { readonly groupId: string; readonly panelId: string } | null {
+  for (const group of groups)
+    for (const pane of groupPaneRefs(group))
+      if (pane.sessionId === sessionId) return { groupId: group.groupId, panelId: pane.panelId };
+  return null;
+}
+function sessionOfPane(groups: readonly TerminalGroupLayout[], panelId: string): string | null {
+  for (const group of groups)
+    for (const pane of groupPaneRefs(group)) if (pane.panelId === panelId) return pane.sessionId;
+  return null;
+}
+function paneBoxes(region: HTMLElement | null): readonly PaneBox[] {
+  return [...(region?.querySelectorAll<HTMLElement>("[data-pane-id]") ?? [])].flatMap((element) => {
+    const panelId = element.dataset.paneId;
+    if (!panelId) return [];
+    const rect = element.getBoundingClientRect();
+    return [{ panelId, left: rect.left, top: rect.top, right: rect.right, bottom: rect.bottom }];
+  });
+}
+function focusPaneInput(region: HTMLElement | null, panelId: string): void {
+  const host = region?.querySelector<HTMLElement>(`[data-pane-id="${panelId}"]`);
+  host?.querySelector<HTMLTextAreaElement>("textarea")?.focus();
+}
+function arrowDirection(key: string): PaneDirection | null {
+  const map: Record<string, PaneDirection> = {
+    ArrowLeft: "left",
+    ArrowRight: "right",
+    ArrowUp: "up",
+    ArrowDown: "down",
+  };
+  return map[key] ?? null;
+}
 function tabFromRow(
   row: AttachRow,
   daemonGeneration: number,
@@ -530,26 +601,6 @@ function tabFromRow(
     warning: row.warning,
     attachable: row.attachable,
   };
-}
-function toggleClassName(selected: boolean): string {
-  return [
-    "px-2 py-1 text-[11px]",
-    selected ? "bg-accent text-accent-fg" : "text-text-muted hover:bg-surface-raised",
-  ].join(" ");
-}
-function tabClassName(selected: boolean): string {
-  return [
-    "inline-flex shrink-0 overflow-hidden rounded border",
-    selected ? "border-accent/60 bg-surface-raised" : "border-border",
-  ].join(" ");
-}
-function Field({ label, children }: { readonly label: string; readonly children: React.ReactNode }) {
-  return (
-    <label className="grid gap-0.5 font-mono text-[10px] uppercase tracking-wide text-text-faint">
-      {label}
-      {children}
-    </label>
-  );
 }
 function isInitial(
   value: TerminalAttachInitial | import("../terminal-model.ts").TerminalStreamFrame,

--- a/packages/gui/test/terminal-split-grid.vitest.ts
+++ b/packages/gui/test/terminal-split-grid.vitest.ts
@@ -1,0 +1,355 @@
+// harness-test-tier: integration
+// @vitest-environment happy-dom
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { setActiveLocale } from "../src/renderer/i18n/core.ts";
+import { TerminalView } from "../src/renderer/views/TerminalView.tsx";
+
+// pane 内容用桩替代真 xterm:本文件测的是 pane 树(分割/关闭/序列化/每 pane 上报),
+// 不是终端仿真;桩把 onFit 暴露成一次点击,才能对「每个 pane 各自上报 cols/rows」下断言。
+vi.mock("../src/renderer/components/terminal/TerminalPane.tsx", () => ({
+  TerminalPane: ({ output, onFit }: { readonly output: string; readonly onFit: (c: number, r: number) => void }) =>
+    createElement("button", {
+      "data-testid": "terminal-pane",
+      "data-output": output,
+      onClick: () => onFit(120, 40),
+    }),
+}));
+
+const AT = "2026-09-01T00:00:00.000Z";
+const layoutKey = "harness:gui:terminal-layout";
+type Row = Record<string, unknown>;
+
+function sessionRow(overrides: Partial<Row> = {}): Row {
+  return {
+    sessionId: "s-restore",
+    repoId: "repo-a",
+    name: "Build",
+    cwd: "/repo/a",
+    shellProfile: "default",
+    requestedBackend: "direct-pty",
+    backend: "direct-pty",
+    status: "running",
+    createdAt: AT,
+    lastActivityAt: AT,
+    exitCode: null,
+    outputSeq: 2,
+    durability: "daemon-process",
+    warning: null,
+    attachable: true,
+    ...overrides,
+  };
+}
+
+/** window.harness 桥 mock:spawn 会向会话表追加一行,split 才拿得到真正的新会话。 */
+function stubBridge(initial: readonly Row[]) {
+  const rows = [...initial];
+  let spawned = 0;
+  const stops = new Map<string, () => void>();
+  const bridge = {
+    listTerminalSessions: vi.fn(async () => ({
+      schema: "terminal-session-list/v1",
+      ok: true,
+      repoId: "repo-a",
+      daemonGeneration: 7,
+      sessions: [...rows],
+    })),
+    spawnTerminal: vi.fn(async () => {
+      spawned += 1;
+      const sessionId = `s-split-${spawned}`;
+      rows.push(sessionRow({ sessionId, name: `Split ${spawned}` }));
+      return controlReceipt(sessionId);
+    }),
+    attachTerminal: vi.fn((payload: Row, onValue: (value: Row) => void) => {
+      const sessionId = String(payload.sessionId);
+      onValue({
+        schema: "terminal-attach/v1",
+        ok: true,
+        sessionId,
+        attachmentId: `attach-${sessionId}`,
+        daemonGeneration: 7,
+        status: "attached",
+        replayFromSeq: 0,
+        outputSeq: 2,
+      });
+      const stop = vi.fn();
+      stops.set(sessionId, stop);
+      return stop;
+    }),
+    sendTerminalInput: vi.fn(async () => ({ schema: "terminal-input-ack/v1", ok: true, acceptedThrough: 1 })),
+    resizeTerminal: vi.fn(async (payload: Row) => controlReceipt(String(payload.sessionId))),
+    detachTerminal: vi.fn(async () => ({ schema: "terminal-detach-ack/v1", ok: true, state: "detached" })),
+    terminateTerminal: vi.fn(async () => controlReceipt("s-restore")),
+  };
+  (window as unknown as Record<string, unknown>).harness = bridge;
+  return { bridge, stops };
+}
+function controlReceipt(sessionId: string): Row {
+  return {
+    schema: "terminal-control-receipt/v1",
+    ok: true,
+    outcome: "applied",
+    operationId: `op-${sessionId}`,
+    sessionId,
+    daemonGeneration: 7,
+    state: "running",
+    error: null,
+  };
+}
+
+/** dockview `toJSON()` 的真实形状:两个左右并排的 pane,载荷各带一个 sessionId。 */
+function storedLayout(): Row {
+  return {
+    schema: "terminal-layout/v1",
+    repos: {
+      "repo-a": {
+        activeGroupId: "group-restored",
+        groups: [
+          {
+            groupId: "group-restored",
+            seeds: [],
+            grid: {
+              grid: {
+                root: {
+                  type: "branch",
+                  data: [
+                    { type: "leaf", data: { views: ["pane-a"], activeView: "pane-a", id: "1" }, size: 100 },
+                    { type: "leaf", data: { views: ["pane-b"], activeView: "pane-b", id: "2" }, size: 100 },
+                  ],
+                  size: 100,
+                },
+                width: 100,
+                height: 100,
+                orientation: "HORIZONTAL",
+              },
+              panels: {
+                "pane-a": {
+                  id: "pane-a",
+                  contentComponent: "terminalPane",
+                  params: { sessionId: "s-restore" },
+                  title: "pane-a",
+                },
+                "pane-b": {
+                  id: "pane-b",
+                  contentComponent: "terminalPane",
+                  params: { sessionId: "s-gone" },
+                  title: "pane-b",
+                },
+              },
+              activeGroup: "1",
+            },
+          },
+        ],
+      },
+    },
+  };
+}
+
+let container: HTMLElement | null = null;
+let root: Root | null = null;
+
+beforeAll(() => {
+  globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+  // 文案断言按 aria-label 走,锁定语言避免跟随宿主 locale 漂移。
+  setActiveLocale("en-US");
+});
+beforeEach(() => {
+  window.localStorage.clear();
+});
+afterEach(() => {
+  if (root) act(() => root!.unmount());
+  container?.remove();
+  root = null;
+  container = null;
+  delete (window as unknown as Record<string, unknown>).harness;
+  vi.restoreAllMocks();
+});
+
+function mountView() {
+  container = document.createElement("div");
+  document.body.append(container);
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  root = createRoot(container);
+  act(() => {
+    root!.render(
+      createElement(
+        QueryClientProvider,
+        { client },
+        createElement(TerminalView, { repoId: "repo-a", daemonGeneration: null, tasks: [] }),
+      ),
+    );
+  });
+}
+async function flush() {
+  for (let round = 0; round < 8; round += 1)
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+}
+function panes(): readonly HTMLElement[] {
+  return [...container!.querySelectorAll<HTMLElement>('[data-testid="terminal-pane-card"]')];
+}
+function tabChips(): readonly HTMLElement[] {
+  return [...container!.querySelectorAll<HTMLElement>('button[aria-label^="Close and detach "]')];
+}
+function clickIn(pane: HTMLElement, selector: string) {
+  const button = pane.querySelector<HTMLButtonElement>(selector);
+  expect(button, selector).not.toBeNull();
+  act(() => button!.click());
+}
+function storedSnapshot(): string {
+  return window.localStorage.getItem(layoutKey) ?? "";
+}
+
+describe("terminal split panes (PLT-TerminalWorkspace W1)", () => {
+  it("splits inside the active tab instead of opening a second tab", async () => {
+    const { bridge } = stubBridge([sessionRow()]);
+    mountView();
+    await flush();
+    expect(panes()).toHaveLength(1);
+    expect(tabChips()).toHaveLength(1);
+
+    clickIn(panes()[0], 'button[aria-label="Split right"]');
+    await flush();
+
+    // tab = group:分屏后仍然只有一个 tab,group 内变成两个 pane。
+    expect(panes()).toHaveLength(2);
+    expect(tabChips()).toHaveLength(1);
+    expect(panes().map((pane) => pane.dataset.sessionId)).toEqual(["s-restore", "s-split-1"]);
+    expect(bridge.spawnTerminal).toHaveBeenCalledTimes(1);
+    expect(bridge.attachTerminal).toHaveBeenCalledWith(
+      { repoId: "repo-a", sessionId: "s-split-1", afterSeq: 0 },
+      expect.any(Function),
+    );
+  });
+
+  it("serializes the pane tree to localStorage with each pane's session id", async () => {
+    stubBridge([sessionRow()]);
+    mountView();
+    await flush();
+    expect(storedSnapshot()).toContain('"sessionId":"s-restore"');
+
+    clickIn(panes()[0], 'button[aria-label="Split right"]');
+    await flush();
+
+    const written: {
+      schema: string;
+      repos: Record<string, { groups: { grid: { panels: Record<string, { params: { sessionId: string } }> } }[] }>;
+    } = JSON.parse(storedSnapshot());
+    expect(written.schema).toBe("terminal-layout/v1");
+    const panels = written.repos["repo-a"].groups[0].grid.panels;
+    expect(
+      Object.values(panels)
+        .map((panel) => panel.params.sessionId)
+        .sort(),
+    ).toEqual(["s-restore", "s-split-1"]);
+  });
+
+  it("restores a stored pane tree, re-attaches live sessions and parks dead ones as closeable placeholders", async () => {
+    window.localStorage.setItem(layoutKey, JSON.stringify(storedLayout()));
+    const { bridge } = stubBridge([sessionRow()]);
+    mountView();
+    await flush();
+
+    // 两个 pane 都恢复;活会话按 id re-attach,死会话只留占位,不去 attach、也不新建。
+    expect(panes().map((pane) => pane.dataset.sessionId)).toEqual(["s-restore", "s-gone"]);
+    expect(bridge.attachTerminal).toHaveBeenCalledTimes(1);
+    expect(bridge.attachTerminal).toHaveBeenCalledWith(
+      { repoId: "repo-a", sessionId: "s-restore", afterSeq: 0 },
+      expect.any(Function),
+    );
+    expect(bridge.spawnTerminal).not.toHaveBeenCalled();
+    const dead = container!.querySelectorAll('[data-testid="terminal-pane-dead"]');
+    expect(dead).toHaveLength(1);
+    expect(panes()[1].querySelector('[data-testid="terminal-pane-dead"]')).not.toBeNull();
+
+    clickIn(panes()[1], '[data-testid="terminal-pane-dead"] button');
+    await flush();
+    expect(panes().map((pane) => pane.dataset.sessionId)).toEqual(["s-restore"]);
+  });
+
+  it("reports fit per pane on the existing resize channel", async () => {
+    const { bridge } = stubBridge([sessionRow()]);
+    mountView();
+    await flush();
+    clickIn(panes()[0], 'button[aria-label="Split right"]');
+    await flush();
+
+    for (const pane of panes()) clickIn(pane, '[data-testid="terminal-pane"]');
+    await flush();
+    expect(bridge.resizeTerminal).toHaveBeenCalledWith({
+      repoId: "repo-a",
+      sessionId: "s-restore",
+      cols: 120,
+      rows: 40,
+    });
+    expect(bridge.resizeTerminal).toHaveBeenCalledWith({
+      repoId: "repo-a",
+      sessionId: "s-split-1",
+      cols: 120,
+      rows: 40,
+    });
+  });
+
+  it("closing a pane detaches only that session and closing the last one retires the tab", async () => {
+    const { bridge } = stubBridge([sessionRow()]);
+    mountView();
+    await flush();
+    clickIn(panes()[0], 'button[aria-label="Split right"]');
+    await flush();
+
+    clickIn(panes()[1], 'button[aria-label^="Close pane "]');
+    await flush();
+    expect(bridge.detachTerminal).toHaveBeenCalledTimes(1);
+    expect(bridge.detachTerminal).toHaveBeenCalledWith({
+      repoId: "repo-a",
+      sessionId: "s-split-1",
+      attachmentId: "attach-s-split-1",
+    });
+    expect(panes()).toHaveLength(1);
+    expect(tabChips()).toHaveLength(1);
+
+    clickIn(panes()[0], 'button[aria-label^="Close pane "]');
+    await flush();
+    expect(panes()).toHaveLength(0);
+    expect(tabChips()).toHaveLength(0);
+  });
+
+  it("splits and closes the focused pane from the keyboard", async () => {
+    const { bridge } = stubBridge([sessionRow()]);
+    mountView();
+    await flush();
+
+    // Ctrl+Shift+5 = 向右分屏(与 useAppShortcuts 同惯例:window keydown + preventDefault)。
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent("keydown", { key: "5", ctrlKey: true, shiftKey: true }));
+    });
+    await flush();
+    expect(bridge.spawnTerminal).toHaveBeenCalledTimes(1);
+    expect(panes()).toHaveLength(2);
+
+    // Ctrl+Shift+W 关掉当前焦点 pane(分屏后焦点落在新 pane 上)。
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent("keydown", { key: "W", ctrlKey: true, shiftKey: true }));
+    });
+    await flush();
+    expect(panes().map((pane) => pane.dataset.sessionId)).toEqual(["s-restore"]);
+    expect(bridge.detachTerminal).toHaveBeenCalledWith({
+      repoId: "repo-a",
+      sessionId: "s-split-1",
+      attachmentId: "attach-s-split-1",
+    });
+  });
+
+  it("bans attaching one session into two panes by disabling it in the attach picker", async () => {
+    // 自动附加取会话表里最后一个可附加的:s-restore 会进 pane,s-free 留在表里。
+    stubBridge([sessionRow({ sessionId: "s-free", name: "Free" }), sessionRow()]);
+    mountView();
+    await flush();
+    const options = [...container!.querySelectorAll<HTMLOptionElement>("option")];
+    expect(options.find((option) => option.value === "s-restore")?.disabled).toBe(true);
+    expect(options.find((option) => option.value === "s-free")?.disabled).toBe(false);
+  });
+});

--- a/packages/gui/test/terminal-split-layout.vitest.ts
+++ b/packages/gui/test/terminal-split-layout.vitest.ts
@@ -1,0 +1,129 @@
+// harness-test-tier: fast
+import { describe, expect, it } from "vitest";
+import {
+  gridPaneRefs,
+  groupPaneRefs,
+  layoutSessionIds,
+  readTerminalLayout,
+  writeTerminalLayout,
+  type TerminalGridSnapshot,
+  type TerminalRepoLayout,
+} from "../src/renderer/terminal-layout.ts";
+import { directionalPane, type PaneBox } from "../src/renderer/terminal-pane-focus.ts";
+
+/** dockview `toJSON()` 的真实形状(两个左右并排的 pane),只有 params.sessionId 被渲染层解释。 */
+const grid: TerminalGridSnapshot = {
+  grid: {
+    root: {
+      type: "branch",
+      data: [
+        { type: "leaf", data: { views: ["pane-a"], activeView: "pane-a", id: "1" }, size: 420 },
+        { type: "leaf", data: { views: ["pane-b"], activeView: "pane-b", id: "2" }, size: 380 },
+      ],
+      size: 600,
+    },
+    width: 800,
+    height: 600,
+    orientation: "HORIZONTAL",
+  },
+  panels: {
+    "pane-a": { id: "pane-a", contentComponent: "terminalPane", params: { sessionId: "s-a" }, title: "pane-a" },
+    "pane-b": { id: "pane-b", contentComponent: "terminalPane", params: { sessionId: "s-b" }, title: "pane-b" },
+  },
+  activeGroup: "2",
+};
+
+function storage(seed: Record<string, string> = {}) {
+  const store = new Map(Object.entries(seed));
+  return {
+    store,
+    getItem: (key: string) => store.get(key) ?? null,
+    setItem: (key: string, value: string) => {
+      store.set(key, value);
+    },
+  };
+}
+
+describe("terminal split layout serialization (PLT-TerminalWorkspace W1)", () => {
+  it("reads the pane→session mapping out of a dockview snapshot", () => {
+    expect(gridPaneRefs(grid)).toEqual([
+      { panelId: "pane-a", sessionId: "s-a" },
+      { panelId: "pane-b", sessionId: "s-b" },
+    ]);
+  });
+
+  it("treats the snapshot as authoritative once present and falls back to seeds otherwise", () => {
+    expect(groupPaneRefs({ groupId: "g1", seeds: [{ panelId: "seed", sessionId: "s-seed" }], grid })).toHaveLength(2);
+    expect(groupPaneRefs({ groupId: "g1", seeds: [{ panelId: "seed", sessionId: "s-seed" }], grid: null })).toEqual([
+      { panelId: "seed", sessionId: "s-seed" },
+    ]);
+    expect(groupPaneRefs({ groupId: "g1", seeds: [], grid: { panels: {} } })).toEqual([]);
+  });
+
+  it("round-trips a layout per repository and keeps other repositories intact", () => {
+    const disk = storage();
+    const repoA: TerminalRepoLayout = { activeGroupId: "g1", groups: [{ groupId: "g1", seeds: [], grid }] };
+    const repoB: TerminalRepoLayout = {
+      activeGroupId: "g2",
+      groups: [{ groupId: "g2", seeds: [{ panelId: "p-1", sessionId: "s-only" }], grid: null }],
+    };
+    writeTerminalLayout(disk, "repo-a", repoA);
+    writeTerminalLayout(disk, "repo-b", repoB);
+    expect(readTerminalLayout(disk, "repo-a")).toEqual(repoA);
+    expect(readTerminalLayout(disk, "repo-b")).toEqual(repoB);
+    expect(layoutSessionIds(readTerminalLayout(disk, "repo-a"))).toEqual(["s-a", "s-b"]);
+    // 写入的 JSON 样本本身也是证据:pane 载荷里必须带得回 sessionId。
+    const written: unknown = JSON.parse(disk.store.get("harness:gui:terminal-layout") ?? "null");
+    expect(JSON.stringify(written)).toContain('"sessionId":"s-a"');
+  });
+
+  it("falls back to an empty layout for foreign schemas, corrupt json and unknown repositories", () => {
+    expect(readTerminalLayout(storage({ "harness:gui:terminal-layout": "{" }), "repo-a").groups).toEqual([]);
+    const foreign = storage({ "harness:gui:terminal-layout": JSON.stringify({ schema: "other/v9", repos: {} }) });
+    expect(readTerminalLayout(foreign, "repo-a").groups).toEqual([]);
+    const disk = storage();
+    writeTerminalLayout(disk, "repo-a", { activeGroupId: "g1", groups: [{ groupId: "g1", seeds: [], grid }] });
+    expect(readTerminalLayout(disk, "repo-missing").groups).toEqual([]);
+  });
+
+  it("drops groups with no panes and repairs a dangling active group id", () => {
+    const disk = storage();
+    writeTerminalLayout(disk, "repo-a", {
+      activeGroupId: "ghost",
+      groups: [
+        { groupId: "empty", seeds: [], grid: null },
+        { groupId: "g1", seeds: [], grid },
+      ],
+    });
+    const restored = readTerminalLayout(disk, "repo-a");
+    expect(restored.groups.map((group) => group.groupId)).toEqual(["g1"]);
+    expect(restored.activeGroupId).toBe("g1");
+  });
+});
+
+describe("terminal pane directional focus (PLT-TerminalWorkspace W1)", () => {
+  // 左侧整列 + 右侧上下两块:方向导航必须按几何相邻挑,而不是按插入顺序。
+  const boxes: readonly PaneBox[] = [
+    { panelId: "left", left: 0, top: 0, right: 400, bottom: 600 },
+    { panelId: "right-top", left: 400, top: 0, right: 800, bottom: 300 },
+    { panelId: "right-bottom", left: 400, top: 300, right: 800, bottom: 600 },
+  ];
+
+  it("prefers the neighbour that overlaps on the orthogonal axis", () => {
+    expect(directionalPane(boxes, "left", "right")).toBe("right-top");
+    expect(directionalPane(boxes, "right-bottom", "left")).toBe("left");
+  });
+
+  it("moves within a column and stops at the edges", () => {
+    expect(directionalPane(boxes, "right-top", "down")).toBe("right-bottom");
+    expect(directionalPane(boxes, "right-bottom", "up")).toBe("right-top");
+    expect(directionalPane(boxes, "left", "up")).toBeNull();
+    expect(directionalPane(boxes, "right-top", "right")).toBeNull();
+  });
+
+  it("returns nothing when the focused pane is unknown or alone", () => {
+    expect(directionalPane(boxes, null, "right")).toBeNull();
+    expect(directionalPane(boxes, "missing", "left")).toBeNull();
+    expect(directionalPane([boxes[0]], "left", "right")).toBeNull();
+  });
+});

--- a/tools/gui-test-manifest.mjs
+++ b/tools/gui-test-manifest.mjs
@@ -23,6 +23,8 @@ export const guiVitestManifest = [
   "packages/gui/test/triadic-read-scoping.vitest.ts",
   "packages/gui/test/terminal-renderer.vitest.ts",
   "packages/gui/test/terminal-page.vitest.ts",
+  "packages/gui/test/terminal-split-layout.vitest.ts",
+  "packages/gui/test/terminal-split-grid.vitest.ts",
   "packages/gui/test/genealogy.vitest.ts",
   "packages/gui/test/territory.vitest.ts",
   "packages/gui/test/territory-layout.vitest.ts",


### PR DESCRIPTION
# English

## Summary

PLT-TerminalWorkspace W1: split terminal tabs into resizable pane trees. Each tab (dockview group) can split horizontally/vertically into nested panes with draggable ratios; the layout tree persists per repository in localStorage and restores on restart with per-pane session re-attach; dead sessions render as closeable placeholders instead of collapsing the layout. Every pane owns its ResizeObserver + fit and reports its own cols/rows over the existing resize channel. Split/close/directional focus work from both keyboard and pane header buttons.

## Architectural Justification

Churn exceeds the threshold because the single-pane `TerminalView` is decomposed into a pane tree: `TerminalChrome` (tab strip and session picker), `TerminalSplitGrid` (dockview host), `TerminalPaneCard` (one pane), plus `terminal-layout.ts` (serialize/restore) and `terminal-pane-focus.ts` (directional navigation). The session state machine (`terminal-model.ts`), transport, and daemon protocol are untouched — layout lives only in the renderer, per the milestone charter's research verdict (dockview first choice; Tabby-style tree semantics). No speculative abstraction: each new module has exactly one caller today.

## What Changed

- New deps: `dockview@8.2.0` + `dockview-react@8.2.0` (research-pinned first choice; same library family, not the fallback path).
- `TerminalView.tsx` rehomed onto a dockview group/pane model; tab=group, split panes inside.
- Layout snapshot (panel payload = session id) persisted per repository; restore re-attaches live sessions by id.
- Attaching one session into two panes remains banned in the picker.
- New targeted tests: `terminal-split-grid.vitest.ts` (grid/split/close/focus), `terminal-split-layout.vitest.ts` (serialize/restore); full GUI vitest suite 73 files / 715 tests green (CEO re-run in worktree).

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: use the single CI-backed `Production-Delta` declaration below; do not enter a second metric.

## Machine-Readable Declarations

Production-Delta: +1099/-317
Dependency-Change: add dockview@8.2.0 and dockview-react@8.2.0 to packages/gui dependencies (deterministic, lockfile updated in the same commit); no other dependency added, removed, or bumped

## Task And Scope

- Harness task: task_7c27e82e8ab8ea6e5218edb927 (W1, under milestone task_d2985b723b87a2cf55aa24d6fe, charter dec_31DA7CDFE06589AD47B56BF11E)
- Branch: codex/terminal-split
- Public scope: packages/gui renderer terminal components/layout/focus + i18n + gui tests + tools/gui-test-manifest.mjs + packages/gui/package.json + root lockfile
- Private planning/evidence updated: yes (task package plan/closeout/report, facts F-A553835F, F-858B49F9)
- Out of scope: link providers (W2), embedded browser (W3), daemon/main-process changes, multi-pane shared-session semantics (deferred to W4 adjudication)

## Version Impact

- Version: no version change because this is a pre-release product slice with no published package surface change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope:
- Authority: dec_31DA7CDFE06589AD47B56BF11E (PLT-TerminalWorkspace charter; no protected surface touched), task_7c27e82e8ab8ea6e5218edb927
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no

## Verification

- Base `origin/main` SHA: 8470f08d0065df55d8cd43b2d08f67c240e2cefd
- Branch merge-base with `origin/main`: 8470f08d0065df55d8cd43b2d08f67c240e2cefd
- Last `git fetch origin` time: 2026-09-01 14:28 (+0800)
- Sync method: none needed (branch created from current origin/main)
- Public diff command: `git diff origin/main...codex/terminal-split`
- Private evidence commit/path: harness ledger `tasks/task_7c27e82e8ab8ea6e5218edb927-terminal-split-w1/` (report, closeout, facts)
- Reviewer evidence path: same task package `artifacts/w1-report.md`
- GitHub Actions `rewrite-ci` run URL: pending (filled by CI on this PR)
- [x] full GUI vitest suite via `npm run test:gui`: 73 files / 715 tests green (CEO re-run in worktree post-review)
- [ ] GitHub Actions `rewrite-ci` passed
- Not run: full `npm run check:local` — worker stop-point policy limits local runs to the touched surface; GitHub CI is the complete authority. dockview×xterm interaction feel (four checks: selection, scroll, focus, drag) is code-tested but real-Electron verification lands post-merge on canonical (dev-electron ff-only constraint, F-2CD6584D) as part of W4 dogfood.

---

# 中文

## 摘要

PLT-TerminalWorkspace W1:终端 tab 内可分屏。每个 tab(dockview group)可横/竖嵌套分割、拖拽调比例;布局树按仓库存 localStorage,重启恢复且每个 pane 按会话 id 重连;死会话渲染为可关闭占位而不是拖垮整个布局。每个 pane 自持 ResizeObserver+fit,独立上报 cols/rows(复用既有 resize 通道)。分割/关闭/方向焦点键盘与按钮双入口。

## 架构辩护

churn 超阈值因为单 pane 的 `TerminalView` 被拆为 pane 树:`TerminalChrome`(tab 条与会话选择)、`TerminalSplitGrid`(dockview 宿主)、`TerminalPaneCard`(单 pane)加 `terminal-layout.ts`(序列化/恢复)与 `terminal-pane-focus.ts`(方向导航)。会话状态机、传输与 daemon 协议零改动——布局只活在 renderer,符合里程碑调研定案(dockview 首选,Tabby 树语义)。无预留抽象:每个新模块当前恰好一个调用方。

## 变更清单

- 新依赖 dockview@8.2.0 + dockview-react@8.2.0(调研钉死的首选,非退路)。
- tab=group、group 内分 pane;布局快照按仓库持久化,panel 载荷=会话 id。
- 同一会话双 pane 附加在选择器层禁止(W4 再裁)。
- 新定向测试两件 + 全量 GUI vitest 73 文件/715 用例绿(CEO 在 worktree 复跑)。

## 任务与范围

- Harness 任务:task_7c27e82e8ab8ea6e5218edb927(W1,里程碑 task_d2985b723b87a2cf55aa24d6fe,charter dec_31DA7CDFE06589AD47B56BF11E)
- 分支:codex/terminal-split;范围仅 GUI renderer/i18n/测试/依赖声明;daemon 与 main 进程零改动
- 范围外:W2 链接、W3 内嵌浏览器、多 pane 共享会话语义(W4 裁)

## 治理声明

- 未触碰 protected surface;无 break-glass。授权:dec_31DA7CDFE06589AD47B56BF11E 与 task_7c27e82e8ab8ea6e5218edb927。

## 验证

- 全量 GUI vitest 73/715 绿(CEO 复跑);完整检查以 GitHub CI 为权威。
- 残余风险:dockview×xterm 的四项真机交互观察(选区/滚动/焦点/拖拽)待合并后 canonical Electron 亲验(dev-electron ff-only 约束,F-2CD6584D),纳入 W4 dogfood;bundle 体积增量未对照。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BE45Q2y1iZzLJNo8j7xhhL
