### PR TITLE
fix(gui,daemon): stop misreporting daemon failures; declare domainTypes on relation-graph results

### DIFF
--- a/packages/daemon/src/client/local-daemon-target.ts
+++ b/packages/daemon/src/client/local-daemon-target.ts
@@ -79,8 +79,11 @@ export function resolveLocalDaemonTarget(input: {
         )
         .sort((left, right) => right.canonicalRoot.length - left.canonicalRoot.length)[0];
   if (!repo || repo.state !== "enabled")
-    throw new Error(
-      `workspace is not registered; run ha daemon repo register --repo-id <id> --root ${JSON.stringify(path.resolve(input.rootDir))}`,
+    throw Object.assign(
+      new Error(
+        `workspace is not registered; run ha daemon repo register --repo-id <id> --root ${JSON.stringify(path.resolve(input.rootDir))}`,
+      ),
+      { code: "workspace_not_registered" },
     );
   const socketPath = resolveLocalDaemonEndpoint({
     userRoot,

--- a/packages/daemon/src/protocol/daemon-protocol-schema-ids.ts
+++ b/packages/daemon/src/protocol/daemon-protocol-schema-ids.ts
@@ -55,6 +55,8 @@ export const DAEMON_AGENDA_SCHEMA = Object.freeze({
 export const DAEMON_RELATION_GRAPH_SCHEMA = Object.freeze({
     id: "daemon.relation-graph/v1",
     required: Object.freeze(["ok", "edges", "coverageRows", "factAnchors", "facts", "warnings"]),
+    // The fact facet carries the fact-type vocabulary; the other facets echo it empty.
+    optional: Object.freeze(["domainTypes"]),
     canonicalCut: Object.freeze(["status", "watermark", "sourceRevision"]),
   }),
   DAEMON_DECISION_LIST_SCHEMA = Object.freeze({

--- a/packages/daemon/src/protocol/daemon-protocol-validate-projections.ts
+++ b/packages/daemon/src/protocol/daemon-protocol-validate-projections.ts
@@ -147,7 +147,10 @@ export function validateDaemonRelationGraph(value: unknown): readonly string[] {
       ...(full && value.page !== undefined ? ["page"] : []),
       ...(full ? [] : ["facet"]),
     ];
-  const shapeError = recordShapeError(entityId, value, topFields);
+  const shapeError = recordShapeError(entityId, value, topFields, [
+    ...topFields,
+    ...DAEMON_RELATION_GRAPH_SCHEMA.optional,
+  ]);
   if (shapeError) return [shapeError];
   for (const [field, actual, valid, expectation] of [
     ["ok", value.ok, value.ok === true, "must be true"],

--- a/packages/daemon/test/json-rpc-protocol.test.ts
+++ b/packages/daemon/test/json-rpc-protocol.test.ts
@@ -250,6 +250,9 @@ test("relation graph contract accepts the materialized ledger row schema and rej
     { ok: true, ...cut, facet: "factAnchors", ...empty, factAnchors: payload.factAnchors, warnings: [] },
   ];
   for (const facet of facets) assert.deepEqual(validateDaemonRelationGraph(facet), [], String(facet.facet));
+  // Every facet echoes the fact-type vocabulary (empty outside `facts`); it is declared, not required.
+  for (const facet of facets) assert.deepEqual(validateDaemonRelationGraph({ ...facet, domainTypes: [] }), [], `${facet.facet}+domainTypes`);
+  assert.deepEqual(validateDaemonRelationGraph({ ...payload, domainTypes: ["lesson"] }), []);
   assertValidationDiagnostic(validateDaemonRelationGraph({ ...facets[0], facet: "unknown" }), /relation-graph:unknown/u, "facet");
   assertValidationDiagnostic(validateDaemonRelationGraph({ ...facets[1], extra: true }), /relation-graph:facts/u, "extra");
   assertValidationDiagnostic(validateDaemonRelationGraph({ ...facets[2], facts: facets[1]!.facts }), /relation-graph:coverageRows/u, "facts");

--- a/packages/gui/src/main/local-composition-root.ts
+++ b/packages/gui/src/main/local-composition-root.ts
@@ -16,6 +16,7 @@ import {
   daemonUserRoot,
   resolveLocalDaemonEndpoint,
 } from "../../../daemon/src/client/local-daemon-target.ts";
+import { defaultProjectionWaitMs } from "../../../daemon/src/projection-readiness-wait.ts";
 import { validateProjectPath } from "../api/local-api.ts";
 import { createGuiServiceBridgeForDaemon, type GuiServiceBridge, type ShippedGuiRoute } from "../api/service-bridge.ts";
 import { streamDaemonFacetAt } from "./agent-runtime-stream-client.ts";
@@ -78,15 +79,12 @@ export async function bootstrapLocalRepository(input: FirstRunBootstrapInput): P
         target,
         "daemon.repo.bootstrap",
         input as unknown as JsonObject,
+        CONNECT_TIMEOUT_MS,
         75_000,
       );
     return await invoke();
   } catch (error) {
-    return daemonProtocolError(
-      "init",
-      "daemon_unavailable",
-      attachOnlyHint(`Repository setup failed. Cause: ${error instanceof Error ? error.message : String(error)}`),
-    ) as unknown as JsonObject;
+    return failure("init", "Repository setup failed", error);
   }
 }
 async function request(rootDir: string, route: ShippedGuiRoute, payload: unknown): Promise<JsonObject> {
@@ -116,24 +114,41 @@ async function request(rootDir: string, route: ShippedGuiRoute, payload: unknown
         target,
         route.rpcMethod,
         params,
-        undefined,
+        CONNECT_TIMEOUT_MS,
         requestTimeoutMs(route, daemonPayload),
       );
     return parse(await invoke());
   } catch (error) {
-    return daemonProtocolError(
-      route.rpcMethod,
-      "daemon_unavailable",
-      attachOnlyHint(`Local daemon request failed. Cause: ${error instanceof Error ? error.message : String(error)}`),
-    ) as unknown as JsonObject;
+    return failure(route.rpcMethod, "Local daemon request failed", error);
   }
 }
-function attachOnlyHint(cause: string): string {
-  return [
-    cause,
-    "The GUI is attach-only and never starts or restarts the daemon.",
-    "Run `ha gui` from an operator shell to acquire the daemon through the CLI, then retry.",
-  ].join(" ");
+// The transport's own connect deadline is 75ms, tuned for the CLI which retries around it. The GUI
+// never retries, and a daemon mid-write on its single event loop easily misses 75ms, so every
+// contention blip used to read as "daemon unreachable". Match the CLI streaming path's 2s.
+const CONNECT_TIMEOUT_MS = 2_000;
+// Socket errors that mean no daemon is listening (missing socket file, nobody accepting).
+const SOCKET_ABSENT_CODES = new Set(["ENOENT", "ECONNREFUSED", "ENOTSOCK", "EACCES"]);
+// Only a socket-level miss means the daemon is absent; a slow or rejected answer came from a live
+// daemon and must keep its own code, otherwise every failure prints the attach-only advice.
+function failure(method: string, prefix: string, error: unknown): JsonObject {
+  const message = error instanceof Error ? error.message : String(error),
+    raw =
+      error instanceof Error && typeof (error as { code?: unknown }).code === "string"
+        ? (error as { code: string }).code
+        : null,
+    code =
+      message === "daemon_unavailable" || (raw !== null && SOCKET_ABSENT_CODES.has(raw))
+        ? "daemon_unavailable"
+        : (raw ?? "daemon_request_failed");
+  const hint =
+    code === "daemon_unavailable"
+      ? [
+          `${prefix}. Cause: ${message}`,
+          "The GUI is attach-only and never starts or restarts the daemon.",
+          "Run `ha gui` from an operator shell to acquire the daemon through the CLI, then retry.",
+        ].join(" ")
+      : `${prefix}. Cause: ${message}`;
+  return daemonProtocolError(method, code, hint) as unknown as JsonObject;
 }
 
 export function reportInvalidTaskSnapshotRows(
@@ -168,9 +183,11 @@ function requestTimeoutMs(route: ShippedGuiRoute, payload: JsonObject): number {
   // Reads share the daemon with the single-writer queue; sustained ledger writes hold the
   // workspace for seconds at a time, so any deadline that undercuts a normal write window
   // turns ordinary contention into a visible GUI error (200ms and 2s both did, live).
-  // 10s bounds "the daemon is actually wedged"; connection-level failures still surface
-  // fast through the socket connect path (泽宇 2026-09-01 两次亲裁调高).
-  return 10_000;
+  // The daemon may legitimately hold a read for its projection catch-up budget, so the GUI deadline
+  // is that budget: anything shorter reports an honest catch-up as a failure (200ms, 2s and 10s all
+  // did, live; 泽宇 2026-09-01/02 三次亲裁调高). Connection-level failures still surface within
+  // CONNECT_TIMEOUT_MS through the socket connect path.
+  return defaultProjectionWaitMs;
 }
 function repoPayload(value: unknown): { readonly repoId: string; readonly payload: JsonObject } {
   if (!value || typeof value !== "object" || Array.isArray(value))

--- a/packages/gui/src/main/local-composition-root.ts
+++ b/packages/gui/src/main/local-composition-root.ts
@@ -132,10 +132,8 @@ const SOCKET_ABSENT_CODES = new Set(["ENOENT", "ECONNREFUSED", "ENOTSOCK", "EACC
 // daemon and must keep its own code, otherwise every failure prints the attach-only advice.
 function failure(method: string, prefix: string, error: unknown): JsonObject {
   const message = error instanceof Error ? error.message : String(error),
-    raw =
-      error instanceof Error && typeof (error as { code?: unknown }).code === "string"
-        ? (error as { code: string }).code
-        : null,
+    rawCode = error instanceof Error ? (error as { readonly code?: unknown }).code : undefined,
+    raw = typeof rawCode === "string" ? rawCode : null,
     code =
       message === "daemon_unavailable" || (raw !== null && SOCKET_ABSENT_CODES.has(raw))
         ? "daemon_unavailable"

--- a/packages/gui/test/service-bridge-repositories-attach.test.ts
+++ b/packages/gui/test/service-bridge-repositories-attach.test.ts
@@ -12,10 +12,7 @@ import { parseDaemonGuiReadResult } from "../../daemon/src/protocol/gui-result-v
 import { createLocalGuiServiceBridge } from "../src/index.ts";
 import { streamAgentRuntimeAt } from "../../daemon/src/client/local-json-rpc-stream.ts";
 import { startGuiResidentDaemonFixture } from "../test-support/resident-daemon.mjs";
-import {
-  seedTriadicEvents,
-  writeTriadicLedger,
-} from "../test-support/triadic-ledger.mjs";
+import { seedTriadicEvents, writeTriadicLedger } from "../test-support/triadic-ledger.mjs";
 
 import type { Failure } from "./service-bridge.fixtures.ts";
 import { restoreEnv } from "./service-bridge.fixtures.ts";
@@ -74,15 +71,11 @@ test("GUI bridge switches between two enabled RepoCells without leaking task row
       bridge.invoke("getTasks", { repoId: repoBId }),
     ]);
     assert.deepEqual(
-      parseDaemonGuiReadResult("repo.tasks.list", repoA).rows.map(
-        ({ taskId }) => taskId,
-      ),
+      parseDaemonGuiReadResult("repo.tasks.list", repoA).rows.map(({ taskId }) => taskId),
       ["task-gui-smoke", "task-repo-a"],
     );
     assert.deepEqual(
-      parseDaemonGuiReadResult("repo.tasks.list", repoB).rows.map(
-        ({ taskId }) => taskId,
-      ),
+      parseDaemonGuiReadResult("repo.tasks.list", repoB).rows.map(({ taskId }) => taskId),
       ["task-repo-b"],
     );
     const [graphA, graphB, catalogA, catalogB] = await Promise.all([
@@ -91,33 +84,15 @@ test("GUI bridge switches between two enabled RepoCells without leaking task row
       bridge.invoke("getCatalogSnapshot", { repoId: fixture.repoId }),
       bridge.invoke("getCatalogSnapshot", { repoId: repoBId }),
     ]);
-    assert.equal(
-      parseDaemonGuiReadResult("repo.triadic.relationGraph", graphA).edges
-        .length > 0,
-      true,
-    );
-    assert.equal(
-      parseDaemonGuiReadResult("repo.triadic.relationGraph", graphB).edges
-        .length,
-      0,
-    );
+    assert.equal(parseDaemonGuiReadResult("repo.triadic.relationGraph", graphA).edges.length > 0, true);
+    assert.equal(parseDaemonGuiReadResult("repo.triadic.relationGraph", graphB).edges.length, 0);
     assert.deepEqual(
-      [
-        (catalogA as { repoId: string }).repoId,
-        (catalogB as { repoId: string }).repoId,
-      ],
+      [(catalogA as { repoId: string }).repoId, (catalogB as { repoId: string }).repoId],
       [fixture.repoId, repoBId],
     );
-    const system = parseDaemonGuiReadResult(
-      "daemon.gui.system.read",
-      await bridge.invoke("getSystemStatus", null),
-    );
+    const system = parseDaemonGuiReadResult("daemon.gui.system.read", await bridge.invoke("getSystemStatus", null));
     assert.deepEqual(
-      system.repos.map((repo) => [
-        repo.repoId,
-        repo.registrationState,
-        repo.cellState,
-      ]),
+      system.repos.map((repo) => [repo.repoId, repo.registrationState, repo.cellState]),
       [
         [fixture.repoId, "enabled", "attached"],
         [repoBId, "enabled", "attached"],
@@ -136,11 +111,8 @@ test("GUI bridge switches between two enabled RepoCells without leaking task row
     );
     assert.deepEqual(
       afterDisable.repos.find((repo) => repo.repoId === repoBId) && {
-        registrationState: afterDisable.repos.find(
-          (repo) => repo.repoId === repoBId,
-        )?.registrationState,
-        cellState: afterDisable.repos.find((repo) => repo.repoId === repoBId)
-          ?.cellState,
+        registrationState: afterDisable.repos.find((repo) => repo.repoId === repoBId)?.registrationState,
+        cellState: afterDisable.repos.find((repo) => repo.repoId === repoBId)?.cellState,
       },
       { registrationState: "disabled", cellState: "not_loaded" },
     );
@@ -148,8 +120,9 @@ test("GUI bridge switches between two enabled RepoCells without leaking task row
       repoId: repoBId,
     })) as Failure;
     assert.equal(denied.ok, false);
-    assert.equal(denied.error?.code, "daemon_unavailable");
+    assert.equal(denied.error?.code, "workspace_not_registered");
     assert.match(denied.error?.hint ?? "", /workspace is not registered/u);
+    assert.doesNotMatch(denied.error?.hint ?? "", /attach-only/u, "an unregistered workspace is not a missing daemon");
   } finally {
     await fixture.stop();
     restoreEnv("HARNESS_DAEMON_USER_ROOT", previous.userRoot);
@@ -185,9 +158,7 @@ test("daemon runtime stream reconnects after transport loss from the last delive
             params: { payload?: { afterCursor?: string } };
           };
           if (request.method === "protocol.hello") {
-            socket.write(
-              `${JSON.stringify({ jsonrpc: "2.0", id: request.id, result: { ok: true } })}\n`,
-            );
+            socket.write(`${JSON.stringify({ jsonrpc: "2.0", id: request.id, result: { ok: true } })}\n`);
             continue;
           }
           attempts.push(request.params.payload?.afterCursor ?? "missing");
@@ -196,9 +167,7 @@ test("daemon runtime stream reconnects after transport loss from the last delive
               `${JSON.stringify({ jsonrpc: "2.0", id: request.id, result: { ok: true, status: "attached", runtimeSessionId: "runtime-reconnect", cursor: "stream:0", events: [] } })}\n${JSON.stringify({ jsonrpc: "2.0", method: "repo.agentRuntime.attach.frame", params: { schema: "agent-runtime-attach-event/v1", type: "heartbeat", runtimeSessionId: "runtime-reconnect", cursor: "stream:1", occurredAt: "2026-08-13T00:00:00.000Z" } })}\n`,
               () => {
                 socket.destroy();
-                server.close(() =>
-                  setTimeout(() => server.listen(socketPath), 120),
-                );
+                server.close(() => setTimeout(() => server.listen(socketPath), 120));
               },
             );
           } else {

--- a/packages/gui/test/service-bridge.test.ts
+++ b/packages/gui/test/service-bridge.test.ts
@@ -692,7 +692,7 @@ test("local GUI bridge fails closed without explicit daemon registration and nev
       repoId: "missing-repo",
     })) as Failure;
     assert.equal(result.ok, false);
-    assert.equal(result.error?.code, "daemon_unavailable");
+    assert.equal(result.error?.code, "workspace_not_registered");
     assert.match(result.error?.hint ?? "", /workspace is not registered/u);
     assert.equal(existsSync(path.join(userRoot, "registry.json")), false);
   } finally {


### PR DESCRIPTION
# English

## Summary

Two causes behind the GUI's recent "cannot reach the daemon / read failed" errors, both diagnosed from today's daemon connection log rather than from the message text:

1. Every `repo.triadic.relationGraph` read has failed its own result validation since ff69ff8e3 (08:55 today) started rejecting undeclared fields: cae15c1e6 had added `domainTypes` to every facet payload without declaring it in the schema. 44 `invalid_result` rejections today; the GUI graph views errored on every load.
2. The GUI main process flattened every failure into `daemon_unavailable` with the attach-only advice, inherited the transport's 75ms connect deadline (tuned for the CLI, which retries around it; the GUI never retries), and capped reads at 10s while the daemon may hold a read for its 30s projection catch-up budget. On a loaded single-event-loop daemon (6 restarts today, load average 7.7) ordinary contention therefore read as "daemon unreachable".

## Architectural Justification

- Not required (churn well under 200 lines).

## What Changed

- `packages/daemon/src/protocol/daemon-protocol-schema-ids.ts`, `daemon-protocol-validate-projections.ts`: declare `domainTypes` as an optional relation-graph field; `json-rpc-protocol.test.ts` covers every facet with and without it.
- `packages/gui/src/main/local-composition-root.ts`: explicit 2s connect deadline (matches the CLI streaming path); read deadline is `defaultProjectionWaitMs` imported from the daemon, one source for both sides; failures keep their own code and cause, and only socket-absent errors (`ENOENT`/`ECONNREFUSED`/…, or the transport's `daemon_unavailable`) carry the attach-only hint; the first-run bootstrap's 75s was passed as the connect deadline and is now the response deadline.
- `packages/daemon/src/client/local-daemon-target.ts`: an unregistered workspace throws with `code: "workspace_not_registered"`; `service-bridge-repositories-attach.test.ts` asserts that code and that the attach-only hint is absent.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: use the single CI-backed `Production-Delta` declaration below; do not enter a second metric.

## Machine-Readable Declarations

Production-Delta: +46/-23

## Task And Scope

- Harness task: task_f22f99e8968179293188baeb53
- Branch: codex/relation-graph-domaintypes
- Public scope: the four production files above plus their two test files
- Private planning/evidence updated: yes
- Out of scope: the 5-way read fan-out and 2s ledger polling in the renderer, and the daemon's synchronous projection catch-up loop (recorded as follow-ups on the task)

## Version Impact

- Version: no version change because these are runtime fixes within the current contract
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none
- Authority: not applicable
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: bc7f9c0f50ee6a765f2c932d274eced27492ceaa
- Branch merge-base with `origin/main`: bc7f9c0f50ee6a765f2c932d274eced27492ceaa
- Last `git fetch origin` time: 2026-09-02 (before branching)
- Sync method: none needed
- Public diff command: `git diff bc7f9c0f50ee6a765f2c932d274eced27492ceaa..HEAD`
- Private evidence commit/path: task_f22f99e8968179293188baeb53 facts; daemon connection log analysis (44× invalid_result on relationGraph, slow-read and restart timeline)
- Reviewer evidence path: this PR
- GitHub Actions `rewrite-ci` run URL: pending
- [ ] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [x] `npm test` (targeted: gui daemon-autostart-bridge, service-bridge-repositories-attach; daemon json-rpc-protocol, validator-diagnostic-contract, task-query-read, relation-runtime-edges — all green)
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Not run: full local suite and typecheck (worktree lacks built project references); CI is the authority.

## Review Evidence

- Self-review: root causes confirmed from the daemon connection log before editing; positive and negative validator cases added.
- Reviewer subagent: read-only code-path survey of every GUI→daemon timeout and error mapping
- Human review: pending
- Blocking findings: none

## Residual Risk

- A 30s read deadline means a genuinely wedged daemon takes 30s to surface in the GUI; the connect path still fails within 2s when nothing is listening.
- Renderer polling and fan-out are unchanged, so daemon load is unchanged; this PR only stops misreporting it.

## References

- Task: task_f22f99e8968179293188baeb53
- Evidence: daemon-default-conn-20260902 log (invalid_result on repo.triadic.relationGraph; -32601 on stale vocabularies; restart timeline)
- Review: this PR

---

# 中文

## 概要

GUI 近期频繁报「连不到 daemon / 读取失败」，从今天的 daemon 连接日志（而不是从报错文案）定位到两条原因：

1. 自今天 08:55 的 ff69ff8e3 开始拒绝未声明字段后，每一次 `repo.triadic.relationGraph` 读都被 daemon 自己的结果校验拒绝：cae15c1e6 给所有 facet 返回加了 `domainTypes`，却没在 schema 里声明。今天 44 次 `invalid_result`，GUI 的关系图视图每次加载都报错。
2. GUI 主进程把所有失败一律映射成 `daemon_unavailable` 并附「attach-only」提示；连接超时沿用传输层为 CLI 调的 75ms（CLI 有重试兜着，GUI 从不重试）；读超时 10s，而 daemon 合法地可能为 projection 追平把一次读拿住 30s。在单事件循环、今天重启 6 次、负载 7.7 的 daemon 上，普通争用就被报成「daemon 不可达」。

## 架构辩护

- 不需要（改动远小于 200 行）。

## 改动内容

- `daemon-protocol-schema-ids.ts`、`daemon-protocol-validate-projections.ts`：把 `domainTypes` 声明为 relation-graph 的可选字段；`json-rpc-protocol.test.ts` 覆盖每个 facet 带与不带该字段。
- `local-composition-root.ts`：显式 2s 连接超时（与 CLI 流式路径一致）；读超时直接引用 daemon 的 `defaultProjectionWaitMs`，两端同源；失败保留各自错误码与原因，只有 socket 不存在类错误才带 attach-only 提示；首次引导原本把 75s 传成了连接超时，改为响应超时。
- `local-daemon-target.ts`：未注册的工作区抛 `code: "workspace_not_registered"`；`service-bridge-repositories-attach.test.ts` 断言该码且不带 attach-only 提示。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 同 commit 删除的门 / fixture：none
- 生产净行数：引用英文块中的 `Production-Delta`。

## 机读声明说明

- 机读声明只在英文块出现。

## 任务与范围

- Harness 任务：task_f22f99e8968179293188baeb53
- 分支：codex/relation-graph-domaintypes
- 公开范围：上述四个生产文件及两个测试文件
- 私有计划 / 证据是否已更新：yes
- 范围外：renderer 的 5 路并发读扇出与 2s 台账轮询、daemon 同步的 projection 追平循环（已作为 task 的后续项记录）

## 版本影响

- 版本：不改版本，原因是契约内的运行时修复
- 发布影响：不发布

## 治理声明

- 是否触碰 protected surface：no
- protected surface 范围：无
- 依据：不适用
- 机器检查边界：本 PR 只声明该段存在；是否真实充分由 reviewer 判断。
- Break-glass：no
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- `origin/main` 基准 SHA：bc7f9c0f50ee6a765f2c932d274eced27492ceaa
- 当前分支与 `origin/main` 的 merge-base：bc7f9c0f50ee6a765f2c932d274eced27492ceaa
- 最近一次 `git fetch origin` 时间：2026-09-02（建分支前）
- 同步方式：不需要
- 公开 diff 命令：`git diff bc7f9c0f50ee6a765f2c932d274eced27492ceaa..HEAD`
- 私有证据 commit/path：task_f22f99e8968179293188baeb53 的 fact；daemon 连接日志分析
- Reviewer 证据路径：本 PR
- GitHub Actions `rewrite-ci` run URL：待定
- [ ] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [x] `npm test`（定向：gui daemon-autostart-bridge、service-bridge-repositories-attach；daemon json-rpc-protocol、validator-diagnostic-contract、task-query-read、relation-runtime-edges，全绿）
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- 未运行：完整本地套件与 typecheck（worktree 缺少已构建的项目引用）；以 CI 为权威。

## 审查证据

- 自查：动手前先从 daemon 连接日志确认根因；补了校验器的正例与反例。
- Reviewer subagent：对 GUI→daemon 全部超时与错误映射做了只读代码链路调查
- 人工审查：待定
- 阻塞发现：无

## 残余风险

- 读超时 30s 意味着 daemon 真卡死时 GUI 要 30s 才显现；无人监听时连接路径仍在 2s 内失败。
- renderer 的轮询与扇出未变，daemon 负载不变；本 PR 只是不再误报。

## 关联材料

- 任务：task_f22f99e8968179293188baeb53
- 证据：daemon-default-conn-20260902 日志
- 审查：本 PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
