### PR TITLE
fix(daemon,cli): 让拒绝回执说清缺什么、期望什么、下一步跑什么

### DIFF
--- a/docs-release/operations-server-daemon.md
+++ b/docs-release/operations-server-daemon.md
@@ -6,11 +6,11 @@ one mode.
 
 ## Connection modes
 
-| Registry mode | Use it for | Local machine | Data and write authority |
-| --- | --- | --- | --- |
-| `local` | Normal local development | daemon, runtime, GUI, and a workspace | local ledger and its single-writer queue |
-| `remote-proxy` | View-only display of a server repository | GUI and a forwarding daemon; no workspace | the remote daemon and its single-writer queue |
-| `remote-center` / `remote-edge` | Existing Fleet center and edge deployment | center or edge components and a mirror as applicable | the Fleet center lease queue |
+| Registry mode                   | Use it for                                | Local machine                                        | Data and write authority                      |
+| ------------------------------- | ----------------------------------------- | ---------------------------------------------------- | --------------------------------------------- |
+| `local`                         | Normal local development                  | daemon, runtime, GUI, and a workspace                | local ledger and its single-writer queue      |
+| `remote-proxy`                  | View-only display of a server repository  | GUI and a forwarding daemon; no workspace            | the remote daemon and its single-writer queue |
+| `remote-center` / `remote-edge` | Existing Fleet center and edge deployment | center or edge components and a mirror as applicable | the Fleet center lease queue                  |
 
 For development on a server repository, SSH to the server. A `remote-proxy`
 machine has no local workspace and is not a remote CLI development environment.
@@ -70,6 +70,21 @@ ha daemon repo register --repo-id <id> --root /path/to/workspace --mode local
 ha daemon start --service
 ha gui
 ```
+
+## Recovering from task and runtime rejections
+
+Receipts include a validation diagnostic with the rejected field, its current
+value, and a retry command. Use these state rules when recovering:
+
+| Code                                    | Condition                                                        | Recovery                                                                                                                                                             |
+| --------------------------------------- | ---------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `invalid_submission`                    | A submission field has the wrong type or value                   | Fix the named JSON field, then retry `ha task submit <task-id> --execution-id <execution-id> --from-file <submission.json>`.                                         |
+| `invalid_runtime_mission`               | `--mission` was given a path or invalid id                       | Use a bare lowercase id. The daemon reads `harness/<task-package>/artifacts/missions/<name>.md`; retry `ha runtime run <runtime> --task <task-id> --mission <name>`. |
+| `invalid_proof` from `declare-executor` | The execution is not `submitted/review` with `executor=none`     | An assigned submitted execution proceeds with `ha task review-execution`; only an unassigned one uses `ha task declare-executor`.                                    |
+| `executor_binding_invalid`              | The claimed executor differs from the task binding or held lease | Run the receipt's retry command from the expected executor named in its diagnostic.                                                                                  |
+| `invalid_transition` from `task start`  | The current round already has an active execution                | Run `ha task start <task-id>` without `--execution-id` to reuse it.                                                                                                  |
+| `lease_required`                        | Submitter does not hold the execution lease                      | Run `ha task start <task-id>`, then retry submit as the holder.                                                                                                      |
+| `lease_not_found`                       | Runtime settlement already released the lease                    | Run `ha task start <task-id>` without a new execution id, then retry submit.                                                                                         |
 
 ## Registry v2 hard cut
 

--- a/docs-release/operations-server-daemon.zh-CN.md
+++ b/docs-release/operations-server-daemon.zh-CN.md
@@ -5,11 +5,11 @@ registry 选择；一个仓库只能注册为其中一种模式。
 
 ## 连接模式 / Connection modes
 
-| Registry 模式 | 适用场景 | 本机运行内容 | 数据与写入权威 |
-| --- | --- | --- | --- |
-| `local` | 普通本地开发 | daemon、runtime、GUI 与工作区 | 本机台账及其单写队列 |
-| `remote-proxy` | 纯展示服务器仓库 | GUI 与透传 daemon；没有工作区 | 远端 daemon 及其单写队列 |
-| `remote-center` / `remote-edge` | 既有 Fleet 中心和边缘部署 | 视场景运行中心或边缘组件与镜像 | Fleet 中心 lease 队列 |
+| Registry 模式                   | 适用场景                  | 本机运行内容                   | 数据与写入权威           |
+| ------------------------------- | ------------------------- | ------------------------------ | ------------------------ |
+| `local`                         | 普通本地开发              | daemon、runtime、GUI 与工作区  | 本机台账及其单写队列     |
+| `remote-proxy`                  | 纯展示服务器仓库          | GUI 与透传 daemon；没有工作区  | 远端 daemon 及其单写队列 |
+| `remote-center` / `remote-edge` | 既有 Fleet 中心和边缘部署 | 视场景运行中心或边缘组件与镜像 | Fleet 中心 lease 队列    |
 
 要开发服务器上的仓库，请 SSH 到服务器。`remote-proxy` 本机没有工作区，也不是远程 CLI
 开发环境。
@@ -63,6 +63,20 @@ ha daemon repo register --repo-id <id> --root /path/to/workspace --mode local
 ha daemon start --service
 ha gui
 ```
+
+## 从 task 与 runtime 拒绝中恢复
+
+回执的 validation diagnostic 会指出被拒字段、当前值与重试命令。恢复时按以下状态规则处理：
+
+| 错误码                                | 条件                                                   | 恢复方式                                                                                                                                                |
+| ------------------------------------- | ------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `invalid_submission`                  | submission 字段类型或取值错误                          | 修正回执点名的 JSON 字段，再运行 `ha task submit <task-id> --execution-id <execution-id> --from-file <submission.json>`。                               |
+| `invalid_runtime_mission`             | `--mission` 收到路径或非法 id                          | 使用小写裸 id；daemon 读取 `harness/<task-package>/artifacts/missions/<name>.md`，再运行 `ha runtime run <runtime> --task <task-id> --mission <name>`。 |
+| `declare-executor` 的 `invalid_proof` | execution 不满足 `submitted/review` 且 `executor=none` | 已分配的 submitted execution 运行 `ha task review-execution`；仅未分配的 execution 使用 `ha task declare-executor`。                                    |
+| `executor_binding_invalid`            | 声明的 executor 与 task binding 或 held lease 不同     | 从 diagnostic 点名的 expected executor 执行回执里的重试命令。                                                                                           |
+| `task start` 的 `invalid_transition`  | 当前 round 已有 active execution                       | 不传 `--execution-id`，运行 `ha task start <task-id>` 复用它。                                                                                          |
+| `lease_required`                      | submit 调用者不持有 execution lease                    | 运行 `ha task start <task-id>`，再由 holder 重试 submit。                                                                                               |
+| `lease_not_found`                     | runtime 结算已释放 lease                               | 不传新的 execution id 运行 `ha task start <task-id>`，再重试 submit。                                                                                   |
 
 ## registry v2 硬切
 

