### PR TITLE
fix(tests): flush discovery list before exit — intermittent full-check discovery race

### DIFF
--- a/tools/run-node-tests.mjs
+++ b/tools/run-node-tests.mjs
@@ -89,9 +89,9 @@ if (selection.files.length === 0) {
 }
 
 if (options.list) {
-  for (const file of selection.files) {
-    console.log(file);
-  }
+  await new Promise((resolveWrite) => {
+    process.stdout.write(`${selection.files.join("\n")}\n`, resolveWrite);
+  });
   process.exit(0);
 }
 


### PR DESCRIPTION
# English

## Summary

Fixes the intermittent full-check red on main (`c0bd65e11`, `b8c659d2b`) where the assertion "integration discovery equals the files executed by the CI runner" failed with exactly one file missing: `tools/quickstart-demo.test.mjs`. Root cause: in `--list` mode, `tools/run-node-tests.mjs` printed each discovered file with `console.log()` and then called `process.exit(0)`. When stdout is a pipe (as under the CI runner capturing the list), `console.log` writes are asynchronous, and the hard exit intermittently pre-empted the flush of the final buffered line — the last entry in the sorted list, which is `tools/quickstart-demo.test.mjs`. The fix emits the list as one buffered write and awaits its stdout completion callback before exiting. The test itself always ran green because the loss was in the discovery listing, not in execution.

## Architectural Justification

- Mechanism sentence: a process that hard-exits after asynchronous pipe writes turns its own output into a race; any consumer comparing that output against ground truth will intermittently see truncation as a phantom discrepancy.
- The guarding assertion is untouched — it is the instrument that caught the defect and remains the regression guard; no retry, no widening, no extra test scaffolding added.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none

## Machine-Readable Declarations

Production-Delta: +3/-3
Dependency-Change: none

### Optional Evidence Claims

None.

## Task And Scope

- Harness task task_1bc2b4cbf78794c1d59ebc142e under the PLT-Ontology supervision line (root task_5fc5080044fcfdbf548008f2f5). Branch `codex/discovery-race-fix`.

## Version Impact

- Version: no change. Publish impact: none.

## Governance Declaration

- Protected surface touched: yes — `tools/run-node-tests.mjs` (test-runner authority surface). Authorized by task_1bc2b4cbf78794c1d59ebc142e, which explicitly targets this runner's discovery race as its scoped fix surface. Break-glass: no. CI workflow definitions untouched.

## Verification

- Positive control: pre-fix reproduction dropped exactly the `tools/quickstart-demo.test.mjs` line; mutation control (fix reverted) reproduced the same loss.
- Post-fix: controlled repetitions 10/10 green; Ubuntu concurrent quickstart/discovery overlap 10/10; focused runner/discovery suite 54/54; ESLint and `git diff --check` clean.
- [ ] Full suites: GitHub CI is the authority.

## Review Evidence

- Diff is 3/3 lines confined to the `--list` branch of `tools/run-node-tests.mjs`; execution path and discovery logic unchanged.
- Root-cause report with reproduction transcripts lives in the private ledger task package (artifacts/root-cause-report.md).

## Residual Risk

- Other scripts that `process.exit()` after piped writes could carry the same class of race; none is currently implicated by a failing gate, so no speculative sweep was done.

---

# 中文

## 概要

修 main 上 full-check 间歇红(`c0bd65e11`/`b8c659d2b`):断言「integration discovery equals the files executed by the CI runner」失败,差集恰好一个文件 `tools/quickstart-demo.test.mjs`。根因:`tools/run-node-tests.mjs` 的 `--list` 模式逐行 `console.log()` 后立刻 `process.exit(0)`;stdout 为管道时(CI runner 捕获清单的场景)写入是异步的,硬退出间歇性抢在最后一行 flush 之前——排序清单的末位正是 `tools/quickstart-demo.test.mjs`。修法:整表一次缓冲写出,await stdout 完成回调后再退出。测试本身一直绿,丢的是 discovery 清单不是执行。

## 架构辩护

- 机制句:在异步管道写之后硬退出的进程,把自己的输出变成一场竞态;任何拿该输出与 ground truth 对账的消费者,都会间歇把截断看成幻影差异。
- 守护断言未动——它是抓住缺陷的仪器,也继续是回归守护;不加重试、不调宽、不加雕花测试。

## 机读声明

`Production-Delta: +3/-3`;无依赖变更。

## 治理声明

- 触碰 protected surface:`tools/run-node-tests.mjs`(runner 权威面),授权来源 = task_1bc2b4cbf78794c1d59ebc142e(该任务的既定修复面就是此 runner 的 discovery 竞态);无 break-glass;CI workflow 定义未动。

## 验证

- 阳性对照:修前复现恰好丢 quickstart-demo 一行;变异检查(撤销修复)同样复现。
- 修后:受控复跑 10/10;Ubuntu 并发重叠 10/10;定向套件 54/54;ESLint 与 `git diff --check` 干净。完整权威=GitHub CI。

## 残余风险

- 其他「管道写后 process.exit」的脚本可能同类竞态;当前无失败门指认,不做猜测性扫荡。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VTzQAqvuFy6ikGjBKxA9xj
