### PR TITLE
feat(gui): move terminal chrome into a resizable left sidebar with popover launch options

### DIFF
--- a/packages/gui/src/renderer/components/Popover.tsx
+++ b/packages/gui/src/renderer/components/Popover.tsx
@@ -1,0 +1,95 @@
+import { useEffect, useLayoutEffect, useRef, useState, type ReactNode } from "react";
+import { createPortal } from "react-dom";
+
+/**
+ * 轻量气泡弹窗:一个触发按钮 + 挂在它下方的面板。面板 portal 到 body 并 fixed 定位,
+ * 不受侧栏 overflow 裁剪;水平方向夹在视口内。Esc / 点外面关闭;children 拿到 close,
+ * 选中项后自行收起。
+ */
+export function Popover({
+  label,
+  trigger,
+  panelClassName = "w-72",
+  testId,
+  children,
+}: {
+  readonly label: string;
+  readonly trigger: ReactNode;
+  readonly panelClassName?: string;
+  readonly testId?: string;
+  readonly children: (close: () => void) => ReactNode;
+}) {
+  const [open, setOpen] = useState(false);
+  const [position, setPosition] = useState({ top: 0, left: 0 });
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const panelRef = useRef<HTMLDivElement>(null);
+  useLayoutEffect(() => {
+    if (!open) return;
+    const anchor = buttonRef.current?.getBoundingClientRect();
+    const width = panelRef.current?.offsetWidth ?? 0;
+    if (!anchor) return;
+    const left = Math.max(8, Math.min(anchor.left, window.innerWidth - width - 8));
+    setPosition({ top: anchor.bottom + 4, left });
+  }, [open]);
+  useEffect(() => {
+    if (!open) return;
+    const inside = (target: EventTarget | null) =>
+      buttonRef.current?.contains(target as Node | null) || panelRef.current?.contains(target as Node | null);
+    const onMouseDown = (event: MouseEvent) => {
+      if (!inside(event.target)) setOpen(false);
+    };
+    const onKeyDown = (event: KeyboardEvent) => {
+      // 面板里展开中的 combobox(task 选择器)自己消费 Esc 收列表,气泡不跟着关。
+      const target = event.target as HTMLElement | null;
+      const comboboxOpen =
+        target?.getAttribute?.("role") === "combobox" && target.getAttribute("aria-expanded") === "true";
+      if (event.key === "Escape" && !comboboxOpen) setOpen(false);
+    };
+    window.addEventListener("mousedown", onMouseDown, true);
+    window.addEventListener("keydown", onKeyDown, true);
+    return () => {
+      window.removeEventListener("mousedown", onMouseDown, true);
+      window.removeEventListener("keydown", onKeyDown, true);
+    };
+  }, [open]);
+  return (
+    <>
+      <button
+        ref={buttonRef}
+        type="button"
+        aria-label={label}
+        title={label}
+        aria-expanded={open}
+        aria-haspopup="dialog"
+        data-testid={testId}
+        onClick={() => setOpen((current) => !current)}
+        className={[
+          "grid size-7 place-items-center rounded border border-border text-text-muted",
+          "hover:border-border-strong hover:bg-surface-raised hover:text-text",
+          open ? "border-accent/60 bg-accent/10 text-text" : "",
+        ].join(" ")}
+      >
+        {trigger}
+      </button>
+      {open &&
+        createPortal(
+          <div
+            ref={panelRef}
+            role="dialog"
+            aria-label={label}
+            data-testid={testId ? `${testId}-panel` : undefined}
+            style={{ top: position.top, left: position.left }}
+            className={[
+              "fixed z-50 max-h-[70vh] max-w-[calc(100vw-1rem)] overflow-y-auto rounded border border-border-strong",
+              "bg-surface-raised",
+              "p-2 text-[12px] shadow-2xl",
+              panelClassName,
+            ].join(" ")}
+          >
+            {children(() => setOpen(false))}
+          </div>,
+          document.body,
+        )}
+    </>
+  );
+}

--- a/packages/gui/src/renderer/components/terminal/TerminalChrome.tsx
+++ b/packages/gui/src/renderer/components/terminal/TerminalChrome.tsx
@@ -1,13 +1,25 @@
-import type { FormEvent, ReactNode } from "react";
+import { useState, type FormEvent, type PointerEvent as ReactPointerEvent, type ReactNode } from "react";
+import { Gear, Plus, PlugsConnected } from "@phosphor-icons/react";
 import type { TerminalSessionRow } from "../../../../../daemon/src/gui-s3-control.ts";
 import type { TerminalPreferences } from "../../terminal-preferences.ts";
 import { t } from "../../i18n/index.tsx";
 import { isMacPlatform } from "../../platform.ts";
