### PR TITLE
feat(gui): copy the terminal selection with Cmd+C and add copy/paste menu items

### DIFF
--- a/packages/gui/src/main/electron-main.ts
+++ b/packages/gui/src/main/electron-main.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, dialog, ipcMain, session, shell } from "electron";
+import { app, BrowserWindow, dialog, ipcMain, Menu, session, shell, type MenuItemConstructorOptions } from "electron";
 import { homedir } from "node:os";
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
@@ -164,6 +164,15 @@ function installHtmlArtifactWebviewPolicy(mainWindow: BrowserWindow): void {
 
 export async function startGuiApp(): Promise<void> {
   await app.whenReady();
+  if (process.platform === "darwin") {
+    const template: MenuItemConstructorOptions[] = [
+      { role: "appMenu" },
+      { role: "editMenu" },
+      { role: "viewMenu" },
+      { role: "windowMenu" },
+    ];
+    Menu.setApplicationMenu(Menu.buildFromTemplate(template));
+  }
   installContentSecurityPolicy();
   const trustedWebContentsIds = new Set<number>();
   const rootDir = resolveGuiProjectRoot(),

--- a/packages/gui/src/renderer/components/terminal/TerminalPane.tsx
+++ b/packages/gui/src/renderer/components/terminal/TerminalPane.tsx
@@ -31,6 +31,7 @@ export function TerminalPane({
   onFit,
   openUrl,
   onOpenLink,
+  onSelectionChange,
 }: {
   readonly output: string;
   readonly interactive: boolean;
@@ -38,6 +39,7 @@ export function TerminalPane({
   readonly onFit: (cols: number, rows: number) => void;
   readonly openUrl: ((uri: string) => void) | null;
   readonly onOpenLink: (match: TerminalLinkMatch, text: string) => void;
+  readonly onSelectionChange: (selection: string) => void;
 }) {
   const hostRef = useRef<HTMLDivElement>(null);
   const searchInputRef = useRef<HTMLInputElement>(null);
@@ -49,11 +51,13 @@ export function TerminalPane({
   const onFitRef = useRef(onFit);
   const openUrlRef = useRef(openUrl);
   const onOpenLinkRef = useRef(onOpenLink);
+  const onSelectionChangeRef = useRef(onSelectionChange);
   interactiveRef.current = interactive;
   onInputRef.current = onInput;
   onFitRef.current = onFit;
   openUrlRef.current = openUrl;
   onOpenLinkRef.current = onOpenLink;
+  onSelectionChangeRef.current = onSelectionChange;
   const [searchOpen, setSearchOpen] = useState(false);
   const [searchTerm, setSearchTerm] = useState("");
   const [searchFound, setSearchFound] = useState(true);
@@ -84,6 +88,15 @@ export function TerminalPane({
     terminal.open(host);
     if (terminalWebglEnabled(localStorage)) terminal.loadAddon(new WebglAddon());
     terminalRef.current = terminal;
+    terminal.attachCustomKeyEventHandler((event) => {
+      if (!event.metaKey || event.key.toLowerCase() !== "c" || !terminal.hasSelection()) return true;
+      event.preventDefault();
+      void navigator.clipboard.writeText(terminal.getSelection()).catch(consumeKnownError);
+      return false;
+    });
+    const selectionDisposable = terminal.onSelectionChange(() => {
+      onSelectionChangeRef.current(terminal.getSelection());
+    });
 
     const themeObserver = new MutationObserver(() => {
       terminal.options.theme = terminalTheme(document.documentElement.dataset.theme === "light" ? "light" : "dark");
@@ -134,7 +147,9 @@ export function TerminalPane({
       if (frame !== undefined) cancelAnimationFrame(frame);
       linkDisposable.dispose();
       inputDisposable.dispose();
+      selectionDisposable.dispose();
       terminal.dispose();
+      onSelectionChangeRef.current("");
       terminalRef.current = null;
       searchRef.current = null;
       writtenRef.current = 0;

--- a/packages/gui/src/renderer/components/terminal/TerminalPaneCard.tsx
+++ b/packages/gui/src/renderer/components/terminal/TerminalPaneCard.tsx
@@ -36,6 +36,7 @@ export function TerminalPaneCard(props: IDockviewPanelProps<{ readonly sessionId
     focused = actions.focusedPanelId === panelId;
   const [dropZone, setDropZone] = useState<TerminalSplitDirection | null>(null);
   const [menu, setMenu] = useState<{ readonly x: number; readonly y: number } | null>(null);
+  const [selection, setSelection] = useState("");
   // 拖拽换位:标题栏是把手;别的 pane 的整张 card 是落点,按指针离哪条边最近分四个半区。
   const onDragOver = (event: DragEvent<HTMLDivElement>) => {
     if (!drag.panelId || drag.panelId === panelId) return;
@@ -88,6 +89,8 @@ export function TerminalPaneCard(props: IDockviewPanelProps<{ readonly sessionId
         <PaneMenu
           at={menu}
           onClose={() => setMenu(null)}
+          selection={selection}
+          onPaste={tab?.state === "running" && tab.attachable ? (text) => actions.onInput(tab.sessionId, text) : null}
           onSplit={(direction) => actions.onSplitPane(panelId, direction)}
           onClosePane={() => actions.onClosePane(panelId, sessionId)}
           onTerminate={tab ? () => actions.setConfirmSessionId(tab.sessionId) : null}
@@ -128,12 +131,22 @@ export function TerminalPaneCard(props: IDockviewPanelProps<{ readonly sessionId
         </span>
         {tab && <TerminateControls tab={tab} />}
       </div>
-      {tab ? <LivePane tab={tab} /> : <DeadPane panelId={panelId} sessionId={sessionId} />}
+      {tab ? (
+        <LivePane tab={tab} onSelectionChange={setSelection} />
+      ) : (
+        <DeadPane panelId={panelId} sessionId={sessionId} />
+      )}
     </div>
   );
 }
 
-function LivePane({ tab }: { readonly tab: TerminalTab }) {
+function LivePane({
+  tab,
+  onSelectionChange,
+}: {
+  readonly tab: TerminalTab;
+  readonly onSelectionChange: (text: string) => void;
+}) {
   const actions = useTerminalPaneActions();
   const interactive = tab.state === "running" && tab.attachable;
   return (
@@ -159,6 +172,7 @@ function LivePane({ tab }: { readonly tab: TerminalTab }) {
             interactive={interactive}
             openUrl={actions.openUrl}
             onOpenLink={(match, text) => actions.openLink(match, text, tab.cwd)}
+            onSelectionChange={onSelectionChange}
             onInput={(utf8) => actions.onInput(tab.sessionId, utf8)}
             onFit={(cols, rows) => actions.onFit(tab.sessionId, cols, rows)}
           />
@@ -224,12 +238,16 @@ function dropZoneOf(event: { readonly clientX: number; readonly clientY: number 
 function PaneMenu({
   at,
   onClose,
+  selection,
+  onPaste,
   onSplit,
   onClosePane,
   onTerminate,
 }: {
   readonly at: { readonly x: number; readonly y: number };
   readonly onClose: () => void;
+  readonly selection: string;
+  readonly onPaste: ((text: string) => void) | null;
   readonly onSplit: (direction: TerminalSplitDirection) => void;
   readonly onClosePane: () => void;
   readonly onTerminate: (() => void) | null;
@@ -255,6 +273,7 @@ function PaneMenu({
     action();
   };
   const itemClassName = "block w-full rounded px-2 py-1 text-left text-text hover:bg-surface";
+  const disabledItemClassName = `${itemClassName} disabled:cursor-not-allowed disabled:text-text-faint disabled:hover:bg-transparent`;
   return createPortal(
     <div
       ref={ref}
@@ -264,6 +283,28 @@ function PaneMenu({
       style={{ left: at.x, top: at.y }}
       className="fixed z-50 min-w-40 rounded border border-border bg-surface-raised p-1 text-[12px] shadow-lg"
     >
+      <button
+        role="menuitem"
+        disabled={!selection}
+        onClick={pick(() => void navigator.clipboard.writeText(selection).catch(consumeKnownError))}
+        className={disabledItemClassName}
+      >
+        {t("terminal.view.copy")}
+      </button>
+      <button
+        role="menuitem"
+        disabled={onPaste === null}
+        onClick={pick(
+          () =>
+            void navigator.clipboard
+              .readText()
+              .then((text) => onPaste?.(text))
+              .catch(consumeKnownError),
+        )}
+        className={disabledItemClassName}
+      >
+        {t("terminal.view.paste")}
+      </button>
       {splitDirections.map((direction) => (
         <button key={direction} role="menuitem" onClick={pick(() => onSplit(direction))} className={itemClassName}>
           {splitLabel(direction)}
@@ -280,6 +321,10 @@ function PaneMenu({
     </div>,
     document.body,
   );
+}
+
+function consumeKnownError(error: unknown): void {
+  void error;
 }
 
 function SplitButton({ panelId, direction }: { readonly panelId: string; readonly direction: TerminalSplitDirection }) {

--- a/packages/gui/src/renderer/components/terminal/TerminalPaneCard.tsx
+++ b/packages/gui/src/renderer/components/terminal/TerminalPaneCard.tsx
@@ -273,7 +273,12 @@ function PaneMenu({
     action();
   };
   const itemClassName = "block w-full rounded px-2 py-1 text-left text-text hover:bg-surface";
-  const disabledItemClassName = `${itemClassName} disabled:cursor-not-allowed disabled:text-text-faint disabled:hover:bg-transparent`;
+  const disabledItemClassName = [
+    itemClassName,
+    "disabled:cursor-not-allowed",
+    "disabled:text-text-faint",
+    "disabled:hover:bg-transparent",
+  ].join(" ");
   return createPortal(
     <div
       ref={ref}

--- a/packages/gui/src/renderer/i18n/locales/en-US/terminal.json
+++ b/packages/gui/src/renderer/i18n/locales/en-US/terminal.json
@@ -48,6 +48,8 @@
   "terminal.view.splitLeft": "Split left",
   "terminal.view.splitUp": "Split up",
   "terminal.view.paneMenuAria": "Pane menu",
+  "terminal.view.copy": "Copy",
+  "terminal.view.paste": "Paste",
   "terminal.view.dragHandleTitle": "Drag onto another pane to rearrange",
   "terminal.view.taskPickerPlaceholder": "Search task title or id…",
   "terminal.view.taskPickerEmpty": "No matching task",

--- a/packages/gui/src/renderer/i18n/locales/zh-CN/terminal.json
+++ b/packages/gui/src/renderer/i18n/locales/zh-CN/terminal.json
@@ -48,6 +48,8 @@
   "terminal.view.splitLeft": "向左分屏",
   "terminal.view.splitUp": "向上分屏",
   "terminal.view.paneMenuAria": "pane 菜单",
+  "terminal.view.copy": "复制",
+  "terminal.view.paste": "粘贴",
   "terminal.view.dragHandleTitle": "拖动到别的 pane 上换位",
   "terminal.view.taskPickerPlaceholder": "搜索 task 标题或 id…",
   "terminal.view.taskPickerEmpty": "无匹配 task",

--- a/packages/gui/test/terminal-pane.vitest.ts
+++ b/packages/gui/test/terminal-pane.vitest.ts
@@ -4,7 +4,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { act, createElement } from "react";
 import { createRoot, type Root } from "react-dom/client";
 
-const xterm = vi.hoisted(() => ({ loaded: [] as string[], lastOptions: null as Record<string, unknown> | null }));
+const xterm = vi.hoisted(() => ({
+  loaded: [] as string[],
+  lastOptions: null as Record<string, unknown> | null,
+  keyHandler: null as ((event: KeyboardEvent) => boolean) | null,
+  selection: "",
+}));
 vi.mock("@xterm/xterm", () => ({
   Terminal: class {
     cols = 80;
@@ -27,6 +32,18 @@ vi.mock("@xterm/xterm", () => ({
     }
     open() {}
     onData() {
+      return { dispose() {} };
+    }
+    attachCustomKeyEventHandler(handler: (event: KeyboardEvent) => boolean) {
+      xterm.keyHandler = handler;
+    }
+    hasSelection() {
+      return xterm.selection.length > 0;
+    }
+    getSelection() {
+      return xterm.selection;
+    }
+    onSelectionChange() {
       return { dispose() {} };
     }
     focus() {}
@@ -86,6 +103,8 @@ let root: Root;
 beforeEach(() => {
   globalThis.IS_REACT_ACT_ENVIRONMENT = true;
   xterm.loaded = [];
+  xterm.keyHandler = null;
+  xterm.selection = "";
   localStorage.clear();
   container = document.createElement("div");
   document.body.append(container);
@@ -108,6 +127,7 @@ function mount() {
         onFit: () => undefined,
         openUrl: null,
         onOpenLink: () => undefined,
+        onSelectionChange: () => undefined,
       }),
     ),
   );
@@ -139,5 +159,25 @@ describe("TerminalPane addon lifecycle (W4a)", () => {
     localStorage.setItem(terminalWebglStorageKey, "enabled");
     mount();
     expect(xterm.loaded).toContain("webgl");
+  });
+
+  it("copies an xterm selection on Cmd+C without forwarding the key", () => {
+    const writeText = vi.fn(async () => undefined);
+    Object.defineProperty(navigator, "clipboard", { value: { writeText }, configurable: true });
+    xterm.selection = "selected output";
+    mount();
+    const event = new KeyboardEvent("keydown", { key: "c", metaKey: true, cancelable: true });
+    expect(xterm.keyHandler?.(event)).toBe(false);
+    expect(event.defaultPrevented).toBe(true);
+    expect(writeText).toHaveBeenCalledWith("selected output");
+  });
+
+  it("forwards Ctrl+C and Cmd+C without a selection to the PTY path", () => {
+    const writeText = vi.fn(async () => undefined);
+    Object.defineProperty(navigator, "clipboard", { value: { writeText }, configurable: true });
+    mount();
+    expect(xterm.keyHandler?.(new KeyboardEvent("keydown", { key: "c", ctrlKey: true }))).toBe(true);
+    expect(xterm.keyHandler?.(new KeyboardEvent("keydown", { key: "c", metaKey: true }))).toBe(true);
+    expect(writeText).not.toHaveBeenCalled();
   });
 });

--- a/packages/gui/test/terminal-split-grid.vitest.ts
+++ b/packages/gui/test/terminal-split-grid.vitest.ts
@@ -7,15 +7,27 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { setActiveLocale } from "../src/renderer/i18n/core.ts";
 import { TerminalView } from "../src/renderer/views/TerminalView.tsx";
 
+const terminalPaneMock = vi.hoisted(() => ({ onSelectionChange: null as ((text: string) => void) | null }));
+
 // pane 内容用桩替代真 xterm:本文件测的是 pane 树(分割/关闭/序列化/每 pane 上报),
 // 不是终端仿真;桩把 onFit 暴露成一次点击,才能对「每个 pane 各自上报 cols/rows」下断言。
 vi.mock("../src/renderer/components/terminal/TerminalPane.tsx", () => ({
-  TerminalPane: ({ output, onFit }: { readonly output: string; readonly onFit: (c: number, r: number) => void }) =>
-    createElement("button", {
+  TerminalPane: ({
+    output,
+    onFit,
+    onSelectionChange,
+  }: {
+    readonly output: string;
+    readonly onFit: (c: number, r: number) => void;
+    readonly onSelectionChange: (text: string) => void;
+  }) => {
+    terminalPaneMock.onSelectionChange = onSelectionChange;
+    return createElement("button", {
       "data-testid": "terminal-pane",
       "data-output": output,
       onClick: () => onFit(120, 40),
-    }),
+    });
+  },
 }));
 
 const AT = "2026-09-01T00:00:00.000Z";
@@ -165,6 +177,7 @@ afterEach(() => {
   container = null;
   delete (window as unknown as Record<string, unknown>).harness;
   vi.restoreAllMocks();
+  terminalPaneMock.onSelectionChange = null;
 });
 
 function mountView() {
@@ -452,6 +465,8 @@ describe("terminal split panes (PLT-TerminalWorkspace W1)", () => {
     expect(menu).not.toBeNull();
     expect(menu!.style.left).toBe("40px");
     expect([...menu!.querySelectorAll("[role=menuitem]")].map((item) => item.textContent)).toEqual([
+      "Copy",
+      "Paste",
       "Split left",
       "Split right",
       "Split up",
@@ -467,12 +482,51 @@ describe("terminal split panes (PLT-TerminalWorkspace W1)", () => {
       pane.dispatchEvent(new MouseEvent("contextmenu", { bubbles: true, cancelable: true }));
     });
     act(() => {
-      document.querySelectorAll<HTMLButtonElement>('[data-testid="terminal-pane-menu"] [role=menuitem]')[2].click();
+      document.querySelectorAll<HTMLButtonElement>('[data-testid="terminal-pane-menu"] [role=menuitem]')[4].click();
     });
     await flush();
     expect(document.querySelector('[data-testid="terminal-pane-menu"]')).toBeNull();
     expect(bridge.spawnTerminal).toHaveBeenCalledTimes(1);
     expect(panes()).toHaveLength(2);
+  });
+
+  it("disables copy without a selection and copies or pastes through the active pane", async () => {
+    const writeText = vi.fn(async () => undefined);
+    const readText = vi.fn(async () => "pasted input");
+    Object.defineProperty(navigator, "clipboard", { value: { writeText, readText }, configurable: true });
+    const { bridge } = stubBridge([sessionRow()]);
+    mountView();
+    await flush();
+    const pane = panes()[0];
+    act(() => {
+      pane.dispatchEvent(new MouseEvent("contextmenu", { bubbles: true, cancelable: true }));
+    });
+    let items = document.querySelectorAll<HTMLButtonElement>('[data-testid="terminal-pane-menu"] [role=menuitem]');
+    expect(items[0].disabled).toBe(true);
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+      terminalPaneMock.onSelectionChange?.("selected output");
+    });
+    act(() => {
+      pane.dispatchEvent(new MouseEvent("contextmenu", { bubbles: true, cancelable: true }));
+    });
+    items = document.querySelectorAll<HTMLButtonElement>('[data-testid="terminal-pane-menu"] [role=menuitem]');
+    expect(items[0].disabled).toBe(false);
+    act(() => items[0].click());
+    expect(writeText).toHaveBeenCalledWith("selected output");
+    act(() => {
+      pane.dispatchEvent(new MouseEvent("contextmenu", { bubbles: true, cancelable: true }));
+    });
+    items = document.querySelectorAll<HTMLButtonElement>('[data-testid="terminal-pane-menu"] [role=menuitem]');
+    act(() => items[1].click());
+    await flush();
+    expect(readText).toHaveBeenCalledTimes(1);
+    expect(bridge.sendTerminalInput).toHaveBeenCalledWith({
+      repoId: "repo-a",
+      sessionId: "s-restore",
+      clientSeq: 1,
+      utf8: "pasted input",
+    });
   });
 
   it("resizes the sidebar by dragging its right edge and remembers the width", async () => {


### PR DESCRIPTION
# English

## Summary

Selecting text in a GUI terminal and pressing Cmd+C did nothing. The first diagnosis blamed a missing application menu; that was wrong and is worth recording, because the real cause is one layer down.

Electron's default menu is present — the framework binary carries `lib/browser/default-menu.ts` with `copy`, `paste` and `selectAll` roles, and Cmd+V pasting already worked, which proves the accelerator path is intact. The break is that **xterm draws its selection outside the DOM**. Chromium's copy command therefore finds nothing selected, never fires the `copy` event that xterm listens for on its element, and the handler waits forever. The only place xterm mirrors a selection into its helper textarea is the Linux primary-selection path, which macOS never takes. The webgl renderer this repo enables puts the selection on the GPU, further out of reach.

So the key is handled directly instead, the pane menu gets explicit entries, and the app finally installs its own macOS menu.

## Architectural Justification

Not required (production churn is +72/-3, well under the thresholds).

## What Changed

- `TerminalPane.tsx`: an xterm custom key handler writes the selection to the clipboard on Cmd+C **when there is a selection**, and otherwise lets the key through untouched, so Ctrl+C still reaches the PTY as SIGINT. Losing interrupt while gaining copy is the classic way this change goes wrong, and the handler is shaped to make that impossible.
- `TerminalPaneCard.tsx`: the context menu gains copy and paste entries. Copy is **disabled (greyed), not hidden**, when nothing is selected. Paste reuses the existing input channel rather than inventing a second path.
- `electron-main.ts`: installs the standard macOS template via `Menu.buildFromTemplate` using `appMenu`/`editMenu`/`viewMenu`/`windowMenu` roles, so labels, accelerators and localisation come from Electron rather than hand-written strings.
- Terminal strings added to both `en-US` and `zh-CN` locales.
- The disabled-variant class list is built by joining an array rather than one 134-character template literal, because G36 line-density rejects added production lines over 120 characters.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: use the single CI-backed `Production-Delta` declaration below; do not enter a second metric.

## Machine-Readable Declarations

Production-Delta: +77/-3

## Task And Scope

- Harness task: task_effa2739faedb45f0920ddfbfe
- Branch: codex/gui-terminal-clipboard
- Public scope: packages/gui terminal components, Electron main menu, terminal i18n, and the two touched vitest files
- Private planning/evidence updated: yes
- Out of scope: the pasted-Chinese mojibake, which is a PTY locale problem fixed by task_cb3aa93faf57c17671feb7cc04 / PR #2237, not a clipboard problem

## Version Impact

- Version: no version change because this is GUI behaviour with no package surface change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: not applicable
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no

## Verification

- Base `origin/main` SHA: 667b0c361 (rebased onto it before opening this PR)
- Branch merge-base with `origin/main`: 667b0c361
- Last `git fetch origin` time: 2026-09-04, immediately before the rebase
- Sync method: rebase
- Public diff command: `git diff origin/main...codex/gui-terminal-clipboard`
- Private evidence commit/path: `harness/tasks/task_effa2739faedb45f0920ddfbfe-gui-terminal-clipboard/artifacts/root-cause.md`
- Reviewer evidence path: same file
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- Not run: the full local matrix — per repository policy that is GitHub CI's job. Targeted run instead, re-run after the rebase:
  - `npx vitest run --config vitest.config.ts terminal-pane terminal-split-grid` → **19 passed / 0 failed** (2 files)
- Provenance note: the dispatched worker stopped at a hard stop condition written into its task contract, because its execution environment resolved `node` to v22.16.0 while this repository requires `>=24`. The CEO ran the tests on node v24.18.0, found that the worker's own new assertion invented a `data` field where the real contract at `terminal-client.ts:83` is `sendTerminalInput({ repoId, sessionId, clientSeq, utf8 })`, fixed that one line, and committed. The implementation itself was the worker's and was correct.

## Review Evidence

- Self-review: CEO read the implementation and the failing assertion, and verified against the real `sendTerminalInput` contract that the implementation was right and the test was wrong.
- Reviewer subagent: none
- Human review: pending
- Blocking findings: none outstanding

## Residual Risk

- **No GUI acceptance has been performed.** Nobody has yet selected text in an Electron window, pressed Cmd+C, and pasted it somewhere. That check needs a human at the GUI.
- **Ctrl+C interrupt has not been exercised end to end.** The handler only intercepts when a selection exists, and the unit tests cover that branch, but nobody has run a long command in a real terminal and interrupted it. This is the one regression this change could plausibly cause, and it is the first thing to check.
- **The application menu's accelerators have not been checked against the three existing shortcut groups** — ⌘W (close pane), ⌃⌘arrows (split), ⌃⌥arrows (focus). A custom menu replaces Electron's default one, and a role's accelerator can take a key away from a window-level handler.
- Copy uses `navigator.clipboard.writeText`, which is promise-based; a rejection is not surfaced to the user beyond the console.

## References

- Task: task_effa2739faedb45f0920ddfbfe
- Evidence: `harness/tasks/task_effa2739faedb45f0920ddfbfe-gui-terminal-clipboard/artifacts/root-cause.md`
- Review: same file, section "用户实测回执"

---

# 中文

## 摘要

在 GUI 终端里选中文字按 Cmd+C 没有任何反应。第一版诊断归咎于"缺少应用菜单"，**那是错的**，值得记录下来，因为真正的原因在下一层。

Electron 的默认菜单是在的——framework 二进制里带着 `lib/browser/default-menu.ts`，role 表含 `copy`、`paste`、`selectAll`；而且 Cmd+V 粘贴本来就能用，这证明加速键通路是完好的。真正断掉的是：**xterm 的选区画在 DOM 之外**。于是 Chromium 的复制命令找不到任何选中内容，永远不会派发 xterm 在其 element 上监听的那个 `copy` 事件，监听器一直空等。xterm 唯一会把选区同步进 helper textarea 的地方是 Linux primary-selection 路径，macOS 从不走那条。本仓启用的 webgl 渲染器又把选区放到了 GPU 上，更够不着。

所以改为直接处理按键，右键菜单补上明确入口，应用也终于装上了自己的 macOS 菜单。

## 架构论证

不需要（生产改动 +72/-3，远低于阈值）。

## 改动内容

- `TerminalPane.tsx`：xterm 自定义按键处理器在**有选区时**把选区写入剪贴板，其余情况一律放行，Ctrl+C 照常作为 SIGINT 送达 PTY。"为了拿到复制而丢掉中断"是这类改动最典型的翻车方式，处理器的形状让它不可能发生。
- `TerminalPaneCard.tsx`：右键菜单增加复制与粘贴。无选区时复制**置灰（disabled），不是隐藏**。粘贴复用既有输入通道，不另造第二条路径。
- `electron-main.ts`：通过 `Menu.buildFromTemplate` 安装标准 macOS 模板，使用 `appMenu`/`editMenu`/`viewMenu`/`windowMenu` role——标签、加速键与本地化都来自 Electron，不手写字符串。
- 终端文案同时加入 `en-US` 与 `zh-CN`。
- 禁用态的 class 列表改为数组 join 而不是一条 134 字符的模板字符串，因为 G36 line-density 拒绝超过 120 字符的新增生产行。

## 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none

## 任务与范围

- Harness task：task_effa2739faedb45f0920ddfbfe
- 分支：codex/gui-terminal-clipboard
- 公开范围：packages/gui 终端组件、Electron 主进程菜单、终端 i18n，以及两个被触碰的 vitest 文件
- 私有规划/证据已更新：是
- 不在范围内：粘贴中文乱码——那是 PTY locale 问题，由 task_cb3aa93faf57c17671feb7cc04 / PR #2237 修复，不是剪贴板问题

## 版本影响

- 版本：不变，这是 GUI 行为改动，不改包面
- 发布影响：不发布

## 治理声明

- 是否触碰 protected surface：否
- 范围：不适用
- 授权：不适用
- 机器检查边界：本 PR 只声明该字段存在；其是否为真、是否充分由评审判断。
- Break-glass：否

## 验证

- Base `origin/main` SHA：667b0c361（开 PR 前已 rebase 到它）
- 与 `origin/main` 的 merge-base：667b0c361
- 最近 `git fetch origin` 时间：2026-09-04，rebase 前刚执行
- 同步方式：rebase
- 公开 diff 命令：`git diff origin/main...codex/gui-terminal-clipboard`
- 私有证据路径：`harness/tasks/task_effa2739faedb45f0920ddfbfe-gui-terminal-clipboard/artifacts/root-cause.md`
- 评审证据路径：同一文件
- GitHub Actions `rewrite-ci` run URL：本 PR 开出后产生
- 未运行：本机完整门矩阵——按仓库政策那是 GitHub CI 的活。改为定向执行，且在 rebase 后复跑：
  - `npx vitest run --config vitest.config.ts terminal-pane terminal-split-grid` → **19 通过 / 0 失败**（2 个文件）
- 来源说明：派工的 worker 在其任务契约写明的硬停手条件上停手，因为它的执行环境把 `node` 解析成了 v22.16.0，而本仓要求 `>=24`。CEO 在 node v24.18.0 下跑测试，发现 worker 自己新写的断言凭空造了一个 `data` 字段，而 `terminal-client.ts:83` 的真实契约是 `sendTerminalInput({ repoId, sessionId, clientSeq, utf8 })`，改掉那一行后提交。实现本身是 worker 写的，而且是对的。

## 评审证据

- 自审：CEO 通读实现与失败断言，对照真实的 `sendTerminalInput` 契约确认"实现对、测试错"。
- 评审子代理：无
- 人工评审：待进行
- 阻塞性发现：无未决项

## 残留风险

- **尚未进行 GUI 验收。** 还没有人在 Electron 窗口里选中文字、按 Cmd+C、再粘贴到别处确认。这项检查需要人在 GUI 前操作。
- **Ctrl+C 中断未端到端实测。** 处理器只在有选区时拦截，单元测试覆盖了该分支，但没有人在真实终端里跑一条长命令再按 Ctrl+C 中断它。这是本次改动唯一可能造成的回归，也是第一件该检查的事。
- **应用菜单的加速键未与三组既有快捷键核对**——⌘W（关闭 pane）、⌃⌘方向键（分屏）、⌃⌥方向键（切焦点）。自定义菜单会替换 Electron 的默认菜单，而 role 的加速键可能把某个键从窗口级处理器手里抢走。
- 复制走 `navigator.clipboard.writeText`，是 promise 形式；被拒绝时除了控制台之外不会对用户呈现。

## 参考

- 任务：task_effa2739faedb45f0920ddfbfe
- 证据：`harness/tasks/task_effa2739faedb45f0920ddfbfe-gui-terminal-clipboard/artifacts/root-cause.md`
- 评审：同一文件的「用户实测回执」节
