### PR TITLE
fix(runtime): restore sub2api compatibility on latest main

### DIFF
--- a/packages/cli/src/cli/thin-command-runtime-instance-create.ts
+++ b/packages/cli/src/cli/thin-command-runtime-instance-create.ts
@@ -13,6 +13,7 @@ export function parseRuntimeInstanceCreate(
   const authMode = flags.one.get("--auth"),
     credentialRef = flags.one.get("--credential-ref"),
     kindId = flags.one.get("--kind"),
+    credentialHeader = flags.one.get("--credential-header"),
     header = runtimeHttpHeaderFlags(flags.many.get("--http-header") ?? []);
   if (authMode === "api-key" && !credentialRef)
     return rejected("missing_field", "API-key instances require --credential-ref <opaque-ref>.", json);
@@ -26,7 +27,14 @@ export function parseRuntimeInstanceCreate(
   if (hasForeignAdapterOptions(kindId, flags, header.value))
     return rejected("invalid_field", "This runtime kind does not accept options for another adapter.", json);
   const baseUrl = flags.one.get("--base-url"),
-    kindConfig = runtimeInstanceKindConfig(kindId, flags.one, flags.booleans, baseUrl, header.value);
+    kindConfig = runtimeInstanceKindConfig(
+      kindId,
+      flags.one,
+      flags.booleans,
+      baseUrl,
+      header.value,
+      credentialHeader,
+    );
   return accepted(
     rootDir,
     undefined,
@@ -57,14 +65,18 @@ function hasForeignAdapterOptions(
 ): boolean {
   return (
     (kindId === "claude" &&
-      (flags.one.has("--wire-api") ||
+      (flags.booleans.has("--allow-insecure-http") ||
+        flags.one.has("--wire-api") ||
         flags.booleans.has("--requires-openai-auth") ||
+        flags.one.has("--credential-header") ||
         headers !== undefined)) ||
     (kindId === "agy" &&
       (flags.one.has("--base-url") ||
+        flags.booleans.has("--allow-insecure-http") ||
         flags.one.has("--wire-api") ||
         flags.booleans.has("--requires-openai-auth") ||
         headers !== undefined ||
+        flags.one.has("--credential-header") ||
         flags.one.has("--isolation")))
   );
 }
@@ -75,6 +87,7 @@ function runtimeInstanceKindConfig(
   booleans: Set<string>,
   baseUrl: string | undefined,
   headers: Readonly<Record<string, string>> | undefined,
+  credentialHeader: string | undefined,
 ) {
   return kindId === "codex"
     ? {
@@ -82,9 +95,11 @@ function runtimeInstanceKindConfig(
           ...(one.get("--effort") ? { reasoningEffort: one.get("--effort") } : {}),
           ...(booleans.has("--fast") ? { fast: true } : {}),
           ...(baseUrl ? { baseUrl } : {}),
+          ...(booleans.has("--allow-insecure-http") ? { allowInsecureHttp: true } : {}),
           ...(one.get("--wire-api") ? { wireApi: one.get("--wire-api") } : {}),
           ...(booleans.has("--requires-openai-auth") ? { requiresOpenAiAuth: true } : {}),
           ...(headers ? { httpHeaders: headers } : {}),
+          ...(credentialHeader ? { credentialHeader } : {}),
         },
       }
     : kindId === "agy"
@@ -107,7 +122,7 @@ function runtimeHttpHeaderFlags(
   | { readonly ok: true; readonly value?: Readonly<Record<string, string>> }
   | { readonly ok: false; readonly hint: string } {
   if (values.length === 0) return { ok: true };
-  const headers: Record<string, string> = {};
+  const headers: Record<string, string> = {}, normalizedNames = new Set<string>();
   for (const value of values) {
     const separator = value.indexOf("=");
     if (separator < 1 || separator === value.length - 1)
@@ -116,12 +131,14 @@ function runtimeHttpHeaderFlags(
         hint: "Use --http-header Name=Value with a non-secret static header.",
       };
     const name = value.slice(0, separator),
-      item = value.slice(separator + 1);
-    if (Object.hasOwn(headers, name))
+      item = value.slice(separator + 1),
+      normalizedName = name.toLowerCase();
+    if (normalizedNames.has(normalizedName))
       return {
         ok: false,
         hint: `HTTP header ${name} was provided more than once.`,
       };
+    normalizedNames.add(normalizedName);
     headers[name] = item;
   }
   return { ok: true, value: headers };

--- a/packages/cli/test/thin-command.test.ts
+++ b/packages/cli/test/thin-command.test.ts
@@ -535,6 +535,42 @@ test("thin parser derives closed preset and task-create payloads from descriptor
     });
 });
 
+test("runtime instance parser rejects repeated static headers regardless of spelling", () => {
+  const base = [
+    "runtime",
+    "instance",
+    "create",
+    "--id",
+    "codex-headers",
+    "--name",
+    "Codex Headers",
+    "--kind",
+    "codex",
+    "--provider",
+    "sidecar",
+    "--model",
+    "gpt-5.6-sol",
+    "--auth",
+    "api-key",
+    "--credential-ref",
+    "credential:v1:codex-headers",
+  ];
+  const accepted = parseThinCommand([...base, "--http-header", "X-Custom=static"]);
+  assert.equal(accepted.ok, true, JSON.stringify(accepted));
+  if (accepted.ok) assert.deepEqual(accepted.command.action.codex, { httpHeaders: { "X-Custom": "static" } });
+  for (const duplicate of [
+    ["X-Custom=first", "X-Custom=second"],
+    ["X-Custom=first", "x-custom=second"],
+  ]) {
+    const rejected = parseThinCommand([...base, ...duplicate.flatMap((value) => ["--http-header", value])]);
+    assert.equal(rejected.ok, false, JSON.stringify(rejected));
+    if (!rejected.ok) {
+      assert.equal(rejected.code, "invalid_field");
+      assert.match(rejected.nextAction, /HTTP header .* was provided more than once\./u);
+    }
+  }
+});
+
 test("thin parser routes CI observation pulls through the repo task command", () => {
   const parsed = parseThinCommand(["ci", "observe", "pull", "--limit", "20"]);
   assert.equal(parsed.ok, true, JSON.stringify(parsed));

--- a/packages/daemon/src/agent-runtime-contract.ts
+++ b/packages/daemon/src/agent-runtime-contract.ts
@@ -50,9 +50,11 @@ export type AgentRuntimeInstanceDto = AgentRuntimeInstanceCommonDto &
           readonly fast: boolean;
           readonly baseUrl: string | null;
           readonly baseUrlConfigured: boolean;
+          readonly allow_insecure_http?: boolean;
           readonly wire_api: string | null;
           readonly requires_openai_auth: boolean | null;
           readonly http_headers: Readonly<Record<string, string>> | null;
+          readonly credential_header?: string;
         };
       }
     | { readonly kindId: "agy"; readonly agy: { readonly effort: "low" | "medium" | "high" | null } }
@@ -400,15 +402,19 @@ function validClaudeInstanceConfig(value: unknown): boolean {
 function validCodexInstanceConfig(value: unknown): boolean {
   return (
     isAgentRuntimeContractRecord(value) &&
-    hasExactAgentRuntimeContractFields(value, [
-      "reasoningEffort",
-      "fast",
-      "baseUrl",
-      "baseUrlConfigured",
-      "wire_api",
-      "requires_openai_auth",
-      "http_headers",
-    ]) &&
+    hasAgentRuntimeContractFields(
+      value,
+      [
+        "reasoningEffort",
+        "fast",
+        "baseUrl",
+        "baseUrlConfigured",
+        "wire_api",
+        "requires_openai_auth",
+        "http_headers",
+      ],
+      ["allow_insecure_http", "credential_header"],
+    ) &&
     (value.reasoningEffort === null || typeof value.reasoningEffort === "string") &&
     typeof value.fast === "boolean" &&
     (value.baseUrl === null || typeof value.baseUrl === "string") &&
@@ -421,7 +427,9 @@ function validCodexInstanceConfig(value: unknown): boolean {
           ([name, header]) =>
             !/(?:authorization|api[-_]?key|cookie|credential|password|secret|token)/iu.test(name) &&
             typeof header === "string",
-        )))
+        ))) &&
+    (value.credential_header === undefined || typeof value.credential_header === "string") &&
+    (value.allow_insecure_http === undefined || value.allow_insecure_http === true)
   );
 }
 function validAgyInstanceConfig(value: unknown): boolean {

--- a/packages/daemon/src/agent-runtime-instance-config.ts
+++ b/packages/daemon/src/agent-runtime-instance-config.ts
@@ -171,17 +171,42 @@ export function runtimeInstanceConfig(value: unknown): RuntimeInstanceConfig {
       agy: agyRuntimeConfig(flat ? {} : value.agy),
     };
   const codex = codexRuntimeConfig(
-    flat ? { reasoningEffort: value.reasoningEffort, baseUrl: value.baseUrl } : value.codex,
+    flat
+      ? {
+          reasoningEffort: value.reasoningEffort,
+          baseUrl: value.baseUrl,
+          allowInsecureHttp: value.allowInsecureHttp,
+        }
+      : value.codex,
   );
+  if (codex.credentialHeader !== undefined && auth.mode !== "api-key")
+    throw runtimeInstanceError(
+      "invalid_runtime_credential_header",
+      "credentialHeader is available only for API-key runtime instances.",
+    );
+  if (
+    codex.credentialHeader !== undefined &&
+    codex.httpHeaders !== undefined &&
+    Object.keys(codex.httpHeaders).some(
+      (header) => header.toLowerCase() === codex.credentialHeader!.toLowerCase(),
+    )
+  )
+    throw runtimeInstanceError(
+      "invalid_runtime_credential_header",
+      "credentialHeader must not overlap a static HTTP header.",
+    );
   if (
     common.providerId === "openai" &&
-    (codex.wireApi !== undefined || codex.requiresOpenAiAuth !== undefined || codex.httpHeaders !== undefined)
+    (codex.allowInsecureHttp !== undefined ||
+      codex.wireApi !== undefined ||
+      codex.requiresOpenAiAuth !== undefined ||
+      codex.httpHeaders !== undefined ||
+      codex.credentialHeader !== undefined)
   )
     throw runtimeInstanceError(
       "invalid_runtime_kind_config",
       [
-        "The built-in openai provider cannot accept a custom wireApi, ",
-        "requiresOpenAiAuth, or httpHeaders; use a distinct providerId.",
+        "The built-in openai provider cannot accept custom transport or credential options; use a distinct providerId.",
       ].join(""),
     );
   return { ...common, kindId: "codex", codex };
@@ -204,29 +229,51 @@ export function codexRuntimeConfig(value: unknown): CodexRuntimeInstanceConfig {
   if (
     !isRuntimeInstanceRecord(value) ||
     Object.keys(value).some(
-      (key) => !["reasoningEffort", "fast", "baseUrl", "wireApi", "requiresOpenAiAuth", "httpHeaders"].includes(key),
+      (key) =>
+        ![
+          "reasoningEffort",
+          "fast",
+          "baseUrl",
+          "allowInsecureHttp",
+          "wireApi",
+          "requiresOpenAiAuth",
+          "httpHeaders",
+          "credentialHeader",
+        ].includes(key),
     )
   )
     throw runtimeInstanceError(
       "invalid_runtime_kind_config",
-      "codex configuration accepts only reasoningEffort, fast, baseUrl, wireApi, requiresOpenAiAuth, and httpHeaders.",
+      [
+        "codex configuration accepts only reasoningEffort, fast, baseUrl, allowInsecureHttp, ",
+        "wireApi, requiresOpenAiAuth, httpHeaders, and credentialHeader.",
+      ].join(""),
     );
   const effort = value.reasoningEffort === undefined ? undefined : runtimeEffort(value.reasoningEffort),
     fast = value.fast === undefined ? undefined : requireBoolean(value.fast, "fast"),
-    baseUrl = value.baseUrl === undefined ? undefined : secureRuntimeBaseUrl(value.baseUrl),
+    allowInsecureHttp =
+      value.allowInsecureHttp === undefined ? undefined : requireBoolean(value.allowInsecureHttp, "allowInsecureHttp"),
+    baseUrl =
+      value.baseUrl === undefined
+        ? undefined
+        : secureRuntimeBaseUrl(value.baseUrl, { allowInsecureHttp: allowInsecureHttp === true }),
     wireApi = value.wireApi === undefined ? undefined : identifier(value.wireApi, "wireApi"),
     requiresOpenAiAuth =
       value.requiresOpenAiAuth === undefined
         ? undefined
         : requireBoolean(value.requiresOpenAiAuth, "requiresOpenAiAuth"),
-    httpHeaders = value.httpHeaders === undefined ? undefined : runtimeHttpHeaders(value.httpHeaders);
+    httpHeaders = value.httpHeaders === undefined ? undefined : runtimeHttpHeaders(value.httpHeaders),
+    credentialHeader =
+      value.credentialHeader === undefined ? undefined : runtimeCredentialHeader(value.credentialHeader);
   return {
     ...(effort ? { reasoningEffort: effort } : {}),
     ...(fast === undefined ? {} : { fast }),
     ...(baseUrl ? { baseUrl } : {}),
+    ...(allowInsecureHttp ? { allowInsecureHttp } : {}),
     ...(wireApi ? { wireApi } : {}),
     ...(requiresOpenAiAuth === undefined ? {} : { requiresOpenAiAuth }),
     ...(httpHeaders ? { httpHeaders } : {}),
+    ...(credentialHeader ? { credentialHeader } : {}),
   };
 }
 
@@ -243,22 +290,35 @@ export function runtimeHttpHeaders(value: unknown): Readonly<Record<string, stri
       "invalid_runtime_http_headers",
       "httpHeaders must be a non-empty object of non-secret HTTP headers.",
     );
