### PR TITLE
refactor(preset): delete the no-op architecture-check vertical script

### DIFF
--- a/packages/cli/test/thin-command-preset-fact-decision.test.ts
+++ b/packages/cli/test/thin-command-preset-fact-decision.test.ts
@@ -9,7 +9,7 @@ test("thin parser derives builtin vertical, template, and script discovery actio
     templates = parseThinCommand(["template", "list"]),
     render = parseThinCommand(["template", "render", "template://repository/adr-template@1", "--locale", "zh-CN"]),
     scripts = parseThinCommand(["script", "list"]),
-    inspect = parseThinCommand(["script", "inspect", "vertical:software-coding:architecture-check"]);
+    inspect = parseThinCommand(["script", "inspect", "vertical:software-coding:repository-audit"]);
   assert.equal(
     [vertical, templates, render, scripts, inspect].every((result) => result.ok),
     true,
@@ -30,12 +30,12 @@ test("thin parser derives builtin vertical, template, and script discovery actio
   if (inspect.ok)
     assert.deepEqual(inspect.command.action, {
       kind: "script-inspect",
-      scriptId: "vertical:software-coding:architecture-check",
+      scriptId: "vertical:software-coding:repository-audit",
     });
   const run = parseThinCommand([
     "script",
     "run",
-    "vertical:software-coding:architecture-check",
+    "vertical:software-coding:repository-audit",
     "--task",
     "task-1",
     "--inputs",
@@ -51,7 +51,7 @@ test("thin parser derives builtin vertical, template, and script discovery actio
       action: {
         schema: "vertical-script-action/v1",
         kind: "script-run",
-        scriptId: "vertical:software-coding:architecture-check",
+        scriptId: "vertical:software-coding:repository-audit",
         taskId: "task-1",
         inputs: { locale: "en-US" },
         dryRun: true,
@@ -59,7 +59,7 @@ test("thin parser derives builtin vertical, template, and script discovery actio
     });
   assert.equal(parseThinCommand(["script", "run", "user-canary/check"]).ok, false);
   assert.equal(
-    parseThinCommand(["script", "run", "vertical:software-coding:architecture-check", "--task-id", "task-1"]).ok,
+    parseThinCommand(["script", "run", "vertical:software-coding:repository-audit", "--task-id", "task-1"]).ok,
     false,
   );
   assert.equal(parseThinCommand(["preset", "run", "standard-task"]).ok, false);

--- a/packages/preset/assets/software-coding/scripts/architecture-check.mjs
+++ b/packages/preset/assets/software-coding/scripts/architecture-check.mjs
@@ -1,2 +1,0 @@
-import { run } from "./runtime.mjs";
-await run("vertical:software-coding:architecture-check");

--- a/packages/preset/assets/software-coding/scripts/runtime.mjs
+++ b/packages/preset/assets/software-coding/scripts/runtime.mjs
@@ -25,7 +25,6 @@ async function waitAtTestBlocker() {
 const handlers = {
   "vertical:software-coding:architecture-init": architectureInit,
   "vertical:software-coding:architecture-snapshot": architectureSnapshot,
-  "vertical:software-coding:architecture-check": architectureCheck,
   "vertical:software-coding:repository-audit": repositoryAudit,
   "vertical:software-coding:decision-conformance": decisionConformance,
 };
@@ -65,29 +64,6 @@ function architectureSnapshot(context) {
     "application/json",
     { fileCount: files.length },
   );
-}
-
-function architectureCheck(context) {
-  if (!context.taskId) return failed("task-required", { message: "architecture-check requires taskId" });
-  const manifest = path.join(context.paths.contextRoot, "architecture/architecture-manifest.json"),
-    snapshot = path.join(context.outputRoot, "artifacts/architecture/code-facts.json");
-  if (!existsSync(manifest)) return success("not-configured", { configured: false }, []);
-  if (!existsSync(snapshot)) return success("snapshot-missing", { configured: true, snapshot: false }, []);
-  try {
-    const parsed = JSON.parse(readFileSync(snapshot, "utf8"));
-    return success(
-      parsed.sourceCommitSha === context.repository.commitSha ? "fresh" : "stale",
-      {
-        configured: true,
-        snapshot: true,
-        sourceCommitSha: parsed.sourceCommitSha,
-        currentCommitSha: context.repository.commitSha,
-      },
-      [],
-    );
-  } catch {
-    return failed("snapshot-invalid", { configured: true, snapshot: true });
-  }
 }
 
 function repositoryAudit() {

--- a/packages/preset/assets/software-coding/vertical.json
+++ b/packages/preset/assets/software-coding/vertical.json
@@ -143,15 +143,6 @@
       "metadata": { "description": "Run declared architecture adapters and write a reproducible code-fact snapshot as a task artifact.", "purpose": "generate", "contractVersion": "script-entry/v1", "produces": ["{{outputRoot}}/artifacts/architecture/**"] }
     },
     {
-      "id": "vertical:software-coding:architecture-check",
-      "type": "script",
-      "command": "scripts/architecture-check.mjs",
-      "reads": ["{{paths.contextRoot}}/architecture/**", "{{outputRoot}}/artifacts/architecture/**"],
-      "writes": [],
-      "inputs": {},
-      "metadata": { "description": "Inspect deterministic architecture configuration, tool, freshness, and drift state.", "purpose": "audit", "contractVersion": "script-entry/v1", "produces": [] }
-    },
-    {
       "id": "vertical:software-coding:repository-audit",
       "type": "script",
       "command": "scripts/repository-audit.mjs",

--- a/packages/preset/test/preset-resolver-discovery-shadowing.test.ts
+++ b/packages/preset/test/preset-resolver-discovery-shadowing.test.ts
@@ -67,7 +67,7 @@ test("template and script discovery expose builtin content with typed vertical e
       rootDir,
       action: { kind: "script-list" },
     })) as Array<{ id: string; purpose: string; execution: string }>;
-    assert.equal(scripts.length, 5);
+    assert.equal(scripts.length, 4);
     assert.deepEqual(
       scripts.map(({ id }) => id),
       [...scripts.map(({ id }) => id)].sort(),
@@ -77,7 +77,7 @@ test("template and script discovery expose builtin content with typed vertical e
       rootDir,
       action: {
         kind: "script-inspect",
-        scriptId: "vertical:software-coding:architecture-check",
+        scriptId: "vertical:software-coding:repository-audit",
       },
     })) as {
       schema: string;
@@ -85,19 +85,19 @@ test("template and script discovery expose builtin content with typed vertical e
       execution: { available: boolean; code: string };
     };
     assert.equal(inspected.schema, "vertical-script-inspection/v1");
-    assert.equal(inspected.declaration.command, "scripts/architecture-check.mjs");
+    assert.equal(inspected.declaration.command, "scripts/repository-audit.mjs");
     assert.deepEqual(inspected.declaration.writes, []);
     assert.deepEqual(inspected.execution, {
       available: true,
       code: "script_run_available",
-      nextAction: "Run ha script run vertical:software-coding:architecture-check [--dry-run].",
+      nextAction: "Run ha script run vertical:software-coding:repository-audit [--dry-run].",
     });
     await assert.rejects(
       runPresetAction({
         rootDir,
         action: {
           kind: "script-run",
-          scriptId: "vertical:software-coding:architecture-check",
+          scriptId: "vertical:software-coding:repository-audit",
         },
       }),
       (error: unknown) => (error as { code?: string }).code === "unsupported_command",

--- a/packages/preset/test/preset-resolver-vertical-scripts.test.ts
+++ b/packages/preset/test/preset-resolver-vertical-scripts.test.ts
@@ -321,7 +321,6 @@ test("software coding declaration closes lifecycle, repository, projection, and 
     [
       "vertical:software-coding:architecture-init",
       "vertical:software-coding:architecture-snapshot",
-      "vertical:software-coding:architecture-check",
       "vertical:software-coding:repository-audit",
       "vertical:software-coding:decision-conformance",
     ],
@@ -430,7 +429,7 @@ test("builtin script preparation binds one declared command and rejects undeclar
   }
 });
 
-test("all five declared builtin script assets emit accepted deterministic plans", () => {
+test("all four declared builtin script assets emit accepted deterministic plans", () => {
   const rootDir = mkdtempSync(path.join(tmpdir(), "ha-script-assets-")),
     taskId = "task_01KZXSYDTJ3K1YE88294X33QNW",
     commitSha = "b".repeat(40);
@@ -482,10 +481,6 @@ test("all five declared builtin script assets emit accepted deterministic plans"
       snapshot.changes.map(({ path: target }) => target),
       [`tasks/${taskId}/artifacts/architecture/code-facts.json`],
     );
-    materialize(snapshot);
-    const check = execute("architecture-check", taskId);
-    assert.equal(check.status, "fresh");
-    assert.deepEqual(check.changes, []);
     const audit = execute("repository-audit");
     assert.equal(audit.status, "conformant");
     assert.deepEqual(audit.changes, []);

--- a/packages/preset/test/vertical-contract-paths.integration.test.ts
+++ b/packages/preset/test/vertical-contract-paths.integration.test.ts
@@ -20,7 +20,7 @@ test("validate, discovery, and create materialization accept one compiled custom
       readonly id: string;
     }>;
     assert.equal(
-      scripts.some(({ id }) => id === "vertical:software-coding:architecture-check"),
+      scripts.some(({ id }) => id === "vertical:software-coding:repository-audit"),
       true,
     );
 

--- a/skills/harness-migration/SKILL.md
+++ b/skills/harness-migration/SKILL.md
@@ -426,7 +426,7 @@ So present **one table** and ask for **one confirmation**:
 | path | resolution | what carries over from the old file |
 | --- | --- | --- |
 | `harness/adr/README.md` | destination | when a lightweight ADR fits, `ha decision propose` for load-bearing choices, back-link rule |
-| `harness/context/architecture/README.md` | destination | manifest read order, `architecture-check`, model update boundary |
+| `harness/context/architecture/README.md` | destination | manifest read order, model update boundary |
 | `harness/people.yaml` | **choose** | nothing — see below |
 
 Say plainly: this is the default, and they can override any row to `source` if


### PR DESCRIPTION
# English

## Summary

`vertical:software-coding:architecture-check` never checked architecture. Its handler in `packages/preset/assets/software-coding/scripts/runtime.mjs` only tested whether the manifest and the code-fact snapshot existed and whether the snapshot's commit sha matched HEAD; it never parsed `sourceScopes`, never compared the authored model against real imports, and never reported a forbidden edge. The root agent entry already routes architecture conformance to eslint `no-restricted-imports`, `tools/check-import-boundaries.mjs` and the manual import matrix. Per the task's delete-first branch this PR removes the script entry, its `runtime.mjs` handler and its `vertical.json` declaration, and repoints the four tests that used that id as a sample script to `repository-audit`. The migration skill row that named `architecture-check` drops it.

## Architectural Justification

No replacement is added: a check that only compared a commit sha was reporting `fresh`/`stale` as if it were conformance, and keeping it would keep that false signal on the task surface. The builtin script set goes from five to four; nothing consumed `architecture-check`'s output.

## Gate Harvest / 门收割

Deleted-Production-Paths: packages/preset/assets/software-coding/scripts/architecture-check.mjs
Deleted-Gates-Fixtures: packages/preset/test/preset-resolver-vertical-scripts.test.ts

## Machine-Readable Declarations

Production-Delta: +0/-0
Dependency-Change: none

### Optional Evidence Claims

none

## Task And Scope

task_4568d2ed2c92767b590aff87bc (architecture-check is a no-op, delete-first). Branch `codex/arch-check-noop`. Public scope: preset assets, preset and CLI tests, migration skill text. Private planning/evidence updated: yes. Out of scope: any new conformance checker.

## Version Impact

No version change: no package is published from this change; publish impact none.

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none
- Authority: not applicable
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` 6943d7f380ab129e0ba712fc8a118cf70f95c78b; merge-base identical; no sync needed.
- Worker ran the four touched test files green before submitting (`thin-command-preset-fact-decision`, `preset-resolver-discovery-shadowing`, `preset-resolver-vertical-scripts`, `vertical-contract-paths.integration`).
- CEO: `grep -rn architecture-check` over the public tree returns nothing outside `.worktrees`; `production-delta.mjs` computes +0/-0. Not run: `check:local` (GitHub CI is the authority).

## Review Evidence

CEO semantic review against the task title: the delete-first branch was taken, the route in the agent entry already said the script was gone, and no compatibility shim or stub remains. GitHub CI is the merge authority.

## Residual Risk

A harness that had `architecture-check` in a custom preset selection will see an unknown script id; the builtin software-coding vertical no longer declares it and nothing in this repository selects it.

# 中文

## 概要

`vertical:software-coding:architecture-check` 从未真正检查过架构:它在 `packages/preset/assets/software-coding/scripts/runtime.mjs` 里只看 manifest 与 code-fact 快照是否存在、快照的 commit sha 是否等于 HEAD,不解析 `sourceScopes`,不比对 authored model 与真实 import,也不报任何禁止边。根 agent 入口已把架构一致性路由到 eslint `no-restricted-imports`、`tools/check-import-boundaries.mjs` 与人工 import 矩阵。按任务的 delete-first 分支,本 PR 删除脚本入口、`runtime.mjs` handler 与 `vertical.json` 声明,把以该 id 作样例的四个测试改指向 `repository-audit`,迁移 skill 里点名它的一行同步去掉。

## 架构辩护

不加替代物:一个只比 commit sha 的检查却以 `fresh`/`stale` 冒充一致性结论,留着就是在任务面上保留假信号。内置脚本从五个变四个,没有任何消费者读它的输出。

## 机读声明

见英文块。

## 治理声明

- 触碰受保护面:否
- 受保护面范围:无
- 授权:不适用
- 机器检查边界:本 PR 只断言声明存在,是否真实充分由评审判断。
- Break-glass:否
- Break-glass 原因:不适用
- 后续治理任务:不适用

## 验证

- 基准 `origin/main` 6943d7f380ab129e0ba712fc8a118cf70f95c78b;merge-base 相同;不需要同步。
- worker 提交前四个触碰测试文件本地绿。
- CEO:公开树内 `grep -rn architecture-check` 在 `.worktrees` 之外零命中;`production-delta.mjs` 算得 +0/-0。未跑:`check:local`(GitHub CI 是权威)。

## 评审证据

CEO 对照任务标题做语义核对:走的是 delete-first 分支,agent 入口的路由早已写明脚本已删,没有留兼容层或桩。GitHub CI 是合并权威。

## 残余风险

若某个 harness 的自定义 preset 选择里写了 `architecture-check`,会看到未知脚本 id;内置 software-coding vertical 不再声明它,本仓库内没有任何选择它的地方。
