### PR TITLE
fix(kernel): reclaim settlement markers left behind by killed writers

### DIFF
--- a/packages/kernel/src/store/local-version-control-system.ts
+++ b/packages/kernel/src/store/local-version-control-system.ts
@@ -653,7 +653,10 @@ function sweepStaleSettlementMarkers(directory: string): void {
     removeNode(path.join(directory, name));
   }
 }
-/** Only ESRCH proves the owner is gone; EPERM or any other probe failure keeps the marker (fail-safe toward not deleting). */
+/**
+ * Only ESRCH proves the owner is gone; EPERM or any other probe failure keeps the
+ * marker (fail-safe toward not deleting).
+ */
 function processMayBeAlive(pid: number): boolean {
   try {
     process.kill(pid, 0);

--- a/packages/kernel/src/store/local-version-control-system.ts
+++ b/packages/kernel/src/store/local-version-control-system.ts
@@ -10,6 +10,7 @@ import {
   lstatSync,
   mkdirSync,
   openSync,
+  readdirSync,
   readFileSync,
   readlinkSync,
   realpathSync,
@@ -367,6 +368,7 @@ export const localGitWorktreeSettlement = Object.freeze({
       const temporary = path.join(path.dirname(target), `.ha-visible-${process.pid}-${index}`);
       /* @gate-identity check-bypass-write-boundary/bypass-write-076 */
       mkdirSync(path.dirname(target), { recursive: true });
+      sweepStaleSettlementMarkers(path.dirname(target));
       removeNode(temporary);
       if (file.mode === "120000")
         /* @gate-identity check-bypass-write-boundary/bypass-write-077 */
@@ -505,6 +507,7 @@ export const localGitWorktreeSettlement = Object.freeze({
     for (const directory of directories) {
       /* @gate-identity check-bypass-write-boundary/bypass-write-083 */
       mkdirSync(directory, { recursive: true });
+      sweepStaleSettlementMarkers(directory);
     }
     const regular = pending.filter(({ mode }) => mode === "100644"),
       links = pending.filter(({ mode }) => mode === "120000"),
@@ -619,6 +622,46 @@ function removeNode(target: string): void {
     unlinkSync(target);
   } catch (error) {
     consumeKnownError(error);
+  }
+}
+// Settlement markers sit beside their target because rename(2) is only atomic
+// within one filesystem, and "same directory" is the one placement that
+// guarantees it. The cost is that a process killed between the durable write
+// and the rename leaves `.ha-settle-<pid>-<index>` (or `.ha-visible-...`)
+// behind forever; F-B16F8586 counted 1225 of them after two `daemon stop
+// --force`. The first time this process settles into a directory it removes
+// every marker whose owner pid no longer exists. Sweeping once per process
+// bounds the readdir cost to the directories a process ever touches, and the
+// failure that produces leftovers (a killed writer) is followed by a new
+// process anyway. Its own pid is never touched: an in-flight marker of this
+// process is only ever reclaimed by the same-index removeNode above.
+const settlementMarkerPattern = /^\.ha-(?:settle|visible)-([1-9][0-9]*)-[0-9]+$/u,
+  sweptMarkerDirectories = new Set<string>();
+function sweepStaleSettlementMarkers(directory: string): void {
+  if (sweptMarkerDirectories.has(directory)) return;
+  sweptMarkerDirectories.add(directory);
+  let names: readonly string[];
+  try {
+    names = readdirSync(directory);
+  } catch (error) {
+    consumeKnownError(error);
+    return;
+  }
+  for (const name of names) {
+    const pid = Number(settlementMarkerPattern.exec(name)?.[1]);
+    if (!Number.isSafeInteger(pid) || pid === process.pid || processMayBeAlive(pid)) continue;
+    removeNode(path.join(directory, name));
+  }
+}
+/** Only ESRCH proves the owner is gone; EPERM or any other probe failure keeps the marker (fail-safe toward not deleting). */
+function processMayBeAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    if (typeof error === "object" && error !== null && "code" in error && error.code === "ESRCH") return false;
+    consumeKnownError(error);
+    return true;
   }
 }
 function gitBlobOid(body: string): string {

--- a/packages/kernel/test/store/local-version-control-settlement.test.ts
+++ b/packages/kernel/test/store/local-version-control-settlement.test.ts
@@ -1,0 +1,206 @@
+// harness-test-tier: integration
+import assert from "node:assert/strict";
+import { execFileSync, spawn, spawnSync } from "node:child_process";
+import { once } from "node:events";
+import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import { localGitWorktreeSettlement } from "../../src/index.ts";
+import { withTempStore, withTempStoreAsync } from "./helpers.ts";
+
+function git(repoRoot: string, ...args: readonly string[]): string {
+  return execFileSync("git", ["-C", repoRoot, ...args], { encoding: "utf8" }).trim();
+}
+
+function ledger(rootDir: string): string {
+  const repoRoot = path.join(rootDir, "ledger");
+  mkdirSync(repoRoot, { recursive: true });
+  git(repoRoot, "init", "--quiet");
+  return repoRoot;
+}
+
+/** Plants a leftover settlement marker exactly where a killed writer would have left it. */
+function plant(directory: string, name: string): string {
+  mkdirSync(directory, { recursive: true });
+  const marker = path.join(directory, name);
+  writeFileSync(marker, "leaked", "utf8");
+  return marker;
+}
+
+function markers(directory: string): readonly string[] {
+  return readdirSync(directory)
+    .filter((name) => name.startsWith(".ha-"))
+    .sort();
+}
+
+/** A pid that belonged to a process which has provably exited. */
+function deadPid(): number {
+  for (let attempt = 0; attempt < 5; attempt += 1) {
+    const { pid } = spawnSync(process.execPath, ["-e", "0"], { stdio: "ignore" });
+    try {
+      process.kill(pid, 0);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ESRCH") return pid;
+    }
+  }
+  throw new Error("could not obtain a pid whose process has exited");
+}
+
+test(
+  "settle reclaims the markers a SIGKILLed settlement left behind",
+  { skip: process.platform === "win32" ? "requires POSIX SIGKILL semantics" : false },
+  () => {
+    withTempStore((rootDir) => {
+      const repoRoot = ledger(rootDir),
+        directory = path.join(repoRoot, "events", "ab"),
+        moduleUrl = new URL("../../src/store/local-version-control-system.ts", import.meta.url).href,
+        child = spawnSync(
+          process.execPath,
+          [
+            "--experimental-strip-types",
+            "--input-type=module",
+            "-e",
+            [
+              `import { localGitWorktreeSettlement } from ${JSON.stringify(moduleUrl)};`,
+              "localGitWorktreeSettlement.settle(process.env.HA_ROOT, [",
+              "  { target: 'events/ab/first.json', body: 'first' },",
+              "  { target: 'events/ab/second.json', body: 'second' },",
+              "], { beforeRename: () => process.kill(process.pid, 'SIGKILL') });",
+            ].join("\n"),
+          ],
+          { encoding: "utf8", env: { ...process.env, HA_ROOT: repoRoot } },
+        );
+      assert.equal(child.signal, "SIGKILL", child.stderr);
+      assert.throws(() => process.kill(child.pid, 0), { code: "ESRCH" });
+      // Negative control: the durable bodies exist under their marker names and nothing renamed them.
+      assert.deepEqual(markers(directory), [`.ha-settle-${child.pid}-0`, `.ha-settle-${child.pid}-1`]);
+      assert.equal(existsSync(path.join(directory, "first.json")), false);
+      const untouched = plant(path.join(repoRoot, "objects", "zz"), `.ha-settle-${child.pid}-0`);
+
+      localGitWorktreeSettlement.settle(repoRoot, [{ target: "events/ab/third.json", body: "third" }]);
+
+      assert.deepEqual(markers(directory), []);
+      assert.equal(readFileSync(path.join(directory, "third.json"), "utf8"), "third");
+      assert.match(git(repoRoot, "ls-files", "--stage", "events/ab/third.json"), /^100644 /u);
+      // Only the directories this settlement touched are swept; cold directories are left alone.
+      assert.equal(existsSync(untouched), true);
+    });
+  },
+);
+
+test("settle keeps markers owned by live, own, or unparseable pids while reclaiming the dead one beside them", async () => {
+  await withTempStoreAsync(async (rootDir) => {
+    const repoRoot = ledger(rootDir),
+      directory = path.join(repoRoot, "events", "cd"),
+      bystander = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"], { stdio: "ignore" });
+    try {
+      await once(bystander, "spawn");
+      const live = plant(directory, `.ha-settle-${bystander.pid}-0`),
+        own = plant(directory, `.ha-visible-${process.pid}-41`),
+        garbage = plant(directory, ".ha-settle-not-a-pid-0"),
+        zero = plant(directory, ".ha-settle-0-0"),
+        dead = plant(directory, `.ha-settle-${deadPid()}-0`);
+
+      localGitWorktreeSettlement.settle(repoRoot, [{ target: "events/cd/entry.json", body: "entry" }]);
+
+      assert.equal(existsSync(live), true, "a live foreign writer keeps its in-flight marker");
+      assert.equal(existsSync(own), true, "our own markers are only reclaimed by same-index reuse");
+      assert.equal(existsSync(garbage), true, "names that do not parse as a marker are never touched");
+      assert.equal(existsSync(zero), true, "pid 0 is not a marker owner");
+      assert.equal(existsSync(dead), false, "the dead writer's marker is reclaimed");
+      assert.equal(readFileSync(path.join(directory, "entry.json"), "utf8"), "entry");
+    } finally {
+      bystander.kill("SIGKILL");
+    }
+  });
+});
+
+test("settle keeps a marker whose owner it is not permitted to probe", (t) => {
+  let probe: string | null = null;
+  try {
+    process.kill(1, 0);
+  } catch (error) {
+    probe = (error as NodeJS.ErrnoException).code ?? "unknown";
+  }
+  if (probe === "ESRCH") return t.skip("pid 1 is not visible on this platform");
+  withTempStore((rootDir) => {
+    const repoRoot = ledger(rootDir),
+      directory = path.join(repoRoot, "events", "ef"),
+      marker = plant(directory, ".ha-settle-1-0");
+
+    localGitWorktreeSettlement.settle(repoRoot, [{ target: "events/ef/entry.json", body: "entry" }]);
+
+    // EPERM (or a permitted probe of a live pid 1) must fail safe toward keeping the marker.
+    assert.equal(existsSync(marker), true, `probe outcome ${probe ?? "permitted"} must not delete`);
+    assert.equal(readFileSync(path.join(directory, "entry.json"), "utf8"), "entry");
+  });
+});
+
+test("settle sweeps each directory once per process, so leftovers from a later death wait for the next process", () => {
+  withTempStore((rootDir) => {
+    const repoRoot = ledger(rootDir),
+      directory = path.join(repoRoot, "events", "gh"),
+      first = plant(directory, `.ha-settle-${deadPid()}-0`);
+    localGitWorktreeSettlement.settle(repoRoot, [{ target: "events/gh/one.json", body: "one" }]);
+    assert.equal(existsSync(first), false);
+
+    const later = plant(directory, `.ha-settle-${deadPid()}-0`);
+    localGitWorktreeSettlement.settle(repoRoot, [{ target: "events/gh/two.json", body: "two" }]);
+
+    // Bounded cost: the readdir runs once per directory per process. The failure that
+    // leaves markers behind (a killed writer) is always followed by a fresh process.
+    assert.equal(existsSync(later), true);
+    assert.equal(readFileSync(path.join(directory, "two.json"), "utf8"), "two");
+  });
+});
+
+test("visible reclaims dead markers of both families in the directory it writes", () => {
+  withTempStore((rootDir) => {
+    const repoRoot = ledger(rootDir),
+      directory = path.join(repoRoot, "tasks", "t1"),
+      pid = deadPid(),
+      settleMarker = plant(directory, `.ha-settle-${pid}-0`),
+      visibleMarker = plant(directory, `.ha-visible-${pid}-3`);
+
+    localGitWorktreeSettlement.visible(repoRoot, [{ target: "tasks/t1/INDEX.md", body: "# t1\n" }]);
+
+    assert.equal(existsSync(settleMarker), false);
+    assert.equal(existsSync(visibleMarker), false);
+    assert.equal(readFileSync(path.join(directory, "INDEX.md"), "utf8"), "# t1\n");
+  });
+});
+
+test("settle still writes, renames, deletes, and indexes with the sweep in its path", () => {
+  withTempStore((rootDir) => {
+    const repoRoot = ledger(rootDir);
+    localGitWorktreeSettlement.settle(repoRoot, [
+      { target: "events/ij/keep.json", body: "keep" },
+      { target: "events/ij/old.json", body: "old" },
+      { target: "events/ij/gone.json", body: "gone" },
+    ]);
+    const leftover = plant(path.join(repoRoot, "events", "kl"), `.ha-settle-${deadPid()}-0`);
+
+    const touched = localGitWorktreeSettlement.settle(repoRoot, [
+      { target: "events/kl/new.json", body: "new" },
+      { from: "events/ij/old.json", to: "events/kl/moved.json" },
+      { delete: "events/ij/gone.json" },
+    ]);
+
+    assert.equal(touched, 3 + 2, "three files across two directories");
+    assert.equal(readFileSync(path.join(repoRoot, "events", "kl", "new.json"), "utf8"), "new");
+    assert.equal(readFileSync(path.join(repoRoot, "events", "kl", "moved.json"), "utf8"), "old");
+    assert.equal(readFileSync(path.join(repoRoot, "events", "ij", "keep.json"), "utf8"), "keep");
+    assert.equal(existsSync(path.join(repoRoot, "events", "ij", "old.json")), false);
+    assert.equal(existsSync(path.join(repoRoot, "events", "ij", "gone.json")), false);
+    assert.equal(existsSync(leftover), false);
+    assert.deepEqual(markers(path.join(repoRoot, "events", "ij")), []);
+    assert.deepEqual(markers(path.join(repoRoot, "events", "kl")), []);
+    assert.deepEqual(
+      git(repoRoot, "ls-files", "--stage")
+        .split("\n")
+        .map((line) => line.split("\t")[1])
+        .sort(),
+      ["events/ij/keep.json", "events/kl/moved.json", "events/kl/new.json"],
+    );
+  });
+});


### PR DESCRIPTION
# English

## Summary

A writer killed between its durable write and the rename left `.ha-settle-<pid>-<index>` and `.ha-visible-<pid>-<index>` markers in the working tree forever (fact F-B16F8586 counted 1225 of them after two forced daemon stops). The markers must sit beside their target because `rename(2)` is atomic only within one filesystem, so a dedicated temporary directory is not an option. The first time a process settles into a directory it now removes every marker whose owner pid no longer exists: only `ESRCH` proves the owner is gone; `EPERM`, its own pid, and unparseable names are kept (fail-safe toward not deleting). Removal reuses the existing `removeNode`; there is no timer, no sweeper process, no configuration. Six integration tests pin the behaviour: reclaim after a SIGKILLed settlement, keep live/own/unparseable/unprobeable markers, sweep once per process, sweep both marker families from `visible`, and settle still writes, renames, deletes and indexes with the sweep in its path.

## Architectural Justification

Not applicable by size; the mechanism is a 43-line addition on the existing settle and visible write paths, with two call sites after the existing `mkdirSync`.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none

## Machine-Readable Declarations

Production-Delta: +46/-0
Dependency-Change: none

### Optional Evidence Claims

none

## Task And Scope

task_38bc061c5a6c7fb1946e9b5cc6 (settle temp file leak from killed writers). Branch `codex/settle-cleanup`. Public scope: kernel store settlement and its test. Private planning/evidence updated: yes. Out of scope: the same leak shape in `packages/daemon/src/durable-file.ts` and elsewhere, tracked in a separate task.

## Version Impact

No version change: no package is published from this change; publish impact none.

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none
- Authority: not applicable
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` merge-base 6943d7f380ab129e0ba712fc8a118cf70f95c78b.
- Worker (Opus runtime_e2f8cefc): `packages/kernel/test/store/local-version-control-settlement.test.ts` 6/6; typecheck, eslint, prettier, bypass-write-boundary (101 to 101), integration-shard manifest (186 to 187), file-complexity pass. A pre-existing local-only failure in `wal-shadow-event-store.test.ts` (macOS `/private/var` tmpdir symlink versus the test regex) is unrelated and not touched.
- CEO: read the production diff line by line. Not run: `check:local` (GitHub CI is the authority).

## Review Evidence

CEO semantic review against the task plan: the sweep is placed where the marker is born, deletion is the default action with a fail-safe probe, no new mechanism beyond one `readdirSync` per touched directory per process. GitHub CI is the merge authority.

## Residual Risk

A marker whose owner pid was reused by an unrelated live process is kept until a later process finds it dead; the leak is bounded, not eliminated, in that rare case.

# 中文

## 概要

writer 在持久写入与 rename 之间被杀,会把 `.ha-settle-<pid>-<index>` / `.ha-visible-<pid>-<index>` 标记永久留在工作树里(fact F-B16F8586 在两次强制停 daemon 之后数到 1225 个)。标记必须与目标同目录,因为 `rename(2)` 只在同一文件系统内原子,专用临时目录行不通。现在进程首次向某目录 settle 时,删除该目录里 owner pid 已不存在的全部标记:只有 `ESRCH` 算死;`EPERM`、自身 pid、解析不出 pid 的名字一律保留(向不删的方向 fail-safe)。删除复用既有 `removeNode`,不加定时器、清扫进程或配置。六条 integration 测试钉住:SIGKILL 后回收、保留活/自身/不可解析/不可探测的标记、每进程每目录只扫一次、`visible` 同样清两族标记、settle 的写/rename/删/索引在清扫在路径上时仍正确。

## 架构辩护

按体量不适用;机制是既有 settle 与 visible 写路径上 43 行新增、两处调用点紧跟既有 `mkdirSync`。

## 机读声明

见英文块。

## 治理声明

- 触碰受保护面:否
- 受保护面范围:无
- 授权:不适用
- 机器检查边界:本 PR 只断言声明存在,是否真实充分由评审判断。
- Break-glass:否
- Break-glass 原因:不适用
- 后续治理任务:不适用

## 验证

- 基准 merge-base 6943d7f380ab129e0ba712fc8a118cf70f95c78b。
- worker(Opus runtime_e2f8cefc):settlement 测试 6/6;typecheck、eslint、prettier、bypass-write-boundary(101→101)、integration-shard manifest(186→187)、file-complexity 通过。`wal-shadow-event-store.test.ts` 一条既有本机失败(macOS `/private/var` tmpdir symlink 与测试正则不匹配)与本改动无关、未触碰。
- CEO 逐行读生产 diff。未跑:`check:local`(GitHub CI 是权威)。

## 评审证据

CEO 对照任务 plan 做语义核对:清扫放在标记诞生的位置,默认动作是删除、探测 fail-safe,除每进程每目录一次 `readdirSync` 外没有新机制。GitHub CI 是合并权威。

## 残余风险

owner pid 被无关活进程复用的标记会保留到后续某个进程发现它已死;这种罕见情况下泄漏是有界的而非消除。