-  const result: Record<string, string> = {};
+  const result: Record<string, string> = {}, normalizedNames = new Set<string>();
   for (const [name, item] of Object.entries(value)) {
+    const normalizedName = name.toLowerCase();
     if (
       !/^[!#$%&'*+.^_`|~0-9A-Za-z-]+$/u.test(name) ||
       /(?:authorization|api[-_]?key|cookie|credential|password|secret|token)/iu.test(name) ||
       typeof item !== "string" ||
       !item ||
-      /[\r\n]/u.test(item)
+      /[\r\n]/u.test(item) ||
+      normalizedNames.has(normalizedName)
     )
       throw runtimeInstanceError(
         "invalid_runtime_http_headers",
         "httpHeaders must contain valid non-secret header names and single-line values.",
       );
+    normalizedNames.add(normalizedName);
     result[name] = item;
   }
   return result;
+}
+
+export function runtimeCredentialHeader(value: unknown): string {
+  const name = typeof value === "string" ? value.trim() : "";
+  if (!/^[!#$%&'*+.^_`|~0-9A-Za-z-]+$/u.test(name))
+    throw runtimeInstanceError(
+      "invalid_runtime_credential_header",
+      "credentialHeader must be a valid HTTP header name.",
+    );
+  return name;
 }
 
 export function needsRuntimeInstanceNormalization(value: unknown): boolean {

--- a/packages/daemon/src/agent-runtime-instance-storage.ts
+++ b/packages/daemon/src/agent-runtime-instance-storage.ts
@@ -162,9 +162,13 @@ export function publicConfig(
         fast: config.codex.fast ?? false,
         baseUrl: config.codex.baseUrl ?? null,
         baseUrlConfigured: config.codex.baseUrl !== undefined,
+        ...(config.codex.allowInsecureHttp ? { allow_insecure_http: true } : {}),
         wire_api: config.codex.wireApi ?? null,
         requires_openai_auth: config.codex.requiresOpenAiAuth ?? null,
         http_headers: config.codex.httpHeaders ?? null,
+        ...(config.codex.credentialHeader === undefined
+          ? {}
+          : { credential_header: config.codex.credentialHeader }),
       },
     };
   return {
@@ -270,6 +274,10 @@ export function writeCodexConfig(
   bearerToken?: string,
 ): void {
   const provider = config.codex,
+    headers =
+      bearerToken && provider.credentialHeader
+        ? { ...(provider.httpHeaders ?? {}), [provider.credentialHeader]: bearerToken }
+        : provider.httpHeaders,
     lines = [
       `model_provider = ${tomlString(config.providerId)}`,
       ...(provider.reasoningEffort ? [`model_reasoning_effort = ${tomlString(provider.reasoningEffort)}`] : []),
@@ -281,12 +289,16 @@ export function writeCodexConfig(
       `name = ${tomlString(config.providerId)}`,
       ...(provider.baseUrl ? [`base_url = ${tomlString(provider.baseUrl)}`] : []),
       ...(provider.wireApi ? [`wire_api = ${tomlString(provider.wireApi)}`] : []),
-      ...(provider.requiresOpenAiAuth === undefined ? [] : [`requires_openai_auth = ${provider.requiresOpenAiAuth}`]),
-      ...(provider.httpHeaders
+      ...(provider.requiresOpenAiAuth === undefined && config.providerId !== "openai"
+        ? ["requires_openai_auth = false"]
+        : provider.requiresOpenAiAuth === undefined
+          ? []
+          : [`requires_openai_auth = ${provider.requiresOpenAiAuth}`]),
+      ...(headers
         ? [
             [
               "http_headers = { ",
-              `${Object.entries(provider.httpHeaders)
+              `${Object.entries(headers)
                 .sort(([a], [b]) => a.localeCompare(b))
                 .map(([key, value]) => `${tomlString(key)} = ${tomlString(value)}`)
                 .join(", ")}`,
@@ -294,7 +306,9 @@ export function writeCodexConfig(
             ].join(""),
           ]
         : []),
-      ...(bearerToken ? [`experimental_bearer_token = ${tomlString(bearerToken)}`] : []),
+      ...(bearerToken && !provider.credentialHeader
+        ? [`experimental_bearer_token = ${tomlString(bearerToken)}`]
+        : []),
     );
   const temp = `${target}.${process.pid}.tmp`;
   // The leftover of a failed write here is a 0600 config carrying the broker bearer token,

--- a/packages/daemon/src/agent-runtime-instance-store.ts
+++ b/packages/daemon/src/agent-runtime-instance-store.ts
@@ -291,7 +291,8 @@ export function openRuntimeInstanceStore(input: {
     }
     if (config.kindId === "codex") {
       const configPath = path.join(env.CODEX_HOME!, "config.toml");
-      if (!codexConfigHasBearer(configPath)) writeCodexConfig(configPath, config, secret);
+      if (!codexConfigHasBearer(configPath) || config.codex.credentialHeader !== undefined)
+        writeCodexConfig(configPath, config, secret);
     } else env.ANTHROPIC_API_KEY = secret;
     rememberAuthReadiness(config.instanceId, available());
     return {

--- a/packages/daemon/src/agent-runtime-instance-types.ts
+++ b/packages/daemon/src/agent-runtime-instance-types.ts
@@ -33,9 +33,12 @@ export interface CodexRuntimeInstanceConfig {
   readonly reasoningEffort?: string;
   readonly fast?: boolean;
   readonly baseUrl?: string;
+  readonly allowInsecureHttp?: boolean;
   readonly wireApi?: string;
   readonly requiresOpenAiAuth?: boolean;
   readonly httpHeaders?: Readonly<Record<string, string>>;
+  /** Header name receiving the resolved API-key credential at launch time. */
+  readonly credentialHeader?: string;
 }
 
 export interface AgyRuntimeInstanceConfig {

--- a/packages/daemon/src/agent-runtime-launch-config.ts
+++ b/packages/daemon/src/agent-runtime-launch-config.ts
@@ -160,7 +160,10 @@ export function credentialHint(error: unknown): string {
     : credentialUnavailableHint;
 }
 
-export function secureRuntimeBaseUrl(value: unknown): string {
+export function secureRuntimeBaseUrl(
+  value: unknown,
+  options: { readonly allowInsecureHttp?: boolean } = {},
+): string {
   const text = requiredRuntimeInstanceText(value, "baseUrl");
   let parsed: URL;
   try {
@@ -174,11 +177,30 @@ export function secureRuntimeBaseUrl(value: unknown): string {
     parsed.search ||
     parsed.hash ||
     (parsed.protocol !== "https:" &&
-      !(parsed.protocol === "http:" && ["127.0.0.1", "::1", "localhost"].includes(parsed.hostname)))
+      !(parsed.protocol === "http:" && ["127.0.0.1", "::1", "localhost"].includes(parsed.hostname)) &&
+      !(
+        parsed.protocol === "http:" &&
+        options.allowInsecureHttp === true &&
+        isPrivateIpv4(parsed.hostname)
+      ))
   )
     throw runtimeInstanceError(
       "invalid_base_url",
-      "baseUrl must use HTTPS or loopback HTTP and cannot contain credentials, query, or fragment.",
+      [
+        "baseUrl must use HTTPS or loopback HTTP; private HTTP requires explicit ",
+        "allowInsecureHttp, and credentials, query, and fragments are forbidden.",
+      ].join(""),
     );
   return parsed.toString();
+}
+
+function isPrivateIpv4(hostname: string): boolean {
+  const octets = hostname.split(".").map(Number);
+  if (
+    octets.length !== 4 ||
+    octets.some((octet) => !Number.isInteger(octet) || octet < 0 || octet > 255)
+  )
+    return false;
+  const [first, second] = octets;
+  return first === 10 || (first === 192 && second === 168) || (first === 172 && second >= 16 && second <= 31);
 }

--- a/packages/daemon/src/protocol/daemon-protocol-commands-runtime-config.ts
+++ b/packages/daemon/src/protocol/daemon-protocol-commands-runtime-config.ts
@@ -256,6 +256,9 @@ export const runtimeConfigProtocolCommands = Object.freeze([
       cliInput("--base-url", "single", false, {
         code: "invalid_field",
       }),
+      cliInput("--allow-insecure-http", "boolean", false, {
+        code: "invalid_field",
+      }),
       cliInput("--wire-api", "single", false, {
         code: "invalid_field",
       }),
@@ -263,6 +266,9 @@ export const runtimeConfigProtocolCommands = Object.freeze([
         code: "invalid_field",
       }),
       cliInput("--http-header", "repeated", false, {
+        code: "invalid_field",
+      }),
+      cliInput("--credential-header", "single", false, {
         code: "invalid_field",
       }),
       cliInput(

--- a/packages/daemon/test/agent-runtime-instances.test.ts
+++ b/packages/daemon/test/agent-runtime-instances.test.ts
@@ -6,6 +6,7 @@ import path from "node:path";
 import test from "node:test";
 import { parseThinCommand } from "../../cli/src/cli/thin-command.ts";
 import { credentialPort, runCredentialCommand } from "../src/agent-runtime-credential-port.ts";
+import { runtimeHttpHeaders } from "../src/agent-runtime-instance-config.ts";
 import { discoverRuntimeInstallations, openRuntimeInstanceStore, type RuntimeAuthReadiness, type RuntimeInstallationWitness } from "../src/agent-runtime-instances.ts";
 import { ensureSharedAuthFile } from "../src/agent-runtime-instance-storage.ts";
 import { daemonProtocolCommands, validateDaemonRpcCall } from "../src/protocol/daemon-protocol.contract.ts";
@@ -120,6 +121,83 @@ test("Codex sidecar launch materializes the complete non-secret provider config 
     assert.equal(launch.prompt, "Inspect"); assert.equal(launch.cwd, "/workspace/repo");
     assert.equal(statSync(path.join(userRoot, "runtime-instances.json")).mode & 0o777, 0o600); for (const directory of [stateRoot, ...["home", "tmp", "run"].map((name) => path.join(stateRoot, name))]) assert.equal(statSync(directory).mode & 0o777, 0o700, directory);
   } finally { rmSync(userRoot, { recursive: true, force: true }); }
+});
+
+test("Codex API-key launches inject the resolved credential into the contracted header", async () => {
+  const userRoot = mkdtempSync(path.join(tmpdir(), "ha-runtime-secret-header-"));
+  try {
+    const store = openRuntimeInstanceStore({
+      userRoot,
+      discover: () => [observed],
+      resolveCredential: () => "instance-secret",
+    });
+    store.create({
+      schemaVersion: 2,
+      instanceId: "codex-sub2api",
+      name: "Codex sub2api",
+      kindId: "codex",
+      installationId: observed.installationId,
+      providerId: "sub2api",
+      models: ["gpt-5.6-sol"],
+      defaultModel: "gpt-5.6-sol",
+      enabled: true,
+      permissionMode: "read-only",
+      isolationState: "enforced",
+      codex: {
+        baseUrl: "http://127.0.0.1:1",
+        wireApi: "responses",
+        requiresOpenAiAuth: false,
+        credentialHeader: "x-api-key",
+      },
+      auth: { mode: "api-key", credentialRef: "credential:v1:codex-sub2api" },
+    });
+    const launch = await store.prepareLaunch("codex-sub2api", { cwd: "/workspace/repo", prompt: "Inspect" });
+    const configText = readFileSync(path.join(launch.env.CODEX_HOME!, "config.toml"), "utf8");
+    assert.match(configText, /http_headers = \{ "x-api-key" = "instance-secret" \}/u);
+    assert.doesNotMatch(configText, /experimental_bearer_token/u);
+    assert.doesNotMatch(JSON.stringify(launch), /instance-secret/u);
+  } finally {
+    rmSync(userRoot, { recursive: true, force: true });
+  }
+});
+
+test("Codex credential header collision is rejected case-insensitively", () => {
+  const userRoot = mkdtempSync(path.join(tmpdir(), "ha-runtime-header-collision-"));
+  try {
+    const store = openRuntimeInstanceStore({ userRoot, discover: () => [observed] });
+    assert.throws(
+      () =>
+        store.create({
+          schemaVersion: 2,
+          instanceId: "codex-header-collision",
+          name: "Codex Header Collision",
+          kindId: "codex",
+          installationId: observed.installationId,
+          providerId: "sub2api",
+          models: ["gpt-5.6-sol"],
+          defaultModel: "gpt-5.6-sol",
+          enabled: true,
+          isolationState: "enforced",
+          codex: {
+            baseUrl: "http://127.0.0.1:1",
+            httpHeaders: { "X-Custom": "static" },
+            credentialHeader: "x-custom",
+          },
+          auth: { mode: "api-key", credentialRef: "credential:v1:codex-header-collision" },
+        }),
+      (error: unknown) => codedAs(error, "invalid_runtime_credential_header"),
+    );
+  } finally {
+    rmSync(userRoot, { recursive: true, force: true });
+  }
+});
+
+test("static HTTP header names reject case-variant duplicates and preserve spelling", () => {
+  assert.deepEqual(runtimeHttpHeaders({ "X-Custom": "static" }), { "X-Custom": "static" });
+  assert.throws(
+    () => runtimeHttpHeaders({ "X-Custom": "first", "x-custom": "second" }),
+    (error: unknown) => codedAs(error, "invalid_runtime_http_headers"),
+  );
 });
 
 test("same-instance API-key launches keep the previous bearer during the next credential lookup", async () => {


### PR DESCRIPTION
# English

## Summary

Carry the runtime compatibility fix onto the latest upstream main so API-key credentials can use a provider-specific header for private HTTP sub2api endpoints. Credential references remain opaque and runtime validation stays fail-closed.

## Architectural Justification

The current runtime contract could not represent custom credential headers or explicitly permitted private HTTP. This change extends the existing Codex runtime configuration and storage paths only; it introduces no provider checkout changes and no arbitrary shell path.

## What Changed
- CLI accepts `--credential-header` and `--allow-insecure-http`.
- Runtime validates custom credential headers, private IPv4 HTTP, and case-insensitive static header collisions.
- Isolated config writes the resolved key to the configured header and avoids bearer fallback.
- CLI and daemon coverage was added for the compatibility behavior.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
Production-Delta: +164/-33
Dependency-Change: none

## Task And Scope
- Harness task: provider compatibility migration for MI HA runtime
- Branch: `codex/mi-runtime-compat-stable-20260904`
- Public scope: Codex runtime CLI and daemon compatibility for custom API-key providers
- Private planning/evidence updated: yes
- Out of scope: upstream provider behavior, HA target source, automatic merge

## Version Impact

No version change; publish impact none.

## Governance Declaration
- Protected surface touched: no
- Protected surface scope: none
- Authority: not applicable
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification
- Base `origin/main` SHA: `9140cd98a52725ec1d1dfafe5b1464c2063fc4ee`
- Branch merge-base with `origin/main`: `9140cd98a52725ec1d1dfafe5b1464c2063fc4ee`
- Sync method: rebase
- Public diff command: `git diff origin/main...HEAD`
- Private evidence commit/path: `302b0ecb37091fa1d8a97b571b5f542425824263`
- Reviewer evidence path: local build, 71 targeted tests, daemon status, runtime probe, and exact sub2api response
- GitHub Actions `rewrite-ci` run URL: https://github.com/FairladyZ625/harness-anything/actions/runs/33887490904
- [x] CLI build
- [x] Targeted runtime and CLI tests
- [x] `git diff --check`
- [ ] `npm run check`
- [x] Full GitHub Actions CI
- Not run: full check is delegated to GitHub Actions for this PR

## Review Evidence

Self-review: the diff is limited to the existing runtime configuration, storage, launch validation, protocol input, and focused tests. The daemon was restarted from the resulting stable build and returned the expected sub2api response.

## Residual Risk

The provider remains an external sub2api endpoint; this change only makes its authentication and private HTTP transport explicit and bounded.

## References
- Task: provider compatibility migration for MI HA runtime
- Evidence: commit `302b0ecb37091fa1d8a97b571b5f542425824263` and local daemon receipts
- Review: latest CI rerun `33887490904` is green; prior run `33886058151` exposed one unrelated load-sensitive daemon performance flake, with no changed test or production path implicated.

---

# 中文

## 概要

将 runtime 兼容修复整理到最新 upstream main，使 API key 能通过 provider 专用 header 发送到内网 HTTP sub2api。凭据引用继续保持 opaque，运行时校验继续 fail-closed。

## 架构辩护

旧 runtime 契约无法表达自定义凭据 header 与显式允许的私有 HTTP。本改动只扩展既有 Codex runtime 配置、存储和启动校验路径，不修改 provider checkout，也不引入任意 shell 路径。

## 改动内容

CLI 新增 `--credential-header` 与 `--allow-insecure-http`；runtime 校验自定义凭据 header、私有 IPv4 HTTP 和大小写不敏感的静态 header 冲突；隔离配置把解析后的 key 写入指定 header，避免 bearer 回退；同时补充 CLI 与 daemon 定向测试。

## 任务与范围

任务是 MI HA runtime provider 兼容迁移；分支为 `codex/mi-runtime-compat-stable-20260904`；公开范围仅限 Codex runtime CLI 与 daemon 兼容；不涉及 upstream provider 行为、HA target 源码或自动合并。

## 版本影响

不改版本，不发布。

## 治理声明
- 触碰 protected surface：否
- protected surface 范围：无
- 依据：不适用
- Break-glass：否

## 验证

稳定目录已快进到 `origin/main` 最新提交并重放兼容修复；CLI 构建通过，定向测试 71/71 通过，daemon status 正常，runtime readiness 为 ready，实际请求返回 `HA_STABLE_PROVIDER_OK`。最新 GitHub CI run `33887490904` 已全部通过；此前 `33886058151` 的单个失败确认是与本改动无关的负载敏感 daemon 性能波动。

## 审阅证据

自查确认改动集中在既有 runtime 配置、存储、启动校验、协议输入和测试；daemon 已从稳定构建重启并完成 sub2api 验证。等待 CI 与 upstream reviewer。

## 残余风险

provider 仍是外部 sub2api endpoint；本改动只把认证 header 与私有 HTTP 传输显式化并限制在受控配置内。