### PR TITLE
fix(gui): show a waiting surface and bounded retry while the daemon is draining or starting

### DIFF
--- a/packages/gui/src/renderer/App.tsx
+++ b/packages/gui/src/renderer/App.tsx
@@ -47,6 +47,7 @@ import { ProvidersView } from "./views/ProvidersView.tsx";
 import { useTaskActions } from "./task-actions.ts";
 import { useDecisionActions } from "./decision-actions.ts";
 import { selectActiveRepoId, useSystemStatusQuery } from "./system-data.ts";
+import { daemonErrorCode, daemonStartupPhase, isRetryableDaemonError } from "./daemon-startup.ts";
 import { useCatalogSnapshot } from "./catalog-data.ts";
 import { adaptRepoProject } from "./model/project-adapter.ts";
 import { TerminalView, type TerminalLaunchTask } from "./views/TerminalView.tsx";
@@ -754,13 +755,64 @@ function AppShell() {
   );
 }
 
+function DaemonStartupGate() {
+  const systemQuery = useSystemStatusQuery();
+  const [startedAt, setStartedAt] = useState(() => Date.now());
+  const [elapsedMs, setElapsedMs] = useState(0);
+  useEffect(() => {
+    if (systemQuery.isSuccess) return;
+    const timer = window.setInterval(() => setElapsedMs(Date.now() - startedAt), 250);
+    return () => window.clearInterval(timer);
+  }, [startedAt, systemQuery.isSuccess]);
+  const phase = daemonStartupPhase({
+    pending: systemQuery.isPending,
+    ready: systemQuery.isSuccess,
+    elapsedMs,
+  });
+  if (phase === "ready") return <AppShell />;
+  const code = daemonErrorCode(systemQuery.error);
+  const retryable = systemQuery.error === null || isRetryableDaemonError(systemQuery.error);
+  if (!retryable || phase === "timeout")
+    return (
+      <main className="grid min-h-screen place-items-center bg-bg p-6" data-testid="daemon-startup-timeout">
+        <section className="max-w-xl rounded-xl border border-danger/50 bg-surface p-6 text-center">
+          <h1 className="ui-heading mb-2">Daemon 尚未就绪</h1>
+          <p className="mb-4 text-text-muted">
+            {code ? `原因：${code}。` : "等待已超过 30 秒。"} 请运行 <code>ha daemon status</code> 检查状态。
+          </p>
+          <button
+            className="rounded-md bg-accent px-4 py-2 font-medium text-accent-fg"
+            type="button"
+            onClick={() => {
+              setStartedAt(Date.now());
+              setElapsedMs(0);
+              void systemQuery.refetch();
+            }}
+          >
+            重试
+          </button>
+        </section>
+      </main>
+    );
+  return (
+    <main className="grid min-h-screen place-items-center bg-bg p-6" data-testid="daemon-startup-waiting">
+      <section className="max-w-xl text-center" role="status">
+        <h1 className="ui-heading mb-2">正在等待 daemon</h1>
+        <p className="text-text-muted">
+          GUI 会自动重试；若 daemon 尚未启动，请在终端运行 <code>ha gui</code>。
+        </p>
+      </section>
+    </main>
+  );
+}
+
 export function App() {
   return (
     <ThemeProvider>
       {/* 本机文档浮层(task_89d324b5)挂在 AppShell 内:它需要当前仓的连接模式 ——
           纯展示(remote-proxy)仓本机无文件,项目外本机文件链接禁用并提示
           (PLT-EdgeGUI-W3);其余模式照常读取。 */}
-      <AppShell />
+      <DaemonStartupGate />
     </ThemeProvider>
   );
 }

