### PR TITLE
fix(daemon): degrade invalid collection rows individually instead of rejecting the whole read

### DIFF
--- a/packages/cli/src/cli/receipt-render-registry.ts
+++ b/packages/cli/src/cli/receipt-render-registry.ts
@@ -3,6 +3,7 @@ import {
   renderEntityActionExplanation,
   type EntityActionExplanationRenderInput,
 } from "./entity-action-explain-render.ts";
+import { consumeKnownError } from "../daemon/client.ts";
 import { humanError, renderReceiptGuidance } from "./guidance-plane.ts";
 import { renderScheduleList, renderScheduleRuns, renderScheduleShow } from "./thin-command-schedule.ts";
 
@@ -30,6 +31,7 @@ const commandRenderers = new Map<string, ReceiptRenderer>([
   ["schedule-list", renderScheduleReceipt],
   ["schedule-show", renderScheduleReceipt],
   ["schedule-runs", renderScheduleReceipt],
+  ["squad-list", renderSquadListReceipt],
 ]);
 
 const preOutcomeCommandRenderers = new Map<string, ReceiptRenderer>([["runtime-batch", renderRuntimeBatchReceipt]]);
@@ -112,6 +114,36 @@ function renderScheduleReceipt(receipt: Record<string, unknown>): string {
     renderScheduleRuns(receipt) ??
     renderSuccessfulReceipt(receipt)
   );
