### PR TITLE
fix(gui): derive the dev renderer origin from ELECTRON_RENDERER_URL

### DIFF
--- a/packages/gui/src/main/window-config.ts
+++ b/packages/gui/src/main/window-config.ts
@@ -17,6 +17,21 @@ export interface GuiWindowOptions {
   readonly webPreferences: GuiWebPreferences;
 }
 
+const defaultDevRendererOrigin = "http://127.0.0.1:5173";
+
+/** dev renderer 只接受 loopback 上的 http 源;端口跟随 dev 脚本经 ELECTRON_RENDERER_URL 传入的地址。 */
+export function devRendererOriginFrom(value: string | undefined): string {
+  if (!value) return defaultDevRendererOrigin;
+  try {
+    const parsed = new URL(value);
+    return parsed.protocol === "http:" && parsed.hostname === "127.0.0.1" ? parsed.origin : defaultDevRendererOrigin;
+  } catch {
+    return defaultDevRendererOrigin;
+  }
+}
+
+export const devRendererOrigin = devRendererOriginFrom(process.env.ELECTRON_RENDERER_URL);
+
 export interface GuiContentSecurityPolicyOptions {
   readonly allowDevRenderer?: boolean;
 }
@@ -28,7 +43,7 @@ export interface TrustedRendererUrlOptions {
 
 export function createGuiContentSecurityPolicy(options: GuiContentSecurityPolicyOptions = {}): string {
   const connectSrc = options.allowDevRenderer
-    ? "connect-src 'self' http://127.0.0.1:5173 ws://127.0.0.1:5173"
+    ? `connect-src 'self' ${devRendererOrigin} ${devRendererOrigin.replace("http://", "ws://")}`
     : "connect-src 'self'";
   // Dev only: the Vite dev server injects the react-refresh preamble as an inline script.
   const scriptSrc = options.allowDevRenderer ? "script-src 'self' 'unsafe-inline'" : "script-src 'self'";
@@ -49,7 +64,7 @@ export function createGuiContentSecurityPolicy(options: GuiContentSecurityPolicy
 
 export const guiContentSecurityPolicy = createGuiContentSecurityPolicy();
 
-export const allowedRendererOrigins = Object.freeze(["file://", "http://127.0.0.1:5173"] as const);
+export const allowedRendererOrigins = Object.freeze(["file://", devRendererOrigin] as const);
 
 export function createGuiWindowOptions(preloadPath: string): GuiWindowOptions {
   return {
@@ -72,7 +87,7 @@ export function createGuiWindowOptions(preloadPath: string): GuiWindowOptions {
 
 export function assertDevRendererUrl(url: string): true {
   const parsed = new URL(url);
-  if (parsed.origin !== "http://127.0.0.1:5173") {
+  if (parsed.origin !== devRendererOrigin) {
     throw new Error("GUI V1 may load only the local dev renderer server.");
   }
   return true;
@@ -85,7 +100,7 @@ export function createPackagedRendererUrl(): string {
 export function isTrustedRendererUrl(url: string, options: TrustedRendererUrlOptions = {}): boolean {
   try {
     const parsed = new URL(url);
-    if (parsed.origin === "http://127.0.0.1:5173") return options.allowDevRenderer === true;
+    if (parsed.origin === devRendererOrigin) return options.allowDevRenderer === true;
     if (parsed.protocol !== "file:") return false;
     const packagedRendererUrl = options.packagedRendererUrl ?? createPackagedRendererUrl();
     return parsed.href === new URL(packagedRendererUrl).href;

--- a/packages/gui/test/window-config.test.ts
+++ b/packages/gui/test/window-config.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import {
   assertDevRendererUrl,
+  devRendererOriginFrom,
   createGuiContentSecurityPolicy,
   createGuiWindowOptions,
   guiContentSecurityPolicy,
@@ -91,4 +92,11 @@ test("the main window enables only the policy-guarded HTML artifact webview surf
   assert.equal(options.webPreferences.contextIsolation, true);
   assert.equal(options.webPreferences.sandbox, true);
   assert.equal(options.webPreferences.webSecurity, true);
+});
+
+test("dev renderer origin follows the loopback URL the dev script passes and ignores anything else", () => {
+  assert.equal(devRendererOriginFrom("http://127.0.0.1:5174"), "http://127.0.0.1:5174");
+  assert.equal(devRendererOriginFrom("http://localhost:5174"), "http://127.0.0.1:5173");
+  assert.equal(devRendererOriginFrom("not a url"), "http://127.0.0.1:5173");
+  assert.equal(devRendererOriginFrom(undefined), "http://127.0.0.1:5173");
 });


### PR DESCRIPTION
# English

## Summary

PR #2199 made the dev script honour `HARNESS_GUI_DEV_PORT`, but the Electron main process still pinned `http://127.0.0.1:5173` in four places: the CSP `connect-src`, `allowedRendererOrigins`, `assertDevRendererUrl` and `isTrustedRendererUrl`. Starting on 5174 therefore opened a blank window and logged "GUI V1 may load only the local dev renderer server". This PR derives one `devRendererOrigin` from the `ELECTRON_RENDERER_URL` the dev script already passes, accepting only `http://127.0.0.1:<port>` and falling back to 5173 for anything else, and feeds it to all four sites. Packaged builds are unaffected: the env var is unset there and the origin stays 5173, which the file-URL checks never match anyway.

## Architectural Justification

The trust boundary is unchanged in kind: the dev renderer must be a loopback http origin, and the packaged renderer must be the bundled file URL. What changes is that the loopback port is read once from the value the shell hands the main process instead of being restated as a literal four times, so the dev script and the main process cannot disagree about it again.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none

## Machine-Readable Declarations

Production-Delta: +19/-4
Dependency-Change: none

### Optional Evidence Claims

none

## Task And Scope

Completes the dev-port friction fix from PR #2199, found during the Ontology 4.2 slice-2 visual acceptance (task_9e383c5f410f863d3eecb9d10a).

## Version Impact

None.

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none
- Authority: not applicable
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Follow-up governance task: not applicable

## Verification

- `packages/gui/test/window-config.test.ts` (new case: 5174 loopback accepted, `localhost`, garbage and unset fall back to 5173), `electron-security-policy.test.ts`, `trust-policy-contract.test.ts`: 15/15 pass.
- `npx tsc -b packages/gui` clean; `tools/check-implementation-contracts.mjs` pass; `tools/gates/line-density.mjs --base origin/main` pass.
- Manual: `HARNESS_GUI_DEV_PORT=5174 npm run dev:electron` from canonical after merge is the acceptance run (recorded in the task ledger).
- Not run locally: full CI (authority), `check:local`.

## Review Evidence

CEO-authored; the four literal sites were found from the blank-window stack trace at `window-config.ts:76` and a grep for 5173 under `packages/gui`. GitHub CI is the merge authority.

## Residual Risk

A future site that needs the dev origin must import `devRendererOrigin` rather than restate the literal; the comment on the helper says so. Nothing else changes for packaged windows.

# 中文

## 概要

PR #2199 让 dev 脚本读 `HARNESS_GUI_DEV_PORT`,但 Electron 主进程仍在四处钉死 `http://127.0.0.1:5173`:CSP 的 `connect-src`、`allowedRendererOrigins`、`assertDevRendererUrl`、`isTrustedRendererUrl`。用 5174 启动时窗口空白,日志报 "GUI V1 may load only the local dev renderer server"。本 PR 从 dev 脚本已经传入的 `ELECTRON_RENDERER_URL` 派生唯一的 `devRendererOrigin`(只接受 `http://127.0.0.1:<port>`,其它一律回落 5173),四处共用。打包态不受影响:那里没有该环境变量,origin 仍是 5173,而 file URL 检查本来就不会匹配它。

## 架构辩护

信任边界的性质不变:dev renderer 必须是 loopback 上的 http 源,打包 renderer 必须是内置的 file URL。变的只是 loopback 端口从 shell 交给主进程的值里读一次,而不是当字面量抄四遍,dev 脚本与主进程不会再对端口各说各话。

## 机读声明

见英文块。

## 治理声明

- 触碰受保护面:否
- 受保护面范围:无
- 授权:不适用
- 机器检查边界:本 PR 只断言声明存在,是否真实充分由评审判断。
- Break-glass:否
- Break-glass 原因:不适用
- 后续治理任务:不适用

## 验证

- `packages/gui/test/window-config.test.ts`(新增用例:5174 loopback 接受,`localhost`、乱串与未设置回落 5173)、`electron-security-policy.test.ts`、`trust-policy-contract.test.ts`:15/15 通过。
- `npx tsc -b packages/gui` 干净;`tools/check-implementation-contracts.mjs` 通过;`tools/gates/line-density.mjs --base origin/main` 通过。
- 手工:合并后在 canonical 用 `HARNESS_GUI_DEV_PORT=5174 npm run dev:electron` 做验收实跑(记入任务台账)。
- 本地未跑:完整 CI(权威面)、`check:local`。

## 评审证据

CEO 亲自完成;四处字面量来自空白窗口的堆栈(`window-config.ts:76`)与 `packages/gui` 下对 5173 的 grep。GitHub CI 是合并权威。

## 残余风险

今后需要 dev origin 的地方必须 import `devRendererOrigin` 而不是再抄字面量;helper 上的注释已说明。打包窗口没有其它变化。
