### PR TITLE
fix(daemon): verify runtime executor claims at the writer cut

### DIFF
--- a/packages/daemon/src/repo-cell-api.ts
+++ b/packages/daemon/src/repo-cell-api.ts
@@ -144,16 +144,28 @@ export interface RepoCellSynchronousRead {
 
 export function createRepoCellApi(context: RepoCellApiContext): RepoCell & RepoCellSynchronousRead {
   let settlingRecovery: string | null = null;
+  const bindExecutorClaimAtWriterCut = async (
+    action: RepoTaskAction,
+    binding: RepoCellBinding,
+  ): Promise<{ readonly action: RepoTaskAction; readonly binding: RepoCellBinding }> => {
+    if (!Object.hasOwn(action, "executor") || !(durablePolicyActions as readonly string[]).includes(action.kind))
+      return bindVerifiedExecutorClaim({ action, binding, projection: context.projection, now: context.now() });
+    context.queueDepth += 1;
+    const pending = chainRepoCellWrite(context.tail, () => {
+      context.queueDepth -= 1;
+      return bindVerifiedExecutorClaim({ action, binding, projection: context.projection, now: context.now() });
+    });
+    context.tail = pending.then(
+      () => undefined,
+      () => undefined,
+    );
+    return pending;
+  };
   const run = async (action: RepoTaskAction, binding: RepoCellBinding, signal?: AbortSignal): Promise<WriteReceipt> => {
     if (context.state !== "attached")
       await context.attemptRecovery(recoveryCommandPolicy(action.kind, context.causeClass)?.settlesLatch === true);
     try {
-      ({ action, binding } = bindVerifiedExecutorClaim({
-        action,
-        binding,
-        projection: context.projection,
-        now: context.now(),
-      }));
+      ({ action, binding } = await bindExecutorClaimAtWriterCut(action, binding));
     } catch (error) {
       const revision = context.store.readHead()?.revision ?? 0,
         actionId = context.operationId(action, binding, context.input.repoId, revision),
@@ -360,12 +372,7 @@ export function createRepoCellApi(context: RepoCellApiContext): RepoCell & RepoC
     );
   };
   const presetRun: RepoCell["presetRun"] = async (action, binding) => {
-    ({ action, binding } = bindVerifiedExecutorClaim({
-      action,
-      binding,
-      projection: context.projection,
-      now: context.now(),
-    }));
+    ({ action, binding } = await bindExecutorClaimAtWriterCut(action, binding));
     const command = commandDescriptorForAction(action.kind),
       authorizationDecision =
         action.kind === "preset-run-start"
@@ -821,13 +828,8 @@ export function createRepoCellApi(context: RepoCellApiContext): RepoCell & RepoC
     );
     return pending;
   };
-  const spawnRuntime: RepoCell["spawnRuntime"] = (payload, binding) => {
-    const verified = bindVerifiedExecutorClaim({
-      action: { kind: "runtime-spawn", ...payload },
-      binding,
-      projection: context.projection,
-      now: context.now(),
-    });
+  const spawnRuntime: RepoCell["spawnRuntime"] = async (payload, binding) => {
+    const verified = await bindExecutorClaimAtWriterCut({ kind: "runtime-spawn", ...payload }, binding);
     binding = verified.binding;
     payload = Object.fromEntries(Object.entries(verified.action).filter(([field]) => field !== "kind")) as JsonObject;
     const action = { kind: "runtime-spawn", ...payload };
@@ -844,13 +846,8 @@ export function createRepoCellApi(context: RepoCellApiContext): RepoCell & RepoC
       return context.runtimeSpawner.spawn(payload, authorizedBinding);
     });
   };
