### PR TITLE
fix(kernel): keep recovery materialization suffix-bounded

### DIFF
--- a/packages/kernel/src/store/wal-git-materializer.ts
+++ b/packages/kernel/src/store/wal-git-materializer.ts
@@ -28,6 +28,8 @@ export interface WalGitMaterializerOptions {
   readonly withAppendFence?: <T>(operation: () => T) => T;
   /** Keep immutable event/content objects in Git while excluding them from the active worktree. */
   readonly compactWorktree?: boolean;
+  /** Layout already verified for the expected Git cut by the materialization host. */
+  readonly layout: LedgerLayoutState;
 }
 
 export interface WalGitMaterializationReceipt {
@@ -60,7 +62,12 @@ export function flushWalToGit(
   options: WalGitMaterializerOptions,
 ): WalGitMaterializationReceipt {
   const records = wal.records();
-  if (records.length === 0) return { commitSha: git.currentCommit().sha, head: git.readHead(), layout: git.layout() };
+  if (records.length === 0)
+    return {
+      commitSha: git.currentCommit().sha,
+      head: git.readHead(),
+      layout: options.layout,
+    };
   const input = options.rootInput ?? options.rootDir;
   if (input === undefined) throw new Error("canonical event store requires rootInput or rootDir");
   const ledger = resolveLedgerGitLayout(input);
@@ -76,7 +83,7 @@ export function flushWalToGit(
   }
   const pending = records.filter((record) => record.revision > through);
   const settlementRecords = pending.length === 0 ? records : pending;
-  const layoutState = git.layout();
+  const layoutState = options.layout;
   if (layoutState === "mixed")
     throw new TaskEventStoreError("invalid_store", "cannot flush WAL into a mixed Git layout");
   const files = batchFiles(wal, ledger, settlementRecords, layoutState);

--- a/packages/kernel/src/store/wal-materialization-protocol.ts
+++ b/packages/kernel/src/store/wal-materialization-protocol.ts
@@ -28,6 +28,7 @@ export interface WalMaterializationRequestV1 {
   readonly expectedGit: {
     readonly revision: number;
     readonly commitSha: string;
+    readonly layout: LedgerLayoutState;
   };
   readonly context: string;
   readonly compactWorktree: boolean;

--- a/packages/kernel/src/store/wal-materialization-worker.ts
+++ b/packages/kernel/src/store/wal-materialization-worker.ts
@@ -180,6 +180,7 @@ export function runWalMaterializationRequest(
     const materializationStarted = performance.now(),
       result = flushWalToGit(source, git, {
         rootDir: config.rootDir,
+        layout: request.expectedGit.layout,
         ...(config.authoredBranch ? { authoredBranch: config.authoredBranch } : {}),
         compactWorktree: request.compactWorktree,
         ...(finalizeFence

--- a/packages/kernel/src/store/wal-shadow-event-store.ts
+++ b/packages/kernel/src/store/wal-shadow-event-store.ts
@@ -315,7 +315,11 @@ export function makeWalShadowEventStore(options: StoreOptions): CanonicalEventSt
       const response = await materializationWorker.materialize({
         schema: "harness-wal-materialization-request/v1",
         cut,
-        expectedGit: { revision: gitRevisionBeforeFlush, commitSha: git.currentCommit().sha },
+        expectedGit: {
+          revision: gitRevisionBeforeFlush,
+          commitSha: git.currentCommit().sha,
+          layout: gitLayout,
+        },
         context,
         compactWorktree,
         previousSettlementFingerprint: lastSettlementFingerprint,


### PR DESCRIPTION
# English

## Summary

Repairs the main red introduced by #2114: the rewrite-ci full-check lanes (Node 24 and 26) both failed "startup recovery is independent of 100 versus 10,000-event history" with a paired p50 ratio of 2.83×. Root cause: recovery materialization called `git.layout()` inside the per-repo worker, recursively scanning the canonical events tree — startup cost scaled with total history. The fix keeps recovery suffix-bounded by carrying the host-verified layout on the durable-cut request instead of rediscovering it in the worker. With CI=1 on Node 24 the ratio settles at 1.012×/1.009×/1.023× over three runs; wal-shadow-event-store 17/17 and read-stopgap 2/2 stay green.

## Architectural Justification

- Mechanism sentence: a recovery path that rediscovers repository layout by walking the store recouples startup cost to total history; passing the already-verified layout with the cut keeps recovery proportional to the durable suffix, which is the invariant the test freezes.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none

## Machine-Readable Declarations

Production-Delta: +16/-3
Dependency-Change: none

### Optional Evidence Claims

None.

## Task And Scope

- Post-merge repair on the C hard-isolation line, harness task task_4f51ac90c61b755fa017c5dfc2 (fact F-4DD32DA1). Branch `codex/recovery-scaling-fix`.

## Version Impact

- Version: no change. Publish impact: none.

## Governance Declaration

- Protected surface touched: no. Break-glass: no.

## Verification

- Local repro on main d466c045b confirmed the mechanism; after the fix, CI=1 Node 24 paired ratios 1.012×/1.009×/1.023× (three runs); WAL 17/17, read-stopgap 2/2, gate tests 177/177, G33/G36/canonical-compat/file-complexity green.
- The failing lane (rewrite-ci full-check) runs only on main; shared-runner confirmation lands with the post-merge main run.
- [ ] Full suites: GitHub CI is the authority.

## Review Evidence

- CEO ground-truthed the two-lane failure (run 33510877265), the pre-#2114 green baseline on the same lanes, and the local 1.06× repro that hid the regression on fast disks.

## Residual Risk

- Shared-runner behavior is only fully provable on the post-merge main run; main-await will watch it.

---

# 中文

## 概要

修 #2114 引入的 main 红:rewrite-ci full-check 两个 Node lane 同红「startup recovery 与 100 vs 10,000 事件历史无关」(p50 比 2.83×)。根因:recovery materialization 在每 repo worker 内调 `git.layout()` 递归扫描 canonical events 树——启动开销随全历史规模化。修法=host 已验证 layout 随 durable-cut 请求携带,worker 不再自行重发现;recovery 恢复为只与 durable suffix 成比例。CI=1 Node24 三轮 ratio 1.012/1.009/1.023×;WAL 17/17、read-stopgap 2/2 不回归。

## 架构辩护

- 机制句:靠遍历 store 重发现仓库布局的恢复路径,会把启动开销重新耦合到全历史;随 cut 传递已验证布局,恢复就保持与 durable suffix 成比例——这正是该测试冻结的不变量。

## 机读声明

`Production-Delta: +16/-3`

## 治理声明

- 未触碰 protected surface;无 break-glass。

## 验证

- 见英文节;失败 lane 只在 main 跑,共享 runner 最终确认由合并后 main run 提供,main-await 盯守。

## 残余风险

- 共享 runner 行为需合并后 main run 终证。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VTzQAqvuFy6ikGjBKxA9xj
