### PR TITLE
fix(runtime): make dispatch surface claims exact

### DIFF
--- a/packages/cli/src/cli/thin-command-flags.ts
+++ b/packages/cli/src/cli/thin-command-flags.ts
@@ -104,22 +104,8 @@ export function readFlags(
             : [];
     if (input.required && values.length === 0)
       return { ok: false, code: input.error.code, nextAction: inputGuidance(input, descriptor.helpCommand, true) };
-    if (values.length > 0) {
-      const missing = input.requires?.filter((name) => !inputPresent(name, one, many, flags)) ?? [];
-      if (missing.length > 0)
-        return {
-          ok: false,
-          code: "invalid_field",
-          nextAction: `${input.name} requires ${missing.join(", ")}.`,
-        };
-      const conflicts = input.conflictsWith?.filter((name) => inputPresent(name, one, many, flags)) ?? [];
-      if (conflicts.length > 0)
-        return {
-          ok: false,
-          code: "invalid_field",
-          nextAction: `${input.name} is mutually exclusive with ${conflicts.join(", ")}.`,
-        };
-    }
+    const relation = values.length > 0 ? inputRelationFailure(input, one, many, flags) : null;
+    if (relation) return relation;
     const invalidValue = values.find(
       (value) =>
         (input.enum !== undefined && !input.enum.includes(value)) ||
@@ -134,6 +120,25 @@ export function readFlags(
       };
   }
   return { ok: true, one, many, booleans: flags };
+}
+
+function inputRelationFailure(
+  input: ThinCliInput,
+  one: ReadonlyMap<string, string>,
+  many: ReadonlyMap<string, readonly string[]>,
+  booleans: ReadonlySet<string>,
+): { readonly ok: false; readonly code: "invalid_field"; readonly nextAction: string } | null {
+  const missing = input.requires?.filter((name) => !inputPresent(name, one, many, booleans)) ?? [];
+  if (missing.length > 0)
+    return { ok: false, code: "invalid_field", nextAction: `${input.name} requires ${missing.join(", ")}.` };
+  const conflicts = input.conflictsWith?.filter((name) => inputPresent(name, one, many, booleans)) ?? [];
+  if (conflicts.length > 0)
+    return {
+      ok: false,
+      code: "invalid_field",
+      nextAction: `${input.name} is mutually exclusive with ${conflicts.join(", ")}.`,
+    };
+  return null;
 }
 
 function inputPresent(

--- a/packages/cli/src/cli/thin-command-flags.ts
+++ b/packages/cli/src/cli/thin-command-flags.ts
@@ -104,6 +104,22 @@ export function readFlags(
             : [];
     if (input.required && values.length === 0)
       return { ok: false, code: input.error.code, nextAction: inputGuidance(input, descriptor.helpCommand, true) };
+    if (values.length > 0) {
+      const missing = input.requires?.filter((name) => !inputPresent(name, one, many, flags)) ?? [];
+      if (missing.length > 0)
+        return {
+          ok: false,
+          code: "invalid_field",
+          nextAction: `${input.name} requires ${missing.join(", ")}.`,
+        };
+      const conflicts = input.conflictsWith?.filter((name) => inputPresent(name, one, many, flags)) ?? [];
+      if (conflicts.length > 0)
+        return {
+          ok: false,
+          code: "invalid_field",
+          nextAction: `${input.name} is mutually exclusive with ${conflicts.join(", ")}.`,
+        };
+    }
     const invalidValue = values.find(
       (value) =>
         (input.enum !== undefined && !input.enum.includes(value)) ||
@@ -118,6 +134,15 @@ export function readFlags(
       };
   }
   return { ok: true, one, many, booleans: flags };
+}
+
+function inputPresent(
+  name: string,
+  one: ReadonlyMap<string, string>,
+  many: ReadonlyMap<string, readonly string[]>,
+  booleans: ReadonlySet<string>,
+): boolean {
+  return one.has(name) || (many.get(name)?.length ?? 0) > 0 || booleans.has(name);
 }
 
 export function rejectInput(

--- a/packages/cli/src/cli/thin-command-runtime.ts
+++ b/packages/cli/src/cli/thin-command-runtime.ts
@@ -37,10 +37,6 @@ export function parseRuntime(
     detach = f.booleans.has("--detach"),
     onExitCommand = f.one.get("--on-exit");
   if (!prompt && (promptFlagPresent || !taskId)) return rejectInput(inputs, kind, "--prompt", json);
-  if (missionName && !taskId)
-    return rejected("invalid_field", "Use --mission <name> only with --task <task-id>.", json);
-  if (missionName && prompt)
-    return rejected("invalid_field", "Use --mission <name> or --prompt <text>, not both.", json);
   if (waitProjectionMs === null)
     return rejected("invalid_field", "Use a non-negative safe integer projection wait limit in milliseconds.", json);
   if (onExitCommand && !detach) return rejectInput(inputs, kind, "--on-exit", json);

--- a/packages/cli/src/cli/thin-command-types.ts
+++ b/packages/cli/src/cli/thin-command-types.ts
@@ -40,6 +40,8 @@ export interface ThinCliInput {
   readonly projection?: "number" | "fact-hold-array";
   readonly requiredWhen?: { readonly field: string; readonly values: readonly string[] };
   readonly allowedWhen?: { readonly field: string; readonly values: readonly string[] };
+  readonly requires?: readonly string[];
+  readonly conflictsWith?: readonly string[];
   readonly error: { readonly code: string };
 }
 

--- a/packages/cli/test/thin-command-script-doc-runtime.test.ts
+++ b/packages/cli/test/thin-command-script-doc-runtime.test.ts
@@ -195,6 +195,16 @@ test("runtime work commands parse into closed daemon facade actions", () => {
     taskOnly = parseThinCommand(["runtime", "run", "worker", "--agent", "terra", "--task", "task-1", "--cwd", "."]),
     file = parseThinCommand(["runtime", "run", "worker", "--prompt-file", "prompt.txt"]),
     mission = parseThinCommand(["runtime", "run", "worker", "--task", "task-1", "--mission", "api-review"]),
+    missionJson = parseThinCommand([
+      "runtime",
+      "run",
+      "worker",
+      "--task",
+      "task-1",
+      "--mission",
+      "api-review",
+      "--json",
+    ]),
     batch = parseThinCommand(["runtime", "batch", "dispatches.json"]),
     detached = parseThinCommand([
       "runtime",
@@ -219,7 +229,20 @@ test("runtime work commands parse into closed daemon facade actions", () => {
     show = parseThinCommand(["runtime", "status", "runtime-1"]),
     wait = parseThinCommand(["runtime", "status", "runtime-1", "--wait", "--no-stream"]),
     cancel = parseThinCommand(["runtime", "cancel", "runtime-1"]);
-  for (const parsed of [run, taskOnly, mission, batch, detached, resumed, dispatches, list, show, wait, cancel])
+  for (const parsed of [
+    run,
+    taskOnly,
+    mission,
+    missionJson,
+    batch,
+    detached,
+    resumed,
+    dispatches,
+    list,
+    show,
+    wait,
+    cancel,
+  ])
     assert.equal(parsed.ok, true, JSON.stringify(parsed));
   assert.equal(file.ok, false);
   if (run.ok)
@@ -253,6 +276,10 @@ test("runtime work commands parse into closed daemon facade actions", () => {
       cwd: { scope: "repo-root" },
       taskId: "task-1",
     });
+  if (mission.ok && missionJson.ok) {
+    assert.equal(missionJson.command.json, true);
+    assert.deepEqual(missionJson.command.action, mission.command.action);
+  }
   if (batch.ok)
     assert.deepEqual(batch.command.action, {
       kind: "runtime-batch",
@@ -333,6 +360,31 @@ test("runtime work commands parse into closed daemon facade actions", () => {
     false,
   );
   assert.equal(parseThinCommand(["runtime", "run", "worker", "--to", "terra", "--prompt", "Inspect"]).ok, false);
+  assert.deepEqual(
+    parseThinCommand([
+      "runtime",
+      "run",
+      "worker",
+      "--task",
+      "task-1",
+      "--mission",
+      "api-review",
+      "--prompt",
+      "Inspect",
+    ]),
+    {
+      ok: false,
+      code: "invalid_field",
+      nextAction: "--prompt is mutually exclusive with --mission.",
+      json: false,
+    },
+  );
+  assert.deepEqual(parseThinCommand(["runtime", "run", "worker", "--mission", "api-review"]), {
+    ok: false,
+    code: "invalid_field",
+    nextAction: "--mission requires --task.",
+    json: false,
+  });
   assert.equal(parseThinCommand(["runtime", "status", "runtime-1", "--task", "task-1"]).ok, false);
   const taskWait = parseThinCommand(["runtime", "status", "--task", "task-1", "--wait", "--no-stream"]);
   assert.equal(taskWait.ok, true);

--- a/packages/daemon/src/dispatch-read.ts
+++ b/packages/daemon/src/dispatch-read.ts
@@ -1,5 +1,8 @@
+import { existsSync } from "node:fs";
+import path from "node:path";
 import {
   consumeKnownError,
+  resolveHarnessLayout,
   runtimeSessionOutcomeFromEvidence,
   type AgentRuntimeEventV1,
   type RuntimeSession,
@@ -83,7 +86,17 @@ export function readTaskDispatches(
       const read = input.projection.readDocument(documentPath);
       const archive = read.document ? parseArchive(read.document.body) : null;
       if (archive?.taskId !== target.taskId) continue;
-      rows.set(dispatchId, archiveRow(archive, stream, candidate.session, target.packagePath, lost));
+      rows.set(
+        dispatchId,
+        archiveRow(
+          archive,
+          stream,
+          candidate.session,
+          target.packagePath,
+          existingReportPath(input.rootDir, target.packagePath, dispatchId),
+          lost,
+        ),
+      );
       if (candidate.indexed) staleIndexEntries.set(dispatchId, indexedEntries.get(dispatchId)!);
       break;
     }
@@ -102,6 +115,7 @@ export function readTaskDispatches(
         candidate.session,
         live,
         candidate.taskPackages[0]?.packagePath ?? null,
+        existingReportPath(input.rootDir, candidate.taskPackages[0]?.packagePath ?? null, dispatchId),
         lost,
       ),
     );
@@ -179,7 +193,7 @@ export function readSessionGroupDispatches(input: {
         startedAt: event.occurredAt,
         eventStreamRef: `file:.harness/runtime/dispatches/${dispatchId}.jsonl`,
       };
-    return [liveRow(sourceHeader, null, session.providerSessionId, session, false, null, false)];
+    return [liveRow(sourceHeader, null, session.providerSessionId, session, false, null, null, false)];
   });
 }
 
@@ -251,6 +265,7 @@ function archiveRow(
   stream: ReturnType<typeof readDispatchStream>,
   session: RuntimeSession | undefined,
   packagePath: string,
+  reportPath: string | null,
   lost: boolean,
 ): TaskDispatchRow {
   const archivedProvider = isRecord(value.provider) ? value.provider : null,
@@ -325,7 +340,7 @@ function archiveRow(
     resultRef,
     exitCode,
     dispatchPath: `${packagePath}/artifacts/dispatches/${String(value.dispatchId)}.json`,
-    reportPath: `${packagePath}/artifacts/reports/${String(value.dispatchId)}.md`,
+    ...(reportPath ? { reportPath } : {}),
   };
 }
 function liveRow(
@@ -335,6 +350,7 @@ function liveRow(
   session: RuntimeSession | undefined,
   processRunning: boolean,
   packagePath: string | null,
+  reportPath: string | null,
   lost: boolean,
 ): TaskDispatchRow {
   const outcome = session ? runtimeSessionOutcomeFromEvidence(session) : null;
@@ -375,10 +391,17 @@ function liveRow(
     ...(packagePath
       ? {
           dispatchPath: `${packagePath}/artifacts/dispatches/${header.dispatchId}.json`,
-          reportPath: `${packagePath}/artifacts/reports/${header.dispatchId}.md`,
+          ...(reportPath ? { reportPath } : {}),
         }
       : {}),
   };
+}
+
+function existingReportPath(rootDir: string, packagePath: string | null, dispatchId: string): string | null {
+  if (packagePath === null) return null;
+  const reportPath = `${packagePath}/artifacts/reports/${dispatchId}.md`,
+    absolute = path.join(resolveHarnessLayout(rootDir).authoredRoot, ...reportPath.split("/"));
+  return existsSync(absolute) ? reportPath : null;
 }
 function parseArchive(body: string): Record<string, unknown> | null {
   try {

--- a/packages/daemon/src/protocol/daemon-protocol-commands-runtime-fleet.ts
+++ b/packages/daemon/src/protocol/daemon-protocol-commands-runtime-fleet.ts
@@ -54,12 +54,14 @@ export const runtimeFleetProtocolCommands = Object.freeze([
         },
         { enum: ["bypass", "workspace-write", "read-only"] },
       ),
-      cliInput("--prompt", "single", false, {
-        code: "invalid_field",
-      }),
-      cliInput("--mission", "single", false, {
-        code: "invalid_field",
-      }),
+      cliInput("--prompt", "single", false, { code: "invalid_field" }, { conflictsWith: ["--mission"] }),
+      cliInput(
+        "--mission",
+        "single",
+        false,
+        { code: "invalid_field" },
+        { requires: ["--task"], conflictsWith: ["--prompt"] },
+      ),
       cliInput(
         "--wait-projection",
         "single",

--- a/packages/daemon/src/squad-coordinator.ts
+++ b/packages/daemon/src/squad-coordinator.ts
@@ -684,9 +684,9 @@ export function makeSquadCoordinator(input: {
 
   function leaderAuthoredSynthesisReport(state: SquadState, reportPath: string): boolean {
     const packagePath = dispatchRows(state)
-      .map((row) => row.reportPath)
+      .map((row) => row.dispatchPath)
       .find((candidate): candidate is string => typeof candidate === "string")
-      ?.split("/artifacts/reports/", 1)[0];
+      ?.split("/artifacts/dispatches/", 1)[0];
     if (!packagePath) return false;
     const logicalPath = `${packagePath}/${reportPath}`,
       store = input.store(),

--- a/packages/daemon/test/dispatch-read.test.ts
+++ b/packages/daemon/test/dispatch-read.test.ts
@@ -1,6 +1,6 @@
 // harness-test-tier: fast
 import assert from "node:assert/strict";
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -285,6 +285,12 @@ test("archived dispatch rows expose terminal result and task artifact references
         throw new Error("dispatch reads must not enumerate the replica document basis");
       },
     } as unknown as TaskProjection;
+    const withoutReport = readTaskDispatches({ rootDir, projection, taskId });
+    assert.equal(Object.hasOwn(withoutReport.dispatches[0] ?? {}, "reportPath"), false);
+    const reportPath = "tasks/task-1/artifacts/reports/dispatch_a1b2c3d4e5f60718293a4b5c.md",
+      absoluteReportPath = path.join(rootDir, "harness", ...reportPath.split("/"));
+    mkdirSync(path.dirname(absoluteReportPath), { recursive: true });
+    writeFileSync(absoluteReportPath, "# Runtime result\n");
     const result = readTaskDispatches({ rootDir, projection, taskId });
     assert.deepEqual(result.dispatches[0], {
       dispatchId,
@@ -308,7 +314,7 @@ test("archived dispatch rows expose terminal result and task artifact references
       resultRef: archived.resultRef,
       exitCode: 0,
       dispatchPath: "tasks/task-1/artifacts/dispatches/dispatch_a1b2c3d4e5f60718293a4b5c.json",
-      reportPath: "tasks/task-1/artifacts/reports/dispatch_a1b2c3d4e5f60718293a4b5c.md",
+      reportPath,
     });
   } finally {
     rmSync(rootDir, { recursive: true, force: true });


### PR DESCRIPTION
# English

## Summary

Two dispatch-surface frictions the CEO hit while dispatching workers (task_6d874cfa). First, `ThinCliInput` descriptors already carried `requires`/`conflictsWith`, but the shared flag reader ignored them, so each command parser re-implemented the relationships unevenly; `readFlags` now enforces both from the descriptor, `runtime run` declares that `--mission` requires `--task` and conflicts with `--prompt`, and the two parser-local mission branches are deleted. The originally recorded receipt (fact F-4BB0E4B1, `--mission` rejected together with `--json`) could not be reproduced on the post-#2177 base and its prose no longer exists there: a stale-client result, not a surviving bug. Second, the dispatch read projection unconditionally synthesized `artifacts/reports/<dispatchId>.md` for archived and live rows even though runtime result archival is best-effort, producing false references; it now publishes `reportPath` only when the daemon-authored report exists on disk, and squad synthesis package discovery uses the always-present `dispatchPath` instead.

## Architectural Justification

Cross-field CLI rules belong to the canonical command descriptor, not to individual parsers: enforcing them in `readFlags` deletes the per-command copies and makes every command that declares a relationship (task-submit/closeout/create, fact-record, decision-propose/accept, the people commands, runtime-run) behave the same. A read projection must not promise an optional artifact before its single authoritative writer (`doc-sync-publication.ts`) has materialized it. Multi-node: parsing is deterministic and stateless; a report path is keyed by the dispatch occurrence's globally distinct `dispatchId`; the center's authored store remains the single publication and read authority, so no shared task-level artifact is overwritten.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none

## Machine-Readable Declarations

Production-Delta: +69/-16
Dependency-Change: none

### Optional Evidence Claims

none

## Task And Scope

task_6d874cfadbdcb8851ddd386bfe (dispatch surface friction). In-file removals: the two `runtime run` parser-local mission checks (`thin-command-runtime.ts`) and the two unconditional `reportPath` projections (`dispatch-read.ts`). The separate `requiresAny` vocabulary, whose members can be semantic non-flag tokens, is out of scope: it cannot be enforced by flag presence.

## Version Impact

None.

## Governance Declaration

No protected path touched. No break-glass.

## Verification

- Worker stop point (targeted tests + local commit, no `check:local`): focused parser/read-projection 16/16; adjacent thin-command and squad/dispatch suite 71/71; Ubuntu isolated `runtime-cli.integration.test.ts` 1/1; typecheck, lint, cli-help-contract, cli-error-codes, implementation-contracts (allowlist 129 → 129), line-density, canonical-event-compat (171 samples), gate tests 184/184, test-selection, file-complexity, production-delta green.
- Contract tests: `thin-command-script-doc-runtime.test.ts` asserts JSON/non-JSON action equality for `--mission` and both precise negative diagnostics; `dispatch-read.test.ts` reads an archived dispatch without a report (no `reportPath`), then materializes the canonical report and asserts the same read returns it.
- Facts F-A69333C1, F-9165B106. CI is the full authority.

## Review Evidence

Worker report: `harness/tasks/task_6d874cfadbdcb8851ddd386bfe-*/artifacts/dispatch-surface-friction-report.md` (private ledger). CEO semantic review read the production diff: descriptor-wide enforcement replaces two parser-local branches (the relationship check was lifted into `inputRelationFailure` to keep `readFlags` under the cli-structure branch ceiling); existence-aware `reportPath` replaces two unconditional projections; the squad consumer keys package discovery on `dispatchPath`.

## Residual Risk

The shared canonical daemon runs the pre-change build until the CEO rebuilds and restarts it; until then its `ha task dispatches` output still shows synthetic report paths.

---

# 中文

## 概要

CEO 派工时撞到的两处派工面摩擦(task_6d874cfa)。其一,`ThinCliInput` 描述符早就带 `requires`/`conflictsWith`,但共享 flag 读取器不理它,于是各命令解析器各自零散实现;现在 `readFlags` 按描述符统一执行,`runtime run` 声明 `--mission` 依赖 `--task`、与 `--prompt` 互斥,两处解析器本地的 mission 分支删除。原记录的回执(fact F-4BB0E4B1,`--mission` 与 `--json` 同用被拒)在 #2177 之后的基线上无法复现,那段文案也已不存在:是陈旧客户端结果,不是残存 bug。其二,派工读投影对归档行与在飞行无条件合成 `artifacts/reports/<dispatchId>.md`,而 runtime 结果归档是 best-effort,于是给出假引用;现在只在 daemon 写出的报告真实存在于磁盘时才发布 `reportPath`,squad 综合的包发现改用恒存在的 `dispatchPath`。

## 架构辩护

跨字段的 CLI 规则属于 canonical 命令描述符,不属于单个解析器:在 `readFlags` 里执行就删掉了各命令的手抄副本,让所有声明了关系的命令(task submit/closeout/create、fact record、decision propose/accept、people 系列、runtime run)行为一致。读投影不得在唯一权威写入者(`doc-sync-publication.ts`)落盘之前承诺可选 artifact。多节点:解析确定且无状态;报告路径按派工 occurrence 全局唯一的 `dispatchId` 定位;中心的 authored store 仍是唯一发布与读取权威,不会覆盖共享的 task 级 artifact。

## 机读声明

见英文块。

## 治理声明

未触碰 protected 路径。无 break-glass。

## 验证

- worker 停止点(定向测试 + 本地 commit,不跑 `check:local`):解析器/读投影定向 16/16;相邻 thin-command 与 squad/dispatch 套件 71/71;Ubuntu 隔离机 `runtime-cli.integration.test.ts` 1/1;typecheck、lint、cli-help-contract、cli-error-codes、implementation-contracts(allowlist 129 → 129)、line-density、canonical-event-compat(171 样本)、门测试 184/184、test-selection、file-complexity、production-delta 各绿。
- 契约测试:`thin-command-script-doc-runtime.test.ts` 断言 `--mission` 在 JSON/非 JSON 下动作相等以及两条精确负例诊断;`dispatch-read.test.ts` 先读无报告的归档派工(无 `reportPath`),再落盘 canonical 报告并断言同一读取返回它。
- facts F-A69333C1、F-9165B106。CI 是完整权威。

## 评审证据

worker 报告见任务包 `artifacts/dispatch-surface-friction-report.md`(私有台账)。CEO 语义验收通读生产 diff:描述符级执行替代两处解析器本地分支(关系检查抽成 `inputRelationFailure`,让 `readFlags` 留在 cli-structure 分支上限内);存在性感知的 `reportPath` 替代两处无条件投影;squad 消费方以 `dispatchPath` 定位包。

## 残余风险

共享 canonical daemon 在 CEO 重建并重启前仍跑旧构建;此前其 `ha task dispatches` 输出仍显示合成的报告路径。
