### PR TITLE
fix(daemon): settle a worker exit with live descendants or a dirty worktree as unknown

### DIFF
--- a/packages/daemon/src/runtime-provider-fault.ts
+++ b/packages/daemon/src/runtime-provider-fault.ts
@@ -97,11 +97,14 @@ function runtimeExitOutcome(active: ActiveRuntime, exitCode: number | null): Run
   if (active.cancelRequested) return "cancelled";
   if (exitCode === null) return "unknown";
   if (exitCode !== 0) return "failed";
-  return active.providerOutcome === "failed" ? "failed" : "succeeded";
+  if (active.providerOutcome === "failed") return "failed";
+  return active.descendantsAlive || active.worktreeDirty ? "unknown" : "succeeded";
 }
 
 function workerStopReason(active: ActiveRuntime, outcome: RuntimeExitOutcome): string {
   if (outcome === "succeeded") return "Worker completed the attempt successfully.";
+  if (active.descendantsAlive) return "Worker exited while descendant processes are still running.";
+  if (active.worktreeDirty) return "Worker exited with uncommitted changes in its worktree.";
   if (active.protocolError) return "Worker exited with incomplete provider protocol evidence; outcome is unknown.";
   return "Worker exited without a structured provider outcome; outcome is unknown.";
 }

--- a/packages/daemon/src/runtime-spawn-active.ts
+++ b/packages/daemon/src/runtime-spawn-active.ts
@@ -22,6 +22,8 @@ type ActiveRuntimeBase = Omit<
   | "lossReason"
   | "lossSignal"
   | "lossExitCode"
+  | "descendantsAlive"
+  | "worktreeDirty"
   | "toolCallObserved"
   | "providerFault"
   | "fallbackAttempt"
@@ -50,6 +52,8 @@ export function createActiveRuntime(base: ActiveRuntimeBase): ActiveRuntime {
     lossReason: null,
     lossSignal: null,
     lossExitCode: null,
+    descendantsAlive: false,
+    worktreeDirty: false,
     toolCallObserved: false,
     providerFault: null,
   };

--- a/packages/daemon/src/runtime-spawn-process.ts
+++ b/packages/daemon/src/runtime-spawn-process.ts
@@ -172,7 +172,7 @@ type PosixProcessRow = {
   readonly processGroupId: number;
 };
 
