### PR TITLE
fix(migrate): import dispatch records whose result blobs were lost

### DIFF
--- a/packages/daemon/src/migration-import-backfill.ts
+++ b/packages/daemon/src/migration-import-backfill.ts
@@ -235,7 +235,7 @@ function runtimeSessionBundles(
   session: RuntimeSession,
   startedAt: string,
   outcome: {
-    readonly result: { readonly sha256: string; readonly size: number; readonly mediaType: string };
+    readonly result: { readonly sha256: string; readonly size: number; readonly mediaType: string } | null;
     readonly reasonCode?: string;
   } | null,
   initialRevision: number,
@@ -307,8 +307,23 @@ function runtimeSessionBundles(
       occurredAt: session.lastObservedAt,
       payload: { runtimeSessionId: session.runtimeSessionId, liveness: session.liveness },
     });
-  if (session.outcome !== null) {
-    if (outcome === null) throw new Error("runtime outcome projection has no source result claim");
+  if (session.outcome !== null && outcome === null)
+    throw new Error("runtime outcome projection has no source result claim");
+  if (session.outcome !== null && outcome?.result === null)
+    specs.push({
+      suffix: "outcome",
+      type: "runtime_session_outcome_observed",
+      occurredAt: session.lastObservedAt,
+      payload: {
+        runtimeSessionId: session.runtimeSessionId,
+        outcome: session.outcome,
+        exitCode: session.exitCode,
+        resultRef: session.resultRef,
+        result: null,
+        ...(outcome.reasonCode ? { reasonCode: outcome.reasonCode } : {}),
+      },
+    });
+  if (session.outcome !== null && outcome !== null && outcome.result !== null) {
     if (
       outcome.result.sha256 !== session.resultRef?.slice("artifact:runtime-result/sha256/".length) ||
       outcome.result.mediaType !== "text/plain; charset=utf-8"

--- a/packages/daemon/src/migration-import-oracle.ts
+++ b/packages/daemon/src/migration-import-oracle.ts
@@ -92,7 +92,7 @@ export interface ProjectionOracleRuntimeSession {
   readonly startedAt: string;
   readonly sourceAnchor: MigrationSourceAnchor;
   readonly outcome: {
-    readonly result: RuntimeResultClaim;
+    readonly result: RuntimeResultClaim | null;
     readonly reasonCode?: string;
   } | null;
 }
@@ -445,9 +445,12 @@ function readEntitySourceEvents(database: DatabaseSync): {
       held = runtime.get(sessionId) ?? { startedAt: occurredAt, latest: anchor, outcome: null };
     held.latest = anchor;
     if (event.type === "runtime_session_started") held.startedAt = occurredAt;
-    if (event.type === "runtime_session_outcome_observed" && isMigrationImportRecord(payload.result))
+    if (
+      event.type === "runtime_session_outcome_observed" &&
+      (payload.result === null || isMigrationImportRecord(payload.result))
+    )
       held.outcome = {
-        result: payload.result as unknown as RuntimeResultClaim,
+        result: payload.result as RuntimeResultClaim | null,
         ...(typeof payload.reasonCode === "string" ? { reasonCode: payload.reasonCode } : {}),
       };
     runtime.set(sessionId, held);

--- a/packages/daemon/test/event-shape-migration.integration.test.ts
+++ b/packages/daemon/test/event-shape-migration.integration.test.ts
@@ -17,6 +17,7 @@ import {
   runDispatchRecordMigration,
   runtimeArchiveText,
   runtimeDefinitionSnapshotArtifact,
+  runtimeEventContentClaims,
   sha256Text,
   type AgentDefinitionSnapshot,
   type AgentRuntimeEventV1,
@@ -730,7 +731,7 @@ test("dispatch migration retries a lease settlement that failed after terminal e
   }
 });
 
-test("dispatch migration skips unproven bindings and selects the latest definition effective at dispatch time", async (context) => {
+test("dispatch migration safely plans missing executions, result blobs, bindings, and definitions", async (context) => {
   const scratch = mkdtempSync(path.join(tmpdir(), "ha-dispatch-safe-planning-")),
     repoId = "dispatch-safe-planning",
     binding: RepoCellBinding = { actor: { principal: actor.principal, executor: null }, source },
@@ -748,6 +749,7 @@ test("dispatch migration skips unproven bindings and selects the latest definiti
     }),
     definitionLatest = syntheticDispatchRecord("1", { instanceId: "definition-history" }),
     definitionAmbiguous = syntheticDispatchRecord("2", { instanceId: "definition-ambiguous" }),
+    settledWithoutExecution = syntheticDispatchRecord("3", { instanceId: "definition-common" }),
     records = [
       executionMissing,
       bindingMismatch,
@@ -757,6 +759,7 @@ test("dispatch migration skips unproven bindings and selects the latest definiti
       resultMissing,
       definitionLatest,
       definitionAmbiguous,
+      settledWithoutExecution,
     ];
   let cell: Awaited<ReturnType<typeof openBootstrappedRepoCell>> | undefined;
   try {
@@ -776,7 +779,7 @@ test("dispatch migration skips unproven bindings and selects the latest definiti
       await realizeTaskPlanFixture(scratch, String(created.packagePath), (planPath) =>
         cell!.run({ kind: "doc-submit", paths: [planPath] }, binding),
       );
-      if (record !== executionMissing) {
+      if (record !== executionMissing && record !== settledWithoutExecution) {
         const started = await cell.run(
           { kind: "task-start", taskId: record.taskId, executionId: record.executionId },
           binding,
@@ -813,7 +816,12 @@ test("dispatch migration skips unproven bindings and selects the latest definiti
     appendDefinitionCandidate(store, ambiguousLeft, "2026-09-02T00:40:00.000Z", "ambiguous-left");
     appendDefinitionCandidate(store, ambiguousRight, "2026-09-02T00:40:00.000Z", "ambiguous-right");
     appendMismatchedRuntimeSession(store, bindingMismatch, bindingDefinition);
+    appendSettledRuntimeSession(store, settledWithoutExecution, common);
     await store.drain();
+    assert.equal(
+      store.readContentBlob(definitionLatest.resultRef.slice("artifact:runtime-result/sha256/".length)),
+      null,
+    );
 
     cell = await openBootstrappedRepoCell({
       repoId: workspaceId(repoId),
@@ -830,17 +838,18 @@ test("dispatch migration skips unproven bindings and selects the latest definiti
     assert.deepEqual(report.categories, {
       "skip:execution-not-found": 1,
       "skip:session-binding-mismatch": 1,
-      "import-full": 2,
+      "import-full": 3,
       "skip:duplicate-session": 1,
       "skip:definition-not-found": 1,
-      "skip:result-content-missing": 1,
       "skip:definition-ambiguous": 1,
+      "skip:already-settled": 1,
     });
     assert.equal(byDispatch.get(executionMissing.dispatchId)?.action, "skip:execution-not-found");
     assert.equal(byDispatch.get(bindingMismatch.dispatchId)?.action, "skip:session-binding-mismatch");
     assert.equal(byDispatch.get(duplicateSecond.dispatchId)?.action, "skip:duplicate-session");
     assert.equal(byDispatch.get(definitionMissing.dispatchId)?.action, "skip:definition-not-found");
     assert.equal(byDispatch.get(definitionAmbiguous.dispatchId)?.action, "skip:definition-ambiguous");
+    assert.equal(byDispatch.get(settledWithoutExecution.dispatchId)?.action, "skip:already-settled");
     assert.deepEqual(
       {
         action: byDispatch.get(resultMissing.dispatchId)?.action,
@@ -849,18 +858,20 @@ test("dispatch migration skips unproven bindings and selects the latest definiti
         resultBlobMissing: byDispatch.get(resultMissing.dispatchId)?.resultBlobMissing,
       },
       {
-        action: "skip:result-content-missing",
+        action: "import-full",
         sourceResultRef: resultMissing.resultRef,
         recoveredResultRef: null,
         resultBlobMissing: true,
       },
     );
     assert.equal(byDispatch.get(definitionLatest.dispatchId)?.resultBlobMissing, false);
+    assert.equal(report.resultBlobMissing, 1);
     context.diagnostic(
       `dispatch-records safe planning ${JSON.stringify({
         categories: report.categories,
         missingResultRef: byDispatch.get(resultMissing.dispatchId)?.sourceResultRef,
         resultBlobMissing: byDispatch.get(resultMissing.dispatchId)?.resultBlobMissing,
+        matchingResultMaterialized: byDispatch.get(definitionLatest.dispatchId)?.resultBlobMissing === false,
       })}`,
     );
 
@@ -893,8 +904,16 @@ test("dispatch migration skips unproven bindings and selects the latest definiti
       historyNew.installationId,
     );
     assert.equal(duplicateStarts.length, 1);
-    assert.equal(missingOutcomes.length, 0);
+    assert.equal(missingOutcomes.length, 1);
+    assert.equal(missingOutcomes[0]?.payload.resultRef, resultMissing.resultRef);
+    assert.equal(missingOutcomes[0]?.payload.result, null);
     assert.equal(reader.readContentBlob("0".repeat(64)), null);
+    assert.equal(
+      Buffer.from(
+        reader.readContentBlob(definitionLatest.resultRef.slice("artifact:runtime-result/sha256/".length)) ?? [],
+      ).toString("utf8"),
+      normalizedReportBody(definitionLatest),
+    );
     const projection = makeTaskProjection({
       rootDir: scratch,
       eventStore: reader,
@@ -964,7 +983,9 @@ async function addDispatchArtifacts(
 }
 
 function rawReportBody(record: DispatchRecordFixture): string {
-  const ending = record.dispatchId === "dispatch_58d3d4f10a20791ac746e2e9" ? "\r\n" : "\n";
+  const windowsArchive =
+      record.dispatchId === "dispatch_58d3d4f10a20791ac746e2e9" || record.dispatchId === `dispatch_${"1".repeat(24)}`,
+    ending = windowsArchive ? "\r\n" : "\n";
   return `Recovered report for ${record.dispatchId}.${ending}`;
 }
 
@@ -1115,6 +1136,88 @@ function appendMismatchedRuntimeSession(
   });
 }
 
+function appendSettledRuntimeSession(
+  store: ReturnType<typeof makeTaskEventStore>,
+  record: DispatchRecordFixture,
+  definition: AgentDefinitionSnapshot,
+): void {
+  const artifact = runtimeDefinitionSnapshotArtifact(definition),
+    base = `fixture-settled-${record.dispatchId}`,
+    resultBody = normalizedReportBody(record),
+    result = {
+      sha256: sha256Text(resultBody),
+      size: Buffer.byteLength(resultBody),
+      mediaType: "text/plain; charset=utf-8" as const,
+    };
+  appendRuntimeFixtureEvent(
+    store,
+    {
+      type: "runtime_dispatch_requested",
+      opId: base,
+      occurredAt: record.startedAt,
+      payload: {
+        dispatchId: record.dispatchId,
+        runtimeSessionId: record.runtimeSessionId,
+        instanceId: definition.instanceId,
+        installationId: definition.installationId,
+        kindId: definition.kindId,
+        idempotencyKey: base,
+        definitionSnapshotRef: artifact.ref,
+        definitionSnapshot: definition,
+      },
+    },
+    artifact.body,
+  );
+  appendRuntimeFixtureEvent(store, {
+    type: "runtime_session_started",
+    opId: `${base}-started`,
+    occurredAt: record.startedAt,
+    payload: {
+      runtimeSessionId: record.runtimeSessionId,
+      instanceId: definition.instanceId,
+      installationId: definition.installationId,
+      kindId: definition.kindId,
+      definitionSnapshotRef: artifact.ref,
+      launchGeneration: 1,
+      attachable: true,
+    },
+  });
+  appendRuntimeFixtureEvent(store, {
+    type: "runtime_session_task_bound",
+    opId: `${base}-task`,
+    occurredAt: record.startedAt,
+    payload: {
+      runtimeSessionId: record.runtimeSessionId,
+      taskId: record.taskId,
+      executionId: record.executionId,
+      providerSessionId: record.providerSessionId,
+      transcriptRef: record.eventStreamRef,
+    },
+  });
+  appendRuntimeFixtureEvent(store, {
+    type: "runtime_session_exited",
+    opId: `${base}-exited`,
+    occurredAt: record.endedAt,
+    payload: { runtimeSessionId: record.runtimeSessionId },
+  });
+  appendRuntimeFixtureEvent(
+    store,
+    {
+      type: "runtime_session_outcome_observed",
+      opId: `${base}-outcome`,
+      occurredAt: record.endedAt,
+      payload: {
+        runtimeSessionId: record.runtimeSessionId,
+        outcome: record.outcome,
+        exitCode: record.exitCode,
+        resultRef: record.resultRef,
+        result,
+      },
+    },
+    resultBody,
+  );
+}
+
 async function appendRuntimeMigrationBaseline(
   rootDir: string,
   repoId: string,
@@ -1253,10 +1356,7 @@ function appendRuntimeFixtureEvent(
       occurredAt: fixture.occurredAt,
       payload: fixture.payload,
     } as AgentRuntimeEventV1,
-    claims =
-      event.type === "runtime_dispatch_requested"
-        ? [runtimeDefinitionSnapshotArtifact(event.payload.definitionSnapshot).claim]
-        : [];
+    claims = runtimeEventContentClaims(event);
   store.append({
     event,
     plan: canonicalEventWritePlan(event, "agent-runtime/v1", event.opId),
@@ -1288,6 +1388,7 @@ function migrationDispatchOpId(record: DispatchRecordFixture): string {
 function dispatchMigrationReport(receipt: Record<string, unknown>): {
   readonly categories: Record<string, number>;
   readonly plannedLeaseReleases: number;
+  readonly resultBlobMissing: number;
   readonly appliedEvents?: number;
   readonly releasedLeases?: number;
   readonly dispatches: readonly {

--- a/packages/daemon/test/runtime-spawn-ingress.integration.test.ts
+++ b/packages/daemon/test/runtime-spawn-ingress.integration.test.ts
@@ -967,7 +967,7 @@ test("daemon ingress persists scrubbed provider JSONL while returning canonical 
           if (outcome?.type === "runtime_session_outcome_observed")
             assert.equal(
               Buffer.from(
-                makeTaskEventReader({ repoId, rootDir: root }).readContentBlob(outcome.payload.result.sha256)!,
+                makeTaskEventReader({ repoId, rootDir: root }).readContentBlob(outcome.payload.result!.sha256)!,
               ).toString("utf8"),
               `${kindId} final result`,
             );

--- a/packages/kernel/src/domain/agent-runtime.ts
+++ b/packages/kernel/src/domain/agent-runtime.ts
@@ -319,7 +319,7 @@ interface RuntimePayloads {
     readonly outcome: "succeeded" | "failed" | "unknown" | "cancelled";
     readonly exitCode: number | null;
     readonly resultRef: string;
-    readonly result: RuntimeResultClaim;
+    readonly result: RuntimeResultClaim | null;
     readonly reasonCode?: string;
   };
   readonly runtime_dispatch_outcome_unknown: { readonly dispatchId: string; readonly runtimeSessionId: string };
@@ -468,7 +468,8 @@ export function isAgentRuntimeEvent(event: { readonly schema: string }): event i
 export function runtimeEventContentClaims(
   event: AgentRuntimeEventV1,
 ): readonly (RuntimeResultClaim | RuntimeDefinitionSnapshotClaim)[] {
-  if (event.type === "runtime_session_outcome_observed") return [event.payload.result];
+  if (event.type === "runtime_session_outcome_observed")
+    return event.payload.result === null ? [] : [event.payload.result];
   if (
     event.type === "runtime_dispatch_requested" &&
     /^artifact:runtime-definition\/sha256\/[0-9a-f]{64}$/u.test(event.payload.definitionSnapshotRef)
@@ -683,7 +684,8 @@ function validDefinitionSnapshot(value: unknown, allowUnknownFields: boolean): v
     ["subscription", "api-key"].includes(String(value.authMode))
   );
 }
-function validResult(ref: unknown, value: unknown, allowUnknownFields: boolean): value is RuntimeResultClaim {
+function validResult(ref: unknown, value: unknown, allowUnknownFields: boolean): value is RuntimeResultClaim | null {
+  if (value === null) return /^artifact:runtime-result\/sha256\/[0-9a-f]{64}$/u.test(String(ref));
   return (
     isRecord(value) &&
     (allowUnknownFields ? hasRequiredFields : hasOnlyFields)(value, ["sha256", "size", "mediaType"]) &&

--- a/packages/kernel/src/domain/runtime-session-action-contract.ts
+++ b/packages/kernel/src/domain/runtime-session-action-contract.ts
@@ -240,7 +240,7 @@ function compileRuntimeSessionAction(
   if (event.type === "runtime_session_outcome_observed" && typeof resultBody === "string") {
     const result = event.payload.result,
       bytes = new TextEncoder().encode(resultBody);
-    if (bytes.byteLength !== result.size || sha256Text(resultBody) !== result.sha256)
+    if (result === null || bytes.byteLength !== result.size || sha256Text(resultBody) !== result.sha256)
       invalidRuntimeSessionAction(
         "content_claim_mismatch",
         "Runtime result bytes do not match the declared result claim.",

--- a/packages/kernel/src/store/dispatch-record-migration.ts
+++ b/packages/kernel/src/store/dispatch-record-migration.ts
@@ -12,6 +12,7 @@ import path from "node:path";
 import {
   runtimeArchiveText,
   runtimeDefinitionSnapshotArtifact,
+  runtimeEventContentClaims,
   validateCurrentAgentRuntimeEvent,
   type AgentDefinitionSnapshot,
   type AgentRuntimeEventV1,
@@ -253,8 +254,6 @@ function planDispatchDocument(
   };
   const task = projection.read(record.taskId).snapshot;
   if (!task.task) return skipped(document, "task-not-found", record);
-  if (!task.executions.some(({ executionId }) => executionId === record.executionId))
-    return skipped(document, "execution-not-found", record);
   const session = projection.readRuntimeSession(record.runtimeSessionId),
     settlement = leaseSettlement(projection, record);
   if (session !== null) {
@@ -272,37 +271,39 @@ function planDispatchDocument(
             recoveredResultRef: null,
             resultBlobMissing: store.readContentBlob(resultHash(record)) === null,
           };
+    if (!task.executions.some(({ executionId }) => executionId === record.executionId))
+      return skipped(document, "execution-not-found", record);
     if (session.liveness !== "unknown" || session.outcome !== null)
       return skipped(document, "session-not-settleable", record);
     const result = recoveredResult(store, projection, document.sourcePath, record);
-    if (result === null) return skipped(document, "result-content-missing", record, true);
     return {
       ...document,
       ...identity,
       action: "settle-tail",
       events: terminalEvents(record, actor, result),
       settlement,
-      sourceResultRef: result.sourceRef,
-      recoveredResultRef: result.sourceRef,
-      resultBlobMissing: false,
+      sourceResultRef: record.resultRef,
+      recoveredResultRef: result?.sourceRef ?? null,
+      resultBlobMissing: result === null,
     };
   }
+  if (!task.executions.some(({ executionId }) => executionId === record.executionId))
+    return skipped(document, "execution-not-found", record);
   const definitionMatch = matchingDefinition(projection, record);
   if (definitionMatch.kind !== "found") return skipped(document, `definition-${definitionMatch.kind}`, record);
   const definition = definitionMatch.definition,
     definitionArtifact = runtimeDefinitionSnapshotArtifact(definition.snapshot);
   if (definitionArtifact.ref !== definition.ref) return skipped(document, "runtime-definition-content-invalid", record);
   const result = recoveredResult(store, projection, document.sourcePath, record);
-  if (result === null) return skipped(document, "result-content-missing", record, true);
   return {
     ...document,
     ...identity,
     action: "import-full",
     events: fullEvents(record, actor, definition, definitionArtifact.body, result),
     settlement,
-    sourceResultRef: result.sourceRef,
-    recoveredResultRef: result.sourceRef,
-    resultBlobMissing: false,
+    sourceResultRef: record.resultRef,
+    recoveredResultRef: result?.sourceRef ?? null,
+    resultBlobMissing: result === null,
   };
 }
 
@@ -494,7 +495,7 @@ function fullEvents(
   actor: ActorIdentity,
   definition: { readonly ref: string; readonly snapshot: AgentDefinitionSnapshot },
   definitionBody: string,
-  recovered: RecoveredResult,
+  recovered: RecoveredResult | null,
 ): readonly PlannedRuntimeEvent[] {
   const base = dispatchOpId(record),
     dispatcher = { principal: actor.principal, executor: null } as const,
@@ -548,7 +549,7 @@ function fullEvents(
 function terminalEvents(
   record: RuntimeDispatchRecordV1,
   actor: ActorIdentity,
-  recovered: RecoveredResult,
+  recovered: RecoveredResult | null,
 ): readonly PlannedRuntimeEvent[] {
   const base = dispatchOpId(record),
     terminalActor = {
@@ -577,10 +578,10 @@ function terminalEvents(
         runtimeSessionId: record.runtimeSessionId,
         outcome: record.outcome,
         exitCode: record.exitCode,
-        resultRef: recovered.sourceRef,
-        result: recovered.claim,
+        resultRef: record.resultRef,
+        result: recovered?.claim ?? null,
       },
-      recovered.body,
+      recovered?.body,
     ),
   ];
 }
@@ -623,12 +624,7 @@ function appendRuntimeEvent(input: DispatchRecordMigrationInput, planned: Planne
     } as AgentRuntimeEventV1,
     errors = validateCurrentAgentRuntimeEvent(event);
   if (errors.length) throw new Error(`Recovered runtime event ${planned.opId} is invalid: ${errors.join("; ")}`);
-  const claims =
-      event.type === "runtime_dispatch_requested"
-        ? [runtimeDefinitionSnapshotArtifact(event.payload.definitionSnapshot).claim]
-        : event.type === "runtime_session_outcome_observed"
-          ? [event.payload.result]
-          : [],
+  const claims = runtimeEventContentClaims(event),
     blobs = claims.map((claim) => ({ ...claim, body: planned.body ?? "" }));
   input.store.append({
     event,
@@ -715,6 +711,7 @@ function dispatchRecordMigrationReport(headRevision: number, gitRevision: number
     dispatchRecords: planned.length,
     plannedEvents: planned.reduce((total, entry) => total + entry.events.length, 0),
     plannedLeaseReleases: planned.filter(({ settlement }) => settlement !== null).length,
+    resultBlobMissing: planned.filter((entry) => entry.resultBlobMissing).length,
     categories: counts,
     dispatches: planned.map((entry) => ({
       sourcePath: entry.sourcePath,


### PR DESCRIPTION
# English

## Summary

Follow-up to #2167 (`ha migrate dispatch-records`). The first canonical dry-run (997 dispatch records) classified all 7 sessions that must be re-imported as `skip:result-content-missing` and 850 records as `skip:execution-not-found`, so the migration planned zero events. Both classifications were wrong for the incident data.

1. A missing result blob is the normal state of a session whose events were destroyed (the blob was lost together with revisions 52140–52224). The planner now imports the session anyway: `runtime_session_outcome_observed` is published with the record's own `resultRef` and `result: null`; the blob is only re-materialized when the archived report body hashes to the recorded sha (no guessing, no replacement of the ref). The plan and report carry `resultBlobMissing` per dispatch and as a count.
2. Records whose runtime session is already exited with an outcome and holds no lease are classified `skip:already-settled` before the execution-existence check, so the report says "nothing to do" instead of "execution not found". Records with no settled session and no execution stay `skip:execution-not-found` (5 on canonical).
3. The one `skip:schema-mismatch` record declares `runtime-dispatch/v1` but has `providerSessionId: null`; the validator is unchanged, it is reported as-is.

`runtime_session_outcome_observed.payload.result` becomes `RuntimeResultClaim | null` in the kernel contract; the action contract still rejects a null claim when a result body is supplied (`content_claim_mismatch`), and `runtimeEventContentClaims` yields no blob claim for a null result. Isolated dry-run on a canonical snapshot with this branch: `already-settled 984, execution-not-found 5, schema-mismatch 1, import-full 7, plannedEvents 49, resultBlobMissing 7`.

## Architectural Justification

Standing policy dec_558977E9272F532D6DCFDB7F90 (historical data is migrated, never shimmed): the event stream records what is known (ref) and what is lost (null claim) instead of skipping the session and leaving the task ledger unable to declare its executor. Multi-node view unchanged: the command still runs once on the center writer and is idempotent per runtime session id.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none

## Machine-Readable Declarations

Production-Delta: +48/-31
Dependency-Change: none

### Optional Evidence Claims

none

## Task And Scope

task_046460a29d5a147d3c9ecf7f92 round 3 (child of incident root task_98a824499e96f27b66797d227d). Scope: kernel dispatch-record planner and runtime event contract, daemon migration oracle/backfill null-result handling, integration fixture.

## Version Impact

None (no published package version changes).

## Governance Declaration

No CI, gate, or branch-protection change. No new durable action (the existing `migrate dispatch-records` policy entry covers this).

## Verification

- Worker stop point (targeted tests + local commit, no `check:local`): `packages/daemon/test/event-shape-migration.integration.test.ts` 5/5 passed; related runtime/contract suites 26/26 passed; tsc, eslint, check-duplicate-definitions, check-import-boundaries, check-implementation-contracts, ontology-daemon-specialization-lines, canonical-event-compat, line-density, file-complexity passed locally.
- Fixture "dispatch migration safely plans missing executions, result blobs, bindings, and definitions": blob missing + report hash mismatch → `import-full` with `resultBlobMissing: true` and a null-result outcome event whose `resultRef` is the record's ref; blob missing + report hash equal → `import-full` with the blob re-materialized; settled session without execution → `skip:already-settled`.
- Canonical run (dry-run → apply → `ha daemon projection rebuild` → declare-executor for the 5 replayed tasks) is performed by the CEO after merge and recorded on the task.

## Review Evidence

Worker report: `harness/tasks/task_046460a29d5a147d3c9ecf7f92-*/artifacts/fix-round3-report.md` (private ledger, fact F-69A3B77E). CEO semantic review of the diff: the null-result branch is the honest representation of lost blobs (one of the 7 archived reports was hashed by hand and does not match the recorded sha, so nothing is re-materialized), the ref is never replaced, and the already-settled ordering only reclassifies records that need no write.

## Residual Risk

Sessions imported with `result: null` cannot serve their result text; readers that dereference the ref see a missing blob rather than fabricated content. The 5 remaining `execution-not-found` records are left untouched by design.

---

# 中文

## 概要

#2167(`ha migrate dispatch-records`)的后续。第一次 canonical dry-run(997 条派工记录)把 7 个必须重新导入的会话全部判成 `skip:result-content-missing`,把 850 条记录判成 `skip:execution-not-found`,于是迁移计划了零个事件。对事故数据来说这两种分类都是错的。

1. 结果 blob 缺失是事件被毁的会话的常态(blob 与 revision 52140–52224 一起丢失)。planner 现在照常导入:`runtime_session_outcome_observed` 用记录自带的 `resultRef` 发布,`result: null`;只有归档 report 正文哈希等于记录 sha 时才重新物化 blob(不猜、不替换 ref)。计划与报告逐条带 `resultBlobMissing`,并单列计数。
2. 运行时会话已 exited、已有 outcome 且不持租约的记录,先于 execution 存在性检查归为 `skip:already-settled`,报告如实反映「无需处理」而不是「找不到」。既无已结算会话又无 execution 的记录仍严格保持 `skip:execution-not-found`(canonical 上剩 5 条)。
3. 唯一的 `skip:schema-mismatch` 记录声明 `runtime-dispatch/v1` 但 `providerSessionId: null`;validator 不改,报告照实列出。

kernel 契约里 `runtime_session_outcome_observed.payload.result` 变为 `RuntimeResultClaim | null`;action contract 在提供了结果正文却声明为 null 时仍拒绝(`content_claim_mismatch`),`runtimeEventContentClaims` 对 null 结果不产生 blob claim。用本分支对 canonical 快照隔离 dry-run:`already-settled 984、execution-not-found 5、schema-mismatch 1、import-full 7、plannedEvents 49、resultBlobMissing 7`。

## 架构辩护

常设政策 dec_558977E9272F532D6DCFDB7F90(历史数据一律迁移、不做兜底):事件流记录已知的(ref)与已丢失的(null claim),而不是跳过会话、让任务台账永远无法声明执行者。多节点视角不变:命令仍只在 center 写入端跑一次,按 runtime session id 幂等。

## 机读声明

见英文块。

## 治理声明

不改 CI、gate 或分支保护;不新增 durable action(沿用 `migrate dispatch-records` 既有政策项)。

## 验证

- worker 停止点(定向测试 + 本地 commit,不跑 `check:local`):`packages/daemon/test/event-shape-migration.integration.test.ts` 5/5 通过;相关 runtime/contract 套件 26/26 通过;tsc、eslint、check-duplicate-definitions、check-import-boundaries、check-implementation-contracts、ontology-daemon-specialization-lines、canonical-event-compat、line-density、file-complexity 本地通过。
- fixture「dispatch migration safely plans missing executions, result blobs, bindings, and definitions」:blob 缺失 + report 哈希不等 → `import-full` 且 `resultBlobMissing: true`,outcome 事件 result 为 null、`resultRef` 为记录的 ref;blob 缺失 + report 哈希相等 → `import-full` 且 blob 被物化;已结算会话无 execution → `skip:already-settled`。
- canonical 实跑(dry-run → apply → `ha daemon projection rebuild` → 五个重放任务 declare-executor)由 CEO 合并后执行并记录在任务上。

## 评审证据

worker 报告见任务包 `artifacts/fix-round3-report.md`(私有台账,fact F-69A3B77E)。CEO 语义验收:null-result 分支是丢失 blob 的诚实表示(手工对 7 份归档 report 之一做哈希,与记录 sha 不等,因此不物化任何东西),ref 永不被替换,already-settled 的排序只重分类不需要写入的记录。

## 残余风险

以 `result: null` 导入的会话无法提供结果文本;解引用该 ref 的读取看到的是 blob 缺失而不是伪造内容。剩余 5 条 `execution-not-found` 记录按设计不动。
