### PR TITLE
fix(daemon): 停机时无条件释放 pid 文件与单例锁

### DIFF
--- a/packages/daemon/src/daemon-host-lifecycle-api.ts
+++ b/packages/daemon/src/daemon-host-lifecycle-api.ts
@@ -83,7 +83,13 @@ export function createDaemonHostLifecycleApi(
       for (const runtime of context.fleetEdgeRuntimes.values()) runtime.close();
       context.fleetEdgeRuntimes.clear();
       context.remoteProxy.close();
-      await Promise.all([...context.cells.values()].map((cell) => cell.close()));
+      // Every cell gets its close awaited even when one of them rejects: Promise.all would return
+      // on the first rejection while the other cells were still tearing down, and the stop sequence
+      // above this would release the pid file and lock under threads that are still alive. The
+      // first rejection still propagates so the drain failure is not swallowed.
+      const settled = await Promise.allSettled([...context.cells.values()].map((cell) => cell.close())),
+        rejected = settled.find((outcome): outcome is PromiseRejectedResult => outcome.status === "rejected");
+      if (rejected) throw rejected.reason;
     },
   };
 }

--- a/packages/daemon/src/runtime.ts
+++ b/packages/daemon/src/runtime.ts
@@ -23,6 +23,16 @@ export interface DaemonServeDeferred {
   readonly witness: "unix-socket" | "singleton-lock";
 }
 export type DaemonServeStart = RunningDaemon | DaemonServeDeferred;
