### PR TITLE
test(runtime): anchor lifecycle waits to observed state

### DIFF
--- a/packages/cli/test/runtime-wait-reconnect.integration.test.ts
+++ b/packages/cli/test/runtime-wait-reconnect.integration.test.ts
@@ -73,7 +73,11 @@ test("runtime status --wait reads once after an attached stream reports exit", a
 test("runtime status --wait reads once when an attached stream requires a snapshot", async () => {
   const fixture = await openFixtureDaemon("stream-gap");
   let statusReads = 0,
-    terminal = false;
+    terminal = false,
+    terminalStatusServed!: () => void;
+  const terminalStatus = new Promise<void>((resolve) => {
+    terminalStatusServed = resolve;
+  });
   fixture.onRequest = (socket, request) => {
     if (request.method === "protocol.hello") {
       reply(socket, request.id, { ok: true });
@@ -102,9 +106,11 @@ test("runtime status --wait reads once when an attached stream requires a snapsh
     assert.equal(request.method, "repo.agentRuntime.sessions.read");
     statusReads += 1;
     reply(socket, request.id, runtimeStatus(terminal));
+    if (terminal) terminalStatusServed();
   };
   const invocation = runWait(fixture, ["runtime", "status", runtimeSessionId, "--wait"], false);
   try {
+    await terminalStatus;
     const result = await invocation.result(2_000);
     assert.equal(result.code, 0, result.stderr);
     assert.equal(result.stdout.trim(), "settled after reconnect");
@@ -300,17 +306,24 @@ test("runtime status --wait bounds an exited session whose outcome never becomes
 
 test("runtime status --wait surfaces a canonical settlement failure diagnostic", async () => {
   const fixture = await openFixtureDaemon("settlement-outcome");
-  let statusReads = 0;
+  let statusReads = 0,
+    terminalStatusServed!: () => void;
+  const terminalStatus = new Promise<void>((resolve) => {
+    terminalStatusServed = resolve;
+  });
   fixture.onRequest = (socket, request) => {
     if (request.method === "protocol.hello") {
       reply(socket, request.id, { ok: true });
       return;
     }
+    assert.equal(request.method, "repo.agentRuntime.sessions.read");
     statusReads += 1;
     reply(socket, request.id, runtimeStatus(false, true, true));
+    terminalStatusServed();
   };
   const invocation = runWait(fixture);
   try {
+    await terminalStatus;
     const result = await invocation.result(2_000);
     assert.equal(result.code, 1, result.stderr);
     assert.equal(result.receipt.code, "runtime_settlement_failed");
@@ -325,15 +338,22 @@ test("runtime status --wait surfaces a canonical settlement failure diagnostic",
 
 test("runtime status --wait does not infer settlement failure from an unknown outcome's text", async () => {
   const fixture = await openFixtureDaemon("unknown-outcome");
+  let terminalStatusServed!: () => void;
+  const terminalStatus = new Promise<void>((resolve) => {
+    terminalStatusServed = resolve;
+  });
   fixture.onRequest = (socket, request) => {
     if (request.method === "protocol.hello") {
       reply(socket, request.id, { ok: true });
       return;
     }
+    assert.equal(request.method, "repo.agentRuntime.sessions.read");
     reply(socket, request.id, runtimeStatus(false, true, false, true));
+    terminalStatusServed();
   };
   const invocation = runWait(fixture);
   try {
+    await terminalStatus;
     const result = await invocation.result(2_000);
     assert.equal(result.code, 1, result.stderr);
     assert.equal(result.receipt.code, "provider_exit");

--- a/packages/daemon/test/runtime-spawn-lifecycle.integration.test.ts
+++ b/packages/daemon/test/runtime-spawn-lifecycle.integration.test.ts
@@ -299,18 +299,12 @@ test("runtime spawn publishes a canonical session and makes it visible in overvi
       });
       assert.ok(firstExit, "runtime exit listener must be attached before the provider exits");
       firstExit(0);
-      await eventually(() =>
-        makeTaskEventReader({ repoId: "runtime-spawn", rootDir: root })
-          .read()
-          .events.some(
-            (candidate) =>
-              candidate.type === "runtime_session_exited" &&
-              candidate.payload.runtimeSessionId === receipt.runtimeSessionId,
-          ),
-      );
-      const settled = (await cell.read("repo.agentRuntime.overview", {})).sessions.find(
-        (candidate) => candidate.runtimeSessionId === receipt.runtimeSessionId,
-      );
+      const settled = await eventuallyValue(async () => {
+        const projected = (await cell.read("repo.agentRuntime.overview", {})).sessions.find(
+          (candidate) => candidate.runtimeSessionId === receipt.runtimeSessionId,
+        );
+        return projected?.liveness === "exited" ? projected : null;
+      });
       assert.equal(settled?.liveness, "exited");
       assert.notEqual(settled?.semanticState, "running");
       const alternate = await cell.spawnRuntime(

--- a/packages/preset/test/preset-process-service.test.ts
+++ b/packages/preset/test/preset-process-service.test.ts
@@ -6,6 +6,7 @@ import {
   mkdtempSync,
   readFileSync,
   rmSync,
+  watch,
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
@@ -253,9 +254,6 @@ test("bounded child protocol classifies every failure without a silent phase", a
 });
 
 test("timeout forcibly reaps a child that ignores SIGTERM before publishing terminal receipt", async () => {
-  // Loaded measurements did not reproduce the CI failure, so these remain explicit wall-clock
-  // premises: the child must write its pid before 2s, then the timeout and SIGTERM handler must
-  // become observable within waitFor's 5s polling budget. Keep both margins coupled when changing them.
   const fixture = scriptedPackage(
       'const { writeFileSync } = await import("node:fs"); process.on("SIGTERM", () => writeFileSync("term.seen", "yes")); writeFileSync("child.pid", String(process.pid)); setInterval(() => {}, 1_000);',
     ),
@@ -281,19 +279,17 @@ test("timeout forcibly reaps a child that ignores SIGTERM before publishing term
         started.runId,
       ),
       pidPath = path.join(staging, "child.pid"),
-      termPath = path.join(staging, "term.seen");
+      termPath = path.join(staging, "term.seen"),
+      termSeen = process.platform === "win32" ? null : observeFileAppearance(termPath);
     await waitFor(
       "child.pid file for timeout fixture",
       () => existsSync(pidPath),
       Boolean,
     );
     pid = Number(readFileSync(pidPath, "utf8"));
-    if (process.platform !== "win32")
-      await waitFor(
-        "term.seen file after timeout SIGTERM",
-        () => existsSync(termPath),
-        Boolean,
-      ); // On Windows kill(SIGTERM) terminates unconditionally, so the handler phase cannot be witnessed; the reaped end state is asserted instead.
+    if (termSeen) await termSeen;
+    // On Windows kill(SIGTERM) terminates unconditionally, so the handler phase cannot be witnessed;
+    // the reaped end state is asserted instead.
     assert.doesNotThrow(() => process.kill(pid!, 0));
     assert.equal(terminalOutcome(service.status(started.runId).outcome), false);
     const terminal = await waitFor(
@@ -341,7 +337,8 @@ test("close forcibly reaps a child that ignores SIGTERM within a fixed bound", a
         started.runId,
       ),
       pidPath = path.join(staging, "child.pid"),
-      termPath = path.join(staging, "term.seen");
+      termPath = path.join(staging, "term.seen"),
+      termSeen = process.platform === "win32" ? null : observeFileAppearance(termPath);
     await waitFor(
       "child.pid file for close fixture",
       () => existsSync(pidPath),
@@ -356,11 +353,7 @@ test("close forcibly reaps a child that ignores SIGTERM within a fixed bound", a
         false,
       ); // Windows terminates unconditionally once close() runs, so only the pre-reap state is observable in flight.
     else {
-      await waitFor(
-        "term.seen file after close SIGTERM",
-        () => existsSync(termPath),
-        Boolean,
-      );
+      await termSeen;
       assert.doesNotThrow(() => process.kill(pid!, 0));
       assert.equal(
         terminalOutcome(service.status(started.runId).outcome),
@@ -652,6 +645,36 @@ function terminalOutcome(outcome: string): boolean {
   return ["applied", "op_rejected", "failed", "outcome_unknown"].includes(
     outcome,
   );
+}
+function observeFileAppearance(target: string): Promise<void> {
+  const root = path.dirname(path.dirname(target)),
+    relativeTarget = path.normalize(path.relative(root, target));
+  return new Promise<void>((resolve, reject) => {
+    let settled = false;
+    const watcher = watch(root, { recursive: true }, (_event, filename) => {
+      if (
+        !settled &&
+        ((filename !== null &&
+          path.normalize(String(filename)) === relativeTarget) ||
+          existsSync(target))
+      ) {
+        settled = true;
+        watcher.close();
+        resolve();
+      }
+    });
+    watcher.once("error", (error) => {
+      if (settled) return;
+      settled = true;
+      watcher.close();
+      reject(error);
+    });
+    if (existsSync(target)) {
+      settled = true;
+      watcher.close();
+      resolve();
+    }
+  });
 }
 async function waitFor<T>(
   description: string,


### PR DESCRIPTION
# English

## Summary

Three integration-test families flaked on CI because their completion budgets or one-shot reads were bound to the moment an asynchronous producer started rather than to the state the consumer can actually observe. `runtime-spawn-lifecycle.integration.test.ts` now waits for `liveness === "exited"` on the host-side projection instead of racing the canonical exit event; the `runtime status --wait` cases in `runtime-wait-reconnect.integration.test.ts` start their 2000 ms deadline only after the fake daemon has served the terminal status (the budget itself is unchanged); and the preset SIGTERM tests in `preset-process-service.test.ts` observe the transient `term.seen` files through `fs.watch`, including the adjacent close case. Production delta is +0/-0.

## Architectural Justification

Each family had the same shape: a fixed budget anchored on producer start time. Re-anchoring the wait on the consumer-observable transition removes the timing assumption without loosening any assertion, extending any timeout, or adding retries. A controlled red→green replay (5/6 failing with `'live' !== 'exited'` before, 6/6 after) shows the fix addresses the observed failure rather than masking it.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none

## Machine-Readable Declarations

Production-Delta: +0/-0
Dependency-Change: none

### Optional Evidence Claims

none

## Task And Scope

task_1e817a927ce4c47afaf475b8a0 (three CI flake families: runtime exit-event wait, `runtime status --wait` 2000 ms budget, Node 26 SIGTERM reap). Worker commit 926c16689 (Sol), CEO semantic review.

## Version Impact

None.

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none
- Authority: not applicable
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Follow-up governance task: not applicable

## Verification

- Isolated Ubuntu target (`node tools/dispatch-isolated-test.mjs --target ubuntu --file …`): runtime-spawn-lifecycle 6/6, runtime-spawn-settlement 6/6, runtime-spawn 5/5, runtime-wait-reconnect 10/10 (the two historically red cases finish in ~244 ms and ~226 ms), preset-process-service 8/8 (timeout case 2240 ms, close case 174 ms).
- Controlled replay on the previous test code: 5/6 failing with `'live' !== 'exited'`; 6/6 after the change.
- `npm run typecheck` clean; ESLint on the three files clean; `git diff --check` clean. Fact F-DFDFCE3D recorded.
- Not run: `check:local`; Windows lane (its unobservable SIGTERM-handler branch is unchanged).

## Review Evidence

CEO semantic check against the task plan: all three families are addressed, the sibling stream-gap and close cases found by the worker's same-mechanism search are fixed in the same change, no timeout was raised and no assertion weakened. GitHub CI is the merge authority.

## Residual Risk

The Windows lane exercises a different SIGTERM path that this change does not touch; it stays nightly-only per dec_630DB4EB.

# 中文

## 概要

三个集成测试族在 CI 上抖动,共因是把完成预算或一次性读取绑定在异步 producer 的启动时刻,而不是 consumer 真正可观察的状态。`runtime-spawn-lifecycle.integration.test.ts` 改为等待宿主侧投影的 `liveness === "exited"`,不再与 canonical exit 事件赛跑;`runtime-wait-reconnect.integration.test.ts` 里 `runtime status --wait` 的 2000 ms 期限改为在假 daemon 送出终态状态之后才开始计(预算本身不变);`preset-process-service.test.ts` 的 SIGTERM 用例改用 `fs.watch` 观察瞬时的 `term.seen` 文件,含相邻的 close 用例。生产 delta +0/-0。

## 架构辩护

三族形状相同:固定预算锚在 producer 启动时间。把等待重新锚到 consumer 可观察的转换上,去掉了时序假设,没有放松任何断言、没有加长任何超时、没有加重试。受控的红→绿回放(改前 5/6 失败于 `'live' !== 'exited'`,改后 6/6)说明修的是观察到的失败而不是遮住它。

## 机读声明

见英文块。

## 治理声明

- 触碰受保护面:否
- 受保护面范围:无
- 授权:不适用
- 机器检查边界:本 PR 只断言声明存在,是否真实充分由评审判断。
- Break-glass:否
- Break-glass 原因:不适用
- 后续治理任务:不适用

## 验证

- Ubuntu 隔离机(`node tools/dispatch-isolated-test.mjs --target ubuntu --file …`):runtime-spawn-lifecycle 6/6、runtime-spawn-settlement 6/6、runtime-spawn 5/5、runtime-wait-reconnect 10/10(两条历史红用例约 244 ms 与 226 ms 完成)、preset-process-service 8/8(timeout 用例 2240 ms,close 用例 174 ms)。
- 对旧测试代码的受控回放:5/6 失败于 `'live' !== 'exited'`;改后 6/6。
- `npm run typecheck` 干净;三文件 ESLint 干净;`git diff --check` 干净。已记 fact F-DFDFCE3D。
- 未跑:`check:local`;Windows lane(其不可观察的 SIGTERM-handler 分支未改)。

## 评审证据

CEO 对照任务 plan 做语义核对:三族全部处理,worker 同机制搜索发现的 stream-gap 与 close 两处同一变更内修掉,没有抬超时、没有削断言。GitHub CI 是合并权威。

## 残余风险

Windows lane 走的是本改动未触碰的另一条 SIGTERM 路径,按 dec_630DB4EB 仍只在 nightly 跑。
