### PR TITLE
fix(daemon): bind runtime event cursors to the projection cut

### DIFF
--- a/packages/daemon/src/agent-runtime-contract.ts
+++ b/packages/daemon/src/agent-runtime-contract.ts
@@ -134,7 +134,9 @@ export type AgentRuntimeEventsResult = {
   readonly runtimeSessionId: string;
   readonly events: readonly AgentRuntimeLifecycleDto[];
   readonly cursor: string;
+  /** End of the projection snapshot that supplied this page; it never describes a newer canonical-store cut. */
   readonly sourceCursor: string;
+  /** Whether this page reached sourceCursor within that same projection snapshot. */
   readonly done: boolean;
 };
 export type AgentRuntimeSessionGroupBy = "task" | "squad" | "agent" | "day";

--- a/packages/daemon/src/agent-runtime-read.ts
+++ b/packages/daemon/src/agent-runtime-read.ts
@@ -247,7 +247,7 @@ export function makeAgentRuntimeReadModel(input: {
     events: (payload: Readonly<Record<string, unknown>>): AgentRuntimeEventsResult => {
       const runtimeSessionIdValue = requiredRuntimeReadField(payload, "runtimeSessionId"),
         after = lifecycleCursor(requiredRuntimeReadField(payload, "afterCursor")),
-        source = input.store.readHead()?.revision ?? 0;
+        source = input.projection.readCut().watermark;
       if (after > source)
         throw coded("invalid_cursor", `Lifecycle cursor lifecycle:${after} is ahead of lifecycle:${source}.`);
       const matching = input.projection.readRuntimeSessionEvents(runtimeSessionIdValue, after, 65),

--- a/packages/daemon/src/repo-cell-proxy.ts
+++ b/packages/daemon/src/repo-cell-proxy.ts
@@ -149,9 +149,7 @@ export async function openRepoCellProxy(
         [
           "repo.entity.actions.explain",
           "repo.agentRuntime.overview",
-          "repo.agentRuntime.sessionGroups",
           "repo.agentRuntime.sessions.read",
-          "repo.agentRuntime.events.read",
         ] as readonly string[]
       ).includes(method),
       readStore = needsWalOverlay

--- a/packages/daemon/test/agent-runtime-read-cut.contract.test.ts
+++ b/packages/daemon/test/agent-runtime-read-cut.contract.test.ts
@@ -1,0 +1,183 @@
+// harness-test-tier: contract
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import {
+  eventObjectTarget,
+  makeTaskEventStore,
+  makeTaskProjection,
+  type AgentRuntimeEventV1,
+  type FrozenWritePlan,
+} from "../../kernel/src/index.ts";
+import { makeAgentRuntimeReadModel } from "../src/agent-runtime-read.ts";
+
+test("runtime lifecycle cursors stay at the projection cut while the canonical stream is ahead", async (t) => {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-runtime-read-cut-"));
+  let projection: ReturnType<typeof makeTaskProjection> | undefined,
+    store: ReturnType<typeof makeTaskEventStore> | undefined;
+  try {
+    initRepo(rootDir);
+    store = makeTaskEventStore({ repoId: "runtime-read-cut", rootDir });
+    projection = makeTaskProjection({ rootDir, eventStore: store });
+    const events = runtimeEvents();
+    for (const event of events) store.append({ event, plan: runtimeWritePlan(event), blobs: [] });
+    projection.apply(events[0]!);
+    projection.apply(events[1]!);
+
+    const reads = makeAgentRuntimeReadModel({ store, projection, stream: {} as never }),
+      lagged = reads.events({ runtimeSessionId: "runtime-session", afterCursor: "lifecycle:0" });
+    assert.deepEqual(lagged, {
+      ok: true,
+      runtimeSessionId: "runtime-session",
+      events: [
+        {
+          cursor: "lifecycle:2",
+          runtimeSessionId: "runtime-session",
+          type: "runtime_dispatch_requested",
+          occurredAt: "2026-09-03T00:00:02.000Z",
+        },
+      ],
+      cursor: "lifecycle:2",
+      sourceCursor: "lifecycle:2",
+      done: true,
+    });
+    assert.throws(
+      () => reads.events({ runtimeSessionId: "runtime-session", afterCursor: "lifecycle:3" }),
+      (error: unknown) => error instanceof Error && "code" in error && error.code === "invalid_cursor",
+    );
+
+    projection.apply(events[2]!);
+    const continued = reads.events({ runtimeSessionId: "runtime-session", afterCursor: lagged.cursor }),
+      synchronized = reads.events({ runtimeSessionId: "runtime-session", afterCursor: "lifecycle:0" }),
+      expectedSynchronized = {
+        ok: true,
+        runtimeSessionId: "runtime-session",
+        events: [
+          {
+            cursor: "lifecycle:2",
+            runtimeSessionId: "runtime-session",
+            type: "runtime_dispatch_requested",
+            occurredAt: "2026-09-03T00:00:02.000Z",
+          },
+          {
+            cursor: "lifecycle:3",
+            runtimeSessionId: "runtime-session",
+            type: "runtime_session_started",
+            occurredAt: "2026-09-03T00:00:03.000Z",
+          },
+        ],
+        cursor: "lifecycle:3",
+        sourceCursor: "lifecycle:3",
+        done: true,
+      };
+    assert.deepEqual(
+      [...lagged.events, ...continued.events].map(({ type }) => type),
+      expectedSynchronized.events.map(({ type }) => type),
+    );
+    assert.equal(JSON.stringify(synchronized), JSON.stringify(expectedSynchronized));
+    t.diagnostic(`lagged=${JSON.stringify(lagged)}`);
+    t.diagnostic(`continued=${JSON.stringify(continued)}`);
+    t.diagnostic(`synchronized-bytes=${JSON.stringify(synchronized)}`);
+  } finally {
+    await store?.drain();
+    projection?.close();
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});
+
+function runtimeEvents(): readonly AgentRuntimeEventV1[] {
+  const actor = { principal: { personId: "person-runtime-cut" }, executor: null } as const,
+    definition = {
+      schema: "agent-definition-snapshot/v1",
+      configVersion: 1,
+      instanceId: "instance-runtime",
+      installationId: "installation-runtime",
+      kindId: "codex",
+      providerId: "openai",
+      model: "gpt-5.6-sol",
+      reasoningEffort: "high",
+      baseUrl: null,
+      authMode: "subscription",
+    } as const;
+  return [
+    {
+      schema: "agent-runtime-event/v1",
+      eventId: "event-runtime-installation",
+      workspaceRevision: 1,
+      opId: "op-runtime-installation",
+      actor,
+      source: "local",
+      occurredAt: "2026-09-03T00:00:01.000Z",
+      type: "runtime_installation_observed",
+      payload: {
+        installationId: definition.installationId,
+        kindId: definition.kindId,
+        protocolFamily: "codex",
+        hostRef: "host:local",
+        version: "1.0.0",
+        discoverySource: "wrapper",
+        capabilities: ["structured_witness", "attach"],
+      },
+    },
+    {
+      schema: "agent-runtime-event/v1",
+      eventId: "event-runtime-dispatch",
+      workspaceRevision: 2,
+      opId: "op-runtime-dispatch",
+      actor,
+      source: "local",
+      occurredAt: "2026-09-03T00:00:02.000Z",
+      type: "runtime_dispatch_requested",
+      payload: {
+        dispatchId: "dispatch-runtime",
+        runtimeSessionId: "runtime-session",
+        instanceId: definition.instanceId,
+        installationId: definition.installationId,
+        kindId: definition.kindId,
+        idempotencyKey: "runtime-read-cut",
+        definitionSnapshotRef: "artifact:runtime-definition/test",
+        definitionSnapshot: definition,
+      },
+    },
+    {
+      schema: "agent-runtime-event/v1",
+      eventId: "event-runtime-session",
+      workspaceRevision: 3,
+      opId: "op-runtime-session",
+      actor,
+      source: "local",
+      occurredAt: "2026-09-03T00:00:03.000Z",
+      type: "runtime_session_started",
+      payload: {
+        runtimeSessionId: "runtime-session",
+        instanceId: definition.instanceId,
+        installationId: definition.installationId,
+        kindId: definition.kindId,
+        definitionSnapshotRef: "artifact:runtime-definition/test",
+        launchGeneration: 1,
+        attachable: true,
+      },
+    },
+  ];
+}
+
+function runtimeWritePlan(event: AgentRuntimeEventV1): FrozenWritePlan {
+  return Object.freeze({
+    commandType: event.type,
+    targets: Object.freeze([
+      Object.freeze({ kind: "event_file", path: eventObjectTarget(event.opId), operation: "create" }),
+      Object.freeze({ kind: "event_head", path: "harness/events/head.json", operation: "replace" }),
+      Object.freeze({ kind: "projection_invalidation", projection: "agent-runtime/v1", key: event.opId }),
+    ]),
+  }) as FrozenWritePlan;
+}
+
+function initRepo(rootDir: string): void {
+  execFileSync("git", ["-C", rootDir, "init", "-q"]);
+  execFileSync("git", ["-C", rootDir, "config", "user.name", "Runtime Read Cut Test"]);
+  execFileSync("git", ["-C", rootDir, "config", "user.email", "runtime-read-cut@example.invalid"]);
+  execFileSync("git", ["-C", rootDir, "commit", "--allow-empty", "-qm", "base"]);
+}

--- a/tools/gates/ontology-event-read-truth.mjs
+++ b/tools/gates/ontology-event-read-truth.mjs
@@ -7,6 +7,7 @@ import { exitCodeFor, lineNumber, parseCommonArgs, parseTypeScript } from "./ont
 const eventReadPaths = Object.freeze([
   "packages/daemon/src/task-query-read.ts",
   "packages/daemon/src/repo-cell-task-query.ts",
+  "packages/daemon/src/agent-runtime-read.ts",
 ]);
 const legacyReadCalls = new Set([
   "readRelationGraphProjection",
@@ -48,11 +49,63 @@ export function auditEventReadTruth(rootDir = process.cwd()) {
       }
       ts.forEachChild(node, visit);
     }
+    if (file === "packages/daemon/src/agent-runtime-read.ts") auditRuntimeEventCut(sourceFile, report);
   }
   const deduped = [
     ...new Map(findings.map((finding) => [`${finding.file}:${finding.line}:${finding.reason}`, finding])).values(),
   ];
   return { findings: deduped.sort((left, right) => left.file.localeCompare(right.file) || left.line - right.line) };
+}
+
+function auditRuntimeEventCut(sourceFile, report) {
+  let handler = null;
+  visit(sourceFile);
+  if (handler === null) {
+    report(sourceFile, "runtime event read handler is missing");
+    return;
+  }
+  const source = findNode(
+    handler,
+    (node) => ts.isVariableDeclaration(node) && ts.isIdentifier(node.name) && node.name.text === "source",
+  );
+  if (!source || !projectionWatermark(source.initializer, sourceFile))
+    report(handler, "runtime event source cursor must come from the projection reader watermark");
+
+  function visit(node) {
+    if (
+      handler === null &&
+      ts.isPropertyAssignment(node) &&
+      node.name.getText(sourceFile) === "events" &&
+      (ts.isArrowFunction(node.initializer) || ts.isFunctionExpression(node.initializer))
+    )
+      handler = node.initializer;
+    ts.forEachChild(node, visit);
+  }
+}
+
+function findNode(root, matches) {
+  let found = null;
+  visit(root);
+  return found;
+
+  function visit(node) {
+    if (found !== null) return;
+    if (matches(node)) {
+      found = node;
+      return;
+    }
+    ts.forEachChild(node, visit);
+  }
+}
+
+function projectionWatermark(expression, sourceFile) {
+  return (
+    expression !== undefined &&
+    ts.isPropertyAccessExpression(expression) &&
+    expression.name.text === "watermark" &&
+    ts.isCallExpression(expression.expression) &&
+    expression.expression.expression.getText(sourceFile) === "input.projection.readCut"
+  );
 }
 
 function callName(expression) {

--- a/tools/gates/test/ontology-event-read-truth.test.mjs
+++ b/tools/gates/test/ontology-event-read-truth.test.mjs
@@ -24,10 +24,29 @@ test("G0-3 reports the base advisory and points to an L1 read injected into a na
     ].join("\n"),
   );
   writeRepoFile(rootDir, "packages/daemon/src/repo-cell-task-query.ts", "export {};\n");
+  writeRepoFile(
+    rootDir,
+    "packages/daemon/src/agent-runtime-read.ts",
+    [
+      "export function runtimeReads(input) {",
+      "  return {",
+      "    events: () => {",
+      "      const source = input.store.readHead()?.revision ?? 0;",
+      "      return { source };",
+      "    },",
+      "  };",
+      "}",
+      "",
+    ].join("\n"),
+  );
   const result = auditEventReadTruth(rootDir);
   assert.match(
     result.findings.map((finding) => `${finding.file}:${finding.line} ${finding.reason}`).join("\n"),
     /task-query-read\.ts:3.*readRelationGraphProjection/u,
+  );
+  assert.match(
+    result.findings.map((finding) => `${finding.file}:${finding.line} ${finding.reason}`).join("\n"),
+    /agent-runtime-read\.ts:3.*source cursor must come from the projection reader watermark/u,
   );
   const positive = captureGate(() => main(["--root", rootDir, "--mode", "ratchet"]));
   assert.equal(positive.code, 1);


### PR DESCRIPTION
# English

## Summary

`repo.agentRuntime.events.read` (`packages/daemon/src/agent-runtime-read.ts`) took its `source`/`sourceCursor` from the canonical store's WAL head while the event rows came from the main-thread query-only projection. Since #2149 moved writes into the writer thread, the projection routinely lags the WAL for a few hundred milliseconds; in that window the read returned fewer rows than the stream had, set `done=true`, and advanced the returned cursor to the WAL head, so a client continuing from that cursor permanently skipped the events the projection applied afterwards. The read now describes one cut only: rows, `sourceCursor`, `done`, the trailing `cursor` and the `invalid_cursor` upper bound all come from `TaskProjection.readCut().watermark` observed in the same SQLite snapshot; the `readHead()` call is gone and the method is removed from `repo-cell-proxy.ts`'s `needsWalOverlay` list (together with the unreachable `repo.agentRuntime.sessionGroups` entry that a use-case projection replaced). No wait, poll, catch-up or retry was added.

`tools/gates/ontology-event-read-truth.mjs` now covers `agent-runtime-read.ts` and requires, by TypeScript AST, that the runtime event handler's `source` comes from the projection reader watermark; the negative fixture that restores `input.store.readHead()` is reported as `runtime event source cursor must come from the projection reader watermark`.

Same-family scan of every `needsWalOverlay` method: `entity.actions.explain` targets the canonical cut and answers `projection_pending` explicitly (kept); `agentRuntime.overview` and `sessions.read` pick sessions/result refs from the projection and use the store only for content-addressed blobs not yet in Git (kept); only `events.read` mixed cuts.

## Architectural Justification

Read-at-cut is the repo's self-consistent read contract; a receipt must describe the cut it actually read. Multi-node view: the cursor is `workspaceRevision` on the node's own projection, which is what the read now reports; no cross-node state, and edge nodes (no WAL) no longer hit a code path that references a WAL head they do not have.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none

## Machine-Readable Declarations

Production-Delta: +56/-3
Dependency-Change: none

### Optional Evidence Claims

none

## Task And Scope

task_21ae92c2a8a9af0c46c95f5ea4 (PLT-Ontology; same family as the ingress test race fixed in #2169 and the executor-binding task). Scope: `agent-runtime-read.ts`, `agent-runtime-contract.ts` (type), `repo-cell-proxy.ts` overlay list, the read-truth gate and its test, new contract test.

## Version Impact

None.

## Governance Declaration

Protected path touched: `tools/gates/ontology-event-read-truth.mjs` (+ its test) — the gate's own predicate is extended to the runtime events handler; no required-check, workflow, allowlist, or branch-protection change. Authorized under task_21ae92c2a8a9af0c46c95f5ea4, whose plan grants the read-truth gate predicate extension, within standing policy dec_558977E9272F532D6DCFDB7F90. No break-glass.

## Verification

- Worker stop point (targeted tests + local commit, no `check:local`): new `packages/daemon/test/agent-runtime-read-cut.contract.test.ts` run on the isolated Ubuntu runner (`tools/dispatch-isolated-test.mjs --target ubuntu`) 1/1 passed: with the canonical stream at revision 3 and the projection at watermark 2 the read returns `cursor lifecycle:2`, `sourceCursor lifecycle:2`, `done true`; `afterCursor lifecycle:3` is `invalid_cursor`; after the projection catches up, continuing from `lifecycle:2` yields revision 3 and the two pages equal the full projected stream. Synchronized-case JSON bytes are pinned as the negative control.
- Gate self-test with the negative fixture passes; `discoverTestFiles` 475→476 with the set difference exactly the new file (first-line tier `contract`).
- Fact recorded on the task by the worker.

## Review Evidence

Worker report: `harness/tasks/task_21ae92c2a8a9af0c46c95f5ea4-*/artifacts/runtime-events-cut-report.md` (private ledger). CEO semantic review: single cut, no waiting layer, gate predicate names the invariant, overlay list narrowed rather than widened.

## Residual Risk

`overview` / `sessions.read` still combine projection-selected refs with store blobs; that is by construction (blobs are content-addressed, not a cut) and was left as is.

---

# 中文

## 概要

`repo.agentRuntime.events.read`(`packages/daemon/src/agent-runtime-read.ts`)的 `source`/`sourceCursor` 取自 canonical store 的 WAL head,事件行却来自主线程的 query-only 投影。#2149 把写入搬进 writer 线程后,投影常态性落后 WAL 几百毫秒;窗口内该读返回的行少于流里已有的,却置 `done=true` 并把返回 cursor 推到 WAL head,客户端从该 cursor 续读会永久跳过投影随后才 apply 的事件。现在这次读只描述一个 cut:行、`sourceCursor`、`done`、末尾 `cursor` 与 `invalid_cursor` 上界全部来自同一 SQLite 快照里观察到的 `TaskProjection.readCut().watermark`;`readHead()` 调用删除,方法从 `repo-cell-proxy.ts` 的 `needsWalOverlay` 列表移除(连同已被 use-case projection 取代、不可达的 `repo.agentRuntime.sessionGroups` 项)。没有加等待、轮询、catch-up 或重试。

`tools/gates/ontology-event-read-truth.mjs` 现在覆盖 `agent-runtime-read.ts`,以 TypeScript AST 要求 runtime event handler 的 `source` 直接来自投影 reader 的 watermark;把它换回 `input.store.readHead()` 的负向夹具被报为 `runtime event source cursor must come from the projection reader watermark`。

对 `needsWalOverlay` 每个方法的同族扫描:`entity.actions.explain` 以 canonical cut 为目标并明确回 `projection_pending`(保留);`agentRuntime.overview` 与 `sessions.read` 由投影选定 session/result ref,store 只供尚未落 Git 的 content-addressed blob(保留);只有 `events.read` 混 cut。

## 架构辩护

read-at-cut 是仓库自洽的读契约:receipt 必须描述它真正读的那个 cut。多节点视角:cursor 是节点自己投影上的 `workspaceRevision`,读现在如实报告它;不跨节点,且没有 WAL 的边缘节点不再经过引用 WAL head 的代码路径。

## 机读声明

见英文块。

## 治理声明

触碰 protected 路径:`tools/gates/ontology-event-read-truth.mjs`(及其测试)——只扩展门自身的判据到 runtime events handler;不改必需 check、workflow、allowlist 或分支保护。授权来源:task_21ae92c2a8a9af0c46c95f5ea4(其 plan 授权 read-truth 门判据扩展),在常设政策 dec_558977E9272F532D6DCFDB7F90 之下。无 break-glass。

## 验证

- worker 停止点(定向测试 + 本地 commit,不跑 `check:local`):新 `packages/daemon/test/agent-runtime-read-cut.contract.test.ts` 在隔离 Ubuntu runner(`tools/dispatch-isolated-test.mjs --target ubuntu`)1/1 通过:canonical 流到 revision 3、投影 watermark 2 时,读返回 `cursor lifecycle:2`、`sourceCursor lifecycle:2`、`done true`;`afterCursor lifecycle:3` 为 `invalid_cursor`;投影追上后从 `lifecycle:2` 续读得到 revision 3,两页合并等于完整投影流。同步场景的 JSON 字节被固定为阴性对照。
- 门自测含负向夹具通过;`discoverTestFiles` 475→476,差集恰为新文件(首行 tier `contract`)。
- worker 已在任务上记 fact。

## 评审证据

worker 报告见任务包 `artifacts/runtime-events-cut-report.md`(私有台账)。CEO 语义验收:单一 cut、无等待层、门判据点名不变量、overlay 列表只收窄不放宽。

## 残余风险

`overview` / `sessions.read` 仍把投影选定的 ref 与 store blob 组合;这是构造使然(blob 是 content-addressed,不是 cut),按原样保留。
