### PR TITLE
fix(daemon): accept the reviewer role in the runtime spawn payload shape

### DIFF
--- a/packages/daemon/src/protocol/daemon-protocol-gui-actions.ts
+++ b/packages/daemon/src/protocol/daemon-protocol-gui-actions.ts
@@ -69,8 +69,7 @@ export const daemonGuiActionMethods = Object.freeze([
     "/api/tasks/:taskId/submit",
     "repo-write",
   ),
-  // Pin/unpin is a named ingress onto task-amend, not a second path; the closed
-  // payload and actionDefaults keep WriteCoordinator/event/projection canonical.
+  // Pin/unpin is a named ingress onto task-amend, not a second path; its closed payload keeps the write canonical.
   guiAction(
     "task.pin",
     "repo.task.pin",
@@ -222,6 +221,7 @@ export const daemonGuiActionMethods = Object.freeze([
       agentId: "string?",
       targetAgentId: "string?",
       squadId: "string?",
+      role: "string?",
       model: "string?",
       effort: "string?",
       fast: "boolean?",


### PR DESCRIPTION
# English

## Summary

`ha runtime run <instance> --task <id> --role reviewer` (#2213) never reached the spawner. The CLI sends the flag as `payload.role`, and the daemon's RPC parser validates every payload against the contracted shape in `daemon-protocol-gui-actions.ts` before dispatch; that shape did not declare `role`, so the call was refused as `invalid_request` (reproduced with `parseDaemonRpcParams`: unknown field "role", allowed fields end at "executor"). The shape now declares `role` as an optional string; the existing enum check (`reviewer` only) in the RPC validation and the spawner's own field list already cover it. The file is a shrink-only G0-5 baseline at 456 lines, so the added field is paid for by folding a two-line comment into one; the ratchet reports delta 0.

## Architectural Justification

Not applicable by size.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none

## Machine-Readable Declarations

Production-Delta: +2/-2
Dependency-Change: none

### Optional Evidence Claims

none

## Task And Scope

task_b45c8a60cad5001e291f40fbcb (independent reviewer dispatch). Branch `codex/reviewer-role-payload`. Public scope: one payload shape line and one comment. Private planning/evidence updated: yes. Out of scope: the principal path for executor-less executions and the reviewer contract fixture, still open on the task.

## Version Impact

No version change: no package is published from this change; publish impact none.

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none
- Authority: task_b45c8a60cad5001e291f40fbcb
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Follow-up governance task: not applicable

## Verification

- CEO on Node 24: `parseDaemonRpcParams("repo.agentRuntime.spawn", …role: "reviewer"…)` ok (was unknown-field); `json-rpc-protocol.test.ts` 53/53; `runtime-spawn-lifecycle.integration.test.ts` 6/6; G0-5 ratchet delta 0; prettier pass. Not run: `check:local` (GitHub CI is the authority).

## Review Evidence

CEO found and fixed this while making the first live reviewer dispatch against a stuck task; the live dispatch is the acceptance and will be recorded on the task. GitHub CI is the merge authority.

## Residual Risk

None beyond the open items already on the task.

# 中文

## 概要

`ha runtime run <instance> --task <id> --role reviewer`(#2213)从未到达 spawner:CLI 把旗标作为 `payload.role` 发出,daemon 的 RPC 解析器在派发前按 `daemon-protocol-gui-actions.ts` 里契约化的形状校验每个 payload,该形状没有声明 `role`,于是整个调用被判 `invalid_request`(用 `parseDaemonRpcParams` 复现:未知字段 "role",允许字段到 "executor" 为止)。现在形状声明 `role` 为可选字符串;RPC 校验里既有的枚举检查(只允许 `reviewer`)与 spawner 自己的字段清单已经覆盖它。该文件是 456 行的 G0-5 shrink-only 基线文件,新增字段的一行由把两行注释并成一行抵消;ratchet 报 delta 0。

## 架构辩护

按体量不适用。

## 机读声明

见英文块。

## 治理声明

- 触碰受保护面:否
- 受保护面范围:无
- 授权:task_b45c8a60cad5001e291f40fbcb
- 机器检查边界:本 PR 只断言声明存在,是否真实充分由评审判断。
- Break-glass:否
- Break-glass 原因:不适用
- 后续治理任务:不适用

## 验证

- CEO 在 Node 24 下:`parseDaemonRpcParams` 带 role 通过(此前未知字段);`json-rpc-protocol.test.ts` 53/53;`runtime-spawn-lifecycle.integration.test.ts` 6/6;G0-5 ratchet delta 0;prettier 通过。未跑:`check:local`(GitHub CI 是权威)。

## 评审证据

CEO 在对一个卡住任务做首次真实 reviewer 派工时发现并修复;那次真实派工就是验收,记在任务上。GitHub CI 是合并权威。

## 残余风险

除任务上已开的项目外无。
