### PR TITLE
test(daemon): assert the canonical head instead of which WAL writer won the seed submit

### DIFF
--- a/packages/daemon/test/authored-wal-doc-sync.integration.test.ts
+++ b/packages/daemon/test/authored-wal-doc-sync.integration.test.ts
@@ -68,7 +68,12 @@ test("WAL flush keeps forbidden and unresolved candidates out of an eligible bat
     );
     const unresolved = "context/unresolved.md";
     write(rootDir, unresolved, "---\nowner: canonical\n---\n# Unresolved\n\nbase\n");
-    assert.equal((await cell.run({ kind: "doc-submit", paths: [unresolved] }, binding)).outcome, "applied");
+    // The idle authored-candidate settler may publish these bytes before the explicit
+    // submit reaches the cell; both writers are by design and publish the same content,
+    // so the receipt is either applied or a truthful no_changes. The canonical head is
+    // the assertion, not which writer won the race.
+    const seeded = (await cell.run({ kind: "doc-submit", paths: [unresolved] }, binding)).outcome;
+    assert.ok(seeded === "applied" || seeded === "no_changes", JSON.stringify(seeded));
     await waitForHeadBody(rootDir, unresolved, "---\nowner: canonical\n---\n# Unresolved\n\nbase\n");
 
     write(rootDir, unresolved, "---\nowner: hand-edit\n---\n# Unresolved\n\nbase\n");


### PR DESCRIPTION
# English

## Summary

`authored-wal-doc-sync` "WAL flush keeps forbidden and unresolved candidates out of an eligible batch" went red on 3 of 5 CI runs since 2b94abdc while staying green in isolation. Root cause is a race between two by-design writers: the repo cell's idle authored-candidate settler (worker thread, `afterFlush`) can publish a freshly written document before the caller's explicit `doc-submit` is dequeued, so the explicit submit truthfully returns `no_changes`. The test's seed step asserted which writer won; it now asserts the canonical head and accepts either receipt. No product code changes.

## Architectural Justification

Ruling recorded as fact F-E017158E on the task: both writers publish identical bytes under the single-writer queue, the later receipt is honest, and neither a quiet period on the settler nor a retry would add an invariant. The fix is the deletion of a race assertion, not a new mechanism.

## What Changed

- `packages/daemon/test/authored-wal-doc-sync.integration.test.ts`: the seed `doc-submit` accepts `applied` or `no_changes`; the head-body wait and the mixed-batch assertions are unchanged.

## Gate Harvest / 门收割

No gate change.

## Machine-Readable Declarations

Production-Delta: +0/-0
Dependency-Change: none

### Optional Evidence Claims

none

## Task And Scope

task_8ab9263815b746b55b2e86742e. Branch `codex/wal-docsync-nochanges`.

Fleet view: two edge nodes submitting the same bytes collapse to one canonical revision the same way; the explicit-submit receipt after the settler is the same `no_changes`.

## Version Impact

No version change; publish impact none.

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none
- Authority: task_8ab9263815b746b55b2e86742e
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Follow-up governance task: not applicable

## Verification

- Base merge-base 0dd34cd473d47916951bc2a5bf31dbbdaa167ce2.
- Worker (Opus) reproducer on isolated Ubuntu: 40 loops under git/fs plus CPU load, 75 to 82 percent red before; CPU-only load 0 percent red (negative control); instrumented queue order shows the settler landing between two queued submits.
- CEO: the edited file green on isolated Ubuntu.
- CI is the complete authority.

## Review Evidence

CEO ruling against the worker's three options: the explicit submit has no ordering privilege over the settler; the test was asserting a race. Worker facts and the reproducer are on the task package.

## Residual Risk

Path-selected `doc-submit` receipts still do not say that the settler already published the bytes; the summary line only reports `no_changes`. Tracked on the task, not a blocker.

# 中文

## 概要

该用例在 2b94abdc 后 5 次 CI 里红 3 次而隔离单跑绿。根因是两个设计内写者的竞态:repo cell 的 idle 结算器(worker 线程,afterFlush)能在调用方显式 doc-submit 出队之前把刚写入的文档发布出去,显式 submit 于是如实回 no_changes。测试的 seed 步骤断言了「哪个写者赢」;现在改为断言 canonical head 并接受两种回执。无生产代码改动。

## 架构辩护

裁决记为 fact F-E017158E:两个写者在单写队列下发布同一份字节,后到的回执是真话;给结算器加静默期或加重试都不会增加任何不变量。修法是删掉一条竞态断言,不是新增机制。

## 机读声明

生产行数增减(与上文机读声明一致):+0/-0

## 治理声明

- 触碰受保护面:否
- 授权:task_8ab9263815b746b55b2e86742e
- Break-glass:否

## 验证

Opus 复现器:40 次 + git/fs+CPU 负载 75–82% 红,仅 CPU 负载 0% 红(阴性对照);CEO 改后隔离单跑绿。

## 评审证据

CEO 裁决:显式 submit 对结算器没有顺序特权,测试断言的是竞态。

## 残余风险

按路径 submit 的回执仍不会说明结算器已先行发布,只报 no_changes;记在任务上,不阻塞。
