### PR TITLE
feat(gui): searchable task picker for terminal binding and open-terminal from task detail

### DIFF
--- a/packages/gui/src/renderer/App.tsx
+++ b/packages/gui/src/renderer/App.tsx
@@ -49,7 +49,7 @@ import { useDecisionActions } from "./decision-actions.ts";
 import { selectActiveRepoId, useSystemStatusQuery } from "./system-data.ts";
 import { useCatalogSnapshot } from "./catalog-data.ts";
 import { adaptRepoProject } from "./model/project-adapter.ts";
-import { TerminalView } from "./views/TerminalView.tsx";
+import { TerminalView, type TerminalLaunchTask } from "./views/TerminalView.tsx";
 import { BrowserView } from "./views/BrowserView.tsx";
 import { NavigationHistoryBar } from "./components/NavigationHistoryBar.tsx";
 import { useViewHistory } from "./navigation/useViewHistory.ts";
@@ -161,6 +161,8 @@ function AppShell() {
   const { openLocalDocument } = useLocalDocOpener();
 
   const projectTasks = useMemo(() => tasks.filter((t) => t.projectId === projectId), [tasks, projectId]);
+  /** task 详情「打开终端」→ 终端页进页即建绑定会话;requestId 让同一请求只消费一次。 */
+  const [terminalLaunch, setTerminalLaunch] = useState<TerminalLaunchTask | null>(null);
   const selected = useMemo(() => tasks.find((t) => t.taskId === selectedId) ?? null, [tasks, selectedId]);
   const previewTask = useMemo(() => tasks.find((t) => t.taskId === previewId) ?? null, [previewId, tasks]);
   const filteredProjectTasks = useMemo(
@@ -413,6 +415,11 @@ function AppShell() {
                 onSetPin={(task, pinned) => {
                   void taskActions.setTaskPin(task, pinned);
                 }}
+                onOpenTerminal={(task) => {
+                  setTerminalLaunch({ requestId: crypto.randomUUID(), taskId: task.taskId, title: task.title });
+                  updateLocation({ selectedId: null });
+                  goto("terminal");
+                }}
                 onFocusGraph={focusEntityInGraph}
               />
             ) : view === "home" ? (
@@ -644,6 +651,7 @@ function AppShell() {
                 repoId={projectId}
                 daemonGeneration={activeRepo?.generation ?? null}
                 tasks={projectTasks.map(({ taskId, title }) => ({ taskId, title }))}
+                launchTask={terminalLaunch}
                 repoRoot={activeRepo?.canonicalRoot ?? null}
                 onNavigateEntity={navigateToEntity}
                 onOpenDocument={openLocalDocument}

--- a/packages/gui/src/renderer/components/terminal/TerminalChrome.tsx
+++ b/packages/gui/src/renderer/components/terminal/TerminalChrome.tsx
@@ -3,6 +3,7 @@ import type { TerminalSessionRow } from "../../../../../daemon/src/gui-s3-contro
 import type { TerminalPreferences } from "../../terminal-preferences.ts";
 import { t } from "../../i18n/index.tsx";
 import { isMacPlatform } from "../../platform.ts";
+import { TerminalTaskPicker } from "./TerminalTaskPicker.tsx";
 
 const shellOptions = ["default", "zsh", "bash", "sh", "fish"] as const;
 
@@ -195,19 +196,7 @@ export function TerminalChrome({
             </select>
           </Field>
           <Field label={t("terminal.view.task")}>
-            <select
-              value={spawn.taskId}
-              onChange={(event) => onSpawnChange({ taskId: event.target.value })}
-              className="control max-w-44"
-            >
-              <option value="">{t("terminal.view.unbound")}</option>
-              {tasks.map((task) => (
-                // G10:实体 ID 不落在不可激活文本里;taskId 走机器值/tooltip,文本用标题。
-                <option key={task.taskId} value={task.taskId} title={task.taskId}>
-                  {task.title}
-                </option>
-              ))}
-            </select>
+            <TerminalTaskPicker tasks={tasks} value={spawn.taskId} onChange={(taskId) => onSpawnChange({ taskId })} />
           </Field>
           <button className="rounded border border-accent/60 bg-accent/10 px-3 py-1 text-[12px] text-text">
             {t("terminal.view.startCustom")}

--- a/packages/gui/src/renderer/components/terminal/TerminalTaskPicker.tsx
+++ b/packages/gui/src/renderer/components/terminal/TerminalTaskPicker.tsx
@@ -1,0 +1,135 @@
+import { useEffect, useMemo, useRef, useState, type KeyboardEvent } from "react";
+import { t } from "../../i18n/index.tsx";
+
+export interface TerminalTaskOption {
+  readonly taskId: string;
+  readonly title: string;
+}
+
+/** 一次最多列多少条;超过就提示继续输入缩小范围,几千个 task 不进 DOM。 */
+const listLimit = 40;
+
+/**
+ * task 绑定选择器:可检索 combobox,取代原来的 <select>(几千个 task 的下拉不可用)。
+ *
+ * - 关闭态显示当前绑定的 task 标题(没绑定显示占位),点/聚焦即打开并以输入内容过滤
+ *   (标题 + taskId 子串,大小写不敏感)。
+ * - 列表首项永远是「不绑定」;↑/↓ 移动,Enter 选中,Esc 关闭;点选用 mousedown
+ *   防止 input 先失焦把列表收起。
+ */
+export function TerminalTaskPicker({
+  tasks,
+  value,
+  onChange,
+}: {
+  readonly tasks: readonly TerminalTaskOption[];
+  readonly value: string;
+  readonly onChange: (taskId: string) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const [active, setActive] = useState(0);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const selected = useMemo(() => tasks.find((task) => task.taskId === value) ?? null, [tasks, value]);
+  const matches = useMemo(() => filterTasks(tasks, query), [tasks, query]);
+  const shown = matches.slice(0, listLimit);
+  useEffect(() => setActive(0), [query, open]);
+
+  const pick = (taskId: string) => {
+    onChange(taskId);
+    setOpen(false);
+    setQuery("");
+  };
+  const onKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    if (!open) {
+      if (event.key === "ArrowDown" || event.key === "Enter") setOpen(true);
+      return;
+    }
+    if (event.key === "Escape") setOpen(false);
+    else if (event.key === "ArrowDown") setActive((index) => Math.min(index + 1, shown.length));
+    else if (event.key === "ArrowUp") setActive((index) => Math.max(index - 1, 0));
+    else if (event.key === "Enter") pick(active === 0 ? "" : (shown[active - 1]?.taskId ?? ""));
+    else return;
+    event.preventDefault();
+  };
+  const optionClassName = (index: number) =>
+    `flex w-full flex-col items-start rounded px-2 py-1 text-left ${index === active ? "bg-surface" : ""}`;
+
+  return (
+    <div className="relative">
+      <input
+        ref={inputRef}
+        role="combobox"
+        aria-expanded={open}
+        aria-autocomplete="list"
+        aria-controls="terminal-task-picker-list"
+        data-testid="terminal-task-picker"
+        value={open ? query : (selected?.title ?? "")}
+        placeholder={open ? t("terminal.view.taskPickerPlaceholder") : t("terminal.view.unbound")}
+        title={selected?.taskId}
+        onFocus={() => setOpen(true)}
+        onClick={() => setOpen(true)}
+        onBlur={() => setOpen(false)}
+        onChange={(event) => {
+          setQuery(event.target.value);
+          setOpen(true);
+        }}
+        onKeyDown={onKeyDown}
+        className="control w-56"
+      />
+      {open && (
+        <div
+          id="terminal-task-picker-list"
+          role="listbox"
+          data-testid="terminal-task-picker-list"
+          className={
+            "absolute left-0 top-full z-40 mt-1 max-h-72 w-[28rem] max-w-[80vw] overflow-y-auto rounded " +
+            "border border-border-strong bg-surface-raised p-1 text-[12px] shadow-2xl"
+          }
+        >
+          <button
+            type="button"
+            role="option"
+            aria-selected={active === 0}
+            onMouseDown={(event) => event.preventDefault()}
+            onMouseEnter={() => setActive(0)}
+            onClick={() => pick("")}
+            className={`${optionClassName(0)} text-text-muted`}
+          >
+            {t("terminal.view.unbound")}
+          </button>
+          {shown.map((task, index) => (
+            <button
+              key={task.taskId}
+              type="button"
+              role="option"
+              aria-selected={active === index + 1}
+              onMouseDown={(event) => event.preventDefault()}
+              onMouseEnter={() => setActive(index + 1)}
+              onClick={() => pick(task.taskId)}
+              className={optionClassName(index + 1)}
+            >
+              <span className="w-full truncate text-text">{task.title}</span>
+              {/* G10:实体 id 只作辅助文本,标题才是可读主体。 */}
+              <span className="font-mono text-[10px] text-text-faint">{task.taskId}</span>
+            </button>
+          ))}
+          {matches.length === 0 && <p className="px-2 py-2 text-text-faint">{t("terminal.view.taskPickerEmpty")}</p>}
+          {matches.length > shown.length && (
+            <p className="px-2 py-1 text-[11px] text-text-faint">
+              {t("terminal.view.taskPickerMore", { count: matches.length - shown.length })}
+            </p>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function filterTasks(tasks: readonly TerminalTaskOption[], query: string): TerminalTaskOption[] {
+  const needle = query.trim().toLowerCase();
+  if (!needle) return [...tasks];
+  return tasks.filter(
+    (task) => task.title.toLowerCase().includes(needle) || task.taskId.toLowerCase().includes(needle),
+  );
+}

--- a/packages/gui/src/renderer/i18n/locales/en-US/terminal.json
+++ b/packages/gui/src/renderer/i18n/locales/en-US/terminal.json
@@ -48,5 +48,8 @@
   "terminal.view.splitLeft": "Split left",
   "terminal.view.splitUp": "Split up",
   "terminal.view.paneMenuAria": "Pane menu",
-  "terminal.view.dragHandleTitle": "Drag onto another pane to rearrange"
+  "terminal.view.dragHandleTitle": "Drag onto another pane to rearrange",
+  "terminal.view.taskPickerPlaceholder": "Search task title or id…",
+  "terminal.view.taskPickerEmpty": "No matching task",
+  "terminal.view.taskPickerMore": "{count} more — keep typing to narrow down"
 }

--- a/packages/gui/src/renderer/i18n/locales/en-US/views.json
+++ b/packages/gui/src/renderer/i18n/locales/en-US/views.json
@@ -685,5 +685,6 @@
   "views.overviewView.statsRevisionUnknown": "ledger cut not read yet, revision pair unknown",
   "views.overviewView.statsAnomalyDaemon": "daemon unresponsive",
   "views.overviewView.statsAnomalyProjection": "projection behind by {lag}",
-  "views.overviewView.statsAnomalyRead": "read failed"
+  "views.overviewView.statsAnomalyRead": "read failed",
+  "views.taskDetailView.openTerminal": "Open terminal"
 }

--- a/packages/gui/src/renderer/i18n/locales/zh-CN/terminal.json
+++ b/packages/gui/src/renderer/i18n/locales/zh-CN/terminal.json
@@ -48,5 +48,8 @@
   "terminal.view.splitLeft": "向左分屏",
   "terminal.view.splitUp": "向上分屏",
   "terminal.view.paneMenuAria": "pane 菜单",
-  "terminal.view.dragHandleTitle": "拖动到别的 pane 上换位"
+  "terminal.view.dragHandleTitle": "拖动到别的 pane 上换位",
+  "terminal.view.taskPickerPlaceholder": "搜索 task 标题或 id…",
+  "terminal.view.taskPickerEmpty": "无匹配 task",
+  "terminal.view.taskPickerMore": "还有 {count} 个,继续输入缩小范围"
 }

--- a/packages/gui/src/renderer/i18n/locales/zh-CN/views.json
+++ b/packages/gui/src/renderer/i18n/locales/zh-CN/views.json
@@ -685,5 +685,6 @@
   "views.overviewView.statsRevisionUnknown": "台账切面尚未读到,版本对未知",
   "views.overviewView.statsAnomalyDaemon": "daemon 无响应",
   "views.overviewView.statsAnomalyProjection": "投影落后 {lag}",
-  "views.overviewView.statsAnomalyRead": "读失败"
+  "views.overviewView.statsAnomalyRead": "读失败",
+  "views.taskDetailView.openTerminal": "打开终端"
 }

--- a/packages/gui/src/renderer/views/TaskDetailView.tsx
+++ b/packages/gui/src/renderer/views/TaskDetailView.tsx
@@ -9,6 +9,7 @@ import {
   PushPin,
   SealCheck,
   ShareNetwork,
+  TerminalWindow,
 } from "@phosphor-icons/react";
 import type { GuiSubmissionV1 } from "../../api/renderer-dto.ts";
 import { EngineBadge, FreshnessTag, StatusBadge } from "../components/badges.tsx";
@@ -53,6 +54,7 @@ export function TaskDetailView({
   fromViewLabel = t("views.taskDetailView.workspace"),
   onNavigateDecision,
   onNavigateEntity,
+  onOpenTerminal,
   mutationFeedback,
   onProgress,
   onSubmit,
@@ -71,6 +73,8 @@ export function TaskDetailView({
   /** G10 实体互链:详情页内出现的其他实体 ID 必须有路;必填,不给回调就没有路。 */
   onNavigateDecision: (decisionId: string) => void;
   onNavigateEntity: (ref: string) => void;
+  /** 「打开终端」:在终端页建一个绑定本 task 的会话(App 负责切页与建会话)。 */
+  onOpenTerminal?: (task: TaskRow) => void;
   mutationFeedback?: TaskMutationFeedback;
   onProgress?: (input: {
     text: string;
@@ -147,6 +151,21 @@ export function TaskDetailView({
             <span className="whitespace-nowrap">
               <EngineBadge engine={task.engine} locked={external} />
             </span>
+            {onOpenTerminal && (
+              <button
+                type="button"
+                data-testid="task-detail-open-terminal"
+                onClick={() => onOpenTerminal(task)}
+                title={t("views.taskDetailView.openTerminal")}
+                className={[
+                  "flex shrink-0 items-center gap-1 rounded-md border border-border px-1.5 py-1 font-mono text-[10px]",
+                  "text-text-faint hover:border-border-strong hover:text-text-muted",
+                ].join(" ")}
+              >
+                <TerminalWindow weight="bold" />
+                {t("views.taskDetailView.openTerminal")}
+              </button>
+            )}
             {onSetPin ? (
               <button
                 type="button"

--- a/packages/gui/src/renderer/views/TerminalView.tsx
+++ b/packages/gui/src/renderer/views/TerminalView.tsx
@@ -74,6 +74,13 @@ interface Props {
   readonly onOpenDocument: (path: string) => void;
   /** URL 打开接缝(W3 内嵌浏览器接线点);缺省走 web-links 默认行为(新窗口)。 */
   readonly openUrl?: (uri: string) => void;
+  /** 从 task 详情「打开终端」进来:进页即按该 task 建一个绑定会话;requestId 防 StrictMode 双跑。 */
+  readonly launchTask?: TerminalLaunchTask | null;
+}
+export interface TerminalLaunchTask {
+  readonly requestId: string;
+  readonly taskId: string;
+  readonly title: string;
 }
 type AttachRow = Pick<
   TerminalSessionRow,
@@ -98,6 +105,7 @@ export function TerminalView({
   daemonGeneration,
   tasks,
   repoRoot,
+  launchTask = null,
   onNavigateEntity,
   onOpenDocument,
   openUrl,
@@ -266,21 +274,21 @@ export function TerminalView({
   );
 
   const start = useCallback(
-    async (custom: boolean, placement: Placement = { kind: "group" }) => {
+    async (custom: boolean, placement: Placement = { kind: "group" }, draft: TerminalSpawnDraft = spawn) => {
       setError(null);
       const cwd: TerminalSpawnInput["cwd"] =
-        custom && spawn.cwdScope === "repo-relative"
-          ? { scope: "repo-relative", path: spawn.path }
+        custom && draft.cwdScope === "repo-relative"
+          ? { scope: "repo-relative", path: draft.path }
           : { scope: "repo-root" };
-      const name = custom ? spawn.name : t("terminal.view.title");
+      const name = custom ? draft.name : t("terminal.view.title");
       try {
         const receipt = await terminalClient.spawn(repoId, {
           idempotencyKey: `terminal-gui-${crypto.randomUUID()}`,
           backend: preferences.backend,
           name: name || undefined,
           cwd,
-          shellProfileId: custom ? spawn.shellProfileId || undefined : "default",
-          taskId: custom ? spawn.taskId || undefined : undefined,
+          shellProfileId: custom ? draft.shellProfileId || undefined : "default",
+          taskId: custom ? draft.taskId || undefined : undefined,
         });
         if (receipt.outcome !== "applied" || !receipt.sessionId)
           throw new Error(
@@ -303,6 +311,15 @@ export function TerminalView({
     },
     [attach, preferences.backend, queryClient, repoId, spawn],
   );
+  // task 详情「打开终端」:同一 requestId 只处理一次(StrictMode 双跑 / 父组件重渲染都不重复建会话)。
+  const launchedRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (!launchTask || launchedRef.current === launchTask.requestId) return;
+    launchedRef.current = launchTask.requestId;
+    const draft = { ...spawn, taskId: launchTask.taskId, name: launchTask.title.slice(0, 48) };
+    setSpawn(draft);
+    void start(true, { kind: "group" }, draft);
+  }, [launchTask, spawn, start]);
 
   useEffect(() => {
     if (generation !== null && generation !== undefined)
@@ -328,8 +345,8 @@ export function TerminalView({
     }
     const restored = mostRecentAttachableTerminal(sessions.data.sessions);
     if (restored) attach(restored, 0);
-    else void start(false);
-  }, [attach, attachStream, repoId, sessions.data, sessions.isSuccess, start]);
+    else if (!launchTask) void start(false); // 带 launchTask 进页时由它建绑定会话,不再另开一个未绑定的。
+  }, [attach, attachStream, launchTask, repoId, sessions.data, sessions.isSuccess, start]);
 
   const create = (event: FormEvent) => {
     event.preventDefault();

--- a/packages/gui/test/task-detail-expression.vitest.ts
+++ b/packages/gui/test/task-detail-expression.vitest.ts
@@ -222,6 +222,22 @@ afterEach(async () => {
 });
 
 describe("Task detail expression", () => {
+  it("offers an open-terminal action in the header only when the app wires one", async () => {
+    await mount();
+    expect(document.querySelector('[data-testid="task-detail-open-terminal"]')).toBeNull();
+    const opened: TaskRow[] = [];
+    onOpenTerminal = (row) => opened.push(row);
+    try {
+      await mount();
+      const button = document.querySelector<HTMLButtonElement>('[data-testid="task-detail-open-terminal"]');
+      expect(button?.textContent).toContain("打开终端");
+      await act(async () => button!.click());
+      expect(opened.map((row) => row.taskId)).toEqual([task.taskId]);
+    } finally {
+      onOpenTerminal = undefined;
+    }
+  });
+
   it("renders compact task identity, six task-first tabs and a permanent document tree", async () => {
     const bridge = installBridge();
     await mount();
@@ -563,6 +579,8 @@ function installBridge({ uncommittedPlan = false }: { readonly uncommittedPlan?:
   return bridge;
 }
 
+let onOpenTerminal: ((task: TaskRow) => void) | undefined;
+
 async function mount() {
   const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   const container = document.createElement("div"),
@@ -583,6 +601,7 @@ async function mount() {
           onSelect: () => undefined,
           onNavigateDecision: () => undefined,
           onNavigateEntity: () => undefined,
+          onOpenTerminal,
           projectName: "Harness",
         }),
       ),

--- a/packages/gui/test/terminal-page.vitest.ts
+++ b/packages/gui/test/terminal-page.vitest.ts
@@ -351,6 +351,81 @@ describe("Ctrl+` shortcut wiring", () => {
   });
 });
 
+/** 受控 input:必须走原生 value setter 再派 input,否则 React 的 value tracker 会把事件当无变化吞掉。 */
+function typeInto(input: HTMLInputElement, value: string) {
+  Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")!.set!.call(input, value);
+  input.dispatchEvent(new Event("input", { bubbles: true }));
+}
+
+describe("task binding (searchable picker + open-from-task-detail)", () => {
+  const manyTasks = Array.from({ length: 300 }, (_, index) => ({
+    taskId: `task_${String(index).padStart(4, "0")}`,
+    title: index === 42 ? "Fix xterm colour palette" : `Task number ${index}`,
+  }));
+
+  it("filters thousands of tasks by title or id and binds the picked one to the custom launch", async () => {
+    const { bridge } = stubBridge([sessionRow()], null); // 已有会话 → 进页只附加,不自动 spawn。
+    mountView({ repoId: "repo-a", daemonGeneration: null, tasks: manyTasks });
+    await flush();
+    const picker = container!.querySelector<HTMLInputElement>('[data-testid="terminal-task-picker"]')!;
+    act(() => picker.focus());
+    // 打开后只列前 40 条,余量用提示承接,几千个 option 不进 DOM。
+    expect(container!.querySelectorAll('[role="option"]')).toHaveLength(41);
+    expect(container!.textContent).toContain("260");
+    act(() => typeInto(picker, "colour"));
+    const options = [...container!.querySelectorAll<HTMLButtonElement>('[role="option"]')];
+    expect(options.map((option) => option.textContent)).toEqual(["unbound", "Fix xterm colour palettetask_0042"]);
+    act(() => options[1].click());
+    expect(picker.value).toBe("Fix xterm colour palette");
+    expect(picker.title).toBe("task_0042");
+    act(() => typeInto(picker, "task_00"));
+    expect(container!.querySelectorAll('[role="option"]')).toHaveLength(41);
+    act(() => picker.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true })));
+    expect(container!.querySelector('[data-testid="terminal-task-picker-list"]')).toBeNull();
+    const form = picker.closest("form")!;
+    act(() => form.requestSubmit());
+    await flush();
+    expect(bridge.spawnTerminal).toHaveBeenCalledTimes(1);
+    expect(bridge.spawnTerminal.mock.calls[0][0]).toMatchObject({ taskId: "task_0042" });
+  });
+
+  it("spawns one session bound to the launch task when entered from task detail, even under StrictMode", async () => {
+    const { bridge } = stubBridge([], null);
+    const launchTask = { requestId: "req-1", taskId: "task_0042", title: "Fix xterm colour palette" };
+    container = document.createElement("div");
+    document.body.append(container);
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    root = createRoot(container);
+    act(() => {
+      root!.render(
+        createElement(
+          StrictMode,
+          null,
+          createElement(
+            QueryClientProvider,
+            { client },
+            createElement(TerminalView, {
+              repoId: "repo-a",
+              daemonGeneration: null,
+              tasks: manyTasks,
+              repoRoot: null,
+              launchTask,
+              onNavigateEntity: () => undefined,
+              onOpenDocument: () => undefined,
+            }),
+          ),
+        ),
+      );
+    });
+    await flush();
+    expect(bridge.spawnTerminal).toHaveBeenCalledTimes(1);
+    expect(bridge.spawnTerminal.mock.calls[0][0]).toMatchObject({
+      taskId: "task_0042",
+      name: "Fix xterm colour palette",
+    });
+  });
+});
+
 describe("terminal links dispatch (PLT-TerminalWorkspace W2)", () => {
   function attachBridge() {
     return stubBridge([sessionRow()], {


### PR DESCRIPTION
# English

## Summary

Binding a terminal to a task went through a plain `<select>` listing every project task. With thousands of tasks that control is unusable. This PR replaces it with a searchable picker and adds a direct entry from the task itself.

- **Searchable task picker** in the terminal launch options: a combobox that filters by title or task id as you type, shows at most 40 matches (plus a "N more, keep typing" hint), is keyboard-navigable (↑/↓/Enter/Esc) and always offers "unbound" as the first option. Thousands of tasks never enter the DOM.
- **Open terminal from task detail**: a header action on the task detail page switches to the terminal page and spawns a session bound to that task, named after the task. A request id makes the launch idempotent (StrictMode double effects, re-renders), and the page skips its default unbound auto-start when it is entered this way.

## What Changed

- `components/terminal/TerminalTaskPicker.tsx` (new): the combobox + `filterTasks`.
- `components/terminal/TerminalChrome.tsx`: `<select>` → `<TerminalTaskPicker>`.
- `views/TerminalView.tsx`: `launchTask` prop consumed once per request id; `start()` accepts a draft override; auto-start is skipped under `launchTask`.
- `views/TaskDetailView.tsx`: optional `onOpenTerminal` + header button (rendered only when wired).
- `App.tsx`: `terminalLaunch` state, wires detail → terminal.
- i18n (zh-CN / en-US): picker placeholder / empty / more, `views.taskDetailView.openTerminal`.
- Tests: `terminal-page.vitest.ts` (picker filters 300 tasks, caps at 40, picks by keyboard, submits with the chosen taskId; launchTask spawns exactly one bound session under StrictMode), `task-detail-expression.vitest.ts` (open-terminal action present only when wired and calls back with the task).

## Verification

- `vitest run terminal-page terminal-split-grid task-detail-expression i18n-locale-parity`: 30 passed. `tsc -b`, eslint, prettier, line-density clean.
- Live packaged-mode Electron (Playwright): picker opened with 41 options, typing `knowledge` narrowed to 3, ↓↓Enter picked the second one and the input showed its title with the id as tooltip. Board card → preview → detail → "打开终端" switched to the terminal page with a new tab named after the task and a live xterm.

## Architectural Justification

Net +168 lines. The picker is one self-contained component with no shared state; the launch path reuses the existing `start()` by letting it take a draft instead of reading component state, and is keyed by a request id rather than adding a second spawn path. No new store, layer or module boundary; the `<select>` is deleted, not kept as a fallback.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none

## Machine-Readable Declarations

Production-Delta: +190/-22

## Task And Scope

- Harness task: task_38514e01f4dafa2a792b798956 (child of PLT-TerminalWorkspace milestone task_d2985b723b87a2cf55aa24d6fe)
- Branch: codex/terminal-task-picker
- Public scope: terminal launch form, task detail header action, App wiring (renderer only)
- Private planning/evidence updated: yes
- Out of scope: a right-click "open terminal" on board cards (the detail-page action covers the ask; board cards already have a preview drawer that leads to detail).

## Residual Risk

The picker filters on the client over the in-memory task list already held by the app, so no new query path; with very large lists the filter is a linear scan per keystroke, which is fine at the thousands scale.

## Version Impact

- Version: no version change (renderer interaction only).
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none
- Authority: not applicable
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no

---

# 中文

## 摘要

终端绑定 task 原来走一个列出全部项目 task 的 `<select>`,几千个 task 时根本没法用。本 PR 换成可检索选择器,并从 task 自身加一个直达入口。

- **可检索 task 选择器**(终端高级启动选项):combobox,输入即按标题或 task id 过滤,最多列 40 条(多余的用「还有 N 个,继续输入缩小范围」承接),↑/↓/Enter/Esc 键盘可用,首项永远是「未绑定」。几千个 task 不进 DOM。
- **从 task 详情打开终端**:详情页头部加一个动作,切到终端页并直接建一个绑定该 task、以 task 标题命名的会话。requestId 让这次启动幂等(StrictMode 双跑 / 重渲染不重复建),这种进页方式下终端页跳过默认的未绑定自动启动。

## 变更内容

- `components/terminal/TerminalTaskPicker.tsx`(新):combobox + `filterTasks`。
- `components/terminal/TerminalChrome.tsx`:`<select>` → `<TerminalTaskPicker>`。
- `views/TerminalView.tsx`:`launchTask` prop 按 requestId 只消费一次;`start()` 接受 draft 覆盖;`launchTask` 下跳过自动启动。
- `views/TaskDetailView.tsx`:可选 `onOpenTerminal` + 头部按钮(只在接线时渲染)。
- `App.tsx`:`terminalLaunch` 状态,把详情接到终端页。
- i18n(zh-CN / en-US):选择器占位 / 空态 / 余量提示,`views.taskDetailView.openTerminal`。
- 测试:`terminal-page.vitest.ts`(300 个 task 过滤、上限 40、键盘选中、提交带所选 taskId;StrictMode 下 launchTask 恰好建一个绑定会话),`task-detail-expression.vitest.ts`(仅接线时出现动作并回调该 task)。

## 验证

- `vitest run terminal-page terminal-split-grid task-detail-expression i18n-locale-parity`:30 项通过。`tsc -b`、eslint、prettier、line-density 干净。
- 打包态 Electron 真机(Playwright):选择器打开 41 项,输入 `knowledge` 收窄到 3 项,↓↓Enter 选中第二项,输入框显示其标题、tooltip 为 id。看板卡片 → 预览 → 详情 → 「打开终端」切到终端页,新 tab 以 task 标题命名且 xterm 已挂载。

## 架构辩护

净增约 168 行。选择器是一个无共享状态的独立组件;启动路径复用既有 `start()`,只是让它接受 draft 而不是读组件 state,并用 requestId 去重而不是另加一条 spawn 路径。没有新 store、新层或新模块边界;`<select>` 直接删除,不留回退。

## 任务与范围

- Harness 任务:task_38514e01f4dafa2a792b798956(PLT-TerminalWorkspace 里程碑 task_d2985b723b87a2cf55aa24d6fe 的子任务)
- 分支:codex/terminal-task-picker
- 公开范围:终端启动表单、task 详情头部动作、App 接线(仅 renderer)
- 私有规划/证据已更新:是
- 不在范围:看板卡片右键「打开终端」(详情页动作已覆盖诉求;卡片本就有预览抽屉通往详情)。

## 残余风险

选择器在客户端对 App 已持有的内存 task 列表过滤,没有新查询路径;每次按键是一次线性扫描,几千量级足够。

## 版本影响

- 版本:不变(仅 renderer 交互)。
- 发布影响:不发布

🤖 Generated with [Claude Code](https://claude.com/claude-code)
