### PR TITLE
fix(daemon): hold the endpoint through shutdown drain and report daemon_stopping

### DIFF
--- a/packages/cli/src/cli/guidance-plane.ts
+++ b/packages/cli/src/cli/guidance-plane.ts
@@ -82,6 +82,13 @@ const guidanceTemplates = new Map<string, GuidanceTemplate>([
   ["*:remove-dry-run", (args) => `next: remove --dry-run and rerun ${textArg(args, "command")}`],
   ["*:no-action", () => "next: no action required"],
   [
+    "failure:daemon-stopping",
+    () =>
+      "The daemon is draining its write queues before it exits and admits no new work; it releases its " +
+      "endpoint, pid file and singleton lock together when the drain finishes. Run ha daemon status to see " +
+      "what is still draining, then retry — the next command starts the replacement daemon.",
+  ],
+  [
     "failure:squad-leader",
     (args) => `Leader dispatch rejected: code=${textArg(args, "code")} hint=${textArg(args, "hint")}`,
   ],
@@ -156,6 +163,7 @@ export function humanError(receipt: Record<string, unknown>): { readonly code: s
     leader = record(receipt.leader) ? humanError(receipt.leader) : null;
   if (code === "squad_leader_failed" && leader && leader.code !== "unknown")
     return { code, hint: renderTemplate("failure", "squad-leader", leader) };
+  if (code === "daemon_stopping") return { code, hint: renderTemplate("failure", "daemon-stopping", {}) };
   const diagnostic = record(receipt.diagnostic) ? receipt.diagnostic : null,
     diagnosticHint = diagnostic ? renderDiagnostic(diagnostic) : null,
     declaredGuidance = renderReceiptGuidance(receipt),

--- a/packages/cli/src/daemon/control.ts
+++ b/packages/cli/src/daemon/control.ts
@@ -1,4 +1,3 @@
-import { existsSync } from "node:fs";
 import path from "node:path";
 import {
   daemonIdFromEnv,
@@ -87,17 +86,13 @@ export async function runDaemonControl(argv: readonly string[], renderReceipt: R
         return finish(forced, forced.ok === true ? 0 : 1);
       }
       const exchange = await requestCooperativeStop(userRoot, daemonId, pid);
-      const stopped = await waitForDaemonStop(userRoot, daemonId, pid);
-      return stopped
-        ? finish({ ok: true, command: "daemon-stop", pid }, 0)
-        : finish(
-            daemonFailure(
-              "daemon-stop",
-              "daemon_stop_timeout",
-              await stopTimeoutHint(userRoot, daemonId, pid, exchange),
-            ),
-            1,
-          );
+      const outcome = await waitForDaemonStop(userRoot, daemonId, pid, exchange);
+      if (outcome === "stopped") return finish({ ok: true, command: "daemon-stop", pid }, 0);
+      if (outcome === "draining") return finish(drainingStopReceipt(pid), 0);
+      return finish(
+        daemonFailure("daemon-stop", "daemon_stop_timeout", await stopTimeoutHint(userRoot, daemonId, pid, exchange)),
+        1,
+      );
     }
     return finish(
       daemonFailure(
@@ -557,24 +552,49 @@ function signalStop(pid: number): void {
     consumeKnownError(error);
   }
 }
-// Stop is done when nothing is held any more, and there are two ways to get there. Shutdown
-// releases the pid file and the endpoint as its last acts, which is the fast path and the only
-// one the original predicate knew. But Windows has no signals: process.kill terminates
-// unconditionally, shutdown never runs, and those two never go -- so a stop that had already
-// succeeded reported daemon_stop_timeout for the full five seconds (#1565). A dead process holds
-// nothing, so its exit is the second way, and whoever killed it clears the bookkeeping it left.
-async function waitForDaemonStop(userRoot: string, daemonId: string, pid: number): Promise<boolean> {
-  const endpoint = localUserDaemonEndpoint(userRoot, daemonId);
+// Stop is done when nothing is held any more, and there are two ways to get there. Shutdown releases
+// the pid file, the endpoint and the singleton lock in one step, so the pid file alone now witnesses
+// the whole release; the endpoint check it used to carry could only disagree with it while the daemon
+// was draining, which is the window this predicate kept misreading. But Windows has no signals:
+// process.kill terminates unconditionally, shutdown never runs, and the pid file never goes -- so a
+// stop that had already succeeded reported daemon_stop_timeout for the full five seconds (#1565). A
+// dead process holds nothing, so its exit is the second way, and whoever killed it clears the
+// bookkeeping it left. Anything else is judged on what the daemon said: one that acknowledged the
+// stop and still answers on its endpoint is draining, because a bound endpoint now outlives nothing.
+type DaemonStopOutcome = "stopped" | "draining" | "timeout";
+async function waitForDaemonStop(
+  userRoot: string,
+  daemonId: string,
+  pid: number,
+  exchange: DaemonShutdownExchange | null,
+): Promise<DaemonStopOutcome> {
   for (const deadline = Date.now() + 5_000; Date.now() < deadline; ) {
-    if (readDaemonPid(userRoot, daemonId) === null && !existsSync(endpoint)) return true;
+    if (readDaemonPid(userRoot, daemonId) === null) return "stopped";
     if (!daemonProcessAlive(pid)) {
       releaseDaemonPidFile(userRoot, daemonId, pid);
       releaseDaemonSingletonLock(userRoot, daemonId, pid);
-      return true;
+      return "stopped";
     }
     await new Promise((resolve) => setTimeout(resolve, 10));
   }
-  return false;
+  return exchange?.stopReply?.ok === true && (await daemonSocketProbe(localUserDaemonEndpoint(userRoot, daemonId)))
+    ? "draining"
+    : "timeout";
+}
+// Draining is the daemon doing what it was asked, not a failure: it accepted the stop, it is emptying
+// its write queues, and it says so on an endpoint that disappears with its pid file and its lock.
+function drainingStopReceipt(pid: number): Record<string, unknown> {
+  return {
+    ok: true,
+    command: "daemon-stop",
+    pid,
+    draining: true,
+    summary:
+      `daemon-stop: pid ${pid} accepted the stop and is draining its write queues; its endpoint, ` +
+      "pid file and singleton lock are released together when the drain finishes.",
+    nextAction:
+      "Run `ha daemon status` to see what is still draining; `ha daemon stop --force` ends it without draining.",
+  };
 }
 function finishControlReceipt(
   renderReceipt: ReceiptEmitter,

--- a/packages/cli/test/daemon-stop-drain-window.test.ts
+++ b/packages/cli/test/daemon-stop-drain-window.test.ts
@@ -1,0 +1,329 @@
+// harness-test-tier: integration
+import assert from "node:assert/strict";
+import { execFileSync, spawn, spawnSync } from "node:child_process";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { connect } from "node:net";
+import { hostname, tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { readDaemonStartProgress, type DaemonLaunchSpec } from "../../daemon/src/client/daemon-autostart.ts";
+import { localUserDaemonEndpoint } from "../../daemon/src/client/local-daemon-target.ts";
+import { daemonProcessAlive, daemonSingletonLockPath } from "../../daemon/src/daemon-singleton.ts";
+import { openDaemonLifecycleLog } from "../../daemon/src/lifecycle-log.ts";
+import { daemonPidPath, readDaemonPid } from "../../daemon/src/runtime.ts";
+import { registerBootstrappedDaemonRepo } from "../../daemon/test/repo-settings.fixture.ts";
+
+const cli = path.resolve("packages/cli/src/index.ts"),
+  repoRoot = path.resolve("."),
+  drainMs = 8_000;
+
+// Shutdown used to close the socket first and release the pid file and the singleton lock after the
+// WAL drain. For the whole length of that drain the four bookkeeping surfaces contradicted each other
+// -- endpoint gone, pid file present, lock held, process alive -- and three separate observers each
+// guessed differently: `daemon stop` called it a timeout, every other command called it
+// daemon_unavailable, and autostart read the dying generation as a starting one and waited out
+// readyTimeoutMs * 6. These fixtures pin the window itself: one drain longer than the stop budget,
+// one shorter, and the lifecycle read that used to mistake an exited generation for a starting one.
+test("a drain longer than the stop budget is reported as draining, not as a timeout", async () => {
+  const fixture = await spawnDrainingDaemon("drain-slow", drainMs);
+  try {
+    const stopStartedAt = Date.now(),
+      stop = runCli(fixture, ["daemon", "stop", "--json"]);
+    // The refusal is what marks the drain as begun, so every observation below is inside the window.
+    const refused = await waitForStoppingRefusal(fixture),
+      inWindow = await snapshot(fixture),
+      status = await runCli(fixture, ["daemon", "status", "--json"]);
+    const stopped = JSON.parse((await stop).stdout) as Record<string, unknown>;
+
+    assert.notEqual(stopped.code, "daemon_stop_timeout", JSON.stringify(stopped));
+    assert.equal(stopped.ok, true, JSON.stringify(stopped));
+    assert.equal(stopped.draining, true, JSON.stringify(stopped));
+    assert.equal(
+      JSON.stringify(inWindow),
+      JSON.stringify({ socketAccepting: true, pidFilePid: fixture.daemonPid, lockPid: fixture.daemonPid, alive: true }),
+      "the drain window must show one consistent daemon, not a socket that disagrees with the pid file",
+    );
+
+    const reported = JSON.parse(status.stdout) as Record<string, unknown>;
+    assert.equal(reported.ok, true, JSON.stringify(reported));
+    assert.match(String(reported.summary), /Stopping: draining \d+ live runtime session\(s\)/u);
+    assert.ok(
+      refused.elapsedMs < drainMs,
+      `a draining daemon must answer at once, not be waited out: ${refused.elapsedMs}ms`,
+    );
+
+    await waitForRelease(fixture);
+    assert.ok(Date.now() - stopStartedAt >= drainMs, "the fixture must have exercised a drain longer than the budget");
+  } finally {
+    await cleanup(fixture);
+  }
+});
+
+test("a drain shorter than the stop budget still reports a plain stop and leaves nothing behind", async () => {
+  const fixture = await spawnDrainingDaemon("drain-fast", 0);
+  try {
+    const stop = await runCli(fixture, ["daemon", "stop", "--json"]),
+      stopped = JSON.parse(stop.stdout) as Record<string, unknown>;
+    assert.equal(stopped.ok, true, JSON.stringify(stopped));
+    assert.equal(stopped.draining, undefined, "a drain inside the budget is a completed stop, not a draining one");
+    assert.ok(stop.elapsedMs < 5_000, `a fast drain must not spend the whole budget: ${stop.elapsedMs}ms`);
+    await waitForRelease(fixture);
+  } finally {
+    await cleanup(fixture);
+  }
+});
+
+test("a generation that recorded its exit is not read as a starting daemon", () => {
+  const parent = mkdtempSync(path.join(tmpdir(), "ha-drain-progress-")),
+    userRoot = path.join(parent, "user"),
+    daemonId = "exited-generation",
+    // The pid is this live test process: without the exit record, liveness alone reads as "starting".
+    lifecycle = openDaemonLifecycleLog({ userRoot, daemonId });
+  try {
+    lifecycle.record({ event: "process_start", endpoint: "endpoint" });
+    lifecycle.record({ event: "socket_bound", endpoint: "endpoint" });
+    assert.notEqual(readDaemonStartProgress(launchSpec(userRoot, daemonId), 0), null);
+    lifecycle.record({ event: "process_exit", outcome: "stop_requested" });
+    assert.equal(readDaemonStartProgress(launchSpec(userRoot, daemonId), 0), null);
+  } finally {
+    rmSync(parent, { recursive: true, force: true });
+  }
+});
+
+interface Fixture {
+  readonly parent: string;
+  readonly rootDir: string;
+  readonly userRoot: string;
+  readonly daemonId: string;
+  readonly daemonPid: number;
+}
+
+function launchSpec(userRoot: string, daemonId: string): DaemonLaunchSpec {
+  return {
+    command: process.execPath,
+    args: ["index.ts", "daemon", "serve", "--user-root", userRoot, "--daemon-id", daemonId],
+    env: {},
+  };
+}
+
+// A real startDaemon() whose single repository cell takes a controlled time to close, which is where
+// the WAL drain lives. Nothing else about the daemon is stubbed, so the socket, the pid file and the
+// singleton lock are released by the production shutdown path.
+const DRAINING_DAEMON = `import path from "node:path";
+import { pathToFileURL } from "node:url";
+const [repoRoot, userRoot, daemonId, closeDelayMs] = process.argv.slice(2);
+const load = (rel) => import(pathToFileURL(path.join(repoRoot, rel)).href);
+const { startDaemon } = await load("packages/daemon/src/runtime.ts");
+const { openBootstrappedRepoCell } = await load("packages/daemon/test/repo-settings.fixture.ts");
+let stopping = null, daemon;
+const requestStop = () => {
+  stopping ??= (async () => {
+    if (daemon && "stop" in daemon) await daemon.stop();
+  })();
+};
+daemon = await startDaemon({
+  userRoot,
+  daemonId,
+  shutdownRequested: () => stopping !== null,
+  requestShutdown: requestStop,
+  openCell: async (input) => {
+    const cell = await openBootstrappedRepoCell(input);
+    const closeCell = cell.close.bind(cell);
+    return Object.assign(Object.create(cell), {
+      close: async () => {
+        await new Promise((resolve) => setTimeout(resolve, Number(closeDelayMs)));
+        await closeCell();
+      },
+    });
+  },
+});
+process.on("SIGTERM", requestStop);
+process.on("SIGINT", requestStop);
+if (stopping) await stopping;
+`;
+
+async function spawnDrainingDaemon(daemonId: string, closeDelayMs: number): Promise<Fixture> {
+  const parent = mkdtempSync(path.join(tmpdir(), `ha-${daemonId}-`)),
+    rootDir = path.join(parent, "repo"),
+    userRoot = path.join(parent, "user"),
+    script = path.join(parent, "draining-daemon.mjs"),
+    launcher = path.join(parent, "launcher.mjs"),
+    endpoint = localUserDaemonEndpoint(userRoot, daemonId);
+  rosterRepo(rootDir, daemonId);
+  registerBootstrappedDaemonRepo({ canonicalRoot: rootDir, repoId: daemonId, userRoot, createConvenienceLinks: false });
+  writeFileSync(script, DRAINING_DAEMON, "utf8");
+  // The resident daemon is orphaned by a launcher that exits, exactly as `daemon start --service`
+  // leaves it, so an exited fixture is reaped instead of lingering as a zombie of this test process.
+  writeFileSync(
+    launcher,
+    `import { spawn } from "node:child_process";\nconst child = spawn(process.execPath, [${JSON.stringify(
+      script,
+    )}, ...process.argv.slice(2)], { stdio: "ignore", detached: true, env: process.env });\nchild.unref();\n`,
+    "utf8",
+  );
+  mkdirSync(path.dirname(endpoint), { recursive: true });
+  const nodeOptions = [process.env.NODE_OPTIONS, "--experimental-strip-types"].filter(Boolean).join(" "),
+    launched = spawnSync(process.execPath, [launcher, repoRoot, userRoot, daemonId, String(closeDelayMs)], {
+      encoding: "utf8",
+      env: { ...process.env, NODE_OPTIONS: nodeOptions },
+      timeout: 30_000,
+    });
+  assert.equal(launched.status, 0, launched.stderr);
+  const deadline = Date.now() + 60_000;
+  let fixture: Fixture;
+  for (;;) {
+    const pid = readDaemonPid(userRoot, daemonId);
+    if (pid !== null && (await socketAccepting(endpoint))) {
+      fixture = { parent, rootDir, userRoot, daemonId, daemonPid: pid };
+      break;
+    }
+    if (Date.now() > deadline) throw new Error(`fixture daemon ${daemonId} never became socket-ready`);
+    await delay(50);
+  }
+  // The drain these fixtures measure is the cell close, so the repository must be attached first.
+  while (!(await attached(fixture))) {
+    if (Date.now() > deadline) throw new Error(`fixture daemon ${daemonId} never attached its repository`);
+    await delay(100);
+  }
+  return fixture;
+}
+
+async function attached(fixture: Fixture): Promise<boolean> {
+  const probe = await runCli(fixture, ["daemon", "status", "--json"]);
+  const receipt = JSON.parse(probe.stdout) as { readonly repos?: readonly { readonly state?: string }[] };
+  return receipt.repos?.[0]?.state === "attached";
+}
+
+async function snapshot(
+  fixture: Fixture,
+): Promise<{ socketAccepting: boolean; pidFilePid: number | null; lockPid: number | null; alive: boolean }> {
+  const lockPath = daemonSingletonLockPath(fixture.userRoot, fixture.daemonId);
+  return {
+    socketAccepting: await socketAccepting(localUserDaemonEndpoint(fixture.userRoot, fixture.daemonId)),
+    pidFilePid: readDaemonPid(fixture.userRoot, fixture.daemonId),
+    lockPid: existsSync(lockPath) ? Number(readFileSync(lockPath, "utf8").trim()) : null,
+    alive: daemonProcessAlive(fixture.daemonPid),
+  };
+}
+
+// Before the stop request lands the daemon still serves normally, so the fixture waits for the first
+// refusal rather than assuming a freshly spawned `daemon stop` has already reached it.
+async function waitForStoppingRefusal(fixture: Fixture): Promise<CliRun> {
+  const deadline = Date.now() + drainMs;
+  for (;;) {
+    const run = await runCli(fixture, ["task", "list", "--json"], "env"),
+      receipt = JSON.parse(run.stdout) as { readonly code?: string };
+    if (receipt.code === "daemon_stopping") return run;
+    if (Date.now() > deadline) throw new Error(`daemon ${fixture.daemonId} never refused new work: ${run.stdout}`);
+    await delay(50);
+  }
+}
+async function waitForRelease(fixture: Fixture): Promise<void> {
+  const deadline = Date.now() + drainMs + 20_000;
+  for (;;) {
+    const state = await snapshot(fixture);
+    if (!state.socketAccepting && state.pidFilePid === null && state.lockPid === null && !state.alive) return;
+    if (Date.now() > deadline) throw new Error(`daemon ${fixture.daemonId} never released: ${JSON.stringify(state)}`);
+    await delay(50);
+  }
+}
+
+interface CliRun {
+  readonly elapsedMs: number;
+  readonly status: number | null;
+  readonly stdout: string;
+  readonly stderr: string;
+}
+
+// Workspace commands take their target from the environment, control commands from flags; both must
+// run without this process's own harness environment, which would otherwise refuse an autostart.
+function runCli(fixture: Fixture, args: readonly string[], target: "flags" | "env" = "flags"): Promise<CliRun> {
+  const env: NodeJS.ProcessEnv = { ...process.env };
+  for (const key of Object.keys(env)) if (key.startsWith("HARNESS_")) delete env[key];
+  if (target === "env")
+    Object.assign(env, { HARNESS_DAEMON_USER_ROOT: fixture.userRoot, HARNESS_DAEMON_ID: fixture.daemonId });
+  const flags = target === "flags" ? ["--user-root", fixture.userRoot, "--daemon-id", fixture.daemonId] : [],
+    startedAt = Date.now();
+  return new Promise((resolve) => {
+    const child = spawn(process.execPath, [cli, ...args, ...flags], { env, cwd: fixture.rootDir });
+    let stdout = "",
+      stderr = "";
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (chunk: string) => (stdout += chunk));
+    child.stderr.on("data", (chunk: string) => (stderr += chunk));
+    child.on("close", (status) => resolve({ elapsedMs: Date.now() - startedAt, status, stdout, stderr }));
+  });
+}
+
+function socketAccepting(socketPath: string): Promise<boolean> {
+  return new Promise((resolve) => {
+    const socket = connect(socketPath),
+      settle = (ready: boolean) => {
+        socket.removeAllListeners();
+        socket.destroy();
+        resolve(ready);
+      };
+    socket.once("connect", () => settle(true));
+    socket.once("error", () => settle(false));
+  });
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function rosterRepo(rootDir: string, repoId: string): void {
+  mkdirSync(rootDir, { recursive: true });
+  for (const args of [
+    ["init", "--quiet"],
+    ["config", "user.name", "Daemon Stop Drain Window Test"],
+    ["config", "user.email", "daemon-stop-drain-window@example.invalid"],
+    ["config", "gc.auto", "0"],
+    ["commit", "--allow-empty", "--quiet", "-m", "fixture base"],
+  ])
+    execFileSync("git", ["-C", rootDir, ...args], { encoding: "utf8" });
+  mkdirSync(path.join(rootDir, "harness"));
+  writeFileSync(
+    path.join(rootDir, "harness/harness.yaml"),
+    `schema: harness-anything/v1\nname: ${repoId}\nlayout:\n  authoredRoot: harness\n  localRoot: .harness\n`,
+  );
+  writeFileSync(
+    path.join(rootDir, "harness/people.yaml"),
+    `${JSON.stringify(
+      {
+        schema: "harness-people/v1",
+        people: [
+          {
+            personId: "writer",
+            displayName: "writer",
+            roles: ["writer"],
+            credentials: [
+              {
+                kind: "unix-socket-owner-boundary",
+                issuer: `host:${hostname()}`,
+                subject: String(process.getuid?.() ?? 0),
+              },
+            ],
+          },
+        ],
+        roles: [{ roleId: "writer", commandClasses: ["repo-read", "repo-write", "admin"] }],
+      },
+      null,
+      2,
+    )}\n`,
+  );
+  execFileSync("git", ["-C", rootDir, "add", "harness"], { encoding: "utf8" });
+  execFileSync("git", ["-C", rootDir, "commit", "--quiet", "-m", "add roster fixture"], { encoding: "utf8" });
+}
+
+async function cleanup(fixture: Fixture): Promise<void> {
+  try {
+    process.kill(fixture.daemonPid, "SIGKILL");
+  } catch {
+    /* already gone */
+  }
+  rmSync(daemonPidPath(fixture.userRoot, fixture.daemonId), { force: true });
+  rmSync(localUserDaemonEndpoint(fixture.userRoot, fixture.daemonId), { force: true });
+  rmSync(fixture.parent, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 });
+}

--- a/packages/daemon/src/client/daemon-autostart.ts
+++ b/packages/daemon/src/client/daemon-autostart.ts
@@ -195,6 +195,11 @@ export function readDaemonStartProgress(launch: DaemonLaunchSpec, waitedMs: numb
   if (start < 0) return null;
   const generation = records.slice(start),
     processRecord = generation[0]!;
+  // A generation that has recorded its exit is terminal, whatever its pid still looks like: shutdown
+  // records process_exit once the drain is done and then releases the endpoint, the pid file and the
+  // singleton lock together, so reading those last milliseconds as "starting" would report the
+  // outgoing daemon's progress to a caller that is waiting for its replacement.
+  if (generation.some((record) => record.event === "process_exit")) return null;
   if (!daemonProcessAlive(processRecord.pid)) return null;
   for (let index = generation.length - 1; index >= 0; index -= 1) {
     const record = generation[index]!;

--- a/packages/daemon/src/daemon-build-drain.ts
+++ b/packages/daemon/src/daemon-build-drain.ts
@@ -23,15 +23,23 @@ export function daemonBuildStaleNotice(
   };
 }
 
-export function withDaemonBuildDrainSummary(
+// One summary for both drains an operator can be waiting on: the build supersession that will end
+// this daemon, and the shutdown that already has. The counts are the same three in either case.
+export function withDaemonDrainSummary(
   status: ReturnType<DaemonHost["status"]>,
   warning: DaemonBuildStaleNotice | null,
+  shutdown?: { readonly stopping?: () => boolean; readonly buildDrainStatus?: () => DaemonBuildDrainStatus },
 ): ReturnType<DaemonHost["status"]> {
-  if (!warning) return status;
-  return {
-    ...status,
-    summary:
-      `${status.summary} Drain status: ${warning.liveRuntimeSessions} live runtime session(s), ` +
-      `${warning.pendingWrites} queued write(s), ${warning.attachingRepositories} attaching repository/repositories.`,
-  };
+  const drain = shutdown?.stopping?.() === true ? (shutdown.buildDrainStatus?.() ?? null) : null;
+  if (!warning && !drain) return status;
+  const stale = warning
+    ? ` Drain status: ${warning.liveRuntimeSessions} live runtime session(s), ` +
+      `${warning.pendingWrites} queued write(s), ${warning.attachingRepositories} attaching repository/repositories.`
+    : "";
+  const stopping = drain
+    ? ` Stopping: draining ${drain.liveRuntimeSessions} live runtime session(s), ` +
+      `${drain.pendingWrites} queued write(s), ${drain.attachingRepositories} attaching ` +
+      "repository/repositories before exit."
+    : "";
+  return { ...status, summary: `${status.summary}${stale}${stopping}` };
 }

--- a/packages/daemon/src/protocol/json-rpc-dispatch-support.ts
+++ b/packages/daemon/src/protocol/json-rpc-dispatch-support.ts
@@ -105,10 +105,13 @@ export function protocolErrorMessage(error: unknown): string {
 
 // A draining daemon keeps its endpoint bound so callers can hear why, but it admits no new work: this
 // refusal is what closing the socket first used to do silently, and silence is what every observer in
-// the shutdown window then had to guess at. Status stays open because it is the one answer that
-// reports what is still draining; stop stays open because it is idempotent.
+// the shutdown window then had to guess at. Status stays served because it is the one answer that
+// reports what is still draining; stop stays served because it is idempotent.
+const methodsServedWhileDraining: ReadonlySet<DaemonRpcMethod> = new Set(["daemon.status", "daemon.stop"]);
+// `stopping` is the runtime's own shutdown flag, handed in by the composition that owns the drain;
+// the daemon has no second opinion about whether it is stopping.
 export function daemonStoppingRefusal(method: DaemonRpcMethod, stopping: boolean): DaemonProtocolErrorResult | null {
-  if (!stopping || method === "daemon.status" || method === "daemon.stop") return null;
+  if (!stopping || methodsServedWhileDraining.has(method)) return null;
   return daemonProtocolError(method, "daemon_stopping", "The daemon is draining before it exits.");
 }
 // Stop is the one command that ends the process, so it is reachable only from the local session and

--- a/packages/daemon/src/protocol/json-rpc-dispatch-support.ts
+++ b/packages/daemon/src/protocol/json-rpc-dispatch-support.ts
@@ -1,4 +1,7 @@
+import type { DaemonAuthenticationContext } from "../transport/auth-context.ts";
 import type { DaemonRequestLogEntry } from "../request-log.ts";
+import { daemonProtocolError } from "./daemon-protocol-validate-results.ts";
+import type { DaemonProtocolErrorResult } from "./daemon-protocol-gui-types.ts";
 import {
   isDaemonGuiActionMethod,
   isDaemonGuiReadMethod,
@@ -98,4 +101,29 @@ export function protocolErrorMessage(error: unknown): string {
     case "UnknownThrownValue":
       return normalized.message;
   }
+}
+
+// A draining daemon keeps its endpoint bound so callers can hear why, but it admits no new work: this
+// refusal is what closing the socket first used to do silently, and silence is what every observer in
+// the shutdown window then had to guess at. Status stays open because it is the one answer that
+// reports what is still draining; stop stays open because it is idempotent.
+export function daemonStoppingRefusal(method: DaemonRpcMethod, stopping: boolean): DaemonProtocolErrorResult | null {
+  if (!stopping || method === "daemon.status" || method === "daemon.stop") return null;
+  return daemonProtocolError(method, "daemon_stopping", "The daemon is draining before it exits.");
+}
+// Stop is the one command that ends the process, so it is reachable only from the local session and
+// only from a composition that owns a shutdown.
+export function daemonStopRefusal(
+  authContext: DaemonAuthenticationContext,
+  requestShutdown?: () => void,
+): DaemonProtocolErrorResult | null {
+  if (authContext.transportKind !== "unix-socket" || authContext.assignmentBinding)
+    return daemonProtocolError(
+      "daemon-stop",
+      "local_transport_required",
+      "Stop is available only through the local session token.",
+    );
+  if (!requestShutdown)
+    return daemonProtocolError("daemon-stop", "shutdown_unavailable", "This daemon composition has no shutdown owner.");
+  return null;
 }

--- a/packages/daemon/src/protocol/json-rpc-server.ts
+++ b/packages/daemon/src/protocol/json-rpc-server.ts
@@ -23,6 +23,8 @@ import {
   isRuntimeInstanceAuthCall,
   isRuntimeInstanceCall,
   isTerminalActionCall,
+  daemonStopRefusal,
+  daemonStoppingRefusal,
   protocolErrorMessage,
   repoIdFromParams,
   resultErrorCode,
@@ -44,7 +46,7 @@ import type { CoreDomainError } from "../../../kernel/src/index.ts";
 import type { DaemonBuildObserver, DaemonBuildStamp } from "../build-identity.ts";
 import { diagnosticForError } from "../receipt-guidance.ts";
 import { remoteProxyEventMethod } from "../remote-proxy.ts";
-import { daemonBuildStaleNotice, withDaemonBuildDrainSummary } from "../daemon-build-drain.ts";
+import { daemonBuildStaleNotice, withDaemonDrainSummary } from "../daemon-build-drain.ts";
 export interface JsonRpcProtocolServer {
   readonly handle: (
     message: JsonRpcRequest | JsonRpcRequest[],
@@ -68,6 +70,7 @@ export function createJsonRpcProtocolServer(options: {
   readonly recordTraffic?: (entry: DaemonTrafficLogEntry) => void;
   readonly requestShutdown?: () => void;
   readonly buildDrainStatus?: () => DaemonBuildDrainStatus;
+  readonly stopping?: () => boolean;
   readonly onRequestStarted?: (method: string) => void;
   readonly onRequestSettled?: (method: string) => void;
   readonly onBuildDriftObserved?: () => void;
@@ -157,6 +160,8 @@ export function createJsonRpcProtocolServer(options: {
       });
     }
     if (!handshaken) return reply(method, daemonProtocolError(method, "hello_required", "Call protocol.hello first."));
+    const stoppingRefusal = daemonStoppingRefusal(method, options.stopping?.() === true);
+    if (stoppingRefusal) return reply(method, stoppingRefusal);
     const remoteProxy = options.host.remoteProxy;
     if (method === "daemon.repo.bootstrap" && remoteProxy?.route(params.repoId))
       return reply(
@@ -184,25 +189,13 @@ export function createJsonRpcProtocolServer(options: {
     }
     if (request.method === "daemon.status") {
       const warning = daemonBuildStaleNotice(options.buildObserver, options.buildDrainStatus);
-      return reply("daemon.status", { ok: true, ...withDaemonBuildDrainSummary(options.host.status(), warning) });
+      return reply("daemon.status", { ok: true, ...withDaemonDrainSummary(options.host.status(), warning, options) });
     }
     if (request.method === "daemon.stop" && method === request.method) {
-      if (options.authContext.transportKind !== "unix-socket" || options.authContext.assignmentBinding)
-        return reply(
-          method,
-          daemonProtocolError(
-            "daemon-stop",
-            "local_transport_required",
-            "Stop is available only through the local session token.",
-          ),
-        );
-      if (!options.requestShutdown)
-        return reply(
-          method,
-          daemonProtocolError("daemon-stop", "shutdown_unavailable", "This daemon composition has no shutdown owner."),
-        );
+      const refusal = daemonStopRefusal(options.authContext, options.requestShutdown);
+      if (refusal) return reply(method, refusal);
       const response = reply(method, { ok: true, command: "daemon-stop", pid: process.pid });
-      options.requestShutdown();
+      options.requestShutdown?.();
       return response;
     }
     if (request.method === "daemon.repo.bootstrap" && method === request.method) {

--- a/packages/daemon/src/runtime.ts
+++ b/packages/daemon/src/runtime.ts
@@ -53,7 +53,9 @@ export async function startDaemon(input: {
     stopPromise: Promise<void> | null = null,
     activeRequests = 0,
     drainCheckScheduled = false,
-    buildSupersessionObserved = false;
+    buildSupersessionObserved = false,
+    socketBound = false,
+    stopping = false;
   const liveRuntimeSessions = new Set<string>();
   const buildDrainStatus = (): DaemonBuildDrainStatus => {
     const repos = host?.status().repos ?? [];
@@ -63,14 +65,21 @@ export async function startDaemon(input: {
       attachingRepositories: repos.filter((repo) => repo.state === "warming").length,
     };
   };
+  // Shutdown used to close the socket first and release the pid file and the singleton lock after the
+  // WAL drain, so for the whole length of that drain the endpoint said "gone" while the pid file and
+  // the lock said "here". Three observers each guessed differently in that gap. Admission is now this
+  // flag rather than a closed socket, so the endpoint stays bound and answers `daemon_stopping` until
+  // the drain finishes, and endpoint, pid file and lock are released together: an observer either
+  // finds a daemon that can speak for itself, or finds nothing at all.
   const stop = (outcome: "stop_requested" | "build_superseded" = "stop_requested"): Promise<void> => {
     if (stopPromise) return stopPromise;
+    stopping = true;
     stopPromise = (async () => {
+      // RepoCell.close drains each local WAL before the daemon advertises its terminal boundary.
+      await host!.close();
+      lifecycle.record({ event: "process_exit", outcome });
       await transport!.stop();
       await connLog.settle();
-      await host!.close();
-      // RepoCell.close drains each local WAL before the daemon advertises its terminal boundary.
-      lifecycle.record({ event: "process_exit", outcome });
       rmSync(pidPath, { force: true });
       singleton.release();
     })();
@@ -117,6 +126,7 @@ export async function startDaemon(input: {
           recordRequest: requestLog.record,
           recordTraffic: connLog.request,
           buildDrainStatus,
+          stopping: () => stopping,
           onRequestStarted: () => {
             activeRequests += 1;
           },
@@ -136,6 +146,7 @@ export async function startDaemon(input: {
       onConnectionClosed: (connection) => connLog.connectionClosed(connection.connectionId),
     });
     await transport.start();
+    socketBound = true;
     lifecycle.record({ event: "socket_bound", endpoint });
     host.startAttachments();
   } catch (error) {
@@ -144,6 +155,9 @@ export async function startDaemon(input: {
       outcome: "startup_failed",
       error: error instanceof Error ? (error.stack ?? error.message) : String(error),
     });
+    // A failed startup releases the same three keys in the same order a drained shutdown does, so a
+    // bound endpoint never outlives the pid file that names its owner.
+    if (socketBound) await transport!.stop();
     await connLog.settle();
     await host?.close();
     rmSync(pidPath, { force: true });


### PR DESCRIPTION
# English

## Summary

`ha daemon stop` used to report `daemon_stop_timeout` and the next command `daemon_unavailable` while the daemon was actually draining: the socket was closed first, the pid file and singleton lock stayed, and three observers (stop client, autostart, status) each guessed differently about that middle state. The daemon now keeps its endpoint until shutdown has drained, answers every request in that window with an explicit `daemon_stopping` refusal, and the CLI reports a draining daemon instead of inventing a timeout. Nothing about the 5-second budget, the singleton lock or the build-drift self-exit changed.

## Architectural Justification

The task plan falsified two of its own premises (there is no post-merge daemon self-heal, and the new daemon did start 2 seconds later) and kept the one real defect: an unreadable middle state. The fix makes the state readable at its single source (the server's stopping flag on the request path) so the guessing branches in the stop client and autostart can be deleted; the stop order in `runtime.ts` becomes host close, then transport stop, then connection log settle. Decision `dec_4E7C69255588FAC14675540742` records the rejected shapes (bigger budget, retries, sleep-and-reread, early lock release).

## What Changed

- `packages/daemon/src/runtime.ts`: hold the socket through drain; expose `stopping` to the server.
- `packages/daemon/src/protocol/json-rpc-server.ts` / `json-rpc-dispatch-support.ts`: one `daemon_stopping` refusal on the request path; stop refusal helper; drain summary on `daemon.status`.
- `packages/daemon/src/daemon-build-drain.ts`, `client/daemon-autostart.ts`: read the explicit state instead of inferring it.
- `packages/cli/src/daemon/control.ts`, `cli/guidance-plane.ts`: report draining; the protocol hint text now reaches the user.
- `packages/cli/test/daemon-stop-drain-window.test.ts`: drain window fixture with a slow `close()`, fast-drain control, and the wedged-daemon timeout kept as the negative control.

## Gate Harvest / 门收割

No gate change.

## Machine-Readable Declarations

Production-Delta: +131/-52
Dependency-Change: none

### Optional Evidence Claims

none

## Task And Scope

task_c2477c407d9577a50fbbe26f0a (daemon stop middle state). Branch `codex/daemon-stop-midstate`.

Fleet view: the stopping flag is per daemon process; an edge node draining its own daemon refuses only its own clients, and the center queue is not involved.

## Version Impact

No version change; publish impact none.

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none
- Authority: task_c2477c407d9577a50fbbe26f0a
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Follow-up governance task: not applicable

## Verification

- Base merge-base d33942e26d76e79f9915ac20433a3ef633ff1d73.
- Worker (Opus) on isolated Ubuntu: slow-drain before/after, fast-drain control, 10 consecutive runs of the new test (reports under the task package).
- CEO after rebase onto d33942e2: `daemon-stop-drain-window.test.ts` exit 0 on isolated Ubuntu; file-complexity and cli-structure gates pass.
- CI is the complete authority.

## Review Evidence

CEO semantic review against the task plan: both falsified premises are recorded as facts, not padded; the delivered mechanism is one readable state plus deletions of the guessing branches; no budget, retry or lock-order change. The new error code is a behavior change and is listed below.

## Residual Risk

`daemon_stopping` is a new external error code seen only during a drain window; downstream code that switches on `daemon_unavailable` will see it instead. The drain window still costs the existing 5-second budget before the CLI says "draining". Long real drains with non-empty WAL queues were not exercised.

# 中文

## 概要

`ha daemon stop` 在 daemon 其实正在 drain 时报 `daemon_stop_timeout`,下一条命令报 `daemon_unavailable`:socket 先关了,pid 文件与单例锁还在,三个观察者各自猜。现在 daemon 把 endpoint 留到 drain 结束,窗口内所有请求收到明确的 `daemon_stopping`,CLI 如实报「正在 drain」。5 秒预算、单例锁、build 漂移自退都没动。

## 架构辩护

plan 证伪了自己两个前提,只留下真缺陷:中间态不可读。修法是在唯一来源(server 请求路径上的 stopping 标志)把状态变成可读的,从而删掉 stop 客户端与 autostart 里的猜测分支;decision dec_4E7C69255588FAC14675540742 记录了被否的形状。

## 机读声明

生产行数增减(与上文机读声明一致):+131/-52

## 治理声明

- 触碰受保护面:否
- 授权:task_c2477c407d9577a50fbbe26f0a
- Break-glass:否

## 验证

Opus 隔离 Ubuntu 上前后对照与 10 次连跑;CEO rebase 后复跑新测试 exit 0,结构门绿。

## 评审证据

CEO 语义复核:一个可读状态加删除猜测分支,无预算/重试/锁序改动。

## 残余风险

`daemon_stopping` 是新对外错误码;drain 窗口仍先花满 5 秒;长 drain 未实测。

