### PR TITLE
test(cli): order the notification hold with an explicit release handshake instead of a wall clock

### DIFF
--- a/packages/cli/test/runtime-cli.integration.test.ts
+++ b/packages/cli/test/runtime-cli.integration.test.ts
@@ -32,6 +32,7 @@ test("real CLI runs, archives task-bound dispatches, resumes, waits through stat
     tracker = path.join(root, ".batch-tracker"),
     nonzeroTrace = path.join(root, ".notify-nonzero.json"),
     notificationStarted = path.join(root, ".notify-hold-started"),
+    notificationRelease = path.join(root, ".notify-hold-release"),
     notificationFinished = path.join(root, ".notify-hold-finished"),
     notificationOnce = path.join(root, ".notify-once"),
     version = "0.0.0-runtime-cli-fixture",
@@ -50,7 +51,10 @@ test("real CLI runs, archives task-bound dispatches, resumes, waits through stat
     ),
     holdNotifier = writeProviderExecutable(
       path.join(parent, "notify-hold"),
-      `const fs = require("node:fs"); fs.readFileSync(0, "utf8"); fs.writeFileSync(".notify-hold-started", "started\\n"); setTimeout(() => { fs.writeFileSync(".notify-hold-finished", "finished\\n"); }, 4000);\n`,
+      'const fs = require("node:fs"); fs.readFileSync(0, "utf8"); ' +
+        'const watcher = fs.watch(".", (_, filename) => { if (filename !== ".notify-hold-release") return; ' +
+        'watcher.close(); fs.writeFileSync(".notify-hold-finished", "finished\\n"); }); ' +
+        'fs.writeFileSync(".notify-hold-started", "started\\n");\n',
     ),
     onceNotifier = writeProviderExecutable(
       path.join(parent, "notify-once"),
@@ -832,7 +836,6 @@ test("real CLI runs, archives task-bound dispatches, resumes, waits through stat
     await eventuallyFile(notificationStarted);
     run(root, env, ["task", "start", taskId, "--execution-id", executionId]);
     const revisionBefore = makeTaskEventReader({ repoId: "runtime-cli", rootDir: root }).readHead()?.revision ?? 0,
-      writeStartedAt = performance.now(),
       queueWrite = run(root, env, [
         "task",
         "progress",
@@ -843,20 +846,20 @@ test("real CLI runs, archives task-bound dispatches, resumes, waits through stat
         "--evidence",
         "test:reports/notification-queue.txt:write progressed while callback was active",
       ]),
-      writeLatencyMs = performance.now() - writeStartedAt,
       revisionAfter = makeTaskEventReader({ repoId: "runtime-cli", rootDir: root }).readHead()?.revision ?? 0;
     assert.ok(revisionAfter > revisionBefore, `${revisionBefore} -> ${revisionAfter}`);
-    assert.ok(writeLatencyMs < 3000, `repo write waited ${writeLatencyMs.toFixed(3)}ms behind a 4000ms notifier`);
     assert.equal(
       existsSync(notificationFinished),
       false,
       "the notification must still be executing when the repo write commits",
     );
+    writeFileSync(notificationRelease, "release\n");
     const queueNotificationTrace = await eventuallyNotification(root, String(queueNotification.dispatchId));
+    assert.equal(queueNotificationTrace.started?.phase, "started");
     assert.equal(queueNotificationTrace.finished?.timedOut, false);
     assert.equal(existsSync(notificationFinished), true);
     context.diagnostic(
-      `notification queue concurrency: ${JSON.stringify({ revisionBefore, revisionAfter, writeReceiptRevision: queueWrite.revision, writeLatencyMs: Number(writeLatencyMs.toFixed(3)), notifierStillRunningAtCommit: true })}`,
+      `notification queue concurrency: ${JSON.stringify({ revisionBefore, revisionAfter, writeReceiptRevision: queueWrite.revision, notifierStillRunningAtCommit: true })}`,
     );
     const submittedTaskId = `${taskId}-submitted`,
       submittedExecutionId = `${executionId}-submitted`,


### PR DESCRIPTION
# English

## Summary

The `runtime-cli.integration` case "real CLI runs, archives task-bound dispatches, resumes, waits through status, streams, and cancels idempotently" went red again on CI today with `the notification must still be executing when the repo write commits` (actual true, expected false). The first fix (PR #2093) removed two of three failure sources and named the third in its closeout: the hold notifier ran a 4000 ms countdown from launch and the test inferred "still executing" from a sub-3000 ms write latency. On a cold shared runner that window is gone. This change replaces the countdown with an explicit ready/release handshake: the notifier publishes a started file, waits on a release file, and the test writes the release only after the repo write has committed and the notification is asserted unfinished. The ordering is now guaranteed by the protocol, not by milliseconds.

## Architectural Justification

Test-only change, production delta zero. It deletes a wall-clock assumption instead of widening it, in line with the testing standard's platform-assumption rule and the standing wall-clock inventory task.

## What Changed

- `packages/cli/test/runtime-cli.integration.test.ts`: ready/release handshake for the hold notifier; removed the 4000 ms auto-finish, the write-latency timer and the `< 3000 ms` assertion; asserts the started phase explicitly.

## Gate Harvest / 门收割

No gate change. / 门未改。

## Machine-Readable Declarations

Production-Delta: +0/-0
Dependency-Change: none

### Optional Evidence Claims

none

## Task And Scope

task_d912cfd11a7ef746aaebf74bfe (parent task_f9443002, relates task_0f9c6bbd). Branch `codex/runtime-cli-flake`.

## Version Impact

No version change; publish impact none.

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none
- Authority: task_d912cfd11a7ef746aaebf74bfe
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Follow-up governance task: not applicable

## Verification

- Negative control: releasing the notifier before the repo write turns the target assertion red (actual true / expected false).
- Five consecutive local runs of the file green (90 to 95 s each); lint, line-density, file-complexity, production-delta pass. Fact F-CE21DF2D.
- CI is the complete authority.

## Review Evidence

CEO read the diff: the only ordering primitive left is the release file written by the test after the commit; no sleeps, no widened timeouts, no retries around assertions.

## Residual Risk

`fs.watch` on the notifier's cwd is the wake-up mechanism; if a platform drops the event the case would hang until the test timeout rather than pass falsely.

# 中文

## 概要

`runtime-cli.integration` 的「real CLI runs…」用例今天在 CI 再次红:`the notification must still be executing when the repo write commits`。首修(PR #2093)已消掉两种来源,并在 closeout 里点名第三种:hold notifier 启动即 4000ms 倒计时,测试拿「repo write 低于 3000ms」推断通知仍在执行,冷启动的共享 runner 上窗口耗尽。本改动改为显式 ready/release 握手:notifier 发布 started 文件后等待 release 文件,测试在 repo write 提交并断言通知未完成之后才写 release。顺序由协议保证,不再由毫秒推断。

## 架构辩护

纯测试改动,生产 +0/-0;删掉墙钟假设而不是放宽它,符合测试标准的平台假设条款与常设墙钟盘点任务。

## 机读声明

生产行数增减(与上文机读声明一致):+0/-0

## 治理声明

- 触碰受保护面:否
- 授权:task_d912cfd11a7ef746aaebf74bfe
- Break-glass:否

## 验证

阴性对照:提前 release 时目标断言红;修复后本文件连续 5 次绿;lint/line-density/file-complexity/production-delta 通过;Fact F-CE21DF2D。CI 为完整权威。

## 评审证据

CEO 读 diff:唯一剩下的排序原语是测试在提交后写的 release 文件;无 sleep、无放宽超时、无断言重试。

## 残余风险

以 `fs.watch` 作为唤醒;若平台丢事件,用例会挂到超时而不是假绿。
