### PR TITLE
fix(kernel): stop re-deriving the settings facet from code defaults during projection rebuild

### DIFF
--- a/packages/kernel/src/projection/rebuildable-task-projection-event-application.ts
+++ b/packages/kernel/src/projection/rebuildable-task-projection-event-application.ts
@@ -27,7 +27,6 @@ import { isTaskProgressEvent } from "../domain/task-progress-event.ts";
 import { isPresetSnapshotUpgradeEvent } from "../domain/preset-snapshot-upgrade-event.ts";
 import { isScheduleEvent } from "../domain/schedule-event.ts";
 import { isSettingsEvent } from "../domain/settings-event.ts";
-import { readSettingsFacet, repositorySettings } from "../domain/settings.ts";
 import { isPeopleEvent } from "../domain/people-event.ts";
 import { isCiRunObservationEvent } from "../domain/ci-run-observation-event.ts";
 import { parsePeopleRosterDocument } from "../domain/people-roster.ts";
@@ -255,11 +254,6 @@ export function applyEvent(
       throw new Error(`settings harness.yaml blob ${claim.sha256} is not UTF-8`);
     }
     if (sha256Text(body) !== claim.sha256) throw new Error(`settings harness.yaml blob ${claim.sha256} hash mismatch`);
-    if (
-      canonicalJson(repositorySettings(readSettingsFacet(body))) !==
-      canonicalJson(repositorySettings(event.payload.settings))
-    )
-      throw new Error(`settings harness.yaml blob ${claim.sha256} does not match the event settings facet`);
     const document: DocumentState = {
       path: claim.path as DocumentState["path"],
       blobSha256: claim.sha256,


### PR DESCRIPTION
# English

## Summary

Cold projection rebuilds re-derived the settings facet from the `harness.yaml` blob using the running code's defaults and compared it with the facet recorded in the `settings_changed` event. `harness.yaml` omits default blocks by design, so once a default changes (8be16189e raised `walFlush.milliseconds` from 2000 to 3600000) every cold rebuild of a ledger initialized under the old default throws `does not match the event settings facet` and the daemon latches the workspace as `repo_unavailable`. This happened to the canonical ledger on 2026-09-02 after a cache reset. The blob hash check stays; the comparison and its now-unused import are deleted. The recorded facet is what the projection serves.

## Architectural Justification

Not required (churn 6 lines, net -6). The deleted check asserted an invariant that is false by construction: `facet(blob)` depends on code defaults, the recorded payload does not.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none

## Machine-Readable Declarations

Production-Delta: +0/-6
Dependency-Change: none

### Optional Evidence Claims

none

## Task And Scope

Incident fix for the canonical ledger recovery of 2026-09-02. The harness ledger is unavailable until this merges, so the task package and facts are recorded after recovery (tracked in the CEO recovery list).

## Version Impact

None. No public interface changes; projection behavior only.

## Governance Declaration

No protected surface touched. No CI or gate changes.

## Verification

- `npx tsc -p packages/kernel/tsconfig.json --noEmit` passes.
- `node --test packages/kernel/test/store/settings-projection.test.ts` passes (3/3).
- Negative control: canonical daemon (dist 097ea77f) cold rebuild latched with `settings harness.yaml blob ce17b981… does not match the event settings facet`; a script diffing `repositorySettings(readSettingsFacet(harness.yaml))` against the genesis event payload shows exactly one difference, `walFlush.milliseconds` 3600000 vs 2000.
- Positive control: a cold rebuild of the canonical ledger (52139 events) with the patched kernel source into a scratch SQLite was still running at merge time (205 MB written, no error). The canonical daemon's own cold rebuild after this merge is the acceptance; the result is appended to Review Evidence when it lands.

## Review Evidence

CEO-authored 6-line deletion; reviewed by the CEO against the incident evidence above.

## Residual Risk

If a future default change also needs the materialized `harness.yaml` to change, the document will not be rewritten by rebuild; events remain the source of truth and `ha settings` writes carry explicit blocks.

---

# 中文

## 概要

投影冷重建时用当前代码默认值从 `harness.yaml` blob 重新推导 settings facet,再与 `settings_changed` 事件记录的 facet 比对。`harness.yaml` 按设计不写默认块,所以默认值一变(8be16189e 把 `walFlush.milliseconds` 从 2000 改成 3600000),旧默认值下初始化的台账每次冷重建都会抛 `does not match the event settings facet`,daemon 把工作区 latch 成 `repo_unavailable`。2026-09-02 canonical 台账清缓存后正是这样。blob 哈希校验保留,删掉比对和随之无用的 import。投影以事件记录的 facet 为准。

## 架构辩护

不需要(改动 6 行,净 -6)。被删的校验断言的不变量在构造上就不成立:`facet(blob)` 依赖代码默认值,事件里记录的 facet 不依赖。

## 机读声明

见英文块。

## 治理声明

未触碰受保护面,无 CI 或 gate 变更。

## 验证

kernel tsc 通过;settings-projection 测试 3/3 通过;阴性对照:canonical daemon 冷重建 latch,facet 差异恰好只有 `walFlush.milliseconds`;阳性对照:打补丁的内核对 canonical 台账的冷重建合并时仍在跑(已写 205 MB,无报错);合并后 canonical daemon 自身的冷重建即验收,结果落地后补入 Review Evidence。

## 残余风险

未来默认值变更不会让重建改写已物化的 `harness.yaml`;事件是真源,`ha settings` 写入带显式块。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xya5P7vnE4P29vXmHAkFhd
