### PR TITLE
fix(tools): resolve the worker git guard's repository from -C, not the shell cwd

### DIFF
--- a/tools/git-hooks/git
+++ b/tools/git-hooks/git
@@ -12,7 +12,26 @@ for entry in ${PATH:-}; do
 done
 IFS=$old_ifs
 
-repo_root=$(PATH=$filtered_path command git rev-parse --show-toplevel 2>/dev/null || true)
+# Resolve the repository git itself would operate on: honour leading -C <dir>
+# globals instead of the shell cwd, so a worker touching another repo via -C is
+# not misattributed to the canonical root.
+resolve_repo_root() {
+  value_of=
+  for argument in "$@"; do
+    if [ -n "$value_of" ]; then
+      if [ "$value_of" = "-C" ] && [ -n "$argument" ]; then cd -- "$argument" 2>/dev/null || return 0; fi
+      value_of=
+      continue
+    fi
+    case "$argument" in
+      (-C|-c|--git-dir|--work-tree|--namespace|--exec-path|--config-env) value_of=$argument ;;
+      (-*) ;;
+      (*) break ;;
+    esac
+  done
+  PATH=$filtered_path command git rev-parse --show-toplevel 2>/dev/null || true
+}
+repo_root=$(resolve_repo_root "$@")
 canonical_root=${HARNESS_CANONICAL_ROOT:-}
 if [ -n "$repo_root" ] && [ -n "$canonical_root" ] && [ -d "$canonical_root" ]; then
   canonical_root=$(cd "$canonical_root" && pwd -P)

--- a/tools/worker-discipline-hooks.test.mjs
+++ b/tools/worker-discipline-hooks.test.mjs
@@ -55,6 +55,15 @@ test("canonical hooks reject worker commit and checkout", (context) => {
   });
   assert.equal(commit.status, 1, commit.stderr);
   assert.match(commit.stderr, /Refusing a worker git commit in the canonical repository root/u);
