### PR TITLE
feat(gui): show unsupported runtime capabilities disabled instead of hiding them

### DIFF
--- a/packages/gui/src/renderer/components/runtime/NewRuntimeDialog.tsx
+++ b/packages/gui/src/renderer/components/runtime/NewRuntimeDialog.tsx
@@ -173,24 +173,26 @@ export function NewRuntimeDialog({
           <Hint>{t("agentRuntime.callPathCodex")}</Hint>
         </div>
       )}
-      {planeUsesApiOverride(form.kindId) && (
-        <div>
-          <div className="flex flex-wrap items-center gap-2">
-            <Toggle
-              checked={apiOn}
-              label={t("agentRuntime.apiOverride")}
-              onChange={(next) =>
-                setForm((current) => applyRuntimeAuthMode(current, next ? "api-key" : "subscription"))
-              }
-            />
-            <b className="ui-micro">{t("agentRuntime.apiOverride")}</b>
-            <Badge status={apiOn ? "active" : "planned"}>
-              {t(apiOn ? "agentRuntime.apiOverrideOn" : "agentRuntime.apiOverrideOff")}
-            </Badge>
-          </div>
-          <p className="mt-1 ui-micro text-text-faint">{t("agentRuntime.callPathClaude")}</p>
+      <div>
+        <div className="flex flex-wrap items-center gap-2">
+          <Toggle
+            checked={apiOn}
+            label={t("agentRuntime.apiOverride")}
+            disabled={!planeUsesApiOverride(form.kindId)}
+            onChange={(next) => setForm((current) => applyRuntimeAuthMode(current, next ? "api-key" : "subscription"))}
+          />
+          <b className="ui-micro">{t("agentRuntime.apiOverride")}</b>
+          <Badge status={apiOn ? "active" : "planned"}>
+            {t(apiOn ? "agentRuntime.apiOverrideOn" : "agentRuntime.apiOverrideOff")}
+          </Badge>
         </div>
-      )}
+        <p className="mt-1 ui-micro text-text-faint">
+          {t(planeUsesApiOverride(form.kindId) ? "agentRuntime.callPathClaude" : "agentRuntime.capabilityUnsupported", {
+            provider: form.kindId,
+            capability: t("agentRuntime.apiOverride"),
+          })}
+        </p>
+      </div>
 
       <div className="mt-3 grid grid-cols-[repeat(auto-fill,minmax(215px,1fr))] gap-x-[18px] gap-y-2">
         <Labelled label={t("agentRuntime.instanceId")}>
