### PR TITLE
feat(governance): expand the single-definition gate to seven domain judgments

### DIFF
--- a/packages/application/test/task-lifecycle-transition-service.test.ts
+++ b/packages/application/test/task-lifecycle-transition-service.test.ts
@@ -470,7 +470,11 @@ test("reinstate rolls a cancelled task back to planned, active, or in_review wit
     await transition("cancelled", "CH6 batch cleanup cancelled in error", true);
     await assert.rejects(
       transition("planned", ""),
-      /auditable reason/u,
+      (error) =>
+        error instanceof Error &&
+        "code" in error &&
+        error.code === "missing_field" &&
+        /auditable reason/u.test(error.message),
       "reinstate is audit-first: an empty reason never publishes",
     );
     const planned = await transition("planned", "Owner adjudicated rollback of the batch cancellation");

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -20,7 +20,7 @@
     "node": ">=24"
   },
   "scripts": {
-    "build": "tsc -p tsconfig.build.json && node scripts/copy-assets.mjs",
+    "build": "node ../../tools/generate-daemon-status-vocabulary.mjs --check && tsc -p tsconfig.build.json && node scripts/copy-assets.mjs",
     "prepack": "npm run build"
   },
   "bin": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -20,7 +20,7 @@
     "node": ">=24"
   },
   "scripts": {
-    "build": "node ../../tools/generate-daemon-status-vocabulary.mjs --check && tsc -p tsconfig.build.json && node scripts/copy-assets.mjs",
+    "build": "tsc -p tsconfig.build.json && node scripts/copy-assets.mjs",
     "prepack": "npm run build"
   },
   "bin": {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -108,7 +108,9 @@ export async function main(argv: readonly string[] = process.argv.slice(2)): Pro
       ? Number(receipt.exitCode)
       : receipt.ok === true || receipt.schema === "entity-action-explanation/v1"
         ? 0
-        : 1;
+        : receipt.code === "missing_field"
+          ? 2
+          : 1;
   } catch (error) {
     const autostartCode = daemonAutostartFailureCode(error),
       timeoutCode = daemonResponseTimeoutCode(error),

--- a/packages/cli/test/thin-command.test.ts
+++ b/packages/cli/test/thin-command.test.ts
@@ -209,7 +209,7 @@ test("capabilities is an exact-set projection of the command contract", () => {
   });
 });
 
