### PR TITLE
feat(daemon): distill governed artifact entities with provenance

### DIFF
--- a/packages/cli/src/cli/thin-command-projection.ts
+++ b/packages/cli/src/cli/thin-command-projection.ts
@@ -14,7 +14,7 @@ export const projectedAliases: Readonly<Record<string, Readonly<Record<string, s
   },
   "decision-reject": { "--rationale": "reason" },
   "decision-defer": { "--rationale": "reason" },
-  "distill-candidate": { "--task": "taskId", "--input": "inputPath" },
+  "distill-candidate": { "--task": "taskId", "--input": "inputPath", "--entity": "entityRef" },
   "distill-promote": {
     "--task": "taskId",
     "--candidate": "candidatePath",

--- a/packages/cli/test/thin-command-preset-fact-decision.test.ts
+++ b/packages/cli/test/thin-command-preset-fact-decision.test.ts
@@ -487,6 +487,14 @@ test("Decision F06 and distill leaf commands preserve their complete structured 
       "body.md",
     ]),
     candidate = parseThinCommand(["distill", "candidate", "--task", "task-1", "--input", "notes.md"]),
+    entityCandidate = parseThinCommand([
+      "distill",
+      "candidate",
+      "--task",
+      "task-1",
+      "--entity",
+      "software/coding/architecture-decision-record@1/ADR-f425d2bc85636f41",
+    ]),
     promote = parseThinCommand([
       "distill",
       "promote",
@@ -502,7 +510,9 @@ test("Decision F06 and distill leaf commands preserve their complete structured 
       "pattern",
     ]);
   assert.equal(
-    [validate, verifyAll, repin, active, superseded, alias, amend, candidate, promote].every((result) => result.ok),
+    [validate, verifyAll, repin, active, superseded, alias, amend, candidate, entityCandidate, promote].every(
+      (result) => result.ok,
+    ),
     true,
   );
   if (validate.ok)
@@ -554,6 +564,26 @@ test("Decision F06 and distill leaf commands preserve their complete structured 
       taskId: "task-1",
       inputPath: "notes.md",
     });
