### PR TITLE
feat(runtime): dispatch independent reviewers with --role reviewer

### DIFF
--- a/packages/cli/src/cli/thin-command-runtime.ts
+++ b/packages/cli/src/cli/thin-command-runtime.ts
@@ -44,6 +44,7 @@ export function parseRuntime(
     agentId = f.one.get("--agent"),
     targetAgentId = f.one.get("--to"),
     squadId = f.one.get("--squad");
+  const role = f.one.get("--role");
   if (targetAgentId && !agentId)
     return rejected("invalid_field", "Use --to <worker-agent-id> only with --agent <leader-agent-id>.", json);
   if (squadId && !agentId)
@@ -58,6 +59,7 @@ export function parseRuntime(
       ...(agentId ? { agentId } : {}),
       ...(targetAgentId ? { targetAgentId } : {}),
       ...(squadId ? { squadId } : {}),
+      ...(role ? { role } : {}),
       ...(f.one.get("--model") ? { model: f.one.get("--model") } : {}),
       ...(f.one.get("--effort") ? { effort: f.one.get("--effort") } : {}),
       ...(f.booleans.has("--fast") ? { fast: true } : {}),

--- a/packages/daemon/src/protocol/daemon-protocol-commands-runtime-fleet.ts
+++ b/packages/daemon/src/protocol/daemon-protocol-commands-runtime-fleet.ts
@@ -24,6 +24,7 @@ export const runtimeFleetProtocolCommands = Object.freeze([
       cliInput("--agent", "single", false, {
         code: "invalid_field",
       }),
+      cliInput("--role", "single", false, { code: "invalid_field" }, { enum: ["reviewer"] }),
       cliInput("--to", "single", false, {
         code: "invalid_field",
       }),

--- a/packages/daemon/src/protocol/daemon-protocol-rpc-validation.ts
+++ b/packages/daemon/src/protocol/daemon-protocol-rpc-validation.ts
@@ -388,6 +388,7 @@ export function validateGuiActionPayload(method: DaemonGuiActionMethod, value: u
       (value.agentId !== undefined && !nonEmpty(value.agentId)) ||
       (value.targetAgentId !== undefined && !nonEmpty(value.targetAgentId)) ||
       (value.squadId !== undefined && !nonEmpty(value.squadId)) ||
+      (value.role !== undefined && value.role !== "reviewer") ||
       (value.model !== undefined && !nonEmpty(value.model)) ||
       (value.effort !== undefined && !nonEmpty(value.effort)) ||
       (value.fast !== undefined && typeof value.fast !== "boolean") ||

--- a/packages/daemon/src/repo-cell-proof.ts
+++ b/packages/daemon/src/repo-cell-proof.ts
@@ -134,7 +134,11 @@ export async function proofFor(
         : undefined;
     if (!reviewCriterion)
       throw new Error(`Task review criterion ${REVIEW_PROOF_CRITERION} has no capability evaluation.`);
-    if (runtimeBinding !== null)
+    const executionActor = execution?.actor,
+      leaseHolder = snapshot.lease?.executionId === command.executionId ? snapshot.lease.actor : null,
+      runtimeIsExecutionActor = executionActor !== undefined && isSamePerson(executionActor, command.actor),
+      runtimeHoldsLease = leaseHolder !== null && isSamePerson(leaseHolder, command.actor);
+    if (runtimeBinding !== null && (runtimeIsExecutionActor || runtimeHoldsLease))
       throw cellCriterionError(
         "runtime_task_self_review_forbidden",
         "Task review runtime-binding independence proof was not satisfied.",

--- a/packages/daemon/src/runtime-spawner.ts
+++ b/packages/daemon/src/runtime-spawner.ts
@@ -229,6 +229,7 @@ export function makeRuntimeSpawner(input: RuntimeSpawnerInput) {
         "agentId",
         "targetAgentId",
         "squadId",
+        "role",
         "model",
         "effort",
         "fast",
@@ -266,6 +267,7 @@ export function makeRuntimeSpawner(input: RuntimeSpawnerInput) {
           ? undefined
           : requiredRuntimeSpawnText(payload.targetAgentId, "targetAgentId"),
       squadId = payload.squadId === undefined ? undefined : requiredRuntimeSpawnText(payload.squadId, "squadId"),
+      role = payload.role === undefined ? undefined : requiredRuntimeSpawnText(payload.role, "role"),
       // Delegation provenance: which already-running runtime session invoked this spawn.
       parentRuntimeSessionId = runtimeSessionIdFromActor(binding.actor),
       model = payload.model === undefined ? undefined : requiredRuntimeSpawnText(payload.model, "model"),

--- a/packages/daemon/src/runtime-spawner.ts
+++ b/packages/daemon/src/runtime-spawner.ts
@@ -310,6 +310,7 @@ export function makeRuntimeSpawner(input: RuntimeSpawnerInput) {
       store = input.remote ? null : requiredRuntimeStore(input),
       projection = input.remote ? null : requiredRuntimeProjection(input),
       remoteTask = taskId && input.remote ? await input.remote.taskContext(taskId, missionName) : null;
+    const reviewerBinding = role === "reviewer";
     if (taskId && !input.remote)
       await waitForTaskProjection({
         budget: projectionWaitBudget(waitProjectionMs),
@@ -333,7 +334,7 @@ export function makeRuntimeSpawner(input: RuntimeSpawnerInput) {
       dispatchOpId = `runtime-spawn-${hash.slice(0, 32)}`,
       trustedHandoffSource = handoffFromRuntimeSessionId ?? resumed?.header.runtimeSessionId ?? null;
     const authorizationDecision: AuthorizationDecision | null = binding.authorizationDecision ?? null;
-    if (taskId && !input.remote) {
+    if (taskId && !input.remote && !reviewerBinding) {
       const callerRuntimeSessionId = runtimeSessionIdFromActor(binding.actor),
         runtimeBinding =
           callerRuntimeSessionId === null || leaseAtAdmission === null
@@ -368,8 +369,8 @@ export function makeRuntimeSpawner(input: RuntimeSpawnerInput) {
           runtimeTaskLeaseRequiredMessage(taskId, leaseAtAdmission),
         );
     }
-    const daemonRoute = taskId || trustedSchedule ? input.runtimeDaemonRoute : undefined;
-    if ((taskId || trustedSchedule) && !daemonRoute)
+    const daemonRoute = taskId || trustedSchedule || reviewerBinding ? input.runtimeDaemonRoute : undefined;
+    if ((taskId || trustedSchedule || reviewerBinding) && !daemonRoute)
       throw runtimeSpawnError(
         "runtime_preconditions_unavailable",
         "Task-bound and scheduled runtime spawn require a sealed daemon route before dispatch.",
@@ -540,7 +541,7 @@ export function makeRuntimeSpawner(input: RuntimeSpawnerInput) {
     // same lease generation. Direct runtime/batch dispatches still transfer ownership even when
     // they select a squad member through --to.
     const taskLeaseHandoff =
-        taskId && !input.remote && reviewExecution === null && !retainCoordinatorTaskLease
+        taskId && !input.remote && !reviewerBinding && reviewExecution === null && !retainCoordinatorTaskLease
           ? input.handoffTaskLease
           : undefined,
       activeBinding = taskLeaseHandoff
@@ -561,7 +562,7 @@ export function makeRuntimeSpawner(input: RuntimeSpawnerInput) {
     // Enforced runtimes replace HOME and TMPDIR, so a task worker needs the daemon's sealed callback
     // route as well as its own executor identity.
     const workerLaunch =
-      (taskId || trustedSchedule) && daemonRoute
+      (taskId || trustedSchedule || reviewerBinding) && daemonRoute
         ? {
             ...prepared,
             env: {

--- a/packages/daemon/test/runtime-spawn-lifecycle.integration.test.ts
+++ b/packages/daemon/test/runtime-spawn-lifecycle.integration.test.ts
@@ -159,7 +159,7 @@ test("runtime spawn publishes a canonical session and makes it visible in overvi
           error.code === "invalid_runtime_spawn" &&
           error.message ===
             'Runtime spawn payload contains an unknown field "permission_mode"; allowed fields: "runtimeInstanceId", ' +
-              '"dispatchId", "agentId", "targetAgentId", "squadId", "model", "effort", "fast", "permissionMode", "cwd", ' +
+              '"dispatchId", "agentId", "targetAgentId", "squadId", "role", "model", "effort", "fast", "permissionMode", "cwd", ' +
               '"prompt", "promptSource", "missionName", "waitProjectionMs", "onExitCommand", "taskId", "idempotencyKey", ' +
               '"providerSessionId".',
       );


### PR DESCRIPTION
# English

## Summary

An independent reviewer could not be dispatched against a task. A task-bound runtime (`--task`) is admitted as the task's executor and takes its lease, so its `review-execution` is refused as self-review; a prompt-only runtime is never given the sealed daemon route (enforced runtimes replace HOME and TMPDIR), so its ledger writes fail with `daemon_unavailable`. This PR adds `ha runtime run <instance> --task <task-id> --role reviewer`: the mission is still derived from the task package and the dispatch still belongs to the task, but the spawner skips executor admission and the task-lease handoff for a reviewer, and always injects the daemon route. The self-review proof now refuses only a runtime that is the execution's actor or holds the task lease, instead of any runtime bound to the task. The existing independence diagnostics stay green, including the case where the executor runtime is still forbidden.

## Architectural Justification

Not applicable by size; seventeen production lines across the CLI flag, protocol validation, spawner and proof.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none

## Machine-Readable Declarations

Production-Delta: +17/-6
Dependency-Change: none

### Optional Evidence Claims

none

## Task And Scope

task_b45c8a60cad5001e291f40fbcb (independent reviewer dispatch friction). Branch `codex/reviewer-binding`. Public scope: runtime run CLI flag, protocol command and validation, runtime spawner, repo-cell proof. Private planning/evidence updated: yes (facts F-FFDEB033, F-71DF9B50, F-250D79AA). Out of scope, still open on the task: the principal path for an execution submitted with `executor=null` (`declare-executor` still answers `invalid_proof`) and a spawner-level contract fixture for the reviewer role; the first live use of `--role reviewer` against the three merged tasks currently stuck in review is the acceptance for this slice.

Fleet view: a reviewer runtime owns no lease and no execution, so several nodes may review the same task concurrently and produce independent review records; the review id is caller-chosen and duplicates are refused by the store.

## Version Impact

No version change: no package is published from this change; publish impact none.

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none
- Authority: task_b45c8a60cad5001e291f40fbcb
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Follow-up governance task: not applicable

## Verification

- Base merge-base f54a99cc1e5d87982240c1b1ab6868594d31aa08.
- Worker (Sol runtime_f53c4b0c) and CEO on Node 24: `npm run typecheck` exit 0; `packages/daemon/test/review-independence-diagnostics.integration.test.ts` 4/4; line-density and file-complexity pass. No new automated test in this slice; see Task And Scope for what remains open. Not run: `check:local` (GitHub CI is the authority).

## Review Evidence

CEO semantic review against the task plan: the command shape is the plan's first option; the reviewer path removes executor admission and lease handoff rather than adding a bypass; the proof narrows to actor-or-lease-holder. The missing contract fixture and the principal path are recorded on the task, not glossed. GitHub CI is the merge authority.

## Residual Risk

A reviewer runtime still receives `HARNESS_TASK_BOUND=1` and the task-bound git push restriction, which is intended; whether every ledger write a reviewer needs is admitted without a lease is proven only by the first live review, tracked on the task.

# 中文

## 概要

独立 reviewer 派不出去:绑 `--task` 的 runtime 被当作 executor 接管并占 lease,它写 `review-execution` 会被判自审;只给 `--prompt` 的 runtime 拿不到 daemon 路由(enforced runtime 替换 HOME/TMPDIR),写台账 `daemon_unavailable`。本 PR 加 `ha runtime run <instance> --task <task-id> --role reviewer`:mission 仍从任务包派生、dispatch 仍归属该 task,但 spawner 对 reviewer 跳过 executor 准入与 lease 交接,并始终注入 daemon 路由。自审证明改为只拒绝「是该 execution 的 actor 或持有该 task lease」的 runtime,而不是任何绑定到该 task 的 runtime。既有独立性诊断测试保持绿,含 executor runtime 仍被拒的那条。

## 架构辩护

按体量不适用;CLI 旗标、协议校验、spawner、proof 共十七行生产改动。

## 机读声明

见英文块。

## 治理声明

- 触碰受保护面:否
- 受保护面范围:无
- 授权:task_b45c8a60cad5001e291f40fbcb
- 机器检查边界:本 PR 只断言声明存在,是否真实充分由评审判断。
- Break-glass:否
- Break-glass 原因:不适用
- 后续治理任务:不适用

## 验证

- 基准 merge-base f54a99cc1e5d87982240c1b1ab6868594d31aa08。
- worker(Sol runtime_f53c4b0c)与 CEO 在 Node 24 下:`npm run typecheck` exit 0;`review-independence-diagnostics.integration.test.ts` 4/4;line-density、file-complexity 通过。本切片没有新增自动化测试;未完成项见任务与范围。未跑:`check:local`(GitHub CI 是权威)。

## 评审证据

CEO 对照任务 plan 做语义核对:命令形状是 plan 的第一选项;reviewer 路径是删掉 executor 准入与 lease 交接而不是加旁路;proof 收窄为 actor 或 lease holder。缺失的契约 fixture 与 principal 路径记在任务上,没有掩盖。GitHub CI 是合并权威。

## 残余风险

reviewer runtime 仍带 `HARNESS_TASK_BOUND=1` 与 task-bound 的 git push 限制(这是有意的);reviewer 需要的每一种台账写入是否都能在无 lease 下被准入,只由第一次真实复核证明,记在任务上。
