### PR TITLE
fix(daemon,kernel): validator discipline — structured placeholder-gate diagnostics and id/field/value on every validate* failure

### DIFF
--- a/packages/cli/test/runtime-cli.integration.test.ts
+++ b/packages/cli/test/runtime-cli.integration.test.ts
@@ -243,7 +243,7 @@ test("real CLI runs, archives task-bound dispatches, resumes, waits through stat
     );
     assert.match(
       String(placeholderLease.receipt.nextAction),
-      /missing required section is: CI\/Gate Authority Stop Condition/u,
+      /required-section diagnostics:\n- CI\/Gate Authority Stop Condition: 空/u,
     );
     assert.doesNotMatch(String(placeholderLease.receipt.nextAction), /missing required sections are: Brief/u);
     assert.match(

--- a/packages/daemon/src/conn-log.ts
+++ b/packages/daemon/src/conn-log.ts
@@ -40,6 +40,7 @@ export interface DaemonTrafficLogEntry {
   readonly durationMs: number;
   readonly ok: boolean;
   readonly code: string | null;
+  readonly detail: string | null;
 }
 
 export interface DaemonConnLog {
@@ -147,6 +148,7 @@ export function openDaemonConnLog(options: DaemonConnLogOptions): DaemonConnLog 
         durationMs: entry.durationMs,
         ok: entry.ok,
         code: entry.code,
+        ...(!entry.ok ? { detail: entry.detail ?? "Unknown request failure." } : {}),
       });
     },
     settle: async () => {

--- a/packages/daemon/src/protocol/daemon-protocol-validate-entities.ts
+++ b/packages/daemon/src/protocol/daemon-protocol-validate-entities.ts
@@ -54,7 +54,10 @@ export function validationValueSummary(value: unknown): string {
 }
 
 export function validationError(entityId: string, field: string, actual: unknown, expectation: string): string {
-  return `entity=${validationValueSummary(entityId)} field=${field} ${expectation}; actual=${validationValueSummary(actual)}`;
+  return (
+    `entity=${validationValueSummary(entityId)} field=${field} ${expectation}; ` +
+    `actual=${validationValueSummary(actual)}`
+  );
 }
 
 export function validationEntityId(value: unknown, fields: readonly string[], fallback: string): string {

--- a/packages/daemon/src/protocol/daemon-protocol-validate-entities.ts
+++ b/packages/daemon/src/protocol/daemon-protocol-validate-entities.ts
@@ -1,3 +1,4 @@
+import { inspect } from "node:util";
 import {
   executionStateWords,
   executionV1StateWords,
@@ -36,6 +37,63 @@ export const sha = (value: unknown): boolean => typeof value === "string" && /^[
 export const statusWord = (vocabulary: readonly string[], value: unknown): boolean =>
   vocabulary.includes(String(value));
 
+const validationValueLimit = 120;
+
+export function validationValueSummary(value: unknown): string {
+  const rendered = inspect(value, {
+    breakLength: Infinity,
+    compact: true,
+    depth: 3,
+    maxArrayLength: 20,
+    maxStringLength: 100,
+  });
+  const characters = [...rendered];
+  return characters.length <= validationValueLimit
+    ? rendered
+    : `${characters.slice(0, validationValueLimit - 1).join("")}…`;
+}
+
+export function validationError(entityId: string, field: string, actual: unknown, expectation: string): string {
+  return `entity=${validationValueSummary(entityId)} field=${field} ${expectation}; actual=${validationValueSummary(actual)}`;
+}
+
+export function validationEntityId(value: unknown, fields: readonly string[], fallback: string): string {
+  if (isJsonObject(value)) {
+    for (const field of fields) if (nonEmpty(value[field])) return value[field];
+  }
+  return fallback;
+}
+
+export function recordShapeError(
+  entityId: string,
+  value: unknown,
+  required: readonly string[],
+  allowed: readonly string[] = required,
+  prefix = "",
+): string | null {
+  const root = prefix || "$";
+  if (!isJsonObject(value)) return validationError(entityId, root, value, "must be an object");
+  const missing = required.find((field) => !Object.hasOwn(value, field));
+  if (missing) return validationError(entityId, joinValidationPath(prefix, missing), undefined, "field is required");
+  const unknown = Object.keys(value).find((field) => !allowed.includes(field));
+  return unknown
+    ? validationError(entityId, joinValidationPath(prefix, unknown), value[unknown], "field is not declared")
+    : null;
+}
+
+export function validationValueAtPath(value: unknown, field: string): unknown {
+  let current = value;
+  for (const segment of field.match(/[^.[\]]+/gu) ?? []) {
+    if (!isJsonObject(current) && !Array.isArray(current)) return undefined;
+    current = (current as unknown as Readonly<Record<string, unknown>>)[segment];
+  }
+  return current;
+}
+
+function joinValidationPath(prefix: string, field: string): string {
+  return prefix ? `${prefix}.${field}` : field;
+}
+
 export function actor(value: unknown): boolean {
   return (
     exactRecord(value, ["principal", "executor"]) &&
@@ -70,8 +128,7 @@ export function sessionProvenance(value: unknown): boolean {
 }
 
 export function validateGuiSubmission(value: unknown): readonly string[] {
-  if (
-    !exactRecord(value, [
+  const fields = [
       "completionClaim",
       "deliverables",
       "outputs",
@@ -79,19 +136,19 @@ export function validateGuiSubmission(value: unknown): readonly string[] {
       "knownGaps",
       "residualRisks",
       "commitSha",
-    ])
-  )
-    return [
-      [
-        "SubmissionV1 requires exactly: completionClaim, deliverables, outputs, ",
-        "verificationNotes, knownGaps, residualRisks, commitSha",
-      ].join(""),
-    ];
+    ],
+    entityId = validationEntityId(value, ["commitSha"], "submission:<unknown>"),
+    shapeError = recordShapeError(entityId, value, fields);
+  if (shapeError) return [shapeError];
+  if (!isJsonObject(value)) return [];
   const errors: string[] = [];
-  if (!nonEmpty(value.completionClaim)) errors.push("completionClaim must be a non-empty string");
+  if (!nonEmpty(value.completionClaim))
+    errors.push(validationError(entityId, "completionClaim", value.completionClaim, "must be a non-empty string"));
   for (const field of ["deliverables", "outputs", "verificationNotes", "knownGaps", "residualRisks"] as const)
-    if (!stringArray(value[field])) errors.push(`${field} must be an array of non-empty strings`);
-  if (!sha(value.commitSha)) errors.push("commitSha must be a native 40-character commit SHA");
+    if (!stringArray(value[field]))
+      errors.push(validationError(entityId, field, value[field], "must be an array of non-empty strings"));
+  if (!sha(value.commitSha))
+    errors.push(validationError(entityId, "commitSha", value.commitSha, "must be a native 40-character commit SHA"));
   return errors;
 }
 

--- a/packages/daemon/src/protocol/daemon-protocol-validate-projections.ts
+++ b/packages/daemon/src/protocol/daemon-protocol-validate-projections.ts
@@ -12,7 +12,10 @@ import {
   sha,
   statusWord,
   stringArray,
+  validationEntityId,
+  validationError,
   warningArray,
+  recordShapeError,
 } from "./daemon-protocol-validate-entities.ts";
 import { blockingAssessment, queryPageRow } from "./daemon-protocol-validate-task.ts";
 import { decisionStateWords, factLivenessWords, taskStatusWords } from "./daemon-protocol-vocabulary.ts";
@@ -53,34 +56,89 @@ export function agendaAwaiting(value: unknown): boolean {
 }
 
 export function validateDaemonAgenda(value: unknown): readonly string[] {
-  if (
-    !exactRecord(value, DAEMON_AGENDA_SCHEMA.required) ||
-    value.schema !== DAEMON_AGENDA_SCHEMA.id ||
-    value.ok !== true ||
-    value.command !== "agenda" ||
-    (value.status !== "ready" && value.status !== "pending") ||
-    !integer(value.watermark) ||
-    !integer(value.sourceRevision) ||
-    !warningArray(value.warnings) ||
-    !nonEmpty(value.summary) ||
-    !exactRecord(value.page, ["sourceLimit", "cursor", "nextCursor"]) ||
-    !integer(value.page.sourceLimit) ||
-    Number(value.page.sourceLimit) < 1 ||
-    Number(value.page.sourceLimit) > 500 ||
-    (value.page.cursor !== null && !nonEmpty(value.page.cursor)) ||
-    (value.page.nextCursor !== null && !nonEmpty(value.page.nextCursor)) ||
-    ![value.inFlight, value.waitingOnOthers, value.dispatchable].every(
-      (rows) => Array.isArray(rows) && rows.every(agendaTask),
-    ) ||
-    !Array.isArray(value.awaitingDecision) ||
-    !value.awaitingDecision.every(agendaAwaiting)
-  )
-    return ["daemon agenda is invalid"];
+  const entityId = validationEntityId(value, ["command"], "agenda"),
+    shapeError = recordShapeError(entityId, value, DAEMON_AGENDA_SCHEMA.required);
+  if (shapeError) return [shapeError];
+  if (!isJsonObject(value)) return [];
+  for (const [field, actual, valid, expectation] of [
+    ["schema", value.schema, value.schema === DAEMON_AGENDA_SCHEMA.id, "must match the agenda schema"],
+    ["ok", value.ok, value.ok === true, "must be true"],
+    ["command", value.command, value.command === "agenda", "must be agenda"],
+    ["status", value.status, value.status === "ready" || value.status === "pending", "must be ready or pending"],
+    ["watermark", value.watermark, integer(value.watermark), "must be an integer"],
+    ["sourceRevision", value.sourceRevision, integer(value.sourceRevision), "must be an integer"],
+    ["warnings", value.warnings, warningArray(value.warnings), "must contain valid warnings"],
+    ["summary", value.summary, nonEmpty(value.summary), "must be a non-empty string"],
+  ] as const)
+    if (!valid) return [validationError(entityId, field, actual, expectation)];
+  const pageShapeError = recordShapeError(
+    entityId,
+    value.page,
+    ["sourceLimit", "cursor", "nextCursor"],
+    undefined,
+    "page",
+  );
+  if (pageShapeError) return [pageShapeError];
+  if (!isJsonObject(value.page)) return [];
+  for (const [field, actual, valid, expectation] of [
+    [
+      "page.sourceLimit",
+      value.page.sourceLimit,
+      integer(value.page.sourceLimit) && Number(value.page.sourceLimit) >= 1 && Number(value.page.sourceLimit) <= 500,
+      "must be an integer from 1 through 500",
+    ],
+    [
+      "page.cursor",
+      value.page.cursor,
+      value.page.cursor === null || nonEmpty(value.page.cursor),
+      "must be null or non-empty",
+    ],
+    [
+      "page.nextCursor",
+      value.page.nextCursor,
+      value.page.nextCursor === null || nonEmpty(value.page.nextCursor),
+      "must be null or non-empty",
+    ],
+  ] as const)
+    if (!valid) return [validationError(entityId, field, actual, expectation)];
+  for (const field of ["inFlight", "waitingOnOthers", "dispatchable"] as const) {
+    if (!Array.isArray(value[field])) return [validationError(entityId, field, value[field], "must be an array")];
+    const invalidIndex = value[field].findIndex((row) => !agendaTask(row));
+    if (invalidIndex >= 0)
+      return [
+        validationError(
+          validationEntityId(value[field][invalidIndex], ["taskId"], entityId),
+          `${field}[${invalidIndex}]`,
+          value[field][invalidIndex],
+          "must be a valid agenda task",
+        ),
+      ];
+  }
+  if (!Array.isArray(value.awaitingDecision))
+    return [validationError(entityId, "awaitingDecision", value.awaitingDecision, "must be an array")];
+  const awaitingIndex = value.awaitingDecision.findIndex((row) => !agendaAwaiting(row));
+  if (awaitingIndex >= 0)
+    return [
+      validationError(
+        validationEntityId(value.awaitingDecision[awaitingIndex], ["taskId", "decisionId", "executionId"], entityId),
+        `awaitingDecision[${awaitingIndex}]`,
+        value.awaitingDecision[awaitingIndex],
+        "must be a valid awaiting item",
+      ),
+    ];
   return [];
 }
 
 export function validateDaemonRelationGraph(value: unknown): readonly string[] {
-  if (!recordWith(value, DAEMON_RELATION_GRAPH_SCHEMA.required)) return ["daemon relation graph is invalid"];
+  const entityId = `relation-graph:${isJsonObject(value) && nonEmpty(value.facet) ? value.facet : "full"}`,
+    requiredShapeError = recordShapeError(
+      entityId,
+      value,
+      DAEMON_RELATION_GRAPH_SCHEMA.required,
+      isJsonObject(value) ? Object.keys(value) : DAEMON_RELATION_GRAPH_SCHEMA.required,
+    );
+  if (requiredShapeError) return [requiredShapeError];
+  if (!isJsonObject(value)) return [];
   const full = value.facet === undefined,
     canonicalCut = full || value.facet !== "runtimeEdges",
     topFields = [
@@ -89,49 +147,87 @@ export function validateDaemonRelationGraph(value: unknown): readonly string[] {
       ...(full && value.page !== undefined ? ["page"] : []),
       ...(full ? [] : ["facet"]),
     ];
+  const shapeError = recordShapeError(entityId, value, topFields);
+  if (shapeError) return [shapeError];
+  for (const [field, actual, valid, expectation] of [
+    ["ok", value.ok, value.ok === true, "must be true"],
+    [
+      "status",
+      value.status,
+      !canonicalCut || value.status === "ready" || value.status === "pending",
+      "must be ready or pending",
+    ],
+    ["watermark", value.watermark, !canonicalCut || integer(value.watermark), "must be an integer"],
+    ["sourceRevision", value.sourceRevision, !canonicalCut || integer(value.sourceRevision), "must be an integer"],
+    ["warnings", value.warnings, warningArray(value.warnings), "must contain valid warnings"],
+    ["page", value.page, !full || value.page === undefined || queryPageRow(value.page), "must be a valid query page"],
+    ["edges", value.edges, Array.isArray(value.edges), "must be an array"],
+    ["coverageRows", value.coverageRows, Array.isArray(value.coverageRows), "must be an array"],
+    ["factAnchors", value.factAnchors, Array.isArray(value.factAnchors), "must be an array"],
+    ["facts", value.facts, Array.isArray(value.facts), "must be an array"],
+  ] as const)
+    if (!valid) return [validationError(entityId, field, actual, expectation)];
   if (
-    !exactRecord(value, topFields) ||
-    value.ok !== true ||
-    (canonicalCut &&
-      ((value.status !== "ready" && value.status !== "pending") ||
-        !integer(value.watermark) ||
-        !integer(value.sourceRevision))) ||
-    !warningArray(value.warnings) ||
-    (full && value.page !== undefined && !queryPageRow(value.page)) ||
     !Array.isArray(value.edges) ||
     !Array.isArray(value.coverageRows) ||
     !Array.isArray(value.factAnchors) ||
     !Array.isArray(value.facts)
   )
-    return ["daemon relation graph is invalid"];
+    return [];
   if (full) {
-    if (
-      value.edges.some(relationEdgeInvalid) ||
-      value.coverageRows.some(coverageRowInvalid) ||
-      value.factAnchors.some(factAnchorInvalid) ||
-      value.facts.some(fullFactInvalid)
-    )
-      return ["daemon relation graph is invalid"];
+    for (const [field, rows, invalid] of [
+      ["edges", value.edges, relationEdgeInvalid],
+      ["coverageRows", value.coverageRows, coverageRowInvalid],
+      ["factAnchors", value.factAnchors, factAnchorInvalid],
+      ["facts", value.facts, fullFactInvalid],
+    ] as const) {
+      const index = rows.findIndex(invalid);
+      if (index >= 0)
+        return [
+          validationError(
+            validationEntityId(rows[index], ["relationId", "decisionRef", "factRef", "factId", "ref"], entityId),
+            `${field}[${index}]`,
+            rows[index],
+            "must be a valid relation-graph row",
+          ),
+        ];
+    }
     return [];
   }
   if (!["edges", "facts", "coverageRows", "factAnchors", "runtimeEdges"].includes(String(value.facet)))
-    return ["daemon relation graph is invalid"];
+    return [validationError(entityId, "facet", value.facet, "must name a supported relation-graph facet")];
   // `runtimeEdges` 与 `edges` 同为边切面:选中的数组是 edges,其余必须为空。
   const edgesFacet = value.facet === "edges" || value.facet === "runtimeEdges";
-  const unselected = [
-    ...(edgesFacet ? [] : [value.edges]),
-    ...(value.facet === "coverageRows" ? [] : [value.coverageRows]),
-    ...(value.facet === "factAnchors" ? [] : [value.factAnchors]),
-    ...(value.facet === "facts" ? [] : [value.facts]),
-  ];
-  if (
-    unselected.some((rows) => rows.length !== 0) ||
-    (edgesFacet && value.edges.some(relationEdgeInvalid)) ||
-    (value.facet === "coverageRows" && value.coverageRows.some(coverageRowInvalid)) ||
-    (value.facet === "factAnchors" && value.factAnchors.some(factAnchorInvalid)) ||
-    (value.facet === "facts" && value.facts.some(factSummaryInvalid))
-  )
-    return ["daemon relation graph is invalid"];
+  const populatedUnselected = [
+    ["edges", value.edges, edgesFacet],
+    ["coverageRows", value.coverageRows, value.facet === "coverageRows"],
+    ["factAnchors", value.factAnchors, value.facet === "factAnchors"],
+    ["facts", value.facts, value.facet === "facts"],
+  ] as const;
+  const unexpected = populatedUnselected.find(([, rows, selected]) => !selected && rows.length !== 0);
+  if (unexpected)
+    return [validationError(entityId, unexpected[0], unexpected[1], "must be empty when its facet is not selected")];
+  const selected = edgesFacet
+    ? (["edges", value.edges, relationEdgeInvalid] as const)
+    : value.facet === "coverageRows"
+      ? (["coverageRows", value.coverageRows, coverageRowInvalid] as const)
+      : value.facet === "factAnchors"
+        ? (["factAnchors", value.factAnchors, factAnchorInvalid] as const)
+        : (["facts", value.facts, factSummaryInvalid] as const);
+  const invalidIndex = selected[1].findIndex(selected[2]);
+  if (invalidIndex >= 0)
+    return [
+      validationError(
+        validationEntityId(
+          selected[1][invalidIndex],
+          ["relationId", "decisionRef", "factRef", "factId", "anchor"],
+          entityId,
+        ),
+        `${selected[0]}[${invalidIndex}]`,
+        selected[1][invalidIndex],
+        "must be a valid selected-facet row",
+      ),
+    ];
   return [];
 }
 
@@ -262,23 +358,34 @@ export function readiness(value: unknown): boolean {
 
 export function validateDaemonDecisionList(value: unknown): readonly string[] {
   if (isJsonObject(value) && value.projection === "summary") {
-    if (
-      !exactRecord(value, ["ok", "projection", "decisions", "warnings"]) ||
-      value.ok !== true ||
-      !warningArray(value.warnings) ||
-      !Array.isArray(value.decisions) ||
-      value.decisions.some(
-        (row) =>
-          !exactRecord(row, ["decisionId", "title", "state", "appliesTo"]) ||
-          !nonEmpty(row.decisionId) ||
-          !nonEmpty(row.title) ||
-          !statusWord(decisionStateWords, row.state) ||
-          !exactRecord(row.appliesTo, ["modules", "productLines"]) ||
-          !stringArray(row.appliesTo.modules) ||
-          !stringArray(row.appliesTo.productLines),
-      )
-    )
-      return ["daemon decision list is invalid"];
+    const firstDecision = Array.isArray(value.decisions) ? value.decisions[0] : undefined,
+      entityId = validationEntityId(firstDecision, ["decisionId"], "decision-list:summary"),
+      shapeError = recordShapeError(entityId, value, ["ok", "projection", "decisions", "warnings"]);
+    if (shapeError) return [shapeError];
+    if (value.ok !== true) return [validationError(entityId, "ok", value.ok, "must be true")];
+    if (!warningArray(value.warnings))
+      return [validationError(entityId, "warnings", value.warnings, "must contain valid warnings")];
+    if (!Array.isArray(value.decisions))
+      return [validationError(entityId, "decisions", value.decisions, "must be an array")];
+    const invalidIndex = value.decisions.findIndex(
+      (row) =>
+        !exactRecord(row, ["decisionId", "title", "state", "appliesTo"]) ||
+        !nonEmpty(row.decisionId) ||
+        !nonEmpty(row.title) ||
+        !statusWord(decisionStateWords, row.state) ||
+        !exactRecord(row.appliesTo, ["modules", "productLines"]) ||
+        !stringArray(row.appliesTo.modules) ||
+        !stringArray(row.appliesTo.productLines),
+    );
+    if (invalidIndex >= 0)
+      return [
+        validationError(
+          validationEntityId(value.decisions[invalidIndex], ["decisionId"], entityId),
+          `decisions[${invalidIndex}]`,
+          value.decisions[invalidIndex],
+          "must be a valid decision summary",
+        ),
+      ];
     return [];
   }
   const fields = [
@@ -336,47 +443,62 @@ export function validateDaemonDecisionList(value: unknown): readonly string[] {
     ...DAEMON_DECISION_LIST_SCHEMA.required,
     ...(isJsonObject(value) && value.projection === "full" ? ["projection"] : []),
   ];
-  if (
-    !recordWith(value, DAEMON_DECISION_LIST_SCHEMA.required) ||
-    !exactRecord(value, topFields) ||
-    (value.projection !== undefined && value.projection !== "full") ||
-    value.ok !== true ||
-    !warningArray(value.warnings) ||
-    !Array.isArray(value.decisions) ||
-    value.decisions.some(
-      (row) =>
-        !recordWith(row, fields) ||
-        Object.keys(row).some((key) => !allowed.includes(key)) ||
-        history(row) ||
-        row.schema !== "decision-row/v1" ||
-        !integer(row.workspaceRevision) ||
-        [
-          "decisionId",
-          "path",
-          "state",
-          "title",
-          "question",
-          "riskTier",
-          "urgency",
-          "vertical",
-          "preset",
-          "decisionClass",
-          "proposedAt",
-        ].some((field) => !nonEmpty(row[field])) ||
-        (row.legacyId !== undefined && !/^E[1-9][0-9]*$/u.test(String(row.legacyId))) ||
-        (row.readiness !== undefined && !readiness(row.readiness)) ||
-        !Array.isArray(row.chosen) ||
-        !Array.isArray(row.rejected) ||
-        !Array.isArray(row.claims) ||
-        (row.provenance !== undefined &&
-          (!Array.isArray(row.provenance) || row.provenance.some((entry) => !sessionProvenance(entry)))) ||
-        !Array.isArray(row.judgmentConsents) ||
-        !isJsonObject(row.appliesTo) ||
-        !isJsonObject(row.proposer) ||
-        (row.arbiter !== null && !isJsonObject(row.arbiter)) ||
-        (row.body !== null && !isJsonObject(row.body)),
-    )
-  )
-    return ["daemon decision list is invalid"];
+  const entityId =
+      isJsonObject(value) && Array.isArray(value.decisions)
+        ? validationEntityId(value.decisions[0], ["decisionId"], "decision-list:full")
+        : "decision-list:full",
+    shapeError = recordShapeError(entityId, value, topFields);
+  if (shapeError) return [shapeError];
+  if (!isJsonObject(value)) return [];
+  for (const [field, actual, valid, expectation] of [
+    ["projection", value.projection, value.projection === undefined || value.projection === "full", "must be full"],
+    ["ok", value.ok, value.ok === true, "must be true"],
+    ["warnings", value.warnings, warningArray(value.warnings), "must contain valid warnings"],
+    ["decisions", value.decisions, Array.isArray(value.decisions), "must be an array"],
+  ] as const)
+    if (!valid) return [validationError(entityId, field, actual, expectation)];
+  if (!Array.isArray(value.decisions)) return [];
+  const invalidIndex = value.decisions.findIndex(
+    (row) =>
+      !recordWith(row, fields) ||
+      Object.keys(row).some((key) => !allowed.includes(key)) ||
+      history(row) ||
+      row.schema !== "decision-row/v1" ||
+      !integer(row.workspaceRevision) ||
+      [
+        "decisionId",
+        "path",
+        "state",
+        "title",
+        "question",
+        "riskTier",
+        "urgency",
+        "vertical",
+        "preset",
+        "decisionClass",
+        "proposedAt",
+      ].some((field) => !nonEmpty(row[field])) ||
+      (row.legacyId !== undefined && !/^E[1-9][0-9]*$/u.test(String(row.legacyId))) ||
+      (row.readiness !== undefined && !readiness(row.readiness)) ||
+      !Array.isArray(row.chosen) ||
+      !Array.isArray(row.rejected) ||
+      !Array.isArray(row.claims) ||
+      (row.provenance !== undefined &&
+        (!Array.isArray(row.provenance) || row.provenance.some((entry) => !sessionProvenance(entry)))) ||
+      !Array.isArray(row.judgmentConsents) ||
+      !isJsonObject(row.appliesTo) ||
+      !isJsonObject(row.proposer) ||
+      (row.arbiter !== null && !isJsonObject(row.arbiter)) ||
+      (row.body !== null && !isJsonObject(row.body)),
+  );
+  if (invalidIndex >= 0)
+    return [
+      validationError(
+        validationEntityId(value.decisions[invalidIndex], ["decisionId"], entityId),
+        `decisions[${invalidIndex}]`,
+        value.decisions[invalidIndex],
+        "must be a valid decision row",
+      ),
+    ];
   return [];
 }

--- a/packages/daemon/src/protocol/daemon-protocol-validate-results.ts
+++ b/packages/daemon/src/protocol/daemon-protocol-validate-results.ts
@@ -10,9 +10,11 @@ import {
   exactRecord,
   integer,
   nonEmpty,
-  recordWith,
   statusWord,
   stringArray,
+  validationEntityId,
+  validationError,
+  recordShapeError,
 } from "./daemon-protocol-validate-entities.ts";
 import {
   validateDaemonAgenda,
@@ -152,59 +154,95 @@ function scheduleListRow(value: unknown): value is ScheduleListRow {
 }
 
 export function validateDaemonDocumentRead(value: unknown): readonly string[] {
-  if (
-    !recordWith(value, DAEMON_DOCUMENT_READ_SCHEMA.required) ||
-    value.ok !== true ||
-    (value.status !== "ready" && value.status !== "pending") ||
-    !nonEmpty(value.taskId) ||
-    !nonEmpty(value.path) ||
-    typeof value.body !== "string" ||
-    (value.blobSha256 !== null &&
-      (typeof value.blobSha256 !== "string" || !/^[0-9a-f]{64}$/u.test(value.blobSha256))) ||
-    (value.worktreeBody !== null && typeof value.worktreeBody !== "string") ||
-    typeof value.uncommitted !== "boolean" ||
-    !integer(value.watermark) ||
-    !integer(value.sourceRevision)
-  )
-    return ["daemon document read is invalid"];
+  const entityId = validationEntityId(value, ["taskId"], "task:<unknown>"),
+    shapeError = recordShapeError(
+      entityId,
+      value,
+      DAEMON_DOCUMENT_READ_SCHEMA.required,
+      isJsonObject(value) ? Object.keys(value) : DAEMON_DOCUMENT_READ_SCHEMA.required,
+    );
+  if (shapeError) return [shapeError];
+  if (!isJsonObject(value)) return [];
+  for (const [field, actual, valid, expectation] of [
+    ["ok", value.ok, value.ok === true, "must be true"],
+    ["status", value.status, value.status === "ready" || value.status === "pending", "must be ready or pending"],
+    ["taskId", value.taskId, nonEmpty(value.taskId), "must be a non-empty string"],
+    ["path", value.path, nonEmpty(value.path), "must be a non-empty string"],
+    ["body", value.body, typeof value.body === "string", "must be a string"],
+    [
+      "blobSha256",
+      value.blobSha256,
+      value.blobSha256 === null || (typeof value.blobSha256 === "string" && /^[0-9a-f]{64}$/u.test(value.blobSha256)),
+      "must be null or a 64-character SHA-256",
+    ],
+    [
+      "worktreeBody",
+      value.worktreeBody,
+      value.worktreeBody === null || typeof value.worktreeBody === "string",
+      "must be null or a string",
+    ],
+    ["uncommitted", value.uncommitted, typeof value.uncommitted === "boolean", "must be a boolean"],
+    ["watermark", value.watermark, integer(value.watermark), "must be an integer"],
+    ["sourceRevision", value.sourceRevision, integer(value.sourceRevision), "must be an integer"],
+  ] as const)
+    if (!valid) return [validationError(entityId, field, actual, expectation)];
   return [];
 }
 
 export function validateDaemonTaskDocumentList(value: unknown): readonly string[] {
-  if (
-    !recordWith(value, DAEMON_TASK_DOCUMENT_LIST_SCHEMA.required) ||
-    value.ok !== true ||
-    (value.status !== "ready" && value.status !== "pending") ||
-    !nonEmpty(value.taskId) ||
-    !Array.isArray(value.documents) ||
-    value.documents.some(
-      (row) =>
-        !exactRecord(row, ["path", "blobSha256", "size", "mediaType", "uncommitted"]) ||
-        !nonEmpty(row.path) ||
-        row.path.startsWith("/") ||
-        row.path.split("/").includes("..") ||
-        !/^[0-9a-f]{64}$/u.test(String(row.blobSha256)) ||
-        !integer(row.size) ||
-        !nonEmpty(row.mediaType) ||
-        typeof row.uncommitted !== "boolean",
-    ) ||
-    !integer(value.watermark) ||
-    !integer(value.sourceRevision)
-  )
-    return ["daemon task document list is invalid"];
+  const entityId = validationEntityId(value, ["taskId"], "task:<unknown>"),
+    shapeError = recordShapeError(
+      entityId,
+      value,
+      DAEMON_TASK_DOCUMENT_LIST_SCHEMA.required,
+      isJsonObject(value) ? Object.keys(value) : DAEMON_TASK_DOCUMENT_LIST_SCHEMA.required,
+    );
+  if (shapeError) return [shapeError];
+  if (!isJsonObject(value)) return [];
+  for (const [field, actual, valid, expectation] of [
+    ["ok", value.ok, value.ok === true, "must be true"],
+    ["status", value.status, value.status === "ready" || value.status === "pending", "must be ready or pending"],
+    ["taskId", value.taskId, nonEmpty(value.taskId), "must be a non-empty string"],
+    ["documents", value.documents, Array.isArray(value.documents), "must be an array"],
+    ["watermark", value.watermark, integer(value.watermark), "must be an integer"],
+    ["sourceRevision", value.sourceRevision, integer(value.sourceRevision), "must be an integer"],
+  ] as const)
+    if (!valid) return [validationError(entityId, field, actual, expectation)];
+  if (!Array.isArray(value.documents)) return [];
+  const invalidIndex = value.documents.findIndex(
+    (row) =>
+      !exactRecord(row, ["path", "blobSha256", "size", "mediaType", "uncommitted"]) ||
+      !nonEmpty(row.path) ||
+      row.path.startsWith("/") ||
+      row.path.split("/").includes("..") ||
+      !/^[0-9a-f]{64}$/u.test(String(row.blobSha256)) ||
+      !integer(row.size) ||
+      !nonEmpty(row.mediaType) ||
+      typeof row.uncommitted !== "boolean",
+  );
+  if (invalidIndex >= 0)
+    return [
+      validationError(
+        entityId,
+        `documents[${invalidIndex}]`,
+        value.documents[invalidIndex],
+        "must be a valid document row",
+      ),
+    ];
   return [];
 }
 
 export function validateDaemonTaskDispatches(value: unknown): readonly string[] {
-  if (
-    !isJsonObject(value) ||
-    value.ok !== true ||
-    !["ready", "pending"].includes(String(value.status)) ||
-    !Array.isArray(value.dispatches) ||
-    !integer(value.watermark) ||
-    !integer(value.sourceRevision)
-  )
-    return ["daemon task dispatches is invalid"];
+  const entityId = validationEntityId(value, ["taskId"], "task-dispatches");
+  if (!isJsonObject(value)) return [validationError(entityId, "$", value, "must be an object")];
+  for (const [field, actual, valid, expectation] of [
+    ["ok", value.ok, value.ok === true, "must be true"],
+    ["status", value.status, value.status === "ready" || value.status === "pending", "must be ready or pending"],
+    ["dispatches", value.dispatches, Array.isArray(value.dispatches), "must be an array"],
+    ["watermark", value.watermark, integer(value.watermark), "must be an integer"],
+    ["sourceRevision", value.sourceRevision, integer(value.sourceRevision), "must be an integer"],
+  ] as const)
+    if (!valid) return [validationError(entityId, field, actual, expectation)];
   const taskIds = Array.isArray(value.taskIds) ? value.taskIds : [],
     unavailableTaskIds = Array.isArray(value.unavailableTaskIds) ? value.unavailableTaskIds : [],
     single =
@@ -228,8 +266,17 @@ export function validateDaemonTaskDispatches(value: unknown): readonly string[] 
         "watermark",
         "sourceRevision",
       ]);
-  if (!single && !batch) return ["daemon task dispatches is invalid"];
-  return value.dispatches.some(
+  if (!single && !batch)
+    return [
+      validationError(
+        validationEntityId(value, ["taskId"], validationEntityId({ taskId: taskIds[0] }, ["taskId"], entityId)),
+        "taskId|taskIds",
+        { taskId: value.taskId, taskIds: value.taskIds },
+        "must select one valid single or batch task scope",
+      ),
+    ];
+  if (!Array.isArray(value.dispatches)) return [];
+  const invalidIndex = value.dispatches.findIndex(
     (row) =>
       !isJsonObject(row) ||
       !nonEmpty(row.dispatchId) ||
@@ -264,26 +311,50 @@ export function validateDaemonTaskDispatches(value: unknown): readonly string[] 
       (row.exitCode !== undefined && row.exitCode !== null && (!integer(row.exitCode) || Number(row.exitCode) < 0)) ||
       (row.dispatchPath !== undefined && row.dispatchPath !== null && !nonEmpty(row.dispatchPath)) ||
       (row.reportPath !== undefined && row.reportPath !== null && !nonEmpty(row.reportPath)),
-  )
-    ? ["daemon task dispatch row is invalid"]
+  );
+  return invalidIndex >= 0
+    ? [
+        validationError(
+          validationEntityId(value.dispatches[invalidIndex], ["dispatchId", "taskId", "runtimeSessionId"], entityId),
+          `dispatches[${invalidIndex}]`,
+          value.dispatches[invalidIndex],
+          "must be a valid dispatch row",
+        ),
+      ]
     : [];
 }
 
 export function validateDaemonProtocolError(value: unknown): readonly string[] {
-  if (
-    !recordWith(value, DAEMON_PROTOCOL_ERROR_SCHEMA.required) ||
-    value.schema !== "command-receipt/v2" ||
-    value.ok !== false ||
-    value.outcome !== "op_rejected" ||
-    value.opId !== "N/A" ||
-    value.origin !== "daemon" ||
-    !recordWith(value.error, ["code", "hint"]) ||
-    [value.command, value.code, value.evidence, value.nextAction, value.error.code, value.error.hint].some(
-      (item) => !nonEmpty(item),
-    ) ||
-    value.code !== value.error.code
-  )
-    return ["daemon protocol error is invalid"];
+  const entityId = validationEntityId(value, ["command", "opId"], "protocol-error"),
+    shapeError = recordShapeError(
+      entityId,
+      value,
+      DAEMON_PROTOCOL_ERROR_SCHEMA.required,
+      isJsonObject(value) ? Object.keys(value) : DAEMON_PROTOCOL_ERROR_SCHEMA.required,
+    );
+  if (shapeError) return [shapeError];
+  if (!isJsonObject(value)) return [];
+  for (const [field, actual, valid, expectation] of [
+    ["schema", value.schema, value.schema === "command-receipt/v2", "must match command-receipt/v2"],
+    ["ok", value.ok, value.ok === false, "must be false"],
+    ["outcome", value.outcome, value.outcome === "op_rejected", "must be op_rejected"],
+    ["opId", value.opId, value.opId === "N/A", "must be N/A"],
+    ["origin", value.origin, value.origin === "daemon", "must be daemon"],
+    ["command", value.command, nonEmpty(value.command), "must be a non-empty string"],
+    ["code", value.code, nonEmpty(value.code), "must be a non-empty string"],
+    ["evidence", value.evidence, nonEmpty(value.evidence), "must be a non-empty string"],
+    ["nextAction", value.nextAction, nonEmpty(value.nextAction), "must be a non-empty string"],
+  ] as const)
+    if (!valid) return [validationError(entityId, field, actual, expectation)];
+  const errorShapeError = recordShapeError(entityId, value.error, ["code", "hint"], undefined, "error");
+  if (errorShapeError) return [errorShapeError];
+  if (!isJsonObject(value.error)) return [];
+  if (!nonEmpty(value.error.code))
+    return [validationError(entityId, "error.code", value.error.code, "must be a non-empty string")];
+  if (!nonEmpty(value.error.hint))
+    return [validationError(entityId, "error.hint", value.error.hint, "must be a non-empty string")];
+  if (value.code !== value.error.code)
+    return [validationError(entityId, "error.code", value.error.code, "must equal code")];
   return [];
 }
 
@@ -351,6 +422,7 @@ export const writeReceiptFields = [
 
 export function writeReceipt(value: JsonObject): string[] {
   const outcome = value.outcome,
+    entityId = validationEntityId(value, ["opId", "taskId", "decisionId", "command"], "receipt:<unknown>"),
     proof = isJsonObject(value.proof) ? value.proof : {},
     applied = outcome === "applied",
     pending = outcome === "pending",
@@ -363,37 +435,63 @@ export function writeReceipt(value: JsonObject): string[] {
       typeof proof.durable === "boolean" &&
       typeof proof.canonicalVisible === "boolean" &&
       (proof.worktreeVisible === null || typeof proof.worktreeVisible === "boolean");
-  return !statusWord(receiptOutcomeWords, outcome) ||
-    !nonEmpty(value.opId) ||
-    (value.revision !== undefined && (!integer(value.revision) || Number(value.revision) < 0)) ||
-    ((applied || pending || noChanges) &&
-      (!validProof || value.visibility !== "center" || !integer(value.revision) || !nonEmpty(value.evidence))) ||
-    (applied && (!proof.durable || !proof.canonicalVisible || proof.committedRevision !== proof.appliedCut)) ||
-    (pending && !nonEmpty(value.nextAction)) ||
-    (noChanges && (![value.code, value.origin, value.nextAction].every(nonEmpty) || value.code !== "no_changes")) ||
-    (failed &&
-      (![value.code, value.origin, value.nextAction].every(nonEmpty) ||
-        (value.evidence !== undefined && !nonEmpty(value.evidence))))
-    ? ["write receipt is invalid"]
-    : [];
+  if (!statusWord(receiptOutcomeWords, outcome))
+    return [validationError(entityId, "outcome", outcome, "must be a declared receipt outcome")];
+  if (!nonEmpty(value.opId)) return [validationError(entityId, "opId", value.opId, "must be a non-empty string")];
+  if (value.revision !== undefined && (!integer(value.revision) || Number(value.revision) < 0))
+    return [validationError(entityId, "revision", value.revision, "must be a non-negative integer")];
+  if ((applied || pending || noChanges) && !validProof)
+    return [validationError(entityId, "proof", value.proof, "must be a valid committed proof")];
+  if ((applied || pending || noChanges) && value.visibility !== "center")
+    return [validationError(entityId, "visibility", value.visibility, "must be center")];
+  if ((applied || pending || noChanges) && !integer(value.revision))
+    return [validationError(entityId, "revision", value.revision, "must be an integer")];
+  if ((applied || pending || noChanges) && !nonEmpty(value.evidence))
+    return [validationError(entityId, "evidence", value.evidence, "must be a non-empty string")];
+  if (applied && (!proof.durable || !proof.canonicalVisible || proof.committedRevision !== proof.appliedCut))
+    return [validationError(entityId, "proof", value.proof, "must prove durable canonical visibility at one cut")];
+  if (pending && !nonEmpty(value.nextAction))
+    return [validationError(entityId, "nextAction", value.nextAction, "must be a non-empty string")];
+  if (noChanges) {
+    for (const field of ["code", "origin", "nextAction"] as const)
+      if (!nonEmpty(value[field]))
+        return [validationError(entityId, field, value[field], "must be a non-empty string")];
+    if (value.code !== "no_changes") return [validationError(entityId, "code", value.code, "must be no_changes")];
+  }
+  if (failed) {
+    for (const field of ["code", "origin", "nextAction"] as const)
+      if (!nonEmpty(value[field]))
+        return [validationError(entityId, field, value[field], "must be a non-empty string")];
+    if (value.evidence !== undefined && !nonEmpty(value.evidence))
+      return [validationError(entityId, "evidence", value.evidence, "must be absent or non-empty")];
+  }
+  return [];
 }
 
 export function validateDaemonGuiCommandReceipt(value: unknown): readonly string[] {
-  if (!isJsonObject(value)) return ["GUI command receipt must be an object"];
+  const entityId = validationEntityId(
+    value,
+    ["opId", "taskId", "decisionId", "runtimeSessionId", "command"],
+    "receipt:<unknown>",
+  );
+  if (!isJsonObject(value)) return [validationError(entityId, "$", value, "must be an object")];
   const allowed = ["schema", "ok", "command", ...writeReceiptFields, ...guiReceiptExtensions],
     receipt = Object.fromEntries(
       writeReceiptFields.filter((field) => Object.hasOwn(value, field)).map((field) => [field, value[field]]),
     ) as JsonObject,
     ok = value.outcome === "applied" || value.outcome === "pending" || value.outcome === "no_changes",
-    errors =
-      Object.keys(value).some((field) => !allowed.includes(field)) ||
-      value.schema !== "command-receipt/v2" ||
-      typeof value.ok !== "boolean" ||
-      value.ok !== ok ||
-      !nonEmpty(value.command) ||
-      !daemonGuiActionMethods.some(({ actionKind }) => actionKind === value.command)
-        ? ["GUI command receipt envelope is invalid"]
-        : writeReceipt(receipt);
+    unknown = Object.keys(value).find((field) => !allowed.includes(field)),
+    errors: string[] = [];
+  if (unknown) errors.push(validationError(entityId, unknown, value[unknown], "field is not declared"));
+  else if (value.schema !== "command-receipt/v2")
+    errors.push(validationError(entityId, "schema", value.schema, "must match command-receipt/v2"));
+  else if (typeof value.ok !== "boolean") errors.push(validationError(entityId, "ok", value.ok, "must be a boolean"));
+  else if (value.ok !== ok) errors.push(validationError(entityId, "ok", value.ok, `must be ${ok}`));
+  else if (!nonEmpty(value.command))
+    errors.push(validationError(entityId, "command", value.command, "must be a non-empty string"));
+  else if (!daemonGuiActionMethods.some(({ actionKind }) => actionKind === value.command))
+    errors.push(validationError(entityId, "command", value.command, "must name a declared GUI action"));
+  else errors.push(...writeReceipt(receipt));
   if (
     (value.ok === false &&
       (!exactRecord(value.error, ["code", "hint"]) ||
@@ -402,7 +500,7 @@ export function validateDaemonGuiCommandReceipt(value: unknown): readonly string
         value.error.code !== value.code)) ||
     (value.ok === true && value.error !== undefined)
   )
-    errors.push("GUI command receipt error is invalid");
+    errors.push(validationError(entityId, "error", value.error, "must match the rejected receipt code"));
   const decisionFields = ["path", "commitSha", "documentSha256", "worktreeVisible", "consentId"],
     decision =
       (["decision-propose", "decision-accept", "decision-reject", "decision-defer"].includes(String(value.command)) &&
@@ -419,7 +517,7 @@ export function validateDaemonGuiCommandReceipt(value: unknown): readonly string
       value.worktreeVisible !== true ||
       (value.consentId !== null && !nonEmpty(value.consentId)))
   )
-    errors.push("decision receipt fidelity is invalid");
+    errors.push(validationError(entityId, "decisionReceipt", value, "must carry complete decision fidelity fields"));
   return errors;
 }
 

--- a/packages/daemon/src/protocol/daemon-protocol-validate-task.ts
+++ b/packages/daemon/src/protocol/daemon-protocol-validate-task.ts
@@ -313,7 +313,9 @@ function taskSnapshotRowErrors(value: unknown, index: number): readonly DaemonTa
       rowIndex: index,
       taskId,
       field: `rows[${index}]${field ? `.${field}` : ""}`,
-      message: `actual=${validationValueSummary(field ? validationValueAtPath(value, field) : value)}: Task snapshot field is invalid.`,
+      message:
+        `actual=${validationValueSummary(field ? validationValueAtPath(value, field) : value)}: ` +
+        "Task snapshot field is invalid.",
     });
   if (!isJsonObject(value)) return [error("")];
   const missing = taskSnapshotListRowFields.find((field) => !Object.hasOwn(value, field));

--- a/packages/daemon/src/protocol/daemon-protocol-validate-task.ts
+++ b/packages/daemon/src/protocol/daemon-protocol-validate-task.ts
@@ -19,7 +19,12 @@ import {
   statusWord,
   stringArray,
   task,
+  validationEntityId,
+  validationError,
+  validationValueAtPath,
+  validationValueSummary,
   warningArray,
+  recordShapeError,
 } from "./daemon-protocol-validate-entities.ts";
 import {
   decisionStateWords,
@@ -27,7 +32,7 @@ import {
   relationStateWords,
   taskStatusWords,
 } from "./daemon-protocol-vocabulary.ts";
-import { isJsonObject, unknownFieldViolation, type JsonObject } from "./json-rpc-types.ts";
+import { isJsonObject, type JsonObject } from "./json-rpc-types.ts";
 import type { DaemonTaskSnapshotInvalidRow } from "./daemon-protocol-gui-types.ts";
 
 export const availabilityFields = ["consents", "codeDocWitnesses", "gateWitnesses"] as const,
@@ -58,13 +63,16 @@ function validateProjectedTaskActionInput(
   record: Readonly<Record<string, unknown>>,
 ): readonly string[] {
   const allowed = new Set(["kind", "executor", ...input.fields.map(({ field }) => field)]),
+    entityId = validationEntityId(record, ["taskId", "executionId"], `action:${ingress}`),
     errors = Object.keys(record)
       .filter((field) => !allowed.has(field))
-      .map((field) => `${ingress}.${field} is not declared by the Action input schema`);
+      .map((field) =>
+        validationError(entityId, `action.${field}`, record[field], "is not declared by the Action input schema"),
+      );
   for (const field of input.fields) {
     const item = record[field.field];
     if (field.required && (item === undefined || item === "")) {
-      errors.push(`${ingress}.${field.field} is required`);
+      errors.push(validationError(entityId, `action.${field.field}`, item, "field is required"));
       continue;
     }
     if (item === undefined) continue;
@@ -82,32 +90,49 @@ function validateProjectedTaskActionInput(
             typeof (entry as { readonly factRef?: unknown }).factRef === "string" &&
             typeof (entry as { readonly rationale?: unknown }).rationale === "string",
         ));
-    if (!valid) errors.push(`${ingress}.${field.field} must be ${field.type}`);
+    if (!valid) errors.push(validationError(entityId, `action.${field.field}`, item, `must be ${field.type}`));
     if (field.enum && !field.enum.includes(String(item)))
-      errors.push(`${ingress}.${field.field} must be one of ${field.enum.join(", ")}`);
+      errors.push(validationError(entityId, `action.${field.field}`, item, `must be one of ${field.enum.join(", ")}`));
     if (field.regex && typeof item === "string" && !new RegExp(field.regex, "u").test(item))
-      errors.push(`${ingress}.${field.field} does not match its Action input pattern`);
+      errors.push(validationError(entityId, `action.${field.field}`, item, "does not match its Action input pattern"));
   }
   for (const group of input.exactlyOneOf) {
     const present = group.filter((field) => record[field] !== undefined);
-    if (present.length !== 1) errors.push(`${ingress} requires exactly one of ${group.join(", ")}`);
+    if (present.length !== 1)
+      errors.push(
+        validationError(
+          entityId,
+          `action.[${group.join("|")}]`,
+          Object.fromEntries(group.map((field) => [field, record[field]])),
+          "requires exactly one declared field",
+        ),
+      );
   }
   return errors;
 }
 
 export function validateSessionEnvironment(value: unknown): string[] {
   if (value === undefined) return [];
-  if (!isJsonObject(value)) return ["session environment must be an object"];
+  const entityId = validationEntityId(
+    value,
+    ["HARNESS_ACTOR", "CODEX_THREAD_ID", "CODEX_SESSION_ID", "CLAUDE_CODE_SESSION_ID"],
+    "session:<unknown>",
+  );
+  if (!isJsonObject(value)) return [validationError(entityId, "sessionEnvironment", value, "must be an object")];
   const allowed = ["CLAUDE_CODE_SESSION_ID", "CODEX_THREAD_ID", "CODEX_SESSION_ID", "HARNESS_ACTOR"],
-    unknown = unknownFieldViolation(value, allowed);
-  if (unknown) return [`session environment contains an ${unknown}`];
-  if (!Object.values(value).every((item) => typeof item === "string" && item.trim().length > 0))
-    return ["session environment values must be non-empty strings"];
+    unknown = Object.keys(value).find((field) => !allowed.includes(field));
+  if (unknown)
+    return [validationError(entityId, `sessionEnvironment.${unknown}`, value[unknown], "field is not declared")];
+  const invalidValue = Object.entries(value).find(([, item]) => typeof item !== "string" || item.trim().length === 0);
+  if (invalidValue)
+    return [
+      validationError(entityId, `sessionEnvironment.${invalidValue[0]}`, invalidValue[1], "must be a non-empty string"),
+    ];
   if (
     typeof value.HARNESS_ACTOR === "string" &&
     !/^agent:[A-Za-z0-9][A-Za-z0-9._:-]*$/u.test(value.HARNESS_ACTOR.trim())
   )
-    return ["session environment HARNESS_ACTOR must use agent:<id>"];
+    return [validationError(entityId, "sessionEnvironment.HARNESS_ACTOR", value.HARNESS_ACTOR, "must use agent:<id>")];
   return [];
 }
 
@@ -217,23 +242,39 @@ export function queryPageRow(value: unknown): boolean {
 }
 
 export function validateDaemonTaskSnapshotList(value: unknown): readonly string[] {
-  if (!recordWith(value, DAEMON_TASK_SNAPSHOT_LIST_SCHEMA.required)) return ["daemon task snapshot list is invalid"];
-  if (
-    Object.keys(value).some((field) => ![...DAEMON_TASK_SNAPSHOT_LIST_SCHEMA.required, "page"].includes(field)) ||
-    value.ok !== true ||
-    (value.status !== "ready" && value.status !== "pending") ||
-    !integer(value.watermark) ||
-    !integer(value.sourceRevision) ||
-    !warningArray(value.warnings) ||
-    (value.page !== undefined && !queryPageRow(value.page)) ||
-    !Array.isArray(value.rows) ||
-    !Array.isArray(value.invalidRows) ||
-    !value.invalidRows.every(invalidTaskSnapshotRow)
-  )
-    return ["daemon task snapshot list is invalid"];
-  return isolateDaemonTaskSnapshotRows(value.rows).invalidRows.length === 0
-    ? []
-    : ["daemon task snapshot list contains an unisolated invalid row"];
+  const entityId = taskSnapshotListEntityId(value),
+    shapeError = recordShapeError(entityId, value, DAEMON_TASK_SNAPSHOT_LIST_SCHEMA.required, [
+      ...DAEMON_TASK_SNAPSHOT_LIST_SCHEMA.required,
+      "page",
+    ]);
+  if (shapeError) return [shapeError];
+  if (!isJsonObject(value)) return [];
+  for (const [field, actual, valid, expectation] of [
+    ["ok", value.ok, value.ok === true, "must be true"],
+    ["status", value.status, value.status === "ready" || value.status === "pending", "must be ready or pending"],
+    ["watermark", value.watermark, integer(value.watermark), "must be an integer"],
+    ["sourceRevision", value.sourceRevision, integer(value.sourceRevision), "must be an integer"],
+    ["warnings", value.warnings, warningArray(value.warnings), "must contain valid warnings"],
+    ["page", value.page, value.page === undefined || queryPageRow(value.page), "must be a valid query page"],
+    ["rows", value.rows, Array.isArray(value.rows), "must be an array"],
+    ["invalidRows", value.invalidRows, Array.isArray(value.invalidRows), "must be an array"],
+  ] as const)
+    if (!valid) return [validationError(entityId, field, actual, expectation)];
+  if (!Array.isArray(value.invalidRows) || !Array.isArray(value.rows)) return [];
+  const invalidRowIndex = value.invalidRows.findIndex((row) => !invalidTaskSnapshotRow(row));
+  if (invalidRowIndex >= 0)
+    return [
+      validationError(
+        validationEntityId(value.invalidRows[invalidRowIndex], ["taskId"], entityId),
+        `invalidRows[${invalidRowIndex}]`,
+        value.invalidRows[invalidRowIndex],
+        "must be a valid isolated-row diagnostic",
+      ),
+    ];
+  const unisolated = isolateDaemonTaskSnapshotRows(value.rows).invalidRows[0];
+  return unisolated
+    ? [`entity=${validationValueSummary(unisolated.taskId)} field=${unisolated.field} ${unisolated.message}`]
+    : [];
 }
 
 export function isolateDaemonTaskSnapshotRows<T>(values: readonly T[]): {
@@ -272,9 +313,13 @@ function taskSnapshotRowErrors(value: unknown, index: number): readonly DaemonTa
       rowIndex: index,
       taskId,
       field: `rows[${index}]${field ? `.${field}` : ""}`,
-      message: "Task snapshot field is invalid.",
+      message: `actual=${validationValueSummary(field ? validationValueAtPath(value, field) : value)}: Task snapshot field is invalid.`,
     });
-  if (!exactRecord(value, taskSnapshotListRowFields)) return [error("")];
+  if (!isJsonObject(value)) return [error("")];
+  const missing = taskSnapshotListRowFields.find((field) => !Object.hasOwn(value, field));
+  if (missing) return [error(missing)];
+  const unknown = Object.keys(value).find((field) => !taskSnapshotListRowFields.includes(field as never));
+  if (unknown) return [error(unknown)];
   const errors: DaemonTaskSnapshotInvalidRow[] = [];
   if (!nonEmpty(value.taskId)) errors.push(error("taskId"));
   if (value.packagePath !== null && !nonEmpty(value.packagePath)) errors.push(error("packagePath"));
@@ -303,7 +348,8 @@ function invalidTaskSnapshotRow(value: unknown): boolean {
     Number(value.rowIndex) < 0 ||
     !nonEmpty(value.taskId) ||
     !nonEmpty(value.field) ||
-    !nonEmpty(value.message)
+    !nonEmpty(value.message) ||
+    !value.message.startsWith("actual=")
   )
     return false;
   const rowPath = `rows[${value.rowIndex}]`;
@@ -363,48 +409,89 @@ function snapshotFailurePaths(value: unknown, availability: unknown): readonly s
 }
 
 export function validateDaemonWorkspaceSummary(value: unknown): readonly string[] {
-  if (
-    !exactRecord(value, DAEMON_WORKSPACE_SUMMARY_SCHEMA.required) ||
-    value.schema !== DAEMON_WORKSPACE_SUMMARY_SCHEMA.id ||
-    value.ok !== true ||
-    (value.status !== "ready" && value.status !== "pending") ||
-    !integer(value.watermark) ||
-    !integer(value.sourceRevision) ||
-    !warningArray(value.warnings)
-  )
-    return ["daemon workspace summary is invalid"];
+  const entityId = "workspace",
+    shapeError = recordShapeError(entityId, value, DAEMON_WORKSPACE_SUMMARY_SCHEMA.required);
+  if (shapeError) return [shapeError];
+  if (!isJsonObject(value)) return [];
+  for (const [field, actual, valid, expectation] of [
+    ["schema", value.schema, value.schema === DAEMON_WORKSPACE_SUMMARY_SCHEMA.id, "must match the workspace schema"],
+    ["ok", value.ok, value.ok === true, "must be true"],
+    ["status", value.status, value.status === "ready" || value.status === "pending", "must be ready or pending"],
+    ["watermark", value.watermark, integer(value.watermark), "must be an integer"],
+    ["sourceRevision", value.sourceRevision, integer(value.sourceRevision), "must be an integer"],
+    ["warnings", value.warnings, warningArray(value.warnings), "must contain valid warnings"],
+  ] as const)
+    if (!valid) return [validationError(entityId, field, actual, expectation)];
   const taskStatuses = [...taskStatusWords, "unknown"],
     tasks = value.tasks,
     decisions = value.decisions;
-  if (!exactRecord(tasks, ["total", "byStatus"]) || !integer(tasks.total) || Number(tasks.total) < 0)
-    return ["daemon workspace task summary is invalid"];
+  const tasksShapeError = recordShapeError(entityId, tasks, ["total", "byStatus"], undefined, "tasks");
+  if (tasksShapeError) return [tasksShapeError];
+  if (!isJsonObject(tasks)) return [];
+  if (!integer(tasks.total) || Number(tasks.total) < 0)
+    return [validationError(entityId, "tasks.total", tasks.total, "must be a non-negative integer")];
   const byStatus = tasks.byStatus;
-  if (
-    !exactRecord(byStatus, taskStatuses) ||
-    taskStatuses.some((status) => !integer(byStatus[status]) || Number(byStatus[status]) < 0) ||
-    taskStatuses.reduce((sum, status) => sum + Number(byStatus[status]), 0) !== tasks.total
-  )
-    return ["daemon workspace task summary is invalid"];
-  if (
-    !exactRecord(decisions, ["total", "inboxCount", "byState", "groups"]) ||
-    !integer(decisions.total) ||
-    Number(decisions.total) < 0 ||
-    !integer(decisions.inboxCount) ||
-    Number(decisions.inboxCount) < 0 ||
-    !Array.isArray(decisions.groups)
-  )
-    return ["daemon workspace decision summary is invalid"];
+  const statusShapeError = recordShapeError(entityId, byStatus, taskStatuses, undefined, "tasks.byStatus");
+  if (statusShapeError) return [statusShapeError];
+  if (!isJsonObject(byStatus)) return [];
+  const invalidTaskStatus = taskStatuses.find((status) => !integer(byStatus[status]) || Number(byStatus[status]) < 0);
+  if (invalidTaskStatus)
+    return [
+      validationError(
+        entityId,
+        `tasks.byStatus.${invalidTaskStatus}`,
+        byStatus[invalidTaskStatus],
+        "must be a non-negative integer",
+      ),
+    ];
+  if (taskStatuses.reduce((sum, status) => sum + Number(byStatus[status]), 0) !== tasks.total)
+    return [validationError(entityId, "tasks.total", tasks.total, "must equal the by-status sum")];
+  const decisionsShapeError = recordShapeError(
+    entityId,
+    decisions,
+    ["total", "inboxCount", "byState", "groups"],
+    undefined,
+    "decisions",
+  );
+  if (decisionsShapeError) return [decisionsShapeError];
+  if (!isJsonObject(decisions)) return [];
+  if (!integer(decisions.total) || Number(decisions.total) < 0)
+    return [validationError(entityId, "decisions.total", decisions.total, "must be a non-negative integer")];
+  if (!integer(decisions.inboxCount) || Number(decisions.inboxCount) < 0)
+    return [validationError(entityId, "decisions.inboxCount", decisions.inboxCount, "must be a non-negative integer")];
+  if (!Array.isArray(decisions.groups))
+    return [validationError(entityId, "decisions.groups", decisions.groups, "must be an array")];
   const byDecisionState = decisions.byState;
-  if (
-    !exactRecord(byDecisionState, decisionStateWords) ||
-    decisionStateWords.some((state) => !integer(byDecisionState[state]) || Number(byDecisionState[state]) < 0) ||
-    decisionStateWords.reduce((sum, state) => sum + Number(byDecisionState[state]), 0) !== decisions.total
-  )
-    return ["daemon workspace decision summary is invalid"];
+  const stateShapeError = recordShapeError(
+    entityId,
+    byDecisionState,
+    decisionStateWords,
+    undefined,
+    "decisions.byState",
+  );
+  if (stateShapeError) return [stateShapeError];
+  if (!isJsonObject(byDecisionState)) return [];
+  const invalidDecisionState = decisionStateWords.find(
+    (state) => !integer(byDecisionState[state]) || Number(byDecisionState[state]) < 0,
+  );
+  if (invalidDecisionState)
+    return [
+      validationError(
+        entityId,
+        `decisions.byState.${invalidDecisionState}`,
+        byDecisionState[invalidDecisionState],
+        "must be a non-negative integer",
+      ),
+    ];
+  if (decisionStateWords.reduce((sum, state) => sum + Number(byDecisionState[state]), 0) !== decisions.total)
+    return [validationError(entityId, "decisions.total", decisions.total, "must equal the by-state sum")];
   const groupIds = ["proposed", "in_effect", "rejected", "deferred", "retired"],
     decisionIds: string[] = [],
     states: string[] = [];
-  if (decisions.groups.length !== groupIds.length) return ["daemon workspace decision groups are invalid"];
+  if (decisions.groups.length !== groupIds.length)
+    return [
+      validationError(entityId, "decisions.groups.length", decisions.groups.length, `must be ${groupIds.length}`),
+    ];
   for (const [index, group] of decisions.groups.entries()) {
     if (
       !exactRecord(group, ["id", "states", "count", "decisionIds"]) ||
@@ -418,7 +505,14 @@ export function validateDaemonWorkspaceSummary(value: unknown): readonly string[
       new Set(group.decisionIds).size !== group.decisionIds.length ||
       group.count !== group.decisionIds.length
     )
-      return ["daemon workspace decision groups are invalid"];
+      return [
+        validationError(
+          validationEntityId(group, ["id"], `decision-group:${index}`),
+          `decisions.groups[${index}]`,
+          group,
+          "must be a valid decision group",
+        ),
+      ];
     states.push(...group.states.map(String));
     decisionIds.push(...group.decisionIds.map(String));
   }
@@ -429,6 +523,16 @@ export function validateDaemonWorkspaceSummary(value: unknown): readonly string[
     decisions.total !== decisionIds.length ||
     decisions.inboxCount !== decisions.groups[0].count
   )
-    return ["daemon workspace decision totals are invalid"];
+    return [
+      validationError(entityId, "decisions.total", decisions.total, "must match unique grouped decisions and inbox"),
+    ];
   return [];
+}
+
+function taskSnapshotListEntityId(value: unknown): string {
+  if (isJsonObject(value) && Array.isArray(value.rows)) {
+    const rowId = validationEntityId(value.rows[0], ["taskId"], "");
+    if (rowId) return rowId;
+  }
+  return "task-snapshot-list";
 }

--- a/packages/daemon/src/protocol/gui-result-validation.ts
+++ b/packages/daemon/src/protocol/gui-result-validation.ts
@@ -18,6 +18,7 @@ import {
   validateSquadEntityDetail,
 } from "../agent-entities.contract.ts";
 import { validateObserveTailResult } from "./daemon-protocol-gui-types.ts";
+import { validationError } from "./daemon-protocol-validate-entities.ts";
 import { validateArtifactsList } from "./artifacts-gui-contract.ts";
 import { validateSchedulesList } from "./schedules-gui-contract.ts";
 import { validateScheduleRuns } from "../schedule-runs-read.ts";
@@ -59,14 +60,31 @@ import {
   type DaemonProtocolErrorResult,
 } from "./daemon-protocol.contract.ts";
 type ResultValidator = (value: unknown) => readonly string[];
-const validateDaemonSettingsRead: ResultValidator = (value) =>
+export const validateDaemonSettingsRead: ResultValidator = (value) =>
   isJsonObject(value) &&
   Object.keys(value).length === 3 &&
   value.schema === "daemon.settings-read/v1" &&
   value.ok === true &&
   validateSettingsV1(value.settings).length === 0
     ? []
-    : ["daemon settings read is invalid"];
+    : [
+        validationError(
+          "settings",
+          isJsonObject(value) && value.schema !== "daemon.settings-read/v1"
+            ? "schema"
+            : isJsonObject(value) && value.ok !== true
+              ? "ok"
+              : "settings",
+          isJsonObject(value)
+            ? value.schema !== "daemon.settings-read/v1"
+              ? value.schema
+              : value.ok !== true
+                ? value.ok
+                : value.settings
+            : value,
+          "must be a valid daemon settings read",
+        ),
+      ];
 const resultValidators = {
   "daemon.gui.system.read": validateSystemStatus,
   "daemon.gui.control.receipt": validateDaemonControlReceipt,

--- a/packages/daemon/src/protocol/json-rpc-dispatch-support.ts
+++ b/packages/daemon/src/protocol/json-rpc-dispatch-support.ts
@@ -68,6 +68,15 @@ export function resultErrorCode(result: object): string | null {
   const error = "error" in result ? result.error : undefined;
   return isJsonObject(error) && typeof error.code === "string" ? error.code : null;
 }
+export function resultErrorDetail(result: object): string | null {
+  if (resultOk(result)) return null;
+  const error = "error" in result ? result.error : undefined,
+    detail =
+      (isJsonObject(error) && typeof error.hint === "string" ? error.hint : null) ??
+      ("nextAction" in result && typeof result.nextAction === "string" ? result.nextAction : null) ??
+      ("evidence" in result && typeof result.evidence === "string" ? result.evidence : null);
+  return detail?.split(/;\s*/u, 1)[0]?.slice(0, 500) ?? "Unknown request failure.";
+}
 export function rpcError(id: JsonRpcId, errorCode: number, message: string): JsonRpcResponse {
   return { jsonrpc: "2.0", id, error: { code: errorCode, message } };
 }

--- a/packages/daemon/src/protocol/json-rpc-server.ts
+++ b/packages/daemon/src/protocol/json-rpc-server.ts
@@ -25,6 +25,7 @@ import {
   protocolErrorMessage,
   repoIdFromParams,
   resultErrorCode,
+  resultErrorDetail,
   resultOk,
   rpcError,
   rpcServerErrorCode,
@@ -90,11 +91,12 @@ export function createJsonRpcProtocolServer(options: {
         Date.now(),
         false,
         "-32600",
+        "Invalid Request",
       );
       return rpcError(id, -32600, "Invalid Request");
     }
     if (!isContractedDaemonRpcMethod(request.method)) {
-      traffic(request.method, frameReceivedAt, startedAt, Date.now(), false, "-32601");
+      traffic(request.method, frameReceivedAt, startedAt, Date.now(), false, "-32601", "Method not found");
       return rpcError(id, -32601, "Method not found");
     }
     const reply = <Method extends DaemonRpcMethod>(
@@ -104,7 +106,15 @@ export function createJsonRpcProtocolServer(options: {
       const repliedAt = Date.now(),
         serviceMs = repliedAt - startedAt;
       recordRequest(method, observed, result, dispatchDelayMs, serviceMs);
-      traffic(method, frameReceivedAt, startedAt, repliedAt, resultOk(result), resultErrorCode(result));
+      traffic(
+        method,
+        frameReceivedAt,
+        startedAt,
+        repliedAt,
+        resultOk(result),
+        resultErrorCode(result),
+        resultErrorDetail(result),
+      );
       return request.id === undefined ? undefined : { jsonrpc: "2.0", id, result };
     };
     const parsed = parseDaemonRpcParams(request.method, request.params);
@@ -517,6 +527,7 @@ export function createJsonRpcProtocolServer(options: {
     repliedAt: number,
     ok: boolean,
     code: string | null,
+    detail: string | null,
   ): void {
     if (!options.recordTraffic) return;
     options.recordTraffic({
@@ -532,6 +543,7 @@ export function createJsonRpcProtocolServer(options: {
       durationMs: Math.max(0, repliedAt - handlerStartedAt),
       ok,
       code,
+      detail,
     });
   }
 }

--- a/packages/daemon/src/transition-document-access.ts
+++ b/packages/daemon/src/transition-document-access.ts
@@ -8,6 +8,7 @@ import {
   resolveHarnessLayout,
   sha256Text,
   type TaskProjection,
+  type TransitionDocumentMissingSection,
 } from "../../kernel/src/index.ts";
 
 export type TaskTransitionDocumentSlot = "task.plan" | "task.closeout";
@@ -148,16 +149,32 @@ function readOnDiskBody(rootDir: string, documentPath: string): string | null {
     : null;
 }
 
-function transitionMissingSections(error: object): readonly string[] {
+function transitionMissingSections(error: object): readonly TransitionDocumentMissingSection[] {
   return "missingSections" in error && Array.isArray(error.missingSections)
-    ? error.missingSections.filter((value): value is string => typeof value === "string")
+    ? error.missingSections.filter(
+        (value): value is TransitionDocumentMissingSection =>
+          value !== null &&
+          typeof value === "object" &&
+          "section" in value &&
+          typeof value.section === "string" &&
+          "reason" in value &&
+          (value.reason === "empty" || value.reason === "scaffold") &&
+          (value.reason === "empty" || ("retainedScaffold" in value && typeof value.retainedScaffold === "string")),
+      )
     : [];
 }
 
-function missingSectionsHint(sections: readonly string[]): string {
+export function missingSectionsHint(sections: readonly TransitionDocumentMissingSection[]): string {
   return sections.length === 0
     ? "it has no missing required sections."
-    : `its missing required ${sections.length === 1 ? "section is" : "sections are"}: ${sections.join(", ")}.`;
+    : [
+        "required-section diagnostics:",
+        ...sections.map((entry) =>
+          entry.reason === "empty"
+            ? `- ${entry.section}: 空`
+            : `- ${entry.section}: 仍含模板句「${entry.retainedScaffold ?? ""}」`,
+        ),
+      ].join("\n");
 }
 
 function transitionDocumentAccessError(code: string, message: string): Error {

--- a/packages/daemon/test/conn-log.test.ts
+++ b/packages/daemon/test/conn-log.test.ts
@@ -5,65 +5,174 @@ import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 import { daemonConnLogFileStem, DAEMON_CONN_LOG_SCHEMA, openDaemonConnLog } from "../src/conn-log.ts";
+import { resultErrorDetail } from "../src/protocol/json-rpc-dispatch-support.ts";
 
-function tempRoot(): string { return mkdtempSync(path.join(os.tmpdir(), "harness-conn-log-")); }
+function tempRoot(): string {
+  return mkdtempSync(path.join(os.tmpdir(), "harness-conn-log-"));
+}
 function recordsOf(userRoot: string, daemonId = "test-daemon"): Record<string, unknown>[] {
   const dir = path.join(userRoot, "logs");
-  return readdirSync(dir).filter((name) => name.startsWith(daemonConnLogFileStem(daemonId)) && name.endsWith(".jsonl")).flatMap((name) =>
-    readFileSync(path.join(dir, name), "utf8").split("\n").filter((line) => line.length > 0).map((line) => JSON.parse(line) as Record<string, unknown>));
+  return readdirSync(dir)
+    .filter((name) => name.startsWith(daemonConnLogFileStem(daemonId)) && name.endsWith(".jsonl"))
+    .flatMap((name) =>
+      readFileSync(path.join(dir, name), "utf8")
+        .split("\n")
+        .filter((line) => line.length > 0)
+        .map((line) => JSON.parse(line) as Record<string, unknown>),
+    );
 }
 const at = (iso: string) => () => new Date(iso);
 
+test("request failure detail selects only the first validator error", () => {
+  assert.equal(
+    resultErrorDetail({ ok: false, error: { code: "invalid_result", hint: "first validator error; second error" } }),
+    "first validator error",
+  );
+  assert.equal(resultErrorDetail({ ok: true }), null);
+});
+
 test("conn log records open/request/close with monotonic ids, active counts, and per-connection request totals", async () => {
-  const userRoot = tempRoot(), log = openDaemonConnLog({ userRoot, daemonId: "test-daemon", now: at("2026-08-20T13:00:00Z") });
-  const first = log.connectionOpened("uuid-1", "unix-socket"), second = log.connectionOpened("uuid-2", "unix-socket");
-  assert.equal(first, "c-1"); assert.equal(second, "c-2");
-  log.request({ conn: first, transport: "unix-socket", method: "protocol.hello", frameReceivedAt: Date.parse("2026-08-20T13:00:00.990Z"), handlerStartedAt: Date.parse("2026-08-20T13:00:01Z"), repliedAt: Date.parse("2026-08-20T13:00:01.003Z"), startedAt: Date.parse("2026-08-20T13:00:01Z"), dispatchDelayMs: 10, serviceMs: 3, durationMs: 3, ok: true, code: null });
-  log.request({ conn: first, transport: "unix-socket", method: "daemon.status", startedAt: Date.parse("2026-08-20T13:00:02Z"), durationMs: 11, ok: true, code: null });
+  const userRoot = tempRoot(),
+    log = openDaemonConnLog({ userRoot, daemonId: "test-daemon", now: at("2026-08-20T13:00:00Z") });
+  const first = log.connectionOpened("uuid-1", "unix-socket"),
+    second = log.connectionOpened("uuid-2", "unix-socket");
+  assert.equal(first, "c-1");
+  assert.equal(second, "c-2");
+  log.request({
+    conn: first,
+    transport: "unix-socket",
+    method: "protocol.hello",
+    frameReceivedAt: Date.parse("2026-08-20T13:00:00.990Z"),
+    handlerStartedAt: Date.parse("2026-08-20T13:00:01Z"),
+    repliedAt: Date.parse("2026-08-20T13:00:01.003Z"),
+    startedAt: Date.parse("2026-08-20T13:00:01Z"),
+    dispatchDelayMs: 10,
+    serviceMs: 3,
+    durationMs: 3,
+    ok: true,
+    code: null,
+    detail: null,
+  });
+  log.request({
+    conn: first,
+    transport: "unix-socket",
+    method: "daemon.status",
+    startedAt: Date.parse("2026-08-20T13:00:02Z"),
+    durationMs: 11,
+    ok: true,
+    code: null,
+    detail: null,
+  });
   log.connectionClosed("uuid-1");
-  log.request({ conn: second, transport: "unix-socket", method: "repo.task.run", startedAt: Date.parse("2026-08-20T13:00:04Z"), durationMs: 40, ok: false, code: "repo_warming" });
+  log.request({
+    conn: second,
+    transport: "unix-socket",
+    method: "repo.task.run",
+    startedAt: Date.parse("2026-08-20T13:00:04Z"),
+    durationMs: 40,
+    ok: false,
+    code: "repo_warming",
+    detail: 'entity="task-1" field=status must be ready; actual="warming"',
+  });
   log.connectionClosed("uuid-2");
   await log.settle();
   const records = recordsOf(userRoot);
-  assert.deepEqual(records.map((record) => record.event), ["conn_open", "conn_open", "request", "request", "conn_close", "request", "conn_close"]);
-  assert.equal(records[0].conn, "c-1"); assert.equal(records[0].active, 1); assert.equal(records[1].conn, "c-2"); assert.equal(records[1].active, 2);
-  const hello = records[2] as { at: string; atEnd: string; frameReceivedAt: string; handlerStartedAt: string; repliedAt: string; dispatchDelayMs: number; serviceMs: number; durationMs: number; method: string; ok: boolean };
-  assert.equal(hello.method, "protocol.hello"); assert.equal(hello.at, "2026-08-20T13:00:01.000Z"); assert.equal(hello.frameReceivedAt, "2026-08-20T13:00:00.990Z"); assert.equal(hello.handlerStartedAt, hello.at); assert.equal(hello.repliedAt, "2026-08-20T13:00:01.003Z"); assert.equal(hello.atEnd, hello.repliedAt); assert.equal(hello.dispatchDelayMs, 10); assert.equal(hello.serviceMs, 3); assert.equal(hello.durationMs, 3); assert.equal(hello.ok, true);
+  assert.deepEqual(
+    records.map((record) => record.event),
+    ["conn_open", "conn_open", "request", "request", "conn_close", "request", "conn_close"],
+  );
+  assert.equal(records[0].conn, "c-1");
+  assert.equal(records[0].active, 1);
+  assert.equal(records[1].conn, "c-2");
+  assert.equal(records[1].active, 2);
+  const hello = records[2] as {
+    at: string;
+    atEnd: string;
+    frameReceivedAt: string;
+    handlerStartedAt: string;
+    repliedAt: string;
+    dispatchDelayMs: number;
+    serviceMs: number;
+    durationMs: number;
+    method: string;
+    ok: boolean;
+  };
+  assert.equal(hello.method, "protocol.hello");
+  assert.equal(hello.at, "2026-08-20T13:00:01.000Z");
+  assert.equal(hello.frameReceivedAt, "2026-08-20T13:00:00.990Z");
+  assert.equal(hello.handlerStartedAt, hello.at);
+  assert.equal(hello.repliedAt, "2026-08-20T13:00:01.003Z");
+  assert.equal(hello.atEnd, hello.repliedAt);
+  assert.equal(hello.dispatchDelayMs, 10);
+  assert.equal(hello.serviceMs, 3);
+  assert.equal(hello.durationMs, 3);
+  assert.equal(hello.ok, true);
   const close = records[4] as { conn: string; active: number; durationMs: number; requests: number };
-  assert.equal(close.conn, "c-1"); assert.equal(close.active, 1); assert.equal(close.requests, 2); assert.equal(close.durationMs, 0);
-  const rejected = records[5] as { ok: boolean; code: string | null };
-  assert.equal(rejected.ok, false); assert.equal(rejected.code, "repo_warming");
+  assert.equal(close.conn, "c-1");
+  assert.equal(close.active, 1);
+  assert.equal(close.requests, 2);
+  assert.equal(close.durationMs, 0);
+  const rejected = records[5] as { ok: boolean; code: string | null; detail: string };
+  assert.equal(rejected.ok, false);
+  assert.equal(rejected.code, "repo_warming");
+  assert.match(rejected.detail, /task-1.*field=status/u);
   const lastClose = records[6] as { conn: string; active: number };
-  assert.equal(lastClose.conn, "c-2"); assert.equal(lastClose.active, 0);
-  for (const record of records) { assert.equal(record.schema, DAEMON_CONN_LOG_SCHEMA.id); assert.equal(record.daemonId, "test-daemon"); assert.equal(typeof record.pid, "number"); assert.equal(typeof record.at, "string"); }
+  assert.equal(lastClose.conn, "c-2");
+  assert.equal(lastClose.active, 0);
+  for (const record of records) {
+    assert.equal(record.schema, DAEMON_CONN_LOG_SCHEMA.id);
+    assert.equal(record.daemonId, "test-daemon");
+    assert.equal(typeof record.pid, "number");
+    assert.equal(typeof record.at, "string");
+  }
   rmSync(userRoot, { recursive: true, force: true });
 });
 
 test("conn log rolls over at a UTC day boundary and keeps both day files", async () => {
-  const userRoot = tempRoot(); let iso = "2026-08-20T23:59:58Z";
+  const userRoot = tempRoot();
+  let iso = "2026-08-20T23:59:58Z";
   const log = openDaemonConnLog({ userRoot, daemonId: "day", now: () => new Date(iso) });
   // The write picks its day file asynchronously, so each day's write is flushed before the clock
   // advances — the same ordering a real midnight rollover produces.
-  log.connectionOpened("a", "unix-socket"); await log.settle();
-  iso = "2026-08-21T00:00:01Z"; log.connectionOpened("b", "unix-socket"); await log.settle();
+  log.connectionOpened("a", "unix-socket");
+  await log.settle();
+  iso = "2026-08-21T00:00:01Z";
+  log.connectionOpened("b", "unix-socket");
+  await log.settle();
   const names = readdirSync(path.join(userRoot, "logs")).sort();
   assert.deepEqual(names, ["daemon-day-conn-20260820.jsonl", "daemon-day-conn-20260821.jsonl"]);
   rmSync(userRoot, { recursive: true, force: true });
 });
 
 test("conn log prunes day files beyond the kept-days horizon", async () => {
-  const userRoot = tempRoot(), dir = path.join(userRoot, "logs"); mkdirSync(dir, { recursive: true });
-  for (let day = 1; day <= 12; day += 1) writeFileSync(path.join(dir, `daemon-prune-conn-202608${String(day).padStart(2, "0")}.jsonl`), "\n", "utf8");
+  const userRoot = tempRoot(),
+    dir = path.join(userRoot, "logs");
+  mkdirSync(dir, { recursive: true });
+  for (let day = 1; day <= 12; day += 1)
+    writeFileSync(path.join(dir, `daemon-prune-conn-202608${String(day).padStart(2, "0")}.jsonl`), "\n", "utf8");
   const log = openDaemonConnLog({ userRoot, daemonId: "prune", keptDays: 7, now: at("2026-08-13T10:00:00Z") });
-  log.connectionOpened("a", "unix-socket"); await log.settle();
+  log.connectionOpened("a", "unix-socket");
+  await log.settle();
   const names = readdirSync(dir).sort();
-  assert.deepEqual(names, ["daemon-prune-conn-20260806.jsonl", "daemon-prune-conn-20260807.jsonl", "daemon-prune-conn-20260808.jsonl", "daemon-prune-conn-20260809.jsonl", "daemon-prune-conn-20260810.jsonl", "daemon-prune-conn-20260811.jsonl", "daemon-prune-conn-20260812.jsonl", "daemon-prune-conn-20260813.jsonl"]);
+  assert.deepEqual(names, [
+    "daemon-prune-conn-20260806.jsonl",
+    "daemon-prune-conn-20260807.jsonl",
+    "daemon-prune-conn-20260808.jsonl",
+    "daemon-prune-conn-20260809.jsonl",
+    "daemon-prune-conn-20260810.jsonl",
+    "daemon-prune-conn-20260811.jsonl",
+    "daemon-prune-conn-20260812.jsonl",
+    "daemon-prune-conn-20260813.jsonl",
+  ]);
   rmSync(userRoot, { recursive: true, force: true });
 });
 
 test("conn log rotates the day file by size into generation suffixes", async () => {
-  const userRoot = tempRoot(), log = openDaemonConnLog({ userRoot, daemonId: "size", maxBytes: 220, now: at("2026-08-20T10:00:00Z") });
-  log.connectionOpened("a", "unix-socket"); log.connectionOpened("b", "unix-socket"); log.connectionOpened("c", "unix-socket");
+  const userRoot = tempRoot(),
+    log = openDaemonConnLog({ userRoot, daemonId: "size", maxBytes: 220, now: at("2026-08-20T10:00:00Z") });
+  log.connectionOpened("a", "unix-socket");
+  log.connectionOpened("b", "unix-socket");
+  log.connectionOpened("c", "unix-socket");
   await log.settle();
   const names = readdirSync(path.join(userRoot, "logs")).sort();
   assert.deepEqual(names, ["daemon-size-conn-20260820.jsonl", "daemon-size-conn-20260820.jsonl.1"]);
@@ -71,21 +180,46 @@ test("conn log rotates the day file by size into generation suffixes", async () 
 });
 
 test("a failing conn log reports once and never throws into the request path", async () => {
-  const userRoot = tempRoot(), blocker = path.join(userRoot, "logs"); writeFileSync(blocker, "not a directory", "utf8");
+  const userRoot = tempRoot(),
+    blocker = path.join(userRoot, "logs");
+  writeFileSync(blocker, "not a directory", "utf8");
   const failures: unknown[] = [];
-  const log = openDaemonConnLog({ userRoot, daemonId: "fail", now: at("2026-08-20T10:00:00Z"), onFailure: (error) => failures.push(error) });
-  log.connectionOpened("a", "unix-socket"); log.request({ conn: "c-1", transport: "unix-socket", method: "protocol.hello", startedAt: 0, durationMs: 1, ok: true, code: null });
+  const log = openDaemonConnLog({
+    userRoot,
+    daemonId: "fail",
+    now: at("2026-08-20T10:00:00Z"),
+    onFailure: (error) => failures.push(error),
+  });
+  log.connectionOpened("a", "unix-socket");
+  log.request({
+    conn: "c-1",
+    transport: "unix-socket",
+    method: "protocol.hello",
+    startedAt: 0,
+    durationMs: 1,
+    ok: true,
+    code: null,
+    detail: null,
+  });
   await log.settle();
-  log.connectionOpened("b", "unix-socket"); await log.settle();
+  log.connectionOpened("b", "unix-socket");
+  await log.settle();
   assert.equal(failures.length, 1);
   rmSync(userRoot, { recursive: true, force: true });
 });
 
 test("a close for a connection this sink never saw is ignored instead of corrupting the active count", async () => {
-  const userRoot = tempRoot(), log = openDaemonConnLog({ userRoot, daemonId: "ghost", now: at("2026-08-20T10:00:00Z") });
-  log.connectionOpened("a", "unix-socket"); log.connectionClosed("never-opened"); log.connectionClosed("a"); await log.settle();
+  const userRoot = tempRoot(),
+    log = openDaemonConnLog({ userRoot, daemonId: "ghost", now: at("2026-08-20T10:00:00Z") });
+  log.connectionOpened("a", "unix-socket");
+  log.connectionClosed("never-opened");
+  log.connectionClosed("a");
+  await log.settle();
   const records = recordsOf(userRoot, "ghost");
-  assert.deepEqual(records.map((record) => record.event), ["conn_open", "conn_close"]);
+  assert.deepEqual(
+    records.map((record) => record.event),
+    ["conn_open", "conn_close"],
+  );
   assert.equal((records.at(-1) as { active: number }).active, 0);
   rmSync(userRoot, { recursive: true, force: true });
 });

--- a/packages/daemon/test/daemon-conn-log.integration.test.ts
+++ b/packages/daemon/test/daemon-conn-log.integration.test.ts
@@ -9,18 +9,37 @@ import { daemonConnLogFileStem } from "../src/conn-log.ts";
 import { startDaemon } from "../src/runtime.ts";
 import { currentDaemonProtocolVersion } from "../src/protocol/version.ts";
 
-interface ConnRecord { readonly event: string; readonly conn?: string; readonly method?: string | null; readonly ok?: boolean; readonly code?: string | null; readonly active?: number; readonly requests?: number }
+interface ConnRecord {
+  readonly event: string;
+  readonly conn?: string;
+  readonly method?: string | null;
+  readonly ok?: boolean;
+  readonly code?: string | null;
+  readonly detail?: string;
+  readonly active?: number;
+  readonly requests?: number;
+}
 
-function tempRoot(): string { return mkdtempSync(path.join(os.tmpdir(), "harness-daemon-conn-")); }
+function tempRoot(): string {
+  return mkdtempSync(path.join(os.tmpdir(), "harness-daemon-conn-"));
+}
 
 // One socket, several frames, half-closed as soon as every response arrived — the same shape a
 // short-lived CLI client produces (connect, hello, command, close).
 async function session(endpoint: string, frames: readonly string[]): Promise<readonly string[]> {
   return await new Promise((resolve, reject) => {
-    const socket = net.connect(endpoint), lines: string[] = [];
-    socket.on("connect", () => { for (const frame of frames) socket.write(`${frame}\n`); });
+    const socket = net.connect(endpoint),
+      lines: string[] = [];
+    socket.on("connect", () => {
+      for (const frame of frames) socket.write(`${frame}\n`);
+    });
     socket.on("data", (chunk: Buffer) => {
-      lines.push(...chunk.toString().split("\n").filter((line) => line.length > 0));
+      lines.push(
+        ...chunk
+          .toString()
+          .split("\n")
+          .filter((line) => line.length > 0),
+      );
       if (lines.length >= frames.length) socket.end();
     });
     socket.on("error", reject);
@@ -29,32 +48,61 @@ async function session(endpoint: string, frames: readonly string[]): Promise<rea
 }
 
 test("a live daemon logs hello, dispatched requests, rejections, and connection open/close per socket", async () => {
-  const userRoot = tempRoot(), daemon = await startDaemon({ daemonId: "connlog", userRoot });
+  const userRoot = tempRoot(),
+    daemon = await startDaemon({ daemonId: "connlog", userRoot });
   assert.ok(!("pid" in daemon), "no incumbent daemon can hold a claim over a fresh temp user root");
   try {
-    const hello = { jsonrpc: "2.0", id: 1, method: "protocol.hello", params: { protocolVersion: currentDaemonProtocolVersion } };
-    const first = await session(daemon.endpoint, [JSON.stringify(hello), JSON.stringify({ jsonrpc: "2.0", id: 2, method: "daemon.status" }), JSON.stringify({ jsonrpc: "2.0", id: 3, method: "no.such.method" })]);
+    const hello = {
+      jsonrpc: "2.0",
+      id: 1,
+      method: "protocol.hello",
+      params: { protocolVersion: currentDaemonProtocolVersion },
+    };
+    const first = await session(daemon.endpoint, [
+      JSON.stringify(hello),
+      JSON.stringify({ jsonrpc: "2.0", id: 2, method: "daemon.status" }),
+      JSON.stringify({ jsonrpc: "2.0", id: 3, method: "no.such.method" }),
+    ]);
     assert.equal(first.length, 3);
     await new Promise((resolve) => setTimeout(resolve, 25));
     const second = await session(daemon.endpoint, [JSON.stringify(hello)]);
     assert.equal(second.length, 1);
     await new Promise((resolve) => setTimeout(resolve, 25));
     await daemon.stop();
-    const dir = path.join(userRoot, "logs"), day = new Date().toISOString().slice(0, 10).replaceAll("-", "");
+    const dir = path.join(userRoot, "logs"),
+      day = new Date().toISOString().slice(0, 10).replaceAll("-", "");
     const file = readdirSync(dir).find((name) => name === `${daemonConnLogFileStem("connlog")}${day}.jsonl`);
     assert.ok(file, `conn log file for today exists among ${readdirSync(dir).join(", ")}`);
-    const records = readFileSync(path.join(dir, file!), "utf8").split("\n").filter((line) => line.length > 0).map((line) => JSON.parse(line) as ConnRecord);
-    assert.deepEqual(records.filter((record) => record.event === "conn_open").map((record) => record.conn), ["c-1", "c-2"]);
+    const records = readFileSync(path.join(dir, file!), "utf8")
+      .split("\n")
+      .filter((line) => line.length > 0)
+      .map((line) => JSON.parse(line) as ConnRecord);
+    assert.deepEqual(
+      records.filter((record) => record.event === "conn_open").map((record) => record.conn),
+      ["c-1", "c-2"],
+    );
     const firstRequests = records.filter((record) => record.event === "request" && record.conn === "c-1");
-    assert.deepEqual(firstRequests.map((record) => record.method), ["protocol.hello", "daemon.status", "no.such.method"]);
-    assert.deepEqual(firstRequests.map((record) => record.ok), [true, true, false]);
+    assert.deepEqual(
+      firstRequests.map((record) => record.method),
+      ["protocol.hello", "daemon.status", "no.such.method"],
+    );
+    assert.deepEqual(
+      firstRequests.map((record) => record.ok),
+      [true, true, false],
+    );
     assert.equal((firstRequests.at(-1) as ConnRecord).code, "-32601");
+    assert.equal((firstRequests.at(-1) as ConnRecord).detail, "Method not found");
     const closes = records.filter((record) => record.event === "conn_close");
-    assert.deepEqual(closes.map((record) => record.conn), ["c-1", "c-2"]);
+    assert.deepEqual(
+      closes.map((record) => record.conn),
+      ["c-1", "c-2"],
+    );
     // Sequential sessions: each socket is fully closed before the next dials in, so the count
     // drains to zero at every close; the unit suite covers the overlapping-connection shape.
-    assert.equal((closes[0] as ConnRecord).requests, 3); assert.equal((closes[0] as ConnRecord).active, 0);
-    assert.equal((closes[1] as ConnRecord).requests, 1); assert.equal((closes[1] as ConnRecord).active, 0);
+    assert.equal((closes[0] as ConnRecord).requests, 3);
+    assert.equal((closes[0] as ConnRecord).active, 0);
+    assert.equal((closes[1] as ConnRecord).requests, 1);
+    assert.equal((closes[1] as ConnRecord).active, 0);
   } finally {
     await daemon.stop();
     rmSync(userRoot, { recursive: true, force: true });

--- a/packages/daemon/test/gui-submission-validation.test.ts
+++ b/packages/daemon/test/gui-submission-validation.test.ts
@@ -10,7 +10,7 @@ const valid = Object.freeze({
   verificationNotes: ["npm test green"],
   knownGaps: [],
   residualRisks: [],
-  commitSha: "a".repeat(40)
+  commitSha: "a".repeat(40),
 });
 
 test("#1546: a valid submission has no issues", () => {
@@ -19,20 +19,33 @@ test("#1546: a valid submission has no issues", () => {
 
 test("#1546: a wrong-shape field is named with its expected shape, not a generic sentence", () => {
   const wrongDeliverables = validateGuiSubmission({ ...valid, deliverables: [{ kind: "text" }] });
-  assert.deepEqual(wrongDeliverables, ["deliverables must be an array of non-empty strings"]);
+  assert.deepEqual(wrongDeliverables, [
+    "entity='aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' field=deliverables must be an array of non-empty strings; actual=[ { kind: 'text' } ]",
+  ]);
   const wrongCommitSha = validateGuiSubmission({ ...valid, commitSha: "not-a-sha" });
-  assert.deepEqual(wrongCommitSha, ["commitSha must be a native 40-character commit SHA"]);
+  assert.deepEqual(wrongCommitSha, [
+    "entity='not-a-sha' field=commitSha must be a native 40-character commit SHA; actual='not-a-sha'",
+  ]);
   const emptyClaim = validateGuiSubmission({ ...valid, completionClaim: "" });
-  assert.deepEqual(emptyClaim, ["completionClaim must be a non-empty string"]);
+  assert.deepEqual(emptyClaim, [
+    "entity='aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' field=completionClaim must be a non-empty string; actual=''",
+  ]);
 });
 
 test("#1546: multiple simultaneously wrong fields are all named, not just the first", () => {
   const issues = validateGuiSubmission({ ...valid, deliverables: [1], commitSha: "bad" });
-  assert.deepEqual(issues, ["deliverables must be an array of non-empty strings", "commitSha must be a native 40-character commit SHA"]);
+  assert.deepEqual(issues, [
+    "entity='bad' field=deliverables must be an array of non-empty strings; actual=[ 1 ]",
+    "entity='bad' field=commitSha must be a native 40-character commit SHA; actual='bad'",
+  ]);
 });
 
 test("#1546: a wrong field SET still fails closed with one message naming the exact contract", () => {
   const { knownGaps: _knownGaps, ...missingField } = valid;
-  assert.deepEqual(validateGuiSubmission(missingField), ["SubmissionV1 requires exactly: completionClaim, deliverables, outputs, verificationNotes, knownGaps, residualRisks, commitSha"]);
-  assert.deepEqual(validateGuiSubmission({ ...valid, extra: "unexpected" }), ["SubmissionV1 requires exactly: completionClaim, deliverables, outputs, verificationNotes, knownGaps, residualRisks, commitSha"]);
+  assert.deepEqual(validateGuiSubmission(missingField), [
+    "entity='aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' field=knownGaps field is required; actual=undefined",
+  ]);
+  assert.deepEqual(validateGuiSubmission({ ...valid, extra: "unexpected" }), [
+    "entity='aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' field=extra field is not declared; actual='unexpected'",
+  ]);
 });

--- a/packages/daemon/test/hitrate-task-lifecycle.integration.test.ts
+++ b/packages/daemon/test/hitrate-task-lifecycle.integration.test.ts
@@ -72,7 +72,10 @@ test("task start, inline submit, and code-doc reconcile reuse daemon-known lifec
       /task\.plan readiness judged the canonical projection document at workspace revision \d+/u,
     );
     assert.match(placeholder.nextAction ?? "", /The on-disk harness\/tasks\/.*\/task_plan\.md differs/u);
-    assert.match(placeholder.nextAction ?? "", /missing required section is: CI\/Gate Authority Stop Condition/u);
+    assert.match(
+      placeholder.nextAction ?? "",
+      /required-section diagnostics:\n- CI\/Gate Authority Stop Condition: 空/u,
+    );
     assert.match(placeholder.nextAction ?? "", new RegExp(`ha doc sync --submit --path ${planPath}`, "u"));
     assert.doesNotMatch(placeholder.nextAction ?? "", /missing required sections are: Brief/u);
     const closeoutPath = `${packagePath}/closeout.md`;

--- a/packages/daemon/test/json-rpc-protocol.test.ts
+++ b/packages/daemon/test/json-rpc-protocol.test.ts
@@ -42,6 +42,13 @@ import { openRepoCell as openProductRepoCell } from "../src/repo-cell.ts";
 import { openBootstrappedRepoCell as openRepoCell, seedSettingsEvent } from "./repo-settings.fixture.ts";
 const DOC_POLICY_ID = "markdown-body-replaceable/v1";
 
+function assertValidationDiagnostic(errors: readonly string[], entity: RegExp, field: string): void {
+  assert.equal(errors.length, 1);
+  assert.match(errors[0]!, entity);
+  assert.match(errors[0]!, new RegExp(`field=${field.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&")}(?: |$)`, "u"));
+  assert.match(errors[0]!, /actual=/u);
+}
+
 const actor = { principal: { personId: "person-owner" }, executor: { kind: "agent", id: "codex" } } as const;
 const repoWriteBinding = withRoleBinding({ actor, source: "local" as const }, "repo-write");
 
@@ -156,9 +163,15 @@ test("protocol hello accepts only runtime identity and executor-attribution vari
   const hello = (sessionEnvironment?: Record<string, unknown>) => parseDaemonRpcParams("protocol.hello", { protocolVersion: currentDaemonProtocolVersion, ...(sessionEnvironment ? { sessionEnvironment } : {}) });
   assert.equal(hello().ok, true);
   assert.equal(hello({ CLAUDE_CODE_SESSION_ID: "claude-session", CODEX_THREAD_ID: "codex-thread", CODEX_SESSION_ID: "codex-thread", HARNESS_ACTOR: "agent:worker" }).ok, true);
-  assert.deepEqual(hello({ CLAUDE_CODE_HOST_SESSION_ID: "local-wrong" }), { ok: false, errors: ["session environment contains an unknown field \"CLAUDE_CODE_HOST_SESSION_ID\"; allowed fields: \"CLAUDE_CODE_SESSION_ID\", \"CODEX_THREAD_ID\", \"CODEX_SESSION_ID\", \"HARNESS_ACTOR\"."] });
-  assert.deepEqual(hello({ CODEX_THREAD_ID: " " }), { ok: false, errors: ["session environment values must be non-empty strings"] });
-  assert.deepEqual(hello({ HARNESS_ACTOR: "person:spoof" }), { ok: false, errors: ["session environment HARNESS_ACTOR must use agent:<id>"] });
+  for (const [input, field] of [
+    [{ CLAUDE_CODE_HOST_SESSION_ID: "local-wrong" }, "sessionEnvironment.CLAUDE_CODE_HOST_SESSION_ID"],
+    [{ CODEX_THREAD_ID: " " }, "sessionEnvironment.CODEX_THREAD_ID"],
+    [{ HARNESS_ACTOR: "person:spoof" }, "sessionEnvironment.HARNESS_ACTOR"],
+  ] as const) {
+    const result = hello(input);
+    assert.equal(result.ok, false);
+    if (!result.ok) assertValidationDiagnostic(result.errors, /entity=/u, field);
+  }
 });
 
 // prettier-ignore
@@ -211,15 +224,15 @@ test("relation graph contract accepts the materialized ledger row schema and rej
   const cut = { status: "ready", watermark: 7, sourceRevision: 7 }, payload = { ok: true, ...cut, edges: [{ relationId: "rel_real", sourceRef: "decision/dec_REAL/C1", targetRef: "fact/F-REAL", relationType: "evidenced-by", direction: "directed", strength: "strong", origin: "declared", state: "active", rationale: "Observed.", ownerRef: "decision/dec_REAL", sourcePath: "harness/decisions/decision-dec_REAL/decision.md", recordIndex: 0 }], coverageRows: [{ decisionRef: "decision/dec_REAL", claimRef: "decision/dec_REAL/C1", status: "covered", fulfillment: "standing-policy", relationPath: ["rel_real"] }], factAnchors: [{ factRef: "fact/F-REAL", taskId: "task_REAL", factId: "F-REAL", sourcePath: "harness/facts/F-REAL.md" }], facts: [{ schema: "task-fact-row/v1", ref: "fact/F-REAL", taskId: "task_REAL", factId: "F-REAL", statement: "Real observation.", source: "harness/facts/F-REAL.md", observedAt: "2026-08-14T00:00:00.000Z", confidence: "high", memoryClass: "semantic", memoryTags: [], provenance: [], liveness: "standing" }], warnings: [] };
   assert.deepEqual(validateDaemonRelationGraph(payload), []);
   assert.deepEqual(validateDaemonRelationGraph({ ...payload, page: { limit: 25, cursor: null, nextCursor: "WyJyZWxfcmVhbCJd" } }), []);
-  assert.deepEqual(validateDaemonRelationGraph({ ...payload, page: { limit: 0, cursor: null, nextCursor: null } }), ["daemon relation graph is invalid"]);
-  assert.deepEqual(validateDaemonRelationGraph({ ...payload, coverageRows: [{ ...payload.coverageRows[0], fulfillment: "standing_policy" }] }), ["daemon relation graph is invalid"]);
+  assertValidationDiagnostic(validateDaemonRelationGraph({ ...payload, page: { limit: 0, cursor: null, nextCursor: null } }), /relation-graph:full/u, "page");
+  assertValidationDiagnostic(validateDaemonRelationGraph({ ...payload, coverageRows: [{ ...payload.coverageRows[0], fulfillment: "standing_policy" }] }), /decision\/dec_REAL/u, "coverageRows[0]");
   // The optional uncovered-cause classification is accepted per registered word and
   // rejected on garbage; absence (older daemons, covered rows) stays valid.
   assert.deepEqual(validateDaemonRelationGraph({ ...payload, coverageRows: [{ ...payload.coverageRows[0], status: "uncovered", fulfillment: null, freshnessReason: "fulfillment-undeclared" }] }), []);
   assert.deepEqual(validateDaemonRelationGraph({ ...payload, coverageRows: [{ ...payload.coverageRows[0], status: "uncovered", fulfillment: null, freshnessReason: "no-live-evidence" }] }), []);
   assert.deepEqual(validateDaemonRelationGraph({ ...payload, coverageRows: [{ ...payload.coverageRows[0], status: "uncovered", fulfillment: null, freshnessReason: "refuted", refutingFactRefs: ["fact/F-REAL"] }] }), []);
-  assert.deepEqual(validateDaemonRelationGraph({ ...payload, coverageRows: [{ ...payload.coverageRows[0], status: "uncovered", fulfillment: null, freshnessReason: "stale" }] }), ["daemon relation graph is invalid"]);
-  const { observedAt: _observedAt, ...missingObservedAt } = payload.facts[0]; assert.deepEqual(validateDaemonRelationGraph({ ...payload, facts: [missingObservedAt] }), ["daemon relation graph is invalid"]);
+  assertValidationDiagnostic(validateDaemonRelationGraph({ ...payload, coverageRows: [{ ...payload.coverageRows[0], status: "uncovered", fulfillment: null, freshnessReason: "stale" }] }), /decision\/dec_REAL/u, "coverageRows[0]");
+  const { observedAt: _observedAt, ...missingObservedAt } = payload.facts[0]; assertValidationDiagnostic(validateDaemonRelationGraph({ ...payload, facts: [missingObservedAt] }), /F-REAL/u, "facts[0]");
   const empty = { edges: [], coverageRows: [], factAnchors: [], facts: [] };
   const facets = [
     { ok: true, ...cut, facet: "edges", ...empty, edges: payload.edges, warnings: [] },
@@ -228,10 +241,10 @@ test("relation graph contract accepts the materialized ledger row schema and rej
     { ok: true, ...cut, facet: "factAnchors", ...empty, factAnchors: payload.factAnchors, warnings: [] },
   ];
   for (const facet of facets) assert.deepEqual(validateDaemonRelationGraph(facet), [], String(facet.facet));
-  assert.deepEqual(validateDaemonRelationGraph({ ...facets[0], facet: "unknown" }), ["daemon relation graph is invalid"]);
-  assert.deepEqual(validateDaemonRelationGraph({ ...facets[1], extra: true }), ["daemon relation graph is invalid"]);
-  assert.deepEqual(validateDaemonRelationGraph({ ...facets[2], facts: facets[1]!.facts }), ["daemon relation graph is invalid"]);
-  assert.deepEqual(validateDaemonRelationGraph({ ...facets[1], facts: [{ ...facets[1]!.facts[0], category: "semantic" }] }), ["daemon relation graph is invalid"]);
+  assertValidationDiagnostic(validateDaemonRelationGraph({ ...facets[0], facet: "unknown" }), /relation-graph:unknown/u, "facet");
+  assertValidationDiagnostic(validateDaemonRelationGraph({ ...facets[1], extra: true }), /relation-graph:facts/u, "extra");
+  assertValidationDiagnostic(validateDaemonRelationGraph({ ...facets[2], facts: facets[1]!.facts }), /relation-graph:coverageRows/u, "facts");
+  assertValidationDiagnostic(validateDaemonRelationGraph({ ...facets[1], facts: [{ ...facets[1]!.facts[0], category: "semantic" }] }), /F-REAL/u, "facts[0]");
 });
 
 // prettier-ignore
@@ -1171,11 +1184,11 @@ test("decision readiness survives the wire when the canonical Git cut is unavail
   assert.deepEqual(validateDaemonDecisionList({ ...decisionList(noCut[0]!), projection: "full" }), []);
   const summary = { ok: true, projection: "summary", decisions: [{ decisionId: "dec_1", title: "Title", state: "in_effect", appliesTo: { modules: ["daemon"], productLines: ["gui"] } }], warnings: [] };
   assert.deepEqual(validateDaemonDecisionList(summary), []);
-  assert.deepEqual(validateDaemonDecisionList({ ...summary, decisions: [{ ...summary.decisions[0]!, readiness: noCut[0] }] }), ["daemon decision list is invalid"]);
-  assert.deepEqual(validateDaemonDecisionList({ ...summary, decisions: [{ ...summary.decisions[0]!, state: "unknown" }] }), ["daemon decision list is invalid"]);
+  assertValidationDiagnostic(validateDaemonDecisionList({ ...summary, decisions: [{ ...summary.decisions[0]!, readiness: noCut[0] }] }), /dec_1/u, "decisions[0]");
+  assertValidationDiagnostic(validateDaemonDecisionList({ ...summary, decisions: [{ ...summary.decisions[0]!, state: "unknown" }] }), /dec_1/u, "decisions[0]");
 
   const verdictWithoutBasis = { ...noCut[0]!, appliesToDrift: { ...noCut[0]!.appliesToDrift, state: "clear" as const } };
-  assert.deepEqual(validateDaemonDecisionList(decisionList(verdictWithoutBasis)), ["daemon decision list is invalid"]);
+  assertValidationDiagnostic(validateDaemonDecisionList(decisionList(verdictWithoutBasis)), /dec_1/u, "decisions[0]");
 });
 
 // A flag can be declared on the init command, parsed by the CLI, and honored by the bootstrap

--- a/packages/daemon/test/task-query-read.test.ts
+++ b/packages/daemon/test/task-query-read.test.ts
@@ -170,14 +170,11 @@ test("task snapshot list isolates an invalid row and continues serving valid row
     result.rows.map(({ taskId }) => taskId),
     ["task_valid"],
   );
-  assert.deepEqual(result.invalidRows, [
-    {
-      rowIndex: 1,
-      taskId: "task_invalid",
-      field: "rows[1].snapshot.codeDocWitnesses[0]",
-      message: "Task snapshot field is invalid.",
-    },
-  ]);
+  assert.deepEqual(
+    result.invalidRows.map(({ message: _message, ...diagnostic }) => diagnostic),
+    [{ rowIndex: 1, taskId: "task_invalid", field: "rows[1].snapshot.codeDocWitnesses[0]" }],
+  );
+  assert.match(result.invalidRows[0]!.message, /^actual=.*Task snapshot field is invalid\.$/u);
 });
 
 test("a surface fails closed instead of stitching mismatched projection cuts", () => {
@@ -201,12 +198,12 @@ test("task reads fail closed when event truth has no packageDisposition", () => 
 test("relation graph validator accepts the canonical cut and rejects invented fields", () => {
   const result = queryRead(process.cwd(), projectionStub()).relationGraph();
   assert.deepEqual(validateDaemonRelationGraph(result), []);
-  assert.deepEqual(
-    validateDaemonRelationGraph({ ...result, projection: { schema: "event-projection-cut/v1", ...readyCut } }),
-    ["daemon relation graph is invalid"],
+  assert.match(
+    validateDaemonRelationGraph({ ...result, projection: { schema: "event-projection-cut/v1", ...readyCut } })[0]!,
+    /entity=.*field=projection .*actual=/u,
   );
   const { sourceRevision: _sourceRevision, ...missingCut } = result;
-  assert.deepEqual(validateDaemonRelationGraph(missingCut), ["daemon relation graph is invalid"]);
+  assert.match(validateDaemonRelationGraph(missingCut)[0]!, /entity=.*field=sourceRevision .*actual=/u);
 });
 
 function queryRead(rootDir: string, projection: TaskProjection) {

--- a/packages/daemon/test/task-snapshot-protocol.contract.test.ts
+++ b/packages/daemon/test/task-snapshot-protocol.contract.test.ts
@@ -81,13 +81,10 @@ test("task snapshot protocol isolates a malformed field with its source row iden
     result = { ...list, ...isolated };
 
   assert.deepEqual(isolated.rows, [row]);
-  assert.deepEqual(isolated.invalidRows, [
-    {
-      rowIndex: 1,
-      taskId: "task-invalid",
-      field: "rows[1].snapshot.codeDocWitnesses[0]",
-      message: "Task snapshot field is invalid.",
-    },
-  ]);
+  assert.deepEqual(
+    isolated.invalidRows.map(({ message: _message, ...diagnostic }) => diagnostic),
+    [{ rowIndex: 1, taskId: "task-invalid", field: "rows[1].snapshot.codeDocWitnesses[0]" }],
+  );
+  assert.match(isolated.invalidRows[0]!.message, /^actual=.*Task snapshot field is invalid\.$/u);
   assert.deepEqual(validateDaemonTaskSnapshotList(result), []);
 });

--- a/packages/daemon/test/transition-document-access.test.ts
+++ b/packages/daemon/test/transition-document-access.test.ts
@@ -1,0 +1,70 @@
+// harness-test-tier: fast
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import { assessTransitionDocument } from "../../kernel/src/index.ts";
+import { missingSectionsHint } from "../src/transition-document-access.ts";
+
+const planHeadings = [
+  "Brief",
+  "Goal",
+  "Context",
+  "Required Reading",
+  "Entry Conditions",
+  "Dependencies",
+  "Execution Surface",
+  "Constraints",
+  "Checkpoint",
+  "CI/Gate Authority Stop Condition",
+  "Implementation Plan",
+  "Deliverable Contract",
+  "Evidence Protocol",
+  "Verification",
+] as const;
+
+test("transition-document hints explain scaffold, empty, and ready sections line by line", () => {
+  const template = readFileSync(
+      new URL("../../preset/assets/software-coding/templates/task.plan/en-US.md", import.meta.url),
+      "utf8",
+    ),
+    partial = realizedPlan().replace(
+      "## Brief\n\nImplemented Brief.",
+      "## Brief\n\nOne-line statement of the task objective and scope.",
+    ),
+    empty = realizedPlan().replace("## Verification\n\nImplemented Verification.", "## Verification\n\n"),
+    cases = [
+      {
+        name: "all-template plan",
+        body: template,
+        expectedFirst: "- Brief: 仍含模板句「One-line statement of the task objective and scope.」",
+        expectedLines: 15,
+      },
+      {
+        name: "partially realized plan",
+        body: partial,
+        expectedFirst: "- Brief: 仍含模板句「One-line statement of the task objective and scope.」",
+        expectedLines: 2,
+      },
+      { name: "empty section", body: empty, expectedFirst: "- Verification: 空", expectedLines: 2 },
+      {
+        name: "fully realized plan",
+        body: realizedPlan(),
+        expectedFirst: "it has no missing required sections.",
+        expectedLines: 1,
+      },
+    ] as const;
+
+  for (const fixture of cases) {
+    const hint = missingSectionsHint(assessTransitionDocument("task.plan", fixture.body).missingSections);
+    assert.equal(hint.split("\n").length, fixture.expectedLines, fixture.name);
+    assert.match(hint, new RegExp(escapeRegExp(fixture.expectedFirst), "u"), fixture.name);
+  }
+});
+
+function realizedPlan(): string {
+  return `# Plan\n\n${planHeadings.map((heading) => `## ${heading}\n\nImplemented ${heading}.`).join("\n\n")}\n`;
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
+}

--- a/packages/daemon/test/validator-diagnostic-contract.test.ts
+++ b/packages/daemon/test/validator-diagnostic-contract.test.ts
@@ -1,0 +1,299 @@
+// harness-test-tier: contract
+import assert from "node:assert/strict";
+import test from "node:test";
+import { validateDaemonSettingsRead } from "../src/protocol/gui-result-validation.ts";
+import {
+  validateDaemonAgenda,
+  validateDaemonDecisionList,
+  validateDaemonDocumentRead,
+  validateDaemonGuiCommandReceipt,
+  validateDaemonProtocolError,
+  validateDaemonRelationGraph,
+  validateDaemonTaskDispatches,
+  validateDaemonTaskDocumentList,
+  validateDaemonTaskSnapshotList,
+  validateDaemonWorkspaceSummary,
+  validateGuiSubmission,
+} from "../src/protocol/daemon-protocol.contract.ts";
+import {
+  validateCatalogActionPayload,
+  validateSessionEnvironment,
+} from "../src/protocol/daemon-protocol-validate-task.ts";
+import { writeReceipt } from "../src/protocol/daemon-protocol-validate-results.ts";
+import type { JsonObject } from "../src/protocol/json-rpc-types.ts";
+
+interface ValidatorCase {
+  readonly name: string;
+  readonly entityId: string;
+  readonly field: string;
+  readonly validate: () => readonly string[];
+}
+
+const relationGraph = {
+    ok: true,
+    status: "ready",
+    watermark: 1,
+    sourceRevision: 1,
+    edges: [{ relationId: "rel-contract", sourceRef: "task/a" }],
+    coverageRows: [],
+    factAnchors: [],
+    facts: [],
+    warnings: [],
+  },
+  agendaTask = {
+    taskId: "task-agenda-contract",
+    title: "Agenda contract",
+    status: "planned",
+    pinned: "not-a-boolean",
+    updatedAt: "2026-09-02T00:00:00.000Z",
+    leaseExecutionId: null,
+    activeExecutionIds: [],
+    blockingAssessment: { taskId: "task-agenda-contract", state: "clear", blockers: [], warnings: [] },
+  },
+  agenda = {
+    schema: "daemon.agenda/v1",
+    ok: true,
+    command: "agenda",
+    status: "ready",
+    inFlight: [agendaTask],
+    awaitingDecision: [],
+    waitingOnOthers: [],
+    dispatchable: [],
+    page: { sourceLimit: 100, cursor: null, nextCursor: null },
+    watermark: 1,
+    sourceRevision: 1,
+    warnings: [],
+    summary: "one invalid row",
+  },
+  cases: readonly ValidatorCase[] = [
+    {
+      name: "validateGuiSubmission",
+      entityId: "a".repeat(40),
+      field: "completionClaim",
+      validate: () =>
+        validateGuiSubmission({
+          completionClaim: "",
+          deliverables: [],
+          outputs: [],
+          verificationNotes: [],
+          knownGaps: [],
+          residualRisks: [],
+          commitSha: "a".repeat(40),
+        }),
+    },
+    {
+      name: "validateCatalogActionPayload",
+      entityId: "task-action-contract",
+      field: "action.ttlMs",
+      validate: () =>
+        validateCatalogActionPayload({
+          payload: { action: { kind: "task-start", taskId: "task-action-contract", ttlMs: -1 } },
+        } as JsonObject),
+    },
+    {
+      name: "validateSessionEnvironment",
+      entityId: "agent:session-contract",
+      field: "sessionEnvironment.CODEX_THREAD_ID",
+      validate: () => validateSessionEnvironment({ HARNESS_ACTOR: "agent:session-contract", CODEX_THREAD_ID: "" }),
+    },
+    {
+      name: "validateDaemonAgenda",
+      entityId: "task-agenda-contract",
+      field: "inFlight[0]",
+      validate: () => validateDaemonAgenda(agenda),
+    },
+    {
+      name: "validateDaemonRelationGraph",
+      entityId: "rel-contract",
+      field: "edges[0]",
+      validate: () => validateDaemonRelationGraph(relationGraph),
+    },
+    {
+      name: "validateDaemonDecisionList",
+      entityId: "decision-contract",
+      field: "decisions[0]",
+      validate: () =>
+        validateDaemonDecisionList({
+          ok: true,
+          projection: "summary",
+          decisions: [
+            {
+              decisionId: "decision-contract",
+              title: "Contract decision",
+              state: "not-a-state",
+              appliesTo: { modules: [], productLines: [] },
+            },
+          ],
+          warnings: [],
+        }),
+    },
+    {
+      name: "validateDaemonDocumentRead",
+      entityId: "task-document-contract",
+      field: "path",
+      validate: () =>
+        validateDaemonDocumentRead({
+          ok: true,
+          status: "ready",
+          taskId: "task-document-contract",
+          path: "",
+          body: "body",
+          blobSha256: null,
+          worktreeBody: null,
+          uncommitted: false,
+          watermark: 1,
+          sourceRevision: 1,
+        }),
+    },
+    {
+      name: "validateDaemonTaskDocumentList",
+      entityId: "task-documents-contract",
+      field: "documents[0]",
+      validate: () =>
+        validateDaemonTaskDocumentList({
+          ok: true,
+          status: "ready",
+          taskId: "task-documents-contract",
+          documents: [
+            { path: "/outside", blobSha256: "a".repeat(64), size: 1, mediaType: "text/plain", uncommitted: false },
+          ],
+          watermark: 1,
+          sourceRevision: 1,
+        }),
+    },
+    {
+      name: "validateDaemonTaskDispatches",
+      entityId: "dispatch-contract",
+      field: "dispatches[0]",
+      validate: () =>
+        validateDaemonTaskDispatches({
+          ok: true,
+          status: "ready",
+          taskId: "task-dispatch-contract",
+          dispatches: [{ dispatchId: "dispatch-contract" }],
+          watermark: 1,
+          sourceRevision: 1,
+        }),
+    },
+    {
+      name: "validateDaemonProtocolError",
+      entityId: "repo.contract.read",
+      field: "error.hint",
+      validate: () =>
+        validateDaemonProtocolError({
+          schema: "command-receipt/v2",
+          ok: false,
+          command: "repo.contract.read",
+          outcome: "op_rejected",
+          opId: "N/A",
+          origin: "daemon",
+          code: "invalid_result",
+          evidence: "validation failed",
+          error: { code: "invalid_result", hint: "" },
+          nextAction: "inspect the response",
+        }),
+    },
+    {
+      name: "writeReceipt",
+      entityId: "op-contract",
+      field: "revision",
+      validate: () =>
+        writeReceipt({
+          outcome: "op_rejected",
+          opId: "op-contract",
+          revision: -1,
+          code: "invalid_result",
+          origin: "daemon",
+          nextAction: "fix the response",
+        }),
+    },
+    {
+      name: "validateDaemonGuiCommandReceipt",
+      entityId: "op-gui-contract",
+      field: "schema",
+      validate: () =>
+        validateDaemonGuiCommandReceipt({
+          schema: "wrong-schema",
+          ok: false,
+          command: "task-start",
+          outcome: "op_rejected",
+          opId: "op-gui-contract",
+          code: "invalid_result",
+          origin: "daemon",
+          nextAction: "fix the response",
+        }),
+    },
+    {
+      name: "validateDaemonTaskSnapshotList",
+      entityId: "task-snapshot-contract",
+      field: "rows[0].packagePath",
+      validate: () =>
+        validateDaemonTaskSnapshotList({
+          ok: true,
+          status: "ready",
+          rows: [{ taskId: "task-snapshot-contract" }],
+          invalidRows: [],
+          watermark: 1,
+          sourceRevision: 1,
+          warnings: [],
+        }),
+    },
+    {
+      name: "validateDaemonWorkspaceSummary",
+      entityId: "workspace",
+      field: "tasks.total",
+      validate: () =>
+        validateDaemonWorkspaceSummary({
+          schema: "daemon.workspace-summary/v1",
+          ok: true,
+          status: "ready",
+          tasks: {
+            total: -1,
+            byStatus: { planned: 0, active: 0, blocked: 0, in_review: 0, done: 0, cancelled: 0, unknown: 0 },
+          },
+          decisions: {},
+          watermark: 1,
+          sourceRevision: 1,
+          warnings: [],
+        }),
+    },
+    {
+      name: "validateDaemonSettingsRead",
+      entityId: "settings",
+      field: "settings",
+      validate: () => validateDaemonSettingsRead({ schema: "daemon.settings-read/v1", ok: true, settings: {} }),
+    },
+  ];
+
+test("every scoped validator reports entity id, field path, and a truncated actual value", () => {
+  for (const fixture of cases) {
+    const errors = fixture.validate(),
+      first = errors[0];
+    assert.ok(first, `${fixture.name} must reject its bad row`);
+    assert.match(first, /entity=/u, fixture.name);
+    assert.ok(first.includes(fixture.entityId), `${fixture.name} must identify ${fixture.entityId}: ${first}`);
+    assert.ok(first.includes(`field=${fixture.field}`), `${fixture.name} must identify ${fixture.field}: ${first}`);
+    assert.match(first, /actual=/u, fixture.name);
+    assert.ok(first.length < 360, `${fixture.name} must truncate its actual value: ${first.length}`);
+  }
+});
+
+test("task snapshot isolated-row diagnostics require an actual-value summary", () => {
+  const errors = validateDaemonTaskSnapshotList({
+    ok: true,
+    status: "ready",
+    rows: [],
+    invalidRows: [
+      {
+        rowIndex: 0,
+        taskId: "task-isolated-contract",
+        field: "rows[0].snapshot.task",
+        message: "Task snapshot field is invalid.",
+      },
+    ],
+    watermark: 1,
+    sourceRevision: 1,
+    warnings: [],
+  });
+  assert.match(errors[0]!, /task-isolated-contract.*field=invalidRows\[0\].*actual=/u);
+});

--- a/packages/gui/test/service-bridge.test.ts
+++ b/packages/gui/test/service-bridge.test.ts
@@ -45,7 +45,7 @@ test("GUI main reports every isolated task snapshot row with field-level context
           rowIndex: 4,
           taskId: "task-invalid",
           field: "rows[4].snapshot.codeDocWitnesses[0]",
-          message: "Task snapshot field is invalid.",
+          message: "actual={ witnessId: '' }: Task snapshot field is invalid.",
         },
       ],
     },
@@ -54,7 +54,7 @@ test("GUI main reports every isolated task snapshot row with field-level context
 
   assert.deepEqual(messages, [
     "[repo.tasks.list] isolated invalid task snapshot row rowIndex=4 taskId=task-invalid " +
-      "field=rows[4].snapshot.codeDocWitnesses[0]: Task snapshot field is invalid.",
+      "field=rows[4].snapshot.codeDocWitnesses[0]: actual={ witnessId: '' }: Task snapshot field is invalid.",
   ]);
 });
 

--- a/packages/kernel/src/domain/index.ts
+++ b/packages/kernel/src/domain/index.ts
@@ -73,6 +73,7 @@ export {
   assertTransitionDocumentReady,
   requireTransitionDocumentKind,
 } from "./transition-document-readiness.ts";
+export type { TransitionDocumentMissingSection } from "./transition-document-readiness.ts";
 
 export { freshnessReasonOf } from "./decision-coverage.ts";
 export type { FreshnessReason, FreshnessReasonInput } from "./decision-coverage.ts";

--- a/packages/kernel/src/domain/transition-document-readiness.ts
+++ b/packages/kernel/src/domain/transition-document-readiness.ts
@@ -21,10 +21,16 @@ const transitionDocumentBindings: readonly TransitionDocumentBinding[] = Object.
   { transition: "squad.install", documentKind: "squad.roster" },
 ]);
 
+export interface TransitionDocumentMissingSection {
+  readonly section: string;
+  readonly reason: "empty" | "scaffold";
+  readonly retainedScaffold?: string;
+}
+
 interface TransitionDocumentReadiness {
   readonly ready: boolean;
   readonly code: TransitionDocumentPlaceholderCode;
-  readonly missingSections: readonly string[];
+  readonly missingSections: readonly TransitionDocumentMissingSection[];
 }
 
 type MarkdownDocumentContract = {
@@ -135,10 +141,8 @@ export function assessTransitionDocument(kind: TransitionDocumentKind, body: str
         : kind === "decision.body"
           ? meaningfulMarkdown(body)
             ? []
-            : ["body"]
-          : declarationTextReady(kind, body)
-            ? []
-            : [kind === "agent.instructions" ? "instructions" : "roster"];
+            : [{ section: "body", reason: "empty" } as const]
+          : declarationMissingSection(kind, body);
   return Object.freeze({
     ready: missingSections.length === 0,
     code: placeholderCodes[kind],
@@ -155,16 +159,19 @@ export function requireTransitionDocumentKind(transition: string): TransitionDoc
 export function assertTransitionDocumentReady(kind: TransitionDocumentKind, body: string): void {
   const assessment = assessTransitionDocument(kind, body);
   if (assessment.ready) return;
-  const sections = assessment.missingSections.join(", "),
+  const sections = assessment.missingSections.map(({ section }) => section).join(", "),
     error = new Error(
       `${assessment.code}: ${kind} has empty or scaffold-equivalent required content: ${sections}.`,
-    ) as Error & { code: TransitionDocumentPlaceholderCode; missingSections: readonly string[] };
+    ) as Error & {
+      code: TransitionDocumentPlaceholderCode;
+      missingSections: readonly TransitionDocumentMissingSection[];
+    };
   error.code = assessment.code;
   error.missingSections = assessment.missingSections;
   throw error;
 }
 
-function missingMarkdownSections(body: string, contract: MarkdownDocumentContract): string[] {
+function missingMarkdownSections(body: string, contract: MarkdownDocumentContract): TransitionDocumentMissingSection[] {
   const sections = markdownSections(body),
     untouchedScaffold = contract.requiredSections.every((heading) => {
       const content = sections.get(normalizeHeading(heading));
@@ -175,16 +182,21 @@ function missingMarkdownSections(body: string, contract: MarkdownDocumentContrac
         )
       );
     });
-  return contract.requiredSections.filter((heading) => {
+  return contract.requiredSections.flatMap((heading): readonly TransitionDocumentMissingSection[] => {
     const content = sections.get(normalizeHeading(heading));
-    if (!content?.trim()) return true;
+    if (!content?.trim()) return [{ section: heading, reason: "empty" }];
     const scaffolds = contract.scaffoldBySection[heading] ?? [],
       normalized = normalizeText(content),
       retained = scaffolds.filter((scaffold) => normalized.includes(normalizeText(scaffold)));
-    if (retained.length === 0) return false;
-    if (untouchedScaffold) return true;
+    if (retained.length === 0) return [];
+    const issue = (): TransitionDocumentMissingSection => ({
+      section: heading,
+      reason: "scaffold",
+      retainedScaffold: clipScaffold(retained[0]!),
+    });
+    if (untouchedScaffold) return [issue()];
     const remainder = retained.reduce((value, scaffold) => value.replaceAll(normalizeText(scaffold), " "), normalized);
-    return !/[\p{L}\p{N}]/u.test(remainder);
+    return /[\p{L}\p{N}]/u.test(remainder) ? [] : [issue()];
   });
 }
 
@@ -211,6 +223,23 @@ function meaningfulMarkdown(body: string): boolean {
 function declarationTextReady(kind: "agent.instructions" | "squad.roster", body: string): boolean {
   const normalized = normalizeText(body);
   return normalized.length > 0 && !declarationScaffolds[kind].some((value) => normalized === normalizeText(value));
+}
+
+function declarationMissingSection(
+  kind: "agent.instructions" | "squad.roster",
+  body: string,
+): readonly TransitionDocumentMissingSection[] {
+  if (declarationTextReady(kind, body)) return [];
+  const section = kind === "agent.instructions" ? "instructions" : "roster",
+    normalized = normalizeText(body),
+    retained = declarationScaffolds[kind].find((value) => normalized === normalizeText(value));
+  return retained
+    ? [{ section, reason: "scaffold", retainedScaffold: clipScaffold(retained) }]
+    : [{ section, reason: "empty" }];
+}
+
+function clipScaffold(value: string): string {
+  return [...value].slice(0, 60).join("");
 }
 
 function stripFrontmatter(body: string): string {

--- a/packages/kernel/test/transition-document-readiness.test.ts
+++ b/packages/kernel/test/transition-document-readiness.test.ts
@@ -57,10 +57,20 @@ test("task plan rejects pure scaffolds but accepts a retained scaffold sentence 
   const scaffold = assessTransitionDocument("task.plan", template);
   assert.equal(scaffold.ready, false);
   assert.equal(scaffold.code, "plan_placeholder");
-  assert.deepEqual(scaffold.missingSections, planHeadings);
+  assert.deepEqual(
+    scaffold.missingSections.map(({ section }) => section),
+    planHeadings,
+  );
+  assert.deepEqual(scaffold.missingSections[0], {
+    section: "Brief",
+    reason: "scaffold",
+    retainedScaffold: "One-line statement of the task objective and scope.",
+  });
 
   const emptyGoal = realizedPlan().replace("## Goal\n\nImplemented Goal.", "## Goal\n\n");
-  assert.deepEqual(assessTransitionDocument("task.plan", emptyGoal).missingSections, ["Goal"]);
+  assert.deepEqual(assessTransitionDocument("task.plan", emptyGoal).missingSections, [
+    { section: "Goal", reason: "empty" },
+  ]);
 
   const retainedScaffold = realizedPlan().replace(
     "## Brief\n\nImplemented Brief.",
@@ -71,7 +81,13 @@ test("task plan rejects pure scaffolds but accepts a retained scaffold sentence 
     "## Verification\n\nImplemented Verification.",
     "## Verification\n\nStop point = targeted tests for the surface you touched, green, plus a local commit.",
   );
-  assert.deepEqual(assessTransitionDocument("task.plan", pureScaffoldSection).missingSections, ["Verification"]);
+  assert.deepEqual(assessTransitionDocument("task.plan", pureScaffoldSection).missingSections, [
+    {
+      section: "Verification",
+      reason: "scaffold",
+      retainedScaffold: "Stop point = targeted tests for the surface you touched, gre",
+    },
+  ]);
   assert.equal(assessTransitionDocument("task.plan", realizedPlan()).ready, true);
 });
 
@@ -80,12 +96,18 @@ test("closeout uses the same required-section and scaffold rules", () => {
     new URL("../../preset/assets/software-coding/templates/task.closeout/zh-CN.md", import.meta.url),
     "utf8",
   );
-  assert.deepEqual(assessTransitionDocument("task.closeout", template).missingSections, [
-    "Summary",
-    "Verification",
-    "Residual Risk",
-    "Same Mechanism Elsewhere",
-  ]);
+  assert.deepEqual(
+    assessTransitionDocument("task.closeout", template).missingSections.map(({ section, reason }) => ({
+      section,
+      reason,
+    })),
+    [
+      { section: "Summary", reason: "scaffold" },
+      { section: "Verification", reason: "scaffold" },
+      { section: "Residual Risk", reason: "scaffold" },
+      { section: "Same Mechanism Elsewhere", reason: "scaffold" },
+    ],
+  );
   assert.equal(
     assessTransitionDocument(
       "task.closeout",


### PR DESCRIPTION
# English

## Summary

Two slices of validator discipline (Phase 0.28), ruled by 泽宇 on 2026-09-02: keep every check, make every failure say exactly what is wrong.

Slice 1 — transition-document (plan/closeout placeholder gate) diagnostics: `assessTransitionDocument` now returns `missingSections` as structured entries `{section, reason: "empty" | "scaffold", retainedScaffold?}` (scaffold text capped at 60 chars), and the daemon hint renders one line per section, e.g. `Brief: 仍含模板句「One-line statement of the task objective and scope.」` / `Verification: 空`. Readiness predicates and the untouched/retained-scaffold rules are unchanged; the same inputs produce the same ready/not-ready verdicts, only the message changed. Before the change the gate listed 14 section names with no reason, which cost three dispatch attempts on 2026-09-01.

Slice 2 — every daemon `validate*` failure now carries entity id + field path + actual-value summary (the family the 13-hour GUI outage of 0.25 came from), aligned to the InvalidRow shape introduced by #2125; the conn log `request` event carries `detail` (first error) when `ok:false`; a table-driven contract test injects one bad row per validator and asserts id + field path are present. No validation was loosened.

## Architectural Justification

- Mechanism sentence: a validator that rejects without naming the entity, field, and value converts every data defect into a search problem for the reader; structured diagnostics at the point of detection make the reader's next action deterministic.
- Boundary with task_c789eaa0 (receipt guidance generation): this PR produces structured failure data on the daemon side; CLI-side rendering/registry consolidation stays in that task and consumes these fields.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none

## Machine-Readable Declarations

Production-Delta: +780/-306
Dependency-Change: none

### Optional Evidence Claims

None.

## Task And Scope

- Harness task task_7ddbab43f664e45f04cefc2991 (Phase 0.28) under PLT-Ontology (root task_5fc5080044fcfdbf548008f2f5). Branch `codex/validator-discipline`.

## Version Impact

- Version: no change. Publish impact: none.

## Governance Declaration

- Protected surface touched: no (kernel readiness assessment, daemon validators/hints, conn log; no CI/gate files). Authorizing task: task_7ddbab43f664e45f04cefc2991. Break-glass: no.

## Verification

- Mutation check: parent vs final implementation on the same all-template plan — BEFORE lists 14 bare section names; AFTER lists each section with reason and the retained template sentence (transcript in the ledger report).
- Four fixtures (all-template / partial / empty-section / fully-authored) verified; verdicts identical to before.
- Focused tests 28/28; contract tier 863/863; typecheck and lint green.
- [ ] Full suites: GitHub CI is the authority.

## Review Evidence

- Validator inventory (artifacts/validator-inventory.md in the ledger) lists every function with its before/after message shape.
- Fact F-A4E915ED records the before/after diagnostic comparison.

## Residual Risk

- Hint text is still rendered on the daemon side (current design); consolidating rendering into the CLI registry is task_c789eaa0's scope.

---

# 中文

## 概要

校验器纪律两切片(Phase 0.28,泽宇 2026-09-02 裁:检查要保留,报错要说清)。

切片 1:plan/closeout 占位门返回升为逐节条目 `{section, reason: "empty"|"scaffold", retainedScaffold?}`(模板句截断 60 字),daemon hint 逐节渲染,如 `Brief: 仍含模板句「一句话说明任务目标与范围。」` / `Verification: 空`。判定逻辑与 untouched/retained 规则未动,同样输入同样结论,只有报错变了。修前该门只列 14 个节名不给原因,9/1 夜间因此白派三次。

切片 2:daemon 全部 `validate*` 失败信息带实体 id + 字段路径 + 实际值摘要(0.25 那次 GUI 坏 13 小时的同族),形状对齐 #2125 的 InvalidRow;conn log 的 `request` 事件在 `ok:false` 时带 `detail`;表驱动契约测试对每个校验器注入一条坏行断言 id 与字段路径。无任何校验放宽。

## 架构辩护

- 机制句:不说实体、字段、实际值就拒绝的校验器,把每个数据缺陷都变成读者的搜索题;在检测点给结构化诊断,读者的下一步就是确定的。
- 与 task_c789eaa0(回执指引生成)的边界:本 PR 在 daemon 侧产生结构化失败数据;CLI 侧渲染/注册表归那条线消费。

## 机读声明

`Production-Delta: +780/-306`;无依赖变更。

## 治理声明

- 未触碰 protected surface;授权任务 task_7ddbab43f664e45f04cefc2991;无 break-glass。

## 验证

- 变异对照:同一全模板 plan,修前 14 个裸节名 → 修后逐节带原因与模板句(报告有全文);四 fixture 结论与修前一致;定向 28/28、contract 863/863、typecheck/lint 绿;完整权威=GitHub CI。

## 残余风险

- hint 文案仍在 daemon 侧渲染(现状);收进 CLI 渲染注册表归 task_c789eaa0。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VTzQAqvuFy6ikGjBKxA9xj
