### PR TITLE
refactor(settings): remove the one-shot --layout-unset path

### DIFF
--- a/packages/cli/test/settings-command.test.ts
+++ b/packages/cli/test/settings-command.test.ts
@@ -22,8 +22,6 @@ test("Settings CLI projects read and owned update flags to the closed daemon act
     "zh-CN",
     "--task-scaffold",
     "governance/task-scaffold.json",
-    "--layout-unset",
-    "adrRoot",
     "--expected-version",
     "42",
     "--idempotency-key",
@@ -36,7 +34,6 @@ test("Settings CLI projects read and owned update flags to the closed daemon act
       defaultPreset: "strict-task",
       locale: "zh-CN",
       taskScaffold: "governance/task-scaffold.json",
-      layoutUnset: "adrRoot",
       expectedVersion: 42,
       idempotencyKey: "settings-one",
     });
@@ -45,6 +42,5 @@ test("Settings CLI projects read and owned update flags to the closed daemon act
 test("Settings CLI rejects unknown and unsupported locale fields", () => {
   assert.equal(parseThinCommand(["settings", "update", "--locale", "fr-FR"]).ok, false);
   assert.equal(parseThinCommand(["settings", "update", "--wip-limit", "1"]).ok, false);
-  assert.equal(parseThinCommand(["settings", "update", "--layout-unset", "unknownRoot"]).ok, false);
   assert.equal(parseThinCommand(["settings", "read", "--locale", "en-US"]).ok, false);
 });

--- a/packages/daemon/src/protocol/daemon-protocol-commands.ts
+++ b/packages/daemon/src/protocol/daemon-protocol-commands.ts
@@ -76,7 +76,6 @@ const settingsWriteTopology = {
         positiveSettingInput("--wal-flush-events"),
         positiveSettingInput("--wal-flush-bytes"),
         positiveSettingInput("--wal-flush-milliseconds"),
-        cliInput("--layout-unset", "single", false, { code: "invalid_field" }, { enum: ["adrRoot"] }),
         cliInput(
           "--expected-version",
           "single",

--- a/packages/daemon/test/repo-cell-settings.integration.test.ts
+++ b/packages/daemon/test/repo-cell-settings.integration.test.ts
@@ -47,7 +47,6 @@ test("settings writes reject catalog-inconsistent vertical, preset, and profile 
         defaultVertical: "software/coding",
         defaultPreset: "docs-task",
         defaultProfile: "baseline",
-        layoutUnset: "adrRoot",
         expectedVersion: initialRevision,
         idempotencyKey: "valid-settings-selection",
       } as const,
@@ -79,7 +78,6 @@ test("settings writes reject catalog-inconsistent vertical, preset, and profile 
       },
     ]);
     assert.match(readFileSync(configPath, "utf8"), /defaultPreset: docs-task[\s\S]*defaultProfile: baseline/u);
-    assert.equal(readFileSync(configPath, "utf8").includes("adrRoot"), false);
     const eventStore = makeTaskEventStore({ repoId: "settings-catalog", rootDir: root }),
       audited = eventStore.readEvent(applied.opId);
     assert.equal(audited?.schema, "settings-event/v1");
@@ -154,7 +152,6 @@ function initRepo(root: string): void {
       "layout:",
       "  authoredRoot: harness",
       "  localRoot: .harness",
-      "  adrRoot: harness/adr",
       "settings:",
       "  defaultVertical: software/coding",
       "  defaultPreset: standard-task",

--- a/packages/kernel/src/domain/settings-action-contract.ts
+++ b/packages/kernel/src/domain/settings-action-contract.ts
@@ -1,5 +1,4 @@
 import { sha256Text, stableStringify } from "../integrity/stable-hash.ts";
-import { removableLayoutKeys } from "../layout/harness-settings.ts";
 import type {
   EntityActionContract,
   EntityActionInputContract,
@@ -45,7 +44,6 @@ const repositoryFieldNames = Object.freeze([
   "walFlushEvents",
   "walFlushBytes",
   "walFlushMilliseconds",
-  "layoutUnset",
 ] as const);
 
 const input = (fields: readonly EntityActionInputField[]): EntityActionInputContract =>
@@ -129,7 +127,6 @@ export function createSettingsActionCatalog(
           field("walFlushEvents", "number"),
           field("walFlushBytes", "number"),
           field("walFlushMilliseconds", "number"),
-          field("layoutUnset", "string", false, removableLayoutKeys),
           field("expectedVersion", "number"),
           field("idempotencyKey"),
         ]),
@@ -179,7 +176,6 @@ export function compileSettingsUpdate(input: EntityActionCompileInput): Settings
     expectedVersion = input.action.expectedVersion,
     repositoryChangeRequested = repositoryFieldNames.some((name) => Object.hasOwn(input.action, name));
   settingsActionLocale(input.action.locale);
-  settingsLayoutUnset(input.action.layoutUnset);
   if (expectedVersion !== undefined && (!Number.isSafeInteger(expectedVersion) || Number(expectedVersion) < 0))
     rejectSettings("invalid_command", "expectedVersion must be a non-negative integer when supplied.");
   if (!repositoryChangeRequested) return { kind: "no-changes", settings: current, revision };
@@ -231,12 +227,6 @@ export function compileSettingsUpdate(input: EntityActionCompileInput): Settings
       occurredAt: input.occurredAt,
     }),
   };
