### PR TITLE
refactor(kernel): remove declared-only entity action aliases

### DIFF
--- a/packages/kernel/src/domain/entity-kind-registry.ts
+++ b/packages/kernel/src/domain/entity-kind-registry.ts
@@ -139,6 +139,7 @@ export type EntityKindContract<E extends BaseEntity = BaseEntity, T = unknown> =
   readonly actionCatalog: {
     readonly ref: string;
     readonly actions: readonly EntityActionContract[];
+    readonly reason?: string;
   } | null;
   readonly entityStore: {
     readonly document: {
@@ -267,6 +268,7 @@ export interface EntityKindExplanation {
     readonly catalogRef: string | null;
     readonly available: readonly string[];
     readonly actions: readonly EntityActionExplanation[];
+    readonly reason: string | null;
   };
   readonly authoring: EntityKindContract["authoring"];
   readonly sdkExposure: EntitySdkExposure;
@@ -316,13 +318,7 @@ const entityAction = (
     sdkExposure,
     execution,
   });
-const actionCatalog = (
-  ref: string,
-  kind: string,
-  identity: EntityKindContract["id"],
-  ids: readonly string[],
-  sdkExposure: EntitySdkExposure = noSdkExposure,
-) => Object.freeze({ ref, actions: Object.freeze(ids.map((id) => entityAction(kind, identity, id, sdkExposure))) });
+const noActionCatalog = (ref: string, reason: string) => Object.freeze({ ref, actions: Object.freeze([]), reason });
 
 const executionContract = (
   ingress: string,
@@ -456,7 +452,6 @@ const taskIdentity = requireEntityTypeContract("task").id;
 const factIdentity = requireEntityTypeContract("fact").id;
 const decisionIdentity = requireEntityTypeContract("decision").id;
 const agentIdentity = requireEntityTypeContract("agent").id;
-const policyIdentity = requireEntityTypeContract("policy").id;
 const executionIdentity = requireEntityTypeContract("execution").id;
 const reviewIdentity = requireEntityTypeContract("review").id;
 const runtimeSessionIdentity = requireEntityTypeContract("runtime-session").id;
@@ -781,7 +776,10 @@ export const entityKindContracts = Object.freeze([
     schema: POLICY_DECLARATION_V1_SCHEMA,
     relations: { directions: [], edges: [] },
     canonicalProjection: null,
-    actionCatalog: actionCatalog("kernel/policy/v1", "policy", policyIdentity, ["draft", "activate", "retire"]),
+    actionCatalog: noActionCatalog(
+      "kernel/policy/v1",
+      "Declaration entity; no independent write path (decision/dec_6FCDFB67623333335987D2542E/CH1).",
+    ),
     entityStore: null,
     authoring: null,
     sdkExposure: noSdkExposure,
@@ -836,13 +834,10 @@ export const entityKindContracts = Object.freeze([
       row: { idField: "executionId", ownerField: "taskId" },
     },
     statusVocabulary: [{ field: "state", words: executionStates }],
-    actionCatalog: actionCatalog("kernel/task-lifecycle/v1", "execution", executionIdentity, [
-      "start",
-      "renew",
-      "submit",
-      "complete",
-      "release",
-    ]),
+    actionCatalog: noActionCatalog(
+      "kernel/task-lifecycle/v1",
+      "Task lifecycle projection; no independent actions (decision/dec_A6B0EF213AE9643FD84EC5F197/CH1).",
+    ),
     entityStore: null,
     authoring: { kind: "task-lifecycle", contractRef: "task-event/v1" },
     sdkExposure: noSdkExposure,
@@ -880,7 +875,10 @@ export const entityKindContracts = Object.freeze([
       row: { idField: "reviewId", ownerField: "taskId" },
     },
     statusVocabulary: [{ field: "verdict", words: reviewVerdicts }],
-    actionCatalog: actionCatalog("kernel/task-lifecycle/v1", "review", reviewIdentity, ["record"]),
+    actionCatalog: noActionCatalog(
+      "kernel/task-lifecycle/v1",
+      "Task lifecycle projection; no independent actions (decision/dec_A6B0EF213AE9643FD84EC5F197/CH1).",
+    ),
     entityStore: null,
     authoring: { kind: "task-lifecycle", contractRef: "task-event/v1" },
     sdkExposure: noSdkExposure,
@@ -1070,6 +1068,7 @@ export function explainEntityKind(kind: string): EntityKindExplanation {
       available:
         contract.actionCatalog?.actions.filter(({ execution }) => execution !== null).map(({ id }) => id) ?? [],
       actions,
+      reason: contract.actionCatalog?.reason ?? null,
     },
     authoring: contract.authoring,
     sdkExposure: contract.sdkExposure,

--- a/packages/kernel/test/contracts/action-envelope.test.ts
+++ b/packages/kernel/test/contracts/action-envelope.test.ts
@@ -25,7 +25,7 @@ test("Action envelope is one closed kernel contract with a stable replay identit
   assert.match(validateActionEnvelope({ ...action, idempotencyKey: "" }).join("\n"), /idempotencyKey is required/u);
 });
 
-test("promoted Entity catalogs distinguish executable Agent and RuntimeSession actions", () => {
+test("Entity catalogs omit actions that decisions assign to another owner or no write path", () => {
   const catalogs = Object.fromEntries(
     ["execution", "review", "agent", "runtime-session", "policy"].map((kind) => [kind, explainEntityKind(kind)]),
   );
@@ -34,19 +34,31 @@ test("promoted Entity catalogs distinguish executable Agent and RuntimeSession a
     { field: "state", words: ["active", "submitted", "accepted", "changes_requested", "abandoned"] },
   ]);
   assert.deepEqual(catalogs.execution?.transitions.available, []);
-  assert.deepEqual(declared("execution"), ["start", "renew", "submit", "complete", "release"]);
+  assert.deepEqual(declared("execution"), []);
+  assert.equal(
+    catalogs.execution?.transitions.reason,
+    "Task lifecycle projection; no independent actions (decision/dec_A6B0EF213AE9643FD84EC5F197/CH1).",
+  );
   assert.deepEqual(catalogs.review?.statusVocabulary, [
     { field: "verdict", words: ["approved", "changes_requested", "dismissed"] },
   ]);
   assert.deepEqual(catalogs.review?.transitions.available, []);
-  assert.deepEqual(declared("review"), ["record"]);
+  assert.deepEqual(declared("review"), []);
+  assert.equal(
+    catalogs.review?.transitions.reason,
+    "Task lifecycle projection; no independent actions (decision/dec_A6B0EF213AE9643FD84EC5F197/CH1).",
+  );
   assert.deepEqual(catalogs.agent?.statusVocabulary, []);
   assert.equal(catalogs.agent?.transitions.catalogRef, "kernel/agent-action/v1");
   assert.deepEqual(catalogs.agent?.transitions.available, ["install", "validate", "list", "inspect"]);
   assert.deepEqual(declared("agent"), ["install", "validate", "list", "inspect"]);
   assert.deepEqual(catalogs.policy?.statusVocabulary, []);
   assert.deepEqual(catalogs.policy?.transitions.available, []);
-  assert.deepEqual(declared("policy"), ["draft", "activate", "retire"]);
+  assert.deepEqual(declared("policy"), []);
+  assert.equal(
+    catalogs.policy?.transitions.reason,
+    "Declaration entity; no independent write path (decision/dec_6FCDFB67623333335987D2542E/CH1).",
+  );
   assert.deepEqual(catalogs["runtime-session"]?.transitions.available, [
     "runtime_session_started",
     "runtime_session_provider_bound",

--- a/packages/kernel/test/contracts/kind-authority-version.test.ts
+++ b/packages/kernel/test/contracts/kind-authority-version.test.ts
@@ -55,6 +55,11 @@ test("one named kind-contract authority explains all thirteen entity kinds with 
         .map(({ id }) => id),
       `${explanation.kind} available Actions`,
     );
+  for (const kind of ["execution", "review", "policy"] as const) {
+    const transitions = explanations.find((explanation) => explanation.kind === kind)?.transitions;
+    assert.deepEqual(transitions?.actions, [], `${kind} declared Actions`);
+    assert.match(transitions?.reason ?? "", /decision\/dec_[A-Z0-9]+\/CH1/u, `${kind} no-Action decision`);
+  }
   assert.deepEqual(explanations.find(({ kind }) => kind === "task")?.sdkExposure, {
     sdk: { target: "TaskCapability", schemaId: "task-frontmatter" },
     agentCapability: { target: "task", schemaId: "task-frontmatter" },


### PR DESCRIPTION
# English

## Summary

Removes the declared-only Action aliases of `execution` (5), `review` (1) and `policy` (3) from the kernel entity-kind registry. These nine Actions were declared but never executable (`transitions.available` was empty for all three kinds), so `ha explain` and the GUI advertised phantom Actions. The three kinds stay registered entities; their catalogs are now empty and carry a decision-backed `reason` (`dec_A6B0EF21` for the Task-lifecycle projections `execution`/`review`, `dec_6FCDFB67` for the declaration entity `policy`). No hide switch, no compatibility branch.

## Architectural Justification

One capability, one production implementation: an Action that is declared but can never run is a second, fake implementation of a write path that does not exist. Deleting the alias makes the explain surface equal to the executable surface. The empty registered catalog keeps catalog-mode explanation admission for CLI/GUI consumers. Read-only projection change; no write subject, no concurrency implication for the fleet.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none

## Machine-Readable Declarations

Production-Delta: +16/-17
Dependency-Change: none

### Optional Evidence Claims

none

## Task And Scope

task_b4cf410d727e817ff62d67c4f3 (child of the tier-2 entity epic task_acd06bb4; derived from dec_6FCDFB67623333335987D2542E/CH1). In-file removals: the generic declared-only catalog constructor `actionCatalog(...)` and the nine alias entries in `entity-kind-registry.ts`; assertions that expected phantom Actions in `action-envelope.test.ts`.

## Version Impact

None.

## Governance Declaration

No protected path touched. No break-glass. The five daemon specialization files under the ontology ratchet and the GUI are untouched.

## Verification

- Worker stop point (targeted tests + local commit, no `check:local`): kernel `action-envelope` + `kind-authority-version` contract tests green; explain reproduction before/after: policy 3/0 → 0/0, execution 5/0 → 0/0, review 1/0 → 0/0, the other six kinds unchanged (agent 4/4, squad 7/7, runtime-session 7/7, schedule 13/13, settings 2/2, person 6/6); Task 11/11, Fact 6/6, Decision 15/15, Relation 3/3 unchanged.
- derived-contracts and implementation-contracts gates green locally. Fact F-9C258AB9 on the task.
- Branch merged with `origin/main` (`4c56e539`) before the PR; CI is the full authority.

## Review Evidence

Worker report: `harness/tasks/task_b4cf410d727e817ff62d67c4f3-*/artifacts/*-report.md` (private ledger). CEO semantic review: the diff is a pure narrowing (+16/-17 in the registry) that matches the two decisions verbatim and adds only the reason facet the explain surface needs; no daemon or GUI file changed.

## Residual Risk

Consumers that enumerated `execution`/`review`/`policy` Actions for display now get an empty list plus a reason; the focused kernel tests cover the explain projection, and CI covers the GUI explain views.

---

# 中文

## 概要

从 kernel entity-kind 注册表删除 `execution`(5)、`review`(1)、`policy`(3)的 declared-only 动作 alias。这九个动作只有声明、从不可执行(三者 `transitions.available` 均为空),`ha explain` 与 GUI 因此列出幻影动作。三种 kind 仍是注册实体;它们的 catalog 现在为空并带 decision 背书的 `reason`(`execution`/`review` 是 Task 生命周期投影,`dec_A6B0EF21`;`policy` 是声明实体,`dec_6FCDFB67`)。没有隐藏开关、没有兼容分支。

## 架构辩护

同一能力只允许一个生产实现:声明了却永远跑不了的动作,是对一条不存在写路的第二份假实现。删掉 alias 让 explain 面等于可执行面;空的注册 catalog 保留 CLI/GUI 的 catalog 模式解释准入。只读投影改动,不涉及写主体,对 fleet 无并发含义。

## 机读声明

见英文块。

## 治理声明

未触碰 protected 路径。无 break-glass。ontology 棘轮下的五个 daemon 特化文件与 GUI 零改动。

## 验证

- worker 停止点(定向测试 + 本地 commit,不跑 `check:local`):kernel `action-envelope` + `kind-authority-version` 契约测试绿;explain 前后复现:policy 3/0 → 0/0、execution 5/0 → 0/0、review 1/0 → 0/0,其余六 kind 不变(agent 4/4、squad 7/7、runtime-session 7/7、schedule 13/13、settings 2/2、person 6/6);Task 11/11、Fact 6/6、Decision 15/15、Relation 3/3 不变。
- derived-contracts 与 implementation-contracts 门本地绿。任务上 fact F-9C258AB9。
- 开 PR 前已与 `origin/main`(`4c56e539`)合并;CI 是完整权威。

## 评审证据

worker 报告见任务包 `artifacts/*-report.md`(私有台账)。CEO 语义验收:diff 是纯收窄(注册表 +16/-17),与两份 decision 逐字一致,只加了 explain 面需要的 reason facet;daemon 与 GUI 零改动。

## 残余风险

原先枚举 `execution`/`review`/`policy` 动作用于展示的消费方现在拿到空列表加 reason;kernel 定向测试覆盖 explain 投影,GUI explain 视图由 CI 覆盖。
