### PR TITLE
fix(daemon): upgrade daemon registry v1 to v2 on read

### DIFF
--- a/packages/cli/src/cli-runtime-wait.ts
+++ b/packages/cli/src/cli-runtime-wait.ts
@@ -282,7 +282,7 @@ function recoverableSubscriptionFailure(error: unknown): boolean {
 }
 
 async function daemonGone(command: ThinCommand): Promise<boolean> {
-  const target = resolveLocalDaemonTarget({ rootDir: command.rootDir, repoIdOverride: command.repoId }),
+  const target = await resolveLocalDaemonTarget({ rootDir: command.rootDir, repoIdOverride: command.repoId }),
     { daemonProcessAlive, daemonSocketProbe, readDaemonPid } = await import("../../daemon/src/daemon-singleton.ts"),
     pid = readDaemonPid(target.userRoot, target.daemonId),
     livePid = pid !== null && daemonProcessAlive(pid),

--- a/packages/cli/src/daemon/client.ts
+++ b/packages/cli/src/daemon/client.ts
@@ -241,7 +241,7 @@ export async function runCommandThroughDaemon(
     );
   }
   const target = {
-    ...resolveLocalDaemonTarget({ rootDir: command.rootDir, repoIdOverride: command.repoId, env }),
+    ...(await resolveLocalDaemonTarget({ rootDir: command.rootDir, repoIdOverride: command.repoId, env })),
     sessionEnvironment: interactiveSessionEnvironment(env),
   };
   const requestPayload = daemonRequestPayload(command, env);
