### PR TITLE
feat(kernel): compile governed vertical relation rows (GovernedEntity W1-C)

### DIFF
--- a/packages/kernel/src/domain/entity-relation.ts
+++ b/packages/kernel/src/domain/entity-relation.ts
@@ -1,7 +1,7 @@
 import { sha256Text } from "../integrity/stable-hash.ts";
 import { parseEntityRef } from "./entity-ref.ts";
 import type { ParsedEntityRef } from "./entity-ref.ts";
-import { canonicalRelationDirections } from "./relation-direction.ts";
+import { canonicalRelationDirections, type CanonicalRelationDirection } from "./relation-direction.ts";
 
 export const relationTypes = [
   "supports",
@@ -83,6 +83,7 @@ export function formatRelationFlowRecord(record: EntityRelationRecord): string {
 export function validateRelationRecordsForHost(
   host: string,
   records: ReadonlyArray<EntityRelationRecord>,
+  registry: readonly CanonicalRelationDirection[] = canonicalRelationDirections,
 ): ReadonlyArray<EntityRelationValidationIssue> {
   const issues: EntityRelationValidationIssue[] = [];
   const hostRef = parseEntityRef(host);
@@ -110,7 +111,7 @@ export function validateRelationRecordsForHost(
     // The type-subset whitelist only governs live edges. Retired/deleted records are
     // audit history: a migration retires an illegal edge in place, and re-validating the
     // corpse would permanently block every future write to the host document.
-    if (record.state === "active" && !isAllowedRelationKindTriple(source.kind, record.type, target.kind)) {
+    if (record.state === "active" && !isAllowedRelationRecord(record, source.kind, target.kind, registry)) {
       issues.push({
         code: "invalid_relation_type_subset",
         relationId: record.relation_id,
@@ -162,9 +163,10 @@ export function relationOwnerRef(sourceRef: string): string {
 }
 
 export function isAllowedRelationKindTriple(
-  sourceKind: ParsedEntityRef["kind"],
+  sourceKind: string,
   type: RelationType,
-  targetKind: ParsedEntityRef["kind"],
+  targetKind: string,
+  registry: readonly CanonicalRelationDirection[] = canonicalRelationDirections,
 ): boolean {
   // Ratified convention (dec_mr74sbka, 2026-07-05): every edge reads as one sentence,
   // `source <verb> target`, in the physical (host -> target) direction — no cell whose
@@ -175,12 +177,28 @@ export function isAllowedRelationKindTriple(
   // blocks were retired with zero stored active edges (2026-08-17 census); the retired
   // aliases remain parse-only vocabulary and reverse questions go through
   // `incomingRelations` in relation-direction.ts.
-  return canonicalRelationDirections.some(
+  return registry.some(
     (direction) =>
       direction.registration !== "derived" &&
       direction.sourceKind === sourceKind &&
       direction.type === type &&
       direction.targetKind === targetKind,
+  );
+}
+
+export function isAllowedRelationRecord(
+  record: Pick<EntityRelationRecord, "type" | "strength">,
+  sourceKind: string,
+  targetKind: string,
+  registry: readonly CanonicalRelationDirection[] = canonicalRelationDirections,
+): boolean {
+  return registry.some(
+    (direction) =>
+      direction.registration !== "derived" &&
+      direction.sourceKind === sourceKind &&
+      direction.type === record.type &&
+      direction.targetKind === targetKind &&
+      (direction.strength === undefined || direction.strength === record.strength),
   );
 }
 

--- a/packages/kernel/src/domain/governed-relation-direction.ts
+++ b/packages/kernel/src/domain/governed-relation-direction.ts
@@ -1,0 +1,180 @@
+import { entityTypeContracts } from "./base-entity.ts";
+import type { CanonicalRelationDirection } from "./relation-direction.ts";
+import type { ArtifactEntityKindDefinition, ArtifactRelationDefinition } from "../schemas/vertical-definition.ts";
+
+export interface GovernedRelationDecision {
+  readonly decisionId: string;
+  readonly state: string;
+  readonly contentPin: `sha256:${string}`;
+  readonly claimIds: readonly string[];
+}
+
+export interface GovernedRelationCompilationAuthority {
+  readonly decisions: readonly GovernedRelationDecision[];
+}
+
+export interface GovernedArtifactRelationRequest {
+  readonly artifactTypeIdentity: string;
+  readonly declaration: ArtifactRelationDefinition;
+}
+
+/**
+ * The accepted decision receipt shipped with the kernel policy it authorizes.
+ * Callers compiling later governance decisions supply a fresh authority snapshot.
+ */
+export const canonicalGovernedRelationAuthority: GovernedRelationCompilationAuthority = Object.freeze({
+  decisions: Object.freeze([
+    Object.freeze({
+      decisionId: "dec_29CCC98CD0241D0C9806AC1CF1",
+      state: "in_effect",
+      contentPin: "sha256:f8ccb58e91a8da7c67fe57d1e02e78bdb1bf1972abc721d4a542d27f5919ffdb",
+      claimIds: Object.freeze(["CH1"]),
+    }),
+  ]),
+});
+
+export function compileGovernedRelationDirections(input: {
+  readonly verticalId: string;
+  readonly artifacts: readonly {
+    readonly declaration: ArtifactEntityKindDefinition;
+    readonly typeIdentity: string;
+    readonly relationRequests: readonly GovernedArtifactRelationRequest[];
+  }[];
+  readonly authority?: GovernedRelationCompilationAuthority;
+}): readonly CanonicalRelationDirection[] {
+  const authority = input.authority ?? canonicalGovernedRelationAuthority,
+    artifactsByKind = new Map<string, string>(),
+    artifactTypeIdentities = new Set<string>();
+  for (const artifact of input.artifacts) {
+    artifactsByKind.set(artifact.declaration.id, artifact.typeIdentity);
+    artifactsByKind.set(artifact.typeIdentity, artifact.typeIdentity);
+    artifactTypeIdentities.add(artifact.typeIdentity);
+  }
+  const builtinKinds = new Set<string>(entityTypeContracts.map(({ kind }) => kind)),
+    rows = new Map<string, CanonicalRelationDirection>(),
+    relatesOrientations = new Map<string, CanonicalRelationDirection>();
+  for (const request of input.artifacts.flatMap(({ relationRequests }) => relationRequests)) {
+    const declaration = request.declaration,
+      sourceKind = resolveKind(declaration.sourceKind, artifactsByKind, builtinKinds),
+      targetKind = resolveKind(declaration.targetKind, artifactsByKind, builtinKinds);
+    if (!sourceKind)
+      invalidGovernedRelation(
+        `Relation source kind ${declaration.sourceKind} is not registered for vertical ${input.verticalId}.`,
+      );
+    if (!targetKind)
+      invalidGovernedRelation(
+        `Relation target kind ${declaration.targetKind} is not registered for vertical ${input.verticalId}.`,
+      );
+    if (!artifactTypeIdentities.has(sourceKind) && !artifactTypeIdentities.has(targetKind)) {
+      invalidGovernedRelation(
+        `Relation ${sourceKind} --${declaration.type}--> ${targetKind} must include an artifact kind ` +
+          `declared by vertical ${input.verticalId}.`,
+      );
+    }
+    validateGovernedSemantics(declaration, sourceKind, targetKind);
+    validateDecisionPin(declaration, authority);
+    const row: CanonicalRelationDirection = Object.freeze({
+        type: declaration.type,
+        sourceKind,
+        targetKind,
+        reads: declaration.reads,
+        registration: "ratified",
+        strength: declaration.strength,
+        governance: Object.freeze({
+          decisionClaimRef: declaration.decisionClaimRef,
+          decisionContentPin: declaration.decisionContentPin as `sha256:${string}`,
+          ...(declaration.rationale ? { rationale: declaration.rationale } : {}),
+        }),
+      }),
+      key = `${sourceKind}|${declaration.type}|${targetKind}`,
+      previous = rows.get(key);
+    if (previous) {
+      if (!sameGovernance(previous, row)) {
+        invalidGovernedRelation(
+          `Duplicate relation triple ${key} has conflicting reads, strength, or decision governance.`,
+        );
+      }
+      continue;
+    }
+    if (declaration.type === "relates" && sourceKind !== targetKind) {
+      const orientationKey = [sourceKind, targetKind].sort().join("|relates|"),
+        oriented = relatesOrientations.get(orientationKey);
+      if (oriented && (oriented.sourceKind !== sourceKind || oriented.targetKind !== targetKind)) {
+        invalidGovernedRelation(
+          `Relation direction is duplicated in reverse: ${sourceKind} --relates--> ${targetKind} conflicts with ` +
+            `${oriented.sourceKind} --relates--> ${oriented.targetKind}.`,
+        );
+      }
+      relatesOrientations.set(orientationKey, row);
+    }
+    rows.set(key, row);
+  }
+  return Object.freeze([...rows.values()]);
+}
+
+function resolveKind(
+  kind: string,
+  artifactsByKind: ReadonlyMap<string, string>,
+  builtinKinds: ReadonlySet<string>,
+): string | null {
+  return artifactsByKind.get(kind) ?? (builtinKinds.has(kind) ? kind : null);
+}
+
+function validateGovernedSemantics(
+  declaration: ArtifactRelationDefinition,
+  sourceKind: string,
+  targetKind: string,
+): void {
+  if (declaration.type === "relates") {
+    if (declaration.strength !== "weak")
+      invalidGovernedRelation("User-configured relates rows must have strength weak.");
+    return;
+  }
+  if (declaration.type !== "supersedes") {
+    invalidGovernedRelation(`Relation type ${declaration.type} is not open to governed vertical configuration.`);
+  }
+  if (sourceKind !== targetKind)
+    invalidGovernedRelation("User-configured supersedes rows must have the same source and target kind.");
+  if (declaration.strength === "strong" && !declaration.rationale?.trim()) {
+    invalidGovernedRelation("Strong user-configured supersedes rows require a non-blank rationale.");
+  }
+}
+
+function validateDecisionPin(
+  declaration: ArtifactRelationDefinition,
+  authority: GovernedRelationCompilationAuthority,
+): void {
+  const match = /^decision\/(?<decisionId>dec_[A-Za-z0-9_-]+)\/(?<claimId>(?:CH|C)[1-9][0-9]*)$/u.exec(
+      declaration.decisionClaimRef,
+    ),
+    decisionId = match?.groups?.decisionId,
+    claimId = match?.groups?.claimId;
+  if (!decisionId || !claimId)
+    invalidGovernedRelation(`Decision claim ref ${declaration.decisionClaimRef} is not canonical.`);
+  const decision = authority.decisions.find((candidate) => candidate.decisionId === decisionId);
+  if (!decision || !decision.claimIds.includes(claimId)) {
+    invalidGovernedRelation(
+      `Decision claim ref ${declaration.decisionClaimRef} does not exist in the compilation authority.`,
+    );
+  }
+  if (decision.state !== "in_effect") {
+    invalidGovernedRelation(
+      `Decision ${decisionId} is ${decision.state}; governed relation approval must be in_effect.`,
+    );
+  }
+  if (decision.contentPin !== declaration.decisionContentPin) {
+    invalidGovernedRelation(`Decision content pin mismatch for ${declaration.decisionClaimRef}.`);
+  }
+}
+
+function sameGovernance(left: CanonicalRelationDirection, right: CanonicalRelationDirection): boolean {
+  return (
+    left.reads === right.reads &&
+    left.strength === right.strength &&
+    JSON.stringify(left.governance ?? null) === JSON.stringify(right.governance ?? null)
+  );
+}
+
+function invalidGovernedRelation(message: string): never {
+  throw new Error(message);
+}

--- a/packages/kernel/src/domain/relation-direction.ts
+++ b/packages/kernel/src/domain/relation-direction.ts
@@ -1,5 +1,5 @@
 import type { RelationStrength, RelationType } from "./entity-relation.ts";
-import { entityTypeContracts, type EntityKind } from "./base-entity.ts";
+import { entityTypeContracts } from "./base-entity.ts";
 
 /** Whether the reading of an allowed triple has a registered semantics. */
 export type RelationDirectionRegistration = "ratified" | "unregistered" | "derived";

--- a/packages/kernel/src/domain/relation-direction.ts
+++ b/packages/kernel/src/domain/relation-direction.ts
@@ -1,4 +1,4 @@
-import type { RelationType } from "./entity-relation.ts";
+import type { RelationStrength, RelationType } from "./entity-relation.ts";
 import { entityTypeContracts, type EntityKind } from "./base-entity.ts";
 
 /** Whether the reading of an allowed triple has a registered semantics. */
@@ -12,8 +12,8 @@ export type RelationDirectionRegistration = "ratified" | "unregistered" | "deriv
  */
 export interface CanonicalRelationDirection {
   readonly type: RelationType;
-  readonly sourceKind: EntityKind;
-  readonly targetKind: EntityKind;
+  readonly sourceKind: string;
+  readonly targetKind: string;
   /** dec_mr74sbka: an active edge reads as `source <reads> target` in the storage direction. */
   readonly reads: string;
   /** The retired reverse alias this direction replaced, if the pair had one. The alias
@@ -22,6 +22,16 @@ export interface CanonicalRelationDirection {
   /** "ratified" = registered reading. "unregistered" = the grammar allows the triple but
    * its semantics await an owner decision; new data should avoid leaning on it. */
   readonly registration: RelationDirectionRegistration;
+  /** Code rows leave strength unconstrained. Governed vertical rows pin the only
+   * strength that may be written through that compiled registry revision. */
+  readonly strength?: RelationStrength;
+  /** Present only on governed vertical rows. This is an approval witness, not a
+   * second relation allowlist; writability still derives from this registry row. */
+  readonly governance?: {
+    readonly decisionClaimRef: string;
+    readonly decisionContentPin: `sha256:${string}`;
+    readonly rationale?: string;
+  };
 }
 
 /** Canonical Relation endpoint kinds derive from the BaseEntity contracts. */
@@ -226,6 +236,45 @@ export const canonicalRelationDirections: readonly CanonicalRelationDirection[] 
     return kind === "relation" ? [outgoing] : [outgoing, incoming];
   }),
 ];
+
+/**
+ * Build the one runtime registry consumed by relation admission. Kernel rows stay
+ * authoritative and governed rows can only add new, already-compiled cells.
+ */
+export function composeCanonicalRelationDirections(
+  compiledRows: readonly CanonicalRelationDirection[],
+): readonly CanonicalRelationDirection[] {
+  const rows = new Map<string, CanonicalRelationDirection>();
+  for (const row of [...canonicalRelationDirections, ...compiledRows]) {
+    const key = relationDirectionKey(row),
+      previous = rows.get(key);
+    if (!previous) {
+      rows.set(key, row);
+      continue;
+    }
+    if (!sameDirectionGovernance(previous, row)) {
+      throw new Error(
+        `Conflicting relation direction governance for ${row.sourceKind} --${row.type}--> ${row.targetKind}.`,
+      );
+    }
+  }
+  return Object.freeze([...rows.values()].map((row) => Object.freeze(row)));
+}
+
+export function relationDirectionKey(
+  row: Pick<CanonicalRelationDirection, "sourceKind" | "type" | "targetKind">,
+): string {
+  return `${row.sourceKind}|${row.type}|${row.targetKind}`;
+}
+
+function sameDirectionGovernance(left: CanonicalRelationDirection, right: CanonicalRelationDirection): boolean {
+  return (
+    left.reads === right.reads &&
+    left.registration === right.registration &&
+    left.strength === right.strength &&
+    JSON.stringify(left.governance ?? null) === JSON.stringify(right.governance ?? null)
+  );
+}
 
 /** Minimal structural shape the reverse query needs; callers keep their own richer rows. */
 export interface DirectedRelationEdge {

--- a/packages/kernel/src/domain/vertical-contract.ts
+++ b/packages/kernel/src/domain/vertical-contract.ts
@@ -15,6 +15,11 @@ import {
   noSdkExposure,
   type EntityKindContract,
 } from "./entity-kind-registry.ts";
+import {
+  compileGovernedRelationDirections,
+  type GovernedRelationCompilationAuthority,
+} from "./governed-relation-direction.ts";
+import { composeCanonicalRelationDirections, type CanonicalRelationDirection } from "./relation-direction.ts";
 
 export const COMPILED_VERTICAL_CONTRACT_SCHEMA = "compiled-vertical-contract/v1" as const;
 
@@ -42,6 +47,7 @@ export interface CompiledVerticalContract {
 export interface CompiledVerticalRegistry {
   readonly revision: number;
   readonly verticals: readonly CompiledVerticalContract[];
+  readonly relationDirections: readonly CanonicalRelationDirection[];
 }
 
 export class VerticalContractError extends Error {
@@ -57,7 +63,10 @@ export class VerticalContractError extends Error {
  * Pure five-stage compiler: strict decode, uniqueness/portability checks, entity contracts,
  * relation-request decoding, then one deeply immutable value for every consumer.
  */
-export function compileVerticalContract(source: unknown): CompiledVerticalContract {
+export function compileVerticalContract(
+  source: unknown,
+  authority?: GovernedRelationCompilationAuthority,
+): CompiledVerticalContract {
   let definition: VerticalDefinition;
   try {
     definition = decodeVerticalDefinition(source);
@@ -120,12 +129,31 @@ export function compileVerticalContract(source: unknown): CompiledVerticalContra
     });
   });
 
-  return deepFreeze({
+  const compiled = deepFreeze({
     schema: COMPILED_VERTICAL_CONTRACT_SCHEMA,
     typeIdentity: `${definition.id}@${definition.version}`,
     definition,
     artifactKinds: compiledArtifacts,
   });
+  compiledRelationDirections(compiled, authority);
+  return compiled;
+}
+
+export function compiledRelationDirections(
+  compiled: CompiledVerticalContract,
+  authority?: GovernedRelationCompilationAuthority,
+): readonly CanonicalRelationDirection[] {
+  try {
+    return compileGovernedRelationDirections({
+      verticalId: compiled.definition.id,
+      artifacts: compiled.artifactKinds,
+      ...(authority ? { authority } : {}),
+    });
+  } catch (error) {
+    throw new VerticalContractError(
+      `Vertical relation compilation failed: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
 }
 
 /**
@@ -136,6 +164,7 @@ export function acceptVerticalRegistryCandidate(input: {
   readonly current: CompiledVerticalRegistry;
   readonly expectedRevision: number;
   readonly source: unknown;
+  readonly decisionAuthority?: GovernedRelationCompilationAuthority;
 }): CompiledVerticalRegistry {
   if (input.expectedRevision !== input.current.revision) {
     throw Object.assign(
@@ -145,16 +174,23 @@ export function acceptVerticalRegistryCandidate(input: {
       { code: "stale_vertical_registry_revision" },
     );
   }
-  const accepted = compileVerticalContract(input.source),
+  const accepted = compileVerticalContract(input.source, input.decisionAuthority),
     verticals = input.current.verticals
       .filter(({ definition }) => definition.id !== accepted.definition.id)
       .concat(accepted)
-      .sort((left, right) => left.definition.id.localeCompare(right.definition.id));
-  return deepFreeze({ revision: input.current.revision + 1, verticals });
+      .sort((left, right) => left.definition.id.localeCompare(right.definition.id)),
+    relationDirections = composeCanonicalRelationDirections(
+      verticals.flatMap((vertical) => compiledRelationDirections(vertical, input.decisionAuthority)),
+    );
+  return deepFreeze({ revision: input.current.revision + 1, verticals, relationDirections });
 }
 
 export function emptyCompiledVerticalRegistry(): CompiledVerticalRegistry {
-  return Object.freeze({ revision: 0, verticals: Object.freeze([]) });
+  return Object.freeze({
+    revision: 0,
+    verticals: Object.freeze([]),
+    relationDirections: composeCanonicalRelationDirections([]),
+  });
 }
 
 function validateUniqueContracts(

--- a/packages/kernel/src/schemas/vertical-definition.ts
+++ b/packages/kernel/src/schemas/vertical-definition.ts
@@ -115,7 +115,11 @@ const ArtifactRelationSchema = Schema.Struct({
   type: RelationTypeSchema,
   sourceKind: NonBlankStringSchema,
   targetKind: NonBlankStringSchema,
+  reads: NonBlankStringSchema,
+  strength: Schema.Literal("weak", "strong"),
+  rationale: Schema.optional(NonBlankStringSchema),
   decisionClaimRef: NonBlankStringSchema,
+  decisionContentPin: Schema.String.pipe(Schema.pattern(/^sha256:[0-9a-f]{64}$/u)),
 });
 
 const ArtifactEntityKindSchema = Schema.Struct({

--- a/packages/kernel/test/contracts/governed-relation-rows.test.ts
+++ b/packages/kernel/test/contracts/governed-relation-rows.test.ts
@@ -1,0 +1,347 @@
+// harness-test-tier: contract
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import {
+  canonicalGovernedRelationAuthority,
+  type GovernedRelationCompilationAuthority,
+} from "../../src/domain/governed-relation-direction.ts";
+import { isAllowedRelationKindTriple, isAllowedRelationRecord } from "../../src/domain/entity-relation.ts";
+import {
+  acceptVerticalRegistryCandidate,
+  compiledRelationDirections,
+  compileVerticalContract,
+  emptyCompiledVerticalRegistry,
+} from "../../src/domain/vertical-contract.ts";
+
+const baseVertical = JSON.parse(
+    readFileSync(new URL("../../fixtures/schemas/vertical-definition/valid.json", import.meta.url), "utf8"),
+  ) as Record<string, unknown> & { entityKinds: unknown[]; projectionSchemas: unknown[] },
+  governancePin = canonicalGovernedRelationAuthority.decisions[0]!.contentPin,
+  artifactType = "custom/engineering/architecture-decision-record@1";
+
+test("governed triples compile into the one canonical runtime registry", () => {
+  const compiled = compileVerticalContract(verticalWith(artifact({ relations: [relation()] }))),
+    rows = compiledRelationDirections(compiled);
+  assert.deepEqual(rows, [
+    {
+      type: "relates",
+      sourceKind: artifactType,
+      targetKind: "decision",
+      reads: "the architecture decision record relates to the target decision",
+      registration: "ratified",
+      strength: "weak",
+      governance: {
+        decisionClaimRef: "decision/dec_29CCC98CD0241D0C9806AC1CF1/CH1",
+        decisionContentPin: governancePin,
+      },
+    },
+  ]);
+
+  const accepted = acceptVerticalRegistryCandidate({
+    current: emptyCompiledVerticalRegistry(),
+    expectedRevision: 0,
+    source: verticalWith(artifact({ relations: [relation()] })),
+  });
+  assert.equal(isAllowedRelationKindTriple(artifactType, "relates", "decision"), false);
+  assert.equal(isAllowedRelationKindTriple(artifactType, "relates", "decision", accepted.relationDirections), true);
+  assert.equal(
+    isAllowedRelationRecord(
+      { type: "relates", strength: "weak" },
+      artifactType,
+      "decision",
+      accepted.relationDirections,
+    ),
+    true,
+  );
+  assert.equal(
+    isAllowedRelationRecord(
+      { type: "relates", strength: "strong" },
+      artifactType,
+      "decision",
+      accepted.relationDirections,
+    ),
+    false,
+  );
+  assert.equal(Object.isFrozen(accepted.relationDirections), true);
+  assert.equal(
+    accepted.relationDirections.every((row) => Object.isFrozen(row)),
+    true,
+  );
+});
+
+for (const counterexample of [
+  {
+    name: "missing decision ref",
+    source() {
+      const { decisionClaimRef: _omitted, ...withoutDecision } = relation();
+      return verticalWith(artifact({ relations: [withoutDecision] }));
+    },
+    message: /decisionClaimRef/is,
+  },
+  {
+    name: "decision is not in_effect",
+    source: () => verticalWith(artifact({ relations: [relation()] })),
+    authority: authority({ state: "proposed" }),
+    message: /is proposed.*must be in_effect/is,
+  },
+  {
+    name: "decision content pin mismatch",
+    source: () => verticalWith(artifact({ relations: [relation({ decisionContentPin: `sha256:${"0".repeat(64)}` })] })),
+    message: /content pin mismatch/is,
+  },
+  {
+    name: "load-bearing relation type",
+    source: () => verticalWith(artifact({ relations: [relation({ type: "derives" })] })),
+    message: /derives is not open/is,
+  },
+  {
+    name: "reversed duplicate direction",
+    source: () =>
+      verticalWith(
+        artifact({
+          relations: [
+            relation(),
+            relation({
+              sourceKind: "decision",
+              targetKind: "architecture-decision-record",
+              reads: "the decision relates to the target architecture decision record",
+            }),
+          ],
+        }),
+      ),
+    message: /duplicated in reverse/is,
+  },
+  {
+    name: "builtin-only endpoints",
+    source: () =>
+      verticalWith(
+        artifact({
+          relations: [relation({ sourceKind: "decision", targetKind: "task" })],
+        }),
+      ),
+    message: /must include an artifact kind/is,
+  },
+  {
+    name: "unregistered endpoint kind",
+    source: () => verticalWith(artifact({ relations: [relation({ targetKind: "unregistered-report" })] })),
+    message: /target kind unregistered-report is not registered/is,
+  },
+  {
+    name: "duplicate triple with conflicting governance",
+    source: () =>
+      verticalWith(
+        artifact({
+          relations: [
+            relation({
+              type: "supersedes",
+              targetKind: "architecture-decision-record",
+              reads: "the architecture decision record supersedes the target record",
+            }),
+            relation({
+              type: "supersedes",
+              targetKind: "architecture-decision-record",
+              reads: "the newer architecture decision record supersedes the target record",
+              strength: "strong",
+              rationale: "A reviewed replacement may carry the stronger lineage signal.",
+            }),
+          ],
+        }),
+      ),
+    message: /conflicting reads, strength, or decision governance/is,
+  },
+] as const) {
+  test(`the whole vertical fails closed on ${counterexample.name}`, () => {
+    assert.throws(
+      () => compileVerticalContract(counterexample.source(), counterexample.authority),
+      counterexample.message,
+    );
+  });
+}
+
+test("identical duplicate triples fold into one row", () => {
+  const declaration = relation(),
+    compiled = compileVerticalContract(verticalWith(artifact({ relations: [declaration, { ...declaration }] })));
+  assert.equal(compiledRelationDirections(compiled).length, 1);
+});
+
+test("same-kind supersedes may be strong only with a rationale", () => {
+  const strong = relation({
+    type: "supersedes",
+    targetKind: "architecture-decision-record",
+    reads: "the architecture decision record supersedes the target record",
+    strength: "strong",
+    rationale: "The replacement was explicitly reviewed by the vertical owner.",
+  });
+  assert.equal(
+    compiledRelationDirections(compileVerticalContract(verticalWith(artifact({ relations: [strong] }))))[0]?.strength,
+    "strong",
+  );
+  assert.throws(
+    () => compileVerticalContract(verticalWith(artifact({ relations: [{ ...strong, rationale: undefined }] }))),
+    /require a non-blank rationale/is,
+  );
+});
+
+test("the governed vocabulary stays narrowed to relates and same-kind supersedes", () => {
+  assert.throws(
+    () =>
+      compileVerticalContract(
+        verticalWith(artifact({ relations: [relation({ type: "relates", strength: "strong" })] })),
+      ),
+    /relates rows must have strength weak/is,
+  );
+  assert.throws(
+    () =>
+      compileVerticalContract(
+        verticalWith(
+          artifact({
+            relations: [
+              relation({
+                type: "supersedes",
+                targetKind: "decision",
+                reads: "the architecture decision record supersedes the target decision",
+              }),
+            ],
+          }),
+        ),
+      ),
+    /supersedes rows must have the same source and target kind/is,
+  );
+  assert.throws(
+    () => compileVerticalContract(verticalWith(artifact({ relations: [relation({ type: "references" })] }))),
+    /vertical definition decode failed/is,
+  );
+});
+
+test("decision approval must resolve the exact decision anchor", () => {
+  assert.throws(
+    () =>
+      compileVerticalContract(
+        verticalWith(
+          artifact({
+            relations: [
+              relation({
+                decisionClaimRef: "decision/dec_29CCC98CD0241D0C9806AC1CF1/CH2",
+              }),
+            ],
+          }),
+        ),
+      ),
+    /does not exist in the compilation authority/is,
+  );
+});
+
+test("configuration removal denies new writes without mutating an existing active edge", () => {
+  const first = acceptVerticalRegistryCandidate({
+      current: emptyCompiledVerticalRegistry(),
+      expectedRevision: 0,
+      source: verticalWith(artifact({ relations: [relation()] })),
+    }),
+    existingEdge = Object.freeze({
+      type: "relates" as const,
+      strength: "weak" as const,
+      state: "active" as const,
+      eventHistory: Object.freeze(["relation_created"]),
+    }),
+    removed = acceptVerticalRegistryCandidate({
+      current: first,
+      expectedRevision: 1,
+      source: verticalWith(artifact({ relations: [] })),
+    });
+  assert.equal(isAllowedRelationRecord(existingEdge, artifactType, "decision", first.relationDirections), true);
+  assert.equal(isAllowedRelationRecord(existingEdge, artifactType, "decision", removed.relationDirections), false);
+  assert.equal(existingEdge.state, "active");
+  assert.deepEqual(existingEdge.eventHistory, ["relation_created"]);
+
+  const explicitlyRetired = Object.freeze({
+    ...existingEdge,
+    state: "retired" as const,
+    eventHistory: Object.freeze([...existingEdge.eventHistory, "relation_retired"]),
+  });
+  assert.equal(explicitlyRetired.state, "retired");
+  assert.deepEqual(explicitlyRetired.eventHistory, ["relation_created", "relation_retired"]);
+});
+
+test("the center serializes competing edge candidates on the registry revision fence", () => {
+  const initial = emptyCompiledVerticalRegistry(),
+    edgeOne = verticalWith(artifact({ relations: [relation()] })),
+    edgeTwo = verticalWith(
+      artifact({
+        relations: [
+          relation({
+            type: "supersedes",
+            targetKind: "architecture-decision-record",
+            reads: "the architecture decision record supersedes the target record",
+          }),
+        ],
+      }),
+    ),
+    accepted = acceptVerticalRegistryCandidate({ current: initial, expectedRevision: 0, source: edgeOne });
+  assert.throws(
+    () => acceptVerticalRegistryCandidate({ current: accepted, expectedRevision: 0, source: edgeTwo }),
+    (error: unknown) => (error as { code?: string }).code === "stale_vertical_registry_revision",
+  );
+  assert.equal(isAllowedRelationKindTriple(artifactType, "relates", "decision", accepted.relationDirections), true);
+  assert.equal(
+    isAllowedRelationKindTriple(artifactType, "supersedes", artifactType, accepted.relationDirections),
+    false,
+  );
+});
+
+function authority(
+  overrides: Partial<GovernedRelationCompilationAuthority["decisions"][number]> = {},
+): GovernedRelationCompilationAuthority {
+  return {
+    decisions: [
+      {
+        decisionId: "dec_29CCC98CD0241D0C9806AC1CF1",
+        state: "in_effect",
+        contentPin: governancePin,
+        claimIds: ["CH1"],
+        ...overrides,
+      },
+    ],
+  };
+}
+
+function verticalWith(...artifacts: readonly unknown[]): Record<string, unknown> {
+  return {
+    ...baseVertical,
+    id: "custom/engineering",
+    version: "1.0.0",
+    entityKinds: [...baseVertical.entityKinds, ...artifacts],
+    projectionSchemas: [
+      ...baseVertical.projectionSchemas,
+      { id: "artifact-descriptor", schemaRef: "schema://artifact-descriptor" },
+    ],
+  };
+}
+
+function artifact(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id: "architecture-decision-record",
+    entityType: "artifact",
+    version: 1,
+    idPrefix: "ADR",
+    display: { singular: "Architecture Decision Record", plural: "Architecture Decision Records" },
+    descriptorSchemaRef: "schema://artifact-descriptor",
+    store: { pathTemplate: "entities/architecture-decision-records/{id}.json" },
+    locatorKinds: ["repository-path"],
+    relations: [],
+    ...overrides,
+  };
+}
+
+function relation(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    type: "relates",
+    sourceKind: "architecture-decision-record",
+    targetKind: "decision",
+    reads: "the architecture decision record relates to the target decision",
+    strength: "weak",
+    decisionClaimRef: "decision/dec_29CCC98CD0241D0C9806AC1CF1/CH1",
+    decisionContentPin: governancePin,
+    ...overrides,
+  };
+}

--- a/packages/preset/assets/software-coding/vertical.json
+++ b/packages/preset/assets/software-coding/vertical.json
@@ -48,7 +48,17 @@
         "pathTemplate": "entities/architecture-decision-records/{id}.json"
       },
       "locatorKinds": ["repository-path"],
-      "relations": []
+      "relations": [
+        {
+          "type": "relates",
+          "sourceKind": "architecture-decision-record",
+          "targetKind": "decision",
+          "reads": "the architecture decision record relates to the target decision",
+          "strength": "weak",
+          "decisionClaimRef": "decision/dec_29CCC98CD0241D0C9806AC1CF1/CH1",
+          "decisionContentPin": "sha256:f8ccb58e91a8da7c67fe57d1e02e78bdb1bf1972abc721d4a542d27f5919ffdb"
+        }
+      ]
     }
   ],
   "contractEntityKinds": ["task", "decision", "fact"],

--- a/packages/preset/src/preset-extension-model.ts
+++ b/packages/preset/src/preset-extension-model.ts
@@ -431,7 +431,16 @@ function validateVerticalDefinitionShape(input: unknown, path: string, issues: E
             validateObjectKeys(
               relation,
               `${entityPath}.relations[${relationIndex}]`,
-              ["type", "sourceKind", "targetKind", "decisionClaimRef"],
+              [
+                "type",
+                "sourceKind",
+                "targetKind",
+                "reads",
+                "strength",
+                "rationale",
+                "decisionClaimRef",
+                "decisionContentPin",
+              ],
               issues,
             );
           }

--- a/packages/preset/test/preset-resolver-vertical-scripts.test.ts
+++ b/packages/preset/test/preset-resolver-vertical-scripts.test.ts
@@ -280,7 +280,17 @@ test("software coding declaration closes lifecycle, repository, projection, and 
         pathTemplate: "entities/architecture-decision-records/{id}.json",
       },
       locatorKinds: ["repository-path"],
-      relations: [],
+      relations: [
+        {
+          type: "relates",
+          sourceKind: "architecture-decision-record",
+          targetKind: "decision",
+          reads: "the architecture decision record relates to the target decision",
+          strength: "weak",
+          decisionClaimRef: "decision/dec_29CCC98CD0241D0C9806AC1CF1/CH1",
+          decisionContentPin: "sha256:f8ccb58e91a8da7c67fe57d1e02e78bdb1bf1972abc721d4a542d27f5919ffdb",
+        },
+      ],
     },
   ]);
   assert.deepEqual(vertical.contractEntityKinds, ["task", "decision", "fact"]);


### PR DESCRIPTION
# English

## Summary

GovernedEntity W1-C (task_9008af16): vertical `relations[]` declarations compile into governed
relation rows through the W1-A compiler, so an artifact kind's relations are data the kernel validates
rather than code each consumer re-derives.

- `packages/kernel/src/schemas/vertical-definition.ts` decodes the `relations[]` declaration on an
  artifact kind; `packages/kernel/src/domain/governed-relation-direction.ts` and the `relations[]`
  branch of `vertical-contract.ts` compile each row into a canonical direction triple that the
  existing relation-direction registry accepts.
- Governance policy (dec_29CCC98CD0241D0C9806AC1CF1): user rows normalize artifact ids to compiled type
  identities; only weak `relates` and same-kind `supersedes` (weak, or strong with a non-blank
  rationale) enter the composed canonical registry; every row must resolve an in_effect decision
  claim and match its sha256 content pin. Exact duplicates fold; reversed `relates`, unregistered
  endpoints, builtin-only triples and read/strength/governance conflicts fail the whole vertical.
- `references` is not added to the vocabulary (the plan's narrow default; no synonym substituted).
- `software-coding/vertical.json` declares the ADR kind's relations as the living fixture.

## Architectural Justification

- Mechanism sentence: a relation that lives only in a vertical's JSON but is validated by the same
  registry as builtin relations can neither invent a direction nor escape the decision pin; the
  compiler is the one place where "declared" becomes "governed".
- Rebased on top of W1-B (#2151): the compiler keeps B's descriptor-schema / action-catalog wiring and
  C's `relations[]` branch; `CompiledVerticalContract` shape unchanged (CEO ruling F-E96079E6).

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none

## Machine-Readable Declarations

Production-Delta: +312/-16
Dependency-Change: none

### Optional Evidence Claims

None.

## Task And Scope

- Harness task task_9008af1613ce919f94cc6e81ab (GovernedEntity W1-C) under milestone root
  task_e91dd004d2a4e7a7c90a6fd40a; depends on W1-A (#2148) and, by ordering ruling, W1-B (#2151).
  Branch `codex/ge-w1c-relation-rows`. Fact F-0771346F.

## Version Impact

- Version: no change. Publish impact: none (declaration path; existing verticals without
  `relations[]` compile as before).

## Governance Declaration

- Protected surface touched: no (`tools/` and `.github/` untouched). Authorizing task:
  task_9008af1613ce919f94cc6e81ab. Break-glass: no.

## Verification

- Worker (Sol): governed relation rows contract 13/13, vertical contract 5/5, relation direction 8/8,
  isolated Ubuntu integration 4/4; entry walls 12 PASS / 0 RED.
- CEO after rebase onto cf1eadae4: typecheck 0; cli-structure, dead-export, duplicate-definition,
  implementation-contracts, W3 write-authority, import-boundaries, schema-closure, G36, G0-5 all green.
- [ ] Full suites: GitHub CI is the authority.

## Review Evidence

- CEO semantic review against the W1-C plan and dec_29CCC98C: whitelist limited to weak `relates` and
  same-kind `supersedes`, decision-claim pin required, fail-closed on conflicts, `references` left out.

## Residual Risk

- The global relation-lifecycle vocabulary migration is out of scope: it touches W1-B's exclusive
  daemon entity-action surface; old lifecycle words are not claimed to be at zero production hits.

---

# 中文

## 概要

GovernedEntity W1-C(task_9008af16):vertical 的 `relations[]` 声明经 W1-A 编译器编译成受治理的关系行,
artifact kind 的关系是 kernel 校验的数据,不是每个消费者各自推导的代码。

- 解码 `relations[]`,`governed-relation-direction.ts` + 编译器 `relations[]` 分支把每行编译成既有关系方向注册表接受的规范三元组。
- 治理策略(dec_29CCC98C):只允许 weak `relates` 与同 kind `supersedes`(strong 必须带 rationale);每行必须解析到 in_effect
  的 decision claim 并匹配 sha256 内容钉;重复折叠,反向 relates / 未注册端点 / builtin-only 三元组 / 冲突整体失败。
- `references` 未进词表(plan 收窄默认),未用近义词替代;`vertical.json` 声明 ADR kind 的关系作活体夹具。

## 架构辩护

- 机制句:只写在 vertical JSON 里却由同一注册表校验的关系,既不能自造方向也逃不出 decision 钉;编译器是「声明」变
  「受治理」的唯一一处。
- 在 W1-B 之上 rebase:保留 B 的 descriptor/action 接入与 C 的 relations[] 分支,合同形状不变(F-E96079E6)。

## 机读声明

`Production-Delta: +312/-16`;无依赖变更。

## 治理声明

- 未触碰 protected surface;授权任务 task_9008af1613ce919f94cc6e81ab;无 break-glass。

## 验证

- worker:契约 13/13、编译器 5/5、方向 8/8、Ubuntu 隔离 4/4;CEO rebase 到 cf1eadae4 后 typecheck 0、九门绿。完整权威 = GitHub CI。

## 残余风险

- 全局 relation lifecycle 词表迁移不在本切片(触及 W1-B 独占面)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xya5P7vnE4P29vXmHAkFhd
