### PR TITLE
fix: limit doc sync region guards to machine content

### DIFF
--- a/packages/cli/test/daemon-multi-repo-lifecycle-cli.test.ts
+++ b/packages/cli/test/daemon-multi-repo-lifecycle-cli.test.ts
@@ -304,7 +304,8 @@ test("real CLI reaches one resident multi-workspace daemon and publishes Git eve
       eligiblePath = "context/this-session.md",
       blockedFile = path.join(fixture.alpha, "harness", blockedPath);
     mkdirSync(path.dirname(blockedFile), { recursive: true });
-    writeFileSync(blockedFile, "# Stable\n");
+    const stableMachineDocument = "---\nschema: stable\n---\n# Stable\n";
+    writeFileSync(blockedFile, stableMachineDocument);
     // Same background local-repair reconciliation as the notes submit above (repo-cell
     // settleAuthoredCandidates): it may incorporate this freshly authored doc first, which leaves this
     // explicit submit nothing to apply. Both outcomes mean the doc reached canonical.
@@ -313,22 +314,22 @@ test("real CLI reaches one resident multi-workspace daemon and publishes Git eve
       stableSubmit.outcome === "applied" || stableSubmit.outcome === "no_changes",
       `submit must reconcile the authored doc (applied or no_changes), saw ${JSON.stringify(stableSubmit)}`,
     );
-    writeFileSync(blockedFile, "# Renamed\n");
+    writeFileSync(blockedFile, "---\nschema: changed\n---\n# Stable\n");
     writeFileSync(path.join(fixture.alpha, "harness", eligiblePath), "# Eligible\n");
     // The background reconciliation issues this exact command — doc-submit over an empty selection.
     // Whichever sweep runs first applies context/this-session.md and skips the blocked
     // context/other-session.md; the sweep that runs second has no eligible row left and rejects on the
     // blocked row alone, which is the decided contract (doc-sync-slice-a-implicit-lease: "a blocked-only
     // implicit submit must reject without publishing an event"). Asserting one outcome raced that sweep
-    // (flake). What holds either way: the blocked path is reported against its missing base region, the
+    // (flake). What holds either way: the blocked path is reported against its changed machine region, the
     // eligible doc reaches canonical, and the blocked edit does not.
     const partial = runMaybe(fixture.alpha, fixture.userRoot, ["doc", "sync", "--submit"]),
-      blockedTouch = 'context/other-session.md\tbase region is missing: "# Stable"';
+      blockedTouch = "context/other-session.md\tmachine region changed";
     if (partial.status === 0) {
       assert.equal(partial.receipt.outcome, "applied", JSON.stringify(partial.receipt));
       assert.match(
         String(partial.receipt.summary),
-        /doc-submit: applied[\s\S]*skipped:[\s\S]*context\/other-session\.md\tblocked\tbase region is missing: "# Stable"/u,
+        /doc-submit: applied[\s\S]*skipped:[\s\S]*context\/other-session\.md\tblocked\tmachine region changed/u,
       );
     } else {
       assert.equal(partial.receipt.outcome, "op_rejected", JSON.stringify(partial.receipt));
@@ -345,7 +346,10 @@ test("real CLI reaches one resident multi-workspace daemon and publishes Git eve
       run(fixture.alpha, fixture.userRoot, ["doc", "show", "--path", eligiblePath]).evidence,
       "# Eligible\n",
     );
-    assert.equal(run(fixture.alpha, fixture.userRoot, ["doc", "show", "--path", blockedPath]).evidence, "# Stable\n");
+    assert.equal(
+      run(fixture.alpha, fixture.userRoot, ["doc", "show", "--path", blockedPath]).evidence,
+      stableMachineDocument,
+    );
     const spoof = await requestLocalDaemonJsonRpc(
       fixture.alpha,
       "repo.task.create",

--- a/packages/daemon/src/doc-sync-settlement.ts
+++ b/packages/daemon/src/doc-sync-settlement.ts
@@ -84,7 +84,6 @@ export function scanDetail(input: Input, scan: DocCandidateScan, code: string): 
           (code === "lease_conflict"
             ? "refresh status and submit through the matching execution or repository prose channel"
             : null)),
-    headingRestore = taskPlanHeadingRestore(input, scan),
     blocked = scan.rows.find((row) => row.state === "blocked");
   return {
     kind: "doc_sync",
@@ -137,7 +136,6 @@ export function scanDetail(input: Input, scan: DocCandidateScan, code: string): 
           )
         : (executionChoice ??
           leaseConflict ??
-          headingRestore ??
           (blocked
             ? blockedCandidateNextAction(blocked)
             : scan.rows.some((row) => row.state === "eligible")
@@ -201,32 +199,6 @@ export function leaseConflictNextAction(input: Input, scan: DocCandidateScan): s
     "non-runtime principal may rerun ha doc sync --submit through the ",
     "repository prose channel)",
   ].join("");
-}
-
-// The base-region guard keeps a task plan's H1 pinned to the ledger title;
-// when the missing base region IS that title heading, the fix is mechanical
-// and the receipt can name it exactly. A region that matches the pre-amended
-// title instead (the base predates ha task amend) deliberately keeps the
-// generic guidance here — that shape is resolved on the typed route, not by
-// prose edits.
-export function taskPlanHeadingRestore(input: Input, scan: DocCandidateScan): string | null {
-  for (const row of scan.rows) {
-    if (row.state !== "blocked" || row.requiredRoute !== "refresh-region-policy" || !row.path.endsWith("/task_plan.md"))
-      continue;
-    const taskId = input.projection.taskIdForDocumentPath(row.path),
-      task = taskId === null ? null : input.projection.read(taskId).snapshot.task;
-    if (task !== null && row.regionId === `heading/${task.title.toLowerCase()}`)
-      return [
-        "restore the H1 of ",
-        `${row.path}`,
-        ' to the task title verbatim ("# ',
-        `${task.title}`,
-        '"), then rerun ha doc sync --submit --path ',
-        `${row.path}`,
-        "",
-      ].join("");
-  }
-  return null;
 }
 
 export function noOp(input: Input, scan: DocCandidateScan): DocSettlementReceipt {

--- a/packages/daemon/test/doc-sync-artifact-opaque.test.ts
+++ b/packages/daemon/test/doc-sync-artifact-opaque.test.ts
@@ -427,9 +427,14 @@ test("task_plan.md and closeout.md retain prose policy, proofs, and deletion pro
     }
     for (const logical of prosePaths) {
       write(rootDir, logical, "# Removed\n");
-      const blocked = await blockedRow(cell, logical);
-      assert.equal(blocked[0], logical);
-      assert.match(String(blocked[1]), /missing|forbidden/u);
+      const replaced = await cell.run({ kind: "doc-submit", paths: [logical] }, binding);
+      assert.equal(replaced.outcome, "applied", JSON.stringify(replaced));
+      rmSync(path.join(rootDir, "harness", logical));
+      const status = await cell.run({ kind: "doc-status", paths: [logical] }, binding),
+        row = rows(status.evidence)[0];
+      assert.equal(row?.path, logical);
+      assert.equal(row?.state, "deletion");
+      assert.match(String(row?.reason), /canonical document is missing/u);
     }
   } finally {
     await cell.close();
@@ -570,18 +575,6 @@ async function reachGreenInReview(
   assert.equal(consented.outcome, "applied", JSON.stringify(consented));
 }
 
-async function blockedRow(
-  cell: Awaited<ReturnType<typeof openRepoCell>>,
-  logical: string,
-): Promise<readonly unknown[]> {
-  const dry = (await cell.run({ kind: "doc-dry-run", paths: [logical] }, { actor, source: "local" })) as Record<
-    string,
-    unknown
-  >;
-  const row = rows(String(dry.evidence)).find((candidate) => candidate.path === logical);
-  assert.equal(row?.state, "blocked", JSON.stringify(row));
-  return [row?.path, row?.reason];
-}
 function rows(evidence: string): readonly {
   readonly path: string;
   readonly state: string;

--- a/packages/daemon/test/doc-sync-slice-a-implicit-lease.test.ts
+++ b/packages/daemon/test/doc-sync-slice-a-implicit-lease.test.ts
@@ -12,7 +12,7 @@ import { openBootstrappedRepoCell as openRepoCell } from "./repo-settings.fixtur
 import { realizeTaskPlanFixture } from "../../../tools/fixtures/task-plan.mjs";
 import { withRoleBinding } from "./role-binding.fixtures.ts";
 
-import { git, initRepo, ownerBinding, rows, write } from "./doc-sync-slice-a.fixtures.ts";
+import { initRepo, ownerBinding, rows, write } from "./doc-sync-slice-a.fixtures.ts";
 test("implicit submit accepts two authored paths with identical content", async () => {
   const rootDir = mkdtempSync(path.join(tmpdir(), "ha-doc-a-identical-content-"));
   initRepo(rootDir);
@@ -45,7 +45,7 @@ test("implicit submit accepts two authored paths with identical content", async 
   }
 });
 
-test("implicit submit applies eligible prose and reports an unrelated blocked row as skipped", async () => {
+test("implicit submit applies prose after its heading is rewritten", async () => {
   const rootDir = mkdtempSync(path.join(tmpdir(), "ha-doc-a-partial-blocked-"));
   initRepo(rootDir);
   const repoId = workspaceId("partial-blocked"),
@@ -62,33 +62,18 @@ test("implicit submit applies eligible prose and reports an unrelated blocked ro
     write(rootDir, "context/eligible.md", "# Eligible\n\nship me\n");
     const submitted = (await cell.run({ kind: "doc-submit", paths: [] }, binding)) as Record<string, unknown>;
     assert.equal(submitted.outcome, "applied", JSON.stringify(submitted));
-    assert.match(
-      String(submitted.summary),
-      /doc-submit: applied[\s\S]*context\/eligible\.md[\s\S]*skipped:[\s\S]*context\/blocked\.md\tblocked\tbase region is missing: "# Stable"/u,
-    );
+    assert.match(String(submitted.summary), /skipped:\n\(none\)/u);
     const event = makeTaskEventStore({ repoId, rootDir }).readEvent(String(submitted.opId));
     assert.equal(event?.schema, "doc-event/v1");
     if (event?.schema === "doc-event/v1")
       assert.deepEqual(
         event.payload.changes.map((change) => change.path),
-        ["context/eligible.md"],
+        ["context/blocked.md", "context/eligible.md"],
       );
     assert.equal(readFileSync(path.join(rootDir, "harness/context/eligible.md"), "utf8"), "# Eligible\n\nship me\n");
     assert.equal(readFileSync(path.join(rootDir, "harness/context/blocked.md"), "utf8"), "# Renamed\n\nbase\n");
-    const settledHead = git(rootDir, "rev-parse", "HEAD"),
-      skippedOnly = (await cell.run({ kind: "doc-submit", paths: [] }, binding)) as Record<string, unknown>;
-    assert.equal(skippedOnly.outcome, "op_rejected", JSON.stringify(skippedOnly));
-    assert.equal(skippedOnly.code, "preview_blocked");
-    assert.match(
-      String(skippedOnly.nextAction),
-      /resolve context\/blocked\.md through refresh-region-policy: base region is missing: "# Stable"/u,
-    );
-    assert.doesNotMatch(String(skippedOnly.nextAction), /ha doc status/u);
-    assert.equal(
-      git(rootDir, "rev-parse", "HEAD"),
-      settledHead,
-      "a blocked-only implicit submit must reject without publishing an event",
-    );
+    const clean = (await cell.run({ kind: "doc-submit", paths: [] }, binding)) as Record<string, unknown>;
+    assert.equal(clean.outcome, "no_changes", JSON.stringify(clean));
   } finally {
     await cell.close();
     rmSync(rootDir, { recursive: true, force: true });

--- a/packages/daemon/test/doc-sync-slice-a-task-plan-titles.test.ts
+++ b/packages/daemon/test/doc-sync-slice-a-task-plan-titles.test.ts
@@ -15,11 +15,8 @@ import {
 import { canonicalRoot, workspaceId } from "../src/protocol/daemon-protocol.contract.ts";
 import { openBootstrappedRepoCell as openRepoCell } from "./repo-settings.fixture.ts";
 
-import { actor, blockedReason, initRepo, rows, write } from "./doc-sync-slice-a.fixtures.ts";
-// F-42D28979/F-F4814511: a task plan whose H1 no longer matches the ledger
-// title is the highest-frequency doc-sync block; the receipt must name the
-// mechanical fix, and following it verbatim must leave the healed task idempotent.
-test("a renamed task plan H1 receipt names the exact title restore and the heal is idempotent", async () => {
+import { actor, initRepo, rows, write } from "./doc-sync-slice-a.fixtures.ts";
+test("a renamed task plan H1 remains authored prose and submits normally", async () => {
   const rootDir = mkdtempSync(path.join(tmpdir(), "ha-doc-a-h1-restore-"));
   initRepo(rootDir);
   const repoId = workspaceId("h1-restore"),
@@ -45,23 +42,11 @@ test("a renamed task plan H1 receipt names the exact title restore and the heal 
       `restore the H1 of ${plan.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&")} to the task title verbatim \\("# ${title.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&")}"\\), then rerun ha doc sync --submit --path ${plan.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&")}`,
       "u",
     );
-    const status = (await cell.run({ kind: "doc-status", paths: [plan] }, binding)) as {
-      detail?: { nextAction?: string };
-    };
-    assert.equal(rows((await cell.run({ kind: "doc-status", paths: [plan] }, binding)).evidence)[0]?.state, "blocked");
-    assert.match(status.detail?.nextAction ?? "", restore);
-    const rejected = (await cell.run({ kind: "doc-submit", paths: [plan] }, binding)) as {
-      outcome?: string;
-      code?: string;
-      nextAction?: string;
-    };
-    assert.equal(rejected.outcome, "op_rejected");
-    assert.equal(rejected.code, "preview_blocked");
-    assert.match(rejected.nextAction ?? "", restore);
-    writeFileSync(target, readFileSync(target, "utf8").replace("# 好读的短标题", `# ${title}`));
-    const healed = await cell.run({ kind: "doc-submit", taskId }, binding);
-    assert.equal(healed.outcome, "no_changes", JSON.stringify(healed));
-    assert.equal(healed.code, "no_changes", JSON.stringify(healed));
+    const status = await cell.run({ kind: "doc-status", paths: [plan] }, binding);
+    assert.equal(rows(status.evidence)[0]?.state, "eligible", JSON.stringify(status));
+    assert.doesNotMatch(JSON.stringify(status), restore);
+    const submitted = await cell.run({ kind: "doc-submit", paths: [plan] }, binding);
+    assert.equal(submitted.outcome, "applied", JSON.stringify(submitted));
   } finally {
     await cell.close();
     rmSync(rootDir, { recursive: true, force: true });
@@ -209,9 +194,8 @@ test("a no-op title amend heals a plan whose canonical base still holds the pre-
       .replace(`# ${firstTitle}`, `# ${secondTitle}`)
       .concat("\n## Drift\n\nworker prose written under the already-renamed H1\n");
     writeFileSync(target, workerBody);
-    const blocked = await cell.run({ kind: "doc-status", paths: [plan] }, binding);
-    assert.equal(rows(blocked.evidence)[0]?.state, "blocked", JSON.stringify(blocked));
-    assert.match(blockedReason(blocked.evidence), /base region is missing: "# no-op amend first title"/u);
+    const authored = await cell.run({ kind: "doc-status", paths: [plan] }, binding);
+    assert.equal(rows(authored.evidence)[0]?.state, "eligible", JSON.stringify(authored));
     const noop = (await cell.run(
       {
         kind: "task-amend",

--- a/packages/daemon/test/doc-sync-slice-a.test.ts
+++ b/packages/daemon/test/doc-sync-slice-a.test.ts
@@ -1,6 +1,6 @@
 // harness-test-tier: integration
 import assert from "node:assert/strict";
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -79,26 +79,17 @@ test("status, dry-run, and submit share the repeatable-path scanner and automati
       ],
     );
     write(rootDir, "context/a.md", "# Renamed\n\nfirst\n");
-    const acceptedCut = git(rootDir, "rev-parse", "HEAD"),
-      blocked = await cell.run({ kind: "doc-dry-run", paths: ["context/a.md"] }, binding);
-    assert.equal(rows(blocked.evidence)[0]?.state, "blocked");
-    assert.match(
-      blocked.detail?.nextAction ?? "",
-      /resolve context\/a\.md through refresh-region-policy: base region is missing: "# A"/u,
-    );
-    assert.doesNotMatch(blocked.detail?.nextAction ?? "", /ha doc status/u);
-    assert.doesNotMatch(blocked.detail?.nextAction ?? "", /doc retire|conflict scratch/iu);
-    const rejected = await cell.run({ kind: "doc-submit", paths: ["context/a.md"] }, binding);
-    assert.equal(rejected.outcome, "op_rejected");
-    assert.equal(rejected.code, "preview_blocked");
-    assert.equal(git(rootDir, "rev-parse", "HEAD"), acceptedCut);
+    const renamed = await cell.run({ kind: "doc-dry-run", paths: ["context/a.md"] }, binding);
+    assert.equal(rows(renamed.evidence)[0]?.state, "eligible");
+    const accepted = await cell.run({ kind: "doc-submit", paths: ["context/a.md"] }, binding);
+    assert.equal(accepted.outcome, "applied", JSON.stringify(accepted));
   } finally {
     await cell.close();
     rmSync(rootDir, { recursive: true, force: true });
   }
 });
 
-test("blocked-only submit names the scanner-first closeout recovery", async () => {
+test("blocked-only submit names the scanner-first machine-region recovery", async () => {
   const rootDir = mkdtempSync(path.join(tmpdir(), "ha-doc-a-blocked-closeout-"));
   initRepo(rootDir);
   const repoId = workspaceId("blocked-closeout"),
@@ -110,28 +101,15 @@ test("blocked-only submit names the scanner-first closeout recovery", async () =
     binding = { actor, source: "local" as const },
     laterBlocked = "tmp/z-blocked.md";
   try {
-    write(rootDir, laterBlocked, "# Stable\n\nbase\n");
+    write(rootDir, laterBlocked, "---\nowner: stable\n---\n# Stable\n\nbase\n");
     assert.equal((await cell.run({ kind: "doc-submit", paths: [laterBlocked] }, binding)).outcome, "applied");
-    const created = (await cell.run(
-      {
-        kind: "task-create",
-        taskId: "task_CLOSEOUTRECOVERY0000AAAAA",
-        title: "closeout recovery receipt",
-      },
-      binding,
-    )) as { outcome?: string; packagePath?: string };
-    assert.equal(created.outcome, "applied", JSON.stringify(created));
-    const closeout = `${created.packagePath}/closeout.md`,
-      closeoutTarget = path.join(rootDir, "harness", closeout);
-    write(rootDir, closeout, readFileSync(closeoutTarget, "utf8").replace("# Closeout", "# Removed"));
-    write(rootDir, laterBlocked, "# Removed\n\nbase\n");
+    write(rootDir, laterBlocked, "---\nowner: changed\n---\n# Removed\n\nbase\n");
     const rejected = (await cell.run({ kind: "doc-submit", paths: [] }, binding)) as Record<string, unknown>;
     assert.equal(rejected.outcome, "op_rejected", JSON.stringify(rejected));
     assert.equal(rejected.code, "preview_blocked");
-    assert.match(String(rejected.nextAction), new RegExp(closeout.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&"), "u"));
-    assert.match(String(rejected.nextAction), /refresh-region-policy/u);
-    assert.match(String(rejected.nextAction), /base region is missing: "# Closeout"/u);
-    assert.equal(String(rejected.nextAction).includes(laterBlocked), false);
+    assert.match(String(rejected.nextAction), /typed-machine-writer/u);
+    assert.match(String(rejected.nextAction), /machine region changed/u);
+    assert.equal(String(rejected.nextAction).includes(laterBlocked), true);
     assert.doesNotMatch(String(rejected.nextAction), /ha doc status/u);
   } finally {
     await cell.close();

--- a/packages/kernel/src/domain/doc-sync-regions.ts
+++ b/packages/kernel/src/domain/doc-sync-regions.ts
@@ -52,11 +52,12 @@ export function additiveProof(
       next: rightById.get(region.id),
       nextOrder: right.regions.findIndex((candidateRegion) => candidateRegion.id === region.id),
     })),
-    missing = indexed.filter(({ next }) => !next).map(({ region }) => region),
+    guarded = indexed.filter(({ region }) => region.mode === "equal"),
+    missing = guarded.filter(({ next }) => !next).map(({ region }) => region),
     reordered = new Map<string, Region>();
   let order = -1,
     orderedAfter: Region | null = null;
-  for (const entry of indexed) {
+  for (const entry of guarded) {
     if (!entry.next) continue;
     if (entry.nextOrder < order) reordered.set(entry.region.id, orderedAfter!);
     else {
@@ -82,7 +83,7 @@ export function additiveProof(
     unresolved: DocSyncUnresolvedTouch[] = [];
   for (const { region, next } of indexed) {
     if (!next) {
-      unresolved.push(touch(path, region.id, missingReason, "refresh-region-policy"));
+      if (region.mode === "equal") unresolved.push(touch(path, region.id, missingReason, "refresh-region-policy"));
       continue;
     }
     if (reordered.has(region.id)) {

--- a/packages/kernel/test/contracts/doc-sync-conflicts-retirement.test.ts
+++ b/packages/kernel/test/contracts/doc-sync-conflicts-retirement.test.ts
@@ -46,7 +46,7 @@ test("stale ledger and stale blob reject the entire batch with current holder an
   }
 });
 
-test("claim mismatch, deletion, heading rename, machine touch, and ambiguous headings fail closed", () => {
+test("claim mismatch, deletion, machine touch, and ambiguous headings fail closed", () => {
   const base = "# Notes\nA\n",
     additive = `${base}B\n`,
     change = {
@@ -64,7 +64,7 @@ test("claim mismatch, deletion, heading rename, machine touch, and ambiguous hea
     assert.equal(deletion.code, "deletion_forbidden");
     assert.equal(deletion.detail.deletions[0]?.source, "intent");
   }
-  for (const candidate of ["# Renamed\nA\n", "---\nowner: other\n---\n# Notes\nA\n", "# Same\nA\n# Same\nB\n"]) {
+  for (const candidate of ["---\nowner: other\n---\n# Notes\nA\n", "# Same\nA\n# Same\nB\n"]) {
     const current = candidate.startsWith("---") ? "---\nowner: owner\n---\n# Notes\nA\n" : base,
       rejected = decide(
         {
@@ -170,7 +170,7 @@ test("direct CRLF claims name the line-ending repair when the contract rejects t
   }
 });
 
-test("prose regression controls reject deletion and duplicate headings while naming missing and reordered base regions", () => {
+test("prose regions may be removed, renamed, or reordered while file deletion and duplicate headings stay guarded", () => {
   const base = "# One\nA\n# Two\nB\n",
     prose = {
       path: "context/notes.md",
@@ -188,20 +188,11 @@ test("prose regression controls reject deletion and duplicate headings while nam
     assert.equal(duplicateResult.detail.unresolvedTouches[0]?.reason, "duplicate heading anchor");
   const missing = "# One\nA\n",
     missingResult = decide({ ...prose, candidate: claim(missing) }, state(base), Buffer.from(missing));
-  assert.equal(missingResult.accepted, false);
-  if (!missingResult.accepted)
-    assert.equal(missingResult.detail.unresolvedTouches[0]?.reason, 'base region is missing: "# Two"');
+  assert.equal(missingResult.accepted, true, JSON.stringify(missingResult));
   const allMissing = "Replacement prose.\n",
     allMissingResult = decide({ ...prose, candidate: claim(allMissing) }, state(base), Buffer.from(allMissing));
-  assert.equal(allMissingResult.accepted, false);
-  if (!allMissingResult.accepted)
-    assert.equal(allMissingResult.detail.unresolvedTouches[0]?.reason, 'base regions are missing: "# One", "# Two"');
+  assert.equal(allMissingResult.accepted, true, JSON.stringify(allMissingResult));
   const reordered = "# Two\nB\n# One\nA\n",
     reorderedResult = decide({ ...prose, candidate: claim(reordered) }, state(base), Buffer.from(reordered));
-  assert.equal(reorderedResult.accepted, false);
-  if (!reorderedResult.accepted)
-    assert.equal(
-      reorderedResult.detail.unresolvedTouches[0]?.reason,
-      'base regions are reordered: candidate places "# Two" before "# One"; expected "# One" before "# Two"',
-    );
+  assert.equal(reorderedResult.accepted, true, JSON.stringify(reorderedResult));
 });

--- a/packages/kernel/test/contracts/doc-sync-upgrades-receipts.test.ts
+++ b/packages/kernel/test/contracts/doc-sync-upgrades-receipts.test.ts
@@ -92,7 +92,7 @@ test("the first authored write on a migrated document upgrades its policy one-wa
   if (native.accepted) assert.equal("policyUpgrade" in native.event.payload.changes[0]!, false);
 });
 
-test("an upgraded write still runs the full region differ and heading preservation", () => {
+test("an upgraded write still allows authored prose heading reordering", () => {
   const base = "# One\nA\n# Two\nB\n",
     reordered = "# Two\nB\n# One\nA\n",
     result = decide(
@@ -105,18 +105,7 @@ test("an upgraded write still runs the full region differ and heading preservati
       { ...state(base), policyId: MIGRATION_DOCUMENT_POLICY_ID },
       Buffer.from(reordered),
     );
-  assert.equal(result.accepted, false, JSON.stringify(result));
-  if (!result.accepted) {
-    assert.equal(result.code, "unresolved_touch");
-    assert.equal(
-      result.detail.unresolvedTouches.some(
-        ({ reason }) =>
-          reason ===
-          'base regions are reordered: candidate places "# Two" before "# One"; expected "# One" before "# Two"',
-      ),
-      true,
-    );
-  }
+  assert.equal(result.accepted, true, JSON.stringify(result));
 });
 
 test("receipt detail registry rejects unregistered or open-ended detail shapes", () => {


### PR DESCRIPTION
# English

## Summary

Authored prose documents are no longer required to keep their heading structure byte-identical to the canonical version. `additiveProof` now applies its missing/reordered guards only to machine regions (`mode === "equal"`, i.e. frontmatter); regions derived from Markdown headings may be removed, renamed, or reordered. The specialized `taskPlanHeadingRestore` diagnostic — which existed only to explain the failures this guard produced — is deleted in the same change.

The guard was rejecting a normal action. Region identity is the literal heading text (`heading/<lowercased heading>`), so rewording a heading was judged as deleting a document region, and the affected file could never enter the ledger. It bit twice in two days (`task_956a0f26`, `task_5284063b`), with no write-time warning of any kind.

What the guard was trying to protect — that a task plan has the sections it should — is already covered by `transition-document-readiness`'s `requiredSections` at the start-of-work gate, on a sharper criterion: whether placeholder text was actually replaced. That path is untouched, so the protection remains.

## What Changed

- `packages/kernel/src/domain/doc-sync-regions.ts`: `additiveProof` computes `missing`/`reordered` from machine regions only; `additive` (heading-derived) regions no longer emit unresolved touches when absent or moved. Machine-region guards (`machine region changed`, `new machine region is forbidden`) are unchanged.
- `packages/daemon/src/doc-sync-settlement.ts`: deleted the exported `taskPlanHeadingRestore` function, its explanatory comment, and both call sites in `scanDetail`. Its failure shape no longer exists.
- Six test files updated. Assertions that pinned the removed behavior were replaced with assertions of the new behavior, and the negative controls were kept explicit rather than folded together.

Not changed on purpose: `regions()` heading-splitting and region-id derivation. This change does not address "rewording changes the region id" — only "a missing prose region blocks the document".

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: use the single CI-backed `Production-Delta` declaration below; do not enter a second metric.

Note: no whole file was removed, so the path list is `none`. The deleted production path is the exported `taskPlanHeadingRestore` in `packages/daemon/src/doc-sync-settlement.ts` plus its two call sites; remaining occurrences of that symbol in production: 0.

## Machine-Readable Declarations

Production-Delta: +4/-31
Dependency-Change: none

## Task And Scope

- Harness task: task_a9d634eea5ee611e88391d3d1f
- Branch: codex/prose-region-guard
- Public scope: `packages/kernel/src/domain/doc-sync-regions.ts`, `packages/daemon/src/doc-sync-settlement.ts`, and the six corresponding test files.
- Private planning/evidence updated: yes
- Out of scope: region-id derivation, write-time warnings, explicit region anchors. All three were explicitly rejected in the governing decision (RJ1/RJ2/RJ3) as additive fixes to a problem whose correct fix is deletion.

## Version Impact

- Version: no version change because this is an internal write-path validation change with no packaged surface.
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: yes
- Protected surface scope: the doc-sync write-path validation contract (`additiveProof`), which gates whether authored documents may enter the ledger.
- Authority: dec_8AF65DA6436BAEF9DE764B485B
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no

## Verification

- Base `origin/main` SHA: 38636b2fd2f47ba2053a6289d116a91b73cfe376
- Branch merge-base with `origin/main`: 38636b2fd2f47ba2053a6289d116a91b73cfe376
- Last `git fetch origin` time: 2026-09-02, immediately before opening this PR
- Sync method: rebase (ahead 1 / behind 0 at submission)
- Public diff command: `git diff origin/main...HEAD`
- Private evidence commit/path: `harness/tasks/task_a9d634eea5ee611e88391d3d1f-authored-prose-region-task-plan-doc-sync-machine-region/`
- Reviewer evidence path: `.../artifacts/reports/dispatch_8d41b82411b1f3f8cd5f9b3c.md`
- GitHub Actions `rewrite-ci` run URL: pending — CI runs on this PR; it is the authority, not the local runs below.
- [x] `git diff --check`
- Kernel targeted tests: 12/12 passed.
- Isolated Ubuntu integration tests: 29/29 passed (7/7, 10/10, 5/5, 7/7).
- `eslint`, `tsc -b`, line-density, file-complexity, production-delta: passed.
- Not run: `npm run check:local` and the full local gate matrix — per the repository's stop condition, a worker's stop point is targeted tests on the touched surface plus a local commit; GitHub CI is the complete authority.
- Not run: manual `ha doc sync --dry-run` against a previously blocked task plan. The equivalent behavior is covered by the isolated integration tests, and the one real blocked instance (`task_5284063b`) was repaired by another line before this change landed.

## Review Evidence

- Self-review: verified the two acceptance criteria I set before dispatch. (1) Negative control present: frontmatter mutation still fails closed (`doc-sync-conflicts-retirement.test.ts` retains the `owner: other` case; `doc-sync-slice-a.test.ts:111` still asserts `machine region changed`). Without this, "removed the prose guard" and "removed the whole guard" would be indistinguishable in tests. (2) Production is a net deletion (+4/-31), and no additive mechanism was introduced.
- Reviewer subagent: implementation by dispatched worker `debug-minimal-fixer` (`dispatch_8d41b82411b1f3f8cd5f9b3c`); review by the dispatching CEO session.
- Human review: pending.
- Blocking findings: none.

## Residual Risk

- Rewording a heading still changes its region id. For machine regions this is now the only guarded shape, and it is intentional; for prose regions it no longer matters. If a future document type needs a stable prose skeleton, it must declare machine regions rather than rely on heading text.
- `AGENTS.md` still instructs agents to read `read_set.md`, which does not exist anywhere in the repository. Unrelated to this change; tracked under the PLT-GovernedEntity W3 design.

---

# 中文

## 摘要

authored prose 文档不再被要求其标题结构与 canonical 版逐字节一致。`additiveProof` 的 missing/reordered 判定现在只作用于 machine region(`mode === "equal"`,即 frontmatter);由 Markdown 标题切出的 region 允许删除、改写措辞与换序。同一变更内删除了专用诊断 `taskPlanHeadingRestore`——它存在的唯一理由就是解释这层守卫制造出来的失败。

这层守卫在拒绝一个正常动作。region 的身份是标题的字面文字(`heading/<标题原文小写>`),所以改写一个标题的措辞在判定上等同于删除文档区块,该文件从此永远进不了台账。两天内咬中两次(`task_956a0f26`、`task_5284063b`),且写入侧没有任何提示。

这层守卫想保的东西——task plan 有该有的章节——已经由 `transition-document-readiness` 的 `requiredSections` 在开工门上覆盖,判据更准:占位文字有没有被真正替换。该路径未被触碰,保障仍在。

## 变更内容

- `packages/kernel/src/domain/doc-sync-regions.ts`:`additiveProof` 的 `missing`/`reordered` 只从 machine region 计算;`additive`(标题派生)region 缺失或换序时不再产生 unresolved touch。machine region 的两条守卫(`machine region changed`、`new machine region is forbidden`)不变。
- `packages/daemon/src/doc-sync-settlement.ts`:删除导出函数 `taskPlanHeadingRestore`、其说明注释,以及 `scanDetail` 里的两个调用点。它服务的失败形态已不存在。
- 六个测试文件同步更新。原先锁定旧行为的断言换成新行为的断言,阴性对照保持显式而非被并进同一个正则。

刻意不改:`regions()` 的标题切分与 region id 派生。本次不解决「改措辞即换 id」,只解决「prose region 缺失即 blocked」。

## 门收割

删除的生产路径:无整文件删除,故路径清单为 `none`。实际删除的生产路径是 `packages/daemon/src/doc-sync-settlement.ts` 中导出的 `taskPlanHeadingRestore` 及其两个调用点;该符号在生产代码中剩余出现次数为 0。

## 任务与范围

- Harness 任务:task_a9d634eea5ee611e88391d3d1f
- 分支:codex/prose-region-guard
- 公开范围:上述两个生产文件与六个对应测试文件。
- 私有规划/证据已更新:是
- 不在范围内:region id 派生方式、写入侧提示、显式 region 锚。这三条在承重裁定里被明确否掉(RJ1/RJ2/RJ3)——它们都是对一个应当以删除来修的问题做加法。

## 版本影响

- 版本:无变更。这是内部写路校验改动,不涉及打包面。
- 发布影响:不发布。

## 治理声明

- 触碰 protected surface:是
- 范围:doc-sync 写路校验契约(`additiveProof`),它决定 authored 文档能否进入台账。
- 权威:dec_8AF65DA6436BAEF9DE764B485B
- Break-glass:否

## 验证

- Base `origin/main` SHA:38636b2fd2f47ba2053a6289d116a91b73cfe376(与 merge-base 一致,提交时 ahead 1 / behind 0)
- Kernel 定向测试:12/12 通过。
- Ubuntu 隔离 integration:29/29 通过(7/7、10/10、5/5、7/7)。
- `eslint`、`tsc -b`、line-density、file-complexity、production-delta、`git diff --check`:全部通过。
- 未跑:`npm run check:local` 与本机完整门矩阵。按本仓停止点纪律,worker 的停止点是触碰面定向测试绿 + 本地 commit,GitHub CI 是完整权威。
- 未跑:对历史 blocked task plan 的人工 `ha doc sync --dry-run`。等价行为已由隔离 integration 覆盖,且唯一的真实 blocked 实例(`task_5284063b`)在本变更落地前已由另一条线修复。

## 评审证据

- 自审:核对派工前设定的两条验收判据。①阴性对照在:frontmatter 改动仍 fail closed(`doc-sync-conflicts-retirement.test.ts` 保留 `owner: other` 用例;`doc-sync-slice-a.test.ts:111` 仍断言 `machine region changed`)。没有这条,「删掉 prose 守卫」与「删掉整层守卫」在测试上无法区分。②生产代码是净删除(+4/-31),未引入任何新增机制。
- 评审子代理:实现由派工 worker `debug-minimal-fixer` 完成(`dispatch_8d41b82411b1f3f8cd5f9b3c`),评审由派工的 CEO session 执行。
- 人工评审:待办。
- 阻塞发现:无。

## 残余风险

- 改写标题仍然会改变其 region id。对 machine region 而言这现在是唯一被守的形态,且是有意为之;对 prose region 已不再有影响。将来若有文档类型需要稳定的 prose 骨架,应当声明 machine region,而不是依赖标题文字。
- `AGENTS.md` 仍要求 agent 先读 `read_set.md`,而该文件在仓库中一个都不存在。与本变更无关,已在 PLT-GovernedEntity W3 设计中跟踪。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P5svwhZpinU67QyZDLBnnA