+import { Popover } from "../Popover.tsx";
 import { TerminalTaskPicker } from "./TerminalTaskPicker.tsx";
 
 const shellOptions = ["default", "zsh", "bash", "sh", "fish"] as const;
+const sidebarWidthKey = "harness:gui:terminal-sidebar-width";
+const sidebarWidthRange = { min: 160, max: 480, initial: 224 } as const;
 
-/** 一个终端 tab(= pane group)在 tab 条上的投影。 */
+function readSidebarWidth(): number {
+  const stored = Number(localStorage.getItem(sidebarWidthKey));
+  return Number.isFinite(stored) && stored > 0 ? clampWidth(stored) : sidebarWidthRange.initial;
+}
+function clampWidth(width: number): number {
+  return Math.min(sidebarWidthRange.max, Math.max(sidebarWidthRange.min, Math.round(width)));
+}
+
+/** 一个终端 tab(= pane group)在侧栏上的投影。 */
 export interface TerminalTabChip {
   readonly groupId: string;
   readonly title: string;
@@ -23,11 +35,13 @@ export interface TerminalSpawnDraft {
 }
 
 /**
- * 终端页的固定 chrome:标题栏、tab 条、高级启动表单(PLT-TerminalWorkspace,W1 从
- * TerminalView 抽出以隔离状态机与展示)。纯展示组件,不持状态、不直接调 terminal-client。
+ * 终端页的左侧栏(PLT-TerminalWorkspace):顶部一排小功能区(新建 / 附加已有会话 / 启动
+ * 选项),下面是纵向的 tab 列表,底部是 repo · generation。启动选项(后端、名称、cwd、
+ * shell、task 绑定)与附加列表都收进气泡弹窗,不再常驻占高。右缘可拖拽调宽(localStorage)。
+ * 除侧栏宽度外不持状态。
  *
- * tab 条的语义是 W1 的二级模型:一个 chip = 一个 group,chip 上的关闭键关的是整个 group
- * (含其中全部 pane);group 内部的 split/关闭 pane 由 pane 自己的 header 承担。
+ * tab 的语义仍是二级模型:一行 = 一个 group,行上的关闭键关的是整个 group(含全部 pane);
+ * group 内部的 split/关闭 pane 由 pane 自己的 header 承担。
  */
 export function TerminalChrome({
   repoId,
@@ -64,20 +78,164 @@ export function TerminalChrome({
   readonly onCreate: (event: FormEvent) => void;
   readonly tasks: readonly { readonly taskId: string; readonly title: string }[];
 }) {
+  const attachable = sessions.filter((row) => row.attachable && !openSessionIds.includes(row.sessionId));
+  const [width, setWidth] = useState(readSidebarWidth);
+  // 右缘拖拽调宽:按下后在 window 上跟指针(越过 xterm/iframe 也不丢),松手落 localStorage。
+  const startResize = (event: ReactPointerEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    const origin = event.clientX,
+      base = width;
+    const onMove = (move: PointerEvent) => setWidth(clampWidth(base + move.clientX - origin));
+    const onUp = (up: PointerEvent) => {
+      window.removeEventListener("pointermove", onMove);
+      window.removeEventListener("pointerup", onUp);
+      localStorage.setItem(sidebarWidthKey, String(clampWidth(base + up.clientX - origin)));
+    };
+    window.addEventListener("pointermove", onMove);
+    window.addEventListener("pointerup", onUp);
+  };
   return (
-    <>
-      <header className="flex items-center gap-2 border-b border-border px-3 py-1.5">
-        <strong className="text-[13px]">{t("terminal.view.localTerminal")}</strong>
-        <span className="font-mono text-[11px] text-text-faint">
-          {t("terminal.view.repoGeneration", {
-            repoId,
-            generation: generation ?? t("views.settingsView.systemUnknownDash"),
-          })}
-        </span>
-        <span
-          className="inline-flex overflow-hidden rounded border border-border-strong"
-          aria-label={t("terminal.view.backendForNew")}
+    <aside
+      data-testid="terminal-sidebar"
+      style={{ width }}
+      className="relative flex shrink-0 flex-col overflow-hidden border-r border-border bg-surface"
+    >
+      <div
+        role="separator"
+        aria-orientation="vertical"
+        aria-label={t("terminal.view.sidebarResize")}
+        data-testid="terminal-sidebar-resize"
+        onPointerDown={startResize}
+        className="absolute inset-y-0 right-0 z-10 w-1 cursor-col-resize hover:bg-accent/40"
+      />
+      <div className="flex items-center gap-1 border-b border-border px-2 py-1.5">
+        <button
+          onClick={onNewTab}
+          title={t("terminal.view.quickStartTitle")}
+          aria-label={t("terminal.view.newTab")}
+          className={
+            "grid size-7 place-items-center rounded border border-accent/60 bg-accent/10 text-text " +
+            "hover:bg-accent/20"
+          }
         >
+          <Plus weight="bold" />
+        </button>
+        <Popover label={t("terminal.view.attachExisting")} trigger={<PlugsConnected />} testId="terminal-attach">
+          {(close) => (
+            <div className="flex flex-col gap-0.5" data-testid="terminal-attach-list">
+              <p className="px-1 pb-1 text-[11px] text-text-faint">{t("terminal.view.attachSession")}</p>
+              {attachable.length === 0 && <p className="px-1 text-text-faint">{t("terminal.view.noAttachable")}</p>}
+              {sessions
+                .filter((row) => row.attachable)
+                .map((row) => (
+                  // 只列可附加的;同一会话被两个 pane 同时 attach 本波不支持,已在 pane 里的禁选。
+                  <button
+                    key={row.sessionId}
+                    type="button"
+                    data-session-id={row.sessionId}
+                    disabled={!row.attachable || openSessionIds.includes(row.sessionId)}
+                    onClick={() => {
+                      onAttachSession(row.sessionId);
+                      close();
+                    }}
+                    className={
+                      "flex w-full flex-col items-start rounded px-2 py-1 text-left text-text " +
+                      "hover:bg-surface disabled:cursor-not-allowed disabled:text-text-faint " +
+                      "disabled:hover:bg-transparent"
+                    }
+                  >
+                    <span className="w-full truncate">{row.name}</span>
+                    <span className="font-mono text-[10px] text-text-faint">
+                      {row.backend} · {row.status}
+                    </span>
+                  </button>
+                ))}
+            </div>
+          )}
+        </Popover>
+        <span className="ml-auto" />
+        <Popover
+          label={t("terminal.view.launchOptions")}
+          trigger={<Gear />}
+          panelClassName="w-[22rem]"
+          testId="terminal-launch-options"
+        >
+          {() => (
+            <LaunchOptions
+              preferences={preferences}
+              onPreferenceChange={onPreferenceChange}
+              spawn={spawn}
+              onSpawnChange={onSpawnChange}
+              onCreate={onCreate}
+              tasks={tasks}
+            />
+          )}
+        </Popover>
+      </div>
+      <div
+        className="flex min-h-0 flex-1 flex-col gap-0.5 overflow-y-auto p-1"
+        role="tablist"
+        aria-orientation="vertical"
+      >
+        {chips.map((chip) => (
+          <div key={chip.groupId} className={tabClassName(activeGroupId === chip.groupId)}>
+            <button
+              role="tab"
+              aria-selected={activeGroupId === chip.groupId}
+              onClick={() => onSelectGroup(chip.groupId)}
+              className="flex min-w-0 flex-1 flex-col items-start px-2 py-1 text-left"
+            >
+              <span className="w-full truncate text-[12px] text-text">{chip.title}</span>
+              <span className="font-mono text-[10px] text-text-faint">
+                {chip.backend}
+                {chip.paneCount > 1 && ` · ${t("terminal.view.groupPaneCount", { count: chip.paneCount })}`}
+              </span>
+            </button>
+            <button
+              onClick={() => onCloseGroup(chip.groupId)}
+              aria-label={t("terminal.view.closeTabAria", { name: chip.title })}
+              title={t("terminal.view.closeDetachTitle")}
+              className="self-stretch px-1.5 text-text-faint hover:bg-surface-overlay hover:text-text"
+            >
+              ×
+            </button>
+          </div>
+        ))}
+        {chips.length === 0 && <p className="px-2 py-3 text-[11px] text-text-faint">{t("terminal.view.startHint")}</p>}
+      </div>
+      <p
+        className="truncate border-t border-border px-2 py-1 font-mono text-[10px] text-text-faint"
+        title={splitShortcutHint()}
+      >
+        {t("terminal.view.repoGeneration", {
+          repoId,
+          generation: generation ?? t("views.settingsView.systemUnknownDash"),
+        })}
+      </p>
+    </aside>
+  );
+}
+
+/** 启动选项气泡:新会话后端 + 高级启动表单(名称 / cwd / shell / task 绑定)+ 快捷键提示。 */
+function LaunchOptions({
+  preferences,
+  onPreferenceChange,
+  spawn,
+  onSpawnChange,
+  onCreate,
+  tasks,
+}: {
+  readonly preferences: TerminalPreferences;
+  readonly onPreferenceChange: (update: Partial<TerminalPreferences>) => void;
+  readonly spawn: TerminalSpawnDraft;
+  readonly onSpawnChange: (update: Partial<TerminalSpawnDraft>) => void;
+  readonly onCreate: (event: FormEvent) => void;
+  readonly tasks: readonly { readonly taskId: string; readonly title: string }[];
+}) {
+  return (
+    <div className="flex flex-col gap-2">
+      <Field label={t("terminal.view.backendForNew")}>
+        <span className="inline-flex self-start overflow-hidden rounded border border-border-strong">
           <button
             aria-pressed={preferences.backend === "direct-pty"}
             onClick={() => onPreferenceChange({ backend: "direct-pty" })}
@@ -93,73 +251,15 @@ export function TerminalChrome({
             {t("terminal.view.backendTmux")}
           </button>
         </span>
-        <span className="ml-auto font-mono text-[11px] text-text-faint" title={splitShortcutHint()}>
-          {t("terminal.view.shortcut")} · {splitShortcutHint()}
-        </span>
-      </header>
-      <div className="flex min-w-0 items-center gap-1 overflow-x-auto border-b border-border px-2 py-1">
-        {chips.map((chip) => (
-          <span key={chip.groupId} className={tabClassName(activeGroupId === chip.groupId)}>
-            <button
-              onClick={() => onSelectGroup(chip.groupId)}
-              className="max-w-44 truncate px-2 py-1 text-[11px] text-text"
-            >
-              {chip.title} <span className="font-mono text-text-faint">· {chip.backend}</span>
-              {chip.paneCount > 1 && (
-                <span className="font-mono text-text-faint">
-                  {" "}
-                  · {t("terminal.view.groupPaneCount", { count: chip.paneCount })}
-                </span>
-              )}
-            </button>
-            <button
-              onClick={() => onCloseGroup(chip.groupId)}
-              aria-label={t("terminal.view.closeTabAria", { name: chip.title })}
-              title={t("terminal.view.closeDetachTitle")}
-              className="border-l border-border px-1.5 text-text-faint hover:bg-surface-overlay"
-            >
-              ×
-            </button>
-          </span>
-        ))}
-        <button
-          onClick={onNewTab}
-          title={t("terminal.view.quickStartTitle")}
-          aria-label={t("terminal.view.newTab")}
-          className="shrink-0 rounded border border-accent/60 bg-accent/10 px-2 py-1 text-[13px] text-text"
-        >
-          +
-        </button>
-        <select
-          aria-label={t("terminal.view.attachExisting")}
-          defaultValue=""
-          onChange={(event) => {
-            if (event.target.value) onAttachSession(event.target.value);
-            event.target.value = "";
-          }}
-          className="control ml-auto shrink-0"
-        >
-          <option value="">{t("terminal.view.attachSession")}</option>
-          {sessions.map((row) => (
-            // 同一会话被两个 pane 同时 attach 的语义本波不支持:已在某个 pane 里的会话直接禁选。
-            <option
-              key={row.sessionId}
-              value={row.sessionId}
-              disabled={!row.attachable || openSessionIds.includes(row.sessionId)}
-            >
-              {row.name} · {row.backend} · {row.status}
-            </option>
-          ))}
-        </select>
-      </div>
-      <details className="border-b border-border px-3 py-1 text-[11px]">
-        <summary className="cursor-pointer text-text-muted">{t("terminal.view.advanced")}</summary>
-        <form onSubmit={onCreate} className="flex flex-wrap items-end gap-2 py-2">
+      </Field>
+      <form onSubmit={onCreate} className="flex flex-col gap-2 border-t border-border pt-2">
+        <p className="text-[11px] text-text-muted">{t("terminal.view.advanced")}</p>
+        <div className="flex flex-wrap items-end gap-2">
           <Field label={t("terminal.view.name")}>
             <input
               value={spawn.name}
               onChange={(event) => onSpawnChange({ name: event.target.value })}
-              className="control w-28"
+              className="control w-32"
             />
           </Field>
           <Field label={t("terminal.view.cwd")}>
@@ -195,15 +295,18 @@ export function TerminalChrome({
               ))}
             </select>
           </Field>
-          <Field label={t("terminal.view.task")}>
-            <TerminalTaskPicker tasks={tasks} value={spawn.taskId} onChange={(taskId) => onSpawnChange({ taskId })} />
-          </Field>
-          <button className="rounded border border-accent/60 bg-accent/10 px-3 py-1 text-[12px] text-text">
-            {t("terminal.view.startCustom")}
-          </button>
-        </form>
-      </details>
-    </>
+        </div>
+        <Field label={t("terminal.view.task")}>
+          <TerminalTaskPicker tasks={tasks} value={spawn.taskId} onChange={(taskId) => onSpawnChange({ taskId })} />
+        </Field>
+        <button className="self-start rounded border border-accent/60 bg-accent/10 px-3 py-1 text-[12px] text-text">
+          {t("terminal.view.startCustom")}
+        </button>
+      </form>
+      <p className="border-t border-border pt-2 font-mono text-[10px] text-text-faint">
+        {t("terminal.view.shortcut")} · {splitShortcutHint()}
+      </p>
+    </div>
   );
 }
 
@@ -215,19 +318,18 @@ function toggleClassName(selected: boolean): string {
 }
 function tabClassName(selected: boolean): string {
   return [
-    "inline-flex shrink-0 overflow-hidden rounded border",
-    selected ? "border-accent/60 bg-surface-raised" : "border-border",
+    "flex items-stretch overflow-hidden rounded border",
+    selected ? "border-accent/60 bg-surface-raised" : "border-transparent hover:bg-surface-raised/60",
   ].join(" ");
 }
 function Field({ label, children }: { readonly label: string; readonly children: ReactNode }) {
   return (
-    <label className="grid gap-0.5 font-mono text-[10px] uppercase tracking-wide text-text-faint">
-      {label}
+    <label className="flex flex-col gap-1 text-[11px] text-text-muted">
+      <span>{label}</span>
       {children}
     </label>
   );
 }
-
 function splitShortcutHint(): string {
   return t(isMacPlatform() ? "terminal.view.splitShortcutMac" : "terminal.view.splitShortcut");
 }

--- a/packages/gui/src/renderer/i18n/locales/en-US/terminal.json
+++ b/packages/gui/src/renderer/i18n/locales/en-US/terminal.json
@@ -51,5 +51,8 @@
   "terminal.view.dragHandleTitle": "Drag onto another pane to rearrange",
   "terminal.view.taskPickerPlaceholder": "Search task title or id…",
   "terminal.view.taskPickerEmpty": "No matching task",
-  "terminal.view.taskPickerMore": "{count} more — keep typing to narrow down"
+  "terminal.view.taskPickerMore": "{count} more — keep typing to narrow down",
+  "terminal.view.launchOptions": "Launch options",
+  "terminal.view.noAttachable": "No session to attach",
+  "terminal.view.sidebarResize": "Drag to resize the sidebar"
 }

--- a/packages/gui/src/renderer/i18n/locales/zh-CN/terminal.json
+++ b/packages/gui/src/renderer/i18n/locales/zh-CN/terminal.json
@@ -51,5 +51,8 @@
   "terminal.view.dragHandleTitle": "拖动到别的 pane 上换位",
   "terminal.view.taskPickerPlaceholder": "搜索 task 标题或 id…",
   "terminal.view.taskPickerEmpty": "无匹配 task",
-  "terminal.view.taskPickerMore": "还有 {count} 个,继续输入缩小范围"
+  "terminal.view.taskPickerMore": "还有 {count} 个,继续输入缩小范围",
+  "terminal.view.launchOptions": "启动选项",
+  "terminal.view.noAttachable": "没有可附加的会话",
+  "terminal.view.sidebarResize": "拖动调整侧栏宽度"
 }

--- a/packages/gui/src/renderer/views/TerminalView.tsx
+++ b/packages/gui/src/renderer/views/TerminalView.tsx
@@ -561,7 +561,7 @@ export function TerminalView({
     <section
       aria-label={t("terminal.view.title")}
       data-testid="terminal-view"
-      className="flex min-h-0 flex-1 flex-col overflow-hidden"
+      className="flex min-h-0 flex-1 flex-row overflow-hidden"
     >
       <TerminalChrome
         repoId={repoId}
@@ -584,34 +584,40 @@ export function TerminalView({
         onCreate={create}
         tasks={tasks}
       />
-      {/* pane 区:一个 tab(group)一棵 pane 树,切 tab 即换 dockview 实例。 */}
-      <div ref={regionRef} data-testid="terminal-pane-region" className="flex min-h-0 flex-1 flex-col overflow-hidden">
-        {activeGroup ? (
-          <TerminalPaneContext.Provider value={paneActions}>
-            <TerminalSplitGrid
-              key={activeGroup.groupId}
-              seeds={activeGroup.seeds}
-              grid={activeGroup.grid}
-              onApiReady={(api) => {
-                gridApi.current = api;
-              }}
-              onLayoutChange={(grid) => applyGrid(activeGroup.groupId, grid)}
-              onActivePaneChange={(panelId) => {
-                if (panelId) focusPane(panelId);
-              }}
-            />
-          </TerminalPaneContext.Provider>
-        ) : (
-          <div className="grid h-full place-items-center px-4 text-center text-[12px] text-text-faint">
-            {t("terminal.view.startHint")}
-          </div>
+      <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
+        {/* pane 区:一个 tab(group)一棵 pane 树,切 tab 即换 dockview 实例。 */}
+        <div
+          ref={regionRef}
+          data-testid="terminal-pane-region"
+          className="flex min-h-0 flex-1 flex-col overflow-hidden"
+        >
+          {activeGroup ? (
+            <TerminalPaneContext.Provider value={paneActions}>
+              <TerminalSplitGrid
+                key={activeGroup.groupId}
+                seeds={activeGroup.seeds}
+                grid={activeGroup.grid}
+                onApiReady={(api) => {
+                  gridApi.current = api;
+                }}
+                onLayoutChange={(grid) => applyGrid(activeGroup.groupId, grid)}
+                onActivePaneChange={(panelId) => {
+                  if (panelId) focusPane(panelId);
+                }}
+              />
+            </TerminalPaneContext.Provider>
+          ) : (
+            <div className="grid h-full place-items-center px-4 text-center text-[12px] text-text-faint">
+              {t("terminal.view.startHint")}
+            </div>
+          )}
+        </div>
+        {error && (
+          <p role="alert" className="border-t border-status-blocked/30 px-3 py-1 text-[11px] text-status-blocked">
+            {error}
+          </p>
         )}
       </div>
-      {error && (
-        <p role="alert" className="border-t border-status-blocked/30 px-3 py-1 text-[11px] text-status-blocked">
-          {error}
-        </p>
-      )}
     </section>
   );
 }

--- a/packages/gui/test/terminal-page.vitest.ts
+++ b/packages/gui/test/terminal-page.vitest.ts
@@ -367,21 +367,23 @@ describe("task binding (searchable picker + open-from-task-detail)", () => {
     const { bridge } = stubBridge([sessionRow()], null); // 已有会话 → 进页只附加,不自动 spawn。
     mountView({ repoId: "repo-a", daemonGeneration: null, tasks: manyTasks });
     await flush();
-    const picker = container!.querySelector<HTMLInputElement>('[data-testid="terminal-task-picker"]')!;
+    // 启动选项收在侧栏的气泡里,先打开。
+    act(() => container!.querySelector<HTMLButtonElement>('[data-testid="terminal-launch-options"]')!.click());
+    const picker = document.querySelector<HTMLInputElement>('[data-testid="terminal-task-picker"]')!;
     act(() => picker.focus());
     // 打开后只列前 40 条,余量用提示承接,几千个 option 不进 DOM。
-    expect(container!.querySelectorAll('[role="option"]')).toHaveLength(41);
-    expect(container!.textContent).toContain("260");
+    expect(document.querySelectorAll('[role="option"]')).toHaveLength(41);
+    expect(document.body.textContent).toContain("260");
     act(() => typeInto(picker, "colour"));
-    const options = [...container!.querySelectorAll<HTMLButtonElement>('[role="option"]')];
+    const options = [...document.querySelectorAll<HTMLButtonElement>('[role="option"]')];
     expect(options.map((option) => option.textContent)).toEqual(["unbound", "Fix xterm colour palettetask_0042"]);
     act(() => options[1].click());
     expect(picker.value).toBe("Fix xterm colour palette");
     expect(picker.title).toBe("task_0042");
     act(() => typeInto(picker, "task_00"));
-    expect(container!.querySelectorAll('[role="option"]')).toHaveLength(41);
+    expect(document.querySelectorAll('[role="option"]')).toHaveLength(41);
     act(() => picker.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true })));
-    expect(container!.querySelector('[data-testid="terminal-task-picker-list"]')).toBeNull();
+    expect(document.querySelector('[data-testid="terminal-task-picker-list"]')).toBeNull();
     const form = picker.closest("form")!;
     act(() => form.requestSubmit());
     await flush();

--- a/packages/gui/test/terminal-split-grid.vitest.ts
+++ b/packages/gui/test/terminal-split-grid.vitest.ts
@@ -475,13 +475,35 @@ describe("terminal split panes (PLT-TerminalWorkspace W1)", () => {
     expect(panes()).toHaveLength(2);
   });
 
+  it("resizes the sidebar by dragging its right edge and remembers the width", async () => {
+    stubBridge([sessionRow()]);
+    mountView();
+    await flush();
+    const aside = container!.querySelector<HTMLElement>('[data-testid="terminal-sidebar"]')!;
+    const handle = container!.querySelector<HTMLElement>('[data-testid="terminal-sidebar-resize"]')!;
+    expect(aside.style.width).toBe("224px");
+    act(() => {
+      handle.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true, clientX: 224, pointerId: 1 }));
+      window.dispatchEvent(new PointerEvent("pointermove", { clientX: 300, pointerId: 1 }));
+      window.dispatchEvent(new PointerEvent("pointerup", { clientX: 300, pointerId: 1 }));
+    });
+    expect(aside.style.width).toBe("300px");
+    expect(localStorage.getItem("harness:gui:terminal-sidebar-width")).toBe("300");
+    act(() => {
+      handle.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true, clientX: 300, pointerId: 1 }));
+      window.dispatchEvent(new PointerEvent("pointerup", { clientX: 20, pointerId: 1 }));
+    });
+    expect(localStorage.getItem("harness:gui:terminal-sidebar-width")).toBe("160");
+  });
+
   it("bans attaching one session into two panes by disabling it in the attach picker", async () => {
     // 自动附加取会话表里最后一个可附加的:s-restore 会进 pane,s-free 留在表里。
     stubBridge([sessionRow({ sessionId: "s-free", name: "Free" }), sessionRow()]);
     mountView();
     await flush();
-    const options = [...container!.querySelectorAll<HTMLOptionElement>("option")];
-    expect(options.find((option) => option.value === "s-restore")?.disabled).toBe(true);
-    expect(options.find((option) => option.value === "s-free")?.disabled).toBe(false);
+    act(() => container!.querySelector<HTMLButtonElement>('[data-testid="terminal-attach"]')!.click());
+    const options = [...document.querySelectorAll<HTMLButtonElement>('[data-testid="terminal-attach-list"] button')];
+    expect(options.find((option) => option.dataset.sessionId === "s-restore")?.disabled).toBe(true);
+    expect(options.find((option) => option.dataset.sessionId === "s-free")?.disabled).toBe(false);
   });
 });


