### PR TITLE
fix(daemon): retry transient Git index locks during WAL materialization

### DIFF
--- a/docs-release/migration-legacy-ledger-recovery.md
+++ b/docs-release/migration-legacy-ledger-recovery.md
@@ -192,7 +192,7 @@ relation / execution — against a same-cut or disposable rebuilt oracle. Read
 | Report | What it means | Action |
 | --- | --- | --- |
 | `recovery_conflict` | Another recovery command already holds this repository's single-writer recovery ingress. | Wait for the command named in the hint to settle, then rerun. Do not open a second path in. |
-| `publication_indeterminate` with a `git … update-ref …` hint | A commit was made outside the daemon, so the ledger branch no longer points at the last published event commit. | Run the `git -C … update-ref …` command exactly as printed — it moves only the branch pointer and leaves every file in place — then `ha daemon stop`, then retry the recovery. |
+| `publication_indeterminate` with a `git … update-ref …` hint | A commit was made outside the daemon, so the ledger branch no longer points at the last published event commit. | Run the `git -C … update-ref …` command exactly as printed — it moves only the branch pointer and leaves every file in place — then retry the recovery. The repository re-probes the repaired refs without restarting the daemon; if the first retry still reports the old latch, wait for `ha daemon status` to return to `ok` and retry again. |
 | Source rejected as not completely committed | The ledger work tree has uncommitted changes. | Commit them (or park them), then rerun the dry-run. Do not migrate a dirty cut. |
 | `migration_projection_oracle_cut_mismatch` | A stale derived projection does not match the canonical event head. | The oracle falls back to a disposable rebuild on its own. If the error persists, stop the source's writers and read the nested cause. Do not delete or move `.harness/cache/task.sqlite` by hand — a stale cache is rebuilt in place, and moving it away returns the same verdict. |
 | A typed rejection other than the missing-provenance shape | The ledger contains an invalid event this recovery does not restate. | Keep the ledger, capture the named event and schema, and report it. Guessing a restatement for an undescribed shape is not a recovery. |
@@ -221,8 +221,8 @@ which events, how many, and nothing else — before any byte changes.
 
 **Do I need to stop the daemon?**
 No. The recovery command runs through the daemon's single-writer queue; that queue is what makes the
-rewrite safe. Stop the repository's *other* writers instead. The one place `ha daemon stop` appears
-is the `publication_indeterminate` recovery above, and there it follows the ref repair.
+rewrite safe. Stop the repository's *other* writers instead. A repaired `publication_indeterminate`
+latch is re-probed by the resident daemon when you retry the command.
 
 **My counts are not zero on the other surfaces. What do I do?**
 Stop and read the report before applying. This page describes a recovery whose only planned work is

--- a/docs-release/migration-legacy-ledger-recovery.zh-CN.md
+++ b/docs-release/migration-legacy-ledger-recovery.zh-CN.md
@@ -174,7 +174,7 @@ dry-run。
 | 报告 | 含义 | 动作 |
 | --- | --- | --- |
 | `recovery_conflict` | 另一条恢复命令已持有该仓库的单写者恢复准入。 | 等 hint 点名的那条命令 settle，再重跑。不要另开第二条路。 |
-| `publication_indeterminate`（带 `git … update-ref …` 提示） | daemon 之外有人 commit 过，台账分支不再指向最后一个已发布事件 commit。 | 原样执行报错里打印的那条 `git -C … update-ref …`——它只移动分支指针，不动任何文件——然后 `ha daemon stop`，再重试恢复。 |
+| `publication_indeterminate`（带 `git … update-ref …` 提示） | daemon 之外有人 commit 过，台账分支不再指向最后一个已发布事件 commit。 | 原样执行报错里打印的那条 `git -C … update-ref …`——它只移动分支指针，不动任何文件——然后重试恢复。仓库会在不重启 daemon 的情况下重新探测已修复的 refs；若第一次重试仍返回旧闩，等 `ha daemon status` 回到 `ok` 后再重试一次。 |
 | 源因未完全提交被拒收 | 台账工作树有未提交改动。 | 提交（或移开）后重跑 dry-run。不要迁移脏切面。 |
 | `migration_projection_oracle_cut_mismatch` | 过期的派生投影与 canonical 事件头不一致。 | oracle 会自行回落到一次性重建。若报错持续，停掉源的写入者并读内层原因。不要手工删除或移动 `.harness/cache/task.sqlite`——过期缓存会被就地重建，把它移开只会得到同样的判定。 |
 | 缺 provenance 形态之外的 typed 拒绝 | 台账里有本恢复不重述的无效事件。 | 保留台账，收集点名的事件与 schema，然后报告。为未描述的形状猜一个重述不是恢复。 |
@@ -201,8 +201,7 @@ dry-run 不发布任何东西，也不清闩。它存在的意义是让你在任
 
 **我需要停 daemon 吗？**
 不需要。恢复命令走 daemon 的单写队列；正是这条队列让重写变得安全。要停的是这个仓库的
-*其他* 写入者。`ha daemon stop` 只出现在上面 `publication_indeterminate` 的恢复里，而且
-那是跟在 ref 修复之后的动作。
+*其他* 写入者。修复 `publication_indeterminate` 后，重试命令会让常驻 daemon 重新探测并清闩。
 
 **其他面上的计数不是零，怎么办？**
 停下来，先读报告再决定。本页描述的恢复，其唯一计划的工作量就是 provenance 重述；另一个