--- a/packages/gui/src/renderer/api-client.ts
+++ b/packages/gui/src/renderer/api-client.ts
@@ -26,6 +26,7 @@ import type {
 import { isFactDomainTypeSummaryRow, isRendererRecord, type FactDomainTypeSummaryRow } from "./result-validation.ts";
 import { isSettingsSuccess } from "./settings-payload.ts";
 import { invoke } from "./api-client-invoke.ts";
+import { daemonBridgeError } from "./daemon-startup.ts";
 
 export interface TaskListSuccess {
   readonly ok: true;
@@ -901,8 +902,7 @@ function readDecisionShowResult(value: unknown): DecisionShowSuccess {
 }
 
 function readSystemStatus(value: unknown): SystemStatusSuccess {
-  if (!isSystemStatusSuccess(value))
-    throw new Error(localErrorHint(value, "System status bridge returned an invalid result."));
+  if (!isSystemStatusSuccess(value)) throw daemonBridgeError(value, "System status bridge returned an invalid result.");
   return value;
 }
 function readDaemonControlReceipt(value: unknown): DaemonControlReceipt {

--- a/packages/gui/src/renderer/daemon-startup.ts
+++ b/packages/gui/src/renderer/daemon-startup.ts
@@ -11,7 +11,7 @@ export type DaemonStartupPhase = "pending" | "waiting" | "timeout" | "ready";
 
 export function daemonErrorCode(error: unknown): string | null {
   return error instanceof Error && typeof (error as { readonly code?: unknown }).code === "string"
-    ? String((error as { readonly code: string }).code)
+    ? (error as Error & { readonly code: string }).code
     : null;
 }
 

--- a/packages/gui/src/renderer/daemon-startup.ts
+++ b/packages/gui/src/renderer/daemon-startup.ts
@@ -1,0 +1,45 @@
+export const daemonStartupBudgetMs = 30_000;
+
+const retryableDaemonCodes = new Set([
+  "daemon_closed",
+  "daemon_response_timeout",
+  "daemon_stopping",
+  "daemon_unavailable",
+]);
+
+export type DaemonStartupPhase = "pending" | "waiting" | "timeout" | "ready";
+
+export function daemonErrorCode(error: unknown): string | null {
+  return error instanceof Error && typeof (error as { readonly code?: unknown }).code === "string"
+    ? String((error as { readonly code: string }).code)
+    : null;
+}
+
+export function daemonBridgeError(value: unknown, fallback: string): Error & { readonly code?: string } {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return new Error(fallback);
+  const bridge = value as { readonly ok?: unknown; readonly error?: unknown };
+  if (bridge.ok !== false || bridge.error === null || typeof bridge.error !== "object" || Array.isArray(bridge.error))
+    return new Error(fallback);
+  const detail = bridge.error as { readonly code?: unknown; readonly hint?: unknown };
+  const error = new Error(typeof detail.hint === "string" ? detail.hint : fallback);
+  return typeof detail.code === "string" ? Object.assign(error, { code: detail.code }) : error;
+}
+
+export function isRetryableDaemonError(error: unknown): boolean {
+  const code = daemonErrorCode(error);
+  return code !== null && retryableDaemonCodes.has(code);
+}
+
+export function daemonStartupPhase(input: {
+  readonly pending: boolean;
+  readonly ready: boolean;
+  readonly elapsedMs: number;
+}): DaemonStartupPhase {
+  if (input.ready) return "ready";
+  if (input.elapsedMs >= daemonStartupBudgetMs) return "timeout";
+  return input.pending ? "pending" : "waiting";
+}
+
+export function daemonRetryDelay(attempt: number): number {
+  return Math.min(250 * 2 ** attempt, 2_000);
+}

--- a/packages/gui/src/renderer/system-data.ts
+++ b/packages/gui/src/renderer/system-data.ts
@@ -1,6 +1,7 @@
 import { useCallback, useState } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { harnessClient, type DaemonControlReceipt, type SystemRepoRow } from "./api-client.ts";
+import { daemonRetryDelay, isRetryableDaemonError } from "./daemon-startup.ts";
 
 export const systemQueryKeys = {
   status: () => ["system", "global", "status"] as const,
@@ -18,6 +19,8 @@ export function useSystemStatusQuery() {
     queryFn: () => harnessClient.getSystemStatus(),
     staleTime: 3_000,
     refetchInterval: 10_000,
+    retry: (failureCount, error) => failureCount < 16 && isRetryableDaemonError(error),
+    retryDelay: daemonRetryDelay,
   });
 }
 

--- a/packages/gui/test-support/resident-daemon.mjs
+++ b/packages/gui/test-support/resident-daemon.mjs
@@ -18,6 +18,20 @@ export async function startGuiResidentDaemonFixture({
     userRoot = path.join(parent, "user");
   let daemon = await startDaemon({ daemonId, userRoot });
   let stopped = false;
+  const pauseDaemon = async () => {
+    await daemon.stop();
+  };
+  const resumeDaemon = async () => {
+    const originalTmpdir = process.env.TMPDIR;
+    process.env.TMPDIR = "/tmp";
+    try {
+      daemon = await startDaemon({ daemonId, userRoot });
+      return daemon.endpoint;
+    } finally {
+      if (originalTmpdir === undefined) delete process.env.TMPDIR;
+      else process.env.TMPDIR = originalTmpdir;
+    }
+  };
   const stop = async () => {
     if (stopped) return;
     stopped = true;
@@ -69,6 +83,8 @@ export async function startGuiResidentDaemonFixture({
       packagePath,
       endpoint: daemon.endpoint,
       env: { HARNESS_DAEMON_USER_ROOT: userRoot, HARNESS_DAEMON_ID: daemonId, HARNESS_DAEMON_REPO_ID: repoId },
+      pauseDaemon,
+      resumeDaemon,
       stop,
     };
   } catch (error) {

--- a/packages/gui/test/daemon-startup.vitest.ts
+++ b/packages/gui/test/daemon-startup.vitest.ts
@@ -1,0 +1,46 @@
+// harness-test-tier: integration
+// @vitest-environment happy-dom
+import { describe, expect, it } from "vitest";
+import {
+  daemonRetryDelay,
+  daemonStartupBudgetMs,
+  daemonStartupPhase,
+  isRetryableDaemonError,
+} from "../src/renderer/daemon-startup.ts";
+import { harnessClient } from "../src/renderer/api-client.ts";
+
+describe("daemon startup state machine", () => {
+  it("moves pending to waiting and then ready", () => {
+    expect(daemonStartupPhase({ pending: true, ready: false, elapsedMs: 0 })).toBe("pending");
+    expect(daemonStartupPhase({ pending: false, ready: false, elapsedMs: 1_000 })).toBe("waiting");
+    expect(daemonStartupPhase({ pending: false, ready: true, elapsedMs: 1_001 })).toBe("ready");
+  });
+
+  it("moves waiting to timeout and a fresh retry can become ready", () => {
+    expect(daemonStartupPhase({ pending: false, ready: false, elapsedMs: daemonStartupBudgetMs })).toBe("timeout");
+    expect(daemonStartupPhase({ pending: true, ready: false, elapsedMs: 0 })).toBe("pending");
+    expect(daemonStartupPhase({ pending: false, ready: true, elapsedMs: 250 })).toBe("ready");
+  });
+
+  it("retries only classified daemon availability failures with capped backoff", () => {
+    for (const code of ["daemon_unavailable", "daemon_stopping", "daemon_closed", "daemon_response_timeout"])
+      expect(isRetryableDaemonError(Object.assign(new Error(code), { code }))).toBe(true);
+    expect(isRetryableDaemonError(Object.assign(new Error("bad request"), { code: "invalid_request" }))).toBe(false);
+    expect(daemonRetryDelay(0)).toBe(250);
+    expect(daemonRetryDelay(20)).toBe(2_000);
+  });
+
+  it("preserves the bridge error code for retry classification", async () => {
+    Object.defineProperty(window, "harness", {
+      configurable: true,
+      value: {
+        getSystemStatus: async () => ({
+          ok: false,
+          error: { code: "daemon_stopping", hint: "The daemon is draining." },
+        }),
+      },
+    });
+    await expect(harnessClient.getSystemStatus()).rejects.toMatchObject({ code: "daemon_stopping" });
+    Reflect.deleteProperty(window, "harness");
+  });
+});

--- a/tools/gui-e2e/catalog.mjs
+++ b/tools/gui-e2e/catalog.mjs
@@ -14,6 +14,7 @@ import declaredEntityKinds from "./scenarios/declared-entity-kinds.mjs";
 import systemDaemonLogs from "./scenarios/system-daemon-logs.mjs";
 import sessionsGrouping from "./scenarios/sessions-grouping.mjs";
 import scheduleRunHistory from "./scenarios/schedule-run-history.mjs";
+import daemonStartupWait from "./scenarios/daemon-startup-wait.mjs";
 
 export const catalog = [
   shellNavigation,
@@ -32,6 +33,7 @@ export const catalog = [
   systemDaemonLogs,
   sessionsGrouping,
   scheduleRunHistory,
+  daemonStartupWait,
 ];
 
 export function selectScenarios({ lane, ids }) {

--- a/tools/gui-e2e/lanes.mjs
+++ b/tools/gui-e2e/lanes.mjs
@@ -103,6 +103,7 @@ export async function openLane({ lane, workspaceRoot, env, runRoot, startDriver 
     runRoot,
   });
   driver.runRoot = runRoot;
+  driver.fixture = fixture;
   return {
     driver,
     async close() {

--- a/tools/gui-e2e/scenarios/daemon-startup-wait.mjs
+++ b/tools/gui-e2e/scenarios/daemon-startup-wait.mjs
@@ -1,0 +1,15 @@
+export default {
+  id: "daemon-startup-wait",
+  feature: "daemon-startup",
+  lane: "isolated",
+  description: "A renderer reload waits visibly for an unavailable daemon and recovers without another reload.",
+  async run({ page, fixture, shot }) {
+    await fixture.pauseDaemon();
+    await page.reload();
+    await page.getByTestId("daemon-startup-waiting").waitFor();
+    await shot("daemon-startup-waiting");
+    await fixture.resumeDaemon();
+    await page.getByTestId("daemon-startup-waiting").waitFor({ state: "detached" });
+    await page.getByRole("button", { name: /^(?:总览|Overview)$/u }).waitFor();
+  },
+};

--- a/tools/gui-test-manifest.mjs
+++ b/tools/gui-test-manifest.mjs
@@ -17,6 +17,7 @@ export const guiVitestManifest = [
   "packages/gui/test/local-main-controls.vitest.ts",
   "packages/gui/test/secure-runtime-instance-broker.vitest.ts",
   "packages/gui/test/daemon-supervisor.vitest.ts",
+  "packages/gui/test/daemon-startup.vitest.ts",
   "packages/gui/test/renderer-app-model.vitest.ts",
   "packages/gui/test/fact-triage.vitest.ts",
   "packages/gui/test/taskFilters.vitest.ts",


### PR DESCRIPTION
# English

## Summary

When the Electron GUI starts while the local daemon is draining, restarting or not yet autostarted, the renderer's first bridge read hangs and the window stays white forever. This change puts an explicit startup gate in front of the app shell: the first frame is a "waiting for daemon" surface, the system read retries only on the daemon's retryable error codes with a 250ms to 2s backoff through React Query's own retry hooks, and after the 30 second budget (the daemon's projection readiness ceiling) the surface shows the reason, the `ha daemon status` command and a retry button. A blank window is no longer a reachable state.

## Architectural Justification

No second heartbeat or probe: the gate consumes the same system read the shell already issues and the structured error codes the bridge already returns; the only fix in the bridge path is that the renderer stops discarding the daemon's `error.code`. The retry loop is React Query's retry/retryDelay, not a hand-written timer. The isolated e2e fixture gained pause/resume so the scenario can stop and restart its own daemon without touching the canonical one.

## What Changed

- `packages/gui/src/renderer/App.tsx`: startup gate before `AppShell`; waiting, timeout and retry surfaces.
- `packages/gui/src/renderer/daemon-startup.ts` (new): budget, phase derivation, retryable code set, backoff.
- `packages/gui/src/renderer/api-client.ts`, `system-data.ts`: keep the bridge error code; retry only retryable codes.
- `packages/gui/test/daemon-startup.vitest.ts` (new): pending→waiting→ready, waiting→timeout→retry→ready, error classification.
- `packages/gui/test-support/resident-daemon.mjs`, `tools/gui-e2e/{catalog,lanes}.mjs`, `tools/gui-e2e/scenarios/daemon-startup-wait.mjs` (new): isolated scenario that stops the fixture daemon, reloads, asserts the waiting surface, resumes the daemon and asserts the shell mounts without a manual reload.

## Gate Harvest / 门收割

No gate change. / 门未改。

## Machine-Readable Declarations

Production-Delta: +122/-3
Dependency-Change: none

### Optional Evidence Claims

none

## Task And Scope

task_9f901a59e70257632ed65e54de. Branch `codex/gui-daemon-wait`. Fact F-E6CDD99B records the two white-screen reproductions on 2026-09-04.

## Version Impact

No version change; publish impact none.

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none
- Authority: task_9f901a59e70257632ed65e54de
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Follow-up governance task: not applicable

## Verification

- Worker (Sol): `npx vitest run test/daemon-startup.vitest.ts` 4/4; full `npx vitest run` 85 files / 824 tests; isolated e2e `daemon-startup-wait` healthy; negative control `overview-first-usable` healthy; lint, line-density, file-complexity, production-delta pass.
- CEO read the state machine and the gate; CI is the complete authority.

## Review Evidence

CEO semantic review against the task plan: waiting state is event and error-code driven (no sleeps), retry reuses React Query, the 30 second budget cites the daemon readiness ceiling, the timeout surface carries an action, and the e2e scenario exercises stop→wait→resume→mount. The worker could not write facts (`executor_binding_invalid`, tracked separately); the CEO records the fact at closeout.

## Residual Risk

The 30 second timeout branch is covered by the unit state machine, not by e2e (kept fast on purpose). The change was not exercised against the user's live desktop daemon; the isolated fixture is the equivalent.

# 中文

## 概要

Electron GUI 在本地 daemon draining/重启/尚未自启的窗口内启动时,渲染层首个桥接读挂起,窗口永远白屏。本改动在 AppShell 前加显式启动门:首帧即「等待 daemon」面,system 读只对 daemon 的可重试错误码经 React Query 自带 retry 做 250ms→2s 退避,超过 30 秒预算(daemon 投影就绪上限)显示原因、`ha daemon status` 命令与重试按钮。白屏不再是可达状态。

## 架构辩护

不新造第二套心跳/探针:启动门消费 shell 本来就发的 system 读与桥接已有的结构化错误码,桥接路径唯一的修正是渲染层不再丢掉 `error.code`;重试循环用 React Query 的 retry/retryDelay 而非手写定时器。isolated e2e fixture 加 pause/resume 让场景自管 daemon,不碰 canonical daemon。

## 机读声明

生产行数增减(与上文机读声明一致):+122/-3

## 治理声明

- 触碰受保护面:否
- 授权:task_9f901a59e70257632ed65e54de
- Break-glass:否

## 验证

Sol:状态机单测 4/4,GUI vitest 824/824,isolated e2e `daemon-startup-wait` 与阴性对照 `overview-first-usable` 均 healthy,lint/line-density/file-complexity/production-delta 通过。CI 为完整权威。

## 评审证据

CEO 按 plan 复核:等待态由事件与错误码驱动,不加 sleep;重试复用 React Query;30 秒预算引用 daemon 就绪上限;超时面带动作;e2e 覆盖停→等→恢复→挂载。

## 残余风险

30 秒超时分支只有单测覆盖;未在泽宇桌面的真实 daemon 上实测,以 isolated fixture 等价。