-test("task transition conditional inputs preserve audited cancellation and reinstatement", () => {
+test("task transition leaves lifecycle eligibility to the kernel", () => {
   for (const argv of [
     ["task", "transition", "task-1", "planned"],
     ["task", "transition", "task-1", "cancelled"],
@@ -217,7 +217,7 @@ test("task transition conditional inputs preserve audited cancellation and reins
     ["task", "transition", "task-1", "cancelled", "--reason", "Scope withdrawn"],
     ["task", "transition", "task-1", "active", "--force"],
   ])
-    assert.equal(parseThinCommand(argv).ok, false, argv.join(" "));
+    assert.equal(parseThinCommand(argv).ok, true, argv.join(" "));
   assert.equal(
     parseThinCommand(["task", "transition", "task-1", "planned", "--reason", "Owner adjudicated rollback"]).ok,
     true,

--- a/packages/daemon/src/protocol/daemon-protocol-commands-task-surface.ts
+++ b/packages/daemon/src/protocol/daemon-protocol-commands-task-surface.ts
@@ -66,33 +66,14 @@ export const taskSurfaceProtocolCommands = Object.freeze([
     summary: "Move lifecycle status; done and in_review remain reserved for complete and submit.",
     method: "repo.task.run",
     inputs: [
-      cliInput(
-        "--force",
-        "boolean",
-        false,
-        {
-          code: "invalid_field",
-          nextAction: "Audited cancellation requires --force; use it only when the target status is cancelled.",
-        },
-        {
-          field: "force",
-          requiredWhen: { field: "status", values: ["cancelled"] },
-          allowedWhen: { field: "status", values: ["cancelled"] },
-        },
-      ),
-      cliInput(
-        "--reason",
-        "single",
-        false,
-        {
-          code: "missing_field",
-          nextAction: "Forced cancellation and cancelled-task reinstatement require --reason <auditable-reason>.",
-        },
-        {
-          field: "reason",
-          requiredWhen: { field: "status", values: ["planned", "cancelled"] },
-        },
-      ),
+      cliInput("--force", "boolean", false, {
+        code: "invalid_field",
+        nextAction: "Use --force once.",
+      }),
+      cliInput("--reason", "single", false, {
+        code: "missing_field",
+        nextAction: "Use one non-empty --reason.",
+      }),
     ],
   }),
   defineLedgerWriteCommand({

--- a/packages/daemon/src/protocol/daemon-protocol-validate-projections.ts
+++ b/packages/daemon/src/protocol/daemon-protocol-validate-projections.ts
@@ -15,7 +15,7 @@ import {
   warningArray,
 } from "./daemon-protocol-validate-entities.ts";
 import { blockingAssessment, queryPageRow } from "./daemon-protocol-validate-task.ts";
-import { decisionStateWords, taskStatusWords } from "./daemon-protocol-vocabulary.ts";
+import { decisionStateWords, factLivenessWords, taskStatusWords } from "./daemon-protocol-vocabulary.ts";
 import { isJsonObject, type JsonObject } from "./json-rpc-types.ts";
 
 export function agendaTask(value: unknown): boolean {
@@ -208,7 +208,7 @@ function fullFactInvalid(row: unknown): boolean {
       "liveness",
     ]) ||
     row.schema !== "task-fact-row/v1" ||
-    !["standing", "superseded_fact"].includes(String(row.liveness)) ||
+    !statusWord(factLivenessWords, row.liveness) ||
     !["low", "medium", "high"].includes(String(row.confidence)) ||
     !["semantic", "episodic", "procedural"].includes(String(row.memoryClass)) ||
     !stringArray(row.memoryTags) ||

--- a/packages/daemon/src/protocol/daemon-protocol-vocabulary.ts
+++ b/packages/daemon/src/protocol/daemon-protocol-vocabulary.ts
@@ -1,6 +1,20 @@
 import type { CredentialKind, DaemonRepoMode, PeopleCommandClass } from "../../../kernel/src/index.ts";
 
+// daemon-status-vocabulary:generated:start
 export const taskStatusWords = ["planned", "active", "blocked", "in_review", "done", "cancelled"] as const;
+
+export const decisionStateWords = [
+  "proposed",
+  "in_effect",
+  "rejected",
+  "deferred",
+  "superseded",
+  "outcome_retired",
+] as const;
+
+export const factLivenessWords = ["standing", "superseded_fact"] as const;
+
+// daemon-status-vocabulary:generated:end
 
 export const executionV1StateWords = ["active", "submitted", "changes_requested", "accepted"] as const;
 
@@ -39,15 +53,6 @@ export const relationOriginWords = ["declared", "imported_snapshot", "generated"
 export const packageDispositionWords = ["active", "archived", "tombstoned"] as const;
 
 export const reviewVerdictWords = ["approved", "changes_requested", "dismissed"] as const;
-
-export const decisionStateWords = [
-  "proposed",
-  "in_effect",
-  "rejected",
-  "deferred",
-  "superseded",
-  "outcome_retired",
-] as const;
 
 export const receiptOutcomeWords = ["applied", "pending", "no_changes", "indeterminate", "op_rejected"] as const;
 

--- a/packages/daemon/src/protocol/daemon-protocol.contract.ts
+++ b/packages/daemon/src/protocol/daemon-protocol.contract.ts
@@ -37,12 +37,11 @@ export {
 
 export const currentDaemonProtocolVersion = Object.freeze({ major: 1, minor: 0 }) satisfies ContractVersion;
 
-// Wire-validator mirrors of the kernel status vocabularies (register:
+// Build-time projections of the kernel status vocabularies (register:
 // packages/kernel/src/domain/status-vocabulary.ts, blueprint 铁律四). This module sits
 // on the CLI's eager startup path, so it must not import the kernel barrel — the p50
 // overhead gate refuses eager module growth — and deep kernel imports are restricted.
-// The mirrors stay plain data; the status-vocabulary ratchet gate locks them against
-// the kernel vocabularies so they cannot drift.
+// The status-vocabulary ratchet rejects a stale generated region.
 export const daemonProtocolMethods = Object.freeze([
   {
     id: "protocol.hello",

--- a/packages/daemon/src/repo-cell-command.ts
+++ b/packages/daemon/src/repo-cell-command.ts
@@ -103,9 +103,7 @@ export function buildCommand(
         "invalid_transition",
         "Use planned, active, blocked, in_review, done, or cancelled as the target status.",
       );
-    const suppliedReason = typeof action.reason === "string" && action.reason.trim() ? action.reason.trim() : null,
-      requiresExplicitReason = status === "cancelled" || snapshot.task?.status === "cancelled",
-      reason = suppliedReason ?? (requiresExplicitReason ? "" : `Explicit lifecycle transition to ${status}`);
+    const reason = typeof action.reason === "string" && action.reason.trim() ? action.reason.trim() : "";
     return normalizeTaskLifecycleCommand(bound, {
       type: "TransitionTask",
       taskId,

--- a/packages/daemon/test/task-surface-status-archive.integration.test.ts
+++ b/packages/daemon/test/task-surface-status-archive.integration.test.ts
@@ -36,19 +36,16 @@ test("cancellation and reinstatement are audited and terminal tasks require supe
       },
       binding,
     );
-    assert.equal(
-      (
-        await cell.run(
-          {
-            kind: "task-transition",
-            taskId: "task_terminal",
-            status: "cancelled",
-          },
-          binding,
-        )
-      ).outcome,
-      "op_rejected",
+    const bareCancellation = await cell.run(
+      {
+        kind: "task-transition",
+        taskId: "task_terminal",
+        status: "cancelled",
+      },
+      binding,
     );
+    assert.equal(bareCancellation.outcome, "op_rejected");
+    assert.equal(bareCancellation.code, "missing_field");
     const cancelled = await cell.run(
       {
         kind: "task-transition",
@@ -65,7 +62,7 @@ test("cancellation and reinstatement are audited and terminal tasks require supe
       binding,
     );
     assert.equal(bareReinstate.outcome, "op_rejected");
-    assert.equal(bareReinstate.code, "invalid_transition");
+    assert.equal(bareReinstate.code, "missing_field");
     assert.match(String(bareReinstate.nextAction), /auditable reason/u);
     const expectedVersion = cancelled.revision,
       [reinstated, staleReinstate] = await Promise.all([

--- a/packages/kernel/src/domain/fact-event.ts
+++ b/packages/kernel/src/domain/fact-event.ts
@@ -18,6 +18,7 @@ import { codePoints, requiredWithOptional } from "./event-validation.ts";
 import { includes } from "./decision-event-validation-shared.ts";
 import { timestamp } from "./timestamp.ts";
 import { validateSessionIdentity, validateSessionProvenance, type SessionProvenanceV1 } from "./agent-runtime.ts";
+import type { FactLiveness } from "./fact-liveness.ts";
 
 export const factConfidenceLevels = ["low", "medium", "high"] as const;
 export const factMemoryClasses = ["semantic", "episodic", "procedural"] as const;
@@ -50,7 +51,7 @@ export interface FactDocumentRecord {
   readonly evidenceSource: string;
   readonly observedAt: string;
   readonly confidence: FactConfidence;
-  readonly state: "standing" | "superseded_fact";
+  readonly state: FactLiveness;
   readonly workspaceRevision: number;
 }
 export interface FactContentBlob {

--- a/packages/kernel/src/domain/fact-liveness.ts
+++ b/packages/kernel/src/domain/fact-liveness.ts
@@ -1,4 +1,5 @@
-export type FactLiveness = "standing" | "superseded_fact";
+export const factLivenessStates = ["standing", "superseded_fact"] as const;
+export type FactLiveness = (typeof factLivenessStates)[number];
 export interface FactLivenessInput {
   readonly ref: string;
 }

--- a/packages/kernel/src/domain/index.ts
+++ b/packages/kernel/src/domain/index.ts
@@ -69,8 +69,6 @@ export {
 } from "./closeout-readiness.ts";
 export type { CloseoutReadiness, CloseoutSnapshot } from "./closeout-readiness.ts";
 export { blockingOf } from "./task-blocking.ts";
-export { queryPayloadValidation } from "./query-payload-validation.ts";
-export type { QueryPayloadKind, QueryPayloadValidationIssue } from "./query-payload-validation.ts";
 
 export {
   assessTransitionDocument,

--- a/packages/kernel/src/domain/index.ts
+++ b/packages/kernel/src/domain/index.ts
@@ -69,6 +69,8 @@ export {
 } from "./closeout-readiness.ts";
 export type { CloseoutReadiness, CloseoutSnapshot } from "./closeout-readiness.ts";
 export { blockingOf } from "./task-blocking.ts";
+export { queryPayloadValidation } from "./query-payload-validation.ts";
+export type { QueryPayloadKind, QueryPayloadValidationIssue } from "./query-payload-validation.ts";
 
 export {
   assessTransitionDocument,

--- a/packages/kernel/src/domain/query-payload-validation.ts
+++ b/packages/kernel/src/domain/query-payload-validation.ts
@@ -1,0 +1,49 @@
+/** @slice-activation G4 registers the authority before the C phase-2 query
+ * cutover removes the two in-flight consumers. */
+import { relationStates } from "./entity-relation.ts";
+import { domainStatuses } from "./lifecycle-status.ts";
+import { timestamp } from "./timestamp.ts";
+
+export type QueryPayloadKind = "task-list" | "relation-graph";
+
+export type QueryPayloadValidationIssue =
+  | "payload_not_object"
+  | "status_invalid"
+  | "changed_after_revision_invalid"
+  | "time_window_invalid"
+  | "limit_invalid"
+  | "cursor_invalid";
+
+/** Canonical domain constraints shared by query transport and execution adapters. */
+export function queryPayloadValidation(kind: QueryPayloadKind, value: unknown): readonly QueryPayloadValidationIssue[] {
+  if (value === undefined) return [];
+  if (!isRecord(value)) return ["payload_not_object"];
+  const issues: QueryPayloadValidationIssue[] = [],
+    status = value.status,
+    changedAfterRevision = value.changedAfterRevision,
+    after = value.updatedAfter,
+    before = value.updatedBefore,
+    limit = value.limit,
+    cursor = value.cursor,
+    statusWords = kind === "task-list" ? domainStatuses : relationStates;
+  if (status !== undefined && !(statusWords as readonly unknown[]).includes(status)) issues.push("status_invalid");
+  if (
+    kind === "task-list" &&
+    changedAfterRevision !== undefined &&
+    (!Number.isInteger(changedAfterRevision) || Number(changedAfterRevision) < 0)
+  )
+    issues.push("changed_after_revision_invalid");
+  if (
+    [after, before].some((item) => item !== undefined && !timestamp(item)) ||
+    (typeof after === "string" && typeof before === "string" && after > before)
+  )
+    issues.push("time_window_invalid");
+  if (limit !== undefined && (!Number.isInteger(limit) || Number(limit) < 1 || Number(limit) > 500))
+    issues.push("limit_invalid");
+  if (cursor !== undefined && (typeof cursor !== "string" || cursor.length === 0)) issues.push("cursor_invalid");
+  return issues;
+}
+
+function isRecord(value: unknown): value is Readonly<Record<string, unknown>> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/packages/kernel/src/domain/query-payload-validation.ts
+++ b/packages/kernel/src/domain/query-payload-validation.ts
@@ -1,6 +1,7 @@
 /** @slice-activation G4 registers the authority before the C phase-2 query
  * cutover removes the two in-flight consumers. */
 import { relationStates } from "./entity-relation.ts";
+import { isRecord } from "./write-chain.contract.ts";
 import { domainStatuses } from "./lifecycle-status.ts";
 import { timestamp } from "./timestamp.ts";
 
@@ -42,8 +43,4 @@ export function queryPayloadValidation(kind: QueryPayloadKind, value: unknown): 
     issues.push("limit_invalid");
   if (cursor !== undefined && (typeof cursor !== "string" || cursor.length === 0)) issues.push("cursor_invalid");
   return issues;
-}
-
-function isRecord(value: unknown): value is Readonly<Record<string, unknown>> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
 }

--- a/packages/kernel/src/domain/status-vocabulary-catalog.ts
+++ b/packages/kernel/src/domain/status-vocabulary-catalog.ts
@@ -1,5 +1,8 @@
 import type { StatusVocabulary } from "./status-vocabulary-types.ts";
+import { decisionStates } from "./decision-event-types.ts";
 import { relationStates } from "./entity-relation.ts";
+import { factLivenessStates } from "./fact-liveness.ts";
+import { domainStatuses } from "./lifecycle-status.ts";
 
 export const statusVocabularies: readonly StatusVocabulary[] = [
   {
@@ -24,7 +27,7 @@ export const statusVocabularies: readonly StatusVocabulary[] = [
     field: "status",
     module: "packages/kernel/src/domain/lifecycle-status.ts",
     anchor: "domainStatuses",
-    words: ["planned", "active", "blocked", "in_review", "done", "cancelled"],
+    words: domainStatuses,
   },
   {
     id: "task.status.open",
@@ -82,7 +85,7 @@ export const statusVocabularies: readonly StatusVocabulary[] = [
     field: "state",
     module: "packages/kernel/src/domain/decision-event-types.ts",
     anchor: "decisionStates",
-    words: ["proposed", "in_effect", "rejected", "deferred", "superseded", "outcome_retired"],
+    words: decisionStates,
   },
   {
     id: "decision.judgment.target",
@@ -184,11 +187,9 @@ export const statusVocabularies: readonly StatusVocabulary[] = [
     entity: "FactRecord",
     field: "liveness",
     module: "packages/kernel/src/domain/fact-liveness.ts",
-    anchor: "FactLiveness",
-    words: ["standing", "superseded_fact"],
-    note:
-      "Single domain derivation of fact liveness (factLiveness); same two words and meanings as " +
-      "fact-record.state, now computed in one place.",
+    anchor: "factLivenessStates",
+    words: factLivenessStates,
+    note: "Single domain derivation of both projected liveness and authored Fact record state.",
   },
   {
     id: "closeout.gate-status",
@@ -235,17 +236,6 @@ export const statusVocabularies: readonly StatusVocabulary[] = [
     words: ["active", "archived", "tombstoned"],
     subsetOf: "package.disposition",
     note: "WIP snapshot entry mirror of the package disposition vocabulary.",
-  },
-  {
-    id: "fact-record.state",
-    entity: "FactRecord",
-    field: "state",
-    module: "packages/kernel/src/domain/fact-event.ts",
-    anchor: "#state",
-    words: ["standing", "superseded_fact"],
-    note:
-      "Per-fact row state in authored facts documents; the SQL projection derives the same two words from active " +
-      "supersedes-fact edges.",
   },
   {
     id: "review.verdict",
@@ -378,7 +368,7 @@ export const statusVocabularies: readonly StatusVocabulary[] = [
     field: "status",
     module: "packages/gui/src/renderer/model/types.ts",
     anchor: "CanonicalStatus",
-    words: ["planned", "active", "blocked", "in_review", "done", "cancelled"],
+    words: domainStatuses,
     mirrorOf: "task.status",
   },
   {
@@ -411,16 +401,15 @@ export const statusVocabularies: readonly StatusVocabulary[] = [
     mirrorOf: "package.disposition",
   },
 
-  // Daemon wire-protocol mirrors. The contract sits on the CLI's eager startup path, so
-  // it must not import the kernel barrel (the p50 overhead gate refuses eager module
-  // growth); the mirrors stay plain data and the ratchet gate locks them to the kernel.
+  // Daemon wire-protocol vocabularies are build-time projections because their eager
+  // CLI path cannot load the kernel barrel. The ratchet rejects a stale generated region.
   {
     id: "daemon.task.status",
     entity: "DaemonWire",
     field: "status",
     module: "packages/daemon/src/protocol/daemon-protocol-vocabulary.ts",
     anchor: "taskStatusWords",
-    words: ["planned", "active", "blocked", "in_review", "done", "cancelled"],
+    words: domainStatuses,
     mirrorOf: "task.status",
   },
   {
@@ -483,8 +472,17 @@ export const statusVocabularies: readonly StatusVocabulary[] = [
     field: "state",
     module: "packages/daemon/src/protocol/daemon-protocol-vocabulary.ts",
     anchor: "decisionStateWords",
-    words: ["proposed", "in_effect", "rejected", "deferred", "superseded", "outcome_retired"],
+    words: decisionStates,
     mirrorOf: "decision.state",
+  },
+  {
+    id: "daemon.fact.liveness",
+    entity: "DaemonWire",
+    field: "liveness",
+    module: "packages/daemon/src/protocol/daemon-protocol-vocabulary.ts",
+    anchor: "factLivenessWords",
+    words: factLivenessStates,
+    mirrorOf: "fact.liveness",
   },
   {
     id: "daemon.receipt.outcome",

--- a/packages/kernel/src/domain/task-lifecycle-command-transitions.ts
+++ b/packages/kernel/src/domain/task-lifecycle-command-transitions.ts
@@ -213,10 +213,7 @@ function transitionTask(
       status,
       ...(status === "cancelled" ? { pinned: false } : {}),
     },
-    reason =
-      status === "active" && !isNonEmptyString(command.reason)
-        ? "Explicit lifecycle transition to active"
-        : command.reason,
+    reason = isNonEmptyString(command.reason) ? command.reason : `Explicit lifecycle transition to ${status}`,
     mutation = { command: "transition" as const, reason, fields: ["status"] };
   return {
     snapshot: { ...snapshot, revision: command.workspaceRevision, task },
@@ -232,7 +229,7 @@ export const block: Transition = {
   from: "planned|active|in_review",
   proof: [],
   eventType: "task_transitioned",
-  matches: (command) => command.type === "TransitionTask" && command.status === "blocked" && !command.force,
+  matches: (command) => command.type === "TransitionTask" && command.status === "blocked",
   validate: (snapshot, raw) => {
     const command = raw as TransitionTaskCommand,
       issues = revisionIssues(snapshot, command);
@@ -243,8 +240,6 @@ export const block: Transition = {
           "BlockTask requires an unleased planned, active, or in_review task",
         ),
       );
-    if (!isNonEmptyString(command.reason))
-      issues.push(lifecycleContractIssue("invalid_schema", "BlockTask requires a reason"));
     return issues;
   },
   reduce: (snapshot, raw) => transitionTask(snapshot, raw as TransitionTaskCommand, "blocked"),
@@ -262,8 +257,7 @@ export const reinstate: Transition = {
   matches: (command, snapshot) =>
     command.type === "TransitionTask" &&
     (reinstateTaskTargets as readonly DomainStatus[]).includes(command.status) &&
-    snapshot.task?.status === "cancelled" &&
-    !command.force,
+    snapshot.task?.status === "cancelled",
   validate: (snapshot, raw) => {
     const command = raw as TransitionTaskCommand,
       issues = revisionIssues(snapshot, command);
@@ -280,7 +274,7 @@ export const reinstate: Transition = {
         ),
       );
     if (!isNonEmptyString(command.reason))
-      issues.push(lifecycleContractIssue("invalid_schema", "ReinstateTask requires an auditable reason"));
+      issues.push(lifecycleContractIssue("missing_field", "ReinstateTask requires an auditable reason"));
     return issues;
   },
   reduce: (snapshot, raw) =>
@@ -297,10 +291,7 @@ export const returnToPlanned: Transition = {
   proof: ["auditedReason"],
   eventType: "task_transitioned",
   matches: (command, snapshot) =>
-    command.type === "TransitionTask" &&
-    command.status === "planned" &&
-    snapshot.task?.status === "active" &&
-    !command.force,
+    command.type === "TransitionTask" && command.status === "planned" && snapshot.task?.status === "active",
   validate: (snapshot, raw) => {
     const command = raw as TransitionTaskCommand,
       issues = revisionIssues(snapshot, command);
@@ -316,7 +307,7 @@ export const returnToPlanned: Transition = {
         ),
       );
     if (!isNonEmptyString(command.reason))
-      issues.push(lifecycleContractIssue("invalid_schema", "ReturnToPlanned requires an auditable reason"));
+      issues.push(lifecycleContractIssue("missing_field", "ReturnToPlanned requires an auditable reason"));
     return issues;
   },
   reduce: (snapshot, raw) => transitionTask(snapshot, raw as TransitionTaskCommand, "planned"),
@@ -327,7 +318,7 @@ export const unblock: Transition = {
   from: "blocked",
   proof: [],
   eventType: "task_transitioned",
-  matches: (command) => command.type === "TransitionTask" && command.status === "active" && !command.force,
+  matches: (command) => command.type === "TransitionTask" && command.status === "active",
   validate: (snapshot, raw) => {
     const command = raw as TransitionTaskCommand,
       issues = revisionIssues(snapshot, command);

--- a/packages/kernel/src/domain/task-lifecycle-command-transitions.ts
+++ b/packages/kernel/src/domain/task-lifecycle-command-transitions.ts
@@ -232,7 +232,7 @@ export const block: Transition = {
   from: "planned|active|in_review",
   proof: [],
   eventType: "task_transitioned",
-  matches: (command) => command.type === "TransitionTask" && command.status === "blocked",
+  matches: (command) => command.type === "TransitionTask" && command.status === "blocked" && !command.force,
   validate: (snapshot, raw) => {
     const command = raw as TransitionTaskCommand,
       issues = revisionIssues(snapshot, command);
@@ -262,7 +262,8 @@ export const reinstate: Transition = {
   matches: (command, snapshot) =>
     command.type === "TransitionTask" &&
     (reinstateTaskTargets as readonly DomainStatus[]).includes(command.status) &&
-    snapshot.task?.status === "cancelled",
+    snapshot.task?.status === "cancelled" &&
+    !command.force,
   validate: (snapshot, raw) => {
     const command = raw as TransitionTaskCommand,
       issues = revisionIssues(snapshot, command);
@@ -296,7 +297,10 @@ export const returnToPlanned: Transition = {
   proof: ["auditedReason"],
   eventType: "task_transitioned",
   matches: (command, snapshot) =>
-    command.type === "TransitionTask" && command.status === "planned" && snapshot.task?.status === "active",
+    command.type === "TransitionTask" &&
+    command.status === "planned" &&
+    snapshot.task?.status === "active" &&
+    !command.force,
   validate: (snapshot, raw) => {
     const command = raw as TransitionTaskCommand,
       issues = revisionIssues(snapshot, command);
@@ -323,7 +327,7 @@ export const unblock: Transition = {
   from: "blocked",
   proof: [],
   eventType: "task_transitioned",
-  matches: (command) => command.type === "TransitionTask" && command.status === "active",
+  matches: (command) => command.type === "TransitionTask" && command.status === "active" && !command.force,
   validate: (snapshot, raw) => {
     const command = raw as TransitionTaskCommand,
       issues = revisionIssues(snapshot, command);

--- a/packages/kernel/src/domain/task-lifecycle-contract-support.ts
+++ b/packages/kernel/src/domain/task-lifecycle-contract-support.ts
@@ -179,15 +179,16 @@ export function canonicalDocumentPaths(value: unknown): value is readonly string
   }
 }
 export function errorCode(issues: readonly ContractValidationIssue[]): TaskLifecycleErrorCode {
-  return issues.some((value) => value.code === "manual_intervention_required")
-    ? "manual_intervention_required"
-    : issues.some(
-          (value) => value.code.includes("graph") || value.code.includes("edge") || value.code.includes("atomicity"),
-        )
-      ? "invalid_graph"
-      : issues.some((value) => value.code === "invalid_proof")
-        ? "invalid_proof"
-        : "invalid_transition";
+  if (issues.some((value) => value.code === "missing_field" || value.code === "force_reason_required"))
+    return "missing_field";
+  if (issues.some((value) => value.code === "manual_intervention_required")) return "manual_intervention_required";
+  if (
+    issues.some(
+      (value) => value.code.includes("graph") || value.code.includes("edge") || value.code.includes("atomicity"),
+    )
+  )
+    return "invalid_graph";
+  return issues.some((value) => value.code === "invalid_proof") ? "invalid_proof" : "invalid_transition";
 }
 export function lifecycleContractIssue(code: string, message: string): ContractValidationIssue {
   return { code, message };

--- a/packages/kernel/src/domain/task-lifecycle-event.ts
+++ b/packages/kernel/src/domain/task-lifecycle-event.ts
@@ -232,6 +232,7 @@ export type TaskEventV1 =
   | LeaseReleasedEvent
   | TaskMutationEvent;
 export type TaskLifecycleErrorCode =
+  | "missing_field"
   | "invalid_schema"
   | "invalid_transition"
   | "invalid_proof"

--- a/packages/kernel/test/query-payload-validation.test.ts
+++ b/packages/kernel/test/query-payload-validation.test.ts
@@ -1,0 +1,35 @@
+// harness-test-tier: fast
+import assert from "node:assert/strict";
+import test from "node:test";
+import { queryPayloadValidation } from "../src/domain/query-payload-validation.ts";
+
+test("query payload validation accepts task and relation query facets", () => {
+  assert.deepEqual(
+    queryPayloadValidation("task-list", {
+      status: "blocked",
+      changedAfterRevision: 0,
+      updatedAfter: "2026-08-01T00:00:00.000Z",
+      updatedBefore: "2026-08-31T00:00:00.000Z",
+      limit: 500,
+      cursor: "next-page",
+    }),
+    [],
+  );
+  assert.deepEqual(queryPayloadValidation("relation-graph", { status: "edge_retired", limit: 1 }), []);
+});
+
+test("query payload validation owns status, revision, time, limit, and cursor rules", () => {
+  assert.deepEqual(
+    queryPayloadValidation("task-list", {
+      status: "edge_retired",
+      changedAfterRevision: -1,
+      updatedAfter: "2026-09-01T00:00:00.000Z",
+      updatedBefore: "2026-08-01T00:00:00.000Z",
+      limit: 0,
+      cursor: "",
+    }),
+    ["status_invalid", "changed_after_revision_invalid", "time_window_invalid", "limit_invalid", "cursor_invalid"],
+  );
+  assert.deepEqual(queryPayloadValidation("relation-graph", { changedAfterRevision: -1 }), []);
+  assert.deepEqual(queryPayloadValidation("task-list", []), ["payload_not_object"]);
+});

--- a/tools/check-domain-judgment-single-definition.mjs
+++ b/tools/check-domain-judgment-single-definition.mjs
@@ -7,12 +7,49 @@ import { readdirSync, readFileSync } from "node:fs";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 
-const judgments = ["closeoutReadiness", "factLiveness", "coverageOf", "blockingOf"];
-const canonical = new Map([
-  ["closeoutReadiness", "packages/kernel/src/domain/closeout-readiness.ts"],
-  ["factLiveness", "packages/kernel/src/domain/fact-liveness.ts"],
-  ["coverageOf", "packages/kernel/src/domain/decision-coverage.ts"],
-  ["blockingOf", "packages/kernel/src/domain/task-blocking.ts"],
+const judgments = Object.freeze([
+  {
+    id: "closeoutReadiness",
+    symbol: "closeoutReadiness",
+    canonical: "packages/kernel/src/domain/closeout-readiness.ts",
+    declaration: "function",
+  },
+  {
+    id: "factLiveness",
+    symbol: "factLiveness",
+    canonical: "packages/kernel/src/domain/fact-liveness.ts",
+    declaration: "function",
+  },
+  {
+    id: "coverageOf",
+    symbol: "coverageOf",
+    canonical: "packages/kernel/src/domain/decision-coverage.ts",
+    declaration: "function",
+  },
+  {
+    id: "blockingOf",
+    symbol: "blockingOf",
+    canonical: "packages/kernel/src/domain/task-blocking.ts",
+    declaration: "function",
+  },
+  {
+    id: "startability",
+    symbol: "canStartExecution",
+    canonical: "packages/kernel/src/domain/task-lifecycle-command-transitions.ts",
+    declaration: "function",
+  },
+  {
+    id: "queryPayloadValidation",
+    symbol: "queryPayloadValidation",
+    canonical: "packages/kernel/src/domain/query-payload-validation.ts",
+    declaration: "function",
+  },
+  {
+    id: "statusVocabulary",
+    symbol: "statusVocabularies",
+    canonical: "packages/kernel/src/domain/status-vocabulary-catalog.ts",
+    declaration: "const",
+  },
 ]);
 const requiredConsumers = new Map([
   ["packages/kernel/src/domain/task-lifecycle-review-transitions.ts", "closeoutReadiness("],
@@ -23,21 +60,35 @@ const requiredConsumers = new Map([
   ["packages/kernel/src/projection/cold-rebuild-source.ts#liveness", "factLiveness("],
   ["packages/daemon/src/repo-cell.ts#closeout", "closeoutReadiness("],
   ["packages/daemon/src/repo-cell.ts#blocking", "blockingOf("],
+  ["packages/kernel/src/domain/task-action-capability.ts", "canStartExecution("],
+  ["packages/kernel/src/domain/status-vocabulary.ts", 'from "./status-vocabulary-catalog.ts"'],
+  [
+    "packages/daemon/src/protocol/daemon-protocol-vocabulary.ts#generated-start",
+    "// daemon-status-vocabulary:generated:start",
+  ],
+  ["packages/daemon/src/protocol/daemon-protocol-vocabulary.ts#task", "export const taskStatusWords = ["],
+  ["packages/daemon/src/protocol/daemon-protocol-vocabulary.ts#decision", "export const decisionStateWords = ["],
+  ["packages/daemon/src/protocol/daemon-protocol-vocabulary.ts#fact", "export const factLivenessWords = ["],
 ]);
 
 export function checkDomainJudgmentSingleDefinition(root = process.cwd()) {
   const findings = [],
     files = walk(root, path.join(root, "packages"));
-  for (const name of judgments) {
-    const definition = new RegExp(`(?:export\\s+)?function\\s+${name}\\s*\\(`, "gu"),
+  for (const judgment of judgments) {
+    const definition =
+        judgment.declaration === "function"
+          ? new RegExp(`(?:export\\s+)?function\\s+${judgment.symbol}\\s*\\(`, "gu")
+          : new RegExp(`(?:export\\s+)?const\\s+${judgment.symbol}(?:\\s*:[^=]+)?\\s*=`, "gu"),
       hits = [];
     for (const file of files) {
       const count = [...readFileSync(file, "utf8").matchAll(definition)].length;
       for (let index = 0; index < count; index += 1) hits.push(relative(root, file));
     }
-    const expected = canonical.get(name);
-    if (hits.length !== 1 || hits[0] !== expected)
-      findings.push(`${name}: expected one definition at ${expected}; found ${hits.length ? hits.join(", ") : "none"}`);
+    if (hits.length !== 1 || hits[0] !== judgment.canonical)
+      findings.push(
+        `${judgment.id}: expected one definition of ${judgment.symbol} at ${judgment.canonical}; ` +
+          `found ${hits.length ? hits.join(", ") : "none"}`,
+      );
   }
   for (const [key, call] of requiredConsumers) {
     const file = key.split("#")[0],
@@ -56,6 +107,8 @@ export function checkDomainJudgmentSingleDefinition(root = process.cwd()) {
   const taskAdapter = read(root, "packages/gui/src/renderer/task-adapter.ts"),
     triadic = read(root, "packages/gui/src/renderer/triadic-data.ts"),
     guiTriadic = read(root, "packages/gui/src/renderer/model/triadic.ts");
+  const daemonDispatch = read(root, "packages/daemon/src/repo-cell-action-dispatch.ts"),
+    taskSurface = read(root, "packages/daemon/src/protocol/daemon-protocol-commands-task-surface.ts");
   if (/function\s+(?:deriveBlocking|closeoutReadiness|gateResults)\s*\(/u.test(taskAdapter))
     findings.push("packages/gui/src/renderer/task-adapter.ts: recomputes closeout or blocking judgment");
   if (
@@ -66,6 +119,16 @@ export function checkDomainJudgmentSingleDefinition(root = process.cwd()) {
     findings.push("packages/gui/src/renderer/triadic-data.ts: must consume projected fact liveness");
   if (/function\s+coverageOf\s*\(/u.test(guiTriadic))
     findings.push("packages/gui/src/renderer/model/triadic.ts: carries a renderer coverage algorithm");
+  if (
+    /preview\s*&&\s*!current\.snapshot\.task|preview\s*&&\s*current\.snapshot\.lease|isTerminalStatus\(current\.snapshot\.task\.status\)/u.test(
+      daemonDispatch,
+    )
+  )
+    findings.push("packages/daemon/src/repo-cell-action-dispatch.ts: carries a second Task startability preview");
+  if (/(?:requiredWhen|allowedWhen):\s*\{\s*field:\s*"status"/su.test(taskSurface))
+    findings.push(
+      "packages/daemon/src/protocol/daemon-protocol-commands-task-surface.ts: projects cancellation eligibility into the CLI",
+    );
   return findings;
 }
 
@@ -108,7 +171,7 @@ async function main() {
     for (const finding of findings) console.error(`- ${finding}`);
     process.exit(1);
   }
-  console.log("Domain judgment single-definition check passed (four judgments resolve to kernel domain services).");
+  console.log("Domain judgment single-definition check passed (seven judgments resolve to kernel domain services).");
 }
 const invokedDirectly =
   process.argv[1] !== undefined && import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href;

--- a/tools/check-domain-judgment-single-definition.test.mjs
+++ b/tools/check-domain-judgment-single-definition.test.mjs
@@ -8,13 +8,48 @@ import { checkDomainJudgmentSingleDefinition } from "./check-domain-judgment-sin
 const repoRoot = path.resolve(import.meta.dirname, "..");
 
 test("domain judgment single-definition gate accepts the repository", () => {
-  const result = spawnSync("node", [path.join(repoRoot, "tools/check-domain-judgment-single-definition.mjs")], { cwd: repoRoot, encoding: "utf8" });
+  const result = spawnSync("node", [path.join(repoRoot, "tools/check-domain-judgment-single-definition.mjs")], {
+    cwd: repoRoot,
+    encoding: "utf8",
+  });
   assert.equal(result.status, 0, result.stderr);
-  assert.match(result.stdout, /four judgments resolve to kernel domain services/u);
+  assert.match(result.stdout, /seven judgments resolve to kernel domain services/u);
 });
 
 test("positive fixture: a renderer readiness definition is refused", () => {
   const fixture = path.join(repoRoot, "tools/fixtures/domain-judgment-single-definition");
   const findings = checkDomainJudgmentSingleDefinition(fixture);
-  assert.ok(findings.some((finding) => finding.includes("closeoutReadiness") && finding.includes("packages/gui/src/duplicate-readiness.ts")), findings.join("\n"));
+  assert.ok(
+    findings.some(
+      (finding) => finding.includes("closeoutReadiness") && finding.includes("packages/gui/src/duplicate-readiness.ts"),
+    ),
+    findings.join("\n"),
+  );
+});
+
+test("positive fixture: startability, query validation, and status vocabulary copies are refused", () => {
+  const fixture = path.join(repoRoot, "tools/fixtures/domain-judgment-single-definition");
+  const findings = checkDomainJudgmentSingleDefinition(fixture);
+  for (const [judgment, file] of [
+    ["startability", "packages/daemon/src/duplicate-judgments.ts"],
+    ["queryPayloadValidation", "packages/daemon/src/duplicate-judgments.ts"],
+    ["statusVocabulary", "packages/daemon/src/duplicate-judgments.ts"],
+  ])
+    assert.ok(
+      findings.some((finding) => finding.includes(judgment) && finding.includes(file)),
+      findings.join("\n"),
+    );
+});
+
+test("positive fixture: daemon start preview and CLI cancellation eligibility copies are refused", () => {
+  const fixture = path.join(repoRoot, "tools/fixtures/domain-judgment-single-definition"),
+    findings = checkDomainJudgmentSingleDefinition(fixture);
+  assert.ok(
+    findings.some((finding) => finding.includes("second Task startability preview")),
+    findings.join("\n"),
+  );
+  assert.ok(
+    findings.some((finding) => finding.includes("cancellation eligibility")),
+    findings.join("\n"),
+  );
 });

--- a/tools/check-status-vocabulary.mjs
+++ b/tools/check-status-vocabulary.mjs
@@ -24,13 +24,14 @@
 import { readdirSync, readFileSync } from "node:fs";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
+import { daemonStatusVocabularyProjectionFinding } from "./generate-daemon-status-vocabulary.mjs";
 
 const REGISTER = "../packages/kernel/src/domain/status-vocabulary.ts";
 const KERNEL_DOMAIN = "packages/kernel/src/domain";
 const GUI_MODEL = "packages/gui/src/renderer/model/types.ts";
 const GUI_ADAPTER = "packages/gui/src/renderer/triadic-data.ts";
 const DAEMON_PROTOCOL = "packages/daemon/src/protocol/daemon-protocol-vocabulary.ts";
-const DAEMON_MIRROR_CONST = /(?:Status|State|Phase|Disposition|Verdict|Outcome)Words$/u;
+const DAEMON_MIRROR_CONST = /(?:Status|State|Phase|Disposition|Verdict|Outcome|Liveness)Words$/u;
 const LOCAL_MIRROR_CONST =
   /const\s+([A-Za-z_][A-Za-z0-9_]*Words)\s*(?::[^=\n]+)?=\s*(?:Object\.freeze\(\s*)?\[([^\]]*)\]\s*as\s+const/gu;
 const LOCAL_MIRROR_ALIAS = /export\s+const\s+([A-Za-z_][A-Za-z0-9_]*Words)\s*=\s*([A-Za-z_][A-Za-z0-9_]*)\s*;/gu;
@@ -279,23 +280,23 @@ export function checkGuiMirrorAgreement(register, guiModelText, guiAdapterText, 
 }
 
 export function checkDaemonMirrorAgreement(register, daemonText, findings = []) {
-  // The daemon vocabulary module is imported by the wire contract on the CLI's eager
-  // startup path, so it carries plain-data mirrors. This check makes those mirrors
-  // ratchet-locked to the register instead of being free-floating hand copies.
+  // Core wire vocabularies are generated from their kernel runtime authorities because
+  // the thin CLI path must stay dependency-free. Remaining mirrors stay parity-checked.
   const registered = register.statusVocabularies.filter((vocabulary) => vocabulary.module === DAEMON_PROTOCOL);
-  const aliases = [...daemonText.matchAll(LOCAL_MIRROR_ALIAS)].map((match) => {
+  const localDeclarations = [...daemonText.matchAll(LOCAL_MIRROR_CONST)].map((match) => ({
+      anchor: match[1],
+      words: literalWords(match[2]),
+    })),
+    aliasDeclarations = [...daemonText.matchAll(LOCAL_MIRROR_ALIAS)],
+    aliases = aliasDeclarations.map((match) => {
       const source = register.statusVocabularies.find((vocabulary) => vocabulary.anchor === match[2]);
       if (!source)
         findings.push(`${DAEMON_PROTOCOL}#${match[1]}: mirror alias ${match[2]} has no registered vocabulary`);
       return { anchor: match[1], words: source?.words ?? [] };
     }),
-    declared = [
-      ...[...daemonText.matchAll(LOCAL_MIRROR_CONST)].map((match) => ({
-        anchor: match[1],
-        words: literalWords(match[2]),
-      })),
-      ...aliases,
-    ].filter((entry) => DAEMON_MIRROR_CONST.test(entry.anchor));
+    declared = [...localDeclarations, ...aliases].filter((entry) => DAEMON_MIRROR_CONST.test(entry.anchor));
+  const projectionFinding = daemonStatusVocabularyProjectionFinding(daemonText);
+  if (projectionFinding) findings.push(`${DAEMON_PROTOCOL}: ${projectionFinding}`);
   for (const entry of declared) {
     const match = registered.find(
       (vocabulary) => vocabulary.anchor === entry.anchor && sameWords(vocabulary.words, entry.words),
@@ -368,7 +369,7 @@ async function main() {
     process.exit(1);
   }
   console.log(
-    "Status vocabulary check passed (register, kernel vocabularies, and GUI mirrors agree; unknown stays unknown).",
+    "Status vocabulary check passed (register, kernel vocabularies, generated daemon mirrors, and GUI mirrors agree).",
   );
 }
 

--- a/tools/check-status-vocabulary.test.mjs
+++ b/tools/check-status-vocabulary.test.mjs
@@ -159,13 +159,16 @@ test("bypass fixture: smoothing an unknown decision state into a neighbour is re
 });
 
 test("bypass fixture: a daemon wire mirror drifting from the kernel vocabulary is refused", () => {
-  // The wire contract's eager vocabulary dependency carries plain-data mirrors, and
-  // the gate must keep them from silently diverging.
+  // Mutating the build-time projection must fail both freshness and parity.
   const daemonText = readFileSync(
     path.join(repoRoot, "packages/daemon/src/protocol/daemon-protocol-vocabulary.ts"),
     "utf8",
   ).replace('  "superseded",\n', "");
   const findings = checkDaemonMirrorAgreement(register, daemonText);
+  assert.ok(
+    findings.some((finding) => finding.includes("Generated daemon status vocabulary is stale")),
+    findings.join("\n"),
+  );
   assert.ok(
     findings.some((finding) => finding.includes("decisionStateWords") && finding.includes("drift")),
     findings.join("\n"),

--- a/tools/fixtures/domain-judgment-single-definition/packages/daemon/src/duplicate-judgments.ts
+++ b/tools/fixtures/domain-judgment-single-definition/packages/daemon/src/duplicate-judgments.ts
@@ -1,0 +1,10 @@
+// Positive-control fixture: daemon-owned definitions must fail the single-definition gate.
+export function canStartExecution(): boolean {
+  return true;
+}
+
+export function queryPayloadValidation(): readonly string[] {
+  return [];
+}
+
+export const statusVocabularies = ["copied"] as const;

--- a/tools/fixtures/domain-judgment-single-definition/packages/daemon/src/protocol/daemon-protocol-commands-task-surface.ts
+++ b/tools/fixtures/domain-judgment-single-definition/packages/daemon/src/protocol/daemon-protocol-commands-task-surface.ts
@@ -1,0 +1,4 @@
+// Positive-control fixture: transport metadata must not decide cancellation eligibility for the CLI.
+export const input = {
+  requiredWhen: { field: "status", values: ["cancelled"] },
+};

--- a/tools/fixtures/domain-judgment-single-definition/packages/daemon/src/repo-cell-action-dispatch.ts
+++ b/tools/fixtures/domain-judgment-single-definition/packages/daemon/src/repo-cell-action-dispatch.ts
@@ -1,0 +1,15 @@
+// Positive-control fixture: the daemon must not preview startability independently.
+export function previewStart(current: {
+  readonly snapshot: { readonly task?: { readonly status: string }; readonly lease?: unknown };
+}) {
+  const preview = true;
+  return preview && !current.snapshot.task
+    ? false
+    : preview && current.snapshot.lease
+      ? false
+      : isTerminalStatus(current.snapshot.task!.status);
+}
+
+function isTerminalStatus(status: string): boolean {
+  return status === "done";
+}

--- a/tools/gates/test/task-lifecycle-transitions.test.mjs
+++ b/tools/gates/test/task-lifecycle-transitions.test.mjs
@@ -226,10 +226,9 @@ test("G10 block, unblock, and cancel are catalog transitions while unrelated act
     blocked.snapshot,
     "the unchanged task_transitioned event shape must replay exactly",
   );
-  assert.throws(
-    () => applyTransition(created.snapshot, transition(2, "blocked", "Force is cancellation-only", true), {}),
-    (error) => error instanceof TaskLifecycleContractError && error.code === "invalid_transition",
-  );
+  const forcedBlock = applyTransition(created.snapshot, transition(2, "blocked", "", true), {});
+  assert.equal(forcedBlock.snapshot.task.status, "blocked");
+  assert.equal(forcedBlock.event.payload.mutation.reason, "Explicit lifecycle transition to blocked");
   const unblocked = applyTransition(blocked.snapshot, transition(3, "active"), {});
   assert.equal(unblocked.snapshot.task.status, "active");
   assert.deepEqual(unblocked.event.payload.mutation, {

--- a/tools/gates/test/task-lifecycle-transitions.test.mjs
+++ b/tools/gates/test/task-lifecycle-transitions.test.mjs
@@ -226,10 +226,9 @@ test("G10 block, unblock, and cancel are catalog transitions while unrelated act
     blocked.snapshot,
     "the unchanged task_transitioned event shape must replay exactly",
   );
-  assert.equal(
-    applyTransition(created.snapshot, transition(2, "blocked", "Force remains an ignored block flag", true), {})
-      .snapshot.task.status,
-    "blocked",
+  assert.throws(
+    () => applyTransition(created.snapshot, transition(2, "blocked", "Force is cancellation-only", true), {}),
+    (error) => error instanceof TaskLifecycleContractError && error.code === "invalid_transition",
   );
   const unblocked = applyTransition(blocked.snapshot, transition(3, "active"), {});
   assert.equal(unblocked.snapshot.task.status, "active");

--- a/tools/generate-daemon-status-vocabulary.mjs
+++ b/tools/generate-daemon-status-vocabulary.mjs
@@ -1,0 +1,75 @@
+#!/usr/bin/env node
+
+import { readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { decisionStates } from "../packages/kernel/src/domain/decision-event-types.ts";
+import { factLivenessStates } from "../packages/kernel/src/domain/fact-liveness.ts";
+import { domainStatuses } from "../packages/kernel/src/domain/lifecycle-status.ts";
+
+const root = path.resolve(import.meta.dirname, "..");
+const target = path.join(root, "packages/daemon/src/protocol/daemon-protocol-vocabulary.ts");
+const markers = {
+  start: "// daemon-status-vocabulary:generated:start",
+  end: "// daemon-status-vocabulary:generated:end",
+};
+
+const projections = [
+  ["taskStatusWords", domainStatuses],
+  ["decisionStateWords", decisionStates],
+  ["factLivenessWords", factLivenessStates],
+];
+
+export function renderDaemonStatusVocabularyProjection() {
+  return [
+    markers.start,
+    ...projections.flatMap(([name, words]) => [...renderDeclaration(name, words), ""]),
+    markers.end,
+  ].join("\n");
+}
+
+function renderDeclaration(name, words) {
+  const inline = `export const ${name} = [${words.map((word) => JSON.stringify(word)).join(", ")}] as const;`;
+  return inline.length <= 120
+    ? [inline]
+    : [`export const ${name} = [`, ...words.map((word) => `  ${JSON.stringify(word)},`), "] as const;"];
+}
+
+export function normalizeProjectionLineEndings(source) {
+  return source.replaceAll("\r\n", "\n");
+}
+
+function generatedRegion(source, sourcePath = target) {
+  const start = source.indexOf(markers.start),
+    end = source.indexOf(markers.end, start);
+  if (start < 0 || end < 0) throw new Error(`Generated daemon status vocabulary markers are missing in ${sourcePath}.`);
+  return source.slice(start, end + markers.end.length);
+}
+
+export function daemonStatusVocabularyProjectionFinding(source) {
+  const current = generatedRegion(source),
+    expected = renderDaemonStatusVocabularyProjection();
+  return normalizeProjectionLineEndings(current) === normalizeProjectionLineEndings(expected)
+    ? null
+    : "Generated daemon status vocabulary is stale; run tools/generate-daemon-status-vocabulary.mjs.";
+}
+
+export function checkDaemonStatusVocabularyProjection() {
+  const finding = daemonStatusVocabularyProjectionFinding(readFileSync(target, "utf8"));
+  if (finding) throw new Error(finding);
+}
+
+export function generateDaemonStatusVocabularyProjection() {
+  const source = readFileSync(target, "utf8"),
+    current = generatedRegion(source),
+    start = source.indexOf(current);
+  writeFileSync(
+    target,
+    `${source.slice(0, start)}${renderDaemonStatusVocabularyProjection()}${source.slice(start + current.length)}`,
+  );
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href) {
+  if (process.argv.includes("--check")) checkDaemonStatusVocabularyProjection();
+  else generateDaemonStatusVocabularyProjection();
+}

--- a/tools/generate-daemon-status-vocabulary.test.mjs
+++ b/tools/generate-daemon-status-vocabulary.test.mjs
@@ -1,0 +1,25 @@
+// harness-test-tier: contract
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import {
+  checkDaemonStatusVocabularyProjection,
+  daemonStatusVocabularyProjectionFinding,
+  normalizeProjectionLineEndings,
+} from "./generate-daemon-status-vocabulary.mjs";
+
+const root = path.resolve(import.meta.dirname, "..");
+
+test("daemon status vocabulary has one current build-time projection", () => {
+  assert.doesNotThrow(() => checkDaemonStatusVocabularyProjection());
+  const source = readFileSync(path.join(root, "packages/daemon/src/protocol/daemon-protocol-vocabulary.ts"), "utf8");
+  assert.match(source, /daemon-status-vocabulary:generated:start/u);
+  assert.match(source, /daemon-status-vocabulary:generated:end/u);
+});
+
+test("daemon status projection freshness catches edits and normalizes checkout line endings", () => {
+  const source = readFileSync(path.join(root, "packages/daemon/src/protocol/daemon-protocol-vocabulary.ts"), "utf8");
+  assert.match(daemonStatusVocabularyProjectionFinding(source.replace('"standing", ', "")) ?? "", /is stale/u);
+  assert.equal(normalizeProjectionLineEndings("first\r\nsecond\r\n"), "first\nsecond\n");
+});


### PR DESCRIPTION
# English

## Summary

Phase G4 expands the domain-judgment single-definition gate from four to seven named judgments and deletes the reachable duplicates in the same change. New registered kernel definition points: `startability` (`canStartExecution`), `queryPayloadValidation` (new `packages/kernel/src/domain/query-payload-validation.ts`), `statusVocabulary` (`status-vocabulary-catalog.ts`). The daemon wire status vocabulary is no longer a hand-copied mirror: `tools/generate-daemon-status-vocabulary.mjs` generates the daemon block from the kernel task/decision/fact word sets, `check-status-vocabulary` becomes a freshness + register-agreement check, and the CLI build fails if the generated region is stale. The daemon's independent Task start preview and the CLI's status-conditioned cancellation eligibility are deleted and now rejected by the gate (positive-control fixtures included). The two pre-existing query validations (protocol RPC shape vs RepoCell) are explicitly retained and marked for second-stage deletion after the C hard-isolation line merges — that surface is an in-flight no-go zone for this PR.

## Architectural Justification

- Mechanism sentence: a domain judgment with more than one definition point makes any consumer's choice a silent fork; the gate pins each judgment to one kernel definition and rejects re-derivations, and a wire mirror that must exist becomes a generated artifact instead of a third copy.

## Gate Harvest / 门收割

Deleted-Production-Paths: daemon Task start preview re-derivation; CLI status-conditioned cancellation eligibility; hand-written daemon status vocabulary mirror
Deleted-Gates-Fixtures: check-status-vocabulary parity mode replaced by freshness + register-agreement mode (same file, old mode deleted)

## Machine-Readable Declarations

Production-Delta: +280/-113
Dependency-Change: none

### Optional Evidence Claims

None.

## Task And Scope

- Harness task task_c0948107192cbcf9949016e06f (Phase G4, adversarial-audit F4). Branch `codex/phase-g4-single-definition`.

## Version Impact

- Version: no change. Publish impact: none.

## Governance Declaration

- Protected surface touched: yes — `tools/check-domain-judgment-single-definition.mjs` and `tools/check-status-vocabulary.mjs` are gate authority files. Authorized by the task's CI/Gate authority clause (task_c0948107, Phase G governance line, dec_99000027E6BCC263E341D38DC0 lineage: plan-20260830-governance-phase.md G4 row, 泽宇 2026-08-30 裁决 F4「继续跟进」). Break-glass: no.

## Verification

- Worker: single-definition gate 7/7 green with positive-control fixtures (re-introducing a daemon-owned definition turns the gate red); generator freshness test; query-payload-validation fast tests; status-vocabulary freshness + register agreement; targeted kernel/daemon/CLI suites green; local commit on base c2754d64.
- CEO re-ran `node tools/check-domain-judgment-single-definition.mjs` → "seven judgments resolve to kernel domain services".
- [ ] Full suites: GitHub CI is the authority.

## Review Evidence

- CEO ground-truthed the gate expansion and the in-flight no-go compliance (`repo-cell-api.ts` untouched; both query validations retained and marked "second stage after C-line merge" in the worker closeout).

## Residual Risk

- The query-validation duplicate pair (protocol RPC vs RepoCell) survives this PR by design; its deletion is staged after the C hard-isolation merge and tracked in the G4 worker closeout. B3 (buildCommand mapping) and B17 (string-prefix routing family) are routed to task_ce7c579a (anti-entropy fixes), not this slice.

---

# 中文

## 概要

G4 把 domain-judgment single-definition 门从四项扩到七项(新增 startability / queryPayloadValidation / statusVocabulary 三个 kernel 唯一定义点),同一变更删除可达副本:daemon 独立 start preview、CLI 按 status 判取消资格、手抄的 daemon 状态词表镜像(改为生成物:generate-daemon-status-vocabulary 从 kernel 词集生成,check-status-vocabulary 变 freshness+register 一致性检查,CLI build 对过期生成区报错)。protocol 与 RepoCell 两份 query 校验按在飞禁区显式保留,标记「C 线合并后二段删除」。

## 架构辩护

- 机制句:一个领域判定有第二个定义点,消费者的选择就是一次静默分叉;门把每个判定钉死在一个 kernel 定义点,必须存在的 wire 镜像改为生成物而非第三份手抄。

## 机读声明

`Production-Delta: +280/-113`(numstat 实测,不含 tools/fixtures 阳性对照)。

## 治理声明

- 触碰 protected gate 面(single-definition 与 status-vocabulary 两个门脚本),授权来源:task_c0948107 的 CI/Gate authority 条款(Phase G 治理线,plan-20260830-governance-phase.md G4 行,泽宇 2026-08-30 F4 裁决)。无 break-glass。

## 验证

- worker:七项门绿 + 阳性对照(放回 daemon 定义门必红)+ 定向套件绿;CEO 复跑门脚本七项绿;完整权威=GitHub CI。

## 残余风险

- query 校验对按设计保留至 C 线合并后二段;B3/B17 归 task_ce7c579a,不在本片。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VTzQAqvuFy6ikGjBKxA9xj

