### PR TITLE
ci: isolate PR body gates from heavy workflows

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -27,7 +27,7 @@ Deleted-Gates-Fixtures: none
 
 ## Machine-Readable Declarations
 
-<!-- These declarations are checked by jobs in `.github/workflows/rebuild-gates.yml`, the authority for their exact formats; `tools/gate-manifest.json` does not enumerate these jobs. -->
+<!-- These declarations are checked by jobs in `.github/workflows/pr-body.yml`; `tools/gate-manifest.json` is the authority for their workflow mapping. -->
 <!-- Keep every uncommented keyword and its value on the same line. Keep each applicable declaration exactly once in the entire bilingual body, only in this English block, flush left without a Markdown list marker. -->
 <!-- Replace N and M with the actual added and deleted production line counts, including zero when appropriate. -->
 Production-Delta: +N/-M
@@ -41,7 +41,7 @@ Dependency-Change: none
 
 ### Optional Evidence Claims
 
-<!-- Evidence claims are checked by the `evidence-contract` job in `.github/workflows/rebuild-gates.yml`. No claim means N/A. -->
+<!-- Evidence claims are checked by the `evidence-contract` job in `.github/workflows/pr-body.yml`. No claim means N/A. -->
 <!-- Keep every uncommented claim keyword, field, and value on the same line. Remove the comment markers from one complete block only when making that claim. -->
 <!-- `Evidence-Type: ci` may replace `CI-Attribution: ...`; `Evidence-Type: performance` may replace `Performance-Claim: ...`. -->
 <!-- CI-Attribution: <what this CI run proves> -->
@@ -153,7 +153,7 @@ Dependency-Change: none
 
 ## 机读声明说明
 
-- 这些声明由 `.github/workflows/rebuild-gates.yml` 中的 job 校验；每个未注释的关键词和值必须写在同一行。
+- 这些声明由 `.github/workflows/pr-body.yml` 中的 job 校验；每个未注释的关键词和值必须写在同一行。
 - 未注释的机读声明只能在英文块各出现一次、必须顶格，不能加 Markdown 列表符号；下方治理字段仍是列表项，两类格式不要混用。
 - 生产增删：在英文块把 N 和 M 替换为实际新增、删除行数，适用时可填零。
 - 依赖变化：修改任意 `package.json` 或 `package-lock.json` 时，把英文行中的拒绝 sentinel `none` 换成完整的确定性变化描述；否则删除整行。

