### PR TITLE
fix(gui): one ledger probe drives dependent reads; share query keys across views

### DIFF
--- a/packages/gui/src/renderer/agenda-data.ts
+++ b/packages/gui/src/renderer/agenda-data.ts
@@ -15,8 +15,11 @@ export function agendaQuery(repoId: string) {
     queryKey: agendaQueryKeys.read(repoId),
     queryFn: () => readAgenda(repoId),
     staleTime: 10_000,
-    refetchInterval: AGENDA_REFRESH_INTERVAL_MS,
-    refetchOnWindowFocus: "always" as const,
+    // The interval only carries an unfinished cursor read to completion; a settled agenda is
+    // refetched by the ledger cut (invalidateLedgerDependents), not by its own timer.
+    refetchInterval: (query: { readonly state: { readonly data?: AgendaSuccess } }) =>
+      query.state.data?.page?.nextCursor ? AGENDA_REFRESH_INTERVAL_MS : false,
+    refetchOnWindowFocus: true,
   };
 }
 

--- a/packages/gui/src/renderer/agent-runtime-client.ts
+++ b/packages/gui/src/renderer/agent-runtime-client.ts
@@ -36,6 +36,20 @@ export type SessionGroupsQuery = {
   readonly squadId?: string;
   readonly limit?: number;
 };
