### PR TITLE
fix(gui): let dev:electron take the renderer port from HARNESS_GUI_DEV_PORT

### DIFF
--- a/packages/gui/scripts/dev-electron.mjs
+++ b/packages/gui/scripts/dev-electron.mjs
@@ -10,7 +10,8 @@ import { fileURLToPath } from "node:url";
 const require = createRequire(import.meta.url);
 const guiRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const repoRoot = path.resolve(guiRoot, "../..");
-const rendererUrl = "http://127.0.0.1:5173";
+const rendererPort = process.env.HARNESS_GUI_DEV_PORT ?? "5173";
+const rendererUrl = `http://127.0.0.1:${rendererPort}`;
 
 const electronPath = require("electron");
 // Resolve vite's own bin script through Node's module resolution rather than shelling
@@ -35,7 +36,7 @@ if (preloadBuild.status !== 0) {
 }
 
 log(`starting renderer dev server at ${rendererUrl} ...`);
-const vite = spawn(process.execPath, [viteBin, "--host", "127.0.0.1", "--port", "5173", "--strictPort"], {
+const vite = spawn(process.execPath, [viteBin, "--host", "127.0.0.1", "--port", rendererPort, "--strictPort"], {
   cwd: guiRoot,
   env: { ...process.env, BROWSER: "none" },
   stdio: ["ignore", "pipe", "pipe"],
@@ -53,7 +54,7 @@ async function waitForRenderer() {
   let lastError;
   while (Date.now() < deadline) {
     if (vite.exitCode !== null) {
-      throw new Error(`renderer dev server exited early with code ${vite.exitCode} (is port 5173 busy?)`);
+      throw new Error(`renderer dev server exited early with code ${vite.exitCode} (is port ${rendererPort} busy?)`);
     }
     try {
       const response = await fetch(rendererUrl);


### PR DESCRIPTION
# English

## Summary

`npm run dev:electron` hard-coded the renderer dev server to port 5173 with `--strictPort`, so any other local Vite project already listening there made the Electron window unstartable ("Port 5173 is already in use", then the shell shuts down to avoid a black window). The script now reads `HARNESS_GUI_DEV_PORT` and falls back to 5173; the URL handed to Electron, the Vite `--port` argument and the early-exit hint all derive from the same value.

## Architectural Justification

One value, one source: the port is computed once and threaded through the three places that previously repeated the literal. No new configuration surface beyond an optional environment variable read by the dev script only; production Electron packaging is untouched.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none

## Machine-Readable Declarations

Production-Delta: +0/-0
Dependency-Change: none

### Optional Evidence Claims

none

## Task And Scope

CEO dogfooding friction found during the Ontology 4.2 slice-2 visual acceptance (task_9e383c5f410f863d3eecb9d10a): the operator's other project held 5173 on the same machine.

## Version Impact

None.

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none
- Authority: not applicable
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Follow-up governance task: not applicable

## Verification

- `node --check packages/gui/scripts/dev-electron.mjs` passes; the diff is three lines in a dev-only script.
- Manual: with 5173 busy, `HARNESS_GUI_DEV_PORT=5174 npm run dev:electron` will be exercised from canonical after merge (the worktree has no hoisted node_modules); result recorded in the task ledger.
- Not run locally: full CI (authority), `check:local`.

## Review Evidence

CEO-authored three-line dev-script change; GitHub CI is the merge authority.

## Residual Risk

None beyond the dev script: a wrong `HARNESS_GUI_DEV_PORT` value fails the same way an occupied port did, with the port named in the message.

# 中文

## 概要

`npm run dev:electron` 把 renderer dev server 写死在 5173 且带 `--strictPort`,本机另一个 Vite 项目占着该端口时 Electron 窗口就起不来("Port 5173 is already in use",随后 shell 主动退出以免黑窗)。脚本现在读 `HARNESS_GUI_DEV_PORT`,缺省仍为 5173;交给 Electron 的 URL、Vite 的 `--port` 参数与早退提示都从同一个值派生。

## 架构辩护

一个值、一个来源:端口只算一次,穿过原来重复字面量的三处。除了 dev 脚本读取的一个可选环境变量,不新增任何配置面;生产 Electron 打包不受影响。

## 机读声明

见英文块。

## 治理声明

- 触碰受保护面:否
- 受保护面范围:无
- 授权:不适用
- 机器检查边界:本 PR 只断言声明存在,是否真实充分由评审判断。
- Break-glass:否
- Break-glass 原因:不适用
- 后续治理任务:不适用

## 验证

- `node --check packages/gui/scripts/dev-electron.mjs` 通过;diff 是 dev 脚本里的三行。
- 手工:5173 被占时用 `HARNESS_GUI_DEV_PORT=5174 npm run dev:electron` 在合并后于 canonical 实跑(worktree 没有提升的 node_modules),结果记入任务台账。
- 本地未跑:完整 CI(权威面)、`check:local`。

## 评审证据

CEO 亲自完成的三行 dev 脚本改动;GitHub CI 是合并权威。

## 残余风险

仅限 dev 脚本:错误的 `HARNESS_GUI_DEV_PORT` 值与端口被占失败方式相同,报错里带端口号。
