### PR TITLE
feat(cli): unify structured packet inputs

### DIFF
--- a/packages/application/src/task-closeout-action.ts
+++ b/packages/application/src/task-closeout-action.ts
@@ -40,12 +40,11 @@ export type CloseoutStep =
   | "complete"
   | "task-show";
 export interface TaskCloseoutActionDependencies {
-  readonly rootDir: string;
   readonly action: Readonly<Record<string, unknown>>;
   readonly caller: ActorIdentity;
   readonly authorizationDecision: AuthorizationDecision;
   readonly opId: string;
-  readonly readWorkspaceText: (rootDir: string, requested: string, field: string) => string;
+  readonly readPacket: () => string;
   readonly read: () => Promise<Snapshot>;
   readonly presetSnapshotCurrent: () => boolean;
   readonly invoke: (
@@ -75,11 +74,14 @@ export async function runTaskCloseoutAction(dependencies: TaskCloseoutActionDepe
       });
     return discoveryReceipt(opId, snapshot, template);
   }
-  const fromFile = requiredText(action.fromFile, "fromFile"),
-    invocation = closeoutInvocation(taskId, fromFile, executionId);
+  const packetArgument =
+      typeof action.fromFile === "string"
+        ? `--from-file ${requiredText(action.fromFile, "fromFile")}`
+        : "--json-input '<json>'",
+    invocation = closeoutInvocation(taskId, packetArgument, executionId);
   let judgment: TaskCloseoutPacket;
   try {
-    judgment = readJudgment(() => dependencies.readWorkspaceText(dependencies.rootDir, fromFile, "fromFile"));
+    judgment = readJudgment(dependencies.readPacket);
   } catch (error) {
     return reject(opId, "invalid_judgment", {
       commands: [invocation],
@@ -152,7 +154,7 @@ export async function runTaskCloseoutAction(dependencies: TaskCloseoutActionDepe
         commands: [`ha task start ${taskId} --execution-id <execution-id>`, invocation],
       });
     if (executionId && snapshot.lease.executionId !== executionId)
-      return candidateRejection(opId, taskId, fromFile, [snapshot.lease.executionId]);
+      return candidateRejection(opId, taskId, packetArgument, [snapshot.lease.executionId]);
     const active = snapshot.executions.find(
       (candidate) =>
         candidate.executionId === snapshot.lease?.executionId &&
@@ -169,7 +171,7 @@ export async function runTaskCloseoutAction(dependencies: TaskCloseoutActionDepe
       return candidateRejection(
         opId,
         taskId,
-        fromFile,
+        packetArgument,
         cuts.map((candidate) => candidate.executionId),
       );
     const selected = candidates[0]!;
@@ -359,21 +361,21 @@ function deterministicReviewId(
 ): string {
   return deterministicId("review-closeout", taskId, String(iteration), commitSha, review);
 }
-function closeoutInvocation(taskId: string, fromFile: string, executionId?: string): string {
-  return `ha task closeout ${taskId} --from-file ${fromFile}${executionId ? ` --execution-id ${executionId}` : ""}`;
+function closeoutInvocation(taskId: string, packetArgument: string, executionId?: string): string {
+  return `ha task closeout ${taskId} ${packetArgument}${executionId ? ` --execution-id ${executionId}` : ""}`;
 }
 function candidateRejection(
   opId: string,
   taskId: string,
-  fromFile: string,
+  packetArgument: string,
   candidates: readonly string[],
 ): WriteReceipt {
-  const commands = candidates.map((candidate) => closeoutInvocation(taskId, fromFile, candidate));
+  const commands = candidates.map((candidate) => closeoutInvocation(taskId, packetArgument, candidate));
   return reject(opId, "ambiguous_execution", {
     commands:
       commands.length > 0
         ? commands
-        : [`ha task submit ${taskId} --json-input '<submission-json>'`, closeoutInvocation(taskId, fromFile)],
+        : [`ha task submit ${taskId} --json-input '<submission-json>'`, closeoutInvocation(taskId, packetArgument)],
   });
 }
 function reject(

--- a/packages/cli/src/cli/thin-command-router.ts
+++ b/packages/cli/src/cli/thin-command-router.ts
@@ -161,13 +161,18 @@ function parsePeople(
   if (!projected.ok) return projected;
   const action = projected.command.action,
     fromFile = typeof action.fromFile === "string",
-    directFields = Object.keys(action).filter((field) => field !== "kind" && field !== "fromFile");
-  if (fromFile)
+    jsonInput = typeof action.jsonInput === "string",
+    directFields = Object.keys(action).filter(
+      (field) => field !== "kind" && field !== "fromFile" && field !== "jsonInput",
+    );
+  if (fromFile && jsonInput)
+    return rejected("invalid_field", "Use only one of --from-file <path> or --json-input <json|@->.", json);
+  if (fromFile || jsonInput)
     return directFields.length === 0
       ? projected
       : rejected(
           "invalid_field",
-          "Use --from-file <packet.json> by itself, or provide the complete direct flag set.",
+          "Use one of --from-file <path> or --json-input <json|@-> by itself, or provide the complete direct flag set.",
           json,
         );
   for (const input of peopleRequiredInputs[route.id] ?? []) {

--- a/packages/cli/src/cli/thin-command-schedule.ts
+++ b/packages/cli/src/cli/thin-command-schedule.ts
@@ -36,7 +36,8 @@ export function parseSchedule(
         })
       : rejected(
           "invalid_field",
-          "Use one of --from-file <path> or --json-input <json|@-> by itself, or provide the direct Schedule arguments.",
+          "Use one of --from-file <path> or --json-input <json|@-> by itself, " +
+            "or provide the direct Schedule arguments.",
           json,
         );
   if (!nonEmpty(scheduleId))

--- a/packages/cli/src/cli/thin-command-schedule.ts
+++ b/packages/cli/src/cli/thin-command-schedule.ts
@@ -22,17 +22,21 @@ export function parseSchedule(
     return args.length === 2
       ? accepted(rootDir, repoId, json, { kind: "schedule-list" })
       : rejected("unknown_field", "ha schedule list takes no options or positional arguments.", json);
-  const packetOnly = args[2] === "--from-file" || args[2]?.startsWith("--from-file=") === true,
+  const packetOnly = isPacketInputToken(args[2]),
     scheduleId = packetOnly ? undefined : args[2],
     flags = readFlags(route.id, args.slice(packetOnly ? 2 : 3), inputs);
   if (!flags.ok) return rejected(flags.code, flags.nextAction, json);
-  const fromFile = flags.one.get("--from-file");
-  if (fromFile)
+  const fromFile = flags.one.get("--from-file"),
+    jsonInput = flags.one.get("--json-input");
+  if (fromFile || jsonInput)
     return scheduleId === undefined && flags.one.size === 1
-      ? accepted(rootDir, repoId, json, { kind: route.id, fromFile })
+      ? accepted(rootDir, repoId, json, {
+          kind: route.id,
+          ...(fromFile ? { fromFile } : { jsonInput }),
+        })
       : rejected(
           "invalid_field",
-          "Use --from-file <packet.json> by itself, or provide the direct Schedule arguments.",
+          "Use one of --from-file <path> or --json-input <json|@-> by itself, or provide the direct Schedule arguments.",
           json,
         );
   if (!nonEmpty(scheduleId))
@@ -144,6 +148,10 @@ export function parseSchedule(
     ...(flags.booleans.has("--disabled") ? { disabled: true } : {}),
     ...retry,
   });
+}
+
+function isPacketInputToken(value: string | undefined): boolean {
+  return ["--from-file", "--json-input"].some((name) => value === name || value?.startsWith(`${name}=`) === true);
 }
 
 export function parseScheduleDuration(value: string): number | null {

--- a/packages/cli/src/cli/thin-command-task.ts
+++ b/packages/cli/src/cli/thin-command-task.ts
@@ -67,13 +67,16 @@ export function parseTask(
     const f = readFlags(id, args.slice(3), inputs);
     if (!f.ok) return rejected(f.code, f.nextAction, json);
     const fromFile = f.one.get("--from-file"),
+      jsonInput = f.one.get("--json-input"),
       printTemplate = f.booleans.has("--print-template"),
       printSchema = f.booleans.has("--print-schema"),
-      modes = Number(fromFile !== undefined) + Number(printTemplate) + Number(printSchema);
+      modes = Number(fromFile !== undefined || jsonInput !== undefined) + Number(printTemplate) + Number(printSchema);
+    if (fromFile !== undefined && jsonInput !== undefined)
+      return rejected("invalid_field", "Use only one of --from-file <path> or --json-input <json|@->.", json);
     if (modes !== 1)
       return rejected(
         modes === 0 ? "missing_field" : "invalid_field",
-        "Choose exactly one of --from-file <judgment.json>, --print-template, or --print-schema.",
+        "Choose exactly one of --from-file <path>, --json-input <json|@->, --print-template, or --print-schema.",
         json,
       );
     const executionId = f.one.get("--execution-id");
@@ -84,6 +87,7 @@ export function parseTask(
       taskId,
       ...(executionId ? { executionId } : {}),
       ...(fromFile ? { fromFile } : {}),
+      ...(jsonInput ? { jsonInput } : {}),
       ...(printTemplate ? { printTemplate: true } : {}),
       ...(printSchema ? { printSchema: true } : {}),
     });
@@ -101,11 +105,17 @@ export function parseTask(
         })
       : rejected(f.code, f.nextAction, json);
   }
-  if (id === "task-review-consent")
-    return parseProjected(id, args.slice(3), rootDir, repoId, json, inputs, {
+  if (id === "task-review-consent") {
+    const projected = parseProjected(id, args.slice(3), rootDir, repoId, json, inputs, {
       taskId,
       commandType: "RecordReviewConsent",
     });
+    return projected.ok &&
+      projected.command.action.fromFile !== undefined &&
+      projected.command.action.jsonInput !== undefined
+      ? rejected("invalid_field", "Use only one of --from-file <path> or --json-input <json|@->.", json)
+      : projected;
+  }
   if (id === "task-code-doc-reconcile") return parseCodeDoc(rootDir, repoId, json, args, taskId, inputs);
   if (id === "task-code-doc-repoint") return parseCodeDocRepoint(rootDir, repoId, json, args, taskId, inputs);
   return rejected(

--- a/packages/cli/src/cli/thin-command-task.ts
+++ b/packages/cli/src/cli/thin-command-task.ts
@@ -71,8 +71,6 @@ export function parseTask(
       printTemplate = f.booleans.has("--print-template"),
       printSchema = f.booleans.has("--print-schema"),
       modes = Number(fromFile !== undefined || jsonInput !== undefined) + Number(printTemplate) + Number(printSchema);
-    if (fromFile !== undefined && jsonInput !== undefined)
-      return rejected("invalid_field", "Use only one of --from-file <path> or --json-input <json|@->.", json);
     if (modes !== 1)
       return rejected(
         modes === 0 ? "missing_field" : "invalid_field",
@@ -105,17 +103,11 @@ export function parseTask(
         })
       : rejected(f.code, f.nextAction, json);
   }
-  if (id === "task-review-consent") {
-    const projected = parseProjected(id, args.slice(3), rootDir, repoId, json, inputs, {
+  if (id === "task-review-consent")
+    return parseProjected(id, args.slice(3), rootDir, repoId, json, inputs, {
       taskId,
       commandType: "RecordReviewConsent",
     });
-    return projected.ok &&
-      projected.command.action.fromFile !== undefined &&
-      projected.command.action.jsonInput !== undefined
-      ? rejected("invalid_field", "Use only one of --from-file <path> or --json-input <json|@->.", json)
-      : projected;
-  }
   if (id === "task-code-doc-reconcile") return parseCodeDoc(rootDir, repoId, json, args, taskId, inputs);
   if (id === "task-code-doc-repoint") return parseCodeDocRepoint(rootDir, repoId, json, args, taskId, inputs);
   return rejected(

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -88,7 +88,7 @@ async function runThinCli(argv: readonly string[]): Promise<number> {
   }
   let typedCommand: ThinCommand;
   try {
-    typedCommand = materializeDecisionStdin(parsed.command);
+    typedCommand = materializePacketStdin(parsed.command);
   } catch (error) {
     emit(
       cliFailure(
@@ -148,11 +148,11 @@ function finishTimingWithoutChangingOutcome(argv: readonly string[], exitCode: n
   }
 }
 
-export function materializeDecisionStdin(
+export function materializePacketStdin(
   command: ThinCommand,
   readStdin: () => string = () => readFileSync(0, "utf8"),
 ): ThinCommand {
-  if (command.action.kind !== "decision-propose" || command.action.jsonInput !== "@-") return command;
+  if (command.action.jsonInput !== "@-") return command;
   return {
     ...command,
     action: { ...command.action, jsonInput: readStdin() },

--- a/packages/cli/test/people-command.test.ts
+++ b/packages/cli/test/people-command.test.ts
@@ -1,6 +1,7 @@
 // harness-test-tier: fast
 import assert from "node:assert/strict";
 import test from "node:test";
+import { materializePacketStdin } from "../src/index.ts";
 import { parseThinCommand } from "../src/cli/thin-command.ts";
 
 test("People CLI projects registry and delegated-token mutations onto closed Action payloads", () => {
@@ -154,9 +155,24 @@ test("People CLI exposes one closed structured packet facet per public command",
     assert.equal(parsed.ok, true);
     if (parsed.ok) assert.deepEqual(parsed.command.action, action);
   }
+  const packet = '{"personId":"person_alice"}',
+    inline = parseThinCommand(["people", "remove", "--json-input", packet]),
+    stdin = parseThinCommand(["people", "remove", "--json-input", "@-"]);
+  assert.equal(inline.ok, true);
+  assert.equal(stdin.ok, true);
+  if (inline.ok) assert.deepEqual(inline.command.action, { kind: "people-remove", jsonInput: packet });
+  if (stdin.ok)
+    assert.deepEqual(materializePacketStdin(stdin.command, () => packet).action, {
+      kind: "people-remove",
+      jsonInput: packet,
+    });
   assert.equal(parseThinCommand(["people", "add", "--person-id", "person_alice"]).ok, false);
   assert.equal(
     parseThinCommand(["people", "remove", "--from-file", "people-remove.json", "--person-id", "person_alice"]).ok,
+    false,
+  );
+  assert.equal(
+    parseThinCommand(["people", "remove", "--from-file", "people-remove.json", "--json-input", packet]).ok,
     false,
   );
 });

--- a/packages/cli/test/schedule-command.test.ts
+++ b/packages/cli/test/schedule-command.test.ts
@@ -1,6 +1,7 @@
 // harness-test-tier: fast
 import assert from "node:assert/strict";
 import test from "node:test";
+import { materializePacketStdin } from "../src/index.ts";
 import { createScheduleV1 } from "../../kernel/src/index.ts";
 import { parseThinCommand } from "../src/cli/thin-command.ts";
 import {
@@ -230,7 +231,19 @@ test("Schedule show, update, and delete expose closed structured packet inputs",
         fromFile: packet,
       });
   }
+  const packet = '{"scheduleId":"probe"}',
+    inline = parseThinCommand(["schedule", "show", "--json-input", packet]),
+    stdin = parseThinCommand(["schedule", "show", "--json-input", "@-"]);
+  assert.equal(inline.ok, true);
+  assert.equal(stdin.ok, true);
+  if (inline.ok) assert.deepEqual(inline.command.action, { kind: "schedule-show", jsonInput: packet });
+  if (stdin.ok)
+    assert.deepEqual(materializePacketStdin(stdin.command, () => packet).action, {
+      kind: "schedule-show",
+      jsonInput: packet,
+    });
   assert.equal(parseThinCommand(["schedule", "update", "probe", "--from-file", "update.json"]).ok, false);
+  assert.equal(parseThinCommand(["schedule", "show", "--from-file", "show.json", "--json-input", packet]).ok, false);
   assert.equal(parseThinCommand(["schedule", "update", "probe", "--mode", "observe"]).ok, false);
 });
 

--- a/packages/cli/test/task-closeout.integration.test.ts
+++ b/packages/cli/test/task-closeout.integration.test.ts
@@ -65,19 +65,16 @@ test("a submitted fixture reaches done through one ha task closeout command", (c
       String(run(root, userRoot, ["task", "closeout", taskId, "--print-template"]).summary),
     ) as Record<string, unknown>;
     assert.equal(Object.hasOwn(resumeTemplate, "submission"), false);
-    writeFileSync(
-      path.join(root, "judgment.json"),
-      JSON.stringify({
-        review: {
-          verdict: "approved",
-          reason: "Independent fixture review passed.",
-          evidenceChecked: ["submitted execution"],
-        },
-        consent: { approved: true },
-        completion: { ci: "passed", codeDocPaths: ["README.md"] },
-      }),
-    );
-    const closeout = runMaybe(root, userRoot, ["task", "closeout", taskId, "--from-file", "judgment.json"]);
+    const judgment = JSON.stringify({
+      review: {
+        verdict: "approved",
+        reason: "Independent fixture review passed.",
+        evidenceChecked: ["submitted execution"],
+      },
+      consent: { approved: true },
+      completion: { ci: "passed", codeDocPaths: ["README.md"] },
+    });
+    const closeout = runMaybe(root, userRoot, ["task", "closeout", taskId, "--json-input", "@-"], undefined, judgment);
     context.diagnostic(`closeout-e2e-output=${closeout.stdout}`);
     assert.equal(closeout.status, 0, closeout.stderr);
     const receipt = JSON.parse(closeout.stdout) as Record<string, unknown>;
@@ -241,6 +238,7 @@ function runMaybe(
   userRoot: string,
   args: readonly string[],
   actor?: string,
+  input?: string,
 ): {
   readonly status: number | null;
   readonly stdout: string;
@@ -249,6 +247,7 @@ function runMaybe(
   const result = spawnSync(process.execPath, [cli, "--root", root, "--json", ...args], {
     encoding: "utf8",
     env: environment(root, userRoot, actor),
+    ...(input === undefined ? {} : { input }),
   });
   return {
     status: result.status,

--- a/packages/cli/test/task-closeout.test.ts
+++ b/packages/cli/test/task-closeout.test.ts
@@ -2,6 +2,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { parseThinCommand, renderThinHelp } from "../src/cli/thin-command.ts";
+import { materializePacketStdin } from "../src/index.ts";
 
 test("task closeout accepts one execution, template, or schema mode and discloses the packet fields", () => {
   const derived = parseThinCommand(["task", "closeout", "task-closeout", "--from-file", "judgment.json"]),
@@ -14,6 +15,9 @@ test("task closeout accepts one execution, template, or schema mode and disclose
       "--from-file",
       "judgment.json",
     ]),
+    inlinePacket = '{"review":{},"consent":{},"completion":{}}',
+    inline = parseThinCommand(["task", "closeout", "task-closeout", "--json-input", inlinePacket]),
+    stdin = parseThinCommand(["task", "closeout", "task-closeout", "--json-input", "@-"]),
     template = parseThinCommand(["task", "closeout", "task-closeout", "--print-template"]),
     schema = parseThinCommand(["task", "closeout", "task-closeout", "--print-schema"]),
     missing = parseThinCommand(["task", "closeout", "task-closeout"]),
@@ -25,6 +29,15 @@ test("task closeout accepts one execution, template, or schema mode and disclose
       "judgment.json",
       "--print-template",
     ]),
+    conflictingSources = parseThinCommand([
+      "task",
+      "closeout",
+      "task-closeout",
+      "--from-file",
+      "judgment.json",
+      "--json-input",
+      inlinePacket,
+    ]),
     irrelevantSelector = parseThinCommand([
       "task",
       "closeout",
@@ -35,10 +48,13 @@ test("task closeout accepts one execution, template, or schema mode and disclose
     ]);
   assert.equal(derived.ok, true);
   assert.equal(explicit.ok, true);
+  assert.equal(inline.ok, true);
+  assert.equal(stdin.ok, true);
   assert.equal(template.ok, true);
   assert.equal(schema.ok, true);
   assert.equal(missing.ok, false);
   assert.equal(conflicting.ok, false);
+  assert.equal(conflictingSources.ok, false);
   assert.equal(irrelevantSelector.ok, false);
   if (derived.ok)
     assert.deepEqual(derived.command.action, {
@@ -52,6 +68,18 @@ test("task closeout accepts one execution, template, or schema mode and disclose
       taskId: "task-closeout",
       executionId: "execution-closeout",
       fromFile: "judgment.json",
+    });
+  if (inline.ok)
+    assert.deepEqual(inline.command.action, {
+      kind: "task-closeout",
+      taskId: "task-closeout",
+      jsonInput: inlinePacket,
+    });
+  if (stdin.ok)
+    assert.deepEqual(materializePacketStdin(stdin.command, () => inlinePacket).action, {
+      kind: "task-closeout",
+      taskId: "task-closeout",
+      jsonInput: inlinePacket,
     });
   if (template.ok)
     assert.deepEqual(template.command.action, {

--- a/packages/cli/test/thin-command-closeout-progress.test.ts
+++ b/packages/cli/test/thin-command-closeout-progress.test.ts
@@ -160,7 +160,25 @@ test("lifecycle CLI maps explicit selectors and accepts every derivable executio
       "--from-file",
       "review.json",
     ]),
+    inlineReview = parseThinCommand([
+      "task",
+      "review-execution",
+      "task-1",
+      "--review-id",
+      "review-2",
+      "--json-input",
+      '{"verdict":"approved","reason":"ok","evidenceChecked":[]}',
+    ]),
     derivedPairConsent = parseThinCommand(["task", "review-consent", "task-1", "--consent-id", "consent-1"]),
+    inlineConsent = parseThinCommand([
+      "task",
+      "review-consent",
+      "task-1",
+      "--consent-id",
+      "consent-2",
+      "--json-input",
+      '{"reviewDigest":"sha256:a","contentDigest":"sha256:b"}',
+    ]),
     derivedComplete = parseThinCommand([
       "task",
       "complete",
@@ -170,7 +188,15 @@ test("lifecycle CLI maps explicit selectors and accepts every derivable executio
       "--path",
       "packages/kernel/src/domain/task.ts",
     ]);
-  for (const parsed of [derivedDeclare, derivedSubmit, derivedReview, derivedPairConsent, derivedComplete])
+  for (const parsed of [
+    derivedDeclare,
+    derivedSubmit,
+    derivedReview,
+    inlineReview,
+    derivedPairConsent,
+    inlineConsent,
+    derivedComplete,
+  ])
     assert.equal(parsed.ok, true, JSON.stringify(parsed));
   if (derivedDeclare.ok)
     assert.deepEqual(derivedDeclare.command.action, {
@@ -194,12 +220,28 @@ test("lifecycle CLI maps explicit selectors and accepts every derivable executio
       commandType: "RecordReview",
       fromFile: "review.json",
     });
+  if (inlineReview.ok)
+    assert.deepEqual(inlineReview.command.action, {
+      kind: "task-review-execution",
+      taskId: "task-1",
+      reviewId: "review-2",
+      commandType: "RecordReview",
+      jsonInput: '{"verdict":"approved","reason":"ok","evidenceChecked":[]}',
+    });
   if (derivedPairConsent.ok)
     assert.deepEqual(derivedPairConsent.command.action, {
       kind: "task-review-consent",
       taskId: "task-1",
       commandType: "RecordReviewConsent",
       consentId: "consent-1",
+    });
+  if (inlineConsent.ok)
+    assert.deepEqual(inlineConsent.command.action, {
+      kind: "task-review-consent",
+      taskId: "task-1",
+      commandType: "RecordReviewConsent",
+      consentId: "consent-2",
+      jsonInput: '{"reviewDigest":"sha256:a","contentDigest":"sha256:b"}',
     });
   if (derivedComplete.ok)
     assert.deepEqual(derivedComplete.command.action, {
@@ -211,6 +253,20 @@ test("lifecycle CLI maps explicit selectors and accepts every derivable executio
       paths: ["packages/kernel/src/domain/task.ts"],
     });
   assert.equal(parseThinCommand(["task", "submit", "task-1", "--execution-id", "execution-1"]).ok, false);
+  assert.equal(
+    parseThinCommand([
+      "task",
+      "review-consent",
+      "task-1",
+      "--consent-id",
+      "consent-1",
+      "--from-file",
+      "consent.json",
+      "--json-input",
+      "{}",
+    ]).ok,
+    false,
+  );
   assert.equal(parseThinCommand(["task", "declare-executor", "task-1", "--execution-id", "execution-1"]).ok, false);
   assert.equal(
     parseThinCommand(["task", "review-execution", "task-1", "--execution-id", "execution-1", "--review-id", "review-1"])

--- a/packages/cli/test/thin-command-contract-parity.test.ts
+++ b/packages/cli/test/thin-command-contract-parity.test.ts
@@ -86,6 +86,9 @@ test("all public commands expose the canonical structured input facet", () => {
     "schedule-runs",
   );
   for (const id of [
+    "task-closeout",
+    "task-review-execution",
+    "task-review-consent",
     "people-add",
     "people-set-role",
     "people-bind",
@@ -96,13 +99,22 @@ test("all public commands expose the canonical structured input facet", () => {
     "schedule-update",
     "schedule-delete",
   ]) {
-    const fromFile = daemonProtocolCommands
-      .find((command) => command.id === id)
-      ?.inputs.find((input) => input.name === "--from-file");
-    assert.ok(fromFile, `${id}: --from-file`);
+    const command = daemonProtocolCommands.find((candidate) => candidate.id === id),
+      fromFile = command?.inputs.find((input) => input.name === "--from-file"),
+      jsonInput = command?.inputs.find((input) => input.name === "--json-input");
+    assert.ok(fromFile && jsonInput, `${id}: structured packet inputs`);
     assert.equal(fromFile.kind, "single", id);
     assert.equal((fromFile.jsonFields?.length ?? 0) > 0, true, `${id}: JSON required fields`);
-    assert.equal((fromFile.jsonAllowedFields?.length ?? 0) >= (fromFile.jsonFields?.length ?? 0), true, id);
+    assert.equal(
+      (fromFile.jsonAllowedFields ?? fromFile.jsonFields ?? []).length >= (fromFile.jsonFields?.length ?? 0),
+      true,
+      id,
+    );
+    assert.deepEqual(jsonInput.jsonFields, fromFile.jsonFields, `${id}: JSON required fields match`);
+    assert.deepEqual(jsonInput.jsonAllowedFields, fromFile.jsonAllowedFields, `${id}: JSON allowed fields match`);
+    assert.equal(jsonInput.format, "<json|@->", `${id}: stdin format`);
+    assert.equal(fromFile.conflictsWith?.includes("--json-input"), true, `${id}: file conflict`);
+    assert.equal(jsonInput.conflictsWith?.includes("--from-file"), true, `${id}: inline conflict`);
   }
   const taskSubmit = daemonProtocolCommands.find((command) => command.id === "task-submit"),
     submitFile = taskSubmit?.inputs.find((input) => input.name === "--from-file"),

--- a/packages/cli/test/thin-command-preset-fact-decision.test.ts
+++ b/packages/cli/test/thin-command-preset-fact-decision.test.ts
@@ -2,7 +2,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { parseThinCommand } from "../src/cli/thin-command.ts";
-import { materializeDecisionStdin } from "../src/index.ts";
+import { materializePacketStdin } from "../src/index.ts";
 
 test("thin parser derives builtin vertical, template, and script discovery actions", () => {
   const vertical = parseThinCommand(["vertical", "validate", "--source", "software/coding"]),
@@ -391,7 +391,7 @@ test("Decision CLI maps every canonical command and keeps the five local error c
       body: "# Canonical\n\nInitial prose.\n",
     });
   if (stdin.ok)
-    assert.deepEqual(materializeDecisionStdin(stdin.command, () => packet).action, {
+    assert.deepEqual(materializePacketStdin(stdin.command, () => packet).action, {
       kind: "decision-propose",
       jsonInput: packet,
     });

--- a/packages/daemon/src/person-action-runtime.ts
+++ b/packages/daemon/src/person-action-runtime.ts
@@ -189,7 +189,6 @@ function peopleContract(required: readonly string[], allowed: readonly string[])
   return {
     required,
     allowed,
-    source: "from-file",
     invalid: invalidPersonCommand,
     messages: {
       parse: "People input must be one UTF-8 JSON object; repair the JSON and retry",

--- a/packages/daemon/src/protocol/daemon-protocol-commands-people.ts
+++ b/packages/daemon/src/protocol/daemon-protocol-commands-people.ts
@@ -35,16 +35,27 @@ const peopleWriteTopology = {
   },
   textInput = (name: string, required: boolean) =>
     cliInput(name, "single", required, { code: "invalid_field" }, { minLength: 1 }),
-  fromFileInput = (requiredFields: readonly string[], allowedFields: readonly string[]) =>
+  packetInputs = (requiredFields: readonly string[], allowedFields: readonly string[]) => [
     cliInput(
       "--from-file",
       "single",
       false,
-      {
-        code: "invalid_field",
-      },
-      { jsonFields: requiredFields, jsonAllowedFields: allowedFields },
+      { code: "invalid_field" },
+      { jsonFields: requiredFields, jsonAllowedFields: allowedFields, conflictsWith: ["--json-input"] },
     ),
+    cliInput(
+      "--json-input",
+      "single",
+      false,
+      { code: "invalid_field" },
+      {
+        jsonFields: requiredFields,
+        jsonAllowedFields: allowedFields,
+        format: "<json|@->",
+        conflictsWith: ["--from-file"],
+      },
+    ),
+  ],
   personIdInput = () =>
     cliInput(
       "--person-id",
@@ -116,7 +127,7 @@ export const peopleProtocolCommands = Object.freeze([
     summary: "Add a Person to people.yaml through the canonical Action writer.",
     method: "repo.task.run",
     inputs: [
-      fromFileInput(peopleAddJsonFields, peopleAddJsonAllowedFields),
+      ...packetInputs(peopleAddJsonFields, peopleAddJsonAllowedFields),
       personIdInput(),
       cliInput(
         "--display-name",
@@ -154,7 +165,7 @@ export const peopleProtocolCommands = Object.freeze([
     summary: "Declare one Actor role on one EntityRef through the canonical Action writer.",
     method: "repo.task.run",
     inputs: [
-      fromFileInput(peopleBindJsonFields, peopleBindJsonAllowedFields),
+      ...packetInputs(peopleBindJsonFields, peopleBindJsonAllowedFields),
       actorInput(),
       roleInput(),
       textInput("--target", false),
@@ -171,7 +182,7 @@ export const peopleProtocolCommands = Object.freeze([
     summary: "Delegate a closed Action set from the authenticated principal to one RuntimeSession.",
     method: "repo.task.run",
     inputs: [
-      fromFileInput(peopleDelegateJsonFields, peopleDelegateJsonAllowedFields),
+      ...packetInputs(peopleDelegateJsonFields, peopleDelegateJsonAllowedFields),
       tokenIdInput(),
       cliInput(
         "--runtime-session-id",
@@ -217,7 +228,7 @@ export const peopleProtocolCommands = Object.freeze([
     summary: "Revoke one DelegatedExecutionToken through the canonical Action writer.",
     method: "repo.task.run",
     inputs: [
-      fromFileInput(peopleRevokeDelegationJsonFields, peopleRevokeDelegationJsonAllowedFields),
+      ...packetInputs(peopleRevokeDelegationJsonFields, peopleRevokeDelegationJsonAllowedFields),
       tokenIdInput(),
       idempotencyInput(),
     ],
@@ -231,7 +242,7 @@ export const peopleProtocolCommands = Object.freeze([
     summary: "Set one Person role and its command classes through the canonical Action writer.",
     method: "repo.task.run",
     inputs: [
-      fromFileInput(peopleSetRoleJsonFields, peopleSetRoleJsonAllowedFields),
+      ...packetInputs(peopleSetRoleJsonFields, peopleSetRoleJsonAllowedFields),
       personIdInput(),
       roleInput(),
       commandClassInput(),
@@ -246,7 +257,11 @@ export const peopleProtocolCommands = Object.freeze([
     path: ["people", "remove"],
     summary: "Remove a Person from people.yaml through the canonical Action writer.",
     method: "repo.task.run",
-    inputs: [fromFileInput(peopleRemoveJsonFields, peopleRemoveJsonAllowedFields), personIdInput(), idempotencyInput()],
+    inputs: [
+      ...packetInputs(peopleRemoveJsonFields, peopleRemoveJsonAllowedFields),
+      personIdInput(),
+      idempotencyInput(),
+    ],
     ...peopleWriteTopology,
   }),
 ]);

--- a/packages/daemon/src/protocol/daemon-protocol-commands-runtime-fleet.ts
+++ b/packages/daemon/src/protocol/daemon-protocol-commands-runtime-fleet.ts
@@ -288,16 +288,27 @@ export const scheduleShowJsonFields = Object.freeze(["scheduleId"] as const),
   scheduleDeleteJsonAllowedFields = Object.freeze([...scheduleDeleteJsonFields, "reason", "idempotencyKey"] as const),
   scheduleReasoningEfforts = ["minimal", "low", "medium", "high", "xhigh", "max"] as const;
 
-const scheduleFromFileInput = (requiredFields: readonly string[], allowedFields: readonly string[]) =>
+const schedulePacketInputs = (requiredFields: readonly string[], allowedFields: readonly string[]) => [
   cliInput(
     "--from-file",
     "single",
     false,
+    { code: "invalid_field" },
+    { jsonFields: requiredFields, jsonAllowedFields: allowedFields, conflictsWith: ["--json-input"] },
+  ),
+  cliInput(
+    "--json-input",
+    "single",
+    false,
+    { code: "invalid_field" },
     {
-      code: "invalid_field",
+      jsonFields: requiredFields,
+      jsonAllowedFields: allowedFields,
+      format: "<json|@->",
+      conflictsWith: ["--from-file"],
     },
-    { jsonFields: requiredFields, jsonAllowedFields: allowedFields },
-  );
+  ),
+];
 
 export const scheduleProtocolCommands = Object.freeze([
   defineCenterForwardWriteCommand({
@@ -397,7 +408,7 @@ export const scheduleProtocolCommands = Object.freeze([
     summary: "Show one canonical Schedule definition and projected run state.",
     method: "repo.task.read",
     positional: "scheduleId",
-    inputs: [scheduleFromFileInput(scheduleShowJsonFields, scheduleShowJsonAllowedFields)],
+    inputs: schedulePacketInputs(scheduleShowJsonFields, scheduleShowJsonAllowedFields),
   }),
   defineCenterForwardWriteCommand({
     id: "schedule-update",
@@ -407,7 +418,7 @@ export const scheduleProtocolCommands = Object.freeze([
     method: "repo.task.run",
     positional: "scheduleId",
     inputs: [
-      scheduleFromFileInput(scheduleUpdateJsonFields, scheduleUpdateJsonAllowedFields),
+      ...schedulePacketInputs(scheduleUpdateJsonFields, scheduleUpdateJsonAllowedFields),
       cliInput(
         "--mode",
         "single",
@@ -470,7 +481,7 @@ export const scheduleProtocolCommands = Object.freeze([
     method: "repo.task.run",
     positional: "scheduleId",
     inputs: [
-      scheduleFromFileInput(scheduleDeleteJsonFields, scheduleDeleteJsonAllowedFields),
+      ...schedulePacketInputs(scheduleDeleteJsonFields, scheduleDeleteJsonAllowedFields),
       cliInput("--reason", "single", false, {
         code: "invalid_field",
       }),

--- a/packages/daemon/src/protocol/daemon-protocol-commands-task.ts
+++ b/packages/daemon/src/protocol/daemon-protocol-commands-task.ts
@@ -275,16 +275,35 @@ export const generatedTaskActionProtocolDeclarations = Object.freeze([
         {
           field: "fromFile",
           type: "string",
-          required: true,
+          required: false,
           cli: {
             jsonFields: ["verdict", "reason", "evidenceChecked"],
             jsonEnums: {
               verdict: ["approved", "changes_requested", "dismissed"],
             },
+            conflictsWith: ["--json-input"],
             name: "--from-file",
             kind: "single",
             error: {
-              code: "missing_field",
+              code: "invalid_field",
+            },
+          },
+        },
+        {
+          field: "jsonInput",
+          type: "string",
+          required: false,
+          cli: {
+            jsonFields: ["verdict", "reason", "evidenceChecked"],
+            jsonEnums: {
+              verdict: ["approved", "changes_requested", "dismissed"],
+            },
+            format: "<json|@->",
+            conflictsWith: ["--from-file"],
+            name: "--json-input",
+            kind: "single",
+            error: {
+              code: "invalid_field",
             },
           },
         },
@@ -295,7 +314,7 @@ export const generatedTaskActionProtocolDeclarations = Object.freeze([
           enum: ["RecordReview"],
         },
       ],
-      exactlyOneOf: [],
+      exactlyOneOf: [["fromFile", "jsonInput"]],
     },
     explain: "Record an independent, content-pinned review for the submitted execution.",
     execution: {
@@ -542,7 +561,19 @@ export const taskExecutionProtocolCommands = Object.freeze([
           jsonFields: ["review", "consent", "completion"],
           jsonAllowedFields: ["submission", "review", "consent", "completion"],
           format: "task-closeout-packet/v1 JSON; run --print-schema for the field contract",
-          conflictsWith: ["--print-template", "--print-schema"],
+          conflictsWith: ["--json-input", "--print-template", "--print-schema"],
+        },
+      ),
+      cliInput(
+        "--json-input",
+        "single",
+        false,
+        { code: "missing_field" },
+        {
+          jsonFields: ["review", "consent", "completion"],
+          jsonAllowedFields: ["submission", "review", "consent", "completion"],
+          format: "<json|@->",
+          conflictsWith: ["--from-file", "--print-template", "--print-schema"],
         },
       ),
       cliInput(
@@ -552,7 +583,7 @@ export const taskExecutionProtocolCommands = Object.freeze([
         {
           code: "invalid_field",
         },
-        { conflictsWith: ["--from-file", "--print-schema"] },
+        { conflictsWith: ["--from-file", "--json-input", "--print-schema"] },
       ),
       cliInput(
         "--print-schema",
@@ -561,7 +592,7 @@ export const taskExecutionProtocolCommands = Object.freeze([
         {
           code: "invalid_field",
         },
-        { conflictsWith: ["--from-file", "--print-template", "--execution-id"] },
+        { conflictsWith: ["--from-file", "--json-input", "--print-template", "--execution-id"] },
       ),
     ],
   }),
@@ -588,7 +619,14 @@ export const taskExecutionProtocolCommands = Object.freeze([
         {
           code: "invalid_field",
         },
-        { jsonFields: consentJsonFields },
+        { jsonFields: consentJsonFields, conflictsWith: ["--json-input"] },
+      ),
+      cliInput(
+        "--json-input",
+        "single",
+        false,
+        { code: "invalid_field" },
+        { jsonFields: consentJsonFields, format: "<json|@->", conflictsWith: ["--from-file"] },
       ),
     ],
   }),

--- a/packages/daemon/src/repo-cell-action-parse.ts
+++ b/packages/daemon/src/repo-cell-action-parse.ts
@@ -2,7 +2,7 @@ import { realpathSync } from "node:fs";
 import path from "node:path";
 import { decisionProposalJsonFields, taskCreateJsonFields } from "../../preset/src/index.ts";
 import { cellCodedError, cellErrorCode } from "./repo-cell-errors.ts";
-import { packetFile, packetJson, workspaceText } from "./repo-cell-packets.ts";
+import { packetRecord, readPacketSource, workspaceText } from "./repo-cell-packets.ts";
 import { requiredCellText } from "./repo-cell-settlement.ts";
 import type { RepoTaskAction } from "./repo-cell-types.ts";
 
@@ -13,7 +13,6 @@ export const taskCreateFields = taskCreateJsonFields;
 export type PacketActionContract = Readonly<{
   required: readonly string[];
   allowed: readonly string[];
-  source: "from-file" | "from-file-or-json-input";
   actionOverrides?: readonly string[];
   invalid: (message: string) => Error;
   messages: Readonly<{
@@ -34,17 +33,8 @@ export function resolvePacketAction(
 ): RepoTaskAction {
   const fromFile = typeof action.fromFile === "string",
     jsonInput = typeof action.jsonInput === "string",
-    hasSource = contract.source === "from-file" ? fromFile : fromFile || jsonInput,
-    sourceFields =
-      contract.source === "from-file"
-        ? fromFile
-          ? ["fromFile"]
-          : contract.allowed
-        : fromFile
-          ? ["fromFile"]
-          : jsonInput
-            ? ["jsonInput"]
-            : contract.allowed,
+    hasSource = fromFile || jsonInput,
+    sourceFields = fromFile ? ["fromFile"] : jsonInput ? ["jsonInput"] : contract.allowed,
     actionAllowed = contract.actionOverrides
       ? new Set(["kind", ...sourceFields, ...contract.actionOverrides])
       : undefined,
@@ -54,10 +44,7 @@ export function resolvePacketAction(
   if (!hasSource) return action;
   let parsed: unknown;
   try {
-    const raw = fromFile
-      ? workspaceText(rootDir, action.fromFile, "fromFile")
-      : requiredCellText(action.jsonInput, "jsonInput");
-    parsed = JSON.parse(raw);
+    parsed = JSON.parse(readPacketSource(rootDir, action));
   } catch (error) {
     if (error instanceof SyntaxError) throw contract.invalid(contract.messages.parse);
     throw error;
@@ -94,7 +81,6 @@ export function taskCreateAction(rootDir: string, action: RepoTaskAction): RepoT
   const resolved = resolvePacketAction(rootDir, action, {
     required: [],
     allowed: taskCreateFields,
-    source: "from-file-or-json-input",
     invalid: (message) => cellCodedError("invalid_command", message),
     messages: {
       parse: "Task create input must be one UTF-8 JSON object; repair the JSON and retry.",
@@ -199,9 +185,7 @@ export function decisionProposalAction(rootDir: string, action: RepoTaskAction):
       "invalid_command",
       "Decision propose requires one structured packet and at most one body source.",
     );
-  const packet = fromFile
-      ? packetFile(rootDir, action.fromFile, decisionProposalFields).value
-      : packetJson(action.jsonInput, decisionProposalFields),
+  const packet = packetRecord(rootDir, action, decisionProposalFields).value,
     body =
       typeof action.body === "string"
         ? action.body

--- a/packages/daemon/src/repo-cell-closeout.ts
+++ b/packages/daemon/src/repo-cell-closeout.ts
@@ -2,6 +2,7 @@ import { runTaskCloseoutAction } from "../../application/src/task-closeout-actio
 import { closeoutReadiness, type WriteReceiptDraft } from "../../kernel/src/index.ts";
 import { authorizeRepoCellAction } from "./repo-cell-authorization.ts";
 import { isPresetSnapshotCurrent } from "./repo-cell-task-progress.ts";
+import { readPacketSource } from "./repo-cell-packets.ts";
 import type { RepoCellOperationalContext } from "./repo-cell-action-context.ts";
 import type { RepoCellBinding, RepoTaskAction, Snapshot } from "./repo-cell-types.ts";
 
@@ -14,7 +15,6 @@ export async function closeoutTask(
     initial = await cell.service.read(taskId),
     opId = cell.operationId(action, binding, cell.input.repoId, initial.snapshot.revision);
   return runTaskCloseoutAction({
-    rootDir: cell.rootDir,
     action,
     caller: binding.actor,
     authorizationDecision:
@@ -26,7 +26,7 @@ export async function closeoutTask(
         );
       })(),
     opId,
-    readWorkspaceText: cell.workspaceText,
+    readPacket: () => readPacketSource(cell.rootDir, action),
     read: async () =>
       (await cell.service.read(taskId)).snapshot as Parameters<typeof closeoutReadiness>[0] & {
         readonly revision: number;
@@ -40,7 +40,9 @@ export async function closeoutTask(
         taskId,
         projected.snapshot,
         projected.packagePath,
-        `ha task closeout ${taskId} --from-file ${String(action.fromFile)}`,
+        `ha task closeout ${taskId} ${
+          typeof action.fromFile === "string" ? `--from-file ${action.fromFile}` : "--json-input '<json>'"
+        }`,
       );
     },
     invoke: async (stage, leaf, actor) => {

--- a/packages/daemon/src/repo-cell-command.ts
+++ b/packages/daemon/src/repo-cell-command.ts
@@ -19,7 +19,7 @@ import {
   reviewConsentSelection,
   uniqueDerivedExecutionId,
 } from "./repo-cell-execution-selection.ts";
-import { packetFile, reviewPacket, reviewQualificationFields, submissionPacket } from "./repo-cell-packets.ts";
+import { packetRecord, reviewPacket, reviewQualificationFields, submissionPacket } from "./repo-cell-packets.ts";
 import { actorHint, operationId } from "./repo-cell-proof.ts";
 import { digest, reviewVerdict } from "./repo-cell-review-lint.ts";
 import { cellStringList, requiredCellText } from "./repo-cell-settlement.ts";
@@ -194,8 +194,8 @@ export function buildCommand(
       selected = reviewConsentSelection(action, snapshot, taskId, consentId),
       executionId = selected.executionId,
       reviewId = selected.reviewId;
-    if (action.fromFile !== undefined) {
-      const packet = packetFile(rootDir, action.fromFile, consentJsonFields);
+    if (action.fromFile !== undefined || action.jsonInput !== undefined) {
+      const packet = packetRecord(rootDir, action, consentJsonFields);
       return normalizeTaskLifecycleCommand(bound, {
         type: "RecordReviewConsent",
         taskId,

--- a/packages/daemon/src/repo-cell-packets.ts
+++ b/packages/daemon/src/repo-cell-packets.ts
@@ -38,19 +38,31 @@ export function workspaceText(rootDir: string, requestedValue: unknown, field: s
   return readWorkspaceText(rootDir, requiredCellText(requestedValue, field), field);
 }
 
-export function packetFile(
+export function readPacketSource(rootDir: string, action: Readonly<Record<string, unknown>>): string {
+  const fromFile = action.fromFile !== undefined,
+    jsonInput = action.jsonInput !== undefined;
+  if (fromFile === jsonInput)
+    throw cellCodedError(
+      "invalid_command",
+      "Use exactly one structured input source: --from-file <path> or --json-input <json>.",
+    );
+  return fromFile
+    ? workspaceText(rootDir, action.fromFile, "fromFile")
+    : requiredCellText(action.jsonInput, "jsonInput");
+}
+
+export function packetRecord(
   rootDir: string,
-  value: unknown,
+  action: Readonly<Record<string, unknown>>,
   fields: readonly string[],
 ): {
   readonly value: Record<string, unknown>;
   readonly digest: `sha256:${string}`;
 } {
-  const body = workspaceText(rootDir, value, "fromFile"),
-    parsed = packetJson(body, fields);
+  const body = readPacketSource(rootDir, action);
   return {
-    value: parsed,
-    digest: `sha256:${createHash("sha256").update(body).digest("hex")}`,
+    value: packetJson(body, fields),
+    digest: packetDigest(body),
   };
 }
 
@@ -61,15 +73,7 @@ export function reviewPacket(
   readonly value: Record<string, unknown>;
   readonly digest: `sha256:${string}`;
 } {
-  if (action.jsonInput !== undefined && action.fromFile !== undefined)
-    throw cellCodedError(
-      "invalid_command",
-      "Review accepts either the public fromFile packet or one daemon-internal JSON packet, not both.",
-    );
-  const body =
-    action.jsonInput === undefined
-      ? workspaceText(rootDir, action.fromFile, "fromFile")
-      : requiredCellText(action.jsonInput, "jsonInput");
+  const body = readPacketSource(rootDir, action);
   let value: Record<string, unknown>;
   try {
     const parsed = JSON.parse(body) as unknown,
@@ -92,8 +96,12 @@ export function reviewPacket(
   }
   return {
     value,
-    digest: `sha256:${createHash("sha256").update(body).digest("hex")}`,
+    digest: packetDigest(body),
   };
+}
+
+function packetDigest(body: string): `sha256:${string}` {
+  return `sha256:${createHash("sha256").update(body).digest("hex")}`;
 }
 
 /**
@@ -125,23 +133,13 @@ export function reviewQualificationFields(value: Record<string, unknown>): {
 }
 
 export function submissionPacket(action: RepoTaskAction, rootDir: string): GuiSubmissionV1 {
-  const fromFile = action.fromFile !== undefined,
-    jsonInput = action.jsonInput !== undefined;
-  if (action.submission !== undefined && (fromFile || jsonInput))
+  const hasPacketSource = action.fromFile !== undefined || action.jsonInput !== undefined;
+  if (action.submission !== undefined && hasPacketSource)
     throw cellCodedError(
       "invalid_command",
       "Submit accepts either its RPC submission or one CLI JSON source, not both.",
     );
-  if (action.submission === undefined && fromFile === jsonInput)
-    throw cellCodedError(
-      "invalid_command",
-      "Use exactly one submission source: --json-input <json> or workspace-local --from-file <path>.",
-    );
-  const value =
-      action.submission ??
-      (jsonInput
-        ? packetJson(action.jsonInput, taskSubmissionJsonFields)
-        : packetFile(rootDir, action.fromFile, taskSubmissionJsonFields).value),
+  const value = action.submission ?? packetRecord(rootDir, action, taskSubmissionJsonFields).value,
     issues = validateGuiSubmission(value);
   if (issues.length) throw cellCodedError("invalid_submission", issues.join("; "));
   return value as unknown as GuiSubmissionV1;

--- a/packages/daemon/src/schedule-action-runtime.ts
+++ b/packages/daemon/src/schedule-action-runtime.ts
@@ -395,7 +395,6 @@ function packetContract(required: readonly string[], allowed: readonly string[])
   return {
     required,
     allowed,
-    source: "from-file",
     invalid: (message) => Object.assign(new Error(message), { code: "invalid_command" }),
     messages: {
       parse: "Schedule input must be one UTF-8 JSON object; repair the JSON and retry",

--- a/packages/daemon/test/closeout-ci-judgment-contract.test.ts
+++ b/packages/daemon/test/closeout-ci-judgment-contract.test.ts
@@ -102,11 +102,10 @@ async function closeout(completionGateIds: readonly string[], ci: string, status
   writeFileSync(path.join(rootDir, fromFile), JSON.stringify(packet(ci)));
   try {
     const receipt = await runTaskCloseoutAction({
-      rootDir,
       action: { kind: "task-closeout", taskId, fromFile },
       caller: person,
       opId: "op-ci-judgment",
-      readWorkspaceText,
+      readPacket: () => readWorkspaceText(rootDir, fromFile, "fromFile"),
       read: async () => fixture(completionGateIds, status) as never,
       presetSnapshotCurrent: () => true,
       invoke: async (stage, action) => {

--- a/packages/daemon/test/hitrate-task-lifecycle.integration.test.ts
+++ b/packages/daemon/test/hitrate-task-lifecycle.integration.test.ts
@@ -164,10 +164,6 @@ test("task start, inline submit, and code-doc reconcile reuse daemon-known lifec
       reconciledAt: event.occurredAt,
     });
 
-    writeFileSync(
-      path.join(rootDir, "review.json"),
-      JSON.stringify({ verdict: "approved", reason: "Independent review passed.", evidenceChecked: ["tests"] }),
-    );
     const reviewer = withRoleBinding(
         {
           actor: {
@@ -183,7 +179,11 @@ test("task start, inline submit, and code-doc reconcile reuse daemon-known lifec
           kind: "task-review-execution",
           taskId,
           reviewId: "review-hitrate-lifecycle",
-          fromFile: "review.json",
+          jsonInput: JSON.stringify({
+            verdict: "approved",
+            reason: "Independent review passed.",
+            evidenceChecked: ["tests"],
+          }),
         },
         reviewer,
       );

--- a/packages/daemon/test/people-actions.integration.test.ts
+++ b/packages/daemon/test/people-actions.integration.test.ts
@@ -256,7 +256,7 @@ test("People Action commands create people.yaml through the null roster transiti
   }
 });
 
-test("People Action commands hydrate closed from-file packets inside the workspace", async () => {
+test("People Action commands hydrate closed file and inline packets", async () => {
   const root = mkdtempSync(path.join(tmpdir(), "ha-people-packets-"));
   let cell: Awaited<ReturnType<typeof openRepoCell>> | undefined;
   try {
@@ -278,12 +278,16 @@ test("People Action commands hydrate closed from-file packets inside the workspa
       }),
     );
     assert.equal((await cell.run({ kind: "people-add", fromFile: "people-add.json" }, binding)).outcome, "applied");
-    writeFileSync(
-      path.join(root, "people-role.json"),
-      JSON.stringify({ personId: "person_alice", role: "reviewer", commandClass: ["repo-read"] }),
-    );
     assert.equal(
-      (await cell.run({ kind: "people-set-role", fromFile: "people-role.json" }, binding)).outcome,
+      (
+        await cell.run(
+          {
+            kind: "people-set-role",
+            jsonInput: JSON.stringify({ personId: "person_alice", role: "reviewer", commandClass: ["repo-read"] }),
+          },
+          binding,
+        )
+      ).outcome,
       "applied",
     );
     writeFileSync(

--- a/packages/daemon/test/review-consent.integration.test.ts
+++ b/packages/daemon/test/review-consent.integration.test.ts
@@ -183,10 +183,6 @@ test("review-consent derives the recorded Review digests without a packet and st
     )) as unknown as Record<string, unknown>;
     const real = String(mismatchReviewed.reviewDigest),
       flipped = `sha256:${real[7] === "0" ? "1" : "0"}${real.slice(8)}`;
-    writeFileSync(
-      path.join(rootDir, "consent.json"),
-      JSON.stringify({ reviewDigest: flipped, contentDigest: mismatchReviewed.contentDigest }),
-    );
     const beforeMismatch = store().readHead()?.revision,
       mismatch = (await cell.run(
         {
@@ -195,7 +191,7 @@ test("review-consent derives the recorded Review digests without a packet and st
           executionId: mismatchExecutionId,
           reviewId: "review-mismatch",
           consentId: "consent-mismatch",
-          fromFile: "consent.json",
+          jsonInput: JSON.stringify({ reviewDigest: flipped, contentDigest: mismatchReviewed.contentDigest }),
         },
         binding,
       )) as unknown as Record<string, unknown>;

--- a/packages/daemon/test/schedule-actions.integration.test.ts
+++ b/packages/daemon/test/schedule-actions.integration.test.ts
@@ -361,8 +361,10 @@ test("run-now launches only after an applied claim, stays single-flight, and set
       );
       const updated = await cell.run({ kind: "schedule-update", fromFile: "schedule-update.json" }, actor);
       assert.equal(updated.outcome, "applied", JSON.stringify(updated));
-      writeFileSync(path.join(root, "schedule-show.json"), JSON.stringify({ scheduleId: "e2e-probe" }));
-      const shown = (await cell.run({ kind: "schedule-show", fromFile: "schedule-show.json" }, actor)) as unknown as {
+      const shown = (await cell.run(
+        { kind: "schedule-show", jsonInput: JSON.stringify({ scheduleId: "e2e-probe" }) },
+        actor,
+      )) as unknown as {
         readonly schedule: {
           readonly name: string;
           readonly spec: { readonly trigger: { readonly everyMs: number }; readonly mission: string };

--- a/packages/daemon/test/task-closeout-action.test.ts
+++ b/packages/daemon/test/task-closeout-action.test.ts
@@ -143,12 +143,11 @@ function setup(
     }> = [],
     run = () =>
       runTaskCloseoutAction({
-        rootDir,
         action: closeoutAction,
         caller: setupCaller,
         authorizationDecision: { ...authorizationDecision, actor: setupCaller },
         opId: "op-closeout",
-        readWorkspaceText,
+        readPacket: () => readWorkspaceText(rootDir, fromFile, "fromFile"),
         read: async () => initial as never,
         presetSnapshotCurrent: () => presetSnapshotCurrent,
         invoke: async (stage, action, stepActor) => {

--- a/packages/kernel/src/domain/task-action-contract.ts
+++ b/packages/kernel/src/domain/task-action-contract.ts
@@ -217,16 +217,26 @@ const taskActionDeclarations = Object.freeze([
     topology: "local-arbiter",
     coordination: "execute",
     targetIdField: "taskId",
-    input: actionInput([
-      taskIdInput,
-      expectedVersionInput,
-      cliField("executionId", "string", false, "--execution-id", "single"),
-      cliField("reviewId", "string", true, "--review-id", "single"),
-      cliField("fromFile", "string", true, "--from-file", "single", {
-        jsonFields: TASK_REVIEW_JSON_FIELDS,
-        jsonEnums: { verdict: REVIEW_V1_SCHEMA.verdicts },
-      }),
-    ]),
+    input: actionInput(
+      [
+        taskIdInput,
+        expectedVersionInput,
+        cliField("executionId", "string", false, "--execution-id", "single"),
+        cliField("reviewId", "string", true, "--review-id", "single"),
+        cliField("fromFile", "string", false, "--from-file", "single", {
+          jsonFields: TASK_REVIEW_JSON_FIELDS,
+          jsonEnums: { verdict: REVIEW_V1_SCHEMA.verdicts },
+          conflictsWith: ["--json-input"],
+        }),
+        cliField("jsonInput", "string", false, "--json-input", "single", {
+          jsonFields: TASK_REVIEW_JSON_FIELDS,
+          jsonEnums: { verdict: REVIEW_V1_SCHEMA.verdicts },
+          format: "<json|@->",
+          conflictsWith: ["--from-file"],
+        }),
+      ],
+      [["fromFile", "jsonInput"]],
+    ),
     policyAction: "task-review-execution",
     criteria: Object.freeze([
       {


### PR DESCRIPTION
# English

## Summary

Hit-rate item #4: every packet-taking command now takes one structured input in three forms — `--from-file <path>`, `--json-input <json>`, `--json-input @-` (stdin). Twelve commands that only had `--from-file` gain the inline and stdin forms: `task closeout`, `task review-execution`, `task review-consent`, the six `people` commands and `schedule show|update|delete`. The CLI has one `materializePacketStdin` (generalised from the decision-only stdin reader) and the daemon one `readPacketSource` for file-versus-inline selection; task submit, decision propose, review/consent, closeout, People and Schedule all use it, and the former per-command source-selection branches are deleted. After #2191 the shared flag reader enforces the descriptor's `conflictsWith`, so the two parser-local `--from-file`/`--json-input` checks the worker had added were deleted by the CEO as duplicates.

## Architectural Justification

Packet ingestion is normalised before the typed action crosses the daemon protocol; no new write authority, lease, queue or artifact is created. Only the CLI process can read its own stdin, so stdin materialisation stays in the CLI and the long-lived daemon never reads it. Multi-node: Schedule occurrence ownership stays fenced by the existing occurrence claim and `claimFence`; all writes still reach the center-owned RepoCell queue, so two edge nodes cannot produce a conflicting shared artifact because this change creates none.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none

## Machine-Readable Declarations

Production-Delta: +190/-116
Dependency-Change: none

### Optional Evidence Claims

none

## Task And Scope

task_7f289ab044a9cb9357a4220455 (child of task_b6439558, hit-rate pack). In-file removals: per-command file/inline selection in `repo-cell-action-parse.ts`, `repo-cell-packets.ts` (`packetFile` + `packetJson` folded into `packetRecord`), the decision-only stdin reader, and the two parser-local exclusivity checks in `thin-command-task.ts`. `--from-file` is retained as one of the three required forms, so it has no deletion date.

## Version Impact

None.

## Governance Declaration

No protected path touched. No break-glass.

## Verification

- Worker stop point (targeted tests + local commit, no `check:local`): `tsc -b` pass; targeted fast tests 43/43; Task Action contract/projection tests 6/6; Ubuntu isolated `task-closeout.integration.test.ts` 2/2 including real `@-` stdin, `people-actions.integration.test.ts` 6/6, `schedule-actions.integration.test.ts` 2/2 including the fleet Schedule claim path, `hitrate-task-lifecycle.integration.test.ts` 1/1, `review-consent.integration.test.ts` 1/1; cli-help-contract, cli-structure, import-boundaries, implementation-contracts, file-complexity and the generated Task Action protocol projection `--check` green. Stdin transcript: `ha --root <fixture> --json task closeout <id> --json-input @-` → `outcome=applied steps=review-execution,review-consent,complete task.status=done`.
- CEO: branch merged with `origin/main` `7d97f3b46` (#2191 descriptor relationships) before the PR; after deleting the duplicate checks the eight parser/contract test files pass 50/50, tsc and cli-structure green; the contract-parity tests assert bidirectional source conflicts for all 12 switched commands. First CI run: `closeout-ci-judgment-contract.test.ts` still built the closeout action with the retired `rootDir`/`readWorkspaceText` inputs and was not in the worker's targeted set; it now feeds the judgment through `readPacket` (7/7).
- CI is the full authority.

## Review Evidence

Worker report: `harness/tasks/task_7f289ab044a9cb9357a4220455-*/artifacts/reports/r1.md` (private ledger). CEO semantic review read the production diff: one daemon packet-source reader, one CLI stdin materialiser, descriptors switched from `from-file` to `from-file-or-json-input` with `exactlyOneOf`, no compatibility layer.

## Residual Risk

The shared canonical daemon runs the pre-change build until the CEO rebuilds and restarts it; until then `--json-input` on the twelve commands is rejected there as an unknown field.

---

# 中文

## 概要

命中率清单第 4 项:所有接 packet 的命令统一为一种结构化输入的三种形态——`--from-file <path>`、`--json-input <json>`、`--json-input @-`(stdin)。原先只有 `--from-file` 的十二条命令补齐内联与 stdin 形态:`task closeout`、`task review-execution`、`task review-consent`、六条 `people` 命令与 `schedule show|update|delete`。CLI 只有一个 `materializePacketStdin`(由原 decision 专用的 stdin 读取泛化而来),daemon 只有一个 `readPacketSource` 做文件/内联选择;task submit、decision propose、review/consent、closeout、People、Schedule 全走它,原各命令自己的来源选择分支删除。#2191 之后共享 flag 读取器按描述符执行 `conflictsWith`,worker 加的两处解析器本地 `--from-file`/`--json-input` 互斥检查由 CEO 当重复删除。

## 架构辩护

packet 摄入在类型化动作跨过 daemon 协议之前归一;不新建写权威、租约、队列或 artifact。只有 CLI 进程能读自己的 stdin,所以 stdin 物化留在 CLI,常驻 daemon 永不读它。多节点:Schedule occurrence 归属仍由既有 occurrence claim 与 `claimFence` 围栏;所有写入仍进中心所有的 RepoCell 队列,本变更不产生任何新的共享 artifact,两个边缘节点无从互相覆盖。

## 机读声明

见英文块。

## 治理声明

未触碰 protected 路径。无 break-glass。

## 验证

- worker 停止点(定向测试 + 本地 commit,不跑 `check:local`):`tsc -b` 过;定向 fast 43/43;Task Action 契约/投影 6/6;Ubuntu 隔离机 `task-closeout.integration.test.ts` 2/2(含真实 `@-` stdin)、`people-actions.integration.test.ts` 6/6、`schedule-actions.integration.test.ts` 2/2(含 fleet Schedule claim 路径)、`hitrate-task-lifecycle.integration.test.ts` 1/1、`review-consent.integration.test.ts` 1/1;cli-help-contract、cli-structure、import-boundaries、implementation-contracts、file-complexity 与生成的 Task Action 协议投影 `--check` 绿。stdin 实录:`ha --root <fixture> --json task closeout <id> --json-input @-` → `outcome=applied steps=review-execution,review-consent,complete task.status=done`。
- CEO:开 PR 前已与 `origin/main` `7d97f3b46`(#2191 描述符关系)合并;删掉重复检查后八个解析器/契约测试文件 50/50、tsc 与 cli-structure 绿;契约一致性测试对全部 12 条切换命令断言双向来源冲突。首轮 CI:`closeout-ci-judgment-contract.test.ts` 仍用已退役的 `rootDir`/`readWorkspaceText` 输入构造 closeout 动作且不在 worker 的定向集里;现改为经 `readPacket` 送判定包(7/7)。
- CI 是完整权威。

## 评审证据

worker 报告见任务包 `artifacts/reports/r1.md`(私有台账)。CEO 语义验收通读生产 diff:daemon 一个 packet 来源读取器、CLI 一个 stdin 物化器、描述符由 `from-file` 切到 `from-file-or-json-input` 并带 `exactlyOneOf`,无兼容层。

## 残余风险

共享 canonical daemon 在 CEO 重建并重启前仍跑旧构建;此前这十二条命令的 `--json-input` 在其上会被当未知字段拒绝。
