### PR TITLE
fix(cli): reconnect runtime waits across daemon restarts instead of failing on the first probe

### DIFF
--- a/packages/cli/src/cli-runtime-wait.ts
+++ b/packages/cli/src/cli-runtime-wait.ts
@@ -5,7 +5,6 @@ import type { ThinCommand } from "./cli/thin-command.ts";
 import {
   consumeKnownError,
   openRuntimeStatusReader,
-  resolveLocalDaemonTarget,
   runCommandThroughDaemon,
   streamRuntimeThroughDaemon,
 } from "./daemon/client.ts";
@@ -24,6 +23,7 @@ type RuntimeStreamWait = {
 
 const fallbackPollBaseMs = 500,
   fallbackPollMaxMs = 2_000,
+  subscriptionReconnectAttemptLimit = 5,
   settlementWaitMs = 5_000;
 
 export async function waitForRuntime(
@@ -39,7 +39,6 @@ export async function waitForRuntime(
   try {
     const readStatus = () =>
         readDaemonSubscription(
-          command,
           async () => {
             statusReader ??= await openRuntimeStatusReader(command, runtimeSessionId, target);
             return statusReader.read();
@@ -193,7 +192,7 @@ export async function waitForTaskDispatches(command: ThinCommand, taskId: string
   };
   let current: JsonObject | undefined;
   for (;;) {
-    const next = await readDaemonSubscription(command, () =>
+    const next = await readDaemonSubscription(() =>
       runCommandThroughDaemon(readCommand, () => undefined, { autostart: false }),
     );
     if (isDaemonGone(next)) {
@@ -250,7 +249,6 @@ export async function waitForTaskDispatches(command: ThinCommand, taskId: string
 }
 
 async function readDaemonSubscription(
-  command: ThinCommand,
   read: () => Promise<JsonObject>,
   reset: () => void = () => undefined,
 ): Promise<JsonObject | DaemonGone> {
@@ -262,7 +260,11 @@ async function readDaemonSubscription(
       consumeKnownError(error);
       reset();
       if (!recoverableSubscriptionFailure(error)) throw error;
-      if (await daemonGone(command)) return { kind: "daemon-gone", cause: cliErrorMessage(error) };
+      if (attempt >= subscriptionReconnectAttemptLimit)
+        return {
+          kind: "daemon-gone",
+          cause: `reconnect budget exhausted after ${String(attempt)} attempts: ${cliErrorMessage(error)}`,
+        };
       await new Promise((resolve) => setTimeout(resolve, Math.min(250 * 2 ** attempt++, 5_000)));
     }
   }
@@ -279,15 +281,6 @@ function recoverableSubscriptionFailure(error: unknown): boolean {
     message === "daemon_unavailable" ||
     message === "daemon_stream_unavailable"
   );
-}
-
-async function daemonGone(command: ThinCommand): Promise<boolean> {
-  const target = await resolveLocalDaemonTarget({ rootDir: command.rootDir, repoIdOverride: command.repoId }),
-    { daemonProcessAlive, daemonSocketProbe, readDaemonPid } = await import("../../daemon/src/daemon-singleton.ts"),
-    pid = readDaemonPid(target.userRoot, target.daemonId),
-    livePid = pid !== null && daemonProcessAlive(pid),
-    liveSocket = await daemonSocketProbe(target.socketPath);
-  return !livePid && !liveSocket;
 }
 
 function isDaemonGone(value: JsonObject | DaemonGone): value is DaemonGone {
@@ -326,7 +319,8 @@ function daemonGoneReceipt(
   summaryCommand = command,
 ): JsonObject {
   const hint =
-    `The daemon process and socket are gone. Last known dispatch status: ${lastKnownStatus}. ` +
+    `The daemon connection could not be restored within its reconnect budget. ` +
+    `Last known dispatch status: ${lastKnownStatus}. ` +
     "Restart the daemon, then inspect the recorded status before deciding whether to run again.";
   return {
     schema: "command-receipt/v2",

--- a/packages/cli/test/runtime-wait-reconnect.integration.test.ts
+++ b/packages/cli/test/runtime-wait-reconnect.integration.test.ts
@@ -239,6 +239,38 @@ test("runtime status --wait reconnects after a protocol.hello deadline and retur
   }
 });
 
+test("runtime status --wait reconnects after the daemon disappears and returns the adopted terminal dispatch", async () => {
+  const fixture = await openFixtureDaemon("daemon-restart");
+  let statusReads = 0,
+    restarted = false;
+  fixture.onRequest = (socket, request) => {
+    if (request.method === "protocol.hello") {
+      reply(socket, request.id, { ok: true });
+      return;
+    }
+    assert.equal(request.method, "repo.agentRuntime.sessions.read");
+    statusReads += 1;
+    if (!restarted) {
+      reply(socket, request.id, runtimeStatus(false));
+      restarted = true;
+      void fixture.restart();
+      return;
+    }
+    reply(socket, request.id, runtimeStatus(true));
+  };
+  const invocation = runWait(fixture);
+  try {
+    const result = await invocation.result(12_000);
+    assert.equal(result.code, 0, result.stderr);
+    assert.equal(result.receipt.outcome, "succeeded");
+    assert.equal((result.receipt.result as Record<string, unknown>).text, "settled after reconnect");
+    assert.equal(statusReads, 2, "the new daemon must provide the terminal status after adoption");
+  } finally {
+    invocation.stop();
+    await fixture.close();
+  }
+});
+
 test("runtime status --wait returns daemon_gone with the last-known dispatch after pid and socket loss", async () => {
   const fixture = await openFixtureDaemon("daemon-gone");
   let statusReads = 0;
@@ -397,6 +429,7 @@ interface FixtureDaemon {
   readonly daemonId: string;
   onRequest: (socket: net.Socket, request: RpcRequest) => void;
   readonly die: () => void;
+  readonly restart: () => Promise<void>;
   readonly close: () => Promise<void>;
 }
 
@@ -433,8 +466,32 @@ async function openFixtureDaemon(daemonId: string): Promise<FixtureDaemon> {
       ],
     }),
   );
-  writeFileSync(daemonPidPath(userRoot, daemonId), `${process.pid}\n`);
-  const fixture = {
+  let server: net.Server;
+  const start = async (): Promise<void> => {
+      rmSync(socketPath, { force: true });
+      server = net.createServer((socket) => {
+        sockets.add(socket);
+        socket.once("close", () => sockets.delete(socket));
+        socket.on("error", () => undefined);
+        let buffered = "";
+        socket.on("data", (chunk) => {
+          buffered += String(chunk);
+          for (;;) {
+            const newline = buffered.indexOf("\n");
+            if (newline < 0) break;
+            const line = buffered.slice(0, newline);
+            buffered = buffered.slice(newline + 1);
+            fixture.onRequest(socket, JSON.parse(line) as RpcRequest);
+          }
+        });
+      });
+      await new Promise<void>((resolve, reject) => {
+        server.once("error", reject);
+        server.listen(socketPath, () => resolve());
+      });
+      writeFileSync(daemonPidPath(userRoot, daemonId), `${process.pid}\n`);
+    },
+    fixture = {
       root,
       userRoot,
       daemonId,
@@ -445,6 +502,16 @@ async function openFixtureDaemon(daemonId: string): Promise<FixtureDaemon> {
         for (const socket of sockets) socket.destroy();
         rmSync(socketPath, { force: true });
       },
+      restart: async () => {
+        await new Promise<void>((resolve) => {
+          if (!server.listening) resolve();
+          else {
+            server.once("close", resolve);
+            fixture.die();
+          }
+        });
+        await start();
+      },
       close: async () => {
         fixture.die();
         await new Promise<void>((resolve) => {
@@ -453,28 +520,8 @@ async function openFixtureDaemon(daemonId: string): Promise<FixtureDaemon> {
         });
         rmSync(parent, { recursive: true, force: true });
       },
-    } satisfies FixtureDaemon,
-    server = net.createServer((socket) => {
-      sockets.add(socket);
-      socket.once("close", () => sockets.delete(socket));
-      socket.on("error", () => undefined);
-      let buffered = "";
-      socket.on("data", (chunk) => {
-        buffered += String(chunk);
-        for (;;) {
-          const newline = buffered.indexOf("\n");
-          if (newline < 0) break;
-          const line = buffered.slice(0, newline);
-          buffered = buffered.slice(newline + 1);
-          fixture.onRequest(socket, JSON.parse(line) as RpcRequest);
-        }
-      });
-    });
-  rmSync(socketPath, { force: true });
-  await new Promise<void>((resolve, reject) => {
-    server.once("error", reject);
-    server.listen(socketPath, () => resolve());
-  });
+    } satisfies FixtureDaemon;
+  await start();
   return fixture;
 }
 


### PR DESCRIPTION
# English

## Summary

`ha runtime status <session> --wait` (and the task-dispatch wait that shares its subscription loop) could exit 0 after a daemon disconnect without ever seeing a terminal outcome: on the first recoverable connection error the CLI probed the daemon PID and socket, and the transient window of a build-drift restart, where both are momentarily absent, was read as permanent loss. Three downstream hits on 2026-09-03/04. This change removes that probe and replaces it with a bounded reconnect: five exponential attempts (250 ms to 4 s) against the same endpoint, exit 0 only when a terminal outcome is actually observed, and a `daemon_gone` error with exit 1 carrying the last observed liveness and outcome once the budget is exhausted. A restarted daemon adopts the still-running worker by PID, so the reconnected read returns the real terminal state.

## Architectural Justification

Deletes the PID/socket liveness probe (a second, racy source of truth) instead of tuning it; the only remaining signal is the authoritative subscription read. Production delta is negative. The reconnect budget is explicit and fails loud on the safe side.

## What Changed

- `packages/cli/src/cli-runtime-wait.ts`: removed `daemonGone()` probe; added `subscriptionReconnectAttemptLimit = 5` with backoff; `daemon_gone` message now states the exhausted budget and last known status.
- `packages/cli/test/runtime-wait-reconnect.integration.test.ts`: fixture can close and relisten on the same endpoint; new regressions for a live session surviving a daemon restart and for budget exhaustion; the fixture sequences on server close/relisten events, not sleeps.

## Gate Harvest / 门收割

No gate change. / 门未改。

## Machine-Readable Declarations

Production-Delta: +9/-15
Dependency-Change: none

### Optional Evidence Claims

none

## Task And Scope

task_0893b2a8c49a87878f03e1926b (C2 of the integrator feedback list); also closes the sibling task_3b90438fa3258d917a8d662333 (silent early return after reconnect), which shares the same loop. Branch `codex/runtime-status-wait`.

## Version Impact

No version change; publish impact none.

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none
- Authority: task_0893b2a8c49a87878f03e1926b
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Follow-up governance task: not applicable

## Verification

- Worker (Sol): `runtime-wait-reconnect.integration.test.ts` 11/11; targeted `runtime-cli.integration` restart and `--wait` cases pass; gate tests 185/185; lint, line-density, canonical-event-compat, test-selection, file-complexity, production-delta pass.
- CI is the complete authority.

## Review Evidence

CEO read the production diff: the probe branch is gone, the only exit-0 path requires an observed terminal outcome, and exhaustion produces a coded error. The 7.75 s budget is shorter than a slow autostart could be; that path now fails loud (`daemon_gone`, exit 1) rather than falsely succeeding, which is the ruled direction.

## Residual Risk

A daemon restart slower than the five-attempt budget yields `daemon_gone` instead of waiting longer; the budget is a single constant if experience says it should grow. The disconnect window is exercised by a same-endpoint fixture restart, not by stopping the shared default daemon.

# 中文

## 概要

`ha runtime status <session> --wait`(以及共用同一订阅循环的派工 wait)在 daemon 断连后可能没等到 terminal outcome 就 exit 0:首次可恢复连接错误时 CLI 去探 daemon 的 PID 与 socket,build-drift 重启那几秒两者同时缺席,被误判为永久丢失。2026-09-03/04 下游命中三次。本改动删掉该探针,改为有界重连:同一 endpoint 五次指数退避(250ms→4s),只在真正观察到 terminal outcome 时 exit 0;预算耗尽返回 `daemon_gone`、exit 1 并携带最后观测的 liveness/outcome。重启后的 daemon 按 PID 收养仍在跑的 worker,重连读到的是真实终态。

## 架构辩护

删掉 PID/socket 活性探针这个第二真源而不是调它;唯一保留的信号是权威订阅读。生产行数净减;重连预算显式,失败方向是响亮失败。

## 机读声明

生产行数增减(与上文机读声明一致):+9/-15

## 治理声明

- 触碰受保护面:否
- 授权:task_0893b2a8c49a87878f03e1926b
- Break-glass:否

## 验证

Sol:reconnect 集成测试 11/11,runtime-cli 定向 restart/--wait 用例过,gate tests 185/185,lint 与全部规定门通过。CI 为完整权威。

## 评审证据

CEO 读生产 diff:探针分支已删,唯一 exit 0 路径要求观察到终态,耗尽给编码错误。7.75s 预算可能短于慢速 autostart,但该路径现在响亮失败而不是假成功,方向符合裁决。

## 残余风险

慢于五次预算的重启会得到 `daemon_gone` 而非继续等;预算是单个常量。断连窗口由同 endpoint 的 fixture 重启覆盖,未停共享 default daemon。