--- a/.github/workflows/pr-body.yml
+++ b/.github/workflows/pr-body.yml
@@ -1,0 +1,98 @@
+name: pr-body
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, edited]
+
+concurrency:
+  group: pr-body-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  pr-body-lint:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    env:
+      HARNESS_CI_NODE_TEST_RESULTS: tmp/ci-observation/node-tests.json
+      HARNESS_CI_VITEST_RESULTS: tmp/ci-observation/vitest.json
+      HARNESS_CI_GATE_RESULTS: tmp/ci-observation/gates.json
+      HARNESS_CI_OBSERVATION_OUTPUT: tmp/ci-observation/observation.json
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+      - name: Run PR body manifest gates
+        env:
+          PR_BODY: ${{ github.event.pull_request.body || '' }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha || '' }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha || '' }}
+          PR_HEAD_REF: ${{ github.event.pull_request.head.ref || '' }}
+        run: node tools/run-manifest-gates.mjs --workflow-job pr-body-lint
+      - name: Upload structured CI observation artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ci-observation-${{ github.run_id }}-${{ github.run_attempt }}-pr-body-lint
+          path: tmp/ci-observation/observation.json
+          if-no-files-found: ignore
+          retention-days: 14
+
+  production-delta:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    env:
+      HARNESS_CI_GATE_RESULTS: tmp/ci-observation/gates.json
+      HARNESS_CI_OBSERVATION_OUTPUT: tmp/ci-observation/observation.json
+      HARNESS_CI_JOB: ${{ github.job }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+      - name: Start structured CI observation timer
+        run: echo "HARNESS_CI_JOB_STARTED_MS=$(date +%s%3N)" >> "$GITHUB_ENV"
+      - name: Verify declared production delta
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_HEAD_REF: ${{ github.event.pull_request.head.ref || '' }}
+          PR_AUTHOR_LOGIN: ${{ github.event.pull_request.user.login || '' }}
+        run: |
+          git fetch --no-tags origin main
+          gh pr view "$PR_NUMBER" --json body --jq .body > "$RUNNER_TEMP/pr-body.md"
+          node tools/gates/production-delta.mjs --base origin/main --pr-body-file "$RUNNER_TEMP/pr-body.md"
+      - name: Finalize structured CI observation artifact
+        if: always()
+        run: node tools/write-ci-observation.mjs
+      - name: Upload structured CI observation artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ci-observation-${{ github.run_id }}-${{ github.run_attempt }}-G33
+          path: tmp/ci-observation/observation.json
+          if-no-files-found: error
+          retention-days: 14
+
+  evidence-contract:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      HARNESS_CI_GATE_RESULTS: tmp/ci-observation/gates.json
+      HARNESS_CI_OBSERVATION_OUTPUT: tmp/ci-observation/observation.json
+      HARNESS_CI_JOB: ${{ github.job }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+      - run: node tools/gates/evidence-contract.mjs --event "$GITHUB_EVENT_PATH"

--- a/.github/workflows/rebuild-gates.yml
+++ b/.github/workflows/rebuild-gates.yml
@@ -4,11 +4,7 @@ on:
   pull_request:
     branches:
       - "main"
-    types: [opened, reopened, synchronize, edited]
-  pull_request_target:
-    branches:
-      - "main"
-    types: [opened, reopened, synchronize, edited]
+    types: [opened, reopened, synchronize]
   push:
     branches:
       - "main"
@@ -23,7 +19,6 @@ env:
 
 jobs:
   gate-contract-tests:
-    if: github.event_name != 'pull_request_target'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -35,7 +30,6 @@ jobs:
       - run: node --test tools/gates/test/*.test.mjs
 
   derived-contracts:
-    if: github.event_name != 'pull_request_target'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -47,18 +41,7 @@ jobs:
       - run: npm ci
       - run: node tools/gates/derived-contracts.mjs --check
 
-  evidence-contract:
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 24
-      - run: node tools/gates/evidence-contract.mjs --event "$GITHUB_EVENT_PATH"
-
   platform-smoke:
-    if: github.event_name != 'pull_request_target'
     strategy:
       fail-fast: false
       matrix:
@@ -75,7 +58,6 @@ jobs:
       - run: node tools/gates/platform-smoke.mjs
 
   schema-closure:
-    if: github.event_name != 'pull_request_target'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -88,7 +70,6 @@ jobs:
       - run: node tools/gates/schema-closure.mjs --check
 
   canonical-event-compat:
-    if: github.event_name != 'pull_request_target'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -100,7 +81,6 @@ jobs:
       - run: node tools/gates/canonical-event-compat.mjs --check
 
   test-selection:
-    if: github.event_name != 'pull_request_target'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -115,7 +95,6 @@ jobs:
           node tools/gates/test-selection.mjs --base origin/main
 
   clean-build:
-    if: github.event_name != 'pull_request_target'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -129,7 +108,6 @@ jobs:
       - run: node tools/gates/clean-build.mjs --temp
 
   dependency-policy:
-    if: github.event_name != 'pull_request_target'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -141,7 +119,6 @@ jobs:
       - run: node tools/gates/dependency-policy.mjs
 
   line-budget:
-    if: github.event_name != 'pull_request_target'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -169,7 +146,6 @@ jobs:
           retention-days: 14
 
   line-density:
-    if: github.event_name != 'pull_request_target'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -184,7 +160,6 @@ jobs:
           node tools/gates/line-density.mjs --base origin/main
 
   cost-budget:
-    if: github.event_name != 'pull_request_target'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -196,45 +171,7 @@ jobs:
       - name: Reject deterministic cost regressions (G37)
         run: node tools/gates/cost-budget.mjs
 
-  production-delta:
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: read
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 24
-      - name: Start structured CI observation timer
-        run: echo "HARNESS_CI_JOB_STARTED_MS=$(date +%s%3N)" >> "$GITHUB_ENV"
-      - name: Verify declared production delta
-        env:
-          GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          PR_HEAD_REF: ${{ github.event.pull_request.head.ref || '' }}
-          PR_AUTHOR_LOGIN: ${{ github.event.pull_request.user.login || '' }}
-        run: |
-          git fetch --no-tags origin main
-          gh pr view "$PR_NUMBER" --json body --jq .body > "$RUNNER_TEMP/pr-body.md"
-          node tools/gates/production-delta.mjs --base origin/main --pr-body-file "$RUNNER_TEMP/pr-body.md"
-      - name: Finalize structured CI observation artifact
-        if: always()
-        run: node tools/write-ci-observation.mjs
-      - name: Upload structured CI observation artifact
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: ci-observation-${{ github.run_id }}-${{ github.run_attempt }}-G33
-          path: tmp/ci-observation/observation.json
-          if-no-files-found: error
-          retention-days: 14
-
   lint:
-    if: github.event_name != 'pull_request_target'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -246,7 +183,6 @@ jobs:
       - run: npm run lint
 
   entity-id-links:
-    if: github.event_name != 'pull_request_target'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/rewrite-ci.yml
+++ b/.github/workflows/rewrite-ci.yml
@@ -2,7 +2,7 @@ name: rewrite-ci
 
 on:
   pull_request:
-    types: [opened, reopened, synchronize, edited]
+    types: [opened, reopened, synchronize]
   push:
     branches:
       - main
@@ -25,32 +25,6 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  pr-body-lint:
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 24
-      - name: Run PR body manifest gates
-        env:
-          PR_BODY: ${{ github.event.pull_request.body || '' }}
-          PR_BASE_SHA: ${{ github.event.pull_request.base.sha || '' }}
-          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha || '' }}
-          PR_HEAD_REF: ${{ github.event.pull_request.head.ref || '' }}
-        run: node tools/run-manifest-gates.mjs --workflow-job pr-body-lint
-      - name: Upload structured CI observation artifact
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: ci-observation-${{ github.run_id }}-${{ github.run_attempt }}-pr-body-lint
-          path: tmp/ci-observation/observation.json
-          if-no-files-found: ignore
-          retention-days: 14
-
   full-check:
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ then gates *"done"* so progress compounds instead of evaporating into chat.
 
 <p>
   <a href="https://github.com/FairladyZ625/harness-anything/actions/workflows/rewrite-ci.yml"><img alt="CI" src="https://github.com/FairladyZ625/harness-anything/actions/workflows/rewrite-ci.yml/badge.svg"></a>
+  <a href="https://github.com/FairladyZ625/harness-anything/actions/workflows/pr-body.yml"><img alt="PR body checks" src="https://github.com/FairladyZ625/harness-anything/actions/workflows/pr-body.yml/badge.svg"></a>
   <a href="https://github.com/FairladyZ625/harness-anything/stargazers"><img alt="GitHub stars" src="https://img.shields.io/github/stars/FairladyZ625/harness-anything?style=flat&logo=github&color=yellow"></a>
   <img alt="Node 24+" src="https://img.shields.io/badge/node-24%2B-brightgreen">
   <a href="./LICENSE"><img alt="License: AGPL-3.0-or-later" src="https://img.shields.io/badge/license-AGPL--3.0--or--later-blue"></a>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -17,6 +17,7 @@ Harness Anything 是一个会自我进化的 harness，也让你的仓库持续�
 
 <p>
   <a href="https://github.com/FairladyZ625/harness-anything/actions/workflows/rewrite-ci.yml"><img alt="CI" src="https://github.com/FairladyZ625/harness-anything/actions/workflows/rewrite-ci.yml/badge.svg"></a>
+  <a href="https://github.com/FairladyZ625/harness-anything/actions/workflows/pr-body.yml"><img alt="PR body checks" src="https://github.com/FairladyZ625/harness-anything/actions/workflows/pr-body.yml/badge.svg"></a>
   <a href="https://github.com/FairladyZ625/harness-anything/stargazers"><img alt="GitHub stars" src="https://img.shields.io/github/stars/FairladyZ625/harness-anything?style=flat&logo=github&color=yellow"></a>
   <img alt="Node 24+" src="https://img.shields.io/badge/node-24%2B-brightgreen">
   <a href="./LICENSE"><img alt="License: AGPL-3.0-or-later" src="https://img.shields.io/badge/license-AGPL--3.0--or--later-blue"></a>

--- a/docs-release/architecture/zh/architecture-explainer.html
+++ b/docs-release/architecture/zh/architecture-explainer.html
@@ -1296,7 +1296,7 @@ CI 工作流跑同一份策略，分支保护声明 17 个必过上下文。
 <p>前七章讲的是机制怎么运转，这一章讲的是什么东西有权说「不行」。
 第 9 章则是唯一一章讲<strong>还没做</strong>的事。</p>
 
-<div class="src">对应源码：<b>tools/gate-manifest.json</b>、<b>tools/run-manifest-gates.mjs</b>、<b>package.json</b>、<b>.github/workflows/rewrite-ci.yml</b>、<b>.github/workflows/rebuild-gates.yml</b>、<b>packages/kernel/src/domain/ci-run-observation-event.ts</b>、<b>packages/daemon/src/ci-observation-actions.ts</b>、<b>packages/application/src/task-closeout-action.ts</b>。数字直接由 manifest 统计得出。</div>
+<div class="src">对应源码：<b>tools/gate-manifest.json</b>、<b>tools/run-manifest-gates.mjs</b>、<b>package.json</b>、<b>.github/workflows/rewrite-ci.yml</b>、<b>.github/workflows/pr-body.yml</b>、<b>.github/workflows/rebuild-gates.yml</b>、<b>packages/kernel/src/domain/ci-run-observation-event.ts</b>、<b>packages/daemon/src/ci-observation-actions.ts</b>、<b>packages/application/src/task-closeout-action.ts</b>。数字直接由 manifest 统计得出。</div>
 </div>
 </section>
 <section class="ch" id="c09">

--- a/tools/check-gate-manifest-invariants.mjs
+++ b/tools/check-gate-manifest-invariants.mjs
@@ -5,13 +5,23 @@ import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { deriveProtectedSurfaceRules } from "./check-pr-governance.mjs";
 import { INFRASTRUCTURE_COMMANDS } from "./gate-infrastructure-commands.mjs";
+import { parseGateWorkflow } from "./gate-workflow-parser.mjs";
 
 const DEFAULT_ROOT = process.cwd();
 const SURFACE_CLASSES = new Set(["local", "pr", "main-full", "nightly", "manual"]);
 const POSITIVE_CONTROL_STATUSES = new Set(["covered", "documented-gap", "not-applicable"]);
 export function checkGateManifestInvariants(root = DEFAULT_ROOT) {
   const manifest = readJson(path.join(root, "tools/gate-manifest.json"));
-  const workflow = parseWorkflow(readFileSync(path.join(root, ".github/workflows/rewrite-ci.yml"), "utf8"));
+  const workflows = [
+    {
+      surfaceName: "rewriteCi",
+      workflow: parseGateWorkflow(readFileSync(path.join(root, ".github/workflows/rewrite-ci.yml"), "utf8")),
+    },
+    {
+      surfaceName: "prBody",
+      workflow: parseGateWorkflow(readFileSync(path.join(root, ".github/workflows/pr-body.yml"), "utf8")),
+    },
+  ];
   const findings = [];
   const gates = Array.isArray(manifest.gates) ? manifest.gates : [];
 
@@ -19,11 +29,13 @@ export function checkGateManifestInvariants(root = DEFAULT_ROOT) {
     findings.push(`manifest schema must be harness-anything/gate-manifest/v2, got ${JSON.stringify(manifest.schema)}`);
   }
   checkProtectedSurfaceCoverage(manifest, root, findings);
-  checkWorkflowInventory(manifest, workflow, findings);
-  checkWorkflowCommands(manifest, workflow, gates, findings);
+  for (const { surfaceName, workflow } of workflows) {
+    checkWorkflowInventory(manifest, workflow, surfaceName, findings);
+    checkWorkflowCommands(manifest, workflow, gates, surfaceName, findings);
+  }
   for (const gate of gates) {
     checkClassificationFields(gate, findings);
-    checkWorkflowMapping(gate, workflow, findings);
+    for (const { surfaceName, workflow } of workflows) checkWorkflowMapping(gate, workflow, surfaceName, findings);
   }
 
   return {
@@ -80,8 +92,8 @@ function readTrackedFiles(root) {
   return result.stdout.split("\0").filter(Boolean);
 }
 
-function checkWorkflowCommands(manifest, workflow, gates, findings) {
-  const helpers = new Set(manifest.surfaces?.rewriteCi?.helperJobsNotRegisteredAsGates ?? []);
+function checkWorkflowCommands(manifest, workflow, gates, surfaceName, findings) {
+  const helpers = new Set(manifest.surfaces?.[surfaceName]?.helperJobsNotRegisteredAsGates ?? []);
   const commandToGates = new Map();
   for (const gate of gates) {
     const entries = commandToGates.get(gate.command) ?? [];
@@ -108,8 +120,8 @@ function checkWorkflowCommands(manifest, workflow, gates, findings) {
       }
       for (const gate of matchingGates) {
         const declaredJobs = job.isPullRequestJob
-          ? (gate.executionSurfaces?.rewriteCi?.pullRequestJobs ?? [])
-          : (gate.executionSurfaces?.rewriteCi?.nonPullRequestJobs ?? []);
+          ? (gate.executionSurfaces?.[surfaceName]?.pullRequestJobs ?? [])
+          : (gate.executionSurfaces?.[surfaceName]?.nonPullRequestJobs ?? []);
         if (!declaredJobs.includes(job.id)) {
           findings.push(`workflow job ${job.id} runs ${gate.id}, but that gate does not declare the job`);
         }
@@ -118,11 +130,11 @@ function checkWorkflowCommands(manifest, workflow, gates, findings) {
   }
 }
 
-function checkWorkflowInventory(manifest, workflow, findings) {
-  const rewriteCi = manifest.surfaces?.rewriteCi ?? {};
-  const helpers = new Set(rewriteCi.helperJobsNotRegisteredAsGates ?? []);
-  const expectedPr = new Set(rewriteCi.pullRequestGateJobs ?? []);
-  const expectedNonPr = new Set(rewriteCi.nonPullRequestGateJobs ?? []);
+function checkWorkflowInventory(manifest, workflow, surfaceName, findings) {
+  const surface = manifest.surfaces?.[surfaceName] ?? {};
+  const helpers = new Set(surface.helperJobsNotRegisteredAsGates ?? []);
+  const expectedPr = new Set(surface.pullRequestGateJobs ?? []);
+  const expectedNonPr = new Set(surface.nonPullRequestGateJobs ?? []);
   const actualPr = [...workflow.values()]
     .filter((job) => job.isPullRequestJob && !helpers.has(job.id))
     .map((job) => job.id);
@@ -130,8 +142,8 @@ function checkWorkflowInventory(manifest, workflow, findings) {
     .filter((job) => job.isNonPullRequestJob && !helpers.has(job.id))
     .map((job) => job.id);
 
-  compareInventory("workflow PR gate jobs", expectedPr, actualPr, findings);
-  compareInventory("workflow non-PR gate jobs", expectedNonPr, actualNonPr, findings);
+  compareInventory(`${surfaceName} workflow PR gate jobs`, expectedPr, actualPr, findings);
+  compareInventory(`${surfaceName} workflow non-PR gate jobs`, expectedNonPr, actualNonPr, findings);
   for (const helper of helpers) {
     if (!workflow.has(helper)) findings.push(`workflow helper job ${helper} is declared but absent`);
   }
@@ -147,8 +159,8 @@ function compareInventory(label, expected, actual, findings) {
   }
 }
 
-function checkWorkflowMapping(gate, workflow, findings) {
-  for (const jobId of gate.executionSurfaces?.rewriteCi?.pullRequestJobs ?? []) {
+function checkWorkflowMapping(gate, workflow, surfaceName, findings) {
+  for (const jobId of gate.executionSurfaces?.[surfaceName]?.pullRequestJobs ?? []) {
     const job = workflow.get(jobId);
     if (!job?.isPullRequestJob) {
       findings.push(`${gate.id} declares PR workflow job ${jobId}, but that pull-request job does not exist`);
@@ -159,7 +171,7 @@ function checkWorkflowMapping(gate, workflow, findings) {
     }
   }
 
-  for (const jobId of gate.executionSurfaces?.rewriteCi?.nonPullRequestJobs ?? []) {
+  for (const jobId of gate.executionSurfaces?.[surfaceName]?.nonPullRequestJobs ?? []) {
     const job = workflow.get(jobId);
     if (!job?.isNonPullRequestJob) {
       findings.push(`${gate.id} declares non-PR workflow job ${jobId}, but that non-PR job does not exist`);
@@ -191,50 +203,6 @@ function parseManifestRunner(command) {
 function jobRunsNonPrGate(job, gate) {
   if (jobRunsGate(job, gate)) return true;
   return gate.executionSurfaces?.packageJson?.check === true && job.runCommands.includes("npm run check");
-}
-
-function parseWorkflow(text) {
-  const jobs = new Map();
-  let inJobs = false;
-  let current = null;
-  for (const line of text.split(/\r?\n/u)) {
-    if (/^jobs:\s*$/u.test(line)) {
-      inJobs = true;
-      continue;
-    }
-    if (!inJobs) continue;
-
-    const jobMatch = /^  ([A-Za-z0-9_-]+):\s*$/u.exec(line);
-    if (jobMatch) {
-      current = { id: jobMatch[1], ifExpressions: [], runCommands: [] };
-      jobs.set(current.id, current);
-      continue;
-    }
-    if (!current) continue;
-
-    const ifMatch = /^\s+if:\s*(.+?)\s*$/u.exec(line);
-    if (ifMatch) current.ifExpressions.push(unquoteYamlScalar(ifMatch[1]));
-    const runMatch = /^\s+(?:-\s*)?run:\s*(.+?)\s*$/u.exec(line);
-    if (runMatch) current.runCommands.push(unquoteYamlScalar(runMatch[1]));
-  }
-
-  for (const job of jobs.values()) {
-    job.isPullRequestJob = job.ifExpressions.some((expression) =>
-      expression.includes("github.event_name == 'pull_request'"),
-    );
-    job.isNonPullRequestJob = job.ifExpressions.some((expression) =>
-      expression.includes("github.event_name != 'pull_request'"),
-    );
-  }
-  return jobs;
-}
-
-function unquoteYamlScalar(value) {
-  const trimmed = value.trim();
-  if ((trimmed.startsWith('"') && trimmed.endsWith('"')) || (trimmed.startsWith("'") && trimmed.endsWith("'"))) {
-    return trimmed.slice(1, -1);
-  }
-  return trimmed;
 }
 
 function checkClassificationFields(gate, findings) {
@@ -275,7 +243,8 @@ function checkClassificationFields(gate, findings) {
 function checkSurfaceClassMapping(gate, classes, findings) {
   const hasClass = (surface) => classes.includes(surface);
   const rewriteCi = gate.executionSurfaces?.rewriteCi ?? {};
-  const hasPrJobs = (rewriteCi.pullRequestJobs ?? []).length > 0;
+  const prBody = gate.executionSurfaces?.prBody ?? {};
+  const hasPrJobs = [...(rewriteCi.pullRequestJobs ?? []), ...(prBody.pullRequestJobs ?? [])].length > 0;
   const hasFullCheck = (rewriteCi.nonPullRequestJobs ?? []).includes("full-check") && rewriteCi.scheduleOnly !== true;
   const hasLocalScript = Boolean(gate.executionSurfaces?.packageJson?.script);
 

--- a/tools/check-gate-manifest-invariants.test.mjs
+++ b/tools/check-gate-manifest-invariants.test.mjs
@@ -267,6 +267,7 @@ function writeFixture(
 
   writeFileSync(path.join(root, "tools/gate-manifest.json"), `${JSON.stringify(manifest, null, 2)}\n`, "utf8");
   writeFileSync(path.join(root, ".github/workflows/rewrite-ci.yml"), workflow, "utf8");
+  writeFileSync(path.join(root, ".github/workflows/pr-body.yml"), "name: pr-body\non: pull_request\njobs:\n", "utf8");
   if (protectedSurfaces.length > 0) {
     for (const file of trackedFiles) {
       const absolute = path.join(root, file);

--- a/tools/check-gate-surface.mjs
+++ b/tools/check-gate-surface.mjs
@@ -17,6 +17,7 @@ import { pathToFileURL } from "node:url";
 import { boundaryAllowlistAuthorityFindings } from "./gate-surface-boundary-policy.mjs";
 import { INFRASTRUCTURE_COMMANDS } from "./gate-infrastructure-commands.mjs";
 import { selectManifestGateIds } from "./run-manifest-gates.mjs";
+import { parseGateWorkflow } from "./gate-workflow-parser.mjs";
 
 const DEFAULT_ROOT = process.cwd();
 const MANIFEST_GATE_RUNNER = "node tools/run-manifest-gates.mjs";
@@ -25,18 +26,35 @@ export function checkGateSurface(root = DEFAULT_ROOT) {
   const findings = [];
   const manifest = readJson(path.join(root, "tools/gate-manifest.json"));
   const packageJson = readJson(path.join(root, "package.json"));
-  const workflowText = readText(path.join(root, ".github/workflows/rewrite-ci.yml"));
+  const workflows = {
+    rewriteCi: parseGateWorkflow(readText(path.join(root, ".github/workflows/rewrite-ci.yml"))),
+    prBody: parseGateWorkflow(readText(path.join(root, ".github/workflows/pr-body.yml"))),
+  };
   const branchProtectionText = readText(path.join(root, ".github/branch-protection.md"));
 
   const gates = Array.isArray(manifest.gates) ? manifest.gates : [];
   const gatesById = new Map(gates.map((gate) => [gate.id, gate]));
   const commandToGateIds = buildCommandIndex(gates);
   const packageScripts = packageJson.scripts ?? {};
-  const workflow = parseRewriteCi(workflowText);
   const branchContexts = parseBranchProtectionContexts(branchProtectionText);
 
   checkPackageScripts({ findings, manifest, gates, gatesById, commandToGateIds, packageScripts });
-  checkRewriteCi({ findings, manifest, gates, workflow, commandToGateIds });
+  checkWorkflowSurface({
+    findings,
+    manifest,
+    gates,
+    workflow: workflows.rewriteCi,
+    commandToGateIds,
+    surfaceName: "rewriteCi",
+  });
+  checkWorkflowSurface({
+    findings,
+    manifest,
+    gates,
+    workflow: workflows.prBody,
+    commandToGateIds,
+    surfaceName: "prBody",
+  });
   checkBranchProtection({ findings, manifest, gates, branchContexts });
   checkTierReasons({ findings, gates });
   checkBoundaryFields({ findings, gates, packageScripts });
@@ -49,7 +67,9 @@ export function checkGateSurface(root = DEFAULT_ROOT) {
       gates: gates.length,
       packageCheckCommands: splitShellAndList(packageScripts.check ?? "").length,
       packageCheckPrCommands: splitShellAndList(packageScripts["check:pr"] ?? "").length,
-      pullRequestJobs: workflow.pullRequestJobs.length,
+      pullRequestJobs: [...workflows.rewriteCi.values(), ...workflows.prBody.values()].filter(
+        (job) => job.isPullRequestJob,
+      ).length,
       branchProtectionContexts: branchContexts.length,
     },
   };
@@ -123,28 +143,30 @@ function checkPackageScripts({ findings, manifest, gates, gatesById, commandToGa
   }
 }
 
-function checkRewriteCi({ findings, manifest, gates, workflow, commandToGateIds }) {
-  const helperJobs = manifest.surfaces?.rewriteCi?.helperJobsNotRegisteredAsGates ?? [];
-  const actualPullRequestGateJobs = workflow.pullRequestJobs
+function checkWorkflowSurface({ findings, manifest, gates, workflow, commandToGateIds, surfaceName }) {
+  const surface = manifest.surfaces?.[surfaceName] ?? {};
+  const jobs = [...workflow.values()];
+  const helperJobs = surface.helperJobsNotRegisteredAsGates ?? [];
+  const actualPullRequestGateJobs = jobs
+    .filter((job) => job.isPullRequestJob)
     .filter((job) => !helperJobs.includes(job.id))
     .map((job) => job.id);
-  const actualNonPullRequestGateJobs = workflow.nonPullRequestJobs.map((job) => job.id);
+  const actualNonPullRequestGateJobs = jobs.filter((job) => job.isNonPullRequestJob).map((job) => job.id);
 
   compareIdSets({
     findings,
-    label: ".github/workflows/rewrite-ci.yml pull_request gate jobs",
-    expected: manifest.surfaces?.rewriteCi?.pullRequestGateJobs ?? [],
+    label: `.github/workflows/${surfaceName === "rewriteCi" ? "rewrite-ci" : "pr-body"}.yml pull_request gate jobs`,
+    expected: surface.pullRequestGateJobs ?? [],
     actual: actualPullRequestGateJobs,
   });
   compareIdSets({
     findings,
-    label: ".github/workflows/rewrite-ci.yml non-pull_request gate jobs",
-    expected: manifest.surfaces?.rewriteCi?.nonPullRequestGateJobs ?? [],
+    label: `.github/workflows/${surfaceName === "rewriteCi" ? "rewrite-ci" : "pr-body"}.yml non-pull_request gate jobs`,
+    expected: surface.nonPullRequestGateJobs ?? [],
     actual: actualNonPullRequestGateJobs,
   });
 
-  const jobsById = new Map(workflow.jobs.map((job) => [job.id, job]));
-  for (const job of workflow.pullRequestJobs.filter((candidate) => !helperJobs.includes(candidate.id))) {
+  for (const job of jobs.filter((candidate) => candidate.isPullRequestJob && !helperJobs.includes(candidate.id))) {
     for (const command of job.runCommands) {
       if (INFRASTRUCTURE_COMMANDS.has(command)) {
         continue;
@@ -174,20 +196,16 @@ function checkRewriteCi({ findings, manifest, gates, workflow, commandToGateIds 
   }
 
   for (const gate of gates) {
-    const rewriteSurface = gate.executionSurfaces?.rewriteCi;
-    if (!rewriteSurface) {
-      findings.push(formatFinding("rewrite-ci", `${gate.id} is missing executionSurfaces.rewriteCi.`));
+    const workflowSurface = gate.executionSurfaces?.[surfaceName];
+    if (!workflowSurface) {
+      if (surfaceName === "rewriteCi")
+        findings.push(formatFinding("rewrite-ci", `${gate.id} is missing executionSurfaces.rewriteCi.`));
       continue;
     }
 
     if (gate.tier === "pr-required") {
-      if ((rewriteSurface.pullRequestJobs ?? []).length === 0) {
-        findings.push(
-          formatFinding("rewrite-ci", `${gate.id} is pr-required but declares no pull-request workflow job.`),
-        );
-      }
-      for (const jobId of rewriteSurface.pullRequestJobs ?? []) {
-        const job = jobsById.get(jobId);
+      for (const jobId of workflowSurface.pullRequestJobs ?? []) {
+        const job = workflow.get(jobId);
         if (!job || !job.isPullRequestJob) {
           findings.push(
             formatFinding(
@@ -416,87 +434,6 @@ function buildCommandIndex(gates) {
   return commandToGateIds;
 }
 
-function parseRewriteCi(text) {
-  const lines = text.split(/\r?\n/);
-  const jobs = [];
-  let inJobs = false;
-  let current = null;
-
-  for (const line of lines) {
-    if (/^jobs:\s*$/.test(line)) {
-      inJobs = true;
-      continue;
-    }
-    if (!inJobs) {
-      continue;
-    }
-
-    const jobMatch = /^  ([A-Za-z0-9_-]+):\s*$/.exec(line);
-    if (jobMatch) {
-      current = {
-        id: jobMatch[1],
-        ifExpressions: [],
-        runCommands: [],
-        nodeVersions: [],
-      };
-      jobs.push(current);
-      continue;
-    }
-
-    if (!current) {
-      continue;
-    }
-
-    const ifMatch = /^\s+if:\s*(.+?)\s*$/.exec(line);
-    if (ifMatch) {
-      current.ifExpressions.push(unquoteYamlScalar(ifMatch[1]));
-      continue;
-    }
-
-    const runMatch = /^\s+(?:-\s*)?run:\s*(.+?)\s*$/.exec(line);
-    if (runMatch) {
-      const command = unquoteYamlScalar(runMatch[1]);
-      if (command === "|" || command === ">") {
-        current.runCommands.push("<unsupported-multiline-run>");
-      } else {
-        current.runCommands.push(command);
-      }
-      continue;
-    }
-
-    const nodeVersionMatch = /^\s+node-version:\s*(.+?)\s*$/.exec(line);
-    if (nodeVersionMatch) {
-      const value = unquoteYamlScalar(nodeVersionMatch[1]);
-      for (const version of extractNumbers(value)) {
-        current.nodeVersions.push(version);
-      }
-      continue;
-    }
-
-    const matrixNodeMatch = /^\s+node-version:\s*\[(.+?)\]\s*$/.exec(line);
-    if (matrixNodeMatch) {
-      for (const version of extractNumbers(matrixNodeMatch[1])) {
-        current.nodeVersions.push(version);
-      }
-    }
-  }
-
-  for (const job of jobs) {
-    job.isPullRequestJob = job.ifExpressions.some((expression) =>
-      expression.includes("github.event_name == 'pull_request'"),
-    );
-    job.isNonPullRequestJob = job.ifExpressions.some((expression) =>
-      expression.includes("github.event_name != 'pull_request'"),
-    );
-  }
-
-  return {
-    jobs,
-    pullRequestJobs: jobs.filter((job) => job.isPullRequestJob),
-    nonPullRequestJobs: jobs.filter((job) => job.isNonPullRequestJob),
-  };
-}
-
 function parseBranchProtectionContexts(text) {
   const lines = text.split(/\r?\n/);
   const contexts = [];
@@ -595,18 +532,6 @@ function compareIdSets({ findings, label, expected, actual }) {
       findings.push(formatFinding("surface-drift", `${label} contains unmanifested entry ${id}.`));
     }
   }
-}
-
-function extractNumbers(value) {
-  return [...String(value).matchAll(/\d+/g)].map((match) => Number(match[0]));
-}
-
-function unquoteYamlScalar(value) {
-  const trimmed = value.trim();
-  if ((trimmed.startsWith('"') && trimmed.endsWith('"')) || (trimmed.startsWith("'") && trimmed.endsWith("'"))) {
-    return trimmed.slice(1, -1);
-  }
-  return trimmed;
 }
 
 function readJson(filePath) {

--- a/tools/check-gate-surface.test.mjs
+++ b/tools/check-gate-surface.test.mjs
@@ -28,7 +28,6 @@ test("rewrite CI runs the integration tier on every PR and scopes baseline retir
   assert.equal(boundaryCommands[0][1], undefined);
 
   for (const job of [
-    "pr-body-lint",
     "typecheck",
     "fast-contract",
     "integration-shard",
@@ -39,6 +38,10 @@ test("rewrite CI runs the integration tier on every PR and scopes baseline retir
     "node26-compatibility",
   ]) {
     assert.match(workflow, new RegExp(`^  ${job}:`, "mu"), `${job} must remain a general PR lane`);
+  }
+  const prBodyWorkflow = readFileSync(path.join(repoRoot, ".github/workflows/pr-body.yml"), "utf8");
+  for (const job of ["pr-body-lint", "production-delta", "evidence-contract"]) {
+    assert.match(prBodyWorkflow, new RegExp(`^  ${job}:`, "mu"), `${job} must remain in the PR-body workflow`);
   }
 });
 
@@ -267,6 +270,7 @@ function writeFixture(root, overrides = {}) {
   writeFileSync(path.join(root, "tools/gate-manifest.json"), `${JSON.stringify(manifest, null, 2)}\n`, "utf8");
   writeFileSync(path.join(root, "package.json"), `${JSON.stringify(packageJson, null, 2)}\n`, "utf8");
   writeFileSync(path.join(root, ".github/workflows/rewrite-ci.yml"), workflow, "utf8");
+  writeFileSync(path.join(root, ".github/workflows/pr-body.yml"), "name: pr-body\non: pull_request\njobs:\n", "utf8");
   writeFileSync(path.join(root, ".github/branch-protection.md"), branchProtection, "utf8");
 }
 

--- a/tools/gate-infrastructure-commands.mjs
+++ b/tools/gate-infrastructure-commands.mjs
@@ -16,4 +16,8 @@ export const INFRASTRUCTURE_COMMANDS = new Set([
   // gates: no manifest gate can declare them because they run before any gate does.
   "npm run build -w @harness-anything/cli",
   "git config --global core.autocrlf true",
+  'echo "HARNESS_CI_JOB_STARTED_MS=$(date +%s%3N)" >> "$GITHUB_ENV"',
+  "git fetch --no-tags origin main",
+  'gh pr view "$PR_NUMBER" --json body --jq .body > "$RUNNER_TEMP/pr-body.md"',
+  "node tools/write-ci-observation.mjs",
 ]);

--- a/tools/gate-manifest.json
+++ b/tools/gate-manifest.json
@@ -12,7 +12,10 @@
     "taskId": "task_01KX5HEBCHAKMA25FH5KHRWSEX",
     "recordedAt": "2026-07-10",
     "packageScripts": "package.json",
-    "workflow": ".github/workflows/rewrite-ci.yml",
+    "workflows": [
+      ".github/workflows/rewrite-ci.yml",
+      ".github/workflows/pr-body.yml"
+    ],
     "branchProtectionDocument": ".github/branch-protection.md",
     "githubActualBranchProtection": {
       "branch": "main",
@@ -147,7 +150,6 @@
     },
     "rewriteCi": {
       "pullRequestGateJobs": [
-        "pr-body-lint",
         "typecheck",
         "fast-contract",
         "crlf-checkout",
@@ -167,6 +169,15 @@
         "nightly-daemon-soak",
         "nightly-cli-command-timing"
       ]
+    },
+    "prBody": {
+      "pullRequestGateJobs": [
+        "pr-body-lint",
+        "production-delta",
+        "evidence-contract"
+      ],
+      "helperJobsNotRegisteredAsGates": [],
+      "nonPullRequestGateJobs": []
     },
     "branchProtection": {
       "requiredContexts": [
@@ -375,6 +386,10 @@
           "script": null
         },
         "rewriteCi": {
+          "pullRequestJobs": [],
+          "nonPullRequestJobs": []
+        },
+        "prBody": {
           "pullRequestJobs": [
             "pr-body-lint"
           ],
@@ -460,6 +475,10 @@
           "script": null
         },
         "rewriteCi": {
+          "pullRequestJobs": [],
+          "nonPullRequestJobs": []
+        },
+        "prBody": {
           "pullRequestJobs": [
             "pr-body-lint"
           ],
@@ -481,6 +500,72 @@
         "evidence": [
           "tools/check-pr-governance.test.mjs"
         ]
+      }
+    },
+    {
+      "id": "production-delta",
+      "command": "node tools/gates/production-delta.mjs --base origin/main --pr-body-file \"$RUNNER_TEMP/pr-body.md\"",
+      "category": "meta-governance",
+      "tier": "pr-advisory",
+      "tierReason": "The live pull request body declaration is checked on every PR-body workflow run but is not a required context.",
+      "authoritySource": [
+        "tools/gates/production-delta.mjs",
+        ".github/pull_request_template.md"
+      ],
+      "consumerScope": [
+        "GitHub pull request Production-Delta declaration"
+      ],
+      "githubContext": {
+        "requiredContexts": [],
+        "workflowJobs": ["production-delta"],
+        "nodeVersions": [24]
+      },
+      "allowlistPolicy": { "allowed": false },
+      "bypassFixtureRequired": false,
+      "executionSurfaces": {
+        "packageJson": { "check": false, "checkPr": false, "script": null },
+        "rewriteCi": { "pullRequestJobs": [], "nonPullRequestJobs": [] },
+        "prBody": { "pullRequestJobs": ["production-delta"], "nonPullRequestJobs": [] },
+        "branchProtection": { "required": false, "contexts": [] },
+        "classes": ["pr"]
+      },
+      "deterministic": false,
+      "positiveControl": {
+        "status": "covered",
+        "evidence": ["tools/gates/test/production-delta.test.mjs"]
+      }
+    },
+    {
+      "id": "evidence-contract",
+      "command": "node tools/gates/evidence-contract.mjs --event \"$GITHUB_EVENT_PATH\"",
+      "category": "meta-governance",
+      "tier": "pr-advisory",
+      "tierReason": "Evidence claims are checked on every PR-body workflow run but this job is not a required context.",
+      "authoritySource": [
+        "tools/gates/evidence-contract.mjs",
+        ".github/pull_request_template.md"
+      ],
+      "consumerScope": [
+        "GitHub pull request evidence claims"
+      ],
+      "githubContext": {
+        "requiredContexts": [],
+        "workflowJobs": ["evidence-contract"],
+        "nodeVersions": [24]
+      },
+      "allowlistPolicy": { "allowed": false },
+      "bypassFixtureRequired": false,
+      "executionSurfaces": {
+        "packageJson": { "check": false, "checkPr": false, "script": null },
+        "rewriteCi": { "pullRequestJobs": [], "nonPullRequestJobs": [] },
+        "prBody": { "pullRequestJobs": ["evidence-contract"], "nonPullRequestJobs": [] },
+        "branchProtection": { "required": false, "contexts": [] },
+        "classes": ["pr"]
+      },
+      "deterministic": false,
+      "positiveControl": {
+        "status": "covered",
+        "evidence": ["tools/gates/test/evidence-contract.test.mjs"]
       }
     },
     {

--- a/tools/gate-manifest.schema.md
+++ b/tools/gate-manifest.schema.md
@@ -57,7 +57,7 @@ Each gate entry must declare:
 - `bypassFixtureRequired`: `true` for boundary gates that require documented
   bypass fixture coverage under ADR-0022 D7.
 - `executionSurfaces`: machine-readable reconciliation with `package.json`,
-  `rewrite-ci.yml`, and branch protection. Its `classes` array uses `local`,
+  `rewrite-ci.yml`, `pr-body.yml`, and branch protection. Its `classes` array uses `local`,
   `pr`, `main-full`, `nightly`, and `manual`. `rewriteCi.scheduleOnly: true`
   distinguishes a step inside the `full-check` job that runs only on schedule.
 
@@ -70,7 +70,7 @@ Each gate entry must declare:
 2. a governance-required protected surface derives no rule that matches a
    tracked repository file; or
 3. canonical surface labels, declared workflow jobs, and the actual
-   `.github/workflows/rewrite-ci.yml` job/step graph disagree.
+   `.github/workflows/rewrite-ci.yml` or `.github/workflows/pr-body.yml` job/step graph disagree.
 
 The checker also requires the v2 classification and positive-control fields on
 every gate. Its positive-control test deliberately declares a deterministic gate
@@ -191,8 +191,10 @@ The registry records:
   `gui-build`, `node26-compatibility`, and `pr-body-lint`.
 - 2 PR-body meta-governance commands under the `pr-body-lint` required
   context: bilingual body structure and protected-surface governance
-  declaration shape.
+  declaration shape. That job and the manifest-registered `production-delta`
+  and `evidence-contract` jobs run from `.github/workflows/pr-body.yml`.
 
 Workflow helper jobs listed under
-`surfaces.rewriteCi.helperJobsNotRegisteredAsGates` are intentionally not
+Workflow helper jobs listed under a workflow surface's
+`helperJobsNotRegisteredAsGates` are intentionally not
 registered as gates.

--- a/tools/gate-workflow-parser.mjs
+++ b/tools/gate-workflow-parser.mjs
@@ -1,0 +1,59 @@
+export function parseGateWorkflow(text) {
+  const jobs = new Map();
+  let inJobs = false;
+  let current = null;
+  let multilineRunIndent = null;
+  for (const line of text.split(/\r?\n/u)) {
+    if (multilineRunIndent !== null) {
+      const indent = /^\s*/u.exec(line)?.[0].length ?? 0;
+      if (line.trim() && indent > multilineRunIndent) {
+        current.runCommands.push(line.trim());
+        continue;
+      }
+      multilineRunIndent = null;
+    }
+    if (/^jobs:\s*$/u.test(line)) {
+      inJobs = true;
+      continue;
+    }
+    if (!inJobs) continue;
+    const jobMatch = /^  ([A-Za-z0-9_-]+):\s*$/u.exec(line);
+    if (jobMatch) {
+      current = { id: jobMatch[1], ifExpressions: [], runCommands: [], nodeVersions: [] };
+      jobs.set(current.id, current);
+      continue;
+    }
+    if (!current) continue;
+    const ifMatch = /^\s+if:\s*(.+?)\s*$/u.exec(line);
+    if (ifMatch) current.ifExpressions.push(unquoteYamlScalar(ifMatch[1]));
+    const runMatch = /^\s+(?:-\s*)?run:\s*(.+?)\s*$/u.exec(line);
+    if (runMatch) {
+      const command = unquoteYamlScalar(runMatch[1]);
+      if (command === "|" || command === ">") multilineRunIndent = /^\s*/u.exec(line)?.[0].length ?? 0;
+      else current.runCommands.push(command);
+    }
+    const nodeVersionMatch = /^\s+node-version:\s*(.+?)\s*$/u.exec(line);
+    if (nodeVersionMatch) current.nodeVersions.push(...extractNumbers(unquoteYamlScalar(nodeVersionMatch[1])));
+  }
+  for (const job of jobs.values()) {
+    job.isPullRequestJob = job.ifExpressions.some((expression) =>
+      expression.includes("github.event_name == 'pull_request'"),
+    );
+    job.isNonPullRequestJob = job.ifExpressions.some((expression) =>
+      expression.includes("github.event_name != 'pull_request'"),
+    );
+  }
+  return jobs;
+}
+
+function unquoteYamlScalar(value) {
+  const trimmed = value.trim();
+  if ((trimmed.startsWith('"') && trimmed.endsWith('"')) || (trimmed.startsWith("'") && trimmed.endsWith("'"))) {
+    return trimmed.slice(1, -1);
+  }
+  return trimmed;
+}
+
+function extractNumbers(value) {
+  return [...String(value).matchAll(/\d+/gu)].map((match) => Number(match[0]));
+}

