### PR TITLE
fix(daemon): archive submitted runtime results

### DIFF
--- a/packages/cli/test/runtime-cli.integration.test.ts
+++ b/packages/cli/test/runtime-cli.integration.test.ts
@@ -858,6 +858,39 @@ test("real CLI runs, archives task-bound dispatches, resumes, waits through stat
     context.diagnostic(
       `notification queue concurrency: ${JSON.stringify({ revisionBefore, revisionAfter, writeReceiptRevision: queueWrite.revision, writeLatencyMs: Number(writeLatencyMs.toFixed(3)), notifierStillRunningAtCommit: true })}`,
     );
+    const submittedTaskId = `${taskId}-submitted`,
+      submittedExecutionId = `${executionId}-submitted`,
+      submittedTask = run(root, env, [
+        "task",
+        "create",
+        "--id",
+        submittedTaskId,
+        "--admin",
+        "--title",
+        "Submitted runtime archive",
+      ]),
+      submittedPackagePath = String(submittedTask.packagePath),
+      submittedPlanPath = `${submittedPackagePath}/task_plan.md`;
+    writeFileSync(path.join(root, "harness", submittedPlanPath), realizedPlan("Submitted runtime archive"));
+    run(root, env, ["doc", "sync", "--submit", "--path", submittedPlanPath]);
+    run(root, env, ["task", "start", submittedTaskId, "--execution-id", submittedExecutionId]);
+    const submittedRuntime = run(root, env, [
+        "runtime",
+        "run",
+        "cli-worker",
+        "--prompt",
+        `submit-before-exit:${submittedTaskId}`,
+        "--task",
+        submittedTaskId,
+        "--no-stream",
+      ]),
+      submittedDispatchId = String((submittedRuntime.spawn as Record<string, unknown>).dispatchId),
+      submittedReportPath = `${submittedPackagePath}/artifacts/reports/${submittedDispatchId}.md`,
+      submittedDispatch = (
+        run(root, env, ["task", "dispatches", submittedTaskId]).dispatches as Array<Record<string, unknown>>
+      ).find((row) => row.dispatchId === submittedDispatchId);
+    assert.equal(existsSync(path.join(root, "harness", submittedReportPath)), true);
+    assert.equal(submittedDispatch?.reportPath, submittedReportPath);
     const readOnly = runMaybe(root, env, [
       "runtime",
       "run",
@@ -1533,8 +1566,12 @@ function writeProgressProvider(target: string, version: string): void {
     batchMarker =
       'const batch = mission.includes("batch hold"), mark = (event) => { if (batch) fs.appendFileSync(".batch-tracker", event + "\\n"); };\n',
     threadMarker = 'console.log(JSON.stringify({ type: "thread.started", thread_id: session })); if (readOnly)',
-    progressSetup = `${batchMarker}const progressTask = mission.startsWith("progress-middle:") ? mission.slice("progress-middle:".length) : null;\n`,
-    progressWrite = `console.log(JSON.stringify({ type: "thread.started", thread_id: session })); if (progressTask) { for (const text of ["Provider checkpoint one.", "Provider checkpoint two."]) { let result; for (let attempt = 0; attempt < 20; attempt += 1) { result = require("node:child_process").spawnSync(process.execPath, [${JSON.stringify(cli)}, "--root", process.cwd(), "--json", "task", "progress", "append", progressTask, "--text", text, "--evidence", "test:reports/runtime-progress.txt:provider checkpoint"], { encoding: "utf8", env: process.env }); if (result.status === 0) break; Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 50); } if (result.status !== 0) { process.stderr.write("progress append failed: " + result.stdout + result.stderr); process.exit(8); } } } if (readOnly)`,
+    progressSetup =
+      `${batchMarker}const progressTask = mission.startsWith("progress-middle:") ? mission.slice("progress-middle:".length) : null;\n` +
+      'const submitTask = mission.startsWith("submit-before-exit:") ? mission.slice("submit-before-exit:".length) : null;\n',
+    progressWrite =
+      `console.log(JSON.stringify({ type: "thread.started", thread_id: session })); if (progressTask) { for (const text of ["Provider checkpoint one.", "Provider checkpoint two."]) { let result; for (let attempt = 0; attempt < 20; attempt += 1) { result = require("node:child_process").spawnSync(process.execPath, [${JSON.stringify(cli)}, "--root", process.cwd(), "--json", "task", "progress", "append", progressTask, "--text", text, "--evidence", "test:reports/runtime-progress.txt:provider checkpoint"], { encoding: "utf8", env: process.env }); if (result.status === 0) break; Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 50); } if (result.status !== 0) { process.stderr.write("progress append failed: " + result.stdout + result.stderr); process.exit(8); } } } ` +
+      `if (submitTask) { const submission = JSON.stringify({ completionClaim: "Runtime worker submitted before exit.", deliverables: ["runtime archive"], outputs: ["runtime archive"], verificationNotes: ["integration"], knownGaps: [], residualRisks: [], commitSha: "a".repeat(40) }); const result = require("node:child_process").spawnSync(process.execPath, [${JSON.stringify(cli)}, "--root", process.cwd(), "--json", "task", "submit", submitTask, "--json-input", submission], { encoding: "utf8", env: process.env }); if (result.status !== 0) { process.stderr.write("task submit failed: " + result.stdout + result.stderr); process.exit(8); } } if (readOnly)`,
     next = source.replace(batchMarker, progressSetup).replace(threadMarker, progressWrite);
   if (next === source) throw new Error("runtime progress provider marker changed");
   writeFileSync(target, next);

--- a/packages/daemon/src/doc-sync-adjudication.ts
+++ b/packages/daemon/src/doc-sync-adjudication.ts
@@ -12,6 +12,7 @@ import {
   type DocSyncReceiptDetail,
   type DocWriteIntent,
   type AuthorizationDecision,
+  type RuntimeArchiveWriteScope,
 } from "../../kernel/src/index.ts";
 import { scanDocCandidates, type DocCandidateScan, validateSelectedDocPaths } from "./doc-sync-candidate-scanner.ts";
 import type { Input } from "./doc-sync-command-actions.ts";
@@ -58,6 +59,7 @@ export function adjudicateDocIntent(
   input: Omit<Input, "action"> & {
     readonly taskDocumentChannel?: DocIntentChannel;
     readonly taskId?: string;
+    readonly runtimeArchive?: RuntimeArchiveWriteScope;
   },
   intent: DocWriteIntent,
   claims: readonly (Uint8Array | null)[],
@@ -120,6 +122,7 @@ export function adjudicateDocIntent(
     resolvedTaskIds,
     ...(runtimeBinding ? { runtimeBinding } : {}),
     ...(runtimeDelegatedTaskId ? { runtimeDelegatedTaskId } : {}),
+    ...(input.runtimeArchive ? { runtimeArchive: input.runtimeArchive } : {}),
   });
   return decision.accepted
     ? { accepted: true, decision: { ...decision, authorizationDecision } }

--- a/packages/daemon/src/doc-sync-command-actions.ts
+++ b/packages/daemon/src/doc-sync-command-actions.ts
@@ -16,6 +16,7 @@ import {
   type ActorIdentity,
   type AuthorizationDecision,
   type EventPublicationKillpoint,
+  type RuntimeArchiveWriteScope,
   type WriteReceiptDraft as WriteReceipt,
   type WriteSource,
 } from "../../kernel/src/index.ts";
@@ -60,6 +61,7 @@ export type Input = {
   readonly now: () => string;
   readonly killpoint?: (point: EventPublicationKillpoint) => void;
   readonly authoredCandidateInventory?: AuthoredCandidateInventoryV1;
+  readonly runtimeArchive?: RuntimeArchiveWriteScope;
 };
 
 export type DocSettlementReceipt = WriteReceipt & {
@@ -254,7 +256,7 @@ export function runDocRetire(input: Input): DocSettlementReceipt {
     },
     input.workspaceId,
   );
-  return publishDocIntent(input, intent, [null], null, reason);
+  return publishDocIntent(input, intent, [null], null, { retirementReason: reason });
 }
 
 export function runArtifactAdd(input: Input): ArtifactAddReceipt {

--- a/packages/daemon/src/doc-sync-details.ts
+++ b/packages/daemon/src/doc-sync-details.ts
@@ -181,11 +181,12 @@ export function matches(
   actor: ActorIdentity,
   source: WriteSource,
   retirementReason?: string,
+  ignoreBaseLedgerSha = false,
 ): boolean {
   return (
     event.payload.executionId === intent.executionId &&
     event.payload.retirementReason === retirementReason &&
-    stableStringify(event.payload.baseLedgerSha) === stableStringify(intent.baseLedgerSha) &&
+    (ignoreBaseLedgerSha || stableStringify(event.payload.baseLedgerSha) === stableStringify(intent.baseLedgerSha)) &&
     stableStringify(event.actor) === stableStringify(actor) &&
     stableStringify(event.source) === stableStringify(source) &&
     stableStringify(

--- a/packages/daemon/src/doc-sync-publication.ts
+++ b/packages/daemon/src/doc-sync-publication.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { existsSync } from "node:fs";
 import path from "node:path";
 import type { TaskProjection } from "../../kernel/src/index.ts";
@@ -70,6 +71,24 @@ export function archiveRuntimeDispatch(
     task = input.projection.read(value.taskId);
   if (task.watermark !== task.sourceRevision || !task.packagePath || !task.snapshot.task)
     throw docSyncError("content_not_ready", `Task ${value.taskId} is not ready for runtime archive`);
+  const occurrence = input.projection
+      .readRuntimeDispatches()
+      .find((event) => event.payload.dispatchId === value.dispatchId),
+    session = input.projection.readRuntimeSession(value.runtimeSessionId),
+    runtimeActor = input.binding.actor.executor?.id === `runtime-session:${value.runtimeSessionId}`,
+    matchingTask = session?.taskBindings.some(
+      (binding) => binding.taskId === value.taskId && binding.executionId === value.executionId,
+    );
+  if (
+    occurrence?.payload.runtimeSessionId !== value.runtimeSessionId ||
+    occurrence.payload.instanceId !== value.instanceId ||
+    !matchingTask ||
+    !runtimeActor
+  )
+    throw docSyncError(
+      "runtime_archive_occurrence_mismatch",
+      `Runtime archive ${value.dispatchId} does not match its canonical dispatch occurrence`,
+    );
   const existingMissionRef = runtimeArchiveMissionRef(input, task.packagePath, value),
     missionRef = existingMissionRef ?? `${task.packagePath}/artifacts/missions/${value.dispatchId}.md`,
     dispatch = {
@@ -133,52 +152,67 @@ export function archiveRuntimeDispatch(
       bytes: Buffer.from(document.body),
     })),
     layout = resolveHarnessLayout(input.rootDir),
-    reads = documents.map((document) => input.projection.readDocument(document.path));
+    reads = documents.map((document) => input.projection.readDocument(document.path)),
+    opId = `runtime-archive-${createHash("sha256")
+      .update(`${input.workspaceId}\0${value.dispatchId}\0${value.runtimeSessionId}`)
+      .digest("hex")}`,
+    existing = input.store.readEvent(opId);
   if (
-    !directPaths(
+    existing === null &&
+    (!directPaths(
       input.rootDir,
       documents.map(({ path: target }) => target),
     ) ||
-    documents.some(({ path: target }) => !resolveDocRoute(target).allowed) ||
-    documents.some(
-      ({ path: target }, index) =>
-        reads[index]!.status !== "ready" ||
-        reads[index]!.document !== null ||
-        existsSync(path.join(layout.authoredRoot, ...target.split("/"))),
-    )
+      documents.some(({ path: target }) => !resolveDocRoute(target).allowed) ||
+      documents.some(
+        ({ path: target }, index) =>
+          reads[index]!.status !== "ready" ||
+          reads[index]!.document !== null ||
+          existsSync(path.join(layout.authoredRoot, ...target.split("/"))),
+      ))
   )
     throw docSyncError(
       "runtime_archive_collision",
       `Runtime archive ${value.dispatchId} is not a fresh task artifact set`,
     );
-  const lease = input.projection.currentLease(value.taskId, input.now()),
-    intent = parseDocWriteIntent(
-      {
-        schema: "doc-write-intent/v1",
-        executionId: lease?.executionId ?? null,
-        baseLedgerSha: input.store.currentCut(),
-        changes: documents.map(({ path: target, bytes, mediaType }) => {
-          const sha = sha256Bytes(bytes);
-          return {
-            path: target,
-            baseBlobSha256: null,
-            policyId: classifyTextualArtifactPath(target)?.policyId ?? DOC_POLICY_ID,
-            candidate: {
-              ref: `doc-sync-claims/${sha}`,
-              sha256: sha,
-              size: bytes.byteLength,
-              mediaType,
-            },
-          };
-        }),
-      },
-      input.workspaceId,
-    );
+  const intent = parseDocWriteIntent(
+    {
+      schema: "doc-write-intent/v1",
+      executionId: null,
+      baseLedgerSha: input.store.currentCut(),
+      changes: documents.map(({ path: target, bytes, mediaType }) => {
+        const sha = sha256Bytes(bytes);
+        return {
+          path: target,
+          baseBlobSha256: null,
+          policyId: classifyTextualArtifactPath(target)?.policyId ?? DOC_POLICY_ID,
+          candidate: {
+            ref: `doc-sync-claims/${sha}`,
+            sha256: sha,
+            size: bytes.byteLength,
+            mediaType,
+          },
+        };
+      }),
+    },
+    input.workspaceId,
+  );
   return publishDocIntent(
-    { ...input, action: { kind: "runtime-archive" } },
+    {
+      ...input,
+      action: { kind: "runtime-archive" },
+      runtimeArchive: {
+        dispatchId: value.dispatchId,
+        runtimeSessionId: value.runtimeSessionId,
+        taskId: value.taskId,
+        executionId: value.executionId,
+        packagePath: task.packagePath,
+      },
+    },
     intent,
     documents.map(({ bytes }) => bytes),
-    lease,
+    null,
+    { opId, ignoreBaseLedgerShaOnReplay: true },
   );
 }
 
@@ -227,8 +261,13 @@ export function publishDocIntent(
   intent: DocWriteIntent,
   claims: readonly (Uint8Array | null)[],
   lease: ReturnType<TaskProjection["currentLeaseForExecution"]>,
-  retirementReason?: string,
+  options: {
+    readonly retirementReason?: string;
+    readonly opId?: string;
+    readonly ignoreBaseLedgerShaOnReplay?: boolean;
+  } = {},
 ): DocSettlementReceipt {
+  const retirementReason = options.retirementReason;
   const baseRevision = intent.baseLedgerSha.revision,
     command = retirementReason === undefined ? intent : { ...intent, retirementReason },
     envelope = normalizeCommandEnvelope({
@@ -238,18 +277,22 @@ export function publishDocIntent(
       expectedRevision: baseRevision ?? 0,
       command: command as unknown as Readonly<Record<string, unknown>>,
     }),
-    existing = input.store.readEvent(envelope.opId);
+    opId = options.opId ?? envelope.opId,
+    existing = input.store.readEvent(opId);
   if (existing !== null) {
     if (
       !isDocEvent(existing) ||
-      !matches(existing, intent, input.binding.actor, input.binding.source, retirementReason)
+      !matches(
+        existing,
+        intent,
+        input.binding.actor,
+        input.binding.source,
+        retirementReason,
+        options.ignoreBaseLedgerShaOnReplay,
+      )
     ) {
       recycleClaims(input.rootDir, intent);
-      return rejectDocSyncAction(
-        envelope.opId,
-        "op_conflict",
-        detail(intent, input.store.currentCut(), "op_conflict", null),
-      );
+      return rejectDocSyncAction(opId, "op_conflict", detail(intent, input.store.currentCut(), "op_conflict", null));
     }
     if (input.projection.readOperation(existing.opId) === null)
       input.projection.apply(existing, docSyncWritePlan(existing));
@@ -265,21 +308,21 @@ export function publishDocIntent(
     intent,
     claims,
     lease,
-    envelope.opId,
+    opId,
     retirementReason,
   );
   if (!adjudication.accepted) {
     if (adjudication.code === "projection_pending")
       return {
         outcome: "indeterminate",
-        opId: envelope.opId,
-        receiptId: envelope.opId,
+        opId,
+        receiptId: opId,
         code: "projection_pending",
         origin: "N/A",
       };
     recycleClaims(input.rootDir, intent);
     return {
-      ...rejectDocSyncAction(envelope.opId, adjudication.code, adjudication.detail),
+      ...rejectDocSyncAction(opId, adjudication.code, adjudication.detail),
       authorizationDecision: adjudication.authorizationDecision,
     };
   }
@@ -289,10 +332,10 @@ export function publishDocIntent(
     blobs: adjudication.decision.blobs,
   });
   input.projection.apply(adjudication.decision.event, adjudication.decision.plan);
-  postCommit(input, "after_sqlite_commit", envelope.opId);
-  postCommit(input, "before_response_write", envelope.opId);
+  postCommit(input, "after_sqlite_commit", opId);
+  postCommit(input, "before_response_write", opId);
   const applied = readDocReceipt(input, adjudication.decision.event);
-  postCommit(input, "after_response_write", envelope.opId);
+  postCommit(input, "after_response_write", opId);
   recycleClaims(input.rootDir, intent);
   return { ...applied, authorizationDecision: adjudication.decision.authorizationDecision };
 }

--- a/packages/daemon/src/doc-sync-publication.ts
+++ b/packages/daemon/src/doc-sync-publication.ts
@@ -75,10 +75,25 @@ export function archiveRuntimeDispatch(
       .readRuntimeDispatches()
       .find((event) => event.payload.dispatchId === value.dispatchId),
     session = input.projection.readRuntimeSession(value.runtimeSessionId),
-    runtimeActor = input.binding.actor.executor?.id === `runtime-session:${value.runtimeSessionId}`,
-    matchingTask = session?.taskBindings.some(
-      (binding) => binding.taskId === value.taskId && binding.executionId === value.executionId,
-    );
+    runtimeExecutorId = `runtime-session:${value.runtimeSessionId}`,
+    assignmentScope = input.binding.assignmentScope,
+    runtimeActor = input.binding.actor.executor?.id === runtimeExecutorId,
+    matchingTask =
+      session?.taskBindings.some(
+        (binding) => binding.taskId === value.taskId && binding.executionId === value.executionId,
+      ) === true ||
+      input.projection
+        .readLeaseIntervals(value.taskId)
+        .some(
+          (interval) =>
+            interval.executionId === value.executionId &&
+            interval.holder.actor.executor?.id === runtimeExecutorId &&
+            interval.holder.actor.principal.personId === input.binding.actor.principal.personId,
+        ) ||
+      (assignmentScope?.repoId === input.workspaceId &&
+        assignmentScope.scope.kind === "task" &&
+        assignmentScope.scope.taskId === value.taskId &&
+        assignmentScope.scope.executionId === value.executionId);
   if (
     occurrence?.payload.runtimeSessionId !== value.runtimeSessionId ||
     occurrence.payload.instanceId !== value.instanceId ||

--- a/packages/daemon/src/repo-cell-api.ts
+++ b/packages/daemon/src/repo-cell-api.ts
@@ -837,19 +837,29 @@ export function createRepoCellApi(context: RepoCellApiContext): RepoCell & RepoC
     );
   };
   const runtimeIngress: RepoCell["runtimeIngress"] = (action, binding) => {
-    if (
-      action.kind === "event" &&
-      (action.type === "runtime_session_exited" || action.type === "runtime_session_outcome_observed") &&
-      typeof action.payload.runtimeSessionId === "string"
-    )
+    const settlementRuntimeSessionId =
+      action.kind === "archive"
+        ? action.archive.runtimeSessionId
+        : action.type === "runtime_session_exited" || action.type === "runtime_session_outcome_observed"
+          ? action.payload.runtimeSessionId
+          : null;
+    if (typeof settlementRuntimeSessionId === "string")
       binding = {
         ...binding,
         actor: {
           principal: binding.actor.principal,
-          executor: { kind: "agent", id: `runtime-session:${action.payload.runtimeSessionId}` },
+          executor: { kind: "agent", id: `runtime-session:${settlementRuntimeSessionId}` },
         },
       };
-    const policyAction = { ...action, kind: "runtime-run" };
+    const policyAction =
+      action.kind === "archive"
+        ? {
+            kind: "runtime-run",
+            taskId: action.archive.taskId,
+            executionId: action.archive.executionId,
+            runtimeSessionId: action.archive.runtimeSessionId,
+          }
+        : { ...action, kind: "runtime-run" };
     return enqueueRuntimePublication("runtime-run", policyAction, binding, async (authorizedBinding) => {
       if (action.kind === "event" && runtimeSessionActionIds.includes(action.type as never)) {
         const receipt = await commitRuntimeSessionAction(context.extracted, action, authorizedBinding);

--- a/packages/daemon/src/repo-cell-open.ts
+++ b/packages/daemon/src/repo-cell-open.ts
@@ -522,6 +522,17 @@ export async function openRepoWriterCell(
         binding,
         `runtime-event:${opId}`,
       ),
+    authorizeRuntimeArchive: (archive, binding) =>
+      authorizeRuntimeAction(
+        {
+          kind: "runtime-run",
+          taskId: archive.taskId,
+          executionId: archive.executionId,
+          runtimeSessionId: archive.runtimeSessionId,
+        },
+        binding,
+        `runtime-archive:${archive.dispatchId}`,
+      ),
     ...(input.recordLifecycle ? { recordLifecycle: input.recordLifecycle } : {}),
     ...(input.runtimeLaunch ? { launch: input.runtimeLaunch } : {}),
   });

--- a/packages/daemon/src/runtime-spawn-settlement.ts
+++ b/packages/daemon/src/runtime-spawn-settlement.ts
@@ -104,7 +104,7 @@ export async function publishExit(
             reason: attemptOutcome.reason,
           }
         : null;
-    if (archive)
+    if (archive) {
       try {
         const archived = context.input.remote
           ? await context.input.remote.archive(archive)
@@ -113,7 +113,7 @@ export async function publishExit(
               rootDir: context.input.rootDir,
               store: context.requiredRuntimeStore(context.input),
               projection: context.requiredRuntimeProjection(context.input),
-              binding: active.binding,
+              binding: context.input.authorizeRuntimeArchive?.(archive, terminalBinding) ?? terminalBinding,
               now: context.input.now,
               archive,
             });
@@ -125,8 +125,10 @@ export async function publishExit(
       } catch (error) {
         consumeKnownError(error);
         const detail = String(scrubProviderValue(error instanceof Error ? error.message : String(error))).slice(0, 512);
-        console.warn(`[runtime-archive] ${active.dispatchId} could not be archived: ${detail}`);
+        console.error(`[runtime-archive] ${active.dispatchId} could not be archived: ${detail}`);
+        throw error;
       }
+    }
     if (cancelled) {
       await context.publishRuntimeEvent(
         "runtime_session_cancelled",

--- a/packages/daemon/src/runtime-spawn-settlement.ts
+++ b/packages/daemon/src/runtime-spawn-settlement.ts
@@ -125,8 +125,8 @@ export async function publishExit(
       } catch (error) {
         consumeKnownError(error);
         const detail = String(scrubProviderValue(error instanceof Error ? error.message : String(error))).slice(0, 512);
+        // The exit event below must still publish: a lost report must not leave the runtime "live".
         console.error(`[runtime-archive] ${active.dispatchId} could not be archived: ${detail}`);
-        throw error;
       }
     }
     if (cancelled) {

--- a/packages/daemon/src/runtime-spawner.ts
+++ b/packages/daemon/src/runtime-spawner.ts
@@ -32,6 +32,7 @@ import {
   scrubProviderValue,
   type DispatchStreamWriter,
 } from "./dispatch-stream.ts";
+import type { RuntimeDispatchArchive } from "./doc-sync-actions.ts";
 import { unknownFieldViolation, type JsonObject } from "./protocol/json-rpc-types.ts";
 import { runtimeKindForId } from "./runtime-inventory.ts";
 import { runtimePermissionMode } from "./runtime-permissions.ts";
@@ -168,6 +169,8 @@ export interface RuntimeSpawnerInput {
     readonly opId: string;
     readonly binding: RuntimeBinding;
   }) => RuntimeBinding;
+  /** Re-authorizes a local terminal archive at the settlement cut. */
+  readonly authorizeRuntimeArchive?: (archive: RuntimeDispatchArchive, binding: RuntimeBinding) => RuntimeBinding;
   readonly recordLifecycle?: DaemonLifecycleRecorder;
 }
 

--- a/packages/daemon/test/runtime-spawn-settlement.test.ts
+++ b/packages/daemon/test/runtime-spawn-settlement.test.ts
@@ -1,7 +1,12 @@
 // harness-test-tier: fast
 import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
 import test from "node:test";
 import { classifyRuntimeExit } from "../src/runtime-provider-fault.ts";
+import { publishExit } from "../src/runtime-spawn-settlement.ts";
+import type { RuntimeSpawnerContext } from "../src/runtime-spawn-context.ts";
 import type { ActiveRuntime } from "../src/runtime-spawn-types.ts";
 
 test("exit zero is success evidence even when provider protocol evidence is incomplete", () => {
@@ -48,6 +53,73 @@ test("a non-zero squad leader exit is failed even when its final text declares c
     1,
   );
   assert.equal(result.outcome, "failed");
+});
+
+test("terminal settlement does not swallow a runtime archive failure", async () => {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "runtime-archive-failure-")),
+    runtime = active({
+      process: {
+        pid: 123,
+        onOutput: () => undefined,
+        onErrorOutput: () => undefined,
+        onExit: () => undefined,
+        terminate: () => undefined,
+      },
+      runtimeSessionId: "runtime-archive-failure",
+      dispatchOpId: "dispatch-op",
+      binding: {
+        actor: {
+          principal: { kind: "human", id: "operator" },
+          executor: { kind: "agent", id: "runtime-session:runtime-archive-failure" },
+        },
+        source: "local",
+      },
+      task: { taskId: "task-owner", executionId: "execution-owner", leaseVersion: 1 },
+      schedule: null,
+      cwd: rootDir,
+      prompt: "archive this result",
+      onExitCommand: null,
+      reasoningEffort: null,
+      fast: false,
+      startedAt: "2026-09-03T00:00:00.000Z",
+      stream: {
+        ref: "runtime-stream:dispatch_0123456789abcdef01234567",
+        appendAttemptOutcome: () => undefined,
+      } as never,
+      buffer: "",
+      durableOutputCount: 0,
+      stdoutObserved: true,
+      providerSessionId: "provider-session",
+      resumeProviderSessionId: null,
+      finalText: null,
+      cancelBinding: null,
+      cancelOpId: null,
+    }),
+    archiveError = new Error("archive publication failed"),
+    errors: string[] = [],
+    originalError = console.error,
+    context = {
+      exiting: new Set<string>(),
+      processes: new Map([[runtime.runtimeSessionId, runtime]]),
+      input: {
+        repoId: "canonical",
+        rootDir,
+        now: () => "2026-09-03T00:01:00.000Z",
+        stream: { publish: () => ({}) },
+        remote: { archive: async () => Promise.reject(archiveError) },
+      },
+      resultMediaType: "text/markdown",
+      runtimeResultText: () => "failed result",
+      markProtocolError: () => undefined,
+    } as unknown as RuntimeSpawnerContext;
+  console.error = (...values: unknown[]) => errors.push(values.map(String).join(" "));
+  try {
+    await assert.rejects(publishExit(context, runtime, 1), archiveError);
+    assert.match(errors.join("\n"), /could not be archived: archive publication failed/u);
+  } finally {
+    console.error = originalError;
+    rmSync(rootDir, { recursive: true, force: true });
+  }
 });
 
 function active(overrides: Partial<ActiveRuntime>): ActiveRuntime {

--- a/packages/daemon/test/runtime-spawn-settlement.test.ts
+++ b/packages/daemon/test/runtime-spawn-settlement.test.ts
@@ -55,7 +55,7 @@ test("a non-zero squad leader exit is failed even when its final text declares c
   assert.equal(result.outcome, "failed");
 });
 
-test("terminal settlement does not swallow a runtime archive failure", async () => {
+test("terminal settlement reports a runtime archive failure and still publishes the exit", async () => {
   const rootDir = mkdtempSync(path.join(tmpdir(), "runtime-archive-failure-")),
     runtime = active({
       process: {
@@ -97,6 +97,7 @@ test("terminal settlement does not swallow a runtime archive failure", async () 
     }),
     archiveError = new Error("archive publication failed"),
     errors: string[] = [],
+    published: string[] = [],
     originalError = console.error,
     context = {
       exiting: new Set<string>(),
@@ -111,11 +112,17 @@ test("terminal settlement does not swallow a runtime archive failure", async () 
       resultMediaType: "text/markdown",
       runtimeResultText: () => "failed result",
       markProtocolError: () => undefined,
+      publishRuntimeEvent: async (type: string) => {
+        published.push(type);
+        return {};
+      },
+      settleFallback: async () => undefined,
     } as unknown as RuntimeSpawnerContext;
   console.error = (...values: unknown[]) => errors.push(values.map(String).join(" "));
   try {
-    await assert.rejects(publishExit(context, runtime, 1), archiveError);
+    await publishExit(context, runtime, 1);
     assert.match(errors.join("\n"), /could not be archived: archive publication failed/u);
+    assert.deepEqual(published, ["runtime_session_exited", "runtime_session_outcome_observed"]);
   } finally {
     console.error = originalError;
     rmSync(rootDir, { recursive: true, force: true });

--- a/packages/kernel/src/domain/doc-sync-types.ts
+++ b/packages/kernel/src/domain/doc-sync-types.ts
@@ -110,6 +110,14 @@ export interface DocWriteIntent {
   readonly changes: readonly DocWriteChange[];
 }
 
+export interface RuntimeArchiveWriteScope {
+  readonly dispatchId: string;
+  readonly runtimeSessionId: string;
+  readonly taskId: string;
+  readonly executionId: string;
+  readonly packagePath: string;
+}
+
 export interface RegionProof {
   readonly regionId: string;
   readonly policyId: string;
@@ -218,6 +226,8 @@ export interface DocWriteDecisionInput {
   readonly lease: LeaseV1 | null;
   /** Decision evaluated by the daemon AuthorizationPort for execution-bound writes. */
   readonly authorizationDecision: AuthorizationDecision | null;
+  /** Canonical dispatch occurrence validated by the daemon for lease-free terminal archival. */
+  readonly runtimeArchive?: RuntimeArchiveWriteScope;
   readonly runtimeBinding?: TaskBoundRuntimeBinding;
   /** Strict descendant package selected by a task-bound runtime acting through its own live lease. */
   readonly runtimeDelegatedTaskId?: string;

--- a/packages/kernel/src/domain/doc-sync-writer.ts
+++ b/packages/kernel/src/domain/doc-sync-writer.ts
@@ -14,6 +14,7 @@ import type {
   DocPolicyUpgrade,
   DocWriteDecision,
   DocWriteDecisionInput,
+  RuntimeArchiveWriteScope,
 } from "./doc-sync-types.ts";
 import { policyMatchesClaim, taskArtifactPath, taskFromPath, validDocEventChange } from "./doc-sync-validation.ts";
 import { MIGRATION_DOCUMENT_POLICY_ID } from "./migration-import-event.ts";
@@ -89,14 +90,24 @@ function decideDocWriteInternal(input: DocWriteDecisionInput, requireAuthorizati
       input.intent.executionId !== null)
   )
     return reject("invalid_retirement");
-  const runtimeActor = runtimeSessionIdFromActor(input.actor) !== null;
+  const runtimeSessionId = runtimeSessionIdFromActor(input.actor),
+    runtimeActor = runtimeSessionId !== null,
+    runtimeArchive = input.runtimeArchive,
+    runtimeArchiveAccepted =
+      runtimeArchive !== undefined &&
+      runtimeSessionId === runtimeArchive.runtimeSessionId &&
+      validRuntimeArchiveChanges(input, runtimeArchive);
   if (
     input.intent.executionId === null
-      ? input.lease !== null || runtimeActor
+      ? input.lease !== null || (runtimeArchive !== undefined ? !runtimeArchiveAccepted : runtimeActor)
       : input.lease === null || input.lease.phase !== "held" || input.lease.executionId !== input.intent.executionId
   )
     return reject("lease_conflict");
-  if (requireAuthorization && input.intent.executionId !== null && authorizationDecision?.outcome !== "allowed")
+  if (
+    requireAuthorization &&
+    (input.intent.executionId !== null || runtimeArchiveAccepted) &&
+    authorizationDecision?.outcome !== "allowed"
+  )
     return reject("authorization_denied");
   const directHolder =
       input.lease !== null &&
@@ -248,6 +259,25 @@ function decideDocWriteInternal(input: DocWriteDecisionInput, requireAuthorizati
     plan: docSyncWritePlan(event),
     authorizationDecision,
   };
+}
+
+function validRuntimeArchiveChanges(input: DocWriteDecisionInput, scope: RuntimeArchiveWriteScope): boolean {
+  const artifactRoot = `${scope.packagePath}/artifacts`,
+    requiredPaths = new Set([
+      `${artifactRoot}/dispatches/${scope.dispatchId}.json`,
+      `${artifactRoot}/reports/${scope.dispatchId}.md`,
+    ]),
+    allowedMission = `${artifactRoot}/missions/${scope.dispatchId}.md`,
+    paths = input.intent.changes.map(({ path }) => String(path));
+  return (
+    input.intent.executionId === null &&
+    input.lease === null &&
+    paths.length === new Set(paths).size &&
+    [...requiredPaths].every((path) => paths.includes(path)) &&
+    paths.every((path) => requiredPaths.has(path) || path === allowedMission) &&
+    input.intent.changes.every((change) => change.baseBlobSha256 === null && change.candidate !== null) &&
+    input.resolvedTaskIds?.every((taskId) => taskId === scope.taskId) === true
+  );
 }
 
 export function docSyncWritePlan(event: DocEventV1): FrozenWritePlan<"DocSyncSubmit"> {

--- a/packages/kernel/src/index.ts
+++ b/packages/kernel/src/index.ts
@@ -165,6 +165,7 @@ export type {
   DocumentState,
   DocWriteIntent,
   PersistedCanonicalEventV1,
+  RuntimeArchiveWriteScope,
 } from "./domain/doc-sync.contract.ts";
 export {
   MIGRATION_DOCUMENT_POLICY_ID,

--- a/packages/kernel/test/contracts/doc-sync-runtime-artifacts.test.ts
+++ b/packages/kernel/test/contracts/doc-sync-runtime-artifacts.test.ts
@@ -137,6 +137,77 @@ test("a task-bound runtime may write only its assigned task artifacts subtree wh
   );
 });
 
+test("a canonical runtime occurrence archives only its dispatch artifacts without an execution lease", () => {
+  const runtimeActor = {
+      principal: actor.principal,
+      executor: { kind: "agent", id: "runtime-session:runtime-archive" },
+    } as const,
+    scope = {
+      dispatchId: "dispatch_0123456789abcdef01234567",
+      runtimeSessionId: "runtime-archive",
+      taskId: "task-owner",
+      executionId: "execution-1",
+      packagePath: "tasks/task-owner-docs",
+    },
+    bodies = ["{}\n", "Runtime result\n"],
+    paths = [
+      `tasks/task-owner-docs/artifacts/dispatches/${scope.dispatchId}.json`,
+      `tasks/task-owner-docs/artifacts/reports/${scope.dispatchId}.md`,
+    ],
+    run = (overrides: Record<string, unknown> = {}) =>
+      decideDocWrite({
+        intent: {
+          schema: "doc-write-intent/v1",
+          executionId: null,
+          baseLedgerSha,
+          changes: [
+            {
+              path: documentPath(paths[0]!),
+              baseBlobSha256: null,
+              policyId: OPAQUE_TEXTUAL_POLICY_ID,
+              candidate: opaqueClaim(bodies[0]!, "application/json"),
+            },
+            {
+              path: documentPath(paths[1]!),
+              baseBlobSha256: null,
+              policyId: DOC_POLICY_ID,
+              candidate: claim(bodies[1]!),
+            },
+          ],
+        },
+        opId: "runtime-archive-op",
+        eventId: "runtime-archive-event",
+        workspaceRevision: 3,
+        actor: runtimeActor,
+        source: "local",
+        occurredAt: "2026-08-12T11:00:00.000Z",
+        currentLedgerSha,
+        lease: null,
+        authorizationDecision: authorizeDocWrite(runtimeActor),
+        runtimeArchive: scope,
+        documents: [null, null],
+        claims: bodies.map((body) => Buffer.from(body)),
+        resolvedTaskIds: [scope.taskId, scope.taskId],
+        ...overrides,
+      });
+  const accepted = run();
+  assert.equal(accepted.accepted, true, JSON.stringify(accepted));
+  if (accepted.accepted) assert.equal(accepted.event.payload.executionId, null);
+  for (const [name, result, code] of [
+    ["occurrence proof required", run({ runtimeArchive: undefined }), "lease_conflict"],
+    ["settlement authorization required", run({ authorizationDecision: null }), "authorization_denied"],
+    [
+      "matching runtime actor required",
+      run({ actor: { ...runtimeActor, executor: { kind: "agent", id: "runtime-session:other" } } }),
+      "lease_conflict",
+    ],
+    ["matching task paths required", run({ resolvedTaskIds: [scope.taskId, "task-other"] }), "lease_conflict"],
+  ] as const) {
+    assert.equal(result.accepted, false, name);
+    if (!result.accepted) assert.equal(result.code, code, name);
+  }
+});
+
 test("an opaque artifact write reclassifies an existing prose record without a policy upgrade", () => {
   const base = "---\ntitle: Legacy report\n---\n\n# Same\n\n# Same\n",
     candidate = "---\ntitle: Rewritten report\n---\n\n# Same\n\n# Same\n\nAll bytes are opaque.\n",


### PR DESCRIPTION
# English

## Summary

Every worker exit on 2026-09-03 logged `[runtime-archive] dispatch_* could not be archived: refresh status and submit through the matching execution or repository prose channel`. The terminal archive (`artifacts/{dispatches,reports,missions}/<dispatchId>.*`) was published through the task-bound binding captured at spawn, and that channel closes the moment the worker runs `ha task submit`, so the normal happy path could never archive and `reportPath` was never materialised. The archive is now a lease-free write scoped to the canonical dispatch occurrence: the daemon re-authorises it at the settlement cut as `runtime-session:<id>` against the dispatch's `taskId`/`executionId` (`authorizeRuntimeArchive`), the kernel doc-sync writer accepts it only when the actor is that session and the changes are exactly the dispatch's own artifact paths under the owning task package (`RuntimeArchiveWriteScope`), and the op id derives from workspace + dispatch + session so a repeated archive replays instead of colliding. Remote (edge) settlement carries the same `archive` action through `runtimeIngress` into the center queue. CEO trim: an archive failure is logged at error level but no longer blocks `runtime_session_exited`, so a lost report cannot leave a runtime "live".

## Architectural Justification

The archive belongs to the dispatch occurrence, not to the task lease: it is written after the worker has already handed the task back, by the daemon on the session's behalf, and only into the three files that occurrence owns. Scoping the write in the kernel writer (paths, actor, no lease, fresh candidates) keeps RepoCell's single-write authority and adds no second channel or retry. Multi-node: a `dispatchId` is globally unique, the artifact paths are keyed by it, edge nodes forward through `remote.archive` into the center-owned queue, and the occurrence-derived op id makes duplicate archive calls idempotent, so two nodes cannot overwrite each other's reports.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none

## Machine-Readable Declarations

Production-Delta: +195/-64
Dependency-Change: none

### Optional Evidence Claims

none

## Task And Scope

task_26c66c20da29315868bce6f103. In-file replacements: the spawn-time task-bound archive binding in `runtime-spawn-settlement.ts` and the lease lookup in `doc-sync-publication.ts`; the warn-and-swallow branch became an error-level log that still lets the exit publish.

## Version Impact

None.

## Governance Declaration

No protected path touched. No break-glass.

## Verification

- Round 2 (fe2ea8931): `archiveRuntimeDispatch` no longer treats the provider-derived session task binding as the only task/execution proof; it also accepts the runtime's own lease interval (local direct runtimes) and the authenticated fleet assignment scope (edge runtimes). Root cause of the shard-2 `provider fallback did not settle` and the shard-5 re-adopt `outcome: null` results: empty-success providers never emit an identity frame, so the binding never existed and the archive was rejected with `runtime_archive_occurrence_mismatch`. Occurrence and actor checks are unchanged.
- Worker stop point (targeted tests + local commit, no `check:local`): boundaries job 45/45 commands; implementation-contracts, canonical-event-compat, kernel dead-exports, line-density, production-delta green; Ubuntu isolated `runtime-cli.integration.test.ts` regression (worker submits before exit, report artifact must exist) red before the change and green after; new kernel contract test `doc-sync-runtime-artifacts.test.ts` for the scoped lease-free write. Fact F-50D15F9E.
- CEO: branch merged with `origin/main` `035eedb4b`; after the trim `runtime-spawn-settlement.test.ts` 6/6 asserts the archive error is logged and both `runtime_session_exited` and `runtime_session_outcome_observed` still publish; kernel + daemon typecheck green.
- CI is the full authority.

## Review Evidence

Worker report: `harness/tasks/task_26c66c20da29315868bce6f103-*/artifacts/reports/r1.md` (private ledger); the write-path design was checkpointed to the CEO before implementation and approved as proposed. CEO semantic review read the settlement, authorization, publication and kernel writer diffs.

## Residual Risk

The shared canonical daemon switches builds only after its live runtimes drain; until then its exits keep logging the old archive failure. No real multi-edge simultaneous-exit end-to-end was run; the concurrency argument rests on the occurrence path, the assignment fence and the center single-write queue.

---

# 中文

## 概要

2026-09-03 每一条 worker 退出都打 `[runtime-archive] dispatch_* could not be archived: refresh status and submit through the matching execution or repository prose channel`。终态归档(`artifacts/{dispatches,reports,missions}/<dispatchId>.*`)走的是 spawn 时抓下的 task-bound 绑定,而 worker 一执行 `ha task submit` 该通道就关闭,于是正常收口路径上永远归不了档,`reportPath` 也永远落不了盘。现在归档是限定在 canonical 派工 occurrence 上的免租约写入:daemon 在结算 cut 以 `runtime-session:<id>` 对该 dispatch 的 `taskId`/`executionId` 重新授权(`authorizeRuntimeArchive`),kernel 的 doc-sync 写入器只在 actor 就是该会话、且改动恰好是该 dispatch 自己在所属任务包下的 artifact 路径时接受(`RuntimeArchiveWriteScope`),opId 由 workspace + dispatch + session 派生,重复归档是重放而非碰撞。远端(边缘)结算把同一个 `archive` 动作经 `runtimeIngress` 送进中心队列。CEO 裁剪:归档失败以 error 级别记日志,但不再阻塞 `runtime_session_exited`,丢一份报告不能让 runtime 永远「live」。

## 架构辩护

归档属于派工 occurrence 而不是 task 租约:它在 worker 已交回任务之后由 daemon 代该会话写入,且只写该 occurrence 自己拥有的三个文件。把写入范围收在 kernel 写入器里(路径、actor、无租约、新候选)保住了 RepoCell 的单写权威,不开第二通道、不加重试。多节点:`dispatchId` 全局唯一,artifact 路径按它定位,边缘节点经 `remote.archive` 进中心所有的队列,occurrence 派生的 opId 让重复归档幂等,两个节点覆盖不了彼此的报告。

## 机读声明

见英文块。

## 治理声明

未触碰 protected 路径。无 break-glass。

## 验证

- worker 停止点(定向测试 + 本地 commit,不跑 `check:local`):boundaries job 45/45 命令;implementation-contracts、canonical-event-compat、kernel dead-exports、line-density、production-delta 绿;Ubuntu 隔离机 `runtime-cli.integration.test.ts` 回归(worker 先 submit 再退出,报告 artifact 必须存在)改前红改后绿;新增 kernel 契约测试 `doc-sync-runtime-artifacts.test.ts` 覆盖限定范围的免租约写入。fact F-50D15F9E。
- CEO:分支已与 `origin/main` `035eedb4b` 合并;裁剪后 `runtime-spawn-settlement.test.ts` 6/6 断言归档错误被记录且 `runtime_session_exited` 与 `runtime_session_outcome_observed` 仍发布;kernel + daemon typecheck 绿。
- CI 是完整权威。

## 评审证据

worker 报告见任务包 `artifacts/reports/r1.md`(私有台账);写路方案在实现前先 checkpoint 给 CEO,按原案批准。CEO 语义验收通读结算、授权、发布与 kernel 写入器四处 diff。

## 残余风险

共享 canonical daemon 要等在飞 runtime 收口后才切新 build;此前其退出仍会记旧的归档失败。未做真实多边缘同时退出的端到端;并发论证依赖 occurrence 路径、assignment fence 与中心单写队列。
