### PR TITLE
refactor(daemon): drop the unreachable Electron guard from the vertical script child env

### DIFF
--- a/packages/daemon/src/vertical-script-actions.ts
+++ b/packages/daemon/src/vertical-script-actions.ts
@@ -48,9 +48,6 @@ export async function executeVerticalScriptAction(input: ExecutionInput): Promis
   const testPermissions = blocker ? [`--allow-fs-read=${blocker}`, `--allow-fs-write=${blocker}.started`] : [],
     childEnvironment = {
       PATH: process.env.PATH,
-      // When the daemon itself runs inside Electron (GUI-launched), process.execPath is the Electron
-      // binary; without this flag Electron opens the script as an app instead of running it as node.
-      ...(process.versions.electron ? { ELECTRON_RUN_AS_NODE: "1" } : {}),
       ...(blocker ? { HARNESS_TEST_VERTICAL_SCRIPT_BLOCK_FILE: blocker } : {}),
     };
   const stdout = await runProcessTextAsync(

--- a/packages/daemon/test/vertical-script-actions.test.ts
+++ b/packages/daemon/test/vertical-script-actions.test.ts
@@ -240,6 +240,58 @@ test("same-repo writes advance while a vertical script is running", async (conte
   }
 });
 
+test(
+  "the vertical script child inherits nothing beyond its declared environment keys",
+  {
+    skip:
+      process.platform === "win32" ? "requires POSIX per-process environment introspection (/proc or ps -E)" : false,
+  },
+  async (context) => {
+    const rootDir = mkdtempSync(path.join(tmpdir(), "ha-vertical-script-env-")),
+      blocker = path.join(rootDir, "vertical-script.block"),
+      started = `${blocker}.started`,
+      previousBlocker = process.env.HARNESS_TEST_VERTICAL_SCRIPT_BLOCK_FILE,
+      previousProbe = process.env.HARNESS_TEST_VERTICAL_SCRIPT_ENV_PROBE;
+    initRepo(rootDir);
+    let cell: Awaited<ReturnType<typeof openRepoCell>> | undefined;
+    const action = {
+      schema: "vertical-script-action/v1",
+      kind: "script-run",
+      scriptId: "vertical:software-coding:repository-audit",
+      taskId: null,
+      inputs: {},
+      dryRun: true,
+    } as const;
+    const runs: Promise<unknown>[] = [];
+    try {
+      writeFileSync(blocker, "blocked\n", "utf8");
+      process.env.HARNESS_TEST_VERTICAL_SCRIPT_BLOCK_FILE = blocker;
+      // A parent-only key: if the child inherited process.env at all, this key would show up downstream.
+      process.env.HARNESS_TEST_VERTICAL_SCRIPT_ENV_PROBE = "parent-only";
+      cell = await openRepoCell({
+        repoId: workspaceId("vertical-script-env"),
+        rootDir: canonicalRoot(rootDir),
+        ownerId: "vertical-script-env-test",
+      });
+      runs.push(cell.run(action, binding));
+      await waitForPath(started);
+      const childPid = Number(readFileSync(started, "utf8").trim());
+      assert.equal(Number.isInteger(childPid) && childPid > 0, true, `unusable child pid: ${childPid}`);
+      const observed = childEnvironmentKeys(childPid);
+      context.diagnostic(`vertical script child env keys: ${JSON.stringify(observed)}`);
+      assert.deepEqual(observed, ["HARNESS_TEST_VERTICAL_SCRIPT_BLOCK_FILE", "PATH"]);
+    } finally {
+      rmSync(blocker, { force: true });
+      await Promise.allSettled(runs);
+      if (previousBlocker === undefined) Reflect.deleteProperty(process.env, "HARNESS_TEST_VERTICAL_SCRIPT_BLOCK_FILE");
+      else process.env.HARNESS_TEST_VERTICAL_SCRIPT_BLOCK_FILE = previousBlocker;
+      if (previousProbe === undefined) Reflect.deleteProperty(process.env, "HARNESS_TEST_VERTICAL_SCRIPT_ENV_PROBE");
+      else process.env.HARNESS_TEST_VERTICAL_SCRIPT_ENV_PROBE = previousProbe;
+      await cell?.close();
+      rmSync(rootDir, { recursive: true, force: true });
+    }
+  },
+);
 function initRepo(rootDir: string): void {
   git(rootDir, "init", "-q");
   git(rootDir, "config", "user.name", "Vertical Script Test");
@@ -265,4 +317,22 @@ async function waitForPath(target: string): Promise<void> {
 }
 function delay<T>(milliseconds: number, value: T): Promise<T> {
   return new Promise((resolve) => setTimeout(() => resolve(value), milliseconds));
+}
+
+// Reads a live child's environment from the operating system rather than from this process, so the
+// assertion observes what was actually handed to the child instead of what the parent believes it sent.
+function childEnvironmentKeys(pid: number): string[] {
+  if (process.platform === "linux")
+    return environmentKeys(readFileSync(`/proc/${pid}/environ`, "utf8").split("\0").filter(Boolean));
+  const argv = processCommand(pid, "-ww"),
+    full = processCommand(pid, "-Ewww");
+  assert.equal(full.startsWith(argv), true, `ps -E output must extend the argv-only output: ${full}`);
+  return environmentKeys(full.slice(argv.length).trim().split(" "));
+}
+function environmentKeys(entries: readonly string[]): string[] {
+  const assignments = entries.filter((entry) => /^[A-Za-z_][A-Za-z0-9_]*=/u.test(entry));
+  return [...new Set(assignments.map((entry) => entry.slice(0, entry.indexOf("="))))].sort();
+}
+function processCommand(pid: number, flags: string): string {
+  return execFileSync("ps", ["-p", String(pid), flags, "-o", "command="], { encoding: "utf8" }).trim();
 }


### PR DESCRIPTION
# English

## Summary

`executeVerticalScriptAction` carried a guard that set `ELECTRON_RUN_AS_NODE=1` in the vertical script child environment whenever the daemon itself ran inside Electron. The launch path that made the daemon run inside Electron was deleted in 49c8cc1ce: the GUI now starts the daemon through the CLI entry as a plain Node process, so `process.versions.electron` is never set in the daemon and the guard is unreachable. This PR deletes the guard and its two comment lines. A new integration test pins the child environment to a closed key set by reading the live child's environment from the operating system (`/proc/<pid>/environ` on Linux, `ps -Ewww` minus the argv prefix on macOS; Windows skips by the repository's existing convention) and injects a probe key in the parent that the child must not see. Mutating the expected set to include `ELECTRON_RUN_AS_NODE` turns the test red.