### PR DESCRIPTION
# English

## Summary

The terminal page's chrome (title, backend toggle, tab strip, advanced launch form, attach dropdown, shortcut hint) stacked several rows above the panes. Per the product owner's review it moves into a **left sidebar**: a small toolbar on top (new terminal / attach existing session / launch options), the tabs listed vertically beneath, `repo · generation` at the bottom. The panes now start at the top of the page.

- **Popovers** for launch options (backend, name, cwd, shell, task binding, shortcut hint) and for the attach list. A small shared `Popover` component portals its panel to `body` (so the sidebar's `overflow-hidden` cannot clip it), positions it under the trigger and clamps it to the viewport; Esc / outside click close it, except that Esc inside an open combobox (the task picker) only closes the combobox.
- **Resizable sidebar**: drag its right edge (160–480px, remembered in localStorage). Pointer tracking is on `window`, so the drag survives crossing xterm.
- The attach list only shows attachable sessions (no more wall of exited tmux rows); sessions already open in a pane stay disabled.

## What Changed

- `components/Popover.tsx` (new), `components/terminal/TerminalChrome.tsx` (rewritten as the sidebar; `LaunchOptions` sub-form), `views/TerminalView.tsx` (row layout: sidebar + pane column), i18n keys `launchOptions`, `noAttachable`, `sidebarResize`.
- Tests: attach-picker test now opens the popover and asserts disabled rows; task-picker test opens launch options first; new sidebar-resize test (drag to 300px persists; drag past the minimum clamps to 160).

## Verification

- `vitest run terminal-page terminal-split-grid i18n-locale-parity`: 26 passed. `tsc -b`, eslint, prettier, line-density clean.
- Live packaged-mode Electron (Playwright): pane region top moved from y=127 to y=29; two tabs listed vertically; launch-options popover renders fully outside the sidebar; attach popover closes on Esc; dragging the edge resized the sidebar 224→343px and localStorage holds `343`.

## Architectural Justification

Net +203 lines, but the chrome file is a rewrite of the same surface (+325/−122 in total): the only new module is a 90-line `Popover` that both the launch options and the attach list use, replacing a `<details>`-style inline panel that would have been clipped. No new state store; the sidebar width is a single localStorage key read at mount. The old top-row markup and its attach `<select>` are deleted.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none

## Machine-Readable Declarations

Production-Delta: +325/-122

## Task And Scope

- Harness task: task_38514e01f4dafa2a792b798956 (child of PLT-TerminalWorkspace milestone task_d2985b723b87a2cf55aa24d6fe)
- Branch: codex/terminal-sidebar
- Public scope: terminal page chrome/layout (renderer only)
- Private planning/evidence updated: yes
- Out of scope: the tree-structured task picker (next PR), a global CSS adaptiveness pass (audit in progress).

## Residual Risk

Popover positioning is computed once on open (no reposition on window resize while open); closing and reopening recomputes. Acceptable for a transient panel.

## Version Impact

- Version: no version change (renderer layout only).
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none
- Authority: not applicable
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no

---

# 中文

## 摘要

终端页的功能区(标题、后端切换、tab 条、高级启动表单、附加下拉、快捷键提示)原来在 pane 上方叠了好几行。按产品负责人的反馈改成**左侧栏**:顶部一排小功能区(新建 / 附加已有会话 / 启动选项),下面纵向列出 tab,底部 `repo · generation`。pane 区从页面顶部开始。

- **气泡弹窗**承载启动选项(后端、名称、cwd、shell、task 绑定、快捷键提示)和附加列表。新增一个小的共用 `Popover`:面板 portal 到 `body`(侧栏的 `overflow-hidden` 裁不到它),定位在触发按钮下方并夹在视口内;Esc / 点外面关闭,但展开中的 combobox(task 选择器)里按 Esc 只收列表不关气泡。
- **侧栏可拖拽调宽**:拖右缘(160–480px,记在 localStorage)。指针跟踪挂在 `window` 上,拖过 xterm 也不丢。
- 附加列表只列可附加的会话(不再是一墙已退出的 tmux 行);已在 pane 里的会话仍禁选。

## 变更内容

- `components/Popover.tsx`(新)、`components/terminal/TerminalChrome.tsx`(重写为侧栏;`LaunchOptions` 子表单)、`views/TerminalView.tsx`(左右布局:侧栏 + pane 列),i18n 键 `launchOptions`、`noAttachable`、`sidebarResize`。
- 测试:附加选择测试改为先开气泡再断言禁用行;task 选择器测试先开启动选项;新增侧栏拖拽测试(拖到 300px 持久化;拖过下限夹到 160)。

## 验证

- `vitest run terminal-page terminal-split-grid i18n-locale-parity`:26 项通过。`tsc -b`、eslint、prettier、line-density 干净。
- 打包态 Electron 真机(Playwright):pane 区顶部从 y=127 提到 y=29;两个 tab 纵向列出;启动选项气泡完整显示在侧栏之外;附加气泡 Esc 关闭;拖右缘把侧栏从 224 拉到 343px,localStorage 记为 `343`。

## 架构辩护

净增约 203 行,但 chrome 文件是同一表面的重写(合计 +325/−122):唯一新模块是 90 行的 `Popover`,启动选项与附加列表共用,取代会被裁剪的 `<details>` 式内联面板。没有新 store;侧栏宽度只是挂载时读一次的 localStorage 键。旧的顶部行标记与附加 `<select>` 直接删除。

## 任务与范围

- Harness 任务:task_38514e01f4dafa2a792b798956(PLT-TerminalWorkspace 里程碑 task_d2985b723b87a2cf55aa24d6fe 的子任务)
- 分支:codex/terminal-sidebar
- 公开范围:终端页 chrome / 布局(仅 renderer)
- 私有规划/证据已更新:是
- 不在范围:树结构 task 选择器(下一个 PR)、全局 CSS 自适应整理(审计进行中)。

## 残余风险

气泡位置在打开时算一次(打开期间窗口缩放不重定位);关掉再开会重算。对瞬时面板可接受。

## 版本影响

- 版本:不变(仅 renderer 布局)。
- 发布影响:不发布

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FEFvD9mQXyi5affbRZuYHh
