### PR TITLE
fix(gui): keep the resident daemon log pane from shrinking to zero on the System tab

### DIFF
--- a/packages/gui/src/renderer/views/SystemView.tsx
+++ b/packages/gui/src/renderer/views/SystemView.tsx
@@ -336,7 +336,7 @@ export function SystemView({
           )}
         </section>
       </div>
-      <section data-testid="system-daemon-logs" className="flex h-[24rem] min-h-0 w-full flex-col px-4 pb-4">
+      <section data-testid="system-daemon-logs" className="flex h-[24rem] min-h-0 w-full shrink-0 flex-col px-4 pb-4">
         <p data-testid="system-daemon-logs-scope" className="pb-1.5 ui-micro text-text-faint">
           {t("views.systemView.logsScope", { daemonId: daemon.daemonId })}
         </p>


### PR DESCRIPTION
# English

## Summary

The resident daemon log panel mounted on the System tab by #2224 was invisible in the Electron window: its section is a fixed `h-[24rem]` flex child with `min-h-0` and the default `flex-shrink: 1`, so whenever the status and repository blocks above it overflow the viewport the section collapses to the height of its one caption line. Adding `shrink-0` keeps the 24rem panel at its declared height and lets the page scroll instead.

## Architectural Justification

One utility class on the existing section; no layout restructuring, no new component. Observed on the canonical checkout at 602e24be with the renderer served by Vite and verified through HMR before the change was moved to this branch (fact F-1DE6DC52).

## What Changed

- `packages/gui/src/renderer/views/SystemView.tsx`: `shrink-0` on the `system-daemon-logs` section.

## Gate Harvest / 门收割

No gate change.

## Machine-Readable Declarations

Production-Delta: +1/-1
Dependency-Change: none

### Optional Evidence Claims

none

## Task And Scope

task_32212e8e (PLT-Ontology Phase 4 GUI-UX log stream), acceptance follow-up found during CEO Electron verification. Branch `codex/system-log-pane-shrink`.

## Version Impact

No version change; publish impact none.

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none
- Authority: task_32212e8e
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Follow-up governance task: not applicable

## Verification

- Base merge-base 16d0876294b9a09efc7e7ee8f33bc6c490c60869.
- `system-observe.vitest.ts` and `system-group-widescreen.vitest.ts`: 14/14 pass.
- Electron: before the change only the caption line was visible at 920px and 1400px window heights; after the change the panel header, kind toggle and status strip render (screenshots kept in the CEO session).
- CI is the complete authority.

## Review Evidence

CEO authored and verified in the live window. A gui-e2e scenario asserting the panel's visible height is being added under a separate task so the 6h catalog run covers it.

## Residual Risk

None beyond layout; the fixed 24rem height is unchanged.

# 中文

## 概要

#2224 挂到系统 tab 的常驻日志面板在 Electron 里看不见:section 是 `h-[24rem]` + `min-h-0` 的 flex 子项,默认 flex-shrink=1,上面状态与仓库块一溢出视口它就被压成只剩一行说明。加 `shrink-0` 让它保持声明高度,页面改为滚动。

## 机读声明

生产行数增减(与上文机读声明一致):+1/-1

## 治理声明

- 触碰受保护面:否
- 授权:task_32212e8e
- Break-glass:否

## 验证

触碰面 vitest 14/14 绿;Electron 改前只见说明行、改后面板出现(fact F-1DE6DC52)。CI 为完整权威。

## 评审证据

CEO 亲写亲验;gui-e2e 场景另立任务补齐。

## 残余风险

无。
