### PR TITLE
fix(daemon,kernel): keep the writer attach alive on progress instead of a fixed 30 s ready deadline

### DIFF
--- a/packages/daemon/src/daemon-host-open.ts
+++ b/packages/daemon/src/daemon-host-open.ts
@@ -92,7 +92,9 @@ export interface DaemonHostOpenInput {
   readonly shutdownRequested?: () => boolean;
   readonly recordLifecycle?: DaemonLifecycleRecorder;
   readonly attachTimeoutMs?: number;
-  readonly openCell?: typeof openRepoCell;
+  readonly openCell?: (
+    input: Parameters<typeof openRepoCell>[0] & { readonly onStatus?: (status: RepoCellStatus) => void },
+  ) => Promise<RepoCell>;
 }
 
 export async function openDaemonHost(input: DaemonHostOpenInput): Promise<DaemonHost> {
@@ -226,6 +228,12 @@ export async function openDaemonHost(input: DaemonHostOpenInput): Promise<Daemon
     recoveryMs: null,
     lastError: null,
     causeClass: null,
+    attach: {
+      phase: "opening",
+      applied: null,
+      total: null,
+      watermark: null,
+    },
   });
   const warmingMessage = (repoId: string): string =>
     `Repository ${repoId} is still warming; wait for its background attachment to complete.`;

