### PR TITLE
test(squad): recognize the leader retry prompt header in the fake provider

### DIFF
--- a/packages/cli/test/squad-resident-leader.integration.test.ts
+++ b/packages/cli/test/squad-resident-leader.integration.test.ts
@@ -382,7 +382,7 @@ if (args[0] === "login" && args[1] === "status") {
 const prompt = fs.readFileSync(0, "utf8");
 const frame = (value) => process.stdout.write(JSON.stringify(value) + "\\n");
 const initialLeader = prompt.includes("# Squad dispatch protocol");
-const callbackLeader = prompt.includes("# Squad worker callback");
+const callbackLeader = prompt.includes("# Squad worker callback") || prompt.includes("# Squad leader retry");
 const terra = prompt.includes("# Agent Identity: Terra (terra)");
 const luna = prompt.includes("# Agent Identity: Luna (luna)");
 const retry = terra && prompt.includes("Terra retry mission");
@@ -514,7 +514,8 @@ if (!config.includes("experimental_bearer_token = \\"squad-secret\\"")) {
   process.exit(1);
 }
 const frame = (value) => process.stdout.write(JSON.stringify(value) + "\\n");
-const leader = prompt.includes("# Squad dispatch protocol") || prompt.includes("# Squad worker callback");
+const callback = prompt.includes("# Squad worker callback") || prompt.includes("# Squad leader retry");
+const leader = prompt.includes("# Squad dispatch protocol") || callback;
 const terra = prompt.includes("# Agent Identity: Terra (terra)");
 const luna = prompt.includes("# Agent Identity: Luna (luna)");
 const writeSynthesisReport = () => {
@@ -533,7 +534,7 @@ const writeSynthesisReport = () => {
 frame({ type: "thread.started", thread_id: leader ? "leader-api-session" : terra ? "terra-api-session" : "luna-api-session" });
 if (prompt.includes("# Squad dispatch protocol")) {
   frame({ type: "item.completed", item: { type: "agent_message", text: JSON.stringify({ schema: "runtime-batch/v1", dispatches: [{ instance: "squad-api", to: "terra", prompt: "terra API mission" }, { instance: "squad-api", to: "luna", prompt: "luna API mission" }] }) } });
-} else if (prompt.includes("# Squad worker callback")) {
+} else if (callback) {
   const running = /^worker .*status=running/mu.test(prompt);
   if (running) {
     frame({ type: "item.completed", item: { type: "agent_message", text: JSON.stringify({ schema: "squad-decision/v1", action: "waiting" }) } });


### PR DESCRIPTION
# English

## Summary

`integration-shard (5)` has been flaking on `packages/cli/test/squad-resident-leader.integration.test.ts` ("same-instance API-key squad workers reuse the materialized bearer": squad run `failed` instead of `converged`). The same commit passed and failed the shard in consecutive runs, and the failure receipt shows the mechanism: a transient leader-turn failure made the coordinator retry the leader, the product then prompts with the `# Squad leader retry` header (`packages/daemon/src/squad-leader-decision.ts:119`), and the test's fake codex provider only recognised `# Squad dispatch protocol` and `# Squad worker callback`. The retry prompt fell through to the worker branch, the provider bound `luna-api-session`, and the daemon killed the resume with "provider bound unexpected session". Any leader retry was therefore an unconditional hard failure of the test, even though the product's retry path is exactly what should absorb it.

This PR teaches both fake providers in that file to treat the retry header as a leader callback (three lines, test-only). No waits, no timeouts, no product change.

## Architectural Justification

Test-only. The product's three leader prompt headers are unchanged; the stub now mirrors them.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none

## Machine-Readable Declarations

Production-Delta: +0/-0
Dependency-Change: none

### Optional Evidence Claims

none

## Task And Scope

CI hygiene follow-up from the #2169 shard-5 diagnosis (task_c09369abd2d6d1e0c41c07f7b5 review). Scope: one integration test file.

## Version Impact

None.

## Governance Declaration

No CI, gate, or branch-protection change.

## Verification

- The test is Linux-only (needs `secret-tool`); on this macOS host it is skipped. The diagnosis ran the single file on the branch and on main in a 4-CPU Linux container (pass, 3.7 s each), the full shard 5 (250/250, 101 s), and 12 runs each under CPU pressure (24/24 pass), without reproducing the retry path locally; the fix is derived from the CI failure receipt and the product header at `squad-leader-decision.ts:119`.
- CI on this PR is the verification of record.

## Review Evidence

CEO read the failing receipt timeline (terra callback → leader turn 2 → `executor_binding_invalid` on the synthesis `ha task artifact add` → leader retry → resume killed) and the stub classification code; the change is the minimal mirror of the product's header set.

## Residual Risk

The underlying transient (`executor_binding_invalid` on `ha task artifact add` issued from a running leader under load) is a separate product defect tracked as its own task; with this fix the product's retry can now absorb it in the test. The resident-leader variant of the test asserts exactly three callback leaders, so a retry there would still fail, now with an honest message.

---

# 中文

## 概要

`integration-shard (5)` 一直在 `packages/cli/test/squad-resident-leader.integration.test.ts`(「same-instance API-key squad workers reuse the materialized bearer」:squad run 变成 `failed` 而不是 `converged`)上 flake。同一 commit 连续两次 run 一过一挂,失败 receipt 给出了机制:一次瞬时的 leader turn 失败让 coordinator 重试 leader,产品此时用 `# Squad leader retry` 头发 prompt(`packages/daemon/src/squad-leader-decision.ts:119`),而测试的假 codex provider 只认 `# Squad dispatch protocol` 与 `# Squad worker callback`。重试 prompt 落到 worker 分支,provider 绑成 `luna-api-session`,daemon 以「provider bound unexpected session」杀掉 resume。于是任何 leader 重试都是这条测试的必败,而产品的重试路径恰恰是用来吸收它的。

本 PR 让该文件里两个假 provider 把重试头当作 leader callback(三行,只改测试)。不加等待、不加超时、不改产品。

## 架构辩护

只改测试。产品的三种 leader prompt 头不变;stub 现在如实镜像它们。

## 机读声明

见英文块。

## 治理声明

不改 CI、gate 或分支保护。

## 验证

- 该测试只在 Linux 跑(需要 `secret-tool`),本机 macOS 会跳过。诊断在 4 CPU 的 Linux 容器里分别在分支与 main 上单跑该文件(各通过,3.7 秒)、整跑 shard 5(250/250,101 秒)、CPU 压力下各 12 次(24/24 通过),本地都没能复现重试路径;修法由 CI 失败 receipt 与 `squad-leader-decision.ts:119` 的产品头推导。
- 本 PR 的 CI 是权威验证。

## 评审证据

CEO 读了失败 receipt 的时间线(terra 回调 → leader 第 2 轮 → 综合报告 `ha task artifact add` 被 `executor_binding_invalid` 拒 → leader 重试 → resume 被杀)与 stub 的分类代码;改动是对产品头集合的最小镜像。

## 残余风险

底层瞬时故障(运行中的 leader 在负载下发 `ha task artifact add` 被 `executor_binding_invalid` 拒)是另一个产品缺陷,已单独立 task;本修复之后产品的重试在测试里能吸收它。resident-leader 变体断言恰好三次 callback leader,重试仍会失败,但会给出诚实的信息。
