### PR TITLE
test(daemon): make fleet-transport coalescing assertion deterministic (unblocks milestone flake)

### DIFF
--- a/packages/daemon/src/repo-cell-open.ts
+++ b/packages/daemon/src/repo-cell-open.ts
@@ -5,6 +5,7 @@ import {
   isSameExecution,
   isSamePerson,
   type CanonicalEventAppendReceipt,
+  type CanonicalEventStore,
   type DaemonRepoMode,
   type EventPublicationKillpoint,
   type SettingsV1,
@@ -138,6 +139,8 @@ export async function openRepoCell(input: {
     >,
   ) => void;
   readonly onAttemptTerminal?: (terminal: RuntimeAttemptTerminal) => void;
+  /** Test seam for controlling WAL materialization without wall-clock scheduling. */
+  readonly onStoreOpened?: (store: CanonicalEventStore) => void;
   readonly now?: () => string;
   readonly killpoint?: (point: EventPublicationKillpoint) => void;
   readonly shouldStop?: () => boolean;

--- a/packages/daemon/src/repo-cell.ts
+++ b/packages/daemon/src/repo-cell.ts
@@ -50,6 +50,7 @@ export interface RepoCellCoreInput {
     readonly repoId: string;
     readonly killpoint?: Parameters<typeof makeTaskEventStore>[0]["killpoint"];
     readonly runtimeInstances?: () => readonly RuntimeInstanceSummary[];
+    readonly onStoreOpened?: (store: ReturnType<typeof makeTaskEventStore>) => void;
   };
   readonly rootDir: string;
   readonly authoredBranch?: string;
@@ -136,6 +137,7 @@ export function initializeRepoCell(context: RepoCellCoreInput): RepoCellCore {
     rejectPreparedRecovery: context.mode === "remote-center",
     walFlushPolicy: () => readSettingsFacet(existsSync(configPath) ? readFileSync(configPath, "utf8") : "").walFlush,
   });
+  context.input.onStoreOpened?.(store);
   let recovery = store.recover();
   projection = makeTaskProjection({ rootDir: context.rootDir, eventStore: store, now: context.now });
   // Attach advances one bounded, complete projection cut. Serving reads never mutates L2; future

--- a/packages/daemon/test/fleet-transport-scale.integration.test.ts
+++ b/packages/daemon/test/fleet-transport-scale.integration.test.ts
@@ -7,12 +7,9 @@ import path from "node:path";
 import test from "node:test";
 import { openDaemonHost } from "../src/daemon-host.ts";
 import { listenFleetTls, type FleetAssignmentRecord, type FleetTlsCenter } from "../src/fleet/center.ts";
+import { openRepoCell } from "../src/repo-cell.ts";
 import { registerBootstrappedDaemonRepo as registerDaemonRepo } from "./repo-settings.fixture.ts";
 import { realizeTaskPlanFixture } from "../../../tools/fixtures/task-plan.mjs";
-
-// Idle WAL→Git materialization defaults to one hour (owner ruling 2026-08-31). These suites
-// wait for materialized commits, so pin the test-local idle timer to a fast interval.
-process.env.HARNESS_WAL_FLUSH_MS = "250";
 
 const replicaQuota = 64 * 1024 * 1024;
 function reclaimer() {
@@ -34,76 +31,71 @@ function reclaimer() {
   };
 }
 
-test(
-  "production Fleet TLS entry sustains 3/10/32 Git-less edge processes across eight repos without duplicate writes",
-  { timeout: 240_000 },
-  async (t) => {
-    const fixture = await scaleFixture();
-    t.after(() => fixture.close());
-    const center = await fixture.center();
-    for (const count of [3, 10, 32]) {
-      const clients = fixture.clients.splice(0, count),
-        before = fixture.commitCounts(),
-        children = await startChildrenAtWriteBarrier(fixture, center.port, clients);
-      for (const child of children) child.release();
-      const results = await Promise.all(children.map((child) => child.result));
-      assert.equal(results.length, count);
-      assert.equal(
-        results.every((result) => result.ok && result.gitAbsent && result.replica.outcome === "applied"),
-        true,
-      );
-      await Promise.all(
-        results.map((result, index) =>
-          waitForReceiptCommit(fixture.host, result.repoId, result.center.opId, clients[index]!.assignment),
-        ),
-      );
-      const repoCuts = fixture
-          .commitCounts()
-          .map((row, index) => ({ repoId: row.repoId, commits: row.commits - before[index]!.commits })),
-        materializedCommits = repoCuts.reduce((sum, row) => sum + row.commits, 0),
-        touchedRepos = new Set(results.map((result) => result.repoId)).size,
-        childWindows = results.map((result, index) => ({
-          label: clients[index]!.label,
-          repoId: result.repoId,
-          startedAt: result.startedAt,
-          endedAt: result.endedAt,
-        })),
-        evidence = `Fleet coalescing evidence: ${JSON.stringify({ count, materializedCommits, touchedRepos, repoCuts, childWindows })}`;
-      t.diagnostic(evidence);
-      assert.equal(materializedCommits >= touchedRepos, true, evidence);
-      assert.equal(materializedCommits <= count, true, evidence);
-      if (count > touchedRepos)
-        assert.equal(
-          materializedCommits < count,
-          true,
-          `${count} writes must coalesce into fewer Git cuts; ${evidence}`,
-        );
-      const intervalsOverlap = results.some((left, index) =>
-        results
-          .slice(index + 1)
-          .some(
-            (right) =>
-              left.repoId !== right.repoId &&
-              Math.max(left.startedAt, right.startedAt) < Math.min(left.endedAt, right.endedAt),
-          ),
-      );
-      assert.equal(intervalsOverlap, true, "at least two repo transport/write windows must overlap");
-      const readMs: number[] = [];
-      for (const client of clients) {
-        const started = performance.now(),
-          shown = await fixture.host.run(
-            client.assignment.repoId,
-            { kind: "doc-show", path: client.path },
-            { transportKind: "fleet-tls", assignmentBinding: client.assignment },
-          );
-        readMs.push(performance.now() - started);
-        assert.equal(shown.evidence, client.body);
-      }
-      readMs.sort((a, b) => a - b);
-      assert.ok(readMs[Math.ceil(readMs.length * 0.95) - 1]! < 2_000);
+test("production Fleet TLS entry sustains 3/10/32 Git-less edge processes across eight repos without duplicate writes", async (t) => {
+  const fixture = await scaleFixture();
+  t.after(() => fixture.close());
+  const center = await fixture.center();
+  for (const count of [3, 10, 32]) {
+    const clients = fixture.clients.splice(0, count),
+      before = fixture.commitCounts(),
+      children = await startChildrenAtWriteBarrier(fixture, center.port, clients),
+      batch = fixture.beginBatch(clients.map((client) => client.assignment.repoId));
+    for (const child of children) child.release();
+    let results: ChildResult[];
+    try {
+      results = await Promise.all(children.map((child) => child.result));
+    } finally {
+      await batch.finish();
     }
-  },
-);
+    assert.equal(results.length, count);
+    assert.equal(
+      results.every((result) => result.ok && result.gitAbsent && result.replica.outcome === "applied"),
+      true,
+    );
+    await Promise.all(
+      results.map((result, index) =>
+        waitForReceiptCommit(fixture.host, result.repoId, result.center.opId, clients[index]!.assignment),
+      ),
+    );
+    const repoCuts = fixture
+        .commitCounts()
+        .map((row, index) => ({ repoId: row.repoId, commits: row.commits - before[index]!.commits })),
+      materializedCommits = repoCuts.reduce((sum, row) => sum + row.commits, 0),
+      touchedRepos = new Set(results.map((result) => result.repoId)).size,
+      childWindows = results.map((result, index) => ({
+        label: clients[index]!.label,
+        repoId: result.repoId,
+        startedAt: result.startedAt,
+        endedAt: result.endedAt,
+      })),
+      evidence = `Fleet coalescing evidence: ${JSON.stringify({ count, materializedCommits, touchedRepos, repoCuts, childWindows })}`;
+    t.diagnostic(evidence);
+    assert.equal(materializedCommits, touchedRepos, evidence);
+    const intervalsOverlap = results.some((left, index) =>
+      results
+        .slice(index + 1)
+        .some(
+          (right) =>
+            left.repoId !== right.repoId &&
+            Math.max(left.startedAt, right.startedAt) < Math.min(left.endedAt, right.endedAt),
+        ),
+    );
+    assert.equal(intervalsOverlap, true, "at least two repo transport/write windows must overlap");
+    const readMs: number[] = [];
+    for (const client of clients) {
+      const started = performance.now(),
+        shown = await fixture.host.run(
+          client.assignment.repoId,
+          { kind: "doc-show", path: client.path },
+          { transportKind: "fleet-tls", assignmentBinding: client.assignment },
+        );
+      readMs.push(performance.now() - started);
+      assert.equal(shown.evidence, client.body);
+    }
+    readMs.sort((a, b) => a - b);
+    assert.ok(readMs[Math.ceil(readMs.length * 0.95) - 1]! < 2_000);
+  }
+});
 
 function initRepo(rootDir: string): void {
   git(rootDir, "init", "-q");
@@ -206,12 +198,20 @@ async function scaleFixture() {
     ],
     { stdio: "ignore" },
   );
-  const host = await openDaemonHost({ daemonId: "fleet-scale", userRoot }),
+  const stores = new Map<string, Parameters<NonNullable<Parameters<typeof openRepoCell>[0]["onStoreOpened"]>>[0]>(),
+    host = await openDaemonHost({
+      daemonId: "fleet-scale",
+      userRoot,
+      openCell: (input) =>
+        openRepoCell({
+          ...input,
+          onStoreOpened: (store) => stores.set(input.repoId, store),
+        }),
+    }),
     clients: ScaleClient[] = [],
     assignments = new Map<string, FleetAssignmentRecord>();
   await host.attachmentsSettled();
-  const prepared = await Promise.all(
-    Array.from({ length: 45 }, async (_, index) => {
+  const drafts = Array.from({ length: 45 }, (_, index) => {
       const repo = repos[index % repos.length]!,
         taskId = `task-f${index}`,
         assignment: FleetAssignmentRecord = {
@@ -224,34 +224,61 @@ async function scaleFixture() {
           viewId: `view-${index}`,
           expiresAt: "2099-01-01T00:00:00.000Z",
           actor: { principal: { personId: "fleet-owner" }, executor: { kind: "agent", id: `edge-${index}` } },
-        },
-        auth = { transportKind: "fleet-tls" as const, assignmentBinding: assignment },
-        created = await host.run(repo.repoId, { kind: "task-create", taskId, title: taskId }, auth);
-      assert.equal(created.outcome, "applied");
-      await realizeTaskPlanFixture(
-        repo.rootDir,
-        String((created as Record<string, unknown>).packagePath),
-        (planPath) => host.run(repo.repoId, { kind: "doc-submit", paths: [planPath] }, localAuthFixture()),
-        taskId,
-      );
-      const started = await host.run(
-        repo.repoId,
-        { kind: "task-start", taskId, executionId: assignment.executionId },
-        auth,
-      );
-      assert.equal(started.outcome, "applied", JSON.stringify(started));
-      return {
-        assignment,
-        opId: started.opId,
-        client: {
-          assignment,
-          path: assignment.paths[0]!,
-          body: `# ${taskId}\n\nbody-${index}\n`,
-          label: `client-${index}`,
-        },
-      };
+        };
+      return { index, repo, taskId, assignment };
     }),
-  );
+    repoIds = repos.map((repo) => repo.repoId),
+    creationBatch = beginStoreBatch(stores, repoIds);
+  let created: Array<(typeof drafts)[number] & { packagePath: string }>;
+  try {
+    created = await Promise.all(
+      drafts.map(async (draft) => {
+        const auth = { transportKind: "fleet-tls" as const, assignmentBinding: draft.assignment },
+          receipt = await host.run(
+            draft.repo.repoId,
+            { kind: "task-create", taskId: draft.taskId, title: draft.taskId },
+            auth,
+          );
+        assert.equal(receipt.outcome, "applied");
+        return { ...draft, packagePath: String((receipt as Record<string, unknown>).packagePath) };
+      }),
+    );
+  } finally {
+    await creationBatch.finish();
+  }
+  const preparationBatch = beginStoreBatch(stores, repoIds);
+  let prepared: Array<{ assignment: FleetAssignmentRecord; opId: string; client: ScaleClient }>;
+  try {
+    prepared = await Promise.all(
+      created.map(async ({ assignment, index, packagePath, repo, taskId }) => {
+        await realizeTaskPlanFixture(
+          repo.rootDir,
+          packagePath,
+          (planPath) => host.run(repo.repoId, { kind: "doc-submit", paths: [planPath] }, localAuthFixture()),
+          taskId,
+        );
+        const auth = { transportKind: "fleet-tls" as const, assignmentBinding: assignment },
+          started = await host.run(
+            repo.repoId,
+            { kind: "task-start", taskId, executionId: assignment.executionId },
+            auth,
+          );
+        assert.equal(started.outcome, "applied", JSON.stringify(started));
+        return {
+          assignment,
+          opId: started.opId,
+          client: {
+            assignment,
+            path: assignment.paths[0]!,
+            body: `# ${taskId}\n\nbody-${index}\n`,
+            label: `client-${index}`,
+          },
+        };
+      }),
+    );
+  } finally {
+    await preparationBatch.finish();
+  }
   for (const value of prepared) {
     assignments.set(value.assignment.assignmentId, value.assignment);
     clients.push(value.client);
@@ -285,12 +312,28 @@ async function scaleFixture() {
         repoId: repo.repoId,
         commits: Number(git(repo.rootDir, "rev-list", "--count", "refs/ha/canonical")),
       })),
+    beginBatch: (repoIds: readonly string[]) => {
+      return beginStoreBatch(stores, repoIds);
+    },
     close: async () => {
       await owned.reclaim();
       await host.close();
       rmSync(root, { recursive: true, force: true });
     },
   };
+}
+
+function beginStoreBatch(
+  stores: ReadonlyMap<string, Parameters<NonNullable<Parameters<typeof openRepoCell>[0]["onStoreOpened"]>>[0]>,
+  repoIds: readonly string[],
+) {
+  const batches = [...new Set(repoIds)].map((repoId) => {
+    const store = stores.get(repoId),
+      batch = store?.beginBulkWrite?.();
+    assert.ok(batch, `repo ${repoId} must expose deterministic WAL batching`);
+    return batch;
+  });
+  return { finish: () => Promise.all(batches.map((batch) => batch.finish())) };
 }
 // Edge children report their result on stdout, so both runners settle on `close`, not `exit`:
 // `exit` fires when the process ends and can precede the last stdout chunk, which under a


### PR DESCRIPTION
# English

## Summary

Make the `fleet-transport-scale` integration test's coalescing assertion deterministic instead of wall-clock-timing dependent. The test pinned `HARNESS_WAL_FLUSH_MS=250` and asserted `materializedCommits < count`, which only holds when concurrent writes to the same repo happen to land inside the same 250ms flush window — under load (local dev, shared CI runners) writes serialize past the window, each flushes separately, and the assertion fails. This flake blocked the terminal-workspace milestone three times (PRs #2096 ×2, #2099). The fix drives materialization through an explicit WAL batch (`beginBatch`/`finish`) via a minimal test seam, and tightens the assertion to `materializedCommits === touchedRepos` (each touched repo produces exactly one cut per batch).

## Architectural Justification

The coalescing guarantee is now tested by mechanism, not by racing the flush clock: writes are issued, then a single explicit batch flush is awaited, then the exact cut count is asserted. To hand the test a deterministic materialization trigger, `repo-cell.ts` / `repo-cell-open.ts` gain one optional `onStoreOpened?` seam (a no-op when unset, ~5 lines, no production behavior change) — the minimal hook needed to control WAL materialization without wall-clock scheduling, which is exactly what the flake required us to escape. The new assertion (`=== touchedRepos`) is strictly stronger than the old `< count`.

## What Changed

- `fleet-transport-scale.integration.test.ts`: issue writes then drive an explicit `beginBatch(repoIds).finish()`; assert `materializedCommits === touchedRepos`.
- `repo-cell.ts` / `repo-cell-open.ts`: optional `onStoreOpened?(store)` test seam (no-op by default) so the test can trigger deterministic materialization.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: use the single CI-backed `Production-Delta` declaration below; do not enter a second metric.

## Machine-Readable Declarations

Production-Delta: +5/-0

## Task And Scope

- Harness task: task_20a3c274802d68955a24db9c63 (CI flake: fleet-transport Fleet TLS coalescing)
- Branch: codex/fleet-flake-fix
- Public scope: packages/daemon test + repo-cell seam
- Private planning/evidence updated: yes (task package; facts F-4D492A77, F-F70E5DDB, F-AFB8E568 context)
- Out of scope: the terminal-workspace milestone features (unrelated); the 120s runtime dimension is reduced in practice by removing the retry loops but not further split here

## Version Impact

- Version: no version change because this is a test-determinism fix with a no-op production seam
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope:
- Authority: task_20a3c274802d68955a24db9c63
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no

## Verification

- Base `origin/main` SHA: a72e1ad60f324cc5120f575ac035df41514a1922
- Sync method: none needed (branch created from origin/main; rebase confirms up to date)
- Public diff command: `git diff origin/main...codex/fleet-flake-fix`
- [x] `node --test packages/daemon/test/fleet-transport-scale.integration.test.ts`: 1/1 pass under CEO's loaded machine (97s under heavy concurrent load; deterministic assertion holds where the old wall-clock assertion would fail). Worker isolated-Ubuntu run: 33.86s, 3/8/8 cuts for 3/8/8 touched repos.
- [x] positive mutation control (worker): temporarily reverting to the timing-dependent path reproduces the failure.
- [ ] GitHub Actions `rewrite-ci` passed
- Not run: full local suite — GitHub CI is authority.
- Note: implemented by the Sol worker; its ledger writes were rejected by a runtime `executor_binding_invalid` (framework friction, tracked), so the coordinator ground-truthed the fix (passing under load) and closed out the task.

---

# 中文

## 摘要

把 `fleet-transport-scale` 集成测试的 coalescing 断言从依赖墙钟时序改为确定性。测试原 pin `HARNESS_WAL_FLUSH_MS=250`、断言 `materializedCommits < count`,只在同一 repo 的并发写恰好落入同一 250ms flush 窗口时成立;负载下(本地/共享 CI runner)写超出窗口各自 flush,断言失败。此 flake 连挡终端里程碑三次(PR #2096 ×2、#2099)。修法:经显式 WAL 批次(`beginBatch`/`finish`)驱动物化,断言收紧为 `materializedCommits === touchedRepos`(每 repo 每批恰好 1 cut)。

## 架构辩护

coalescing 保证现在按机制测、不再赛 flush 时钟:发出写→await 一次显式批次 flush→断言精确 cut 数。为给测试一个确定性物化触发,`repo-cell.ts`/`repo-cell-open.ts` 加一个可选 `onStoreOpened?` seam(未设时 no-op,约 5 行,不改生产行为)——这是脱离墙钟调度控制 WAL 物化所需的最小钩子,正是 flake 逼我们脱离的东西。新断言(`=== touchedRepos`)严格强于旧的 `< count`。

## 任务与范围

- Harness 任务:task_20a3c274802d68955a24db9c63
- 分支:codex/fleet-flake-fix;范围外:终端里程碑功能(无关)

## 治理声明

- 未触碰 protected surface;无 break-glass。授权:task_20a3c274802d68955a24db9c63。

## 验证

- CEO 亲跑 fleet-transport-scale 测试 1/1 通过(超载机器 97s;确定性断言在旧墙钟断言会失败的负载下仍成立);worker 隔离 Ubuntu 33.86s,3/8/8 cut。
- 阳性变异对照(worker):临时恢复时序依赖路径可复现失败。
- 说明:Sol 实现,其台账写入被 runtime `executor_binding_invalid` 拒(框架摩擦,已记),由协调者 ground-truth(负载下通过)后代收口。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BE45Q2y1iZzLJNo8j7xhhL
