### PR TITLE
fix(gates): stop freezing the B13 allowlist entry count in its own test

### DIFF
--- a/tools/gates/test/allowlist-path-existence.test.mjs
+++ b/tools/gates/test/allowlist-path-existence.test.mjs
@@ -12,7 +12,7 @@ const repoRoot = path.resolve(import.meta.dirname, "../../..");
 test("B13 ratchet accepts live paths and rejects an allowlist row for a missing file", () => {
   const repository = captureGate(() => main(["--root", repoRoot, "--mode", "ratchet"]));
   assert.equal(repository.code, 0, repository.stderr || repository.stdout);
-  assert.match(repository.stdout, /checked path-accounting entries \(80\)/u);
+  assert.match(repository.stdout, /checked path-accounting entries \([1-9]\d*\)/u);
   assert.match(repository.stdout, /findings \(0\)/u);
 
   const fixturePath = path.join(import.meta.dirname, "fixtures/allowlist-path-existence-missing.json");


### PR DESCRIPTION
# English

## Summary

Main went red after #2111 and #2112 landed together: the B13 allowlist-path-existence gate's own test froze the exact repository entry count (80), and the kernel-debt cleanup legitimately shrank the allowlists to 77 entries. This hotfix removes the frozen count — the repository run now asserts a positive entry count and zero findings. Detection strength is unchanged: the positive-control fixture in the same test still proves a registered-but-missing path fails the gate with exactly one finding.

## Architectural Justification

- Mechanism sentence: a gate test that pins a number owned by other changes turns every legitimate allowlist edit into a false red; the invariant worth freezing is "all entries checked, none dangling", not the entry count.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none

## Machine-Readable Declarations

Production-Delta: +0/-0
Dependency-Change: none

### Optional Evidence Claims

None.

## Task And Scope

- Post-merge repair of the cross-PR interaction between #2111 (allowlist shrink) and #2112 (B13 gate); routes to task_01130d097481420c8d59e1fe08 (B13 铸门). Branch `codex/b13-count-hotfix`.

## Version Impact

- Version: no change. Publish impact: none.

## Governance Declaration

- Protected surface touched: yes — one assertion inside the B13 gate's test. Authorization: same as the gate itself, dec_99000027E6BCC263E341D38DC0/CH2; this is a main-red repair, no break-glass.

## Verification

- Local repro on main tip e38214300: gate reports 77 entries, test fails on the frozen 80; after the fix the test passes 1/1 with the positive-control fixture still failing closed.
- [ ] Full suites: GitHub CI is the authority.

## Review Evidence

- CEO-authored one-line hotfix; the brittle assertion is the only change.

## Residual Risk

- None beyond the gate no longer pinning a count; entry-level honesty remains enforced per entry by the gate itself.

---

# 中文

## 概要

#2111 与 #2112 同落 main 后交叉撞红:B13 门自己的测试冻结了仓库条目精确数(80),而 kernel 债务清理合法地把白名单缩到 77。本热修删掉冻结数,仓库跑断言改为「正数条目 + 0 findings」;检测力不变——同测试内的阳性对照 fixture 仍证明「登记了但文件不存在」会以恰好 1 条 finding 拒绝。

## 架构辩护

- 机制句:gate 测试钉死一个由其他变更拥有的数字,等于把每次合法白名单编辑都变成假红;值得冻结的不变量是「每条都被检查、无悬空」,不是条目数。

## 机读声明

`Production-Delta: +0/-0`

## 治理声明

- 触碰 B13 门测试一处断言;授权与铸门同源(dec_99000027/CH2),main 红修复,无 break-glass。

## 验证

- main tip 本地复现后修复,测试 1/1,阳性对照仍 fail-closed;完整权威=GitHub CI。

## 残余风险

- 无;逐条诚实性仍由门本身逐条执法。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VTzQAqvuFy6ikGjBKxA9xj

