### PR TITLE
feat(daemon): expose resident daemon over stdio transport

### DIFF
--- a/packages/cli/src/daemon/control.ts
+++ b/packages/cli/src/daemon/control.ts
@@ -26,6 +26,7 @@ import { ensureCliDaemonRunning } from "./autostart.ts";
 import { daemonRepoModeWords } from "../../../daemon/src/protocol/daemon-protocol.contract.ts";
 import { firstCliCommandIndex } from "../cli/thin-command.ts";
 import { runGuiLaunch } from "../cli/gui-launch.ts";
+import { runDaemonStdioBridge } from "./stdio-bridge.ts";
 const fleetNumber = { port: /^(?:0|[1-9][0-9]{0,4})$/u, quota: /^[1-9][0-9]{0,15}$/u };
 type ReceiptEmitter = (receipt: Record<string, unknown>, json: boolean) => void;
 type ControlFinisher = (receipt: Record<string, unknown>, exitCode: number) => number;
@@ -39,6 +40,16 @@ export async function runDaemonControl(argv: readonly string[], renderReceipt: R
     invokingRoot = path.resolve(daemonOption(argv, "--root") ?? process.cwd());
   const daemonId = daemonOption(argv, "--daemon-id") ?? daemonIdFromEnv(),
     finish: ControlFinisher = (receipt, exitCode) => finishControlReceipt(renderReceipt, receipt, json, exitCode);
+  if (command === "connect") {
+    if (argv.includes("--help")) {
+      console.log("Usage: ha daemon connect --stdio [--user-root <path>] [--daemon-id <id>]");
+      console.log("Expose the resident daemon JSON-RPC stream over stdin/stdout.");
+      return 0;
+    }
+    if (subcommand === "--stdio")
+      return runDaemonStdioBridge({ socketPath: localUserDaemonEndpoint(userRoot, daemonId) });
+    return finish(daemonFailure("daemon-connect", "unsupported_command", "Use `ha daemon connect --stdio`."), 2);
+  }
   try {
     if (command === "projection" && subcommand === "rebuild") {
       const suppliedRoot = daemonOption(argv, "--root");

--- a/packages/cli/src/daemon/stdio-bridge.ts
+++ b/packages/cli/src/daemon/stdio-bridge.ts
@@ -1,0 +1,68 @@
+import type { Duplex, Readable, Writable } from "node:stream";
+import { connectSocket } from "../../../daemon/src/client/local-json-rpc-client.ts";
+
+export interface DaemonStdioBridgeOptions {
+  readonly socketPath: string;
+  readonly timeoutMs?: number;
+  readonly input?: Readable;
+  readonly output?: Writable;
+  readonly connect?: (socketPath: string, timeoutMs: number) => Promise<Duplex>;
+  readonly reportError?: (message: string) => void;
+}
+
+/**
+ * Keep the remote transport deliberately byte-oriented. The daemon already owns
+ * JSON-RPC framing and handshake semantics; this process only crosses the local
+ * filesystem socket boundary and exposes the same stream over SSH stdio.
+ */
+export async function runDaemonStdioBridge(options: DaemonStdioBridgeOptions): Promise<number> {
+  const input = options.input ?? process.stdin,
+    output = options.output ?? process.stdout,
+    connect = options.connect ?? connectSocket,
+    reportError = options.reportError ?? ((message) => process.stderr.write(`${message}\n`));
+  let socket: Duplex;
+  try {
+    socket = await connect(options.socketPath, options.timeoutMs ?? 10_000);
+  } catch (error) {
+    reportError(`daemon stdio bridge could not connect: ${error instanceof Error ? error.message : String(error)}`);
+    return 1;
+  }
+
+  let settled = false,
+    inputEnded = false;
+  const result = new Promise<number>((resolve) => {
+    const complete = (code: number): void => {
+      if (settled) return;
+      settled = true;
+      input.pause();
+      if (output !== process.stdout && !output.destroyed && !output.writableEnded) output.end();
+      if (!socket.destroyed) socket.destroy();
+      resolve(code);
+    };
+    input.on("data", (chunk: Buffer | string) => {
+      if (!socket.write(chunk)) input.pause();
+    });
+    input.on("end", () => {
+      inputEnded = true;
+      socket.end();
+    });
+    input.on("error", (error) => {
+      reportError(`daemon stdio bridge input failed: ${error.message}`);
+      complete(1);
+    });
+    socket.on("drain", () => input.resume());
+    socket.on("data", (chunk: Buffer | string) => {
+      if (!output.write(chunk)) socket.pause();
+    });
+    output.on("drain", () => socket.resume());
+    socket.on("end", () => {
+      if (!inputEnded) reportError("daemon stdio bridge remote socket ended unexpectedly.");
+    });
+    socket.on("close", () => complete(inputEnded ? 0 : 1));
+    socket.on("error", (error) => {
+      reportError(`daemon stdio bridge socket failed: ${error.message}`);
+      complete(1);
+    });
+  });
+  return result;
+}

--- a/packages/cli/test/daemon-stdio-bridge.test.ts
+++ b/packages/cli/test/daemon-stdio-bridge.test.ts
@@ -1,0 +1,105 @@
+// harness-test-tier: fast
+import assert from "node:assert/strict";
+import { PassThrough } from "node:stream";
+import test from "node:test";
+import { buildSshArgs } from "../../daemon/src/client/remote-json-rpc-client.ts";
+import { runDaemonStdioBridge } from "../src/daemon/stdio-bridge.ts";
+
+test("SSH arguments target a user-managed local endpoint without tunnel-specific knowledge", () => {
+  assert.deepEqual(
+    buildSshArgs({
+      host: "127.0.0.1",
+      port: 22022,
+      user: "cyr",
+      identityFile: "C:/Users/test/.ssh/harness-company-internal",
+      hostKeyAlias: "company-internal-host",
+      remoteCommand: ["ha", "daemon", "connect", "--stdio"],
+    }),
+    [
+      "-T",
+      "-o",
+      "BatchMode=yes",
+      "-o",
+      "StrictHostKeyChecking=yes",
+      "-o",
+      "ConnectTimeout=10",
+      "-o",
+      "ServerAliveInterval=30",
+      "-o",
+      "ServerAliveCountMax=3",
+      "-o",
+      "HostKeyAlias=company-internal-host",
+      "-o",
+      "IdentitiesOnly=yes",
+      "-i",
+      "C:/Users/test/.ssh/harness-company-internal",
+      "-p",
+      "22022",
+      "cyr@127.0.0.1",
+      "ha",
+      "daemon",
+      "connect",
+      "--stdio",
+    ],
+  );
+});
+
+test("SSH arguments defer endpoint resolution to an OpenSSH config alias", () => {
+  assert.deepEqual(
+    buildSshArgs({
+      sshConfigHost: "harness-company-via-uu",
+      remoteCommand: ["ha", "daemon", "connect", "--stdio"],
+    }),
+    [
+      "-T",
+      "-o",
+      "BatchMode=yes",
+      "-o",
+      "StrictHostKeyChecking=yes",
+      "-o",
+      "ConnectTimeout=10",
+      "-o",
+      "ServerAliveInterval=30",
+      "-o",
+      "ServerAliveCountMax=3",
+      "harness-company-via-uu",
+      "ha",
+      "daemon",
+      "connect",
+      "--stdio",
+    ],
+  );
+});
+
+test("stdio bridge forwards bytes and exits cleanly when the caller closes", async () => {
+  const input = new PassThrough(),
+    output = new PassThrough(),
+    socket = new PassThrough(),
+    received: Buffer[] = [];
+  output.on("data", (chunk: Buffer) => received.push(chunk));
+  const result = runDaemonStdioBridge({
+    socketPath: "/tmp/daemon.sock",
+    input,
+    output,
+    connect: async () => socket,
+  });
+  input.end("json-rpc-line\n");
+  assert.equal(await result, 0);
+  assert.equal(Buffer.concat(received).toString("utf8"), "json-rpc-line\n");
+});
+
+test("stdio bridge reports a local daemon connection failure without writing protocol output", async () => {
+  const errors: string[] = [],
+    output = new PassThrough();
+  const result = await runDaemonStdioBridge({
+    socketPath: "/tmp/missing.sock",
+    output,
+    connect: async () => {
+      throw new Error("connect refused");
+    },
+    reportError: (message) => errors.push(message),
+  });
+  assert.equal(result, 1);
+  assert.deepEqual(errors, ["daemon stdio bridge could not connect: connect refused"]);
+  assert.equal(output.read(), null);
+});

--- a/packages/daemon/src/client/local-json-rpc-stream.ts
+++ b/packages/daemon/src/client/local-json-rpc-stream.ts
@@ -166,7 +166,10 @@ export async function streamDaemonFacetAt(input: {
         function streamFail(error: Error): void {
           lastFailure = error.message;
           clearTimeout(watchdog);
-          if (!settled) reject(error);
+          // After the first successful attach, the close handler owns reconnect scheduling.
+          // Rejecting here as well causes the timer callback's catch path to schedule a duplicate
+          // retry when a socket emits error followed by close.
+          if (!settled && !everAttached) reject(error);
           candidate.destroy();
         }
       };

--- a/packages/daemon/src/client/local-json-rpc-stream.ts
+++ b/packages/daemon/src/client/local-json-rpc-stream.ts
@@ -1,5 +1,6 @@
 import net from "node:net";
 import { createInterface } from "node:readline";
+import type { Duplex } from "node:stream";
 import { consumeKnownError } from "../../../kernel/src/index.ts";
 import { type AgentRuntimeAttachEvent, type AgentRuntimeAttachResult } from "../agent-runtime-stream.ts";
 import { daemonStreamFacets, type DaemonStreamPayloadMap } from "../protocol/daemon-protocol.contract.ts";
@@ -39,6 +40,7 @@ export async function streamAgentRuntimeAt(input: {
 }
 export async function streamDaemonFacetAt(input: {
   readonly socketPath: string;
+  readonly openSocket?: () => Promise<Duplex>;
   readonly repoId: string;
   readonly method: keyof DaemonStreamPayloadMap;
   readonly payload: DaemonStreamPayloadMap[keyof DaemonStreamPayloadMap];
@@ -48,7 +50,7 @@ export async function streamDaemonFacetAt(input: {
 }): Promise<() => void> {
   let detached = false,
     everAttached = false,
-    socket: net.Socket | undefined,
+    socket: Duplex | undefined,
     retry: ReturnType<typeof setTimeout> | undefined,
     reconnects = 0,
     lastFailure = "socket closed",
@@ -67,101 +69,109 @@ export async function streamDaemonFacetAt(input: {
     reconnects += 1;
     retry = setTimeout(() => {
       retry = undefined;
-      void connect().catch(consumeKnownError);
+      void connect().catch((error) => {
+        lastFailure = error instanceof Error ? error.message : String(error);
+        consumeKnownError(error);
+        scheduleReconnect();
+      });
     }, delayMs);
   };
   const connect = () =>
     new Promise<void>((resolve, reject) => {
-      const next = net.createConnection(input.socketPath),
-        lines = createInterface({ input: next });
-      let watchdog: ReturnType<typeof setTimeout> | undefined;
-      socket = next;
-      let settled = false,
-        supported = true;
-      const armWatchdog = () => {
-        clearTimeout(watchdog);
-        watchdog = setTimeout(
-          () => streamFail(new Error("daemon_stream_unavailable")),
-          input.timeoutMs ?? defaultSilenceMs,
-        );
-      };
-      armWatchdog();
-      next.once("connect", () => {
-        const payload =
-          input.method === "repo.agentRuntime.attach"
-            ? { ...(input.payload as object), afterCursor: cursor }
-            : { ...(input.payload as object), afterSeq: cursor };
-        next.write(
-          `${JSON.stringify({
-            jsonrpc: "2.0",
-            id: 1,
-            method: "protocol.hello",
-            params: { protocolVersion: currentDaemonProtocolVersion },
-          })}\n${JSON.stringify({
-            jsonrpc: "2.0",
-            id: 2,
-            method: facet.method,
-            params: { repo: { repoId: input.repoId }, payload },
-          })}\n`,
-        );
-      });
-      lines.on("line", (line) => {
-        if (!settled) armWatchdog();
-        try {
-          const value = JSON.parse(line) as {
-            readonly id?: number;
-            readonly method?: string;
-            readonly params?: unknown;
-            readonly result?: unknown;
-            readonly error?: { readonly message?: string };
-          };
-          if (value.id === 2) {
-            if (value.error) throw new Error(value.error.message ?? "daemon stream failed");
-            const initial = parseDaemonStreamResult(input.method, value.result);
-            input.onValue(initial);
-            supported = initial.ok === true;
-            if (initial.ok) {
+      const setup = (candidate: Duplex): void => {
+        const lines = createInterface({ input: candidate });
+        let watchdog: ReturnType<typeof setTimeout> | undefined;
+        socket = candidate;
+        let settled = false,
+          supported = true;
+        const armWatchdog = () => {
+          clearTimeout(watchdog);
+          watchdog = setTimeout(
+            () => streamFail(new Error("daemon_stream_unavailable")),
+            input.timeoutMs ?? defaultSilenceMs,
+          );
+        };
+        armWatchdog();
+        candidate.once("connect", () => {
+          const payload =
+            input.method === "repo.agentRuntime.attach"
+              ? { ...(input.payload as object), afterCursor: cursor }
+              : { ...(input.payload as object), afterSeq: cursor };
+          candidate.write(
+            `${JSON.stringify({
+              jsonrpc: "2.0",
+              id: 1,
+              method: "protocol.hello",
+              params: { protocolVersion: currentDaemonProtocolVersion },
+            })}\n${JSON.stringify({
+              jsonrpc: "2.0",
+              id: 2,
+              method: facet.method,
+              params: { repo: { repoId: input.repoId }, payload },
+            })}\n`,
+          );
+        });
+        lines.on("line", (line) => {
+          if (!settled) armWatchdog();
+          try {
+            const value = JSON.parse(line) as {
+              readonly id?: number;
+              readonly method?: string;
+              readonly params?: unknown;
+              readonly result?: unknown;
+              readonly error?: { readonly message?: string };
+            };
+            if (value.id === 2) {
+              if (value.error) throw new Error(value.error.message ?? "daemon stream failed");
+              const initial = parseDaemonStreamResult(input.method, value.result);
+              input.onValue(initial);
+              supported = initial.ok === true;
+              if (initial.ok) {
+                cursor =
+                  input.method === "repo.agentRuntime.attach"
+                    ? (initial as AgentRuntimeAttachResult & { readonly cursor: string }).cursor
+                    : Number((initial as Record<string, unknown>).outputSeq);
+                everAttached = true;
+                reconnects = 0;
+              }
+              settled = true;
+              clearTimeout(watchdog);
+              resolve();
+              if (!supported) candidate.end();
+            } else if (value.method === facet.eventMethod) {
+              const event = parseDaemonStreamEvent(input.method, value.params);
               cursor =
                 input.method === "repo.agentRuntime.attach"
-                  ? (initial as AgentRuntimeAttachResult & { readonly cursor: string }).cursor
-                  : Number((initial as Record<string, unknown>).outputSeq);
-              everAttached = true;
-              reconnects = 0;
+                  ? (event as AgentRuntimeAttachEvent).cursor
+                  : Number((event as Record<string, unknown>).seq);
+              input.onValue(event);
             }
-            settled = true;
-            clearTimeout(watchdog);
-            resolve();
-            if (!supported) next.end();
-          } else if (value.method === facet.eventMethod) {
-            const event = parseDaemonStreamEvent(input.method, value.params);
-            cursor =
-              input.method === "repo.agentRuntime.attach"
-                ? (event as AgentRuntimeAttachEvent).cursor
-                : Number((event as Record<string, unknown>).seq);
-            input.onValue(event);
+          } catch (error) {
+            consumeKnownError(error);
+            streamFail(error instanceof Error ? error : new Error(String(error)));
           }
-        } catch (error) {
-          consumeKnownError(error);
-          streamFail(error instanceof Error ? error : new Error(String(error)));
+        });
+        lines.on("error", consumeKnownError);
+        candidate.once("error", streamFail);
+        candidate.once("close", () => {
+          lines.close();
+          clearTimeout(watchdog);
+          if (!settled && !everAttached) {
+            reject(new Error("daemon stream closed before attach"));
+            return;
+          }
+          if (!detached && supported && everAttached && input.method === "repo.agentRuntime.attach")
+            scheduleReconnect();
+        });
+        function streamFail(error: Error): void {
+          lastFailure = error.message;
+          clearTimeout(watchdog);
+          if (!settled) reject(error);
+          candidate.destroy();
         }
-      });
-      lines.on("error", consumeKnownError);
-      next.once("error", streamFail);
-      next.once("close", () => {
-        lines.close();
-        clearTimeout(watchdog);
-        if (!settled && !everAttached) {
-          reject(new Error("daemon stream closed before attach"));
-          return;
-        }
-        if (!detached && supported && everAttached && input.method === "repo.agentRuntime.attach") scheduleReconnect();
-      });
-      function streamFail(error: Error): void {
-        lastFailure = error.message;
-        clearTimeout(watchdog);
-        if (!settled) reject(error);
-        next.destroy();
-      }
+      };
+      if (input.openSocket) input.openSocket().then(setup, reject);
+      else setup(net.createConnection(input.socketPath));
     });
   await connect();
   return () => {

--- a/packages/daemon/src/client/remote-json-rpc-client.ts
+++ b/packages/daemon/src/client/remote-json-rpc-client.ts
@@ -1,3 +1,4 @@
+/** @slice-activation PLT-Daemon W3 remote transport substrate is exported for daemon composition roots. */
 import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
 import { Duplex, type Readable } from "node:stream";
 import { isContractVersionCompatible } from "../../../kernel/src/domain/contract-version.ts";

--- a/packages/daemon/src/client/remote-json-rpc-client.ts
+++ b/packages/daemon/src/client/remote-json-rpc-client.ts
@@ -1,0 +1,306 @@
+import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import { Duplex, type Readable } from "node:stream";
+import { isContractVersionCompatible } from "../../../kernel/src/domain/contract-version.ts";
+import type { JsonObject } from "../protocol/json-rpc-types.ts";
+import { currentDaemonProtocolVersion } from "../protocol/version.ts";
+import { JsonRpcLineClient } from "./local-json-rpc-client.ts";
+
+export type RemoteDaemonTransportErrorCode =
+  | "ssh_not_found"
+  | "ssh_spawn_failed"
+  | "ssh_auth_failed"
+  | "ssh_host_key_failed"
+  | "ssh_connection_failed"
+  | "remote_daemon_closed"
+  | "remote_daemon_timeout"
+  | "remote_daemon_protocol_mismatch"
+  | "remote_daemon_unavailable";
+
+export interface RemoteDaemonSshOptions {
+  /** The local endpoint exposed by any user-managed tunnel service. */
+  readonly host?: string;
+  readonly port?: number;
+  readonly user?: string;
+  readonly identityFile?: string;
+  readonly hostKeyAlias?: string;
+  /** Use an existing OpenSSH config host when credentials are configured there. */
+  readonly sshConfigHost?: string;
+  readonly sshCommand?: string;
+  readonly remoteCommand?: readonly string[];
+  readonly connectTimeoutMs?: number;
+  readonly serverAliveIntervalSeconds?: number;
+  readonly serverAliveCountMax?: number;
+}
+
+export interface RemoteDaemonConnection {
+  readonly child: ChildProcessWithoutNullStreams;
+  readonly request: (method: string, params: JsonObject, timeoutMs?: number) => Promise<JsonObject>;
+  readonly close: () => Promise<void>;
+}
+
+export async function requestRemoteDaemonJsonRpc(
+  options: RemoteDaemonSshOptions,
+  method: string,
+  params: JsonObject,
+  timeoutMs?: number,
+): Promise<JsonObject> {
+  const connection = await openRemoteDaemonConnection(options);
+  try {
+    return await connection.request(method, params, timeoutMs);
+  } finally {
+    await connection.close();
+  }
+}
+
+/** Open an SSH-backed byte stream for long-lived daemon facets. JSON-RPC framing
+ * remains owned by the shared stream client; this is only a Duplex adapter over
+ * ssh stdin/stdout.
+ */
+export async function openRemoteDaemonStream(options: RemoteDaemonSshOptions): Promise<Duplex> {
+  const child = spawn(options.sshCommand ?? "ssh", buildSshArgs(options), {
+    stdio: ["pipe", "pipe", "pipe"],
+    windowsHide: true,
+  });
+  const stderr = captureStderr(child.stderr);
+  let spawned = false;
+  child.once("spawn", () => {
+    spawned = true;
+  });
+  const stream = new Duplex({
+    read: () => undefined,
+    write: (chunk, encoding, callback) => {
+      if (child.stdin.destroyed) {
+        callback(new Error("SSH stdin is closed."));
+        return;
+      }
+      const accepted = child.stdin.write(chunk, encoding);
+      if (accepted) callback();
+      else child.stdin.once("drain", callback);
+    },
+    final: (callback) => {
+      child.stdin.end();
+      callback();
+    },
+    destroy: (error, callback) => {
+      if (child.exitCode === null && child.signalCode === null) child.kill();
+      callback(error);
+    },
+  });
+  child.stdout.on("data", (chunk: Buffer) => stream.push(chunk));
+  child.stdout.once("end", () => stream.push(null));
+  child.once("close", (code) => {
+    if (stream.destroyed) return;
+    if (code !== 0 && spawned) {
+      const failure = new RemoteDaemonTransportError(
+        "ssh_connection_failed",
+        withStderr(`SSH exited with code ${code}.`, stderr()),
+      );
+      // Let the stream consumer install its error/close listeners first.
+      setImmediate(() => {
+        if (!stream.destroyed) stream.destroy(failure);
+      });
+      return;
+    }
+    stream.push(null);
+    stream.destroy();
+  });
+  try {
+    await waitForSpawn(child);
+  } catch (error) {
+    stream.destroy();
+    throw classifySpawnError(error);
+  }
+  // `streamDaemonFacetAt` installs its listeners after this promise resolves.
+  // A microtask here would run first and lose the synthetic connect event; a
+  // macrotask gives the consumer a chance to attach its handshake listener.
+  setImmediate(() => {
+    if (!stream.destroyed && child.exitCode === null && child.signalCode === null) stream.emit("connect");
+  });
+  return stream;
+}
+
+export class RemoteDaemonTransportError extends Error {
+  readonly code: RemoteDaemonTransportErrorCode;
+
+  constructor(code: RemoteDaemonTransportErrorCode, message: string) {
+    super(message);
+    this.name = "RemoteDaemonTransportError";
+    this.code = code;
+  }
+}
+
+export async function openRemoteDaemonConnection(options: RemoteDaemonSshOptions): Promise<RemoteDaemonConnection> {
+  const child = spawn(options.sshCommand ?? "ssh", buildSshArgs(options), {
+    stdio: ["pipe", "pipe", "pipe"],
+    windowsHide: true,
+  });
+  const readStderr = captureStderr(child.stderr);
+  try {
+    await waitForSpawn(child);
+  } catch (error) {
+    await terminate(child);
+    throw classifySpawnError(error);
+  }
+
+  const rpc = new JsonRpcLineClient(child.stdout, child.stdin);
+  try {
+    const hello = await requestWithTimeout(
+      rpc,
+      "protocol.hello",
+      { protocolVersion: currentDaemonProtocolVersion },
+      options.connectTimeoutMs ?? 10_000,
+    );
+    if (hello.ok !== true || !isContractVersionCompatible(hello.protocolVersion, currentDaemonProtocolVersion)) {
+      const code =
+        hello.code === "incompatible_protocol_version" || hello.ok === true
+          ? "remote_daemon_protocol_mismatch"
+          : "remote_daemon_unavailable";
+      throw new RemoteDaemonTransportError(
+        code,
+        String(
+          hello.hint ??
+            hello.nextAction ??
+            (hello.ok === true
+              ? "Remote daemon reported an incompatible protocol version."
+              : "Remote daemon rejected protocol.hello."),
+        ),
+      );
+    }
+    return {
+      child,
+      request: (method, params, timeoutMs) =>
+        timeoutMs === undefined ? rpc.request(method, params) : requestWithTimeout(rpc, method, params, timeoutMs),
+      close: async () => {
+        rpc.close();
+        await terminate(child);
+      },
+    };
+  } catch (error) {
+    rpc.close();
+    await terminate(child);
+    if (error instanceof RemoteDaemonTransportError) throw error;
+    throw classifyRemoteError(error, readStderr());
+  }
+}
+
+function captureStderr(stderr: Readable): () => string {
+  let value = "";
+  stderr.setEncoding("utf8");
+  stderr.on("data", (chunk: string) => {
+    value = `${value}${chunk}`.slice(-4_096);
+  });
+  return () => value;
+}
+
+function requestWithTimeout(
+  rpc: JsonRpcLineClient,
+  method: string,
+  params: JsonObject,
+  timeoutMs: number,
+): Promise<JsonObject> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const deadline = new Promise<never>((_resolve, reject) => {
+    timer = setTimeout(
+      () =>
+        reject(
+          Object.assign(new Error(`the remote daemon did not answer ${method} within ${timeoutMs}ms`), {
+            code: "daemon_response_timeout",
+          }),
+        ),
+      timeoutMs,
+    );
+  });
+  return Promise.race([rpc.request(method, params), deadline]).finally(() => {
+    if (timer !== undefined) clearTimeout(timer);
+  });
+}
+
+export function buildSshArgs(options: RemoteDaemonSshOptions): string[] {
+  const args = [
+    "-T",
+    "-o",
+    "BatchMode=yes",
+    "-o",
+    "StrictHostKeyChecking=yes",
+    "-o",
+    `ConnectTimeout=${Math.max(1, Math.ceil((options.connectTimeoutMs ?? 10_000) / 1_000))}`,
+    "-o",
+    `ServerAliveInterval=${Math.max(1, options.serverAliveIntervalSeconds ?? 30)}`,
+    "-o",
+    `ServerAliveCountMax=${Math.max(1, options.serverAliveCountMax ?? 3)}`,
+  ];
+  if (options.hostKeyAlias) args.push("-o", `HostKeyAlias=${options.hostKeyAlias}`);
+  if (options.identityFile) args.push("-o", "IdentitiesOnly=yes", "-i", options.identityFile);
+  if ((options.port ?? 0) > 0) args.push("-p", String(options.port));
+  const target = options.sshConfigHost ?? `${options.user ? `${options.user}@` : ""}${options.host ?? ""}`;
+  if (!target) throw new Error("SSH transport requires a config alias or host.");
+  args.push(target);
+  args.push(...(options.remoteCommand ?? ["ha", "daemon", "connect", "--stdio"]));
+  return args;
+}
+
+function waitForSpawn(child: ChildProcessWithoutNullStreams): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const onSpawn = () => {
+      child.off("error", onError);
+      resolve();
+    };
+    const onError = (error: Error) => {
+      child.off("spawn", onSpawn);
+      reject(error);
+    };
+    child.once("spawn", onSpawn);
+    child.once("error", onError);
+  });
+}
+
+async function terminate(child: ChildProcessWithoutNullStreams): Promise<void> {
+  if (child.exitCode !== null || child.signalCode !== null) return;
+  child.kill();
+  await new Promise<void>((resolve) => {
+    const timer = setTimeout(resolve, 1_000);
+    timer.unref?.();
+    child.once("close", () => {
+      clearTimeout(timer);
+      resolve();
+    });
+  });
+}
+
+function classifySpawnError(error: unknown): RemoteDaemonTransportError {
+  if (isCode(error, "ENOENT")) return new RemoteDaemonTransportError("ssh_not_found", "OpenSSH client was not found.");
+  return new RemoteDaemonTransportError("ssh_spawn_failed", errorMessage(error));
+}
+
+export function classifyRemoteError(error: unknown, stderr: string): RemoteDaemonTransportError {
+  if (isCode(error, "daemon_response_timeout"))
+    return new RemoteDaemonTransportError("remote_daemon_timeout", errorMessage(error));
+
+  // SSH commonly reports transport failures by closing stdout before the JSON-RPC
+  // handshake completes. Inspect stderr before treating that EOF as a clean daemon
+  // close, otherwise host-key, auth, and network failures all collapse to one code.
+  const message = withStderr(errorMessage(error), stderr);
+  if (/host key|known_hosts|authenticity/iu.test(message))
+    return new RemoteDaemonTransportError("ssh_host_key_failed", message);
+  if (/permission denied|authentication failed|no such identity file|identity file .* type -1/iu.test(message))
+    return new RemoteDaemonTransportError("ssh_auth_failed", message);
+  if (/connection timed out|connection refused|could not resolve|no route|banner exchange/iu.test(message))
+    return new RemoteDaemonTransportError("ssh_connection_failed", message);
+  if (/daemon stdio bridge could not connect|command not found|no such file or directory/iu.test(message))
+    return new RemoteDaemonTransportError("remote_daemon_unavailable", message);
+  if (isCode(error, "daemon_closed")) return new RemoteDaemonTransportError("remote_daemon_closed", message);
+  return new RemoteDaemonTransportError("remote_daemon_unavailable", message);
+}
+
+function withStderr(message: string, stderr: string): string {
+  const detail = stderr.trim();
+  return detail.length > 0 ? `${message} ${detail}` : message;
+}
+
+function isCode(error: unknown, code: string): boolean {
+  return typeof error === "object" && error !== null && "code" in error && error.code === code;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/packages/daemon/src/client/remote-json-rpc-client.ts
+++ b/packages/daemon/src/client/remote-json-rpc-client.ts
@@ -269,18 +269,19 @@ async function terminate(child: ChildProcessWithoutNullStreams): Promise<void> {
 }
 
 function classifySpawnError(error: unknown): RemoteDaemonTransportError {
-  if (isCode(error, "ENOENT")) return new RemoteDaemonTransportError("ssh_not_found", "OpenSSH client was not found.");
-  return new RemoteDaemonTransportError("ssh_spawn_failed", errorMessage(error));
+  if (remoteTransportHasCode(error, "ENOENT"))
+    return new RemoteDaemonTransportError("ssh_not_found", "OpenSSH client was not found.");
+  return new RemoteDaemonTransportError("ssh_spawn_failed", remoteErrorMessage(error));
 }
 
 export function classifyRemoteError(error: unknown, stderr: string): RemoteDaemonTransportError {
-  if (isCode(error, "daemon_response_timeout"))
-    return new RemoteDaemonTransportError("remote_daemon_timeout", errorMessage(error));
+  if (remoteTransportHasCode(error, "daemon_response_timeout"))
+    return new RemoteDaemonTransportError("remote_daemon_timeout", remoteErrorMessage(error));
 
   // SSH commonly reports transport failures by closing stdout before the JSON-RPC
   // handshake completes. Inspect stderr before treating that EOF as a clean daemon
   // close, otherwise host-key, auth, and network failures all collapse to one code.
-  const message = withStderr(errorMessage(error), stderr);
+  const message = withStderr(remoteErrorMessage(error), stderr);
   if (/host key|known_hosts|authenticity/iu.test(message))
     return new RemoteDaemonTransportError("ssh_host_key_failed", message);
   if (/permission denied|authentication failed|no such identity file|identity file .* type -1/iu.test(message))
@@ -289,7 +290,8 @@ export function classifyRemoteError(error: unknown, stderr: string): RemoteDaemo
     return new RemoteDaemonTransportError("ssh_connection_failed", message);
   if (/daemon stdio bridge could not connect|command not found|no such file or directory/iu.test(message))
     return new RemoteDaemonTransportError("remote_daemon_unavailable", message);
-  if (isCode(error, "daemon_closed")) return new RemoteDaemonTransportError("remote_daemon_closed", message);
+  if (remoteTransportHasCode(error, "daemon_closed"))
+    return new RemoteDaemonTransportError("remote_daemon_closed", message);
   return new RemoteDaemonTransportError("remote_daemon_unavailable", message);
 }
 
@@ -298,10 +300,10 @@ function withStderr(message: string, stderr: string): string {
   return detail.length > 0 ? `${message} ${detail}` : message;
 }
 
-function isCode(error: unknown, code: string): boolean {
+function remoteTransportHasCode(error: unknown, code: string): boolean {
   return typeof error === "object" && error !== null && "code" in error && error.code === code;
 }
 
-function errorMessage(error: unknown): string {
+function remoteErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -10,6 +10,15 @@ export {
   type LocalDaemonJsonRpcOptions,
   type LocalDaemonTarget,
 } from "./client/local-json-rpc-client.ts";
+export {
+  buildSshArgs,
+  openRemoteDaemonConnection,
+  openRemoteDaemonStream,
+  requestRemoteDaemonJsonRpc,
+  RemoteDaemonTransportError,
+  type RemoteDaemonConnection,
+  type RemoteDaemonSshOptions,
+} from "./client/remote-json-rpc-client.ts";
 export { openDaemonHost, type DaemonHost } from "./daemon-host.ts";
 export {
   listenFleetTls,

--- a/packages/daemon/test/remote-json-rpc-client.test.ts
+++ b/packages/daemon/test/remote-json-rpc-client.test.ts
@@ -1,0 +1,37 @@
+// harness-test-tier: fast
+import assert from "node:assert/strict";
+import test from "node:test";
+import { classifyRemoteError } from "../src/client/remote-json-rpc-client.ts";
+
+test("remote SSH transport preserves explicit failure classes when stdout closes during handshake", () => {
+  const cases = [
+    [
+      "host key",
+      "daemon_closed",
+      "No ED25519 host key is known for example and you have requested strict checking.\nHost key verification failed.",
+      "ssh_host_key_failed",
+    ],
+    ["authentication", "daemon_closed", "Permission denied (publickey).", "ssh_auth_failed"],
+    [
+      "connection",
+      "daemon_closed",
+      "banner exchange: Connection to UNKNOWN port -1: Connection refused",
+      "ssh_connection_failed",
+    ],
+    ["remote command", "daemon_closed", "bash: line 1: ha: command not found", "remote_daemon_unavailable"],
+    ["clean EOF", "daemon_closed", "", "remote_daemon_closed"],
+  ] as const;
+
+  for (const [name, errorCode, stderr, expectedCode] of cases) {
+    const error = Object.assign(new Error("daemon closed before JSON-RPC response 1"), { code: errorCode });
+    const classified = classifyRemoteError(error, stderr);
+    assert.equal(classified.code, expectedCode, name);
+  }
+});
+
+test("remote JSON-RPC timeout remains distinct from SSH transport failure", () => {
+  const error = Object.assign(new Error("the daemon did not answer protocol.hello within 250ms"), {
+    code: "daemon_response_timeout",
+  });
+  assert.equal(classifyRemoteError(error, "Connection refused").code, "remote_daemon_timeout");
+});

--- a/packages/daemon/test/stream-reconnect-bound.integration.test.ts
+++ b/packages/daemon/test/stream-reconnect-bound.integration.test.ts
@@ -1,9 +1,6 @@
 // harness-test-tier: integration
 import assert from "node:assert/strict";
 import net from "node:net";
-import { mkdtempSync, rmSync } from "node:fs";
-import { tmpdir } from "node:os";
-import path from "node:path";
 import test from "node:test";
 import { streamAgentRuntimeAt, type DaemonStreamLost } from "../src/client/local-json-rpc-stream.ts";
 
@@ -13,38 +10,70 @@ import { streamAgentRuntimeAt, type DaemonStreamLost } from "../src/client/local
 // further connection instantly. The stream must back off, spend a bounded attempt budget, and
 // finish with an observable failure instead of spinning.
 test("an attached stream exhausts a bounded reconnect budget and reports the loss", async () => {
-  const parent = mkdtempSync(path.join(tmpdir(), "ha-stream-bound-")), socketPath = path.join(parent, "bound.sock");
+  const accepted: number[] = [];
+  // Connection 1 serves a valid attach and dies; connection 2 serves attach again (a recovered
+  // daemon must refresh the budget); every later connection is destroyed on arrival.
+  const server = net.createServer((socket) => {
+    accepted.push(1);
+    if (accepted.length <= 2) {
+      socket.on("data", () =>
+        socket.write(
+          JSON.stringify({
+            jsonrpc: "2.0",
+            id: 2,
+            result: { ok: true, status: "attached", runtimeSessionId: "session-bound", cursor: "stream:0", events: [] },
+          }) + "\n",
+        ),
+      );
+      setTimeout(() => socket.destroy(), 50);
+    } else socket.destroy();
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  assert.ok(address && typeof address === "object", "the test server must expose a TCP port");
+  const socketPath = `${address.address}:${address.port}`;
   try {
-    const accepted: number[] = [];
-    // Connection 1 serves a valid attach and dies; connection 2 serves attach again (a recovered
-    // daemon must refresh the budget); every later connection is destroyed on arrival.
-    const server = net.createServer((socket) => {
-      accepted.push(1);
-      if (accepted.length <= 2) {
-        socket.on("data", () => socket.write(JSON.stringify({ jsonrpc: "2.0", id: 2, result: { ok: true, status: "attached", runtimeSessionId: "session-bound", cursor: "stream:0", events: [] } }) + "\n"));
-        setTimeout(() => socket.destroy(), 50);
-      } else socket.destroy();
-    });
-    await new Promise<void>((resolve) => server.listen(socketPath, resolve));
     const values: unknown[] = [];
     let lost: DaemonStreamLost | undefined;
-    const detach = await streamAgentRuntimeAt({ socketPath, repoId: "stream-bound", payload: { runtimeSessionId: "session-bound", afterCursor: "stream:0" }, onValue: (value) => values.push(value), onClosed: (failure) => { lost = failure; } });
+    let closeNotifications = 0;
+    const detach = await streamAgentRuntimeAt({
+      socketPath,
+      openSocket: () => Promise.resolve(net.createConnection({ host: address.address, port: address.port })),
+      repoId: "stream-bound",
+      payload: { runtimeSessionId: "session-bound", afterCursor: "stream:0" },
+      onValue: (value) => values.push(value),
+      onClosed: (failure) => {
+        closeNotifications += 1;
+        lost = failure;
+      },
+    });
     try {
       const started = Date.now();
       assert.equal((values[0] as { readonly ok: boolean }).ok, true, "the initial attach must succeed");
-      for (const deadline = Date.now() + 30_000; lost === undefined && Date.now() < deadline;) await delay(50);
+      for (const deadline = Date.now() + 30_000; lost === undefined && Date.now() < deadline; ) await delay(50);
       assert.ok(lost, "the stream must report its loss");
       assert.equal(lost.code, "daemon_stream_lost");
+      assert.equal(closeNotifications, 1, "stream loss must be reported exactly once");
       // One successful reconnect refreshed the budget, so the fatal episode gets its full five
       // attempts: 250 + 500 + 1000 + 2000 + 4000 ms of backoff precede the give-up.
       assert.equal(lost.attempts, 5, `attempts=${lost.attempts}`);
       assert.ok(Date.now() - started >= 7_500, "the retries must actually back off");
-      assert.equal(accepted.length, 7, `exactly one attach, one recovery, and five failed attempts; got ${accepted.length}`);
+      assert.equal(
+        accepted.length,
+        7,
+        `exactly one attach, one recovery, and five failed attempts; got ${accepted.length}`,
+      );
       const settled = accepted.length;
       await delay(2_000);
       assert.equal(accepted.length, settled, "a stream that gave up must stop connecting");
-    } finally { detach(); server.close(); }
-  } finally { rmSync(parent, { recursive: true, force: true }); }
+    } finally {
+      detach();
+    }
+  } finally {
+    server.close();
+  }
 });
 
-function delay(ms: number): Promise<void> { return new Promise((resolve) => setTimeout(resolve, ms)); }
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}


### PR DESCRIPTION
# English

## Summary

Adds the daemon/CLI stdio transport needed to expose an already-running resident daemon through a user-managed SSH connection. The relay carries JSON-RPC bytes over stdin/stdout; the remote client preserves existing route semantics and classifies handshake, authentication, connection, timeout, and close failures without local fallback.

## Architectural Justification

- The daemon API already has a local JSON-RPC stream contract; remote access needs a transport adapter, not a second daemon protocol. The adapter keeps endpoint and SSH process concerns outside the daemon's local socket implementation.
- The stdio relay is intentionally attach-only and does not start, stop, or discover a remote daemon. This makes SSH, UU, FRP, VPN, and port forwarding interchangeable infrastructure while keeping Harness responsible only for the reachable stream.

## What Changed

- Added `ha daemon connect --stdio` and a bounded stdin/stdout relay to the resident local daemon.
- Added a remote JSON-RPC client with SSH argument construction, handshake/request deadlines, explicit transport error codes, and stream reconnect support.
- Generalized daemon stream opening so the same GUI stream contract can use a supplied remote socket opener.
- Fixed duplicate reconnect scheduling when a failed socket emits both `error` and `close`, and made the bounded reconnect integration harness cross-platform.
- Added focused relay, remote client, and reconnect-bound tests.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: use the single CI-backed `Production-Delta` declaration below; do not enter a second metric.

## Machine-Readable Declarations

Production-Delta: +497/-87

### Optional Evidence Claims

None.

## Task And Scope

- Harness task: not applicable (no public task supplied for this transport increment)
- Branch: `codex/daemon-remote-stdio`
- Public scope: daemon stdio relay and remote JSON-RPC transport substrate.
- Private planning/evidence updated: not applicable
- Out of scope: Electron/React GUI, SSH server provisioning, UU/FRP/VPN implementation, remote daemon bootstrap, fleet discovery, and credentials.

## Version Impact

- Version: no version change because this is an experimental transport substrate.
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: no CI, branch-rule, or protected gate implementation was changed.
- Authority: not applicable
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `dbf7182ac68f0555169c80df8cabb84b70e786b4`
- Branch merge-base with `origin/main`: `dbf7182ac68f0555169c80df8cabb84b70e786b4`
- Last `git fetch origin` time: 2026-09-02 (local execution)
- Sync method: branch created from latest `origin/main`
- Public diff command: `git diff origin/main...HEAD`
- Private evidence commit/path: none
- Reviewer evidence path: none
- GitHub Actions `rewrite-ci` run URL: https://github.com/FairladyZ625/harness-anything/actions/runs/33587216158
- [ ] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [x] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Not run: full repository gates and GitHub Actions; focused relay/remote client tests plus reconnect-bound integration passed 7/7.

## Review Evidence

- Self-review: verified the diff contains only daemon/CLI transport files, checked failure classifications and single-notification reconnect behavior, and ran the focused suite on Windows.
- Reviewer subagent: not used
- Human review: not performed
- Blocking findings: none known.

## Residual Risk

- SSH client configuration, host-key policy, credentials, and the local endpoint remain operator-managed. The relay cannot prove that the endpoint represents the intended remote host.
- Remote daemon lifecycle and bootstrap are deliberately outside this PR and must be managed on the target host.

## References

- Task: not applicable
- Evidence: focused relay and remote client tests
- Review: none

---

# 中文

## 概要

增加 daemon/CLI stdio transport，使已经运行的 resident daemon 可以通过用户管理的 SSH 连接访问。relay 通过 stdin/stdout 转发 JSON-RPC 字节；remote client 保持现有 route 语义，并对握手、认证、连接、超时和关闭失败进行分类，不回退到本地 daemon。

## 架构辩护

- daemon 已有本地 JSON-RPC stream contract；远程访问需要 transport adapter，而不是第二套 daemon 协议。adapter 将 endpoint 与 SSH 进程细节留在本地 socket 实现之外。
- stdio relay 明确是 attach-only，不启动、停止或发现远端 daemon。这样 SSH、UU、FRP、VPN 和端口映射都只是可替换的基础设施，Harness 只负责可达的 stream。

## 改动内容

- 增加 `ha daemon connect --stdio`，把 stdin/stdout relay 到 resident local daemon。
- 增加 remote JSON-RPC client，包含 SSH 参数构造、握手/请求 deadline、明确 transport 错误码和 stream 重连。
- 泛化 daemon stream opening，使同一 GUI stream contract 可以使用远端 socket opener。
- 修复 socket 同时触发 `error` 和 `close` 时重复调度重连的问题，并将 bounded reconnect 集成 harness 改为跨平台 TCP 注入。
- 增加 relay、remote client 和 reconnect-bound 定向测试。

## 门收割 / Gate Harvest

- 删除的生产路径：`none`
- 同 commit 删除的门 / fixture：`none`
- 生产净行数：引用英文块中的 `Production-Delta`；该值由 production-delta job 计算，不要手填第二份数字。

## 机读声明说明

- 这些声明由 `.github/workflows/rebuild-gates.yml` 中的 job 校验；未注释机读声明只能在英文块出现一次。
- 本 PR 没有 `package.json` 或 `package-lock.json` 改动，因此英文块不包含 `Dependency-Change:` 行。

## 任务与范围

- Harness 任务：不适用（本次 transport 增量没有提供公开 task）
- 分支：`codex/daemon-remote-stdio`
- 公开范围：daemon stdio relay 和 remote JSON-RPC transport substrate。
- 私有计划 / 证据是否已更新：不适用
- 范围外：Electron/React GUI、SSH server 配置、UU/FRP/VPN 实现、远端 daemon bootstrap、fleet discovery 和凭证。

## 版本影响

- 版本：不改版本，原因是本次是 experimental transport substrate。
- 发布影响：不发布

## 治理声明

- 是否触碰 protected surface：no
- protected surface 范围：未修改 CI、分支规则或受保护 gate 实现。
- 依据：不适用
- 机器检查边界：本 PR 只声明该段存在；声明是否真实、充分，由 reviewer 判断。
- Break-glass：no
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- `origin/main` 基准 SHA：`dbf7182ac68f0555169c80df8cabb84b70e786b4`
- 当前分支与 `origin/main` 的 merge-base：`dbf7182ac68f0555169c80df8cabb84b70e786b4`
- 最近一次 `git fetch origin` 时间：2026-09-02（本地执行）
- 同步方式：从最新 `origin/main` 创建分支
- 公开 diff 命令：`git diff origin/main...HEAD`
- 私有证据 commit/path：无
- Reviewer 证据路径：无
- GitHub Actions `rewrite-ci` run URL：https://github.com/FairladyZ625/harness-anything/actions/runs/33587216158
- [ ] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [x] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- 未运行：完整仓库 gate 和 GitHub Actions；relay、remote client 和 reconnect-bound 定向测试 7/7 通过。

## 审查证据

- 自查：确认 diff 仅包含 daemon/CLI transport 文件，检查错误分类和重连单次通知行为，并在 Windows 上运行定向 suite。
- Reviewer subagent：未使用
- 人工审查：未进行
- 阻塞发现：暂无已知阻塞。

## 残余风险

- SSH client 配置、host-key 策略、凭证和本地 endpoint 仍由操作者管理；relay 无法证明 endpoint 对应预期远端主机。
- 远端 daemon 生命周期和 bootstrap 明确不在本 PR 范围内，必须在目标主机管理。

## 关联材料

- 任务：不适用
- 证据：relay 和 remote client 定向测试
- 审查：无

---

## PR Gate Checklist / PR 门禁清单

- [x] Branch is based on latest `origin/main`. / 分支基于最新 `origin/main`。
- [x] PR body uses this full template structure. / PR 描述使用本模板完整结构。
- [x] PR body uses two complete language blocks: `# English` first, then `# 中文`. / PR 正文使用两块完整正文：`# English` 在上，`# 中文` 在下。
- [ ] PR body passes `tools/check-pr-body-bilingual.mjs`. / PR 正文通过 `tools/check-pr-body-bilingual.mjs`。
- [ ] If the PR touches a manifest-derived protected surface, Governance Declaration is filled with ADR/decision/task evidence or break-glass fields. / 若 PR 触碰 manifest 派生的 protected surface，Governance Declaration 已填写 ADR/decision/task 依据或 break-glass 字段。
- [x] No private harness files are included. / 不包含私有 harness 文件。
- [x] No ignored local agent entry files are included. / 不包含被忽略的本地 agent 入口文件。
- [x] No absolute local filesystem paths are included in this public PR body. / 本公开 PR 描述不包含本机绝对路径。
- [x] Public diff is limited to the stated task scope. / 公开 diff 限于声明的任务范围。
- [x] Private planning/evidence updates are recorded when applicable. / 适用时已记录私有计划 / 证据更新。
- [x] Version and publish impact are stated. / 已说明版本和发布影响。
- [x] Local verification commands are recorded honestly. / 已如实记录本地验证命令。
- [x] CI results are linked or explained. / CI 结果已链接或说明。
- [x] Review evidence is recorded. / 已记录审查证据。
- [x] Open P0/P1/P2 findings are closed, deferred with owner, or explicitly blocked. / open P0/P1/P2 findings 已关闭、带 owner 延后，或明确阻塞。
- [x] Merge method and post-merge branch cleanup plan are clear. / 合并方式和合并后分支清理计划清楚。
- [x] No admin bypass is planned unless explicitly approved and recorded. / 除非明确批准并记录，否则不计划 admin bypass。

