### PR TITLE
fix(gui): keep terminal mounted ref live across StrictMode remount

### DIFF
--- a/packages/gui/src/renderer/views/TerminalView.tsx
+++ b/packages/gui/src/renderer/views/TerminalView.tsx
@@ -171,13 +171,15 @@ export function TerminalView({
       ),
     );
   }, []);
-  useEffect(
-    () => () => {
+  useEffect(() => {
+    // StrictMode(dev)会 mount→cleanup→remount:必须在 body 里把 mounted 设回 true,
+    // 否则第一次 cleanup 之后它永久为 false,start() 会在 spawn 成功后静默 return、终端永远建不出来。
+    mountedRef.current = true;
+    return () => {
       mountedRef.current = false;
       void releaseTabs(repoIdRef.current);
-    },
-    [releaseTabs],
-  );
+    };
+  }, [releaseTabs]);
   // 仓内 session 全部按 repoId 限定:切仓而页面未卸载时,旧仓 tab 必须先释放,
   // 否则后续 input/resize 会以新 repoId 打到旧仓 session 上。
   useEffect(() => {

--- a/packages/gui/test/terminal-page.vitest.ts
+++ b/packages/gui/test/terminal-page.vitest.ts
@@ -1,7 +1,7 @@
 // harness-test-tier: integration
 // @vitest-environment happy-dom
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import { act, createElement } from "react";
+import { act, createElement, StrictMode } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { useAppShortcuts } from "../src/renderer/navigation/useAppShortcuts.ts";
@@ -163,6 +163,74 @@ describe("terminal first-class page (PLT-TerminalWorkspace W0)", () => {
       expect.any(Function),
     );
     expect(container!.textContent).toContain("Build");
+    expect(container!.querySelector('[data-testid="terminal-pane"]')).not.toBeNull();
+  });
+
+  // Regression: under StrictMode (dev) the page mounts, its cleanup runs, then it remounts. The
+  // release effect only reset `mounted` to false in cleanup and never back to true on (re)mount, so
+  // after the remount `mounted` was stuck false and start() spawned a session but returned before
+  // attaching it — every "new terminal" (auto-start and the + button) silently did nothing.
+  it("spawns and attaches a new terminal after a StrictMode mount/cleanup/remount", async () => {
+    const stop = vi.fn();
+    const spawnedRow = sessionRow({ sessionId: "s-new", name: "Spawned" });
+    let rows: Row[] = [];
+    const bridge = {
+      listTerminalSessions: vi.fn(async () => sessionList(rows)),
+      spawnTerminal: vi.fn(async () => {
+        rows = [spawnedRow];
+        return controlReceipt("s-new");
+      }),
+      attachTerminal: vi.fn((_payload: Row, onValue: (value: Row) => void) => {
+        onValue({
+          schema: "terminal-attach/v1",
+          ok: true,
+          sessionId: "s-new",
+          attachmentId: "attach-new",
+          daemonGeneration: 7,
+          status: "attached",
+          replayFromSeq: 0,
+          outputSeq: 0,
+        });
+        return stop;
+      }),
+      sendTerminalInput: vi.fn(async () => ({ schema: "terminal-input-ack/v1", ok: true, acceptedThrough: 1 })),
+      resizeTerminal: vi.fn(async () => controlReceipt("s-new")),
+      detachTerminal: vi.fn(async () => ({ schema: "terminal-detach-ack/v1", ok: true, state: "detached" })),
+      terminateTerminal: vi.fn(async () => controlReceipt("s-new")),
+    };
+    (window as unknown as Record<string, unknown>).harness = bridge;
+
+    container = document.createElement("div");
+    document.body.append(container);
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    root = createRoot(container);
+    act(() => {
+      root!.render(
+        createElement(
+          StrictMode,
+          null,
+          createElement(
+            QueryClientProvider,
+            { client },
+            createElement(TerminalView, {
+              repoId: "repo-a",
+              daemonGeneration: null,
+              tasks: [],
+              repoRoot: null,
+              onNavigateEntity: () => undefined,
+              onOpenDocument: () => undefined,
+            }),
+          ),
+        ),
+      );
+    });
+    await flush();
+
+    expect(bridge.spawnTerminal).toHaveBeenCalled();
+    expect(bridge.attachTerminal).toHaveBeenCalledWith(
+      { repoId: "repo-a", sessionId: "s-new", afterSeq: 0 },
+      expect.any(Function),
+    );
     expect(container!.querySelector('[data-testid="terminal-pane"]')).not.toBeNull();
   });
 


### PR DESCRIPTION
# English

## Summary

Fix the "new terminal does nothing" defect: on the terminal page, the daemon spawns the session successfully but the GUI silently drops it, so New Terminal (and auto-start on page entry) never renders anything in dev.

Root cause, ground-truthed with in-component instrumentation: the release effect set `mountedRef` to `false` in its cleanup but never back to `true` on (re)mount. Under `StrictMode` (dev) the page mounts, its cleanup runs, then it remounts, so `mountedRef` is stuck `false`. `start()` spawns the session, receives `outcome: applied`, then hits `if (!mountedRef.current ...) return` and bails before attaching — the daemon has a live session, the GUI shows nothing. Attach-to-existing works because that path does not read `mountedRef`, which is why entering the page could show a restored session while `+` did nothing.

This is dev-only (StrictMode double-invokes effects only in development), and `dev:electron` is exactly how the app is run day to day.

## What Changed

- `packages/gui/src/renderer/views/TerminalView.tsx`: set `mountedRef.current = true` at the top of the release effect body so a StrictMode remount restores it; cleanup still sets it false on real unmount/repo-switch.
- `packages/gui/test/terminal-page.vitest.ts`: add a StrictMode regression test that mounts the page, lets auto-start spawn, and asserts the new session is attached and its pane renders. Negative control verified: reverting the fix fails this test (attach is never called) while the other nine keep passing.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none

## Machine-Readable Declarations

Production-Delta: +7/-5

## Task And Scope

- Harness task: task_38514e01f4dafa2a792b798956 (child of PLT-TerminalWorkspace milestone task_d2985b723b87a2cf55aa24d6fe)
- Branch: codex/terminal-strictmode-spawn
- Public scope: GUI terminal page renderer + its unit test
- Private planning/evidence updated: yes
- Out of scope: renderer error boundary and dev-electron launcher lifecycle (separate resilience PR).

## Version Impact

- Version: no version change because this is a bug fix with no packaged-surface or API change.
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none
- Authority: not applicable
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no

---

# 中文

## 摘要

修复「点新建终端没反应」的缺陷:终端页里 daemon 其实 spawn 成功了,但 GUI 静默把它丢掉,于是 dev 下「新建终端」（以及进页时的自动 start）永远渲染不出东西。

根因(用组件内插桩 ground-truth):释放用的 effect 只在 cleanup 里把 `mountedRef` 设 `false`、**mount 时从不设回 `true`**。dev 的 `StrictMode` 会 mount→cleanup→remount,于是 `mountedRef` 永久卡在 `false`。`start()` spawn 会话、拿到 `outcome: applied`,紧接着 `if (!mountedRef.current ...) return` 就在 attach 之前 bail——daemon 侧会话是活的,GUI 却什么都不显示。附加已有会话能用,是因为那条路不读 `mountedRef`;这正解释了「进页能看到恢复的会话、但点 + 没反应」。

这是 dev-only(StrictMode 只在开发下双调用 effect),而 `dev:electron` 正是日常运行方式。

## 变更内容

- `packages/gui/src/renderer/views/TerminalView.tsx`:在释放 effect 的 body 顶部 `mountedRef.current = true`,让 StrictMode remount 后恢复;cleanup 仍在真正卸载/切仓时设 false。
- `packages/gui/test/terminal-page.vitest.ts`:加一条 StrictMode 回归测试,挂载页面、让自动 start spawn,断言新会话被 attach 且 pane 渲染。阳性对照已验证:退回修复该测试变红(attach 从不被调用),其余九条照常绿。

## 任务与范围

- Harness 任务:task_38514e01f4dafa2a792b798956(PLT-TerminalWorkspace 里程碑 task_d2985b723b87a2cf55aa24d6fe 的子任务)
- 分支:codex/terminal-strictmode-spawn
- 公开范围:GUI 终端页 renderer 及其单测
- 私有规划/证据已更新:是
- 不在范围:renderer error boundary、dev-electron launcher 生命周期(另一个韧性 PR)。

## 版本影响

- 版本:不变,纯 bug 修复,无打包面/API 改动。
- 发布影响:不发布
