### PR TITLE
fix(gui): enable xterm allowProposedApi so terminal panes mount

### DIFF
--- a/packages/gui/src/renderer/components/terminal/TerminalPane.tsx
+++ b/packages/gui/src/renderer/components/terminal/TerminalPane.tsx
@@ -62,6 +62,7 @@ export function TerminalPane({
     const host = hostRef.current;
     if (!host) return;
     const terminal = new Terminal({
+      allowProposedApi: true, // Unicode11Addon + terminal.unicode.activeVersion 走 xterm proposed API,缺此项 loadAddon 直接抛。
       cursorBlink: true,
       convertEol: false,
       fontFamily: '"Geist Mono Variable", ui-monospace, monospace',

--- a/packages/gui/test/terminal-pane.vitest.ts
+++ b/packages/gui/test/terminal-pane.vitest.ts
@@ -4,13 +4,24 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { act, createElement } from "react";
 import { createRoot, type Root } from "react-dom/client";
 
-const xterm = vi.hoisted(() => ({ loaded: [] as string[] }));
+const xterm = vi.hoisted(() => ({ loaded: [] as string[], lastOptions: null as Record<string, unknown> | null }));
 vi.mock("@xterm/xterm", () => ({
   Terminal: class {
     cols = 80;
     rows = 24;
-    unicode = { activeVersion: "6" };
-    options = {};
+    options: Record<string, unknown>;
+    #unicode = { activeVersion: "6" };
+    constructor(options: Record<string, unknown> = {}) {
+      this.options = options;
+      xterm.lastOptions = options;
+    }
+    // Mirror xterm's real gate: reading `unicode` (what Unicode11Addon.activate does, and what
+    // TerminalPane's `terminal.unicode.activeVersion = "11"` does) throws unless allowProposedApi is on.
+    get unicode() {
+      if (this.options.allowProposedApi !== true)
+        throw new Error("You must set the allowProposedApi option to true to use proposed API");
+      return this.#unicode;
+    }
     loadAddon(addon: { readonly name: string }) {
       xterm.loaded.push(addon.name);
     }
@@ -106,6 +117,14 @@ describe("TerminalPane addon lifecycle (W4a)", () => {
   it("loads Unicode 11, serialization and search for every terminal pane", () => {
     mount();
     expect(xterm.loaded).toEqual(["fit", "unicode11", "serialize", "search", "web-links"]);
+  });
+
+  // Regression: Unicode11Addon activation and `terminal.unicode.activeVersion = "11"` are xterm
+  // proposed API. Constructing the terminal without allowProposedApi threw on mount, crashing every
+  // pane (and, with no error boundary, blanking the whole window). Pin the option on.
+  it("constructs xterm with allowProposedApi so the pane mounts without throwing", () => {
+    expect(() => mount()).not.toThrow();
+    expect(xterm.lastOptions?.allowProposedApi).toBe(true);
   });
 
   it("loads WebGL only when the centralized preference opts in", () => {


### PR DESCRIPTION
# English

## Summary

Fix a W4a regression that made the GUI terminal unusable: constructing the xterm `Terminal` without `allowProposedApi: true` threw on every pane mount, so no terminal ever rendered. With no error boundary in the renderer, that mount throw unmounted the React tree and blanked the whole window; when only the terminal chrome was mounted (no session yet) the app appeared to "do nothing" on New Terminal.

Root cause was ground-truthed end to end: the canonical daemon spawns PTYs correctly (`repo.terminal.spawn` → `outcome: applied, state: running`), and a live Electron repro captured the exact throw — `You must set the allowProposedApi option to true to use proposed API` from `Unicode11Addon.activate` at `TerminalPane.tsx`. After the fix the same repro renders a live shell prompt with zero pageerror/console error.

## What Changed

- `packages/gui/src/renderer/components/terminal/TerminalPane.tsx`: add `allowProposedApi: true` to the `Terminal` constructor. `Unicode11Addon` activation and `terminal.unicode.activeVersion = "11"` are xterm proposed API and require this option.
- `packages/gui/test/terminal-pane.vitest.ts`: the existing test fully mocked `@xterm/xterm` with a plain `unicode` object, so it never exercised the proposed-API gate and the defect shipped green. Make the mock mirror xterm's real gate (reading `unicode` throws unless `allowProposedApi` is on) and add a regression assertion that pins the option. Negative control verified: removing the option fails all three tests with the production error message.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none

## Machine-Readable Declarations

Production-Delta: +1/-0

## Task And Scope

- Harness task: task_38514e01f4dafa2a792b798956 (child of PLT-TerminalWorkspace milestone task_d2985b723b87a2cf55aa24d6fe)
- Branch: codex/terminal-proposed-api-fix
- Public scope: GUI terminal pane renderer + its unit test
- Private planning/evidence updated: yes
- Out of scope: the renderer error boundary (a single pane crash blanking the whole app is a separate resilience gap), and the dev-electron launcher lifecycle asymmetry (a dead vite dev server leaves an orphaned black Electron window).

## Version Impact

- Version: no version change because this is a bug fix with no packaged-surface or API change.
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none
- Authority: not applicable
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no

---

# 中文

## 摘要

修复 W4a 的一个回归，它让 GUI 终端完全不可用：构造 xterm `Terminal` 时未带 `allowProposedApi: true`，导致每次终端 pane 挂载都在 mount 期抛错，终端永远渲染不出来。renderer 里没有 error boundary，这个 mount 抛错会把整棵 React 树卸载、整窗变黑；当只挂了终端 chrome（还没会话）时，表现为点「新建终端」毫无反应。

根因已端到端 ground-truth：canonical daemon 能正确 spawn PTY（`repo.terminal.spawn` → `outcome: applied, state: running`），而真机 Electron 复现抓到确切抛错——`Unicode11Addon.activate` 在 `TerminalPane.tsx` 处报 `You must set the allowProposedApi option to true to use proposed API`。修复后同一复现渲染出**活着的 shell 提示符**，零 pageerror / console error。

## 变更内容

- `packages/gui/src/renderer/components/terminal/TerminalPane.tsx`：给 `Terminal` 构造加 `allowProposedApi: true`。`Unicode11Addon` 激活与 `terminal.unicode.activeVersion = "11"` 都是 xterm proposed API，必须开这个选项。
- `packages/gui/test/terminal-pane.vitest.ts`：原测试把 `@xterm/xterm` 完全 mock 成带普通 `unicode` 对象的假类，因而从未走过 proposed-API 门，缺陷带绿溜过。改成让 mock 忠实复刻 xterm 的真实门（读 `unicode` 时若未开 `allowProposedApi` 即抛），并加一条钉住该选项的回归断言。阳性对照已验证：摘掉该选项，三条测试全红，报生产同款错误。

## 任务与范围

- Harness 任务：task_38514e01f4dafa2a792b798956（PLT-TerminalWorkspace 里程碑 task_d2985b723b87a2cf55aa24d6fe 的子任务）
- 分支：codex/terminal-proposed-api-fix
- 公开范围：GUI 终端 pane renderer 及其单测
- 私有规划/证据已更新：是
- 不在范围：renderer 的 error boundary（单个 pane 崩溃拖黑整个 app 是另一处韧性缺口）、dev-electron launcher 的生命周期不对称（vite dev server 死掉会留下一个黑屏的孤儿 Electron 窗口）。

## 版本影响

- 版本：不变，这是纯 bug 修复，无打包面/API 改动。
- 发布影响：不发布
