### PR TITLE
perf(kernel): read relations by target and join freshness witnesses on the primary key during projection rebuild

### DIFF
--- a/packages/kernel/src/projection/entity-freshness-projection.ts
+++ b/packages/kernel/src/projection/entity-freshness-projection.ts
@@ -29,7 +29,10 @@ export function readEntityVersionWitnesses(
     }),
     joins = [
       tables.has("entity_projection")
-        ? "LEFT JOIN entity_projection projected ON projected.entity_kind || '/' || projected.entity_id=requested.ref"
+        ? [
+            "LEFT JOIN entity_projection projected ON projected.entity_kind=requested.kind",
+            "AND projected.entity_id=requested.id AND requested.ref=requested.kind || '/' || requested.id",
+          ].join(" ")
         : "",
       ...coreVersionLookups
         .filter(({ table }) => tables.has(table))

--- a/packages/kernel/src/projection/rebuildable-task-projection-migration.ts
+++ b/packages/kernel/src/projection/rebuildable-task-projection-migration.ts
@@ -215,7 +215,7 @@ export function projectMigration(
     return;
   }
   if (entity.kind === "task-document") {
-    if (!readSnapshot(db, entity.taskId).task)
+    if (!hasTaskSnapshot(db, entity.taskId))
       throw new Error(`migration task document owner is missing for ${entity.taskId}`);
     storeMigrationDocument(db, event, entity.documentClaim, readBlob);
     return;
@@ -271,4 +271,13 @@ export function storeMigrationDocument(
 export function migrationDocument(db: DatabaseSync, path: string): DocumentState | null {
   const row = queryRows(db, "SELECT value_json FROM document WHERE path=?", path)[0];
   return row ? (JSON.parse(String(row.value_json)) as DocumentState) : null;
+}
+
+function hasTaskSnapshot(db: DatabaseSync, taskId: string): boolean {
+  const row =
+    /* @gate-identity check-bypass-write-boundary/bypass-write-037 */
+    db
+      .prepare("SELECT json_type(snapshot_json, '$.task') AS task_type FROM task_snapshot WHERE task_id = ?")
+      .get(taskId) as { readonly task_type: string | null } | undefined;
+  return row !== undefined && row.task_type !== null && row.task_type !== "null";
 }

--- a/packages/kernel/src/projection/rebuildable-task-projection-migration.ts
+++ b/packages/kernel/src/projection/rebuildable-task-projection-migration.ts
@@ -275,7 +275,7 @@ export function migrationDocument(db: DatabaseSync, path: string): DocumentState
 
 function hasTaskSnapshot(db: DatabaseSync, taskId: string): boolean {
   const row =
-    /* @gate-identity check-bypass-write-boundary/bypass-write-037 */
+    /* @gate-identity check-bypass-write-boundary/bypass-write-098 */
     db
       .prepare("SELECT json_type(snapshot_json, '$.task') AS task_type FROM task_snapshot WHERE task_id = ?")
       .get(taskId) as { readonly task_type: string | null } | undefined;

--- a/packages/kernel/src/projection/rebuildable-task-projection-runtime.ts
+++ b/packages/kernel/src/projection/rebuildable-task-projection-runtime.ts
@@ -132,9 +132,8 @@ export function readSnapshot(db: DatabaseSync, taskId: string, now?: string): Ta
   const lease = now === undefined ? storedLease(db, taskId) : effectiveLease(db, taskId, now);
   // The stored snapshot is pure task-aggregate state; the decision relations this task is a
   // target of are stamped at read time as-of the applied cut, the same join the live lease uses.
-  const decisionRelations = readRelationProjectionRows(db)
-    .filter(({ targetRef }) => targetRef === `task/${taskId}`)
-    .map(({ relationId, sourceRef, targetRef, relationType, state, strength, freshness }) => ({
+  const decisionRelations = readRelationProjectionRows(db, `task/${taskId}`).map(
+    ({ relationId, sourceRef, targetRef, relationType, state, strength, freshness }) => ({
       relationId,
       sourceRef,
       targetRef,
@@ -142,7 +141,8 @@ export function readSnapshot(db: DatabaseSync, taskId: string, now?: string): Ta
       state,
       strength,
       freshness,
-    }));
+    }),
+  );
   return {
     ...snapshot,
     executions,

--- a/packages/kernel/src/projection/rebuildable-task-projection-sql.ts
+++ b/packages/kernel/src/projection/rebuildable-task-projection-sql.ts
@@ -47,7 +47,10 @@ export function watermark(db: DatabaseSync): number {
   return Number(row.watermark);
 }
 
-export function readProjectionCut(db: DatabaseSync, readHead: EventStreamPort["readHead"]): {
+export function readProjectionCut(
+  db: DatabaseSync,
+  readHead: EventStreamPort["readHead"],
+): {
   readonly status: "ready" | "pending";
   readonly watermark: number;
   readonly sourceRevision: number;
@@ -92,8 +95,8 @@ export function refreshStateDigestAtSourceCut(db: DatabaseSync, sourceRevision: 
   let digest = sha256Text("task-projection-state/v1");
   for (const [table, order] of stateDigestTables) {
     digest = sha256Text(`${digest}\n${table}`);
-    for (const row of queryRows(db, `SELECT * FROM ${table} ORDER BY ${order}`))
-      digest = sha256Text(`${digest}\n${canonicalJson(row)}`);
+    for (const row of prepareQuery(db, `SELECT * FROM ${table} ORDER BY ${order}`).iterate())
+      digest = sha256Text(`${digest}\n${canonicalJson(row as ProjectionSqlRow)}`);
   }
   const value = `sha256:${digest}` as `sha256:${string}`;
   runSql(db, "UPDATE projection_meta SET state_digest = ? WHERE singleton = 1", value);

--- a/packages/kernel/src/projection/relation-entity-projection.ts
+++ b/packages/kernel/src/projection/relation-entity-projection.ts
@@ -201,8 +201,19 @@ export function readRelationProjectionRow(db: DatabaseSync, relationId: string):
     : null;
 }
 
-export function readRelationProjectionRows(db: DatabaseSync): readonly VersionedRelationProjectionRow[] {
-  const rows = queryRows<{ readonly row_json: string }>(db, "SELECT row_json FROM relation_edge ORDER BY relation_id")
+export function readRelationProjectionRows(
+  db: DatabaseSync,
+  targetRef?: string,
+): readonly VersionedRelationProjectionRow[] {
+  const rows = (
+    targetRef === undefined
+      ? queryRows<{ readonly row_json: string }>(db, "SELECT row_json FROM relation_edge ORDER BY relation_id")
+      : queryRows<{ readonly row_json: string }>(
+          db,
+          "SELECT row_json FROM relation_edge WHERE target_ref = ? ORDER BY relation_id",
+          targetRef,
+        )
+  )
     .map((row) => JSON.parse(row.row_json) as Partial<VersionedRelationProjectionRow>)
     .filter(
       (row): row is VersionedRelationProjectionRow =>

--- a/tools/gate-allowlists/check-bypass-write-boundary.json
+++ b/tools/gate-allowlists/check-bypass-write-boundary.json
@@ -41,7 +41,8 @@
       { "value": "bypass-write-036", "api": "sqlite.prepare", "ref": "task_01KZQ944F7RH6E0153Q3Q86Y63", "reason": "Prepares a query against the disposable projection." },
       { "value": "bypass-write-037", "api": "sqlite.prepare", "ref": "task_01KZQ944F7RH6E0153Q3Q86Y63", "reason": "Reads a disposable canonical operation row." },
       { "value": "bypass-write-038", "api": "sqlite.prepare", "ref": "task_01KZRMKPA7XGF0NGBE961MCGET", "reason": "Reads a disposable canonical operation row before typed task dispatch." },
-      { "value": "bypass-write-039", "api": "sqlite.prepare", "ref": "task_01KZXGJWVCKCA6B0MKB220PKFB", "reason": "Resolves the projected package owner for document routing." }
+      { "value": "bypass-write-039", "api": "sqlite.prepare", "ref": "task_01KZXGJWVCKCA6B0MKB220PKFB", "reason": "Resolves the projected package owner for document routing." },
+      { "value": "bypass-write-098", "api": "sqlite.prepare", "ref": "task_6d847ff57bf88357cfd7c64f8e", "reason": "Checks that a migration task-document owner snapshot exists without loading the whole task snapshot and relation graph." }
     ],
     "coordinatedCore": [
       { "value": "bypass-write-043", "api": "rmSync", "ref": "task_01KZRMKJT7YKQ2TNXA8WR1W5DN", "reason": "RepoCell-owned recovery removes only an abandoned prepared artifact." },


### PR DESCRIPTION
# English

## Summary

Projection cold rebuild spent 95% of its CPU in one query: `readSnapshot` loaded the entire relation graph for every task event, migration task-document, and migration execution, and `readEntityVersionWitnesses` joined `entity_projection` on a concatenated expression (`entity_kind || '/' || entity_id = ref`) that no index can serve. Each call cost about 6.45 million row accesses on the canonical ledger (6,150 edges, 1,049 entities). A cold rebuild of the 52,139-event canonical ledger ran for more than two hours without finishing; the daemon was unresponsive to reads and writes for the whole time.

This change reads relations by `target_ref` (existing `relation_edge_target` index), joins the freshness witnesses on the `entity_projection` primary key with the ref equality kept as a guard, replaces the migration task-document owner check with an existence query on `task_snapshot`, and streams the state-digest rows instead of materializing every table with `.all()`.

## Architectural Justification

Not required (churn 48 lines, net +26). No new module or abstraction; the same functions do the same work through indexed paths.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none

## Machine-Readable Declarations

Production-Delta: +37/-11
Dependency-Change: none

### Optional Evidence Claims

none

## Task And Scope

Incident follow-up for the 2026-09-02 canonical ledger recovery (the harness ledger is unavailable until the recovery lands; the task package and facts are recorded afterwards, tracked in the CEO recovery notes). Scope: kernel projection read paths only.

## Version Impact

None. No public interface or schema changes; projection output is byte-identical.

## Governance Declaration

No protected surface touched. No CI or gate changes. The check-bypass-write-boundary allowlist grows by one entry (bypass-write-098, sqlite.prepare, ref task_6d847ff57bf88357cfd7c64f8e) for the migration owner-existence query that replaces a full snapshot read.

## Verification

- `npx tsc -p packages/kernel/tsconfig.json --noEmit` passes; nine targeted projection/store test files pass.
- Equivalence: catch-up of revisions 1..12,000 on the canonical ledger produces a table-level dump byte-identical to the unpatched code; at 41,500 events, witness queries for 7,717 refs show zero differences.
- Timing on the canonical ledger (same machine, scratch SQLite): 1..12,000 catch-up 115 s → 10 s; 1..41,500 (all migration events plus 1,500 native) 31 s versus the unpatched daemon not finishing in 60 minutes; full 52,139-event `rebuild()` including digest 41.7 s. The full-ledger run needed two temporary replay shims for pre-existing native-event blockers (legacy `strength` on `relation_created`, decision consent digest re-derivation) that are unrelated to this change and are being fixed by data migrations in a separate PR; the shims are not part of this branch.

## Review Evidence

CEO reviewed the diff against the profiler findings (95% of main-thread samples in `sqlite3_step` under the `json_each` witness query; EXPLAIN QUERY PLAN showed a full scan of `entity_projection` per outer row).

## Residual Risk

`journal_mode` stays DELETE, so a rebuild still holds an exclusive lock for each 4,096-event round; with the rebuild now taking seconds this no longer matters in practice and is tracked separately.

---

# 中文

## 概要

投影冷重建 95% 的 CPU 花在一条查询上:`readSnapshot` 对每条 task 事件、迁移 task-document、迁移 execution 都拉整张关系图,而 `readEntityVersionWitnesses` 用拼接表达式(`entity_kind || '/' || entity_id = ref`)做 JOIN,任何索引都用不上。在 canonical 台账上单次约 645 万次行访问(6,150 条边、1,049 个实体)。5.2 万条事件的冷重建跑两小时没完成,期间 daemon 读写全部无响应。

本改动按 `target_ref` 定向读关系(已有 `relation_edge_target` 索引)、JOIN 改为 `entity_projection` 主键匹配并保留 ref 等式作守卫、迁移 task-document 的 owner 检查改为对 `task_snapshot` 的存在性查询、state digest 改为流式迭代而不是把每张表 `.all()` 进内存。

## 架构辩护

不需要(改动 48 行,净 +26)。没有新模块或抽象,同样的函数走索引路径做同样的事。

## 机读声明

见英文块。

## 治理声明

未触碰受保护面,无 CI 或 gate 变更。check-bypass-write-boundary allowlist 增加一条(bypass-write-098,sqlite.prepare,ref task_6d847ff57bf88357cfd7c64f8e),对应替代整份快照读取的 owner 存在性查询。

## 验证

kernel tsc 通过,九个定向投影/存储测试文件通过;1..12,000 的表级 dump 与未打补丁代码逐字节一致,41,500 状态下 7,717 个 ref 的见证查询零差异;计时:1..12,000 从 115 秒到 10 秒,1..41,500 为 31 秒(原 daemon 60 分钟未完),全量 52,139 条含 digest 41.7 秒。全量跑依赖两处与本改动无关的临时重放 shim(历史 `strength` 字段、decision consent digest 重推导),这两处由另一 PR 的数据迁移解决,shim 不在本分支。

## 残余风险

`journal_mode` 仍为 DELETE,每轮 4,096 条重建仍持独占锁;重建已降到秒级,实际不再构成问题,另行跟踪。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xya5P7vnE4P29vXmHAkFhd
