### PR TITLE
test: remove wall-clock verdicts from the PR critical path

### DIFF
--- a/packages/cli/test/daemon-thin-client-cli.test.ts
+++ b/packages/cli/test/daemon-thin-client-cli.test.ts
@@ -16,19 +16,17 @@ test("daemon process port hides detached startup windows", () => {
 test("daemon-missing write rejects without autostart or local fallback", () => {
   const root = mkdtempSync(path.join(tmpdir(), "ha-no-daemon-"));
   try {
-    // The pid/dir assertions prove that rejection does not autostart. The one-second bound
-    // catches the connect/hello backoff family without coupling the test to concurrent CI load.
-    const started = performance.now(),
-      result = spawnSync(
-        process.execPath,
-        [path.resolve("packages/cli/src/index.ts"), "--root", root, "--json", "task", "create", "--title", "No daemon"],
-        {
-          encoding: "utf8",
-          env: { ...process.env, HOME: path.join(root, ".home"), HARNESS_DAEMON_USER_ROOT: path.join(root, "user") },
-        },
-      );
-    const elapsedMs = performance.now() - started,
-      receipt = JSON.parse(result.stdout) as { ok: boolean; error: { code: string } };
+    // The pid/dir assertions prove that rejection does not autostart. Timing is observed by
+    // the nightly daemon soak lane because scheduler load makes a PR wall-clock verdict flaky.
+    const result = spawnSync(
+      process.execPath,
+      [path.resolve("packages/cli/src/index.ts"), "--root", root, "--json", "task", "create", "--title", "No daemon"],
+      {
+        encoding: "utf8",
+        env: { ...process.env, HOME: path.join(root, ".home"), HARNESS_DAEMON_USER_ROOT: path.join(root, "user") },
+      },
+    );
+    const receipt = JSON.parse(result.stdout) as { ok: boolean; error: { code: string } };
     assert.notEqual(result.status, 0);
     assert.equal(receipt.ok, false);
     assert.equal(receipt.error.code, "daemon_unavailable");
@@ -38,11 +36,6 @@ test("daemon-missing write rejects without autostart or local fallback", () => {
       existsSync(path.join(root, "user", "daemon-default.pid")),
       false,
       "an unregistered workspace must not launch a daemon",
-    );
-    assert.equal(
-      elapsedMs < 1_000,
-      true,
-      `source-mode diagnostic ${elapsedMs.toFixed(3)}ms reached the connect/hello backoff family`,
     );
   } finally {
     rmSync(root, { recursive: true, force: true });
@@ -89,8 +82,7 @@ test("daemon-missing doc submit is explicitly rejected without a local Git or sc
 test("daemon-missing preset run rejects promptly without child or direct fallback", () => {
   const root = mkdtempSync(path.join(tmpdir(), "ha-no-preset-daemon-"));
   try {
-    const started = performance.now(),
-      result = spawnSync(
+    const result = spawnSync(
         process.execPath,
         [
           path.resolve("packages/cli/src/index.ts"),
@@ -113,7 +105,6 @@ test("daemon-missing preset run rejects promptly without child or direct fallbac
       receipt = JSON.parse(result.stdout) as { error: { code: string } };
     assert.notEqual(result.status, 0);
     assert.equal(receipt.error.code, "daemon_unavailable");
-    assert.equal(performance.now() - started < 1_000, true);
     assert.equal(existsSync(path.join(root, ".harness")), false);
     assert.equal(
       existsSync(path.join(root, "user", "daemon-default.pid")),

--- a/tools/gates/test/canonical-event-compat.test.mjs
+++ b/tools/gates/test/canonical-event-compat.test.mjs
@@ -108,7 +108,7 @@ test("canonical event compatibility gate projects the locked history through pro
   const result = validateFrozenDaemonReadside(repoRoot());
   assert.deepEqual(result.errors, []);
   assert.equal(result.eventCount, 8);
-  assert.ok(result.durationMs < 8_000);
+  assert.equal(typeof result.durationMs, "number");
 });
 
 test("pre-#2158 relation strength history fails the production replay with its source event id", () => {


### PR DESCRIPTION
# English

## Summary

Three wall-clock verdicts on the PR critical path are removed. `packages/cli/test/daemon-thin-client-cli.test.ts` asserted that a missing-daemon write and a missing-daemon preset run each reject in under one second; both false-red under scheduler load (the last one on 2026-09-04 measured 1889 ms on a shared runner), and neither is what the tests prove. The deterministic guards stay: non-zero exit, a structured `daemon_unavailable` receipt, and the absence of any daemon pid file or workspace directory, which is the check that turns red the moment autostart or a local fallback is introduced. `tools/gates/test/canonical-event-compat.test.mjs` asserted the frozen read-side replay under 8000 ms; it now asserts only that the duration is reported, while every event and read-compatibility assertion is unchanged. The census of every timing assertion in `packages/*/test` and `tools/gates` is recorded in the task package: four PR wall-clock verdicts before, zero after; the remaining timing checks are either explicit product timeout contracts or nightly diagnostics.

## Architectural Justification

Not applicable by size; the change is test-only.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none

## Machine-Readable Declarations

Production-Delta: +0/-0
Dependency-Change: none

### Optional Evidence Claims

none

## Task And Scope

task_30efcfc36d9b70fb197f438fc8 (wall-clock and ratio assertions false-red on the PR critical path). Branch `codex/flaky-wallclock`. Public scope: two test files. Private planning/evidence updated: yes (timing census in the task package). Out of scope: the two fleet race tests (`fleet-lease-broker` first-starts, `fleet-transport` 64 uploads) are convergence races, not wall-clock verdicts, and are tracked in task_f9443002d6d995489ebf082911.

## Version Impact

No version change: no package is published from this change; publish impact none.

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none
- Authority: task_30efcfc36d9b70fb197f438fc8
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Follow-up governance task: not applicable

## Verification

- Base merge-base f54a99cc1e5d87982240c1b1ab6868594d31aa08.
- CEO on Node 24: `daemon-thin-client-cli.test.ts` 13/13, `canonical-event-compat.test.mjs` 9/9; `git diff --check` and prettier pass. The worker could not start these tests under Node 22; the CEO run is the evidence. Not run: `check:local` (GitHub CI is the authority).

## Review Evidence

CEO semantic review against the task plan: each removed verdict is a pure wall-clock bound with a retained structural guard beside it; no tier marker, gate manifest or threshold changed; the census names what was kept and why. GitHub CI is the merge authority.

## Residual Risk

A future regression that makes the missing-daemon rejection slow but still correct is no longer caught on the PR lane; the nightly daemon soak lane is where latency is observed.

# 中文

## 概要

删除 PR 关键路径上的三处墙钟判定。`packages/cli/test/daemon-thin-client-cli.test.ts` 断言 daemon 缺失时的写入与 preset run 各在一秒内拒绝;两者在调度负载下假红(2026-09-04 最近一次在共享 runner 上测到 1889 ms),而且都不是这两条测试要证明的东西。确定性守卫保留:非零退出、结构化的 `daemon_unavailable` 回执、没有任何 daemon pid 文件或 workspace 目录——一旦引入 autostart 或本地回退,这条立刻红。`tools/gates/test/canonical-event-compat.test.mjs` 断言冻结读侧回放在 8000 ms 内,现在只断言时长有上报,事件与读兼容断言一条未动。`packages/*/test` 与 `tools/gates` 里全部时序断言的盘点记录在任务包:PR 墙钟判定 4→0;其余时序检查要么是显式产品超时契约,要么是 nightly 诊断。

## 架构辩护

按体量不适用;纯测试改动。

## 机读声明

见英文块。

## 治理声明

- 触碰受保护面:否
- 受保护面范围:无
- 授权:task_30efcfc36d9b70fb197f438fc8
- 机器检查边界:本 PR 只断言声明存在,是否真实充分由评审判断。
- Break-glass:否
- Break-glass 原因:不适用
- 后续治理任务:不适用

## 验证

- 基准 merge-base f54a99cc1e5d87982240c1b1ab6868594d31aa08。
- CEO 在 Node 24 下:`daemon-thin-client-cli.test.ts` 13/13,`canonical-event-compat.test.mjs` 9/9;`git diff --check` 与 prettier 通过。worker 在 Node 22 下起不来这些测试,以 CEO 这次运行为证据。未跑:`check:local`(GitHub CI 是权威)。

## 评审证据

CEO 对照任务 plan 做语义核对:每处删除都是纯墙钟界限且旁边保留了结构守卫;没有改 tier marker、gate manifest 或阈值;census 写明保留了什么、为什么。GitHub CI 是合并权威。

## 残余风险

若将来 daemon 缺失时的拒绝变慢但仍正确,PR 面不再抓;时延由 nightly daemon soak lane 观测。