+/** Teardown must reach the pid file and the lock even when an earlier step rejects; the drain's own
+ *  rejection is the one that propagates, so a failing teardown step must not mask or replace it. */
+async function settleTeardownStep(step: () => Promise<void>): Promise<void> {
+  try {
+    await step();
+  } catch {
+    // Intentionally swallowed: the caller is already unwinding and the remaining teardown matters more.
+  }
+}
+
 export async function startDaemon(input: {
   readonly daemonId: string;
   readonly userRoot: string;
@@ -75,18 +85,20 @@ export async function startDaemon(input: {
     if (stopPromise) return stopPromise;
     stopping = true;
     stopPromise = (async () => {
-      // The release below is in `finally` because the invariant above is unconditional: whatever the
-      // drain does, the pid file and the lock must not outlive this call. They used to sit after the
-      // awaits, so any rejection on the way down — most easily a long migration replay failing inside
-      // RepoCell.close — left the lock held by a process that was already gone, and the next daemon
-      // could never claim it.
+      // Only the drain belongs in `try`; everything below it is teardown and the invariant above is
+      // unconditional. These used to sit after the awaits, so any rejection on the way down — most
+      // easily a long migration replay failing inside RepoCell.close — left the socket bound, the pid
+      // file present and the lock held by a process that was already gone, and the next daemon could
+      // never claim it. Each teardown step is also individually guarded, because one of them failing
+      // must not strand the ones after it: a half-released daemon is the state this whole comment
+      // exists to prevent.
       try {
         // RepoCell.close drains each local WAL before the daemon advertises its terminal boundary.
         await host!.close();
-        lifecycle.record({ event: "process_exit", outcome });
-        await transport!.stop();
-        await connLog.settle();
       } finally {
+        lifecycle.record({ event: "process_exit", outcome });
+        await settleTeardownStep(() => transport!.stop());
+        await settleTeardownStep(() => connLog.settle());
         rmSync(pidPath, { force: true });
         singleton.release();
       }

--- a/packages/daemon/src/runtime.ts
+++ b/packages/daemon/src/runtime.ts
@@ -75,13 +75,21 @@ export async function startDaemon(input: {
     if (stopPromise) return stopPromise;
     stopping = true;
     stopPromise = (async () => {
-      // RepoCell.close drains each local WAL before the daemon advertises its terminal boundary.
-      await host!.close();
-      lifecycle.record({ event: "process_exit", outcome });
-      await transport!.stop();
-      await connLog.settle();
-      rmSync(pidPath, { force: true });
-      singleton.release();
+      // The release below is in `finally` because the invariant above is unconditional: whatever the
+      // drain does, the pid file and the lock must not outlive this call. They used to sit after the
+      // awaits, so any rejection on the way down — most easily a long migration replay failing inside
+      // RepoCell.close — left the lock held by a process that was already gone, and the next daemon
+      // could never claim it.
+      try {
+        // RepoCell.close drains each local WAL before the daemon advertises its terminal boundary.
+        await host!.close();
+        lifecycle.record({ event: "process_exit", outcome });
+        await transport!.stop();
+        await connLog.settle();
+      } finally {
+        rmSync(pidPath, { force: true });
+        singleton.release();
+      }
     })();
     return stopPromise;
   };

--- a/packages/daemon/src/runtime.ts
+++ b/packages/daemon/src/runtime.ts
@@ -1,5 +1,6 @@
 import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import path from "node:path";
+import { consumeKnownError } from "../../kernel/src/index.ts";
 import { localUserDaemonEndpoint } from "./client/local-daemon-target.ts";
 import { acquireDaemonSingleton, daemonPidPath } from "./daemon-singleton.ts";
 import { openDaemonHost } from "./daemon-host.ts";
@@ -28,8 +29,9 @@ export type DaemonServeStart = RunningDaemon | DaemonServeDeferred;
 async function settleTeardownStep(step: () => Promise<void>): Promise<void> {
   try {
     await step();
-  } catch {
-    // Intentionally swallowed: the caller is already unwinding and the remaining teardown matters more.
+  } catch (error) {
+    // The caller is already unwinding and the remaining teardown matters more than this step's reason.
+    consumeKnownError(error);
   }
 }
 

--- a/packages/daemon/test/daemon-build-drain.integration.test.ts
+++ b/packages/daemon/test/daemon-build-drain.integration.test.ts
@@ -298,6 +298,7 @@ test("a drain that rejects still releases the pid file and the singleton lock", 
 
     assert.equal(existsSync(lockPath), false, "stop exit must release the singleton lock");
     assert.equal(readDaemonPid(userRoot, repoId), null, "stop exit must remove the pid file");
+    assert.equal(existsSync(testEndpoint(repoId)), false, "stop exit must remove the socket");
     daemon = undefined;
   } finally {
     await daemon?.stop().catch(() => undefined);

--- a/packages/daemon/test/daemon-build-drain.integration.test.ts
+++ b/packages/daemon/test/daemon-build-drain.integration.test.ts
@@ -265,7 +265,10 @@ test("a drain that rejects still releases the pid file and the singleton lock", 
     userRoot = path.join(parent, "user"),
     repoId = "stop-drain-reject",
     lockPath = daemonSingletonLockPath(userRoot, repoId);
-  let daemon: RunningDaemon | undefined;
+  let daemon: RunningDaemon | undefined,
+    // The injected close never reaches the real cell, so the test owns closing it: otherwise its
+    // worker thread keeps the test process alive after every assertion has passed.
+    realCell: Awaited<ReturnType<typeof openBootstrappedRepoCell>> | undefined;
   rosterRepo(rootDir, repoId);
   registerBootstrappedDaemonRepo({ canonicalRoot: rootDir, repoId, userRoot, createConvenienceLinks: false });
   try {
@@ -276,6 +279,7 @@ test("a drain that rejects still releases the pid file and the singleton lock", 
         endpoint: testEndpoint(repoId),
         openCell: async (input) => {
           const cell = await openBootstrappedRepoCell(input);
+          realCell = cell;
           return {
             ...cell,
             close: async () => {
@@ -302,6 +306,7 @@ test("a drain that rejects still releases the pid file and the singleton lock", 
     daemon = undefined;
   } finally {
     await daemon?.stop().catch(() => undefined);
+    await realCell?.close().catch(() => undefined);
     rmSync(parent, { recursive: true, force: true });
   }
 });

--- a/packages/daemon/test/daemon-build-drain.integration.test.ts
+++ b/packages/daemon/test/daemon-build-drain.integration.test.ts
@@ -8,6 +8,7 @@ import test from "node:test";
 import { ensureLocalDaemonRunning, type DaemonLaunchSpec } from "../src/client/daemon-autostart.ts";
 import { requestDaemonJsonRpcAt } from "../src/client/local-json-rpc-client.ts";
 import { readDaemonLifecycleRecords, type DaemonLifecycleRecorder } from "../src/lifecycle-log.ts";
+import { daemonSingletonLockPath } from "../src/daemon-singleton.ts";
 import { readDaemonPid, startDaemon, type RunningDaemon } from "../src/runtime.ts";
 import { openBootstrappedRepoCell, registerBootstrappedDaemonRepo } from "./repo-settings.fixture.ts";
 
@@ -251,6 +252,55 @@ test("autostart readiness is independent of a simulated 32 second canonical repo
     attachmentGate.resolve();
     if (!daemon && daemonStart) daemon = await daemonStart;
     await daemon?.stop();
+    rmSync(parent, { recursive: true, force: true });
+  }
+});
+
+test("a drain that rejects still releases the pid file and the singleton lock", async () => {
+  // The stop sequence used to release the pid file and the lock after the awaits, so any rejection on
+  // the way down left both behind and the next daemon could never claim the singleton. A long
+  // migration replay failing inside RepoCell.close is the path that surfaced this on main.
+  const parent = mkdtempSync(path.join(tmpdir(), "ha-daemon-stop-drain-reject-")),
+    rootDir = path.join(parent, "repo"),
+    userRoot = path.join(parent, "user"),
+    repoId = "stop-drain-reject",
+    lockPath = daemonSingletonLockPath(userRoot, repoId);
+  let daemon: RunningDaemon | undefined;
+  rosterRepo(rootDir, repoId);
+  registerBootstrappedDaemonRepo({ canonicalRoot: rootDir, repoId, userRoot, createConvenienceLinks: false });
+  try {
+    daemon = runningDaemon(
+      await startDaemon({
+        daemonId: repoId,
+        userRoot,
+        endpoint: testEndpoint(repoId),
+        openCell: async (input) => {
+          const cell = await openBootstrappedRepoCell(input);
+          return {
+            ...cell,
+            close: async () => {
+              throw new Error("simulated migration replay failure during close");
+            },
+          };
+        },
+      }),
+    );
+    assert.equal(existsSync(lockPath), true, "the running daemon holds the singleton lock");
+    // Attachment is async: stopping before the cell lands would close an empty registry and never
+    // reach the injected failure, which is the same trap that makes this bug hard to see.
+    for (let attempt = 0; attempt < 100; attempt += 1) {
+      const status = await requestDaemonJsonRpcAt(daemon.endpoint, "daemon.status", {}, 2_000, 2_000);
+      if ((status.repos as { readonly state: string }[])[0]?.state === "attached") break;
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    }
+
+    await assert.rejects(daemon.stop(), /simulated migration replay failure during close/u);
+
+    assert.equal(existsSync(lockPath), false, "stop exit must release the singleton lock");
+    assert.equal(readDaemonPid(userRoot, repoId), null, "stop exit must remove the pid file");
+    daemon = undefined;
+  } finally {
+    await daemon?.stop().catch(() => undefined);
     rmSync(parent, { recursive: true, force: true });
   }
 });


### PR DESCRIPTION
Production-Delta: +36/-8

# English

## Problem

`main`'s `rewrite-ci` has been red across several consecutive commits on the same test:

```
✖ platform stop during a long migration replay exits the daemon in bounded time and releases every lock
  AssertionError: stop exit must release the singleton lock
    actual:   true      // still held
    expected: false
```

The shard number alternated between 24 and 26 across unrelated merge points, with one green in between — a load-dependent race, not a regression from any one change.

## Root cause

`runtime.ts`'s stop sequence placed the teardown steps **after** the drain await:

```ts
await host!.close();          // ← a long migration replay failing in here…
lifecycle.record(...);
await transport!.stop();
await connLog.settle();
rmSync(pidPath, { force: true });   // ← …skips everything below
singleton.release();
```

Any rejection on the way down leaves the lock held by a process that is already gone, and the next daemon can never claim it. The comment directly above the function already states the invariant — "endpoint, pid file and lock are released together: an observer either finds a daemon that can speak for itself, or finds nothing at all" — so the error path was violating the function's own documented contract.

## The first fix was directionally right and too narrow

The first commit moved only `rmSync(pidPath)` and `singleton.release()` into `finally`. CI then reported the **same test** failing on a **different assertion**:

```
AssertionError: stop exit must remove the socket
  actual:   true
  expected: false
```

That is the fix working and the scope being wrong: with the lock now released, the next thing the invariant promises — the socket — was still stranded, because `transport.stop()` is *also* teardown and was still inside `try`.

## Fix

Only the drain belongs in `try`. Every step below it is teardown, and the invariant above it is unconditional:

```ts
try {
  await host!.close();
} finally {
  lifecycle.record({ event: "process_exit", outcome });
  await settleTeardownStep(() => transport!.stop());
  await settleTeardownStep(() => connLog.settle());
  rmSync(pidPath, { force: true });
  singleton.release();
}
```

Each teardown step is *individually* guarded as well, because one of them failing must not strand the ones after it — a half-released daemon is the exact state this whole comment exists to prevent. `settleTeardownStep` swallows the step's own rejection so the drain's rejection stays the one that propagates. `singleton.release` delegates to `releaseIfHeld`, which is idempotent, so a repeat call is safe.

## Negative control

The new test injects a cell whose `close()` throws, then asserts the lock file, the pid file and the socket are all gone.

One trap worth recording: the first version of the test called `stop()` immediately after `startDaemon`, before attachment settled. The cell registry was still empty, `host.close()` closed nothing, and the injected failure was never reached — so the test failed identically with and without the fix, which reads exactly like "the fix does not work". The test now polls `daemon.status` until it reports `attached` first.

- Without the fix: ✖ fails
- With the fix: ✔ passes

## Verification

Local daemon integration shards. Shards 4 and 2 were re-run against the second commit:

| shard | tests | pass | fail | run |
|---|---|---|---|---|
| 1 | 43 | 43 | 0 | first commit |
| 2 | 145 | 145 | 0 | **second commit** |
| 3 | 189 | 189 | 0 | first commit |
| 4 | 141 | 141 | 0 | **second commit** |
| 6 | 154 | 152 | 0 (2 skipped) | first commit |

Shard 4 carries the `platform stop …` test this PR fixes; shard 2 carries the two tests CI reported alongside it.

Shard 5 fails locally, and an A/B control shows it is **not** caused by this change: with the change `exit 1 after 1009.0s`, on the stashed clean baseline `exit 1 after 1005.0s` — identical timings, with no test-level assertion on either side, so it is an environment/timeout failure of the shard runner on this machine.

`npm run typecheck`: exit 0.

## Lint

The third commit is a lint fix, not a behaviour change. `ha/no-swallowed-failure` rejected the bare `catch {}` in `settleTeardownStep` — a caught failure may neither rethrow nor go undeclared. That rule guards exactly the class of bug this PR is fixing, so it should not be disabled; the helper now calls the kernel's `consumeKnownError(error)` to declare the swallow as intentional, which is what `schedule-scheduler` and `repo-writer-worker` already do in this package. `npx eslint packages/daemon/src/runtime.ts`: exit 0.

---

# 中文

## 问题

`main` 的 `rewrite-ci` 已连续多个提交红在同一条测试上：

```
✖ platform stop during a long migration replay exits the daemon in bounded time and releases every lock
  AssertionError: stop exit must release the singleton lock
    actual:   true      // 锁仍被持有
    expected: false
```

分片编号在 24 与 26 之间轮换、横跨多个互不相关的合入点、中间还夹着一次绿——是负载相关的竞态，不是某次改动的回归。

## 根因

`runtime.ts` 的 stop 序列把拆除步骤放在了 drain 的 await **之后**：

```ts
await host!.close();          // ← 长迁移重放在这里失败…
lifecycle.record(...);
await transport!.stop();
await connLog.settle();
rmSync(pidPath, { force: true });   // ← …底下全部跳过
singleton.release();
```

任何一步拒绝，锁就被一个已经不在的进程持有，下一个 daemon 永远 claim 不到。该函数上方的注释本来就写明了不变量——「endpoint、pid file 与 lock 一起释放：观察者要么看到一个能自述的 daemon，要么什么都看不到」——错误路径违反了它自己的注释。

## 第一版方向对、范围不够

第一个提交只把 `rmSync(pidPath)` 与 `singleton.release()` 移进了 `finally`。CI 随后报了**同一条测试**红在**另一条断言**上：

```
AssertionError: stop exit must remove the socket
  actual:   true
  expected: false
```

这恰恰说明修复生效了、而范围划小了：锁释放之后，不变量承诺的下一样东西——socket——仍被搁浅，因为 `transport.stop()` **也是**拆除，却还留在 `try` 里。

## 修法

只有 drain 属于 `try`。它下面每一步都是拆除，而它上面那条不变量是无条件的：

```ts
try {
  await host!.close();
} finally {
  lifecycle.record({ event: "process_exit", outcome });
  await settleTeardownStep(() => transport!.stop());
  await settleTeardownStep(() => connLog.settle());
  rmSync(pidPath, { force: true });
  singleton.release();
}
```

每一个拆除步骤**各自**再守护一层，因为其中一步失败不能把它后面的步骤一起搁浅——半释放的 daemon 正是这整段注释存在的理由。`settleTeardownStep` 吞掉步骤自身的拒绝，好让 drain 的拒绝仍是那个向外传播的。`singleton.release` 走的是 `releaseIfHeld`，本身幂等，重复调用安全。

## 阴性对照

新增测试注入一个 `close()` 抛错的 cell，断言锁文件、pid 文件与 socket 三者都已消失。

一个值得记下的坑：第一版测试在 `startDaemon` 之后立刻调 `stop()`，附着还没落地，cell 注册表是空的，`host.close()` 什么也没关，注入的失败根本到不了——于是测试在修复前后同样红，看起来完全就是「这个修复不管用」。现在测试会先轮询 `daemon.status` 直到它报 `attached`。

- 不带修复：✖ 红
- 带修复：✔ 绿

## 验证

本地跑 daemon 集成分片。shard 4 与 shard 2 是对着第二个提交重跑的：

| 分片 | tests | pass | fail | 对应提交 |
|---|---|---|---|---|
| 1 | 43 | 43 | 0 | 第一个提交 |
| 2 | 145 | 145 | 0 | **第二个提交** |
| 3 | 189 | 189 | 0 | 第一个提交 |
| 4 | 141 | 141 | 0 | **第二个提交** |
| 6 | 154 | 152 | 0（2 skipped）| 第一个提交 |

shard 4 装着本 PR 要修的 `platform stop …` 那条测试；shard 2 装着 CI 与它一起报红的另外两条。

shard 5 在本地红，A/B 对照证明**与本改动无关**：带改动 `exit 1 after 1009.0s`，stash 掉改动的干净基线 `exit 1 after 1005.0s`，两侧耗时一致且都没有任何测试级断言，是该机器上分片 runner 的环境/超时失败。

`npm run typecheck`：exit 0。

## Lint

第三个提交是 lint 修复，不是行为改动。`ha/no-swallowed-failure` 拦下了 `settleTeardownStep` 里的裸 `catch {}`——捕获的失败不能既不 rethrow 也不声明消费。这条规则防的正是本 PR 在修的那类问题，所以不该 disable；helper 改为调用 kernel 的 `consumeKnownError(error)` 显式声明这次吞是有意的，本包内 `schedule-scheduler`、`repo-writer-worker` 已是同一写法。`npx eslint packages/daemon/src/runtime.ts`：exit 0。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