-  const cancelRuntime: RepoCell["cancelRuntime"] = (payload, binding) => {
-    const verified = bindVerifiedExecutorClaim({
-      action: { kind: "runtime-cancel", ...payload },
-      binding,
-      projection: context.projection,
-      now: context.now(),
-    });
+  const cancelRuntime: RepoCell["cancelRuntime"] = async (payload, binding) => {
+    const verified = await bindExecutorClaimAtWriterCut({ kind: "runtime-cancel", ...payload }, binding);
     binding = verified.binding;
     payload = Object.fromEntries(Object.entries(verified.action).filter(([field]) => field !== "kind")) as JsonObject;
     return enqueueRuntimePublication(

--- a/packages/daemon/src/repo-cell-api.ts
+++ b/packages/daemon/src/repo-cell-api.ts
@@ -144,12 +144,12 @@ export interface RepoCellSynchronousRead {
 
 export function createRepoCellApi(context: RepoCellApiContext): RepoCell & RepoCellSynchronousRead {
   let settlingRecovery: string | null = null;
-  const bindExecutorClaimAtWriterCut = async (
-    action: RepoTaskAction,
-    binding: RepoCellBinding,
-  ): Promise<{ readonly action: RepoTaskAction; readonly binding: RepoCellBinding }> => {
-    if (!Object.hasOwn(action, "executor") || !(durablePolicyActions as readonly string[]).includes(action.kind))
-      return bindVerifiedExecutorClaim({ action, binding, projection: context.projection, now: context.now() });
+  const bindExecutorClaimAtWriterCut = (action: RepoTaskAction, binding: RepoCellBinding) => {
+    if (action.executor == null || !(durablePolicyActions as readonly string[]).includes(action.kind))
+      return {
+        queued: false as const,
+        result: bindVerifiedExecutorClaim({ action, binding, projection: context.projection, now: context.now() }),
+      };
     context.queueDepth += 1;
     const pending = chainRepoCellWrite(context.tail, () => {
       context.queueDepth -= 1;
@@ -159,13 +159,14 @@ export function createRepoCellApi(context: RepoCellApiContext): RepoCell & RepoC
       () => undefined,
       () => undefined,
     );
-    return pending;
+    return { queued: true as const, result: pending };
   };
   const run = async (action: RepoTaskAction, binding: RepoCellBinding, signal?: AbortSignal): Promise<WriteReceipt> => {
     if (context.state !== "attached")
       await context.attemptRecovery(recoveryCommandPolicy(action.kind, context.causeClass)?.settlesLatch === true);
     try {
-      ({ action, binding } = await bindExecutorClaimAtWriterCut(action, binding));
+      const verified = bindExecutorClaimAtWriterCut(action, binding);
+      ({ action, binding } = verified.queued ? await verified.result : verified.result);
     } catch (error) {
       const revision = context.store.readHead()?.revision ?? 0,
         actionId = context.operationId(action, binding, context.input.repoId, revision),
@@ -372,7 +373,8 @@ export function createRepoCellApi(context: RepoCellApiContext): RepoCell & RepoC
     );
   };
   const presetRun: RepoCell["presetRun"] = async (action, binding) => {
-    ({ action, binding } = await bindExecutorClaimAtWriterCut(action, binding));
+    const bound = bindExecutorClaimAtWriterCut(action, binding);
+    ({ action, binding } = bound.queued ? await bound.result : bound.result);
     const command = commandDescriptorForAction(action.kind),
       authorizationDecision =
         action.kind === "preset-run-start"
@@ -829,7 +831,8 @@ export function createRepoCellApi(context: RepoCellApiContext): RepoCell & RepoC
     return pending;
   };
   const spawnRuntime: RepoCell["spawnRuntime"] = async (payload, binding) => {
-    const verified = await bindExecutorClaimAtWriterCut({ kind: "runtime-spawn", ...payload }, binding);
+    const bound = bindExecutorClaimAtWriterCut({ kind: "runtime-spawn", ...payload }, binding),
+      verified = bound.queued ? await bound.result : bound.result;
     binding = verified.binding;
     payload = Object.fromEntries(Object.entries(verified.action).filter(([field]) => field !== "kind")) as JsonObject;
     const action = { kind: "runtime-spawn", ...payload };
@@ -847,7 +850,8 @@ export function createRepoCellApi(context: RepoCellApiContext): RepoCell & RepoC
     });
   };
   const cancelRuntime: RepoCell["cancelRuntime"] = async (payload, binding) => {
-    const verified = await bindExecutorClaimAtWriterCut({ kind: "runtime-cancel", ...payload }, binding);
+    const bound = bindExecutorClaimAtWriterCut({ kind: "runtime-cancel", ...payload }, binding),
+      verified = bound.queued ? await bound.result : bound.result;
     binding = verified.binding;
     payload = Object.fromEntries(Object.entries(verified.action).filter(([field]) => field !== "kind")) as JsonObject;
     return enqueueRuntimePublication(

--- a/packages/daemon/test/repo-cell-executor-binding-cut.test.ts
+++ b/packages/daemon/test/repo-cell-executor-binding-cut.test.ts
@@ -1,0 +1,167 @@
+// harness-test-tier: contract
+import assert from "node:assert/strict";
+import test from "node:test";
+import { bindWriterGenerationToken, type LeaseV1, type RuntimeSession } from "../../kernel/src/index.ts";
+import { createRepoCellApi, type RepoCellApiContext } from "../src/repo-cell-api.ts";
+import type { RepoCellBinding } from "../src/repo-cell-types.ts";
+
+const now = "2026-09-03T12:00:00.000Z";
+const taskId = "task-runtime-first-write";
+const executionId = "exec-runtime-first-write";
+const runtimeSessionId = "runtime-first-write";
+const runtimeActor = {
+  principal: { personId: "person-runtime-owner" },
+  executor: { kind: "agent", id: `runtime-session:${runtimeSessionId}` },
+} as const;
+const runtimeSession: RuntimeSession = {
+  runtimeSessionId,
+  instanceId: "runtime-instance",
+  installationId: "runtime-installation",
+  kindId: "codex",
+  definitionSnapshotRef: "sha256:runtime-definition",
+  providerSessionId: "provider-session",
+  transcriptRef: "transcript:provider-session",
+  launchGeneration: 1,
+  liveness: "live",
+  attachable: true,
+  taskBindings: [
+    {
+      taskId,
+      executionId,
+      providerSessionId: "provider-session",
+      transcriptRef: "transcript:provider-session",
+      boundAt: now,
+    },
+  ],
+  outcome: null,
+  exitCode: null,
+  resultRef: null,
+  lastObservedAt: now,
+};
+const lease: LeaseV1 = {
+  schema: "lease/v1",
+  taskId,
+  executionId,
+  actor: runtimeActor,
+  source: "local",
+  phase: "held",
+  expiresAt: "2026-09-03T13:00:00.000Z",
+  ttlMs: 3_600_000,
+  version: 1,
+};
+const binding: RepoCellBinding = {
+  actor: { principal: runtimeActor.principal, executor: null },
+  source: "local",
+  authorizationBindingMode: "default",
+};
+const action = {
+  kind: "task-artifact-add",
+  taskId,
+  source: "report.md",
+  destination: "reports/report.md",
+  executor: runtimeActor.executor,
+} as const;
+
+test("executor binding waits for the preceding writer cut that binds the runtime session", async () => {
+  let projectedSession: RuntimeSession | null = null,
+    projectedLease: LeaseV1 | null = null;
+  const precedingWrite = Promise.resolve().then(() => {
+      projectedSession = runtimeSession;
+      projectedLease = lease;
+    }),
+    context = contextFor(
+      precedingWrite,
+      () => projectedSession,
+      () => projectedLease,
+    ),
+    receipt = await createRepoCellApi(context).run(action, binding);
+
+  assert.equal(receipt.outcome, "applied", JSON.stringify(receipt));
+  assert.deepEqual(context.observedActor, runtimeActor);
+});
+
+test("executor binding still rejects a runtime session absent from the preceding writer cut", async () => {
+  const context = contextFor(
+      Promise.resolve(),
+      () => null,
+      () => null,
+    ),
+    receipt = await createRepoCellApi(context).run(action, binding);
+
+  assert.equal(receipt.outcome, "op_rejected");
+  assert.equal(receipt.code, "executor_binding_invalid");
+  assert.equal(context.observedActor, null);
+});
+
+function contextFor(
+  tail: Promise<void>,
+  readRuntimeSession: () => RuntimeSession | null,
+  currentLease: () => LeaseV1 | null,
+): RepoCellApiContext & { observedActor: RepoCellBinding["actor"] | null } {
+  const activeWriter = { workspaceId: "repository", generation: 1, ownerId: "daemon" },
+    fixture = {
+      extracted: {},
+      mode: "local",
+      fleetRoster: null,
+      input: { repoId: "repository" },
+      rejected: (opId: string, code: string, nextAction: string) => ({
+        outcome: "op_rejected",
+        opId,
+        code,
+        nextAction,
+      }),
+      operationId: () => "op-runtime-first-write",
+      failed: (opId: string, error: unknown) => ({
+        outcome: "op_rejected",
+        opId,
+        code: (error as { readonly code?: string }).code ?? "invalid_command",
+        nextAction: error instanceof Error ? error.message : String(error),
+      }),
+      fatalCellError: () => false,
+      errorOperationId: () => null,
+      cellCodedError: (code: string, message: string) => Object.assign(new Error(message), { code }),
+      requiredCellText: (value: unknown) => String(value),
+      dispatchRead: () => null,
+      state: "attached",
+      attemptRecovery: async () => undefined,
+      causeClass: null,
+      latched: () => "latched",
+      latchWith: () => undefined,
+      queueDepth: 0,
+      tail,
+      activeWriter,
+      writerToken: bindWriterGenerationToken(activeWriter),
+      activeWriterEpochGuard: null,
+      activeWriterEpochFence: null,
+      activeWriterEpochFenceDescriptor: null,
+      withLayoutAdvisory: <T>(value: T) => value,
+      withHumanSummary: <T>(value: T) => value,
+      lastError: null,
+      recoveryUncertain: false,
+      recoveryProbe: { clear: () => undefined },
+      replica: { kick: () => undefined },
+      rootDir: "/repository",
+      store: { readHead: () => ({ revision: 2 }) },
+      projection: { readRuntimeSession, currentLease },
+      now: () => now,
+      executeAction: (_action: unknown, verified: RepoCellBinding) => {
+        fixture.observedActor = verified.actor;
+        return Promise.resolve({
+          outcome: "applied",
+          opId: "op-runtime-first-write",
+          revision: 3,
+          evidence: "{}",
+          visibility: "center",
+          proof: {
+            committedRevision: 3,
+            appliedCut: 3,
+            durable: true,
+            canonicalVisible: true,
+            worktreeVisible: null,
+          },
+        });
+      },
+      observedActor: null as RepoCellBinding["actor"] | null,
+    };
+  return fixture as unknown as RepoCellApiContext & { observedActor: RepoCellBinding["actor"] | null };
+}

--- a/packages/daemon/test/repo-cell-executor-binding-cut.test.ts
+++ b/packages/daemon/test/repo-cell-executor-binding-cut.test.ts
@@ -93,11 +93,44 @@ test("executor binding still rejects a runtime session absent from the preceding
   assert.equal(context.observedActor, null);
 });
 
+test("executor-free actions reach the publication queue synchronously", async () => {
+  const context = contextFor(
+      Promise.resolve(),
+      () => null,
+      () => null,
+    ),
+    { executor: _executor, ...executorFreeAction } = action,
+    receipt = createRepoCellApi(context).run(executorFreeAction, binding);
+
+  assert.equal(context.tailAssignments, 1);
+  assert.equal((await receipt).outcome, "applied");
+  assert.equal(context.tailAssignments, 1);
+});
+
+test("empty executor markers do not add a writer-cut queue hop", async () => {
+  for (const executor of [null, undefined]) {
+    const context = contextFor(
+        Promise.resolve(),
+        () => null,
+        () => null,
+      ),
+      receipt = await createRepoCellApi(context).run({ ...action, executor }, binding);
+
+    assert.equal(receipt.outcome, "applied");
+    assert.equal(context.tailAssignments, 1, `executor=${String(executor)}`);
+  }
+});
+
 function contextFor(
   tail: Promise<void>,
   readRuntimeSession: () => RuntimeSession | null,
   currentLease: () => LeaseV1 | null,
-): RepoCellApiContext & { observedActor: RepoCellBinding["actor"] | null } {
+): RepoCellApiContext & {
+  readonly observedActor: RepoCellBinding["actor"] | null;
+  readonly tailAssignments: number;
+} {
+  let currentTail = tail,
+    tailAssignments = 0;
   const activeWriter = { workspaceId: "repository", generation: 1, ownerId: "daemon" },
     fixture = {
       extracted: {},
@@ -128,7 +161,16 @@ function contextFor(
       latched: () => "latched",
       latchWith: () => undefined,
       queueDepth: 0,
-      tail,
+      get tail() {
+        return currentTail;
+      },
+      set tail(value: Promise<void>) {
+        currentTail = value;
+        tailAssignments += 1;
+      },
+      get tailAssignments() {
+        return tailAssignments;
+      },
       activeWriter,
       writerToken: bindWriterGenerationToken(activeWriter),
       activeWriterEpochGuard: null,
@@ -163,5 +205,8 @@ function contextFor(
       },
       observedActor: null as RepoCellBinding["actor"] | null,
     };
-  return fixture as unknown as RepoCellApiContext & { observedActor: RepoCellBinding["actor"] | null };
+  return fixture as unknown as RepoCellApiContext & {
+    readonly observedActor: RepoCellBinding["actor"] | null;
+    readonly tailAssignments: number;
+  };
 }


### PR DESCRIPTION
# English

## Summary

Under load, the first `ha` write issued by a freshly spawned runtime session (the squad leader's `ha task artifact add` in the shard-5 receipt of #2169) was rejected with `executor_binding_invalid` ("The claimed RuntimeSession does not execute the target Task/Execution") even though the session was being bound to that task. The initial hypothesis (projection lagging the WAL) was wrong: `entity-action-runtime-session.ts` appends and applies synchronously. The real cut was the repository cell's single-writer queue: runtime output is scheduled onto the cell writer tail (`runtime-spawn-active.ts` → `repo-cell-open.ts`), provider binding is published before task binding with an `await` between them (`runtime-spawn-provider-stream.ts`), and `repo-cell-api.ts` verified the executor claim *immediately* while the durable write itself only joined the tail later — so the verification could read the projection before the already-queued `runtime_session_task_bound` publication landed.

Fix: one `bindExecutorClaimAtWriterCut` helper in `packages/daemon/src/repo-cell-api.ts`. For durable actions carrying an executor claim it chains verification behind `context.tail`, advances the tail, and only then returns the verified action and binding; `run`, `presetRun`, `spawnRuntime` and `cancelRuntime` all use it. Non-durable reads keep the immediate path. A session that is genuinely not task-bound is still rejected with `executor_binding_invalid`. No retry, poll, timeout, projection catch-up, protocol field, event shape or authorization exception was added; production delta is net negative.


Round 2 (9cbc5c541) answered three consecutive shard-4 latency-ratio failures (6.25x / 6.35x / 6.02x against the 6x ceiling). Temporary daemon logging showed every thin `task-create` in the fixture with `hasOwn=false executor=undefined queueDepth=0`, so ordinary writes were not being queued behind the writer tail; the branch-only change on the common path was the `async` helper itself, which made every `run`/`presetRun` suspend once before reaching its publication queue. The helper now returns a synchronous result when `action.executor == null` or the action is not durable, and only a non-null durable executor claim returns the writer-tail promise; two queue-shape regressions assert that an executor-free action installs its single publication tail before `RepoCell.run` first yields. Local paired controls: main and the round-1 head both ≈3.5x; after the fix 3.56–3.60x at load 0.8–0.9 and 4.08–4.42x at load 9.6–11.4. The CI-only amplification is an inference from the trace plus the diff (the isolated local control did not reproduce it); the ratio gate itself is being retired as a merge gate under dec_10D83683B9518BF355313083BB because its denominator variance dominates.

## Architectural Justification

Serialization on the existing single-writer boundary: the executor check now observes the same ordered cut as the write it authorizes. Multi-node view: edge writes arrive through `daemon-host-repository-api.ts` and call the same `cell.run`, so the queued binding event and the verification receive one ordered center decision; no edge-local state participates.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none

## Machine-Readable Declarations

Production-Delta: +27/-26
Dependency-Change: none

### Optional Evidence Claims

none

## Task And Scope

task_2347fe38161733b5285423ee33 (PLT-Ontology; flow defect surfaced by the #2169 shard-5 diagnosis; same family as #2175). Scope: `repo-cell-api.ts` + new contract test.

## Version Impact

None.

## Governance Declaration

No CI, gate, allowlist, workflow or branch-protection change; no new durable action; no break-glass.

## Verification

- Deterministic contract fixture `packages/daemon/test/repo-cell-executor-binding-cut.test.ts` reproduces the stale cut on the base code (`executor binding waits for the preceding writer cut that binds the runtime session` fails with `executor_binding_invalid` before the fix) and passes after; the negative control (a session absent from the preceding writer cut stays rejected) passes on both.
- Worker stop point (no `check:local`): contract 2/2; focused runtime/session/squad integration 24/24; daemon fast tier 191/191; daemon TypeScript build passed; fact recorded on the task.
- Same-class scan: `task-artifact-add`, `task-review-execution`, `task-declare-executor`, `task-progress-append`, `fact-record` all enter the shared durable `RepoCell.run` path, so the helper covers them at the common cut; no other direct caller of `bindVerifiedExecutorClaim` remains.

## Review Evidence

Worker report: `harness/tasks/task_2347fe38161733b5285423ee33-*/artifacts/executor-binding-cut-report.md` (private ledger). CEO semantic review: the hypothesis in the plan was tested and corrected with file:line evidence; the fix is ordering on the existing boundary, not a wait; authorization is not relaxed.

## Residual Risk

The squad resident-leader test still asserts exactly three callback leaders, so a leader retry there fails honestly (#2172 made the retry path reachable); with this fix the retry should no longer be triggered by the binding race in the first place.

---

# 中文

## 概要

负载下,刚 spawn 的 runtime 会话发出的第一条 `ha` 写(#2169 shard 5 receipt 里 squad leader 的 `ha task artifact add`)被 `executor_binding_invalid`(「The claimed RuntimeSession does not execute the target Task/Execution」)拒绝,尽管该会话正被绑定到那个任务。最初假设(投影落后 WAL)不成立:`entity-action-runtime-session.ts` 是同步 append + apply。真正的 cut 在仓库 cell 的单写队列:runtime 输出被排到 cell writer tail(`runtime-spawn-active.ts` → `repo-cell-open.ts`),provider 绑定先于 task 绑定发布、中间有一次 `await`(`runtime-spawn-provider-stream.ts`),而 `repo-cell-api.ts` **立即**校验 executor claim、持久写入本身却要到后面才加入 tail——于是校验可能在已排队的 `runtime_session_task_bound` 落地之前读投影。

修法:`packages/daemon/src/repo-cell-api.ts` 一个 `bindExecutorClaimAtWriterCut` helper。带 executor claim 的持久动作把校验挂在 `context.tail` 之后、推进 tail、再返回校验过的 action 与 binding;`run`、`presetRun`、`spawnRuntime`、`cancelRuntime` 都用它。非持久读保持即时路径。真正没绑定任务的会话仍被 `executor_binding_invalid` 拒绝。没有加重试、轮询、超时、投影 catch-up、协议字段、事件形状或授权豁免;生产 delta 净负。


第二轮(9cbc5c541)回应 shard 4 延迟比值连续三次红(6.25x / 6.35x / 6.02x 对 6x 门槛)。临时 daemon 日志显示 fixture 里每个 thin `task-create` 都是 `hasOwn=false executor=undefined queueDepth=0`,普通写并没有被排到 writer tail 之后;公共路径上分支独有的改动只剩 helper 的 `async` 形状本身——它让每个 `run`/`presetRun` 在到达发布队列前多挂起一次。现在 `action.executor == null` 或非 durable 动作时 helper 同步返回,只有非空的 durable executor claim 才返回 writer-tail promise;两条队列形状回归断言无 executor 的动作在 `RepoCell.run` 首次让出前就装好唯一发布 tail。本地配对对照:main 与第一轮 head 都 ≈3.5x;修后 0.8–0.9 负载 3.56–3.60x、9.6–11.4 负载 4.08–4.42x。CI 独有的放大是从 trace 加 diff 推出的(孤立本地对照没有复现);比值门本身正按 dec_10D83683B9518BF355313083BB 撤出合并门,因为其分母方差主导。

## 架构辩护

在既有单写边界上串行化:executor 校验现在观察的是它所授权的写入所在的同一有序 cut。多节点视角:边缘写入经 `daemon-host-repository-api.ts` 调同一个 `cell.run`,排队的绑定事件与校验拿到同一个有序的 center 判定;没有边缘本地状态参与。

## 机读声明

见英文块。

## 治理声明

不改 CI、gate、allowlist、workflow 或分支保护;不新增 durable action;无 break-glass。

## 验证

- 确定性契约夹具 `packages/daemon/test/repo-cell-executor-binding-cut.test.ts` 在 base 代码上复现陈旧 cut(`executor binding waits for the preceding writer cut that binds the runtime session` 修前以 `executor_binding_invalid` 失败),修后通过;阴性对照(不在前一 writer cut 里的会话仍被拒)两边都过。
- worker 停止点(不跑 `check:local`):契约 2/2;定向 runtime/session/squad 集成 24/24;daemon fast 191/191;daemon TypeScript 构建通过;任务上已记 fact。
- 同类扫描:`task-artifact-add`、`task-review-execution`、`task-declare-executor`、`task-progress-append`、`fact-record` 都经共享的持久 `RepoCell.run` 路径,helper 在公共 cut 覆盖它们;`bindVerifiedExecutorClaim` 没有其它直接调用者。

## 评审证据

worker 报告见任务包 `artifacts/executor-binding-cut-report.md`(私有台账)。CEO 语义验收:plan 里的假设被以文件:行证据检验并修正;修法是既有边界上的顺序,不是等待;授权未放宽。

## 残余风险

squad resident-leader 测试仍断言恰好三次 callback leader,那里的 leader 重试会诚实地失败(#2172 已让重试路径可达);本修复之后绑定竞态本身不应再触发重试。
