### PR TITLE
fix(gui): raise the shared read deadline from 200ms to 2s

### DIFF
--- a/packages/gui/src/main/local-composition-root.ts
+++ b/packages/gui/src/main/local-composition-root.ts
@@ -217,7 +217,10 @@ function requestTimeoutMs(route: ShippedGuiRoute, payload: JsonObject): number {
   if (["showRuntimeInstance", "updateRuntimeInstance", "deleteRuntimeInstance"].includes(route.guiBridgeMethod))
     return 2_000;
   if (["signInRuntimeInstance", "signOutRuntimeInstance"].includes(route.guiBridgeMethod)) return 1_000;
-  return 200;
+  // Reads share the daemon with the single-writer queue; a long ledger write can hold the
+  // workspace past 200ms, which turned every such window into a visible GUI error. 2s keeps
+  // the read honest without failing on ordinary write contention (泽宇 2026-09-01 亲裁调高).
+  return 2_000;
 }
 function repoPayload(value: unknown): { readonly repoId: string; readonly payload: JsonObject } {
   if (!value || typeof value !== "object" || Array.isArray(value))


### PR DESCRIPTION
# English

## Summary

Raises the GUI's shared read deadline from 200ms to 2s (`requestTimeoutMs` fallback in `local-composition-root.ts` — the single definition every shipped read route falls through to; the "within 0.2s" error text is formatted from this same value). Under the current architecture reads share the daemon with the single-writer workspace queue, so any ledger write longer than 200ms surfaced as a visible `daemon_unavailable` error on whatever face the user was looking at — hit repeatedly in live use today (泽宇 direct ruling to raise it). Write deadlines (20s), runtime-instance probe deadlines, and sign-in/out deadlines are unchanged.

## Architectural Justification

- Mechanism sentence: a read deadline tighter than the writer's ordinary hold time converts normal queue contention into user-visible failure; the deadline should bound "daemon is actually gone", not "a write is in progress". The structural fix (reads not sharing the writer's queue at all) is the C hard-isolation line (#2114, in CI); this keeps the GUI honest until that lands.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none

## Machine-Readable Declarations

Production-Delta: +4/-1
Dependency-Change: none

### Optional Evidence Claims

None.

## Task And Scope

- Live-use defect fix under the PLT-Ontology supervision line (root task_5fc5080044fcfdbf548008f2f5); family fact F-C2C261BD (the 0.2s-budget daemon_unavailable flake family). Branch `codex/gui-read-budget`.

## Version Impact

- Version: no change. Publish impact: none.

## Governance Declaration

- Protected surface touched: no. Break-glass: no.

## Verification

- Reproduced live: GUI faces repeatedly errored with "did not answer repo.workspace.summary.read within 0.2s" while a dispatched worker wrote to the ledger; after the change (running locally via dev:electron) the same faces render normally under the same write load.
- [ ] Full suites: GitHub CI is the authority.

## Review Evidence

- One-value change plus comment; the 0.2s error text is derived from this value, so no second site exists (grep: the only other `responseTimeoutMs` sources are the unchanged 20s/2s/1s branches above it).

## Residual Risk

- A genuinely wedged daemon now takes up to 2s to surface on read faces instead of 0.2s — acceptable against eliminating false errors during every ordinary write window; the structural cure remains #2114/stage 3.

---

# 中文

## 概要

把 GUI 共享读 deadline 从 200ms 调到 2s(`local-composition-root.ts` 的 `requestTimeoutMs` 兜底值——所有 shipped 读路由的唯一落点,「within 0.2s」报错文案就是由它格式化)。现架构下读与单写队列同 daemon,任何超过 200ms 的台账写都会把用户正在看的面变成可见的 `daemon_unavailable` 错——今天实际使用中反复命中(泽宇亲裁调高)。写 deadline(20s)、runtime 探测与登录/登出 deadline 不动。

## 架构辩护

- 机制句:比写侧常规占用时间更紧的读 deadline,会把正常队列争用转换成用户可见故障;deadline 应当界定「daemon 真没了」,不是「有写在进行」。结构性修复是 C 硬隔离线(#2114,CI 中);本改动让 GUI 在其落地前保持诚实。

## 机读声明

`Production-Delta: +4/-1`

## 治理声明

- 未触碰 protected surface;无 break-glass。

## 验证

- 实况复现:worker 写台账时 GUI 各面反复报 0.2s 超时;改后同负载下正常渲染。完整权威=GitHub CI。

## 残余风险

- daemon 真挂时读面报错从 0.2s 延后到最多 2s;换来消除所有普通写窗的假错,可接受;根治仍在 #2114/阶段 3。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VTzQAqvuFy6ikGjBKxA9xj
