### PR TITLE
test(gui-e2e): cover the system log panel, session grouping and the external-issue kind

### DIFF
--- a/packages/gui/src/renderer/components/GraphFilterPanel.tsx
+++ b/packages/gui/src/renderer/components/GraphFilterPanel.tsx
@@ -431,6 +431,7 @@ export function GraphFilterPanel({
                 return (
                   <button
                     key={mode}
+                    data-testid={`graph-density-${mode}`}
                     onClick={() => setDensity(mode)}
                     title={t("components.graphFilterPanel.densityHint")}
                     className={`flex-1 rounded-md px-2 py-1 ui-micro font-medium transition-colors ${

--- a/packages/gui/src/renderer/views/SessionsView.tsx
+++ b/packages/gui/src/renderer/views/SessionsView.tsx
@@ -387,7 +387,7 @@ export function SessionsView({
             "outline-none focus-visible:border-accent"
           }
         />
-        <span className="ml-auto truncate font-mono ui-micro text-text-faint">
+        <span data-testid="sessions-counts" className="ml-auto truncate font-mono ui-micro text-text-faint">
           {segment === "sessions"
             ? t("agentRuntime.sessionsCounts", {
                 range: rangeLabel[range],

--- a/tools/gui-e2e/catalog.mjs
+++ b/tools/gui-e2e/catalog.mjs
@@ -11,6 +11,8 @@ import sessionsArtifacts from "./scenarios/sessions-artifacts.mjs";
 import artifactsHtmlPreview from "./scenarios/artifacts-html-preview.mjs";
 import settings from "./scenarios/settings-appearance.mjs";
 import declaredEntityKinds from "./scenarios/declared-entity-kinds.mjs";
+import systemDaemonLogs from "./scenarios/system-daemon-logs.mjs";
+import sessionsGrouping from "./scenarios/sessions-grouping.mjs";
 
 export const catalog = [
   shellNavigation,
@@ -26,6 +28,8 @@ export const catalog = [
   artifactsHtmlPreview,
   settings,
   declaredEntityKinds,
+  systemDaemonLogs,
+  sessionsGrouping,
 ];
 
 export function selectScenarios({ lane, ids }) {

--- a/tools/gui-e2e/lanes.mjs
+++ b/tools/gui-e2e/lanes.mjs
@@ -13,6 +13,7 @@ import {
 } from "../../packages/daemon/src/protocol/daemon-protocol.contract.ts";
 import { startGuiResidentDaemonFixture } from "../../packages/gui/test-support/resident-daemon.mjs";
 import { seedTriadicEvents, writeTriadicLedger } from "../../packages/gui/test-support/triadic-ledger.mjs";
+import { seedGuiE2eRuntimeSessions } from "./scenarios/sessions-grouping.mjs";
 import { warmDaemonProjection } from "../e2e-probe.mjs";
 
 // Long script-free HTML report: tall enough that a 150px-default webview clips after
@@ -82,7 +83,10 @@ export async function openLane({ lane, workspaceRoot, env, runRoot, startDriver 
       daemonId: "g",
       repoId: "gui-e2e-catalog",
       task: { taskId: "task-gui-smoke", title: "Render the real triadic projection" },
-      beforeRestart: seedTriadicEvents,
+      beforeRestart: async (rootDir, repoId) => {
+        await seedTriadicEvents(rootDir, repoId);
+        await seedGuiE2eRuntimeSessions(rootDir, repoId);
+      },
     });
   } finally {
     if (originalTmpdir === undefined) delete process.env.TMPDIR;

--- a/tools/gui-e2e/scenarios/declared-entity-kinds.mjs
+++ b/tools/gui-e2e/scenarios/declared-entity-kinds.mjs
@@ -1,65 +1,133 @@
 import assert from "node:assert/strict";
+import { createServer } from "node:http";
 
 const ADR_KIND = "software/coding/architecture-decision-record@1";
 const LOCATOR = "docs/adr/ADR-0001-declared-entity-probe.md";
+/** W2-C(#2217)声明的第二种 kind:locatorKinds 是 url/external-key,正文不在仓里。 */
+const ISSUE_KIND = "software/coding/external-issue@1";
 
 /**
  * 声明出来的实体种类在 GUI 上可见、可建、可打开、可筛选——而且**不靠 GUI 里的任何清单**。
  *
- * 本仓 vertical 声明了 architecture-decision-record。这条用例走完整一圈:说明面自己长出
- * 「声明实体」一组 → 在 GUI 上按 import 动作合同派生的表单新建一个(与 CLI 同一条写路)
- * → 新实体出现在列表 → 点开落到既有 Markdown 渲染器 → 领地筛选面板出现同一个 kind 的
- * 类型 chip,标签是声明里的显示名。
+ * 本仓 vertical 声明了 architecture-decision-record 与 external-issue 两种。这条用例对
+ * 两种各走完整一圈:说明面自己长出「声明实体」一组 → 在 GUI 上按 import 动作合同派生的
+ * 表单新建一个(与 CLI 同一条写路)→ 新实体出现在列表 → 点开落到既有渲染器 → 领地
+ * 筛选面板出现同一个 kind 的类型 chip,标签是声明里的显示名。
+ *
+ * 两种 locator 形状都覆盖:ADR 走 repository-path(仓内 Markdown,既有断言);external-issue
+ * 的 locator 是 url——daemon 的 url 解析器会真的 HTTP GET,所以场景在本机起一个一次性
+ * HTTP 服务来当「外部系统」,拿到的是真实响应正文,不是 mock 页面。全程不改 GUI 源码
+ * (W2-0 #2215 的自适应能力);若哪个面必须改代码才出现,那是 W2-0 的缺口,不是本场景的事。
  */
 export default {
   id: "declared-entity-kinds",
   feature: "entities",
   lane: "isolated",
-  description: "A vertical-declared kind reaches the docs page, is creatable via entity import, renders, and filters.",
+  description:
+    "Vertical-declared kinds (repository-path ADR and url external-issue) reach the docs page, are creatable via entity import, render, and reach the graph filter and territory nodes.",
   async run({ page }) {
-    await page.getByRole("button", { name: /实体说明|Entities/u }).click();
-    await page.getByTestId("entities-content").waitFor();
+    // 外部系统替身:external-issue 的 url locator 由 daemon 真实 GET。
+    const served = await new Promise((resolve) => {
+      const server = createServer((request, response) => {
+        response.writeHead(200, { "content-type": "application/json" });
+        response.end(
+          `${JSON.stringify(
+            {
+              schema: "external-issue-probe/v1",
+              number: 2224,
+              title: "Resident daemon log panel on the System tab",
+              state: "closed",
+            },
+            null,
+            2,
+          )}\n`,
+        );
+      });
+      server.listen(0, "127.0.0.1", () => resolve(server));
+    });
+    try {
+      const issueUrl = `http://127.0.0.1:${served.address().port}/issues/2224`;
 
-    // 1. 说明面按声明长出「声明实体」一组——GUI 没有这份清单,它来自读面。
-    await page.getByTestId("entity-doc-group-declared").waitFor();
-    const adrCard = page.getByTestId(`entity-doc-card-${ADR_KIND}`);
-    await adrCard.waitFor();
-    await adrCard.click();
+      await page.getByRole("button", { name: /实体说明|Entities/u }).click();
+      await page.getByTestId("entities-content").waitFor();
 
-    // 2. 声明的可配置项只读呈现;实体列表初始是真实空态,不预填示例。
-    await page.getByTestId("entity-declaration-facets").waitFor();
-    await page.getByTestId("governed-entity-empty").waitFor();
+      // 1. 说明面按声明长出「声明实体」一组——GUI 没有这份清单,它来自读面。
+      await page.getByTestId("entity-doc-group-declared").waitFor();
+      const adrCard = page.getByTestId(`entity-doc-card-${ADR_KIND}`);
+      await adrCard.waitFor();
+      await adrCard.click();
 
-    // 3. 新建走 entity import:表单字段由 import 动作合同派生,只有 locator 与 title。
-    await page.getByTestId("governed-entity-new").click();
-    await page.getByTestId("new-governed-entity-form").waitFor();
-    await page.getByTestId("new-governed-entity-locator").fill(LOCATOR);
-    await page.getByTestId("new-governed-entity-title").fill("ADR-0001 · 声明实体探针");
-    await page.getByTestId("new-governed-entity-submit").click();
+      // 2. 声明的可配置项只读呈现;实体列表初始是真实空态,不预填示例。
+      await page.getByTestId("entity-declaration-facets").waitFor();
+      await page.getByTestId("governed-entity-empty").waitFor();
 
-    // 4. 建立之后可见:实体行来自账本投影,不是表单的本地回声。
-    const list = page.getByTestId("governed-entity-list");
-    await list.waitFor();
-    const rows = list.getByRole("button");
-    assert.ok((await rows.count()) > 0, "the imported entity must appear in the ledger-backed list");
+      // 3. 新建走 entity import:表单字段由 import 动作合同派生,只有 locator 与 title。
+      await page.getByTestId("governed-entity-new").click();
+      await page.getByTestId("new-governed-entity-form").waitFor();
+      await page.getByTestId("new-governed-entity-locator").fill(LOCATOR);
+      await page.getByTestId("new-governed-entity-title").fill("ADR-0001 · 声明实体探针");
+      await page.getByTestId("new-governed-entity-submit").click();
 
-    // 5. 点击即渲染:locator 指向 Markdown → 既有 Markdown 渲染器。
-    await rows.first().click();
-    const markdown = page.getByTestId("entity-locator-markdown");
-    await markdown.waitFor();
-    assert.match(await markdown.innerText(), /声明实体探针/u);
+      // 4. 建立之后可见:实体行来自账本投影,不是表单的本地回声。
+      const list = page.getByTestId("governed-entity-list");
+      await list.waitFor();
+      const rows = list.getByRole("button");
+      assert.ok((await rows.count()) > 0, "the imported entity must appear in the ledger-backed list");
 
-    // 6. 领地筛选按 kind 生效:类型 chip 由读面派生,标签取声明里的显示名。
-    await page
-      .getByRole("button", { name: /关系图|Relation Graph/u })
-      .first()
-      .click();
-    await page
-      .getByRole("button", { name: /筛选|Filters/u })
-      .first()
-      .click();
-    const typeChip = page.getByTestId(`graph-filter-entity-type-${ADR_KIND}`);
-    await typeChip.waitFor();
-    assert.equal(await typeChip.innerText(), "Architecture Decision Record");
+      // 5. 点击即渲染:locator 指向 Markdown → 既有 Markdown 渲染器。
+      await rows.first().click();
+      const markdown = page.getByTestId("entity-locator-markdown");
+      await markdown.waitFor();
+      assert.match(await markdown.innerText(), /声明实体探针/u);
+
+      // 6. 第二种声明 kind:external-issue(url locator)不改 GUI 就出现在同一目录里。
+      await page
+        .getByRole("button", { name: /返回上一级|Back to previous/u })
+        .first()
+        .click();
+      await page.getByTestId("entities-content").waitFor();
+      const issueCard = page.getByTestId(`entity-doc-card-${ISSUE_KIND}`);
+      await issueCard.waitFor();
+      await issueCard.click();
+      await page.getByTestId(`entity-doc-detail-${ISSUE_KIND}`).waitFor();
+      await page.getByTestId("entity-declaration-facets").waitFor();
+      await page.getByTestId("governed-entity-empty").waitFor();
+
+      // 7. url locator 的新建:表单出现 locator 类型选择(声明给了 url/external-key),
+      //    locator 字符串按 http(s) 前缀推断为 url kind,daemon 真实 GET 一次性 HTTP 服务。
+      await page.getByTestId("governed-entity-new").click();
+      await page.getByTestId("new-governed-entity-form").waitFor();
+      await page.getByTestId("new-governed-entity-locator-kind").waitFor();
+      await page.getByTestId("new-governed-entity-locator").fill(issueUrl);
+      await page.getByTestId("new-governed-entity-title").fill("Issue 2224 · external probe");
+      await page.getByTestId("new-governed-entity-submit").click();
+      const issueRows = list.getByRole("button");
+      await issueRows.first().waitFor();
+      const issueRowText = await issueRows.first().innerText();
+      assert.match(issueRowText, /issues\/2224/u, "the external-issue row must show its url locator");
+
+      // 8. 领地筛选按 kind 生效:两个声明 kind 的类型 chip 都由读面派生,标签取声明显示名;
+      //    图节点层:每种声明 kind 一块领地,chip 的 navRef 是 <kind>/<entityId>。
+      await page
+        .getByRole("button", { name: /关系图|Relation Graph/u })
+        .first()
+        .click();
+      await page
+        .getByRole("button", { name: /筛选|Filters/u })
+        .first()
+        .click();
+      const adrChip = page.getByTestId(`graph-filter-entity-type-${ADR_KIND}`);
+      await adrChip.waitFor();
+      assert.equal(await adrChip.innerText(), "Architecture Decision Record");
+      const issueChip = page.getByTestId(`graph-filter-entity-type-${ISSUE_KIND}`);
+      await issueChip.waitFor();
+      assert.equal(await issueChip.innerText(), "External Issue");
+      // 重点模式(默认)会把焦点邻域外的 chip 折进「重点外 N 项」;切「全部」后领地才平铺。
+      await page.getByTestId("graph-density-all").click();
+      const issueNode = page.locator(`[data-testid="territory-chip"][data-nav-ref^="${ISSUE_KIND}/"]`);
+      await issueNode.waitFor();
+    } finally {
+      await new Promise((resolve) => served.close(resolve));
+    }
   },
 };

--- a/tools/gui-e2e/scenarios/sessions-grouping.mjs
+++ b/tools/gui-e2e/scenarios/sessions-grouping.mjs
@@ -1,0 +1,249 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { canonicalEventWritePlan, makeTaskEventStore, makeTaskProjection } from "../../../packages/kernel/src/index.ts";
+import { requestDaemonJsonRpcAt } from "../../../packages/daemon/src/client/local-json-rpc-client.ts";
+import { nav } from "./helpers.mjs";
+
+/**
+ * #2225 会话页:状态筛选 + 按缺失原因命名的 unattributed 三桶。
+ *
+ * 种法(resident-daemon 的 beforeRestart 钩子,与 triadic-ledger 同一条夹具路):
+ * 直接向 canonical 事件流 append 真实的 agent-runtime 事件——GUI 随后读到的是
+ * daemon 从这些事件投影出来的会话,不是页面 mock。三个会话覆盖三种成因:
+ *
+ *   runtime_e2e_notask   有 dispatch_requested 记录(无 stream header,taskId 回落
+ *                        "unattributed")、无 task 绑定、退出+失败 → `unattributed:no-task`
+ *                        (dispatch 存在但没名字叫谁,桶按缺失的东西命名,dec_054C39DA…)。
+ *   runtime_e2e_free     只有 started(live)→ `unattributed:no-dispatch`,状态 running。
+ *   runtime_e2e_bound    task_bound 到夹具任务 + 退出 + 成功 → task 组,状态 succeeded。
+ *
+ * 派工行(readSessionGroupDispatches)要求 dispatchId 形如 dispatch_[a-f0-9]{24},
+ * 否则读面抛「dispatch id is invalid」——id 全部用合法形状。
+ * outcome 事件带 result claim + 内容 blob:SessionsPanel 的精确读会取 result 文本,
+ * 缺 blob 会让那条读红。
+ */
+const identity = (key) => createHash("sha256").update(`gui-e2e-catalog\0${key}`).digest("hex"),
+  // 派工行读面要求 dispatch_[a-f0-9]{24};会话 id 用 runtime_ + 24 hex,与 runtimeIngress 同一形状。
+  SESSION_NOTASK = `runtime_${identity("no-task").slice(24, 48)}`,
+  SESSION_FREE = `runtime_${identity("free").slice(24, 48)}`,
+  SESSION_BOUND = `runtime_${identity("bound").slice(24, 48)}`,
+  DISPATCH_NOTASK = `dispatch_${identity("no-task").slice(0, 24)}`,
+  FIXTURE_TASK = "task-gui-smoke",
+  REPO = "gui-e2e-catalog";
+
+const definitionSnapshot = (instanceId, installationId) => ({
+  schema: "agent-definition-snapshot/v1",
+  configVersion: 1,
+  instanceId,
+  installationId,
+  kindId: "codex",
+  providerId: "openai",
+  model: "gpt-e2e",
+  reasoningEffort: null,
+  baseUrl: null,
+  authMode: "subscription",
+});
+
+/** 夹具种子:在 daemon 停机窗口里追加 agent-runtime 事件(lanes.mjs 的 beforeRestart 调用)。 */
+export async function seedGuiE2eRuntimeSessions(rootDir, repoId) {
+  const store = makeTaskEventStore({ rootDir, repoId }),
+    projection = makeTaskProjection({ rootDir, eventStore: store }),
+    actor = { principal: { personId: "person-gui" }, executor: null },
+    claim = (body) => {
+      const sha256 = createHash("sha256").update(body).digest("hex");
+      return { sha256, size: Buffer.byteLength(body), mediaType: "text/plain; charset=utf-8" };
+    };
+  const append = (type, payload, blobs = []) => {
+    const revision = (store.readHead()?.revision ?? 0) + 1,
+      opId = `gui-e2e-sessions-${type}-${revision}`,
+      event = {
+        schema: "agent-runtime-event/v1",
+        eventId: `event-${createHash("sha256").update(opId).digest("hex")}`,
+        workspaceRevision: revision,
+        opId,
+        type,
+        actor,
+        source: "local",
+        occurredAt: new Date().toISOString(),
+        payload,
+      };
+    store.append({ event, plan: canonicalEventWritePlan(event, "agent-runtime/v1", opId), blobs });
+    projection.apply(event);
+  };
+  try {
+    const notaskBody = "gui-e2e unattributed no-task session failed its probe\n",
+      notaskClaim = claim(notaskBody),
+      boundBody = "gui-e2e task-bound session succeeded its probe\n",
+      boundClaim = claim(boundBody);
+    // A:dispatch_requested(无 stream header)→ 派工行 taskId 回落 "unattributed" → no-task 桶。
+    append("runtime_dispatch_requested", {
+      dispatchId: DISPATCH_NOTASK,
+      runtimeSessionId: SESSION_NOTASK,
+      instanceId: "instance-e2e-notask",
+      installationId: "installation-e2e-notask",
+      kindId: "codex",
+      idempotencyKey: "gui-e2e-notask",
+      definitionSnapshotRef: "provider:definition/e2e-notask",
+      definitionSnapshot: definitionSnapshot("instance-e2e-notask", "installation-e2e-notask"),
+    });
+    append("runtime_session_started", {
+      runtimeSessionId: SESSION_NOTASK,
+      instanceId: "instance-e2e-notask",
+      installationId: "installation-e2e-notask",
+      kindId: "codex",
+      definitionSnapshotRef: "provider:definition/e2e-notask",
+      launchGeneration: 1,
+      attachable: false,
+    });
+    append("runtime_session_exited", { runtimeSessionId: SESSION_NOTASK });
+    append(
+      "runtime_session_outcome_observed",
+      {
+        runtimeSessionId: SESSION_NOTASK,
+        outcome: "failed",
+        exitCode: 1,
+        resultRef: `artifact:runtime-result/sha256/${notaskClaim.sha256}`,
+        result: notaskClaim,
+      },
+      [{ ...notaskClaim, body: notaskBody }],
+    );
+    // B:裸 started(live)→ no-dispatch 桶,状态 running。
+    append("runtime_session_started", {
+      runtimeSessionId: SESSION_FREE,
+      instanceId: "instance-e2e-free",
+      installationId: "installation-e2e-free",
+      kindId: "codex",
+      definitionSnapshotRef: "provider:definition/e2e-free",
+      launchGeneration: 1,
+      attachable: false,
+    });
+    // C:task_bound 到夹具任务 → task 组,退出 + 成功。
+    append("runtime_session_started", {
+      runtimeSessionId: SESSION_BOUND,
+      instanceId: "instance-e2e-bound",
+      installationId: "installation-e2e-bound",
+      kindId: "codex",
+      definitionSnapshotRef: "provider:definition/e2e-bound",
+      launchGeneration: 1,
+      attachable: false,
+    });
+    append("runtime_session_task_bound", {
+      runtimeSessionId: SESSION_BOUND,
+      taskId: FIXTURE_TASK,
+      executionId: "exe-e2e-bound",
+      providerSessionId: "provider-e2e-bound",
+      transcriptRef: "file:transcript/e2e-bound.log",
+    });
+    append("runtime_session_exited", { runtimeSessionId: SESSION_BOUND });
+    append(
+      "runtime_session_outcome_observed",
+      {
+        runtimeSessionId: SESSION_BOUND,
+        outcome: "succeeded",
+        exitCode: 0,
+        resultRef: `artifact:runtime-result/sha256/${boundClaim.sha256}`,
+        result: boundClaim,
+      },
+      [{ ...boundClaim, body: boundBody }],
+    );
+  } finally {
+    projection.close();
+    await store.drain();
+  }
+}
+
+/** 从 Electron 主进程环境拿隔离 lane 的 daemon 端点与仓 id(driver 把它们注入 app env)。 */
+async function isolatedDaemonTarget(app) {
+  const env = await app.evaluate(() => ({
+    endpoint: process.env.HARNESS_DAEMON_ENDPOINT,
+    repoId: process.env.HARNESS_DAEMON_REPO_ID,
+  }));
+  assert.ok(env.endpoint, "the isolated daemon endpoint is missing from the app environment");
+  assert.ok(env.repoId, "the isolated repo id is missing from the app environment");
+  return env;
+}
+
+async function sessionTotals(endpoint, repoId, groupBy) {
+  const response = await requestDaemonJsonRpcAt(
+    endpoint,
+    "repo.projection.read",
+    {
+      repo: { repoId },
+      payload: { name: "runtime-session-groups", groupBy, since: new Date(0).toISOString() },
+    },
+    8_000,
+  );
+  assert.equal(response.ok, true, `runtime-session-groups read failed for ${groupBy}`);
+  return response.projection.totals;
+}
+
+export default {
+  id: "sessions-grouping",
+  feature: "sessions",
+  lane: "isolated",
+  description:
+    "Seeded runtime sessions group into reason-named unattributed buckets, the status filter narrows the list and says so, and totals.sessions agree across group-by dimensions.",
+  async run({ page, app }) {
+    // 隔离 daemon 的仓先 warming 后 attached:分组读在 warming 期会被拒(bootstrap_failed)
+    // 且 react-query 只重试一次。先等系统读面说仓已挂载,再进会话页。
+    const deadline = Date.now() + 20_000;
+    for (;;) {
+      const attached = await page.evaluate(
+        async ({ repoId }) => {
+          const repos = (await globalThis.harness.getSystemStatus()).repos ?? [];
+          return repos.some((repo) => repo.repoId === repoId && repo.cellState === "attached");
+        },
+        { repoId: REPO },
+      );
+      if (attached) break;
+      if (Date.now() > deadline) throw new Error(`the isolated repo ${REPO} never reached cellState=attached`);
+      await page.waitForTimeout(500);
+    }
+    await nav(page, /^(?:会话|Sessions)$/u, "sessions-view");
+
+    // 1. 按缺失原因命名的桶 + task 组:判别式在 key(dec_054C39DA50CAD4D4E0D62B726E)。
+    await page.getByTestId(`session-group-${FIXTURE_TASK}`).waitFor();
+    await page.getByTestId("session-group-unattributed:no-task").waitFor();
+    await page.getByTestId("session-group-unattributed:no-dispatch").waitFor();
+
+    // 2. 状态筛选:开启后列表只剩该状态,计数行把「筛选已开」说出来。
+    await page.getByTestId("sessions-status-failed").click();
+    await page.getByTestId("session-group-unattributed:no-task").waitFor();
+    assert.equal(
+      await page.getByTestId(`session-group-${FIXTURE_TASK}`).count(),
+      0,
+      "the failed filter must remove the succeeded session's task group",
+    );
+    assert.equal(
+      await page.getByTestId("session-group-unattributed:no-dispatch").count(),
+      0,
+      "the failed filter must remove the running session's no-dispatch group",
+    );
+    const counts = await page.getByTestId("sessions-counts").innerText();
+    assert.match(counts, /已按状态筛选|filtered to/u, "the counts line must say the status filter is on");
+
+    // 3. 关掉筛选:列表回到全部桶。
+    await page.getByTestId("sessions-status-failed").click();
+    await page.getByTestId(`session-group-${FIXTURE_TASK}`).waitFor();
+    await page.getByTestId("session-group-unattributed:no-dispatch").waitFor();
+
+    // 4. 各维度 totals.sessions 相等:对照 daemon 的 runtime-session-groups 读命令。
+    const { endpoint, repoId } = await isolatedDaemonTarget(app);
+    const byDimension = new Map(
+      await Promise.all(
+        ["task", "squad", "agent", "day"].map(async (groupBy) => [
+          groupBy,
+          await sessionTotals(endpoint, repoId, groupBy),
+        ]),
+      ),
+    );
+    const sessions = byDimension.get("task").sessions;
+    assert.ok(sessions >= 3, `expected at least the 3 seeded sessions, read ${sessions}`);
+    for (const [groupBy, totals] of byDimension)
+      assert.equal(
+        totals.sessions,
+        sessions,
+        `totals.sessions for groupBy=${groupBy} (${totals.sessions}) must match groupBy=task (${sessions})`,
+      );
+  },
+};

--- a/tools/gui-e2e/scenarios/system-daemon-logs.mjs
+++ b/tools/gui-e2e/scenarios/system-daemon-logs.mjs
@@ -1,0 +1,60 @@
+import assert from "node:assert/strict";
+
+/**
+ * #2224 系统 tab 常驻日志面板 + #2227 的「面板被 flex 压成 0 高」回归。
+ *
+ * 三层断言,全部对着真实夹具 daemon(不 mock 任何读面):
+ *   1. 高度:面板声明 h-[24rem](384px),断言 getBoundingClientRect().height >= 300 是
+ *      该声明的下界。SystemView 的父级是 overflow-y-auto 的 flex 列,面板自身带
+ *      min-h-0——没有 shrink-0 时(#2227 之前)上方内容一满,这个 section 就会被
+ *      压到远小于 24rem,这里就是抓它的探针。阈值不许为了变绿放宽。
+ *   2. 「生命周期」kind:observe.tail 读 daemon 的 lifecycle JSONL,夹具 daemon 启动、
+ *      挂仓本身就是真实事件源,至少 1 行。
+ *   3. 「请求」kind:切换不报读取失败(observe-error-* / observe-unavailable-* 都算红)。
+ *
+ * 已知坑(SKILL):首次运行会让 driver 重建 renderer/preload;面板轮询 1s 一拍,
+ * 行断言用默认 20s 超时足够。
+ */
+export default {
+  id: "system-daemon-logs",
+  feature: "system",
+  lane: "isolated",
+  description:
+    "The System tab keeps its resident daemon log panel at the declared 24rem height, shows real lifecycle rows, and the request kind switch does not fail.",
+  async run({ page }) {
+    await page.getByRole("button", { name: /^(?:系统|System)$/u }).click();
+    const panel = page.getByTestId("system-daemon-logs");
+    await panel.waitFor();
+    await page.getByTestId("system-daemon-logs-scope").waitFor();
+    // 仓刚起时先处于 warming:面板会短暂呈现「无路由」说明,挂载完成后必须换成真面板。
+    await page.getByTestId("observe-pane-lifecycle").waitFor();
+    assert.equal(
+      await page.getByTestId("system-daemon-logs-unavailable").count(),
+      0,
+      "an attached repo must route observe.tail for the system log panel",
+    );
+
+    // 1. 声明高度下界:24rem = 384px,断言 >= 300 抓 flex 塌陷(#2227)。
+    const height = await panel.evaluate((node) => node.getBoundingClientRect().height);
+    assert.ok(height >= 300, `system-daemon-logs height ${height}px is below the 24rem lower bound 300px`);
+
+    // 2. 生命周期 kind:夹具 daemon 的真实 lifecycle 事件,至少一行。
+    await page.getByTestId("observe-kind-lifecycle").click();
+    await page.getByTestId("observe-pane-lifecycle").waitFor();
+    await page.getByTestId("observe-row").first().waitFor();
+
+    // 3. 「请求」kind 切换:读面不得失败(失败会渲染 error/unavailable 横幅)。
+    await page.getByTestId("observe-kind-daemon-log").click();
+    await page.getByTestId("observe-pane-daemon-log").waitFor();
+    assert.equal(
+      await page.getByTestId("observe-error-daemon-log").count(),
+      0,
+      "the request-kind log pane must not report a read error",
+    );
+    assert.equal(
+      await page.getByTestId("observe-unavailable-daemon-log").count(),
+      0,
+      "the request-kind log pane must not be unavailable",
+    );
+  },
+};


### PR DESCRIPTION
# English

## Summary

Three GUI capabilities that landed on main without e2e coverage now have scenarios in the gui-e2e catalogue, so the 6-hour schedule and the PR lane guard them instead of a person clicking through Electron: `system-daemon-logs` (the resident log panel keeps its declared height, the lifecycle kind shows at least one real daemon event, the request kind does not fail to read), `sessions-grouping` (status filter narrows the list and shows the filter-on indicator; the three unattributed buckets are named after what is missing, seeded from real agent-runtime events in the fixture daemon), and an extension of `declared-entity-kinds` that imports an `external-issue` with a URL locator served by a throwaway local HTTP server and asserts it appears in the entity explanation page, the territory filter and the graph without any GUI code change.

## Architectural Justification

Scenarios follow the gui-e2e discipline: isolated lane, fixture-seeded data, `data-testid` hooks. The product diff is two `data-testid` attributes. The height assertion was proven capable of failing: it is red on main before #2227 and green with it (fact F-68C68A4A).

## What Changed

- `tools/gui-e2e/scenarios/system-daemon-logs.mjs`, `sessions-grouping.mjs`: new.
- `tools/gui-e2e/scenarios/declared-entity-kinds.mjs`: external-issue path.
- `tools/gui-e2e/catalog.mjs`: registrations; `lanes.mjs`: isolated-lane `beforeRestart` composition only.
- `packages/gui/src/renderer/components/GraphFilterPanel.tsx`, `views/SessionsView.tsx`: one `data-testid` each.

## Gate Harvest / 门收割

No gate change.

## Machine-Readable Declarations

Production-Delta: +431/-45
Dependency-Change: none

### Optional Evidence Claims

none

## Task And Scope

task_754afb427cc99581e692f9f260. Branch `codex/gui-e2e-scenarios`. Known documentation drift found and not fixed here: the gui-e2e SKILL says the driver passes `ctx.fixture`; it does not, so the scenario reads the fixture through the Electron main-process environment and a read-only daemon JSON-RPC check instead.

## Version Impact

No version change; publish impact none.

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none
- Authority: task_754afb427cc99581e692f9f260
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Follow-up governance task: not applicable

## Verification

- Base merge-base ecfd386bd477633b3814b59b4a1a30473b7f0bdd.
- Worker (GLM): `sessions-grouping` healthy four runs in a row; extended `declared-entity-kinds` healthy; `system-daemon-logs` red on 16d0876 (56 px / 15 px panel) and green with the #2227 line (10.5 s); full isolated lane 14 of 15 green with the one red being that negative control; screenshots and facts F-68C68A4A, F-FDBA6640, F-4E659B1A on the task.
- Rebased onto main after #2227 and #2228 merged with no conflicts. CI is the complete authority.

## Review Evidence

CEO semantic review: each scenario asserts the behaviour the corresponding PR claimed, with fixture data rather than canonical entities, and the product change is limited to test hooks.

## Residual Risk

The external-issue scenario starts a local HTTP listener; on a runner without loopback it would fail at setup rather than assert.

# 中文

## 概要

三项已合入但无 e2e 覆盖的 GUI 能力沉淀为场景:系统 tab 常驻日志面板(高度下界、生命周期 kind 有真实事件、请求 kind 不报读取失败)、会话页状态筛选与三类 unattributed 桶(夹具种真实 agent-runtime 事件)、declared-entity-kinds 扩展 external-issue(本地一次性 HTTP 服务当外部系统,不改 GUI 逻辑即出现在实体说明/领地筛选/关系图)。高度断言在 #2227 前红、之后绿,证明它能出声。

## 架构辩护

场景遵循 gui-e2e 纪律:isolated lane、夹具种数据、data-testid 钩子;产品 diff 只有两处 data-testid。高度断言先在 main 上证明会红、再随 #2227 变绿,证明它能出声。

## 机读声明

生产行数增减(与上文机读声明一致):+431/-45

## 治理声明

- 触碰受保护面:否
- 授权:task_754afb427cc99581e692f9f260
- Break-glass:否

## 验证

GLM:sessions-grouping 连跑 4 次绿、declared-entity-kinds 绿、system-daemon-logs 双侧对照;全 isolated lane 14/15(唯一红即阴性对照)。rebase 到 #2227/#2228 之后无冲突。CI 为完整权威。

## 评审证据

每个场景断言对应 PR 声明的行为,用夹具不用 canonical 实体,产品改动只有两处 data-testid。

## 残余风险

external-issue 场景起本地 HTTP 监听,无 loopback 的 runner 会在 setup 失败。
