### PR TITLE
fix(tools): resolve the real git before the -C cd so the wrapper cannot capture itself

### DIFF
--- a/tools/fixtures/deadline-spawn.mjs
+++ b/tools/fixtures/deadline-spawn.mjs
@@ -1,0 +1,37 @@
+import { spawn } from "node:child_process";
+
+// Runs the command in its own process group and kills the whole group at the deadline.
+// A wrapper that re-invokes itself leaves a chain of live descendants, and killing only
+// the direct child orphans that chain instead of reporting it.
+export function spawnWithDeadline(command, args, options, deadlineMs = 2_000) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, { ...options, detached: true, stdio: ["ignore", "pipe", "pipe"] }),
+      stdout = [],
+      stderr = [];
+    let timedOut = false;
+    child.stdout.on("data", (chunk) => stdout.push(chunk));
+    child.stderr.on("data", (chunk) => stderr.push(chunk));
+    const timer = setTimeout(() => {
+      timedOut = true;
+      try {
+        process.kill(-child.pid, "SIGKILL");
+      } catch (error) {
+        if (error?.code !== "ESRCH") reject(error);
+      }
+    }, deadlineMs);
+    child.once("error", (error) => {
+      clearTimeout(timer);
+      reject(error);
+    });
+    child.once("close", (status, signal) => {
+      clearTimeout(timer);
+      resolve({
+        status,
+        signal,
+        stderr: Buffer.concat(stderr).toString("utf8"),
+        stdout: Buffer.concat(stdout).toString("utf8"),
+        timedOut,
+      });
+    });
+  });
+}

--- a/tools/git-hooks/git
+++ b/tools/git-hooks/git
@@ -12,6 +12,15 @@ for entry in ${PATH:-}; do
 done
 IFS=$old_ifs
 
