### PR TITLE
fix(daemon): remove an already-disabled registration on the second unregister and name the blocking row

### DIFF
--- a/packages/cli/test/daemon-receipt-cli.test.ts
+++ b/packages/cli/test/daemon-receipt-cli.test.ts
@@ -132,10 +132,15 @@ test("daemon control renders status and fails closed when repository materializa
     assert.match(unregistered.stdout, /repoId=receipt/u);
     assert.match(unregistered.stdout, /changed=true/u);
 
-    const alreadyUnregistered = runText(fixture, ["daemon", "repo", "unregister", "--repo-id", "receipt"]);
-    assert.equal(alreadyUnregistered.status, 0, alreadyUnregistered.stderr);
-    assert.match(alreadyUnregistered.stdout, /repoId=receipt/u);
-    assert.match(alreadyUnregistered.stdout, /changed=false/u);
+    // The first unregister disables and keeps history; the second removes the disabled row.
+    const removed = runText(fixture, ["daemon", "repo", "unregister", "--repo-id", "receipt"]);
+    assert.equal(removed.status, 0, removed.stderr);
+    assert.match(removed.stdout, /repoId=receipt/u);
+    assert.match(removed.stdout, /changed=true/u);
+
+    const gone = runText(fixture, ["daemon", "repo", "unregister", "--repo-id", "receipt"]);
+    assert.notEqual(gone.status, 0);
+    assert.match(`${gone.stdout}${gone.stderr}`, /not registered/u);
   } finally {
     rmSync(indexLock, { force: true });
     if (canonical !== null) {

--- a/packages/cli/test/daemon-receipt-cli.test.ts
+++ b/packages/cli/test/daemon-receipt-cli.test.ts
@@ -140,7 +140,8 @@ test("daemon control renders status and fails closed when repository materializa
 
     const gone = runText(fixture, ["daemon", "repo", "unregister", "--repo-id", "receipt"]);
     assert.notEqual(gone.status, 0);
-    assert.match(`${gone.stdout}${gone.stderr}`, /not registered/u);
+    // The daemon route refuses an unknown repoId as repo_namespace_unknown; the kernel path says "not registered".
+    assert.match(`${gone.stdout}${gone.stderr}`, /not registered|repo_namespace_unknown/u);
   } finally {
     rmSync(indexLock, { force: true });
     if (canonical !== null) {

--- a/packages/daemon/src/client/local-daemon-target.ts
+++ b/packages/daemon/src/client/local-daemon-target.ts
@@ -99,7 +99,9 @@ export function resolveLocalDaemonTargetFromRepos(
   if (!repo || repo.state !== "enabled")
     throw Object.assign(
       new Error(
-        `workspace is not registered; run ha daemon repo register --repo-id <id> --root ${JSON.stringify(path.resolve(input.rootDir))}`,
+        repo
+          ? `workspace is blocked by disabled repoId ${JSON.stringify(repo.repoId)} at ${JSON.stringify(repo.canonicalRoot)}; run ha daemon repo unregister --repo-id ${repo.repoId} twice to remove it`
+          : `workspace is not registered; run ha daemon repo register --repo-id <id> --root ${JSON.stringify(path.resolve(input.rootDir))}`,
       ),
       { code: "workspace_not_registered" },
     );

--- a/packages/daemon/src/client/local-daemon-target.ts
+++ b/packages/daemon/src/client/local-daemon-target.ts
@@ -100,7 +100,9 @@ export function resolveLocalDaemonTargetFromRepos(
     throw Object.assign(
       new Error(
         repo
-          ? `workspace is blocked by disabled repoId ${JSON.stringify(repo.repoId)} at ${JSON.stringify(repo.canonicalRoot)}; run ha daemon repo unregister --repo-id ${repo.repoId} twice to remove it`
+          ? `workspace is blocked by disabled repoId ${JSON.stringify(repo.repoId)} at ` +
+            `${JSON.stringify(repo.canonicalRoot)}; run ha daemon repo unregister --repo-id ${repo.repoId} ` +
+            "twice to remove it"
           : `workspace is not registered; run ha daemon repo register --repo-id <id> --root ${JSON.stringify(path.resolve(input.rootDir))}`,
       ),
       { code: "workspace_not_registered" },

--- a/packages/daemon/src/client/local-daemon-target.ts
+++ b/packages/daemon/src/client/local-daemon-target.ts
@@ -103,7 +103,8 @@ export function resolveLocalDaemonTargetFromRepos(
           ? `workspace is blocked by disabled repoId ${JSON.stringify(repo.repoId)} at ` +
             `${JSON.stringify(repo.canonicalRoot)}; run ha daemon repo unregister --repo-id ${repo.repoId} ` +
             "twice to remove it"
-          : `workspace is not registered; run ha daemon repo register --repo-id <id> --root ${JSON.stringify(path.resolve(input.rootDir))}`,
+          : `workspace is not registered; run ha daemon repo register --repo-id <id> --root ` +
+            JSON.stringify(path.resolve(input.rootDir)),
       ),
       { code: "workspace_not_registered" },
     );

--- a/packages/daemon/test/local-daemon-target.test.ts
+++ b/packages/daemon/test/local-daemon-target.test.ts
@@ -115,7 +115,7 @@ test("local daemon target rejects a disabled nested workspace instead of falling
 
     await assert.rejects(
       () => resolveLocalDaemonTarget({ rootDir: nestedRoot, userRoot, env: {} }),
-      /workspace is not registered/u,
+      /workspace is blocked by disabled repoId "inner" at .*ha daemon repo unregister --repo-id inner twice/u,
     );
   } finally {
     rmSync(fixtureRoot, { recursive: true, force: true });

--- a/packages/kernel/src/daemon/registry.ts
+++ b/packages/kernel/src/daemon/registry.ts
@@ -367,10 +367,13 @@ export function unregisterDaemonRepo(
   const invalid = registry.invalidRepos.find((repo) => repo.repoId === normalizedRepoId);
   if (!existing && !invalid) throw new Error(`repoId "${normalizedRepoId}" is not registered`);
   if (invalid) {
-    const raw = isDaemonRegistryRecord(invalid.raw) ? { ...invalid.raw, state: "disabled" } : invalid.raw,
+    const alreadyDisabled = invalid.state === "disabled",
+      raw = isDaemonRegistryRecord(invalid.raw) ? { ...invalid.raw, state: "disabled" } : invalid.raw,
       repo = { ...invalid, state: "disabled" as const, raw },
-      next = replaceInvalidRepo(registry, repo),
-      changed = invalid.state !== "disabled";
+      next = alreadyDisabled
+        ? { ...registry, invalidRepos: registry.invalidRepos.filter((candidate) => candidate !== invalid) }
+        : replaceInvalidRepo(registry, repo),
+      changed = true;
     if (changed) writeDaemonRegistry(next, options);
     const warnings = invalid.canonicalRoot
       ? removeConvenienceLink({ repoId: normalizedRepoId, canonicalRoot: invalid.canonicalRoot }, options)
@@ -378,9 +381,12 @@ export function unregisterDaemonRepo(
     return { registry: next, repo, registryPath: paths.registryPath, changed, warnings };
   }
   const valid = existing!;
-  const repo = { ...valid, state: "disabled" as const };
-  const next = replaceRepo(registry, repo);
-  const changed = !daemonRepoEquals(valid, repo);
+  const alreadyDisabled = valid.state === "disabled",
+    repo = { ...valid, state: "disabled" as const },
+    next = alreadyDisabled
+      ? { ...registry, repos: registry.repos.filter((candidate) => candidate !== valid) }
+      : replaceRepo(registry, repo),
+    changed = true;
   if (changed) writeDaemonRegistry(next, options);
   const warnings = repo.canonicalRoot === null ? [] : removeConvenienceLink(repo as LocalDaemonRegistryRepo, options);
   return { registry: next, repo, registryPath: paths.registryPath, changed, warnings };

--- a/packages/kernel/test/store/daemon-registry.test.ts
+++ b/packages/kernel/test/store/daemon-registry.test.ts
@@ -367,6 +367,63 @@ test("daemon registry unregister disables a repo without deleting registry histo
   });
 });
 
+test("daemon registry removes an already disabled repo on a second unregister", () => {
+  withTempDir((root) => {
+    const userRoot = path.join(root, "user-harness");
+    const canonicalRoot = createHarnessRepo(path.join(root, "project"));
+
+    registerDaemonRepo({ userRoot, canonicalRoot, repoId: "canonical", createConvenienceLinks: false });
+    unregisterDaemonRepo("canonical", { userRoot, createConvenienceLinks: false });
+    const result = unregisterDaemonRepo("canonical", { userRoot, createConvenienceLinks: false });
+
+    assert.equal(result.changed, true);
+    assert.equal(result.repo.state, "disabled");
+    assert.deepEqual(readDaemonRegistry({ userRoot }).repos, []);
+
+    const rebound = registerDaemonRepo({
+      userRoot,
+      canonicalRoot,
+      repoId: "canonical",
+      createConvenienceLinks: false,
+    });
+    assert.equal(rebound.repo.state, "enabled");
+  });
+});
+
+test("daemon registry removes an already disabled invalid repo on a second unregister", () => {
+  withTempDir((root) => {
+    const userRoot = path.join(root, "user-harness");
+    mkdirSync(userRoot, { recursive: true });
+    writeFileSync(
+      path.join(userRoot, "registry.json"),
+      `${JSON.stringify({
+        schema: daemonRegistrySchema,
+        connections: [localConnection],
+        repos: [
+          {
+            repoId: "invalid",
+            canonicalRoot: path.join(root, "missing"),
+            displayName: "invalid",
+            authoredBranch: "main",
+            mode: "local",
+            connectionId: "missing-connection",
+            state: "enabled",
+            registeredAt: "2026-09-04T00:00:00.000Z",
+          },
+        ],
+      })}\n`,
+      "utf8",
+    );
+
+    const first = unregisterDaemonRepo("invalid", { userRoot, createConvenienceLinks: false });
+    const result = unregisterDaemonRepo("invalid", { userRoot, createConvenienceLinks: false });
+
+    assert.equal(first.repo.state, "disabled");
+    assert.equal(result.changed, true);
+    assert.deepEqual(readDaemonRegistry({ userRoot }).invalidRepos, []);
+  });
+});
+
 test("daemon registry rebinds an unregistered repoId to a new canonical root", () => {
   withTempDir((root) => {
     const userRoot = path.join(root, "user-harness");


### PR DESCRIPTION
# English

## Summary

A daemon registration whose canonical root no longer exists could be disabled but never removed from the registry without editing JSON by hand, and the `workspace_not_registered` message pointed operators at `register`, which fails in exactly that state. This change makes the second `ha daemon repo unregister` remove an already-disabled row (valid or invalid), keeps the first call as the history-preserving disable, and names the blocking disabled row plus the two-step recovery command in the error text. The fallback refusal for a disabled nested workspace is unchanged.

## Architectural Justification

The worker's isolated reproduction falsified the plan's shadowing premise: `resolveLocalDaemonTargetFromRepos` binds the canonical root before it selects a disabled candidate, so a deleted root cannot shadow anything beneath it. The remaining defect is the removal path, which is one more branch in the existing unregister command rather than a new flag, command, cleanup daemon or lock. `writeDaemonRegistry` and the kernel index are untouched.

## What Changed

- `packages/kernel/src/daemon/registry.ts`: `unregisterDaemonRepo` removes an already-disabled valid or invalid row on the second call.
- `packages/daemon/src/client/local-daemon-target.ts`: the blocked message names the disabled repoId and root and gives the two-unregister recovery.
- Tests: kernel registry cases for valid and invalid removal, rebind and idempotence; daemon target message assertion updated.

## Gate Harvest / 门收割

No gate change.

## Machine-Readable Declarations

Production-Delta: +18/-7
Dependency-Change: none

### Optional Evidence Claims

none

## Task And Scope

task_956a0f26e561346fefaccc0cf8. Branch `codex/registry-dead-row`. Out of scope by CEO ruling recorded on the task plan: proving a deleted-root shadow path (unreachable under supported usage).

Fleet view: the daemon registry is per-machine local state; no center write path is involved.

## Version Impact

No version change; publish impact none.

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none
- Authority: task_956a0f26e561346fefaccc0cf8
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Follow-up governance task: not applicable

## Verification

- Base merge-base 16d0876294b9a09efc7e7ee8f33bc6c490c60869.
- Worker (Codex Terra): kernel registry suite 15/15, local daemon target suite 10/10, fleet dead-registry regression pass, all on the isolated Ubuntu VM; mutation check (tests fail with production files stashed, pass after restore); lint, line-density, complexity and production delta pass. Facts F-AC3C7A49 and F-76E64F2E on the task.
- CEO: read the production diff; the isolated `daemon-host-recovery` file is being re-run by the CEO because the worker's capture hit its output time limit.
- CI is the complete authority.

## Review Evidence

CEO semantic review: the worker stopped at the plan's checkpoint with an isolated repro instead of forcing the shadow scenario; the CEO narrowed the task on the plan and the delivered change matches that ruling. The removal is only reachable on a row that is already disabled, so the first unregister keeps its history-preserving behaviour and the existing assertions.

## Residual Risk

A second unregister now deletes a row that an operator might have wanted to keep as disabled history; the first call still preserves it, and the message says the second call removes it.

# 中文

## 概要

canonical root 已删的 daemon 注册行以前只能 disabled、无法经 CLI 删除,且 `workspace_not_registered` 文案把人送去 `register`(该状态下必失败)。本改动让第二次 `ha daemon repo unregister` 移除已 disabled 的行(valid/invalid 都算),第一次仍是保留历史的 disable;错误文案点名遮蔽的 disabled 行并给出两步恢复命令。disabled 嵌套工作区拒绝回退父仓的行为不变。

## 架构辩护

worker 隔离复现证伪了 plan 的「死行遮蔽活仓」前提(先 bind root 再选候选,已删目录之下不可能有活仓),剩余缺陷只是删除通路——在既有 unregister 命令上多一个分支,不加 flag/命令/清理 daemon/锁。

## 机读声明

生产行数增减(与上文机读声明一致):+18/-7

## 治理声明

- 触碰受保护面:否
- 授权:task_956a0f26e561346fefaccc0cf8
- Break-glass:否

## 验证

Terra 在隔离 Ubuntu 跑 kernel registry 15/15、daemon target 10/10、fleet 死行回归;突变检查通过;CEO 读过生产 diff,并补跑 daemon-host-recovery 隔离用例。CI 为完整权威。

## 评审证据

CEO 语义复核:worker 在 Checkpoint 停下带隔离复现,CEO 在 plan 上收窄任务,交付与裁决一致;删除仅对已 disabled 行可达,首次调用行为与既有断言不变。

## 残余风险

第二次 unregister 会删掉操作者本想保留为 disabled 历史的行;首次仍保留,文案已说明第二次即删。
