### PR TITLE
test(daemon): await terminal settlement outcome event

### DIFF
--- a/packages/daemon/test/runtime-spawn-lifecycle.integration.test.ts
+++ b/packages/daemon/test/runtime-spawn-lifecycle.integration.test.ts
@@ -580,23 +580,16 @@ test("attached task runtime settlement releases its execution lease before publi
       });
       assert.ok(exit, "runtime exit listener must be attached before the provider exits");
       exit(0);
-      await eventually(() => {
-        const events = makeTaskEventReader({ repoId: "runtime-attached-tail", rootDir: root }).read().events;
-        return (
-          events.some(
+      const events = await eventuallyValue(() => {
+          const events = makeTaskEventReader({ repoId: "runtime-attached-tail", rootDir: root }).read().events;
+          return events.some(
             (event) =>
               event.type === "runtime_session_outcome_observed" &&
               event.payload.runtimeSessionId === receipt.runtimeSessionId,
-          ) &&
-          events.some(
-            (event) =>
-              event.type === "lease_released" &&
-              event.taskId === taskId &&
-              event.payload.execution.executionId === executionId,
           )
-        );
-      });
-      const events = makeTaskEventReader({ repoId: "runtime-attached-tail", rootDir: root }).read().events,
+            ? events
+            : null;
+        }),
         outcomeIndex = events.findIndex(
           (event) =>
             event.type === "runtime_session_outcome_observed" &&


### PR DESCRIPTION
# English

## Summary

`runtime-spawn-lifecycle.integration` went red twice in one day on "attached task runtime settlement releases its execution lease before publishing the terminal outcome" (#2235 shard 4, main 6b24c642f full-check(24)) with `outcome unknown ≠ succeeded`. The test polled for *both* `lease_released` and `runtime_session_outcome_observed` and then re-read the stream once more, so a settlement that landed between the poll and the re-read was observed half-written. The completion signal is now the terminal outcome event alone; the ordering assertion (lease released before outcome published) is evaluated on the same snapshot that satisfied the wait.

## What Changed

- `packages/daemon/test/runtime-spawn-lifecycle.integration.test.ts`: wait with `eventuallyValue` for the `runtime_session_outcome_observed` event of this runtime session and keep that event list for the ordering assertions; drop the second unconditional read and the joint release/outcome poll.
- Negative control (temporary, reverted): delaying settlement by 250 ms makes an immediate read fail as `live/null`, while the event wait still yields `exited/succeeded`.
- Target file green 5 consecutive runs before commit and 6/6 after; the "timeout forcibly reaps a child that ignores SIGTERM" case is already covered by 926c16689 on main.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: use the single CI-backed `Production-Delta` declaration below; do not enter a second metric.

## Machine-Readable Declarations

Production-Delta: +0/-0

## Task And Scope

- Harness task: task_b535f6468711bede93ec59306f (under the flaky-test line task_f9443002d6d995489ebf082911)
- Branch: codex/settlement-flake
- Public scope: one integration test file
- Private planning/evidence updated: yes
- Out of scope: settlement production code; the fleet race cases tracked by task_f9443002

## Version Impact

- Version: no version change because this is a test-only change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none

## Verification

- `npm test -- --tier integration --file packages/daemon/test/runtime-spawn-lifecycle.integration.test.ts` ×5 before commit, ×6 after: all green
- lint, line-density, file-complexity, production-delta (+0/-0): pass

## Review Evidence

- CEO semantic review: the wait now keys on the single terminal signal, and the lease-before-outcome ordering is asserted on that snapshot instead of on a second read, so a slow settlement can no longer be observed half-way. Negative control confirms the wait is doing work.

## Residual Risk

- Test-only; if settlement ordering ever regresses, this assertion turns red for a real reason.

---

# 中文

## 摘要

`runtime-spawn-lifecycle.integration` 里的「attached task runtime settlement releases its execution lease before publishing the terminal outcome」一天内两次假红(#2235 shard 4、main 6b24c642f full-check(24)),报 `outcome unknown ≠ succeeded`。原用例同时轮询 `lease_released` 与 `runtime_session_outcome_observed` 两个事件,轮询通过后又无条件重读一次事件流,settlement 恰好落在两次读之间时就被读到半截。现在完成信号只剩 terminal outcome 事件一个;「先释放 lease 再发布 outcome」的顺序断言直接在满足等待的那份快照上判。

## 改了什么

- `packages/daemon/test/runtime-spawn-lifecycle.integration.test.ts`:用 `eventuallyValue` 等本 runtime session 的 `runtime_session_outcome_observed`,并把那份事件列表留给顺序断言;删除第二次无条件读取与联合轮询。
- 阴性对照(临时改动,已撤销):把 settlement 延迟 250ms,立即读取臂报 `live/null`,事件等待仍得到 `exited/succeeded`。
- 目标文件提交前连续 5 次、提交后 6/6 全绿;「timeout forcibly reaps a child that ignores SIGTERM」一例已由 main 上的 926c16689 覆盖。

## 任务与范围

- Harness task:task_b535f6468711bede93ec59306f(挂在假红专线 task_f9443002d6d995489ebf082911 下)
- 分支:codex/settlement-flake
- 公开范围:一个集成测试文件
- 私有规划/证据已更新:是
- 范围外:settlement 生产代码;task_f9443002 跟踪的 fleet 竞态用例

## 版本影响

- 版本:无变化(纯测试改动)
- 发布影响:不发布

## 治理声明

- 触碰受保护面:否
- 受保护面范围:无

## 验证

- 目标文件提交前 ×5、提交后 ×6 全绿;lint、line-density、file-complexity、production-delta(+0/-0)通过

## 评审证据

- CEO 语义复核:等待只认唯一的终态信号,顺序断言在同一快照上判而不是二次读,慢 settlement 不再被读到半截;阴性对照证明等待在起作用。

## 残余风险

- 纯测试改动;若 settlement 顺序真回归,这条断言会因真实原因转红。
