### PR TITLE
fix(gates): report an unreachable advisory endpoint as unaudited, not as a finding

### DIFF
--- a/tools/check-supply-chain.mjs
+++ b/tools/check-supply-chain.mjs
@@ -55,6 +55,38 @@ function run(command) {
   return result.stdout;
 }
 
+// The advisory endpoint being down is not a vulnerability finding. Reporting it as one makes the
+// gate say something false, and a gate that cries wolf gets read as noise -- including on the day
+// it is right. These markers come from npm's own failure output, so the distinction is drawn from
+// what npm reports rather than guessed from an exit code.
+const auditUnavailableMarkers = [
+  "audit endpoint returned an error",
+  "Service Unavailable",
+  "ECONNRESET",
+  "ETIMEDOUT",
+  "ENOTFOUND",
+  "socket hang up",
+];
+
+const unavailableAudits = [];
+
+function runAudit(command) {
+  const [binary, ...args] = command.split(" ");
+  const result = spawnSync(binary, args, {
+    cwd: root,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+    shell: process.platform === "win32",
+  });
+  if (result.status === 0) return;
+  const output = [result.stdout, result.stderr].filter(Boolean).join("\n").trim();
+  if (auditUnavailableMarkers.some((marker) => output.includes(marker))) {
+    unavailableAudits.push(`${command}: ${output.split("\n").find((line) => line.trim()) ?? "no output"}`);
+    return;
+  }
+  record(`${command} failed${output ? `:\n${output}` : ""}`);
+}
+
 const policyValidation = validateSupplyChainReleaseReadiness(policy);
 for (const error of policyValidation.errors) {
   record(`supply-chain release readiness policy invalid: ${error.code}: ${error.message}`);
@@ -66,7 +98,7 @@ validateDependabot();
 validateDocsAndWorkflow();
 
 for (const command of policy.auditCommands) {
-  run(command.command);
+  runAudit(command.command);
 }
 
 const sbomOutput = run(policy.sbom.generationCommand);
@@ -78,7 +110,21 @@ if (errors.length > 0) {
   process.exit(1);
 }
 
-console.log(`Supply chain check passed with ${policy.sbom.format} SBOM and release/license gates.`);
+// Surfaced as a GitHub annotation so "not audited" is visible on the PR itself, not only to whoever
+// opens the job log. Silence here would let an unaudited change look identical to an audited one.
+for (const entry of unavailableAudits) {
+  console.log(`::warning title=Supply chain audit did not run::${entry}`);
+  console.warn(`Audit unavailable, not a finding: ${entry}`);
+}
+
+if (unavailableAudits.length > 0) {
+  console.log(
+    `Supply chain check passed its offline gates with ${policy.sbom.format} SBOM; ` +
+      `${unavailableAudits.length} audit command(s) could not reach the advisory endpoint and did not run.`,
+  );
+} else {
+  console.log(`Supply chain check passed with ${policy.sbom.format} SBOM and release/license gates.`);
+}
 
 function validatePackageMetadata() {
   for (const packagePath of policy.workspacePackagePaths) {

--- a/tools/check-supply-chain.test.mjs
+++ b/tools/check-supply-chain.test.mjs
@@ -204,6 +204,31 @@ test("supply-chain check rejects Dependabot directory under wrong ecosystem", as
   });
 });
 
