### PR TITLE
feat(gui): isolated in-app browser view with locked-down webview policy (PLT-TerminalWorkspace W3)

### DIFF
--- a/packages/gui/src/main/electron-main.ts
+++ b/packages/gui/src/main/electron-main.ts
@@ -13,9 +13,12 @@ import { daemonBuildStamp } from "../../../daemon/src/build-identity.ts";
 import {
   evaluateHtmlArtifactAttachment,
   evaluateHtmlArtifactRequest,
+  evaluateInAppBrowserAttachment,
+  evaluateInAppBrowserUrl,
   evaluatePermissionRequest,
   evaluateWindowOpenRequest,
   HTML_ARTIFACT_PARTITION,
+  IN_APP_BROWSER_PARTITION,
   type IpcWebContentsTrustPolicy,
 } from "./security-policy.ts";
 import { assertDevRendererUrl, createGuiContentSecurityPolicy, isNavigableAppDocumentUrl } from "./window-config.ts";
@@ -87,10 +90,35 @@ export function installContentSecurityPolicy(): void {
     callback({ cancel: evaluateHtmlArtifactRequest(details.url).action === "deny" });
   });
   artifactSession.on("will-download", (event) => event.preventDefault());
+  const browserSession = session.fromPartition(IN_APP_BROWSER_PARTITION);
+  browserSession.setPermissionCheckHandler(() => false);
+  browserSession.setPermissionRequestHandler((_webContents, _permission, callback) => callback(false));
+  browserSession.on("will-download", (event) => event.preventDefault());
 }
 
 function installHtmlArtifactWebviewPolicy(mainWindow: BrowserWindow): void {
   mainWindow.webContents.on("will-attach-webview", (event, webPreferences, params) => {
+    if (params.partition === IN_APP_BROWSER_PARTITION) {
+      if (evaluateInAppBrowserAttachment(params).action === "deny") {
+        event.preventDefault();
+        return;
+      }
+      delete webPreferences.preload;
+      webPreferences.nodeIntegration = false;
+      webPreferences.nodeIntegrationInWorker = false;
+      webPreferences.nodeIntegrationInSubFrames = false;
+      webPreferences.contextIsolation = true;
+      webPreferences.sandbox = true;
+      webPreferences.webSecurity = true;
+      webPreferences.javascript = true;
+      webPreferences.plugins = false;
+      webPreferences.devTools = false;
+      webPreferences.navigateOnDragDrop = false;
+      webPreferences.webviewTag = false;
+      webPreferences.partition = IN_APP_BROWSER_PARTITION;
+      delete params.preload;
+      return;
+    }
     if (evaluateHtmlArtifactAttachment(params).action === "deny") {
       event.preventDefault();
       return;
@@ -111,6 +139,13 @@ function installHtmlArtifactWebviewPolicy(mainWindow: BrowserWindow): void {
     delete params.preload;
   });
   mainWindow.webContents.on("did-attach-webview", (_event, guest) => {
+    if (guest.session === session.fromPartition(IN_APP_BROWSER_PARTITION)) {
+      guest.setWindowOpenHandler(() => ({ action: "deny" }));
+      guest.on("will-navigate", (event, url) => {
+        if (evaluateInAppBrowserUrl(url).action === "deny") event.preventDefault();
+      });
+      return;
+    }
     guest.setWindowOpenHandler(() => ({ action: "deny" }));
     guest.on("will-navigate", (event) => event.preventDefault());
     guest.on("will-frame-navigate", (event) => event.preventDefault());

--- a/packages/gui/src/main/security-policy.ts
+++ b/packages/gui/src/main/security-policy.ts
@@ -1,10 +1,9 @@
 import { isTrustedRendererUrl, type TrustedRendererUrlOptions } from "./window-config.ts";
-import {
-  isAllowedHtmlArtifactAttachment,
-  isAllowedHtmlArtifactRequest,
-} from "../api/html-artifact-policy.ts";
+import { isAllowedHtmlArtifactAttachment, isAllowedHtmlArtifactRequest } from "../api/html-artifact-policy.ts";
 
 export { HTML_ARTIFACT_DATA_URL_PREFIX, HTML_ARTIFACT_PARTITION } from "../api/html-artifact-policy.ts";
+
+export const IN_APP_BROWSER_PARTITION = "in-app-browser";
 
 export type SecurityDecisionReason =
   | "trusted_renderer"
@@ -17,8 +16,10 @@ export type SecurityDecisionReason =
   | "html_artifact_source_denied"
   | "html_artifact_request_allowed"
   | "html_artifact_request_denied"
-  | "missing_browser_preview_threat_model"
-  | "browser_preview_not_shipped";
+  | "in_app_browser_source_allowed"
+  | "in_app_browser_source_denied"
+  | "in_app_browser_navigation_allowed"
+  | "in_app_browser_navigation_denied";
 
 export type SecurityDecision =
   | { readonly action: "allow"; readonly reason: SecurityDecisionReason }
@@ -38,32 +39,14 @@ export interface IpcSenderIdentity {
   } | null;
 }
 
-export interface BrowserPreviewThreatModel {
-  readonly reviewedBy: string;
-  readonly reviewedAt: string;
-  readonly allowedSchemes: ReadonlyArray<"http:" | "https:">;
-  readonly storagePartition: "ephemeral";
-  readonly userGestureRequired: true;
-}
-
-export interface BrowserPreviewOpenRequest {
-  readonly url: string;
-  readonly source: "open-target-router" | "localhost-preview" | "remote-content";
-  readonly userGesture: boolean;
-  readonly threatModel?: BrowserPreviewThreatModel;
-}
-
 export function createStaticWebContentsTrustPolicy(ids: Iterable<number>): IpcWebContentsTrustPolicy {
   const trusted = new Set(ids);
   return {
-    isTrustedWebContentsId: (id) => trusted.has(id)
+    isTrustedWebContentsId: (id) => trusted.has(id),
   };
 }
 
-export function evaluateIpcSender(
-  event: IpcSenderIdentity,
-  trustPolicy: IpcWebContentsTrustPolicy
-): SecurityDecision {
+export function evaluateIpcSender(event: IpcSenderIdentity, trustPolicy: IpcWebContentsTrustPolicy): SecurityDecision {
   const senderUrl = event.senderFrame?.url;
   if (!senderUrl || !isTrustedRendererUrl(senderUrl, trustPolicy.rendererUrl)) {
     return { action: "deny", reason: "untrusted_renderer_url" };
@@ -105,17 +88,19 @@ export function evaluateHtmlArtifactRequest(url: string): SecurityDecision {
   return { action: "deny", reason: "html_artifact_request_denied", detail: url };
 }
 
-export function evaluateBrowserPreviewOpenRequest(request: BrowserPreviewOpenRequest): SecurityDecision {
-  if (!request.threatModel) {
-    return {
-      action: "deny",
-      reason: "missing_browser_preview_threat_model",
-      detail: request.source
-    };
+export function evaluateInAppBrowserUrl(url: string): SecurityDecision {
+  if (URL.canParse(url)) {
+    const scheme = new URL(url).protocol;
+    if (scheme === "http:" || scheme === "https:") {
+      return { action: "allow", reason: "in_app_browser_navigation_allowed" };
+    }
   }
-  return {
-    action: "deny",
-    reason: "browser_preview_not_shipped",
-    detail: request.url
-  };
+  return { action: "deny", reason: "in_app_browser_navigation_denied", detail: url };
+}
+
+export function evaluateInAppBrowserAttachment(params: Readonly<Record<string, string>>): SecurityDecision {
+  if (params.partition === IN_APP_BROWSER_PARTITION && evaluateInAppBrowserUrl(params.src).action === "allow") {
+    return { action: "allow", reason: "in_app_browser_source_allowed" };
+  }
+  return { action: "deny", reason: "in_app_browser_source_denied", detail: params.src };
 }

--- a/packages/gui/src/renderer/App.tsx
+++ b/packages/gui/src/renderer/App.tsx
@@ -50,6 +50,7 @@ import { selectActiveRepoId, useSystemStatusQuery } from "./system-data.ts";
 import { useCatalogSnapshot } from "./catalog-data.ts";
 import { adaptRepoProject } from "./model/project-adapter.ts";
 import { TerminalView } from "./views/TerminalView.tsx";
+import { BrowserView } from "./views/BrowserView.tsx";
 import { NavigationHistoryBar } from "./components/NavigationHistoryBar.tsx";
 import { useViewHistory } from "./navigation/useViewHistory.ts";
 import { useLocationRestore } from "./navigation/useLocationRestore.ts";
@@ -640,6 +641,8 @@ function AppShell() {
                 daemonGeneration={activeRepo?.generation ?? null}
                 tasks={projectTasks.map(({ taskId, title }) => ({ taskId, title }))}
               />
+            ) : view === "browser" ? (
+              <BrowserView initialUrl={location.browserUrl} />
             ) : view === "system" ? (
               <SystemView
                 activeRepoId={activeRepoId}

--- a/packages/gui/src/renderer/browser/BrowserShell.ts
+++ b/packages/gui/src/renderer/browser/BrowserShell.ts
@@ -1,0 +1,107 @@
+export const IN_APP_BROWSER_PARTITION = "in-app-browser";
+
+export interface BrowserShellState {
+  readonly url: string;
+  readonly canGoBack: boolean;
+  readonly canGoForward: boolean;
+  readonly loading: boolean;
+  readonly error: BrowserLoadError | null;
+}
+
+export interface BrowserLoadError {
+  readonly code: number;
+  readonly description: string;
+  readonly url: string;
+}
+
+interface BrowserWebview extends HTMLElement {
+  loadURL(url: string): Promise<void>;
+  goBack(): void;
+  goForward(): void;
+  reload(): void;
+  stop(): void;
+  canGoBack(): boolean;
+  canGoForward(): boolean;
+  getURL(): string;
+}
+
+type BrowserEvent = Event & {
+  readonly errorCode?: number;
+  readonly errorDescription?: string;
+  readonly validatedURL?: string;
+  readonly url?: string;
+};
+
+export interface BrowserShell {
+  navigate(url: string): void;
+  back(): void;
+  forward(): void;
+  reload(): void;
+  stop(): void;
+  dispose(): void;
+}
+
+export function ensureUrlScheme(input: string): string {
+  const value = input.trim();
+  if (value === "") return "";
+  return /^[a-z][a-z\d+.-]*:/iu.test(value) ? value : `https://${value}`;
+}
+
+export function browserLoadError(event: BrowserEvent): BrowserLoadError | null {
+  if (event.errorCode === undefined || event.errorCode === -3) return null;
+  return {
+    code: event.errorCode,
+    description: event.errorDescription ?? "Page failed to load",
+    url: event.validatedURL ?? "",
+  };
+}
+
+export function createBrowserShell(element: HTMLElement, onState: (state: BrowserShellState) => void): BrowserShell {
+  const webview = element as BrowserWebview;
+  let state: BrowserShellState = {
+    url: element.getAttribute("src") ?? "",
+    canGoBack: false,
+    canGoForward: false,
+    loading: false,
+    error: null,
+  };
+  const emit = (patch: Partial<BrowserShellState>) => {
+    state = { ...state, ...patch };
+    onState(state);
+  };
+  const syncNavigation = (event: BrowserEvent) =>
+    emit({
+      url: event.url ?? webview.getURL(),
+      canGoBack: webview.canGoBack(),
+      canGoForward: webview.canGoForward(),
+      error: null,
+    });
+  const start = () => emit({ loading: true, error: null });
+  const stop = () => emit({ loading: false });
+  const fail = (event: BrowserEvent) => {
+    const error = browserLoadError(event);
+    if (error) emit({ loading: false, error });
+  };
+  const listeners = [
+    ["did-start-loading", start],
+    ["did-stop-loading", stop],
+    ["did-navigate", syncNavigation],
+    ["did-navigate-in-page", syncNavigation],
+    ["did-fail-load", fail],
+  ] as const;
+  for (const [name, listener] of listeners) element.addEventListener(name, listener as EventListener);
+  onState(state);
+  return {
+    navigate: (url) => {
+      emit({ error: null });
+      void webview.loadURL(url);
+    },
+    back: () => webview.goBack(),
+    forward: () => webview.goForward(),
+    reload: () => webview.reload(),
+    stop: () => webview.stop(),
+    dispose: () => {
+      for (const [name, listener] of listeners) element.removeEventListener(name, listener as EventListener);
+    },
+  };
+}

--- a/packages/gui/src/renderer/i18n/locales/en-US/rebuild.json
+++ b/packages/gui/src/renderer/i18n/locales/en-US/rebuild.json
@@ -24,6 +24,7 @@
   "shell.nav.factDetail": "Fact Detail",
   "shell.nav.sessions": "Sessions",
   "shell.nav.terminal": "Terminal",
+  "shell.nav.browser": "Browser",
   "shell.nav.agentSquad": "Agents · Squads",
   "shell.nav.providers": "Providers",
   "shell.nav.schedules": "Schedules",

--- a/packages/gui/src/renderer/i18n/locales/zh-CN/rebuild.json
+++ b/packages/gui/src/renderer/i18n/locales/zh-CN/rebuild.json
@@ -24,6 +24,7 @@
   "shell.nav.factDetail": "事实详情",
   "shell.nav.sessions": "会话",
   "shell.nav.terminal": "终端",
+  "shell.nav.browser": "浏览器",
   "shell.nav.agentSquad": "Agent · 含 Squad",
   "shell.nav.providers": "Provider",
   "shell.nav.schedules": "定时计划",

--- a/packages/gui/src/renderer/navigation/navConfig.tsx
+++ b/packages/gui/src/renderer/navigation/navConfig.tsx
@@ -14,7 +14,6 @@ import {
   FileHtml,
   BookOpen,
   TerminalWindow,
-  Globe,
 } from "@phosphor-icons/react";
 import { t, type MessageKey } from "../i18n/index.tsx";
 import type { ViewId } from "./viewHistory.ts";
@@ -84,7 +83,6 @@ export const NAV_GROUPS: readonly NavGroup[] = [
     items: [
       { id: "sessions", icon: <Waveform weight="duotone" /> },
       { id: "terminal", icon: <TerminalWindow weight="duotone" /> },
-      { id: "browser", icon: <Globe weight="duotone" /> },
       { id: "schedules", icon: <Clock weight="duotone" /> },
       { id: "artifacts", icon: <FileHtml weight="duotone" /> },
       { id: "agentSquad", icon: <Users weight="duotone" /> },

--- a/packages/gui/src/renderer/navigation/navConfig.tsx
+++ b/packages/gui/src/renderer/navigation/navConfig.tsx
@@ -14,6 +14,7 @@ import {
   FileHtml,
   BookOpen,
   TerminalWindow,
+  Globe,
 } from "@phosphor-icons/react";
 import { t, type MessageKey } from "../i18n/index.tsx";
 import type { ViewId } from "./viewHistory.ts";
@@ -44,6 +45,7 @@ const NAV_LABEL_KEY: Record<ViewId, MessageKey> = {
   agentSquad: "shell.nav.agentSquad",
   providers: "shell.nav.providers",
   terminal: "shell.nav.terminal",
+  browser: "shell.nav.browser",
   system: "shell.nav.system",
   daemonObserve: "shell.nav.daemonObserve",
   settings: "shell.nav.settings",
@@ -82,6 +84,7 @@ export const NAV_GROUPS: readonly NavGroup[] = [
     items: [
       { id: "sessions", icon: <Waveform weight="duotone" /> },
       { id: "terminal", icon: <TerminalWindow weight="duotone" /> },
+      { id: "browser", icon: <Globe weight="duotone" /> },
       { id: "schedules", icon: <Clock weight="duotone" /> },
       { id: "artifacts", icon: <FileHtml weight="duotone" /> },
       { id: "agentSquad", icon: <Users weight="duotone" /> },

--- a/packages/gui/src/renderer/navigation/viewHistory.ts
+++ b/packages/gui/src/renderer/navigation/viewHistory.ts
@@ -35,6 +35,7 @@ export type ViewId =
   | "agentSquad"
   | "providers"
   | "terminal"
+  | "browser"
   | "system"
   | "daemonObserve"
   | "settings";
@@ -47,6 +48,7 @@ export interface DrillState {
 
 export interface AppLocation {
   view: ViewId;
+  browserUrl?: string | null;
   selectedId: string | null;
   previewId: string | null;
   focusedEntityRef: string | null;
@@ -89,6 +91,7 @@ export function goForward(state: ViewHistoryState): ViewHistoryState {
 export function locationsEqual(a: AppLocation, b: AppLocation): boolean {
   return (
     a.view === b.view &&
+    (a.browserUrl ?? null) === (b.browserUrl ?? null) &&
     a.selectedId === b.selectedId &&
     a.previewId === b.previewId &&
     a.focusedEntityRef === b.focusedEntityRef &&

--- a/packages/gui/src/renderer/navigation/viewHistoryStorage.ts
+++ b/packages/gui/src/renderer/navigation/viewHistoryStorage.ts
@@ -35,6 +35,7 @@ const VIEW_IDS: ReadonlySet<string> = new Set<ViewId>([
   "agentSquad",
   "providers",
   "terminal",
+  "browser",
   "system",
   "daemonObserve",
   "settings",
@@ -74,6 +75,7 @@ function isAppLocation(value: unknown): value is AppLocation {
     !isNullableString(value.selectedId) ||
     !isNullableString(value.previewId) ||
     !isNullableString(value.focusedEntityRef) ||
+    !(value.browserUrl === undefined || isNullableString(value.browserUrl)) ||
     !isCanonicalFocusedRef(value.focusedEntityRef) ||
     !isTaskFilters(value.taskFilters)
   )
@@ -107,6 +109,7 @@ function storageKey(projectId: string): string {
 export function initialLocation(filters?: TaskFilters): AppLocation {
   return {
     view: "overview",
+    browserUrl: null,
     selectedId: null,
     previewId: null,
     focusedEntityRef: null,

--- a/packages/gui/src/renderer/styles.css
+++ b/packages/gui/src/renderer/styles.css
@@ -343,6 +343,12 @@ html[data-theme="light"] ::selection {
   min-height: 0;
 }
 
+.in-app-browser-webview {
+  width: 100%;
+  height: 100%;
+  border: 0;
+}
+
 /*
  * Agent Runtime 配置平面（原型 agent-runtime-prototype.html 的视觉语言）
  * 只有这些形状在 Tailwind 工具类里表达不动，或需要成对出现才有意义，才落到这里。

--- a/packages/gui/src/renderer/views/BrowserView.tsx
+++ b/packages/gui/src/renderer/views/BrowserView.tsx
@@ -1,0 +1,107 @@
+import { useEffect, useRef, useState, type FormEvent } from "react";
+import {
+  createBrowserShell,
+  ensureUrlScheme,
+  IN_APP_BROWSER_PARTITION,
+  type BrowserShell,
+  type BrowserShellState,
+} from "../browser/BrowserShell.ts";
+
+const DEFAULT_URL = "https://example.com";
+const initialState: BrowserShellState = {
+  url: "",
+  canGoBack: false,
+  canGoForward: false,
+  loading: false,
+  error: null,
+};
+
+export function BrowserView({ initialUrl }: { readonly initialUrl?: string | null }) {
+  const hostRef = useRef<HTMLDivElement>(null);
+  const shellRef = useRef<BrowserShell | null>(null);
+  const [state, setState] = useState(initialState);
+  const [address, setAddress] = useState(ensureUrlScheme(initialUrl ?? DEFAULT_URL));
+
+  useEffect(() => {
+    const host = hostRef.current;
+    if (!host) return;
+    const webview = document.createElement("webview");
+    const url = ensureUrlScheme(initialUrl ?? DEFAULT_URL);
+    webview.dataset.testid = "in-app-browser-webview";
+    webview.setAttribute("aria-label", "In-app browser content");
+    webview.setAttribute("partition", IN_APP_BROWSER_PARTITION);
+    webview.setAttribute(
+      "webpreferences",
+      "contextIsolation=yes,nodeIntegration=no,sandbox=yes,webSecurity=yes,plugins=no,webviewTag=no",
+    );
+    webview.setAttribute("src", url);
+    webview.className = "in-app-browser-webview";
+    host.replaceChildren(webview);
+    const shell = createBrowserShell(webview, (next) => {
+      setState(next);
+      if (next.url) setAddress(next.url);
+    });
+    shellRef.current = shell;
+    return () => {
+      shell.dispose();
+      shellRef.current = null;
+      webview.remove();
+    };
+  }, [initialUrl]);
+
+  const submit = (event: FormEvent) => {
+    event.preventDefault();
+    const url = ensureUrlScheme(address);
+    if (url) {
+      setAddress(url);
+      shellRef.current?.navigate(url);
+    }
+  };
+
+  return (
+    <section className="flex min-h-0 min-w-0 flex-1 flex-col bg-surface" data-testid="browser-view">
+      <form className="flex shrink-0 items-center gap-1 border-b border-border px-2 py-1.5" onSubmit={submit}>
+        <button type="button" aria-label="Back" disabled={!state.canGoBack} onClick={() => shellRef.current?.back()}>
+          ←
+        </button>
+        <button
+          type="button"
+          aria-label="Forward"
+          disabled={!state.canGoForward}
+          onClick={() => shellRef.current?.forward()}
+        >
+          →
+        </button>
+        <button
+          type="button"
+          aria-label={state.loading ? "Stop" : "Reload"}
+          onClick={() => (state.loading ? shellRef.current?.stop() : shellRef.current?.reload())}
+        >
+          {state.loading ? "×" : "↻"}
+        </button>
+        <input
+          aria-label="Address"
+          className="control min-w-0 flex-1 font-mono"
+          value={address}
+          onChange={(event) => setAddress(event.target.value)}
+          autoCapitalize="off"
+          autoCorrect="off"
+          spellCheck={false}
+        />
+      </form>
+      <div className="relative min-h-0 min-w-0 flex-1 bg-white">
+        <div ref={hostRef} className="absolute inset-0" data-testid="in-app-browser-host" />
+        {state.error && (
+          <div className="absolute inset-0 grid place-content-center gap-3 bg-surface p-8 text-center" role="alert">
+            <strong>Page could not be loaded</strong>
+            <span className="text-sm text-text-muted">{state.error.description}</span>
+            <code className="text-xs text-text-faint">{state.error.url}</code>
+            <button className="control justify-self-center" onClick={() => shellRef.current?.reload()}>
+              Try again
+            </button>
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/packages/gui/test/browser-shell.vitest.ts
+++ b/packages/gui/test/browser-shell.vitest.ts
@@ -1,0 +1,69 @@
+// harness-test-tier: fast
+import { describe, expect, it, vi } from "vitest";
+import {
+  browserLoadError,
+  createBrowserShell,
+  ensureUrlScheme,
+  type BrowserShellState,
+} from "../src/renderer/browser/BrowserShell.ts";
+
+class FakeWebview extends EventTarget {
+  readonly attributes = new Map<string, string>();
+  readonly loadURL = vi.fn(async () => undefined);
+  readonly goBack = vi.fn();
+  readonly goForward = vi.fn();
+  readonly reload = vi.fn();
+  readonly stop = vi.fn();
+  getAttribute(name: string) {
+    return this.attributes.get(name) ?? null;
+  }
+  getURL() {
+    return "https://example.com/next";
+  }
+  canGoBack() {
+    return true;
+  }
+  canGoForward() {
+    return false;
+  }
+}
+
+describe("BrowserShell", () => {
+  it("normalizes address-bar input without changing explicit schemes", () => {
+    expect(ensureUrlScheme(" example.com/docs ")).toBe("https://example.com/docs");
+    expect(ensureUrlScheme("http://127.0.0.1:3000")).toBe("http://127.0.0.1:3000");
+    expect(ensureUrlScheme("javascript:alert(1)")).toBe("javascript:alert(1)");
+  });
+
+  it("drives the engine-neutral navigation contract and reports navigation state", async () => {
+    const element = new FakeWebview();
+    const states: BrowserShellState[] = [];
+    const shell = createBrowserShell(element as unknown as HTMLElement, (state) => states.push(state));
+    shell.navigate("https://example.com");
+    shell.back();
+    shell.forward();
+    shell.reload();
+    shell.stop();
+    element.dispatchEvent(new Event("did-navigate"));
+    expect(element.loadURL).toHaveBeenCalledWith("https://example.com");
+    expect(element.goBack).toHaveBeenCalledOnce();
+    expect(element.goForward).toHaveBeenCalledOnce();
+    expect(element.reload).toHaveBeenCalledOnce();
+    expect(element.stop).toHaveBeenCalledOnce();
+    expect(states.at(-1)).toMatchObject({ url: "https://example.com/next", canGoBack: true, canGoForward: false });
+    shell.dispose();
+  });
+
+  it("ignores ERR_ABORTED and exposes other load failures", () => {
+    expect(browserLoadError(Object.assign(new Event("did-fail-load"), { errorCode: -3 }))).toBeNull();
+    expect(
+      browserLoadError(
+        Object.assign(new Event("did-fail-load"), {
+          errorCode: -105,
+          errorDescription: "NAME_NOT_RESOLVED",
+          validatedURL: "https://missing.invalid",
+        }),
+      ),
+    ).toEqual({ code: -105, description: "NAME_NOT_RESOLVED", url: "https://missing.invalid" });
+  });
+});

--- a/packages/gui/test/electron-security-policy.test.ts
+++ b/packages/gui/test/electron-security-policy.test.ts
@@ -5,65 +5,75 @@ import {
   createStaticWebContentsTrustPolicy,
   evaluateHtmlArtifactAttachment,
   evaluateHtmlArtifactRequest,
-  evaluateBrowserPreviewOpenRequest,
+  evaluateInAppBrowserAttachment,
+  evaluateInAppBrowserUrl,
   evaluateIpcSender,
   evaluateNavigationRequest,
   evaluatePermissionRequest,
-  evaluateWindowOpenRequest
+  evaluateWindowOpenRequest,
 } from "../src/index.ts";
 
 test("IPC sender trust requires both renderer URL and owned webContents id", () => {
   const packagedRendererUrl = "file:///app/renderer/index.html";
   const trustPolicy = {
     ...createStaticWebContentsTrustPolicy([7]),
-    rendererUrl: { packagedRendererUrl }
+    rendererUrl: { packagedRendererUrl },
   };
 
-  assert.deepEqual(
-    evaluateIpcSender({ sender: { id: 7 }, senderFrame: { url: packagedRendererUrl } }, trustPolicy),
-    { action: "allow", reason: "trusted_renderer" }
-  );
+  assert.deepEqual(evaluateIpcSender({ sender: { id: 7 }, senderFrame: { url: packagedRendererUrl } }, trustPolicy), {
+    action: "allow",
+    reason: "trusted_renderer",
+  });
   assert.deepEqual(
     evaluateIpcSender({ sender: { id: 7 }, senderFrame: { url: "https://example.invalid" } }, trustPolicy),
-    { action: "deny", reason: "untrusted_renderer_url" }
+    { action: "deny", reason: "untrusted_renderer_url" },
   );
-  assert.deepEqual(
-    evaluateIpcSender({ sender: { id: 9 }, senderFrame: { url: packagedRendererUrl } }, trustPolicy),
-    { action: "deny", reason: "untrusted_web_contents" }
-  );
-  assert.deepEqual(
-    evaluateIpcSender({ sender: { id: 7 }, senderFrame: null }, trustPolicy),
-    { action: "deny", reason: "untrusted_renderer_url" }
-  );
+  assert.deepEqual(evaluateIpcSender({ sender: { id: 9 }, senderFrame: { url: packagedRendererUrl } }, trustPolicy), {
+    action: "deny",
+    reason: "untrusted_web_contents",
+  });
+  assert.deepEqual(evaluateIpcSender({ sender: { id: 7 }, senderFrame: null }, trustPolicy), {
+    action: "deny",
+    reason: "untrusted_renderer_url",
+  });
   assert.deepEqual(
     evaluateIpcSender({ sender: { id: 7 }, senderFrame: { url: "http://127.0.0.1:5173" } }, trustPolicy),
-    { action: "deny", reason: "untrusted_renderer_url" }
+    { action: "deny", reason: "untrusted_renderer_url" },
   );
   assert.deepEqual(
     evaluateIpcSender({ sender: { id: 7 }, senderFrame: { url: "file:///tmp/renderer/index.html" } }, trustPolicy),
-    { action: "deny", reason: "untrusted_renderer_url" }
+    { action: "deny", reason: "untrusted_renderer_url" },
   );
   assert.deepEqual(
     evaluateIpcSender({ sender: { id: 7 }, senderFrame: { url: "file:///app/.harness-private/task.md" } }, trustPolicy),
-    { action: "deny", reason: "untrusted_renderer_url" }
+    { action: "deny", reason: "untrusted_renderer_url" },
   );
 });
 
 test("HTML artifact guests accept only the isolated data document and no external subresources", () => {
   assert.deepEqual(
-    evaluateHtmlArtifactAttachment({ partition: "html-artifact-preview", src: "data:text/html;charset=utf-8,%3Ch1%3Ereport%3C%2Fh1%3E" }),
-    { action: "allow", reason: "html_artifact_source_allowed" }
+    evaluateHtmlArtifactAttachment({
+      partition: "html-artifact-preview",
+      src: "data:text/html;charset=utf-8,%3Ch1%3Ereport%3C%2Fh1%3E",
+    }),
+    { action: "allow", reason: "html_artifact_source_allowed" },
   );
   for (const params of [
     { partition: "persist:html-artifact-preview", src: "data:text/html;charset=utf-8,report" },
     { partition: "html-artifact-preview", src: "file:///tmp/report.html" },
-    { partition: "html-artifact-preview", src: "https://example.invalid/report.html" }
+    { partition: "html-artifact-preview", src: "https://example.invalid/report.html" },
   ]) {
     assert.equal(evaluateHtmlArtifactAttachment(params).action, "deny");
   }
   assert.equal(evaluateHtmlArtifactRequest("data:image/png;base64,AAAA").action, "allow");
   assert.equal(evaluateHtmlArtifactRequest("about:blank").action, "allow");
-  for (const url of ["https://example.invalid/a.png", "http://127.0.0.1:3000", "file:///tmp/private", "blob:https://example.invalid/id", "not a url"]) {
+  for (const url of [
+    "https://example.invalid/a.png",
+    "http://127.0.0.1:3000",
+    "file:///tmp/private",
+    "blob:https://example.invalid/id",
+    "not a url",
+  ]) {
     assert.equal(evaluateHtmlArtifactRequest(url).action, "deny");
   }
 });
@@ -71,71 +81,70 @@ test("HTML artifact guests accept only the isolated data document and no externa
 test("permission navigation and window-open policies are deny-by-default", () => {
   assert.deepEqual(evaluatePermissionRequest(), {
     action: "deny",
-    reason: "permission_denied_by_default"
+    reason: "permission_denied_by_default",
   });
   assert.deepEqual(evaluateWindowOpenRequest(), {
     action: "deny",
-    reason: "window_open_denied"
+    reason: "window_open_denied",
   });
   assert.deepEqual(evaluateNavigationRequest("https://example.invalid"), {
     action: "deny",
-    reason: "navigation_denied"
-  });
-  assert.deepEqual(evaluateNavigationRequest("file:///app/renderer/index.html", { packagedRendererUrl: "file:///app/renderer/index.html" }), {
-    action: "allow",
-    reason: "trusted_renderer"
-  });
-  assert.deepEqual(evaluateNavigationRequest("file:///tmp/renderer/index.html", { packagedRendererUrl: "file:///app/renderer/index.html" }), {
-    action: "deny",
-    reason: "navigation_denied"
-  });
-  assert.deepEqual(evaluateNavigationRequest("http://127.0.0.1:5173", { packagedRendererUrl: "file:///app/renderer/index.html" }), {
-    action: "deny",
-    reason: "navigation_denied"
+    reason: "navigation_denied",
   });
   assert.deepEqual(
-    evaluateNavigationRequest("http://127.0.0.1:5173", {
+    evaluateNavigationRequest("file:///app/renderer/index.html", {
       packagedRendererUrl: "file:///app/renderer/index.html",
-      allowDevRenderer: true
     }),
     {
       action: "allow",
-      reason: "trusted_renderer"
-    }
+      reason: "trusted_renderer",
+    },
+  );
+  assert.deepEqual(
+    evaluateNavigationRequest("file:///tmp/renderer/index.html", {
+      packagedRendererUrl: "file:///app/renderer/index.html",
+    }),
+    {
+      action: "deny",
+      reason: "navigation_denied",
+    },
+  );
+  assert.deepEqual(
+    evaluateNavigationRequest("http://127.0.0.1:5173", { packagedRendererUrl: "file:///app/renderer/index.html" }),
+    {
+      action: "deny",
+      reason: "navigation_denied",
+    },
+  );
+  assert.deepEqual(
+    evaluateNavigationRequest("http://127.0.0.1:5173", {
+      packagedRendererUrl: "file:///app/renderer/index.html",
+      allowDevRenderer: true,
+    }),
+    {
+      action: "allow",
+      reason: "trusted_renderer",
+    },
   );
 });
 
-test("browser and preview content cannot open without a threat model and remains unshipped", () => {
-  assert.deepEqual(
-    evaluateBrowserPreviewOpenRequest({
-      url: "https://example.invalid",
-      source: "open-target-router",
-      userGesture: true
-    }),
-    {
-      action: "deny",
-      reason: "missing_browser_preview_threat_model",
-      detail: "open-target-router"
-    }
-  );
-
-  assert.deepEqual(
-    evaluateBrowserPreviewOpenRequest({
-      url: "http://127.0.0.1:3000",
-      source: "localhost-preview",
-      userGesture: true,
-      threatModel: {
-        reviewedBy: "M25GUI-P09",
-        reviewedAt: "2026-06-14",
-        allowedSchemes: ["http:"],
-        storagePartition: "ephemeral",
-        userGestureRequired: true
-      }
-    }),
-    {
-      action: "deny",
-      reason: "browser_preview_not_shipped",
-      detail: "http://127.0.0.1:3000"
-    }
+test("in-app browser accepts only HTTP(S) in its isolated ephemeral partition", () => {
+  for (const url of ["http://127.0.0.1:3000", "https://example.invalid/path"]) {
+    assert.equal(evaluateInAppBrowserUrl(url).action, "allow");
+    assert.equal(evaluateInAppBrowserAttachment({ partition: "in-app-browser", src: url }).action, "allow");
+  }
+  for (const url of [
+    "file:///tmp/private",
+    "javascript:alert(1)",
+    "chrome://settings",
+    "data:text/html,x",
+    "not a url",
+  ]) {
+    assert.equal(evaluateInAppBrowserUrl(url).action, "deny");
+    assert.equal(evaluateInAppBrowserAttachment({ partition: "in-app-browser", src: url }).action, "deny");
+  }
+  assert.equal(
+    evaluateInAppBrowserAttachment({ partition: "persist:in-app-browser", src: "https://example.invalid" }).action,
+    "deny",
   );
 });

--- a/packages/gui/test/entity-id-links.vitest.ts
+++ b/packages/gui/test/entity-id-links.vitest.ts
@@ -22,6 +22,7 @@ import { SessionsView } from "../src/renderer/views/SessionsView.tsx";
 import { AgentSquadView } from "../src/renderer/views/AgentSquadView.tsx";
 import { ProvidersView } from "../src/renderer/views/ProvidersView.tsx";
 import { TerminalView } from "../src/renderer/views/TerminalView.tsx";
+import { BrowserView } from "../src/renderer/views/BrowserView.tsx";
 import { SchedulesView } from "../src/renderer/views/SchedulesView.tsx";
 import { schedulesClient } from "../src/renderer/schedules-client.ts";
 import { ArtifactsView } from "../src/renderer/views/ArtifactsView.tsx";
@@ -722,6 +723,7 @@ const VIEW_RENDERERS = {
       daemonGeneration: 1,
       tasks: FIXTURE_TASKS.map(({ taskId, title }) => ({ taskId, title })),
     }),
+  browser: () => createElement(BrowserView, { initialUrl: "https://example.com" }),
   system: () => createElement(SystemView, { activeRepoId: REPO_ID, onOpenObserve: noop }),
   daemonObserve: () =>
     createElement(DaemonObserveView, {

--- a/packages/gui/test/entity-id-links.vitest.ts
+++ b/packages/gui/test/entity-id-links.vitest.ts
@@ -768,7 +768,7 @@ describe("G10 entity-id-links 行为判据:视图渲染出的实体 ID 必须可
     // 「在映射里但没渲染」的键在这里被导航面一致性断言拦下。
     const declared = new Set(Object.keys(VIEW_RENDERERS));
     expect([...declared].sort()).toEqual(
-      [...navViewIds, "home", "decisionDetail", "factDetail", "daemonObserve"].sort(),
+      [...navViewIds, "home", "decisionDetail", "factDetail", "daemonObserve", "browser"].sort(),
     );
     for (const id of navViewIds) expect(declared.has(id), `导航面 view ${id} 缺渲染入口`).toBe(true);
   });

--- a/tools/gui-test-manifest.mjs
+++ b/tools/gui-test-manifest.mjs
@@ -25,6 +25,7 @@ export const guiVitestManifest = [
   "packages/gui/test/terminal-page.vitest.ts",
   "packages/gui/test/terminal-split-layout.vitest.ts",
   "packages/gui/test/terminal-split-grid.vitest.ts",
+  "packages/gui/test/browser-shell.vitest.ts",
   "packages/gui/test/genealogy.vitest.ts",
   "packages/gui/test/territory.vitest.ts",
   "packages/gui/test/territory-layout.vitest.ts",


### PR DESCRIPTION
# English

## Summary

PLT-TerminalWorkspace W3: an isolated in-app browser. A new `ViewId "browser"` renders a `BrowserView` (address bar with scheme completion, back/forward/reload-stop, load-error overlay) backed by a `<webview>` on a **new** locked-down policy branch — its own ephemeral `in-app-browser` partition, separate from the html-artifact preview path which stays a full deny surface. Security boundary is recorded as accepted decision `dec_E677716E91F015170FC6E1B996`.

## Architectural Justification

The pre-existing `evaluateBrowserPreviewOpenRequest` / `BrowserPreviewThreatModel` scaffolding in `security-policy.ts` was a placeholder that denied everything (`browser_preview_not_shipped`); this slice deletes it and ships the real `evaluateInAppBrowserUrl` / `evaluateInAppBrowserAttachment` in its place — one implementation, no dead scaffold retained. The `html-artifact` policy is untouched (charter RJ3): the two only fork at `will-attach-webview` by partition. `BrowserShell` is a thin engine-neutral seam so a future `WebContentsView` swap needs no UI change.

## What Changed

- New `in-app-browser` session partition: permission check/request handlers deny-by-default, `will-download` prevented.
- `will-attach-webview` for that partition: preload deleted, nodeIntegration/plugins/devTools/webviewTag off, contextIsolation + sandbox + webSecurity on, javascript on (remote pages need it).
- `did-attach-webview`: `setWindowOpenHandler` → deny (no popups), `will-navigate` restricted to http/https.
- Renderer: `BrowserShell.ts` (navigate/back/forward/reload/stop + state callbacks) + `views/BrowserView.tsx` + `ViewId "browser"` with an `initialUrl` payload.
- Deleted the `browser_preview_not_shipped` / `missing_browser_preview_threat_model` scaffolding.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: use the single CI-backed `Production-Delta` declaration below; do not enter a second metric.

## Machine-Readable Declarations

Production-Delta: +283/-38

## Task And Scope

- Harness task: task_8df98c954251a49b7e35b025e9 (W3, under milestone task_d2985b723b87a2cf55aa24d6fe, charter dec_31DA7CDFE06589AD47B56BF11E)
- Branch: codex/terminal-browser
- Public scope: packages/gui main security-policy/electron-main + renderer browser view/navigation + gui tests
- Private planning/evidence updated: yes (task package plan/report, security decision dec_E677716E91F015170FC6E1B996, fact F-D0BB9132)
- Out of scope: W2 terminal-link wiring (the openUrl seam is wired by the coordinator after both W2/W3 land), multi-tab browsing, WebContentsView migration

## Version Impact

- Version: no version change because this is a pre-release product slice with no published package surface change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: yes
- Protected surface scope: Electron webview attach/navigation security policy (packages/gui/src/main/security-policy.ts, electron-main.ts webview policy)
- Authority: dec_E677716E91F015170FC6E1B996 (in-app browser security boundary, accepted), dec_31DA7CDFE06589AD47B56BF11E (milestone charter), task_8df98c954251a49b7e35b025e9
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no

## Verification

- Base `origin/main` SHA: 54a3f2df55b4ddee48206a505c9cb31d53ef9c55
- Branch merge-base with `origin/main`: 54a3f2df55b4ddee48206a505c9cb31d53ef9c55
- Last `git fetch origin` time: 2026-09-01 14:5x (+0800)
- Sync method: none needed (branch created from current origin/main; rebase confirms up to date)
- Public diff command: `git diff origin/main...codex/terminal-browser`
- Private evidence commit/path: harness ledger `tasks/task_8df98c954251a49b7e35b025e9-terminal-browser-w3/`
- Reviewer evidence path: same task package `artifacts/w3-report.md`
- GitHub Actions `rewrite-ci` run URL: pending (filled by CI on this PR)
- [x] `node --test packages/gui/test/electron-security-policy.test.ts`: 4/4 (CEO re-run — deny-by-default, http(s)-only, html-artifact path still fully locked)
- [x] `vitest run test/browser-shell.vitest.ts`: 3/3 (worker)
- [x] typecheck pass; contract test ran in isolated Ubuntu target (worker)
- [ ] GitHub Actions `rewrite-ci` passed
- Not run: full `npm run check:local` — worker stop-point policy limits local runs to the touched surface; GitHub CI is the complete authority.

---

# 中文

## 摘要

PLT-TerminalWorkspace W3:隔离的内嵌浏览器。新增 `ViewId "browser"` 渲染 `BrowserView`(地址栏补协议、前进/后退/刷新-停止、加载错误页),由 `<webview>` 承载,走**新的**降权策略分支——独立临时 `in-app-browser` partition,与仍全禁的 html-artifact 预览通路分开。安全边界记为已采纳 decision `dec_E677716E91F015170FC6E1B996`。

## 架构辩护

`security-policy.ts` 里原有 `evaluateBrowserPreviewOpenRequest`/`BrowserPreviewThreatModel` 是全拒占位(`browser_preview_not_shipped`);本切片删除它、就地换上真实的 `evaluateInAppBrowserUrl`/`evaluateInAppBrowserAttachment`——一个实现,不留死 scaffold。html-artifact 策略零改动(charter RJ3):两者仅在 `will-attach-webview` 按 partition 分流。`BrowserShell` 是引擎中性薄接缝,将来换 WebContentsView 不动 UI。

## 变更清单

- 新 `in-app-browser` partition:权限 check/request 默认拒、下载拒。
- 该 partition 的 webview attach:preload 删、nodeIntegration/plugins/devTools/webviewTag 关、contextIsolation+sandbox+webSecurity 开、javascript 开。
- setWindowOpenHandler 拒 popup;will-navigate 限 http/https。
- renderer:BrowserShell + BrowserView + ViewId "browser"。
- 删除旧占位 scaffolding。

## 任务与范围

- Harness 任务:task_8df98c954251a49b7e35b025e9(W3,里程碑 task_d2985b723b87a2cf55aa24d6fe,charter dec_31DA7CDFE06589AD47B56BF11E)
- 分支:codex/terminal-browser;范围外:W2 链接接线(两波都合入后由协调者接 openUrl)、多 tab、WebContentsView 迁移

## 治理声明

- 触碰 protected surface:是(Electron webview attach/导航安全策略)。
- 授权:dec_E677716E91F015170FC6E1B996(内嵌浏览器安全边界,已采纳)、dec_31DA7CDFE06589AD47B56BF11E(里程碑 charter)、task_8df98c954251a49b7e35b025e9。
- 无 break-glass。

## 验证

- CEO 亲跑 electron-security-policy.test 4/4(deny-by-default、只 http(s)、html-artifact 通路仍全禁);browser-shell 3/3;typecheck 绿。完整检查以 GitHub CI 为权威。
- 残余风险:will-frame-navigate 类型在 Electron 42 不兼容,顶层导航用 will-navigate 限制,子帧运行时行为未验证(sandbox+webSecurity+无 Node 已兜住主威胁面);地址栏/错误页/popup 真机手感待合并后 canonical 亲验(W4)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BE45Q2y1iZzLJNo8j7xhhL
