### PR TITLE
fix(kernel): make vertical artifact kinds parseable relation endpoints

### DIFF
--- a/packages/daemon/src/artifact-entity-action.ts
+++ b/packages/daemon/src/artifact-entity-action.ts
@@ -8,13 +8,17 @@ import {
   type ArtifactSourceResolution,
 } from "../../application/src/index.ts";
 import {
+  compiledRelationDirections,
   compileVerticalContract,
+  composeCanonicalRelationDirections,
   isEntityDeclarationEvent,
   isEntityEvent,
   normalizeRelativeDocumentPath,
   type AuthorizationDecision,
   type CanonicalEventStore,
+  type CanonicalRelationDirection,
   type CompiledArtifactKindContract,
+  type CompiledVerticalContract,
   type EntityActionContract,
   type EntityEventV1,
   type TaskProjection,
@@ -24,13 +28,27 @@ import { defaultAssets } from "../../preset/src/preset-resolver-common.ts";
 import { loadCanonicalAssets } from "../../preset/src/preset-assets.ts";
 import type { RepoCellBinding, RepoTaskAction } from "./repo-cell-types.ts";
 
-let cachedArtifactKinds: readonly CompiledArtifactKindContract[] | null = null;
+let cachedVertical: CompiledVerticalContract | null = null,
+  cachedRelationDirections: readonly CanonicalRelationDirection[] | null = null;
 type ArtifactImportReceipt = WriteReceipt & { readonly entityId: string };
 
+function canonicalVertical(): CompiledVerticalContract {
+  if (cachedVertical === null) cachedVertical = loadCanonicalAssets(defaultAssets).compiledVertical;
+  return cachedVertical;
+}
+
 export function compiledArtifactKinds(): readonly CompiledArtifactKindContract[] {
-  if (cachedArtifactKinds === null)
-    cachedArtifactKinds = loadCanonicalAssets(defaultAssets).compiledVertical.artifactKinds;
-  return cachedArtifactKinds;
+  return canonicalVertical().artifactKinds;
+}
+
+/**
+ * The registry relation writes are admitted against: kernel rows plus the governed rows the canonical
+ * vertical compiled, so a kind-declared triple is writable through the same authority as a code row.
+ */
+export function relationDirectionRegistry(): readonly CanonicalRelationDirection[] {
+  if (cachedRelationDirections === null)
+    cachedRelationDirections = composeCanonicalRelationDirections(compiledRelationDirections(canonicalVertical()));
+  return cachedRelationDirections;
 }
 
 /** Test seam for custom verticals: callers compile the same source value and pass its artifactKinds. */

--- a/packages/daemon/src/entity-action-relation.ts
+++ b/packages/daemon/src/entity-action-relation.ts
@@ -12,6 +12,7 @@ import {
   type TaskProjection,
   type WriteReceiptDraft as WriteReceipt,
 } from "../../kernel/src/index.ts";
+import { relationDirectionRegistry } from "./artifact-entity-action.ts";
 import type { RepoCellBinding, RepoTaskAction } from "./repo-cell-types.ts";
 
 type ExecutableRelationAction = EntityActionContract & { readonly execution: EntityActionExecutionContract };
@@ -69,6 +70,7 @@ export function executeRelationAction(input: {
           workspaceRevision: headRevision + 1,
           priorTargetVersion: current?.targetObservedVersion ?? null,
           currentTargetVersion: target?.currentVersion ?? null,
+          relationDirections: relationDirectionRegistry(),
         }),
     compiled = replay ?? (draft?.kind === "relation" ? draft.event : null);
   if (!compiled || !isRelationEvent(compiled))

--- a/packages/daemon/test/artifact-relation-endpoint.integration.test.ts
+++ b/packages/daemon/test/artifact-relation-endpoint.integration.test.ts
@@ -1,0 +1,143 @@
+// harness-test-tier: integration
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { deriveRelationId, makeTaskEventReader, makeTaskProjection } from "../../kernel/src/index.ts";
+import { canonicalRoot, workspaceId } from "../src/protocol/daemon-protocol.contract.ts";
+import { withRoleBinding } from "./role-binding.fixtures.ts";
+import { openBootstrappedRepoCell as openRepoCell } from "./repo-settings.fixture.ts";
+
+const kind = "software/coding/architecture-decision-record@1",
+  binding = withRoleBinding(
+    {
+      actor: {
+        principal: { personId: "person-artifact-relation" },
+        executor: { kind: "agent" as const, id: "artifact-relation-edge" },
+      },
+      source: "local" as const,
+    },
+    "repo-write",
+  );
+
+test("A vertical artifact entity is a relation endpoint for its declared triple only", async () => {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-artifact-relation-")),
+    sourcePath = "docs/adr-0001.md",
+    repoId = workspaceId("artifact-relation");
+  let cell: Awaited<ReturnType<typeof openRepoCell>> | undefined;
+  try {
+    initRepo(rootDir);
+    mkdirSync(path.join(rootDir, "docs"), { recursive: true });
+    writeFileSync(path.join(rootDir, sourcePath), "# Adopt the event ledger\n\nFirst observation.\n");
+    git(rootDir, "add", sourcePath);
+    git(rootDir, "commit", "-qm", "add artifact source");
+    cell = await openRepoCell({
+      repoId,
+      rootDir: canonicalRoot(rootDir),
+      ownerId: "artifact-relation-center",
+      now: monotonicClock(),
+    });
+    const imported = await cell.run(
+      { kind: "entity-import", entityKind: kind, locator: sourcePath, expectedVersion: 0 },
+      binding,
+    );
+    assert.equal(imported.outcome, "applied", JSON.stringify(imported));
+    const entityRef = `${kind}/${String((imported as { readonly entityId?: string }).entityId)}`,
+      proposed = await cell.run(proposal("Artifact relation endpoint"), binding),
+      decisionId = String(receiptJson(proposed).decisionId);
+    assert.equal(proposed.outcome, "applied", JSON.stringify(proposed));
+
+    const declared = await cell.run(
+      {
+        kind: "relation-relate",
+        sourceRef: entityRef,
+        targetRef: `decision/${decisionId}`,
+        relationType: "relates",
+        rationale: "The architecture decision record relates to the decision it records.",
+        expectedVersion: 0,
+      },
+      binding,
+    );
+    assert.equal(declared.outcome, "applied", JSON.stringify(declared));
+
+    const undeclared = await cell.run(
+      {
+        kind: "relation-relate",
+        sourceRef: entityRef,
+        targetRef: `decision/${decisionId}`,
+        relationType: "derives",
+        rationale: "An undeclared triple must be refused by the direction registry.",
+        expectedVersion: 0,
+      },
+      binding,
+    );
+    assert.equal(undeclared.outcome, "op_rejected", JSON.stringify(undeclared));
+    assert.equal(undeclared.code, "relation_triple_undeclared", JSON.stringify(undeclared));
+
+    await cell.close();
+    cell = undefined;
+    const relationId = deriveRelationId({
+        source: entityRef,
+        target: `decision/${decisionId}`,
+        type: "relates",
+        direction: "directed",
+      }),
+      rebuildStore = makeTaskEventReader({ repoId, rootDir }),
+      rebuilt = makeTaskProjection({ rootDir, eventStore: rebuildStore, now: () => "2026-09-04T00:01:00.000Z" });
+    try {
+      rebuilt.rebuild();
+      const edge = rebuilt.readRelationTruth().edges.find((row) => row.relationId === relationId);
+      assert.equal(edge?.sourceRef, entityRef, "the artifact edge must survive a cold rebuild");
+      assert.equal(edge?.state, "active");
+    } finally {
+      rebuilt.close();
+    }
+  } finally {
+    await cell?.close();
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});
+
+function proposal(title: string) {
+  return {
+    kind: "decision-propose",
+    jsonInput: JSON.stringify({
+      title,
+      question: "Should artifact entities be relation endpoints?",
+      riskTier: "medium",
+      urgency: "high",
+      vertical: "software/coding",
+      preset: "standard-task",
+      decisionClass: "ordinary",
+      appliesTo: { modules: ["daemon"], productLines: [] },
+      chosen: [{ id: "CH1", text: "Yes, through the compiled direction registry" }],
+      rejected: [{ id: "RJ1", text: "Special-case artifact refs", whyNot: "It forks ref parsing" }],
+      claims: [{ id: "C1", text: "The record documents this decision.", loadBearing: true }],
+      fulfillments: [],
+    }),
+  } as const;
+}
+function receiptJson(receipt: { readonly evidence?: string }): Record<string, unknown> {
+  return JSON.parse(String(receipt.evidence)) as Record<string, unknown>;
+}
+function monotonicClock(): () => string {
+  let second = 0;
+  return () => `2026-09-04T00:00:${String(second++).padStart(2, "0")}.000Z`;
+}
+function initRepo(rootDir: string): void {
+  git(rootDir, "init", "-q");
+  git(rootDir, "config", "user.name", "Artifact Relation Test");
+  git(rootDir, "config", "user.email", "artifact-relation@example.invalid");
+  mkdirSync(path.join(rootDir, "harness"), { recursive: true });
+  writeFileSync(
+    path.join(rootDir, "harness/harness.yaml"),
+    "layout:\n  authoredRoot: harness\n  localRoot: .harness\n",
+  );
+  git(rootDir, "add", ".");
+  git(rootDir, "commit", "-qm", "base");
+}
+function git(rootDir: string, ...args: string[]): string {
+  return execFileSync("git", ["-C", rootDir, ...args], { encoding: "utf8" });
+}

--- a/packages/kernel/src/domain/artifact-entity.ts
+++ b/packages/kernel/src/domain/artifact-entity.ts
@@ -1,6 +1,7 @@
 import { sha256Bytes, sha256Text } from "../integrity/stable-hash.ts";
 import { normalizeRelativeDocumentPath } from "../layout/portable-path.ts";
 import type { ArtifactEntityKindDefinition } from "../schemas/vertical-definition.ts";
+import { artifactEntityIdPattern } from "./entity-ref.ts";
 import {
   parseEntityJsonSchema,
   serializeEntityJsonSchema,
@@ -237,7 +238,7 @@ export function artifactEntityContractFromSnapshot(
   const decoded = decodeArtifactEntityContractSnapshot(snapshot, allowUnknownFields),
     identity = Object.freeze({
       field: "entityId",
-      pattern: `^${decoded.idPrefix}-[a-f0-9]{16}$`,
+      pattern: artifactEntityIdPattern(decoded.idPrefix),
       refTemplate: `${decoded.typeIdentity}/{id}` as `${string}/{id}`,
     });
   return deepFreeze({

--- a/packages/kernel/src/domain/entity-action-execution.ts
+++ b/packages/kernel/src/domain/entity-action-execution.ts
@@ -9,6 +9,7 @@ import {
 } from "./decision-event.ts";
 import { proposalIssues } from "./decision-event-payload-validation.ts";
 import { deriveRelationId } from "./entity-relation.ts";
+import type { CanonicalRelationDirection } from "./relation-direction.ts";
 import {
   compileRelationCreatedEvent,
   compileRelationReconfirmedEvent,
@@ -101,6 +102,8 @@ export interface EntityActionCompileInput {
   readonly currentDocumentBody?: string;
   readonly priorTargetVersion?: EntityVersion | null;
   readonly currentTargetVersion?: EntityVersion | null;
+  /** The composed direction registry (kernel rows plus the compiled vertical rows) admitting the write. */
+  readonly relationDirections?: readonly CanonicalRelationDirection[];
   readonly coverage?: {
     readonly decisionId: string;
     readonly taskId: string;
@@ -311,6 +314,7 @@ export function relationActionCompiler(id: "relate" | "unrelate" | "reconfirm"):
         opId: input.opId,
         occurredAt: input.occurredAt,
         workspaceRevision: input.workspaceRevision,
+        ...(input.relationDirections ? { directions: input.relationDirections } : {}),
       }),
     };
   };

--- a/packages/kernel/src/domain/entity-ref.ts
+++ b/packages/kernel/src/domain/entity-ref.ts
@@ -4,7 +4,8 @@ export { ENTITY_ID_PATTERN };
 export type EntityKindRefAuthority<K extends EntityKind = EntityKind> = EntityIdentityContract<K> & {
   readonly kind: K;
 };
-export type EntityRefKind = EntityKind;
+/** A built-in kind, or the type identity of a vertical Artifact kind compiled at load time. */
+export type EntityRefKind = string;
 
 export interface ParsedEntityRef {
   readonly raw: string;
@@ -19,6 +20,29 @@ export type EntityRef = ParsedEntityRef["raw"];
 
 const entityRefPrefixPattern = /^(?:(?<alias>[A-Za-z][A-Za-z0-9_-]*):)?(?<body>.+)$/u;
 const templateTokenPattern = /^\{(?<kind>[a-z-]+)\}$/u;
+
+/** The identity prefix a vertical declares for its Artifact kind (`vertical-definition/v1`). */
+const artifactIdPrefixPattern = "[A-Z][A-Z0-9]{0,15}",
+  artifactIdSuffixPattern = "-[a-f0-9]{16}";
+
+/** The id pattern an Artifact kind contract carries, so kind compilation and ref parsing share one grammar. */
+export function artifactEntityIdPattern(idPrefix: string): string {
+  return `^${idPrefix}${artifactIdSuffixPattern}$`;
+}
+/**
+ * Vertical Artifact kinds are compiled from a vertical definition when the daemon loads it, so they
+ * cannot be static rows in `entityTypeContracts`. Their ref body is fixed by the compiler: the type
+ * identity `<verticalId>/<kindId>@<version>` names the kind, then the entity id. The `@<version>`
+ * segment is what separates it from every built-in kind, none of which carries one. Parsing stays
+ * syntactic: whether the kind is registered stays the direction registry's answer, and whether the
+ * entity exists stays the projection's.
+ */
+function artifactRefBodyPattern(capture: boolean): string {
+  const kind = String.raw`[A-Za-z0-9][A-Za-z0-9_.\-/]*@[1-9][0-9]*`,
+    id = `${artifactIdPrefixPattern}${artifactIdSuffixPattern}`;
+  return capture ? `(?<kind>${kind})/(?<id>${id})` : `(?:${kind})/(?:${id})`;
+}
+const artifactRefPattern = new RegExp(`^${artifactRefBodyPattern(true)}$`, "u");
 
 export function parseEntityRef(value: string): ParsedEntityRef | null {
   const prefix = value.match(entityRefPrefixPattern),
@@ -41,7 +65,15 @@ export function parseEntityRef(value: string): ParsedEntityRef | null {
       externalHarness: Boolean(harnessAlias),
     };
   }
-  return null;
+  const artifact = body.match(artifactRefPattern)?.groups;
+  if (!artifact?.kind || !artifact.id) return null;
+  return {
+    raw: value,
+    kind: artifact.kind,
+    id: artifact.id,
+    ...(harnessAlias ? { harnessAlias } : {}),
+    externalHarness: Boolean(harnessAlias),
+  };
 }
 
 export function findEntityRefs(body: string): ReadonlyArray<ParsedEntityRef> {
@@ -83,7 +115,10 @@ function refAuthorities(): readonly EntityKindRefAuthority[] {
 }
 
 function entityRefSearchPattern(): RegExp {
-  const bodies = refAuthorities().map((contract) => compileRefBodyPattern(contract, false));
+  const bodies = [
+    ...refAuthorities().map((contract) => compileRefBodyPattern(contract, false)),
+    artifactRefBodyPattern(false),
+  ];
   return new RegExp(String.raw`(?<![A-Za-z0-9_/-])(?:[A-Za-z][A-Za-z0-9_-]*:)?(?:${bodies.join("|")})\b(?!\/)`, "gu");
 }
 

--- a/packages/kernel/src/domain/entity-relation.ts
+++ b/packages/kernel/src/domain/entity-relation.ts
@@ -299,22 +299,11 @@ function validGovernedRelationApproval(value: unknown): boolean {
 }
 
 function governedRelationEndpointKind(ref: string, witness: GovernedRelationRegistryWitness): string | null {
-  const builtin = parseEntityRef(ref);
-  if (builtin && !builtin.externalHarness) return builtin.kind;
-  for (const endpoint of witness.artifactEndpoints) {
-    const [prefix, suffix] = endpoint.refTemplate.split("{id}"),
-      trailing = suffix ?? "";
-    if (
-      prefix === undefined ||
-      !ref.startsWith(prefix) ||
-      !ref.endsWith(trailing) ||
-      ref.length <= prefix.length + trailing.length
-    )
-      continue;
-    const id = ref.slice(prefix.length, trailing ? -trailing.length : undefined);
-    if (new RegExp(endpoint.idPattern, "u").test(id)) return endpoint.kind;
-  }
-  return null;
+  const parsed = parseEntityRef(ref);
+  if (!parsed || parsed.externalHarness) return null;
+  const endpoint = witness.artifactEndpoints.find(({ kind }) => kind === parsed.kind);
+  if (!endpoint) return parsed.kind;
+  return new RegExp(endpoint.idPattern, "u").test(parsed.id) ? parsed.kind : null;
 }
 
 function validGovernedArtifactEndpoint(

--- a/packages/kernel/src/domain/index.ts
+++ b/packages/kernel/src/domain/index.ts
@@ -185,8 +185,10 @@ export type { UseCaseProjectionName } from "./use-case-projection-catalog.ts";
 
 export { projectBaseEntityAtCut, requireEntityTypeContract } from "./base-entity.ts";
 export type { BaseEntity } from "./base-entity.ts";
-export { compileVerticalContract } from "./vertical-contract.ts";
+export { compiledRelationDirections, compileVerticalContract } from "./vertical-contract.ts";
 export type { CompiledArtifactKindContract, CompiledVerticalContract } from "./vertical-contract.ts";
+export { composeCanonicalRelationDirections } from "./relation-direction.ts";
+export type { CanonicalRelationDirection } from "./relation-direction.ts";
 export type {
   EntityActionCriterionFailure,
   EntityActionCompileInput,

--- a/packages/kernel/src/domain/relation-event.ts
+++ b/packages/kernel/src/domain/relation-event.ts
@@ -14,6 +14,7 @@ import {
 } from "./entity-relation.ts";
 import type { EntityVersion } from "./entity-freshness.ts";
 import { parseEntityRef } from "./entity-ref.ts";
+import { canonicalRelationDirections, type CanonicalRelationDirection } from "./relation-direction.ts";
 import type { DecisionEventV1 } from "./decision-event.ts";
 import { factRef, type FactEventV1 } from "./fact-event.ts";
 import type { MigrationImportEventV1 } from "./migration-import-event.ts";
@@ -286,8 +287,10 @@ export function compileRelationCreatedEvent(input: {
   readonly opId: string;
   readonly occurredAt: string;
   readonly workspaceRevision: number;
+  readonly directions?: readonly CanonicalRelationDirection[];
 }): RelationCreated {
   assertRelationEventRecord(input.record);
+  assertRelationAdmission(input.record, input.directions);
   return {
     schema: "relation-event/v1",
     eventId: `event-${input.opId}`,
@@ -476,13 +479,40 @@ function replayCreatedEvent(
   });
 }
 
-export function assertRelationRecord(record: EntityRelationRecord): void {
-  const source = parseEntityRef(record.source),
-    target = parseEntityRef(record.target);
+/**
+ * 铁律三 admission: a triple is writable exactly when the direction registry the caller compiled has
+ * a row for it. Callers that admit vertical Artifact endpoints pass the composed registry; stored
+ * history is deliberately not re-judged against it, because a later registry revision must not make
+ * an already written edge unreplayable (governed-entity-design §5).
+ */
+export function assertRelationAdmission(
+  record: Pick<EntityRelationRecord, "source" | "target" | "type">,
+  directions: readonly CanonicalRelationDirection[] = canonicalRelationDirections,
+): void {
+  const kinds = relationEndpointKinds(record);
+  if (!isAllowedRelationKindTriple(kinds.source, record.type, kinds.target, directions))
+    throw Object.assign(
+      new Error(
+        `Relation triple ${kinds.source} --${record.type}--> ${kinds.target} is not declared ` +
+          "in the canonical direction registry",
+      ),
+      { code: "relation_triple_undeclared" },
+    );
+}
+
+function relationEndpointKinds(record: Pick<EntityRelationRecord, "source" | "target">): {
+  readonly source: string;
+  readonly target: string;
+} {
+  const source = parseEntityRef(String(record.source)),
+    target = parseEntityRef(String(record.target));
   if (!source || source.externalHarness || !target || target.externalHarness)
     throw new Error("Relation endpoints must be canonical registered Entity refs");
-  if (!isAllowedRelationKindTriple(source.kind, record.type, target.kind))
-    throw new Error(`Relation type ${record.type} is not writable for ${source.kind}->${target.kind}`);
+  return { source: source.kind, target: target.kind };
+}
+
+export function assertRelationRecord(record: EntityRelationRecord): void {
+  assertRelationAdmission(record);
   if (
     record.relation_id !== deriveRelationId(record) ||
     !relationTypes.includes(record.type) ||
@@ -529,14 +559,9 @@ function assertRelationEventRecord(
       },
       registry,
     );
-  else {
-    const source = parseEntityRef(String(record.source)),
-      target = parseEntityRef(String(record.target));
-    if (!source || source.externalHarness || !target || target.externalHarness)
-      throw new Error("Relation endpoints must be canonical registered Entity refs");
-    if (!isAllowedRelationKindTriple(source.kind, record.type as EntityRelationRecord["type"], target.kind))
-      throw new Error(`Relation type ${String(record.type)} is not writable for ${source.kind}->${target.kind}`);
-  }
+  // Endpoint refs must resolve here; the triple itself is admitted at write time (assertRelationAdmission),
+  // so a later registry revision cannot make stored history unreplayable.
+  else relationEndpointKinds(record as unknown as EntityRelationRecord);
   if (
     record.relation_id !== deriveRelationId(record as unknown as EntityRelationRecord) ||
     !relationTypes.includes(record.type as EntityRelationRecord["type"]) ||

--- a/packages/kernel/src/domain/vertical-contract.ts
+++ b/packages/kernel/src/domain/vertical-contract.ts
@@ -6,6 +6,7 @@ import {
   type VerticalDefinition,
 } from "../schemas/vertical-definition.ts";
 import { baseEntityTypeContract, entityTypeContracts, type EntityTypeContract } from "./base-entity.ts";
+import { artifactEntityIdPattern } from "./entity-ref.ts";
 import { artifactDescriptorSchema, deepFreeze } from "./artifact-entity.ts";
 import {
   artifactEntityActionCatalog,
@@ -87,7 +88,7 @@ export function compileVerticalContract(
     const typeIdentity = `${definition.id}/${artifact.id}@${artifact.version}`,
       identity = Object.freeze({
         field: "entityId",
-        pattern: `^${artifact.idPrefix}-[a-f0-9]{16}$`,
+        pattern: artifactEntityIdPattern(artifact.idPrefix),
         refTemplate: `${typeIdentity}/{id}` as `${string}/{id}`,
       }),
       residency = Object.freeze({ authored: "ledger" as const }),

--- a/packages/kernel/test/contracts/governed-relation-rows.test.ts
+++ b/packages/kernel/test/contracts/governed-relation-rows.test.ts
@@ -7,6 +7,8 @@ import {
   type GovernedRelationCompilationAuthority,
 } from "../../src/domain/governed-relation-direction.ts";
 import { isAllowedRelationKindTriple, isAllowedRelationRecord } from "../../src/domain/entity-relation.ts";
+import { parseEntityRef } from "../../src/domain/entity-ref.ts";
+import { assertRelationAdmission } from "../../src/domain/relation-event.ts";
 import {
   acceptVerticalRegistryCandidate,
   compiledRelationDirections,
@@ -68,6 +70,30 @@ test("governed triples compile into the one canonical runtime registry", () => {
     accepted.relationDirections.every((row) => Object.isFrozen(row)),
     true,
   );
+});
+
+test("an artifact entity is a relation endpoint for its declared triple only", () => {
+  const accepted = acceptVerticalRegistryCandidate({
+      current: emptyCompiledVerticalRegistry(),
+      expectedRevision: 0,
+      source: verticalWith(artifact({ relations: [relation()] })),
+    }),
+    artifactRef = `${artifactType}/ADR-0123456789abcdef`,
+    declared = { source: artifactRef, target: "decision/dec_29CCC98CD0241D0C9806AC1CF1", type: "relates" } as const;
+  assert.deepEqual(parseEntityRef(artifactRef), {
+    raw: artifactRef,
+    kind: artifactType,
+    id: "ADR-0123456789abcdef",
+    externalHarness: false,
+  });
+  assertRelationAdmission(declared, accepted.relationDirections);
+  assert.throws(
+    () => assertRelationAdmission({ ...declared, type: "derives" }, accepted.relationDirections),
+    (error: unknown) =>
+      (error as { readonly code?: string }).code === "relation_triple_undeclared" &&
+      /custom\/engineering\/architecture-decision-record@1 --derives--> decision/u.test(String(error)),
+  );
+  assert.throws(() => assertRelationAdmission(declared), /is not declared in the canonical direction registry/u);
 });
 
 for (const counterexample of [

--- a/packages/kernel/test/contracts/relation-entity.test.ts
+++ b/packages/kernel/test/contracts/relation-entity.test.ts
@@ -202,7 +202,7 @@ test("entity_migrated is valid Relation genesis and replacement is an explicit f
 });
 
 test("a governed migration witness admits only its pinned artifact Relation direction", () => {
-  const sourceRef = "software/coding/architecture-decision-record@1/ADR-1234567890ABCDEF",
+  const sourceRef = "software/coding/architecture-decision-record@1/ADR-1234567890abcdef",
     relation = record(sourceRef, "decision/dec_ADR_0001_TEST"),
     registry: GovernedRelationRegistryWitness = {
       schema: "governed-relation-registry-witness/v1",
@@ -210,7 +210,7 @@ test("a governed migration witness admits only its pinned artifact Relation dire
       artifactEndpoints: [
         {
           kind: "software/coding/architecture-decision-record@1",
-          idPattern: "^ADR-[A-F0-9]{16}$",
+          idPattern: "^ADR-[a-f0-9]{16}$",
           refTemplate: "software/coding/architecture-decision-record@1/{id}",
         },
       ],
@@ -257,6 +257,19 @@ test("a governed migration witness admits only its pinned artifact Relation dire
         entity: {
           ...migrated.payload.entity,
           registry: { ...registry, direction: { ...registry.direction, targetKind: "task" } },
+        },
+      },
+    }),
+    [],
+  );
+  assert.notDeepEqual(
+    validateCurrentMigrationImportEvent({
+      ...migrated,
+      payload: {
+        ...migrated.payload,
+        entity: {
+          ...migrated.payload.entity,
+          registry: { ...registry, artifactEndpoints: [{ ...registry.artifactEndpoints[0]!, idPattern: "^ADR-x$" }] },
         },
       },
     }),


### PR DESCRIPTION
# English

## Summary

Vertical-declared artifact kinds could be imported and listed but never used as relation endpoints: `parseEntityRef` only knew the static core kinds, so `ha relation relate` on an `external-issue` or ADR entity failed with `entity_not_found`, and behind that wall the relation direction registry also ignored the compiled governed triples. This change makes artifact refs parseable through the same id grammar the kind compiler uses, admits kind-declared triples at write time with an explicit `relation_triple_undeclared` rejection, and deletes the second artifact-ref parser that had grown beside `parseEntityRef`.

## Architectural Justification

One id grammar (`artifactEntityIdPattern()`) now serves kind compilation and ref parsing, replacing three inline copies. Triple admission moves from decode time to write time: an edge, once written, is not silently dropped when the vertical changes later, which is what governed-entity-design §5 requires. No kind-specific branch was added; the direction registry is kernel rows plus compiled governed rows.

## What Changed

- `packages/kernel/src/domain/entity-ref.ts`: artifact ref syntax in `parseEntityRef`/`findEntityRefs`.
- `packages/kernel/src/domain/relation-event.ts`: `assertRelationAdmission()` at write time; decode-time triple check removed; two inline endpoint parsers merged.
- `packages/kernel/src/domain/entity-relation.ts`: the bypassing `governedRelationEndpointKind` parser deleted.
- `packages/kernel/src/domain/vertical-contract.ts`, `artifact-entity.ts`: shared id pattern instead of literal regexes.
- `packages/daemon/src/artifact-entity-action.ts`, `entity-action-relation.ts`: `relationDirectionRegistry()` passed into the relation write path.
- Tests: new `artifact-relation-endpoint.integration.test.ts` (legal edge applied, undeclared triple rejected, edge survives cold rebuild); contract tests extended.

## Gate Harvest / 门收割

No gate change.

## Machine-Readable Declarations

Production-Delta: +116/-39
Dependency-Change: none

### Optional Evidence Claims

none

## Task And Scope

task_0b99ce971745e5a77e4e213fee (child of GovernedEntity root task_e91dd004d2a4e7a7c90a6fd40a). Branch `codex/artifact-relation-endpoints`. Unblocks W2-C criterion 3 and W2-B.

Fleet view: relation ids derive from (source, target, type, direction); two edge nodes writing the same triple collide on the existing expected-version fence. Admission reads the compiled vertical of the writing node; the center single-writer queue is unchanged.

## Version Impact

No version change; publish impact none.

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none
- Authority: task_0b99ce971745e5a77e4e213fee
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Follow-up governance task: not applicable

## Verification

- Base merge-base 0dd34cd473d47916951bc2a5bf31dbbdaa167ce2.
- Worker (Opus) on isolated Ubuntu: new integration case red before / green after; contract tier 978 pass; 9 targeted integration files green; 16 local gates green. Facts F-AF26DD52, F-8CBDA98B, F-89154AF5.
- CI is the complete authority.

## Review Evidence

CEO semantic review: both worker objections accepted as rulings. (1) The ref authority reuses the compiler-fixed id shape instead of a runtime injection point, avoiding global mutable state and cold-rebuild ordering risk. (2) Moving triple admission to write time is a load-bearing change and is consistent with the design's "existing edges are never silently deleted by configuration change". Goal 1 (the real `ha relation relate` on canonical) is run by the CEO after merge.

## Residual Risk

`external-issue` was not exercised end to end in isolation (no external-key resolver in the fixture); the ADR kind of the same vertical was used. A previously written edge whose triple is no longer declared stays active by design.

# 中文

## 概要

vertical 声明的 artifact kind 能导入、能列出,却不能做 relation 端点:`parseEntityRef` 只认静态核心 kind,`ha relation relate` 对 external-issue / ADR 实体报 entity_not_found;这道墙后面,方向注册表也没把编译出的 governed 三元组算进去。本改动让 artifact ref 走 kind 编译器同一份 id 语法解析,写时用显式的 `relation_triple_undeclared` 准入 kind 声明的三元组,并删掉旁边长出来的第二套 artifact ref 解析。

## 架构辩护

一份 id 语法同时服务 kind 编译与 ref 解析,替代三处内联拷贝;三元组准入从 decode 移到写时,已写入的边不会因 vertical 后来的改动被静默删掉(设计 §5)。没有 kind 专属分支。

## 机读声明

生产行数增减(与上文机读声明一致):+116/-39

## 治理声明

- 触碰受保护面:否
- 授权:task_0b99ce971745e5a77e4e213fee
- Break-glass:否

## 验证

Opus 隔离 Ubuntu:新用例修前红修后绿;contract 978 通过;9 个定向集成文件绿;16 个本地门绿。

## 评审证据

CEO 语义复核:两条异议均采纳为裁决(ref 权威复用编译器固定形状;准入移到写时是承重变更但与设计一致)。Goal 1 的真实命令合并后由 CEO 在 canonical 复跑。

## 残余风险

external-issue 未在隔离环境端到端跑(夹具无 external-key resolver),用了同 vertical 的 ADR kind;已写入但三元组后来被取消声明的边按设计保持 active。