+  const other = makeRepo(context, "hook-other-repo-");
+  writeFileSync(path.join(other, "source.txt"), "other change\n");
+  git(other, "add", "source.txt");
+  const commitElsewhere = spawnSync(
+    "git",
+    ["-C", other, "-c", "core.hooksPath=/dev/null", "commit", "--quiet", "-m", "elsewhere"],
+    { cwd: root, encoding: "utf8", env },
+  );
+  assert.equal(commitElsewhere.status, 0, commitElsewhere.stderr);
   const checkoutViaGit = spawnSync("git", ["-C", root, "checkout", "-b", "worker-branch"], {
     cwd: root,
     encoding: "utf8",


### PR DESCRIPTION
# English

## Summary

The worker git shim (`tools/git-hooks/git`) decided whether a command targets the canonical root by running `rev-parse` from the process cwd, ignoring leading `-C <dir>` globals. A worker whose cwd is the canonical checkout therefore could not commit into any other repository via `-C`. The isolated GUI e2e lane hit this: its fixture daemon bootstraps a temporary harness ledger with `git -C <tmp>/harness commit` and was refused as a canonical commit, so the scheduled `gui-e2e-runner` probe failed before executing a single scenario.

## Architectural Justification

- Not required (churn well under 200 lines).

## What Changed

- `tools/git-hooks/git`: walk the leading git globals and `cd` through each `-C` before resolving the toplevel, so the guard judges the repository git itself will operate on.
- `tools/worker-discipline-hooks.test.mjs`: regression case — with cwd in the canonical root and `HARNESS_ACTOR=agent:*`, `git -C <other-repo> commit` succeeds while the direct canonical commit is still refused.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: use the single CI-backed `Production-Delta` declaration below; do not enter a second metric.

## Machine-Readable Declarations

Production-Delta: +0/-0

## Task And Scope

- Harness task: task_98d2a4bbfcab04f0739df47a79
- Branch: codex/git-shim-dash-c
- Public scope: tools/git-hooks/git, tools/worker-discipline-hooks.test.mjs
- Private planning/evidence updated: yes
- Out of scope: the e2e runner and schedule themselves (already merged in #2138)

## Version Impact

- Version: no version change because this is a tooling fix
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none
- Authority: not applicable
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: 585627fbb02803128e1fce9d9fc9b28344930f4c
- Branch merge-base with `origin/main`: 585627fbb02803128e1fce9d9fc9b28344930f4c
- Last `git fetch origin` time: 2026-09-02 (before branching)
- Sync method: none needed
- Public diff command: `git diff 585627fbb02803128e1fce9d9fc9b28344930f4c..HEAD`
- Private evidence commit/path: harness task_98d2a4bbfcab04f0739df47a79 dispatch reports
- Reviewer evidence path: this PR
- GitHub Actions `rewrite-ci` run URL: pending
- [ ] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [x] `npm test` (targeted: `node --test tools/worker-discipline-hooks.test.mjs`, 6/6 pass)
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Not run: full local suite; CI is the authority for the complete matrix.

## Review Evidence

- Self-review: shim traced with `sh -x` against a temp repo; targeted test file green.
- Reviewer subagent: none
- Human review: pending
- Blocking findings: none

## Residual Risk

- `--git-dir`/`--work-tree` globals are still resolved from cwd; only `-C` changes the resolution directory, matching the failing usage.

## References

- Task: task_98d2a4bbfcab04f0739df47a79
- Evidence: gui-e2e-runner dispatch report (bootstrap_failed: "Refusing a worker git commit in the canonical repository root")
- Review: this PR

---

# 中文

## 概要

worker git shim（`tools/git-hooks/git`）判断命令是否落在 canonical 根时，直接在进程 cwd 上跑 `rev-parse`，忽略了前置的 `-C <dir>` 全局参数。cwd 在 canonical checkout 里的 worker 因此无法用 `-C` 向任何其他仓库提交。隔离 lane 的 GUI e2e 正好踩中：fixture daemon 用 `git -C <tmp>/harness commit` 引导临时台账，被当成 canonical 提交拒掉，定时 `gui-e2e-runner` 探针一个场景都没跑就失败。

## 架构辩护

- 不需要（改动远小于 200 行）。

## 改动内容

- `tools/git-hooks/git`：先遍历前置全局参数，逐个 `cd` 进 `-C` 目录再解析 toplevel，让守卫判断的是 git 真正要操作的仓库。
- `tools/worker-discipline-hooks.test.mjs`：回归用例——cwd 在 canonical 根、`HARNESS_ACTOR=agent:*` 时，`git -C <其他仓库> commit` 成功，而直接对 canonical 提交仍被拒绝。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 同 commit 删除的门 / fixture：none
- 生产净行数：引用英文块中的 `Production-Delta`。

## 机读声明说明

- 机读声明只在英文块出现。

## 任务与范围

- Harness 任务：task_98d2a4bbfcab04f0739df47a79
- 分支：codex/git-shim-dash-c
- 公开范围：tools/git-hooks/git、tools/worker-discipline-hooks.test.mjs
- 私有计划 / 证据是否已更新：yes
- 范围外：e2e 运行器与 schedule 本身（已在 #2138 合入）

## 版本影响

- 版本：不改版本，原因是纯工具修复
- 发布影响：不发布

## 治理声明

- 是否触碰 protected surface：no
- protected surface 范围：无
- 依据：不适用
- 机器检查边界：本 PR 只声明该段存在；是否真实充分由 reviewer 判断。
- Break-glass：no
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- `origin/main` 基准 SHA：585627fbb02803128e1fce9d9fc9b28344930f4c
- 当前分支与 `origin/main` 的 merge-base：585627fbb02803128e1fce9d9fc9b28344930f4c
- 最近一次 `git fetch origin` 时间：2026-09-02（建分支前）
- 同步方式：不需要
- 公开 diff 命令：`git diff 585627fbb02803128e1fce9d9fc9b28344930f4c..HEAD`
- 私有证据 commit/path：harness task_98d2a4bbfcab04f0739df47a79 派工报告
- Reviewer 证据路径：本 PR
- GitHub Actions `rewrite-ci` run URL：待定
- [ ] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [x] `npm test`（定向：`node --test tools/worker-discipline-hooks.test.mjs`，6/6 通过）
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- 未运行：完整本地套件；完整矩阵以 CI 为权威。

## 审查证据

- 自查：用 `sh -x` 对临时仓库追踪 shim；定向测试文件全绿。
- Reviewer subagent：无
- 人工审查：待定
- 阻塞发现：无

## 残余风险

- `--git-dir`/`--work-tree` 仍按 cwd 解析，只有 `-C` 改变解析目录，与本次失败用法一致。

## 关联材料

- 任务：task_98d2a4bbfcab04f0739df47a79
- 证据：gui-e2e-runner 派工报告（bootstrap_failed："Refusing a worker git commit in the canonical repository root"）
- 审查：本 PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
