### PR TITLE
fix: allow empty task cancellation without force

### DIFF
--- a/packages/daemon/src/task-action-catalog-runtime.ts
+++ b/packages/daemon/src/task-action-catalog-runtime.ts
@@ -322,12 +322,28 @@ function taskActionFailure(
   const failure = actionCriterionFailure(error);
   if (!contract || failure?.actionId !== contract.id) return null;
   const evaluation = evaluations.find(({ criterionRef }) => criterionRef === failure.criterionRef),
-    rejected = cell.failed(
+    failed = cell.failed(
       cell.errorOperationId(error) ?? cell.operationId(action, binding, cell.input.repoId, revision),
       error,
       contract,
       action,
-    );
+    ),
+    missingCancellationField = cancellationMissingField(action, error),
+    rejected = missingCancellationField
+      ? {
+          ...failed,
+          diagnostic: {
+            kind: "validation" as const,
+            entity: "task-transition",
+            field: missingCancellationField,
+            actual: "missing",
+            expectation:
+              missingCancellationField === "reason"
+                ? "a non-empty cancellation reason"
+                : "--force after execution has started",
+          },
+        }
+      : failed;
   return taskActionRejection(
     cell,
     action,
@@ -404,4 +420,15 @@ function invocationCriterionRef(contract: EntityActionContract): string {
 function isTaskLifecycleContractError(error: unknown): error is Error & { readonly issues: readonly unknown[] } {
   if (!(error instanceof Error) || error.name !== "TaskLifecycleContractError") return false;
   return Array.isArray((error as Error & { readonly issues?: unknown }).issues);
+}
+
+function cancellationMissingField(action: RepoTaskAction, error: unknown): "reason" | "force" | null {
+  if (action.kind !== "task-transition" || action.status !== "cancelled") return null;
+  if (typeof action.reason !== "string" || !action.reason.trim()) return "reason";
+  return isTaskLifecycleContractError(error) &&
+    error.issues.some(
+      (issue) => issue && typeof issue === "object" && "code" in issue && issue.code === "force_reason_required",
+    )
+    ? "force"
+    : null;
 }

--- a/packages/daemon/src/task-action-catalog-runtime.ts
+++ b/packages/daemon/src/task-action-catalog-runtime.ts
@@ -422,13 +422,12 @@ function isTaskLifecycleContractError(error: unknown): error is Error & { readon
   return Array.isArray((error as Error & { readonly issues?: unknown }).issues);
 }
 
+// The kernel cancel rule is the single source: it emits `missing_field` for an empty reason and
+// `force_reason_required` once execution has started. The handler only names the field.
 function cancellationMissingField(action: RepoTaskAction, error: unknown): "reason" | "force" | null {
-  if (action.kind !== "task-transition" || action.status !== "cancelled") return null;
-  if (typeof action.reason !== "string" || !action.reason.trim()) return "reason";
-  return isTaskLifecycleContractError(error) &&
-    error.issues.some(
-      (issue) => issue && typeof issue === "object" && "code" in issue && issue.code === "force_reason_required",
-    )
-    ? "force"
-    : null;
+  if (action.kind !== "task-transition" || !isTaskLifecycleContractError(error)) return null;
+  const codes = new Set(
+    error.issues.map((issue) => (issue && typeof issue === "object" && "code" in issue ? String(issue.code) : "")),
+  );
+  return codes.has("missing_field") ? "reason" : codes.has("force_reason_required") ? "force" : null;
 }

--- a/packages/daemon/test/task-surface-status-archive.integration.test.ts
+++ b/packages/daemon/test/task-surface-status-archive.integration.test.ts
@@ -4,6 +4,7 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
+import { realizeTaskPlanFixture } from "../../../tools/fixtures/task-plan.mjs";
 import {
   makeTaskEventReader,
   makeTaskEventStore,
@@ -47,12 +48,18 @@ test("cancellation and reinstatement are audited and terminal tasks require supe
     );
     assert.equal(bareCancellation.outcome, "op_rejected");
     assert.equal(bareCancellation.code, "missing_field");
+    assert.deepEqual(bareCancellation.diagnostic, {
+      kind: "validation",
+      entity: "task-transition",
+      field: "reason",
+      actual: "missing",
+      expectation: "a non-empty cancellation reason",
+    });
     const cancelled = await cell.run(
       {
         kind: "task-transition",
         taskId: "task_terminal",
         status: "cancelled",
-        force: true,
         reason: "Audited cancellation after invalid scope",
       },
       binding,
@@ -105,6 +112,40 @@ test("cancellation and reinstatement are audited and terminal tasks require supe
       ).outcome,
       "applied",
     );
+    const leased = await cell.run(
+      {
+        kind: "task-create",
+        taskId: "task_leased",
+        title: "Leased terminal",
+        profileId: "baseline",
+      },
+      binding,
+    );
+    await realizeTaskPlanFixture(rootDir, String(leased.packagePath), (planPath) =>
+      cell!.run({ kind: "doc-submit", paths: [planPath] }, binding),
+    );
+    assert.equal(
+      (await cell.run({ kind: "task-start", taskId: "task_leased", executionId: "execution_leased" }, binding)).outcome,
+      "applied",
+    );
+    const leasedCancellation = await cell.run(
+      {
+        kind: "task-transition",
+        taskId: "task_leased",
+        status: "cancelled",
+        reason: "Cancellation requires execution confirmation",
+      },
+      binding,
+    );
+    assert.equal(leasedCancellation.outcome, "op_rejected");
+    assert.equal(leasedCancellation.code, "missing_field");
+    assert.deepEqual(leasedCancellation.diagnostic, {
+      kind: "validation",
+      entity: "task-transition",
+      field: "force",
+      actual: "missing",
+      expectation: "--force after execution has started",
+    });
     await cell.run(
       {
         kind: "task-archive",

--- a/packages/kernel/src/domain/task-lifecycle-command-transitions.ts
+++ b/packages/kernel/src/domain/task-lifecycle-command-transitions.ts
@@ -312,8 +312,12 @@ export const cancel: Transition = {
       issues = revisionIssues(snapshot, command);
     if (!allowsTaskStatusMove(snapshot, "cancelled"))
       issues.push(lifecycleContractIssue("invalid_transition", "CancelTask requires an unleased non-terminal task"));
-    if (!command.force || !isNonEmptyString(command.reason))
-      issues.push(lifecycleContractIssue("force_reason_required", "CancelTask requires force and an auditable reason"));
+    if (!isNonEmptyString(command.reason))
+      issues.push(lifecycleContractIssue("missing_field", "CancelTask requires an auditable reason"));
+    if (snapshot.executions.length > 0 && !command.force)
+      issues.push(
+        lifecycleContractIssue("force_reason_required", "CancelTask requires force after execution has started"),
+      );
     return issues;
   },
   reduce: (snapshot, raw) => transitionTask(snapshot, raw as TransitionTaskCommand, "cancelled"),

--- a/tools/gates/test/task-lifecycle-transitions.test.mjs
+++ b/tools/gates/test/task-lifecycle-transitions.test.mjs
@@ -248,7 +248,7 @@ test("G10 block, unblock, and cancel are catalog transitions while unrelated act
   assert.deepEqual(reduceTaskEvent(blocked.snapshot, cancelled.event), cancelled.snapshot);
   assert.throws(
     () => applyTransition(blocked.snapshot, transition(3, "cancelled", "", false), {}),
-    /force and an auditable reason/u,
+    /auditable reason/u,
   );
 
   const started = applyTransition(created.snapshot, start(2), startProof());


### PR DESCRIPTION
# English

## Summary

`ha task transition <id> cancelled` was rejected with `missing_field` and an empty diagnostic unless `--force` was passed — even for a planned task that nobody had ever started. The kernel validator required `force && reason` unconditionally and folded both into one `force_reason_required` issue, and the daemon receipt did not say which field was missing. Now a task with no execution history cancels with a non-empty reason alone; `--force` is required only once execution has started; and the rejection names the missing field (`reason` or `force`) with what is expected.

## What Changed

- `packages/kernel/src/domain/task-lifecycle-command-transitions.ts`: split the rule — `missing_field` when the reason is empty; `force_reason_required` only when `snapshot.executions.length > 0` and `force` is absent.
- `packages/daemon/src/task-action-catalog-runtime.ts`: cancellation rejections carry a structured `diagnostic` (`entity: task-transition`, `field: reason|force`, `actual: missing`, `expectation`).
- `packages/daemon/test/task-surface-status-archive.integration.test.ts`: covers reason-only cancellation of a planned task (`applied`), missing reason (`field: reason`), and a leased task without `--force` (`field: force`).

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: use the single CI-backed `Production-Delta` declaration below; do not enter a second metric.

## Machine-Readable Declarations

Production-Delta: +34/-4

## Task And Scope

- Harness task: task_96a6eb92443cbfba9e5ff13822
- Branch: codex/cancel-missing-field
- Public scope: kernel cancel transition rule, daemon cancellation diagnostics, status/archive integration test
- Private planning/evidence updated: yes
- Out of scope: the general "rejections carry no reason" line (task_89cc19f9 / task_ed3596218)

## Version Impact

- Version: no version change because the CLI flag surface is unchanged (`--force` stays optional)
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none

## Verification

- `npm test -- --tier integration --file packages/daemon/test/task-surface-status-archive.integration.test.ts`: 4/4 pass
- `npm run typecheck`, eslint on the three touched files, G36 line-density, G33 production-delta: pass

## Review Evidence

- CEO semantic review: `--force` now means what its name says — override after execution has started — instead of a ritual flag on every cancellation; the audited reason stays mandatory. The kernel rule is the single source; the daemon only translates it into a field-level diagnostic. Accepted.

## Residual Risk

- Callers that scripted `--force` on every cancellation keep working (the flag is still accepted). `ha task transition --help` was not re-generated because the flag surface did not change (worker-reported unverified).

---

# 中文

## 摘要

`ha task transition <id> cancelled` 不带 `--force` 就被 `missing_field` 拒收且诊断为空——哪怕是一个从未开工的 planned 任务。内核校验器无条件要求 `force && reason` 并把两者并成一条 `force_reason_required`,daemon 回执也不说缺哪个字段。现在:没有执行历史的任务只要非空 reason 即可取消;`--force` 只在执行已经开始后才要求;拒收回执点名缺失字段(`reason` 或 `force`)与期望。

## 改了什么

- `packages/kernel/src/domain/task-lifecycle-command-transitions.ts`:拆规则——reason 为空报 `missing_field`;仅当 `snapshot.executions.length > 0` 且无 `force` 时报 `force_reason_required`。
- `packages/daemon/src/task-action-catalog-runtime.ts`:取消类拒收带结构化 `diagnostic`(`entity: task-transition`、`field: reason|force`、`actual: missing`、`expectation`)。
- `packages/daemon/test/task-surface-status-archive.integration.test.ts`:覆盖 planned 任务仅凭 reason 取消(`applied`)、缺 reason(`field: reason`)、已租约任务不带 `--force`(`field: force`)。

## 任务与范围

- Harness task:task_96a6eb92443cbfba9e5ff13822
- 分支:codex/cancel-missing-field
- 公开范围:内核 cancel 转换规则、daemon 取消诊断、status/archive 集成测试
- 私有规划/证据已更新:是
- 范围外:「拒绝码不带原因」总线(task_89cc19f9 / task_ed3596218)

## 版本影响

- 版本:无变化(CLI flag 面不变,`--force` 仍可选)
- 发布影响:不发布

## 治理声明

- 触碰受保护面:否
- 受保护面范围:无

## 验证

- 目标集成测试 4/4;typecheck、eslint、G36、G33 通过

## 评审证据

- CEO 语义复核:`--force` 回到字面含义——执行已开始后的覆盖——而不是每次取消都要带的仪式 flag;可审计 reason 仍强制。规则单源在内核,daemon 只把它翻译成字段级诊断。接受。

## 残余风险

- 习惯每次都带 `--force` 的脚本不受影响(flag 仍接受)。`ha task transition --help` 未重新生成,因 flag 面未变(worker 报 unverified)。
