### PR TITLE
fix(runtime): authorize descendant task orchestration for commander runtimes

### DIFF
--- a/packages/daemon/src/doc-sync-adjudication.ts
+++ b/packages/daemon/src/doc-sync-adjudication.ts
@@ -7,6 +7,7 @@ import {
   resolveRetirableDocument,
   runtimeSessionIdFromActor,
   sha256Bytes,
+  taskIsDescendantOf,
   type DocEventV1,
   type DocSyncReceiptDetail,
   type DocWriteIntent,
@@ -56,6 +57,7 @@ export type DocIntentAdjudication =
 export function adjudicateDocIntent(
   input: Omit<Input, "action"> & {
     readonly taskDocumentChannel?: DocIntentChannel;
+    readonly taskId?: string;
   },
   intent: DocWriteIntent,
   claims: readonly (Uint8Array | null)[],
@@ -91,6 +93,16 @@ export function adjudicateDocIntent(
     runtimeSession = runtimeSessionId === null ? null : input.projection.readRuntimeSession(runtimeSessionId),
     runtimeBinding =
       lease === null ? null : resolveTaskBoundRuntimeBinding(runtimeSession, lease.taskId, lease.executionId),
+    runtimeDelegatedTaskId =
+      runtimeBinding !== null &&
+      input.taskId !== undefined &&
+      taskIsDescendantOf(
+        input.taskId,
+        runtimeBinding.taskId,
+        (current) => input.projection.read(current).snapshot.task?.metadata?.parentTaskId ?? null,
+      )
+        ? input.taskId
+        : null,
     authorization = authorizationDecision;
   const decision = decideDocWrite({
     intent,
@@ -108,6 +120,7 @@ export function adjudicateDocIntent(
     retirementReason,
     resolvedTaskIds,
     ...(runtimeBinding ? { runtimeBinding } : {}),
+    ...(runtimeDelegatedTaskId ? { runtimeDelegatedTaskId } : {}),
   });
   return decision.accepted
     ? { accepted: true, decision: { ...decision, authorizationDecision } }

--- a/packages/daemon/src/doc-sync-candidate-scanner.ts
+++ b/packages/daemon/src/doc-sync-candidate-scanner.ts
@@ -21,6 +21,7 @@ import {
   isTaskBoundRuntimeWriter,
   sameWriteSource,
   sha256Bytes,
+  taskIsDescendantOf,
   type ActorIdentity,
   type CanonicalEventStore,
   type DocWriteIntent,
@@ -119,7 +120,15 @@ export function scanDocCandidates(input: {
       )
       .sort(),
     baseLedgerSha = input.inventory?.baseLedgerSha ?? input.store.currentCut(),
-    execution = executionBinding(paths, input.executionId, input.projection, input.actor, input.source, input.now),
+    execution = executionBinding(
+      paths,
+      input.executionId,
+      input.projection,
+      input.actor,
+      input.source,
+      input.now,
+      input.taskId,
+    ),
     runtimeSessionId = runtimeSessionIdFromActor(input.actor),
     runtimeSession = runtimeSessionId === null ? null : input.projection.readRuntimeSession(runtimeSessionId),
     runtimeBinding =
@@ -254,6 +263,7 @@ export function scanDocCandidates(input: {
         claims: [bytes],
         resolvedTaskIds: [input.projection.taskIdForDocumentPath(logical)],
         ...(runtimeBinding ? { runtimeBinding } : {}),
+        ...(execution.runtimeDelegatedTaskId ? { runtimeDelegatedTaskId: execution.runtimeDelegatedTaskId } : {}),
       });
     if (decision.accepted) return scannedCandidateRow("eligible", null, bytes, base, candidate, mediaType);
     const unresolved = decision.detail.unresolvedTouches,
@@ -409,13 +419,20 @@ function executionBinding(
   actor: ActorIdentity,
   source: WriteSource,
   now: string,
+  taskId: string | undefined,
 ) {
-  if (explicit) return { id: explicit, candidates: [], lease: projection.currentLeaseForExecution(explicit, now) };
+  if (explicit)
+    return {
+      id: explicit,
+      candidates: [],
+      lease: projection.currentLeaseForExecution(explicit, now),
+      runtimeDelegatedTaskId: null,
+    };
   const tasks = new Set(paths.flatMap((value) => projection.taskIdForDocumentPath(value) ?? [])),
     runtimeSessionId = runtimeSessionIdFromActor(actor);
   if (runtimeSessionId !== null) {
     const session = projection.readRuntimeSession(runtimeSessionId),
-      matches =
+      exactMatches =
         session?.taskBindings.flatMap((binding) => {
           if (!tasks.has(binding.taskId)) return [];
           const lease = projection.currentLeaseForExecution(binding.executionId, now),
@@ -425,10 +442,40 @@ function executionBinding(
             ? [{ id: binding.executionId, lease }]
             : [];
         }) ?? [],
+      descendantMatches =
+        exactMatches.length > 0 || taskId === undefined || !tasks.has(taskId)
+          ? []
+          : (session?.taskBindings.flatMap((binding) => {
+              if (
+                !taskIsDescendantOf(
+                  taskId,
+                  binding.taskId,
+                  (current) => projection.read(current).snapshot.task?.metadata?.parentTaskId ?? null,
+                )
+              )
+                return [];
+              const lease = projection.currentLeaseForExecution(binding.executionId, now),
+                runtimeBinding = resolveTaskBoundRuntimeBinding(session, binding.taskId, binding.executionId);
+              if (lease === null || runtimeBinding === null) return [];
+              return isTaskBoundRuntimeWriter(lease, actor, source, runtimeBinding)
+                ? [{ id: binding.executionId, lease }]
+                : [];
+            }) ?? []),
+      matches = exactMatches.length > 0 ? exactMatches : descendantMatches,
       unique = [...new Map(matches.map((match) => [match.id, match])).values()];
     return unique.length === 1
-      ? { id: unique[0]!.id, candidates: [], lease: unique[0]!.lease }
-      : { id: null, candidates: unique.map((match) => match.id).sort(), lease: null };
+      ? {
+          id: unique[0]!.id,
+          candidates: [],
+          lease: unique[0]!.lease,
+          runtimeDelegatedTaskId: exactMatches.length === 0 ? (taskId ?? null) : null,
+        }
+      : {
+          id: null,
+          candidates: unique.map((match) => match.id).sort(),
+          lease: null,
+          runtimeDelegatedTaskId: null,
+        };
   }
   // Channel selection must authorize the caller, not just observe the scanned
   // path set: pinning a non-holder to a task lease they cannot hold turns a
@@ -444,8 +491,9 @@ function executionBinding(
       current?.phase === "held" && isSameExecution(current.actor, actor) && sameWriteSource(current.source, source)
         ? current
         : null;
-  return { id: lease?.executionId ?? null, candidates: [], lease };
+  return { id: lease?.executionId ?? null, candidates: [], lease, runtimeDelegatedTaskId: null };
 }
+
 function dirtyPaths(repoRoot: string, authoredPrefix: string): string[] {
   const scope = authoredPrefix || ".",
     changed = gitNames(repoRoot, ["diff", "--name-only", "-z", "HEAD", "--", scope]),

--- a/packages/daemon/src/doc-sync-publication.ts
+++ b/packages/daemon/src/doc-sync-publication.ts
@@ -258,7 +258,17 @@ export function publishDocIntent(
     recycleClaims(input.rootDir, intent);
     return receipt;
   }
-  const adjudication = adjudicateDocIntent(input, intent, claims, lease, envelope.opId, retirementReason);
+  const adjudication = adjudicateDocIntent(
+    {
+      ...input,
+      ...(typeof input.action.taskId === "string" ? { taskId: input.action.taskId } : {}),
+    },
+    intent,
+    claims,
+    lease,
+    envelope.opId,
+    retirementReason,
+  );
   if (!adjudication.accepted) {
     if (adjudication.code === "projection_pending")
       return {

--- a/packages/daemon/src/repo-cell-authorization.ts
+++ b/packages/daemon/src/repo-cell-authorization.ts
@@ -4,6 +4,7 @@ import {
   isSameExecution,
   isSamePerson,
   parseEntityRef,
+  taskIsDescendantOf,
   type AuthorizationContext,
   type AuthorizationDecision,
   type EntityRef,
@@ -309,7 +310,7 @@ export function authorizeDurableRepoCellAction(
 export function bindVerifiedExecutorClaim(input: {
   readonly action: RepoTaskAction;
   readonly binding: RepoCellBinding;
-  readonly projection: Pick<TaskProjection, "readRuntimeSession" | "currentLease">;
+  readonly projection: Pick<TaskProjection, "read" | "readRuntimeSession" | "currentLease">;
   readonly now: string;
 }): { readonly action: RepoTaskAction; readonly binding: RepoCellBinding } {
   if (!Object.hasOwn(input.action, "executor")) return { action: input.action, binding: input.binding };
@@ -363,14 +364,39 @@ export function bindVerifiedExecutorClaim(input: {
     executionId = typeof action.executionId === "string" ? action.executionId : null;
   if (session === null)
     throw invalidExecutorBinding("The claimed RuntimeSession is not canonically bound to this Task action.");
-  const taskBinding =
-    taskId === null
-      ? session.taskBindings.length === 1
-        ? session.taskBindings[0]
-        : undefined
-      : session.taskBindings.find(
-          (candidate) => candidate.taskId === taskId && (executionId === null || candidate.executionId === executionId),
-        );
+  const exactBinding =
+      taskId === null
+        ? session.taskBindings.length === 1
+          ? session.taskBindings[0]
+          : undefined
+        : session.taskBindings.find(
+            (candidate) =>
+              candidate.taskId === taskId && (executionId === null || candidate.executionId === executionId),
+          ),
+    descendantBinding =
+      exactBinding === undefined && taskId !== null && (action.kind === "doc-submit" || action.kind === "runtime-spawn")
+        ? session.taskBindings.find((candidate) => {
+            if (
+              !taskIsDescendantOf(
+                taskId,
+                candidate.taskId,
+                (current) => input.projection.read(current).snapshot.task?.metadata?.parentTaskId ?? null,
+              )
+            )
+              return false;
+            const candidateLease = input.projection.currentLease(candidate.taskId, input.now),
+              candidateActor = {
+                principal: input.binding.actor.principal,
+                executor: { kind: "agent" as const, id: `runtime-session:${runtimeSessionId}` },
+              };
+            return (
+              candidateLease !== null &&
+              candidateLease.executionId === candidate.executionId &&
+              isSamePerson(candidateLease.actor, candidateActor)
+            );
+          })
+        : undefined,
+    taskBinding = exactBinding ?? descendantBinding;
   if (!taskBinding)
     throw invalidExecutorBinding("The claimed RuntimeSession does not execute the target Task/Execution.");
   const lease = input.projection.currentLease(taskBinding.taskId, input.now),

--- a/packages/daemon/test/runtime-spawn-ingress.integration.test.ts
+++ b/packages/daemon/test/runtime-spawn-ingress.integration.test.ts
@@ -11,7 +11,7 @@ import { createJsonRpcProtocolServer } from "../src/protocol/json-rpc-server.ts"
 import { createUnixSocketTransportServer } from "../src/transport/unix-socket.ts";
 import { writeProviderExecutable } from "./fixtures/runtime-stub.ts";
 import { registerBootstrappedDaemonRepo as registerDaemonRepo } from "./repo-settings.fixture.ts";
-import { createRealizedTaskPlanFixture } from "../../../tools/fixtures/task-plan.mjs";
+import { createRealizedTaskPlanFixture, realizeTaskPlanFixture } from "../../../tools/fixtures/task-plan.mjs";
 import {
   definition,
   installation,
@@ -634,6 +634,118 @@ test("daemon ingress preserves executor-scoped task-bound runtime spawn", async 
         } finally {
           replay.close();
         }
+      },
+    );
+    await t.test(
+      "a task-bound runtime syncs and dispatches its descendant task but not an unrelated task",
+      async () => {
+        const parentTaskId = "task-runtime-commander-parent",
+          parentExecutionId = "exec-runtime-commander-parent",
+          unrelatedTaskId = "task-runtime-commander-unrelated";
+        await createReadyTask(parentTaskId, "Runtime commander parent");
+        assert.equal(
+          (await host.run(repoId, { kind: "task-start", taskId: parentTaskId, executionId: parentExecutionId }, auth))
+            .outcome,
+          "applied",
+        );
+        const commander = await rpc(host, auth, "repo.agentRuntime.spawn", {
+          repo: { repoId },
+          payload: {
+            runtimeInstanceId: ingressDefinition.instanceId,
+            cwd: { scope: "repo-root" },
+            prompt: "Plan and dispatch the child task.",
+            taskId: parentTaskId,
+            idempotencyKey: "runtime-commander-parent",
+          },
+        });
+        assert.equal(commander.outcome, "applied", JSON.stringify(commander));
+        await eventuallyValue(
+          async () =>
+            makeTaskEventReader({ repoId, rootDir: root })
+              .read()
+              .events.find(
+                (event) =>
+                  event.type === "runtime_session_task_bound" &&
+                  event.payload.runtimeSessionId === commander.runtimeSessionId,
+              ) ?? null,
+        );
+        const commanderExecutor = {
+            kind: "agent",
+            id: `runtime-session:${commander.runtimeSessionId}`,
+          } as const,
+          child = await host.run(
+            repoId,
+            {
+              kind: "task-create",
+              title: "Runtime commander child",
+              parentTaskId,
+              executor: commanderExecutor,
+            },
+            auth,
+          );
+        assert.equal(child.outcome, "applied", JSON.stringify(child));
+        assert.equal(typeof child.taskId, "string", JSON.stringify(child));
+        assert.equal(typeof child.packagePath, "string", JSON.stringify(child));
+        const childTaskId = String(child.taskId);
+        await realizeTaskPlanFixture(
+          root,
+          String(child.packagePath),
+          (_planPath) =>
+            host.run(repoId, { kind: "doc-submit", taskId: childTaskId, executor: commanderExecutor }, auth),
+          "Runtime commander child",
+        );
+
+        const childDispatch = await rpc(host, auth, "repo.agentRuntime.spawn", {
+          repo: { repoId },
+          payload: {
+            runtimeInstanceId: ingressDefinition.instanceId,
+            cwd: { scope: "repo-root" },
+            taskId: childTaskId,
+            idempotencyKey: "runtime-commander-child",
+            executor: commanderExecutor,
+          },
+        });
+        assert.equal(childDispatch.outcome, "applied", JSON.stringify(childDispatch));
+        await eventuallyValue(
+          async () =>
+            makeTaskEventReader({ repoId, rootDir: root })
+              .read()
+              .events.find(
+                (event) =>
+                  event.type === "runtime_session_task_bound" &&
+                  event.payload.runtimeSessionId === childDispatch.runtimeSessionId &&
+                  event.payload.taskId === childTaskId,
+              ) ?? null,
+        );
+
+        await createReadyTask(unrelatedTaskId, "Runtime commander unrelated");
+        const unrelatedDoc = await host.run(
+          repoId,
+          { kind: "doc-submit", taskId: unrelatedTaskId, executor: commanderExecutor },
+          auth,
+        );
+        assert.deepEqual(
+          { outcome: unrelatedDoc.outcome, code: unrelatedDoc.code },
+          { outcome: "op_rejected", code: "executor_binding_invalid" },
+          JSON.stringify(unrelatedDoc),
+        );
+        const launchesBeforeUnrelated = launchCount,
+          unrelatedDispatch = await rpc(host, auth, "repo.agentRuntime.spawn", {
+            repo: { repoId },
+            payload: {
+              runtimeInstanceId: ingressDefinition.instanceId,
+              cwd: { scope: "repo-root" },
+              taskId: unrelatedTaskId,
+              idempotencyKey: "runtime-commander-unrelated",
+              executor: commanderExecutor,
+            },
+          });
+        assert.deepEqual(
+          { outcome: unrelatedDispatch.outcome, code: unrelatedDispatch.code },
+          { outcome: "op_rejected", code: "executor_binding_invalid" },
+          JSON.stringify(unrelatedDispatch),
+        );
+        assert.equal(launchCount, launchesBeforeUnrelated);
       },
     );
     await t.test(

--- a/packages/kernel/src/domain/doc-sync-types.ts
+++ b/packages/kernel/src/domain/doc-sync-types.ts
@@ -219,6 +219,8 @@ export interface DocWriteDecisionInput {
   /** Decision evaluated by the daemon AuthorizationPort for execution-bound writes. */
   readonly authorizationDecision: AuthorizationDecision | null;
   readonly runtimeBinding?: TaskBoundRuntimeBinding;
+  /** Strict descendant package selected by a task-bound runtime acting through its own live lease. */
+  readonly runtimeDelegatedTaskId?: string;
   readonly documents: readonly (DocumentState | null)[];
   readonly claims: readonly (Uint8Array | null)[];
   readonly resolvedTaskIds?: readonly (string | null)[];

--- a/packages/kernel/src/domain/doc-sync-writer.ts
+++ b/packages/kernel/src/domain/doc-sync-writer.ts
@@ -123,8 +123,14 @@ function decideDocWriteInternal(input: DocWriteDecisionInput, requireAuthorizati
   for (const [index, change] of input.intent.changes.entries()) {
     const current = input.documents[index] ?? null,
       route = resolveDocRoute(change.path),
-      task = input.resolvedTaskIds === undefined ? taskFromPath(change.path) : (input.resolvedTaskIds[index] ?? null);
-    if (runtimeWorker && !directHolder && (task !== input.runtimeBinding!.taskId || !taskArtifactPath(change.path)))
+      task = input.resolvedTaskIds === undefined ? taskFromPath(change.path) : (input.resolvedTaskIds[index] ?? null),
+      delegatedRuntimeTask = runtimeWorker && task === input.runtimeDelegatedTaskId;
+    if (
+      runtimeWorker &&
+      !directHolder &&
+      !delegatedRuntimeTask &&
+      (task !== input.runtimeBinding!.taskId || !taskArtifactPath(change.path))
+    )
       unresolvedTouches.push(
         touch(
           change.path,
@@ -135,7 +141,7 @@ function decideDocWriteInternal(input: DocWriteDecisionInput, requireAuthorizati
           "task-bound-runtime-artifacts",
         ),
       );
-    if (task !== null && input.lease !== null && task !== input.lease.taskId)
+    if (task !== null && input.lease !== null && task !== input.lease.taskId && !delegatedRuntimeTask)
       unresolvedTouches.push(
         touch(change.path, null, "target task does not match the execution lease", "matching-task-lease"),
       );

--- a/packages/kernel/src/domain/task-bound-runtime-authority.ts
+++ b/packages/kernel/src/domain/task-bound-runtime-authority.ts
@@ -38,6 +38,22 @@ export function resolveTaskBoundRuntimeBinding(
   return { runtimeSessionId: session.runtimeSessionId, taskId, executionId };
 }
 
+/** A strict task descendant is reached only by following canonical parent bindings upward. */
+export function taskIsDescendantOf(
+  taskId: string,
+  ancestorTaskId: string,
+  parentTaskId: (candidateTaskId: string) => string | null,
+): boolean {
+  const visited = new Set([taskId]);
+  let candidate = parentTaskId(taskId);
+  while (candidate !== null && !visited.has(candidate)) {
+    if (candidate === ancestorTaskId) return true;
+    visited.add(candidate);
+    candidate = parentTaskId(candidate);
+  }
+  return false;
+}
+
 export function isTaskBoundRuntimeWriter(
   lease: LeaseV1,
   actor: ActorIdentity,

--- a/packages/kernel/src/index.ts
+++ b/packages/kernel/src/index.ts
@@ -51,6 +51,7 @@ export {
   isTaskBoundRuntimeWriter,
   resolveTaskBoundRuntimeBinding,
   runtimeSessionIdFromActor,
+  taskIsDescendantOf,
 } from "./domain/task-bound-runtime-authority.ts";
 export type { TaskBoundRuntimeBinding } from "./domain/task-bound-runtime-authority.ts";
 export {

--- a/packages/kernel/test/contracts/doc-sync-runtime-artifacts.test.ts
+++ b/packages/kernel/test/contracts/doc-sync-runtime-artifacts.test.ts
@@ -3,7 +3,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { OPAQUE_TEXTUAL_POLICY_ID } from "../../src/domain/artifact-text-classification.ts";
 import { DOC_POLICY_ID, decideDocWrite, documentPath, type DocumentState } from "../../src/domain/doc-sync.contract.ts";
-import { resolveTaskBoundRuntimeBinding } from "../../src/domain/task-bound-runtime-authority.ts";
+import { resolveTaskBoundRuntimeBinding, taskIsDescendantOf } from "../../src/domain/task-bound-runtime-authority.ts";
 import { validateWriteReceipt } from "../../src/domain/write-chain.contract.ts";
 import { sha256Text } from "../../src/integrity/stable-hash.ts";
 
@@ -61,6 +61,10 @@ test("a task-bound runtime may write only its assigned task artifacts subtree wh
     });
   const accepted = run("tasks/task-owner-docs/artifacts/report.md", lease.taskId);
   assert.equal(accepted.accepted, true, JSON.stringify(accepted));
+  const delegated = run("tasks/task-child-docs/task_plan.md", "task-child", {
+    runtimeDelegatedTaskId: "task-child",
+  });
+  assert.equal(delegated.accepted, true, JSON.stringify(delegated));
   for (const [name, result, code] of [
     [
       "canonical binding required",
@@ -72,6 +76,11 @@ test("a task-bound runtime may write only its assigned task artifacts subtree wh
     ],
     ["assigned task required", run("tasks/task-other-docs/artifacts/report.md", "task-other"), "unresolved_touch"],
     ["artifacts subtree required", run("tasks/task-owner-docs/task_plan.md", lease.taskId), "unresolved_touch"],
+    [
+      "delegation remains task specific",
+      run("tasks/task-other-docs/task_plan.md", "task-other", { runtimeDelegatedTaskId: "task-child" }),
+      "unresolved_touch",
+    ],
   ] as const) {
     assert.equal(result.accepted, false, name);
     if (!result.accepted) assert.equal(result.code, code, name);
@@ -108,6 +117,24 @@ test("a task-bound runtime may write only its assigned task artifacts subtree wh
     runtimeBinding,
   );
   assert.equal(resolveTaskBoundRuntimeBinding(session, lease.taskId, "another-execution"), null);
+  const parents = new Map([
+    ["task-child", lease.taskId],
+    ["task-grandchild", "task-child"],
+    ["task-cycle-a", "task-cycle-b"],
+    ["task-cycle-b", "task-cycle-a"],
+  ]);
+  assert.equal(
+    taskIsDescendantOf("task-grandchild", lease.taskId, (taskId) => parents.get(taskId) ?? null),
+    true,
+  );
+  assert.equal(
+    taskIsDescendantOf("task-other", lease.taskId, (taskId) => parents.get(taskId) ?? null),
+    false,
+  );
+  assert.equal(
+    taskIsDescendantOf("task-cycle-a", lease.taskId, (taskId) => parents.get(taskId) ?? null),
+    false,
+  );
 });
 
 test("an opaque artifact write reclassifies an existing prose record without a policy upgrade", () => {


### PR DESCRIPTION
# English

## Summary

A Commander runtime dispatched with `ha runtime run --task <parent>` could not act on the child tasks it created: `ha doc sync --submit --task <child>` and `ha runtime run --task <child>` both failed with `executor_binding_invalid` (facts F-A48CF979, F-F240465C), so three-tier orchestration (CEO → Commander → Worker) was impossible inside the harness. The executor-claim predicate in `repo-cell-authorization.ts` required an exact `(taskId, executionId)` binding. This PR adds a narrow descendant branch at the same decision point: for `doc-submit` and `runtime-spawn` only, a RuntimeSession may act on a strict descendant of a task it is bound to, provided the bound (ancestor) task's live lease is held by that same runtime-session actor. Unrelated tasks are still rejected; cyclic lineage fails closed. The doc-sync scanner/adjudication carry the parent execution lease so a task-scoped descendant package reaches the kernel writer, which still validates the target task per path.

## Architectural Justification

The invariant the predicate protects is "a runtime must not claim an unrelated Task/Execution", not "one session executes exactly one task". Direct descendant authority keeps the Commander runtime as the recorded actor (no person-principal delegation identity needed) and proves authority from the canonical parent chain plus the live parent lease. Writes still enter the RepoCell single-writer queue; no new concurrency subject. Exact binding remains the default path; the descendant branch is a narrow extension inside the same adjudication, so nothing is superseded and no removal date applies.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none

## Machine-Readable Declarations

Production-Delta: +141/-19
Dependency-Change: none

### Optional Evidence Claims

none

## Task And Scope

task_e2eac1fa7a667d288224082d3d (framework friction found by the Fable Commander on task_8a6b9ae1; blocks every Commander line). In-file removals: the single `taskBinding` lookup in `bindVerifiedExecutorClaim` is restructured into exact-or-descendant; no path deleted.

## Version Impact

None.

## Governance Declaration

No protected path touched. No break-glass. Authorization seam change is covered by contract and integration tests for both acceptance and rejection.

## Verification

- Worker stop point (targeted tests + local commit, no `check:local`): kernel `doc-sync-runtime-artifacts` contract tests (descendant plan doc allowed, unrelated task rejected, cyclic lineage fail-closed); daemon `runtime-spawn-ingress` integration (Commander creates a child, syncs the child `task_plan.md`, dispatches a child runtime; unrelated-task doc sync and dispatch both rejected, launch count unchanged); typecheck, ESLint, architecture and complexity gates green locally.
- Positive control before the fix: the new child `task_plan.md` sync case returned `outcome=op_rejected code=executor_binding_invalid` on an Ubuntu isolation run (report).
- Branch merged with `origin/main` before the PR; CI is the full authority.

## Review Evidence

Worker report: `harness/tasks/task_e2eac1fa7a667d288224082d3d-*/artifacts/commander-runtime-descendant-authority-report.md` (private ledger). CEO semantic review: the descendant branch is gated by (a) action kind ∈ {doc-submit, runtime-spawn}, (b) strict parent chain through the canonical projection with cycle guard, (c) the ancestor task's live lease held by the same runtime-session actor; the exact path is untouched and unrelated-task rejection is asserted. No second independent reviewer was run on this PR; the residual is stated below.

## Residual Risk

The descendant proof reads the parent chain from the canonical projection at claim time; a parent re-binding between claim and write is caught by the writer's per-path task validation, not by this predicate. Authorization changes were reviewed by the CEO only; a later anti-entropy squad pass on the authorization seam is the planned second look.

---

# 中文

## 概要

用 `ha runtime run --task <父任务>` 派出的 Commander runtime 无法操作自己创建的子任务:`ha doc sync --submit --task <子>` 与 `ha runtime run --task <子>` 都被 `executor_binding_invalid` 拒(fact F-A48CF979、F-F240465C),三层编排(CEO → Commander → Worker)在 harness 内不可能。`repo-cell-authorization.ts` 的 executor claim 谓词要求精确命中 `(taskId, executionId)`。本 PR 在同一裁决点加一条窄的 descendant 分支:仅对 `doc-submit` 与 `runtime-spawn`,RuntimeSession 可以操作其已绑定任务的严格后代,前提是该祖先任务的 live lease 由同一个 runtime-session actor 持有。无关任务仍被拒;循环血缘 fail-closed。doc-sync 的扫描/裁决携带父 execution lease,把 task 限定的后代包交给 kernel writer,writer 仍逐路径校验目标任务。

## 架构辩护

该谓词保护的不变量是「runtime 不得冒领无关 Task/Execution」,不是「一个 session 只能执行一个 task」。直接的后代授权让 Commander runtime 继续作为记录中的 actor(不需要 person principal 代持身份),权限由 canonical 父链 + 父任务 live lease 证明。写入仍走 RepoCell 单写队列,没有新并发主体。精确绑定仍是默认路径,后代分支是同一裁决内的窄扩展,不替代任何路径,故无删除日期。

## 机读声明

见英文块。

## 治理声明

未触碰 protected 路径。无 break-glass。授权面改动有接受与拒绝两侧的契约与集成测试覆盖。

## 验证

- worker 停止点(定向测试 + 本地 commit,不跑 `check:local`):kernel `doc-sync-runtime-artifacts` 契约测试(后代 plan 文档允许、无关任务拒绝、循环血缘 fail-closed);daemon `runtime-spawn-ingress` 集成(Commander 建子任务、同步子 `task_plan.md`、派子 runtime;无关任务的 doc sync 与派工双拒,launch 计数不变);typecheck、ESLint、架构与复杂度门本地绿。
- 修前阳性对照:新增的子 `task_plan.md` 同步用例在 Ubuntu 隔离环境返回 `outcome=op_rejected code=executor_binding_invalid`(报告)。
- 开 PR 前已与 `origin/main` 合并;CI 是完整权威。

## 评审证据

worker 报告见任务包 `artifacts/commander-runtime-descendant-authority-report.md`(私有台账)。CEO 语义验收:后代分支受三重门控——(a)动作种类 ∈ {doc-submit, runtime-spawn};(b)经 canonical 投影的严格父链且有环保护;(c)祖先任务 live lease 由同一 runtime-session actor 持有;精确路径未动,无关任务拒绝有断言。本 PR 没有跑第二个独立评审者,残余见下。

## 残余风险

后代证明在 claim 时刻读 canonical 投影的父链;claim 与写入之间父绑定若变化,由 writer 的逐路径任务校验兜住,不由本谓词兜住。授权改动只经 CEO 复核;计划由反熵 squad 对授权面做第二次审视。
