### PR TITLE
fix(cli,daemon): make dispatch and ledger rejections self-describing

### DIFF
--- a/packages/daemon/src/task-action-catalog-runtime.ts
+++ b/packages/daemon/src/task-action-catalog-runtime.ts
@@ -101,8 +101,6 @@ export async function runTaskActionCatalogRuntime(
     action.executionId.trim()
   )
     assertCurrentSubmittedExecution(current.snapshot, taskId, action.executionId);
-  if (action.kind === "task-submit" && submitValidationUnmet && contract)
-    return submitActionRejection(cell, action, binding, current.snapshot, contract, submitValidationEvaluation);
   if (action.kind === "task-submit" && submitLeaseUnmet && contract)
     return submitActionRejection(cell, action, binding, current.snapshot, contract, submitLeaseEvaluation);
   if (lifecycle?.coordination === "reserve" && !preview)
@@ -137,6 +135,8 @@ export async function runTaskActionCatalogRuntime(
     if (rejection) return rejection;
     throw error;
   }
+  if (action.kind === "task-submit" && submitValidationUnmet && contract)
+    return submitActionRejection(cell, action, binding, current.snapshot, contract, submitValidationEvaluation);
   if (
     contract?.target.kind === "task" &&
     revisionIssues(current.snapshot, {


### PR DESCRIPTION
# English

## Summary

**This PR has been reduced to a single two-line fix.** Its original scope — making five rejection codes self-describing — was delivered independently by #2240 while this branch was in flight. Rather than rebase a duplicate implementation on top, the three superseded commits were dropped.

What remains is the one thing #2240 did not do: **submit checks the lease before parsing the submission packet**. Without it, a caller with no lease is rejected as `submit.validate` ("your packet is malformed") instead of being told it holds no lease — the wrong cause, reported confidently.

## Architectural Justification

Not required: production delta is `+2/-2`.

## What Changed

- `packages/daemon/src/task-action-catalog-runtime.ts`: unmet lease/proof criteria are handled before the submission packet is parsed, restoring the rejection precedence that `829f856fc` inverted.

## What was dropped, and why

Verified by measurement against a daemon running the current `main`, not by reading diffs:

| Code | Covered by #2240? |
|---|---|
| `invalid_submission` | yes |
| `invalid_runtime_mission` / `runtime_mission_unavailable` | yes |
| `invalid_proof` | yes |
| `executor_binding_invalid` | yes |
| `missing_field` | yes — `{"field":"riskTier","actual":"missing","expectation":"Required fields: …"}` |
| `agentId` stale-build gate | already on `main` |

Three commits were deleted rather than merged. Keeping them would have been a second production implementation of the same capability.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none

## Machine-Readable Declarations

Production-Delta: +2/-2

## Task And Scope

- Harness task: task_c8a28f6ae18a17e5877d8f4eef
- Evidence: `F-B9B3FE13`
- The rejection-precedence regression this fixes was caught by CEO acceptance on this branch's own CI, not by review.

## Version Impact

- Version: no change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Machine-check boundary: this PR asserts the declaration exists.
- Break-glass: no

## Verification

- Base `origin/main`: 63726aa48
- `json-rpc-protocol.test.ts` 55/55, `runtime-cli.integration.test.ts` 1/1, `runtime-spawn-ingress.integration.test.ts` 22/22, `rejection-next-actions.integration.test.ts` 5/5 — all via isolated Ubuntu dispatch with hermetic preflight passing.
- `production-delta` → pass at `+2/-2`.
- Not run: `check:local` or the full matrix.

## Review Evidence

- CEO acceptance rejected an earlier revision of this branch when its CI turned red on `action-failure-explanation.integration.test.ts`; the negative control (`main` green, branch red) established it was introduced here, and the fix in this PR is that regression's remedy.
- Human review: pending.

## Residual Risk

- None specific to two lines of precedence ordering. The broader self-describing-rejection surface now lives in #2240's implementation, which this branch no longer duplicates.

---

# 中文

## 摘要

**本 PR 已收缩为两行修复。** 它原本的范围——让五个拒绝码自描述——在本分支在飞期间被 #2240 独立交付了。与其把一份重复实现 rebase 上去，不如把那三个已被取代的提交直接删掉。

保留下来的是 #2240 没做的那一件事：**submit 先检查 lease，再解析 submission packet**。没有它，一个没有 lease 的调用者会被判成 `submit.validate`（「你的包格式不对」）而不是被告知它没有持有 lease——归因错了，而且报得很笃定。

## 架构辩护

不适用：production delta 为 `+2/-2`。

## 改动内容

- `packages/daemon/src/task-action-catalog-runtime.ts`：未满足的 lease/proof criterion 在解析 submission packet 之前处理，恢复被 `829f856fc` 颠倒的拒绝优先级。

## 删掉了什么，为什么

对着跑在当前 `main` 上的 daemon 实测得出，不是读 diff 猜的：

| 码 | #2240 是否已覆盖 |
|---|---|
| `invalid_submission` | 是 |
| `invalid_runtime_mission` / `runtime_mission_unavailable` | 是 |
| `invalid_proof` | 是 |
| `executor_binding_invalid` | 是 |
| `missing_field` | 是——`{"field":"riskTier","actual":"missing","expectation":"Required fields: …"}` |
| `agentId` stale-build 闸门 | `main` 上已有 |

三个提交被删除而不是被合并。留着它们等于让同一能力有第二份生产实现。

## 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none

## 任务与范围

- Harness task：task_c8a28f6ae18a17e5877d8f4eef
- 证据：`F-B9B3FE13`
- 本 PR 修的那个拒绝优先级回归，是 CEO 在本分支自己的 CI 上验收时抓到的，不是评审发现的。

## 版本影响

- 版本：不变
- 发布影响：不发布

## 治理声明

- 是否触碰 protected surface：否
- 机器检查边界：本 PR 声明该字段存在。
- Break-glass：否

## 验证

- Base `origin/main`：63726aa48
- `json-rpc-protocol.test.ts` 55/55、`runtime-cli.integration.test.ts` 1/1、`runtime-spawn-ingress.integration.test.ts` 22/22、`rejection-next-actions.integration.test.ts` 5/5——全部经 Ubuntu 隔离派测，hermetic preflight 通过。
- `production-delta` → 在 `+2/-2` 下通过。
- 未运行：`check:local` 与全量矩阵。

## 评审证据

- CEO 验收曾驳回本分支的一个较早版本——它的 CI 在 `action-failure-explanation.integration.test.ts` 上转红；阴性对照（`main` 绿、分支红）确认是本分支引入的，本 PR 的改动就是那个回归的解药。
- 人工评审：待进行。

## 残留风险

- 两行优先级顺序本身没有特有风险。更大的「拒绝自描述」面现在归 #2240 的实现所有，本分支不再重复它。
