### PR TITLE
fix(daemon): reclaim orphaned execution leases from dead-process dispatches

### DIFF
--- a/packages/daemon/src/repo-cell-task-mutation.ts
+++ b/packages/daemon/src/repo-cell-task-mutation.ts
@@ -13,6 +13,7 @@ import {
   type TaskV2,
 } from "../../kernel/src/index.ts";
 import { readDispatchStreamHeaders, readDispatchStreamSummary } from "./dispatch-stream.ts";
+import { runtimePidIsAlive } from "./runtime-spawn-process.ts";
 import type { RepoCellBinding, RepoTaskAction, Snapshot } from "./repo-cell-types.ts";
 import type { RepoCellActionContext } from "./repo-cell-action-context.ts";
 
@@ -327,11 +328,7 @@ function terminalExecutionRuntimeBinding(
             .map((header) => readDispatchStreamSummary(cell.rootDir, header.dispatchId))
             .filter(
               (stream) =>
-                stream?.attemptOutcome !== null &&
-                stream?.attemptOutcome !== undefined &&
-                (stream.attemptOutcome.classification !== "provider_fault" ||
-                  stream.header.fallbackAttempt === undefined ||
-                  stream.fallbackState === "exhausted"),
+                stream !== null && (dispatchReachedTerminalAttempt(stream) || dispatchProcessIsOrphaned(stream)),
             )
             .map((stream) => stream!.header.runtimeSessionId),
         )
@@ -341,9 +338,32 @@ function terminalExecutionRuntimeBinding(
   for (const session of sessions) {
     if (runtimeSessionId !== null && session.runtimeSessionId !== runtimeSessionId) continue;
     if (inferredTerminalSessionIds !== null && !inferredTerminalSessionIds.has(session.runtimeSessionId)) continue;
-    if (session.liveness !== "exited" || runtimeSessionSemanticState(session) === "running") continue;
+    if (
+      (session.liveness !== "exited" || runtimeSessionSemanticState(session) === "running") &&
+      !inferredTerminalSessionIds?.has(session.runtimeSessionId)
+    )
+      continue;
     const binding = resolveTaskBoundRuntimeBinding(session, lease.taskId, lease.executionId);
     if (binding) return binding;
   }
   return null;
+}
+
+function dispatchReachedTerminalAttempt(stream: NonNullable<ReturnType<typeof readDispatchStreamSummary>>): boolean {
+  return (
+    stream.attemptOutcome !== null &&
+    stream.attemptOutcome !== undefined &&
+    (stream.attemptOutcome.classification !== "provider_fault" ||
+      stream.header.fallbackAttempt === undefined ||
+      stream.fallbackState === "exhausted")
+  );
+}
+
+function dispatchProcessIsOrphaned(stream: NonNullable<ReturnType<typeof readDispatchStreamSummary>>): boolean {
+  return (
+    stream.fallbackState !== "scheduled" &&
+    stream.process !== null &&
+    stream.process !== undefined &&
+    (stream.process.exited || !runtimePidIsAlive(stream.process.pid))
+  );
 }

--- a/packages/daemon/test/lease-reservation-reclaim.contract.test.ts
+++ b/packages/daemon/test/lease-reservation-reclaim.contract.test.ts
@@ -7,7 +7,7 @@ import test from "node:test";
 import { type ActorIdentity, type LeaseV1, type TaskLifecycleSnapshot, type TaskV2 } from "../../kernel/src/index.ts";
 import { taskSurfaceWrite } from "../src/repo-cell-task-command-docs.ts";
 import { taskMutation } from "../src/repo-cell-task-command.ts";
