### PR TITLE
test(gui): cover Ctrl+C interrupting while text is selected

### DIFF
--- a/packages/gui/test/terminal-pane.vitest.ts
+++ b/packages/gui/test/terminal-pane.vitest.ts
@@ -172,6 +172,19 @@ describe("TerminalPane addon lifecycle (W4a)", () => {
     expect(writeText).toHaveBeenCalledWith("selected output");
   });
 
+  it("still interrupts on Ctrl+C while text is selected", () => {
+    const writeText = vi.fn(async () => undefined);
+    Object.defineProperty(navigator, "clipboard", { value: { writeText }, configurable: true });
+    mount();
+    xterm.selection = "a long-running command's output";
+    const event = new KeyboardEvent("keydown", { key: "c", ctrlKey: true, cancelable: true });
+    // Selecting output must not disarm SIGINT. Copying is bound to the meta key alone, so this
+    // event has to reach the PTY unchanged even though a selection exists.
+    expect(xterm.keyHandler?.(event)).toBe(true);
+    expect(event.defaultPrevented).toBe(false);
+    expect(writeText).not.toHaveBeenCalled();
+  });
+
   it("forwards Ctrl+C and Cmd+C without a selection to the PTY path", () => {
     const writeText = vi.fn(async () => undefined);
     Object.defineProperty(navigator, "clipboard", { value: { writeText }, configurable: true });


### PR DESCRIPTION
# English

## Summary

The terminal suite covered Ctrl+C **without** a selection. The branch that can actually break is the other one: if the copy handler ever keyed off `hasSelection()` rather than off the meta key, selecting output would silently disarm SIGINT — you would highlight a runaway command's output, press Ctrl+C, and nothing would happen. This adds the missing case.

No production code changes.

## Architectural Justification

Not required: production delta is `+0/-0`.

## What Changed

- `packages/gui/test/terminal-pane.vitest.ts`: one case asserting that with a selection present, Ctrl+C returns `true` from the custom key handler (reaches the PTY), does not call `preventDefault`, and does not write to the clipboard.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none

## Machine-Readable Declarations

Production-Delta: +0/-0

## Task And Scope

- Harness task: task_effa2739faedb45f0920ddfbfe (terminal copy/paste, merged as #2239)
- This closes a coverage gap in an already-merged change rather than fixing a defect: the current implementation is correct.

## Version Impact

- Version: no change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Machine-check boundary: this PR only asserts the declaration exists.
- Break-glass: no

## Verification

- Base `origin/main`: 7becf32b5
- `npx vitest run packages/gui/test/terminal-pane.vitest.ts` → **7 passed** (6 pre-existing + 1 new)
- **Negative control:** removing the `!event.metaKey` guard from `TerminalPane.tsx` — the exact mistake this case exists to catch — turns the new test red and leaves the other six green (1 failed, 6 passed). Restoring the guard returns to 7.
- `production-delta` → pass at `+0/-0`.

## Review Evidence

- CEO wrote the case after noticing the existing one only covered the no-selection path while auditing the terminal line against its acceptance checks.
- Human review: pending.

## Residual Risk

- This is a unit test against a mocked xterm. It proves the handler returns the right value; it does not prove the real xterm forwards that keystroke to the PTY. Confirming the interrupt actually reaches a running process still requires using the terminal.

---

# 中文

## 摘要

终端测试覆盖了**没有选区**时的 Ctrl+C。真正会坏的是另一支：如果复制处理器哪天改成以 `hasSelection()` 而不是 meta 键为判据，选中输出就会静默地让 SIGINT 失效——你划中一个失控命令的输出、按下 Ctrl+C，什么都不会发生。本 PR 补上这个用例。

无生产代码改动。

## 架构辩护

不适用：production delta 为 `+0/-0`。

## 改动内容

- `packages/gui/test/terminal-pane.vitest.ts`：一条用例，断言存在选区时 Ctrl+C 让自定义按键处理器返回 `true`（到达 PTY）、不调用 `preventDefault`、不写剪贴板。

## 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none

## 任务与范围

- Harness task：task_effa2739faedb45f0920ddfbfe（终端复制粘贴，已作为 #2239 合并）
- 这是给一个已合并改动补覆盖缺口，不是修缺陷：当前实现是正确的。

## 版本影响

- 版本：不变
- 发布影响：不发布

## 治理声明

- 是否触碰 protected surface：否
- 机器检查边界：本 PR 只声明该字段存在。
- Break-glass：否

## 验证

- Base `origin/main`：7becf32b5
- `npx vitest run packages/gui/test/terminal-pane.vitest.ts` → **7 通过**（原有 6 条 + 新增 1 条）
- **阴性对照**：把 `TerminalPane.tsx` 里的 `!event.metaKey` 守卫去掉——正是本用例要抓的那个写错法——新测试转红、其余六条保持绿（1 失败、6 通过）；恢复守卫后回到 7 通过。
- `production-delta` → 在 `+0/-0` 下通过。

## 评审证据

- CEO 在按验收检查项审查终端线时发现原有用例只覆盖无选区那一支，据此补写。
- 人工评审：待进行。

## 残留风险

- 这是对 mock xterm 的单元测试。它证明处理器返回了正确的值，不证明真实 xterm 把该按键转发给了 PTY。要确认中断真的送达一个运行中的进程，仍然需要实际使用终端。