+/**
+ * One query key per daemon read, shared by every view that shows it (task detail, sessions page,
+ * runtime workspace): the same dispatch list or runtime overview was fetched under three
+ * different keys, so react-query could neither dedupe the requests nor invalidate them together.
+ */
+export const runtimeQueryKeys = {
+  dispatchesAll: (repoId: string) => ["dispatches", repoId] as const,
+  dispatches: (repoId: string, taskId: string) => ["dispatches", repoId, taskId] as const,
+  overviewAll: (repoId: string) => ["runtime-overview", repoId] as const,
+  overview: (repoId: string, taskId: string) => ["runtime-overview", repoId, taskId] as const,
+  sessionAll: (repoId: string) => ["runtime-session", repoId] as const,
+  session: (repoId: string, runtimeSessionId: string) => ["runtime-session", repoId, runtimeSessionId] as const,
+};
+
 export const agentRuntimeClient = {
   overview: async (
     repoId: string,

--- a/packages/gui/src/renderer/components/runtime/useRuntimeWorkspace.ts
+++ b/packages/gui/src/renderer/components/runtime/useRuntimeWorkspace.ts
@@ -4,7 +4,7 @@ import { consumeKnownError } from "../../../api/error-consumption.ts";
 import type { AgentDeclarationV1, SquadDeclarationV1 } from "../../../../../daemon/src/agent-entities.contract.ts";
 import { successfulAgentRuntimeResult } from "../../../../../daemon/src/agent-runtime-contract.ts";
 import { agentEntityClient, type EntitySaveResult } from "../../agent-entity-client.ts";
-import { agentRuntimeClient } from "../../agent-runtime-client.ts";
+import { agentRuntimeClient, runtimeQueryKeys } from "../../agent-runtime-client.ts";
 import { harnessClient } from "../../api-client.ts";
 import { buildDispatchSpawnInput, type DispatchRequest } from "../../dispatch-flow.ts";
 import { runtimeCommandClient } from "../../runtime-command-client.ts";
@@ -218,7 +218,9 @@ export function useSessionsWorkspace(
       client.invalidateQueries({ queryKey: ["session-groups", repoId] }),
       client.invalidateQueries({ queryKey: ["squad-runs", repoId] }),
       client.invalidateQueries({ queryKey: ["squad-run-detail", repoId] }),
-      client.invalidateQueries({ queryKey: ["sessions-page", repoId] }),
+      client.invalidateQueries({ queryKey: runtimeQueryKeys.dispatchesAll(repoId) }),
+      client.invalidateQueries({ queryKey: runtimeQueryKeys.overviewAll(repoId) }),
+      client.invalidateQueries({ queryKey: runtimeQueryKeys.sessionAll(repoId) }),
     ]);
   });
   return {

--- a/packages/gui/src/renderer/components/taskDetail/TaskDetailSections.tsx
+++ b/packages/gui/src/renderer/components/taskDetail/TaskDetailSections.tsx
@@ -14,7 +14,7 @@ import type {
   AgentRuntimeSessionResult,
 } from "../../../../../daemon/src/agent-runtime-contract.ts";
 import type { GuiSubmissionV1, RelationFactRow, TaskDispatchProjectionRow } from "../../../api/renderer-dto.ts";
-import { agentRuntimeClient } from "../../agent-runtime-client.ts";
+import { agentRuntimeClient, runtimeQueryKeys } from "../../agent-runtime-client.ts";
 import { harnessClient } from "../../api-client.ts";
 import type { TaskMutationFeedback } from "../../task-actions.ts";
 import { useTaskDocumentQuery } from "../../task-data.ts";
@@ -142,14 +142,14 @@ export function TaskDispatchTab({
   readonly onNavigateEntity: (ref: string) => void;
 }) {
   const dispatches = useQuery({
-    queryKey: ["task-detail", task.projectId, task.taskId, "dispatches"],
+    queryKey: runtimeQueryKeys.dispatches(task.projectId, task.taskId),
     queryFn: () => harnessClient.getTaskDispatches({ repoId: task.projectId, taskId: task.taskId }),
     staleTime: 4_000,
   });
   const rows = dispatches.data?.dispatches ?? [];
   const sessions = useQueries({
     queries: rows.map((row) => ({
-      queryKey: ["task-detail", task.projectId, row.runtimeSessionId, "session"],
+      queryKey: runtimeQueryKeys.session(task.projectId, row.runtimeSessionId),
       queryFn: () => agentRuntimeClient.session(task.projectId, row.runtimeSessionId),
       staleTime: 4_000,
     })),
@@ -520,7 +520,7 @@ export function TaskRelationsTab({
   readonly onOpenSession: (runtimeSessionId: string) => void;
 }) {
   const runtime = useQuery({
-    queryKey: ["task-detail", task.projectId, task.taskId, "runtime-overview"],
+    queryKey: runtimeQueryKeys.overview(task.projectId, task.taskId),
     queryFn: () => agentRuntimeClient.overview(task.projectId, task.taskId),
     staleTime: 4_000,
   });

--- a/packages/gui/src/renderer/task-data.ts
+++ b/packages/gui/src/renderer/task-data.ts
@@ -1,6 +1,7 @@
 import { useQuery, useQueryClient, type QueryClient } from "@tanstack/react-query";
 import { harnessClient, type TaskListSuccess, type TaskQueryFacets } from "./api-client.ts";
 import { agendaQueryKeys } from "./agenda-data.ts";
+import { runtimeQueryKeys } from "./agent-runtime-client.ts";
 import { workspaceSummaryQueryKeys } from "./workspace-summary-data.ts";
 
 export const LEDGER_REFRESH_INTERVAL_MS = 2_000;
@@ -19,6 +20,9 @@ export function taskListQuery(repoId: string) {
     queryFn: () => readTaskList(repoId),
     staleTime: 10_000,
     refetchInterval: LEDGER_REFRESH_INTERVAL_MS,
+    // This list is the one ledger probe: its interval and an immediate re-probe on focus are what
+    // advance the cut, and a changed cut fans out to every dependent read (invalidateLedgerDependents).
+    // Dependent reads therefore need neither their own timer nor an unconditional focus refetch.
     refetchOnWindowFocus: "always" as const,
   };
 }
@@ -125,6 +129,8 @@ export async function invalidateLedgerDependents(queryClient: QueryClient, repoI
     queryClient.invalidateQueries({ queryKey: ["triadic", repoId], refetchType: "active" }),
     queryClient.invalidateQueries({ queryKey: agendaQueryKeys.read(repoId), refetchType: "active" }),
     queryClient.invalidateQueries({ queryKey: workspaceSummaryQueryKeys.read(repoId), refetchType: "active" }),
+    queryClient.invalidateQueries({ queryKey: runtimeQueryKeys.dispatchesAll(repoId), refetchType: "active" }),
+    queryClient.invalidateQueries({ queryKey: runtimeQueryKeys.overviewAll(repoId), refetchType: "active" }),
   ]);
 }
 

--- a/packages/gui/src/renderer/views/DecisionPoolView.tsx
+++ b/packages/gui/src/renderer/views/DecisionPoolView.tsx
@@ -233,7 +233,7 @@ export function DecisionPoolView({
         ...(productLineFilter !== "all" ? { productLine: productLineFilter } : {}),
       }),
     enabled: remoteEnabled,
-    staleTime: 0,
+    staleTime: 4_000,
   });
   const remoteIds = remote.data?.status === "ready" ? new Set(remote.data.decisionIds) : null;
   const currentGroup = summary.groups.find((group) => group.id === tab) ?? summary.groups[0]!;

--- a/packages/gui/src/renderer/views/SessionsView.tsx
+++ b/packages/gui/src/renderer/views/SessionsView.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useQueries, useQuery } from "@tanstack/react-query";
 import { agentEntityClient } from "../agent-entity-client.ts";
