### PR TITLE
fix(daemon): settle local doc conflict exits — register conflict actions in isDocAction routing

### DIFF
--- a/packages/cli/test/fleet-task-route.test.ts
+++ b/packages/cli/test/fleet-task-route.test.ts
@@ -60,6 +60,18 @@ test("fleet task routing requires both edge config and remote-edge registry mode
   assert.equal(docStatus?.method, "daemon.fleet.doc.sync");
   assert.equal(docStatus?.payload.dryRun, true);
   assert.deepEqual(docStatus?.payload.paths, ["context/notes.md"]);
+  for (const [kind, action] of [
+    ["doc-conflict-resolve", "resolve"],
+    ["doc-conflict-discard-local", "discard-local"],
+    ["doc-conflict-overwrite-center", "overwrite-center"],
+  ] as const) {
+    const conflict = command("repo.task.run", { kind, conflictId: "cflt-one" });
+    assert.equal(await fleetTaskRoute(conflict, env), null);
+    const routedConflict = await fleetDocRoute(conflict, env);
+    assert.equal(routedConflict?.method, "daemon.fleet.conflict.exit");
+    assert.equal(routedConflict?.payload.action, action);
+    assert.equal(routedConflict?.payload.conflictId, "cflt-one");
+  }
   const child = path.join(root, "worktrees", "nested");
   mkdirSync(child, { recursive: true });
   const childRouted = await fleetTaskRoute(

--- a/packages/cli/test/thin-command.test.ts
+++ b/packages/cli/test/thin-command.test.ts
@@ -228,6 +228,18 @@ test("task transition leaves lifecycle eligibility to the kernel", () => {
   );
 });
 
+test("doc conflict exits preserve the conflict id for daemon dispatch", () => {
+  for (const action of ["resolve", "discard-local", "overwrite-center"] as const) {
+    const parsed = parseThinCommand(["doc", "conflict", action, "abcdef12"]);
+    assert.equal(parsed.ok, true, JSON.stringify(parsed));
+    if (parsed.ok)
+      assert.deepEqual(parsed.command.action, {
+        kind: `doc-conflict-${action}`,
+        conflictId: "abcdef12",
+      });
+  }
+});
+
 test("CLI version is read from the CLI package metadata", () => {
   const packageJson = JSON.parse(readFileSync(new URL("../package.json", import.meta.url), "utf8"));
   assert.equal(resolveCliVersion(), packageJson.version);

--- a/packages/daemon/src/doc-sync-command-actions.ts
+++ b/packages/daemon/src/doc-sync-command-actions.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, lstatSync, readFileSync, readdirSync } from "node:fs";
 import path from "node:path";
 import type { CanonicalEventStore, TaskProjection } from "../../kernel/src/index.ts";
 import {
@@ -22,7 +22,7 @@ import {
 import { assignmentIntent, scannerSubmit } from "./doc-sync-adjudication.ts";
 import { intentFromScan } from "./doc-sync-candidate-scanner.ts";
 import type { AuthoredCandidateInventoryV1 } from "./doc-sync-candidate-scanner.ts";
-import { claimBytes, directPaths } from "./doc-sync-details.ts";
+import { claimBytes, directPaths, settleConflictScratch } from "./doc-sync-details.ts";
 import {
   artifactSource,
   docSyncError,
@@ -81,13 +81,17 @@ export function isDocAction(kind: string): boolean {
     kind === "doc-submit" ||
     kind === "doc-materialize" ||
     kind === "doc-show" ||
-    kind === "doc-retire"
+    kind === "doc-retire" ||
+    kind === "doc-conflict-resolve" ||
+    kind === "doc-conflict-discard-local" ||
+    kind === "doc-conflict-overwrite-center"
   );
 }
 
 export async function runDocAction(input: Input): Promise<WriteReceipt> {
   if (Buffer.byteLength(JSON.stringify(input.action)) > DOC_COMMAND_FRAME_MAX_BYTES)
     throw docSyncError("invalid_command", "doc command frame exceeds the descriptor-only limit");
+  if (input.action.kind.startsWith("doc-conflict-")) return runLocalDocConflictExit(input);
   if (input.action.kind === "doc-materialize") {
     if (!hasExactDocSyncActionFields(input.action, ["kind"]))
       throw docSyncError("invalid_command", "doc materialize takes no options");
@@ -134,6 +138,87 @@ export async function runDocAction(input: Input): Promise<WriteReceipt> {
   return scan && (receipt.outcome === "applied" || receipt.outcome === "pending")
     ? scannerSettlement(input, scan, receipt)
     : receipt;
+}
+
+async function runLocalDocConflictExit(input: Input): Promise<WriteReceipt> {
+  if (!hasExactDocSyncActionFields(input.action, ["kind", "conflictId"]))
+    throw docSyncError("invalid_command", "doc conflict exit requires one conflictId");
+  const conflictId = requiredDocSyncText(input.action.conflictId, "conflictId");
+  if (!/^[0-9a-f]{8}$/u.test(conflictId))
+    throw docSyncError("invalid_command", "local doc conflictId must be eight lowercase hexadecimal characters");
+  const conflict = localDocConflict(input.rootDir, conflictId);
+  if (input.action.kind === "doc-conflict-discard-local") {
+    settleConflictScratch(conflict.scratch);
+    const revision = input.store.readHead()?.revision ?? 0;
+    return {
+      outcome: "applied",
+      opId: `doc-conflict:discard-local:${conflictId}:${revision}`,
+      revision,
+      origin: "doc-sync",
+      evidence: stableStringify({ conflictId, path: conflict.logical, resolvedVia: "discard-local" }),
+      visibility: "center",
+      proof: proof(revision, revision, true, true),
+      nextAction: `Local conflict scratch was discarded; ${conflict.logical} retains the canonical bytes.`,
+    };
+  }
+  const source = input.action.kind === "doc-conflict-overwrite-center" ? conflict.scratch : conflict.target;
+  if (!existsSync(source) || !lstatSync(source).isFile())
+    throw docSyncError(
+      "conflict_source_missing",
+      input.action.kind === "doc-conflict-overwrite-center"
+        ? "local conflict scratch is not a direct regular file"
+        : "merge the conflict into its canonical document before resolving it",
+    );
+  const submitted = await runDocAction({
+    ...input,
+    action: { kind: "doc-submit", paths: [conflict.logical] },
+    authoredCandidateInventory: {
+      schema: "harness-authored-candidate-inventory/v1",
+      baseLedgerSha: input.store.currentCut(),
+      rows: [
+        {
+          path: conflict.logical,
+          safe: true,
+          bytes: readFileSync(source),
+          conflicts: [],
+          legacyDocument: null,
+        },
+      ],
+    },
+  });
+  if (["applied", "pending", "no_changes"].includes(submitted.outcome)) settleConflictScratch(conflict.scratch);
+  return submitted;
+}
+
+function localDocConflict(
+  rootDir: string,
+  conflictId: string,
+): { readonly logical: string; readonly scratch: string; readonly target: string } {
+  const authoredRoot = resolveHarnessLayout(rootDir).authoredRoot,
+    marker = `.conflict-${conflictId}`,
+    matches: { readonly logical: string; readonly scratch: string; readonly target: string }[] = [];
+  const visit = (directory: string): void => {
+    if (!existsSync(directory)) return;
+    for (const entry of readdirSync(directory, { withFileTypes: true })) {
+      const absolute = path.join(directory, entry.name);
+      if (entry.isDirectory()) {
+        visit(absolute);
+        continue;
+      }
+      if (!entry.isFile()) continue;
+      const extension = path.extname(entry.name),
+        stem = entry.name.slice(0, -extension.length);
+      if (![".md", ".txt"].includes(extension) || !stem.endsWith(marker)) continue;
+      const target = path.join(directory, `${stem.slice(0, -marker.length)}${extension}`),
+        logical = path.relative(authoredRoot, target).split(path.sep).join("/");
+      if (directPaths(rootDir, [logical])) matches.push({ logical, scratch: absolute, target });
+    }
+  };
+  visit(authoredRoot);
+  if (matches.length === 0) throw docSyncError("conflict_not_found", `local doc conflict ${conflictId} was not found`);
+  if (matches.length > 1)
+    throw docSyncError("conflict_ambiguous", `local doc conflict ${conflictId} matches more than one scratch file`);
+  return matches[0]!;
 }
 
 export function runDocRetire(input: Input): DocSettlementReceipt {

--- a/packages/daemon/src/doc-sync-details.ts
+++ b/packages/daemon/src/doc-sync-details.ts
@@ -17,6 +17,7 @@ import {
   type WriteSource,
 } from "../../kernel/src/index.ts";
 import type { Input } from "./doc-sync-command-actions.ts";
+import { syncDirectory } from "./durable-file.ts";
 import { localProseSource } from "./doc-sync-files.ts";
 
 interface BlockedCandidate {
@@ -144,6 +145,11 @@ export function recycleClaims(rootDir: string, intent: DocWriteIntent): void {
     const target = change.candidate && claimFile(rootDir, change.candidate.ref);
     if (target) unlinkSync(target);
   }
+}
+
+export function settleConflictScratch(scratch: string): void {
+  unlinkSync(scratch);
+  syncDirectory(path.dirname(scratch));
 }
 
 export function directPaths(rootDir: string, paths: readonly string[]): boolean {

--- a/packages/daemon/src/doc-sync-settlement.ts
+++ b/packages/daemon/src/doc-sync-settlement.ts
@@ -121,9 +121,9 @@ export function scanDetail(input: Input, scan: DocCandidateScan, code: string): 
       })),
     nextAction: hasConflict
       ? [
-          "merge the listed conflict scratch into the canonical file, run ha doc ",
-          "sync --dry-run --path <path> for a fresh base, then save to submit a new ",
-          "opId",
+          "merge the listed conflict scratch into the canonical file, then run ha doc ",
+          "conflict resolve <conflict-id>; use discard-local or overwrite-center ",
+          "when either side should win unchanged",
         ].join("")
       : deletion
         ? blockedCandidateNextAction(

--- a/packages/daemon/test/doc-sync-slice-a-materialization.test.ts
+++ b/packages/daemon/test/doc-sync-slice-a-materialization.test.ts
@@ -4,25 +4,12 @@ import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
-import {
-  makeTaskEventStore,
-  makeTaskProjection,
-} from "../../kernel/src/index.ts";
+import { makeTaskEventStore, makeTaskProjection } from "../../kernel/src/index.ts";
 import { readDocReceipt } from "../src/doc-sync-actions.ts";
-import {
-  canonicalRoot,
-  workspaceId,
-} from "../src/protocol/daemon-protocol.contract.ts";
+import { canonicalRoot, workspaceId } from "../src/protocol/daemon-protocol.contract.ts";
 import { openBootstrappedRepoCell as openRepoCell } from "./repo-settings.fixture.ts";
 
-import {
-  actor,
-  git,
-  initRepo,
-  materializeReport,
-  rows,
-  write,
-} from "./doc-sync-slice-a.fixtures.ts";
+import { actor, git, initRepo, materializeReport, rows, write } from "./doc-sync-slice-a.fixtures.ts";
 test("a committed DocEvent reports pending with its stable receipt id until L2 reaches the event cut", async () => {
   const rootDir = mkdtempSync(path.join(tmpdir(), "ha-doc-a-pending-")),
     repoId = workspaceId("doc-pending"),
@@ -34,15 +21,9 @@ test("a committed DocEvent reports pending with its stable receipt id until L2 r
     ownerId: "doc-pending",
   });
   try {
-    await cell.run(
-      { kind: "task-create", taskId: "task-pending", title: "Pending" },
-      binding,
-    );
+    await cell.run({ kind: "task-create", taskId: "task-pending", title: "Pending" }, binding);
     write(rootDir, "context/pending.md", "# Pending\n");
-    const applied = await cell.run(
-      { kind: "doc-submit", paths: ["context/pending.md"] },
-      binding,
-    );
+    const applied = await cell.run({ kind: "doc-submit", paths: ["context/pending.md"] }, binding);
     assert.equal(applied.outcome, "applied");
     await cell.close();
     const store = makeTaskEventStore({ repoId, rootDir }),
@@ -69,10 +50,7 @@ test("a committed DocEvent reports pending with its stable receipt id until L2 r
     assert.equal(pending.opId, event.opId);
     assert.equal(pending.proof?.committedRevision, event.workspaceRevision);
     assert.equal(pending.proof?.canonicalVisible, false);
-    assert.match(
-      pending.nextAction ?? "",
-      new RegExp(`receipt show ${event.opId}`, "u"),
-    );
+    assert.match(pending.nextAction ?? "", new RegExp(`receipt show ${event.opId}`, "u"));
     projection.close();
   } finally {
     await cell.close();
@@ -105,20 +83,14 @@ test("materialize restores task-bootstrap and doc-event files and is idempotent"
     );
     const packagePath = "tasks/task-materialize-materialize",
       taskRoot = path.join(rootDir, "harness", packagePath),
-      prosePaths = [
-        `${packagePath}/task_plan.md`,
-        `${packagePath}/closeout.md`,
-      ];
+      prosePaths = [`${packagePath}/task_plan.md`, `${packagePath}/closeout.md`];
     for (const logical of prosePaths)
       write(
         rootDir,
         logical,
         `${readFileSync(path.join(rootDir, "harness", logical), "utf8")}\n## Project Extension\n\nCanonical prose update.\n`,
       );
-    const prose = await cell.run(
-      { kind: "doc-submit", paths: prosePaths },
-      binding,
-    );
+    const prose = await cell.run({ kind: "doc-submit", paths: prosePaths }, binding);
     assert.equal(prose.outcome, "applied", JSON.stringify(prose));
     const proseEvent = makeTaskEventStore({
       repoId: "materialize",
@@ -126,20 +98,9 @@ test("materialize restores task-bootstrap and doc-event files and is idempotent"
     }).readEvent(prose.opId);
     assert.equal(proseEvent?.schema, "doc-event/v1");
     if (proseEvent?.schema === "doc-event/v1")
-      assert.deepEqual(
-        proseEvent.payload.changes.map(({ path: target }) => target).sort(),
-        [...prosePaths].sort(),
-      );
+      assert.deepEqual(proseEvent.payload.changes.map(({ path: target }) => target).sort(), [...prosePaths].sort());
     write(rootDir, "context/notes.md", "# Notes\n\ncanonical\n");
-    assert.equal(
-      (
-        await cell.run(
-          { kind: "doc-submit", paths: ["context/notes.md"] },
-          binding,
-        )
-      ).outcome,
-      "applied",
-    );
+    assert.equal((await cell.run({ kind: "doc-submit", paths: ["context/notes.md"] }, binding)).outcome, "applied");
     const cut = git(rootDir, "rev-parse", "HEAD"),
       count = git(rootDir, "rev-list", "--count", "HEAD");
     rmSync(taskRoot, { recursive: true, force: true });
@@ -154,10 +115,7 @@ test("materialize restores task-bootstrap and doc-event files and is idempotent"
     );
     assert.equal(existsSync(taskRoot), true);
     for (const logical of prosePaths)
-      assert.match(
-        readFileSync(path.join(rootDir, "harness", logical), "utf8"),
-        /Canonical prose update/u,
-      );
+      assert.match(readFileSync(path.join(rootDir, "harness", logical), "utf8"), /Canonical prose update/u);
     assert.equal(git(rootDir, "diff", "--name-only"), "");
     const second = await cell.run({ kind: "doc-materialize" }, binding),
       secondReport = materializeReport(second.evidence);
@@ -172,7 +130,7 @@ test("materialize restores task-bootstrap and doc-event files and is idempotent"
   }
 });
 
-test("materialize preserves a divergent local edit in one ignored deterministic conflict scratch", async () => {
+test("local conflict exits run through the doc-sync write path", async (t) => {
   const rootDir = mkdtempSync(path.join(tmpdir(), "ha-doc-a-conflict-"));
   initRepo(rootDir);
   const cell = await openRepoCell({
@@ -185,55 +143,82 @@ test("materialize preserves a divergent local edit in one ignored deterministic 
     local = "# Notes\n\nlocal draft\n";
   try {
     write(rootDir, "context/notes.md", canonical);
-    assert.equal(
-      (
-        await cell.run(
-          { kind: "doc-submit", paths: ["context/notes.md"] },
-          binding,
-        )
-      ).outcome,
-      "applied",
-    );
+    assert.equal((await cell.run({ kind: "doc-submit", paths: ["context/notes.md"] }, binding)).outcome, "applied");
     write(rootDir, "context/notes.md", local);
-    const first = materializeReport(
-      (await cell.run({ kind: "doc-materialize" }, binding)).evidence,
-    );
+    const first = materializeReport((await cell.run({ kind: "doc-materialize" }, binding)).evidence);
     assert.deepEqual(first.changed, ["context/notes.md"]);
     assert.equal(first.conflicts.length, 1);
-    assert.equal(
-      readFileSync(path.join(rootDir, first.conflicts[0]!), "utf8"),
-      local,
-    );
-    assert.equal(
-      readFileSync(path.join(rootDir, "harness/context/notes.md"), "utf8"),
-      canonical,
-    );
-    assert.equal(
-      git(rootDir, "status", "--porcelain", "-uall").includes("conflict-"),
-      false,
-    );
-    const conflicted = await cell.run(
-      { kind: "doc-status", paths: ["context/notes.md"] },
-      binding,
-    );
+    assert.equal(readFileSync(path.join(rootDir, first.conflicts[0]!), "utf8"), local);
+    assert.equal(readFileSync(path.join(rootDir, "harness/context/notes.md"), "utf8"), canonical);
+    assert.equal(git(rootDir, "status", "--porcelain", "-uall").includes("conflict-"), false);
+    const conflicted = await cell.run({ kind: "doc-status", paths: ["context/notes.md"] }, binding);
     assert.equal(rows(conflicted.evidence)[0]?.state, "conflict");
-    assert.match(
-      conflicted.detail?.nextAction ?? "",
-      /listed conflict scratch/u,
-    );
-    assert.doesNotMatch(
-      conflicted.detail?.nextAction ?? "",
-      /doc retire|blocked candidates/iu,
-    );
-    const second = materializeReport(
-      (await cell.run({ kind: "doc-materialize" }, binding)).evidence,
-    );
-    assert.deepEqual(second, { changed: [], conflicts: [] });
+    assert.match(conflicted.detail?.nextAction ?? "", /listed conflict scratch/u);
+    assert.match(conflicted.detail?.nextAction ?? "", /ha doc conflict resolve <conflict-id>/u);
+    assert.doesNotMatch(conflicted.detail?.nextAction ?? "", /doc retire|blocked candidates/iu);
+    await t.test("discard-local removes the scratch and retains center bytes", async () => {
+      const conflictId = conflictIdOf(first.conflicts[0]!);
+      const discarded = await cell.run({ kind: "doc-conflict-discard-local", conflictId }, binding);
+      assert.equal(discarded.outcome, "applied", JSON.stringify(discarded));
+      assert.equal(existsSync(path.join(rootDir, first.conflicts[0]!)), false);
+      assert.equal(readFileSync(path.join(rootDir, "harness/context/notes.md"), "utf8"), canonical);
+      assert.equal((await cell.run({ kind: "doc-show", path: "context/notes.md" }, binding)).evidence, canonical);
+      assert.equal(
+        rows((await cell.run({ kind: "doc-status", paths: ["context/notes.md"] }, binding)).evidence)[0]?.state,
+        "clean",
+      );
+    });
+
+    await t.test("overwrite-center publishes scratch bytes and returns clean", async () => {
+      const overwrite = "# Notes\n\nlocal overwrite\n";
+      write(rootDir, "context/notes.md", overwrite);
+      const overwriteConflict = materializeReport((await cell.run({ kind: "doc-materialize" }, binding)).evidence)
+          .conflicts[0]!,
+        overwritten = await cell.run(
+          { kind: "doc-conflict-overwrite-center", conflictId: conflictIdOf(overwriteConflict) },
+          binding,
+        );
+      assert.equal(overwritten.outcome, "applied", JSON.stringify(overwritten));
+      assert.equal(existsSync(path.join(rootDir, overwriteConflict)), false);
+      assert.equal(readFileSync(path.join(rootDir, "harness/context/notes.md"), "utf8"), overwrite);
+      assert.equal((await cell.run({ kind: "doc-show", path: "context/notes.md" }, binding)).evidence, overwrite);
+      assert.equal(
+        rows((await cell.run({ kind: "doc-status", paths: ["context/notes.md"] }, binding)).evidence)[0]?.state,
+        "clean",
+      );
+    });
+
+    await t.test("resolve publishes the hand-merged document and returns clean", async () => {
+      const unresolved = "# Notes\n\nsecond local draft\n",
+        merged = "# Notes\n\nlocal overwrite and second local draft\n";
+      write(rootDir, "context/notes.md", unresolved);
+      const resolveConflict = materializeReport((await cell.run({ kind: "doc-materialize" }, binding)).evidence)
+        .conflicts[0]!;
+      write(rootDir, "context/notes.md", merged);
+      const resolved = await cell.run(
+        { kind: "doc-conflict-resolve", conflictId: conflictIdOf(resolveConflict) },
+        binding,
+      );
+      assert.equal(resolved.outcome, "applied", JSON.stringify(resolved));
+      assert.equal(existsSync(path.join(rootDir, resolveConflict)), false);
+      assert.equal(readFileSync(path.join(rootDir, "harness/context/notes.md"), "utf8"), merged);
+      assert.equal((await cell.run({ kind: "doc-show", path: "context/notes.md" }, binding)).evidence, merged);
+      assert.equal(
+        rows((await cell.run({ kind: "doc-status", paths: ["context/notes.md"] }, binding)).evidence)[0]?.state,
+        "clean",
+      );
+    });
   } finally {
     await cell.close();
     rmSync(rootDir, { recursive: true, force: true });
   }
 });
+
+function conflictIdOf(relativePath: string): string {
+  const conflictId = /\.conflict-([0-9a-f]{8})\.(?:md|txt)$/u.exec(relativePath)?.[1];
+  assert.ok(conflictId, `expected a deterministic conflict id in ${relativePath}`);
+  return conflictId;
+}
 
 test("an authored branch advanced outside the daemon remains an ancestor of the asynchronously materialized cut", async () => {
   const rootDir = mkdtempSync(path.join(tmpdir(), "ha-doc-a-diverged-"));
@@ -249,22 +234,13 @@ test("an authored branch advanced outside the daemon remains an ancestor of the 
     git(rootDir, "add", "harness/context/notes.md");
     git(rootDir, "commit", "-qm", "external advance");
     const external = git(rootDir, "rev-parse", "HEAD"),
-      result = await cell.run(
-        { kind: "doc-submit", paths: ["context/notes.md"] },
-        binding,
-      );
+      result = await cell.run({ kind: "doc-submit", paths: ["context/notes.md"] }, binding);
     assert.equal(result.outcome, "applied");
     assert.equal(result.commitSha, null);
     assert.equal(cell.status().state, "attached");
     await cell.close();
-    assert.equal(
-      git(rootDir, "merge-base", "--is-ancestor", external, "HEAD") === "",
-      true,
-    );
-    assert.equal(
-      git(rootDir, "log", "-1", "--format=%s"),
-      `harness WAL flush ${result.revision}-${result.revision}`,
-    );
+    assert.equal(git(rootDir, "merge-base", "--is-ancestor", external, "HEAD") === "", true);
+    assert.equal(git(rootDir, "log", "-1", "--format=%s"), `harness WAL flush ${result.revision}-${result.revision}`);
   } finally {
     await cell.close();
     rmSync(rootDir, { recursive: true, force: true });


### PR DESCRIPTION
# English

## Summary

Repairs all three `ha doc conflict` resolution subcommands (`resolve` / `discard-local` / `overwrite-center`), which uniformly failed with the daemon error "taskId is required" — leaving hand-deleting `*.conflict-<id>.md` scratch files as the only (ledger-less) way out of a doc conflict. Root cause: the three conflict actions were not recognized by `isDocAction()` in the daemon's doc-sync command dispatch, so they fell through into the task-lifecycle runtime, whose validator demands a taskId the doc-conflict payload legitimately does not carry. The fleet RPC contract (`daemon.fleet.conflict.exit`) itself was correct. The fix registers the three actions as doc actions and implements each exit semantic through the existing doc-sync write path (scratch settled, `doc status` returns to clean); the daemon's fail-closed validation is untouched.

## Architectural Justification

- Mechanism sentence: a command dispatcher that classifies by an incomplete allowlist silently routes unrecognized members of a family into a neighboring runtime, where they fail with that runtime's error vocabulary — an error message pointing at the wrong contract.
- The three semantics reuse the existing doc-sync write path rather than growing a parallel conflict machinery; no daemon validation was loosened.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none

## Machine-Readable Declarations

Production-Delta: +97/-6
Dependency-Change: none

### Optional Evidence Claims

None.

## Task And Scope

- Harness task task_a55b2c8461fe0f2f8200274551 under the PLT-Ontology supervision line (root task_5fc5080044fcfdbf548008f2f5). Branch `codex/doc-conflict-taskid`.

## Version Impact

- Version: no change. Publish impact: none.

## Governance Declaration

- Protected surface touched: no (daemon doc-sync actions and CLI routing tests; no CI/gate files). Authorizing task: task_a55b2c8461fe0f2f8200274551. Break-glass: no.

## Verification

- Positive control: before the fix, all three subcommands reproduce `taskId is required.` on a constructed conflict; mutation check (fix reverted) restores the same error for all three.
- After the fix: each of the three semantics settles the conflict end-to-end in an isolated Ubuntu run — scratch cleaned, `doc-status` back to clean, content matching the chosen semantic. Suites: daemon doc-sync 7/7, CLI parser 12/12 (re-run green post-rebase), fleet route 1/1.
- [ ] Full suites: GitHub CI is the authority.

## Review Evidence

- CLI parser and fleet-route tests now pin the routing: conflict exits go to `daemon.fleet.conflict.exit` with `action` + `conflictId`, never into the task route (asserted null).
- Rebased onto main including #2124/#2125 before this PR; targeted parser suite re-run green on the rebased base.

## Residual Risk

- Conflict exits for non-task doc families (if any emerge later) follow the same registered path; no separate machinery to drift.

---

# 中文

## 概要

修 `ha doc conflict` 三条解决子命令(resolve/discard-local/overwrite-center)全断问题——一律报 daemon 错误「taskId is required」,doc 冲突只能靠手删 `*.conflict-<id>.md` scratch 文件这条无台账旁路出清。根因:三种 conflict action 未被 daemon doc-sync 命令分发的 `isDocAction()` 识别,落进相邻的 task lifecycle runtime,其校验器要求 doc-conflict payload 本就不该携带的 taskId;fleet RPC 契约(`daemon.fleet.conflict.exit`)本身是对的。修法:把三种 action 注册为 doc action,三种出清语义均经既有 doc-sync 写路实现(scratch 正常清理、`doc status` 回 clean);daemon 的 fail-closed 校验未放宽。

## 架构辩护

- 机制句:按不完整白名单分类的命令分发器,会把同族未识别成员静默路由进邻近 runtime,用那个 runtime 的错误词表报错——错误信息指向错误的契约。
- 三种语义复用既有 doc-sync 写路,不长出平行的冲突机器;无校验放宽。

## 机读声明

`Production-Delta: +97/-6`;无依赖变更。

## 治理声明

- 未触碰 protected surface(daemon doc-sync 与 CLI 路由测试,无 CI/gate 文件);授权任务 task_a55b2c8461fe0f2f8200274551;无 break-glass。

## 验证

- 阳性对照:修前三条命令在构造冲突上各自复现「taskId is required.」;变异检查(撤销修复)三条全部回红。
- 修后:三种语义各自端到端出清(Ubuntu 隔离环境)——scratch 清理、doc-status 回 clean、内容符合所选语义;套件 daemon 7/7、CLI parser 12/12(rebase 后复跑绿)、fleet route 1/1。完整权威=GitHub CI。

## 残余风险

- 未来若出现非 task 族 doc 的冲突出清,走同一注册路径,无第二套机器可漂移。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VTzQAqvuFy6ikGjBKxA9xj
