### PR TITLE
test(daemon): measure ledger movement by merged stream revision

### DIFF
--- a/packages/daemon/test/fleet-dual-sync.integration.test.ts
+++ b/packages/daemon/test/fleet-dual-sync.integration.test.ts
@@ -13,7 +13,7 @@ import { mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSyn
 import { hostname, tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
-import { sha256Bytes } from "../../kernel/src/index.ts";
+import { makeTaskEventStore, sha256Bytes } from "../../kernel/src/index.ts";
 import { openDaemonHost } from "../src/daemon-host.ts";
 import { runFleetEdgeTask } from "../src/fleet-edge-task.ts";
 import { runFleetEdgeConflictExit, runFleetEdgeDocSync, settlePushRejection } from "../src/fleet-edge-doc-sync.ts";
@@ -26,6 +26,13 @@ import { realizedTaskPlan } from "../../../tools/fixtures/task-plan.mjs";
 // Idle WAL→Git materialization defaults to one hour (owner ruling 2026-08-31). These suites
 // wait for materialized commits, so pin the test-local idle timer to a fast interval.
 process.env.HARNESS_WAL_FLUSH_MS = "250";
+
+// "The ledger must not move" is a statement about the merged WAL+Git event stream, not about
+// Git commit counts: a background idle flush may materialize earlier events between two
+// measurements without any new append. Read the flush-timing-invariant revision instead.
+function ledgerRevision(fixture: Fixture): number {
+  return makeTaskEventStore({ repoId: "dual-repo", rootDir: path.join(fixture.root, "repo") }).read().revision;
+}
 
 const replicaQuota = 64 * 1024 * 1024,
   nodes = ["node-one", "node-two"] as const;
@@ -511,7 +518,7 @@ test(
     assert.equal(started.ok, true);
     const planPath = `${created.packagePath}/task_plan.md`,
       original = readFileSync(fixture.worktree("node-one", planPath), "utf8");
-    const before = Number(fixture.git("rev-list", "--count", "refs/ha/canonical"));
+    const before = ledgerRevision(fixture);
     // node-two names the holder's execution but is a different principal: the
     // domain lease rejects the push, bypassing the automatic entry changes
     // nothing.
@@ -528,11 +535,7 @@ test(
     );
     assert.equal(attempt.center.outcome, "op_rejected");
     assert.equal(attempt.center.code, "lease_conflict");
-    assert.equal(
-      Number(fixture.git("rev-list", "--count", "refs/ha/canonical")),
-      before,
-      "the ledger must not move for a non-holder push",
-    );
+    assert.equal(ledgerRevision(fixture), before, "the ledger must not move for a non-holder push");
   },
 );
 
@@ -748,7 +751,7 @@ test("F4: an unresolved conflict gates this task's later commands at the edge", 
   assert.equal((diverged as { readonly syncState?: string }).syncState, "CONFLICT_STAGED");
   // The unresolved record gates this task's commands BEFORE any upload: no
   // center round-trip, no ledger movement.
-  const beforeGate = Number(fixture.git("rev-list", "--count", "refs/ha/canonical"));
+  const beforeGate = ledgerRevision(fixture);
   const gated = await fixture.edgeTask("node-one", {
     kind: "task-start",
     taskId: created.taskId,
@@ -756,11 +759,7 @@ test("F4: an unresolved conflict gates this task's later commands at the edge", 
   });
   assert.equal(gated.ok, false);
   assert.equal((gated as { readonly code?: string }).code, "conflict_open");
-  assert.equal(
-    Number(fixture.git("rev-list", "--count", "refs/ha/canonical")),
-    beforeGate,
-    "the gate must refuse without touching the center",
-  );
+  assert.equal(ledgerRevision(fixture), beforeGate, "the gate must refuse without touching the center");
   // Another task is unaffected: its commands stay canonically admissible even
   // while this task's conflict is open (the mirror may still report the other
   // task's divergence on the dual axis — that is the honest outcome).
@@ -874,7 +873,7 @@ test(
       { path: shared, body: stagedLocal, baseBlobSha256: sha256Bytes(Buffer.from(`${baseline}\nCenter moved.\n`)) },
     ]);
     assert.equal(manual.center.outcome, "applied", JSON.stringify(manual.center));
-    const commitsAfterAppend = Number(fixture.git("rev-list", "--count", "refs/ha/canonical"));
+    const revisionAfterAppend = ledgerRevision(fixture);
     const idempotent = await fixture.conflictExit("node-one", "overwrite-center", settledRecord.conflictId);
     assert.equal(idempotent.ok, true, JSON.stringify(idempotent).slice(0, 400));
     assert.equal((idempotent as { readonly idempotent?: boolean }).idempotent, true);
@@ -893,8 +892,8 @@ test(
     ) as { readonly state: string };
     assert.equal(after.state, "resolved");
     assert.equal(
-      Number(fixture.git("rev-list", "--count", "refs/ha/canonical")),
-      commitsAfterAppend,
+      ledgerRevision(fixture),
+      revisionAfterAppend,
       "the idempotent retry must not append a second doc event",
     );
   },


### PR DESCRIPTION
# English

## Summary

Fixes the recurring main red in `fleet-dual-sync.integration.test.ts` (twice today: PR #2097 shard 3 and main full-check on c88eb55db). Three assertion pairs proxied "the ledger must not move" with `git rev-list --count refs/ha/canonical`; since the idle WAL flush default moved to one hour (#2069) and these suites pin `HARNESS_WAL_FLUSH_MS=250`, a background materialization can land a Git commit between the two measurements without any append — the F5/F6 failure was `4 !== 3` on commit count while the receipt-level `idempotent: true` assertion (the real invariant) passed. The guarded invariant is about the merged WAL+Git event stream, so the instrument now reads `makeTaskEventStore(...).read().revision`, which is flush-timing-invariant. No production change; the three tests still fail on any real second append.

## Architectural Justification

- Mechanism sentence: a derived artifact count (materialized Git commits) is not a valid instrument for a source-stream invariant (no new events) once materialization timing is independent of appends.
- Same-mechanism sweep inside the file covered all six `rev-list` sites (three before/after pairs); no other suite asserts ledger stillness via commit counts.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none

## Machine-Readable Declarations

Production-Delta: +0/-0
Dependency-Change: none

### Optional Evidence Claims

None.

## Task And Scope

- Follow-up of PR #2069 test pinning; adjudicated under the CEO supervision line (main-red repair). Branch `codex/fleet-test-instrument`; one test file.

## Version Impact

- Version: no change. Publish impact: none.

## Governance Declaration

- Protected surface touched: no. Break-glass: no.

## Verification

- The three rewritten tests pass locally 3/3 (`--test-name-pattern "non-holder|gates this task|idempotent across a crash"`).
- [ ] Full suites: GitHub CI is the authority.

## Review Evidence

- CEO-authored after two independent CI reproductions; the failing assertion's sibling (`idempotent: true` on the retry receipt) passing in the same runs is the positive control that no real double-append occurred.

## Residual Risk

- The Node-26 `3/10/32` coalescing assertion in `fleet-transport-scale` measures materialized-commit batching on purpose and stays timing-sensitive; it is a separate known family, not touched here.

---

# 中文

## 概要

修 main 上今天两次复现的 fleet-dual-sync 红:三对断言用 `git rev-list --count` 的 commit 数代理「账本没动」,但 #2069 之后空闲 flush(测试内固定 250ms)可以在两次测量之间落一笔 materialization commit——F5/F6 的 `4 !== 3` 是 commit 计数,而同用例里真正的不变量断言(`idempotent: true` 回执)一直是过的。仪器改为读合并流(WAL+Git)的 `revision`,与 flush 时机无关;真发生第二次 append 仍会红。零生产改动。

## 机读声明

`Production-Delta: +0/-0` 由 gate 实测。

## 验证

- 三个改写用例本地 3/3 绿;完整权威=GitHub CI。

## 残余风险

- Node26 的 3/10/32 coalescing 断言本意就是测 materialization 批次,保持原样,属另一已知家族。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VTzQAqvuFy6ikGjBKxA9xj
