### PR TITLE
feat(kernel): generic artifact entity import aggregate (GovernedEntity W1-B)

### DIFF
--- a/packages/application/src/artifact-entity-service.ts
+++ b/packages/application/src/artifact-entity-service.ts
@@ -143,7 +143,8 @@ export function makeArtifactEntityService(options: {
     if (!replay && request.expectedVersion !== (current?.revision ?? 0))
       throw new ArtifactEntityServiceError(
         "revision_conflict",
-        `Entity ${entityId} expected revision ${request.expectedVersion}, current revision is ${current?.revision ?? 0}.`,
+        `Entity ${entityId} expected revision ${request.expectedVersion}, ` +
+          `current revision is ${current?.revision ?? 0}.`,
       );
     if (current?.descriptor && current.descriptor.source !== sourceIdentity)
       throw new ArtifactEntityServiceError(

--- a/packages/application/src/artifact-entity-service.ts
+++ b/packages/application/src/artifact-entity-service.ts
@@ -1,0 +1,271 @@
+import {
+  artifactEntityContractSnapshot,
+  artifactImportOperationId,
+  artifactObservationId,
+  canonicalArtifactLocator,
+  canonicalSourceIdentity,
+  compileEntityContentObserved,
+  compileEntityTargetMissing,
+  decodeArtifactDescriptor,
+  deriveArtifactContentVersion,
+  deriveArtifactEntityId,
+  type ActorIdentity,
+  type ArtifactContentWitness,
+  type ArtifactDescriptor,
+  type ArtifactLocator,
+  type ArtifactSourceIdentityInput,
+  type CompiledArtifactKindContract,
+  type EntityContentObservedBundle,
+  type EntityEventV1,
+  type EntityTargetMissingBundle,
+  type WriteSource,
+} from "../../kernel/src/index.ts";
+
+export interface ArtifactSourceObserved {
+  readonly status: "observed";
+  readonly source: ArtifactSourceIdentityInput;
+  readonly witness: ArtifactContentWitness;
+  readonly title: string;
+  readonly resolver: string;
+}
+
+export interface ArtifactSourceMissing {
+  readonly status: "missing";
+  readonly source: ArtifactSourceIdentityInput;
+  readonly reason: string;
+  readonly resolver: string;
+}
+
+export type ArtifactSourceResolution = ArtifactSourceObserved | ArtifactSourceMissing;
+
+export interface ArtifactEntityImportRequest {
+  readonly kind: string;
+  readonly locator: string;
+  readonly expectedVersion: number;
+  readonly title?: string;
+  /** Explicit relink pins the original source identity while changing only the locator. */
+  readonly entityId?: string;
+  readonly sourceIdentity?: string;
+  readonly dryRun?: boolean;
+}
+
+export interface ArtifactEntityCurrent {
+  readonly descriptor: ArtifactDescriptor | null;
+  readonly revision: number;
+}
+
+export interface ArtifactEntityImportPreview {
+  readonly schema: "artifact-entity-import-preview/v1";
+  readonly entityId: string;
+  readonly typeIdentity: string;
+  readonly sourceIdentity: string;
+  readonly locator: ArtifactLocator;
+  readonly currentContentVersion: string | null;
+  readonly candidateContentVersion: string | null;
+  readonly relationChanges: number;
+  readonly expectedVersion: number;
+  readonly currentRevision: number;
+  readonly artifactOwner: string;
+  readonly eventType: EntityEventV1["type"];
+  readonly operationId: string;
+  readonly dryRun: boolean;
+}
+
+export interface PreparedArtifactEntityImport {
+  readonly contract: CompiledArtifactKindContract;
+  readonly bundle: EntityContentObservedBundle | EntityTargetMissingBundle;
+  readonly preview: ArtifactEntityImportPreview;
+  readonly replay: EntityEventV1 | null;
+}
+
+export class ArtifactEntityServiceError extends Error {
+  readonly code: "entity_kind_not_found" | "invalid_command" | "revision_conflict" | "source_resolution_failed";
+
+  constructor(code: ArtifactEntityServiceError["code"], message: string) {
+    super(message);
+    this.name = "ArtifactEntityServiceError";
+    this.code = code;
+  }
+}
+
+export function makeArtifactEntityService(options: {
+  readonly contracts: readonly CompiledArtifactKindContract[];
+  readonly resolveSource: (
+    locator: ArtifactLocator,
+    contract: CompiledArtifactKindContract,
+  ) => Promise<ArtifactSourceResolution>;
+  readonly readCurrent: (kind: string, entityId: string) => ArtifactEntityCurrent | null;
+  readonly readOperation: (opId: string) => EntityEventV1 | null;
+  readonly countRelationChanges: (entityRef: string) => number;
+}) {
+  const prepare = async (
+    request: ArtifactEntityImportRequest,
+    envelope: {
+      readonly actor: ActorIdentity;
+      readonly source: WriteSource;
+      readonly occurredAt: string;
+      readonly workspaceRevision: number;
+    },
+  ): Promise<PreparedArtifactEntityImport> => {
+    const contract = options.contracts.find(({ typeIdentity }) => typeIdentity === request.kind);
+    if (!contract)
+      throw new ArtifactEntityServiceError("entity_kind_not_found", `Artifact kind ${request.kind} is not compiled.`);
+    if (!Number.isSafeInteger(request.expectedVersion) || request.expectedVersion < 0)
+      throw new ArtifactEntityServiceError("invalid_command", "expectedVersion must be a non-negative integer.");
+    const locator = resolveLocator(request.locator, contract),
+      resolution = await resolveAuthoritatively(options.resolveSource, locator, contract),
+      resolvedSourceIdentity = canonicalSourceIdentity(resolution.source),
+      sourceIdentity = request.sourceIdentity ?? resolvedSourceIdentity;
+    if (request.sourceIdentity && !request.entityId)
+      throw new ArtifactEntityServiceError(
+        "invalid_command",
+        "Explicit sourceIdentity is only valid for relink and requires entityId.",
+      );
+    const entityId = deriveArtifactEntityId({
+      idPrefix: contract.declaration.idPrefix,
+      typeIdentity: contract.typeIdentity,
+      sourceIdentity,
+    });
+    if (request.entityId && request.entityId !== entityId)
+      throw new ArtifactEntityServiceError(
+        "invalid_command",
+        `Relink entityId ${request.entityId} does not match frozen source identity ${sourceIdentity}.`,
+      );
+    const current = options.readCurrent(contract.typeIdentity, entityId),
+      candidateContentVersion =
+        resolution.status === "observed" ? deriveArtifactContentVersion(resolution.witness) : null,
+      resolutionWitness = resolution.status === "observed" ? candidateContentVersion! : `missing:${resolution.reason}`,
+      observationId = artifactObservationId({ entityId, locator, resolution: resolutionWitness }),
+      opId = artifactImportOperationId({ entityId, locator, resolution: resolutionWitness }),
+      replay = options.readOperation(opId);
+    if (replay && !isMatchingReplay(replay, contract.typeIdentity, entityId, observationId))
+      throw new ArtifactEntityServiceError("invalid_command", `Operation ${opId} is not the requested observation.`);
+    if (!replay && request.expectedVersion !== (current?.revision ?? 0))
+      throw new ArtifactEntityServiceError(
+        "revision_conflict",
+        `Entity ${entityId} expected revision ${request.expectedVersion}, current revision is ${current?.revision ?? 0}.`,
+      );
+    if (current?.descriptor && current.descriptor.source !== sourceIdentity)
+      throw new ArtifactEntityServiceError(
+        "invalid_command",
+        `Entity ${entityId} is pinned to source identity ${current.descriptor.source}.`,
+      );
+    const contractSnapshot = artifactEntityContractSnapshot(contract),
+      eventInput = {
+        eventId: `event-${observationId}`,
+        opId,
+        workspaceRevision: envelope.workspaceRevision,
+        actor: envelope.actor,
+        source: envelope.source,
+        occurredAt: envelope.occurredAt,
+      },
+      bundle =
+        resolution.status === "observed"
+          ? compileEntityContentObserved({
+              ...eventInput,
+              contract: contract.entityKindContract as Parameters<typeof compileEntityContentObserved>[0]["contract"],
+              contractSnapshot,
+              descriptor: {
+                schema: descriptorSchemaRef(contract),
+                typeIdentity: contract.typeIdentity,
+                entityId,
+                title: request.title?.trim() || resolution.title.trim(),
+                locator,
+                contentVersion: candidateContentVersion!,
+                source: sourceIdentity,
+              },
+              resolver: resolution.resolver,
+              observationId,
+            })
+          : compileEntityTargetMissing({
+              ...eventInput,
+              contractSnapshot,
+              entityId,
+              locator,
+              sourceIdentity,
+              resolver: resolution.resolver,
+              observationId,
+              reason: resolution.reason,
+            });
+    const entityRef = `${contract.typeIdentity}/${entityId}`,
+      preview: ArtifactEntityImportPreview = Object.freeze({
+        schema: "artifact-entity-import-preview/v1",
+        entityId,
+        typeIdentity: contract.typeIdentity,
+        sourceIdentity,
+        locator,
+        currentContentVersion: current?.descriptor?.contentVersion ?? null,
+        candidateContentVersion,
+        relationChanges: options.countRelationChanges(entityRef),
+        expectedVersion: request.expectedVersion,
+        currentRevision: current?.revision ?? 0,
+        artifactOwner: `entity/${entityId}/revision/${String(envelope.workspaceRevision)}`,
+        eventType: bundle.event.type,
+        operationId: opId,
+        dryRun: request.dryRun === true,
+      });
+    return Object.freeze({ contract, bundle, preview, replay });
+  };
+  return Object.freeze({ prepare });
+}
+
+function resolveLocator(value: string, contract: CompiledArtifactKindContract): ArtifactLocator {
+  const allowed = contract.declaration.locatorKinds,
+    inferred = /^https?:\/\//iu.test(value)
+      ? "url"
+      : allowed.includes("repository-path")
+        ? "repository-path"
+        : allowed.length === 1
+          ? allowed[0]!
+          : null;
+  if (!inferred || !allowed.includes(inferred))
+    throw new ArtifactEntityServiceError(
+      "invalid_command",
+      `Locator ${value} is ambiguous or is not allowed for ${contract.typeIdentity}.`,
+    );
+  try {
+    return canonicalArtifactLocator({ kind: inferred, value });
+  } catch (error) {
+    throw new ArtifactEntityServiceError("invalid_command", error instanceof Error ? error.message : String(error));
+  }
+}
+
+async function resolveAuthoritatively(
+  resolver: (locator: ArtifactLocator, contract: CompiledArtifactKindContract) => Promise<ArtifactSourceResolution>,
+  locator: ArtifactLocator,
+  contract: CompiledArtifactKindContract,
+): Promise<ArtifactSourceResolution> {
+  try {
+    const resolution = await resolver(locator, contract);
+    if (!resolution.resolver.trim()) throw new Error("resolver identity is empty");
+    if (resolution.status === "observed" && !resolution.title.trim()) throw new Error("resolved title is empty");
+    if (resolution.status === "missing" && !resolution.reason.trim()) throw new Error("missing reason is empty");
+    return resolution;
+  } catch (error) {
+    if (error instanceof ArtifactEntityServiceError) throw error;
+    throw new ArtifactEntityServiceError(
+      "source_resolution_failed",
+      error instanceof Error ? error.message : String(error),
+    );
+  }
+}
+
+function descriptorSchemaRef(contract: CompiledArtifactKindContract): string {
+  const value = contract.entityKindContract.schema.properties.schema;
+  if (value.type !== "string" || typeof value.const !== "string")
+    throw new ArtifactEntityServiceError("invalid_command", `${contract.typeIdentity} has no descriptor schema ref.`);
+  return value.const;
+}
+
+function isMatchingReplay(event: EntityEventV1, kind: string, entityId: string, observationId: string): boolean {
+  return (
+    event.payload.entityKind === kind &&
+    event.payload.entityId === entityId &&
+    "observationId" in event.payload &&
+    event.payload.observationId === observationId
+  );
+}
+
+export function readArtifactDescriptor(contract: CompiledArtifactKindContract, value: unknown): ArtifactDescriptor {
+  return decodeArtifactDescriptor(contract.entityKindContract, value);
+}

--- a/packages/application/src/index.ts
+++ b/packages/application/src/index.ts
@@ -14,6 +14,18 @@ export type {
 export { makeDecisionService } from "./decision-service.ts";
 export { FactServiceError, makeFactService } from "./fact-service.ts";
 export type { FactRecordResult, FactWriteBundle } from "./fact-service.ts";
+export {
+  ArtifactEntityServiceError,
+  makeArtifactEntityService,
+  readArtifactDescriptor,
+} from "./artifact-entity-service.ts";
+export type {
+  ArtifactEntityCurrent,
+  ArtifactEntityImportPreview,
+  ArtifactEntityImportRequest,
+  ArtifactSourceResolution,
+  PreparedArtifactEntityImport,
+} from "./artifact-entity-service.ts";
 export { makeTaskActionExplanationService } from "./task-action-explanation-service.ts";
 export { makePersonActionExplanationService } from "./person-action-explanation-service.ts";
 export { makeSquadActionExplanationService } from "./squad-action-explanation-service.ts";

--- a/packages/application/test/artifact-entity-service.test.ts
+++ b/packages/application/test/artifact-entity-service.test.ts
@@ -1,0 +1,102 @@
+// harness-test-tier: fast
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import { compileVerticalContract, type ArtifactDescriptor, type EntityEventV1 } from "../../kernel/src/index.ts";
+import { makeArtifactEntityService } from "../src/artifact-entity-service.ts";
+
+const sourceVertical = JSON.parse(
+  readFileSync(new URL("../../kernel/fixtures/schemas/vertical-definition/valid.json", import.meta.url), "utf8"),
+) as Record<string, unknown> & { entityKinds: unknown[]; projectionSchemas: unknown[] };
+const contract = compileVerticalContract({
+  ...sourceVertical,
+  id: "custom/engineering",
+  entityKinds: [
+    ...sourceVertical.entityKinds,
+    {
+      id: "architecture-decision-record",
+      entityType: "artifact",
+      version: 1,
+      idPrefix: "ADR",
+      display: { singular: "ADR", plural: "ADRs" },
+      descriptorSchemaRef: "schema://artifact-descriptor",
+      store: { pathTemplate: "entities/adrs/{id}.json" },
+      locatorKinds: ["repository-path"],
+      relations: [],
+    },
+  ],
+  projectionSchemas: [
+    ...sourceVertical.projectionSchemas,
+    { id: "artifact-descriptor", schemaRef: "schema://artifact-descriptor" },
+  ],
+}).artifactKinds[0]!;
+const actor = { principal: { personId: "person-edge" }, executor: null } as const,
+  envelope = { actor, source: "local" as const, occurredAt: "2026-09-02T00:00:00.000Z", workspaceRevision: 1 };
+
+test("two edges derive one identity and operation; replay precedes the Entity revision fence", async () => {
+  let content = "# ADR\nfirst\n",
+    current: { descriptor: ArtifactDescriptor; revision: number } | null = null;
+  const operations = new Map<string, EntityEventV1>(),
+    service = makeArtifactEntityService({
+      contracts: [contract],
+      resolveSource: async (locator) => ({
+        status: "observed",
+        source: { kind: "repository-path", repositoryId: "canonical", path: locator.value },
+        witness: { kind: "content", content },
+        title: "ADR",
+        resolver: "repository:canonical",
+      }),
+      readCurrent: () => current,
+      readOperation: (opId) => operations.get(opId) ?? null,
+      countRelationChanges: () => 3,
+    }),
+    request = { kind: contract.typeIdentity, locator: "docs/adr.md", expectedVersion: 0 },
+    edgeOne = await service.prepare(request, envelope);
+  operations.set(edgeOne.bundle.event.opId, edgeOne.bundle.event);
+  current = { descriptor: JSON.parse(edgeOne.bundle.blobs[0]!.body) as ArtifactDescriptor, revision: 1 };
+
+  const edgeTwo = await service.prepare(request, { ...envelope, workspaceRevision: 2 });
+  assert.equal(edgeOne.preview.entityId, edgeTwo.preview.entityId);
+  assert.equal(edgeOne.bundle.event.opId, edgeTwo.bundle.event.opId);
+  assert.equal(edgeTwo.replay?.opId, edgeOne.bundle.event.opId);
+  assert.equal(edgeTwo.preview.relationChanges, 3);
+  assert.equal(edgeOne.preview.artifactOwner, `entity/${edgeOne.preview.entityId}/revision/1`);
+
+  content = "# ADR\nsecond\n";
+  await assert.rejects(
+    service.prepare(request, { ...envelope, workspaceRevision: 2 }),
+    (error: unknown) => (error as { code?: string }).code === "revision_conflict",
+  );
+  const updated = await service.prepare({ ...request, expectedVersion: 1 }, { ...envelope, workspaceRevision: 2 });
+  assert.equal(updated.preview.entityId, edgeOne.preview.entityId);
+  assert.notEqual(updated.preview.candidateContentVersion, edgeOne.preview.candidateContentVersion);
+  assert.notEqual(updated.bundle.event.opId, edgeOne.bundle.event.opId);
+});
+
+test("dry-run and missing resolution compile plans without mutating any dependency", async () => {
+  let reads = 0;
+  const service = makeArtifactEntityService({
+      contracts: [contract],
+      resolveSource: async (locator) => ({
+        status: "missing",
+        source: { kind: "repository-path", repositoryId: "canonical", path: locator.value },
+        reason: "ENOENT",
+        resolver: "repository:canonical",
+      }),
+      readCurrent: () => {
+        reads += 1;
+        return null;
+      },
+      readOperation: () => null,
+      countRelationChanges: () => 0,
+    }),
+    prepared = await service.prepare(
+      { kind: contract.typeIdentity, locator: "docs/missing.md", expectedVersion: 0, dryRun: true },
+      envelope,
+    );
+  assert.equal(prepared.bundle.event.type, "entity_target_missing");
+  assert.equal(prepared.bundle.blobs.length, 0);
+  assert.equal(prepared.preview.candidateContentVersion, null);
+  assert.equal(prepared.preview.dryRun, true);
+  assert.equal(reads, 1);
+});

--- a/packages/cli/src/cli/thin-command-explain.ts
+++ b/packages/cli/src/cli/thin-command-explain.ts
@@ -3,7 +3,7 @@ import { accepted, globalOption, nonEmpty, rejected, stripGlobals } from "./thin
 import type { ThinHelpOverlayRoute, ThinParseResult } from "./thin-command-types.ts";
 
 const explainUsage =
-  "Use ha explain task|person|squad for a catalog, or ha explain <entity-ref> [<entity-ref>...] for 1..500 objects.";
+  "Use ha explain task|person|squad|<artifact-type@version> for a catalog, or ha explain <entity-ref>... for objects.";
 
 export function taskExplainHelpOverlay(argv: readonly string[]): ThinHelpOverlayRoute | undefined {
   const args = stripGlobals(argv);
@@ -43,7 +43,13 @@ export function parseExplain(
   method: string,
 ): ThinParseResult {
   const targets = args.slice(1);
-  if (targets.length === 1 && (targets[0] === "task" || targets[0] === "person" || targets[0] === "squad"))
+  if (
+    targets.length === 1 &&
+    (targets[0] === "task" ||
+      targets[0] === "person" ||
+      targets[0] === "squad" ||
+      /^[a-z0-9][a-z0-9/-]*\/[a-z0-9][a-z0-9-]*@[1-9][0-9]*$/u.test(targets[0] ?? ""))
+  )
     return accepted(
       rootDir,
       repoId,

--- a/packages/cli/src/cli/thin-command-router.ts
+++ b/packages/cli/src/cli/thin-command-router.ts
@@ -94,6 +94,20 @@ export function parseRouted(
     );
   if (rootCommand === "relation") return parseRelationRouted(route, args, rootDir, repoId, json, inputs);
   if (rootCommand === "entity") {
+    if (route.id === "entity-import") {
+      const projected = parseProjected(route.id, args.slice(2), rootDir, repoId, json, inputs, {}, {}, route.method);
+      if (!projected.ok) return projected;
+      const action = projected.command.action,
+        hasEntityId = typeof action.entityId === "string",
+        hasSourceIdentity = typeof action.sourceIdentity === "string";
+      return hasEntityId === hasSourceIdentity
+        ? projected
+        : rejected(
+            "invalid_field",
+            "Use --entity-id and --source-identity together for an explicit relink, or omit both.",
+            json,
+          );
+    }
     const entityKind = args[2],
       f = readFlags(route.id, args.slice(3), inputs);
     if (!nonEmpty(entityKind))

--- a/packages/cli/src/cli/thin-command-router.ts
+++ b/packages/cli/src/cli/thin-command-router.ts
@@ -94,20 +94,7 @@ export function parseRouted(
     );
   if (rootCommand === "relation") return parseRelationRouted(route, args, rootDir, repoId, json, inputs);
   if (rootCommand === "entity") {
-    if (route.id === "entity-import") {
-      const projected = parseProjected(route.id, args.slice(2), rootDir, repoId, json, inputs, {}, {}, route.method);
-      if (!projected.ok) return projected;
-      const action = projected.command.action,
-        hasEntityId = typeof action.entityId === "string",
-        hasSourceIdentity = typeof action.sourceIdentity === "string";
-      return hasEntityId === hasSourceIdentity
-        ? projected
-        : rejected(
-            "invalid_field",
-            "Use --entity-id and --source-identity together for an explicit relink, or omit both.",
-            json,
-          );
-    }
+    if (route.id === "entity-import") return parseEntityImportRouted(route, args, rootDir, repoId, json, inputs);
     const entityKind = args[2],
       f = readFlags(route.id, args.slice(3), inputs);
     if (!nonEmpty(entityKind))
@@ -132,6 +119,28 @@ const peopleRequiredInputs: Readonly<Record<string, readonly string[]>> = Object
   "people-revoke-delegation": ["--token-id"],
   "people-remove": ["--person-id"],
 });
+
+function parseEntityImportRouted(
+  route: ProtocolCommand,
+  args: readonly string[],
+  rootDir: SafePath,
+  repoId: string | undefined,
+  json: boolean,
+  inputs: ThinCliInputDirectory,
+): ThinParseResult {
+  const projected = parseProjected(route.id, args.slice(2), rootDir, repoId, json, inputs, {}, {}, route.method);
+  if (!projected.ok) return projected;
+  const action = projected.command.action,
+    hasEntityId = typeof action.entityId === "string",
+    hasSourceIdentity = typeof action.sourceIdentity === "string";
+  return hasEntityId === hasSourceIdentity
+    ? projected
+    : rejected(
+        "invalid_field",
+        "Use --entity-id and --source-identity together for an explicit relink, or omit both.",
+        json,
+      );
+}
 
 function parsePeople(
   route: ProtocolCommand,

--- a/packages/cli/test/explain-command.test.ts
+++ b/packages/cli/test/explain-command.test.ts
@@ -8,6 +8,7 @@ import { parseThinCommand } from "../src/cli/thin-command.ts";
 test("explain parser selects catalog/object mode without duplicating EntityRef validation", () => {
   const catalog = parseThinCommand(["explain", "task", "--json"]),
     squadCatalog = parseThinCommand(["explain", "squad", "--json"]),
+    artifactCatalog = parseThinCommand(["explain", "software/coding/architecture-decision-record@1", "--json"]),
     objects = parseThinCommand(["explain", "task/task-one", "fact/F-ABCDEFGH", "not-a-ref"]),
     fiveHundredRefs = Array.from({ length: 500 }, (_, index) => `task/task-${index}`),
     maximum = parseThinCommand(["explain", ...fiveHundredRefs]),
@@ -18,6 +19,7 @@ test("explain parser selects catalog/object mode without duplicating EntityRef v
 
   assert.equal(catalog.ok, true);
   assert.equal(squadCatalog.ok, true);
+  assert.equal(artifactCatalog.ok, true);
   assert.equal(objects.ok, true);
   assert.equal(maximum.ok, true);
   assert.equal(empty.ok, false);
@@ -40,6 +42,14 @@ test("explain parser selects catalog/object mode without duplicating EntityRef v
     schema: "entity-action-explain-request/v1",
     mode: "catalog",
     entityKind: "squad",
+    refs: [],
+  });
+  if (!artifactCatalog.ok) return;
+  assert.deepEqual(artifactCatalog.command.action, {
+    kind: "entity-action-explain",
+    schema: "entity-action-explain-request/v1",
+    mode: "catalog",
+    entityKind: "software/coding/architecture-decision-record@1",
     refs: [],
   });
   const personCatalog = parseThinCommand(["explain", "person"]);

--- a/packages/cli/test/thin-command.test.ts
+++ b/packages/cli/test/thin-command.test.ts
@@ -69,6 +69,45 @@ test("an unknown command domain reports unknown with the available set instead o
   assert.match(logs[0] ?? "", /ha migrate rekey-facts(?: --dry-run)?/u);
 });
 
+test("entity import projects its concurrency and dry-run flags into one daemon Action", () => {
+  const parsed = parseThinCommand([
+    "entity",
+    "import",
+    "--kind",
+    "software/coding/architecture-decision-record@1",
+    "--locator",
+    "harness/adr/0001.md",
+    "--expected-version",
+    "0",
+    "--dry-run",
+  ]);
+  assert.equal(parsed.ok, true);
+  if (!parsed.ok) return;
+  assert.equal(parsed.command.method, "repo.task.run");
+  assert.deepEqual(parsed.command.action, {
+    kind: "entity-import",
+    entityKind: "software/coding/architecture-decision-record@1",
+    locator: "harness/adr/0001.md",
+    expectedVersion: 0,
+    dryRun: true,
+  });
+  assert.equal(
+    parseThinCommand([
+      "entity",
+      "import",
+      "--kind",
+      "software/coding/architecture-decision-record@1",
+      "--locator",
+      "moved.md",
+      "--expected-version",
+      "1",
+      "--source-identity",
+      "repo:canonical:old.md",
+    ]).ok,
+    false,
+  );
+});
+
 test("capabilities is an exact-set projection of the command contract", () => {
   assert.deepEqual(deriveCliCapabilities(), {
     agenda: ["agenda"],
@@ -114,7 +153,7 @@ test("capabilities is an exact-set projection of the command contract", () => {
       "doc-sync-dry-run",
       "doc-sync-submit",
     ],
-    entity: ["entity-get", "entity-list"],
+    entity: ["entity-get", "entity-import", "entity-list"],
     explain: ["explain"],
     fact: ["fact-reclassify", "fact-record", "fact-search", "fact-show", "fact-type-list", "fact-type-register"],
     gui: ["gui"],

--- a/packages/daemon/src/artifact-entity-action.ts
+++ b/packages/daemon/src/artifact-entity-action.ts
@@ -1,0 +1,299 @@
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import {
+  ArtifactEntityServiceError,
+  makeArtifactEntityService,
+  readArtifactDescriptor,
+  type ArtifactEntityCurrent,
+  type ArtifactSourceResolution,
+} from "../../application/src/index.ts";
+import {
+  compileVerticalContract,
+  isEntityDeclarationEvent,
+  isEntityEvent,
+  normalizeRelativeDocumentPath,
+  type AuthorizationDecision,
+  type CanonicalEventStore,
+  type CompiledArtifactKindContract,
+  type EntityActionContract,
+  type EntityEventV1,
+  type TaskProjection,
+  type WriteReceiptDraft as WriteReceipt,
+} from "../../kernel/src/index.ts";
+import { defaultAssets } from "../../preset/src/preset-resolver-common.ts";
+import { loadCanonicalAssets } from "../../preset/src/preset-assets.ts";
+import type { RepoCellBinding, RepoTaskAction } from "./repo-cell-types.ts";
+
+let cachedArtifactKinds: readonly CompiledArtifactKindContract[] | null = null;
+type ArtifactImportReceipt = WriteReceipt & { readonly entityId: string };
+
+export function compiledArtifactKinds(): readonly CompiledArtifactKindContract[] {
+  if (cachedArtifactKinds === null)
+    cachedArtifactKinds = loadCanonicalAssets(defaultAssets).compiledVertical.artifactKinds;
+  return cachedArtifactKinds;
+}
+
+/** Test seam for custom verticals: callers compile the same source value and pass its artifactKinds. */
+export function artifactKindsFromVertical(source: unknown): readonly CompiledArtifactKindContract[] {
+  return compileVerticalContract(source).artifactKinds;
+}
+
+export function resolveArtifactImportAction(
+  kind: unknown,
+  contracts: readonly CompiledArtifactKindContract[],
+): EntityActionContract | null {
+  if (typeof kind !== "string") return null;
+  const contract = contracts.find(({ typeIdentity }) => typeIdentity === kind);
+  return contract?.entityKindContract.actionCatalog?.actions.find(({ id }) => id === "import") ?? null;
+}
+
+export async function executeArtifactEntityImport(input: {
+  readonly rootDir: string;
+  readonly repositoryId: string;
+  readonly action: RepoTaskAction;
+  readonly binding: RepoCellBinding;
+  readonly store: CanonicalEventStore;
+  readonly projection: TaskProjection;
+  readonly now: () => string;
+  readonly authorizationDecision: AuthorizationDecision;
+}): Promise<{
+  readonly action: RepoTaskAction;
+  readonly contract: EntityActionContract;
+  readonly receipt: ArtifactImportReceipt;
+}> {
+  const contracts = compiledArtifactKinds(),
+    contract = resolveArtifactImportAction(input.action.entityKind, contracts);
+  if (!contract?.execution)
+    throw Object.assign(
+      new Error(`Artifact kind ${String(input.action.entityKind)} has no executable import action.`),
+      { code: "unsupported_command" },
+    );
+  const receipt = await runArtifactEntityImport({ ...input, contracts });
+  return { action: { ...input.action, entityId: receipt.entityId }, contract, receipt };
+}
+
+export async function runArtifactEntityImport(input: {
+  readonly rootDir: string;
+  readonly repositoryId: string;
+  readonly contracts: readonly CompiledArtifactKindContract[];
+  readonly action: RepoTaskAction;
+  readonly binding: RepoCellBinding;
+  readonly store: CanonicalEventStore;
+  readonly projection: TaskProjection;
+  readonly now: () => string;
+  readonly authorizationDecision: AuthorizationDecision;
+}): Promise<ArtifactImportReceipt> {
+  const service = makeArtifactEntityService({
+      contracts: input.contracts,
+      resolveSource: (locator, contract) =>
+        resolveArtifactSource({
+          rootDir: input.rootDir,
+          repositoryId: input.repositoryId,
+          locator,
+          contract,
+        }),
+      readCurrent: (kind, entityId) => readCurrentArtifact(input.store, input.contracts, kind, entityId),
+      readOperation: (opId) => readEntityOperation(input.store, opId),
+      countRelationChanges: (entityRef) =>
+        input.projection
+          .readRelationTruth()
+          .edges.filter(
+            ({ sourceRef, targetRef, state }) =>
+              state === "active" && (sourceRef === entityRef || targetRef === entityRef),
+          ).length,
+    }),
+    prepared = await service.prepare(
+      {
+        kind: requiredText(input.action.entityKind, "entityKind"),
+        locator: requiredText(input.action.locator, "locator"),
+        expectedVersion: Number(input.action.expectedVersion),
+        ...(typeof input.action.title === "string" ? { title: input.action.title } : {}),
+        ...(typeof input.action.entityId === "string" ? { entityId: input.action.entityId } : {}),
+        ...(typeof input.action.sourceIdentity === "string" ? { sourceIdentity: input.action.sourceIdentity } : {}),
+        ...(input.action.dryRun === true ? { dryRun: true } : {}),
+      },
+      {
+        actor: input.binding.actor,
+        source: input.binding.source,
+        occurredAt: input.now(),
+        workspaceRevision: (input.store.readHead()?.revision ?? 0) + 1,
+      },
+    );
+  if (input.action.dryRun === true) return previewReceipt(prepared.preview, input, prepared.contract);
+  if (prepared.replay) return replayReceipt(prepared.replay, prepared.preview, input.authorizationDecision);
+  const appended = input.store.append(prepared.bundle);
+  input.projection.apply(prepared.bundle.event, prepared.bundle.plan);
+  const applied = input.projection.readOperation(prepared.bundle.event.opId),
+    visible = !!applied && applied.watermark >= prepared.bundle.event.workspaceRevision,
+    base = {
+      opId: prepared.bundle.event.opId,
+      revision: appended.revision,
+      entityId: prepared.preview.entityId,
+      evidence: JSON.stringify({
+        schema: "artifact-entity-import-result/v1",
+        preview: prepared.preview,
+        dryRun: false,
+        commitSha: appended.commitSha?.sha ?? null,
+      }),
+      visibility: "center" as const,
+      proof: {
+        committedRevision: appended.revision,
+        appliedCut: applied?.watermark ?? 0,
+        durable: true,
+        canonicalVisible: visible,
+        worktreeVisible: prepared.bundle.event.type === "entity_content_observed",
+      },
+      authorizationDecision: input.authorizationDecision,
+      commitSha: appended.commitSha?.sha ?? null,
+      cut: appended.cut,
+    };
+  return visible
+    ? { outcome: "applied", ...base }
+    : {
+        outcome: "pending",
+        ...base,
+        nextAction: `Query receipt ${prepared.bundle.event.opId} after the Entity projection catches up.`,
+      };
+}
+
+async function resolveArtifactSource(input: {
+  readonly rootDir: string;
+  readonly repositoryId: string;
+  readonly locator: Parameters<Parameters<typeof makeArtifactEntityService>[0]["resolveSource"]>[0];
+  readonly contract: CompiledArtifactKindContract;
+}): Promise<ArtifactSourceResolution> {
+  const locator = input.locator;
+  if (locator.kind === "repository-path") {
+    const relative = normalizeRelativeDocumentPath(locator.value),
+      target = path.resolve(input.rootDir, relative),
+      rootPrefix = `${path.resolve(input.rootDir)}${path.sep}`,
+      source = { kind: "repository-path" as const, repositoryId: input.repositoryId, path: relative };
+    if (!target.startsWith(rootPrefix)) throw new Error(`Repository locator ${relative} escapes the repository root.`);
+    if (!existsSync(target))
+      return {
+        status: "missing",
+        source,
+        reason: "ENOENT",
+        resolver: `repository:${input.repositoryId}`,
+      };
+    const content = readFileSync(target);
+    return {
+      status: "observed",
+      source,
+      witness: { kind: "content", content },
+      title: titleFromContent(content, relative),
+      resolver: `repository:${input.repositoryId}`,
+    };
+  }
+  if (locator.kind === "url") {
+    const response = await fetch(locator.value, { redirect: "follow" }),
+      source = { kind: "url" as const, url: locator.value };
+    if (response.status === 404 || response.status === 410)
+      return { status: "missing", source, reason: `HTTP ${response.status}`, resolver: "http" };
+    if (!response.ok) throw new Error(`URL resolver returned HTTP ${response.status}.`);
+    const content = new Uint8Array(await response.arrayBuffer());
+    return {
+      status: "observed",
+      source,
+      witness: { kind: "content", content },
+      title: path.basename(new URL(locator.value).pathname) || new URL(locator.value).hostname,
+      resolver: "http",
+    };
+  }
+  throw new ArtifactEntityServiceError(
+    "source_resolution_failed",
+    `No external-key resolver is installed for ${input.contract.typeIdentity}.`,
+  );
+}
+
+function readCurrentArtifact(
+  store: CanonicalEventStore,
+  contracts: readonly CompiledArtifactKindContract[],
+  kind: string,
+  entityId: string,
+): ArtifactEntityCurrent | null {
+  const contract = contracts.find(({ typeIdentity }) => typeIdentity === kind);
+  if (!contract) return null;
+  let revision = 0,
+    descriptor: ReturnType<typeof readArtifactDescriptor> | null = null;
+  for (const event of store.read().events) {
+    if (!isEntityEvent(event) || event.payload.entityKind !== kind || event.payload.entityId !== entityId) continue;
+    revision = Math.max(revision, event.workspaceRevision);
+    if (!isEntityDeclarationEvent(event) || event.type !== "entity_content_observed") continue;
+    const claim = event.payload.declarationDocumentClaim,
+      bytes = store.readContentBlob(claim.sha256);
+    if (!bytes) throw new Error(`Artifact descriptor blob ${claim.sha256} is unavailable.`);
+    descriptor = readArtifactDescriptor(contract, JSON.parse(new TextDecoder("utf-8", { fatal: true }).decode(bytes)));
+  }
+  return revision === 0 ? null : { descriptor, revision };
+}
+
+function readEntityOperation(store: CanonicalEventStore, opId: string): EntityEventV1 | null {
+  const event = store.readEvent(opId);
+  if (event === null) return null;
+  if (!isEntityEvent(event) || event.schema !== "entity-event/v1")
+    throw new ArtifactEntityServiceError("invalid_command", `Operation id ${opId} belongs to another event.`);
+  return event;
+}
+
+function previewReceipt(
+  preview: Awaited<ReturnType<ReturnType<typeof makeArtifactEntityService>["prepare"]>>["preview"],
+  input: Pick<Parameters<typeof runArtifactEntityImport>[0], "store" | "authorizationDecision">,
+  contract: CompiledArtifactKindContract,
+): ArtifactImportReceipt {
+  const revision = input.store.readHead()?.revision ?? 0;
+  return {
+    outcome: "pending",
+    opId: `preview:${preview.operationId}`,
+    revision,
+    entityId: preview.entityId,
+    evidence: JSON.stringify(preview),
+    visibility: "center",
+    proof: {
+      committedRevision: revision,
+      appliedCut: revision,
+      durable: false,
+      canonicalVisible: false,
+      worktreeVisible: false,
+    },
+    authorizationDecision: input.authorizationDecision,
+    effects: [],
+    updatedProjection: null,
+    nextAction: `Remove --dry-run to run ${contract.typeIdentity}.import.`,
+  };
+}
+
+function replayReceipt(
+  event: EntityEventV1,
+  preview: Awaited<ReturnType<ReturnType<typeof makeArtifactEntityService>["prepare"]>>["preview"],
+  authorizationDecision: AuthorizationDecision,
+): ArtifactImportReceipt {
+  return {
+    outcome: "no_changes",
+    opId: event.opId,
+    revision: event.workspaceRevision,
+    entityId: preview.entityId,
+    evidence: JSON.stringify({ ...preview, idempotent: true, sameResult: true }),
+    visibility: "center",
+    proof: {
+      committedRevision: event.workspaceRevision,
+      appliedCut: event.workspaceRevision,
+      durable: true,
+      canonicalVisible: true,
+      worktreeVisible: event.type === "entity_content_observed",
+    },
+    authorizationDecision,
+  };
+}
+
+function titleFromContent(content: Uint8Array, relative: string): string {
+  const decoded = new TextDecoder("utf-8").decode(content),
+    heading = /^#\s+(.+)$/mu.exec(decoded)?.[1]?.trim();
+  return heading || path.basename(relative, path.extname(relative));
+}
+
+function requiredText(value: unknown, field: string): string {
+  if (typeof value !== "string" || !value.trim())
+    throw new ArtifactEntityServiceError("invalid_command", `${field} is required.`);
+  return value.trim();
+}

--- a/packages/daemon/src/artifact-entity-action.ts
+++ b/packages/daemon/src/artifact-entity-action.ts
@@ -104,8 +104,8 @@ export async function runArtifactEntityImport(input: {
     }),
     prepared = await service.prepare(
       {
-        kind: requiredText(input.action.entityKind, "entityKind"),
-        locator: requiredText(input.action.locator, "locator"),
+        kind: requiredArtifactText(input.action.entityKind, "entityKind"),
+        locator: requiredArtifactText(input.action.locator, "locator"),
         expectedVersion: Number(input.action.expectedVersion),
         ...(typeof input.action.title === "string" ? { title: input.action.title } : {}),
         ...(typeof input.action.entityId === "string" ? { entityId: input.action.entityId } : {}),
@@ -120,7 +120,7 @@ export async function runArtifactEntityImport(input: {
       },
     );
   if (input.action.dryRun === true) return previewReceipt(prepared.preview, input, prepared.contract);
-  if (prepared.replay) return replayReceipt(prepared.replay, prepared.preview, input.authorizationDecision);
+  if (prepared.replay) return artifactReplayReceipt(prepared.replay, prepared.preview, input.authorizationDecision);
   const appended = input.store.append(prepared.bundle);
   input.projection.apply(prepared.bundle.event, prepared.bundle.plan);
   const applied = input.projection.readOperation(prepared.bundle.event.opId),
@@ -263,7 +263,7 @@ function previewReceipt(
   };
 }
 
-function replayReceipt(
+function artifactReplayReceipt(
   event: EntityEventV1,
   preview: Awaited<ReturnType<ReturnType<typeof makeArtifactEntityService>["prepare"]>>["preview"],
   authorizationDecision: AuthorizationDecision,
@@ -292,7 +292,7 @@ function titleFromContent(content: Uint8Array, relative: string): string {
   return heading || path.basename(relative, path.extname(relative));
 }
 
-function requiredText(value: unknown, field: string): string {
+function requiredArtifactText(value: unknown, field: string): string {
   if (typeof value !== "string" || !value.trim())
     throw new ArtifactEntityServiceError("invalid_command", `${field} is required.`);
   return value.trim();

--- a/packages/daemon/src/artifact-entity-action.ts
+++ b/packages/daemon/src/artifact-entity-action.ts
@@ -188,8 +188,8 @@ async function resolveArtifactSource(input: {
   if (locator.kind === "url") {
     const response = await fetch(locator.value, { redirect: "follow" }),
       source = { kind: "url" as const, url: locator.value };
-    if (response.status === 404 || response.status === 410)
-      return { status: "missing", source, reason: `HTTP ${response.status}`, resolver: "http" };
+    const code = response.status;
+    if (code === 404 || code === 410) return { status: "missing", source, reason: `HTTP ${code}`, resolver: "http" };
     if (!response.ok) throw new Error(`URL resolver returned HTTP ${response.status}.`);
     const content = new Uint8Array(await response.arrayBuffer());
     return {

--- a/packages/daemon/src/entity-action-catalog-executor.ts
+++ b/packages/daemon/src/entity-action-catalog-executor.ts
@@ -8,6 +8,7 @@ import {
   entityUpsertWritePlan,
   factWritePlan,
   getExecutableEntityAction,
+  isEntityDeclarationEvent,
   isRelationEvent,
   isSameExecution,
   relationEventWritePlan,
@@ -22,7 +23,6 @@ import {
   type EntityActionDraft,
   type EntityActionExecutionContract,
   type EntityActionUnmetCriterionV1,
-  type EntityEventV1,
   type EntityUpsertBundle,
   type EventPublicationKillpoint,
   type FactConfidence,
@@ -44,6 +44,7 @@ import {
   matchingRuntimeSessionReplayBundle,
   type RuntimeSessionBundle,
 } from "./entity-action-runtime-session.ts";
+import { executeArtifactEntityImport } from "./artifact-entity-action.ts";
 
 type ExecutableAction = EntityActionContract & { readonly execution: EntityActionExecutionContract };
 type FactBundle = ReturnType<typeof compileFactWrite>;
@@ -68,6 +69,8 @@ export interface EntityActionCatalogRuntimes {
 }
 
 export function makeEntityActionCatalogExecutor(input: {
+  readonly rootDir?: string;
+  readonly repositoryId?: string;
   readonly store: CanonicalEventStore;
   readonly projection: TaskProjection;
   readonly now: () => string;
@@ -111,6 +114,19 @@ export function makeEntityActionCatalogExecutor(input: {
     opId: string,
     runtimes: EntityActionCatalogRuntimes = {},
   ): WriteReceipt | Promise<WriteReceipt> => {
+    if (action.kind === "entity-import") {
+      const authorizationDecision = decisionAuthorization(action, binding, opId, input);
+      return executeArtifactEntityImport({
+        rootDir: input.rootDir ?? process.cwd(),
+        repositoryId: input.repositoryId ?? "repository",
+        action,
+        binding,
+        store: input.store,
+        projection: input.projection,
+        now: input.now,
+        authorizationDecision,
+      }).then((result) => deriveActionResult(result.contract, result.action, result.receipt));
+    }
     const contract = executableAction(action.kind),
       prepare = runtimes.prepare?.[contract.target.kind],
       preparedAction = prepare?.(contract, action, binding, opId) ?? action;
@@ -603,13 +619,18 @@ function matchingReplayBundle(
   const writesFact = contract.target.kind === "fact" || contract.id === "reckon";
   if (contract.target.kind === "runtime-session" && existing !== null)
     return matchingRuntimeSessionReplayBundle(store, contract, action, existing);
-  if (existing?.schema === "entity-event/v1" && existing.payload.entityKind === contract.target.kind) {
+  if (
+    existing?.schema === "entity-event/v1" &&
+    existing.type === "entity_upserted" &&
+    isEntityDeclarationEvent(existing) &&
+    existing.payload.entityKind === contract.target.kind
+  ) {
     const claim = existing.payload.declarationDocumentClaim,
       bytes = store.readContentBlob(claim.sha256);
     if (!bytes) reject("content_not_ready", `Entity content for ${claim.path} is unavailable.`);
     return {
       event: existing,
-      plan: entityUpsertWritePlan(existing as EntityEventV1),
+      plan: entityUpsertWritePlan(existing),
       blobs: [
         {
           sha256: claim.sha256,

--- a/packages/daemon/src/fact-rekey.ts
+++ b/packages/daemon/src/fact-rekey.ts
@@ -14,6 +14,7 @@ import {
   documentPath,
   eventObjectRelativePath,
   isFactEvent,
+  isEntityDeclarationEvent,
   isEntityEvent,
   isMigrationImportEvent,
   localGitObjectRefStore,
@@ -343,7 +344,7 @@ function buildPlan(rootDir: string, store: CanonicalEventStore): FactRekeyPlan {
   }
   const currentSquadClaims = new Map<string, EntityDeclarationClaimSnapshot>();
   for (const event of events)
-    if (event.schema === "entity-event/v1" && event.payload.entityKind === "squad")
+    if (event.schema === "entity-event/v1" && isEntityDeclarationEvent(event) && event.payload.entityKind === "squad")
       currentSquadClaims.set(event.payload.entityId, event.payload.declarationDocumentClaim);
   const eventRewrites: { event: PersistedCanonicalEventV1; body: string }[] = [],
     rewrittenEntityBlobs = new Map<string, RewrittenEntityBlob>(),
@@ -566,7 +567,7 @@ function rewriteRetiredAgentEntity(
   event: PersistedCanonicalEventV1,
   store: CanonicalEventStore,
 ): { readonly event: CanonicalEventV1; readonly path: string; readonly blob: RewrittenEntityBlob } | null {
-  if (!isEntityEvent(event) || event.payload.entityKind !== "agent") return null;
+  if (!isEntityEvent(event) || !isEntityDeclarationEvent(event) || event.payload.entityKind !== "agent") return null;
   const claim = event.payload.declarationDocumentClaim,
     bytes = store.readContentBlob(claim.sha256);
   if (bytes === null || bytes.byteLength !== claim.size)

--- a/packages/daemon/src/protocol/daemon-protocol-commands-agent.ts
+++ b/packages/daemon/src/protocol/daemon-protocol-commands-agent.ts
@@ -1,5 +1,6 @@
 import {
   cliInput,
+  defineCenterForwardWriteCommand,
   defineHostAdminCommand,
   defineLedgerWriteCommand,
   defineRepoReadCommand,
@@ -194,10 +195,62 @@ export const agentProtocolCommands = Object.freeze([
     id: "explain",
     actionKind: "entity-action-explain",
     phase: "Ontology-Explain-A",
-    path: ["explain", "<task|person|squad|entity/ref>..."],
-    summary: "Explain a Task, Person, or Squad Action catalog, or evaluate object refs at the current canonical cut.",
+    path: ["explain", "<kind|entity/ref>..."],
+    summary: "Explain a builtin or compiled Artifact Action catalog, or evaluate object refs at the canonical cut.",
     method: "repo.entity.actions.explain",
     inputs: [],
+  }),
+  defineCenterForwardWriteCommand({
+    id: "entity-import",
+    phase: "Governed-Entity-W1-B",
+    path: ["entity", "import"],
+    summary: "Resolve and import one compiled vertical Artifact Entity through the canonical entity action path.",
+    method: "repo.task.run",
+    inputs: [
+      cliInput(
+        "--kind",
+        "single",
+        true,
+        {
+          code: "missing_field",
+          nextAction: "Add --kind <vertical/artifact@version>.",
+        },
+        { field: "entityKind" },
+      ),
+      cliInput("--locator", "single", true, {
+        code: "missing_field",
+        nextAction: "Add --locator <repository-path|url|external-key>.",
+      }),
+      cliInput(
+        "--expected-version",
+        "single",
+        true,
+        {
+          code: "missing_field",
+          nextAction: "Add --expected-version <non-negative-entity-revision>.",
+        },
+        { regex: "^(?:0|[1-9][0-9]*)$", projection: "number" },
+      ),
+      cliInput("--title", "single", false, {
+        code: "invalid_field",
+        nextAction: "Use one non-empty --title value or omit it to use the resolved title.",
+      }),
+      cliInput("--entity-id", "single", false, {
+        code: "invalid_field",
+        nextAction: "Use --entity-id only for an explicit relink of an existing Artifact Entity.",
+      }),
+      cliInput("--source-identity", "single", false, {
+        code: "invalid_field",
+        nextAction: "Use --source-identity with --entity-id to preserve identity during relink.",
+      }),
+      cliInput(
+        "--dry-run",
+        "boolean",
+        false,
+        { code: "invalid_field", nextAction: "Use --dry-run once." },
+        { field: "dryRun" },
+      ),
+    ],
   }),
   defineRepoReadCommand({
     id: "entity-get",

--- a/packages/daemon/src/protocol/daemon-protocol-validate-task.ts
+++ b/packages/daemon/src/protocol/daemon-protocol-validate-task.ts
@@ -2,6 +2,7 @@ import {
   generatedTaskActionProtocolDeclarations,
   type GeneratedTaskActionProtocolDeclaration,
 } from "./daemon-protocol-commands-task.ts";
+import { artifactEntityImportActionInput } from "../../../kernel/src/index.ts";
 import { DAEMON_TASK_SNAPSHOT_LIST_SCHEMA, DAEMON_WORKSPACE_SUMMARY_SCHEMA } from "./daemon-protocol-schema-ids.ts";
 import {
   codeDocRecord,
@@ -54,12 +55,15 @@ export function validateCatalogActionPayload(value: JsonObject): readonly string
   const action = (value.payload as JsonObject).action;
   if (!isJsonObject(action) || typeof action.kind !== "string") return [];
   const declaration = taskActionProtocolByIngress.get(action.kind);
-  return declaration ? validateProjectedTaskActionInput(action.kind, declaration.input, action) : [];
+  if (declaration) return validateProjectedTaskActionInput(action.kind, declaration.input, action);
+  return action.kind === "entity-import"
+    ? validateProjectedTaskActionInput(action.kind, artifactEntityImportActionInput, action)
+    : [];
 }
 
 function validateProjectedTaskActionInput(
   ingress: string,
-  input: GeneratedTaskActionProtocolDeclaration["input"],
+  input: GeneratedTaskActionProtocolDeclaration["input"] | typeof artifactEntityImportActionInput,
   record: Readonly<Record<string, unknown>>,
 ): readonly string[] {
   const allowed = new Set(["kind", "executor", ...input.fields.map(({ field }) => field)]),

--- a/packages/daemon/src/protocol/daemon-protocol-validate-task.ts
+++ b/packages/daemon/src/protocol/daemon-protocol-validate-task.ts
@@ -2,7 +2,7 @@ import {
   generatedTaskActionProtocolDeclarations,
   type GeneratedTaskActionProtocolDeclaration,
 } from "./daemon-protocol-commands-task.ts";
-import { artifactEntityImportActionInput } from "../../../kernel/src/index.ts";
+import type { artifactEntityImportActionInput } from "../../../kernel/src/index.ts";
 import { DAEMON_TASK_SNAPSHOT_LIST_SCHEMA, DAEMON_WORKSPACE_SUMMARY_SCHEMA } from "./daemon-protocol-schema-ids.ts";
 import {
   codeDocRecord,
@@ -47,6 +47,21 @@ export const availabilityFields = ["consents", "codeDocWitnesses", "gateWitnesse
     "decisionRelations",
   ] as const;
 
+const artifactEntityImportProtocolInput = Object.freeze({
+  schema: "entity-action-input/v1",
+  fields: Object.freeze([
+    { field: "entityKind", type: "string", required: true },
+    { field: "locator", type: "string", required: true },
+    { field: "expectedVersion", type: "number", required: true },
+    { field: "title", type: "string", required: false },
+    { field: "entityId", type: "string", required: false },
+    { field: "sourceIdentity", type: "string", required: false },
+    { field: "idempotencyKey", type: "string", required: false },
+    { field: "dryRun", type: "boolean", required: false },
+  ]),
+  exactlyOneOf: Object.freeze([]),
+} as const satisfies typeof artifactEntityImportActionInput);
+
 const taskActionProtocolByIngress: ReadonlyMap<string, GeneratedTaskActionProtocolDeclaration> = new Map(
   generatedTaskActionProtocolDeclarations.map((action) => [action.execution.ingress, action] as const),
 );
@@ -57,13 +72,13 @@ export function validateCatalogActionPayload(value: JsonObject): readonly string
   const declaration = taskActionProtocolByIngress.get(action.kind);
   if (declaration) return validateProjectedTaskActionInput(action.kind, declaration.input, action);
   return action.kind === "entity-import"
-    ? validateProjectedTaskActionInput(action.kind, artifactEntityImportActionInput, action)
+    ? validateProjectedTaskActionInput(action.kind, artifactEntityImportProtocolInput, action)
     : [];
 }
 
 function validateProjectedTaskActionInput(
   ingress: string,
-  input: GeneratedTaskActionProtocolDeclaration["input"] | typeof artifactEntityImportActionInput,
+  input: GeneratedTaskActionProtocolDeclaration["input"],
   record: Readonly<Record<string, unknown>>,
 ): readonly string[] {
   const allowed = new Set(["kind", "executor", ...input.fields.map(({ field }) => field)]),

--- a/packages/daemon/src/protocol/daemon-protocol.contract.ts
+++ b/packages/daemon/src/protocol/daemon-protocol.contract.ts
@@ -615,6 +615,7 @@ export default Object.freeze({
     "Ontology-Explain-A",
     "Relation-G3c",
     "PLT-Ontology-4.1",
+    "Governed-Entity-W1-B",
   ]),
   commands: daemonOwnedProtocolCommands,
   methods: Object.freeze([

--- a/packages/daemon/src/repo-cell-action-dispatch.ts
+++ b/packages/daemon/src/repo-cell-action-dispatch.ts
@@ -8,6 +8,7 @@ import {
   isLedgerLayoutMigrationEvent,
   lifecycleDocumentPaths,
   type WriteReceiptDraft as WriteReceipt,
+  type EntityStoreKindContract,
 } from "../../kernel/src/index.ts";
 import { runPresetAction } from "../../preset/src/index.ts";
 import { runAgentEntityAction } from "./agent-entities.ts";
@@ -21,6 +22,7 @@ import { readTaskLineageDispatches } from "./dispatch-read.ts";
 import type { RepoCellOperationalContext } from "./repo-cell-action-context.ts";
 import { runFactAction } from "./repo-cell-fact-action.ts";
 import type { TaskCommandWithDocsAction } from "./repo-cell-task-command-docs.ts";
+import { compiledArtifactKinds } from "./artifact-entity-action.ts";
 
 export async function executeAction(
   cell: RepoCellOperationalContext,
@@ -181,6 +183,17 @@ export async function executeAction(
       ),
     );
   }
+  if (action.kind === "entity-import")
+    return cell.entityActionExecutor.run(
+      action,
+      binding,
+      cell.operationId(
+        action,
+        binding,
+        cell.input.repoId,
+        Number(action.expectedVersion ?? cell.store.readHead()?.revision ?? 0),
+      ),
+    );
   const actionContract = getExecutableEntityAction(action.kind);
   if (actionContract?.target.kind === "task" && actionContract.execution) {
     const targetIdField = actionContract.execution.targetIdField ?? "taskId",
@@ -256,7 +269,10 @@ export async function executeAction(
   if (/^entity-(?:get|list)$/u.test(action.kind)) {
     const revision = cell.store.readHead()?.revision ?? 0,
       kind = cell.requiredCellText(action.entityKind, "entityKind"),
-      entities = createEntityStore(cell.store);
+      entities = createEntityStore(
+        cell.store,
+        compiledArtifactKinds().map(({ entityKindContract }) => entityKindContract as EntityStoreKindContract),
+      );
     if (action.kind === "entity-list")
       return cell.readResult(
         cell.operationId(action, binding, cell.input.repoId, revision),

--- a/packages/daemon/src/repo-cell-authorization.ts
+++ b/packages/daemon/src/repo-cell-authorization.ts
@@ -137,6 +137,8 @@ export function authorizeDurableRepoCellAction(
       return authorizeRepoCellAction(input);
     case "doc-submit":
       return authorizeRepoCellAction(input);
+    case "entity-import":
+      return authorizeRepoCellAction(input);
     case "fact-reclassify":
       return authorizeRepoCellAction(input);
     case "fact-record":

--- a/packages/daemon/src/repo-cell-receipts.ts
+++ b/packages/daemon/src/repo-cell-receipts.ts
@@ -2,7 +2,7 @@ import {
   isEntityEvent,
   isTaskEvent,
   isTaskProgressEvent,
-  requireEntityKindContract,
+  contractForDeclarationEvent,
   type CanonicalEventV1,
   type TaskProgressEventV1,
   type WriteReceiptDraft as WriteReceipt,
@@ -87,13 +87,31 @@ export function receiptForOperation(cell: RepoCellActionContext, opId: string, b
       worktreeVisible: isTaskEvent(event) || event.schema === "decision-event/v1" ? true : null,
     };
   if (isEntityEvent(event)) {
+    if (event.type !== "entity_upserted")
+      return cell.canonicalSettlement(
+        {
+          outcome: visible ? "applied" : "pending",
+          opId,
+          revision: event.workspaceRevision,
+          evidence: JSON.stringify({
+            schema: event.schema,
+            eventId: event.eventId,
+            entityId: event.payload.entityId,
+            eventType: event.type,
+          }),
+          visibility: "center",
+          proof: { ...proof, worktreeVisible: event.type === "entity_content_observed" },
+          ...(!visible ? { nextAction: `Retry after the projection records observation ${opId}.` } : {}),
+        },
+        event,
+      );
     const claim = event.payload.declarationDocumentClaim,
       declarationProof = { ...proof, worktreeVisible: true },
       detail = {
         kind: "entity_upsert" as const,
         entityKind: event.payload.entityKind,
         entityId: event.payload.entityId,
-        schemaId: requireEntityKindContract(event.payload.entityKind).schema.$id,
+        schemaId: contractForDeclarationEvent(event).schema.$id,
         path: claim.path,
       };
     return visible

--- a/packages/daemon/src/repo-cell.ts
+++ b/packages/daemon/src/repo-cell.ts
@@ -170,6 +170,8 @@ export function initializeRepoCell(context: RepoCellCoreInput): RepoCellCore {
   if (deferredSettlement) void settleAuthoredCandidates(deferredSettlement.actor, deferredSettlement.inventory);
   const currentSessionIdentity = (binding: RepoCellBinding) => resolveWriteSessionIdentity(binding, projection!);
   const entityActionExecutor = makeEntityActionCatalogExecutor({
+    rootDir: context.rootDir,
+    repositoryId: context.input.repoId,
     store,
     projection,
     now: context.now,

--- a/packages/daemon/src/task-action-explanation-read.ts
+++ b/packages/daemon/src/task-action-explanation-read.ts
@@ -29,6 +29,7 @@ import {
   type TaskProjection,
 } from "../../kernel/src/index.ts";
 import { authorizeRepoCellAction } from "./repo-cell-authorization.ts";
+import { compiledArtifactKinds } from "./artifact-entity-action.ts";
 import type { RepoCellBinding, RepoTaskAction } from "./repo-cell-types.ts";
 
 export interface TaskActionExplanationReadDependencies {
@@ -319,6 +320,50 @@ function catalogExplanation(kind: string, binding: RepoCellBinding): EntityActio
   if (kind === "task") return makeTaskActionExplanationService(dependencies).catalog();
   if (kind === "person") return makePersonActionExplanationService(dependencies).catalog();
   if (kind === "squad") return makeSquadActionExplanationService(dependencies).catalog();
+  const artifact = compiledArtifactKinds().find(({ typeIdentity }) => typeIdentity === kind),
+    catalog = artifact?.entityKindContract.actionCatalog;
+  if (artifact && catalog) {
+    const result: EntityActionExplanationSetV1 = {
+        schema: ENTITY_ACTION_EXPLANATION_SCHEMA.id,
+        mode: "catalog",
+        subjects: [
+          {
+            kind,
+            ref: null,
+            revision: null,
+            actions: catalog.actions.map((action) => ({
+              action: {
+                kind,
+                id: action.id,
+                catalogRef: catalog.ref,
+                contractVersion: `${action.version.major}.${action.version.minor}`,
+                explain: action.explain,
+                syntax: {
+                  usage: `ha entity import --kind ${kind} --locator <locator> --expected-version <revision>`,
+                  inputs: action.input.fields,
+                },
+              },
+              target: null,
+              available: null,
+              criteria: action.criteria.map((criterion) => ({
+                ...criterion,
+                status: "not-evaluated" as const,
+                nextActions: [],
+              })),
+              unmetCriteria: [],
+              authorizationDecision: null,
+              nextActions: [],
+              evaluatedAtCut: null,
+            })),
+            failure: null,
+          },
+        ],
+        evaluatedAtCut: null,
+      },
+      issues = validateEntityActionExplanationSet(result);
+    if (issues.length) throw new Error(`Invalid Artifact Action explanation: ${issues.join("; ")}`);
+    return Object.freeze(result);
+  }
   throw invalidCommand(`Entity Action catalog explain does not support ${kind}.`);
 }
 

--- a/packages/daemon/test/artifact-entity-action.integration.test.ts
+++ b/packages/daemon/test/artifact-entity-action.integration.test.ts
@@ -1,0 +1,143 @@
+// harness-test-tier: integration
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { makeTaskEventStore, makeTaskProjection } from "../../kernel/src/index.ts";
+import { canonicalRoot, workspaceId } from "../src/protocol/daemon-protocol.contract.ts";
+import { withRoleBinding } from "./role-binding.fixtures.ts";
+import { openBootstrappedRepoCell as openRepoCell } from "./repo-settings.fixture.ts";
+import { initRepo } from "./task-surface.fixtures.ts";
+
+const kind = "software/coding/architecture-decision-record@1",
+  binding = withRoleBinding(
+    {
+      actor: {
+        principal: { personId: "person-artifact-import" },
+        executor: { kind: "agent" as const, id: "artifact-edge" },
+      },
+      source: "local" as const,
+    },
+    "repo-write",
+  );
+
+test("Artifact import is dry-run safe, edge-idempotent, fenced, and cold-rebuildable", async () => {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-artifact-import-")),
+    sourcePath = "docs/adr-0001.md",
+    absoluteSource = path.join(rootDir, sourcePath),
+    repoId = workspaceId("artifact-import");
+  let cell: Awaited<ReturnType<typeof openRepoCell>> | undefined;
+  try {
+    initRepo(rootDir);
+    mkdirSync(path.dirname(absoluteSource), { recursive: true });
+    writeFileSync(absoluteSource, "# Adopt the event ledger\n\nFirst observation.\n");
+    git(rootDir, "add", sourcePath);
+    git(rootDir, "commit", "-qm", "add artifact source");
+    cell = await openRepoCell({
+      repoId,
+      rootDir: canonicalRoot(rootDir),
+      ownerId: "artifact-import-center",
+      now: () => "2026-09-02T02:00:00.000Z",
+    });
+    const explained = await cell.read(
+      "repo.entity.actions.explain",
+      { schema: "entity-action-explain-request/v1", mode: "catalog", entityKind: kind, refs: [] },
+      binding,
+    );
+    assert.deepEqual(
+      explained.subjects[0]?.actions.map(({ action }) => action.id),
+      ["import"],
+    );
+    assert.equal(explained.subjects[0]?.actions[0]?.available, null);
+
+    const observer = makeTaskEventStore({ repoId, rootDir }),
+      beforeEvents = observer.read().events.length,
+      beforeStatus = git(rootDir, "status", "--porcelain=v1"),
+      request = { kind: "entity-import", entityKind: kind, locator: sourcePath, expectedVersion: 0 },
+      previewReceipt = await cell.run({ ...request, dryRun: true }, binding);
+    assert.equal(previewReceipt.outcome, "pending", JSON.stringify(previewReceipt));
+    const preview = JSON.parse(String(previewReceipt.evidence)) as {
+      entityId: string;
+      candidateContentVersion: string;
+      artifactOwner: string;
+      operationId: string;
+    };
+    assert.equal(observer.read().events.length, beforeEvents, "dry-run must not append an event");
+    assert.equal(git(rootDir, "status", "--porcelain=v1"), beforeStatus, "dry-run must not touch the worktree");
+    assert.match(preview.entityId, /^ADR-[a-f0-9]{16}$/u);
+    assert.match(preview.candidateContentVersion, /^sha256:[a-f0-9]{64}$/u);
+    assert.equal(preview.artifactOwner, `entity/${preview.entityId}/revision/${beforeEvents + 1}`);
+
+    const first = await cell.run(request, binding),
+      replay = await cell.run(request, binding);
+    assert.equal(first.outcome, "applied", JSON.stringify(first));
+    assert.equal(replay.outcome, "no_changes", JSON.stringify(replay));
+    assert.equal(first.opId, replay.opId);
+    assert.equal(first.opId, preview.operationId);
+    assert.equal(
+      (JSON.parse(String(replay.evidence)) as { sameResult: boolean }).sameResult,
+      true,
+      "the second edge must receive the original same-result operation",
+    );
+
+    writeFileSync(absoluteSource, "# Adopt the event ledger\n\nSecond observation.\n");
+    const stale = await cell.run(request, binding);
+    assert.equal(stale.outcome, "op_rejected", JSON.stringify(stale));
+    assert.equal(stale.code, "revision_conflict");
+    const updated = await cell.run({ ...request, expectedVersion: first.revision }, binding),
+      updatedEvidence = JSON.parse(String(updated.evidence)) as {
+        preview: { entityId: string; candidateContentVersion: string };
+      };
+    assert.equal(updated.outcome, "applied", JSON.stringify(updated));
+    assert.equal(updatedEvidence.preview.entityId, preview.entityId);
+    assert.notEqual(updatedEvidence.preview.candidateContentVersion, preview.candidateContentVersion);
+
+    rmSync(absoluteSource);
+    const missing = await cell.run({ ...request, expectedVersion: updated.revision }, binding);
+    assert.equal(missing.outcome, "applied", JSON.stringify(missing));
+    const missingReplay = await cell.run({ kind: "receipt-show", opId: missing.opId }, binding);
+    assert.equal(
+      (JSON.parse(String(missingReplay.evidence)) as { eventType: string }).eventType,
+      "entity_target_missing",
+    );
+    assert.equal(missingReplay.proof?.worktreeVisible, false);
+    const artifactEvents = makeTaskEventStore({ repoId, rootDir })
+      .read()
+      .events.filter((event) => event.schema === "entity-event/v1" && event.payload.entityKind === kind);
+    assert.deepEqual(
+      artifactEvents.map(({ type }) => type),
+      ["entity_content_observed", "entity_content_observed", "entity_target_missing"],
+    );
+
+    const listed = await cell.run({ kind: "entity-list", entityKind: kind }, binding),
+      listedEntities = (JSON.parse(String(listed.evidence)) as { entities: readonly { id: string }[] }).entities;
+    assert.deepEqual(
+      listedEntities.map(({ id }) => id),
+      [preview.entityId],
+    );
+    await cell.close();
+    cell = undefined;
+
+    const rebuildStore = makeTaskEventStore({ repoId, rootDir }),
+      rebuilt = makeTaskProjection({ rootDir, eventStore: rebuildStore, now: () => "2026-09-02T02:01:00.000Z" });
+    try {
+      const receipt = rebuilt.rebuild(),
+        row = rebuilt.getEntity(kind, preview.entityId);
+      assert.equal(receipt.watermark, rebuildStore.readHead()?.revision);
+      assert.equal(row?.id, preview.entityId);
+      assert.equal(row?.workspaceRevision, missing.revision);
+      assert.equal(row?.value.contentVersion, updatedEvidence.preview.candidateContentVersion);
+    } finally {
+      rebuilt.close();
+    }
+  } finally {
+    await cell?.close();
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});
+
+function git(rootDir: string, ...args: readonly string[]): string {
+  return execFileSync("git", ["-C", rootDir, ...args], { encoding: "utf8" }).trim();
+}

--- a/packages/daemon/test/command-admission.test.ts
+++ b/packages/daemon/test/command-admission.test.ts
@@ -40,8 +40,7 @@ test("all daemon commands close every repo-mode admission cell", () => {
 test("legacy repo reads have no descriptor left on the serialized write method", () => {
   const legacyReadIds = ["task-list", "task-show", "doc-status", "settings-read"];
   for (const command of daemonProtocolCommands)
-    if (command.commandClass === "repo-read")
-      assert.notEqual(command.method, "repo.task.run", command.id);
+    if (command.commandClass === "repo-read") assert.notEqual(command.method, "repo.task.run", command.id);
   for (const id of legacyReadIds)
     assert.equal(daemonProtocolCommands.find((command) => command.id === id)?.method, "repo.task.read", id);
 });
@@ -100,6 +99,16 @@ test("Settings CLI read uses the common read topology while update forwards from
   });
   assert.equal(byId.get("settings-read")?.commandClass, "repo-read");
   assert.equal(byId.get("settings-update")?.commandClass, "repo-write");
+});
+
+test("Artifact import forwards edge observations into the center single-writer queue", () => {
+  const command = daemonProtocolCommands.find(({ id }) => id === "entity-import");
+  assert.deepEqual(command?.admission, {
+    local: "direct",
+    "remote-center": "via-assignment",
+    "remote-edge": "via-center-forward",
+  });
+  assert.equal(command?.commandClass, "repo-write");
 });
 
 test("Settings locale-only updates use local admission while repository fields keep center routing", () => {

--- a/packages/daemon/test/validator-diagnostic-contract.test.ts
+++ b/packages/daemon/test/validator-diagnostic-contract.test.ts
@@ -30,6 +30,33 @@ interface ValidatorCase {
   readonly validate: () => readonly string[];
 }
 
+test("entity import wire input is exact and projected from its executable Action contract", () => {
+  const payload = {
+    payload: {
+      action: {
+        kind: "entity-import",
+        entityKind: "software/coding/architecture-decision-record@1",
+        locator: "docs/adr.md",
+        expectedVersion: 0,
+        dryRun: true,
+      },
+    },
+  } as JsonObject;
+  assert.deepEqual(validateCatalogActionPayload(payload), []);
+  assert.match(
+    validateCatalogActionPayload({
+      payload: { action: { ...payload.payload.action, body: "must not cross the descriptor boundary" } },
+    } as JsonObject).join("\n"),
+    /action\.body.*not declared/u,
+  );
+  assert.match(
+    validateCatalogActionPayload({
+      payload: { action: { ...payload.payload.action, expectedVersion: -1 } },
+    } as JsonObject).join("\n"),
+    /action\.expectedVersion.*must be number/u,
+  );
+});
+
 const relationGraph = {
     ok: true,
     status: "ready",

--- a/packages/kernel/src/domain/artifact-entity.ts
+++ b/packages/kernel/src/domain/artifact-entity.ts
@@ -1,4 +1,4 @@
-import { createHash } from "node:crypto";
+import { sha256Bytes, sha256Text } from "../integrity/stable-hash.ts";
 import { normalizeRelativeDocumentPath } from "../layout/portable-path.ts";
 import type { ArtifactEntityKindDefinition } from "../schemas/vertical-definition.ts";
 import {
@@ -137,7 +137,7 @@ export function deriveArtifactContentVersion(witness: ArtifactContentWitness): s
     typeof witness.content === "string"
       ? new TextEncoder().encode(normalizeArtifactText(witness.content))
       : witness.content;
-  return `sha256:${createHash("sha256").update(bytes).digest("hex")}`;
+  return `sha256:${sha256Bytes(bytes)}`;
 }
 
 export function artifactDescriptorSchema(
@@ -356,7 +356,7 @@ function normalizeArtifactText(value: string): string {
 }
 
 function sha256(value: string): string {
-  return createHash("sha256").update(value).digest("hex");
+  return sha256Text(value);
 }
 
 export function deepFreeze<T>(value: T): T {

--- a/packages/kernel/src/domain/artifact-entity.ts
+++ b/packages/kernel/src/domain/artifact-entity.ts
@@ -1,0 +1,366 @@
+import { createHash } from "node:crypto";
+import { normalizeRelativeDocumentPath } from "../layout/portable-path.ts";
+import type { ArtifactEntityKindDefinition } from "../schemas/vertical-definition.ts";
+import {
+  parseEntityJsonSchema,
+  serializeEntityJsonSchema,
+  type EntityDocumentJsonSchema,
+} from "./entity-json-schema.ts";
+import {
+  genericAuthoring,
+  genericEntityStore,
+  noSdkExposure,
+  type EntityKindContract,
+  type EntityStoreKindContract,
+} from "./entity-kind-registry.ts";
+import { isRecord } from "./write-chain.contract.ts";
+
+export const ARTIFACT_DESCRIPTOR_FIELDS = Object.freeze([
+  "schema",
+  "typeIdentity",
+  "entityId",
+  "title",
+  "locator",
+  "contentVersion",
+  "source",
+] as const);
+
+export type ArtifactLocatorKind = "repository-path" | "url" | "external-key";
+
+export interface ArtifactLocator {
+  readonly kind: ArtifactLocatorKind;
+  readonly value: string;
+}
+
+export interface ArtifactDescriptor {
+  readonly schema: string;
+  readonly typeIdentity: string;
+  readonly entityId: string;
+  readonly title: string;
+  readonly locator: ArtifactLocator;
+  readonly contentVersion: string;
+  readonly source: string;
+}
+
+export type ArtifactSourceIdentityInput =
+  | {
+      readonly kind: "repository-path";
+      readonly repositoryId: string;
+      readonly path: string;
+    }
+  | { readonly kind: "url"; readonly url: string }
+  | {
+      readonly kind: "external-key";
+      readonly provider: string;
+      readonly project: string;
+      readonly externalKey: string;
+    };
+
+export type ArtifactContentWitness =
+  | { readonly kind: "git-object"; readonly objectId: string }
+  | { readonly kind: "external-revision"; readonly revision: string }
+  | { readonly kind: "content"; readonly content: string | Uint8Array };
+
+export interface ArtifactEntityContractSnapshot {
+  readonly schema: "artifact-entity-contract/v1";
+  readonly typeIdentity: string;
+  readonly descriptorSchemaRef: string;
+  readonly idPrefix: string;
+  readonly pathTemplate: string;
+  readonly locatorKinds: readonly ArtifactLocatorKind[];
+}
+
+export class ArtifactEntityContractError extends Error {
+  readonly code = "invalid_artifact_entity";
+
+  constructor(message: string) {
+    super(message);
+    this.name = "ArtifactEntityContractError";
+  }
+}
+
+export function canonicalSourceIdentity(input: ArtifactSourceIdentityInput): string {
+  if (input.kind === "repository-path") {
+    const repositoryId = requiredIdentityPart(input.repositoryId, "repositoryId"),
+      documentPath = normalizeRelativeDocumentPath(input.path);
+    return `repo:${repositoryId}:${documentPath}`;
+  }
+  if (input.kind === "url") return canonicalArtifactUrl(input.url);
+  return [
+    requiredIdentityPart(input.provider, "provider"),
+    requiredIdentityPart(input.project, "project"),
+    requiredIdentityPart(input.externalKey, "externalKey"),
+  ].join(":");
+}
+
+export function canonicalArtifactUrl(value: string): string {
+  let parsed: URL;
+  try {
+    parsed = new URL(value);
+  } catch {
+    throw new ArtifactEntityContractError("Artifact URL must be an absolute URL.");
+  }
+  if (!(["http:", "https:"] as const).includes(parsed.protocol as "http:" | "https:"))
+    throw new ArtifactEntityContractError("Artifact URL must use http or https.");
+  if (parsed.username || parsed.password)
+    throw new ArtifactEntityContractError("Artifact URL must not contain credentials.");
+  parsed.hash = "";
+  const sorted = [...parsed.searchParams.entries()].sort(([leftKey, leftValue], [rightKey, rightValue]) =>
+    leftKey === rightKey ? leftValue.localeCompare(rightValue) : leftKey.localeCompare(rightKey),
+  );
+  parsed.search = "";
+  for (const [key, item] of sorted) parsed.searchParams.append(key, item);
+  return parsed.toString();
+}
+
+export function deriveArtifactEntityId(input: {
+  readonly idPrefix: string;
+  readonly typeIdentity: string;
+  readonly sourceIdentity: string;
+}): string {
+  const prefix = requiredIdentityPart(input.idPrefix, "idPrefix"),
+    sourceIdentity = requiredIdentityPart(input.sourceIdentity, "sourceIdentity"),
+    digest = sha256(sourceIdentity).slice(0, 16);
+  requiredIdentityPart(input.typeIdentity, "typeIdentity");
+  return `${prefix}-${digest}`;
+}
+
+export function deriveArtifactContentVersion(witness: ArtifactContentWitness): string {
+  if (witness.kind === "git-object") {
+    const objectId = witness.objectId.trim().toLowerCase();
+    if (!/^[0-9a-f]{40}(?:[0-9a-f]{24})?$/u.test(objectId))
+      throw new ArtifactEntityContractError("Git object id must be a 40- or 64-character hexadecimal digest.");
+    return `git:${objectId}`;
+  }
+  if (witness.kind === "external-revision") return `revision:${requiredIdentityPart(witness.revision, "revision")}`;
+  const bytes =
+    typeof witness.content === "string"
+      ? new TextEncoder().encode(normalizeArtifactText(witness.content))
+      : witness.content;
+  return `sha256:${createHash("sha256").update(bytes).digest("hex")}`;
+}
+
+export function artifactDescriptorSchema(
+  artifact: Pick<ArtifactEntityKindDefinition, "descriptorSchemaRef" | "idPrefix" | "locatorKinds">,
+  typeIdentity: string,
+): EntityDocumentJsonSchema<ArtifactDescriptor> {
+  return deepFreeze({
+    $schema: "https://json-schema.org/draft/2020-12/schema",
+    $id: `${artifact.descriptorSchemaRef}#${typeIdentity}`,
+    type: "object",
+    properties: {
+      schema: { type: "string", const: artifact.descriptorSchemaRef },
+      typeIdentity: { type: "string", const: typeIdentity },
+      entityId: { type: "string", pattern: `^${artifact.idPrefix}-[a-f0-9]{16}$` },
+      title: { type: "string", minLength: 1 },
+      locator: {
+        type: "object",
+        properties: {
+          kind: { type: "string", enum: artifact.locatorKinds },
+          value: { type: "string", minLength: 1 },
+        },
+        required: ["kind", "value"],
+        additionalProperties: false,
+      },
+      contentVersion: { type: "string", minLength: 1 },
+      source: { type: "string", minLength: 1 },
+    },
+    required: ARTIFACT_DESCRIPTOR_FIELDS,
+    additionalProperties: false,
+  });
+}
+
+export function decodeArtifactDescriptor(
+  contract: Pick<EntityKindContract, "kind" | "schema">,
+  value: unknown,
+): ArtifactDescriptor {
+  const descriptor = parseEntityJsonSchema(contract.schema, value, `${contract.kind} artifact descriptor`);
+  if (!isArtifactDescriptor(descriptor))
+    throw new ArtifactEntityContractError("Artifact descriptor fields do not match artifact-descriptor/v1.");
+  const locator = canonicalArtifactLocator(descriptor.locator);
+  if (locator.value !== descriptor.locator.value)
+    throw new ArtifactEntityContractError("Artifact descriptor locator must already be canonical.");
+  if (descriptor.typeIdentity !== contract.kind)
+    throw new ArtifactEntityContractError("Artifact descriptor typeIdentity does not match its kind contract.");
+  if (canonicalArtifactSourceIdentity(descriptor.source) !== descriptor.source)
+    throw new ArtifactEntityContractError("Artifact descriptor source identity must already be canonical.");
+  const prefix = descriptor.entityId.slice(0, descriptor.entityId.indexOf("-")),
+    expected = deriveArtifactEntityId({
+      idPrefix: prefix,
+      typeIdentity: descriptor.typeIdentity,
+      sourceIdentity: descriptor.source,
+    });
+  if (descriptor.entityId !== expected)
+    throw new ArtifactEntityContractError("Artifact descriptor entityId does not match its immutable source identity.");
+  return deepFreeze({ ...descriptor, locator });
+}
+
+export function encodeArtifactDescriptor(
+  contract: Pick<EntityKindContract, "kind" | "schema">,
+  value: unknown,
+): string {
+  return serializeEntityJsonSchema(
+    contract.schema,
+    decodeArtifactDescriptor(contract, value),
+    `${contract.kind} descriptor`,
+  );
+}
+
+export function canonicalArtifactLocator(locator: ArtifactLocator): ArtifactLocator {
+  if (locator.kind === "repository-path")
+    return Object.freeze({ kind: locator.kind, value: normalizeRelativeDocumentPath(locator.value) });
+  if (locator.kind === "url") return Object.freeze({ kind: locator.kind, value: canonicalArtifactUrl(locator.value) });
+  return Object.freeze({ kind: locator.kind, value: canonicalExternalLocator(locator.value) });
+}
+
+export function artifactEntityContractSnapshot(input: {
+  readonly declaration: Pick<
+    ArtifactEntityKindDefinition,
+    "descriptorSchemaRef" | "idPrefix" | "locatorKinds" | "store"
+  >;
+  readonly typeIdentity: string;
+}): ArtifactEntityContractSnapshot {
+  return deepFreeze({
+    schema: "artifact-entity-contract/v1",
+    typeIdentity: input.typeIdentity,
+    descriptorSchemaRef: input.declaration.descriptorSchemaRef,
+    idPrefix: input.declaration.idPrefix,
+    pathTemplate: input.declaration.store.pathTemplate,
+    locatorKinds: [...input.declaration.locatorKinds] as ArtifactLocatorKind[],
+  });
+}
+
+export function artifactEntityContractFromSnapshot(snapshot: unknown): EntityStoreKindContract {
+  const decoded = decodeArtifactEntityContractSnapshot(snapshot),
+    identity = Object.freeze({
+      field: "entityId",
+      pattern: `^${decoded.idPrefix}-[a-f0-9]{16}$`,
+      refTemplate: `${decoded.typeIdentity}/{id}` as `${string}/{id}`,
+    });
+  return deepFreeze({
+    kind: decoded.typeIdentity,
+    id: identity,
+    residency: { authored: "ledger" as const },
+    relationEndpoint: { eligible: true as const },
+    baseActions: ["pin", "unpin", "relate", "unrelate", "archive", "explain"],
+    schema: artifactDescriptorSchema(
+      {
+        descriptorSchemaRef: decoded.descriptorSchemaRef,
+        idPrefix: decoded.idPrefix,
+        locatorKinds: decoded.locatorKinds,
+      },
+      decoded.typeIdentity,
+    ),
+    relations: { directions: [], edges: [] },
+    canonicalProjection: { embeddedEvents: [], row: { idField: "entityId", ownerField: null } },
+    actionCatalog: null,
+    entityStore: genericEntityStore(decoded.pathTemplate),
+    authoring: genericAuthoring,
+    sdkExposure: noSdkExposure,
+  });
+}
+
+export function decodeArtifactEntityContractSnapshot(value: unknown): ArtifactEntityContractSnapshot {
+  const fields = ["schema", "typeIdentity", "descriptorSchemaRef", "idPrefix", "pathTemplate", "locatorKinds"];
+  if (
+    !isRecord(value) ||
+    Object.keys(value).some((field) => !fields.includes(field)) ||
+    fields.some((field) => !Object.hasOwn(value, field)) ||
+    value.schema !== "artifact-entity-contract/v1" ||
+    typeof value.typeIdentity !== "string" ||
+    !value.typeIdentity ||
+    typeof value.descriptorSchemaRef !== "string" ||
+    !value.descriptorSchemaRef ||
+    typeof value.idPrefix !== "string" ||
+    !/^[A-Z][A-Z0-9]{0,15}$/u.test(value.idPrefix) ||
+    typeof value.pathTemplate !== "string" ||
+    value.pathTemplate.split("{id}").length !== 2 ||
+    !Array.isArray(value.locatorKinds) ||
+    value.locatorKinds.length === 0 ||
+    value.locatorKinds.some((kind) => !(["repository-path", "url", "external-key"] as const).includes(kind as never)) ||
+    new Set(value.locatorKinds).size !== value.locatorKinds.length
+  )
+    throw new ArtifactEntityContractError("Artifact entity contract snapshot is invalid.");
+  normalizeRelativeDocumentPath(value.pathTemplate);
+  return deepFreeze(value as unknown as ArtifactEntityContractSnapshot);
+}
+
+export function artifactObservationId(input: {
+  readonly entityId: string;
+  readonly locator: ArtifactLocator;
+  readonly resolution: string;
+}): string {
+  return `obs_${sha256(`${input.entityId}\u0000${input.locator.kind}:${input.locator.value}\u0000${input.resolution}`).slice(0, 24)}`;
+}
+
+export function artifactImportOperationId(input: {
+  readonly entityId: string;
+  readonly locator: ArtifactLocator;
+  readonly resolution: string;
+}): string {
+  return `entity-import-${sha256(`${input.entityId}\u0000${input.locator.kind}:${input.locator.value}\u0000${input.resolution}`).slice(0, 32)}`;
+}
+
+function isArtifactDescriptor(value: unknown): value is ArtifactDescriptor {
+  return (
+    isRecord(value) &&
+    ARTIFACT_DESCRIPTOR_FIELDS.every((field) => Object.hasOwn(value, field)) &&
+    Object.keys(value).every((field) => (ARTIFACT_DESCRIPTOR_FIELDS as readonly string[]).includes(field)) &&
+    typeof value.schema === "string" &&
+    typeof value.typeIdentity === "string" &&
+    typeof value.entityId === "string" &&
+    typeof value.title === "string" &&
+    typeof value.contentVersion === "string" &&
+    typeof value.source === "string" &&
+    isRecord(value.locator) &&
+    typeof value.locator.kind === "string" &&
+    typeof value.locator.value === "string"
+  );
+}
+
+function canonicalExternalLocator(value: string): string {
+  const parts = value.split(":");
+  if (parts.length < 3)
+    throw new ArtifactEntityContractError("External locator must be provider:project:external-key.");
+  return [
+    requiredIdentityPart(parts[0], "provider"),
+    requiredIdentityPart(parts[1], "project"),
+    requiredIdentityPart(parts.slice(2).join(":"), "externalKey"),
+  ].join(":");
+}
+
+export function canonicalArtifactSourceIdentity(value: string): string {
+  if (value.startsWith("repo:")) {
+    const separator = value.indexOf(":", "repo:".length);
+    if (separator < 0) throw new ArtifactEntityContractError("Repository source identity is incomplete.");
+    return canonicalSourceIdentity({
+      kind: "repository-path",
+      repositoryId: value.slice("repo:".length, separator),
+      path: value.slice(separator + 1),
+    });
+  }
+  if (/^https?:\/\//iu.test(value)) return canonicalArtifactUrl(value);
+  return canonicalExternalLocator(value);
+}
+
+function requiredIdentityPart(value: string | undefined, label: string): string {
+  if (typeof value !== "string" || !value || value.trim() !== value || /[\u0000\r\n]/u.test(value))
+    throw new ArtifactEntityContractError(`Artifact ${label} must be a non-empty canonical string.`);
+  return value;
+}
+
+function normalizeArtifactText(value: string): string {
+  return value.replace(/^\uFEFF/u, "").replace(/\r\n?/gu, "\n");
+}
+
+function sha256(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function deepFreeze<T>(value: T): T {
+  if (value && typeof value === "object" && !Object.isFrozen(value)) {
+    for (const child of Object.values(value)) deepFreeze(child);
+    Object.freeze(value);
+  }
+  return value;
+}

--- a/packages/kernel/src/domain/artifact-entity.ts
+++ b/packages/kernel/src/domain/artifact-entity.ts
@@ -290,7 +290,8 @@ export function artifactObservationId(input: {
   readonly locator: ArtifactLocator;
   readonly resolution: string;
 }): string {
-  return `obs_${sha256(`${input.entityId}\u0000${input.locator.kind}:${input.locator.value}\u0000${input.resolution}`).slice(0, 24)}`;
+  const identity = `${input.entityId}\u0000${input.locator.kind}:${input.locator.value}\u0000${input.resolution}`;
+  return `obs_${sha256(identity).slice(0, 24)}`;
 }
 
 export function artifactImportOperationId(input: {
@@ -298,7 +299,8 @@ export function artifactImportOperationId(input: {
   readonly locator: ArtifactLocator;
   readonly resolution: string;
 }): string {
-  return `entity-import-${sha256(`${input.entityId}\u0000${input.locator.kind}:${input.locator.value}\u0000${input.resolution}`).slice(0, 32)}`;
+  const identity = `${input.entityId}\u0000${input.locator.kind}:${input.locator.value}\u0000${input.resolution}`;
+  return `entity-import-${sha256(identity).slice(0, 32)}`;
 }
 
 function isArtifactDescriptor(value: unknown): value is ArtifactDescriptor {
@@ -357,7 +359,7 @@ function sha256(value: string): string {
   return createHash("sha256").update(value).digest("hex");
 }
 
-function deepFreeze<T>(value: T): T {
+export function deepFreeze<T>(value: T): T {
   if (value && typeof value === "object" && !Object.isFrozen(value)) {
     for (const child of Object.values(value)) deepFreeze(child);
     Object.freeze(value);

--- a/packages/kernel/src/domain/default-policy.ts
+++ b/packages/kernel/src/domain/default-policy.ts
@@ -23,6 +23,7 @@ const repositoryWriteActions = Object.freeze([
   "doc-materialize",
   "doc-retire",
   "doc-submit",
+  "entity-import",
   "fact-reclassify",
   "fact-record",
   "fact-rekey",

--- a/packages/kernel/src/domain/entity-action-explanation.ts
+++ b/packages/kernel/src/domain/entity-action-explanation.ts
@@ -1,6 +1,7 @@
 import { validateActorIdentity } from "./actor-identity.ts";
 import { parseEntityRef, type EntityRef } from "./entity-ref.ts";
 import {
+  artifactEntityActionCatalog,
   getEntityKindContract,
   type EntityActionContract,
   type EntityActionInputField,
@@ -103,7 +104,7 @@ export function validateEntityActionExplainRequest(value: unknown): readonly str
   if (value.mode !== "object" && value.mode !== "catalog") errors.push("Entity Action explain request mode is invalid");
   if (
     value.mode === "catalog" &&
-    (!explanationNonEmpty(value.entityKind) || !getEntityKindContract(String(value.entityKind))?.actionCatalog)
+    (!explanationNonEmpty(value.entityKind) || !explanationCatalog(String(value.entityKind)))
   )
     errors.push("Entity Action catalog explain kind is unsupported");
   if (value.mode === "object" && value.entityKind !== null)
@@ -114,8 +115,8 @@ export function validateEntityActionExplainRequest(value: unknown): readonly str
     errors.push("Entity Action object explain requires 1..500 refs");
   else if (value.mode === "catalog") {
     const selector = value.refs[0];
-    if (value.refs.length > 1 || (selector !== undefined && selector !== "task" && selector !== "person"))
-      errors.push("Entity Action catalog explain accepts at most one supported Task or Person kind selector");
+    if (value.refs.length > 1 || (selector !== undefined && selector !== value.entityKind))
+      errors.push("Entity Action catalog explain accepts at most one matching kind selector");
   }
   return errors;
 }
@@ -182,9 +183,7 @@ function validateSubject(value: unknown, mode: unknown, cut: unknown): readonly 
           explanationRecord(action) && explanationRecord(action.action) ? action.action.id : undefined,
         ),
         canonicalIds =
-          typeof value.kind === "string"
-            ? (getEntityKindContract(value.kind)?.actionCatalog?.actions.map(({ id }) => id) ?? null)
-            : null;
+          typeof value.kind === "string" ? (explanationCatalog(value.kind)?.actions.map(({ id }) => id) ?? null) : null;
       if (canonicalIds === null || JSON.stringify(ids) !== JSON.stringify(canonicalIds))
         errors.push("successful Entity subject actions must follow its canonical catalog order");
     }
@@ -196,7 +195,7 @@ function validateSubject(value: unknown, mode: unknown, cut: unknown): readonly 
   )
     errors.push("only an invalid EntityRef failure may have no kind");
   if (mode === "catalog") {
-    const catalog = typeof value.kind === "string" ? getEntityKindContract(value.kind)?.actionCatalog : null;
+    const catalog = typeof value.kind === "string" ? explanationCatalog(value.kind) : null;
     if (
       catalog === null ||
       catalog === undefined ||
@@ -210,7 +209,7 @@ function validateSubject(value: unknown, mode: unknown, cut: unknown): readonly 
   } else if (
     value.failure === null &&
     (typeof value.kind !== "string" ||
-      !getEntityKindContract(value.kind)?.actionCatalog ||
+      !explanationCatalog(value.kind) ||
       value.ref === null ||
       !positiveInteger(value.revision))
   )
@@ -339,7 +338,7 @@ function validActionDescriptor(value: unknown): boolean {
     Array.isArray(value.syntax.inputs) &&
     value.syntax.inputs.every(validInputField) &&
     canonical !== null &&
-    value.catalogRef === getEntityKindContract(String(value.kind))?.actionCatalog?.ref &&
+    value.catalogRef === explanationCatalog(String(value.kind))?.ref &&
     value.contractVersion === `${canonical.version.major}.${canonical.version.minor}` &&
     value.explain === canonical.explain &&
     JSON.stringify(value.syntax.inputs) === JSON.stringify(canonical.input.fields)
@@ -348,7 +347,18 @@ function validActionDescriptor(value: unknown): boolean {
 
 function actionContract(value: unknown): EntityActionContract | null {
   if (!explanationRecord(value) || typeof value.kind !== "string" || typeof value.id !== "string") return null;
-  return getEntityKindContract(value.kind)?.actionCatalog?.actions.find(({ id }) => id === value.id) ?? null;
+  return explanationCatalog(value.kind)?.actions.find(({ id }) => id === value.id) ?? null;
+}
+
+function explanationCatalog(kind: string) {
+  const registered = getEntityKindContract(kind)?.actionCatalog;
+  if (registered) return registered;
+  if (!/^[a-z0-9][a-z0-9/-]*\/[a-z0-9][a-z0-9-]*@[1-9][0-9]*$/u.test(kind)) return null;
+  return artifactEntityActionCatalog(kind, {
+    field: "entityId",
+    pattern: "^[A-Z][A-Z0-9]{0,15}-[a-f0-9]{16}$",
+    refTemplate: `${kind}/{id}`,
+  });
 }
 
 function staticCriterion(value: unknown): unknown {

--- a/packages/kernel/src/domain/entity-event.ts
+++ b/packages/kernel/src/domain/entity-event.ts
@@ -1,11 +1,24 @@
 import { eventObjectTarget } from "../layout/ledger-object-layout.ts";
 import { normalizeRelativeDocumentPath } from "../layout/portable-path.ts";
 import { sha256Text, stableStringify } from "../integrity/stable-hash.ts";
+import {
+  artifactEntityContractFromSnapshot,
+  artifactImportOperationId,
+  artifactObservationId,
+  canonicalArtifactLocator,
+  canonicalArtifactSourceIdentity,
+  decodeArtifactDescriptor,
+  deriveArtifactEntityId,
+  type ArtifactDescriptor,
+  type ArtifactEntityContractSnapshot,
+  type ArtifactLocator,
+} from "./artifact-entity.ts";
 import { parseEntityJsonSchema, serializeEntityJsonSchema } from "./entity-json-schema.ts";
 import {
   ENTITY_DOCUMENT_POLICY_ID,
   entityDocumentPath,
   requireEntityStoreKindContract,
+  type EntityStoreKindContract,
 } from "./entity-kind-registry.ts";
 import {
   freezeDeclaredWritePlan,
@@ -28,97 +41,197 @@ export interface EntityDeclarationClaim {
   readonly mediaType: "application/json";
   readonly policyId: typeof ENTITY_DOCUMENT_POLICY_ID;
 }
-interface EntityEventPayload {
+
+interface EntityUpsertPayload {
   readonly entityKind: string;
   readonly entityId: string;
   readonly declarationDocumentClaim: EntityDeclarationClaim;
 }
-export type EntityEventV1 = EventEnvelope<"entity-event/v1", "entity_upserted", ActorIdentity, EntityEventPayload>;
-// Ledger history written before the generic entity store (agent/squad installs up to 2026-08-25) carries the
-// same payload under the retired agent-specific envelope. The ledger is append-only, so readers accept both.
+
+export interface ArtifactContentObservedPayload extends EntityUpsertPayload {
+  readonly locator: ArtifactLocator;
+  readonly sourceIdentity: string;
+  readonly observedContentVersion: string;
+  readonly resolver: string;
+  readonly observationId: string;
+  readonly artifactContract: ArtifactEntityContractSnapshot;
+}
+
+export interface ArtifactTargetMissingPayload {
+  readonly entityKind: string;
+  readonly entityId: string;
+  readonly locator: ArtifactLocator;
+  readonly sourceIdentity: string;
+  readonly resolver: string;
+  readonly observationId: string;
+  readonly reason: string;
+  readonly artifactContract: ArtifactEntityContractSnapshot;
+}
+
+export type EntityUpsertEventV1 = EventEnvelope<
+  "entity-event/v1",
+  "entity_upserted",
+  ActorIdentity,
+  EntityUpsertPayload
+>;
+export type EntityContentObservedEventV1 = EventEnvelope<
+  "entity-event/v1",
+  "entity_content_observed",
+  ActorIdentity,
+  ArtifactContentObservedPayload
+>;
+export type EntityTargetMissingEventV1 = EventEnvelope<
+  "entity-event/v1",
+  "entity_target_missing",
+  ActorIdentity,
+  ArtifactTargetMissingPayload
+>;
+export type EntityEventV1 = EntityUpsertEventV1 | EntityContentObservedEventV1 | EntityTargetMissingEventV1;
+
+// Append-only history predating the generic store carries the upsert payload under this retired envelope.
 export type LegacyAgentEntityEventV1 = EventEnvelope<
   "agent-entity-event/v1",
   "agent_entity_written",
   ActorIdentity,
-  EntityEventPayload
+  EntityUpsertPayload
 >;
 export type StoredEntityEventV1 = EntityEventV1 | LegacyAgentEntityEventV1;
+export type EntityDeclarationEventV1 = EntityUpsertEventV1 | EntityContentObservedEventV1 | LegacyAgentEntityEventV1;
+
 const entityEventEnvelopes: ReadonlyArray<readonly [schema: string, type: string]> = [
   ["entity-event/v1", "entity_upserted"],
+  ["entity-event/v1", "entity_content_observed"],
+  ["entity-event/v1", "entity_target_missing"],
   ["agent-entity-event/v1", "agent_entity_written"],
 ];
 const LEGACY_AGENT_ENTITY_POLICY_ID = "typed-agent-entity/v1";
-function acceptedPolicyIds(schema: unknown): readonly string[] {
-  return schema === "agent-entity-event/v1"
-    ? [ENTITY_DOCUMENT_POLICY_ID, LEGACY_AGENT_ENTITY_POLICY_ID]
-    : [ENTITY_DOCUMENT_POLICY_ID];
-}
-function isEntityEventEnvelope(schema: unknown, type: unknown): boolean {
-  return entityEventEnvelopes.some(([s, t]) => s === schema && t === type);
-}
-export interface EntityUpsertBundle {
-  readonly event: EntityEventV1;
-  readonly plan: FrozenWritePlan<"EntityUpsert">;
-  readonly blobs: readonly [
-    { readonly sha256: string; readonly size: number; readonly mediaType: "application/json"; readonly body: string },
-  ];
+
+interface EntityDeclarationBlob {
+  readonly sha256: string;
+  readonly size: number;
+  readonly mediaType: "application/json";
+  readonly body: string;
 }
 
-export function compileEntityUpsert(input: {
-  readonly entityKind: string;
-  readonly entity: unknown;
+export interface EntityUpsertBundle {
+  readonly event: EntityUpsertEventV1;
+  readonly plan: FrozenWritePlan<"EntityUpsert">;
+  readonly blobs: readonly [EntityDeclarationBlob];
+}
+
+export interface EntityContentObservedBundle {
+  readonly event: EntityContentObservedEventV1;
+  readonly plan: FrozenWritePlan<"EntityContentObserved">;
+  readonly blobs: readonly [EntityDeclarationBlob];
+}
+
+export interface EntityTargetMissingBundle {
+  readonly event: EntityTargetMissingEventV1;
+  readonly plan: FrozenWritePlan<"EntityTargetMissing">;
+  readonly blobs: readonly [];
+}
+
+interface EntityEventEnvelopeInput {
   readonly eventId: string;
   readonly opId: string;
   readonly workspaceRevision: number;
   readonly actor: ActorIdentity;
   readonly source: WriteSource;
   readonly occurredAt: string;
-}): EntityUpsertBundle {
-  const contract = requireEntityStoreKindContract(input.entityKind);
-  const entity = parseEntityJsonSchema(contract.schema, input.entity, `${input.entityKind} declaration`),
+}
+
+export function compileEntityUpsert(
+  input: EntityEventEnvelopeInput & {
+    readonly entityKind: string;
+    readonly entity: unknown;
+  },
+): EntityUpsertBundle {
+  const contract = requireEntityStoreKindContract(input.entityKind),
+    entity = parseEntityJsonSchema(contract.schema, input.entity, `${input.entityKind} declaration`),
     entityId = isRecord(entity) ? entity[contract.id.field] : undefined;
   const contractErrors = contract.entityStore.validate?.(entity) ?? [];
   if (contractErrors.length) throw new Error(contractErrors.join("; "));
   if (typeof entityId !== "string") throw new Error(`${input.entityKind} declaration has no string identity`);
-  const body = serializeEntityJsonSchema(contract.schema, entity, `${input.entityKind} declaration`),
-    claim: EntityDeclarationClaim = {
-      path: normalizeRelativeDocumentPath(entityDocumentPath(contract, entityId)),
-      sha256: sha256Text(body),
-      size: Buffer.byteLength(body),
-      mediaType: contract.entityStore.document.mediaType,
-      policyId: contract.entityStore.document.policyId,
-    },
-    event: EntityEventV1 = {
-      schema: "entity-event/v1",
-      eventId: input.eventId,
-      workspaceRevision: input.workspaceRevision,
-      opId: input.opId,
+  const { body, claim } = declarationContent(contract, entityId, entity),
+    event: EntityUpsertEventV1 = {
+      ...eventEnvelope(input),
       type: "entity_upserted",
-      actor: input.actor,
-      source: input.source,
-      occurredAt: input.occurredAt,
       payload: { entityKind: contract.kind, entityId, declarationDocumentClaim: claim },
     };
-  const errors = validateCurrentEntityEvent(event);
-  if (errors.length) throw new Error(errors.join("; "));
-  return {
-    event,
-    plan: entityUpsertWritePlan(event),
-    blobs: [{ sha256: claim.sha256, size: claim.size, mediaType: claim.mediaType, body }],
+  assertValidCurrent(event);
+  return { event, plan: entityUpsertWritePlan(event), blobs: [blob(claim, body)] };
+}
+
+export function compileEntityContentObserved(
+  input: EntityEventEnvelopeInput & {
+    readonly contract: EntityStoreKindContract;
+    readonly contractSnapshot: ArtifactEntityContractSnapshot;
+    readonly descriptor: ArtifactDescriptor;
+    readonly resolver: string;
+    readonly observationId: string;
+  },
+): EntityContentObservedBundle {
+  const descriptor = decodeArtifactDescriptor(input.contract, input.descriptor),
+    { body, claim } = declarationContent(input.contract, descriptor.entityId, descriptor),
+    event: EntityContentObservedEventV1 = {
+      ...eventEnvelope(input),
+      type: "entity_content_observed",
+      payload: {
+        entityKind: input.contract.kind,
+        entityId: descriptor.entityId,
+        declarationDocumentClaim: claim,
+        locator: descriptor.locator,
+        sourceIdentity: descriptor.source,
+        observedContentVersion: descriptor.contentVersion,
+        resolver: input.resolver,
+        observationId: input.observationId,
+        artifactContract: input.contractSnapshot,
+      },
+    };
+  assertValidCurrent(event);
+  return { event, plan: entityContentObservedWritePlan(event), blobs: [blob(claim, body)] };
+}
+
+export function compileEntityTargetMissing(
+  input: EntityEventEnvelopeInput & {
+    readonly contractSnapshot: ArtifactEntityContractSnapshot;
+    readonly entityId: string;
+    readonly locator: ArtifactLocator;
+    readonly sourceIdentity: string;
+    readonly resolver: string;
+    readonly observationId: string;
+    readonly reason: string;
+  },
+): EntityTargetMissingBundle {
+  const event: EntityTargetMissingEventV1 = {
+    ...eventEnvelope(input),
+    type: "entity_target_missing",
+    payload: {
+      entityKind: input.contractSnapshot.typeIdentity,
+      entityId: input.entityId,
+      locator: canonicalArtifactLocator(input.locator),
+      sourceIdentity: input.sourceIdentity,
+      resolver: input.resolver,
+      observationId: input.observationId,
+      reason: input.reason,
+      artifactContract: input.contractSnapshot,
+    },
   };
+  assertValidCurrent(event);
+  return { event, plan: entityTargetMissingWritePlan(event), blobs: [] };
 }
 
 export function validateEntityEvent(value: unknown): readonly string[] {
   return validateEntityEventFields(value, true);
 }
+
 export function validateCurrentEntityEvent(value: unknown): readonly string[] {
   return validateEntityEventFields(value, false);
 }
+
 function validateEntityEventFields(value: unknown, allowUnknownFields: boolean): readonly string[] {
-  const hasFields = allowUnknownFields ? hasRequiredFields : hasOnlyFields;
-  if (
-    !isRecord(value) ||
-    !hasFields(value, [
+  const hasFields = allowUnknownFields ? hasRequiredFields : hasOnlyFields,
+    envelopeFields = [
       "schema",
       "eventId",
       "workspaceRevision",
@@ -128,43 +241,298 @@ function validateEntityEventFields(value: unknown, allowUnknownFields: boolean):
       "source",
       "occurredAt",
       "payload",
-    ]) ||
-    (!allowUnknownFields
-      ? value.schema !== "entity-event/v1" || value.type !== "entity_upserted"
-      : !isEntityEventEnvelope(value.schema, value.type)) ||
-    !isRecord(value.payload) ||
-    !hasFields(value.payload, ["entityKind", "entityId", "declarationDocumentClaim"])
+    ];
+  if (
+    !isRecord(value) ||
+    !hasFields(value, envelopeFields) ||
+    (!allowUnknownFields && value.schema !== "entity-event/v1") ||
+    !isEntityEventEnvelope(value.schema, value.type) ||
+    !isRecord(value.payload)
   )
     return ["entity event envelope or payload is invalid"];
-  const kind = value.payload.entityKind,
-    id = value.payload.entityId,
-    claim = value.payload.declarationDocumentClaim;
-  if (typeof kind !== "string" || typeof id !== "string") return ["entity event kind and identity are invalid"];
-  let contract;
-  try {
-    contract = requireEntityStoreKindContract(kind);
-  } catch {
-    return ["entity event kind is not registered"];
-  }
-  if (
-    !new RegExp(contract.id.pattern, "u").test(id) ||
-    !isRecord(claim) ||
-    !hasFields(claim, ["path", "sha256", "size", "mediaType", "policyId"]) ||
-    claim.path !== entityDocumentPath(contract, id) ||
-    !/^[0-9a-f]{64}$/u.test(String(claim.sha256)) ||
-    !Number.isSafeInteger(claim.size) ||
-    (claim.size as number) < 0 ||
-    claim.mediaType !== contract.entityStore.document.mediaType ||
-    !acceptedPolicyIds(value.schema).includes(String(claim.policyId))
-  )
-    return ["entity declaration claim is invalid"];
-  return validateEventEnvelopeIdentity(value, allowUnknownFields).length ? ["entity event identity is invalid"] : [];
+  if (validateEventEnvelopeIdentity(value, allowUnknownFields).length) return ["entity event identity is invalid"];
+  if (value.type === "entity_content_observed")
+    return validateObservedPayload(value.payload, hasFields, String(value.opId));
+  if (value.type === "entity_target_missing")
+    return validateMissingPayload(value.payload, hasFields, String(value.opId));
+  return validateUpsertPayload(value.schema, value.payload, hasFields);
 }
 
 export function isEntityEvent(event: { readonly schema: string; readonly type: string }): event is StoredEntityEventV1 {
   return isEntityEventEnvelope(event.schema, event.type);
 }
-export function entityUpsertWritePlan(event: EntityEventV1): FrozenWritePlan<"EntityUpsert"> {
+
+export function isEntityDeclarationEvent(event: StoredEntityEventV1): event is EntityDeclarationEventV1 {
+  return event.type !== "entity_target_missing";
+}
+
+export function entityUpsertWritePlan(event: EntityUpsertEventV1): FrozenWritePlan<"EntityUpsert"> {
+  return declarationWritePlan("EntityUpsert", event, "document/v1");
+}
+
+export function entityContentObservedWritePlan(
+  event: EntityContentObservedEventV1,
+): FrozenWritePlan<"EntityContentObserved"> {
+  return declarationWritePlan("EntityContentObserved", event, "entity/v1");
+}
+
+export function entityTargetMissingWritePlan(
+  event: EntityTargetMissingEventV1,
+): FrozenWritePlan<"EntityTargetMissing"> {
+  return freezeDeclaredWritePlan(
+    {
+      commandType: "EntityTargetMissing",
+      targets: [
+        { kind: "event_file", path: eventObjectTarget(event.opId), operation: "create" },
+        { kind: "event_head", path: "harness/events/head.json", operation: "replace" },
+        { kind: "projection_invalidation", projection: "entity/v1", key: event.payload.entityId },
+      ],
+    },
+    ["EntityTargetMissing"],
+  );
+}
+
+export function assertEntityEventInputs(
+  event: EntityEventV1,
+  plan: FrozenWritePlan | undefined,
+  blobs: readonly {
+    readonly sha256: string;
+    readonly size: number;
+    readonly mediaType: string;
+    readonly body: string;
+  }[],
+): void {
+  if (event.type === "entity_target_missing") {
+    assertExactWritePlan(plan, entityTargetMissingWritePlan(event));
+    if (blobs.length) throw new Error("entity target-missing event must not carry content blobs");
+    return;
+  }
+  const expected =
+    event.type === "entity_content_observed" ? entityContentObservedWritePlan(event) : entityUpsertWritePlan(event);
+  assertExactWritePlan(plan, expected);
+  const claim = event.payload.declarationDocumentClaim,
+    declarationBlob = blobs.find((candidate) => candidate.sha256 === claim.sha256),
+    contract = contractForDeclarationEvent(event);
+  if (
+    !declarationBlob ||
+    declarationBlob.size !== claim.size ||
+    declarationBlob.mediaType !== claim.mediaType ||
+    sha256Text(declarationBlob.body) !== claim.sha256
+  )
+    throw new Error("entity declaration blob must be exact");
+  let value: unknown;
+  try {
+    value = JSON.parse(declarationBlob.body);
+  } catch {
+    throw new Error("entity declaration blob must be JSON");
+  }
+  const entity =
+    event.type === "entity_content_observed"
+      ? decodeArtifactDescriptor(contract, value)
+      : parseEntityJsonSchema(contract.schema, value, `${contract.kind} declaration`);
+  if (!isRecord(entity) || entity[contract.id.field] !== event.payload.entityId)
+    throw new Error("entity declaration identity must match its event");
+  if (
+    event.type === "entity_content_observed" &&
+    (entity.source !== event.payload.sourceIdentity ||
+      entity.contentVersion !== event.payload.observedContentVersion ||
+      stableStringify(entity.locator) !== stableStringify(event.payload.locator))
+  )
+    throw new Error("entity observation fields must match its declaration descriptor");
+}
+
+/** Retained for generic-store callers; all current entity variants use the shared assertion above. */
+export function assertEntityUpsertInputs(
+  event: EntityEventV1,
+  plan: FrozenWritePlan | undefined,
+  blobs: readonly {
+    readonly sha256: string;
+    readonly size: number;
+    readonly mediaType: string;
+    readonly body: string;
+  }[],
+): void {
+  assertEntityEventInputs(event, plan, blobs);
+}
+
+export function assertEntityUpsertWritePlan(event: EntityEventV1, plan: FrozenWritePlan | undefined): void {
+  const expected =
+    event.type === "entity_target_missing"
+      ? entityTargetMissingWritePlan(event)
+      : event.type === "entity_content_observed"
+        ? entityContentObservedWritePlan(event)
+        : entityUpsertWritePlan(event);
+  assertExactWritePlan(plan, expected);
+}
+
+export function contractForDeclarationEvent(event: EntityDeclarationEventV1): EntityStoreKindContract {
+  return event.type === "entity_content_observed"
+    ? artifactEntityContractFromSnapshot(event.payload.artifactContract)
+    : requireEntityStoreKindContract(event.payload.entityKind);
+}
+
+function validateObservedPayload(
+  payload: Record<string, unknown>,
+  hasFields: typeof hasOnlyFields | typeof hasRequiredFields,
+  opId: string,
+): readonly string[] {
+  const fields = [
+    "entityKind",
+    "entityId",
+    "declarationDocumentClaim",
+    "locator",
+    "sourceIdentity",
+    "observedContentVersion",
+    "resolver",
+    "observationId",
+    "artifactContract",
+  ];
+  if (!hasFields(payload, fields)) return ["entity_content_observed payload is invalid"];
+  const common = validateArtifactPayload(payload);
+  if (common.length) return common;
+  if (typeof payload.observedContentVersion !== "string" || !payload.observedContentVersion)
+    return ["entity observed content version is invalid"];
+  if (!validObservationIdentity(payload, payload.observedContentVersion, opId))
+    return ["entity observed idempotency identity is invalid"];
+  let contract: EntityStoreKindContract;
+  try {
+    contract = artifactEntityContractFromSnapshot(payload.artifactContract);
+  } catch {
+    return ["entity artifact contract is invalid"];
+  }
+  return validateClaim(payload, contract);
+}
+
+function validateMissingPayload(
+  payload: Record<string, unknown>,
+  hasFields: typeof hasOnlyFields | typeof hasRequiredFields,
+  opId: string,
+): readonly string[] {
+  const fields = [
+    "entityKind",
+    "entityId",
+    "locator",
+    "sourceIdentity",
+    "resolver",
+    "observationId",
+    "reason",
+    "artifactContract",
+  ];
+  if (!hasFields(payload, fields)) return ["entity_target_missing payload is invalid"];
+  const common = validateArtifactPayload(payload);
+  if (common.length) return common;
+  if (typeof payload.reason !== "string" || !payload.reason) return ["entity target-missing reason is invalid"];
+  return validObservationIdentity(payload, `missing:${payload.reason}`, opId)
+    ? []
+    : ["entity missing idempotency identity is invalid"];
+}
+
+function validateArtifactPayload(payload: Record<string, unknown>): readonly string[] {
+  let contract: EntityStoreKindContract;
+  try {
+    contract = artifactEntityContractFromSnapshot(payload.artifactContract);
+  } catch {
+    return ["entity artifact contract is invalid"];
+  }
+  const locator = payload.locator,
+    snapshot = payload.artifactContract as ArtifactEntityContractSnapshot;
+  let expectedEntityId: string;
+  try {
+    expectedEntityId = deriveArtifactEntityId({
+      idPrefix: snapshot.idPrefix,
+      typeIdentity: contract.kind,
+      sourceIdentity: String(payload.sourceIdentity),
+    });
+    if (canonicalArtifactSourceIdentity(String(payload.sourceIdentity)) !== payload.sourceIdentity)
+      return ["entity artifact source identity is not canonical"];
+  } catch {
+    return ["entity artifact source identity is invalid"];
+  }
+  if (
+    payload.entityKind !== contract.kind ||
+    typeof payload.entityId !== "string" ||
+    typeof payload.sourceIdentity !== "string" ||
+    expectedEntityId !== payload.entityId ||
+    !isRecord(locator) ||
+    !(["repository-path", "url", "external-key"] as const).includes(locator.kind as never) ||
+    typeof locator.value !== "string" ||
+    typeof payload.resolver !== "string" ||
+    !payload.resolver ||
+    typeof payload.observationId !== "string" ||
+    !/^obs_[0-9a-f]{24}$/u.test(payload.observationId)
+  )
+    return ["entity artifact observation identity is invalid"];
+  try {
+    const canonical = canonicalArtifactLocator(locator as unknown as ArtifactLocator);
+    if (canonical.value !== locator.value) return ["entity artifact locator is not canonical"];
+  } catch {
+    return ["entity artifact locator is invalid"];
+  }
+  return [];
+}
+
+function validateUpsertPayload(
+  schema: unknown,
+  payload: Record<string, unknown>,
+  hasFields: typeof hasOnlyFields | typeof hasRequiredFields,
+): readonly string[] {
+  if (!hasFields(payload, ["entityKind", "entityId", "declarationDocumentClaim"]))
+    return ["entity upsert payload is invalid"];
+  let contract: EntityStoreKindContract;
+  try {
+    contract = requireEntityStoreKindContract(String(payload.entityKind));
+  } catch {
+    return ["entity event kind is not registered"];
+  }
+  if (typeof payload.entityId !== "string" || !new RegExp(contract.id.pattern, "u").test(payload.entityId))
+    return ["entity event kind and identity are invalid"];
+  return validateClaim(payload, contract, schema);
+}
+
+function validObservationIdentity(payload: Record<string, unknown>, resolution: string, opId: string): boolean {
+  const locator = payload.locator as unknown as ArtifactLocator,
+    expected = artifactObservationId({ entityId: String(payload.entityId), locator, resolution }),
+    expectedOperation = artifactImportOperationId({ entityId: String(payload.entityId), locator, resolution });
+  return payload.observationId === expected && opId === expectedOperation;
+}
+
+function validateClaim(
+  payload: Record<string, unknown>,
+  contract: EntityStoreKindContract,
+  schema: unknown = "entity-event/v1",
+): readonly string[] {
+  const claim = payload.declarationDocumentClaim;
+  if (
+    !isRecord(claim) ||
+    !hasOnlyFields(claim, ["path", "sha256", "size", "mediaType", "policyId"]) ||
+    claim.path !== entityDocumentPath(contract, String(payload.entityId)) ||
+    !/^[0-9a-f]{64}$/u.test(String(claim.sha256)) ||
+    !Number.isSafeInteger(claim.size) ||
+    Number(claim.size) < 0 ||
+    claim.mediaType !== contract.entityStore.document.mediaType ||
+    !acceptedPolicyIds(schema).includes(String(claim.policyId))
+  )
+    return ["entity declaration claim is invalid"];
+  return [];
+}
+
+function declarationContent(contract: EntityStoreKindContract, entityId: string, entity: unknown) {
+  const body = serializeEntityJsonSchema(contract.schema, entity, `${contract.kind} declaration`),
+    claim: EntityDeclarationClaim = {
+      path: normalizeRelativeDocumentPath(entityDocumentPath(contract, entityId)),
+      sha256: sha256Text(body),
+      size: Buffer.byteLength(body),
+      mediaType: contract.entityStore.document.mediaType,
+      policyId: contract.entityStore.document.policyId,
+    };
+  return { body, claim };
+}
+
+function declarationWritePlan<Command extends "EntityUpsert" | "EntityContentObserved">(
+  commandType: Command,
+  event: EntityDeclarationEventV1,
+  projection: string,
+): FrozenWritePlan<Command> {
   const claim = event.payload.declarationDocumentClaim,
     targets: WriteTarget[] = [
       { kind: "event_file", path: eventObjectTarget(event.opId), operation: "create" },
@@ -177,44 +545,48 @@ export function entityUpsertWritePlan(event: EntityEventV1): FrozenWritePlan<"En
         size: claim.size,
         mediaType: claim.mediaType,
       },
-      { kind: "projection_invalidation", projection: "document/v1", key: claim.path },
+      { kind: "projection_invalidation", projection, key: claim.path },
       { kind: "content_blob", sha256: claim.sha256, size: claim.size, mediaType: claim.mediaType },
     ];
-  return freezeDeclaredWritePlan({ commandType: "EntityUpsert", targets }, ["EntityUpsert"]);
-}
-export function assertEntityUpsertInputs(
-  event: EntityEventV1,
-  plan: FrozenWritePlan<"EntityUpsert"> | undefined,
-  blobs: readonly {
-    readonly sha256: string;
-    readonly size: number;
-    readonly mediaType: string;
-    readonly body: string;
-  }[],
-): asserts plan is FrozenWritePlan<"EntityUpsert"> {
-  assertEntityUpsertWritePlan(event, plan);
-  const claim = event.payload.declarationDocumentClaim,
-    blob = blobs.find((candidate) => candidate.sha256 === claim.sha256),
-    contract = requireEntityStoreKindContract(event.payload.entityKind);
-  if (!blob || blob.size !== claim.size || blob.mediaType !== claim.mediaType || sha256Text(blob.body) !== claim.sha256)
-    throw new Error("entity upsert declaration blob must be exact");
-  let value: unknown;
-  try {
-    value = JSON.parse(blob.body);
-  } catch {
-    throw new Error("entity upsert declaration blob must be JSON");
-  }
-  const entity = parseEntityJsonSchema(contract.schema, value, `${contract.kind} declaration`);
-  if (!isRecord(entity) || entity[contract.id.field] !== event.payload.entityId)
-    throw new Error("entity upsert declaration identity must match its event");
+  return freezeDeclaredWritePlan({ commandType, targets }, [commandType]);
 }
 
-export function assertEntityUpsertWritePlan(
-  event: EntityEventV1,
-  plan: FrozenWritePlan<"EntityUpsert"> | undefined,
-): asserts plan is FrozenWritePlan<"EntityUpsert"> {
-  const shape = (value: FrozenWritePlan<"EntityUpsert">) =>
+function assertExactWritePlan(plan: FrozenWritePlan | undefined, expected: FrozenWritePlan): void {
+  const shape = (value: FrozenWritePlan) =>
     stableStringify({ commandType: value.commandType, targets: value.targets.map(stableStringify).sort() });
-  if (plan === undefined || !isFrozenWritePlan(plan) || shape(plan) !== shape(entityUpsertWritePlan(event)))
-    throw new Error("entity upsert plan must exactly declare event, declaration, projection, and content targets");
+  if (plan === undefined || !isFrozenWritePlan(plan) || shape(plan) !== shape(expected))
+    throw new Error("entity write plan must exactly declare its event, declaration, projection, and content targets");
+}
+
+function eventEnvelope(input: EntityEventEnvelopeInput) {
+  return {
+    schema: "entity-event/v1" as const,
+    eventId: input.eventId,
+    workspaceRevision: input.workspaceRevision,
+    opId: input.opId,
+    actor: input.actor,
+    source: input.source,
+    occurredAt: input.occurredAt,
+  };
+}
+
+function blob(claim: EntityDeclarationClaim, body: string): EntityDeclarationBlob {
+  return { sha256: claim.sha256, size: claim.size, mediaType: claim.mediaType, body };
+}
+
+function assertValidCurrent(event: EntityEventV1): void {
+  const errors = validateCurrentEntityEvent(event);
+  if (errors.length) throw new Error(errors.join("; "));
+}
+
+function acceptedPolicyIds(schema: unknown): readonly string[] {
+  return schema === "agent-entity-event/v1"
+    ? [ENTITY_DOCUMENT_POLICY_ID, LEGACY_AGENT_ENTITY_POLICY_ID]
+    : [ENTITY_DOCUMENT_POLICY_ID];
+}
+
+function isEntityEventEnvelope(schema: unknown, type: unknown): boolean {
+  return entityEventEnvelopes.some(
+    ([registeredSchema, registeredType]) => registeredSchema === schema && registeredType === type,
+  );
 }

--- a/packages/kernel/src/domain/entity-event.ts
+++ b/packages/kernel/src/domain/entity-event.ts
@@ -486,7 +486,7 @@ function validateUpsertPayload(
   }
   if (typeof payload.entityId !== "string" || !new RegExp(contract.id.pattern, "u").test(payload.entityId))
     return ["entity event kind and identity are invalid"];
-  return validateClaim(payload, contract, schema);
+  return validateClaim(payload, contract, hasFields, schema);
 }
 
 function validObservationIdentity(payload: Record<string, unknown>, resolution: string, opId: string): boolean {
@@ -499,12 +499,13 @@ function validObservationIdentity(payload: Record<string, unknown>, resolution: 
 function validateClaim(
   payload: Record<string, unknown>,
   contract: EntityStoreKindContract,
+  hasFields: typeof hasOnlyFields | typeof hasRequiredFields = hasOnlyFields,
   schema: unknown = "entity-event/v1",
 ): readonly string[] {
   const claim = payload.declarationDocumentClaim;
   if (
     !isRecord(claim) ||
-    !hasOnlyFields(claim, ["path", "sha256", "size", "mediaType", "policyId"]) ||
+    !hasFields(claim, ["path", "sha256", "size", "mediaType", "policyId"]) ||
     claim.path !== entityDocumentPath(contract, String(payload.entityId)) ||
     !/^[0-9a-f]{64}$/u.test(String(claim.sha256)) ||
     !Number.isSafeInteger(claim.size) ||

--- a/packages/kernel/src/domain/entity-kind-registry.ts
+++ b/packages/kernel/src/domain/entity-kind-registry.ts
@@ -366,6 +366,80 @@ export const genericAuthoring = Object.freeze({
 export const genericEntityStore = (pathTemplate: string, validate?: (value: unknown) => readonly string[]) =>
   Object.freeze({ document: declarationDocument(pathTemplate), ...(validate ? { validate } : {}) });
 
+export const artifactEntityImportActionInput: EntityActionInputContract = Object.freeze({
+  schema: "entity-action-input/v1" as const,
+  fields: Object.freeze([
+    { field: "entityKind", type: "string" as const, required: true },
+    { field: "locator", type: "string" as const, required: true },
+    { field: "expectedVersion", type: "number" as const, required: true },
+    { field: "title", type: "string" as const, required: false },
+    { field: "entityId", type: "string" as const, required: false },
+    { field: "sourceIdentity", type: "string" as const, required: false },
+    { field: "idempotencyKey", type: "string" as const, required: false },
+    { field: "dryRun", type: "boolean" as const, required: false },
+  ]),
+  exactlyOneOf: Object.freeze([]),
+});
+
+export function artifactEntityActionCatalog(
+  kind: string,
+  identity: EntityKindContract["id"],
+): NonNullable<EntityKindContract["actionCatalog"]> {
+  const declared = entityAction(
+    kind,
+    identity,
+    "import",
+    noSdkExposure,
+    Object.freeze({
+      ingress: "entity-import",
+      compile: null,
+      read: false,
+      implementation: "catalog-runtime" as const,
+      topology: "center-forward-write" as const,
+      targetIdField: "entityId",
+    }),
+  );
+  return Object.freeze({
+    ref: "kernel/entity-event/v1",
+    actions: Object.freeze([
+      Object.freeze({
+        ...declared,
+        input: artifactEntityImportActionInput,
+        criteria: Object.freeze([
+          Object.freeze({
+            ref: "entity/aggregate-revision",
+            failureCode: "revision_conflict",
+            explain: "The expected Entity revision must equal the latest canonical observation revision.",
+          }),
+          Object.freeze({
+            ref: "entity/source-resolution",
+            failureCode: "source_resolution_failed",
+            explain:
+              "The declared resolver must return either authoritative content or an authoritative missing result.",
+          }),
+        ]),
+        concurrency: Object.freeze({
+          expectedVersion: Object.freeze({ authority: "entity-aggregate-revision", required: true }),
+          leasePolicy: Object.freeze({ authority: "center-repo-cell-single-writer" }),
+          occurrenceClaim: Object.freeze({ authority: "entity-observation-id" }),
+          idempotency: Object.freeze({ authority: "entity-source-resolution-operation-id" }),
+          artifactOwnership: Object.freeze({
+            owner: "entity-revision",
+            refTemplate: "entity/{entityId}/revision/{revision}",
+          }),
+        }),
+        effects: Object.freeze([
+          Object.freeze({ ref: "entity-event/entity_content_observed", projection: "entity/v1" }),
+          Object.freeze({ ref: "entity-event/entity_target_missing", projection: "entity/v1" }),
+        ]),
+        explain:
+          `${kind}.import resolves one artifact source and appends entity-event/v1 under the ` +
+          "entity aggregate revision fence; dry-run performs no write.",
+      }),
+    ]),
+  });
+}
+
 const taskExposure = capabilityExposure("task", "task-frontmatter");
 const factExposure = capabilityExposure("fact", "fact-event");
 const decisionExposure = capabilityExposure("decision", "decision-package");

--- a/packages/kernel/src/domain/entity-kind-registry.ts
+++ b/packages/kernel/src/domain/entity-kind-registry.ts
@@ -366,7 +366,7 @@ export const genericAuthoring = Object.freeze({
 export const genericEntityStore = (pathTemplate: string, validate?: (value: unknown) => readonly string[]) =>
   Object.freeze({ document: declarationDocument(pathTemplate), ...(validate ? { validate } : {}) });
 
-export const artifactEntityImportActionInput: EntityActionInputContract = Object.freeze({
+export const artifactEntityImportActionInput = Object.freeze({
   schema: "entity-action-input/v1" as const,
   fields: Object.freeze([
     { field: "entityKind", type: "string" as const, required: true },
@@ -379,7 +379,7 @@ export const artifactEntityImportActionInput: EntityActionInputContract = Object
     { field: "dryRun", type: "boolean" as const, required: false },
   ]),
   exactlyOneOf: Object.freeze([]),
-});
+} as const satisfies EntityActionInputContract);
 
 export function artifactEntityActionCatalog(
   kind: string,

--- a/packages/kernel/src/domain/index.ts
+++ b/packages/kernel/src/domain/index.ts
@@ -148,13 +148,20 @@ export type { ContractVersion } from "./contract-version.ts";
 export { normalizePersistedTimestamp, timestamp } from "./timestamp.ts";
 
 export {
+  artifactEntityActionCatalog,
+  artifactEntityImportActionInput,
   getExecutableEntityAction,
   getEntityKindContract,
   getTaskActionForTransition,
   requireEntityKindContract,
   requireEntityStoreKindContract,
 } from "./entity-kind-registry.ts";
-export type { EntityActionContract, EntityResidencyFacets } from "./entity-kind-registry.ts";
+export type {
+  EntityActionContract,
+  EntityKindContract,
+  EntityResidencyFacets,
+  EntityStoreKindContract,
+} from "./entity-kind-registry.ts";
 
 export { deriveUseCaseProjectionInputs } from "./use-case-projection-catalog.ts";
 export type { UseCaseProjectionName } from "./use-case-projection-catalog.ts";
@@ -162,7 +169,7 @@ export type { UseCaseProjectionName } from "./use-case-projection-catalog.ts";
 export { projectBaseEntityAtCut, requireEntityTypeContract } from "./base-entity.ts";
 export type { BaseEntity } from "./base-entity.ts";
 export { compileVerticalContract } from "./vertical-contract.ts";
-export type { CompiledVerticalContract } from "./vertical-contract.ts";
+export type { CompiledArtifactKindContract, CompiledVerticalContract } from "./vertical-contract.ts";
 export type {
   EntityActionCriterionFailure,
   EntityActionCompileInput,
@@ -274,7 +281,49 @@ export type {
 } from "./agent-squad-schema.ts";
 export { EntitySchemaContractError } from "./entity-json-schema.ts";
 
-export { compileEntityUpsert, entityUpsertWritePlan, isEntityEvent } from "./entity-event.ts";
-export type { EntityEventV1, EntityUpsertBundle } from "./entity-event.ts";
+export {
+  assertEntityEventInputs,
+  compileEntityContentObserved,
+  compileEntityTargetMissing,
+  compileEntityUpsert,
+  contractForDeclarationEvent,
+  entityContentObservedWritePlan,
+  entityTargetMissingWritePlan,
+  entityUpsertWritePlan,
+  isEntityDeclarationEvent,
+  isEntityEvent,
+} from "./entity-event.ts";
+export type {
+  EntityContentObservedBundle,
+  EntityContentObservedEventV1,
+  EntityEventV1,
+  EntityTargetMissingBundle,
+  EntityTargetMissingEventV1,
+  EntityUpsertBundle,
+} from "./entity-event.ts";
+export {
+  ARTIFACT_DESCRIPTOR_FIELDS,
+  artifactDescriptorSchema,
+  artifactEntityContractFromSnapshot,
+  artifactEntityContractSnapshot,
+  artifactImportOperationId,
+  artifactObservationId,
+  canonicalArtifactLocator,
+  canonicalArtifactSourceIdentity,
+  canonicalArtifactUrl,
+  canonicalSourceIdentity,
+  decodeArtifactDescriptor,
+  deriveArtifactContentVersion,
+  deriveArtifactEntityId,
+  encodeArtifactDescriptor,
+} from "./artifact-entity.ts";
+export type {
+  ArtifactContentWitness,
+  ArtifactDescriptor,
+  ArtifactEntityContractSnapshot,
+  ArtifactLocator,
+  ArtifactLocatorKind,
+  ArtifactSourceIdentityInput,
+} from "./artifact-entity.ts";
 export type { CiRunObservationEventV1 } from "./ci-run-observation-event.ts";
 export { ciRunObservationWritePlan, validateCurrentCiRunObservationEvent } from "./ci-run-observation-event.ts";

--- a/packages/kernel/src/domain/index.ts
+++ b/packages/kernel/src/domain/index.ts
@@ -148,20 +148,13 @@ export type { ContractVersion } from "./contract-version.ts";
 export { normalizePersistedTimestamp, timestamp } from "./timestamp.ts";
 
 export {
-  artifactEntityActionCatalog,
   artifactEntityImportActionInput,
   getExecutableEntityAction,
   getEntityKindContract,
   getTaskActionForTransition,
-  requireEntityKindContract,
   requireEntityStoreKindContract,
 } from "./entity-kind-registry.ts";
-export type {
-  EntityActionContract,
-  EntityKindContract,
-  EntityResidencyFacets,
-  EntityStoreKindContract,
-} from "./entity-kind-registry.ts";
+export type { EntityActionContract, EntityResidencyFacets, EntityStoreKindContract } from "./entity-kind-registry.ts";
 
 export { deriveUseCaseProjectionInputs } from "./use-case-projection-catalog.ts";
 export type { UseCaseProjectionName } from "./use-case-projection-catalog.ts";
@@ -282,47 +275,34 @@ export type {
 export { EntitySchemaContractError } from "./entity-json-schema.ts";
 
 export {
-  assertEntityEventInputs,
   compileEntityContentObserved,
   compileEntityTargetMissing,
   compileEntityUpsert,
   contractForDeclarationEvent,
-  entityContentObservedWritePlan,
-  entityTargetMissingWritePlan,
   entityUpsertWritePlan,
   isEntityDeclarationEvent,
   isEntityEvent,
 } from "./entity-event.ts";
 export type {
   EntityContentObservedBundle,
-  EntityContentObservedEventV1,
   EntityEventV1,
   EntityTargetMissingBundle,
-  EntityTargetMissingEventV1,
   EntityUpsertBundle,
 } from "./entity-event.ts";
 export {
-  ARTIFACT_DESCRIPTOR_FIELDS,
-  artifactDescriptorSchema,
-  artifactEntityContractFromSnapshot,
   artifactEntityContractSnapshot,
   artifactImportOperationId,
   artifactObservationId,
   canonicalArtifactLocator,
-  canonicalArtifactSourceIdentity,
-  canonicalArtifactUrl,
   canonicalSourceIdentity,
   decodeArtifactDescriptor,
   deriveArtifactContentVersion,
   deriveArtifactEntityId,
-  encodeArtifactDescriptor,
 } from "./artifact-entity.ts";
 export type {
   ArtifactContentWitness,
   ArtifactDescriptor,
-  ArtifactEntityContractSnapshot,
   ArtifactLocator,
-  ArtifactLocatorKind,
   ArtifactSourceIdentityInput,
 } from "./artifact-entity.ts";
 export type { CiRunObservationEventV1 } from "./ci-run-observation-event.ts";

--- a/packages/kernel/src/domain/vertical-contract.ts
+++ b/packages/kernel/src/domain/vertical-contract.ts
@@ -6,7 +6,7 @@ import {
   type VerticalDefinition,
 } from "../schemas/vertical-definition.ts";
 import { baseEntityTypeContract, entityTypeContracts, type EntityTypeContract } from "./base-entity.ts";
-import { artifactDescriptorSchema } from "./artifact-entity.ts";
+import { artifactDescriptorSchema, deepFreeze } from "./artifact-entity.ts";
 import {
   artifactEntityActionCatalog,
   entityKindContracts,
@@ -251,12 +251,4 @@ function assertUniqueValues(values: readonly string[], label: string): void {
 
 function duplicate(field: string, value: string): never {
   throw new VerticalContractError(`Duplicate artifact ${field}: ${value}.`);
-}
-
-function deepFreeze<T>(value: T): T {
-  if (value && typeof value === "object" && !Object.isFrozen(value)) {
-    for (const child of Object.values(value)) deepFreeze(child);
-    Object.freeze(value);
-  }
-  return value;
 }

--- a/packages/kernel/src/domain/vertical-contract.ts
+++ b/packages/kernel/src/domain/vertical-contract.ts
@@ -6,8 +6,9 @@ import {
   type VerticalDefinition,
 } from "../schemas/vertical-definition.ts";
 import { baseEntityTypeContract, entityTypeContracts, type EntityTypeContract } from "./base-entity.ts";
-import type { EntityDocumentJsonSchema } from "./entity-json-schema.ts";
+import { artifactDescriptorSchema } from "./artifact-entity.ts";
 import {
+  artifactEntityActionCatalog,
   entityKindContracts,
   genericAuthoring,
   genericEntityStore,
@@ -92,7 +93,7 @@ export function compileVerticalContract(source: unknown): CompiledVerticalContra
       ),
       entityKindContract: EntityKindContract = Object.freeze({
         ...entityTypeContract,
-        schema: descriptorSchema(artifact, typeIdentity),
+        schema: artifactDescriptorSchema(artifact, typeIdentity),
         relations: Object.freeze({ directions: Object.freeze([]), edges: Object.freeze([]) }),
         canonicalProjection: Object.freeze({
           embeddedEvents: Object.freeze([]),
@@ -105,7 +106,7 @@ export function compileVerticalContract(source: unknown): CompiledVerticalContra
               ]),
             }
           : {}),
-        actionCatalog: null,
+        actionCatalog: artifactEntityActionCatalog(typeIdentity, identity),
         entityStore: genericEntityStore(artifact.store.pathTemplate),
         authoring: genericAuthoring,
         sdkExposure: noSdkExposure,
@@ -240,37 +241,6 @@ function builtinIdPrefixes(): Set<string> {
     if (prefix) prefixes.add(prefix.toUpperCase());
   }
   return prefixes;
-}
-
-function descriptorSchema(artifact: ArtifactEntityKindDefinition, typeIdentity: string): EntityDocumentJsonSchema {
-  const properties: EntityDocumentJsonSchema["properties"] = {
-    schema: { type: "string", const: artifact.descriptorSchemaRef },
-    typeIdentity: { type: "string", const: typeIdentity },
-    entityId: { type: "string", pattern: `^${artifact.idPrefix}-[a-f0-9]{16}$` },
-    title: { type: "string", minLength: 1 },
-    locator: {
-      type: "object",
-      properties: {
-        kind: { type: "string", enum: artifact.locatorKinds },
-        value: { type: "string", minLength: 1 },
-      },
-      required: ["kind", "value"],
-      additionalProperties: false,
-    },
-    contentVersion: { type: "string", minLength: 1 },
-    source: { type: "string", minLength: 1 },
-    ...(artifact.maturityVocabulary
-      ? { maturity: { type: "string" as const, enum: artifact.maturityVocabulary } }
-      : {}),
-  };
-  return deepFreeze({
-    $schema: "https://json-schema.org/draft/2020-12/schema",
-    $id: `${artifact.descriptorSchemaRef}#${typeIdentity}`,
-    type: "object",
-    properties,
-    required: ["schema", "typeIdentity", "entityId", "title", "locator", "contentVersion", "source"],
-    additionalProperties: false,
-  });
 }
 
 function assertUniqueValues(values: readonly string[], label: string): void {

--- a/packages/kernel/src/projection/rebuildable-task-projection-entities.ts
+++ b/packages/kernel/src/projection/rebuildable-task-projection-entities.ts
@@ -99,7 +99,8 @@ export function advanceEntityProjectionRevision(
 ): void {
   runSql(
     db,
-    "UPDATE entity_projection SET workspace_revision = ? WHERE entity_kind = ? AND entity_id = ? AND workspace_revision <= ?",
+    "UPDATE entity_projection SET workspace_revision = ? " +
+      "WHERE entity_kind = ? AND entity_id = ? AND workspace_revision <= ?",
     workspaceRevision,
     entityKind,
     entityId,

--- a/packages/kernel/src/projection/rebuildable-task-projection-entities.ts
+++ b/packages/kernel/src/projection/rebuildable-task-projection-entities.ts
@@ -91,6 +91,22 @@ export function deleteEntityProjectionRow(db: DatabaseSync, entityKind: string, 
   runSql(db, "DELETE FROM entity_projection WHERE entity_kind = ? AND entity_id = ?", entityKind, entityId);
 }
 
+export function advanceEntityProjectionRevision(
+  db: DatabaseSync,
+  entityKind: string,
+  entityId: string,
+  workspaceRevision: number,
+): void {
+  runSql(
+    db,
+    "UPDATE entity_projection SET workspace_revision = ? WHERE entity_kind = ? AND entity_id = ? AND workspace_revision <= ?",
+    workspaceRevision,
+    entityKind,
+    entityId,
+    workspaceRevision,
+  );
+}
+
 function entityProjectionRow(row: Readonly<Record<string, unknown>>): EntityProjectionRow {
   const value = JSON.parse(String(row.value_json)) as unknown;
   if (typeof value !== "object" || value === null || Array.isArray(value))

--- a/packages/kernel/src/projection/rebuildable-task-projection-event-application.ts
+++ b/packages/kernel/src/projection/rebuildable-task-projection-event-application.ts
@@ -20,9 +20,8 @@ import {
   reduceRuntimeSession,
   runtimeSessionId,
 } from "../domain/agent-runtime.ts";
-import { isEntityEvent } from "../domain/entity-event.ts";
+import { contractForDeclarationEvent, isEntityDeclarationEvent, isEntityEvent } from "../domain/entity-event.ts";
 import { interpretEntityValue } from "../domain/entity-kind-projection.ts";
-import { requireEntityStoreKindContract } from "../domain/entity-kind-registry.ts";
 import { isTaskBootstrapEvent, taskBootstrapPackagePath } from "../domain/task-bootstrap-event.ts";
 import { isTaskProgressEvent } from "../domain/task-progress-event.ts";
 import { isPresetSnapshotUpgradeEvent } from "../domain/preset-snapshot-upgrade-event.ts";
@@ -41,6 +40,7 @@ import { projectMigration } from "./rebuildable-task-projection-migration.ts";
 import { projectDecision, projectFact, projectProgress } from "./rebuildable-task-projection-write-model.ts";
 import { applyTaskEvent } from "./rebuildable-task-projection-task-events.ts";
 import {
+  advanceEntityProjectionRevision,
   deleteEntityProjectionRow,
   projectEmbeddedCanonicalEntities,
   projectInterpretedEntityValue,
@@ -131,6 +131,17 @@ export function applyEvent(
     return;
   }
   if (isEntityEvent(event)) {
+    if (!isEntityDeclarationEvent(event)) {
+      runSql(
+        db,
+        "INSERT INTO event_index(op_id, workspace_revision, task_id, event_json) VALUES (?, ?, NULL, ?)",
+        event.opId,
+        event.workspaceRevision,
+        eventJson,
+      );
+      advanceEntityProjectionRevision(db, event.payload.entityKind, event.payload.entityId, event.workspaceRevision);
+      return;
+    }
     const claim = event.payload.declarationDocumentClaim,
       bytes = readBlob(claim.sha256);
     if (!bytes || bytes.byteLength !== claim.size)
@@ -148,7 +159,7 @@ export function applyEvent(
     } catch {
       throw new Error(`entity declaration blob ${claim.sha256} is not JSON`);
     }
-    const contract = requireEntityStoreKindContract(event.payload.entityKind),
+    const contract = contractForDeclarationEvent(event),
       entity = interpretEntityValue(contract, value),
       contractErrors = contract.entityStore.validate?.(entity.value) ?? [];
     if (contractErrors.length) throw new Error(contractErrors.join("; "));

--- a/packages/kernel/src/store/entity-store.ts
+++ b/packages/kernel/src/store/entity-store.ts
@@ -1,12 +1,14 @@
 import type { HarnessLayoutInput } from "../layout/index.ts";
 import {
   compileEntityUpsert,
+  contractForDeclarationEvent,
+  isEntityDeclarationEvent,
   isEntityEvent,
   type EntityUpsertBundle,
   type StoredEntityEventV1,
 } from "../domain/entity-event.ts";
 import { interpretEntityValue } from "../domain/entity-kind-projection.ts";
-import { requireEntityStoreKindContract } from "../domain/entity-kind-registry.ts";
+import { requireEntityStoreKindContract, type EntityStoreKindContract } from "../domain/entity-kind-registry.ts";
 import { sha256Text } from "../integrity/stable-hash.ts";
 import { resolveLedgerGitLayout } from "./ledger-git-layout.ts";
 import { publicationRefs } from "./task-event-store-git-refs.ts";
@@ -29,17 +31,41 @@ export interface EntityStore {
 
 type EntityEventSource = Pick<CanonicalEventStore, "read" | "readContentBlob">;
 
-export function createEntityStore(source: EntityEventSource): EntityStore {
+export function createEntityStore(
+  source: EntityEventSource,
+  dynamicContracts: readonly EntityStoreKindContract[] = [],
+): EntityStore {
+  const contractForKind = (kind: string): EntityStoreKindContract => {
+    const dynamic = dynamicContracts.find((candidate) => candidate.kind === kind);
+    if (dynamic) return dynamic;
+    try {
+      return requireEntityStoreKindContract(kind);
+    } catch (error) {
+      const declaration = source
+        .read()
+        .events.find(
+          (event) =>
+            isEntityEvent(event) &&
+            isEntityDeclarationEvent(event) &&
+            event.payload.entityKind === kind &&
+            event.type === "entity_content_observed",
+        );
+      if (declaration && declaration.type === "entity_content_observed")
+        return contractForDeclarationEvent(declaration);
+      throw error;
+    }
+  };
   const latestEvents = (kind: string): ReadonlyMap<string, StoredEntityEventV1> => {
-    const contract = requireEntityStoreKindContract(kind),
+    const contract = contractForKind(kind),
       latest = new Map<string, StoredEntityEventV1>();
     for (const event of source.read().events) {
-      if (isEntityEvent(event) && event.payload.entityKind === contract.kind) latest.set(event.payload.entityId, event);
+      if (isEntityEvent(event) && isEntityDeclarationEvent(event) && event.payload.entityKind === contract.kind)
+        latest.set(event.payload.entityId, event);
     }
     return latest;
   };
   const records = (kind: string): readonly StoredEntity[] => {
-    const contract = requireEntityStoreKindContract(kind);
+    const contract = contractForKind(kind);
     return [...latestEvents(kind).values()]
       .map((event) => entityEventRecord(event, source, contract))
       .sort((left, right) => left.id.localeCompare(right.id));
@@ -47,7 +73,7 @@ export function createEntityStore(source: EntityEventSource): EntityStore {
   return {
     upsert: compileEntityUpsert,
     get: <T>(kind: string, id: string) => {
-      const contract = requireEntityStoreKindContract(kind),
+      const contract = contractForKind(kind),
         event = latestEvents(kind).get(id);
       return event === undefined ? null : (entityEventRecord(event, source, contract) as StoredEntity<T>);
     },
@@ -74,6 +100,7 @@ function entityEventRecord(
   source: EntityEventSource,
   contract: ReturnType<typeof requireEntityStoreKindContract>,
 ): StoredEntity {
+  if (!isEntityDeclarationEvent(event)) throw new Error("entity target-missing event has no declaration document");
   const claim = event.payload.declarationDocumentClaim,
     bytes = source.readContentBlob(claim.sha256);
   if (!bytes || bytes.byteLength !== claim.size)
@@ -91,7 +118,9 @@ function entityEventRecord(
   } catch {
     throw new Error(`entity declaration blob ${claim.sha256} is not JSON`);
   }
-  const entity = interpretEntityValue(contract, decoded),
+  const eventContract = contractForDeclarationEvent(event);
+  if (eventContract.kind !== contract.kind) throw new Error("entity declaration contract kind mismatch");
+  const entity = interpretEntityValue(eventContract, decoded),
     contractErrors = contract.entityStore.validate?.(entity.value) ?? [];
   if (contractErrors.length) throw new Error(contractErrors.join("; "));
   if (entity.id !== event.payload.entityId)

--- a/packages/kernel/src/store/task-event-store-claims-layout.ts
+++ b/packages/kernel/src/store/task-event-store-claims-layout.ts
@@ -1,5 +1,5 @@
 import { isAgentRuntimeEvent, runtimeEventContentClaims } from "../domain/agent-runtime.ts";
-import { isEntityEvent } from "../domain/entity-event.ts";
+import { isEntityDeclarationEvent, isEntityEvent } from "../domain/entity-event.ts";
 import { isScheduleEvent } from "../domain/schedule-event.ts";
 import { isSettingsEvent } from "../domain/settings-event.ts";
 import { isPeopleEvent } from "../domain/people-event.ts";
@@ -37,7 +37,7 @@ export function canonicalDocumentClaims(event: PersistedCanonicalEventV1): reado
   readonly size: number;
   readonly mediaType: string;
 }[] {
-  if (isEntityEvent(event)) return [event.payload.declarationDocumentClaim];
+  if (isEntityEvent(event)) return isEntityDeclarationEvent(event) ? [event.payload.declarationDocumentClaim] : [];
   if (isScheduleEvent(event))
     return "declarationDocumentClaim" in event.payload ? [event.payload.declarationDocumentClaim] : [];
   if (isSettingsEvent(event)) return [event.payload.harnessDocumentClaim];
@@ -98,7 +98,9 @@ export function contentClaims(event: CanonicalEventV1): readonly {
   const claims = isDocEvent(event)
     ? event.payload.changes.flatMap((change) => (change.candidate === null ? [] : [change.candidate]))
     : isEntityEvent(event)
-      ? [event.payload.declarationDocumentClaim]
+      ? isEntityDeclarationEvent(event)
+        ? [event.payload.declarationDocumentClaim]
+        : []
       : isTaskEvent(event)
         ? [
             ...(event.payload.documentClaims ?? []),

--- a/packages/kernel/src/store/task-event-store-validation.ts
+++ b/packages/kernel/src/store/task-event-store-validation.ts
@@ -1,4 +1,4 @@
-import { assertEntityUpsertInputs, isEntityEvent } from "../domain/entity-event.ts";
+import { assertEntityEventInputs, isEntityEvent } from "../domain/entity-event.ts";
 import {
   assertDocSyncWritePlan,
   isDecisionEvent,
@@ -68,11 +68,11 @@ export function assertBundle(bundle: CanonicalEventWriteBundle): void {
     );
   if (isEntityEvent(event))
     try {
-      assertEntityUpsertInputs(event, plan as FrozenWritePlan<"EntityUpsert">, blobs);
+      assertEntityEventInputs(event, plan, blobs);
     } catch {
       throw new TaskEventStoreError(
         "invalid_write_plan",
-        "entity upsert must carry a schema-valid declaration and exact write plan",
+        "entity event must carry schema-valid evidence and an exact write plan",
       );
     }
   if (isScheduleEvent(event))

--- a/packages/kernel/test/contracts/artifact-entity.test.ts
+++ b/packages/kernel/test/contracts/artifact-entity.test.ts
@@ -1,0 +1,215 @@
+// harness-test-tier: contract
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import {
+  artifactEntityContractSnapshot,
+  artifactImportOperationId,
+  artifactObservationId,
+  assertEntityEventInputs,
+  canonicalArtifactUrl,
+  canonicalSourceIdentity,
+  compileEntityContentObserved,
+  compileEntityTargetMissing,
+  compileVerticalContract,
+  createEntityStore,
+  decodeArtifactDescriptor,
+  deriveArtifactContentVersion,
+  deriveArtifactEntityId,
+  encodeArtifactDescriptor,
+  type ArtifactDescriptor,
+  type EntityStoreKindContract,
+} from "../../src/index.ts";
+
+const vertical = JSON.parse(
+  readFileSync(new URL("../../fixtures/schemas/vertical-definition/valid.json", import.meta.url), "utf8"),
+) as Record<string, unknown> & { entityKinds: unknown[]; projectionSchemas: unknown[] };
+const actor = { principal: { personId: "person-artifact" }, executor: null } as const;
+
+test("Artifact descriptor codec is seven-field exact and repository paths use the portable path contract", () => {
+  const artifact = compiledArtifact(1),
+    source = canonicalSourceIdentity({
+      kind: "repository-path",
+      repositoryId: "canonical",
+      path: "docs/adr-0001.md",
+    }),
+    descriptor = makeDescriptor(artifact, source);
+  assert.deepEqual(Object.keys(decodeArtifactDescriptor(artifact.entityKindContract, descriptor)), [
+    "schema",
+    "typeIdentity",
+    "entityId",
+    "title",
+    "locator",
+    "contentVersion",
+    "source",
+  ]);
+  assert.equal(
+    JSON.parse(encodeArtifactDescriptor(artifact.entityKindContract, descriptor)).entityId,
+    descriptor.entityId,
+  );
+  for (const unknown of ["body", "summary", "attachments", "embedding", "freshness"])
+    assert.throws(
+      () => decodeArtifactDescriptor(artifact.entityKindContract, { ...descriptor, [unknown]: "forbidden" }),
+      /unknown; remove it/u,
+    );
+  for (const value of ["/absolute.md", "../outside.md", "docs\\windows.md"])
+    assert.throws(
+      () =>
+        decodeArtifactDescriptor(artifact.entityKindContract, {
+          ...descriptor,
+          locator: { kind: "repository-path", value },
+        }),
+      /path|relative|backslash|absolute/iu,
+    );
+});
+
+test("source-derived identity is stable across content and relink, while schema identity changes it", () => {
+  const v1 = compiledArtifact(1),
+    v2 = compiledArtifact(2, "ADR2"),
+    source = canonicalSourceIdentity({ kind: "repository-path", repositoryId: "canonical", path: "docs/adr.md" }),
+    idV1 = deriveArtifactEntityId({ idPrefix: "ADR", typeIdentity: v1.typeIdentity, sourceIdentity: source }),
+    changedContentVersion = deriveArtifactContentVersion({ kind: "content", content: "changed\r\nbody\r\n" }),
+    normalizedContentVersion = deriveArtifactContentVersion({ kind: "content", content: "changed\nbody\n" });
+  assert.equal(changedContentVersion, normalizedContentVersion);
+  assert.notEqual(changedContentVersion, deriveArtifactContentVersion({ kind: "content", content: "original" }));
+  assert.equal(
+    idV1,
+    deriveArtifactEntityId({ idPrefix: "ADR", typeIdentity: v1.typeIdentity, sourceIdentity: source }),
+  );
+  assert.notEqual(
+    idV1,
+    deriveArtifactEntityId({ idPrefix: "ADR2", typeIdentity: v2.typeIdentity, sourceIdentity: source }),
+  );
+  assert.equal(
+    idV1.slice("ADR-".length),
+    deriveArtifactEntityId({ idPrefix: "ALT", typeIdentity: v2.typeIdentity, sourceIdentity: source }).slice(
+      "ALT-".length,
+    ),
+    "the digest is exactly sha256(canonicalSourceIdentity), independent of type and edge",
+  );
+  const relinked = makeDescriptor(v1, source, { locator: { kind: "repository-path", value: "docs/moved/adr.md" } });
+  assert.equal(decodeArtifactDescriptor(v1.entityKindContract, relinked).entityId, idV1);
+  assert.equal(canonicalArtifactUrl("HTTPS://Example.COM:443/a?z=2&a=1#fragment"), "https://example.com/a?a=1&z=2");
+});
+
+test("observed and missing artifact events are self-validating generic entity events", () => {
+  const artifact = compiledArtifact(1),
+    source = canonicalSourceIdentity({ kind: "repository-path", repositoryId: "canonical", path: "docs/adr.md" }),
+    descriptor = makeDescriptor(artifact, source),
+    snapshot = artifactEntityContractSnapshot(artifact);
+  const compiledObserved = compileObservedWithDerivedIds(artifact, descriptor);
+  assert.equal(compiledObserved.event.type, "entity_content_observed");
+  assert.doesNotThrow(() =>
+    assertEntityEventInputs(compiledObserved.event, compiledObserved.plan, compiledObserved.blobs),
+  );
+  const rebuiltStore = createEntityStore({
+    read: () => ({ schema: "canonical-event-stream/v1", revision: 1, events: [compiledObserved.event] }),
+    readContentBlob: (sha256) =>
+      sha256 === compiledObserved.blobs[0].sha256 ? Buffer.from(compiledObserved.blobs[0].body) : null,
+  });
+  assert.equal(
+    rebuiltStore.get<ArtifactDescriptor>(artifact.typeIdentity, descriptor.entityId)?.value.contentVersion,
+    descriptor.contentVersion,
+    "the generic store must rebuild a compiled kind from the event snapshot without a kind-specific store",
+  );
+  assert.throws(() =>
+    assertEntityEventInputs(compiledObserved.event, compiledObserved.plan, [
+      { ...compiledObserved.blobs[0], body: `${compiledObserved.blobs[0].body} ` },
+    ]),
+  );
+
+  const missingResolution = "missing:ENOENT",
+    locator = descriptor.locator,
+    ids = observationIds(descriptor.entityId, locator, missingResolution),
+    missing = compileEntityTargetMissing({
+      contractSnapshot: snapshot,
+      entityId: descriptor.entityId,
+      locator,
+      sourceIdentity: source,
+      resolver: "repository:canonical",
+      observationId: ids.observationId,
+      reason: "ENOENT",
+      eventId: `event-${ids.observationId}`,
+      opId: ids.opId,
+      workspaceRevision: 2,
+      actor,
+      source: "local",
+      occurredAt: "2026-09-02T00:01:00.000Z",
+    });
+  assert.equal(missing.event.type, "entity_target_missing");
+  assert.doesNotThrow(() => assertEntityEventInputs(missing.event, missing.plan, missing.blobs));
+  assert.equal(
+    missing.plan.targets.some(({ kind }) => kind === "authored_file"),
+    false,
+  );
+});
+
+function compiledArtifact(version: number, idPrefix = "ADR") {
+  return compileVerticalContract({
+    ...vertical,
+    id: "custom/engineering",
+    entityKinds: [
+      ...vertical.entityKinds,
+      {
+        id: "architecture-decision-record",
+        entityType: "artifact",
+        version,
+        idPrefix,
+        display: { singular: "ADR", plural: "ADRs" },
+        descriptorSchemaRef: "schema://artifact-descriptor",
+        store: { pathTemplate: "entities/adrs/{id}.json" },
+        locatorKinds: ["repository-path", "url", "external-key"],
+        relations: [],
+      },
+    ],
+    projectionSchemas: [
+      ...vertical.projectionSchemas,
+      { id: "artifact-descriptor", schemaRef: "schema://artifact-descriptor" },
+    ],
+  }).artifactKinds[0]!;
+}
+
+function makeDescriptor(
+  artifact: ReturnType<typeof compiledArtifact>,
+  source: string,
+  overrides: Partial<ArtifactDescriptor> = {},
+): ArtifactDescriptor {
+  return {
+    schema: "schema://artifact-descriptor",
+    typeIdentity: artifact.typeIdentity,
+    entityId: deriveArtifactEntityId({
+      idPrefix: artifact.declaration.idPrefix,
+      typeIdentity: artifact.typeIdentity,
+      sourceIdentity: source,
+    }),
+    title: "ADR One",
+    locator: { kind: "repository-path", value: "docs/adr.md" },
+    contentVersion: deriveArtifactContentVersion({ kind: "content", content: "# ADR One\n" }),
+    source,
+    ...overrides,
+  };
+}
+
+function observationIds(entityId: string, locator: ArtifactDescriptor["locator"], resolution: string) {
+  return {
+    observationId: artifactObservationId({ entityId, locator, resolution }),
+    opId: artifactImportOperationId({ entityId, locator, resolution }),
+  };
+}
+
+function compileObservedWithDerivedIds(artifact: ReturnType<typeof compiledArtifact>, descriptor: ArtifactDescriptor) {
+  const ids = observationIds(descriptor.entityId, descriptor.locator, descriptor.contentVersion);
+  return compileEntityContentObserved({
+    contract: artifact.entityKindContract as EntityStoreKindContract,
+    contractSnapshot: artifactEntityContractSnapshot(artifact),
+    descriptor,
+    resolver: "repository:canonical",
+    observationId: ids.observationId,
+    eventId: `event-${ids.observationId}`,
+    opId: ids.opId,
+    workspaceRevision: 1,
+    actor,
+    source: "local",
+    occurredAt: "2026-09-02T00:00:00.000Z",
+  });
+}

--- a/packages/kernel/test/contracts/artifact-entity.test.ts
+++ b/packages/kernel/test/contracts/artifact-entity.test.ts
@@ -6,8 +6,6 @@ import {
   artifactEntityContractSnapshot,
   artifactImportOperationId,
   artifactObservationId,
-  assertEntityEventInputs,
-  canonicalArtifactUrl,
   canonicalSourceIdentity,
   compileEntityContentObserved,
   compileEntityTargetMissing,
@@ -16,10 +14,11 @@ import {
   decodeArtifactDescriptor,
   deriveArtifactContentVersion,
   deriveArtifactEntityId,
-  encodeArtifactDescriptor,
   type ArtifactDescriptor,
   type EntityStoreKindContract,
 } from "../../src/index.ts";
+import { canonicalArtifactUrl, encodeArtifactDescriptor } from "../../src/domain/artifact-entity.ts";
+import { assertEntityEventInputs } from "../../src/domain/entity-event.ts";
 
 const vertical = JSON.parse(
   readFileSync(new URL("../../fixtures/schemas/vertical-definition/valid.json", import.meta.url), "utf8"),

--- a/packages/kernel/test/contracts/authorization-port.test.ts
+++ b/packages/kernel/test/contracts/authorization-port.test.ts
@@ -42,7 +42,7 @@ function roleContext(role: string, roleActor = actor): AuthorizationContext {
 test("the default Policy covers the frozen durable inventory exactly once", () => {
   // 这个数字是有意手写的安全棘轮:durable inventory 就是授权面,它变大必须有人显式确认一次。
   // 从数组自算会退化成恒等式,任何新增 Action 都自动放行——那正是这条断言要防的事。
-  assert.equal(durablePolicyActions.length, 105);
+  assert.equal(durablePolicyActions.length, 106);
   // 其余两条是自洽不变量,不需要第二个硬编码数字:清单内无重复(三个角色分段互不重叠),
   // 且每个 durable Action 恰好被一条 rule 覆盖。
   assert.equal(new Set(durablePolicyActions).size, durablePolicyActions.length);

--- a/packages/kernel/test/contracts/vertical-contract.test.ts
+++ b/packages/kernel/test/contracts/vertical-contract.test.ts
@@ -35,7 +35,11 @@ test("artifact declarations compile to immutable BaseEntity and generic entity-s
     kind: "generic-entity-store",
     contractRef: "entity-event/v1",
   });
-  assert.equal(artifactContract.entityKindContract.actionCatalog, null);
+  assert.equal(artifactContract.entityKindContract.actionCatalog?.actions[0]?.id, "import");
+  assert.equal(
+    artifactContract.entityKindContract.actionCatalog?.actions[0]?.execution?.implementation,
+    "catalog-runtime",
+  );
   assert.deepEqual(Object.keys(artifactContract.entityKindContract.schema.properties), [
     "schema",
     "typeIdentity",


### PR DESCRIPTION
# English

## Summary

GovernedEntity W1-B (task_ffc1e79e): a generic artifact entity aggregate on top of the W1-A compiled
vertical contract, with one import action as the only write road.

- `packages/kernel/src/domain/artifact-entity.ts`: the seven-field descriptor codec
  (`schema` / `typeIdentity` / `entityId` / `title` / `locator` / `contentVersion` / `source`),
  unknown fields fail closed; no body, summary, attachment or embedding enters the descriptor.
- Identity is derived from the canonical source identity (`repo:<id>:<path>`, normalized URL, or
  `<provider>:<project>:<key>`) as `<idPrefix>-<sha256[0..15]>`; title, content hash and importing
  node do not participate. `contentVersion` is the stable witness of the source content version;
  content change updates the version, never the identity. Moving a file keeps the identity; a
  rename is an explicit relink of the locator.
- Generic `entity_content_observed` / `entity_target_missing` events with cold-rebuildable contract
  snapshots (`entity-event.ts`), projected through the existing generic entity store; no artifact
  kind gets its own store or event family.
- `packages/application/src/artifact-entity-service.ts`: revision fencing, idempotency, relink and a
  mutation-free dry run. Daemon execution + center forwarding + receipts + explain, and the thin
  `ha entity import --kind <typeIdentity> --locator ... --expected-version N [--dry-run]` route.

## Architectural Justification

- Mechanism sentence: an artifact whose identity is a function of its source, not of its title or
  content, can be re-imported, moved and re-versioned without ever forking into two entities; the
  single import action is where resolve, validate, derive and append happen together, so a scanner
  can only propose imports and never write descriptors or projections directly.
- Consumers: W1-D (freshness) reads the two events and the `contentVersion` projection; W1-E (ADR
  cutover) drives the import action.
- Second commit (worker, after CEO rebase): daemon protocol files stay inside the transport
  allowlist, the barrel exports only consumed symbols, one shared `deepFreeze`, lines under 120.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none

## Machine-Readable Declarations

Production-Delta: +1855/-189
Dependency-Change: none

### Optional Evidence Claims

None.

## Task And Scope

- Harness task task_ffc1e79eebc91ed377de7185b0 (GovernedEntity W1-B) under milestone root
  task_e91dd004d2a4e7a7c90a6fd40a; depends on W1-A (#2148, done). Branch
  `codex/ge-w1b-artifact-aggregate`. Fact F-397F23FD.

## Version Impact

- Version: no change. Publish impact: one new CLI route (`ha entity import`); existing routes unchanged.

## Governance Declaration

- Protected surface touched: no (`tools/` and `.github/` untouched). Authorizing task:
  task_ffc1e79eebc91ed377de7185b0. Break-glass: no.

## Verification

- Worker (Sol): TypeScript build; focused tests 39/39; isolated Ubuntu integration 1/1; targeted
  ESLint, file-complexity and line-budget checks.
- CEO after rebase onto bc7f9c0f5: typecheck 0; cli-structure, dead-export, duplicate-definition,
  W3 write-authority, bypass-write-boundary, G36, G0-5 ratchet all green.
- Overlap check: W1-C's exclusive files (`relation-direction.ts`, `entity-relation.ts`) untouched;
  the compiler edit in `vertical-contract.ts` swaps the descriptor schema / action catalog source
  without changing the `CompiledVerticalContract` shape (W1-C rebases on top by CEO ruling
  F-E96079E6).
- [ ] Full suites: GitHub CI is the authority.

## Review Evidence

- CEO semantic review against the W1-B plan's six goals (codec, identity, version, locator
  mutability, single write road with dry run, no specialized store): all present in the diff.

## Residual Risk

- Production delta +1854 is the generic aggregate mechanism (descriptor codec, event family,
  service, daemon action, CLI route); W1-E will delete the ADR-specific import path it replaces.
- The `references` relation vocabulary and the executable-vs-declared-only artifact ruling
  (task_acd06bb4) are not decided by this slice.

---

# 中文

## 概要

GovernedEntity W1-B(task_ffc1e79e):在 W1-A 编译合同之上的通用 artifact 实体聚合,唯一写路是一条 import action。

- 七字段描述符编解码,未知字段 fail closed;正文/摘要/附件/向量不进描述符。
- identity 由规范化 source identity 派生,标题、正文 hash、导入节点不参与;`contentVersion` 是来源版本见证,
  内容变化只换版本不换身份;移动文件不换身份,rename 走显式 relink。
- 通用 `entity_content_observed` / `entity_target_missing` 事件走既有 generic entity store,无专属 store 或事件族。
- `ha entity import --kind --locator --expected-version [--dry-run]` 在一个 action 内完成 resolve/validate/派生/append,
  dry-run 不写任何面。

## 架构辩护

- 机制句:身份是来源的函数而非标题或内容的函数,artifact 才能被重复导入、移动、换版本而永不分叉;单一 import action
  让扫描器只能提候选、不能直写描述符或投影。
- 消费方:W1-D(freshness)与 W1-E(ADR cutover)。

## 机读声明

`Production-Delta: +1855/-189`;无依赖变更。

## 治理声明

- 未触碰 protected surface;授权任务 task_ffc1e79eebc91ed377de7185b0;无 break-glass。

## 验证

- worker:build、定向 39/39、Ubuntu 隔离 1/1、ESLint/复杂度/行预算绿;CEO rebase 到 bc7f9c0f5 后 typecheck 0、七门绿;
  未触碰 W1-C 独占文件。完整权威 = GitHub CI。

## 残余风险

- +1854 为通用聚合机制,W1-E 删除被替代的 ADR 专属导入路径;`references` 词表与 executable/declared-only 裁决不在本切片。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xya5P7vnE4P29vXmHAkFhd