## Architectural Justification

Not applicable by size: production delta is a three-line deletion.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none

## Machine-Readable Declarations

Production-Delta: +0/-3
Dependency-Change: none

### Optional Evidence Claims

none

## Task And Scope

task_799f5af59b215c112fea642112 (GUI-launched daemon and ELECTRON_RUN_AS_NODE for vertical scripts). Branch `codex/gui-daemon-electron-env`. Public scope: one daemon source file and its test. Private planning/evidence updated: yes (facts F-7E60BC7D, F-74EFB34F). Out of scope: the second instance of the same guard shape in `preset-process-service.ts` stays untouched per the plan's keep-branch condition.

## Version Impact

No version change: no package is published from this change; publish impact none.

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none
- Authority: task_799f5af59b215c112fea642112
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Follow-up governance task: not applicable

## Verification

- Base merge-base f54a99cc1e5d87982240c1b1ab6868594d31aa08.
- Worker (Opus runtime_05352672): `packages/daemon/test/vertical-script-actions.test.ts` 4/4 on the isolated Linux runner and 4/4 on macOS; mutation check (expected set with `ELECTRON_RUN_AS_NODE`) fails 1; `packages/cli/test/daemon-thin-client-cli.test.ts` 13/13; `production-delta` and `line-density` pass.
- CEO: read the production diff. Not run: `check:local` (GitHub CI is the authority).

## Review Evidence

CEO semantic review against the task plan: the delete branch was taken because the triggering launch path no longer exists, the negative control observes the real child environment rather than a self-report, and no compatibility shim remains. GitHub CI is the merge authority.

## Residual Risk

If a future launcher runs the daemon inside Electron again, vertical scripts would open as Electron apps; the closed-key-set test would not catch that by itself, the launcher change would.

# 中文

## 概要

`executeVerticalScriptAction` 里有一段守卫:daemon 自己跑在 Electron 内时给 vertical script 子进程注入 `ELECTRON_RUN_AS_NODE=1`。让 daemon 跑在 Electron 内的那条启动路径已在 49c8cc1ce 删除,GUI 现在经 CLI 入口以普通 Node 进程起 daemon,daemon 里 `process.versions.electron` 永远不会置位,守卫不可达。本 PR 删掉守卫与两行注释。新增 integration 测试把子进程环境钉成封闭键集:从操作系统读活着的子进程环境(Linux `/proc/<pid>/environ`,macOS `ps -Ewww` 减去 argv 前缀,Windows 按仓内既有约定跳过),父进程另注入一个探针键,子进程必须看不见。把期望集改成含 `ELECTRON_RUN_AS_NODE` 时测试变红。

## 架构辩护

按体量不适用:生产净变化是三行删除。

## 机读声明

见英文块。

## 治理声明

- 触碰受保护面:否
- 受保护面范围:无
- 授权:task_799f5af59b215c112fea642112
- 机器检查边界:本 PR 只断言声明存在,是否真实充分由评审判断。
- Break-glass:否
- Break-glass 原因:不适用
- 后续治理任务:不适用

## 验证

- 基准 merge-base f54a99cc1e5d87982240c1b1ab6868594d31aa08。
- worker(Opus runtime_05352672):`vertical-script-actions.test.ts` 隔离 Linux runner 4/4、本机 macOS 4/4;变异检查(期望集含 `ELECTRON_RUN_AS_NODE`)fail 1;`daemon-thin-client-cli.test.ts` 13/13;production-delta 与 line-density 通过。
- CEO 读生产 diff。未跑:`check:local`(GitHub CI 是权威)。

## 评审证据

CEO 对照任务 plan 做语义核对:走删除分支是因为触发它的启动路径已不存在,阴性对照读的是真实子进程环境而非自报,没有兼容层残留。GitHub CI 是合并权威。

## 残余风险

若将来某个启动器又让 daemon 跑进 Electron,vertical script 会被当成 Electron 应用打开;封闭键集测试本身抓不到这点,要靠启动器改动时的评审。

