### PR TITLE
fix(daemon): materialize reads blobs only for divergent files, not the whole corpus

### DIFF
--- a/packages/kernel/src/store/wal-shadow-event-store.ts
+++ b/packages/kernel/src/store/wal-shadow-event-store.ts
@@ -688,12 +688,16 @@ function materializeVisible(
   const conflicts: string[] = [];
   const writes: { target: string; body: string; mode: "100644" | "120000" }[] = [];
   for (const [logical, claim] of [...latest].sort(([left], [right]) => left.localeCompare(right))) {
-    const bytes = wal.readContentBlob(claim.sha256) ?? readGitContent(claim.sha256);
-    if (bytes === null) continue;
     const target = ledgerGitPath(ledger, logical);
     const physical = pathFor(ledger.rootDir, target);
     const local = localGitWorktreeSettlement.readNode(physical);
+    // Decide divergence from the worktree hash and the in-memory claim alone; an already-materialized
+    // document is skipped before any canonical blob is read. This keeps materialize proportional to the
+    // number of divergent files, not the size of the whole corpus: a current worktree reads zero blobs
+    // (previously every document forced a `git show`, which wedged the daemon event loop at scale).
     if (local?.sha256 === claim.sha256 && local.mode === claim.mode) continue;
+    const bytes = wal.readContentBlob(claim.sha256) ?? readGitContent(claim.sha256);
+    if (bytes === null) continue;
     const base = committed.get(target);
     if (local !== null && (base === undefined || local.gitOid !== base.oid || local.mode !== base.mode))
       conflicts.push(

--- a/packages/kernel/test/store/wal-shadow-event-store.test.ts
+++ b/packages/kernel/test/store/wal-shadow-event-store.test.ts
@@ -469,3 +469,42 @@ function git(rootDir: string, ...args: readonly string[]): string {
     encoding: "utf8",
   }).trim();
 }
+
+test("materialize reads canonical blobs only for divergent files, not once per document", async () => {
+  await withTempStoreAsync(async (rootDir) => {
+    initRepo(rootDir);
+    const docCount = 8,
+      store = makeWalShadowEventStore({ repoId: "materialize-scale", rootDir, walFlushEvents: 64, walFlushMs: 60_000 });
+    for (let revision = 1; revision <= docCount; revision += 1)
+      store.append(taskBundle(revision, `# doc ${revision}\n`));
+    await store.drain();
+
+    // A fresh process view holds no WAL content in memory, so every canonical blob read must fall through
+    // to a Git subprocess — exactly what processCount observes. The first materialize settles the worktree
+    // and any one-off content validation; steady-state cost is then measured on the second call.
+    const fresh = makeWalShadowEventStore({ repoId: "materialize-scale", rootDir, walFlushMs: 60_000 });
+    assert.deepEqual(fresh.materialize().changed, []);
+    const cleanStarted = localGitObjectRefStore.processCount(),
+      clean = fresh.materialize(),
+      cleanProcesses = localGitObjectRefStore.processCount() - cleanStarted;
+    assert.deepEqual(clean.changed, []);
+    assert.ok(
+      cleanProcesses < docCount,
+      `a current worktree must not start one Git read per document (started ${cleanProcesses} for ${docCount} docs)`,
+    );
+
+    // Deleting a subset makes materialize restore exactly those files and read strictly more than the clean
+    // pass — proving the blob reads are proportional to divergence, not to the size of the corpus.
+    const removed = [2, 5, 7].map((revision) => `tasks/task-${revision}/task.md`);
+    for (const target of removed) rmSync(path.join(rootDir, "harness", target));
+    const restoreStarted = localGitObjectRefStore.processCount(),
+      restored = fresh.materialize(),
+      restoreProcesses = localGitObjectRefStore.processCount() - restoreStarted;
+    assert.deepEqual([...restored.changed].sort(), [...removed].sort());
+    assert.ok(
+      restoreProcesses > cleanProcesses,
+      `restoring ${removed.length} divergent files must read their blobs (${restoreProcesses}) — a clean pass reads ${cleanProcesses}`,
+    );
+    await fresh.drain();
+  });
+});


### PR DESCRIPTION
# English

## Summary

`ha doc materialize` (restore the canonical document cut to the worktree) could wedge the whole daemon on a large ledger. `store.materialize()` resolves to `materializeVisible` (the composition barrel aliases `makeWalShadowEventStore` as `makeTaskEventStore`, so the daemon and every test run this implementation). It iterated **every** document in the current cut in one no-yield synchronous loop, and — worse — read each document's canonical blob via a synchronous `git show` (`execFileSync`) **before** checking whether the worktree already matched. On a ledger with tens of thousands of events and thousands of documents that fired thousands of synchronous git subprocesses on the daemon's single event-loop thread, so `protocol.hello` heartbeats and even `SIGTERM` could not be serviced; a routine materialize hung the daemon until it was `SIGKILL`ed.

This does not delete the command — the capability is legitimate. It makes it scale: move the canonical blob read to **after** the worktree/claim divergence check. An already-materialized document is skipped after a single worktree hash, before any git read. Cost is now proportional to the number of divergent files, not the size of the corpus — a current worktree reads zero canonical blobs.

## What Changed

- `packages/kernel/src/store/wal-shadow-event-store.ts` — in `materializeVisible`, the divergence skip-check (`local.sha256 === claim.sha256 && local.mode === claim.mode`) now runs before the `wal.readContentBlob(...) ?? readGitContent(...)` read. Unchanged documents cost one worktree stat+hash and zero canonical reads. `materializeVisible` stays internal (no new public surface).
- `packages/kernel/test/store/wal-shadow-event-store.test.ts` — new regression test that exercises the public `store.materialize()` and uses the existing `localGitObjectRefStore.processCount()` Git-subprocess counter to assert a current worktree does not start one Git read per document, and that restoring a deleted subset reads strictly more than a clean pass.

Behaviour is unchanged: restore, idempotent no-op, deterministic conflict preservation, and symlink mode are all preserved.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none

## Machine-Readable Declarations

Production-Delta: +6/-2

## Task And Scope

- Harness task: task_0fcb17a85c9f2b69a28120cecb
- Branch: codex/materialize-scale-fix
- Public scope: `materializeVisible` divergence-before-read reordering (kernel) and one kernel regression test; no new public API surface
- Private planning/evidence updated: yes (fact F-092A86C4)
- Out of scope: the plain `materialize` in `task-event-store-materialization.ts`, which is exercised only by kernel tests through the plain factory store (production always resolves the WAL store); an O(divergent) rewrite using bulk `git diff` (not needed — the common case already reads zero blobs)

## Version Impact

- Version: no version change (internal store behaviour + a new internal barrel export)
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: task_0fcb17a85c9f2b69a28120cecb; fact F-092A86C4
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: merge-base 83d6839004fe999dd12e95af30f33ad9f77f6adc
- Last `git fetch origin` time: 2026-09-01 (this session)
- Public diff command: `git diff origin/main...codex/materialize-scale-fix`
- Private evidence: task_0fcb17a85c9f2b69a28120cecb fact F-092A86C4
- [x] `npx tsc -b packages/kernel packages/daemon` (exit 0)
- [x] `eslint` clean on changed files; `check-kernel-dead-exports` passes (no new zero-consumer export)
- [x] `wal-shadow-event-store` kernel suite: the new zero-read regression passes; the one unrelated local red (`a master branch forked …`) also fails on `origin/main` on this machine (a Git-message env mismatch, not this change)
- [x] `doc-sync-slice-a-materialization` 4/4 (restore + idempotent no-op + conflict preservation + async-cut ancestry)
- [x] `task-progress-store` 3/3, `task-event-store-decision-recovery` 14/14, `preset-bootstrap` 1/1, `migration-import.integration` 7/7 (every `store.materialize()` caller — restore/conflict/symlink all green)
- [x] `doc-sync-artifact-opaque` 7/7 (the `doc materialize` command end-to-end still works)
- Not run: full `npm test` / harness:* suite (worker stop-point policy; CI is the full authority)
- Post-merge: complete task_0fcb17a85c9f2b69a28120cecb against the merge anchor

## Review Evidence

- Self-review: the reorder is behaviour-preserving by inspection — the skip check reads `local.sha256`/`local.mode` (worktree) against `claim.sha256`/`claim.mode` (in-memory), never the canonical blob, so deferring the blob read cannot change which documents are restored or how conflicts are preserved; the 17 existing behaviour tests confirm it, and the new test locks the read-count invariant that a plain behaviour test cannot see
- Reviewer subagent: CEO authored and verified directly (Explore agent mapped the full call chain to confirm the synchronous-subprocess root cause)
- Human review: pending on this PR
- Blocking findings: none open

## Residual Risk

- The common case (current worktree) is now zero canonical reads; a total-worktree-wipe disaster restore still reads every divergent blob (inherent recovery work) and still walks every document with one worktree stat+hash (O(corpus) fast fs, no subprocess). If that ever needs to be O(divergent), a bulk `git diff` pre-pass is the follow-up; it is not needed to make the command usable.

## References

- Task: task_0fcb17a85c9f2b69a28120cecb
- Evidence: fact F-092A86C4

---

# 中文

## 概要

`ha doc materialize`（把 canonical 文档切面还原到 worktree）在大台账上会堵死整个 daemon。`store.materialize()` 解析到 `materializeVisible`（composition barrel 把 `makeWalShadowEventStore` 别名为 `makeTaskEventStore`，故 daemon 与全部测试走此实现）。它对当前 cut 的**每一个**文档跑一个无 yield 的同步循环，而且——更糟——在判断 worktree 是否已匹配**之前**，就对每个文档用同步 `git show`（`execFileSync`）读它的 canonical blob。几万事件、几千文档时，就是在 daemon 单一事件循环线程上 fork 几千次同步 git 子进程，`protocol.hello` 心跳与 `SIGTERM` 都进不来，一次常规 materialize 把 daemon 挂到只能 `SIGKILL`。

本 PR **不删命令**——这个能力是正当的，而是让它 scale：把 canonical blob 读移到 worktree/claim 发散判断**之后**。已物化的文档只花一次 worktree 哈希就跳过、不碰 git。开销从此正比于发散文件数，而非仓库规模——worktree 已最新时读零个 blob。

## 改动内容

- `packages/kernel/src/store/wal-shadow-event-store.ts` —— `materializeVisible` 里，发散跳过判断（`local.sha256 === claim.sha256 && local.mode === claim.mode`）现在跑在 `wal.readContentBlob(...) ?? readGitContent(...)` 之前。未变文档只花一次 worktree stat+哈希、零 canonical 读。`materializeVisible` 保持内部（不新增任何 public 面）。
- `packages/kernel/test/store/wal-shadow-event-store.test.ts` —— 新增回归测试：走公开 `store.materialize()`，用该文件已有的 `localGitObjectRefStore.processCount()` git 子进程计数器断言——当前 worktree 不会每文档起一次 git 读，删一个子集后还原读的 git 严格多于干净跑。

行为不变：restore、幂等 no-op、确定性 conflict 保留、symlink 模式全部保持。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 同 commit 删除的门 / fixture：none

## 机读声明说明

- 机读声明只在英文块出现一次，见上。

## 任务与范围

- Harness 任务：task_0fcb17a85c9f2b69a28120cecb
- 分支：codex/materialize-scale-fix
- 公开范围：`materializeVisible` 的「先判发散再读」重排（kernel）、一个 kernel 回归测试；不新增任何 public API 面
- 私有计划 / 证据是否已更新：yes（fact F-092A86C4）
- 范围外：`task-event-store-materialization.ts` 里的 plain `materialize`（仅 kernel 测试经 plain factory store 走它，生产恒解析到 WAL store）；用批量 `git diff` 的 O(发散) 重写（不需要——常态已零 blob 读）

## 版本影响

- 版本：不改版本（内部 store 行为 + 一个新的内部 barrel 导出）
- 发布影响：不发布

## 治理声明

- 是否触碰 protected surface：no
- protected surface 范围：不适用
- 依据：task_0fcb17a85c9f2b69a28120cecb；fact F-092A86C4
- 机器检查边界：本 PR 只声明该段存在；声明是否真实、充分，由 reviewer 判断。
- Break-glass：no
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- `origin/main` 基准 SHA：merge-base 83d6839004fe999dd12e95af30f33ad9f77f6adc
- 最近一次 `git fetch origin` 时间：2026-09-01（本会话）
- 公开 diff 命令：`git diff origin/main...codex/materialize-scale-fix`
- 私有证据：task_0fcb17a85c9f2b69a28120cecb 的 fact F-092A86C4
- [x] `npx tsc -b packages/kernel packages/daemon`（退出码 0）
- [x] 改动文件 `eslint` 干净；`check-kernel-dead-exports` 通过（无新增零消费导出）
- [x] `wal-shadow-event-store` kernel 套件：新增零读回归通过；唯一无关的本地红（`a master branch forked …`）在 `origin/main` 上同样红（本机 git 错误信息环境不匹配，非本改动）
- [x] `doc-sync-slice-a-materialization` 4/4（restore + 幂等 no-op + conflict 保留 + async-cut 祖先）
- [x] `task-progress-store` 3/3、`task-event-store-decision-recovery` 14/14、`preset-bootstrap` 1/1、`migration-import.integration` 7/7（每个 `store.materialize()` 调用方——restore/conflict/symlink 全绿）
- [x] `doc-sync-artifact-opaque` 7/7（`doc materialize` 命令端到端仍工作）
- 未运行：完整 `npm test` / harness:* 套件（worker 停止点纪律；完整权威是 CI）
- 合并后：以 merge 锚收口 task_0fcb17a85c9f2b69a28120cecb

## 审查证据

- 自查：该重排按代码可断定行为保持——跳过判断只比较 `local.sha256`/`local.mode`（worktree）与 `claim.sha256`/`claim.mode`（内存），从不读 canonical blob，故推迟 blob 读不改变哪些文档被还原、也不改变 conflict 如何保留；17 个既有行为测试佐证，新增测试锁住行为测试看不见的「读计数」不变量
- Reviewer subagent：CEO 亲自编写并验证（Explore 子代理已把完整调用链摸清，确认同步子进程根因）
- 人工审查：本 PR 上待进行
- 阻塞发现：无未关闭项

## 残余风险

- 常态（worktree 已最新）现在零 canonical 读；worktree 被整体清空的灾难还原仍会读每个发散 blob（固有恢复工作），且仍会对每个文档走一次 worktree stat+哈希（O(仓库) 的快速 fs、无子进程）。若哪天需要做到 O(发散)，后续用批量 `git diff` 预筛即可；让命令可用并不需要它。

## 关联材料

- 任务：task_0fcb17a85c9f2b69a28120cecb
- 证据：fact F-092A86C4

---

## PR Gate Checklist / PR 门禁清单

- [x] Branch is based on latest `origin/main`. / 分支基于最新 `origin/main`。
- [x] PR body uses this full template structure. / PR 描述使用本模板完整结构。
- [x] PR body uses two complete language blocks: `# English` first, then `# 中文`. / PR 正文使用两块完整正文。
- [x] If the PR touches a manifest-derived protected surface, Governance Declaration is filled. / 若触碰 protected surface，Governance Declaration 已填。
- [x] No private harness files are included. / 不包含私有 harness 文件。
- [x] No ignored local agent entry files are included. / 不包含被忽略的本地 agent 入口文件。
- [x] No absolute local filesystem paths are included in this public PR body. / 本公开 PR 描述不包含本机绝对路径。
- [x] Public diff is limited to the stated task scope. / 公开 diff 限于声明的任务范围。
- [x] Private planning/evidence updates are recorded. / 已记录私有计划 / 证据更新。
- [x] Version and publish impact are stated. / 已说明版本与发布影响。
- [x] Local verification commands are recorded honestly. / 已如实记录本地验证命令。
- [x] CI results are linked or explained. / CI 结果已链接或说明。
- [x] Review evidence is recorded. / 已记录审查证据。
- [x] Open P0/P1/P2 findings are closed or deferred. / open findings 已关闭或延后。
- [x] Merge method and post-merge branch cleanup plan are clear. / 合并方式和合并后清理计划清楚。
- [x] No admin bypass is planned unless explicitly approved. / 除非明确批准，否则不计划 admin bypass。
