### PR TITLE
fix(kernel,daemon): let a decision reach in_effect when its fulfillments were declared at proposal

### DIFF
--- a/packages/daemon/src/entity-action-catalog-executor.ts
+++ b/packages/daemon/src/entity-action-catalog-executor.ts
@@ -263,6 +263,7 @@ export function makeEntityActionCatalogExecutor(input: {
     if (dryRun) {
       if (bundle.event.schema !== "decision-event/v1")
         reject("invalid_command", `${contract.execution.ingress} does not support --dry-run.`);
+      input.projection.admitDecision(bundle.event);
       return { ...decisionPreview(bundle.event, input.store.readHead()?.revision ?? 0), authorizationDecision };
     }
     if (isFactBundle(bundle)) {

--- a/packages/daemon/test/decision-surface.test.ts
+++ b/packages/daemon/test/decision-surface.test.ts
@@ -317,6 +317,100 @@ test("decision accept rejects a heading-only proposal body", async () => {
   }
 });
 
+test("decision transition accepts repeated matching proposal fulfillments and dry-run uses admission", async () => {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-decision-fulfillments-"));
+  initRepo(rootDir);
+  const cell = await openRepoCell({
+    repoId: workspaceId("decision-fulfillments"),
+    rootDir: canonicalRoot(rootDir),
+    ownerId: "decision-fulfillments-test",
+    now: monotonicClock(),
+  });
+  try {
+    const proposed = await cell.run(
+        {
+          kind: "decision-propose",
+          jsonInput: JSON.stringify({
+            title: "Pre-fulfilled claims",
+            question: "Can acceptance repeat the proposal fulfillment declarations?",
+            riskTier: "high",
+            urgency: "high",
+            vertical: "software/coding",
+            preset: "architecture-decision",
+            decisionClass: "ordinary",
+            appliesTo: { modules: ["daemon"], productLines: [] },
+            chosen: [{ id: "CH1", text: "Treat matching declarations as idempotent" }],
+            rejected: [{ id: "RJ1", text: "Reject every repeat", whyNot: "It rejects the canonical CLI flow" }],
+            claims: [
+              { id: "C1", text: "The first claim is evidenced.", loadBearing: true },
+              { id: "C2", text: "The second claim is evidenced.", loadBearing: true },
+            ],
+            fulfillments: [
+              { claimId: "C1", mode: "evidenced" },
+              { claimId: "C2", mode: "evidenced" },
+            ],
+          }),
+          body: "# Pre-fulfilled claims\n\nThe complete proposal body.\n",
+        },
+        proposer,
+      ),
+      decisionId = String(receiptJson(proposed).decisionId),
+      before = makeTaskEventReader({ repoId: "decision-fulfillments", rootDir }).read().revision,
+      transition = {
+        kind: "decision-transition",
+        targetState: "in_effect",
+        decisionId,
+        judgmentOnlyRationale: "The arbiter verified both claims and accepts the recorded evidence.",
+        standingPolicy: false,
+        fulfillments: [
+          { claimId: "C1", mode: "evidenced" },
+          { claimId: "C2", mode: "evidenced" },
+        ],
+      } as const,
+      conflictingPreview = await cell.run(
+        {
+          ...transition,
+          fulfillments: [
+            { claimId: "C1", mode: "delivered" },
+            { claimId: "C2", mode: "evidenced" },
+          ],
+          dryRun: true,
+        },
+        arbiter,
+      ),
+      preview = await cell.run({ ...transition, dryRun: true }, arbiter);
+    assert.equal(conflictingPreview.outcome, "op_rejected", JSON.stringify(conflictingPreview));
+    assert.equal(conflictingPreview.code, "invalid_transition");
+    assert.equal(preview.outcome, "pending", JSON.stringify(preview));
+    assert.equal(makeTaskEventReader({ repoId: "decision-fulfillments", rootDir }).read().revision, before);
+    const accepted = await cell.run(transition, arbiter);
+    assert.equal(accepted.outcome, "applied", JSON.stringify(accepted));
+
+    const unevidenced = await cell.run(
+        { ...proposal("Unevidenced preview"), body: "# Unevidenced preview\n\nComplete prose without evidence.\n" },
+        proposer,
+      ),
+      unevidencedId = String(receiptJson(unevidenced).decisionId),
+      rejectedPreview = await cell.run(
+        {
+          kind: "decision-transition",
+          targetState: "in_effect",
+          decisionId: unevidencedId,
+          judgmentOnlyRationale: null,
+          standingPolicy: false,
+          fulfillments: [],
+          dryRun: true,
+        },
+        arbiter,
+      );
+    assert.equal(rejectedPreview.outcome, "op_rejected", JSON.stringify(rejectedPreview));
+    assert.equal(rejectedPreview.code, "invalid_transition");
+  } finally {
+    await cell.close();
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});
+
 function proposal(title: string) {
   return {
     kind: "decision-propose",

--- a/packages/kernel/src/projection/decision-projection-admission.ts
+++ b/packages/kernel/src/projection/decision-projection-admission.ts
@@ -44,7 +44,12 @@ export function assertDecisionAdmission(db: DatabaseSync, event: DecisionEventV1
       for (const fulfillment of event.payload.fulfillments ?? []) {
         const claim = current.claims.find((entry) => entry.id === fulfillment.claimId);
         if (!claim) fail("anchor_not_found", `Claim ${fulfillment.claimId} does not exist.`);
-        if (claim.fulfillment) fail("invalid_transition", `Claim ${fulfillment.claimId} already has a fulfillment.`);
+        if (claim.fulfillment && claim.fulfillment !== fulfillment.mode)
+          fail(
+            "invalid_transition",
+            `Claim ${fulfillment.claimId} already has fulfillment ${claim.fulfillment}; ` +
+              `cannot change it to ${fulfillment.mode}.`,
+          );
       }
       if (
         event.payload.standingPolicy &&


### PR DESCRIPTION
# English

## Summary

A Decision that declared its claim fulfillments at proposal time could never reach `in_effect`. `ha decision transition in_effect --fulfillment C1:evidenced` was rejected with `invalid_transition` because the admission check treated *any* existing fulfillment as a conflict, including one identical to what was being submitted. Re-declaring the same fulfillment is now idempotent; declaring a *different* mode is still refused, and the refusal now names both modes.

The same commit makes `--dry-run` run the same read-only admission before building its preview, so the preview stops disagreeing with the write it is previewing.

## Architectural Justification

Not required: churn is 8 lines, well under the 200-line threshold.

## What Changed

- `packages/kernel/src/projection/decision-projection-admission.ts`: the conflict test narrows from "a fulfillment exists" to "a fulfillment exists **with a different mode**", and the rejection text becomes `Claim C1 already has fulfillment evidenced; cannot change it to delivered` instead of a bare category name.
- `packages/daemon/src/entity-action-catalog-executor.ts`: one line — dry-run calls `admitDecision` before producing the preview.
- `packages/daemon/test/decision-surface.test.ts`: a fixture shaped like the real failing Decision (two claims, both fulfilled at proposal), plus dry-run coverage in both directions and an assertion that the preview writes nothing.

**This is a narrowing, not a new mechanism.** The evidence floor is untouched; a Decision still cannot reach `in_effect` without a claim-to-evidence relation.

## Three CEO assumptions this work disproved

The task package was written from a CEO reproduction, and the worker's investigation showed two of its three premises were wrong. Recording them because the task text will outlive this PR:

1. **"`ha relation relate` writes to a place the evidence floor cannot read."** False. `readDecisionGraph()` does inject the global relation edges; both edges on the real Decision were active and visible. The root AGENTS.md instructions are correct as written.
2. **"`decision show` reporting `body=null` means `--body-file` was silently dropped."** False. `decision show` hides the body by default; `--include-body` returns the full 4,340-byte document.
3. **"`--dry-run` lies."** True, and fixed here — but the cause was that the preview never ran admission, not that admission was inconsistent.

Separately, `--from-file` rejecting a relative path is not a path-form restriction: the daemon resolves it against the **registered repository root**, not the shell's working directory. From inside `harness/`, `harness/scratch/…` works.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none

## Machine-Readable Declarations

Production-Delta: +7/-1

## Task And Scope

- Harness task: task_0d18e8ca0cb0bcd9c7764e1ad1
- Branch: codex/decision-effect-chain
- Out of scope: the receipt-settlement diagnostic loss that strips `Error.message` from coded rejections — that is PR #2232's surface, and it is what made this defect cost a source-code read instead of five seconds.

## Version Impact

- Version: no change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true.
- Break-glass: no

## Verification

- Base `origin/main`: 57104a58684d22fa5053aaf89ce214b1331f1f74
- Isolated Ubuntu run, **before** the fix: the real-shaped transition returns `invalid_transition` (run `harness-test-isolation-46491-…`).
- Isolated Ubuntu run, **after** the fix: 3 passed, 0 failed (run `harness-test-isolation-56375-…`).
- `node tools/gates/line-density.mjs --base origin/main` → pass
- `production-delta` → computed `+7/-1`, matching the declaration above. The worker's first attempt declared `+0/-0` and the gate correctly refused it.
- Not run: `check:local` or the full matrix — other workers share this machine.

## Review Evidence

- CEO semantic acceptance: verified that the change narrows an existing check rather than adding a mechanism, that the evidence floor is untouched, and that the new rejection text names both the existing and the requested mode.
- Human review: pending.

## Residual Risk

- The fixture reproduces the real Decision's *shape*; the actual `dec_5E1C0DFBACC617FFD9CABF546F` has not been pushed to `in_effect` yet, because that requires this fix to be merged and the daemon restarted. **That is the acceptance step, and it has not happened.**
- Idempotent re-declaration means a caller can submit the same fulfillment repeatedly without feedback that it was already recorded. That is the intended trade — silence on a no-op beats refusing a correct request — but it is a deliberate choice, not an oversight.

---

# 中文

## 摘要

一条在 propose 阶段就声明了 claim fulfillment 的 Decision，永远无法走到 `in_effect`。`ha decision transition in_effect --fulfillment C1:evidenced` 被 `invalid_transition` 拒绝，因为准入检查把**任何**已存在的 fulfillment 都当成冲突，包括与本次提交完全相同的那个。现在重复声明同一个 fulfillment 是幂等的；声明**不同的** mode 仍然拒绝，且拒绝信息会同时说出两个 mode。

同一个提交让 `--dry-run` 在生成预览前跑同一套只读准入，预览不再与它所预览的写入相矛盾。

## 架构辩护

不适用：churn 为 8 行，远低于 200 行阈值。

## 改动内容

- `packages/kernel/src/projection/decision-projection-admission.ts`：冲突判定从「存在 fulfillment」收窄为「存在 fulfillment **且 mode 不同**」，拒绝文案从光秃秃的类别名变成 `Claim C1 already has fulfillment evidenced; cannot change it to delivered`。
- `packages/daemon/src/entity-action-catalog-executor.ts`：一行——dry-run 在产出预览前调用 `admitDecision`。
- `packages/daemon/test/decision-surface.test.ts`：一个与真实失败 Decision 同形的夹具（两条 claim、propose 时均已 fulfilled），加上 dry-run 正反两路覆盖，以及「预览不落盘」的断言。

**这是一次收窄，不是新增机制。** 证据门未被触碰：没有 claim→证据关系的 Decision 仍然到不了 `in_effect`。

## 本次工作证伪的三条 CEO 假设

任务包是照 CEO 的复现写的，worker 的调查显示其中两条前提是错的。记录在此，因为任务文本会比这个 PR 活得久：

1. **「`ha relation relate` 写到了 evidence floor 读不到的地方。」** 错。`readDecisionGraph()` 确实注入了全局关系边，真实 Decision 上那两条边都是 active 且可见的。根 AGENTS.md 的写法是对的。
2. **「`decision show` 显示 `body=null` 说明 `--body-file` 被静默丢弃。」** 错。`decision show` 默认隐藏正文，`--include-body` 能返回完整的 4,340 字节文档。
3. **「`--dry-run` 撒谎。」** 对，且已在此修复——但成因是预览从不跑准入，而不是准入本身不一致。

另外，`--from-file` 拒绝相对路径并不是「必须绝对路径」：daemon 是按**注册仓库根**解析它，不按 shell 的当前目录。在 `harness/` 里应该写 `harness/scratch/…`。

## 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none

## 任务与范围

- Harness task：task_0d18e8ca0cb0bcd9c7764e1ad1
- 分支：codex/decision-effect-chain
- 不在范围内：receipt settlement 把 coded rejection 的 `Error.message` 剥掉那条诊断丢失——那是 PR #2232 的面，也正是它让这个缺陷的定位成本从五秒变成一次源码阅读。

## 版本影响

- 版本：不变
- 发布影响：不发布

## 治理声明

- 是否触碰 protected surface：否
- 机器检查边界：本 PR 只声明该字段存在；是否为真由评审判断。
- Break-glass：否

## 验证

- Base `origin/main`：57104a58684d22fa5053aaf89ce214b1331f1f74
- Ubuntu 隔离环境，**修复前**：真实形状的 transition 返回 `invalid_transition`（run `harness-test-isolation-46491-…`）。
- Ubuntu 隔离环境，**修复后**：3 通过、0 失败（run `harness-test-isolation-56375-…`）。
- `node tools/gates/line-density.mjs --base origin/main` → pass
- `production-delta` → 实测 `+7/-1`，与上面的声明一致。worker 首次声明 `+0/-0` 时门正确地拒绝了它。
- 未运行：`check:local` 与全量矩阵——本机还有其他 worker。

## 评审证据

- CEO 语义验收：确认本次改动是收窄既有检查而非新增机制、证据门未被触碰、新的拒绝文案同时说出已有 mode 与请求的 mode。
- 人工评审：待进行。

## 残留风险

- 夹具复现的是真实 Decision 的**形状**；真实的 `dec_5E1C0DFBACC617FFD9CABF546F` **尚未**被推到 `in_effect`，因为那需要本修复合并且 daemon 重启。**这是验收步骤，它还没发生。**
- 幂等重复声明意味着调用者可以反复提交同一个 fulfillment 而得不到「它已经记录过了」的反馈。这是有意的取舍——对无操作保持沉默好过拒绝一个正确的请求——但它是一个选择，不是疏漏。