--- a/packages/daemon/src/daemon-host-registry.ts
+++ b/packages/daemon/src/daemon-host-registry.ts
@@ -143,7 +143,9 @@ export async function performOpenRegistered(
       ...(context.input.shutdownRequested ? { shouldStop: context.input.shutdownRequested } : {}),
       ...(context.input.recordLifecycle ? { recordLifecycle: context.input.recordLifecycle } : {}),
       onAttemptTerminal: (_terminal: RuntimeAttemptTerminal) => void context.scheduleScheduler.refresh(),
-      onStatus: (status) => context.markWarming(repo.repoId, status),
+      onStatus: (status) => {
+        if (context.warming.has(repo.repoId)) context.warming.set(repo.repoId, status);
+      },
       // Live getter: cells attach at daemon boot, before the fleet center may be
       // admitted, so the schedule read resolves the roster at read time.
       fleetRoster: () => context.fleetRoster,

--- a/packages/daemon/src/daemon-host-registry.ts
+++ b/packages/daemon/src/daemon-host-registry.ts
@@ -143,6 +143,7 @@ export async function performOpenRegistered(
       ...(context.input.shutdownRequested ? { shouldStop: context.input.shutdownRequested } : {}),
       ...(context.input.recordLifecycle ? { recordLifecycle: context.input.recordLifecycle } : {}),
       onAttemptTerminal: (_terminal: RuntimeAttemptTerminal) => void context.scheduleScheduler.refresh(),
+      onStatus: (status) => context.markWarming(repo.repoId, status),
       // Live getter: cells attach at daemon boot, before the fleet center may be
       // admitted, so the schedule read resolves the roster at read time.
       fleetRoster: () => context.fleetRoster,

--- a/packages/daemon/src/repo-cell-proxy.ts
+++ b/packages/daemon/src/repo-cell-proxy.ts
@@ -43,18 +43,29 @@ const validTaskStatusFilter = (value: string | undefined): boolean =>
   value === undefined || TASK_STATUS_FILTERS.includes(value);
 
 /** Host-side RepoCell boundary: admission/proxy plus completed-cut projection reads only. */
-export async function openRepoCellProxy(input: RepoCellOpenInput): Promise<RepoCell> {
+export async function openRepoCellProxy(
+  input: RepoCellOpenInput & { readonly onStatus?: (status: ReturnType<RepoCell["status"]>) => void },
+): Promise<RepoCell> {
   const lock = await acquireWorkspaceLock(input.rootDir);
   let relayRuntimeSignal: NonNullable<RepoCellOpenInput["onRuntimeSignal"]> = () => undefined;
-  let supervisor: Awaited<ReturnType<typeof openWriterSupervisor>>;
+  let supervisor: Awaited<ReturnType<typeof openWriterSupervisor>>,
+    opening = true;
   try {
-    supervisor = await openWriterSupervisor({
-      ...input,
-      onRuntimeSignal: (runtimeSessionId, signal) => {
-        relayRuntimeSignal(runtimeSessionId, signal);
-        input.onRuntimeSignal?.(runtimeSessionId, signal);
+    supervisor = await openWriterSupervisor(
+      {
+        ...input,
+        onRuntimeSignal: (runtimeSessionId, signal) => {
+          relayRuntimeSignal(runtimeSessionId, signal);
+          input.onRuntimeSignal?.(runtimeSessionId, signal);
+        },
       },
-    });
+      {
+        onStatus: (status) => {
+          if (opening && status.state === "warming") input.onStatus?.(status);
+        },
+      },
+    );
+    opening = false;
   } catch (error) {
     await lock.close();
     throw error;

--- a/packages/daemon/src/repo-cell-proxy.ts
+++ b/packages/daemon/src/repo-cell-proxy.ts
@@ -48,8 +48,7 @@ export async function openRepoCellProxy(
 ): Promise<RepoCell> {
   const lock = await acquireWorkspaceLock(input.rootDir);
   let relayRuntimeSignal: NonNullable<RepoCellOpenInput["onRuntimeSignal"]> = () => undefined;
-  let supervisor: Awaited<ReturnType<typeof openWriterSupervisor>>,
-    opening = true;
+  let supervisor: Awaited<ReturnType<typeof openWriterSupervisor>>;
   try {
     supervisor = await openWriterSupervisor(
       {
@@ -60,12 +59,9 @@ export async function openRepoCellProxy(
         },
       },
       {
-        onStatus: (status) => {
-          if (opening && status.state === "warming") input.onStatus?.(status);
-        },
+        onAttachStatus: input.onStatus,
       },
     );
-    opening = false;
   } catch (error) {
     await lock.close();
     throw error;

--- a/packages/daemon/src/repo-cell-types.ts
+++ b/packages/daemon/src/repo-cell-types.ts
@@ -83,6 +83,13 @@ export type TaskProgressReceipt = WriteReceiptDraft & {
   readonly worktreeVisible: true;
 };
 
+export interface RepoCellAttachProgress {
+  readonly phase: "opening" | "recovering" | "catching-up";
+  readonly applied: number | null;
+  readonly total: number | null;
+  readonly watermark: number | null;
+}
+
 export interface RepoCellStatus {
   readonly repoId: string;
   readonly rootDir: string;
@@ -93,6 +100,7 @@ export interface RepoCellStatus {
   readonly lastError: string | null;
   readonly causeClass: "data-shape" | "infrastructure" | "projection" | null;
   readonly recoveryMs: number | null;
+  readonly attach?: RepoCellAttachProgress;
 }
 
 export type RepoCellReadMethod = Exclude<

--- a/packages/daemon/src/repo-cell.ts
+++ b/packages/daemon/src/repo-cell.ts
@@ -26,7 +26,7 @@ import { scanAuthoredCandidateInventory, type AuthoredCandidateInventoryV1 } fro
 import { makeEntityActionCatalogExecutor } from "./entity-action-catalog-executor.ts";
 import { openReplicaCutSource } from "./fleet/replica-cut-store.ts";
 import { cellErrorCode, cellErrorMessage } from "./repo-cell-errors.ts";
-import type { RepoCellBinding } from "./repo-cell-types.ts";
+import type { RepoCellAttachProgress, RepoCellBinding } from "./repo-cell-types.ts";
 import { authorizeRepoCellAction } from "./repo-cell-authorization.ts";
 import { declaredRoleBindingsForActor } from "./identity/declared-role-binding-projection.ts";
 import { resolveWriteSessionIdentity } from "./session-identity/index.ts";
@@ -58,6 +58,7 @@ export interface RepoCellCoreInput {
     readonly walMaterializationTestFault?: Parameters<typeof makeTaskEventStore>[0]["walMaterializationTestFault"];
     readonly runtimeInstances?: () => readonly RuntimeInstanceSummary[];
     readonly onStoreOpened?: (store: ReturnType<typeof makeTaskEventStore>) => void;
+    readonly onOpenProgress?: (progress: RepoCellAttachProgress) => void;
   };
   readonly rootDir: string;
   readonly authoredBranch?: string;
@@ -173,8 +174,25 @@ export async function initializeRepoCell(context: RepoCellCoreInput): Promise<Re
   });
   try {
     context.input.onStoreOpened?.(store);
+    context.input.onOpenProgress?.({
+      phase: "recovering",
+      applied: null,
+      total: null,
+      watermark: null,
+    });
     let recovery = store.recover();
-    projection = makeTaskProjection({ rootDir: context.rootDir, eventStore: store, now: context.now });
+    projection = makeTaskProjection({
+      rootDir: context.rootDir,
+      eventStore: store,
+      now: context.now,
+      onProgress: (progress) =>
+        context.input.onOpenProgress?.({
+          phase: "catching-up",
+          applied: progress.applied,
+          total: progress.total ?? null,
+          watermark: progress.watermark,
+        }),
+    });
     // Attach advances one bounded, complete projection cut. Serving reads never mutates L2; future
     // writer events remain the authority and apply through the normal single-writer path.
     try {
@@ -191,6 +209,12 @@ export async function initializeRepoCell(context: RepoCellCoreInput): Promise<Re
         errorCode: cellErrorCode(error),
       };
     }
+    context.input.onOpenProgress?.({
+      phase: "opening",
+      applied: null,
+      total: null,
+      watermark: null,
+    });
     const deferredSettlement = pendingSettlement as {
       readonly actor: ActorIdentity;
       readonly inventory: unknown | null;

--- a/packages/daemon/src/repo-writer-protocol.ts
+++ b/packages/daemon/src/repo-writer-protocol.ts
@@ -5,7 +5,7 @@ import type { FleetRoster } from "./fleet-center-admission.ts";
 import type { JsonObject } from "./protocol/json-rpc-types.ts";
 import { diagnosticForError } from "./receipt-guidance.ts";
 import type { RepoBootstrapInput } from "./repo-bootstrap.ts";
-import type { RepoCellBinding, RepoTaskAction, RuntimeIngressAction } from "./repo-cell-types.ts";
+import type { RepoCellBinding, RepoCellStatus, RepoTaskAction, RuntimeIngressAction } from "./repo-cell-types.ts";
 import type { RuntimeAttemptTerminal, RuntimeDaemonRoute } from "./runtime-spawn.ts";
 
 export const REPO_WRITER_PROTOCOL_VERSION = 1 as const;
@@ -76,7 +76,7 @@ export interface RepoWriterStatusV1 {
   readonly schema: "harness-repo-writer-status/v1";
   readonly protocolVersion: typeof REPO_WRITER_PROTOCOL_VERSION;
   readonly kind: "ready" | "cut" | "status" | "closed";
-  readonly status?: unknown;
+  readonly status?: RepoCellStatus;
   readonly bootstrapReceipt?: unknown;
   readonly error?: SerializedWriterErrorV1;
 }

--- a/packages/daemon/src/repo-writer-worker.ts
+++ b/packages/daemon/src/repo-writer-worker.ts
@@ -3,7 +3,7 @@ import { isMainThread, parentPort, workerData } from "node:worker_threads";
 import { consumeKnownError, type CanonicalEventStore } from "../../kernel/src/index.ts";
 import type { RepoCellOpenInput } from "./repo-cell-open.ts";
 import { openRepoWriterCell } from "./repo-cell-open.ts";
-import type { RepoCellBinding } from "./repo-cell-types.ts";
+import type { RepoCellAttachProgress, RepoCellBinding, RepoCellStatus } from "./repo-cell-types.ts";
 import {
   REPO_WRITER_PROTOCOL_VERSION,
   deserializeWriterError,
@@ -42,6 +42,15 @@ async function startRepoWriterWorker(): Promise<void> {
   let cell: Awaited<ReturnType<typeof openRepoWriterCell>> | null = null,
     writerStore: CanonicalEventStore | null = null,
     bulkWrite: ReturnType<NonNullable<CanonicalEventStore["beginBulkWrite"]>> | null = null;
+  let openingStatus = statusDuringOpen({
+    phase: "opening",
+    applied: null,
+    total: null,
+    watermark: null,
+  });
+  postStatus({ kind: "status", status: openingStatus });
+  const heartbeat = setInterval(() => postStatus({ kind: "status", status: openingStatus }), 4_000);
+  heartbeat.unref?.();
 
   parentPort.on("message", (message: unknown) => {
     if (isCapabilityResult(message)) {
@@ -70,7 +79,9 @@ async function startRepoWriterWorker(): Promise<void> {
 
   try {
     const config = bootstrap.config,
-      input: RepoCellOpenInput = {
+      input: RepoCellOpenInput & {
+        readonly onOpenProgress: (progress: RepoCellAttachProgress) => void;
+      } = {
         ...config,
         repoId: config.repoId as RepoCellOpenInput["repoId"],
         rootDir: config.rootDir as RepoCellOpenInput["rootDir"],
@@ -112,6 +123,11 @@ async function startRepoWriterWorker(): Promise<void> {
             }
           : {}),
         onBootstrap: (receipt) => notify("bootstrap", receipt),
+        onOpenProgress: (progress) => {
+          if (cell !== null) return;
+          openingStatus = statusDuringOpen(progress);
+          postStatus({ kind: "status", status: openingStatus });
+        },
         onRuntimeOutcome: (event) => notify("runtimeOutcome", event),
         onAttemptTerminal: (terminal) => notify("attemptTerminal", terminal),
         recordLifecycle: (record) => notify("lifecycle", record),
@@ -125,6 +141,23 @@ async function startRepoWriterWorker(): Promise<void> {
   } catch (error) {
     consumeKnownError(error);
     postStatus({ kind: "closed", error: serializeWriterError(error) });
+  } finally {
+    clearInterval(heartbeat);
+  }
+
+  function statusDuringOpen(attach: RepoCellAttachProgress): RepoCellStatus {
+    return {
+      repoId: bootstrap.config.repoId,
+      rootDir: bootstrap.config.rootDir,
+      mode: bootstrap.config.mode ?? "local",
+      state: "warming",
+      generation: null,
+      queueDepth: 0,
+      lastError: null,
+      causeClass: null,
+      recoveryMs: null,
+      attach,
+    };
   }
 
   async function handleRequest(request: RepoWriterRequestV1): Promise<void> {

--- a/packages/daemon/src/writer-supervisor.ts
+++ b/packages/daemon/src/writer-supervisor.ts
@@ -36,7 +36,16 @@ export interface WriterSupervisor {
   readonly close: () => Promise<void>;
 }
 
-export async function openWriterSupervisor(input: RepoCellOpenInput): Promise<WriterSupervisor> {
+export async function openWriterSupervisor(
+  input: RepoCellOpenInput,
+  options: {
+    readonly createWorker?: (
+      url: URL,
+      workerOptions: { readonly execArgv: readonly string[]; readonly workerData: RepoWriterBootstrapV1 },
+    ) => Worker;
+    readonly onStatus?: (status: RepoCellStatus) => void;
+  } = {},
+): Promise<WriterSupervisor> {
   let worker: Worker | null = null,
     closed = false,
     opened = false,
@@ -51,6 +60,12 @@ export async function openWriterSupervisor(input: RepoCellOpenInput): Promise<Wr
       lastError: null,
       causeClass: null,
       recoveryMs: null,
+      attach: {
+        phase: "opening",
+        applied: null,
+        total: null,
+        watermark: null,
+      },
     },
     publishedBootstrapReceipt: unknown,
     ready: Promise<void>;
@@ -142,25 +157,34 @@ export async function openWriterSupervisor(input: RepoCellOpenInput): Promise<Wr
   function startWriterWorker(): Promise<void> {
     if (closed) return Promise.reject(new Error("WriterSupervisor is closed"));
     return new Promise((resolve, reject) => {
-      const candidate = new Worker(writerWorkerUrl(), {
+      const workerOptions = {
         execArgv: process.execArgv.filter(
           (argument) => argument === "--experimental-strip-types" || argument === "--enable-source-maps",
         ),
         workerData: bootstrapMessage(input),
-      });
+      };
+      const candidate =
+        options.createWorker?.(writerWorkerUrl(), workerOptions) ?? new Worker(writerWorkerUrl(), workerOptions);
       let settled = false;
-      const readyTimer = setTimeout(() => {
+      let readyWatchdog: ReturnType<typeof setTimeout>;
+      const readyInactive = () => {
         if (settled) return;
         settled = true;
-        const error = new Error("RepoWriterCell did not publish ready within 30000ms");
+        const error = new Error("RepoWriterCell did not publish ready after 30000ms without a message");
         if (!opened) closed = true;
         reject(error);
         failActive(error);
         void candidate.terminate();
-      }, 30_000);
-      readyTimer.unref?.();
+      };
+      const armReadyWatchdog = () => {
+        clearTimeout(readyWatchdog);
+        readyWatchdog = setTimeout(readyInactive, 30_000);
+        readyWatchdog.unref?.();
+      };
+      armReadyWatchdog();
       worker = candidate;
       candidate.on("message", (message: unknown) => {
+        if (!settled) armReadyWatchdog();
         if (isReceipt(message)) {
           const operation = pending.get(message.requestId);
           if (!operation) return;
@@ -173,7 +197,10 @@ export async function openWriterSupervisor(input: RepoCellOpenInput): Promise<Wr
         }
         if (isStatus(message)) {
           const published = message.status;
-          if (published && typeof published === "object") status = published as RepoCellStatus;
+          if (published && typeof published === "object") {
+            status = published;
+            options.onStatus?.(status);
+          }
           if (message.bootstrapReceipt !== undefined) {
             publishedBootstrapReceipt = message.bootstrapReceipt;
             input.onBootstrap?.(message.bootstrapReceipt as never);
@@ -181,11 +208,11 @@ export async function openWriterSupervisor(input: RepoCellOpenInput): Promise<Wr
           if (message.kind === "ready") {
             restartAttempt = 0;
             settled = true;
-            clearTimeout(readyTimer);
+            clearTimeout(readyWatchdog);
             resolve();
           } else if (message.kind === "closed" && message.error && !settled) {
             settled = true;
-            clearTimeout(readyTimer);
+            clearTimeout(readyWatchdog);
             if (!opened) closed = true;
             reject(deserializeWriterError(message.error));
             void candidate.terminate();
@@ -197,14 +224,14 @@ export async function openWriterSupervisor(input: RepoCellOpenInput): Promise<Wr
       candidate.once("error", (error) => {
         if (!settled) {
           settled = true;
-          clearTimeout(readyTimer);
+          clearTimeout(readyWatchdog);
           if (!opened) closed = true;
           reject(error);
         }
         failActive(error);
       });
       candidate.once("exit", (code) => {
-        clearTimeout(readyTimer);
+        clearTimeout(readyWatchdog);
         if (worker === candidate) worker = null;
         const error = new Error(`RepoWriterCell exited with code ${code}`);
         if (!settled) {

--- a/packages/daemon/src/writer-supervisor.ts
+++ b/packages/daemon/src/writer-supervisor.ts
@@ -43,7 +43,7 @@ export async function openWriterSupervisor(
       url: URL,
       workerOptions: { readonly execArgv: readonly string[]; readonly workerData: RepoWriterBootstrapV1 },
     ) => Worker;
-    readonly onStatus?: (status: RepoCellStatus) => void;
+    readonly onAttachStatus?: (status: RepoCellStatus) => void;
   } = {},
 ): Promise<WriterSupervisor> {
   let worker: Worker | null = null,
@@ -198,8 +198,9 @@ export async function openWriterSupervisor(
         if (isStatus(message)) {
           const published = message.status;
           if (published && typeof published === "object") {
-            status = published;
-            options.onStatus?.(status);
+            const attachStatus = published.attach !== undefined;
+            if (!settled || !attachStatus) status = published;
+            if (!settled && attachStatus) options.onAttachStatus?.(published);
           }
           if (message.bootstrapReceipt !== undefined) {
             publishedBootstrapReceipt = message.bootstrapReceipt;

--- a/packages/daemon/test/daemon-host-recovery.test.ts
+++ b/packages/daemon/test/daemon-host-recovery.test.ts
@@ -8,7 +8,9 @@ import path from "node:path";
 import test from "node:test";
 import { makeTaskProjection, readDaemonRegistry } from "../../kernel/src/index.ts";
 import { openDaemonHost } from "../src/daemon-host.ts";
+import type { DaemonHostOpenInput } from "../src/daemon-host-open.ts";
 import { canonicalRoot, workspaceId } from "../src/protocol/daemon-protocol.contract.ts";
+import type { RepoCellStatus } from "../src/repo-cell-types.ts";
 import {
   openBootstrappedRepoCell as openRepoCell,
   registerBootstrappedDaemonRepo as registerDaemonRepo,
@@ -139,6 +141,80 @@ test("a request arriving while a registered repo warms parks until background at
     assert.equal(receipt.outcome, "applied", JSON.stringify(receipt));
     assert.equal(host.status().repos.find((repo) => repo.repoId === "host-warming")?.state, "attached");
   } finally {
+    await host.close();
+    rmSync(parent, { recursive: true, force: true });
+  }
+});
+
+test("daemon status exposes the writer phase and progress while a repository attaches", async (context) => {
+  const parent = mkdtempSync(path.join(tmpdir(), "ha-host-attach-progress-")),
+    rootDir = path.join(parent, "repo"),
+    userRoot = path.join(parent, "user");
+  rosterRepo(rootDir, "host-attach-progress");
+  registerDaemonRepo({
+    canonicalRoot: rootDir,
+    repoId: "host-attach-progress",
+    userRoot,
+    createConvenienceLinks: false,
+  });
+  let publishProgress!: () => void, releaseOpen!: () => void;
+  const workerStatuses: RepoCellStatus[] = [],
+    progressPublished = new Promise<void>((resolve) => {
+      publishProgress = resolve;
+    }),
+    openReleased = new Promise<void>((resolve) => {
+      releaseOpen = resolve;
+    }),
+    openCell: NonNullable<DaemonHostOpenInput["openCell"]> = async (cellInput) => {
+      cellInput.onStatus?.({
+        repoId: cellInput.repoId,
+        rootDir: cellInput.rootDir,
+        mode: cellInput.mode ?? "local",
+        state: "warming",
+        generation: null,
+        queueDepth: 0,
+        lastError: null,
+        causeClass: null,
+        recoveryMs: null,
+        attach: {
+          phase: "catching-up",
+          applied: 4_096,
+          total: 8_192,
+          watermark: 4_096,
+        },
+      });
+      publishProgress();
+      await openReleased;
+      return openRepoCell({
+        ...cellInput,
+        onStatus: (status) => {
+          workerStatuses.push(status);
+          cellInput.onStatus?.(status);
+        },
+      });
+    },
+    host = await openDaemonHost({ daemonId: "host-attach-progress", userRoot, openCell }),
+    attachments = host.attachmentsSettled();
+  await progressPublished;
+  try {
+    const row = host.status().repos.find((repo) => repo.repoId === "host-attach-progress");
+    context.diagnostic(`ha daemon status repo row: ${JSON.stringify(row)}`);
+    assert.equal(row?.state, "warming");
+    assert.deepEqual(row?.attach, {
+      phase: "catching-up",
+      applied: 4_096,
+      total: 8_192,
+      watermark: 4_096,
+    });
+    releaseOpen();
+    await attachments;
+    assert.ok(
+      workerStatuses.some((status) => status.attach?.phase === "catching-up"),
+      "the real writer must relay its catch-up boundary through the existing status message",
+    );
+  } finally {
+    releaseOpen();
+    await attachments;
     await host.close();
     rmSync(parent, { recursive: true, force: true });
   }

--- a/packages/daemon/test/daemon-host-recovery.test.ts
+++ b/packages/daemon/test/daemon-host-recovery.test.ts
@@ -212,6 +212,10 @@ test("daemon status exposes the writer phase and progress while a repository att
       workerStatuses.some((status) => status.attach?.phase === "catching-up"),
       "the real writer must relay its catch-up boundary through the existing status message",
     );
+    const attachedRows = host.status().repos.filter((repo) => repo.repoId === "host-attach-progress");
+    assert.equal(attachedRows.length, 1);
+    assert.equal(attachedRows[0]?.state, "attached");
+    assert.equal(attachedRows[0]?.attach, undefined);
   } finally {
     releaseOpen();
     await attachments;
@@ -570,6 +574,7 @@ test("daemon admission rejects a mismatched kernel projection schema and recover
     clock = "2026-08-18T00:00:06.000Z";
     assert.equal((await host.run("schema-admission", { kind: "task-list" }, auth)).outcome, "applied");
     assert.equal(host.status().repos.find((repo) => repo.repoId === "schema-admission")?.state, "attached");
+    assert.equal(host.status().repos.find((repo) => repo.repoId === "schema-admission")?.attach, undefined);
   } finally {
     await host.close();
     rmSync(parent, { recursive: true, force: true });

--- a/packages/daemon/test/runtime-spawn-ingress.integration.test.ts
+++ b/packages/daemon/test/runtime-spawn-ingress.integration.test.ts
@@ -1342,9 +1342,12 @@ test("daemon ingress resumes the same provider session for Claude and Codex", as
                 event.payload.runtimeSessionId === second.runtimeSessionId,
             ),
         );
-        const read = await rpc(host, auth, "repo.agentRuntime.sessions.read", {
-          repo: { repoId },
-          payload: { runtimeSessionId: second.runtimeSessionId },
+        const read = await eventuallyValue(async () => {
+          const value = await rpc(host, auth, "repo.agentRuntime.sessions.read", {
+            repo: { repoId },
+            payload: { runtimeSessionId: second.runtimeSessionId },
+          });
+          return value.result ? value : null;
         });
         assert.equal((read.session as Record<string, unknown>).providerSessionId, providerSessionId);
         assert.equal(

--- a/packages/daemon/test/runtime-spawn-lifecycle.integration.test.ts
+++ b/packages/daemon/test/runtime-spawn-lifecycle.integration.test.ts
@@ -264,8 +264,11 @@ test("runtime spawn publishes a canonical session and makes it visible in overvi
         started?.type === "runtime_session_started" && started.payload.definitionSnapshotRef,
         dispatch?.type === "runtime_dispatch_requested" && dispatch.payload.definitionSnapshotRef,
       );
-      const overview = await cell.read("repo.agentRuntime.overview", {});
-      const session = overview.sessions.find((candidate) => candidate.runtimeSessionId === receipt.runtimeSessionId);
+      const { session } = await eventuallyValue(async () => {
+        const overview = await cell.read("repo.agentRuntime.overview", {}),
+          projected = overview.sessions.find((candidate) => candidate.runtimeSessionId === receipt.runtimeSessionId);
+        return projected?.liveness === "live" ? { session: projected } : null;
+      });
       assert.equal(session?.instanceId, definition.instanceId);
       assert.deepEqual(session?.definitionSnapshot, definition);
       assert.equal(session?.definitionSnapshotPersisted, true);

--- a/packages/daemon/test/writer-supervisor-liveness.test.ts
+++ b/packages/daemon/test/writer-supervisor-liveness.test.ts
@@ -24,7 +24,7 @@ test("a writer may open beyond 30 seconds when messages keep the ready watchdog 
     published: RepoCellStatus[] = [],
     opening = openWriterSupervisor(supervisorInput, {
       createWorker: () => writer as unknown as Worker,
-      onStatus: (status) => published.push(status),
+      onAttachStatus: (status) => published.push(status),
     });
 
   context.mock.timers.tick(29_999);
@@ -34,9 +34,15 @@ test("a writer may open beyond 30 seconds when messages keep the ready watchdog 
   context.mock.timers.tick(29_999);
   assert.equal(writer.terminateCalls, 0);
   writer.publish(writerStatus("ready", attachedStatus()));
+  writer.publish(
+    writerStatus("status", warmingStatus({ phase: "catching-up", applied: 8_192, total: 8_192, watermark: 8_192 })),
+  );
 
   const supervisor = await opening;
   assert.equal(supervisor.status().state, "attached");
+  assert.equal(supervisor.status().generation, 1);
+  assert.equal(supervisor.status().attach, undefined);
+  assert.equal(published.length, 1);
   assert.deepEqual(published[0]?.attach, {
     phase: "catching-up",
     applied: 4_096,

--- a/packages/daemon/test/writer-supervisor-liveness.test.ts
+++ b/packages/daemon/test/writer-supervisor-liveness.test.ts
@@ -1,0 +1,131 @@
+// harness-test-tier: contract
+import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
+import test from "node:test";
+import type { Worker } from "node:worker_threads";
+import type { RepoCellOpenInput } from "../src/repo-cell-open.ts";
+import type { RepoCellStatus } from "../src/repo-cell-types.ts";
+import {
+  REPO_WRITER_PROTOCOL_VERSION,
+  type RepoWriterControlV1,
+  type RepoWriterStatusV1,
+} from "../src/repo-writer-protocol.ts";
+import { openWriterSupervisor } from "../src/writer-supervisor.ts";
+
+const supervisorInput = {
+  repoId: "writer-liveness",
+  rootDir: "/tmp/writer-liveness",
+  ownerId: "writer-liveness-test",
+} as RepoCellOpenInput;
+
+test("a writer may open beyond 30 seconds when messages keep the ready watchdog active", async (context) => {
+  context.mock.timers.enable({ apis: ["setTimeout"] });
+  const writer = new FakeWriter(),
+    published: RepoCellStatus[] = [],
+    opening = openWriterSupervisor(supervisorInput, {
+      createWorker: () => writer as unknown as Worker,
+      onStatus: (status) => published.push(status),
+    });
+
+  context.mock.timers.tick(29_999);
+  writer.publish(
+    writerStatus("status", warmingStatus({ phase: "catching-up", applied: 4_096, total: 8_192, watermark: 4_096 })),
+  );
+  context.mock.timers.tick(29_999);
+  assert.equal(writer.terminateCalls, 0);
+  writer.publish(writerStatus("ready", attachedStatus()));
+
+  const supervisor = await opening;
+  assert.equal(supervisor.status().state, "attached");
+  assert.deepEqual(published[0]?.attach, {
+    phase: "catching-up",
+    applied: 4_096,
+    total: 8_192,
+    watermark: 4_096,
+  });
+  await supervisor.close();
+});
+
+test("a writer with no messages is terminated after 30 seconds of ready inactivity", async (context) => {
+  context.mock.timers.enable({ apis: ["setTimeout"] });
+  const writer = new FakeWriter(),
+    opening = openWriterSupervisor(supervisorInput, {
+      createWorker: () => writer as unknown as Worker,
+    }),
+    rejected = assert.rejects(opening, /RepoWriterCell did not publish ready/u);
+
+  context.mock.timers.tick(29_999);
+  assert.equal(writer.terminateCalls, 0);
+  context.mock.timers.tick(1);
+  await rejected;
+  assert.equal(writer.terminateCalls, 1);
+});
+
+class FakeWriter extends EventEmitter {
+  terminateCalls = 0;
+
+  postMessage(message: unknown): void {
+    if (!isControl(message)) return;
+    this.emit("message", {
+      schema: "harness-repo-writer-receipt/v1",
+      protocolVersion: REPO_WRITER_PROTOCOL_VERSION,
+      requestId: message.requestId,
+      outcome: "ok",
+    });
+  }
+
+  publish(message: RepoWriterStatusV1): void {
+    this.emit("message", message);
+  }
+
+  terminate(): Promise<number> {
+    this.terminateCalls += 1;
+    return Promise.resolve(0);
+  }
+}
+
+function writerStatus(kind: RepoWriterStatusV1["kind"], status: RepoCellStatus): RepoWriterStatusV1 {
+  return {
+    schema: "harness-repo-writer-status/v1",
+    protocolVersion: REPO_WRITER_PROTOCOL_VERSION,
+    kind,
+    status,
+  };
+}
+
+function warmingStatus(attach: NonNullable<RepoCellStatus["attach"]>): RepoCellStatus {
+  return {
+    repoId: supervisorInput.repoId,
+    rootDir: supervisorInput.rootDir,
+    mode: "local",
+    state: "warming",
+    generation: null,
+    queueDepth: 0,
+    lastError: null,
+    causeClass: null,
+    recoveryMs: null,
+    attach,
+  };
+}
+
+function attachedStatus(): RepoCellStatus {
+  return {
+    repoId: supervisorInput.repoId,
+    rootDir: supervisorInput.rootDir,
+    mode: "local",
+    state: "attached",
+    generation: 1,
+    queueDepth: 0,
+    lastError: null,
+    causeClass: null,
+    recoveryMs: 1,
+  };
+}
+
+function isControl(value: unknown): value is RepoWriterControlV1 {
+  return (
+    value !== null &&
+    typeof value === "object" &&
+    (value as { readonly schema?: unknown }).schema === "harness-repo-writer-control/v1"
+  );
+}

--- a/packages/kernel/src/projection/rebuildable-task-projection-factory.ts
+++ b/packages/kernel/src/projection/rebuildable-task-projection-factory.ts
@@ -58,6 +58,12 @@ import {
 export type { ProjectionPage, TaskProjectionListQuery, TaskRelationQuery } from "./task-query-projection.ts";
 export type { TaskProjection } from "./task-projection-port.ts";
 
+export interface TaskProjectionCatchUpProgress {
+  readonly applied: number;
+  readonly total?: number;
+  readonly watermark: number;
+}
+
 // Public projection construction and local source-head handling.
 export function defaultLifecycleTaskProjectionPath(rootDir: string): string {
   return path.join(path.resolve(rootDir), ".harness/cache/task.sqlite");
@@ -68,10 +74,12 @@ export function makeTaskProjection(options: {
   readonly projectionPath?: string;
   readonly catchUpLimit?: number;
   readonly now?: () => string;
+  readonly onProgress?: (progress: TaskProjectionCatchUpProgress) => void;
 }): TaskProjection {
   const projectionPath = options.projectionPath ?? defaultLifecycleTaskProjectionPath(options.rootDir);
   const limit = options.catchUpLimit ?? 4096,
     now = options.now ?? (() => new Date().toISOString()),
+    onProgress = options.onProgress ?? (() => undefined),
     sourceReadHead = options.eventStore.readHead;
   let observedSourceHead = false,
     hotAppliedHead: ReturnType<EventStreamPort["readHead"]> = null;
@@ -150,6 +158,7 @@ export function makeTaskProjection(options: {
       return rebuildProjection(projectionPath, readHead, options.eventStore, limit);
     },
     catchUp: () => {
+      const initialWatermark = withDatabase(projectionPath, readHead, watermark);
       let sqliteTransactions = 0,
         reducedItems = 0,
         maxBatchItems = 0;
@@ -158,6 +167,12 @@ export function makeTaskProjection(options: {
         sqliteTransactions += round.sqliteTransactions;
         reducedItems += round.reducedItems;
         maxBatchItems = Math.max(maxBatchItems, round.accessedItems);
+        const total = Math.max(0, round.sourceRevision - initialWatermark);
+        onProgress({
+          applied: Math.min(total, Math.max(0, round.watermark - initialWatermark)),
+          total,
+          watermark: round.watermark,
+        });
         if (round.watermark !== round.sourceRevision) continue;
         const settled = withDatabase(projectionPath, readHead, (db) =>
           transaction(db, () => ({

--- a/packages/kernel/test/store/task-query-projection.test.ts
+++ b/packages/kernel/test/store/task-query-projection.test.ts
@@ -1,5 +1,6 @@
 // harness-test-tier: integration
 import assert from "node:assert/strict";
+import path from "node:path";
 import test from "node:test";
 import { makeTaskProjection } from "../../src/projection/rebuildable-task-projection.ts";
 import {
@@ -227,6 +228,35 @@ test("narrow task list pages concatenate to the unparameterized result and keep 
       projection.list({ status: "active", limit: 1 }).rows.map((row) => row.taskId),
       ["task_query_01"],
     );
+  });
+});
+
+test("catch-up reports every bounded round and keeps an omitted progress callback as a no-op", async () => {
+  const events = taskFixture().events.slice(0, 3);
+  await withTempStoreAsync(async (rootDir) => {
+    const progress: Array<{ readonly applied: number; readonly total: number; readonly watermark: number }> = [],
+      projection = makeTaskProjection({
+        rootDir,
+        eventStore: memoryEventStore(events),
+        catchUpLimit: 1,
+        onProgress: (round) => progress.push({ ...round, total: round.total ?? -1 }),
+      });
+    projection.catchUp();
+    assert.deepEqual(progress, [
+      { applied: 1, total: 3, watermark: 1 },
+      { applied: 2, total: 3, watermark: 2 },
+      { applied: 3, total: 3, watermark: 3 },
+    ]);
+    projection.close();
+
+    const quiet = makeTaskProjection({
+      rootDir,
+      projectionPath: path.join(rootDir, ".harness/cache/task-quiet.sqlite"),
+      eventStore: memoryEventStore(events),
+      catchUpLimit: 1,
+    });
+    assert.equal(quiet.catchUp().watermark, 3);
+    quiet.close();
   });
 });
 


### PR DESCRIPTION
# English

## Summary

After stage-3 (#2149) merged, the first daemon start on the new code could not attach the canonical repository: `WriterSupervisor` gave the writer worker a fixed 30 000 ms deadline to publish `ready`, but the worker only publishes `ready` after `openRepoWriterCell` finishes (WAL recovery + projection catch-up), which takes about 32 s on the canonical ledger of this machine. Every attempt was terminated at 30 s and the whole ledger was unreadable and unwritable until a local break-glass raised the compiled timeout (fact F-CBEDEFB4, task task_c09369abd2d6d1e0c41c07f7b5).

This PR replaces the deadline with a liveness criterion. The kernel projection catch-up gains an optional per-round `onProgress` callback (default no-op); the writer worker posts a `status` heartbeat every 4 s and at each open phase (`opening` / `recovering` / `catching-up` with applied/total/watermark); the supervisor's ready watchdog is re-armed by every worker message and only fires after 30 s of silence, keeping the "dead worker" detection while no longer killing a worker that is visibly making progress. `ready` semantics are unchanged. The daemon status row of a warming repo now carries the attach phase and progress.

Deleted: the fixed "ready within 30 s of start" timer branch and its cleanup path.

## Architectural Justification

The 30 s number was never the invariant; "a worker that stops talking is dead" is. Making the watchdog inactivity-based fixes the class (any repository whose cold open exceeds a constant) rather than the instance, without a configurable timeout or a second status channel. The kernel callback is the progress surface that task_580dc15e8d0bd720e4f3e60787 (rebuild off the main thread, status "rebuilding N/M") will reuse; no thread restructuring or async rebuild is done here. Single-process supervisor↔worker protocol; no ledger writes, no multi-node concurrency subject.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none

## Machine-Readable Declarations

Production-Delta: +152/-26
Dependency-Change: none

### Optional Evidence Claims

none

## Task And Scope

task_c09369abd2d6d1e0c41c07f7b5 (child of incident root task_98a824499e96f27b66797d227d). Scope: `writer-supervisor.ts`, `repo-writer-worker.ts`, `repo-writer-protocol.ts`, warming-status projection in `repo-cell.ts` / `repo-cell-proxy.ts` / `daemon-host-*.ts`, kernel `rebuildable-task-projection-factory.ts` progress callback, tests.

## Version Impact

None.

## Governance Declaration

No CI workflow, required check, gate script or allowlist is modified. The local break-glass (a 600 000 ms literal patched into the compiled dist on the CEO machine, never committed) is superseded by this mechanism and disappears with the next dist rebuild.

## Verification

- Worker stop point (targeted tests + local commit; no `check:local`): slow writer with heartbeats simulating a 59.998 s open → attach succeeds; silent writer → terminated at 30 s (negative control preserved); attach status snapshot `{"state":"warming","attach":{"phase":"catching-up","applied":4096,"total":8192,"watermark":4096}}`; kernel per-round callback and default no-op 6/6; typecheck, lint, Prettier, line-density, file-complexity, test-selection, canonical-event-compat and 179 gate tests pass locally.
- Post-merge: CEO rebuilds dist, restarts the canonical daemon without the break-glass and records the attach duration on the task.

## Review Evidence

Worker report `harness/tasks/task_c09369abd2d6d1e0c41c07f7b5-*/artifacts/reports/` (private ledger). CEO reviewed the supervisor watchdog (armed on start, re-armed on every message before `ready`, cleared on ready / closed / error / exit), the worker heartbeat and the kernel callback diff.

## Residual Risk

A worker that keeps posting heartbeats but never completes open is no longer killed by the supervisor; that case is surfaced through the attach phase in `ha daemon status` rather than by a timeout, which is the intended trade (task_580dc15e follows up with progress-based reporting for rebuilds).

---

# 中文

## 概要

stage-3(#2149)合入后,新代码第一次启动 daemon 时 canonical 仓库无法 attach:`WriterSupervisor` 给 writer 线程一个固定 30 000 ms 的 ready 期限,而 worker 只有在 `openRepoWriterCell`(WAL 恢复 + 投影 catch-up)整个完成后才发 `ready`,本机 canonical 台账需要约 32 秒。每次尝试都在 30 秒被 terminate,整套台账不可读写,直到本地 break-glass 把编译产物里的超时改大(fact F-CBEDEFB4,任务 task_c09369abd2d6d1e0c41c07f7b5)。

本 PR 用活性判据替代期限:kernel 投影 catch-up 增加可选的每轮 `onProgress` 回调(默认 no-op);writer 线程每 4 秒及每个打开阶段(`opening` / `recovering` / `catching-up`,带 applied/total/watermark)发一条 `status` 心跳;supervisor 的 ready 看门狗在每条 worker 消息上续期,只有连续 30 秒无消息才触发——保留「死 worker 会被判死」,不再杀掉明显在推进的 worker。`ready` 语义不变。warming 中的仓库在 daemon status 行里可见 attach 阶段与进度。

删除:固定「启动后 30 秒内必须 ready」的计时器分支及其清理路径。

## 架构辩护

30 秒这个数字从来不是不变量,「不说话的 worker 就是死的」才是。看门狗改成按不活动判定,修的是这一类(任何冷打开超过常数的仓库)而不是这一例,不加可配置超时、不加第二条状态通道。kernel 回调就是 task_580dc15e8d0bd720e4f3e60787(重建挪出主线程、status 报「重建中 N/M」)将复用的进度面;本 PR 不做线程重构或异步化。单进程 supervisor↔worker 协议,无台账写入、无多节点并发主体。

## 机读声明

见英文块。

## 治理声明

不修改任何 CI workflow、required check、gate 脚本或 allowlist。本地 break-glass(CEO 机器上贴进 dist 的 600 000 ms 字面量,从未提交)被本机制替代,随下一次 dist 重建消失。

## 验证

- worker 停止点(定向测试 + 本地 commit,不跑 `check:local`):慢 writer 持续心跳、模拟打开 59.998 秒 → attach 成功;无消息 writer → 30 秒被 terminate(阴性对照保留);attach 状态快照 `{"state":"warming","attach":{"phase":"catching-up","applied":4096,"total":8192,"watermark":4096}}`;kernel 每轮回调与默认 no-op 6/6;typecheck、lint、Prettier、line-density、file-complexity、test-selection、canonical-event-compat 与 179 个 gate tests 本地全绿。
- 合入后:CEO 重建 dist、不带 break-glass 重启 canonical daemon,并把 attach 耗时记到任务。

## 评审证据

worker 报告见任务包 `artifacts/reports/`(私有台账)。CEO 复核了 supervisor 看门狗(启动即武装、ready 前每条消息续期、ready / closed / error / exit 全部清除)、worker 心跳与 kernel 回调 diff。

## 残余风险

持续发心跳但永远打不开的 worker 不再被 supervisor 杀掉;这种情况通过 `ha daemon status` 的 attach 阶段暴露而不是靠超时,这是有意的取舍(task_580dc15e 后续以进度上报承接重建场景)。

