### PR TITLE
fix(gui): restore the html artifact webview sizing rule

### DIFF
--- a/packages/gui/src/renderer/components/HtmlArtifactPreview.tsx
+++ b/packages/gui/src/renderer/components/HtmlArtifactPreview.tsx
@@ -61,7 +61,7 @@ export function HtmlArtifactPreview({
       </header>
       <div
         ref={hostRef}
-        className={fillAvailable ? "min-h-0 min-w-0 flex-1 overflow-hidden bg-white" : "min-h-[42rem] bg-white"}
+        className={fillAvailable ? "min-h-0 min-w-0 flex-1 overflow-hidden bg-white" : "h-[42rem] bg-white"}
         data-testid="html-artifact-host"
       />
     </section>

--- a/packages/gui/src/renderer/styles.css
+++ b/packages/gui/src/renderer/styles.css
@@ -374,6 +374,17 @@ html[data-theme="light"] ::selection {
   border: 0;
 }
 
+/* Electron guest surface sizing; class-based so the strict host CSP remains unchanged.
+ * Without this rule the webview keeps Chromium's ~150px replaced-element default and the
+ * host's bg-white paints the rest — the preview clipped after its first card. display must
+ * stay flex (not block): with block the guest WebContents stops tracking the element's
+ * height and stays at the 150px default, clipping the guest the same way. */
+.html-artifact-webview {
+  display: flex;
+  width: 100%;
+  height: 100%;
+}
+
 /*
  * Agent Runtime 配置平面（原型 agent-runtime-prototype.html 的视觉语言）
  * 只有这些形状在 Tailwind 工具类里表达不动，或需要成对出现才有意义，才落到这里。

--- a/packages/gui/test-support/resident-daemon.mjs
+++ b/packages/gui/test-support/resident-daemon.mjs
@@ -32,6 +32,7 @@ export async function startGuiResidentDaemonFixture({
       1_000,
     );
     if (bootstrapped.ok !== true) throw new Error(`GUI daemon bootstrap failed: ${JSON.stringify(bootstrapped)}`);
+    let packagePath = null;
     if (task) {
       const created = await requestDaemonJsonRpcAt(
         daemon.endpoint,
@@ -40,6 +41,7 @@ export async function startGuiResidentDaemonFixture({
         1_000,
       );
       if (created.ok !== true) throw new Error(`GUI daemon task fixture failed: ${JSON.stringify(created)}`);
+      packagePath = String(created.packagePath);
       await realizeTaskPlanFixture(
         rootDir,
         String(created.packagePath),
@@ -64,6 +66,7 @@ export async function startGuiResidentDaemonFixture({
       userRoot,
       daemonId,
       repoId,
+      packagePath,
       endpoint: daemon.endpoint,
       env: { HARNESS_DAEMON_USER_ROOT: userRoot, HARNESS_DAEMON_ID: daemonId, HARNESS_DAEMON_REPO_ID: repoId },
       stop,

--- a/packages/gui/test/artifacts-view.vitest.ts
+++ b/packages/gui/test/artifacts-view.vitest.ts
@@ -307,9 +307,17 @@ describe("artifacts timeline — list, preview, and task jump", () => {
     const host = container.querySelector<HTMLElement>('[data-testid="html-artifact-host"]');
     expect(host?.classList.contains("flex-1")).toBe(true);
     expect(host?.classList.contains("min-h-0")).toBe(true);
+    // 尺寸契约:webview 类必须给出撑满 host 的显式宽高。没有这条规则,Electron 的
+    // webview 元素保持 Chromium 替换元素默认值(宽 300 高 150),宿主 bg-white 涂满
+    // 剩余空间——即「只显示标题与第一张卡片」的截断(task_419dc330)。
+    // display 必须是 flex 而非 block:block 下 guest WebContents 不再跟随元素高度,
+    // 停在 150px 默认值,肉眼看到的截断完全一样(e2e artifacts-html-preview 实测)。
     const styles = readFileSync("src/renderer/styles.css", "utf8");
-    expect(styles).not.toMatch(/\.html-artifact-webview\s*\{/u);
-    expect(styles).not.toMatch(/\.html-artifact-preview-fill \.html-artifact-webview\s*\{/u);
+    const webviewRule = styles.match(/\.html-artifact-webview\s*\{([^}]*)\}/u)?.[1];
+    expect(webviewRule).toContain("display: flex");
+    expect(webviewRule).toContain("width: 100%");
+    expect(webviewRule).toContain("height: 100%");
+    expect(webview?.classList.contains("html-artifact-webview")).toBe(true);
   });
 
   it("renders a Markdown artifact with the shared markdown reader, not a webview", async () => {

--- a/packages/gui/test/task-detail-expression.vitest.ts
+++ b/packages/gui/test/task-detail-expression.vitest.ts
@@ -408,6 +408,11 @@ describe("Task detail expression", () => {
     expect(webview.getAttribute("partition")).toBe("html-artifact-preview");
     expect(webview.getAttribute("preload")).toBeNull();
     expect(webview.getAttribute("src")).toMatch(/^data:text\/html;charset=utf-8,/u);
+    // 非 fill 布局:host 必须是定高(h-[42rem]),webview 的 height:100% 才有可解析的
+    // 百分比基准;只给 min-height 时 webview 会落回 150px 默认高(task_419dc330)。
+    const host = byTestId("html-artifact-host");
+    expect(host.classList.contains("h-[42rem]")).toBe(true);
+    expect(webview.classList.contains("html-artifact-webview")).toBe(true);
   });
 });
 

--- a/tools/gui-e2e/catalog.mjs
+++ b/tools/gui-e2e/catalog.mjs
@@ -8,6 +8,7 @@ import terminalSidebar from "./scenarios/terminal-sidebar.mjs";
 import terminalTaskTree from "./scenarios/terminal-task-tree.mjs";
 import decisions from "./scenarios/decisions.mjs";
 import sessionsArtifacts from "./scenarios/sessions-artifacts.mjs";
+import artifactsHtmlPreview from "./scenarios/artifacts-html-preview.mjs";
 import settings from "./scenarios/settings-appearance.mjs";
 
 export const catalog = [
@@ -21,6 +22,7 @@ export const catalog = [
   terminalTaskTree,
   decisions,
   sessionsArtifacts,
+  artifactsHtmlPreview,
   settings,
 ];
 

--- a/tools/gui-e2e/lanes.mjs
+++ b/tools/gui-e2e/lanes.mjs
@@ -1,6 +1,27 @@
+import { mkdirSync, writeFileSync } from "node:fs";
+import path from "node:path";
 import { startGuiResidentDaemonFixture } from "../../packages/gui/test-support/resident-daemon.mjs";
 import { seedTriadicEvents, writeTriadicLedger } from "../../packages/gui/test-support/triadic-ledger.mjs";
 import { warmDaemonProjection } from "../e2e-probe.mjs";
+
+// Long script-free HTML report: tall enough that a 150px-default webview clips after
+// the first section, so the preview-height scenario measures real guest-side scrolling.
+function writeHtmlPreviewArtifact(rootDir, packagePath) {
+  const artifactsRoot = path.join(rootDir, "harness", packagePath, "artifacts");
+  mkdirSync(artifactsRoot, { recursive: true });
+  const sections = Array.from(
+    { length: 24 },
+    (_, index) =>
+      `<section><h2>第 ${index + 1} 段</h2><p>夜班战报第 ${index + 1} 段正文,占位三行,保证总高远超单屏。</p>` +
+      `<p>第二段正文,占位,加高页面。</p></section>`,
+  ).join("\n");
+  writeFileSync(
+    path.join(artifactsRoot, "preview-height.html"),
+    `<!doctype html>\n<html lang="zh-CN">\n<head><meta charset="utf-8"><title>Preview height probe</title></head>\n` +
+      `<body style="margin:0;padding:16px;font:14px/1.7 system-ui">\n<h1>Preview height probe</h1>\n` +
+      `${sections}\n</body>\n</html>\n`,
+  );
+}
 
 export async function openLane({ lane, workspaceRoot, env, runRoot, startDriver }) {
   if (lane === "canonical") {
@@ -25,6 +46,7 @@ export async function openLane({ lane, workspaceRoot, env, runRoot, startDriver 
     else process.env.TMPDIR = originalTmpdir;
   }
   writeTriadicLedger(fixture.rootDir);
+  writeHtmlPreviewArtifact(fixture.rootDir, fixture.packagePath);
   const isolatedEnv = { ...env, ...fixture.env, HARNESS_DAEMON_ENDPOINT: fixture.endpoint };
   const driver = await startDriver({
     workspaceRoot,

--- a/tools/gui-e2e/scenarios/artifacts-html-preview.mjs
+++ b/tools/gui-e2e/scenarios/artifacts-html-preview.mjs
@@ -1,0 +1,53 @@
+import assert from "node:assert/strict";
+import { nav } from "./helpers.mjs";
+
+// The guest WebContents attaches asynchronously after the embedder element mounts, and it
+// is the surface the reader actually sees — the element alone can be full height while the
+// guest stays at Chromium's 150px default (display:block on the element does exactly that).
+async function guestViewportHeight(app, scale) {
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    const size = await app.evaluate(({ webContents }) => {
+      const guest = webContents
+        .getAllWebContents()
+        .find((contents) => contents.getURL().startsWith("data:text/html;charset=utf-8,"));
+      if (!guest) return { width: -1, height: -1 };
+      return guest.capturePage().then((image) => image.getSize());
+    });
+    if (size.height > 0) return Math.round(size.height / scale);
+    await new Promise((resolve) => setTimeout(resolve, 250));
+  }
+  return -1;
+}
+
+export default {
+  id: "artifacts-html-preview",
+  feature: "sessions-artifacts",
+  lane: "isolated",
+  description: "An HTML artifact preview fills its host box so long reports scroll inside the webview.",
+  async run({ app, page }) {
+    await nav(page, /^(?:产物|Artifacts)$/u, "artifacts-view");
+    await page.getByTestId("artifact-focus-task-gui-smoke-artifacts/preview-height.html").click();
+    await page.getByTestId("html-artifact-webview").waitFor();
+    const measured = await page.evaluate(() => {
+      const host = globalThis.document.querySelector('[data-testid="html-artifact-host"]');
+      const webview = globalThis.document.querySelector('[data-testid="html-artifact-webview"]');
+      const scale = globalThis.devicePixelRatio || 1;
+      if (host === null || webview === null) return { host: -1, element: -1, scale };
+      return {
+        host: Math.round(host.getBoundingClientRect().height),
+        element: Math.round(webview.getBoundingClientRect().height),
+        scale,
+      };
+    });
+    const guest = await guestViewportHeight(app, measured.scale);
+    assert.ok(
+      measured.element >= measured.host * 0.9,
+      `webview element ${measured.element}px is under 90% of host ${measured.host}px`,
+    );
+    assert.ok(
+      guest >= measured.host * 0.9,
+      `webview guest viewport ${guest}px is under 90% of host ${measured.host}px` +
+        ` (element ${measured.element}px) — the guest stopped tracking the element height`,
+    );
+  },
+};


### PR DESCRIPTION
# English

## Summary

The GUI artifacts page rendered an HTML artifact preview as only its title and first card, clipped, with the rest of the panel white (reported by 泽宇 on 2026-09-03 with `night-report-20260902.html`). Root cause, with measurements: commit 44d27e465 ("make the renderer adaptive") meant to remove a duplicated `min-height: 42rem` but deleted the whole `.html-artifact-webview` sizing rule from `styles.css` and flipped the test into a negative assertion, so the Electron `<webview>` fell back to Chromium's 300×150 replaced-element default while the white host filled the rest. A second, non-obvious layer: with `display: block` the element fills the host but the guest WebContents keeps a 150 px viewport; only `display: flex` (or an explicit inline height) makes the guest track the element (probe on Electron 42.5.1: block+height:100% → element 800×600, guest 150; flex+height:100% → guest 600).

Fix (task_419dc330dce9608757a6d96217): restore `.html-artifact-webview { display: flex; width: 100%; height: 100% }` (no `min-height`, honouring the earlier de-duplication), and change the non-fill host from `min-h-[42rem]` to `h-[42rem]` because a min-height is not a percentage-height base. Isolation (`javascript=no`, `sandbox=yes`, partition, webSecurity) is untouched. Before/after in the isolated e2e lane: artifacts page host 526 px, webview element and guest 478×150 before, 478×526 after; task-detail file page 850×588 after; a 2,400 px wheel scroll changes the guest content. The e2e assertion measures the guest viewport, not the element, and the rule-reverted-to-block control fails with `webview guest viewport 150px is under 90% of host 526px`. The vitest that asserted the rule's absence now asserts its presence.

## Architectural Justification

Renderer-only change; the preview reads a local artifact through a data URL inside the same sandboxed partition. No write, no concurrency subject.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none

## Machine-Readable Declarations

Production-Delta: +78/-1
Dependency-Change: none

### Optional Evidence Claims

none

## Task And Scope

task_419dc330dce9608757a6d96217 (PLT-Ontology root task_5fc5080044fcfdbf548008f2f5, GUI line). Scope: `packages/gui/src/renderer/styles.css`, `HtmlArtifactPreview.tsx`, two vitest files, and the GUI e2e catalog/lanes plus a new `artifacts-html-preview` scenario under `tools/gui-e2e/`.

## Version Impact

None.

## Governance Declaration

No protected path touched (`tools/gui-e2e/**` is the GUI e2e scenario catalog, not a gate or allowlist). No break-glass.

## Verification

- Worker stop point (targeted tests + local commit, no `check:local`): `artifacts-view.vitest.ts` and `task-detail-expression.vitest.ts` pass; GUI build passes; new e2e scenario `artifacts-html-preview` passes in the isolated lane (guest viewport ≥ 90% of host on both layouts, scroll changes guest content); the `display: block` control fails the same scenario with the message above. Fact F-ECBBB586 on the task.
- Production delta from the official gate: `+78/-1`.

## Review Evidence

Worker report: `harness/tasks/task_419dc330dce9608757a6d96217-*/artifacts/gui-html-artifact-preview-clip-report.md` (private ledger). CEO semantic review: root cause is the container not the artifact, both layers are evidenced with measurements, isolation unchanged, the fix is a CSS rule plus one class, and the regression test measures what actually clips (guest viewport).

## Residual Risk

The e2e scenario needs an Electron binary; CI lanes without one skip it by the existing named rule, so the vitest presence assertion is the always-on guard.

---

# 中文

## 概要

GUI 产物页的 HTML 产物预览只渲染标题和第一张卡片、卡片被裁、面板其余全白(泽宇 2026-09-03 以 `night-report-20260902.html` 报告)。根因(带实测):44d27e465「make the renderer adaptive」本意只删重复的 `min-height: 42rem`,实际把 `styles.css` 里整条 `.html-artifact-webview` 尺寸规则删了,还把测试改成负向断言,于是 Electron `<webview>` 落回 Chromium 替换元素默认的 300×150,白色宿主填满其余部分。第二层反直觉:`display: block` 时元素撑满宿主但 guest WebContents 视口仍是 150 px,只有 `display: flex`(或显式内联高度)能让 guest 跟随元素(Electron 42.5.1 探针:block+height:100% → 元素 800×600、guest 150;flex+height:100% → guest 600)。

修复(task_419dc330dce9608757a6d96217):恢复 `.html-artifact-webview { display: flex; width: 100%; height: 100% }`(不含 `min-height`,尊重此前去重意图),非 fill 宿主由 `min-h-[42rem]` 改为 `h-[42rem]`,因为 min-height 不构成百分比高度基准。隔离策略(`javascript=no`、`sandbox=yes`、partition、webSecurity)未动。隔离 e2e lane 修前/修后:产物页宿主 526 px,webview 元素与 guest 修前 478×150、修后 478×526;任务详情文件页修后 850×588;滚轮 2,400 px 后 guest 内容变化。e2e 断言量的是 guest 视口而不是元素;把规则改回 block 的对照以 `webview guest viewport 150px is under 90% of host 526px` 失败。原来断言规则不存在的 vitest 改为断言存在。

## 架构辩护

纯渲染层改动;预览在同一沙箱 partition 内经 data URL 读本地产物。无写入、无并发主体。

## 机读声明

见英文块。

## 治理声明

未触碰 protected 路径(`tools/gui-e2e/**` 是 GUI e2e 场景目录,不是门或 allowlist)。无 break-glass。

## 验证

- worker 停止点(定向测试 + 本地 commit,不跑 `check:local`):`artifacts-view.vitest.ts` 与 `task-detail-expression.vitest.ts` 通过;GUI 构建通过;新 e2e 场景 `artifacts-html-preview` 在隔离 lane 通过(两种布局 guest 视口 ≥ 宿主 90%,滚动改变 guest 内容);`display: block` 对照以上述信息失败。任务上 fact F-ECBBB586。
- 官方门 production delta:`+78/-1`。

## 评审证据

worker 报告见任务包 `artifacts/gui-html-artifact-preview-clip-report.md`(私有台账)。CEO 语义验收:根因在容器不在产物,两层都有实测证据,隔离不变,修复是一条 CSS 规则加一个类,回归测试量的是真正会裁的东西(guest 视口)。

## 残余风险

e2e 场景需要 Electron 二进制,没有它的 CI lane 按既有具名规则 skip,常开的守卫是 vitest 的规则存在断言。