@@ -230,56 +232,86 @@ export function NewRuntimeDialog({
             testIdPrefix="new-runtime"
           />
         </Labelled>
-        {planeAllowsBaseUrl(form.kindId, form.authMode) && (
-          <Labelled label={t("agentRuntime.baseUrl")} hint={t("agentRuntime.baseUrlHint")}>
+        <Labelled
+          label={t("agentRuntime.baseUrl")}
+          hint={
+            planeAllowsBaseUrl(form.kindId, form.authMode)
+              ? t("agentRuntime.baseUrlHint")
+              : t("agentRuntime.capabilityUnsupported", {
+                  provider: form.kindId,
+                  capability: t("agentRuntime.baseUrl"),
+                })
+          }
+        >
+          <TextInput
+            label={t("agentRuntime.baseUrl")}
+            testId="new-runtime-base-url"
+            mono
+            value={form.baseUrl}
+            disabled={!planeAllowsBaseUrl(form.kindId, form.authMode)}
+            onChange={(baseUrl) => patch({ baseUrl })}
+            placeholder="https://open.bigmodel.cn/api/anthropic"
+          />
+        </Labelled>
+        <Labelled
+          label={t("agentRuntime.apiKey")}
+          hint={
+            planeAllowsApiKey(form.kindId, form.authMode)
+              ? t("agentRuntime.apiKeyHint")
+              : t("agentRuntime.capabilityUnsupported", {
+                  provider: form.kindId,
+                  capability: t("agentRuntime.apiKey"),
+                })
+          }
+        >
+          <TextInput
+            label={t("agentRuntime.apiKey")}
+            testId="new-runtime-api-key"
+            type="password"
+            value={form.apiKey}
+            disabled={!planeAllowsApiKey(form.kindId, form.authMode)}
+            onChange={(apiKey) => patch({ apiKey })}
+            placeholder={t("agentRuntime.apiKeyPlaceholder")}
+          />
+        </Labelled>
+        {plane.effort === "enum" ? (
+          <Labelled label={t("agentRuntime.effort")}>
+            <select
+              aria-label={t("agentRuntime.effort")}
+              value={form.reasoningEffort}
+              onChange={(event) => patch({ reasoningEffort: event.target.value })}
+              className="control"
+            >
+              <option value="">{t("agentRuntime.providerDefault")}</option>
+              {plane.effortValues.map((effort) => (
+                <option key={effort} value={effort}>
+                  {effort}
+                </option>
+              ))}
+            </select>
+          </Labelled>
+        ) : (
+          <Labelled
+            label={t("agentRuntime.effort")}
+            hint={
+              planeAllowsEffort(form.kindId)
+                ? undefined
+                : t("agentRuntime.capabilityUnsupported", {
+                    provider: form.kindId,
+                    capability: t("agentRuntime.effort"),
+                  })
+            }
+          >
             <TextInput
-              label={t("agentRuntime.baseUrl")}
-              testId="new-runtime-base-url"
+              label={t("agentRuntime.effort")}
               mono
-              value={form.baseUrl}
-              onChange={(baseUrl) => patch({ baseUrl })}
-              placeholder="https://open.bigmodel.cn/api/anthropic"
+              value={form.reasoningEffort}
+              disabled={!planeAllowsEffort(form.kindId)}
+              onChange={(reasoningEffort) => patch({ reasoningEffort })}
+              placeholder="xhigh"
             />
           </Labelled>
         )}
-        {planeAllowsApiKey(form.kindId, form.authMode) && (
-          <Labelled label={t("agentRuntime.apiKey")} hint={t("agentRuntime.apiKeyHint")}>
-            <TextInput
-              label={t("agentRuntime.apiKey")}
-              testId="new-runtime-api-key"
-              type="password"
-              value={form.apiKey}
-              onChange={(apiKey) => patch({ apiKey })}
-              placeholder={t("agentRuntime.apiKeyPlaceholder")}
-            />
-          </Labelled>
-        )}
-        {planeAllowsEffort(form.kindId) &&
-          (plane.effort === "enum" ? (
-            <Labelled label={t("agentRuntime.effort")}>
-              <select
-                aria-label={t("agentRuntime.effort")}
-                value={form.reasoningEffort}
-                onChange={(event) => patch({ reasoningEffort: event.target.value })}
-                className="control"
-              >
-                <option value="">{t("agentRuntime.providerDefault")}</option>
-                <option value="low">low</option>
-                <option value="medium">medium</option>
-                <option value="high">high</option>
-              </select>
-            </Labelled>
-          ) : (
-            <Labelled label={t("agentRuntime.effort")}>
-              <TextInput
-                label={t("agentRuntime.effort")}
-                mono
-                value={form.reasoningEffort}
-                onChange={(reasoningEffort) => patch({ reasoningEffort })}
-                placeholder="xhigh"
-              />
-            </Labelled>
-          ))}
         {form.kindId === "codex" && (
           <Labelled label={t("agentRuntime.fast")} hint={t("agentRuntime.fastHint")}>
             <span
@@ -305,35 +337,53 @@ export function NewRuntimeDialog({
             </select>
           </Labelled>
         )}
-        {planeAllowsPermissions(form.kindId) && (
-          <Labelled label={t("agentRuntime.permissionMode")}>
-            <select
-              aria-label={t("agentRuntime.permissionMode")}
-              value={form.permissionMode}
-              onChange={(event) =>
-                patch({ permissionMode: event.target.value as CreateInstanceFormState["permissionMode"] })
-              }
-              className="control"
-            >
-              <option value="bypass">{t("agentRuntime.permissionBypass")}</option>
-              <option value="workspace-write">{t("agentRuntime.permissionWorkspaceWrite")}</option>
-              <option value="read-only">{t("agentRuntime.permissionReadOnly")}</option>
-            </select>
-          </Labelled>
-        )}
-        {planeAllowsPermissions(form.kindId) && (
-          <Labelled label={t("agentRuntime.isolation")}>
-            <select
-              aria-label={t("agentRuntime.isolation")}
-              value={form.isolation}
-              onChange={(event) => patch({ isolation: event.target.value as CreateInstanceFormState["isolation"] })}
-              className="control"
-            >
-              <option value="operator-environment">{t("agentRuntime.operatorEnvironment")}</option>
-              <option value="enforced">{t("agentRuntime.instanceStateRoot")}</option>
-            </select>
-          </Labelled>
-        )}
+        <Labelled
+          label={t("agentRuntime.permissionMode")}
+          hint={
+            planeAllowsPermissions(form.kindId)
+              ? undefined
+              : t("agentRuntime.capabilityUnsupported", {
+                  provider: form.kindId,
+                  capability: t("agentRuntime.permissionMode"),
+                })
+          }
+        >
+          <select
+            aria-label={t("agentRuntime.permissionMode")}
+            value={form.permissionMode}
+            disabled={!planeAllowsPermissions(form.kindId)}
+            onChange={(event) =>
+              patch({ permissionMode: event.target.value as CreateInstanceFormState["permissionMode"] })
+            }
+            className="control"
+          >
+            <option value="bypass">{t("agentRuntime.permissionBypass")}</option>
+            <option value="workspace-write">{t("agentRuntime.permissionWorkspaceWrite")}</option>
+            <option value="read-only">{t("agentRuntime.permissionReadOnly")}</option>
+          </select>
+        </Labelled>
+        <Labelled
+          label={t("agentRuntime.isolation")}
+          hint={
+            planeAllowsPermissions(form.kindId)
+              ? undefined
+              : t("agentRuntime.capabilityUnsupported", {
+                  provider: form.kindId,
+                  capability: t("agentRuntime.isolation"),
+                })
+          }
+        >
+          <select
+            aria-label={t("agentRuntime.isolation")}
+            value={form.isolation}
+            disabled={!planeAllowsPermissions(form.kindId)}
+            onChange={(event) => patch({ isolation: event.target.value as CreateInstanceFormState["isolation"] })}
+            className="control"
+          >
+            <option value="operator-environment">{t("agentRuntime.operatorEnvironment")}</option>
+            <option value="enforced">{t("agentRuntime.instanceStateRoot")}</option>
+          </select>
+        </Labelled>
       </div>
       {form.kindId === "codex" && apiOn && (
         <label className="mt-2 flex items-center gap-1.5 font-mono ui-micro uppercase text-text-faint">

--- a/packages/gui/src/renderer/components/runtime/RuntimeCard.tsx
+++ b/packages/gui/src/renderer/components/runtime/RuntimeCard.tsx
@@ -263,11 +263,16 @@ export function RuntimeCard({
               )}
             </div>
             {apiMode && <p className="mt-2 ui-micro text-text-faint">{t("agentRuntime.apiKeySealed")}</p>}
-            {planeUsesApiOverride(instance.kindId) && (
-              <p className="mt-2 ui-micro text-text-faint">
-                {t(apiMode ? "agentRuntime.claudeApiOverrideOn" : "agentRuntime.claudeApiOverrideOff")}
-              </p>
-            )}
+            <p className="mt-2 ui-micro text-text-faint">
+              {t(
+                planeUsesApiOverride(instance.kindId)
+                  ? apiMode
+                    ? "agentRuntime.claudeApiOverrideOn"
+                    : "agentRuntime.claudeApiOverrideOff"
+                  : "agentRuntime.capabilityUnsupported",
+                { provider: instance.kindId, capability: t("agentRuntime.apiOverride") },
+              )}
+            </p>
           </div>
         </CardBody>
       </Card>
@@ -316,17 +321,22 @@ export function RuntimeCard({
         </CardBody>
       </Card>
 
-      {planeAllowsPermissions(instance.kindId) && (
-        <Card testId="runtime-card-isolation">
-          <CardHead>
-            <CardTitle>{t("agentRuntime.isolationTitle")}</CardTitle>
-            <Hint>{t("agentRuntime.isolationHint")}</Hint>
-          </CardHead>
-          <CardBody>
-            <PermissionsEditor instance={instance} busy={busy} onUpdate={onUpdate} />
-          </CardBody>
-        </Card>
-      )}
+      <Card testId="runtime-card-isolation">
+        <CardHead>
+          <CardTitle>{t("agentRuntime.isolationTitle")}</CardTitle>
+          <Hint>
+            {t(
+              planeAllowsPermissions(instance.kindId)
+                ? "agentRuntime.isolationHint"
+                : "agentRuntime.capabilityUnsupported",
+              { provider: instance.kindId, capability: t("agentRuntime.isolationTitle") },
+            )}
+          </Hint>
+        </CardHead>
+        <CardBody>
+          <PermissionsEditor instance={instance} busy={busy} onUpdate={onUpdate} />
+        </CardBody>
+      </Card>
 
       <Card>
         <CardHead>
@@ -464,22 +474,28 @@ function ProviderEditor({
             ))}
           </select>
         </label>
-        {planeAllowsBaseUrl(instance.kindId, instance.authMode) && (
-          <label className="grid gap-0.5">
-            <span className="font-mono ui-micro uppercase tracking-[0.08em] text-text-faint">
-              {t("agentRuntime.baseUrl")}
-            </span>
-            <TextInput
-              label={t("agentRuntime.baseUrl")}
-              testId="runtime-provider-base-url"
-              mono
-              value={draft.baseUrl}
-              onChange={(baseUrl) => patch({ baseUrl })}
-              placeholder="https://api.third-party.example/v1"
-            />
-            <span className="ui-micro text-text-faint">{t("agentRuntime.baseUrlHint")}</span>
-          </label>
-        )}
+        <label className="grid gap-0.5">
+          <span className="font-mono ui-micro uppercase tracking-[0.08em] text-text-faint">
+            {t("agentRuntime.baseUrl")}
+          </span>
+          <TextInput
+            label={t("agentRuntime.baseUrl")}
+            testId="runtime-provider-base-url"
+            mono
+            value={draft.baseUrl}
+            disabled={!planeAllowsBaseUrl(instance.kindId, instance.authMode)}
+            onChange={(baseUrl) => patch({ baseUrl })}
+            placeholder="https://api.third-party.example/v1"
+          />
+          <span className="ui-micro text-text-faint">
+            {t(
+              planeAllowsBaseUrl(instance.kindId, instance.authMode)
+                ? "agentRuntime.baseUrlHint"
+                : "agentRuntime.capabilityUnsupported",
+              { provider: instance.kindId, capability: t("agentRuntime.baseUrl") },
+            )}
+          </span>
+        </label>
         <label className="grid gap-0.5">
           <span className="font-mono ui-micro uppercase tracking-[0.08em] text-text-faint">
             {t("agentRuntime.model")}
@@ -534,12 +550,13 @@ function PermissionsEditor({
   const [isolationState, setIsolationState] = useState(() =>
     runtimeIsolationState(instance.isolationState, instance.kindId),
   );
-  if (!permissionMode) return <Empty>{t("agentRuntime.permissionsUnsupported")}</Empty>;
+  const supported = planeAllowsPermissions(instance.kindId);
   return (
     <form
       data-testid="runtime-instance-permissions"
       onSubmit={(event) => {
         event.preventDefault();
+        if (!supported || !permissionMode) return;
         onUpdate({
           instanceId: instance.instanceId,
           permissionMode,
@@ -552,6 +569,7 @@ function PermissionsEditor({
           data-testid="runtime-instance-permission-mode"
           aria-label={t("agentRuntime.permissionMode")}
           value={permissionMode}
+          disabled={!supported}
           onChange={(event) => setPermissionMode(event.target.value as typeof permissionMode)}
           className="control"
         >
@@ -566,6 +584,7 @@ function PermissionsEditor({
             data-testid="runtime-instance-isolation"
             aria-label={t("agentRuntime.isolation")}
             value={isolationState}
+            disabled={!supported}
             onChange={(event) => setIsolationState(event.target.value as typeof isolationState)}
             className="control"
           >
@@ -574,7 +593,8 @@ function PermissionsEditor({
           </select>
         </CfgRow>
       )}
-      <Btn type="submit" size="sm" disabled={busy}>
+      {!supported && <Hint>{t("agentRuntime.permissionsUnsupported")}</Hint>}
+      <Btn type="submit" size="sm" disabled={busy || !supported}>
         {t("agentRuntime.savePermissions")}
       </Btn>
     </form>

--- a/packages/gui/src/renderer/components/runtime/parts.tsx
+++ b/packages/gui/src/renderer/components/runtime/parts.tsx
@@ -365,10 +365,12 @@ export function Toggle({
   checked,
   onChange,
   label,
+  disabled,
 }: {
   readonly checked: boolean;
   readonly onChange: (checked: boolean) => void;
   readonly label: string;
+  readonly disabled?: boolean;
 }) {
   return (
     <button
@@ -376,8 +378,12 @@ export function Toggle({
       role="switch"
       aria-checked={checked}
       aria-label={label}
+      disabled={disabled}
       onClick={() => onChange(!checked)}
-      className={`relative h-4 w-[30px] shrink-0 rounded-full border transition-colors ${checked ? "border-transparent bg-accent" : "border-border-strong bg-surface"}`}
+      className={
+        "relative h-4 w-[30px] shrink-0 rounded-full border transition-colors disabled:opacity-50 " +
+        (checked ? "border-transparent bg-accent" : "border-border-strong bg-surface")
+      }
     >
       <span
         className={`absolute top-[2px] size-2.5 rounded-full transition-transform ${checked ? "translate-x-[16px] bg-accent-fg" : "translate-x-[2px] bg-text-faint"}`}

--- a/packages/gui/src/renderer/i18n/locales/en-US/agentRuntime.json
+++ b/packages/gui/src/renderer/i18n/locales/en-US/agentRuntime.json
@@ -73,6 +73,7 @@
   "agentRuntime.operatorEnvironment": "Operator environment",
   "agentRuntime.savePermissions": "Save permissions",
   "agentRuntime.permissionsUnsupported": "This provider owns its own access policy; harness adds no permission mode.",
+  "agentRuntime.capabilityUnsupported": "{provider} does not support {capability} in this call path.",
   "agentRuntime.compatibleAgents": "Compatible agents",
   "agentRuntime.compatibleAgentsHint": "runtime_type = {kind} or any",
   "agentRuntime.noCompatibleAgent": "No compatible agent",

--- a/packages/gui/src/renderer/i18n/locales/zh-CN/agentRuntime.json
+++ b/packages/gui/src/renderer/i18n/locales/zh-CN/agentRuntime.json
@@ -73,6 +73,7 @@
   "agentRuntime.operatorEnvironment": "操作者环境",
   "agentRuntime.savePermissions": "保存权限",
   "agentRuntime.permissionsUnsupported": "该 provider 自己管访问策略,harness 不加权限档。",
+  "agentRuntime.capabilityUnsupported": "{provider} 的当前调用方式不支持{capability}。",
   "agentRuntime.compatibleAgents": "兼容 Agents",
   "agentRuntime.compatibleAgentsHint": "runtime_type = {kind} 或 any",
   "agentRuntime.noCompatibleAgent": "没有兼容的 Agent",

--- a/packages/gui/src/renderer/runtime-provider-planes.ts
+++ b/packages/gui/src/renderer/runtime-provider-planes.ts
@@ -19,35 +19,55 @@ export interface RuntimeProviderPlane {
   /** Models the user may type freely, or a fixed provider family they may only pick within. */
   readonly modelFamily: "open" | "codex-only" | "gemini-only";
   readonly effort: "none" | "free" | "enum";
+  readonly effortValues: readonly string[];
   readonly permissions: boolean;
 }
 
 const PLANES: Readonly<Record<RuntimeKindId, RuntimeProviderPlane>> = {
   agy: {
+    // Product identifiers/defaults; not covered by the capability matrix.
     kindId: "agy",
     defaultProviderId: "google",
+    // Matrix dimension 13 (C): subscription login only.
     authShape: "subscription-only",
     authModes: ["subscription"],
+    // Product model-catalog constraint; unverified and not covered by matrix dimension 11.
     modelFamily: "gemini-only",
+    // Matrix dimension 12: flag registration is E; these values remain H (unverified).
     effort: "enum",
+    effortValues: ["low", "medium", "high"],
+    // Matrix dimensions 5-6 (C/E): harness exposes no mapped permission control for agy.
     permissions: false,
   },
   claude: {
+    // Product identifiers/defaults; not covered by the capability matrix.
     kindId: "claude",
     defaultProviderId: "anthropic",
+    // Matrix dimension 13 (C): subscription login plus API-key override.
     authShape: "api-override",
     authModes: ["subscription", "api-key"],
+    // Product model-catalog constraint; unverified and not covered by matrix dimension 11.
     modelFamily: "open",
+    // Claude 2.1.260 实测接受 effort 且 launch 侧已在传，但提交链路在 preload/protocol/store 三处缺字段，
+    // 见 task_ec4aa7c3fc0a66a574dba873ab；在那条修完之前这里保持 none，以免渲染一个存不下的输入框。
     effort: "none",
+    effortValues: [],
+    // Matrix dimensions 5-6 (C/E): harness maps permission and isolation controls.
     permissions: true,
   },
   codex: {
+    // Product identifiers/defaults; not covered by the capability matrix.
     kindId: "codex",
     defaultProviderId: "openai",
+    // Matrix dimension 13 (C): subscription and API-key instances are separate.
     authShape: "separate",
     authModes: ["subscription", "api-key"],
+    // Product model-catalog constraint; unverified and not covered by matrix dimension 11.
     modelFamily: "codex-only",
+    // Matrix dimension 12 (C): harness passes a free TOML effort value.
     effort: "free",
+    effortValues: [],
+    // Matrix dimensions 5-6 (C/E): harness maps permission and sandbox controls.
     permissions: true,
   },
 };

--- a/packages/gui/test/agent-runtime-renderer.vitest.ts
+++ b/packages/gui/test/agent-runtime-renderer.vitest.ts
@@ -673,7 +673,7 @@ describe("agent runtime renderer", () => {
     expect(assertPreloadPayload("listSquads", { repoId: "repo-a" })).toBe(true);
     expect(() => assertPreloadPayload("listAgents", { repoId: "repo-a", agentId: "fable" })).toThrow(/not allowed/u);
   });
-  it("takes the API key only as a masked one-shot input, and only where the plane has an API mode", () => {
+  it("keeps the masked API key visible and disables it when the call path has no API mode", () => {
     const field = renderToStaticMarkup(
       createElement(TextInput, { label: "API key", type: "password", value: "", onChange: noop }),
     );
@@ -691,13 +691,19 @@ describe("agent runtime renderer", () => {
           onCreate: noop,
         }),
       );
-    for (const kind of ["claude", "codex", "agy"] as const) expect(dialog(kind)).not.toMatch(/type="password"/u);
+    for (const kind of ["claude", "codex", "agy"] as const) expect(dialog(kind)).toMatch(/type="password"/u);
+    expect(dialog("claude")).toMatch(/type="password"[^>]*disabled=""/u);
     expect(dialog("claude")).toContain("API override");
     expect(dialog("codex")).toContain("Codex-family models only.");
     expect(dialog("codex")).toContain("Fast mode");
     expect(dialog("codex")).toContain('data-testid="new-runtime-fast"');
     expect(dialog("agy")).toContain("AGY supports only its own login flow");
-    expect(dialog("agy")).not.toContain("API override");
+    expect(dialog("agy")).toContain("API override");
+    expect(dialog("agy")).toMatch(/<button[^>]*aria-label="API override"[^>]*disabled=""/u);
+    expect(dialog("agy")).toContain("agy does not support API override in this call path.");
+    expect(dialog("agy")).toMatch(/<input[^>]*data-testid="new-runtime-base-url"[^>]*disabled=""/u);
+    expect(dialog("agy")).toMatch(/<input[^>]*data-testid="new-runtime-api-key"[^>]*disabled=""/u);
+    expect(dialog("claude")).toMatch(/<input[^>]*aria-label="Effort"[^>]*disabled=""/u);
     expect(dialog("agy")).not.toContain("Fast mode");
   });
   it("renders detected models as selected checkboxes and keeps custom text behind an override", () => {
@@ -761,7 +767,9 @@ describe("agent runtime renderer", () => {
     expect(codex).not.toContain('data-testid="runtime-instance-isolation"');
     expect(claude).toContain('data-testid="runtime-instance-permission-mode"');
     expect(claude).toContain('data-testid="runtime-instance-isolation"');
-    expect(agy).not.toContain('data-testid="runtime-instance-permissions"');
+    expect(agy).toContain('data-testid="runtime-instance-permissions"');
+    expect(agy).toMatch(/data-testid="runtime-instance-permission-mode"[^>]*disabled=""/u);
+    expect(agy).toContain("This provider owns its own access policy; harness adds no permission mode.");
   });
   it("rejects a malformed session-groups projection instead of rendering it", async () => {
     const readUseCaseProjection = vi.fn(async () => sessionGroupsEnvelope({ ok: true, groups: "not-an-array" })),

--- a/packages/gui/test/runtime-workspace-interactions.vitest.ts
+++ b/packages/gui/test/runtime-workspace-interactions.vitest.ts
@@ -734,11 +734,11 @@ describe("runtime entry split (W6 IA)", () => {
     expect(onUpdate).toHaveBeenCalledWith(expect.objectContaining({ baseUrl: "" }));
   });
 
-  it("does not offer a base URL field on a subscription provider", async () => {
+  it("keeps the base URL field disabled on a subscription provider", async () => {
     const onUpdate = vi.fn();
     await mountProviderCard(onUpdate);
     await click("runtime-provider-edit");
-    expect(document.querySelector('[data-testid="runtime-provider-base-url"]')).toBeNull();
+    expect((byTestId("runtime-provider-base-url") as HTMLInputElement).disabled).toBe(true);
     await click("runtime-provider-cancel");
     expect(onUpdate).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
# English

## Summary

When a runtime provider does not support a capability, the GUI used to remove the control from the form entirely (`{planeAllowsX(kind) && <control/>}`). A user could not tell whether the provider lacks the capability or whether we simply never built it. Every control now renders in every case, disabled when the provider does not support it, with a sentence naming which provider lacks which capability.

The same pass gives every value in the provider plane table an evidence annotation, because until now those values were assertions with no traceable source — and at least one of them was measurably wrong.

## Architectural Justification

Churn is 348 lines, above the 200 threshold, so this section is required. The change is not new capability: it converts an existing semantic (hide) into a different one (disable and explain), and the churn comes from that semantic appearing **six times across two components** — API override, base URL, API key, effort, permission mode, isolation — in both `NewRuntimeDialog` and `RuntimeCard`, plus a shared control extraction into `parts.tsx` and the repository's pre-commit Prettier reflow.

**Why the scope cannot be narrowed:** greying out is a single semantic. Converting only some controls leaves a form where some unsupported capabilities are invisible and others are visibly disabled — self-contradicting, and worse for the user than either consistent choice.

**What obsolete code was removed:** the conditional-render wrappers that previously deleted controls from the tree. No file was added or deleted.

## What Changed

- `NewRuntimeDialog.tsx`, `RuntimeCard.tsx`, `parts.tsx`: unsupported capabilities render disabled instead of being removed. Six controls covered.
- New i18n string `agentRuntime.capabilityUnsupported`, wired at six sites, rendering "{provider} does not support {capability} in this call path." Both `en-US` and `zh-CN`.
- `runtime-provider-planes.ts`: every value now carries an evidence annotation in one of three classes:
  - **`E`/`C` from the capability matrix** — annotated with the matrix dimension (auth is dimension 13, permission/sandbox are 5-6, Codex effort is 12).
  - **`H` (unverified)** — agy's effort enum keeps its current values but is now explicitly marked: "flag registration is E; these values remain H (unverified)".
  - **Not covered by the matrix at all** — `modelFamily` and provider identifiers/defaults. Matrix dimension 11 measures whether the parser accepts a free model string; `modelFamily` expresses a backend catalog constraint. **Different layers — neither is evidence for the other**, and the annotation says so rather than borrowing dimension 11's number as a false source.
- The value-sanitising logic in `runtime-instance-form.ts` is kept: greying out is a presentation concern, sanitising is a submission concern, and both are still needed.

## Claude effort deliberately stays `none` — please do not read this as an omission

The capability matrix proves Claude 2.1.260 accepts effort, and `agent-runtime-launch-config.ts:81` already passes `--effort`. But the submission path is missing the field in **three** further places: the preload allowlist, the protocol contract's update payload, and the daemon instance store's update branch. Flipping the plane value to `enum` here would render an input the user can fill and cannot save — a fake feature, worse than honestly not showing it.

That four-layer chain is tracked as `task_ec4aa7c3fc0a66a574dba873ab`. The plane entry carries the reason inline so nobody has to rediscover it.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: use the single CI-backed `Production-Delta` declaration below; do not enter a second metric.

## Machine-Readable Declarations

Production-Delta: +222/-126

## Task And Scope

- Harness task: task_364b7a645ff980b9e56269f53b
- Branch: codex/gui-capability-greyout
- Public scope: GUI runtime capability presentation and the provider plane table
- Private planning/evidence updated: yes
- Out of scope: the Claude effort submission chain (task_ec4aa7c3fc0a66a574dba873ab), and the runtime kind declaration refactor (task_f53452ed8a83945b6f8b5f2b52)

## Version Impact

- Version: no version change because this is GUI presentation with no package surface change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: not applicable
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no

## Verification

- Base `origin/main` SHA: 6b24c642f (branch is up to date with it)
- Branch merge-base with `origin/main`: 6b24c642f
- Last `git fetch origin` time: 2026-09-04, immediately before this PR
- Sync method: none needed
- Public diff command: `git diff origin/main...codex/gui-capability-greyout`
- Private evidence commit/path: `harness/tasks/task_364b7a645ff980b9e56269f53b-gui-capability-greyout/`
- Reviewer evidence path: `artifacts/reports/` (three worker reports, each a checkpoint escalation) and `task_plan.md` (three CEO rulings recorded inline)
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- Not run: the full local matrix — that is GitHub CI's job. Targeted runs instead:
  - `npm run test:gui -w @harness-anything/gui` → **84 files passed, 831 tests passed**
  - `node tools/gates/line-density.mjs --base origin/main` → pass
  - `node -v` → v24.18.0 (repository requires >= 24)

## Review Evidence

- Self-review: CEO verified each of the three rulings against the implementation — that controls are `disabled` rather than removed, that the reason string is wired at all six sites (not merely added to the locale files), and that the Claude effort annotation matches the ruling text verbatim.
- Reviewer subagent: none
- Human review: pending
- Blocking findings: none outstanding

## Residual Risk

- **No GUI acceptance has been performed.** Nobody has opened the runtime form and confirmed the disabled controls look disabled and the reason text is legible at the rendered size.
- The reason string interpolates provider and capability names; long capability names in `zh-CN` have not been checked against the control width.
- `modelFamily` remains an unverified product assertion. It is now labelled as such, but it is still the value that decides whether a user may type an arbitrary model id — labelling it did not make it true.

## References

- Task: task_364b7a645ff980b9e56269f53b
- Evidence: `harness/tasks/task_5ceb49d958f779999529d8e763-provider-capability-probe/artifacts/capability-matrix.md`
- Review: `harness/tasks/task_364b7a645ff980b9e56269f53b-gui-capability-greyout/task_plan.md`

---

# 中文

## 摘要

当某个 runtime provider 不支持某项能力时，GUI 过去是把控件整个从表单里移除（`{planeAllowsX(kind) && <control/>}`）。用户分不清是这个 provider 缺这项能力，还是我们压根没做。现在所有控件在任何情况下都渲染，不支持时置灰，并给出一句话说明是哪个 provider 缺哪项能力。

同一轮里给 provider plane 表的每个取值加上了证据标注——在此之前那些取值都是没有可追溯来源的断言，而且其中至少有一个已被实测证伪。

## 架构辩护

churn 为 348 行，超过 200 阈值，故本节必填。本次改动不是新增能力，而是把既有语义（隐藏）转换成另一种（置灰并说明）；churn 来自该语义**在两个组件里出现了六次**——API 覆盖、base URL、API key、effort、权限模式、隔离——涉及 `NewRuntimeDialog` 与 `RuntimeCard`，外加共享控件抽取到 `parts.tsx`，以及仓库 pre-commit 的 Prettier 重排。

**为什么范围不能更窄**：置灰是一个整体语义。只转换一部分控件，会得到一个「有些不支持的能力不可见、有些可见但置灰」的表单——自相矛盾，比任何一种一致的选择都更糟。

**删除了什么过时代码**：此前把控件从树里删掉的那些条件渲染外壳。无新增或删除文件。

## 改动内容

- `NewRuntimeDialog.tsx`、`RuntimeCard.tsx`、`parts.tsx`：不支持的能力改为渲染并置灰，覆盖六个控件。
- 新增 i18n 文案 `agentRuntime.capabilityUnsupported`，在六处接线，渲染为「{provider} 的当前调用方式不支持{capability}。」，`en-US` 与 `zh-CN` 同步。
- `runtime-provider-planes.ts`：每个取值带上证据标注，分三类：
  - **矩阵里的 `E`/`C` 级**——标出对应维度（auth 是维度 13，权限/沙箱是 5-6，Codex effort 是 12）。
  - **`H` 级（未实测）**——agy 的 effort 枚举保持现值，但明确标注「flag 注册是 E 级，取值仍是 H 级 unverified」。
  - **矩阵根本没覆盖的**——`modelFamily` 与 provider 标识/默认值。矩阵维度 11 测的是 parser 是否接受自由模型字符串，而 `modelFamily` 表达的是后端目录约束。**两者不是同一层，谁也不是谁的证据**；注释如实这么写，而不是借用维度 11 的编号伪造一个来源。
- `runtime-instance-form.ts` 的值清洗保留：置灰是呈现层的事，清洗是提交层的事，两者都还需要。

## Claude effort 刻意保持 `none`——请不要读成遗漏

能力矩阵证明 Claude 2.1.260 接受 effort，`agent-runtime-launch-config.ts:81` 也确实在传 `--effort`。但提交链路还在**另外三处**缺这个字段：preload allowlist、protocol 契约的 update payload、daemon 实例 store 的 update 分支。此处若把 plane 值改成 `enum`，就会渲染出一个用户填得进去、却存不下来的输入框——那是假功能，比诚实地不显示更糟。

这条四层链路由 `task_ec4aa7c3fc0a66a574dba873ab` 跟踪。plane 条目里内联写了原因，免得日后有人重新发现一遍。

## 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none

## 任务与范围

- Harness task：task_364b7a645ff980b9e56269f53b
- 分支：codex/gui-capability-greyout
- 公开范围：GUI 运行时能力呈现与 provider plane 表
- 私有规划/证据已更新：是
- 不在范围内：Claude effort 提交链路（task_ec4aa7c3fc0a66a574dba873ab）、runtime kind 声明化重构（task_f53452ed8a83945b6f8b5f2b52）

## 版本影响

- 版本：不变，这是 GUI 呈现层改动，不改包面
- 发布影响：不发布

## 治理声明

- 是否触碰 protected surface：否
- 范围：不适用
- 授权：不适用
- 机器检查边界：本 PR 只声明该字段存在；其是否为真、是否充分由评审判断。
- Break-glass：否

## 验证

- Base `origin/main` SHA：6b24c642f（分支与其一致）
- 与 `origin/main` 的 merge-base：6b24c642f
- 最近 `git fetch origin` 时间：2026-09-04，开 PR 前刚执行
- 同步方式：无需同步
- 公开 diff 命令：`git diff origin/main...codex/gui-capability-greyout`
- 私有证据路径：`harness/tasks/task_364b7a645ff980b9e56269f53b-gui-capability-greyout/`
- 评审证据路径：`artifacts/reports/`（三份 worker 报告，每份都是一次 checkpoint 上报）与 `task_plan.md`（三次 CEO 裁决内联记录）
- GitHub Actions `rewrite-ci` run URL：本 PR 开出后产生
- 未运行：本机完整门矩阵——那是 GitHub CI 的活。改为定向执行：
  - `npm run test:gui -w @harness-anything/gui` → **84 个文件通过，831 个测试通过**
  - `node tools/gates/line-density.mjs --base origin/main` → pass
  - `node -v` → v24.18.0（仓库要求 >= 24）

## 评审证据

- 自审：CEO 逐条对照三次裁决核对实现——控件是 `disabled` 而非被移除；原因文案在**全部六处**接线（不只是加进 locale 文件）；Claude effort 的注释与裁决原文逐字一致。
- 评审子代理：无
- 人工评审：待进行
- 阻塞性发现：无未决项

## 残留风险

- **尚未进行 GUI 验收。** 还没有人打开 runtime 表单确认置灰控件看起来确实是禁用态、原因文案在实际字号下可读。
- 原因文案会插值 provider 与能力名称；`zh-CN` 下较长的能力名未与控件宽度核对过。
- `modelFamily` 仍是未经实测的产品断言。现在它被如实标注了，但它依然是决定「用户能否输入任意 model id」的那个值——**标注它并没有让它变成真的**。

## 参考

- 任务：task_364b7a645ff980b9e56269f53b
- 证据：`harness/tasks/task_5ceb49d958f779999529d8e763-provider-capability-probe/artifacts/capability-matrix.md`
- 评审：`harness/tasks/task_364b7a645ff980b9e56269f53b-gui-capability-greyout/task_plan.md`
