### PR TITLE
fix(daemon): preserve task identity scan failures

### DIFF
--- a/packages/daemon/src/repo-cell-receipts.ts
+++ b/packages/daemon/src/repo-cell-receipts.ts
@@ -199,29 +199,16 @@ export function projectedTaskIds(cell: ProjectedTaskIdsContext): Set<string> {
   }
   const taskIds = new Set<string>();
   let cursor: string | null = null;
-  try {
-    for (;;) {
-      const batch = cell.store.readBatch(cursor, 4096) as {
-        readonly events: readonly CanonicalEventV1[];
-        readonly cursor: string | null;
-        readonly done: boolean;
-      };
-      for (const event of batch.events) if (isTaskEvent(event)) taskIds.add(event.taskId);
-      if (batch.done) break;
-      if (batch.cursor === cursor) throw new Error("canonical task event scan did not advance");
-      cursor = batch.cursor;
-    }
-  } catch {
-    throw cell.cellCodedError(
-      "content_not_ready",
-      [
-        "Task projection is catching up from revision ",
-        `${read.watermark}`,
-        " to ",
-        `${read.sourceRevision}`,
-        "; task identity cannot be determined until the canonical event stream is readable.",
-      ].join(""),
-    );
+  for (;;) {
+    const batch = cell.store.readBatch(cursor, 4096) as {
+      readonly events: readonly CanonicalEventV1[];
+      readonly cursor: string | null;
+      readonly done: boolean;
+    };
+    for (const event of batch.events) if (isTaskEvent(event)) taskIds.add(event.taskId);
+    if (batch.done) break;
+    if (batch.cursor === cursor) throw new Error("canonical task event scan did not advance");
+    cursor = batch.cursor;
   }
   cell.knownTaskIds = taskIds;
   return cell.knownTaskIds;

--- a/packages/daemon/test/repo-cell-latch-recovery.test.ts
+++ b/packages/daemon/test/repo-cell-latch-recovery.test.ts
@@ -42,6 +42,26 @@ test("task identity lookup remains available while the projection catches up", (
   assert.deepEqual([...projectedTaskIds(cell)], ["task-existing"]);
 });
 
+test("task identity lookup preserves a canonical scan failure while the projection catches up", () => {
+  const scanFailure = Object.assign(new Error("canonical event object is unavailable"), { code: "invalid_store" }),
+    cell = {
+      knownTaskIds: null,
+      projection: { list: () => ({ watermark: 2, sourceRevision: 4, rows: [] }) },
+      store: {
+        readBatch: () => {
+          throw scanFailure;
+        },
+      },
+      cellCodedError,
+    };
+
+  assert.throws(
+    () => projectedTaskIds(cell),
+    (error: unknown) => error === scanFailure,
+  );
+  assert.equal(cell.knownTaskIds, null);
+});
+
 test("projection recovery names and carries the reachable rebuild command", () => {
   assert.equal(causeClassOf(new Error("lifecycle document projection mismatch for INDEX.md")), "projection");
   assert.equal(


### PR DESCRIPTION
# English

## Summary

`ha task start` / `ha runtime run` intermittently rejected tasks that already had a failed dispatch with `content_not_ready` (and downstream `task_not_found`). The cause was in `projectedTaskIds`: while the task projection is catching up it scans the canonical event stream, and a `try/catch` around that scan rewrote *every* failure — including a real `invalid_store` from `readBatch` — into "projection is catching up", so the caller retried forever against a store that was actually broken. The rewrite is deleted: a scan failure now propagates with its own code and message, and `knownTaskIds` is left unset so the next call re-scans instead of caching a half-built set.

## What Changed

- `packages/daemon/src/repo-cell-receipts.ts`: remove the catch-and-rewrite around the canonical scan in `projectedTaskIds`; the scan loop itself is unchanged.
- `packages/daemon/test/repo-cell-latch-recovery.test.ts`: new deterministic case — a lagging projection cut plus an injected `invalid_store` scan failure must surface that exact error object and leave the cache empty.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: use the single CI-backed `Production-Delta` declaration below; do not enter a second metric.

## Machine-Readable Declarations

Production-Delta: +10/-23

## Task And Scope

- Harness task: task_9a5f18a94206a170d973d6168a
- Branch: codex/task-start-race
- Public scope: daemon task-identity readiness path and its latch-recovery test
- Private planning/evidence updated: yes
- Out of scope: task lifecycle validation; projection readiness waiters

## Version Impact

- Version: no version change because this is a daemon bug fix with no contract change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none

## Verification

- `node --test --test-name-pattern='task identity lookup preserves a canonical scan failure while the projection catches up' packages/daemon/test/repo-cell-latch-recovery.test.ts`: 1 pass
- eslint on the two touched files, `npm run typecheck`, `npm run lint`, G36 line-density, canonical-event-compat (171 samples), gate tests 185/185, test-selection, file-complexity, G33: pass

## Review Evidence

- CEO semantic review: the plan offered "wait for readiness or report the real cause"; the worker chose the latter with a stated reason (the sync helper would otherwise grow a second async retry layer). Deleting the rewrite is the smaller diff and turns a misleading `content_not_ready` into the real store error. Accepted.

## Residual Risk

- If the canonical store is genuinely unreadable for a moment, the command now fails with the store's own error instead of being disguised; callers see the true cause. No end-to-end replay against the original `drg-hospital-platform` history was done (worker-reported unverified).

---

# 中文

## 摘要

`ha task start` / `ha runtime run` 在已有失败派工的任务上间歇报 `content_not_ready`(下游再变成 `task_not_found`)。根因在 `projectedTaskIds`:投影落后时它扫描 canonical 事件流,而包住扫描的 `try/catch` 把**一切**失败——包括 `readBatch` 抛出的真实 `invalid_store`——都改写成「投影正在追赶」,调用方于是对一个真坏了的 store 无限重试。本 PR 删掉这层改写:扫描失败原样传播自己的 code 与 message,`knownTaskIds` 保持未设置,下次调用重新扫描而不是缓存半截集合。

## 改了什么

- `packages/daemon/src/repo-cell-receipts.ts`:删除 `projectedTaskIds` 里对 canonical 扫描的 catch-and-rewrite;扫描循环本身不变。
- `packages/daemon/test/repo-cell-latch-recovery.test.ts`:新增确定性用例——落后的 projection cut + 注入的 `invalid_store` 扫描失败,必须原样抛出同一个 error 对象,且缓存为空。

## 任务与范围

- Harness task:task_9a5f18a94206a170d973d6168a
- 分支:codex/task-start-race
- 公开范围:daemon task identity 就绪路径与其 latch-recovery 测试
- 私有规划/证据已更新:是
- 范围外:task 生命周期校验;projection readiness waiter

## 版本影响

- 版本:无变化(daemon 缺陷修复,无契约变化)
- 发布影响:不发布

## 治理声明

- 触碰受保护面:否
- 受保护面范围:无

## 验证

- 新增用例定向运行 1 pass;eslint、typecheck、lint、G36、canonical-event-compat、gate tests 185/185、test-selection、file-complexity、G33 通过

## 评审证据

- CEO 语义复核:plan 给了「等就绪或报真实原因」两条路,worker 选后者并说明理由(同步 helper 若接异步 waiter 会长出第二层重试)。删改写是更小的 diff,把误导性的 `content_not_ready` 换成 store 的真实错误。接受。

## 残余风险

- canonical store 真的短暂不可读时,命令现在以 store 自己的错误失败而不是被伪装;调用方看到真实原因。未在原始 `drg-hospital-platform` 历史上做端到端复现(worker 报 unverified)。
