### PR TITLE
fix(gates): classify npm audit endpoint failures separately and retry them within an explicit budget

### DIFF
--- a/tools/check-supply-chain.mjs
+++ b/tools/check-supply-chain.mjs
@@ -5,10 +5,12 @@ import {
   harnessSupplyChainReleaseReadiness,
   validateSupplyChainReleaseReadiness,
 } from "../packages/gui/src/distribution/supply-chain-release-readiness.ts";
+import { writeCiGateResult } from "./ci-gate-result.mjs";
 import { selectManifestGateIds } from "./run-manifest-gates.mjs";
 
 const root = process.cwd();
 const errors = [];
+const auditInfrastructureFailures = [];
 const policy = harnessSupplyChainReleaseReadiness;
 const manifestGateRunner = "node tools/run-manifest-gates.mjs";
 const gateManifest = existsSync(path.join(root, "tools/gate-manifest.json"))
@@ -48,6 +50,10 @@ function run(command) {
 
   if (result.status !== 0) {
     const output = [result.stdout, result.stderr].filter(Boolean).join("\n").trim();
+    if (command.startsWith("npm audit ") && isAuditInfrastructureFailure(output)) {
+      auditInfrastructureFailures.push(`${command} failed${output ? `:\n${output}` : ""}`);
+      return "";
+    }
     record(`${command} failed${output ? `:\n${output}` : ""}`);
     return "";
   }
@@ -67,18 +73,34 @@ validateDocsAndWorkflow();
 
 for (const command of policy.auditCommands) {
   run(command.command);
+  if (auditInfrastructureFailures.length > 0) break;
+}
+
+if (auditInfrastructureFailures.length > 0) {
+  writeCiGateResult("check-supply-chain", false, { failureKind: "audit-infrastructure" });
+  console.error("Supply chain audit infrastructure failure: npm audit endpoint is unreachable.");
+  for (const error of auditInfrastructureFailures) console.error(`- ${error}`);
+  process.exit(2);
 }
 
 const sbomOutput = run(policy.sbom.generationCommand);
 if (sbomOutput) validateSbom(sbomOutput);
 
 if (errors.length > 0) {
+  writeCiGateResult("check-supply-chain", false, { failureKind: "gate-failure" });
   console.error("Supply chain check failed:");
   for (const error of errors) console.error(`- ${error}`);
   process.exit(1);
 }
 
+writeCiGateResult("check-supply-chain", true, {});
 console.log(`Supply chain check passed with ${policy.sbom.format} SBOM and release/license gates.`);
+
+function isAuditInfrastructureFailure(output) {
+  return /(?:audit endpoint returned an error|\bHTTP(?:\/\S+)?\s+5\d\d\b|\b5\d\d Service Unavailable\b|\bE(?:CONNRESET|CONNREFUSED|TIMEDOUT|NETUNREACH)\b|socket hang up|network timeout|request timed out)/iu.test(
+    output,
+  );
+}
 
 function validatePackageMetadata() {
   for (const packagePath of policy.workspacePackagePaths) {

--- a/tools/check-supply-chain.mjs
+++ b/tools/check-supply-chain.mjs
@@ -11,6 +11,10 @@ import { selectManifestGateIds } from "./run-manifest-gates.mjs";
 const root = process.cwd();
 const errors = [];
 const auditInfrastructureFailures = [];
+const auditRetryDelaysMs = [15_000, 30_000];
+const auditRetryWaitMs = process.env.HARNESS_SUPPLY_CHAIN_TEST_FAST_RETRY === "1" ? [0, 0] : auditRetryDelaysMs;
+const auditFetchTimeoutMs = 60_000;
+let auditAttempts = 0;
 const policy = harnessSupplyChainReleaseReadiness;
 const manifestGateRunner = "node tools/run-manifest-gates.mjs";
 const gateManifest = existsSync(path.join(root, "tools/gate-manifest.json"))
@@ -46,6 +50,13 @@ function run(command) {
     // error wearing the costume of a real finding. No argument below contains a
     // space, so the shell re-parse cannot change what npm receives.
     shell: process.platform === "win32",
+    env: command.startsWith("npm audit ")
+      ? {
+          ...process.env,
+          npm_config_fetch_retries: "0",
+          npm_config_fetch_timeout: String(auditFetchTimeoutMs),
+        }
+      : process.env,
   });
 
   if (result.status !== 0) {
@@ -61,6 +72,22 @@ function run(command) {
   return result.stdout;
 }
 
+function runAudit(command) {
+  for (let attempt = 1; attempt <= auditRetryDelaysMs.length + 1; attempt += 1) {
+    auditAttempts = attempt;
+    const failureCount = auditInfrastructureFailures.length;
+    run(command);
+    if (auditInfrastructureFailures.length === failureCount) {
+      if (attempt > 1) console.error(`${auditRetrySummary(attempt)} Audit infrastructure recovered.`);
+      return;
+    }
+
+    if (attempt > auditRetryDelaysMs.length) return;
+    auditInfrastructureFailures.pop();
+    sleep(auditRetryWaitMs[attempt - 1]);
+  }
+}
+
 const policyValidation = validateSupplyChainReleaseReadiness(policy);
 for (const error of policyValidation.errors) {
   record(`supply-chain release readiness policy invalid: ${error.code}: ${error.message}`);
@@ -72,13 +99,13 @@ validateDependabot();
 validateDocsAndWorkflow();
 
 for (const command of policy.auditCommands) {
-  run(command.command);
+  runAudit(command.command);
   if (auditInfrastructureFailures.length > 0) break;
 }
 
 if (auditInfrastructureFailures.length > 0) {
   writeCiGateResult("check-supply-chain", false, { failureKind: "audit-infrastructure" });
-  console.error("Supply chain audit infrastructure failure: npm audit endpoint is unreachable.");
+  console.error(`${auditRetrySummary(auditAttempts)} Audit infrastructure failure: endpoint unreachable.`);
   for (const error of auditInfrastructureFailures) console.error(`- ${error}`);
   process.exit(2);
 }
@@ -100,6 +127,15 @@ function isAuditInfrastructureFailure(output) {
   return /(?:audit endpoint returned an error|\bHTTP(?:\/\S+)?\s+5\d\d\b|\b5\d\d Service Unavailable\b|\bE(?:CONNRESET|CONNREFUSED|TIMEDOUT|NETUNREACH)\b|socket hang up|network timeout|request timed out)/iu.test(
     output,
   );
+}
+
+function auditRetrySummary(attempts) {
+  const delays = auditRetryDelaysMs.map((delay) => `${delay / 1_000}s`).join("/");
+  return `Supply chain audit retry budget: ${auditRetryDelaysMs.length} retries (${delays}); actual attempts: ${attempts}.`;
+}
+
+function sleep(delayMs) {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, delayMs);
 }
 
 function validatePackageMetadata() {

--- a/tools/check-supply-chain.test.mjs
+++ b/tools/check-supply-chain.test.mjs
@@ -1,6 +1,6 @@
 // harness-test-tier: integration
 import assert from "node:assert/strict";
-import { chmodSync, mkdirSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
@@ -191,6 +191,48 @@ test("supply-chain check invokes npm instead of reading fixture output from env"
   });
 });
 
+test("supply-chain check reports an unreachable audit endpoint as infrastructure failure", async () => {
+  await withFixtureRepo((root) => {
+    writeValidSupplyChainFixture(root, {
+      auditFailure: {
+        output:
+          "npm warn audit request failed, reason: connect ECONNREFUSED 127.0.0.1:9\nnpm error audit endpoint returned an error",
+        status: 1,
+      },
+    });
+    const gateResults = path.join(root, "gate-results.json");
+
+    const result = runCheck(root, { HARNESS_CI_GATE_RESULTS: gateResults });
+
+    assert.equal(result.status, 2);
+    assert.match(result.stderr, /^Supply chain audit infrastructure failure:/u);
+    assert.deepEqual(JSON.parse(readFileSync(gateResults, "utf8")), [
+      { gate: "check-supply-chain", pass: false, metrics: { failureKind: "audit-infrastructure" } },
+    ]);
+  });
+});
+
+test("supply-chain check preserves the vulnerability failure path", async () => {
+  await withFixtureRepo((root) => {
+    writeValidSupplyChainFixture(root, {
+      auditFailure: {
+        output: "lodash  <=4.17.20\nSeverity: high\nfix available via npm audit fix\n1 high severity vulnerability",
+        status: 1,
+      },
+    });
+    const gateResults = path.join(root, "gate-results.json");
+
+    const result = runCheck(root, { HARNESS_CI_GATE_RESULTS: gateResults });
+
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /^Supply chain check failed:/u);
+    assert.match(result.stderr, /1 high severity vulnerability/u);
+    assert.deepEqual(JSON.parse(readFileSync(gateResults, "utf8")), [
+      { gate: "check-supply-chain", pass: false, metrics: { failureKind: "gate-failure" } },
+    ]);
+  });
+});
+
 test("supply-chain check rejects Dependabot directory under wrong ecosystem", async () => {
   await withFixtureRepo((root) => {
     writeValidSupplyChainFixture(root, {
@@ -204,12 +246,13 @@ test("supply-chain check rejects Dependabot directory under wrong ecosystem", as
   });
 });
 
-function runCheck(root) {
+function runCheck(root, environment = {}) {
   return spawnSync(process.execPath, [scriptPath], {
     cwd: root,
     encoding: "utf8",
     env: {
       ...process.env,
+      ...environment,
       PATH: `${path.join(root, ".mock-bin")}${path.delimiter}${process.env.PATH ?? ""}`,
     },
   });
@@ -310,7 +353,7 @@ function writeValidSupplyChainFixture(root, options = {}) {
   writeFile(root, ".github/workflows/rewrite-ci.yml", options.workflowBody ?? validWorkflow());
   writeFile(root, "README.md", validReadme());
   writeFile(root, "docs-release/release-posture.md", options.supplyDocBody ?? validSupplyDoc());
-  writeMockNpm(root, options.sbomMutator);
+  writeMockNpm(root, options.sbomMutator, options.auditFailure);
 }
 
 function validReadme() {
@@ -357,7 +400,7 @@ function validWorkflow() {
   ].join("\n");
 }
 
-function writeMockNpm(root, sbomMutator) {
+function writeMockNpm(root, sbomMutator, auditFailure) {
   const mockPath = path.join(root, ".mock-bin/npm");
   const sbomValue = validSbom();
   sbomMutator?.(sbomValue);
@@ -369,8 +412,8 @@ function writeMockNpm(root, sbomMutator) {
       "#!/usr/bin/env node",
       "const args = process.argv.slice(2).join(' ');",
       "if (args === 'audit --audit-level=high' || args === 'audit --omit=dev --audit-level=high') {",
-      "  console.log('found 0 vulnerabilities');",
-      "  process.exit(0);",
+      `  console.log(${JSON.stringify(auditFailure?.output ?? "found 0 vulnerabilities")});`,
+      `  process.exit(${auditFailure?.status ?? 0});`,
       "}",
       "if (args === 'sbom --sbom-format=cyclonedx --sbom-type=application') {",
       `  console.log(${JSON.stringify(sbom)});`,

--- a/tools/check-supply-chain.test.mjs
+++ b/tools/check-supply-chain.test.mjs
@@ -193,19 +193,50 @@ test("supply-chain check invokes npm instead of reading fixture output from env"
 
 test("supply-chain check reports an unreachable audit endpoint as infrastructure failure", async () => {
   await withFixtureRepo((root) => {
+    writeValidSupplyChainFixture(root, { auditFailure: auditInfrastructureFailure() });
+    const gateResults = path.join(root, "gate-results.json");
+
+    const result = runCheck(root, {
+      HARNESS_CI_GATE_RESULTS: gateResults,
+      HARNESS_SUPPLY_CHAIN_TEST_FAST_RETRY: "1",
+    });
+
+    assert.equal(result.status, 2);
+    assert.match(result.stderr, /^Supply chain audit retry budget:/u);
+    assert.deepEqual(JSON.parse(readFileSync(gateResults, "utf8")), [
+      { gate: "check-supply-chain", pass: false, metrics: { failureKind: "audit-infrastructure" } },
+    ]);
+  });
+});
+
+test("supply-chain check retries an audit infrastructure failure and then succeeds", async () => {
+  await withFixtureRepo((root) => {
     writeValidSupplyChainFixture(root, {
-      auditFailure: {
-        output:
-          "npm warn audit request failed, reason: connect ECONNREFUSED 127.0.0.1:9\nnpm error audit endpoint returned an error",
-        status: 1,
-      },
+      auditResults: [auditInfrastructureFailure(), { output: "found 0 vulnerabilities", status: 0 }],
+    });
+
+    const result = runCheck(root, { HARNESS_SUPPLY_CHAIN_TEST_FAST_RETRY: "1" });
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stderr, /^Supply chain audit retry budget: 2 retries \(15s\/30s\); actual attempts: 2\./u);
+    assert.match(result.stderr, /Audit infrastructure recovered/u);
+  });
+});
+
+test("supply-chain check exhausts bounded retries before reporting infrastructure failure", async () => {
+  await withFixtureRepo((root) => {
+    writeValidSupplyChainFixture(root, {
+      auditResults: [auditInfrastructureFailure(), auditInfrastructureFailure(), auditInfrastructureFailure()],
     });
     const gateResults = path.join(root, "gate-results.json");
 
-    const result = runCheck(root, { HARNESS_CI_GATE_RESULTS: gateResults });
+    const result = runCheck(root, {
+      HARNESS_CI_GATE_RESULTS: gateResults,
+      HARNESS_SUPPLY_CHAIN_TEST_FAST_RETRY: "1",
+    });
 
     assert.equal(result.status, 2);
-    assert.match(result.stderr, /^Supply chain audit infrastructure failure:/u);
+    assert.match(result.stderr, /actual attempts: 3\. Audit infrastructure failure: endpoint unreachable\./u);
     assert.deepEqual(JSON.parse(readFileSync(gateResults, "utf8")), [
       { gate: "check-supply-chain", pass: false, metrics: { failureKind: "audit-infrastructure" } },
     ]);
@@ -353,7 +384,15 @@ function writeValidSupplyChainFixture(root, options = {}) {
   writeFile(root, ".github/workflows/rewrite-ci.yml", options.workflowBody ?? validWorkflow());
   writeFile(root, "README.md", validReadme());
   writeFile(root, "docs-release/release-posture.md", options.supplyDocBody ?? validSupplyDoc());
-  writeMockNpm(root, options.sbomMutator, options.auditFailure);
+  writeMockNpm(root, options.sbomMutator, options.auditFailure, options.auditResults);
+}
+
+function auditInfrastructureFailure() {
+  return {
+    output:
+      "npm warn audit request failed, reason: connect ECONNREFUSED 127.0.0.1:9\nnpm error audit endpoint returned an error",
+    status: 1,
+  };
 }
 
 function validReadme() {
@@ -400,7 +439,7 @@ function validWorkflow() {
   ].join("\n");
 }
 
-function writeMockNpm(root, sbomMutator, auditFailure) {
+function writeMockNpm(root, sbomMutator, auditFailure, auditResults) {
   const mockPath = path.join(root, ".mock-bin/npm");
   const sbomValue = validSbom();
   sbomMutator?.(sbomValue);
@@ -410,10 +449,16 @@ function writeMockNpm(root, sbomMutator, auditFailure) {
     ".mock-bin/npm",
     [
       "#!/usr/bin/env node",
+      "import fs from 'node:fs';",
       "const args = process.argv.slice(2).join(' ');",
       "if (args === 'audit --audit-level=high' || args === 'audit --omit=dev --audit-level=high') {",
-      `  console.log(${JSON.stringify(auditFailure?.output ?? "found 0 vulnerabilities")});`,
-      `  process.exit(${auditFailure?.status ?? 0});`,
+      `  const results = ${JSON.stringify(auditResults ?? (auditFailure ? [auditFailure] : []))};`,
+      "  const statePath = new URL('../.mock-audit-count', import.meta.url);",
+      "  const count = fs.existsSync(statePath) ? Number(fs.readFileSync(statePath, 'utf8')) : 0;",
+      "  fs.writeFileSync(statePath, String(count + 1));",
+      "  const result = results[count] ?? results.at(-1) ?? { output: 'found 0 vulnerabilities', status: 0 };",
+      "  console.log(result.output);",
+      "  process.exit(result.status);",
       "}",
       "if (args === 'sbom --sbom-format=cyclonedx --sbom-type=application') {",
       `  console.log(${JSON.stringify(sbom)});`,


### PR DESCRIPTION
# English

## Summary

`check-supply-chain` runs `npm audit --omit=dev --audit-level=high`. When the npm advisories endpoint is unreachable (503, timeout, socket hang up) the command exits non-zero and the gate went red exactly like a real high-severity finding. On 2026-09-04 that happened six times across five pull requests and main, each time consuming a full CI slot in the serialized merge queue. This change keeps the vulnerability judgement and its blocking power untouched and gives the infrastructure failure its own path: exit code 2, a first log line that names the endpoint failure, and `failureKind: "audit-infrastructure"` in the gate result JSON (real findings keep exit 1 and `failureKind: "gate-failure"`). A bounded retry is added under the ruling's data clause: on 2026-09-04 eight endpoint failures all passed on rerun, so audit commands whose failure is classified as infrastructure are retried at most twice (15 s, 30 s) with a 60 s fetch timeout per attempt; the budget and the actual attempt count are printed on the first line; exhaustion still exits 2 (no fail-open); vulnerability failures are never retried.

## Architectural Justification

Distinguishes two failure modes inside the existing gate script; no workflow, manifest, threshold or dependency change. The gate still fails closed on infrastructure failure, so nothing can slip through while the endpoint is down. Authorized by decision dec_7AE4A85E0680F842DAAE968A7C (in effect).

## What Changed

- `tools/check-supply-chain.mjs`: classify audit endpoint/network failures; exit 2 with a named first line; write `failureKind` into the CI gate result.
- `tools/check-supply-chain.test.mjs`: two new cases (unreachable endpoint → exit 2 + audit-infrastructure; vulnerability output → exit 1 + gate-failure) plus gate JSON assertions.

## Gate Harvest / 门收割

Gate script `tools/check-supply-chain.mjs` changed under decision dec_7AE4A85E0680F842DAAE968A7C: failure classification only; predicate, threshold and blocking unchanged. / 门脚本按裁决只加失败分类,判定、阈值与阻塞力不变。

## Machine-Readable Declarations

Production-Delta: +59/-1
Dependency-Change: none

### Optional Evidence Claims

none

## Task And Scope

task_514ac2c4f8f171d0284fd11425, derived from decision dec_7AE4A85E0680F842DAAE968A7C. Branch `codex/supply-chain-gate`.

## Version Impact

No version change; publish impact none.

## Governance Declaration

- Protected surface touched: yes
- Protected surface scope: CI gate script `tools/check-supply-chain.mjs` (failure classification; no threshold, workflow or manifest change)
- Authority: decision dec_7AE4A85E0680F842DAAE968A7C (in effect) and task_514ac2c4f8f171d0284fd11425
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Follow-up governance task: not applicable

## Verification

- Worker (Sol): `node --test tools/**/check-supply-chain*.test.mjs` 14/14 (two retry cases added: first failure then success → exit 0 with the retry recorded; three infrastructure failures → exit 2); negative control with `npm_config_registry=http://127.0.0.1:9` exits 2 with the infrastructure first line; positive control with a pinned vulnerable lockfile against a controlled local audit response exits 1 with the vulnerability output; lint, line-density, file-complexity, test-selection, canonical-event-compat, gate tests 185/185 pass.
- CI is the complete authority; note the public endpoint may still be flaky while this PR runs, in which case the supply-chain job will now fail with exit 2 and the audit-infrastructure marker.

## Review Evidence

CEO read the diff against CH1: threshold and command unchanged; infrastructure failures are detected by output pattern, exit 2, named first line, gate JSON kind; vulnerability path unchanged; no fail-open; bounded retry only on the classified infrastructure path with an explicit printed budget.

## Residual Risk

The pattern list for infrastructure failures is a heuristic over npm's output; an unlisted error string falls back to the ordinary gate failure, which is the safe direction. With three attempts at a 60 s fetch timeout the job can still take up to about 3 min 45 s when every attempt times out; the gate keeps blocking merges while the endpoint stays down for that long.

# 中文

## 概要

`check-supply-chain` 跑 `npm audit --omit=dev --audit-level=high`。npm advisories 端点不可达(503/超时/socket hang up)时命令非零退出,门红得和真的发现高危漏洞一样。2026-09-04 这一天在五条 PR 与 main 上发生六次,每次吃掉串行合并队列一整轮。本改动保持漏洞判定与阻塞力不变,给基础设施失败单独路径:退出码 2、首行点名端点故障、gate 结果 JSON 写 `failureKind: "audit-infrastructure"`(真漏洞仍 exit 1、`gate-failure`)。按裁决的数据条款加有界重试:2026-09-04 八次端点故障全部重跑即过,故仅对被分类为基础设施故障的 audit 命令最多重试 2 次(15s/30s),单次 fetch 超时 60s;预算与实际尝试次数打印在首行;耗尽仍 exit 2(不 fail-open);漏洞失败永不重试。

## 架构辩护

在既有门脚本内区分两种失败;不改 workflow、manifest、阈值、依赖。基础设施失败仍 fail-closed,端点故障期间没有东西能溜进去。授权:decision dec_7AE4A85E0680F842DAAE968A7C(in_effect)。

## 机读声明

生产行数增减(与上文机读声明一致):+59/-1

## 治理声明

- 触碰受保护面:是(CI 门脚本 `tools/check-supply-chain.mjs`,只加失败分类)
- 授权:decision dec_7AE4A85E0680F842DAAE968A7C 与 task_514ac2c4f8f171d0284fd11425
- Break-glass:否

## 验证

Sol:定向测试 14/14(新增重试成功与重试耗尽两条);不可达阴性对照 exit 2 带首行标记;固定漏洞 lockfile 阳性对照 exit 1;lint/line-density/file-complexity/test-selection/canonical-event-compat/gate tests 全过。CI 为完整权威;公共端点若仍抖动,本 PR 的 supply-chain job 会以 exit 2 与 audit-infrastructure 标记失败。

## 评审证据

CEO 对照 CH1 读 diff:阈值与命令不变;基础设施失败按输出模式识别、exit 2、首行点名、gate JSON 分类;漏洞路径不变;无 fail-open;有界重试只走已分类的基础设施路径且预算显式打印。

## 残余风险

模式列表是对 npm 输出的启发式匹配;未列出的错误串回落到普通门失败,是安全方向。三次尝试各等满 60s 时 job 最长约 3 分 45 秒;端点持续故障超过这个窗口,门仍阻塞合并。
