### PR TITLE
perf(migrate): replay only cut-dependent rewrites one revision at a time

### DIFF
--- a/packages/daemon/test/event-shape-migration.integration.test.ts
+++ b/packages/daemon/test/event-shape-migration.integration.test.ts
@@ -16,6 +16,7 @@ import {
 } from "../../kernel/src/index.ts";
 import { canonicalRoot, workspaceId } from "../src/protocol/daemon-protocol.contract.ts";
 import { openRepoCell } from "../src/repo-cell.ts";
+import { openBootstrappedRepoCell } from "./repo-settings.fixture.ts";
 import { actor, initRepo } from "./migration-import.fixtures.ts";
 
 const source = "local" as const;
@@ -162,6 +163,140 @@ test("relation_created history in the pre-derived-strength shape cold-rebuilds o
     const repeat = (await cell.run({ kind: "relation-events-migrate" }, binding)) as Record<string, unknown>;
     assert.equal(repeat.outcome, "pending");
     assert.match(String(repeat.nextAction), /Nothing to migrate/u);
+  } finally {
+    await cell?.close?.();
+    rmSync(scratch, { recursive: true, force: true });
+  }
+});
+
+// Candidates separated by runs of non-candidate events: the batched replay must hand each legacy
+// relation the projection state at its own revision-1, which the live write recorded as the
+// target witness before the bytes were rewritten to the historical shape.
+test("a migrating replay that batches non-candidates still witnesses each candidate at its own cut", async () => {
+  const scratch = mkdtempSync(path.join(tmpdir(), "ha-relation-events-batched-"));
+  let cell: Awaited<ReturnType<typeof openBootstrappedRepoCell>> | undefined;
+  const repoId = "event-shape-batched",
+    binding = { actor, source },
+    open = () =>
+      openBootstrappedRepoCell({
+        repoId: workspaceId(repoId),
+        rootDir: canonicalRoot(scratch),
+        ownerId: "event-shape-test",
+        now: () => "2026-09-02T12:00:00.000Z",
+      }),
+    run = async (action: Record<string, unknown>) => {
+      const receipt = (await cell!.run(action as never, binding)) as Record<string, unknown>;
+      assert.equal(receipt.outcome, "applied", JSON.stringify(receipt));
+      return receipt;
+    },
+    bump = async (taskId: string, times: number) => {
+      for (let index = 0; index < times; index += 1)
+        await run({
+          kind: "task-amend",
+          taskId,
+          patches: [{ field: "pinned", value: index % 2 === 0 ? "true" : "false" }],
+        });
+    },
+    relate = (sourceRef: string) =>
+      run({
+        kind: "relation-relate",
+        sourceRef,
+        targetRef: "task/task_target",
+        relationType: "depends-on",
+        rationale: "Batched replay witness sample.",
+        expectedVersion: 0,
+      });
+  try {
+    initRepo(scratch);
+    cell = await open();
+    await run({ kind: "task-create", taskId: "task_first", title: "First source" });
+    await run({ kind: "task-create", taskId: "task_target", title: "Target" });
+    await bump("task_target", 3);
+    const first = await relate("task/task_first");
+    await run({ kind: "task-create", taskId: "task_second", title: "Second source" });
+    await bump("task_target", 3);
+    const second = await relate("task/task_second");
+    await bump("task_target", 2);
+    await cell.close?.();
+    cell = undefined;
+
+    const store = makeTaskEventStore({ repoId, rootDir: scratch });
+    await store.settlePendingMaterialization?.("fixture");
+    const layout = store.layout(),
+      witnessOf = (opId: string) =>
+        (
+          JSON.parse(
+            readFileSync(
+              path.join(scratch, "harness", eventObjectRelativePath(opId, layout as "sharded-sha256-2/v1")),
+              "utf8",
+            ),
+          ) as { payload: { relation: { targetObservedVersion: number } } }
+        ).payload.relation.targetObservedVersion,
+      firstWitness = witnessOf(String(first.opId)),
+      secondWitness = witnessOf(String(second.opId));
+    assert.ok(
+      secondWitness > firstWitness,
+      `target version must advance between candidates: ${firstWitness} -> ${secondWitness}`,
+    );
+    for (const receipt of [first, second]) {
+      const stored = JSON.parse(
+        readFileSync(
+          path.join(scratch, "harness", eventObjectRelativePath(String(receipt.opId), layout as "sharded-sha256-2/v1")),
+          "utf8",
+        ),
+      ) as RelationEventV1;
+      legacyRelationBytes(scratch, layout, stored);
+    }
+    execFileSync("git", ["-C", scratch, "commit", "-qam", "legacy relation shape"], { stdio: "ignore" });
+    execFileSync("git", ["-C", scratch, "update-ref", "refs/ha/canonical", "HEAD"], { stdio: "ignore" });
+
+    cell = await open();
+    const preview = (await cell.run({ kind: "relation-events-migrate", dryRun: true }, binding)) as Record<
+      string,
+      unknown
+    >;
+    assert.equal(preview.outcome, "pending", JSON.stringify(preview));
+    const report = JSON.parse(String(preview.evidence)) as {
+      readonly rewrittenEvents: number;
+      readonly categories: Record<string, number>;
+      readonly samples: readonly {
+        readonly opId: string;
+        readonly workspaceRevision: number;
+        readonly after: Record<string, unknown>;
+      }[];
+    };
+    assert.equal(report.rewrittenEvents, 2);
+    assert.deepEqual(report.categories, { "strength dropped, witness filled at cut": 2 });
+    assert.deepEqual(
+      report.samples.map((sample) => [sample.opId, sample.workspaceRevision, sample.after.targetObservedVersion]),
+      [
+        [first.opId, first.revision, firstWitness],
+        [second.opId, second.revision, secondWitness],
+      ],
+    );
+
+    const applied = (await cell.run({ kind: "relation-events-migrate" }, binding)) as Record<string, unknown>;
+    assert.equal(applied.outcome, "applied", JSON.stringify(applied));
+    const coldPath = path.join(scratch, ".harness/cache/cold-batched.sqlite"),
+      cold = makeTaskProjection({
+        rootDir: scratch,
+        eventStore: makeTaskEventStore({ repoId, rootDir: scratch }),
+        projectionPath: coldPath,
+      });
+    assert.equal(cold.rebuild().watermark, applied.revision);
+    cold.close();
+    const db = new DatabaseSync(coldPath, { readOnly: true }),
+      rows = db
+        .prepare("SELECT source_ref, target_observed_version FROM relation_edge ORDER BY workspace_revision")
+        .all() as readonly { readonly source_ref: string; readonly target_observed_version: number }[];
+    db.close();
+    assert.deepEqual(
+      rows.map((row) => [row.source_ref, row.target_observed_version]),
+      [
+        ["task/task_first", firstWitness],
+        ["task/task_second", secondWitness],
+      ],
+    );
   } finally {
     await cell?.close?.();
     rmSync(scratch, { recursive: true, force: true });

--- a/packages/kernel/src/store/event-shape-migration.ts
+++ b/packages/kernel/src/store/event-shape-migration.ts
@@ -25,9 +25,10 @@ import type { TaskProjection } from "../projection/task-projection-port.ts";
 import { ledgerGitPath, resolveLedgerGitLayout } from "./ledger-git-layout.ts";
 import type { CanonicalEventStore, PublicationFile } from "./task-event-store-types.ts";
 
-// One-shot history upcasts. A migrating replay walks the ledger one revision at a time into a
-// scratch projection; each event is rewritten against the projection state at its own cut and
-// the rewritten event is what the scratch projection applies. The rewrites are then published
+// One-shot history upcasts. A migrating replay walks the ledger into a scratch projection:
+// candidates (`matches`) are replayed alone so each is rewritten against the projection state at
+// its own cut, everything between them is caught up in bulk rounds, and the rewritten event is
+// what the scratch projection applies. The rewrites are then published
 // atomically as rewritten event objects alongside a migration marker, the same publication
 // shape `fact-rekey` uses, so the ledger head and commit are produced by the store. The live
 // projection is left alone: every rewrite is, by construction, what the projection already
@@ -43,6 +44,10 @@ export interface EventShapeRewrite {
 export type EventShapeCut = Pick<TaskProjection, "readEntityVersionWitness" | "readDecisionDocumentState">;
 export interface EventShapeMigrationSpec {
   readonly name: EventShapeMigrationName;
+  // Pure on the event: true for every event whose `rewrite` reads the cut. Only these are replayed
+  // one revision at a time; every other event is rewritten inside bulk rounds, so a rewrite may
+  // touch `cut` only when `matches` is true for that event.
+  readonly matches: (event: CanonicalEventV1) => boolean;
   readonly rewrite: (event: CanonicalEventV1, cut: EventShapeCut) => EventShapeRewrite | null;
 }
 export interface EventShapeMigrationInput {
@@ -55,6 +60,12 @@ export interface EventShapeMigrationInput {
 
 const relationEventsMigration: EventShapeMigrationSpec = {
   name: "relation-events",
+  // Only a missing target witness needs the projection at the event's cut; dropping strength and
+  // normalising the state word are pure on the event.
+  matches: (event) =>
+    isRelationEvent(event) &&
+    (event.type === "relation_created" || event.type === "relation_replaced") &&
+    !Object.hasOwn(event.payload.relation, "targetObservedVersion"),
   rewrite: (event, cut) => {
     if (isMigrationImportEvent(event)) {
       const entity = event.payload.entity;
@@ -99,6 +110,11 @@ const relationEventsMigration: EventShapeMigrationSpec = {
 
 const decisionDigestsMigration: EventShapeMigrationSpec = {
   name: "decision-digests",
+  matches: (event) => {
+    if (event.schema !== "decision-event/v1") return false;
+    const payload = (event as DecisionEventV1).payload as Readonly<Record<string, unknown>>;
+    return payload.judgmentConsent !== undefined || payload.contentPin !== undefined;
+  },
   rewrite: (event, cut) => {
     if (event.schema !== "decision-event/v1") return null;
     const decision = event as DecisionEventV1,
@@ -243,6 +259,8 @@ export async function runEventShapeMigration(
   };
 }
 
+const BULK_ROUND_LIMIT = 4096;
+
 function replayRewrites(
   spec: EventShapeMigrationSpec,
   input: EventShapeMigrationInput,
@@ -250,33 +268,62 @@ function replayRewrites(
   head: ReturnType<CanonicalEventStore["readHead"]>,
 ): readonly EventShapeRewrite[] {
   const rewrites: EventShapeRewrite[] = [],
-    scratchPath = path.join(tmpdir(), `ha-${spec.name}-${process.pid}-${Date.now()}.sqlite`);
+    scratchPath = path.join(tmpdir(), `ha-${spec.name}-${process.pid}-${Date.now()}.sqlite`),
+    pending: CanonicalEventV1[] = [];
   let cap = 0,
     cursor: string | null = null,
+    exhausted = false,
+    prefetchContent: ReturnType<CanonicalEventStore["readBatch"]>["prefetchContent"],
     projection: TaskProjection | null = null;
+  // Read ahead from the real store until the buffer holds a full bulk round or the stream ends.
+  const fill = (): void => {
+    while (!exhausted && pending.length < BULK_ROUND_LIMIT) {
+      const batch = input.store.readBatch(cursor, BULK_ROUND_LIMIT);
+      pending.push(...batch.events);
+      cursor = batch.cursor;
+      exhausted = batch.done;
+      if (batch.prefetchContent) prefetchContent = batch.prefetchContent;
+    }
+  };
+  // Every migration's rewrite is applied to the scratch projection so it stays valid past shapes
+  // the other migrations own (a decision digest is derived over rewritten relations, and the
+  // strict reducer rejects both legacy shapes); only the requested migration's rewrites are
+  // reported and published.
+  const migrations = Object.values(eventShapeMigrations);
+  // A round ends at the next candidate when it is the next event (so its rewrite sees the
+  // projection at revision-1), otherwise right before it or after a full bulk round; with no
+  // events left it ends at the head.
+  const nextCap = (): number => {
+    fill();
+    if (pending.length === 0) return headRevision;
+    const candidate = pending.findIndex((event) => migrations.some((migration) => migration.matches(event))),
+      count = candidate === 0 ? 1 : Math.min(candidate === -1 ? pending.length : candidate, BULK_ROUND_LIMIT);
+    return pending[count - 1]!.workspaceRevision;
+  };
   const stream = {
     readHead: () =>
       cap >= headRevision
         ? head
         : { revision: cap, eventDigest: `sha256:${sha256Text(`event-shape-migration:${cap}`)}` as `sha256:${string}` },
     readBatch: () => {
-      const batch = input.store.readBatch(cursor, 1);
-      cursor = batch.cursor;
-      const events = batch.events
-        .filter((event) => event.workspaceRevision <= cap)
-        .map((event) => {
-          const rewrite = spec.rewrite(event, projection!);
-          if (rewrite === null) return event;
-          rewrites.push(rewrite);
-          return rewrite.event;
+      const beyond = pending.findIndex((event) => event.workspaceRevision > cap),
+        events = pending.splice(0, beyond === -1 ? pending.length : beyond).map((event) => {
+          let current = event;
+          for (const migration of migrations) {
+            const rewrite = migration.rewrite(current, projection!);
+            if (rewrite === null) continue;
+            if (migration === spec) rewrites.push(rewrite);
+            current = rewrite.event;
+          }
+          return current;
         });
       return {
         sourceRevision: cap,
         events,
         cursor: null,
         done: true,
-        accessedItems: batch.accessedItems,
-        ...(batch.prefetchContent ? { prefetchContent: batch.prefetchContent } : {}),
+        accessedItems: events.length,
+        ...(prefetchContent ? { prefetchContent } : {}),
       };
     },
     readContentBlob: (sha256: string) => input.store.readContentBlob(sha256),
@@ -285,13 +332,16 @@ function replayRewrites(
     rootDir: input.rootDir,
     eventStore: stream,
     projectionPath: scratchPath,
-    catchUpLimit: 1,
+    catchUpLimit: BULK_ROUND_LIMIT,
   });
   try {
-    for (cap = 1; cap <= headRevision; cap += 1) {
+    let watermark = 0;
+    while (watermark < headRevision) {
+      cap = nextCap();
       const round = projection.catchUp!();
       if (round.watermark !== cap)
         throw new Error(`${spec.name} migrating replay stalled at revision ${round.watermark} before ${cap}`);
+      watermark = cap;
     }
   } finally {
     projection.close();


### PR DESCRIPTION
# English

## Summary

The event-shape migration engine (#2164) replayed the ledger one revision per round so that every rewrite could read the projection state at its own cut. On the 52,139-event canonical ledger that is an hours-long run per invocation (the first dry-run was killed after 40 minutes without a receipt), and each migration runs twice (dry-run, apply). Only rewrites that read the cut need single-revision rounds: the 86 native relation events missing `targetObservedVersion` and the 22 decision events carrying a consent or content pin. Everything else is rewritten inside bulk rounds.

- Each migration now declares `matches(event)`, true only for events whose `rewrite` reads the cut. Bulk rounds of up to 4,096 events run until the next candidate, which is then replayed alone so its rewrite sees revision-1; the migration-import relation state normalization (1,097 events) happens inside bulk rounds.
- The scratch replay applies every migration's rewrite to each event and publishes only the requested migration's rewrites. The two migrations are mutually prerequisite on the canonical ledger (a relation-events replay dies at 42579 on the decision consent digest, a decision-digests replay dies at 42281 on the legacy `strength`), so the scratch projection must stay valid past both defects while each command still publishes exactly its own change.

## Architectural Justification

Not required (churn below 200 lines, net below +300).

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none

## Machine-Readable Declarations

Production-Delta: +67/-17
Dependency-Change: none

### Optional Evidence Claims

none

## Task And Scope

Incident follow-up for the 2026-09-02 canonical ledger recovery (ledger unavailable until the migrations run; task and facts recorded afterwards, tracked in `harness/context/development/incident-20260902-wal-gap/`). Scope: kernel store migration engine and its fixture test.

## Version Impact

None. Command surface and receipts unchanged; only replay scheduling inside the engine.

## Governance Declaration

No protected surface touched. No CI or gate changes.

## Verification

- Semantics: the fixture test gains a case with two legacy relation events separated by a task create and three amends (target version advances), then two more amends; the dry-run samples' `targetObservedVersion` equal the witnesses recorded at native write time (read before the events were rewritten to the legacy shape), the two witnesses differ, category `strength dropped, witness filled at cut: 2`, and the cold rebuild after apply yields the same `relation_edge` rows. Fixture 2/2; with relation-actors and relation-entity suites 13/13.
- Canonical read-only timing (git store, scratch projection, the two runs partly overlapping): relation-events dry-run 511.5 s, decision-digests dry-run 524.9 s; the one-revision-per-round baseline did not finish in 40 minutes.
- Canonical dry-run results: relation-events rewrites 1,183 events (1,097 import relation states normalized, 83 `strength` dropped with witness filled at cut, 3 with genesis null); decision-digests rewrites 4 events (3 consent digest plus content pin, 1 content pin only), first at 42579 (dec_3EDA6CB3); before digests match the values derived statically under the previous engine.

## Review Evidence

CEO reviewed the engine diff: candidate detection, bulk-round boundary at the next candidate, all-migration rewrite in the scratch replay with request-scoped publication.

## Residual Risk

About 8.5 minutes per canonical run remains, dominated by the fixed per-round cost of projection catch-up (108 single-revision rounds plus bulk rounds); acceptable for one-shot migrations and not measured further.

---

# 中文

## 概要

事件形状迁移引擎(#2164)为了让每次改写读到它自己那一刀的投影状态,逐条 revision 重放;在 5.2 万条事件的 canonical 台账上单次要跑小时级(第一次 dry-run 40 分钟没有回执被杀),而每条迁移要跑两次。真正需要按刀状态的只有 86 条缺 `targetObservedVersion` 的原生 relation 事件和 22 条带 consent 或 content pin 的 decision 事件,其余都可以在批量轮里改写。

- 每条迁移声明 `matches(event)`,只对 `rewrite` 需要读刀的事件为真。批量轮最多 4,096 条,跑到下一个候选前停下,候选单独重放一轮使其改写看到 revision-1;迁移导入关系的 state 归一(1,097 条)在批量轮内完成。
- scratch 重放对每条事件套用所有迁移的改写,只发布本次请求那条迁移的改写。两条迁移在 canonical 上互为前置(relation-events 的重放在 42579 撞 decision consent digest,decision-digests 的重放在 42281 撞历史 `strength`),scratch 投影必须同时越过两个缺陷,而每条命令仍只发布自己的改动。

## 架构辩护

不需要(改动量低于 200 行,净增低于 +300)。

## 机读声明

见英文块。

## 治理声明

未触碰受保护面,无 CI 或 gate 变更。

## 验证

fixture 新增用例(两条 legacy relation 之间夹 task create 与三次 amend,之后再两次 amend):dry-run 样例的 `targetObservedVersion` 与原生写入时记录的 witness 完全相等、两条不同、类别计数为 2,应用后冷重建 `relation_edge` 行同值;fixture 2/2,连同 relation-actors、relation-entity 13/13。canonical 只读计时:relation-events 511.5 秒、decision-digests 524.9 秒(两次部分并行),逐条基线 40 分钟未完。canonical dry-run 结果:relation-events 改写 1,183 条(1,097 归一、83 补 witness、3 创世 null),decision-digests 改写 4 条(首条 42579 dec_3EDA6CB3),before digest 与此前静态推得一致。

## 残余风险

单次仍约 8.5 分钟,来自投影 catch-up 每轮固定开销(108 个单步轮加批量轮);一次性迁移可接受,未再深究。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xya5P7vnE4P29vXmHAkFhd