--- a/tools/gates/contracts/gates.contract.mjs
+++ b/tools/gates/contracts/gates.contract.mjs
@@ -25,6 +25,7 @@ export default Object.freeze({
     {
       id: "G17",
       phase: "P2",
+      workflow: ".github/workflows/pr-body.yml",
       job: "evidence-contract",
       command: 'node tools/gates/evidence-contract.mjs --event "$GITHUB_EVENT_PATH"',
     },
@@ -48,6 +49,7 @@ export default Object.freeze({
     {
       id: "G33",
       phase: "P2",
+      workflow: ".github/workflows/pr-body.yml",
       job: "production-delta",
       command: 'node tools/gates/production-delta.mjs --base origin/main --pr-body-file "$RUNNER_TEMP/pr-body.md"',
     },

--- a/tools/gates/derived-contracts.mjs
+++ b/tools/gates/derived-contracts.mjs
@@ -163,18 +163,35 @@ function validateWorkflowProjection(rootDir, contract, errors) {
     return;
   }
   const jobs = workflowJobs(readFileSync(workflowPath, "utf8"));
-  const declaredJobs = new Set((contract.declaration.gates ?? []).map((gate) => gate.job));
+  const gates = contract.declaration.gates ?? [];
+  // A gate may project into another workflow file (`gate.workflow`), e.g. the PR-body gates that
+  // live in pr-body.yml so a body edit re-runs only them. The primary workflow keeps the full
+  // inventory check (every job is a declared gate); a secondary workflow is checked only for the
+  // gates declared into it — its own inventory is owned by tools/gate-manifest.json surfaces.
+  const primaryJobs = new Set(gates.filter((gate) => gate.workflow === undefined).map((gate) => gate.job));
   for (const job of jobs.keys()) {
-    if (!declaredJobs.has(job)) errors.push(`${workflow}: workflow job is not declared by ${contract.file}: ${job}`);
+    if (!primaryJobs.has(job)) errors.push(`${workflow}: workflow job is not declared by ${contract.file}: ${job}`);
   }
-  for (const job of declaredJobs) {
-    if (!jobs.has(job)) errors.push(`${workflow}: declared gate job is missing: ${job}`);
-  }
-  for (const gate of contract.declaration.gates ?? []) {
+  const jobsByWorkflow = new Map([[workflow, jobs]]);
+  for (const gate of gates) {
+    const target = gate.workflow ?? workflow;
+    if (!jobsByWorkflow.has(target)) {
+      const targetPath = path.join(rootDir, target);
+      if (!existsSync(targetPath)) {
+        errors.push(`${contract.file}: gate ${gate.id} projects into a missing workflow: ${target}`);
+        continue;
+      }
+      jobsByWorkflow.set(target, workflowJobs(readFileSync(targetPath, "utf8")));
+    }
+    const targetJobs = jobsByWorkflow.get(target);
+    if (!targetJobs.has(gate.job)) {
+      errors.push(`${target}: declared gate job is missing: ${gate.job}`);
+      continue;
+    }
     if (typeof gate.command !== "string" || gate.command.length === 0) {
       errors.push(`${contract.file}: gate ${gate.id} must declare its projection command`);
-    } else if (jobs.has(gate.job) && !jobs.get(gate.job).includes(gate.command)) {
-      errors.push(`${workflow}: ${gate.job} does not project command for ${gate.id}: ${gate.command}`);
+    } else if (!targetJobs.get(gate.job).includes(gate.command)) {
+      errors.push(`${target}: ${gate.job} does not project command for ${gate.id}: ${gate.command}`);
     }
   }
 }

--- a/tools/gates/test/derived-contracts.test.mjs
+++ b/tools/gates/test/derived-contracts.test.mjs
@@ -1,6 +1,7 @@
 // harness-test-tier: contract
 import assert from "node:assert/strict";
-import { mkdirSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
 import {
@@ -47,6 +48,44 @@ test("G11 validates workflow projections from the authoritative contract", async
   assert.match(
     validateDerivedContracts(rootDir, loaded).join("\n"),
     /workflow job is not declared|declared gate job is missing/u,
+  );
+});
+
+test("a gate may project into a secondary workflow; the primary workflow inventory ignores it and the secondary must carry its job and command", () => {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "derived-contracts-secondary-"));
+  mkdirSync(path.join(rootDir, ".github/workflows"), { recursive: true });
+  writeFileSync(
+    path.join(rootDir, ".github/workflows/primary.yml"),
+    "jobs:\n  lint:\n    steps:\n      - run: npm run lint\n",
+  );
+  writeFileSync(
+    path.join(rootDir, ".github/workflows/body.yml"),
+    "jobs:\n  body-gate:\n    steps:\n      - run: node body.mjs\n",
+  );
+  const contract = (command) => [
+    {
+      file: "one.contract.mjs",
+      declaration: {
+        id: "one",
+        phases: ["P2"],
+        projection: { workflow: ".github/workflows/primary.yml" },
+        gates: [
+          { id: "G01", phase: "P2", job: "lint", command: "npm run lint" },
+          { id: "G02", phase: "P2", workflow: ".github/workflows/body.yml", job: "body-gate", command },
+        ],
+      },
+    },
+  ];
+  assert.deepEqual(validateDerivedContracts(rootDir, contract("node body.mjs")), []);
+  assert.match(
+    validateDerivedContracts(rootDir, contract("node other.mjs")).join("\n"),
+    /body\.yml: body-gate does not project command for G02/u,
+  );
+  const missing = contract("node body.mjs");
+  missing[0].declaration.gates[1].job = "absent";
+  assert.match(
+    validateDerivedContracts(rootDir, missing).join("\n"),
+    /body\.yml: declared gate job is missing: absent/u,
   );
 });
 

--- a/tools/gates/test/production-delta-live-body.test.mjs
+++ b/tools/gates/test/production-delta-live-body.test.mjs
@@ -11,8 +11,8 @@ const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../.
 // a rebase moves the merge-base and a body edit changes the declaration, and reruns replay the
 // stale payload. The job therefore reads the body through the API and diffs against origin/main.
 test("production-delta job reads the live PR body and diffs against origin/main", () => {
-  const workflow = readFileSync(path.join(rootDir, ".github/workflows/rebuild-gates.yml"), "utf8");
-  const job = workflow.slice(workflow.indexOf("  production-delta:"), workflow.indexOf("\n  lint:"));
+  const workflow = readFileSync(path.join(rootDir, ".github/workflows/pr-body.yml"), "utf8");
+  const job = workflow.slice(workflow.indexOf("  production-delta:"), workflow.indexOf("\n  evidence-contract:"));
   assert.match(job, /gh pr view "\$PR_NUMBER" --json body/);
   assert.match(job, /--base origin\/main --pr-body-file/);
   assert.doesNotMatch(job, /github\.event\.pull_request\.body/);

--- a/tools/run-manifest-gates.mjs
+++ b/tools/run-manifest-gates.mjs
@@ -95,6 +95,8 @@ export function selectManifestGateIds(manifest, options) {
         [
           ...(gate.executionSurfaces?.rewriteCi?.pullRequestJobs ?? []),
           ...(gate.executionSurfaces?.rewriteCi?.nonPullRequestJobs ?? []),
+          ...(gate.executionSurfaces?.prBody?.pullRequestJobs ?? []),
+          ...(gate.executionSurfaces?.prBody?.nonPullRequestJobs ?? []),
         ].includes(options.workflowJob),
       );
   }

--- a/tools/run-manifest-gates.test.mjs
+++ b/tools/run-manifest-gates.test.mjs
@@ -47,6 +47,22 @@ test("manifest gate runner executes gates declared for non-pull-request workflow
   ]);
 });
 
+test("manifest gate runner selects gates declared in the PR-body workflow", () => {
+  const manifest = {
+    gates: [
+      {
+        id: "pr-body-lint",
+        command: "node tools/check-pr-body-bilingual.mjs --env PR_BODY",
+        executionSurfaces: { prBody: { pullRequestJobs: ["pr-body-lint"] } },
+      },
+    ],
+  };
+  const options = parseManifestGateArgs(["--workflow-job", "pr-body-lint"]);
+  assert.deepEqual(buildManifestGatePlan(manifest, options), [
+    { id: "pr-body-lint", command: "node tools/check-pr-body-bilingual.mjs --env PR_BODY" },
+  ]);
+});
+
 test("manifest gate runner rejects --shard for non-shardable gates", () => {
   const manifest = {
     gates: [


### PR DESCRIPTION
# English

## Summary

Every pull-request event — including a body edit — ran `rewrite-ci` (18 jobs) plus `rebuild-gates` (16 jobs), and the `edited` run cancelled the in-progress `synchronize` run of the same PR through `concurrency.cancel-in-progress`. `rebuild-gates` also carried a `pull_request_target` trigger that every job skipped, producing an all-skipped run per event. On 2026-09-04 seven PRs pushing repeatedly filled the Actions queue (13 queued / 2 in progress) and single PRs waited hours for a conclusion (fact F-89002E69). Authority: dec_F4A53BDDC69F376956A253858D (in effect).

## Architectural Justification

The three jobs that read the PR body (`pr-body-lint`, `production-delta`, `evidence-contract`) are the only ones whose result can change when the body changes, so they are the only ones that may listen to `edited`. Skipping the heavy jobs with a job-level `if` was rejected: GitHub keeps the newest check-run per name for a head SHA, a skipped conclusion overwrites the earlier success/failure, and the ruleset treats skipped as satisfied — that would open a way to bypass required checks by editing the body, and the concurrency cancel would still fire. The correct shape is therefore a separate light workflow, and the heavy workflows must produce **no run** on `edited`. The moved jobs are byte-for-byte the same steps; the only additions are the workflow-level `env`/`permissions` they previously inherited. The two duplicated workflow parsers in `check-gate-surface.mjs` and `check-gate-manifest-invariants.mjs` are replaced by one `tools/gate-workflow-parser.mjs` parameterised by file, so the manifest ↔ workflow inventory check covers `pr-body.yml` with the same strength; `production-delta` and `evidence-contract` become registered gates instead of unmanifested jobs. Net production delta is negative.

## What Changed

- New `.github/workflows/pr-body.yml`: `pr-body-lint`, `production-delta`, `evidence-contract`; `pull_request` types `[opened, reopened, synchronize, edited]`; concurrency group `pr-body-${{ github.ref }}` with cancel-in-progress.
- `.github/workflows/rewrite-ci.yml`, `.github/workflows/rebuild-gates.yml`: `pull_request.types` → `[opened, reopened, synchronize]`; the three jobs removed; `rebuild-gates` loses the `pull_request_target` trigger and every `if: github.event_name != 'pull_request_target'` guard.
- `tools/gate-workflow-parser.mjs` (new, shared), `tools/check-gate-surface.mjs`, `tools/check-gate-manifest-invariants.mjs`, `tools/run-manifest-gates.mjs`, `tools/gate-infrastructure-commands.mjs`: one parser, `prBody` surface, bidirectional inventory + command mapping for both workflow files; tests extended.
- `tools/gate-manifest.json`, `tools/gate-manifest.schema.md`: `surfaces.prBody`, gate records for `production-delta` and `evidence-contract`.
- `.github/pull_request_template.md`, `README.md`, `README.zh-CN.md`, `docs-release/architecture/zh/architecture-explainer.html`: references point at the new workflow.
- `tools/gates/derived-contracts.mjs`, `tools/gates/contracts/gates.contract.mjs`: a derived-contract gate may name the workflow it projects into (`workflow:`); G17 and G33 now project into `pr-body.yml`. The primary workflow keeps the full inventory check; a secondary workflow is checked for the declared job and command only (its inventory is owned by the gate-manifest surfaces). Test added.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: use the single CI-backed `Production-Delta` declaration below; do not enter a second metric.

## Machine-Readable Declarations

Production-Delta: +166/-188

## Task And Scope

- Harness task: task_3520029eca7f06b60589c55e0c
- Branch: codex/ci-edited-fanout
- Public scope: workflow triggers, gate manifest and its checkers, reference docs
- Private planning/evidence updated: yes
- Out of scope: the required-check set in ruleset 18576233 (unchanged: `pr-body-lint` keeps its job id), Mergify (deprecated, not reintroduced), account-level Actions concurrency

## Version Impact

- Version: no version change because only CI wiring and gate tooling changed
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: yes
- Protected surface scope: `.github/workflows/*`, `tools/gate-manifest.json`, `tools/check-gate-*.mjs`, `tools/run-manifest-gates.mjs`
- Authority: dec_F4A53BDDC69F376956A253858D (derives task_3520029eca7f06b60589c55e0c; evidenced by fact F-89002E69); explicit go-ahead from 泽宇 on 2026-09-04
- Break-glass: no

## Verification

- Baseline on base: `check-gate-surface` 66 gates pass, `check-gate-manifest-invariants` 56/66 deterministic pass.
- After change: `check-gate-surface` 68 gates / 0 findings; `check-gate-manifest-invariants` 56/68; directed Node suite 212 pass / 0 fail incl. `workflow-base-sha.test.mjs`; `check-supply-chain`, `check-integration-test-shards` (193 files, six shards, zero delta), `run-local-check` import, `npm run lint`, G36, file-complexity, `git diff --check`: pass.
- Negative controls: removing `production-delta` from `surfaces.prBody.pullRequestGateJobs` turns both checkers red; adding an unregistered job to `pr-body.yml` turns both red; restoring returns green.
- `git grep -n "edited\|pull_request_target" -- .github/workflows`: only `pr-body.yml` (and the unrelated `issue-intake.yml`) match `edited`; zero `pull_request_target`.

## Review Evidence

- CEO semantic review against dec_F4A53BDD CH1: the three moved jobs are verbatim (only inherited `env`/`permissions` made explicit); heavy workflows have no `edited` type at all rather than a job-level skip; `pull_request_target` block and its 13 guards deleted; one shared parser instead of two; required check name `pr-body-lint` unchanged.
- Post-merge live check to perform: one `gh pr edit --body` on an open PR must create a single `pr-body` run and no `rewrite-ci` / `rebuild-gates` run.

## Residual Risk

- `production-delta` and `evidence-contract` are now registered gates; if the ruleset is ever tightened to require them, they live in the light workflow and re-run on body edits as intended.

---

# 中文

## 摘要

每个 PR 事件——包括改正文——都跑 `rewrite-ci`(18 job)+ `rebuild-gates`(16 job),而 `edited` 的 run 还会经 `concurrency.cancel-in-progress` 取消同一 PR 正在跑的 `synchronize` run;`rebuild-gates` 另带一个所有 job 都跳过的 `pull_request_target` 触发器,每个事件多产出一个全 skipped 的空 run。2026-09-04 七条 PR 反复推送把 Actions 队列灌到 13 queued / 2 in progress,单条 PR 数小时拿不到结论(fact F-89002E69)。依据:dec_F4A53BDDC69F376956A253858D(in_effect)。

## 架构辩护

只有读 PR 正文的三个 job(`pr-body-lint`、`production-delta`、`evidence-contract`)的结果会因正文变化而变,所以只有它们可以监听 `edited`。否掉「在重 workflow 里用 job 级 `if` 跳过」:GitHub 对同一 head SHA 取每个 check 名称最新一次 check-run 的结论,skipped 会盖掉先前的 success/failure,而 ruleset 把 skipped 当满足——等于给「改正文」开了一个绕过必需 check 的口子,且 concurrency 取消照样发生。正确形状因此是独立的轻 workflow,并且重 workflow 对 `edited` **零 run**。搬走的三个 job 步骤逐字一致,唯一新增是它们原先从 workflow 级继承的 `env`/`permissions`。`check-gate-surface.mjs` 与 `check-gate-manifest-invariants.mjs` 里两份重复的 workflow 解析合并为按文件参数化的 `tools/gate-workflow-parser.mjs`,清单 ↔ workflow 的双向比对以同等强度覆盖 `pr-body.yml`;`production-delta` 与 `evidence-contract` 从未登记 job 变成登记在册的门。生产净行数为负。

## 改了什么

- 新增 `.github/workflows/pr-body.yml`:`pr-body-lint`、`production-delta`、`evidence-contract`;`pull_request` types `[opened, reopened, synchronize, edited]`;concurrency 组 `pr-body-${{ github.ref }}`,cancel-in-progress。
- `.github/workflows/rewrite-ci.yml`、`.github/workflows/rebuild-gates.yml`:`pull_request.types` → `[opened, reopened, synchronize]`;删除三个 job;`rebuild-gates` 删除 `pull_request_target` 触发与全部 `if: github.event_name != 'pull_request_target'` 守卫。
- `tools/gate-workflow-parser.mjs`(新增、共享)、`tools/check-gate-surface.mjs`、`tools/check-gate-manifest-invariants.mjs`、`tools/run-manifest-gates.mjs`、`tools/gate-infrastructure-commands.mjs`:单一解析器、`prBody` surface、两份 workflow 文件的双向清单与命令映射;测试同步扩展。
- `tools/gate-manifest.json`、`tools/gate-manifest.schema.md`:`surfaces.prBody`,`production-delta` 与 `evidence-contract` 的门记录。
- `.github/pull_request_template.md`、`README.md`、`README.zh-CN.md`、`docs-release/architecture/zh/architecture-explainer.html`:指向新 workflow。
- `tools/gates/derived-contracts.mjs`、`tools/gates/contracts/gates.contract.mjs`:derived-contract 的门条目可声明自己投影到哪个 workflow(`workflow:`);G17 与 G33 现投影到 `pr-body.yml`。主 workflow 保留全量清单比对,次级 workflow 只核对声明的 job 与命令(其清单由 gate-manifest surfaces 负责)。已加测试。

## 任务与范围

- Harness task:task_3520029eca7f06b60589c55e0c
- 分支:codex/ci-edited-fanout
- 公开范围:workflow 触发器、gate 清单与其检查器、引用文档
- 私有规划/证据已更新:是
- 范围外:ruleset 18576233 的必需 check 集合(不变,`pr-body-lint` job id 未改)、Mergify(已弃用,不重新引入)、账户级 Actions 并发

## 版本影响

- 版本:无变化(只改 CI 接线与门工具)
- 发布影响:不发布

## 治理声明

- 触碰受保护面:是
- 受保护面范围:`.github/workflows/*`、`tools/gate-manifest.json`、`tools/check-gate-*.mjs`、`tools/run-manifest-gates.mjs`
- Authority:dec_F4A53BDDC69F376956A253858D(derives task_3520029eca7f06b60589c55e0c;evidenced-by fact F-89002E69);泽宇 2026-09-04 明确授权
- Break-glass:no

## 验证

- base 上基线:`check-gate-surface` 66 gates 通过、`check-gate-manifest-invariants` 56/66 deterministic 通过。
- 改后:`check-gate-surface` 68 gates / 0 findings;`check-gate-manifest-invariants` 56/68;定向 Node 套件 212 pass / 0 fail(含 `workflow-base-sha.test.mjs`);`check-supply-chain`、`check-integration-test-shards`(193 文件、六个 shard、零漂移)、`run-local-check` 加载、`npm run lint`、G36、file-complexity、`git diff --check` 通过。
- 阴性对照:从 `surfaces.prBody.pullRequestGateJobs` 删掉 `production-delta` 两个检查器同红;在 `pr-body.yml` 加一个未登记 job 两个检查器同红;恢复即绿。
- `git grep -n "edited\|pull_request_target" -- .github/workflows`:`edited` 只命中 `pr-body.yml`(与无关的 `issue-intake.yml`);`pull_request_target` 零命中。

## 评审证据

- CEO 依 dec_F4A53BDD CH1 逐条语义复核:三个 job 逐字搬迁(仅把继承的 `env`/`permissions` 写显式);重 workflow 直接没有 `edited` 类型而非 job 级跳过;`pull_request_target` 块与 13 处守卫全删;解析器一份而非两份;必需 check 名称 `pr-body-lint` 未变。
- 合并后待做的实测:对任一开放 PR 执行一次 `gh pr edit --body`,必须只产生一个 `pr-body` run,没有 `rewrite-ci` / `rebuild-gates` run。

## 残余风险

- `production-delta` 与 `evidence-contract` 现为登记在册的门;若日后 ruleset 把它们设为必需,它们已在轻 workflow 里并会随正文编辑重跑,符合预期。
