### PR TITLE
fix(gui): stop entity kind cards from overflowing and rebuild the entity detail page as two columns

### DIFF
--- a/packages/gui/src/renderer/components/entityDoc/EntityLocatorPreview.tsx
+++ b/packages/gui/src/renderer/components/entityDoc/EntityLocatorPreview.tsx
@@ -6,7 +6,7 @@ import { HtmlArtifactPreview } from "../HtmlArtifactPreview.tsx";
 import { DocTree } from "../taskDetail/DocTree.tsx";
 import { buildDocTree } from "../../model/docTree.ts";
 import type { DocEntry } from "../../model/types.ts";
-import { readEntityLocatorContent } from "../../entity-locator-client.ts";
+import { entityLocatorContentQuery } from "../../entity-locator-client.ts";
 import { selectEntityLocatorRenderer, type EntityLocator } from "../../entity-locator-renderer.ts";
 import { openArtifactExternally } from "../../artifact-open-client.ts";
 
@@ -24,12 +24,7 @@ export function EntityLocatorPreview({
   readonly locator: EntityLocator;
 }) {
   const renderer = selectEntityLocatorRenderer(locator);
-  const read = useQuery({
-    queryKey: ["entity-locator", repoId, locator.kind, locator.value],
-    queryFn: () => readEntityLocatorContent(repoId, locator),
-    enabled: locator.kind === "repository-path",
-    staleTime: 4_000,
-  });
+  const read = useQuery(entityLocatorContentQuery(repoId, locator));
 
   if (renderer === "opaque")
     return <OpaqueLocator repoId={repoId} locator={locator} note="这个指针没有对应的 GUI 渲染器。" />;

--- a/packages/gui/src/renderer/components/entityDoc/FactVocabularySections.tsx
+++ b/packages/gui/src/renderer/components/entityDoc/FactVocabularySections.tsx
@@ -1,0 +1,77 @@
+import { FACT_TYPE_VOCABULARY } from "../../entity-docs.ts";
+import type { useFactFacetStats } from "../../entities-data.ts";
+
+/**
+ * Fact 详情专属的两个区块(dec_2935057783CD5D56E9F287AE4D CH1-CH3):Type 受控词表
+ * 配置区与本仓实况。词表值来自 fact_domain_type 投影读面;空结果呈真实空态,
+ * 禁止示例词冒充词表。从详情视图拆出后,视图本体只管两栏骨架。
+ */
+
+export function FactTypeVocabulary({ stats }: { readonly stats: ReturnType<typeof useFactFacetStats> }) {
+  return (
+    <section data-testid="fact-type-vocabulary" className="mt-6 rounded-lg border border-border bg-surface p-4">
+      <div className="flex flex-wrap items-center gap-2">
+        <h3 className="ui-meta font-semibold uppercase tracking-wide text-text-muted">Fact Type 受控词表</h3>
+        <span className="rounded border border-accent/60 px-1.5 py-0.5 font-mono ui-micro text-accent">配置区</span>
+        <span className="rounded border border-border px-1.5 py-0.5 font-mono ui-micro text-text-faint">投影实况</span>
+      </div>
+      <p className="mt-2 ui-meta leading-relaxed text-text-muted">
+        裁决 {FACT_TYPE_VOCABULARY.decisionId}:Type 不允许自由文本——随手写会把「分面检索」退化成它要解决的 混乱。一个
+        Type 值必须经一次显式登记才可使用;一条 fact 可同时归属多个 Type;已记录的 fact
+        允许重新归类,以新事件表达并保留审计轨迹。
+      </p>
+      <div
+        className="mt-3 rounded-md border border-dashed border-border px-3 py-3"
+        data-testid="fact-type-registered-list"
+      >
+        <div className="font-mono ui-micro uppercase tracking-wide text-text-faint">已登记 Type</div>
+        {stats.state === "pending" ? <p className="mt-1 ui-meta text-text-faint">正在读取已登记 Type…</p> : null}
+        {stats.state === "error" ? <p className="mt-1 ui-meta text-status-blocked">Type 词表读取失败。</p> : null}
+        {stats.state === "ready" && stats.domainTypes.length === 0 ? (
+          <p className="mt-1 ui-meta leading-relaxed text-text-faint">
+            空——本仓尚未登记 Fact Type。这里展示真实投影结果,不用示例词冒充词表。
+          </p>
+        ) : null}
+        {stats.state === "ready" && stats.domainTypes.length > 0 ? (
+          <ul className="mt-2 space-y-1">
+            {stats.domainTypes.map((entry) => (
+              <li key={entry.domainType} className="flex items-center gap-2 ui-meta">
+                <code className="font-mono text-text">{entry.domainType}</code>
+                <span className="text-text-faint">由 fact/{entry.registeredByFactId} 登记</span>
+              </li>
+            ))}
+          </ul>
+        ) : null}
+      </div>
+    </section>
+  );
+}
+
+export function FactFacetLive({ stats }: { readonly stats: ReturnType<typeof useFactFacetStats> }) {
+  return (
+    <section data-testid="fact-facet-live" className="mt-4 border-t border-border pt-4">
+      <h3 className="mb-2 ui-meta font-semibold uppercase tracking-wide text-text-muted">本仓实况</h3>
+      {stats.state === "pending" && <p className="ui-meta text-text-faint">正在读取事实切面…</p>}
+      {stats.state === "error" && <p className="ui-meta text-status-blocked">事实切面读取失败。</p>}
+      {stats.state === "ready" && (
+        <div className="flex flex-wrap items-center gap-2 ui-meta">
+          <span className="font-mono text-text">{stats.total} 条 fact</span>
+          {stats.byCategory.map((entry) => (
+            <span
+              key={entry.category}
+              className="rounded border border-border px-1.5 py-0.5 font-mono ui-micro text-text-muted"
+            >
+              {entry.category} · {entry.count}
+            </span>
+          ))}
+        </div>
+      )}
+      {stats.state === "ready" && (
+        <p className="mt-2 ui-micro leading-relaxed text-text-faint">
+          来自既有 facts 切面读(与 ⌘K 面板同一条,共享缓存)。category 是 memoryClass 在读面上的折叠:
+          semantic→lesson、procedural→progress、episodic→finding。Type 轴的分布等登记面合入后在此并列。
+        </p>
+      )}
+    </section>
+  );
+}

--- a/packages/gui/src/renderer/components/entityDoc/GovernedEntityPanel.tsx
+++ b/packages/gui/src/renderer/components/entityDoc/GovernedEntityPanel.tsx
@@ -3,13 +3,14 @@ import { useQueryClient } from "@tanstack/react-query";
 import { Plus } from "@phosphor-icons/react";
 import type { EntityKindRow } from "../../entity-kind-catalog-client.ts";
 import type { GovernedEntityRow } from "../../graph/governedEntities.ts";
-import { entityKindQueryKeys, useGovernedEntityRows } from "../../entity-kind-data.ts";
+import { entityKindQueryKeys } from "../../entity-kind-data.ts";
 import { importEntity } from "../../entity-locator-client.ts";
-import { EntityLocatorPreview } from "./EntityLocatorPreview.tsx";
 import { NewGovernedEntityForm, type NewGovernedEntityInput } from "./NewGovernedEntityForm.tsx";
 
 /**
- * 声明实体的实况面:这个 kind 现在有哪些实体、点开看它的正文、以及新建一个。
+ * 声明实体的实况面·左列形态:这个 kind 现在有哪些实体、搜一个、新建一个。
+ * 选中哪条的正文渲染在详情页右栏(EntityLocatorPreview),所以选择状态上提到
+ * EntityDocDetailView,本组件只报 `onSelect`。
  *
  * 「新建」按钮只在读面说这个 kind `importable` 时出现——判据是它有没有可执行的 import
  * 动作,不是一份写死的可写 kind 名单。提交走 `repo.entity.import`,与 CLI 同一条写路。
@@ -17,58 +18,79 @@ import { NewGovernedEntityForm, type NewGovernedEntityInput } from "./NewGoverne
 export function GovernedEntityPanel({
   repoId,
   row,
-  selectedEntityRef,
+  rows,
+  selectedRef,
+  onSelect,
 }: {
   readonly repoId: string;
   readonly row: EntityKindRow;
-  readonly selectedEntityRef: string | null;
+  readonly rows: readonly GovernedEntityRow[];
+  readonly selectedRef: string | null;
+  readonly onSelect: (ref: string) => void;
 }) {
-  const rows = useGovernedEntityRows(repoId).filter((entity) => entity.kind === row.kind);
-  const [selected, setSelected] = useState<string | null>(selectedEntityRef);
-  const active = rows.find((entity) => entity.ref === (selected ?? selectedEntityRef)) ?? rows[0] ?? null;
+  const [query, setQuery] = useState("");
+  const needle = query.trim().toLowerCase();
+  const visible =
+    needle === ""
+      ? rows
+      : rows.filter((entity) =>
+          [entity.title ?? "", entity.entityId, entity.locator?.value ?? ""].some((text) =>
+            text.toLowerCase().includes(needle),
+          ),
+        );
   return (
-    <section data-testid={`governed-entity-panel`} className="flex flex-col gap-3">
+    <section data-testid="governed-entity-panel" className="mt-6 border-t border-border pt-4">
       <header className="flex flex-wrap items-center gap-2">
         <h2 className="ui-body font-semibold">本仓实体</h2>
         <span className="ui-micro text-text-faint">{rows.length} 条</span>
         {row.importable && <NewEntityControl repoId={repoId} row={row} />}
       </header>
       {rows.length === 0 ? (
-        <p data-testid="governed-entity-empty" className="ui-meta text-text-faint">
+        <p data-testid="governed-entity-empty" className="mt-2 ui-meta text-text-faint">
           本仓还没有这个 kind 的实体。
         </p>
       ) : (
-        <div className="grid gap-3 md:grid-cols-[minmax(220px,320px)_1fr]">
-          <ul data-testid="governed-entity-list" className="flex max-h-96 flex-col gap-1 overflow-y-auto">
-            {rows.map((entity) => (
-              <li key={entity.ref}>
-                <button
-                  type="button"
-                  data-testid={`governed-entity-row-${entity.entityId}`}
-                  onClick={() => setSelected(entity.ref)}
-                  className={[
-                    "w-full rounded-md border px-2 py-1.5 text-left",
-                    entity.ref === active?.ref
-                      ? "border-border-strong bg-surface-raised"
-                      : "border-border hover:bg-surface-raised",
-                  ].join(" ")}
-                >
-                  <span className="block truncate ui-meta text-text">{entity.title ?? entity.entityId}</span>
-                  <span className="block truncate font-mono ui-micro text-text-faint">
-                    {entity.locator?.value ?? entity.entityId}
-                  </span>
-                </button>
-              </li>
-            ))}
-          </ul>
-          <div className="flex min-h-0 flex-col rounded-md border border-border">
-            {active === null || active.locator === null ? (
-              <p className="p-4 ui-meta text-text-faint">这条实体没有 locator,没有可渲染的正文。</p>
-            ) : (
-              <EntityLocatorPreview repoId={repoId} locator={active.locator} />
-            )}
-          </div>
-        </div>
+        <>
+          <input
+            type="search"
+            data-testid="governed-entity-search"
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder="搜索标题 / id / locator"
+            className={[
+              "mt-2 w-full rounded-md border border-border bg-surface px-2 py-1 ui-meta",
+              "text-text placeholder:text-text-faint focus:border-border-strong focus:outline-none",
+            ].join(" ")}
+          />
+          {visible.length === 0 ? (
+            <p data-testid="governed-entity-search-empty" className="mt-2 ui-meta text-text-faint">
+              没有匹配「{query.trim()}」的实体。
+            </p>
+          ) : (
+            <ul data-testid="governed-entity-list" className="mt-2 flex flex-col gap-1">
+              {visible.map((entity) => (
+                <li key={entity.ref}>
+                  <button
+                    type="button"
+                    data-testid={`governed-entity-row-${entity.entityId}`}
+                    onClick={() => onSelect(entity.ref)}
+                    className={[
+                      "w-full rounded-md border px-2 py-1.5 text-left",
+                      entity.ref === selectedRef
+                        ? "border-border-strong bg-surface-raised"
+                        : "border-border hover:bg-surface-raised",
+                    ].join(" ")}
+                  >
+                    <span className="block truncate ui-meta text-text">{entity.title ?? entity.entityId}</span>
+                    <span className="block truncate font-mono ui-micro text-text-faint">
+                      {entity.locator?.value ?? entity.entityId}
+                    </span>
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </>
       )}
     </section>
   );

--- a/packages/gui/src/renderer/entity-kind-data.ts
+++ b/packages/gui/src/renderer/entity-kind-data.ts
@@ -55,14 +55,19 @@ export function useEntityKindOptions(repoId: string): readonly EntityTypeOption[
   );
 }
 
+/** 声明实体行读的 query 选项:面板消费与深链接预取共用同一份 key 与新鲜度。 */
+export function governedEntityRowsQuery(repoId: string) {
+  return {
+    queryKey: entityKindQueryKeys.rows(repoId),
+    queryFn: () => readGovernedEntityRows(repoId),
+    staleTime: 4_000,
+  };
+}
+
 const NO_GOVERNED_ROWS: readonly GovernedEntityRow[] = [];
 
 /** 声明实体的行:领地分块与聚光灯节点的数据源。读失败/未就绪时是空,不冒充有数据。 */
 export function useGovernedEntityRows(repoId: string): readonly GovernedEntityRow[] {
-  const query = useQuery({
-    queryKey: entityKindQueryKeys.rows(repoId),
-    queryFn: () => readGovernedEntityRows(repoId),
-    staleTime: 4_000,
-  });
+  const query = useQuery(governedEntityRowsQuery(repoId));
   return query.data ?? NO_GOVERNED_ROWS;
 }

--- a/packages/gui/src/renderer/entity-locator-client.ts
+++ b/packages/gui/src/renderer/entity-locator-client.ts
@@ -36,6 +36,21 @@ type LocatorBridge = {
 
 const bridge = (): Partial<LocatorBridge> => (window.harness as unknown as Partial<LocatorBridge> | undefined) ?? {};
 
+/**
+ * locator 正文读的 query 声明。渲染面与深链接预取共用同一份 key / 读函数 / 新鲜度 /
+ * 适用判定,不在两处各拼一份——两处拼出不同的 key 就会各读一次,拼出不同的适用
+ * 判定就会给渲染不了的指针白发一次 IPC。
+ */
+export function entityLocatorContentQuery(repoId: string, locator: EntityLocator) {
+  return {
+    queryKey: ["entity-locator", repoId, locator.kind, locator.value] as const,
+    queryFn: () => readEntityLocatorContent(repoId, locator),
+    // 只有仓内路径指针能读出正文;别的指针走元数据卡,没有可读的内容。
+    enabled: locator.kind === "repository-path",
+    staleTime: 4_000,
+  };
+}
+
 export async function readEntityLocatorContent(repoId: string, locator: EntityLocator): Promise<EntityLocatorContent> {
   const channel = bridge().readEntityLocator;
   if (!channel) throw new Error("Entity locator bridge is unavailable.");

--- a/packages/gui/src/renderer/views/EntitiesView.tsx
+++ b/packages/gui/src/renderer/views/EntitiesView.tsx
@@ -1,10 +1,14 @@
+import { useEffect } from "react";
+import { useQueryClient } from "@tanstack/react-query";
 import { BookOpen } from "@phosphor-icons/react";
 import { entityDocGroups, type EntityKindDoc } from "../entity-docs.ts";
 import type { ViewId } from "../navigation/viewHistory.ts";
 import { useEntityLiveCounts, type EntityLiveCount } from "../entities-data.ts";
 import { EntityDocDetailView } from "./EntityDocDetailView.tsx";
-import { useEntityKindCatalog } from "../entity-kind-data.ts";
+import { entityKindQueryKeys, governedEntityRowsQuery, useEntityKindCatalog } from "../entity-kind-data.ts";
+import { entityLocatorContentQuery } from "../entity-locator-client.ts";
 import type { EntityKindCatalog } from "../entity-kind-catalog-client.ts";
+import type { GovernedEntityRow } from "../graph/governedEntities.ts";
 
 /**
  * 实体说明面(dec_2935057783CD5D56E9F287AE4D CH4):三元语与扩展实体集中在一
@@ -35,6 +39,7 @@ export function EntitiesView({
   const liveCounts = useEntityLiveCounts(repoId);
   // 分组来自已注册 kind 读面:声明一个新 kind,这一页不改代码就多一条目录项。
   const { catalog } = useEntityKindCatalog(repoId);
+  useDeepLinkedEntityContent(repoId, focusedRef);
   const groups = entityDocGroups(catalog);
   const focus = resolveEntityDocFocus(focusedRef, catalog);
   if (focus)
@@ -156,6 +161,34 @@ function liveLabel(live: EntityLiveCount): string {
   if (live.state === "ready") return `${live.count}`;
   if (live.state === "error") return "读取失败";
   return "…";
+}
+
+/**
+ * 落点数据的预取:让深链接的正文不被渲染门控。
+ *
+ * 不预取时这条读链是三段串行,而且每段都要等上一段**渲染完**才开始:kind 目录回
+ * 来详情才挂载,详情挂载了行读才发出,行读回来才知道选中谁、才挂渲染面,渲染面
+ * 挂上了 locator 正文读才发出。query 通知订阅者走宏任务,于是深链接的正文比别的
+ * 落点整整多等两轮——本地看不出来,CI 上就是间歇性的空白右栏。
+ *
+ * 依赖是数据依赖,不是渲染依赖:行读不依赖 kind 目录,locator 只依赖行读。所以在
+ * 挂载当拍直接按数据依赖把两段拉进 query 缓存,渲染面照常消费同一份声明(命中缓
+ * 存,不重复读)。落点不是声明实体时没有行能匹配上 ref,链在第一段自然停住。
+ */
+function useDeepLinkedEntityContent(repoId: string, focusedRef: string | null) {
+  const queryClient = useQueryClient();
+  useEffect(() => {
+    if (focusedRef === null) return;
+    void (async () => {
+      await queryClient.prefetchQuery(governedEntityRowsQuery(repoId));
+      const rows = queryClient.getQueryData<readonly GovernedEntityRow[]>(entityKindQueryKeys.rows(repoId));
+      const locator = rows?.find((entity) => entity.ref === focusedRef)?.locator ?? null;
+      if (locator === null) return;
+      const content = entityLocatorContentQuery(repoId, locator);
+      if (!content.enabled) return;
+      await queryClient.prefetchQuery(content);
+    })();
+  }, [focusedRef, queryClient, repoId]);
 }
 
 /**

--- a/packages/gui/src/renderer/views/EntitiesView.tsx
+++ b/packages/gui/src/renderer/views/EntitiesView.tsx
@@ -90,6 +90,11 @@ export function EntitiesView({
 
 const NAV_SELF_LABEL = "实体说明";
 
+/**
+ * 目录卡片。长 kind 名(声明实体的 `software/coding/x@1`)与它的路径模板都是
+ * 不含空格的机器字面量,常规断行救不了:kind 名 `break-all` 兜底换行并把全名放进
+ * `title`,路径模板独立成第二行——两者不再共享一行窄空间互相顶出去。
+ */
 function EntityDocCard({
   doc,
   live,
@@ -109,15 +114,24 @@ function EntityDocCard({
         "hover:border-border-strong",
       ].join(" ")}
     >
-      <div className="flex min-w-0 items-center gap-2">
-        <b className="font-mono ui-body">{doc.kind}</b>
-        {doc.refTemplate && <code className="shrink-0 font-mono ui-micro text-text-faint">{doc.refTemplate}</code>}
+      <div className="flex min-w-0 items-start gap-2">
+        <b title={doc.kind} className="min-w-0 flex-1 self-center break-all font-mono ui-body leading-snug text-text">
+          {doc.kind}
+        </b>
         {live ? (
-          <span title="本仓活行数" className="ml-auto shrink-0 font-mono ui-micro text-text-muted">
+          <span title="本仓活行数" className="ml-auto shrink-0 self-center font-mono ui-micro text-text-muted">
             {liveLabel(live)}
           </span>
         ) : null}
       </div>
+      {doc.refTemplate ? (
+        <code
+          title={doc.refTemplate}
+          className="mt-0.5 block break-all font-mono ui-micro leading-snug text-text-faint"
+        >
+          {doc.refTemplate}
+        </code>
+      ) : null}
       <p className="mt-1 line-clamp-2 ui-meta leading-relaxed text-text-muted">{doc.definition}</p>
       <div className="mt-1.5 flex flex-wrap items-center gap-1">
         {doc.schemaId && (

--- a/packages/gui/src/renderer/views/EntityDocDetailView.tsx
+++ b/packages/gui/src/renderer/views/EntityDocDetailView.tsx
@@ -1,16 +1,26 @@
+import { useEffect, useState } from "react";
 import { ArrowLeft, ArrowSquareOut, CaretRight } from "@phosphor-icons/react";
-import { entityDocIndex, FACT_TYPE_VOCABULARY, type EntityFieldDoc, type EntityKindDoc } from "../entity-docs.ts";
-import { useEntityKindCatalog } from "../entity-kind-data.ts";
-import { findEntityKind, type EntityKindDeclaration } from "../entity-kind-catalog-client.ts";
+import { entityDocIndex, type EntityFieldDoc, type EntityKindDoc } from "../entity-docs.ts";
+import { useEntityKindCatalog, useGovernedEntityRows } from "../entity-kind-data.ts";
+import { findEntityKind, type EntityKindDeclaration, type EntityKindRow } from "../entity-kind-catalog-client.ts";
 import { GovernedEntityPanel } from "../components/entityDoc/GovernedEntityPanel.tsx";
+import { EntityLocatorPreview } from "../components/entityDoc/EntityLocatorPreview.tsx";
+import { FactFacetLive, FactTypeVocabulary } from "../components/entityDoc/FactVocabularySections.tsx";
 import type { ViewId } from "../navigation/viewHistory.ts";
 import { useFactFacetStats, type EntityLiveCounts } from "../entities-data.ts";
+import type { GovernedEntityRow } from "../graph/governedEntities.ts";
+
+/** 左列宽度:说明内容(字段表/词表/实体清单)的可读下限,右栏渲染器吃掉全部剩余。 */
+const LEFT_COLUMN_CLASS = "w-[400px] shrink-0 overflow-y-auto border-r border-border px-4 py-4";
 
 /**
- * 实体说明面·详情:一个实体是什么、字段什么含义、状态词表、与谁有什么关系、
- * 合法写入动作。与 PresetDetailView 同构(面包屑头部 + 回撤原路返回)。
- * Fact 详情额外承载 Type 受控词表配置区(dec_2935057783CD5D56E9F287AE4D):
- * 词表由既有 facts 切面读返回;空结果呈真实空态,禁止示例词冒充词表。
+ * 实体说明面·详情:两栏骨架——左列(固定宽,内部自滚动)承载说明本体:描述、存放、
+ * GUI 入口、核心字段(含合法写入动作)、状态词表、关系,以及声明实体的「本仓实体」
+ * 清单(含搜索与新建);右栏是选中实体的自适应渲染器(`entity-locator-renderer.ts`
+ * 按 locator 类型选),占满剩余宽度与全高,未选中时呈真实空态。内核实体(task /
+ * decision / …)沿用同一骨架,右栏保持空态——不做两套布局。
+ *
+ * Fact 详情额外承载 Type 受控词表配置区(dec_2935057783CD5D56E9F287AE4D)。
  */
 export function EntityDocDetailView({
   repoId,
@@ -36,6 +46,17 @@ export function EntityDocDetailView({
   const doc = entityDocIndex(catalog).get(kind) ?? null;
   const catalogRow = findEntityKind(catalog, kind);
   const factStats = useFactFacetStats(repoId, kind === "fact");
+  // 选中实体由右栏渲染,选择状态上提到这里:左列清单只报 onSelect。
+  const [selectedRef, setSelectedRef] = useState<string | null>(selectedEntityRef);
+  useEffect(() => {
+    setSelectedRef(selectedEntityRef);
+  }, [selectedEntityRef]);
+  const allGovernedRows = useGovernedEntityRows(repoId);
+  const governedRows =
+    catalogRow !== null && catalogRow.origin === "vertical"
+      ? allGovernedRows.filter((entity) => entity.kind === kind)
+      : [];
+  const selectedEntity = governedRows.find((entity) => entity.ref === selectedRef) ?? null;
   if (doc === null)
     return (
       <div className="flex min-h-0 flex-1 flex-col overflow-y-auto" data-testid="entity-doc-detail-unknown">
@@ -58,7 +79,7 @@ export function EntityDocDetailView({
       </div>
     );
   return (
-    <div className="flex min-h-0 flex-1 flex-col overflow-y-auto" data-testid={`entity-doc-detail-${doc.kind}`}>
+    <div className="flex min-h-0 flex-1 flex-col overflow-hidden" data-testid={`entity-doc-detail-${doc.kind}`}>
       <header className="shrink-0 border-b border-border px-4 py-3" data-testid="entity-doc-detail-header">
         <div className="flex min-w-0 items-center gap-2.5">
           <button
@@ -85,7 +106,10 @@ export function EntityDocDetailView({
               <span className="truncate font-mono ui-micro leading-3 text-text-muted">{doc.kind}</span>
             </div>
             <div className="mt-0.5 flex min-w-0 flex-wrap items-center gap-2">
-              <h1 className="truncate font-mono ui-title font-semibold leading-5 tracking-[-0.01em] text-text">
+              <h1
+                title={doc.kind}
+                className="truncate font-mono ui-title font-semibold leading-5 tracking-[-0.01em] text-text"
+              >
                 {doc.kind}
               </h1>
               {doc.schemaId && <DocBadge value={doc.schemaId} />}
@@ -110,114 +134,202 @@ export function EntityDocDetailView({
         </div>
       </header>
 
-      <main className="min-h-0 flex-1 px-4 py-4" data-testid="entity-doc-detail-content">
-        <section className="max-w-3xl">
-          <p className="ui-body leading-relaxed text-text">{doc.definition}</p>
-          <dl className="mt-3 grid grid-cols-[auto_1fr] gap-x-4 gap-y-1.5 ui-meta">
-            <dt className="font-mono ui-micro uppercase tracking-wide text-text-faint">存放</dt>
-            <dd className="text-text-muted">{doc.storage}</dd>
-            {doc.guiEntry && (
-              <>
-                <dt className="font-mono ui-micro uppercase tracking-wide text-text-faint">GUI 入口</dt>
-                <dd className="text-text-muted">{doc.guiEntry.note}</dd>
-              </>
-            )}
-            {!doc.guiEntry && (
-              <>
-                <dt className="font-mono ui-micro uppercase tracking-wide text-text-faint">GUI 入口</dt>
-                <dd className="text-text-muted">当前没有专页;写入走 CLI,如实标注不硬造入口。</dd>
-              </>
-            )}
-          </dl>
-        </section>
+      <div className="flex min-h-0 flex-1">
+        <aside className={LEFT_COLUMN_CLASS} data-testid="entity-doc-detail-left">
+          <section>
+            <p className="ui-body leading-relaxed text-text">{doc.definition}</p>
+            <dl className="mt-3 grid grid-cols-[auto_1fr] gap-x-4 gap-y-1.5 ui-meta">
+              <dt className="font-mono ui-micro uppercase tracking-wide text-text-faint">存放</dt>
+              <dd className="text-text-muted">{doc.storage}</dd>
+              {doc.guiEntry && (
+                <>
+                  <dt className="font-mono ui-micro uppercase tracking-wide text-text-faint">GUI 入口</dt>
+                  <dd className="text-text-muted">{doc.guiEntry.note}</dd>
+                </>
+              )}
+              {!doc.guiEntry && (
+                <>
+                  <dt className="font-mono ui-micro uppercase tracking-wide text-text-faint">GUI 入口</dt>
+                  <dd className="text-text-muted">当前没有专页;写入走 CLI,如实标注不硬造入口。</dd>
+                </>
+              )}
+            </dl>
+          </section>
 
-        <DetailSection title="核心字段" testId="entity-doc-fields">
-          <FieldTable fields={doc.fields} />
-          {doc.nestedFields.map((nested) => (
-            <div key={nested.container} className="mt-3">
-              <h4 className="mb-1.5 font-mono ui-micro uppercase tracking-wide text-text-faint">{nested.container}</h4>
-              <FieldTable fields={nested.fields} />
-            </div>
-          ))}
-        </DetailSection>
-
-        {doc.statuses.length > 0 && (
-          <DetailSection title="状态词表" testId="entity-doc-statuses">
-            {doc.statuses.map((status) => (
-              <div key={status.field} className="mb-2 last:mb-0">
-                <code className="font-mono ui-micro text-text-muted">{status.field}</code>
-                <div className="mt-1 flex flex-wrap gap-1">
-                  {status.words.map((word) => (
-                    <span
-                      key={word}
-                      data-testid={`entity-status-word-${word}`}
-                      className="rounded border border-border px-1.5 py-0.5 font-mono ui-micro text-text-muted"
-                    >
-                      {word}
-                    </span>
-                  ))}
-                </div>
+          <DetailSection title="核心字段" testId="entity-doc-fields">
+            <FieldTable fields={doc.fields} />
+            {doc.nestedFields.map((nested) => (
+              <div key={nested.container} className="mt-3">
+                <h4 className="mb-1.5 font-mono ui-micro uppercase tracking-wide text-text-faint">
+                  {nested.container}
+                </h4>
+                <FieldTable fields={nested.fields} />
               </div>
             ))}
-            <p className="mt-2 ui-micro leading-relaxed text-text-faint">
-              词表逐字来自内核注册表;这里的每个词都是合法值,不在词表里的状态写不进台账。
-            </p>
           </DetailSection>
-        )}
 
-        {doc.edges.length > 0 && (
-          <DetailSection title="关系" testId="entity-doc-relations">
-            <ul className="space-y-1">
-              {doc.edges.map((edge) => (
-                <li
-                  key={`${edge.sourceKind}-${edge.type}-${edge.targetKind}`}
-                  className="flex min-w-0 flex-wrap items-center gap-1.5 font-mono ui-micro"
-                >
-                  <span className={edge.sourceKind === doc.kind ? "font-semibold text-text" : "text-text-muted"}>
-                    {edge.sourceKind}
+          {doc.actions.length > 0 && (
+            <DetailSection title="合法写入动作" testId="entity-doc-actions">
+              <div className="flex flex-wrap gap-1">
+                {doc.actions.map((action) => (
+                  <span
+                    key={action}
+                    className="rounded border border-border px-1.5 py-0.5 font-mono ui-micro text-text-muted"
+                  >
+                    {action}
                   </span>
-                  <span className="text-text-faint">--</span>
-                  <span className="rounded bg-surface-raised px-1.5 py-0.5 text-accent">{edge.type}</span>
-                  <span className="text-text-faint">--&gt;</span>
-                  <span className={edge.targetKind === doc.kind ? "font-semibold text-text" : "text-text-muted"}>
-                    {edge.targetKind}
-                  </span>
-                </li>
-              ))}
-            </ul>
-            <p className="mt-2 ui-micro leading-relaxed text-text-faint">
-              加粗端是本实体。方向注册表规定哪种(源, 动词, 目标)三元组合法;未注册的组合写不进台账。
-            </p>
-          </DetailSection>
-        )}
+                ))}
+              </div>
+              <p className="mt-2 ui-micro leading-relaxed text-text-faint">
+                动作目录来自内核;不在此列的写入路径不存在。GUI 是视图消费者,写操作与 CLI 同面。
+              </p>
+            </DetailSection>
+          )}
 
-        {doc.actions.length > 0 && (
-          <DetailSection title="合法写入动作" testId="entity-doc-actions">
-            <div className="flex flex-wrap gap-1">
-              {doc.actions.map((action) => (
-                <span
-                  key={action}
-                  className="rounded border border-border px-1.5 py-0.5 font-mono ui-micro text-text-muted"
-                >
-                  {action}
-                </span>
+          {doc.statuses.length > 0 && (
+            <DetailSection title="状态词表" testId="entity-doc-statuses">
+              {doc.statuses.map((status) => (
+                <div key={status.field} className="mb-2 last:mb-0">
+                  <code className="font-mono ui-micro text-text-muted">{status.field}</code>
+                  <div className="mt-1 flex flex-wrap gap-1">
+                    {status.words.map((word) => (
+                      <span
+                        key={word}
+                        data-testid={`entity-status-word-${word}`}
+                        className="rounded border border-border px-1.5 py-0.5 font-mono ui-micro text-text-muted"
+                      >
+                        {word}
+                      </span>
+                    ))}
+                  </div>
+                </div>
               ))}
-            </div>
-            <p className="mt-2 ui-micro leading-relaxed text-text-faint">
-              动作目录来自内核;不在此列的写入路径不存在。GUI 是视图消费者,写操作与 CLI 同面。
-            </p>
-          </DetailSection>
-        )}
+              <p className="mt-2 ui-micro leading-relaxed text-text-faint">
+                词表逐字来自内核注册表;这里的每个词都是合法值,不在词表里的状态写不进台账。
+              </p>
+            </DetailSection>
+          )}
 
-        {doc.kind === "fact" && <FactTypeVocabulary stats={factStats} />}
-        {doc.kind === "fact" && <FactFacetLive stats={factStats} />}
-        {catalogRow !== null && catalogRow.origin === "vertical" && (
-          <div className="mt-6 max-w-3xl border-t border-border pt-4">
-            <GovernedEntityPanel repoId={repoId} row={catalogRow} selectedEntityRef={selectedEntityRef} />
-          </div>
-        )}
-        {catalogRow?.declaration != null && <DeclarationFacets declaration={catalogRow.declaration} />}
-      </main>
+          {doc.edges.length > 0 && (
+            <DetailSection title="关系" testId="entity-doc-relations">
+              <ul className="space-y-1">
+                {doc.edges.map((edge) => (
+                  <li
+                    key={`${edge.sourceKind}-${edge.type}-${edge.targetKind}`}
+                    className="flex min-w-0 flex-wrap items-center gap-1.5 font-mono ui-micro"
+                  >
+                    <span className={edge.sourceKind === doc.kind ? "font-semibold text-text" : "text-text-muted"}>
+                      {edge.sourceKind}
+                    </span>
+                    <span className="text-text-faint">--</span>
+                    <span className="rounded bg-surface-raised px-1.5 py-0.5 text-accent">{edge.type}</span>
+                    <span className="text-text-faint">--&gt;</span>
+                    <span className={edge.targetKind === doc.kind ? "font-semibold text-text" : "text-text-muted"}>
+                      {edge.targetKind}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+              <p className="mt-2 ui-micro leading-relaxed text-text-faint">
+                加粗端是本实体。方向注册表规定哪种 (源, 动词, 目标) 三元组合法;未注册的组合写不进台账。
+              </p>
+            </DetailSection>
+          )}
+
+          {doc.kind === "fact" && <FactTypeVocabulary stats={factStats} />}
+          {doc.kind === "fact" && <FactFacetLive stats={factStats} />}
+          {catalogRow !== null && catalogRow.origin === "vertical" && (
+            <DeclarationFacets declaration={catalogRow.declaration} />
+          )}
+          {catalogRow !== null && catalogRow.origin === "vertical" && (
+            <GovernedEntityPanel
+              repoId={repoId}
+              row={catalogRow}
+              rows={governedRows}
+              selectedRef={selectedRef}
+              onSelect={setSelectedRef}
+            />
+          )}
+        </aside>
+
+        <section
+          className="flex min-h-0 min-w-0 flex-1 flex-col"
+          data-testid="entity-doc-detail-right"
+          aria-label="实体正文"
+        >
+          <DetailRendererPane
+            repoId={repoId}
+            doc={doc}
+            catalogRow={catalogRow}
+            governedRowCount={governedRows.length}
+            selectedEntity={selectedEntity}
+          />
+        </section>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * 右栏:声明实体选中后按 locator 渲染正文;未选中呈真实空态。内核实体的正文不在
+ * 账本里,右栏保持空态并指向它的实况入口,不编造内容。
+ */
+function DetailRendererPane({
+  repoId,
+  doc,
+  catalogRow,
+  governedRowCount,
+  selectedEntity,
+}: {
+  readonly repoId: string;
+  readonly doc: EntityKindDoc;
+  readonly catalogRow: EntityKindRow | null;
+  readonly governedRowCount: number;
+  readonly selectedEntity: GovernedEntityRow | null;
+}) {
+  const declared = catalogRow !== null && catalogRow.origin === "vertical";
+  if (!declared)
+    return (
+      <RendererEmptyState
+        message={
+          doc.guiEntry
+            ? "这个 kind 的实况在专属页面;从右上「看实况」进入,说明看左列。"
+            : "这个 kind 没有仓内正文;这一页只做说明。"
+        }
+      />
+    );
+  if (selectedEntity === null)
+    return (
+      <RendererEmptyState
+        message={
+          governedRowCount === 0
+            ? "本仓还没有这个 kind 的实体;在左列新建后,正文在这里渲染。"
+            : "从左侧选择一个实体,正文在这里渲染。"
+        }
+      />
+    );
+  if (selectedEntity.locator === null)
+    return (
+      <div className="flex flex-1 items-center justify-center p-6" data-testid="entity-locator-none">
+        <p className="max-w-sm text-center ui-meta leading-relaxed text-text-faint">
+          {selectedEntity.title ?? selectedEntity.entityId} 没有 locator,没有可渲染的正文。
+        </p>
+      </div>
+    );
+  return (
+    <div className="flex min-h-0 min-w-0 flex-1 flex-col" data-testid="entity-doc-renderer">
+      <EntityLocatorPreview repoId={repoId} locator={selectedEntity.locator} />
+    </div>
+  );
+}
+
+function RendererEmptyState({ message }: { readonly message: string }) {
+  return (
+    <div
+      data-testid="entity-doc-renderer-empty"
+      className="flex min-h-0 flex-1 flex-col items-center justify-center p-6"
+    >
+      <p className="max-w-sm text-center ui-meta leading-relaxed text-text-faint">{message}</p>
     </div>
   );
 }
@@ -232,41 +344,35 @@ function DetailSection({
   readonly children: React.ReactNode;
 }) {
   return (
-    <section data-testid={testId} className="mt-6 max-w-3xl border-t border-border pt-4">
+    <section data-testid={testId} className="mt-6 border-t border-border pt-4">
       <h3 className="mb-2 ui-meta font-semibold uppercase tracking-wide text-text-muted">{title}</h3>
       {children}
     </section>
   );
 }
 
+/**
+ * 字段清单:左列只有 400px,四列表格会被挤成竖排文字墙。改为每字段一小块——
+ * 名字(可断行)+ 必填/可选 + 形状一行,人话含义换行跟在下面。
+ */
 function FieldTable({ fields }: { readonly fields: readonly EntityFieldDoc[] }) {
   return (
-    <table className="w-full border-collapse ui-meta">
-      <thead>
-        <tr className="border-b border-border text-left font-mono ui-micro uppercase tracking-wide text-text-faint">
-          <th className="py-1 pr-3 font-normal">字段</th>
-          <th className="py-1 pr-3 font-normal">必填</th>
-          <th className="py-1 pr-3 font-normal">形状</th>
-          <th className="py-1 font-normal">含义</th>
-        </tr>
-      </thead>
-      <tbody>
-        {fields.map((field) => (
-          <tr key={field.name} className="border-b border-border/60 align-top">
-            <td className="py-1.5 pr-3 font-mono ui-micro text-text">{field.name}</td>
-            <td className="py-1.5 pr-3 font-mono ui-micro">
-              {field.required ? (
-                <span className="text-accent">必填</span>
-              ) : (
-                <span className="text-text-faint">可选</span>
-              )}
-            </td>
-            <td className="py-1.5 pr-3 font-mono ui-micro text-text-faint">{field.shape}</td>
-            <td className="py-1.5 leading-relaxed text-text-muted">{field.meaning}</td>
-          </tr>
-        ))}
-      </tbody>
-    </table>
+    <ul className="border-t border-border/60">
+      {fields.map((field) => (
+        <li key={field.name} className="flex flex-col gap-0.5 border-b border-border/60 py-1.5">
+          <div className="flex min-w-0 flex-wrap items-baseline gap-x-2 gap-y-0.5">
+            <code className="break-all font-mono ui-micro text-text">{field.name}</code>
+            {field.required ? (
+              <span className="font-mono ui-micro text-accent">必填</span>
+            ) : (
+              <span className="font-mono ui-micro text-text-faint">可选</span>
+            )}
+            <span className="font-mono ui-micro text-text-faint">{field.shape}</span>
+          </div>
+          <p className="leading-relaxed text-text-muted ui-meta">{field.meaning}</p>
+        </li>
+      ))}
+    </ul>
   );
 }
 
@@ -290,87 +396,11 @@ function LiveCountBadge({ doc, liveCounts }: { readonly doc: EntityKindDoc; read
 }
 
 /**
- * Fact Type 受控词表配置区(本面第一个可配置项)。裁决 dec_2935057783CD5D56E9F287AE4D:
- * Type 必须显式登记后可用(CH1,不允许自由文本)、一条 fact 可属多个 Type(CH2)、
- * 已记录的 fact 可重新归类且保留审计轨迹(CH3)。登记面后端未合入,这里呈真实空态。
- */
-function FactTypeVocabulary({ stats }: { readonly stats: ReturnType<typeof useFactFacetStats> }) {
-  return (
-    <section
-      data-testid="fact-type-vocabulary"
-      className="mt-6 max-w-3xl rounded-lg border border-border bg-surface p-4"
-    >
-      <div className="flex flex-wrap items-center gap-2">
-        <h3 className="ui-meta font-semibold uppercase tracking-wide text-text-muted">Fact Type 受控词表</h3>
-        <span className="rounded border border-accent/60 px-1.5 py-0.5 font-mono ui-micro text-accent">配置区</span>
-        <span className="rounded border border-border px-1.5 py-0.5 font-mono ui-micro text-text-faint">投影实况</span>
-      </div>
-      <p className="mt-2 ui-meta leading-relaxed text-text-muted">
-        裁决 {FACT_TYPE_VOCABULARY.decisionId}:Type 不允许自由文本——随手写会把「分面检索」退化成它要解决的 混乱。一个
-        Type 值必须经一次显式登记才可使用;一条 fact 可同时归属多个 Type;已记录的 fact
-        允许重新归类,以新事件表达并保留审计轨迹。
-      </p>
-      <div
-        className="mt-3 rounded-md border border-dashed border-border px-3 py-3"
-        data-testid="fact-type-registered-list"
-      >
-        <div className="font-mono ui-micro uppercase tracking-wide text-text-faint">已登记 Type</div>
-        {stats.state === "pending" ? <p className="mt-1 ui-meta text-text-faint">正在读取已登记 Type…</p> : null}
-        {stats.state === "error" ? <p className="mt-1 ui-meta text-status-blocked">Type 词表读取失败。</p> : null}
-        {stats.state === "ready" && stats.domainTypes.length === 0 ? (
-          <p className="mt-1 ui-meta leading-relaxed text-text-faint">
-            空——本仓尚未登记 Fact Type。这里展示真实投影结果,不用示例词冒充词表。
-          </p>
-        ) : null}
-        {stats.state === "ready" && stats.domainTypes.length > 0 ? (
-          <ul className="mt-2 space-y-1">
-            {stats.domainTypes.map((entry) => (
-              <li key={entry.domainType} className="flex items-center gap-2 ui-meta">
-                <code className="font-mono text-text">{entry.domainType}</code>
-                <span className="text-text-faint">由 fact/{entry.registeredByFactId} 登记</span>
-              </li>
-            ))}
-          </ul>
-        ) : null}
-      </div>
-    </section>
-  );
-}
-
-function FactFacetLive({ stats }: { readonly stats: ReturnType<typeof useFactFacetStats> }) {
-  return (
-    <section data-testid="fact-facet-live" className="mt-4 max-w-3xl border-t border-border pt-4">
-      <h3 className="mb-2 ui-meta font-semibold uppercase tracking-wide text-text-muted">本仓实况</h3>
-      {stats.state === "pending" && <p className="ui-meta text-text-faint">正在读取事实切面…</p>}
-      {stats.state === "error" && <p className="ui-meta text-status-blocked">事实切面读取失败。</p>}
-      {stats.state === "ready" && (
-        <div className="flex flex-wrap items-center gap-2 ui-meta">
-          <span className="font-mono text-text">{stats.total} 条 fact</span>
-          {stats.byCategory.map((entry) => (
-            <span
-              key={entry.category}
-              className="rounded border border-border px-1.5 py-0.5 font-mono ui-micro text-text-muted"
-            >
-              {entry.category} · {entry.count}
-            </span>
-          ))}
-        </div>
-      )}
-      {stats.state === "ready" && (
-        <p className="mt-2 ui-micro leading-relaxed text-text-faint">
-          来自既有 facts 切面读(与 ⌘K 面板同一条,共享缓存)。category 是 memoryClass 在读面上的折叠:
-          semantic→lesson、procedural→progress、episodic→finding。Type 轴的分布等登记面合入后在此并列。
-        </p>
-      )}
-    </section>
-  );
-}
-
-/**
  * 声明的可配置项(governed-entity-design §2 的九项,不多不少)。本波次是**只读呈现**:
  * 写路在 vertical 声明文件上,GUI 不做第二条编辑入口。
  */
-function DeclarationFacets({ declaration }: { readonly declaration: EntityKindDeclaration }) {
+function DeclarationFacets({ declaration }: { readonly declaration: EntityKindDeclaration | null }) {
+  if (declaration === null) return null;
   const rows: readonly (readonly [string, string])[] = [
     ["id", declaration.id],
     ["version", String(declaration.version)],
@@ -383,13 +413,13 @@ function DeclarationFacets({ declaration }: { readonly declaration: EntityKindDe
     ["maturityVocabulary", declaration.maturityVocabulary.join(", ") || "(未声明)"],
   ];
   return (
-    <section data-testid="entity-declaration-facets" className="mt-6 max-w-3xl border-t border-border pt-4">
+    <section data-testid="entity-declaration-facets" className="mt-6 border-t border-border pt-4">
       <h2 className="ui-body font-semibold">声明的可配置项</h2>
       <p className="mt-1 ui-micro leading-relaxed text-text-faint">
         这些值来自本仓 vertical 声明。id / version 一起构成身份——改它们是换一个类型,不是改一个字段; display
         只影响呈现。此面只读,改声明请改 vertical 定义文件。
       </p>
-      <dl className="mt-2 grid grid-cols-[minmax(140px,auto)_1fr] gap-x-3 gap-y-1">
+      <dl className="mt-2 grid grid-cols-[minmax(110px,auto)_1fr] gap-x-3 gap-y-1">
         {rows.map(([label, value]) => (
           <div key={label} className="contents">
             <dt className="font-mono ui-micro text-text-faint">{label}</dt>

--- a/packages/gui/test/entities-view.vitest.ts
+++ b/packages/gui/test/entities-view.vitest.ts
@@ -20,6 +20,65 @@ const REPO_ID = "repo-entities";
 const noop = () => undefined;
 const mounted: { root: Root; container: HTMLElement }[] = [];
 
+/** 与 e2e declared-entity-kinds 场景同一个声明 kind:名字里带斜杠,是排版压力最大的样本。 */
+const ADR_KIND = "software/coding/architecture-decision-record@1";
+
+function declaredAdrKindRow() {
+  return {
+    kind: ADR_KIND,
+    origin: "vertical",
+    verticalId: "software/coding",
+    refTemplate: `${ADR_KIND}/{id}`,
+    relationEndpoint: true,
+    importable: true,
+    declaration: {
+      id: "architecture-decision-record",
+      version: 1,
+      idPrefix: "ADR",
+      display: { singular: "Architecture Decision Record", plural: "Architecture Decision Records" },
+      descriptorSchemaRef: "descriptor/v1",
+      pathTemplate: "entities/adrs/{id}.json",
+      locatorKinds: ["repository-path"],
+      maturityVocabulary: [],
+    },
+    explanation: {
+      kind: ADR_KIND,
+      documentSchema: {
+        id: "adr-descriptor/v1",
+        fields: [{ name: "locator", type: "string", required: true, description: "正文指针。" }],
+      },
+      relations: { edges: [] },
+      statusVocabulary: [],
+      transitions: {
+        available: ["import"],
+        actions: [
+          {
+            id: "import",
+            input: {
+              schema: "import/v1",
+              fields: [
+                { field: "locator", type: "string", required: true },
+                { field: "title", type: "string", required: false },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  };
+}
+
+function governedRow(entityId: string, title: string | null = null) {
+  return {
+    kind: ADR_KIND,
+    entityId,
+    ref: `${ADR_KIND}/${entityId}`,
+    title,
+    locator: { kind: "repository-path", value: `docs/adr/${entityId}.md` },
+    revision: 0,
+  };
+}
+
 beforeAll(() => {
   setActiveLocale("zh-CN");
   globalThis.IS_REACT_ACT_ENVIRONMENT = true;
@@ -34,6 +93,12 @@ afterEach(async () => {
 
 function stubBridge(
   domainTypes: ReadonlyArray<{ readonly domainType: string; readonly registeredByFactId: string }> = [],
+  extras: {
+    /** 已注册 kind 读面回包里的 kinds(声明实体详情布局用)。 */
+    readonly kinds?: readonly unknown[];
+    /** 声明实体行读面回包里的 rows。 */
+    readonly rows?: readonly unknown[];
+  } = {},
 ) {
   const calls = { relationGraph: 0 };
   vi.stubGlobal("window", {
@@ -112,8 +177,17 @@ function stubBridge(
         sourceRevision: 3,
       })),
       // 已注册 kind 读面:目录分组与详情落点都从这里派生。
-      readEntityKinds: vi.fn(async () => ({ schema: "entity-kind-catalog/v1", kinds: [] })),
-      readEntityRows: vi.fn(async () => ({ schema: "entity-row-list/v1", ok: true, rows: [] })),
+      readEntityKinds: vi.fn(async () => ({ schema: "entity-kind-catalog/v1", kinds: extras.kinds ?? [] })),
+      readEntityRows: vi.fn(async () => ({ schema: "entity-row-list/v1", ok: true, rows: extras.rows ?? [] })),
+      readEntityLocator: vi.fn(async ({ locatorValue }: { readonly locatorValue: string }) => ({
+        schema: "entity-locator-read/v1",
+        outcome: "file",
+        path: locatorValue,
+        content: `# ${locatorValue}\n\n这条正文来自 locator 读面。`,
+        sizeBytes: 48,
+        entries: [],
+        truncated: false,
+      })),
       getRelationGraph: vi.fn(async () => {
         calls.relationGraph += 1;
         return {
@@ -265,5 +339,118 @@ describe("fact type vocabulary area (negative control)", () => {
     await renderSurface(view("entitydoc/task"));
     await settle();
     expect(calls.relationGraph).toBe(0);
+  });
+});
+
+describe("declared entity card overflow", () => {
+  it("keeps the kind name and ref template on separate lines with full names in title attributes", async () => {
+    stubBridge([], { kinds: [declaredAdrKindRow()] });
+    const container = await renderSurface(view(null));
+    // 已注册 kind 读面是异步的:声明实体那一组要等 query 回来才长出来。
+    await settle();
+    const card = container.querySelector<HTMLElement>(`[data-testid="entity-doc-card-${ADR_KIND}"]`);
+    expect(card).not.toBeNull();
+    // 长机器名不再被路径模板顶出去:标题独占一行(b),模板独占一行(code),全名进 title。
+    const kindTitle = card!.querySelector("b");
+    expect(kindTitle?.getAttribute("title")).toBe(ADR_KIND);
+    expect(kindTitle?.textContent).toBe(ADR_KIND);
+    const template = card!.querySelector("code");
+    expect(template?.getAttribute("title")).toBe(`${ADR_KIND}/{id}`);
+    expect(template?.textContent).toBe(`${ADR_KIND}/{id}`);
+  });
+});
+
+describe("declared entity detail two-column layout", () => {
+  it("renders an honest right-pane empty state before an entity is selected", async () => {
+    stubBridge([], { kinds: [declaredAdrKindRow()], rows: [] });
+    const container = await renderSurface(view(`entitydoc/${ADR_KIND}`));
+    await settle();
+    // 同一骨架:左列(说明 + 本仓实体清单)与右栏(渲染器)并存。
+    expect(container.querySelector('[data-testid="entity-doc-detail-left"]')).not.toBeNull();
+    const right = container.querySelector('[data-testid="entity-doc-detail-right"]');
+    expect(right).not.toBeNull();
+    // 空清单是真实空态:左列如实说明没有实体,右栏空态不冒充内容。
+    expect(container.querySelector('[data-testid="governed-entity-empty"]')).not.toBeNull();
+    const empty = right!.querySelector('[data-testid="entity-doc-renderer-empty"]');
+    expect(empty?.textContent).toContain("本仓还没有这个 kind 的实体");
+    expect(container.querySelector('[data-testid="entity-doc-renderer"]')).toBeNull();
+  });
+
+  it("renders the selected entity's document in the right pane via its locator", async () => {
+    stubBridge([], {
+      kinds: [declaredAdrKindRow()],
+      rows: [governedRow("ADR-0001", "ADR-0001 · 探针"), governedRow("ADR-0002", "ADR-0002 · 复核")],
+    });
+    const container = await renderSurface(view(`entitydoc/${ADR_KIND}`));
+    await settle();
+    // 未选中时右栏是选择空态,不是第一条的预览。
+    expect(container.querySelector('[data-testid="entity-doc-renderer-empty"]')?.textContent).toContain(
+      "从左侧选择一个实体",
+    );
+    const row = container.querySelector<HTMLButtonElement>('[data-testid="governed-entity-row-ADR-0001"]');
+    expect(row).not.toBeNull();
+    await act(async () => {
+      row!.click();
+    });
+    await settle();
+    // 右栏按 locator 类型选渲染器:repository-path 的 Markdown 走既有 Markdown 渲染器。
+    const renderer = container.querySelector('[data-testid="entity-doc-renderer"]');
+    expect(renderer).not.toBeNull();
+    const markdown = renderer!.querySelector('[data-testid="entity-locator-markdown"]');
+    expect(markdown?.textContent).toContain("docs/adr/ADR-0001.md");
+    expect(markdown?.textContent).toContain("这条正文来自 locator 读面");
+    // 左列清单还在:选择不清空目录。
+    expect(container.querySelector('[data-testid="governed-entity-list"]')).not.toBeNull();
+  });
+
+  it("preselects the deep-linked entity and renders its content", async () => {
+    stubBridge([], {
+      kinds: [declaredAdrKindRow()],
+      rows: [governedRow("ADR-0001", "ADR-0001 · 探针"), governedRow("ADR-0002", "ADR-0002 · 复核")],
+    });
+    const container = await renderSurface(view(`${ADR_KIND}/ADR-0002`));
+    await settle();
+    const markdown = container.querySelector('[data-testid="entity-locator-markdown"]');
+    expect(markdown?.textContent).toContain("docs/adr/ADR-0002.md");
+  });
+
+  it("narrows the entity list by search with an honest no-match state", async () => {
+    stubBridge([], {
+      kinds: [declaredAdrKindRow()],
+      rows: [governedRow("ADR-0001", "ADR-0001 · 探针"), governedRow("ADR-0002", "ADR-0002 · 复核")],
+    });
+    const container = await renderSurface(view(`entitydoc/${ADR_KIND}`));
+    await settle();
+    const search = container.querySelector<HTMLInputElement>('[data-testid="governed-entity-search"]');
+    expect(search).not.toBeNull();
+    const type = async (text: string) => {
+      await act(async () => {
+        const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")?.set;
+        setter?.call(search!, text);
+        search!.dispatchEvent(new Event("input", { bubbles: true }));
+      });
+    };
+    await type("0002");
+    const rows = container.querySelectorAll('[data-testid^="governed-entity-row-"]');
+    expect(rows.length).toBe(1);
+    expect(rows[0]?.getAttribute("data-testid")).toBe("governed-entity-row-ADR-0002");
+    await type("不存在的词");
+    expect(container.querySelector('[data-testid="governed-entity-search-empty"]')).not.toBeNull();
+    expect(container.querySelectorAll('[data-testid^="governed-entity-row-"]').length).toBe(0);
+  });
+});
+
+describe("kernel entity detail keeps the same skeleton", () => {
+  it("shows the doc columns on the left and an honest empty right pane", async () => {
+    stubBridge();
+    const container = await renderSurface(view("entitydoc/task"));
+    await settle();
+    expect(container.querySelector('[data-testid="entity-doc-detail-left"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="entity-doc-fields"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="entity-doc-actions"]')).not.toBeNull();
+    // 内核实体没有仓内 locator:右栏保持空态并指向实况入口,不做第二套布局。
+    const empty = container.querySelector('[data-testid="entity-doc-renderer-empty"]');
+    expect(empty?.textContent).toContain("看实况");
+    expect(container.querySelector('[data-testid="governed-entity-panel"]')).toBeNull();
   });
 });

--- a/packages/gui/test/entities-view.vitest.ts
+++ b/packages/gui/test/entities-view.vitest.ts
@@ -222,9 +222,14 @@ async function renderSurface(element: ReturnType<typeof createElement>): Promise
   return container;
 }
 
+/**
+ * 一拍宏任务 = react-query 通知订阅者的一轮。判据是「一轮通知内内容就位」,不是
+ * 「若干毫秒内碰运气」:读链每多一段渲染门控的串行读,就要多一拍,这里必然红。
+ * 原来的 20ms 预算在快机器上能盖住多余的轮次,只在 CI 上间歇性地暴露出来。
+ */
 async function settle(): Promise<void> {
   await act(async () => {
-    await new Promise((resolve) => setTimeout(resolve, 20));
+    await new Promise((resolve) => setTimeout(resolve, 0));
   });
 }
 


### PR DESCRIPTION
# English

## Summary

On the entity explanation page long declared kind names such as `software/coding/architecture-decision-record@1` overflowed their cards and collided with the path template, and the declared-entity detail page crammed fields, write actions, the repository entity list and the document renderer into the left half of the window. This change breaks long kind names, moves the path template to its own line, and rebuilds the detail page as two columns: a fixed left column (description, storage, GUI entry, fields, legal write actions, vocabulary, relations, repository entities with search and create) and a full-height right column that hosts the locator-driven adaptive renderer for the selected entity, with a real empty state when nothing is selected.

## Architectural Justification

Layout only, per the CEO's direction after Electron review: the kind catalogue still comes from the daemon registry and the renderer is still chosen by locator type; no data path changes. Existing `data-testid` hooks are kept and only added to, so the `declared-entity-kinds` e2e scenario stays green.

## What Changed

- `packages/gui/src/renderer/views/EntitiesView.tsx`: card title wrapping and separate template line.
- `packages/gui/src/renderer/views/EntityDocDetailView.tsx`: two-column skeleton; right column is the renderer.
- `components/entityDoc/GovernedEntityPanel.tsx`, new `FactVocabularySections.tsx`: left-column extraction.
- `packages/gui/test/entities-view.vitest.ts`: five new cases.

## Gate Harvest / 门收割

No gate change.

## Machine-Readable Declarations

Production-Delta: +464/-273
Dependency-Change: none

### Optional Evidence Claims

none

## Task And Scope

task_e005fc1c74f25fb22a858765b4. Branch `codex/entity-doc-layout`. Behaviour note: the right column no longer auto-selects the first entity; only a deep link or a click selects, matching the "real empty state" ruling. Same-mechanism overflow remains in GraphDrawer edge refs, RelationRow peer and SessionsPanel taskId, outside this task's surface.

## Version Impact

No version change; publish impact none.

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none
- Authority: task_e005fc1c74f25fb22a858765b4
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Follow-up governance task: not applicable

## Verification

- Base merge-base ecfd386bd477633b3814b59b4a1a30473b7f0bdd.
- Worker (GLM): `entities-view.vitest.ts` 14/14; `declared-entity-kinds` isolated e2e healthy; file-complexity, prettier, eslint pass; geometry probe shows the ADR card overflowed 199 to 221 px before and 0 violations after at 1440x920 and 1760x1400; before/after screenshots on the task (fact F-567B9D4D).
- CEO viewed the after screenshot of the detail page. CI is the complete authority.

## Review Evidence

CEO semantic review against the ruling: left column with fields above and repository entities below, right column full-height renderer; no second layout for kernel entities.

## Residual Risk

The 400 px left column is fixed; very long field names wrap inside it.

# 中文

## 概要

实体说明页长 kind 名溢出卡片并与路径模板重叠;声明实体详情页把字段、写入动作、本仓实体列表与渲染器全塞在左半边。本改动让长名断行、模板独立一行,详情页改为两栏:左列固定(描述/存放/GUI 入口/字段/合法写入动作/词表/关系/本仓实体含搜索与新建),右栏全高承载按 locator 选择的自适应渲染器,未选中时真实空态。

## 架构辩护

只改布局:kind 目录仍来自 daemon 注册表,渲染器仍按 locator 类型选择,数据路径零改动;既有 data-testid 只增不删,declared-entity-kinds e2e 场景继续绿。

## 机读声明

生产行数增减(与上文机读声明一致):+464/-273

## 治理声明

- 触碰受保护面:否
- 授权:task_e005fc1c74f25fb22a858765b4
- Break-glass:否

## 验证

GLM:vitest 14/14、declared-entity-kinds e2e 绿、几何探针改后 0 溢出、改前/改后截图两种窗口;CEO 看过改后截图。CI 为完整权威。

## 评审证据

与裁定一致:左列字段在上实体在下,右栏整栏渲染器;内核实体不做第二套布局。

## 残余风险

左列 400px 固定宽,超长字段名在列内换行。
