### PR TITLE
feat(gui): drag panes by their title bar, four-way split shortcuts and a pane context menu

### DIFF
--- a/packages/gui/src/renderer/components/terminal/TerminalChrome.tsx
+++ b/packages/gui/src/renderer/components/terminal/TerminalChrome.tsx
@@ -2,6 +2,7 @@ import type { FormEvent, ReactNode } from "react";
 import type { TerminalSessionRow } from "../../../../../daemon/src/gui-s3-control.ts";
 import type { TerminalPreferences } from "../../terminal-preferences.ts";
 import { t } from "../../i18n/index.tsx";
+import { isMacPlatform } from "../../platform.ts";
 
 const shellOptions = ["default", "zsh", "bash", "sh", "fish"] as const;
 
@@ -91,8 +92,8 @@ export function TerminalChrome({
             {t("terminal.view.backendTmux")}
           </button>
         </span>
-        <span className="ml-auto font-mono text-[11px] text-text-faint" title={t("terminal.view.splitShortcut")}>
-          {t("terminal.view.shortcut")} · {t("terminal.view.splitShortcut")}
+        <span className="ml-auto font-mono text-[11px] text-text-faint" title={splitShortcutHint()}>
+          {t("terminal.view.shortcut")} · {splitShortcutHint()}
         </span>
       </header>
       <div className="flex min-w-0 items-center gap-1 overflow-x-auto border-b border-border px-2 py-1">
@@ -236,4 +237,8 @@ function Field({ label, children }: { readonly label: string; readonly children:
       {children}
     </label>
   );
+}
+
+function splitShortcutHint(): string {
+  return t(isMacPlatform() ? "terminal.view.splitShortcutMac" : "terminal.view.splitShortcut");
 }

--- a/packages/gui/src/renderer/components/terminal/TerminalPaneCard.tsx
+++ b/packages/gui/src/renderer/components/terminal/TerminalPaneCard.tsx
@@ -79,7 +79,9 @@ export function TerminalPaneCard(props: IDockviewPanelProps<{ readonly sessionId
         <div
           data-testid="terminal-pane-drop"
           data-zone={dropZone}
-          className={`pointer-events-none absolute z-10 border-2 border-accent bg-accent/20 ${dropZoneClassName[dropZone]}`}
+          className={`pointer-events-none absolute z-10 border-2 border-accent bg-accent/20 ${
+            dropZoneClassName[dropZone]
+          }`}
         />
       )}
       {menu && (
@@ -104,7 +106,10 @@ export function TerminalPaneCard(props: IDockviewPanelProps<{ readonly sessionId
         onDragEnd={() => {
           drag.panelId = null;
         }}
-        className="flex cursor-grab flex-wrap items-center gap-2 border-b border-border px-2 py-1 text-[11px] active:cursor-grabbing"
+        className={
+          "flex cursor-grab flex-wrap items-center gap-2 border-b border-border px-2 py-1 text-[11px] " +
+          "active:cursor-grabbing"
+        }
       >
         <span className="truncate font-mono text-text-faint">
           {tab ? `${tab.name} · ${tab.cwd} · ${tab.backend} · ${tab.durability} · ${tab.state}` : sessionId}

--- a/packages/gui/src/renderer/components/terminal/TerminalPaneCard.tsx
+++ b/packages/gui/src/renderer/components/terminal/TerminalPaneCard.tsx
@@ -1,3 +1,5 @@
+import { useEffect, useRef, useState, type DragEvent, type MouseEvent } from "react";
+import { createPortal } from "react-dom";
 import type { IDockviewPanelProps } from "dockview-react";
 import { TerminalPane } from "./TerminalPane.tsx";
 import { ErrorBoundary } from "../ErrorBoundary.tsx";
@@ -9,6 +11,15 @@ const warningClassName = [
   "border-b border-status-blocked/30 bg-status-blocked/10",
   "px-2 py-1 text-[11px] text-status-blocked",
 ].join(" ");
+const splitDirections: readonly TerminalSplitDirection[] = ["left", "right", "above", "below"];
+/** 正在被拖的 pane;一个窗口同一时刻只有一场拖拽,不经 dataTransfer(happy-dom 里也能驱动)。 */
+const drag: { panelId: string | null } = { panelId: null };
+const dropZoneClassName: Record<TerminalSplitDirection, string> = {
+  left: "inset-y-0 left-0 w-1/2",
+  right: "inset-y-0 right-0 w-1/2",
+  above: "inset-x-0 top-0 h-1/2",
+  below: "inset-x-0 bottom-0 h-1/2",
+};
 
 /**
  * 一个 split pane 的完整外观:自带 header(会话元信息 + 分割/关闭/终止)与 xterm 面板。
@@ -23,6 +34,22 @@ export function TerminalPaneCard(props: IDockviewPanelProps<{ readonly sessionId
     sessionId = props.params.sessionId,
     tab = actions.session(sessionId),
     focused = actions.focusedPanelId === panelId;
+  const [dropZone, setDropZone] = useState<TerminalSplitDirection | null>(null);
+  const [menu, setMenu] = useState<{ readonly x: number; readonly y: number } | null>(null);
+  // 拖拽换位:标题栏是把手;别的 pane 的整张 card 是落点,按指针离哪条边最近分四个半区。
+  const onDragOver = (event: DragEvent<HTMLDivElement>) => {
+    if (!drag.panelId || drag.panelId === panelId) return;
+    event.preventDefault();
+    setDropZone(dropZoneOf(event, event.currentTarget));
+  };
+  const onDrop = (event: DragEvent<HTMLDivElement>) => {
+    const source = drag.panelId;
+    setDropZone(null);
+    if (!source || source === panelId) return;
+    event.preventDefault();
+    drag.panelId = null;
+    actions.onMovePane(source, panelId, dropZoneOf(event, event.currentTarget));
+  };
   return (
     <div
       data-testid="terminal-pane-card"
@@ -31,14 +58,54 @@ export function TerminalPaneCard(props: IDockviewPanelProps<{ readonly sessionId
       data-focused={focused ? "true" : "false"}
       onFocusCapture={() => actions.onFocusPane(panelId)}
       onMouseDownCapture={() => actions.onFocusPane(panelId)}
+      onDragOver={onDragOver}
+      onDragLeave={(event) => {
+        if (!event.currentTarget.contains(event.relatedTarget as Node | null)) setDropZone(null);
+      }}
+      onDrop={onDrop}
+      onContextMenu={(event) => {
+        event.preventDefault();
+        actions.onFocusPane(panelId);
+        setMenu({ x: event.clientX, y: event.clientY });
+      }}
       className={[
         // dockview 的 panel 宿主(dv-react-part)是 block、非 flex,flex-1 在这里不生效,card 会缩到
         // 内容高、底下露黑。用 h-full 填满宿主高度,再由内部 flex-col 把终端撑到整个 pane。
-        "flex h-full min-h-0 min-w-0 flex-col overflow-hidden",
+        "relative flex h-full min-h-0 min-w-0 flex-col overflow-hidden",
         focused ? "outline outline-1 -outline-offset-1 outline-accent/50" : "",
       ].join(" ")}
     >
-      <div className="flex flex-wrap items-center gap-2 border-b border-border px-2 py-1 text-[11px]">
+      {dropZone && (
+        <div
+          data-testid="terminal-pane-drop"
+          data-zone={dropZone}
+          className={`pointer-events-none absolute z-10 border-2 border-accent bg-accent/20 ${dropZoneClassName[dropZone]}`}
+        />
+      )}
+      {menu && (
+        <PaneMenu
+          at={menu}
+          onClose={() => setMenu(null)}
+          onSplit={(direction) => actions.onSplitPane(panelId, direction)}
+          onClosePane={() => actions.onClosePane(panelId, sessionId)}
+          onTerminate={tab ? () => actions.setConfirmSessionId(tab.sessionId) : null}
+        />
+      )}
+      <div
+        draggable
+        title={t("terminal.view.dragHandleTitle")}
+        onDragStart={(event) => {
+          drag.panelId = panelId;
+          if (event.dataTransfer) {
+            event.dataTransfer.effectAllowed = "move";
+            event.dataTransfer.setData("text/plain", panelId);
+          }
+        }}
+        onDragEnd={() => {
+          drag.panelId = null;
+        }}
+        className="flex cursor-grab flex-wrap items-center gap-2 border-b border-border px-2 py-1 text-[11px] active:cursor-grabbing"
+      >
         <span className="truncate font-mono text-text-faint">
           {tab ? `${tab.name} · ${tab.cwd} · ${tab.backend} · ${tab.durability} · ${tab.state}` : sessionId}
         </span>
@@ -120,9 +187,99 @@ function DeadPane({ panelId, sessionId }: { readonly panelId: string; readonly s
   );
 }
 
+function splitLabel(direction: TerminalSplitDirection): string {
+  switch (direction) {
+    case "left":
+      return t("terminal.view.splitLeft");
+    case "right":
+      return t("terminal.view.splitRight");
+    case "above":
+      return t("terminal.view.splitUp");
+    case "below":
+      return t("terminal.view.splitDown");
+  }
+}
+
+/** 指针离 card 哪条边最近,就落到那一侧;card 无尺寸(测试环境)时默认落右侧。 */
+function dropZoneOf(event: { readonly clientX: number; readonly clientY: number }, card: HTMLElement) {
+  const rect = card.getBoundingClientRect();
+  if (rect.width === 0 || rect.height === 0) return "right";
+  const x = (event.clientX - rect.left) / rect.width,
+    y = (event.clientY - rect.top) / rect.height;
+  const edges: readonly (readonly [TerminalSplitDirection, number])[] = [
+    ["left", x],
+    ["right", 1 - x],
+    ["above", y],
+    ["below", 1 - y],
+  ];
+  return edges.reduce((best, edge) => (edge[1] < best[1] ? edge : best))[0];
+}
+
+/** 右键菜单:portal 到 body 逃出 dockview 的 overflow 裁剪;点外面 / Esc / 选中任一项都关闭。 */
+function PaneMenu({
+  at,
+  onClose,
+  onSplit,
+  onClosePane,
+  onTerminate,
+}: {
+  readonly at: { readonly x: number; readonly y: number };
+  readonly onClose: () => void;
+  readonly onSplit: (direction: TerminalSplitDirection) => void;
+  readonly onClosePane: () => void;
+  readonly onTerminate: (() => void) | null;
+}) {
+  const ref = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    const onMouseDown = (event: globalThis.MouseEvent) => {
+      if (!ref.current?.contains(event.target as Node | null)) onClose();
+    };
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") onClose();
+    };
+    window.addEventListener("mousedown", onMouseDown, true);
+    window.addEventListener("keydown", onKeyDown, true);
+    return () => {
+      window.removeEventListener("mousedown", onMouseDown, true);
+      window.removeEventListener("keydown", onKeyDown, true);
+    };
+  }, [onClose]);
+  const pick = (action: () => void) => (event: MouseEvent<HTMLButtonElement>) => {
+    event.preventDefault();
+    onClose();
+    action();
+  };
+  const itemClassName = "block w-full rounded px-2 py-1 text-left text-text hover:bg-surface";
+  return createPortal(
+    <div
+      ref={ref}
+      role="menu"
+      aria-label={t("terminal.view.paneMenuAria")}
+      data-testid="terminal-pane-menu"
+      style={{ left: at.x, top: at.y }}
+      className="fixed z-50 min-w-40 rounded border border-border bg-surface-raised p-1 text-[12px] shadow-lg"
+    >
+      {splitDirections.map((direction) => (
+        <button key={direction} role="menuitem" onClick={pick(() => onSplit(direction))} className={itemClassName}>
+          {splitLabel(direction)}
+        </button>
+      ))}
+      <button role="menuitem" onClick={pick(onClosePane)} className={itemClassName}>
+        {t("terminal.view.closePane")}
+      </button>
+      {onTerminate && (
+        <button role="menuitem" onClick={pick(onTerminate)} className={`${itemClassName} text-status-blocked`}>
+          {t("terminal.view.terminate")}
+        </button>
+      )}
+    </div>,
+    document.body,
+  );
+}
+
 function SplitButton({ panelId, direction }: { readonly panelId: string; readonly direction: TerminalSplitDirection }) {
   const actions = useTerminalPaneActions();
-  const label = direction === "right" ? t("terminal.view.splitRight") : t("terminal.view.splitDown");
+  const label = splitLabel(direction);
   return (
     <button
       onClick={() => actions.onSplitPane(panelId, direction)}

--- a/packages/gui/src/renderer/components/terminal/terminal-pane-context.ts
+++ b/packages/gui/src/renderer/components/terminal/terminal-pane-context.ts
@@ -2,8 +2,8 @@ import { createContext, useContext } from "react";
 import type { TerminalTab } from "../../terminal-model.ts";
 import type { TerminalLinkMatch } from "./terminal-links.ts";
 
-/** 分割方向:right = 竖直分隔条(左右并排),below = 水平分隔条(上下叠放)。 */
-export type TerminalSplitDirection = "right" | "below";
+/** 分割/落位方向:新 pane(或被拖来的 pane)放到参照 pane 的哪一侧;与 dockview 的 Direction 同名。 */
+export type TerminalSplitDirection = "left" | "right" | "above" | "below";
 
 /**
  * pane 载荷与动作的注入面(PLT-TerminalWorkspace W1)。
@@ -22,6 +22,8 @@ export interface TerminalPaneActions {
   readonly onFocusPane: (panelId: string) => void;
   readonly onClosePane: (panelId: string, sessionId: string) => void;
   readonly onSplitPane: (panelId: string, direction: TerminalSplitDirection) => void;
+  /** 拖拽换位:把 panelId 挪到 targetPanelId 的 position 一侧(只在同一 tab 的 pane 树内)。 */
+  readonly onMovePane: (panelId: string, targetPanelId: string, position: TerminalSplitDirection) => void;
   readonly onTerminate: (sessionId: string) => void;
   /** W2 链接分发:match/text 来自 provider,cwd 是本 pane 会话的 daemon 侧工作目录。 */
   readonly openLink: (match: TerminalLinkMatch, text: string, cwd: string | null) => void;

--- a/packages/gui/src/renderer/i18n/locales/en-US/terminal.json
+++ b/packages/gui/src/renderer/i18n/locales/en-US/terminal.json
@@ -34,7 +34,7 @@
   "terminal.view.cancel": "Cancel",
   "terminal.view.confirmTerminate": "Confirm terminate",
   "terminal.view.terminate": "Terminate…",
-  "terminal.view.splitShortcut": "Ctrl+Shift+5/6 split · Ctrl+Shift+W close pane · Ctrl+Alt+Arrows focus",
+  "terminal.view.splitShortcut": "Ctrl+W close pane · Ctrl+Shift+Arrows split · Ctrl+Alt+Arrows focus · drag the title bar to rearrange · right-click for menu",
   "terminal.view.splitRight": "Split right",
   "terminal.view.splitDown": "Split down",
   "terminal.view.closePane": "Close pane",
@@ -43,5 +43,10 @@
   "terminal.view.groupPaneCount": "{count} panes",
   "terminal.view.findInTerminal": "Find in terminal",
   "terminal.view.noSearchMatch": "No match",
-  "terminal.view.closeSearch": "Close terminal search"
+  "terminal.view.closeSearch": "Close terminal search",
+  "terminal.view.splitShortcutMac": "⌘W close pane · ⌃⌘Arrows split · ⌃⌥Arrows focus · drag the title bar to rearrange · right-click for menu",
+  "terminal.view.splitLeft": "Split left",
+  "terminal.view.splitUp": "Split up",
+  "terminal.view.paneMenuAria": "Pane menu",
+  "terminal.view.dragHandleTitle": "Drag onto another pane to rearrange"
 }

--- a/packages/gui/src/renderer/i18n/locales/zh-CN/terminal.json
+++ b/packages/gui/src/renderer/i18n/locales/zh-CN/terminal.json
@@ -34,7 +34,7 @@
   "terminal.view.cancel": "取消",
   "terminal.view.confirmTerminate": "确认终止",
   "terminal.view.terminate": "终止…",
-  "terminal.view.splitShortcut": "Ctrl+Shift+5/6 分屏 · Ctrl+Shift+W 关 pane · Ctrl+Alt+方向键 切焦点",
+  "terminal.view.splitShortcut": "Ctrl+W 关 pane · Ctrl+Shift+方向键 分屏 · Ctrl+Alt+方向键 切焦点 · 拖标题栏换位 · 右键菜单",
   "terminal.view.splitRight": "向右分屏",
   "terminal.view.splitDown": "向下分屏",
   "terminal.view.closePane": "关闭 pane",
@@ -43,5 +43,10 @@
   "terminal.view.groupPaneCount": "{count} pane",
   "terminal.view.findInTerminal": "在终端中查找",
   "terminal.view.noSearchMatch": "没有匹配项",
-  "terminal.view.closeSearch": "关闭终端查找"
+  "terminal.view.closeSearch": "关闭终端查找",
+  "terminal.view.splitShortcutMac": "⌘W 关 pane · ⌃⌘方向键 分屏 · ⌃⌥方向键 切焦点 · 拖标题栏换位 · 右键菜单",
+  "terminal.view.splitLeft": "向左分屏",
+  "terminal.view.splitUp": "向上分屏",
+  "terminal.view.paneMenuAria": "pane 菜单",
+  "terminal.view.dragHandleTitle": "拖动到别的 pane 上换位"
 }

--- a/packages/gui/src/renderer/platform.ts
+++ b/packages/gui/src/renderer/platform.ts
@@ -1,0 +1,4 @@
+/** macOS 用 ⌘ 作主修饰键,其余平台用 Ctrl;快捷键表与提示文案都按这一判断分叉。 */
+export function isMacPlatform(nav: Pick<Navigator, "platform" | "userAgent"> = navigator): boolean {
+  return /^Mac/u.test(nav.platform) || /Macintosh/u.test(nav.userAgent);
+}

--- a/packages/gui/src/renderer/views/TerminalView.tsx
+++ b/packages/gui/src/renderer/views/TerminalView.tsx
@@ -31,6 +31,7 @@ import {
   type TerminalGroupLayout,
 } from "../terminal-layout.ts";
 import { directionalPane, type PaneBox, type PaneDirection } from "../terminal-pane-focus.ts";
+import { isMacPlatform } from "../platform.ts";
 import { terminalLinkTargetOf, type TerminalLinkMatch } from "../components/terminal/terminal-links.ts";
 import {
   TerminalChrome,
@@ -466,16 +467,27 @@ export function TerminalView({
     focusPaneInput(regionRef.current, target);
   }, []);
 
+  /** 拖拽换位:同一 tab 的 dockview 内,把 source pane 挪到 target pane 的某一侧;空掉的 group 由 dockview 回收。 */
+  const movePane = useCallback((panelId: string, targetPanelId: string, position: TerminalSplitDirection) => {
+    const api = gridApi.current;
+    const source = api?.getPanel(panelId),
+      target = api?.getPanel(targetPanelId);
+    if (!source || !target || source === target) return;
+    source.api.moveTo({ group: target.api.group, position: dockviewPosition(position) });
+    setFocusedPanelId(panelId);
+  }, []);
+
   // 分屏快捷键(与 useAppShortcuts 同一惯例:window keydown + preventDefault)。
-  // Ctrl+Shift+5/6 分割,Ctrl+Shift+W 关 pane,Ctrl+Alt+方向键 移动焦点。
+  // macOS:⌘W 关 pane、⌃⌘方向键 朝该方向分屏;其他平台:Ctrl+W 关 pane、Ctrl+Shift+方向键 分屏。
+  // 两边都用 Ctrl+Alt+方向键 切焦点。只在真的有动作时 preventDefault,没有焦点 pane 的 ⌘W 仍归窗口。
   useEffect(() => {
+    const mac = isMacPlatform();
     const onKey = (event: KeyboardEvent) => {
-      if (!event.ctrlKey) return;
       const arrow = arrowDirection(event.key);
-      if (event.shiftKey && ["5", "%"].includes(event.key)) run(event, () => splitFocused("right"));
-      else if (event.shiftKey && ["6", "^"].includes(event.key)) run(event, () => splitFocused("below"));
-      else if (event.shiftKey && event.key.toLowerCase() === "w") run(event, closeFocused);
-      else if (event.altKey && arrow) run(event, () => moveFocus(arrow));
+      if (arrow && event.ctrlKey && event.altKey && !event.metaKey) return run(event, () => moveFocus(arrow));
+      if (!(mac ? event.metaKey : event.ctrlKey)) return;
+      if (arrow && (mac ? event.ctrlKey : event.shiftKey)) run(event, () => splitFocused(splitDirectionOf(arrow)));
+      else if (event.key.toLowerCase() === "w" && !event.shiftKey && !event.altKey) closeFocused(event);
     };
     const run = (event: KeyboardEvent, action: () => void) => {
       event.preventDefault();
@@ -486,10 +498,10 @@ export function TerminalView({
       if (panelId) splitPane(panelId, direction);
       else void start(false);
     };
-    const closeFocused = () => {
+    const closeFocused = (event: KeyboardEvent) => {
       const panelId = focusedPanelIdRef.current;
       const sessionId = panelId ? sessionOfPane(groupsRef.current, panelId) : null;
-      if (panelId && sessionId) void closePane(panelId, sessionId);
+      if (panelId && sessionId) run(event, () => void closePane(panelId, sessionId));
     };
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
@@ -507,11 +519,25 @@ export function TerminalView({
       onFocusPane: focusPane,
       onClosePane: (panelId, sessionId) => void closePane(panelId, sessionId),
       onSplitPane: splitPane,
+      onMovePane: movePane,
       onTerminate: (sessionId) => void terminate(sessionId),
       openLink,
       openUrl: openUrl ?? null,
     }),
-    [closePane, confirmId, focusPane, focusedPanelId, openLink, openUrl, refit, send, splitPane, tabs, terminate],
+    [
+      closePane,
+      confirmId,
+      focusPane,
+      focusedPanelId,
+      movePane,
+      openLink,
+      openUrl,
+      refit,
+      send,
+      splitPane,
+      tabs,
+      terminate,
+    ],
   );
 
   return (
@@ -610,6 +636,12 @@ function paneBoxes(region: HTMLElement | null): readonly PaneBox[] {
 function focusPaneInput(region: HTMLElement | null, panelId: string): void {
   const host = region?.querySelector<HTMLElement>(`[data-pane-id="${panelId}"]`);
   host?.querySelector<HTMLTextAreaElement>("textarea")?.focus();
+}
+function splitDirectionOf(arrow: PaneDirection): TerminalSplitDirection {
+  return arrow === "up" ? "above" : arrow === "down" ? "below" : arrow;
+}
+function dockviewPosition(direction: TerminalSplitDirection): "left" | "right" | "top" | "bottom" {
+  return direction === "above" ? "top" : direction === "below" ? "bottom" : direction;
 }
 function arrowDirection(key: string): PaneDirection | null {
   const map: Record<string, PaneDirection> = {

--- a/packages/gui/test/terminal-split-grid.vitest.ts
+++ b/packages/gui/test/terminal-split-grid.vitest.ts
@@ -336,22 +336,22 @@ describe("terminal split panes (PLT-TerminalWorkspace W1)", () => {
     expect(tabChips()).toHaveLength(0);
   });
 
-  it("splits and closes the focused pane from the keyboard", async () => {
+  it("splits and closes the focused pane from the keyboard (Ctrl+Shift+Arrow / Ctrl+W off macOS)", async () => {
     const { bridge } = stubBridge([sessionRow()]);
     mountView();
     await flush();
 
-    // Ctrl+Shift+5 = 向右分屏(与 useAppShortcuts 同惯例:window keydown + preventDefault)。
+    // Ctrl+Shift+→ = 向右分屏(与 useAppShortcuts 同惯例:window keydown + preventDefault)。
     act(() => {
-      window.dispatchEvent(new KeyboardEvent("keydown", { key: "5", ctrlKey: true, shiftKey: true }));
+      window.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowRight", ctrlKey: true, shiftKey: true }));
     });
     await flush();
     expect(bridge.spawnTerminal).toHaveBeenCalledTimes(1);
     expect(panes()).toHaveLength(2);
 
-    // Ctrl+Shift+W 关掉当前焦点 pane(分屏后焦点落在新 pane 上)。
+    // Ctrl+W 关掉当前焦点 pane(分屏后焦点落在新 pane 上)。
     act(() => {
-      window.dispatchEvent(new KeyboardEvent("keydown", { key: "W", ctrlKey: true, shiftKey: true }));
+      window.dispatchEvent(new KeyboardEvent("keydown", { key: "w", ctrlKey: true }));
     });
     await flush();
     expect(panes().map((pane) => pane.dataset.sessionId)).toEqual(["s-restore"]);
@@ -360,6 +360,119 @@ describe("terminal split panes (PLT-TerminalWorkspace W1)", () => {
       sessionId: "s-split-1",
       attachmentId: "attach-s-split-1",
     });
+  });
+
+  it("uses ⌃⌘Arrow to split and ⌘W to close on macOS, leaving ⌘W to the window with no focused pane", async () => {
+    Object.defineProperty(navigator, "platform", { value: "MacIntel", configurable: true });
+    try {
+      const { bridge } = stubBridge([sessionRow()]);
+      mountView();
+      await flush();
+      act(() => {
+        window.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowDown", ctrlKey: true, metaKey: true }));
+      });
+      await flush();
+      expect(bridge.spawnTerminal).toHaveBeenCalledTimes(1);
+      expect(panes()).toHaveLength(2);
+      const close = new KeyboardEvent("keydown", { key: "w", metaKey: true, cancelable: true });
+      act(() => {
+        window.dispatchEvent(close);
+      });
+      await flush();
+      expect(close.defaultPrevented).toBe(true);
+      expect(panes()).toHaveLength(1);
+      act(() => {
+        window.dispatchEvent(new KeyboardEvent("keydown", { key: "w", metaKey: true, cancelable: true }));
+      });
+      await flush();
+      expect(panes()).toHaveLength(0);
+      // 没有焦点 pane 时 ⌘W 不再被本页吞掉,留给窗口。
+      const orphan = new KeyboardEvent("keydown", { key: "w", metaKey: true, cancelable: true });
+      act(() => {
+        window.dispatchEvent(orphan);
+      });
+      expect(orphan.defaultPrevented).toBe(false);
+    } finally {
+      Reflect.deleteProperty(navigator, "platform");
+    }
+  });
+
+  it("rearranges panes by dragging one pane's title bar onto another pane's edge", async () => {
+    stubBridge([sessionRow()]);
+    localStorage.setItem(layoutKey, JSON.stringify(storedLayout()));
+    mountView();
+    await flush();
+    const [left, right] = panes();
+    expect([left.dataset.sessionId, right.dataset.sessionId]).toEqual(["s-restore", "s-gone"]);
+    // 落点 card 在 happy-dom 里没有尺寸:给它一个 200×100 的盒子;指针在左缘 → 放到它左边。
+    const box = () =>
+      ({
+        left: 0,
+        top: 0,
+        width: 200,
+        height: 100,
+        right: 200,
+        bottom: 100,
+        x: 0,
+        y: 0,
+        toJSON: () => ({}),
+      }) as DOMRect;
+    right.getBoundingClientRect = box;
+    act(() => {
+      left.querySelector<HTMLElement>("[draggable]")!.dispatchEvent(new Event("dragstart", { bubbles: true }));
+      right.dispatchEvent(new MouseEvent("dragover", { bubbles: true, cancelable: true, clientX: 10, clientY: 50 }));
+    });
+    expect(right.querySelector<HTMLElement>('[data-testid="terminal-pane-drop"]')?.dataset.zone).toBe("left");
+    act(() => {
+      right.dispatchEvent(new MouseEvent("drop", { bubbles: true, cancelable: true, clientX: 10, clientY: 50 }));
+    });
+    await flush();
+    expect(panes().map((pane) => pane.dataset.sessionId)).toEqual(["s-restore", "s-gone"]);
+    // 再拖到右缘:两个 pane 交换位置(死会话占位 pane 一样可以当落点)。
+    const [a, b] = panes();
+    b.getBoundingClientRect = box;
+    act(() => {
+      a.querySelector<HTMLElement>("[draggable]")!.dispatchEvent(new Event("dragstart", { bubbles: true }));
+      b.dispatchEvent(new MouseEvent("drop", { bubbles: true, cancelable: true, clientX: 190, clientY: 50 }));
+    });
+    await flush();
+    expect(panes().map((pane) => pane.dataset.sessionId)).toEqual(["s-gone", "s-restore"]);
+    expect(document.querySelector('[data-testid="terminal-pane-drop"]')).toBeNull();
+  });
+
+  it("opens a right-click menu on a pane with split/close/terminate and closes it on Escape", async () => {
+    const { bridge } = stubBridge([sessionRow()]);
+    mountView();
+    await flush();
+    const [pane] = panes();
+    act(() => {
+      pane.dispatchEvent(new MouseEvent("contextmenu", { bubbles: true, cancelable: true, clientX: 40, clientY: 30 }));
+    });
+    const menu = document.querySelector<HTMLElement>('[data-testid="terminal-pane-menu"]');
+    expect(menu).not.toBeNull();
+    expect(menu!.style.left).toBe("40px");
+    expect([...menu!.querySelectorAll("[role=menuitem]")].map((item) => item.textContent)).toEqual([
+      "Split left",
+      "Split right",
+      "Split up",
+      "Split down",
+      "Close pane",
+      "Terminate…",
+    ]);
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+    });
+    expect(document.querySelector('[data-testid="terminal-pane-menu"]')).toBeNull();
+    act(() => {
+      pane.dispatchEvent(new MouseEvent("contextmenu", { bubbles: true, cancelable: true }));
+    });
+    act(() => {
+      document.querySelectorAll<HTMLButtonElement>('[data-testid="terminal-pane-menu"] [role=menuitem]')[2].click();
+    });
+    await flush();
+    expect(document.querySelector('[data-testid="terminal-pane-menu"]')).toBeNull();
+    expect(bridge.spawnTerminal).toHaveBeenCalledTimes(1);
+    expect(panes()).toHaveLength(2);
   });
 
   it("bans attaching one session into two panes by disabling it in the attach picker", async () => {


### PR DESCRIPTION
# English

## Summary

Terminal split panes get the interaction model the product owner asked for after using the terminal page:

- **Drag to rearrange**: each pane's existing title bar is a drag handle. Drop it on another pane and it lands on that pane's nearest edge (left / right / above / below); a half-pane highlight shows the target while dragging. Backed by dockview `panel.api.moveTo`, so the empty source group is collected and the layout snapshot persists as before.
- **Shortcuts**: on macOS `⌘W` closes the focused pane and `⌃⌘←/→/↑/↓` splits toward the arrow; elsewhere `Ctrl+W` and `Ctrl+Shift+Arrow`. `Ctrl+Alt+Arrow` still moves focus. `⌘W` is consumed only when a pane is focused, so it keeps reaching the window otherwise. The old `Ctrl+Shift+5/6/W` chords are removed.
- **Right-click menu** on a pane: split left/right/up/down, close pane, terminate (opens the existing confirm). Closes on Escape, outside click or selection; portaled to `body` so dockview's overflow does not clip it.
- The chrome's shortcut hint follows the platform (`⌘W 关 pane · ⌃⌘方向键 分屏 …` on macOS).

## What Changed

- `terminal-pane-context.ts`: `TerminalSplitDirection` is now `left | right | above | below`; new `onMovePane`.
- `TerminalView.tsx`: `movePane` (dockview `moveTo`), platform-aware shortcut table, `splitDirectionOf` / `dockviewPosition` helpers.
- `TerminalPaneCard.tsx`: draggable title bar, drop-zone computation + highlight, `PaneMenu` (portal), four-direction `splitLabel`.
- `TerminalChrome.tsx` + `platform.ts`: platform-aware hint; `isMacPlatform()`.
- i18n (zh-CN / en-US): `splitShortcut` reworded, new `splitShortcutMac`, `splitLeft`, `splitUp`, `paneMenuAria`, `dragHandleTitle`.
- `terminal-split-grid.vitest.ts`: keyboard test rewritten for the new chords (non-mac + mac, incl. `⌘W` pass-through with no focused pane), plus drag-to-rearrange and context-menu tests.

## Verification

- `vitest run test/terminal-split-grid.vitest.ts test/terminal-page.vitest.ts test/i18n-locale-parity.vitest.ts`: 23 passed.
- `tsc -b`, eslint, prettier clean on touched files.
- Live packaged-mode Electron (Playwright, real xterm): `⌃⌘→` then `⌃⌘↓` produced three panes at the expected positions; dragging pane A's title bar onto the right edge of pane B swapped them (A x 196→818, B x 818→196); right-click showed the six menu items and Escape dismissed it; `⌘W` with a focused pane removed only that pane and the window count stayed 1.

## Architectural Justification

Net +200 lines, all in the existing pane component and view; no new module, layer or state store. The pane tree stays dockview-owned: rearrange is expressed as one `moveTo` call on the existing API rather than a parallel layout model, and the drag handle reuses the title bar the pane already renders. The context menu is the only new UI element and it was explicitly requested; it is a local component in the same file, portaled only to escape overflow clipping. The platform helper is a three-line function shared by the shortcut table and the hint so the two cannot drift. Old chords were deleted rather than kept as aliases.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none

## Machine-Readable Declarations

Production-Delta: +221/-16

## Task And Scope

- Harness task: task_38514e01f4dafa2a792b798956 (child of PLT-TerminalWorkspace milestone task_d2985b723b87a2cf55aa24d6fe)
- Branch: codex/terminal-pane-ux
- Public scope: terminal pane interaction (renderer only)
- Private planning/evidence updated: yes
- Out of scope: cross-tab drags (panes only move within their tab's pane tree), an Electron application menu (none exists today; `⌘W` is handled in the renderer).

## Residual Risk

Drag uses native HTML5 drag events; dockview's own DnD stays disabled, so there is no second drop model to conflict with. If a drop lands on the source pane itself it is a no-op.

## Version Impact

- Version: no version change (renderer interaction only).
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none
- Authority: not applicable
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no

---

# 中文

## 摘要

终端分屏 pane 补上产品负责人试用后提出的交互模型:

- **拖拽换位**:每个 pane 现有的标题栏就是拖拽把手。拖到另一个 pane 上松手,就落到该 pane 离指针最近的一侧(左/右/上/下);拖动过程中用半个 pane 的高亮标出落点。底层走 dockview `panel.api.moveTo`,空出来的源 group 由 dockview 回收,布局快照照旧持久化。
- **快捷键**:macOS 上 `⌘W` 关焦点 pane,`⌃⌘←/→/↑/↓` 朝箭头方向分屏;其他平台 `Ctrl+W` 与 `Ctrl+Shift+方向键`。`Ctrl+Alt+方向键` 仍切焦点。`⌘W` 只在有焦点 pane 时被吞,否则照常交给窗口。旧的 `Ctrl+Shift+5/6/W` 一并删除。
- **右键菜单**:向左/右/上/下分屏、关闭 pane、终止(走现有确认)。Esc / 点外面 / 选中任一项即关闭;portal 到 `body`,不被 dockview 的 overflow 裁掉。
- 顶栏快捷键提示按平台显示(macOS 显示 `⌘W 关 pane · ⌃⌘方向键 分屏 …`)。

## 变更内容

- `terminal-pane-context.ts`:`TerminalSplitDirection` 扩成 `left | right | above | below`;新增 `onMovePane`。
- `TerminalView.tsx`:`movePane`(dockview `moveTo`)、按平台分叉的快捷键表、`splitDirectionOf` / `dockviewPosition`。
- `TerminalPaneCard.tsx`:可拖标题栏、落点计算与高亮、`PaneMenu`(portal)、四向 `splitLabel`。
- `TerminalChrome.tsx` + `platform.ts`:按平台的提示;`isMacPlatform()`。
- i18n(zh-CN / en-US):`splitShortcut` 改写,新增 `splitShortcutMac`、`splitLeft`、`splitUp`、`paneMenuAria`、`dragHandleTitle`。
- `terminal-split-grid.vitest.ts`:键盘测试按新和弦重写(非 mac + mac,含无焦点 pane 时 `⌘W` 放行),新增拖拽换位与右键菜单测试。

## 验证

- `vitest run test/terminal-split-grid.vitest.ts test/terminal-page.vitest.ts test/i18n-locale-parity.vitest.ts`:23 项通过。
- 触碰文件 `tsc -b`、eslint、prettier 干净。
- 打包态 Electron 真机(Playwright,真 xterm):`⌃⌘→` 再 `⌃⌘↓` 得到三个位置正确的 pane;把 A 的标题栏拖到 B 的右缘后两者互换(A x 196→818,B x 818→196);右键出现六个菜单项、Esc 关闭;有焦点 pane 时 `⌘W` 只移除该 pane,窗口数仍为 1。

## 架构辩护

净增约 200 行,全部落在既有的 pane 组件与视图内;没有新模块、新层或新状态仓。pane 树仍由 dockview 持有:换位表达为既有 API 的一次 `moveTo`,不另造一套平行布局模型;拖拽把手复用 pane 本来就画的标题栏。右键菜单是唯一新增的 UI 元素,且是明确要求的;它是同文件里的局部组件,portal 仅为逃出 overflow 裁剪。平台判断是快捷键表与提示共用的三行函数,两者不会漂移。旧和弦直接删除,不留别名。

## 任务与范围

- Harness 任务:task_38514e01f4dafa2a792b798956(PLT-TerminalWorkspace 里程碑 task_d2985b723b87a2cf55aa24d6fe 的子任务)
- 分支:codex/terminal-pane-ux
- 公开范围:终端 pane 交互(仅 renderer)
- 私有规划/证据已更新:是
- 不在范围:跨 tab 拖拽(pane 只在本 tab 的 pane 树内移动)、Electron 应用菜单(目前没有;`⌘W` 在 renderer 处理)。

## 残余风险

拖拽用原生 HTML5 drag 事件,dockview 自身 DnD 仍关闭,不存在第二套落点模型互相打架。落回源 pane 自身是 no-op。

## 版本影响

- 版本:不变(仅 renderer 交互)。
- 发布影响:不发布

🤖 Generated with [Claude Code](https://claude.com/claude-code)
