### PR TITLE
feat(gui): isolate terminal pane crashes and fail the dev launcher loud

### DIFF
--- a/packages/gui/scripts/dev-electron.mjs
+++ b/packages/gui/scripts/dev-electron.mjs
@@ -129,11 +129,26 @@ const electron = spawn(electronPath, [path.join(guiRoot, "src/main/electron-main
   stdio: "inherit",
 });
 
+let shuttingDown = false;
 const shutdown = async (code) => {
+  shuttingDown = true;
   await stopVite();
   process.exit(code);
 };
 electron.on("close", (code) => void shutdown(code ?? 0));
+// Lifecycle symmetry: the launcher already stops Vite when Electron closes. The reverse was missing —
+// if the Vite dev server died (crash, or the launcher's own vite child getting killed) while Electron
+// stayed up, Electron kept rendering a dead http://127.0.0.1:5173 as an unrecoverable black window
+// with no error. Tear Electron down loudly instead so the failure is visible and there is no orphan.
+vite.on("close", (code) => {
+  if (shuttingDown) return;
+  console.error(
+    `[dev-electron] renderer dev server exited unexpectedly (code ${code}); ` +
+      "shutting down Electron to avoid an orphaned black window. Re-run 'npm run dev:electron'.",
+  );
+  electron.kill("SIGTERM");
+  process.exit(code ?? 1);
+});
 process.on("SIGINT", () => {
   electron.kill("SIGTERM");
 });

--- a/packages/gui/src/renderer/components/ErrorBoundary.tsx
+++ b/packages/gui/src/renderer/components/ErrorBoundary.tsx
@@ -1,0 +1,67 @@
+import { Component, type ErrorInfo, type ReactNode } from "react";
+
+/**
+ * 视图级错误边界。子树(如某个终端 pane)在渲染/挂载期抛错时,兜底为一个可恢复面板,
+ * 而不是让抛错一路冒泡把整棵 React 树卸载成黑屏——App 此前没有边界,一个 pane 崩溃
+ * 就拖黑整个窗口,连侧边栏都没了。挂在 pane/视图外层:其余部分不受影响。文案内联
+ * (不走 i18n),因为崩溃路径不应再依赖可能同样出错的子系统。
+ */
+interface Props {
+  readonly children: ReactNode;
+}
+interface State {
+  readonly error: Error | null;
+}
+
+export class ErrorBoundary extends Component<Props, State> {
+  override state: State = { error: null };
+
+  static getDerivedStateFromError(error: Error): State {
+    return { error };
+  }
+
+  override componentDidCatch(error: Error, info: ErrorInfo): void {
+    console.error("[ErrorBoundary] 视图渲染出错:", error, info.componentStack);
+  }
+
+  private readonly reset = (): void => this.setState({ error: null });
+
+  override render(): ReactNode {
+    const { error } = this.state;
+    if (!error) return this.props.children;
+    return (
+      <div className="grid min-h-0 flex-1 place-items-center p-6">
+        <div className="max-w-lg rounded-lg border border-border bg-surface-raised p-5 text-center">
+          <p className="text-sm font-medium text-text">此视图出现错误</p>
+          <p className="mt-0.5 text-[11px] text-text-faint">This view hit an error</p>
+          <p
+            className={
+              "mt-3 max-h-40 overflow-auto break-words rounded border border-border bg-surface " +
+              "p-2 text-left font-mono text-[11px] text-status-blocked"
+            }
+          >
+            {error.message || String(error)}
+          </p>
+          <div className="mt-4 flex justify-center gap-2">
+            <button
+              type="button"
+              onClick={this.reset}
+              className={
+                "rounded border border-accent/60 bg-accent/10 px-3 py-1 text-[12px] text-text hover:bg-accent/20"
+              }
+            >
+              重试 · Retry
+            </button>
+            <button
+              type="button"
+              onClick={() => window.location.reload()}
+              className="rounded border border-border px-3 py-1 text-[12px] text-text-muted hover:bg-surface"
+            >
+              重新加载 · Reload
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+}

--- a/packages/gui/src/renderer/components/terminal/TerminalPaneCard.tsx
+++ b/packages/gui/src/renderer/components/terminal/TerminalPaneCard.tsx
@@ -1,5 +1,6 @@
 import type { IDockviewPanelProps } from "dockview-react";
 import { TerminalPane } from "./TerminalPane.tsx";
+import { ErrorBoundary } from "../ErrorBoundary.tsx";
 import { useTerminalPaneActions, type TerminalSplitDirection } from "./terminal-pane-context.ts";
 import type { TerminalTab } from "../../terminal-model.ts";
 import { t } from "../../i18n/index.tsx";
@@ -76,14 +77,18 @@ function LivePane({ tab }: { readonly tab: TerminalTab }) {
         </p>
       )}
       {tab.state === "running" || tab.output ? (
-        <TerminalPane
-          output={tab.output}
-          interactive={interactive}
-          openUrl={actions.openUrl}
-          onOpenLink={(match, text) => actions.openLink(match, text, tab.cwd)}
-          onInput={(utf8) => actions.onInput(tab.sessionId, utf8)}
-          onFit={(cols, rows) => actions.onFit(tab.sessionId, cols, rows)}
-        />
+        // pane 级错误边界:单个 pane 渲染抛错(如某个 addon/renderer)只在本 pane 兜底,
+        // tab 条、其他 pane 与整窗都不受影响,不再一个 pane 崩溃就拖黑整个终端页。
+        <ErrorBoundary>
+          <TerminalPane
+            output={tab.output}
+            interactive={interactive}
+            openUrl={actions.openUrl}
+            onOpenLink={(match, text) => actions.openLink(match, text, tab.cwd)}
+            onInput={(utf8) => actions.onInput(tab.sessionId, utf8)}
+            onFit={(cols, rows) => actions.onFit(tab.sessionId, cols, rows)}
+          />
+        </ErrorBoundary>
       ) : (
         <div className="grid flex-1 place-items-center px-4 text-center text-[12px] text-text-faint">
           {tab.notice ?? t("terminal.view.sessionNotInteractive")}

--- a/packages/gui/test/error-boundary.vitest.ts
+++ b/packages/gui/test/error-boundary.vitest.ts
@@ -1,0 +1,70 @@
+// harness-test-tier: integration
+// @vitest-environment happy-dom
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, createElement, type ReactNode } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { ErrorBoundary } from "../src/renderer/components/ErrorBoundary.tsx";
+
+let container: HTMLElement;
+let root: Root;
+
+beforeAll(() => {
+  globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+});
+beforeEach(() => {
+  // React logs the caught error to console.error; keep the test output clean.
+  vi.spyOn(console, "error").mockImplementation(() => undefined);
+  container = document.createElement("div");
+  document.body.append(container);
+  root = createRoot(container);
+});
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  vi.restoreAllMocks();
+});
+
+function mount(children: ReactNode) {
+  act(() => root.render(createElement(ErrorBoundary, null, children)));
+}
+
+describe("ErrorBoundary", () => {
+  it("renders a recoverable fallback instead of unmounting when a child throws", () => {
+    const Boom = () => {
+      throw new Error("boom-marker-42");
+    };
+    mount(createElement(Boom));
+    // The fallback panel is shown (not a blank tree) and carries the error message.
+    expect(container.textContent).toContain("此视图出现错误");
+    expect(container.textContent).toContain("boom-marker-42");
+    // The two recovery affordances are present.
+    const labels = [...container.querySelectorAll("button")].map((b) => b.textContent ?? "");
+    expect(labels.some((l) => l.includes("重试"))).toBe(true);
+    expect(labels.some((l) => l.includes("重新加载"))).toBe(true);
+  });
+
+  it("renders children normally when nothing throws", () => {
+    mount(createElement("div", { "data-testid": "ok" }, "healthy-content"));
+    expect(container.querySelector('[data-testid="ok"]')).not.toBeNull();
+    expect(container.textContent).toContain("healthy-content");
+    expect(container.textContent).not.toContain("此视图出现错误");
+  });
+
+  it("recovers to the children on retry once the child stops throwing", () => {
+    let shouldThrow = true;
+    const Maybe = () => {
+      if (shouldThrow) throw new Error("transient");
+      return createElement("div", null, "recovered-content");
+    };
+    mount(createElement(Maybe));
+    expect(container.textContent).toContain("此视图出现错误");
+
+    shouldThrow = false;
+    const retry = [...container.querySelectorAll("button")].find((b) => (b.textContent ?? "").includes("重试"));
+    expect(retry).toBeTruthy();
+    act(() => retry!.dispatchEvent(new MouseEvent("click", { bubbles: true })));
+
+    expect(container.textContent).toContain("recovered-content");
+    expect(container.textContent).not.toContain("此视图出现错误");
+  });
+});

--- a/tools/gui-test-manifest.mjs
+++ b/tools/gui-test-manifest.mjs
@@ -24,6 +24,7 @@ export const guiVitestManifest = [
   "packages/gui/test/terminal-renderer.vitest.ts",
   "packages/gui/test/terminal-pane.vitest.ts",
   "packages/gui/test/terminal-page.vitest.ts",
+  "packages/gui/test/error-boundary.vitest.ts",
   "packages/gui/test/terminal-split-layout.vitest.ts",
   "packages/gui/test/terminal-split-grid.vitest.ts",
   "packages/gui/test/browser-shell.vitest.ts",


### PR DESCRIPTION
# English

## Summary

Two resilience fixes that surfaced while debugging the terminal going black — approved as follow-ups to the two spawn bugs (allowProposedApi #2120, StrictMode mounted-ref #2121).

1. The renderer had no error boundary. A throw inside a terminal pane (which is exactly what the missing `allowProposedApi` did on every pane mount) unmounted the whole React tree — sidebar, tab strip and all — to a black window. Wrap each `TerminalPane` in a small `ErrorBoundary` so a crashing pane shows a recoverable panel (with retry/reload) in just that pane, while the tab strip, sibling panes and the rest of the app stay usable.
2. `dev-electron` only stopped Vite when Electron closed; the reverse was missing. If the Vite dev server died while Electron stayed up, Electron kept rendering a dead `http://127.0.0.1:5173` as an unrecoverable black window with no error (the first symptom seen this session, from an orphaned launcher). Tear Electron down loudly on unexpected Vite exit instead.

## What Changed

- `packages/gui/src/renderer/components/ErrorBoundary.tsx` (new): a small class error boundary. Fallback text is inline (not i18n) so the crash path does not depend on a subsystem that may itself be failing; retry clears the error, reload refreshes the renderer.
- `packages/gui/src/renderer/components/terminal/TerminalPaneCard.tsx`: wrap the rendered `TerminalPane` in `ErrorBoundary` (pane-level isolation).
- `packages/gui/scripts/dev-electron.mjs`: on unexpected Vite child exit while Electron is alive, log loudly and kill Electron (fail-loud), guarded so intentional shutdown does not trip it.
- `packages/gui/test/error-boundary.vitest.ts` (new): asserts the boundary renders a recoverable fallback when a child throws, passes children through when nothing throws, and recovers to the children on retry.
- `tools/gui-test-manifest.mjs`: register the new vitest file (the GUI test manifest is an explicit allowlist).

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none

## Machine-Readable Declarations

Production-Delta: +81/-8

## Task And Scope

- Harness task: task_38514e01f4dafa2a792b798956 (child of PLT-TerminalWorkspace milestone task_d2985b723b87a2cf55aa24d6fe)
- Branch: codex/gui-resilience
- Public scope: GUI terminal pane card, a new error boundary component, and the dev launcher.
- Private planning/evidence updated: yes
- Out of scope: a general app-wide error boundary around every view (would re-indent ~300 lines for a cosmetic wrap; the demonstrated failure is the terminal, and pane-level containment covers it).

## Version Impact

- Version: no version change because this is a resilience/dev-tooling change with no packaged-surface or API change.
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: yes
- Protected surface scope: tools/gui-test-manifest.mjs — registering the new GUI vitest file, which the gui-build gate requires for any new GUI test (no gate logic changed).
- Authority: task_38514e01f4dafa2a792b798956
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no

---

# 中文

## 摘要

两处韧性修复,是排查「终端黑屏」时暴露出来的,已获批作为两个 spawn bug(allowProposedApi #2120、StrictMode mounted-ref #2121)的后续。

1. renderer 此前没有 error boundary。终端 pane 内一处抛错(缺 `allowProposedApi` 正是每次 pane 挂载都触发的那种)会把整棵 React 树卸载——侧边栏、tab 条全没——变成黑窗。给每个 `TerminalPane` 套一个小 `ErrorBoundary`:某个 pane 崩溃时只在该 pane 显示可恢复面板(带重试/重载),tab 条、其他 pane 与整个 app 照常可用。
2. `dev-electron` 只在 Electron 关闭时停 Vite,反向缺失。若 Vite dev server 先死而 Electron 还活着,Electron 就一直渲染一个已死的 `http://127.0.0.1:5173`、变成无法恢复且无报错的黑窗(本次会话最初见到的症状,来自孤儿 launcher)。改为 Vite 意外退出时 fail-loud 收掉 Electron。

## 变更内容

- `packages/gui/src/renderer/components/ErrorBoundary.tsx`(新):小的 class 错误边界。兜底文案内联(不走 i18n),避免崩溃路径再依赖可能同样出错的子系统;重试清错,重载刷新 renderer。
- `packages/gui/src/renderer/components/terminal/TerminalPaneCard.tsx`:把渲染的 `TerminalPane` 套进 `ErrorBoundary`(pane 级隔离)。
- `packages/gui/scripts/dev-electron.mjs`:Electron 存活期间 Vite 子进程意外退出时,大声记录并收掉 Electron(fail-loud),并加守卫使有意关停不误触。
- `packages/gui/test/error-boundary.vitest.ts`(新):断言子组件抛错时边界渲染可恢复兜底、无错时透传子组件、重试后恢复到子组件。
- `tools/gui-test-manifest.mjs`:登记新 vitest 文件(GUI 测试清单是显式白名单)。

## 任务与范围

- Harness 任务:task_38514e01f4dafa2a792b798956(PLT-TerminalWorkspace 里程碑 task_d2985b723b87a2cf55aa24d6fe 的子任务)
- 分支:codex/gui-resilience
- 公开范围:GUI 终端 pane 卡片、新 error boundary 组件、dev launcher。
- 私有规划/证据已更新:是
- 不在范围:围绕每个视图的全 app 级 error boundary(会为一个装饰性包裹重排约 300 行;已演示的失败面是终端,pane 级隔离已覆盖)。

## 版本影响

- 版本:不变,纯韧性/开发工具改动,无打包面/API 改动。
- 发布影响:不发布
