### PR TITLE
feat(closeout): let ha task closeout carry review qualification fields

### DIFF
--- a/packages/kernel/src/schemas/task-closeout-packet.ts
+++ b/packages/kernel/src/schemas/task-closeout-packet.ts
@@ -12,6 +12,10 @@ export interface TaskCloseoutPacket {
     readonly verdict: ReviewVerdict;
     readonly reason: string;
     readonly evidenceChecked: readonly string[];
+    readonly externalCompletionAnchor?: string;
+    readonly noDispatchReason?: string;
+    readonly noIndependentReview?: true;
+    readonly noIndependentReviewReason?: string;
   };
   readonly consent: { readonly approved: true };
   readonly completion: {
@@ -20,6 +24,9 @@ export interface TaskCloseoutPacket {
   };
 }
 
+// `templateOmit` marks an optional field that is valid input but is left out of the generated
+// `--print-template` scaffold, so the default template stays the standard shape while the field
+// remains accepted when a caller supplies it.
 type SchemaNode =
   | {
       readonly type: "object";
@@ -28,6 +35,7 @@ type SchemaNode =
       readonly additionalProperties: false;
       readonly description?: string;
       readonly example?: unknown;
+      readonly templateOmit?: true;
     }
   | {
       readonly type: "array";
@@ -35,6 +43,7 @@ type SchemaNode =
       readonly minItems?: number;
       readonly description?: string;
       readonly example?: unknown;
+      readonly templateOmit?: true;
     }
   | {
       readonly type: "string";
@@ -44,12 +53,14 @@ type SchemaNode =
       readonly enum?: readonly string[];
       readonly description?: string;
       readonly example?: unknown;
+      readonly templateOmit?: true;
     }
   | {
       readonly type: "boolean";
       readonly const: boolean;
       readonly description?: string;
       readonly example?: unknown;
+      readonly templateOmit?: true;
     };
 
 const nonEmptyString = (example: string, description: string): SchemaNode => ({
@@ -122,6 +133,11 @@ export const taskCloseoutPacketSchema = Object.freeze({
       type: "object",
       additionalProperties: false,
       required: ["verdict", "reason", "evidenceChecked"],
+      // The optional qualification fields let an owner-direct closeout justify a same-person review
+      // when no dispatch record exists: an external completion anchor (a merged PR / commit SHA / CI
+      // run), or an explicit no-independent-review weak mark. Which exact combination is admissible
+      // stays governed downstream by the review packet, so the rule lives in one place; here they are
+      // only allowed through the closeout packet shape.
       properties: {
         verdict: {
           type: "string",
@@ -131,6 +147,38 @@ export const taskCloseoutPacketSchema = Object.freeze({
         },
         reason: nonEmptyString("Explain why the delivery satisfies the task intent.", "Review rationale."),
         evidenceChecked: stringArray("Name one inspected evidence item.", "Inspected evidence identifiers."),
+        externalCompletionAnchor: {
+          ...nonEmptyString(
+            "e63a871c71520ae75a6854c20204aebccb726ef4",
+            "Optional: a merged PR number, a 40-char origin/main commit SHA, or a CI run URL standing in for " +
+              "dispatch attribution when none exists. Pair with noDispatchReason.",
+          ),
+          templateOmit: true,
+        },
+        noDispatchReason: {
+          ...nonEmptyString(
+            "Delivered through a retired external channel, so ha task dispatches is empty.",
+            "Optional: why this task has no dispatch record. Required with externalCompletionAnchor.",
+          ),
+          templateOmit: true,
+        },
+        noIndependentReview: {
+          type: "boolean",
+          const: true,
+          example: true,
+          templateOmit: true,
+          description:
+            "Optional: explicitly declare there was no independent review. The recorded Review is marked " +
+            "NO INDEPENDENT REVIEW and never passes as an independently-reviewed approval. " +
+            "Pair with noIndependentReviewReason.",
+        },
+        noIndependentReviewReason: {
+          ...nonEmptyString(
+            "No independent reviewer was available for this documentation-only delivery.",
+            "Optional: why no independent review is possible. Required with noIndependentReview.",
+          ),
+          templateOmit: true,
+        },
       },
     },
     consent: {
@@ -245,7 +293,11 @@ function validatePortablePath(value: string, path: string, issues: string[]): vo
 function exampleValue(schema: SchemaNode): unknown {
   if (schema.example !== undefined) return structuredClone(schema.example);
   if (schema.type === "object")
-    return Object.fromEntries(Object.entries(schema.properties).map(([field, child]) => [field, exampleValue(child)]));
+    return Object.fromEntries(
+      Object.entries(schema.properties)
+        .filter(([, child]) => child.templateOmit !== true)
+        .map(([field, child]) => [field, exampleValue(child)]),
+    );
   if (schema.type === "array") return [];
   if (schema.type === "boolean") return schema.const;
   return schema.enum?.[0] ?? "";

--- a/packages/kernel/test/contracts/task-closeout-packet.test.ts
+++ b/packages/kernel/test/contracts/task-closeout-packet.test.ts
@@ -12,6 +12,40 @@ test("closeout packet templates are derived from the authoritative schema", () =
   assert.equal(resumed.completion.ci, "not_applicable");
 });
 
+test("closeout review accepts the optional qualification fields but omits them from the template", () => {
+  const template = createTaskCloseoutPacketTemplate({ includeSubmission: false, ci: "not_applicable" });
+  // The default scaffold stays the standard shape; the optional qualifiers are documented, not seeded.
+  assert.deepEqual(Object.keys(template.review).sort(), ["evidenceChecked", "reason", "verdict"]);
+
+  const base = {
+    consent: { approved: true } as const,
+    completion: { ci: "not_applicable" as const, codeDocPaths: [] },
+  };
+  const anchored = validateTaskCloseoutPacket({
+    ...base,
+    review: {
+      verdict: "approved",
+      reason: "Delivered and merged.",
+      evidenceChecked: ["origin/main ancestry"],
+      externalCompletionAnchor: "e63a871c71520ae75a6854c20204aebccb726ef4",
+      noDispatchReason: "Delivered through a retired external channel.",
+    },
+  });
+  assert.equal(anchored.ok, true, JSON.stringify(anchored));
+
+  const weaklyMarked = validateTaskCloseoutPacket({
+    ...base,
+    review: {
+      verdict: "approved",
+      reason: "Documentation-only delivery.",
+      evidenceChecked: ["authored documentation"],
+      noIndependentReview: true,
+      noIndependentReviewReason: "No independent reviewer was available.",
+    },
+  });
+  assert.equal(weaklyMarked.ok, true, JSON.stringify(weaklyMarked));
+});
+
 test("closeout packet validation reports every independent field error at once", () => {
   const invalid = validateTaskCloseoutPacket({
     unexpected: true,


### PR DESCRIPTION
# English

## Summary

Completes the owner-direct closeout fix so it works through the ergonomic path. The review-independence escape (an external completion anchor, or an explicit no-independent-review weak mark) was reachable only through the low-level `task-review-execution` action; the `task-closeout-packet/v1` schema rejected the qualification fields with `packet.review.<field> is not allowed`, so `ha task closeout` — the one path people use — could not complete an owner-direct task. This allows the four optional fields through the closeout review shape and omits them from the generated template.

## What Changed

- `TaskCloseoutPacket.review` and `taskCloseoutPacketSchema.properties.review` gain four optional fields: `externalCompletionAnchor`, `noDispatchReason`, `noIndependentReview`, `noIndependentReviewReason`.
- Which exact combination is admissible (standard, or standard + anchor pair, or standard + weak-mark pair) stays governed downstream by the review packet, so that rule lives in one place; the closeout schema only allows the fields through the packet shape.
- A `templateOmit` marker keeps these optional fields out of the generated `--print-template` scaffold, so the default closeout template stays the standard shape and never seeds both mutually-exclusive pairs at once.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: use the single CI-backed `Production-Delta` declaration below; do not enter a second metric.

## Machine-Readable Declarations

Production-Delta: +53/-1

## Task And Scope

- Harness task: task_b1ee750c44907f6bab44883196
- Branch: codex/closeout-facade
- Public scope: task-closeout-packet schema (kernel) and its contract test
- Private planning/evidence updated: yes
- Out of scope: the review-independence proof itself (landed in PR #2100), any CLI flag surface

## Version Impact

- Version: no version change because this is an internal schema change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: dec_758112A30EBC78EB678723EA96 (accepted, in_effect); task_b1ee750c44907f6bab44883196
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: current origin/main (fresh worktree this session)
- Branch merge-base with `origin/main`: current
- Last `git fetch origin` time: 2026-09-01 (this session)
- Sync method: none needed
- Public diff command: `git diff origin/main...codex/closeout-facade`
- Private evidence commit/path: task_b1ee750c fact F-D03C1DCD
- Reviewer evidence path: see Review Evidence
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [x] `git diff --check`
- [x] `npm run typecheck` (`tsc -b`, exit 0)
- [x] `task-closeout-packet` contract test 3/3 via `node --test` (template omits the optional fields; anchor pair accepted; weak-mark pair accepted); eslint clean; closeout facade/action tests show no failures
- Not run: full `npm test`/harness:* suite (worker stop-point policy; CI is the full authority)
- Post-merge dogfood planned: complete a real owner-direct task (task_0f9c6bbd, PR #2093 merged) through `ha task closeout` with the anchor, proving the ergonomic path end to end.

## Review Evidence

- Self-review: the closeout facade already serializes `judgment.review` verbatim into the `task-review-execution` action (task-closeout-action.ts), so the only gap was the closeout packet schema rejecting the fields; this widens exactly that shape and keeps the combination rule single-sourced in the review packet
- Reviewer subagent: CEO authored and verified directly (rich context from the death-lock fix line)
- Human review: pending on this PR
- Blocking findings: none open

## Residual Risk

- A caller who supplies a partial or conflicting combination (e.g. an anchor without a reason, or both pairs) is rejected downstream by the review packet with its own message rather than at closeout-packet parse time. This keeps the combination rule single-sourced; the rejection is still early and deterministic.

## References

- Task: task_b1ee750c44907f6bab44883196
- Decision: dec_758112A30EBC78EB678723EA96
- Evidence: fact F-D03C1DCD

---

# 中文

## 概要

把 owner-direct 收口修复补全到人用的唯一路径上。review 独立性逃生口（外部完工锚，或显式「无独立复核」弱标记）此前只有底层 `task-review-execution` 动作能用；`task-closeout-packet/v1` schema 会以 `packet.review.<field> is not allowed` 拒收这些字段，导致人人都在用的 `ha task closeout` 无法收口一个 owner-direct 任务。本 PR 让这四个可选字段透传过 closeout 的 review 形状，并把它们从生成的模板中排除。

## 改动内容

- `TaskCloseoutPacket.review` 与 `taskCloseoutPacketSchema.properties.review` 新增四个可选字段：`externalCompletionAnchor`、`noDispatchReason`、`noIndependentReview`、`noIndependentReviewReason`。
- 哪种组合合法（标准、或标准+锚对、或标准+弱标对）仍由下游 review packet 单点裁定，规则只有一份；closeout schema 只负责让字段透传过 packet 形状。
- 一个 `templateOmit` 标记让这些可选字段不进 `--print-template` 脚手架，默认 closeout 模板保持标准形状，绝不会一次种下两对互斥字段。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 同 commit 删除的门 / fixture：none
- 生产净行数：引用英文块中的 `Production-Delta`。

## 机读声明说明

- 机读声明只在英文块出现一次，见上。

## 任务与范围

- Harness 任务：task_b1ee750c44907f6bab44883196
- 分支：codex/closeout-facade
- 公开范围：task-closeout-packet schema（kernel）及其契约测试
- 私有计划 / 证据是否已更新：yes
- 范围外：review 独立性证明本身（已随 PR #2100 落地）、任何 CLI flag 面

## 版本影响

- 版本：不改版本，原因是内部 schema 改动
- 发布影响：不发布

## 治理声明

- 是否触碰 protected surface：no
- protected surface 范围：不适用
- 依据：dec_758112A30EBC78EB678723EA96（已 accept，in_effect）；task_b1ee750c44907f6bab44883196
- 机器检查边界：本 PR 只声明该段存在；声明是否真实、充分，由 reviewer 判断。
- Break-glass：no
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- `origin/main` 基准 SHA：当前 origin/main（本会话新建 worktree）
- 当前分支与 `origin/main` 的 merge-base：当前
- 最近一次 `git fetch origin` 时间：2026-09-01（本会话）
- 同步方式：不需要
- 公开 diff 命令：`git diff origin/main...codex/closeout-facade`
- 私有证据 commit/path：task_b1ee750c 的 fact F-D03C1DCD
- Reviewer 证据路径：见审查证据
- GitHub Actions `rewrite-ci` run URL：待本 PR 运行附上
- [x] `git diff --check`
- [x] `npm run typecheck`（`tsc -b`，退出码 0）
- [x] `task-closeout-packet` 契约测试经 `node --test` 3/3（模板排除可选字段；锚对被接受；弱标对被接受）；eslint 干净；closeout facade/action 测试无失败
- 未运行：完整 `npm test` / harness:* 套件（worker 停止点纪律；完整权威是 CI）
- 合并后 dogfood 计划：用真实 owner-direct 任务（task_0f9c6bbd，PR #2093 已合）经 `ha task closeout` 带锚收口，端到端证明人用路径打通。

## 审查证据

- 自查：closeout facade 本就把 `judgment.review` 原样序列化进 `task-review-execution` 动作（task-closeout-action.ts），唯一缺口就是 closeout packet schema 拒收字段；本 PR 恰好放宽这一形状，组合规则仍单点保留在 review packet
- Reviewer subagent：CEO 亲自编写并验证（承接死锁修复线，上下文充分）
- 人工审查：本 PR 上待进行
- 阻塞发现：无未关闭项

## 残余风险

- 若调用方给出部分或冲突组合（如只有锚没理由、或两对都给），由下游 review packet 用它自己的消息拒绝，而非在 closeout packet 解析时。这保持组合规则单点；拒绝仍是早期且确定的。

## 关联材料

- 任务：task_b1ee750c44907f6bab44883196
- 裁决：dec_758112A30EBC78EB678723EA96
- 证据：fact F-D03C1DCD

---

## PR Gate Checklist / PR 门禁清单

- [x] Branch is based on latest `origin/main`. / 分支基于最新 `origin/main`。
- [x] PR body uses this full template structure. / PR 描述使用本模板完整结构。
- [x] PR body uses two complete language blocks: `# English` first, then `# 中文`. / PR 正文使用两块完整正文：`# English` 在上，`# 中文` 在下。
- [x] PR body passes `tools/check-pr-body-bilingual.mjs`. / PR 正文通过 `tools/check-pr-body-bilingual.mjs`。
- [x] If the PR touches a manifest-derived protected surface, Governance Declaration is filled with ADR/decision/task evidence or break-glass fields. / 若 PR 触碰 manifest 派生的 protected surface，Governance Declaration 已填写 ADR/decision/task 依据或 break-glass 字段。
- [x] No private harness files are included. / 不包含私有 harness 文件。
- [x] No ignored local agent entry files are included. / 不包含被忽略的本地 agent 入口文件。
- [x] No absolute local filesystem paths are included in this public PR body. / 本公开 PR 描述不包含本机绝对路径。
- [x] Public diff is limited to the stated task scope. / 公开 diff 限于声明的任务范围。
- [x] Private planning/evidence updates are recorded when applicable. / 适用时已记录私有计划 / 证据更新。
- [x] Version and publish impact are stated. / 已说明版本与发布影响。
- [x] Local verification commands are recorded honestly. / 已如实记录本地验证命令。
- [x] CI results are linked or explained. / CI 结果已链接或说明。
- [x] Review evidence is recorded. / 已记录审查证据。
- [x] Open P0/P1/P2 findings are closed, deferred with owner, or explicitly blocked. / open P0/P1/P2 findings 已关闭、带 owner 延后，或明确阻塞。
- [x] Merge method and post-merge branch cleanup plan are clear. / 合并方式和合并后分支清理计划清楚。
- [x] No admin bypass is planned unless explicitly approved and recorded. / 除非明确批准并记录，否则不计划 admin bypass。
