### PR TITLE
fix(daemon): carry squad synthesis report in leader convergence decision

### DIFF
--- a/packages/cli/test/squad-resident-leader.integration.test.ts
+++ b/packages/cli/test/squad-resident-leader.integration.test.ts
@@ -5,6 +5,7 @@ import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
+import { makeTaskEventStore } from "../../kernel/src/index.ts";
 import { writeProviderExecutable } from "../../daemon/test/fixtures/runtime-stub.ts";
 import { realizedTaskPlan as realizedPlan } from "../../../tools/fixtures/task-plan.mjs";
 
@@ -147,6 +148,17 @@ test("each worker outcome calls back into a new leader turn and a failed worker 
     assert.match(String(calls.find((call) => call.kind === "leader-initial")?.prompt), /Your task package is/u);
 
     run(root, env, ["daemon", "stop"]);
+    const synthesisBody = "# Squad synthesis\n\nWorker receipts verified.\n",
+      synthesisPath = `${residentPackage}/artifacts/reports/${String(started.squadRunId)}.md`,
+      synthesisEvent = makeTaskEventStore({ repoId: "squad-resident", rootDir: root })
+        .read()
+        .events.findLast(
+          (event) =>
+            event.schema === "doc-event/v1" && event.payload.changes.some((change) => change.path === synthesisPath),
+        );
+    assert.equal(readFileSync(path.join(root, "harness", synthesisPath), "utf8"), synthesisBody);
+    assert.equal(synthesisEvent?.schema, "doc-event/v1");
+    assert.equal(synthesisEvent?.actor.executor?.id, `runtime-session:${leaderRuntimeSessionIds.at(-1)}`);
     rmSync(path.join(root, ".harness", "cache", "task.sqlite"), { force: true });
     run(root, env, ["daemon", "start", "--service"]);
     const afterRestart = run(root, env, ["squad", "status", String(started.squadRunId)]);
@@ -658,9 +670,6 @@ function writeResidentProvider(target: string): void {
   writeProviderExecutable(
     target,
     `const fs = require("node:fs");
-const childProcess = require("node:child_process");
-const path = require("node:path");
-const cli = ${JSON.stringify(cli)};
 const args = process.argv.slice(2);
 if (args[0] === "--version") {
   console.log("codex resident-test");
@@ -678,19 +687,6 @@ const luna = prompt.includes("# Agent Identity: Luna (luna)");
 const retry = terra && prompt.includes("Terra retry mission");
 const rows = prompt.match(/^worker /gmu) || [];
 const workerRunning = /^worker .*status=running/mu.test(prompt);
-const writeSynthesisReport = () => {
-  const taskPackage = /Your task package is ([^\\n]+)\\./u.exec(prompt)?.[1];
-  const reportPath = /Before declaring convergence, write and submit the synthesis report to ([A-Za-z0-9/_.-]+\\.md)\\./u.exec(prompt)?.[1];
-  const taskId = /ha task artifact add ([A-Za-z0-9._-]+) /u.exec(prompt)?.[1];
-  if (!taskPackage || !reportPath || !taskId) throw new Error("synthesis report contract missing from leader prompt");
-  const root = path.resolve(taskPackage, "../../..");
-  const source = path.join(root, ".harness", "squad-synthesis-" + process.pid + "-" + Date.now() + ".md");
-  fs.mkdirSync(path.dirname(source), { recursive: true });
-  fs.writeFileSync(source, "# Squad synthesis\\n\\nWorker receipts verified.\\n");
-  const synced = childProcess.spawnSync(process.execPath, [cli, "--root", root, "--json", "task", "artifact", "add", taskId, "--source", path.relative(root, source), "--destination", reportPath.replace(/^artifacts\\//u, "")], { encoding: "utf8", env: process.env });
-  const receipt = synced.stdout.trim() ? JSON.parse(synced.stdout) : null;
-  if (synced.status !== 0 || receipt?.outcome !== "applied") throw new Error("synthesis report sync failed: " + synced.stderr + synced.stdout);
-};
 fs.appendFileSync(
   process.env.CODEX_HOME + "/provider.jsonl",
   JSON.stringify({
@@ -751,7 +747,6 @@ if (initialLeader) {
     },
   });
 } else if (callbackLeader) {
-  writeSynthesisReport();
   frame({
     type: "item.completed",
     item: {
@@ -759,6 +754,7 @@ if (initialLeader) {
       text: JSON.stringify({
         schema: "squad-decision/v1",
         action: "converged",
+        report: "# Squad synthesis\\n\\nWorker receipts verified.\\n",
       }),
     },
   });
@@ -789,9 +785,6 @@ function writeApiKeyProvider(target: string): void {
   writeProviderExecutable(
     target,
     `const fs = require("node:fs");
-const childProcess = require("node:child_process");
-const path = require("node:path");
-const cli = ${JSON.stringify(cli)};
 const args = process.argv.slice(2);
 if (args[0] === "--version") { console.log("codex api-key-test"); process.exit(0); }
 const prompt = fs.readFileSync(0, "utf8");
@@ -805,19 +798,6 @@ const callback = prompt.includes("# Squad worker callback") || prompt.includes("
 const leader = prompt.includes("# Squad dispatch protocol") || callback;
 const terra = prompt.includes("# Agent Identity: Terra (terra)");
 const luna = prompt.includes("# Agent Identity: Luna (luna)");
-const writeSynthesisReport = () => {
-  const taskPackage = /Your task package is ([^\\n]+)\\./u.exec(prompt)?.[1];
-  const reportPath = /Before declaring convergence, write and submit the synthesis report to ([A-Za-z0-9/_.-]+\\.md)\\./u.exec(prompt)?.[1];
-  const taskId = /ha task artifact add ([A-Za-z0-9._-]+) /u.exec(prompt)?.[1];
-  if (!taskPackage || !reportPath || !taskId) throw new Error("synthesis report contract missing from leader prompt");
-  const root = path.resolve(taskPackage, "../../..");
-  const source = path.join(root, ".harness", "squad-synthesis-" + process.pid + "-" + Date.now() + ".md");
-  fs.mkdirSync(path.dirname(source), { recursive: true });
-  fs.writeFileSync(source, "# Squad synthesis\\n\\nWorker receipts verified.\\n");
-  const synced = childProcess.spawnSync(process.execPath, [cli, "--root", root, "--json", "task", "artifact", "add", taskId, "--source", path.relative(root, source), "--destination", reportPath.replace(/^artifacts\\//u, "")], { encoding: "utf8", env: process.env });
-  const receipt = synced.stdout.trim() ? JSON.parse(synced.stdout) : null;
-  if (synced.status !== 0 || receipt?.outcome !== "applied") throw new Error("synthesis report sync failed: " + synced.stderr + synced.stdout);
-};
 frame({ type: "thread.started", thread_id: leader ? "leader-api-session" : terra ? "terra-api-session" : "luna-api-session" });
 if (prompt.includes("# Squad dispatch protocol")) {
   frame({ type: "item.completed", item: { type: "agent_message", text: JSON.stringify({ schema: "runtime-batch/v1", dispatches: [{ to: "terra", prompt: "terra API mission" }, { to: "luna", prompt: "luna API mission" }] }) } });
@@ -826,8 +806,7 @@ if (prompt.includes("# Squad dispatch protocol")) {
   if (running) {
     frame({ type: "item.completed", item: { type: "agent_message", text: JSON.stringify({ schema: "squad-decision/v1", action: "waiting" }) } });
   } else {
-    writeSynthesisReport();
-    frame({ type: "item.completed", item: { type: "agent_message", text: JSON.stringify({ schema: "squad-decision/v1", action: "converged" }) } });
+    frame({ type: "item.completed", item: { type: "agent_message", text: JSON.stringify({ schema: "squad-decision/v1", action: "converged", report: "# Squad synthesis\\n\\nWorker receipts verified.\\n" }) } });
   }
 } else {
   frame({ type: "item.completed", item: { type: "agent_message", text: "worker output" } });

--- a/packages/daemon/src/doc-sync-actions.ts
+++ b/packages/daemon/src/doc-sync-actions.ts
@@ -1,6 +1,12 @@
 export { adjudicateDocIntent } from "./doc-sync-adjudication.ts";
 export type { DocIntentAdjudication, DocIntentChannel } from "./doc-sync-adjudication.ts";
-export { DOC_COMMAND_FRAME_MAX_BYTES, isDocAction, runArtifactAdd, runDocAction } from "./doc-sync-command-actions.ts";
+export {
+  DOC_COMMAND_FRAME_MAX_BYTES,
+  isDocAction,
+  publishTaskArtifact,
+  runArtifactAdd,
+  runDocAction,
+} from "./doc-sync-command-actions.ts";
 export type { ArtifactAddReceipt, DocSettlementReceipt } from "./doc-sync-command-actions.ts";
 export { claimBytes, recycleClaims } from "./doc-sync-details.ts";
 export { rejectDocSyncAction } from "./doc-sync-files.ts";

--- a/packages/daemon/src/doc-sync-command-actions.ts
+++ b/packages/daemon/src/doc-sync-command-actions.ts
@@ -263,6 +263,31 @@ export function runArtifactAdd(input: Input): ArtifactAddReceipt {
     destinationValue = requiredDocSyncText(input.action.destination, "destination");
   if (!hasExactDocSyncActionFields(input.action, ["kind", "taskId", "source", "destination"]))
     throw docSyncError("invalid_command", "task artifact add requires taskId, source, and destination");
+  const target = taskArtifactTarget(input, taskId, destinationValue),
+    source = artifactSource(input, sourceValue),
+    receipt = publishTaskArtifactBytes(input, target, readFileSync(source.absolute));
+  return receipt.outcome === "applied" || receipt.outcome === "pending"
+    ? { ...receipt, source: source.relative, destination: target.destination }
+    : receipt;
+}
+
+export function publishTaskArtifact(
+  input: Omit<Input, "action">,
+  artifact: {
+    readonly taskId: string;
+    readonly destination: string;
+    readonly bytes: Uint8Array;
+  },
+): ArtifactAddReceipt {
+  const taskId = requiredDocSyncText(artifact.taskId, "taskId"),
+    destinationValue = requiredDocSyncText(artifact.destination, "destination"),
+    action = { kind: "task-artifact-add", taskId },
+    publicationInput: Input = { ...input, action },
+    target = taskArtifactTarget(publicationInput, taskId, destinationValue);
+  return publishTaskArtifactBytes(publicationInput, target, artifact.bytes);
+}
+
+function taskArtifactTarget(input: Input, taskId: string, destinationValue: string) {
   const task = input.projection.read(taskId);
   if (task.watermark !== task.sourceRevision || !task.packagePath || !task.snapshot.task)
     throw docSyncError("content_not_ready", `Task ${taskId} is not ready for artifact add`);
@@ -290,23 +315,39 @@ export function runArtifactAdd(input: Input): ArtifactAddReceipt {
     );
   const layout = resolveHarnessLayout(input.rootDir),
     ledger = resolveLedgerGitLayout(input.rootDir),
-    source = artifactSource(input, sourceValue),
     authoredTarget = path.join(layout.authoredRoot, ...destination.split("/")),
     gitTarget = ledgerGitPath(ledger, destination),
     projected = input.projection.readDocument(destination),
     tracked = gitTracked(ledger.rootDir, gitTarget);
+  return {
+    taskId,
+    destination,
+    classification,
+    authoredTarget,
+    gitTarget,
+    ledgerRootDir: ledger.rootDir,
+    projected,
+    tracked,
+  };
+}
+
+function publishTaskArtifactBytes(
+  input: Input,
+  target: ReturnType<typeof taskArtifactTarget>,
+  bytes: Uint8Array,
+): ArtifactAddReceipt {
+  const { taskId, destination, classification, authoredTarget, gitTarget, ledgerRootDir, projected, tracked } = target;
   const projectedEdit =
     projected.document !== null &&
     existsSync(authoredTarget) &&
     sha256Bytes(readFileSync(authoredTarget)) !== projected.document.blobSha256;
-  if (projectedEdit || (tracked && gitModified(ledger.rootDir, gitTarget)))
+  if (projectedEdit || (tracked && gitModified(ledgerRootDir, gitTarget)))
     throw docSyncError(
       "artifact_tracked_edit",
       `destination is a tracked edit; use ha doc sync --submit --path ${destination}`,
     );
   if (tracked || existsSync(authoredTarget) || projected.document !== null) {
-    const bytes = readFileSync(source.absolute),
-      sha = sha256Bytes(bytes),
+    const sha = sha256Bytes(bytes),
       replay =
         existsSync(authoredTarget) &&
         projected.document?.blobSha256 === sha &&
@@ -321,7 +362,7 @@ export function runArtifactAdd(input: Input): ArtifactAddReceipt {
                   ),
               )
           : undefined;
-    if (replay && isDocEvent(replay)) return { ...readDocReceipt(input, replay), source: source.relative, destination };
+    if (replay && isDocEvent(replay)) return { ...readDocReceipt(input, replay), destination };
     throw docSyncError("artifact_collision", `artifact destination already exists: ${destination}`);
   }
   if (projected.watermark !== projected.sourceRevision)
@@ -331,7 +372,6 @@ export function runArtifactAdd(input: Input): ArtifactAddReceipt {
       code: "projection_pending",
       origin: "N/A",
     };
-  const bytes = readFileSync(source.absolute);
   try {
     new TextDecoder("utf-8", { fatal: true }).decode(bytes);
   } catch {
@@ -362,7 +402,5 @@ export function runArtifactAdd(input: Input): ArtifactAddReceipt {
       input.workspaceId,
     ),
     receipt = publishDocIntent(input, intent, [bytes], lease);
-  return receipt.outcome === "applied" || receipt.outcome === "pending"
-    ? { ...receipt, source: source.relative, destination }
-    : receipt;
+  return receipt.outcome === "applied" || receipt.outcome === "pending" ? { ...receipt, destination } : receipt;
 }

--- a/packages/daemon/src/repo-cell-open.ts
+++ b/packages/daemon/src/repo-cell-open.ts
@@ -37,6 +37,7 @@ import {
 } from "./repo-cell-action-context.ts";
 import { createRepoCellApi } from "./repo-cell-api.ts";
 import { dispatchRead } from "./repo-cell-command.ts";
+import { publishTaskArtifact } from "./doc-sync-actions.ts";
 import {
   cellCodedError,
   cellCriterionError,
@@ -552,6 +553,31 @@ export async function openRepoWriterCell(
           return extracted.lifecycleAction(action, { ...binding, authorizationDecision });
         },
       });
+    },
+    publishSynthesisReport: async (report, binding) => {
+      const action = { kind: "task-artifact-add", taskId: report.taskId },
+        authorizedBinding = authorizeRuntimeAction(action, binding, `squad-synthesis-report:${report.squadRunId}`),
+        receipt = publishTaskArtifact(
+          {
+            binding: authorizedBinding,
+            workspaceId: input.repoId,
+            rootDir,
+            store,
+            projection,
+            now,
+            killpoint: input.killpoint,
+          },
+          {
+            taskId: report.taskId,
+            destination: report.reportPath,
+            bytes: Buffer.from(report.body),
+          },
+        );
+      if (receipt.outcome !== "applied" && receipt.outcome !== "pending")
+        throw cellCodedError(
+          receipt.code ?? "squad_report_publication_failed",
+          `Squad synthesis report was ${receipt.outcome}.`,
+        );
     },
     runtimeSpawner: () => ({
       spawn: (payload, binding) => {

--- a/packages/daemon/src/repo-cell-proxy.ts
+++ b/packages/daemon/src/repo-cell-proxy.ts
@@ -167,6 +167,7 @@ export async function openRepoCellProxy(
         projection: () => writableProjection,
         store: () => readStore,
         reacquireTaskLease: unsupportedWrite,
+        publishSynthesisReport: unsupportedWrite,
         runtimeSpawner: () => ({ spawn: unsupportedWrite, cancel: unsupportedWrite }),
       }),
       runtimeReads = makeAgentRuntimeReadModel({

--- a/packages/daemon/src/squad-coordinator.ts
+++ b/packages/daemon/src/squad-coordinator.ts
@@ -85,6 +85,16 @@ export function makeSquadCoordinator(input: {
   readonly projection: () => TaskProjection;
   readonly store: () => CanonicalEventStore;
   readonly reacquireTaskLease: (taskId: string, binding: RuntimeBinding) => Promise<void>;
+  readonly publishSynthesisReport: (
+    report: {
+      readonly taskId: string;
+      readonly squadRunId: string;
+      readonly reportPath: string;
+      readonly body: string;
+      readonly leaderRuntimeSessionId: string;
+    },
+    binding: RuntimeBinding,
+  ) => Promise<void>;
   readonly runtimeSpawner: () => {
     readonly spawn: (payload: JsonObject, binding: RuntimeBinding) => Promise<JsonObject>;
     readonly cancel: (payload: JsonObject, binding: RuntimeBinding) => Promise<JsonObject>;
@@ -461,9 +471,34 @@ export function makeSquadCoordinator(input: {
     }
     const running = hasRunningWorkers(updated);
     if (decision.kind === "converged") {
-      const error = running
+      let error = running
         ? "Leader declared convergence while worker dispatches were still running."
-        : convergenceError(updated);
+        : convergenceError(updated, decision);
+      if (error === null) {
+        try {
+          await input.reacquireTaskLease(updated.taskId, updated.binding);
+          const leaderBinding: RuntimeBinding = {
+            ...updated.binding,
+            actor: {
+              principal: updated.binding.actor.principal,
+              executor: { kind: "agent", id: `runtime-session:${runtimeSessionId}` },
+            },
+          };
+          await input.publishSynthesisReport(
+            {
+              taskId: updated.taskId,
+              squadRunId: updated.squadRunId,
+              reportPath: synthesisReportPath(updated)!,
+              body: decision.report!,
+              leaderRuntimeSessionId: runtimeSessionId,
+            },
+            leaderBinding,
+          );
+        } catch (cause) {
+          consumeKnownError(cause);
+          error = `Leader synthesis report publication failed: ${errorText(cause)}`;
+        }
+      }
       writeState(
         revise(updated, {
           phase: error ? "failed" : "converged",
@@ -669,51 +704,19 @@ export function makeSquadCoordinator(input: {
     return workerRows(state).some(({ attempt, row }) => attempt.rejection === null && (!row || row.outcome === null));
   }
 
-  function convergenceError(state: SquadState): string | null {
+  function convergenceError(
+    state: SquadState,
+    decision: Extract<LeaderDecision, { readonly kind: "converged" }>,
+  ): string | null {
     const missing: string[] = [];
     if (!workerRows(state).some(({ attempt, row }) => attempt.rejection === null && row?.outcome !== null))
       missing.push("a terminal worker dispatch");
     const reportPath = synthesisReportPath(state);
     if (reportPath === null) missing.push("a roster-declared synthesis report path");
-    else if (!leaderAuthoredSynthesisReport(state, reportPath))
-      missing.push(`leader-authored synthesis report ${reportPath}`);
+    if (decision.report !== null && decision.report.trim().length > 0)
+      return missing.length ? `Leader declared convergence without ${missing.join(" and ")}.` : null;
+    missing.push("a non-empty synthesis report");
     return missing.length ? `Leader declared convergence without ${missing.join(" and ")}.` : null;
-  }
-
-  function leaderAuthoredSynthesisReport(state: SquadState, reportPath: string): boolean {
-    const packagePath = dispatchRows(state)
-      .map((row) => row.dispatchPath)
-      .find((candidate): candidate is string => typeof candidate === "string")
-      ?.split("/artifacts/dispatches/", 1)[0];
-    if (!packagePath) return false;
-    const logicalPath = `${packagePath}/${reportPath}`,
-      store = input.store(),
-      events = store.read().events,
-      currentEvent = events.findLast(
-        (candidate) =>
-          candidate.schema === "doc-event/v1" &&
-          candidate.type === "documents_written" &&
-          candidate.payload.changes.some((change) => change.path === logicalPath),
-      );
-    if (!currentEvent || currentEvent.schema !== "doc-event/v1") return false;
-    const current = currentEvent.payload.changes.find((candidate) => candidate.path === logicalPath);
-    if (!current?.candidate) return false;
-    const bytes = store.readContentBlob(current.candidate.sha256),
-      leaderExecutors = new Set(state.leaderTurns.map((turn) => `runtime-session:${turn.runtimeSessionId}`));
-    return (
-      bytes !== null &&
-      new TextDecoder().decode(bytes).trim().length > 0 &&
-      events.some(
-        (event) =>
-          event.schema === "doc-event/v1" &&
-          event.type === "documents_written" &&
-          event.actor.executor?.kind === "agent" &&
-          leaderExecutors.has(event.actor.executor.id) &&
-          event.payload.changes.some(
-            (change) => change.path === logicalPath && change.candidate?.sha256 === current.candidate?.sha256,
-          ),
-      )
-    );
   }
 
   function workerRows(state: SquadState): readonly {

--- a/packages/daemon/src/squad-leader-decision.ts
+++ b/packages/daemon/src/squad-leader-decision.ts
@@ -1,7 +1,7 @@
 import type { TaskDispatchRow } from "./protocol/daemon-protocol.contract.ts";
 
 export type LeaderDecision =
-  | { readonly kind: "converged" }
+  | { readonly kind: "converged"; readonly report: string | null }
   | { readonly kind: "waiting" }
   | {
       readonly kind: "plan";
@@ -14,7 +14,8 @@ export function squadDecisionFromValue(value: unknown): SquadDecision | null {
   if (!value || typeof value !== "object" || Array.isArray(value)) return null;
   const row = value as Record<string, unknown>;
   if (row.schema !== "squad-decision/v1") return null;
-  if (row.action === "converged") return { kind: "converged" };
+  if (row.action === "converged")
+    return { kind: "converged", report: typeof row.report === "string" ? row.report : null };
   if (row.action === "waiting") return { kind: "waiting" };
   return null;
 }
@@ -124,7 +125,8 @@ export function callbackLeaderPrompt(
       "Return runtime-batch/v1 to reassign or add work. " +
       "Every runtime-batch/v1 must contain at least one dispatch. " +
       'Return {"schema":"squad-decision/v1","action":"waiting"} while another worker is running. ' +
-      'Return {"schema":"squad-decision/v1","action":"converged"} only when no worker is running. ' +
+      'Return {"schema":"squad-decision/v1","action":"converged","report":"<non-empty Markdown synthesis>"} ' +
+      "only when no worker is running. " +
       "Return exactly one JSON object and no Markdown.",
     synthesisReportInstruction(state),
     ...statusRows,
@@ -185,11 +187,8 @@ function synthesisReportInstruction(state: LeaderPromptState): string {
   const reportPath = synthesisReportPath(state);
   return reportPath === null
     ? "The squad roster does not declare exactly one synthesis report under artifacts/reports; convergence will fail."
-    : [
-        `Before declaring convergence, write and submit the synthesis report to ${reportPath}.`,
-        `Publish it from an untracked source with ha task artifact add ${state.taskId} --source <source.md> ` +
-          `--destination ${reportPath.slice("artifacts/".length)}.`,
-      ].join(" ");
+    : `Put the complete, non-empty Markdown synthesis in the converged decision's report field. ` +
+        `Harness publishes that field to ${reportPath}; do not write or submit a report file yourself.`;
 }
 
 export function synthesisReportPath(state: { readonly roster: string; readonly squadRunId: string }): string | null {

--- a/packages/daemon/test/dispatch-parent-session.integration.test.ts
+++ b/packages/daemon/test/dispatch-parent-session.integration.test.ts
@@ -365,7 +365,11 @@ function fakeProcess(pid: number, behavior: "success" | "converged" | "failed-co
               id: "message",
               type: "agent_message",
               text: behavior.includes("converged")
-                ? JSON.stringify({ schema: "squad-decision/v1", action: "converged" })
+                ? JSON.stringify({
+                    schema: "squad-decision/v1",
+                    action: "converged",
+                    report: "# Parent session synthesis\n\nWorker result verified.\n",
+                  })
                 : "done",
             },
           },

--- a/packages/daemon/test/runtime-spawn-settlement.test.ts
+++ b/packages/daemon/test/runtime-spawn-settlement.test.ts
@@ -27,7 +27,7 @@ test("a write-capable squad leader converged decision settles as succeeded witho
     active({
       squadId: "core-squad",
       delegatedBy: null,
-      finalText: JSON.stringify({ schema: "squad-decision/v1", action: "converged" }),
+      finalText: JSON.stringify({ schema: "squad-decision/v1", action: "converged", report: "# Synthesis" }),
       writeItemObserved: false,
       planObserved: false,
     }),
@@ -41,7 +41,7 @@ test("a non-zero squad leader exit is failed even when its final text declares c
     active({
       squadId: "core-squad",
       delegatedBy: null,
-      finalText: JSON.stringify({ schema: "squad-decision/v1", action: "converged" }),
+      finalText: JSON.stringify({ schema: "squad-decision/v1", action: "converged", report: "# Synthesis" }),
       writeItemObserved: false,
       planObserved: false,
     }),

--- a/packages/daemon/test/squad-coordinator-recovery.test.ts
+++ b/packages/daemon/test/squad-coordinator-recovery.test.ts
@@ -20,6 +20,7 @@ const SQUAD_RUN_ID = "squad_0123456789abcdef01234567",
   LEADER_DISPATCH_ID = "dispatch_000000000000000000000001",
   LEADER_SESSION_ID = "runtime-leader-1",
   SYNTHESIS_REPORT_PATH = `artifacts/reports/${SQUAD_RUN_ID}.md`,
+  SYNTHESIS_BODY = "# Squad synthesis\n\nVerified worker outcomes.",
   RESULT_SHA = "1".repeat(64),
   RESULT_REF = `artifact:runtime-result/sha256/${RESULT_SHA}`;
 
@@ -34,6 +35,16 @@ type RecoveryFixture = {
   readonly coordinator: ReturnType<typeof makeSquadCoordinator>;
   readonly spawns: JsonObject[];
   readonly cancellations: JsonObject[];
+  readonly publications: Array<{
+    readonly report: {
+      readonly taskId: string;
+      readonly squadRunId: string;
+      readonly reportPath: string;
+      readonly body: string;
+      readonly leaderRuntimeSessionId: string;
+    };
+    readonly binding: unknown;
+  }>;
   readonly reacquired: () => number;
   readonly state: () => Readonly<Record<string, unknown>>;
   readonly resetProjection: () => void;
@@ -51,8 +62,6 @@ function makeRecoveryFixture(
     readonly currentLeaderRuntimeSessionId?: string | null;
     readonly pendingLeaderTriggers?: readonly Readonly<Record<string, unknown>>[];
     readonly rejectWorkerOnce?: string;
-    readonly leaderReport?: boolean;
-    readonly mirrorLeaderReport?: boolean;
     readonly observedWorkerRuntimeSessionIds?: readonly string[];
   },
 ): RecoveryFixture {
@@ -75,74 +84,14 @@ function makeRecoveryFixture(
     rows: { squadRunId: string; revision: number; state: Readonly<Record<string, unknown>> }[] = [],
     spawns: JsonObject[] = [],
     cancellations: JsonObject[] = [],
-    resultBodies = new Map<string, Uint8Array>(),
-    reportLogicalPath = `tasks/${TASK_ID}/${SYNTHESIS_REPORT_PATH}`,
-    reportDocument = options.leaderReport
-      ? {
-          path: reportLogicalPath,
-          blobSha256: "a".repeat(64),
-          body: "# Squad synthesis\n\nVerified worker outcomes.",
-          size: 44,
-          mediaType: "text/markdown",
-          policyId: "markdown-body-replaceable/v1",
-          workspaceRevision: 2,
-        }
-      : null,
-    reportEvent = options.leaderReport
-      ? {
-          schema: "doc-event/v1",
-          eventId: "event-squad-synthesis",
-          workspaceRevision: 2,
-          opId: "op-squad-synthesis",
-          type: "documents_written",
-          actor: {
-            principal: { personId: "person-squad" },
-            executor: { kind: "agent", id: `runtime-session:${LEADER_SESSION_ID}` },
-          },
-          source: "local",
-          occurredAt: "2026-08-27T00:00:30.000Z",
-          payload: {
-            executionId: "execution-squad",
-            baseLedgerSha: { repoId: "squad-recovery", revision: 1, headDigest: `sha256:${"b".repeat(64)}` },
-            changes: [
-              {
-                path: reportLogicalPath,
-                baseBlobSha256: null,
-                candidate: {
-                  sha256: reportDocument!.blobSha256,
-                  size: reportDocument!.size,
-                  mediaType: "text/markdown",
-                },
-                policyId: reportDocument!.policyId,
-                regionProofs: [],
-              },
-            ],
-          },
-        }
-      : null;
-  const mirrorReportEvent =
-      options.mirrorLeaderReport && reportEvent
-        ? {
-            ...reportEvent,
-            eventId: "event-squad-synthesis-mirror",
-            workspaceRevision: 3,
-            opId: "op-squad-synthesis-mirror",
-            actor: {
-              principal: { personId: "person-squad" },
-              executor: { kind: "agent" as const, id: "runtime-session:unrelated-observer" },
-            },
-          }
-        : null,
-    reportEvents = [reportEvent, mirrorReportEvent].filter((event) => event !== null);
+    publications: RecoveryFixture["publications"] = [],
+    resultBodies = new Map<string, Uint8Array>();
   let reacquired = 0,
     nextSpawn = 0,
     nextResult = 2,
     rejectedWorker = false;
 
   if (options.leaderResult !== undefined) resultBodies.set(RESULT_SHA, new TextEncoder().encode(options.leaderResult));
-  if (reportDocument !== null)
-    resultBodies.set(reportDocument.blobSha256, new TextEncoder().encode(reportDocument.body));
-
   for (const [runtimeSessionId, dispatchId] of dispatchBySession)
     openDispatchStream(rootDir, {
       dispatchId,
@@ -247,8 +196,8 @@ function makeRecoveryFixture(
     store = {
       read: () => ({
         schema: "canonical-event-stream/v1",
-        revision: reportEvents.at(-1)?.workspaceRevision ?? 0,
-        events: reportEvents,
+        revision: 0,
+        events: [],
       }),
       readContentBlob: (sha256: string) => resultBodies.get(sha256) ?? null,
     } as CanonicalEventStore;
@@ -259,6 +208,10 @@ function makeRecoveryFixture(
       store: () => store,
       reacquireTaskLease: () => {
         reacquired += 1;
+        return Promise.resolve();
+      },
+      publishSynthesisReport: (report, binding) => {
+        publications.push({ report, binding });
         return Promise.resolve();
       },
       runtimeSpawner: () => ({
@@ -295,6 +248,7 @@ function makeRecoveryFixture(
     }),
     spawns,
     cancellations,
+    publications,
     reacquired: () => reacquired,
     state: () => {
       const state = rows.find((row) => row.squadRunId === SQUAD_RUN_ID)?.state;
@@ -424,9 +378,8 @@ test("convergence fails when no worker dispatch reached a terminal state", async
   await withRootDir(async (rootDir) => {
     const fixture = makeRecoveryFixture(rootDir, {
       leaderOutcome: "succeeded",
-      leaderResult: JSON.stringify({ schema: "squad-decision/v1", action: "converged" }),
+      leaderResult: JSON.stringify({ schema: "squad-decision/v1", action: "converged", report: SYNTHESIS_BODY }),
       leaderTurnBudget: 3,
-      leaderReport: true,
     });
     await fixture.coordinator.observeOutcome(outcomeEvent(LEADER_SESSION_ID));
 
@@ -436,7 +389,7 @@ test("convergence fails when no worker dispatch reached a terminal state", async
   });
 });
 
-test("convergence fails when the leader did not author the roster-declared synthesis report", async () => {
+test("convergence fails when the leader decision has no synthesis report", async () => {
   await withRootDir(async (rootDir) => {
     const fixture = makeRecoveryFixture(rootDir, {
       leaderOutcome: "succeeded",
@@ -456,21 +409,17 @@ test("convergence fails when the leader did not author the roster-declared synth
 
     const status = fixture.coordinator.status(SQUAD_RUN_ID);
     assert.equal(status.status, "failed");
-    assert.equal(
-      status.error,
-      `Leader declared convergence without leader-authored synthesis report ${SYNTHESIS_REPORT_PATH}.`,
-    );
+    assert.equal(status.error, "Leader declared convergence without a non-empty synthesis report.");
+    assert.equal(fixture.publications.length, 0);
   });
 });
 
-test("convergence preserves leader authorship when a later observer mirrors the current report blob", async () => {
+test("convergence publishes the decision report for the terminal leader runtime session", async () => {
   await withRootDir(async (rootDir) => {
     const fixture = makeRecoveryFixture(rootDir, {
       leaderOutcome: "succeeded",
-      leaderResult: JSON.stringify({ schema: "squad-decision/v1", action: "converged" }),
+      leaderResult: JSON.stringify({ schema: "squad-decision/v1", action: "converged", report: SYNTHESIS_BODY }),
       leaderTurnBudget: 3,
-      leaderReport: true,
-      mirrorLeaderReport: true,
       workers: [
         {
           workerId: "sol",
@@ -486,6 +435,24 @@ test("convergence preserves leader authorship when a later observer mirrors the 
     const status = fixture.coordinator.status(SQUAD_RUN_ID);
     assert.equal(status.status, "converged", String(status.error));
     assert.equal(status.error, null);
+    assert.deepEqual(fixture.publications, [
+      {
+        report: {
+          taskId: TASK_ID,
+          squadRunId: SQUAD_RUN_ID,
+          reportPath: SYNTHESIS_REPORT_PATH,
+          body: SYNTHESIS_BODY,
+          leaderRuntimeSessionId: LEADER_SESSION_ID,
+        },
+        binding: {
+          actor: {
+            principal: { personId: "person-squad" },
+            executor: { kind: "agent", id: `runtime-session:${LEADER_SESSION_ID}` },
+          },
+          source: "local",
+        },
+      },
+    ]);
   });
 });
 
@@ -634,7 +601,6 @@ test("one callback turn drains more worker outcomes than the leader turn budget"
         leaderOutcome: null,
         leaderTurnBudget: 3,
         workers,
-        leaderReport: true,
       });
 
     for (const worker of workers) {
@@ -662,7 +628,10 @@ test("one callback turn drains more worker outcomes than the leader turn budget"
       );
 
     const callbackSessionId = String(status.currentLeaderRuntimeSessionId);
-    fixture.completeLeader(callbackSessionId, JSON.stringify({ schema: "squad-decision/v1", action: "converged" }));
+    fixture.completeLeader(
+      callbackSessionId,
+      JSON.stringify({ schema: "squad-decision/v1", action: "converged", report: SYNTHESIS_BODY }),
+    );
     await fixture.coordinator.observeOutcome(outcomeEvent(callbackSessionId));
 
     status = fixture.coordinator.status(SQUAD_RUN_ID);
@@ -693,7 +662,6 @@ test("a leader retry remains primary while coalescing queued worker outcomes", a
         leaderResult: "not json",
         leaderTurnBudget: 3,
         workers,
-        leaderReport: true,
       });
     for (const worker of workers) {
       fixture.completeWorker(worker.runtimeSessionId);
@@ -719,7 +687,10 @@ test("a leader retry remains primary while coalescing queued worker outcomes", a
     assert.match(String(fixture.spawns[0]?.prompt), /Previous turn could not advance: Leader result was not JSON\./u);
 
     const retrySessionId = String(status.currentLeaderRuntimeSessionId);
-    fixture.completeLeader(retrySessionId, JSON.stringify({ schema: "squad-decision/v1", action: "converged" }));
+    fixture.completeLeader(
+      retrySessionId,
+      JSON.stringify({ schema: "squad-decision/v1", action: "converged", report: SYNTHESIS_BODY }),
+    );
     await fixture.coordinator.observeOutcome(outcomeEvent(retrySessionId));
     status = fixture.coordinator.status(SQUAD_RUN_ID);
     assert.equal(status.status, "converged", String(status.error));

--- a/packages/daemon/test/squad-coordinator.test.ts
+++ b/packages/daemon/test/squad-coordinator.test.ts
@@ -94,6 +94,8 @@ test("runtime-batch leaves worker instance selection to the harness", () => {
     );
 
   assert.doesNotMatch(prompt, /"instance"/u);
+  assert.match(prompt, /converged decision's report field/u);
+  assert.doesNotMatch(prompt, /task artifact add|untracked source/u);
   assert.deepEqual(decision, {
     kind: "plan",
     dispatches: [{ workerId: "terra", prompt: "Review it." }],
@@ -108,5 +110,19 @@ test("runtime-batch leaves worker instance selection to the harness", () => {
         ["terra"],
       ),
     /Leader dispatch contains harness-owned fields\./u,
+  );
+});
+
+test("converged decisions carry the synthesis report while missing content remains a convergence error", () => {
+  assert.deepEqual(
+    parseLeaderDecision(
+      JSON.stringify({ schema: "squad-decision/v1", action: "converged", report: "# Synthesis\n\nDone." }),
+      ["terra"],
+    ),
+    { kind: "converged", report: "# Synthesis\n\nDone." },
+  );
+  assert.deepEqual(
+    parseLeaderDecision(JSON.stringify({ schema: "squad-decision/v1", action: "converged" }), ["terra"]),
+    { kind: "converged", report: null },
   );
 });

--- a/packages/daemon/test/squad-run-detail-read.test.ts
+++ b/packages/daemon/test/squad-run-detail-read.test.ts
@@ -173,6 +173,7 @@ function coordinator(
         readContentBlob: (sha256: string) => (sha256 === LEADER_RESULT_SHA ? options.receiptBlob : null),
       }) as unknown as CanonicalEventStore,
     reacquireTaskLease: async () => undefined,
+    publishSynthesisReport: async () => undefined,
     runtimeSpawner: () => ({
       spawn: async (): Promise<JsonObject> => ({
         ok: true,

--- a/packages/daemon/test/squad-run-list-window.test.ts
+++ b/packages/daemon/test/squad-run-list-window.test.ts
@@ -204,6 +204,8 @@ function coordinator(
       store: () => {
         throw new Error("store is not exercised by the list window");
       },
+      reacquireTaskLease: async () => undefined,
+      publishSynthesisReport: async () => undefined,
       runtimeSpawner: () => {
         throw new Error("runtime spawner is not exercised by the list window");
       },


### PR DESCRIPTION
# English

## Summary

`ha squad run` required the leader to publish the synthesis report itself through `ha task artifact add`, while the coordinator launched the leader read-only, so a leader running under `--sandbox read-only` could never write the source file and every run failed convergence (task_6d571310 probe, F-00D187CB family). The synthesis now travels inside the leader's `squad-decision/v1` `converged` decision as a `report` field; the coordinator re-acquires the task lease and publishes that Markdown to the roster-declared `artifacts/reports/<squadRunId>.md` through the existing task-artifact writer as the terminal leader session. An empty or missing report fails convergence. The coordinator's historical doc-event scan that tried to prove leader authorship after the fact is deleted, and the leader prompt no longer instructs a disk-source `artifact add`. The leader stays read-only by default.

## Architectural Justification

Authorship is proven at publication time by the actor on the doc event, not reconstructed by scanning history: the coordinator publishes with `executor = runtime-session:<leaderSession>` through `publishTaskArtifact`, which is the same code path as `ha task artifact add` (`runArtifactAdd` now calls it). This deletes a second read-side proof and removes the leader's need for any writable directory. The read-only proxy cell rejects `publishSynthesisReport` as an unsupported write, so a display-only node cannot publish. Multi-node: one squad run has one `squadRunId` and one report path; the publication goes through the center-owned writer cell like every other artifact, so two nodes cannot produce two reports for the same run.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none

## Machine-Readable Declarations

Production-Delta: +132/-59
Dependency-Change: none

### Optional Evidence Claims

none

## Task And Scope

task_f4cf8cbb8d90f360507083d51e (child of the Fable-led anti-entropy squad line task_6d571310). In-file removals: `leaderAuthoredSynthesisReport` and its doc-event history scan in `squad-coordinator.ts`; the disk-source report instruction in `squad-leader-decision.ts`. `runArtifactAdd` is split into `taskArtifactTarget` + `publishTaskArtifactBytes` so the CLI path and the coordinator share one writer.

## Version Impact

None.

## Governance Declaration

No protected path touched. No break-glass.

## Verification

- Worker stop point (targeted tests + local commit, no `check:local`): typecheck, lint, file-complexity, implementation-contracts and canonical-event-compat green; the four required Ubuntu isolated suites green (squad-coordinator, squad-coordinator-recovery, dispatch-parent-session, runtime-spawn-settlement); a real CLI run `squad_9b38a6580acd422c86c6337e` converged with the report published and its doc event carrying the leader session as executor. Fact F-273D9A5D.
- CEO semantic review: the report rides in the decision, publication uses the existing artifact writer with the leader session as executor, the history scan is gone (net deletion), the proxy cell refuses the write. Live acceptance of `fable-antientropy-squad` without `--permission-mode` on the shared daemon is the CEO's post-merge step.
- CI is the full authority.

## Review Evidence

Worker report and fact in the private ledger (task_f4cf8cbb8d90f360507083d51e). Branch base `0dc87bd45` is the current `origin/main`.

## Residual Risk

The shared canonical daemon switches builds only after its live runtimes drain; until then squad runs on it still use the old convergence rule.

---

# 中文

## 概要

`ha squad run` 要求 leader 本人经 `ha task artifact add` 发布综合报告,而 coordinator 又以只读方式起 leader,于是 `--sandbox read-only` 下 leader 连源文件都写不出,每次 run 都在收敛门失败(task_6d571310 探针,F-00D187CB 一族)。现在综合报告作为 `report` 字段随 leader 的 `squad-decision/v1` `converged` 决策一起返回;coordinator 重新取得 task 租约后,以终止的 leader 会话身份经既有 task-artifact 写入器把该 Markdown 发布到 roster 声明的 `artifacts/reports/<squadRunId>.md`。报告为空或缺失即收敛失败。coordinator 里那段事后扫描 doc-event 历史来证明 leader 作者身份的代码删除,leader prompt 不再指示磁盘来源的 `artifact add`。leader 默认仍只读。

## 架构辩护

作者身份在发布时由 doc event 上的 actor 证明,不靠事后扫描历史重建:coordinator 以 `executor = runtime-session:<leaderSession>` 经 `publishTaskArtifact` 发布,这与 `ha task artifact add` 是同一条代码路径(`runArtifactAdd` 现在调用它)。这删掉了第二条读侧证明,也去掉了 leader 对任何可写目录的依赖。只读 proxy cell 把 `publishSynthesisReport` 当不支持的写拒绝,展示面节点发不了报告。多节点:一次 squad run 只有一个 `squadRunId` 与一个报告路径,发布与其他 artifact 一样走中心所有的 writer cell,两个节点产不出同一 run 的两份报告。

## 机读声明

见英文块。

## 治理声明

未触碰 protected 路径。无 break-glass。

## 验证

- worker 停止点(定向测试 + 本地 commit,不跑 `check:local`):typecheck、lint、file-complexity、implementation-contracts、canonical-event-compat 绿;四个必需的 Ubuntu 隔离套件绿(squad-coordinator、squad-coordinator-recovery、dispatch-parent-session、runtime-spawn-settlement);真实 CLI run `squad_9b38a6580acd422c86c6337e` 收敛、报告已发布且 doc event 的 executor 是 leader 会话。fact F-273D9A5D。
- CEO 语义验收:报告随决策走,发布复用既有 artifact 写入器且 executor 为 leader 会话,历史扫描已删(净删除),proxy cell 拒写。共享 daemon 上不带 `--permission-mode` 跑 `fable-antientropy-squad` 的实况验收是 CEO 合并后的步骤。
- CI 是完整权威。

## 评审证据

worker 报告与 fact 在私有台账(task_f4cf8cbb8d90f360507083d51e)。分支基线 `0dc87bd45` 即当前 `origin/main`。

## 残余风险

共享 canonical daemon 要等在飞 runtime 收口后才切新 build;此前其上的 squad run 仍按旧收敛规则。
