### PR TITLE
fix(kernel): recover stranded review lifecycle

### DIFF
--- a/packages/kernel/src/domain/task-lifecycle-command-transitions.ts
+++ b/packages/kernel/src/domain/task-lifecycle-command-transitions.ts
@@ -86,23 +86,25 @@ export const create: Transition = {
   },
 };
 /**
- * The state-side admissibility of StartExecution: a new execution, or the
- * unleased active execution of the current round.
+ * The state-side admissibility of StartExecution: a new execution, the
+ * unleased active execution of the current round, or a review node stranded
+ * without the submitted execution needed to proceed.
  * Exported so the daemon preview and this transition answer with one rule instead of two. */
 export function canStartExecution(snapshot: TaskLifecycleSnapshot, executionId: string): boolean {
   const task = snapshot.task,
     rejoin = snapshot.executions.find((value) => value.executionId === executionId),
     round = snapshot.executions.find(
       (value) => isNativeExecution(value) && value.iteration === task?.iteration && value.state === "active",
-    );
-  return (
-    Boolean(task) &&
-    ["planned", "active"].includes(task!.status) &&
-    task!.currentNode === "implementation" &&
-    !snapshot.lease &&
-    isNonEmptyString(executionId) &&
-    rejoin === round
-  );
+    ),
+    recoverableReview =
+      task?.currentNode === "review" &&
+      !snapshot.executions.some(
+        (value) => isNativeExecution(value) && value.iteration === task.iteration && value.state === "submitted",
+      ),
+    startablePhase =
+      (["planned", "active"].includes(task?.status ?? "") && task?.currentNode === "implementation") ||
+      (["planned", "active", "in_review"].includes(task?.status ?? "") && recoverableReview);
+  return Boolean(task) && startablePhase && !snapshot.lease && isNonEmptyString(executionId) && rejoin === round;
 }
 /** The state-side admissibility shared by the block/unblock/cancel catalog entries. */
 export function allowsTaskStatusMove(
@@ -117,7 +119,7 @@ export function allowsTaskStatusMove(
 export const start: Transition = {
   id: "start_execution",
   commandType: "StartExecution",
-  from: "planned|active/implementation",
+  from: "planned|active/implementation|planned|active|in_review/recoverable-review",
   proof: ["actorBinding", "reservation"],
   eventType: "execution_started",
   matches: (command) => command.type === "StartExecution",
@@ -131,7 +133,7 @@ export const start: Transition = {
         lifecycleContractIssue(
           "invalid_transition",
           "StartExecution requires a new execution, or the unleased active execution of the current round, " +
-            "in planned or returned implementation",
+            "in planned or returned implementation, or a review node with no current submitted execution",
         ),
       );
     if (
@@ -152,7 +154,7 @@ export const start: Transition = {
   reduce: (snapshot, raw, rawProof) => {
     const command = raw as StartExecutionCommand,
       reservation = (rawProof as StartExecutionProof).reservation,
-      task = { ...(snapshot.task as TaskV2), status: "active" as const },
+      task = { ...(snapshot.task as TaskV2), status: "active" as const, currentNode: "implementation" as const },
       rejoin = snapshot.executions.find((value) => value.executionId === command.executionId) as
         | ExecutionV1
         | undefined,

--- a/packages/kernel/test/contracts/start-execution-admissibility.test.ts
+++ b/packages/kernel/test/contracts/start-execution-admissibility.test.ts
@@ -10,6 +10,7 @@ import {
   validateTransition,
   type CreateReplayTaskProof,
   type StartExecutionProof,
+  type SubmitExecutionProof,
   type TaskLifecycleCommand,
   type TaskLifecycleSnapshot,
 } from "../../src/domain/task-lifecycle.contract.ts";
@@ -36,7 +37,7 @@ function command<C extends Parameters<typeof normalizeTaskLifecycleCommand>[1]>(
 function apply(
   snapshot: TaskLifecycleSnapshot,
   next: TaskLifecycleCommand,
-  proof: CreateReplayTaskProof | StartExecutionProof,
+  proof: CreateReplayTaskProof | StartExecutionProof | SubmitExecutionProof,
 ): TaskLifecycleSnapshot {
   return applyTransition(snapshot, next, proof as never).snapshot;
 }
@@ -78,6 +79,44 @@ function started(): TaskLifecycleSnapshot {
   );
 }
 
+function submitted(): TaskLifecycleSnapshot {
+  return apply(
+    started(),
+    command(3, {
+      type: "SubmitExecution",
+      taskId: "task-1",
+      executionId: "execution-1",
+      submission: {
+        completionClaim: "Implementation complete",
+        deliverables: ["repair"],
+        outputs: ["commit"],
+        verificationNotes: ["contract test"],
+        knownGaps: [],
+        residualRisks: [],
+        commitSha: "a".repeat(40),
+      },
+    }) as TaskLifecycleCommand,
+    { actorBinding: implementer, leaseVersion: 0, sessionDisposition: "complete" },
+  );
+}
+
+/** A review-node task whose only execution relation was retired from the projection. */
+function strandedInReview(status: "planned" | "active" | "in_review" = "active"): TaskLifecycleSnapshot {
+  const snapshot = planned();
+  return {
+    ...snapshot,
+    task: { ...snapshot.task!, status, currentNode: "review" },
+    executions: [],
+    lease: null,
+  };
+}
+
+function hasTransitionIssue(snapshot: TaskLifecycleSnapshot, intent: Parameters<typeof command>[1]): boolean {
+  return validateTransition(snapshot, command(snapshot.revision + 1, intent) as TaskLifecycleCommand, {} as never).some(
+    ({ code }) => code === "invalid_transition",
+  );
+}
+
 test("a fresh task admits any execution id", () => {
   assert.equal(canStartExecution(planned(), "execution-1"), true);
   assert.equal(canStartExecution(planned(), "anything-else"), true);
@@ -89,6 +128,78 @@ test("a held lease blocks StartExecution regardless of the execution id", () => 
   assert.equal(held.lease?.phase, "held", "fixture precondition: the lease is held");
   assert.equal(canStartExecution(held, "execution-1"), false);
   assert.equal(canStartExecution(held, "execution-fresh"), false);
+});
+
+test("a submitted execution preserves review integrity and blocks StartExecution", () => {
+  const review = submitted();
+  assert.equal(review.task?.status, "in_review");
+  assert.equal(review.task?.currentNode, "review");
+  assert.equal(review.executions[0]?.state, "submitted");
+  assert.equal(canStartExecution(review, "execution-1"), false);
+  assert.equal(canStartExecution(review, "execution-fresh"), false);
+});
+
+test("a review node with no submitted execution recovers exclusively through StartExecution", () => {
+  for (const status of ["planned", "active", "in_review"] as const) {
+    const stranded = strandedInReview(status),
+      startIntent = {
+        type: "StartExecution",
+        taskId: "task-1",
+        executionId: "execution-recovery",
+      } as const,
+      submitIntent = {
+        type: "SubmitExecution",
+        taskId: "task-1",
+        executionId: "execution-recovery",
+        submission: {
+          completionClaim: "Recovered execution complete",
+          deliverables: ["repair"],
+          outputs: ["commit"],
+          verificationNotes: ["contract test"],
+          knownGaps: [],
+          residualRisks: [],
+          commitSha: "a".repeat(40),
+        },
+      } as const,
+      reviewIntent = {
+        type: "RecordReview",
+        taskId: "task-1",
+        executionId: "execution-recovery",
+        reviewId: "review-recovery",
+        verdict: "approved",
+        reason: "reviewed",
+        evidenceChecked: ["contract test"],
+        commitSha: "a".repeat(40),
+        iteration: 0,
+        contentDigest: `sha256:${"b".repeat(64)}`,
+      } as const,
+      completeIntent = {
+        type: "CompleteTask",
+        taskId: "task-1",
+        executionId: "execution-recovery",
+      } as const;
+
+    assert.equal(hasTransitionIssue(stranded, startIntent), false, `${status}/review must admit recovery start`);
+    assert.equal(hasTransitionIssue(stranded, submitIntent), true, "submit still requires the recovered execution");
+    assert.equal(hasTransitionIssue(stranded, reviewIntent), true, "review still requires a submission");
+    assert.equal(hasTransitionIssue(stranded, completeIntent), true, "complete still requires approved consent");
+
+    const recovered = apply(stranded, command(stranded.revision + 1, startIntent) as TaskLifecycleCommand, {
+      actorBinding: implementer,
+      reservation: {
+        taskId: "task-1",
+        executionId: "execution-recovery",
+        expiresAt: "2026-08-17T01:00:00.000Z",
+        ttlMs: 1_800_000,
+        previousHolder: null,
+        reason: "initial_claim",
+        version: 0,
+      },
+    });
+    assert.equal(recovered.task?.status, "active");
+    assert.equal(recovered.task?.currentNode, "implementation");
+    assert.equal(hasTransitionIssue(recovered, submitIntent), false, "the normal submit path is reachable again");
+  }
 });
 
 test("two edge commands with the same expected version cannot both commit", () => {


### PR DESCRIPTION
# English

## Summary

Fixes a lifecycle dead zone found while closing out Phase G0 (task_6afb9b18): a task whose graph node is `review` but whose only execution's `executes` edge was retired has no reachable action — start requires the implementation node, submit requires a live lease, review requires a submitted execution, and status transitions do not move the graph node. The fix makes the illegal state unrepresentable instead of adding a repair command: `canStartExecution` now treats a review node **with no submitted execution** as startable, and StartExecution atomically resets the task to `active/implementation`. When a submitted execution exists the old refusal stands, so review integrity is unchanged. A contract test constructs the stranded snapshot as positive control (all four actions unavailable before the fix, start available after).

## Architectural Justification

- Mechanism sentence: a state machine whose status field and graph node can be moved independently will strand aggregates in unreachable combinations; the fix collapses the stranded combination into a legal transition at the single startability definition point (single-definition gate stays green — no second definition introduced).

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none

## Machine-Readable Declarations

Production-Delta: +16/-14
Dependency-Change: none

### Optional Evidence Claims

None.

## Task And Scope

- Harness task task_87685fc380fecf0333186329ad (流转缺陷修复). Branch `codex/lifecycle-node-desync`; kernel lifecycle transitions + contract tests only.

## Version Impact

- Version: no change. Publish impact: none.

## Governance Declaration

- Protected surface touched: no. Break-glass: no.

## Verification

- 37 targeted lifecycle/explain tests green; kernel typecheck, ESLint, and the domain-judgment single-definition gate green; canonical projection read of the stranded G0 task shows `start=true` with the other three actions still ordered-unavailable.
- [ ] Full suites: GitHub CI is the authority.

## Review Evidence

- CEO reproduced the dead zone live on task_6afb9b18 (command sequence in the task package) before dispatching; the fix follows the plan's Scheme A and was verified against that same task's projection. Evidence fact F-D25FE0E2.

## Residual Risk

- The literal `ha explain` re-check on the resident daemon happens after merge + daemon reload (task-bound runtimes cannot restart the default daemon); the equivalent canonical projection receipt is in the repair report.

---

# 中文

## 概要

修 G0 销账时踩到的流转死区:task 图节点停在 `review` 而唯一 execution 的 executes 边已 retired 时,四个动作全部不可达(start 要 implementation 节点、submit 要活 lease、review 要 submitted execution,而 status 转移不动图节点)。修法=让非法状态不可表达而不是加修复命令:`canStartExecution` 对**无 submitted execution** 的 review 节点放行,StartExecution 原子归位 `active/implementation`;存在 submitted execution 时维持旧拒绝,review 完整性不变。契约测试以搁浅快照做阳性对照。

## 架构辩护

- 机制句:status 与图节点可独立移动的状态机必然把聚合搁浅在不可达组合;修复把该组合收敛为唯一 startability 定义点上的合法转移(single-definition 门保持绿,未引入第二定义)。

## 机读声明

`Production-Delta: +16/-14`(numstat 实测,净 +2)。

## 验证

- 定向 37 测绿 + kernel typecheck/ESLint/single-definition 门绿;G0 canonical 投影实测 start=true;完整权威=GitHub CI。

## 残余风险

- 常驻 daemon 上的字面 `ha explain` 复核在合并+daemon 重载后由 CEO 做(报告已留等价投影回执)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VTzQAqvuFy6ikGjBKxA9xj
