### PR TITLE
fix(daemon): resolve WAL materialization worker from runtime layout — dist-entry daemons could never materialize

### DIFF
--- a/packages/cli/test/daemon-autostart-cli.test.ts
+++ b/packages/cli/test/daemon-autostart-cli.test.ts
@@ -46,6 +46,9 @@ test("registered checkout autostarts the daemon while its worktree only connects
     assert.equal(run(fixture.root, fixture.userRoot, ["daemon", "start", "--service"]).ok, true);
     register(fixture.root, fixture.userRoot, "autostart");
     const status = run(fixture.root, fixture.userRoot, ["daemon", "status"]);
+    assert.equal(status.entry, "source");
+    assert.equal(typeof (status.build as { readonly commit?: unknown }).commit, "string");
+    assert.match(String(status.summary), /entry=source commit=[0-9a-f]{40}/u);
     assert.deepEqual(status.target, {
       endpoint: localUserDaemonEndpoint(fixture.userRoot, "default"),
       daemonId: "default",
@@ -77,10 +80,9 @@ test("registered checkout autostarts the daemon while its worktree only connects
       "stop receipt settles only after pid and socket are gone",
     );
     const lifecycle = readDaemonLifecycleRecords(fixture.userRoot, "default");
-    assert.equal(
-      lifecycle.some((record) => record.event === "process_start"),
-      true,
-    );
+    const processStart = lifecycle.find((record) => record.event === "process_start");
+    assert.equal(processStart?.entry, "source");
+    assert.match(processStart?.commit ?? "", /^[0-9a-f]{40}$/u);
     assert.equal(
       lifecycle.some((record) => record.event === "socket_bound"),
       true,

--- a/packages/daemon/src/build-identity.ts
+++ b/packages/daemon/src/build-identity.ts
@@ -7,7 +7,9 @@ import { runProcessText } from "./process-port.ts";
 export interface DaemonBuildStamp {
   readonly commit: string | null;
 }
+export type DaemonEntry = "source" | "dist";
 export interface DaemonBuildStatus extends DaemonBuildStamp {
+  readonly entry: DaemonEntry;
   readonly loadedBuildId: string | null;
   readonly diskBuildId: string | null;
   readonly drifted: boolean;
@@ -30,12 +32,13 @@ export function daemonBuildStamp(): DaemonBuildStamp {
 }
 export function observeDaemonBuild(runtimeFile?: string): DaemonBuildObserver {
   const markerPath = runtimeFile === undefined ? processMarkerPath : buildMarkerPath(runtimeFile),
+    entry: DaemonEntry = markerPath === null ? "source" : "dist",
     loadedBuildId =
       runtimeFile === undefined ? processLoadedBuildId : markerPath === null ? null : readBuildId(markerPath);
   return {
     status: () => {
       const diskBuildId = markerPath === null ? null : readBuildId(markerPath);
-      return { ...daemonBuildStamp(), loadedBuildId, diskBuildId, drifted: loadedBuildId !== diskBuildId };
+      return { ...daemonBuildStamp(), entry, loadedBuildId, diskBuildId, drifted: loadedBuildId !== diskBuildId };
     },
   };
 }

--- a/packages/daemon/src/daemon-host-lifecycle-api.ts
+++ b/packages/daemon/src/daemon-host-lifecycle-api.ts
@@ -6,7 +6,7 @@ export function createDaemonHostLifecycleApi(
 ): Pick<DaemonHost, "status" | "startAttachments" | "attachmentsSettled" | "close"> {
   return {
     status: () => {
-      const observedBuild = context.buildObserver.status(),
+      const { entry, ...observedBuild } = context.buildObserver.status(),
         build = {
           ...observedBuild,
           version: process.env.npm_package_version ?? "0.0.0",
@@ -16,6 +16,10 @@ export function createDaemonHostLifecycleApi(
           `${process.pid}`,
           " repos=",
           `${context.cells.size + context.warming.size + context.unavailable.size}`,
+          " entry=",
+          entry,
+          " commit=",
+          build.commit ?? "unknown",
           "",
         ].join(""),
         summary = observedBuild.drifted
@@ -34,6 +38,7 @@ export function createDaemonHostLifecycleApi(
         daemonId: context.input.daemonId,
         pid: process.pid,
         startedAt: context.startedAt,
+        entry,
         build,
         repos: [
           ...[...context.cells.values()].map((cell) => cell.status()),

--- a/packages/daemon/src/daemon-host-types.ts
+++ b/packages/daemon/src/daemon-host-types.ts
@@ -111,7 +111,8 @@ export interface DaemonHost {
     readonly daemonId: string;
     readonly pid: number;
     readonly startedAt: string;
-    readonly build: DaemonBuildStatus & { readonly version: string };
+    readonly entry: DaemonBuildStatus["entry"];
+    readonly build: Omit<DaemonBuildStatus, "entry"> & { readonly version: string };
     readonly repos: readonly RepoCellStatus[];
     readonly summary: string;
   };

--- a/packages/daemon/src/lifecycle-log.ts
+++ b/packages/daemon/src/lifecycle-log.ts
@@ -11,6 +11,7 @@ import {
 } from "node:fs";
 import path from "node:path";
 import { consumeKnownError } from "../../kernel/src/index.ts";
+import type { DaemonEntry } from "./build-identity.ts";
 
 export const DAEMON_LIFECYCLE_LOG_SCHEMA = Object.freeze({ id: "daemon-lifecycle/v1" });
 const defaultMaxBytes = 4 * 1024 * 1024;
@@ -49,6 +50,7 @@ export interface DaemonLifecycleEntry {
   readonly signal?: string | null;
   readonly reason?: string | null;
   readonly commit?: string | null;
+  readonly entry?: DaemonEntry;
   readonly loadedBuildId?: string | null;
   readonly diskBuildId?: string | null;
   readonly drifted?: boolean;

--- a/packages/daemon/src/protocol/daemon-protocol.contract.ts
+++ b/packages/daemon/src/protocol/daemon-protocol.contract.ts
@@ -499,6 +499,7 @@ export interface DaemonStatusResult {
   readonly daemonId: string;
   readonly pid: number;
   readonly startedAt: string;
+  readonly entry: "source" | "dist";
   readonly build: {
     readonly version: string;
     readonly commit: string | null;

--- a/packages/daemon/src/repo-cell.ts
+++ b/packages/daemon/src/repo-cell.ts
@@ -1,5 +1,6 @@
 import path from "node:path";
 import { existsSync, readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 import { makeTaskLifecycleService } from "../../application/src/task-lifecycle-service.ts";
 import {
   blockingOf,
@@ -76,6 +77,12 @@ export interface RepoCellCore {
   readonly replica: ReturnType<typeof openReplicaCutSource>;
 }
 
+export function daemonWalMaterializationWorkerUrl(moduleUrl: string | URL = import.meta.url): URL {
+  const currentModuleUrl = new URL(moduleUrl),
+    extension = path.extname(fileURLToPath(currentModuleUrl));
+  return new URL(`./wal-materialization-daemon-worker${extension}`, currentModuleUrl);
+}
+
 export function initializeRepoCell(context: RepoCellCoreInput): RepoCellCore {
   let projection: ReturnType<typeof makeTaskProjection> | null = null;
   let pendingSettlement: { readonly actor: ActorIdentity; readonly inventory: unknown | null } | null = null;
@@ -131,7 +138,7 @@ export function initializeRepoCell(context: RepoCellCoreInput): RepoCellCore {
     authoredBranch: context.authoredBranch,
     killpoint: context.input.killpoint,
     afterFlush: settleAuthoredCandidates,
-    walMaterializationWorkerUrl: new URL("./wal-materialization-daemon-worker.ts", import.meta.url),
+    walMaterializationWorkerUrl: daemonWalMaterializationWorkerUrl(),
     walMaterializationTestFault: context.input.walMaterializationTestFault,
     walMaterializationFence: () => context.activeWriterEpochFenceDescriptor,
     beforeAppend: () => context.activeWriterEpochGuard?.(),

--- a/packages/daemon/test/daemon-build-drift.integration.test.ts
+++ b/packages/daemon/test/daemon-build-drift.integration.test.ts
@@ -22,6 +22,8 @@ test("a dist rebuild is observable while the daemon keeps serving and its runtim
     const worker = await host.spawnRuntime(repoId, { runtimeInstanceId: "build-drift-worker", cwd: { scope: "repo-root" }, prompt: "Keep running across the dist rebuild.", taskId: null, idempotencyKey: "build-drift-worker" }, auth);
     assert.equal(worker.outcome, "applied", JSON.stringify(worker));
     const matched = host.status();
+    assert.equal(matched.entry, "dist");
+    assert.match(matched.summary, /entry=dist commit=/u);
     assert.deepEqual(matched.build, { ...matched.build, loadedBuildId: "build-a", diskBuildId: "build-a", drifted: false });
     assert.doesNotMatch(matched.summary, /build drift/u);
 

--- a/packages/daemon/test/daemon-host-recovery.test.ts
+++ b/packages/daemon/test/daemon-host-recovery.test.ts
@@ -331,7 +331,7 @@ test("repository modes close local, center-assignment, and edge command families
         ["local", "local"],
       ],
     );
-    assert.match(host.status().summary, /repos=3$/u);
+    assert.match(host.status().summary, /repos=3 entry=(?:source|dist) commit=[0-9a-f]{40}$/u);
     assert.equal(
       (await host.run("local", { kind: "task-create", taskId: "task-local", title: "Local" }, auth)).outcome,
       "applied",

--- a/packages/daemon/test/protocol-hello-build.test.ts
+++ b/packages/daemon/test/protocol-hello-build.test.ts
@@ -27,7 +27,7 @@ test("protocol.hello rejects a stale dist fingerprint and requests one restart",
   const server = createJsonRpcProtocolServer({
     host: {} as never,
     build: { commit: "loaded" },
-    buildObserver: { status: () => ({ commit: "loaded", loadedBuildId: "build-a", diskBuildId: "build-b", drifted: true }) },
+    buildObserver: { status: () => ({ commit: "loaded", entry: "dist", loadedBuildId: "build-a", diskBuildId: "build-b", drifted: true }) },
     authContext: { transportKind: "unix-socket" } as DaemonAuthenticationContext,
     emit: async () => undefined,
     requestShutdown: () => { shutdowns += 1; },

--- a/packages/daemon/test/wal-materialization-worker-path.test.ts
+++ b/packages/daemon/test/wal-materialization-worker-path.test.ts
@@ -1,0 +1,15 @@
+// harness-test-tier: fast
+import assert from "node:assert/strict";
+import test from "node:test";
+import { daemonWalMaterializationWorkerUrl } from "../src/repo-cell.ts";
+
+test("the daemon WAL worker keeps the executing module extension in source and dist layouts", () => {
+  assert.equal(
+    daemonWalMaterializationWorkerUrl("file:///repo/packages/daemon/src/repo-cell.ts").href,
+    "file:///repo/packages/daemon/src/wal-materialization-daemon-worker.ts",
+  );
+  assert.equal(
+    daemonWalMaterializationWorkerUrl("file:///repo/packages/cli/dist/daemon/src/repo-cell.js").href,
+    "file:///repo/packages/cli/dist/daemon/src/wal-materialization-daemon-worker.js",
+  );
+});


### PR DESCRIPTION
# English

## Summary

Fixes a live ledger outage: a daemon started from the CLI's dist build could never materialize the WAL. The per-repo materialization worker (introduced with the worker_threads move in #2114/#2117) was located with a source-layout assumption (`./wal-materialization-daemon-worker.ts` next to the module), which does not exist under `packages/cli/dist`; every materialization attempt failed with `Cannot find module`, the retry budget was exhausted, and all acknowledged writes stayed in the WAL. Because the `ha` bin points at dist and the canonical post-merge hook self-restarts the daemon through it, this fired twice on 2026-09-02 (07:07 and 08:45 local) and left 453 revisions unmaterialized until the CEO restarted from source. The worker path is now resolved once from the runtime layout (source or dist), and the daemon reports which entry it runs from: `ha daemon status` prints `entry=source|dist commit=<sha>`, the lifecycle `process_start` event carries `entry`, and the protocol status result exposes it.

## Architectural Justification

- Mechanism sentence: a process that locates its own helper by a build-layout assumption works in exactly one of its two shipped layouts, and fails in the other only at the first write that needs the helper, long after startup looked healthy; resolving the helper from the runtime layout and reporting the entry makes the mismatch impossible in one case and visible in every other.
- No fallback to in-process materialization was added; failure stays visible. The fix removes the cause.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none

## Machine-Readable Declarations

Production-Delta: +23/-4
Dependency-Change: none

### Optional Evidence Claims

None.

## Task And Scope

- Harness task task_3605b3b8ecf4d4e48e476f257a (流转缺陷, high) under PLT-Ontology (root task_5fc5080044fcfdbf548008f2f5). Branch `codex/dist-daemon-wal-worker`. Incident fact F-BA56AE4C; fix fact F-ACDCE1D9.

## Version Impact

- Version: no change. Publish impact: none.

## Governance Declaration

- Protected surface touched: no (daemon materializer path resolution, build identity, status/lifecycle fields; no CI/gate files). Authorizing task: task_3605b3b8ecf4d4e48e476f257a. Break-glass: no.

## Verification

- Positive control: an isolated dist-entry daemon reproduced `Cannot find module …/dist/daemon/src/wal-materialization-daemon-worker.ts`; after the fix the same dist-entry daemon materialized revisions 1–2 (WAL flush commit in the temp repo) and the source-entry daemon materialized 1–3.
- Mutation check: hard-coding the `.ts` path again makes the new regression test fail.
- Typecheck, ESLint, CLI build, and 5 targeted tests green. The real default daemon was not touched by the worker.
- [ ] Full suites: GitHub CI is the authority.
- [ ] CEO dogfood after merge: restart the default daemon through the `ha` bin (dist entry), perform one ledger write, confirm a WAL flush commit appears.

## Review Evidence

- `ha daemon status` now shows `entry=` and `commit=`, so the next dist-vs-source confusion is diagnosable from the first command.
- Ledger report with both entry transcripts: artifacts/dist-daemon-report.md.

## Residual Risk

- Other helper scripts resolved by source-layout assumptions, if any exist, are not swept here; none is currently implicated.

---

# 中文

## 概要

修实况台账事故:从 CLI dist 构建启动的 daemon 永远无法物化 WAL。per-repo 物化 worker(#2114/#2117 搬进 worker_threads 时引入)按源码布局假设定位(`./wal-materialization-daemon-worker.ts`),dist 下不存在,每次物化都 `Cannot find module`、重试耗尽,所有已确认写入滞留 WAL。由于 `ha` bin 指向 dist、canonical post-merge hook 经它自愈重启 daemon,2026-09-02 07:07 与 08:45 两次触发,453 个 revision 滞留直到 CEO 从源码重启。现改为按运行时布局(source/dist)一处解析 worker 路径,并让 daemon 报告启动入口:`ha daemon status` 打印 `entry=source|dist commit=<sha>`,lifecycle `process_start` 带 `entry`,协议 status 结果暴露该字段。

## 架构辩护

- 机制句:靠构建布局假设定位自身 helper 的进程,只在两种发布布局之一能跑,在另一种里要到第一次需要 helper 的写入才失败,而启动看起来一切正常;按运行时布局解析并报告入口,让错配在一种情况下不可能、在其余情况下可见。
- 不加进程内物化兜底;失败保持可见,修的是根因。

## 机读声明

`Production-Delta: +23/-4`;无依赖变更。

## 治理声明

- 未触碰 protected surface;授权任务 task_3605b3b8ecf4d4e48e476f257a;无 break-glass。事故 fact F-BA56AE4C,修复 fact F-ACDCE1D9。

## 验证

- 阳性对照:隔离 dist 入口 daemon 复现 Cannot find module;修后 dist 入口物化 1–2、源码入口物化 1–3(各有临时仓 WAL flush commit);变异检查:写死 `.ts` 路径回红。typecheck/ESLint/CLI build/5 定向测试绿;完整权威=GitHub CI。合并后 CEO 用 `ha` bin 重启 default daemon 做一次写入 dogfood。

## 残余风险

- 其他按源码布局假设定位的 helper 脚本(若有)本 PR 不扫荡,当前无失败指认。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VTzQAqvuFy6ikGjBKxA9xj
