### PR TITLE
feat(preset): declare the external-issue artifact kind as the second governed artifact caller

### DIFF
--- a/packages/preset/assets/software-coding/vertical.json
+++ b/packages/preset/assets/software-coding/vertical.json
@@ -59,6 +59,32 @@
           "decisionContentPin": "sha256:f8ccb58e91a8da7c67fe57d1e02e78bdb1bf1972abc721d4a542d27f5919ffdb"
         }
       ]
+    },
+    {
+      "id": "external-issue",
+      "entityType": "artifact",
+      "version": 1,
+      "idPrefix": "ISSUE",
+      "display": {
+        "singular": "External Issue",
+        "plural": "External Issues"
+      },
+      "descriptorSchemaRef": "schema://artifact-descriptor",
+      "store": {
+        "pathTemplate": "entities/external-issues/{id}.json"
+      },
+      "locatorKinds": ["url", "external-key"],
+      "relations": [
+        {
+          "type": "relates",
+          "sourceKind": "external-issue",
+          "targetKind": "task",
+          "reads": "the external issue relates to the target task for traceability",
+          "strength": "weak",
+          "decisionClaimRef": "decision/dec_29CCC98CD0241D0C9806AC1CF1/CH1",
+          "decisionContentPin": "sha256:f8ccb58e91a8da7c67fe57d1e02e78bdb1bf1972abc721d4a542d27f5919ffdb"
+        }
+      ]
     }
   ],
   "contractEntityKinds": ["task", "decision", "fact"],

--- a/packages/preset/test/preset-resolver-vertical-scripts.test.ts
+++ b/packages/preset/test/preset-resolver-vertical-scripts.test.ts
@@ -292,6 +292,27 @@ test("software coding declaration closes lifecycle, repository, projection, and 
         },
       ],
     },
+    {
+      id: "external-issue",
+      entityType: "artifact",
+      version: 1,
+      idPrefix: "ISSUE",
+      display: { singular: "External Issue", plural: "External Issues" },
+      descriptorSchemaRef: "schema://artifact-descriptor",
+      store: { pathTemplate: "entities/external-issues/{id}.json" },
+      locatorKinds: ["url", "external-key"],
+      relations: [
+        {
+          type: "relates",
+          sourceKind: "external-issue",
+          targetKind: "task",
+          reads: "the external issue relates to the target task for traceability",
+          strength: "weak",
+          decisionClaimRef: "decision/dec_29CCC98CD0241D0C9806AC1CF1/CH1",
+          decisionContentPin: "sha256:f8ccb58e91a8da7c67fe57d1e02e78bdb1bf1972abc721d4a542d27f5919ffdb",
+        },
+      ],
+    },
   ]);
   assert.deepEqual(vertical.contractEntityKinds, ["task", "decision", "fact"]);
   assert.deepEqual(


### PR DESCRIPTION
# English

## Summary

Declare a second artifact kind, `external-issue`, in the `software/coding` vertical (GovernedEntity W2-C) to prove the generic artifact-entity abstraction has a second caller. The kind uses the `ISSUE` id prefix, `url` and `external-key` locators, the generic entity store path template, and one weak `relates` edge to `task` pinned to the standing relation decision. No kind-specific code was needed, which is the point of the slice.

## Architectural Justification

The W1 series turned ADR into a vertical-declared artifact entity and removed every ADR special case. A single declared kind cannot show that the abstraction is generic; this PR adds the second kind purely as configuration plus contract tests. `grep -rn architecture-decision-record packages --include='*.ts' | grep -v test` finds no production branch keyed on the kind name, so there was nothing to delete in the same slice.

## What Changed

- `packages/preset/assets/software-coding/vertical.json`: new `entityKinds[]` entry `external-issue@1`.
- `packages/preset/test/preset-resolver-vertical-scripts.test.ts`: the vertical contract test now asserts both artifact kinds resolve and validate.

## Gate Harvest / 门收割

No gate change. Kind declarations are validated by `ArtifactEntityKindSchema` and the preset three-path (validate / discovery / create) tests.

## Machine-Readable Declarations

Production-Delta: +0/-0
Dependency-Change: none

### Optional Evidence Claims

none

## Task And Scope

task_caaf85f421d2c9bcc22d67ece7 (GovernedEntity W2-C: second artifact kind pilot). Branch `codex/w2c-second-kind`. Scope: the vertical declaration and its preset contract test. The real ledger import and edge (Goal criteria 2 and 3) run against the canonical daemon after this merges, because the resident daemon only knows the kinds declared in the checked-out vertical; the GUI visibility criterion (4) is verified on the W2-0 surface that landed in #2215.

Fleet view: an external-issue entity is an aggregate under the entity revision fence like any other artifact kind; two edge nodes importing the same URL produce one entity with two observations, never two files.

## Version Impact

No version change; publish impact none.

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none
- Authority: task_caaf85f421d2c9bcc22d67ece7
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Follow-up governance task: not applicable

## Verification

- Base merge-base baa00112fa05d6c010b0668f7fbdde2b58d5e215.
- Worker (Sol, codex-api) on the touched preset tests: 10/10 pass.
- CI is the complete authority for the rest.

## Review Evidence

CEO semantic review: the declaration mirrors the ADR entry shape (`vertical.json:38-62`), the relation triple cites the in-effect relation decision `dec_29CCC98CD0241D0C9806AC1CF1/CH1` with its content pin, and no kind-specific mechanism was added. Criteria 2-4 are deliberately post-merge and tracked on the task.

## Residual Risk

The import/edge proof is not in this PR; if the daemon rejects `external-issue@1` import after merge, that is an abstraction defect to fix in the generic path, not a reason to add a kind-specific branch.

# 中文

## 概要

在 `software/coding` vertical 里声明第二个 artifact kind `external-issue`(GovernedEntity W2-C),证明通用实体抽象有第二个调用方。`ISSUE` 前缀、`url`/`external-key` locator、通用存储路径模板、一条指向 task 的弱 `relates` 边(钉在常设关系 decision 上)。全程不需要任何 kind 专属代码。

## 架构辩护

W1 已把 ADR 做成 vertical 声明的通用实体并删光特例;只有一个 kind 证明不了抽象是通用的。本 PR 只加配置和契约测试。生产路径 grep 不到按 kind 名硬编码的分支,同片无可删项。

## 机读声明

生产行数增减(与上文机读声明一致):+0/-0

## 治理声明

- 触碰受保护面:否
- 授权:task_caaf85f421d2c9bcc22d67ece7
- Break-glass:否

## 验证

Sol 在触碰的 preset 测试上 10/10;其余以 CI 为准。

## 评审证据

CEO 语义复核:声明形态与 ADR 一致,关系三元组引用 in_effect 的 decision claim 并带 content pin,无 kind 专属机制。判据 2-4 合并后在 canonical daemon 上完成,记在任务上。

## 残余风险

导入/建边证明不在本 PR;若合并后 daemon 拒绝 import,那是通用路径的缺陷,不得加 kind 专属分支。