--- a/packages/cli/src/daemon/client.ts
+++ b/packages/cli/src/daemon/client.ts
@@ -104,11 +104,19 @@ export async function runCommandThroughDaemon(
 ): Promise<JsonObject> {
   command = materializeScheduleMission(command);
   const rpc = await import("../../../daemon/src/client/local-json-rpc-client.ts"),
-    // The CLI renders build drift alongside the successful receipt. Attach-only clients keep their
-    // existing command-result shape while the resident daemon drains cooperatively.
+    // The CLI renders build drift alongside ordinary receipts. A schema-sensitive request is held
+    // back until the resident daemon has drained, so a new field never reaches an older validator.
+    staleSensitiveField =
+      command.method === "repo.agentRuntime.spawn" && typeof command.action.agentId === "string"
+        ? "agentId"
+        : undefined,
     requestLocalDaemonJsonRpcForTarget = (timeRequest ?? ((f) => f))(((target, ...rest) =>
       rpc.requestLocalDaemonJsonRpcForTarget(
-        { ...target, reportStaleBuild: true },
+        {
+          ...target,
+          reportStaleBuild: true,
+          ...(staleSensitiveField ? { rejectStaleBuildField: staleSensitiveField } : {}),
+        },
         ...rest,
       )) as typeof rpc.requestLocalDaemonJsonRpcForTarget),
     autostart = options.autostart ?? command.action.kind !== "receipt-show",

--- a/packages/cli/test/daemon-multi-repo-lifecycle-cli.test.ts
+++ b/packages/cli/test/daemon-multi-repo-lifecycle-cli.test.ts
@@ -368,7 +368,7 @@ test("real CLI reaches one resident multi-workspace daemon and publishes Git eve
       { userRoot: fixture.userRoot },
     );
     assert.equal(spoof.ok, false);
-    assert.equal((spoof.error as { code?: string }).code, "invalid_request");
+    assert.equal((spoof.error as { code?: string }).code, "unknown_field");
     const logicalRevisions = new Map([
       [fixture.alpha, makeTaskEventReader({ rootDir: fixture.alpha, repoId: "alpha" }).read().revision],
       [fixture.beta, makeTaskEventReader({ rootDir: fixture.beta, repoId: "beta" }).read().revision],

--- a/packages/cli/test/runtime-cli.integration.test.ts
+++ b/packages/cli/test/runtime-cli.integration.test.ts
@@ -511,6 +511,28 @@ test("real CLI runs, archives task-bound dispatches, resumes, waits through stat
     assert.equal(mismatch.status, 1);
     assert.equal(mismatch.receipt.code, "agent_runtime_type_mismatch");
     const existingMissionPath = `${packagePath}/artifacts/missions/existing-mission.md`;
+    const pathLikeMission = runMaybe(root, env, [
+      "runtime",
+      "run",
+      "cli-worker",
+      "--mission",
+      existingMissionPath,
+      "--task",
+      taskId,
+      "--no-stream",
+    ]);
+    assert.equal(pathLikeMission.status, 1);
+    assert.equal(pathLikeMission.receipt.code, "invalid_runtime_mission");
+    assert.deepEqual(pathLikeMission.receipt.diagnostic, {
+      kind: "validation",
+      entity: "runtime mission",
+      field: "mission",
+      actual: "path-like value",
+      expectation:
+        "Expected a bare mission id; the daemon resolves harness/<task-package>/artifacts/missions/<name>.md " +
+        "and did not look up this file. Retry ha runtime run <runtime-instance> --task <task-id> --mission <name>",
+    });
+    context.diagnostic(`invalid_runtime_mission receipt=${JSON.stringify(pathLikeMission.receipt)}`);
     // The unavailable rejection is only deterministic while the file is absent: once it exists on
     // disk, the WAL materializer's authored-candidate settlement may auto-submit it after any
     // flush, racing both this rejection and a doc status that expects "eligible".
@@ -906,6 +928,15 @@ test("real CLI runs, archives task-bound dispatches, resumes, waits through stat
     ]);
     assert.equal(readOnly.status, 0, `${readOnly.stderr}\n${JSON.stringify(readOnly.receipt)}`);
     assert.equal(readOnly.receipt.outcome, "succeeded");
+    const readOnlySpawn = readOnly.receipt.spawn as Record<string, unknown>;
+    assert.deepEqual(
+      { ledgerAccess: readOnlySpawn.ledgerAccess, reportDelivery: readOnlySpawn.reportDelivery },
+      { ledgerAccess: "unavailable", reportDelivery: "stdout" },
+    );
+    assert.match(
+      String((readOnly.receipt.result as Record<string, unknown>).text),
+      /Read-only Dispatch Contract[\s\S]*daemon-ledger commands are unavailable[\s\S]*final stdout/u,
+    );
     const noAction = runMaybe(root, env, ["runtime", "run", "cli-worker", "--prompt", "no-action", "--no-stream"]);
     assert.equal(noAction.status, 0, `${noAction.stderr}\n${JSON.stringify(noAction.receipt)}`);
     assert.equal(noAction.receipt.outcome, "succeeded");
@@ -953,7 +984,23 @@ test("real CLI runs, archives task-bound dispatches, resumes, waits through stat
       undefined,
       { env },
     );
-    assert.equal(unknownSpawn.code, "invalid_request");
+    assert.equal(unknownSpawn.code, "unknown_field");
+    const unknownSpawnDiagnostic = unknownSpawn.diagnostic as Record<string, unknown>;
+    assert.deepEqual(
+      {
+        kind: unknownSpawnDiagnostic.kind,
+        entity: unknownSpawnDiagnostic.entity,
+        field: unknownSpawnDiagnostic.field,
+        actual: unknownSpawnDiagnostic.actual,
+      },
+      {
+        kind: "validation",
+        entity: "repo.agentRuntime.spawn",
+        field: "permission_mode",
+        actual: "unknown",
+      },
+    );
+    assert.match(String(unknownSpawnDiagnostic.expectation), /Allowed fields:.*agentId.*permissionMode/u);
     const unknownCancel = await runCommandThroughDaemon(
       {
         rootDir: safePath(root),
@@ -965,7 +1012,14 @@ test("real CLI runs, archives task-bound dispatches, resumes, waits through stat
       undefined,
       { env },
     );
-    assert.equal(unknownCancel.code, "invalid_request");
+    assert.equal(unknownCancel.code, "unknown_field");
+    assert.deepEqual(
+      {
+        kind: (unknownCancel.diagnostic as Record<string, unknown>).kind,
+        field: (unknownCancel.diagnostic as Record<string, unknown>).field,
+      },
+      { kind: "validation", field: "force" },
+    );
     const unknownFact = await runCommandThroughDaemon(
       {
         rootDir: safePath(root),

--- a/packages/daemon/src/client/local-json-rpc-client.ts
+++ b/packages/daemon/src/client/local-json-rpc-client.ts
@@ -52,6 +52,7 @@ export async function requestLocalDaemonJsonRpcForTarget(
     readonly socketPath: string;
     readonly repoId?: string;
     readonly reportStaleBuild?: boolean;
+    readonly rejectStaleBuildField?: string;
     readonly canonicalRoot?: string;
     readonly userRoot?: string;
     readonly daemonId?: string;
@@ -70,6 +71,7 @@ export async function requestLocalDaemonJsonRpcForTarget(
     responseTimeoutMs,
     target.sessionEnvironment,
     target.reportStaleBuild === true,
+    target.rejectStaleBuildField,
   );
 }
 
@@ -81,6 +83,7 @@ export async function requestDaemonJsonRpcAt(
   responseTimeoutMs?: number,
   sessionEnvironment?: DaemonSessionEnvironment,
   reportStaleBuild = false,
+  rejectStaleBuildField?: string,
 ): Promise<JsonObject> {
   return requestWithSocket(
     await connectSocket(socketPath, timeoutMs),
@@ -89,6 +92,7 @@ export async function requestDaemonJsonRpcAt(
     responseTimeoutMs,
     sessionEnvironment,
     reportStaleBuild,
+    rejectStaleBuildField,
   );
 }
 
@@ -184,6 +188,7 @@ async function requestWithSocket(
   responseTimeoutMs?: number,
   sessionEnvironment?: DaemonSessionEnvironment,
   reportStaleBuild = false,
+  rejectStaleBuildField?: string,
 ): Promise<JsonObject> {
   const client = new JsonRpcLineClient(socket, socket);
   try {
@@ -207,7 +212,10 @@ async function requestWithSocket(
         (hello.warning as JsonObject).code === "daemon_build_stale"
           ? (hello.warning as JsonObject)
           : null,
-      result = await client.request(method, params, responseTimeoutMs);
+      result =
+        warning && rejectStaleBuildField
+          ? staleBuildRejection(method, rejectStaleBuildField, warning)
+          : await client.request(method, params, responseTimeoutMs);
     return warning ? { ...result, daemonBuild: warning } : result;
   } catch (error) {
     if (
@@ -240,6 +248,31 @@ function assertDaemonAdvertisesMethod(hello: JsonObject, method: string): void {
     ),
     { code: "daemon_method_unavailable" },
   );
+}
+
+function staleBuildRejection(method: string, field: string, warning: JsonObject): JsonObject {
+  const loaded = String(warning.loadedBuildId ?? "missing"),
+    disk = String(warning.diskBuildId ?? "missing");
+  return {
+    schema: "command-receipt/v2",
+    ok: false,
+    command: method,
+    outcome: "op_rejected",
+    opId: "N/A",
+    origin: "daemon",
+    code: "daemon_build_stale",
+    evidence: "rejection:daemon_build_stale",
+    error: { code: "daemon_build_stale" },
+    diagnostic: {
+      kind: "validation",
+      entity: method,
+      field,
+      actual: `loaded build ${loaded}`,
+      expectation:
+        `Daemon build must match disk build ${disk} before sending this field; ` +
+        "wait for the stale daemon to drain, then retry",
+    },
+  };
 }
 // A daemon that never answers leaves the caller with no output and no error, so a caller that knows its request is
 // cheap can name a deadline and get a classified failure instead of an open-ended wait. The hint is forked by what

--- a/packages/daemon/src/gui-s3-control.ts
+++ b/packages/daemon/src/gui-s3-control.ts
@@ -69,6 +69,7 @@ export class GuiS3ContractError extends Error {
 
 type Rule =
   | "string"
+  | "optional-string"
   | "any-string"
   | "number"
   | "boolean"
@@ -87,6 +88,7 @@ function closed(value: unknown, fields: Readonly<Record<string, Rule>>, label: s
   for (const [key, rule] of Object.entries(fields)) {
     const item = value[key];
     if (
+      (rule === "optional-string" && (item === undefined || typeof item === "string")) ||
       (rule === "optional-object" && (item === undefined || record(item))) ||
       (rule === "null-string" && (item === null || typeof item === "string")) ||
       (rule === "null-number" && (item === null || typeof item === "number")) ||
@@ -465,6 +467,8 @@ export function validateRuntimeSpawnReceipt(value: unknown): readonly string[] {
       evidence: "string",
       visibility: "string",
       proof: "object",
+      ledgerAccess: "optional-string",
+      reportDelivery: "optional-string",
 
       authorizationDecision: "nullable-object",
     },
@@ -472,6 +476,10 @@ export function validateRuntimeSpawnReceipt(value: unknown): readonly string[] {
   );
   if (!record(value)) return errors;
   if (value.schema !== "command-receipt/v2") errors.push("runtime spawn receipt schema is invalid");
+  if (value.ledgerAccess !== undefined && value.ledgerAccess !== "unavailable")
+    errors.push("runtime spawn receipt ledgerAccess is invalid");
+  if (value.reportDelivery !== undefined && value.reportDelivery !== "stdout")
+    errors.push("runtime spawn receipt reportDelivery is invalid");
   return errors;
 }
 

--- a/packages/daemon/src/protocol/daemon-protocol-validate-entities.ts
+++ b/packages/daemon/src/protocol/daemon-protocol-validate-entities.ts
@@ -60,6 +60,19 @@ export function validationError(entityId: string, field: string, actual: unknown
   );
 }
 
+export function validationDiagnostic(hint: string) {
+  const match = hint.match(/^entity=(.+?) field=(\S+) (.+); actual=(.*)$/u);
+  return match
+    ? {
+        kind: "validation" as const,
+        entity: match[1]!,
+        field: match[2]!,
+        expectation: match[3]!,
+        actual: match[4]!,
+      }
+    : null;
+}
+
 export function validationEntityId(value: unknown, fields: readonly string[], fallback: string): string {
   if (isJsonObject(value)) {
     for (const field of fields) if (nonEmpty(value[field])) return value[field];

--- a/packages/daemon/src/protocol/daemon-protocol-validate-results.ts
+++ b/packages/daemon/src/protocol/daemon-protocol-validate-results.ts
@@ -12,6 +12,7 @@ import {
   nonEmpty,
   statusWord,
   stringArray,
+  validationDiagnostic,
   validationEntityId,
   validationError,
   recordShapeError,
@@ -381,6 +382,8 @@ export const writeReceiptFields = generatedWriteReceiptFields,
     "receiptId",
     "runtimeSessionId",
     "dispatchId",
+    "ledgerAccess",
+    "reportDelivery",
     "scheduleId",
     "schedule",
     "claimFence",
@@ -428,6 +431,10 @@ export function writeReceipt(value: JsonObject): string[] {
     return [validationError(entityId, "guidance", value.guidance, "must include structured guidance")];
   if (value.guidance !== undefined && (!Array.isArray(value.guidance) || !value.guidance.every(isStructuredGuidance)))
     return [validationError(entityId, "guidance", value.guidance, "must be structured receipt guidance")];
+  if (value.ledgerAccess !== undefined && value.ledgerAccess !== "unavailable")
+    return [validationError(entityId, "ledgerAccess", value.ledgerAccess, "must be unavailable")];
+  if (value.reportDelivery !== undefined && value.reportDelivery !== "stdout")
+    return [validationError(entityId, "reportDelivery", value.reportDelivery, "must be stdout")];
   if (value.diagnostic !== undefined && !isStructuredDiagnostic(value.diagnostic))
     return [validationError(entityId, "diagnostic", value.diagnostic, "must be a structured receipt diagnostic")];
   if (noChanges) {
@@ -538,17 +545,19 @@ export function daemonProtocolError(
   };
 }
 
-function validationDiagnostic(hint: string) {
-  const match = hint.match(/^entity=(.+?) field=(\S+) (.+); actual=(.*)$/u);
-  return match
-    ? {
-        kind: "validation" as const,
-        entity: match[1]!,
-        field: match[2]!,
-        expectation: match[3]!,
-        actual: match[4]!,
-      }
-    : null;
+export function invalidParamsReceipt(method: string, errors: readonly string[]) {
+  const detail = errors.join("; "),
+    unknown = /unknown field ("(?:[^"\\]|\\.)*"); allowed fields: ((?:"(?:[^"\\]|\\.)*"(?:, )?)+)\./u.exec(detail);
+  if (!unknown) return daemonProtocolError(method, "invalid_request", detail);
+  const field = JSON.parse(unknown[1]!) as string,
+    allowed = [...unknown[2]!.matchAll(/"(?:[^"\\]|\\.)*"/gu)].map((match) => JSON.parse(match[0]!) as string);
+  return daemonProtocolError(method, "unknown_field", detail, {
+    kind: "validation",
+    entity: method,
+    field,
+    actual: "unknown",
+    expectation: `Allowed fields: ${allowed.join(", ")}`,
+  });
 }
 
 // Transport validates shape only; the kernel receipt registry owns the guidance kind vocabulary.

--- a/packages/daemon/src/protocol/daemon-protocol.contract.ts
+++ b/packages/daemon/src/protocol/daemon-protocol.contract.ts
@@ -870,6 +870,7 @@ export {
 export {
   daemonCommandReceiptRejectionCode,
   daemonProtocolError,
+  invalidParamsReceipt,
   makeDaemonCommandReceipt,
   serializeDaemonAgenda,
   serializeDaemonDecisionList,

--- a/packages/daemon/src/protocol/json-rpc-server.ts
+++ b/packages/daemon/src/protocol/json-rpc-server.ts
@@ -7,6 +7,7 @@ import {
   actionForDaemonMethod,
   daemonStreamFacets,
   daemonProtocolError,
+  invalidParamsReceipt,
   isDaemonGuiActionMethod,
   jsonRpcMethodContracts,
   makeDaemonCommandReceipt,
@@ -129,8 +130,7 @@ export function createJsonRpcProtocolServer(options: {
       return request.id === undefined ? undefined : { jsonrpc: "2.0", id, result };
     };
     const parsed = parseDaemonRpcParams(request.method, request.params);
-    if (!parsed.ok)
-      return reply(request.method, daemonProtocolError(request.method, "invalid_request", parsed.errors.join("; ")));
+    if (!parsed.ok) return reply(request.method, invalidParamsReceipt(request.method, parsed.errors));
     const call = parsed.call,
       { method, params } = call;
     observed = { ...observed, repoId: repoIdFromParams(params) };

--- a/packages/daemon/src/repo-cell-action-dispatch.ts
+++ b/packages/daemon/src/repo-cell-action-dispatch.ts
@@ -19,7 +19,7 @@ import { runFactRekey } from "./fact-rekey.ts";
 import { assertExecutionExecutorDeclarationEligible } from "./repo-cell-execution-selection.ts";
 import { runDispatchRecordMigrationAction, runEventShapeMigrationAction } from "./repo-cell-migration-actions.ts";
 import { runSquadEntityMigration } from "./squad-entity-migration.ts";
-import { type RepoCellBinding, type RepoTaskAction } from "./repo-cell-types.ts";
+import { type RepoCellBinding, type RepoTaskAction, type Snapshot } from "./repo-cell-types.ts";
 import { pullAndIngestCiObservations } from "./ci-observation-actions.ts";
 import { readTaskLineageDispatches } from "./dispatch-read.ts";
 import type { RepoCellOperationalContext } from "./repo-cell-action-context.ts";
@@ -433,9 +433,9 @@ export function declareExecutionExecutor(
         (candidate: string) =>
           `ha task declare-executor ${taskId} --execution-id ${candidate} --agent <dispatch-agent> --reason <reason>`,
       );
+  const dispatchProof = dispatchedExecutor(cell, action, taskId, executionId, snapshot, candidates);
   assertExecutionExecutorDeclarationEligible(snapshot, taskId, executionId, candidates);
-  const dispatchProof = dispatchedExecutor(cell, action, taskId, executionId),
-    canonicalAction = { ...action, agent: dispatchProof.executor.id },
+  const canonicalAction = { ...action, agent: dispatchProof.executor.id },
     opId = cell.operationId(canonicalAction, binding, cell.input.repoId, snapshot.revision),
     existing = cell.store.readEvent(opId);
   if (existing) return cell.receiptForOperation(opId, binding);
@@ -479,6 +479,8 @@ function dispatchedExecutor(
   action: RepoTaskAction,
   taskId: string,
   executionId: string,
+  snapshot: Snapshot,
+  declarationCandidates: readonly { readonly executionId: string }[],
 ): {
   readonly executor: { readonly kind: "agent"; readonly id: string };
   readonly dispatchTaskId: string;
@@ -514,13 +516,15 @@ function dispatchedExecutor(
       dispatchTaskId: matches[0]!.dispatchTaskId,
     };
   const choices = candidates.map((candidate) => candidate.executorId);
-  if (candidates.length === 0)
+  if (candidates.length === 0) {
+    assertExecutionExecutorDeclarationEligible(snapshot, taskId, executionId, declarationCandidates);
     throw cell.cellCodedError(
       "invalid_proof",
       `Task ${taskId} has no recorded runtime dispatch on itself or its parent chain. ` +
         `Run ha task dispatches ${taskId}; ` +
         "executor declaration remains unavailable until a real dispatch record exists.",
     );
+  }
   if (requested)
     throw cell.cellCodedError(
       "invalid_proof",

--- a/packages/daemon/src/repo-cell-action-dispatch.ts
+++ b/packages/daemon/src/repo-cell-action-dispatch.ts
@@ -16,6 +16,7 @@ import { distillPromotionAction, prepareDistillCandidate, readDistillEntity } fr
 import { isDocAction, runArtifactAdd, runDocAction } from "./doc-sync-actions.ts";
 import { runMigrationImport } from "./migration-import.ts";
 import { runFactRekey } from "./fact-rekey.ts";
+import { assertExecutionExecutorDeclarationEligible } from "./repo-cell-execution-selection.ts";
 import { runDispatchRecordMigrationAction, runEventShapeMigrationAction } from "./repo-cell-migration-actions.ts";
 import { runSquadEntityMigration } from "./squad-entity-migration.ts";
 import { type RepoCellBinding, type RepoTaskAction } from "./repo-cell-types.ts";
@@ -419,10 +420,11 @@ export function declareExecutionExecutor(
         " --reason <reason>.",
       ].join(""),
     );
-  const executionId =
+  const candidates = executionExecutorDeclarationCandidates(snapshot, taskId, binding.actor),
+    executionId =
       requestedExecutionId ??
       cell.uniqueDerivedExecutionId(
-        executionExecutorDeclarationCandidates(snapshot, taskId, binding.actor),
+        candidates,
         "Eligible executor-declaration execution",
         [
           `Run ha task show ${taskId}; unblock the Task if needed, then retry when`,
@@ -430,8 +432,9 @@ export function declareExecutionExecutor(
         ].join(" "),
         (candidate: string) =>
           `ha task declare-executor ${taskId} --execution-id ${candidate} --agent <dispatch-agent> --reason <reason>`,
-      ),
-    dispatchProof = dispatchedExecutor(cell, action, taskId, executionId),
+      );
+  assertExecutionExecutorDeclarationEligible(snapshot, taskId, executionId, candidates);
+  const dispatchProof = dispatchedExecutor(cell, action, taskId, executionId),
     canonicalAction = { ...action, agent: dispatchProof.executor.id },
     opId = cell.operationId(canonicalAction, binding, cell.input.repoId, snapshot.revision),
     existing = cell.store.readEvent(opId);

--- a/packages/daemon/src/repo-cell-authorization.ts
+++ b/packages/daemon/src/repo-cell-authorization.ts
@@ -9,6 +9,7 @@ import {
   type AuthorizationDecision,
   type EntityRef,
   type ReceiptJsonValue,
+  type ReceiptDiagnostic,
   type TaskProjection,
 } from "../../kernel/src/index.ts";
 import { authorizeAction } from "./authorization.ts";
@@ -315,18 +316,18 @@ export function bindVerifiedExecutorClaim(input: {
   const { executor: raw, ...action } = input.action;
   if (typeof input.binding.source === "object" && input.binding.source.kind === "assignment") {
     if (raw !== undefined && raw !== null)
-      throw invalidExecutorBinding("Assignment ingress already carries its verified executor binding.");
+      throw invalidExecutorBindingFor(input, raw, "Assignment ingress already carries its verified executor binding.");
     return { action, binding: input.binding };
   }
   if (raw === undefined || raw === null) return { action, binding: input.binding };
   if (!isExecutorDescriptorRecord(raw) || raw.kind !== "agent" || typeof raw.id !== "string")
-    throw invalidExecutorBinding("Executor claims must identify one agent actor.");
+    throw invalidExecutorBindingFor(input, raw, "Executor claims must identify one agent actor.");
   if (!raw.id.startsWith("runtime-session:")) {
     if (
       !/^[A-Za-z0-9][A-Za-z0-9._:-]*$/u.test(raw.id) ||
       Object.keys(raw).some((field) => field !== "kind" && field !== "id")
     )
-      throw invalidExecutorBinding("Executor claims must use a valid agent id.");
+      throw invalidExecutorBindingFor(input, raw, "Executor claims must use a valid agent id.");
     // Host-derived bindings always declare how authorization was projected. A binding without
     // that marker is the legacy direct RepoCell API, where action.executor was never authoritative.
     if (input.binding.authorizationBindingMode === undefined) return { action, binding: input.binding };
@@ -338,7 +339,9 @@ export function bindVerifiedExecutorClaim(input: {
       lease = taskId === null ? null : input.projection.currentLease(taskId, input.now),
       attributedByCliSession = input.binding.sessionEnvironment?.HARNESS_ACTOR?.trim() === `agent:${raw.id}`;
     if (!attributedByCliSession && (lease === null || !isSameExecution(lease.actor, claimedActor)))
-      throw invalidExecutorBinding(
+      throw invalidExecutorBindingFor(
+        input,
+        raw,
         "Executor claims must use runtime-session:<runtime-id> or match the held execution.",
       );
     return {
@@ -355,13 +358,17 @@ export function bindVerifiedExecutorClaim(input: {
     return { action, binding: input.binding };
   const match = /^runtime-session:([A-Za-z0-9][A-Za-z0-9._-]*)$/u.exec(raw.id);
   if (!match || Object.keys(raw).some((field) => field !== "kind" && field !== "id"))
-    throw invalidExecutorBinding("Executor claims must use runtime-session:<runtime-id>.");
+    throw invalidExecutorBindingFor(input, raw, "Executor claims must use runtime-session:<runtime-id>.");
   const runtimeSessionId = match[1]!,
     session = input.projection.readRuntimeSession(runtimeSessionId),
     taskId = typeof action.taskId === "string" ? action.taskId : null,
     executionId = typeof action.executionId === "string" ? action.executionId : null;
   if (session === null)
-    throw invalidExecutorBinding("The claimed RuntimeSession is not canonically bound to this Task action.");
+    throw invalidExecutorBindingFor(
+      input,
+      raw,
+      "The claimed RuntimeSession is not canonically bound to this Task action.",
+    );
   const exactBinding =
       taskId === null
         ? session.taskBindings.length === 1
@@ -396,14 +403,22 @@ export function bindVerifiedExecutorClaim(input: {
         : undefined,
     taskBinding = exactBinding ?? descendantBinding;
   if (!taskBinding)
-    throw invalidExecutorBinding("The claimed RuntimeSession does not execute the target Task/Execution.");
+    throw invalidExecutorBindingFor(
+      input,
+      raw,
+      "The claimed RuntimeSession does not execute the target Task/Execution.",
+    );
   const lease = input.projection.currentLease(taskBinding.taskId, input.now),
     runtimeActor = {
       principal: input.binding.actor.principal,
       executor: { kind: "agent" as const, id: `runtime-session:${runtimeSessionId}` },
     };
   if (lease === null || lease.executionId !== taskBinding.executionId || !isSamePerson(lease.actor, runtimeActor))
-    throw invalidExecutorBinding("The claimed RuntimeSession has no matching canonical execution lease.");
+    throw invalidExecutorBindingFor(
+      input,
+      raw,
+      "The claimed RuntimeSession has no matching canonical execution lease.",
+    );
   return { action, binding: { ...input.binding, actor: runtimeActor } };
 }
 
@@ -425,8 +440,54 @@ function actionTarget(action: RepoTaskAction): EntityRef {
   return repositoryTarget;
 }
 
-function invalidExecutorBinding(message: string): Error & { readonly code: "executor_binding_invalid" } {
-  return Object.assign(new Error(message), { code: "executor_binding_invalid" as const });
+function invalidExecutorBindingFor(
+  input: Parameters<typeof bindVerifiedExecutorClaim>[0],
+  raw: unknown,
+  message: string,
+): Error & { readonly code: "executor_binding_invalid" } {
+  const taskId = typeof input.action.taskId === "string" ? input.action.taskId : null,
+    requestedExecutionId = typeof input.action.executionId === "string" ? input.action.executionId : null,
+    lease = taskId === null ? null : input.projection.currentLease(taskId, input.now),
+    executionId = requestedExecutionId ?? lease?.executionId ?? null,
+    actual =
+      isExecutorDescriptorRecord(raw) && raw.kind === "agent" && typeof raw.id === "string"
+        ? `agent:${raw.id}`
+        : "malformed executor descriptor",
+    expected = lease?.actor.executor ? `agent:${lease.actor.executor.id}` : null,
+    retry = executorRetryCommand(input.action, taskId, executionId),
+    expectation = expected
+      ? `Expected ${expected} from the held execution lease; run from that executor, then retry ${retry}`
+      : "Expected a task-bound executor with a matching held execution lease; run ha task start " +
+        `${taskId ?? "<task-id>"}, then retry ${retry}`,
+    diagnostic: ReceiptDiagnostic = {
+      kind: "validation",
+      entity: [taskId ? `task ${taskId}` : "repository", executionId ? `execution ${executionId}` : ""]
+        .filter(Boolean)
+        .join(" "),
+      field: "executor",
+      actual,
+      expectation,
+    };
+  return Object.assign(new Error(message), { code: "executor_binding_invalid" as const, diagnostic });
+}
+
+function executorRetryCommand(action: RepoTaskAction, taskId: string | null, executionId: string | null): string {
+  const task = taskId ?? "<task-id>",
+    execution = executionId ?? "<execution-id>";
+  switch (action.kind) {
+    case "task-submit":
+      return `ha task submit ${task} --execution-id ${execution} --from-file <submission.json>`;
+    case "task-progress-append":
+      return `ha task progress append ${task} --text <progress-text>`;
+    case "fact-record":
+      return `ha fact record ${task} --statement <observation> --source <source>`;
+    case "task-artifact-add":
+      return `ha task artifact add ${task} --source <path> --destination <artifact-path>`;
+    case "doc-submit":
+      return `ha doc sync --submit --task ${task}`;
+    default:
+      return `the ha ${action.kind.replaceAll("-", " ")} command`;
+  }
 }
 
 function isExecutorDescriptorRecord(value: unknown): value is Readonly<Record<string, unknown>> {

--- a/packages/daemon/src/repo-cell-command.ts
+++ b/packages/daemon/src/repo-cell-command.ts
@@ -15,6 +15,7 @@ import { consentJsonFields } from "../../preset/src/index.ts";
 import { type DaemonGuiReadResultMap } from "./protocol/daemon-protocol.contract.ts";
 import { cellCodedError } from "./repo-cell-errors.ts";
 import {
+  assertCurrentSubmittedExecution,
   explicitExecutionId,
   reviewExecutionSelection,
   reviewConsentSelection,
@@ -117,8 +118,9 @@ export function buildCommand(
     const amendment = action.amend === true,
       held = heldLeaseForExecutionActor(snapshot, undefined, binding.actor),
       flags = `${amendment ? " --amend" : ""} --json-input '<submission-json>'`,
+      requestedExecutionId = explicitExecutionId(action),
       executionId =
-        explicitExecutionId(action) ??
+        requestedExecutionId ??
         uniqueDerivedExecutionId(
           amendment ? currentSubmittedExecutions(snapshot) : held ? [held] : [],
           amendment ? "Current submitted execution" : "Authenticated active-lease execution",
@@ -130,6 +132,7 @@ export function buildCommand(
               : `Run ha task start ${taskId}, then retry ha task submit ${taskId} --json-input '<submission-json>'.`,
           (candidate) => `ha task submit ${taskId} --execution-id ${candidate}${flags}`,
         );
+    if (amendment && requestedExecutionId) assertCurrentSubmittedExecution(snapshot, taskId, requestedExecutionId);
     return normalizeTaskLifecycleCommand(bound, {
       type: "SubmitExecution",
       taskId,

--- a/packages/daemon/src/repo-cell-command.ts
+++ b/packages/daemon/src/repo-cell-command.ts
@@ -9,7 +9,6 @@ import {
   makeTaskEventStore,
   normalizeTaskLifecycleCommand,
   reviewDigest,
-  submissionDigest,
   type TaskLifecycleCommand,
 } from "../../kernel/src/index.ts";
 import { consentJsonFields } from "../../preset/src/index.ts";
@@ -17,6 +16,7 @@ import { type DaemonGuiReadResultMap } from "./protocol/daemon-protocol.contract
 import { cellCodedError } from "./repo-cell-errors.ts";
 import {
   explicitExecutionId,
+  reviewExecutionSelection,
   reviewConsentSelection,
   uniqueDerivedExecutionId,
 } from "./repo-cell-execution-selection.ts";
@@ -140,50 +140,20 @@ export function buildCommand(
   }
   if (lifecycleAction?.commandType === "RecordReview") {
     const packet = reviewPacket(rootDir, action),
-      executionId =
-        explicitExecutionId(action) ??
-        uniqueDerivedExecutionId(
-          currentSubmittedExecutions(snapshot),
-          "Current submitted execution",
-          [
-            "Run ha task show ",
-            `${taskId}`,
-            "; if the task is active, run ha task submit ",
-            `${taskId}`,
-            " --json-input '<submission-json>'.",
-          ].join(""),
-          (candidate) =>
-            [
-              "ha task review-execution ",
-              `${taskId}`,
-              " --execution-id ",
-              `${candidate}`,
-              " --review-id <review-id> --from-file <review.json>",
-            ].join(""),
-        ),
-      submitted = snapshot.executions.find(
-        (candidate) => candidate.executionId === executionId && candidate.iteration === snapshot.task?.iteration,
-      );
-    if (!submitted?.submission)
-      throw cellCodedError(
-        "invalid_transition",
-        `Execution Review requires a submitted execution on the current iteration; current task status is ` +
-          `${snapshot.task?.status ?? "missing"} and execution status is ${submitted?.state ?? "missing"}. ` +
-          `Submit ${executionId} before review.`,
-      );
+      selection = reviewExecutionSelection(action, snapshot, taskId);
     return normalizeTaskLifecycleCommand(bound, {
       type: "RecordReview",
       taskId,
-      executionId,
+      executionId: selection.executionId,
       reviewId: requiredCellText(action.reviewId, "reviewId"),
       verdict: reviewVerdict(packet.value.verdict),
       reason: requiredCellText(packet.value.reason, "reason"),
       evidenceChecked: cellStringList(packet.value.evidenceChecked),
       ...reviewQualificationFields(packet.value),
-      commitSha: submitted.submission.commitSha,
-      iteration: submitted.iteration,
+      commitSha: selection.commitSha,
+      iteration: selection.iteration,
       contentDigest: packet.digest,
-      submissionDigest: submissionDigest(submitted.submission),
+      submissionDigest: selection.submissionDigest,
     });
   }
   if (action.kind === "task-review-consent") {

--- a/packages/daemon/src/repo-cell-execution-selection.ts
+++ b/packages/daemon/src/repo-cell-execution-selection.ts
@@ -3,6 +3,7 @@ import {
   closeoutReadiness,
   currentSubmittedExecutions,
   getExecutableEntityAction,
+  submissionDigest,
   taskActionUsage,
 } from "../../kernel/src/index.ts";
 import { cellCodedError, cellCriterionError } from "./repo-cell-errors.ts";
@@ -21,6 +22,93 @@ export function uniqueDerivedExecutionId(
 ): string {
   if (candidates.length === 1) return candidates[0]!.executionId;
   return rejectExecutionSelection(candidates, label, zeroNext, commandFor);
+}
+
+export function reviewExecutionSelection(
+  action: RepoTaskAction,
+  snapshot: Snapshot,
+  taskId: string,
+): {
+  readonly executionId: string;
+  readonly commitSha: string;
+  readonly iteration: 0 | 1;
+  readonly submissionDigest: `sha256:${string}`;
+} {
+  const requestedExecutionId = explicitExecutionId(action),
+    submittedExecutions = currentSubmittedExecutions(snapshot);
+  const executionId =
+      requestedExecutionId ??
+      uniqueDerivedExecutionId(
+        submittedExecutions,
+        "Current submitted execution",
+        `Run ha task show ${taskId}; if the task is active, run ha task submit ${taskId} ` +
+          "--json-input '<submission-json>'.",
+        (candidate) =>
+          `ha task review-execution ${taskId} --execution-id ${candidate} ` +
+          "--review-id <review-id> --from-file <review.json>",
+      ),
+    submitted = snapshot.executions.find(
+      (candidate) => candidate.executionId === executionId && candidate.iteration === snapshot.task?.iteration,
+    );
+  if (!submitted?.submission) throw reviewExecutionStateError(snapshot, taskId, submitted, executionId);
+  return {
+    executionId,
+    commitSha: submitted.submission.commitSha,
+    iteration: submitted.iteration,
+    submissionDigest: submissionDigest(submitted.submission),
+  };
+}
+
+export function assertExecutionExecutorDeclarationEligible(
+  snapshot: Snapshot,
+  taskId: string,
+  executionId: string,
+  candidates: readonly { readonly executionId: string }[],
+): void {
+  if (candidates.some((candidate) => candidate.executionId === executionId)) return;
+  const execution = snapshot.executions.find((candidate) => candidate.executionId === executionId),
+    executor = execution?.actor.executor,
+    assigned = executor !== null && executor !== undefined;
+  throw cellCodedError(
+    "invalid_proof",
+    "Executor declaration is only valid for a current submitted review execution with no executor.",
+    {
+      kind: "validation",
+      entity: `execution ${executionId}`,
+      field: "declareExecutor",
+      actual:
+        `status=${execution?.state ?? "missing"} node=${snapshot.task?.currentNode ?? "missing"} ` +
+        `executor=${executor ? `${executor.kind}:${executor.id}` : "none"}`,
+      expectation: assigned
+        ? "Use declare-executor only when status=submitted node=review executor=none; this assigned execution " +
+          `must continue with ha task review-execution ${taskId} --execution-id ${executionId} ` +
+          "--review-id <review-id> --from-file <review.json>"
+        : "Use declare-executor only when status=submitted node=review executor=none; run " +
+          `ha task show ${taskId}, submit the current execution if needed, then retry the declaration`,
+    },
+  );
+}
+
+function reviewExecutionStateError(
+  snapshot: Snapshot,
+  taskId: string,
+  execution: Snapshot["executions"][number] | undefined,
+  requestedExecutionId?: string,
+): Error {
+  const executionId = requestedExecutionId ?? execution?.executionId;
+  return cellCodedError(
+    "invalid_transition",
+    `Execution Review requires a submitted execution on the current iteration; current task status is ` +
+      `${snapshot.task?.status ?? "missing"} and execution status is ${execution?.state ?? "missing"}. ` +
+      `Submit ${executionId ?? "the current execution"} before review.`,
+    {
+      kind: "validation",
+      entity: executionId ? `execution ${executionId}` : `task ${taskId}`,
+      field: "status",
+      actual: execution?.state ?? "missing",
+      expectation: "Execution status must be submitted on the current task iteration before review",
+    },
+  );
 }
 
 export function rejectExecutionSelection(

--- a/packages/daemon/src/repo-cell-execution-selection.ts
+++ b/packages/daemon/src/repo-cell-execution-selection.ts
@@ -14,6 +14,33 @@ export function explicitExecutionId(action: RepoTaskAction): string | undefined 
   return action.executionId === undefined ? undefined : requiredCellText(action.executionId, "executionId");
 }
 
+export function assertCurrentSubmittedExecution(
+  snapshot: Snapshot,
+  taskId: string,
+  requestedExecutionId: string,
+): void {
+  const currentIds = currentSubmittedExecutions(snapshot).map(({ executionId }) => executionId);
+  if (currentIds.includes(requestedExecutionId)) return;
+  const current = currentIds.length ? currentIds.join(", ") : "none",
+    expectation =
+      currentIds.length === 1
+        ? `Current submitted execution is ${current}; retry ha task submit ${taskId} --execution-id ${current} ` +
+          "--amend --json-input '<submission-json>'"
+        : `Choose a current submitted execution (${current}) after running ha task show ${taskId}`;
+  throw cellCodedError(
+    "invalid_transition",
+    `Execution ${requestedExecutionId} is not the current submitted execution for task ${taskId}; ` +
+      `current submitted execution: ${current}.`,
+    {
+      kind: "validation",
+      entity: `task ${taskId}`,
+      field: "executionId",
+      actual: requestedExecutionId,
+      expectation,
+    },
+  );
+}
+
 export function uniqueDerivedExecutionId(
   candidates: readonly { readonly executionId: string }[],
   label: string,

--- a/packages/daemon/src/repo-cell-packets.ts
+++ b/packages/daemon/src/repo-cell-packets.ts
@@ -9,13 +9,14 @@ import {
 } from "../../kernel/src/index.ts";
 import { validateGuiSubmission, type GuiSubmissionV1 } from "./protocol/daemon-protocol.contract.ts";
 import { reviewJsonFields, taskSubmissionJsonFields } from "./protocol/daemon-protocol-commands-task.ts";
+import { validationDiagnostic } from "./protocol/daemon-protocol-validate-entities.ts";
 import { cellCodedError } from "./repo-cell-errors.ts";
 import { gateChecks } from "./repo-cell-proof.ts";
 import { requiredCellText } from "./repo-cell-settlement.ts";
 import type { PublicPublication, RepoTaskAction, Snapshot } from "./repo-cell-types.ts";
 import { readWorkspaceText } from "./workspace-text-port.ts";
 
-export function packetJson(value: unknown, fields: readonly string[]): Record<string, unknown> {
+export function packetJson(value: unknown, fields: readonly string[], entity = "JSON packet"): Record<string, unknown> {
   let parsed: unknown;
   try {
     parsed = JSON.parse(requiredCellText(value, "jsonInput"));
@@ -27,13 +28,20 @@ export function packetJson(value: unknown, fields: readonly string[]): Record<st
   }
   if (!parsed || typeof parsed !== "object" || Array.isArray(parsed))
     throw cellCodedError("invalid_command", `JSON packet requires exactly: ${fields.join(", ")}.`);
-  const present = Object.keys(parsed),
+  const packet = parsed as Record<string, unknown>,
+    present = Object.keys(packet),
     missing = fields.filter((field) => !present.includes(field));
   if (missing.length)
-    throw cellCodedError("missing_field", `JSON packet is missing required fields: ${missing.join(", ")}.`);
+    throw cellCodedError("missing_field", `JSON packet is missing required fields: ${missing.join(", ")}.`, {
+      kind: "validation",
+      entity,
+      field: missing[0]!,
+      actual: "missing",
+      expectation: `Required fields: ${fields.join(", ")}`,
+    });
   if (present.sort().join("\0") !== [...fields].sort().join("\0"))
     throw cellCodedError("invalid_command", `JSON packet requires exactly: ${fields.join(", ")}.`);
-  return parsed as Record<string, unknown>;
+  return packet;
 }
 
 export function workspaceText(rootDir: string, requestedValue: unknown, field: string): string {
@@ -57,13 +65,14 @@ export function packetRecord(
   rootDir: string,
   action: Readonly<Record<string, unknown>>,
   fields: readonly string[],
+  entity?: string,
 ): {
   readonly value: Record<string, unknown>;
   readonly digest: `sha256:${string}`;
 } {
   const body = readPacketSource(rootDir, action);
   return {
-    value: packetJson(body, fields),
+    value: packetJson(body, fields, entity),
     digest: packetDigest(body),
   };
 }
@@ -141,9 +150,24 @@ export function submissionPacket(action: RepoTaskAction, rootDir: string): GuiSu
       "invalid_command",
       "Submit accepts either its RPC submission or one CLI JSON source, not both.",
     );
-  const value = action.submission ?? packetRecord(rootDir, action, taskSubmissionJsonFields).value,
+  const value = action.submission ?? packetRecord(rootDir, action, taskSubmissionJsonFields, "task submission").value,
     issues = validateGuiSubmission(value);
-  if (issues.length) throw cellCodedError("invalid_submission", issues.join("; "));
+  if (issues.length) {
+    const first = validationDiagnostic(issues[0]!);
+    throw cellCodedError(
+      "invalid_submission",
+      issues.join("; "),
+      first
+        ? {
+            ...first,
+            entity: "task submission",
+            expectation:
+              `${first.expectation}; fix the packet, then retry ha task submit ${String(action.taskId)} ` +
+              `--execution-id ${String(action.executionId)} --from-file <submission.json>`,
+          }
+        : undefined,
+    );
+  }
   return value as unknown as GuiSubmissionV1;
 }
 

--- a/packages/daemon/src/repo-cell-proof.ts
+++ b/packages/daemon/src/repo-cell-proof.ts
@@ -201,6 +201,7 @@ export async function proofFor(
               verified.missingPaths.join(", "),
               ".",
             ].join(""),
+        codeDocVerificationDiagnostic("code-doc reconciliation", command.commitSha, command.paths, verified),
       );
     return {
       actorBinding: command.actor,
@@ -230,6 +231,7 @@ export async function proofFor(
               verified.missingPaths.join(", "),
               ".",
             ].join(""),
+        codeDocVerificationDiagnostic("code-doc repoint", command.commitSha, command.paths, verified),
       );
     return {
       actorBinding: command.actor,
@@ -241,6 +243,33 @@ export async function proofFor(
   if (command.type !== "CompleteTask")
     throw cellCodedError("invalid_command", `No authority proof plan exists for ${command.type}.`);
   return completeProof(command, snapshot, binding) as TaskLifecycleServiceProof<typeof command>;
+}
+
+function codeDocVerificationDiagnostic(
+  entity: string,
+  commitSha: string,
+  paths: readonly string[],
+  verified: ReturnType<typeof verifyCodeDocCommitPaths>,
+) {
+  if (verified.ok)
+    throw cellCodedError("invalid_store", "Code-doc verification produced a rejection diagnostic for a valid cut.");
+  if (verified.code === "commit_not_found")
+    return {
+      kind: "validation" as const,
+      entity,
+      field: "commitSha",
+      actual: commitSha,
+      expectation: "Commit must exist in the public or authored Git repository",
+    };
+  const missing = verified.missingPaths[0]!,
+    index = Math.max(0, paths.indexOf(missing));
+  return {
+    kind: "validation" as const,
+    entity,
+    field: `paths[${String(index)}]`,
+    actual: missing,
+    expectation: "Path must be relative to the Git repository that owns the submitted commit",
+  };
 }
 
 function validNoIndependentReview(

--- a/packages/daemon/src/repo-cell-task-query.ts
+++ b/packages/daemon/src/repo-cell-task-query.ts
@@ -7,6 +7,7 @@ import {
   isDomainStatus,
   taskWipOccupyingStatuses,
   type DomainStatus,
+  type ReceiptDiagnostic,
   type TaskProjection,
   type TaskProjectionListQuery,
   type TaskRelationQuery,
@@ -40,7 +41,7 @@ export interface TaskQueryCell {
     worktreeVisible: boolean | null,
     cut?: { readonly status: "ready" | "pending"; readonly watermark: number; readonly sourceRevision: number },
   ) => WriteReceipt;
-  readonly cellCodedError: (code: string, message: string) => Error;
+  readonly cellCodedError: (code: string, message: string, diagnostic?: ReceiptDiagnostic) => Error;
   readonly requiredCellText: (value: unknown, name: string) => string;
   readonly wipSnapshotEntries: () => readonly TaskWipSnapshotEntryV1[];
   readonly legacyReviewLint: typeof import("./repo-cell-review-lint.ts").legacyReviewLint;

--- a/packages/daemon/src/runtime-spawn-errors.ts
+++ b/packages/daemon/src/runtime-spawn-errors.ts
@@ -1,4 +1,4 @@
-import type { AgentRuntimeEventV1, TaskProjection } from "../../kernel/src/index.ts";
+import type { AgentRuntimeEventV1, ReceiptDiagnostic, TaskProjection } from "../../kernel/src/index.ts";
 import { scrubProviderValue } from "./dispatch-stream.ts";
 
 export function requiredRuntimeSpawnText(value: unknown, field: string): string {
@@ -64,8 +64,8 @@ export function runtimeTaskLeaseRequiredMessage(
   ].join("");
 }
 
-export function runtimeSpawnError(code: string, message: string): Error {
-  return Object.assign(new Error(message), { code });
+export function runtimeSpawnError(code: string, message: string, diagnostic?: ReceiptDiagnostic): Error {
+  return Object.assign(new Error(message), { code, ...(diagnostic ? { diagnostic } : {}) });
 }
 
 export function runtimeErrorCode(error: unknown): string | null {

--- a/packages/daemon/src/runtime-spawn-mission.ts
+++ b/packages/daemon/src/runtime-spawn-mission.ts
@@ -51,6 +51,19 @@ export function assembleAgentPrompt(
   ].join("\n\n");
 }
 
+export function dispatchMissionForPermission(mission: string, permissionMode: string | undefined): string {
+  if (permissionMode !== "read-only") return mission;
+  return [
+    mission,
+    "",
+    "# Read-only Dispatch Contract",
+    "",
+    "Repository writes and daemon-ledger commands are unavailable in this runtime.",
+    "Do not call `ha task progress append`, `ha fact record`, or `ha doc sync --submit`;",
+    "return the complete report in final stdout for the dispatcher to persist.",
+  ].join("\n");
+}
+
 export async function resolveRuntimeInstanceId(input: {
   readonly requested?: string;
   readonly providerSessionId?: string;

--- a/packages/daemon/src/runtime-spawn-mission.ts
+++ b/packages/daemon/src/runtime-spawn-mission.ts
@@ -168,6 +168,15 @@ export function runtimeMissionName(value: unknown): string {
     throw runtimeSpawnError(
       "invalid_runtime_mission",
       "Use --mission <name> with 1..64 lowercase letters, digits, or hyphens; path separators are forbidden.",
+      {
+        kind: "validation",
+        entity: "runtime mission",
+        field: "mission",
+        actual: typeof value === "string" && /[/\\]/u.test(value) ? "path-like value" : "invalid mission id",
+        expectation:
+          "Expected a bare mission id; the daemon resolves harness/<task-package>/artifacts/missions/<name>.md " +
+          "and did not look up this file. Retry ha runtime run <runtime-instance> --task <task-id> --mission <name>",
+      },
     );
   return value;
 }

--- a/packages/daemon/src/runtime-spawner.ts
+++ b/packages/daemon/src/runtime-spawner.ts
@@ -52,6 +52,7 @@ import {
   assembleScheduledMission,
   assembleTaskMission,
   deriveTaskMission,
+  dispatchMissionForPermission,
   resolveRuntimeCwd,
   resolveRuntimeInstanceId,
   runtimeMissionName,
@@ -487,9 +488,7 @@ export function makeRuntimeSpawner(input: RuntimeSpawnerInput) {
         undefined,
       effectivePermissionMode = permissionMode ?? configuredPermissionMode,
       readOnlyDispatch = effectivePermissionMode === "read-only",
-      dispatchMission = readOnlyDispatch
-        ? `${selfContainedMission ?? mission}\n\n${readOnlyDispatchNotice}`
-        : (selfContainedMission ?? mission),
+      dispatchMission = dispatchMissionForPermission(selfContainedMission ?? mission, effectivePermissionMode),
       prompt = agent ? assembleAgentPrompt(agent, dispatchMission, preset, resolvedSkills) : dispatchMission,
       prepared = await input.prepareLaunch(runtimeInstanceId, {
         cwd,
@@ -1044,14 +1043,6 @@ export function makeRuntimeSpawner(input: RuntimeSpawnerInput) {
     timer.unref();
   }
 }
-
-const readOnlyDispatchNotice = [
-  "# Read-only Dispatch Contract",
-  "",
-  "Repository writes and daemon-ledger commands are unavailable in this runtime.",
-  "Do not call `ha task progress append`, `ha fact record`, or `ha doc sync --submit`;",
-  "return the complete report in final stdout for the dispatcher to persist.",
-].join("\n");
 
 function requiredRuntimeFast(value: unknown): boolean {
   if (typeof value !== "boolean") throw runtimeSpawnError("invalid_runtime_fast", "Runtime fast must be a boolean.");

--- a/packages/daemon/src/runtime-spawner.ts
+++ b/packages/daemon/src/runtime-spawner.ts
@@ -472,9 +472,6 @@ export function makeRuntimeSpawner(input: RuntimeSpawnerInput) {
         inheritedFallback ??
         initialFallbackAttempt(agent, explicitRuntimeInstanceId, model, providerSessionId, idempotencyKey, mission),
       fallbackCandidate = fallbackAttempt?.candidates[fallbackAttempt.attemptIndex],
-      prompt = agent
-        ? assembleAgentPrompt(agent, selfContainedMission ?? mission, preset, resolvedSkills)
-        : (selfContainedMission ?? mission),
       selectedModel = fallbackCandidate?.model ?? model ?? agent?.model ?? undefined,
       runtimeSessions = input.remote ? await input.remote.readRuntimeSessions() : projection!.readRuntimeSessions(),
       runtimeInstanceId = await resolveRuntimeInstanceId({
@@ -489,6 +486,11 @@ export function makeRuntimeSpawner(input: RuntimeSpawnerInput) {
         input.runtimeInstances?.().find((instance) => instance.instanceId === runtimeInstanceId)?.permissionMode ??
         undefined,
       effectivePermissionMode = permissionMode ?? configuredPermissionMode,
+      readOnlyDispatch = effectivePermissionMode === "read-only",
+      dispatchMission = readOnlyDispatch
+        ? `${selfContainedMission ?? mission}\n\n${readOnlyDispatchNotice}`
+        : (selfContainedMission ?? mission),
+      prompt = agent ? assembleAgentPrompt(agent, dispatchMission, preset, resolvedSkills) : dispatchMission,
       prepared = await input.prepareLaunch(runtimeInstanceId, {
         cwd,
         prompt,
@@ -799,10 +801,12 @@ export function makeRuntimeSpawner(input: RuntimeSpawnerInput) {
           ...requested.receipt,
           runtimeSessionId,
           dispatchId: newDispatchId,
+          ...(readOnlyDispatch ? { ledgerAccess: "unavailable", reportDelivery: "stdout" } : {}),
           authorizationDecision: authorizationDecision as unknown as JsonObject | null,
         }
       : {
           ...applied(requested.event, requested.publication!, runtimeSessionId, newDispatchId),
+          ...(readOnlyDispatch ? { ledgerAccess: "unavailable", reportDelivery: "stdout" } : {}),
           authorizationDecision: authorizationDecision as unknown as JsonObject | null,
         };
   };
@@ -1040,6 +1044,14 @@ export function makeRuntimeSpawner(input: RuntimeSpawnerInput) {
     timer.unref();
   }
 }
+
+const readOnlyDispatchNotice = [
+  "# Read-only Dispatch Contract",
+  "",
+  "Repository writes and daemon-ledger commands are unavailable in this runtime.",
+  "Do not call `ha task progress append`, `ha fact record`, or `ha doc sync --submit`;",
+  "return the complete report in final stdout for the dispatcher to persist.",
+].join("\n");
 
 function requiredRuntimeFast(value: unknown): boolean {
   if (typeof value !== "boolean") throw runtimeSpawnError("invalid_runtime_fast", "Runtime fast must be a boolean.");

--- a/packages/daemon/src/task-action-catalog-runtime.ts
+++ b/packages/daemon/src/task-action-catalog-runtime.ts
@@ -300,7 +300,10 @@ function submitActionRejection(
       contract,
       action,
     );
-  return taskActionRejection(cell, action, binding, snapshot.revision, contract, [evaluation], rejected);
+  return {
+    ...taskActionRejection(cell, action, binding, snapshot.revision, contract, [evaluation], rejected),
+    nextActions: Object.freeze([...new Set(evaluation.nextActions)]),
+  };
 }
 
 function taskActionFailure(

--- a/packages/daemon/src/task-action-catalog-runtime.ts
+++ b/packages/daemon/src/task-action-catalog-runtime.ts
@@ -93,12 +93,6 @@ export async function runTaskActionCatalogRuntime(
     submitLeaseEvaluation = evaluations.find(({ criterionRef }) => criterionRef === SUBMIT_PROOF_CRITERION),
     submitValidationUnmet = submitValidationEvaluation?.status === "unmet",
     submitLeaseUnmet = submitLeaseEvaluation?.status === "unmet";
-  if (action.kind === "task-submit" && submitValidationUnmet && contract)
-    return taskActionRejection(cell, action, binding, current.snapshot.revision, contract, [
-      submitValidationEvaluation,
-    ]);
-  if (action.kind === "task-submit" && submitLeaseUnmet && contract)
-    return taskActionRejection(cell, action, binding, current.snapshot.revision, contract, [submitLeaseEvaluation]);
   if (lifecycle?.coordination === "reserve" && !preview)
     cell.assertTaskTransitionDocumentReady({
       rootDir: cell.rootDir,
@@ -107,6 +101,8 @@ export async function runTaskActionCatalogRuntime(
       slot: "task.plan",
       transition: "task.start",
     });
+  if (action.kind === "task-submit" && submitLeaseUnmet && contract)
+    return taskActionRejection(cell, action, binding, current.snapshot.revision, contract, [submitLeaseEvaluation]);
   let normalized: ReturnType<RepoCellOperationalContext["buildCommand"]>;
   try {
     normalized = cell.buildCommand(
@@ -131,6 +127,10 @@ export async function runTaskActionCatalogRuntime(
     if (rejection) return rejection;
     throw error;
   }
+  if (action.kind === "task-submit" && submitValidationUnmet && contract)
+    return taskActionRejection(cell, action, binding, current.snapshot.revision, contract, [
+      submitValidationEvaluation,
+    ]);
   if (
     contract?.target.kind === "task" &&
     revisionIssues(current.snapshot, {
@@ -153,10 +153,43 @@ export async function runTaskActionCatalogRuntime(
       executionId = commandFields[lifecycle.targetIdField];
     if (typeof executionId !== "string")
       throw cell.cellCodedError("invalid_command", `${lifecycle.commandType} requires a target entity id.`);
-    if (!canStartExecution(current.snapshot, executionId) && contract)
-      return taskActionRejection(cell, action, binding, current.snapshot.revision, contract, [
-        criterionEvaluation(evaluations, START_CRITERION),
-      ]);
+    if (!canStartExecution(current.snapshot, executionId) && contract) {
+      const activeExecution = current.snapshot.executions.find(
+          (candidate) => candidate.state === "active" && candidate.iteration === current.snapshot.task?.iteration,
+        ),
+        rejected = activeExecution
+          ? cell.failed(
+              cell.operationId(action, binding, cell.input.repoId, current.snapshot.revision),
+              cell.cellCodedError(
+                "invalid_transition",
+                `Current task round already has active execution ${activeExecution.executionId}.`,
+                {
+                  kind: "validation",
+                  entity: `task ${taskId}`,
+                  field: "executionId",
+                  actual:
+                    `active execution=${activeExecution.executionId} ` +
+                    `status=${current.snapshot.task?.status ?? "missing"} ` +
+                    `node=${current.snapshot.task?.currentNode ?? "missing"}`,
+                  expectation:
+                    `Current round already has an active execution; run ha task start ${taskId} ` +
+                    "without --execution-id to reuse it",
+                },
+              ),
+              contract,
+              action,
+            )
+          : undefined;
+      return taskActionRejection(
+        cell,
+        action,
+        binding,
+        current.snapshot.revision,
+        contract,
+        [criterionEvaluation(evaluations, START_CRITERION)],
+        rejected,
+      );
+    }
   }
   if (preview && lifecycle) {
     const commandFields = normalized as unknown as Readonly<Record<string, unknown>>,

--- a/packages/daemon/src/task-action-catalog-runtime.ts
+++ b/packages/daemon/src/task-action-catalog-runtime.ts
@@ -10,7 +10,8 @@ import {
   type WriteReceiptDraft as WriteReceipt,
 } from "../../kernel/src/index.ts";
 import { actionCriterionFailure, attributeCellCriterion } from "./repo-cell-errors.ts";
-import { leaseTtlMs, type RepoCellBinding, type RepoTaskAction } from "./repo-cell-types.ts";
+import { assertCurrentSubmittedExecution } from "./repo-cell-execution-selection.ts";
+import { leaseTtlMs, type RepoCellBinding, type RepoTaskAction, type Snapshot } from "./repo-cell-types.ts";
 import type { RepoCellOperationalContext } from "./repo-cell-action-context.ts";
 
 const REVISION_CRITERION = "task-lifecycle-contract-support/revisionIssues";
@@ -93,6 +94,17 @@ export async function runTaskActionCatalogRuntime(
     submitLeaseEvaluation = evaluations.find(({ criterionRef }) => criterionRef === SUBMIT_PROOF_CRITERION),
     submitValidationUnmet = submitValidationEvaluation?.status === "unmet",
     submitLeaseUnmet = submitLeaseEvaluation?.status === "unmet";
+  if (
+    action.kind === "task-submit" &&
+    action.amend === true &&
+    typeof action.executionId === "string" &&
+    action.executionId.trim()
+  )
+    assertCurrentSubmittedExecution(current.snapshot, taskId, action.executionId);
+  if (action.kind === "task-submit" && submitValidationUnmet && contract)
+    return submitActionRejection(cell, action, binding, current.snapshot, contract, submitValidationEvaluation);
+  if (action.kind === "task-submit" && submitLeaseUnmet && contract)
+    return submitActionRejection(cell, action, binding, current.snapshot, contract, submitLeaseEvaluation);
   if (lifecycle?.coordination === "reserve" && !preview)
     cell.assertTaskTransitionDocumentReady({
       rootDir: cell.rootDir,
@@ -125,12 +137,6 @@ export async function runTaskActionCatalogRuntime(
     if (rejection) return rejection;
     throw error;
   }
-  if (action.kind === "task-submit" && submitValidationUnmet && contract)
-    return taskActionRejection(cell, action, binding, current.snapshot.revision, contract, [
-      submitValidationEvaluation,
-    ]);
-  if (action.kind === "task-submit" && submitLeaseUnmet && contract)
-    return taskActionRejection(cell, action, binding, current.snapshot.revision, contract, [submitLeaseEvaluation]);
   if (
     contract?.target.kind === "task" &&
     revisionIssues(current.snapshot, {
@@ -257,6 +263,44 @@ export async function runTaskActionCatalogRuntime(
       proof: result.proof,
     };
   return cell.rejected(command.opId, result.code ?? "publication_unknown");
+}
+
+function submitActionRejection(
+  cell: RepoCellOperationalContext,
+  action: RepoTaskAction,
+  binding: RepoCellBinding,
+  snapshot: Snapshot,
+  contract: EntityActionContract,
+  evaluation: { readonly criterionRef: string; readonly nextActions: readonly string[] },
+): WriteReceipt {
+  const criterion = contract.criteria.find(({ ref }) => ref === evaluation.criterionRef);
+  if (!criterion) throw new Error(`Task Action ${contract.id} criterion ${evaluation.criterionRef} is not declared.`);
+  const proofFailure = evaluation.criterionRef === SUBMIT_PROOF_CRITERION,
+    lease = snapshot.lease,
+    executor = lease?.actor.executor,
+    actual = proofFailure
+      ? lease
+        ? `held by personId=${lease.actor.principal.personId}, ` +
+          `executor=${executor ? `${executor.kind}:${executor.id}` : "none"}`
+        : "no matching active lease for the authenticated actor"
+      : `status=${snapshot.task?.status ?? "missing"} node=${snapshot.task?.currentNode ?? "missing"} ` +
+        `amend=${String(action.amend === true)}`,
+    rejected = cell.failed(
+      cell.operationId(action, binding, cell.input.repoId, snapshot.revision),
+      cell.cellCodedError(criterion.failureCode, criterion.explain, {
+        kind: "validation",
+        entity:
+          typeof action.executionId === "string"
+            ? `task ${String(action.taskId)} execution ${action.executionId}`
+            : `task ${String(action.taskId)}`,
+        field: proofFailure ? "lease" : "status",
+        actual,
+        expectation: evaluation.nextActions.join(" ") || criterion.explain,
+      }),
+      contract,
+      action,
+    );
+  return taskActionRejection(cell, action, binding, snapshot.revision, contract, [evaluation], rejected);
 }
 
 function taskActionFailure(

--- a/packages/daemon/src/task-action-catalog-runtime.ts
+++ b/packages/daemon/src/task-action-catalog-runtime.ts
@@ -101,8 +101,6 @@ export async function runTaskActionCatalogRuntime(
       slot: "task.plan",
       transition: "task.start",
     });
-  if (action.kind === "task-submit" && submitLeaseUnmet && contract)
-    return taskActionRejection(cell, action, binding, current.snapshot.revision, contract, [submitLeaseEvaluation]);
   let normalized: ReturnType<RepoCellOperationalContext["buildCommand"]>;
   try {
     normalized = cell.buildCommand(
@@ -131,6 +129,8 @@ export async function runTaskActionCatalogRuntime(
     return taskActionRejection(cell, action, binding, current.snapshot.revision, contract, [
       submitValidationEvaluation,
     ]);
+  if (action.kind === "task-submit" && submitLeaseUnmet && contract)
+    return taskActionRejection(cell, action, binding, current.snapshot.revision, contract, [submitLeaseEvaluation]);
   if (
     contract?.target.kind === "task" &&
     revisionIssues(current.snapshot, {

--- a/packages/daemon/test/action-failure-explanation.integration.test.ts
+++ b/packages/daemon/test/action-failure-explanation.integration.test.ts
@@ -34,7 +34,7 @@ const owner = {
   ),
   selfReviewer = withRoleBinding(owner, "arbiter");
 
-test("Task execution rejects with the exact Action criterion and performs no rejected mutation", async () => {
+test("Task execution rejects with the exact Action criterion and performs no rejected mutation", async (context) => {
   const rootDir = workspace("criteria"),
     repoId = workspaceId("action-failure-criteria"),
     taskId = "task-action-failure",
@@ -49,12 +49,23 @@ test("Task execution rejects with the exact Action criterion and performs no rej
     );
     assert.equal((await cell.run({ kind: "task-start", taskId, executionId }, owner)).outcome, "applied");
 
-    await assertRejectedWithoutMutation(
+    const leaseRejected = await assertRejectedWithoutMutation(
       rootDir,
       repoId,
       () => cell!.run({ kind: "task-submit", taskId, executionId }, otherWriter),
       ["repo-cell-proof/proofFor.SubmitExecution"],
     );
+    assert.deepEqual(leaseRejected.diagnostic, {
+      kind: "validation",
+      entity: `task ${taskId} execution ${executionId}`,
+      field: "lease",
+      actual: "held by personId=person-failure-owner, executor=agent:failure-owner",
+      expectation:
+        "The authenticated actor owns the active lease or the submitted execution being amended. Then retry " +
+        `ha task submit ${taskId} [--execution-id <execution-id>] [--amend] ` +
+        "[--from-file <from-file>] [--json-input <json|@->].",
+    });
+    context.diagnostic(`submit proof rejection=${JSON.stringify(leaseRejected)}`);
     await assertRejectedWithoutMutation(
       rootDir,
       repoId,

--- a/packages/daemon/test/daemon-stale-schema-client.test.ts
+++ b/packages/daemon/test/daemon-stale-schema-client.test.ts
@@ -1,0 +1,61 @@
+// harness-test-tier: fast
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import net from "node:net";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { requestLocalDaemonJsonRpcForTarget } from "../src/client/local-json-rpc-client.ts";
+
+test("a schema-sensitive request stops at a stale-build handshake with a named field", async () => {
+  const parent = mkdtempSync(path.join(tmpdir(), "ha-stale-schema-client-")),
+    socketPath = path.join(parent, "client.sock"),
+    methods: string[] = [],
+    server = net.createServer((socket) => {
+      socket.on("data", (chunk: Buffer) => {
+        for (const line of chunk.toString("utf8").split("\n").filter(Boolean)) {
+          const request = JSON.parse(line) as { readonly id: number; readonly method: string };
+          methods.push(request.method);
+          const result =
+            request.method === "protocol.hello"
+              ? {
+                  ok: true,
+                  warning: {
+                    code: "daemon_build_stale",
+                    loadedBuildId: "build-a",
+                    diskBuildId: "build-b",
+                    liveRuntimeSessions: 2,
+                    pendingWrites: 0,
+                    attachingRepositories: 0,
+                    message: "Loaded daemon build is stale and will exit after its work drains.",
+                  },
+                }
+              : { ok: true };
+          socket.write(`${JSON.stringify({ jsonrpc: "2.0", id: request.id, result })}\n`);
+        }
+      });
+    });
+  await new Promise<void>((resolve) => server.listen(socketPath, resolve));
+  try {
+    const receipt = await requestLocalDaemonJsonRpcForTarget(
+      { socketPath, reportStaleBuild: true, rejectStaleBuildField: "agentId" },
+      "repo.agentRuntime.spawn",
+      { repo: { repoId: "alpha" }, payload: { agentId: "reviewer" } },
+      2_000,
+      5_000,
+    );
+    assert.equal(receipt.code, "daemon_build_stale");
+    assert.deepEqual(receipt.diagnostic, {
+      kind: "validation",
+      entity: "repo.agentRuntime.spawn",
+      field: "agentId",
+      actual: "loaded build build-a",
+      expectation:
+        "Daemon build must match disk build build-b before sending this field; wait for the stale daemon to drain, then retry",
+    });
+    assert.deepEqual(methods, ["protocol.hello"], "the incompatible payload must not reach the stale daemon");
+  } finally {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+    rmSync(parent, { recursive: true, force: true });
+  }
+});

--- a/packages/daemon/test/gui-s3-resident.integration.test.ts
+++ b/packages/daemon/test/gui-s3-resident.integration.test.ts
@@ -20,70 +20,358 @@ import { createUnixSocketTransportServer } from "../src/transport/unix-socket.ts
 import { writeProviderExecutable } from "./fixtures/runtime-stub.ts";
 
 test("a caller that names a response deadline gets a classified failure instead of an open-ended silent socket", async () => {
-  const root = mkdtempSync(path.join(tmpdir(), "daemon-response-deadline-")), endpoint = localEndpoint(root, "quiet.sock");
-  const server = net.createServer((socket) => { socket.on("data", (chunk) => { for (const line of String(chunk).split("\n").filter(Boolean)) { const request = JSON.parse(line) as { readonly id: number; readonly method: string };
-    if (request.method === "protocol.hello") socket.write(`${JSON.stringify({ jsonrpc: "2.0", id: request.id, result: { ok: true } })}\n`); } }); });
+  const root = mkdtempSync(path.join(tmpdir(), "daemon-response-deadline-")),
+    endpoint = localEndpoint(root, "quiet.sock");
+  const server = net.createServer((socket) => {
+    socket.on("data", (chunk) => {
+      for (const line of String(chunk).split("\n").filter(Boolean)) {
+        const request = JSON.parse(line) as { readonly id: number; readonly method: string };
+        if (request.method === "protocol.hello")
+          socket.write(`${JSON.stringify({ jsonrpc: "2.0", id: request.id, result: { ok: true } })}\n`);
+      }
+    });
+  });
   await new Promise<void>((resolve) => server.listen(endpoint, resolve));
   try {
     const started = Date.now();
-    await assert.rejects(() => requestDaemonJsonRpcAt(endpoint, "repo.task.run", {}, 2_000, 250), (error: unknown) => { assert.equal((error as { readonly code?: string }).code, "daemon_response_timeout"); return /did not answer repo\.task\.run within 0\.25s/u.test(String(error)); });
+    await assert.rejects(
+      () => requestDaemonJsonRpcAt(endpoint, "repo.task.run", {}, 2_000, 250),
+      (error: unknown) => {
+        assert.equal((error as { readonly code?: string }).code, "daemon_response_timeout");
+        return /did not answer repo\.task\.run within 0\.25s/u.test(String(error));
+      },
+    );
     assert.equal(Date.now() - started < 2_000, true, "the deadline must fire without waiting for the connect timeout");
-    assert.deepEqual(await requestDaemonJsonRpcAt(endpoint, "protocol.hello", { protocolVersion: currentDaemonProtocolVersion }, 2_000, 2_000), { ok: true });
-  } finally { server.close(); rmSync(root, { recursive: true, force: true }); }
+    assert.deepEqual(
+      await requestDaemonJsonRpcAt(
+        endpoint,
+        "protocol.hello",
+        { protocolVersion: currentDaemonProtocolVersion },
+        2_000,
+        2_000,
+      ),
+      { ok: true },
+    );
+  } finally {
+    server.close();
+    rmSync(root, { recursive: true, force: true });
+  }
 });
 
 test("a silent protocol.hello is reported as a startup wedge, never as a long write holding the queue", async () => {
-  const root = mkdtempSync(path.join(tmpdir(), "daemon-hello-deadline-")), endpoint = path.join(root, "silent.sock");
-  const server = net.createServer(() => { /* accepts connections but never answers */ });
+  const root = mkdtempSync(path.join(tmpdir(), "daemon-hello-deadline-")),
+    endpoint = path.join(root, "silent.sock");
+  const server = net.createServer(() => {
+    /* accepts connections but never answers */
+  });
   await new Promise<void>((resolve) => server.listen(endpoint, resolve));
   try {
-    await assert.rejects(() => requestDaemonJsonRpcAt(endpoint, "repo.task.run", {}, 2_000, 250), (error: unknown) => {
-      assert.equal((error as { readonly code?: string }).code, "daemon_response_timeout");
-      assert.match(String(error), /did not answer protocol\.hello within 0\.25s/u);
-      assert.match(String(error), /still starting \(repository attach\) or wedged during startup/u);
-      assert.doesNotMatch(String(error), /long write is holding the workspace queue/u);
-      return true;
-    });
-  } finally { server.close(); rmSync(root, { recursive: true, force: true }); }
+    await assert.rejects(
+      () => requestDaemonJsonRpcAt(endpoint, "repo.task.run", {}, 2_000, 250),
+      (error: unknown) => {
+        assert.equal((error as { readonly code?: string }).code, "daemon_response_timeout");
+        assert.match(String(error), /did not answer protocol\.hello within 0\.25s/u);
+        assert.match(String(error), /still starting \(repository attach\) or wedged during startup/u);
+        assert.doesNotMatch(String(error), /long write is holding the workspace queue/u);
+        return true;
+      },
+    );
+  } finally {
+    server.close();
+    rmSync(root, { recursive: true, force: true });
+  }
 });
 
 test("GUI S3 resident daemon bridge serves two RepoCells, catalog/runtime/control, secret rejection, and real PTY", async (t) => {
-    const parent = mkdtempSync(path.join(tmpdir(), "ha-gui-s3-resident-")), userRoot = path.join(parent, "user"), alpha = path.join(parent, "alpha"), beta = path.join(parent, "beta"), endpoint = localEndpoint(parent, "daemon.sock"), executablePath = writeProviderExecutable(path.join(parent, "runtime-stub.mjs"), `if (process.argv[2] === "--version") console.log("resident-runtime-stub 1.0.0");\nprocess.exit(0);\n`), uid = process.getuid?.() ?? 0;
-    initRepo(alpha, "alpha", uid); initRepo(beta, "beta", uid); registerDaemonRepo({ canonicalRoot: alpha, repoId: "alpha", userRoot, createConvenienceLinks: false }); registerDaemonRepo({ canonicalRoot: beta, repoId: "beta", userRoot, createConvenienceLinks: false });
-    const locked = await openRepoCell({ repoId: workspaceId("beta"), rootDir: canonicalRoot(beta), ownerId: "other-daemon" });
-    let launched: Record<string, unknown> | null = null; const host = await openDaemonHost({ daemonId: "gui-s3", userRoot, endpoint, runtimeDiscover: () => [{ installationId: "installation-codex", kindId: "codex", executablePath, version: "1.0.0", observedAt: "2026-08-14T00:00:00.000Z" }], runtimeLaunch: (prepared) => { launched = prepared as unknown as Record<string, unknown>; return { pid: 4242, onOutput: () => undefined, onErrorOutput: () => undefined, onExit: () => undefined, terminate: () => undefined }; } });
-    await host.attachmentsSettled();
-    const transport = createUnixSocketTransportServer({ daemonId: "gui-s3", socketPath: endpoint, createProtocolServer: (authContext, emit) => createJsonRpcProtocolServer({ host, build: { commit: null }, authContext, emit }) }); await transport.start();
-    const rpc = (method: string, params: Record<string, unknown>) => requestDaemonJsonRpcAt(endpoint, method, params, 2_000);
-    try {
-      const initial = await rpc("daemon.gui.system.read", {}), rows = initial.repos as Array<Record<string, unknown>>, attached = rows.find((row) => row.repoId === "alpha");
-      assert.equal(initial.schema, "gui-system-status/v1"); assert.equal(attached?.cellState, "attached"); assert.equal(attached?.queueDepth, 0); assert.equal(attached?.lockState, "held"); assert.equal(attached?.lastError, null);
-      const unavailable = rows.find((row) => row.repoId === "beta"); assert.equal(unavailable?.cellState, "unavailable"); assert.equal(unavailable?.queueDepth, null); assert.equal(unavailable?.lockState, "unknown"); assert.equal(typeof unavailable?.unavailableReason, "string");
-      const refresh = await rpc("daemon.gui.control.request", { payload: { kind: "refresh", authorityRepoId: "alpha", reason: "resident test" } }); assert.equal(refresh.outcome, "pending"); const firstSettled = await waitReceipt(rpc, String(refresh.operationId)); assert.equal(firstSettled.phase, "settled"); t.diagnostic(`daemon-control-initial-refresh-ms=${controlSettlementMs(firstSettled)}`);
-      const restart = await rpc("daemon.gui.control.request", { payload: { kind: "restart", authorityRepoId: "alpha" } }); assert.equal(restart.outcome, "op_rejected"); assert.equal((restart.error as Record<string, unknown>).code, "supervisor_required"); assert.equal(typeof restart.operationId, "string");
-      await locked.close(); const retry = await rpc("daemon.gui.control.request", { payload: { kind: "refresh", authorityRepoId: "alpha" } }); const retrySettled = await waitReceipt(rpc, String(retry.operationId)); assert.equal(retrySettled.phase, "settled"); t.diagnostic(`daemon-control-attach-refresh-ms=${controlSettlementMs(retrySettled)}`); const refreshed = await rpc("daemon.gui.system.read", {}); assert.equal((refreshed.repos as Array<Record<string, unknown>>).find((row) => row.repoId === "beta")?.cellState, "attached");
+  const parent = mkdtempSync(path.join(tmpdir(), "ha-gui-s3-resident-")),
+    userRoot = path.join(parent, "user"),
+    alpha = path.join(parent, "alpha"),
+    beta = path.join(parent, "beta"),
+    endpoint = localEndpoint(parent, "daemon.sock"),
+    executablePath = writeProviderExecutable(
+      path.join(parent, "runtime-stub.mjs"),
+      `if (process.argv[2] === "--version") console.log("resident-runtime-stub 1.0.0");\nprocess.exit(0);\n`,
+    ),
+    uid = process.getuid?.() ?? 0;
+  initRepo(alpha, "alpha", uid);
+  initRepo(beta, "beta", uid);
+  registerDaemonRepo({ canonicalRoot: alpha, repoId: "alpha", userRoot, createConvenienceLinks: false });
+  registerDaemonRepo({ canonicalRoot: beta, repoId: "beta", userRoot, createConvenienceLinks: false });
+  const locked = await openRepoCell({
+    repoId: workspaceId("beta"),
+    rootDir: canonicalRoot(beta),
+    ownerId: "other-daemon",
+  });
+  let launched: Record<string, unknown> | null = null;
+  const host = await openDaemonHost({
+    daemonId: "gui-s3",
+    userRoot,
+    endpoint,
+    runtimeDiscover: () => [
+      {
+        installationId: "installation-codex",
+        kindId: "codex",
+        executablePath,
+        version: "1.0.0",
+        observedAt: "2026-08-14T00:00:00.000Z",
+      },
+    ],
+    runtimeLaunch: (prepared) => {
+      launched = prepared as unknown as Record<string, unknown>;
+      return {
+        pid: 4242,
+        onOutput: () => undefined,
+        onErrorOutput: () => undefined,
+        onExit: () => undefined,
+        terminate: () => undefined,
+      };
+    },
+  });
+  await host.attachmentsSettled();
+  const transport = createUnixSocketTransportServer({
+    daemonId: "gui-s3",
+    socketPath: endpoint,
+    createProtocolServer: (authContext, emit) =>
+      createJsonRpcProtocolServer({ host, build: { commit: null }, authContext, emit }),
+  });
+  await transport.start();
+  const rpc = (method: string, params: Record<string, unknown>) =>
+    requestDaemonJsonRpcAt(endpoint, method, params, 2_000);
+  try {
+    const initial = await rpc("daemon.gui.system.read", {}),
+      rows = initial.repos as Array<Record<string, unknown>>,
+      attached = rows.find((row) => row.repoId === "alpha");
+    assert.equal(initial.schema, "gui-system-status/v1");
+    assert.equal(attached?.cellState, "attached");
+    assert.equal(attached?.queueDepth, 0);
+    assert.equal(attached?.lockState, "held");
+    assert.equal(attached?.lastError, null);
+    const unavailable = rows.find((row) => row.repoId === "beta");
+    assert.equal(unavailable?.cellState, "unavailable");
+    assert.equal(unavailable?.queueDepth, null);
+    assert.equal(unavailable?.lockState, "unknown");
+    assert.equal(typeof unavailable?.unavailableReason, "string");
+    const refresh = await rpc("daemon.gui.control.request", {
+      payload: { kind: "refresh", authorityRepoId: "alpha", reason: "resident test" },
+    });
+    assert.equal(refresh.outcome, "pending");
+    const firstSettled = await waitReceipt(rpc, String(refresh.operationId));
+    assert.equal(firstSettled.phase, "settled");
+    t.diagnostic(`daemon-control-initial-refresh-ms=${controlSettlementMs(firstSettled)}`);
+    const restart = await rpc("daemon.gui.control.request", { payload: { kind: "restart", authorityRepoId: "alpha" } });
+    assert.equal(restart.outcome, "op_rejected");
+    assert.equal((restart.error as Record<string, unknown>).code, "supervisor_required");
+    assert.equal(typeof restart.operationId, "string");
+    await locked.close();
+    const retry = await rpc("daemon.gui.control.request", { payload: { kind: "refresh", authorityRepoId: "alpha" } });
+    const retrySettled = await waitReceipt(rpc, String(retry.operationId));
+    assert.equal(retrySettled.phase, "settled");
+    t.diagnostic(`daemon-control-attach-refresh-ms=${controlSettlementMs(retrySettled)}`);
+    const refreshed = await rpc("daemon.gui.system.read", {});
+    assert.equal(
+      (refreshed.repos as Array<Record<string, unknown>>).find((row) => row.repoId === "beta")?.cellState,
+      "attached",
+    );
 
-      const catalog = await rpc("repo.gui.catalog.snapshot", { repo: { repoId: "alpha" } }); assert.equal(catalog.schema, "gui-catalog-snapshot/v1"); assert.equal((catalog.presets as unknown[]).length, 12); const reread = await rpc("repo.gui.catalog.reread", { repo: { repoId: "alpha" }, payload: { expectedDigest: catalog.catalogDigest } }); assert.equal(reread.schema, "catalog-reread-receipt/v1"); assert.equal(reread.outcome, "applied"); assert.equal(reread.beforeDigest, catalog.catalogDigest); assert.equal(reread.afterDigest, catalog.catalogDigest);
-      const created = await rpc("daemon.runtimeInstance.create", { payload: { instanceId: "resident-codex", name: "Resident Codex", kindId: "codex", installationId: "installation-codex", providerId: "openai", models: ["runtime-test-model"], authMode: "subscription" } }); assert.equal(created.outcome, "applied", JSON.stringify(created));
-      const updated = await rpc("daemon.runtimeInstance.update", { payload: { instanceId: "resident-codex", models: ["runtime-test-model", "runtime-test-model-2"], defaultModel: "runtime-test-model-2" } }); assert.equal(updated.outcome, "applied", JSON.stringify(updated));
-      const beforeSpawn = await rpc("repo.agentRuntime.overview", { repo: { repoId: "alpha" }, payload: {} }); assert.equal((beforeSpawn.instances as Array<Record<string, unknown>>)[0]?.instanceId, "resident-codex"); assert.deepEqual((beforeSpawn.instances as Array<Record<string, unknown>>)[0]?.models, ["runtime-test-model", "runtime-test-model-2"]); assert.doesNotMatch(JSON.stringify(beforeSpawn), /credentialRef|executablePath/iu);
-      const spawnedRuntime = await rpc("repo.agentRuntime.spawn", { repo: { repoId: "alpha" }, payload: { runtimeInstanceId: "resident-codex", model: "runtime-test-model-2", cwd: { scope: "repo-root" }, prompt: "Inspect", taskId: null, idempotencyKey: "resident-runtime" } }); assert.equal(spawnedRuntime.outcome, "applied"); const overview = await rpc("repo.agentRuntime.overview", { repo: { repoId: "alpha" }, payload: {} }), session = (overview.sessions as Array<Record<string, unknown>>).find((candidate) => candidate.runtimeSessionId === spawnedRuntime.runtimeSessionId); assert.equal(session?.instanceId, "resident-codex"); assert.equal((session?.definitionSnapshot as Record<string, unknown>).installationId, "installation-codex"); assert.equal((session?.definitionSnapshot as Record<string, unknown>).model, "runtime-test-model-2"); assert.equal(launched?.executablePath, executablePath); assert.deepEqual(launched?.args, ["exec", "--json", "--sandbox", "danger-full-access", "--model", "runtime-test-model-2", "-"]); assert.match(String((launched?.env as Record<string, unknown>).HOME), /runtime-instances\/resident-codex\/home$/u);
-      const secretRejected = await rpc("repo.agentRuntime.spawn", { repo: { repoId: "alpha" }, payload: { runtimeInstanceId: "resident-codex", cwd: { scope: "repo-root" }, prompt: "Inspect", taskId: null, idempotencyKey: "bad", nested: { apiToken: "must-not-cross" } } }); assert.equal(secretRejected.ok, false); assert.equal(secretRejected.code, "invalid_request"); assert.doesNotMatch(JSON.stringify(secretRejected), /must-not-cross/u);
+    const catalog = await rpc("repo.gui.catalog.snapshot", { repo: { repoId: "alpha" } });
+    assert.equal(catalog.schema, "gui-catalog-snapshot/v1");
+    assert.equal((catalog.presets as unknown[]).length, 12);
+    const reread = await rpc("repo.gui.catalog.reread", {
+      repo: { repoId: "alpha" },
+      payload: { expectedDigest: catalog.catalogDigest },
+    });
+    assert.equal(reread.schema, "catalog-reread-receipt/v1");
+    assert.equal(reread.outcome, "applied");
+    assert.equal(reread.beforeDigest, catalog.catalogDigest);
+    assert.equal(reread.afterDigest, catalog.catalogDigest);
+    const created = await rpc("daemon.runtimeInstance.create", {
+      payload: {
+        instanceId: "resident-codex",
+        name: "Resident Codex",
+        kindId: "codex",
+        installationId: "installation-codex",
+        providerId: "openai",
+        models: ["runtime-test-model"],
+        authMode: "subscription",
+      },
+    });
+    assert.equal(created.outcome, "applied", JSON.stringify(created));
+    const updated = await rpc("daemon.runtimeInstance.update", {
+      payload: {
+        instanceId: "resident-codex",
+        models: ["runtime-test-model", "runtime-test-model-2"],
+        defaultModel: "runtime-test-model-2",
+      },
+    });
+    assert.equal(updated.outcome, "applied", JSON.stringify(updated));
+    const beforeSpawn = await rpc("repo.agentRuntime.overview", { repo: { repoId: "alpha" }, payload: {} });
+    assert.equal((beforeSpawn.instances as Array<Record<string, unknown>>)[0]?.instanceId, "resident-codex");
+    assert.deepEqual((beforeSpawn.instances as Array<Record<string, unknown>>)[0]?.models, [
+      "runtime-test-model",
+      "runtime-test-model-2",
+    ]);
+    assert.doesNotMatch(JSON.stringify(beforeSpawn), /credentialRef|executablePath/iu);
+    const spawnedRuntime = await rpc("repo.agentRuntime.spawn", {
+      repo: { repoId: "alpha" },
+      payload: {
+        runtimeInstanceId: "resident-codex",
+        model: "runtime-test-model-2",
+        cwd: { scope: "repo-root" },
+        prompt: "Inspect",
+        taskId: null,
+        idempotencyKey: "resident-runtime",
+      },
+    });
+    assert.equal(spawnedRuntime.outcome, "applied");
+    const overview = await rpc("repo.agentRuntime.overview", { repo: { repoId: "alpha" }, payload: {} }),
+      session = (overview.sessions as Array<Record<string, unknown>>).find(
+        (candidate) => candidate.runtimeSessionId === spawnedRuntime.runtimeSessionId,
+      );
+    assert.equal(session?.instanceId, "resident-codex");
+    assert.equal((session?.definitionSnapshot as Record<string, unknown>).installationId, "installation-codex");
+    assert.equal((session?.definitionSnapshot as Record<string, unknown>).model, "runtime-test-model-2");
+    assert.equal(launched?.executablePath, executablePath);
+    assert.deepEqual(launched?.args, [
+      "exec",
+      "--json",
+      "--sandbox",
+      "danger-full-access",
+      "--model",
+      "runtime-test-model-2",
+      "-",
+    ]);
+    assert.match(String((launched?.env as Record<string, unknown>).HOME), /runtime-instances\/resident-codex\/home$/u);
+    const secretRejected = await rpc("repo.agentRuntime.spawn", {
+      repo: { repoId: "alpha" },
+      payload: {
+        runtimeInstanceId: "resident-codex",
+        cwd: { scope: "repo-root" },
+        prompt: "Inspect",
+        taskId: null,
+        idempotencyKey: "bad",
+        nested: { apiToken: "must-not-cross" },
+      },
+    });
+    assert.equal(secretRejected.ok, false);
+    assert.equal(secretRejected.code, "unknown_field");
+    assert.doesNotMatch(JSON.stringify(secretRejected), /must-not-cross/u);
 
-      const terminal = await rpc("repo.terminal.spawn", { repo: { repoId: "alpha" }, payload: { idempotencyKey: "resident-pty", backend: "direct-pty", name: "Resident", cwd: { scope: "repo-root" }, shellProfileId: process.platform === "win32" ? "powershell" : "sh" } }); assert.equal(terminal.outcome, "applied", JSON.stringify(terminal)); const frames: Array<Record<string, unknown>> = []; let attachmentId = "";
-      const detachStream = await streamDaemonFacetAt({ socketPath: endpoint, repoId: "alpha", method: "repo.terminal.attach", payload: { sessionId: terminal.sessionId as string, afterSeq: 0 }, timeoutMs: 2_000, onValue: (value) => { const frame = value as Record<string, unknown>; if (frame.schema === "terminal-attach/v1") attachmentId = String(frame.attachmentId); else frames.push(frame); } });
-      assert.equal((await rpc("repo.terminal.resize", { repo: { repoId: "alpha" }, payload: { sessionId: terminal.sessionId, cols: 101, rows: 32 } })).state, "running");
-      // `echo` is a shell builtin in both the POSIX profiles and PowerShell, so this
-      // round-trip exercises the terminal bridge without depending on shell syntax.
-      await rpc("repo.terminal.input", { repo: { repoId: "alpha" }, payload: { sessionId: terminal.sessionId, clientSeq: 1, utf8: "echo __S3_RESIDENT_PTY__\r" } }); await eventually(() => terminalOutput(frames).includes("__S3_RESIDENT_PTY__"));
-      assert.equal((await rpc("repo.terminal.detach", { repo: { repoId: "alpha" }, payload: { sessionId: terminal.sessionId, attachmentId } })).state, "detached"); detachStream(); assert.equal((await rpc("repo.terminal.terminate", { repo: { repoId: "alpha" }, payload: { sessionId: terminal.sessionId, confirmed: true } })).state, "exited");
-    } finally { await transport.stop(); await host.close(); await locked.close(); rmSync(parent, { recursive: true, force: true }); }
+    const terminal = await rpc("repo.terminal.spawn", {
+      repo: { repoId: "alpha" },
+      payload: {
+        idempotencyKey: "resident-pty",
+        backend: "direct-pty",
+        name: "Resident",
+        cwd: { scope: "repo-root" },
+        shellProfileId: process.platform === "win32" ? "powershell" : "sh",
+      },
+    });
+    assert.equal(terminal.outcome, "applied", JSON.stringify(terminal));
+    const frames: Array<Record<string, unknown>> = [];
+    let attachmentId = "";
+    const detachStream = await streamDaemonFacetAt({
+      socketPath: endpoint,
+      repoId: "alpha",
+      method: "repo.terminal.attach",
+      payload: { sessionId: terminal.sessionId as string, afterSeq: 0 },
+      timeoutMs: 2_000,
+      onValue: (value) => {
+        const frame = value as Record<string, unknown>;
+        if (frame.schema === "terminal-attach/v1") attachmentId = String(frame.attachmentId);
+        else frames.push(frame);
+      },
+    });
+    assert.equal(
+      (
+        await rpc("repo.terminal.resize", {
+          repo: { repoId: "alpha" },
+          payload: { sessionId: terminal.sessionId, cols: 101, rows: 32 },
+        })
+      ).state,
+      "running",
+    );
+    // `echo` is a shell builtin in both the POSIX profiles and PowerShell, so this
+    // round-trip exercises the terminal bridge without depending on shell syntax.
+    await rpc("repo.terminal.input", {
+      repo: { repoId: "alpha" },
+      payload: { sessionId: terminal.sessionId, clientSeq: 1, utf8: "echo __S3_RESIDENT_PTY__\r" },
+    });
+    await eventually(() => terminalOutput(frames).includes("__S3_RESIDENT_PTY__"));
+    assert.equal(
+      (
+        await rpc("repo.terminal.detach", {
+          repo: { repoId: "alpha" },
+          payload: { sessionId: terminal.sessionId, attachmentId },
+        })
+      ).state,
+      "detached",
+    );
+    detachStream();
+    assert.equal(
+      (
+        await rpc("repo.terminal.terminate", {
+          repo: { repoId: "alpha" },
+          payload: { sessionId: terminal.sessionId, confirmed: true },
+        })
+      ).state,
+      "exited",
+    );
+  } finally {
+    await transport.stop();
+    await host.close();
+    await locked.close();
+    rmSync(parent, { recursive: true, force: true });
+  }
 });
 
-async function waitReceipt(rpc: (method: string, params: Record<string, unknown>) => Promise<Record<string, unknown>>, operationId: string): Promise<Record<string, unknown>> { for (let attempt = 0; attempt < 500; attempt += 1) { const receipt = await rpc("daemon.gui.control.receipt", { payload: { operationId } }); if (receipt.phase === "settled" || receipt.phase === "failed") return receipt; await new Promise((resolve) => setTimeout(resolve, 10)); } throw new Error(`control receipt did not settle: ${operationId}`); }
-function controlSettlementMs(receipt: Record<string, unknown>): number { return Date.parse(String(receipt.completedAt)) - Date.parse(String(receipt.requestedAt)); }
-async function eventually(predicate: () => boolean): Promise<void> { for (let attempt = 0; attempt < 50; attempt += 1) { if (predicate()) return; await new Promise((resolve) => setTimeout(resolve, 20)); } throw new Error("resident PTY output did not arrive"); }
-function terminalOutput(frames: readonly Record<string, unknown>[]): string { return frames.filter((frame) => frame.kind === "output" && typeof frame.utf8 === "string").map((frame) => frame.utf8).join(""); }
-function localEndpoint(parent: string, name: string): string { return process.platform === "win32" ? `\\\\.\\pipe\\harness-anything-${process.pid}-${Date.now()}-${name}` : path.join(parent, name); }
-function initRepo(root: string, repoId: string, uid: number): void { mkdirSync(path.join(root, "harness"), { recursive: true }); git(root, "init", "-q"); git(root, "config", "user.name", "S3 Resident"); git(root, "config", "user.email", "s3@example.invalid"); writeFileSync(path.join(root, "harness/harness.yaml"), `schema: harness-anything/v1\nname: ${repoId}\nlayout:\n  authoredRoot: harness\n  localRoot: .harness\n`); writeFileSync(path.join(root, "harness/people.yaml"), `${JSON.stringify({ schema: "harness-people/v1", people: [{ personId: "owner", displayName: "Owner", roles: ["owner"], credentials: [{ kind: "unix-socket-owner-boundary", issuer: `host:${hostname()}`, subject: String(uid) }] }], roles: [{ roleId: "owner", commandClasses: ["repo-read", "repo-write", "admin", "arbiter"] }] }, null, 2)}\n`); git(root, "add", "harness"); git(root, "commit", "-qm", "fixture"); }
-function git(root: string, ...args: string[]): void { execFileSync("git", ["-C", root, ...args], { stdio: "ignore" }); }
+async function waitReceipt(
+  rpc: (method: string, params: Record<string, unknown>) => Promise<Record<string, unknown>>,
+  operationId: string,
+): Promise<Record<string, unknown>> {
+  for (let attempt = 0; attempt < 500; attempt += 1) {
+    const receipt = await rpc("daemon.gui.control.receipt", { payload: { operationId } });
+    if (receipt.phase === "settled" || receipt.phase === "failed") return receipt;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  throw new Error(`control receipt did not settle: ${operationId}`);
+}
+function controlSettlementMs(receipt: Record<string, unknown>): number {
+  return Date.parse(String(receipt.completedAt)) - Date.parse(String(receipt.requestedAt));
+}
+async function eventually(predicate: () => boolean): Promise<void> {
+  for (let attempt = 0; attempt < 50; attempt += 1) {
+    if (predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+  throw new Error("resident PTY output did not arrive");
+}
+function terminalOutput(frames: readonly Record<string, unknown>[]): string {
+  return frames
+    .filter((frame) => frame.kind === "output" && typeof frame.utf8 === "string")
+    .map((frame) => frame.utf8)
+    .join("");
+}
+function localEndpoint(parent: string, name: string): string {
+  return process.platform === "win32"
+    ? `\\\\.\\pipe\\harness-anything-${process.pid}-${Date.now()}-${name}`
+    : path.join(parent, name);
+}
+function initRepo(root: string, repoId: string, uid: number): void {
+  mkdirSync(path.join(root, "harness"), { recursive: true });
+  git(root, "init", "-q");
+  git(root, "config", "user.name", "S3 Resident");
+  git(root, "config", "user.email", "s3@example.invalid");
+  writeFileSync(
+    path.join(root, "harness/harness.yaml"),
+    `schema: harness-anything/v1\nname: ${repoId}\nlayout:\n  authoredRoot: harness\n  localRoot: .harness\n`,
+  );
+  writeFileSync(
+    path.join(root, "harness/people.yaml"),
+    `${JSON.stringify({ schema: "harness-people/v1", people: [{ personId: "owner", displayName: "Owner", roles: ["owner"], credentials: [{ kind: "unix-socket-owner-boundary", issuer: `host:${hostname()}`, subject: String(uid) }] }], roles: [{ roleId: "owner", commandClasses: ["repo-read", "repo-write", "admin", "arbiter"] }] }, null, 2)}\n`,
+  );
+  git(root, "add", "harness");
+  git(root, "commit", "-qm", "fixture");
+}
+function git(root: string, ...args: string[]): void {
+  execFileSync("git", ["-C", root, ...args], { stdio: "ignore" });
+}

--- a/packages/daemon/test/hitrate-task-lifecycle.integration.test.ts
+++ b/packages/daemon/test/hitrate-task-lifecycle.integration.test.ts
@@ -155,6 +155,15 @@ test("task start, inline submit, and code-doc reconcile reuse daemon-known lifec
     )) as Record<string, unknown>;
     assert.equal(wrongExecutionAmend.outcome, "op_rejected", JSON.stringify(wrongExecutionAmend));
     assert.equal(wrongExecutionAmend.code, "invalid_transition");
+    assert.deepEqual(wrongExecutionAmend.diagnostic, {
+      kind: "validation",
+      entity: `task ${taskId}`,
+      field: "executionId",
+      actual: "execution-not-current",
+      expectation:
+        `Current submitted execution is ${executionId}; retry ha task submit ${taskId} ` +
+        `--execution-id ${executionId} --amend --json-input '<submission-json>'`,
+    });
 
     const noOpAmend = (await cell.run(
       {

--- a/packages/daemon/test/json-rpc-protocol.test.ts
+++ b/packages/daemon/test/json-rpc-protocol.test.ts
@@ -738,7 +738,21 @@ test("invalid Decision payload stays invalid_command and reckon records exact pr
 test("Decision proposal packet is closed, UTF-8, atomic, and leaves the Task INDEX untouched", async () => {
   const rootDir = mkdtempSync(path.join(tmpdir(), "ha-decision-packet-")), outside = `${rootDir}-outside.json`; let cell: Awaited<ReturnType<typeof openRepoCell>> | undefined;
   try { initRepo(rootDir); cell = await openRepoCell({ repoId: workspaceId("decision-packet"), rootDir: canonicalRoot(rootDir), ownerId: "daemon-test" }); const baselineCanonicalCommits = Number(git(rootDir, "rev-list", "--count", "refs/ha/canonical")), binding = repoWriteBinding, created = await cell.run({ kind: "task-create", taskId: "task-related", title: "Related Task" }, binding) as Record<string, unknown>, index = path.join(rootDir, "harness", String(created.packagePath), "INDEX.md"), indexBefore = readFileSync(index); const packet = { title: "Atomic proposal", question: "Can one event publish the whole proposal?", riskTier: "medium", urgency: "high", vertical: "default", preset: "default", decisionClass: "ordinary", appliesTo: { modules: ["daemon"], productLines: [] }, chosen: [{ id: "CH1", text: "Publish once" }], rejected: [{ id: "RJ1", text: "Patch later", whyNot: "It exposes partial state" }], claims: [{ id: "C1", text: "The packet is atomic.", loadBearing: true }], fulfillments: [{ claimId: "C1", mode: "delivered" }] }, missingPacket = (({ fulfillments: _fulfillments, ...missing }) => missing)(packet), legacyPacket = { ...packet, relations: [{ anchor: "C1", type: "derives", target: "task/task-related", rationale: "The Decision creates this delivery." }] }, before = makeTaskEventReader({ repoId: "decision-packet", rootDir }).readHead()!.revision;
-    for (const [action, code] of [[{ kind: "decision-propose", jsonInput: JSON.stringify({ ...packet, unknown: true }) }, "invalid_command"], [{ kind: "decision-propose", jsonInput: JSON.stringify(missingPacket) }, "missing_field"], [{ kind: "decision-propose", jsonInput: JSON.stringify(legacyPacket) }, "invalid_command"], [{ kind: "decision-propose", jsonInput: JSON.stringify(packet), body: "inline", bodyFile: "body.md" }, "invalid_command"]] as const) { const rejected = await cell.run(action, binding); assert.equal(rejected.outcome, "op_rejected"); assert.equal(rejected.code, code); assert.equal(makeTaskEventReader({ repoId: "decision-packet", rootDir }).readHead()?.revision, before); }
+    // Missing packet fields retain their structured diagnostic without changing the closed-packet rejection codes.
+    for (const { action, code, field } of [
+      { action: { kind: "decision-propose", jsonInput: JSON.stringify({ ...packet, unknown: true }) }, code: "invalid_command", field: undefined },
+      { action: { kind: "decision-propose", jsonInput: JSON.stringify(missingPacket) }, code: "missing_field", field: "fulfillments" },
+      { action: { kind: "decision-propose", jsonInput: JSON.stringify(legacyPacket) }, code: "invalid_command", field: undefined },
+      { action: { kind: "decision-propose", jsonInput: JSON.stringify(packet), body: "inline", bodyFile: "body.md" }, code: "invalid_command", field: undefined },
+    ] as const) {
+      const rejected = await cell.run(action, binding);
+      assert.equal(rejected.outcome, "op_rejected");
+      assert.equal(rejected.code, code);
+      if (field !== undefined) {
+        assert.equal((rejected.diagnostic as { readonly field?: string } | undefined)?.field, field);
+      }
+      assert.equal(makeTaskEventReader({ repoId: "decision-packet", rootDir }).readHead()?.revision, before);
+    }
     const badJson = await cell.run({ kind: "decision-propose", jsonInput: "{" }, binding); assert.equal(badJson.code, "invalid_command"); assert.deepEqual(badJson.diagnostic, { kind: "failure", code: "invalid_command" });
     writeFileSync(path.join(rootDir, "proposal.json"), JSON.stringify(packet)); writeFileSync(outside, JSON.stringify(packet)); const outsidePacket = await cell.run({ kind: "decision-propose", fromFile: outside }, binding); assert.equal(outsidePacket.code, "invalid_command"); assert.deepEqual(outsidePacket.diagnostic, { kind: "workspace-boundary", field: "fromFile", workspaceRoot: realpathSync(rootDir) });
     writeFileSync(path.join(rootDir, "bad.md"), Buffer.from([0xff])); const invalidUtf8 = await cell.run({ kind: "decision-propose", fromFile: "proposal.json", bodyFile: "bad.md" }, binding); assert.equal(invalidUtf8.code, "invalid_command"); assert.equal(makeTaskEventReader({ repoId: "decision-packet", rootDir }).readHead()?.revision, before);
@@ -959,7 +973,9 @@ test("JSON-RPC failure receipt carries formal operation identity and origin", as
   assert.ok(response && !Array.isArray(response) && "result" in response); if (response && !Array.isArray(response) && "result" in response) {
     const receipt = response.result as Record<string, unknown>; assert.deepEqual(receipt, { schema: "command-receipt/v2", ok: false, command: "protocol.hello", outcome: "op_rejected", opId: "N/A", origin: "daemon", code: "incompatible_protocol_version", evidence: "rejection:incompatible_protocol_version", error: { code: "incompatible_protocol_version" } }); }
   await server.handle({ jsonrpc: "2.0", id: 2, method: "protocol.hello", params: { protocolVersion: currentDaemonProtocolVersion } });
-  const malformed = await server.handle({ jsonrpc: "2.0", id: 3, method: "daemon.status", params: "not-an-object" });
+  const unknown = await server.handle({ jsonrpc: "2.0", id: 3, method: "repo.agentRuntime.spawn", params: { repo: { repoId: "alpha" }, payload: { runtimeInstanceId: "codex", cwd: { scope: "repo-root" }, prompt: "Inspect", taskId: null, idempotencyKey: "unknown", permission_mode: "read-only" } } });
+  assert.ok(unknown && !Array.isArray(unknown) && "result" in unknown); if (unknown && !Array.isArray(unknown) && "result" in unknown) { const receipt = unknown.result as Record<string, unknown>, diagnostic = receipt.diagnostic as Record<string, unknown>; assert.equal(receipt.code, "unknown_field"); assert.deepEqual({ kind: diagnostic.kind, entity: diagnostic.entity, field: diagnostic.field, actual: diagnostic.actual }, { kind: "validation", entity: "repo.agentRuntime.spawn", field: "permission_mode", actual: "unknown" }); assert.match(String(diagnostic.expectation), /Allowed fields:.*agentId.*permissionMode/u); }
+  const malformed = await server.handle({ jsonrpc: "2.0", id: 4, method: "daemon.status", params: "not-an-object" });
   assert.ok(malformed && !Array.isArray(malformed) && "result" in malformed); if (malformed && !Array.isArray(malformed) && "result" in malformed) assert.equal((malformed.result as Record<string, unknown>).code, "invalid_request");
 });
 
@@ -1016,6 +1032,155 @@ test("runtime witness issuance binds the server principal without transport role
   const host = await openDaemonHost({ daemonId: "runtime-witness", userRoot }); try { await host.admin({ kind: "register", rootDir: root, repoId: "runtime-witness" }, auth(ids.admin)); const issued = await host.issueRuntimeWitness("runtime-witness", "session-runtime", auth(ids.writer)), bound = host.bindRuntimeWitness("runtime-witness", issued.token); assert.equal(bound.actor.principal.personId, "writer"); assert.deepEqual(bound.actor.executor, { kind: "agent", id: "runtime-session:session-runtime" }); assert.equal(host.publishRuntimeWitness("runtime-witness", issued.token, { type: "activity", activity: "tool" }).type, "activity"); assert.throws(() => host.publishRuntimeWitness("runtime-witness", issued.token, { type: "heartbeat", actor: "provider-supplied" } as never), hasCode("invalid_provider_frame")); const assignment = { transportKind: "unix-socket", assignmentBinding: { nodeId: "node-runtime", repoId: "runtime-witness", taskId: "task-runtime", executionId: "execution-runtime", assignmentId: "assignment-runtime", paths: [], actor: { principal: { personId: "worker" }, executor: null } } } as const, assignmentToken = await host.issueRuntimeWitness("runtime-witness", "session-runtime", assignment), assignmentBound = host.bindRuntimeWitness("runtime-witness", assignmentToken.token); assert.deepEqual(assignmentBound.source, { kind: "assignment", nodeId: "node-runtime", assignmentId: "assignment-runtime" }); assert.deepEqual(assignmentBound.actor.executor, { kind: "agent", id: "runtime-session:session-runtime" }); for (const [personId, ownerUid] of [["dualAdmin", ids.dualAdmin], ["dualArbiter", ids.dualArbiter]] as const) { const token = await host.issueRuntimeWitness("runtime-witness", "session-runtime", auth(ownerUid)); assert.equal(host.bindRuntimeWitness("runtime-witness", token.token).actor.principal.personId, personId); } } finally { await host.close(); rmSync(parent, { recursive: true, force: true }); }
 });
 
+test("task mutation rejections name the missing field and current execution status", async (context) => {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-task-rejection-diagnostics-")),
+    taskId = "task-rejection-diagnostics",
+    executionId = "execution-rejection-diagnostics";
+  let cell: Awaited<ReturnType<typeof openRepoCell>> | undefined;
+  try {
+    initRepo(rootDir);
+    cell = await openRepoCell({
+      repoId: workspaceId("task-rejection-diagnostics"),
+      rootDir: canonicalRoot(rootDir),
+      ownerId: "task-rejection-diagnostics",
+    });
+    const created = await cell.run({ kind: "task-create", taskId, title: "Rejection diagnostics" }, repoWriteBinding);
+    await realizeTaskPlanFixture(rootDir, String((created as Record<string, unknown>).packagePath), (planPath) =>
+      cell!.run({ kind: "doc-submit", paths: [planPath] }, repoWriteBinding),
+    );
+    await cell.run({ kind: "task-start", taskId, executionId }, repoWriteBinding);
+    writeFileSync(
+      path.join(rootDir, "submission.json"),
+      JSON.stringify({
+        completionClaim: "Ready.",
+        deliverables: ["README.md"],
+        outputs: ["README.md"],
+        verificationNotes: "fixture",
+        knownGaps: [],
+        residualRisks: [],
+        commitSha: "a".repeat(40),
+      }),
+    );
+    const invalidSubmission = await cell.run(
+      { kind: "task-submit", taskId, executionId, fromFile: "submission.json" },
+      repoWriteBinding,
+    );
+    assert.equal(invalidSubmission.code, "invalid_submission", JSON.stringify(invalidSubmission));
+    assert.deepEqual(invalidSubmission.diagnostic, {
+      kind: "validation",
+      entity: "task submission",
+      field: "verificationNotes",
+      actual: "'fixture'",
+      expectation:
+        `must be an array of non-empty strings; fix the packet, then retry ha task submit ${taskId} ` +
+        `--execution-id ${executionId} --from-file <submission.json>`,
+    });
+    context.diagnostic(`invalid_submission receipt=${JSON.stringify(invalidSubmission)}`);
+    writeFileSync(
+      path.join(rootDir, "submission.json"),
+      JSON.stringify({
+        completionClaim: "Ready except for the omitted commit.",
+        deliverables: ["README.md"],
+        outputs: ["README.md"],
+        verificationNotes: ["fixture"],
+        knownGaps: [],
+        residualRisks: [],
+      }),
+    );
+    const missingCommit = await cell.run(
+      { kind: "task-submit", taskId, executionId, fromFile: "submission.json" },
+      repoWriteBinding,
+    );
+    assert.equal(missingCommit.code, "missing_field", JSON.stringify(missingCommit));
+    assert.deepEqual(missingCommit.diagnostic, {
+      kind: "validation",
+      entity: "task submission",
+      field: "commitSha",
+      actual: "missing",
+      expectation:
+        "Required fields: completionClaim, deliverables, outputs, verificationNotes, knownGaps, residualRisks, commitSha",
+    });
+    writeFileSync(
+      path.join(rootDir, "review.json"),
+      JSON.stringify({ verdict: "approved", reason: "Premature review.", evidenceChecked: ["fixture"] }),
+    );
+    const prematureReview = await cell.run(
+      {
+        kind: "task-review-execution",
+        taskId,
+        executionId,
+        reviewId: "review-premature",
+        fromFile: "review.json",
+      },
+      withRoleBinding(
+        {
+          actor: { principal: { personId: "person-reviewer" }, executor: { kind: "agent", id: "arbiter" } },
+          source: "local",
+        },
+        "arbiter",
+      ),
+    );
+    assert.equal(prematureReview.code, "invalid_transition", JSON.stringify(prematureReview));
+    assert.deepEqual(prematureReview.diagnostic, {
+      kind: "validation",
+      entity: `execution ${executionId}`,
+      field: "status",
+      actual: "active",
+      expectation: "Execution status must be submitted on the current task iteration before review",
+    });
+    const derivedPrematureReview = await cell.run(
+      { kind: "task-review-execution", taskId, reviewId: "review-derived-premature", fromFile: "review.json" },
+      withRoleBinding(
+        {
+          actor: { principal: { personId: "person-reviewer" }, executor: { kind: "agent", id: "arbiter" } },
+          source: "local",
+        },
+        "arbiter",
+      ),
+    );
+    assert.equal(derivedPrematureReview.code, "invalid_command", JSON.stringify(derivedPrematureReview));
+  } finally {
+    await cell?.close();
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});
+
+test("task complete identifies a code-doc path outside the submitted commit root", async () => {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-complete-path-diagnostic-")),
+    taskId = "task-complete-path-diagnostic",
+    executionId = "execution-complete-path-diagnostic";
+  let cell: Awaited<ReturnType<typeof openRepoCell>> | undefined;
+  try {
+    initRepo(rootDir);
+    cell = await openRepoCell({
+      repoId: workspaceId("complete-path-diagnostic"),
+      rootDir: canonicalRoot(rootDir),
+      ownerId: "complete-path-diagnostic",
+    });
+    await prepareReadyCompletion(cell, rootDir, taskId, executionId, "Complete Path Diagnostic", false);
+    const rejected = await cell.run(
+      {
+        kind: "task-complete",
+        taskId,
+        executionId,
+        paths: ["harness/agents/sol-implementer.json"],
+      },
+      repoWriteBinding,
+    );
+    assert.equal(rejected.code, "invalid_proof", JSON.stringify(rejected));
+    assert.deepEqual(rejected.diagnostic, {
+      kind: "validation",
+      entity: "code-doc reconciliation",
+      field: "paths[0]",
+      actual: "harness/agents/sol-implementer.json",
+      expectation: "Path must be relative to the Git repository that owns the submitted commit",
+    });
+  } finally {
+    await cell?.close();
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});
+
 function initRepo(rootDir: string): void {
   git(rootDir, "init", "--quiet");
   git(rootDir, "config", "user.name", "RepoCell Test");
@@ -1070,6 +1235,7 @@ async function prepareReadyCompletion(
   taskId: string,
   executionId: string,
   title: string,
+  reconcileCodeDoc = true,
 ): Promise<void> {
   const binding = repoWriteBinding;
   const created = await cell.run({ kind: "task-create", taskId, title }, binding);
@@ -1132,7 +1298,7 @@ async function prepareReadyCompletion(
     binding,
   );
   await cell.run({ kind: "task-complete", taskId, executionId, ci: "passed" }, binding);
-  await cell.run({ kind: "task-code-doc-reconcile", taskId, paths: ["README.md"] }, binding);
+  if (reconcileCodeDoc) await cell.run({ kind: "task-code-doc-reconcile", taskId, paths: ["README.md"] }, binding);
 }
 function rbacRepo(rootDir: string, ids: Readonly<Record<string, number>>): void {
   mkdirSync(rootDir, { recursive: true });

--- a/packages/daemon/test/rejection-next-actions.integration.test.ts
+++ b/packages/daemon/test/rejection-next-actions.integration.test.ts
@@ -123,6 +123,83 @@ test("progress lease mismatch names the holder and a release plus re-entry route
   }
 });
 
+test("start rejection identifies the active execution and its reuse command", async (context) => {
+  const rootDir = workspace("start-reuse"),
+    taskId = "task-start-reuse",
+    executionId = "exec-start-reuse",
+    owner = binding("owner");
+  let cell: Awaited<ReturnType<typeof openRepoCell>> | undefined;
+  try {
+    cell = await openRepoCell({
+      repoId: workspaceId("start-reuse"),
+      rootDir: canonicalRoot(rootDir),
+      ownerId: "start-reuse",
+    });
+    const created = await cell.run({ kind: "task-create", taskId, title: "Start reuse" }, owner);
+    assert.equal(created.outcome, "applied");
+    await realizeTaskPlanFixture(rootDir, String((created as Record<string, unknown>).packagePath), (planPath) =>
+      cell!.run({ kind: "doc-submit", paths: [planPath] }, owner),
+    );
+    assert.equal((await cell.run({ kind: "task-start", taskId, executionId }, owner)).outcome, "applied");
+    assert.equal((await cell.run({ kind: "task-release", taskId }, owner)).outcome, "applied");
+    const rejected = await cell.run({ kind: "task-start", taskId, executionId: "exec-replacement" }, owner);
+    assert.equal(rejected.code, "invalid_transition", JSON.stringify(rejected));
+    assert.deepEqual(rejected.diagnostic, {
+      kind: "validation",
+      entity: `task ${taskId}`,
+      field: "executionId",
+      actual: `active execution=${executionId} status=active node=implementation`,
+      expectation: `Current round already has an active execution; run ha task start ${taskId} without --execution-id to reuse it`,
+    });
+    context.diagnostic(`invalid_transition receipt=${JSON.stringify(rejected)}`);
+    assert.equal((await cell.run({ kind: "task-start", taskId }, owner)).outcome, "applied");
+  } finally {
+    await cell?.close();
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});
+
+test("executor declaration rejection names its eligibility rule and review command", async (context) => {
+  const rootDir = workspace("declare-assigned"),
+    taskId = "task-declare-assigned",
+    executionId = "exec-declare-assigned",
+    worker = binding("assigned-worker");
+  let cell: Awaited<ReturnType<typeof openRepoCell>> | undefined;
+  try {
+    cell = await openRepoCell({
+      repoId: workspaceId("declare-assigned"),
+      rootDir: canonicalRoot(rootDir),
+      ownerId: "declare-assigned",
+    });
+    const created = await cell.run({ kind: "task-create", taskId, title: "Declare assigned" }, worker);
+    assert.equal(created.outcome, "applied");
+    await realizeTaskPlanFixture(rootDir, String((created as Record<string, unknown>).packagePath), (planPath) =>
+      cell!.run({ kind: "doc-submit", paths: [planPath] }, worker),
+    );
+    assert.equal((await cell.run({ kind: "task-start", taskId, executionId }, worker)).outcome, "applied");
+    assert.equal((await cell.run({ kind: "task-submit", taskId, executionId, submission }, worker)).outcome, "applied");
+    const rejected = await cell.run(
+      { kind: "task-declare-executor", taskId, executionId, agent: "assigned-worker", reason: "Already assigned" },
+      worker,
+    );
+    assert.equal(rejected.code, "invalid_proof", JSON.stringify(rejected));
+    assert.deepEqual(rejected.diagnostic, {
+      kind: "validation",
+      entity: `execution ${executionId}`,
+      field: "declareExecutor",
+      actual: "status=submitted node=review executor=agent:assigned-worker",
+      expectation:
+        "Use declare-executor only when status=submitted node=review executor=none; this assigned execution " +
+        `must continue with ha task review-execution ${taskId} --execution-id ${executionId} ` +
+        "--review-id <review-id> --from-file <review.json>",
+    });
+    context.diagnostic(`invalid_proof receipt=${JSON.stringify(rejected)}`);
+  } finally {
+    await cell?.close();
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});
+
 test("executor declaration and completion context refusals name projection rebuild and the exact retry", async () => {
   const rootDir = workspace("projection-exits"),
     repoId = workspaceId("projection-exits"),

--- a/packages/daemon/test/repo-cell-executor-binding-cut.test.ts
+++ b/packages/daemon/test/repo-cell-executor-binding-cut.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { bindWriterGenerationToken, type LeaseV1, type RuntimeSession } from "../../kernel/src/index.ts";
 import { createRepoCellApi, type RepoCellApiContext } from "../src/repo-cell-api.ts";
+import { failed } from "../src/repo-cell-settlement.ts";
 import type { RepoCellBinding } from "../src/repo-cell-types.ts";
 
 const now = "2026-09-03T12:00:00.000Z";
@@ -80,16 +81,29 @@ test("executor binding waits for the preceding writer cut that binds the runtime
   assert.deepEqual(context.observedActor, runtimeActor);
 });
 
-test("executor binding still rejects a runtime session absent from the preceding writer cut", async () => {
+test("executor binding rejection names the claimed and held executors", async (testContext) => {
   const context = contextFor(
       Promise.resolve(),
       () => null,
-      () => null,
+      () => lease,
     ),
-    receipt = await createRepoCellApi(context).run(action, binding);
+    receipt = await createRepoCellApi(context).run(
+      { ...action, executor: { kind: "agent", id: "runtime-session:unrelated-runtime" } },
+      binding,
+    );
 
   assert.equal(receipt.outcome, "op_rejected");
   assert.equal(receipt.code, "executor_binding_invalid");
+  assert.deepEqual(receipt.diagnostic, {
+    kind: "validation",
+    entity: `task ${taskId} execution ${executionId}`,
+    field: "executor",
+    actual: "agent:runtime-session:unrelated-runtime",
+    expectation:
+      `Expected agent:${runtimeActor.executor.id} from the held execution lease; run from that executor, then retry ` +
+      `ha task artifact add ${taskId} --source <path> --destination <artifact-path>`,
+  });
+  testContext.diagnostic(`executor_binding_invalid receipt=${JSON.stringify(receipt)}`);
   assert.equal(context.observedActor, null);
 });
 
@@ -144,12 +158,7 @@ function contextFor(
         nextAction,
       }),
       operationId: () => "op-runtime-first-write",
-      failed: (opId: string, error: unknown) => ({
-        outcome: "op_rejected",
-        opId,
-        code: (error as { readonly code?: string }).code ?? "invalid_command",
-        nextAction: error instanceof Error ? error.message : String(error),
-      }),
+      failed,
       fatalCellError: () => false,
       errorOperationId: () => null,
       cellCodedError: (code: string, message: string) => Object.assign(new Error(message), { code }),

--- a/packages/daemon/test/runtime-spawn-ingress.integration.test.ts
+++ b/packages/daemon/test/runtime-spawn-ingress.integration.test.ts
@@ -204,6 +204,56 @@ test("daemon ingress preserves executor-scoped task-bound runtime spawn", async 
         true,
       );
     });
+    await t.test("the real CLI carries --agent identity through the daemon into the provider mission", async () => {
+      const installed = await host.run(
+        repoId,
+        {
+          kind: "agent-install",
+          declaration: {
+            schema: "agent-declaration/v1",
+            id: "sol-reviewer",
+            name: "Sol Reviewer",
+            instructions: "Include AGENT_CLI_INGRESS_WITNESS in the review.",
+            runtime_type: "codex",
+            role: "worker",
+          },
+        },
+        auth,
+      );
+      assert.equal(installed.outcome, "applied", JSON.stringify(installed));
+      const result = await spawnCli(
+        [
+          "--root",
+          workerRoot,
+          "--json",
+          "runtime",
+          "run",
+          ingressDefinition.instanceId,
+          "--agent",
+          "sol-reviewer",
+          "--role",
+          "reviewer",
+          "--prompt",
+          "Review through the declared identity.",
+          "--permission-mode",
+          "read-only",
+          "--detach",
+        ],
+        launchedEnv!,
+      );
+      assert.equal(result.status, 0, `${result.stderr}\n${result.stdout}`);
+      const receipt = JSON.parse(result.stdout) as Record<string, unknown>;
+      assert.equal(receipt.outcome, "running", JSON.stringify(receipt));
+      assert.equal(receipt.code, undefined, JSON.stringify(receipt));
+      assert.deepEqual(
+        { ledgerAccess: receipt.ledgerAccess, reportDelivery: receipt.reportDelivery },
+        { ledgerAccess: "unavailable", reportDelivery: "stdout" },
+      );
+      assert.match(
+        launchedPrompt,
+        /^# Agent Identity: Sol Reviewer \(sol-reviewer\)[\s\S]*AGENT_CLI_INGRESS_WITNESS[\s\S]*# Mission\n\nReview through the declared identity\.[\s\S]*# Read-only Dispatch Contract[\s\S]*final stdout/u,
+      );
+    });
     await t.test("the first dispatch holds the task lease and a concurrent second dispatch is rejected", async () => {
       const taskId = "task-runtime-dispatcher-handoff",
         executionId = "exec-runtime-dispatcher-handoff";
@@ -886,6 +936,16 @@ test("daemon ingress preserves executor-scoped task-bound runtime spawn", async 
           { outcome: "op_rejected", code: "executor_binding_invalid" },
           JSON.stringify(nonHolder),
         );
+        assert.deepEqual(nonHolder.diagnostic, {
+          kind: "validation",
+          entity: `task ${taskId} execution ${executionId}`,
+          field: "executor",
+          actual: "agent:runtime-session:unrelated-runtime",
+          expectation:
+            `Expected agent:${worker.id} from the held execution lease; run from that executor, then retry ` +
+            `ha task submit ${taskId} --execution-id ${executionId} --from-file <submission.json>`,
+        });
+        t.diagnostic(`executor_binding_invalid receipt=${JSON.stringify(nonHolder)}`);
         assert.equal(
           (await host.run(repoId, { kind: "task-start", taskId, executionId, executor: worker }, auth)).outcome,
           "applied",
@@ -919,6 +979,17 @@ test("daemon ingress preserves executor-scoped task-bound runtime spawn", async 
         );
         assert.equal(declaration.outcome, "op_rejected", JSON.stringify(declaration));
         assert.equal(declaration.code, "invalid_proof", JSON.stringify(declaration));
+        assert.deepEqual(declaration.diagnostic, {
+          kind: "validation",
+          entity: `execution ${executionId}`,
+          field: "declareExecutor",
+          actual: `status=submitted node=review executor=agent:${worker.id}`,
+          expectation:
+            "Use declare-executor only when status=submitted node=review executor=none; this assigned execution " +
+            `must continue with ha task review-execution ${taskId} --execution-id ${executionId} ` +
+            "--review-id <review-id> --from-file <review.json>",
+        });
+        t.diagnostic(`invalid_proof receipt=${JSON.stringify(declaration)}`);
       },
     );
   } finally {

--- a/packages/daemon/test/runtime-spawn-settlement.test.ts
+++ b/packages/daemon/test/runtime-spawn-settlement.test.ts
@@ -5,9 +5,32 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
 import { classifyRuntimeExit } from "../src/runtime-provider-fault.ts";
+import { failed } from "../src/repo-cell-settlement.ts";
+import { runtimeMissionName } from "../src/runtime-spawn-mission.ts";
 import { publishExit } from "../src/runtime-spawn-settlement.ts";
 import type { RuntimeSpawnerContext } from "../src/runtime-spawn-context.ts";
 import type { ActiveRuntime } from "../src/runtime-spawn-types.ts";
+
+test("path-like runtime missions produce an actionable receipt without exposing the path", (context) => {
+  let error: unknown;
+  try {
+    runtimeMissionName("tasks/task-owner/artifacts/missions/continue-01.md");
+  } catch (caught) {
+    error = caught;
+  }
+  const receipt = failed("op-runtime-mission", error);
+  assert.equal(receipt.code, "invalid_runtime_mission");
+  assert.deepEqual(receipt.diagnostic, {
+    kind: "validation",
+    entity: "runtime mission",
+    field: "mission",
+    actual: "path-like value",
+    expectation:
+      "Expected a bare mission id; the daemon resolves harness/<task-package>/artifacts/missions/<name>.md " +
+      "and did not look up this file. Retry ha runtime run <runtime-instance> --task <task-id> --mission <name>",
+  });
+  context.diagnostic(`invalid_runtime_mission receipt=${JSON.stringify(receipt)}`);
+});
 
 test("exit zero is success evidence even when provider protocol evidence is incomplete", () => {
   const result = classifyRuntimeExit(active({ protocolError: true }), 0);

--- a/packages/daemon/test/runtime-spawn.integration.test.ts
+++ b/packages/daemon/test/runtime-spawn.integration.test.ts
@@ -8,7 +8,13 @@ import test from "node:test";
 import { makeTaskEventStore, registerDaemonRepo, type AgentDefinitionSnapshot } from "../../kernel/src/index.ts";
 import { openRuntimeInstanceStore, type RuntimeInstallationWitness } from "../src/agent-runtime-instances.ts";
 import { openDaemonHost } from "../src/daemon-host.ts";
-import { canonicalRoot, workspaceId } from "../src/protocol/daemon-protocol.contract.ts";
+import { validateRuntimeSpawnReceipt } from "../src/gui-s3-control.ts";
+import {
+  canonicalRoot,
+  makeDaemonCommandReceipt,
+  validateDaemonGuiCommandReceipt,
+  workspaceId,
+} from "../src/protocol/daemon-protocol.contract.ts";
 import { createJsonRpcProtocolServer } from "../src/protocol/json-rpc-server.ts";
 import { currentDaemonProtocolVersion } from "../src/protocol/version.ts";
 import { openBootstrappedRepoCell as openRepoCell } from "./repo-settings.fixture.ts";
@@ -434,6 +440,28 @@ test("runtime spawn resolves command model, Agent model, then instance default w
         (launched?.prompt ?? "").indexOf("PROMPT_FRAGMENT_SECOND") <
           (launched?.prompt ?? "").indexOf("# Standard Task") &&
         (launched?.prompt ?? "").indexOf("# Standard Task") < (launched?.prompt ?? "").indexOf("# Mission"),
+    );
+    const readOnly = await cell.spawnRuntime(
+      {
+        runtimeInstanceId: "codex-agent-model",
+        agentId: "declared-model",
+        cwd: { scope: "repo-root" },
+        prompt: "Review without writes.",
+        permissionMode: "read-only",
+        taskId: null,
+        idempotencyKey: "agent-model-read-only",
+      },
+      binding,
+    );
+    assert.deepEqual(
+      { ledgerAccess: readOnly.ledgerAccess, reportDelivery: readOnly.reportDelivery },
+      { ledgerAccess: "unavailable", reportDelivery: "stdout" },
+    );
+    assert.deepEqual(validateDaemonGuiCommandReceipt(makeDaemonCommandReceipt("runtime-spawn", readOnly)), []);
+    assert.deepEqual(validateRuntimeSpawnReceipt(makeDaemonCommandReceipt("runtime-spawn", readOnly)), []);
+    assert.match(
+      launched?.prompt ?? "",
+      /# Read-only Dispatch Contract[\s\S]*daemon-ledger commands are unavailable[\s\S]*final stdout/u,
     );
     await cell.spawnRuntime(
       {


### PR DESCRIPTION
Production-Delta: +481/-94

# English

## Problem

Five rejection codes across different subsystems returned only a category name. Callers had to read the source or guess. In one orchestration session the CEO hit all five; `invalid_submission` alone cost half an hour — the real cause was `verificationNotes` being a string instead of a string array, and nothing in the receipt pointed there.

## Where the diagnostic was lost

`repo-cell-settlement.ts:failed()` builds `{kind:"failure", code}` and only replaces it when `receipt-guidance.ts:diagnosticForError` finds an explicit `error.diagnostic`. A plain `cellCodedError` message is dropped at that point.

This explains an otherwise puzzling asymmetry: on the same `ha task submit`, a bad file path returns a full hint while `invalid_submission` returns nothing — even though `repo-cell-packets.ts:145` throws with `issues.join("; ")`.

## What changed

Five codes now carry `entity` / `field` / `actual` / `expectation`, with a runnable retry command in `expectation`:

| Code | Now says |
|---|---|
| `invalid_submission` | which field is invalid and the expected type |
| `invalid_runtime_mission` | a mission id is expected, not a path, plus the daemon's resolution rule |
| `invalid_proof` | when `declare-executor` applies, and the execution's current state |
| `executor_binding_invalid` | the expected and actual executor |
| `invalid_transition` | the round already has an active execution; `ha task start` without `--execution-id` reuses it |

The last one matters most: its silence led to a task filed against a wrong premise ("the lease is orphaned and no actor can advance it"), which the dispatched worker had to disprove with evidence.

## Relationship to #2232

**Converges, does not fork.** #2232 already established the `ReceiptDiagnostic → failed() → CLI` channel; this PR only covers the five codes it left out, through that same channel. Only closed validation diagnostics are constructed — no arbitrary messages, internal paths, or credentials are forwarded.

## Verification

- Negative control: the five targeted tests were `0/5` before the change, `5/5` after.
- `npm run typecheck`: exit 0
- G36 line-density: pass
- G0-5 daemon specialization ratchet: pass (`273/305` for command, no increase elsewhere)
- Targeted runtime suite: 37 tests, 35 pass. The 2 `daemon-multi-repo-lifecycle-cli` failures were verified by the CEO as contention between concurrent workers on the shared daemon — both a clean baseline and this change pass `2/2` when run alone.

## Rebase conflict resolution

main merged #2231 and six other PRs onto the same surface. Three conflicts were resolved as a **union**, not either-or:

- `repo-cell-packets.ts`: main's `missing_field` / `invalid_command` behaviour and wording kept, with the structured diagnostic added on top.
- `repo-cell-command.ts`: routed through the extracted `reviewExecutionSelection`, which carries main's selection rules and hint text unchanged.
- `json-rpc-protocol.test.ts`: both assertions kept (incomplete→`missing_field`, unknown→`invalid_command`), plus diagnostic-field checks.

## Second CI round

The first run was 21 pass / 2 fail. Both were real:

**`integration-shard (3)` was a genuine regression.** The refactor reordered checks, so `task-submit` with a non-existent `executionId` returned `lease_required` instead of `invalid_transition`. **The test expectation was not changed to match the implementation** — a return code is a downstream contract, and editing the test would disguise a regression as intent. The order was restored instead (`task-action-catalog-runtime.ts:128` checks transition first, lease at 132), the code stays `invalid_transition`, and the information went into the diagnostic:

```json
{"kind":"validation","entity":"task task-hitrate-lifecycle","field":"executionId",
 "actual":"execution-not-current",
 "expectation":"Current submitted execution is execution-hitrate-lifecycle; retry ha task submit task-hitrate-lifecycle --execution-id execution-hitrate-lifecycle --amend --json-input '<submission-json>'"}
```

`repeatedSubmit`, `noOpAmend`, `rejectedAmendments[0]` and `amendCompleted` were each confirmed to still return `invalid_transition`.

**`check-file-complexity` was a real breach**, not staleness: `runtime-spawner.ts` reached 1103 lines against a 1100 limit. The read-only dispatch prompt assembly moved to `runtime-spawn-mission.ts`, bringing it to 1093. **The allowlist in `tools/check-file-complexity.mjs` was not touched** — that file is a protected surface (`ordinaryImplementationMayModify: false`).

Re-run: five codes 5/5, hitrate 1/1, runtime-spawn 5/5, typecheck exit 0, G36 pass, G0-5 ratchet pass, file-complexity pass.

---

# 中文

## 问题

五个不同子系统的拒绝码都只回一个类别名，调用者必须读源码或试错才能继续。CEO 在一轮编排里连撞五次，其中 `invalid_submission` 一条就耗掉半小时——实际原因是 `verificationNotes` 传了字符串而不是字符串数组，而回执里没有任何字段指向这一点。

## 丢失点

`repo-cell-settlement.ts:failed()` 先造 `{kind:"failure", code}`，只有当 `receipt-guidance.ts:diagnosticForError` 读到显式 `error.diagnostic` 时才替换，所以普通 `cellCodedError` 的 message 到此被丢掉。

这解释了一个原本很费解的现象：**同一条 `ha task submit`，文件路径错时回执带完整 hint，而 `invalid_submission` 一个字都没有**——尽管 `repo-cell-packets.ts:145` 抛的时候明明带着 `issues.join("; ")`。

## 改了什么

覆盖五个码，各自给出 `entity` / `field` / `actual` / `expectation`，`expectation` 里带可直接执行的重试命令：

| 码 | 现在会说 |
|---|---|
| `invalid_submission` | 哪个字段不合格、期望什么类型 |
| `invalid_runtime_mission` | 期望的是 mission id 而非路径，以及 daemon 的解析规则 |
| `invalid_proof` | `declare-executor` 的适用条件与当前 execution 状态 |
| `executor_binding_invalid` | 期望与实际的 executor 分别是谁 |
| `invalid_transition` | 当前 round 已有 active execution，不带 `--execution-id` 可复用 |

最后一条尤其值钱：CEO 原本据此误判为「lease 悬空、任何 actor 都推不动」并立了一个方向错误的任务，是派出的 Worker 带证据驳回才纠正的。

## 与 #2232 的关系

**合流，不另建机制。** #2232 已建立 `ReceiptDiagnostic → failed() → CLI` 的统一通道，本 PR 只补它未覆盖的五码，沿用同一通道。只构造封闭的 validation diagnostic，不透传任意 message、内部路径或凭据。

## 验证

- 阴性对照：五码定向测试改前 `0/5`，改后 `5/5`。
- `npm run typecheck`：exit 0
- G36 line-density：pass
- G0-5 daemon specialization ratchet：pass（command `273/305`，其余非增）
- runtime 定向 37 项 35 pass；余 2 项 `daemon-multi-repo-lifecycle-cli` 失败经 CEO 复验为多 worker 争用共享 daemon 的偶发——干净基线与本改动上单独复跑均 `2/2` 通过。

## rebase 冲突消解

main 期间合入 #2231 等七个 PR，与本改动落在同一个面上，三处冲突按**取并集**消解而非二选一：

- `repo-cell-packets.ts`：保留 main 的 `missing_field` / `invalid_command` 行为与文案，同时挂上结构化诊断。
- `repo-cell-command.ts`：统一走抽出的 `reviewExecutionSelection`，main 的选择规则与提示文案原样保留在其中。
- `json-rpc-protocol.test.ts`：incomplete→`missing_field`、unknown→`invalid_command` 两条断言并存，并额外验证诊断字段。

## CI 修红（第二轮）

首轮 21 过 2 红，两条都是真的：

**`integration-shard (3)` 是真回归。** 重构把检查顺序换了，`task-submit` 传一个不存在的 `executionId` 时返回 `lease_required` 而非原来的 `invalid_transition`。**没有改测试期望值去迁就实现**——返回码是下游契约，改测试等于把回归伪装成预期。做法是恢复顺序（`task-action-catalog-runtime.ts:128` 先判 transition、132 后判 lease），码保持 `invalid_transition`，把信息加在诊断里：

```json
{"kind":"validation","entity":"task task-hitrate-lifecycle","field":"executionId",
 "actual":"execution-not-current",
 "expectation":"Current submitted execution is execution-hitrate-lifecycle; retry ha task submit task-hitrate-lifecycle --execution-id execution-hitrate-lifecycle --amend --json-input '<submission-json>'"}
```

同族的 `repeatedSubmit` / `noOpAmend` / `rejectedAmendments[0]` / `amendCompleted` 均已确认仍返回 `invalid_transition`。

**`check-file-complexity` 是真超标**，不是陈旧：`runtime-spawner.ts` 1103 行超过上限 1100。把只读派工提示的组装迁到 `runtime-spawn-mission.ts`，降到 1093 行。**未碰 `tools/check-file-complexity.mjs` 的 allowlist**——该文件是 protected surface（`ordinaryImplementationMayModify: false`）。

复跑：五码 5/5、hitrate 1/1、runtime-spawn 5/5、typecheck exit 0、G36 pass、G0-5 ratchet pass、file-complexity pass。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


