### PR TITLE
fix(daemon): unblock owner-direct closeout via external anchor or honest weak mark

### DIFF
--- a/packages/application/src/task-lifecycle-service.ts
+++ b/packages/application/src/task-lifecycle-service.ts
@@ -549,6 +549,12 @@ function operationIdentityFromCommand<C extends TaskLifecycleCommand>(command: C
       verdict: command.verdict,
       reason: command.reason,
       evidenceChecked: command.evidenceChecked,
+      ...(command.externalCompletionAnchor === undefined
+        ? {}
+        : {
+            externalCompletionAnchor: command.externalCompletionAnchor,
+            noDispatchReason: command.noDispatchReason,
+          }),
       commitSha: command.commitSha,
       iteration: command.iteration,
       contentDigest: command.contentDigest,

--- a/packages/daemon/src/dispatch-read.ts
+++ b/packages/daemon/src/dispatch-read.ts
@@ -129,6 +129,31 @@ export function readTaskDispatches(
       };
 }
 
+export function readTaskLineageDispatches(input: {
+  readonly rootDir: string;
+  readonly projection: TaskProjection;
+  readonly taskId: string;
+}): readonly TaskDispatchRow[] {
+  const taskIds: string[] = [],
+    visited = new Set<string>();
+  let candidate: string | null = input.taskId;
+  while (candidate !== null && !visited.has(candidate)) {
+    taskIds.push(candidate);
+    visited.add(candidate);
+    candidate = input.projection.read(candidate).snapshot.task?.metadata?.parentTaskId ?? null;
+  }
+  const rows: TaskDispatchRow[] = [];
+  for (let offset = 0; offset < taskIds.length; offset += 500)
+    rows.push(
+      ...readTaskDispatches({
+        rootDir: input.rootDir,
+        projection: input.projection,
+        taskIds: taskIds.slice(offset, offset + 500),
+      }).dispatches,
+    );
+  return rows.sort((left, right) => left.startedAt.localeCompare(right.startedAt));
+}
+
 /** Header-only dispatch metadata for the grouped-session read. Unlike the task
  * detail facet this never opens archived documents or provider-event bodies. */
 export function readSessionGroupDispatches(input: {

--- a/packages/daemon/src/repo-cell-action-dispatch.ts
+++ b/packages/daemon/src/repo-cell-action-dispatch.ts
@@ -17,11 +17,10 @@ import { runMigrationImport } from "./migration-import.ts";
 import { runFactRekey } from "./fact-rekey.ts";
 import { type RepoCellBinding, type RepoTaskAction } from "./repo-cell-types.ts";
 import { pullAndIngestCiObservations } from "./ci-observation-actions.ts";
-import { readTaskDispatches } from "./dispatch-read.ts";
+import { readTaskLineageDispatches } from "./dispatch-read.ts";
 import type { RepoCellOperationalContext } from "./repo-cell-action-context.ts";
 import { runFactAction } from "./repo-cell-fact-action.ts";
 import type { TaskCommandWithDocsAction } from "./repo-cell-task-command-docs.ts";
-import type { TaskDispatchRow } from "./protocol/daemon-protocol.contract.ts";
 
 export async function executeAction(
   cell: RepoCellOperationalContext,
@@ -475,7 +474,7 @@ function dispatchedExecutor(
   readonly dispatchTaskId: string;
 } {
   const requested = action.agent === undefined ? undefined : cell.requiredCellText(action.agent, "agent"),
-    rows = taskLineageDispatches(cell, taskId),
+    rows = readTaskLineageDispatches({ rootDir: cell.rootDir, projection: cell.projection, taskId }),
     exactRows = rows.filter((dispatch) => dispatch.executionId === executionId),
     eligibleRows = exactRows.length ? exactRows : rows,
     candidates = [
@@ -527,25 +526,4 @@ function dispatchedExecutor(
       )
       .join(" or ")}.`,
   );
-}
-
-function taskLineageDispatches(cell: RepoCellOperationalContext, taskId: string): readonly TaskDispatchRow[] {
-  const taskIds: string[] = [],
-    visited = new Set<string>();
-  let candidate: string | null = taskId;
-  while (candidate !== null && !visited.has(candidate)) {
-    taskIds.push(candidate);
-    visited.add(candidate);
-    candidate = cell.projection.read(candidate).snapshot.task?.metadata?.parentTaskId ?? null;
-  }
-  const rows: TaskDispatchRow[] = [];
-  for (let offset = 0; offset < taskIds.length; offset += 500)
-    rows.push(
-      ...readTaskDispatches({
-        rootDir: cell.rootDir,
-        projection: cell.projection,
-        taskIds: taskIds.slice(offset, offset + 500),
-      }).dispatches,
-    );
-  return rows.sort((left, right) => left.startedAt.localeCompare(right.startedAt));
 }

--- a/packages/daemon/src/repo-cell-command.ts
+++ b/packages/daemon/src/repo-cell-command.ts
@@ -19,7 +19,7 @@ import {
   reviewConsentSelection,
   uniqueDerivedExecutionId,
 } from "./repo-cell-execution-selection.ts";
-import { packetFile, reviewPacket, submissionPacket } from "./repo-cell-packets.ts";
+import { packetFile, reviewPacket, reviewQualificationFields, submissionPacket } from "./repo-cell-packets.ts";
 import { actorHint, operationId } from "./repo-cell-proof.ts";
 import { digest, reviewVerdict } from "./repo-cell-review-lint.ts";
 import { cellStringList, requiredCellText } from "./repo-cell-settlement.ts";
@@ -185,24 +185,7 @@ export function buildCommand(
       verdict: reviewVerdict(packet.value.verdict),
       reason: requiredCellText(packet.value.reason, "reason"),
       evidenceChecked: cellStringList(packet.value.evidenceChecked),
-      ...(packet.value.externalCompletionAnchor === undefined
-        ? {}
-        : {
-            externalCompletionAnchor: requiredCellText(
-              packet.value.externalCompletionAnchor,
-              "externalCompletionAnchor",
-            ),
-            noDispatchReason: requiredCellText(packet.value.noDispatchReason, "noDispatchReason"),
-          }),
-      ...(packet.value.noIndependentReview === undefined
-        ? {}
-        : {
-            noIndependentReview: packet.value.noIndependentReview === true,
-            noIndependentReviewReason: requiredCellText(
-              packet.value.noIndependentReviewReason,
-              "noIndependentReviewReason",
-            ),
-          }),
+      ...reviewQualificationFields(packet.value),
       commitSha: submitted.submission.commitSha,
       iteration: submitted.iteration,
       contentDigest: packet.digest,

--- a/packages/daemon/src/repo-cell-command.ts
+++ b/packages/daemon/src/repo-cell-command.ts
@@ -194,6 +194,15 @@ export function buildCommand(
             ),
             noDispatchReason: requiredCellText(packet.value.noDispatchReason, "noDispatchReason"),
           }),
+      ...(packet.value.noIndependentReview === undefined
+        ? {}
+        : {
+            noIndependentReview: packet.value.noIndependentReview === true,
+            noIndependentReviewReason: requiredCellText(
+              packet.value.noIndependentReviewReason,
+              "noIndependentReviewReason",
+            ),
+          }),
       commitSha: submitted.submission.commitSha,
       iteration: submitted.iteration,
       contentDigest: packet.digest,

--- a/packages/daemon/src/repo-cell-command.ts
+++ b/packages/daemon/src/repo-cell-command.ts
@@ -185,6 +185,15 @@ export function buildCommand(
       verdict: reviewVerdict(packet.value.verdict),
       reason: requiredCellText(packet.value.reason, "reason"),
       evidenceChecked: cellStringList(packet.value.evidenceChecked),
+      ...(packet.value.externalCompletionAnchor === undefined
+        ? {}
+        : {
+            externalCompletionAnchor: requiredCellText(
+              packet.value.externalCompletionAnchor,
+              "externalCompletionAnchor",
+            ),
+            noDispatchReason: requiredCellText(packet.value.noDispatchReason, "noDispatchReason"),
+          }),
       commitSha: submitted.submission.commitSha,
       iteration: submitted.iteration,
       contentDigest: packet.digest,

--- a/packages/daemon/src/repo-cell-packets.ts
+++ b/packages/daemon/src/repo-cell-packets.ts
@@ -96,6 +96,34 @@ export function reviewPacket(
   };
 }
 
+/**
+ * The optional review-qualification fields a RecordReview command carries when a same-person
+ * review is justified without a dispatch: an external completion anchor, or an explicit
+ * no-independent-review weak mark. Kept beside the packet field-set validation so the two field
+ * families stay described in one place.
+ */
+export function reviewQualificationFields(value: Record<string, unknown>): {
+  readonly externalCompletionAnchor?: string;
+  readonly noDispatchReason?: string;
+  readonly noIndependentReview?: boolean;
+  readonly noIndependentReviewReason?: string;
+} {
+  return {
+    ...(value.externalCompletionAnchor === undefined
+      ? {}
+      : {
+          externalCompletionAnchor: requiredCellText(value.externalCompletionAnchor, "externalCompletionAnchor"),
+          noDispatchReason: requiredCellText(value.noDispatchReason, "noDispatchReason"),
+        }),
+    ...(value.noIndependentReview === undefined
+      ? {}
+      : {
+          noIndependentReview: value.noIndependentReview === true,
+          noIndependentReviewReason: requiredCellText(value.noIndependentReviewReason, "noIndependentReviewReason"),
+        }),
+  };
+}
+
 export function submissionPacket(action: RepoTaskAction, rootDir: string): GuiSubmissionV1 {
   const fromFile = action.fromFile !== undefined,
     jsonInput = action.jsonInput !== undefined;

--- a/packages/daemon/src/repo-cell-packets.ts
+++ b/packages/daemon/src/repo-cell-packets.ts
@@ -66,10 +66,28 @@ export function reviewPacket(
       "invalid_command",
       "Review accepts either the public fromFile packet or one daemon-internal JSON packet, not both.",
     );
-  if (action.jsonInput === undefined) return packetFile(rootDir, action.fromFile, reviewJsonFields);
-  const body = requiredCellText(action.jsonInput, "jsonInput");
+  const body =
+    action.jsonInput === undefined
+      ? workspaceText(rootDir, action.fromFile, "fromFile")
+      : requiredCellText(action.jsonInput, "jsonInput");
+  let value: Record<string, unknown>;
+  try {
+    const parsed = JSON.parse(body) as unknown,
+      standardFields = [...reviewJsonFields].sort().join("\0"),
+      externalFields = [...reviewJsonFields, "externalCompletionAnchor", "noDispatchReason"].sort().join("\0");
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) throw new Error("not an object");
+    const fields = Object.keys(parsed).sort().join("\0");
+    if (fields !== standardFields && fields !== externalFields) throw new Error("unexpected fields");
+    value = parsed as Record<string, unknown>;
+  } catch {
+    throw cellCodedError(
+      "invalid_command",
+      `Review JSON requires exactly ${reviewJsonFields.join(", ")}, or those fields plus ` +
+        "externalCompletionAnchor and noDispatchReason.",
+    );
+  }
   return {
-    value: packetJson(body, reviewJsonFields),
+    value,
     digest: `sha256:${createHash("sha256").update(body).digest("hex")}`,
   };
 }

--- a/packages/daemon/src/repo-cell-packets.ts
+++ b/packages/daemon/src/repo-cell-packets.ts
@@ -74,16 +74,20 @@ export function reviewPacket(
   try {
     const parsed = JSON.parse(body) as unknown,
       standardFields = [...reviewJsonFields].sort().join("\0"),
-      externalFields = [...reviewJsonFields, "externalCompletionAnchor", "noDispatchReason"].sort().join("\0");
+      externalFields = [...reviewJsonFields, "externalCompletionAnchor", "noDispatchReason"].sort().join("\0"),
+      noIndependentReviewFields = [...reviewJsonFields, "noIndependentReview", "noIndependentReviewReason"]
+        .sort()
+        .join("\0");
     if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) throw new Error("not an object");
     const fields = Object.keys(parsed).sort().join("\0");
-    if (fields !== standardFields && fields !== externalFields) throw new Error("unexpected fields");
+    if (fields !== standardFields && fields !== externalFields && fields !== noIndependentReviewFields)
+      throw new Error("unexpected fields");
     value = parsed as Record<string, unknown>;
   } catch {
     throw cellCodedError(
       "invalid_command",
       `Review JSON requires exactly ${reviewJsonFields.join(", ")}, or those fields plus ` +
-        "externalCompletionAnchor and noDispatchReason.",
+        "externalCompletionAnchor and noDispatchReason, or noIndependentReview and noIndependentReviewReason.",
     );
   }
   return {

--- a/packages/daemon/src/repo-cell-proof.ts
+++ b/packages/daemon/src/repo-cell-proof.ts
@@ -129,8 +129,9 @@ export async function proofFor(
     const independentActor = execution !== undefined && isIndependentFrom(execution.actor, command.actor),
       externalCompletionEvidence = independentActor
         ? false
-        : validExternalCompletionEvidence(command, projection, rootDir);
-    if (!independentActor && !externalCompletionEvidence) {
+        : validExternalCompletionEvidence(command, projection, rootDir),
+      explicitlyUnreviewed = independentActor ? false : validNoIndependentReview(command, projection, rootDir);
+    if (!independentActor && !externalCompletionEvidence && !explicitlyUnreviewed) {
       throw cellCriterionError(
         "actor_unauthorized",
         "Task review actor independence proof was not satisfied.",
@@ -220,6 +221,19 @@ export async function proofFor(
   if (command.type !== "CompleteTask")
     throw cellCodedError("invalid_command", `No authority proof plan exists for ${command.type}.`);
   return completeProof(command, snapshot, binding) as TaskLifecycleServiceProof<typeof command>;
+}
+
+function validNoIndependentReview(
+  command: Extract<TaskLifecycleCommand, { readonly type: "RecordReview" }>,
+  projection: ReturnType<typeof makeTaskProjection>,
+  rootDir: string,
+): boolean {
+  return (
+    command.noIndependentReview === true &&
+    command.noIndependentReviewReason !== undefined &&
+    command.noIndependentReviewReason.trim().length > 0 &&
+    readTaskLineageDispatches({ projection, rootDir, taskId: command.taskId }).length === 0
+  );
 }
 
 function validExternalCompletionEvidence(

--- a/packages/daemon/src/repo-cell-proof.ts
+++ b/packages/daemon/src/repo-cell-proof.ts
@@ -2,6 +2,7 @@ import { type TaskLifecycleServiceProof } from "../../application/src/task-lifec
 import {
   canonicalGateReceipts,
   codeDocRecordId,
+  consumeKnownError,
   consentedApprovedReview,
   currentCodeDocWitness,
   evaluateTaskActionCapability,
@@ -9,6 +10,7 @@ import {
   getTaskActionForTransition,
   isIndependentFrom,
   isSamePerson,
+  localGitObjectRefStore,
   makeTaskProjection,
   normalizeCommandEnvelope,
   requiredGateWitnessCount,
@@ -23,6 +25,7 @@ import {
 } from "../../kernel/src/index.ts";
 import { cellCodedError, cellCriterionError } from "./repo-cell-errors.ts";
 import { verifyCodeDocCommitPaths } from "./code-doc-path-verification.ts";
+import { readTaskLineageDispatches } from "./dispatch-read.ts";
 import type { PublicPublication, RepoCellBinding, RepoTaskAction, Snapshot } from "./repo-cell-types.ts";
 import { leaseTtlMs } from "./repo-cell-types.ts";
 
@@ -35,7 +38,7 @@ export async function proofFor(
   command: TaskLifecycleCommand,
   snapshot: Snapshot,
   binding: RepoCellBinding,
-  projection: Pick<ReturnType<typeof makeTaskProjection>, "readRuntimeSession">,
+  projection: ReturnType<typeof makeTaskProjection>,
   rootDir: string,
 ): Promise<TaskLifecycleServiceProof<typeof command> & { readonly authorizationDecision?: AuthorizationDecision }> {
   if (command.type === "CreateReplayTask") return { taskIdUnique: true, actorBinding: command.actor };
@@ -123,7 +126,11 @@ export async function proofFor(
         REVIEW_PROOF_CRITERION,
         reviewCriterion.nextActions,
       );
-    if (execution === undefined || !isIndependentFrom(execution.actor, command.actor)) {
+    const independentActor = execution !== undefined && isIndependentFrom(execution.actor, command.actor),
+      externalCompletionEvidence = independentActor
+        ? false
+        : validExternalCompletionEvidence(command, projection, rootDir);
+    if (!independentActor && !externalCompletionEvidence) {
       throw cellCriterionError(
         "actor_unauthorized",
         "Task review actor independence proof was not satisfied.",
@@ -213,6 +220,34 @@ export async function proofFor(
   if (command.type !== "CompleteTask")
     throw cellCodedError("invalid_command", `No authority proof plan exists for ${command.type}.`);
   return completeProof(command, snapshot, binding) as TaskLifecycleServiceProof<typeof command>;
+}
+
+function validExternalCompletionEvidence(
+  command: Extract<TaskLifecycleCommand, { readonly type: "RecordReview" }>,
+  projection: ReturnType<typeof makeTaskProjection>,
+  rootDir: string,
+): boolean {
+  if (
+    command.externalCompletionAnchor === undefined ||
+    command.noDispatchReason === undefined ||
+    command.noDispatchReason.trim().length === 0 ||
+    readTaskLineageDispatches({ projection, rootDir, taskId: command.taskId }).length > 0
+  )
+    return false;
+  const anchor = command.externalCompletionAnchor.trim();
+  if (/^[0-9a-f]{40}$/u.test(anchor))
+    try {
+      const originMain = localGitObjectRefStore.resolveCommit(rootDir, "refs/remotes/origin/main");
+      return localGitObjectRefStore.isAncestor(rootDir, anchor, originMain);
+    } catch (error) {
+      consumeKnownError(error);
+      return false;
+    }
+  return (
+    /^PR #[1-9][0-9]*$/u.test(anchor) ||
+    /^https:\/\/github\.com\/[^/]+\/[^/]+\/pull\/[1-9][0-9]*$/u.test(anchor) ||
+    /^https:\/\/github\.com\/[^/]+\/[^/]+\/actions\/runs\/[1-9][0-9]*$/u.test(anchor)
+  );
 }
 
 export function completeProof(

--- a/packages/daemon/test/review-independence-diagnostics.integration.test.ts
+++ b/packages/daemon/test/review-independence-diagnostics.integration.test.ts
@@ -308,6 +308,28 @@ test("a child bare-invocation execution can recover from its parent Task dispatc
     assert.match(String(refused.nextAction), /original start/u);
     assert.deepEqual(refused.nextActions, [refused.nextAction]);
 
+    writeFileSync(
+      path.join(rootDir, "external-review.json"),
+      JSON.stringify({
+        verdict: "approved",
+        reason: "External delivery evidence was inspected.",
+        evidenceChecked: ["merged delivery"],
+        externalCompletionAnchor: "PR #2088",
+        noDispatchReason: "The work was assigned through a legacy external channel.",
+      }),
+    );
+    const dispatchCannotBeSkipped = await cell.run(
+      {
+        kind: "task-review-execution",
+        taskId,
+        executionId,
+        reviewId: "r-external-disallowed",
+        fromFile: "external-review.json",
+      },
+      bare,
+    );
+    assert.equal(dispatchCannotBeSkipped.code, "actor_unauthorized", JSON.stringify(dispatchCannotBeSkipped));
+
     const wrongPrincipal = withRoleBinding(
       {
         actor: { principal: { personId: "1" }, executor: null },
@@ -414,6 +436,7 @@ test("a reviewed child execution cannot declare an executor when neither it nor 
     writeFileSync(path.join(rootDir, "README.md"), "# Reviewed executor repair fixture\n");
     git(rootDir, "add", "README.md");
     git(rootDir, "commit", "--quiet", "-m", "fixture output");
+    git(rootDir, "update-ref", "refs/remotes/origin/main", "HEAD");
     cell = await openRepoCell({ repoId, rootDir: canonicalRoot(rootDir), ownerId: "review-bare-reviewed" });
     const parentCreated = await cell.run(
       { kind: "task-create", taskId: parentTaskId, title: "Bare reviewed parent" },
@@ -457,6 +480,7 @@ test("a reviewed child execution cannot declare an executor when neither it nor 
         residualRisks: [],
         commitSha,
       };
+    git(rootDir, "update-ref", "refs/remotes/origin/main", commitSha);
     writeFileSync(
       closeoutPath,
       "# Closeout\n\n## Summary\n\nReviewed executor repair.\n\n## Verification\n\nDaemon integration.\n\n## Residual Risk\n\nNone.\n\n## Same Mechanism Elsewhere\n\nCovered by the declaration audit.\n",
@@ -474,6 +498,37 @@ test("a reviewed child execution cannot declare an executor when neither it nor 
         reason: "Independent review passed.",
         evidenceChecked: ["daemon integration"],
       }),
+    );
+    writeFileSync(
+      path.join(rootDir, "external-review.json"),
+      JSON.stringify({
+        verdict: "approved",
+        reason: "The origin/main delivery anchor was inspected.",
+        evidenceChecked: ["origin/main"],
+        externalCompletionAnchor: commitSha,
+        noDispatchReason: "The repository owner implemented the delivery directly.",
+      }),
+    );
+    const externallyAnchored = (await cell.run(
+      {
+        kind: "task-review-execution",
+        taskId,
+        executionId,
+        reviewId: "review-external-anchor",
+        fromFile: "external-review.json",
+      },
+      bare,
+    )) as Record<string, unknown>;
+    assert.equal(externallyAnchored.outcome, "applied", JSON.stringify(externallyAnchored));
+    const externalReviewEvent = makeTaskEventStore({ repoId, rootDir }).readEvent(String(externallyAnchored.opId));
+    assert.equal(externalReviewEvent?.type, "review_recorded");
+    assert.deepEqual(
+      externalReviewEvent?.type === "review_recorded" ? externalReviewEvent.payload.review.evidenceChecked : [],
+      [
+        "origin/main",
+        `external completion anchor: ${commitSha}`,
+        "no dispatch reason: The repository owner implemented the delivery directly.",
+      ],
     );
     const reviewer = withRoleBinding(
       {

--- a/packages/daemon/test/review-independence-diagnostics.integration.test.ts
+++ b/packages/daemon/test/review-independence-diagnostics.integration.test.ts
@@ -329,6 +329,27 @@ test("a child bare-invocation execution can recover from its parent Task dispatc
       bare,
     );
     assert.equal(dispatchCannotBeSkipped.code, "actor_unauthorized", JSON.stringify(dispatchCannotBeSkipped));
+    writeFileSync(
+      path.join(rootDir, "no-independent-review.json"),
+      JSON.stringify({
+        verdict: "approved",
+        reason: "The delivery is ready to record.",
+        evidenceChecked: ["authored documentation"],
+        noIndependentReview: true,
+        noIndependentReviewReason: "No independent reviewer was available.",
+      }),
+    );
+    const dispatchCannotUseWeakMarker = await cell.run(
+      {
+        kind: "task-review-execution",
+        taskId,
+        executionId,
+        reviewId: "r-no-independent-review-disallowed",
+        fromFile: "no-independent-review.json",
+      },
+      bare,
+    );
+    assert.equal(dispatchCannotUseWeakMarker.code, "actor_unauthorized", JSON.stringify(dispatchCannotUseWeakMarker));
 
     const wrongPrincipal = withRoleBinding(
       {
@@ -508,6 +529,47 @@ test("a reviewed child execution cannot declare an executor when neither it nor 
         externalCompletionAnchor: commitSha,
         noDispatchReason: "The repository owner implemented the delivery directly.",
       }),
+    );
+    const unmarked = await cell.run(
+      {
+        kind: "task-review-execution",
+        taskId,
+        executionId,
+        reviewId: "review-unmarked",
+        fromFile: "review.json",
+      },
+      bare,
+    );
+    assert.equal(unmarked.code, "actor_unauthorized", JSON.stringify(unmarked));
+    writeFileSync(
+      path.join(rootDir, "no-independent-review.json"),
+      JSON.stringify({
+        verdict: "approved",
+        reason: "The documentation-only delivery is ready to record.",
+        evidenceChecked: ["authored documentation"],
+        noIndependentReview: true,
+        noIndependentReviewReason: "No independent reviewer was available for this documentation-only delivery.",
+      }),
+    );
+    const weaklyMarked = (await cell.run(
+      {
+        kind: "task-review-execution",
+        taskId,
+        executionId,
+        reviewId: "review-no-independent-review",
+        fromFile: "no-independent-review.json",
+      },
+      bare,
+    )) as Record<string, unknown>;
+    assert.equal(weaklyMarked.outcome, "applied", JSON.stringify(weaklyMarked));
+    const weakReviewEvent = makeTaskEventStore({ repoId, rootDir }).readEvent(String(weaklyMarked.opId));
+    assert.equal(weakReviewEvent?.type, "review_recorded");
+    assert.deepEqual(
+      weakReviewEvent?.type === "review_recorded" ? weakReviewEvent.payload.review.evidenceChecked : [],
+      [
+        "authored documentation",
+        "NO INDEPENDENT REVIEW: No independent reviewer was available for this documentation-only delivery.",
+      ],
     );
     const externallyAnchored = (await cell.run(
       {

--- a/packages/kernel/src/domain/task-lifecycle-contract-internal-types.ts
+++ b/packages/kernel/src/domain/task-lifecycle-contract-internal-types.ts
@@ -69,6 +69,8 @@ export interface RecordReviewIntent extends Intent<"RecordReview"> {
   readonly evidenceChecked: readonly string[];
   readonly externalCompletionAnchor?: string;
   readonly noDispatchReason?: string;
+  readonly noIndependentReview?: boolean;
+  readonly noIndependentReviewReason?: string;
   readonly commitSha: string;
   readonly iteration: number;
   readonly contentDigest: `sha256:${string}`;

--- a/packages/kernel/src/domain/task-lifecycle-contract-internal-types.ts
+++ b/packages/kernel/src/domain/task-lifecycle-contract-internal-types.ts
@@ -67,6 +67,8 @@ export interface RecordReviewIntent extends Intent<"RecordReview"> {
   readonly verdict: ReviewVerdict;
   readonly reason: string;
   readonly evidenceChecked: readonly string[];
+  readonly externalCompletionAnchor?: string;
+  readonly noDispatchReason?: string;
   readonly commitSha: string;
   readonly iteration: number;
   readonly contentDigest: `sha256:${string}`;

--- a/packages/kernel/src/domain/task-lifecycle-review-transitions.ts
+++ b/packages/kernel/src/domain/task-lifecycle-review-transitions.ts
@@ -85,6 +85,13 @@ function reviewIssues(
   return issues;
 }
 function reviewFrom(command: RecordReviewCommand, proof: ReviewProof): ReviewV1 {
+  const externalEvidence =
+    command.externalCompletionAnchor === undefined
+      ? []
+      : [
+          `external completion anchor: ${command.externalCompletionAnchor}`,
+          `no dispatch reason: ${command.noDispatchReason}`,
+        ];
   return {
     schema: "review/v1",
     reviewId: command.reviewId,
@@ -94,7 +101,7 @@ function reviewFrom(command: RecordReviewCommand, proof: ReviewProof): ReviewV1 
     actor: command.actor,
     capabilityRef: proof.capabilityRef,
     reason: command.reason,
-    evidenceChecked: command.evidenceChecked,
+    evidenceChecked: [...command.evidenceChecked, ...externalEvidence],
     commitSha: command.commitSha,
     iteration: command.iteration as 0 | 1,
     contentDigest: command.contentDigest,

--- a/packages/kernel/src/domain/task-lifecycle-review-transitions.ts
+++ b/packages/kernel/src/domain/task-lifecycle-review-transitions.ts
@@ -85,9 +85,11 @@ function reviewIssues(
   return issues;
 }
 function reviewFrom(command: RecordReviewCommand, proof: ReviewProof): ReviewV1 {
-  const externalEvidence =
+  const qualificationEvidence =
     command.externalCompletionAnchor === undefined
-      ? []
+      ? command.noIndependentReview === true
+        ? [`NO INDEPENDENT REVIEW: ${command.noIndependentReviewReason}`]
+        : []
       : [
           `external completion anchor: ${command.externalCompletionAnchor}`,
           `no dispatch reason: ${command.noDispatchReason}`,
@@ -101,7 +103,7 @@ function reviewFrom(command: RecordReviewCommand, proof: ReviewProof): ReviewV1 
     actor: command.actor,
     capabilityRef: proof.capabilityRef,
     reason: command.reason,
-    evidenceChecked: [...command.evidenceChecked, ...externalEvidence],
+    evidenceChecked: [...command.evidenceChecked, ...qualificationEvidence],
     commitSha: command.commitSha,
     iteration: command.iteration as 0 | 1,
     contentDigest: command.contentDigest,


### PR DESCRIPTION
# English

## Summary

Fixes a closeout death-lock: same-person review recovery required a real runtime dispatch record, so any task delivered by the owner directly (or through the now-retired external companion channel) could never complete — its `ha task dispatches` is permanently empty. The review-independence proof now accepts two additional, explicitly-declared paths when a dispatch is genuinely absent: an externally verifiable completion anchor, or an on-record "no independent review" weak mark. Implements accepted decision `dec_758112A30EBC78EB678723EA96`.

## What Changed

- `RecordReview` gains four optional fields: `externalCompletionAnchor` + `noDispatchReason` (anchor path) and `noIndependentReview` + `noIndependentReviewReason` (weak-mark path). The review packet parser accepts exactly the standard field set, or the standard set plus one of these two pairs — nothing else.
- Anchor path (`validExternalCompletionEvidence`): admits when the task/lineage has no dispatch, a `noDispatchReason` is given, and the anchor is a 40-hex commit SHA that is an ancestor of `refs/remotes/origin/main` (i.e. actually merged), or a `PR #<n>` / GitHub PR URL / GitHub Actions run URL by format.
- Weak-mark path (`validNoIndependentReview`): admits when the task/lineage has no dispatch, `noIndependentReview` is explicitly `true`, and a non-empty reason is given. The recorded Review carries `NO INDEPENDENT REVIEW: <reason>` in `evidenceChecked`, so the completion record never masquerades as an independently-reviewed approval.
- Default (no anchor, no explicit weak mark) stays fail-closed with the same `actor_unauthorized` refusal.
- Invariant preserved: when a dispatch record does exist on the task or its lineage, neither escape opens — attribution is still forced.
- The two optional field blocks are extracted into a `reviewQualificationFields` helper beside the packet validation, keeping `repo-cell-command.ts` at its G0-5 specialization-lines baseline.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: use the single CI-backed `Production-Delta` declaration below; do not enter a second metric.

## Machine-Readable Declarations

Production-Delta: +153/-31

## Task And Scope

- Harness task: task_b1ee750c44907f6bab44883196
- Branch: codex/closeout-deadlock
- Public scope: RecordReview independence proof (daemon repo-cell) and its command/packet plumbing; new integration coverage
- Private planning/evidence updated: yes
- Out of scope: CLI-surface flags for the new fields (daemon-internal JSON packet path is what this PR wires), any change to the dispatch-attributed normal path

## Version Impact

- Version: no version change because this is an internal lifecycle-proof change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: dec_758112A30EBC78EB678723EA96 (accepted, in_effect); task_b1ee750c44907f6bab44883196
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: (rebased onto current origin/main this session)
- Branch merge-base with `origin/main`: current
- Last `git fetch origin` time: 2026-09-01 (this session, immediately before rebase)
- Sync method: rebase
- Public diff command: `git diff origin/main...codex/closeout-deadlock`
- Private evidence commit/path: task_b1ee750c facts F-45163D90 / F-CC45B108 / F-BE1C34EA
- Reviewer evidence path: see Review Evidence
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [x] `git diff --check`
- [x] `npm run typecheck` (`tsc -b`, exit 0) — post-rebase
- [x] targeted tests: review-independence (three branches, positive+negative controls) + closeout/review/lifecycle regression 39/39 pass; eslint clean on touched files
- Not run: full `npm test`/`npm run check`/harness:* suite (worker stop-point policy; CI is the full authority)

## Review Evidence

- Self-review: CEO semantic acceptance against the accepted decision — CH1 (external anchor first-class, SHA ancestry-verified), CH2 (escape only with no-dispatch + anchor + reason), CH3 (default refuse, explicit weak mark honest and un-maskable), CH4 (dispatch present → escape closed) all confirmed against the diff
- Reviewer subagent: implemented across two dispatched worker rounds (anchor path, then the weak-mark path added at CEO direction after review found it missing), each verified by the session before acceptance
- Human review: pending on this PR
- Blocking findings: none open

## Residual Risk

- The `PR #<n>` / PR-URL / CI-URL anchor forms are format-validated only; the 40-hex SHA form is the one verified against origin/main ancestry. Callers wanting the strongest guarantee should use the merged SHA. The weak-mark path is honest-by-construction (it never claims independent review) but is, by design, the weakest evidence tier.

## References

- Task: task_b1ee750c44907f6bab44883196
- Decision: dec_758112A30EBC78EB678723EA96
- Evidence: facts F-45163D90, F-CC45B108, F-BE1C34EA

---

# 中文

## 概要

修复一个收口死锁：same-person review 的恢复要求真实 runtime dispatch 记录，因此 owner 亲手交付、或经已废弃外部通道交付的任务永远收不了口（`ha task dispatches` 恒为空）。现在当 dispatch 真实缺席时，review 独立性证明接受两条额外的、必须显式声明的路径：外部可验证的完工锚，或一条落在记录里的「无独立复核」弱标记。实现已 accept 的裁决 `dec_758112A30EBC78EB678723EA96`。

## 改动内容

- `RecordReview` 新增四个可选字段：`externalCompletionAnchor` + `noDispatchReason`（锚定路径），`noIndependentReview` + `noIndependentReviewReason`（弱标记路径）。review packet 解析器只接受标准字段集、或标准集加上这两对之一，别的一律拒。
- 锚定路径（`validExternalCompletionEvidence`）：任务/父链无 dispatch、给了 `noDispatchReason`、且锚是 `refs/remotes/origin/main` 祖先的 40 位 commit SHA（即真的合并过），或格式合法的 `PR #<n>` / GitHub PR URL / GitHub Actions run URL 时放行。
- 弱标记路径（`validNoIndependentReview`）：任务/父链无 dispatch、`noIndependentReview` 显式为 `true`、给了非空理由时放行。产出的 Review 在 `evidenceChecked` 里带 `NO INDEPENDENT REVIEW: <reason>`，完工记录绝不冒充已独立复核的 approved。
- 默认（无锚、无显式弱标记）仍 fail-closed，维持同样的 `actor_unauthorized` 拒绝。
- 不变量保留：任务或父链确有 dispatch 记录时，两条逃生口都不开——仍强制归因。
- 两段可选字段抽成 `reviewQualificationFields` helper 置于 packet 校验旁，使 `repo-cell-command.ts` 保持在 G0-5 specialization-lines 基线。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 同 commit 删除的门 / fixture：none
- 生产净行数：引用英文块中的 `Production-Delta`。

## 机读声明说明

- 机读声明只在英文块出现一次，见上。

## 任务与范围

- Harness 任务：task_b1ee750c44907f6bab44883196
- 分支：codex/closeout-deadlock
- 公开范围：RecordReview 独立性证明（daemon repo-cell）及其 command/packet 管线；新增集成测试
- 私有计划 / 证据是否已更新：yes
- 范围外：新字段的 CLI 面 flag（本 PR 接的是 daemon 内部 JSON packet 路径）、dispatch 归因的正常路径

## 版本影响

- 版本：不改版本，原因是内部生命周期证明改动
- 发布影响：不发布

## 治理声明

- 是否触碰 protected surface：no
- protected surface 范围：不适用
- 依据：dec_758112A30EBC78EB678723EA96（已 accept，in_effect）；task_b1ee750c44907f6bab44883196
- 机器检查边界：本 PR 只声明该段存在；声明是否真实、充分，由 reviewer 判断。
- Break-glass：no
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- `origin/main` 基准 SHA：（本会话已 rebase 到当前 origin/main）
- 当前分支与 `origin/main` 的 merge-base：当前
- 最近一次 `git fetch origin` 时间：2026-09-01（本会话，rebase 前）
- 同步方式：rebase
- 公开 diff 命令：`git diff origin/main...codex/closeout-deadlock`
- 私有证据 commit/path：task_b1ee750c 的 fact F-45163D90 / F-CC45B108 / F-BE1C34EA
- Reviewer 证据路径：见审查证据
- GitHub Actions `rewrite-ci` run URL：待本 PR 运行附上
- [x] `git diff --check`
- [x] `npm run typecheck`（`tsc -b`，退出码 0）——rebase 后
- [x] 定向测试：review 独立性（三分支，阳性+阴性对照）+ closeout/review/lifecycle 回归 39/39 绿；触碰文件 eslint 干净
- 未运行：完整 `npm test` / `npm run check` / harness:* 套件（worker 停止点纪律；完整权威是 CI）

## 审查证据

- 自查：CEO 对照已 accept 的裁决做语义验收——CH1（外部锚一等、SHA 验 origin/main 祖先）、CH2（逃生口仅在无 dispatch + 锚 + 理由时开）、CH3（默认拒绝、显式弱标记诚实且不可伪装）、CH4（有 dispatch 即关闭逃生口）逐条对照 diff 确认
- Reviewer subagent：分两轮派工实现（先锚定路径，CEO 复核发现缺弱标记后按指令补第二轮），每轮由本会话验证后再接受
- 人工审查：本 PR 上待进行
- 阻塞发现：无未关闭项

## 残余风险

- `PR #<n>` / PR-URL / CI-URL 三种锚形式只做格式校验；只有 40 位 SHA 那种验了 origin/main 祖先关系。要最强保证应使用已合并的 SHA。弱标记路径是构造上诚实的（从不声称已独立复核），但按设计就是最弱的证据档。

## 关联材料

- 任务：task_b1ee750c44907f6bab44883196
- 裁决：dec_758112A30EBC78EB678723EA96
- 证据：fact F-45163D90、F-CC45B108、F-BE1C34EA

---

## PR Gate Checklist / PR 门禁清单

- [x] Branch is based on latest `origin/main`. / 分支基于最新 `origin/main`。
- [x] PR body uses this full template structure. / PR 描述使用本模板完整结构。
- [x] PR body uses two complete language blocks: `# English` first, then `# 中文`. / PR 正文使用两块完整正文：`# English` 在上，`# 中文` 在下。
- [x] PR body passes `tools/check-pr-body-bilingual.mjs`. / PR 正文通过 `tools/check-pr-body-bilingual.mjs`。
- [x] If the PR touches a manifest-derived protected surface, Governance Declaration is filled with ADR/decision/task evidence or break-glass fields. / 若 PR 触碰 manifest 派生的 protected surface，Governance Declaration 已填写 ADR/decision/task 依据或 break-glass 字段。
- [x] No private harness files are included. / 不包含私有 harness 文件。
- [x] No ignored local agent entry files are included. / 不包含被忽略的本地 agent 入口文件。
- [x] No absolute local filesystem paths are included in this public PR body. / 本公开 PR 描述不包含本机绝对路径。
- [x] Public diff is limited to the stated task scope. / 公开 diff 限于声明的任务范围。
- [x] Private planning/evidence updates are recorded when applicable. / 适用时已记录私有计划 / 证据更新。
- [x] Version and publish impact are stated. / 已说明版本与发布影响。
- [x] Local verification commands are recorded honestly. / 已如实记录本地验证命令。
- [x] CI results are linked or explained. / CI 结果已链接或说明。
- [x] Review evidence is recorded. / 已记录审查证据。
- [x] Open P0/P1/P2 findings are closed, deferred with owner, or explicitly blocked. / open P0/P1/P2 findings 已关闭、带 owner 延后，或明确阻塞。
- [x] Merge method and post-merge branch cleanup plan are clear. / 合并方式和合并后分支清理计划清楚。
- [x] No admin bypass is planned unless explicitly approved and recorded. / 除非明确批准并记录，否则不计划 admin bypass。