-import { agentRuntimeClient } from "../agent-runtime-client.ts";
+import { agentRuntimeClient, runtimeQueryKeys } from "../agent-runtime-client.ts";
 import { harnessClient } from "../api-client.ts";
 import { t } from "../i18n/index.tsx";
 import { Badge, Btn, Empty, SegCtl } from "../components/runtime/parts.tsx";
@@ -145,14 +145,14 @@ export function SessionsView({
   );
   const roundsQueries = useQueries({
     queries: expandedTasks.map((group) => ({
-      queryKey: ["sessions-page", repoId, "rounds", group.taskId],
+      queryKey: runtimeQueryKeys.dispatches(repoId, group.taskId),
       queryFn: () => harnessClient.getTaskDispatches({ repoId, taskId: group.taskId }),
       staleTime: 4_000,
     })),
   });
   const taskSessionQueries = useQueries({
     queries: expandedTasks.map((group) => ({
-      queryKey: ["sessions-page", repoId, "task-sessions", group.taskId],
+      queryKey: runtimeQueryKeys.overview(repoId, group.taskId),
       queryFn: () => agentRuntimeClient.overview(repoId, group.taskId),
       staleTime: 4_000,
     })),
@@ -204,7 +204,7 @@ export function SessionsView({
       groups.find(({ latestRound }) => latestRound !== null)?.latestRound?.runtimeSessionId ?? null,
     selectedSessionId = focusedSessionId ?? defaultSessionId;
   const selectedSession = useQuery({
-    queryKey: ["sessions-page", repoId, "session", selectedSessionId],
+    queryKey: runtimeQueryKeys.session(repoId, selectedSessionId ?? ""),
     queryFn: () => agentRuntimeClient.session(repoId, selectedSessionId!),
     enabled: selectedSessionId !== null,
     staleTime: 4_000,

--- a/packages/gui/src/renderer/workspace-summary-data.ts
+++ b/packages/gui/src/renderer/workspace-summary-data.ts
@@ -2,7 +2,7 @@ import { useQuery } from "@tanstack/react-query";
 import { harnessClient } from "./api-client.ts";
 
 export const workspaceSummaryQueryKeys = {
-  read: (repoId: string) => ["workspace-summary", repoId] as const
+  read: (repoId: string) => ["workspace-summary", repoId] as const,
 };
 
 export function workspaceSummaryQuery(repoId: string) {
@@ -10,7 +10,7 @@ export function workspaceSummaryQuery(repoId: string) {
     queryKey: workspaceSummaryQueryKeys.read(repoId),
     queryFn: () => harnessClient.getWorkspaceSummary({ repoId }),
     staleTime: 10_000,
-    refetchOnWindowFocus: "always" as const
+    refetchOnWindowFocus: true,
   };
 }
 
@@ -18,6 +18,6 @@ export function useWorkspaceSummaryQuery(repoId: string | null) {
   const selectedRepoId = repoId ?? "unselected";
   return useQuery({
     ...workspaceSummaryQuery(selectedRepoId),
-    enabled: repoId !== null
+    enabled: repoId !== null,
   });
 }

--- a/packages/gui/test/agenda-data.vitest.ts
+++ b/packages/gui/test/agenda-data.vitest.ts
@@ -1,6 +1,6 @@
 // harness-test-tier: contract
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { readAgenda } from "../src/renderer/agenda-data.ts";
+import { AGENDA_REFRESH_INTERVAL_MS, agendaQuery, readAgenda } from "../src/renderer/agenda-data.ts";
 import { harnessClient, type AgendaSuccess } from "../src/renderer/api-client.ts";
 import type { AgendaRead } from "../src/api/renderer-dto.ts";
 
@@ -92,5 +92,18 @@ describe("agenda read discipline", () => {
     );
     const pending = await readAgenda("repo-a");
     expect(pending.status).toBe("pending");
+  });
+});
+
+describe("agenda refresh cadence", () => {
+  it("polls only to finish an open cursor window; a settled agenda waits for the ledger cut", () => {
+    const interval = agendaQuery("repo-a").refetchInterval as (query: {
+      readonly state: { readonly data?: Partial<AgendaSuccess> };
+    }) => number | false;
+    expect(interval({ state: { data: { page: { nextCursor: "c2" } } as Partial<AgendaSuccess> } })).toBe(
+      AGENDA_REFRESH_INTERVAL_MS,
+    );
+    expect(interval({ state: { data: { page: { nextCursor: null } } as Partial<AgendaSuccess> } })).toBe(false);
+    expect(interval({ state: {} })).toBe(false);
   });
 });

--- a/packages/gui/test/gui-s3-r1-repo-isolation.vitest.ts
+++ b/packages/gui/test/gui-s3-r1-repo-isolation.vitest.ts
@@ -61,7 +61,9 @@ describe("GUI S3 R1 repository isolation", () => {
       await observer.refetch();
       await vi.advanceTimersByTimeAsync(20_000);
       expect(read).toHaveBeenCalledTimes(1);
-      expect(options.refetchOnWindowFocus).toBe("always");
+      // Focus refetches past staleTime only; an immediate refresh on focus comes through the ledger
+      // probe (taskListQuery is "always") advancing the cut, not from every read re-probing itself.
+      expect(options.refetchOnWindowFocus).toBe(true);
     } finally {
       unsubscribe();
       client.clear();


### PR DESCRIPTION
# English

## Summary

Follow-up to the GUI↔daemon investigation (#2152, #2153). The renderer already refetches every dependent read when the ledger cut moves (`invalidateLedgerDependents`), yet several reads also ran their own timers and refetched unconditionally on every window focus, and the same daemon read (task dispatches, runtime overview, runtime session) was fetched under three different query keys by task detail, the sessions page and the runtime workspace, so react-query could neither dedupe those requests nor invalidate them together. On a loaded single-event-loop daemon this fan-out is what turned into visible read failures. This PR keeps one ledger probe and makes everything else follow it.

## Architectural Justification

- Not required (churn well under 200 lines).

## What Changed

- `task-data.ts`: `tasks.list` stays the single ledger probe (2s interval, immediate re-probe on focus); the cut invalidation set now also covers the shared dispatch and runtime-overview keys.
- `agenda-data.ts`: the interval only carries an open cursor window to completion; a settled agenda waits for the ledger cut. Focus refetch past staleTime only.
- `workspace-summary-data.ts`: focus refetch past staleTime only (an immediate refresh on focus arrives through the probe advancing the cut).
- `agent-runtime-client.ts`: `runtimeQueryKeys` — one key per daemon read; `TaskDetailSections.tsx`, `SessionsView.tsx` use them; `useRuntimeWorkspace.ts`'s runtime channel invalidates those keys instead of the per-view `sessions-page` prefix.
- `DecisionPoolView.tsx`: remote decision read gets a 4s staleTime instead of refetching on every mount.
- Tests: `agenda-data.vitest.ts` covers the conditional interval; `gui-s3-r1-repo-isolation.vitest.ts` expectation updated from `"always"` to `true` with the reasoning inline.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: use the single CI-backed `Production-Delta` declaration below; do not enter a second metric.

## Machine-Readable Declarations

Production-Delta: +41/-16

## Task And Scope

- Harness task: task_ceb7630377af8c6e7d38d4ff45
- Branch: codex/gui-read-load
- Public scope: packages/gui/src/renderer (8 files) and two vitest files
- Private planning/evidence updated: yes
- Out of scope: a daemon-side change stream replacing the probe (needs a new protocol facet; recorded on the task), the terminal components (untouched)

## Version Impact

- Version: no version change because this is a renderer behaviour fix
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none
- Authority: not applicable
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: 428c419f1fcfc07c859facebc35d781d54e7bd5f
- Branch merge-base with `origin/main`: 428c419f1fcfc07c859facebc35d781d54e7bd5f
- Last `git fetch origin` time: 2026-09-02 (before branching)
- Sync method: none needed
- Public diff command: `git diff 428c419f1fcfc07c859facebc35d781d54e7bd5f..HEAD`
- Private evidence commit/path: task_ceb7630377af8c6e7d38d4ff45; read-only survey of every renderer query (intervals, focus, keys, fan-out) recorded as a fact
- Reviewer evidence path: this PR
- GitHub Actions `rewrite-ci` run URL: pending
- [ ] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [x] `npm test` (targeted vitest: triadic-read-scoping, entity-id-links, gui-s3-r1-repo-isolation, agenda-data, ledger-invalidation-scope, runtime-workspace-interactions, task-detail-expression, agent-runtime-sessions, gui-w6-ledger-read-shape — 116 tests green)
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Not run: full local suite and typecheck (worktree lacks built project references); CI is the authority.

## Review Evidence

- Self-review: every changed key site grepped; no remaining `sessions-page` or per-view `task-detail` dispatch/overview keys.
- Reviewer subagent: read-only survey of renderer polling, fan-out and available push channels
- Human review: pending
- Blocking findings: none

## Residual Risk

- A settled agenda now refreshes only when the ledger cut moves; if an agenda source ever changed without a ledger event it would wait for the next cut.
- Steady-state daemon load drops from roughly 48 requests a minute to about 36 at the root shell; view-level fan-out (sessions page per expanded group, task detail per dispatch) is unchanged.

## References

- Task: task_ceb7630377af8c6e7d38d4ff45
- Evidence: fact on the task (query survey); daemon connection log analysis on task_f22f99e8968179293188baeb53
- Review: this PR

---

# 中文

## 概要

GUI↔daemon 排查（#2152、#2153）的后续。renderer 本来就在台账 cut 前进时重取全部依赖读面（`invalidateLedgerDependents`），但若干读面还各自开着定时器、每次窗口聚焦无条件重读；同一份 daemon 读（任务派工、runtime 概览、runtime 会话）在任务详情、会话页、runtime 工作区用三套不同 query key 拉取，react-query 既无法去重也无法一起失效。在单事件循环的 daemon 负载高时，这些扇出就变成可见的读取失败。本 PR 只保留一个台账探针，其余都跟着它走。

## 架构辩护

- 不需要（改动远小于 200 行）。

## 改动内容

- `task-data.ts`：`tasks.list` 仍是唯一台账探针（2s 间隔、聚焦即重探）；cut 失效集合新增共享的派工与 runtime 概览 key。
- `agenda-data.ts`：定时器只负责把未读完的 cursor 窗口读完；读完的议程等台账 cut。聚焦只在超过 staleTime 时重读。
- `workspace-summary-data.ts`：聚焦只在超过 staleTime 时重读（聚焦时的即时刷新由探针推进 cut 带来）。
- `agent-runtime-client.ts`：`runtimeQueryKeys`，每个 daemon 读一个 key；`TaskDetailSections.tsx`、`SessionsView.tsx` 改用；`useRuntimeWorkspace.ts` 的 runtime 通道失效这些 key 而不是按视图前缀。
- `DecisionPoolView.tsx`：远端决策读改为 4s staleTime，不再每次挂载必读。
- 测试：`agenda-data.vitest.ts` 覆盖条件间隔；`gui-s3-r1-repo-isolation.vitest.ts` 的期望由 `"always"` 改为 `true` 并写明理由。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 同 commit 删除的门 / fixture：none
- 生产净行数：引用英文块中的 `Production-Delta`。

## 机读声明说明

- 机读声明只在英文块出现。

## 任务与范围

- Harness 任务：task_ceb7630377af8c6e7d38d4ff45
- 分支：codex/gui-read-load
- 公开范围：packages/gui/src/renderer 8 个文件与两个 vitest 文件
- 私有计划 / 证据是否已更新：yes
- 范围外：用 daemon 变更流替代探针（需新增协议 facet，已记在 task 上）；终端组件未动

## 版本影响

- 版本：不改版本，原因是 renderer 行为修复
- 发布影响：不发布

## 治理声明

- 是否触碰 protected surface：no
- protected surface 范围：无
- 依据：不适用
- 机器检查边界：本 PR 只声明该段存在；是否真实充分由 reviewer 判断。
- Break-glass：no
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- `origin/main` 基准 SHA：428c419f1fcfc07c859facebc35d781d54e7bd5f
- 当前分支与 `origin/main` 的 merge-base：428c419f1fcfc07c859facebc35d781d54e7bd5f
- 最近一次 `git fetch origin` 时间：2026-09-02（建分支前）
- 同步方式：不需要
- 公开 diff 命令：`git diff 428c419f1fcfc07c859facebc35d781d54e7bd5f..HEAD`
- 私有证据 commit/path：task_ceb7630377af8c6e7d38d4ff45；renderer 全部 query 的只读调查已记为 fact
- Reviewer 证据路径：本 PR
- GitHub Actions `rewrite-ci` run URL：待定
- [ ] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [x] `npm test`（定向 vitest 9 个文件 116 个用例全绿）
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- 未运行：完整本地套件与 typecheck（worktree 缺少已构建的项目引用）；以 CI 为权威。

## 审查证据

- 自查：所有改动的 key 调用点已 grep；不再有 `sessions-page` 或按视图的 `task-detail` 派工/概览 key。
- Reviewer subagent：renderer 轮询、扇出与可用推送通道的只读调查
- 人工审查：待定
- 阻塞发现：无

## 残余风险

- 读完的议程只在台账 cut 前进时刷新；若某个议程来源在没有台账事件的情况下变化，会等到下一个 cut。
- 根壳稳态请求量约从每分钟 48 次降到 36 次；视图级扇出（会话页每个展开组、任务详情每条派工）未变。

## 关联材料

- 任务：task_ceb7630377af8c6e7d38d4ff45
- 证据：task 上的 fact；task_f22f99e8968179293188baeb53 上的连接日志分析
- 审查：本 PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