+}
+
+function renderSquadListReceipt(receipt: Record<string, unknown>): string {
+  if (typeof receipt.evidence !== "string") return renderSuccessfulReceipt(receipt);
+  try {
+    const parsed: unknown = JSON.parse(receipt.evidence);
+    if (!isRecord(parsed) || parsed.schema !== "squad-list/v1" || !Array.isArray(parsed.squads))
+      return renderSuccessfulReceipt(receipt);
+    if (parsed.squads.length === 0) return "No squads.";
+    return parsed.squads.map(squadListColumns).join("\n");
+  } catch (error) {
+    consumeKnownError(error);
+    return renderSuccessfulReceipt(receipt);
+  }
+}
+
+function squadListColumns(value: unknown): string {
+  if (!isRecord(value) || typeof value.id !== "string") throw new TypeError("Squad list row is invalid.");
+  if (value.state === "invalid") {
+    if (!isRecord(value.error) || typeof value.error.code !== "string" || typeof value.error.hint !== "string")
+      throw new TypeError("Degraded Squad list row is missing its structured error.");
+    return [value.id, value.state, `${value.error.code}: ${value.error.hint}`].join("\t");
+  }
+  if (value.validity !== "valid" && value.validity !== "blocked")
+    throw new TypeError("Available Squad list row is missing its validity.");
+  return [value.id, value.validity, "none"].join("\t");
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 function renderInitReceipt(receipt: Record<string, unknown>): string {

--- a/packages/cli/test/squad-list-render.test.ts
+++ b/packages/cli/test/squad-list-render.test.ts
@@ -1,0 +1,45 @@
+// harness-test-tier: fast
+import assert from "node:assert/strict";
+import test from "node:test";
+import { renderCliReceipt } from "../src/cli/receipt-render-registry.ts";
+
+test("Squad list renders healthy and degraded rows with state and error columns", () => {
+  const rendered = renderCliReceipt({
+    ok: true,
+    command: "squad-list",
+    evidence: JSON.stringify({
+      schema: "squad-list/v1",
+      squads: [
+        {
+          schema: "squad-declaration/v1",
+          id: "core-squad",
+          name: "Core Squad",
+          leader: "leader",
+          workers: ["worker"],
+          leaderTurnBudget: 4,
+          layer: "user",
+          source: "squads/core-squad.json",
+          validity: "valid",
+          issues: [],
+        },
+        {
+          id: "broken-squad",
+          layer: "user",
+          state: "invalid",
+          error: {
+            code: "invalid_entity_contract",
+            hint: 'squad declaration is missing required field "leader".',
+          },
+        },
+      ],
+    }),
+  });
+
+  assert.deepEqual(rendered, {
+    stream: "stdout",
+    text: [
+      "core-squad\tvalid\tnone",
+      'broken-squad\tinvalid\tinvalid_entity_contract: squad declaration is missing required field "leader".',
+    ].join("\n"),
+  });
+});

--- a/packages/daemon/src/agent-entities.contract.ts
+++ b/packages/daemon/src/agent-entities.contract.ts
@@ -102,6 +102,7 @@ function entityReadRowErrors(value: unknown, fields: readonly string[], prefix: 
 }
 const agentCatalogRowFields = Object.freeze(["id", "name", "runtimeType", "role", "layer", "validity", "issues"]),
   squadCatalogRowFields = Object.freeze(["id", "name", "leader", "workers", "layer", "validity", "issues"]),
+  degradedCatalogRowFields = Object.freeze(["id", "layer", "state", "error"]),
   agentDetailFields = Object.freeze([
     "id",
     "name",
@@ -126,15 +127,36 @@ function catalogErrors(
   if (!isEntityRecord(value) || !Array.isArray(value[field]))
     return [...errors, `${schema} field "${field}" must be an array.`];
   value[field].forEach((row, index) =>
-    errors.push(
-      ...entityReadRowErrors(row, rowFields, `${field}[${index}]`),
-      ...(isEntityRecord(row) ? rowChecks(row) : []),
-      ...(isEntityRecord(row) && Array.isArray(row.issues)
-        ? row.issues.flatMap(entityIssueRow)
-        : [`${field}[${index}] field "issues" must be an array.`]),
-    ),
+    errors.push(...catalogRowErrors(row, rowFields, rowChecks, `${field}[${index}]`)),
   );
   return errors;
+}
+function catalogRowErrors(
+  row: unknown,
+  rowFields: readonly string[],
+  rowChecks: (row: Record<string, unknown>) => readonly string[],
+  prefix: string,
+): readonly string[] {
+  if (isEntityRecord(row) && Object.hasOwn(row, "state")) {
+    const errors = [...entityReadRowErrors(row, degradedCatalogRowFields, prefix)];
+    if (!(entityNonEmpty(row.id) && row.layer === "user" && ["invalid", "missing"].includes(String(row.state))))
+      errors.push(`${prefix} degraded rows need an id, user layer, and invalid or missing state.`);
+    if (
+      !isEntityRecord(row.error) ||
+      Object.keys(row.error).length !== 2 ||
+      !entityNonEmpty(row.error.code) ||
+      !entityNonEmpty(row.error.hint)
+    )
+      errors.push(`${prefix} degraded rows need an exact non-empty error {code, hint}.`);
+    return errors;
+  }
+  return [
+    ...entityReadRowErrors(row, rowFields, prefix),
+    ...(isEntityRecord(row) ? rowChecks(row) : []),
+    ...(isEntityRecord(row) && Array.isArray(row.issues)
+      ? row.issues.flatMap(entityIssueRow)
+      : [`${prefix} field "issues" must be an array.`]),
+  ];
 }
 function detailErrors(
   value: unknown,

--- a/packages/daemon/src/agent-entities.ts
+++ b/packages/daemon/src/agent-entities.ts
@@ -31,7 +31,7 @@ export type SquadCatalogRow = Omit<SquadDeclarationV1, "roster"> & {
   readonly validity: "valid" | "blocked";
   readonly issues: readonly { readonly code: string; readonly message: string }[];
 };
-export interface AgentEntityGuiRow {
+export interface AgentEntityGuiAvailableRow {
   readonly id: string;
   readonly name: string;
   readonly runtimeType: string;
@@ -40,7 +40,7 @@ export interface AgentEntityGuiRow {
   readonly validity: "valid" | "blocked";
   readonly issues: readonly { readonly code: string; readonly message: string }[];
 }
-export interface SquadEntityGuiRow {
+export interface SquadEntityGuiAvailableRow {
   readonly id: string;
   readonly name: string;
   readonly leader: string;
@@ -48,6 +48,22 @@ export interface SquadEntityGuiRow {
   readonly layer: string;
   readonly validity: "valid" | "blocked";
   readonly issues: readonly { readonly code: string; readonly message: string }[];
+}
+export interface AgentEntityGuiDegradedRow {
+  readonly id: string;
+  readonly layer: "user";
+  readonly state: "invalid" | "missing";
+  readonly error: { readonly code: string; readonly hint: string };
+}
+export type AgentEntityGuiRow = AgentEntityGuiAvailableRow | AgentEntityGuiDegradedRow;
+export type SquadEntityGuiRow = SquadEntityGuiAvailableRow | AgentEntityGuiDegradedRow;
+
+export function isAvailableAgentEntityGuiRow(row: AgentEntityGuiRow): row is AgentEntityGuiAvailableRow {
+  return !("state" in row);
+}
+
+export function isAvailableSquadEntityGuiRow(row: SquadEntityGuiRow): row is SquadEntityGuiAvailableRow {
+  return !("state" in row);
 }
 export interface AgentEntityGuiDetail {
   readonly id: string;
@@ -163,19 +179,16 @@ export function readAgentEntityGuiProjection<
     return {
       schema: "agent-entity-catalog/v1",
       ok: true,
-      agents: entities.map(({ value }) =>
-        agentEntityRow({ ...parseAgentDeclarationV1(value), layer: "user", validity: "valid", issues: [] }),
-      ),
+      agents: entities.map((row) => agentEntityCatalogRow(row)),
     } as never;
   }
   if (input.kind === "squad-list") {
-    const entities = readyEntityList(input.projection, "squad");
+    const entities = readyEntityList(input.projection, "squad"),
+      agents = new Map(readyEntityList(input.projection, "agent").map((row) => [row.id, agentEntityCatalogRow(row)]));
     return {
       schema: "squad-entity-catalog/v1",
       ok: true,
-      squads: entities.map(({ value }) =>
-        squadEntityRow({ ...parseSquadDeclarationV1(value), layer: "user", validity: "valid", issues: [] }),
-      ),
+      squads: entities.map((row) => squadEntityCatalogRow(row, agents)),
     } as never;
   }
   const entityId = requiredEntityText(input.entityId, "entityId");
@@ -230,6 +243,73 @@ export function readAgentEntityGuiProjection<
 
 function readyEntityList(projection: Pick<TaskProjection, "listEntities">, kind: AgentEntityKind) {
   return projection.listEntities(kind);
+}
+
+type AgentEntityProjectionRow = ReturnType<Pick<TaskProjection, "listEntities">["listEntities"]>[number];
+
+function projectionEntityState(row: AgentEntityProjectionRow): AgentEntityGuiDegradedRow | null {
+  if (row.freshness === "current") return null;
+  const state = row.freshness === "orphaned" ? "missing" : "invalid";
+  return {
+    id: row.id,
+    layer: "user",
+    state,
+    error: {
+      code: state === "missing" ? `${row.kind}_not_found` : "invalid_entity_projection",
+      hint:
+        state === "missing"
+          ? `${row.id} is not an installed ${row.kind}.`
+          : `${row.kind} projection ${row.id} is not current.`,
+    },
+  };
+}
+
+function invalidEntityCatalogRow(row: AgentEntityProjectionRow, error: unknown): AgentEntityGuiDegradedRow {
+  if ((error as { readonly code?: unknown })?.code !== "invalid_entity_contract") throw error;
+  return {
+    id: row.id,
+    layer: "user",
+    state: "invalid",
+    error: { code: "invalid_entity_contract", hint: error instanceof Error ? error.message : String(error) },
+  };
+}
+
+function agentEntityCatalogRow(row: AgentEntityProjectionRow): AgentEntityGuiRow {
+  const degraded = projectionEntityState(row);
+  if (degraded) return degraded;
+  try {
+    return agentEntityRow({ ...parseAgentDeclarationV1(row.value), layer: "user", validity: "valid", issues: [] });
+  } catch (error) {
+    return invalidEntityCatalogRow(row, error);
+  }
+}
+
+function squadEntityCatalogRow(
+  row: AgentEntityProjectionRow,
+  agents: ReadonlyMap<string, AgentEntityGuiRow>,
+): SquadEntityGuiRow {
+  const degraded = projectionEntityState(row);
+  if (degraded) return degraded;
+  try {
+    const squad = parseSquadDeclarationV1(row.value),
+      missing = [...new Set([squad.leader, ...squad.workers])].filter((agentId) => {
+        const agent = agents.get(agentId);
+        return agent === undefined || !isAvailableAgentEntityGuiRow(agent);
+      });
+    if (missing.length)
+      return {
+        id: row.id,
+        layer: "user",
+        state: "missing",
+        error: {
+          code: "squad_agent_not_found",
+          hint: `Squad ${squad.id} references unavailable agents: ${missing.join(", ")}.`,
+        },
+      };
+    return squadEntityRow({ ...squad, layer: "user", validity: "valid", issues: [] });
+  } catch (error) {
+    return invalidEntityCatalogRow(row, error);
+  }
 }
 
 function readyEntityValue(
@@ -466,7 +546,7 @@ function listStoredEntities(
     })
     .sort((left, right) => left.id.localeCompare(right.id));
 }
-function agentEntityRow(value: Record<string, unknown>): AgentEntityGuiRow {
+function agentEntityRow(value: Record<string, unknown>): AgentEntityGuiAvailableRow {
   return {
     id: entityText(value.id),
     name: entityText(value.name),
@@ -477,7 +557,7 @@ function agentEntityRow(value: Record<string, unknown>): AgentEntityGuiRow {
     issues: entityIssues(value.issues),
   };
 }
-function squadEntityRow(value: Record<string, unknown>): SquadEntityGuiRow {
+function squadEntityRow(value: Record<string, unknown>): SquadEntityGuiAvailableRow {
   return {
     id: entityText(value.id),
     name: entityText(value.name),

--- a/packages/daemon/src/protocol/schedules-gui-contract.ts
+++ b/packages/daemon/src/protocol/schedules-gui-contract.ts
@@ -29,12 +29,26 @@ export interface ScheduleGuiActionFacet {
   readonly nextAction: string | null;
 }
 
+export type ScheduleGuiAgentOptionDto =
+  | {
+      readonly agentId: string;
+      readonly name: string;
+      readonly runtimeType: string;
+    }
+  | {
+      readonly agentId: string;
+      readonly state: "invalid" | "missing";
+      readonly error: { readonly code: string; readonly hint: string };
+    };
+
+export function isAvailableScheduleGuiAgentOption(
+  option: ScheduleGuiAgentOptionDto,
+): option is Extract<ScheduleGuiAgentOptionDto, { readonly name: string }> {
+  return !("state" in option);
+}
+
 export interface ScheduleGuiOptionsDto {
-  readonly agents: readonly {
-    readonly agentId: string;
-    readonly name: string;
-    readonly runtimeType: string;
-  }[];
+  readonly agents: readonly ScheduleGuiAgentOptionDto[];
   readonly instances: readonly {
     readonly instanceId: string;
     readonly name: string;
@@ -65,6 +79,8 @@ export interface ScheduleGuiRowDto {
         readonly cwd: string | null;
       }
     | { readonly kind: "squad"; readonly squadId: string };
+  readonly targetState?: "invalid" | "missing";
+  readonly targetError?: { readonly code: string; readonly hint: string };
   readonly mission: string;
   readonly executionAvailability: ScheduleExecutionAvailability;
   readonly claim: { readonly nodeId: string | null; readonly assignmentId: string | null };
@@ -147,6 +163,8 @@ const scheduleGuiRowFields = [
   "definitionRevision",
   "trigger",
   "target",
+  "targetState",
+  "targetError",
   "mission",
   "executionAvailability",
   "claim",
@@ -319,6 +337,7 @@ export function validateSchedulesList(value: unknown): readonly string[] {
       Number(row.definitionRevision) < 0 ||
       !validTriggerDto(row.trigger) ||
       !validTargetDto(row.target) ||
+      !validTargetProjection(row) ||
       typeof row.mission !== "string" ||
       !scheduleGuiAvailabilityWords.includes(String(row.executionAvailability)) ||
       !isJsonObject(row.claim) ||
@@ -366,14 +385,7 @@ function validOptions(value: unknown): boolean {
   )
     return false;
   return (
-    value.agents.every(
-      (agent) =>
-        isJsonObject(agent) &&
-        Object.keys(agent).length === 3 &&
-        scheduleNonEmptyText(agent.agentId) &&
-        scheduleNonEmptyText(agent.name) &&
-        scheduleNonEmptyText(agent.runtimeType),
-    ) &&
+    value.agents.every(validAgentOption) &&
     value.instances.every(
       (instance) =>
         isJsonObject(instance) &&
@@ -389,6 +401,38 @@ function validOptions(value: unknown): boolean {
     value.cwd.length > 0 &&
     value.cwd[0] === "." &&
     value.cwd.every(scheduleNonEmptyText)
+  );
+}
+
+function validAgentOption(agent: unknown): boolean {
+  if (!isJsonObject(agent) || !scheduleNonEmptyText(agent.agentId)) return false;
+  if (Object.hasOwn(agent, "state"))
+    return (
+      Object.keys(agent).length === 3 &&
+      ["invalid", "missing"].includes(String(agent.state)) &&
+      validProjectionError(agent.error)
+    );
+  return Object.keys(agent).length === 3 && scheduleNonEmptyText(agent.name) && scheduleNonEmptyText(agent.runtimeType);
+}
+
+function validProjectionError(value: unknown): boolean {
+  return (
+    isJsonObject(value) &&
+    Object.keys(value).length === 2 &&
+    scheduleNonEmptyText(value.code) &&
+    scheduleNonEmptyText(value.hint)
+  );
+}
+
+function validTargetProjection(row: Record<string, unknown>): boolean {
+  const hasState = Object.hasOwn(row, "targetState"),
+    hasError = Object.hasOwn(row, "targetError");
+  if (!hasState && !hasError) return true;
+  return (
+    hasState &&
+    hasError &&
+    ["invalid", "missing"].includes(String(row.targetState)) &&
+    validProjectionError(row.targetError)
   );
 }
 

--- a/packages/daemon/src/schedules-gui-read.ts
+++ b/packages/daemon/src/schedules-gui-read.ts
@@ -14,6 +14,7 @@ import { scheduleReasoningEfforts } from "./protocol/daemon-protocol-commands-ru
 import { commandDescriptorForAction } from "./protocol/daemon-protocol-commands.ts";
 import type {
   ScheduleExecutionAvailability,
+  ScheduleGuiAgentOptionDto,
   ScheduleGuiActionFacet,
   ScheduleGuiInvalidRowDto,
   ScheduleGuiListRowDto,
@@ -22,6 +23,7 @@ import type {
   ScheduleGuiTriggerDto,
   SchedulesListResult,
 } from "./protocol/schedules-gui-contract.ts";
+import { isAvailableScheduleGuiAgentOption } from "./protocol/schedules-gui-contract.ts";
 import { admitRepoMode } from "./repo-mode.ts";
 import { makeGitReadinessSource } from "./process-port.ts";
 
@@ -42,6 +44,7 @@ export interface SchedulesGuiReadContext {
       readonly id?: string;
       readonly value: unknown;
       readonly workspaceRevision: number;
+      readonly freshness?: "current" | "orphaned" | "unknown";
     }[];
     readonly readTaskStatuses: () => {
       readonly status: "ready" | "pending";
@@ -275,7 +278,9 @@ export function readSchedulesGui(context: SchedulesGuiReadContext): SchedulesLis
     now = context.now(),
     viewerNodeId = viewerNodeIdOf(mode, context.rootDir),
     roster = rosterOf(mode, context.rootDir, context.fleetRoster),
-    cut = context.projection.readTaskStatuses();
+    cut = context.projection.readTaskStatuses(),
+    agentOptions = scheduleAgentOptions(context),
+    agentsById = new Map(agentOptions.map((agent) => [agent.agentId, agent]));
   const schedules = context.projection
     .listEntities("schedule")
     .map((row): ScheduleGuiListRowDto => {
@@ -292,7 +297,21 @@ export function readSchedulesGui(context: SchedulesGuiReadContext): SchedulesLis
           activeNodeId: schedule.status.activeRun?.nodeId ?? null,
           now,
         }),
-        assignment = scheduleAssignmentOf(roster, context.input.repoId, schedule.scheduleId, now);
+        assignment = scheduleAssignmentOf(roster, context.input.repoId, schedule.scheduleId, now),
+        targetProjection =
+          schedule.spec.target.kind === "agent"
+            ? scheduleTargetProjection(schedule.spec.target.agentId, agentsById.get(schedule.spec.target.agentId))
+            : null,
+        runNow = runNowFacet({
+          mode,
+          state: schedule.state,
+          availability,
+          active: schedule.status.activeRun
+            ? { occurrenceId: schedule.status.activeRun.occurrenceId, nodeId: schedule.status.activeRun.nodeId }
+            : null,
+          claimNodeId: assignment?.nodeId ?? null,
+          targetKind: schedule.spec.target.kind,
+        });
       return {
         scheduleId: schedule.scheduleId,
         name: schedule.name,
@@ -313,6 +332,7 @@ export function readSchedulesGui(context: SchedulesGuiReadContext): SchedulesLis
                 cwd: schedule.spec.target.cwd ?? null,
               }
             : { kind: "squad", squadId: schedule.spec.target.squadId },
+        ...(targetProjection ? { targetState: targetProjection.state, targetError: targetProjection.error } : {}),
         mission: schedule.spec.mission,
         executionAvailability: availability,
         claim: active
@@ -326,16 +346,14 @@ export function readSchedulesGui(context: SchedulesGuiReadContext): SchedulesLis
           delete: deleteFacet(mode, schedule.status.activeRun),
           enable: stateFacet("schedule-enable", mode, schedule.state),
           disable: stateFacet("schedule-disable", mode, schedule.state),
-          runNow: runNowFacet({
-            mode,
-            state: schedule.state,
-            availability,
-            active: schedule.status.activeRun
-              ? { occurrenceId: schedule.status.activeRun.occurrenceId, nodeId: schedule.status.activeRun.nodeId }
-              : null,
-            claimNodeId: assignment?.nodeId ?? null,
-            targetKind: schedule.spec.target.kind,
-          }),
+          runNow:
+            targetProjection && runNow.available
+              ? {
+                  available: false,
+                  code: "schedule_target_unavailable",
+                  nextAction: targetProjection.error.hint,
+                }
+              : runNow,
         },
         activeRun: active,
         lastRun: lastRunDtoOf(schedule),
@@ -356,7 +374,7 @@ export function readSchedulesGui(context: SchedulesGuiReadContext): SchedulesLis
     repoMode: mode,
     viewerNodeId,
     actions: { create: admissionFacet("schedule-create", mode) },
-    options: scheduleOptions(context, schedules),
+    options: scheduleOptions(context, schedules, agentOptions),
     schedules,
     watermark: cut.watermark,
     sourceRevision: cut.sourceRevision,
@@ -366,12 +384,9 @@ export function readSchedulesGui(context: SchedulesGuiReadContext): SchedulesLis
 function scheduleOptions(
   context: SchedulesGuiReadContext,
   schedules: readonly ScheduleGuiListRowDto[],
+  agents: readonly ScheduleGuiAgentOptionDto[],
 ): ScheduleGuiOptionsDto {
-  const agents = context.projection.listEntities("agent").map(({ value }) => {
-      const agent = parseAgentDeclarationV1(value);
-      return { agentId: agent.id, name: agent.name, runtimeType: agent.runtime_type };
-    }),
-    instances = (context.input.runtimeInstances?.() ?? [])
+  const instances = (context.input.runtimeInstances?.() ?? [])
       .filter(({ enabled }) => enabled)
       .map((instance) => ({
         instanceId: instance.instanceId,
@@ -390,10 +405,58 @@ function scheduleOptions(
     if (schedule.state !== "invalid" && schedule.target.kind === "agent" && schedule.target.cwd)
       cwd.add(schedule.target.cwd);
   return {
-    agents: agents.sort((left, right) => left.agentId.localeCompare(right.agentId)),
+    agents: [...agents].sort((left, right) => left.agentId.localeCompare(right.agentId)),
     instances: instances.sort((left, right) => left.instanceId.localeCompare(right.instanceId)),
     cwd: [...cwd].sort((left, right) => (left === "." ? -1 : right === "." ? 1 : left.localeCompare(right))),
   };
+}
+
+function scheduleAgentOptions(context: SchedulesGuiReadContext): readonly ScheduleGuiAgentOptionDto[] {
+  return context.projection.listEntities("agent").map((row) => {
+    const agentId = row.id ?? projectedAgentId(row.value);
+    if (row.freshness === "orphaned")
+      return {
+        agentId,
+        state: "missing",
+        error: { code: "agent_not_found", hint: `${agentId} is not an installed agent.` },
+      };
+    if (row.freshness === "unknown")
+      return {
+        agentId,
+        state: "invalid",
+        error: { code: "invalid_entity_projection", hint: `Agent projection ${agentId} is not current.` },
+      };
+    try {
+      const agent = parseAgentDeclarationV1(row.value);
+      return { agentId: agent.id, name: agent.name, runtimeType: agent.runtime_type };
+    } catch (error) {
+      if ((error as { readonly code?: unknown })?.code !== "invalid_entity_contract") throw error;
+      return {
+        agentId,
+        state: "invalid",
+        error: { code: "invalid_entity_contract", hint: error instanceof Error ? error.message : String(error) },
+      };
+    }
+  });
+}
+
+function projectedAgentId(value: unknown): string {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return "unknown";
+  const id = (value as Readonly<Record<string, unknown>>).id;
+  return typeof id === "string" && id ? id : "unknown";
+}
+
+function scheduleTargetProjection(
+  agentId: string,
+  option: ScheduleGuiAgentOptionDto | undefined,
+): Extract<ScheduleGuiAgentOptionDto, { readonly state: "invalid" | "missing" }> | null {
+  if (option === undefined)
+    return {
+      agentId,
+      state: "missing",
+      error: { code: "agent_not_found", hint: `${agentId} is not an installed agent.` },
+    };
+  return isAvailableScheduleGuiAgentOption(option) ? null : option;
 }
 
 function invalidScheduleGuiRow(

--- a/packages/daemon/src/squad-action-runtime.ts
+++ b/packages/daemon/src/squad-action-runtime.ts
@@ -1,6 +1,7 @@
 import {
   parseAgentDeclarationV1,
   parseSquadDeclarationV1,
+  type SquadDeclarationV1,
   type WriteReceiptDraft as WriteReceipt,
 } from "../../kernel/src/index.ts";
 import { runAgentEntityAction } from "./agent-entities.ts";
@@ -51,17 +52,47 @@ export function makeSquadActionRuntime(cell: RepoCellRuntimeContext): EntityActi
   };
 }
 
-function listSquads(cell: RepoCellRuntimeContext): object {
-  const squads = cell.projection.listEntities("squad").map(({ value, id }) => {
-    const declaration = parseSquadDeclarationV1(value),
-      { roster: _roster, ...row } = declaration;
-    return {
-      ...row,
-      layer: "user",
-      source: `squads/${id}.json`,
-      validity: "valid",
-      issues: [],
+type SquadListRow =
+  | (Omit<SquadDeclarationV1, "roster"> & {
+      readonly layer: "user";
+      readonly source: string;
+      readonly validity: "valid";
+      readonly issues: readonly [];
+    })
+  | {
+      readonly id: string;
+      readonly layer: "user";
+      readonly state: "invalid";
+      readonly error: { readonly code: "invalid_entity_contract"; readonly hint: string };
     };
+
+function listSquads(cell: RepoCellRuntimeContext): {
+  readonly schema: "squad-list/v1";
+  readonly squads: SquadListRow[];
+} {
+  const squads = cell.projection.listEntities("squad").map(({ value, id }) => {
+    try {
+      const declaration = parseSquadDeclarationV1(value),
+        { roster: _roster, ...row } = declaration;
+      return {
+        ...row,
+        layer: "user" as const,
+        source: `squads/${id}.json`,
+        validity: "valid" as const,
+        issues: [] as const,
+      };
+    } catch (error) {
+      if ((error as { readonly code?: unknown })?.code !== "invalid_entity_contract") throw error;
+      return {
+        id,
+        layer: "user" as const,
+        state: "invalid" as const,
+        error: {
+          code: "invalid_entity_contract" as const,
+          hint: error instanceof Error ? error.message : String(error),
+        },
+      };
+    }
   });
   return { schema: "squad-list/v1", squads };
 }

--- a/packages/daemon/src/squad-coordinator.ts
+++ b/packages/daemon/src/squad-coordinator.ts
@@ -37,6 +37,7 @@ import {
   listQuery,
   matchesRunQuery,
   runInActivityWindow,
+  squadReadError,
 } from "./squad-run-list.ts";
 import type {
   SquadRunInvalidSummaryDto,
@@ -1043,12 +1044,6 @@ function dispatchRowStamps(row: TaskDispatchRow | undefined): readonly string[] 
 
 function validSquadRunId(value: unknown): value is string {
   return typeof value === "string" && /^squad_[a-f0-9]{24}$/u.test(value);
-}
-
-function squadReadError(code: string, message: string): Error {
-  const error = new Error(message) as Error & { code: string };
-  error.code = code;
-  return error;
 }
 
 function errorText(error: unknown): string {

--- a/packages/daemon/src/squad-coordinator.ts
+++ b/packages/daemon/src/squad-coordinator.ts
@@ -30,12 +30,23 @@ import {
   type WorkerPlan,
   type WorkerWaitTrigger,
 } from "./squad-leader-decision.ts";
+import {
+  activePhase,
+  compareRunSummaries,
+  invalidSquadRunProjection,
+  listQuery,
+  matchesRunQuery,
+  runInActivityWindow,
+} from "./squad-run-list.ts";
 import type {
+  SquadRunInvalidSummaryDto,
+  SquadRunListRowDto,
   SquadRunPhase,
   SquadRunReadResult,
   SquadRunsListResult,
   SquadRunSummaryDto,
 } from "./squad-run-contract.ts";
+import { isAvailableSquadRunSummary } from "./squad-run-contract.ts";
 
 type SquadState = {
   readonly schema: "squad-run/v1";
@@ -172,6 +183,18 @@ export function makeSquadCoordinator(input: {
         "squad/run-present",
         ["Run ha squad run <squad-id> --instance <runtime-instance-id> --task <task-id> first."],
       );
+    if ("projectionState" in state)
+      return {
+        schema: "command-receipt/v2",
+        ok: true,
+        command: "squad-status",
+        outcome: "applied",
+        ...state,
+        status: "invalid",
+        summary: state.projectionError.hint,
+        nextAction: state.projectionError.hint,
+        exitCode: 0,
+      };
     const detail = statusDto(state);
     return {
       schema: "command-receipt/v2",
@@ -201,6 +224,14 @@ export function makeSquadCoordinator(input: {
         "cancel",
         "squad/run-present",
         ["Run ha squad status <squad-run-id> and choose an existing run."],
+      );
+    if ("projectionState" in state)
+      throw cellCriterionError(
+        state.projectionError.code,
+        state.projectionError.hint,
+        "cancel",
+        "squad/run-projection-valid",
+        ["Repair or rebuild the Squad run projection, then retry the cancellation."],
       );
     if (state.phase !== "cancelled")
       writeState(
@@ -277,9 +308,14 @@ export function makeSquadCoordinator(input: {
       cut = input.projection().readTaskStatuses([]),
       // 一次 list 内按 taskId memo 派工台账读:同 task 的多个 run 共享一次读,读放大按 task 数结算。
       dispatchesByTaskId = new Map<string, readonly TaskDispatchRow[]>(),
-      matching = readStates()
-        .map((state) => summaryDto(state, dispatchesByTaskId))
-        .filter((run) => activePhase(run.phase) || query.since === null || runInActivityWindow(run, query.since))
+      matching = readListRows(dispatchesByTaskId)
+        .filter(
+          (run) =>
+            !isAvailableSquadRunSummary(run) ||
+            activePhase(run.phase) ||
+            query.since === null ||
+            runInActivityWindow(run, query.since),
+        )
         .filter((run) => matchesRunQuery(run, query.tokens))
         .sort(compareRunSummaries),
       selected = matching.slice(0, query.limit);
@@ -306,6 +342,14 @@ export function makeSquadCoordinator(input: {
     const state = readSquadRunState(squadRunId);
     if (!state) throw squadReadError("squad_run_not_found", `Squad run ${squadRunId} does not exist.`);
     const cut = input.projection().readTaskStatuses([]);
+    if ("projectionState" in state)
+      return {
+        ok: true,
+        status: cut.status,
+        run: state,
+        watermark: cut.watermark,
+        sourceRevision: cut.sourceRevision,
+      };
     return detailDto(state, cut);
   };
 
@@ -317,12 +361,12 @@ export function makeSquadCoordinator(input: {
     for (const candidate of readStates()) {
       if (terminal(candidate)) continue;
       let state = readSquadRunState(candidate.squadRunId);
-      if (!state || terminal(state)) continue;
+      if (!state || "projectionState" in state || terminal(state)) continue;
       const currentLeader = state.currentLeaderRuntimeSessionId;
       if (currentLeader && terminalRow(state, currentLeader)) {
         await observeRuntimeSession(currentLeader);
         state = readSquadRunState(candidate.squadRunId);
-        if (!state || terminal(state)) continue;
+        if (!state || "projectionState" in state || terminal(state)) continue;
       }
       const discovered = discoverWorkerCallbacks(state);
       if (discovered !== state) {
@@ -337,7 +381,7 @@ export function makeSquadCoordinator(input: {
     for (const candidate of readStates()) {
       if (terminal(candidate)) continue;
       const state = readSquadRunState(candidate.squadRunId);
-      if (!state || terminal(state)) continue;
+      if (!state || "projectionState" in state || terminal(state)) continue;
       if (state.currentLeaderRuntimeSessionId === runtimeSessionId) {
         await continueLeader(state, runtimeSessionId);
         return;
@@ -725,13 +769,12 @@ export function makeSquadCoordinator(input: {
     return blob ? new TextDecoder().decode(blob) || null : null;
   }
 
-  function readSquadRunState(squadRunId: string): SquadState | null {
+  function readSquadRunState(squadRunId: string): SquadState | SquadRunInvalidSummaryDto | null {
     if (!validSquadRunId(squadRunId)) return null;
     ensureSquadRunProjection();
     const row = input.projection().readSquadRun(squadRunId),
       state = squadState(row?.state);
-    if (row !== null && state === null) throw new Error(`Squad run projection ${squadRunId} is invalid.`);
-    return state;
+    return row !== null && state === null ? invalidSquadRunProjection(squadRunId) : state;
   }
 
   function readStates(): readonly SquadState[] {
@@ -739,10 +782,20 @@ export function makeSquadCoordinator(input: {
     return input
       .projection()
       .readSquadRuns()
+      .flatMap((row) => {
+        const state = squadState(row.state);
+        return state ? [state] : [];
+      });
+  }
+
+  function readListRows(dispatchesByTaskId: Map<string, readonly TaskDispatchRow[]>): readonly SquadRunListRowDto[] {
+    ensureSquadRunProjection();
+    return input
+      .projection()
+      .readSquadRuns()
       .map((row) => {
         const state = squadState(row.state);
-        if (!state) throw new Error(`Squad run projection ${row.squadRunId} is invalid.`);
-        return state;
+        return state ? summaryDto(state, dispatchesByTaskId) : invalidSquadRunProjection(row.squadRunId);
       });
   }
 
@@ -983,56 +1036,9 @@ function cwdPayload(rootDir: string, cwd: string): JsonObject {
   return relative ? { scope: "repo-relative", path: relative } : { scope: "repo-root" };
 }
 
-function listQuery(payload: Readonly<Record<string, unknown>>): {
-  readonly since: string | null;
-  readonly tokens: readonly string[];
-  readonly limit: number;
-} {
-  const fields = Object.keys(payload),
-    since = payload.since,
-    query = payload.query,
-    limit = payload.limit;
-  if (
-    fields.some((field) => !["since", "query", "limit"].includes(field)) ||
-    (since !== undefined && (typeof since !== "string" || !Number.isFinite(Date.parse(since)))) ||
-    (query !== undefined && typeof query !== "string") ||
-    (limit !== undefined && (!Number.isSafeInteger(limit) || Number(limit) < 1 || Number(limit) > 1_000))
-  )
-    throw squadReadError("invalid_request", "Squad run lists accept ISO since, text query, and limit 1..1000.");
-  return {
-    since: typeof since === "string" ? new Date(since).toISOString() : null,
-    tokens: typeof query === "string" ? query.toLocaleLowerCase().trim().split(/\s+/u).filter(Boolean) : [],
-    limit: typeof limit === "number" ? limit : 200,
-  };
-}
-
-function matchesRunQuery(run: SquadRunSummaryDto, tokens: readonly string[]): boolean {
-  const searchable = [run.squadRunId, run.squadId, run.taskId, run.mission, run.phase].join("\n").toLocaleLowerCase();
-  return tokens.every((token) => searchable.includes(token));
-}
-
-function activePhase(phase: SquadRunPhase): boolean {
-  return phase === "planning" || phase === "leader_running" || phase === "workers_running";
-}
-
-/** 小队 run 版的活动窗判定,语义对齐 kernel 的 runtimeSessionInActivityWindow:比时间
- * 瞬值而非字符串,不同毫秒精度/秒精度的 ISO 戳不会因字典序错判进出窗口。 */
-function runInActivityWindow(run: SquadRunSummaryDto, since: string): boolean {
-  return Date.parse(run.latestActivityAt) >= Date.parse(since);
-}
-
 /** 派工台账行的已落盘时间事实:startedAt 恒有,endedAt 仅归档结算行有;无台账行的派工不贡献时间。 */
 function dispatchRowStamps(row: TaskDispatchRow | undefined): readonly string[] {
   return row === undefined ? [] : [row.startedAt, ...(row.endedAt === null ? [] : [row.endedAt])];
-}
-
-function compareRunSummaries(left: SquadRunSummaryDto, right: SquadRunSummaryDto): number {
-  const active = Number(activePhase(right.phase)) - Number(activePhase(left.phase));
-  return (
-    active ||
-    Date.parse(right.latestActivityAt) - Date.parse(left.latestActivityAt) ||
-    left.squadRunId.localeCompare(right.squadRunId)
-  );
 }
 
 function validSquadRunId(value: unknown): value is string {

--- a/packages/daemon/src/squad-run-contract.ts
+++ b/packages/daemon/src/squad-run-contract.ts
@@ -12,10 +12,22 @@ export interface SquadRunSummaryDto {
   readonly latestActivityAt: string;
 }
 
+export interface SquadRunInvalidSummaryDto {
+  readonly squadRunId: string;
+  readonly projectionState: "invalid";
+  readonly projectionError: { readonly code: "squad_run_projection_invalid"; readonly hint: string };
+}
+
+export type SquadRunListRowDto = SquadRunSummaryDto | SquadRunInvalidSummaryDto;
+
+export function isAvailableSquadRunSummary(row: SquadRunListRowDto): row is SquadRunSummaryDto {
+  return !("projectionState" in row);
+}
+
 export type SquadRunsListResult = {
   readonly ok: true;
   readonly status: "ready" | "pending";
-  readonly runs: readonly SquadRunSummaryDto[];
+  readonly runs: readonly SquadRunListRowDto[];
   readonly totals: { readonly runs: number };
   readonly truncated: boolean;
   readonly watermark: number;
@@ -61,20 +73,28 @@ export interface SquadRunWorkerAttemptDto {
 /** `ha squad status` 的 statusDto 对 GUI 开放的编排流转扇出树(leaderTurnId 是
  * 父子边,turn.resultText 是该轮 receipt 原文):全部来自 SquadState、既有派工
  * 台账行及其 resultRef 指向的内容包,零新计算。 */
+export interface SquadRunDetailDto {
+  readonly squadRunId: string;
+  readonly squadId: string;
+  readonly taskId: string;
+  readonly mission: string;
+  readonly phase: SquadRunPhase;
+  readonly error: string | null;
+  readonly currentLeaderRuntimeSessionId: string | null;
+  readonly leaderTurns: readonly SquadRunLeaderTurnDto[];
+  readonly workerAttempts: readonly SquadRunWorkerAttemptDto[];
+}
+
+export function isAvailableSquadRunDetail(
+  run: SquadRunDetailDto | SquadRunInvalidSummaryDto,
+): run is SquadRunDetailDto {
+  return !("projectionState" in run);
+}
+
 export type SquadRunReadResult = {
   readonly ok: true;
   readonly status: "ready" | "pending";
-  readonly run: {
-    readonly squadRunId: string;
-    readonly squadId: string;
-    readonly taskId: string;
-    readonly mission: string;
-    readonly phase: SquadRunPhase;
-    readonly error: string | null;
-    readonly currentLeaderRuntimeSessionId: string | null;
-    readonly leaderTurns: readonly SquadRunLeaderTurnDto[];
-    readonly workerAttempts: readonly SquadRunWorkerAttemptDto[];
-  };
+  readonly run: SquadRunDetailDto | SquadRunInvalidSummaryDto;
   readonly watermark: number;
   readonly sourceRevision: number;
 };
@@ -111,6 +131,17 @@ export const serializeSquadRunsList = (value: unknown): string =>
   serializeSquadRunContract(value, validateSquadRunsList);
 
 export function validateSquadRunRead(value: unknown): readonly string[] {
+  if (
+    squadRunRecord(value) &&
+    exactSquadRunFields(value, ["ok", "status", "run", "watermark", "sourceRevision"]) &&
+    value.ok === true &&
+    squadRunReadyStatus(value.status) &&
+    validInvalidSquadRunProjection(value.run) &&
+    squadRunCount(value.watermark) &&
+    squadRunCount(value.sourceRevision) &&
+    squadRunSafeKeys(value)
+  )
+    return [];
   return squadRunRecord(value) &&
     exactSquadRunFields(value, ["ok", "status", "run", "watermark", "sourceRevision"]) &&
     value.ok === true &&
@@ -225,7 +256,8 @@ function validSquadRunDecision(value: unknown): value is SquadRunDecisionDto {
   );
 }
 
-function validSquadRunSummary(value: unknown): value is SquadRunSummaryDto {
+function validSquadRunSummary(value: unknown): value is SquadRunListRowDto {
+  if (validInvalidSquadRunProjection(value)) return true;
   return (
     squadRunRecord(value) &&
     exactSquadRunFields(value, [
@@ -243,6 +275,19 @@ function validSquadRunSummary(value: unknown): value is SquadRunSummaryDto {
     phases.includes(value.phase as SquadRunPhase) &&
     [value.leaderTurnCount, value.workerAttemptCount, value.runningCount].every(squadRunCount) &&
     squadRunIso(value.latestActivityAt)
+  );
+}
+
+function validInvalidSquadRunProjection(value: unknown): value is SquadRunInvalidSummaryDto {
+  return (
+    squadRunRecord(value) &&
+    value.projectionState === "invalid" &&
+    exactSquadRunFields(value, ["squadRunId", "projectionState", "projectionError"]) &&
+    squadRunText(value.squadRunId) &&
+    squadRunRecord(value.projectionError) &&
+    exactSquadRunFields(value.projectionError, ["code", "hint"]) &&
+    value.projectionError.code === "squad_run_projection_invalid" &&
+    squadRunText(value.projectionError.hint)
   );
 }
 

--- a/packages/daemon/src/squad-run-list.ts
+++ b/packages/daemon/src/squad-run-list.ts
@@ -1,0 +1,80 @@
+import {
+  isAvailableSquadRunSummary,
+  type SquadRunInvalidSummaryDto,
+  type SquadRunListRowDto,
+  type SquadRunPhase,
+  type SquadRunSummaryDto,
+} from "./squad-run-contract.ts";
+
+export function listQuery(payload: Readonly<Record<string, unknown>>): {
+  readonly since: string | null;
+  readonly tokens: readonly string[];
+  readonly limit: number;
+} {
+  const fields = Object.keys(payload),
+    since = payload.since,
+    query = payload.query,
+    limit = payload.limit;
+  if (
+    fields.some((field) => !["since", "query", "limit"].includes(field)) ||
+    (since !== undefined && (typeof since !== "string" || !Number.isFinite(Date.parse(since)))) ||
+    (query !== undefined && typeof query !== "string") ||
+    (limit !== undefined && (!Number.isSafeInteger(limit) || Number(limit) < 1 || Number(limit) > 1_000))
+  )
+    throw squadReadError("invalid_request", "Squad run lists accept ISO since, text query, and limit 1..1000.");
+  return {
+    since: typeof since === "string" ? new Date(since).toISOString() : null,
+    tokens: typeof query === "string" ? query.toLocaleLowerCase().trim().split(/\s+/u).filter(Boolean) : [],
+    limit: typeof limit === "number" ? limit : 200,
+  };
+}
+
+export function matchesRunQuery(run: SquadRunListRowDto, tokens: readonly string[]): boolean {
+  const searchable = (
+    isAvailableSquadRunSummary(run)
+      ? [run.squadRunId, run.squadId, run.taskId, run.mission, run.phase]
+      : [run.squadRunId, run.projectionState, run.projectionError.code, run.projectionError.hint]
+  )
+    .join("\n")
+    .toLocaleLowerCase();
+  return tokens.every((token) => searchable.includes(token));
+}
+
+export function activePhase(phase: SquadRunPhase): boolean {
+  return phase === "planning" || phase === "leader_running" || phase === "workers_running";
+}
+
+/** 小队 run 版的活动窗判定,语义对齐 kernel 的 runtimeSessionInActivityWindow:比时间
+ * 瞬值而非字符串,不同毫秒精度/秒精度的 ISO 戳不会因字典序错判进出窗口。 */
+export function runInActivityWindow(run: SquadRunSummaryDto, since: string): boolean {
+  return Date.parse(run.latestActivityAt) >= Date.parse(since);
+}
+
+export function compareRunSummaries(left: SquadRunListRowDto, right: SquadRunListRowDto): number {
+  if (!isAvailableSquadRunSummary(left))
+    return isAvailableSquadRunSummary(right) ? 1 : left.squadRunId.localeCompare(right.squadRunId);
+  if (!isAvailableSquadRunSummary(right)) return -1;
+  const active = Number(activePhase(right.phase)) - Number(activePhase(left.phase));
+  return (
+    active ||
+    Date.parse(right.latestActivityAt) - Date.parse(left.latestActivityAt) ||
+    left.squadRunId.localeCompare(right.squadRunId)
+  );
+}
+
+export function invalidSquadRunProjection(squadRunId: string): SquadRunInvalidSummaryDto {
+  return {
+    squadRunId,
+    projectionState: "invalid",
+    projectionError: {
+      code: "squad_run_projection_invalid",
+      hint: `Squad run projection ${squadRunId} is invalid.`,
+    },
+  };
+}
+
+function squadReadError(code: string, message: string): Error {
+  const error = new Error(message) as Error & { code: string };
+  error.code = code;
+  return error;
+}

--- a/packages/daemon/src/squad-run-list.ts
+++ b/packages/daemon/src/squad-run-list.ts
@@ -73,7 +73,7 @@ export function invalidSquadRunProjection(squadRunId: string): SquadRunInvalidSu
   };
 }
 
-function squadReadError(code: string, message: string): Error {
+export function squadReadError(code: string, message: string): Error {
   const error = new Error(message) as Error & { code: string };
   error.code = code;
   return error;

--- a/packages/daemon/test/agent-entities.test.ts
+++ b/packages/daemon/test/agent-entities.test.ts
@@ -26,6 +26,12 @@ import {
   resolveSquadDispatch,
   runAgentEntityAction,
 } from "../src/agent-entities.ts";
+import {
+  serializeAgentEntityCatalog,
+  serializeSquadEntityCatalog,
+  validateAgentEntityCatalog,
+  validateSquadEntityCatalog,
+} from "../src/agent-entities.contract.ts";
 import { discoverAgentSkills, resolveAgentSkills } from "../src/agent-skills.ts";
 import { validateAgentDeclarationV1, validateSquadDeclarationV1 } from "../../kernel/src/index.ts";
 
@@ -618,6 +624,90 @@ test("the GUI entity projection lists closed rows and reads closed declarations"
     projection?.close();
     rmSync(rootDir, { recursive: true, force: true });
   }
+});
+
+test("GUI Agent and Squad catalogs isolate invalid and missing projection rows", () => {
+  const current = {
+      kind: "agent",
+      id: "terra",
+      ownerId: null,
+      workspaceRevision: 3,
+      freshness: "current",
+      currentVersion: 3,
+      value: agent,
+    },
+    invalidAgent = {
+      ...current,
+      id: "broken-agent",
+      workspaceRevision: 4,
+      currentVersion: 4,
+      value: { ...agent, id: "broken-agent", runtime_type: "NOT VALID" },
+    },
+    currentSquad = {
+      kind: "squad",
+      id: "core-squad",
+      ownerId: null,
+      workspaceRevision: 5,
+      freshness: "current",
+      currentVersion: 5,
+      value: squad,
+    },
+    missingMemberSquad = {
+      ...currentSquad,
+      id: "orphan-squad",
+      workspaceRevision: 6,
+      currentVersion: 6,
+      value: { ...squad, id: "orphan-squad", name: "Orphan Squad", leader: "ghost" },
+    },
+    projection = {
+      listEntities: (kind: string) =>
+        kind === "agent" ? [current, invalidAgent] : kind === "squad" ? [currentSquad, missingMemberSquad] : [],
+      getEntity: (kind: string, id: string) => {
+        const rows = kind === "agent" ? [current, invalidAgent] : [currentSquad, missingMemberSquad];
+        return rows.find((row) => row.id === id) ?? null;
+      },
+    } as never;
+
+  const agents = readAgentEntityGuiProjection({ kind: "agent-list", projection }),
+    squads = readAgentEntityGuiProjection({ kind: "squad-list", projection });
+  assert.equal(agents.agents.length, 2);
+  assert.deepEqual(agents.agents[0], {
+    id: "terra",
+    name: "Terra",
+    runtimeType: "codex",
+    role: "worker",
+    layer: "user",
+    validity: "valid",
+    issues: [],
+  });
+  assert.deepEqual(agents.agents[1], {
+    id: "broken-agent",
+    layer: "user",
+    state: "invalid",
+    error: {
+      code: "invalid_entity_contract",
+      hint: 'agent declaration field "runtime_type" must be a non-empty lowercase runtime identifier such as claude, codex, or opencode.',
+    },
+  });
+  assert.equal(squads.squads.length, 2);
+  assert.deepEqual(squads.squads[1], {
+    id: "orphan-squad",
+    layer: "user",
+    state: "missing",
+    error: {
+      code: "squad_agent_not_found",
+      hint: "Squad orphan-squad references unavailable agents: ghost.",
+    },
+  });
+  assert.deepEqual(validateAgentEntityCatalog(agents), []);
+  assert.deepEqual(validateSquadEntityCatalog(squads), []);
+
+  const healthyAgents = { ...agents, agents: [agents.agents[0]!] },
+    healthySquads = { ...squads, squads: [squads.squads[0]!] };
+  assert.equal(serializeAgentEntityCatalog(healthyAgents), `${JSON.stringify(healthyAgents, null, 2)}\n`);
+  assert.equal(serializeSquadEntityCatalog(healthySquads), `${JSON.stringify(healthySquads, null, 2)}\n`);
+  assert.equal(Object.hasOwn(healthyAgents.agents[0]!, "state"), false);
+  assert.equal(Object.hasOwn(healthySquads.squads[0]!, "state"), false);
 });
 
 test("Squad dispatch resolution selects one declared worker and rejects outsiders or ambiguous lineage", async () => {

--- a/packages/daemon/test/schedules-gui.contract.test.ts
+++ b/packages/daemon/test/schedules-gui.contract.test.ts
@@ -61,6 +61,13 @@ const armedSchedule = createScheduleV1({
   actor,
   occurredAt: "2026-08-27T07:00:00.000Z",
 });
+const probeAgent = {
+  schema: "agent-declaration/v1",
+  id: "probe-agent",
+  name: "Probe Agent",
+  instructions: "Inspect scheduled work.",
+  runtime_type: "codex",
+};
 
 function guiContext(overrides: Partial<SchedulesGuiReadContext> = {}): SchedulesGuiReadContext {
   return {
@@ -69,7 +76,12 @@ function guiContext(overrides: Partial<SchedulesGuiReadContext> = {}): Schedules
     now: () => now,
     input: { repoId: "schedule-gui" },
     projection: {
-      listEntities: (kind) => (kind === "schedule" ? [{ value: armedSchedule, workspaceRevision: 3 }] : []),
+      listEntities: (kind) =>
+        kind === "schedule"
+          ? [{ id: armedSchedule.scheduleId, value: armedSchedule, workspaceRevision: 3 }]
+          : kind === "agent"
+            ? [{ id: probeAgent.id, value: probeAgent, workspaceRevision: 2 }]
+            : [],
       readTaskStatuses: () => ({ status: "ready", watermark: 9, sourceRevision: 9 }),
     },
     ...overrides,
@@ -221,7 +233,11 @@ test("the schedules list validator locks the joined wire shape", () => {
   assert.equal(row.actions.enable.available, false);
   assert.equal(row.actions.enable.code, "no_changes");
   assert.equal(result.actions.create.available, true);
-  assert.deepEqual(result.options, { agents: [], instances: [], cwd: ["."] });
+  assert.deepEqual(result.options, {
+    agents: [{ agentId: "probe-agent", name: "Probe Agent", runtimeType: "codex" }],
+    instances: [],
+    cwd: ["."],
+  });
   assert.equal(row.watermarkParent, undefined);
   for (const mutation of [
     (value: SchedulesListResult) => ({ ...value, repoMode: "fleet" }),
@@ -338,6 +354,77 @@ test("malformed definitions degrade to invalid rows while trigger DTO variants r
     [],
     "a cron trigger DTO without its required timezone must stay invalid on the wire",
   );
+});
+
+test("invalid Agent options and schedules with unavailable Agent targets degrade row by row", () => {
+  const invalidAgent = { ...probeAgent, id: "broken-agent", name: "Broken Agent", runtime_type: "NOT VALID" },
+    invalidTarget = {
+      ...armedSchedule,
+      scheduleId: "invalid-target",
+      name: "Invalid target",
+      spec: {
+        ...armedSchedule.spec,
+        target: { ...armedSchedule.spec.target, agentId: "broken-agent" },
+      },
+    },
+    missingTarget = {
+      ...armedSchedule,
+      scheduleId: "missing-target",
+      name: "Missing target",
+      spec: {
+        ...armedSchedule.spec,
+        target: { ...armedSchedule.spec.target, agentId: "ghost-agent" },
+      },
+    },
+    result = readSchedulesGui(
+      guiContext({
+        projection: {
+          listEntities: (kind) =>
+            kind === "schedule"
+              ? [armedSchedule, invalidTarget, missingTarget].map((value, index) => ({
+                  id: value.scheduleId,
+                  value,
+                  workspaceRevision: index + 1,
+                }))
+              : kind === "agent"
+                ? [
+                    { id: probeAgent.id, value: probeAgent, workspaceRevision: 1 },
+                    { id: invalidAgent.id, value: invalidAgent, workspaceRevision: 2 },
+                  ]
+                : [],
+          readTaskStatuses: guiContext().projection.readTaskStatuses,
+        },
+      }),
+    );
+
+  assert.equal(result.options.agents.length, 2);
+  assert.deepEqual(result.options.agents[0], {
+    agentId: "broken-agent",
+    state: "invalid",
+    error: {
+      code: "invalid_entity_contract",
+      hint: (result.options.agents[0] as { readonly error: { readonly hint: string } }).error.hint,
+    },
+  });
+  assert.match((result.options.agents[0] as { readonly error: { readonly hint: string } }).error.hint, /runtime_type/u);
+  assert.deepEqual(result.options.agents[1], {
+    agentId: "probe-agent",
+    name: "Probe Agent",
+    runtimeType: "codex",
+  });
+  const healthy = result.schedules.find((row) => row.scheduleId === "heartbeat-probe")!,
+    invalid = result.schedules.find((row) => row.scheduleId === "invalid-target")!,
+    missing = result.schedules.find((row) => row.scheduleId === "missing-target")!;
+  assert.equal(Object.hasOwn(healthy, "targetState"), false);
+  assert.equal(invalid.state, "armed");
+  assert.equal((invalid as ScheduleGuiRowDto).targetState, "invalid");
+  assert.equal((invalid as ScheduleGuiRowDto).targetError?.code, "invalid_entity_contract");
+  assert.equal((invalid as ScheduleGuiRowDto).actions.runNow.available, false);
+  assert.equal(missing.state, "armed");
+  assert.equal((missing as ScheduleGuiRowDto).targetState, "missing");
+  assert.equal((missing as ScheduleGuiRowDto).targetError?.code, "agent_not_found");
+  assert.equal((missing as ScheduleGuiRowDto).actions.runNow.available, false);
+  assert.deepEqual(validateSchedulesList(result), []);
 });
 
 test("availability distinguishes the four execution states from roster truth", () => {

--- a/packages/daemon/test/squad-action.integration.test.ts
+++ b/packages/daemon/test/squad-action.integration.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
 import test from "node:test";
 import { getEntityKindContract, makeTaskEventStore } from "../../kernel/src/index.ts";
 import { canonicalRoot, workspaceId } from "../src/protocol/daemon-protocol.contract.ts";
@@ -149,6 +150,45 @@ test("Squad Action catalog owns install, read surfaces, and exact rejected crite
   }
 });
 
+test("Squad list retains one invalid declaration projection beside healthy rows", async () => {
+  const rootDir = workspace("invalid-list-row"),
+    repoId = workspaceId("squad-action-invalid-list-row");
+  let cell: Awaited<ReturnType<typeof openRepoCell>> | undefined;
+  try {
+    cell = await openRepoCell({ repoId, rootDir: canonicalRoot(rootDir), ownerId: "squad-action-invalid-list-row" });
+    await installFixture(cell);
+    const invalidId = "broken-squad",
+      installed = await cell.run(
+        { kind: "squad-install", declaration: { ...squad, id: invalidId, name: "Broken Squad" } },
+        owner,
+      );
+    assert.equal(installed.outcome, "applied", JSON.stringify(installed));
+    corruptSquadProjection(rootDir, invalidId);
+
+    const listed = await cell.run({ kind: "squad-list" }, owner),
+      rows = evidence(listed).squads as Array<Record<string, unknown>>;
+    assert.equal(listed.outcome, "applied", JSON.stringify(listed));
+    assert.deepEqual(
+      rows.find(({ id }) => id === invalidId),
+      {
+        id: invalidId,
+        layer: "user",
+        state: "invalid",
+        error: {
+          code: "invalid_entity_contract",
+          hint: 'squad declaration is missing required field "leader".',
+        },
+      },
+    );
+    const healthy = rows.find(({ id }) => id === squad.id);
+    assert.equal(healthy?.validity, "valid");
+    assert.equal(Object.hasOwn(healthy ?? {}, "state"), false);
+  } finally {
+    await cell?.close();
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});
+
 test("two actors contending for one Task fence reject the non-holder before Squad state or artifacts", async () => {
   const rootDir = workspace("fence"),
     repoId = workspaceId("squad-action-fence"),
@@ -233,4 +273,16 @@ function workspace(name: string): string {
   const rootDir = mkdtempSync(path.join(tmpdir(), `ha-squad-action-${name}-`));
   initRepo(rootDir);
   return rootDir;
+}
+
+function corruptSquadProjection(rootDir: string, squadId: string): void {
+  const database = new DatabaseSync(path.join(rootDir, ".harness/cache/task.sqlite")),
+    { leader: _leader, ...invalid } = { ...squad, id: squadId, name: "Broken Squad" };
+  try {
+    database
+      .prepare("UPDATE entity_projection SET value_json = ? WHERE entity_kind = 'squad' AND entity_id = ?")
+      .run(JSON.stringify(invalid), squadId);
+  } finally {
+    database.close();
+  }
 }

--- a/packages/daemon/test/squad-run-list-window.test.ts
+++ b/packages/daemon/test/squad-run-list-window.test.ts
@@ -7,7 +7,7 @@ import test from "node:test";
 import { type RuntimeSession, type TaskProjection } from "../../kernel/src/index.ts";
 import { makeSquadCoordinator } from "../src/squad-coordinator.ts";
 import { appendRuntimeWorkerRecord, openDispatchStream } from "../src/dispatch-stream.ts";
-import { validateSquadRunsList } from "../src/squad-run-contract.ts";
+import { validateSquadRunRead, validateSquadRunsList } from "../src/squad-run-contract.ts";
 
 // 固定「现在」:窗口断言只看相对时间,不依赖真实时钟。
 const NOW = "2026-08-27T12:00:00.000Z",
@@ -324,6 +324,48 @@ test("active runs always pass the window and a missing since lists every run", (
     const { coordinator: squad } = coordinator(rootDir, []);
     assert.deepEqual(squad.list({ since: sinceAgo(DAY) }).totals, { runs: 1 });
     assert.deepEqual(squad.list({}).totals, { runs: 2 });
+  });
+});
+
+test("one invalid Squad run projection degrades without hiding valid runs", () => {
+  withRootDir((rootDir) => {
+    seedSquadRun(rootDir, {
+      squadRunId: "squad_0123456789abcdef01234567",
+      phase: "converged",
+      leader: {
+        dispatchId: "dispatch_00000000000000000000a1b2",
+        runtimeSessionId: "runtime-leader",
+        startedAt: "2026-08-27T11:00:00.000Z",
+      },
+    });
+    const { coordinator: squad, projection } = coordinator(rootDir, []);
+    assert.equal(squad.list({}).runs.length, 1, "materialize the healthy run projection first");
+    projection.upsertSquadRun({
+      squadRunId: "squad_0123456789abcdef99887766",
+      revision: 4,
+      state: { schema: "squad-run/v1", squadRunId: "squad_0123456789abcdef99887766" },
+    });
+
+    const listed = squad.list({});
+    assert.equal(listed.runs.length, 2);
+    assert.deepEqual(
+      listed.runs.find((run) => run.squadRunId === "squad_0123456789abcdef99887766"),
+      {
+        squadRunId: "squad_0123456789abcdef99887766",
+        projectionState: "invalid",
+        projectionError: {
+          code: "squad_run_projection_invalid",
+          hint: "Squad run projection squad_0123456789abcdef99887766 is invalid.",
+        },
+      },
+    );
+    assert.deepEqual(validateSquadRunsList(listed), []);
+    const detail = squad.read("squad_0123456789abcdef99887766");
+    assert.deepEqual(detail.run, listed.runs[1]);
+    assert.deepEqual(validateSquadRunRead(detail), []);
+    const status = squad.status("squad_0123456789abcdef99887766");
+    assert.equal(status.projectionState, "invalid");
+    assert.equal((status.projectionError as { readonly code: string }).code, "squad_run_projection_invalid");
   });
 });
 

--- a/packages/gui/src/renderer/agent-entity-client.ts
+++ b/packages/gui/src/renderer/agent-entity-client.ts
@@ -1,14 +1,26 @@
 import type { AgentDeclarationV1, SquadDeclarationV1 } from "../../../daemon/src/agent-entities.contract.ts";
 import type {
   AgentEntityGuiDetail as AgentEntityDetail,
+  AgentEntityGuiAvailableRow as AgentEntityAvailableRow,
   AgentEntityGuiRead as AgentEntityRead,
   AgentEntityGuiRow as AgentEntityRow,
   AgentSkillGuiRead,
   SquadEntityGuiDetail as SquadEntityDetail,
+  SquadEntityGuiAvailableRow as SquadEntityAvailableRow,
   SquadEntityGuiRow as SquadEntityRow,
 } from "../../../daemon/src/agent-entities.ts";
 import { containsSecretLikeKey, entityRecord } from "../api/entity-payload-hygiene.ts";
-export type { AgentEntityDetail, AgentEntityRead, AgentEntityRow, SquadEntityDetail, SquadEntityRow };
+export type {
+  AgentEntityAvailableRow,
+  AgentEntityDetail,
+  AgentEntityRead,
+  AgentEntityRow,
+  SquadEntityAvailableRow,
+  SquadEntityDetail,
+  SquadEntityRow,
+};
+export const isAvailableAgentEntityRow = (row: AgentEntityRow): row is AgentEntityAvailableRow => !("state" in row);
+export const isAvailableSquadEntityRow = (row: SquadEntityRow): row is SquadEntityAvailableRow => !("state" in row);
 export type AgentSkillRow = AgentSkillGuiRead["skills"][number];
 export type EntitySaveResult = {
   readonly outcome: "applied" | "pending" | "op_rejected";

--- a/packages/gui/src/renderer/components/ScheduleFormDialog.tsx
+++ b/packages/gui/src/renderer/components/ScheduleFormDialog.tsx
@@ -1,11 +1,13 @@
 import { useMemo, useState, type ReactNode } from "react";
-import type {
+import {
+  isAvailableScheduleGuiAgentOption,
+  type ScheduleGuiAgentOptionDto,
   ScheduleGuiOptionsDto,
   ScheduleGuiRowDto,
 } from "../../../../daemon/src/protocol/schedules-gui-contract.ts";
 import type { ScheduleDefinitionInput, ScheduleModeWord } from "../schedules-client.ts";
 import { t, type MessageKey } from "../i18n/index.tsx";
-import { Btn, Chip, Hint, Modal, PlannedBox, TextInput, Toggle, WarnBar } from "./runtime/parts.tsx";
+import { Badge, Btn, Chip, Hint, Modal, PlannedBox, TextInput, Toggle, WarnBar } from "./runtime/parts.tsx";
 
 // M5 guided form: one segment asks one thing (identity → trigger → executor →
 // purpose → outcome routing → mission). Two write paths are still pending the
@@ -73,7 +75,12 @@ export function ScheduleForm({
   readonly onCancel: () => void;
   readonly onSubmit: (input: ScheduleDefinitionInput) => void;
 }) {
-  const initialAgentTarget = initial?.target.kind === "agent" ? initial.target : undefined,
+  const availableAgents = options.agents.filter(isAvailableScheduleGuiAgentOption),
+    unavailableAgents = options.agents.filter(
+      (option): option is Extract<ScheduleGuiAgentOptionDto, { readonly state: "invalid" | "missing" }> =>
+        !isAvailableScheduleGuiAgentOption(option),
+    ),
+    initialAgentTarget = initial?.target.kind === "agent" ? initial.target : undefined,
     duration = durationOf(initial?.trigger.everyMs ?? 30 * UNIT_MS.m),
     [scheduleId, setScheduleId] = useState(initial?.scheduleId ?? ""),
     [name, setName] = useState(initial?.name ?? ""),
@@ -84,7 +91,7 @@ export function ScheduleForm({
     [cronTime, setCronTime] = useState("02:30"),
     [cronWeekdays, setCronWeekdays] = useState<ReadonlySet<number>>(() => new Set([1])),
     [cronTimezone, setCronTimezone] = useState("UTC"),
-    [agentId, setAgentId] = useState(initialAgentTarget?.agentId ?? options.agents[0]?.agentId ?? ""),
+    [agentId, setAgentId] = useState(initialAgentTarget?.agentId ?? availableAgents[0]?.agentId ?? ""),
     [runtimeInstanceId, setRuntimeInstanceId] = useState(initialAgentTarget?.runtimeInstanceId ?? ""),
     [model, setModel] = useState(initialAgentTarget?.model ?? ""),
     [reasoningEffort, setReasoningEffort] = useState(initialAgentTarget?.reasoningEffort ?? ""),
@@ -100,7 +107,7 @@ export function ScheduleForm({
       notify: false,
       remediationTask: false,
     });
-  const agent = options.agents.find((candidate) => candidate.agentId === agentId) ?? null,
+  const agent = availableAgents.find((candidate) => candidate.agentId === agentId) ?? null,
     compatibleInstances = useMemo(
       () =>
         options.instances.filter(
@@ -323,12 +330,22 @@ export function ScheduleForm({
                 setFast(false);
               }}
             >
-              {options.agents.map((option) => (
+              {availableAgents.map((option) => (
                 <option key={option.agentId} value={option.agentId}>
                   {option.name} · {option.agentId}
                 </option>
               ))}
             </select>
+            {unavailableAgents.map((option) => (
+              <span
+                key={option.agentId}
+                data-testid={`schedule-agent-option-${option.agentId}`}
+                className="mt-1 flex items-center gap-1.5 font-mono ui-micro text-text-faint"
+              >
+                {option.agentId}
+                <Badge tip={option.error.hint}>{scheduleAgentStateLabels()[option.state]}</Badge>
+              </span>
+            ))}
           </FormField>
           <FormField label={t("schedules.fields.instance")}>
             <select
@@ -534,6 +551,13 @@ export function ScheduleForm({
       </div>
     </div>
   );
+}
+
+function scheduleAgentStateLabels(): Readonly<Record<"invalid" | "missing", string>> {
+  return {
+    invalid: t("agentRuntime.catalogInvalid"),
+    missing: t("agentRuntime.catalogMissing"),
+  };
 }
 
 export function ScheduleFormDialog({

--- a/packages/gui/src/renderer/components/runtime/AgentCard.tsx
+++ b/packages/gui/src/renderer/components/runtime/AgentCard.tsx
@@ -2,7 +2,12 @@ import { useEffect, useState } from "react";
 import type { AgentDeclarationV1 } from "../../../../../daemon/src/agent-entities.contract.ts";
 import type { RuntimeInstanceSummary } from "../../../../../daemon/src/agent-runtime-instances.ts";
 import { runtimeTypeMatchesKind } from "../../../../../daemon/src/agent-runtime-contract.ts";
-import type { AgentEntityDetail, AgentEntityRow, AgentSkillRow, SquadEntityRow } from "../../agent-entity-client.ts";
+import type {
+  AgentEntityAvailableRow,
+  AgentEntityDetail,
+  AgentSkillRow,
+  SquadEntityAvailableRow,
+} from "../../agent-entity-client.ts";
 import { t } from "../../i18n/index.tsx";
 import { EntityRefLink } from "../EntityRefLink.tsx";
 import { ViewInGraphButton } from "../ViewInGraphButton.tsx";
@@ -67,8 +72,8 @@ export const agentDraftDirty = (detail: AgentEntityDetail, draft: AgentDraft): b
 
 type Props = {
   readonly detail: AgentEntityDetail;
-  readonly row: AgentEntityRow | null;
-  readonly squads: readonly SquadEntityRow[];
+  readonly row: AgentEntityAvailableRow | null;
+  readonly squads: readonly SquadEntityAvailableRow[];
   readonly instances: readonly RuntimeInstanceSummary[];
   readonly availableSkills?: readonly AgentSkillRow[];
   readonly presets?: readonly { readonly id: string; readonly title: string; readonly description: string }[];

--- a/packages/gui/src/renderer/components/runtime/NewEntityDialog.tsx
+++ b/packages/gui/src/renderer/components/runtime/NewEntityDialog.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import type { AgentEntityRow, SquadEntityRow } from "../../agent-entity-client.ts";
+import type { AgentEntityAvailableRow, SquadEntityAvailableRow } from "../../agent-entity-client.ts";
 import { t } from "../../i18n/index.tsx";
 import { Avatar, Badge, Btn, CfgRow, Hint, KindDot, Modal, TextInput, WarnBar } from "./parts.tsx";
 
@@ -27,8 +27,8 @@ export function NewEntityDialog({
   onCreate,
 }: {
   readonly kind: "agent" | "squad";
-  readonly agents: readonly AgentEntityRow[];
-  readonly squads: readonly SquadEntityRow[];
+  readonly agents: readonly AgentEntityAvailableRow[];
+  readonly squads: readonly SquadEntityAvailableRow[];
   readonly busy: boolean;
   readonly taken: readonly string[];
   readonly onCancel: () => void;

--- a/packages/gui/src/renderer/components/runtime/RuntimeCard.tsx
+++ b/packages/gui/src/renderer/components/runtime/RuntimeCard.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 import type { RuntimeInstanceSummary } from "../../../../../daemon/src/agent-runtime-instances.ts";
 import { runtimeIsolationState, runtimePermissionMode } from "../../../../../daemon/src/runtime-permissions.ts";
 import { runtimeTypeMatchesKind } from "../../../../../daemon/src/agent-runtime-contract.ts";
-import type { AgentEntityRow } from "../../agent-entity-client.ts";
+import type { AgentEntityAvailableRow } from "../../agent-entity-client.ts";
 import type { RuntimeInstallationRow, RuntimeInstanceUpdateInput } from "../../runtime-instance-client.ts";
 import {
   runtimeAuthPresentation,
@@ -56,7 +56,7 @@ import { RuntimeModelEditor } from "./RuntimeModelEditor.tsx";
 type Props = {
   readonly instance: RuntimeInstanceSummary;
   readonly installations: readonly RuntimeInstallationRow[];
-  readonly agents: readonly AgentEntityRow[];
+  readonly agents: readonly AgentEntityAvailableRow[];
   readonly liveSessions: number;
   readonly busy: boolean;
   readonly authProbeState?: RuntimeAuthProbeState;

--- a/packages/gui/src/renderer/components/runtime/RuntimeInspector.tsx
+++ b/packages/gui/src/renderer/components/runtime/RuntimeInspector.tsx
@@ -1,7 +1,7 @@
 import { type ReactNode } from "react";
 import type { AgentRuntimeSessionDto } from "../../../../../daemon/src/agent-runtime-contract.ts";
 import type { RuntimeInstanceSummary } from "../../../../../daemon/src/agent-runtime-instances.ts";
-import type { AgentEntityRow, SquadEntityRow } from "../../agent-entity-client.ts";
+import type { AgentEntityAvailableRow, SquadEntityAvailableRow } from "../../agent-entity-client.ts";
 import { formatTime } from "../../model/time.ts";
 import { sessionStatusDot, type SessionStatus } from "../../sessions-model.ts";
 import { t } from "../../i18n/index.tsx";
@@ -74,8 +74,8 @@ export function IdentityInspector({
   onOpenSession,
 }: {
   readonly selection: RuntimeSelection;
-  readonly agents: readonly AgentEntityRow[];
-  readonly squads: readonly SquadEntityRow[];
+  readonly agents: readonly AgentEntityAvailableRow[];
+  readonly squads: readonly SquadEntityAvailableRow[];
   readonly rows: readonly RuntimeDockRow[];
   readonly onSelect: (selection: RuntimeSelection) => void;
   readonly onOpenSession: OpenSession;
@@ -224,8 +224,8 @@ function AgentFacts({
   squads,
   onSelect,
 }: {
-  readonly agent: AgentEntityRow | null;
-  readonly squads: readonly SquadEntityRow[];
+  readonly agent: AgentEntityAvailableRow | null;
+  readonly squads: readonly SquadEntityAvailableRow[];
   readonly onSelect: (selection: RuntimeSelection) => void;
 }) {
   if (!agent)
@@ -279,7 +279,7 @@ function SquadFacts({
   squad,
   onSelect,
 }: {
-  readonly squad: SquadEntityRow | null;
+  readonly squad: SquadEntityAvailableRow | null;
   readonly onSelect: (selection: RuntimeSelection) => void;
 }) {
   if (!squad)

--- a/packages/gui/src/renderer/components/runtime/RuntimeRail.tsx
+++ b/packages/gui/src/renderer/components/runtime/RuntimeRail.tsx
@@ -1,13 +1,18 @@
 import { useState, type ReactNode } from "react";
 import type { RuntimeInstanceSummary } from "../../../../../daemon/src/agent-runtime-instances.ts";
-import type { AgentEntityRow, SquadEntityRow } from "../../agent-entity-client.ts";
+import {
+  isAvailableAgentEntityRow,
+  isAvailableSquadEntityRow,
+  type AgentEntityRow,
+  type SquadEntityRow,
+} from "../../agent-entity-client.ts";
 import { t } from "../../i18n/index.tsx";
 import {
   runtimeAuthPresentation,
   runtimeAuthPresentationText,
   type RuntimeAuthProbeState,
 } from "../../runtime-auth-presentation.ts";
-import { Avatar, CapDot, KindDot, LiveDot } from "./parts.tsx";
+import { Avatar, Badge, CapDot, KindDot, LiveDot } from "./parts.tsx";
 import type { RuntimeSelection } from "./useRuntimeWorkspace.ts";
 
 // W6 IA 拆分:原四段聚合 rail 随「Agent 运行时」入口撤销,拆成页级 rail——
@@ -112,25 +117,45 @@ export function IdentityRail({
         onToggle={() => onToggle("agents")}
         onNew={() => onNew("agents")}
       >
-        {agents.map((agent) => (
-          <Row
-            key={agent.id}
-            tip={agent.id}
-            testId={`rail-agent-${agent.id}`}
-            selected={picked("agent", agent.id)}
-            onSelect={() => onSelect({ type: "agent", id: agent.id })}
-          >
-            <Avatar id={agent.id} />
-            <span className="min-w-0 flex-1 truncate ui-meta">{agent.name}</span>
-            <span
-              data-tip={t("agentRuntime.layerTip", { layer: agent.layer })}
-              className="shrink-0 rounded-[3px] border border-border-strong px-1 font-mono ui-micro tracking-[0.04em] text-text-faint"
+        {agents.map((agent) => {
+          if (!isAvailableAgentEntityRow(agent))
+            return (
+              <Row
+                key={agent.id}
+                tip={agent.error.hint}
+                testId={`rail-agent-${agent.id}`}
+                selected={false}
+                disabled
+                onSelect={() => undefined}
+              >
+                <Avatar id={agent.id} />
+                <span className="min-w-0 flex-1 truncate font-mono ui-meta text-text-faint">{agent.id}</span>
+                <Badge tip={agent.error.hint}>{degradedStateLabels()[agent.state]}</Badge>
+              </Row>
+            );
+          return (
+            <Row
+              key={agent.id}
+              tip={agent.id}
+              testId={`rail-agent-${agent.id}`}
+              selected={picked("agent", agent.id)}
+              onSelect={() => onSelect({ type: "agent", id: agent.id })}
             >
-              {agent.layer}
-            </span>
-            {agent.validity === "blocked" && <LiveDot state="failed" tip={t("agentRuntime.declarationBlocked")} />}
-          </Row>
-        ))}
+              <Avatar id={agent.id} />
+              <span className="min-w-0 flex-1 truncate ui-meta">{agent.name}</span>
+              <span
+                data-tip={t("agentRuntime.layerTip", { layer: agent.layer })}
+                className={[
+                  "shrink-0 rounded-[3px] border border-border-strong px-1 font-mono",
+                  "ui-micro tracking-[0.04em] text-text-faint",
+                ].join(" ")}
+              >
+                {agent.layer}
+              </span>
+              {agent.validity === "blocked" && <LiveDot state="failed" tip={t("agentRuntime.declarationBlocked")} />}
+            </Row>
+          );
+        })}
       </Segment>
       <Segment
         segment="squads"
@@ -141,21 +166,43 @@ export function IdentityRail({
         onToggle={() => onToggle("squads")}
         onNew={() => onNew("squads")}
       >
-        {squads.map((squad) => (
-          <Row
-            key={squad.id}
-            tip={squad.id}
-            testId={`rail-squad-${squad.id}`}
-            selected={picked("squad", squad.id)}
-            onSelect={() => onSelect({ type: "squad", id: squad.id })}
-          >
-            <KindDot kind="any" />
-            <span className="min-w-0 flex-1 truncate ui-meta">{squad.name}</span>
-            <span className="shrink-0 rounded-[3px] border border-border-strong px-1 font-mono ui-micro text-text-faint">
-              {t("agentRuntime.memberCount", { count: squad.workers.length + 1 })}
-            </span>
-          </Row>
-        ))}
+        {squads.map((squad) => {
+          if (!isAvailableSquadEntityRow(squad))
+            return (
+              <Row
+                key={squad.id}
+                tip={squad.error.hint}
+                testId={`rail-squad-${squad.id}`}
+                selected={false}
+                disabled
+                onSelect={() => undefined}
+              >
+                <KindDot kind="any" />
+                <span className="min-w-0 flex-1 truncate font-mono ui-meta text-text-faint">{squad.id}</span>
+                <Badge tip={squad.error.hint}>{degradedStateLabels()[squad.state]}</Badge>
+              </Row>
+            );
+          return (
+            <Row
+              key={squad.id}
+              tip={squad.id}
+              testId={`rail-squad-${squad.id}`}
+              selected={picked("squad", squad.id)}
+              onSelect={() => onSelect({ type: "squad", id: squad.id })}
+            >
+              <KindDot kind="any" />
+              <span className="min-w-0 flex-1 truncate ui-meta">{squad.name}</span>
+              <span
+                className={[
+                  "shrink-0 rounded-[3px] border border-border-strong px-1 font-mono",
+                  "ui-micro text-text-faint",
+                ].join(" ")}
+              >
+                {t("agentRuntime.memberCount", { count: squad.workers.length + 1 })}
+              </span>
+            </Row>
+          );
+        })}
       </Segment>
       <details className="px-2.5 py-2 ui-micro leading-[1.5] text-text-faint">
         <summary className="cursor-pointer list-none">{t("agentRuntime.thesisSummary")}</summary>
@@ -223,12 +270,14 @@ function Row({
   testId,
   selected,
   onSelect,
+  disabled = false,
   children,
 }: {
   readonly tip: string;
   readonly testId?: string;
   readonly selected: boolean;
   readonly onSelect: () => void;
+  readonly disabled?: boolean;
   readonly children: ReactNode;
 }) {
   return (
@@ -237,10 +286,25 @@ function Row({
       data-tip={tip}
       data-testid={testId}
       aria-current={selected}
+      disabled={disabled}
       onClick={onSelect}
-      className={`flex w-full items-center gap-[7px] rounded border px-2 py-1 text-left ${selected ? "border-accent/40 bg-accent/[0.14]" : "border-transparent hover:bg-surface-raised"}`}
+      className={[
+        "flex w-full items-center gap-[7px] rounded border px-2 py-1 text-left",
+        disabled
+          ? "cursor-not-allowed border-transparent opacity-70"
+          : selected
+            ? "border-accent/40 bg-accent/[0.14]"
+            : "border-transparent hover:bg-surface-raised",
+      ].join(" ")}
     >
       {children}
     </button>
   );
+}
+
+function degradedStateLabels(): Readonly<Record<"invalid" | "missing", string>> {
+  return {
+    invalid: t("agentRuntime.catalogInvalid"),
+    missing: t("agentRuntime.catalogMissing"),
+  };
 }

--- a/packages/gui/src/renderer/components/runtime/SquadCard.tsx
+++ b/packages/gui/src/renderer/components/runtime/SquadCard.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import type { SquadDeclarationV1 } from "../../../../../daemon/src/agent-entities.contract.ts";
-import type { AgentEntityRow, SquadEntityDetail, SquadEntityRow } from "../../agent-entity-client.ts";
+import type { AgentEntityAvailableRow, SquadEntityAvailableRow, SquadEntityDetail } from "../../agent-entity-client.ts";
 import { t } from "../../i18n/index.tsx";
 import { EntityRefLink } from "../EntityRefLink.tsx";
 import {
@@ -63,8 +63,8 @@ export function squadChartLayout(workers: number): {
 
 type Props = {
   readonly detail: SquadEntityDetail;
-  readonly row: SquadEntityRow | null;
-  readonly agents: readonly AgentEntityRow[];
+  readonly row: SquadEntityAvailableRow | null;
+  readonly agents: readonly AgentEntityAvailableRow[];
   readonly busy: boolean;
   readonly onSave: (declaration: SquadDeclarationV1) => void;
   readonly onSelectAgent: (agentId: string) => void;
@@ -304,7 +304,7 @@ function SlotConfig({
   onClear,
   onSelectAgent,
 }: {
-  readonly agents: readonly AgentEntityRow[];
+  readonly agents: readonly AgentEntityAvailableRow[];
   readonly slot: SquadSlot;
   readonly draft: SquadDraft;
   readonly onPatch: (value: Partial<SquadDraft>) => void;

--- a/packages/gui/src/renderer/components/sessions/SquadRunDetail.tsx
+++ b/packages/gui/src/renderer/components/sessions/SquadRunDetail.tsx
@@ -1,7 +1,8 @@
-import type {
-  SquadRunReadResult,
-  SquadRunLeaderTurnDto,
-  SquadRunWorkerAttemptDto,
+import {
+  isAvailableSquadRunDetail,
+  type SquadRunLeaderTurnDto,
+  type SquadRunReadResult,
+  type SquadRunWorkerAttemptDto,
 } from "../../../../../daemon/src/squad-run-contract.ts";
 import {
   sessionStatusDot,
@@ -13,7 +14,7 @@ import {
 import { t } from "../../i18n/index.tsx";
 import { formatTime } from "../../model/time.ts";
 import { EntityRefLink } from "../EntityRefLink.tsx";
-import { LiveDot } from "../runtime/parts.tsx";
+import { Badge, LiveDot } from "../runtime/parts.tsx";
 
 /**
  * 小队编排详情(G12 §2b/§2c):`ha squad status` 的 statusDto 对 GUI 开放的读面
@@ -47,6 +48,13 @@ export function SquadRunDetail({
   if (pending || detail === null)
     return <p className="px-4 py-4 ui-micro text-text-faint">{t("agentRuntime.loading")}</p>;
   const run = detail.run;
+  if (!isAvailableSquadRunDetail(run))
+    return (
+      <div data-testid="squad-run-detail" className="flex items-center gap-2 px-4 py-4 text-text-faint">
+        <span className="font-mono ui-micro">{run.squadRunId}</span>
+        <Badge tip={run.projectionError.hint}>{t("agentRuntime.catalogInvalid")}</Badge>
+      </div>
+    );
   return (
     <div data-testid="squad-run-detail" className="flex flex-col gap-4 px-4 pt-3.5 pb-6">
       <header className="flex flex-col gap-1">

--- a/packages/gui/src/renderer/components/sessions/SquadRunList.tsx
+++ b/packages/gui/src/renderer/components/sessions/SquadRunList.tsx
@@ -1,7 +1,11 @@
-import type { SquadRunSummaryDto } from "../../../../../daemon/src/squad-run-contract.ts";
+import {
+  isAvailableSquadRunSummary,
+  type SquadRunListRowDto,
+  type SquadRunSummaryDto,
+} from "../../../../../daemon/src/squad-run-contract.ts";
 import { relativeTime, shortRef } from "../../sessions-model.ts";
 import { t } from "../../i18n/index.tsx";
-import { LiveDot } from "../runtime/parts.tsx";
+import { Badge, LiveDot } from "../runtime/parts.tsx";
 
 /**
  * 小队编排段:一次 `ha squad run` 一个列表单元。GUI 发起的单次 squad 派工
@@ -19,7 +23,7 @@ export function SquadRunList({
   selectedId,
   onSelectRun,
 }: {
-  readonly runs: readonly SquadRunSummaryDto[];
+  readonly runs: readonly SquadRunListRowDto[];
   readonly truncated: boolean;
   readonly totalRuns: number;
   readonly squadNames: ReadonlyMap<string, string>;
@@ -46,15 +50,34 @@ export function SquadRunList({
           )}
         </p>
       ) : (
-        runs.map((run) => (
-          <RunSection
-            key={run.squadRunId}
-            run={run}
-            squadNames={squadNames}
-            selected={selectedId === run.squadRunId}
-            onSelectRun={onSelectRun}
-          />
-        ))
+        runs.map((run) =>
+          isAvailableSquadRunSummary(run) ? (
+            <RunSection
+              key={run.squadRunId}
+              run={run}
+              squadNames={squadNames}
+              selected={selectedId === run.squadRunId}
+              onSelectRun={onSelectRun}
+            />
+          ) : (
+            <section
+              key={run.squadRunId}
+              data-testid={`squad-run-${run.squadRunId}`}
+              className="border-b border-border"
+            >
+              <button
+                type="button"
+                disabled
+                data-tip={run.projectionError.hint}
+                data-testid={`squad-run-toggle-${run.squadRunId}`}
+                className="flex w-full cursor-not-allowed items-center gap-2 px-4 py-3 text-left opacity-70"
+              >
+                <span className="min-w-0 flex-1 truncate font-mono ui-micro text-text-faint">{run.squadRunId}</span>
+                <Badge tip={run.projectionError.hint}>{t("agentRuntime.catalogInvalid")}</Badge>
+              </button>
+            </section>
+          ),
+        )
       )}
       {truncated && (
         <p data-testid="squad-runs-truncated" className="border-t border-border px-4 py-2 ui-micro text-text-faint">

--- a/packages/gui/src/renderer/graph/runtimeEntities.ts
+++ b/packages/gui/src/renderer/graph/runtimeEntities.ts
@@ -1,4 +1,4 @@
-import type { AgentEntityGuiRow } from "../../../../daemon/src/agent-entities.ts";
+import type { AgentEntityGuiAvailableRow } from "../../../../daemon/src/agent-entities.ts";
 import type { ScheduleGuiRowDto } from "../../../../daemon/src/protocol/schedules-gui-contract.ts";
 import type { RelationEdge } from "../model/types";
 
@@ -38,7 +38,7 @@ export interface ScheduleNodeRow {
 }
 
 /** agent 目录行 → 图节点行。`taskCount` 由切面边数补齐(见 withAgentTaskCounts)。 */
-export function agentNodeRowOf(row: AgentEntityGuiRow): AgentNodeRow {
+export function agentNodeRowOf(row: AgentEntityGuiAvailableRow): AgentNodeRow {
   return { id: agentNodeId(row.id), name: row.name, sub: `${row.role} · ${row.runtimeType}`, taskCount: 0 };
 }
 

--- a/packages/gui/src/renderer/i18n/locales/en-US/agentRuntime.json
+++ b/packages/gui/src/renderer/i18n/locales/en-US/agentRuntime.json
@@ -381,5 +381,7 @@
   "agentRuntime.cockpitNoWorkers": "No workers dispatched yet by this Commander run.",
   "agentRuntime.cockpitWorkersOf": "Workers dispatched by {name}",
   "agentRuntime.cockpitUnboundWorkers": "Worker runs without a parent-session edge",
-  "agentRuntime.cockpitUnboundWorkersHint": "Recorded before the parent edge existed; grouped by squad and delegation."
+  "agentRuntime.cockpitUnboundWorkersHint": "Recorded before the parent edge existed; grouped by squad and delegation.",
+  "agentRuntime.catalogInvalid": "Invalid",
+  "agentRuntime.catalogMissing": "Missing"
 }

--- a/packages/gui/src/renderer/i18n/locales/zh-CN/agentRuntime.json
+++ b/packages/gui/src/renderer/i18n/locales/zh-CN/agentRuntime.json
@@ -381,5 +381,7 @@
   "agentRuntime.cockpitNoWorkers": "这次 Commander 运行还没有派出下级。",
   "agentRuntime.cockpitWorkersOf": "{name} 派出的下级",
   "agentRuntime.cockpitUnboundWorkers": "无父会话边的 worker 运行",
-  "agentRuntime.cockpitUnboundWorkersHint": "记于父会话边存在之前;按小队与委派关系归组。"
+  "agentRuntime.cockpitUnboundWorkersHint": "记于父会话边存在之前;按小队与委派关系归组。",
+  "agentRuntime.catalogInvalid": "无效",
+  "agentRuntime.catalogMissing": "缺失"
 }

--- a/packages/gui/src/renderer/triadic-data.ts
+++ b/packages/gui/src/renderer/triadic-data.ts
@@ -7,6 +7,7 @@ import { agentEntityClient } from "./agent-entity-client.ts";
 import { schedulesClient } from "./schedules-client.ts";
 import { KIND_LABEL } from "./graph/constants.ts";
 import { agentNodeRowOf, scheduleNodeRowOf, withAgentTaskCounts } from "./graph/runtimeEntities.ts";
+import { isAvailableAgentEntityRow } from "./agent-entity-client.ts";
 import type { ScheduleGuiRowDto } from "../../../daemon/src/protocol/schedules-gui-contract.ts";
 import type { DecisionClaim, DecisionRow, DecisionState, FactRef, RelationEdge } from "./model/types.ts";
 import { activeProducesFactRefs } from "./model/triadic.ts";
@@ -166,7 +167,10 @@ export function useRuntimePlaneQuery(repoId: string | null, options: { readonly 
     [schedules.data],
   );
   return useMemo(() => {
-    const agentRows = withAgentTaskCounts((agents.data ?? []).map(agentNodeRowOf), relations);
+    const agentRows = withAgentTaskCounts(
+      (agents.data ?? []).filter(isAvailableAgentEntityRow).map(agentNodeRowOf),
+      relations,
+    );
     return {
       agents: agentRows,
       schedules: scheduleRows,

--- a/packages/gui/src/renderer/views/AgentSquadView.tsx
+++ b/packages/gui/src/renderer/views/AgentSquadView.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
-import { agentEntityClient } from "../agent-entity-client.ts";
+import { agentEntityClient, isAvailableAgentEntityRow, isAvailableSquadEntityRow } from "../agent-entity-client.ts";
 import { useCatalogSnapshot } from "../catalog-data.ts";
 import type { DispatchRequest, DispatchSubject } from "../dispatch-flow.ts";
 import { t } from "../i18n/index.tsx";
@@ -66,8 +66,10 @@ export function AgentSquadView({
     });
   const [dialog, setDialog] = useState<Dialog | null>(null),
     [inspector, setInspector] = useState(true);
-  const agents = workspace.agents.data ?? [],
-    squads = workspace.squads.data ?? [];
+  const agentRows = workspace.agents.data ?? [],
+    squadRows = workspace.squads.data ?? [],
+    agents = agentRows.filter(isAvailableAgentEntityRow),
+    squads = squadRows.filter(isAvailableSquadEntityRow);
   // 深链指向的实体可能已被删除(或仍在读取):存在才采用,否则回落首项 Agent、再
   // 回落首项 Squad——派生选择,不写回导航栈。
   const current: RuntimeSelection | null =
@@ -174,8 +176,8 @@ export function AgentSquadView({
         <b className="ui-body tracking-[0.02em]">{t("agentRuntime.agentsTitle")}</b>
         <span className="truncate font-mono ui-micro text-text-faint">{t("agentRuntime.agentsSubtitle")}</span>
         <span className="flex-1" />
-        <Badge>{t("agentRuntime.agentCount", { count: agents.length })}</Badge>
-        <Badge>{t("agentRuntime.squadCount", { count: squads.length })}</Badge>
+        <Badge>{t("agentRuntime.agentCount", { count: agentRows.length })}</Badge>
+        <Badge>{t("agentRuntime.squadCount", { count: squadRows.length })}</Badge>
         <Btn size="sm" variant="ghost" onClick={() => setInspector(!inspector)} tip={t("agentRuntime.toggleInspector")}>
           ▐
         </Btn>
@@ -203,8 +205,8 @@ export function AgentSquadView({
       )}
       <div className="flex min-h-0 flex-1">
         <IdentityRail
-          agents={agents}
-          squads={squads}
+          agents={agentRows}
+          squads={squadRows}
           selection={current}
           onSelect={(selection) => onSelectEntity(runtimeSelectionRef(selection))}
           onNew={(segment) => setDialog({ kind: "new-entity", entity: segment === "agents" ? "agent" : "squad" })}

--- a/packages/gui/src/renderer/views/ProvidersView.tsx
+++ b/packages/gui/src/renderer/views/ProvidersView.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { isAvailableAgentEntityRow } from "../agent-entity-client.ts";
 import { t } from "../i18n/index.tsx";
 import { Btn, CapDot, Empty, Hint } from "../components/runtime/parts.tsx";
 import { NewRuntimeDialog } from "../components/runtime/NewRuntimeDialog.tsx";
@@ -105,7 +106,7 @@ export function ProvidersView({
               instance={instance}
               installations={installations}
               authProbeState={workspace.authProbeStates.get(instance.instanceId)}
-              agents={workspace.agents.data ?? []}
+              agents={(workspace.agents.data ?? []).filter(isAvailableAgentEntityRow)}
               liveSessions={liveSessions}
               busy={workspace.busy}
               onSelectAgent={(agentId) => onSelectEntity(`agent/${agentId}`)}

--- a/packages/gui/src/renderer/views/ScheduleDetailView.tsx
+++ b/packages/gui/src/renderer/views/ScheduleDetailView.tsx
@@ -5,7 +5,7 @@ import type {
   ScheduleGuiOptionsDto,
   ScheduleGuiRowDto,
 } from "../../../../daemon/src/protocol/schedules-gui-contract.ts";
-import type { SquadRunReadResult } from "../../../../daemon/src/squad-run-contract.ts";
+import { isAvailableSquadRunDetail, type SquadRunReadResult } from "../../../../daemon/src/squad-run-contract.ts";
 import {
   Badge,
   Btn,
@@ -60,6 +60,10 @@ const AVAILABILITY_META: Record<ScheduleGuiRowDto["executionAvailability"], Mess
   "claimed-elsewhere": "schedules.availability.claimedElsewhere",
   unassigned: "schedules.availability.unassigned",
   "not-on-this-node": "schedules.availability.notOnThisNode",
+};
+const TARGET_STATE_KEY: Readonly<Record<NonNullable<ScheduleGuiRowDto["targetState"]>, MessageKey>> = {
+  invalid: "agentRuntime.catalogInvalid",
+  missing: "agentRuntime.catalogMissing",
 };
 const OUTCOME_META: Record<string, MessageKey> = {
   succeeded: "schedules.outcome.succeeded",
@@ -276,6 +280,9 @@ export function ScheduleDetailView({
             <Chip tone="mono">
               {targetKind === "squad" ? t("schedules.executor.squad") : t("schedules.executor.agent")}
             </Chip>
+            {row.targetState !== undefined && row.targetError !== undefined && (
+              <Badge tip={row.targetError.hint}>{t(TARGET_STATE_KEY[row.targetState])}</Badge>
+            )}
           </div>
           <p className="font-mono ui-micro text-text-faint">
             {`schedule/${row.scheduleId}`} · {t("schedules.detail.rev", { rev: String(row.definitionRevision) })} ·{" "}
@@ -942,6 +949,16 @@ function ArtifactRow({
  * on occurrence rows today, so this placeholder names the read it is waiting for.
  */
 export function ScheduleSquadLanes({ run }: { readonly run: SquadRunReadResult["run"] }) {
+  if (!isAvailableSquadRunDetail(run))
+    return (
+      <div
+        data-testid="schedule-run-squad-lanes"
+        className="mt-2 flex items-center gap-2 rounded border border-border px-2.5 py-2"
+      >
+        <span className="font-mono ui-micro text-text-faint">{run.squadRunId}</span>
+        <Badge tip={run.projectionError.hint}>{t("agentRuntime.catalogInvalid")}</Badge>
+      </div>
+    );
   return (
     <div data-testid="schedule-run-squad-lanes" className="mt-2 rounded border border-border px-2.5 py-2">
       <b className="ui-meta">{t("schedules.run.squad.leaderTurns", { count: String(run.leaderTurns.length) })}</b>

--- a/packages/gui/src/renderer/views/SchedulesView.tsx
+++ b/packages/gui/src/renderer/views/SchedulesView.tsx
@@ -41,6 +41,10 @@ const AVAILABILITY_META: Record<ScheduleGuiRowDto["executionAvailability"], Mess
   unassigned: "schedules.availability.unassigned",
   "not-on-this-node": "schedules.availability.notOnThisNode",
 };
+const TARGET_STATE_KEY: Readonly<Record<NonNullable<ScheduleGuiRowDto["targetState"]>, MessageKey>> = {
+  invalid: "agentRuntime.catalogInvalid",
+  missing: "agentRuntime.catalogMissing",
+};
 const OUTCOME_META: Record<string, MessageKey> = {
   succeeded: "schedules.outcome.succeeded",
   failed: "schedules.outcome.failed",
@@ -449,11 +453,16 @@ function ScheduleListPane({
                       )}
                     </td>
                     <td className="px-2.5 py-1.5">
-                      {t(
-                        scheduleRowTargetKind(row) === "squad"
-                          ? "schedules.executor.squad"
-                          : "schedules.executor.agent",
-                      )}
+                      <span className="inline-flex items-center gap-1.5">
+                        {t(
+                          scheduleRowTargetKind(row) === "squad"
+                            ? "schedules.executor.squad"
+                            : "schedules.executor.agent",
+                        )}
+                        {row.targetState !== undefined && row.targetError !== undefined && (
+                          <Badge tip={row.targetError.hint}>{t(TARGET_STATE_KEY[row.targetState])}</Badge>
+                        )}
+                      </span>
                     </td>
                     <td className="px-2.5 py-1.5">
                       <Chip tone="mono" tip={t("schedules.triggerTip")}>

--- a/packages/gui/src/renderer/views/SessionsView.tsx
+++ b/packages/gui/src/renderer/views/SessionsView.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useQueries, useQuery } from "@tanstack/react-query";
-import { agentEntityClient } from "../agent-entity-client.ts";
+import { isAvailableSquadRunSummary } from "../../../../daemon/src/squad-run-contract.ts";
+import { agentEntityClient, isAvailableSquadEntityRow } from "../agent-entity-client.ts";
 import { agentRuntimeClient, runtimeQueryKeys } from "../agent-runtime-client.ts";
 import { harnessClient } from "../api-client.ts";
 import { t } from "../i18n/index.tsx";
@@ -251,20 +252,24 @@ export function SessionsView({
           (row) => row.taskId === selectedRow.taskId && row.runtimeSessionId !== selectedRow.runtimeSessionId,
         );
   const liveCount = groups.reduce((total, group) => total + group.runningCount, 0);
-  const activeRunCount = runs.filter((run) => run.phase !== "converged" && run.phase !== "failed").length;
+  const availableRuns = runs.filter(isAvailableSquadRunSummary);
+  const activeRunCount = availableRuns.filter((run) => run.phase !== "converged" && run.phase !== "failed").length;
 
   const squads = useQuery({
     queryKey: ["squads", repoId],
     queryFn: () => agentEntityClient.listSquads(repoId),
     staleTime: 4_000,
   });
-  const squadNames = useMemo(() => new Map((squads.data ?? []).map((squad) => [squad.id, squad.name])), [squads.data]);
+  const squadNames = useMemo(
+    () => new Map((squads.data ?? []).filter(isAvailableSquadEntityRow).map((squad) => [squad.id, squad.name])),
+    [squads.data],
+  );
 
   // 小队编排详情(G12 §2b/§2c):选中行的 repo.squad.run.read,渲染 leader 轮次 →
   // worker 派工链扇出树;只有显式点击行才读取详情,切换范围后若该 run 不在列表则
   // 回到空选中。读面收敛在 useSquadRunDetail(与失效键同源)。
   const selectedSquadRun =
-    selectedSquadRunId === null ? null : (runs.find((run) => run.squadRunId === selectedSquadRunId) ?? null);
+    selectedSquadRunId === null ? null : (availableRuns.find((run) => run.squadRunId === selectedSquadRunId) ?? null);
   const squadRunDetail = useSquadRunDetail(
     repoId,
     segment === "squads" && selectedSquadRun !== null ? selectedSquadRun.squadRunId : null,

--- a/packages/gui/test/agent-runtime-renderer.vitest.ts
+++ b/packages/gui/test/agent-runtime-renderer.vitest.ts
@@ -557,6 +557,40 @@ describe("agent runtime renderer", () => {
     );
     for (const text of ["fable", "luna", "sol", "terra", "commander", "worker"]) expect(inspector).toContain(text);
   });
+  it("keeps invalid and missing identity rows visible as disabled grey hints", () => {
+    const markup = renderToStaticMarkup(
+      createElement(IdentityRail, {
+        agents: [
+          ...agentRows,
+          {
+            id: "broken-agent",
+            layer: "user",
+            state: "invalid",
+            error: { code: "invalid_entity_contract", hint: "Repair broken-agent." },
+          },
+        ] as never,
+        squads: [
+          ...squadRows,
+          {
+            id: "orphan-squad",
+            layer: "user",
+            state: "missing",
+            error: { code: "squad_agent_not_found", hint: "Install the missing Agent." },
+          },
+        ] as never,
+        selection: null,
+        onSelect: noop,
+        onNew: noop,
+      }),
+    );
+    expect(markup).toMatch(/rail-agent-broken-agent[^>]*disabled/u);
+    expect(markup).toMatch(/rail-squad-orphan-squad[^>]*disabled/u);
+    expect(markup).toContain("Repair broken-agent.");
+    expect(markup).toContain("Install the missing Agent.");
+    expect(markup).toContain("Invalid");
+    expect(markup).toContain("Missing");
+    expect(markup).not.toContain("runtime-read-error");
+  });
   it("renders the agent and squad declarations behind showAgent/showSquad", () => {
     const agent = renderToStaticMarkup(
       createElement(AgentCard, {

--- a/packages/gui/test/agent-runtime-sessions.vitest.ts
+++ b/packages/gui/test/agent-runtime-sessions.vitest.ts
@@ -471,6 +471,23 @@ describe("sessions page: squad orchestration", () => {
     expect(markup).toMatch(/squad-run-toggle-squad_a{18}"[^>]*class="[^"]*bg-accent/u);
   });
 
+  it("keeps a corrupt run projection as a disabled grey row without hiding healthy runs", () => {
+    const invalid = {
+        squadRunId: "squad_" + "c".repeat(18),
+        projectionState: "invalid" as const,
+        projectionError: {
+          code: "squad_run_projection_invalid" as const,
+          hint: "Squad run projection is invalid.",
+        },
+      },
+      markup = squadRunView({ runs: [squadRunSummary, invalid] });
+    expect(markup).toContain("ontology-squad");
+    expect(markup).toMatch(/disabled=""[^>]*squad-run-toggle-squad_c{18}/u);
+    expect(markup).toContain("Squad run projection is invalid.");
+    expect(markup).toContain("Invalid");
+    expect(markup).not.toContain("runtime-read-error");
+  });
+
   it("keeps the empty state honest when no squad run matches the range (G12 §2a)", () => {
     const inWindow = squadRunView({ runs: [], totalRuns: 0, squadNames: new Map(), range: "30d" });
     expect(inWindow).toContain("No squad runs in this range (30d)");
@@ -673,5 +690,27 @@ describe("sessions page: squad run detail", () => {
     const error = detailView({ detail: null, pending: false, error: "squad read failed" });
     expect(error).toContain("squad read failed");
     expect(error).toMatch(/data-testid="squad-run-detail-error"/u);
+  });
+
+  it("renders an invalid detail projection as a grey hint instead of a read error", () => {
+    const invalid = detailView({
+      detail: {
+        ok: true,
+        status: "ready",
+        run: {
+          squadRunId: "squad_" + "d".repeat(24),
+          projectionState: "invalid",
+          projectionError: {
+            code: "squad_run_projection_invalid",
+            hint: "Repair the invalid Squad run projection.",
+          },
+        },
+        watermark: 9,
+        sourceRevision: 9,
+      },
+    });
+    expect(invalid).toContain("Invalid");
+    expect(invalid).toContain("Repair the invalid Squad run projection.");
+    expect(invalid).not.toContain("squad-run-detail-error");
   });
 });

--- a/packages/gui/test/schedules-view.vitest.ts
+++ b/packages/gui/test/schedules-view.vitest.ts
@@ -139,6 +139,56 @@ describe("schedules plane (S4) — matrix list (M1)", () => {
     expect(container.querySelector('[data-testid="schedules-inspector"]')).toBeNull();
   });
 
+  it("renders unavailable Agent targets and options as row-level grey hints", async () => {
+    const hint = "Install agent/ghost-agent, then retry.",
+      data = dto(
+        {
+          target: {
+            kind: "agent",
+            agentId: "ghost-agent",
+            runtimeInstanceId: "codex-schedule",
+            model: "gpt-5.6",
+            reasoningEffort: "high",
+            fast: false,
+            cwd: null,
+          },
+          targetState: "missing",
+          targetError: { code: "agent_not_found", hint },
+          actions: {
+            ...(dto().schedules[0] as ScheduleGuiRowDto).actions,
+            runNow: { available: false, code: "schedule_target_unavailable", nextAction: hint },
+          },
+        },
+        {
+          options: {
+            ...dto().options,
+            agents: [
+              { agentId: "ghost-agent", state: "missing", error: { code: "agent_not_found", hint } },
+              { agentId: "probe-agent", name: "Probe Agent", runtimeType: "codex" },
+            ],
+          },
+        },
+      ),
+      container = await renderSurface(
+        createElement(ScheduleWorkspace, {
+          repoId: "repo-a",
+          data,
+          pending: false,
+          focusedEntityRef: null,
+          onSelectEntity: noop,
+          onFocusSchedule: noop,
+        }),
+      );
+    expect(container.textContent).toContain("Missing");
+    expect(container.querySelector(`[data-tip="${hint}"]`)).not.toBeNull();
+    expect(container.querySelector('[data-testid="schedules-read-error"]')).toBeNull();
+    await click(container, "schedule-action-create");
+    expect(container.querySelector('[data-testid="schedule-agent-option-ghost-agent"]')?.textContent).toContain(
+      "Missing",
+    );
+    expect(container.querySelectorAll('[data-testid="schedule-form-agent"] option')).toHaveLength(1);
+  });
+
   it("filters rows by state, and keeps mode/health facets off until the daemon projects them", async () => {
     const first = dto({
       missed: { count: 0, lastMissedAt: null, lastMissedReason: null },


### PR DESCRIPTION
# English

## Summary

Five daemon collection reads let one bad row reject the whole table (fact F-6F836337, same mechanism as PR #2181): the Agent GUI catalog, the Squad GUI catalog, the Schedule GUI agent options, the Squad-run projections (list and direct read), and the post-migration `ha squad list` CLI path (`squad-action-runtime.ts:listSquads`). Each now keeps the bad row as a closed degraded DTO (`state: "invalid" | "missing"` with a structured `{code, hint}` error, or `projectionState: "invalid"` + `projectionError` for runs) and returns every healthy row. Healthy DTOs are byte-for-byte unchanged. GUI views render degraded rows as disabled grey badges with the daemon hint and never route them into the query error channel; the CLI Squad list renders state/error columns instead of aborting. Mutations on a corrupt Squad-run projection still fail closed.

## Architectural Justification

Degradation is expressed in the read projection only: rows derive their state from projection freshness (`current` → available, `orphaned` → missing, otherwise invalid) or from the contract parse error, so no retry, cache, feature flag or ledger write was added. Type guards give functional consumers (dispatch, editing, graphs) only available rows. The Squad-run list/query responsibility was moved into `squad-run-list.ts` because the file-complexity gate required a responsibility split of `squad-coordinator.ts`, not a line shave or a gate change.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none

## Machine-Readable Declarations

Production-Delta: +808/-236
Dependency-Change: none

### Optional Evidence Claims

none

## Task And Scope

task_76edd748eda44d7ce03da340a9 (child of the GovernedEntity root task_e91dd004; follow-up class of PR #2181 / fact F-6F836337; the fifth path was ruled into scope by the CEO after the worker's checkpoint, fact F-BB3C15A0). In-file removals: the five collection-wide throw/map branches and the full-row assumptions they carried in `agent-entities.ts`, `schedules-gui-read.ts`, `squad-coordinator.ts`, `squad-action-runtime.ts`.

## Version Impact

None.

## Governance Declaration

No protected path touched. No break-glass. The ontology daemon-specialization ratchet files are untouched.

## Verification

- Worker stop point (targeted tests + local commit, no `check:local`): isolated daemon/CLI suites 71/71 (agent entities 21, schedule contract 15, squad-run list 11, schedule integration 2, coordinator 1 + recovery 13, squad-run wire 4, squad action integration 3, CLI squad renderer 1); focused GUI Vitest 3 files 67/67; typecheck, lint, derived-contracts, implementation-contracts (delta 0), cli-error-codes, gui-status-judgments (frozen 38/10/45/21, no new allowlist), line-density, file-complexity all green locally.
- Positive control per path: a single invalid row previously rejected the whole read; now it is returned as a degraded row next to the healthy ones. Negative control: healthy Agent/Squad/Schedule/Squad-run objects keep their existing serializers unchanged.
- Facts F-BB3C15A0 (fifth path), worker facts on the task. Branch merged with `origin/main` (`4c56e539`) before the PR; CI is the full authority.

## Review Evidence

Worker report: `harness/tasks/task_76edd748eda44d7ce03da340a9-*/artifacts/daemon-collection-read-degrade-report.md` (private ledger). CEO semantic review: round 1 stopped at the plan checkpoint on discovering the fifth path; the CEO ruled it into the same change rather than a separate task. The degraded DTO shape and naming follow PR #2181; the diff read for `agent-entities.ts` shows the closed union + type guards derived from projection freshness.

## Residual Risk

The CLI table renderer and the daemon collection behavior are covered by separate tests rather than one end-to-end human-output subprocess (JSON transport tests retain their coverage). `squad-coordinator.ts` is 1066 lines after the split; the structural-split task task_ab6a4f4d remains queued for the three largest daemon files.

---

# 中文

## 概要

daemon 有五处集合读会因一行坏数据整表抛错(fact F-6F836337,与 PR #2181 同一机制):Agent GUI catalog、Squad GUI catalog、Schedule GUI 的 agent options、Squad-run 投影(列表与直读)、以及迁移后的 `ha squad list` CLI 路径(`squad-action-runtime.ts:listSquads`)。现在每处都把坏行保留为闭合的退化 DTO(`state: "invalid" | "missing"` + 结构化 `{code, hint}`;run 用 `projectionState: "invalid"` + `projectionError`),其余健康行照常返回;健康 DTO 逐字节不变。GUI 视图把退化行渲染成灰态禁用徽章并带 daemon 提示,不进 query 的错误通道;CLI Squad 列表输出 state/error 列而不是中止。对损坏 Squad-run 投影的变更仍 fail closed。

## 架构辩护

退化只在读投影层表达:行状态由投影新鲜度派生(`current` → 可用,`orphaned` → missing,其余 invalid)或来自契约解析错误,没有加重试、缓存、feature flag 或台账写入。类型守卫让功能消费方(派工、编辑、图)只拿到可用行。Squad-run 列表/查询职责移到 `squad-run-list.ts`,因为 file-complexity 门要求对 `squad-coordinator.ts` 做职责拆分,而不是削行或改门。

## 机读声明

见英文块。

## 治理声明

未触碰 protected 路径。无 break-glass。ontology daemon 特化棘轮文件零改动。

## 验证

- worker 停止点(定向测试 + 本地 commit,不跑 `check:local`):隔离 daemon/CLI 套件 71/71(agent entities 21、schedule contract 15、squad-run list 11、schedule integration 2、coordinator 1 + recovery 13、squad-run wire 4、squad action integration 3、CLI squad renderer 1);GUI Vitest 3 文件 67/67;typecheck、lint、derived-contracts、implementation-contracts(delta 0)、cli-error-codes、gui-status-judgments(冻结 38/10/45/21,无新 allowlist)、line-density、file-complexity 本地全绿。
- 每处阳性对照:一行无效此前整表拒绝,现在与健康行并列返回退化行;阴性对照:健康 Agent/Squad/Schedule/Squad-run 对象的序列化不变。
- fact F-BB3C15A0(第五处)与任务上的 worker fact。开 PR 前已与 `origin/main`(`4c56e539`)合并;CI 是完整权威。

## 评审证据

worker 报告见任务包 `artifacts/daemon-collection-read-degrade-report.md`(私有台账)。CEO 语义验收:第一轮在 plan checkpoint 停手(发现第五处),CEO 裁决并入同一变更而非另立任务;退化 DTO 形状与命名沿用 PR #2181;`agent-entities.ts` 的 diff 显示闭合联合 + 类型守卫由投影新鲜度派生。

## 残余风险

CLI 表格渲染与 daemon 集合行为分别由各自测试覆盖,没有一条端到端的人读输出子进程测试(JSON 传输测试保留覆盖)。拆分后 `squad-coordinator.ts` 仍 1066 行;三个最大 daemon 文件的结构拆分任务 task_ab6a4f4d 仍在队列。
