### PR TITLE
feat(gates): enforce allowlist path existence

### DIFF
--- a/tools/gate-manifest.json
+++ b/tools/gate-manifest.json
@@ -4710,6 +4710,56 @@
       }
     },
     {
+      "id": "allowlist-path-existence",
+      "command": "node tools/gates/allowlist-path-existence.mjs --mode ratchet",
+      "category": "boundary",
+      "tier": "pr-advisory",
+      "tierReason": "B13 starts in the existing advisory governance job; promotion to a required context remains a CEO-controlled switch after observation.",
+      "authoritySource": [
+        "task_01130d097481420c8d59e1fe08",
+        "decision/dec_99000027E6BCC263E341D38DC0/CH2"
+      ],
+      "consumerScope": [
+        "path-accounting sections in tools/gate-allowlists/*.json",
+        "path fingerprints and known-debt entries in the five registered inline baseline modules"
+      ],
+      "githubContext": {
+        "requiredContexts": [],
+        "workflowJobs": ["ontology-advisory"],
+        "nodeVersions": [24]
+      },
+      "allowlistPolicy": {
+        "allowed": false,
+        "location": null,
+        "adrOrDecisionRequired": false,
+        "notes": "Missing targets and unclassified JSON allowlist sections fail closed; intentional absence ledgers are classified as non-path semantics."
+      },
+      "changeControl": {
+        "ordinaryImplementationMayModify": false,
+        "requiresGovernanceEvidence": true,
+        "protectedSurfaces": [
+          "tools/gates/allowlist-path-existence.mjs",
+          "tools/gates/test/allowlist-path-existence.test.mjs",
+          "tools/gate-manifest.json"
+        ]
+      },
+      "bypassFixtureRequired": true,
+      "executionSurfaces": {
+        "packageJson": { "check": false, "checkPr": false, "script": null },
+        "rewriteCi": { "pullRequestJobs": ["ontology-advisory"], "nonPullRequestJobs": [] },
+        "branchProtection": { "required": false, "contexts": [] },
+        "classes": ["pr"]
+      },
+      "deterministic": true,
+      "positiveControl": {
+        "status": "covered",
+        "evidence": [
+          "tools/gates/test/allowlist-path-existence.test.mjs",
+          "tools/gates/test/fixtures/allowlist-path-existence-missing.json"
+        ]
+      }
+    },
+    {
       "id": "ontology-kind-authority",
       "command": "node tools/gates/ontology-kind-authority.mjs",
       "category": "boundary",

--- a/tools/gates/allowlist-path-existence.mjs
+++ b/tools/gates/allowlist-path-existence.mjs
@@ -1,0 +1,238 @@
+#!/usr/bin/env node
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { TASK_EVENT_CONSTRUCTION_ALLOWLIST } from "../gate-allowlists/task-event-aggregate-entry.mjs";
+import { kernelImportBoundaryKnownDebt } from "../kernel-import-boundary-known-debt.mjs";
+import { portPhysicalIoBoundaryKnownDebt } from "../port-physical-io-boundary-known-debt.mjs";
+import { exitCodeFor, parseCommonArgs } from "./ontology-gate-lib.mjs";
+import { noSwallowedFailureBaseline } from "./no-swallowed-failure-baseline.mjs";
+import { processPortOnlyBaseline } from "./process-port-only-baseline.mjs";
+
+const allowlistSchema = "harness-anything/gate-allowlist/v1";
+const jsonPolicies = Object.freeze({
+  "check-bypass-write-boundary.json": {
+    pathSections: {},
+    nonPathSections: [
+      "rebuildable-projection",
+      "coordinatedCore",
+      "exemptHumanOrBootstrap",
+      "legacyArchive",
+      "freshGateRegistry",
+    ],
+  },
+  "check-implementation-contracts.json": {
+    pathSections: {
+      expectedRuntimeTestFiles: "value",
+      expectedWorkspaceTsconfigs: "value",
+      guiCliTextFiles: "value",
+      localLifecycleCliTextFiles: "value",
+      extensionSchemaPaths: "value",
+    },
+    nonPathSections: [
+      "packageLockVersions",
+      "forbiddenLockfiles",
+      "requiredCompilerOptions",
+      "portablePathRequiredSnippets",
+      "portablePathTestEvidence",
+      "guiImplementationSnippets",
+      "applicationServiceSnippets",
+      "guiSecurityEvidence",
+      "storeRequiredSnippets",
+      "localLifecycleRequiredSnippets",
+      "taskProjectionRequiredSnippets",
+      "multicaRequiredSnippets",
+      "multicaForbiddenVerbs",
+      "extensionRequiredSnippets",
+      "browserWindowRequiredPatterns",
+    ],
+  },
+  "check-import-boundaries.json": {
+    pathSections: {
+      guiAdapterCompositionRoots: "value",
+      cliAdapterCompositionRoots: "value",
+      kernelStoreCompositionRoots: "value",
+      cliAdapterKnownDebt: "value",
+    },
+    nonPathSections: [],
+  },
+  "check-integration-test-shards.json": {
+    pathSections: {},
+    nonPathSections: ["intentionalTestDeletions"],
+  },
+  "check-integrity-single-source.json": {
+    pathSections: { authorities: "path" },
+    nonPathSections: [],
+  },
+  "check-kernel-dead-exports.json": {
+    pathSections: {},
+    nonPathSections: ["zeroConsumptionExports"],
+  },
+  "check-private-boundary.json": {
+    pathSections: {},
+    nonPathSections: ["privateContentMarkers"],
+  },
+  "scan-forbidden-symbols.json": {
+    pathSections: {},
+    nonPathSections: ["forbiddenSymbols"],
+  },
+});
+
+const explicitExclusions = Object.freeze([
+  "check-implementation-contracts.packageLockVersions (package-lock keys, not checkout paths)",
+  "check-implementation-contracts.forbiddenLockfiles (absence is the contract)",
+  "check-integration-test-shards.intentionalTestDeletions (intentional deletion tombstones)",
+  "scan-forbidden-symbols.forbiddenSymbols (symbol and regex entries)",
+]);
+
+export function collectAllowlistPathEntries(rootDir = process.cwd()) {
+  return [...collectJsonPathEntries(rootDir), ...collectInlinePathEntries()];
+}
+
+export function auditAllowlistPathExistence(rootDir, entries) {
+  const findings = [];
+  for (const entry of entries) {
+    const invalidReason = invalidRelativePathReason(entry.relativePath);
+    if (invalidReason !== null) {
+      findings.push(`${entry.source}: ${JSON.stringify(entry.relativePath)} ${invalidReason}`);
+      continue;
+    }
+    if (!existsSync(path.join(rootDir, ...entry.relativePath.split("/")))) {
+      findings.push(`${entry.source}: ${entry.relativePath} does not exist`);
+    }
+  }
+  return { checked: entries.length, findings };
+}
+
+function collectJsonPathEntries(rootDir) {
+  const allowlistRoot = path.join(rootDir, "tools/gate-allowlists");
+  const jsonFiles = readdirSync(allowlistRoot)
+    .filter((name) => name.endsWith(".json"))
+    .sort();
+  const unclassifiedFiles = jsonFiles.filter((name) => !Object.hasOwn(jsonPolicies, name));
+  if (unclassifiedFiles.length > 0) {
+    throw new Error(`unclassified JSON allowlist(s): ${unclassifiedFiles.join(", ")}`);
+  }
+
+  const entries = [];
+  for (const [fileName, policy] of Object.entries(jsonPolicies)) {
+    const relativeFile = `tools/gate-allowlists/${fileName}`;
+    const parsed = JSON.parse(readFileSync(path.join(rootDir, relativeFile), "utf8"));
+    if (parsed.schema !== allowlistSchema || typeof parsed.entries !== "object" || parsed.entries === null) {
+      throw new Error(`${relativeFile} must use ${allowlistSchema} and define entries`);
+    }
+    const classifiedSections = new Set([...Object.keys(policy.pathSections), ...policy.nonPathSections]);
+    const unclassifiedSections = Object.keys(parsed.entries).filter((section) => !classifiedSections.has(section));
+    if (unclassifiedSections.length > 0) {
+      throw new Error(`${relativeFile} has unclassified section(s): ${unclassifiedSections.join(", ")}`);
+    }
+    for (const [section, field] of Object.entries(policy.pathSections)) {
+      if (!Object.hasOwn(parsed.entries, section)) {
+        throw new Error(`${relativeFile} is missing classified path section entries.${section}`);
+      }
+      collectEntryTree(entries, parsed.entries[section], `${relativeFile}:entries.${section}`, field);
+    }
+  }
+  return entries;
+}
+
+function collectEntryTree(entries, value, source, field) {
+  if (Array.isArray(value)) {
+    for (const [index, entry] of value.entries()) {
+      if (typeof entry?.[field] !== "string" || entry[field].trim() === "") {
+        throw new Error(`${source}[${index}].${field} must be a non-empty path`);
+      }
+      entries.push({ source: `${source}[${index}].${field}`, relativePath: entry[field] });
+    }
+    return;
+  }
+  if (typeof value !== "object" || value === null) {
+    throw new Error(`${source} must be an entry list or nested object of entry lists`);
+  }
+  for (const [key, child] of Object.entries(value)) {
+    collectEntryTree(entries, child, `${source}.${key}`, field);
+  }
+}
+
+function collectInlinePathEntries() {
+  const entries = [];
+  collectFingerprintPaths(entries, noSwallowedFailureBaseline, "tools/gates/no-swallowed-failure-baseline.mjs");
+  collectFingerprintPaths(entries, processPortOnlyBaseline, "tools/gates/process-port-only-baseline.mjs");
+  for (const key of Object.keys(TASK_EVENT_CONSTRUCTION_ALLOWLIST)) {
+    const separator = key.indexOf("|");
+    if (separator <= 0) throw new Error(`task-event aggregate allowlist key has no path prefix: ${key}`);
+    entries.push({
+      source: `tools/gate-allowlists/task-event-aggregate-entry.mjs:${key}`,
+      relativePath: key.slice(0, separator),
+    });
+  }
+  for (const [index, entry] of kernelImportBoundaryKnownDebt.entries()) {
+    entries.push(
+      {
+        source: `tools/kernel-import-boundary-known-debt.mjs:kernelImportBoundaryKnownDebt[${index}].file`,
+        relativePath: entry.file,
+      },
+      {
+        source: `tools/kernel-import-boundary-known-debt.mjs:kernelImportBoundaryKnownDebt[${index}].target`,
+        relativePath: entry.target,
+      },
+    );
+  }
+  for (const [index, entry] of portPhysicalIoBoundaryKnownDebt.entries()) {
+    entries.push({
+      source: `tools/port-physical-io-boundary-known-debt.mjs:portPhysicalIoBoundaryKnownDebt[${index}].file`,
+      relativePath: entry.file,
+    });
+  }
+  return entries;
+}
+
+function collectFingerprintPaths(entries, baseline, source) {
+  for (const [index, entry] of baseline.entries()) {
+    const match = /^(.*):\d+:\d+#[0-9a-f]{64}$/u.exec(entry);
+    if (match === null) throw new Error(`${source}[${index}] is not a path fingerprint`);
+    entries.push({ source: `${source}[${index}]`, relativePath: match[1] });
+  }
+}
+
+function invalidRelativePathReason(relativePath) {
+  if (relativePath.trim() !== relativePath || relativePath === "") return "must be a non-empty trimmed path";
+  if (path.posix.isAbsolute(relativePath) || path.win32.isAbsolute(relativePath)) {
+    return "must be repository-relative";
+  }
+  if (relativePath.includes("\\") || relativePath.split("/").some((part) => part === "." || part === "..")) {
+    return "must use normalized repository-relative path segments";
+  }
+  return null;
+}
+
+function loadFixturePathEntries(fixture) {
+  const parsed = JSON.parse(readFileSync(fixture, "utf8"));
+  if (parsed.schema !== allowlistSchema || !Array.isArray(parsed.entries?.paths)) {
+    throw new Error(`fixture must use ${allowlistSchema} and define entries.paths`);
+  }
+  const entries = [];
+  collectEntryTree(entries, parsed.entries.paths, `${fixture}:entries.paths`, "value");
+  return entries;
+}
+
+export function main(argv = process.argv.slice(2)) {
+  try {
+    const { rootDir, mode, fixture } = parseCommonArgs(argv, { allowFixture: true });
+    const entries = fixture === null ? collectAllowlistPathEntries(rootDir) : loadFixturePathEntries(fixture);
+    const result = auditAllowlistPathExistence(rootDir, entries);
+    console.log(`B13 allowlist-path-existence: ${mode}`);
+    console.log(`checked path-accounting entries (${result.checked})`);
+    console.log(`explicit non-path exclusions (${explicitExclusions.length}): ${explicitExclusions.join("; ")}`);
+    console.log(`findings (${result.findings.length}):`);
+    for (const finding of result.findings) console.log(`- ${finding}`);
+    return exitCodeFor(mode, result.findings.length);
+  } catch (error) {
+    console.error(`B13 allowlist-path-existence: ${error instanceof Error ? error.message : String(error)}`);
+    return 1;
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href) {
+  process.exitCode = main();
+}

--- a/tools/gates/test/allowlist-path-existence.test.mjs
+++ b/tools/gates/test/allowlist-path-existence.test.mjs
@@ -1,0 +1,35 @@
+// harness-test-tier: fast
+import assert from "node:assert/strict";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { main } from "../allowlist-path-existence.mjs";
+import { captureGate, writeRepoFile } from "./helpers.mjs";
+
+const repoRoot = path.resolve(import.meta.dirname, "../../..");
+
+test("B13 ratchet accepts live paths and rejects an allowlist row for a missing file", () => {
+  const repository = captureGate(() => main(["--root", repoRoot, "--mode", "ratchet"]));
+  assert.equal(repository.code, 0, repository.stderr || repository.stdout);
+  assert.match(repository.stdout, /checked path-accounting entries \(80\)/u);
+  assert.match(repository.stdout, /findings \(0\)/u);
+
+  const fixturePath = path.join(import.meta.dirname, "fixtures/allowlist-path-existence-missing.json");
+
+  const positive = captureGate(() => main(["--root", repoRoot, "--fixture", fixturePath, "--mode", "ratchet"]));
+  assert.equal(positive.code, 1);
+  assert.match(positive.stdout, /findings \(1\)/u);
+  assert.match(positive.stdout, /packages\/allowlist-positive-control-does-not-exist\.ts does not exist/u);
+  assert.doesNotMatch(positive.stdout, /packages does not exist/u);
+
+  const unclassifiedRoot = mkdtempSync(path.join(tmpdir(), "allowlist-path-unclassified-"));
+  writeRepoFile(
+    unclassifiedRoot,
+    "tools/gate-allowlists/new-governance-list.json",
+    '{"schema":"harness-anything/gate-allowlist/v1","gateId":"new-governance-list","entries":{}}\n',
+  );
+  const unclassified = captureGate(() => main(["--root", unclassifiedRoot, "--mode", "ratchet"]));
+  assert.equal(unclassified.code, 1);
+  assert.match(unclassified.stderr, /unclassified JSON allowlist\(s\): new-governance-list\.json/u);
+});

--- a/tools/gates/test/fixtures/allowlist-path-existence-missing.json
+++ b/tools/gates/test/fixtures/allowlist-path-existence-missing.json
@@ -1,0 +1,18 @@
+{
+  "schema": "harness-anything/gate-allowlist/v1",
+  "gateId": "allowlist-path-existence-positive-control",
+  "entries": {
+    "paths": [
+      {
+        "value": "packages",
+        "ref": "task_01130d097481420c8d59e1fe08",
+        "reason": "Existing directories are valid path-accounting targets."
+      },
+      {
+        "value": "packages/allowlist-positive-control-does-not-exist.ts",
+        "ref": "task_01130d097481420c8d59e1fe08",
+        "reason": "Positive control: a missing allowlist target must make the ratchet red."
+      }
+    ]
+  }
+}


### PR DESCRIPTION
# English

## Summary

Forges the B13 governance gate (泽宇 2026-09-01 ruling, dec_99000027E6BCC263E341D38DC0/CH2): every path-carrying allowlist/baseline entry must reference a file that exists in the checkout. `tools/gates/allowlist-path-existence.mjs` verifies all 80 current path entries — JSON allowlist path fields, the four inline baselines, and the task-event construction allowlist path keys found by the same-mechanism sweep — with a fail-closed classification: an unknown JSON allowlist file or unknown section fails the gate outright. Four field classes that are semantically not checkout paths (package-lock keys, must-not-exist lockfiles, deletion tombstones, symbol/regex entries) are explicitly excluded and printed in the gate output. Registered in the existing `ontology-advisory` CI job as `pr-advisory` (requiredContext: null); the required promotion stays with the CEO per the ruling. Root cause context: the residue audit found 70 dead allowlist entries that had silently outlived their files.

## Architectural Justification

- Mechanism sentence: an exception register whose entries are never checked against the thing they exempt degrades into untracked permission; existence is the cheapest invariant that keeps every register row honest, checked where the register is loaded.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none

## Machine-Readable Declarations

Production-Delta: +238/-0
Dependency-Change: none

### Optional Evidence Claims

None.

## Task And Scope

- Harness task task_01130d097481420c8d59e1fe08 (B13 铸门). Branch `codex/allowlist-existence-gate`.

## Version Impact

- Version: no change. Publish impact: none.

## Governance Declaration

- Protected surface touched: yes — new gate file plus its registration in the gate manifest / ontology-advisory job. This task is itself the forging authorization: dec_99000027E6BCC263E341D38DC0/CH2 (泽宇残余审计 B13 亲裁, fact F-0650A7F1), advisory-first per the G0 pattern. Break-glass: no.

## Verification

- Worker: real-repo run 80 entries / 0 findings; positive-control fixture (a registered path that does not exist) fails with exactly one finding; gate/manifest targeted suites 203/203; ontology-advisory job 5/5 with the new gate live; contract tier 855/855; lint / line-density / file-complexity / canonical-event-compat / G33 (+238/-0) all green.
- CEO independently re-ran the gate (80/0) and the positive-control fixture (1 finding) in the worktree.
- [ ] Full suites: GitHub CI is the authority.

## Review Evidence

- Environment-limited layers are reported honestly, not claimed: full integration tier shows macOS long-socket-path `listen EINVAL` failures with no import-chain relation to the four changed files; five fast-tier failures are the task-bound git wrapper correctly refusing fixture pushes to main.

## Residual Risk

- G-FIX-05 ref-object reachability is deliberately not forged here: the public repo carries no consumable authored Task/Decision/ADR index, and pointing a public gate at the private ledger would import machine-local state. It routes to a follow-up task (public evidence index first, then the reachability gate). `task_P4_INT` therefore remains unresolved by design in this PR.

---

# 中文

## 概要

铸 B13 治理门(dec_99000027/CH2,泽宇亲裁):所有路径型 allowlist/baseline 条目必须指向 checkout 中真实存在的文件。`allowlist-path-existence.mjs` 以 fail-closed 分类核验当前 80 条(JSON 路径字段 + 4 个 inline baseline + 同机制扫入的 task-event 路径键),未知 allowlist 文件/未知 section 直接红;四类语义非路径字段显式排除并在输出列明。注册进既有 ontology-advisory job,advisory 起步,required 晋升按裁决留给 CEO。根因背景:残余审计发现 70 条死条目静默滞留。

## 架构辩护

- 机制句:从不与其豁免对象对账的例外登记簿会退化成无主许可;存在性是让每一行保持诚实的最便宜不变量,在装载处执法。

## 机读声明

`Production-Delta: +238/-0`(新门+测试+阳性 fixture,无旧实现可删)。

## 治理声明

- 本任务即铸门授权(CH2 + F-0650A7F1),沿 G0 advisory 模式;无 break-glass。

## 验证

- worker 九面绿 + 真仓 80/0 + 阳性对照 1 finding;CEO 亲验复跑两者;完整权威=GitHub CI。

## 残余风险

- G-FIX-05 的 ref 可达性有意不在本 PR 硬做(公开仓无可消费台账索引,公共 gate 不得读私有 ledger),另立件先建公开 evidence index;`task_P4_INT` 因此在本 PR 保持未解。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VTzQAqvuFy6ikGjBKxA9xj
