### PR TITLE
fix(daemon): feed the writer watchdog only on monotonic attach progress

### DIFF
--- a/packages/daemon/src/protocol/daemon-protocol.contract.ts
+++ b/packages/daemon/src/protocol/daemon-protocol.contract.ts
@@ -566,6 +566,13 @@ export interface DaemonStopResult {
   readonly pid: number;
 }
 
+export interface DaemonRepoAttachProgress {
+  readonly phase: "opening" | "recovering" | "catching-up";
+  readonly applied: number | null;
+  readonly total: number | null;
+  readonly watermark: number | null;
+}
+
 export interface DaemonStatusResult {
   readonly ok: true;
   readonly daemonId: string;
@@ -604,6 +611,7 @@ export interface DaemonStatusResult {
       readonly reason?: "git_diverged" | "deterministic_failure" | "retry_budget_exhausted";
       readonly lastError?: string;
     } | null;
+    readonly attach?: DaemonRepoAttachProgress;
   }[];
   readonly summary: string;
 }

--- a/packages/daemon/src/repo-cell-types.ts
+++ b/packages/daemon/src/repo-cell-types.ts
@@ -18,6 +18,7 @@ import type { FleetAssignmentScope } from "./fleet/contract.ts";
 import { type ReplicaCutSource } from "./fleet/replica-cut-store.ts";
 import { openGuiCatalog } from "./gui-catalog.ts";
 import {
+  type DaemonRepoAttachProgress,
   type DaemonGuiReadMethod,
   type DaemonGuiReadResultMap,
   type ObserveTailResult,
@@ -84,12 +85,7 @@ export type TaskProgressReceipt = WriteReceiptDraft & {
   readonly worktreeVisible: true;
 };
 
-export interface RepoCellAttachProgress {
-  readonly phase: "opening" | "recovering" | "catching-up";
-  readonly applied: number | null;
-  readonly total: number | null;
-  readonly watermark: number | null;
-}
+export type RepoCellAttachProgress = DaemonRepoAttachProgress;
 
 export interface RepoCellStatus {
   readonly repoId: string;

--- a/packages/daemon/src/repo-cell.ts
+++ b/packages/daemon/src/repo-cell.ts
@@ -17,6 +17,7 @@ import {
   type ActorIdentity,
   type DaemonRepoMode,
   type DocSyncReceiptDetail,
+  type WalRecoveryProgress,
 } from "../../kernel/src/index.ts";
 import { makeAgentRuntimeReadModel } from "./agent-runtime-read.ts";
 import { readRuntimeAttemptChain, readSessionGroupDispatches, readTaskDispatches } from "./dispatch-read.ts";
@@ -138,6 +139,17 @@ export async function initializeRepoCell(context: RepoCellCoreInput): Promise<Re
     killpoint: context.input.killpoint,
     afterFlush: settleAuthoredCandidates,
     onMaterializationHealthChange: context.input.onMaterializationHealthChange,
+    ...(context.input.onOpenProgress
+      ? {
+          onRecoveryProgress: (progress: WalRecoveryProgress) =>
+            context.input.onOpenProgress?.({
+              phase: "recovering",
+              applied: progress.applied,
+              total: progress.total ?? null,
+              watermark: progress.watermark,
+            }),
+        }
+      : {}),
     walMaterialize: (config, request) => {
       const response = runWalMaterializationRequest(config, request, {
         withFinalizeFence: (fence, operation) => withWriterEpochFenceDescriptor(fence, operation),

--- a/packages/daemon/src/repo-writer-protocol.ts
+++ b/packages/daemon/src/repo-writer-protocol.ts
@@ -75,7 +75,7 @@ export interface RepoWriterCancelV1 {
 export interface RepoWriterStatusV1 {
   readonly schema: "harness-repo-writer-status/v1";
   readonly protocolVersion: typeof REPO_WRITER_PROTOCOL_VERSION;
-  readonly kind: "ready" | "cut" | "status" | "closed";
+  readonly kind: "ready" | "cut" | "status" | "attach-progress" | "closed";
   readonly status?: RepoCellStatus;
   readonly bootstrapReceipt?: unknown;
   readonly error?: SerializedWriterErrorV1;

--- a/packages/daemon/src/repo-writer-worker.ts
+++ b/packages/daemon/src/repo-writer-worker.ts
@@ -48,9 +48,7 @@ async function startRepoWriterWorker(): Promise<void> {
     total: null,
     watermark: null,
   });
-  postStatus({ kind: "status", status: openingStatus });
-  const heartbeat = setInterval(() => postStatus({ kind: "status", status: openingStatus }), 4_000);
-  heartbeat.unref?.();
+  postStatus({ kind: "attach-progress", status: openingStatus });
 
   parentPort.on("message", (message: unknown) => {
     if (isCapabilityResult(message)) {
@@ -131,7 +129,7 @@ async function startRepoWriterWorker(): Promise<void> {
         onOpenProgress: (progress) => {
           if (cell !== null) return;
           openingStatus = statusDuringOpen(progress);
-          postStatus({ kind: "status", status: openingStatus });
+          postStatus({ kind: "attach-progress", status: openingStatus });
         },
         onRuntimeOutcome: (event) => notify("runtimeOutcome", event),
         onAttemptTerminal: (terminal) => notify("attemptTerminal", terminal),
@@ -146,8 +144,6 @@ async function startRepoWriterWorker(): Promise<void> {
   } catch (error) {
     consumeKnownError(error);
     postStatus({ kind: "closed", error: serializeWriterError(error) });
-  } finally {
-    clearInterval(heartbeat);
   }
 
   function statusDuringOpen(attach: RepoCellAttachProgress): RepoCellStatus {

--- a/packages/daemon/src/writer-supervisor.ts
+++ b/packages/daemon/src/writer-supervisor.ts
@@ -4,7 +4,7 @@ import { fileURLToPath } from "node:url";
 import { Worker } from "node:worker_threads";
 import { consumeKnownError } from "../../kernel/src/index.ts";
 import type { RepoCellOpenInput } from "./repo-cell-open.ts";
-import type { RepoCellBinding, RepoCellStatus } from "./repo-cell-types.ts";
+import type { RepoCellAttachProgress, RepoCellBinding, RepoCellStatus } from "./repo-cell-types.ts";
 import {
   REPO_WRITER_PROTOCOL_VERSION,
   deserializeWriterError,
@@ -166,12 +166,13 @@ export async function openWriterSupervisor(
       };
       const candidate =
         options.createWorker?.(writerWorkerUrl(), workerOptions) ?? new Worker(writerWorkerUrl(), workerOptions);
-      let settled = false;
+      let settled = false,
+        lastAttachProgress: RepoCellAttachProgress | null = null;
       let readyWatchdog: ReturnType<typeof setTimeout>;
       const readyInactive = () => {
         if (settled) return;
         settled = true;
-        const error = new Error("RepoWriterCell did not publish ready after 30000ms without a message");
+        const error = new Error("RepoWriterCell did not publish ready after 30000ms without progress");
         if (!opened) closed = true;
         reject(error);
         failActive(error);
@@ -185,7 +186,6 @@ export async function openWriterSupervisor(
       armReadyWatchdog();
       worker = candidate;
       candidate.on("message", (message: unknown) => {
-        if (!settled) armReadyWatchdog();
         if (isReceipt(message)) {
           const operation = pending.get(message.requestId);
           if (!operation) return;
@@ -199,9 +199,19 @@ export async function openWriterSupervisor(
         if (isStatus(message)) {
           const published = message.status;
           if (published && typeof published === "object") {
-            const attachStatus = published.attach !== undefined;
-            if (!settled || !attachStatus) status = published;
-            if (!settled && attachStatus) options.onAttachStatus?.(published);
+            const attaching = published.state === "warming";
+            if (!settled || !attaching) status = published;
+            if (!settled && attaching) options.onAttachStatus?.(published);
+            if (
+              !settled &&
+              attaching &&
+              message.kind === "attach-progress" &&
+              published.attach !== undefined &&
+              attachProgressAdvanced(lastAttachProgress, published.attach)
+            ) {
+              lastAttachProgress = published.attach;
+              armReadyWatchdog();
+            }
           }
           if (message.bootstrapReceipt !== undefined) {
             publishedBootstrapReceipt = message.bootstrapReceipt;
@@ -477,6 +487,20 @@ function isReceipt(value: unknown): value is RepoWriterReceiptV1 {
 }
 function isStatus(value: unknown): value is RepoWriterStatusV1 {
   return isWriterSupervisorMessageRecord(value) && value.schema === "harness-repo-writer-status/v1";
+}
+
+function attachProgressAdvanced(previous: RepoCellAttachProgress | null, next: RepoCellAttachProgress): boolean {
+  if (previous === null) return true;
+  if (previous.phase !== next.phase) return attachPhaseOrder(next.phase) > attachPhaseOrder(previous.phase);
+  if (next.phase === "recovering")
+    return next.applied !== null && (previous.applied === null || next.applied > previous.applied);
+  if (next.phase === "catching-up")
+    return next.watermark !== null && (previous.watermark === null || next.watermark > previous.watermark);
+  return false;
+}
+
+function attachPhaseOrder(phase: RepoCellAttachProgress["phase"]): number {
+  return phase === "opening" ? 0 : phase === "recovering" ? 1 : 2;
 }
 function isCapabilityCall(value: unknown): value is RepoWriterCapabilityCallV1 {
   return isWriterSupervisorMessageRecord(value) && value.schema === "harness-repo-writer-capability-call/v1";

--- a/packages/daemon/test/daemon-host-recovery.test.ts
+++ b/packages/daemon/test/daemon-host-recovery.test.ts
@@ -10,7 +10,7 @@ import { makeTaskProjection, readDaemonRegistry, taskLifecycleWritePlan } from "
 import { lifecycleFixture } from "../../kernel/test/store/task-lifecycle-fixture.ts";
 import { openDaemonHost } from "../src/daemon-host.ts";
 import type { DaemonHostOpenInput } from "../src/daemon-host-open.ts";
-import { canonicalRoot, workspaceId } from "../src/protocol/daemon-protocol.contract.ts";
+import { canonicalRoot, workspaceId, type DaemonStatusResult } from "../src/protocol/daemon-protocol.contract.ts";
 import type { RepoCellStatus } from "../src/repo-cell-types.ts";
 import {
   openBootstrappedRepoCell as openRepoCell,
@@ -199,9 +199,11 @@ test("daemon status exposes the writer phase and progress while a repository att
     attachments = host.attachmentsSettled();
   await progressPublished;
   try {
-    const row = host.status().repos.find((repo) => repo.repoId === "host-attach-progress");
+    const response = { ok: true as const, ...host.status() } satisfies DaemonStatusResult,
+      row = response.repos.find((repo) => repo.repoId === "host-attach-progress");
     context.diagnostic(`ha daemon status repo row: ${JSON.stringify(row)}`);
     assert.equal(row?.state, "warming");
+    assert.match(response.summary, /attaching 0\/1/u);
     assert.deepEqual(row?.attach, {
       phase: "catching-up",
       applied: 4_096,

--- a/packages/daemon/test/writer-supervisor-liveness.test.ts
+++ b/packages/daemon/test/writer-supervisor-liveness.test.ts
@@ -18,7 +18,7 @@ const supervisorInput = {
   ownerId: "writer-liveness-test",
 } as RepoCellOpenInput;
 
-test("a writer may open beyond 30 seconds when messages keep the ready watchdog active", async (context) => {
+test("a writer may open beyond 30 seconds when attach progress advances the ready watchdog", async (context) => {
   context.mock.timers.enable({ apis: ["setTimeout"] });
   const writer = new FakeWriter(),
     published: RepoCellStatus[] = [],
@@ -29,13 +29,19 @@ test("a writer may open beyond 30 seconds when messages keep the ready watchdog 
 
   context.mock.timers.tick(29_999);
   writer.publish(
-    writerStatus("status", warmingStatus({ phase: "catching-up", applied: 4_096, total: 8_192, watermark: 4_096 })),
+    writerStatus(
+      "attach-progress",
+      warmingStatus({ phase: "catching-up", applied: 4_096, total: 8_192, watermark: 4_096 }),
+    ),
   );
   context.mock.timers.tick(29_999);
   assert.equal(writer.terminateCalls, 0);
   writer.publish(writerStatus("ready", attachedStatus()));
   writer.publish(
-    writerStatus("status", warmingStatus({ phase: "catching-up", applied: 8_192, total: 8_192, watermark: 8_192 })),
+    writerStatus(
+      "attach-progress",
+      warmingStatus({ phase: "catching-up", applied: 8_192, total: 8_192, watermark: 8_192 }),
+    ),
   );
 
   const supervisor = await opening;

--- a/packages/daemon/test/writer-watchdog-feed.test.ts
+++ b/packages/daemon/test/writer-watchdog-feed.test.ts
@@ -1,0 +1,192 @@
+// harness-test-tier: contract
+import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
+import test from "node:test";
+import type { Worker } from "node:worker_threads";
+import type { RepoCellOpenInput } from "../src/repo-cell-open.ts";
+import type { RepoCellAttachProgress, RepoCellStatus } from "../src/repo-cell-types.ts";
+import type { DaemonStatusResult } from "../src/protocol/daemon-protocol.contract.ts";
+import {
+  REPO_WRITER_PROTOCOL_VERSION,
+  type RepoWriterControlV1,
+  type RepoWriterStatusV1,
+} from "../src/repo-writer-protocol.ts";
+import { openWriterSupervisor } from "../src/writer-supervisor.ts";
+
+const supervisorInput = {
+  repoId: "writer-watchdog-feed",
+  rootDir: "/tmp/writer-watchdog-feed",
+  ownerId: "writer-watchdog-feed-test",
+} as RepoCellOpenInput;
+
+test("the daemon status contract carries repository attach progress", () => {
+  const attach = { phase: "catching-up", applied: 256, total: 512, watermark: 256 } as const,
+    row = warmingStatus(attach) satisfies DaemonStatusResult["repos"][number];
+  assert.deepEqual(row.attach, attach);
+});
+
+test("an unchanged catch-up watermark does not feed the ready watchdog", async (context) => {
+  context.mock.timers.enable({ apis: ["setTimeout"] });
+  const writer = new FakeWriter(),
+    opening = openWriterSupervisor(supervisorInput, { createWorker: () => writer as unknown as Worker }),
+    rejected = assert.rejects(opening, /30000ms without progress/u),
+    progress = { phase: "catching-up", applied: 256, total: 512, watermark: 256 } as const;
+
+  writer.publish(writerStatus("attach-progress", progress));
+  context.mock.timers.tick(29_999);
+  writer.publish(writerStatus("attach-progress", progress));
+  context.mock.timers.tick(1);
+
+  await rejected;
+  assert.equal(writer.terminateCalls, 1);
+});
+
+test("segmented recovery progress keeps a writer alive beyond the ready threshold", async (context) => {
+  context.mock.timers.enable({ apis: ["setTimeout"] });
+  const writer = new FakeWriter(),
+    opening = openWriterSupervisor(supervisorInput, { createWorker: () => writer as unknown as Worker });
+
+  for (const applied of [256, 512, 768]) {
+    context.mock.timers.tick(29_999);
+    writer.publish(
+      writerStatus("attach-progress", {
+        phase: "recovering",
+        applied,
+        total: 768,
+        watermark: applied,
+      }),
+    );
+    assert.equal(writer.terminateCalls, 0);
+  }
+  writer.publish(writerStatus("ready", undefined, attachedStatus()));
+
+  const supervisor = await opening;
+  assert.equal(supervisor.status().state, "attached");
+  assert.equal(writer.terminateCalls, 0);
+  await supervisor.close();
+});
+
+test("a warming status carrying attach data is not itself a watchdog feed", async (context) => {
+  context.mock.timers.enable({ apis: ["setTimeout"] });
+  const writer = new FakeWriter(),
+    opening = openWriterSupervisor(supervisorInput, { createWorker: () => writer as unknown as Worker }),
+    rejected = assert.rejects(opening, /30000ms without progress/u);
+
+  context.mock.timers.tick(29_999);
+  writer.publish(
+    writerStatus("status", {
+      phase: "recovering",
+      applied: 256,
+      total: 512,
+      watermark: 256,
+    }),
+  );
+  context.mock.timers.tick(1);
+
+  await rejected;
+  assert.equal(writer.terminateCalls, 1);
+});
+
+test("a regressing attach phase does not feed the ready watchdog", async (context) => {
+  context.mock.timers.enable({ apis: ["setTimeout"] });
+  const writer = new FakeWriter(),
+    opening = openWriterSupervisor(supervisorInput, { createWorker: () => writer as unknown as Worker }),
+    rejected = assert.rejects(opening, /30000ms without progress/u);
+
+  writer.publish(
+    writerStatus("attach-progress", {
+      phase: "catching-up",
+      applied: 256,
+      total: 512,
+      watermark: 256,
+    }),
+  );
+  context.mock.timers.tick(29_999);
+  writer.publish(
+    writerStatus("attach-progress", {
+      phase: "recovering",
+      applied: 512,
+      total: 512,
+      watermark: 512,
+    }),
+  );
+  context.mock.timers.tick(1);
+
+  await rejected;
+  assert.equal(writer.terminateCalls, 1);
+});
+
+class FakeWriter extends EventEmitter {
+  terminateCalls = 0;
+
+  postMessage(message: unknown): void {
+    if (!isControl(message)) return;
+    this.emit("message", {
+      schema: "harness-repo-writer-receipt/v1",
+      protocolVersion: REPO_WRITER_PROTOCOL_VERSION,
+      requestId: message.requestId,
+      outcome: "ok",
+    });
+  }
+
+  publish(message: RepoWriterStatusV1): void {
+    this.emit("message", message);
+  }
+
+  terminate(): Promise<number> {
+    this.terminateCalls += 1;
+    return Promise.resolve(0);
+  }
+}
+
+function writerStatus(
+  kind: RepoWriterStatusV1["kind"],
+  attach?: RepoCellAttachProgress,
+  status = warmingStatus(attach),
+): RepoWriterStatusV1 {
+  return {
+    schema: "harness-repo-writer-status/v1",
+    protocolVersion: REPO_WRITER_PROTOCOL_VERSION,
+    kind,
+    status,
+  };
+}
+
+function warmingStatus(attach?: RepoCellAttachProgress): RepoCellStatus {
+  return {
+    repoId: supervisorInput.repoId,
+    rootDir: supervisorInput.rootDir,
+    mode: "local",
+    state: "warming",
+    generation: null,
+    queueDepth: 0,
+    lastError: null,
+    causeClass: null,
+    recoveryMs: null,
+    materialization: null,
+    ...(attach ? { attach } : {}),
+  };
+}
+
+function attachedStatus(): RepoCellStatus {
+  return {
+    repoId: supervisorInput.repoId,
+    rootDir: supervisorInput.rootDir,
+    mode: "local",
+    state: "attached",
+    generation: 1,
+    queueDepth: 0,
+    lastError: null,
+    causeClass: null,
+    recoveryMs: 1,
+    materialization: null,
+  };
+}
+
+function isControl(value: unknown): value is RepoWriterControlV1 {
+  return (
+    value !== null &&
+    typeof value === "object" &&
+    (value as { readonly schema?: unknown }).schema === "harness-repo-writer-control/v1"
+  );
+}

--- a/packages/kernel/src/composition/index.ts
+++ b/packages/kernel/src/composition/index.ts
@@ -10,6 +10,7 @@ export {
   makeWalShadowEventReader as makeTaskEventReader,
   makeWalShadowEventStore as makeTaskEventStore,
 } from "../store/wal-shadow-event-store.ts";
+export type { WalRecoveryProgress } from "../store/wal-shadow-event-store.ts";
 export { ledgerGitPath, resolveLedgerGitLayout } from "../store/ledger-git-layout.ts";
 export { eventShapeMigrations, runEventShapeMigration } from "../store/event-shape-migration.ts";
 export { runDispatchRecordMigration } from "../store/dispatch-record-migration.ts";

--- a/packages/kernel/src/index.ts
+++ b/packages/kernel/src/index.ts
@@ -312,6 +312,7 @@ export type {
   TaskRelationProjectionRead,
   TaskRelationQuery,
   WalMaterializationFenceV1,
+  WalRecoveryProgress,
 } from "./composition/index.ts";
 export {
   readDaemonRegistry,

--- a/packages/kernel/src/projection/rebuildable-task-projection-factory.ts
+++ b/packages/kernel/src/projection/rebuildable-task-projection-factory.ts
@@ -143,18 +143,22 @@ export function makeTaskProjection(options: {
       const initialWatermark = withDatabase(projectionPath, readHead, watermark);
       let sqliteTransactions = 0,
         reducedItems = 0,
-        maxBatchItems = 0;
+        maxBatchItems = 0,
+        reportedWatermark = initialWatermark;
       for (;;) {
         const round = withDatabase(projectionPath, readHead, (db) => catchUpRound(db, options.eventStore, limit));
         sqliteTransactions += round.sqliteTransactions;
         reducedItems += round.reducedItems;
         maxBatchItems = Math.max(maxBatchItems, round.accessedItems);
         const total = Math.max(0, round.sourceRevision - initialWatermark);
-        onProgress({
-          applied: Math.min(total, Math.max(0, round.watermark - initialWatermark)),
-          total,
-          watermark: round.watermark,
-        });
+        if (round.watermark > reportedWatermark) {
+          onProgress({
+            applied: Math.min(total, Math.max(0, round.watermark - initialWatermark)),
+            total,
+            watermark: round.watermark,
+          });
+          reportedWatermark = round.watermark;
+        }
         if (round.watermark !== round.sourceRevision) continue;
         const settled = withDatabase(projectionPath, readHead, (db) =>
           transaction(db, () => ({

--- a/packages/kernel/src/store/wal-event-log.ts
+++ b/packages/kernel/src/store/wal-event-log.ts
@@ -5,11 +5,13 @@ import {
   serializePersistedCanonicalEvent,
   type CanonicalEventV1,
 } from "../domain/doc-sync.contract.ts";
+import { DEFAULT_WAL_FLUSH_SETTINGS } from "../domain/settings.ts";
 import { sha256Text, stableStringify } from "../integrity/stable-hash.ts";
 import { localWalFileSystem as fileSystem } from "../local/local-layout-file-system.ts";
 
 const WAL_SCHEMA = "harness-wal/v1" as const;
 const WAL_SEGMENT = "seg-000000.log";
+const WAL_READ_PROGRESS_BATCH_SIZE = DEFAULT_WAL_FLUSH_SETTINGS.events;
 
 export interface WalContentObject {
   readonly sha256: string;
@@ -25,6 +27,12 @@ export interface WalEventRecord {
   readonly blobs: readonly WalContentObject[];
   readonly eventDigest: `sha256:${string}`;
   readonly previousDigest: `sha256:${string}` | null;
+}
+
+export interface WalEventLogProgress {
+  readonly applied: number;
+  readonly total?: number;
+  readonly watermark: number;
 }
 
 export interface WalHead {
@@ -81,7 +89,13 @@ export interface WalAuditReceipt {
 
 const mutableWalOwners = new Set<string>();
 
-export function openWalEventLog(rootDir: string, options: { readonly mutable?: boolean } = {}): WalEventLog {
+export function openWalEventLog(
+  rootDir: string,
+  options: {
+    readonly mutable?: boolean;
+    readonly onInitialReadProgress?: (progress: WalEventLogProgress) => void;
+  } = {},
+): WalEventLog {
   const normalizedRoot = fileSystem.realpath(path.resolve(rootDir));
   const walRoot = path.join(normalizedRoot, ".harness", "wal");
   const segmentPath = path.join(walRoot, WAL_SEGMENT);
@@ -100,28 +114,35 @@ export function openWalEventLog(rootDir: string, options: { readonly mutable?: b
     fileSystem.mkdirp(walRoot);
     fileSystem.mkdirp(objectsRoot);
   };
-  const readDiskRecords = (): WalEventRecord[] => {
+  const readDiskRecords = (onProgress?: (progress: WalEventLogProgress) => void): WalEventRecord[] => {
     if (!fileSystem.exists(segmentPath)) {
       return [];
     }
     const raw = fileSystem.readText(segmentPath);
     const complete = raw.endsWith("\n") ? raw : raw.slice(0, raw.lastIndexOf("\n") + 1);
     if (complete !== raw && mutable) fileSystem.replace(segmentPath, complete);
-    const rows = complete
-      .split("\n")
-      .filter(Boolean)
-      .map((line, index) => parseRecord(line, index));
+    const lines = complete.split("\n").filter(Boolean);
+    const rows: WalEventRecord[] = [];
+    for (const [index, line] of lines.entries()) {
+      const record = parseRecord(line, index);
+      rows.push(record);
+      const applied = index + 1;
+      if (applied % WAL_READ_PROGRESS_BATCH_SIZE === 0 || applied === lines.length)
+        onProgress?.({ applied, watermark: record.revision });
+    }
     for (let index = 1; index < rows.length; index += 1) {
       const previous = rows[index - 1]!;
       const current = rows[index]!;
       if (current.revision !== previous.revision + 1 || current.previousDigest !== previous.eventDigest)
         throw new Error(`WAL revision or digest chain is not contiguous at revision ${current.revision}`);
+      if (index % WAL_READ_PROGRESS_BATCH_SIZE === 0 || index === rows.length - 1)
+        onProgress?.({ applied: rows.length + index, watermark: current.revision });
     }
     return rows;
   };
   const readRecords = (): readonly WalEventRecord[] => {
     if (cached !== null) return cached;
-    cached = readDiskRecords();
+    cached = readDiskRecords(options.onInitialReadProgress);
     cachedByOpId = new Map(cached.map((record) => [record.opId, record] as const));
     return cached;
   };

--- a/packages/kernel/src/store/wal-shadow-event-store.ts
+++ b/packages/kernel/src/store/wal-shadow-event-store.ts
@@ -23,7 +23,6 @@ import {
   type CanonicalWriteBundle,
   type EventFileBatch,
   type EventRecoveryReceipt,
-  type MaterializationReceipt,
   type MaterializationFailureReason,
   type MaterializationHealth,
   type PublicationFile,
@@ -34,9 +33,11 @@ import {
   openWalEventLog,
   type WalDurableCutDescriptor,
   type WalEventLog,
+  type WalEventLogProgress,
   type WalEventRecord,
 } from "./wal-event-log.ts";
 import { WalMaterializerDivergedError } from "./wal-git-materializer.ts";
+import { latestDocumentClaims, materializeVisible } from "./wal-visible-materialization.ts";
 import type {
   WalBaselineDeltaV1,
   WalMaterializationFenceV1,
@@ -51,6 +52,7 @@ export { canonicalDocumentClaims, canonicalEventWritePlan, TaskEventStoreError }
 // Retry transient Git locks/resource pressure for ~32s before imposing fail-closed recovery cost.
 const DEFAULT_RETRY_LIMIT = 8;
 const DEFAULT_RETRY_BASE_MS = 250;
+export type WalRecoveryProgress = WalEventLogProgress;
 
 export interface WalFlushPolicy {
   readonly adaptive: boolean;
@@ -84,6 +86,8 @@ type StoreOptions = Parameters<typeof makeGitEventStore>[0] & {
   }) => void;
   /** Publishes health changes through the owning writer cell's existing status channel. */
   readonly onMaterializationHealthChange?: (health: MaterializationHealth) => void;
+  /** Reports bounded WAL recovery work through the owning writer cell's attach-progress channel. */
+  readonly onRecoveryProgress?: (progress: WalRecoveryProgress) => void;
   readonly walMaterializationTestFault?: {
     readonly point: "before_materialization" | "worker_exit" | "after_git_commit" | "after_git_ref_update";
     readonly failures: number;
@@ -111,7 +115,24 @@ export function makeWalShadowEventStore(options: StoreOptions): CanonicalEventSt
   let gitStream: CanonicalEventStreamV1 | null = null;
   let mergedStream: CanonicalEventStreamV1 | null = null;
   const mutable = options.mutable !== false;
-  const wal = openWalEventLog(rootDir, { mutable });
+  let reportedRecoveryWork = 0,
+    reportedRecoveryWatermark = 0;
+  const recoveryProgressReporter = (): ((progress: WalRecoveryProgress) => void) | undefined => {
+    const publish = options.onRecoveryProgress;
+    if (publish === undefined) return undefined;
+    const offset = reportedRecoveryWork;
+    return (progress) => {
+      const observed = {
+        applied: offset + progress.applied,
+        ...(progress.total === undefined ? {} : { total: offset + progress.total }),
+        watermark: Math.max(reportedRecoveryWatermark, progress.watermark),
+      };
+      reportedRecoveryWork = Math.max(reportedRecoveryWork, observed.applied);
+      reportedRecoveryWatermark = observed.watermark;
+      publish(observed);
+    };
+  };
+  const wal = openWalEventLog(rootDir, { mutable, onInitialReadProgress: recoveryProgressReporter() });
   const materializationConfig = {
     schema: "harness-wal-materialization-worker/v1",
     repoId: options.repoId,
@@ -660,7 +681,8 @@ export function makeWalShadowEventStore(options: StoreOptions): CanonicalEventSt
     try {
       recovered = git.recover();
       reloadGit();
-      const records = wal.records();
+      const records = wal.records(),
+        onRecoveryProgress = recoveryProgressReporter();
       if (records.length > 0)
         materializeVisible(
           ledger,
@@ -669,6 +691,7 @@ export function makeWalShadowEventStore(options: StoreOptions): CanonicalEventSt
           gitBaseline.files,
           git.currentCommit(),
           (sha256) => git.readContentBlob(sha256),
+          onRecoveryProgress,
         );
     } catch (error) {
       consumeKnownError(error);
@@ -906,58 +929,6 @@ function makeVisible(
     if (wal.readContentBlob(claim.sha256) === null && supplied === undefined)
       throw new TaskEventStoreError("invalid_store", `visible document ${claim.sha256} is absent from the durable WAL`);
   }
-}
-
-function materializeVisible(
-  ledger: ReturnType<typeof resolveLedgerGitLayout>,
-  wal: WalEventLog,
-  events: CanonicalEventStreamV1["events"],
-  committed: ReadonlyMap<string, GitBaselineNode>,
-  commitSha: ReturnType<CanonicalEventStore["currentCommit"]>,
-  readGitContent: (sha256: string) => Uint8Array | null,
-): MaterializationReceipt {
-  const latest = latestDocumentClaims(events);
-  const changed: string[] = [];
-  const conflicts: string[] = [];
-  const writes: { target: string; body: string; mode: "100644" | "120000" }[] = [];
-  for (const [logical, claim] of [...latest].sort(([left], [right]) => left.localeCompare(right))) {
-    const target = ledgerGitPath(ledger, logical);
-    const physical = pathFor(ledger.rootDir, target);
-    const local = localGitWorktreeSettlement.readNode(physical);
-    // Decide divergence from the worktree hash and the in-memory claim alone; an already-materialized
-    // document is skipped before any canonical blob is read. This keeps materialize proportional to the
-    // number of divergent files, not the size of the whole corpus: a current worktree reads zero blobs
-    // (previously every document forced a `git show`, which wedged the daemon event loop at scale).
-    if (local?.sha256 === claim.sha256 && local.mode === claim.mode) continue;
-    const bytes = wal.readContentBlob(claim.sha256) ?? readGitContent(claim.sha256);
-    if (bytes === null) continue;
-    const base = committed.get(target);
-    if (local !== null && (base === undefined || local.gitOid !== base.oid || local.mode !== base.mode))
-      conflicts.push(
-        localGitWorktreeSettlement.preserveVisibleConflict(
-          ledger.rootDir,
-          physical,
-          target,
-          `${events.at(-1)?.workspaceRevision ?? 0}:${claim.sha256}`,
-        ),
-      );
-    changed.push(logical);
-    writes.push({ target, body: Buffer.from(bytes).toString("utf8"), mode: claim.mode });
-  }
-  localGitWorktreeSettlement.visible(ledger.rootDir, writes);
-  return { status: "visible", commitSha, changed, conflicts };
-}
-
-function latestDocumentClaims(
-  events: CanonicalEventStreamV1["events"],
-): Map<string, { sha256: string; mode: "100644" | "120000" }> {
-  const latest = new Map<string, { sha256: string; mode: "100644" | "120000" }>();
-  for (const event of events) {
-    for (const retirement of canonicalDocumentRetirements(event)) latest.delete(retirement.path);
-    for (const claim of canonicalDocumentClaims(event))
-      latest.set(claim.path, { sha256: claim.sha256, mode: canonicalDocumentMode(event, claim.path) });
-  }
-  return latest;
 }
 
 function applyDocumentClaims(

--- a/packages/kernel/src/store/wal-visible-materialization.ts
+++ b/packages/kernel/src/store/wal-visible-materialization.ts
@@ -1,0 +1,106 @@
+import { DEFAULT_WAL_FLUSH_SETTINGS } from "../domain/settings.ts";
+import { ledgerGitPath, resolveLedgerGitLayout } from "./ledger-git-layout.ts";
+import { localGitWorktreeSettlement } from "./local-version-control-system.ts";
+import {
+  canonicalDocumentClaims,
+  canonicalDocumentMode,
+  canonicalDocumentRetirements,
+  type CanonicalEventStore,
+  type CanonicalEventStreamV1,
+  type MaterializationReceipt,
+} from "./task-event-store.ts";
+import type { WalEventLog, WalEventLogProgress } from "./wal-event-log.ts";
+
+interface WalVisibleBaselineNode {
+  readonly mode: "100644" | "120000";
+  readonly oid: string;
+}
+
+export function materializeVisible(
+  ledger: ReturnType<typeof resolveLedgerGitLayout>,
+  wal: WalEventLog,
+  events: CanonicalEventStreamV1["events"],
+  committed: ReadonlyMap<string, WalVisibleBaselineNode>,
+  commitSha: ReturnType<CanonicalEventStore["currentCommit"]>,
+  readGitContent: (sha256: string) => Uint8Array | null,
+  onProgress?: (progress: WalEventLogProgress) => void,
+): MaterializationReceipt {
+  const latest = latestDocumentClaims(events, onProgress);
+  const changed: string[] = [];
+  const conflicts: string[] = [];
+  const writes: { target: string; body: string; mode: "100644" | "120000" }[] = [];
+  const claims = [...latest].sort(([left], [right]) => left.localeCompare(right));
+  for (const [index, [logical, claim]] of claims.entries()) {
+    const target = ledgerGitPath(ledger, logical);
+    const physical = [ledger.rootDir, ...target.split("/")].join("/");
+    const local = localGitWorktreeSettlement.readNode(physical);
+    // Decide divergence from the worktree hash and the in-memory claim alone; an already-materialized
+    // document is skipped before any canonical blob is read. This keeps materialize proportional to the
+    // number of divergent files, not the size of the whole corpus: a current worktree reads zero blobs
+    // (previously every document forced a `git show`, which wedged the daemon event loop at scale).
+    if (local?.sha256 === claim.sha256 && local.mode === claim.mode) {
+      reportInspectedClaim(index);
+      continue;
+    }
+    const bytes = wal.readContentBlob(claim.sha256) ?? readGitContent(claim.sha256);
+    if (bytes === null) {
+      reportInspectedClaim(index);
+      continue;
+    }
+    const base = committed.get(target);
+    if (local !== null && (base === undefined || local.gitOid !== base.oid || local.mode !== base.mode))
+      conflicts.push(
+        localGitWorktreeSettlement.preserveVisibleConflict(
+          ledger.rootDir,
+          physical,
+          target,
+          `${events.at(-1)?.workspaceRevision ?? 0}:${claim.sha256}`,
+        ),
+      );
+    changed.push(logical);
+    writes.push({ target, body: Buffer.from(bytes).toString("utf8"), mode: claim.mode });
+    reportInspectedClaim(index);
+  }
+  const completedInspection = events.length + claims.length;
+  let visibleWrites = 0;
+  localGitWorktreeSettlement.visible(ledger.rootDir, writes, {
+    afterRename: () => {
+      visibleWrites += 1;
+      if (visibleWrites % DEFAULT_WAL_FLUSH_SETTINGS.events === 0 || visibleWrites === writes.length)
+        onProgress?.({
+          applied: completedInspection + visibleWrites,
+          total: completedInspection + writes.length,
+          watermark: events.at(-1)?.workspaceRevision ?? 0,
+        });
+    },
+  });
+  if (writes.length === 0 && completedInspection > 0)
+    onProgress?.({
+      applied: completedInspection,
+      total: completedInspection,
+      watermark: events.at(-1)?.workspaceRevision ?? 0,
+    });
+  return { status: "visible", commitSha, changed, conflicts };
+
+  function reportInspectedClaim(index: number): void {
+    const applied = events.length + index + 1;
+    if ((index + 1) % DEFAULT_WAL_FLUSH_SETTINGS.events === 0 || index + 1 === claims.length)
+      onProgress?.({ applied, watermark: events.at(-1)?.workspaceRevision ?? 0 });
+  }
+}
+
+export function latestDocumentClaims(
+  events: CanonicalEventStreamV1["events"],
+  onProgress?: (progress: WalEventLogProgress) => void,
+): Map<string, { sha256: string; mode: "100644" | "120000" }> {
+  const latest = new Map<string, { sha256: string; mode: "100644" | "120000" }>();
+  for (const [index, event] of events.entries()) {
+    for (const retirement of canonicalDocumentRetirements(event)) latest.delete(retirement.path);
+    for (const claim of canonicalDocumentClaims(event))
+      latest.set(claim.path, { sha256: claim.sha256, mode: canonicalDocumentMode(event, claim.path) });
+    const applied = index + 1;
+    if (applied % DEFAULT_WAL_FLUSH_SETTINGS.events === 0 || applied === events.length)
+      onProgress?.({ applied, watermark: event.workspaceRevision });
+  }
+  return latest;
+}

--- a/packages/kernel/test/store/task-query-projection.test.ts
+++ b/packages/kernel/test/store/task-query-projection.test.ts
@@ -260,6 +260,41 @@ test("catch-up reports every bounded round and keeps an omitted progress callbac
   });
 });
 
+test("catch-up does not report rounds whose projection watermark stays fixed", async () => {
+  const event = taskFixture().events[0]!;
+  await withTempStoreAsync(async (rootDir) => {
+    let reads = 0;
+    const progress: number[] = [],
+      projection = makeTaskProjection({
+        rootDir,
+        eventStore: {
+          readHead: () => ({
+            revision: 1,
+            eventDigest: `sha256:${sha256Text(serializeCanonicalEvent(event))}`,
+          }),
+          readBatch: () => {
+            reads += 1;
+            if (reads === 4) throw new Error("stop stalled catch-up fixture");
+            return {
+              sourceRevision: 1,
+              events: [],
+              cursor: String(reads),
+              done: false,
+              accessedItems: 1,
+              prefetchContent: () => new Map<string, Uint8Array | null>(),
+            };
+          },
+          readContentBlob: () => null,
+        },
+        onProgress: ({ watermark }) => progress.push(watermark),
+      });
+    assert.throws(() => projection.catchUp(), /stop stalled catch-up fixture/u);
+    assert.equal(reads, 4);
+    assert.deepEqual(progress, []);
+    projection.close();
+  });
+});
+
 test("task runtime batch reads up to 500 ids without a variable SQLite IN list", async () => {
   const fixture = taskFixture();
   await withTempStoreAsync(async (rootDir) => {

--- a/packages/kernel/test/store/wal-shadow-event-store.test.ts
+++ b/packages/kernel/test/store/wal-shadow-event-store.test.ts
@@ -1,7 +1,7 @@
 // harness-test-tier: integration
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { appendFileSync, existsSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { appendFileSync, existsSync, readFileSync, readdirSync, rmSync, statSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import test from "node:test";
 import { serializePersistedCanonicalEvent } from "../../src/domain/doc-sync.contract.ts";
@@ -670,19 +670,20 @@ test("healthy materialization reports an ok checkpoint before and after a WAL fl
   });
 });
 
-test("restart recovery settles and checkpoints a WAL cut whose Git refs already advanced", async () => {
+test("restart recovery reports bounded progress and checkpoints a WAL cut whose Git refs already advanced", async (context) => {
   await withTempStoreAsync(async (rootDir) => {
     initRepo(rootDir);
     const first = makeWalShadowEventStore({
       repoId: "wal-recovery",
       rootDir,
-      walFlushEvents: 64,
+      walFlushEvents: 512,
       walFlushMs: 60_000,
       walRetryLimit: 1,
       walRetryBaseMs: 1,
       walMaterializationTestFault: { point: "after_git_ref_update", failures: 1 },
     });
     const receipt = first.append(taskBundle(1, "recover me\n"));
+    for (let revision = 2; revision <= 257; revision += 1) first.append(taskBundle(revision));
     assert.equal(receipt.commitSha, null);
     await assert.rejects(
       first.drain(),
@@ -690,13 +691,32 @@ test("restart recovery settles and checkpoints a WAL cut whose Git refs already 
     );
     const documentPath = path.join(rootDir, "harness", "tasks", "task-1", "task.md");
     rmSync(documentPath);
-    assert.equal(openWalEventLog(rootDir, { mutable: false }).records().length, 1);
-    const recovered = makeWalShadowEventStore({ repoId: "wal-recovery", rootDir, walFlushMs: 60_000 });
-    recovered.recover();
+    assert.equal(openWalEventLog(rootDir, { mutable: false }).records().length, 257);
+    const progress: Array<{ readonly applied: number; readonly total?: number; readonly watermark: number }> = [],
+      recovered = makeWalShadowEventStore({
+        repoId: "wal-recovery",
+        rootDir,
+        walFlushMs: 60_000,
+        onRecoveryProgress: (observed) => progress.push(observed),
+      }),
+      walPath = path.join(rootDir, ".harness", "wal", "seg-000000.log"),
+      recovery = recovered.recover();
+    context.diagnostic(
+      `recovered ${String(progress.at(-1)?.applied)} work units from ${String(statSync(walPath).size)} WAL bytes in ${recovery.elapsedMs.toFixed(3)}ms`,
+    );
+    assert.deepEqual(progress, [
+      { applied: 256, watermark: 256 },
+      { applied: 257, watermark: 257 },
+      { applied: 513, watermark: 257 },
+      { applied: 769, watermark: 257 },
+      { applied: 770, watermark: 257 },
+      { applied: 771, watermark: 257 },
+      { applied: 772, total: 772, watermark: 257 },
+    ]);
     await recovered.drain();
     assert.equal(readFileSync(documentPath, "utf8"), "recover me\n");
     assert.deepEqual(openWalEventLog(rootDir, { mutable: false }).records(), []);
-    assert.equal(recovered.read().revision, 1);
+    assert.equal(recovered.read().revision, 257);
   });
 });
 


### PR DESCRIPTION
# English

## Summary

Closes the three writer-watchdog feed gaps found in the PR #2169 review (task_55b925fc). The ready watchdog was rearmed by every worker message, so a stalled writer that kept emitting unchanged status could never trip it. Now it rearms only on an explicit `attach-progress` message that proves monotonic attach work: a forward phase transition, a strictly larger recovery `applied` count, or a strictly larger catch-up `watermark`. `store.recover()` reports progress through the same `{ applied, total?, watermark }` shape at the normal 256-event flush batch boundary, so a residual WAL feeds the watchdog per segment instead of going silent. Projection catch-up publishes only when its watermark strictly exceeds the last reported one. The 4-second status interval in the worker is deleted; `attach` progress joins the public `DaemonStatusResult` contract and `ha daemon status` renders `attaching N/M`. Attach state is discriminated by `status.state === "warming"`, not by field presence.

## Architectural Justification

The watchdog is a daemon-local relation between the supervisor and its writer thread; each node advances or times out only its own writer and shares no counters across the fleet. Progress is derived from work the writer already does (WAL apply, catch-up watermark), so no second heartbeat or bypass exists: the only way to keep the watchdog alive is to make observable progress. `wal-visible-materialization.ts` is split out of `wal-shadow-event-store.ts` by responsibility to stay under the file-complexity gate.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none

## Machine-Readable Declarations

Production-Delta: +228/-88
Dependency-Change: none

### Optional Evidence Claims

none

## Task And Scope

task_55b925fca13d9c687338bdd808 (should-fix from the #2169 review, incident root task_98a824499e96f27b66797d227d). In-file removals: the unconditional per-message rearm and field-presence attach classification in `writer-supervisor.ts`; the 4-second `setInterval` heartbeat in `repo-writer-worker.ts`; the unconditional catch-up publish in `rebuildable-task-projection-factory.ts`.

## Version Impact

None.

## Governance Declaration

No protected path touched. No break-glass.

## Verification

- Worker stop point (targeted tests + local commit, no `check:local`): daemon `writer-supervisor-liveness` + new `writer-watchdog-feed` 7/7 under fake timers (fixed-watermark rounds and unchanged status do not rearm; advancing recovery and catch-up do); kernel `wal-shadow-event-store` 26/26 including a 257-record residual-WAL recovery that emits applied `[256,257,513,769,770,771,772]`; `task-query-projection` + `daemon-host-recovery` 21/21 including the `attaching 0/1` render assertion.
- typecheck, lint, implementation-contracts (129/129, delta 0), duplicate-definitions, file-complexity, line-density and the ontology daemon-specialization advisory gate green locally on `ebc4f285`.
- Fact F-AC7950F3 on the task. CI is the full authority; branch was pushed by the worker (discipline deviation recorded).

## Review Evidence

Worker report: `harness/tasks/task_55b925fca13d9c687338bdd808-*/artifacts/writer-watchdog-feed-report.md` (private ledger). CEO semantic review against the plan: goal ① feed-only-on-progress with a single progress shape (no second heartbeat) ✔; goal ② the attach contract question resolved by admitting `attach` into `DaemonStatusResult` and rendering it, with explicit state discrimination ✔; goal ③ the 4-second heartbeat deleted ✔; goal ④ mock-timer tests for stalled rounds, segmented recovery and the contract ✔.

## Residual Risk

Recovery progress granularity is the 256-event batch, so a single pathological batch longer than the 30 s watchdog budget would still time out; the report measured 257 records in 147 ms, three orders of magnitude of headroom (measured, not modelled). The canonical daemon restart is the manual acceptance step and is done by the CEO after merge.

---

# 中文

## 概要

修掉 PR #2169 复核指出的三处 writer 看门狗喂食缺口(task_55b925fc)。此前任意 worker 消息都会重武装 ready 看门狗,一个卡住但仍在重复发相同状态的 writer 永远触发不了它。现在只有带 `attach-progress` 且能证明单调推进的消息才重武装:阶段前进、恢复 `applied` 严格增大、或 catch-up `watermark` 严格增大。`store.recover()` 用同一 `{ applied, total?, watermark }` 形状按 256 事件的正常 flush 批边界上报进度,残留 WAL 按段喂食而不是沉默。投影 catch-up 只在水位严格超过上次时才发布。删除 worker 的 4 秒状态心跳;`attach` 进度进入公开的 `DaemonStatusResult` 契约,`ha daemon status` 渲染 `attaching N/M`;attach 态用 `status.state === "warming"` 判别,不再看字段存在与否。

## 架构辩护

看门狗是 daemon 本地 supervisor 与其 writer 线程的关系,每个节点只推进或超时自己的 writer,fleet 间不共享计数。进度从 writer 本来就在做的工作派生(WAL apply、catch-up 水位),因此没有第二心跳、没有旁路:让看门狗活着的唯一办法是产生可观测推进。`wal-visible-materialization.ts` 按职责从 `wal-shadow-event-store.ts` 拆出以过 file-complexity 门。

## 机读声明

见英文块。

## 治理声明

未触碰 protected 路径。无 break-glass。

## 验证

- worker 停止点(定向测试 + 本地 commit,不跑 `check:local`):daemon `writer-supervisor-liveness` + 新增 `writer-watchdog-feed` 7/7(假时钟:水位不变的轮次与相同状态不重武装,推进的恢复与 catch-up 会);kernel `wal-shadow-event-store` 26/26,含 257 条残留 WAL 恢复 applied `[256,257,513,769,770,771,772]`;`task-query-projection` + `daemon-host-recovery` 21/21,含 `attaching 0/1` 渲染断言。
- typecheck、lint、implementation-contracts(129/129,delta 0)、duplicate-definitions、file-complexity、line-density 与 ontology daemon-specialization advisory 门在 `ebc4f285` 本地全绿。
- 任务上 fact F-AC7950F3。CI 是完整权威;分支由 worker 自行 push(纪律偏差已记录)。

## 评审证据

worker 报告见任务包 `artifacts/writer-watchdog-feed-report.md`(私有台账)。CEO 按 plan 语义验收:目标①只按推进喂食且只有一种进度形状(无第二心跳)✔;目标②attach 契约二选一,选择进入 `DaemonStatusResult` 并渲染,判别器显式化 ✔;目标③删 4 秒心跳 ✔;目标④假时钟测试覆盖停滞轮次、分段恢复与契约 ✔。

## 残余风险

恢复进度粒度是 256 事件一批,单批若超过 30 秒预算仍会超时;报告实测 257 条 147 ms,余量三个数量级(实测,非模型)。canonical daemon 重启是合并后 CEO 的手工验收步骤。
