### PR TITLE
feat(squad): migrate legacy squad declarations into the entity store

### DIFF
--- a/packages/cli/src/cli/thin-command-router.ts
+++ b/packages/cli/src/cli/thin-command-router.ts
@@ -52,7 +52,7 @@ export function parseRouted(
         })
       : rejected(f.code, f.nextAction, json);
   }
-  if (route.id === "entity-migrate-adrs")
+  if (route.id === "entity-migrate-adrs" || route.id === "entity-migrate-squads")
     return parseProjected(route.id, args.slice(2), rootDir, repoId, json, inputs, {}, {}, route.method);
   if (
     route.id === "fact-rekey" ||

--- a/packages/cli/test/thin-command.test.ts
+++ b/packages/cli/test/thin-command.test.ts
@@ -154,6 +154,27 @@ test("ADR migration projects its registry and occurrence fences into one center 
   if (!missingSourceRoot.ok) assert.equal(missingSourceRoot.code, "missing_field");
 });
 
+test("Squad migration projects legacy sources and dry-run into one center Action", () => {
+  const parsed = parseThinCommand([
+    "migrate",
+    "squads",
+    "--source",
+    "harness/squads/ledger-squad.json",
+    "--source",
+    "harness/squads/debug-squad.json",
+    "--dry-run",
+  ]);
+  assert.equal(parsed.ok, true);
+  if (!parsed.ok) return;
+  assert.equal(parsed.command.method, "repo.task.run");
+  assert.deepEqual(parsed.command.action, {
+    kind: "entity-migrate-squads",
+    sourcePaths: ["harness/squads/ledger-squad.json", "harness/squads/debug-squad.json"],
+    dryRun: true,
+  });
+  assert.equal(parseThinCommand(["migrate", "squads", "--dry-run"]).ok, false);
+});
+
 test("capabilities is an exact-set projection of the command contract", () => {
   assert.deepEqual(deriveCliCapabilities(), {
     agenda: ["agenda"],
@@ -213,6 +234,7 @@ test("capabilities is an exact-set projection of the command contract", () => {
       "decision-digests-migrate",
       "dispatch-records-migrate",
       "entity-migrate-adrs",
+      "entity-migrate-squads",
       "fact-rekey",
       "ledger-migrate",
       "migrate-import",

--- a/packages/daemon/src/adr-entity-migration.ts
+++ b/packages/daemon/src/adr-entity-migration.ts
@@ -29,6 +29,7 @@ import {
 import { defaultAssets } from "../../preset/src/preset-resolver-common.ts";
 import { loadCanonicalAssets } from "../../preset/src/preset-assets.ts";
 import { runArtifactEntityImport } from "./artifact-entity-action.ts";
+import { migrationError } from "./repo-cell-errors.ts";
 import type { RepoCellBinding, RepoTaskAction } from "./repo-cell-types.ts";
 
 const ADR_KIND = "software/coding/architecture-decision-record@1";
@@ -682,8 +683,4 @@ function isDirectory(target: string): boolean {
 
 function isRegularFile(target: string): boolean {
   return existsSync(target) && lstatSync(target).isFile() && !lstatSync(target).isSymbolicLink();
-}
-
-function migrationError(code: string, message: string): never {
-  throw Object.assign(new Error(message), { code });
 }

--- a/packages/daemon/src/protocol/daemon-protocol-commands-agent.ts
+++ b/packages/daemon/src/protocol/daemon-protocol-commands-agent.ts
@@ -142,6 +142,32 @@ export const agentProtocolCommands = Object.freeze([
       ),
     ],
   }),
+  defineCenterForwardWriteCommand({
+    id: "entity-migrate-squads",
+    phase: "Governed-Entity-W1-F",
+    path: ["migrate", "squads"],
+    summary: "Install legacy Squad JSON declarations through the canonical Squad entity action.",
+    method: "repo.task.run",
+    inputs: [
+      cliInput(
+        "--source",
+        "repeated",
+        true,
+        {
+          code: "missing_field",
+          nextAction: "Add each legacy Squad declaration with --source <repo-relative-json>.",
+        },
+        { field: "sourcePaths" },
+      ),
+      cliInput(
+        "--dry-run",
+        "boolean",
+        false,
+        { code: "invalid_field", nextAction: "Use --dry-run once." },
+        { field: "dryRun" },
+      ),
+    ],
+  }),
   defineRuntimeLocalWriteCommand({
     id: "agent-create",
     phase: "Runtime-B",

--- a/packages/daemon/src/protocol/daemon-protocol-validate-task.ts
+++ b/packages/daemon/src/protocol/daemon-protocol-validate-task.ts
@@ -79,6 +79,15 @@ const adrMigrationProtocolInput = Object.freeze({
   exactlyOneOf: Object.freeze([]),
 });
 
+const squadMigrationProtocolInput = Object.freeze({
+  schema: "entity-action-input/v1",
+  fields: Object.freeze([
+    { field: "sourcePaths", type: "string-array" as const, required: true },
+    { field: "dryRun", type: "boolean" as const, required: false },
+  ]),
+  exactlyOneOf: Object.freeze([]),
+});
+
 const taskActionProtocolByIngress: ReadonlyMap<string, GeneratedTaskActionProtocolDeclaration> = new Map(
   generatedTaskActionProtocolDeclarations.map((action) => [action.execution.ingress, action] as const),
 );
@@ -90,6 +99,8 @@ export function validateCatalogActionPayload(value: JsonObject): readonly string
   if (declaration) return validateProjectedTaskActionInput(action.kind, declaration.input, action);
   if (action.kind === "entity-import")
     return validateProjectedTaskActionInput(action.kind, artifactEntityImportProtocolInput, action);
+  if (action.kind === "entity-migrate-squads")
+    return validateProjectedTaskActionInput(action.kind, squadMigrationProtocolInput, action);
   return action.kind === "entity-migrate-adrs"
     ? validateProjectedTaskActionInput(action.kind, adrMigrationProtocolInput, action)
     : [];

--- a/packages/daemon/src/protocol/daemon-protocol.contract.ts
+++ b/packages/daemon/src/protocol/daemon-protocol.contract.ts
@@ -697,6 +697,7 @@ export default Object.freeze({
     "PLT-EdgeGUI-W2",
     "Governed-Entity-W1-D",
     "Governed-Entity-W1-E",
+    "Governed-Entity-W1-F",
   ]),
   commands: daemonOwnedProtocolCommands,
   methods: Object.freeze([

--- a/packages/daemon/src/repo-cell-action-dispatch.ts
+++ b/packages/daemon/src/repo-cell-action-dispatch.ts
@@ -17,6 +17,7 @@ import { isDocAction, runArtifactAdd, runDocAction } from "./doc-sync-actions.ts
 import { runMigrationImport } from "./migration-import.ts";
 import { runFactRekey } from "./fact-rekey.ts";
 import { runDispatchRecordMigrationAction, runEventShapeMigrationAction } from "./repo-cell-migration-actions.ts";
+import { runSquadEntityMigration } from "./squad-entity-migration.ts";
 import { type RepoCellBinding, type RepoTaskAction } from "./repo-cell-types.ts";
 import { pullAndIngestCiObservations } from "./ci-observation-actions.ts";
 import { readTaskLineageDispatches } from "./dispatch-read.ts";
@@ -54,6 +55,7 @@ export async function executeAction(
   if (action.kind === "relation-events-migrate" || action.kind === "decision-digests-migrate")
     return runEventShapeMigrationAction(cell, eventShapeMigrations[action.kind], action, binding);
   if (action.kind === "dispatch-records-migrate") return runDispatchRecordMigrationAction(cell, action, binding);
+  if (action.kind === "entity-migrate-squads") return runSquadEntityMigration(cell, action, binding);
   if (action.kind === "projection-rebuild") {
     cell.settings.initializeFromAuthoredDocument(binding);
     const rebuilt = cell.projection.rebuild(),

--- a/packages/daemon/src/repo-cell-authorization.ts
+++ b/packages/daemon/src/repo-cell-authorization.ts
@@ -141,6 +141,8 @@ export function authorizeDurableRepoCellAction(
       return authorizeRepoCellAction(input);
     case "entity-migrate-adrs":
       return authorizeRepoCellAction(input);
+    case "entity-migrate-squads":
+      return authorizeRepoCellAction(input);
     case "fact-reclassify":
       return authorizeRepoCellAction(input);
     case "fact-record":

--- a/packages/daemon/src/repo-cell-errors.ts
+++ b/packages/daemon/src/repo-cell-errors.ts
@@ -16,6 +16,10 @@ export function cellCodedError(code: string, text: string): Error {
   return error;
 }
 
+export function migrationError(code: string, message: string): never {
+  throw Object.assign(new Error(message), { code });
+}
+
 export function cellCriterionError(
   code: string,
   text: string,

--- a/packages/daemon/src/squad-entity-migration.ts
+++ b/packages/daemon/src/squad-entity-migration.ts
@@ -10,6 +10,7 @@ import {
   type WriteReceiptDraft as WriteReceipt,
 } from "../../kernel/src/index.ts";
 import type { RepoCellOperationalContext } from "./repo-cell-action-context.ts";
+import { migrationError } from "./repo-cell-errors.ts";
 import type { RepoCellBinding, RepoTaskAction } from "./repo-cell-types.ts";
 
 // One-time cutover for direct-authored Squad declarations. Delete this command after the canonical
@@ -57,7 +58,8 @@ export async function runSquadEntityMigration(
       cell.entityActionRuntimes,
     );
 
-  if (action.dryRun === true) return previewReceipt(cell, action, binding, reportFor(candidates, true));
+  if (action.dryRun === true)
+    return squadMigrationPreviewReceipt(cell, action, binding, squadMigrationReport(candidates, true));
 
   let marker: WriteReceipt | null = null;
   for (const candidate of candidates) {
@@ -74,7 +76,7 @@ export async function runSquadEntityMigration(
         `Squad ${candidate.declaration.id} did not become visible at the canonical projection cut.`,
       );
   }
-  return appliedReceipt(cell, action, binding, reportFor(candidates, false), marker);
+  return squadMigrationAppliedReceipt(cell, action, binding, squadMigrationReport(candidates, false), marker);
 }
 
 function readCandidates(cell: RepoCellOperationalContext, value: unknown): readonly SquadMigrationCandidate[] {
@@ -171,7 +173,7 @@ function childOperationId(
   return cell.operationId(installAction(candidate, dryRun), binding, cell.input.repoId, candidate.currentRevision);
 }
 
-function reportFor(candidates: readonly SquadMigrationCandidate[], dryRun: boolean): SquadMigrationReport {
+function squadMigrationReport(candidates: readonly SquadMigrationCandidate[], dryRun: boolean): SquadMigrationReport {
   return {
     schema: "squad-entity-migration-report/v1",
     mode: dryRun ? "dry-run" : "apply",
@@ -200,7 +202,7 @@ function reportFor(candidates: readonly SquadMigrationCandidate[], dryRun: boole
   };
 }
 
-function previewReceipt(
+function squadMigrationPreviewReceipt(
   cell: RepoCellOperationalContext,
   action: RepoTaskAction,
   binding: RepoCellBinding,
@@ -226,7 +228,7 @@ function previewReceipt(
   };
 }
 
-function appliedReceipt(
+function squadMigrationAppliedReceipt(
   cell: RepoCellOperationalContext,
   action: RepoTaskAction,
   binding: RepoCellBinding,
@@ -253,8 +255,4 @@ function appliedReceipt(
 
 function duplicates(values: readonly string[]): readonly string[] {
   return [...new Set(values.filter((value, index) => values.indexOf(value) !== index))].sort();
-}
-
-function migrationError(code: string, message: string): never {
-  throw Object.assign(new Error(message), { code });
 }

--- a/packages/daemon/src/squad-entity-migration.ts
+++ b/packages/daemon/src/squad-entity-migration.ts
@@ -1,0 +1,260 @@
+import { existsSync, lstatSync, readFileSync } from "node:fs";
+import path from "node:path";
+import {
+  consumeKnownError,
+  normalizeRelativeDocumentPath,
+  parseSquadDeclarationV1,
+  resolveHarnessLayout,
+  stableStringify,
+  type SquadDeclarationV1,
+  type WriteReceiptDraft as WriteReceipt,
+} from "../../kernel/src/index.ts";
+import type { RepoCellOperationalContext } from "./repo-cell-action-context.ts";
+import type { RepoCellBinding, RepoTaskAction } from "./repo-cell-types.ts";
+
+// One-time cutover for direct-authored Squad declarations. Delete this command after the canonical
+// migration is recorded; normal Squad reads and writes remain on the entity action/projection path.
+interface SquadMigrationCandidate {
+  readonly source: string;
+  readonly target: string;
+  readonly declaration: SquadDeclarationV1;
+  readonly currentRevision: number;
+  readonly change: "install" | "replace" | "already-installed";
+}
+
+interface SquadMigrationReport {
+  readonly schema: "squad-entity-migration-report/v1";
+  readonly mode: "dry-run" | "apply";
+  readonly packageShape: {
+    readonly manifest: "squad.json";
+    readonly schema: "squad-declaration/v1";
+  };
+  readonly summary: {
+    readonly requested: number;
+    readonly installs: number;
+    readonly replacements: number;
+    readonly alreadyInstalled: number;
+  };
+  readonly squads: readonly {
+    readonly source: string;
+    readonly entityId: string;
+    readonly target: string;
+    readonly result: "would-install" | "would-replace" | "installed" | "replaced" | "already-installed";
+  }[];
+}
+
+export async function runSquadEntityMigration(
+  cell: RepoCellOperationalContext,
+  action: RepoTaskAction,
+  binding: RepoCellBinding,
+): Promise<WriteReceipt> {
+  const candidates = readCandidates(cell, action.sourcePaths);
+  for (const candidate of candidates)
+    await cell.entityActionExecutor.run(
+      installAction(candidate, true),
+      binding,
+      childOperationId(cell, candidate, binding, true),
+      cell.entityActionRuntimes,
+    );
+
+  if (action.dryRun === true) return previewReceipt(cell, action, binding, reportFor(candidates, true));
+
+  let marker: WriteReceipt | null = null;
+  for (const candidate of candidates) {
+    if (candidate.change === "already-installed") continue;
+    marker = await cell.entityActionExecutor.run(
+      installAction(candidate, false),
+      binding,
+      childOperationId(cell, candidate, binding, false),
+      cell.entityActionRuntimes,
+    );
+    if (marker.outcome !== "applied")
+      migrationError(
+        "squad_migration_incomplete",
+        `Squad ${candidate.declaration.id} did not become visible at the canonical projection cut.`,
+      );
+  }
+  return appliedReceipt(cell, action, binding, reportFor(candidates, false), marker);
+}
+
+function readCandidates(cell: RepoCellOperationalContext, value: unknown): readonly SquadMigrationCandidate[] {
+  if (!Array.isArray(value) || value.length === 0 || value.some((item) => typeof item !== "string" || !item.trim()))
+    migrationError("invalid_command", "sourcePaths must contain one or more repository-relative legacy Squad files.");
+  const sources = value.map((source) => portableSource(source as string));
+  if (new Set(sources).size !== sources.length)
+    migrationError("squad_migration_reconciliation_failed", "Legacy Squad sources must be unique.");
+
+  const candidates = sources.map((source) => readCandidate(cell, source));
+  const ids = candidates.map(({ declaration }) => declaration.id);
+  if (new Set(ids).size !== ids.length)
+    migrationError(
+      "squad_migration_reconciliation_failed",
+      `Legacy Squad sources contain duplicate entity ids: ${duplicates(ids).join(", ")}.`,
+    );
+  return candidates;
+}
+
+function readCandidate(cell: RepoCellOperationalContext, source: string): SquadMigrationCandidate {
+  const sourcePath = path.join(cell.rootDir, ...source.split("/"));
+  if (!existsSync(sourcePath) || !lstatSync(sourcePath).isFile() || lstatSync(sourcePath).isSymbolicLink())
+    migrationError("invalid_package", `Legacy Squad source ${source} is not a regular file.`);
+  let value: unknown;
+  try {
+    value = JSON.parse(readFileSync(sourcePath, "utf8"));
+  } catch (error) {
+    consumeKnownError(error);
+    migrationError("invalid_manifest", `Legacy Squad source ${source} is not valid JSON.`);
+  }
+  let declaration: SquadDeclarationV1;
+  try {
+    declaration = parseSquadDeclarationV1(value);
+  } catch (error) {
+    consumeKnownError(error);
+    migrationError(
+      "invalid_manifest",
+      `Legacy Squad source ${source} is invalid: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+  const targetPath = path.join(resolveHarnessLayout(cell.rootDir).authoredRoot, "squads", `${declaration.id}.json`),
+    target = normalizeRelativeDocumentPath(path.relative(cell.rootDir, targetPath).split(path.sep).join("/"));
+  if (path.resolve(sourcePath) !== path.resolve(targetPath))
+    migrationError(
+      "squad_migration_reconciliation_failed",
+      `Legacy Squad ${declaration.id} must be read from its canonical projection path ${target}; received ${source}.`,
+    );
+  const current = cell.projection.getEntity("squad", declaration.id),
+    change =
+      current === null
+        ? "install"
+        : stableStringify(current.value) === stableStringify(declaration)
+          ? "already-installed"
+          : "replace";
+  return {
+    source,
+    target,
+    declaration,
+    currentRevision: current?.workspaceRevision ?? 0,
+    change,
+  };
+}
+
+function portableSource(value: string): string {
+  try {
+    return normalizeRelativeDocumentPath(value);
+  } catch (error) {
+    consumeKnownError(error);
+    migrationError(
+      "invalid_command",
+      `Legacy Squad source must be a portable repository-relative path: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+  }
+}
+
+function installAction(candidate: SquadMigrationCandidate, dryRun: boolean): RepoTaskAction {
+  return {
+    kind: "squad-install",
+    declaration: candidate.declaration,
+    declarationSource: candidate.source,
+    expectedVersion: candidate.currentRevision,
+    ...(dryRun ? { dryRun: true } : {}),
+  };
+}
+
+function childOperationId(
+  cell: RepoCellOperationalContext,
+  candidate: SquadMigrationCandidate,
+  binding: RepoCellBinding,
+  dryRun: boolean,
+): string {
+  return cell.operationId(installAction(candidate, dryRun), binding, cell.input.repoId, candidate.currentRevision);
+}
+
+function reportFor(candidates: readonly SquadMigrationCandidate[], dryRun: boolean): SquadMigrationReport {
+  return {
+    schema: "squad-entity-migration-report/v1",
+    mode: dryRun ? "dry-run" : "apply",
+    packageShape: { manifest: "squad.json", schema: "squad-declaration/v1" },
+    summary: {
+      requested: candidates.length,
+      installs: candidates.filter(({ change }) => change === "install").length,
+      replacements: candidates.filter(({ change }) => change === "replace").length,
+      alreadyInstalled: candidates.filter(({ change }) => change === "already-installed").length,
+    },
+    squads: candidates.map(({ source, target, declaration, change }) => ({
+      source,
+      entityId: declaration.id,
+      target,
+      result:
+        change === "already-installed"
+          ? change
+          : dryRun
+            ? change === "install"
+              ? "would-install"
+              : "would-replace"
+            : change === "install"
+              ? "installed"
+              : "replaced",
+    })),
+  };
+}
+
+function previewReceipt(
+  cell: RepoCellOperationalContext,
+  action: RepoTaskAction,
+  binding: RepoCellBinding,
+  report: SquadMigrationReport,
+): WriteReceipt {
+  const revision = cell.store.readHead()?.revision ?? 0,
+    opId = cell.operationId({ ...action, dryRun: false }, binding, cell.input.repoId, revision);
+  return {
+    outcome: "pending",
+    opId: `preview:${opId}`,
+    revision,
+    evidence: JSON.stringify(report),
+    visibility: "center",
+    proof: {
+      committedRevision: revision,
+      appliedCut: revision,
+      durable: false,
+      canonicalVisible: false,
+      worktreeVisible: false,
+    },
+    authorizationDecision: binding.authorizationDecision,
+    nextAction: "Remove --dry-run to install every listed Squad through the canonical entity event stream.",
+  };
+}
+
+function appliedReceipt(
+  cell: RepoCellOperationalContext,
+  action: RepoTaskAction,
+  binding: RepoCellBinding,
+  report: SquadMigrationReport,
+  marker: WriteReceipt | null,
+): WriteReceipt {
+  const revision = marker?.revision ?? cell.store.readHead()?.revision ?? 0;
+  return {
+    outcome: "applied",
+    opId: marker?.opId ?? cell.operationId(action, binding, cell.input.repoId, revision),
+    revision,
+    evidence: JSON.stringify(report),
+    visibility: "center",
+    proof: marker?.proof ?? {
+      committedRevision: revision,
+      appliedCut: revision,
+      durable: true,
+      canonicalVisible: true,
+      worktreeVisible: true,
+    },
+    authorizationDecision: binding.authorizationDecision,
+  };
+}
+
+function duplicates(values: readonly string[]): readonly string[] {
+  return [...new Set(values.filter((value, index) => values.indexOf(value) !== index))].sort();
+}
+
+function migrationError(code: string, message: string): never {
+  throw Object.assign(new Error(message), { code });
+}

--- a/packages/daemon/test/command-admission.test.ts
+++ b/packages/daemon/test/command-admission.test.ts
@@ -123,6 +123,9 @@ test("Artifact import forwards edge observations into the center single-writer q
   const migration = daemonProtocolCommands.find(({ id }) => id === "entity-migrate-adrs");
   assert.deepEqual(migration?.admission, command?.admission);
   assert.equal(migration?.commandClass, "repo-write");
+  const squadMigration = daemonProtocolCommands.find(({ id }) => id === "entity-migrate-squads");
+  assert.deepEqual(squadMigration?.admission, command?.admission);
+  assert.equal(squadMigration?.commandClass, "repo-write");
 });
 
 test("Settings locale-only updates use local admission while repository fields keep center routing", () => {

--- a/packages/daemon/test/squad-entity-migration.integration.test.ts
+++ b/packages/daemon/test/squad-entity-migration.integration.test.ts
@@ -1,0 +1,190 @@
+// harness-test-tier: integration
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { makeTaskEventStore } from "../../kernel/src/index.ts";
+import { canonicalRoot, workspaceId } from "../src/protocol/daemon-protocol.contract.ts";
+import { openBootstrappedRepoCell as openRepoCell } from "./repo-settings.fixture.ts";
+import { evidence, git, initRepo } from "./task-surface.fixtures.ts";
+
+const owner = {
+    actor: {
+      principal: { personId: "person-squad-migration" },
+      executor: { kind: "agent" as const, id: "squad-migration-worker" },
+    },
+    source: "local" as const,
+  },
+  leader = {
+    schema: "agent-declaration/v1",
+    id: "migration-leader",
+    name: "Migration Leader",
+    instructions: "Coordinate the migration fixture workers.",
+    runtime_type: "codex",
+  },
+  worker = {
+    schema: "agent-declaration/v1",
+    id: "migration-worker",
+    name: "Migration Worker",
+    instructions: "Complete one migration fixture assignment.",
+    runtime_type: "codex",
+  },
+  squadIds = ["ci-triage-squad", "debug-squad", "gui-squad", "ledger-squad", "ontology-squad"] as const;
+
+test("five legacy Squad declarations dry-run, install, and surface through canonical CLI and GUI reads", async () => {
+  const rootDir = workspace("five"),
+    repoId = workspaceId("squad-entity-migration-five"),
+    declarations = squadIds.map((id, index) => squad(id, index + 4)),
+    sources = declarations.map((declaration) => writeLegacySquad(rootDir, declaration));
+  git(rootDir, "add", "harness/squads");
+  git(rootDir, "commit", "-qm", "seed legacy Squad declarations");
+  let cell: Awaited<ReturnType<typeof openRepoCell>> | undefined;
+  try {
+    cell = await openRepoCell({ repoId, rootDir: canonicalRoot(rootDir), ownerId: "squad-entity-migration-five" });
+    for (const declaration of [leader, worker])
+      assert.equal((await cell.run({ kind: "agent-install", declaration }, owner)).outcome, "applied");
+
+    assert.deepEqual((evidence(await cell.run({ kind: "squad-list" }, owner)).squads as unknown[]).length, 0);
+    const revisionBefore = makeTaskEventStore({ repoId, rootDir, mutable: false }).read().revision,
+      preview = await cell.run({ kind: "entity-migrate-squads", sourcePaths: sources, dryRun: true }, owner),
+      previewReport = evidence(preview) as unknown as MigrationReport;
+    assert.equal(preview.outcome, "pending", JSON.stringify(preview));
+    assert.equal(previewReport.mode, "dry-run");
+    assert.deepEqual(previewReport.packageShape, { manifest: "squad.json", schema: "squad-declaration/v1" });
+    assert.deepEqual(previewReport.summary, {
+      requested: 5,
+      installs: 5,
+      replacements: 0,
+      alreadyInstalled: 0,
+    });
+    assert.equal(
+      makeTaskEventStore({ repoId, rootDir, mutable: false }).read().revision,
+      revisionBefore,
+      "dry-run must not append Squad entity events",
+    );
+
+    const applied = await cell.run({ kind: "entity-migrate-squads", sourcePaths: sources }, owner),
+      appliedReport = evidence(applied) as unknown as MigrationReport;
+    assert.equal(applied.outcome, "applied", JSON.stringify(applied));
+    assert.equal(appliedReport.mode, "apply");
+    assert.deepEqual(
+      appliedReport.squads.map(({ entityId, result }) => ({ entityId, result })),
+      declarations.map(({ id }) => ({ entityId: id, result: "installed" })),
+    );
+
+    const listed = evidence(await cell.run({ kind: "squad-list" }, owner)).squads as Array<{
+        id: string;
+        leader: string;
+        workers: string[];
+      }>,
+      generic = evidence(await cell.run({ kind: "entity-list", entityKind: "squad" }, owner)).entities as Array<{
+        id: string;
+        value: Record<string, unknown>;
+      }>,
+      gui = await cell.read("repo.squad.entities.list", {}, owner),
+      detail = await cell.read("repo.squad.entity.read", { squadId: "ledger-squad" }, owner);
+    assert.deepEqual(
+      listed.map(({ id }) => id),
+      [...squadIds].sort(),
+    );
+    assert.deepEqual(
+      generic.map(({ id }) => id),
+      [...squadIds].sort(),
+    );
+    assert.deepEqual(
+      generic.map(({ value }) => value),
+      [...declarations].sort((left, right) => left.id.localeCompare(right.id)),
+    );
+    assert.deepEqual(
+      gui.squads.map(({ id }) => id),
+      [...squadIds].sort(),
+    );
+    const { schema: _schema, ...ledgerSquad } = declarations.find(({ id }) => id === "ledger-squad")!;
+    assert.deepEqual(detail.squad, ledgerSquad);
+    for (const declaration of declarations)
+      assert.equal(
+        readFileSync(path.join(rootDir, `harness/squads/${declaration.id}.json`), "utf8"),
+        `${JSON.stringify(declaration, null, 2)}\n`,
+      );
+
+    const revisionAfter = makeTaskEventStore({ repoId, rootDir, mutable: false }).read().revision,
+      repeated = await cell.run({ kind: "entity-migrate-squads", sourcePaths: sources }, owner),
+      repeatedReport = evidence(repeated) as unknown as MigrationReport;
+    assert.equal(repeated.outcome, "applied", JSON.stringify(repeated));
+    assert.equal(repeatedReport.summary.alreadyInstalled, 5);
+    assert.equal(makeTaskEventStore({ repoId, rootDir, mutable: false }).read().revision, revisionAfter);
+  } finally {
+    await cell?.close();
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});
+
+test("Squad migration rejects a declaration missing leader before appending any entity event", async () => {
+  const rootDir = workspace("missing-leader"),
+    repoId = workspaceId("squad-entity-migration-missing-leader"),
+    declaration = squad("invalid-squad", 4),
+    { leader: _leader, ...missingLeader } = declaration,
+    source = writeLegacySquad(rootDir, missingLeader);
+  git(rootDir, "add", "harness/squads");
+  git(rootDir, "commit", "-qm", "seed invalid legacy Squad declaration");
+  let cell: Awaited<ReturnType<typeof openRepoCell>> | undefined;
+  try {
+    cell = await openRepoCell({
+      repoId,
+      rootDir: canonicalRoot(rootDir),
+      ownerId: "squad-entity-migration-missing-leader",
+    });
+    const before = makeTaskEventStore({ repoId, rootDir, mutable: false }).read().revision,
+      rejected = await cell.run({ kind: "entity-migrate-squads", sourcePaths: [source] }, owner);
+    assert.equal(rejected.outcome, "op_rejected", JSON.stringify(rejected));
+    assert.equal(rejected.code, "invalid_manifest");
+    assert.match(String(rejected.nextAction), /missing required field "leader"/u);
+    assert.equal(makeTaskEventStore({ repoId, rootDir, mutable: false }).read().revision, before);
+    assert.deepEqual(
+      evidence(await cell.run({ kind: "entity-list", entityKind: "squad" }, owner)).entities as unknown[],
+      [],
+    );
+  } finally {
+    await cell?.close();
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});
+
+interface MigrationReport {
+  readonly mode: "dry-run" | "apply";
+  readonly packageShape: { readonly manifest: string; readonly schema: string };
+  readonly summary: {
+    readonly requested: number;
+    readonly installs: number;
+    readonly replacements: number;
+    readonly alreadyInstalled: number;
+  };
+  readonly squads: readonly { readonly entityId: string; readonly result: string }[];
+}
+
+function squad(id: string, leaderTurnBudget: number) {
+  return {
+    schema: "squad-declaration/v1",
+    id,
+    name: `${id} migration fixture`,
+    leader: leader.id,
+    workers: [worker.id],
+    leaderTurnBudget,
+    roster: `${id}: migration-worker handles the bounded fixture.\n\nSummary -> artifacts/reports/{squadRunId}.md`,
+  };
+}
+
+function writeLegacySquad(rootDir: string, declaration: { readonly id: string }): string {
+  const directory = path.join(rootDir, "harness", "squads"),
+    relative = `harness/squads/${declaration.id}.json`;
+  mkdirSync(directory, { recursive: true });
+  writeFileSync(path.join(rootDir, relative), `${JSON.stringify(declaration, null, 2)}\n`);
+  return relative;
+}
+
+function workspace(name: string): string {
+  const rootDir = mkdtempSync(path.join(tmpdir(), `ha-squad-entity-migration-${name}-`));
+  initRepo(rootDir);
+  return rootDir;
+}

--- a/packages/daemon/test/validator-diagnostic-contract.test.ts
+++ b/packages/daemon/test/validator-diagnostic-contract.test.ts
@@ -97,6 +97,31 @@ test("ADR migration wire input requires its source root and accepts an optional 
   );
 });
 
+test("Squad migration wire input is limited to legacy source paths and dry-run", () => {
+  const payload = {
+    payload: {
+      action: {
+        kind: "entity-migrate-squads",
+        sourcePaths: ["harness/squads/ledger-squad.json"],
+        dryRun: true,
+      },
+    },
+  } as JsonObject;
+  assert.deepEqual(validateCatalogActionPayload(payload), []);
+  assert.match(
+    validateCatalogActionPayload({
+      payload: { action: { ...payload.payload.action, sourcePaths: "harness/squads/ledger-squad.json" } },
+    } as JsonObject).join("\n"),
+    /action\.sourcePaths.*must be string-array/u,
+  );
+  assert.match(
+    validateCatalogActionPayload({
+      payload: { action: { ...payload.payload.action, declaration: {} } },
+    } as JsonObject).join("\n"),
+    /action\.declaration.*not declared/u,
+  );
+});
+
 const relationGraph = {
     ok: true,
     status: "ready",

--- a/packages/kernel/src/domain/default-policy.ts
+++ b/packages/kernel/src/domain/default-policy.ts
@@ -28,6 +28,7 @@ const repositoryWriteActions = Object.freeze([
   "doc-submit",
   "entity-import",
   "entity-migrate-adrs",
+  "entity-migrate-squads",
   "fact-reclassify",
   "fact-record",
   "fact-rekey",

--- a/packages/kernel/test/contracts/authorization-port.test.ts
+++ b/packages/kernel/test/contracts/authorization-port.test.ts
@@ -47,7 +47,8 @@ test("the default Policy covers the frozen durable inventory exactly once", () =
   // Action 进入 durable inventory(CEO 确认,与 rekey-facts 同角色),107 → 109。
   // task_046460a29d5a147d3c9ecf7f92:dispatch-records-migrate 从 canonical 派工副本恢复事件,109 → 110。
   // 2026-09-03 W1-E:center-only ADR migration 进入 durable inventory(CEO 已裁 cutover),110 → 111。
-  assert.equal(durablePolicyActions.length, 111);
+  // 2026-09-03 W1-F:center-only Squad migration 进入 durable inventory(CEO 已裁 cutover),111 → 112。
+  assert.equal(durablePolicyActions.length, 112);
   // 其余两条是自洽不变量,不需要第二个硬编码数字:清单内无重复(三个角色分段互不重叠),
   // 且每个 durable Action 恰好被一条 rule 覆盖。
   assert.equal(new Set(durablePolicyActions).size, durablePolicyActions.length);


### PR DESCRIPTION
# English

## Summary

The GUI "Agent · Squad" page listed 0 squads and `ha squad list` / `ha entity list squad` agreed (reported by 泽宇 on 2026-09-03). The five legacy `squad-declaration/v1` files under `harness/squads/` were never installed on the squad entity road: `ha squad install --source` accepts only an entity package directory, and squad is one of the GovernedEntity kinds not yet migrated. Nothing in production reads those JSON files directly, so until they are published as entities every squad consumer sees an empty projection.

This PR adds `ha migrate squads --source <repo-relative-json>... [--dry-run]` (task_b53540f84e816031169a93a48a). The command is a center-forward write: one RepoCell queue preflights every source, then each changed declaration is published through the existing `squad-install` entity action; the materializer rewrites `harness/squads/<id>.json` as the entity-owned projection with the normalized content, so the old files become read-only projections rather than a second authored copy. Re-running the apply is idempotent at the entity-value level (`already-installed`, no duplicate events); a missing `leader` is rejected before any write. No legacy read fallback is added and the GUI keeps reading the entity projection only. The migration module is the only direct reader of the legacy files and is marked one-time, to be deleted once the canonical migration is recorded.


Round 2 answered the first CI run: the `migrationError` helper duplicated in `adr-entity-migration.ts` was extracted to one shared definition (duplicate-definitions gate), and the derived contracts / schema closure were regenerated for the new `migrate squads` command descriptor, which also cleared the fast-contract, crlf-checkout and node26 snapshot failures. No allowlist or gate change.

## Architectural Justification

Squad entities are installed through the center's single-writer queue; the entity id is the squad id, so a concurrent edge invocation reaches the same queue, observes the first batch's values and reports `already-installed` instead of appending duplicates. Edges do not install locally. The rejected alternative, GUI reading `harness/squads/*.json`, would create a second source of truth that drifts from the entity road.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none

## Machine-Readable Declarations

Production-Delta: +307/-5
Dependency-Change: none

### Optional Evidence Claims

none

## Task And Scope

task_b53540f84e816031169a93a48a (GovernedEntity root task_e91dd004d2a4e7a7c90a6fd40a). Scope: new `packages/daemon/src/squad-entity-migration.ts`, the `migrate squads` command descriptor in `daemon-protocol-commands-agent.ts`, admission/validation/dispatch/authorization wiring, thin CLI router, `default-policy.ts` (one line), tests. The canonical apply (backup tag → dry-run → apply for the five named files) is a CEO operation after merge; `harness/squads/` also holds declarations beyond the five plus one duplicate-conflict artifact for `entity-squad`, which stay out of this migration set until resolved.

## Version Impact

None.

## Governance Declaration

No protected path touched. No break-glass.

## Verification

- Worker stop point (targeted tests + local commit, no `check:local`): focused Node tests 54 passed (package install/list, five-file migration, GUI/entity list, idempotency, missing-leader negative); post-commit selection 32 passed; typecheck, lint, CLI help/error, write-road registry, implementation-contract, import-boundary, canonical-event-compat (171 samples / 17 schemas), gate self-tests 184, file-complexity, line-density pass; production-delta `+303/-1`.
- Dry-run evidence: the five canonical files copied into a disposable repository and run through the new action produce a `squad-entity-migration-report/v1` with all five `install` entries and no writes to the canonical repository. Fact F-8D267A12 on the task.
- New test file discovered by `discoverTestFiles` (481 → 482) with the integration tier marker on line 1.

## Review Evidence

Worker report: `harness/tasks/task_b53540f84e816031169a93a48a-*/artifacts/squad-entity-migration-report.md` (private ledger). CEO semantic review: migration is the only path (no fallback), center-forward and idempotent, old files become entity-owned projections, the multi-node question is answered by the single-writer queue, and the residual directory contents are named rather than silently included.

## Residual Risk

Until the CEO applies the migration on the canonical ledger the GUI still shows 0 squads. The one-time migration module remains until the canonical apply is recorded. This PR adds a command descriptor to `daemon-protocol-commands-agent.ts`, which PR #2177 also edits; whichever merges second rebases.

---

# 中文

## 概要

GUI「Agent · 含 Squad」页显示 0 个 squad,`ha squad list` / `ha entity list squad` 也是 0(泽宇 2026-09-03 报告)。`harness/squads/` 下五份旧版 `squad-declaration/v1` 从未安装到 squad 实体路:`ha squad install --source` 只接受实体包目录,而 squad 是 GovernedEntity 里尚未迁移的实体之一。生产里没有任何路径直接读这些 JSON,所以在它们作为实体发布之前,所有 squad 消费方看到的都是空投影。

本 PR 新增 `ha migrate squads --source <仓内 json>... [--dry-run]`(task_b53540f84e816031169a93a48a)。命令是中心前向写:一个 RepoCell 队列预检全部来源,再把每份有变化的声明经既有 `squad-install` 实体动作发布;materializer 把 `harness/squads/<id>.json` 重写为实体拥有的投影(内容规范化),旧文件成为只读投影而不是第二份 authored 副本。重复执行在实体值层幂等(`already-installed`,不追加重复事件);缺 `leader` 的声明在任何写入前被拒。不加旧读兜底,GUI 继续只读实体投影。迁移模块是唯一直接读旧文件的地方,标为一次性,canonical 迁移落账后删除。


第二轮回应首次 CI:与 `adr-entity-migration.ts` 重复的 `migrationError` 抽成一处共用(duplicate-definitions 门),并为新的 `migrate squads` 命令描述符再生派生契约与 schema 闭包,fast-contract、crlf-checkout、node26 三个快照失败随之清除。不加 allowlist、不改门。

## 架构辩护

squad 实体经中心单写队列安装,实体 id 即 squad id,并发的边缘调用到达同一队列,看到第一批的值后报 `already-installed` 而不是重复追加;边缘不本地安装。被否方案「GUI 直读 `harness/squads/*.json`」会造出与实体路漂移的第二真源。

## 机读声明

见英文块。

## 治理声明

未触碰 protected 路径。无 break-glass。

## 验证

- worker 停止点(定向测试 + 本地 commit,不跑 `check:local`):定向 Node 测试 54 通过(包安装/列表、五文件迁移、GUI/实体列表、幂等、缺 leader 阴性);提交后选择集 32 通过;typecheck、lint、CLI help/error、write-road registry、implementation-contract、import-boundary、canonical-event-compat(171 样本 / 17 schema)、门自测 184、file-complexity、line-density 通过;production-delta `+303/-1`。
- dry-run 证据:五份 canonical 文件复制到一次性仓库跑新动作,产出 `squad-entity-migration-report/v1`,五条均为 `install`,canonical 仓库无写入。任务上 fact F-8D267A12。
- 新测试文件经 `discoverTestFiles` 发现(481 → 482),首行 integration tier 标记。

## 评审证据

worker 报告见任务包 `artifacts/squad-entity-migration-report.md`(私有台账)。CEO 语义验收:迁移是唯一路径(无兜底)、中心前向且幂等、旧文件变为实体拥有的投影、多节点问题由单写队列回答、目录里的额外内容被点名而不是静默纳入。

## 残余风险

CEO 在 canonical 台账上实跑迁移前,GUI 仍显示 0 个 squad。一次性迁移模块保留到 canonical 迁移落账。本 PR 在 `daemon-protocol-commands-agent.ts` 加了命令描述符,PR #2177 也改该文件,后合入者 rebase。