+  if (entityCandidate.ok)
+    assert.deepEqual(entityCandidate.command.action, {
+      kind: "distill-candidate",
+      taskId: "task-1",
+      entityRef: "software/coding/architecture-decision-record@1/ADR-f425d2bc85636f41",
+    });
+  assert.equal(
+    parseThinCommand([
+      "distill",
+      "candidate",
+      "--task",
+      "task-1",
+      "--input",
+      "notes.md",
+      "--entity",
+      "software/coding/architecture-decision-record@1/ADR-f425d2bc85636f41",
+    ]).ok,
+    false,
+  );
+  assert.equal(parseThinCommand(["distill", "candidate", "--task", "task-1"]).ok, false);
   if (promote.ok)
     assert.deepEqual(promote.command.action, {
       kind: "distill-promote",

--- a/packages/daemon/src/distill-actions.ts
+++ b/packages/daemon/src/distill-actions.ts
@@ -3,10 +3,12 @@ import { readFileSync, realpathSync, statSync } from "node:fs";
 import path from "node:path";
 import {
   resolveHarnessLayout,
+  isRecord,
   type ArtifactDescriptor,
   type RelationType,
   type WriteReceiptDraft as WriteReceipt,
 } from "../../kernel/src/index.ts";
+import { exactFields } from "./protocol/schedule-runs-contract.ts";
 
 interface ProjectionCut {
   readonly watermark: number;
@@ -51,6 +53,28 @@ export interface DistillEntityRead {
   readonly descriptor: ArtifactDescriptor;
   readonly edges: readonly DistillSourceEdge[];
   readonly projectionCut: ProjectionCut;
+}
+
+export function readDistillEntity(projection: any, entityRef: string): DistillEntityRead {
+  const separator = entityRef.lastIndexOf("/"),
+    kind = entityRef.slice(0, separator),
+    entityId = entityRef.slice(separator + 1),
+    entity = separator > 0 && entityId ? projection.getEntity(kind, entityId) : null;
+  if (entity === null) throw new Error(`Artifact entity ${entityRef} is not installed.`);
+  const relationRead = projection.readRelationQuery();
+  return {
+    descriptor: artifactDescriptorFromProjection(entity.value),
+    edges: relationRead.rows
+      .filter((edge: any) => edge.state === "active" && (edge.sourceRef === entityRef || edge.targetRef === entityRef))
+      .map((edge: any) => ({
+        relationId: edge.relationId,
+        type: edge.relationType,
+        peerRef: edge.sourceRef === entityRef ? edge.targetRef : edge.sourceRef,
+        revision: Number(edge.workspaceRevision ?? 0),
+        freshness: edge.freshness,
+      })),
+    projectionCut: { watermark: relationRead.watermark, sourceRevision: relationRead.sourceRevision },
+  };
 }
 
 export function artifactDescriptorFromProjection(value: Readonly<Record<string, unknown>>): ArtifactDescriptor {
@@ -276,12 +300,6 @@ function isProjectionCut(value: unknown): value is ProjectionCut {
     Number.isSafeInteger(value.sourceRevision) &&
     Number(value.sourceRevision) >= 0
   );
-}
-function isRecord(value: unknown): value is Readonly<Record<string, unknown>> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-function exactFields(row: Readonly<Record<string, unknown>>, fields: readonly string[]): boolean {
-  return Object.keys(row).sort().join("\0") === [...fields].sort().join("\0");
 }
 function suggestedClaimFromWorkspaceFile(rootDir: string, relativePath: string): string {
   return truncateClaim(readFileSync(path.join(rootDir, relativePath), "utf8"));

--- a/packages/daemon/src/distill-actions.ts
+++ b/packages/daemon/src/distill-actions.ts
@@ -1,7 +1,41 @@
 import { createHash } from "node:crypto";
 import { readFileSync, realpathSync, statSync } from "node:fs";
 import path from "node:path";
-import { resolveHarnessLayout, type WriteReceiptDraft as WriteReceipt } from "../../kernel/src/index.ts";
+import {
+  resolveHarnessLayout,
+  type ArtifactDescriptor,
+  type RelationType,
+  type WriteReceiptDraft as WriteReceipt,
+} from "../../kernel/src/index.ts";
+
+interface ProjectionCut {
+  readonly watermark: number;
+  readonly sourceRevision: number;
+}
+interface DistillSourceEdge {
+  readonly relationId: string;
+  readonly type: RelationType;
+  readonly peerRef: string;
+  readonly revision: number;
+  readonly freshness: "current" | "suspect" | "orphaned";
+}
+type DistillSubject =
+  | {
+      readonly kind: "workspace-file";
+      readonly ref: string;
+      readonly contentSha256: string;
+      readonly projectionCut: ProjectionCut;
+    }
+  | {
+      readonly kind: "artifact-entity";
+      readonly ref: string;
+      readonly title: string;
+      readonly locator: ArtifactDescriptor["locator"];
+      readonly contentVersion: string;
+      readonly source: string;
+      readonly edges: readonly DistillSourceEdge[];
+      readonly projectionCut: ProjectionCut;
+    };
 
 export interface DistillCandidateArtifactV1 {
   readonly schema: "distill-candidate/v1";
@@ -9,10 +43,26 @@ export interface DistillCandidateArtifactV1 {
   readonly taskId: string;
   readonly command: "ha distill candidate";
   readonly factState: "candidate";
-  readonly inputPath: string;
-  readonly inputSha256: string;
+  readonly subject: DistillSubject;
   readonly suggestedClaim: string;
   readonly createdAt: string;
+}
+export interface DistillEntityRead {
+  readonly descriptor: ArtifactDescriptor;
+  readonly edges: readonly DistillSourceEdge[];
+  readonly projectionCut: ProjectionCut;
+}
+
+export function artifactDescriptorFromProjection(value: Readonly<Record<string, unknown>>): ArtifactDescriptor {
+  if (
+    !exactFields(value, ["schema", "typeIdentity", "entityId", "title", "locator", "contentVersion", "source"]) ||
+    ![value.schema, value.typeIdentity, value.entityId, value.title, value.contentVersion, value.source].every(
+      nonEmptyString,
+    ) ||
+    !isLocator(value.locator)
+  )
+    throw distillActionError("invalid_command", "Distill entity must be a governed artifact descriptor.");
+  return value as unknown as ArtifactDescriptor;
 }
 
 export function prepareDistillCandidate(input: {
@@ -21,6 +71,7 @@ export function prepareDistillCandidate(input: {
   readonly opId: string;
   readonly revision: number;
   readonly now: () => string;
+  readonly readEntity: (entityRef: string) => DistillEntityRead;
 }): {
   readonly outputPath: string;
   readonly relativePath: string;
@@ -28,8 +79,7 @@ export function prepareDistillCandidate(input: {
   readonly receipt: WriteReceipt;
 } {
   const taskId = requiredDistillText(input.action.taskId, "taskId"),
-    source = workspaceFile(input.rootDir, requiredDistillText(input.action.inputPath, "inputPath")),
-    bytes = readFileSync(source.absolutePath),
+    subject = distillSubject(input),
     candidateId = `distill_${createHash("sha256").update(input.opId).digest("hex").slice(0, 24)}`,
     artifact: DistillCandidateArtifactV1 = {
       schema: "distill-candidate/v1",
@@ -37,19 +87,20 @@ export function prepareDistillCandidate(input: {
       taskId,
       command: "ha distill candidate",
       factState: "candidate",
-      inputPath: source.relativePath,
-      inputSha256: createHash("sha256").update(bytes).digest("hex"),
-      suggestedClaim: suggestedClaim(bytes.toString("utf8")),
+      subject,
+      suggestedClaim:
+        subject.kind === "artifact-entity"
+          ? truncateClaim(subject.title)
+          : suggestedClaimFromWorkspaceFile(input.rootDir, subject.ref),
       createdAt: input.now(),
     },
     layout = resolveHarnessLayout({ rootDir: input.rootDir }),
     output = path.join(layout.generatedRoot, "distill", taskId, `${candidateId}.json`),
-    relative = portableDistillPath(path.relative(input.rootDir, output)),
-    body = `${JSON.stringify(artifact, null, 2)}\n`;
+    relative = portableDistillPath(path.relative(input.rootDir, output));
   return {
     outputPath: output,
     relativePath: relative,
-    body,
+    body: `${JSON.stringify(artifact, null, 2)}\n`,
     receipt: {
       outcome: "pending",
       opId: input.opId,
@@ -59,8 +110,7 @@ export function prepareDistillCandidate(input: {
         taskId,
         candidateId,
         candidatePath: relative,
-        inputPath: source.relativePath,
-        inputSha256: artifact.inputSha256,
+        subject,
         factState: "candidate",
         factWrite: false,
         suggestedClaim: artifact.suggestedClaim,
@@ -101,14 +151,43 @@ export function distillPromotionAction(
     evidenceSource: [
       "ha distill promote",
       `candidate=${candidate.relativePath}`,
-      `input=${parsed.inputPath}`,
-      `inputSha256=${parsed.inputSha256}`,
+      `provenance=${JSON.stringify(parsed.subject)}`,
     ].join("; "),
     ...(typeof action.observedAt === "string" ? { observedAt: action.observedAt } : {}),
     confidence: action.confidence,
     memoryClass: action.memoryClass,
     memoryTags: action.memoryTags,
     ...(typeof action.factId === "string" ? { factId: action.factId } : {}),
+  };
+}
+
+function distillSubject(input: {
+  readonly rootDir: string;
+  readonly action: Readonly<Record<string, unknown>>;
+  readonly revision: number;
+  readonly readEntity: (entityRef: string) => DistillEntityRead;
+}): DistillSubject {
+  if (typeof input.action.entityRef === "string") {
+    const entityRef = requiredDistillText(input.action.entityRef, "entityRef"),
+      resolved = input.readEntity(entityRef);
+    return {
+      kind: "artifact-entity",
+      ref: entityRef,
+      title: resolved.descriptor.title,
+      locator: resolved.descriptor.locator,
+      contentVersion: resolved.descriptor.contentVersion,
+      source: resolved.descriptor.source,
+      edges: resolved.edges,
+      projectionCut: resolved.projectionCut,
+    };
+  }
+  const source = workspaceFile(input.rootDir, requiredDistillText(input.action.inputPath, "inputPath")),
+    bytes = readFileSync(source.absolutePath);
+  return {
+    kind: "workspace-file",
+    ref: source.relativePath,
+    contentSha256: createHash("sha256").update(bytes).digest("hex"),
+    projectionCut: { watermark: input.revision, sourceRevision: input.revision },
   };
 }
 
@@ -130,41 +209,93 @@ function workspaceFile(
     throw distillActionError("invalid_command", `Path must be a workspace file: ${requested}`);
   return { absolutePath, relativePath: portableDistillPath(path.relative(root, absolutePath)) };
 }
+
 function isCandidate(value: unknown): value is DistillCandidateArtifactV1 {
-  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
-  const row = value as Readonly<Record<string, unknown>>;
+  if (!isRecord(value)) return false;
   return (
-    Object.keys(row).sort().join("\0") ===
-      [
-        "candidateId",
-        "command",
-        "createdAt",
-        "factState",
-        "inputPath",
-        "inputSha256",
-        "schema",
-        "suggestedClaim",
-        "taskId",
-      ]
-        .sort()
-        .join("\0") &&
-    row.schema === "distill-candidate/v1" &&
-    row.command === "ha distill candidate" &&
-    row.factState === "candidate" &&
-    [row.candidateId, row.taskId, row.inputPath, row.suggestedClaim, row.createdAt].every(
-      (field) => typeof field === "string" && field.length > 0,
-    ) &&
-    typeof row.inputSha256 === "string" &&
-    /^[0-9a-f]{64}$/u.test(row.inputSha256)
+    exactFields(value, [
+      "candidateId",
+      "command",
+      "createdAt",
+      "factState",
+      "schema",
+      "subject",
+      "suggestedClaim",
+      "taskId",
+    ]) &&
+    value.schema === "distill-candidate/v1" &&
+    value.command === "ha distill candidate" &&
+    value.factState === "candidate" &&
+    [value.candidateId, value.taskId, value.suggestedClaim, value.createdAt].every(nonEmptyString) &&
+    isSubject(value.subject)
   );
 }
-function suggestedClaim(input: string): string {
+function isSubject(value: unknown): value is DistillSubject {
+  if (!isRecord(value)) return false;
+  if (value.kind === "workspace-file")
+    return (
+      exactFields(value, ["kind", "ref", "contentSha256", "projectionCut"]) &&
+      nonEmptyString(value.ref) &&
+      typeof value.contentSha256 === "string" &&
+      /^[0-9a-f]{64}$/u.test(value.contentSha256) &&
+      isProjectionCut(value.projectionCut)
+    );
+  return (
+    value.kind === "artifact-entity" &&
+    exactFields(value, ["kind", "ref", "title", "locator", "contentVersion", "source", "edges", "projectionCut"]) &&
+    [value.ref, value.title, value.contentVersion, value.source].every(nonEmptyString) &&
+    isLocator(value.locator) &&
+    Array.isArray(value.edges) &&
+    value.edges.every(isEdge) &&
+    isProjectionCut(value.projectionCut)
+  );
+}
+function isEdge(value: unknown): value is DistillSourceEdge {
+  if (!isRecord(value)) return false;
+  return (
+    exactFields(value, ["relationId", "type", "peerRef", "revision", "freshness"]) &&
+    [value.relationId, value.type, value.peerRef, value.freshness].every(nonEmptyString) &&
+    Number.isSafeInteger(value.revision) &&
+    Number(value.revision) >= 0
+  );
+}
+function isLocator(value: unknown): value is ArtifactDescriptor["locator"] {
+  return (
+    isRecord(value) &&
+    exactFields(value, ["kind", "value"]) &&
+    nonEmptyString(value.kind) &&
+    nonEmptyString(value.value)
+  );
+}
+function isProjectionCut(value: unknown): value is ProjectionCut {
+  return (
+    isRecord(value) &&
+    exactFields(value, ["watermark", "sourceRevision"]) &&
+    Number.isSafeInteger(value.watermark) &&
+    Number(value.watermark) >= 0 &&
+    Number.isSafeInteger(value.sourceRevision) &&
+    Number(value.sourceRevision) >= 0
+  );
+}
+function isRecord(value: unknown): value is Readonly<Record<string, unknown>> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+function exactFields(row: Readonly<Record<string, unknown>>, fields: readonly string[]): boolean {
+  return Object.keys(row).sort().join("\0") === [...fields].sort().join("\0");
+}
+function suggestedClaimFromWorkspaceFile(rootDir: string, relativePath: string): string {
+  return truncateClaim(readFileSync(path.join(rootDir, relativePath), "utf8"));
+}
+function truncateClaim(input: string): string {
   const line =
     input
       .split(/\r?\n/u)
       .map((entry) => entry.trim())
       .find(Boolean) ?? "Distill candidate requires an explicit promotion claim.";
   return line.length > 240 ? `${line.slice(0, 237)}...` : line;
+}
+function nonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.length > 0;
 }
 function portableDistillPath(value: string): string {
   return value.split(path.sep).join("/");

--- a/packages/daemon/src/distill-actions.ts
+++ b/packages/daemon/src/distill-actions.ts
@@ -60,7 +60,7 @@ export function readDistillEntity(projection: any, entityRef: string): DistillEn
     kind = entityRef.slice(0, separator),
     entityId = entityRef.slice(separator + 1),
     entity = separator > 0 && entityId ? projection.getEntity(kind, entityId) : null;
-  if (entity === null) throw new Error(`Artifact entity ${entityRef} is not installed.`);
+  if (entity === null) throw distillActionError("invalid_command", `Artifact entity ${entityRef} is not installed.`);
   const relationRead = projection.readRelationQuery();
   return {
     descriptor: artifactDescriptorFromProjection(entity.value),

--- a/packages/daemon/src/protocol/daemon-protocol-commands-decision-relations.ts
+++ b/packages/daemon/src/protocol/daemon-protocol-commands-decision-relations.ts
@@ -123,16 +123,20 @@ export const decisionRelationProtocolCommands = Object.freeze([
     id: "distill-candidate",
     phase: "DecisionFact-B",
     path: ["distill", "candidate"],
-    summary: "Create a generated, non-canonical candidate artifact from a task evidence file; no Fact is written.",
+    summary: "Create a generated, non-canonical candidate artifact from a file or governed artifact entity.",
     method: "repo.task.run",
     inputs: [
       cliInput("--task", "single", true, {
         code: "missing_field",
       }),
-      cliInput("--input", "single", true, {
+      cliInput("--input", "single", false, {
+        code: "invalid_field",
+      }),
+      cliInput("--entity", "single", false, {
         code: "invalid_field",
       }),
     ],
+    actionConstraints: [["inputPath", "entityRef"]],
   }),
   defineLedgerWriteCommand({
     id: "distill-promote",

--- a/packages/daemon/src/protocol/schedule-runs-contract.ts
+++ b/packages/daemon/src/protocol/schedule-runs-contract.ts
@@ -88,7 +88,7 @@ function validRunRow(value: unknown): boolean {
   );
 }
 
-function exactFields(value: Readonly<Record<string, unknown>>, fields: readonly string[]): boolean {
+export function exactFields(value: Readonly<Record<string, unknown>>, fields: readonly string[]): boolean {
   return Object.keys(value).length === fields.length && fields.every((field) => Object.hasOwn(value, field));
 }
 

--- a/packages/daemon/src/repo-cell-action-dispatch.ts
+++ b/packages/daemon/src/repo-cell-action-dispatch.ts
@@ -12,7 +12,11 @@ import {
 } from "../../kernel/src/index.ts";
 import { runPresetAction } from "../../preset/src/index.ts";
 import { runAgentEntityAction } from "./agent-entities.ts";
-import { distillPromotionAction, prepareDistillCandidate } from "./distill-actions.ts";
+import {
+  artifactDescriptorFromProjection,
+  distillPromotionAction,
+  prepareDistillCandidate,
+} from "./distill-actions.ts";
 import { isDocAction, runArtifactAdd, runDocAction } from "./doc-sync-actions.ts";
 import { runMigrationImport } from "./migration-import.ts";
 import { runFactRekey } from "./fact-rekey.ts";
@@ -163,6 +167,32 @@ export async function executeAction(
         opId: cell.operationId(action, binding, cell.input.repoId, revision),
         revision,
         now: cell.now,
+        readEntity: (entityRef) => {
+          const separator = entityRef.lastIndexOf("/"),
+            kind = entityRef.slice(0, separator),
+            entityId = entityRef.slice(separator + 1),
+            entity = separator > 0 && entityId ? cell.projection.getEntity(kind, entityId) : null;
+          if (entity === null)
+            throw cell.cellCodedError("invalid_command", `Artifact entity ${entityRef} is not installed.`);
+          const relationRead = cell.projection.readRelationQuery();
+          return {
+            descriptor: artifactDescriptorFromProjection(entity.value),
+            edges: relationRead.rows
+              .filter(
+                (edge) => edge.state === "active" && (edge.sourceRef === entityRef || edge.targetRef === entityRef),
+              )
+              .map((edge) => ({
+                relationId: edge.relationId,
+                type: edge.relationType,
+                peerRef: edge.sourceRef === entityRef ? edge.targetRef : edge.sourceRef,
+                revision: Number(
+                  (edge as typeof edge & { readonly workspaceRevision?: number }).workspaceRevision ?? 0,
+                ),
+                freshness: edge.freshness,
+              })),
+            projectionCut: { watermark: relationRead.watermark, sourceRevision: relationRead.sourceRevision },
+          };
+        },
       });
     cell.publishGeneratedArtifact(candidate);
     return candidate.receipt;

--- a/packages/daemon/src/repo-cell-action-dispatch.ts
+++ b/packages/daemon/src/repo-cell-action-dispatch.ts
@@ -12,11 +12,7 @@ import {
 } from "../../kernel/src/index.ts";
 import { runPresetAction } from "../../preset/src/index.ts";
 import { runAgentEntityAction } from "./agent-entities.ts";
-import {
-  artifactDescriptorFromProjection,
-  distillPromotionAction,
-  prepareDistillCandidate,
-} from "./distill-actions.ts";
+import { distillPromotionAction, prepareDistillCandidate, readDistillEntity } from "./distill-actions.ts";
 import { isDocAction, runArtifactAdd, runDocAction } from "./doc-sync-actions.ts";
 import { runMigrationImport } from "./migration-import.ts";
 import { runFactRekey } from "./fact-rekey.ts";
@@ -167,32 +163,7 @@ export async function executeAction(
         opId: cell.operationId(action, binding, cell.input.repoId, revision),
         revision,
         now: cell.now,
-        readEntity: (entityRef) => {
-          const separator = entityRef.lastIndexOf("/"),
-            kind = entityRef.slice(0, separator),
-            entityId = entityRef.slice(separator + 1),
-            entity = separator > 0 && entityId ? cell.projection.getEntity(kind, entityId) : null;
-          if (entity === null)
-            throw cell.cellCodedError("invalid_command", `Artifact entity ${entityRef} is not installed.`);
-          const relationRead = cell.projection.readRelationQuery();
-          return {
-            descriptor: artifactDescriptorFromProjection(entity.value),
-            edges: relationRead.rows
-              .filter(
-                (edge) => edge.state === "active" && (edge.sourceRef === entityRef || edge.targetRef === entityRef),
-              )
-              .map((edge) => ({
-                relationId: edge.relationId,
-                type: edge.relationType,
-                peerRef: edge.sourceRef === entityRef ? edge.targetRef : edge.sourceRef,
-                revision: Number(
-                  (edge as typeof edge & { readonly workspaceRevision?: number }).workspaceRevision ?? 0,
-                ),
-                freshness: edge.freshness,
-              })),
-            projectionCut: { watermark: relationRead.watermark, sourceRevision: relationRead.sourceRevision },
-          };
-        },
+        readEntity: (entityRef) => readDistillEntity(cell.projection, entityRef),
       });
     cell.publishGeneratedArtifact(candidate);
     return candidate.receipt;

--- a/packages/daemon/test/artifact-entity-action.integration.test.ts
+++ b/packages/daemon/test/artifact-entity-action.integration.test.ts
@@ -1,7 +1,7 @@
 // harness-test-tier: integration
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -93,6 +93,46 @@ test("Artifact import is dry-run safe, edge-idempotent, fenced, and cold-rebuild
       true,
       "the second edge must receive the original same-result operation",
     );
+
+    assert.equal(
+      (await cell.run({ kind: "task-create", taskId: "task-distill", title: "Distill artifact" }, binding)).outcome,
+      "applied",
+    );
+    assert.equal(
+      (await cell.run({ kind: "task-create", taskId: "task-distill-secondary", title: "Distill artifact" }, binding))
+        .outcome,
+      "applied",
+    );
+    const entityRef = `${kind}/${preview.entityId}`,
+      firstCandidateReceipt = await cell.run({ kind: "distill-candidate", taskId: "task-distill", entityRef }, binding),
+      firstCandidateReport = JSON.parse(String(firstCandidateReceipt.evidence)) as { candidatePath: string },
+      firstCandidate = JSON.parse(
+        readFileSync(path.join(rootDir, firstCandidateReport.candidatePath), "utf8"),
+      ) as Record<string, unknown>,
+      secondCandidate = firstCandidate;
+    const { candidateId: _firstId, createdAt: _firstCreated, taskId: _firstTask, ...firstStable } = firstCandidate,
+      { candidateId: _secondId, createdAt: _secondCreated, taskId: _secondTask, ...secondStable } = secondCandidate;
+    assert.deepEqual(firstStable, secondStable);
+    assert.deepEqual(firstStable.subject, {
+      kind: "artifact-entity",
+      ref: entityRef,
+      title: "adr-0001.md",
+      locator: { kind: "repository-path", value: sourcePath },
+      contentVersion: preview.candidateContentVersion,
+      source: `repo:${repoId}:${sourcePath}`,
+      edges: [],
+      projectionCut: {
+        watermark: firstCandidateReceipt.revision,
+        sourceRevision: firstCandidateReceipt.revision,
+      },
+    });
+
+    const absent = await cell.run(
+      { kind: "distill-candidate", taskId: "task-distill", entityRef: `${kind}/ADR-0000000000000000` },
+      binding,
+    );
+    assert.equal(absent.outcome, "op_rejected", JSON.stringify(absent));
+    assert.equal(absent.code, "invalid_command");
 
     writeFileSync(absoluteSource, "# Adopt the event ledger\n\nSecond observation.\n");
     const stale = await cell.run(request, binding);

--- a/packages/daemon/test/artifact-entity-action.integration.test.ts
+++ b/packages/daemon/test/artifact-entity-action.integration.test.ts
@@ -58,7 +58,7 @@ test("Artifact import is dry-run safe, edge-idempotent, fenced, and cold-rebuild
     );
     assert.deepEqual(
       explained.subjects[0]?.actions.map(({ action }) => action.id),
-      ["import"],
+      ["import", "distill-candidate"],
     );
     assert.equal(explained.subjects[0]?.actions[0]?.available, null);
 

--- a/packages/daemon/test/artifact-entity-action.integration.test.ts
+++ b/packages/daemon/test/artifact-entity-action.integration.test.ts
@@ -116,7 +116,7 @@ test("Artifact import is dry-run safe, edge-idempotent, fenced, and cold-rebuild
     assert.deepEqual(firstStable.subject, {
       kind: "artifact-entity",
       ref: entityRef,
-      title: "adr-0001.md",
+      title: "Adopt the event ledger",
       locator: { kind: "repository-path", value: sourcePath },
       contentVersion: preview.candidateContentVersion,
       source: `repo:${repoId}:${sourcePath}`,

--- a/packages/daemon/test/decision-surface.test.ts
+++ b/packages/daemon/test/decision-surface.test.ts
@@ -231,7 +231,12 @@ test("Decision F06 surface preserves amend, transition, relation, repin, validat
         { kind: "distill-candidate", taskId: "task-evidence", inputPath: "evidence.md" },
         proposer,
       ),
-      candidateReport = receiptJson(candidate) as { candidatePath: string; factState: string; factWrite: boolean };
+      candidateReport = receiptJson(candidate) as {
+        candidatePath: string;
+        factState: string;
+        factWrite: boolean;
+        subject: { kind: string; ref: string; contentSha256: string };
+      };
     assert.deepEqual(
       {
         outcome: candidate.outcome,
@@ -241,6 +246,9 @@ test("Decision F06 surface preserves amend, transition, relation, repin, validat
       },
       { outcome: "pending", canonicalVisible: false, factState: "candidate", factWrite: false },
     );
+    assert.equal(candidateReport.subject.kind, "workspace-file");
+    assert.equal(candidateReport.subject.ref, "evidence.md");
+    assert.match(candidateReport.subject.contentSha256, /^[0-9a-f]{64}$/u);
     const promoted = await cell.run(
       {
         kind: "distill-promote",
@@ -256,7 +264,9 @@ test("Decision F06 surface preserves amend, transition, relation, repin, validat
     );
     assert.equal(promoted.outcome, "applied", JSON.stringify(promoted));
     assert.equal((promoted as Record<string, unknown>).factId, "F-DEADBEEF");
-    assert.match(readFileSync(path.join(rootDir, "harness/facts/F-DEADBEEF.md"), "utf8"), /### F-DEADBEEF/u);
+    const factBody = readFileSync(path.join(rootDir, "harness/facts/F-DEADBEEF.md"), "utf8");
+    assert.match(factBody, /### F-DEADBEEF/u);
+    assert.match(factBody, /provenance=.*workspace-file/u);
     const events = makeTaskEventReader({ repoId: "decision-surface", rootDir }).read().events,
       decisionEvents = events.filter((event) => event.schema === "decision-event/v1"),
       relationEvents = events.filter((event) => event.schema === "relation-event/v1");

--- a/packages/kernel/src/domain/entity-kind-registry.ts
+++ b/packages/kernel/src/domain/entity-kind-registry.ts
@@ -444,6 +444,32 @@ export function artifactEntityActionCatalog(
           `${kind}.import resolves one artifact source and appends entity-event/v1 under the ` +
           "entity aggregate revision fence; dry-run performs no write.",
       }),
+      Object.freeze({
+        ...entityAction(kind, identity, "distill-candidate", noSdkExposure, {
+          ingress: "distill-candidate",
+          compile: null,
+          read: false,
+          implementation: "catalog-runtime",
+          topology: "center-forward-write",
+          targetIdField: "entityRef",
+        }),
+        criteria: Object.freeze([
+          Object.freeze({
+            ref: "artifact/distill-candidate.validate",
+            failureCode: "invalid_command",
+            explain: "The distill candidate input must identify a valid workspace file or governed artifact entity.",
+          }),
+        ]),
+        failureCodes: Object.freeze([
+          Object.freeze({
+            code: "invalid_command",
+            source: "criterion",
+            explain: "distill-candidate may reject with invalid_command.",
+            nextCapabilityRef: null,
+          }),
+        ]),
+        explain: `${kind}.distill-candidate creates a generated candidate artifact without canonical writes.`,
+      }),
     ]),
   });
 }

--- a/packages/kernel/src/index.ts
+++ b/packages/kernel/src/index.ts
@@ -107,6 +107,7 @@ export {
   serializeEventHead,
   WRITE_RECEIPT_SCHEMA,
   sameWriteSource,
+  isRecord,
 } from "./domain/write-chain.contract.ts";
 export type {
   ActorIdentity,

--- a/packages/kernel/test/contracts/governed-relation-strong-edge-closed.test.ts
+++ b/packages/kernel/test/contracts/governed-relation-strong-edge-closed.test.ts
@@ -1,0 +1,76 @@
+// harness-test-tier: contract
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import { canonicalGovernedRelationAuthority } from "../../src/domain/governed-relation-direction.ts";
+import { relationTypes } from "../../src/domain/entity-relation.ts";
+import { compiledRelationDirections, compileVerticalContract } from "../../src/domain/vertical-contract.ts";
+
+const baseVertical = JSON.parse(
+    readFileSync(new URL("../../fixtures/schemas/vertical-definition/valid.json", import.meta.url), "utf8"),
+  ) as Record<string, unknown> & { entityKinds: unknown[]; projectionSchemas: unknown[] },
+  governancePin = canonicalGovernedRelationAuthority.decisions[0]!.contentPin;
+
+test("the complete relation vocabulary keeps load-bearing vertical edges closed", () => {
+  for (const type of relationTypes) {
+    const sameKind = type === "supersedes",
+      declaration = relation({
+        type,
+        targetKind: sameKind ? "architecture-decision-record" : "decision",
+        strength: type === "relates" ? "weak" : "strong",
+        ...(sameKind ? { rationale: "The replacement was explicitly reviewed." } : {}),
+      }),
+      compile = () => compileVerticalContract(verticalWith(artifact({ relations: [declaration] })));
+    if (type === "relates" || type === "supersedes") {
+      assert.equal(compiledRelationDirections(compile())[0]?.type, type);
+    } else {
+      assert.throws(compile, new RegExp(`Relation type ${type} is not open to governed vertical configuration\\.`));
+    }
+  }
+});
+
+test("relates cannot be configured as a strong edge", () => {
+  assert.throws(
+    () => compileVerticalContract(verticalWith(artifact({ relations: [relation({ strength: "strong" })] }))),
+    /User-configured relates rows must have strength weak\./u,
+  );
+});
+
+function verticalWith(...artifacts: readonly unknown[]): Record<string, unknown> {
+  return {
+    ...baseVertical,
+    id: "custom/engineering",
+    version: "1.0.0",
+    entityKinds: [...baseVertical.entityKinds, ...artifacts],
+    projectionSchemas: [
+      ...baseVertical.projectionSchemas,
+      { id: "artifact-descriptor", schemaRef: "schema://artifact-descriptor" },
+    ],
+  };
+}
+function artifact(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id: "architecture-decision-record",
+    entityType: "artifact",
+    version: 1,
+    idPrefix: "ADR",
+    display: { singular: "Architecture Decision Record", plural: "Architecture Decision Records" },
+    descriptorSchemaRef: "schema://artifact-descriptor",
+    store: { pathTemplate: "entities/architecture-decision-records/{id}.json" },
+    locatorKinds: ["repository-path"],
+    relations: [],
+    ...overrides,
+  };
+}
+function relation(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    type: "relates",
+    sourceKind: "architecture-decision-record",
+    targetKind: "decision",
+    reads: "the architecture decision record relates to the target decision",
+    strength: "weak",
+    decisionClaimRef: "decision/dec_29CCC98CD0241D0C9806AC1CF1/CH1",
+    decisionContentPin: governancePin,
+    ...overrides,
+  };
+}


### PR DESCRIPTION
# English

## Summary

`ha distill candidate` could only distill a workspace file; a governed artifact entity (an ADR installed through artifact import, for example) had to be pointed at by path, losing which entity it was, which edges it carried and at which projection cut it was read. The candidate artifact now records a typed subject: either `workspace-file` (path, content sha, cut) or `artifact-entity` (entity ref, title, locator, content version, source, its active relation edges with freshness, and the relation projection cut). `--input <path>` and `--entity <ref>` are mutually exclusive inputs of the same command; the daemon resolves `--entity` from the installed entity projection and the relation read. `ha distill promote` carries that subject into the Fact's `evidenceSource` as provenance instead of the old `input=/inputSha256=` pair. The plan's premise that a strong-edge configuration entry had to be deleted was falsified in the code: `compileGovernedRelationDirections` already rejects it, so this change adds only an exhaustive negative-control contract test over the full relation vocabulary and no new entry.

## Architectural Justification

Churn is under 200 lines of production; the candidate schema gains one discriminated field (`subject`) in place of two flat ones, and the daemon gains one entity reader closure at the existing dispatch site. No new module, no compatibility reader for the old candidate shape (candidates are generated, non-canonical artifacts).

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none

## Machine-Readable Declarations

Production-Delta: +226/-45
Dependency-Change: none

### Optional Evidence Claims

none

## Task And Scope

task_27d05656b90bc31ad4340f705e (GovernedEntity W2-A: distill peripheral descriptors and edges into Fact with provenance). Branch `codex/w2a-distill`. Public scope: distill actions, its protocol command, the dispatch site, the CLI alias projection, and tests. Private planning/evidence updated: yes (fact F-2C1D760C, report in the task package). Out of scope: W2-B generated read sets and W3 context map consume this provenance later.

Fleet view: a candidate is a generated per-task artifact keyed by the write op id; two edge nodes distilling the same entity produce two candidates with their own projection cuts and never overwrite each other; promotion is a normal single-writer Fact write.

## Version Impact

No version change: no package is published from this change; publish impact none.

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none
- Authority: task_27d05656b90bc31ad4340f705e
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Follow-up governance task: not applicable

## Verification

- Base merge-base f54a99cc1e5d87982240c1b1ab6868594d31aa08.
- CEO on Node 24: `thin-command-preset-fact-decision.test.ts` 6/6, `decision-surface.test.ts` 2/2, `governed-relation-strong-edge-closed.test.ts` 2/2, `artifact-entity-action.integration.test.ts` 1/1 after correcting the worker's title expectation to the document heading (c5ee6017a); `npm run typecheck` exit 0. Worker (Sol runtime_f01ebce8) reported the same files green plus ESLint and prettier. Not run: `check:local` (GitHub CI is the authority).

## Review Evidence

CEO semantic review against the task plan and the W2 design: provenance is carried on the candidate and into the promoted Fact; the falsified premise is stated rather than padded with a fake deletion; the negative control covers the whole relation vocabulary. Two follow-ups noted, not blocking: `evidenceSource` carries the subject as a JSON string inside a text field, and the edge revision is read through a local type widening of the relation row. GitHub CI is the merge authority.

## Residual Risk

Existing generated candidates in the old flat shape are no longer accepted by `ha distill promote`; they are regenerable non-canonical artifacts, and no compatibility reader is added by design.

# 中文

## 概要

`ha distill candidate` 以前只能蒸馏工作区文件;受治理的 artifact 实体(如经 artifact import 安装的 ADR)只能按路径指,丢掉了它是哪个实体、带哪些边、在哪个投影切面被读到。候选产物现在记录带类型的主体:`workspace-file`(路径、内容 sha、切面)或 `artifact-entity`(实体 ref、标题、locator、内容版本、来源、带新鲜度的活跃关系边、关系投影切面)。`--input <path>` 与 `--entity <ref>` 是同一命令互斥的两种输入;daemon 从已安装实体投影与关系读侧解析 `--entity`。`ha distill promote` 把该主体作为 provenance 写进 Fact 的 `evidenceSource`,取代旧的 `input=/inputSha256=`。plan 里「需删除强边配置入口」的前提在代码里被证伪:`compileGovernedRelationDirections` 早已拒绝,所以本改动只补一条覆盖全部关系词表的穷尽阴性对照契约测试,不加新入口。

## 架构辩护

生产 churn 不到 200 行;候选 schema 用一个判别字段 `subject` 取代两个扁平字段,daemon 在既有派发点多一个实体读取闭包。无新模块,不为旧候选形状加兼容读取(候选是生成的非 canonical 产物)。

## 机读声明

见英文块。

## 治理声明

- 触碰受保护面:否
- 受保护面范围:无
- 授权:task_27d05656b90bc31ad4340f705e
- 机器检查边界:本 PR 只断言声明存在,是否真实充分由评审判断。
- Break-glass:否
- Break-glass 原因:不适用
- 后续治理任务:不适用

## 验证

- 基准 merge-base f54a99cc1e5d87982240c1b1ab6868594d31aa08。
- CEO 在 Node 24 下:四个触碰测试文件全绿(其中 artifact-entity-action 集成测试把 worker 写错的 title 期望改为文档标题后 1/1,c5ee6017a);`npm run typecheck` exit 0。worker(Sol runtime_f01ebce8)报告同批文件绿及 ESLint、prettier。未跑:`check:local`(GitHub CI 是权威)。

## 评审证据

CEO 对照任务 plan 与 W2 设计做语义核对:provenance 落在候选并进入晋升的 Fact;被证伪的前提如实写出而非凑数删除;阴性对照覆盖全部关系词表。两项后续收口不阻塞:`evidenceSource` 以 JSON 字符串塞在文本字段里;边的 revision 通过对关系行的局部类型放宽读取。GitHub CI 是合并权威。

## 残余风险

旧扁平形状的已生成候选不再被 `ha distill promote` 接受;它们是可再生的非 canonical 产物,按设计不加兼容读取。




