### PR TITLE
feat: derive the task read set from declared relations and serve it through ha task read-set

### DIFF
--- a/packages/application/src/index.ts
+++ b/packages/application/src/index.ts
@@ -24,6 +24,8 @@ export type {
   ArtifactSourceResolution,
   PreparedArtifactEntityImport,
 } from "./artifact-entity-service.ts";
+export { readTaskReadSet } from "./task-read-set-service.ts";
+export type { TaskReadSetProjection } from "./task-read-set-service.ts";
 export { makeTaskActionExplanationService } from "./task-action-explanation-service.ts";
 export { makePersonActionExplanationService } from "./person-action-explanation-service.ts";
 export { makeSquadActionExplanationService } from "./squad-action-explanation-service.ts";

--- a/packages/application/src/task-read-set-service.ts
+++ b/packages/application/src/task-read-set-service.ts
@@ -1,0 +1,42 @@
+import {
+  deriveTaskReadSet,
+  parseEntityRef,
+  type TaskProjection,
+  type TaskReadSet,
+  type TaskReadSetCounterpart,
+} from "../../kernel/src/index.ts";
+
+/** The read side this assembler needs; it writes nothing and takes no lease. */
+export type TaskReadSetProjection = Pick<TaskProjection, "read" | "readRelationQuery" | "readEntityVersionWitness">;
+
+/**
+ * Assemble one task's read set from the canonical relation projection at a single cut.
+ * This layer only gathers inputs — the active edges the relation query authority already
+ * serves to `ha relation list`, plus one entity witness per counterpart — and hands them
+ * to the kernel. Every judgment (inclusion, ordering, `required`, `authority`, `blocked`)
+ * stays in `deriveTaskReadSet`, and nothing here is written back to the task package.
+ */
+export function readTaskReadSet(projection: TaskReadSetProjection, taskId: string): TaskReadSet {
+  const taskRef = `task/${taskId}`,
+    relations = projection.readRelationQuery({ entity: taskRef, state: "active" }),
+    counterparts = new Map<string, TaskReadSetCounterpart>();
+  for (const row of relations.rows) {
+    const entityRef = row.sourceRef === taskRef ? row.targetRef : row.sourceRef;
+    if (entityRef === taskRef || counterparts.has(entityRef)) continue;
+    const parsed = parseEntityRef(entityRef);
+    counterparts.set(entityRef, {
+      witness: projection.readEntityVersionWitness(entityRef),
+      ...(parsed?.kind === "task" ? { packagePath: projection.read(parsed.id).packagePath } : {}),
+    });
+  }
+  return deriveTaskReadSet({
+    taskRef,
+    edges: relations.rows,
+    counterparts,
+    projectionCut: {
+      status: relations.status,
+      watermark: relations.watermark,
+      sourceRevision: relations.sourceRevision,
+    },
+  });
+}

--- a/packages/cli/src/cli/thin-command-task.ts
+++ b/packages/cli/src/cli/thin-command-task.ts
@@ -44,6 +44,7 @@ export function parseTask(
     id === "task-complete" ||
     id === "task-release" ||
     id === "task-reopen" ||
+    id === "task-read-set" ||
     id === "task-review"
   )
     return parseProjected(id, args.slice(3), rootDir, repoId, json, inputs, {

--- a/packages/cli/test/thin-command.test.ts
+++ b/packages/cli/test/thin-command.test.ts
@@ -275,6 +275,7 @@ test("capabilities is an exact-set projection of the command contract", () => {
       "task-list",
       "task-pin",
       "task-progress-append",
+      "task-read-set",
       "task-release",
       "task-reopen",
       "task-review",

--- a/packages/daemon/src/protocol/daemon-protocol-commands-task-surface.ts
+++ b/packages/daemon/src/protocol/daemon-protocol-commands-task-surface.ts
@@ -378,4 +378,12 @@ export const taskSurfaceProtocolCommands = Object.freeze([
       }),
     ],
   }),
+  defineRepoReadCommand({
+    id: "task-read-set",
+    phase: "Governed-Entity-W2-B",
+    path: ["task", "read-set", "<task-id>"],
+    summary: "Derive what a Task must read from its declared relations at one projection cut.",
+    method: "repo.task.read",
+    inputs: [],
+  }),
 ] as const);

