### PR TITLE
fix(gui): keep service daemon attachments attach-only (stop killing daemons the GUI didn't spawn)

### DIFF
--- a/packages/gui/src/main/daemon-supervisor.ts
+++ b/packages/gui/src/main/daemon-supervisor.ts
@@ -91,7 +91,7 @@ export function createDaemonSupervisor(input: {
         phase: "failed",
         completedAt: now(),
         error: { code: "restart_failed", hint: error instanceof Error ? error.message : "Daemon restart failed." },
-        nextAction: "Inspect daemon status; the next request starts the daemon automatically.",
+        nextAction: "Inspect daemon status and start the service daemon explicitly if needed.",
       };
     }
     receipts.set(operationId, active);

--- a/packages/gui/src/main/electron-main.ts
+++ b/packages/gui/src/main/electron-main.ts
@@ -6,7 +6,11 @@ import type { HarnessLayoutOverrides } from "../../../kernel/src/index.ts";
 import { registerHarnessIpcHandlers } from "./ipc-handlers.ts";
 import { registerArtifactOpenIpc } from "./artifact-open-ipc.ts";
 import { registerLocalDocIpc } from "./local-doc-ipc.ts";
-import { bootstrapLocalRepository, createLocalGuiServiceBridge } from "./local-composition-root.ts";
+import {
+  bootstrapLocalRepository,
+  createLocalDaemonLifecycle,
+  createLocalGuiServiceBridge,
+} from "./local-composition-root.ts";
 import { addLocalMainControls } from "./local-main-controls.ts";
 import { resolveLocalDaemonTarget } from "../../../daemon/src/client/local-daemon-target.ts";
 import { daemonBuildStamp } from "../../../daemon/src/build-identity.ts";
@@ -159,12 +163,17 @@ export async function startGuiApp(): Promise<void> {
   const trustedWebContentsIds = new Set<number>();
   const rootDir = resolveGuiProjectRoot(),
     packaged = app.isPackaged ? { resourcesPath: process.resourcesPath } : undefined,
-    bridge = createLocalGuiServiceBridge(rootDir, resolveGuiLayoutOverrides(), packaged ? { packaged } : {}),
+    daemonLifecycle = createLocalDaemonLifecycle(),
+    bridge = createLocalGuiServiceBridge(rootDir, resolveGuiLayoutOverrides(), {
+      ...(packaged ? { packaged } : {}),
+      lifecycle: daemonLifecycle,
+    }),
     controlled = addLocalMainControls({
       bridge,
       invokingRoot: rootDir,
       target: async (repoId) => resolveLocalDaemonTarget({ rootDir, ...(repoId ? { repoIdOverride: repoId } : {}) }),
       clientBuildCommit: daemonBuildStamp().commit,
+      canRestartDaemon: daemonLifecycle.isOwned,
       ...(packaged ? { packaged } : {}),
     }),
     trustPolicy: IpcWebContentsTrustPolicy = {

--- a/packages/gui/src/main/local-composition-root.ts
+++ b/packages/gui/src/main/local-composition-root.ts
@@ -39,16 +39,36 @@ interface DaemonClient {
     responseTimeoutMs?: number,
   ) => Promise<JsonObject>;
 }
+export interface LocalDaemonLifecycle {
+  readonly attached: () => void;
+  readonly spawned: () => void;
+  readonly canAutostart: () => boolean;
+  readonly isOwned: () => boolean;
+}
 let client: Promise<DaemonClient> | undefined;
+export function createLocalDaemonLifecycle(): LocalDaemonLifecycle {
+  let owner: "unresolved" | "external" | "gui" = "unresolved";
+  return {
+    attached: () => {
+      if (owner === "unresolved") owner = "external";
+    },
+    spawned: () => {
+      owner = "gui";
+    },
+    canAutostart: () => owner !== "external",
+    isOwned: () => owner === "gui",
+  };
+}
 export function createLocalGuiServiceBridge(
   rootDir: string,
   _layoutOverrides?: { readonly authoredRoot?: string },
-  options: { readonly packaged?: PackagedRuntime } = {},
+  options: { readonly packaged?: PackagedRuntime; readonly lifecycle?: LocalDaemonLifecycle } = {},
 ): GuiServiceBridge {
   const root = path.resolve(rootDir);
+  const lifecycle = options.lifecycle ?? createLocalDaemonLifecycle();
   validateProjectPath(root, ".");
   return createGuiServiceBridgeForDaemon(
-    (route, payload) => request(root, route, payload, options.packaged),
+    (route, payload) => request(root, route, payload, lifecycle, options.packaged),
     async (route, payload, emit) => {
       const daemon = await loadClient(),
         scoped = repoPayload(payload),
@@ -118,6 +138,7 @@ async function request(
   rootDir: string,
   route: ShippedGuiRoute,
   payload: unknown,
+  lifecycle: LocalDaemonLifecycle,
   packaged?: PackagedRuntime,
 ): Promise<JsonObject> {
   try {
@@ -146,9 +167,19 @@ async function request(
         requestTimeoutMs(route, daemonPayload),
       );
     try {
-      return parse(await invoke());
+      const result = parse(await invoke());
+      lifecycle.attached();
+      return result;
     } catch (connectError) {
       if (!isDaemonUnreachable(connectError)) throw connectError;
+      if (!lifecycle.canAutostart())
+        throw new Error(
+          [
+            "The service daemon stopped after this GUI attached to it;",
+            "the GUI is attach-only for that daemon.",
+            "Start the service daemon explicitly, then retry.",
+          ].join(" "),
+        );
       const started = await ensureLocalDaemonRunning({
         socketPath: target.socketPath,
         invokingRoot: rootDir,
@@ -160,6 +191,8 @@ async function request(
           started.code ?? "daemon_start_failed",
           started.hint,
         ) as unknown as JsonObject;
+      if (started.attempts > 0) lifecycle.spawned();
+      else lifecycle.attached();
       return parse(await invoke());
     }
   } catch (error) {

--- a/packages/gui/src/main/local-main-controls.ts
+++ b/packages/gui/src/main/local-main-controls.ts
@@ -21,13 +21,22 @@ export function addLocalMainControls(input: {
   readonly invokingRoot?: string;
   readonly target: (repoId?: string) => Promise<Target>;
   readonly clientBuildCommit: string | null;
+  readonly canRestartDaemon?: () => boolean;
   readonly packaged?: PackagedRuntime;
   readonly credentialPort?: CredentialPort;
 }): GuiServiceBridge {
   const supervisor = createDaemonSupervisor({
     authorize: async (payload) => asRecord(await input.bridge.invoke("requestDaemonControl", payload)),
-    restart: async (repoId) =>
-      restartResidentDaemon(await input.target(repoId), input.invokingRoot ?? process.cwd(), input.packaged),
+    restart: async (repoId) => {
+      if (input.canRestartDaemon?.() === false)
+        throw new Error(
+          [
+            "This GUI attached to an existing service daemon and cannot restart it.",
+            "Restart the service daemon explicitly.",
+          ].join(" "),
+        );
+      return restartResidentDaemon(await input.target(repoId), input.invokingRoot ?? process.cwd(), input.packaged);
+    },
   });
   // API-key creation remains main-process-bound so the daemon receives only an opaque
   // credential reference; the resulting create call returns to the registry-derived bridge.

--- a/packages/gui/test/daemon-autostart-bridge.test.ts
+++ b/packages/gui/test/daemon-autostart-bridge.test.ts
@@ -10,61 +10,191 @@ import { daemonSingletonLockPath } from "../../daemon/src/daemon-singleton.ts";
 import { readDaemonPid, startDaemon, type RunningDaemon } from "../../daemon/src/runtime.ts";
 import { createLocalGuiServiceBridge } from "../src/index.ts";
 
-interface Failure { readonly ok: boolean; readonly error?: { readonly code: string; readonly hint: string } }
+interface Failure {
+  readonly ok: boolean;
+  readonly error?: { readonly code: string; readonly hint: string };
+}
 
 function resident(daemon: Awaited<ReturnType<typeof startDaemon>>): RunningDaemon {
-  if (!("stop" in daemon)) throw new Error(`startDaemon deferred to incumbent pid ${String(daemon.pid)} in a fixture that expects a fresh daemon`);
+  if (!("stop" in daemon))
+    throw new Error(
+      `startDaemon deferred to incumbent pid ${String(daemon.pid)} in a fixture that expects a fresh daemon`,
+    );
   return daemon;
 }
 
 test("GUI bridge auto-starts an unreachable daemon, retries the read, and reaches the resident daemon", async () => {
-  const parent = mkdtempSync(path.join(tmpdir(), "ha-gui-autostart-")), rootDir = path.join(parent, "repo"), userRoot = path.join(parent, "user"), daemonId = "gui-autostart";
-  const previous = process.env.HARNESS_DAEMON_USER_ROOT, previousId = process.env.HARNESS_DAEMON_ID;
-  process.env.HARNESS_DAEMON_USER_ROOT = userRoot; process.env.HARNESS_DAEMON_ID = daemonId;
+  const parent = mkdtempSync(path.join(tmpdir(), "ha-gui-autostart-")),
+    rootDir = path.join(parent, "repo"),
+    userRoot = path.join(parent, "user"),
+    daemonId = "gui-autostart";
+  const previous = process.env.HARNESS_DAEMON_USER_ROOT,
+    previousId = process.env.HARNESS_DAEMON_ID;
+  process.env.HARNESS_DAEMON_USER_ROOT = userRoot;
+  process.env.HARNESS_DAEMON_ID = daemonId;
   const daemon = resident(await startDaemon({ daemonId, userRoot }));
   try {
-    assert.equal((await requestDaemonJsonRpcAt(daemon.endpoint, "daemon.repo.bootstrap", { rootDir, repoId: "gui-autostart", personId: "person-gui", displayName: "GUI Autostart" }, 1_000)).ok, true);
-    assert.equal((await requestDaemonJsonRpcAt(daemon.endpoint, "repo.task.create", { repo: { repoId: "gui-autostart" }, payload: { taskId: "task-gui-autostart", title: "GUI autostart task" } }, 1_000)).ok, true);
-    const beforePid = readDaemonPid(userRoot, daemonId); assert.ok(beforePid);
+    assert.equal(
+      (
+        await requestDaemonJsonRpcAt(
+          daemon.endpoint,
+          "daemon.repo.bootstrap",
+          { rootDir, repoId: "gui-autostart", personId: "person-gui", displayName: "GUI Autostart" },
+          1_000,
+        )
+      ).ok,
+      true,
+    );
+    assert.equal(
+      (
+        await requestDaemonJsonRpcAt(
+          daemon.endpoint,
+          "repo.task.create",
+          { repo: { repoId: "gui-autostart" }, payload: { taskId: "task-gui-autostart", title: "GUI autostart task" } },
+          1_000,
+        )
+      ).ok,
+      true,
+    );
+    const beforePid = readDaemonPid(userRoot, daemonId);
+    assert.ok(beforePid);
     await daemon.stop();
     // No in-process daemon and no pid file: the first bridge read must launch a
     // detached daemon through the main-process launch seam and then answer.
     const tasks = await createLocalGuiServiceBridge(rootDir).invoke("getTasks", { repoId: "gui-autostart" });
     assert.equal(tasks.ok, true, JSON.stringify(tasks));
     const rows = (tasks as { rows?: Array<{ taskId?: string }> }).rows ?? [];
-    assert.deepEqual(rows.map((row) => row.taskId), ["task-gui-autostart"], JSON.stringify(tasks));
-    const afterPid = readDaemonPid(userRoot, daemonId); assert.ok(afterPid, "bridge autostart must leave a resident daemon pid file"); assert.notEqual(afterPid, beforePid);
+    assert.deepEqual(
+      rows.map((row) => row.taskId),
+      ["task-gui-autostart"],
+      JSON.stringify(tasks),
+    );
+    const afterPid = readDaemonPid(userRoot, daemonId);
+    assert.ok(afterPid, "bridge autostart must leave a resident daemon pid file");
+    assert.notEqual(afterPid, beforePid);
     // A live resident daemon is probed and reused, never respawned: a second
     // bridge read must keep the same generation and the same singleton holder.
     const again = await createLocalGuiServiceBridge(rootDir).invoke("getTasks", { repoId: "gui-autostart" });
     assert.equal(again.ok, true, JSON.stringify(again));
-    assert.equal(readDaemonPid(userRoot, daemonId), afterPid, "a reachable daemon must not be replaced by a second spawn");
-    assert.equal(readFileSync(daemonSingletonLockPath(userRoot, daemonId), "utf8"), `${afterPid}\n`, "the bridge must not disturb the daemon singleton claim");
+    assert.equal(
+      readDaemonPid(userRoot, daemonId),
+      afterPid,
+      "a reachable daemon must not be replaced by a second spawn",
+    );
+    assert.equal(
+      readFileSync(daemonSingletonLockPath(userRoot, daemonId), "utf8"),
+      `${afterPid}\n`,
+      "the bridge must not disturb the daemon singleton claim",
+    );
     await stopResident(userRoot, daemonId);
   } finally {
-    process.env.HARNESS_DAEMON_USER_ROOT = previous; process.env.HARNESS_DAEMON_ID = previousId;
-    await daemon.stop().catch(() => undefined); rmSync(parent, { recursive: true, force: true });
+    process.env.HARNESS_DAEMON_USER_ROOT = previous;
+    process.env.HARNESS_DAEMON_ID = previousId;
+    await daemon.stop().catch(() => undefined);
+    rmSync(parent, { recursive: true, force: true });
   }
 });
 
-test("GUI bridge reports the single-flight lock permission failure without spawning", { skip: process.platform === "win32" || process.getuid?.() === 0 ? "requires POSIX non-root permission semantics" : false }, async () => {
-  const parent = mkdtempSync(path.join(tmpdir(), "ha-gui-autostart-fail-")), rootDir = path.join(parent, "repo"), userRoot = path.join(parent, "user"), daemonId = "gui-autostart-fail";
-  const previous = process.env.HARNESS_DAEMON_USER_ROOT, previousId = process.env.HARNESS_DAEMON_ID;
-  process.env.HARNESS_DAEMON_USER_ROOT = userRoot; process.env.HARNESS_DAEMON_ID = daemonId;
+test("GUI bridge stays attach-only after its resident service daemon stops", async () => {
+  const parent = mkdtempSync(path.join(tmpdir(), "ha-gui-attach-only-")),
+    rootDir = path.join(parent, "repo"),
+    userRoot = path.join(parent, "user"),
+    daemonId = "gui-attach-only";
+  const previous = process.env.HARNESS_DAEMON_USER_ROOT,
+    previousId = process.env.HARNESS_DAEMON_ID;
+  process.env.HARNESS_DAEMON_USER_ROOT = userRoot;
+  process.env.HARNESS_DAEMON_ID = daemonId;
   const daemon = resident(await startDaemon({ daemonId, userRoot }));
   try {
-    assert.equal((await requestDaemonJsonRpcAt(daemon.endpoint, "daemon.repo.bootstrap", { rootDir, repoId: "gui-autostart-fail", personId: "person-gui", displayName: "GUI Autostart" }, 1_000)).ok, true);
+    assert.equal(
+      (
+        await requestDaemonJsonRpcAt(
+          daemon.endpoint,
+          "daemon.repo.bootstrap",
+          { rootDir, repoId: "gui-attach-only", personId: "person-gui", displayName: "GUI Attach" },
+          1_000,
+        )
+      ).ok,
+      true,
+    );
+    const bridge = createLocalGuiServiceBridge(rootDir);
+    assert.equal((await bridge.invoke("getTasks", { repoId: "gui-attach-only" })).ok, true);
     await daemon.stop();
-    chmodSync(userRoot, 0o555);
-    const failure = await createLocalGuiServiceBridge(rootDir).invoke("getTasks", { repoId: "gui-autostart-fail" }) as Failure;
-    assert.equal(failure.ok, false); assert.equal(failure.error?.code, "daemon_spawn_permission");
-    assert.match(failure.error?.hint ?? "", /permission was denied/u);
-    assert.equal(readDaemonPid(userRoot, daemonId), null, "the permission failure must happen before any daemon spawn");
+    const stopped = (await bridge.invoke("getTasks", { repoId: "gui-attach-only" })) as Failure;
+    assert.equal(stopped.ok, false);
+    assert.equal(stopped.error?.code, "daemon_unavailable");
+    assert.match(stopped.error?.hint ?? "", /GUI is attach-only/u);
+    assert.equal(readDaemonPid(userRoot, daemonId), null, "an attached GUI must not respawn a stopped service daemon");
   } finally {
-    process.env.HARNESS_DAEMON_USER_ROOT = previous; process.env.HARNESS_DAEMON_ID = previousId;
-    chmodSync(userRoot, 0o755); await daemon.stop().catch(() => undefined); rmSync(parent, { recursive: true, force: true });
+    process.env.HARNESS_DAEMON_USER_ROOT = previous;
+    process.env.HARNESS_DAEMON_ID = previousId;
+    await daemon.stop().catch(() => undefined);
+    await stopResident(userRoot, daemonId);
+    rmSync(parent, { recursive: true, force: true });
   }
 });
 
-async function stopResident(userRoot: string, daemonId: string): Promise<void> { const pid = readDaemonPid(userRoot, daemonId);
-  if (pid === null) return; terminateProcess(pid); for (let attempt = 0; attempt < 200; attempt += 1) { try { process.kill(pid, 0); } catch { return; } await new Promise((resolve) => setTimeout(resolve, 10)); } }
+test(
+  "GUI bridge reports the single-flight lock permission failure without spawning",
+  {
+    skip:
+      process.platform === "win32" || process.getuid?.() === 0 ? "requires POSIX non-root permission semantics" : false,
+  },
+  async () => {
+    const parent = mkdtempSync(path.join(tmpdir(), "ha-gui-autostart-fail-")),
+      rootDir = path.join(parent, "repo"),
+      userRoot = path.join(parent, "user"),
+      daemonId = "gui-autostart-fail";
+    const previous = process.env.HARNESS_DAEMON_USER_ROOT,
+      previousId = process.env.HARNESS_DAEMON_ID;
+    process.env.HARNESS_DAEMON_USER_ROOT = userRoot;
+    process.env.HARNESS_DAEMON_ID = daemonId;
+    const daemon = resident(await startDaemon({ daemonId, userRoot }));
+    try {
+      assert.equal(
+        (
+          await requestDaemonJsonRpcAt(
+            daemon.endpoint,
+            "daemon.repo.bootstrap",
+            { rootDir, repoId: "gui-autostart-fail", personId: "person-gui", displayName: "GUI Autostart" },
+            1_000,
+          )
+        ).ok,
+        true,
+      );
+      await daemon.stop();
+      chmodSync(userRoot, 0o555);
+      const failure = (await createLocalGuiServiceBridge(rootDir).invoke("getTasks", {
+        repoId: "gui-autostart-fail",
+      })) as Failure;
+      assert.equal(failure.ok, false);
+      assert.equal(failure.error?.code, "daemon_spawn_permission");
+      assert.match(failure.error?.hint ?? "", /permission was denied/u);
+      assert.equal(
+        readDaemonPid(userRoot, daemonId),
+        null,
+        "the permission failure must happen before any daemon spawn",
+      );
+    } finally {
+      process.env.HARNESS_DAEMON_USER_ROOT = previous;
+      process.env.HARNESS_DAEMON_ID = previousId;
+      chmodSync(userRoot, 0o755);
+      await daemon.stop().catch(() => undefined);
+      rmSync(parent, { recursive: true, force: true });
+    }
+  },
+);
+
+async function stopResident(userRoot: string, daemonId: string): Promise<void> {
+  const pid = readDaemonPid(userRoot, daemonId);
+  if (pid === null) return;
+  terminateProcess(pid);
+  for (let attempt = 0; attempt < 200; attempt += 1) {
+    try {
+      process.kill(pid, 0);
+    } catch {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+}

--- a/packages/gui/test/local-main-controls.vitest.ts
+++ b/packages/gui/test/local-main-controls.vitest.ts
@@ -2,37 +2,116 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { addLocalMainControls } from "../src/main/local-main-controls.ts";
 
-const rawRequests: string[] = [], invokes: Array<{ readonly method: string; readonly payload: unknown }> = [];
+const rawRequests: string[] = [],
+  invokes: Array<{ readonly method: string; readonly payload: unknown }> = [];
 vi.mock("../../daemon/src/client/local-json-rpc-client.ts", () => ({
-  requestDaemonJsonRpcAt: async (_socketPath: string, method: string) => { rawRequests.push(method); return { ok: true }; }
+  requestDaemonJsonRpcAt: async (_socketPath: string, method: string) => {
+    rawRequests.push(method);
+    return { ok: true };
+  },
 }));
 
-const target = async () => ({ repoId: "repo-a", socketPath: "/tmp/socket", userRoot: "/tmp/root", daemonId: "daemon-a" });
-const controls = (credentialPort?: Parameters<typeof addLocalMainControls>[0]["credentialPort"]) => addLocalMainControls({
-  bridge: { stream: (() => () => undefined) as never, invoke: async (method, payload) => { invokes.push({ method, payload }); return { schema: "command-receipt/v2", ok: true, command: "runtime-instance-create", outcome: "applied", opId: "created" }; } },
-  target, clientBuildCommit: null, ...(credentialPort ? { credentialPort } : {})
+const target = async () => ({
+  repoId: "repo-a",
+  socketPath: "/tmp/socket",
+  userRoot: "/tmp/root",
+  daemonId: "daemon-a",
 });
+const controls = (credentialPort?: Parameters<typeof addLocalMainControls>[0]["credentialPort"]) =>
+  addLocalMainControls({
+    bridge: {
+      stream: (() => () => undefined) as never,
+      invoke: async (method, payload) => {
+        invokes.push({ method, payload });
+        return {
+          schema: "command-receipt/v2",
+          ok: true,
+          command: "runtime-instance-create",
+          outcome: "applied",
+          opId: "created",
+        };
+      },
+    },
+    target,
+    clientBuildCommit: null,
+    ...(credentialPort ? { credentialPort } : {}),
+  });
 
-beforeEach(() => { rawRequests.length = 0; invokes.length = 0; });
+beforeEach(() => {
+  rawRequests.length = 0;
+  invokes.length = 0;
+});
 
 describe("local main controls runtime-instance boundary", () => {
   it("forwards every non-create runtime call through the registry-derived bridge", async () => {
-    const bridge = controls(), calls = [
-      ["listRuntimeInstances", { all: true }], ["showRuntimeInstance", { instanceId: "codex-sidecar", probe: true }],
-      ["updateRuntimeInstance", { instanceId: "codex-sidecar", enabled: false }], ["deleteRuntimeInstance", { instanceId: "codex-sidecar" }],
-      ["signInRuntimeInstance", { repoId: "repo-a", instanceId: "codex-sidecar", idempotencyKey: "login-once" }],
-      ["signOutRuntimeInstance", { repoId: "repo-a", instanceId: "codex-sidecar", idempotencyKey: "logout-once" }]
-    ] as const;
+    const bridge = controls(),
+      calls = [
+        ["listRuntimeInstances", { all: true }],
+        ["showRuntimeInstance", { instanceId: "codex-sidecar", probe: true }],
+        ["updateRuntimeInstance", { instanceId: "codex-sidecar", enabled: false }],
+        ["deleteRuntimeInstance", { instanceId: "codex-sidecar" }],
+        ["signInRuntimeInstance", { repoId: "repo-a", instanceId: "codex-sidecar", idempotencyKey: "login-once" }],
+        ["signOutRuntimeInstance", { repoId: "repo-a", instanceId: "codex-sidecar", idempotencyKey: "logout-once" }],
+      ] as const;
     for (const [method, payload] of calls) await bridge.invoke(method, payload);
     expect(invokes).toEqual(calls.map(([method, payload]) => ({ method, payload })));
     expect(rawRequests).toEqual([]);
   });
 
+  it("refuses to restart a service daemon that this GUI only attached to", async () => {
+    const target = vi.fn(async () => {
+      throw new Error("attach-only restart must not resolve a process target");
+    });
+    const bridge = addLocalMainControls({
+      bridge: {
+        stream: (() => () => undefined) as never,
+        invoke: async () => ({ ok: false, error: { code: "supervisor_required" } }),
+      },
+      target,
+      clientBuildCommit: null,
+      canRestartDaemon: () => false,
+    });
+    const pending = await bridge.invoke("requestDaemonControl", { kind: "restart", authorityRepoId: "repo-a" });
+    await vi.waitFor(async () => {
+      const receipt = await bridge.invoke("getDaemonControlReceipt", {
+        operationId: String((pending as Record<string, unknown>).operationId),
+      });
+      expect(receipt).toMatchObject({
+        ok: false,
+        phase: "failed",
+        error: { code: "restart_failed", hint: expect.stringContaining("attached to an existing service daemon") },
+      });
+    });
+    expect(target).not.toHaveBeenCalled();
+  });
+
   it("seals the API key before returning create to the registry-derived bridge", async () => {
-    const stored: Array<{ readonly reference: string; readonly secret: string }> = [], bridge = controls({ issue: () => "credential:v1:issued-ref", store: async (reference, secret) => { stored.push({ reference, secret }); }, resolve: async () => "" });
-    await bridge.invoke("createRuntimeInstance", { instanceId: "codex-sidecar", name: "Codex sidecar", kindId: "codex", installationId: "codex-install", providerId: "openai", models: ["gpt-5.6-sol"], codex: {}, authMode: "api-key", apiKey: "sk-user-input" });
+    const stored: Array<{ readonly reference: string; readonly secret: string }> = [],
+      bridge = controls({
+        issue: () => "credential:v1:issued-ref",
+        store: async (reference, secret) => {
+          stored.push({ reference, secret });
+        },
+        resolve: async () => "",
+      });
+    await bridge.invoke("createRuntimeInstance", {
+      instanceId: "codex-sidecar",
+      name: "Codex sidecar",
+      kindId: "codex",
+      installationId: "codex-install",
+      providerId: "openai",
+      models: ["gpt-5.6-sol"],
+      codex: {},
+      authMode: "api-key",
+      apiKey: "sk-user-input",
+    });
     expect(stored).toEqual([{ reference: "credential:v1:issued-ref", secret: "sk-user-input" }]);
-    expect(invokes).toEqual([{ method: "createRuntimeInstance", payload: expect.objectContaining({ credentialRef: "credential:v1:issued-ref" }) }]);
+    expect(invokes).toEqual([
+      {
+        method: "createRuntimeInstance",
+        payload: expect.objectContaining({ credentialRef: "credential:v1:issued-ref" }),
+      },
+    ]);
     expect(JSON.stringify(invokes)).not.toContain("sk-user-input");
     expect(rawRequests).toEqual([]);
   });


### PR DESCRIPTION
# English

## Summary

Make the GUI's local daemon handling attach-only for daemons it did not spawn. Today the GUI main process would restart/respawn the resident daemon from its own source tree regardless of who owns it, so killing or closing the GUI stopped a service daemon it had merely attached to (observed 4× on 2026-09-01, once nearly losing an uncommitted worker output — F-E0B51F80, F-2CD6584D). This adds a `LocalDaemonLifecycle` ownership tracker: the GUI only restarts a daemon it spawned; a service daemon it attached to is never stopped or respawned, and if that daemon stops, the GUI reports it instead of silently taking over.

## Architectural Justification

The autostart path was already attach-if-reachable; the defect was that the restart/respawn control acted on any daemon. The fix threads a single `LocalDaemonLifecycle` (`attached()` / `spawned()` / `isOwned()`) through the composition root so ownership is recorded at connect time, and gates restart on `isOwned()`. No new subsystem — one small ownership seam plus a guard at the one control point (`restartResidentDaemon`) and the one autostart point. The behavior change is a narrowing: the GUI does strictly less to daemons it did not create.

## What Changed

- `local-composition-root.ts`: `LocalDaemonLifecycle` records whether the GUI attached to or spawned the daemon; after an attached service daemon stops, stays attach-only (no silent respawn) and reports it.
- `local-main-controls.ts`: refuse GUI-initiated restart of a daemon the GUI did not spawn (`canRestartDaemon: isOwned`).
- `electron-main.ts` / `daemon-supervisor.ts`: wire the lifecycle through.
- Tests: attach-only + restart-rejection cases added to `daemon-autostart-bridge.test.ts` and `local-main-controls.vitest.ts`, including a positive mutation control (restoring respawn makes the isolated test fail as expected).

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: use the single CI-backed `Production-Delta` declaration below; do not enter a second metric.

## Machine-Readable Declarations

Production-Delta: +59/-8

## Task And Scope

- Harness task: task_9bf47fe17f48b341002002e388 (GUI daemon respawn / attach-only)
- Branch: codex/daemon-attach-only
- Public scope: packages/gui main daemon lifecycle + tests
- Private planning/evidence updated: yes (task package; fact F-AFB8E568; incident facts F-2CD6584D, F-E0B51F80)
- Out of scope: ha gui single-entry re-charter (af65, separate); packaged-runtime manual verification

## Version Impact

- Version: no version change because this narrows GUI daemon lifecycle behavior with no published surface change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope:
- Authority: task_9bf47fe17f48b341002002e388
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no

## Verification

- Base `origin/main` SHA: (post-flake-fix main; rebased clean)
- Sync method: rebase onto post-flake-fix main (no conflict)
- Public diff command: `git diff origin/main...codex/daemon-attach-only`
- [x] `node --test packages/gui/test/daemon-autostart-bridge.test.ts`: 3/3 (CEO re-run)
- [x] `vitest run test/local-main-controls.vitest.ts`: 3/3 (CEO re-run)
- [x] typecheck pass
- [x] positive mutation control (worker): reverting to respawn reproduces 2 pass / 1 fail
- [ ] GitHub Actions `rewrite-ci` passed
- [ ] CEO canonical real-machine check: start GUI, `ha daemon start --service`, close GUI → service daemon survives (runs post-merge on canonical, the very hazard this fixes)
- Not run: full local suite — GitHub CI is authority.
- Note: implemented by the Sol worker; ledger fact F-AFB8E568 recorded.

---

# 中文

## 摘要

让 GUI 对**非自身启动**的 daemon 只 attach、不代管生命周期。此前 GUI 主进程会从自己源码树 restart/respawn 常驻 daemon(无论归属),故关闭/杀掉 GUI 会停掉它只是 attach 上去的 service daemon(2026-09-01 实测 4 次,一次险丢未提交 worker 产出——F-E0B51F80、F-2CD6584D)。本 PR 加 `LocalDaemonLifecycle` 所有权跟踪:GUI 只 restart 自己 spawn 的 daemon;attach 的 service daemon 永不被停/respawn,它停了 GUI 报告而非静默接管。

## 架构辩护

autostart 路径本已是"可达即 attach";缺陷在 restart/respawn 控制对任意 daemon 生效。修法把单个 `LocalDaemonLifecycle`(`attached`/`spawned`/`isOwned`)穿过 composition root,连接时记录归属,restart 以 `isOwned()` 门控。无新子系统——一个小所有权 seam + 一个控制点(`restartResidentDaemon`)与 autostart 点的守卫。行为变化是**收窄**:GUI 对非自身创建的 daemon 做得更少。

## 变更清单

- local-composition-root.ts:LocalDaemonLifecycle 记 attach/spawn;attach 的 service daemon 停后保持 attach-only 并报告。
- local-main-controls.ts:拒绝 GUI 发起的、对非自身 spawn 的 daemon 的 restart。
- electron-main.ts/daemon-supervisor.ts:穿线。
- 测试:attach-only + restart 拒绝用例 + 阳性变异对照(恢复 respawn 则隔离测试如期失败)。

## 任务与范围

- Harness 任务:task_9bf47fe17f48b341002002e388;范围外:ha gui 唯一入口 re-charter(af65,另)。

## 治理声明

- 未触碰 protected surface;无 break-glass。授权:task_9bf47fe17f48b341002002e388。

## 验证

- CEO 亲跑 daemon-autostart-bridge 3/3、local-main-controls 3/3、typecheck 绿;阳性变异对照(worker)恢复 respawn 复现 2 pass/1 fail。
- 待 CEO canonical 真机验:起 GUI + `ha daemon start --service` + 关 GUI → service daemon 存活(合并后在 canonical 验,正是本 PR 修的 hazard)。
- 说明:Sol 实现,fact F-AFB8E568。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BE45Q2y1iZzLJNo8j7xhhL