--- a/packages/cli/src/cli/guidance-plane.ts
+++ b/packages/cli/src/cli/guidance-plane.ts
@@ -50,7 +50,16 @@ const guidanceTemplates = new Map<string, GuidanceTemplate>([
       `lastCheckpointRevision=${numberArg(args, "lastCheckpointRevision")} ` +
       `lastCheckpointAt=${nullableTextArg(args, "lastCheckpointAt")} ` +
       `pendingWalEvents=${numberArg(args, "pendingWalEvents")} lastError=${textArg(args, "lastError")}. ` +
-      "Repair the cause, then use repository recovery/drain or restart the daemon before retrying writes.",
+      "Repair the cause, then retry the write; the repository recovery path will re-probe and resume without a daemon restart.",
+  ],
+  [
+    "failure:materialization-retrying",
+    (args) =>
+      `WAL-to-Git materialization is retrying: waited=${numberArg(args, "retryElapsedMs")}ms ` +
+      `lastCheckpointRevision=${numberArg(args, "lastCheckpointRevision")} ` +
+      `lastCheckpointAt=${nullableTextArg(args, "lastCheckpointAt")} ` +
+      `pendingWalEvents=${numberArg(args, "pendingWalEvents")} lastError=${textArg(args, "lastError")}. ` +
+      "New writes are temporarily refused while the durable WAL retries; wait and retry the write without restarting the daemon.",
   ],
   [
     "failure:invalid-enum",
@@ -172,6 +181,8 @@ function renderDiagnostic(diagnostic: Record<string, unknown>): string | null {
   if (diagnostic.kind === "missing-sections") return renderTemplate("failure", "missing-sections", diagnostic);
   if (diagnostic.kind === "materialization-failed")
     return renderTemplate("failure", "materialization-failed", diagnostic);
+  if (diagnostic.kind === "materialization-retrying")
+    return renderTemplate("failure", "materialization-retrying", diagnostic);
   if (diagnostic.kind === "invalid-enum") return renderTemplate("failure", "invalid-enum", diagnostic);
   if (diagnostic.kind === "failure") return renderTemplate("failure", "failure", diagnostic);
   return null;

--- a/packages/cli/src/cli/guidance-plane.ts
+++ b/packages/cli/src/cli/guidance-plane.ts
@@ -50,7 +50,8 @@ const guidanceTemplates = new Map<string, GuidanceTemplate>([
       `lastCheckpointRevision=${numberArg(args, "lastCheckpointRevision")} ` +
       `lastCheckpointAt=${nullableTextArg(args, "lastCheckpointAt")} ` +
       `pendingWalEvents=${numberArg(args, "pendingWalEvents")} lastError=${textArg(args, "lastError")}. ` +
-      "Repair the cause, then retry the write; the repository recovery path will re-probe and resume without a daemon restart.",
+      "Repair the cause, then retry the write; the repository recovery path will " +
+      "re-probe and resume without a daemon restart.",
   ],
   [
     "failure:materialization-retrying",
@@ -59,7 +60,8 @@ const guidanceTemplates = new Map<string, GuidanceTemplate>([
       `lastCheckpointRevision=${numberArg(args, "lastCheckpointRevision")} ` +
       `lastCheckpointAt=${nullableTextArg(args, "lastCheckpointAt")} ` +
       `pendingWalEvents=${numberArg(args, "pendingWalEvents")} lastError=${textArg(args, "lastError")}. ` +
-      "New writes are temporarily refused while the durable WAL retries; wait and retry the write without restarting the daemon.",
+      "New writes are temporarily refused while the durable WAL retries; wait and retry the write " +
+      "without restarting the daemon.",
   ],
   [
     "failure:invalid-enum",

--- a/packages/cli/src/daemon/control.ts
+++ b/packages/cli/src/daemon/control.ts
@@ -323,7 +323,34 @@ function assessDaemonStatus(result: Record<string, unknown>): {
   readonly receipt: Record<string, unknown>;
   readonly exitCode: 0 | 1;
 } {
-  const failedRows = (Array.isArray(result.repos) ? result.repos : []).filter(
+  const rows = Array.isArray(result.repos) ? result.repos : [],
+    retryingRows = rows.flatMap((value) => {
+      if (!statusRecord(value) || !statusRecord(value.materialization)) return [];
+      const health = value.materialization;
+      if (
+        health.state !== "retrying" ||
+        typeof value.repoId !== "string" ||
+        !Number.isSafeInteger(health.lastCheckpointRevision) ||
+        !Number.isSafeInteger(health.pendingWalEvents) ||
+        !Number.isSafeInteger(health.retryElapsedMs) ||
+        typeof health.lastError !== "string"
+      )
+        return [];
+      return [
+        `repo=${value.repoId} state=retrying waitedMs=${String(health.retryElapsedMs)} ` +
+          `lastCheckpointRevision=${String(health.lastCheckpointRevision)} ` +
+          `pendingWalEvents=${String(health.pendingWalEvents)} ` +
+          `lastError=${health.lastError.replace(/\s+/gu, " ").trim()}`,
+      ];
+    }),
+    assessedResult =
+      retryingRows.length === 0
+        ? result
+        : {
+            ...result,
+            summary: `${String(result.summary ?? "daemon status")}\nWAL-to-Git materialization retrying: ${retryingRows.join("; ")}`,
+          },
+    failedRows = rows.filter(
       (value) => statusRecord(value) && statusRecord(value.materialization) && value.materialization.state === "failed",
     ),
     failures = failedRows.flatMap((value) => {
@@ -353,7 +380,7 @@ function assessDaemonStatus(result: Record<string, unknown>): {
         },
       ];
     });
-  if (failedRows.length === 0) return { receipt: result, exitCode: 0 };
+  if (failedRows.length === 0) return { receipt: assessedResult, exitCode: 0 };
   const first = failures[0],
     details = failedRows
       .map((value) => {
@@ -371,11 +398,11 @@ function assessDaemonStatus(result: Record<string, unknown>): {
       .join("; "),
     hint =
       `WAL-to-Git materialization failed: ${details}. Repair the reported cause, then use the existing ` +
-      "repository recovery/drain path (or restart the daemon for startup recovery) before retrying writes.";
+      "repository recovery path by retrying the write; no daemon restart is required.";
   return {
     exitCode: 1,
     receipt: {
-      ...result,
+      ...assessedResult,
       ok: false,
       outcome: "op_rejected",
       code: "materialization_failed",

--- a/packages/cli/src/daemon/control.ts
+++ b/packages/cli/src/daemon/control.ts
@@ -348,7 +348,9 @@ function assessDaemonStatus(result: Record<string, unknown>): {
         ? result
         : {
             ...result,
-            summary: `${String(result.summary ?? "daemon status")}\nWAL-to-Git materialization retrying: ${retryingRows.join("; ")}`,
+            summary:
+              `${String(result.summary ?? "daemon status")}\n` +
+              `WAL-to-Git materialization retrying: ${retryingRows.join("; ")}`,
           },
     failedRows = rows.filter(
       (value) => statusRecord(value) && statusRecord(value.materialization) && value.materialization.state === "failed",

--- a/packages/cli/test/daemon-receipt-cli.test.ts
+++ b/packages/cli/test/daemon-receipt-cli.test.ts
@@ -12,6 +12,7 @@ const cli = path.resolve("packages/cli/src/index.ts");
 test("daemon control renders status and fails closed when repository materialization is red", () => {
   const fixture = setup();
   let canonical: string | null = null;
+  const indexLock = path.join(fixture.repo, ".git", "index.lock");
   try {
     assert.equal(runJson(fixture, ["daemon", "start", "--service"]).ok, true);
 
@@ -36,6 +37,52 @@ test("daemon control renders status and fails closed when repository materializa
     const healthyStatus = runJson(fixture, ["daemon", "status"]),
       healthyRepo = (healthyStatus.repos as readonly Record<string, unknown>[])[0]!;
     assert.deepEqual((healthyRepo.materialization as Record<string, unknown>).state, "ok");
+
+    writeFileSync(indexLock, "held by CLI contract test\n");
+    const lockAccepted = runJson(fixture, ["task", "create", "--title", "Accepted into WAL before lock retry"]);
+    assert.equal(lockAccepted.outcome, "applied", JSON.stringify(lockAccepted));
+    let retryingRepo: Record<string, unknown> | null = null;
+    for (let attempt = 0; attempt < 100; attempt += 1) {
+      const retryingStatus = runJson(fixture, ["daemon", "status"]),
+        candidate = (retryingStatus.repos as readonly Record<string, unknown>[])[0],
+        materialization = candidate?.materialization as Record<string, unknown> | null;
+      if (materialization?.state === "retrying") {
+        retryingRepo = candidate!;
+        break;
+      }
+    }
+    assert.ok(retryingRepo, "daemon status did not expose the transient Git lock retry");
+    const retryingHealth = retryingRepo.materialization as Record<string, unknown>;
+    assert.equal(retryingHealth.reason, undefined);
+    assert.equal(Number.isSafeInteger(retryingHealth.retryElapsedMs), true);
+    assert.match(String(retryingHealth.lastError), /index\.lock[\s\S]*File exists/iu);
+    const humanRetrying = runText(fixture, ["daemon", "status"]);
+    assert.equal(humanRetrying.status, 0, humanRetrying.stderr);
+    assert.match(humanRetrying.stdout, /state=retrying waitedMs=[0-9]+/u);
+    assert.match(humanRetrying.stdout, /lastError=.*index\.lock/u);
+    const retryingWrite = runJsonResult(fixture, ["task", "create", "--title", "Rejected during lock retry"]);
+    assert.equal(retryingWrite.status, 1, retryingWrite.stderr);
+    assert.equal(retryingWrite.receipt.code, "materialization_failed");
+    assert.equal((retryingWrite.receipt.diagnostic as Record<string, unknown>).kind, "materialization-retrying");
+    assert.equal((retryingWrite.receipt.diagnostic as Record<string, unknown>).state, "retrying");
+    assert.equal((retryingWrite.receipt.diagnostic as Record<string, unknown>).reason, undefined);
+    rmSync(indexLock, { force: true });
+    let lockRecovered = false;
+    for (let attempt = 0; attempt < 100; attempt += 1) {
+      const recoveredStatus = runJson(fixture, ["daemon", "status"]),
+        materialization = (recoveredStatus.repos as readonly Record<string, unknown>[])[0]?.materialization as Record<
+          string,
+          unknown
+        > | null;
+      if (materialization?.state === "ok" && materialization.pendingWalEvents === 0) {
+        lockRecovered = true;
+        break;
+      }
+    }
+    assert.equal(lockRecovered, true, "transient Git lock did not self-heal and checkpoint its WAL");
+    const lockRecoveredWrite = runJson(fixture, ["task", "create", "--title", "Accepted without daemon restart"]);
+    assert.equal(lockRecoveredWrite.outcome, "applied", JSON.stringify(lockRecoveredWrite));
+    waitForMaterializationOk(fixture);
 
     const preparedTask = runJson(fixture, ["task", "create", "--title", "Accepted before materialization latch"]);
     assert.equal(preparedTask.outcome, "applied", JSON.stringify(preparedTask));
@@ -69,18 +116,10 @@ test("daemon control renders status and fails closed when repository materializa
     assert.equal((rejected.receipt.diagnostic as Record<string, unknown>).reason, "git_diverged");
 
     git(fixture.repo, "reset", "--hard", canonical);
-    assert.equal(runJson(fixture, ["daemon", "stop"]).ok, true);
-    assert.equal(runJson(fixture, ["daemon", "start", "--service"]).ok, true);
-    let recoveredRepo: Record<string, unknown> | null = null;
-    for (let attempt = 0; attempt < 100; attempt += 1) {
-      const recoveredStatus = runJson(fixture, ["daemon", "status"]),
-        candidate = (recoveredStatus.repos as readonly Record<string, unknown>[])[0];
-      if ((candidate?.materialization as Record<string, unknown> | null)?.state === "ok") {
-        recoveredRepo = candidate!;
-        break;
-      }
-    }
-    assert.ok(recoveredRepo, "restarted daemon did not publish recovered materialization health");
+    const recoveryProbe = runJsonResult(fixture, ["task", "create", "--title", "Probe repaired latch"]);
+    assert.equal(recoveryProbe.status, 1, recoveryProbe.stderr);
+    assert.equal(recoveryProbe.receipt.code, "materialization_failed");
+    waitForMaterializationOk(fixture);
     const recoveredWrite = runJson(fixture, ["task", "create", "--title", "Accepted after recovery"]);
     assert.equal(recoveredWrite.outcome, "applied", JSON.stringify(recoveredWrite));
 
@@ -98,6 +137,7 @@ test("daemon control renders status and fails closed when repository materializa
     assert.match(alreadyUnregistered.stdout, /repoId=receipt/u);
     assert.match(alreadyUnregistered.stdout, /changed=false/u);
   } finally {
+    rmSync(indexLock, { force: true });
     if (canonical !== null) {
       git(fixture.repo, "reset", "--hard", canonical);
     }
@@ -136,6 +176,18 @@ function setup(): { readonly root: string; readonly repo: string; readonly userR
   git(repo, "commit", "--quiet", "-m", "fixture");
   seedSettingsEvent({ rootDir: repo, repoId: "receipt" });
   return { root, repo, userRoot };
+}
+
+function waitForMaterializationOk(fixture: ReturnType<typeof setup>): void {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    const status = runJson(fixture, ["daemon", "status"]),
+      materialization = (status.repos as readonly Record<string, unknown>[])[0]?.materialization as Record<
+        string,
+        unknown
+      > | null;
+    if (materialization?.state === "ok" && materialization.pendingWalEvents === 0) return;
+  }
+  assert.fail("daemon materialization did not return to ok with an empty WAL");
 }
 function runJson(fixture: ReturnType<typeof setup>, args: readonly string[]): Record<string, unknown> {
   const result = spawnSync(process.execPath, [cli, "--root", fixture.repo, "--json", ...args], {

--- a/packages/daemon/src/protocol/daemon-protocol.contract.ts
+++ b/packages/daemon/src/protocol/daemon-protocol.contract.ts
@@ -608,6 +608,7 @@ export interface DaemonStatusResult {
       readonly lastCheckpointRevision: number;
       readonly lastCheckpointAt: string | null;
       readonly pendingWalEvents: number;
+      readonly retryElapsedMs?: number;
       readonly reason?: "git_diverged" | "deterministic_failure" | "retry_budget_exhausted";
       readonly lastError?: string;
     } | null;

--- a/packages/daemon/src/writer-supervisor.ts
+++ b/packages/daemon/src/writer-supervisor.ts
@@ -50,6 +50,7 @@ export async function openWriterSupervisor(
     closed = false,
     opened = false,
     restartAttempt = 0,
+    statusObservedAt = Date.now(),
     status: RepoCellStatus = {
       repoId: input.repoId,
       rootDir: input.rootDir,
@@ -132,7 +133,7 @@ export async function openWriterSupervisor(
       });
     },
     control: sendControl,
-    status: () => status,
+    status: () => statusWithCurrentRetryElapsed(status, statusObservedAt),
     bootstrapReceipt: () => publishedBootstrapReceipt,
     close: async () => {
       if (closed) return;
@@ -200,7 +201,10 @@ export async function openWriterSupervisor(
           const published = message.status;
           if (published && typeof published === "object") {
             const attaching = published.state === "warming";
-            if (!settled || !attaching) status = published;
+            if (!settled || !attaching) {
+              status = published;
+              statusObservedAt = Date.now();
+            }
             if (!settled && attaching) options.onAttachStatus?.(published);
             if (
               !settled &&
@@ -398,6 +402,18 @@ export async function openWriterSupervisor(
       ...event,
     } satisfies RuntimeProcessEventV1);
   }
+}
+
+function statusWithCurrentRetryElapsed(status: RepoCellStatus, observedAt: number): RepoCellStatus {
+  const materialization = status.materialization;
+  if (materialization?.state !== "retrying" || materialization.retryElapsedMs === undefined) return status;
+  return {
+    ...status,
+    materialization: {
+      ...materialization,
+      retryElapsedMs: materialization.retryElapsedMs + Math.max(0, Date.now() - observedAt),
+    },
+  };
 }
 
 function bootstrapMessage(input: RepoCellOpenInput): RepoWriterBootstrapV1 {

--- a/packages/daemon/test/fleet-writer-epoch.integration.test.ts
+++ b/packages/daemon/test/fleet-writer-epoch.integration.test.ts
@@ -217,6 +217,12 @@ test("RepoWriterCell verifies the writer epoch inside Git ref finalization", asy
 
     fence = { ...fence, epoch: leaseB.epoch, holderId: leaseB.holderId };
     assert.notEqual(store.recover().status, "indeterminate");
+    assert.throws(
+      () => appendWorkerTask(store, 2),
+      (error: unknown) =>
+        (error as { readonly diagnostic?: { readonly kind?: string } }).diagnostic?.kind === "materialization-retrying",
+    );
+    await store.settleRecoveryMaterialization!();
     appendWorkerTask(store, 2);
     await store.settlePendingMaterialization!("writer epoch test");
     assert.equal(JSON.parse(probeGit(repo, "show", "refs/ha/canonical:harness/events/head.json")).revision, 2);

--- a/packages/kernel/src/domain/receipt-domain-registry.ts
+++ b/packages/kernel/src/domain/receipt-domain-registry.ts
@@ -43,6 +43,15 @@ export type ReceiptDiagnostic =
       readonly lastError: string;
     }
   | {
+      readonly kind: "materialization-retrying";
+      readonly state: "retrying";
+      readonly lastCheckpointRevision: number;
+      readonly lastCheckpointAt: string | null;
+      readonly pendingWalEvents: number;
+      readonly retryElapsedMs: number;
+      readonly lastError: string;
+    }
+  | {
       readonly kind: "invalid-enum";
       readonly field: string;
       readonly actual: string;
@@ -390,6 +399,24 @@ export function isReceiptDiagnostic(value: unknown): value is ReceiptDiagnostic 
       (value.reason === "git_diverged" ||
         value.reason === "deterministic_failure" ||
         value.reason === "retry_budget_exhausted") &&
+      isNonEmptyString(value.lastError)
+    );
+  if (value.kind === "materialization-retrying")
+    return (
+      exact(value, [
+        "kind",
+        "state",
+        "lastCheckpointRevision",
+        "lastCheckpointAt",
+        "pendingWalEvents",
+        "retryElapsedMs",
+        "lastError",
+      ]) &&
+      value.state === "retrying" &&
+      cut(value.lastCheckpointRevision) &&
+      (value.lastCheckpointAt === null || isNonEmptyString(value.lastCheckpointAt)) &&
+      cut(value.pendingWalEvents) &&
+      cut(value.retryElapsedMs) &&
       isNonEmptyString(value.lastError)
     );
   if (value.kind === "invalid-enum")

--- a/packages/kernel/src/store/task-event-store-types.ts
+++ b/packages/kernel/src/store/task-event-store-types.ts
@@ -116,6 +116,7 @@ export interface MaterializationHealth {
   readonly lastCheckpointRevision: number;
   readonly lastCheckpointAt: string | null;
   readonly pendingWalEvents: number;
+  readonly retryElapsedMs?: number;
   readonly reason?: MaterializationFailureReason;
   readonly lastError?: string;
 }

--- a/packages/kernel/src/store/wal-materialization-worker.ts
+++ b/packages/kernel/src/store/wal-materialization-worker.ts
@@ -189,7 +189,8 @@ export function isRetryableWalMaterializationError(error: unknown): boolean {
   }
   return (
     error instanceof Error &&
-    new RegExp(`\\b(?:${[...transientSystemErrorCodes].join("|")})\\b`, "u").test(error.message)
+    (transientGitLock.test(error.message) ||
+      new RegExp(`\\b(?:${[...transientSystemErrorCodes].join("|")})\\b`, "u").test(error.message))
   );
 }
 

--- a/packages/kernel/src/store/wal-shadow-event-store.ts
+++ b/packages/kernel/src/store/wal-shadow-event-store.ts
@@ -145,6 +145,7 @@ export function makeWalShadowEventStore(options: StoreOptions): CanonicalEventSt
   let timer: ReturnType<typeof setTimeout> | null = null;
   let immediate: ReturnType<typeof setImmediate> | null = null;
   let consecutiveFailures = 0;
+  let retryStartedAt: number | null = null;
   let lastFlushError: string | null = null;
   let failureLatch: { readonly reason: MaterializationFailureReason; readonly lastError: string } | null = null;
   let lastCheckpointAt =
@@ -188,10 +189,13 @@ export function makeWalShadowEventStore(options: StoreOptions): CanonicalEventSt
   const pendingCount = (): number => pendingWalRecords.length;
   const hasWalRecords = (): boolean => wal.records().length > 0;
   const materializationHealth = (): MaterializationHealth => ({
-    state: failureLatch !== null ? "failed" : consecutiveFailures > 0 ? "retrying" : "ok",
+    state: failureLatch !== null ? "failed" : retryStartedAt !== null ? "retrying" : "ok",
     lastCheckpointRevision: gitHead?.revision ?? 0,
     lastCheckpointAt,
     pendingWalEvents: pendingCount(),
+    ...(failureLatch === null && retryStartedAt !== null
+      ? { retryElapsedMs: Math.max(0, Math.round(performance.now() - retryStartedAt)) }
+      : {}),
     ...(failureLatch ? { reason: failureLatch.reason, lastError: failureLatch.lastError } : {}),
     ...(failureLatch === null && lastFlushError !== null ? { lastError: lastFlushError } : {}),
   });
@@ -228,8 +232,41 @@ export function makeWalShadowEventStore(options: StoreOptions): CanonicalEventSt
       { ...data, data, diagnostic: { kind: "materialization-failed", ...data } as const },
     );
   };
+  const materializationRetryingError = (): TaskEventStoreError => {
+    const health = materializationHealth();
+    if (health.state !== "retrying" || health.lastError === undefined || health.retryElapsedMs === undefined)
+      throw new TaskEventStoreError("invalid_store", "materialization retry has no retry details");
+    const data = {
+      state: health.state,
+      lastCheckpointRevision: health.lastCheckpointRevision,
+      lastCheckpointAt: health.lastCheckpointAt,
+      pendingWalEvents: health.pendingWalEvents,
+      retryElapsedMs: health.retryElapsedMs,
+      lastError: health.lastError,
+    } as const;
+    return Object.assign(
+      new TaskEventStoreError(
+        "materialization_failed",
+        `Git materialization is retrying after a transient failure; waited ${health.retryElapsedMs}ms`,
+      ),
+      { ...data, data, diagnostic: { kind: "materialization-retrying", ...data } as const },
+    );
+  };
   const assertMaterializationWritable = (): void => {
-    if (failureLatch !== null) throw materializationFailedError();
+    if (failureLatch !== null) {
+      const failure = materializationFailedError();
+      const activeFlush = inFlightFlush;
+      if (activeFlush === null) recover();
+      else
+        void activeFlush.then(
+          () => {
+            if (failureLatch !== null) recover();
+          },
+          (error: unknown) => consumeKnownError(error),
+        );
+      throw failure;
+    }
+    if (retryStartedAt !== null) throw materializationRetryingError();
   };
   const flushPolicy = (): WalFlushPolicy => {
     const configured = configuredFlushPolicy;
@@ -408,6 +445,7 @@ export function makeWalShadowEventStore(options: StoreOptions): CanonicalEventSt
       const attempt = consecutiveFailures + 1;
       console.info(`[wal-materializer] materialized revisions ${range} (${context}, attempt ${attempt})`);
       consecutiveFailures = 0;
+      retryStartedAt = null;
       lastFlushError = null;
       failureLatch = null;
       notifyHealthChange();
@@ -425,12 +463,13 @@ export function makeWalShadowEventStore(options: StoreOptions): CanonicalEventSt
       ) {
         latchMaterializationFailure("deterministic_failure", error);
         console.error(
-          `[wal-materializer] deterministic failure; materializer stopped: ${walShadowErrorMessage(error)}`,
+          `[wal-materializer] deterministic failure (${context}); materializer stopped: ${walShadowErrorMessage(error)}`,
         );
         consumeKnownError(error);
         return false;
       }
       consecutiveFailures += 1;
+      retryStartedAt ??= performance.now();
       lastFlushError = walShadowErrorMessage(error);
       const failedAttempt = `${consecutiveFailures}/${retryLimit}`;
       console.warn(
@@ -494,11 +533,11 @@ export function makeWalShadowEventStore(options: StoreOptions): CanonicalEventSt
     }, delay);
     timer.unref?.();
   };
-  const scheduleFlush = (): void => {
+  const scheduleFlush = (force = false): void => {
     if (closed || bulkWriteActive || failureLatch !== null || !hasWalRecords()) return;
     const policy = flushPolicy(),
       threshold = effectiveEventThreshold(policy),
-      thresholdReached = pendingCount() >= threshold || wal.head().lastOffset >= policy.bytes;
+      thresholdReached = force || pendingCount() >= threshold || wal.head().lastOffset >= policy.bytes;
     if (inFlightFlush) {
       coalescedFlush = { context: "coalesced", compactWorktree: false };
       return;
@@ -665,7 +704,9 @@ export function makeWalShadowEventStore(options: StoreOptions): CanonicalEventSt
     return receipt;
   };
   const recover = (): EventRecoveryReceipt => {
-    const started = performance.now();
+    const started = performance.now(),
+      recoveringRetry = retryStartedAt !== null || failureLatch !== null,
+      recoveryError = lastFlushError;
     // Recovery is the full audit entry point: forget any in-process validation floor so the
     // next read revalidates every content claim in the ledger from scratch.
     contentValidatedThrough = 0;
@@ -703,16 +744,17 @@ export function makeWalShadowEventStore(options: StoreOptions): CanonicalEventSt
         ...(error instanceof TaskEventStoreError ? { errorCode: error.code } : {}),
       };
     }
-    failureLatch = null;
-    consecutiveFailures = 0;
-    lastFlushError = null;
-    notifyHealthChange();
     const records = wal.records();
     const hadWalRecords = records.length > 0;
     const hadPendingPublication = (records.at(-1)?.revision ?? 0) > (gitHead?.revision ?? 0);
+    failureLatch = null;
+    consecutiveFailures = 0;
+    retryStartedAt = recoveringRetry && hadWalRecords ? (retryStartedAt ?? performance.now()) : null;
+    lastFlushError = retryStartedAt === null ? null : recoveryError;
+    notifyHealthChange();
     if (hadWalRecords) {
       recoveryMaterializationPending = true;
-      scheduleFlush();
+      scheduleFlush(true);
     }
     if (recovered.status !== "none" || !hadWalRecords) return recovered;
     return {

--- a/packages/kernel/src/store/wal-shadow-event-store.ts
+++ b/packages/kernel/src/store/wal-shadow-event-store.ts
@@ -463,7 +463,8 @@ export function makeWalShadowEventStore(options: StoreOptions): CanonicalEventSt
       ) {
         latchMaterializationFailure("deterministic_failure", error);
         console.error(
-          `[wal-materializer] deterministic failure (${context}); materializer stopped: ${walShadowErrorMessage(error)}`,
+          `[wal-materializer] deterministic failure (${context}); ` +
+            `materializer stopped: ${walShadowErrorMessage(error)}`,
         );
         consumeKnownError(error);
         return false;
@@ -747,6 +748,8 @@ export function makeWalShadowEventStore(options: StoreOptions): CanonicalEventSt
     const records = wal.records();
     const hadWalRecords = records.length > 0;
     const hadPendingPublication = (records.at(-1)?.revision ?? 0) > (gitHead?.revision ?? 0);
+    const recoveryFence = options.walMaterializationFence?.();
+    if (recoveryFence) pendingMaterializationFence = recoveryFence;
     failureLatch = null;
     consecutiveFailures = 0;
     retryStartedAt = recoveringRetry && hadWalRecords ? (retryStartedAt ?? performance.now()) : null;

--- a/packages/kernel/test/store/wal-shadow-event-store.test.ts
+++ b/packages/kernel/test/store/wal-shadow-event-store.test.ts
@@ -380,10 +380,133 @@ test("materialization retry classification admits only recognized transient fail
   );
   assert.equal(
     isRetryableWalMaterializationError(
+      new Error(
+        "Command failed: git update-index\nfatal: Unable to create '/repo/.git/index.lock': File exists.\n\n" +
+          "Another git process seems to be running in this repository.",
+      ),
+    ),
+    true,
+  );
+  assert.equal(isRetryableWalMaterializationError(Object.assign(new Error("resource busy"), { code: "EBUSY" })), true);
+  assert.equal(
+    isRetryableWalMaterializationError(
       Object.assign(new Error("writer epoch is stale"), { code: "writer_epoch_stale" }),
     ),
     false,
   );
+});
+
+test("a temporary real Git index lock reports retrying and self-heals without restart", async () => {
+  await withTempStoreAsync(async (rootDir) => {
+    initRepo(rootDir);
+    const lockPath = path.join(rootDir, ".git", "index.lock"),
+      warnings: string[] = [],
+      originalWarn = console.warn;
+    let retryingHealth: ReturnType<ReturnType<typeof makeWalShadowEventStore>["materializationHealth"]> | null = null,
+      retryingError: Record<string, unknown> | null = null,
+      observeRetry!: () => void;
+    const retryObserved = new Promise<void>((resolve) => {
+      observeRetry = resolve;
+    });
+    let store!: ReturnType<typeof makeWalShadowEventStore>;
+    console.warn = (...args: unknown[]) => warnings.push(args.join(" "));
+    try {
+      store = makeWalShadowEventStore({
+        repoId: "wal-temporary-index-lock",
+        rootDir,
+        walFlushEvents: 1,
+        walFlushMs: 60_000,
+        walRetryLimit: 3,
+        walRetryBaseMs: 1,
+        onMaterializationHealthChange: (health) => {
+          if (health.state !== "retrying" || retryingHealth !== null) return;
+          retryingHealth = health;
+          try {
+            store.append(taskBundle(2, "blocked during retry\n"));
+            assert.fail("a new write must be refused while the durable WAL is retrying");
+          } catch (error) {
+            retryingError = error as Record<string, unknown>;
+          }
+          rmSync(lockPath, { force: true });
+          observeRetry();
+        },
+      });
+      writeFileSync(lockPath, "held by contract test\n");
+      assert.equal(store.append(taskBundle(1, "temporary lock\n")).status, "applied");
+      await retryObserved;
+      await store.drain();
+    } finally {
+      console.warn = originalWarn;
+      rmSync(lockPath, { force: true });
+    }
+    assert.equal(retryingHealth?.state, "retrying");
+    assert.equal(retryingHealth?.reason, undefined);
+    assert.equal(Number.isSafeInteger(retryingHealth?.retryElapsedMs), true);
+    assert.match(retryingHealth?.lastError ?? "", /index\.lock[\s\S]*File exists/iu);
+    assert.equal(retryingError?.code, "materialization_failed");
+    assert.deepEqual((retryingError?.diagnostic as Record<string, unknown>).kind, "materialization-retrying");
+    assert.equal((retryingError?.diagnostic as Record<string, unknown>).state, "retrying");
+    assert.equal(Number.isSafeInteger((retryingError?.diagnostic as Record<string, unknown>).retryElapsedMs), true);
+    assert.equal(warnings.filter((warning) => warning.includes("materialization failed")).length, 1);
+    assert.deepEqual(openWalEventLog(rootDir, { mutable: false }).records(), []);
+    assert.deepEqual(store.materializationHealth(), {
+      state: "ok",
+      lastCheckpointRevision: 1,
+      lastCheckpointAt: "2026-08-20T00:00:00.000Z",
+      pendingWalEvents: 0,
+    });
+  });
+});
+
+test("a persistent real Git index lock exhausts retries and keeps the bounded red light", async () => {
+  await withTempStoreAsync(async (rootDir) => {
+    initRepo(rootDir);
+    const lockPath = path.join(rootDir, ".git", "index.lock"),
+      warnings: string[] = [],
+      originalWarn = console.warn;
+    const store = makeWalShadowEventStore({
+      repoId: "wal-persistent-index-lock",
+      rootDir,
+      walFlushEvents: 1,
+      walFlushMs: 60_000,
+      walRetryLimit: 2,
+      walRetryBaseMs: 1,
+    });
+    console.warn = (...args: unknown[]) => warnings.push(args.join(" "));
+    try {
+      writeFileSync(lockPath, "held by contract test\n");
+      assert.equal(store.append(taskBundle(1, "persistent lock\n")).status, "applied");
+      const failed = await waitForMaterializationState(store, "failed");
+      assert.equal(failed.reason, "retry_budget_exhausted");
+      assert.notEqual(failed.reason, "deterministic_failure");
+      assert.equal(failed.pendingWalEvents, 1);
+      assert.match(failed.lastError ?? "", /index\.lock[\s\S]*File exists/iu);
+      assert.throws(
+        () => store.append(taskBundle(2, "still blocked\n")),
+        (error: unknown) => (error as { readonly code?: string }).code === "materialization_failed",
+      );
+      await waitForMaterializationState(store, "failed");
+      rmSync(lockPath, { force: true });
+      assert.throws(
+        () => store.append(taskBundle(2, "recovery probe\n")),
+        (error: unknown) => (error as { readonly code?: string }).code === "materialization_failed",
+      );
+      await waitForMaterializationState(store, "ok");
+      assert.equal(store.append(taskBundle(2, "accepted after repair\n")).status, "applied");
+      await store.drain();
+    } finally {
+      console.warn = originalWarn;
+      rmSync(lockPath, { force: true });
+    }
+    assert.equal(warnings.filter((warning) => warning.includes("materialization failed")).length, 4);
+    assert.deepEqual(openWalEventLog(rootDir, { mutable: false }).records(), []);
+    assert.deepEqual(store.materializationHealth(), {
+      state: "ok",
+      lastCheckpointRevision: 2,
+      lastCheckpointAt: "2026-08-20T00:00:00.000Z",
+      pendingWalEvents: 0,
+    });
+  });
 });
 
 test("deterministic materialization failure latches before drain consumes the retry budget", async () => {
@@ -504,7 +627,6 @@ test("a master branch forked from canonical rejects writes until refs are repair
       assert.equal(failed.lastCheckpointRevision, 0);
       assert.equal(failed.lastCheckpointAt, null);
       assert.equal(failed.pendingWalEvents, 1);
-      const processesAfterDivergence = localGitObjectRefStore.processCount();
       assert.throws(
         () => store.append(taskBundle(2, "must not queue\n")),
         (error: unknown) => {
@@ -521,12 +643,13 @@ test("a master branch forked from canonical rejects writes until refs are repair
           ]),
         (error: unknown) => (error as { readonly code?: string }).code === "materialization_failed",
       );
+      const processesAfterExplicitProbes = localGitObjectRefStore.processCount();
       await new Promise((resolve) => setTimeout(resolve, 25));
       assert.equal(errors.filter((line) => line.includes("materializer stopped")).length, 1);
       assert.equal(
         localGitObjectRefStore.processCount(),
-        processesAfterDivergence,
-        "a stopped materializer must not spin Git calls",
+        processesAfterExplicitProbes,
+        "a stopped materializer must not spin Git calls between explicit recovery probes",
       );
       const stopped = store.recover();
       assert.equal(stopped.status, "indeterminate");

--- a/skills/harness-install/SKILL.md
+++ b/skills/harness-install/SKILL.md
@@ -646,8 +646,10 @@ Tell the user, in their own terms:
 - **never run `git commit` inside `harness/`.** The ledger's HEAD must be the
   last event commit; an extra commit on top breaks the compare-and-swap and every
   later write fails with `publication_indeterminate`. Recovery is a `git reset`
-  to the sha the error calls `expected` **followed by a daemon restart** — a
-  reset alone leaves the daemon answering from a latched failure;
+  to the sha the error calls `expected`, followed by retrying the write. The
+  repository recovery path re-probes the repaired refs and resumes without a
+  daemon restart; wait for `ha daemon status` to return to `ok` before retrying
+  again if the first retry reports the old latch;
 - **which files the install left uncommitted in the project** — `AGENTS.md`,
   `CLAUDE.md`, `.gitignore` — and that committing them is theirs to decide;
 - **the two `HARNESS_ACTOR` values** the loop used, and that review independence

--- a/skills/harness-migration/SKILL.md
+++ b/skills/harness-migration/SKILL.md
@@ -933,17 +933,15 @@ the daemon; reconcile before publishing: cannot lock ref 'refs/heads/master':
 is at <your commit> but expected <last event commit>
 ```
 
-Two things about that message are worth knowing in advance, because they cost a
-real operator most of an hour:
+Two things about that message are worth knowing in advance:
 
-- **Recovery takes both a `git reset` and a daemon restart, in that order, and
-  neither alone is enough.** Reset back to the expected commit — the sha the
-  message calls `expected`, which appears nowhere on disk to search for — then
-  restart the daemon. `publication_indeterminate` is a fatal cell error: it
-  latches the RepoCell and replays the cached failure on every later write, so
-  after a reset alone you will still see the identical message and conclude the
-  reset failed. It did not; the daemon is answering from a latch. Restarting
-  without the reset fails too, because the ref really is wrong.
+- **Recovery is a `git reset` followed by a write retry, not a daemon restart.**
+  Reset back to the expected commit — the sha the message calls `expected`,
+  which appears nowhere on disk to search for — then retry the command. The
+  repository recovery path re-probes the repaired refs and resumes
+  materialization. The first retry can still report the old latch while that
+  recovery settles; wait for `ha daemon status` to return to `ok`, then retry
+  again. Retrying without the reset still fails because the ref really is wrong.
 - **`reconcile` names no command.** There is no `ha reconcile`; the word
   describes an outcome, not a path. The recovery is the `git reset` above.
 
@@ -1094,8 +1092,8 @@ success and failure paths.
 - **`git commit` inside the ledger wedges every write** with
   `publication_indeterminate`, and the hint's word "reconcile" corresponds to no
   command. Recovery is `git reset` to the sha the message calls `expected`
-  **followed by a daemon restart** — a reset alone leaves the cell latched and
-  reproduces the identical error. See step 9.
+  followed by retrying the write; the repository recovery path clears the latch
+  after it verifies the repaired refs, without restarting the daemon. See step 9.
 - **The expected first read after an import is `status: "ready"` with a
   plausible row count.** Two real migrations of 695 and 963 events both answered
   immediately; treat a normal answer as normal and move on. The exception is


### PR DESCRIPTION
# English

## Summary

WAL-to-Git materialization classified a transient Git index lock (`.git/index.lock: File exists`) as `deterministic_failure` and latched the repository red, refusing every write until the daemon was restarted. The classifier already knew the lock signature on `VcsCommandError.stderrSummary`, but the real materializer runs Git inside the durability worker; across that boundary the failure arrived as a plain `Error.message` and fell through to the deterministic branch. The classifier now recognises the `.lock` / `index.lock` signature on either surface and routes it to the existing bounded retry (8 attempts, 250 ms exponential backoff; no new configuration). While retrying, repository health reports `state=retrying` with `lastError` and `retryElapsedMs`, `ha daemon status` shows the same, and new writes stay fail-closed with a typed `materialization-retrying` diagnostic. A lock that outlives the budget latches red with `reason=retry_budget_exhausted`; repairing it and re-probing the repository recovers without a daemon restart. The install and migration skills and the legacy-ledger recovery guides no longer tell operators to restart the daemon.

## Architectural Justification

The fail-closed semantics of task_2e67cc40 are unchanged: corruption, missing paths, content conflicts and every unrecognised failure still latch red immediately, and writes are refused during retry. Only the classification of a failure that was already defined as transient is corrected, so the fix removes a manual recovery path instead of adding a mechanism.

## Gate Harvest / 门收割

Deleted-Production-Paths: daemon-restart recovery directions in `skills/harness-install/SKILL.md`, `skills/harness-migration/SKILL.md` and the legacy-ledger recovery guides (replaced by resident repository re-probe).
Deleted-Gates-Fixtures: none (new fixtures added: real temporary and persistent `index.lock` cases in `wal-shadow-event-store.test.ts`, CLI/daemon retrying-status and post-recovery write coverage).

## Machine-Readable Declarations

Production-Delta: +152/-19
Dependency-Change: none

### Optional Evidence Claims

none

## Task And Scope

task_c48e03dfc52987c9b952af727d (parent task_2e67cc40041b205e3b9c01384e, WAL/Git materialization). Incident fact F-8E9DF94F (2026-09-03 15:2x: consent write refused on a lock that had already disappeared; recovery required a daemon restart). Worker commit 08f80c703 (Sol), CEO semantic review.

## Version Impact

None.

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none
- Authority: not applicable
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Follow-up governance task: not applicable

## Verification

- Round 2 (b5b666f3f): the CI-red `fleet-writer-epoch` case exposed a recovery-ownership bug, not a classification one. A stale writer epoch still fails Git finalization deterministically and `refs/ha/canonical` does not advance; but the pending materialization kept the stale epoch as its fence, so after the holder reacquired the current epoch and ran repository recovery, the forced WAL proof could never finalize. Recovery now adopts the current non-null writer fence before scheduling the proof; the test makes the intermediate `materialization-retrying` refusal explicit, awaits `settleRecoveryMaterialization()`, then proves revision 2 finalizes (7/7). Three over-long lines were wrapped for the line-density gate.
- `packages/kernel/test/store/wal-shadow-event-store.test.ts` 28/28 (real temporary lock self-heals through the retry loop, driven by the retry-health callback rather than wall-clock sleeps; real persistent lock exhausts a two-attempt test budget into `retry_budget_exhausted`, writes stay refused, repair plus re-probe recovers); `packages/cli/test/daemon-receipt-cli.test.ts` 1/1; `packages/daemon/test/daemon-host-recovery.test.ts` 14/14.
- `node tools/run-manifest-gates.mjs --workflow-job fast-contract --changed origin/main`: fast 590/590, contract 959/959; typecheck, targeted ESLint, Prettier, `git diff --check`, architecture walls 12/12, implementation-contract / status-vocabulary / ontology-specialization / schema gates pass.
- Not run: `check:local`; `check-github-required-contexts` (needs the repository input CI provides).

## Review Evidence

CEO semantic check against the task plan: classification table before/after matches goal 1, retrying status matches goal 2, both positive (persistent lock stays red) and negative (temporary lock self-heals) controls exist for goal 3, and the manual restart path is deleted for goal 4. GitHub CI is the merge authority.

## Residual Risk

The retry budget is the existing default; a lock held longer than roughly the sum of the backoff schedule still latches red by design and needs the documented re-probe, not a restart.

# 中文

## 概要

WAL→Git 物化把瞬时的 Git 索引锁(`.git/index.lock: File exists`)判成 `deterministic_failure`,仓库红锁并拒绝一切写入,直到人工重启 daemon。分类器本来在 `VcsCommandError.stderrSummary` 上认得锁签名,但真实物化在 durability worker 里跑 Git,跨过那道边界后失败只剩普通 `Error.message`,于是落进确定性分支。现在两处都识别 `.lock` / `index.lock` 签名并走既有的有界重试(8 次、250 ms 指数退避,不加配置)。重试期间仓库 health 报 `state=retrying` 带 `lastError` 与 `retryElapsedMs`,`ha daemon status` 同样显示,新写入仍 fail-closed 并带类型化的 `materialization-retrying` 诊断。锁超过预算才红锁,reason=`retry_budget_exhausted`;修好后重新探测仓库即可恢复,不需要重启。install/migration skill 与 legacy 台账恢复指南不再让操作者重启 daemon。

## 架构辩护

task_2e67cc40 的 fail-closed 语义不变:损坏、路径缺失、内容冲突与一切未识别失败仍立即红锁,重试期间拒写。改的只是一种本就定义为 transient 的失败的分类,所以这次修复删掉的是一条手工恢复路径,而不是新加机制。

## 机读声明

见英文块。

## 治理声明

- 触碰受保护面:否
- 受保护面范围:无
- 授权:不适用
- 机器检查边界:本 PR 只断言声明存在,是否真实充分由评审判断。
- Break-glass:否
- Break-glass 原因:不适用
- 后续治理任务:不适用

## 验证

- 第二轮(b5b666f3f):CI 红的 `fleet-writer-epoch` 用例暴露的是恢复所有权缺陷而非分类问题。stale writer epoch 仍确定性地拒绝 Git finalization、`refs/ha/canonical` 不前移;但 pending 物化一直拿着旧 epoch 当 fence,持有者重取当前 epoch 并触发仓库恢复后,强制的 WAL proof 永远完不成。恢复现在先采用当前非空 writer fence 再排 proof;测试把中间的 `materialization-retrying` 拒绝显式化、等 `settleRecoveryMaterialization()`、再证明 revision 2 能 finalize(7/7)。三处超长行按 line-density 门换行。
- `packages/kernel/test/store/wal-shadow-event-store.test.ts` 28/28(真实临时锁经重试循环自愈,由 retry-health 回调驱动而非墙钟 sleep;真实持续锁在两次测试预算后进入 `retry_budget_exhausted`,写入仍拒,修复加重新探测后恢复);`packages/cli/test/daemon-receipt-cli.test.ts` 1/1;`packages/daemon/test/daemon-host-recovery.test.ts` 14/14。
- `node tools/run-manifest-gates.mjs --workflow-job fast-contract --changed origin/main`:fast 590/590、contract 959/959;typecheck、定向 ESLint、Prettier、`git diff --check`、架构墙 12/12、implementation-contract / status-vocabulary / ontology-specialization / schema 各门通过。
- 未跑:`check:local`;`check-github-required-contexts`(需要 CI 提供的仓库输入)。

## 评审证据

CEO 对照任务 plan 做语义核对:分类表前后对应目标 1,retrying 状态对应目标 2,持续锁仍红(阳性)与临时锁自愈(阴性)两条对照对应目标 3,手工重启路径删除对应目标 4。GitHub CI 是合并权威。

## 残余风险

重试预算沿用既有默认值;锁持有时间超过退避总和仍按设计红锁,需要文档写的重新探测,而不是重启。