+# Resolve the real git once, before anything changes directory: a relative PATH entry that
+# names nothing at the shell cwd names a real directory after resolve_repo_root's -C cd,
+# including this wrapper's own tools/git-hooks.
+real_git=$(PATH=$filtered_path command -v git 2>/dev/null) || { printf 'git: not found\n' >&2; exit 127; }
+case $real_git in
+  /*) ;;
+  *) real_git=$(CDPATH= cd -- "$(dirname -- "$real_git")" && pwd -P)/$(basename -- "$real_git") ;;
+esac
+
 # Resolve the repository git itself would operate on: honour leading -C <dir>
 # globals instead of the shell cwd, so a worker touching another repo via -C is
 # not misattributed to the canonical root.
@@ -29,7 +38,7 @@ resolve_repo_root() {
       (*) break ;;
     esac
   done
-  PATH=$filtered_path command git rev-parse --show-toplevel 2>/dev/null || true
+  "$real_git" rev-parse --show-toplevel 2>/dev/null || true
 }
 repo_root=$(resolve_repo_root "$@")
 canonical_root=${HARNESS_CANONICAL_ROOT:-}
@@ -159,4 +168,4 @@ if [ "${HARNESS_TASK_BOUND:-}" = "1" ]; then
   fi
 fi
 
-PATH=$filtered_path exec git "$@"
+PATH=$filtered_path exec "$real_git" "$@"

--- a/tools/git-wrapper-recursion.test.mjs
+++ b/tools/git-wrapper-recursion.test.mjs
@@ -1,0 +1,68 @@
+// harness-test-tier: fast
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import {
+  chmodSync,
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { spawnWithDeadline } from "./fixtures/deadline-spawn.mjs";
+
+const repositoryRoot = path.resolve(import.meta.dirname, "..");
+
+// The wrapper honours a leading `-C <dir>` by cd-ing before it decides which repository a
+// command targets. A relative PATH entry that named nothing at the shell cwd is therefore
+// nothing for the self-exclusion filter to match, yet it names a real directory after that
+// cd — including the wrapper's own `tools/git-hooks`, which is how the wrapper reached
+// itself. The decoy stands in for that directory: reaching it at all is the defect.
+test("the git wrapper resolves git before -C, so no PATH entry can capture it after the cd", async (context) => {
+  const parent = realpathSync(mkdtempSync(path.join(os.tmpdir(), "hook-post-cd-capture-"))),
+    root = path.join(parent, "repo"),
+    decoy = path.join(root, "tools", "git-hooks"),
+    wrapper = path.join(parent, "wrapper"),
+    captured = path.join(parent, "captured");
+  context.after(() => rmSync(parent, { recursive: true, force: true }));
+  mkdirSync(decoy, { recursive: true });
+  mkdirSync(wrapper);
+  installExecutable(path.join(repositoryRoot, "tools", "git-hooks", "git"), path.join(wrapper, "git"));
+  writeExecutable(
+    path.join(decoy, "git"),
+    `#!/usr/bin/env sh\nprintf 'captured\\n' >> ${JSON.stringify(captured)}\nexit 1\n`,
+  );
+  execFileSync("git", ["-C", root, "init", "-q"]);
+
+  const result = await spawnWithDeadline("git", ["-C", root, "rev-parse", "--show-toplevel"], {
+    cwd: parent,
+    env: {
+      ...process.env,
+      PATH: [path.join("tools", "git-hooks"), wrapper, process.env.PATH ?? ""].join(path.delimiter),
+    },
+  });
+
+  assert.equal(result.timedOut, false, `git wrapper did not terminate\n${result.stderr}`);
+  assert.equal(
+    existsSync(captured),
+    false,
+    "wrapper resolved git through a PATH entry that only named a directory after its -C cd",
+  );
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(realpathSync(result.stdout.trim()), root);
+});
+
+function installExecutable(source, destination) {
+  copyFileSync(source, destination);
+  chmodSync(destination, 0o755);
+}
+
+function writeExecutable(destination, body) {
+  writeFileSync(destination, body);
+  chmodSync(destination, 0o755);
+}

--- a/tools/worker-discipline-hooks.test.mjs
+++ b/tools/worker-discipline-hooks.test.mjs
@@ -1,6 +1,6 @@
 // harness-test-tier: fast
 import assert from "node:assert/strict";
-import { execFileSync, spawn, spawnSync } from "node:child_process";
+import { execFileSync, spawnSync } from "node:child_process";
 import { createHash, randomUUID } from "node:crypto";
 import {
   chmodSync,
@@ -16,6 +16,7 @@ import {
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
+import { spawnWithDeadline } from "./fixtures/deadline-spawn.mjs";
 
 const repositoryRoot = path.resolve(import.meta.dirname, "..");
 
@@ -202,41 +203,4 @@ function git(root, ...args) {
 
 function digest(value) {
   return createHash("sha256").update(value).digest("hex");
-}
-
-function spawnWithDeadline(command, args, options) {
-  return new Promise((resolve, reject) => {
-    const child = spawn(command, args, {
-        ...options,
-        detached: true,
-        stdio: ["ignore", "pipe", "pipe"],
-      }),
-      stdout = [],
-      stderr = [];
-    let timedOut = false;
-    child.stdout.on("data", (chunk) => stdout.push(chunk));
-    child.stderr.on("data", (chunk) => stderr.push(chunk));
-    const timer = setTimeout(() => {
-      timedOut = true;
-      try {
-        process.kill(-child.pid, "SIGKILL");
-      } catch (error) {
-        if (error?.code !== "ESRCH") reject(error);
-      }
-    }, 2_000);
-    child.once("error", (error) => {
-      clearTimeout(timer);
-      reject(error);
-    });
-    child.once("close", (status, signal) => {
-      clearTimeout(timer);
-      resolve({
-        status,
-        signal,
-        stderr: Buffer.concat(stderr).toString("utf8"),
-        stdout: Buffer.concat(stdout).toString("utf8"),
-        timedOut,
-      });
-    });
-  });
 }


### PR DESCRIPTION
# English

## Summary

`tools/git-hooks/git` could re-invoke itself. The wrapper filtered its own directory out of PATH at the shell cwd, then cd-ed for a leading `-C <dir>` before looking git up. A relative PATH entry that named nothing at the shell cwd survived the `-ef` filter and, after the cd, named a real directory, including the wrapper's own `tools/git-hooks`, so `git rev-parse --show-toplevel` ran the wrapper again. The fix resolves the real git binary once, as an absolute path, before anything changes directory, and uses it for both the repository probe and the final exec. A fast test plants a decoy git in the post-cd `tools/git-hooks` and fails whenever the wrapper reaches it: red on the old script, green on the new one. The process-group deadline spawner moves from the discipline test into `tools/fixtures/deadline-spawn.mjs` so both wrapper tests share it.

## Architectural Justification

Filtering PATH and resolving git happened at two different moments with a cd between them; the fix collapses them into one moment before any cd. No depth counter, no recursion guard, no timeout: the wrapper simply cannot see a directory that only exists after the cd. The `spawn EAGAIN` fork exhaustion seen under task_34048f37's contract run is not fully reproduced by the current script (its filtered PATH shrinks monotonically, so recursion is bounded; the worker's 17,791-call probe saw max depth 2); that event most likely came from the pre-1b4fdddab script shape. This PR removes the remaining self-invocation path.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none

## Machine-Readable Declarations

Production-Delta: +0/-0
Dependency-Change: none

### Optional Evidence Claims

none

## Task And Scope

task_2d0006006697ca70537266b5fa (git-hook shim recursion), child of PLT-Ontology root task_5fc5080044fcfdbf548008f2f5. Root cause and test by the Opus worker (runtime_41c59994); script fix and commit by the CEO.

## Version Impact

None.

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none
- Authority: not applicable
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Follow-up governance task: not applicable

## Verification

- `tools/git-wrapper-recursion.test.mjs`: red against the origin/main script (`not ok 1`), green against the fixed script.
- `tools/worker-discipline-hooks.test.mjs`: 6/6 green with the shared fixture.
- `tools/formatter-write-paths.test.mjs` and `runtime-worker-github-credentials.integration.test.ts` are red on this machine with and without the change (local npx cannot fetch lint-staged; macOS `/private/var` realpath assertion); GitHub CI is the authority for them.
- `sh -n`, G36 line-density and `git diff --check` pass. Not run: `check:local`.

## Review Evidence

CEO semantic check against the task plan: the fix is a deletion of a window, not a new guard; positive control exists; the unexplained part of the incident is stated, not glossed. GitHub CI is the merge authority.

## Residual Risk

If PATH has no git at all the wrapper now exits 127 with `git: not found` before probing, where it previously reached the same exit through `exec`.

# 中文

## 概要

`tools/git-hooks/git` 会自调用。wrapper 在 shell cwd 下把自己的目录从 PATH 里滤掉,然后为首部 `-C <dir>` 先 `cd`,之后才查找 git。一个在 shell cwd 下不存在的相对 PATH 条目躲过了 `-ef` 过滤,`cd` 之后却指向真实目录,包括 wrapper 自己的 `tools/git-hooks`,于是 `git rev-parse --show-toplevel` 又跑起了 wrapper。修复是在任何 `cd` 之前把真实 git 一次性解析成绝对路径,仓库探测与最终 exec 都用它。新增 fast 测试在 `cd` 后的 `tools/git-hooks` 放一个诱饵 git,wrapper 一碰到就红:旧脚本红、新脚本绿。进程组 deadline spawner 从 discipline 测试抽到 `tools/fixtures/deadline-spawn.mjs`,两个 wrapper 测试共用。

## 架构辩护

「过滤 PATH」和「解析 git」原本是两个时刻,中间夹一次 `cd`;修复把它们并成 `cd` 之前的一个时刻。不加深度计数、不加递归护栏、不加超时:wrapper 根本看不到只在 `cd` 之后才存在的目录。task_34048f37 contract 跑出的 `spawn EAGAIN` fork 枯竭用当前脚本没有完全复现(filtered PATH 单调收缩、递归有界;worker 17,791 次调用探针最大深度 2),更可能来自 1b4fdddab 之前的脚本形态;本 PR 删掉的是剩余的自调用路径。

## 机读声明

见英文块。

## 治理声明

- 触碰受保护面:否
- 受保护面范围:无
- 授权:不适用
- 机器检查边界:本 PR 只断言声明存在,是否真实充分由评审判断。
- Break-glass:否
- Break-glass 原因:不适用
- 后续治理任务:不适用

## 验证

- `tools/git-wrapper-recursion.test.mjs`:对 origin/main 脚本红(`not ok 1`),对修复后脚本绿。
- `tools/worker-discipline-hooks.test.mjs`:共用 fixture 后 6/6 绿。
- `tools/formatter-write-paths.test.mjs` 与 `runtime-worker-github-credentials.integration.test.ts` 在本机改前改后都红(本地 npx 拉不到 lint-staged;macOS `/private/var` realpath 断言),以 GitHub CI 为准。
- `sh -n`、G36 line-density、`git diff --check` 通过。未跑:`check:local`。

## 评审证据

CEO 对照任务 plan 做语义核对:修法是删掉一个窗口而不是加护栏;阳性对照齐全;事故里没解释清的部分如实写出。GitHub CI 是合并权威。

## 残余风险

PATH 里完全没有 git 时,wrapper 现在在探测前就以 127 退出并打印 `git: not found`,以前是经 `exec` 到达同一退出码。
