### PR TITLE
chore(deps): resolve the fast-uri and xmldom audit advisories in the lockfile

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2003,9 +2003,9 @@
       }
     },
     "node_modules/@xmldom/xmldom": {
-      "version": "0.8.13",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
-      "integrity": "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==",
+      "version": "0.8.15",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.15.tgz",
+      "integrity": "sha512-/5NV/vDALVFDXgLmfsy9TRCBlKwO2LNBFzpzvb9iIj+jR+eSc6DLYYvVOdivT/jm7MtU6TebYuRmzEOI7w40UA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4118,9 +4118,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
# English

## Summary

`npm audit --audit-level=high` started failing on every branch today because new advisories were published for two transitive dependencies: fast-uri 3.1.5 (three high advisories, reached through electron-builder → app-builder-lib → ajv) and @xmldom/xmldom 0.8.13 (one moderate). The required supply-chain check therefore blocks every pull request, including the ledger-incident fixes. This change applies `npm audit fix --package-lock-only`: fast-uri 3.1.5 → 3.1.7 and @xmldom/xmldom 0.8.13 → 0.8.15, patch releases within the existing semver ranges. No package.json changes and no source changes.

## Architectural Justification

Not required (lockfile only).

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none

## Machine-Readable Declarations

Production-Delta: +0/-0
Dependency-Change: package-lock.json only via npm audit fix; fast-uri 3.1.5 -> 3.1.7 (GHSA-5jgf-p345-68v8, GHSA-f65p-4m7j-42xc, GHSA-fph4-wmhf-6fwf) and @xmldom/xmldom 0.8.13 -> 0.8.15 (GHSA-6gmq-8vp8-gcm6); both transitive, both patch releases inside the existing ranges; no package.json change

### Optional Evidence Claims

none

## Task And Scope

Unblocks the required supply-chain check for all open pull requests (#2149 and the 2026-09-02 ledger-incident follow-ups). Scope: package-lock.json only.

## Version Impact

None.

## Governance Declaration

Dependency policy surface: declared above. No CI or gate changes; the failing gate is satisfied by the dependency fix, not modified. Unblocks task_6162fe1c06a83eefc869eba27f (PR #2149, read/write isolation stage 3) and the 2026-09-02 ledger-incident follow-ups.

## Verification

- `npm audit --audit-level=high --package-lock-only` on this branch: 0 vulnerabilities (main: 1 high, 1 moderate).
- `npm audit fix --dry-run` on main proposed exactly these two changes without `--force`.

## Review Evidence

CEO reviewed the six-line lockfile diff.

## Residual Risk

None identified; both bumps are patch releases of transitive dependencies used only by the GUI build tooling and XML serialization.

---

# 中文

## 概要

今天两个传递依赖发布了新通告,`npm audit --audit-level=high` 在所有分支上开始失败:fast-uri 3.1.5(三条高危,经 electron-builder → app-builder-lib → ajv 引入)和 @xmldom/xmldom 0.8.13(一条中危)。必需的 supply-chain 检查因此卡住所有 PR,包括台账事故的修复。本变更执行 `npm audit fix --package-lock-only`:fast-uri 3.1.5 → 3.1.7,@xmldom/xmldom 0.8.13 → 0.8.15,都是现有版本范围内的补丁版本。不改 package.json,不改源码。

## 架构辩护

不需要(仅锁文件)。

## 机读声明

见英文块。

## 治理声明

依赖策略面:已在上方声明。无 CI 或 gate 变更;失败的门由依赖修复满足,而非被修改。解除对 task_6162fe1c06a83eefc869eba27f(PR #2149,读写隔离 stage 3)与 2026-09-02 台账事故后续 PR 的阻塞。

## 验证

本分支 `npm audit --audit-level=high --package-lock-only` 为 0 漏洞(main 上 1 高危 1 中危);main 上的 `npm audit fix --dry-run` 给出的正是这两处改动,无需 `--force`。

## 残余风险

未发现;两处都是传递依赖的补丁版本,只用于 GUI 构建工具与 XML 序列化。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xya5P7vnE4P29vXmHAkFhd