--- a/packages/daemon/src/protocol/daemon-protocol.contract.ts
+++ b/packages/daemon/src/protocol/daemon-protocol.contract.ts
@@ -718,6 +718,7 @@ export default Object.freeze({
     "Governed-Entity-W1-D",
     "Governed-Entity-W1-F",
     "Governed-Entity-W2-0",
+    "Governed-Entity-W2-B",
   ]),
   commands: daemonOwnedProtocolCommands,
   methods: Object.freeze([

--- a/packages/daemon/src/repo-cell-action-context.ts
+++ b/packages/daemon/src/repo-cell-action-context.ts
@@ -82,6 +82,7 @@ import {
   listRelations as listRelationsImpl,
   listTasks as listTasksImpl,
   reviewTask as reviewTaskImpl,
+  taskReadSet as taskReadSetImpl,
   taskWipEnteringAction as taskWipEnteringActionImpl,
   wipSnapshotEntries as wipSnapshotEntriesImpl,
 } from "./repo-cell-task-query.ts";
@@ -132,6 +133,7 @@ export interface RepoCellActionContext extends TaskQueryCell {
   readonly listTasks: Bound<typeof listTasksImpl>;
   readonly listRelations: Bound<typeof listRelationsImpl>;
   readonly reviewTask: Bound<typeof reviewTaskImpl>;
+  readonly taskReadSet: Bound<typeof taskReadSetImpl>;
   readonly publishGeneratedArtifact: typeof publishGeneratedArtifact;
   readonly entityActionExecutor: ReturnType<typeof makeEntityActionCatalogExecutor>;
   readonly entityActionRuntimes: EntityActionCatalogRuntimes;
@@ -269,6 +271,7 @@ export function createRepoCellActionContext(bindings: {
     listTasks: bind(listTasksImpl),
     listRelations: bind(listRelationsImpl),
     reviewTask: bind(reviewTaskImpl),
+    taskReadSet: bind(taskReadSetImpl),
     taskListQueryFromAction: (_action: RepoTaskAction) => unavailableTaskQuery(),
     relationQueryFromAction: (_action: RepoTaskAction) => unavailableTaskQuery(),
     queryRead: (): TaskQueryReadModel => unavailableTaskQuery(),

--- a/packages/daemon/src/repo-cell-action-dispatch.ts
+++ b/packages/daemon/src/repo-cell-action-dispatch.ts
@@ -151,6 +151,7 @@ export async function executeAction(
   if (action.kind === "task-show") return cell.showTask(String(action.taskId ?? ""));
   if (action.kind === "task-list") return cell.listTasks(action, binding);
   if (action.kind === "relation-list") return cell.listRelations(action, binding);
+  if (action.kind === "task-read-set") return cell.taskReadSet(action, binding);
   if (action.kind === "task-review") return cell.reviewTask(action, binding);
   if (action.kind === "distill-candidate") {
     const taskId = cell.requiredCellText(action.taskId, "taskId");

--- a/packages/daemon/src/repo-cell-evidence.ts
+++ b/packages/daemon/src/repo-cell-evidence.ts
@@ -17,6 +17,8 @@ export function decodeEvidencePayload(evidence: string): unknown {
 export function renderEvidencePayload(payload: unknown): string {
   const taskIndex = renderTaskIndexPayload(payload);
   if (taskIndex !== null) return taskIndex;
+  const readSet = renderTaskReadSetPayload(payload);
+  if (readSet !== null) return readSet;
   if (Array.isArray(payload)) return renderEvidenceRows(payload);
   if (payload === null || typeof payload !== "object") return String(payload);
   const entries = Object.entries(payload),
@@ -54,4 +56,43 @@ export function renderEvidenceRows(rows: readonly unknown[], named = false): str
             : String(row),
         )
         .join("\n");
+}
+
+/**
+ * The read set carries nested per-entry evidence (why it was included, the edge
+ * revisions), which the generic row renderer drops. Render it so a reader sees, on one
+ * line, what to open, whether it is required, how fresh it is, and which edge said so.
+ */
+function renderTaskReadSetPayload(payload: unknown): string | null {
+  if (payload === null || typeof payload !== "object") return null;
+  const record = payload as Record<string, unknown>;
+  if (record.schema !== "read-set/v1" || !Array.isArray(record.entries)) return null;
+  const entries = record.entries as readonly Record<string, unknown>[],
+    reasons = Array.isArray(record.blockedReasons) ? (record.blockedReasons as readonly Record<string, unknown>[]) : [],
+    gaps = record.blocked === true ? ["blocked:", ...reasons.map(renderReadSetGap)] : [],
+    rows = entries.map(renderReadSetEntry).join("\n");
+  return [
+    ...gaps,
+    "read-set:",
+    rows || "(none)",
+    `task=${String(record.taskRef)}  count=${entries.length}  blocked=${String(record.blocked)}  ` +
+      `status=${String(record.status ?? "unknown")}  watermark=${String(record.watermark ?? "unknown")}  ` +
+      `sourceRevision=${String(record.sourceRevision ?? "unknown")}`,
+  ].join("\n");
+}
+
+function renderReadSetEntry(entry: Record<string, unknown>): string {
+  const why = (entry.whyIncluded ?? {}) as Record<string, unknown>;
+  return [
+    String(entry.entityRef),
+    entry.required === true ? "required" : "recommended",
+    String(entry.authority),
+    String(entry.freshness),
+    entry.locator === null || entry.locator === undefined ? "(no locator)" : String(entry.locator),
+    `${String(why.type)}: ${String(why.rationale)}`,
+  ].join("\t");
+}
+
+function renderReadSetGap(reason: Record<string, unknown>): string {
+  return `  ${String(reason.code)}\t${String(reason.entityRef)}\t${String(reason.detail)}`;
 }

--- a/packages/daemon/src/repo-cell-task-query.ts
+++ b/packages/daemon/src/repo-cell-task-query.ts
@@ -13,6 +13,7 @@ import {
   type TaskWipSnapshotEntryV1,
   type WriteReceiptDraft as WriteReceipt,
 } from "../../kernel/src/index.ts";
+import { readTaskReadSet } from "../../application/src/index.ts";
 import type { RepoCellBinding, RepoTaskAction } from "./repo-cell-types.ts";
 import { requiredPackageDisposition, type TaskQueryReadModel } from "./task-query-read.ts";
 import { resolveTaskRootThreshold, resolveTaskWipLimit } from "./task-wip-settings.ts";
@@ -257,6 +258,29 @@ export function listRelations(cell: TaskQueryCell, action: RepoTaskAction, bindi
     read.sourceRevision,
     null,
     read,
+  );
+}
+
+/**
+ * The read-only read set for one Task: which entities its declared relations say to
+ * read, in what order, and whether the answer is blocked. Pure read — no lease, no
+ * write path, and nothing persisted back into the Task package.
+ */
+export function taskReadSet(cell: TaskQueryCell, action: RepoTaskAction, binding: RepoCellBinding): WriteReceipt {
+  const taskId = cell.requiredCellText(action.taskId, "taskId"),
+    current = cell.projection.read(taskId);
+  if (!cell.projectionReady(current) || !current.snapshot.task)
+    throw cell.cellCodedError(
+      "task_not_found",
+      `Run ha task list, choose an existing task id, then retry task read-set.`,
+    );
+  const derived = readTaskReadSet(cell.projection, taskId);
+  return cell.readResult(
+    cell.operationId(action, binding, cell.input.repoId, current.sourceRevision),
+    derived,
+    current.sourceRevision,
+    null,
+    derived.projectionCut,
   );
 }
 

--- a/packages/daemon/test/task-read-set.integration.test.ts
+++ b/packages/daemon/test/task-read-set.integration.test.ts
@@ -1,0 +1,170 @@
+// harness-test-tier: integration
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { mkdtempSync, readFileSync, readdirSync, rmSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { makeTaskEventReader } from "../../kernel/src/index.ts";
+import { canonicalRoot, workspaceId } from "../src/protocol/daemon-protocol.contract.ts";
+import { withRoleBinding } from "./role-binding.fixtures.ts";
+import { openBootstrappedRepoCell as openRepoCell } from "./repo-settings.fixture.ts";
+import { initRepo } from "./task-surface.fixtures.ts";
+
+const binding = withRoleBinding(
+  {
+    actor: {
+      principal: { personId: "person-task-read-set" },
+      executor: { kind: "agent", id: "agent-task-read-set" },
+    },
+    source: "local" as const,
+  },
+  "repo-write",
+);
+
+interface ReadSetEvidence {
+  readonly schema: string;
+  readonly taskRef: string;
+  readonly entries: readonly {
+    readonly entityRef: string;
+    readonly required: boolean;
+    readonly authority: string;
+    readonly freshness: string;
+    readonly locator: string | null;
+    readonly whyIncluded: { readonly source: string; readonly relationId: string; readonly type: string };
+  }[];
+  readonly blocked: boolean;
+  readonly blockedReasons: readonly { readonly code: string }[];
+  readonly projectionCut: { readonly status: string; readonly watermark: number; readonly sourceRevision: number };
+}
+
+/** Byte-level content of the ledger's task packages, so a read that writes is visible. */
+function taskPackageFingerprint(rootDir: string): readonly string[] {
+  const base = path.join(rootDir, "harness", "tasks");
+  return readdirSync(base, { recursive: true, encoding: "utf8" })
+    .filter((entry) => statSync(path.join(base, entry)).isFile())
+    .sort()
+    .map(
+      (entry) =>
+        `${entry}:${createHash("sha256")
+          .update(readFileSync(path.join(base, entry)))
+          .digest("hex")}`,
+    );
+}
+
+test("task read-set derives one ordered projection per cut and never writes back", async () => {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-task-read-set-"));
+  initRepo(rootDir);
+  const repoId = workspaceId("task-read-set"),
+    cell = await openRepoCell({ repoId, rootDir: canonicalRoot(rootDir), ownerId: "task-read-set-test" });
+  try {
+    for (const [taskId, title] of [
+      ["task_read_set_host", "Read set host"],
+      ["task_read_set_required", "Required dependency"],
+      ["task_read_set_related", "Related sibling"],
+      ["task_read_set_late", "Late sibling"],
+      ["task_read_set_isolated", "Isolated task"],
+    ] as const)
+      assert.equal((await cell.run({ kind: "task-create", taskId, title }, binding)).outcome, "applied");
+
+    for (const [targetRef, relationType, rationale] of [
+      ["task/task_read_set_required", "depends-on", "The host waits for the required dependency."],
+      ["task/task_read_set_related", "relates", "The sibling shares the same surface."],
+    ] as const)
+      assert.equal(
+        (
+          await cell.run(
+            {
+              kind: "relation-relate",
+              sourceRef: "task/task_read_set_host",
+              targetRef,
+              relationType,
+              direction: "directed",
+              origin: "declared",
+              rationale,
+              expectedVersion: 0,
+            },
+            binding,
+          )
+        ).outcome,
+        "applied",
+      );
+
+    const readSet = async (taskId: string) => await cell.run({ kind: "task-read-set", taskId }, binding),
+      warmed = await readSet("task_read_set_host");
+    assert.equal(warmed.outcome, "applied", JSON.stringify(warmed));
+
+    const fingerprintBefore = taskPackageFingerprint(rootDir),
+      eventsBefore = makeTaskEventReader({ repoId, rootDir }).read().events.length,
+      first = JSON.parse(String((await readSet("task_read_set_host")).evidence)) as ReadSetEvidence,
+      second = JSON.parse(String((await readSet("task_read_set_host")).evidence)) as ReadSetEvidence;
+
+    // (1) Two resolutions at the same cut agree field by field.
+    assert.deepEqual(first, second);
+    assert.equal(first.schema, "read-set/v1");
+    assert.deepEqual(
+      first.entries.map(({ entityRef, required, authority, whyIncluded }) => [
+        entityRef,
+        required,
+        authority,
+        whyIncluded.type,
+      ]),
+      [
+        ["task/task_read_set_required", true, "historical", "depends-on"],
+        ["task/task_read_set_related", false, "historical", "relates"],
+      ],
+    );
+    assert.match(String(first.entries[0]?.locator), /^tasks\/task_read_set_required/u);
+    assert.equal(first.entries[0]?.freshness, "current");
+    assert.equal(first.entries[0]?.whyIncluded.source, "task-relation");
+    assert.equal(first.blocked, false);
+    assert.deepEqual(first.blockedReasons, []);
+
+    // (3) Resolving wrote nothing: no ledger event, no byte changed in any task package.
+    assert.deepEqual(taskPackageFingerprint(rootDir), fingerprintBefore);
+    assert.equal(makeTaskEventReader({ repoId, rootDir }).read().events.length, eventsBefore);
+
+    // (2) The answer is bound to the cut, not to who ran first.
+    assert.equal(
+      (
+        await cell.run(
+          {
+            kind: "relation-relate",
+            sourceRef: "task/task_read_set_host",
+            targetRef: "task/task_read_set_late",
+            relationType: "relates",
+            direction: "directed",
+            origin: "declared",
+            rationale: "A late edge must appear in the next cut, not the previous one.",
+            expectedVersion: 0,
+          },
+          binding,
+        )
+      ).outcome,
+      "applied",
+    );
+    const third = JSON.parse(String((await readSet("task_read_set_host")).evidence)) as ReadSetEvidence;
+    assert.ok(
+      third.projectionCut.sourceRevision > first.projectionCut.sourceRevision,
+      `${third.projectionCut.sourceRevision} must advance past ${first.projectionCut.sourceRevision}`,
+    );
+    assert.deepEqual(
+      third.entries.map(({ entityRef }) => entityRef),
+      ["task/task_read_set_required", "task/task_read_set_late", "task/task_read_set_related"],
+    );
+
+    // Negative control: no active edges yields an empty set, not an error or a filename search.
+    const isolated = JSON.parse(String((await readSet("task_read_set_isolated")).evidence)) as ReadSetEvidence;
+    assert.deepEqual(isolated.entries, []);
+    assert.equal(isolated.blocked, false);
+    assert.equal(isolated.taskRef, "task/task_read_set_isolated");
+
+    // Negative control: an unknown task id fails with the standard read command code.
+    const missing = await readSet("task_read_set_absent");
+    assert.equal(missing.outcome, "op_rejected", JSON.stringify(missing));
+    assert.equal(missing.code, "task_not_found", JSON.stringify(missing));
+  } finally {
+    await cell.close();
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});

--- a/packages/kernel/src/domain/index.ts
+++ b/packages/kernel/src/domain/index.ts
@@ -224,20 +224,8 @@ export type {
 } from "./entity-relation.ts";
 export {} from "./entity-freshness.ts";
 export type {} from "./entity-freshness.ts";
-export { deriveTaskReadSet, READ_SET_SCHEMA, readSetAuthorities } from "./task-read-set.ts";
-export type {
-  ReadSetAuthority,
-  ReadSetBlockedCode,
-  ReadSetBlockedReason,
-  ReadSetEdgeVersions,
-  ReadSetEntry,
-  ReadSetInclusion,
-  ReadSetProjectionCut,
-  TaskReadSet,
-  TaskReadSetCounterpart,
-  TaskReadSetEdge,
-  TaskReadSetInput,
-} from "./task-read-set.ts";
+export { deriveTaskReadSet } from "./task-read-set.ts";
+export type { TaskReadSet, TaskReadSetCounterpart } from "./task-read-set.ts";
 
 export { normalizeDomainError } from "./errors.ts";
 export type {

--- a/packages/kernel/src/domain/index.ts
+++ b/packages/kernel/src/domain/index.ts
@@ -224,6 +224,20 @@ export type {
 } from "./entity-relation.ts";
 export {} from "./entity-freshness.ts";
 export type {} from "./entity-freshness.ts";
+export { deriveTaskReadSet, READ_SET_SCHEMA, readSetAuthorities } from "./task-read-set.ts";
+export type {
+  ReadSetAuthority,
+  ReadSetBlockedCode,
+  ReadSetBlockedReason,
+  ReadSetEdgeVersions,
+  ReadSetEntry,
+  ReadSetInclusion,
+  ReadSetProjectionCut,
+  TaskReadSet,
+  TaskReadSetCounterpart,
+  TaskReadSetEdge,
+  TaskReadSetInput,
+} from "./task-read-set.ts";
 
 export { normalizeDomainError } from "./errors.ts";
 export type {

--- a/packages/kernel/src/domain/status-vocabulary-catalog.ts
+++ b/packages/kernel/src/domain/status-vocabulary-catalog.ts
@@ -210,6 +210,15 @@ export const statusVocabularies: readonly StatusVocabulary[] = [
     note: "Relation-projection availability feeding blockingOf; degraded states make every task's blocking unknown.",
   },
   {
+    id: "task-read-set.projection-cut",
+    entity: "Task",
+    field: "read set projection cut",
+    module: "packages/kernel/src/domain/task-read-set.ts",
+    anchor: "#status",
+    words: ["ready", "pending"],
+    note: "Readiness of the single projection cut a task read set is derived at.",
+  },
+  {
     id: "package.disposition",
     entity: "Package",
     field: "disposition",

--- a/packages/kernel/src/domain/status-word-register-domain.ts
+++ b/packages/kernel/src/domain/status-word-register-domain.ts
@@ -159,6 +159,20 @@ export const domainStatusWords: readonly StatusWordRegistration[] = [
     divergence: "entity-scoped",
   },
   {
+    word: "ready",
+    entity: "Task",
+    field: "read set projection cut",
+    meaning: "Read set derived at a caught-up cut; the edge list is complete for that revision.",
+    divergence: "entity-scoped",
+  },
+  {
+    word: "pending",
+    entity: "Task",
+    field: "read set projection cut",
+    meaning: "Read set derived while the projection still trails the canonical revision.",
+    divergence: "entity-scoped",
+  },
+  {
     word: "covered",
     entity: "Decision",
     field: "claim coverage status",

--- a/packages/kernel/src/domain/task-read-set.ts
+++ b/packages/kernel/src/domain/task-read-set.ts
@@ -9,8 +9,7 @@ export const READ_SET_SCHEMA = "read-set/v1" as const;
  * The three authority classes of `context-assembly-design.md` §4: normative rules
  * (standards, decisions in force), descriptive facts, and historical experience.
  */
-export const readSetAuthorities = ["normative", "descriptive", "historical"] as const;
-export type ReadSetAuthority = (typeof readSetAuthorities)[number];
+export type ReadSetAuthority = "normative" | "descriptive" | "historical";
 
 /**
  * Only the edges the task itself declares enter the read set
@@ -20,27 +19,23 @@ export type ReadSetAuthority = (typeof readSetAuthorities)[number];
  */
 const explicitRelationOrigins: readonly RelationOrigin[] = ["declared", "imported_snapshot"];
 
-export interface ReadSetInclusion {
-  /** W3 adds `context-route` here; this wave derives entries from the task's own edges only. */
-  readonly source: "task-relation";
-  readonly relationId: string;
-  readonly type: RelationType;
-  readonly rationale: string;
-}
-
-/** The relation revisions carried through unchanged so two edge nodes can compare answers. */
-export interface ReadSetEdgeVersions {
-  readonly targetObservedVersion: EntityVersion | null;
-  readonly currentTargetVersion: EntityVersion | null;
-}
-
 export interface ReadSetEntry {
   readonly entityRef: string;
   readonly locator: string | null;
   readonly contentVersion: EntityVersion | null;
   readonly freshness: RelationFreshness;
-  readonly whyIncluded: ReadSetInclusion;
-  readonly edgeVersions: ReadSetEdgeVersions;
+  readonly whyIncluded: {
+    /** W3 adds `context-route` here; this wave derives entries from the task's own edges only. */
+    readonly source: "task-relation";
+    readonly relationId: string;
+    readonly type: RelationType;
+    readonly rationale: string;
+  };
+  /** The relation revisions carried through unchanged so two edge nodes can compare answers. */
+  readonly edgeVersions: {
+    readonly targetObservedVersion: EntityVersion | null;
+    readonly currentTargetVersion: EntityVersion | null;
+  };
   readonly required: boolean;
   readonly authority: ReadSetAuthority;
 }
@@ -78,12 +73,10 @@ export interface TaskReadSetInput {
   readonly projectionCut: ReadSetProjectionCut;
 }
 
-export type ReadSetBlockedCode = "required_target_orphaned" | "required_target_unknown" | "required_locator_unresolved";
-
 export interface ReadSetBlockedReason {
   readonly entityRef: string;
   readonly relationId: string;
-  readonly code: ReadSetBlockedCode;
+  readonly code: "required_target_orphaned" | "required_target_unknown" | "required_locator_unresolved";
   readonly detail: string;
 }
 
@@ -142,6 +135,9 @@ export function deriveTaskReadSet(input: TaskReadSetInput): TaskReadSet {
   });
 }
 
+/** Reading order between the authority classes. */
+const readSetAuthorityRank: Record<ReadSetAuthority, number> = { normative: 0, descriptive: 1, historical: 2 };
+
 function readSetAuthority(entityRef: string): ReadSetAuthority {
   const kind = parseEntityRef(entityRef)?.kind;
   if (kind === "decision" || kind === "policy") return "normative";
@@ -193,8 +189,6 @@ function readSetGaps(
   return reasons;
 }
 
-const readSetAuthorityRank = new Map(readSetAuthorities.map((authority, rank) => [authority, rank]));
-
 /**
  * Stable and independent of any file path: required first, then authority class,
  * relation type, entity ref, and finally the relation id so two edges to the same
@@ -202,7 +196,7 @@ const readSetAuthorityRank = new Map(readSetAuthorities.map((authority, rank) =>
  */
 function compareReadSetEntries(left: ReadSetEntry, right: ReadSetEntry): number {
   if (left.required !== right.required) return left.required ? -1 : 1;
-  const authority = readSetAuthorityRank.get(left.authority)! - readSetAuthorityRank.get(right.authority)!;
+  const authority = readSetAuthorityRank[left.authority] - readSetAuthorityRank[right.authority];
   if (authority !== 0) return authority;
   return (
     compareText(left.whyIncluded.type, right.whyIncluded.type) ||

--- a/packages/kernel/src/domain/task-read-set.ts
+++ b/packages/kernel/src/domain/task-read-set.ts
@@ -1,0 +1,216 @@
+import type { EntityVersion, EntityVersionWitness, RelationFreshness } from "./entity-freshness.ts";
+import { getEntityKindContract } from "./entity-kind-registry.ts";
+import type { RelationOrigin, RelationStrength, RelationType } from "./entity-relation.ts";
+import { parseEntityRef } from "./entity-ref.ts";
+
+export const READ_SET_SCHEMA = "read-set/v1" as const;
+
+/**
+ * The three authority classes of `context-assembly-design.md` §4: normative rules
+ * (standards, decisions in force), descriptive facts, and historical experience.
+ */
+export const readSetAuthorities = ["normative", "descriptive", "historical"] as const;
+export type ReadSetAuthority = (typeof readSetAuthorities)[number];
+
+/**
+ * Only the edges the task itself declares enter the read set
+ * (`context-assembly-design.md` §3.2 step 1, "显式 active relations"). Generated and
+ * inferred edges are execution provenance — the execution that runs the task, the
+ * runtime session bound to it, the facts it emitted — not reading material.
+ */
+const explicitRelationOrigins: readonly RelationOrigin[] = ["declared", "imported_snapshot"];
+
+export interface ReadSetInclusion {
+  /** W3 adds `context-route` here; this wave derives entries from the task's own edges only. */
+  readonly source: "task-relation";
+  readonly relationId: string;
+  readonly type: RelationType;
+  readonly rationale: string;
+}
+
+/** The relation revisions carried through unchanged so two edge nodes can compare answers. */
+export interface ReadSetEdgeVersions {
+  readonly targetObservedVersion: EntityVersion | null;
+  readonly currentTargetVersion: EntityVersion | null;
+}
+
+export interface ReadSetEntry {
+  readonly entityRef: string;
+  readonly locator: string | null;
+  readonly contentVersion: EntityVersion | null;
+  readonly freshness: RelationFreshness;
+  readonly whyIncluded: ReadSetInclusion;
+  readonly edgeVersions: ReadSetEdgeVersions;
+  readonly required: boolean;
+  readonly authority: ReadSetAuthority;
+}
+
+export interface TaskReadSetEdge {
+  readonly relationId: string;
+  readonly sourceRef: string;
+  readonly targetRef: string;
+  readonly relationType: RelationType;
+  readonly strength: RelationStrength;
+  readonly origin: RelationOrigin;
+  readonly state: string;
+  readonly freshness: RelationFreshness;
+  readonly rationale: string;
+  readonly targetObservedVersion: EntityVersion | null;
+  readonly currentTargetVersion: EntityVersion | null;
+}
+
+export interface TaskReadSetCounterpart {
+  readonly witness: EntityVersionWitness;
+  /** Only the projection knows a task package path; every other kind derives from its ref. */
+  readonly packagePath?: string | null;
+}
+
+export interface ReadSetProjectionCut {
+  readonly status: "ready" | "pending";
+  readonly watermark: number;
+  readonly sourceRevision: number;
+}
+
+export interface TaskReadSetInput {
+  readonly taskRef: string;
+  readonly edges: readonly TaskReadSetEdge[];
+  readonly counterparts: ReadonlyMap<string, TaskReadSetCounterpart>;
+  readonly projectionCut: ReadSetProjectionCut;
+}
+
+export type ReadSetBlockedCode = "required_target_orphaned" | "required_target_unknown" | "required_locator_unresolved";
+
+export interface ReadSetBlockedReason {
+  readonly entityRef: string;
+  readonly relationId: string;
+  readonly code: ReadSetBlockedCode;
+  readonly detail: string;
+}
+
+export interface TaskReadSet {
+  readonly schema: typeof READ_SET_SCHEMA;
+  readonly taskRef: string;
+  readonly entries: readonly ReadSetEntry[];
+  readonly blocked: boolean;
+  readonly blockedReasons: readonly ReadSetBlockedReason[];
+  readonly projectionCut: ReadSetProjectionCut;
+}
+
+/**
+ * The single authority for what a task must read at one projection cut. Ordering,
+ * `required`, `authority` and `blocked` are decided here and nowhere else; the CLI,
+ * GUI and SDK present this result rather than recomputing it
+ * (`governed-entity-design.md` §6).
+ */
+export function deriveTaskReadSet(input: TaskReadSetInput): TaskReadSet {
+  const entries: ReadSetEntry[] = [],
+    blockedReasons: ReadSetBlockedReason[] = [];
+  for (const edge of input.edges) {
+    if (edge.state !== "active" || !explicitRelationOrigins.includes(edge.origin)) continue;
+    const entityRef = edge.sourceRef === input.taskRef ? edge.targetRef : edge.sourceRef;
+    if (entityRef === input.taskRef) continue;
+    const counterpart = input.counterparts.get(entityRef),
+      entry: ReadSetEntry = {
+        entityRef,
+        locator: readSetLocator(entityRef, counterpart?.packagePath ?? null),
+        contentVersion: counterpart?.witness.currentVersion ?? null,
+        freshness: edge.freshness,
+        whyIncluded: {
+          source: "task-relation",
+          relationId: edge.relationId,
+          type: edge.relationType,
+          rationale: edge.rationale,
+        },
+        edgeVersions: {
+          targetObservedVersion: edge.targetObservedVersion,
+          currentTargetVersion: edge.currentTargetVersion,
+        },
+        required: edge.strength === "strong",
+        authority: readSetAuthority(entityRef),
+      };
+    entries.push(entry);
+    if (entry.required) blockedReasons.push(...readSetGaps(entry, counterpart));
+  }
+  entries.sort(compareReadSetEntries);
+  return Object.freeze({
+    schema: READ_SET_SCHEMA,
+    taskRef: input.taskRef,
+    entries,
+    blocked: blockedReasons.length > 0,
+    blockedReasons,
+    projectionCut: input.projectionCut,
+  });
+}
+
+function readSetAuthority(entityRef: string): ReadSetAuthority {
+  const kind = parseEntityRef(entityRef)?.kind;
+  if (kind === "decision" || kind === "policy") return "normative";
+  if (kind === "fact") return "descriptive";
+  return "historical";
+}
+
+/**
+ * The ledger-relative place a reader opens. Decision and fact paths follow their own
+ * write paths (`decision-event-document.ts`, `fact-event.ts`); entity-store kinds reuse
+ * the registry template; task packages are only known to the projection. A kind with no
+ * document resolves to null instead of guessing a file by name.
+ */
+function readSetLocator(entityRef: string, packagePath: string | null): string | null {
+  const parsed = parseEntityRef(entityRef);
+  if (!parsed) return null;
+  if (parsed.kind === "task") return packagePath;
+  if (parsed.kind === "decision") return `decisions/decision-${parsed.id}/decision.md`;
+  if (parsed.kind === "fact") return `facts/${parsed.id}.md`;
+  const template = getEntityKindContract(parsed.kind)?.entityStore?.document.pathTemplate;
+  return template === undefined ? null : template.replace("{id}", parsed.id);
+}
+
+function readSetGaps(
+  entry: ReadSetEntry,
+  counterpart: TaskReadSetCounterpart | undefined,
+): readonly ReadSetBlockedReason[] {
+  const reasons: ReadSetBlockedReason[] = [],
+    anchor = { entityRef: entry.entityRef, relationId: entry.whyIncluded.relationId },
+    witnessFreshness = counterpart?.witness.freshness ?? "unknown";
+  if (entry.freshness === "orphaned" || witnessFreshness === "orphaned")
+    reasons.push({
+      ...anchor,
+      code: "required_target_orphaned",
+      detail: `Required ${entry.entityRef} is orphaned at this cut.`,
+    });
+  else if (witnessFreshness === "unknown")
+    reasons.push({
+      ...anchor,
+      code: "required_target_unknown",
+      detail: `Required ${entry.entityRef} has no entity witness at this cut.`,
+    });
+  if (entry.locator === null)
+    reasons.push({
+      ...anchor,
+      code: "required_locator_unresolved",
+      detail: `Required ${entry.entityRef} resolves to no locator.`,
+    });
+  return reasons;
+}
+
+const readSetAuthorityRank = new Map(readSetAuthorities.map((authority, rank) => [authority, rank]));
+
+/**
+ * Stable and independent of any file path: required first, then authority class,
+ * relation type, entity ref, and finally the relation id so two edges to the same
+ * entity keep one total order.
+ */
+function compareReadSetEntries(left: ReadSetEntry, right: ReadSetEntry): number {
+  if (left.required !== right.required) return left.required ? -1 : 1;
+  const authority = readSetAuthorityRank.get(left.authority)! - readSetAuthorityRank.get(right.authority)!;
+  if (authority !== 0) return authority;
+  return (
+    compareText(left.whyIncluded.type, right.whyIncluded.type) ||
+    compareText(left.entityRef, right.entityRef) ||
+    compareText(left.whyIncluded.relationId, right.whyIncluded.relationId)
+  );
+}
+
+function compareText(left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0;
+}

--- a/packages/kernel/test/contracts/task-read-set.test.ts
+++ b/packages/kernel/test/contracts/task-read-set.test.ts
@@ -1,0 +1,271 @@
+// harness-test-tier: contract
+import assert from "node:assert/strict";
+import test from "node:test";
+import { deriveTaskReadSet, READ_SET_SCHEMA } from "../../src/index.ts";
+import type { TaskReadSetCounterpart, TaskReadSetEdge } from "../../src/index.ts";
+
+const taskRef = "task/task_readset0000000000",
+  cut = { status: "ready" as const, watermark: 42, sourceRevision: 42 };
+
+function edge(
+  overrides: Partial<TaskReadSetEdge> & Pick<TaskReadSetEdge, "relationId" | "targetRef">,
+): TaskReadSetEdge {
+  return {
+    sourceRef: taskRef,
+    relationType: "relates",
+    strength: "weak",
+    origin: "declared",
+    state: "active",
+    freshness: "current",
+    rationale: "declared by the task plan",
+    targetObservedVersion: 7,
+    currentTargetVersion: 7,
+    ...overrides,
+  };
+}
+
+function counterparts(
+  rows: readonly (readonly [string, Partial<TaskReadSetCounterpart["witness"]> & { packagePath?: string | null }])[],
+): ReadonlyMap<string, TaskReadSetCounterpart> {
+  return new Map(
+    rows.map(([entityRef, { packagePath, ...witness }]) => [
+      entityRef,
+      {
+        witness: { entityRef, freshness: "current" as const, currentVersion: 7, ...witness },
+        ...(packagePath === undefined ? {} : { packagePath }),
+      },
+    ]),
+  );
+}
+
+test("an empty edge set yields an empty read set instead of an error or a filename fallback", () => {
+  const derived = deriveTaskReadSet({ taskRef, edges: [], counterparts: new Map(), projectionCut: cut });
+  assert.equal(derived.schema, READ_SET_SCHEMA);
+  assert.deepEqual(derived.entries, []);
+  assert.equal(derived.blocked, false);
+  assert.deepEqual(derived.blockedReasons, []);
+  assert.deepEqual(derived.projectionCut, cut);
+});
+
+test("only explicitly declared active edges become reading material", () => {
+  const derived = deriveTaskReadSet({
+    taskRef,
+    edges: [
+      edge({ relationId: "rel_declared00000001", targetRef: "task/task_sibling000000000" }),
+      edge({
+        relationId: "rel_generated0000001",
+        sourceRef: "execution/exe_run00000000000000",
+        targetRef: taskRef,
+        relationType: "executes",
+        strength: "strong",
+        origin: "generated",
+      }),
+      edge({
+        relationId: "rel_retired000000001",
+        targetRef: "task/task_retired000000000",
+        state: "retired",
+      }),
+      edge({
+        relationId: "rel_imported00000001",
+        targetRef: "fact/F-11111111",
+        relationType: "evidences",
+        strength: "strong",
+        origin: "imported_snapshot",
+      }),
+    ],
+    counterparts: counterparts([
+      ["task/task_sibling000000000", { packagePath: "tasks/task_sibling000000000-sibling" }],
+      ["fact/F-11111111", {}],
+    ]),
+    projectionCut: cut,
+  });
+  assert.deepEqual(
+    derived.entries.map(({ entityRef }) => entityRef),
+    ["fact/F-11111111", "task/task_sibling000000000"],
+  );
+});
+
+test("required comes from edge strength and authority from the counterpart kind", () => {
+  const derived = deriveTaskReadSet({
+    taskRef,
+    edges: [
+      edge({ relationId: "rel_weak00000000001", targetRef: "task/task_sibling000000000" }),
+      edge({
+        relationId: "rel_strongfact000001",
+        targetRef: "fact/F-22222222",
+        relationType: "evidences",
+        strength: "strong",
+      }),
+      edge({
+        relationId: "rel_strongdec0000001",
+        sourceRef: "decision/dec_ABCDEF0123456789/C1",
+        targetRef: taskRef,
+        relationType: "derives",
+        strength: "strong",
+      }),
+    ],
+    counterparts: counterparts([
+      ["task/task_sibling000000000", { packagePath: "tasks/task_sibling000000000-sibling" }],
+      ["fact/F-22222222", {}],
+      ["decision/dec_ABCDEF0123456789/C1", {}],
+    ]),
+    projectionCut: cut,
+  });
+  assert.deepEqual(
+    derived.entries.map(({ entityRef, required, authority, locator }) => [entityRef, required, authority, locator]),
+    [
+      ["decision/dec_ABCDEF0123456789/C1", true, "normative", "decisions/decision-dec_ABCDEF0123456789/decision.md"],
+      ["fact/F-22222222", true, "descriptive", "facts/F-22222222.md"],
+      ["task/task_sibling000000000", false, "historical", "tasks/task_sibling000000000-sibling"],
+    ],
+  );
+});
+
+test("ordering is stable, total, and independent of input order or file path", () => {
+  const rows: readonly TaskReadSetEdge[] = [
+    edge({ relationId: "rel_b0000000000000b", targetRef: "task/task_zzzz00000000000" }),
+    edge({ relationId: "rel_a0000000000000a", targetRef: "task/task_aaaa00000000000" }),
+    edge({
+      relationId: "rel_c0000000000000c",
+      targetRef: "fact/F-33333333",
+      relationType: "evidences",
+      strength: "strong",
+    }),
+    edge({
+      relationId: "rel_d0000000000000d",
+      targetRef: "fact/F-33333333",
+      relationType: "produces",
+      strength: "strong",
+    }),
+  ];
+  const map = counterparts([
+      ["task/task_zzzz00000000000", { packagePath: "tasks/task_zzzz00000000000-z" }],
+      ["task/task_aaaa00000000000", { packagePath: "tasks/task_aaaa00000000000-a" }],
+      ["fact/F-33333333", {}],
+    ]),
+    expected = [
+      ["fact/F-33333333", "evidences"],
+      ["fact/F-33333333", "produces"],
+      ["task/task_aaaa00000000000", "relates"],
+      ["task/task_zzzz00000000000", "relates"],
+    ];
+  const forward = deriveTaskReadSet({ taskRef, edges: rows, counterparts: map, projectionCut: cut }),
+    reversed = deriveTaskReadSet({ taskRef, edges: [...rows].reverse(), counterparts: map, projectionCut: cut });
+  assert.deepEqual(
+    forward.entries.map(({ entityRef, whyIncluded }) => [entityRef, whyIncluded.type]),
+    expected,
+  );
+  assert.deepEqual(forward.entries, reversed.entries);
+});
+
+test("suspect entries stay in the set, keep their edge revisions, and never pass as current", () => {
+  const derived = deriveTaskReadSet({
+    taskRef,
+    edges: [
+      edge({
+        relationId: "rel_suspect000000001",
+        targetRef: "task/task_moved00000000000",
+        freshness: "suspect",
+        targetObservedVersion: 5,
+        currentTargetVersion: 9,
+      }),
+    ],
+    counterparts: counterparts([
+      ["task/task_moved00000000000", { currentVersion: 9, packagePath: "tasks/task_moved00000000000-moved" }],
+    ]),
+    projectionCut: cut,
+  });
+  const [entry] = derived.entries;
+  assert.equal(entry?.freshness, "suspect");
+  assert.deepEqual(entry?.edgeVersions, { targetObservedVersion: 5, currentTargetVersion: 9 });
+  assert.equal(entry?.contentVersion, 9);
+  assert.equal(derived.blocked, false);
+});
+
+test("a required orphaned or unwitnessed counterpart blocks the whole set and names the gap", () => {
+  const orphaned = deriveTaskReadSet({
+    taskRef,
+    edges: [
+      edge({
+        relationId: "rel_orphaned00000001",
+        targetRef: "fact/F-44444444",
+        relationType: "evidences",
+        strength: "strong",
+        freshness: "orphaned",
+      }),
+    ],
+    counterparts: counterparts([["fact/F-44444444", { freshness: "orphaned", currentVersion: null }]]),
+    projectionCut: cut,
+  });
+  assert.equal(orphaned.blocked, true);
+  assert.equal(orphaned.entries.length, 1);
+  assert.deepEqual(
+    orphaned.blockedReasons.map(({ entityRef, code }) => [entityRef, code]),
+    [["fact/F-44444444", "required_target_orphaned"]],
+  );
+
+  const unwitnessed = deriveTaskReadSet({
+    taskRef,
+    edges: [
+      edge({
+        relationId: "rel_unknown000000001",
+        targetRef: "fact/F-55555555",
+        relationType: "evidences",
+        strength: "strong",
+      }),
+    ],
+    counterparts: new Map(),
+    projectionCut: cut,
+  });
+  assert.equal(unwitnessed.blocked, true);
+  assert.deepEqual(
+    unwitnessed.blockedReasons.map(({ code }) => code),
+    ["required_target_unknown"],
+  );
+});
+
+test("a required entry the projection cannot locate blocks instead of guessing a path", () => {
+  const derived = deriveTaskReadSet({
+    taskRef,
+    edges: [
+      edge({
+        relationId: "rel_nolocator0000001",
+        targetRef: "task/task_unindexed00000",
+        relationType: "depends-on",
+        strength: "strong",
+      }),
+    ],
+    counterparts: counterparts([["task/task_unindexed00000", { packagePath: null }]]),
+    projectionCut: cut,
+  });
+  assert.equal(derived.blocked, true);
+  assert.equal(derived.entries[0]?.locator, null);
+  assert.deepEqual(
+    derived.blockedReasons.map(({ code }) => code),
+    ["required_locator_unresolved"],
+  );
+});
+
+test("every entry says which edge admitted it and the cut it was read at", () => {
+  const derived = deriveTaskReadSet({
+    taskRef,
+    edges: [
+      edge({
+        relationId: "rel_why00000000001a",
+        targetRef: "decision/dec_0123456789ABCDEF",
+        relationType: "implements",
+        strength: "strong",
+        rationale: "the task implements this decision",
+      }),
+    ],
+    counterparts: counterparts([["decision/dec_0123456789ABCDEF", {}]]),
+    projectionCut: cut,
+  });
+  assert.deepEqual(derived.entries[0]?.whyIncluded, {
+    source: "task-relation",
+    relationId: "rel_why00000000001a",
+    type: "implements",
+    rationale: "the task implements this decision",
+  });
+  assert.deepEqual(derived.projectionCut, cut);
+});

--- a/packages/kernel/test/contracts/task-read-set.test.ts
+++ b/packages/kernel/test/contracts/task-read-set.test.ts
@@ -1,8 +1,8 @@
 // harness-test-tier: contract
 import assert from "node:assert/strict";
 import test from "node:test";
-import { deriveTaskReadSet, READ_SET_SCHEMA } from "../../src/index.ts";
-import type { TaskReadSetCounterpart, TaskReadSetEdge } from "../../src/index.ts";
+import { deriveTaskReadSet, READ_SET_SCHEMA } from "../../src/domain/task-read-set.ts";
+import type { TaskReadSetCounterpart, TaskReadSetEdge } from "../../src/domain/task-read-set.ts";
 
 const taskRef = "task/task_readset0000000000",
   cut = { status: "ready" as const, watermark: 42, sourceRevision: 42 };


### PR DESCRIPTION
# English

## Summary

GovernedEntity W2-B: derive a task's reading set from its declared relations at one projection cut and serve it through `ha task read-set <task-id> [--json]`. The kernel function `deriveTaskReadSet` is the single place that decides inclusion, ordering, `required`, `authority`, `blocked` and the locator; the application layer only assembles, the daemon registers one read command and its human rendering. The title's deletion half (hand-written `read_set.md` scaffold) was falsified before work started: no scaffold exists in the public repo, so the deletion side is empty by evidence rather than padded.

## Architectural Justification

Reading sets were a hand-maintained document with no source of truth; the relation graph already carries the edges. The derivation reads explicit active relations only (`origin in {declared, imported_snapshot}`), so generated execution and runtime-session edges do not turn every in-flight task into a blocked read set. No new write path is introduced, so there is no new concurrency subject; the fleet view is a pure read at a cut.

## What Changed

- `packages/kernel/src/domain/task-read-set.ts` (new): `deriveTaskReadSet`.
- `packages/application/src/task-read-set-service.ts` (new): read-only assembler.
- `packages/daemon/src/protocol/daemon-protocol-commands-task-surface.ts`, `repo-cell-*.ts`: `task.read-set` read command, dispatch, evidence rendering (`read-set/v1`); phase vocabulary gains `Governed-Entity-W2-B`.
- `packages/cli/src/cli/thin-command-task.ts`: `ha task read-set`.
- Tests: kernel contract (8 cases), daemon integration (1), CLI capabilities set.

## Gate Harvest / 门收割

No gate change.

## Machine-Readable Declarations

Production-Delta: +358/-0
Dependency-Change: none

### Optional Evidence Claims

none

## Task And Scope

task_20fb3db24fd772dac5e9f9d6d1 (GovernedEntity W2-B). Branch `codex/w2b-read-set`. Artifact entities as read-set members arrive with #2221 (relation endpoints) through one extra locator derivation; W3 consumes this function for the context map.

Fleet view: a pure projection read at one cut; two edge nodes reading the same task get the same set for the same watermark and never write.

## Version Impact

No version change; publish impact none.

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none
- Authority: task_20fb3db24fd772dac5e9f9d6d1
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Follow-up governance task: not applicable

## Verification

- Base merge-base 0dd34cd473d47916951bc2a5bf31dbbdaa167ce2.
- Worker (Opus): kernel 8/8, relation-freshness 5/5, relation-entity 6/6, artifact-entity-service 3/3, thin-command 15/15, two integration files on isolated Ubuntu; mutation checks on ordering and required; real output on the parent task at cut 55413 (count 6) and three negative controls. Facts F-1734852F, F-3314F965.
- CEO after rebase onto 0dd34cd4: the three touched test files green on isolated Ubuntu; file-complexity, cli-structure, implementation-contracts pass.
- CI is the complete authority.

## Review Evidence

CEO semantic review: the read entry moved from `readRelationProjectionRows` (target-only filter) to `readRelationQuery` because the task is mostly the source of its edges; accepted. The worker's objection that `required = strength === "strong"` would mark unwitnessable execution and runtime-session edges as required is mitigated by the explicit-origin filter; redefining `required` through the authority kind table is deferred to W3, where the consumer exists.

## Residual Risk

`required` remains strength-based; if a future declared strong edge points at a kind without a version witness, that task's read set reports blocked. The end-to-end receipt over the real daemon socket was verified against a copy of the canonical projection, not the resident daemon, to avoid rebuilding dist under other in-flight workers.

# 中文

## 概要

W2-B:从任务声明的关系在一个投影 cut 上派生阅读集合,经 `ha task read-set <task-id> [--json]` 提供。kernel 的 `deriveTaskReadSet` 是入选/排序/required/authority/blocked/locator 的唯一判定处;application 只装配,daemon 只注册一条读命令与人读渲染。标题后半句的删除前提开工前已证伪(公开仓没有任何 read_set scaffold),删除侧按证据为空。

## 架构辩护

阅读集合原是没有真源的手写文档,关系图本来就有这些边。派生只读显式 active 关系(origin ∈ {declared, imported_snapshot}),generated 的 execution/runtime-session 边不会把每个在飞任务都判成 blocked。不新增写路,没有新的并发主体。

## 机读声明

生产行数增减(与上文机读声明一致):+358/-0

## 治理声明

- 触碰受保护面:否
- 授权:task_20fb3db24fd772dac5e9f9d6d1
- Break-glass:否

## 验证

Opus 定向测试与两条隔离集成用例全绿,真实输出在 parent 任务 cut 55413(count 6);CEO rebase 后三份测试文件隔离绿,三个结构门过。

## 评审证据

CEO 语义复核:读入口改用 readRelationQuery 成立;required 的重定义推迟到 W3(消费者出现时)。

## 残余风险

required 仍按 strength 判;端到端 socket 回执用 canonical 投影副本验证而非常驻 daemon。

