### PR TITLE
fix(cli): a dead repo registration no longer breaks routing for every command

### DIFF
--- a/packages/cli/src/daemon/fleet-command-route.ts
+++ b/packages/cli/src/daemon/fleet-command-route.ts
@@ -46,12 +46,20 @@ export async function fleetEdgeRegistration(
   const { readFleetEdgeConfig } = await import("../../../daemon/src/client/fleet-edge-config.ts");
   const commandRoot = canonicalRoot(command.rootDir),
     registered = readRegisteredRepos(daemonUserRoot(env))
-      .map((repo) => ({ ...repo, canonicalRoot: canonicalRoot(repo.canonicalRoot, true) }))
+      // 只解析 enabled 条目,且解析不了根目录的(已删除的 e2e 残留登记)直接丢弃:
+      // 它们不可能是本命令的根,不能让一条死登记把所有命令的路由一起炸掉。
+      .filter((repo) => repo.state === "enabled")
+      .flatMap((repo) => {
+        try {
+          return [{ ...repo, canonicalRoot: canonicalRoot(repo.canonicalRoot, true) }];
+        } catch {
+          return [];
+        }
+      })
       .filter(
         (repo) =>
-          repo.state === "enabled" &&
-          (commandRoot === path.resolve(repo.canonicalRoot) ||
-            commandRoot.startsWith(`${path.resolve(repo.canonicalRoot)}${path.sep}`)),
+          commandRoot === path.resolve(repo.canonicalRoot) ||
+          commandRoot.startsWith(`${path.resolve(repo.canonicalRoot)}${path.sep}`),
       )
       .sort((left, right) => path.resolve(right.canonicalRoot).length - path.resolve(left.canonicalRoot).length)[0];
   if (registered?.mode !== "remote-edge") return null;

--- a/packages/cli/test/fleet-command-route-dead-registry.test.ts
+++ b/packages/cli/test/fleet-command-route-dead-registry.test.ts
@@ -1,0 +1,30 @@
+// harness-test-tier: fast
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { fleetEdgeRegistration } from "../src/daemon/fleet-command-route.ts";
+import type { ThinCommand } from "../src/cli/thin-command.ts";
+
+// 2026-09-02 现场:一条指向已删临时目录的 e2e 残留登记(甚至已 disabled)让每一条走路由的
+// ha 命令都报 invalid_root。路由只关心 enabled 且根目录还在的条目,其余必须被忽略。
+test("a registered repo whose root no longer exists does not break routing for other repos", async () => {
+  const userRoot = mkdtempSync(path.join(tmpdir(), "ha-dead-registry-"));
+  const liveRoot = path.join(userRoot, "live-repo");
+  mkdirSync(liveRoot);
+  writeFileSync(
+    path.join(userRoot, "registry.json"),
+    JSON.stringify({
+      schema: "harness-daemon-registry/v1",
+      repos: [
+        { repoId: "dead-disabled", canonicalRoot: "/nonexistent/parent/dead-one", state: "disabled", mode: "local" },
+        { repoId: "dead-enabled", canonicalRoot: "/nonexistent/parent/dead-two", state: "enabled", mode: "local" },
+        { repoId: "live", canonicalRoot: liveRoot, state: "enabled", mode: "local" },
+      ],
+    }),
+  );
+  const command = { rootDir: liveRoot } as ThinCommand;
+  // local mode → no fleet reroute; the point is that it resolves instead of throwing invalid_root.
+  assert.equal(await fleetEdgeRegistration(command, { HARNESS_DAEMON_USER_ROOT: userRoot }), null);
+});


### PR DESCRIPTION
# English

## Summary

One leftover repo registration pointing at a deleted temp directory (`bench-e2e`, left by a write-perf e2e run and already `disabled`) made **every** routed `ha` command fail with `daemon_unavailable … Canonical root does not exist`, while `ha daemon status` still answered. Reproduced today by adding a dead `disabled` entry to `~/.harness/registry.json`: `ha fact search` failed immediately, `ha daemon status` did not.

Root cause: `fleetEdgeRegistration` (the registry-mode gate in front of every fleet reroute) resolved `canonicalRoot()` for **all** registered repos before filtering by state; a root whose parent no longer exists throws, and the throw escapes the whole command.

## What Changed

- `packages/cli/src/daemon/fleet-command-route.ts`: filter to `enabled` entries first, then resolve roots with a per-entry try/catch that drops unresolvable ones (they can never be the command's root).
- `packages/cli/test/fleet-command-route-dead-registry.test.ts` (new, fast tier): a registry with a dead disabled entry, a dead enabled entry and a live one resolves to `null` for the live root. Negative control: with the fix stashed the test fails with `invalid_root`.

## Verification

`node --test packages/cli/test/fleet-command-route-dead-registry.test.ts` passes; fails with `invalid_root` without the fix. eslint, prettier, line-density clean.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none

## Machine-Readable Declarations

Production-Delta: +12/-4

## Task And Scope

- Harness task: task_956a0f26e561346fefaccc0cf8
- Branch: codex/registry-poison
- Public scope: CLI fleet routing gate + its test
- Private planning/evidence updated: yes
- Out of scope: why the write-perf e2e registers into the real user registry and does not clean up (same task, follow-up), and `repo unregister --purge` for already-disabled entries.

## Residual Risk

An enabled registration whose root is temporarily unavailable (unmounted volume) is now silently skipped by the fleet gate instead of failing the command; the daemon-side attach still reports it.

## Version Impact

- Version: no version change (bug fix).
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none
- Authority: not applicable
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no

---

# 中文

## 摘要

一条指向已删除临时目录的残留 repo 登记(`bench-e2e`,写性能 e2e 留下的,且已是 `disabled`)让**所有**走路由的 `ha` 命令都报 `daemon_unavailable … Canonical root does not exist`,而 `ha daemon status` 仍正常。今日复现:往 `~/.harness/registry.json` 加一条死的 `disabled` 条目,`ha fact search` 立刻失败,`ha daemon status` 不受影响。

根因:`fleetEdgeRegistration`(所有 fleet 改道前的登记模式门)先对**全部**登记 repo 做 `canonicalRoot()` 再按状态过滤;父目录已不存在的根会抛错,并逃逸到整条命令。

## 变更内容

- `packages/cli/src/daemon/fleet-command-route.ts`:先过滤 `enabled`,再逐条 try/catch 解析根目录,解析不了的丢弃(它们不可能是本命令的根)。
- `packages/cli/test/fleet-command-route-dead-registry.test.ts`(新,fast tier):登记表含死的 disabled、死的 enabled 与一条活的,对活根解析为 `null`。阴性对照:stash 掉修复后该测试报 `invalid_root`。

## 验证

`node --test packages/cli/test/fleet-command-route-dead-registry.test.ts` 通过;无修复时报 `invalid_root`。eslint、prettier、line-density 干净。

## 任务与范围

- Harness 任务:task_956a0f26e561346fefaccc0cf8
- 分支:codex/registry-poison
- 公开范围:CLI fleet 路由门 + 其测试
- 私有规划/证据已更新:是
- 不在范围:写性能 e2e 为何登记进真实用户 registry 且不清理(同 task 后续),以及对已 disabled 条目的 `repo unregister --purge`。

## 残余风险

根目录暂时不可用(卷未挂载)的 enabled 登记现在会被 fleet 门静默跳过而不是让命令失败;daemon 侧 attach 仍会报告它。

## 版本影响

- 版本:不变(bug 修复)。
- 发布影响:不发布

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FEFvD9mQXyi5affbRZuYHh
