### PR TITLE
perf(kernel): reuse validated WAL-backed ledger prefixes

### DIFF
--- a/packages/kernel/src/store/ledger-git-layout.ts
+++ b/packages/kernel/src/store/ledger-git-layout.ts
@@ -6,15 +6,27 @@ export interface LedgerGitLayout {
   readonly authoredRoot: string;
   readonly authoredPrefix: string;
 }
+// The Git repository root of an existing authored root does not move while a process is
+// attached to it, but deriving it costs a `git rev-parse --show-toplevel` subprocess. The
+// write path resolves the layout on nearly every command and again on every WAL reload, so
+// the derivation — and the layout object identity downstream per-commit caches key on — is
+// memoized per normalized authored root. Harness layout settings stay uncached: a changed
+// harness.yaml resolves to a different authored root and therefore a different key.
+const ledgerTopLevelCache = new Map<string, LedgerGitLayout>();
 export function resolveLedgerGitLayout(input: HarnessLayoutInput): LedgerGitLayout {
   const vcs = makeLocalVersionControlSystem(),
     authoredRoot = vcs.normalizePath(resolveHarnessLayout(input).authoredRoot),
-    rootDir = vcs.topLevel(authoredRoot);
+    cached = ledgerTopLevelCache.get(authoredRoot);
+  if (cached) return cached;
+  const rootDir = vcs.topLevel(authoredRoot);
   if (!rootDir) throw new Error(`authored root must belong to its ledger Git repository: ${authoredRoot}`);
   const authoredPrefix = path.relative(rootDir, authoredRoot).split(path.sep).join("/");
   if (authoredPrefix === ".." || authoredPrefix.startsWith("../"))
     throw new Error(`authored root must be inside its ledger Git repository: ${authoredRoot}`);
-  return { rootDir, authoredRoot, authoredPrefix };
+  const layout = { rootDir, authoredRoot, authoredPrefix };
+  if (ledgerTopLevelCache.size >= 64) ledgerTopLevelCache.clear();
+  ledgerTopLevelCache.set(authoredRoot, layout);
+  return layout;
 }
 export function ledgerGitPath(layout: LedgerGitLayout, authoredRelativePath: string): string {
   return layout.authoredPrefix ? `${layout.authoredPrefix}/${authoredRelativePath}` : authoredRelativePath;

--- a/packages/kernel/src/store/task-event-store-factory.ts
+++ b/packages/kernel/src/store/task-event-store-factory.ts
@@ -53,7 +53,13 @@ function storeApi(runtime: StoreRuntime, publication: ReturnType<typeof createPu
       return canonicalRevisionAt(runtime.ledger, runtime.canonicalCommit, commit.sha);
     },
     read: () => {
-      const stream = readStream(runtime.ledger, runtime.canonicalCommit, runtime.readHead());
+      const floor = runtime.options.contentValidationFloor?.() ?? 0;
+      const stream = readStream(
+        runtime.ledger,
+        runtime.canonicalCommit,
+        runtime.readHead(),
+        floor > 0 ? { validateContentFrom: floor } : undefined,
+      );
       runtime.knownOpIds = new Set(stream.events.map((event) => event.opId));
       runtime.rememberEvents(stream.events);
       return stream;

--- a/packages/kernel/src/store/task-event-store-reads.ts
+++ b/packages/kernel/src/store/task-event-store-reads.ts
@@ -70,12 +70,22 @@ export function receipt(
     },
   };
 }
