### PR TITLE
refactor(daemon): unify RuntimeSession publication and close catalog boundaries (Phase G anti-entropy)

### DIFF
--- a/packages/application/src/task-action-explanation-service.ts
+++ b/packages/application/src/task-action-explanation-service.ts
@@ -3,7 +3,6 @@ import {
   evaluateTaskActionCapability,
   getEntityKindContract,
   taskActionUsage,
-  taskLifecycleActionIds,
   validateEntityActionExplanationSet,
   type ActorIdentity,
   type AuthorizationDecision,
@@ -13,7 +12,6 @@ import {
   type EntityActionExplanationSetV1,
   type EntityActionExplanationV1,
   type EntityRef,
-  type TaskLifecycleActionId,
   type TaskLifecycleSnapshot,
 } from "../../kernel/src/index.ts";
 
@@ -86,16 +84,13 @@ export function makeTaskActionExplanationService(
 function taskActionCatalog(): { readonly ref: string; readonly actions: readonly EntityActionContract[] } {
   const catalog = getEntityKindContract("task")?.actionCatalog;
   if (!catalog) throw new Error("The Task Entity Action catalog is unavailable.");
-  const actions = taskLifecycleActionIds.map((id) => catalog.actions.find((action) => action.id === id));
-  if (actions.some((action) => action === undefined))
-    throw new Error("The Task Entity Action catalog does not contain the four lifecycle actions.");
-  return { ref: catalog.ref, actions: actions as readonly EntityActionContract[] };
+  return catalog;
 }
 
 function descriptor(catalogRef: string, action: EntityActionContract): EntityActionExplanationV1["action"] {
   return Object.freeze({
     kind: "task" as const,
-    id: action.id as TaskLifecycleActionId,
+    id: action.id,
     catalogRef,
     contractVersion: `${action.version.major}.${action.version.minor}`,
     explain: action.explain,

--- a/packages/application/test/task-action-explanation-service.test.ts
+++ b/packages/application/test/task-action-explanation-service.test.ts
@@ -23,7 +23,19 @@ test("Task explanations distinguish lifecycle state, actor capability, invocatio
       plannedStart = row(plannedOwner, "start");
     assert.deepEqual(
       plannedOwner.subjects[0]!.actions.map(({ action }) => action.id),
-      ["start", "submit", "review", "complete"],
+      [
+        "start",
+        "submit",
+        "review",
+        "complete",
+        "release",
+        "amend",
+        "archive",
+        "supersede",
+        "delete",
+        "reopen",
+        "contract-migrate",
+      ],
     );
     assert.equal(plannedStart.available, true);
     assert.deepEqual(
@@ -102,7 +114,9 @@ test("Task explanations distinguish lifecycle state, actor capability, invocatio
       terminalOwner = explain(harness, terminal, owner);
     assert.equal(terminal.task?.status, "done");
     assert.equal(
-      terminalOwner.subjects[0]!.actions.every(({ available }) => available === false),
+      terminalOwner.subjects[0]!.actions.filter(({ action }) =>
+        ["start", "submit", "review", "complete"].includes(action.id),
+      ).every(({ available }) => available === false),
       true,
     );
 

--- a/packages/cli/src/cli/thin-command-decision.ts
+++ b/packages/cli/src/cli/thin-command-decision.ts
@@ -1,5 +1,4 @@
 import type { SafePath } from "../../../daemon/src/protocol/daemon-protocol.contract.ts";
-import { getExecutableEntityAction } from "../../../kernel/src/index.ts";
 import {
   parseDecisionAmend,
   parseDecisionRepin,
@@ -19,15 +18,13 @@ export function parseDecision(
   json: boolean,
   inputs: ThinCliInputDirectory,
 ): ThinParseResult {
-  const id = route.id,
-    actionKind = "actionKind" in route ? route.actionKind : id,
-    contract = getExecutableEntityAction(actionKind);
+  const id = route.id;
   if (id === "decision-validate" || id === "decision-verify")
     return parseDecisionValidation(id, args, rootDir, repoId, json, inputs);
   if (id === "decision-repin") return parseDecisionRepin(args, rootDir, repoId, json, inputs);
   if (id === "decision-transition") return parseDecisionTransition(args, rootDir, repoId, json, inputs);
   const noId = id === "decision-propose" || id === "decision-list",
-    nested = contract?.id === "declare-claim" || contract?.id === "fulfill-claim",
+    nested = route.path[1] === "claim",
     decisionId = noId ? undefined : args[nested ? 3 : 2];
   if (!noId && !nonEmpty(decisionId)) return rejected("missing_field", "Decision id is required.", json);
   if (id === "decision-propose") return parseProposal(args, rootDir, repoId, json, inputs);

--- a/packages/cli/src/cli/thin-command-decision.ts
+++ b/packages/cli/src/cli/thin-command-decision.ts
@@ -1,4 +1,5 @@
 import type { SafePath } from "../../../daemon/src/protocol/daemon-protocol.contract.ts";
+import { getExecutableEntityAction } from "../../../kernel/src/index.ts";
 import {
   parseDecisionAmend,
   parseDecisionRepin,
@@ -8,22 +9,25 @@ import {
 import { parseDecisionRead } from "./thin-command-decision-read.ts";
 import { accepted, nonEmpty, readFlags, rejectInput, rejected } from "./thin-command-flags.ts";
 import { parseProjected } from "./thin-command-projection.ts";
-import type { ThinCliInputDirectory, ThinParseResult } from "./thin-command-types.ts";
+import type { ProtocolCommand, ThinCliInputDirectory, ThinParseResult } from "./thin-command-types.ts";
 
 export function parseDecision(
-  id: string,
+  route: ProtocolCommand,
   args: readonly string[],
   rootDir: SafePath,
   repoId: string | undefined,
   json: boolean,
   inputs: ThinCliInputDirectory,
 ): ThinParseResult {
+  const id = route.id,
+    actionKind = "actionKind" in route ? route.actionKind : id,
+    contract = getExecutableEntityAction(actionKind);
   if (id === "decision-validate" || id === "decision-verify")
     return parseDecisionValidation(id, args, rootDir, repoId, json, inputs);
   if (id === "decision-repin") return parseDecisionRepin(args, rootDir, repoId, json, inputs);
   if (id === "decision-transition") return parseDecisionTransition(args, rootDir, repoId, json, inputs);
   const noId = id === "decision-propose" || id === "decision-list",
-    nested = id.startsWith("decision-claim-"),
+    nested = contract?.id === "declare-claim" || contract?.id === "fulfill-claim",
     decisionId = noId ? undefined : args[nested ? 3 : 2];
   if (!noId && !nonEmpty(decisionId)) return rejected("missing_field", "Decision id is required.", json);
   if (id === "decision-propose") return parseProposal(args, rootDir, repoId, json, inputs);
@@ -43,7 +47,7 @@ export function parseDecision(
       decisionId,
     });
   if (id === "decision-amend") return parseDecisionAmend(decisionId!, args, rootDir, repoId, json, inputs);
-  if (id.startsWith("decision-claim-")) return parseClaim(id, decisionId!, args, rootDir, repoId, json, inputs);
+  if (nested) return parseClaim(id, decisionId!, args, rootDir, repoId, json, inputs);
   if (id === "decision-reckon")
     return parseProjected(id, args.slice(3), rootDir, repoId, json, inputs, {
       decisionId,

--- a/packages/cli/src/cli/thin-command-flags.ts
+++ b/packages/cli/src/cli/thin-command-flags.ts
@@ -5,14 +5,7 @@ import type { ThinCliInputDirectory, ThinCommand, ThinParseResult } from "./thin
 // The command descriptor is the single authority on which closed task-action method serves a kind;
 // parsers that pass no explicit method get the descriptor's routing instead of a hardcoded default.
 export function taskActionMethodFor(kind: string): string {
-  try {
-    // The declaration literals keep their authored "repo.task.run"; the repo-read topology
-    // rewrites the runtime value, so compare on the widened runtime string.
-    const method: string = commandDescriptorForAction(kind).method;
-    return method === "repo.task.read" ? "repo.task.read" : "repo.task.run";
-  } catch {
-    return "repo.task.run";
-  }
+  return commandDescriptorForAction(kind).method;
 }
 
 export function optionalFlags(

--- a/packages/cli/src/cli/thin-command-router.ts
+++ b/packages/cli/src/cli/thin-command-router.ts
@@ -1,5 +1,4 @@
 import type { SafePath } from "../../../daemon/src/protocol/daemon-protocol.contract.ts";
-import { getExecutableEntityAction } from "../../../kernel/src/index.ts";
 import { parseDecision } from "./thin-command-decision.ts";
 import { parseDoc } from "./thin-command-doc.ts";
 import { parseFact } from "./thin-command-fact.ts";
@@ -21,9 +20,7 @@ export function parseRouted(
   inputs: ThinCliInputDirectory,
 ): ThinParseResult | undefined {
   if (!route) return undefined;
-  const actionKind = "actionKind" in route ? route.actionKind : route.id,
-    targetKind = getExecutableEntityAction(actionKind)?.target.kind,
-    rootCommand = route.path[0];
+  const rootCommand = route.path[0];
   if (route.id === "repo-bootstrap") {
     const f = readFlags(route.id, args.slice(1), inputs);
     if (!f.ok) return rejected(f.code, f.nextAction, json);
@@ -72,20 +69,18 @@ export function parseRouted(
   if (rootCommand === "runtime" && route.path[1] === "instance")
     return parseRuntimeInstance(route, args, rootDir, repoId, json, inputs);
   if (rootCommand === "runtime") return parseRuntime(route, args, rootDir, repoId, json, inputs);
-  if (targetKind === "schedule") return parseSchedule(route, args, rootDir, repoId, json, inputs);
-  if (targetKind === "settings")
-    return parseProjected(route.id, args.slice(2), rootDir, repoId, json, inputs, {}, {}, route.method);
-  if (targetKind === "person") return parsePeople(route, args, rootDir, repoId, json, inputs);
-  if (route.id === "ci-observe-pull")
-    return parseProjected(route.id, args.slice(3), rootDir, repoId, json, inputs, {}, {}, route.method);
+  if (rootCommand === "schedule") return parseSchedule(route, args, rootDir, repoId, json, inputs);
+  if (rootCommand === "settings" || rootCommand === "ci")
+    return parseProjected(route.id, args.slice(route.path.length), rootDir, repoId, json, inputs, {}, {}, route.method);
+  if (rootCommand === "people") return parsePeople(route, args, rootDir, repoId, json, inputs);
   if (route.id === "receipt-show" && nonEmpty(args[2]) && args.length === 3)
     return accepted(rootDir, repoId, json, {
       kind: "receipt-show",
       opId: args[2],
     });
   if (rootCommand === "doc") return parseDoc(route.id, args, rootDir, repoId, json, inputs);
-  if (targetKind === "fact") return parseFact(route.id, args, rootDir, repoId, json, inputs);
-  if (targetKind === "decision") return parseDecision(route, args, rootDir, repoId, json, inputs);
+  if (rootCommand === "fact") return parseFact(route.id, args, rootDir, repoId, json, inputs);
+  if (rootCommand === "decision") return parseDecision(route, args, rootDir, repoId, json, inputs);
   if (route.id === "distill-candidate" || route.id === "distill-promote")
     return parseProjected(
       route.id,
@@ -97,7 +92,7 @@ export function parseRouted(
       {},
       route.id === "distill-promote" ? { confidence: "medium", memoryClass: "semantic" } : {},
     );
-  if (targetKind === "relation") return parseRelationRouted(route, args, rootDir, repoId, json, inputs);
+  if (rootCommand === "relation") return parseRelationRouted(route, args, rootDir, repoId, json, inputs);
   if (rootCommand === "entity") {
     const entityKind = args[2],
       f = readFlags(route.id, args.slice(3), inputs);
@@ -110,13 +105,7 @@ export function parseRouted(
       ...(route.id === "entity-get" ? { entityId: f.one.get("--id") } : {}),
     });
   }
-  if (
-    route.phase.startsWith("Preset-") ||
-    targetKind === "agent" ||
-    targetKind === "squad" ||
-    rootCommand === "agent" ||
-    rootCommand === "squad"
-  )
+  if (route.phase.startsWith("Preset-") || rootCommand === "agent" || rootCommand === "squad")
     return parsePreset(route, args, rootDir, repoId, json, inputs);
   return undefined;
 }

--- a/packages/cli/src/cli/thin-command-router.ts
+++ b/packages/cli/src/cli/thin-command-router.ts
@@ -1,4 +1,5 @@
 import type { SafePath } from "../../../daemon/src/protocol/daemon-protocol.contract.ts";
+import { getExecutableEntityAction } from "../../../kernel/src/index.ts";
 import { parseDecision } from "./thin-command-decision.ts";
 import { parseDoc } from "./thin-command-doc.ts";
 import { parseFact } from "./thin-command-fact.ts";
@@ -20,6 +21,9 @@ export function parseRouted(
   inputs: ThinCliInputDirectory,
 ): ThinParseResult | undefined {
   if (!route) return undefined;
+  const actionKind = "actionKind" in route ? route.actionKind : route.id,
+    targetKind = getExecutableEntityAction(actionKind)?.target.kind,
+    rootCommand = route.path[0];
   if (route.id === "repo-bootstrap") {
     const f = readFlags(route.id, args.slice(1), inputs);
     if (!f.ok) return rejected(f.code, f.nextAction, json);
@@ -65,12 +69,13 @@ export function parseRouted(
       ? accepted(rootDir, repoId, json, { kind: "ledger-migrate" })
       : rejected("unknown_field", "ha ledger migrate takes no options.", json);
   if (route.id === "explain") return parseExplain(args, rootDir, repoId, json, route.method);
-  if (route.id.startsWith("runtime-instance-")) return parseRuntimeInstance(route, args, rootDir, repoId, json, inputs);
-  if (route.id.startsWith("runtime-")) return parseRuntime(route, args, rootDir, repoId, json, inputs);
-  if (route.id.startsWith("schedule-")) return parseSchedule(route, args, rootDir, repoId, json, inputs);
-  if (route.id.startsWith("settings-"))
+  if (rootCommand === "runtime" && route.path[1] === "instance")
+    return parseRuntimeInstance(route, args, rootDir, repoId, json, inputs);
+  if (rootCommand === "runtime") return parseRuntime(route, args, rootDir, repoId, json, inputs);
+  if (targetKind === "schedule") return parseSchedule(route, args, rootDir, repoId, json, inputs);
+  if (targetKind === "settings")
     return parseProjected(route.id, args.slice(2), rootDir, repoId, json, inputs, {}, {}, route.method);
-  if (route.id.startsWith("people-")) return parsePeople(route, args, rootDir, repoId, json, inputs);
+  if (targetKind === "person") return parsePeople(route, args, rootDir, repoId, json, inputs);
   if (route.id === "ci-observe-pull")
     return parseProjected(route.id, args.slice(3), rootDir, repoId, json, inputs, {}, {}, route.method);
   if (route.id === "receipt-show" && nonEmpty(args[2]) && args.length === 3)
@@ -78,9 +83,9 @@ export function parseRouted(
       kind: "receipt-show",
       opId: args[2],
     });
-  if (route.id.startsWith("doc-")) return parseDoc(route.id, args, rootDir, repoId, json, inputs);
-  if (route.id.startsWith("fact-")) return parseFact(route.id, args, rootDir, repoId, json, inputs);
-  if (route.id.startsWith("decision-")) return parseDecision(route.id, args, rootDir, repoId, json, inputs);
+  if (rootCommand === "doc") return parseDoc(route.id, args, rootDir, repoId, json, inputs);
+  if (targetKind === "fact") return parseFact(route.id, args, rootDir, repoId, json, inputs);
+  if (targetKind === "decision") return parseDecision(route, args, rootDir, repoId, json, inputs);
   if (route.id === "distill-candidate" || route.id === "distill-promote")
     return parseProjected(
       route.id,
@@ -92,8 +97,8 @@ export function parseRouted(
       {},
       route.id === "distill-promote" ? { confidence: "medium", memoryClass: "semantic" } : {},
     );
-  if (route.id.startsWith("relation-")) return parseRelationRouted(route, args, rootDir, repoId, json, inputs);
-  if (route.id.startsWith("entity-")) {
+  if (targetKind === "relation") return parseRelationRouted(route, args, rootDir, repoId, json, inputs);
+  if (rootCommand === "entity") {
     const entityKind = args[2],
       f = readFlags(route.id, args.slice(3), inputs);
     if (!nonEmpty(entityKind))
@@ -105,7 +110,13 @@ export function parseRouted(
       ...(route.id === "entity-get" ? { entityId: f.one.get("--id") } : {}),
     });
   }
-  if (route.phase.startsWith("Preset-") || /^(?:agent|squad)-/u.test(route.id))
+  if (
+    route.phase.startsWith("Preset-") ||
+    targetKind === "agent" ||
+    targetKind === "squad" ||
+    rootCommand === "agent" ||
+    rootCommand === "squad"
+  )
     return parsePreset(route, args, rootDir, repoId, json, inputs);
   return undefined;
 }

--- a/packages/cli/src/daemon/client.ts
+++ b/packages/cli/src/daemon/client.ts
@@ -1,11 +1,11 @@
 import { realpathSync, readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { getExecutableEntityAction } from "../../../kernel/src/index.ts";
 import type { JsonObject } from "../../../daemon/src/protocol/json-rpc-types.ts";
 import {
   canonicalRoot,
   commandClassForAction,
+  commandDescriptorForAction,
   daemonMethodAcceptsPayload,
   daemonMethodAcceptsPayloadExecutor,
   workspaceId,
@@ -554,6 +554,8 @@ export async function fleetTaskRoute(
   if (!config) return null;
   const { FLEET_TASK_COMMAND_KINDS } = await import("../../../daemon/src/fleet/contract.ts");
   if (!(FLEET_TASK_COMMAND_KINDS as readonly string[]).includes(command.action.kind)) return null;
+  const actionKind = command.action.kind,
+    descriptor = commandDescriptorForAction(actionKind);
   const {
     executor: _executor,
     createMode,
@@ -576,7 +578,7 @@ export async function fleetTaskRoute(
   // outside the remote-edge surface. Falling through produces the existing,
   // explicit repo_mode_read_only receipt instead of silently dropping their
   // authority-bearing fields on the fleet route.
-  if (command.action.kind === "task-create" && (createMode !== undefined || fromLegacyId !== undefined)) return null;
+  if (actionKind === "task-create" && (createMode !== undefined || fromLegacyId !== undefined)) return null;
   const payload: Record<string, unknown> = {
     host: config.host,
     port: config.port,
@@ -611,10 +613,7 @@ export async function fleetTaskRoute(
     }
     if (packet === null || typeof packet !== "object" || Array.isArray(packet))
       throw Object.assign(new Error(`${source} must contain one JSON object.`), { code: "invalid_field" });
-    if (
-      command.action.kind === "task-create" ||
-      getExecutableEntityAction(command.action.kind)?.target.kind === "schedule"
-    ) {
+    if (actionKind === "task-create" || ("path" in descriptor && descriptor.path[0] === "schedule")) {
       const fields = packet as Record<string, unknown>;
       const unsupported = Object.keys(fields).filter((field) =>
         ["fromFile", "jsonInput", "kind", "createMode", "fromLegacyId"].includes(field),

--- a/packages/cli/src/daemon/client.ts
+++ b/packages/cli/src/daemon/client.ts
@@ -1,6 +1,7 @@
 import { realpathSync, readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { getExecutableEntityAction } from "../../../kernel/src/index.ts";
 import type { JsonObject } from "../../../daemon/src/protocol/json-rpc-types.ts";
 import {
   canonicalRoot,
@@ -610,7 +611,10 @@ export async function fleetTaskRoute(
     }
     if (packet === null || typeof packet !== "object" || Array.isArray(packet))
       throw Object.assign(new Error(`${source} must contain one JSON object.`), { code: "invalid_field" });
-    if (command.action.kind === "task-create" || command.action.kind.startsWith("schedule-")) {
+    if (
+      command.action.kind === "task-create" ||
+      getExecutableEntityAction(command.action.kind)?.target.kind === "schedule"
+    ) {
       const fields = packet as Record<string, unknown>;
       const unsupported = Object.keys(fields).filter((field) =>
         ["fromFile", "jsonInput", "kind", "createMode", "fromLegacyId"].includes(field),

--- a/packages/cli/src/daemon/fleet-command-route.ts
+++ b/packages/cli/src/daemon/fleet-command-route.ts
@@ -1,4 +1,5 @@
 import path from "node:path";
+import { getExecutableEntityAction } from "../../../kernel/src/index.ts";
 import { daemonUserRoot, readRegisteredRepos } from "../../../daemon/src/client/local-daemon-target.ts";
 import { canonicalRoot, daemonProtocolCommands } from "../../../daemon/src/protocol/daemon-protocol.contract.ts";
 import type { ThinCommand } from "../cli/thin-command.ts";
@@ -13,7 +14,7 @@ export async function fleetScheduleRoute(
       (candidate) =>
         candidate.method === command.method &&
         candidate.id === command.action.kind &&
-        candidate.id.startsWith("schedule-"),
+        getExecutableEntityAction(candidate.id)?.target.kind === "schedule",
     )
   )
     return null;

--- a/packages/cli/src/daemon/fleet-command-route.ts
+++ b/packages/cli/src/daemon/fleet-command-route.ts
@@ -1,5 +1,4 @@
 import path from "node:path";
-import { getExecutableEntityAction } from "../../../kernel/src/index.ts";
 import { daemonUserRoot, readRegisteredRepos } from "../../../daemon/src/client/local-daemon-target.ts";
 import { canonicalRoot, daemonProtocolCommands } from "../../../daemon/src/protocol/daemon-protocol.contract.ts";
 import type { ThinCommand } from "../cli/thin-command.ts";
@@ -12,9 +11,7 @@ export async function fleetScheduleRoute(
     (command.method !== "repo.task.run" && command.method !== "repo.task.read") ||
     !daemonProtocolCommands.some(
       (candidate) =>
-        candidate.method === command.method &&
-        candidate.id === command.action.kind &&
-        getExecutableEntityAction(candidate.id)?.target.kind === "schedule",
+        candidate.method === command.method && candidate.id === command.action.kind && candidate.path[0] === "schedule",
     )
   )
     return null;

--- a/packages/cli/test/task-action-derivation.test.ts
+++ b/packages/cli/test/task-action-derivation.test.ts
@@ -11,8 +11,10 @@ import {
 import { validateDaemonRpcCall } from "../../daemon/src/protocol/daemon-protocol-rpc-validation.ts";
 import { parseThinCommand } from "../src/cli/thin-command.ts";
 
-test("daemon command inputs and thin CLI parameters are projections of Task Actions", () => {
-  const actions = getEntityKindContract("task")?.actionCatalog?.actions ?? [];
+test("daemon lifecycle command inputs and thin CLI parameters are projections of Task Actions", () => {
+  const actions = (getEntityKindContract("task")?.actionCatalog?.actions ?? []).filter(
+    (action) => action.execution?.lifecycle !== undefined,
+  );
   assert.deepEqual(
     generatedTaskActionProtocolDeclarations,
     actions.map(({ id, input, explain, execution }) => ({ id, input, explain, execution })),

--- a/packages/daemon/src/agent-entities.ts
+++ b/packages/daemon/src/agent-entities.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import {
   attributeEntityActionCriterion,
   consumeKnownError,
+  getExecutableEntityAction,
   openEntityStore,
   type EntityStore,
   type TaskProjection,
@@ -568,9 +569,10 @@ function readStoredDeclaration(rootDir: string, kind: AgentEntityKind, id: strin
   return stored.value;
 }
 function entityKind(actionKind: string): AgentEntityKind {
-  if (!/^(?:agent|squad)-(?:list|inspect|validate|install)$/u.test(actionKind))
+  const kind = getExecutableEntityAction(actionKind)?.target.kind;
+  if (kind !== "agent" && kind !== "squad")
     throw entityError("unsupported_command", `No entity lifecycle contract exists for ${actionKind}.`);
-  return actionKind.startsWith("agent-") ? "agent" : "squad";
+  return kind;
 }
 function requiredEntityText(value: unknown, field: string): string {
   if (typeof value !== "string" || !value.trim()) throw entityError("invalid_command", `${field} is required.`);

--- a/packages/daemon/src/daemon-host-repository-api.ts
+++ b/packages/daemon/src/daemon-host-repository-api.ts
@@ -1,6 +1,7 @@
 /** @daemon-transport-authority Daemon ingress filtering and repository dispatch. */
 import {
   readDaemonRegistry,
+  getExecutableEntityAction,
   registerDaemonRepo,
   resolveHarnessLayout,
   unregisterDaemonRepo,
@@ -274,7 +275,8 @@ export function createDaemonHostRepositoryApi(
       try {
         const serverBinding = await context.binding(cell.status().rootDir, auth);
         const receipt = await cell.run(action as RepoTaskAction, serverBinding, auth.connectionSignal);
-        if (action.kind.startsWith("schedule-")) await context.scheduleScheduler.refresh();
+        if (getExecutableEntityAction(action.kind)?.target.kind === "schedule")
+          await context.scheduleScheduler.refresh();
         return receipt;
       } catch (error) {
         return context.rejectHostAction(action, context.code(error), context.daemonErrorMessage(error));

--- a/packages/daemon/src/entity-action-catalog-executor.ts
+++ b/packages/daemon/src/entity-action-catalog-executor.ts
@@ -36,7 +36,6 @@ import {
 } from "../../kernel/src/index.ts";
 import { prepareDecisionAmend, validateDecisionPackages } from "./decision-surface-actions.ts";
 import { unknownFieldViolation } from "./protocol/json-rpc-types.ts";
-import { actionCriterionFailureOfReceipt } from "./repo-cell-settlement.ts";
 import type { RepoCellBinding, RepoTaskAction } from "./repo-cell-types.ts";
 import {
   commitRuntimeSessionBundle,
@@ -116,7 +115,7 @@ export function makeEntityActionCatalogExecutor(input: {
       prepare = runtimes.prepare?.[contract.target.kind],
       preparedAction = prepare?.(contract, action, binding, opId) ?? action;
     if (contract.execution.implementation === "catalog-runtime") {
-      const runtime = runtimes.entity?.[contract.target.kind];
+      const runtime = contract.target.kind === "task" ? runtimes.task : runtimes.entity?.[contract.target.kind];
       if (!runtime)
         throw Object.assign(new Error(`Action ${action.kind} requires the ${contract.target.kind} catalog runtime.`), {
           code: "unsupported_command",
@@ -473,13 +472,7 @@ export function deriveActionResult(
         : targetIdField && typeof receiptFields[targetIdField] === "string"
           ? receiptFields[targetIdField]
           : null,
-    attributedFailure = actionCriterionFailureOfReceipt(receipt),
-    attributedRefs = attributedFailure
-      ? attributedFailure.actionId === contract.id
-        ? [attributedFailure.criterionRef]
-        : invalidCriterionAttribution(contract, attributedFailure.actionId, attributedFailure.criterionRef)
-      : [],
-    criterionRefs = receipt.unmetCriteria?.map(({ ref }) => ref) ?? attributedRefs,
+    criterionRefs = receipt.unmetCriteria?.map(({ ref }) => ref) ?? [],
     unmetCriteria: readonly EntityActionUnmetCriterionV1[] =
       receipt.outcome === "op_rejected"
         ? criterionRefs.map((criterionRef) => resolveActionCriterion(contract, criterionRef))
@@ -503,17 +496,9 @@ export function deriveActionResult(
             revision: receipt.revision ?? null,
           },
     rejectionExplanation: explanation,
-    nextActions: Object.freeze(
-      unmetCriteria.length > 0
-        ? [
-            ...new Set([
-              ...(receipt.nextActions ?? []),
-              ...(!attributedFailure && receipt.nextAction ? [receipt.nextAction] : []),
-              ...(attributedFailure?.nextActions ?? []),
-            ]),
-          ]
-        : [...new Set([...(receipt.nextActions ?? []), ...(receipt.nextAction ? [receipt.nextAction] : [])])],
-    ),
+    nextActions: Object.freeze([
+      ...new Set([...(receipt.nextActions ?? []), ...(receipt.nextAction ? [receipt.nextAction] : [])]),
+    ]),
   };
 }
 
@@ -525,15 +510,6 @@ function resolveActionCriterion(contract: EntityActionContract, criterionRef: st
       { code: "invalid_store" },
     );
   return { ref: criterion.ref, failureCode: criterion.failureCode, explain: criterion.explain };
-}
-
-function invalidCriterionAttribution(contract: EntityActionContract, actionId: string, criterionRef: string): never {
-  throw Object.assign(
-    new Error(
-      `Action ${contract.target.kind}.${contract.id} received criterion ${criterionRef} attributed to ${actionId}.`,
-    ),
-    { code: "invalid_store" },
-  );
 }
 
 function reclassificationAction(

--- a/packages/daemon/src/entity-action-catalog-executor.ts
+++ b/packages/daemon/src/entity-action-catalog-executor.ts
@@ -223,7 +223,9 @@ export function makeEntityActionCatalogExecutor(input: {
           bundle,
           existing !== null,
           authorizationDecision,
-          () => publicationKillpoints(input.killpoint),
+          () => {
+            if (existing === null) publicationKillpoints(input.killpoint);
+          },
         ),
       );
     }

--- a/packages/daemon/src/protocol/daemon-protocol-commands-agent.ts
+++ b/packages/daemon/src/protocol/daemon-protocol-commands-agent.ts
@@ -169,7 +169,7 @@ export const agentProtocolCommands = Object.freeze([
     phase: "Runtime-B",
     path: ["squad", "status", "<squad-run-id>"],
     summary: "Read a durable Squad run and its leader and worker dispatches.",
-    method: "repo.task.run",
+    method: "repo.task.read",
     positional: "squadRunId",
     inputs: [],
   }),
@@ -204,7 +204,7 @@ export const agentProtocolCommands = Object.freeze([
     phase: "Runtime-B",
     path: ["entity", "get", "<kind>"],
     summary: "Read one canonical Entity declaration.",
-    method: "repo.task.run",
+    method: "repo.task.read",
     positional: "entityKind",
     inputs: [
       cliInput("--id", "single", true, {
@@ -218,7 +218,7 @@ export const agentProtocolCommands = Object.freeze([
     phase: "Runtime-B",
     path: ["entity", "list", "<kind>"],
     summary: "List canonical declarations for one registered Entity kind.",
-    method: "repo.task.run",
+    method: "repo.task.read",
     positional: "entityKind",
     inputs: [],
   }),
@@ -227,7 +227,7 @@ export const agentProtocolCommands = Object.freeze([
     phase: "Runtime-B",
     path: ["agent", "list"],
     summary: "List installed Agent identity declarations.",
-    method: "repo.task.run",
+    method: "repo.task.read",
     inputs: [],
   }),
   defineRepoReadCommand({
@@ -235,7 +235,7 @@ export const agentProtocolCommands = Object.freeze([
     phase: "Runtime-B",
     path: ["agent", "inspect", "<id>"],
     summary: "Inspect one Agent identity including its instructions and runtime type.",
-    method: "repo.task.run",
+    method: "repo.task.read",
     positional: "agentId",
     inputs: [],
   }),
@@ -244,7 +244,7 @@ export const agentProtocolCommands = Object.freeze([
     phase: "Runtime-B",
     path: ["agent", "validate"],
     summary: "Validate one Agent declaration package before installing it.",
-    method: "repo.task.run",
+    method: "repo.task.read",
     inputs: [
       cliInput(
         "--source",
@@ -283,7 +283,7 @@ export const agentProtocolCommands = Object.freeze([
     phase: "Runtime-B",
     path: ["squad", "list"],
     summary: "List installed Squad identity declarations.",
-    method: "repo.task.run",
+    method: "repo.task.read",
     inputs: [],
   }),
   defineRepoReadCommand({
@@ -291,7 +291,7 @@ export const agentProtocolCommands = Object.freeze([
     phase: "Runtime-B",
     path: ["squad", "inspect", "<id>"],
     summary: "Inspect one Squad and its human-editable roster text.",
-    method: "repo.task.run",
+    method: "repo.task.read",
     positional: "squadId",
     inputs: [],
   }),
@@ -351,7 +351,7 @@ export const agentProtocolCommands = Object.freeze([
     phase: "Runtime-B",
     path: ["squad", "validate"],
     summary: "Validate one Squad declaration package before installing it.",
-    method: "repo.task.run",
+    method: "repo.task.read",
     inputs: [
       cliInput(
         "--source",

--- a/packages/daemon/src/protocol/daemon-protocol-commands-decision-lifecycle.ts
+++ b/packages/daemon/src/protocol/daemon-protocol-commands-decision-lifecycle.ts
@@ -13,7 +13,7 @@ export const decisionLifecycleProtocolCommands = Object.freeze([
     phase: "DecisionFact-B",
     path: ["decision", "validate", "[id]"],
     summary: "Read-only validation of one or all Decision packages, pins, and amend history.",
-    method: "repo.task.run",
+    method: "repo.task.read",
     inputs: [
       cliInput("--all", "boolean", false, {
         code: "invalid_field",
@@ -27,7 +27,7 @@ export const decisionLifecycleProtocolCommands = Object.freeze([
     phase: "DecisionFact-B",
     path: ["decision", "verify", "[id]"],
     summary: "Read-only content-pin verification alias; reports every warning without rewriting.",
-    method: "repo.task.run",
+    method: "repo.task.read",
     inputs: [
       cliInput("--all", "boolean", false, {
         code: "invalid_field",

--- a/packages/daemon/src/protocol/daemon-protocol-commands-decision-relations.ts
+++ b/packages/daemon/src/protocol/daemon-protocol-commands-decision-relations.ts
@@ -79,7 +79,7 @@ export const decisionRelationProtocolCommands = Object.freeze([
     phase: "DecisionFact-B",
     path: ["decision", "list"],
     summary: "List the canonical Decision projection without authored prose.",
-    method: "repo.task.run",
+    method: "repo.task.read",
     inputs: [
       cliInput("--search", "single", false, {
         code: "invalid_field",
@@ -129,7 +129,7 @@ export const decisionRelationProtocolCommands = Object.freeze([
     phase: "DecisionFact-B",
     path: ["decision", "show", "<id>"],
     summary: "Show one canonical Decision by id or E-number.",
-    method: "repo.task.run",
+    method: "repo.task.read",
     inputs: [
       cliInput("--include-body", "boolean", false, {
         code: "invalid_field",

--- a/packages/daemon/src/protocol/daemon-protocol-commands-doc-fact.ts
+++ b/packages/daemon/src/protocol/daemon-protocol-commands-doc-fact.ts
@@ -12,7 +12,7 @@ export const docFactProtocolCommands = Object.freeze([
     phase: "DocSync-B",
     path: ["doc", "status"],
     summary: "Scan the authored root for document candidates.",
-    method: "repo.task.run",
+    method: "repo.task.read",
     inputs: [
       cliInput("--task", "single", false, {
         code: "invalid_field",
@@ -30,7 +30,7 @@ export const docFactProtocolCommands = Object.freeze([
     phase: "DocSync-B",
     path: ["doc", "sync", "--dry-run"],
     summary: "Preview the scanner selection without writing.",
-    method: "repo.task.run",
+    method: "repo.task.read",
     inputs: [
       cliInput("--task", "single", false, {
         code: "invalid_field",
@@ -73,7 +73,7 @@ export const docFactProtocolCommands = Object.freeze([
     phase: "DocSync-B",
     path: ["doc", "show"],
     summary: "Show a canonical projected document.",
-    method: "repo.task.run",
+    method: "repo.task.read",
     inputs: [
       cliInput("--path", "single", true, {
         code: "missing_field",
@@ -169,7 +169,7 @@ export const docFactProtocolCommands = Object.freeze([
     phase: "DecisionFact-A",
     path: ["fact", "type", "list"],
     summary: "List registered Fact domain types and the Fact that registered each value.",
-    method: "repo.task.run",
+    method: "repo.task.read",
     inputs: [],
   }),
   defineLedgerWriteCommand({
@@ -279,7 +279,7 @@ export const docFactProtocolCommands = Object.freeze([
     phase: "DecisionFact-A",
     path: ["fact", "search", "[query]"],
     summary: "Search the Fact FTS projection.",
-    method: "repo.task.run",
+    method: "repo.task.read",
     inputs: [
       cliInput("--task", "single", false, {
         code: "invalid_field",
@@ -354,7 +354,7 @@ export const docFactProtocolCommands = Object.freeze([
     phase: "DecisionFact-A",
     path: ["fact", "show"],
     summary: "Show one projected Fact.",
-    method: "repo.task.run",
+    method: "repo.task.read",
     inputs: [
       cliInput(
         "--id",

--- a/packages/daemon/src/protocol/daemon-protocol-commands-runtime-fleet.ts
+++ b/packages/daemon/src/protocol/daemon-protocol-commands-runtime-fleet.ts
@@ -456,7 +456,7 @@ export const scheduleProtocolCommands = Object.freeze([
     phase: "Schedule-S3",
     path: ["schedule", "list"],
     summary: "List canonical Schedules and their projected run state.",
-    method: "repo.task.run",
+    method: "repo.task.read",
     inputs: [],
   }),
   defineCenterForwardReadCommand({
@@ -464,7 +464,7 @@ export const scheduleProtocolCommands = Object.freeze([
     phase: "Schedule-S5",
     path: ["schedule", "runs", "<schedule-id>"],
     summary: "List occurrence history, including active, settled, and missed runs.",
-    method: "repo.task.run",
+    method: "repo.task.read",
     positional: "scheduleId",
     inputs: [
       cliInput(
@@ -481,7 +481,7 @@ export const scheduleProtocolCommands = Object.freeze([
     phase: "Schedule-S3",
     path: ["schedule", "show", "<schedule-id>"],
     summary: "Show one canonical Schedule definition and projected run state.",
-    method: "repo.task.run",
+    method: "repo.task.read",
     positional: "scheduleId",
     inputs: [scheduleFromFileInput(scheduleShowJsonFields, scheduleShowJsonAllowedFields)],
   }),

--- a/packages/daemon/src/protocol/daemon-protocol-commands-task-surface.ts
+++ b/packages/daemon/src/protocol/daemon-protocol-commands-task-surface.ts
@@ -260,7 +260,7 @@ export const taskSurfaceProtocolCommands = Object.freeze([
     phase: "W3",
     path: ["task", "review", "<task-id>"],
     summary: "Lint the legacy review contract without approving completion.",
-    method: "repo.task.run",
+    method: "repo.task.read",
     inputs: [
       cliInput("--reviewer", "single", false, {
         code: "invalid_field",
@@ -273,7 +273,7 @@ export const taskSurfaceProtocolCommands = Object.freeze([
     phase: "W3",
     path: ["task", "list"],
     summary: "List Task projection rows or a recursive parent subtree with canonical filters.",
-    method: "repo.task.run",
+    method: "repo.task.read",
     inputs: [
       cliInput(
         "--status",
@@ -378,7 +378,7 @@ export const taskSurfaceProtocolCommands = Object.freeze([
     phase: "W3",
     path: ["relation", "list"],
     summary: "Query first-class Relation aggregates from the canonical versioned projection.",
-    method: "repo.task.run",
+    method: "repo.task.read",
     inputs: [
       cliInput("--entity", "single", false, {
         code: "invalid_field",

--- a/packages/daemon/src/protocol/daemon-protocol-commands-task.ts
+++ b/packages/daemon/src/protocol/daemon-protocol-commands-task.ts
@@ -657,7 +657,7 @@ export const taskExecutionProtocolCommands = Object.freeze([
     phase: "W3",
     path: ["task", "show", "<task-id>"],
     summary: "Read the task projection.",
-    method: "repo.task.run",
+    method: "repo.task.read",
     inputs: [],
   }),
   defineRepoReadCommand({
@@ -665,7 +665,7 @@ export const taskExecutionProtocolCommands = Object.freeze([
     phase: "W3",
     path: ["receipt", "show", "<op-id>"],
     summary: "Read a write receipt.",
-    method: "repo.task.run",
+    method: "repo.task.read",
     inputs: [],
   }),
 ] as const);

--- a/packages/daemon/src/protocol/daemon-protocol-commands.ts
+++ b/packages/daemon/src/protocol/daemon-protocol-commands.ts
@@ -53,7 +53,7 @@ const settingsWriteTopology = {
       phase: "Settings-Kind",
       path: ["settings", "read"],
       summary: "Read the repository Settings entity from the canonical projection.",
-      method: "repo.task.run",
+      method: "repo.task.read",
       inputs: [],
     }),
     defineCliCommand({

--- a/packages/daemon/src/repo-cell-action-context.ts
+++ b/packages/daemon/src/repo-cell-action-context.ts
@@ -22,7 +22,7 @@ import {
   showTask as showTaskImpl,
 } from "./repo-cell-completion.ts";
 import { cellCodedError, errorOperationId, publishGeneratedArtifact } from "./repo-cell-errors.ts";
-import { decodeEvidencePayload, renderEvidencePayload, taskSurfaceWriteKind } from "./repo-cell-evidence.ts";
+import { decodeEvidencePayload, renderEvidencePayload } from "./repo-cell-evidence.ts";
 import {
   completeExecutionId,
   completeRetryCommand,
@@ -150,7 +150,6 @@ export interface RepoCellActionContext extends TaskQueryCell {
   readonly declareExecutionExecutor: Bound<typeof declareExecutionExecutorImpl>;
   readonly closeoutTask: Bound<typeof closeoutTaskImpl>;
   readonly completeTask: Bound<typeof completeTaskImpl>;
-  readonly taskSurfaceWriteKind: typeof taskSurfaceWriteKind;
   readonly taskSurfaceWrite: Bound<typeof taskSurfaceWriteImpl>;
   readonly rejected: typeof rejected;
   readonly lifecycleAction: Bound<typeof lifecycleActionImpl>;
@@ -293,7 +292,6 @@ export function createRepoCellActionContext(bindings: {
     declareExecutionExecutor: bind(declareExecutionExecutorImpl),
     closeoutTask: bind(closeoutTaskImpl),
     completeTask: bind(completeTaskImpl),
-    taskSurfaceWriteKind,
     taskSurfaceWrite: bind(taskSurfaceWriteImpl),
     rejected,
     lifecycleAction: bind(lifecycleActionImpl),

--- a/packages/daemon/src/repo-cell-action-dispatch.ts
+++ b/packages/daemon/src/repo-cell-action-dispatch.ts
@@ -245,7 +245,7 @@ export async function executeAction(
     );
   }
   const actionVersion = Number(action.expectedVersion ?? cell.store.readHead()?.revision ?? 0);
-  if (actionContract?.execution && !actionContract.execution.read)
+  if (actionContract?.execution && (!actionContract.execution.read || actionContract.target.kind !== "agent"))
     return cell.entityActionExecutor.run(
       action,
       binding,

--- a/packages/daemon/src/repo-cell-action-dispatch.ts
+++ b/packages/daemon/src/repo-cell-action-dispatch.ts
@@ -183,21 +183,40 @@ export async function executeAction(
   }
   const actionContract = getExecutableEntityAction(action.kind);
   if (actionContract?.target.kind === "task" && actionContract.execution) {
-    const taskId = cell.requiredCellText(action.taskId, "taskId"),
+    const targetIdField = actionContract.execution.targetIdField ?? "taskId",
+      targetId =
+        typeof action[targetIdField] === "string" && action[targetIdField] ? String(action[targetIdField]) : null,
+      targetRevision = targetId
+        ? cell.projection.read(targetId).snapshot.revision
+        : (cell.store.readHead()?.revision ?? 0),
       lifecycle = actionContract.execution.lifecycle,
       leasedStart =
         lifecycle?.coordination === "reserve" &&
-        ["held", "reserving"].includes(cell.projection.currentLease(taskId, cell.now())?.phase ?? "");
-    if (lifecycle?.coordination === "reserve" && !leasedStart) cell.assertTaskWipCapacity(taskId, "active");
+        targetId !== null &&
+        ["held", "reserving"].includes(cell.projection.currentLease(targetId, cell.now())?.phase ?? "");
+    if (lifecycle?.coordination === "reserve" && targetId && !leasedStart)
+      cell.assertTaskWipCapacity(targetId, "active");
     return cell.entityActionExecutor.run(
       action,
       binding,
-      cell.operationId(action, binding, cell.input.repoId, cell.projection.read(taskId).snapshot.revision),
+      cell.operationId(action, binding, cell.input.repoId, targetRevision),
       {
         ...cell.entityActionRuntimes,
         task: async (contract, catalogAction, catalogBinding) => {
           if (Array.isArray(catalogAction.docChanges))
             return cell.runTaskCommandWithDocs(catalogAction as TaskCommandWithDocsAction, catalogBinding);
+          if (contract.execution?.implementation === "catalog-runtime") {
+            if (catalogAction.kind === "task-contract-migrate")
+              return cell.migrateTaskContracts(catalogAction, catalogBinding);
+            if (
+              catalogAction.kind === "task-archive" &&
+              (Array.isArray(catalogAction.taskIds) || typeof catalogAction.filter === "string")
+            )
+              return cell.archiveTasks(catalogAction, catalogBinding);
+            if (catalogAction.kind === "task-supersede" && typeof catalogAction.title === "string")
+              return cell.supersedeWithNewTask(catalogAction, catalogBinding);
+            return cell.taskSurfaceWrite(catalogAction, catalogBinding);
+          }
           return contract.execution?.implementation === "task-completion"
             ? cell.completeTask(catalogAction, catalogBinding)
             : cell.lifecycleAction(catalogAction, catalogBinding);
@@ -226,7 +245,7 @@ export async function executeAction(
     );
   }
   const actionVersion = Number(action.expectedVersion ?? cell.store.readHead()?.revision ?? 0);
-  if (actionContract?.execution)
+  if (actionContract?.execution && !actionContract.execution.read)
     return cell.entityActionExecutor.run(
       action,
       binding,
@@ -251,7 +270,11 @@ export async function executeAction(
     const result = { schema: "entity-get/v1", kind, entity };
     return cell.readResult(cell.operationId(action, binding, cell.input.repoId, revision), result, revision, null);
   }
-  if (/^agent-(?:list|inspect|validate)$/u.test(action.kind)) {
+  if (
+    actionContract?.execution?.read &&
+    (actionContract.target.kind === "agent" || actionContract.target.kind === "squad") &&
+    ["list", "inspect", "validate"].includes(actionContract.id)
+  ) {
     const revision = cell.store.readHead()?.revision ?? 0,
       result = runAgentEntityAction({
         rootDir: cell.rootDir,
@@ -363,14 +386,8 @@ export async function executeAction(
   )
     return cell.runTaskCommandWithDocs(action as TaskCommandWithDocsAction, binding);
   if (action.kind === "task-progress-append") return cell.appendProgress(action, binding);
-  if (action.kind === "task-contract-migrate") return cell.migrateTaskContracts(action, binding);
-  if (action.kind === "task-archive" && (Array.isArray(action.taskIds) || typeof action.filter === "string"))
-    return cell.archiveTasks(action, binding);
-  if (action.kind === "task-supersede" && typeof action.title === "string")
-    return cell.supersedeWithNewTask(action, binding);
   if (action.kind === "task-declare-executor") return cell.declareExecutionExecutor(action, binding);
   if (action.kind === "task-closeout") return cell.closeoutTask(action, binding);
-  if (cell.taskSurfaceWriteKind(action.kind)) return cell.taskSurfaceWrite(action, binding);
   return cell.lifecycleAction(action, binding);
 }
 

--- a/packages/daemon/src/repo-cell-api.ts
+++ b/packages/daemon/src/repo-cell-api.ts
@@ -61,6 +61,7 @@ import type { AgentRuntimeStreamHub } from "./agent-runtime-stream.ts";
 import type { RepoBootstrapReceipt } from "./repo-bootstrap.ts";
 import { waitForOptionalTaskProjection } from "./projection-readiness-wait.ts";
 import { explainAuthenticationRequired, readTaskActionExplanation } from "./task-action-explanation-read.ts";
+import { commitRuntimeSessionAction } from "./runtime-session-action-runtime.ts";
 
 export interface RepoCellApiContext {
   readonly extracted: RepoCellOperationalContext;
@@ -199,11 +200,13 @@ export function createRepoCellApi(context: RepoCellApiContext): RepoCell {
     if (claimsRecovery) settlingRecovery = action.kind;
     const failAction = (error: unknown, authorizationDecision?: AuthorizationDecision): WriteReceipt => {
       if (context.fatalCellError(error)) context.latchWith(error);
-      const receipt = context.failed(
-        context.errorOperationId(error) ?? context.operationId(action, binding, context.input.repoId, 0),
-        error,
-      );
-      const contract = getExecutableEntityAction(action.kind);
+      const contract = getExecutableEntityAction(action.kind),
+        receipt = context.failed(
+          context.errorOperationId(error) ?? context.operationId(action, binding, context.input.repoId, 0),
+          error,
+          contract,
+          contract ? action : undefined,
+        );
       const result = contract ? deriveActionResult(contract, action, receipt) : receipt;
       return authorizationDecision
         ? withAuthorizationDecision(
@@ -814,18 +817,7 @@ export function createRepoCellApi(context: RepoCellApiContext): RepoCell {
     const policyAction = { ...action, kind: "runtime-run" };
     return enqueueRuntimePublication("runtime-run", policyAction, binding, async (authorizedBinding) => {
       if (action.kind === "event" && runtimeSessionActionIds.includes(action.type as never)) {
-        const catalogAction = {
-            kind: action.type,
-            ...action.payload,
-            ...(action.resultBody === undefined ? {} : { resultBody: action.resultBody }),
-            idempotencyKey: action.opId,
-          },
-          receipt = await context.extracted.entityActionExecutor.run(
-            catalogAction,
-            authorizedBinding,
-            action.opId,
-            context.extracted.entityActionRuntimes,
-          );
+        const receipt = await commitRuntimeSessionAction(context.extracted, action, authorizedBinding);
         return {
           schema: "command-receipt/v2",
           ok: receipt.outcome === "applied" || receipt.outcome === "no_changes",

--- a/packages/daemon/src/repo-cell-command.ts
+++ b/packages/daemon/src/repo-cell-command.ts
@@ -112,7 +112,7 @@ export function buildCommand(
       force: action.force === true,
     });
   }
-  if (action.kind === "task-submit") {
+  if (lifecycleAction?.commandType === "SubmitExecution") {
     const held = heldLeaseForExecutionActor(snapshot, undefined, binding.actor),
       executionId =
         explicitExecutionId(action) ??
@@ -139,7 +139,7 @@ export function buildCommand(
       submission: submissionPacket(action, rootDir),
     });
   }
-  if (action.kind === "task-review-execution") {
+  if (lifecycleAction?.commandType === "RecordReview") {
     const packet = reviewPacket(rootDir, action),
       executionId =
         explicitExecutionId(action) ??
@@ -268,7 +268,7 @@ export function buildCommand(
       reason: requiredCellText(action.reason, "reason"),
     });
   }
-  if (action.kind === "task-complete")
+  if (lifecycleAction?.commandType === "CompleteTask")
     return normalizeTaskLifecycleCommand(bound, {
       type: "CompleteTask",
       taskId,

--- a/packages/daemon/src/repo-cell-evidence.ts
+++ b/packages/daemon/src/repo-cell-evidence.ts
@@ -55,15 +55,3 @@ export function renderEvidenceRows(rows: readonly unknown[], named = false): str
         )
         .join("\n");
 }
-
-export function taskSurfaceWriteKind(kind: string): boolean {
-  return [
-    "task-release",
-    "task-amend",
-    "task-archive",
-    "task-supersede",
-    "task-delete",
-    "task-reopen",
-    "task-contract-migrate",
-  ].includes(kind);
-}

--- a/packages/daemon/src/repo-cell-open.ts
+++ b/packages/daemon/src/repo-cell-open.ts
@@ -5,6 +5,7 @@ import {
   isSameExecution,
   isSamePerson,
   makeTaskEventStore,
+  runtimeSessionActionIds,
   type AgentRuntimeEventV1,
   type CanonicalEventAppendReceipt,
   type CanonicalEventStore,
@@ -427,12 +428,17 @@ async function openLockedRepoCell(
       input.onAttemptTerminal?.(terminal);
     },
     handoffTaskLease: (handoff) => handoffTaskLease(handoff),
-    commitRuntimeSessionAction: async (draft, binding) => {
-      const receipt = await commitRuntimeSessionAction(extracted, { kind: "event", ...draft }, binding),
-        event = (receipt as typeof receipt & { readonly event?: AgentRuntimeEventV1 }).event;
+    commitRuntimeEvent: async (draft, binding) => {
+      const action = { kind: "event" as const, ...draft },
+        receipt = runtimeSessionActionIds.includes(draft.type as never)
+          ? await commitRuntimeSessionAction(extracted, action, binding)
+          : extracted.appendAuxiliaryRuntimeIngress(action, binding),
+        event = (receipt as typeof receipt & { readonly event?: AgentRuntimeEventV1 }).event,
+        runtimeReceipt = { ...(receipt as unknown as JsonObject) };
+      delete runtimeReceipt.event;
       return {
         ...(event ? { event } : {}),
-        receipt: receipt as unknown as JsonObject,
+        receipt: runtimeReceipt,
       };
     },
     authorizeRuntimeEvent: ({ type, payload, opId, binding }) =>

--- a/packages/daemon/src/repo-cell-open.ts
+++ b/packages/daemon/src/repo-cell-open.ts
@@ -5,6 +5,7 @@ import {
   isSameExecution,
   isSamePerson,
   makeTaskEventStore,
+  type AgentRuntimeEventV1,
   type CanonicalEventAppendReceipt,
   type CanonicalEventStore,
   type DaemonRepoMode,
@@ -20,6 +21,7 @@ import { makeAgentRuntimeStreamHub } from "./agent-runtime-stream.ts";
 import { openGuiCatalog } from "./gui-catalog.ts";
 import type { FleetRoster } from "./fleet-center-admission.ts";
 import { type CanonicalRoot, type WorkspaceId } from "./protocol/daemon-protocol.contract.ts";
+import type { JsonObject } from "./protocol/json-rpc-types.ts";
 import { makeRecoveryProbe } from "./recovery-state.ts";
 import { bootstrapRepo, type RepoBootstrapInput, type RepoBootstrapReceipt } from "./repo-bootstrap.ts";
 import {
@@ -43,7 +45,7 @@ import { acquireWorkspaceLock, causeClassOf, latchReprobeThrottleMs } from "./re
 import { operationId } from "./repo-cell-proof.ts";
 import { makeScheduleActionRuntime } from "./schedule-action-runtime.ts";
 import { makeSettingsActionRuntime } from "./settings-action-runtime.ts";
-import { runtimeSessionActionPreparer } from "./runtime-session-action-runtime.ts";
+import { commitRuntimeSessionAction, runtimeSessionActionPreparer } from "./runtime-session-action-runtime.ts";
 import { makeRepoCellSettingsState } from "./repo-cell-settings-state.ts";
 import { makePersonActionRuntime } from "./person-action-runtime.ts";
 import { authorizeRepoCellAction } from "./repo-cell-authorization.ts";
@@ -425,6 +427,14 @@ async function openLockedRepoCell(
       input.onAttemptTerminal?.(terminal);
     },
     handoffTaskLease: (handoff) => handoffTaskLease(handoff),
+    commitRuntimeSessionAction: async (draft, binding) => {
+      const receipt = await commitRuntimeSessionAction(extracted, { kind: "event", ...draft }, binding),
+        event = (receipt as typeof receipt & { readonly event?: AgentRuntimeEventV1 }).event;
+      return {
+        ...(event ? { event } : {}),
+        receipt: receipt as unknown as JsonObject,
+      };
+    },
     authorizeRuntimeEvent: ({ type, payload, opId, binding }) =>
       authorizeRuntimeAction(
         {

--- a/packages/daemon/src/repo-cell-runtime-ingress.ts
+++ b/packages/daemon/src/repo-cell-runtime-ingress.ts
@@ -22,10 +22,9 @@ export function appendAuxiliaryRuntimeIngress(
   binding: RepoCellBinding,
 ): JsonObject {
   const scope = binding.assignmentScope;
-  if (!scope)
-    throw cell.cellCodedError("assignment_required", "Runtime Fleet ingress requires an authenticated assignment.");
   if (action.kind === "archive") {
     if (
+      !scope ||
       scope.scope.kind !== "task" ||
       action.archive.taskId !== scope.scope.taskId ||
       action.archive.executionId !== scope.scope.executionId
@@ -44,6 +43,8 @@ export function appendAuxiliaryRuntimeIngress(
       archive: action.archive,
     }) as unknown as JsonObject;
   }
+  if (!scope && binding.source !== "local")
+    throw cell.cellCodedError("assignment_required", "Runtime Fleet ingress requires an authenticated assignment.");
   if (!auxiliaryEventTypes.includes(action.type as (typeof auxiliaryEventTypes)[number]))
     throw cell.cellCodedError(
       "invalid_runtime_event",

--- a/packages/daemon/src/repo-cell-settlement.ts
+++ b/packages/daemon/src/repo-cell-settlement.ts
@@ -1,6 +1,8 @@
 import {
   VcsCommandError,
   completionBlockers,
+  getExecutableEntityAction,
+  type EntityActionContract,
   type TaskProgressEvidence,
   type WriteReceiptDraft as WriteReceipt,
 } from "../../kernel/src/index.ts";
@@ -10,12 +12,9 @@ import {
   cellCriterionError,
   cellErrorCode,
   cellErrorMessage,
-  type CellActionCriterionFailure,
 } from "./repo-cell-errors.ts";
 import { gateChecks, selectedReviewId } from "./repo-cell-proof.ts";
 import type { Snapshot } from "./repo-cell-types.ts";
-
-const criterionFailureByReceipt = new WeakMap<object, CellActionCriterionFailure>();
 
 export function completionApplied(
   receipt: WriteReceipt,
@@ -52,7 +51,7 @@ export function completionSettlement(
           ? "Wait for canonical settlement, then query this receipt."
           : "Resolve the rejected canonical step before retrying completion.",
     state = `${snapshot.task?.status ?? "missing"}/${snapshot.task?.currentNode ?? "missing"}`;
-  const settled = {
+  return {
     ...receipt,
     ...(receipt.outcome === "pending" || receipt.outcome === "indeterminate" ? { unmetCriteria: [] } : {}),
     taskId: snapshot.task?.taskId,
@@ -67,7 +66,6 @@ export function completionSettlement(
     steps,
     stoppedAt,
   } as WriteReceipt;
-  return carryActionCriterionFailure(receipt, settled);
 }
 
 export function completionStopped(
@@ -77,13 +75,18 @@ export function completionStopped(
   blocker: ReturnType<typeof completionBlockers>[number],
   steps: readonly WriteReceipt[],
 ): WriteReceipt {
+  const action = { kind: "task-complete", taskId: snapshot.task?.taskId },
+    contract = getExecutableEntityAction(action.kind);
+  if (!contract) throw cellCodedError("invalid_store", "Task complete Action contract is unavailable.");
   const receipt = failed(
     opId,
     cellCriterionError(blocker.code, blocker.next.command, "complete", "closeout-readiness/closeoutReadiness", [
       blocker.next.command,
     ]),
+    contract,
+    action,
   );
-  return carryActionCriterionFailure(receipt, {
+  return {
     ...receipt,
     taskId: snapshot.task?.taskId,
     executionId,
@@ -96,7 +99,7 @@ export function completionStopped(
     next: [blocker.next],
     steps,
     stoppedAt: blocker.code,
-  } as WriteReceipt);
+  } as WriteReceipt;
 }
 
 export function rejected(opId: string, code: string, nextAction: string): WriteReceipt {
@@ -110,7 +113,12 @@ export function rejected(opId: string, code: string, nextAction: string): WriteR
   };
 }
 
-export function failed(opId: string, error: unknown): WriteReceipt {
+export function failed(
+  opId: string,
+  error: unknown,
+  contract?: EntityActionContract,
+  action?: Readonly<Record<string, unknown>>,
+): WriteReceipt {
   const code = cellErrorCode(error);
   const receipt: WriteReceipt =
     error instanceof VcsCommandError || code === "publication_indeterminate"
@@ -127,18 +135,31 @@ export function failed(opId: string, error: unknown): WriteReceipt {
         }
       : rejected(opId, code, cellErrorMessage(error));
   const criterionFailure = actionCriterionFailure(error);
-  if (criterionFailure !== null) criterionFailureByReceipt.set(receipt, criterionFailure);
-  return receipt;
-}
-
-export function actionCriterionFailureOfReceipt(receipt: WriteReceipt): CellActionCriterionFailure | null {
-  return criterionFailureByReceipt.get(receipt) ?? null;
-}
-
-function carryActionCriterionFailure(source: WriteReceipt, target: WriteReceipt): WriteReceipt {
-  const criterionFailure = criterionFailureByReceipt.get(source);
-  if (criterionFailure !== undefined) criterionFailureByReceipt.set(target, criterionFailure);
-  return target;
+  if (criterionFailure === null) return receipt;
+  if (!contract || !action)
+    throw cellCodedError(
+      "invalid_store",
+      `Criterion-bearing ${criterionFailure.actionId} failure reached settlement without its Action contract.`,
+    );
+  if (criterionFailure.actionId !== contract.id)
+    throw cellCodedError(
+      "invalid_store",
+      `Action ${contract.target.kind}.${contract.id} received criterion ${criterionFailure.criterionRef} ` +
+        `attributed to ${criterionFailure.actionId}.`,
+    );
+  const criterion = contract.criteria.find(({ ref }) => ref === criterionFailure.criterionRef);
+  if (!criterion)
+    throw cellCodedError(
+      "invalid_store",
+      `Action ${contract.target.kind}.${contract.id} does not declare criterion ${criterionFailure.criterionRef}.`,
+    );
+  return {
+    ...receipt,
+    evidence: `criterion:${criterion.ref}`,
+    unmetCriteria: [criterion],
+    rejectionExplanation: criterion.explain,
+    nextActions: Object.freeze([...new Set(criterionFailure.nextActions)]),
+  };
 }
 
 export function requiredCellText(value: unknown, name: string): string {

--- a/packages/daemon/src/runtime-session-action-runtime.ts
+++ b/packages/daemon/src/runtime-session-action-runtime.ts
@@ -1,45 +1,90 @@
-import type { TaskProjection } from "../../kernel/src/index.ts";
-import type { EntityActionCatalogPreparer } from "./entity-action-catalog-executor.ts";
+import {
+  attributeEntityActionCriterion,
+  getExecutableEntityAction,
+  type TaskProjection,
+  type WriteReceiptDraft as WriteReceipt,
+} from "../../kernel/src/index.ts";
+import { deriveActionResult, type EntityActionCatalogPreparer } from "./entity-action-catalog-executor.ts";
+import type { RepoCellActionContext } from "./repo-cell-action-context.ts";
+import type { RepoCellBinding, RuntimeIngressAction } from "./repo-cell-types.ts";
 
 export function runtimeSessionActionPreparer(projection: () => TaskProjection): EntityActionCatalogPreparer {
-  return (_contract, action, binding) => {
-    const scope = binding.assignmentScope;
-    if (!scope)
-      invalidRuntimeSessionAction(
-        "assignment_required",
-        "RuntimeSession event ingress requires an authenticated assignment.",
-      );
+  return (contract, action, binding) => {
     const runtimeSessionId = requiredRuntimeActionText(action.runtimeSessionId, "runtimeSessionId"),
       dispatch = projection()
         .readRuntimeDispatches()
         .find((event) => event.payload.runtimeSessionId === runtimeSessionId),
       dispatchSource = dispatch?.source,
-      ingressSource = binding.source;
-    if (
-      !dispatch ||
-      typeof dispatchSource !== "object" ||
-      dispatchSource.kind !== "assignment" ||
-      typeof ingressSource !== "object" ||
-      ingressSource.kind !== "assignment" ||
-      dispatchSource.nodeId !== ingressSource.nodeId ||
-      dispatchSource.assignmentId !== ingressSource.assignmentId
-    )
+      ingressSource = binding.source,
+      localOwner = dispatchSource === "local" && ingressSource === "local";
+    if (!localOwner) {
+      const scope = binding.assignmentScope;
+      if (!scope)
+        invalidRuntimeSessionAction(
+          "assignment_required",
+          "RuntimeSession event ingress requires an authenticated assignment.",
+        );
+      if (
+        !dispatch ||
+        typeof dispatchSource !== "object" ||
+        dispatchSource.kind !== "assignment" ||
+        typeof ingressSource !== "object" ||
+        ingressSource.kind !== "assignment" ||
+        dispatchSource.nodeId !== ingressSource.nodeId ||
+        dispatchSource.assignmentId !== ingressSource.assignmentId
+      )
+        invalidRuntimeSessionAction(
+          "assignment_scope_mismatch",
+          "RuntimeSession events must come from the assignment that owns the session dispatch.",
+          contract.id,
+          "runtime-session/assignment-fence",
+        );
+      if (
+        action.kind === "runtime_session_task_bound" &&
+        (scope.scope.kind !== "task" ||
+          action.taskId !== scope.scope.taskId ||
+          action.executionId !== scope.scope.executionId)
+      )
+        invalidRuntimeSessionAction(
+          "assignment_scope_mismatch",
+          "RuntimeSession task and execution binding must match the authenticated assignment.",
+          contract.id,
+          "runtime-session/task-binding",
+        );
+    }
+    if (!dispatch)
       invalidRuntimeSessionAction(
         "assignment_scope_mismatch",
-        "RuntimeSession events must come from the assignment that owns the session dispatch.",
-      );
-    if (
-      action.kind === "runtime_session_task_bound" &&
-      (scope.scope.kind !== "task" ||
-        action.taskId !== scope.scope.taskId ||
-        action.executionId !== scope.scope.executionId)
-    )
-      invalidRuntimeSessionAction(
-        "assignment_scope_mismatch",
-        "RuntimeSession task and execution binding must match the authenticated assignment.",
+        "RuntimeSession events require a canonical dispatch owned by their ingress source.",
+        contract.id,
+        "runtime-session/assignment-fence",
       );
     return { ...action, dispatchId: dispatch.payload.dispatchId };
   };
+}
+
+/** Commit one RuntimeSession catalog Action while the caller owns the RepoCell writer queue. */
+export async function commitRuntimeSessionAction(
+  cell: RepoCellActionContext,
+  action: Extract<RuntimeIngressAction, { readonly kind: "event" }>,
+  binding: RepoCellBinding,
+): Promise<WriteReceipt> {
+  const catalogAction = {
+      kind: action.type,
+      ...action.payload,
+      ...(action.resultBody === undefined ? {} : { resultBody: action.resultBody }),
+      idempotencyKey: action.opId,
+    },
+    contract = getExecutableEntityAction(catalogAction.kind);
+  if (!contract || contract.target.kind !== "runtime-session")
+    throw Object.assign(new Error(`${catalogAction.kind} is not a RuntimeSession catalog Action.`), {
+      code: "invalid_store",
+    });
+  try {
+    return await cell.entityActionExecutor.run(catalogAction, binding, action.opId, cell.entityActionRuntimes);
+  } catch (error) {
+    return deriveActionResult(contract, catalogAction, cell.failed(action.opId, error, contract, catalogAction));
+  }
 }
 
 function requiredRuntimeActionText(value: unknown, field: string): string {
@@ -47,6 +92,7 @@ function requiredRuntimeActionText(value: unknown, field: string): string {
   invalidRuntimeSessionAction("invalid_runtime_event", `${field} is required.`);
 }
 
-function invalidRuntimeSessionAction(code: string, message: string): never {
-  throw Object.assign(new Error(message), { code });
+function invalidRuntimeSessionAction(code: string, message: string, actionId?: string, criterionRef?: string): never {
+  const error = Object.assign(new Error(message), { code });
+  throw actionId && criterionRef ? attributeEntityActionCriterion(error, actionId, criterionRef) : error;
 }

--- a/packages/daemon/src/runtime-session-action-runtime.ts
+++ b/packages/daemon/src/runtime-session-action-runtime.ts
@@ -83,6 +83,16 @@ export async function commitRuntimeSessionAction(
   try {
     return await cell.entityActionExecutor.run(catalogAction, binding, action.opId, cell.entityActionRuntimes);
   } catch (error) {
+    if (cell.store.readEvent(action.opId))
+      try {
+        return await cell.entityActionExecutor.run(catalogAction, binding, action.opId, cell.entityActionRuntimes);
+      } catch (replayError) {
+        return deriveActionResult(
+          contract,
+          catalogAction,
+          cell.failed(action.opId, replayError, contract, catalogAction),
+        );
+      }
     return deriveActionResult(contract, catalogAction, cell.failed(action.opId, error, contract, catalogAction));
   }
 }

--- a/packages/daemon/src/runtime-spawn-provider-stream.ts
+++ b/packages/daemon/src/runtime-spawn-provider-stream.ts
@@ -29,8 +29,8 @@ export async function publishRuntimeEvent<T extends RuntimeEventType>(
           opId,
           ...(resultBody === undefined ? {} : { resultBody }),
         })
-      : context.input.commitRuntimeSessionAction
-        ? await context.input.commitRuntimeSessionAction(
+      : context.input.commitRuntimeEvent
+        ? await context.input.commitRuntimeEvent(
             {
               type,
               payload,
@@ -42,7 +42,7 @@ export async function publishRuntimeEvent<T extends RuntimeEventType>(
         : (() => {
             throw context.runtimeSpawnError(
               "runtime_preconditions_unavailable",
-              "Local RuntimeSession catalog commit is unavailable.",
+              "Local runtime event commit is unavailable.",
             );
           })();
   if (!published.event) {

--- a/packages/daemon/src/runtime-spawn-provider-stream.ts
+++ b/packages/daemon/src/runtime-spawn-provider-stream.ts
@@ -1,20 +1,14 @@
-import { createHash } from "node:crypto";
 import { setTimeout as delay } from "node:timers/promises";
-import type {
-  AgentRuntimeEventV1,
-  CanonicalContentBlob,
-  CanonicalEventStore,
-  SessionIdentity,
-} from "../../kernel/src/index.ts";
-import { canonicalEventWritePlan, consumeKnownError, runtimeEventContentClaims } from "../../kernel/src/index.ts";
+import type { SessionIdentity } from "../../kernel/src/index.ts";
+import { consumeKnownError } from "../../kernel/src/index.ts";
 import { readDispatchStream, scrubProviderValue } from "./dispatch-stream.ts";
-import { type JsonObject } from "./protocol/json-rpc-types.ts";
 import type { ActiveRuntime, ProviderFrame, RuntimeBinding } from "./runtime-spawn-types.ts";
 import { transcriptRefForSessionIdentity } from "./session-identity/index.ts";
 import { observeProviderFault } from "./runtime-provider-fault.ts";
 import {
   runtimeEventHasType,
   type RuntimeEventOf,
+  type RuntimeEventPublication,
   type RuntimeEventType,
   type RuntimeSpawnerContext,
 } from "./runtime-spawn-context.ts";
@@ -26,55 +20,41 @@ export async function publishRuntimeEvent<T extends RuntimeEventType>(
   opId: string,
   binding: RuntimeBinding,
   resultBody?: string,
-): Promise<{
-  readonly event: RuntimeEventOf<T>;
-  readonly publication?: ReturnType<CanonicalEventStore["append"]>;
-  readonly receipt?: JsonObject;
-}> {
-  if (context.input.remote) {
-    const published = await context.input.remote.publish({
-      type,
-      payload,
-      opId,
-      ...(resultBody === undefined ? {} : { resultBody }),
-    });
-    if (!runtimeEventHasType(published.event, type))
-      throw context.runtimeSpawnError("invalid_runtime_event", "Remote runtime publication changed the event type.");
-    return { ...published, event: published.event };
-  }
+): Promise<RuntimeEventPublication<T>> {
   const authorizedBinding = context.input.authorizeRuntimeEvent?.({ type, payload, opId, binding }) ?? binding,
-    store = context.requiredRuntimeStore(context.input),
-    projection = context.requiredRuntimeProjection(context.input),
-    value = {
-      schema: "agent-runtime-event/v1",
-      eventId: `event-${createHash("sha256").update(opId).digest("hex")}`,
-      workspaceRevision: (store.readHead()?.revision ?? 0) + 1,
-      opId,
-      type,
-      actor: authorizedBinding.actor,
-      source: authorizedBinding.source,
-      occurredAt: context.input.now(),
-      payload,
-    } as AgentRuntimeEventV1;
-  if (!runtimeEventHasType(value, type))
-    throw context.runtimeSpawnError("invalid_runtime_event", "Runtime event construction changed the event type.");
-  const claims = runtimeEventContentClaims(value);
-  let blobs: readonly CanonicalContentBlob[] = [];
-  if (resultBody !== undefined) {
-    if (claims.length !== 1)
-      throw context.runtimeSpawnError(
-        "invalid_runtime_event",
-        "Only a content-bearing runtime event can carry content bytes.",
-      );
-    blobs = [{ ...claims[0]!, body: resultBody }];
+    published = context.input.remote
+      ? await context.input.remote.publish({
+          type,
+          payload,
+          opId,
+          ...(resultBody === undefined ? {} : { resultBody }),
+        })
+      : context.input.commitRuntimeSessionAction
+        ? await context.input.commitRuntimeSessionAction(
+            {
+              type,
+              payload,
+              opId,
+              ...(resultBody === undefined ? {} : { resultBody }),
+            },
+            authorizedBinding,
+          )
+        : (() => {
+            throw context.runtimeSpawnError(
+              "runtime_preconditions_unavailable",
+              "Local RuntimeSession catalog commit is unavailable.",
+            );
+          })();
+  if (!published.event) {
+    const nextAction = typeof published.receipt.nextAction === "string" ? published.receipt.nextAction : null;
+    throw context.runtimeSpawnError(
+      typeof published.receipt.code === "string" ? published.receipt.code : "runtime_event_rejected",
+      nextAction ?? `RuntimeSession Action ${type} was ${String(published.receipt.outcome ?? "rejected")}.`,
+    );
   }
-  const appended = store.append({
-    event: value,
-    plan: canonicalEventWritePlan(value, "agent-runtime/v1", value.opId),
-    blobs,
-  });
-  projection.apply(value);
-  return { event: value, publication: appended };
+  if (!runtimeEventHasType(published.event, type))
+    throw context.runtimeSpawnError("invalid_runtime_event", "Runtime publication changed the event type.");
+  return { ...published, event: published.event };
 }
 
 export async function consumeProviderChunk(

--- a/packages/daemon/src/runtime-spawner.ts
+++ b/packages/daemon/src/runtime-spawner.ts
@@ -116,8 +116,8 @@ export interface RuntimeSpawnerInput {
   readonly projection?: () => TaskProjection;
   readonly readSettings?: () => SettingsV1;
   readonly remote?: RemoteRuntimePersistence;
-  /** Local RuntimeSession catalog commit; the caller already owns the RepoCell writer queue. */
-  readonly commitRuntimeSessionAction?: (
+  /** Local runtime event commit; the caller already owns the RepoCell writer queue. */
+  readonly commitRuntimeEvent?: (
     draft: {
       readonly type: AgentRuntimeEventV1["type"];
       readonly payload: Readonly<Record<string, unknown>>;

--- a/packages/daemon/src/runtime-spawner.ts
+++ b/packages/daemon/src/runtime-spawner.ts
@@ -116,6 +116,16 @@ export interface RuntimeSpawnerInput {
   readonly projection?: () => TaskProjection;
   readonly readSettings?: () => SettingsV1;
   readonly remote?: RemoteRuntimePersistence;
+  /** Local RuntimeSession catalog commit; the caller already owns the RepoCell writer queue. */
+  readonly commitRuntimeSessionAction?: (
+    draft: {
+      readonly type: AgentRuntimeEventV1["type"];
+      readonly payload: Readonly<Record<string, unknown>>;
+      readonly opId: string;
+      readonly resultBody?: string;
+    },
+    binding: RuntimeBinding,
+  ) => Promise<{ readonly event?: AgentRuntimeEventV1; readonly receipt: JsonObject }>;
   readonly stream: Pick<AgentRuntimeStreamHub, "publish">;
   readonly now: () => string;
   readonly runtimeInstances?: () => readonly RuntimeInstanceSummary[];
@@ -151,7 +161,7 @@ export interface RuntimeSpawnerInput {
     readonly fromRuntimeSessionId: string | null;
     readonly binding: RuntimeBinding;
   }) => Promise<RuntimeBinding>;
-  /** Re-authorizes each local canonical Runtime event at the cut where it is appended. */
+  /** Re-authorizes each local RuntimeSession catalog Action at its commit cut. */
   readonly authorizeRuntimeEvent?: (input: {
     readonly type: AgentRuntimeEventV1["type"];
     readonly payload: AgentRuntimeEventV1["payload"];

--- a/packages/daemon/src/task-action-catalog-runtime.ts
+++ b/packages/daemon/src/task-action-catalog-runtime.ts
@@ -249,6 +249,8 @@ function taskActionFailure(
     rejected = cell.failed(
       cell.errorOperationId(error) ?? cell.operationId(action, binding, cell.input.repoId, revision),
       error,
+      contract,
+      action,
     );
   return taskActionRejection(
     cell,

--- a/packages/daemon/test/fleet-transport.integration.test.ts
+++ b/packages/daemon/test/fleet-transport.integration.test.ts
@@ -796,19 +796,15 @@ test(
               event.payload.runtimeSessionId === receipt.runtimeSessionId,
           );
       assert.equal(events.length, 2);
-      for (const event of events)
-        await assert.rejects(
-          fixture.host.runtimeIngress(
-            fixture.assignment.repoId,
-            { kind: "event", type: event.type, payload: event.payload, opId: event.opId },
-            { transportKind: "fleet-tls", assignmentBinding: foreignAssignment },
-          ),
-          (error: unknown) =>
-            typeof error === "object" &&
-            error !== null &&
-            "code" in error &&
-            error.code === "assignment_scope_mismatch",
+      for (const event of events) {
+        const rejected = await fixture.host.runtimeIngress(
+          fixture.assignment.repoId,
+          { kind: "event", type: event.type, payload: event.payload, opId: event.opId },
+          { transportKind: "fleet-tls", assignmentBinding: foreignAssignment },
         );
+        assert.equal(rejected.outcome, "op_rejected");
+        assert.equal(rejected.code, "assignment_scope_mismatch");
+      }
     });
     await runFleetReplicaPullClient({
       port: center.port,

--- a/packages/daemon/test/runtime-session-action.integration.test.ts
+++ b/packages/daemon/test/runtime-session-action.integration.test.ts
@@ -1,7 +1,7 @@
 // harness-test-tier: integration
 import assert from "node:assert/strict";
 import { createHash } from "node:crypto";
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, readdirSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -10,6 +10,14 @@ import { canonicalRoot, workspaceId } from "../src/protocol/daemon-protocol.cont
 import type { RepoCellBinding } from "../src/repo-cell.ts";
 import { openBootstrappedRepoCell as openRepoCell } from "./repo-settings.fixture.ts";
 import { initRepo } from "./task-surface.fixtures.ts";
+
+test("runtime spawn production helpers cannot append canonical events outside the catalog commit", () => {
+  const source = new URL("../src/", import.meta.url),
+    offenders = readdirSync(source)
+      .filter((name) => name.startsWith("runtime-spawn-") && name.endsWith(".ts"))
+      .filter((name) => /store\.append/u.test(readFileSync(new URL(name, source), "utf8")));
+  assert.deepEqual(offenders, []);
+});
 
 test("the center queue admits one RuntimeSession adoption generation and rejects its concurrent sibling", async () => {
   const rootDir = mkdtempSync(path.join(tmpdir(), "ha-runtime-session-action-")),
@@ -95,15 +103,28 @@ test("the center queue admits one RuntimeSession adoption generation and rejects
         start("runtime-start-edge-a", binding),
         start("runtime-start-edge-b", foreignBinding),
       ]);
-    assert.equal(attempts.filter(({ status }) => status === "fulfilled").length, 1);
-    const rejected = attempts.find(({ status }) => status === "rejected");
-    assert.equal(rejected?.status, "rejected");
-    if (rejected?.status === "rejected")
-      assert.equal((rejected.reason as { readonly code?: unknown }).code, "assignment_scope_mismatch");
-    await assert.rejects(
-      start("runtime-start-stale-generation", binding),
-      (error: unknown) => (error as { readonly code?: unknown }).code === "runtime_session_adoption_stale",
-    );
+    assert.equal(attempts.filter(({ status }) => status === "fulfilled").length, 2);
+    const receipts = attempts.flatMap((attempt) => (attempt.status === "fulfilled" ? [attempt.value] : [])),
+      rejected = receipts.find(({ outcome }) => outcome === "op_rejected");
+    assert.equal(receipts.filter(({ outcome }) => outcome === "applied").length, 1);
+    assert.equal(rejected?.code, "assignment_scope_mismatch");
+    assert.deepEqual(rejected?.unmetCriteria, [
+      {
+        ref: "runtime-session/assignment-fence",
+        failureCode: "assignment_scope_mismatch",
+        explain: "The authenticated assignment owns the dispatch that created this RuntimeSession.",
+      },
+    ]);
+    const stale = await start("runtime-start-stale-generation", binding);
+    assert.equal(stale.outcome, "op_rejected");
+    assert.equal(stale.code, "runtime_session_adoption_stale");
+    assert.deepEqual(stale.unmetCriteria, [
+      {
+        ref: "runtime-session/adoption-fence",
+        failureCode: "runtime_session_adoption_stale",
+        explain: "A RuntimeSession start must advance its center-projected launchGeneration.",
+      },
+    ]);
     await cell.close();
     cell = undefined;
     const store = makeTaskEventStore({ repoId, rootDir });

--- a/packages/daemon/test/task-action-catalog-executor.test.ts
+++ b/packages/daemon/test/task-action-catalog-executor.test.ts
@@ -122,6 +122,8 @@ test("criterion-bearing failures resolve descriptors by action plus ref even whe
         cellCriterionError("invalid_transition", "Retry from the validator result.", "start", criterionRef, [
           "Retry from the validator result.",
         ]),
+        contract,
+        { kind: "task-start", taskId: "task_contract" },
       ),
     );
     assert.deepEqual(receipt.unmetCriteria, [descriptor]);

--- a/packages/daemon/test/task-action-explanation-read.integration.test.ts
+++ b/packages/daemon/test/task-action-explanation-read.integration.test.ts
@@ -66,7 +66,7 @@ test("typed Entity Action read preserves one cut for 1..500 refs and has no writ
       new Set(fiveHundred.subjects.flatMap(({ actions }) => actions.map(({ evaluatedAtCut }) => evaluatedAtCut))).size,
       1,
     );
-    assert.equal(one.subjects[0]!.actions.length, 4);
+    assert.equal(one.subjects[0]!.actions.length, 11);
     assert.deepEqual(one.subjects[0]!.actions[0]!.authorizationDecision?.actor, actor);
     assert.doesNotThrow(() => parseDaemonGuiReadResult(method, fiveHundred));
 

--- a/packages/gui/src/renderer/entity-docs.ts
+++ b/packages/gui/src/renderer/entity-docs.ts
@@ -90,7 +90,7 @@ export const KERNEL_ENTITY_CONTRACT = Object.freeze({
     schemaId: "agent-declaration/v1",
     refTemplate: "agent/{id}",
     statuses: [],
-    actions: ["install"],
+    actions: ["install", "validate", "list", "inspect"],
   },
   decision: {
     schemaId: "decision-package",

--- a/packages/gui/src/renderer/entity-docs.ts
+++ b/packages/gui/src/renderer/entity-docs.ts
@@ -252,7 +252,19 @@ export const KERNEL_ENTITY_CONTRACT = Object.freeze({
         words: ["planned", "active", "blocked", "in_review", "done", "cancelled"],
       },
     ],
-    actions: ["start", "submit", "review", "complete"],
+    actions: [
+      "start",
+      "submit",
+      "review",
+      "complete",
+      "release",
+      "amend",
+      "archive",
+      "supersede",
+      "delete",
+      "reopen",
+      "contract-migrate",
+    ],
   },
 } as const satisfies Readonly<Record<string, EntityKernelContract>>);
 

--- a/packages/kernel/src/domain/agent-action-contract.ts
+++ b/packages/kernel/src/domain/agent-action-contract.ts
@@ -13,6 +13,9 @@ export interface AgentActionDraft {
   readonly entity: AgentDeclarationV1;
 }
 
+export const agentActionIds = Object.freeze(["install", "validate", "list", "inspect"] as const);
+export type AgentActionId = (typeof agentActionIds)[number];
+
 const input = (
   fields: readonly EntityActionInputField[],
   exactlyOneOf: readonly (readonly string[])[] = [],
@@ -23,8 +26,16 @@ const input = (
     exactlyOneOf: Object.freeze(exactlyOneOf.map((group) => Object.freeze(group))),
   });
 
+const readConcurrency: EntityActionContract["concurrency"] = Object.freeze({
+  expectedVersion: Object.freeze({ authority: "canonical-projection-cut", required: false }),
+  leasePolicy: Object.freeze({ authority: "not-applicable" }),
+  occurrenceClaim: Object.freeze({ authority: "not-applicable" }),
+  idempotency: Object.freeze({ authority: "operation-id", input: "idempotencyKey" }),
+  artifactOwnership: Object.freeze({ authority: "not-applicable" }),
+});
+
 export function createAgentActionCatalog(
-  baseAction: (id: "install") => EntityActionContract,
+  baseAction: (id: AgentActionId) => EntityActionContract,
   actionResultContract: EntityActionContract["returns"],
 ) {
   const declared = baseAction("install");
@@ -115,6 +126,72 @@ export function createAgentActionCatalog(
           implementation: "compiled-event" as const,
           topology: "center-forward-write" as const,
           targetIdField: "entityId",
+        }),
+      }),
+      Object.freeze({
+        ...baseAction("validate"),
+        input: input([{ field: "packageSource", type: "string", required: true }]),
+        policy: Object.freeze({ ref: "default@5", action: null }),
+        criteria: Object.freeze([
+          {
+            ref: "agent/declaration-schema",
+            failureCode: "invalid_manifest",
+            explain: "The supplied package contains a valid agent-declaration/v1 manifest.",
+          },
+          {
+            ref: "agent/instructions-ready",
+            failureCode: "instructions_placeholder",
+            explain: "The supplied package contains authored Agent instructions.",
+          },
+        ]),
+        concurrency: readConcurrency,
+        effects: Object.freeze([]),
+        returns: actionResultContract,
+        explain: "Validate one Agent declaration package without mutation.",
+        execution: Object.freeze({
+          ingress: "agent-validate",
+          compile: null,
+          read: true,
+          implementation: "catalog-runtime" as const,
+        }),
+      }),
+      Object.freeze({
+        ...baseAction("list"),
+        input: input([]),
+        policy: Object.freeze({ ref: "default@5", action: null }),
+        criteria: Object.freeze([]),
+        concurrency: readConcurrency,
+        effects: Object.freeze([]),
+        returns: actionResultContract,
+        explain: "List installed Agent declarations from the canonical projection cut.",
+        execution: Object.freeze({
+          ingress: "agent-list",
+          compile: null,
+          read: true,
+          implementation: "catalog-runtime" as const,
+        }),
+      }),
+      Object.freeze({
+        ...baseAction("inspect"),
+        input: input([{ field: "agentId", type: "string", required: true }]),
+        policy: Object.freeze({ ref: "default@5", action: null }),
+        criteria: Object.freeze([
+          {
+            ref: "agent/entity-present",
+            failureCode: "agent_not_found",
+            explain: "The requested Agent exists at the canonical cut.",
+          },
+        ]),
+        concurrency: readConcurrency,
+        effects: Object.freeze([]),
+        returns: actionResultContract,
+        explain: "Inspect one Agent declaration and its instructions from the canonical projection cut.",
+        execution: Object.freeze({
+          ingress: "agent-inspect",
+          compile: null,
+          read: true,
+          implementation: "catalog-runtime" as const,
+          targetIdField: "agentId",
         }),
       }),
     ]),

--- a/packages/kernel/src/domain/entity-action-explanation.ts
+++ b/packages/kernel/src/domain/entity-action-explanation.ts
@@ -363,7 +363,9 @@ function validInputField(value: unknown): boolean {
   if (!Object.keys(value).every((field) => allowed.includes(field))) return false;
   if (
     !explanationNonEmpty(value.field) ||
-    !["string", "number", "boolean", "string-array", "fact-hold-array", "json-object"].includes(String(value.type)) ||
+    !["string", "number", "boolean", "string-array", "fact-hold-array", "json-object", "json-object-array"].includes(
+      String(value.type),
+    ) ||
     typeof value.required !== "boolean" ||
     (value.enum !== undefined && !explanationStringList(value.enum)) ||
     (value.regex !== undefined && typeof value.regex !== "string")

--- a/packages/kernel/src/domain/entity-action-explanation.ts
+++ b/packages/kernel/src/domain/entity-action-explanation.ts
@@ -19,8 +19,6 @@ export class EntityActionExplanationContractError extends Error {
   readonly code = "invalid_entity_action_explanation";
 }
 
-export const taskLifecycleActionIds = Object.freeze(["start", "submit", "review", "complete"] as const);
-export type TaskLifecycleActionId = (typeof taskLifecycleActionIds)[number];
 export const entityActionCriterionStatuses = Object.freeze([
   "met",
   "unmet",

--- a/packages/kernel/src/domain/entity-kind-registry.ts
+++ b/packages/kernel/src/domain/entity-kind-registry.ts
@@ -224,7 +224,14 @@ export interface EntityActionContract {
 
 export interface EntityActionInputField {
   readonly field: string;
-  readonly type: "string" | "number" | "boolean" | "string-array" | "fact-hold-array" | "json-object";
+  readonly type:
+    | "string"
+    | "number"
+    | "boolean"
+    | "string-array"
+    | "fact-hold-array"
+    | "json-object"
+    | "json-object-array";
   readonly required: boolean;
   readonly enum?: readonly string[];
   readonly regex?: string;

--- a/packages/kernel/src/domain/index.ts
+++ b/packages/kernel/src/domain/index.ts
@@ -5,7 +5,6 @@ export type { ReceiptJsonValue } from "./receipt-frame.ts";
 export type { AuthorizationDecision } from "./receipt-frame.ts";
 export {
   ENTITY_ACTION_EXPLANATION_SCHEMA,
-  taskLifecycleActionIds,
   validateEntityActionExplainRequest,
   validateEntityActionExplanationSet,
 } from "./entity-action-explanation.ts";
@@ -16,7 +15,6 @@ export type {
   EntityActionExplanationSetV1,
   EntityActionExplanationSubjectV1,
   EntityActionExplanationV1,
-  TaskLifecycleActionId,
 } from "./entity-action-explanation.ts";
 export type { EntityActionUnmetCriterionV1 } from "./receipt-domain-registry.ts";
 export { evaluateTaskActionCapability, taskActionUsage } from "./task-action-capability.ts";

--- a/packages/kernel/src/domain/runtime-session-action-contract.ts
+++ b/packages/kernel/src/domain/runtime-session-action-contract.ts
@@ -11,7 +11,11 @@ import type {
   EntityActionInputContract,
   EntityActionInputField,
 } from "./entity-kind-registry.ts";
-import type { EntityActionCompileHook, EntityActionCompileInput } from "./entity-action-execution.ts";
+import {
+  attributeEntityActionCriterion,
+  type EntityActionCompileHook,
+  type EntityActionCompileInput,
+} from "./entity-action-execution.ts";
 import { sha256Text } from "../integrity/stable-hash.ts";
 import { consumeKnownError } from "../error-consumption.ts";
 
@@ -219,11 +223,12 @@ function compileRuntimeSessionAction(
   } catch (error) {
     consumeKnownError(error);
     const message = error instanceof Error ? error.message : String(error);
+    const adoptionFailure = error instanceof RuntimeSessionAdoptionStaleError;
     invalidRuntimeSessionAction(
-      error instanceof RuntimeSessionAdoptionStaleError
-        ? "runtime_session_adoption_stale"
-        : "runtime_session_transition_invalid",
+      adoptionFailure ? "runtime_session_adoption_stale" : "runtime_session_transition_invalid",
       message,
+      id,
+      adoptionFailure ? "runtime-session/adoption-fence" : "runtime-session/current-state",
     );
   }
   const resultBody = input.action.resultBody;
@@ -248,6 +253,12 @@ function compileRuntimeSessionAction(
   };
 }
 
-function invalidRuntimeSessionAction(code: string, message: string): never {
-  throw Object.assign(new Error(message), { code });
+function invalidRuntimeSessionAction(
+  code: string,
+  message: string,
+  actionId?: RuntimeSessionActionId,
+  criterionRef?: string,
+): never {
+  const error = Object.assign(new Error(message), { code });
+  throw actionId && criterionRef ? attributeEntityActionCriterion(error, actionId, criterionRef) : error;
 }

--- a/packages/kernel/src/domain/task-action-capability.ts
+++ b/packages/kernel/src/domain/task-action-capability.ts
@@ -1,4 +1,4 @@
-import { isIndependentFrom, isSamePerson } from "./actor-domain-services.ts";
+import { isIndependentFrom, isSameExecution, isSamePerson } from "./actor-domain-services.ts";
 import { closeoutReadiness, currentSubmittedExecutions } from "./closeout-readiness.ts";
 import type { EntityActionCriterionStatus } from "./entity-action-explanation.ts";
 import type { EntityActionContract } from "./entity-kind-registry.ts";
@@ -80,6 +80,13 @@ const taskCapabilityEvaluators = Object.freeze(
           ? "met"
           : "unmet",
     ],
+    [key("release", "repo-cell-task-mutation/release"), releaseAvailability],
+    [key("amend", "repo-cell-task-mutation/amend"), mutationInvocation],
+    [key("archive", "repo-cell-task-mutation/archive"), activeDispositionInvocation],
+    [key("supersede", "repo-cell-task-mutation/supersede"), activeDispositionInvocation],
+    [key("delete", "repo-cell-task-mutation/delete"), activeDispositionInvocation],
+    [key("reopen", "repo-cell-task-mutation/reopen"), reopenInvocation],
+    [key("contract-migrate", "repo-cell-task-mutation/contract-migrate"), mutationInvocation],
   ]),
 );
 
@@ -106,6 +113,29 @@ export function evaluateTaskActionCapability(
       ),
     });
   });
+}
+
+function releaseAvailability({ snapshot, actor }: TaskActionCapabilityInput): "met" | "unmet" {
+  return snapshot.lease && isSameExecution(snapshot.lease.actor, actor) ? "met" : "unmet";
+}
+
+function mutationInvocation(): "invocation-required" {
+  return "invocation-required";
+}
+
+function activeDispositionInvocation({ snapshot }: TaskActionCapabilityInput): "invocation-required" | "unmet" {
+  return snapshot.lease === null && (snapshot.task?.packageDisposition ?? "active") === "active"
+    ? "invocation-required"
+    : "unmet";
+}
+
+function reopenInvocation({ snapshot }: TaskActionCapabilityInput): "invocation-required" | "unmet" {
+  return snapshot.lease === null &&
+    snapshot.task !== null &&
+    !["done", "cancelled"].includes(snapshot.task.status) &&
+    ["archived", "tombstoned"].includes(snapshot.task.packageDisposition ?? "active")
+    ? "invocation-required"
+    : "unmet";
 }
 
 function submitValidation(input: TaskActionCapabilityInput): PredicateEvaluation | "invocation-required" {

--- a/packages/kernel/src/domain/task-action-contract.ts
+++ b/packages/kernel/src/domain/task-action-contract.ts
@@ -57,13 +57,25 @@ const cliField = (
 };
 
 type TaskActionDeclaration = {
-  readonly id: "start" | "submit" | "review" | "complete";
-  readonly ingress: "task-start" | "task-submit" | "task-review-execution" | "task-complete";
-  readonly commandType: "StartExecution" | "SubmitExecution" | "RecordReview" | "CompleteTask";
-  readonly transitionId: "start_execution" | "submit_execution" | "record_execution_review" | "complete_task";
-  readonly implementation: "task-lifecycle" | "task-completion";
+  readonly id:
+    | "start"
+    | "submit"
+    | "review"
+    | "complete"
+    | "release"
+    | "amend"
+    | "archive"
+    | "supersede"
+    | "delete"
+    | "reopen"
+    | "contract-migrate";
+  readonly ingress: string;
+  readonly commandType: "StartExecution" | "SubmitExecution" | "RecordReview" | "CompleteTask" | null;
+  readonly transitionId: "start_execution" | "submit_execution" | "record_execution_review" | "complete_task" | null;
+  readonly implementation: "task-lifecycle" | "task-completion" | "catalog-runtime";
   readonly topology: "center-forward-write" | "ledger-write" | "local-arbiter";
-  readonly coordination: "reserve" | "execute";
+  readonly coordination: "reserve" | "execute" | null;
+  readonly targetIdField: "taskId" | "oldTaskId";
   readonly input: EntityActionInputContract;
   readonly policyAction: string | null;
   readonly criteria: EntityActionContract["criteria"];
@@ -88,6 +100,21 @@ const taskConcurrency = (
     artifactOwnership: Object.freeze({ owner: "execution", refTemplate: "execution/{executionId}" }),
   });
 
+const taskMutationConcurrency: EntityActionContract["concurrency"] = Object.freeze({
+  expectedVersion: Object.freeze({
+    authority: "task/v2 canonical projection",
+    default: "daemon-bound-projection-revision",
+    conflict: "revision_conflict",
+  }),
+  leasePolicy: Object.freeze({ authority: "task-lease/v1", mode: "mutation-specific" }),
+  occurrenceClaim: Object.freeze({ authority: "not-applicable" }),
+  idempotency: Object.freeze({ authority: "operation-id", retry: "canonical-event-replay" }),
+  artifactOwnership: Object.freeze({ owner: "task", refTemplate: "task/{taskId}" }),
+});
+
+const mutationCriterion = (id: string, failureCode: string, explain: string): EntityActionContract["criteria"] =>
+  Object.freeze([{ ref: `repo-cell-task-mutation/${id}`, failureCode, explain }]);
+
 const taskActionDeclarations = Object.freeze([
   {
     id: "start",
@@ -97,6 +124,7 @@ const taskActionDeclarations = Object.freeze([
     implementation: "task-lifecycle",
     topology: "center-forward-write",
     coordination: "reserve",
+    targetIdField: "taskId",
     input: actionInput([
       taskIdInput,
       expectedVersionInput,
@@ -141,6 +169,7 @@ const taskActionDeclarations = Object.freeze([
     implementation: "task-lifecycle",
     topology: "ledger-write",
     coordination: "execute",
+    targetIdField: "taskId",
     input: actionInput(
       [
         taskIdInput,
@@ -201,6 +230,7 @@ const taskActionDeclarations = Object.freeze([
     implementation: "task-lifecycle",
     topology: "local-arbiter",
     coordination: "execute",
+    targetIdField: "taskId",
     input: actionInput([
       taskIdInput,
       expectedVersionInput,
@@ -246,6 +276,7 @@ const taskActionDeclarations = Object.freeze([
     implementation: "task-completion",
     topology: "ledger-write",
     coordination: "execute",
+    targetIdField: "taskId",
     input: actionInput([
       taskIdInput,
       expectedVersionInput,
@@ -309,6 +340,195 @@ const taskActionDeclarations = Object.freeze([
     ),
     explain: "Complete the reviewed execution after canonical closeout readiness and gate checks.",
   },
+  {
+    id: "release",
+    ingress: "task-release",
+    commandType: null,
+    transitionId: null,
+    implementation: "catalog-runtime",
+    topology: "center-forward-write",
+    coordination: null,
+    targetIdField: "taskId",
+    input: actionInput([
+      taskIdInput,
+      cliField("reason", "string", false, "--reason", "single", "Use one non-empty release reason."),
+      { field: "terminalExecutionId", type: "string", required: false },
+      { field: "terminalRuntimeSessionId", type: "string", required: false },
+    ]),
+    policyAction: "task-release",
+    criteria: mutationCriterion(
+      "release",
+      "lease_conflict",
+      "The Task has a releasable lease owned by the authenticated holder or an authorized recovery actor.",
+    ),
+    concurrency: taskMutationConcurrency,
+    explain: "Release the current Task execution lease while preserving its audit history.",
+  },
+  {
+    id: "amend",
+    ingress: "task-amend",
+    commandType: null,
+    transitionId: null,
+    implementation: "catalog-runtime",
+    topology: "ledger-write",
+    coordination: null,
+    targetIdField: "taskId",
+    input: actionInput([
+      taskIdInput,
+      cliField("patches", "json-object-array", true, "--set", "repeated", "Use --set <field>:<value> at least once.", {
+        format: "<field>:<value>",
+      }),
+    ]),
+    policyAction: "task-amend",
+    criteria: mutationCriterion(
+      "amend",
+      "invalid_amend",
+      "The requested fields belong to the declared mutable Task metadata and no conflicting lease is active.",
+    ),
+    concurrency: taskMutationConcurrency,
+    explain: "Amend declared Task prose or metadata through the canonical Task event stream.",
+  },
+  {
+    id: "archive",
+    ingress: "task-archive",
+    commandType: null,
+    transitionId: null,
+    implementation: "catalog-runtime",
+    topology: "ledger-write",
+    coordination: null,
+    targetIdField: "taskId",
+    input: actionInput(
+      [
+        { ...taskIdInput, required: false },
+        { field: "taskIds", type: "string-array", required: false },
+        cliField("filter", "string", false, "--filter", "single", "Use --filter state:<status>."),
+        cliField("before", "string", false, "--before", "single", "Use an ISO-compatible date with --before."),
+        cliField("reason", "string", true, "--reason", "single", "Add an auditable archive reason."),
+        cliField("archivedBy", "string", false, "--archived-by", "single", "Use one non-empty actor id."),
+        cliField("archiveField", "string", false, "--archive-field", "single", "Use one declared archive field."),
+      ],
+      [["taskId", "taskIds", "filter"]],
+    ),
+    policyAction: "task-archive",
+    criteria: mutationCriterion(
+      "archive",
+      "invalid_disposition",
+      "Each selected Task is active, unleased, and eligible for archival.",
+    ),
+    concurrency: taskMutationConcurrency,
+    explain: "Archive one or more Task packages while retaining canonical evidence and history.",
+  },
+  {
+    id: "supersede",
+    ingress: "task-supersede",
+    commandType: null,
+    transitionId: null,
+    implementation: "catalog-runtime",
+    topology: "ledger-write",
+    coordination: null,
+    targetIdField: "oldTaskId",
+    input: actionInput(
+      [
+        { field: "oldTaskId", type: "string", required: true },
+        cliField("title", "string", false, "--title", "single", "Choose --title or --by, not both."),
+        cliField("slug", "string", false, "--slug", "single", "Use lowercase kebab-case with --title."),
+        cliField("byTaskId", "string", false, "--by", "single", "Choose --title or --by, not both."),
+        cliField("confirm", "string", false, "--confirm", "single", "Confirm the old Task id when using --by."),
+        cliField("reason", "string", false, "--reason", "single", "Use one non-empty auditable reason."),
+        cliField("deletedBy", "string", false, "--deleted-by", "single", "Use one non-empty actor id."),
+        cliField(
+          "allowOpenFindings",
+          "boolean",
+          false,
+          "--allow-open-findings",
+          "boolean",
+          "Use --allow-open-findings once after reviewing unresolved findings.",
+        ),
+      ],
+      [["title", "byTaskId"]],
+    ),
+    policyAction: "task-supersede",
+    criteria: mutationCriterion(
+      "supersede",
+      "invalid_disposition",
+      "The old Task is active, unleased, and names or creates one valid replacement.",
+    ),
+    concurrency: taskMutationConcurrency,
+    explain: "Archive old work and preserve explicit replacement lineage.",
+  },
+  {
+    id: "delete",
+    ingress: "task-delete",
+    commandType: null,
+    transitionId: null,
+    implementation: "catalog-runtime",
+    topology: "ledger-write",
+    coordination: null,
+    targetIdField: "taskId",
+    input: actionInput([
+      taskIdInput,
+      { field: "mode", type: "string", required: true, enum: ["soft", "hard"] },
+      cliField("confirm", "string", false, "--confirm", "single", "Confirm the selected Task for hard delete."),
+      cliField("reason", "string", false, "--reason", "single", "Soft delete requires an auditable reason."),
+      cliField("deletedBy", "string", false, "--deleted-by", "single", "Use one non-empty actor id."),
+    ]),
+    policyAction: "task-delete",
+    criteria: mutationCriterion(
+      "delete",
+      "hard_delete_forbidden",
+      "Production Task deletion is soft, auditable, and applies only without an active lease.",
+    ),
+    concurrency: taskMutationConcurrency,
+    explain: "Soft-delete a Task through canonical disposition authority; hard delete remains forbidden.",
+  },
+  {
+    id: "reopen",
+    ingress: "task-reopen",
+    commandType: null,
+    transitionId: null,
+    implementation: "catalog-runtime",
+    topology: "ledger-write",
+    coordination: null,
+    targetIdField: "taskId",
+    input: actionInput([
+      taskIdInput,
+      cliField("reason", "string", true, "--reason", "single", "Add an auditable reopen reason."),
+    ]),
+    policyAction: "task-reopen",
+    criteria: mutationCriterion(
+      "reopen",
+      "invalid_disposition",
+      "The Task is nonterminal, unleased, and currently archived or tombstoned.",
+    ),
+    concurrency: taskMutationConcurrency,
+    explain: "Reopen an archived or tombstoned nonterminal Task package.",
+  },
+  {
+    id: "contract-migrate",
+    ingress: "task-contract-migrate",
+    commandType: null,
+    transitionId: null,
+    implementation: "catalog-runtime",
+    topology: "ledger-write",
+    coordination: null,
+    targetIdField: "taskId",
+    input: actionInput([
+      { field: "taskId", type: "string", required: false },
+      { field: "mode", type: "string", required: true, enum: ["dry-run", "apply"] },
+      { field: "repairPresetSnapshotDigest", type: "string", required: false },
+      { field: "repairTaskContractBody", type: "string", required: false },
+      { field: "repairPresetId", type: "string", required: false },
+      { field: "repairTaskClass", type: "string", required: false },
+    ]),
+    policyAction: "task-contract-migrate",
+    criteria: mutationCriterion(
+      "contract-migrate",
+      "contract_current",
+      "Each selected legacy Task has one deterministic task-contract/v1 backfill or repair.",
+    ),
+    concurrency: taskMutationConcurrency,
+    explain: "Plan or apply deterministic Task contract backfills through the catalog runtime.",
+  },
 ] as const satisfies readonly TaskActionDeclaration[]);
 
 export function createTaskActionCatalog(
@@ -335,24 +555,42 @@ export function createTaskActionCatalog(
                       },
                     ]
                   : []),
-                { field: "commandType", type: "string", required: false, enum: [declaration.commandType] },
+                ...(declaration.commandType
+                  ? [
+                      {
+                        field: "commandType" as const,
+                        type: "string" as const,
+                        required: false,
+                        enum: [declaration.commandType],
+                      },
+                    ]
+                  : []),
               ],
               declaration.input.exactlyOneOf,
             ),
             policy: Object.freeze({ ref: "default@5", action: declaration.policyAction }),
             criteria: Object.freeze([
-              {
-                ref: "task-lifecycle-contract-support/revisionIssues",
-                failureCode: "invalid_transition",
-                explain: "The command expectedVersion equals the canonical Task projection revision at commit time.",
-              },
+              ...(declaration.transitionId
+                ? [
+                    {
+                      ref: "task-lifecycle-contract-support/revisionIssues",
+                      failureCode: "invalid_transition",
+                      explain:
+                        "The command expectedVersion equals the canonical Task projection revision at commit time.",
+                    },
+                  ]
+                : []),
               ...declaration.criteria,
             ]),
             concurrency: declaration.concurrency,
-            effects: Object.freeze([
-              { ref: "task-lifecycle-publication/compileTaskLifecycleWrite", projection: "TaskProjection" },
-              { ref: `task-lifecycle-transitions/${declaration.transitionId}`, projection: "TaskProjection" },
-            ]),
+            effects: Object.freeze(
+              declaration.transitionId
+                ? [
+                    { ref: "task-lifecycle-publication/compileTaskLifecycleWrite", projection: "TaskProjection" },
+                    { ref: `task-lifecycle-transitions/${declaration.transitionId}`, projection: "TaskProjection" },
+                  ]
+                : [{ ref: `repo-cell-task-mutation/${declaration.id}`, projection: "TaskProjection" }],
+            ),
             returns: actionResultContract,
             explain: declaration.explain,
             execution: Object.freeze({
@@ -361,13 +599,17 @@ export function createTaskActionCatalog(
               read: false,
               implementation: declaration.implementation,
               topology: declaration.topology,
-              targetIdField: "taskId",
-              lifecycle: Object.freeze({
-                transitionId: declaration.transitionId,
-                commandType: declaration.commandType,
-                targetIdField: "executionId",
-                coordination: declaration.coordination,
-              }),
+              targetIdField: declaration.targetIdField,
+              ...(declaration.transitionId && declaration.commandType && declaration.coordination
+                ? {
+                    lifecycle: Object.freeze({
+                      transitionId: declaration.transitionId,
+                      commandType: declaration.commandType,
+                      targetIdField: "executionId",
+                      coordination: declaration.coordination,
+                    }),
+                  }
+                : {}),
             }),
           }),
       ),

--- a/packages/kernel/test/contracts/action-envelope.test.ts
+++ b/packages/kernel/test/contracts/action-envelope.test.ts
@@ -42,8 +42,8 @@ test("promoted Entity catalogs distinguish executable Agent and RuntimeSession a
   assert.deepEqual(declared("review"), ["record"]);
   assert.deepEqual(catalogs.agent?.statusVocabulary, []);
   assert.equal(catalogs.agent?.transitions.catalogRef, "kernel/agent-action/v1");
-  assert.deepEqual(catalogs.agent?.transitions.available, ["install"]);
-  assert.deepEqual(declared("agent"), ["install"]);
+  assert.deepEqual(catalogs.agent?.transitions.available, ["install", "validate", "list", "inspect"]);
+  assert.deepEqual(declared("agent"), ["install", "validate", "list", "inspect"]);
   assert.deepEqual(catalogs.policy?.statusVocabulary, []);
   assert.deepEqual(catalogs.policy?.transitions.available, []);
   assert.deepEqual(declared("policy"), ["draft", "activate", "retire"]);

--- a/packages/kernel/test/contracts/entity-action-execution.test.ts
+++ b/packages/kernel/test/contracts/entity-action-execution.test.ts
@@ -81,13 +81,13 @@ test("entity explanations expose action identity but keep runtime compile hooks 
   }
 });
 
-test("Agent install owns declaration readiness, revision, idempotency, and artifact contracts", () => {
+test("Agent catalog exposes reads while install owns its write contracts", () => {
   const explanation = explainEntityKind("agent"),
     action = getExecutableEntityAction("agent-install");
-  assert.deepEqual(explanation.transitions.available, ["install"]);
+  assert.deepEqual(explanation.transitions.available, ["install", "validate", "list", "inspect"]);
   assert.deepEqual(
     explanation.transitions.actions.map(({ id }) => id),
-    ["install"],
+    ["install", "validate", "list", "inspect"],
   );
   assert.ok(action?.execution?.compile);
   assert.equal(action.execution.implementation, "compiled-event");

--- a/packages/kernel/test/contracts/entity-action-explanation.test.ts
+++ b/packages/kernel/test/contracts/entity-action-explanation.test.ts
@@ -11,7 +11,6 @@ import {
   type EntityActionContract,
   type EntityActionExplanationSetV1,
   type EntityActionExplanationV1,
-  type TaskLifecycleActionId,
 } from "../../src/index.ts";
 import { serializeEntityActionExplanationSet } from "../../src/domain/entity-action-explanation.ts";
 
@@ -140,7 +139,7 @@ test("catalog and object modes share one strict schema with four honest criterio
   );
   assert.equal(
     actions.reduce((count, action) => count + action.criteria.length, 0),
-    12,
+    19,
   );
 
   const dishonestAvailability = structuredClone(object) as unknown as {
@@ -166,7 +165,7 @@ function taskCatalog(): { readonly ref: string; readonly actions: readonly Entit
 function descriptor(catalogRef: string, action: EntityActionContract): EntityActionExplanationV1["action"] {
   return {
     kind: "task",
-    id: action.id as TaskLifecycleActionId,
+    id: action.id,
     catalogRef,
     contractVersion: `${action.version.major}.${action.version.minor}`,
     explain: action.explain,

--- a/packages/kernel/test/contracts/entity-store.test.ts
+++ b/packages/kernel/test/contracts/entity-store.test.ts
@@ -65,8 +65,8 @@ test("registered declaration Entity kinds explain the same contract shape from t
     },
     {
       catalogRef: "kernel/agent-action/v1",
-      available: ["install"],
-      declared: ["install"],
+      available: ["install", "validate", "list", "inspect"],
+      declared: ["install", "validate", "list", "inspect"],
     },
   );
   assert.deepEqual(

--- a/packages/kernel/test/contracts/task-action-contract.test.ts
+++ b/packages/kernel/test/contracts/task-action-contract.test.ts
@@ -11,30 +11,54 @@ const concurrencyFields = [
   "artifactOwnership",
 ] as const;
 
-test("Task start submit review complete are complete executable Action contracts", () => {
+test("all public Task writes are complete executable Action contracts", () => {
   const task = getEntityKindContract("task"),
     actions = task?.actionCatalog?.actions ?? [];
   assert.deepEqual(
     actions.map(({ id }) => id),
-    ["start", "submit", "review", "complete"],
+    [
+      "start",
+      "submit",
+      "review",
+      "complete",
+      "release",
+      "amend",
+      "archive",
+      "supersede",
+      "delete",
+      "reopen",
+      "contract-migrate",
+    ],
   );
   for (const action of actions) {
     assert.ok(action.execution, action.id);
     assert.equal(action.actor.source, "authenticated-binding");
     assert.equal(action.target.kind, "task");
     assert.equal(action.input.schema, "entity-action-input/v1");
-    assert.ok(action.criteria.length >= 3, action.id);
+    assert.ok(action.criteria.length >= 1, action.id);
     assert.deepEqual(Object.keys(action.concurrency), concurrencyFields);
-    assert.equal(action.concurrency.artifactOwnership.owner, "execution");
+    assert.ok(["execution", "task"].includes(String(action.concurrency.artifactOwnership.owner)), action.id);
     assert.ok(
-      action.effects.every(({ ref }) => ref.includes("task-lifecycle")),
+      action.effects.every(({ ref }) => ref.includes("task-lifecycle") || ref.includes("task-mutation")),
       action.id,
     );
     assert.equal(action.returns.schema, "action-result/v1");
     assert.ok(action.explain.length > 0);
   }
-  assert.deepEqual(explainEntityKind("task").transitions.available, ["start", "submit", "review", "complete"]);
-  assert.deepEqual(explainEntityKind("agent").transitions.available, ["install"]);
+  assert.deepEqual(explainEntityKind("task").transitions.available, [
+    "start",
+    "submit",
+    "review",
+    "complete",
+    "release",
+    "amend",
+    "archive",
+    "supersede",
+    "delete",
+    "reopen",
+    "contract-migrate",
+  ]);
+  assert.deepEqual(explainEntityKind("agent").transitions.available, ["install", "validate", "list", "inspect"]);
 });
 
 test("Agent-readable input and CLI facets share the same field declarations", () => {

--- a/packages/kernel/test/store/wal-shadow-event-store.test.ts
+++ b/packages/kernel/test/store/wal-shadow-event-store.test.ts
@@ -219,19 +219,45 @@ test("bulk writes defer visibility and settle one Git cut", async () => {
 test("byte threshold flushes a durable WAL batch independently of the event threshold", async () => {
   await withTempStoreAsync(async (rootDir) => {
     initRepo(rootDir);
+    const byteThreshold = 1;
+    let resolveCheckpoint!: () => void;
+    const checkpointed = new Promise<void>((resolve) => {
+      resolveCheckpoint = resolve;
+    });
     const store = makeWalShadowEventStore({
       repoId: "wal-bytes",
       rootDir,
       walFlushEvents: 10_000,
-      walFlushBytes: 1,
+      walFlushBytes: byteThreshold,
       walFlushMs: 60_000,
       walFlushAdaptive: false,
+      walMaterializationSpan: (span) => {
+        if (span.name === "checkpoint") resolveCheckpoint();
+      },
     });
-    store.append(taskBundle(1));
-    for (let attempt = 0; attempt < 100 && openWalEventLog(rootDir).records().length > 0; attempt += 1)
-      await new Promise((resolve) => setTimeout(resolve, 10));
-    assert.deepEqual(openWalEventLog(rootDir).records(), []);
-    await store.drain();
+    let checkpointDeadline: ReturnType<typeof setTimeout> | null = null;
+    try {
+      store.append(taskBundle(1));
+      const durableBytes = openWalEventLog(rootDir).head().lastOffset;
+      assert.ok(
+        durableBytes >= byteThreshold,
+        `the fixture must cross its ${byteThreshold}-byte threshold (wrote ${durableBytes} bytes)`,
+      );
+      await Promise.race([
+        checkpointed,
+        new Promise<never>((_, reject) => {
+          checkpointDeadline = setTimeout(
+            () => reject(new Error("byte-threshold WAL materialization did not checkpoint within 30 seconds")),
+            30_000,
+          );
+          checkpointDeadline.unref?.();
+        }),
+      ]);
+      assert.deepEqual(openWalEventLog(rootDir).records(), []);
+    } finally {
+      if (checkpointDeadline !== null) clearTimeout(checkpointDeadline);
+      await store.drain();
+    }
   });
 });
 

--- a/packages/preset/src/preset-command-contract.ts
+++ b/packages/preset/src/preset-command-contract.ts
@@ -182,15 +182,8 @@ type CliCommandDeclaration = {
 };
 const defineTopologyCommand =
   (topology: CommandTopology) =>
-  <const Command extends CliCommandDeclaration>(declaration: Command) => {
-    const routed =
-      topology.commandClass === "repo-read" &&
-      "method" in declaration &&
-      declaration.method === "repo.task.run"
-        ? { ...declaration, method: "repo.task.read" as const }
-        : declaration;
-    return defineCliCommand({ ...routed, ...topology });
-  };
+  <const Command extends CliCommandDeclaration>(declaration: Command) =>
+    defineCliCommand({ ...declaration, ...topology });
 export const defineRepoReadCommand = defineTopologyCommand(repoReadCommandTopology),
   defineLedgerWriteCommand = defineTopologyCommand(ledgerWriteCommandTopology),
   defineCenterForwardReadCommand = defineTopologyCommand(centerForwardReadCommandTopology),

--- a/tools/generate-task-action-protocol.mjs
+++ b/tools/generate-task-action-protocol.mjs
@@ -14,7 +14,9 @@ const protocolMarkers = {
 };
 
 export function projectTaskActionProtocolDeclarations() {
-  const actions = getEntityKindContract("task")?.actionCatalog?.actions ?? [];
+  const actions = (getEntityKindContract("task")?.actionCatalog?.actions ?? []).filter(
+    (action) => action.execution?.lifecycle !== undefined,
+  );
   if (actions.length !== 4 || actions.some((action) => action.execution?.topology === undefined)) {
     throw new Error("Task start, submit, review, and complete must all have executable command topology.");
   }


### PR DESCRIPTION
# English

## Summary

Implements the Phase G anti-entropy fixes (audit task_8b769387; ruling routing B3/B17 per 泽宇 2026-09-01): G-INV-01 unifies RuntimeSession publication behind one `commitRuntimeSessionAction` primitive inside the existing RepoCell writer queue — local provider stream and remote ingress are now just two ingresses to the same seven-event catalog commit, and `rg 'store.append' packages/daemon/src/runtime-spawn-*` is zero with a CEO-verified positive control (restoring a token makes the boundary test fail by name). G-FIX-01 closes the Task catalog at all 11 public writes (release/amend/archive/supersede/delete/reopen/contract-migrate become catalog runtimes) and deletes the `taskSurfaceWriteKind` shadow selector; B3's duplicated buildCommand action-id mapping collapses into lifecycle command metadata. G-FIX-02 corrects 28 repo-read literals to `repo.task.read` and deletes the topology run→read rewrite plus the CLI catch/fallback fold (incomplete catalogs now fail closed at the parse boundary). G-FIX-03 resolves the criterion Error Symbol once at settlement into public `unmetCriteria`/`rejectionExplanation`/`nextActions`, deleting the receipt WeakMap side channel. B17 deletes the string-prefix routing family across six files — routing consumes the contract's `target.kind`.

## Architectural Justification

- Mechanism sentence: every place a second implementation shadows a catalog (a direct append next to a catalog commit, a write-kind selector next to action metadata, a prefix parse next to a declared kind) is a fork whose consumers silently diverge; the fix makes the catalog the only path and deletes the shadow in the same change.
- 中心化仓库视角: the RuntimeSession primitive lives inside the center's single-writer queue; no new concurrency subject is introduced — local and remote are ingresses, the commit subject stays unique.

## Gate Harvest / 门收割

Deleted-Production-Paths: runtime-spawn direct event construction/append/projection-apply; taskSurfaceWriteKind selector and its RepoCell binding; topology run→read runtime rewrite; CLI catch/fallback two-value fold; criterion receipt WeakMap carry/read helpers; six-file string-prefix routing family
Deleted-Gates-Fixtures: none (boundary tests extended, none deleted)

## Machine-Readable Declarations

Production-Delta: +732/-307
Dependency-Change: none

### Optional Evidence Claims

None.

## Task And Scope

- Harness task task_ce7c579a713c89bdba6163bc25 (Phase G 反熵修复件; facts F-2932822D, audit F-loop per plan). Branch `codex/g-anti-entropy-fixes`.

## Version Impact

- Version: no change. Publish impact: none.

## Governance Declaration

- Protected surface touched: no CI/gate config; daemon/kernel/cli production under the task's audited deletion list (anti-entropy report D-01/D-02, B3/B17 泽宇裁决 routing recorded in the task plan). Break-glass: no.

## Verification

- Worker: typecheck, lint, invariant AST scans (`repoReadRunLiterals: 0`, `criterion_side_channels=0`, `b17_prefix_routes=0`, `task_surface_shadow_router=0`), thin-command/fleet-route/admission 55/55, RuntimeSession action + catalog executor + explanation 13/13, task surface/status/read-lease integrations green; positive control on the G-INV-01 boundary test (restored token → named failure → removed → green).
- CEO re-verified in the worktree: `store.append` zero in runtime-spawn production, `taskSurfaceWriteKind` zero repo-wide.
- [ ] Full suites: GitHub CI is the authority.

## Review Evidence

- Full before/after evidence with commands in the task package (`artifacts/fix-report.md`); worktree clean, single commit 96a203a4a, author ZeyuLi.

## Residual Risk

- G4's second-stage deletion of the duplicated common query runtime validation (protocol/repo-cell) remains a separate follow-up now that both C phase-2 and this slice have landed their adjacent surfaces; it stays routed on this task family, not silently claimed here.

---

# 中文

## 概要

实现 Phase G 反熵修复件(审计 task_8b769387;B3/B17 按泽宇 2026-09-01 交接点名并入):G-INV-01 把 RuntimeSession 发布统一到 RepoCell 写队列内的单一 `commitRuntimeSessionAction` 原语——本地 provider stream 与远端 ingress 只是同一七事件 catalog commit 的两个入口,`store.append` 在 runtime-spawn 生产面为零且带阳性对照(放回 token 边界测试点名红);G-FIX-01 把 Task catalog 收满 11 个公开写动作并删除 `taskSurfaceWriteKind` 影子分流,B3 的 buildCommand 重复映射并入 lifecycle command 元数据;G-FIX-02 机械更正 28 处 repo-read literal 并删除 run→read 运行时改写与 CLI catch/fallback 折叠(不完整 catalog 在解析边界 fail closed);G-FIX-03 在 settlement 一次性把 criterion Error Symbol 解析进公开 receipt 字段,删除 WeakMap 旁通道;B17 删除六文件字符串前缀路由族,路由改消费合同 `target.kind`。

## 架构辩护

- 机制句:每一处影子实现(catalog commit 旁的直接 append、action 元数据旁的 write-kind 选择器、声明 kind 旁的前缀解析)都是消费者会静默分叉的岔路;修复=让 catalog 成唯一路径并在同一变更删除影子。
- 中心化视角:原语在 center 单写队列内,不新增并发主体。

## 机读声明

`Production-Delta: +732/-307`

## 治理声明

- 未触碰 CI/gate 配置;删除清单出自审计报告 D-01/D-02 与 B3/B17 裁决;无 break-glass。

## 验证

- worker 不变量扫描四项归零 + 定向 55/55+13/13 + 阳性对照;CEO 亲验两条退出判据 grep=0;完整权威=GitHub CI。

## 残余风险

- G4 禁区的 query 副本二段删除仍为独立后续,不在本 PR 静默宣称。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VTzQAqvuFy6ikGjBKxA9xj
