### PR TITLE
fix(gui): page the whole relation graph instead of consuming the first 500 edges

### DIFF
--- a/packages/gui/src/renderer/triadic-data.ts
+++ b/packages/gui/src/renderer/triadic-data.ts
@@ -195,6 +195,37 @@ export function useRuntimePlaneQuery(repoId: string | null, options: { readonly 
 }
 
 /**
+ * 完整图。daemon 的无参 `repo.triadic.relationGraph` 只给一页(上限 500 条边),而且
+ * facts / factAnchors / coverageRows 只随该页边的端点返回;领地与聚光灯渲染的是整张图,
+ * 500 条之外的 decision/fact 节点会整个消失。所以按 `nextCursor` 翻到底再合并,
+ * 各类行按各自主键去重;各页可能落在不同 cut 上,cut 字段以末页为准。
+ */
+export async function readWholeRelationGraph(
+  read: (payload: { readonly limit: number; readonly cursor?: string }) => Promise<RelationGraphSuccess>,
+): Promise<RelationGraphSuccess> {
+  const edges = new Map<string, ServedRelationEdgeRow>(),
+    coverageRows = new Map<string, RelationCoverageRow>(),
+    factAnchors = new Map<string, RelationGraphSuccess["factAnchors"][number]>(),
+    facts = new Map<string, RelationGraphSuccess["facts"][number]>();
+  let cursor: string | undefined, page: RelationGraphSuccess;
+  do {
+    page = await read(cursor === undefined ? { limit: 500 } : { limit: 500, cursor });
+    for (const row of page.edges) edges.set(row.relationId, row);
+    for (const row of page.coverageRows) coverageRows.set(`${row.decisionRef}\u0000${row.claimRef}`, row);
+    for (const row of page.factAnchors) factAnchors.set(row.factRef, row);
+    for (const row of page.facts) facts.set(row.ref, row);
+    cursor = page.page?.nextCursor ?? undefined;
+  } while (cursor !== undefined);
+  return {
+    ...page,
+    edges: [...edges.values()],
+    coverageRows: [...coverageRows.values()],
+    factAnchors: [...factAnchors.values()],
+    facts: [...facts.values()],
+  };
+}
+
+/**
  * 完整三元投影(图 + 决策)。**只有渲染它的视图挂载时才读**;
  * 总览只渲染决策流,因此调用方可单独关闭 graph。这里没有额外缓存层——
  * 省下的是"没人看的时候不请求",不是对同一个消费者降频。
@@ -208,7 +239,7 @@ export function useTriadicProjectionQuery(
   const decisionsEnabled = enabled && options.decisionsEnabled !== false;
   const graph = useQuery({
     queryKey: triadicQueryKeys.graph(repoId ?? "unselected"),
-    queryFn: () => harnessClient.getRelationGraph({ repoId: repoId! }),
+    queryFn: () => readWholeRelationGraph((payload) => harnessClient.getRelationGraph({ repoId: repoId!, ...payload })),
     enabled: graphEnabled,
     staleTime: 10_000,
   });

--- a/packages/gui/test/triadic-graph-paging.vitest.ts
+++ b/packages/gui/test/triadic-graph-paging.vitest.ts
@@ -1,0 +1,76 @@
+// harness-test-tier: fast
+import { describe, expect, it } from "vitest";
+import type { RelationGraphSuccess } from "../src/renderer/api-client.ts";
+import { readWholeRelationGraph } from "../src/renderer/triadic-data.ts";
+
+type Edge = RelationGraphSuccess["edges"][number];
+type Fact = RelationGraphSuccess["facts"][number];
+type Anchor = RelationGraphSuccess["factAnchors"][number];
+type Coverage = RelationGraphSuccess["coverageRows"][number];
+
+const edge = (relationId: string) => ({ relationId, sourceRef: `decision/${relationId}`, targetRef: "task/t" }) as Edge;
+const fact = (ref: string) => ({ ref, factId: ref.slice(5), statement: ref }) as Fact;
+const anchor = (factRef: string) => ({ factRef, factId: factRef.slice(5), sourcePath: "x.md" }) as Anchor;
+const coverage = (decisionRef: string, claimRef: string) => ({ decisionRef, claimRef }) as Coverage;
+const page = (
+  rows: Partial<Pick<RelationGraphSuccess, "edges" | "facts" | "factAnchors" | "coverageRows">>,
+  nextCursor: string | null,
+  cursor: string | null = null,
+): RelationGraphSuccess => ({
+  ok: true,
+  edges: [],
+  facts: [],
+  factAnchors: [],
+  coverageRows: [],
+  warnings: [],
+  ...rows,
+  page: { limit: 500, cursor, nextCursor },
+});
+
+describe("完整关系图按 nextCursor 翻页合并", () => {
+  it("翻到 nextCursor 为空为止,四类行按主键去重", async () => {
+    const calls: unknown[] = [];
+    const pages = [
+      page(
+        {
+          edges: [edge("r1"), edge("r2")],
+          facts: [fact("fact/F-1")],
+          factAnchors: [anchor("fact/F-1")],
+          coverageRows: [coverage("decision/d1", "decision/d1/C1")],
+        },
+        "cursor-2",
+      ),
+      page(
+        {
+          edges: [edge("r2"), edge("r3")],
+          facts: [fact("fact/F-1"), fact("fact/F-2")],
+          factAnchors: [anchor("fact/F-2")],
+          coverageRows: [coverage("decision/d1", "decision/d1/C1"), coverage("decision/d1", "decision/d1/C2")],
+        },
+        null,
+        "cursor-2",
+      ),
+    ];
+    const graph = await readWholeRelationGraph(async (payload) => {
+      calls.push(payload);
+      return pages[calls.length - 1]!;
+    });
+    expect(calls).toEqual([{ limit: 500 }, { limit: 500, cursor: "cursor-2" }]);
+    expect(graph.edges.map((row) => row.relationId)).toEqual(["r1", "r2", "r3"]);
+    expect(graph.facts.map((row) => row.ref)).toEqual(["fact/F-1", "fact/F-2"]);
+    expect(graph.factAnchors.map((row) => row.factRef)).toEqual(["fact/F-1", "fact/F-2"]);
+    expect(graph.coverageRows.map((row) => row.claimRef)).toEqual(["decision/d1/C1", "decision/d1/C2"]);
+    expect(graph.page).toEqual({ limit: 500, cursor: "cursor-2", nextCursor: null });
+  });
+
+  it("没有分页信息的回答只读一次", async () => {
+    let reads = 0;
+    const graph = await readWholeRelationGraph(async () => {
+      reads += 1;
+      const { page: _page, ...single } = page({ edges: [edge("r1")] }, null);
+      return single;
+    });
+    expect(reads).toBe(1);
+    expect(graph.edges.map((row) => row.relationId)).toEqual(["r1"]);
+  });
+});

--- a/tools/gui-test-manifest.mjs
+++ b/tools/gui-test-manifest.mjs
@@ -25,6 +25,7 @@ export const guiVitestManifest = [
   "packages/gui/test/agenda-data.vitest.ts",
   "packages/gui/test/task-pin-actions.vitest.ts",
   "packages/gui/test/triadic-read-scoping.vitest.ts",
+  "packages/gui/test/triadic-graph-paging.vitest.ts",
   "packages/gui/test/terminal-renderer.vitest.ts",
   "packages/gui/test/terminal-pane.vitest.ts",
   "packages/gui/test/terminal-page.vitest.ts",


### PR DESCRIPTION
# English

## Summary

The GUI relation graph (territory / spotlight) degraded to task-only nodes: Decision and Fact nodes disappeared and Fact entries could not be found. Root cause is a read-shape drift, not the GovernedEntity generalisation: `0fc45cced` removed the unbounded `relationGraph()` read and `f3f830797` made the unparameterized `repo.triadic.relationGraph` call silently return one 500-edge page, whose `facts` / `factAnchors` / `coverageRows` are restricted to that page's endpoints. The renderer kept consuming that answer as the whole graph. In focus mode a decision only enters the focus set as a one-hop neighbour of a seed task, so once its edge fell outside the page the chip was dropped entirely.

## What Changed

- `packages/gui/src/renderer/triadic-data.ts`: new `readWholeRelationGraph(read)` follows `page.nextCursor` to the end with `limit: 500` and merges edges / facts / fact anchors / coverage rows by their primary keys; `useTriadicProjectionQuery` uses it for the full-graph query. Narrow facets (`derives`, `activeEdges`, `facts`, `runtimeEdges`) are unchanged.
- `packages/gui/test/triadic-graph-paging.vitest.ts` (registered in `tools/gui-test-manifest.mjs`): two pages with overlapping rows merge to the deduplicated union and the cursor sequence is exactly `[{limit:500},{limit:500,cursor}]`; an answer without page info is read once.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: use the single CI-backed `Production-Delta` declaration below; do not enter a second metric.

## Machine-Readable Declarations

Production-Delta: +33/-1

## Task And Scope

- Harness task: task_fea5c5ba9a59d0d735d51e171d
- Branch: codex/gui-graph-paging
- Public scope: GUI renderer full-graph read
- Private planning/evidence updated: yes
- Out of scope: the ⌘K fact index being enabled only while the palette is open (left-rail typeahead has no Fact entries until ⌘K was opened once) — separate defect, will be filed

## Version Impact

- Version: no version change because this is a GUI read-path bug fix
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: yes
- Protected surface scope: tools/gui-test-manifest.mjs (registers the new GUI vitest file; no gate command or workflow changed)
- Authority: task_fea5c5ba9a59d0d735d51e171d
- Break-glass: no

## Verification

- `npx vitest run test/triadic-graph-paging.vitest.ts test/triadic-read-scoping.vitest.ts`: 2 files, 10 tests passed
- `npx eslint` on the touched files and `tsc -b`: pass

## Review Evidence

- CEO ground-truth: `ha relation list` shows the decision/fact edges present in the projection (e.g. rel_7117cc440b138378 evidenced-by, rel_b9268f5ffb547c5b derives created 2026-09-04), so the ledger is intact and only the GUI read was truncated. Read-only code survey confirmed `repo-cell-api.ts:744` returns `relationGraphPage({ limit: 500 })` for the unparameterized call and `task-query-read.ts:394-404` filters facts/anchors/coverage by that page's refs.

## Residual Risk

- A very large graph now costs ceil(edges/500) round trips on graph-view mount; the same staleTime/cache applies, and the narrow facets used elsewhere are untouched.

---

# 中文

## 摘要

GUI 关系图(领地/聚光灯)退化成只剩 Task:Decision/Fact 节点消失,Fact 也搜不到。根因是读面形状漂移,不是 GovernedEntity 泛化:`0fc45cced` 删掉了无界的 `relationGraph()` 读,`f3f830797` 又让无参的 `repo.triadic.relationGraph` 静默返回一页 500 条边,其 `facts` / `factAnchors` / `coverageRows` 只随该页端点返回;renderer 却仍把这个回答当整张图消费。重点模式下 decision 只能作为种子 task 的一跳邻居进重点集,边一旦落在页外,chip 就整个被丢弃。

## 改了什么

- `packages/gui/src/renderer/triadic-data.ts`:新增 `readWholeRelationGraph(read)`,以 `limit: 500` 沿 `page.nextCursor` 翻到底,边/事实/事实锚点/覆盖行按各自主键合并去重;`useTriadicProjectionQuery` 的全量图查询改用它。窄切面(`derives`、`activeEdges`、`facts`、`runtimeEdges`)不变。
- `packages/gui/test/triadic-graph-paging.vitest.ts`(已登记 `tools/gui-test-manifest.mjs`):两页有重叠行时合并为去重并集,游标序列恰为 `[{limit:500},{limit:500,cursor}]`;无分页信息的回答只读一次。

## 任务与范围

- Harness task:task_fea5c5ba9a59d0d735d51e171d
- 分支:codex/gui-graph-paging
- 公开范围:GUI renderer 全量图读取
- 私有规划/证据已更新:是
- 范围外:⌘K 的 Fact 索引只在面板打开时才读(左栏 typeahead 在没打开过 ⌘K 前没有 Fact 条目)——独立缺陷,另行立案

## 版本影响

- 版本:无变化(GUI 读路径缺陷修复)
- 发布影响:不发布

## 治理声明

- 触碰受保护面:是
- 受保护面范围:tools/gui-test-manifest.mjs(登记新增 GUI vitest 文件;门命令与 workflow 未变)
- Authority:task_fea5c5ba9a59d0d735d51e171d
- Break-glass:no

## 验证

- 定向 vitest 2 个文件 10 个用例通过;eslint、`tsc -b` 通过

## 评审证据

- CEO ground-truth:`ha relation list` 能查到 decision/fact 的边(如今晚新建的 rel_7117cc440b138378 evidenced-by、rel_b9268f5ffb547c5b derives),台账完整,只是 GUI 的读被截断;只读代码调研确认 `repo-cell-api.ts:744` 对无参调用返回 `relationGraphPage({ limit: 500 })`,`task-query-read.ts:394-404` 按该页 ref 过滤 facts/anchors/coverage。

## 残余风险

- 图很大时关系图挂载要 ceil(边数/500) 次往返;缓存与 staleTime 不变,其它界面用的窄切面不受影响。
