### PR TITLE
fix(daemon): refuse repo-prose candidates under unregistered task package directories

### DIFF
--- a/packages/daemon/src/doc-sync-candidate-scanner.ts
+++ b/packages/daemon/src/doc-sync-candidate-scanner.ts
@@ -95,6 +95,11 @@ export function scanDocCandidates(input: {
           : (() => {
               throw docSyncError("task_not_found", `Task ${input.taskId} has no projected package path.`);
             })(),
+    // `--task` scopes enumeration to that one package. Without it the scope is
+    // the whole authored tree (empty prefix) — stray `tasks/<seg>/` paths stay
+    // enumerated on purpose so scanOne blocks them with an actionable reason
+    // instead of the submit silently dropping them.
+    enumerationScope = taskPrefix ?? "",
     selected = input.selection?.map((value) => documentPath(normalizeSelectedPath(ledger.authoredPrefix, value))),
     inventoryByPath = new Map(input.inventory?.rows.map((row) => [row.path, row] as const) ?? []),
     events = input.inventory ? [] : input.store.read().events,
@@ -110,7 +115,7 @@ export function scanDocCandidates(input: {
             ...(input.inventory?.rows.map((row) => row.path) ?? dirtyPaths(ledger.rootDir, ledger.authoredPrefix)),
             ...pendingPaths,
           ]),
-        ].filter((value) => taskPrefix === null || value.startsWith(taskPrefix)),
+        ].filter((value) => value.startsWith(enumerationScope)),
     paths = candidates
       .filter(
         (value) =>
@@ -146,6 +151,15 @@ export function scanDocCandidates(input: {
   function scanOne(logical: string): ScannedDocCandidate {
     const inventoried = inventoryByPath.get(logical),
       document = documentPath(logical),
+      // The `tasks/<package>/` namespace is admitted by projection, not by path
+      // shape: this is the one layer of the scanner that holds the projection,
+      // so an unregistered package directory must be refused here. Scoped to
+      // the repo-prose channel (no `--task`) — the task-scoped channel keeps
+      // its own prefix filter and lease adjudication verbatim. The kernel path
+      // functions stay shape-based on purpose — `ha doc retire` relies on them
+      // to reach already-committed ghost documents for retirement.
+      taskDirectory = /^tasks\/([^/]+)\//u.exec(document)?.[1] ?? null,
+      claimingTaskId = taskDirectory === null ? null : input.projection.taskIdForDocumentPath(document),
       route = resolveDocRoute(document),
       target = path.join(layout.authoredRoot, ...logical.split("/")),
       projected = input.projection.readDocument(document),
@@ -187,6 +201,18 @@ export function scanDocCandidates(input: {
             route.requiredRoute,
           );
     }
+    if (input.taskId === undefined && taskDirectory !== null && claimingTaskId === null)
+      return scannedCandidateRow(
+        "blocked",
+        `tasks/${taskDirectory} is not the package path of any projected task; publish task artifacts with ` +
+          "ha task artifact add <task-id> --source <file> --destination artifacts/<name> and remove the stray copy",
+        bytes,
+        base,
+        candidate,
+        classification?.mediaType ?? null,
+        "task_package_unregistered",
+        "ha task artifact add",
+      );
     if (classification === null)
       return scannedCandidateRow(
         "blocked",

--- a/packages/daemon/test/doc-sync-ghost-task-package.integration.test.ts
+++ b/packages/daemon/test/doc-sync-ghost-task-package.integration.test.ts
@@ -1,0 +1,150 @@
+// harness-test-tier: integration
+import assert from "node:assert/strict";
+import { existsSync } from "node:fs";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { makeTaskEventStore } from "../../kernel/src/index.ts";
+import { canonicalRoot, workspaceId } from "../src/protocol/daemon-protocol.contract.ts";
+import { openBootstrappedRepoCell as openRepoCell } from "./repo-settings.fixture.ts";
+import { actor, git, initRepo, write } from "./doc-sync-slice-a.fixtures.ts";
+
+interface ScanRow {
+  readonly path: string;
+  readonly state: string;
+  readonly reason: string | null;
+  readonly mediaType: string | null;
+}
+
+test("repo prose channel blocks artifacts under an unregistered tasks/ package directory", async () => {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-ghost-package-"));
+  initRepo(rootDir);
+  const repoId = workspaceId("ghost-package"),
+    cell = await openRepoCell({
+      repoId,
+      rootDir: canonicalRoot(rootDir),
+      ownerId: "ghost-package-daemon",
+    }),
+    binding = { actor, source: "local" as const };
+  try {
+    const created = (await cell.run(
+      { kind: "task-create", taskId: "task-ghost", title: "Ghost Package" },
+      binding,
+    )) as {
+      readonly outcome: string;
+      readonly packagePath: string;
+    };
+    assert.equal(created.outcome, "applied", JSON.stringify(created));
+    const packagePath = created.packagePath;
+    assert.equal(packagePath, "tasks/task-ghost-ghost-package");
+    // The impostor directory shares the task id prefix but is not the projected
+    // packagePath — the exact shape of the four ghost directories in the wild.
+    const impostor = "tasks/task-ghost-wrong-slug",
+      ghost = `${impostor}/artifacts/closeout-packet.md`,
+      real = `${packagePath}/artifacts/report.md`;
+    write(rootDir, ghost, "# Ghosted copy\n\nwritten into a guessed directory name\n");
+    write(rootDir, real, "# Real artifact\n");
+    const statusRows = scanRows(await cell.run({ kind: "doc-status", paths: [] }, binding));
+    const ghostRow = statusRows.find((row) => row.path === ghost),
+      realRow = statusRows.find((row) => row.path === real);
+    assert.deepEqual([ghostRow?.state, realRow?.state], ["blocked", "eligible"]);
+    assert.match(ghostRow?.reason ?? "", /tasks\/task-ghost-wrong-slug is not the package path of any projected task/u);
+    assert.match(ghostRow?.reason ?? "", /ha task artifact add/u);
+    assert.equal(ghostRow?.mediaType, "text/markdown");
+    // Misfire control: the eligible sibling in the registered package still
+    // publishes, and the blocked ghost must not ride along in that submit.
+    const submitted = (await cell.run({ kind: "doc-submit", paths: [] }, binding)) as {
+      readonly outcome: string;
+      readonly opId: string;
+      readonly summary: string | null;
+    };
+    assert.equal(submitted.outcome, "applied", JSON.stringify(submitted));
+    const event = makeTaskEventStore({ repoId, rootDir }).readEvent(submitted.opId);
+    assert.equal(event?.schema, "doc-event/v1");
+    if (event?.schema === "doc-event/v1")
+      assert.deepEqual(
+        event.payload.changes.map((change) => change.path),
+        [real],
+      );
+    assert.match(
+      submitted.summary ?? "",
+      new RegExp(`${ghost.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&")}\\tblocked\\t`, "u"),
+    );
+    assert.equal(existsSync(path.join(rootDir, "harness", ghost)), true);
+    // A submit whose only candidate is the ghost refuses with the recovery route.
+    write(rootDir, `${impostor}/artifacts/second.md`, "# Second ghost\n");
+    const rejected = (await cell.run({ kind: "doc-submit", paths: [] }, binding)) as {
+      readonly outcome: string;
+      readonly code: string;
+      readonly detail: {
+        readonly unresolvedTouches: readonly { readonly path: string; readonly requiredRoute: string }[];
+      };
+    };
+    assert.equal(rejected.outcome, "op_rejected", JSON.stringify(rejected));
+    assert.equal(rejected.code, "preview_blocked");
+    assert.deepEqual(
+      rejected.detail.unresolvedTouches.map((touch) => [touch.path, touch.requiredRoute]),
+      [
+        [ghost, "ha task artifact add"],
+        [`${impostor}/artifacts/second.md`, "ha task artifact add"],
+      ],
+    );
+  } finally {
+    await cell.close();
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});
+
+test("the --task channel keeps its package-prefix enumeration and admits its own artifacts", async () => {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-ghost-package-scoped-"));
+  initRepo(rootDir);
+  const repoId = workspaceId("ghost-package-scoped"),
+    cell = await openRepoCell({
+      repoId,
+      rootDir: canonicalRoot(rootDir),
+      ownerId: "ghost-package-scoped-daemon",
+    }),
+    binding = { actor, source: "local" as const };
+  try {
+    const created = (await cell.run(
+      { kind: "task-create", taskId: "task-scoped", title: "Scoped Ghost" },
+      binding,
+    )) as {
+      readonly outcome: string;
+      readonly packagePath: string;
+    };
+    assert.equal(created.outcome, "applied", JSON.stringify(created));
+    const packagePath = created.packagePath;
+    write(rootDir, `${packagePath}/artifacts/report.md`, "# Registered package artifact\n");
+    write(rootDir, `tasks/task-scoped-wrong-slug/artifacts/x.md`, "# Unregistered neighbor\n");
+    write(rootDir, "context/unrelated.md", "# Unrelated\n");
+    const scopedRows = scanRows(await cell.run({ kind: "doc-status", taskId: "task-scoped" }, binding));
+    assert.equal(
+      scopedRows.every((row) => row.path.startsWith(`${packagePath}/`)),
+      true,
+      `--task enumeration must stay scoped to the package prefix: ${JSON.stringify(scopedRows.map((row) => row.path))}`,
+    );
+    assert.deepEqual(
+      scopedRows.filter((row) => row.path === `${packagePath}/artifacts/report.md`).map((row) => row.state),
+      ["eligible"],
+    );
+    assert.equal(
+      scopedRows.some((row) => row.path === "context/unrelated.md"),
+      false,
+    );
+    const submitted = await cell.run({ kind: "doc-submit", taskId: "task-scoped" }, binding);
+    assert.equal(submitted.outcome, "applied", JSON.stringify(submitted));
+    assert.equal(git(rootDir, "status", "--porcelain", "-uall").includes("context/unrelated"), true);
+  } finally {
+    await cell.close();
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});
+
+function scanRows(receipt: { readonly evidence?: string }): readonly ScanRow[] {
+  assert.match(receipt.evidence ?? "", /^doc-scan:/u);
+  return (
+    JSON.parse((receipt.evidence ?? "").slice("doc-scan:".length) as string) as { readonly rows: readonly ScanRow[] }
+  ).rows;
+}

--- a/packages/daemon/test/doc-sync-slice-a.test.ts
+++ b/packages/daemon/test/doc-sync-slice-a.test.ts
@@ -34,9 +34,15 @@ test("status, dry-run, and submit share the repeatable-path scanner and automati
       [
         ["context/a.md", "eligible"],
         ["context/b.md", "eligible"],
-        ["tasks/task-one/artifacts/data.json", "eligible"],
+        ["tasks/task-one/artifacts/data.json", "blocked"],
         ["tasks/task-one/progress.md", "blocked"],
       ],
+    );
+    // tasks/task-one is not a projected package path: the repo prose channel
+    // must refuse its artifacts directory instead of admitting the ghost.
+    assert.match(
+      statusRows.find((row) => row.path === "tasks/task-one/artifacts/data.json")?.reason ?? "",
+      /tasks\/task-one is not the package path of any projected task/u,
     );
     assert.equal(statusRows.find((row) => row.path.endsWith("artifacts/data.json"))?.mediaType, opaqueTextualMediaType);
     assert.equal(git(rootDir, "rev-parse", "HEAD"), before);
@@ -365,9 +371,14 @@ test("new non-textual artifacts are inapplicable while binary replacement of can
       rootDir: canonicalRoot(rootDir),
       ownerId: "non-textual-daemon",
     }),
-    binding = { actor, source: "local" as const },
-    fresh = "tasks/task-proof/artifacts/screenshots/evidence.png",
-    tracked = "tasks/task-proof/artifacts/report.bin";
+    binding = { actor, source: "local" as const };
+  const proofTask = (await cell.run({ kind: "task-create", taskId: "task-proof", title: "Proof" }, binding)) as {
+    readonly outcome: string;
+    readonly packagePath: string;
+  };
+  assert.equal(proofTask.outcome, "applied", JSON.stringify(proofTask));
+  const fresh = `${proofTask.packagePath}/artifacts/screenshots/evidence.png`,
+    tracked = `${proofTask.packagePath}/artifacts/report.bin`;
   try {
     const freshTarget = path.join(rootDir, "harness", fresh);
     mkdirSync(path.dirname(freshTarget), { recursive: true });


### PR DESCRIPTION
# English

## Summary

Renaming a task's title or slug used to leave a second directory with the same task id on disk; the projection only knows the current slug, yet the repository prose channel happily accepted and committed files under the stale directory, so four ghost package trees accumulated in the canonical ledger. This change makes the doc-sync candidate scanner refuse a repo-prose candidate whose `tasks/<segment>/` is not the package path of any projected task, with a reason that names the correct command (`ha task artifact add`). The kernel path classifiers stay shape-based so `ha doc retire` can still retire the ghosts already committed.

## Architectural Justification

The scanner is the only layer of this channel that holds the projection, so it is the one place the check can live without threading the projection into pure path functions. The gate is scoped to `taskId === undefined` (repository prose) so task-bound executions keep their existing admission. The WAL idle settler shares the scanner, so the ghosts' real ingestion path now fails loudly (`materializer_candidate_blocked`) instead of silently committing.

## What Changed

- `packages/daemon/src/doc-sync-candidate-scanner.ts`: the new blocked branch (+27/-1).
- `packages/daemon/test/doc-sync-ghost-task-package.integration.test.ts`: new; ghost path blocked, projected path accepted, retire still works.
- `packages/daemon/test/doc-sync-slice-a.test.ts`: fixtures now point at projected task packages (fixture correction, not a behaviour relaxation).

## Gate Harvest / 门收割

No gate change.

## Machine-Readable Declarations

Production-Delta: +27/-1
Dependency-Change: none

### Optional Evidence Claims

none

## Task And Scope

task_afdefae4de2e47778d895c768f. Branch `codex/task-rename-ghost`. The ledger migration of the four existing ghost trees (publish five orphans under the real packages, retire eight ghost paths, remove four empty trees) is a CEO ledger operation recorded on the task, not part of this PR.

Fleet view: admission runs in the cell that owns the write; the projection it consults is the cell's own.

## Version Impact

No version change; publish impact none.

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none
- Authority: task_afdefae4de2e47778d895c768f
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Follow-up governance task: not applicable

## Verification

- Base merge-base 16d0876294b9a09efc7e7ee8f33bc6c490c60869.
- Worker (GLM): five preconditions re-run on current main (exactly four duplicated id prefixes, none with two INDEX.md, no `UPDATE task_package`, `createTaskPackagePath` has no production caller, `ha doc status` clean); live pre-fix evidence that `ha doc sync --dry-run` reports a ghost path as `clean`; new integration test and corrected slice-a fixtures green.
- CEO read the scanner diff. CI is the complete authority.

## Review Evidence

CEO semantic review: the plan allowed exactly one production file and forbade widening kernel classifiers; both hold. The worker stopped at the ledger checkpoint and left paste-ready commands with byte-level cmp evidence instead of running them under a task-bound executor.

## Residual Risk

A repo-prose write under a legitimately new task directory that the projection has not yet caught up on is blocked until the projection includes it; the reason text tells the operator what to run.

# 中文

## 概要

task 改标题/slug 后磁盘留下同 id 的第二个目录,投影只认当前 slug,但仓库 prose 通道照收照提交,canonical 里积了 4 棵幽灵包树。本改动让 doc-sync 候选扫描器拒绝 `tasks/<seg>/` 不是任何已投影 task 包路径的 repo-prose 候选,理由点名正确命令;kernel 路径分类器保持形状判定,`ha doc retire` 仍能退役已提交的幽灵。

## 机读声明

生产行数增减(与上文机读声明一致):+27/-1

## 治理声明

- 触碰受保护面:否
- 授权:task_afdefae4de2e47778d895c768f
- Break-glass:否

## 验证

GLM 在当前 main 复跑五项前置、留改前 dry-run 为 clean 的活证据、新增集成测试与修正夹具;CEO 读扫描器 diff;CI 为完整权威。4 棵幽灵树的台账迁移由 CEO 另行执行并记在任务上。

## 评审证据

plan 只允许一个生产文件且禁止放宽 kernel 分类器,均成立;worker 在台账 Checkpoint 停手并留下 cmp 证据与可粘贴命令。

## 残余风险

投影尚未追上的新 task 目录下的 repo-prose 写会被挡到投影追上为止,理由文案已告知怎么做。
