### PR TITLE
fix(tools): make the git wrapper delegate only downstream of its own PATH entry

### DIFF
--- a/tools/git-hooks/git
+++ b/tools/git-hooks/git
@@ -2,12 +2,17 @@
 set -eu
 
 guard_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd -P)
+# Delegate only downstream: the real git is the first git in the PATH entries after this
+# wrapper's own directory. An entry upstream of it can lead back here (a test shim that
+# execs `which git`, a second copy of this wrapper installed into a temporary repository),
+# and the repository probe below would then fork the other party, which forks this wrapper
+# again, without bound.
 filtered_path=
 old_ifs=$IFS
 IFS=:
 for entry in ${PATH:-}; do
   # PATH and $0 can spell the same directory differently through filesystem aliases.
-  [ "$entry" -ef "$guard_dir" ] && continue
+  if [ "$entry" -ef "$guard_dir" ]; then filtered_path=; continue; fi
   if [ -n "$filtered_path" ]; then filtered_path="$filtered_path:$entry"; else filtered_path=$entry; fi
 done
 IFS=$old_ifs

--- a/tools/git-wrapper-recursion.test.mjs
+++ b/tools/git-wrapper-recursion.test.mjs
@@ -7,6 +7,7 @@ import {
   existsSync,
   mkdirSync,
   mkdtempSync,
+  readFileSync,
   realpathSync,
   rmSync,
   writeFileSync,
@@ -55,6 +56,47 @@ test("the git wrapper resolves git before -C, so no PATH entry can capture it af
   );
   assert.equal(result.status, 0, result.stderr);
   assert.equal(realpathSync(result.stdout.trim()), root);
+});
+
+// An upstream PATH entry can lead back into the wrapper: a shim that execs `which git`
+// (the shape of the git-version stub in packages/kernel/test/store/ledger-maintenance.test.ts)
+// or a second copy of the wrapper installed into a temporary repository ahead of the
+// canonical one. Filtering out only its own directory left the wrapper delegating to that
+// upstream entry, so every repository probe forked the other party, which forked the wrapper
+// again, without bound: the 2026-09-03 fork exhaustions. Delegating only downstream of its
+// own PATH entry ends the cycle; the shim must be visited exactly once.
+test("the git wrapper delegates only downstream of its own PATH entry, so an upstream shim cannot cycle back into it", async (context) => {
+  const parent = realpathSync(mkdtempSync(path.join(os.tmpdir(), "hook-upstream-shim-"))),
+    root = path.join(parent, "repo"),
+    wrapper = path.join(parent, "wrapper"),
+    shim = path.join(parent, "shim"),
+    visits = path.join(parent, "visits");
+  context.after(() => rmSync(parent, { recursive: true, force: true }));
+  mkdirSync(root);
+  mkdirSync(wrapper);
+  mkdirSync(shim);
+  installExecutable(path.join(repositoryRoot, "tools", "git-hooks", "git"), path.join(wrapper, "git"));
+  writeExecutable(
+    path.join(shim, "git"),
+    `#!/usr/bin/env sh\nprintf 'visit\\n' >> ${JSON.stringify(visits)}\nexec ${JSON.stringify(path.join(wrapper, "git"))} "$@"\n`,
+  );
+  execFileSync("git", ["-C", root, "init", "-q"]);
+
+  // A per-user process ceiling keeps a regression from exhausting the machine; a green
+  // wrapper never approaches it.
+  const result = await spawnWithDeadline(
+    "sh",
+    ["-c", 'ulimit -u $(( $(ps -U "$(id -un)" -o pid= | wc -l) + 256 )); exec git "$@"', "sh", "-C", root, "rev-parse", "--show-toplevel"],
+    {
+      cwd: parent,
+      env: { ...process.env, PATH: [shim, wrapper, process.env.PATH ?? ""].join(path.delimiter) },
+    },
+  );
+
+  assert.equal(result.timedOut, false, `git wrapper did not terminate\n${result.stderr}`);
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(realpathSync(result.stdout.trim()), root);
+  assert.equal(readFileSync(visits, "utf8"), "visit\n", "the wrapper delegated back upstream into the shim");
 });
 
 function installExecutable(source, destination) {


### PR DESCRIPTION
# English

## Summary

`tools/git-hooks/git` could still fork without bound after #2205. The wrapper filtered only its own directory out of PATH and delegated to whichever `git` came next, and two supported test shapes put a `git` *upstream* of it that leads straight back: the git-version stub in `packages/kernel/test/store/ledger-maintenance.test.ts` (`exec "$(which git)"`, where `which git` is the wrapper inside a worker) and the wrapper copy that `runtime-worker-github-credentials.integration.test.ts` installs into a temporary repository ahead of the canonical one. In both, the wrapper's repository probe (`git rev-parse --show-toplevel`) forked the upstream party, which forked the wrapper again, per hop, until the machine ran out of processes (three fork exhaustions on 2026-09-03; the last reached 10,364 processes). The fix narrows delegation: the real git is the first `git` in the PATH entries *after* the wrapper's own directory. Anything upstream is never a candidate, so no cycle can form. A fast test plants an upstream shim that execs the wrapper and asserts the shim is visited exactly once under a per-user process ceiling: red on the old script (the probe never terminates), green on the new one.

## Architectural Justification

No depth counter, no environment marker, no timeout: the wrapper simply cannot see the entries that could lead back to it. The only behavioural change is that a wrapper invoked with no git downstream of its own PATH entry now exits 127 (`git: not found`) instead of delegating upstream; the daemon always prepends the wrapper to a PATH that already contains the real git, and every hook and test installs it the same way.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none

## Machine-Readable Declarations

Production-Delta: +0/-0
Dependency-Change: none

### Optional Evidence Claims

none

## Task And Scope

task_97ffeb798656e15378bc446225 (fork storm recurrence: locate the re-entrant and remove it at the root), child of PLT-Ontology root task_5fc5080044fcfdbf548008f2f5. Branch `codex/git-wrapper-reentry`. Root cause, fix and test by the CEO from the recorded process chains (facts F-B43DFAB8, F-40B70E34) and the two test files named above. Out of scope: the tests themselves keep their shims; they are now harmless.

## Version Impact

No version change: no package is published from this change; publish impact none.

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none
- Authority: not applicable
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Follow-up governance task: not applicable

## Verification

- `tools/git-wrapper-recursion.test.mjs`: 2/2 green with the new script; with the old script the new case is red (`not ok 2`, the probe times out under the ceiling) while the process count stayed bounded (1518 before, 1517 after).
- `tools/worker-discipline-hooks.test.mjs`: 6/6 green.
- `sh -n tools/git-hooks/git`, `git diff --check`, `production-delta.mjs` (+0/-0) pass. Not run: `check:local` (GitHub CI is the authority).

## Review Evidence

CEO semantic review against the task plan: the fix is a narrowing of delegation, not a guard; the positive control runs under the plan's process fence; the two triggering test shapes are named from the code, not inferred. GitHub CI is the merge authority.

## Residual Risk

A PATH in which the wrapper sits after the real git (so the wrapper is only reachable by explicit path) now yields `git: not found` from the wrapper; no supported launch path builds such a PATH.

# 中文

## 概要

#2205 之后 `tools/git-hooks/git` 仍会无界 fork。wrapper 只把自己所在目录从 PATH 里滤掉,然后把下一个 `git` 当真 git;而两种受支持的测试形状会在它**上游**放一个直接绕回来的 `git`:`packages/kernel/test/store/ledger-maintenance.test.ts` 的 git 版本桩(`exec "$(which git)"`,在 worker 里 `which git` 就是 wrapper),以及 `runtime-worker-github-credentials.integration.test.ts` 复制进临时仓、排在 canonical 之前的 wrapper 副本。两种情况下 wrapper 的仓库探测(`git rev-parse --show-toplevel`)每跳一层就 fork 一次上游那一方,上游又 fork 出 wrapper,直到整机进程耗尽(2026-09-03 三次 fork 枯竭,最后一次 10,364 个进程)。修复是收窄委托:真 git 只从 wrapper 自己目录**之后**的 PATH 项里取,上游的任何项都不再是候选,环不可能形成。新增 fast 测试在上游放一个 exec 回 wrapper 的桩,断言在每用户进程上限下桩恰好被访问一次:旧脚本红(探测永不结束),新脚本绿。

## 架构辩护

不加深度计数、不加环境标记、不加超时:wrapper 根本看不到能绕回自己的那些项。唯一的行为变化是「自己 PATH 项之后没有 git」的 wrapper 现在以 127 退出(`git: not found`)而不是回头找上游;daemon 总是把 wrapper 前置到一条已含真 git 的 PATH 上,所有 hook 与测试也都这样安装。

## 机读声明

见英文块。

## 治理声明

- 触碰受保护面:否
- 受保护面范围:无
- 授权:不适用
- 机器检查边界:本 PR 只断言声明存在,是否真实充分由评审判断。
- Break-glass:否
- Break-glass 原因:不适用
- 后续治理任务:不适用

## 验证

- `tools/git-wrapper-recursion.test.mjs`:新脚本 2/2 绿;旧脚本下新用例红(`not ok 2`,探测在上限下超时),进程数保持有界(前 1518、后 1517)。
- `tools/worker-discipline-hooks.test.mjs`:6/6 绿。
- `sh -n`、`git diff --check`、`production-delta.mjs`(+0/-0)通过。未跑:`check:local`(GitHub CI 是权威)。

## 评审证据

CEO 对照任务 plan 做语义核对:修法是收窄委托而不是加护栏;阳性对照在 plan 要求的进程围栏下跑;两种触发形状从代码点名,不是推断。GitHub CI 是合并权威。

## 残余风险

若 PATH 里 wrapper 排在真 git 之后(只能靠显式路径到达 wrapper),wrapper 现在会报 `git: not found`;没有任何受支持的启动路径会构造这样的 PATH。
