### PR TITLE
test(cli): make the write/no-op latency ratio diagnostic-only

### DIFF
--- a/packages/cli/test/daemon-multi-repo-lifecycle-cli-latency.test.ts
+++ b/packages/cli/test/daemon-multi-repo-lifecycle-cli-latency.test.ts
@@ -6,39 +6,19 @@ import { availableParallelism, loadavg } from "node:os";
 import path from "node:path";
 import test from "node:test";
 
-import {
-  builtCli,
-  median,
-  register,
-  run,
-  runNoop,
-  setup,
-  stop,
-} from "./daemon-multi-repo-lifecycle-cli.fixtures.ts";
+import { builtCli, median, register, run, runNoop, setup, stop } from "./daemon-multi-repo-lifecycle-cli.fixtures.ts";
 test("resident daemon CLI write p50 includes process startup through parsed receipt", async (context) => {
   const fixture = setup();
   try {
     // npm is npm.cmd on Windows, and Node refuses to execute a .cmd directly, so this failed
     // with ENOENT before the measurement even started -- a launcher defect wearing a
     // performance test's clothes. A shell resolves the shim; the arguments here are literals.
-    execFileSync(
-      "npm",
-      ["run", "build", "--workspace", "@harness-anything/cli"],
-      {
-        cwd: process.cwd(),
-        stdio: "pipe",
-        shell: process.platform === "win32",
-      },
-    );
-    assert.equal(
-      run(
-        fixture.alpha,
-        fixture.userRoot,
-        ["daemon", "start", "--service"],
-        builtCli,
-      ).ok,
-      true,
-    );
+    execFileSync("npm", ["run", "build", "--workspace", "@harness-anything/cli"], {
+      cwd: process.cwd(),
+      stdio: "pipe",
+      shell: process.platform === "win32",
+    });
+    assert.equal(run(fixture.alpha, fixture.userRoot, ["daemon", "start", "--service"], builtCli).ok, true);
     register(fixture.alpha, fixture.userRoot, "alpha", builtCli);
     // Warm two short rounds before measuring. GitHub's runner has a cold page/cache
     // penalty that is absent on the developer machine; one measured sample reached
@@ -62,24 +42,13 @@ test("resident daemon CLI write p50 includes process startup through parsed rece
           const receipt = run(
             fixture.alpha,
             fixture.userRoot,
-            [
-              "task",
-              "create",
-              "--id",
-              `task-latency-warmup-${id}`,
-              "--admin",
-              "--title",
-              `Latency warmup ${id}`,
-            ],
+            ["task", "create", "--id", `task-latency-warmup-${id}`, "--admin", "--title", `Latency warmup ${id}`],
             builtCli,
           );
           assert.equal(receipt.outcome, "applied", JSON.stringify(receipt));
         };
         const warmNoop = (): void => {
-          assert.equal(
-            runNoop(fixture.alpha, fixture.userRoot, builtCli).status,
-            0,
-          );
+          assert.equal(runNoop(fixture.alpha, fixture.userRoot, builtCli).status, 0);
         };
         if (first) {
           warmCli();
@@ -100,15 +69,7 @@ test("resident daemon CLI write p50 includes process startup through parsed rece
           const receipt = run(
             fixture.alpha,
             fixture.userRoot,
-            [
-              "task",
-              "create",
-              "--id",
-              `task-latency-${index}`,
-              "--admin",
-              "--title",
-              `Latency ${index}`,
-            ],
+            ["task", "create", "--id", `task-latency-${index}`, "--admin", "--title", `Latency ${index}`],
             builtCli,
           );
           assert.equal(receipt.outcome, "applied", JSON.stringify(receipt));
@@ -118,10 +79,7 @@ test("resident daemon CLI write p50 includes process startup through parsed rece
         };
         const measureNoop = (): void => {
           const started = performance.now();
-          assert.equal(
-            runNoop(fixture.alpha, fixture.userRoot, builtCli).status,
-            0,
-          );
+          assert.equal(runNoop(fixture.alpha, fixture.userRoot, builtCli).status, 0);
           const elapsed = performance.now() - started;
           noopSamples.push(elapsed);
           noopRound.push(elapsed);
@@ -150,42 +108,15 @@ test("resident daemon CLI write p50 includes process startup through parsed rece
     context.diagnostic(
       `latency-ratio=paired-round-cli-write-over-cli-help-noop warmup-rounds=${warmupRounds} rounds=${ratios.length} samples-per-round=${samplesPerRound} p50=${startupRatio.toFixed(3)}x min=${orderedRatios[0]!.toFixed(3)}x max=${orderedRatios.at(-1)!.toFixed(3)}x load1-per-parallelism=${loadSamples.map((value) => value.toFixed(2)).join(",")}`,
     );
-    context.diagnostic(
-      `latency-round-ratios=${ratios.map((value) => value.toFixed(3)).join(",")}`,
-    );
+    context.diagnostic(`latency-round-ratios=${ratios.map((value) => value.toFixed(3)).join(",")}`);
     const walProbe = JSON.parse(
-      execFileSync(
-        process.execPath,
-        [path.resolve("tools/verify-wal-append-fsync.mjs")],
-        { encoding: "utf8" },
-      ),
+      execFileSync(process.execPath, [path.resolve("tools/verify-wal-append-fsync.mjs")], { encoding: "utf8" }),
     ) as { durable: boolean; trace: readonly string[] };
     context.diagnostic(
       `wal-append-fsync=write-then-fsync-before-close durable=${walProbe.durable} trace=${walProbe.trace.join(">")}`,
     );
-    // A write invocation adds one daemon round trip, a canonical persisted write, and a
-    // parsed receipt to an otherwise ordinary CLI invocation. It is measured against the
-    // compiled CLI's adjacent --help no-op, so machine speed and load cancel within each
-    // pair without using the 19.858ms bare-Node denominator that read 14.472x on today's
-    // loaded Linux enforcement runner (and 50.080ms / 20.843x on Windows). An absolute
-    // millisecond bound would only assert how fast the runner is, and
-    // dec_01KY6X4J486MZ35RW1QN51V2V1 restricts performance gates to relative overhead. It
-    // fails if the write path grows relative to ordinary CLI startup, or stops delegating
-    // to the resident daemon and starts doing the write in its own process.
-    //
-    // This used to subtract daemonElapsed first, on the reading that the daemon round trip
-    // is not the CLI's own cost. That subtraction was never valid: daemonElapsed times a
-    // round trip THIS TEST PROCESS makes, not the one the CLI subprocess makes. Subtracting
-    // one operation's duration from an unrelated operation's duration is not a decomposition,
-    // and when the test process's own call ran slow it exceeded the entire CLI run — every
-    // observed run reported negative per-sample ratios, on passing runs as well as failing
-    // ones. Neither raising the bound nor re-running could help: the asserted quantity was
-    // not defined. Governance task task_182bb1c6068a1c36ca11c68185.
-    //
-    // Both terms here are real and positive. Twenty serial local runs at 0.72-1.85
-    // load1/parallelism read 4.225x-4.969x; 6.0x is the observed maximum plus 1.031x
-    // (20.8%) safety margin. A temporary second real daemon write in the timed arm read
-    // 10.494x (9.589x-11.478x), so the margin still rejects a 2x write-path regression.
+    // dec_10D83683B9518BF355313083BB keeps the wall-clock ratio diagnostic-only:
+    // variance in the short no-op denominator makes it non-invariant under CI load.
     // The acknowledged WAL is the durability boundary: localWalFileSystem.append must
     // fsync the segment descriptor after the write and before the close. This used to be
     // gated by a wall-clock ratio (shadow append over an explicit-fsync append), but both
@@ -200,11 +131,6 @@ test("resident daemon CLI write p50 includes process startup through parsed rece
     // probe instruments node:fs in a fresh process before importing the kernel adapter,
     // so the verdict is deterministic under any load and fails closed (empty trace) if
     // the instrumentation ever stops binding on a future Node.
-    assert.equal(
-      startupRatio <= 6,
-      true,
-      `thin CLI write was ${startupRatio.toFixed(3)}x a compiled CLI help no-op (paired round p50; spread ${orderedRatios[0]!.toFixed(3)}x-${orderedRatios.at(-1)!.toFixed(3)}x, write=${p50.toFixed(3)}ms, noop=${noopP50.toFixed(3)}ms)`,
-    );
     assert.equal(
       walProbe.durable,
       true,


### PR DESCRIPTION
# English

## Summary

`packages/cli/test/daemon-multi-repo-lifecycle-cli-latency.test.ts` asserted that a thin CLI write's p50 is at most 6x a compiled CLI `--help` no-op's p50. Measured on 2026-09-02/03 (fact F-3A2B7118): main on an idle shard 3.51x; main under full-check load 5.06x and 5.28x; PR #2176 three runs 6.25x / 6.35x / 6.02x; PR #2177 4.48x; PR #2174, which changes only kernel projection code and never touches the write path, 8.81x. Absolute write latency was stable at roughly 480–530 ms across those PRs while the no-op denominator moved between 60 and 140 ms with the runner, so the ratio measured the runner, not the code. Three PRs were blocked by the same assertion.

Under dec_10D83683B9518BF355313083BB the ratio verdict is removed: the five-line `assert.equal(startupRatio <= 6, …)` and the twenty-three lines that justified the threshold are deleted, two comment lines record the decision, and the paired measurement (warmup 2, rounds 5, samples 3, alternating arm order, medians) stays exactly as it was, printing `latency-window`, `latency-baseline`, `latency-ratio` and per-round load as diagnostics on every run. The test still decides on daemon startup, write receipt, no-op exit and WAL fsync assertions. No threshold tuned, no load-based skip, no environment switch; the pre-commit formatter collapsed seven unchanged multiline constructs, which is the rest of the diff.

## Architectural Justification

Test-only change; no runtime path and no concurrency subject. The rejected alternatives (raise the ceiling, rerun until green, skip under load) are recorded in the decision: moving the floor only trades which side reds, reruns hide a broken instrument, and a load skip makes the gate absent exactly when CI is busiest. Any future ratio gate must first hold on main under CI load for five consecutive runs.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none

## Machine-Readable Declarations

Production-Delta: +0/-0
Dependency-Change: none

### Optional Evidence Claims

none

## Task And Scope

task_19950fb56b3b37f4bbf0c92092 (incident root task_98a824499e96f27b66797d227d), derived from dec_10D83683B9518BF355313083BB/CH1. Scope: one test file.

## Version Impact

None.

## Governance Declaration

No protected path touched (a package test, not `tools/gates/**`, a workflow or an allowlist). The ruling that retires the verdict is dec_10D83683B9518BF355313083BB (in effect). No break-glass.

## Verification

- Worker stop point (targeted test + local commit, no `check:local`): the test passes locally three times and the diagnostic lines print the same fields as before; typecheck pass; production delta `+0/-0` from the official gate.
- Positive control before the change: under local parallel load the ratio crossed 6x and the test went red; after the change the same load leaves the test green with the ratio still printed.

## Review Evidence

Worker report: `harness/tasks/task_19950fb56b3b37f4bbf0c92092-*/artifacts/cli-latency-ratio-flake-report.md` (private ledger). CEO semantic review: the deletion is exactly the verdict and its rationale, measurement logic is byte-for-byte the same, remaining assertions still make the test meaningful, and the decision id is cited at the deletion site.

## Residual Risk

The write/no-op ratio is no longer enforced; it remains visible in every CI log. A regression in thin-CLI write latency would now have to be caught by the absolute `latency-window` diagnostic being read, or by a future gate that proves stability on main first.

---

# 中文

## 概要

`packages/cli/test/daemon-multi-repo-lifecycle-cli-latency.test.ts` 断言 thin CLI 写的 p50 不超过编译后 CLI `--help` 空操作 p50 的 6 倍。2026-09-02/03 实测(fact F-3A2B7118):main 空载分片 3.51x;main 在 full-check 负载下 5.06x 与 5.28x;PR #2176 三次 6.25x / 6.35x / 6.02x;PR #2177 4.48x;只改 kernel 投影、根本不碰写路的 PR #2174 8.81x。写路绝对值在这些 PR 之间稳定在约 480–530 ms,而分母空操作随 runner 在 60–140 ms 之间漂移,所以比值量的是 runner 不是代码。三条 PR 被同一条断言卡住。

按 dec_10D83683B9518BF355313083BB 撤掉比值判定:删掉五行 `assert.equal(startupRatio <= 6, …)` 与二十三行门槛论证,加两行注释记录决策;配对测量(warmup 2、rounds 5、samples 3、交替顺序、中位数)一字不改,每次运行仍以诊断形式打印 `latency-window`、`latency-baseline`、`latency-ratio` 与每轮负载。测试仍由 daemon 启动、写回执、空操作退出与 WAL fsync 断言决定结果。不调门槛、不加负载跳过、不加环境开关;pre-commit 格式化把七处未改的多行结构折叠,这是 diff 的其余部分。

## 架构辩护

纯测试改动;无运行时路径、无并发主体。被否方案(调高门槛、重跑到绿、负载时跳过)记录在决策里:移动地板只是换一边红,重跑掩盖失灵的仪器,负载跳过让门在 CI 最忙时消失。将来任何比值门必须先在 main 上于 CI 负载下连续五次成立。

## 机读声明

见英文块。

## 治理声明

未触碰 protected 路径(是包内测试,不是 `tools/gates/**`、workflow 或 allowlist)。撤掉判定的裁决是 dec_10D83683B9518BF355313083BB(in_effect)。无 break-glass。

## 验证

- worker 停止点(定向测试 + 本地 commit,不跑 `check:local`):该测试本地三次通过,诊断行字段与之前一致;typecheck 通过;官方门 production delta `+0/-0`。
- 改前阳性对照:本地并行加负载时比值越过 6x、测试红;改后同样负载下测试绿且比值仍打印。

## 评审证据

worker 报告见任务包 `artifacts/cli-latency-ratio-flake-report.md`(私有台账)。CEO 语义验收:删除的恰是判定与其论证,测量逻辑逐字节不变,剩余断言仍让测试有意义,删除处引用了决策 id。

## 残余风险

写/空操作比值不再被执行,但每次 CI 日志里仍可见。thin CLI 写延迟的回归现在要靠有人读 `latency-window` 绝对值诊断,或将来先在 main 上证明稳定的新门来抓。