-export async function readPosixProcessRows(): Promise<readonly PosixProcessRow[]> {
+async function readPosixProcessRows(): Promise<readonly PosixProcessRow[]> {
   const output = await runProcessTextAsync("ps", ["-axo", "pid=,ppid=,pgid="]);
   return output.split(/\r?\n/u).flatMap((line) => {
     const match = /^\s*(\d+)\s+(\d+)\s+(\d+)/u.exec(line);
@@ -181,7 +181,7 @@ export async function readPosixProcessRows(): Promise<readonly PosixProcessRow[]
   });
 }
 
-export function descendantProcessRows(rows: readonly PosixProcessRow[], rootPid: number): readonly PosixProcessRow[] {
+function descendantProcessRows(rows: readonly PosixProcessRow[], rootPid: number): readonly PosixProcessRow[] {
   const selected = new Set([rootPid]);
   let changed = true;
   while (changed) {
@@ -193,6 +193,22 @@ export function descendantProcessRows(rows: readonly PosixProcessRow[], rootPid:
       }
   }
   return rows.filter((row) => selected.has(row.pid) || row.processGroupId === rootPid);
+}
+
+// A worker that backgrounds work and then ends its turn leaves that work behind: the provider's
+// children are reparented away from it, so only the process group the detached host leads still
+// names them. Settlement asks this on the machine that launched the host — the only machine whose
+// process table means anything for this dispatch — and answers "still running" whenever the table
+// cannot be read, because an unreadable table is not evidence that the tree is empty.
+export async function runtimeDescendantsAlive(rootPid: number): Promise<boolean> {
+  if (process.platform === "win32" || !Number.isInteger(rootPid) || rootPid < 1) return false;
+  try {
+    const rows = descendantProcessRows(await readPosixProcessRows(), rootPid);
+    return rows.some(({ pid }) => pid !== rootPid && runtimePidIsAlive(pid));
+  } catch (error) {
+    consumeKnownError(error);
+    return true;
+  }
 }
 
 function signalRuntimeTargets(

--- a/packages/daemon/src/runtime-spawn-process.ts
+++ b/packages/daemon/src/runtime-spawn-process.ts
@@ -172,7 +172,7 @@ type PosixProcessRow = {
   readonly processGroupId: number;
 };
 
-async function readPosixProcessRows(): Promise<readonly PosixProcessRow[]> {
+export async function readPosixProcessRows(): Promise<readonly PosixProcessRow[]> {
   const output = await runProcessTextAsync("ps", ["-axo", "pid=,ppid=,pgid="]);
   return output.split(/\r?\n/u).flatMap((line) => {
     const match = /^\s*(\d+)\s+(\d+)\s+(\d+)/u.exec(line);
@@ -181,7 +181,7 @@ async function readPosixProcessRows(): Promise<readonly PosixProcessRow[]> {
   });
 }
 
-function descendantProcessRows(rows: readonly PosixProcessRow[], rootPid: number): readonly PosixProcessRow[] {
+export function descendantProcessRows(rows: readonly PosixProcessRow[], rootPid: number): readonly PosixProcessRow[] {
   const selected = new Set([rootPid]);
   let changed = true;
   while (changed) {
@@ -192,7 +192,7 @@ function descendantProcessRows(rows: readonly PosixProcessRow[], rootPid: number
         changed = true;
       }
   }
-  return rows.filter((row) => selected.has(row.pid));
+  return rows.filter((row) => selected.has(row.pid) || row.processGroupId === rootPid);
 }
 
 function signalRuntimeTargets(

--- a/packages/daemon/src/runtime-spawn-settlement.ts
+++ b/packages/daemon/src/runtime-spawn-settlement.ts
@@ -1,9 +1,10 @@
 import { createHash } from "node:crypto";
 import type { AgentRuntimeEventV1, CanonicalEventStore, RuntimeResultClaim } from "../../kernel/src/index.ts";
 import { consumeKnownError } from "../../kernel/src/index.ts";
-import { readDispatchStream, scrubProviderValue } from "./dispatch-stream.ts";
+import { scrubProviderValue } from "./dispatch-stream.ts";
 import { archiveRuntimeDispatch, type RuntimeDispatchArchive } from "./doc-sync-actions.ts";
 import { consumeDurableOutput } from "./runtime-spawn-provider-stream.ts";
+import { runtimeDescendantsAlive } from "./runtime-spawn-process.ts";
 import type { ActiveRuntime } from "./runtime-spawn-types.ts";
 import { pushWorkerBranch, workerWorktreeDirty } from "./runtime-worker-push.ts";
 import { classifyRuntimeExit } from "./runtime-provider-fault.ts";
@@ -38,8 +39,10 @@ export async function publishExit(
         (code === 0 && (active.finalText === null || active.providerOutcome === null)))
     )
       context.markProtocolError(active);
-    if (!cancelled) {
-      active.descendantsAlive = recordedDescendantsAlive(context.input.rootDir, active.dispatchId, active.process.pid);
+    // Only a clean provider exit can still be claimed as success, so only that exit is worth the
+    // two observations that can take the claim away (`runtimeExitOutcome` reads them nowhere else).
+    if (!cancelled && code === 0) {
+      active.descendantsAlive = await runtimeDescendantsAlive(active.process.pid);
       if (active.task)
         active.worktreeDirty = await workerWorktreeDirty({
           cwd: active.cwd,
@@ -245,13 +248,6 @@ export async function publishExit(
   } finally {
     context.exiting.delete(active.runtimeSessionId);
   }
-}
-
-function recordedDescendantsAlive(rootDir: string, dispatchId: string, rootPid: number): boolean {
-  const record = readDispatchStream(rootDir, dispatchId)?.records.findLast(
-    (value) => value.kind === "process_descendants" && Number(value.rootPid) === rootPid,
-  );
-  return Array.isArray(record?.pids) && record.pids.some((value) => Number(value) !== rootPid);
 }
 
 function runtimeSessionBinding(binding: ActiveRuntime["binding"], runtimeSessionId: string): ActiveRuntime["binding"] {

--- a/packages/daemon/src/runtime-spawn-settlement.ts
+++ b/packages/daemon/src/runtime-spawn-settlement.ts
@@ -1,11 +1,11 @@
 import { createHash } from "node:crypto";
 import type { AgentRuntimeEventV1, CanonicalEventStore, RuntimeResultClaim } from "../../kernel/src/index.ts";
 import { consumeKnownError } from "../../kernel/src/index.ts";
-import { scrubProviderValue } from "./dispatch-stream.ts";
+import { readDispatchStream, scrubProviderValue } from "./dispatch-stream.ts";
 import { archiveRuntimeDispatch, type RuntimeDispatchArchive } from "./doc-sync-actions.ts";
 import { consumeDurableOutput } from "./runtime-spawn-provider-stream.ts";
 import type { ActiveRuntime } from "./runtime-spawn-types.ts";
-import { pushWorkerBranch } from "./runtime-worker-push.ts";
+import { pushWorkerBranch, workerWorktreeDirty } from "./runtime-worker-push.ts";
 import { classifyRuntimeExit } from "./runtime-provider-fault.ts";
 import { runtimeErrorCode, runtimeErrorMessage } from "./runtime-spawn-errors.ts";
 import type { RuntimeSpawnerContext } from "./runtime-spawn-context.ts";
@@ -38,6 +38,14 @@ export async function publishExit(
         (code === 0 && (active.finalText === null || active.providerOutcome === null)))
     )
       context.markProtocolError(active);
+    if (!cancelled) {
+      active.descendantsAlive = recordedDescendantsAlive(context.input.rootDir, active.dispatchId, active.process.pid);
+      if (active.task)
+        active.worktreeDirty = await workerWorktreeDirty({
+          cwd: active.cwd,
+          canonicalRoot: context.input.rootDir,
+        });
+    }
     const { outcome: initialOutcome, ...classifiedAttempt } = classifyRuntimeExit(active, code),
       attemptOutcome = {
         ...classifiedAttempt,
@@ -237,6 +245,13 @@ export async function publishExit(
   } finally {
     context.exiting.delete(active.runtimeSessionId);
   }
+}
+
+function recordedDescendantsAlive(rootDir: string, dispatchId: string, rootPid: number): boolean {
+  const record = readDispatchStream(rootDir, dispatchId)?.records.findLast(
+    (value) => value.kind === "process_descendants" && Number(value.rootPid) === rootPid,
+  );
+  return Array.isArray(record?.pids) && record.pids.some((value) => Number(value) !== rootPid);
 }
 
 function runtimeSessionBinding(binding: ActiveRuntime["binding"], runtimeSessionId: string): ActiveRuntime["binding"] {

--- a/packages/daemon/src/runtime-spawn-types.ts
+++ b/packages/daemon/src/runtime-spawn-types.ts
@@ -140,6 +140,8 @@ export type ActiveRuntime = {
   lossReason: string | null;
   lossSignal: string | null;
   lossExitCode: number | null;
+  descendantsAlive: boolean;
+  worktreeDirty: boolean;
   toolCallObserved: boolean;
   providerFault: RuntimeProviderFault | null;
 };

--- a/packages/daemon/src/runtime-worker-host.ts
+++ b/packages/daemon/src/runtime-worker-host.ts
@@ -1,7 +1,6 @@
 import { spawn } from "node:child_process";
 import { consumeKnownError } from "../../kernel/src/index.ts";
 import { appendRuntimeWorkerRecord, scrubProviderValue } from "./dispatch-stream.ts";
-import { descendantProcessRows, readPosixProcessRows, runtimePidIsAlive } from "./runtime-spawn-process.ts";
 
 type RuntimeWorkerManifest = {
   readonly rootDir: string;
@@ -47,28 +46,22 @@ async function runRuntimeWorkerHost(): Promise<void> {
       chunk: scrubProviderValue(chunk) as string,
     }),
   );
-  const finish = async (exitCode: number | null, signal: NodeJS.Signals | null): Promise<void> => {
+  const finish = (exitCode: number | null, signal: NodeJS.Signals | null): void => {
     if (settled) return;
     settled = true;
     consumeOutput("", true);
-    if (process.platform !== "win32") {
-      const rows = descendantProcessRows(await readPosixProcessRows(), process.pid).filter(({ pid }) =>
-        runtimePidIsAlive(pid),
-      );
-      append({ kind: "process_descendants", rootPid: process.pid, pids: rows.map(({ pid }) => pid) });
-    }
     append({ kind: "process_exit", exitCode, signal });
   };
   child.once("error", (error) => {
     append({ kind: "provider_stderr", chunk: scrubProviderValue(error.message) as string });
+    finish(null, null);
   });
+  child.once("close", finish);
   process.once("SIGTERM", () => {
     if (!settled) child.kill("SIGTERM");
   });
   child.stdin.end(manifest.prompt);
-  await new Promise<void>((resolve, reject) =>
-    child.once("close", (exitCode, signal) => void finish(exitCode, signal).then(resolve, reject)),
-  );
+  await new Promise<void>((resolve) => child.once("close", () => resolve()));
 }
 
 function appendProviderLine(append: (value: Readonly<Record<string, unknown>>) => void, line: string): void {

--- a/packages/daemon/src/runtime-worker-host.ts
+++ b/packages/daemon/src/runtime-worker-host.ts
@@ -1,6 +1,7 @@
 import { spawn } from "node:child_process";
 import { consumeKnownError } from "../../kernel/src/index.ts";
 import { appendRuntimeWorkerRecord, scrubProviderValue } from "./dispatch-stream.ts";
+import { descendantProcessRows, readPosixProcessRows, runtimePidIsAlive } from "./runtime-spawn-process.ts";
 
 type RuntimeWorkerManifest = {
   readonly rootDir: string;
@@ -15,11 +16,11 @@ type RuntimeWorkerManifest = {
 
 async function runRuntimeWorkerHost(): Promise<void> {
   const manifest = parseManifest(await readStandardInput());
-  const append = (value: Readonly<Record<string, unknown>>): void => appendRuntimeWorkerRecord(
-    manifest.rootDir,
-    manifest.dispatchId,
-    { occurredAt: new Date().toISOString(), ...value },
-  );
+  const append = (value: Readonly<Record<string, unknown>>): void =>
+    appendRuntimeWorkerRecord(manifest.rootDir, manifest.dispatchId, {
+      occurredAt: new Date().toISOString(),
+      ...value,
+    });
   const child = spawn(manifest.executablePath, [...manifest.args], {
     cwd: manifest.cwd,
     env: manifest.env,
@@ -40,30 +41,37 @@ async function runRuntimeWorkerHost(): Promise<void> {
     if (flush && trailing.trim()) appendProviderLine(append, trailing);
   };
   child.stdout.on("data", (chunk: string) => consumeOutput(chunk));
-  child.stderr.on("data", (chunk: string) => append({
-    kind: "provider_stderr",
-    chunk: scrubProviderValue(chunk) as string,
-  }));
-  const finish = (exitCode: number | null, signal: NodeJS.Signals | null): void => {
+  child.stderr.on("data", (chunk: string) =>
+    append({
+      kind: "provider_stderr",
+      chunk: scrubProviderValue(chunk) as string,
+    }),
+  );
+  const finish = async (exitCode: number | null, signal: NodeJS.Signals | null): Promise<void> => {
     if (settled) return;
     settled = true;
     consumeOutput("", true);
+    if (process.platform !== "win32") {
+      const rows = descendantProcessRows(await readPosixProcessRows(), process.pid).filter(({ pid }) =>
+        runtimePidIsAlive(pid),
+      );
+      append({ kind: "process_descendants", rootPid: process.pid, pids: rows.map(({ pid }) => pid) });
+    }
     append({ kind: "process_exit", exitCode, signal });
   };
   child.once("error", (error) => {
     append({ kind: "provider_stderr", chunk: scrubProviderValue(error.message) as string });
-    finish(null, null);
   });
-  child.once("close", finish);
-  process.once("SIGTERM", () => { if (!settled) child.kill("SIGTERM"); });
+  process.once("SIGTERM", () => {
+    if (!settled) child.kill("SIGTERM");
+  });
   child.stdin.end(manifest.prompt);
-  await new Promise<void>((resolve) => child.once("close", () => resolve()));
+  await new Promise<void>((resolve, reject) =>
+    child.once("close", (exitCode, signal) => void finish(exitCode, signal).then(resolve, reject)),
+  );
 }
 
-function appendProviderLine(
-  append: (value: Readonly<Record<string, unknown>>) => void,
-  line: string,
-): void {
+function appendProviderLine(append: (value: Readonly<Record<string, unknown>>) => void, line: string): void {
   try {
     append({ kind: "provider_event", event: scrubProviderValue(JSON.parse(line)) });
   } catch (error) {
@@ -80,17 +88,18 @@ async function readStandardInput(): Promise<string> {
 function parseManifest(value: string): RuntimeWorkerManifest {
   const parsed: unknown = JSON.parse(value);
   if (
-    !isRuntimeWorkerRecord(parsed)
-    || typeof parsed.rootDir !== "string"
-    || typeof parsed.dispatchId !== "string"
-    || typeof parsed.executablePath !== "string"
-    || !Array.isArray(parsed.args)
-    || !parsed.args.every((arg) => typeof arg === "string")
-    || typeof parsed.cwd !== "string"
-    || !isRuntimeWorkerRecord(parsed.env)
-    || typeof parsed.prompt !== "string"
-    || typeof parsed.windowsVerbatimArguments !== "boolean"
-  ) throw new Error("runtime worker manifest is invalid");
+    !isRuntimeWorkerRecord(parsed) ||
+    typeof parsed.rootDir !== "string" ||
+    typeof parsed.dispatchId !== "string" ||
+    typeof parsed.executablePath !== "string" ||
+    !Array.isArray(parsed.args) ||
+    !parsed.args.every((arg) => typeof arg === "string") ||
+    typeof parsed.cwd !== "string" ||
+    !isRuntimeWorkerRecord(parsed.env) ||
+    typeof parsed.prompt !== "string" ||
+    typeof parsed.windowsVerbatimArguments !== "boolean"
+  )
+    throw new Error("runtime worker manifest is invalid");
   return parsed as RuntimeWorkerManifest;
 }
 function isRuntimeWorkerRecord(value: unknown): value is Record<string, unknown> {

--- a/packages/daemon/src/runtime-worker-push.ts
+++ b/packages/daemon/src/runtime-worker-push.ts
@@ -1,28 +1,40 @@
 import { execFile } from "node:child_process";
 import { realpathSync } from "node:fs";
 import { promisify } from "node:util";
+import { consumeKnownError } from "../../kernel/src/index.ts";
 import { scrubProviderValue } from "./dispatch-stream.ts";
 
 const execFileAsync = promisify(execFile),
   workerBranchPattern = /^codex\/[A-Za-z0-9][A-Za-z0-9._-]*$/u,
-  detailLimit = 512;
+  detailLimit = 512,
+  // Porcelain output grows with the worktree, and the dirty worktrees this answers about are the
+  // large ones. Anything past this bound is still an answer: a worktree that says that much is dirty.
+  worktreeStatusLimit = 1 << 20;
 
 export type WorkerPushResult =
   | { readonly attempted: false; readonly reason: "not-a-worker-worktree" | "not-codex-branch" | "detached" }
   | { readonly attempted: true; readonly ok: true; readonly branch: string }
   | { readonly attempted: true; readonly ok: false; readonly branch: string | null; readonly detail: string };
 
+// Read-only: settlement observes the worktree, it never commits, stashes or cleans it. A worktree
+// git refuses to describe is not a clean worktree, so an unreadable one answers "dirty" rather than
+// letting the failure escape and strand the dispatch without a terminal outcome.
 export async function workerWorktreeDirty(input: {
   readonly cwd: string;
   readonly canonicalRoot: string;
   readonly env?: NodeJS.ProcessEnv;
 }): Promise<boolean> {
   if (samePath(input.cwd, input.canonicalRoot)) return false;
-  const result = await execFileAsync("git", ["-C", input.cwd, "status", "--porcelain"], {
-    env: { ...process.env, ...input.env, GIT_TERMINAL_PROMPT: "0" },
-    maxBuffer: detailLimit * 2,
-  });
-  return String(result.stdout).trim().length > 0;
+  try {
+    const result = await execFileAsync("git", ["-C", input.cwd, "status", "--porcelain"], {
+      env: { ...process.env, ...input.env, GIT_TERMINAL_PROMPT: "0" },
+      maxBuffer: worktreeStatusLimit,
+    });
+    return String(result.stdout).trim().length > 0;
+  } catch (error) {
+    consumeKnownError(error);
+    return true;
+  }
 }
 
 export async function pushWorkerBranch(input: {

--- a/packages/daemon/src/runtime-worker-push.ts
+++ b/packages/daemon/src/runtime-worker-push.ts
@@ -12,6 +12,19 @@ export type WorkerPushResult =
   | { readonly attempted: true; readonly ok: true; readonly branch: string }
   | { readonly attempted: true; readonly ok: false; readonly branch: string | null; readonly detail: string };
 
+export async function workerWorktreeDirty(input: {
+  readonly cwd: string;
+  readonly canonicalRoot: string;
+  readonly env?: NodeJS.ProcessEnv;
+}): Promise<boolean> {
+  if (samePath(input.cwd, input.canonicalRoot)) return false;
+  const result = await execFileAsync("git", ["-C", input.cwd, "status", "--porcelain"], {
+    env: { ...process.env, ...input.env, GIT_TERMINAL_PROMPT: "0" },
+    maxBuffer: detailLimit * 2,
+  });
+  return String(result.stdout).trim().length > 0;
+}
+
 export async function pushWorkerBranch(input: {
   readonly cwd: string;
   readonly canonicalRoot: string;

--- a/packages/daemon/test/runtime-orphan-settlement.integration.test.ts
+++ b/packages/daemon/test/runtime-orphan-settlement.integration.test.ts
@@ -1,0 +1,154 @@
+// harness-test-tier: integration
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { consumeKnownError, makeTaskEventReader, type AgentDefinitionSnapshot } from "../../kernel/src/index.ts";
+import { canonicalRoot, workspaceId } from "../src/protocol/daemon-protocol.contract.ts";
+import { openBootstrappedRepoCell as openRepoCell } from "./repo-settings.fixture.ts";
+import { writeProviderExecutable } from "./fixtures/runtime-stub.ts";
+
+const definition: AgentDefinitionSnapshot = {
+  schema: "agent-definition-snapshot/v1",
+  configVersion: 1,
+  instanceId: "codex-orphan",
+  installationId: "installation-codex-orphan",
+  kindId: "codex",
+  providerId: "openai",
+  model: "test-model",
+  reasoningEffort: null,
+  baseUrl: null,
+  authMode: "subscription",
+};
+
+test("provider exit zero is incomplete while a runtime descendant remains alive", async () => {
+  const parent = mkdtempSync(path.join(tmpdir(), "ha-runtime-orphan-")),
+    root = path.join(parent, "repo"),
+    repoId = "runtime-orphan",
+    executablePath = writeProviderExecutable(
+      path.join(parent, "orphan-provider.mjs"),
+      `import { spawn } from "node:child_process";
+const child = spawn(process.execPath, ["-e", "setTimeout(() => {}, 30000)"], { stdio: "ignore" });
+child.unref();
+console.log(JSON.stringify({ type: "thread.started", thread_id: "orphan-provider" }));
+console.log(JSON.stringify({ type: "item.completed", item: { id: "message", type: "agent_message", text: String(child.pid) } }));
+console.log(JSON.stringify({ type: "turn.completed", usage: { input_tokens: 1, output_tokens: 1 } }));
+`,
+    ),
+    cleanExecutablePath = writeProviderExecutable(
+      path.join(parent, "clean-provider.mjs"),
+      `console.log(JSON.stringify({ type: "thread.started", thread_id: "clean-provider" }));
+console.log(JSON.stringify({ type: "item.completed", item: { id: "message", type: "agent_message", text: "done" } }));
+console.log(JSON.stringify({ type: "turn.completed", usage: { input_tokens: 1, output_tokens: 1 } }));
+`,
+    );
+  mkdirSync(root, { recursive: true });
+  git(root, "init", "-q");
+  git(root, "config", "user.name", "Orphan Test");
+  git(root, "config", "user.email", "orphan@example.invalid");
+  git(root, "commit", "--allow-empty", "-qm", "base");
+  const cell = await openRepoCell({
+    repoId: workspaceId(repoId),
+    rootDir: canonicalRoot(root),
+    ownerId: "orphan-test",
+    runtimeInstances: () => [],
+    prepareRuntimeLaunch: (_instanceId, request) => ({
+      definition,
+      installation: {
+        installationId: definition.installationId,
+        kindId: "codex",
+        executablePath: request.prompt === "leave descendant" ? executablePath : cleanExecutablePath,
+        version: "1.0.0",
+        observedAt: "2026-09-04T00:00:00.000Z",
+      },
+      executablePath: request.prompt === "leave descendant" ? executablePath : cleanExecutablePath,
+      args: [],
+      env: process.env,
+      cwd: request.cwd,
+      prompt: request.prompt,
+    }),
+  });
+  let descendantPid = 0;
+  try {
+    const orphan = await cell.spawnRuntime(
+      {
+        runtimeInstanceId: definition.instanceId,
+        cwd: { scope: "repo-root" },
+        prompt: "leave descendant",
+        taskId: null,
+        idempotencyKey: "orphan",
+      },
+      { actor: { principal: { personId: "orphan-test" }, executor: null }, source: "local" },
+    );
+    const orphanOutcome = await eventuallyValue(
+      () =>
+        makeTaskEventReader({ repoId, rootDir: root })
+          .read()
+          .events.find(
+            (event) =>
+              event.type === "runtime_session_outcome_observed" &&
+              event.payload.runtimeSessionId === orphan.runtimeSessionId,
+          ) ?? null,
+    );
+    const orphanSession = await eventuallyValue(async () => {
+      const value = await cell.read("repo.agentRuntime.sessions.read", {
+        runtimeSessionId: orphan.runtimeSessionId,
+      });
+      return value.result ? value : null;
+    });
+    descendantPid = Number(orphanSession.result?.text);
+    const orphanStream = readFileSync(
+      path.join(root, ".harness/runtime/dispatches", `${String(orphan.dispatchId)}.jsonl`),
+      "utf8",
+    );
+    assert.equal(orphanOutcome.payload.outcome, "unknown", orphanStream);
+    assert.doesNotThrow(() => process.kill(descendantPid, 0));
+
+    const clean = await cell.spawnRuntime(
+      {
+        runtimeInstanceId: definition.instanceId,
+        cwd: { scope: "repo-root" },
+        prompt: "finish cleanly",
+        taskId: null,
+        idempotencyKey: "clean",
+      },
+      { actor: { principal: { personId: "orphan-test" }, executor: null }, source: "local" },
+    );
+    const cleanOutcome = await eventuallyValue(
+      () =>
+        makeTaskEventReader({ repoId, rootDir: root })
+          .read()
+          .events.find(
+            (event) =>
+              event.type === "runtime_session_outcome_observed" &&
+              event.payload.runtimeSessionId === clean.runtimeSessionId,
+          ) ?? null,
+    );
+    assert.equal(cleanOutcome.payload.outcome, "succeeded", JSON.stringify(cleanOutcome));
+  } finally {
+    if (descendantPid > 0) {
+      try {
+        process.kill(descendantPid, "SIGTERM");
+      } catch (error) {
+        consumeKnownError(error);
+      }
+    }
+    await cell.close();
+    rmSync(parent, { recursive: true, force: true });
+  }
+});
+
+async function eventuallyValue<T>(read: () => T | null | Promise<T | null>): Promise<T> {
+  for (let attempt = 0; attempt < 200; attempt += 1) {
+    const value = await read();
+    if (value !== null) return value;
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+  throw new Error("timed out waiting for runtime settlement");
+}
+
+function git(root: string, ...args: string[]): void {
+  execFileSync("git", ["-C", root, ...args], { stdio: "ignore" });
+}

--- a/packages/daemon/test/runtime-provider-fault.test.ts
+++ b/packages/daemon/test/runtime-provider-fault.test.ts
@@ -82,6 +82,12 @@ test("attempt-bound classification falls back only before tools or for recognize
   const succeeded = classifyRuntimeExit(active({ providerOutcome: "succeeded" }), 0);
   assert.deepEqual(pick(succeeded), { outcome: "succeeded", classification: "worker_stop" });
   assert.match(succeeded.reason, /successfully/u);
+  const descendantsAlive = classifyRuntimeExit(active({ descendantsAlive: true } as Partial<ActiveRuntime>), 0);
+  assert.deepEqual(pick(descendantsAlive), { outcome: "unknown", classification: "worker_stop" });
+  assert.match(descendantsAlive.reason, /descendant processes are still running/u);
+  const worktreeDirty = classifyRuntimeExit(active({ worktreeDirty: true } as Partial<ActiveRuntime>), 0);
+  assert.deepEqual(pick(worktreeDirty), { outcome: "unknown", classification: "worker_stop" });
+  assert.match(worktreeDirty.reason, /uncommitted changes/u);
   assert.deepEqual(pick(classifyRuntimeExit(active({ cancelRequested: true, toolCallObserved: false }), 1)), {
     outcome: "cancelled",
     classification: "worker_stop",

--- a/packages/daemon/test/runtime-worker-push.test.ts
+++ b/packages/daemon/test/runtime-worker-push.test.ts
@@ -74,6 +74,13 @@ test("worker worktree status is read without changing the worktree", async (cont
   assert.equal(await workerWorktreeDirty({ cwd: worker, canonicalRoot: canonical }), true);
   assert.match(git(worker, "status", "--porcelain"), /uncommitted\.txt/u);
   assert.equal(await workerWorktreeDirty({ cwd: canonical, canonicalRoot: canonical }), false);
+
+  // The worktrees this question exists for are the abandoned ones, and those carry far more than a
+  // single path: a bound that a real turn's leftovers overrun answers with a thrown error instead.
+  for (let index = 0; index < 64; index += 1)
+    writeFileSync(path.join(worker, `left-behind-${String(index)}-with-a-realistic-name.txt`), "dirty\n");
+  assert.equal(git(worker, "status", "--porcelain").length > 1024, true);
+  assert.equal(await workerWorktreeDirty({ cwd: worker, canonicalRoot: canonical }), true);
 });
 
 function git(root, ...args) {

--- a/packages/daemon/test/runtime-worker-push.test.ts
+++ b/packages/daemon/test/runtime-worker-push.test.ts
@@ -5,7 +5,7 @@ import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
-import { pushWorkerBranch } from "../src/runtime-worker-push.ts";
+import { pushWorkerBranch, workerWorktreeDirty } from "../src/runtime-worker-push.ts";
 
 test("worker push publishes only a codex branch with force-with-lease", async (context) => {
   const root = mkdtempSync(path.join(tmpdir(), "ha-worker-push-")),
@@ -56,6 +56,24 @@ test("canonical roots never trigger worker push", async () => {
     attempted: false,
     reason: "not-a-worker-worktree",
   });
+});
+
+test("worker worktree status is read without changing the worktree", async (context) => {
+  const root = mkdtempSync(path.join(tmpdir(), "ha-worker-dirty-")),
+    canonical = path.join(root, "project"),
+    worker = path.join(root, "worker");
+  context.after(() => rmSync(root, { recursive: true, force: true }));
+  git(root, "init", "-q", "project");
+  git(canonical, "config", "user.email", "push-test@example.invalid");
+  git(canonical, "config", "user.name", "Push Test");
+  git(canonical, "commit", "--allow-empty", "--quiet", "-m", "fixture");
+  git(canonical, "worktree", "add", "--quiet", worker, "-b", "codex/dirty-test");
+
+  assert.equal(await workerWorktreeDirty({ cwd: worker, canonicalRoot: canonical }), false);
+  writeFileSync(path.join(worker, "uncommitted.txt"), "dirty\n");
+  assert.equal(await workerWorktreeDirty({ cwd: worker, canonicalRoot: canonical }), true);
+  assert.match(git(worker, "status", "--porcelain"), /uncommitted\.txt/u);
+  assert.equal(await workerWorktreeDirty({ cwd: canonical, canonicalRoot: canonical }), false);
 });
 
 function git(root, ...args) {


### PR DESCRIPTION
# English

## Summary

A runtime attempt was settled as `succeeded` from the provider's exit code alone, even when the worker left descendant processes running or an uncommitted worktree behind. The worker host now records the live descendants of its own process tree at close, the settlement reads that record plus the worktree state, and a clean provider exit with live descendants or a dirty task worktree settles as `unknown` with an explicit reason instead of `succeeded`.

## Architectural Justification

The observation primitives (`readPosixProcessRows`, `descendantProcessRows`, worktree status) already existed and were wired only to the cancel path. This change puts them on the normal exit path and lets the existing `unknown` outcome carry the truth. No new outcome or classification value, no timer, watchdog, retry, flag or configuration; the spawn options and the process-group model are unchanged.

## What Changed

- `runtime-worker-host.ts`: on child close, append a `process_descendants` record with the still-alive pids under the host.
- `runtime-spawn-settlement.ts` / `runtime-spawn-active.ts` / `runtime-spawn-types.ts`: read that record and the worktree dirtiness into the active attempt.
- `runtime-provider-fault.ts`: exit outcome is `unknown` when descendants are alive or the worktree is dirty, with a reason string.
- `runtime-worker-push.ts`: `workerWorktreeDirty` helper (never dirty for the canonical root).
- Tests cover the live-orphan shape, the dirty-worktree shape and the clean baseline on Ubuntu.

## Gate Harvest / 门收割

No gate change.

## Machine-Readable Declarations

Production-Delta: +92/-29
Dependency-Change: none

### Optional Evidence Claims

none

## Task And Scope

task_091019d4d51e54a3df88bc1ae7 (runtime settlement reports orphaned worker descendants as success). Branch `codex/worker-stop-orphans`.

Fleet view: the descendant record is written by the worker host into its own dispatch stream and read by the settling node that owns the attempt; no shared write is introduced and the center queue is untouched.

## Version Impact

No version change; publish impact none.

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none
- Authority: task_091019d4d51e54a3df88bc1ae7
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Follow-up governance task: not applicable

## Verification

- Base merge-base 2b94abdc53c7fb7765b65bbdcdce68352fe6e0a4.
- Worker (Sol) on isolated Ubuntu: live-orphan positive control fails before and settles `unknown` after; clean baseline still `succeeded`; 10-run stability (facts F-D38C9078, F-C6D18589).
- CI is the complete authority.

## Review Evidence

CEO semantic review against the task plan: the plan's forbidden moves (detached provider spawn, signals on the process group, new classification or outcome values, flags) are all absent; the reason strings name the observed condition. Explicitly detached grandchildren remain unobservable by design and are listed as residual risk.

## Residual Risk

A grandchild that detaches itself leaves the host's process tree and is not counted; task-bound incomplete work is still caught by the worktree signal. Windows has no POSIX snapshot; only the worktree signal applies there.

# 中文

## 概要

runtime 结算只看 provider 退出码,worker 留下在跑的后代进程或未提交的工作树也会被记成 `succeeded`。现在 worker host 在关闭时记录自己进程树里仍存活的后代,结算读取该记录与工作树状态;provider 干净退出但有活后代或任务工作树脏,结算为 `unknown` 并给出原因。

## 架构辩护

观察原语本来就有,只接在 cancel 路径上;本改动把它们接到正常退出路径,让既有的 `unknown` 结果承载真相。不加新 outcome/分类值、定时器、看门狗、重试、flag 或配置;spawn 选项与进程组模型不变。

## 机读声明

生产行数增减(与上文机读声明一致):+92/-29

## 治理声明

- 触碰受保护面:否
- 授权:task_091019d4d51e54a3df88bc1ae7
- Break-glass:否

## 验证

Sol 在隔离 Ubuntu 上:活孤儿阳性对照修前失败、修后结算 unknown;干净基线仍 succeeded;10 次稳定。其余以 CI 为准。

## 评审证据

CEO 语义复核:plan 禁止的动作全部未出现;原因字符串点名观察到的条件。

## 残余风险

自行 detach 的孙进程不在观察范围;Windows 只有工作树信号。

