### PR TITLE
fix(gates): narrow the GUI status-judgment array rule to consumed collections

### DIFF
--- a/tools/check-gui-status-judgments.mjs
+++ b/tools/check-gui-status-judgments.mjs
@@ -21,7 +21,7 @@ const EQUALITY_OPERATORS = new Set([
   ts.SyntaxKind.EqualsEqualsEqualsToken,
   ts.SyntaxKind.ExclamationEqualsEqualsToken,
   ts.SyntaxKind.EqualsEqualsToken,
-  ts.SyntaxKind.ExclamationEqualsToken
+  ts.SyntaxKind.ExclamationEqualsToken,
 ]);
 const BASELINE_CLASSIFICATIONS = new Set(["domain-judgment"]);
 const BASELINE_KINDS = new Set(["comparison", "group", "membership", "switch"]);
@@ -32,13 +32,17 @@ const VALIDATION_FIELD = /(?:availability|targetState|sessionBinding|witness res
 export function scanGuiStatusJudgments(
   root = process.cwd(),
   vocabularies = statusVocabularies,
-  registrations = vocabularies === statusVocabularies ? statusWordRegister : registrationsFromVocabularies(vocabularies)
+  registrations = vocabularies === statusVocabularies
+    ? statusWordRegister
+    : registrationsFromVocabularies(vocabularies),
 ) {
   const files = walk(path.join(root, GUI_SOURCE));
   if (files.length === 0) return [];
   const program = createGuiProgram(root, files);
   const checker = program.getTypeChecker();
   const vocabulary = vocabularyIndex(vocabularies, registrations);
+  const sourceFiles = files.map((file) => program.getSourceFile(file)).filter(Boolean);
+  const arrayJudgmentMatches = findArrayJudgmentMatches(checker, sourceFiles, vocabulary);
   const sites = [];
 
   for (const file of files) {
@@ -60,14 +64,15 @@ export function scanGuiStatusJudgments(
         shape,
         scope: semanticScope(node, source),
         identity,
-        classification: shape === "complete-mirror"
-          ? "registry-mirror"
-          : shape === "proper-subset" || !isPureDisplayUsage(node, checker)
-            ? "domain-judgment"
-            : "display-only",
+        classification:
+          shape === "complete-mirror"
+            ? "registry-mirror"
+            : shape === "proper-subset" || !isPureDisplayUsage(node, checker)
+              ? "domain-judgment"
+              : "display-only",
         words: [...new Set(words)].sort(),
         vocabularyIds: [...new Set(vocabularyIds)].sort(),
-        content
+        content,
       });
     };
 
@@ -90,21 +95,28 @@ export function scanGuiStatusJudgments(
       } else if (ts.isArrayLiteralExpression(node)) {
         const stringLiterals = node.elements.filter(ts.isStringLiteralLike);
         const literals = stringLiterals.filter((element) => vocabulary.words.has(element.text));
-        if (literals.length > 0) {
-          const contextualIds = literals.flatMap((literal) => vocabularyIdsForType(checker, checker.getContextualType(literal), vocabulary.sets));
-          const groupedIds = vocabularyIdsCoveringWords(literals.map((literal) => literal.text), vocabulary.sets);
-          const allWordsAreEntityJudgments = literals.every((literal) => vocabulary.registrations.some((entry) => entry.word === literal.text && entry.inScope));
-          if (contextualIds.length > 0 || groupedIds.length > 0 || (literals.length > 1 && allWordsAreEntityJudgments)) {
-            const words = literals.map((literal) => literal.text);
-            add(node, "group", words, [...contextualIds, ...groupedIds], vocabulary.completeKeys.has(wordKey(words)) ? "complete-mirror" : "proper-subset");
-          }
+        const match = arrayJudgmentMatches.get(node);
+        if (literals.length > 0 && match) {
+          const words = literals.map((literal) => literal.text);
+          add(
+            node,
+            "group",
+            words,
+            match.vocabularyIds,
+            vocabulary.completeKeys.has(wordKey(words)) ? "complete-mirror" : "proper-subset",
+          );
         }
-      } else if (ts.isCallExpression(node) && ts.isPropertyAccessExpression(node.expression)
-        && ["has", "includes"].includes(node.expression.name.text)) {
-        const literal = node.arguments.find((argument) => ts.isStringLiteralLike(argument) && vocabulary.words.has(argument.text));
+      } else if (
+        ts.isCallExpression(node) &&
+        ts.isPropertyAccessExpression(node.expression) &&
+        ["has", "includes"].includes(node.expression.name.text)
+      ) {
+        const literal = node.arguments.find(
+          (argument) => ts.isStringLiteralLike(argument) && vocabulary.words.has(argument.text),
+        );
         if (literal) {
-          const ids = vocabularyIdsForType(checker, checker.getContextualType(literal), vocabulary.sets);
-          if (ids.length > 0) add(node, "membership", [literal.text], ids);
+          const match = carrierMatch(checker, node.expression.expression, [literal.text], vocabulary);
+          if (match.inScope) add(node, "membership", [literal.text], match.vocabularyIds);
         }
       }
       ts.forEachChild(node, visit);
@@ -114,16 +126,24 @@ export function scanGuiStatusJudgments(
       sites.push({ ...site, key: site.identity ?? `${site.path}:${site.line}:${site.column}` });
     }
   }
-  return sites.sort((left, right) => left.path.localeCompare(right.path) || left.line - right.line || left.column - right.column);
+  return sites.sort(
+    (left, right) => left.path.localeCompare(right.path) || left.line - right.line || left.column - right.column,
+  );
 }
 
 export function checkGuiStatusJudgments(sites, baseline = guiStatusJudgmentBaseline) {
   const findings = [];
   const baselineByKey = new Map();
   for (const entry of baseline) {
-    if (!entry || typeof entry.key !== "string" || !BASELINE_CLASSIFICATIONS.has(entry.classification)
-      || !BASELINE_KINDS.has(entry.kind) || !BASELINE_SHAPES.has(entry.shape)
-      || !Array.isArray(entry.words) || !entry.words.every((word) => typeof word === "string")) {
+    if (
+      !entry ||
+      typeof entry.key !== "string" ||
+      !BASELINE_CLASSIFICATIONS.has(entry.classification) ||
+      !BASELINE_KINDS.has(entry.kind) ||
+      !BASELINE_SHAPES.has(entry.shape) ||
+      !Array.isArray(entry.words) ||
+      !entry.words.every((word) => typeof word === "string")
+    ) {
       findings.push(`invalid baseline entry ${JSON.stringify(entry)}`);
       continue;
     }
@@ -137,9 +157,16 @@ export function checkGuiStatusJudgments(sites, baseline = guiStatusJudgmentBasel
   }
   for (const site of sites) {
     const entry = baselineByKey.get(site.key);
-    if (entry && (entry.classification !== site.classification || entry.kind !== site.kind
-      || entry.shape !== site.shape || wordKey(entry.words) !== wordKey(site.words))) {
-      findings.push(`${site.key}: baseline freezes ${entry.classification}/${entry.shape}/${entry.kind}/${entry.words.join(",")}; site is ${site.classification}/${site.shape}/${site.kind}/${site.words.join(",")}`);
+    if (
+      entry &&
+      (entry.classification !== site.classification ||
+        entry.kind !== site.kind ||
+        entry.shape !== site.shape ||
+        wordKey(entry.words) !== wordKey(site.words))
+    ) {
+      findings.push(
+        `${site.key}: baseline freezes ${entry.classification}/${entry.shape}/${entry.kind}/${entry.words.join(",")}; site is ${site.classification}/${site.shape}/${site.kind}/${site.words.join(",")}`,
+      );
     }
     if (!entry && site.classification === "domain-judgment") {
       findings.push(`${site.key}: new GUI status judgment (${site.shape}; ${site.words.join(", ") || "typed status"})`);
@@ -155,7 +182,8 @@ export function checkGuiStatusJudgments(sites, baseline = guiStatusJudgmentBasel
 
 export function baselineCounts(baseline = guiStatusJudgmentBaseline) {
   const counts = { total: baseline.length, "domain-judgment": 0 };
-  for (const entry of baseline) if (BASELINE_CLASSIFICATIONS.has(entry.classification)) counts[entry.classification] += 1;
+  for (const entry of baseline)
+    if (BASELINE_CLASSIFICATIONS.has(entry.classification)) counts[entry.classification] += 1;
   return counts;
 }
 
@@ -163,7 +191,7 @@ export function inventoryCounts(sites) {
   const counts = {
     total: sites.length,
     shapes: { "proper-subset": 0, "point-comparison": 0, "complete-mirror": 0 },
-    classifications: { "display-only": 0, "domain-judgment": 0, "registry-mirror": 0 }
+    classifications: { "display-only": 0, "domain-judgment": 0, "registry-mirror": 0 },
   };
   for (const site of sites) {
     counts.shapes[site.shape] += 1;
@@ -174,7 +202,14 @@ export function inventoryCounts(sites) {
 
 function createGuiProgram(root, files) {
   const configPath = path.join(root, "packages/gui/tsconfig.renderer.json");
-  let options = { target: ts.ScriptTarget.ESNext, module: ts.ModuleKind.ESNext, moduleResolution: ts.ModuleResolutionKind.Bundler, jsx: ts.JsxEmit.Preserve, allowJs: true, skipLibCheck: true };
+  let options = {
+    target: ts.ScriptTarget.ESNext,
+    module: ts.ModuleKind.ESNext,
+    moduleResolution: ts.ModuleResolutionKind.Bundler,
+    jsx: ts.JsxEmit.Preserve,
+    allowJs: true,
+    skipLibCheck: true,
+  };
   if (existsSync(configPath)) {
     const loaded = ts.readConfigFile(configPath, ts.sys.readFile);
     if (!loaded.error) {
@@ -192,7 +227,7 @@ function vocabularyIndex(vocabularies, registrations = statusWordRegister) {
   const words = new Set(registrations.map((entry) => entry.word));
   const scopedRegistrations = registrations.map((entry) => ({
     ...entry,
-    inScope: isEntityJudgmentRegistration(entry)
+    inScope: isEntityJudgmentRegistration(entry),
   }));
   const mirrorAnchors = new Map();
   for (const entry of vocabularies) {
@@ -209,7 +244,7 @@ function vocabularyIndex(vocabularies, registrations = statusWordRegister) {
       words: new Set(normalized),
       key: wordKey(normalized),
       complete: entry.subsetOf === undefined,
-      inScope: isEntityJudgmentRegistration(authority)
+      inScope: isEntityJudgmentRegistration(authority),
     };
     allSets.push(indexed);
     if (indexed.inScope) sets.push(indexed);
@@ -220,16 +255,18 @@ function vocabularyIndex(vocabularies, registrations = statusWordRegister) {
     words,
     registrations: scopedRegistrations,
     mirrorAnchors,
-    completeKeys: new Set(sets.filter((entry) => entry.complete).map((entry) => entry.key))
+    completeKeys: new Set(sets.filter((entry) => entry.complete).map((entry) => entry.key)),
   };
 }
 
 function registrationsFromVocabularies(vocabularies) {
-  return vocabularies.flatMap((entry) => entry.words.map((word) => ({
-    word,
-    entity: entry.entity,
-    field: entry.field
-  })));
+  return vocabularies.flatMap((entry) =>
+    entry.words.map((word) => ({
+      word,
+      entity: entry.entity,
+      field: entry.field,
+    })),
+  );
 }
 
 function isEntityJudgmentRegistration(entry) {
@@ -239,10 +276,137 @@ function isEntityJudgmentRegistration(entry) {
   return !TRANSIENT_OPERATION_ENTITY.test(entry.entity) && !VALIDATION_FIELD.test(entry.field);
 }
 
+function findArrayJudgmentMatches(checker, sourceFiles, vocabulary) {
+  const candidates = new Map();
+  const byExpression = new Map();
+  const bySymbol = new Map();
+  const collect = (node) => {
+    if (ts.isArrayLiteralExpression(node)) {
+      const words = node.elements
+        .filter(ts.isStringLiteralLike)
+        .filter((element) => vocabulary.words.has(element.text))
+        .map((element) => element.text);
+      if (words.length > 0) {
+        const candidate = { words, matched: false, vocabularyIds: new Set() };
+        candidates.set(node, candidate);
+        const root = collectionRoot(node, byExpression, candidate);
+        if (
+          ts.isVariableDeclaration(root.parent) &&
+          root.parent.initializer === root &&
+          ts.isIdentifier(root.parent.name)
+        ) {
+          const symbol = canonicalSymbol(checker, root.parent.name);
+          if (symbol) bySymbol.set(symbol, candidate);
+        }
+      }
+    }
+    ts.forEachChild(node, collect);
+  };
+  for (const source of sourceFiles) collect(source);
+
+  const matchCarrier = (candidate, expression) => {
+    if (ts.isStringLiteralLike(unwrapExpression(expression))) return;
+    const match = carrierMatch(checker, expression, candidate.words, vocabulary);
+    if (match.inScope) {
+      candidate.matched = true;
+      for (const id of match.vocabularyIds) candidate.vocabularyIds.add(id);
+    }
+  };
+  const inspect = (node) => {
+    if (ts.isCallExpression(node) && ts.isPropertyAccessExpression(node.expression)) {
+      const method = node.expression.name.text;
+      const candidate = collectionCandidate(checker, node.expression.expression, byExpression, bySymbol);
+      if (candidate && ["has", "includes", "indexOf"].includes(method)) {
+        for (const argument of node.arguments) matchCarrier(candidate, argument);
+      } else if (candidate && method === "map") {
+        const callback = node.arguments[0];
+        if (
+          callback &&
+          ts.isFunctionLike(callback) &&
+          callback.parameters.length > 0 &&
+          ts.isIdentifier(callback.parameters[0].name)
+        ) {
+          const parameter = canonicalSymbol(checker, callback.parameters[0].name);
+          const inspectCallback = (current) => {
+            if (parameter && ts.isBinaryExpression(current) && EQUALITY_OPERATORS.has(current.operatorToken.kind)) {
+              if (expressionUsesSymbol(checker, current.left, parameter)) {
+                candidate.matched = true;
+                matchCarrier(candidate, current.right);
+              }
+              if (expressionUsesSymbol(checker, current.right, parameter)) {
+                candidate.matched = true;
+                matchCarrier(candidate, current.left);
+              }
+            }
+            ts.forEachChild(current, inspectCallback);
+          };
+          inspectCallback(callback.body);
+        }
+      }
+    }
+    ts.forEachChild(node, inspect);
+  };
+  for (const source of sourceFiles) inspect(source);
+  return new Map(
+    [...candidates]
+      .filter(([, candidate]) => candidate.matched)
+      .map(([node, candidate]) => [node, { vocabularyIds: [...candidate.vocabularyIds] }]),
+  );
+}
+
+function collectionRoot(node, byExpression, candidate) {
+  let current = node;
+  byExpression.set(current, candidate);
+  while (
+    current.parent &&
+    ((isTransparentExpression(current.parent) && current.parent.expression === current) ||
+      (ts.isNewExpression(current.parent) &&
+        current.parent.arguments?.includes(current) &&
+        /^(?:Readonly)?Set$/u.test(current.parent.expression.getText())))
+  ) {
+    current = current.parent;
+    byExpression.set(current, candidate);
+  }
+  return current;
+}
+
+function collectionCandidate(checker, expression, byExpression, bySymbol) {
+  const unwrapped = unwrapExpression(expression);
+  return byExpression.get(unwrapped) ?? bySymbol.get(canonicalSymbol(checker, unwrapped));
+}
+
+function canonicalSymbol(checker, node) {
+  let symbol = checker.getSymbolAtLocation(ts.isPropertyAccessExpression(node) ? node.name : node);
+  while (symbol && (symbol.flags & ts.SymbolFlags.Alias) !== 0) symbol = checker.getAliasedSymbol(symbol);
+  return symbol;
+}
+
+function expressionUsesSymbol(checker, expression, symbol) {
+  return canonicalSymbol(checker, unwrapExpression(expression)) === symbol;
+}
+
+function unwrapExpression(expression) {
+  let current = expression;
+  while (isTransparentExpression(current)) current = current.expression;
+  return current;
+}
+
+function isTransparentExpression(node) {
+  return (
+    ts.isParenthesizedExpression(node) ||
+    ts.isAsExpression(node) ||
+    ts.isTypeAssertionExpression(node) ||
+    ts.isSatisfiesExpression(node) ||
+    ts.isNonNullExpression(node)
+  );
+}
+
 function carrierMatch(checker, expression, literalWords, vocabulary) {
   const symbol = checker.getSymbolAtLocation(ts.isPropertyAccessExpression(expression) ? expression.name : expression);
   const declaration = symbol?.valueDeclaration ?? symbol?.declarations?.[0];
-  const type = declaration ? checker.getTypeOfSymbolAtLocation(symbol, declaration) : checker.getTypeAtLocation(expression);
+  const type = declaration
+    ? checker.getTypeOfSymbolAtLocation(symbol, declaration)
+    : checker.getTypeAtLocation(expression);
   const words = literalTypeWords(checker, type);
   if (words) {
     const allExactIds = vocabularyIdsForWords(words, vocabulary.allSets);
@@ -257,13 +421,15 @@ function carrierMatch(checker, expression, literalWords, vocabulary) {
     return { inScope: false, vocabularyIds: [] };
   }
   if (!containsBroadString(type)) return { inScope: false, vocabularyIds: [] };
-  const fieldTerms = new Set(vocabulary.registrations
-    .filter((entry) => entry.inScope && literalWords.includes(entry.word))
-    .map((entry) => fieldTerm(entry.field))
-    .filter(Boolean));
+  const fieldTerms = new Set(
+    vocabulary.registrations
+      .filter((entry) => entry.inScope && literalWords.includes(entry.word))
+      .map((entry) => fieldTerm(entry.field))
+      .filter(Boolean),
+  );
   return {
     inScope: statusLikeCarrierName(expression, fieldTerms),
-    vocabularyIds: vocabularyIdsCoveringWords(literalWords, vocabulary.sets)
+    vocabularyIds: vocabularyIdsCoveringWords(literalWords, vocabulary.sets),
   };
 }
 
@@ -272,11 +438,6 @@ function containsBroadString(type) {
   if ((type.flags & ts.TypeFlags.String) !== 0) return true;
   if (type.isUnion()) return type.types.some(containsBroadString);
   return false;
-}
-
-function vocabularyIdsForType(checker, type, sets) {
-  const words = literalTypeWords(checker, type);
-  return words ? vocabularyIdsForWords(words, sets) : [];
 }
 
 function vocabularyIdsForWords(words, sets) {
@@ -307,13 +468,24 @@ function vocabularyIdsCoveringWords(words, sets) {
 }
 
 function statusLikeCarrierName(expression, fieldTerms) {
-  const raw = ts.isPropertyAccessExpression(expression) ? expression.name.text : ts.isIdentifier(expression) ? expression.text : "";
+  const raw = ts.isPropertyAccessExpression(expression)
+    ? expression.name.text
+    : ts.isIdentifier(expression)
+      ? expression.text
+      : "";
   const name = raw.toLowerCase();
-  return [...fieldTerms].some((term) => name.endsWith(term) || name.endsWith(`${term}s`) || (term === "status" && name.endsWith("statuses")));
+  return [...fieldTerms].some(
+    (term) => name.endsWith(term) || name.endsWith(`${term}s`) || (term === "status" && name.endsWith("statuses")),
+  );
 }
 
 function fieldTerm(field) {
-  return field.match(/[A-Za-z]+/gu)?.at(-1)?.toLowerCase() ?? "";
+  return (
+    field
+      .match(/[A-Za-z]+/gu)
+      ?.at(-1)
+      ?.toLowerCase() ?? ""
+  );
 }
 
 function registeredLiteralOperand(node, words) {
@@ -325,7 +497,11 @@ function registeredLiteralOperand(node, words) {
 function isPureDisplayUsage(node, checker) {
   for (let current = node; current; current = current.parent) {
     if (ts.isJsxExpression(current)) {
-      if (ts.isJsxAttribute(current.parent) && /^(?:aria-|className$|style$|title$)/u.test(current.parent.name.getText())) return true;
+      if (
+        ts.isJsxAttribute(current.parent) &&
+        /^(?:aria-|className$|style$|title$)/u.test(current.parent.name.getText())
+      )
+        return true;
       if (current.expression && containsOnlyNonInteractiveIntrinsicJsx(current.expression)) return true;
       break;
     }
@@ -344,7 +520,13 @@ function containsOnlyNonInteractiveIntrinsicJsx(node) {
   const visit = (current) => {
     if (ts.isJsxOpeningElement(current) || ts.isJsxSelfClosingElement(current)) {
       const tag = current.tagName.getText();
-      if (!/^[a-z]/u.test(tag) || current.attributes.properties.some((attribute) => ts.isJsxAttribute(attribute) && /^on[A-Z]/u.test(attribute.name.getText()))) disallowed = true;
+      if (
+        !/^[a-z]/u.test(tag) ||
+        current.attributes.properties.some(
+          (attribute) => ts.isJsxAttribute(attribute) && /^on[A-Z]/u.test(attribute.name.getText()),
+        )
+      )
+        disallowed = true;
       else sawIntrinsic = true;
     }
     ts.forEachChild(current, visit);
@@ -357,7 +539,11 @@ function mirrorDeclarationSpans(source, anchors) {
   const wanted = new Set(anchors);
   const spans = [];
   const visit = (node) => {
-    if ((ts.isTypeAliasDeclaration(node) || ts.isVariableDeclaration(node)) && ts.isIdentifier(node.name) && wanted.has(node.name.text)) {
+    if (
+      (ts.isTypeAliasDeclaration(node) || ts.isVariableDeclaration(node)) &&
+      ts.isIdentifier(node.name) &&
+      wanted.has(node.name.text)
+    ) {
       spans.push([node.getStart(source), node.getEnd()]);
     }
     ts.forEachChild(node, visit);
@@ -369,8 +555,14 @@ function mirrorDeclarationSpans(source, anchors) {
 function semanticScope(node, source) {
   const segments = [];
   for (let current = node.parent; current && !ts.isSourceFile(current); current = current.parent) {
-    if (ts.isVariableDeclaration(current) || ts.isFunctionDeclaration(current) || ts.isMethodDeclaration(current)
-      || ts.isClassDeclaration(current) || ts.isPropertyAssignment(current) || ts.isPropertyDeclaration(current)) {
+    if (
+      ts.isVariableDeclaration(current) ||
+      ts.isFunctionDeclaration(current) ||
+      ts.isMethodDeclaration(current) ||
+      ts.isClassDeclaration(current) ||
+      ts.isPropertyAssignment(current) ||
+      ts.isPropertyDeclaration(current)
+    ) {
       const name = stableName(current.name, source);
       if (name) segments.unshift(name);
     }
@@ -384,28 +576,61 @@ function stableName(name, source) {
   return name.getText(source).replace(/[^A-Za-z0-9_.-]+/gu, "-");
 }
 
-function wordKey(words) { return [...new Set(words)].sort().join("\0"); }
+function wordKey(words) {
+  return [...new Set(words)].sort().join("\0");
+}
 
-function insideAnySpan(node, spans) { return spans.some(([start, end]) => node.getStart() >= start && node.getEnd() <= end); }
-function relative(root, file) { return path.relative(root, file).split(path.sep).join("/"); }
-function walk(directory) { const files = []; let entries; try { entries = readdirSync(directory, { withFileTypes: true }); } catch (error) { if (error?.code === "ENOENT") return files; throw error; } for (const entry of entries.sort((a, b) => a.name.localeCompare(b.name))) { const full = path.join(directory, entry.name); if (entry.isDirectory()) { if (!["dist", "node_modules", "out"].includes(entry.name)) files.push(...walk(full)); } else if (SOURCE_FILE.test(entry.name)) files.push(full); } return files; }
+function insideAnySpan(node, spans) {
+  return spans.some(([start, end]) => node.getStart() >= start && node.getEnd() <= end);
+}
+function relative(root, file) {
+  return path.relative(root, file).split(path.sep).join("/");
+}
+function walk(directory) {
+  const files = [];
+  let entries;
+  try {
+    entries = readdirSync(directory, { withFileTypes: true });
+  } catch (error) {
+    if (error?.code === "ENOENT") return files;
+    throw error;
+  }
+  for (const entry of entries.sort((a, b) => a.name.localeCompare(b.name))) {
+    const full = path.join(directory, entry.name);
+    if (entry.isDirectory()) {
+      if (!["dist", "node_modules", "out"].includes(entry.name)) files.push(...walk(full));
+    } else if (SOURCE_FILE.test(entry.name)) files.push(full);
+  }
+  return files;
+}
 
 function printBaseline(sites) {
   console.log("export const guiStatusJudgmentBaseline = Object.freeze([");
   for (const site of sites.filter((entry) => entry.classification === "domain-judgment")) {
-    console.log(`  { key: ${JSON.stringify(site.key)}, classification: "domain-judgment", kind: ${JSON.stringify(site.kind)}, shape: ${JSON.stringify(site.shape)}, words: ${JSON.stringify(site.words)} }, // @ ${site.scope}`);
+    console.log(
+      `  { key: ${JSON.stringify(site.key)}, classification: "domain-judgment", kind: ${JSON.stringify(site.kind)}, shape: ${JSON.stringify(site.shape)}, words: ${JSON.stringify(site.words)} }, // @ ${site.scope}`,
+    );
   }
   console.log("]);");
 }
 
 function printInventory(sites) {
-  for (const site of sites) console.log(`${site.path}:${site.line}:${site.column} [${site.shape}/${site.classification}] ${site.words.join(", ")} @ ${site.scope}`);
+  for (const site of sites)
+    console.log(
+      `${site.path}:${site.line}:${site.column} [${site.shape}/${site.classification}] ${site.words.join(", ")} @ ${site.scope}`,
+    );
 }
 
 async function main() {
   const sites = scanGuiStatusJudgments();
-  if (process.argv.includes("--print-baseline")) { printBaseline(sites); return; }
-  if (process.argv.includes("--print-inventory")) { printInventory(sites); return; }
+  if (process.argv.includes("--print-baseline")) {
+    printBaseline(sites);
+    return;
+  }
+  if (process.argv.includes("--print-inventory")) {
+    printInventory(sites);
+    return;
+  }
   if (process.argv.includes("--report")) {
     console.log(JSON.stringify({ inventory: inventoryCounts(sites), baseline: baselineCounts() }, null, 2));
     return;
@@ -419,7 +644,10 @@ async function main() {
   }
   const baseline = baselineCounts();
   const inventory = inventoryCounts(sites);
-  console.log(`GUI status judgment check passed (${baseline.total} frozen domain judgments; ${inventory.shapes["proper-subset"]} proper subsets, ${inventory.shapes["point-comparison"]} point comparisons, ${inventory.shapes["complete-mirror"]} complete mirrors).`);
+  console.log(
+    `GUI status judgment check passed (${baseline.total} frozen domain judgments; ${inventory.shapes["proper-subset"]} proper subsets, ${inventory.shapes["point-comparison"]} point comparisons, ${inventory.shapes["complete-mirror"]} complete mirrors).`,
+  );
 }
 
-if (process.argv[1] !== undefined && import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href) await main();
+if (process.argv[1] !== undefined && import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href)
+  await main();

--- a/tools/check-gui-status-judgments.test.mjs
+++ b/tools/check-gui-status-judgments.test.mjs
@@ -14,6 +14,10 @@ test("required positive controls are detected in the repository", () => {
   assert.equal(has("packages/gui/src/renderer/views/DecisionPoolView.tsx", 'decision.state === "proposed"'), true);
   assert.equal(
     has("packages/gui/src/renderer/views/DecisionPoolView.tsx", '["high", "medium", "low", "unknown"]'),
+    false,
+  );
+  assert.equal(
+    has("packages/gui/src/renderer/components/taskDetail/constants.ts", '["planned", "active", "in_review", "done"]'),
     true,
   );
   assert.equal(has("packages/gui/src/renderer/views/DecisionsView.tsx", 'decision.state === "proposed"'), true);
@@ -26,7 +30,7 @@ test("registry-derived detector needs no hand-written status words or file list"
   withFixture(
     {
       "packages/gui/src/new-panel.ts":
-        'type TimewarpState = "before" | "after";\nexport const order: TimewarpState[] = ["before", "after"];\n',
+        'type TimewarpState = "before" | "after" | "lost";\nexport const visible = (row: { state: TimewarpState }) => ["before", "after"].includes(row.state);\n',
     },
     (root) => {
       const register = [
@@ -36,7 +40,7 @@ test("registry-derived detector needs no hand-written status words or file list"
           field: "state",
           module: "packages/kernel/src/domain/timewarp.ts",
           anchor: "timewarpStates",
-          words: ["before", "after"],
+          words: ["before", "after", "lost"],
         },
       ];
       const sites = scanGuiStatusJudgments(root, register);
@@ -142,7 +146,7 @@ test("complete vocabulary mirrors are observed but do not need a baseline exempt
   withFixture(
     {
       "packages/gui/src/panel.ts":
-        'type TaskStatus = "active" | "blocked";\nexport const all: TaskStatus[] = ["active", "blocked"];\n',
+        'type TaskStatus = "active" | "blocked";\nconst all: TaskStatus[] = ["active", "blocked"];\nexport const visible = (task: { status: TaskStatus }) => all.includes(task.status);\n',
     },
     (root) => {
       const register = [
@@ -160,6 +164,37 @@ test("complete vocabulary mirrors are observed but do not need a baseline exempt
       assert.equal(sites[0].shape, "complete-mirror");
       assert.equal(sites[0].classification, "registry-mirror");
       assert.deepEqual(checkGuiStatusJudgments(sites, []), []);
+    },
+  );
+});
+
+test("array groups require consumption by a kernel status carrier", () => {
+  withFixture(
+    {
+      "packages/gui/src/panel.ts": [
+        'type TaskState = "active" | "blocked" | "done" | "unknown";',
+        "type Filters = { status: TaskState[] };",
+        'export const displayOrder = ["active", "blocked"];',
+        'export const visible = (row: { state: TaskState }) => ["active", "blocked"].includes(row.state);',
+        'export const selected = (filters: Filters) => filters.status.includes("unknown");',
+        "",
+      ].join("\n"),
+    },
+    (root) => {
+      const register = [
+        {
+          id: "task.state",
+          entity: "Task",
+          field: "state",
+          module: "packages/kernel/src/domain/task.ts",
+          anchor: "taskStates",
+          words: ["active", "blocked", "done", "unknown"],
+        },
+      ];
+      const sites = scanGuiStatusJudgments(root, register);
+      assert.equal(sites.length, 1);
+      assert.equal(sites[0].kind, "group");
+      assert.equal(sites[0].scope, "visible");
     },
   );
 });

--- a/tools/gate-allowlists/gui-status-judgment-baseline.mjs
+++ b/tools/gate-allowlists/gui-status-judgment-baseline.mjs
@@ -11,23 +11,18 @@ export const guiStatusJudgmentBaseline = Object.freeze([
   { key: "gui-status-003", classification: "domain-judgment", kind: "comparison", shape: "point-comparison", words: ["active"] }, // point-comparison: active @ buildGuiViewModelFromTaskProjection
   { key: "gui-status-004", classification: "domain-judgment", kind: "comparison", shape: "point-comparison", words: ["active"] }, // point-comparison: active @ readGuiTaskListResult
   { key: "gui-status-005", classification: "domain-judgment", kind: "comparison", shape: "point-comparison", words: ["covered"] }, // point-comparison: covered @ FactInspector.coveredDecisionIds
-  { key: "gui-status-006", classification: "domain-judgment", kind: "group", shape: "proper-subset", words: ["unknown"] }, // proper-subset: unknown @ FULFILLMENT_ORDER
   { key: "gui-status-016", classification: "domain-judgment", kind: "group", shape: "proper-subset", words: ["active","done","in_review","planned"] }, // proper-subset: active, done, in_review, planned @ STEP_FLOW
   { key: "gui-status-017", classification: "domain-judgment", kind: "comparison", shape: "point-comparison", words: ["blocked"] }, // point-comparison: blocked @ PhaseSteps.note
   { key: "gui-status-018", classification: "domain-judgment", kind: "comparison", shape: "point-comparison", words: ["cancelled"] }, // point-comparison: cancelled @ PhaseSteps.note
   { key: "gui-status-019", classification: "domain-judgment", kind: "comparison", shape: "point-comparison", words: ["active"] }, // point-comparison: active @ decisionHasReachableEvidence
   { key: "gui-status-020", classification: "domain-judgment", kind: "comparison", shape: "point-comparison", words: ["proposed"] }, // point-comparison: proposed @ useDecisionActions.propose.finish.visible
-  { key: "gui-status-022", classification: "domain-judgment", kind: "group", shape: "proper-subset", words: ["superseded"] }, // proper-subset: superseded @ partitionFactsByAnomaly.order
   { key: "gui-status-030", classification: "domain-judgment", kind: "comparison", shape: "point-comparison", words: ["covered"] }, // point-comparison: covered @ computeFactTriageSignals.citingDecisionIdSet
   { key: "gui-status-031", classification: "domain-judgment", kind: "comparison", shape: "point-comparison", words: ["uncovered"] }, // point-comparison: uncovered @ coverageSignal.uncovered
   { key: "gui-status-032", classification: "domain-judgment", kind: "comparison", shape: "point-comparison", words: ["active"] }, // point-comparison: active @ activeIncomingRelations
   { key: "gui-status-034", classification: "domain-judgment", kind: "comparison", shape: "point-comparison", words: ["cancelled"] }, // point-comparison: cancelled @ matchesTask
   { key: "gui-status-035", classification: "domain-judgment", kind: "comparison", shape: "point-comparison", words: ["unknown"] }, // point-comparison: unknown @ matchesTask
-  { key: "gui-status-036", classification: "domain-judgment", kind: "membership", shape: "point-comparison", words: ["unknown"] }, // point-comparison: unknown @ matchesTask
   { key: "gui-status-037", classification: "domain-judgment", kind: "comparison", shape: "point-comparison", words: ["active"] }, // point-comparison: active @ spawningDecisionOf.decisionIds
   { key: "gui-status-038", classification: "domain-judgment", kind: "comparison", shape: "point-comparison", words: ["active"] }, // point-comparison: active @ derivedTasks.taskIds
-  { key: "gui-status-042", classification: "domain-judgment", kind: "group", shape: "proper-subset", words: ["failed"] }, // proper-subset: failed @ settleDaemonControl
-  { key: "gui-status-043", classification: "domain-judgment", kind: "group", shape: "proper-subset", words: ["failed"] }, // proper-subset: failed @ useDaemonControl.request.settled
   { key: "gui-status-050", classification: "domain-judgment", kind: "comparison", shape: "point-comparison", words: ["unknown"] }, // point-comparison: unknown @ adaptProjectionRow.gates.ok
   { key: "gui-status-051", classification: "domain-judgment", kind: "comparison", shape: "point-comparison", words: ["passed"] }, // point-comparison: passed @ adaptProjectionRow.gates.ok
   { key: "gui-status-052", classification: "domain-judgment", kind: "comparison", shape: "point-comparison", words: ["blocked"] }, // point-comparison: blocked @ adaptProjectionRow.blockingLabel
@@ -35,9 +30,6 @@ export const guiStatusJudgmentBaseline = Object.freeze([
   { key: "gui-status-055", classification: "domain-judgment", kind: "comparison", shape: "point-comparison", words: ["superseded_fact"] }, // point-comparison: superseded_fact @ buildTriadicRendererData.facts.invalidated
   { key: "gui-status-056", classification: "domain-judgment", kind: "comparison", shape: "point-comparison", words: ["active"] }, // point-comparison: active @ adaptRelationRows
   { key: "gui-status-057", classification: "domain-judgment", kind: "comparison", shape: "point-comparison", words: ["active"] }, // point-comparison: active @ adaptDecisionRows
-  { key: "gui-status-059", classification: "domain-judgment", kind: "group", shape: "proper-subset", words: ["unknown"] }, // proper-subset: unknown @ DecisionPoolView
-  { key: "gui-status-060", classification: "domain-judgment", kind: "group", shape: "proper-subset", words: ["unknown"] }, // proper-subset: unknown @ DecisionPoolView
-  { key: "gui-status-061", classification: "domain-judgment", kind: "group", shape: "proper-subset", words: ["unknown"] }, // proper-subset: unknown @ DecisionPoolView
   { key: "gui-status-062", classification: "domain-judgment", kind: "comparison", shape: "point-comparison", words: ["proposed"] }, // point-comparison: proposed @ DecisionPoolView
   { key: "gui-status-063", classification: "domain-judgment", kind: "comparison", shape: "point-comparison", words: ["proposed"] }, // point-comparison: proposed @ DecisionsView.queue.proposed
   { key: "gui-status-065", classification: "domain-judgment", kind: "comparison", shape: "point-comparison", words: ["missing"] }, // point-comparison: missing @ ListView.riskCount


### PR DESCRIPTION
# English

## Summary

Narrows the `check-gui-status-judgments` gate so an array literal containing a registered status word counts as a status judgment only when that collection is consumed by a judgment (a direct `includes`/`indexOf`/`has` argument or an equality comparison checked through the existing `carrierMatch`, including named/imported arrays, `Set` wrappers and mapped values). Pure display orders, filter-option value domains and transient control-receipt phase sets no longer hit the gate. The frozen baseline drops from 38 to 30: exactly the eight misfires ruled by dec_9EE1FD885662D88FFC950E3251 (gui-status-006/022/036/042/043/059/060/061) are removed; the gate, its tests, npm script and gate-manifest entry are kept, and the three legitimate grouped judgment sites are still detected.

## Architectural Justification

The gate exists to catch domain status judgments duplicated in the renderer, not the appearance of a registered word in a list. Fixing the rule in the gate (authorized by the decision) is the only change that removes the misfires without rewriting product code to satisfy a tool; renderer files are untouched, so 4.2 slice 2 starts from an honest baseline.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none

## Machine-Readable Declarations

Production-Delta: +296/-76
Dependency-Change: none

### Optional Evidence Claims

none

## Task And Scope

task_2a91586827872a86a7f4284097 (governance task derived from dec_9EE1FD885662D88FFC950E3251; parent Phase 4 GUI epic task_3b29776e). Touched: `tools/check-gui-status-judgments.mjs`, `tools/check-gui-status-judgments.test.mjs`, `tools/gate-allowlists/gui-status-judgment-baseline.mjs` (eight entries removed). No `packages/gui` change.

## Version Impact

None.

## Governance Declaration

Protected surface (CI gate rule) changed under explicit authorization: decision dec_9EE1FD885662D88FFC950E3251 (in effect) and this task. The gate, its manifest entry and workflow references are unchanged; only the array-literal rule is narrowed. No break-glass.

## Verification

- Worker stop point (targeted tests + local commit, no `check:local`): `node --test tools/check-gui-status-judgments.test.mjs` green with new positive/negative controls (`[a,b].includes(row.state)` still flagged; display order, filter value domain and user-filter `includes("unknown")` not flagged); `npm run harness:check-gui-status-judgments` green on the recomputed baseline (38 → 30 frozen, inventory 76 → 48, proper subsets 10 → 3, point comparisons 45 → 44, complete mirrors 21 → 1); `node --test tools/gates/test/*.test.mjs` green.
- Rebased onto `origin/main` `86338c3b`; CI is the full authority.

## Review Evidence

Worker report: `harness/tasks/task_2a91586827872a86a7f4284097-*/artifacts/gui-status-gate-array-rule-report.md` (private ledger). CEO semantic review: the removed baseline ids are exactly the eight ruled misfires, the rule is narrowed by consumption (not by word), and the legitimate grouped sites remain flagged; the added tracing helpers (collectionRoot/collectionCandidate/canonicalSymbol) exist to keep named and wrapped collections detectable, which is the price of not weakening the gate.

## Residual Risk

Collection tracing follows symbols one level (named arrays, `Set` wrappers, mapped values); a judgment built through a deeper indirection could escape the gate — the same limitation the comparison branch already has. The `check-domain-judgment-single-definition` gate is untouched (site 055 is handled by 4.1c through a kernel boolean).

---

# 中文

## 概要

收窄 `check-gui-status-judgments` 门:含已登记状态词的数组字面量只有在该集合被判定消费时(直接作为 `includes`/`indexOf`/`has` 的参数,或经既有 `carrierMatch` 参与相等比较;含具名/导入数组、`Set` 包装与 map 后的值)才算状态判定。纯展示序、筛选值域、瞬时控制回执阶段集合不再命中。冻结基线 38 → 30:恰好去掉 dec_9EE1FD885662D88FFC950E3251 裁定的 8 条误伤(gui-status-006/022/036/042/043/059/060/061);门本体、测试、npm script 与 gate-manifest 条目保留,仓内三处真正的分组判定站点仍被检出。

## 架构辩护

这道门要抓的是 renderer 里重复的领域状态判定,不是「名单里出现了某个词」。在门里修规则(由 decision 授权)是唯一不为迎合工具而改产品代码的做法;renderer 文件零改动,4.2 切片 2 从诚实的基线起步。

## 机读声明

见英文块。

## 治理声明

protected surface(CI 门规则)在明确授权下改动:decision dec_9EE1FD885662D88FFC950E3251(in effect)与本任务。门、manifest 条目与 workflow 引用不变,只收窄数组字面量规则。无 break-glass。

## 验证

- worker 停止点(定向测试 + 本地 commit,不跑 `check:local`):`node --test tools/check-gui-status-judgments.test.mjs` 绿,含新增阳性/阴性对照(`[a,b].includes(row.state)` 仍命中;展示序、筛选值域、用户筛选 `includes("unknown")` 不命中);`npm run harness:check-gui-status-judgments` 在重算基线上绿(冻结 38 → 30,清单 76 → 48,真子集 10 → 3,点比较 45 → 44,完整镜像 21 → 1);`node --test tools/gates/test/*.test.mjs` 绿。
- 已 rebase 到 `origin/main` `86338c3b`;CI 是完整权威。

## 评审证据

worker 报告见任务包 `artifacts/gui-status-gate-array-rule-report.md`(私有台账)。CEO 语义验收:删掉的基线 id 恰是裁定的 8 条误伤,规则按「被消费」而不是按「出现词」收窄,真正的分组判定站点仍命中;新增的追踪 helper(collectionRoot/collectionCandidate/canonicalSymbol)是为了让具名与包装过的集合仍可检出,这是不削弱门的代价。

## 残余风险

集合追踪只跟一层符号(具名数组、`Set` 包装、map 后的值);经更深间接构造的判定可能逃过门——与比较分支既有的限制相同。`check-domain-judgment-single-definition` 门未动(站点 055 由 4.1c 经 kernel 布尔处理)。
