### PR TITLE
feat(daemon): give GUI terminals the user's real login shell environment

### DIFF
--- a/packages/daemon/src/process-port.ts
+++ b/packages/daemon/src/process-port.ts
@@ -92,12 +92,14 @@ export function runProcessText(
   args: readonly string[],
   cwd?: string,
   env?: NodeJS.ProcessEnv,
+  timeoutMs?: number,
 ): string {
   return (
     /* @gate-identity check-sync-subprocess/sync-subprocess-009 */
     execFileSync(command, [...args], {
       cwd,
       ...(env ? { env } : {}),
+      ...(timeoutMs === undefined ? {} : { timeout: timeoutMs }),
       encoding: "utf8",
       stdio: ["ignore", "pipe", "pipe"],
       windowsHide: true,

--- a/packages/daemon/src/terminal-environment.ts
+++ b/packages/daemon/src/terminal-environment.ts
@@ -1,0 +1,82 @@
+import { runProcessText } from "./process-port.ts";
+
+const loginShellSnapshotTimeoutMs = 4_000;
+
+const sessionEnvironmentKeys = [
+  // Keeps launchd's ssh-agent channel available when profiles do not recreate it.
+  "SSH_AUTH_SOCK",
+  // Keeps macOS per-user temporary files in their session-scoped directory.
+  "TMPDIR",
+  // Keeps home-relative tools working even when the shell does not export HOME.
+  "HOME",
+  // Keeps tools that identify the current account from losing the session user.
+  "USER",
+  // Keeps login-aware tools from falling back to an absent account name.
+  "LOGNAME",
+  // Keeps macOS terminal text encoding aligned with the logged-in user session.
+  "__CF_USER_TEXT_ENCODING",
+] as const;
+
+let cachedPosixEnvironment: Readonly<Record<string, string>> | undefined;
+
+export function terminalEnvironment(
+  platform: NodeJS.Platform,
+  shell: string,
+  capture: (shell: string) => Readonly<Record<string, string>> = captureLoginShellEnvironment,
+): Readonly<Record<string, string>> {
+  if (platform === "win32") return legacyTerminalEnvironment(platform);
+  if (!cachedPosixEnvironment) {
+    try {
+      cachedPosixEnvironment = Object.freeze({
+        ...capture(shell),
+        ...sessionEnvironment(),
+        TERM: "xterm-256color",
+      });
+    } catch (error) {
+      console.warn(
+        `[terminal-environment] login shell snapshot failed; using restricted environment: ${errorMessage(error)}`,
+      );
+      cachedPosixEnvironment = Object.freeze(legacyTerminalEnvironment(platform));
+    }
+  }
+  return cachedPosixEnvironment;
+}
+
+export function captureLoginShellEnvironment(
+  shell: string,
+  run: typeof runProcessText = runProcessText,
+): Readonly<Record<string, string>> {
+  const output = run(
+    "/usr/bin/env",
+    ["-i", shell, "-l", "-i", "-c", "env -0"],
+    undefined,
+    {},
+    loginShellSnapshotTimeoutMs,
+  );
+  const entries = output.split("\0").filter(Boolean);
+  if (entries.length === 0) throw new Error("login shell returned an empty environment");
+  return Object.fromEntries(
+    entries.map((entry) => {
+      const separator = entry.indexOf("=");
+      if (separator <= 0) throw new Error("login shell returned an invalid environment entry");
+      return [entry.slice(0, separator), entry.slice(separator + 1)];
+    }),
+  );
+}
+
+function sessionEnvironment(): Record<string, string> {
+  return Object.fromEntries(
+    sessionEnvironmentKeys.flatMap((key) => (process.env[key] === undefined ? [] : [[key, process.env[key]!]])),
+  );
+}
+
+function legacyTerminalEnvironment(platform: NodeJS.Platform): Record<string, string> {
+  const result: Record<string, string> = { TERM: "xterm-256color" },
+    keys = ["PATH", "HOME", "LANG", "LC_ALL", "TMPDIR", ...(platform === "win32" ? ["SystemRoot"] : [])];
+  for (const key of keys) if (process.env[key]) result[key] = process.env[key]!;
+  return result;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/packages/daemon/src/terminal-environment.ts
+++ b/packages/daemon/src/terminal-environment.ts
@@ -16,6 +16,14 @@ const sessionEnvironmentKeys = [
   "LOGNAME",
   // Keeps macOS terminal text encoding aligned with the logged-in user session.
   "__CF_USER_TEXT_ENCODING",
+  // Keeps the locale identical to the user's session. Login profiles are not the
+  // authority here: this machine's profiles produce C.UTF-8 while the user's own
+  // terminal runs en_US.UTF-8, because terminal apps inject the locale themselves.
+  "LANG",
+  // Keeps an explicit override intact; it outranks LANG wherever the user sets it.
+  "LC_ALL",
+  // Keeps character classification aligned when it is set apart from LANG.
+  "LC_CTYPE",
 ] as const;
 
 const cachedPosixEnvironments = new Map<string, Readonly<Record<string, string>>>();

--- a/packages/daemon/src/terminal-environment.ts
+++ b/packages/daemon/src/terminal-environment.ts
@@ -1,3 +1,4 @@
+import { consumeKnownError } from "../../kernel/src/index.ts";
 import { runProcessText } from "./process-port.ts";
 
 const loginShellSnapshotTimeoutMs = 4_000;
@@ -17,7 +18,7 @@ const sessionEnvironmentKeys = [
   "__CF_USER_TEXT_ENCODING",
 ] as const;
 
-let cachedPosixEnvironment: Readonly<Record<string, string>> | undefined;
+const cachedPosixEnvironments = new Map<string, Readonly<Record<string, string>>>();
 
 export function terminalEnvironment(
   platform: NodeJS.Platform,
@@ -25,9 +26,10 @@ export function terminalEnvironment(
   capture: (shell: string) => Readonly<Record<string, string>> = captureLoginShellEnvironment,
 ): Readonly<Record<string, string>> {
   if (platform === "win32") return legacyTerminalEnvironment(platform);
-  if (!cachedPosixEnvironment) {
+  let environment = cachedPosixEnvironments.get(shell);
+  if (!environment) {
     try {
-      cachedPosixEnvironment = Object.freeze({
+      environment = Object.freeze({
         ...capture(shell),
         ...sessionEnvironment(),
         TERM: "xterm-256color",
@@ -36,10 +38,12 @@ export function terminalEnvironment(
       console.warn(
         `[terminal-environment] login shell snapshot failed; using restricted environment: ${errorMessage(error)}`,
       );
-      cachedPosixEnvironment = Object.freeze(legacyTerminalEnvironment(platform));
+      consumeKnownError(error);
+      environment = Object.freeze(legacyTerminalEnvironment(platform));
     }
+    cachedPosixEnvironments.set(shell, environment);
   }
-  return cachedPosixEnvironment;
+  return environment;
 }
 
 export function captureLoginShellEnvironment(

--- a/packages/daemon/src/terminal-environment.ts
+++ b/packages/daemon/src/terminal-environment.ts
@@ -37,7 +37,7 @@ export function terminalEnvironment(
     });
   } catch (error) {
     console.warn(
-      `[terminal-environment] login shell snapshot failed; using restricted environment: ${errorMessage(error)}`,
+      `[terminal-environment] login shell snapshot failed; using restricted environment: ${error instanceof Error ? error.message : String(error)}`,
     );
     consumeKnownError(error);
     // A failed snapshot is deliberately not cached. Caching it would pin the daemon to the
@@ -82,8 +82,4 @@ function legacyTerminalEnvironment(platform: NodeJS.Platform): Record<string, st
     keys = ["PATH", "HOME", "LANG", "LC_ALL", "TMPDIR", ...(platform === "win32" ? ["SystemRoot"] : [])];
   for (const key of keys) if (process.env[key]) result[key] = process.env[key]!;
   return result;
-}
-
-function errorMessage(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
 }

--- a/packages/daemon/src/terminal-environment.ts
+++ b/packages/daemon/src/terminal-environment.ts
@@ -26,23 +26,26 @@ export function terminalEnvironment(
   capture: (shell: string) => Readonly<Record<string, string>> = captureLoginShellEnvironment,
 ): Readonly<Record<string, string>> {
   if (platform === "win32") return legacyTerminalEnvironment(platform);
-  let environment = cachedPosixEnvironments.get(shell);
-  if (!environment) {
-    try {
-      environment = Object.freeze({
-        ...capture(shell),
-        ...sessionEnvironment(),
-        TERM: "xterm-256color",
-      });
-    } catch (error) {
-      console.warn(
-        `[terminal-environment] login shell snapshot failed; using restricted environment: ${errorMessage(error)}`,
-      );
-      consumeKnownError(error);
-      environment = Object.freeze(legacyTerminalEnvironment(platform));
-    }
-    cachedPosixEnvironments.set(shell, environment);
+  const cached = cachedPosixEnvironments.get(shell);
+  if (cached) return cached;
+  let environment: Readonly<Record<string, string>>;
+  try {
+    environment = Object.freeze({
+      ...capture(shell),
+      ...sessionEnvironment(),
+      TERM: "xterm-256color",
+    });
+  } catch (error) {
+    console.warn(
+      `[terminal-environment] login shell snapshot failed; using restricted environment: ${errorMessage(error)}`,
+    );
+    consumeKnownError(error);
+    // A failed snapshot is deliberately not cached. Caching it would pin the daemon to the
+    // restricted environment for the rest of its life after one transient failure, which is
+    // exactly the silent degradation this module exists to remove.
+    return Object.freeze(legacyTerminalEnvironment(platform));
   }
+  cachedPosixEnvironments.set(shell, environment);
   return environment;
 }
 

--- a/packages/daemon/src/terminal-environment.ts
+++ b/packages/daemon/src/terminal-environment.ts
@@ -36,9 +36,8 @@ export function terminalEnvironment(
       TERM: "xterm-256color",
     });
   } catch (error) {
-    console.warn(
-      `[terminal-environment] login shell snapshot failed; using restricted environment: ${error instanceof Error ? error.message : String(error)}`,
-    );
+    const reason = error instanceof Error ? error.message : String(error);
+    console.warn(`[terminal-environment] login shell snapshot failed; using restricted environment: ${reason}`);
     consumeKnownError(error);
     // A failed snapshot is deliberately not cached. Caching it would pin the daemon to the
     // restricted environment for the rest of its life after one transient failure, which is

--- a/packages/daemon/src/terminal-host.ts
+++ b/packages/daemon/src/terminal-host.ts
@@ -27,6 +27,7 @@ import {
   type TmuxController,
 } from "./terminal-tmux.ts";
 import { resolveContainedPath } from "./contained-path.ts";
+import { terminalEnvironment } from "./terminal-environment.ts";
 
 const scrollbackLimit = 1024 * 1024,
   replayLimit = 256 * 1024,
@@ -84,6 +85,7 @@ type OpenTerminalHostInput = {
   readonly platform?: NodeJS.Platform;
   readonly tmux?: TmuxController;
   readonly registryFilePath?: string;
+  readonly resolveTerminalEnvironment?: (platform: NodeJS.Platform, shell: string) => Readonly<Record<string, string>>;
 };
 type SpawnLaunch = {
   readonly key: string;
@@ -131,7 +133,8 @@ export function openTerminalHost(input: OpenTerminalHostInput): TerminalHost {
   const now = input.now ?? (() => new Date().toISOString()),
     spawnPty = input.spawnPty ?? pty.spawn;
   const platform = input.platform ?? process.platform,
-    tmux = input.tmux ?? systemTmuxController;
+    tmux = input.tmux ?? systemTmuxController,
+    resolveTerminalEnvironment = input.resolveTerminalEnvironment ?? terminalEnvironment;
   const tmuxProbe = tmux.probe();
   const registryFilePath =
     input.registryFilePath ?? path.join(input.rootDir, ".harness", "generated", "terminal-sessions.json");
@@ -173,13 +176,17 @@ export function openTerminalHost(input: OpenTerminalHostInput): TerminalHost {
     const selection = selectLocalTerminalBackend(terminalBackend(payload.backend), tmuxProbe);
     const namespace = selection.backend === "tmux" ? terminalTmuxNamespace(input.repoId, sessionId) : null;
     const executable = selection.backend === "tmux" ? tmuxProbe.executable! : command;
-    const args = selection.backend === "tmux" ? ["-u", "new-session", "-A", "-s", namespace!, "-c", cwd, command] : [];
+    const env = resolveTerminalEnvironment(platform, command);
+    const args =
+      selection.backend === "tmux"
+        ? ["-u", "new-session", "-A", "-s", namespace!, "-c", cwd, ...tmuxEnvironmentArgs(env), command]
+        : [];
     return spawnProcess({
       key,
       name: optional(payload.name) ?? "Terminal",
       command: executable,
       args,
-      env: terminalEnvironment(platform),
+      env,
       cwd,
       publicCwd: path.relative(input.rootDir, cwd) || ".",
       profile,
@@ -475,7 +482,7 @@ export function openTerminalHost(input: OpenTerminalHostInput): TerminalHost {
       cols: 80,
       rows: 24,
       cwd: session.spawnCwd,
-      env: terminalEnvironment(platform),
+      env: resolveTerminalEnvironment(platform, shell(session.shellProfile, platform)),
     });
     bindChild(session, child);
     session.attachable = true;
@@ -704,11 +711,8 @@ function terminalCommand(
 function quoteCmdArgument(value: string): string {
   return /^[^\s"&|<>^()]+$/u.test(value) ? value : `"${value.replaceAll('"', '""')}"`;
 }
-function terminalEnvironment(platform: NodeJS.Platform): Record<string, string> {
-  const result: Record<string, string> = { TERM: "xterm-256color" },
-    keys = ["PATH", "HOME", "LANG", "LC_ALL", "TMPDIR", ...(platform === "win32" ? ["SystemRoot"] : [])];
-  for (const key of keys) if (process.env[key]) result[key] = process.env[key]!;
-  return result;
+function tmuxEnvironmentArgs(environment: Readonly<Record<string, string>>): string[] {
+  return Object.entries(environment).flatMap(([key, value]) => ["-e", `${key}=${value}`]);
 }
 function frameSize(frame: Frame): number {
   return Buffer.byteLength(frame.utf8, "utf8") + 96;

--- a/packages/daemon/test/terminal-environment.test.ts
+++ b/packages/daemon/test/terminal-environment.test.ts
@@ -82,3 +82,18 @@ test("a failed snapshot is not cached so the next terminal retries", () => {
     console.warn = previousWarn;
   }
 });
+
+test("terminal environment prefers the session locale over the one login profiles produce", () => {
+  const previous = process.env.LANG;
+  process.env.LANG = "en_US.UTF-8";
+  try {
+    const environment = terminalEnvironment("darwin", "/test/locale-shell", () => ({
+      LANG: "C.UTF-8",
+      PATH: "/usr/bin",
+    }));
+    assert.equal(environment.LANG, "en_US.UTF-8");
+  } finally {
+    if (previous === undefined) delete process.env.LANG;
+    else process.env.LANG = previous;
+  }
+});

--- a/packages/daemon/test/terminal-environment.test.ts
+++ b/packages/daemon/test/terminal-environment.test.ts
@@ -62,3 +62,23 @@ test("terminal environment warns and falls back to the legacy keys when capture 
     console.warn = previousWarn;
   }
 });
+
+test("a failed snapshot is not cached so the next terminal retries", () => {
+  const previousWarn = console.warn;
+  console.warn = () => {};
+  try {
+    let attempts = 0;
+    const capture = () => {
+      attempts += 1;
+      if (attempts === 1) throw new Error("transient");
+      return { LANG: "en_US.UTF-8", PROFILE_EXPORT: "included" };
+    };
+    const first = terminalEnvironment("linux", "/test/retry-shell", capture);
+    assert.equal("PROFILE_EXPORT" in first, false);
+    const second = terminalEnvironment("linux", "/test/retry-shell", capture);
+    assert.equal(second.PROFILE_EXPORT, "included");
+    assert.equal(attempts, 2);
+  } finally {
+    console.warn = previousWarn;
+  }
+});

--- a/packages/daemon/test/terminal-environment.test.ts
+++ b/packages/daemon/test/terminal-environment.test.ts
@@ -1,7 +1,7 @@
 // harness-test-tier: fast
 import assert from "node:assert/strict";
 import test from "node:test";
-import { captureLoginShellEnvironment } from "../src/terminal-environment.ts";
+import { captureLoginShellEnvironment, terminalEnvironment } from "../src/terminal-environment.ts";
 
 test("login shell environment parser preserves values containing equals signs", () => {
   let invocation: readonly unknown[] | undefined;
@@ -16,4 +16,49 @@ test("login shell environment parser preserves values containing equals signs", 
 test("login shell environment parser rejects empty and malformed output", () => {
   assert.throws(() => captureLoginShellEnvironment("/bin/zsh", () => ""), /empty environment/u);
   assert.throws(() => captureLoginShellEnvironment("/bin/zsh", () => "BROKEN\0"), /invalid environment entry/u);
+});
+
+test("terminal environment caches a clean snapshot and overlays enumerated session channels", () => {
+  const previous = process.env.SSH_AUTH_SOCK,
+    previousSecret = process.env.RUNTIME_ONLY_SECRET;
+  process.env.SSH_AUTH_SOCK = "/private/tmp/agent.sock";
+  process.env.RUNTIME_ONLY_SECRET = "must-not-cross";
+  let captures = 0;
+  try {
+    const capture = () => {
+      captures += 1;
+      return { LANG: "en_US.UTF-8", PROFILE_EXPORT: "included" };
+    };
+    const first = terminalEnvironment("darwin", "/test/cache-shell", capture);
+    const second = terminalEnvironment("darwin", "/test/cache-shell", capture);
+    assert.equal(first, second);
+    assert.equal(captures, 1);
+    assert.equal(first.LANG, "en_US.UTF-8");
+    assert.equal(first.PROFILE_EXPORT, "included");
+    assert.equal(first.SSH_AUTH_SOCK, "/private/tmp/agent.sock");
+    assert.equal(first.TERM, "xterm-256color");
+    assert.equal("RUNTIME_ONLY_SECRET" in first, false);
+  } finally {
+    if (previous === undefined) delete process.env.SSH_AUTH_SOCK;
+    else process.env.SSH_AUTH_SOCK = previous;
+    if (previousSecret === undefined) delete process.env.RUNTIME_ONLY_SECRET;
+    else process.env.RUNTIME_ONLY_SECRET = previousSecret;
+  }
+});
+
+test("terminal environment warns and falls back to the legacy keys when capture fails", () => {
+  const warnings: unknown[][] = [],
+    previousWarn = console.warn;
+  console.warn = (...values: unknown[]) => warnings.push(values);
+  try {
+    const environment = terminalEnvironment("linux", "/test/failing-shell", () => {
+      throw new Error("timed out");
+    });
+    assert.equal(environment.TERM, "xterm-256color");
+    assert.equal(environment.PATH, process.env.PATH);
+    assert.equal("SSH_AUTH_SOCK" in environment, false);
+    assert.match(String(warnings[0]?.[0]), /snapshot failed.*timed out/u);
+  } finally {
+    console.warn = previousWarn;
+  }
 });

--- a/packages/daemon/test/terminal-environment.test.ts
+++ b/packages/daemon/test/terminal-environment.test.ts
@@ -20,9 +20,13 @@ test("login shell environment parser rejects empty and malformed output", () => 
 
 test("terminal environment caches a clean snapshot and overlays enumerated session channels", () => {
   const previous = process.env.SSH_AUTH_SOCK,
-    previousSecret = process.env.RUNTIME_ONLY_SECRET;
+    previousSecret = process.env.RUNTIME_ONLY_SECRET,
+    previousLang = process.env.LANG;
   process.env.SSH_AUTH_SOCK = "/private/tmp/agent.sock";
   process.env.RUNTIME_ONLY_SECRET = "must-not-cross";
+  // LANG is a session channel now, so an ambient value would overlay the captured one and make
+  // this assertion depend on whoever started the test runner.
+  delete process.env.LANG;
   let captures = 0;
   try {
     const capture = () => {
@@ -43,6 +47,8 @@ test("terminal environment caches a clean snapshot and overlays enumerated sessi
     else process.env.SSH_AUTH_SOCK = previous;
     if (previousSecret === undefined) delete process.env.RUNTIME_ONLY_SECRET;
     else process.env.RUNTIME_ONLY_SECRET = previousSecret;
+    if (previousLang === undefined) delete process.env.LANG;
+    else process.env.LANG = previousLang;
   }
 });
 

--- a/packages/daemon/test/terminal-environment.test.ts
+++ b/packages/daemon/test/terminal-environment.test.ts
@@ -1,0 +1,19 @@
+// harness-test-tier: fast
+import assert from "node:assert/strict";
+import test from "node:test";
+import { captureLoginShellEnvironment } from "../src/terminal-environment.ts";
+
+test("login shell environment parser preserves values containing equals signs", () => {
+  let invocation: readonly unknown[] | undefined;
+  const environment = captureLoginShellEnvironment("/bin/zsh", (...args) => {
+    invocation = args;
+    return "LANG=en_US.UTF-8\0TOKEN=left=right\0";
+  });
+  assert.deepEqual(environment, { LANG: "en_US.UTF-8", TOKEN: "left=right" });
+  assert.deepEqual(invocation, ["/usr/bin/env", ["-i", "/bin/zsh", "-l", "-i", "-c", "env -0"], undefined, {}, 4_000]);
+});
+
+test("login shell environment parser rejects empty and malformed output", () => {
+  assert.throws(() => captureLoginShellEnvironment("/bin/zsh", () => ""), /empty environment/u);
+  assert.throws(() => captureLoginShellEnvironment("/bin/zsh", () => "BROKEN\0"), /invalid environment entry/u);
+});

--- a/packages/daemon/test/terminal-host.integration.test.ts
+++ b/packages/daemon/test/terminal-host.integration.test.ts
@@ -1,6 +1,6 @@
 // harness-test-tier: integration
 import assert from "node:assert/strict";
-import { existsSync, mkdtempSync, readFileSync, rmSync, statSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, realpathSync, rmSync, statSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -115,7 +115,8 @@ test("trusted runtime auth terminal executes an exact non-platform fixture witho
 });
 
 test("direct terminals receive the cached login shell environment", async () => {
-  const root = mkdtempSync(path.join(tmpdir(), "ha-terminal-environment-")),
+  // realpath: the host resolves the spawn cwd, and on macOS tmpdir() is the /var symlink.
+  const root = realpathSync(mkdtempSync(path.join(tmpdir(), "ha-terminal-environment-"))),
     launches: RecordedLaunch[] = [];
   try {
     const host = openTerminalHost({

--- a/packages/daemon/test/terminal-host.integration.test.ts
+++ b/packages/daemon/test/terminal-host.integration.test.ts
@@ -8,159 +8,558 @@ import { openTerminalHost } from "../src/terminal-host.ts";
 import type { TmuxController } from "../src/terminal-tmux.ts";
 
 test("daemon terminal host spawns, echoes, attaches, resizes, detaches, and terminates", async () => {
-    const root = mkdtempSync(path.join(tmpdir(), "ha-terminal-"));
-    try {
+  const root = mkdtempSync(path.join(tmpdir(), "ha-terminal-"));
+  try {
     const host = openTerminalHost({ repoId: "repo-a", rootDir: root, daemonGeneration: 7 });
-    const spawned = host.spawn({ idempotencyKey: "terminal-test", backend: "direct-pty", cwd: { scope: "repo-root" }, shellProfileId: "default", name: "Test" });
+    const spawned = host.spawn({
+      idempotencyKey: "terminal-test",
+      backend: "direct-pty",
+      cwd: { scope: "repo-root" },
+      shellProfileId: "default",
+      name: "Test",
+    });
     assert.equal(spawned.ok, true);
     const attached = host.attach(spawned.sessionId!, 0);
     assert.match(String(attached.initial.status), /attached|gap/u);
     assert.equal(host.resize({ sessionId: spawned.sessionId!, cols: 100, rows: 31 }).state, "running");
-    assert.equal(host.input({ sessionId: spawned.sessionId!, clientSeq: 1, utf8: "echo __HA_PTY_OK__\r" }).acceptedThrough, 1);
+    assert.equal(
+      host.input({ sessionId: spawned.sessionId!, clientSeq: 1, utf8: "echo __HA_PTY_OK__\r" }).acceptedThrough,
+      1,
+    );
     let output = "";
     for (let attempts = 0; attempts < 20 && !output.includes("__HA_PTY_OK__"); attempts += 1) {
-      const frame = await Promise.race([attached.next(), new Promise<null>((resolve) => setTimeout(() => resolve(null), 100))]);
+      const frame = await Promise.race([
+        attached.next(),
+        new Promise<null>((resolve) => setTimeout(() => resolve(null), 100)),
+      ]);
       if (frame?.kind === "output") output += String(frame.utf8);
     }
     assert.match(output, /__HA_PTY_OK__/u);
-    assert.equal(host.detach({ sessionId: spawned.sessionId!, attachmentId: attached.initial.attachmentId as string }).state, "detached");
+    assert.equal(
+      host.detach({ sessionId: spawned.sessionId!, attachmentId: attached.initial.attachmentId as string }).state,
+      "detached",
+    );
     assert.equal(host.terminate({ sessionId: spawned.sessionId!, confirmed: true }).state, "exited");
     await host.close();
-    } finally { rmSync(root, { recursive: true, force: true }); }
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
 });
 
 test("trusted runtime auth terminal executes an exact non-platform fixture without exposing its launch spec", async () => {
   const root = mkdtempSync(path.join(tmpdir(), "ha-runtime-auth-terminal-"));
   try {
-    let data: ((value: string) => void) | undefined, exit: ((value: { readonly exitCode: number }) => void) | undefined, launch: { readonly file: string; readonly args: readonly string[]; readonly options: Record<string, unknown> } | undefined;
-    const fakePty = { onData: (listener: (value: string) => void) => { data = listener; return { dispose: () => undefined }; }, onExit: (listener: (value: { readonly exitCode: number }) => void) => { exit = listener; return { dispose: () => undefined }; }, write: () => undefined, resize: () => undefined, kill: () => { exit?.({ exitCode: 0 }); } };
-    const host = openTerminalHost({ repoId: "repo-a", rootDir: root, daemonGeneration: 8, spawnPty: ((file: string, args: readonly string[], options: Record<string, unknown>) => { launch = { file, args, options }; return fakePty; }) as never });
-    const spawned = host.spawnTrusted({ idempotencyKey: "runtime-auth", name: "Codex Review · Sign in", executablePath: process.execPath, args: ["-e", "process.stdout.write(process.env.RUNTIME_AUTH_MARKER ?? 'missing')"], env: { PATH: process.env.PATH ?? "", RUNTIME_AUTH_MARKER: "AUTH_STUB_OK" }, cwd: root, publicCwd: "runtime-instance:codex-review", profile: "runtime-auth" });
-    assert.equal(spawned.ok, true); assert.deepEqual(launch, { file: process.execPath, args: ["-e", "process.stdout.write(process.env.RUNTIME_AUTH_MARKER ?? 'missing')"], options: { name: "xterm-256color", cols: 80, rows: 24, cwd: root, env: { PATH: process.env.PATH ?? "", RUNTIME_AUTH_MARKER: "AUTH_STUB_OK", TERM: "xterm-256color" } } }); const attached = host.attach(spawned.sessionId!, 0); data?.("AUTH_STUB_OK"); const frame = await attached.next(); assert.equal(frame?.utf8, "AUTH_STUB_OK");
-    const listed = JSON.stringify(host.list()); assert.match(listed, /runtime-instance:codex-review/u); assert.doesNotMatch(listed, new RegExp(process.execPath.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&"), "u")); assert.doesNotMatch(listed, /RUNTIME_AUTH_MARKER/u); await host.close();
-  } finally { rmSync(root, { recursive: true, force: true }); }
+    let data: ((value: string) => void) | undefined,
+      exit: ((value: { readonly exitCode: number }) => void) | undefined,
+      launch:
+        | { readonly file: string; readonly args: readonly string[]; readonly options: Record<string, unknown> }
+        | undefined;
+    const fakePty = {
+      onData: (listener: (value: string) => void) => {
+        data = listener;
+        return { dispose: () => undefined };
+      },
+      onExit: (listener: (value: { readonly exitCode: number }) => void) => {
+        exit = listener;
+        return { dispose: () => undefined };
+      },
+      write: () => undefined,
+      resize: () => undefined,
+      kill: () => {
+        exit?.({ exitCode: 0 });
+      },
+    };
+    const host = openTerminalHost({
+      repoId: "repo-a",
+      rootDir: root,
+      daemonGeneration: 8,
+      spawnPty: ((file: string, args: readonly string[], options: Record<string, unknown>) => {
+        launch = { file, args, options };
+        return fakePty;
+      }) as never,
+    });
+    const spawned = host.spawnTrusted({
+      idempotencyKey: "runtime-auth",
+      name: "Codex Review · Sign in",
+      executablePath: process.execPath,
+      args: ["-e", "process.stdout.write(process.env.RUNTIME_AUTH_MARKER ?? 'missing')"],
+      env: { PATH: process.env.PATH ?? "", RUNTIME_AUTH_MARKER: "AUTH_STUB_OK" },
+      cwd: root,
+      publicCwd: "runtime-instance:codex-review",
+      profile: "runtime-auth",
+    });
+    assert.equal(spawned.ok, true);
+    assert.deepEqual(launch, {
+      file: process.execPath,
+      args: ["-e", "process.stdout.write(process.env.RUNTIME_AUTH_MARKER ?? 'missing')"],
+      options: {
+        name: "xterm-256color",
+        cols: 80,
+        rows: 24,
+        cwd: root,
+        env: { PATH: process.env.PATH ?? "", RUNTIME_AUTH_MARKER: "AUTH_STUB_OK", TERM: "xterm-256color" },
+      },
+    });
+    const attached = host.attach(spawned.sessionId!, 0);
+    data?.("AUTH_STUB_OK");
+    const frame = await attached.next();
+    assert.equal(frame?.utf8, "AUTH_STUB_OK");
+    const listed = JSON.stringify(host.list());
+    assert.match(listed, /runtime-instance:codex-review/u);
+    assert.doesNotMatch(listed, new RegExp(process.execPath.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&"), "u"));
+    assert.doesNotMatch(listed, /RUNTIME_AUTH_MARKER/u);
+    await host.close();
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("direct terminals receive the cached login shell environment", async () => {
+  const root = mkdtempSync(path.join(tmpdir(), "ha-terminal-environment-")),
+    launches: RecordedLaunch[] = [];
+  try {
+    const host = openTerminalHost({
+      repoId: "repo-environment",
+      rootDir: root,
+      daemonGeneration: 8,
+      platform: "darwin",
+      spawnPty: recordingPtySpawner(launches, undefined, true),
+      resolveTerminalEnvironment: (_platform, shell) => ({
+        LANG: "zh_TW.UTF-8",
+        PROFILE_EXPORT: shell,
+        TERM: "xterm-256color",
+      }),
+    });
+    host.spawn({
+      idempotencyKey: "environment",
+      backend: "direct-pty",
+      cwd: { scope: "repo-root" },
+      shellProfileId: "zsh",
+      name: "Environment",
+    });
+    assert.deepEqual(launches[0], {
+      file: "/bin/zsh",
+      args: [],
+      cwd: root,
+      env: { LANG: "zh_TW.UTF-8", PROFILE_EXPORT: "/bin/zsh", TERM: "xterm-256color" },
+    });
+    await host.close();
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
 });
 
 test("windows terminals preserve SystemRoot and pass command shims to node-pty as one command line", async () => {
-  const root = mkdtempSync(path.join(tmpdir(), "ha-runtime-auth-terminal-windows-")), previousSystemRoot = process.env.SystemRoot;
+  const root = mkdtempSync(path.join(tmpdir(), "ha-runtime-auth-terminal-windows-")),
+    previousSystemRoot = process.env.SystemRoot;
   try {
     process.env.SystemRoot = "C:\\Windows";
-    const launches: Array<{ readonly file: string; readonly args: readonly string[] | string; readonly options: Record<string, unknown> }> = [];
-    const host = openTerminalHost({ repoId: "repo-windows", rootDir: root, daemonGeneration: 9, platform: "win32", spawnPty: ((file: string, args: readonly string[] | string, options: Record<string, unknown>) => { let exit: ((value: { readonly exitCode: number }) => void) | undefined; launches.push({ file, args, options }); return { onData: () => ({ dispose: () => undefined }), onExit: (listener: (value: { readonly exitCode: number }) => void) => { exit = listener; return { dispose: () => undefined }; }, write: () => undefined, resize: () => undefined, kill: () => { exit?.({ exitCode: 0 }); } }; }) as never });
-    host.spawn({ idempotencyKey: "windows-shell", backend: "direct-pty", cwd: { scope: "repo-root" }, shellProfileId: "default", name: "Windows shell" });
-    host.spawnTrusted({ idempotencyKey: "windows-auth", name: "Codex · Sign in", executablePath: "C:\\Program Files\\Codex\\codex.cmd", args: ["login"], env: { PATH: "C:\\Program Files\\Codex", COMSPEC: "C:\\Windows\\System32\\cmd.exe" }, cwd: root, publicCwd: "runtime-instance:codex", profile: "runtime-auth" });
-    assert.equal(launches[0]?.file, "powershell.exe"); assert.equal((launches[0]?.options.env as Record<string, unknown>).SystemRoot, "C:\\Windows");
-    assert.equal(launches[1]?.file, "C:\\Windows\\System32\\cmd.exe"); assert.equal(launches[1]?.args, '/d /s /c ""C:\\Program Files\\Codex\\codex.cmd" login"');
+    const launches: Array<{
+      readonly file: string;
+      readonly args: readonly string[] | string;
+      readonly options: Record<string, unknown>;
+    }> = [];
+    const host = openTerminalHost({
+      repoId: "repo-windows",
+      rootDir: root,
+      daemonGeneration: 9,
+      platform: "win32",
+      spawnPty: ((file: string, args: readonly string[] | string, options: Record<string, unknown>) => {
+        let exit: ((value: { readonly exitCode: number }) => void) | undefined;
+        launches.push({ file, args, options });
+        return {
+          onData: () => ({ dispose: () => undefined }),
+          onExit: (listener: (value: { readonly exitCode: number }) => void) => {
+            exit = listener;
+            return { dispose: () => undefined };
+          },
+          write: () => undefined,
+          resize: () => undefined,
+          kill: () => {
+            exit?.({ exitCode: 0 });
+          },
+        };
+      }) as never,
+    });
+    host.spawn({
+      idempotencyKey: "windows-shell",
+      backend: "direct-pty",
+      cwd: { scope: "repo-root" },
+      shellProfileId: "default",
+      name: "Windows shell",
+    });
+    host.spawnTrusted({
+      idempotencyKey: "windows-auth",
+      name: "Codex · Sign in",
+      executablePath: "C:\\Program Files\\Codex\\codex.cmd",
+      args: ["login"],
+      env: { PATH: "C:\\Program Files\\Codex", COMSPEC: "C:\\Windows\\System32\\cmd.exe" },
+      cwd: root,
+      publicCwd: "runtime-instance:codex",
+      profile: "runtime-auth",
+    });
+    assert.equal(launches[0]?.file, "powershell.exe");
+    assert.equal((launches[0]?.options.env as Record<string, unknown>).SystemRoot, "C:\\Windows");
+    assert.equal(launches[1]?.file, "C:\\Windows\\System32\\cmd.exe");
+    assert.equal(launches[1]?.args, '/d /s /c ""C:\\Program Files\\Codex\\codex.cmd" login"');
     await host.close();
-  } finally { if (previousSystemRoot === undefined) delete process.env.SystemRoot; else process.env.SystemRoot = previousSystemRoot; rmSync(root, { recursive: true, force: true }); }
+  } finally {
+    if (previousSystemRoot === undefined) delete process.env.SystemRoot;
+    else process.env.SystemRoot = previousSystemRoot;
+    rmSync(root, { recursive: true, force: true });
+  }
 });
 
 test("a terminal child that exits on its own still gets its pty released on windows", async () => {
   const root = mkdtempSync(path.join(tmpdir(), "ha-terminal-selfexit-"));
   try {
-    const kills: number[] = []; let alive = true; let exit: ((value: { readonly exitCode: number }) => void) | undefined;
+    const kills: number[] = [];
+    let alive = true;
+    let exit: ((value: { readonly exitCode: number }) => void) | undefined;
     // kill() models node-pty's WindowsTerminal: it ends a live child and drives the conout worker
     // dispose; once the child has exited on its own the native kill is a no-op, so kill() must not
     // report another exit.
-    const fakePty = { onData: () => ({ dispose: () => undefined }), onExit: (listener: (value: { readonly exitCode: number }) => void) => { exit = listener; return { dispose: () => undefined }; }, write: () => undefined, resize: () => undefined, kill: () => { kills.push(kills.length); if (alive) { alive = false; exit?.({ exitCode: 0 }); } } };
-    const host = openTerminalHost({ repoId: "repo-b", rootDir: root, daemonGeneration: 9, platform: "win32", spawnPty: (() => fakePty) as never });
-    const spawned = host.spawn({ idempotencyKey: "self-exit", backend: "direct-pty", cwd: { scope: "repo-root" }, shellProfileId: "default", name: "Self exit" });
+    const fakePty = {
+      onData: () => ({ dispose: () => undefined }),
+      onExit: (listener: (value: { readonly exitCode: number }) => void) => {
+        exit = listener;
+        return { dispose: () => undefined };
+      },
+      write: () => undefined,
+      resize: () => undefined,
+      kill: () => {
+        kills.push(kills.length);
+        if (alive) {
+          alive = false;
+          exit?.({ exitCode: 0 });
+        }
+      },
+    };
+    const host = openTerminalHost({
+      repoId: "repo-b",
+      rootDir: root,
+      daemonGeneration: 9,
+      platform: "win32",
+      spawnPty: (() => fakePty) as never,
+    });
+    const spawned = host.spawn({
+      idempotencyKey: "self-exit",
+      backend: "direct-pty",
+      cwd: { scope: "repo-root" },
+      shellProfileId: "default",
+      name: "Self exit",
+    });
     assert.equal(spawned.ok, true);
-    alive = false; exit?.({ exitCode: 3 });
+    alive = false;
+    exit?.({ exitCode: 3 });
     assert.deepEqual(kills, [0], "natural exit must release the pty exactly once");
-    const listed = JSON.stringify(host.list()); assert.match(listed, /"status":"exited"/u); assert.match(listed, /"exitCode":3/u);
-    const attached = host.attach(spawned.sessionId!, 0); const frame = await attached.next(); assert.equal(frame?.kind, "exit");
-    assert.throws(() => host.input({ sessionId: spawned.sessionId!, clientSeq: 1, utf8: "x" }), /Terminal session has exited\./u);
+    const listed = JSON.stringify(host.list());
+    assert.match(listed, /"status":"exited"/u);
+    assert.match(listed, /"exitCode":3/u);
+    const attached = host.attach(spawned.sessionId!, 0);
+    const frame = await attached.next();
+    assert.equal(frame?.kind, "exit");
+    assert.throws(
+      () => host.input({ sessionId: spawned.sessionId!, clientSeq: 1, utf8: "x" }),
+      /Terminal session has exited\./u,
+    );
     assert.equal(host.terminate({ sessionId: spawned.sessionId!, confirmed: true }).state, "exited");
     await host.close();
     assert.deepEqual(kills, [0], "terminate and close after a natural exit must not kill again");
-  } finally { rmSync(root, { recursive: true, force: true }); }
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
 });
 
 test("a terminal child that exits on its own is not killed again on posix", async () => {
   const root = mkdtempSync(path.join(tmpdir(), "ha-terminal-selfexit-posix-"));
   try {
-    const kills: number[] = []; let exit: ((value: { readonly exitCode: number }) => void) | undefined;
-    const fakePty = { onData: () => ({ dispose: () => undefined }), onExit: (listener: (value: { readonly exitCode: number }) => void) => { exit = listener; return { dispose: () => undefined }; }, write: () => undefined, resize: () => undefined, kill: () => { kills.push(kills.length); } };
-    const host = openTerminalHost({ repoId: "repo-c", rootDir: root, daemonGeneration: 10, platform: "darwin", spawnPty: (() => fakePty) as never });
-    const spawned = host.spawn({ idempotencyKey: "self-exit", backend: "direct-pty", cwd: { scope: "repo-root" }, shellProfileId: "default", name: "Self exit" });
+    const kills: number[] = [];
+    let exit: ((value: { readonly exitCode: number }) => void) | undefined;
+    const fakePty = {
+      onData: () => ({ dispose: () => undefined }),
+      onExit: (listener: (value: { readonly exitCode: number }) => void) => {
+        exit = listener;
+        return { dispose: () => undefined };
+      },
+      write: () => undefined,
+      resize: () => undefined,
+      kill: () => {
+        kills.push(kills.length);
+      },
+    };
+    const host = openTerminalHost({
+      repoId: "repo-c",
+      rootDir: root,
+      daemonGeneration: 10,
+      platform: "darwin",
+      spawnPty: (() => fakePty) as never,
+    });
+    const spawned = host.spawn({
+      idempotencyKey: "self-exit",
+      backend: "direct-pty",
+      cwd: { scope: "repo-root" },
+      shellProfileId: "default",
+      name: "Self exit",
+    });
     assert.equal(spawned.ok, true);
     exit?.({ exitCode: 0 });
     assert.deepEqual(kills, [], "posix exits release the pty on their own; no post-exit signal");
     assert.equal(host.terminate({ sessionId: spawned.sessionId!, confirmed: true }).state, "exited");
     await host.close();
     assert.deepEqual(kills, []);
-  } finally { rmSync(root, { recursive: true, force: true }); }
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
 });
 
 test("closing a running windows terminal does not kill it twice", async () => {
   const root = mkdtempSync(path.join(tmpdir(), "ha-terminal-close-running-"));
   try {
-    const kills: number[] = []; let exit: ((value: { readonly exitCode: number }) => void) | undefined;
-    const fakePty = { onData: () => ({ dispose: () => undefined }), onExit: (listener: (value: { readonly exitCode: number }) => void) => { exit = listener; return { dispose: () => undefined }; }, write: () => undefined, resize: () => undefined, kill: () => { kills.push(kills.length); exit?.({ exitCode: 137 }); } };
-    const host = openTerminalHost({ repoId: "repo-d", rootDir: root, daemonGeneration: 11, platform: "win32", spawnPty: (() => fakePty) as never });
-    const spawned = host.spawn({ idempotencyKey: "close-running", backend: "direct-pty", cwd: { scope: "repo-root" }, shellProfileId: "default", name: "Close running" });
+    const kills: number[] = [];
+    let exit: ((value: { readonly exitCode: number }) => void) | undefined;
+    const fakePty = {
+      onData: () => ({ dispose: () => undefined }),
+      onExit: (listener: (value: { readonly exitCode: number }) => void) => {
+        exit = listener;
+        return { dispose: () => undefined };
+      },
+      write: () => undefined,
+      resize: () => undefined,
+      kill: () => {
+        kills.push(kills.length);
+        exit?.({ exitCode: 137 });
+      },
+    };
+    const host = openTerminalHost({
+      repoId: "repo-d",
+      rootDir: root,
+      daemonGeneration: 11,
+      platform: "win32",
+      spawnPty: (() => fakePty) as never,
+    });
+    const spawned = host.spawn({
+      idempotencyKey: "close-running",
+      backend: "direct-pty",
+      cwd: { scope: "repo-root" },
+      shellProfileId: "default",
+      name: "Close running",
+    });
     assert.equal(spawned.ok, true);
     await host.close();
     assert.deepEqual(kills, [0], "close must release the pty exactly once");
-  } finally { rmSync(root, { recursive: true, force: true }); }
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
 });
 
 test("selecting TMUX spawns its exact command and confirmed terminate kills the durable session", async () => {
-  const root = mkdtempSync(path.join(tmpdir(), "ha-terminal-tmux-command-")), live = new Set<string>(), launches: RecordedLaunch[] = [], killed: string[] = [];
+  const root = mkdtempSync(path.join(tmpdir(), "ha-terminal-tmux-command-")),
+    live = new Set<string>(),
+    launches: RecordedLaunch[] = [],
+    killed: string[] = [];
   try {
-    const controller = fakeTmuxController(live, killed), host = openTerminalHost({ repoId: "repo-tmux", rootDir: root, daemonGeneration: 12, tmux: controller, spawnPty: recordingPtySpawner(launches, live) });
-    const spawned = host.spawn({ idempotencyKey: "tmux-exact", backend: "tmux", cwd: { scope: "repo-root" }, shellProfileId: "zsh", name: "Durable" });
+    const controller = fakeTmuxController(live, killed),
+      host = openTerminalHost({
+        repoId: "repo-tmux",
+        rootDir: root,
+        daemonGeneration: 12,
+        tmux: controller,
+        spawnPty: recordingPtySpawner(launches, live),
+        resolveTerminalEnvironment: () => ({ LANG: "en_US.UTF-8", TERM: "xterm-256color" }),
+      });
+    const spawned = host.spawn({
+      idempotencyKey: "tmux-exact",
+      backend: "tmux",
+      cwd: { scope: "repo-root" },
+      shellProfileId: "zsh",
+      name: "Durable",
+    });
     assert.equal(spawned.state, "running");
     const namespace = Array.isArray(launches[0]?.args) ? String(launches[0].args[4]) : "";
-    assert.deepEqual(launches[0], { file: "/test/tmux", args: ["-u", "new-session", "-A", "-s", namespace, "-c", root, "/bin/zsh"], cwd: root });
+    assert.deepEqual(launches[0], {
+      file: "/test/tmux",
+      args: [
+        "-u",
+        "new-session",
+        "-A",
+        "-s",
+        namespace,
+        "-c",
+        root,
+        "-e",
+        "LANG=en_US.UTF-8",
+        "-e",
+        "TERM=xterm-256color",
+        "/bin/zsh",
+      ],
+      cwd: root,
+    });
     const row = terminalRows(host)[0];
-    assert.deepEqual(row && { requestedBackend: row.requestedBackend, backend: row.backend, durability: row.durability, warning: row.warning, attachable: row.attachable }, { requestedBackend: "tmux", backend: "tmux", durability: "daemon-restart", warning: null, attachable: true });
+    assert.deepEqual(
+      row && {
+        requestedBackend: row.requestedBackend,
+        backend: row.backend,
+        durability: row.durability,
+        warning: row.warning,
+        attachable: row.attachable,
+      },
+      { requestedBackend: "tmux", backend: "tmux", durability: "daemon-restart", warning: null, attachable: true },
+    );
     assert.equal(host.terminate({ sessionId: spawned.sessionId!, confirmed: true }).state, "exited");
-    assert.deepEqual(killed, [namespace]); assert.equal(live.size, 0);
+    assert.deepEqual(killed, [namespace]);
+    assert.equal(live.size, 0);
     await host.close();
-  } finally { rmSync(root, { recursive: true, force: true }); }
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
 });
 
 test("an unavailable TMUX request visibly falls back to direct PTY", async () => {
-  const root = mkdtempSync(path.join(tmpdir(), "ha-terminal-tmux-fallback-")), launches: RecordedLaunch[] = [];
+  const root = mkdtempSync(path.join(tmpdir(), "ha-terminal-tmux-fallback-")),
+    launches: RecordedLaunch[] = [];
   try {
-    const unavailable: TmuxController = { probe: () => ({ available: false, reason: "fixture unavailable" }), hasSession: () => false, killSession: () => { throw new Error("unexpected kill"); } };
-    const host = openTerminalHost({ repoId: "repo-fallback", rootDir: root, daemonGeneration: 13, tmux: unavailable, spawnPty: recordingPtySpawner(launches) });
-    host.spawn({ idempotencyKey: "tmux-fallback", backend: "tmux", cwd: { scope: "repo-root" }, shellProfileId: "bash", name: "Fallback" });
-    assert.equal(launches[0]?.file, "/bin/bash"); assert.deepEqual(launches[0]?.args, []);
+    const unavailable: TmuxController = {
+      probe: () => ({ available: false, reason: "fixture unavailable" }),
+      hasSession: () => false,
+      killSession: () => {
+        throw new Error("unexpected kill");
+      },
+    };
+    const host = openTerminalHost({
+      repoId: "repo-fallback",
+      rootDir: root,
+      daemonGeneration: 13,
+      tmux: unavailable,
+      spawnPty: recordingPtySpawner(launches),
+    });
+    host.spawn({
+      idempotencyKey: "tmux-fallback",
+      backend: "tmux",
+      cwd: { scope: "repo-root" },
+      shellProfileId: "bash",
+      name: "Fallback",
+    });
+    assert.equal(launches[0]?.file, "/bin/bash");
+    assert.deepEqual(launches[0]?.args, []);
     const row = terminalRows(host)[0];
-    assert.deepEqual(row && { requestedBackend: row.requestedBackend, backend: row.backend, durability: row.durability, warning: row.warning }, { requestedBackend: "tmux", backend: "direct-pty", durability: "daemon-process", warning: "tmux-unavailable" });
-    assert.equal(existsSync(path.join(root, ".harness", "generated", "terminal-sessions.json")), false, "fallback direct PTY must not claim durable registry state");
+    assert.deepEqual(
+      row && {
+        requestedBackend: row.requestedBackend,
+        backend: row.backend,
+        durability: row.durability,
+        warning: row.warning,
+      },
+      { requestedBackend: "tmux", backend: "direct-pty", durability: "daemon-process", warning: "tmux-unavailable" },
+    );
+    assert.equal(
+      existsSync(path.join(root, ".harness", "generated", "terminal-sessions.json")),
+      false,
+      "fallback direct PTY must not claim durable registry state",
+    );
     await host.close();
-  } finally { rmSync(root, { recursive: true, force: true }); }
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
 });
 
 test("a TMUX registry restores a live session and attach uses the existing namespace", async () => {
-  const root = mkdtempSync(path.join(tmpdir(), "ha-terminal-tmux-restore-")), live = new Set<string>(), killed: string[] = [], firstLaunches: RecordedLaunch[] = [], restoredLaunches: RecordedLaunch[] = [], registry = path.join(root, ".harness", "generated", "terminal-sessions.json");
+  const root = mkdtempSync(path.join(tmpdir(), "ha-terminal-tmux-restore-")),
+    live = new Set<string>(),
+    killed: string[] = [],
+    firstLaunches: RecordedLaunch[] = [],
+    restoredLaunches: RecordedLaunch[] = [],
+    registry = path.join(root, ".harness", "generated", "terminal-sessions.json");
   try {
-    const controller = fakeTmuxController(live, killed), first = openTerminalHost({ repoId: "repo-restore", rootDir: root, daemonGeneration: 14, tmux: controller, spawnPty: recordingPtySpawner(firstLaunches, live) });
-    const spawned = first.spawn({ idempotencyKey: "tmux-restore", backend: "tmux", cwd: { scope: "repo-root" }, shellProfileId: "zsh", name: "Restore me" }), namespace = Array.isArray(firstLaunches[0]?.args) ? String(firstLaunches[0].args[4]) : "";
-    assert.equal(live.has(namespace), true); await first.close(); assert.equal(live.has(namespace), true, "daemon close must leave the TMUX server alive");
-    assert.equal(statSync(registry).mode & 0o777, 0o600); assert.doesNotMatch(readFileSync(registry, "utf8"), /"(?:env|PATH|HOME|TERM|output)"/iu);
+    const controller = fakeTmuxController(live, killed),
+      first = openTerminalHost({
+        repoId: "repo-restore",
+        rootDir: root,
+        daemonGeneration: 14,
+        tmux: controller,
+        spawnPty: recordingPtySpawner(firstLaunches, live),
+      });
+    const spawned = first.spawn({
+        idempotencyKey: "tmux-restore",
+        backend: "tmux",
+        cwd: { scope: "repo-root" },
+        shellProfileId: "zsh",
+        name: "Restore me",
+      }),
+      namespace = Array.isArray(firstLaunches[0]?.args) ? String(firstLaunches[0].args[4]) : "";
+    assert.equal(live.has(namespace), true);
+    await first.close();
+    assert.equal(live.has(namespace), true, "daemon close must leave the TMUX server alive");
+    assert.equal(statSync(registry).mode & 0o777, 0o600);
+    assert.doesNotMatch(readFileSync(registry, "utf8"), /"(?:env|PATH|HOME|TERM|output)"/iu);
 
-    const restored = openTerminalHost({ repoId: "repo-restore", rootDir: root, daemonGeneration: 15, tmux: controller, spawnPty: recordingPtySpawner(restoredLaunches, live) }), row = terminalRows(restored)[0];
-    assert.deepEqual(row && { sessionId: row.sessionId, status: row.status, backend: row.backend, attachable: row.attachable }, { sessionId: spawned.sessionId, status: "running", backend: "tmux", attachable: true });
-    const attachment = restored.attach(spawned.sessionId!, 0); assert.deepEqual(restoredLaunches[0], { file: "/test/tmux", args: ["-u", "attach-session", "-t", namespace], cwd: root });
-    assert.equal(restored.detach({ sessionId: spawned.sessionId!, attachmentId: attachment.initial.attachmentId as string }).state, "detached");
-    restored.terminate({ sessionId: spawned.sessionId!, confirmed: true }); assert.equal(live.has(namespace), false); assert.deepEqual(JSON.parse(readFileSync(registry, "utf8")).sessions, []);
+    const restored = openTerminalHost({
+        repoId: "repo-restore",
+        rootDir: root,
+        daemonGeneration: 15,
+        tmux: controller,
+        spawnPty: recordingPtySpawner(restoredLaunches, live),
+      }),
+      row = terminalRows(restored)[0];
+    assert.deepEqual(
+      row && { sessionId: row.sessionId, status: row.status, backend: row.backend, attachable: row.attachable },
+      { sessionId: spawned.sessionId, status: "running", backend: "tmux", attachable: true },
+    );
+    const attachment = restored.attach(spawned.sessionId!, 0);
+    assert.deepEqual(restoredLaunches[0], {
+      file: "/test/tmux",
+      args: ["-u", "attach-session", "-t", namespace],
+      cwd: root,
+    });
+    assert.equal(
+      restored.detach({ sessionId: spawned.sessionId!, attachmentId: attachment.initial.attachmentId as string }).state,
+      "detached",
+    );
+    restored.terminate({ sessionId: spawned.sessionId!, confirmed: true });
+    assert.equal(live.has(namespace), false);
+    assert.deepEqual(JSON.parse(readFileSync(registry, "utf8")).sessions, []);
     await restored.close();
-  } finally { rmSync(root, { recursive: true, force: true }); }
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
 });
 
-interface RecordedLaunch { readonly file: string; readonly args: readonly string[] | string; readonly cwd: unknown }
-function recordingPtySpawner(launches: RecordedLaunch[], live?: Set<string>): never {
+interface RecordedLaunch {
+  readonly file: string;
+  readonly args: readonly string[] | string;
+  readonly cwd: unknown;
+  readonly env?: unknown;
+}
+function recordingPtySpawner(launches: RecordedLaunch[], live?: Set<string>, recordEnvironment = false): never {
   return ((file: string, args: readonly string[] | string, options: Record<string, unknown>) => {
-    const argv = typeof args === "string" ? args : [...args]; launches.push({ file, args: argv, cwd: options.cwd });
+    const argv = typeof args === "string" ? args : [...args];
+    launches.push({ file, args: argv, cwd: options.cwd, ...(recordEnvironment ? { env: options.env } : {}) });
     if (Array.isArray(argv) && argv.includes("new-session")) live?.add(String(argv[4]));
     let exit: ((value: { readonly exitCode: number }) => void) | undefined;
-    return { onData: () => ({ dispose: () => undefined }), onExit: (listener: (value: { readonly exitCode: number }) => void) => { exit = listener; return { dispose: () => undefined }; }, write: () => undefined, resize: () => undefined, kill: () => { exit?.({ exitCode: 0 }); } };
+    return {
+      onData: () => ({ dispose: () => undefined }),
+      onExit: (listener: (value: { readonly exitCode: number }) => void) => {
+        exit = listener;
+        return { dispose: () => undefined };
+      },
+      write: () => undefined,
+      resize: () => undefined,
+      kill: () => {
+        exit?.({ exitCode: 0 });
+      },
+    };
   }) as never;
 }
-function fakeTmuxController(live: Set<string>, killed: string[]): TmuxController { return { probe: () => ({ available: true, executable: "/test/tmux", version: "tmux test" }), hasSession: (_executable, namespace) => live.has(namespace), killSession: (_executable, namespace) => { if (!live.delete(namespace)) throw new Error("tmux session is unavailable"); killed.push(namespace); } }; }
-function terminalRows(host: ReturnType<typeof openTerminalHost>): readonly Record<string, unknown>[] { return (host.list().sessions ?? []) as readonly Record<string, unknown>[]; }
+function fakeTmuxController(live: Set<string>, killed: string[]): TmuxController {
+  return {
+    probe: () => ({ available: true, executable: "/test/tmux", version: "tmux test" }),
+    hasSession: (_executable, namespace) => live.has(namespace),
+    killSession: (_executable, namespace) => {
+      if (!live.delete(namespace)) throw new Error("tmux session is unavailable");
+      killed.push(namespace);
+    },
+  };
+}
+function terminalRows(host: ReturnType<typeof openTerminalHost>): readonly Record<string, unknown>[] {
+  return (host.list().sessions ?? []) as readonly Record<string, unknown>[];
+}


### PR DESCRIPTION
# English

## Summary

GUI terminals ran with a six-key environment (`TERM/PATH/HOME/LANG/LC_ALL/TMPDIR`) copied from whatever process happened to autostart the daemon. On this machine that daemon was started by a Claude Code session, so its environment carried that session's variables and had no `LANG` at all. Two user-visible symptoms followed: CLIs that are logged in inside the user's own terminal appear logged out in the GUI terminal, and pasted Chinese renders as `<0080>`–`<009c>` because the locale degrades to C and UTF-8 bytes are handled one at a time as latin-1.

Terminals now take their environment from a snapshot of the user's login shell captured in a minimal environment, so the result depends only on the user's shell configuration and not on who started the daemon.

## Architectural Justification

Not required (production churn is +104/-9, well under the thresholds).

## What Changed

- New `packages/daemon/src/terminal-environment.ts`: captures `/usr/bin/env -i <shell> -l -i -c "env -0"` with a 4s timeout, parses the NUL-separated output, caches per shell path, and overlays an enumerated set of session-channel keys.
- The six session-channel keys (`SSH_AUTH_SOCK`, `TMPDIR`, `HOME`, `USER`, `LOGNAME`, `__CF_USER_TEXT_ENCODING`) are provided by the macOS session layer rather than rebuilt by shell profiles. Each carries a comment naming the degradation it prevents; losing `SSH_AUTH_SOCK`, for instance, silently breaks every ssh-agent path in the terminal.
- `terminal-host.ts`: direct-pty spawns use the snapshot; the old `terminalEnvironment()` allowlist is gone from this module. tmux sessions get the same values through repeated `new-session -e KEY=VALUE`, because a long-lived tmux server otherwise hands the child whatever the server itself was started with.
- A failed capture warns and returns the restricted key set **without caching it**, so one transient timeout cannot pin the daemon to the degraded environment for the rest of its life.
- Windows keeps its previous behaviour, including `SystemRoot`.
- No local `errorMessage` helper: `check-duplicate-definitions` rejects a second daemon-local copy alongside the one in `schedule-scheduler.ts`, and the single call site is inlined rather than lifted into a new shared module for three lines.
- The 17-key deletion list in `cliDaemonServeLaunch` is deliberately untouched. It protects runtime-instance credential isolation and points the opposite way from this change; the two lists are independent and must not be derived from each other.

- **Second defect, found by CEO acceptance after the worker's delivery.** The login-shell snapshot is not the authority on locale: this machine's login profiles produce `LANG=C.UTF-8` while the user's own terminal runs `en_US.UTF-8`, because terminal applications inject the locale rather than exporting it from a profile. Reading only the snapshot handed the GUI terminal a locale the user never chose. `LANG`, `LC_ALL` and `LC_CTYPE` now join the enumerated session channels, so the daemon's own locale wins where it has one and the snapshot still covers the rest.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: use the single CI-backed `Production-Delta` declaration below; do not enter a second metric.

## Machine-Readable Declarations

Production-Delta: +107/-9

## Task And Scope

- Harness task: task_cb3aa93faf57c17671feb7cc04
- Branch: codex/gui-terminal-env-inheritance
- Public scope: packages/daemon terminal environment and its tests
- Private planning/evidence updated: yes
- Out of scope: the clipboard/copy work (task_effa2739faedb45f0920ddfbfe), and the runtime dispatch PATH/node-version problem (task_d74688df83ffcaa05dfdd9e5d1)

## Version Impact

- Version: no version change because this is an internal daemon behaviour fix with no package surface change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: not applicable
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no

## Verification

- Base `origin/main` SHA: 667b0c361 (rebased onto it)
- Branch merge-base with `origin/main`: 667b0c361
- Last `git fetch origin` time: 2026-09-04, immediately before pushing
- Sync method: none needed
- Public diff command: `git diff origin/main...codex/gui-terminal-env-inheritance`
- Private evidence commit/path: `harness/tasks/task_cb3aa93faf57c17671feb7cc04-gui-terminal-env-inheritance/artifacts/`
- Reviewer evidence path: same directory (`root-cause.md`, `decision-env-snapshot-body.md`)
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- Not run: the full local matrix. Per repository policy the complete gate matrix is GitHub CI's job, not this machine's. Targeted runs instead:
  - `node tools/run-node-tests.mjs --file packages/daemon/test/terminal-environment.test.ts` → 5 pass / 0 fail
  - `node tools/run-node-tests.mjs --file packages/daemon/test/terminal-host.integration.test.ts` → 8 pass / 2 fail
  - `node tools/check-import-boundaries.mjs` → passed, current=3 previous=3 delta=0
- **The 2 failures are pre-existing on `origin/main`, with a negative control**: the same file on `origin/main` gives 7 pass / 2 fail, failing the same two tmux tests for the same reason (`/var` vs `/private/var`; macOS resolves the tmpdir symlink). This branch's own new test hit the same platform assumption and was fixed here; the two inherited ones are left to their own task rather than widening this scope.

- Locale regression test with a negative control: `terminal environment prefers the session locale over the one login profiles produce` — 6 passed with the fix; removing the `LANG` key alone turns exactly that test red (5 passed, 1 failed) and restoring it returns to 6.
- Measured on this machine before the fix: `/usr/bin/env -i /bin/zsh -l -i -c 'env -0'` yields `LANG=C.UTF-8`, the user's terminal reports `LANG=en_US.UTF-8`, and the running daemon reports `LANG=en_US.UTF-8`.

## Review Evidence

- Self-review: CEO read the full implementation and found two defects, both fixed in this branch — the cached fallback (a transient failure pinned the daemon to the degraded environment permanently) and the new test's tmpdir symlink assumption.
- Reviewer subagent: none
- Human review: pending
- Blocking findings: none outstanding

## Residual Risk

- **The GUI acceptance has not been performed.** Nobody has yet opened an Electron window and checked that `echo "$LANG"` has a value, that pasted Chinese renders correctly, and that a CLI logged in inside the user's own terminal is also logged in here. That check needs a human at the GUI and is the real proof this change works.
- tmux injection is implemented and covered by an argv assertion, but has not been exercised against a real long-lived tmux server.
- `-i` (interactive) is passed to the login shell so that `.zshrc` exports are picked up. A shell profile that writes to stdout would corrupt the `env -0` output; parsing rejects malformed entries and falls back, so the failure mode is a degraded environment plus a warning rather than a corrupt one.
- The restricted six-key set survives as the fallback branch inside the new module. It is not a second production implementation — there is one entry point — but it does mean a persistently failing capture silently returns to today's broken behaviour, visible only as a `[terminal-environment]` warning in the daemon log.

## References

- Task: task_cb3aa93faf57c17671feb7cc04
- Evidence: `harness/tasks/task_cb3aa93faf57c17671feb7cc04-gui-terminal-env-inheritance/artifacts/root-cause.md`
- Review: `harness/tasks/task_cb3aa93faf57c17671feb7cc04-gui-terminal-env-inheritance/artifacts/decision-env-snapshot-body.md`

---

# 中文

## 摘要

GUI 终端此前用的是一份六键环境（`TERM/PATH/HOME/LANG/LC_ALL/TMPDIR`），而且是从"碰巧把 daemon 拉起来的那个进程"里复制的。本机上这个 daemon 是被某个 Claude Code 会话启动的，于是它带着那个会话的变量，而 `LANG` 根本不存在。由此产生两个用户可见的症状：在用户自己终端里是登录态的 CLI，在 GUI 终端里显示未登录；粘贴中文变成 `<0080>`–`<009c>`，因为 locale 退化成 C，UTF-8 字节被逐个按 latin-1 处理。

现在终端的环境来自一份"在最小环境下启动用户登录 shell"抓到的快照，结果只取决于用户自己的 shell 配置，与 daemon 由谁启动无关。

## 架构辩护

不需要（生产改动 +104/-9，远低于阈值）。

## 改动内容

- 新增 `packages/daemon/src/terminal-environment.ts`：以 4 秒超时执行 `/usr/bin/env -i <shell> -l -i -c "env -0"`，解析 NUL 分隔输出，按 shell 路径缓存，并叠加一组穷举的 session 通道键。
- 那六个 session 通道键（`SSH_AUTH_SOCK`、`TMPDIR`、`HOME`、`USER`、`LOGNAME`、`__CF_USER_TEXT_ENCODING`）由 macOS session 层提供，而不是由 shell profile 重建。每个键都带注释写明它防止的是哪一种退化——比如丢掉 `SSH_AUTH_SOCK`，终端里所有走 ssh-agent 的路径都会无声地坏掉。
- `terminal-host.ts`：direct-pty 使用快照，本模块里旧的 `terminalEnvironment()` 白名单已删除。tmux 会话通过重复的 `new-session -e KEY=VALUE` 拿到同样的值——否则长驻的 tmux server 只会把它自己启动时的环境交给子进程。
- 抓取失败时打印告警并返回受限键集，**但不缓存**：一次瞬时超时不能把 daemon 在其整个生命周期里钉死在退化环境上。
- Windows 保持原有行为，包括 `SystemRoot`。
- 不再定义本地的 `errorMessage`：`check-duplicate-definitions` 会拒绝 daemon 内与 `schedule-scheduler.ts` 重复的第二份，而它只有一个调用点，因此内联掉，而不是为三行代码新建共享模块。
- `cliDaemonServeLaunch` 的 17 键删除列表**刻意未动**。它保护的是 runtime instance 的凭据隔离，方向与本次改动相反；两份清单相互独立，不得互相派生。

- **第二个缺陷，由 CEO 在 worker 交付后的验收中发现。** login shell 快照不是 locale 的权威：本机 login profile 产出 `LANG=C.UTF-8`，而用户自己的 terminal 是 `en_US.UTF-8`——因为 locale 由终端程序注入，不由 profile 导出。只读快照会给 GUI 终端一个用户从未选择的 locale。现将 `LANG`、`LC_ALL`、`LC_CTYPE` 纳入枚举的会话通道：daemon 自身有 locale 时以它为准，其余仍由快照覆盖。

## 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none

## 任务与范围

- Harness task：task_cb3aa93faf57c17671feb7cc04
- 分支：codex/gui-terminal-env-inheritance
- 公开范围：packages/daemon 的终端环境及其测试
- 私有规划/证据已更新：是
- 不在范围内：复制粘贴那条线（task_effa2739faedb45f0920ddfbfe），以及派工 runtime 的 PATH/node 版本问题（task_d74688df83ffcaa05dfdd9e5d1）

## 版本影响

- 版本：不变，因为这是 daemon 内部行为修复，不改包面
- 发布影响：不发布

## 治理声明

- 是否触碰 protected surface：否
- 范围：不适用
- 授权：不适用
- 机器检查边界：本 PR 只声明该字段存在；其是否为真、是否充分由评审判断。
- Break-glass：否

## 验证

- Base `origin/main` SHA：667b0c361（已 rebase 到它）
- 与 `origin/main` 的 merge-base：667b0c361
- 最近 `git fetch origin` 时间：2026-09-04，push 前刚执行
- 同步方式：无需同步
- 公开 diff 命令：`git diff origin/main...codex/gui-terminal-env-inheritance`
- 私有证据路径：`harness/tasks/task_cb3aa93faf57c17671feb7cc04-gui-terminal-env-inheritance/artifacts/`
- 评审证据路径：同一目录（`root-cause.md`、`decision-env-snapshot-body.md`）
- GitHub Actions `rewrite-ci` run URL：本 PR 开出后产生
- 未运行：本机完整门矩阵。按仓库政策，完整门矩阵是 GitHub CI 的活，不是这台机器的活。改为定向执行：
  - `node tools/run-node-tests.mjs --file packages/daemon/test/terminal-environment.test.ts` → 5 通过 / 0 失败
  - `node tools/run-node-tests.mjs --file packages/daemon/test/terminal-host.integration.test.ts` → 8 通过 / 2 失败
  - `node tools/check-import-boundaries.mjs` → 通过，current=3 previous=3 delta=0
- **那 2 条失败是 `origin/main` 上既有的，并有阴性对照**：同一文件在 `origin/main` 上是 7 通过 / 2 失败，失败的是同样两条 tmux 测试、同样的原因（`/var` 与 `/private/var`；macOS 会解析 tmpdir 的符号链接）。本分支自己新增的那条测试踩了同一个平台假设，已在此修复；继承来的两条留给它们自己的任务，不在本 PR 扩大范围。

- locale 回归测试带阴性对照：`terminal environment prefers the session locale over the one login profiles produce`——带修复时 6 项通过；单独移除 `LANG` 这一个键后恰好该项转红（5 通过 1 失败），还原后回到 6 项通过。
- 修复前本机实测：`/usr/bin/env -i /bin/zsh -l -i -c 'env -0'` 产出 `LANG=C.UTF-8`，用户 terminal 为 `LANG=en_US.UTF-8`，运行中的 daemon 为 `LANG=en_US.UTF-8`。

## 评审证据

- 自审：CEO 通读了完整实现并发现两个缺陷，均已在本分支修复——回退结果被缓存（一次瞬时失败会把 daemon 永久钉在退化环境上），以及新增测试对 tmpdir 符号链接的假设。
- 评审子代理：无
- 人工评审：待进行
- 阻塞性发现：无未决项

## 残留风险

- **GUI 验收尚未进行。** 还没有人打开 Electron 窗口确认 `echo "$LANG"` 有值、粘贴中文正常、以及在用户自己终端里登录的 CLI 在这里同样是登录态。这项检查需要人在 GUI 前操作，它才是这次改动有效的真正证明。
- tmux 注入已实现并有 argv 断言覆盖，但未对真实的长驻 tmux server 实测。
- 传给登录 shell 的 `-i`（交互）是为了读到 `.zshrc` 里的 export。若某个 shell profile 向 stdout 写东西，会污染 `env -0` 的输出；解析对畸形条目会拒绝并回退，所以失败形态是"退化环境 + 告警"，不是"错误环境"。
- 受限六键集作为回退分支保留在新模块内。它不是第二个生产实现（入口只有一个），但确实意味着：持续失败的抓取会无声地回到今天这个坏行为，唯一可见信号是 daemon 日志里的 `[terminal-environment]` 告警。

## 参考

- 任务：task_cb3aa93faf57c17671feb7cc04
- 证据：`harness/tasks/task_cb3aa93faf57c17671feb7cc04-gui-terminal-env-inheritance/artifacts/root-cause.md`
- 评审：`harness/tasks/task_cb3aa93faf57c17671feb7cc04-gui-terminal-env-inheritance/artifacts/decision-env-snapshot-body.md`

