### PR TITLE
fix(gui): fill the terminal pane to its dockview host

### DIFF
--- a/packages/gui/src/renderer/components/terminal/TerminalPaneCard.tsx
+++ b/packages/gui/src/renderer/components/terminal/TerminalPaneCard.tsx
@@ -32,7 +32,9 @@ export function TerminalPaneCard(props: IDockviewPanelProps<{ readonly sessionId
       onFocusCapture={() => actions.onFocusPane(panelId)}
       onMouseDownCapture={() => actions.onFocusPane(panelId)}
       className={[
-        "flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden",
+        // dockview 的 panel 宿主(dv-react-part)是 block、非 flex,flex-1 在这里不生效,card 会缩到
+        // 内容高、底下露黑。用 h-full 填满宿主高度,再由内部 flex-col 把终端撑到整个 pane。
+        "flex h-full min-h-0 min-w-0 flex-col overflow-hidden",
         focused ? "outline outline-1 -outline-offset-1 outline-accent/50" : "",
       ].join(" ")}
     >

--- a/packages/gui/test/terminal-split-grid.vitest.ts
+++ b/packages/gui/test/terminal-split-grid.vitest.ts
@@ -232,6 +232,18 @@ describe("terminal split panes (PLT-TerminalWorkspace W1)", () => {
     );
   });
 
+  // Regression: dockview's panel host (dv-react-part) is a block element, not a flex container, so a
+  // `flex-1` card collapsed to content height and left the pane half-empty (a black band below).
+  // `h-full` is what makes the card fill its host; guard against a revert to flex-1.
+  it("sizes each pane card to fill its dockview host (h-full, not flex-1)", async () => {
+    stubBridge([sessionRow()]);
+    mountView();
+    await flush();
+    const card = panes()[0];
+    expect(card.className).toContain("h-full");
+    expect(card.className).not.toMatch(/(^|\s)flex-1(\s|$)/u);
+  });
+
   it("serializes the pane tree to localStorage with each pane's session id", async () => {
     stubBridge([sessionRow()]);
     mountView();


### PR DESCRIPTION
# English

## Summary

Fix the terminal split panes not filling their cells: a new or split pane only filled the top of its area, leaving a black band below, and dragging a sash made adjacent panes overlap.

Root cause, ground-truthed with live DOM measurement: the pane card root used `flex-1`, but dockview's panel host (`dv-react-part`) is a block element, not a flex container, so `flex-1` did nothing and the card collapsed to its content height (543px) instead of filling the panel (761px). The gap between the card's visual bounds and dockview's logical grid cell is also what made sash resizing look like an overlap.

## What Changed

- `packages/gui/src/renderer/components/terminal/TerminalPaneCard.tsx`: use `h-full` instead of `flex-1` on the card root so it fills the block panel host; the inner `flex-col` then stretches the terminal to the whole pane.
- `packages/gui/test/terminal-split-grid.vitest.ts`: guard that the rendered pane card carries `h-full` and not `flex-1` (negative control verified: reverting to `flex-1` fails the guard).

## Verification

Live Electron measurement (Playwright, real renderer):
- Fill: pane card height 543 → 761, matching its `dv-react-part` host (761); the black band below is gone.
- Resize: dragging the sash left 150px resized both panes 622/622 → 472/772 with a 0px adjacency gap — clean proportional resize, no overlap.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none

## Machine-Readable Declarations

Production-Delta: +3/-1

## Task And Scope

- Harness task: task_38514e01f4dafa2a792b798956 (child of PLT-TerminalWorkspace milestone task_d2985b723b87a2cf55aa24d6fe)
- Branch: codex/terminal-pane-fill
- Public scope: terminal pane card layout + its unit guard
- Private planning/evidence updated: yes
- Out of scope: drag-to-rearrange panes (dockview's native drag handle is the group header, which this design hides in favor of the outer tab strip; enabling rearrange needs a dedicated drag-handle implementation and a visual decision — separate work).

## Version Impact

- Version: no version change because this is a CSS layout bug fix with no packaged-surface or API change.
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none
- Authority: not applicable
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no

---

# 中文

## 摘要

修复终端分屏 pane 不填满单元格:新建或分屏出的 pane 只填了顶部一块、底下露黑带,而且拖 sash 调大小时相邻 pane 会互相叠。

根因(用真机 DOM 测量 ground-truth):pane card 根用了 `flex-1`,但 dockview 的 panel 宿主(`dv-react-part`)是 **block、非 flex 容器**,`flex-1` 不生效,card 缩到内容高(543px)而没有填满 panel(761px)。card 的视觉边界与 dockview 逻辑 grid 单元之间的这个落差,正是拖 sash 看起来"叠加"的原因。

## 变更内容

- `packages/gui/src/renderer/components/terminal/TerminalPaneCard.tsx`:card 根用 `h-full` 取代 `flex-1`,填满 block panel 宿主;内部 `flex-col` 再把终端撑到整个 pane。
- `packages/gui/test/terminal-split-grid.vitest.ts`:守卫渲染出的 pane card 带 `h-full`、不带 `flex-1`(阳性对照已验证:退回 `flex-1` 该守卫变红)。

## 验证

真机 Electron 测量(Playwright,真实 renderer):
- 填满:pane card 高 543 → 761,与其 `dv-react-part` 宿主(761)一致;底下黑带消失。
- Resize:向左拖 sash 150px,两 pane 从 622/622 → 472/772,邻接 gap = 0px——干净比例联动,无重叠。

## 任务与范围

- Harness 任务:task_38514e01f4dafa2a792b798956(PLT-TerminalWorkspace 里程碑 task_d2985b723b87a2cf55aa24d6fe 的子任务)
- 分支:codex/terminal-pane-fill
- 公开范围:终端 pane 卡片布局 + 其单测守卫
- 私有规划/证据已更新:是
- 不在范围:拖拽换位 pane(dockview 原生拖拽把手是 group header,本设计为用外层 tab 条而隐藏了它;启用换位需专门实现拖拽把手并涉及视觉决策——单独处理)。

## 版本影响

- 版本:不变,纯 CSS 布局 bug 修复,无打包面/API 改动。
- 发布影响:不发布
