### PR TITLE
fix(gui): allow inline styles in packaged CSP so xterm renders colors and fonts

### DIFF
--- a/packages/gui/src/main/window-config.ts
+++ b/packages/gui/src/main/window-config.ts
@@ -30,14 +30,14 @@ export function createGuiContentSecurityPolicy(options: GuiContentSecurityPolicy
   const connectSrc = options.allowDevRenderer
     ? "connect-src 'self' http://127.0.0.1:5173 ws://127.0.0.1:5173"
     : "connect-src 'self'";
-  // Dev only: the Vite dev server injects the react-refresh preamble as an
-  // inline script and styles as inline <style> tags. Production stays strict.
+  // Dev only: the Vite dev server injects the react-refresh preamble as an inline script.
   const scriptSrc = options.allowDevRenderer ? "script-src 'self' 'unsafe-inline'" : "script-src 'self'";
-  const styleSrc = options.allowDevRenderer ? "style-src 'self' 'unsafe-inline'" : "style-src 'self'";
   return [
     "default-src 'self'",
     scriptSrc,
-    styleSrc,
+    // 两种模式都放开 inline style:xterm 的 DOM renderer 靠运行时注入的 <style> 下发颜色表、
+    // 字体与 cell 尺寸(库不支持 nonce),style-src 'self' 会让打包态终端整片变白、字体错位。
+    "style-src 'self' 'unsafe-inline'",
     "img-src 'self' data:",
     "font-src 'self'",
     connectSrc,
@@ -50,20 +50,6 @@ export function createGuiContentSecurityPolicy(options: GuiContentSecurityPolicy
 export const guiContentSecurityPolicy = createGuiContentSecurityPolicy();
 
 export const allowedRendererOrigins = Object.freeze(["file://", "http://127.0.0.1:5173"] as const);
-
-export function createGuiIndexContentSecurityPolicy(): string {
-  return [
-    "default-src 'self'",
-    "script-src 'self'",
-    "style-src 'self'",
-    "img-src 'self' data:",
-    "font-src 'self'",
-    "connect-src 'self'",
-    "object-src 'none'",
-    "base-uri 'none'",
-    "frame-ancestors 'none'",
-  ].join("; ");
-}
 
 export function createGuiWindowOptions(preloadPath: string): GuiWindowOptions {
   return {

--- a/packages/gui/src/renderer/components/terminal/TerminalPane.tsx
+++ b/packages/gui/src/renderer/components/terminal/TerminalPane.tsx
@@ -221,7 +221,14 @@ export function TerminalPane({
           </button>
         </form>
       )}
-      <div ref={hostRef} data-testid="terminal-pane" className="min-h-0 flex-1" />
+      {/* 关连字:xterm 用「同一字符重复 32 次」量字宽,Geist Mono 会把 ---/=== 连成一条线,
+          量出 2.7px 再给每个 - 补 5px letter-spacing(路径里 a- b 那种空隙)。测量容器在宿主内一并继承。 */}
+      <div
+        ref={hostRef}
+        data-testid="terminal-pane"
+        className="min-h-0 flex-1"
+        style={{ fontVariantLigatures: "none" }}
+      />
     </div>
   );
 }

--- a/packages/gui/test/terminal-pane.vitest.ts
+++ b/packages/gui/test/terminal-pane.vitest.ts
@@ -127,6 +127,14 @@ describe("TerminalPane addon lifecycle (W4a)", () => {
     expect(xterm.lastOptions?.allowProposedApi).toBe(true);
   });
 
+  // Regression: xterm's DOM renderer measures glyph width from a 32-char repeat; with ligatures on,
+  // Geist Mono shapes "----" into one rule and reports ~1/3 of the cell, so every "-"/"=" got padded.
+  it("disables font ligatures on the host so xterm's width cache measures real cell advances", () => {
+    mount();
+    const host = container.querySelector<HTMLElement>('[data-testid="terminal-pane"]');
+    expect(host?.style.fontVariantLigatures).toBe("none");
+  });
+
   it("loads WebGL only when the centralized preference opts in", () => {
     localStorage.setItem(terminalWebglStorageKey, "enabled");
     mount();

--- a/packages/gui/test/window-config.test.ts
+++ b/packages/gui/test/window-config.test.ts
@@ -24,9 +24,9 @@ test("production CSP does not allow wildcard localhost connections", () => {
   assert.doesNotMatch(createGuiContentSecurityPolicy({ allowDevRenderer: true }), /127\.0\.0\.1:\*/);
 });
 
-test("inline script/style relaxation is dev-only; production CSP stays strict", () => {
-  assert.doesNotMatch(guiContentSecurityPolicy, /unsafe-inline/);
-  assert.doesNotMatch(createGuiContentSecurityPolicy(), /unsafe-inline/);
+test("inline script relaxation is dev-only; inline style stays open for xterm's injected stylesheets", () => {
+  assert.match(guiContentSecurityPolicy, /script-src 'self';/);
+  assert.match(guiContentSecurityPolicy, /style-src 'self' 'unsafe-inline'/);
   const devCsp = createGuiContentSecurityPolicy({ allowDevRenderer: true });
   assert.match(devCsp, /script-src 'self' 'unsafe-inline'/);
   assert.match(devCsp, /style-src 'self' 'unsafe-inline'/);


### PR DESCRIPTION
# English

## Summary

In the packaged GUI (`ha gui`, renderer loaded from `dist/`), every terminal rendered in the sans UI font, all white, with zsh autosuggestions indistinguishable from typed text. Dev mode (`dev:electron`) was fine.

Root cause, ground-truthed in a packaged-mode Electron with Playwright: the production CSP set `style-src 'self'`. xterm's DOM renderer injects `<style>` elements at runtime for its colour palette, font family and cell dimensions and has no nonce option, so all four injections were blocked (four `Applying inline style violates ... 'style-src 'self''` console violations). Dev mode already allowed `'unsafe-inline'`, which is why the bug only showed in the packaged launcher.

## What Changed

- `packages/gui/src/main/window-config.ts`: `style-src 'self' 'unsafe-inline'` in both modes; `script-src` stays strict (`'self'`) in production. Deleted the unused `createGuiIndexContentSecurityPolicy` (no callers).
- `packages/gui/test/window-config.test.ts`: assert production `script-src 'self'` stays strict and `style-src` allows inline.
- `packages/gui/src/renderer/components/terminal/TerminalPane.tsx`: `font-variant-ligatures: none` on the pane host. xterm's DOM renderer measures glyph width from a 32-char repeat; Geist Mono shapes `----`/`====` into one ligature rule, so `-` and `=` were cached at 2.69px instead of 7.81px and every hyphen got 5px of letter-spacing (`brain- os- frontend`). Guarded in `terminal-pane.vitest.ts`.

## Verification

Playwright against the packaged renderer (no Vite), same `dist/`, spawning a real terminal and running `printf '\e[32mGREEN\e[0m plain'`:

| | before (main) | after |
| --- | --- | --- |
| CSP violations in console | 4 | 0 |
| computed `.xterm-rows` font | `"Geist Variable", system-ui, sans-serif` | `"Geist Mono Variable", ui-monospace, monospace` |
| distinct text colours on screen | 1 | 9 |
| `GREEN` span colour | same as default text | green |

Ligature fix, same harness: the prompt path was split into `brain` / `-` (12.9px, letter-spacing 5.11px) / `os` / `-` / `frontend`; after the fix it is one span of 40 cells × 7.79px = 311.5px with default spacing. A direct measurement of 32 repeated glyphs in Geist Mono gives `-`/`=` 2.69px with ligatures and 7.81px without.

`node --test packages/gui/test/window-config.test.ts` and `vitest run test/terminal-pane.vitest.ts` green.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none

## Machine-Readable Declarations

Production-Delta: +12/-19

## Task And Scope

- Harness task: task_38514e01f4dafa2a792b798956 (child of PLT-TerminalWorkspace milestone task_d2985b723b87a2cf55aa24d6fe)
- Branch: codex/terminal-csp-style
- Public scope: main-process CSP builder + terminal pane host style, with their tests
- Private planning/evidence updated: yes
- Out of scope: drag-to-rearrange panes and keyboard-shortcut changes (separate PR).

## Residual Risk

`'unsafe-inline'` for styles applies to the main renderer only; scripts stay `'self'`-only and the artifact/in-app-browser partitions keep their own policies. A CSS-injection vector would require an XSS in the bundled renderer first.

## Version Impact

- Version: no version change (packaged-surface bug fix, no API change).
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none
- Authority: not applicable
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no

---

# 中文

## 摘要

打包态 GUI(`ha gui`,renderer 从 `dist/` 加载)里所有终端都用界面的无衬线字体渲染、整片纯白,zsh 的自动补全建议和已输入文字分不开。dev 模式(`dev:electron`)正常。

根因(在打包态 Electron 里用 Playwright ground-truth):生产 CSP 是 `style-src 'self'`。xterm 的 DOM renderer 运行时注入 `<style>` 元素来下发颜色表、字体与 cell 尺寸,且不支持 nonce,四次注入全被拦(控制台 4 条 `Applying inline style violates ... 'style-src 'self''`)。dev 模式本来就放开了 `'unsafe-inline'`,所以只在打包入口暴露。

## 变更内容

- `packages/gui/src/main/window-config.ts`:两种模式都 `style-src 'self' 'unsafe-inline'`;生产 `script-src` 保持严格(`'self'`)。删掉无调用方的 `createGuiIndexContentSecurityPolicy`。
- `packages/gui/test/window-config.test.ts`:断言生产 `script-src 'self'` 仍严格、`style-src` 允许 inline。
- `packages/gui/src/renderer/components/terminal/TerminalPane.tsx`:pane 宿主上 `font-variant-ligatures: none`。xterm 的 DOM renderer 用「同一字符重复 32 次」量字宽,Geist Mono 会把 `----`/`====` 连成一条连字线,`-`/`=` 被记成 2.69px 而不是 7.81px,于是每个连字符都补了 5px letter-spacing(`brain- os- frontend`)。`terminal-pane.vitest.ts` 加守卫。

## 验证

Playwright 对打包 renderer(不走 Vite,同一份 `dist/`)真起终端并执行 `printf '\e[32mGREEN\e[0m plain'`:

| | 修前(main) | 修后 |
| --- | --- | --- |
| 控制台 CSP 违规 | 4 | 0 |
| `.xterm-rows` 计算字体 | `"Geist Variable", system-ui, sans-serif` | `"Geist Mono Variable", ui-monospace, monospace` |
| 屏上不同文字颜色数 | 1 | 9 |
| `GREEN` span 颜色 | 与默认文字相同 | 绿色 |

连字修复同一套装置:修前 prompt 路径被拆成 `brain` / `-`(12.9px,letter-spacing 5.11px)/ `os` / `-` / `frontend`;修后是一整段 40 格 × 7.79px = 311.5px、默认间距。直接量 32 个重复字形:`-`/`=` 开连字 2.69px、关连字 7.81px。

`node --test packages/gui/test/window-config.test.ts` 与 `vitest run test/terminal-pane.vitest.ts` 绿。

## 任务与范围

- Harness 任务:task_38514e01f4dafa2a792b798956(PLT-TerminalWorkspace 里程碑 task_d2985b723b87a2cf55aa24d6fe 的子任务)
- 分支:codex/terminal-csp-style
- 公开范围:主进程 CSP 构造 + 终端 pane 宿主样式,及各自测试
- 私有规划/证据已更新:是
- 不在范围:pane 拖拽换位与快捷键改造(另开 PR)。

## 残余风险

样式 `'unsafe-inline'` 只作用于主 renderer;脚本仍只允许 `'self'`,artifact / 内嵌浏览器分区各自有独立策略。要利用 CSS 注入得先在打包 renderer 里有 XSS。

## 版本影响

- 版本:不变(打包面 bug 修复,无 API 改动)。
- 发布影响:不发布

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BE45Q2y1iZzLJNo8j7xhhL
