### PR TITLE
fix(gui): keep the terminal writing after output hits the retention cap

### DIFF
--- a/packages/gui/src/renderer/components/terminal/TerminalPane.tsx
+++ b/packages/gui/src/renderer/components/terminal/TerminalPane.tsx
@@ -17,7 +17,8 @@ import { t } from "../../i18n/index.tsx";
  * 输入/输出接到 rebuild 的 daemon 直连 PTY 流)。
  *
  * - 输出:daemon attach 流经 terminal-model 聚成 output 字符串,本组件按
- *   增量写入 xterm;output 因滚动上限被截短(reset)时整屏重写。
+ *   增量写入 xterm。游标用单调的 outputBytes 而不是 output.length——output 到达
+ *   截短上限后长度恒定,用它做游标会让写入永久停止。
  * - 输入:onData → onInput(utf8),由 Dock 携带 clientSeq 串行发 daemon。
  * - 尺寸:ResizeObserver → FitAddon.fit → onFit(cols, rows),Dock 负责
  *   resize receipt;键盘输入焦点在面板自身,行式输入表单退役。
@@ -26,6 +27,7 @@ import { t } from "../../i18n/index.tsx";
  */
 export function TerminalPane({
   output,
+  outputBytes,
   interactive,
   onInput,
   onFit,
@@ -34,6 +36,7 @@ export function TerminalPane({
   onSelectionChange,
 }: {
   readonly output: string;
+  readonly outputBytes: number;
   readonly interactive: boolean;
   readonly onInput: (utf8: string) => void;
   readonly onFit: (cols: number, rows: number) => void;
@@ -178,19 +181,23 @@ export function TerminalPane({
     );
   };
 
-  // 增量写屏;output 缩短(模型截短)时 reset 后整屏重写。
+  // 增量写屏。游标是会话产出的总字节数,单调递增;`output` 被截短上限压住后长度不再增长,
+  // 拿它当游标会让两个分支同时为假,终端在越过上限的那一刻永久停止更新。
   useEffect(() => {
     const terminal = terminalRef.current;
     if (!terminal) return;
-    if (writtenRef.current > output.length) {
+    if (outputBytes < writtenRef.current) {
+      // 会话被重建(计数归零),而不是历史被截短。截短不该 reset:xterm 自己的 scrollback
+      // 已经持有那些行,重写只会清空用户的滚动历史。
       terminal.reset();
       writtenRef.current = 0;
     }
-    if (output.length > writtenRef.current) {
-      terminal.write(output.slice(writtenRef.current));
-      writtenRef.current = output.length;
-    }
-  }, [output]);
+    const pending = outputBytes - writtenRef.current;
+    if (pending <= 0) return;
+    // 单帧产出超过截短上限时只写得到保留的部分;此外 pending 恒 <= output.length。
+    terminal.write(pending >= output.length ? output : output.slice(-pending));
+    writtenRef.current = outputBytes;
+  }, [output, outputBytes]);
 
   return (
     <div className="flex min-h-0 flex-1 flex-col bg-surface p-1">

--- a/packages/gui/src/renderer/components/terminal/TerminalPaneCard.tsx
+++ b/packages/gui/src/renderer/components/terminal/TerminalPaneCard.tsx
@@ -169,6 +169,7 @@ function LivePane({
         <ErrorBoundary>
           <TerminalPane
             output={tab.output}
+            outputBytes={tab.outputBytes}
             interactive={interactive}
             openUrl={actions.openUrl}
             onOpenLink={(match, text) => actions.openLink(match, text, tab.cwd)}

--- a/packages/gui/src/renderer/terminal-model.ts
+++ b/packages/gui/src/renderer/terminal-model.ts
@@ -6,6 +6,9 @@ export interface TerminalTab {
   readonly attachmentId: string | null;
   readonly lastSeq: number;
   readonly output: string;
+  // Monotonic count of every byte the session has ever produced. `output` is capped and therefore
+  // stops growing, so its length cannot be used to track what has been rendered.
+  readonly outputBytes: number;
   readonly notice: string | null;
   readonly cwd: string;
   readonly requestedBackend: "direct-pty" | "tmux";
@@ -47,7 +50,13 @@ export function reduceTerminalStream(tab: TerminalTab, frame: TerminalStreamFram
   if (frame.kind === "exit")
     return { ...tab, state: "exited", lastSeq: frame.seq, notice: skipped ?? "Process exited; this tab is read-only." };
   const output = `${tab.output}${frame.utf8}`;
-  return { ...tab, lastSeq: frame.seq, output: output.slice(-131_072), notice: skipped ?? tab.notice };
+  return {
+    ...tab,
+    lastSeq: frame.seq,
+    output: output.slice(-131_072),
+    outputBytes: tab.outputBytes + frame.utf8.length,
+    notice: skipped ?? tab.notice,
+  };
 }
 
 export function reconcileTerminalGeneration(

--- a/packages/gui/src/renderer/views/TerminalView.tsx
+++ b/packages/gui/src/renderer/views/TerminalView.tsx
@@ -690,6 +690,7 @@ function tabFromRow(
     attachmentId: null,
     lastSeq: existing?.lastSeq ?? afterSeq,
     output: existing?.output ?? "",
+    outputBytes: existing?.outputBytes ?? 0,
     notice: existing?.notice ?? null,
     cwd: row.cwd,
     requestedBackend: row.requestedBackend,

--- a/packages/gui/test/terminal-renderer.vitest.ts
+++ b/packages/gui/test/terminal-renderer.vitest.ts
@@ -24,6 +24,7 @@ const tab: TerminalTab = {
   attachmentId: "attach-a",
   lastSeq: 2,
   output: "ready\n",
+  outputBytes: 6,
   notice: null,
   cwd: ".",
   requestedBackend: "direct-pty",
@@ -52,6 +53,29 @@ describe("terminal renderer control", () => {
     expect(terminate).not.toHaveBeenCalled();
     expect(await requestTerminalTermination("repo-a", tab, true, { terminate })).toEqual({ state: "requested" });
     expect(terminate).toHaveBeenCalledWith("repo-a", "terminal-a", true);
+  });
+
+  it("keeps counting produced bytes after output hits the retention cap", () => {
+    const cap = 131_072,
+      frame = (seq: number, utf8: string) =>
+        ({
+          schema: "terminal-attach-event/v1",
+          sessionId: "terminal-a",
+          seq,
+          kind: "output",
+          utf8,
+          droppedThrough: null,
+          occurredAt: "2026-01-01T00:00:00.000Z",
+        }) as const;
+    // Fill to the cap, then keep going. `output` stops growing here; `outputBytes` must not,
+    // because the pane uses it to decide what still needs to reach xterm. When it stopped, the
+    // terminal froze permanently at the moment the cap was crossed.
+    const filled = reduceTerminalStream(tab, frame(3, "x".repeat(cap)));
+    expect(filled.output.length).toBe(cap);
+    const after = reduceTerminalStream(filled, frame(4, "later"));
+    expect(after.output.length).toBe(cap);
+    expect(after.outputBytes).toBe(filled.outputBytes + 5);
+    expect(after.output.endsWith("later")).toBe(true);
   });
 
   it("surfaces sequence gaps and daemon backpressure instead of presenting continuous output", () => {


### PR DESCRIPTION
# English

## Summary

The GUI terminal stopped updating permanently once a session had produced 128 KB of output, and scrolling up never came back. Reported from real use: "I scroll up and can't get back, then it's all frozen — it does this when I use the Claude Code TUI."

`TerminalPane` tracked rendered content by comparing `output.length` against a cursor. `terminal-model` caps `output` at `slice(-131_072)`, so once a session crossed that, `output.length` became a constant and **both branches went false at the same time**: `writtenRef > output.length` is false so nothing resets, and `output.length > writtenRef` is false so nothing is written. The terminal froze at the exact moment the cap was crossed. A TUI like Claude Code reaches 128 KB quickly, which is why it showed up there first.

## Architectural Justification

Not required: churn is 36 lines, under the 200-line threshold.

## What Changed

- `terminal-model.ts`: `TerminalTab` gains `outputBytes`, a monotonic count of every byte the session has produced. The cap trims `output`; it does not touch this counter.
- `TerminalPane.tsx`: the write cursor is now `outputBytes`. Truncation **no longer resets the terminal** — xterm's own 10 000-line scrollback already holds those lines, and resetting threw away the user's scroll history every time it fired.
- `TerminalView.tsx`, `TerminalPaneCard.tsx`: initialise and thread the new field.

## Two defects, one cause

The freeze and the lost scrollback are the same root cause seen from two sides. `output.length` is not a valid cursor for a value that is deliberately capped — the moment it saturates, it reports "nothing new" forever, and the branch written to handle truncation both fires at the wrong times and does damage when it fires. Counting produced bytes removes the need for that branch to guess.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none

## Machine-Readable Declarations

Production-Delta: +27/-9

## Task And Scope

- Harness task: task_11ae90e7a1354888c75125bb5c
- Evidence: `F-1200BCA2`
- Out of scope: the 128 KB retention cap itself is unchanged. Reattaching a long-lived session still replays only the last 128 KB; that is a separate question about how much transcript the model should hold.

## Version Impact

- Version: no change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Machine-check boundary: this PR asserts the declaration exists.
- Break-glass: no

## Verification

- Base `origin/main`: 17495103d
- `npm run test:gui` → **85 files, 836 tests passed**
- New regression test: fill to the cap, push more, assert `output.length` stays at the cap while `outputBytes` keeps climbing and the tail is the newest bytes.
- **Negative control:** reverting `outputBytes` to the capped length turns exactly that test red and leaves the other nine in the file green. Restoring returns to 10.
- `line-density` pass; `production-delta` computed `+27/-9`.
- **Not verified by me:** that the frozen terminal is fixed in the running app. The reproduction and the fix are both at the model/pane boundary; confirming it in a real Claude Code TUI session is user acceptance, and it has not happened yet.

## Review Evidence

- Root cause was derived from the source and then reproduced with a standalone script before any code was changed: crossing the cap yields `output=131072 written=131062` (one last write), and every frame after that yields `write=false reset=false`.
- Human review: pending.

## Residual Risk

- If a single frame ever exceeds 128 KB, the pane writes only the retained tail; bytes beyond the cap in that one frame are lost to the display. That was already true and is now explicit in the code.
- `outputBytes` counts UTF-16 code units (JS string length), same unit the cap uses. It is a cursor, not a byte-accurate accounting of the PTY stream.

---

# 中文

## 摘要

GUI 终端在会话产出 128 KB 输出后永久停止更新，往上滚也回不来。来自实际使用的报告：「我往上滚就滚不回来，然后都卡住了，用 Claude Code TUI 的时候就这样。」

`TerminalPane` 用 `output.length` 与游标的大小关系判断该写什么。而 `terminal-model` 用 `slice(-131_072)` 把 `output` 压在上限上，于是越过上限之后 `output.length` 变成常量，**两个分支同时为假**：`writtenRef > output.length` 为假所以不 reset，`output.length > writtenRef` 也为假所以不写入。终端就在越线的那一刻冻结。Claude Code 这类 TUI 很快就能产出 128 KB，所以在它身上最先暴露。

## 架构辩护

不适用：churn 为 36 行，低于 200 行阈值。

## 改动内容

- `terminal-model.ts`：`TerminalTab` 增加 `outputBytes`——会话产出过的总字节数，单调递增。上限只修剪 `output`，不碰这个计数器。
- `TerminalPane.tsx`：写入游标改为 `outputBytes`。截短**不再 reset 终端**——xterm 自己的一万行 scrollback 已经持有那些行，而每次 reset 都会把用户的滚动历史清空。
- `TerminalView.tsx`、`TerminalPaneCard.tsx`：初始化并传递新字段。

## 两个症状，同一个成因

冻结和滚动历史丢失是同一根因的两面。对一个被刻意截短的值来说，`output.length` 不是合法的游标——它一旦饱和就永远报告「没有新内容」；而那个本该处理截短的分支既在错误的时机触发，触发时又造成破坏。改成计数产出字节，这个分支就不需要再去猜。

## 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none

## 任务与范围

- Harness task：task_11ae90e7a1354888c75125bb5c
- 证据：`F-1200BCA2`
- 不在范围内：128 KB 保留上限本身未改。重新挂载长会话仍然只回放最后 128 KB；那是「模型该持有多少转录」的另一个问题。

## 版本影响

- 版本：不变
- 发布影响：不发布

## 治理声明

- 是否触碰 protected surface：否
- 机器检查边界：本 PR 声明该字段存在。
- Break-glass：否

## 验证

- Base `origin/main`：17495103d
- `npm run test:gui` → **85 个文件、836 个测试通过**
- 新增回归测试：灌满到上限后继续推送，断言 `output.length` 停在上限而 `outputBytes` 继续增长、且尾部是最新字节。
- **阴性对照**：把 `outputBytes` 改回截短后的长度，恰好该测试转红、同文件其余九条保持绿；恢复后回到 10 条通过。
- `line-density` 通过；`production-delta` 实测 `+27/-9`。
- **我没有验证的**：运行中的应用里终端确实不再冻结。复现与修复都在 model/pane 边界上做的；在真实的 Claude Code TUI 会话里确认属于使用性验收，尚未发生。

## 评审证据

- 根因先从源码推出、再用独立脚本复现，之后才动代码：越线那一帧得到 `output=131072 written=131062`（还能写最后一次），此后每一帧都是 `写入=false reset=false`。
- 人工评审：待进行。

## 残留风险

- 若单帧产出超过 128 KB，pane 只写得到保留的尾部，该帧超出上限的字节在显示上丢失。这在改动前就成立，现在只是在代码里写明了。
- `outputBytes` 计的是 UTF-16 code unit（JS 字符串长度），与上限用的是同一单位。它是游标，不是对 PTY 流的精确字节记账。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018pZepLwmGbrSYzkjLyvBdd