+test("supply-chain check passes and annotates when the advisory endpoint is unreachable", async () => {
+  await withFixtureRepo((root) => {
+    writeValidSupplyChainFixture(root, { auditBehavior: "unavailable" });
+
+    const result = runCheck(root);
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, /::warning title=Supply chain audit did not run::/u);
+    assert.match(result.stdout, /could not reach the advisory endpoint and did not run/u);
+    assert.doesNotMatch(result.stderr, /Supply chain check failed/u);
+  });
+});
+
+test("supply-chain check still fails when the audit runs and finds a vulnerability", async () => {
+  await withFixtureRepo((root) => {
+    writeValidSupplyChainFixture(root, { auditBehavior: "vulnerable" });
+
+    const result = runCheck(root);
+
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /npm audit --audit-level=high failed/u);
+    assert.doesNotMatch(result.stdout, /::warning title=Supply chain audit did not run::/u);
+  });
+});
+
 function runCheck(root) {
   return spawnSync(process.execPath, [scriptPath], {
     cwd: root,
@@ -310,7 +335,7 @@ function writeValidSupplyChainFixture(root, options = {}) {
   writeFile(root, ".github/workflows/rewrite-ci.yml", options.workflowBody ?? validWorkflow());
   writeFile(root, "README.md", validReadme());
   writeFile(root, "docs-release/release-posture.md", options.supplyDocBody ?? validSupplyDoc());
-  writeMockNpm(root, options.sbomMutator);
+  writeMockNpm(root, options.sbomMutator, options.auditBehavior);
 }
 
 function validReadme() {
@@ -357,7 +382,18 @@ function validWorkflow() {
   ].join("\n");
 }
 
-function writeMockNpm(root, sbomMutator) {
+const auditBehaviors = {
+  clean: ["  console.log('found 0 vulnerabilities');", "  process.exit(0);"],
+  // Shaped after npm's real output when the advisory endpoint is down.
+  unavailable: [
+    "  console.error('npm warn audit 503 Service Unavailable - POST https://registry.npmjs.org/-/npm/v1/security/advisories/bulk');",
+    "  console.error('npm error audit endpoint returned an error');",
+    "  process.exit(1);",
+  ],
+  vulnerable: ["  console.log('1 high severity vulnerability');", "  process.exit(1);"],
+};
+
+function writeMockNpm(root, sbomMutator, auditBehavior = "clean") {
   const mockPath = path.join(root, ".mock-bin/npm");
   const sbomValue = validSbom();
   sbomMutator?.(sbomValue);
@@ -369,8 +405,7 @@ function writeMockNpm(root, sbomMutator) {
       "#!/usr/bin/env node",
       "const args = process.argv.slice(2).join(' ');",
       "if (args === 'audit --audit-level=high' || args === 'audit --omit=dev --audit-level=high') {",
-      "  console.log('found 0 vulnerabilities');",
-      "  process.exit(0);",
+      ...auditBehaviors[auditBehavior],
       "}",
       "if (args === 'sbom --sbom-format=cyclonedx --sbom-type=application') {",
       `  console.log(${JSON.stringify(sbom)});`,


### PR DESCRIPTION
# English

## Summary

`npm audit` failing because `registry.npmjs.org/-/npm/v1/security/advisories/bulk` returns 503 or resets the connection is not a vulnerability finding. The gate reported it as one. On 2026-09-04 that blocked merges for over five hours across **seven** runs, with zero vulnerability evidence produced in any of them.

The gate now has three outcomes instead of two: the audit ran and found something at or above the threshold (**fail**), the audit ran and found nothing (**pass**), the audit could not run (**pass, annotated**). A real finding still fails exactly as before.

## Architectural Justification

Not required: churn is 50 lines, under the 200-line threshold.

## What Changed

- `tools/check-supply-chain.mjs`: audit commands go through `runAudit` instead of the generic `run`. When the command fails **and** its output carries one of npm's own unreachability markers (`audit endpoint returned an error`, `Service Unavailable`, `ECONNRESET`, `ETIMEDOUT`, `ENOTFOUND`, `socket hang up`), the failure is recorded as unavailable rather than as an error. Any other failure — including a real finding — still goes to `record()` and still fails the gate.
- Unavailable audits emit `::warning title=Supply chain audit did not run::…`, so "not audited" is visible on the PR's Checks page rather than only to whoever opens the job log. The final pass line also says how many audit commands did not run.
- `tools/check-supply-chain.test.mjs`: the npm mock takes an `auditBehavior`, and two tests cover both directions.

**The markers come from npm's own failure output, not from an exit code.** That matters because npm exits non-zero both when it finds a vulnerability and when it cannot reach the endpoint; only the text distinguishes them.

## Why not the alternatives

Recorded in the decision, repeated here because reviewers will ask:

- **Keep fail-closed.** The instinct is "be conservative when uncertain", but this is not uncertainty — we know precisely that the audit did not run. Reporting "did not test" as "found a problem" makes the gate say something false, and a gate that cries wolf gets read as noise on the day it is right.
- **Retry with a longer timeout.** Retries do not fix an upstream 503. Run 33845845969 already spent 310 seconds before failing.
- **Ship an offline advisory database.** A whole data-sync, freshness and update mechanism for an availability problem — defensive scaffolding for a requirement that is only "stop the gate from lying".

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none

## Machine-Readable Declarations

Production-Delta: +48/-2

## Task And Scope

- Harness task: task_514ac2c4f8f171d0284fd11425
- Authority: `dec_5E1C0DFBACC617FFD9CABF546F`, state `in_effect` since 2026-09-04T07:26:33Z, claims C1/C2 evidenced by `F-3F30FDC9`.
- Out of scope: the `supply-chain` job's required-check status is unchanged; this PR changes what the gate concludes, not which checks are required.

## Version Impact

- Version: no change
- Publish impact: no publish

## Governance Declaration

- **Protected surface touched: yes** — `tools/check-supply-chain.mjs` is a CI gate.
- Protected surface scope: the supply-chain gate's failure classification only. No workflow file, required-check list, timeout or `continue-on-error` was touched.
- Authority: `dec_5E1C0DFBACC617FFD9CABF546F` (in_effect), recorded before implementation, with both load-bearing claims backed by `F-3F30FDC9`.
- Machine-check boundary: this PR asserts the declaration exists; reviewers decide whether the authority is adequate.
- Break-glass: no.

## Verification

- Base `origin/main`: c23abcb14
- `node tools/run-node-tests.mjs --tier integration --file tools/check-supply-chain.test.mjs` → **12 passed, 0 failed**
- **Negative control:** reverting the one call site from `runAudit` back to `run` turns exactly the new unavailability test red (11 passed, 1 failed) and leaves the other eleven green. Restoring it returns to 12.
- The second new test is the negative control in the other direction: a mock npm that exits 1 with `1 high severity vulnerability` — no unreachability marker — still fails the gate and produces no annotation.
- `node tools/gates/line-density.mjs --base origin/main` → pass
- `production-delta` → computed `+48/-2`, matching the declaration.
- **A note on one instrument:** `tools/dispatch-isolated-test.mjs` rsyncs from the canonical checkout, not from the calling worktree. Running it from this worktree reported `pass 10` — the ten pre-existing tests — because the two new ones were never synced. The results above are from running in the worktree directly. Anyone verifying a worktree change with the isolated runner should know it measures canonical.

## Review Evidence

- CEO wrote the decision before implementing, and implemented against it.
- Human review: pending. **The protected-surface classification deserves a second opinion**: this makes a gate stop failing in a case where it currently fails, which is the shape of a weakened gate even though the weakening is precisely the false-positive class.

## Residual Risk

- The marker list is textual. If npm changes its failure wording, an unreachable endpoint would once again be reported as a finding — that is the fail-safe direction (a false alarm, not a missed vulnerability), but it would recreate today's blockage.
- A sufficiently strange npm failure that happens to contain one of these strings would be silently downgraded. All six strings describe transport or endpoint conditions and none appear in npm's vulnerability-report output, but this is a text match, not a typed signal.

---

# 中文

## 摘要

`npm audit` 因为 `registry.npmjs.org/-/npm/v1/security/advisories/bulk` 返回 503 或断开连接而失败，这不是漏洞发现。而门把它报成了漏洞发现。2026-09-04 当天，这让合并被阻塞五个多小时、横跨**七**次 run，其中没有任何一次产出过漏洞证据。

门现在有三种结果而不是两种：审计跑了且发现达到阈值的问题（**fail**）、审计跑了且没发现（**pass**）、审计没能跑成（**pass，带标注**）。真实的漏洞发现仍然与从前完全一样地失败。

## 架构辩护

不适用：churn 为 50 行，低于 200 行阈值。

## 改动内容

- `tools/check-supply-chain.mjs`：audit 命令改走 `runAudit` 而非通用的 `run`。当命令失败**且**输出携带 npm 自己的不可达标记（`audit endpoint returned an error`、`Service Unavailable`、`ECONNRESET`、`ETIMEDOUT`、`ENOTFOUND`、`socket hang up`）时，记为 unavailable 而不是 error。任何其他失败——包括真实的漏洞发现——仍走 `record()`，仍让门失败。
- unavailable 的审计会输出 `::warning title=Supply chain audit did not run::…`，使「未审计」显示在 PR 的 Checks 页面上，而不只对打开 job 日志的人可见。最后的通过行也会说明有几条 audit 命令没跑成。
- `tools/check-supply-chain.test.mjs`：npm mock 接受 `auditBehavior`，两条测试覆盖正反两个方向。

**这些标记取自 npm 自己的失败输出，不是从退出码猜的。** 这一点重要，因为 npm 在「发现漏洞」和「够不到端点」两种情况下都返回非零；只有文本能区分它们。

## 为什么不选其他方案

已记在 decision 里，此处重复因为评审会问：

- **保持 fail-closed。** 直觉理由是「不确定时保守」，但这里并非不确定——我们确知审计没有跑。把「没测」报成「测出问题」让门说了假话，而说假话的门在它真正说对的那天会被当成噪音。
- **加重试与更长超时。** 重试修不了上游 503。run 33845845969 已经跑了 310 秒才失败。
- **引入离线 advisory 数据库。** 为一个可用性问题引入整套数据同步、陈旧度与更新机制——需求只是「让门别说假话」，这是防御性脚手架。

## 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none

## 任务与范围

- Harness task：task_514ac2c4f8f171d0284fd11425
- 授权：`dec_5E1C0DFBACC617FFD9CABF546F`，自 2026-09-04T07:26:33Z 起 `in_effect`，两条 claim 由 `F-3F30FDC9` 提供证据。
- 不在范围内：`supply-chain` job 的 required-check 身份不变；本 PR 改的是门得出什么结论，不是哪些 check 是必需的。

## 版本影响

- 版本：不变
- 发布影响：不发布

## 治理声明

- **是否触碰 protected surface：是** —— `tools/check-supply-chain.mjs` 是 CI 门。
- 范围：仅限 supply-chain 门的失败分类。未触碰任何 workflow 文件、required-check 清单、超时或 `continue-on-error`。
- 授权：`dec_5E1C0DFBACC617FFD9CABF546F`（in_effect），在实现之前落库，两条承重 claim 均由 `F-3F30FDC9` 支撑。
- 机器检查边界：本 PR 声明该字段存在；授权是否充分由评审判断。
- Break-glass：否。

## 验证

- Base `origin/main`：c23abcb14
- `node tools/run-node-tests.mjs --tier integration --file tools/check-supply-chain.test.mjs` → **12 通过、0 失败**
- **阴性对照**：把那一处调用从 `runAudit` 改回 `run`，恰好新增的不可达测试转红（11 通过、1 失败），其余十一条保持绿；恢复后回到 12 通过。
- 第二条新测试是另一个方向的阴性对照：mock npm 以 `1 high severity vulnerability` 退出 1、不含任何不可达标记，门仍然失败且不产生标注。
- `node tools/gates/line-density.mjs --base origin/main` → pass
- `production-delta` → 实测 `+48/-2`，与声明一致。
- **关于一件仪器的说明**：`tools/dispatch-isolated-test.mjs` 是从 canonical checkout 同步的，不是从调用它的 worktree。在本 worktree 里跑它报 `pass 10`——那是原有的十条，两条新测试根本没被同步过去。上面的结果来自直接在 worktree 内运行。任何想用隔离 runner 验证 worktree 改动的人都应该知道它量的是 canonical。

## 评审证据

- CEO 先落 decision 再实现，并照它实现。
- 人工评审：待进行。**protected surface 的定性值得第二意见**：本次改动让门在一类当前会失败的情况下不再失败，这在形状上就是「削弱了门」，尽管被削掉的恰好是误报那一类。

## 残留风险

- 标记列表是文本匹配。若 npm 改了失败措辞，不可达的端点会重新被报成漏洞发现——这是 fail-safe 的方向（虚警而非漏报），但会重现今天的阻塞。
- 某个足够奇怪的 npm 失败若恰好包含这些字符串之一，会被静默降级。六个字符串都描述传输或端点状况，且都不出现在 npm 的漏洞报告输出里，但这终究是文本匹配，不是带类型的信号。
