### PR TITLE
fix(daemon): only step aside on build drift for a caller that will restart it

### DIFF
--- a/packages/cli/src/daemon/client.ts
+++ b/packages/cli/src/daemon/client.ts
@@ -154,7 +154,13 @@ export async function runCommandThroughDaemon(
 ): Promise<JsonObject> {
   command = materializeScheduleMission(command);
   const rpc = await import("../../../daemon/src/client/local-json-rpc-client.ts"),
-    requestLocalDaemonJsonRpcForTarget = (timeRequest ?? ((f) => f))(rpc.requestLocalDaemonJsonRpcForTarget),
+    // The CLI is the one caller that restarts a drifted daemon (withAutostart), so it alone asks
+    // the daemon to step aside on build drift; attach-only clients keep the loaded build.
+    requestLocalDaemonJsonRpcForTarget = (timeRequest ?? ((f) => f))(((target, ...rest) =>
+      rpc.requestLocalDaemonJsonRpcForTarget(
+        { ...target, restartStaleDaemon: true },
+        ...rest,
+      )) as typeof rpc.requestLocalDaemonJsonRpcForTarget),
     autostart = options.autostart ?? command.action.kind !== "receipt-show",
     env = options.env ?? process.env;
   if (command.action.kind === "repo-bootstrap") {

--- a/packages/cli/src/daemon/client.ts
+++ b/packages/cli/src/daemon/client.ts
@@ -22,6 +22,7 @@ import type { DaemonLaunchSpec } from "../../../daemon/src/client/daemon-autosta
 import { cliErrorMessage } from "../cli-error.ts";
 import type { ThinCommand } from "../cli/thin-command.ts";
 import { fleetEdgeRegistration, fleetScheduleRoute } from "./fleet-command-route.ts";
+import { withAutostart } from "./with-autostart.ts";
 export { fleetScheduleRoute } from "./fleet-command-route.ts";
 export {
   daemonIdFromEnv,
@@ -101,50 +102,6 @@ export function daemonBuildStaleCode(error: unknown): "daemon_build_stale" | nul
     (error as { readonly code?: unknown }).code === "daemon_build_stale"
     ? "daemon_build_stale"
     : null;
-}
-// The autostart seam is imported lazily so the thin dist static import graph stays
-// entry/parser/transport-only; it is only reachable on a connection-level failure.
-async function withAutostart(
-  request: () => Promise<JsonObject>,
-  launch: () => DaemonLaunchSpec,
-  socketPath: string,
-  options: { readonly autostart: boolean; readonly env: NodeJS.ProcessEnv; readonly invokingRoot: string },
-): Promise<JsonObject> {
-  try {
-    return await request();
-  } catch (error) {
-    if (!options.autostart) throw error;
-    const { DaemonAutostartError, ensureLocalDaemonRunning, isDaemonUnreachable, runtimeDaemonStartRefusal } =
-      await import("../../../daemon/src/client/daemon-autostart.ts");
-    const buildStale = isDaemonBuildStale(error);
-    if (!buildStale && !isDaemonUnreachable(error)) throw error;
-    if (buildStale) await waitForDaemonRestart(socketPath);
-    // The failed connection (or the completed stale-daemon shutdown wait) already proves this
-    // socket unavailable. A second socket probe can consume its full timeout without adding evidence.
-    const refusal = runtimeDaemonStartRefusal(options.env);
-    if (refusal) throw new DaemonAutostartError({ ok: false, ...refusal, attempts: 0 });
-    const started = await ensureLocalDaemonRunning({
-      socketPath,
-      invokingRoot: options.invokingRoot,
-      launch,
-      onProgress: (progress) => process.stderr.write(`${progress.message}\n`),
-    });
-    if (!started.ok) throw new DaemonAutostartError(started);
-    return await request();
-  }
-}
-function isDaemonBuildStale(error: unknown): boolean {
-  return (
-    typeof error === "object" && error !== null && (error as { readonly code?: unknown }).code === "daemon_build_stale"
-  );
-}
-async function waitForDaemonRestart(socketPath: string): Promise<void> {
-  const { daemonSocketProbe } = await import("../../../daemon/src/client/daemon-autostart.ts"),
-    deadline = Date.now() + 5_000;
-  while (Date.now() < deadline) {
-    if (!(await daemonSocketProbe(socketPath))) return;
-    await new Promise((resolve) => setTimeout(resolve, 25));
-  }
 }
 export async function runCommandThroughDaemon(
   command: ThinCommand,

--- a/packages/cli/src/daemon/with-autostart.ts
+++ b/packages/cli/src/daemon/with-autostart.ts
@@ -1,0 +1,49 @@
+import type { DaemonLaunchSpec } from "../../../daemon/src/client/daemon-autostart.ts";
+import type { JsonObject } from "../../../daemon/src/protocol/json-rpc-types.ts";
+
+// The autostart seam is imported lazily so the thin dist static import graph stays
+// entry/parser/transport-only; it is only reachable on a connection-level failure.
+// The autostart seam is imported lazily so the thin dist static import graph stays
+// entry/parser/transport-only; it is only reachable on a connection-level failure.
+export async function withAutostart(
+  request: () => Promise<JsonObject>,
+  launch: () => DaemonLaunchSpec,
+  socketPath: string,
+  options: { readonly autostart: boolean; readonly env: NodeJS.ProcessEnv; readonly invokingRoot: string },
+): Promise<JsonObject> {
+  try {
+    return await request();
+  } catch (error) {
+    if (!options.autostart) throw error;
+    const { DaemonAutostartError, ensureLocalDaemonRunning, isDaemonUnreachable, runtimeDaemonStartRefusal } =
+      await import("../../../daemon/src/client/daemon-autostart.ts");
+    const buildStale = isDaemonBuildStale(error);
+    if (!buildStale && !isDaemonUnreachable(error)) throw error;
+    if (buildStale) await waitForDaemonRestart(socketPath);
+    // The failed connection (or the completed stale-daemon shutdown wait) already proves this
+    // socket unavailable. A second socket probe can consume its full timeout without adding evidence.
+    const refusal = runtimeDaemonStartRefusal(options.env);
+    if (refusal) throw new DaemonAutostartError({ ok: false, ...refusal, attempts: 0 });
+    const started = await ensureLocalDaemonRunning({
+      socketPath,
+      invokingRoot: options.invokingRoot,
+      launch,
+      onProgress: (progress) => process.stderr.write(`${progress.message}\n`),
+    });
+    if (!started.ok) throw new DaemonAutostartError(started);
+    return await request();
+  }
+}
+function isDaemonBuildStale(error: unknown): boolean {
+  return (
+    typeof error === "object" && error !== null && (error as { readonly code?: unknown }).code === "daemon_build_stale"
+  );
+}
+async function waitForDaemonRestart(socketPath: string): Promise<void> {
+  const { daemonSocketProbe } = await import("../../../daemon/src/client/daemon-autostart.ts"),
+    deadline = Date.now() + 5_000;
+  while (Date.now() < deadline) {
+    if (!(await daemonSocketProbe(socketPath))) return;
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+}

--- a/packages/daemon/src/client/local-json-rpc-client.ts
+++ b/packages/daemon/src/client/local-json-rpc-client.ts
@@ -50,6 +50,7 @@ export async function requestLocalDaemonJsonRpcForTarget(
   target: {
     readonly socketPath: string;
     readonly repoId?: string;
+    readonly restartStaleDaemon?: boolean;
     readonly canonicalRoot?: string;
     readonly userRoot?: string;
     readonly daemonId?: string;
@@ -67,6 +68,7 @@ export async function requestLocalDaemonJsonRpcForTarget(
     timeoutMs,
     responseTimeoutMs,
     target.sessionEnvironment,
+    target.restartStaleDaemon === true,
   );
 }
 
@@ -77,6 +79,7 @@ export async function requestDaemonJsonRpcAt(
   timeoutMs = 75,
   responseTimeoutMs?: number,
   sessionEnvironment?: DaemonSessionEnvironment,
+  restartStaleDaemon = false,
 ): Promise<JsonObject> {
   return requestWithSocket(
     await connectSocket(socketPath, timeoutMs),
@@ -84,6 +87,7 @@ export async function requestDaemonJsonRpcAt(
     params,
     responseTimeoutMs,
     sessionEnvironment,
+    restartStaleDaemon,
   );
 }
 
@@ -164,8 +168,7 @@ export class JsonRpcLineClient {
   }
   private onClosed(): void {
     this.closed = true;
-    for (const waiter of this.waiters.splice(0))
-      waiter.reject(daemonClosedError(waiter.id));
+    for (const waiter of this.waiters.splice(0)) waiter.reject(daemonClosedError(waiter.id));
   }
 }
 
@@ -175,6 +178,7 @@ async function requestWithSocket(
   params: JsonObject,
   responseTimeoutMs?: number,
   sessionEnvironment?: DaemonSessionEnvironment,
+  restartStaleDaemon = false,
 ): Promise<JsonObject> {
   const client = new JsonRpcLineClient(socket, socket);
   try {
@@ -185,15 +189,15 @@ async function requestWithSocket(
         ...(sessionEnvironment && Object.keys(sessionEnvironment).length > 0
           ? { sessionEnvironment: sessionEnvironment as JsonObject }
           : {}),
+        ...(restartStaleDaemon ? { restartStaleDaemon: true } : {}),
       },
       responseTimeoutMs,
     );
-    const staleError = hello.error && typeof hello.error === "object" && !Array.isArray(hello.error)
-      ? hello.error as JsonObject
-      : null,
-      staleHint = staleError && typeof staleError.hint === "string"
-      ? staleError.hint
-      : undefined;
+    const staleError =
+        hello.error && typeof hello.error === "object" && !Array.isArray(hello.error)
+          ? (hello.error as JsonObject)
+          : null,
+      staleHint = staleError && typeof staleError.hint === "string" ? staleError.hint : undefined;
     if (hello.ok === false && hello.code === "daemon_build_stale")
       throw Object.assign(new Error(String(hello.nextAction ?? staleHint ?? "daemon_build_stale")), {
         code: "daemon_build_stale",

--- a/packages/daemon/src/protocol/daemon-protocol.contract.ts
+++ b/packages/daemon/src/protocol/daemon-protocol.contract.ts
@@ -48,7 +48,11 @@ export const daemonProtocolMethods = Object.freeze([
     phase: "W3",
     method: "protocol.hello",
     requiresRepo: false,
-    params: shape({ protocolVersion: shape({ major: "number", minor: "number" }), sessionEnvironment: "json?" }),
+    params: shape({
+      protocolVersion: shape({ major: "number", minor: "number" }),
+      sessionEnvironment: "json?",
+      restartStaleDaemon: "boolean?",
+    }),
   },
   {
     id: "daemon.status",
@@ -451,6 +455,8 @@ type DaemonRpcParamOverrides = {
   readonly "protocol.hello": {
     readonly protocolVersion: ContractVersion;
     readonly sessionEnvironment?: DaemonSessionEnvironment;
+    /** Only a caller that will autostart the daemon again may ask a drifted daemon to stop. */
+    readonly restartStaleDaemon?: boolean;
   };
   readonly "daemon.fleet.task.run": { readonly payload: DaemonFleetTaskPayload };
   readonly "daemon.fleet.doc.sync": { readonly payload: DaemonFleetDocSyncPayload };

--- a/packages/daemon/src/protocol/json-rpc-server.ts
+++ b/packages/daemon/src/protocol/json-rpc-server.ts
@@ -138,8 +138,10 @@ export function createJsonRpcProtocolServer(options: {
         Object.assign(options.authContext, {
           sessionEnvironment: params.sessionEnvironment,
         });
+      // A drifted daemon keeps serving attach-only clients (the GUI) on the loaded build; it only
+      // steps aside for a caller that declares it will start the disk build again (the CLI).
       const buildStatus = options.buildObserver?.status();
-      if (buildStatus?.drifted) {
+      if (buildStatus?.drifted && params.restartStaleDaemon === true) {
         const stale = daemonProtocolError(
           "protocol.hello",
           "daemon_build_stale",

--- a/packages/daemon/src/protocol/json-rpc-server.ts
+++ b/packages/daemon/src/protocol/json-rpc-server.ts
@@ -140,8 +140,9 @@ export function createJsonRpcProtocolServer(options: {
         });
       // A drifted daemon keeps serving attach-only clients (the GUI) on the loaded build; it only
       // steps aside for a caller that declares it will start the disk build again (the CLI).
-      const buildStatus = options.buildObserver?.status();
-      if (buildStatus?.drifted && params.restartStaleDaemon === true) {
+      const buildStatus = options.buildObserver?.status(),
+        callerRestartsDaemon = params.restartStaleDaemon === true;
+      if (buildStatus?.drifted && callerRestartsDaemon) {
         const stale = daemonProtocolError(
           "protocol.hello",
           "daemon_build_stale",

--- a/packages/daemon/test/protocol-hello-build.test.ts
+++ b/packages/daemon/test/protocol-hello-build.test.ts
@@ -11,31 +11,80 @@ import type { DaemonAuthenticationContext } from "../src/transport/auth-context.
 test("protocol.hello answers with the daemon's build stamp", async () => {
   let shutdowns = 0;
   const build = { commit: "0123456789abcdef0123456789abcdef01234567" };
-  const server = createJsonRpcProtocolServer({ host: {} as never, build, authContext: { transportKind: "unix-socket" } as DaemonAuthenticationContext, emit: async () => undefined, requestShutdown: () => { shutdowns += 1; } });
+  const server = createJsonRpcProtocolServer({
+    host: {} as never,
+    build,
+    authContext: { transportKind: "unix-socket" } as DaemonAuthenticationContext,
+    emit: async () => undefined,
+    requestShutdown: () => {
+      shutdowns += 1;
+    },
+  });
   try {
-    const hello = await server.handle({ jsonrpc: "2.0", id: 1, method: "protocol.hello", params: { protocolVersion: currentDaemonProtocolVersion } });
+    const hello = await server.handle({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "protocol.hello",
+      params: { protocolVersion: currentDaemonProtocolVersion },
+    });
     const result = (hello as { readonly result: { readonly build?: { readonly commit: string | null } } }).result;
-    assert.equal(result.build?.commit, build.commit, "hello must report the stamp supplied by the daemon composition root");
+    assert.equal(
+      result.build?.commit,
+      build.commit,
+      "hello must report the stamp supplied by the daemon composition root",
+    );
     const stop = await server.handle({ jsonrpc: "2.0", id: 2, method: "daemon.stop", params: {} });
     assert.equal((stop as { readonly result: { readonly ok: boolean } }).result.ok, true, JSON.stringify(stop));
     assert.equal(shutdowns, 1, "an accepted daemon.stop must reach the shutdown owner exactly once");
-  } finally { server.close(); }
+  } finally {
+    server.close();
+  }
 });
 
-test("protocol.hello rejects a stale dist fingerprint and requests one restart", async () => {
+test("protocol.hello keeps serving a drifted build to attach-only callers and steps aside only for a restarting caller", async () => {
   let shutdowns = 0;
   const server = createJsonRpcProtocolServer({
     host: {} as never,
     build: { commit: "loaded" },
-    buildObserver: { status: () => ({ commit: "loaded", entry: "dist", loadedBuildId: "build-a", diskBuildId: "build-b", drifted: true }) },
+    buildObserver: {
+      status: () => ({
+        commit: "loaded",
+        entry: "dist",
+        loadedBuildId: "build-a",
+        diskBuildId: "build-b",
+        drifted: true,
+      }),
+    },
     authContext: { transportKind: "unix-socket" } as DaemonAuthenticationContext,
     emit: async () => undefined,
-    requestShutdown: () => { shutdowns += 1; },
+    requestShutdown: () => {
+      shutdowns += 1;
+    },
   });
   try {
-    const hello = await server.handle({ jsonrpc: "2.0", id: 1, method: "protocol.hello", params: { protocolVersion: currentDaemonProtocolVersion } });
-    assert.equal((hello as { readonly result: { readonly code: string } }).result.code, "daemon_build_stale");
+    const attachOnly = await server.handle({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "protocol.hello",
+      params: { protocolVersion: currentDaemonProtocolVersion },
+    });
+    assert.equal(
+      (attachOnly as { readonly result: { readonly ok: boolean } }).result.ok,
+      true,
+      "the GUI never restarts the daemon, so drift must not make the daemon leave it",
+    );
+    await new Promise((resolve) => setImmediate(resolve));
+    assert.equal(shutdowns, 0);
+    const restarting = await server.handle({
+      jsonrpc: "2.0",
+      id: 2,
+      method: "protocol.hello",
+      params: { protocolVersion: currentDaemonProtocolVersion, restartStaleDaemon: true },
+    });
+    assert.equal((restarting as { readonly result: { readonly code: string } }).result.code, "daemon_build_stale");
     await new Promise((resolve) => setImmediate(resolve));
     assert.equal(shutdowns, 1);
-  } finally { server.close(); }
+  } finally {
+    server.close();
+  }
 });


### PR DESCRIPTION
# English

## Summary

Since 9da228cd6 a drifted daemon answered every `protocol.hello` with `daemon_build_stale` and shut itself down, trusting the caller to autostart the disk build. Only the CLI does that. The GUI is attach-only and polls every few seconds, so after every merge that rebuilt `dist` the GUI was the first to say hello, the daemon died, and nothing brought it back: every GUI read failed until some CLI command happened to autostart it. Reproduced twice today right after merges (13:00:24 and 14:03:05, both `stop_requested` following a `daemon_build_stale` hello from the GUI's 10s system-status poll).

## Architectural Justification

- Not required (churn well under 200 lines).

## What Changed

- `daemon-protocol.contract.ts`: `protocol.hello` gains optional `restartStaleDaemon: boolean` — the caller declares it will start the disk build again.
- `json-rpc-server.ts`: on build drift the daemon steps aside only when that flag is set; otherwise it keeps serving the loaded build (the GUI already surfaces the build-skew verdict through system status).
- `local-json-rpc-client.ts`: the flag threads from the target through to the hello; default off.
- `packages/cli/src/daemon/client.ts`: the CLI request path sets it, because its existing `withAutostart` wait-and-restart is the one caller that honours the contract. That seam (`withAutostart`, the stale-daemon wait) moves to `packages/cli/src/daemon/with-autostart.ts` because client.ts sat at the 700-line CLI source budget.
- `protocol-hello-build.test.ts`: an attach-only hello on a drifted daemon is `ok` with no shutdown; a restarting hello gets `daemon_build_stale` and exactly one shutdown.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: use the single CI-backed `Production-Delta` declaration below; do not enter a second metric.

## Machine-Readable Declarations

Production-Delta: +81/-56

## Task And Scope

- Harness task: task_c2477c407d9577a50fbbe26f0a
- Branch: codex/stale-daemon-hello
- Public scope: the five production files above and one test file
- Private planning/evidence updated: yes
- Out of scope: a GUI prompt to reload once the daemon has rolled forward (task_f22f99e8968179293188baeb53)

## Version Impact

- Version: no version change because the hello field is optional and defaults to the attach-only behaviour
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: yes
- Protected surface scope: packages/daemon/src/protocol/daemon-protocol.contract.ts (protocol.hello params)
- Authority: task_c2477c407d9577a50fbbe26f0a
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: 9c5277c9ac1e9c65c762ef25082794ddbea4511b
- Branch merge-base with `origin/main`: 9c5277c9ac1e9c65c762ef25082794ddbea4511b
- Last `git fetch origin` time: 2026-09-02 (before branching)
- Sync method: none needed
- Public diff command: `git diff 9c5277c9ac1e9c65c762ef25082794ddbea4511b..HEAD`
- Private evidence commit/path: task_c2477c407d9577a50fbbe26f0a facts (daemon lifecycle + connection log: stop_requested at 05:00:24Z and 06:03:05Z each preceded by a daemon_build_stale hello)
- Reviewer evidence path: this PR
- GitHub Actions `rewrite-ci` run URL: pending
- [ ] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [x] `npm test` (targeted: daemon protocol-hello-build, daemon-build-drift.integration, json-rpc-protocol; cli daemon-multi-repo-lifecycle-cli-upgrades-overlays; gui daemon-autostart-bridge — all green)
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Not run: full local suite and typecheck (worktree lacks built project references); CI is the authority.

## Review Evidence

- Self-review: mechanism confirmed from the daemon connection log (daemon_build_stale hello → stop_requested, no restart) before editing; server test covers both caller kinds.
- Reviewer subagent: none
- Human review: pending
- Blocking findings: none

## Residual Risk

- A GUI that never issues a CLI command keeps talking to the loaded (older) build until one does; the system-status build-skew verdict already reports this, and the reload prompt is tracked separately.

## References

- Task: task_c2477c407d9577a50fbbe26f0a
- Evidence: ~/.harness/logs/daemon-default.log and daemon-default-conn-20260902.jsonl (times above)
- Review: this PR

---

# 中文

## 概要

自 9da228cd6 起，build 漂移的 daemon 会对每一个 `protocol.hello` 回 `daemon_build_stale` 并自行关停，指望调用方把磁盘上的新 build 重新拉起。只有 CLI 会这么做。GUI 是 attach-only 且每隔几秒轮询，于是每次合并重建 `dist` 之后，第一个 hello 的几乎总是 GUI，daemon 就此退出而没有任何一方拉起：GUI 所有读取失败，直到某条 CLI 命令碰巧 autostart。今天在两次合并后各复现一次（13:00:24 与 14:03:05，两次 `stop_requested` 之前都是 GUI 10 秒系统状态轮询发出的 hello 被判 `daemon_build_stale`）。

## 架构辩护

- 不需要（改动远小于 200 行）。

## 改动内容

- `daemon-protocol.contract.ts`：`protocol.hello` 新增可选 `restartStaleDaemon: boolean`，由调用方声明「我会把磁盘 build 再拉起来」。
- `json-rpc-server.ts`：漂移时只有带该标志的调用才让 daemon 退位；否则继续用已加载的 build 服务（GUI 已通过系统状态展示 build 偏差判定）。
- `local-json-rpc-client.ts`：标志从 target 一路传到 hello，默认关闭。
- `packages/cli/src/daemon/client.ts`：CLI 请求路径设置该标志，因为它现有的 `withAutostart` 等待并重启正是履约方。这段自启重试缝（`withAutostart` 与 stale daemon 等待）挪到 `packages/cli/src/daemon/with-autostart.ts`，因为 client.ts 已顶到 700 行的 CLI 源文件预算。
- `protocol-hello-build.test.ts`：attach-only 的 hello 在漂移 daemon 上得到 `ok` 且无关停；带重启标志的 hello 得到 `daemon_build_stale` 且恰好一次关停。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 同 commit 删除的门 / fixture：none
- 生产净行数：引用英文块中的 `Production-Delta`。

## 机读声明说明

- 机读声明只在英文块出现。

## 任务与范围

- Harness 任务：task_c2477c407d9577a50fbbe26f0a
- 分支：codex/stale-daemon-hello
- 公开范围：上述五个生产文件与一个测试文件
- 私有计划 / 证据是否已更新：yes
- 范围外：daemon 前滚后 GUI 的重新加载提示（task_f22f99e8968179293188baeb53）

## 版本影响

- 版本：不改版本，原因是 hello 字段可选且默认即 attach-only 行为
- 发布影响：不发布

## 治理声明

- 是否触碰 protected surface：yes
- protected surface 范围：packages/daemon/src/protocol/daemon-protocol.contract.ts（protocol.hello 参数）
- 依据：task_c2477c407d9577a50fbbe26f0a
- 机器检查边界：本 PR 只声明该段存在；是否真实充分由 reviewer 判断。
- Break-glass：no
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- `origin/main` 基准 SHA：9c5277c9ac1e9c65c762ef25082794ddbea4511b
- 当前分支与 `origin/main` 的 merge-base：9c5277c9ac1e9c65c762ef25082794ddbea4511b
- 最近一次 `git fetch origin` 时间：2026-09-02（建分支前）
- 同步方式：不需要
- 公开 diff 命令：`git diff 9c5277c9ac1e9c65c762ef25082794ddbea4511b..HEAD`
- 私有证据 commit/path：task_c2477c407d9577a50fbbe26f0a 的 fact（daemon 生命周期与连接日志）
- Reviewer 证据路径：本 PR
- GitHub Actions `rewrite-ci` run URL：待定
- [ ] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [x] `npm test`（定向：daemon protocol-hello-build、daemon-build-drift.integration、json-rpc-protocol；cli daemon-multi-repo-lifecycle-cli-upgrades-overlays；gui daemon-autostart-bridge，全绿）
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- 未运行：完整本地套件与 typecheck（worktree 缺少已构建的项目引用）；以 CI 为权威。

## 审查证据

- 自查：动手前先从 daemon 连接日志确认机制（GUI 的 hello 被判 daemon_build_stale → stop_requested → 无人重启）；服务端测试覆盖两类调用方。
- Reviewer subagent：无
- 人工审查：待定
- 阻塞发现：无

## 残余风险

- 若长期没有任何 CLI 命令，GUI 会一直与旧 build 的 daemon 对话；系统状态已有 build 偏差判定，重新加载提示单独跟踪。

## 关联材料

- 任务：task_c2477c407d9577a50fbbe26f0a
- 证据：~/.harness/logs/daemon-default.log 与 daemon-default-conn-20260902.jsonl
- 审查：本 PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
