### PR TITLE
feat(task): allow a submitted execution to be amended before completion

### DIFF
--- a/packages/application/src/task-closeout-action.ts
+++ b/packages/application/src/task-closeout-action.ts
@@ -6,6 +6,7 @@ import {
   isSamePerson,
   isSameExecution,
   stableStringify,
+  submissionDigest,
   taskCloseoutPacketSchema,
   validateTaskCloseoutPacket,
   type ActorIdentity,
@@ -179,7 +180,10 @@ export async function runTaskCloseoutAction(dependencies: TaskCloseoutActionDepe
     submission = selected.submission;
     if (judgment.submission && !sameSubmission(selected.submission, judgment.submission))
       return reject(opId, "submission_mismatch", {
-        commands: [invocation],
+        commands: [
+          `ha task submit ${taskId} --execution-id ${selected.executionId} --amend --json-input '<submission-json>'`,
+          invocation,
+        ],
         diagnostic: {
           kind: "validation",
           entity: `execution/${selected.executionId}`,
@@ -217,7 +221,13 @@ export async function runTaskCloseoutAction(dependencies: TaskCloseoutActionDepe
   }
 
   const reviewId = deterministicReviewId(taskId, task.iteration, submission.commitSha, judgment.review),
-    consentId = deterministicId("consent-closeout", taskId, String(task.iteration), submission.commitSha, reviewId);
+    consentId = deterministicId(
+      "consent-closeout",
+      taskId,
+      String(task.iteration),
+      submissionDigest(submission),
+      reviewId,
+    );
 
   const selector = executionId ? { executionId } : {},
     humanReviewer: ActorIdentity = { principal: caller.principal, executor: null },

--- a/packages/application/src/task-lifecycle-service.ts
+++ b/packages/application/src/task-lifecycle-service.ts
@@ -538,7 +538,12 @@ function operationIdentityFromCommand<C extends TaskLifecycleCommand>(command: C
       ...(command.status === "cancelled" ? { force: command.force } : {}),
     };
   if (command.type === "SubmitExecution")
-    return { ...common, executionId: command.executionId, submission: command.submission };
+    return {
+      ...common,
+      executionId: command.executionId,
+      submission: command.submission,
+      ...(command.amend === true ? { amend: true } : {}),
+    };
   if (command.type === "RecordReview")
     return {
       ...common,
@@ -556,6 +561,7 @@ function operationIdentityFromCommand<C extends TaskLifecycleCommand>(command: C
       commitSha: command.commitSha,
       iteration: command.iteration,
       contentDigest: command.contentDigest,
+      submissionDigest: command.submissionDigest,
       capabilityRef: (proof as { readonly capabilityRef: string }).capabilityRef,
     };
   if (command.type === "RecordReviewConsent")
@@ -645,6 +651,7 @@ function operationIdentityFromEvent(event: TaskEventV1): unknown {
       ...common,
       executionId: event.payload.execution.executionId,
       submission: event.payload.execution.submission,
+      ...(event.payload.supersedesSubmissionId === undefined ? {} : { amend: true }),
     };
   if (event.type === "review_recorded") {
     const review = event.payload.review;
@@ -658,6 +665,7 @@ function operationIdentityFromEvent(event: TaskEventV1): unknown {
       commitSha: review.commitSha,
       iteration: review.iteration,
       contentDigest: review.contentDigest,
+      submissionDigest: review.submissionDigest,
       capabilityRef: review.capabilityRef,
     };
   }

--- a/packages/application/test/execution-approval-idempotency.test.ts
+++ b/packages/application/test/execution-approval-idempotency.test.ts
@@ -1,7 +1,7 @@
 // harness-test-tier: integration
 import assert from "node:assert/strict";
 import test from "node:test";
-import { normalizeTaskLifecycleCommand } from "../../kernel/src/index.ts";
+import { normalizeTaskLifecycleCommand, submissionDigest } from "../../kernel/src/index.ts";
 import { commitSha, lifecycleHarness, reviewer } from "./task-lifecycle-test-harness.ts";
 
 test("approval retry reuses Review identity and ignores transport-only metadata", async () => {
@@ -10,6 +10,7 @@ test("approval retry reuses Review identity and ignores transport-only metadata"
     await harness.create();
     await harness.start("execution-1");
     await harness.submit("execution-1");
+    const submitted = (await harness.service.read("task-1")).snapshot.executions[0]!.submission!;
     const command = {
       ...normalizeTaskLifecycleCommand(
         { workspaceId: harness.rootDir, actor: reviewer, source: "local", expectedRevision: 3 },
@@ -24,6 +25,7 @@ test("approval retry reuses Review identity and ignores transport-only metadata"
           commitSha,
           iteration: 0,
           contentDigest: `sha256:${"b".repeat(64)}` as const,
+          submissionDigest: submissionDigest(submitted),
         },
       ),
       eventId: "event-review-ae",
@@ -54,6 +56,7 @@ test("idempotent retry rejects source, workspace, expectedRevision, digest drift
     await harness.create();
     await harness.start("execution-1");
     await harness.submit("execution-1");
+    const submitted = (await harness.service.read("task-1")).snapshot.executions[0]!.submission!;
     const command = {
       ...normalizeTaskLifecycleCommand(
         { workspaceId: harness.rootDir, actor: reviewer, source: "local", expectedRevision: 3 },
@@ -68,6 +71,7 @@ test("idempotent retry rejects source, workspace, expectedRevision, digest drift
           commitSha,
           iteration: 0,
           contentDigest: `sha256:${"b".repeat(64)}` as const,
+          submissionDigest: submissionDigest(submitted),
         },
       ),
       eventId: "event-review-drift",

--- a/packages/application/test/execution-submit-atomicity.test.ts
+++ b/packages/application/test/execution-submit-atomicity.test.ts
@@ -7,7 +7,6 @@ import {
   approvedReviewsForExecution,
   consentedApprovedReviewForExecution,
   submissionDigest,
-  submissionId,
 } from "../../kernel/src/index.ts";
 import { lifecycleHarness } from "./task-lifecycle-test-harness.ts";
 
@@ -61,7 +60,7 @@ test("a submission amendment supersedes the bad packet and makes code-doc reconc
       throw new Error("initial submission event missing");
     assert.equal(
       submissions[1]?.payload.supersedesSubmissionId,
-      submissionId(submissions[0].payload.execution.submission),
+      `submission:${submissionDigest(submissions[0].payload.execution.submission)}`,
     );
 
     const reconciled = await harness.reconcile("execution-1", "a".repeat(40), "op-code-doc-after-amend");

--- a/packages/application/test/execution-submit-atomicity.test.ts
+++ b/packages/application/test/execution-submit-atomicity.test.ts
@@ -3,6 +3,12 @@ import assert from "node:assert/strict";
 import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import test from "node:test";
+import {
+  approvedReviewsForExecution,
+  consentedApprovedReviewForExecution,
+  submissionDigest,
+  submissionId,
+} from "../../kernel/src/index.ts";
 import { lifecycleHarness } from "./task-lifecycle-test-harness.ts";
 
 test("G29 submit publishes only its frozen targets while preserving unrelated bytes", async () => {
@@ -30,6 +36,74 @@ test("G29 submit publishes only its frozen targets while preserving unrelated by
     );
     assert.equal(read.snapshot.lease, null);
     assert.deepEqual(readFileSync(sentinel), before);
+  } finally {
+    await harness.cleanup();
+  }
+});
+
+test("a submission amendment supersedes the bad packet and makes code-doc reconciliation valid", async () => {
+  const harness = lifecycleHarness(),
+    badCommitSha = "b".repeat(40);
+  try {
+    await harness.create();
+    await harness.start("execution-1");
+    await harness.submit("execution-1", "op-submit-bad", "wrong cut", badCommitSha);
+
+    await assert.rejects(harness.reconcile("execution-1", "a".repeat(40)), /submitted commit/u);
+    const amended = await harness.amend("execution-1", "op-submit-amend", "corrected cut");
+    assert.equal(amended.outcome, "applied");
+    assert.equal(amended.snapshot.executions[0]?.submission?.commitSha, "a".repeat(40));
+
+    const submissions = harness.eventStore.read().events.filter((event) => event.type === "execution_submitted");
+    assert.equal(submissions.length, 2);
+    assert.equal(submissions[0]?.payload.execution.submission?.commitSha, badCommitSha);
+    if (submissions[0]?.type !== "execution_submitted" || !submissions[0].payload.execution.submission)
+      throw new Error("initial submission event missing");
+    assert.equal(
+      submissions[1]?.payload.supersedesSubmissionId,
+      submissionId(submissions[0].payload.execution.submission),
+    );
+
+    const reconciled = await harness.reconcile("execution-1", "a".repeat(40), "op-code-doc-after-amend");
+    assert.equal(reconciled.outcome, "applied");
+    assert.equal(reconciled.snapshot.codeDocWitnesses[0]?.commitSha, "a".repeat(40));
+  } finally {
+    await harness.cleanup();
+  }
+});
+
+test("an amendment makes prior Review and consent pins stale until explicit consent is renewed", async () => {
+  const harness = lifecycleHarness();
+  try {
+    await harness.create();
+    await harness.start("execution-1");
+    await harness.submit("execution-1", "op-submit-original", "original claim");
+    await harness.review("execution-1", "acceptance", "approved", "op-review-original");
+    await harness.consent("execution-1", "op-consent-original");
+
+    const amended = await harness.amend("execution-1", "op-submit-amend", "corrected claim");
+    const execution = amended.snapshot.executions[0];
+    if (execution?.schema !== "execution/v1") throw new Error("native execution missing");
+    assert.deepEqual(approvedReviewsForExecution(amended.snapshot.reviews, execution), []);
+    assert.equal(
+      consentedApprovedReviewForExecution(amended.snapshot.reviews, amended.snapshot.consents, {
+        ...execution,
+        submittedAt: amended.snapshot.consents[0]!.consentedAt,
+      }),
+      undefined,
+      "the old consent stays stale even when the amendment shares its millisecond",
+    );
+    await assert.rejects(harness.complete("execution-1", "op-complete-stale"), /approved Review/u);
+
+    await harness.consent("execution-1", "op-consent-amended", "review-op-review-original");
+    const consented = (await harness.service.read("task-1")).snapshot.consents.at(-1);
+    assert.equal(consented?.submissionDigest, submissionDigest(execution.submission!));
+    const completed = await harness.complete("execution-1", "op-complete-amended");
+    assert.equal(completed.outcome, "applied");
+    assert.equal(completed.snapshot.task?.status, "done");
+
+    await assert.rejects(harness.amend("execution-1", "op-amend-completed"), /current submitted execution/u);
+    await assert.rejects(harness.amend("execution-other", "op-amend-other"), /current submitted execution/u);
   } finally {
     await harness.cleanup();
   }

--- a/packages/application/test/task-action-explanation-service.test.ts
+++ b/packages/application/test/task-action-explanation-service.test.ts
@@ -76,10 +76,7 @@ test("Task explanations distinguish lifecycle state, actor capability, invocatio
       "invocation-required",
     );
     assert.equal(row(activeOther, "submit").available, false);
-    assert.equal(
-      criterion(row(activeOther, "submit"), "actor-domain-services/heldLeaseForExecutionActor").status,
-      "unmet",
-    );
+    assert.equal(criterion(row(activeOther, "submit"), "repo-cell-proof/proofFor.SubmitExecution").status, "unmet");
 
     const lapsed: TaskLifecycleSnapshot = {
       ...active,
@@ -90,8 +87,14 @@ test("Task explanations distinguish lifecycle state, actor capability, invocatio
 
     await harness.submit("execution-1");
     const submitted = await snapshot(harness),
+      submittedOwner = row(explain(harness, submitted, owner), "submit"),
       independentReview = row(explain(harness, submitted, reviewer), "review"),
       selfReview = row(explain(harness, submitted, owner), "review");
+    assert.equal(submittedOwner.available, true);
+    assert.match(
+      criterion(submittedOwner, "task-lifecycle-command-transitions/submit.validate").nextActions[0] ?? "",
+      /--amend/u,
+    );
     assert.equal(independentReview.available, true);
     assert.equal(
       criterion(independentReview, "task-lifecycle-review-transitions/review.validate").status,

--- a/packages/application/test/task-lifecycle-test-harness.ts
+++ b/packages/application/test/task-lifecycle-test-harness.ts
@@ -3,7 +3,11 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import type { TaskLifecycleKillpoint } from "../src/task-lifecycle-service.ts";
-import { normalizeTaskLifecycleCommand, type EventPublicationKillpoint } from "../../kernel/src/index.ts";
+import {
+  normalizeTaskLifecycleCommand,
+  submissionDigest,
+  type EventPublicationKillpoint,
+} from "../../kernel/src/index.ts";
 import { reviewDigest } from "../../kernel/src/index.ts";
 import { makeTaskEventStore, makeTaskProjection } from "../../kernel/test/store/task-lifecycle-runtime.ts";
 import { makeTaskLifecycleService } from "../src/task-lifecycle-service.ts";
@@ -162,7 +166,12 @@ export function lifecycleHarness() {
         },
       });
     },
-    submit: async (executionId: string, opId = `op-submit-${revision() + 1}`, claim = "implemented") => {
+    submit: async (
+      executionId: string,
+      opId = `op-submit-${revision() + 1}`,
+      claim = "implemented",
+      submittedCommitSha = commitSha,
+    ) => {
       const next = revision() + 1;
       const leaseVersion = (await service.read("task-1")).snapshot.lease?.version;
       if (leaseVersion === undefined) throw new Error(`execution ${executionId} has no active lease`);
@@ -181,12 +190,43 @@ export function lifecycleHarness() {
               verificationNotes: ["tests"],
               knownGaps: [],
               residualRisks: [],
-              commitSha,
+              commitSha: submittedCommitSha,
             },
           },
           opId,
         ),
         { actorBinding: owner, leaseVersion, sessionDisposition: "complete" },
+      );
+    },
+    amend: async (
+      executionId: string,
+      opId = `op-amend-${revision() + 1}`,
+      claim = "corrected",
+      submittedCommitSha = commitSha,
+    ) => {
+      const next = revision() + 1;
+      return service.execute(
+        command(
+          owner,
+          next,
+          {
+            type: "SubmitExecution",
+            taskId: "task-1",
+            executionId,
+            amend: true,
+            submission: {
+              completionClaim: claim,
+              deliverables: [],
+              outputs: [],
+              verificationNotes: ["tests"],
+              knownGaps: [],
+              residualRisks: [],
+              commitSha: submittedCommitSha,
+            },
+          },
+          opId,
+        ),
+        { actorBinding: owner, leaseVersion: null, sessionDisposition: "complete" },
       );
     },
     review: async (
@@ -196,7 +236,9 @@ export function lifecycleHarness() {
       opId = `op-review-${revision() + 1}`,
     ) => {
       const next = revision() + 1;
-      const snapshot = (await service.read("task-1")).snapshot;
+      const snapshot = (await service.read("task-1")).snapshot,
+        submitted = snapshot.executions.find((value) => value.executionId === executionId);
+      if (!submitted?.submission) throw new Error(`execution ${executionId} is not submitted`);
       return service.execute(
         command(
           reviewer,
@@ -209,9 +251,10 @@ export function lifecycleHarness() {
             verdict,
             reason: `${kind} ${verdict}`,
             evidenceChecked: [],
-            commitSha,
+            commitSha: submitted.submission.commitSha,
             iteration: snapshot.task?.iteration ?? 0,
             contentDigest: `sha256:${"b".repeat(64)}`,
+            submissionDigest: submissionDigest(submitted.submission),
           },
           opId,
         ),
@@ -219,6 +262,32 @@ export function lifecycleHarness() {
           actorBinding: reviewer,
           capability: "execution-review@v1",
           capabilityRef: `cap-${opId}`,
+        },
+      );
+    },
+    reconcile: async (executionId: string, reconciledCommitSha: string, opId = `op-code-doc-${revision() + 1}`) => {
+      const next = revision() + 1,
+        snapshot = (await service.read("task-1")).snapshot;
+      return service.execute(
+        command(
+          owner,
+          next,
+          {
+            type: "ReconcileCodeDoc",
+            taskId: "task-1",
+            executionId,
+            witnessId: `witness-${next}`,
+            commitSha: reconciledCommitSha,
+            iteration: snapshot.task?.iteration ?? 0,
+            paths: [],
+          },
+          opId,
+        ),
+        {
+          actorBinding: owner,
+          capability: "code-doc-reconcile@v1",
+          capabilityRef: `cap-${opId}`,
+          commitPaths: { commitSha: reconciledCommitSha, paths: [] },
         },
       );
     },

--- a/packages/application/test/task-lifecycle-test-harness.ts
+++ b/packages/application/test/task-lifecycle-test-harness.ts
@@ -171,6 +171,7 @@ export function lifecycleHarness() {
       opId = `op-submit-${revision() + 1}`,
       claim = "implemented",
       submittedCommitSha = commitSha,
+      deliverables: readonly string[] = [],
     ) => {
       const next = revision() + 1;
       const leaseVersion = (await service.read("task-1")).snapshot.lease?.version;
@@ -185,7 +186,7 @@ export function lifecycleHarness() {
             executionId,
             submission: {
               completionClaim: claim,
-              deliverables: [],
+              deliverables,
               outputs: [],
               verificationNotes: ["tests"],
               knownGaps: [],

--- a/packages/application/test/task-lifecycle-transition-service.test.ts
+++ b/packages/application/test/task-lifecycle-transition-service.test.ts
@@ -44,7 +44,9 @@ test("completion blocker matrix returns one canonical next for every substantive
   try {
     const created = await harness.create(),
       started = await harness.start("execution-1"),
-      submitted = await harness.submit("execution-1"),
+      submitted = await harness.submit("execution-1", "op-submit-report-only", "implemented", "a".repeat(40), [
+        "tasks/task-1-audit/artifacts/report.md",
+      ]),
       reviewed = await harness.review("execution-1", "acceptance", "approved"),
       consented = await harness.consent("execution-1");
     const ready = {
@@ -92,15 +94,7 @@ test("completion blocker matrix returns one canonical next for every substantive
       lineage.next.command,
       "ha decision relate <decision-id> --anchor <claim-id> --type derives --target task/task-1 --rationale <why this decision authorises the task>",
     );
-    const reportOnly = {
-      ...withGates(["code-doc-reconciliation"]),
-      executions: consented.snapshot.executions.map((execution) => ({
-        ...execution,
-        submission: execution.submission
-          ? { ...execution.submission, deliverables: ["tasks/task-1-audit/artifacts/report.md"] }
-          : null,
-      })),
-    };
+    const reportOnly = withGates(["code-doc-reconciliation"]);
     assert.deepEqual(
       completionBlockers(reportOnly, "execution-1", ready).map((blocker) => blocker.code),
       ["code_doc_missing"],

--- a/packages/cli/test/task-action-derivation.test.ts
+++ b/packages/cli/test/task-action-derivation.test.ts
@@ -67,6 +67,26 @@ test("daemon lifecycle command inputs and thin CLI parameters are projections of
     assert.deepEqual(complete.command.action.factHolds, [{ factRef: "fact/F-ABCDEFGH", rationale: "Still holds" }]);
   }
   assert.equal(parseThinCommand(["task", "submit", "task_contract"]).ok, false);
+  const amended = parseThinCommand([
+    "task",
+    "submit",
+    "task_contract",
+    "--execution-id",
+    "execution-1",
+    "--amend",
+    "--json-input",
+    JSON.stringify({
+      completionClaim: "corrected",
+      deliverables: [],
+      outputs: [],
+      verificationNotes: [],
+      knownGaps: [],
+      residualRisks: [],
+      commitSha: "a".repeat(40),
+    }),
+  ]);
+  assert.equal(amended.ok, true, JSON.stringify(amended));
+  if (amended.ok) assert.equal(amended.command.action.amend, true);
 });
 
 test("repo.task.run validator consumes the same closed Task Action input", () => {
@@ -76,6 +96,16 @@ test("repo.task.run validator consumes the same closed Task Action input", () =>
       params: { repo: { repoId: "canonical" }, payload: { action } },
     });
   assert.deepEqual(call({ kind: "task-submit", taskId: "task_contract", fromFile: "submission.json" }), []);
+  assert.deepEqual(
+    call({
+      kind: "task-submit",
+      taskId: "task_contract",
+      executionId: "execution-1",
+      amend: true,
+      fromFile: "submission.json",
+    }),
+    [],
+  );
   assert.match(call({ kind: "task-submit", taskId: "task_contract" }).join("\n"), /exactly one/u);
   assert.match(
     call({ kind: "task-start", taskId: "task_contract", expectedVersion: "4" }).join("\n"),

--- a/packages/cli/test/task-action-help.test.ts
+++ b/packages/cli/test/task-action-help.test.ts
@@ -20,6 +20,7 @@ test("Task lifecycle help is projected from the generated Action declarations", 
     ),
   );
   const submit = rows.find(({ usage }) => usage.startsWith("ha task submit "));
+  assert.match(submit?.usage ?? "", /--amend/u);
   assert.match(submit?.usage ?? "", /--from-file.*--json-input/u);
   assert.match(submit?.help ?? "", /mutually exclusive with: --json-input/u);
   assert.equal(

--- a/packages/daemon/src/protocol/daemon-protocol-commands-task.ts
+++ b/packages/daemon/src/protocol/daemon-protocol-commands-task.ts
@@ -158,6 +158,18 @@ export const generatedTaskActionProtocolDeclarations = Object.freeze([
           },
         },
         {
+          field: "amend",
+          type: "boolean",
+          required: false,
+          cli: {
+            name: "--amend",
+            kind: "boolean",
+            error: {
+              code: "invalid_field",
+            },
+          },
+        },
+        {
           field: "fromFile",
           type: "string",
           required: false,
@@ -217,7 +229,7 @@ export const generatedTaskActionProtocolDeclarations = Object.freeze([
       ],
       exactlyOneOf: [["fromFile", "jsonInput"]],
     },
-    explain: "Atomically fence and release the execution lease while publishing its submission.",
+    explain: "Publish the initial submission or amend the current submitted execution without replacing its history.",
     execution: {
       ingress: "task-submit",
       compile: null,

--- a/packages/daemon/src/protocol/daemon-protocol-validate-entities.ts
+++ b/packages/daemon/src/protocol/daemon-protocol-validate-entities.ts
@@ -307,22 +307,23 @@ export function execution(value: unknown): boolean {
 export const reviewAuthorityRefKey = "capab" + "ilityRef";
 
 export function review(value: unknown): boolean {
+  const fields = [
+    "schema",
+    "reviewId",
+    "taskId",
+    "executionId",
+    "verdict",
+    "actor",
+    reviewAuthorityRefKey,
+    "reason",
+    "evidenceChecked",
+    "commitSha",
+    "iteration",
+    "contentDigest",
+    "reviewedAt",
+  ];
   return (
-    exactRecord(value, [
-      "schema",
-      "reviewId",
-      "taskId",
-      "executionId",
-      "verdict",
-      "actor",
-      reviewAuthorityRefKey,
-      "reason",
-      "evidenceChecked",
-      "commitSha",
-      "iteration",
-      "contentDigest",
-      "reviewedAt",
-    ]) &&
+    (exactRecord(value, fields) || exactRecord(value, [...fields, "submissionDigest"])) &&
     value.schema === "review/v1" &&
     [
       value.reviewId,
@@ -337,28 +338,31 @@ export function review(value: unknown): boolean {
     stringArray(value.evidenceChecked) &&
     sha(value.commitSha) &&
     iteration(value.iteration) &&
-    digest(value.contentDigest)
+    digest(value.contentDigest) &&
+    (value.submissionDigest === undefined || digest(value.submissionDigest))
   );
 }
 
 export function consent(value: unknown): boolean {
+  const fields = [
+    "schema",
+    "consentId",
+    "taskId",
+    "executionId",
+    "reviewId",
+    "reviewDigest",
+    "contentDigest",
+    "actor",
+    "source",
+    "consentedAt",
+  ];
   return (
-    exactRecord(value, [
-      "schema",
-      "consentId",
-      "taskId",
-      "executionId",
-      "reviewId",
-      "reviewDigest",
-      "contentDigest",
-      "actor",
-      "source",
-      "consentedAt",
-    ]) &&
+    (exactRecord(value, fields) || exactRecord(value, [...fields, "submissionDigest"])) &&
     value.schema === "review-consent/v1" &&
     [value.consentId, value.taskId, value.executionId, value.reviewId, value.consentedAt].every(nonEmpty) &&
     digest(value.reviewDigest) &&
     digest(value.contentDigest) &&
+    (value.submissionDigest === undefined || digest(value.submissionDigest)) &&
     actor(value.actor) &&
     source(value.source)
   );

--- a/packages/daemon/src/repo-cell-command.ts
+++ b/packages/daemon/src/repo-cell-command.ts
@@ -116,28 +116,19 @@ export function buildCommand(
   if (lifecycleAction?.commandType === "SubmitExecution") {
     const amendment = action.amend === true,
       held = heldLeaseForExecutionActor(snapshot, undefined, binding.actor),
-      candidates = amendment ? currentSubmittedExecutions(snapshot) : held ? [held] : [],
+      flags = `${amendment ? " --amend" : ""} --json-input '<submission-json>'`,
       executionId =
         explicitExecutionId(action) ??
         uniqueDerivedExecutionId(
-          candidates,
+          amendment ? currentSubmittedExecutions(snapshot) : held ? [held] : [],
           amendment ? "Current submitted execution" : "Authenticated active-lease execution",
           amendment
             ? `Run ha task show ${taskId}; only a current submitted execution can be amended.`
             : snapshot.lease
-              ? [
-                  "The authenticated holder (",
-                  `${actorHint(snapshot.lease.actor)}`,
-                  ") must run ha task submit ",
-                  `${taskId}`,
-                  " --json-input '<submission-json>', or ha task release ",
-                  `${taskId}`,
-                  ".",
-                ].join("")
+              ? `The authenticated holder (${actorHint(snapshot.lease.actor)}) must run ` +
+                `ha task submit ${taskId} --json-input '<submission-json>', or ha task release ${taskId}.`
               : `Run ha task start ${taskId}, then retry ha task submit ${taskId} --json-input '<submission-json>'.`,
-          (candidate) =>
-            `ha task submit ${taskId} --execution-id ${candidate}${amendment ? " --amend" : ""} ` +
-            "--json-input '<submission-json>'",
+          (candidate) => `ha task submit ${taskId} --execution-id ${candidate}${flags}`,
         );
     return normalizeTaskLifecycleCommand(bound, {
       type: "SubmitExecution",

--- a/packages/daemon/src/repo-cell-command.ts
+++ b/packages/daemon/src/repo-cell-command.ts
@@ -9,6 +9,7 @@ import {
   makeTaskEventStore,
   normalizeTaskLifecycleCommand,
   reviewDigest,
+  submissionDigest,
   type TaskLifecycleCommand,
 } from "../../kernel/src/index.ts";
 import { consentJsonFields } from "../../preset/src/index.ts";
@@ -113,30 +114,37 @@ export function buildCommand(
     });
   }
   if (lifecycleAction?.commandType === "SubmitExecution") {
-    const held = heldLeaseForExecutionActor(snapshot, undefined, binding.actor),
+    const amendment = action.amend === true,
+      held = heldLeaseForExecutionActor(snapshot, undefined, binding.actor),
+      candidates = amendment ? currentSubmittedExecutions(snapshot) : held ? [held] : [],
       executionId =
         explicitExecutionId(action) ??
         uniqueDerivedExecutionId(
-          held ? [held] : [],
-          "Authenticated active-lease execution",
-          snapshot.lease
-            ? [
-                "The authenticated holder (",
-                `${actorHint(snapshot.lease.actor)}`,
-                ") must run ha task submit ",
-                `${taskId}`,
-                " --json-input '<submission-json>', or ha task release ",
-                `${taskId}`,
-                ".",
-              ].join("")
-            : `Run ha task start ${taskId}, then retry ha task submit ${taskId} --json-input '<submission-json>'.`,
-          () => `ha task submit ${taskId} --json-input '<submission-json>'`,
+          candidates,
+          amendment ? "Current submitted execution" : "Authenticated active-lease execution",
+          amendment
+            ? `Run ha task show ${taskId}; only a current submitted execution can be amended.`
+            : snapshot.lease
+              ? [
+                  "The authenticated holder (",
+                  `${actorHint(snapshot.lease.actor)}`,
+                  ") must run ha task submit ",
+                  `${taskId}`,
+                  " --json-input '<submission-json>', or ha task release ",
+                  `${taskId}`,
+                  ".",
+                ].join("")
+              : `Run ha task start ${taskId}, then retry ha task submit ${taskId} --json-input '<submission-json>'.`,
+          (candidate) =>
+            `ha task submit ${taskId} --execution-id ${candidate}${amendment ? " --amend" : ""} ` +
+            "--json-input '<submission-json>'",
         );
     return normalizeTaskLifecycleCommand(bound, {
       type: "SubmitExecution",
       taskId,
       executionId,
       submission: submissionPacket(action, rootDir),
+      ...(amendment ? { amend: true as const } : {}),
     });
   }
   if (lifecycleAction?.commandType === "RecordReview") {
@@ -187,6 +195,7 @@ export function buildCommand(
       commitSha: submitted.submission.commitSha,
       iteration: submitted.iteration,
       contentDigest: packet.digest,
+      submissionDigest: submissionDigest(submitted.submission),
     });
   }
   if (action.kind === "task-review-consent") {

--- a/packages/daemon/src/repo-cell-execution-selection.ts
+++ b/packages/daemon/src/repo-cell-execution-selection.ts
@@ -1,5 +1,5 @@
 import {
-  approvedReviewsForCut,
+  approvedReviewHistoryForExecution,
   closeoutReadiness,
   currentSubmittedExecutions,
   getExecutableEntityAction,
@@ -59,12 +59,7 @@ export function reviewConsentSelection(
     candidates = executions.flatMap((execution) =>
       execution.submission === null
         ? []
-        : approvedReviewsForCut(
-            snapshot.reviews,
-            execution.executionId,
-            execution.submission.commitSha,
-            execution.iteration,
-          )
+        : approvedReviewHistoryForExecution(snapshot.reviews, execution)
             .filter((review) => reviewId === undefined || review.reviewId === reviewId)
             .map((review) => ({
               executionId: execution.executionId,

--- a/packages/daemon/src/repo-cell-packets.ts
+++ b/packages/daemon/src/repo-cell-packets.ts
@@ -1,7 +1,8 @@
 import { createHash } from "node:crypto";
 import {
-  approvedReviewsForCut,
-  consentedApprovedReview,
+  approvedReviewHistoryForExecution,
+  approvedReviewsForExecution,
+  consentedApprovedReviewForExecution,
   makeTaskEventStore,
   reviewDigest,
   type WriteReceiptDraft as WriteReceipt,
@@ -155,36 +156,23 @@ export function lifecycleReceipt(
   const executionId = "execution" in event.payload ? event.payload.execution.executionId : null,
     execution = snapshot.executions.find((value) => value.executionId === executionId),
     undeclared = execution?.actor.executor === null,
-    reviews = execution?.submission
-      ? snapshot.reviews.filter(
-          (value) =>
-            value.executionId === executionId &&
-            value.commitSha === execution.submission?.commitSha &&
-            value.iteration === execution.iteration,
-        )
-      : [],
-    approved = execution?.submission
-      ? approvedReviewsForCut(snapshot.reviews, executionId ?? "", execution.submission.commitSha, execution.iteration)
-      : [],
+    reviews = execution?.submission ? approvedReviewsForExecution(snapshot.reviews, execution) : [],
+    approved = reviews,
+    approvedHistory = execution?.submission ? approvedReviewHistoryForExecution(snapshot.reviews, execution) : [],
     selected = execution?.submission
-      ? consentedApprovedReview(
-          snapshot.reviews,
-          snapshot.consents,
-          executionId ?? "",
-          execution.submission.commitSha,
-          execution.iteration,
-        )
+      ? consentedApprovedReviewForExecution(snapshot.reviews, snapshot.consents, execution)
       : undefined,
     eventReview =
       event.type === "review_recorded" || event.type === "review_consent_recorded" ? event.payload.review : undefined,
     receiptReview = eventReview ?? selected?.review ?? (reviews.length === 1 ? reviews[0] : undefined),
     reviewId = receiptReview?.reviewId ?? null,
     declarationNeeded = undeclared && reviews.length === 0,
-    consentReviewId = approved.length === 1 ? approved[0]!.reviewId : "<review-id>",
+    consentCandidates = approved.length ? approved : approvedHistory,
+    consentReviewId = consentCandidates.length === 1 ? consentCandidates[0]!.reviewId : "<review-id>",
     from =
       event.type === "execution_started"
         ? "planned/implementation"
-        : event.type === "execution_submitted"
+        : event.type === "execution_submitted" && event.payload.supersedesSubmissionId === undefined
           ? "active/implementation"
           : "in_review/review",
     to = `${snapshot.task?.status ?? "missing"}/${snapshot.task?.currentNode ?? "missing"}`,
@@ -199,7 +187,7 @@ export function lifecycleReceipt(
             ? `ha task start ${event.taskId} --execution-id <id>`
             : snapshot.task?.status !== "in_review"
               ? null
-              : !approved.length
+              : !approved.length && !approvedHistory.length
                 ? declarationNeeded
                   ? [
                       "ha task declare-executor ",
@@ -245,12 +233,14 @@ export function lifecycleReceipt(
       : [],
     changedPaths = (event.payload.documentClaims ?? []).map((claim) => claim.path),
     summary =
-      event.type === "execution_started" && undeclared
-        ? [
-            "Execution declared no executor; a same-person review will require an ",
-            "audited agent executor declaration before review.",
-          ].join("")
-        : undefined;
+      event.type === "execution_submitted" && event.payload.supersedesSubmissionId !== undefined
+        ? "Submission amended; prior Review and consent pins are stale until reviewed or explicitly consented again."
+        : event.type === "execution_started" && undeclared
+          ? [
+              "Execution declared no executor; a same-person review will require an ",
+              "audited agent executor declaration before review.",
+            ].join("")
+          : undefined;
   return {
     outcome: "applied",
     opId: event.opId,

--- a/packages/daemon/src/repo-cell-proof.ts
+++ b/packages/daemon/src/repo-cell-proof.ts
@@ -3,7 +3,7 @@ import {
   canonicalGateReceipts,
   codeDocRecordId,
   consumeKnownError,
-  consentedApprovedReview,
+  consentedApprovedReviewForExecution,
   currentCodeDocWitness,
   evaluateTaskActionCapability,
   heldLeaseForExecutionActor,
@@ -30,7 +30,7 @@ import type { PublicPublication, RepoCellBinding, RepoTaskAction, Snapshot } fro
 import { leaseTtlMs } from "./repo-cell-types.ts";
 
 const START_VALIDATION_CRITERION = "task-lifecycle-command-transitions/start.validate";
-const SUBMIT_LEASE_CRITERION = "actor-domain-services/heldLeaseForExecutionActor";
+const SUBMIT_PROOF_CRITERION = "repo-cell-proof/proofFor.SubmitExecution";
 const REVIEW_PROOF_CRITERION = "repo-cell-proof/proofFor.RecordReview";
 const COMPLETE_VALIDATION_CRITERION = "task-lifecycle-review-transitions/complete.validate";
 
@@ -73,14 +73,30 @@ export async function proofFor(
   }
   if (command.type === "TransitionTask") return {};
   if (command.type === "SubmitExecution") {
+    if (command.amend === true)
+      return {
+        actorBinding: command.actor,
+        leaseVersion: null,
+        sessionDisposition: "unavailable",
+      };
     const lease = heldLeaseForExecutionActor(snapshot, command.executionId, command.actor);
-    if (!lease)
-      throw cellCriterionError(
-        "lease_required",
-        "Task submit lease proof was not satisfied.",
-        "submit",
-        SUBMIT_LEASE_CRITERION,
+    if (!lease) {
+      const alreadySubmitted = snapshot.executions.some(
+        (execution) => execution.executionId === command.executionId && execution.state === "submitted",
       );
+      throw cellCriterionError(
+        alreadySubmitted ? "invalid_transition" : "lease_required",
+        "Task submit requires the active lease; use --amend only to replace the current submitted packet.",
+        "submit",
+        SUBMIT_PROOF_CRITERION,
+        alreadySubmitted
+          ? [
+              `ha task submit ${command.taskId} --execution-id ${command.executionId} ` +
+                "--amend --json-input '<submission-json>'",
+            ]
+          : [],
+      );
+    }
     return {
       actorBinding: command.actor,
       leaseVersion: lease.version,
@@ -383,8 +399,15 @@ export function gateChecks(snapshot: Snapshot, executionId: string) {
     (value) => value.executionId === executionId && value.iteration === snapshot.task?.iteration,
   );
   return (snapshot.task?.completionGateIds ?? []).map((gate) => {
-    const codeDoc =
+    const candidate =
         gate === "code-doc-reconciliation" ? currentCodeDocWitness(snapshot.codeDocWitnesses, executionId) : undefined,
+      codeDoc =
+        candidate &&
+        execution?.submission &&
+        candidate.iteration === execution.iteration &&
+        (candidate.schema === "code-doc-witness-repoint/v1" || candidate.commitSha === execution.submission.commitSha)
+          ? candidate
+          : undefined,
       witness =
         gate !== "code-doc-reconciliation"
           ? snapshot.gateWitnesses.find(
@@ -392,7 +415,8 @@ export function gateChecks(snapshot: Snapshot, executionId: string) {
                 value.gateId === gate &&
                 value.executionId === executionId &&
                 value.commitSha === execution?.submission?.commitSha &&
-                value.iteration === execution?.iteration,
+                value.iteration === execution?.iteration &&
+                value.result === "pass",
             )
           : undefined;
     return {
@@ -406,12 +430,6 @@ export function gateChecks(snapshot: Snapshot, executionId: string) {
 export function selectedReviewId(snapshot: Snapshot, executionId: string): string | null {
   const execution = snapshot.executions.find((value) => value.executionId === executionId);
   return execution?.submission
-    ? (consentedApprovedReview(
-        snapshot.reviews,
-        snapshot.consents,
-        executionId,
-        execution.submission.commitSha,
-        execution.iteration,
-      )?.review.reviewId ?? null)
+    ? (consentedApprovedReviewForExecution(snapshot.reviews, snapshot.consents, execution)?.review.reviewId ?? null)
     : null;
 }

--- a/packages/daemon/src/task-action-catalog-runtime.ts
+++ b/packages/daemon/src/task-action-catalog-runtime.ts
@@ -16,7 +16,7 @@ import type { RepoCellOperationalContext } from "./repo-cell-action-context.ts";
 const REVISION_CRITERION = "task-lifecycle-contract-support/revisionIssues";
 const START_CRITERION = "task-lifecycle-command-transitions/canStartExecution";
 const SUBMIT_VALIDATION_CRITERION = "task-lifecycle-command-transitions/submit.validate";
-const SUBMIT_LEASE_CRITERION = "actor-domain-services/heldLeaseForExecutionActor";
+const SUBMIT_PROOF_CRITERION = "repo-cell-proof/proofFor.SubmitExecution";
 
 export async function runTaskActionCatalogRuntime(
   cell: RepoCellOperationalContext,
@@ -41,6 +41,7 @@ export async function runTaskActionCatalogRuntime(
               taskId,
               ...(typeof action.executionId === "string" ? { executionId: action.executionId } : {}),
               ...(typeof action.reviewId === "string" ? { reviewId: action.reviewId } : {}),
+              ...(action.kind === "task-submit" ? { amend: action.amend === true } : {}),
             },
           })
         : [],
@@ -89,7 +90,7 @@ export async function runTaskActionCatalogRuntime(
   const submitValidationEvaluation = evaluations.find(
       ({ criterionRef }) => criterionRef === SUBMIT_VALIDATION_CRITERION,
     ),
-    submitLeaseEvaluation = evaluations.find(({ criterionRef }) => criterionRef === SUBMIT_LEASE_CRITERION),
+    submitLeaseEvaluation = evaluations.find(({ criterionRef }) => criterionRef === SUBMIT_PROOF_CRITERION),
     submitValidationUnmet = submitValidationEvaluation?.status === "unmet",
     submitLeaseUnmet = submitLeaseEvaluation?.status === "unmet";
   if (action.kind === "task-submit" && submitValidationUnmet && contract)

--- a/packages/daemon/test/action-failure-explanation.integration.test.ts
+++ b/packages/daemon/test/action-failure-explanation.integration.test.ts
@@ -53,7 +53,7 @@ test("Task execution rejects with the exact Action criterion and performs no rej
       rootDir,
       repoId,
       () => cell!.run({ kind: "task-submit", taskId, executionId }, otherWriter),
-      ["actor-domain-services/heldLeaseForExecutionActor"],
+      ["repo-cell-proof/proofFor.SubmitExecution"],
     );
     await assertRejectedWithoutMutation(
       rootDir,

--- a/packages/daemon/test/hitrate-task-lifecycle.integration.test.ts
+++ b/packages/daemon/test/hitrate-task-lifecycle.integration.test.ts
@@ -4,7 +4,7 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
-import { makeTaskEventReader, submissionDigest, submissionId } from "../../kernel/src/index.ts";
+import { makeTaskEventReader, submissionDigest } from "../../kernel/src/index.ts";
 import { canonicalRoot, workspaceId } from "../src/protocol/daemon-protocol.contract.ts";
 import { openBootstrappedRepoCell as openRepoCell } from "./repo-settings.fixture.ts";
 import { withRoleBinding } from "./role-binding.fixtures.ts";
@@ -175,7 +175,7 @@ test("task start, inline submit, and code-doc reconcile reuse daemon-known lifec
       throw new Error("initial submission event missing");
     assert.equal(
       submissionEvents[1]?.payload.supersedesSubmissionId,
-      submissionId(initialSubmission.payload.execution.submission),
+      `submission:${submissionDigest(initialSubmission.payload.execution.submission)}`,
     );
 
     const obsolete = (await cell.run(

--- a/packages/daemon/test/hitrate-task-lifecycle.integration.test.ts
+++ b/packages/daemon/test/hitrate-task-lifecycle.integration.test.ts
@@ -156,16 +156,59 @@ test("task start, inline submit, and code-doc reconcile reuse daemon-known lifec
     assert.equal(wrongExecutionAmend.outcome, "op_rejected", JSON.stringify(wrongExecutionAmend));
     assert.equal(wrongExecutionAmend.code, "invalid_transition");
 
-    const amended = (await cell.run(
+    const noOpAmend = (await cell.run(
       {
         kind: "task-submit",
         taskId,
         executionId,
         amend: true,
-        jsonInput: JSON.stringify({ ...submission, completionClaim: "Corrected lifecycle cut.", commitSha }),
+        jsonInput: JSON.stringify(submission),
       },
       holder,
     )) as Record<string, unknown>;
+    assert.equal(noOpAmend.outcome, "op_rejected", JSON.stringify(noOpAmend));
+    assert.equal(noOpAmend.code, "invalid_transition");
+
+    const crossActorAmend = (await cell.run(
+      {
+        kind: "task-submit",
+        taskId,
+        executionId,
+        amend: true,
+        jsonInput: JSON.stringify({ ...submission, completionClaim: "Foreign correction.", commitSha }),
+      },
+      foreign,
+    )) as Record<string, unknown>;
+    assert.equal(crossActorAmend.outcome, "op_rejected", JSON.stringify(crossActorAmend));
+    assert.equal(crossActorAmend.code, "lease_required");
+
+    const amendRevision = Number(submitted.revision),
+      amendmentPackets = [
+        { ...submission, completionClaim: "Corrected lifecycle cut A.", commitSha },
+        { ...submission, completionClaim: "Corrected lifecycle cut B.", commitSha },
+      ],
+      amendmentResults = (await Promise.all(
+        amendmentPackets.map((packet) =>
+          cell.run(
+            {
+              kind: "task-submit",
+              taskId,
+              executionId,
+              amend: true,
+              expectedVersion: amendRevision,
+              jsonInput: JSON.stringify(packet),
+            },
+            holder,
+          ),
+        ),
+      )) as readonly Record<string, unknown>[],
+      appliedAmendments = amendmentResults.filter(({ outcome }) => outcome === "applied"),
+      rejectedAmendments = amendmentResults.filter(({ outcome }) => outcome === "op_rejected"),
+      amended = appliedAmendments[0]!,
+      amendedPacket = amendmentPackets[amendmentResults.indexOf(amended)]!;
+    assert.equal(appliedAmendments.length, 1, JSON.stringify(amendmentResults));
+    assert.equal(rejectedAmendments.length, 1, JSON.stringify(amendmentResults));
+    assert.equal(rejectedAmendments[0]?.code, "invalid_transition", JSON.stringify(amendmentResults));
     assert.equal(amended.outcome, "applied", JSON.stringify(amended));
     assert.match(String(amended.summary), /prior Review and consent pins are stale/u);
     const submissionEvents = events().filter((candidate) => candidate.type === "execution_submitted");
@@ -251,7 +294,7 @@ test("task start, inline submit, and code-doc reconcile reuse daemon-known lifec
     const consentEvent = makeTaskEventReader({ repoId, rootDir }).readEvent(String(consented.opId));
     assert.equal(
       consentEvent?.type === "review_consent_recorded" ? consentEvent.payload.consent.submissionDigest : null,
-      submissionDigest({ ...submission, completionClaim: "Corrected lifecycle cut.", commitSha }),
+      submissionDigest(amendedPacket),
     );
     const completed = await cell.run({ kind: "task-complete", taskId, ci: "passed" }, holder);
     assert.equal(completed.outcome, "applied", JSON.stringify(completed));

--- a/packages/daemon/test/hitrate-task-lifecycle.integration.test.ts
+++ b/packages/daemon/test/hitrate-task-lifecycle.integration.test.ts
@@ -4,7 +4,7 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
-import { makeTaskEventReader } from "../../kernel/src/index.ts";
+import { makeTaskEventReader, submissionDigest, submissionId } from "../../kernel/src/index.ts";
 import { canonicalRoot, workspaceId } from "../src/protocol/daemon-protocol.contract.ts";
 import { openBootstrappedRepoCell as openRepoCell } from "./repo-settings.fixture.ts";
 import { withRoleBinding } from "./role-binding.fixtures.ts";
@@ -107,6 +107,7 @@ test("task start, inline submit, and code-doc reconcile reuse daemon-known lifec
     assert.equal(events().length, startedEvents, "foreign retry must not append an event");
 
     const commitSha = git(rootDir, "rev-parse", "HEAD"),
+      incorrectCommitSha = "b".repeat(40),
       submission = {
         completionClaim: "Lifecycle behavior is implemented.",
         deliverables: ["README.md"],
@@ -114,7 +115,7 @@ test("task start, inline submit, and code-doc reconcile reuse daemon-known lifec
         verificationNotes: ["integration test"],
         knownGaps: [],
         residualRisks: [],
-        commitSha,
+        commitSha: incorrectCommitSha,
       },
       externalPacket = path.join(parent, "submission.json");
     writeFileSync(externalPacket, JSON.stringify(submission));
@@ -127,6 +128,55 @@ test("task start, inline submit, and code-doc reconcile reuse daemon-known lifec
 
     const submitted = await cell.run({ kind: "task-submit", taskId, jsonInput: JSON.stringify(submission) }, holder);
     assert.equal(submitted.outcome, "applied", JSON.stringify(submitted));
+
+    const repeatedSubmit = (await cell.run(
+      { kind: "task-submit", taskId, executionId, jsonInput: JSON.stringify({ ...submission, commitSha }) },
+      holder,
+    )) as Record<string, unknown>;
+    assert.equal(repeatedSubmit.outcome, "op_rejected", JSON.stringify(repeatedSubmit));
+    assert.equal(repeatedSubmit.code, "invalid_transition");
+
+    const reconcileBeforeAmend = (await cell.run(
+      { kind: "task-code-doc-reconcile", taskId, paths: ["README.md"] },
+      holder,
+    )) as Record<string, unknown>;
+    assert.equal(reconcileBeforeAmend.outcome, "op_rejected", JSON.stringify(reconcileBeforeAmend));
+    assert.equal(reconcileBeforeAmend.code, "invalid_proof");
+
+    const wrongExecutionAmend = (await cell.run(
+      {
+        kind: "task-submit",
+        taskId,
+        executionId: "execution-not-current",
+        amend: true,
+        jsonInput: JSON.stringify({ ...submission, completionClaim: "Wrong execution.", commitSha }),
+      },
+      holder,
+    )) as Record<string, unknown>;
+    assert.equal(wrongExecutionAmend.outcome, "op_rejected", JSON.stringify(wrongExecutionAmend));
+    assert.equal(wrongExecutionAmend.code, "invalid_transition");
+
+    const amended = (await cell.run(
+      {
+        kind: "task-submit",
+        taskId,
+        executionId,
+        amend: true,
+        jsonInput: JSON.stringify({ ...submission, completionClaim: "Corrected lifecycle cut.", commitSha }),
+      },
+      holder,
+    )) as Record<string, unknown>;
+    assert.equal(amended.outcome, "applied", JSON.stringify(amended));
+    assert.match(String(amended.summary), /prior Review and consent pins are stale/u);
+    const submissionEvents = events().filter((candidate) => candidate.type === "execution_submitted");
+    assert.equal(submissionEvents.length, 2);
+    const initialSubmission = submissionEvents[0];
+    if (initialSubmission?.type !== "execution_submitted" || !initialSubmission.payload.execution.submission)
+      throw new Error("initial submission event missing");
+    assert.equal(
+      submissionEvents[1]?.payload.supersedesSubmissionId,
+      submissionId(initialSubmission.payload.execution.submission),
+    );
 
     const obsolete = (await cell.run(
       {
@@ -198,8 +248,26 @@ test("task start, inline submit, and code-doc reconcile reuse daemon-known lifec
       holder,
     );
     assert.equal(consented.outcome, "applied", JSON.stringify(consented));
+    const consentEvent = makeTaskEventReader({ repoId, rootDir }).readEvent(String(consented.opId));
+    assert.equal(
+      consentEvent?.type === "review_consent_recorded" ? consentEvent.payload.consent.submissionDigest : null,
+      submissionDigest({ ...submission, completionClaim: "Corrected lifecycle cut.", commitSha }),
+    );
     const completed = await cell.run({ kind: "task-complete", taskId, ci: "passed" }, holder);
     assert.equal(completed.outcome, "applied", JSON.stringify(completed));
+
+    const amendCompleted = (await cell.run(
+      {
+        kind: "task-submit",
+        taskId,
+        executionId,
+        amend: true,
+        jsonInput: JSON.stringify({ ...submission, completionClaim: "Too late.", commitSha }),
+      },
+      holder,
+    )) as Record<string, unknown>;
+    assert.equal(amendCompleted.outcome, "op_rejected", JSON.stringify(amendCompleted));
+    assert.equal(amendCompleted.code, "invalid_transition");
 
     const beforeDrift = events().length,
       drifted = await cell.run(

--- a/packages/daemon/test/rejection-next-actions.integration.test.ts
+++ b/packages/daemon/test/rejection-next-actions.integration.test.ts
@@ -47,7 +47,7 @@ test("submit lease refusals name the state-specific command that advances the ex
     assert.equal(withoutLease.code, "lease_required", JSON.stringify(withoutLease));
     assert.deepEqual(
       withoutLease.unmetCriteria?.map(({ ref }) => ref),
-      ["actor-domain-services/heldLeaseForExecutionActor"],
+      ["repo-cell-proof/proofFor.SubmitExecution"],
     );
     assert.equal((await cell.run({ kind: "task-start", taskId, executionId }, holder)).outcome, "applied");
     assert.equal(
@@ -64,6 +64,7 @@ test("submit lease refusals name the state-specific command that advances the ex
       alreadySubmitted.unmetCriteria?.map(({ ref }) => ref),
       ["task-lifecycle-command-transitions/submit.validate"],
     );
+    assert.match(alreadySubmitted.nextActions?.join("\n") ?? "", /--amend --json-input/u);
     writeFileSync(
       path.join(rootDir, "review.json"),
       JSON.stringify({ verdict: "approved", reason: "Independent review.", evidenceChecked: ["integration"] }),

--- a/packages/daemon/test/task-closeout-action.test.ts
+++ b/packages/daemon/test/task-closeout-action.test.ts
@@ -6,6 +6,7 @@ import path from "node:path";
 import test from "node:test";
 import type { ActorIdentity, AuthorizationDecision, WriteReceipt } from "../../kernel/src/index.ts";
 import { runTaskCloseoutAction, type CloseoutStep } from "../../application/src/task-closeout-action.ts";
+import { gateChecks } from "../src/repo-cell-proof.ts";
 import { readWorkspaceText } from "../src/workspace-text-port.ts";
 
 const taskId = "task-closeout",
@@ -234,7 +235,7 @@ test("a submitted execution resumes when the packet omits its locked submission"
     rmSync(value.rootDir, { recursive: true, force: true });
   }
 });
-test("a mismatched resubmission reports the locked content and the omission repair", async () => {
+test("a mismatched resubmission reports the locked content and the amendment repair", async () => {
   const value = setup(snapshot("in_review", [execution(executionId, "submitted")]));
   writeFileSync(
     path.join(value.rootDir, "judgment.json"),
@@ -247,11 +248,36 @@ test("a mismatched resubmission reports the locked content and the omission repa
     const receipt = await value.run();
     assert.equal(receipt.code, "submission_mismatch");
     assert.match(JSON.stringify(receipt.diagnostic), /\\"completionClaim\\":\\"Complete\.\\"/u);
+    assert.match(guidanceCommands(receipt), /ha task submit .* --amend --json-input/u);
     assert.match(guidanceCommands(receipt), /ha task closeout/u);
     assert.equal(value.calls.length, 0);
   } finally {
     rmSync(value.rootDir, { recursive: true, force: true });
   }
+});
+test("receipt gate checks reject a code-doc witness from the superseded submission cut", () => {
+  const value = snapshot("in_review", [execution(executionId, "submitted")]),
+    stale = {
+      ...value,
+      task: { ...value.task!, completionGateIds: ["code-doc-reconciliation"] },
+      codeDocWitnesses: [
+        {
+          schema: "code-doc-witness/v1",
+          witnessId: "witness-stale",
+          taskId,
+          executionId,
+          commitSha: "b".repeat(40),
+          iteration: 0,
+          paths: ["README.md"],
+          actor: worker,
+          source: "local",
+          reconciledAt: "2026-08-22T00:02:00.000Z",
+        },
+      ],
+    };
+  assert.deepEqual(gateChecks(stale as never, executionId), [
+    { gate: "code-doc-reconciliation", status: "blocked", witnessRef: null },
+  ]);
 });
 test("one invalid closeout response names every bad field", async () => {
   const value = setup();

--- a/packages/kernel/src/domain/closeout-readiness.ts
+++ b/packages/kernel/src/domain/closeout-readiness.ts
@@ -2,7 +2,7 @@ export const closeoutReadinesses = ["not_required", "missing", "incomplete", "re
 
 export type CloseoutReadiness = (typeof closeoutReadinesses)[number];
 
-import { approvedReviewsForCut, consentedApprovedReview } from "./review.ts";
+import { approvedReviewHistoryForExecution, consentedApprovedReviewForExecution } from "./review.ts";
 import { isNativeExecution } from "./execution.ts";
 import type { ExecutionV1, ProjectedExecution } from "./execution.ts";
 import type { ReviewConsentV1, ReviewV1 } from "./review.ts";
@@ -77,23 +77,10 @@ export function closeoutReadiness(
     gates.some(({ status }) => status === "unknown")
   )
     return { readiness: "incomplete", executionId: execution.executionId, blocker: "projection_unknown", gates };
-  const approved = approvedReviewsForCut(
-    snapshot.reviews,
-    execution.executionId,
-    execution.submission.commitSha,
-    execution.iteration,
-  );
+  const approved = approvedReviewHistoryForExecution(snapshot.reviews, execution);
   if (!approved.length)
     return { readiness: "incomplete", executionId: execution.executionId, blocker: "review", gates };
-  if (
-    !consentedApprovedReview(
-      snapshot.reviews,
-      snapshot.consents,
-      execution.executionId,
-      execution.submission.commitSha,
-      execution.iteration,
-    )
-  )
+  if (!consentedApprovedReviewForExecution(snapshot.reviews, snapshot.consents, execution))
     return { readiness: "incomplete", executionId: execution.executionId, blocker: "consent", gates };
   const failed = gates.some(({ status }) => status === "failed"),
     missing = gates.some(({ status }) => status !== "passed");
@@ -146,7 +133,11 @@ export function gateResults(
     if (codeDoc) {
       const witness = currentCodeDocWitness(snapshot.codeDocWitnesses, executionId);
       // A valid repoint may bind an archival commit rather than the submitted cut.
-      if (witness?.iteration === iteration) return gateResult(gateId, "passed");
+      if (
+        witness?.iteration === iteration &&
+        (witness.schema === "code-doc-witness-repoint/v1" || witness.commitSha === commitSha)
+      )
+        return gateResult(gateId, "passed");
       return gateResult(gateId, "missing", "current execution cut has no code/doc witness");
     }
     const exact = snapshot.gateWitnesses.filter(

--- a/packages/kernel/src/domain/completion-readiness.ts
+++ b/packages/kernel/src/domain/completion-readiness.ts
@@ -1,6 +1,6 @@
 import type { TaskLifecycleSnapshot } from "./task-lifecycle.contract.ts";
 import { closeoutReadiness } from "./closeout-readiness.ts";
-import { approvedReviewsForCut } from "./review.ts";
+import { approvedReviewHistoryForExecution } from "./review.ts";
 
 export type CompletionBlockerCode =
   | "not_in_review"
@@ -78,7 +78,6 @@ export function completionBlockers(
       `ha task show ${task.taskId}`,
       "The Task status does not match its review node; inspect the lifecycle record before completion.",
     );
-  const submission = execution.submission;
   if (snapshot.lease !== null)
     return one(
       "lease_held",
@@ -87,8 +86,8 @@ export function completionBlockers(
       "Release the held execution lease through canonical submit.",
     );
   const assessment = closeoutReadiness(snapshot);
-  const approved = approvedReviewsForCut(snapshot.reviews, executionId, submission.commitSha, execution.iteration);
-  if (assessment.blocker === "review" || !approved.length)
+  const approved = approvedReviewHistoryForExecution(snapshot.reviews, execution);
+  if (assessment.blocker === "review")
     return one(
       "review_missing",
       "review",

--- a/packages/kernel/src/domain/entity-document-schemas.ts
+++ b/packages/kernel/src/domain/entity-document-schemas.ts
@@ -119,6 +119,7 @@ export const reviewSchema: EntityDocumentJsonSchema = {
     commitSha: { type: "string", pattern: "^[0-9a-f]{40}$" },
     iteration: { type: "integer" },
     contentDigest: { type: "string", pattern: "^sha256:[0-9a-f]{64}$" },
+    submissionDigest: { type: "string", pattern: "^sha256:[0-9a-f]{64}$" },
     reviewedAt: { type: "string", minLength: 1 },
   },
   required: [

--- a/packages/kernel/src/domain/execution.ts
+++ b/packages/kernel/src/domain/execution.ts
@@ -4,6 +4,7 @@ import type { TaskNodeId } from "./task-graph.ts";
 import { timestamp } from "./timestamp.ts";
 import { hasRequiredFields, validateWriteSource } from "./write-chain.contract.ts";
 import type { WriteSource } from "./write-chain.contract.ts";
+import { sha256Text, stableStringify } from "../integrity/stable-hash.ts";
 
 export const executionStates = ["active", "submitted", "accepted", "changes_requested", "abandoned"] as const;
 export type ExecutionState = (typeof executionStates)[number];
@@ -20,6 +21,20 @@ export interface SubmissionV1 {
   readonly knownGaps: readonly string[];
   readonly residualRisks: readonly string[];
   readonly commitSha: string;
+}
+export type SubmissionDigest = `sha256:${string}`;
+export type SubmissionId = `submission:${SubmissionDigest}`;
+
+export function submissionDigest(value: SubmissionV1): SubmissionDigest {
+  return `sha256:${sha256Text(stableStringify(value))}`;
+}
+
+export function submissionId(value: SubmissionV1): SubmissionId {
+  return `submission:${submissionDigest(value)}`;
+}
+
+export function isSubmissionId(value: unknown): value is SubmissionId {
+  return typeof value === "string" && /^submission:sha256:[0-9a-f]{64}$/u.test(value);
 }
 export interface ExecutionV1 {
   readonly schema: "execution/v1";

--- a/packages/kernel/src/domain/index.ts
+++ b/packages/kernel/src/domain/index.ts
@@ -48,9 +48,7 @@ export type { TaskLifecycleCommandType } from "./task-write-decision.ts";
 
 export {
   approvedReviewHistoryForExecution,
-  approvedReviewsForCut,
   approvedReviewsForExecution,
-  consentedApprovedReview,
   consentedApprovedReviewForExecution,
   reviewVerdicts,
 } from "./review.ts";

--- a/packages/kernel/src/domain/index.ts
+++ b/packages/kernel/src/domain/index.ts
@@ -46,7 +46,14 @@ export type {
 } from "./task-lifecycle.contract.ts";
 export type { TaskLifecycleCommandType } from "./task-write-decision.ts";
 
-export { approvedReviewsForCut, consentedApprovedReview, reviewVerdicts } from "./review.ts";
+export {
+  approvedReviewHistoryForExecution,
+  approvedReviewsForCut,
+  approvedReviewsForExecution,
+  consentedApprovedReview,
+  consentedApprovedReviewForExecution,
+  reviewVerdicts,
+} from "./review.ts";
 export type { ReviewVerdict } from "./review.ts";
 
 export { isPriorityTier, isTaskWorkKind, priorityTiers, taskWorkKinds } from "./task-metadata.ts";

--- a/packages/kernel/src/domain/review.ts
+++ b/packages/kernel/src/domain/review.ts
@@ -132,40 +132,6 @@ export function validateReviewConsentV1(
     validateWriteSource(value.source, allowUnknownFields).length === 0;
   return valid ? [] : [invalidReviewIssue("consent must bind review/content digests, execution, actor, and source")];
 }
-export function approvedReviewsForCut(
-  reviews: readonly ReviewV1[],
-  executionId: string,
-  commitSha: string,
-  iteration: number,
-): readonly ReviewV1[] {
-  return reviews.filter(
-    (review) =>
-      review.executionId === executionId &&
-      review.verdict === "approved" &&
-      review.commitSha === commitSha &&
-      review.iteration === iteration,
-  );
-}
-export function consentedApprovedReview(
-  reviews: readonly ReviewV1[],
-  consents: readonly ReviewConsentV1[],
-  executionId: string,
-  commitSha: string,
-  iteration: number,
-): ConsentedApprovedReview | undefined {
-  const approved = new Map(
-    approvedReviewsForCut(reviews, executionId, commitSha, iteration).map((review) => [review.reviewId, review]),
-  );
-  for (let index = consents.length - 1; index >= 0; index -= 1) {
-    const consent = consents[index]!;
-    if (consent.executionId !== executionId) continue;
-    const review = approved.get(consent.reviewId);
-    if (review && consent.reviewDigest === reviewDigest(review) && consent.contentDigest === review.contentDigest)
-      return { review, consent };
-  }
-  return undefined;
-}
-
 export function approvedReviewHistoryForExecution(
   reviews: readonly ReviewV1[],
   execution: ExecutionV1,

--- a/packages/kernel/src/domain/review.ts
+++ b/packages/kernel/src/domain/review.ts
@@ -1,4 +1,5 @@
-import { isNativeCommitSha } from "./execution.ts";
+import { isNativeCommitSha, submissionDigest } from "./execution.ts";
+import type { ExecutionV1, SubmissionDigest } from "./execution.ts";
 import { digest } from "./digest.ts";
 import { hasOnlyFields, isNonEmptyString, isRecord, validateActorAxes } from "./task.ts";
 import type { ActorAxes, ContractValidationIssue } from "./task.ts";
@@ -21,6 +22,7 @@ export interface ReviewV1 {
   readonly commitSha: string;
   readonly iteration: 0 | 1;
   readonly contentDigest: `sha256:${string}`;
+  readonly submissionDigest: SubmissionDigest;
   readonly reviewedAt: string;
 }
 export interface ReviewConsentV1 {
@@ -31,6 +33,7 @@ export interface ReviewConsentV1 {
   readonly reviewId: string;
   readonly reviewDigest: `sha256:${string}`;
   readonly contentDigest: `sha256:${string}`;
+  readonly submissionDigest?: SubmissionDigest;
   readonly actor: ActorAxes;
   readonly source: WriteSource;
   readonly consentedAt: string;
@@ -54,6 +57,7 @@ export const REVIEW_V1_SCHEMA = Object.freeze({
     "commitSha",
     "iteration",
     "contentDigest",
+    "submissionDigest",
     "reviewedAt",
   ]),
   verdicts: reviewVerdicts,
@@ -68,13 +72,18 @@ export const REVIEW_CONSENT_V1_SCHEMA = Object.freeze({
     "reviewId",
     "reviewDigest",
     "contentDigest",
+    "submissionDigest",
     "actor",
     "source",
     "consentedAt",
   ]),
 });
 export function validateReviewV1(value: unknown, allowUnknownFields = false): readonly ContractValidationIssue[] {
-  if (!isRecord(value) || !(allowUnknownFields ? hasRequiredFields : hasOnlyFields)(value, REVIEW_V1_SCHEMA.required))
+  const historicalFields = REVIEW_V1_SCHEMA.required.filter((field) => field !== "submissionDigest");
+  if (
+    !isRecord(value) ||
+    !(allowUnknownFields ? hasRequiredFields(value, historicalFields) : hasOnlyFields(value, REVIEW_V1_SCHEMA.required))
+  )
     return [invalidReviewIssue("Review/v1 fields are incomplete or unknown")];
   const issues: ContractValidationIssue[] = [];
   if (
@@ -93,7 +102,8 @@ export function validateReviewV1(value: unknown, allowUnknownFields = false): re
     value.evidenceChecked.some((item) => !isNonEmptyString(item)) ||
     !isNativeCommitSha(value.commitSha) ||
     (value.iteration !== 0 && value.iteration !== 1) ||
-    !digest(value.contentDigest)
+    !digest(value.contentDigest) ||
+    (value.submissionDigest !== undefined && !digest(value.submissionDigest))
   )
     issues.push(invalidReviewIssue("review content cut, evidence, commit, or iteration is invalid"));
   issues.push(...validateActorAxes(value.actor, allowUnknownFields));
@@ -103,9 +113,12 @@ export function validateReviewConsentV1(
   value: unknown,
   allowUnknownFields = false,
 ): readonly ContractValidationIssue[] {
+  const historicalFields = REVIEW_CONSENT_V1_SCHEMA.required.filter((field) => field !== "submissionDigest");
   if (
     !isRecord(value) ||
-    !(allowUnknownFields ? hasRequiredFields : hasOnlyFields)(value, REVIEW_CONSENT_V1_SCHEMA.required)
+    !(allowUnknownFields
+      ? hasRequiredFields(value, historicalFields)
+      : hasOnlyFields(value, REVIEW_CONSENT_V1_SCHEMA.required))
   )
     return [invalidReviewIssue("ReviewConsent/v1 fields are incomplete or unknown")];
   const valid =
@@ -114,6 +127,7 @@ export function validateReviewConsentV1(
     timestamp(value.consentedAt) &&
     digest(value.reviewDigest) &&
     digest(value.contentDigest) &&
+    (value.submissionDigest === undefined || digest(value.submissionDigest)) &&
     validateActorAxes(value.actor, allowUnknownFields).length === 0 &&
     validateWriteSource(value.source, allowUnknownFields).length === 0;
   return valid ? [] : [invalidReviewIssue("consent must bind review/content digests, execution, actor, and source")];
@@ -147,6 +161,66 @@ export function consentedApprovedReview(
     if (consent.executionId !== executionId) continue;
     const review = approved.get(consent.reviewId);
     if (review && consent.reviewDigest === reviewDigest(review) && consent.contentDigest === review.contentDigest)
+      return { review, consent };
+  }
+  return undefined;
+}
+
+export function approvedReviewHistoryForExecution(
+  reviews: readonly ReviewV1[],
+  execution: ExecutionV1,
+): readonly ReviewV1[] {
+  return reviews.filter(
+    (review) =>
+      review.executionId === execution.executionId &&
+      review.verdict === "approved" &&
+      review.iteration === execution.iteration,
+  );
+}
+
+export function approvedReviewsForExecution(reviews: readonly ReviewV1[], execution: ExecutionV1): readonly ReviewV1[] {
+  return reviewsForExecution(reviews, execution).filter((review) => review.verdict === "approved");
+}
+
+export function reviewsForExecution(reviews: readonly ReviewV1[], execution: ExecutionV1): readonly ReviewV1[] {
+  if (!execution.submission || !execution.submittedAt) return [];
+  const pinned = submissionDigest(execution.submission),
+    submittedAt = Date.parse(execution.submittedAt);
+  return reviews.filter(
+    (review) =>
+      review.executionId === execution.executionId &&
+      review.iteration === execution.iteration &&
+      review.commitSha === execution.submission?.commitSha &&
+      Date.parse(review.reviewedAt) >= submittedAt &&
+      (review.submissionDigest === undefined || review.submissionDigest === pinned),
+  );
+}
+
+export function consentedApprovedReviewForExecution(
+  reviews: readonly ReviewV1[],
+  consents: readonly ReviewConsentV1[],
+  execution: ExecutionV1,
+): ConsentedApprovedReview | undefined {
+  if (!execution.submission || !execution.submittedAt) return undefined;
+  const approved = new Map(
+      approvedReviewHistoryForExecution(reviews, execution).map((review) => [review.reviewId, review]),
+    ),
+    currentReviewIds = new Set(approvedReviewsForExecution(reviews, execution).map((review) => review.reviewId)),
+    currentSubmissionDigest = submissionDigest(execution.submission),
+    submittedAt = Date.parse(execution.submittedAt);
+  for (let index = consents.length - 1; index >= 0; index -= 1) {
+    const consent = consents[index]!;
+    if (consent.executionId !== execution.executionId || Date.parse(consent.consentedAt) < submittedAt) continue;
+    const review = approved.get(consent.reviewId);
+    const pinsCurrentSubmission =
+      consent.submissionDigest === currentSubmissionDigest ||
+      (consent.submissionDigest === undefined && currentReviewIds.has(consent.reviewId));
+    if (
+      review &&
+      pinsCurrentSubmission &&
+      consent.reviewDigest === reviewDigest(review) &&
+      consent.contentDigest === review.contentDigest
+    )
       return { review, consent };
   }
   return undefined;

--- a/packages/kernel/src/domain/task-action-capability.ts
+++ b/packages/kernel/src/domain/task-action-capability.ts
@@ -26,6 +26,7 @@ export interface TaskActionCapabilityInvocation {
   readonly taskId: string;
   readonly executionId?: string;
   readonly reviewId?: string;
+  readonly amend?: boolean;
   readonly runtimeTaskBound?: boolean;
 }
 
@@ -62,8 +63,12 @@ const taskCapabilityEvaluators = Object.freeze(
     [key("submit", "task-lifecycle-contract-support/revisionIssues"), revisionCurrent],
     [key("submit", "task-lifecycle-command-transitions/submit.validate"), submitValidation],
     [
-      key("submit", "actor-domain-services/heldLeaseForExecutionActor"),
-      ({ snapshot, actor }) => (heldLeaseForExecutionActor(snapshot, undefined, actor) ? "met" : "unmet"),
+      key("submit", "repo-cell-proof/proofFor.SubmitExecution"),
+      ({ snapshot, actor }) =>
+        heldLeaseForExecutionActor(snapshot, undefined, actor) ||
+        currentSubmittedExecutions(snapshot).some((execution) => isSameExecution(execution.actor, actor))
+          ? "met"
+          : "unmet",
     ],
     [key("review", "task-lifecycle-contract-support/revisionIssues"), revisionCurrent],
     [key("review", "task-lifecycle-review-transitions/review.validate"), reviewValidation],
@@ -139,14 +144,17 @@ function reopenInvocation({ snapshot }: TaskActionCapabilityInput): "invocation-
 }
 
 function submitValidation(input: TaskActionCapabilityInput): PredicateEvaluation | "invocation-required" {
+  if (["done", "cancelled"].includes(input.snapshot.task?.status ?? "")) return { status: "unmet" };
   const submitted = submittedExecution(input);
   if (!submitted) return "invocation-required";
   const taskId = invocationTaskId(input),
-    executionId = submitted.executionId;
+    executionId = submitted.executionId,
+    amend = `ha task submit ${taskId} --execution-id ${executionId} ` + "--amend --json-input '<submission-json>'";
   return {
-    status: "unmet",
+    status: input.invocation?.amend === false ? "unmet" : "invocation-required",
     nextActions: [
-      `Execution ${executionId} is already submitted; run ${reviewCommand(taskId, executionId, "<review-id>")}.`,
+      `Execution ${executionId} is already submitted; use ${amend} to correct it, or run ` +
+        `${reviewCommand(taskId, executionId, "<review-id>")}.`,
     ],
   };
 }

--- a/packages/kernel/src/domain/task-action-contract.ts
+++ b/packages/kernel/src/domain/task-action-contract.ts
@@ -168,6 +168,7 @@ const taskActionDeclarations = Object.freeze([
         taskIdInput,
         expectedVersionInput,
         cliField("executionId", "string", false, "--execution-id", "single"),
+        cliField("amend", "boolean", false, "--amend", "boolean"),
         cliField(
           "fromFile",
           "string",
@@ -197,16 +198,21 @@ const taskActionDeclarations = Object.freeze([
         explain: "The active current execution is submitted with a valid submission packet.",
       },
       {
-        ref: "actor-domain-services/heldLeaseForExecutionActor",
+        ref: "repo-cell-proof/proofFor.SubmitExecution",
         failureCode: "lease_required",
-        explain: "The authenticated actor owns the active execution lease at its current version.",
+        explain: "The authenticated actor owns the active lease or the submitted execution being amended.",
       },
     ]),
     concurrency: taskConcurrency(
-      { authority: "task-lease/v1", mode: "fence-and-release", versionProof: "leaseVersion" },
+      {
+        authority: "task-lease/v1",
+        mode: "fence-and-release-on-initial-submit",
+        amendment: "unleased-current-execution",
+        versionProof: "leaseVersion",
+      },
       { authority: "operation-id", retry: "canonical-event-replay" },
     ),
-    explain: "Atomically fence and release the execution lease while publishing its submission.",
+    explain: "Publish the initial submission or amend the current submitted execution without replacing its history.",
   },
   {
     id: "review",

--- a/packages/kernel/src/domain/task-lifecycle-command-transitions.ts
+++ b/packages/kernel/src/domain/task-lifecycle-command-transitions.ts
@@ -1,4 +1,4 @@
-import { isNativeExecution, validateSubmissionV1 } from "./execution.ts";
+import { isNativeExecution, submissionId, validateSubmissionV1 } from "./execution.ts";
 import type { ExecutionV1, LeaseV1 } from "./execution.ts";
 import { taskClasses } from "./task.ts";
 import type { TaskV2 } from "./task.ts";
@@ -352,7 +352,7 @@ export const submit: Transition = {
   id: "submit_execution",
   commandType: "SubmitExecution",
   from: "active/implementation",
-  proof: ["actorBinding", "leaseVersion", "submission"],
+  proof: ["actorBinding", "leaseVersion-or-submitted-cut", "submission"],
   eventType: "execution_submitted",
   matches: (command) => command.type === "SubmitExecution",
   validate: (snapshot, raw, rawProof) => {
@@ -361,60 +361,84 @@ export const submit: Transition = {
       issues = revisionIssues(snapshot, command),
       task = snapshot.task,
       current = execution(snapshot, command.executionId),
-      lease = snapshot.lease;
-    if (!task || task.status !== "active" || task.currentNode !== "implementation" || current?.state !== "active")
-      issues.push(
-        lifecycleContractIssue("invalid_transition", "SubmitExecution requires the active current execution"),
-      );
-    if (
-      !lease ||
-      lease.phase !== "held" ||
-      lease.executionId !== command.executionId ||
-      !isSameExecution(lease.actor, command.actor) ||
-      stableStringify(lease.source) !== stableStringify(command.source) ||
-      !proof.actorBinding ||
-      !isSameExecution(proof.actorBinding, command.actor) ||
-      proof.leaseVersion !== lease.version ||
-      !["complete", "partial", "unavailable"].includes(String(proof.sessionDisposition))
-    )
-      issues.push(lifecycleContractIssue("invalid_proof", "submit must own and atomically release the active lease"));
+      lease = snapshot.lease,
+      amendment = command.amend === true;
+    if (amendment) {
+      if (
+        !task ||
+        task.status !== "in_review" ||
+        task.currentNode !== "review" ||
+        current?.state !== "submitted" ||
+        !current.submission
+      )
+        issues.push(
+          lifecycleContractIssue("invalid_transition", "submission amendment requires the current submitted execution"),
+        );
+      else if (submissionId(current.submission) === submissionId(command.submission))
+        issues.push(lifecycleContractIssue("invalid_transition", "submission amendment must change the packet"));
+      if (
+        lease !== null ||
+        !proof.actorBinding ||
+        !isSameExecution(proof.actorBinding, command.actor) ||
+        (current !== undefined && !isSameExecution(current.actor, command.actor)) ||
+        proof.leaseVersion !== null ||
+        !["complete", "partial", "unavailable"].includes(String(proof.sessionDisposition))
+      )
+        issues.push(
+          lifecycleContractIssue("invalid_proof", "submission amendment must bind the unleased submitted execution"),
+        );
+    } else {
+      if (!task || task.status !== "active" || task.currentNode !== "implementation" || current?.state !== "active")
+        issues.push(
+          lifecycleContractIssue("invalid_transition", "SubmitExecution requires the active current execution"),
+        );
+      if (
+        !lease ||
+        lease.phase !== "held" ||
+        lease.executionId !== command.executionId ||
+        !isSameExecution(lease.actor, command.actor) ||
+        stableStringify(lease.source) !== stableStringify(command.source) ||
+        !proof.actorBinding ||
+        !isSameExecution(proof.actorBinding, command.actor) ||
+        proof.leaseVersion !== lease.version ||
+        !["complete", "partial", "unavailable"].includes(String(proof.sessionDisposition))
+      )
+        issues.push(lifecycleContractIssue("invalid_proof", "submit must own and atomically release the active lease"));
+    }
     issues.push(...validateSubmissionV1(command.submission));
     return issues;
   },
   reduce: (snapshot, raw) => {
     const command = raw as SubmitExecutionCommand,
       current = execution(snapshot, command.executionId) as ExecutionV1,
+      amendment = command.amend === true,
       nextExecution: ExecutionV1 = {
         ...current,
         state: "submitted",
         submittedAt: command.occurredAt,
         submission: command.submission,
       },
-      task: TaskV2 = {
-        ...(snapshot.task as TaskV2),
-        status: "in_review",
-        currentNode: "review",
-      },
-      edge = takeEdge(
-        task,
-        "submitted",
-        command.submission.completionClaim,
-        command.submission.commitSha,
-        task.iteration,
-      );
+      task: TaskV2 = amendment
+        ? (snapshot.task as TaskV2)
+        : { ...(snapshot.task as TaskV2), status: "in_review", currentNode: "review" },
+      edge = amendment
+        ? undefined
+        : takeEdge(task, "submitted", command.submission.completionClaim, command.submission.commitSha, task.iteration);
     return {
       snapshot: {
         ...snapshot,
         revision: command.workspaceRevision,
         task,
         executions: replaceExecution(snapshot.executions, nextExecution),
-        edgesTaken: [...snapshot.edgesTaken, edge],
+        edgesTaken: edge ? [...snapshot.edgesTaken, edge] : snapshot.edgesTaken,
         lease: null,
       },
       event: envelope<ExecutionSubmittedEvent>(command, "execution_submitted", {
         task,
         execution: nextExecution,
-        edge,
+        ...(edge
+          ? { edge }
+          : { supersedesSubmissionId: submissionId(current.submission as NonNullable<ExecutionV1["submission"]>) }),
       }),
     };
   },

--- a/packages/kernel/src/domain/task-lifecycle-contract-internal-types.ts
+++ b/packages/kernel/src/domain/task-lifecycle-contract-internal-types.ts
@@ -61,6 +61,7 @@ export interface TransitionTaskIntent extends Intent<"TransitionTask"> {
 export interface SubmitExecutionIntent extends Intent<"SubmitExecution"> {
   readonly executionId: string;
   readonly submission: SubmissionV1;
+  readonly amend?: true;
 }
 export interface RecordReviewIntent extends Intent<"RecordReview"> {
   readonly executionId: string;
@@ -75,6 +76,7 @@ export interface RecordReviewIntent extends Intent<"RecordReview"> {
   readonly commitSha: string;
   readonly iteration: number;
   readonly contentDigest: `sha256:${string}`;
+  readonly submissionDigest: `sha256:${string}`;
 }
 export interface RecordReviewConsentIntent extends Intent<"RecordReviewConsent"> {
   readonly executionId: string;
@@ -156,7 +158,7 @@ export interface StartExecutionProof {
 export type TransitionTaskProof = Readonly<Record<never, never>>;
 export interface SubmitExecutionProof {
   readonly actorBinding: ActorAxes;
-  readonly leaseVersion: number;
+  readonly leaseVersion: number | null;
   readonly sessionDisposition: "complete" | "partial" | "unavailable";
 }
 export interface ReviewProof {

--- a/packages/kernel/src/domain/task-lifecycle-event.ts
+++ b/packages/kernel/src/domain/task-lifecycle-event.ts
@@ -1,4 +1,10 @@
-import { isNativeCommitSha, validateExecutionV1, validateLeaseHolder, validateLeaseV1 } from "./execution.ts";
+import {
+  isNativeCommitSha,
+  isSubmissionId,
+  validateExecutionV1,
+  validateLeaseHolder,
+  validateLeaseV1,
+} from "./execution.ts";
 import type { ExecutionV1, LeaseHolder, LeaseV1 } from "./execution.ts";
 import { validateReviewConsentV1, validateReviewV1 } from "./review.ts";
 import type { ReviewConsentV1, ReviewV1 } from "./review.ts";
@@ -111,7 +117,8 @@ export type ExecutionSubmittedEvent = TaskEventEnvelope<
   {
     readonly task: TaskV2;
     readonly execution: ExecutionV1;
-    readonly edge: TaskEdgeTaken;
+    readonly edge?: TaskEdgeTaken;
+    readonly supersedesSubmissionId?: string;
   }
 >;
 export type ExecutionExecutorDeclaredEvent = TaskEventEnvelope<
@@ -307,6 +314,7 @@ function validateTaskEventFields(value: unknown, allowUnknownFields: boolean): r
       Object.hasOwn(payloadWithoutCarried as Record<string, unknown>, "edge"),
       Object.hasOwn(payloadWithoutCarried as Record<string, unknown>, "factRetirementAttestations"),
       Object.hasOwn(payloadWithoutCarried as Record<string, unknown>, "dispatchTaskId"),
+      Object.hasOwn(payloadWithoutCarried as Record<string, unknown>, "supersedesSubmissionId"),
     ),
     claims = payload.documentClaims;
   const claimlessFields =
@@ -317,6 +325,7 @@ function validateTaskEventFields(value: unknown, allowUnknownFields: boolean): r
           Object.hasOwn(payload, "edge"),
           Object.hasOwn(payload, "factRetirementAttestations"),
           Object.hasOwn(payload, "dispatchTaskId"),
+          Object.hasOwn(payload, "supersedesSubmissionId"),
         ).filter((field) => field !== "documentClaims");
   const payloadFields = allowUnknownFields ? hasRequiredFields : hasOnlyFields;
   const validPayloadFields =
@@ -430,6 +439,16 @@ function validateTaskEventFields(value: unknown, allowUnknownFields: boolean): r
       issues.push(invalidEventPayloadIssue("completion gate witness must be pinned to its canonical event receipt"));
   }
   if ("edge" in payload) issues.push(...validateEdge(payload.edge, allowUnknownFields));
+  if (
+    value.type === "execution_submitted" &&
+    ((payload.supersedesSubmissionId === undefined) === (payload.edge === undefined) ||
+      (payload.supersedesSubmissionId !== undefined && !isSubmissionId(payload.supersedesSubmissionId)))
+  )
+    issues.push(
+      invalidEventPayloadIssue(
+        "initial submission requires its graph edge; amended submission requires one superseded submission id",
+      ),
+    );
   if (value.type === "lease_released") {
     issues.push(...validateLeaseV1(payload.releasedLease, allowUnknownFields));
     if (
@@ -455,12 +474,14 @@ function lifecyclePayloadFields(
   edge: boolean,
   factRetirementAttestations = false,
   dispatchTaskId = false,
+  supersedesSubmissionId = false,
 ): readonly string[] {
   const common = ["task", "execution", "documentClaims"];
   if (type === "task_created") return ["task", "documentClaims"];
   if (type === "execution_started" || type === "lease_renewed")
     return [...common, "lease", "previousHolder", "leaseExpiresAt", "reason"];
-  if (type === "execution_submitted") return [...common, "edge"];
+  if (type === "execution_submitted")
+    return [...common, ...(edge ? ["edge"] : []), ...(supersedesSubmissionId ? ["supersedesSubmissionId"] : [])];
   if (type === "execution_executor_declared")
     return [...common, "previousActor", ...(dispatchTaskId ? ["dispatchTaskId"] : []), "reason"];
   if (type === "review_recorded") return [...common, "review", ...(edge ? ["edge"] : [])];

--- a/packages/kernel/src/domain/task-lifecycle-publication.ts
+++ b/packages/kernel/src/domain/task-lifecycle-publication.ts
@@ -1,5 +1,9 @@
 import type { ExecutionV1 } from "./execution.ts";
-import { approvedReviewsForCut, consentedApprovedReview } from "./review.ts";
+import {
+  approvedReviewHistoryForExecution,
+  consentedApprovedReviewForExecution,
+  reviewsForExecution,
+} from "./review.ts";
 import type { ReviewConsentV1, ReviewV1 } from "./review.ts";
 import type { LifecycleDocumentClaim, TaskEventV1 } from "./task-lifecycle-event.ts";
 import type { TaskLifecycleSnapshot } from "./task-lifecycle.contract.ts";
@@ -192,7 +196,10 @@ export function taskLifecycleWritePlan(event: TaskEventV1): FrozenWritePlan {
     );
   if (event.type === "execution_started")
     targets.push(lease(event.taskId, "reserve"), lease(event.taskId, "activate"), lease(event.taskId, "release"));
-  if (event.type === "execution_submitted" || event.type === "lease_released")
+  if (
+    (event.type === "execution_submitted" && event.payload.supersedesSubmissionId === undefined) ||
+    event.type === "lease_released"
+  )
     targets.push(lease(event.taskId, "release"));
   return freezeDeclaredWritePlan({ commandType: event.type, targets }, [event.type]);
 }
@@ -255,23 +262,28 @@ function renderIndex(event: TaskEventV1, snapshot: TaskLifecycleSnapshot, path: 
         ? event.payload.execution
         : snapshot.executions.find((value) => value.iteration === task.iteration && value.state === "submitted"),
     executionId = current?.executionId ?? "",
-    approved = current?.submission
-      ? approvedReviewsForCut(snapshot.reviews, executionId, current.submission.commitSha, current.iteration)
-      : [],
+    approved = current?.submission ? approvedReviewHistoryForExecution(snapshot.reviews, current) : [],
     selected = current?.submission
-      ? consentedApprovedReview(
-          snapshot.reviews,
-          snapshot.consents,
-          executionId,
-          current.submission.commitSha,
-          current.iteration,
-        )
+      ? consentedApprovedReviewForExecution(snapshot.reviews, snapshot.consents, current)
       : undefined,
     consentReviewId = approved.length === 1 ? approved[0]!.reviewId : "<review-id>",
-    gateStatus = (gateId: string) =>
-      gateId === "code-doc-reconciliation"
-        ? currentCodeDocWitness(snapshot.codeDocWitnesses, executionId) !== undefined
-        : snapshot.gateWitnesses.some((value) => value.executionId === executionId && value.gateId === gateId),
+    gateStatus = (gateId: string) => {
+      if (!current?.submission) return false;
+      if (gateId === "code-doc-reconciliation") {
+        const witness = currentCodeDocWitness(snapshot.codeDocWitnesses, executionId);
+        return (
+          witness?.iteration === current.iteration &&
+          (witness.schema === "code-doc-witness-repoint/v1" || witness.commitSha === current.submission.commitSha)
+        );
+      }
+      return snapshot.gateWitnesses.some(
+        (value) =>
+          value.executionId === executionId &&
+          value.gateId === gateId &&
+          value.commitSha === current.submission?.commitSha &&
+          value.iteration === current.iteration,
+      );
+    },
     missingGate = task.completionGateIds.find((gateId) => !gateStatus(gateId)),
     next =
       task.status === "active"
@@ -364,15 +376,8 @@ function renderModule(snapshot: TaskLifecycleSnapshot): string {
 function renderExecution(value: ExecutionV1, snapshot: TaskLifecycleSnapshot): string {
   const packet = value.submission,
     reviews = snapshot.reviews.filter((candidate) => candidate.executionId === value.executionId),
-    selected = packet
-      ? consentedApprovedReview(
-          snapshot.reviews,
-          snapshot.consents,
-          value.executionId,
-          packet.commitSha,
-          value.iteration,
-        )
-      : undefined,
+    currentReviews = packet ? reviewsForExecution(snapshot.reviews, value) : [],
+    selected = packet ? consentedApprovedReviewForExecution(snapshot.reviews, snapshot.consents, value) : undefined,
     witness = currentCodeDocRecord(snapshot.codeDocWitnesses, value.executionId),
     gates = snapshot.gateWitnesses.filter((candidate) => candidate.executionId === value.executionId);
   return [
@@ -387,7 +392,11 @@ function renderExecution(value: ExecutionV1, snapshot: TaskLifecycleSnapshot): s
     `- Commit: ${packet?.commitSha ?? "pending"}\n`,
     `- Completion claim: ${packet?.completionClaim ?? "pending"}\n`,
     `- Reviews: ${
-      reviews.length ? reviews.map((review) => `${review.reviewId}/${review.verdict}`).join(", ") : "pending"
+      reviews.length
+        ? reviews
+            .map((review) => `${review.reviewId}/${review.verdict}${currentReviews.includes(review) ? "" : "/stale"}`)
+            .join(", ")
+        : "pending"
     }\n`,
     `- Selected review: ${selected?.review.reviewId ?? "pending"}\n`,
     `- Consent: ${selected?.consent.consentId ?? "pending"}\n`,
@@ -422,6 +431,7 @@ function renderReview(value: ReviewV1, consent: ReviewConsentV1 | null): string 
     `- Commit: ${value.commitSha}\n`,
     `- Iteration: ${value.iteration}\n`,
     `- Content digest: ${value.contentDigest}\n`,
+    `- Submission digest: ${value.submissionDigest ?? "legacy-unpinned"}\n`,
     `- Reviewed at: ${value.reviewedAt}\n`,
     `- Consent: ${consent ? consent.consentId : "pending"}\n`,
     `- Consent actor: ${consent?.actor.principal.personId ?? "pending"}\n`,

--- a/packages/kernel/src/domain/task-lifecycle-replay.ts
+++ b/packages/kernel/src/domain/task-lifecycle-replay.ts
@@ -1,3 +1,4 @@
+import { submissionDigest, submissionId } from "./execution.ts";
 import type { ExecutionV1, LeaseV1 } from "./execution.ts";
 import { reviewDigest } from "./review.ts";
 import { currentTaskForWrite, type ActorAxes, type ContractValidationIssue } from "./task.ts";
@@ -7,7 +8,7 @@ import type { WriteSource } from "./write-chain.contract.ts";
 import { stableStringify } from "../integrity/stable-hash.ts";
 import { TaskLifecycleContractError, validateTaskEvent } from "./task-lifecycle-event.ts";
 import type { ExecutionExecutorDeclaredEvent, TaskEventV1 } from "./task-lifecycle-event.ts";
-import { isSamePerson } from "./actor-domain-services.ts";
+import { isSameExecution, isSamePerson } from "./actor-domain-services.ts";
 import { codeDocRecordId, currentCodeDocRecord } from "./code-doc-witness.ts";
 import type {
   ProofFor,
@@ -81,6 +82,7 @@ function assertAtomic(snapshot: TaskLifecycleSnapshot, command: TaskLifecycleCom
     ]);
   if (
     command.type === "SubmitExecution" &&
+    command.amend !== true &&
     (result.snapshot.task?.status !== "in_review" ||
       result.snapshot.task.currentNode !== "review" ||
       result.snapshot.lease !== null ||
@@ -93,6 +95,26 @@ function assertAtomic(snapshot: TaskLifecycleSnapshot, command: TaskLifecycleCom
         "submit must finalize Execution, release lease, and enter in_review atomically",
       ),
     ]);
+  if (command.type === "SubmitExecution" && command.amend === true) {
+    const previous = execution(snapshot, command.executionId);
+    if (
+      !previous?.submission ||
+      result.snapshot.task !== snapshot.task ||
+      result.snapshot.lease !== null ||
+      changed?.state !== "submitted" ||
+      changed.submittedAt !== command.occurredAt ||
+      stableStringify(changed.submission) !== stableStringify(command.submission) ||
+      result.event.type !== "execution_submitted" ||
+      result.event.payload.edge !== undefined ||
+      result.event.payload.supersedesSubmissionId !== submissionId(previous.submission)
+    )
+      throw new TaskLifecycleContractError("invalid_transition", [
+        lifecycleContractIssue(
+          "invalid_submit_amendment_atomicity",
+          "amend must replace only the current submission and preserve the unleased review state",
+        ),
+      ]);
+  }
   if (
     command.type === "RecordReview" &&
     command.verdict === "changes_requested" &&
@@ -214,7 +236,7 @@ export function reduceTaskEvent(snapshot: TaskLifecycleSnapshot, event: TaskEven
       revision: event.workspaceRevision,
       task: event.payload.task,
       executions: replaceExecution(snapshot.executions, event.payload.execution),
-      edgesTaken: [...snapshot.edgesTaken, event.payload.edge],
+      edgesTaken: event.payload.edge ? [...snapshot.edgesTaken, event.payload.edge] : snapshot.edgesTaken,
       lease: null,
     };
   else if (event.type === "execution_executor_declared")
@@ -328,17 +350,49 @@ function assertReplay(snapshot: TaskLifecycleSnapshot, event: TaskEventV1, next:
         ),
       ]);
   }
-  if (
-    event.type === "execution_submitted" &&
-    (event.payload.task.status !== "in_review" ||
-      event.payload.task.currentNode !== "review" ||
-      event.payload.execution.state !== "submitted" ||
-      event.payload.edge.on !== "submitted" ||
-      next.lease !== null)
-  )
-    throw new TaskLifecycleContractError("invalid_transition", [
-      lifecycleContractIssue("invalid_submit_atomicity", "replayed submit is incomplete"),
-    ]);
+  if (event.type === "execution_submitted") {
+    const supersedes = event.payload.supersedesSubmissionId;
+    if (supersedes === undefined) {
+      if (
+        event.payload.task.status !== "in_review" ||
+        event.payload.task.currentNode !== "review" ||
+        event.payload.execution.state !== "submitted" ||
+        event.payload.edge?.on !== "submitted" ||
+        next.lease !== null
+      )
+        throw new TaskLifecycleContractError("invalid_transition", [
+          lifecycleContractIssue("invalid_submit_atomicity", "replayed submit is incomplete"),
+        ]);
+    } else {
+      const current = execution(snapshot, event.payload.execution.executionId),
+        expected = current
+          ? {
+              ...current,
+              state: "submitted" as const,
+              submittedAt: event.occurredAt,
+              submission: event.payload.execution.submission,
+            }
+          : null;
+      if (
+        !current?.submission ||
+        current.state !== "submitted" ||
+        snapshot.task?.status !== "in_review" ||
+        snapshot.task.currentNode !== "review" ||
+        snapshot.lease !== null ||
+        !event.payload.execution.submission ||
+        supersedes !== submissionId(current.submission) ||
+        submissionId(current.submission) === submissionId(event.payload.execution.submission) ||
+        !sameReplayTask(event.payload.task, snapshot.task) ||
+        stableStringify(event.payload.execution) !== stableStringify(expected) ||
+        !isSameExecution(current.actor, event.actor) ||
+        event.payload.edge !== undefined ||
+        next.lease !== null
+      )
+        throw new TaskLifecycleContractError("invalid_transition", [
+          lifecycleContractIssue("invalid_submit_amendment_atomicity", "replayed submission amendment is incomplete"),
+        ]);
+    }
+  }
   if (event.type === "lease_released") {
     const changesStatus = event.payload.mutation.fields.includes("status"),
       expectedTask = changesStatus && snapshot.task ? { ...snapshot.task, status: "blocked" as const } : snapshot.task;
@@ -402,7 +456,10 @@ function assertReplay(snapshot: TaskLifecycleSnapshot, event: TaskEventV1, next:
   if (
     event.type === "review_consent_recorded" &&
     (event.payload.consent.reviewDigest !== reviewDigest(event.payload.review) ||
-      event.payload.consent.contentDigest !== event.payload.review.contentDigest)
+      event.payload.consent.contentDigest !== event.payload.review.contentDigest ||
+      !event.payload.execution.submission ||
+      (event.payload.consent.submissionDigest !== undefined &&
+        event.payload.consent.submissionDigest !== submissionDigest(event.payload.execution.submission)))
   )
     throw new TaskLifecycleContractError("invalid_proof", [
       lifecycleContractIssue("invalid_proof", "replayed consent is not content pinned"),

--- a/packages/kernel/src/domain/task-lifecycle-review-transitions.ts
+++ b/packages/kernel/src/domain/task-lifecycle-review-transitions.ts
@@ -1,4 +1,4 @@
-import { isNativeCommitSha } from "./execution.ts";
+import { isNativeCommitSha, submissionDigest } from "./execution.ts";
 import { digest } from "./digest.ts";
 import { sameCodeDocPaths } from "./code-doc-witness.ts";
 import type { ExecutionV1 } from "./execution.ts";
@@ -57,7 +57,11 @@ function reviewIssues(
     issues.push(lifecycleContractIssue("invalid_transition", "Review requires the current submitted execution"));
   else if (snapshot.reviews.some((value) => value.reviewId === command.reviewId))
     issues.push(lifecycleContractIssue("invalid_transition", "append-only Review history requires a new review id"));
-  else if (command.commitSha !== current.submission.commitSha || command.iteration !== current.iteration)
+  else if (
+    command.commitSha !== current.submission.commitSha ||
+    command.iteration !== current.iteration ||
+    command.submissionDigest !== submissionDigest(current.submission)
+  )
     issues.push(lifecycleContractIssue("invalid_proof", "Review must bind the current content cut"));
   if (
     !proof.actorBinding ||
@@ -107,6 +111,7 @@ function reviewFrom(command: RecordReviewCommand, proof: ReviewProof): ReviewV1 
     commitSha: command.commitSha,
     iteration: command.iteration as 0 | 1,
     contentDigest: command.contentDigest,
+    submissionDigest: command.submissionDigest,
     reviewedAt: command.occurredAt,
   };
 }
@@ -186,12 +191,24 @@ export const consent: Transition = {
       current = execution(snapshot, command.executionId),
       recorded = snapshot.reviews.find(
         (value) => value.reviewId === command.reviewId && value.executionId === command.executionId,
-      );
+      ),
+      currentSubmissionDigest = current?.submission ? submissionDigest(current.submission) : undefined,
+      consentAlreadyCurrent =
+        currentSubmissionDigest !== undefined &&
+        snapshot.consents.some(
+          (value) =>
+            value.reviewId === command.reviewId &&
+            value.executionId === command.executionId &&
+            (value.submissionDigest === currentSubmissionDigest ||
+              (value.submissionDigest === undefined &&
+                Date.parse(value.consentedAt) >= Date.parse(current?.submittedAt ?? ""))),
+        );
     if (
       snapshot.task?.status !== "in_review" ||
       current?.state !== "submitted" ||
       recorded?.verdict !== "approved" ||
-      snapshot.consents.some((value) => value.reviewId === command.reviewId)
+      recorded?.iteration !== current?.iteration ||
+      consentAlreadyCurrent
     )
       issues.push(
         lifecycleContractIssue("invalid_transition", "consent must select an unconsented approved current Review"),
@@ -224,6 +241,7 @@ export const consent: Transition = {
         reviewId: command.reviewId,
         reviewDigest: command.reviewDigest,
         contentDigest: command.contentDigest,
+        submissionDigest: submissionDigest(current.submission as NonNullable<ExecutionV1["submission"]>),
         actor: command.actor,
         source: command.source,
         consentedAt: command.occurredAt,

--- a/packages/kernel/src/index.ts
+++ b/packages/kernel/src/index.ts
@@ -188,6 +188,7 @@ export type {
   ProjectedExecution,
   SubmissionV1,
 } from "./domain/execution.ts";
+export { isSubmissionId, submissionDigest, submissionId } from "./domain/execution.ts";
 export { sha256Bytes, sha256Text, stablePayloadHash, stableStringify } from "./integrity/stable-hash.ts";
 export {
   contentObjectRelativePath,

--- a/packages/kernel/src/index.ts
+++ b/packages/kernel/src/index.ts
@@ -188,7 +188,7 @@ export type {
   ProjectedExecution,
   SubmissionV1,
 } from "./domain/execution.ts";
-export { isSubmissionId, submissionDigest, submissionId } from "./domain/execution.ts";
+export { submissionDigest } from "./domain/execution.ts";
 export { sha256Bytes, sha256Text, stablePayloadHash, stableStringify } from "./integrity/stable-hash.ts";
 export {
   contentObjectRelativePath,

--- a/packages/kernel/src/projection/rebuildable-task-projection-task-events.ts
+++ b/packages/kernel/src/projection/rebuildable-task-projection-task-events.ts
@@ -159,6 +159,9 @@ export function applyTaskEvent(
     );
   if (event.type === "execution_started") replayClaim(db, event);
   if (event.type === "lease_renewed") replayRenew(db, event);
-  if (event.type === "execution_submitted" || event.type === "lease_released")
+  if (
+    (event.type === "execution_submitted" && event.payload.supersedesSubmissionId === undefined) ||
+    event.type === "lease_released"
+  )
     replayRelease(db, event.taskId, event.payload.execution.executionId, event.workspaceRevision);
 }

--- a/packages/kernel/test/contracts/start-execution-admissibility.test.ts
+++ b/packages/kernel/test/contracts/start-execution-admissibility.test.ts
@@ -2,6 +2,7 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 import { REPLAY_TASK_GRAPH } from "../../src/domain/task-graph.ts";
+import { submissionDigest } from "../../src/domain/execution.ts";
 import {
   applyTransition,
   canStartExecution,
@@ -172,6 +173,7 @@ test("a review node with no submitted execution recovers exclusively through Sta
         commitSha: "a".repeat(40),
         iteration: 0,
         contentDigest: `sha256:${"b".repeat(64)}`,
+        submissionDigest: submissionDigest(submitIntent.submission),
       } as const,
       completeIntent = {
         type: "CompleteTask",

--- a/packages/kernel/test/contracts/start-execution-admissibility.test.ts
+++ b/packages/kernel/test/contracts/start-execution-admissibility.test.ts
@@ -101,6 +101,32 @@ function submitted(): TaskLifecycleSnapshot {
   );
 }
 
+function amendment(
+  snapshot: TaskLifecycleSnapshot,
+  actor: ActorAxes = implementer,
+  completionClaim = "Corrected implementation",
+) {
+  return command(
+    snapshot.revision + 1,
+    {
+      type: "SubmitExecution",
+      taskId: "task-1",
+      executionId: "execution-1",
+      amend: true,
+      submission: {
+        completionClaim,
+        deliverables: ["repair"],
+        outputs: ["commit"],
+        verificationNotes: ["contract test"],
+        knownGaps: [],
+        residualRisks: [],
+        commitSha: "b".repeat(40),
+      },
+    },
+    actor,
+  ) as TaskLifecycleCommand;
+}
+
 /** A review-node task whose only execution relation was retired from the projection. */
 function strandedInReview(status: "planned" | "active" | "in_review" = "active"): TaskLifecycleSnapshot {
   const snapshot = planned();
@@ -230,6 +256,61 @@ test("two edge commands with the same expected version cannot both commit", () =
     JSON.stringify(loserIssues),
   );
   assert.equal(winner.revision, 2);
+});
+
+test("a submission amendment rejects a live lease with invalid_proof", () => {
+  const current = submitted(),
+    inconsistentLease = { ...current, lease: started().lease },
+    next = amendment(inconsistentLease);
+  assert.throws(
+    () =>
+      applyTransition(inconsistentLease, next, {
+        actorBinding: implementer,
+        leaseVersion: null,
+        sessionDisposition: "complete",
+      }),
+    (error: unknown) => (error as { readonly code?: unknown }).code === "invalid_proof",
+  );
+});
+
+test("a submission amendment rejects another execution actor with invalid_proof", () => {
+  const current = submitted(),
+    otherActor: ActorAxes = {
+      principal: implementer.principal,
+      executor: { kind: "agent", id: "other-worker" },
+    },
+    next = amendment(current, otherActor);
+  assert.throws(
+    () =>
+      applyTransition(current, next, {
+        actorBinding: otherActor,
+        leaseVersion: null,
+        sessionDisposition: "complete",
+      }),
+    (error: unknown) => (error as { readonly code?: unknown }).code === "invalid_proof",
+  );
+});
+
+test("a no-op submission amendment rejects with invalid_transition", () => {
+  const current = submitted(),
+    existing = current.executions[0];
+  if (!existing?.submission) throw new Error("submitted fixture has no packet");
+  const next = command(current.revision + 1, {
+    type: "SubmitExecution",
+    taskId: "task-1",
+    executionId: "execution-1",
+    amend: true,
+    submission: existing.submission,
+  }) as TaskLifecycleCommand;
+  assert.throws(
+    () =>
+      applyTransition(current, next, {
+        actorBinding: implementer,
+        leaseVersion: null,
+        sessionDisposition: "complete",
+      }),
+    (error: unknown) => (error as { readonly code?: unknown }).code === "invalid_transition",
+  );
 });
 
 // The reported failure: the lease expires silently, `progress append` tells you to run `task start`,

--- a/packages/kernel/test/domain/cross-aggregate-judgments.test.ts
+++ b/packages/kernel/test/domain/cross-aggregate-judgments.test.ts
@@ -5,7 +5,7 @@ import { blockingLabels, blockingOf } from "../../src/domain/task-blocking.ts";
 import { closeoutGateOk, closeoutReadiness, type CloseoutSnapshot } from "../../src/domain/closeout-readiness.ts";
 import { coverageOf, freshnessReasonOf } from "../../src/domain/decision-coverage.ts";
 import { factLiveness } from "../../src/domain/fact-liveness.ts";
-import { consentedApprovedReview, reviewDigest } from "../../src/domain/review.ts";
+import { consentedApprovedReviewForExecution, reviewDigest } from "../../src/domain/review.ts";
 import { statusWordRegister } from "../../src/domain/status-word-register.ts";
 
 const actor = { principal: { personId: "owner" }, executor: null } as const;
@@ -171,7 +171,7 @@ test("closeout consumes the latest content-pinned consent selection and ignores 
   const history = { ...base, reviews: [dismissed, unselected, selected], consents: [earlierConsent, selectedConsent] };
 
   assert.equal(
-    consentedApprovedReview(history.reviews, history.consents, "exe-1", commitSha, 0)?.review.reviewId,
+    consentedApprovedReviewForExecution(history.reviews, history.consents, history.executions[0]!)?.review.reviewId,
     selected.reviewId,
   );
   assert.equal(closeoutReadiness(history).readiness, "ready");

--- a/packages/kernel/test/domain/review-consent-digest-fixture.test.ts
+++ b/packages/kernel/test/domain/review-consent-digest-fixture.test.ts
@@ -12,11 +12,18 @@ import { reviewDigest, validateReviewV1, type ReviewV1 } from "../../src/domain/
 // - review-phase1-1.packet.json is the review packet the arbiter submitted, byte for byte.
 // The two digests below are the values that task's production consent (artifacts/consent.json)
 // actually recorded. Deriving consent from the projected Review must keep reproducing them.
-const review = JSON.parse(readFileSync(path.join(path.dirname(fileURLToPath(import.meta.url)), "../fixtures/review-consent/review-phase1-1.json"), "utf8")) as ReviewV1;
-const packet = readFileSync(path.join(path.dirname(fileURLToPath(import.meta.url)), "../fixtures/review-consent/review-phase1-1.packet.json"));
+const review = JSON.parse(
+  readFileSync(
+    path.join(path.dirname(fileURLToPath(import.meta.url)), "../fixtures/review-consent/review-phase1-1.json"),
+    "utf8",
+  ),
+) as ReviewV1;
+const packet = readFileSync(
+  path.join(path.dirname(fileURLToPath(import.meta.url)), "../fixtures/review-consent/review-phase1-1.packet.json"),
+);
 
-test("the projected ReviewV1 is complete and reproduces the production consent digests", () => {
-  assert.deepEqual(validateReviewV1(review), []);
+test("the historical ReviewV1 remains readable and reproduces the production consent digests", () => {
+  assert.deepEqual(validateReviewV1(review, true), []);
   assert.equal(reviewDigest(review), "sha256:c58b4e95b787d1d65258a900acd0a2d44c9b126215aeb706c57c85312559ff1e");
   assert.equal(review.contentDigest, `sha256:${createHash("sha256").update(packet).digest("hex")}`);
   assert.equal(review.contentDigest, "sha256:8973a724a4887c3c533cd1e297937ad12c7de3bb1aefe30dbb8e8cc7f6a79841");

--- a/packages/kernel/test/store/task-lifecycle-fixture.ts
+++ b/packages/kernel/test/store/task-lifecycle-fixture.ts
@@ -4,6 +4,7 @@ import {
   emptyTaskLifecycleSnapshot,
   normalizeTaskLifecycleCommand,
   reviewDigest,
+  submissionDigest,
   type CompleteTaskProof,
   type CreateReplayTaskProof,
   type RecordReviewCommand,
@@ -12,55 +13,147 @@ import {
   type SubmitExecutionProof,
   type TaskEventV1,
   type TaskLifecycleCommand,
-  type TaskLifecycleSnapshot
+  type TaskLifecycleSnapshot,
 } from "../../src/domain/task-lifecycle.contract.ts";
 import type { ActorAxes } from "../../src/domain/task.ts";
 
-export const implementer: ActorAxes = { principal: { personId: "person-owner" }, executor: { kind: "agent", id: "codex" } };
-export const reviewer: ActorAxes = { principal: { personId: "person-reviewer" }, executor: { kind: "agent", id: "reviewer" } };
+export const implementer: ActorAxes = {
+  principal: { personId: "person-owner" },
+  executor: { kind: "agent", id: "codex" },
+};
+export const reviewer: ActorAxes = {
+  principal: { personId: "person-reviewer" },
+  executor: { kind: "agent", id: "reviewer" },
+};
 export const commitSha = "a".repeat(40);
 
-function command<C extends Parameters<typeof normalizeTaskLifecycleCommand>[1]>(actor: ActorAxes, revision: number, intent: C) {
-  return { ...normalizeTaskLifecycleCommand({ workspaceId: "workspace-1", actor, source: "local", expectedRevision: revision - 1 }, intent), eventId: `event-${revision}`,
-    workspaceRevision: revision, occurredAt: `2026-08-11T00:0${revision - 1}:00.000Z` };
+function command<C extends Parameters<typeof normalizeTaskLifecycleCommand>[1]>(
+  actor: ActorAxes,
+  revision: number,
+  intent: C,
+) {
+  return {
+    ...normalizeTaskLifecycleCommand(
+      { workspaceId: "workspace-1", actor, source: "local", expectedRevision: revision - 1 },
+      intent,
+    ),
+    eventId: `event-${revision}`,
+    workspaceRevision: revision,
+    occurredAt: `2026-08-11T00:0${revision - 1}:00.000Z`,
+  };
 }
 
-export function lifecycleFixture(): { readonly events: readonly TaskEventV1[]; readonly snapshot: TaskLifecycleSnapshot } {
+export function lifecycleFixture(): {
+  readonly events: readonly TaskEventV1[];
+  readonly snapshot: TaskLifecycleSnapshot;
+} {
   const events: TaskEventV1[] = [];
   let snapshot = emptyTaskLifecycleSnapshot();
-  const run = (command: TaskLifecycleCommand, proof: CreateReplayTaskProof | StartExecutionProof | SubmitExecutionProof | ReviewProof | CompleteTaskProof) => {
+  const run = (
+    command: TaskLifecycleCommand,
+    proof: CreateReplayTaskProof | StartExecutionProof | SubmitExecutionProof | ReviewProof | CompleteTaskProof,
+  ) => {
     const result = applyTransition(snapshot, command, proof as never);
     snapshot = result.snapshot;
     events.push(result.event);
   };
-  run(command(implementer, 1, {
-    type: "CreateReplayTask", taskId: "task-1", title: "Fixture", taskClass: "standard", graph: REPLAY_TASK_GRAPH, completionGateIds: [], presetSnapshotDigest: null
-  }), { taskIdUnique: true, actorBinding: implementer });
-  run(command(implementer, 2, {
-    type: "StartExecution", taskId: "task-1", executionId: "execution-1"
-  }), {
-    actorBinding: implementer,
-    reservation: { taskId: "task-1", executionId: "execution-1", expiresAt: "2026-08-11T01:00:00.000Z", ttlMs: 1_800_000,
-      previousHolder: null, reason: "initial_claim", version: 0 }
-  });
-  run(command(implementer, 3, {
-    type: "SubmitExecution", taskId: "task-1", executionId: "execution-1",
-    submission: { completionClaim: "implemented", deliverables: [], outputs: [], verificationNotes: ["tests"], knownGaps: [], residualRisks: [], commitSha }
-  }), { actorBinding: implementer, leaseVersion: 0, sessionDisposition: "complete" });
+  run(
+    command(implementer, 1, {
+      type: "CreateReplayTask",
+      taskId: "task-1",
+      title: "Fixture",
+      taskClass: "standard",
+      graph: REPLAY_TASK_GRAPH,
+      completionGateIds: [],
+      presetSnapshotDigest: null,
+    }),
+    { taskIdUnique: true, actorBinding: implementer },
+  );
+  run(
+    command(implementer, 2, {
+      type: "StartExecution",
+      taskId: "task-1",
+      executionId: "execution-1",
+    }),
+    {
+      actorBinding: implementer,
+      reservation: {
+        taskId: "task-1",
+        executionId: "execution-1",
+        expiresAt: "2026-08-11T01:00:00.000Z",
+        ttlMs: 1_800_000,
+        previousHolder: null,
+        reason: "initial_claim",
+        version: 0,
+      },
+    },
+  );
+  run(
+    command(implementer, 3, {
+      type: "SubmitExecution",
+      taskId: "task-1",
+      executionId: "execution-1",
+      submission: {
+        completionClaim: "implemented",
+        deliverables: [],
+        outputs: [],
+        verificationNotes: ["tests"],
+        knownGaps: [],
+        residualRisks: [],
+        commitSha,
+      },
+    }),
+    { actorBinding: implementer, leaseVersion: 0, sessionDisposition: "complete" },
+  );
   run(reviewCommand(4, "approved", "review-execution"), {
-    actorBinding: reviewer, capability: "execution-review@v1", capabilityRef: "cap-review"
+    actorBinding: reviewer,
+    capability: "execution-review@v1",
+    capabilityRef: "cap-review",
   });
   const review = snapshot.reviews[0]!;
-  run(command(implementer, 5, { type: "RecordReviewConsent", taskId: "task-1", executionId: "execution-1", reviewId: review.reviewId, consentId: "consent-1", reviewDigest: reviewDigest(review), contentDigest: review.contentDigest }), { actorBinding: implementer, capability: "execution-consent@v1", capabilityRef: "cap-consent" } as never);
-  run(command(implementer, 6, { type: "CompleteTask", taskId: "task-1", executionId: "execution-1" }),
-    { capability: "task-complete@v1", capabilityRef: "cap-complete", actorRole: "owner", noActiveLease: true, gateReceipts: [] });
+  run(
+    command(implementer, 5, {
+      type: "RecordReviewConsent",
+      taskId: "task-1",
+      executionId: "execution-1",
+      reviewId: review.reviewId,
+      consentId: "consent-1",
+      reviewDigest: reviewDigest(review),
+      contentDigest: review.contentDigest,
+    }),
+    { actorBinding: implementer, capability: "execution-consent@v1", capabilityRef: "cap-consent" } as never,
+  );
+  run(command(implementer, 6, { type: "CompleteTask", taskId: "task-1", executionId: "execution-1" }), {
+    capability: "task-complete@v1",
+    capabilityRef: "cap-complete",
+    actorRole: "owner",
+    noActiveLease: true,
+    gateReceipts: [],
+  });
   return { events, snapshot };
 }
 
 function reviewCommand(revision: number, verdict: "approved", reviewId: string): RecordReviewCommand {
+  const submission = {
+    completionClaim: "implemented",
+    deliverables: [],
+    outputs: [],
+    verificationNotes: ["tests"],
+    knownGaps: [],
+    residualRisks: [],
+    commitSha,
+  };
   return command(reviewer, revision, {
-    type: "RecordReview", taskId: "task-1", executionId: "execution-1", reviewId, verdict,
-    reason: "execution approved", evidenceChecked: [], commitSha, iteration: 0,
-    contentDigest: `sha256:${"b".repeat(64)}`
+    type: "RecordReview",
+    taskId: "task-1",
+    executionId: "execution-1",
+    reviewId,
+    verdict,
+    reason: "execution approved",
+    evidenceChecked: [],
+    commitSha,
+    iteration: 0,
+    contentDigest: `sha256:${"b".repeat(64)}`,
+    submissionDigest: submissionDigest(submission),
   });
 }

--- a/packages/kernel/test/store/task-lifecycle-fixture.ts
+++ b/packages/kernel/test/store/task-lifecycle-fixture.ts
@@ -1,10 +1,10 @@
 import { REPLAY_TASK_GRAPH } from "../../src/domain/task-graph.ts";
+import { submissionDigest } from "../../src/domain/execution.ts";
 import {
   applyTransition,
   emptyTaskLifecycleSnapshot,
   normalizeTaskLifecycleCommand,
   reviewDigest,
-  submissionDigest,
   type CompleteTaskProof,
   type CreateReplayTaskProof,
   type RecordReviewCommand,

--- a/tools/gates/test/task-lifecycle-transitions.test.mjs
+++ b/tools/gates/test/task-lifecycle-transitions.test.mjs
@@ -11,7 +11,7 @@ import {
   TaskLifecycleContractError,
 } from "../../../packages/kernel/src/domain/task-lifecycle.contract.ts";
 import { REPLAY_TASK_GRAPH } from "../../../packages/kernel/src/domain/task-graph.ts";
-import { TASK_LEASE_BROKER_CONTRACT } from "../../../packages/kernel/src/domain/execution.ts";
+import { submissionDigest, TASK_LEASE_BROKER_CONTRACT } from "../../../packages/kernel/src/domain/execution.ts";
 
 const owner = { principal: { personId: "person-owner" }, executor: { kind: "agent", id: "owner-agent" } };
 const executor = { principal: { personId: "person-owner" }, executor: { kind: "agent", id: "worker-agent" } };
@@ -128,6 +128,7 @@ function review(
       commitSha,
       iteration,
       contentDigest,
+      submissionDigest: submissionDigest(submission(commitSha)),
     },
     `${reviewId}-${verdict}`,
   );


### PR DESCRIPTION
# English

## Summary

`ha task submit <task> --execution-id <exe> --amend --json-input|--from-file <packet>` lets the same execution actor replace a submitted packet while the task is still in review. The amendment appends a second `execution_submitted` event whose payload carries `supersedesSubmissionId: submission:sha256:<digest of the prior packet>` instead of a graph edge; replay verifies that id against the previously projected packet, rejects a no-op replacement, and leaves task, lease and edge state untouched. Reviews now pin `submissionDigest`, owner consents pin the current submission digest, and code-doc / gate witnesses must match the latest submission commit and iteration, so nothing recorded against the superseded packet can carry a completion. The commit-only review selection helpers (`approvedReviewsForCut`, `consentedApprovedReview`) are deleted because every production reader moved to the execution-pinned helpers.

## Architectural Justification

Before this change a submission with a wrong `commitSha` was permanent: code-doc reconcile rejected the real commit with `invalid_proof` and the execution could never complete (fact F-84F708F6, task_bf104d14; the same dead end on task_36ed1686). The fix keeps the gates as strict as before and adds exactly one corrective transition on the existing event type. Admissibility is checked in the lifecycle transition (task in review, execution submitted, no live lease, same execution actor, changed packet, current aggregate revision) and concurrent amendments from several edge nodes serialise through the RepoCell revision fence, so the later writer is rejected rather than merged. No skip-code-doc switch, no compatibility reader and no migration are introduced: existing events keep the `edge` shape and the validator requires exactly one of `edge` or `supersedesSubmissionId`.

## Gate Harvest / 门收割

Deleted-Production-Paths: `approvedReviewsForCut` and `consentedApprovedReview` in `packages/kernel/src/domain/review.ts` (commit-only review selection, replaced by `approvedReviewsForExecution` / `consentedApprovedReviewForExecution`); the wall-clock consent ordering and the iteration-only code-doc witness criterion they backed; `isSubmissionId` / `submissionId` removed from the kernel entry (module-internal now).
Deleted-Gates-Fixtures: kernel `cross-aggregate-judgments.test.ts` selection assertion migrated from `consentedApprovedReview` to the execution-pinned helper; `review-consent-digest-fixture.test.ts` historical fixture re-validated with required-field checking now that reviews carry `submissionDigest`.

## Machine-Readable Declarations

Production-Delta: +471/-232
Dependency-Change: none

### Optional Evidence Claims

none

## Task And Scope

task_34048f3732d67eaede2f712c1a (12.a: a submitted execution cannot be amended). Worker commit 458da7447 (Sol) plus a CEO follow-up commit deleting the replaced helpers after the kernel dead-export gate flagged them.

## Version Impact

None.

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none
- Authority: not applicable
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Follow-up governance task: not applicable

## Verification

- Round 3 (d5a16949a, test-only): eight whole-file CI failures traced to two fixture causes — seven files shared a fixture that still imported `submissionId` through the kernel entry after that export was withdrawn, and one fixture mutated the submission after consent while keeping the stale content-pin expectation. The F7 negative controls are added (amend refused while a lease is held, across execution actors, for a no-op packet, and exactly one of two concurrent amendments succeeds). Exact CI job commands then pass locally: shards 1–5 (27/27, 174/174, 146+1 skip, 203/203, 158+2 skip) and fast-contract (contract 962/962). The branch was rebased onto main by the worker; the CEO merge commit was replaced by the same content on top of #2202/#2203.
- Independent functional review (Opus, read-only, 8 checks): admissibility boundary, event/replay shape, downstream consistency (reconcile, review pin, consent pin, completion witness) and CLI/protocol exposure all CONFIRMED; the one BLOCKING finding (kernel dead-export gate red on the branch) is fixed by the follow-up commit.
- Worker and review runs: `npx tsc --noEmit` kernel/daemon/cli/application clean; application execution-submit-atomicity / execution-approval-idempotency / task-action-explanation-service, cli task-action-derivation / task-action-help, kernel review-consent-digest-fixture 12/12; daemon task-closeout-action + rejection-next-actions 19/19; kernel start-execution-admissibility 7/7; daemon hitrate-task-lifecycle integration 1/1; line-density, implementation-contracts, cli-help-contract, domain-judgment-single-definition, duplicate-definitions gates pass.
- After the CEO commit: `npm run typecheck` clean; `tools/check-kernel-dead-exports.mjs` pass (171 allowlisted, 492 consumed); cross-aggregate-judgments, review-consent-digest-fixture, execution-submit-atomicity, hitrate-task-lifecycle 14/14; line-density pass.
- Not run locally: full CI (authority), `check:local`.

## Review Evidence

CEO semantic check against the task plan: goals 1–4 are present (amend transition, latest-submission downstream reads, contract tests for reconcile-before/after, complete-rejects and cross-execution-rejects, `--amend` in help/capabilities with structured guidance). Two reviewer observations are accepted as designed and recorded here: a consent created after the amendment that pins the current submission digest may select an earlier approved review (the plan allows "consent explicitly accepts"), and `repo-cell-proof.ts` now reports non-code-doc gate witnesses as satisfied only when `result === "pass"`, aligning the receipt with the closeout-readiness criterion that already required it. Follow-ups filed under the task: amend is restricted to the same execution actor (an owner-override amend needs its own decision), lease-held / cross-actor / no-op / concurrent amend contract tests, the initial `submitted` graph edge keeps the superseded commit for audit, and the domain vs document JSON schema disagree on whether `submissionDigest` is required.

## Residual Risk

The first submission's graph edge still names the superseded commit; no gate reads `edgesTaken` today, so this is an audit-surface inconsistency rather than a judgment risk. `ha task amend --set` (prose) and `ha task submit --amend` (submission) coexist in the help output.

# 中文

## 概要

`ha task submit <task> --execution-id <exe> --amend --json-input|--from-file <packet>` 允许同一 execution actor 在 task 仍处于 review 时替换已提交的 packet。修正以第二条 `execution_submitted` 事件追加,payload 用 `supersedesSubmissionId: submission:sha256:<前一 packet 的摘要>` 代替图边;replay 校验该 id 等于之前投影出的 packet、拒绝无变化的替换、不动 task/lease/edge 状态。Review 现在 pin `submissionDigest`,owner consent pin 当前 submission 摘要,code-doc 与门 witness 必须匹配最新 submission 的 commit 与 iteration,因此针对被替代 packet 记录的任何东西都不能带出完成。只按 commit 选 review 的旧 helper(`approvedReviewsForCut`、`consentedApprovedReview`)删除,因为所有生产读者都已改用按 execution pin 的 helper。

## 架构辩护

此前写错 `commitSha` 的 submission 是永久的:code-doc reconcile 对真实 commit 报 `invalid_proof`,execution 永远无法完成(fact F-84F708F6,task_bf104d14;task_36ed1686 同样死路)。本修复保持门与之前同样严格,只在既有事件类型上加一条纠正转换。准入在生命周期转换里检查(task 在 review、execution 已提交、无活 lease、同一 execution actor、packet 有变化、aggregate revision 当前),多个边缘节点并发 amend 经 RepoCell revision fence 串行化,后写者被拒而不是合并。不加「跳过 code-doc」开关、不加兼容读取器、不做迁移:既有事件保持 `edge` 形状,validator 要求 `edge` 与 `supersedesSubmissionId` 恰有其一。

## 机读声明

见英文块。

## 治理声明

- 触碰受保护面:否
- 受保护面范围:无
- 授权:不适用
- 机器检查边界:本 PR 只断言声明存在,是否真实充分由评审判断。
- Break-glass:否
- Break-glass 原因:不适用
- 后续治理任务:不适用

## 验证

- 第三轮(d5a16949a,纯测试):八个整文件 CI 失败归到两个夹具根因——七个文件共用的夹具在 `submissionId` 从 kernel 入口撤出后仍经入口导入它;另一个夹具在 consent 之后篡改 submission 却保留旧的 content pin 期望。补上 F7 四条阴性对照(持 lease 时拒、跨 execution actor 拒、no-op packet 拒、并发两次 amend 恰一成功)。CI 原样命令本地全绿:shard 1–5(27/27、174/174、146+1 skip、203/203、158+2 skip)与 fast-contract(contract 962/962)。分支被 worker rebase 到 main 之上,CEO 的 merge commit 由同内容替换,基于 #2202/#2203。
- 独立功能复核(Opus,只读,8 项):准入边界、事件/replay 形状、下游一致(reconcile、review pin、consent pin、完成 witness)、CLI/协议暴露全部 CONFIRMED;唯一 BLOCKING(分支上 kernel dead-export 门红)由后续 commit 修复。
- worker 与复核运行:kernel/daemon/cli/application `npx tsc --noEmit` 干净;application execution-submit-atomicity / execution-approval-idempotency / task-action-explanation-service、cli task-action-derivation / task-action-help、kernel review-consent-digest-fixture 12/12;daemon task-closeout-action + rejection-next-actions 19/19;kernel start-execution-admissibility 7/7;daemon hitrate-task-lifecycle 集成 1/1;line-density、implementation-contracts、cli-help-contract、domain-judgment-single-definition、duplicate-definitions 门通过。
- CEO commit 之后:`npm run typecheck` 干净;`tools/check-kernel-dead-exports.mjs` 通过(171 豁免,492 被消费);cross-aggregate-judgments、review-consent-digest-fixture、execution-submit-atomicity、hitrate-task-lifecycle 14/14;line-density 通过。
- 本地未跑:完整 CI(权威面)、`check:local`。

## 评审证据

CEO 对照任务 plan 做语义核对:目标 1–4 齐全(amend 转换、下游按最新 submission 读、reconcile 前后/complete 拒绝/跨 execution 拒绝的契约测试、help/capabilities 列出 `--amend` 且回执走结构化 guidance)。两条复核观察按设计接受并在此记录:amend 之后新建、pin 当前 submission 摘要的 consent 可以选中更早的 approved review(plan 允许「consent 明确接受」);`repo-cell-proof.ts` 现在只在 `result === "pass"` 时把非 code-doc 门 witness 报为满足,与 closeout-readiness 早已要求的判据对齐。记在任务下的后续项:amend 限同一 execution actor(owner 代改需要单独 decision)、持 lease / 跨 actor / no-op / 并发 amend 的契约测试、首次 `submitted` 图边保留被替代的 commit 作审计、domain 与文档 JSON schema 对 `submissionDigest` 是否必需不一致。

## 残余风险

首次 submission 的图边仍记着被替代的 commit;今天没有任何门读 `edgesTaken`,所以只是审计面不一致而非判定风险。`ha task amend --set`(改 prose)与 `ha task submit --amend`(改 submission)并存于同一份 help 输出。
