### PR TITLE
fix(daemon): degrade runtime sessions whose installation is missing instead of failing the overview

### DIFF
--- a/packages/daemon/src/agent-runtime-contract.ts
+++ b/packages/daemon/src/agent-runtime-contract.ts
@@ -1,8 +1,10 @@
 import type {
   AgentDefinitionSnapshot,
   AgentRuntimeEventV1,
+  RuntimeInstallationState,
   RuntimeSessionSemanticState,
 } from "../../kernel/src/index.ts";
+export type { RuntimeInstallationState } from "../../kernel/src/index.ts";
 export interface AgentRuntimeInstallationDto {
   readonly installationId: string;
   readonly kindId: "claude" | "codex" | "agy";
@@ -87,7 +89,7 @@ export interface AgentRuntimeSessionDto {
   readonly installationId: string;
   readonly kindId: "claude" | "codex" | "agy";
   /** Omitted while the referenced installation is still witnessed, preserving the established DTO bytes. */
-  readonly installationState?: "missing";
+  readonly installationState?: Exclude<RuntimeInstallationState, "present">;
   readonly installationError?: AgentRuntimeInstallationErrorDto;
   readonly definitionSnapshotRef: string;
   readonly definitionSnapshot: AgentDefinitionSnapshot | null;
@@ -106,6 +108,11 @@ export interface AgentRuntimeSessionDto {
     readonly missingEvidence: "exit-code-and-result" | "exit-code" | "result" | null;
     readonly reasonCode?: string;
   };
+}
+export function agentRuntimeInstallationState(
+  session: Pick<AgentRuntimeSessionDto, "installationState">,
+): RuntimeInstallationState {
+  return session.installationState ?? "present";
 }
 export interface AgentRuntimeLifecycleDto {
   readonly cursor: string;

--- a/packages/daemon/src/agent-runtime-contract.ts
+++ b/packages/daemon/src/agent-runtime-contract.ts
@@ -74,6 +74,10 @@ export interface AgentRuntimeAttemptChainDto {
     readonly nextDispatchId: string | null;
   }[];
 }
+export interface AgentRuntimeInstallationErrorDto {
+  readonly code: "runtime_installation_not_found";
+  readonly hint: string;
+}
 export const runtimeTypeMatchesKind = (runtimeType: string, kindId: AgentRuntimeInstanceDto["kindId"]): boolean =>
   runtimeType === "any" || runtimeType === kindId;
 export interface AgentRuntimeSessionDto {
@@ -82,6 +86,9 @@ export interface AgentRuntimeSessionDto {
   readonly instanceId: string;
   readonly installationId: string;
   readonly kindId: "claude" | "codex" | "agy";
+  /** Omitted while the referenced installation is still witnessed, preserving the established DTO bytes. */
+  readonly installationState?: "missing";
+  readonly installationError?: AgentRuntimeInstallationErrorDto;
   readonly definitionSnapshotRef: string;
   readonly definitionSnapshot: AgentDefinitionSnapshot | null;
   readonly definitionSnapshotPersisted: boolean;
@@ -416,7 +423,7 @@ function validSession(value: unknown): value is AgentRuntimeSessionDto {
         "associations",
         "activity",
       ],
-      ["semanticState", "attemptChain"],
+      ["installationState", "installationError", "semanticState", "attemptChain"],
     ) &&
     typeof value.runtimeSessionId === "string" &&
     (value.providerSessionId === null || typeof value.providerSessionId === "string") &&
@@ -424,6 +431,7 @@ function validSession(value: unknown): value is AgentRuntimeSessionDto {
       (item) => typeof item === "string" && item.length > 0,
     ) &&
     ["claude", "codex", "agy"].includes(String(value.kindId)) &&
+    validInstallationState(value.installationState, value.installationError) &&
     typeof value.definitionSnapshotPersisted === "boolean" &&
     (value.definitionSnapshot === null ||
       (isAgentDefinitionSnapshot(value.definitionSnapshot) &&
@@ -453,6 +461,17 @@ function validSession(value: unknown): value is AgentRuntimeSessionDto {
       ["exit-code-and-result", "exit-code", "result"].includes(String(value.activity.missingEvidence))) &&
     (value.activity.reasonCode === undefined ||
       (typeof value.activity.reasonCode === "string" && value.activity.reasonCode.length > 0))
+  );
+}
+function validInstallationState(state: unknown, error: unknown): boolean {
+  if (state === undefined && error === undefined) return true;
+  return (
+    state === "missing" &&
+    isAgentRuntimeContractRecord(error) &&
+    hasExactAgentRuntimeContractFields(error, ["code", "hint"]) &&
+    error.code === "runtime_installation_not_found" &&
+    typeof error.hint === "string" &&
+    error.hint.length > 0
   );
 }
 function validAttemptChain(value: unknown): value is AgentRuntimeAttemptChainDto {

--- a/packages/daemon/src/agent-runtime-read.ts
+++ b/packages/daemon/src/agent-runtime-read.ts
@@ -55,23 +55,29 @@ export function makeAgentRuntimeReadModel(input: {
     definition: { readonly snapshot: AgentDefinitionSnapshot | null; readonly persisted: boolean },
     includeAttemptChain = false,
   ): AgentRuntimeSessionDto => {
-    if (!installation) {
-      throw coded("runtime_installation_not_found", `Runtime installation ${session.installationId} was not found.`);
-    }
-    const attemptChain = includeAttemptChain ? input.readAttemptChain?.(session.runtimeSessionId) : undefined;
+    const attemptChain = includeAttemptChain ? input.readAttemptChain?.(session.runtimeSessionId) : undefined,
+      installationError = installation
+        ? null
+        : {
+            code: "runtime_installation_not_found" as const,
+            hint: `Runtime installation ${session.installationId} was not found.`,
+          };
     return {
       runtimeSessionId: session.runtimeSessionId,
       providerSessionId: session.providerSessionId,
       instanceId: session.instanceId,
       installationId: session.installationId,
-      kindId: runtimeKindForInstallation(installation).kindId,
+      kindId: installation
+        ? runtimeKindForInstallation(installation).kindId
+        : historicalRuntimeKindId(session, definition.snapshot),
+      ...(installationError ? { installationState: "missing" as const, installationError } : {}),
       definitionSnapshotRef: session.definitionSnapshotRef,
       definitionSnapshot: definition.snapshot,
       definitionSnapshotPersisted: definition.persisted,
       liveness: session.liveness,
       semanticState: runtimeSessionSemanticState(session),
       attachCapability:
-        session.attachable && installation.effectiveCapabilities.includes("attach") ? "supported" : "unsupported",
+        session.attachable && installation?.effectiveCapabilities.includes("attach") ? "supported" : "unsupported",
       streamCursor: input.stream.latestCursor(session.runtimeSessionId),
       associations: session.taskBindings.map((binding) => {
         const lease = input.projection.currentLease(binding.taskId),
@@ -283,6 +289,15 @@ export function makeAgentRuntimeReadModel(input: {
     }
     return { ref: session.resultRef, text };
   }
+}
+
+function historicalRuntimeKindId(
+  session: RuntimeSession,
+  definition: AgentDefinitionSnapshot | null,
+): AgentRuntimeSessionDto["kindId"] {
+  const kindId = definition?.kindId ?? session.kindId;
+  if (kindId === "claude" || kindId === "codex" || kindId === "agy") return kindId;
+  throw coded("invalid_result", `Runtime session ${session.runtimeSessionId} has an unsupported runtime kind.`);
 }
 
 function runtimeTaskLabels(projection: TaskProjection, taskIds: readonly string[]): ReadonlyMap<string, string> {

--- a/packages/daemon/test/agent-runtime-read-missing-installation.test.ts
+++ b/packages/daemon/test/agent-runtime-read-missing-installation.test.ts
@@ -1,0 +1,193 @@
+// harness-test-tier: integration
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import {
+  eventObjectTarget,
+  makeTaskEventStore,
+  makeTaskProjection,
+  type AgentDefinitionSnapshot,
+  type AgentRuntimeEventV1,
+  type FrozenWritePlan,
+} from "../../kernel/src/index.ts";
+import { validateAgentRuntimeOverview, validateAgentRuntimeSession } from "../src/agent-runtime-contract.ts";
+import { makeAgentRuntimeReadModel } from "../src/agent-runtime-read.ts";
+import { makeAgentRuntimeStreamHub } from "../src/agent-runtime-stream.ts";
+
+const actor = { principal: { personId: "person-runtime" }, executor: null } as const;
+
+test("runtime reads retain a session whose installation witness is missing", (t) =>
+  withRuntime(false, ({ reads }) => {
+    const overview = reads.overview({}),
+      session = overview.sessions[0]!;
+    assert.equal(overview.status, "ready");
+    assert.equal(session.runtimeSessionId, "runtime-historical");
+    assert.equal(session.kindId, "claude");
+    assert.equal(session.attachCapability, "unsupported");
+    assert.equal(session.installationState, "missing");
+    assert.deepEqual(session.installationError, {
+      code: "runtime_installation_not_found",
+      hint: "Runtime installation installation-missing was not found.",
+    });
+    assert.deepEqual(validateAgentRuntimeOverview(overview), []);
+    const single = reads.session({ runtimeSessionId: session.runtimeSessionId });
+    assert.deepEqual(single.session, session);
+    assert.deepEqual(validateAgentRuntimeSession(single), []);
+    t.diagnostic(JSON.stringify({ status: overview.status, session }));
+  }));
+
+test("an installation-backed session DTO remains byte-for-byte unchanged", () =>
+  withRuntime(true, ({ reads }) => {
+    const session = reads.overview({}).sessions[0]!;
+    assert.equal(
+      JSON.stringify(session),
+      JSON.stringify({
+        runtimeSessionId: "runtime-historical",
+        providerSessionId: null,
+        instanceId: "instance-historical",
+        installationId: "installation-present",
+        kindId: "claude",
+        definitionSnapshotRef: "artifact:runtime-definition/test",
+        definitionSnapshot: definition("installation-present"),
+        definitionSnapshotPersisted: false,
+        liveness: "live",
+        semanticState: "running",
+        attachCapability: "supported",
+        streamCursor: "stream:0",
+        associations: [],
+        activity: {
+          lastObservedAt: "2026-09-03T00:00:03.000Z",
+          outcome: null,
+          exitCode: null,
+          resultRef: null,
+          missingEvidence: null,
+        },
+      }),
+    );
+    assert.equal(Object.hasOwn(session, "installationState"), false);
+    assert.equal(Object.hasOwn(session, "installationError"), false);
+  }));
+
+function withRuntime(
+  installationPresent: boolean,
+  use: (fixture: { readonly reads: ReturnType<typeof makeAgentRuntimeReadModel> }) => void,
+): void {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-runtime-missing-installation-"));
+  let projection: ReturnType<typeof makeTaskProjection> | undefined;
+  try {
+    execFileSync("git", ["-C", rootDir, "init", "-q"]);
+    execFileSync("git", ["-C", rootDir, "config", "user.name", "Runtime Test"]);
+    execFileSync("git", ["-C", rootDir, "config", "user.email", "runtime@example.invalid"]);
+    execFileSync("git", ["-C", rootDir, "commit", "--allow-empty", "-qm", "base"]);
+    const store = makeTaskEventStore({ repoId: "runtime-missing-installation", rootDir });
+    projection = makeTaskProjection({ rootDir, eventStore: store });
+    const installationId = installationPresent ? "installation-present" : "installation-missing";
+    for (const event of events(installationId)) {
+      store.append({ event, plan: runtimeWritePlan(event), blobs: [] });
+      projection.apply(event);
+    }
+    const stream = makeAgentRuntimeStreamHub({
+      readSession: (runtimeSessionId) => projection!.readRuntimeSession(runtimeSessionId),
+      canAttach: () => true,
+    });
+    use({ reads: makeAgentRuntimeReadModel({ store, projection, stream }) });
+  } finally {
+    projection?.close();
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+}
+
+function events(installationId: string): readonly AgentRuntimeEventV1[] {
+  const snapshot = definition(installationId);
+  return [
+    event(
+      "runtime_installation_observed",
+      {
+        installationId: "installation-present",
+        kindId: "claude",
+        protocolFamily: "claude-compatible",
+        hostRef: "host:local",
+        version: "1.0.0",
+        discoverySource: "wrapper",
+        capabilities: ["structured_witness", "attach"],
+      },
+      1,
+    ),
+    event(
+      "runtime_dispatch_requested",
+      {
+        dispatchId: "dispatch-historical",
+        runtimeSessionId: "runtime-historical",
+        instanceId: snapshot.instanceId,
+        installationId,
+        kindId: snapshot.kindId,
+        idempotencyKey: "historical-once",
+        definitionSnapshotRef: "artifact:runtime-definition/test",
+        definitionSnapshot: snapshot,
+      },
+      2,
+    ),
+    event(
+      "runtime_session_started",
+      {
+        runtimeSessionId: "runtime-historical",
+        instanceId: snapshot.instanceId,
+        installationId,
+        kindId: snapshot.kindId,
+        definitionSnapshotRef: "artifact:runtime-definition/test",
+        launchGeneration: 1,
+        attachable: true,
+      },
+      3,
+    ),
+  ];
+}
+
+function definition(installationId: string): AgentDefinitionSnapshot {
+  return {
+    authMode: "subscription",
+    baseUrl: null,
+    configVersion: 1,
+    installationId,
+    instanceId: "instance-historical",
+    kindId: "claude",
+    model: "claude-opus",
+    providerId: "anthropic",
+    reasoningEffort: null,
+    schema: "agent-definition-snapshot/v1",
+  };
+}
+
+function event<T extends AgentRuntimeEventV1["type"]>(
+  type: T,
+  payload: Extract<AgentRuntimeEventV1, { readonly type: T }>["payload"],
+  revision: number,
+): AgentRuntimeEventV1 {
+  return {
+    schema: "agent-runtime-event/v1",
+    eventId: `event-${revision}`,
+    workspaceRevision: revision,
+    opId: `op-${revision}`,
+    actor,
+    source: "local",
+    occurredAt: `2026-09-03T00:00:0${revision}.000Z`,
+    type,
+    payload,
+  } as AgentRuntimeEventV1;
+}
+
+function runtimeWritePlan(event: AgentRuntimeEventV1): FrozenWritePlan {
+  return Object.freeze({
+    commandType: event.type,
+    targets: Object.freeze(
+      [
+        { kind: "event_file", path: eventObjectTarget(event.opId), operation: "create" },
+        { kind: "event_head", path: "harness/events/head.json", operation: "replace" },
+        { kind: "projection_invalidation", projection: "agent-runtime/v1", key: event.opId },
+      ].map((target) => Object.freeze(target)),
+    ),
+  }) as FrozenWritePlan;
+}

--- a/packages/gui/src/renderer/components/runtime/SessionsPanel.tsx
+++ b/packages/gui/src/renderer/components/runtime/SessionsPanel.tsx
@@ -200,6 +200,9 @@ export function SessionDetailView({
             )}
           </CardTitle>
           <Badge status={LIVENESS_BADGE[session.liveness] ?? "unknown"}>{session.liveness}</Badge>
+          {session.installationState === "missing" && (
+            <Badge tip={session.installationError?.hint}>{t("agentRuntime.installationMissing")}</Badge>
+          )}
           <Right>
             {LIVENESS_LIVE[session.liveness] && (
               <Btn

--- a/packages/gui/src/renderer/components/runtime/SessionsPanel.tsx
+++ b/packages/gui/src/renderer/components/runtime/SessionsPanel.tsx
@@ -5,7 +5,7 @@ import type {
 } from "../../../../../daemon/src/agent-runtime-contract.ts";
 import { consumeKnownError } from "../../../api/error-consumption.ts";
 import { agentRuntimeClient } from "../../agent-runtime-client.ts";
-import { type SessionRow, shortRef } from "../../sessions-model.ts";
+import { sessionInstallationBadge, type SessionRow, shortRef } from "../../sessions-model.ts";
 import { t } from "../../i18n/index.tsx";
 import { EntityRefLink } from "../EntityRefLink.tsx";
 import { SessionTranscript } from "../sessions/SessionTranscript.tsx";
@@ -182,7 +182,8 @@ export function SessionDetailView({
           : null,
     agentName = row?.kind === "round" ? row.agentName : null,
     squadId = row?.kind === "round" ? row.squadId : null,
-    squadName = squadId === null ? null : (squadNames.get(squadId) ?? squadId);
+    squadName = squadId === null ? null : (squadNames.get(squadId) ?? squadId),
+    installationBadge = sessionInstallationBadge(session);
   return (
     <div data-testid="session-detail">
       <Card>
@@ -200,9 +201,7 @@ export function SessionDetailView({
             )}
           </CardTitle>
           <Badge status={LIVENESS_BADGE[session.liveness] ?? "unknown"}>{session.liveness}</Badge>
-          {session.installationState === "missing" && (
-            <Badge tip={session.installationError?.hint}>{t("agentRuntime.installationMissing")}</Badge>
-          )}
+          {installationBadge && <Badge tip={session.installationError?.hint}>{t(installationBadge)}</Badge>}
           <Right>
             {LIVENESS_LIVE[session.liveness] && (
               <Btn

--- a/packages/gui/src/renderer/i18n/locales/en-US/agentRuntime.json
+++ b/packages/gui/src/renderer/i18n/locales/en-US/agentRuntime.json
@@ -42,6 +42,7 @@
   "agentRuntime.saveProvider": "Save provider",
   "agentRuntime.providerEditHint": "Credentials and call-path configuration stay unchanged.",
   "agentRuntime.installation": "Installation",
+  "agentRuntime.installationMissing": "Installation missing",
   "agentRuntime.defaultModel": "Default model",
   "agentRuntime.officialEndpoint": "official endpoint",
   "agentRuntime.authTitle": "Authentication",

--- a/packages/gui/src/renderer/i18n/locales/zh-CN/agentRuntime.json
+++ b/packages/gui/src/renderer/i18n/locales/zh-CN/agentRuntime.json
@@ -42,6 +42,7 @@
   "agentRuntime.saveProvider": "保存 Provider",
   "agentRuntime.providerEditHint": "凭证与调用方式配置保持不变。",
   "agentRuntime.installation": "安装",
+  "agentRuntime.installationMissing": "安装见证已缺失",
   "agentRuntime.defaultModel": "默认模型",
   "agentRuntime.officialEndpoint": "官方端点",
   "agentRuntime.authTitle": "认证",

--- a/packages/gui/src/renderer/sessions-model.ts
+++ b/packages/gui/src/renderer/sessions-model.ts
@@ -1,7 +1,9 @@
-import type {
-  AgentRuntimeSessionDto,
-  AgentRuntimeSessionGroupDto,
-  AgentRuntimeSessionGroupStatus,
+import {
+  agentRuntimeInstallationState,
+  type AgentRuntimeSessionDto,
+  type AgentRuntimeSessionGroupDto,
+  type AgentRuntimeSessionGroupStatus,
+  type RuntimeInstallationState,
 } from "../../../daemon/src/agent-runtime-contract.ts";
 import type { TaskDispatchProjectionRow } from "../api/renderer-dto.ts";
 import type { RelationEdge } from "./model/types.ts";
@@ -47,6 +49,16 @@ export const sessionStatusKey: Readonly<Record<SessionStatus, string>> = {
   "ended-indeterminate": "agentRuntime.sessionStatusEndedIndeterminate",
   unavailable: "agentRuntime.sessionStatusUnavailable",
 };
+export const sessionInstallationBadgeKey: Readonly<
+  Record<RuntimeInstallationState, "agentRuntime.installationMissing" | null>
+> = {
+  present: null,
+  missing: "agentRuntime.installationMissing",
+};
+
+export function sessionInstallationBadge(session: Pick<AgentRuntimeSessionDto, "installationState">) {
+  return sessionInstallationBadgeKey[agentRuntimeInstallationState(session)];
+}
 
 /** 组展开行之一:一轮派工(一个 dispatchId 一轮),按 startedAt 倒序编号。 */
 export type SessionRound = {

--- a/packages/gui/test/agent-runtime-renderer.vitest.ts
+++ b/packages/gui/test/agent-runtime-renderer.vitest.ts
@@ -316,6 +316,21 @@ describe("agent runtime renderer", () => {
     expect(markup).toContain("Snapshot artifact was not persisted");
     expect(markup).toContain("Session facts");
   });
+  it("marks a historical session whose installation witness is missing", () => {
+    const markup = detailView({
+      session: {
+        ...session,
+        installationState: "missing",
+        installationError: {
+          code: "runtime_installation_not_found",
+          hint: "Runtime installation installation-codex was not found.",
+        },
+      },
+    });
+    expect(markup).toContain("Installation missing");
+    expect(markup).toContain("Runtime installation installation-codex was not found.");
+    expect(markup).not.toContain("Agent Runtime read failed");
+  });
   it("states which terminal evidence is missing when an outcome is genuinely unknown", () => {
     const markup = detailView({
       session: {

--- a/packages/gui/test/agent-runtime-renderer.vitest.ts
+++ b/packages/gui/test/agent-runtime-renderer.vitest.ts
@@ -317,6 +317,7 @@ describe("agent runtime renderer", () => {
     expect(markup).toContain("Session facts");
   });
   it("marks a historical session whose installation witness is missing", () => {
+    expect(detailView()).not.toContain("Installation missing");
     const markup = detailView({
       session: {
         ...session,

--- a/packages/kernel/src/domain/agent-runtime.ts
+++ b/packages/kernel/src/domain/agent-runtime.ts
@@ -137,6 +137,7 @@ export interface RuntimeSession {
   readonly reasonCode?: string;
   readonly lastObservedAt: string;
 }
+export type RuntimeInstallationState = "present" | "missing";
 export type RuntimeSessionSemanticState =
   | "running"
   | "succeeded"

--- a/packages/kernel/src/domain/status-vocabulary-catalog.ts
+++ b/packages/kernel/src/domain/status-vocabulary-catalog.ts
@@ -262,6 +262,15 @@ export const statusVocabularies: readonly StatusVocabulary[] = [
     words: ["succeeded", "failed", "unknown", "cancelled"],
   },
   {
+    id: "runtime.installation-state",
+    entity: "RuntimeSession",
+    field: "installation state",
+    module: "packages/kernel/src/domain/agent-runtime.ts",
+    anchor: "RuntimeInstallationState",
+    words: ["present", "missing"],
+    note: "Read-time judgment of the session's referenced installation against the local witness set; not stored.",
+  },
+  {
     id: "runtime.semantic-state",
     entity: "RuntimeSession",
     field: "semantic state",

--- a/packages/kernel/src/domain/status-word-register-runtime.ts
+++ b/packages/kernel/src/domain/status-word-register-runtime.ts
@@ -59,6 +59,21 @@ export const runtimeAndRecoveryStatusWords: readonly StatusWordRegistration[] = 
     meaning: "Session was actively terminated by a cancel request.",
     divergence: "entity-scoped",
   },
+  // ---- RuntimeSession installation state (derived against local witnesses) ----
+  {
+    word: "present",
+    entity: "RuntimeSession",
+    field: "installation state",
+    meaning: "The session's referenced installation is witnessed on the reading node.",
+    divergence: "entity-scoped",
+  },
+  {
+    word: "missing",
+    entity: "RuntimeSession",
+    field: "installation state",
+    meaning: "The session remains readable but its referenced installation is not witnessed on the reading node.",
+    divergence: "entity-scoped",
+  },
   {
     word: "by_session_id",
     entity: "RuntimeSession",

--- a/packages/kernel/src/index.ts
+++ b/packages/kernel/src/index.ts
@@ -18,6 +18,7 @@ export type {
   AgentDefinitionSnapshot,
   AgentRuntimeEventV1,
   RuntimeInstallation,
+  RuntimeInstallationState,
   RuntimeKind,
   RuntimeProtocolFamily,
   RuntimeResultClaim,


### PR DESCRIPTION
# English

## Summary

The GUI Agent page showed a banner `读取 Agent Runtime 失败: Runtime installation claude_08d6a351836d8c1fd6c9c0ac was not found.` and rendered nothing else (reported by 泽宇 on 2026-09-03). `packages/daemon/src/agent-runtime-read.ts` built every session DTO by resolving the session's `installationId` against this machine's installation witnesses and threw `runtime_installation_not_found` for the first miss, so one historical session turned the whole `repo.agentRuntime.overview` read into a protocol error. On the canonical ledger 159 of 1,308 sessions reference four installations this machine no longer witnesses (an older codex install alone accounts for 146), which is the normal state of a shared ledger read from a machine whose local installs were re-witnessed.

`sessionDto` now degrades per session: when the installation is missing the DTO keeps the session's own identity and adds `installationState: "missing"`, a field-level `installationError` (`runtime_installation_not_found` plus hint) and `attachCapability: "unsupported"`; `kindId` comes from the persisted definition snapshot or the session's canonical kind, never guessed from local installs. When the installation exists the DTO is byte-for-byte unchanged (golden serialization test). Overview and single-session read share the same function, so the single read keeps a structured field-level diagnostic instead of failing the request. The GUI change is one component: `SessionsPanel.tsx` shows a grey "Installation missing" badge with the hint as tooltip; the banner is still driven only by a real read error. The unconditional throw is deleted; nothing is silently filtered.


Round 3 answered the first CI run: `check-gui-status-judgments` flagged a point comparison on `installationState` inside `SessionsPanel.tsx`; the state is now registered in the status vocabulary and the badge is derived through the registered judgment entry instead of a component-level comparison. No allowlist, no gate change.

## Architectural Justification

Installations are machine-local witnesses while sessions live in the shared canonical ledger, so the center and every edge reading the same sessions will each see a different subset as `missing`. Degrading per row is the only shape that keeps a shared read correct on every node; migrating or rewriting historical `installationId` values would alter facts. Read-only, no concurrency subject.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none

## Machine-Readable Declarations

Production-Delta: +94/-13
Dependency-Change: none

### Optional Evidence Claims

none

## Task And Scope

task_2aa48e3f4b096b0fd1d14d5dd4 (incident root task_98a824499e96f27b66797d227d). Scope: `packages/daemon/src/agent-runtime-read.ts`, `agent-runtime-contract.ts`, new `packages/daemon/test/agent-runtime-read-missing-installation.test.ts`, `packages/gui/src/renderer/components/runtime/SessionsPanel.tsx`, two locale entries, GUI renderer test. The worker's same-mechanism scan found four more collection reads in the daemon where one invalid row fails the whole list (`agent-entities.ts` agent and squad catalogs, `schedules-gui-read.ts` agent options, `squad-coordinator.ts` runs list); per the CEO checkpoint ruling they are recorded as fact F-6F836337 and will be fixed as one class in a separate task after the squad entity migration lands, not widened into this PR.

## Version Impact

None.

## Governance Declaration

No protected path touched. No break-glass.

## Verification

- Reproduction on the canonical ledger before the fix: `repo.agentRuntime.overview` → `op_rejected` / `runtime_installation_not_found`, exit 1. After: `status=ready`, `totalSessions=1308`, `missingSessions=159`.
- Worker stop point (targeted tests + local commit, no `check:local`): daemon integration 15/15 (new test asserts overview ready, missing session fields, both wire validators clean); GUI renderer test 30/30; implementation-contracts 129/129 delta 0; cli-error-codes, error-classification, file-complexity, line-density, test-selection, canonical-event-compat pass; production-delta `+44/-7` pass; `git diff --check` clean. New test file discovered by `discoverTestFiles` (481 → 482) with the integration tier marker on line 1.

## Review Evidence

Worker report: `harness/tasks/task_2aa48e3f4b096b0fd1d14d5dd4-*/artifacts/agent-runtime-read-missing-installation-report.md` (private ledger). CEO semantic review: degrade per session, keep identity, structured field-level diagnostic, no silent filter, no rewrite of history, existing DTO unchanged; the checkpoint on the four sibling paths was honoured and scoped out explicitly.

## Residual Risk

Four sibling collection reads still fail whole on one bad row until the follow-up class fix lands (F-6F836337). Missing-installation sessions cannot be attached from this machine; the badge says so.

---

# 中文

## 概要

GUI「Agent」页出现横幅「读取 Agent Runtime 失败: Runtime installation claude_08d6a351836d8c1fd6c9c0ac was not found.」且其余内容不渲染(泽宇 2026-09-03 报告)。`packages/daemon/src/agent-runtime-read.ts` 组装每条 session DTO 时按本机 installation 见证解析 `installationId`,第一条找不到就抛 `runtime_installation_not_found`,一条历史 session 让整个 `repo.agentRuntime.overview` 读变成协议错误。canonical 台账实测 1,308 条 session 中 159 条引用本机已不再见证的四个 installation(仅旧 codex 安装就占 146),这是「本机安装被重新见证后读共享台账」的常态。

`sessionDto` 现在逐 session 降级:installation 缺失时 DTO 保留 session 自身身份,增加 `installationState: "missing"`、字段级 `installationError`(`runtime_installation_not_found` 与 hint)与 `attachCapability: "unsupported"`;`kindId` 取持久化的 definition snapshot 或 session 自身的 canonical kind,不从本机安装猜。installation 存在时 DTO 逐字节不变(golden 序列化测试)。overview 与单 session 读共用同一函数,单读保留结构化字段级诊断而不是整个请求失败。GUI 只改一个组件:`SessionsPanel.tsx` 显示灰态「Installation missing」徽章、tooltip 给 hint;横幅仍只由真实读错误触发。无条件 throw 删除;不做静默过滤。


第三轮回应首次 CI:`check-gui-status-judgments` 指出 `SessionsPanel.tsx` 内对 `installationState` 的点比较;该状态现登记进状态词表,徽章经登记的判定入口派生,不再在组件里点比较。不加 allowlist、不改门。

## 架构辩护

installation 是机器本地见证,session 在共享 canonical 台账里,center 与每个边缘读同一批 session 时各自看到不同子集为 `missing`。逐行降级是让共享读在每个节点都正确的唯一形状;迁移或改写历史 `installationId` 会篡改事实。只读,无并发主体。

## 机读声明

见英文块。

## 治理声明

未触碰 protected 路径。无 break-glass。

## 验证

- 修前在 canonical 台账复现:`repo.agentRuntime.overview` → `op_rejected` / `runtime_installation_not_found`,退出码 1。修后:`status=ready`、`totalSessions=1308`、`missingSessions=159`。
- worker 停止点(定向测试 + 本地 commit,不跑 `check:local`):daemon integration 15/15(新测试断言 overview ready、missing 字段、两个 wire validator 无错);GUI renderer 测试 30/30;implementation-contracts 129/129 delta 0;cli-error-codes、error-classification、file-complexity、line-density、test-selection、canonical-event-compat 通过;production-delta `+44/-7` 通过;`git diff --check` 干净。新测试文件经 `discoverTestFiles` 发现(481 → 482),首行 integration tier 标记。

## 评审证据

worker 报告见任务包 `artifacts/agent-runtime-read-missing-installation-report.md`(私有台账)。CEO 语义验收:逐 session 降级、保留身份、结构化字段级诊断、不静默过滤、不改写历史、既有 DTO 不变;四条同族路径的 checkpoint 被遵守并明确划出本包(fact F-6F836337,等 squad 实体迁移合入后按类修)。

## 残余风险

四条同族集合读在后续按类修复落地前仍会因一行坏记录整份失败(F-6F836337)。缺失 installation 的 session 在本机不能 attach,徽章如实说明。
