### PR TITLE
test(daemon): pin fleet-scale WAL flush above the widest same-repo write gap

### DIFF
--- a/packages/daemon/test/fleet-transport-scale.integration.test.ts
+++ b/packages/daemon/test/fleet-transport-scale.integration.test.ts
@@ -10,9 +10,11 @@ import { listenFleetTls, type FleetAssignmentRecord, type FleetTlsCenter } from 
 import { registerBootstrappedDaemonRepo as registerDaemonRepo } from "./repo-settings.fixture.ts";
 import { realizeTaskPlanFixture } from "../../../tools/fixtures/task-plan.mjs";
 
-// Idle WAL→Git materialization defaults to one hour (owner ruling 2026-08-31). These suites
-// wait for materialized commits, so pin the test-local idle timer to a fast interval.
-process.env.HARNESS_WAL_FLUSH_MS = "250";
+// Idle WAL→Git materialization defaults to one hour (owner ruling 2026-08-31). This suite
+// waits for materialized commits AND asserts same-repo writes coalesce into fewer Git cuts;
+// the idle timer resets on every append, so the pin must exceed the widest gap between two
+// same-repo writes in a round (~1.4s observed) or sequential writes flush as separate cuts.
+process.env.HARNESS_WAL_FLUSH_MS = "2000";
 
 const replicaQuota = 64 * 1024 * 1024;
 function reclaimer() {


### PR DESCRIPTION
# English

## Summary

Fixes the second main-red instrument family from today: the fleet-transport-scale "3/10/32" coalescing assertion failed three times (PR #2097 shard, c88eb55db full-check 26, c30c2de8a full-check 24). With the suite's idle WAL flush pinned at 250ms and the idle timer resetting on every append, two sequential writes to the same repo separated by more than 250ms materialize as two separate Git cuts — the failing evidence showed exactly that (fleet-r3/fleet-r4 each received two non-overlapping writes and produced two commits each, 10 writes → 10 cuts). "N writes must coalesce into fewer Git cuts" is therefore not guaranteed by construction at a 250ms pin. The fix pins this one suite to 2000ms, wider than the observed ~1.4s round span, so every write of a round lands inside a single idle window and per-repo coalescing becomes deterministic. The 15s receipt-wait budget is unaffected; fleet-dual-sync keeps its 250ms pin (it does not assert coalescing). Suite passes locally 1/1 (97s).

## Architectural Justification

- Mechanism sentence: an assertion about batching must run under a flush window wider than the arrival spread it batches; otherwise the property under test is timing-dependent by construction.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none

## Machine-Readable Declarations

Production-Delta: +0/-0
Dependency-Change: none

### Optional Evidence Claims

None.

## Task And Scope

- CEO supervision line (main-red repair, third same-family occurrence = shape signal). Branch `codex/fleet-scale-pin`; one test file.

## Version Impact

- Version: no change. Publish impact: none.

## Governance Declaration

- Protected surface touched: no. Break-glass: no.

## Verification

- Full fleet-transport-scale suite passes locally: 1 test, 1 pass, 0 fail (97s).
- [ ] Full suites: GitHub CI is the authority.

## Review Evidence

- CEO-authored from three CI reproductions; the failing run's own coalescing evidence (childWindows showing non-overlapping same-repo writes with >250ms gaps) is the positive demonstration of the mechanism.

## Residual Risk

- If a future round spreads same-repo writes wider than 2000ms the assertion can regress; the pin comment states the invariant (pin must exceed the widest same-repo write gap) so the next reader adjusts the pin, not the assertion.

---

# 中文

## 概要

修今天第二个 main 红仪器族:fleet-transport-scale 的 3/10/32 coalescing 断言三次复现失败。250ms idle flush pin 下,idle 计时每次 append 重置,同一 repo 两笔间隔 >250ms 的先后写会各自落成独立 Git cut(失败证据里 fleet-r3/r4 正是各两笔不重叠写 → 各 2 commit,10 写 = 10 cut),「必须 coalesce」在该 pin 下无构造性保证。修法:本套件 pin 提到 2000ms(大于实测 ~1.4s 轮跨度),一轮内全部写落进同一 idle 窗口,coalescing 变确定性;15s 回执等待预算不受影响;fleet-dual-sync 不断言 coalescing,保持 250ms。本地全套件 1/1 绿(97s)。

## 机读声明

`Production-Delta: +0/-0`(仅测试文件)。

## 验证

- 本地完整套件 1/1;完整权威=GitHub CI。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VTzQAqvuFy6ikGjBKxA9xj