@@ -391,7 +391,7 @@ export async function streamRuntimeThroughDaemon(
   onValue: (value: unknown) => void,
   onClosed?: (failure: import("../../../daemon/src/client/local-json-rpc-stream.ts").DaemonStreamLost) => void,
 ): Promise<() => void> {
-  const target = resolveLocalDaemonTarget({ rootDir: command.rootDir, repoIdOverride: command.repoId }),
+  const target = await resolveLocalDaemonTarget({ rootDir: command.rootDir, repoIdOverride: command.repoId }),
     { streamAgentRuntimeAt } = await import("../../../daemon/src/client/local-json-rpc-stream.ts");
   return streamAgentRuntimeAt({
     socketPath: target.socketPath,
@@ -417,7 +417,7 @@ export async function openRuntimeStatusReader(
       read: () => runCommandThroughDaemon(fleetCommand, () => undefined, { autostart: false }),
       close: () => undefined,
     };
-  const daemonTarget = resolveLocalDaemonTarget({ rootDir: command.rootDir, repoIdOverride: command.repoId }),
+  const daemonTarget = await resolveLocalDaemonTarget({ rootDir: command.rootDir, repoIdOverride: command.repoId }),
     { connectSocket, JsonRpcLineClient } = await import("../../../daemon/src/client/local-json-rpc-client.ts"),
     { currentDaemonProtocolVersion } = await import("../../../daemon/src/protocol/version.ts"),
     socket = await connectSocket(daemonTarget.socketPath, 2_000),
@@ -446,7 +446,7 @@ export async function relayRuntimeAuthTerminal(
   sessionId: string,
   onOutput: (text: string) => void,
 ): Promise<number> {
-  const target = resolveLocalDaemonTarget({ rootDir: command.rootDir, repoIdOverride: command.repoId }),
+  const target = await resolveLocalDaemonTarget({ rootDir: command.rootDir, repoIdOverride: command.repoId }),
     { relayDaemonTerminal } = await import("../../../daemon/src/client/terminal-relay.ts");
   return relayDaemonTerminal({ socketPath: target.socketPath, repoId: target.repoId, sessionId, write: onOutput });
 }

--- a/packages/cli/src/daemon/control.ts
+++ b/packages/cli/src/daemon/control.ts
@@ -49,7 +49,7 @@ export async function runDaemonControl(argv: readonly string[], renderReceipt: R
           daemonFailure("daemon-projection-rebuild", "missing_field", "Add a workspace path after --root."),
           2,
         );
-      const target = resolveLocalDaemonTarget({
+      const target = await resolveLocalDaemonTarget({
         rootDir: path.resolve(suppliedRoot ?? process.cwd()),
         repoIdOverride: daemonOption(argv, "--repo"),
         userRoot,
@@ -182,7 +182,7 @@ async function fleetControl(
       "Use a TCP port from 0 to 65535 and a positive integer byte count for --quota-bytes.",
     );
   const edgeTarget = edge
-    ? resolveLocalDaemonTarget({
+    ? await resolveLocalDaemonTarget({
         rootDir: path.resolve(flag("--root") ?? process.cwd()),
         repoIdOverride: flag("--repo"),
         userRoot,
@@ -295,15 +295,14 @@ async function status(
   const root = path.resolve(daemonOption(argv, "--root") ?? process.cwd()),
     repoIdOverride = daemonOption(argv, "--repo") ?? process.env.HARNESS_DAEMON_REPO_ID;
   // Same resolver as every command: canonicalised registry match, and the injected-endpoint conflict check fails closed here too.
-  const resolved = ((): ReturnType<typeof resolveLocalDaemonTarget> | null => {
-    try {
-      return resolveLocalDaemonTarget({ rootDir: root, repoIdOverride, userRoot, daemonId });
-    } catch (error) {
-      if ((error as { readonly code?: unknown }).code === "daemon_target_conflict") throw error;
-      consumeKnownError(error);
-      return null;
-    }
-  })();
+  let resolved: Awaited<ReturnType<typeof resolveLocalDaemonTarget>> | null;
+  try {
+    resolved = await resolveLocalDaemonTarget({ rootDir: root, repoIdOverride, userRoot, daemonId });
+  } catch (error) {
+    if ((error as { readonly code?: unknown }).code === "daemon_target_conflict") throw error;
+    consumeKnownError(error);
+    resolved = null;
+  }
   const endpoint = resolved?.socketPath ?? localUserDaemonEndpoint(userRoot, daemonId),
     result = await requestDaemonJsonRpcAt(endpoint, "daemon.status", {}, 75);
   const target = {

--- a/packages/cli/src/daemon/fleet-command-route.ts
+++ b/packages/cli/src/daemon/fleet-command-route.ts
@@ -45,7 +45,7 @@ export async function fleetEdgeRegistration(
 ): Promise<(FleetEdgeConfigModule & { readonly workspaceRoot: string }) | null> {
   const { readFleetEdgeConfig } = await import("../../../daemon/src/client/fleet-edge-config.ts");
   const commandRoot = canonicalRoot(command.rootDir),
-    registered = readRegisteredRepos(daemonUserRoot(env))
+    registered = (await readRegisteredRepos(daemonUserRoot(env)))
       // 只解析 enabled 条目,且解析不了根目录的(已删除的 e2e 残留登记)直接丢弃:
       // 它们不可能是本命令的根,不能让一条死登记把所有命令的路由一起炸掉。
       .filter((repo) => repo.state === "enabled")

--- a/packages/cli/test/fleet-command-route-dead-registry.test.ts
+++ b/packages/cli/test/fleet-command-route-dead-registry.test.ts
@@ -17,11 +17,11 @@ test("a registered repo whose root no longer exists does not break routing for o
     path.join(userRoot, "registry.json"),
     JSON.stringify({
       schema: "harness-daemon-registry/v2",
-      connections: [],
+      connections: [{ id: "local", kind: "local", displayName: "This device", state: "enabled" }],
       repos: [
-        { repoId: "dead-disabled", canonicalRoot: "/nonexistent/parent/dead-one", state: "disabled", mode: "local" },
-        { repoId: "dead-enabled", canonicalRoot: "/nonexistent/parent/dead-two", state: "enabled", mode: "local" },
-        { repoId: "live", canonicalRoot: liveRoot, state: "enabled", mode: "local" },
+        repo("dead-disabled", "/nonexistent/parent/dead-one", "disabled"),
+        repo("dead-enabled", "/nonexistent/parent/dead-two", "enabled"),
+        repo("live", liveRoot, "enabled"),
       ],
     }),
   );
@@ -29,3 +29,16 @@ test("a registered repo whose root no longer exists does not break routing for o
   // local mode → no fleet reroute; the point is that it resolves instead of throwing invalid_root.
   assert.equal(await fleetEdgeRegistration(command, { HARNESS_DAEMON_USER_ROOT: userRoot }), null);
 });
+
+function repo(repoId: string, canonicalRoot: string, state: "enabled" | "disabled") {
+  return {
+    repoId,
+    canonicalRoot,
+    displayName: repoId,
+    authoredBranch: "main",
+    mode: "local",
+    connectionId: "local",
+    state,
+    registeredAt: "2026-07-07T00:00:00.000Z",
+  };
+}

--- a/packages/cli/test/fleet-task-route.test.ts
+++ b/packages/cli/test/fleet-task-route.test.ts
@@ -28,7 +28,22 @@ test("fleet task routing requires both edge config and remote-edge registry mode
   const registry = (mode: "local" | "remote-edge", canonicalRoot = root) =>
     writeFileSync(
       path.join(userRoot, "registry.json"),
-      `${JSON.stringify({ schema: "harness-daemon-registry/v2", connections: [], repos: [{ repoId: "route-repo", canonicalRoot, state: "enabled", mode }] })}\n`,
+      `${JSON.stringify({
+        schema: "harness-daemon-registry/v2",
+        connections: [{ id: "local", kind: "local", displayName: "This device", state: "enabled" }],
+        repos: [
+          {
+            repoId: "route-repo",
+            canonicalRoot,
+            displayName: "Route Repo",
+            authoredBranch: "main",
+            mode,
+            connectionId: "local",
+            state: "enabled",
+            registeredAt: "2026-07-07T00:00:00.000Z",
+          },
+        ],
+      })}\n`,
     );
   const command = (method: string, action: Record<string, unknown>, rootDir = root) =>
     ({ rootDir, method, action }) as never;

--- a/packages/cli/test/runtime-wait-reconnect.integration.test.ts
+++ b/packages/cli/test/runtime-wait-reconnect.integration.test.ts
@@ -398,8 +398,19 @@ async function openFixtureDaemon(daemonId: string): Promise<FixtureDaemon> {
     path.join(userRoot, "registry.json"),
     JSON.stringify({
       schema: "harness-daemon-registry/v2",
-      connections: [],
-      repos: [{ repoId: "runtime-wait", canonicalRoot: root, state: "enabled", mode: "local" }],
+      connections: [{ id: "local", kind: "local", displayName: "This device", state: "enabled" }],
+      repos: [
+        {
+          repoId: "runtime-wait",
+          canonicalRoot: root,
+          displayName: "Runtime Wait",
+          authoredBranch: "main",
+          mode: "local",
+          connectionId: "local",
+          state: "enabled",
+          registeredAt: "2026-07-07T00:00:00.000Z",
+        },
+      ],
     }),
   );
   writeFileSync(daemonPidPath(userRoot, daemonId), `${process.pid}\n`);

--- a/packages/daemon/src/client/daemon-autostart.ts
+++ b/packages/daemon/src/client/daemon-autostart.ts
@@ -64,12 +64,12 @@ export function runtimeDaemonStartRefusal(
     ].join(" "),
   };
 }
-export function daemonHostStartRefusal(input: {
+export async function daemonHostStartRefusal(input: {
   readonly invokingRoot: string;
   readonly userRoot: string;
-}): { readonly code: "daemon_start_noncanonical_checkout"; readonly hint: string } | null {
+}): Promise<{ readonly code: "daemon_start_noncanonical_checkout"; readonly hint: string } | null> {
   const invokingCheckout = daemonCheckoutRoot(input.invokingRoot),
-    registered = readRegisteredRepos(input.userRoot)
+    registered = (await readRegisteredRepos(input.userRoot))
       .filter((repo) => repo.state === "enabled")
       .map((repo) => daemonCheckoutRoot(repo.canonicalRoot))
       .find(
@@ -126,7 +126,7 @@ export async function ensureLocalDaemonRunning(input: {
     launched = input.launch();
     const target = daemonLaunchTarget(launched);
     if (!target) throw new Error("daemon launch spec does not declare its --user-root and --daemon-id");
-    const refusal = daemonHostStartRefusal({ invokingRoot: input.invokingRoot, userRoot: target.userRoot });
+    const refusal = await daemonHostStartRefusal({ invokingRoot: input.invokingRoot, userRoot: target.userRoot });
     if (refusal) return { ok: false, ...refusal, attempts: 0 };
     flight = await acquireDaemonAutostartFlight(target);
     // The probe belongs inside the claim: another caller may have bound the

--- a/packages/daemon/src/client/local-daemon-target.ts
+++ b/packages/daemon/src/client/local-daemon-target.ts
@@ -1,7 +1,8 @@
 import { createHash } from "node:crypto";
+import { existsSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { readDaemonRegistry, type DaemonRegistryRepo } from "../../../kernel/src/index.ts";
+import type { DaemonRegistryRepo } from "../../../kernel/src/index.ts";
 import {
   canonicalRoot as bindCanonicalRoot,
   endpointIdentity,
@@ -17,6 +18,13 @@ export interface LocalDaemonTarget {
   readonly userRoot: string;
   readonly daemonId: string;
   readonly socketPath: EndpointIdentity;
+}
+export interface LocalDaemonTargetInput {
+  readonly rootDir: string;
+  readonly repoIdOverride?: string;
+  readonly userRoot?: string;
+  readonly daemonId?: string;
+  readonly env?: NodeJS.ProcessEnv;
 }
 export function localUserDaemonEndpoint(
   userRoot = daemonUserRoot(),
@@ -57,22 +65,25 @@ export function resolveLocalDaemonEndpoint(input: {
   const nextAction = `Daemon target conflict: injected target endpoint=${JSON.stringify(endpoint)} userRoot=${JSON.stringify(userRoot)} daemonId=${JSON.stringify(daemonId)} repoId=${JSON.stringify(repoId)} canonicalRoot=${JSON.stringify(canonicalRoot)}; resolved registry target endpoint=${JSON.stringify(expected)} userRoot=${JSON.stringify(userRoot)} daemonId=${JSON.stringify(daemonId)} repoId=${JSON.stringify(repoId)} canonicalRoot=${JSON.stringify(canonicalRoot)}. Unset HARNESS_DAEMON_ENDPOINT to use the resolved registry target, or restore the original HARNESS_DAEMON_USER_ROOT and HARNESS_DAEMON_ID before retrying.`;
   throw Object.assign(new Error(nextAction), { code: "daemon_target_conflict", nextAction });
 }
-export function resolveLocalDaemonTarget(input: {
-  readonly rootDir: string;
-  readonly repoIdOverride?: string;
-  readonly userRoot?: string;
-  readonly daemonId?: string;
-  readonly env?: NodeJS.ProcessEnv;
-}): LocalDaemonTarget {
+export async function resolveLocalDaemonTarget(input: LocalDaemonTargetInput): Promise<LocalDaemonTarget> {
+  const userRoot = path.resolve(input.userRoot ?? daemonUserRoot(input.env ?? process.env));
+  return resolveLocalDaemonTargetFromRepos(input, await readRegisteredRepos(userRoot));
+}
+export function resolveLocalDaemonTargetFromRepos(
+  input: LocalDaemonTargetInput,
+  repos: ReadonlyArray<DaemonRegistryRepo>,
+): LocalDaemonTarget {
   const env = input.env ?? process.env,
     userRoot = path.resolve(input.userRoot ?? daemonUserRoot(env));
   const daemonId = input.daemonId ?? daemonIdFromEnv(env),
-    repos = readRegisteredRepos(userRoot);
+    registeredRepos = repos.filter(
+      (repo): repo is DaemonRegistryRepo & { readonly canonicalRoot: string } => repo.canonicalRoot !== null,
+    );
   const requested = input.repoIdOverride ?? env.HARNESS_DAEMON_REPO_ID;
   const rootDir = bindCanonicalRoot(input.rootDir);
   const repo = requested
-    ? repos.find((candidate) => candidate.repoId === requested && candidate.state === "enabled")
-    : repos
+    ? registeredRepos.find((candidate) => candidate.repoId === requested && candidate.state === "enabled")
+    : registeredRepos
         .filter(
           (candidate) =>
             candidate.canonicalRoot === rootDir || rootDir.startsWith(`${candidate.canonicalRoot}${path.sep}`),
@@ -100,12 +111,11 @@ export function resolveLocalDaemonTarget(input: {
     socketPath,
   };
 }
-export function readRegisteredRepos(userRoot: string): readonly {
-  readonly repoId: string;
-  readonly canonicalRoot: string;
-  readonly state: string;
-  readonly mode?: string;
-}[] {
+export async function readRegisteredRepos(
+  userRoot: string,
+): Promise<ReadonlyArray<DaemonRegistryRepo & { readonly canonicalRoot: string }>> {
+  if (!existsSync(path.join(userRoot, "registry.json"))) return [];
+  const { readDaemonRegistry } = await import("../../../kernel/src/index.ts");
   return readDaemonRegistry({ userRoot }).repos.filter(
     (repo): repo is DaemonRegistryRepo & { readonly canonicalRoot: string } => repo.canonicalRoot !== null,
   );

--- a/packages/daemon/src/client/local-daemon-target.ts
+++ b/packages/daemon/src/client/local-daemon-target.ts
@@ -1,7 +1,7 @@
 import { createHash } from "node:crypto";
-import { existsSync, readFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { readDaemonRegistry, type DaemonRegistryRepo } from "../../../kernel/src/index.ts";
 import {
   canonicalRoot as bindCanonicalRoot,
   endpointIdentity,
@@ -106,23 +106,9 @@ export function readRegisteredRepos(userRoot: string): readonly {
   readonly state: string;
   readonly mode?: string;
 }[] {
-  const registryPath = path.join(userRoot, "registry.json");
-  if (!existsSync(registryPath)) return [];
-  const value: unknown = JSON.parse(readFileSync(registryPath, "utf8"));
-  if (daemonRegistryRecord(value) && value.schema === "harness-daemon-registry/v1")
-    throw new Error(`unsupported daemon registry v1 at ${registryPath}; remove it and re-register repositories`);
-  if (!daemonRegistryRecord(value) || value.schema !== "harness-daemon-registry/v2" || !Array.isArray(value.repos))
-    throw new Error(`invalid daemon registry at ${registryPath}`);
-  return value.repos.filter(
-    (repo): repo is { repoId: string; canonicalRoot: string; state: string; mode?: string } =>
-      daemonRegistryRecord(repo) &&
-      typeof repo.repoId === "string" &&
-      typeof repo.canonicalRoot === "string" &&
-      typeof repo.state === "string",
+  return readDaemonRegistry({ userRoot }).repos.filter(
+    (repo): repo is DaemonRegistryRepo & { readonly canonicalRoot: string } => repo.canonicalRoot !== null,
   );
-}
-function daemonRegistryRecord(value: unknown): value is Record<string, unknown> {
-  return value !== null && typeof value === "object" && !Array.isArray(value);
 }
 function localDaemonTargetHash(value: string): string {
   return createHash("sha256").update(value).digest("hex").slice(0, 16);

--- a/packages/daemon/src/client/local-json-rpc-client.ts
+++ b/packages/daemon/src/client/local-json-rpc-client.ts
@@ -10,6 +10,7 @@ export {
   daemonUserRoot,
   localUserDaemonEndpoint,
   resolveLocalDaemonTarget,
+  resolveLocalDaemonTargetFromRepos,
   type LocalDaemonTarget,
 } from "./local-daemon-target.ts";
 
@@ -29,7 +30,7 @@ export async function requestLocalDaemonJsonRpc(
   timeoutMs = 75,
   options: LocalDaemonJsonRpcOptions = {},
 ): Promise<JsonObject> {
-  const target = resolveLocalDaemonTarget({
+  const target = await resolveLocalDaemonTarget({
     rootDir,
     repoIdOverride: options.repoIdOverride,
     userRoot: options.userRoot,

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -7,6 +7,7 @@ export {
   requestLocalDaemonJsonRpc,
   requestLocalDaemonJsonRpcForTarget,
   resolveLocalDaemonTarget,
+  resolveLocalDaemonTargetFromRepos,
   type LocalDaemonJsonRpcOptions,
   type LocalDaemonTarget,
 } from "./client/local-json-rpc-client.ts";

--- a/packages/daemon/test/daemon-autostart.test.ts
+++ b/packages/daemon/test/daemon-autostart.test.ts
@@ -71,13 +71,13 @@ test("a worktree is refused before spawn while the registered canonical checkout
       })}\n`,
       "utf8",
     );
-    assert.equal(daemonHostStartRefusal({ invokingRoot: path.join(canonical, "packages"), userRoot }), null);
+    assert.equal(await daemonHostStartRefusal({ invokingRoot: path.join(canonical, "packages"), userRoot }), null);
     assert.equal(
-      daemonHostStartRefusal({ invokingRoot: independent, userRoot }),
+      await daemonHostStartRefusal({ invokingRoot: independent, userRoot }),
       null,
       "a different, not-yet-registered repository owns its own checkout identity",
     );
-    const refusal = daemonHostStartRefusal({ invokingRoot: worktree, userRoot });
+    const refusal = await daemonHostStartRefusal({ invokingRoot: worktree, userRoot });
     assert.equal(refusal?.code, "daemon_start_noncanonical_checkout");
     assert.match(refusal?.hint ?? "", /A worktree may connect to an existing daemon but cannot host it/u);
     assert.match(refusal?.hint ?? "", new RegExp(escapeRegExp(canonical), "u"));

--- a/packages/daemon/test/daemon-autostart.test.ts
+++ b/packages/daemon/test/daemon-autostart.test.ts
@@ -53,7 +53,22 @@ test("a worktree is refused before spawn while the registered canonical checkout
     writeFileSync(path.join(canonical, ".git", "worktrees", "feature", "commondir"), "../..\n", "utf8");
     writeFileSync(
       path.join(userRoot, "registry.json"),
-      `${JSON.stringify({ schema: "harness-daemon-registry/v2", connections: [], repos: [{ repoId: "canonical", canonicalRoot: canonical, state: "enabled" }] })}\n`,
+      `${JSON.stringify({
+        schema: "harness-daemon-registry/v2",
+        connections: [{ id: "local", kind: "local", displayName: "This device", state: "enabled" }],
+        repos: [
+          {
+            repoId: "canonical",
+            canonicalRoot: canonical,
+            displayName: "Canonical",
+            authoredBranch: "main",
+            mode: "local",
+            connectionId: "local",
+            state: "enabled",
+            registeredAt: "2026-07-07T00:00:00.000Z",
+          },
+        ],
+      })}\n`,
       "utf8",
     );
     assert.equal(daemonHostStartRefusal({ invokingRoot: path.join(canonical, "packages"), userRoot }), null);

--- a/packages/daemon/test/local-daemon-target.test.ts
+++ b/packages/daemon/test/local-daemon-target.test.ts
@@ -10,7 +10,7 @@ import { createPresetProcessService } from "../../preset/src/index.ts";
 import { localUserDaemonEndpoint, resolveLocalDaemonTarget } from "../src/client/local-daemon-target.ts";
 import { daemonRequestLogPath } from "../src/request-log.ts";
 
-test("local daemon target resolves a v1 workspace after the shared registry reader upgrades it", () => {
+test("local daemon target resolves a v1 workspace after the shared registry reader upgrades it", async () => {
   const fixtureRoot = mkdtempSync(path.join(tmpdir(), "ha-local-daemon-v1-")),
     workspaceRoot = path.join(fixtureRoot, "workspace"),
     userRoot = path.join(fixtureRoot, "user");
@@ -34,7 +34,7 @@ test("local daemon target resolves a v1 workspace after the shared registry read
       })}\n`,
     );
 
-    const target = resolveLocalDaemonTarget({ rootDir: workspaceRoot, userRoot, env: {} });
+    const target = await resolveLocalDaemonTarget({ rootDir: workspaceRoot, userRoot, env: {} });
     const persisted = JSON.parse(readFileSync(path.join(userRoot, "registry.json"), "utf8")) as {
       schema: string;
       repos: Record<string, unknown>[];
@@ -49,7 +49,7 @@ test("local daemon target resolves a v1 workspace after the shared registry read
   }
 });
 
-test("local daemon target resolves a registered workspace from its subdirectory", () => {
+test("local daemon target resolves a registered workspace from its subdirectory", async () => {
   const fixtureRoot = mkdtempSync(path.join(tmpdir(), "ha-local-daemon-target-"));
   const workspaceRoot = path.join(fixtureRoot, "workspace"),
     nestedRoot = path.join(workspaceRoot, "harness", "tasks"),
@@ -63,7 +63,7 @@ test("local daemon target resolves a registered workspace from its subdirectory"
       `${JSON.stringify(registry([repo("workspace", canonicalWorkspaceRoot)]), null, 2)}\n`,
     );
 
-    const target = resolveLocalDaemonTarget({ rootDir: nestedRoot, userRoot, env: {} });
+    const target = await resolveLocalDaemonTarget({ rootDir: nestedRoot, userRoot, env: {} });
 
     assert.equal(target.repoId, "workspace");
     assert.equal(target.canonicalRoot, canonicalWorkspaceRoot);
@@ -72,7 +72,7 @@ test("local daemon target resolves a registered workspace from its subdirectory"
   }
 });
 
-test("local daemon target chooses the deepest nested registered workspace", () => {
+test("local daemon target chooses the deepest nested registered workspace", async () => {
   const fixtureRoot = mkdtempSync(path.join(tmpdir(), "ha-local-daemon-target-"));
   const outerRoot = path.join(fixtureRoot, "outer"),
     innerRoot = path.join(outerRoot, "packages", "inner"),
@@ -88,7 +88,7 @@ test("local daemon target chooses the deepest nested registered workspace", () =
       `${JSON.stringify(registry([repo("outer", canonicalOuterRoot), repo("inner", canonicalInnerRoot)]), null, 2)}\n`,
     );
 
-    const target = resolveLocalDaemonTarget({ rootDir: nestedRoot, userRoot, env: {} });
+    const target = await resolveLocalDaemonTarget({ rootDir: nestedRoot, userRoot, env: {} });
 
     assert.equal(target.repoId, "inner");
     assert.equal(target.canonicalRoot, canonicalInnerRoot);
@@ -97,7 +97,7 @@ test("local daemon target chooses the deepest nested registered workspace", () =
   }
 });
 
-test("local daemon target rejects a disabled nested workspace instead of falling back to its enabled parent", () => {
+test("local daemon target rejects a disabled nested workspace instead of falling back to its enabled parent", async () => {
   const fixtureRoot = mkdtempSync(path.join(tmpdir(), "ha-local-daemon-target-"));
   const outerRoot = path.join(fixtureRoot, "outer"),
     innerRoot = path.join(outerRoot, "packages", "inner"),
@@ -113,7 +113,7 @@ test("local daemon target rejects a disabled nested workspace instead of falling
       `${JSON.stringify(registry([repo("outer", canonicalOuterRoot), repo("inner", canonicalInnerRoot, "disabled")]), null, 2)}\n`,
     );
 
-    assert.throws(
+    await assert.rejects(
       () => resolveLocalDaemonTarget({ rootDir: nestedRoot, userRoot, env: {} }),
       /workspace is not registered/u,
     );
@@ -122,7 +122,7 @@ test("local daemon target rejects a disabled nested workspace instead of falling
   }
 });
 
-test("local daemon target honors an explicit root instead of the process working directory", () => {
+test("local daemon target honors an explicit root instead of the process working directory", async () => {
   const fixtureRoot = mkdtempSync(path.join(tmpdir(), "ha-local-daemon-target-"));
   const outerRoot = path.join(fixtureRoot, "outer"),
     innerRoot = path.join(outerRoot, "packages", "inner"),
@@ -140,7 +140,7 @@ test("local daemon target honors an explicit root instead of the process working
     assert.equal(parsed.ok, true, JSON.stringify(parsed));
     if (!parsed.ok) return;
 
-    const target = resolveLocalDaemonTarget({ rootDir: parsed.command.rootDir, userRoot, env: {} });
+    const target = await resolveLocalDaemonTarget({ rootDir: parsed.command.rootDir, userRoot, env: {} });
 
     assert.equal(target.repoId, "outer");
     assert.equal(target.canonicalRoot, canonicalOuterRoot);
@@ -149,7 +149,7 @@ test("local daemon target honors an explicit root instead of the process working
   }
 });
 
-test("local daemon target keeps the environment repo id override authoritative", () => {
+test("local daemon target keeps the environment repo id override authoritative", async () => {
   const fixtureRoot = mkdtempSync(path.join(tmpdir(), "ha-local-daemon-target-"));
   const firstRoot = path.join(fixtureRoot, "first"),
     secondRoot = path.join(fixtureRoot, "second"),
@@ -165,7 +165,7 @@ test("local daemon target keeps the environment repo id override authoritative",
       `${JSON.stringify(registry([repo("first", canonicalFirstRoot), repo("second", canonicalSecondRoot)]), null, 2)}\n`,
     );
 
-    const target = resolveLocalDaemonTarget({
+    const target = await resolveLocalDaemonTarget({
       rootDir: firstRoot,
       userRoot,
       env: { HARNESS_DAEMON_REPO_ID: "second" },
@@ -178,7 +178,7 @@ test("local daemon target keeps the environment repo id override authoritative",
   }
 });
 
-test("local daemon target rejects a path outside every registered workspace", () => {
+test("local daemon target rejects a path outside every registered workspace", async () => {
   const fixtureRoot = mkdtempSync(path.join(tmpdir(), "ha-local-daemon-target-"));
   const workspaceRoot = path.join(fixtureRoot, "workspace"),
     unrelatedRoot = path.join(fixtureRoot, "unrelated"),
@@ -192,7 +192,7 @@ test("local daemon target rejects a path outside every registered workspace", ()
       `${JSON.stringify(registry([repo("workspace", realpathSync.native(workspaceRoot))]), null, 2)}\n`,
     );
 
-    assert.throws(
+    await assert.rejects(
       () => resolveLocalDaemonTarget({ rootDir: unrelatedRoot, userRoot, env: {} }),
       /workspace is not registered/u,
     );
@@ -218,7 +218,7 @@ test("local daemon target routes a repository worktree to the canonical workspac
       `${JSON.stringify(registry([repo("workspace", canonicalWorkspaceRoot)]), null, 2)}\n`,
     );
 
-    const target = resolveLocalDaemonTarget({ rootDir: worktreeRoot, userRoot, env: {} });
+    const target = await resolveLocalDaemonTarget({ rootDir: worktreeRoot, userRoot, env: {} });
     const layout = resolveHarnessLayout(target.canonicalRoot);
     const presetProcess = createPresetProcessService({
       rootDir: target.canonicalRoot,
@@ -246,7 +246,7 @@ test("local daemon target routes a repository worktree to the canonical workspac
   }
 });
 
-test("local daemon target keeps a matching injected endpoint across an isolated runtime temp directory", () => {
+test("local daemon target keeps a matching injected endpoint across an isolated runtime temp directory", async () => {
   const fixtureRoot = mkdtempSync(path.join(tmpdir(), "ha-local-daemon-endpoint-")),
     workspaceRoot = path.join(fixtureRoot, "workspace"),
     userRoot = path.join(fixtureRoot, "user"),
@@ -261,7 +261,7 @@ test("local daemon target keeps a matching injected endpoint across an isolated 
       path.join(userRoot, "registry.json"),
       `${JSON.stringify(registry([repo("runtime-worker", canonicalWorkspaceRoot)]), null, 2)}\n`,
     );
-    const target = resolveLocalDaemonTarget({
+    const target = await resolveLocalDaemonTarget({
       rootDir: workspaceRoot,
       userRoot,
       daemonId,
@@ -273,7 +273,7 @@ test("local daemon target keeps a matching injected endpoint across an isolated 
   }
 });
 
-test("local daemon target rejects an injected endpoint owned by another user root", () => {
+test("local daemon target rejects an injected endpoint owned by another user root", async () => {
   const fixtureRoot = mkdtempSync(path.join(tmpdir(), "ha-local-daemon-conflict-")),
     workspaceRoot = path.join(fixtureRoot, "workspace"),
     userRoot = path.join(fixtureRoot, "isolated-user"),
@@ -289,7 +289,7 @@ test("local daemon target rejects an injected endpoint owned by another user roo
       `${JSON.stringify(registry([repo("runtime-worker", canonicalWorkspaceRoot)]), null, 2)}\n`,
     );
 
-    assert.throws(
+    await assert.rejects(
       () =>
         resolveLocalDaemonTarget({
           rootDir: workspaceRoot,

--- a/packages/daemon/test/local-daemon-target.test.ts
+++ b/packages/daemon/test/local-daemon-target.test.ts
@@ -1,6 +1,6 @@
 // harness-test-tier: integration
 import assert from "node:assert/strict";
-import { existsSync, mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -10,19 +10,40 @@ import { createPresetProcessService } from "../../preset/src/index.ts";
 import { localUserDaemonEndpoint, resolveLocalDaemonTarget } from "../src/client/local-daemon-target.ts";
 import { daemonRequestLogPath } from "../src/request-log.ts";
 
-test("local daemon target rejects v1 registries with re-registration guidance", () => {
+test("local daemon target resolves a v1 workspace after the shared registry reader upgrades it", () => {
   const fixtureRoot = mkdtempSync(path.join(tmpdir(), "ha-local-daemon-v1-")),
+    workspaceRoot = path.join(fixtureRoot, "workspace"),
     userRoot = path.join(fixtureRoot, "user");
   try {
+    mkdirSync(workspaceRoot);
     mkdirSync(userRoot);
     writeFileSync(
       path.join(userRoot, "registry.json"),
-      `${JSON.stringify({ schema: "harness-daemon-registry/v1", repos: [] })}\n`,
+      `${JSON.stringify({
+        schema: "harness-daemon-registry/v1",
+        repos: [
+          {
+            repoId: "legacy",
+            canonicalRoot: workspaceRoot,
+            displayName: "Legacy",
+            authoredBranch: "main",
+            state: "enabled",
+            registeredAt: "2026-07-07T00:00:00.000Z",
+          },
+        ],
+      })}\n`,
     );
-    assert.throws(
-      () => resolveLocalDaemonTarget({ rootDir: fixtureRoot, userRoot, env: {} }),
-      /unsupported daemon registry v1.*re-register/u,
-    );
+
+    const target = resolveLocalDaemonTarget({ rootDir: workspaceRoot, userRoot, env: {} });
+    const persisted = JSON.parse(readFileSync(path.join(userRoot, "registry.json"), "utf8")) as {
+      schema: string;
+      repos: Record<string, unknown>[];
+    };
+
+    assert.equal(target.repoId, "legacy");
+    assert.equal(target.canonicalRoot, realpathSync.native(workspaceRoot));
+    assert.equal(persisted.schema, "harness-daemon-registry/v2");
+    assert.equal(persisted.repos[0]?.connectionId, "local");
   } finally {
     rmSync(fixtureRoot, { recursive: true, force: true });
   }

--- a/packages/gui/src/main/electron-main.ts
+++ b/packages/gui/src/main/electron-main.ts
@@ -14,7 +14,11 @@ import {
 } from "./local-composition-root.ts";
 import { registerConnectionAdminIpc } from "./connection-admin-ipc.ts";
 import { addLocalMainControls } from "./local-main-controls.ts";
-import { daemonUserRoot, resolveLocalDaemonTarget } from "../../../daemon/src/client/local-daemon-target.ts";
+import {
+  daemonUserRoot,
+  resolveLocalDaemonTarget,
+  resolveLocalDaemonTargetFromRepos,
+} from "../../../daemon/src/client/local-daemon-target.ts";
 import { daemonBuildStamp } from "../../../daemon/src/build-identity.ts";
 import {
   evaluateHtmlArtifactAttachment,
@@ -183,7 +187,10 @@ export async function startGuiApp(): Promise<void> {
     ipcMain,
     {
       canonicalRootOf: (repoId) => {
-        const target = resolveLocalDaemonTarget({ rootDir, repoIdOverride: repoId });
+        const target = resolveLocalDaemonTargetFromRepos(
+          { rootDir, repoIdOverride: repoId },
+          readDaemonRegistry({ userRoot: daemonUserRoot() }).repos,
+        );
         if (target.repoId !== repoId) throw new Error(`Repository ${repoId} is not registered and enabled.`);
         return target.canonicalRoot;
       },

--- a/packages/gui/src/main/local-composition-root.ts
+++ b/packages/gui/src/main/local-composition-root.ts
@@ -25,7 +25,10 @@ import { defaultRegistryReader, resolveRepoScopedTarget } from "./repo-scoped-ta
 type JsonObject = { readonly [key: string]: JsonValue };
 type JsonValue = string | number | boolean | null | JsonObject | ReadonlyArray<JsonValue>;
 interface DaemonClient {
-  readonly resolveLocalDaemonTarget: (input: { readonly rootDir: string; readonly repoIdOverride?: string }) => {
+  readonly resolveLocalDaemonTargetFromRepos: (
+    input: { readonly rootDir: string; readonly repoIdOverride?: string },
+    repos: ReturnType<typeof defaultRegistryReader>["repos"],
+  ) => {
     readonly repoId: string;
     readonly socketPath: string;
     readonly canonicalRoot: string;
@@ -205,13 +208,13 @@ function repoTarget(
   daemon: DaemonClient,
   rootDir: string,
   repoId: string,
-): ReturnType<DaemonClient["resolveLocalDaemonTarget"]> {
+): ReturnType<DaemonClient["resolveLocalDaemonTargetFromRepos"]> {
   return resolveRepoScopedTarget(
-    () => daemon.resolveLocalDaemonTarget({ rootDir, repoIdOverride: repoId }),
+    () => daemon.resolveLocalDaemonTargetFromRepos({ rootDir, repoIdOverride: repoId }, defaultRegistryReader().repos),
     defaultRegistryReader,
     globalTarget,
     repoId,
-  ) as ReturnType<DaemonClient["resolveLocalDaemonTarget"]>;
+  ) as ReturnType<DaemonClient["resolveLocalDaemonTargetFromRepos"]>;
 }
 
 /** Settings → 仓库与连接 的 admin 通道:同一 one-shot 客户端直达本机 daemon 的 admin RPC。 */

--- a/packages/kernel/src/daemon/registry.ts
+++ b/packages/kernel/src/daemon/registry.ts
@@ -140,6 +140,11 @@ export function readDaemonRegistry(options: DaemonRegistryOptions = {}): DaemonR
   const { registryPath } = daemonRegistryPaths(options);
   if (!existsSync(registryPath)) return emptyDaemonRegistry();
   const decoded = JSON.parse(readFileSync(registryPath, "utf8")) as unknown;
+  if (isDaemonRegistryRecord(decoded) && decoded.schema === "harness-daemon-registry/v1") {
+    const upgraded = decodeDaemonRegistry(upgradeDaemonRegistryV1(decoded, registryPath), registryPath);
+    writeDaemonRegistry(upgraded, options);
+    return upgraded;
+  }
   return decodeDaemonRegistry(decoded, registryPath);
 }
 
@@ -394,8 +399,6 @@ function emptyDaemonRegistry(): DaemonRegistry {
 }
 
 function decodeDaemonRegistry(value: unknown, source: string): DaemonRegistry {
-  if (isDaemonRegistryRecord(value) && value.schema === "harness-daemon-registry/v1")
-    throw new Error(`unsupported daemon registry v1 at ${source}; remove it and re-register repositories`);
   if (
     !isDaemonRegistryRecord(value) ||
     value.schema !== daemonRegistrySchema ||
@@ -422,6 +425,25 @@ function decodeDaemonRegistry(value: unknown, source: string): DaemonRegistry {
     }
   });
   return sortDaemonRegistry({ schema: daemonRegistrySchema, connections, repos, invalidRepos });
+}
+
+function upgradeDaemonRegistryV1(value: Record<string, unknown>, source: string): Record<string, unknown> {
+  if (!Array.isArray(value.repos)) throw new Error(`invalid daemon registry at ${source}`);
+  return {
+    schema: daemonRegistrySchema,
+    connections: [localConnection()],
+    repos: value.repos
+      .map((repo) =>
+        isDaemonRegistryRecord(repo)
+          ? {
+              ...repo,
+              mode: repo.mode ?? "local",
+              connectionId: "local",
+            }
+          : repo,
+      )
+      .sort(compareRegistryEntries),
+  };
 }
 
 function decodeDaemonRegistryConnection(value: unknown, source: string): DaemonRegistryConnection {

--- a/packages/kernel/test/store/daemon-registry.test.ts
+++ b/packages/kernel/test/store/daemon-registry.test.ts
@@ -9,7 +9,9 @@ import {
   readFileSync,
   realpathSync,
   rmSync,
+  statSync,
   symlinkSync,
+  utimesSync,
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
@@ -106,16 +108,102 @@ test("daemon registry persists explicit workspace modes and rejects rows that om
   });
 });
 
-test("daemon registry rejects v1 without compatibility or migration", () => {
+test("daemon registry upgrades v1 repos and invalid rows to v2 exactly once", () => {
   withTempDir((root) => {
-    const userRoot = path.join(root, "user-harness");
+    const userRoot = path.join(root, "user-harness"),
+      registryPath = path.join(userRoot, "registry.json"),
+      registeredAt = "2026-07-07T00:00:00.000Z",
+      legacyRoot = path.join(root, "legacy"),
+      brokenRoot = path.join(root, "broken");
     mkdirSync(userRoot, { recursive: true });
     writeFileSync(
-      path.join(userRoot, "registry.json"),
-      `${JSON.stringify({ schema: "harness-daemon-registry/v1", repos: [] })}\n`,
+      registryPath,
+      `${JSON.stringify({
+        schema: "harness-daemon-registry/v1",
+        repos: [
+          {
+            repoId: "legacy",
+            canonicalRoot: legacyRoot,
+            displayName: "Legacy",
+            authoredBranch: "main",
+            state: "enabled",
+            registeredAt,
+          },
+          {
+            repoId: "broken",
+            canonicalRoot: brokenRoot,
+            authoredBranch: "main",
+            state: "disabled",
+            registeredAt,
+          },
+        ],
+      })}\n`,
       "utf8",
     );
-    assert.throws(() => readDaemonRegistry({ userRoot }), /unsupported daemon registry v1.*re-register/u);
+
+    const upgraded = readDaemonRegistry({ userRoot });
+
+    assert.deepEqual(upgraded.connections, [localConnection]);
+    assert.deepEqual(upgraded.repos, [
+      {
+        repoId: "legacy",
+        canonicalRoot: legacyRoot,
+        displayName: "Legacy",
+        authoredBranch: "main",
+        mode: "local",
+        connectionId: "local",
+        state: "enabled",
+        registeredAt,
+      },
+    ]);
+    assert.equal(upgraded.invalidRepos.length, 1);
+    assert.deepEqual(upgraded.invalidRepos[0]?.raw, {
+      repoId: "broken",
+      canonicalRoot: brokenRoot,
+      authoredBranch: "main",
+      mode: "local",
+      connectionId: "local",
+      state: "disabled",
+      registeredAt,
+    });
+    const persisted = JSON.parse(readFileSync(registryPath, "utf8")) as {
+      schema: string;
+      connections: unknown[];
+      repos: Record<string, unknown>[];
+    };
+    assert.equal(persisted.schema, daemonRegistrySchema);
+    assert.deepEqual(persisted.connections, [localConnection]);
+    assert.equal(
+      persisted.repos.every((repo) => repo.mode === "local" && repo.connectionId === "local"),
+      true,
+    );
+
+    const oldTime = new Date("2000-01-01T00:00:00.000Z");
+    utimesSync(registryPath, oldTime, oldTime);
+    const beforeSecondRead = statSync(registryPath).mtimeMs;
+    assert.deepEqual(readDaemonRegistry({ userRoot }), upgraded);
+    assert.equal(statSync(registryPath).mtimeMs, beforeSecondRead);
+  });
+});
+
+test("daemon registry leaves the v1 file intact when its atomic upgrade cannot write the temp file", () => {
+  withTempDir((root) => {
+    const userRoot = path.join(root, "user-harness"),
+      registryPath = path.join(userRoot, "registry.json"),
+      timestamp = 1_788_000_000_000,
+      tempPath = `${registryPath}.${process.pid}.${timestamp}.tmp`,
+      originalNow = Date.now,
+      original = `${JSON.stringify({ schema: "harness-daemon-registry/v1", repos: [] })}\n`;
+    mkdirSync(userRoot, { recursive: true });
+    writeFileSync(registryPath, original, "utf8");
+    mkdirSync(tempPath);
+    Date.now = () => timestamp;
+    try {
+      assert.throws(() => readDaemonRegistry({ userRoot }));
+      assert.equal(readFileSync(registryPath, "utf8"), original);
+    } finally {
+      Date.now = originalNow;
+    }
   });
 });
 

--- a/tools/gate-allowlists/check-kernel-dead-exports.json
+++ b/tools/gate-allowlists/check-kernel-dead-exports.json
@@ -148,12 +148,6 @@
         "until": "2026-09-30"
       },
       {
-        "value": "DaemonRegistryRepo",
-        "ref": "task_01KZRMKJT7YKQ2TNXA8WR1W5DN",
-        "reason": "W3 production flip removed the former CLI barrel consumer; the private kernel export remains contract/test surface while thin CLI is forbidden from importing the kernel barrel.",
-        "until": "2026-09-30"
-      },
-      {
         "value": "decisionEntityId",
         "ref": "task_01KZRMKJT7YKQ2TNXA8WR1W5DN",
         "reason": "W3 production flip removed the former CLI barrel consumer; the private kernel export remains contract/test surface while thin CLI is forbidden from importing the kernel barrel.",


### PR DESCRIPTION
# English

## Summary

Incident 2026-09-02 defect #7: a freshly built dist refused to start against a `harness-daemon-registry/v1` file (`unsupported daemon registry v1 … remove it and re-register repositories`), and the daemon client carried its own copy of the same parser and refusal. This PR makes `readDaemonRegistry` the only production parser of `<userRoot>/registry.json`: a v1 file is mapped to the v2 shape in memory (one local connection, `connectionId: local`, `mode` defaulting to `local`, all workspace fields preserved, invalid rows retained as v2 `invalidRepos`), persisted atomically through the existing temp-file + rename writer, and returned; a later read takes the v2 fast path and does not write (asserted by unchanged mtime). The mapping was derived from the commit that introduced v2 (`4e2631095`), not guessed. The daemon client's `readFileSync` + `JSON.parse` + version checks + structural filter are deleted in favour of the kernel reader. Malformed registries still fail closed with `invalid daemon registry`.

Round 2 (a1447edd8) answered the first CI run: the daemon client had imported the kernel public barrel statically, which the `check-cli-structure` gate refuses (the thin transport's static import graph must not reach the kernel barrel) and which made the source-mode daemon-missing diagnostic take 1.5 s instead of milliseconds. `readRegisteredRepos` now loads the kernel reader through a dynamic `import()` and is therefore async (`daemonHostStartRefusal` and `resolveLocalDaemonTarget` follow); callers that already hold registry rows (the GUI composition root, which reads the registry through the kernel directly) use the synchronous `resolveLocalDaemonTargetFromRepos`. The stale `DaemonRegistryRepo` entry was removed from the kernel dead-export allowlist. Both gates pass locally.

## Architectural Justification

Standing policy dec_558977E9272F532D6DCFDB7F90 (historical data is migrated, never shimmed): the v1 shape exists only for the instant of the read and is rewritten to v2; the in-memory model is v2 only. One parser instead of two removes a duplicated invariant. Multi-node view: the registry is a per-machine file under `userRoot`, so there is no cross-node concurrency subject; on one machine a CLI and a daemon may both read v1 and each rename its own temp file, and both renames produce identical bytes.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none

## Machine-Readable Declarations

Production-Delta: +92/-63
Dependency-Change: none

### Optional Evidence Claims

none

## Task And Scope

task_f8272716fac647ea9882b2f242 (child of incident root task_98a824499e96f27b66797d227d). Scope: `packages/kernel/src/daemon/registry.ts` (v1 detect → upgrade → atomic persist), `packages/daemon/src/client/local-daemon-target.ts` (delegate to kernel reader), tests and fixtures that previously wrote v1 files.

## Version Impact

None (no published package version changes).

## Governance Declaration

Protected path touched: `tools/gate-allowlists/check-kernel-dead-exports.json` (one stale entry removed because the kernel dead-export gate itself reported `DaemonRegistryRepo` now has a consumer). Authorized under task_f8272716fac647ea9882b2f242 (incident root task_98a824499e96f27b66797d227d, defect #7) and standing policy dec_558977E9272F532D6DCFDB7F90. No CI workflow, required check, or branch-protection change; no new durable action; no break-glass.

## Verification

- Worker stop point (targeted tests + local commit, no `check:local`): `packages/kernel/test/store/daemon-registry.test.ts` + `packages/daemon/test/local-daemon-target.test.ts` 23 passed / 0 failed (positive control: v1 upgraded exactly once, v2 bytes on disk, unchanged mtime on second read; negative controls: blocked temp path leaves v1 bytes intact; malformed registry still `invalid daemon registry`); affected fast fixtures 17/17; `runtime-wait-reconnect` 10/10; typecheck, lint, duplicate-definitions, import-boundaries (3→3), implementation-contracts (129→129), line-density, file-complexity, canonical-event-compat, gate self-tests 179/179 passed locally.
- Fact F-9DDA1483 on the task records the mapping table and the runner output.

## Review Evidence

Worker report: `harness/tasks/task_f8272716fac647ea9882b2f242-*/artifacts/registry-upgrade-report.md` (private ledger). CEO semantic review of the diff: the mapping table cites the introducing commit, the writer is the pre-existing atomic one, the v1 refusal and the duplicate client parser are gone, and no read path keeps a v1 model.

## Residual Risk

The upgrade writes the registry during a read; if `userRoot` is read-only the read fails instead of silently continuing with an in-memory v2 (fail-closed by design). This machine's registry is already v2, so the canonical daemon is unaffected; edge machines still on v1 gain the fix on their next dist upgrade.

---

# 中文

## 概要

2026-09-02 事故缺陷#7:新构建的 dist 遇到 `harness-daemon-registry/v1` 文件直接拒绝启动(`unsupported daemon registry v1 … remove it and re-register repositories`),而 daemon client 还抄了一份同样的解析与拒绝。本 PR 让 `readDaemonRegistry` 成为 `<userRoot>/registry.json` 唯一的生产解析器:读到 v1 时在内存里映射成 v2 形状(一条 local connection、`connectionId: local`、`mode` 缺省 `local`、workspace 字段全部保留、无效行保留为 v2 `invalidRepos`),用既有的 temp-file + rename 写回,再返回;之后的读走 v2 快路径、不写盘(用 mtime 不变断言)。映射从引入 v2 的提交(`4e2631095`)推导,不是猜的。daemon client 自己的 `readFileSync` + `JSON.parse` + 版本判定 + 结构过滤全部删除,改调 kernel 读取函数。损坏的 registry 仍以 `invalid daemon registry` fail-closed。

第二轮(a1447edd8)回应第一次 CI:daemon client 静态导入了 kernel 公共 barrel,`check-cli-structure` 门拒绝(thin transport 的静态导入图不得到达 kernel barrel),而且让源码模式下 daemon-missing 诊断从毫秒级变成 1.5 秒。`readRegisteredRepos` 改为动态 `import()` 加载 kernel 读取函数,因此变成 async(`daemonHostStartRefusal` 与 `resolveLocalDaemonTarget` 随之);已经持有 registry 行的调用方(GUI composition root,它本来就直接经 kernel 读 registry)改用同步的 `resolveLocalDaemonTargetFromRepos`。kernel dead-export allowlist 里过期的 `DaemonRegistryRepo` 条目删除。两个门本地通过。

## 架构辩护

常设政策 dec_558977E9272F532D6DCFDB7F90(历史数据一律迁移、不做兜底):v1 形状只在读入的一瞬间存在并被写回成 v2,内存模型只有 v2;两个解析器合成一个,消掉一份重复不变量。多节点视角:registry 是每台机器 `userRoot` 下的本地文件,没有跨节点并发主体;同一台机器上 CLI 与 daemon 可能同时读到 v1,各自 rename 自己的临时文件,两次 rename 产出相同字节。

## 机读声明

见英文块。

## 治理声明

触碰 protected 路径:`tools/gate-allowlists/check-kernel-dead-exports.json`(删除一条过期条目,kernel dead-export 门自己报告 `DaemonRegistryRepo` 已有消费者)。授权来源:task_f8272716fac647ea9882b2f242(事故根任务 task_98a824499e96f27b66797d227d 缺陷#7)与常设政策 dec_558977E9272F532D6DCFDB7F90。不改 CI workflow、必需 check 或分支保护;不新增 durable action;无 break-glass。

## 验证

- worker 停止点(定向测试 + 本地 commit,不跑 `check:local`):`packages/kernel/test/store/daemon-registry.test.ts` + `packages/daemon/test/local-daemon-target.test.ts` 23 通过 / 0 失败(阳性对照:v1 恰好升级一次、磁盘为 v2 字节、二次读 mtime 不变;阴性对照:临时文件路径被占时 v1 字节原样保留;损坏文件仍 `invalid daemon registry`);受影响 fast fixture 17/17;`runtime-wait-reconnect` 10/10;typecheck、lint、duplicate-definitions、import-boundaries(3→3)、implementation-contracts(129→129)、line-density、file-complexity、canonical-event-compat、门自测 179/179 本地通过。
- 任务上的 fact F-9DDA1483 记录映射表与 runner 输出。

## 评审证据

worker 报告见任务包 `artifacts/registry-upgrade-report.md`(私有台账)。CEO 语义验收:映射表引用引入提交、写回复用既有原子写、v1 拒绝与 client 重复解析已删、没有读路径保留 v1 模型。

## 残余风险

升级在读取时写盘;`userRoot` 只读时读取会失败而不是静默用内存 v2 继续(按设计 fail-closed)。本机 registry 已是 v2,canonical daemon 不受影响;仍停在 v1 的边缘机器在下次升级 dist 时受益。