-import { openDispatchStream } from "../src/dispatch-stream.ts";
+import { appendRuntimeWorkerRecord, openDispatchStream } from "../src/dispatch-stream.ts";
 
 const now = "2026-08-25T03:15:20.000Z";
 const owner = (executorId: string): ActorIdentity => ({
@@ -272,6 +272,91 @@ test("the task owner reclaims a held lease after its bound dispatch reaches a te
       ownedTask,
       terminalSnapshot,
       taskOwnerBinding,
+    );
+    assert.equal(mutation.type, "lease_released");
+    assert.equal(mutation.releasedLease, heldLease);
+  } finally {
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});
+
+test("the same principal reclaims a live-projected RuntimeSession only after its dispatch process dies", () => {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-dead-runtime-lease-reclaim-")),
+    runtimeSessionId = "runtime-dead-process-reclaim",
+    runtimeActor = {
+      principal: { personId: "person-owner" },
+      executor: { kind: "agent" as const, id: `runtime-session:${runtimeSessionId}` },
+    },
+    heldLease = { ...lease, actor: runtimeActor },
+    execution = {
+      schema: "execution/v1" as const,
+      executionId: heldLease.executionId,
+      taskId: heldLease.taskId,
+      nodeId: "implementation" as const,
+      iteration: 0 as const,
+      state: "active" as const,
+      actor: runtimeActor,
+      claimedAt: now,
+      submittedAt: null,
+      closedAt: null,
+      submission: null,
+    },
+    runtimeSession = {
+      runtimeSessionId,
+      instanceId: "codex-test",
+      installationId: "installation-test",
+      kindId: "codex",
+      definitionSnapshotRef: "artifact:runtime-definition/test",
+      providerSessionId: null,
+      transcriptRef: null,
+      launchGeneration: 1,
+      liveness: "live" as const,
+      attachable: true,
+      taskBindings: [
+        {
+          taskId: heldLease.taskId,
+          executionId: heldLease.executionId,
+          providerSessionId: null,
+          transcriptRef: null,
+          boundAt: now,
+        },
+      ],
+      outcome: null,
+      exitCode: null,
+      resultRef: null,
+      lastObservedAt: now,
+    },
+    reclaimCell = {
+      ...cell,
+      rootDir,
+      projection: { readRuntimeSessionsForTask: () => [runtimeSession] },
+    },
+    heldSnapshot = { ...snapshot(), executions: [execution], lease: heldLease },
+    replacement = authorized(owner("replacement-worker")),
+    dispatchId = "dispatch_bbbbbbbbbbbbbbbbbbbbbbbb";
+  try {
+    openDispatchStream(rootDir, {
+      dispatchId,
+      taskId: heldLease.taskId,
+      executionId: heldLease.executionId,
+      runtimeSessionId,
+      instanceId: "codex-test",
+      startedAt: now,
+    });
+    appendRuntimeWorkerRecord(rootDir, dispatchId, { kind: "process_started", pid: process.pid });
+    assert.throws(
+      () => taskMutation(reclaimCell, { kind: "task-release", taskId: task.taskId }, task, heldSnapshot, replacement),
+      (error: unknown) => error instanceof Error && "code" in error && error.code === "lease_conflict",
+      "a live dispatch process must retain its lease",
+    );
+
+    appendRuntimeWorkerRecord(rootDir, dispatchId, { kind: "process_started", pid: 2_147_483_647 });
+    const mutation = taskMutation(
+      reclaimCell,
+      { kind: "task-release", taskId: task.taskId, reason: "The bound dispatch process is gone." },
+      task,
+      heldSnapshot,
+      replacement,
     );
     assert.equal(mutation.type, "lease_released");
     assert.equal(mutation.releasedLease, heldLease);


### PR DESCRIPTION
# English

## Summary

Reclaim orphaned execution leases. When a task-bound dispatch dies abnormally (provider-fault / process crash / daemon interruption) its RuntimeSession's canonical liveness projection can remain `live` while the worker PID is already gone; that stale-projection window left the held execution lease unreclaimable — a same-principal `task-release` and `task-start` both returned `lease_conflict`, deadlocking the task (observed live in fact `F-5B1B20A4`). This adds an orphan predicate: a dispatch whose stream proves the process is dead (`process.exited` or PID not alive) and whose fallback is not `scheduled` is treated as terminal, so its lease becomes reclaimable by the same principal / task owner. Normal provider-fault settlement (which already released the lease) is unchanged.

## Architectural Justification

The fix narrows the reclaim dead-zone rather than adding a force bypass. `terminalExecutionRuntimeBinding` already inferred terminal sessions from settled dispatch outcomes; that predicate is extracted as `dispatchReachedTerminalAttempt`, and a second `dispatchProcessIsOrphaned` predicate is added for the stale-projection window (dead PID + not scheduled fallback). The session loop stops skipping a session whose canonical projection still says `live`/`running` only when the dispatch stream has proven its process dead. Liveness is checked with the existing `runtimePidIsAlive` (`process.kill(pid, 0)`). Live-worker lease protection is intact: a live worker's PID is alive with no settled outcome, so neither predicate fires and the session is still skipped — its lease cannot be stolen.

## What Changed

- `packages/daemon/src/repo-cell-task-mutation.ts`: extract `dispatchReachedTerminalAttempt`; add `dispatchProcessIsOrphaned` (dead PID + not scheduled); allow reclaim when the dispatch stream proves the process dead even though the canonical RuntimeSession projection is still `live`.
- `packages/daemon/test/lease-reservation-reclaim.contract.test.ts`: dead-PID positive reclaim case + live-PID negative control.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: use the single CI-backed `Production-Delta` declaration below; do not enter a second metric.

## Machine-Readable Declarations

Production-Delta: +26/-6
Dependency-Change: none

## Task And Scope

- Harness task: task_3289e25f3459b4085b01d2822d (orphaned-lease-reclaim; spun off from self-closeout investigation task_f998c4c5b0b7032cc8fff90fde)
- Branch: codex/orphaned-lease
- Public scope: packages/daemon dispatch/lease reclaim + its contract test
- Private planning/evidence updated: yes (task package; facts F-5B1B20A4 repro sample, F-B2D3F796 fix)
- Out of scope: worker self-closeout identity gate (already fixed by #2085 + attach-only), GUI, CI/gate

## Version Impact

- Version: no version change because this is a pre-release product slice with no published package surface change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope:
- Authority: task_3289e25f3459b4085b01d2822d, fact F-5B1B20A4 (live deadlock sample)
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no

## Verification

- Base `origin/main` SHA: rebased clean onto latest main (post-W4a #2108)
- Sync method: rebase onto latest main (no conflict)
- Public diff command: `git diff origin/main...codex/orphaned-lease`
- [x] Isolated contract `lease-reservation-reclaim.contract.test.ts`: 7/7 (incl. live-PID negative control, dead-PID positive reclaim)
- [x] Isolated provider-fallback integration: 2/2
- [x] `npm run lint`, line-density, file-complexity, production-delta, `git diff --check`: pass
- [ ] GitHub Actions passed
- [ ] CEO post-merge real-machine: reclaim + re-dispatch the deadlocked legacy task_ca15895a
- Note: implemented by the Sol worker; author ZeyuLi.

---

# 中文

## 摘要

回收孤儿 execution lease。task-bound dispatch 异常终止（provider-fault / 进程崩溃 / daemon 中断）时,其 RuntimeSession 的 canonical liveness 投影可能仍是 `live`,而 worker PID 已死;这个 stale-projection 窗口让占用的 lease 无法回收——同 principal 的 `task-release` 与 `task-start` 都返回 `lease_conflict`,task 彻底 deadlock(活样本 fact `F-5B1B20A4`)。本 PR 加孤儿判定:dispatch stream 证明进程已死(`process.exited` 或 PID 不在)且 fallback 非 `scheduled` 时视为终态,其 lease 可被同 principal / task owner 回收。正常 provider-fault settle(本就释放 lease)不变。

## 架构辩护

修复收窄回收死区,不加 force 旁路。`terminalExecutionRuntimeBinding` 原本从 settled outcome 推断终态 session,该谓词抽为 `dispatchReachedTerminalAttempt`;新增 `dispatchProcessIsOrphaned`(死 PID + 非 scheduled fallback)覆盖 stale-projection 窗口。session loop 仅在 dispatch stream 已证进程死亡时,才不再跳过 canonical 投影仍为 `live`/`running` 的 session。存活用既有 `runtimePidIsAlive`(`process.kill(pid,0)`)判定。活 worker lease 保护完好:活 worker PID 活着且无 settled outcome,两谓词都不触发,session 照旧跳过——lease 抢不动。

## 变更清单

- `repo-cell-task-mutation.ts`:抽 `dispatchReachedTerminalAttempt`;加 `dispatchProcessIsOrphaned`;允许在 dispatch 证进程死亡时回收(即便 canonical 投影仍 live)。
- `lease-reservation-reclaim.contract.test.ts`:死 PID 阳性回收 + 活 PID 阴性对照。

## 任务与范围

- Harness 任务:task_3289e25f3459b4085b01d2822d(从 self-closeout 调查 task_f998c4c5 分出);范围外:worker 自助收口身份门(#2085 已修)、GUI、CI/gate。

## 治理声明

- 未触碰 protected surface;无 break-glass。授权:task_3289e25f3459b4085b01d2822d、fact F-5B1B20A4(活 deadlock 样本)。

## 验证

- 隔离 contract 7/7(含活 PID 阴性对照、死 PID 阳性回收);隔离 provider-fallback integration 2/2;lint/line-density/file-complexity/production-delta/diff --check 均过。
- CEO 合并后真机验证:回收并重派 deadlock 遗留 task_ca15895a。
- 说明:Sol 实现;作者 ZeyuLi。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BE45Q2y1iZzLJNo8j7xhhL