-}
-
-function settingsLayoutUnset(value: unknown): void {
-  if (value === undefined) return;
-  if (removableLayoutKeys.includes(value as (typeof removableLayoutKeys)[number])) return;
-  rejectSettings("invalid_command", `layoutUnset must be one of ${removableLayoutKeys.join(", ")}.`);
 }
 
 export function settingsActionLocale(value: unknown): SettingsLocale | undefined {

--- a/packages/kernel/src/domain/settings.ts
+++ b/packages/kernel/src/domain/settings.ts
@@ -1,4 +1,4 @@
-import { removeLayoutKey, setting, settingBlockValue } from "../layout/harness-settings.ts";
+import { setting, settingBlockValue } from "../layout/harness-settings.ts";
 import type { EntityDocumentJsonSchema } from "./entity-json-schema.ts";
 import { validateEntityJsonSchema } from "./entity-json-schema.ts";
 
@@ -299,7 +299,6 @@ export function writeRepositorySettingsFacet(body: string, settings: RepositoryS
     INITIAL_SETTINGS_V1.scaffolds.repository,
   );
   next = removeLegacyLocale(next);
-  next = removeLayoutKey(next, "adrRoot");
   if (JSON.stringify(repositorySettings(readSettingsFacet(next))) !== JSON.stringify(repository))
     throw new Error("repository settings facet replacement did not round-trip exactly");
   return next;

--- a/packages/kernel/src/layout/harness-settings.ts
+++ b/packages/kernel/src/layout/harness-settings.ts
@@ -18,9 +18,6 @@ const horizontal = "[^\\S\\r\\n]*";
 const scalar = (indent: string, key: string) =>
   new RegExp(`^${indent}${key}:${horizontal}([^#\\s][^#\\r\\n]*?)${horizontal}(?:#[^\\r\\n]*)?$`, "mu");
 
-export const removableLayoutKeys = ["adrRoot"] as const;
-export type RemovableLayoutKey = (typeof removableLayoutKeys)[number];
-
 /** Reads a scalar directly under `settings:`, for example `defaultVertical`. */
 export function setting(body: string, key: string): string | undefined {
   return scalar("  ", key).exec(body)?.[1];
@@ -31,14 +28,4 @@ export function settingBlockValue(body: string, block: string, key: string): str
   const section =
     new RegExp(`^  ${block}:[^\\S\\r\\n]*(?:\\r?\\n)((?:    [^\\r\\n]*(?:\\r?\\n|$))*)`, "mu").exec(body)?.[1] ?? "";
   return scalar("    ", key).exec(section)?.[1];
-}
-
-export function removeLayoutKey(body: string, key: RemovableLayoutKey): string {
-  const section = /(^layout:[^\S\r\n]*(?:\r?\n))((?:  [^\r\n]*(?:\r?\n|$))*)/mu,
-    match = section.exec(body);
-  if (!match) return body;
-  const line = new RegExp(`^  ${key}:[^\\r\\n]*(?:\\r?\\n|$)`, "mu");
-  if (!line.test(match[2]!)) return body;
-  const replacement = `${match[1]}${match[2]!.replace(line, "")}`;
-  return `${body.slice(0, match.index)}${replacement}${body.slice(match.index + match[0].length)}`;
 }

--- a/packages/kernel/test/contracts/settings-action.test.ts
+++ b/packages/kernel/test/contracts/settings-action.test.ts
@@ -10,7 +10,6 @@ const documentBody = [
   "name: settings-action-test",
   "layout:",
   "  authoredRoot: harness",
-  "  adrRoot: harness/adr",
   "settings:",
   "  defaultVertical: software/coding",
   "  defaultPreset: standard-task",
@@ -48,14 +47,6 @@ test("Settings update compiles the existing audit event with actor and parent do
   assert.equal(draft.result.bundle.event.payload.settings.defaultPreset, "docs-task");
   assert.equal(Object.hasOwn(draft.result.bundle.event.payload.settings, "locale"), false);
   assert.match(draft.result.bundle.blobs[0].body, /defaultPreset: docs-task/u);
-});
-
-test("Settings update removes the retired layout key through the existing event path", () => {
-  const draft = compile({ layoutUnset: "adrRoot", expectedVersion: 7 });
-  assert.equal(draft.kind, "settings");
-  if (draft.kind !== "settings" || draft.result.kind !== "event") return;
-  assert.equal(draft.result.bundle.blobs[0].body.includes("adrRoot"), false);
-  assert.equal(draft.result.bundle.event.payload.settings.defaultPreset, "standard-task");
 });
 
 test("Settings expectedVersion rejects a stale edge update with a typed error", () => {


### PR DESCRIPTION
# English

## Summary

Remove the one-shot `--layout-unset` path that stripped the retired `adrRoot` layout key on every settings update. The key was unset on the canonical repository after the ADR entity migration (PR #2190, task_39cc8158d2f76a930bf4dcd0de), so `removeLayoutKey`, the `layoutUnset` settings-action field, its CLI flag in the thin command directory, and the fixtures that carried `adrRoot` are deleted. The layout reader already ignores keys it does not declare, so a stray `adrRoot` in another checkout's settings is inert rather than an error.

## Architectural Justification

The migration cutover left a write-path hook whose only purpose was to run once. Keeping it would make every settings write carry a migration step forever; deleting it keeps the settings write path equal to the settings facet it round-trips. No replacement mechanism is added.

## Gate Harvest / 门收割

Deleted-Production-Paths: `removeLayoutKey` / `removableLayoutKeys` / `RemovableLayoutKey` in `packages/kernel/src/layout/harness-settings.ts`; the `removeLayoutKey(next, "adrRoot")` call in `packages/kernel/src/domain/settings.ts`; the `layoutUnset` field, `settingsLayoutUnset` validator and its import in `packages/kernel/src/domain/settings-action-contract.ts`; the `--layout-unset` CLI input in `packages/daemon/src/protocol/daemon-protocol-commands.ts`.
Deleted-Gates-Fixtures: kernel contract test "Settings update removes the retired layout key through the existing event path"; the `--layout-unset adrRoot` parse case and the `unknownRoot` rejection assertion in `packages/cli/test/settings-command.test.ts`; the `layoutUnset` payload field, the `adrRoot` fixture line and the post-update `adrRoot` absence assertion in `packages/daemon/test/repo-cell-settings.integration.test.ts`; the `adrRoot` fixture line in `packages/kernel/test/contracts/settings-action.test.ts`.

## Machine-Readable Declarations

Production-Delta: +1/-26
Dependency-Change: none

### Optional Evidence Claims

none

## Task And Scope

task_39cc8158d2f76a930bf4dcd0de closeout follow-up (ADR entity migration: delete the one-shot layout-unset code once canonical settings no longer carry `adrRoot`). Canonical `ha settings update --layout-unset adrRoot` was applied on 2026-09-03 before this PR.

## Version Impact

None.

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none
- Authority: not applicable
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Follow-up governance task: not applicable

## Verification

- Touched tests `packages/cli/test/settings-command.test.ts`, `packages/kernel/test/contracts/settings-action.test.ts`, `packages/daemon/test/repo-cell-settings.integration.test.ts`: 7/7 pass under `node --test --experimental-strip-types`.
- `npx tsc -b packages/kernel packages/daemon packages/cli` clean; `tools/check-kernel-dead-exports.mjs` pass (171 allowlisted, 497 consumed); `tools/check-catalog-schema.mjs` pass; `tools/gates/line-density.mjs --base origin/main` pass.
- Not run locally: full CI (authority), `check:local`.

## Review Evidence

CEO-authored deletion (<50 production lines); semantic check against task_39cc8158 closeout note: the one-shot path is deleted in full and no replacement hook or compatibility shim is introduced. GitHub CI is the merge authority.

## Residual Risk

A checkout whose settings still list `adrRoot` under `layout:` keeps that line until someone edits the file; the reader ignores it, so behaviour is unchanged. Edge nodes register through the same daemon and inherit the canonical settings, so no per-node migration is needed.

# 中文

## 概要

删除一次性的 `--layout-unset` 路径:它在每次 settings 更新时剥掉已退役的 `adrRoot` layout 键。ADR 实体迁移(PR #2190,task_39cc8158d2f76a930bf4dcd0de)之后 canonical 仓库已经卸掉该键,所以 `removeLayoutKey`、settings-action 的 `layoutUnset` 字段、thin command directory 里的 CLI flag、以及携带 `adrRoot` 的测试夹具一并删除。layout 读取器本来就忽略未声明的键,其它 checkout 里残留的 `adrRoot` 只是惰性文本,不会报错。

## 架构辩护

迁移切换留下了一个只该跑一次的写路挂钩;留着它等于让每次 settings 写入永远背着一步迁移。删掉后 settings 写路与它往返的 settings facet 完全一致,不新增任何替代机制。

## 机读声明

见英文块。

## 治理声明

- 触碰受保护面:否
- 受保护面范围:无
- 授权:不适用
- 机器检查边界:本 PR 只断言声明存在,是否真实充分由评审判断。
- Break-glass:否
- Break-glass 原因:不适用
- 后续治理任务:不适用

## 验证

- 触碰测试 `packages/cli/test/settings-command.test.ts`、`packages/kernel/test/contracts/settings-action.test.ts`、`packages/daemon/test/repo-cell-settings.integration.test.ts`:`node --test --experimental-strip-types` 下 7/7 通过。
- `npx tsc -b packages/kernel packages/daemon packages/cli` 干净;`tools/check-kernel-dead-exports.mjs` 通过(171 条豁免,497 条被消费);`tools/check-catalog-schema.mjs` 通过;`tools/gates/line-density.mjs --base origin/main` 通过。
- 本地未跑:完整 CI(权威面)、`check:local`。

## 评审证据

CEO 亲自完成的删除(生产代码不足 50 行);对照 task_39cc8158 closeout 备注做语义核对:一次性路径整体删除,没有引入替代挂钩或兼容层。GitHub CI 是合并权威。

## 残余风险

某个 checkout 的 settings 若仍在 `layout:` 下列有 `adrRoot`,该行会留到有人手动编辑为止;读取器忽略它,行为不变。边缘节点经同一 daemon 注册并继承 canonical settings,不需要逐节点迁移。