-export function readStream(ledger: LedgerGitLayout, commit: string, head: EventHead | null): CanonicalEventStreamV1 {
+export interface ReadStreamOptions {
+  /** Events at or below this revision are content-validation exempt in this process. */
+  readonly validateContentFrom?: number;
+}
+export function readStream(
+  ledger: LedgerGitLayout,
+  commit: string,
+  head: EventHead | null,
+  options: ReadStreamOptions = {},
+): CanonicalEventStreamV1 {
   if (head === null) return { schema: "canonical-event-stream/v1", revision: 0, events: [] };
   const events = readEventsAt(ledger, commit, eventEntries(ledger, commit)).sort(
     (a, b) => a.workspaceRevision - b.workspaceRevision,
   );
-  validateStreamContent(ledger, commit, events);
+  const floor = options.validateContentFrom ?? 0;
+  validateStreamContent(ledger, commit, floor > 0 ? events.filter((event) => event.workspaceRevision > floor) : events);
   const opIds = new Set<string>();
   for (const [index, event] of events.entries()) {
     if (event.workspaceRevision !== index + 1)

--- a/packages/kernel/src/store/task-event-store-runtime.ts
+++ b/packages/kernel/src/store/task-event-store-runtime.ts
@@ -18,6 +18,8 @@ export function createStoreRuntime(options: {
   readonly beforeAppend?: () => void;
   readonly withAppendFence?: <T>(operation: () => T) => T;
   readonly rejectPreparedRecovery?: boolean;
+  /** Reports the highest revision whose content this process already validated exactly. */
+  readonly contentValidationFloor?: () => number;
 }) {
   const input = options.rootInput ?? options.rootDir;
   if (input === undefined) throw new Error("canonical event store requires rootInput or rootDir");

--- a/packages/kernel/src/store/wal-git-materializer.ts
+++ b/packages/kernel/src/store/wal-git-materializer.ts
@@ -225,6 +225,8 @@ function batchFiles(
 function requiredWalBlob(wal: WalEventLog, sha256: string): Uint8Array {
   const bytes = wal.readContentBlob(sha256);
   if (bytes === null) throw new TaskEventStoreError("invalid_store", `WAL content object ${sha256} is missing`);
+  if (sha256Text(Buffer.from(bytes).toString("utf8")) !== sha256)
+    throw new TaskEventStoreError("invalid_store", `WAL content object ${sha256} is corrupt`);
   return bytes;
 }
 

--- a/packages/kernel/src/store/wal-shadow-event-store.ts
+++ b/packages/kernel/src/store/wal-shadow-event-store.ts
@@ -59,10 +59,14 @@ export function makeWalShadowEventStore(options: StoreOptions): CanonicalEventSt
   if (input === undefined) throw new Error("canonical event store requires rootInput or rootDir");
   const rootDir = resolveHarnessLayout(input).rootDir;
   const ledger = resolveLedgerGitLayout(input);
+  // Git content through this revision was validated in this process. Materialization
+  // rechecks WAL object bytes before this watermark can advance across a flushed suffix.
+  let contentValidatedThrough = 0;
   const gitOptions = {
     ...options,
     beforeAppend: undefined,
     withAppendFence: undefined,
+    contentValidationFloor: () => contentValidatedThrough,
   };
   let git = makeGitEventStore(gitOptions);
   let gitHead = git.readHead();
@@ -100,7 +104,11 @@ export function makeWalShadowEventStore(options: StoreOptions): CanonicalEventSt
     walByOpId = new Map(wal.records().map((record) => [record.opId, record.event] as const));
     latestPendingClaims = latestDocumentClaims(pendingWalRecords.map((record) => record.event));
   };
-  const readGitStream = (): CanonicalEventStreamV1 => (gitStream ??= git.read());
+  const readGitStream = (): CanonicalEventStreamV1 => {
+    gitStream ??= git.read();
+    contentValidatedThrough = Math.max(contentValidatedThrough, gitHead?.revision ?? 0);
+    return gitStream;
+  };
   const stream = (): CanonicalEventStreamV1 => (mergedStream ??= mergeStream(readGitStream(), wal.records()));
   const pendingCount = (): number => pendingWalRecords.length;
   const hasWalRecords = (): boolean => wal.records().length > 0;
@@ -184,11 +192,17 @@ export function makeWalShadowEventStore(options: StoreOptions): CanonicalEventSt
     const first = records[0]!.revision;
     const last = records.at(-1)!.revision;
     const started = performance.now();
+    const gitRevisionBeforeFlush = gitHead?.revision ?? 0;
     try {
       const advancedBaseline =
         pendingRecords.length > 0 ? advanceGitBaseline(gitBaseline, ledger, wal, pendingRecords) : undefined;
       flushWalToGit(wal, git, { ...options, compactWorktree });
       reloadGit(advancedBaseline);
+      // Advance only when the old Git prefix was already checked in this process. The
+      // materializer rechecks every WAL content object before writing the new suffix.
+      const gitRevisionAfterFlush = gitHead?.revision ?? 0;
+      if (contentValidatedThrough >= gitRevisionBeforeFlush)
+        contentValidatedThrough = Math.max(contentValidatedThrough, gitRevisionAfterFlush);
       lastFlushDurationMs = performance.now() - started;
       // Authored settlement observes the durable cut. It is intentionally outside the
       // materialization transaction: an ineligible edit must remain visible for doc status,
@@ -341,6 +355,9 @@ export function makeWalShadowEventStore(options: StoreOptions): CanonicalEventSt
         throw new TaskEventStoreError("publication_indeterminate", "WAL must drain before an atomic ledger rewrite");
       const receipt = git.append(bundle, additionalFiles);
       reloadGit();
+      // An atomic ledger rewrite rebuilds history through the validating Git publication
+      // path; drop the floor so subsequent reads reverify the rewritten ledger.
+      contentValidatedThrough = 0;
       notifyAfterFlush(
         new Set(additionalFiles.flatMap((file) => ("target" in file ? [file.target] : []))),
         bundle.event.actor,
@@ -416,6 +433,9 @@ export function makeWalShadowEventStore(options: StoreOptions): CanonicalEventSt
   };
   const recover = (): EventRecoveryReceipt => {
     const started = performance.now();
+    // Recovery is the full audit entry point: forget any in-process validation floor so the
+    // next read revalidates every content claim in the ledger from scratch.
+    contentValidatedThrough = 0;
     if (!resumeAfterRepair())
       return {
         status: "indeterminate",
@@ -578,6 +598,7 @@ export function makeWalShadowEventStore(options: StoreOptions): CanonicalEventSt
         throw new TaskEventStoreError("publication_indeterminate", "WAL must drain before a ledger layout migration");
       const receipt = git.migrateLayout(migration);
       reloadGit();
+      contentValidatedThrough = 0;
       return receipt;
     },
     recover,

--- a/packages/kernel/test/store/wal-shadow-event-store.test.ts
+++ b/packages/kernel/test/store/wal-shadow-event-store.test.ts
@@ -1,19 +1,34 @@
 // harness-test-tier: integration
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { appendFileSync, existsSync, readFileSync, readdirSync, rmSync } from "node:fs";
+import { appendFileSync, existsSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import test from "node:test";
 import { REPLAY_TASK_GRAPH } from "../../src/domain/task-graph.ts";
 import { type TaskCreatedEvent } from "../../src/domain/task-lifecycle.contract.ts";
 import { taskLifecycleWritePlan } from "../../src/domain/task-lifecycle-publication.ts";
 import { sha256Text } from "../../src/integrity/stable-hash.ts";
+import { contentObjectRelativePath } from "../../src/layout/ledger-object-layout.ts";
 import { localWalFileSystem } from "../../src/local/local-layout-file-system.ts";
+import { resolveLedgerGitLayout } from "../../src/store/ledger-git-layout.ts";
 import { localGitObjectRefStore } from "../../src/store/local-version-control-system.ts";
 import { makeTaskEventStore as makeGitEventStore } from "../../src/store/task-event-store.ts";
 import { makeWalShadowEventStore } from "../../src/store/wal-shadow-event-store.ts";
 import { openWalEventLog } from "../../src/store/wal-event-log.ts";
 import { withTempStoreAsync } from "./helpers.ts";
+
+test("ledger Git layout resolution reuses one normalized-root identity", async () => {
+  await withTempStoreAsync(async (rootDir) => {
+    initRepo(rootDir);
+    const before = localGitObjectRefStore.processCount(),
+      first = resolveLedgerGitLayout(rootDir),
+      afterFirst = localGitObjectRefStore.processCount(),
+      second = resolveLedgerGitLayout(rootDir);
+    assert.equal(first, second);
+    assert.equal(afterFirst - before, 1, "the first layout resolution probes the Git top level");
+    assert.equal(localGitObjectRefStore.processCount() - afterFirst, 0, "the cached layout starts no subprocess");
+  });
+});
 
 test("S4 acknowledges the durable WAL cut with zero Git processes and immediate worktree visibility", async () => {
   await withTempStoreAsync(async (rootDir) => {
@@ -82,6 +97,96 @@ test("S4 batches a WAL suffix into one Git commit and garbage-collects local con
       [1, 2, 3],
     );
     await reopened.drain();
+  });
+});
+
+test("a verified WAL flush reuses the process-local Git content validation prefix", async () => {
+  await withTempStoreAsync(async (rootDir) => {
+    initRepo(rootDir);
+    const store = makeWalShadowEventStore({
+      repoId: "wal-validation-prefix",
+      rootDir,
+      walFlushEvents: 64,
+      walFlushMs: 60_000,
+    });
+    store.append(taskBundle(1, "validated once\n"));
+    await store.drain();
+
+    const trustedStarted = localGitObjectRefStore.processCount();
+    assert.equal(store.read().revision, 1);
+    const trustedProcesses = localGitObjectRefStore.processCount() - trustedStarted;
+
+    const fresh = makeWalShadowEventStore({ repoId: "wal-validation-prefix", rootDir, walFlushMs: 60_000 });
+    const freshStarted = localGitObjectRefStore.processCount();
+    assert.equal(fresh.read().revision, 1);
+    const freshProcesses = localGitObjectRefStore.processCount() - freshStarted;
+    assert.equal(
+      freshProcesses,
+      trustedProcesses + 1,
+      "a fresh process view performs the content batch that the validated prefix can omit",
+    );
+    await fresh.drain();
+  });
+});
+
+test("an unvalidated Git prefix is still checked after a WAL suffix flush", async () => {
+  await withTempStoreAsync(async (rootDir) => {
+    initRepo(rootDir);
+    const first = taskBundle(1, "valid history\n"),
+      gitStore = makeGitEventStore({ repoId: "wal-unvalidated-prefix", rootDir });
+    gitStore.append(first);
+    writeFileSync(
+      path.join(rootDir, "harness", contentObjectRelativePath(first.blobs[0]!.sha256)),
+      "corrupt history\n",
+    );
+    git(rootDir, "add", "harness/objects");
+    git(rootDir, "commit", "-qm", "corrupt historical content fixture");
+    git(rootDir, "update-ref", "refs/ha/canonical", "HEAD");
+
+    const store = makeWalShadowEventStore({
+      repoId: "wal-unvalidated-prefix",
+      rootDir,
+      walFlushEvents: 64,
+      walFlushMs: 60_000,
+    });
+    store.append(taskBundle(2, "verified suffix\n"));
+    await store.drain();
+    assert.throws(
+      () => store.read(),
+      (error: unknown) => {
+        assert.equal((error as { readonly code?: string }).code, "invalid_store");
+        return /content blob.*not reachable and exact/u.test(String(error));
+      },
+    );
+  });
+});
+
+test("WAL materialization rechecks content bytes before trusting the flushed suffix", async () => {
+  await withTempStoreAsync(async (rootDir) => {
+    initRepo(rootDir);
+    const store = makeWalShadowEventStore({
+        repoId: "wal-corrupt-object",
+        rootDir,
+        walFlushEvents: 64,
+        walFlushMs: 60_000,
+        walRetryLimit: 1,
+      }),
+      bundle = taskBundle(1, "durable bytes\n");
+    store.append(bundle);
+    writeFileSync(path.join(rootDir, ".harness", "wal", "objects", bundle.blobs[0]!.sha256), "corrupt\n");
+    const warnings: string[] = [],
+      originalWarn = console.warn;
+    console.warn = (...args: unknown[]) => warnings.push(args.join(" "));
+    try {
+      await assert.rejects(store.drain(), /WAL drain exhausted 1 attempt/u);
+    } finally {
+      console.warn = originalWarn;
+    }
+    assert.equal(
+      warnings.some((warning) => warning.includes("WAL content object") && warning.includes("corrupt")),
+      true,
+    );
+    assert.equal(makeGitEventStore({ repoId: "wal-corrupt-object", rootDir }).read().revision, 0);
   });
 });
 


### PR DESCRIPTION
# English

## Summary

Write-path quick win from the p50 attribution line (task_5e58b26b): the doc-submit cold path spent most of its wall re-validating the full Git content history on every candidate scan, linearly with ledger size (201ms at 50 revisions, 774ms at 1458). This change lets a process reuse the Git prefix it has already fully read-validated: `readStream` accepts a content-validation floor, the WAL shadow store advances that floor only after this process has actually validated the old prefix, and the floor is dropped to zero on atomic ledger rewrite, layout migration, and recovery. `resolveLedgerGitLayout` additionally memoizes the `git rev-parse --show-toplevel` subprocess per normalized authored root (bounded 64-entry cache), which removes two fixed Git subprocesses per flush.

Measured on the same rebased baseline, 250-revision sample: doc-submit cold wall 269ms → 137ms (−49%), cold store read 214ms → 122ms (−43%), task-complete 962ms → 665ms (−31%). WAL fsync, ACK boundaries, ref atomic updates, recovery, and corruption detection semantics are unchanged.

## Architectural Justification

- Mechanism sentence: content-body hashes of an immutable, already-validated Git prefix cannot change while a process is attached; re-hashing them on every read is pure repeated work, while revision continuity, opId uniqueness, and head identity remain validated on every read.
- Fail-closed guards: the floor only advances after a full validated read in this process; a WAL suffix is re-hashed before materialization can carry it under the floor; rewrite/migrate/recover reset the floor so the next read re-validates from scratch.
- No new configuration, no fsync change, no ACK movement.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none

## Machine-Readable Declarations

Production-Delta: +59/-6
Dependency-Change: none

### Optional Evidence Claims

None.

## Task And Scope

- Harness task: `task_5e58b26bb576a2ee7514a12df0` (write-path p50 attribution and quick wins)
- Branch: `codex/write-perf`; scope: kernel store only (`ledger-git-layout`, `task-event-store-reads/-factory/-runtime`, `wal-shadow-event-store`, `wal-git-materializer`) plus its test file.

## Version Impact

- Version: no change. Publish impact: none.

## Governance Declaration

- Protected surface touched: no. Authority: task_5e58b26bb576a2ee7514a12df0. Break-glass: no.

## Verification

- New negative/safety tests in `wal-shadow-event-store.test.ts`: unvalidated old prefix does not advance the floor; a corrupted WAL blob cannot gain validated identity; a validated prefix is reused (0 subprocesses on second layout resolve, identical object identity); cache identity across layouts.
- Before/after span data: `write-path-spans-before-quickwin.json` / `-after-quickwin.json` (private task artifacts); doc-submit cold −49%, task-complete −31%.
- [ ] Full suites: GitHub CI is the authority.

## Review Evidence

- CEO semantic review: watermark only advances after in-process full validation; flush advances it only when the old prefix was already checked; rewrite/migration/recovery reset it — the predecessor's unsafe half-finished watermark (trusting unvalidated history after a flush) was explicitly rejected and replaced.

## Residual Risk

- Cold reads still parse the full event stream (122ms at 250 revisions); getting to O(delta) needs a persisted, verifiable index — out of scope by design (dec_47A663A8 sequencing applies to the separate batching work, not this change).

---

# 中文

## 概要

写路 p50 归因线(task_5e58b26b)的快赢:doc-submit 冷路径大头是每次 candidate scan 都对完整 Git content 历史重复做 content-body 校验,随账本线性放大(50 revision 201ms,1458 revision 774ms)。本变更允许进程复用**本进程已完整读验过的 Git 前缀**:`readStream` 接受校验下限,WAL shadow store 只在旧前缀真的被本进程验证后才推进该下限;原子重写、layout 迁移、recovery 一律清零重验。另外 `resolveLedgerGitLayout` 按 normalized authored root 记忆化 `git rev-parse`(有界 64 项),每次 flush 少两个固定 Git 子进程。

同一 rebased 基线、250 revision 实测:doc-submit 冷 269ms→137ms(−49%),冷 store read 214→122ms(−43%),task-complete 962→665ms(−31%)。WAL fsync、ACK 边界、ref 原子更新、recovery 与 corruption 检测语义不变。

## 架构辩护

- 机制句:已验证的不可变 Git 前缀的 content hash 在进程 attach 期间不会变,逐读重 hash 是纯重复工;revision 连续性/opId 唯一性/head 一致性仍每读全验。
- fail-closed:下限只在本进程完整读验后推进;WAL 后缀 materialize 前重新 hash;rewrite/migrate/recover 清零。
- 无新配置、不动 fsync、不动 ACK。

## 门收割

- 无删除。

## 任务与范围

- task_5e58b26bb576a2ee7514a12df0;分支 codex/write-perf;只触 kernel store 六文件 + 测试。

## 版本影响 / 治理声明

- 不改版本、不发布;未触保护面;非 break-glass。

## 验证

- 新增四个负向/安全测试(未验证前缀不推进、坏 WAL blob 不获身份、已验前缀复用零子进程、cache identity);前后 span 数据在任务包 artifacts。
- 完整权威=GitHub CI。

## 审查证据

- CEO 语义验收:前任 GLM 的 watermark 半成品(flush 后信任未验证历史)已被显式否决并重写为「本进程验后才推进」。

## 残余风险

- 冷读仍解析全量 event stream(250 revision 122ms);降到 O(delta) 需要持久化可验证索引,超出本轮低风险范围。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VTzQAqvuFy6ikGjBKxA9xj
