### PR TITLE
test(daemon): await observable fleet ledger cut

### DIFF
--- a/packages/daemon/test/fleet-transport.integration.test.ts
+++ b/packages/daemon/test/fleet-transport.integration.test.ts
@@ -21,6 +21,7 @@ import { runFleetEdgeTask } from "../src/fleet-edge-task.ts";
 import { applyFleetMirrorCut, locateFleetMirrorView } from "../src/fleet-edge-mirror.ts";
 import { listenFleetTls, type FleetAssignmentRecord, type FleetTlsCenter } from "../src/fleet/center.ts";
 import {
+  readFleetAssignmentClient,
   runFleetReplicaPullClient,
   runFleetWriteClient,
   type FleetReplicaPullClientOptions,
@@ -78,6 +79,10 @@ async function runFleetRoundTrip(options: RoundTripOptions) {
   };
   await runFleetReplicaPullClient({ ...peer, viewRoot: options.viewRoot, diskQuotaBytes: replicaQuota });
   const write = await runFleetWriteClient({ ...options, channel: "replica" });
+  // The applied receipt can precede host-side ledger visibility. Anchor the pull to the
+  // same assignment read that the edge can observe, or it may legally return the prior current cut.
+  if (write.center.outcome === "applied" && write.center.revision !== null)
+    await waitForCenterLedgerRevision(peer, write.center.revision, options.timeoutMs ?? 5_000);
   const pulled = await runFleetReplicaPullClient({
     ...peer,
     viewRoot: options.viewRoot,
@@ -1603,6 +1608,23 @@ async function waitForReceiptCommit(
     await new Promise((resolve) => setTimeout(resolve, 25));
   } while (performance.now() < deadline);
   throw new Error(`Git materialization did not publish ${opId} within the bounded wait`);
+}
+async function waitForCenterLedgerRevision(
+  peer: Parameters<typeof readFleetAssignmentClient>[0],
+  expected: number,
+  timeoutMs: number,
+): Promise<void> {
+  const deadline = performance.now() + timeoutMs;
+  let observed: number;
+  do {
+    observed = (await readFleetAssignmentClient(peer)).baseLedgerSha.revision;
+    if (observed >= expected) return;
+    await delay(10);
+  } while (performance.now() < deadline);
+  assert.ok(
+    observed >= expected,
+    `center assignment read did not expose ledger revision ${expected} within the bounded wait`,
+  );
 }
 async function waitForCommitCount(fixture: Awaited<ReturnType<typeof fleetFixture>>, expected: number): Promise<void> {
   const deadline = performance.now() + 15_000;


### PR DESCRIPTION
# English

## Summary

The `fleet-transport.integration.test.ts` case "more than 64 completed uploads remain bounded across center restart" went red twice on main today (Node 26 and Node 24 full-check lanes) and green on every rerun. The test pulled the replica before the center had observably applied the assignment ledger cut it was about to check, so the bound assertion raced the center's own write. The helper now waits for the center-observable assignment ledger revision before pulling, which is the same re-anchoring used for the three families fixed in PR #2201. Production delta is +0/-0; assertions go from 114 to 115.

## Architectural Justification

The wait is bound to a state the consumer can observe (the ledger revision the center reports) instead of to the moment the producer started. No timeout is raised, no retry is added and no assertion is weakened; a controlled 250 ms delay makes the old helper fail and the new one pass.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none

## Machine-Readable Declarations

Production-Delta: +0/-0
Dependency-Change: none

### Optional Evidence Claims

none

## Task And Scope

task_61b71e44006c0da7bc72380123 (CI flake family: fleet upload boundedness across center restart; fact F-9285F7B7 records the two main reds). Worker commit 0c39a3e1b (Sol), CEO semantic review.

## Version Impact

None.

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none
- Authority: not applicable
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Follow-up governance task: not applicable

## Verification

- Controlled 250 ms delay: old helper fails, new helper passes.
- Local Node 24: 3 consecutive passes; Node 26: pass. Isolated Ubuntu target: 3 consecutive full-file passes, 13/13 each.
- Typecheck, ESLint on the file and `git diff --check` pass. Fact F-4D3B18E3 recorded.
- Not run: `check:local`.

## Review Evidence

CEO semantic check against the task plan: the wait is re-anchored to an observable state, the positive/negative controls exist, and the change is test-only. GitHub CI is the merge authority.

## Residual Risk

Other fleet-transport cases share the same helper and inherit the fix; none showed the flake today.

# 中文

## 概要

`fleet-transport.integration.test.ts` 的「more than 64 completed uploads remain bounded across center restart」今日在 main 的 full-check lane 红了两次(Node 26 与 Node 24 各一次),每次补跑都绿。测试在 center 可观察地应用了它要检查的 assignment ledger cut 之前就拉取 replica,有界断言与 center 自己的写入赛跑。helper 现在先等 center 可观察的 assignment ledger revision 再拉取,与 PR #2201 修三族用的重新锚定方式相同。生产 delta +0/-0;断言 114 → 115。

## 架构辩护

等待绑定到 consumer 可观察的状态(center 报出的 ledger revision),而不是 producer 启动时刻。不抬超时、不加重试、不削断言;受控 250 ms 延迟下旧 helper 红、新 helper 绿。

## 机读声明

见英文块。

## 治理声明

- 触碰受保护面:否
- 受保护面范围:无
- 授权:不适用
- 机器检查边界:本 PR 只断言声明存在,是否真实充分由评审判断。
- Break-glass:否
- Break-glass 原因:不适用
- 后续治理任务:不适用

## 验证

- 受控 250 ms 延迟:旧 helper 红、新 helper 绿。
- 本机 Node 24 连续 3 次绿;Node 26 绿。Ubuntu 隔离机整文件连续 3 次 13/13。
- typecheck、该文件 ESLint、`git diff --check` 通过。已记 fact F-4D3B18E3。
- 未跑:`check:local`。

## 评审证据

CEO 对照任务 plan 做语义核对:等待改锚到可观察状态、阳性/阴性对照齐全、纯测试面。GitHub CI 是合并权威。

## 残余风险

fleet-transport 其它用例共用同一 helper,一并受益;今日未见其它用例抖动。
