### PR TITLE
fix(daemon): keep the singleton lock release reachable when the pid file cannot be removed

### DIFF
--- a/packages/daemon/src/daemon-host-lifecycle-api.ts
+++ b/packages/daemon/src/daemon-host-lifecycle-api.ts
@@ -76,19 +76,27 @@ export function createDaemonHostLifecycleApi(
     attachmentsSettled: context.startInitialAttachments,
     close: async () => {
       context.closing = true;
-      context.scheduleScheduler.close();
-      if (context.initialAttachments) await context.initialAttachments;
-      for (const repoId of [...context.warming.keys()]) context.settleWarming(repoId);
-      if (context.fleetCenter) await context.fleetCenter.close();
-      for (const runtime of context.fleetEdgeRuntimes.values()) runtime.close();
-      context.fleetEdgeRuntimes.clear();
-      context.remoteProxy.close();
-      // Every cell gets its close awaited even when one of them rejects: Promise.all would return
-      // on the first rejection while the other cells were still tearing down, and the stop sequence
-      // above this would release the pid file and lock under threads that are still alive. The
-      // first rejection still propagates so the drain failure is not swallowed.
+      // The cells close no matter what fails before them: they own the worker threads and WAL drains
+      // that the stop sequence releases the pid file and lock on top of. So the steps above them are
+      // settled into a value instead of unwinding past the cell close.
+      const preamble = await Promise.allSettled([
+        (async () => {
+          context.scheduleScheduler.close();
+          if (context.initialAttachments) await context.initialAttachments;
+          for (const repoId of [...context.warming.keys()]) context.settleWarming(repoId);
+          if (context.fleetCenter) await context.fleetCenter.close();
+          for (const runtime of context.fleetEdgeRuntimes.values()) runtime.close();
+          context.fleetEdgeRuntimes.clear();
+          context.remoteProxy.close();
+        })(),
+      ]);
+      // Every cell gets its close awaited even when one of them rejects (Promise.all would return on
+      // the first rejection while the others were still tearing down), and the first rejection still
+      // propagates so a drain failure is not swallowed.
       const settled = await Promise.allSettled([...context.cells.values()].map((cell) => cell.close())),
-        rejected = settled.find((outcome): outcome is PromiseRejectedResult => outcome.status === "rejected");
+        rejected = [...settled, ...preamble].find(
+          (outcome): outcome is PromiseRejectedResult => outcome.status === "rejected",
+        );
       if (rejected) throw rejected.reason;
     },
   };

--- a/packages/daemon/src/runtime.ts
+++ b/packages/daemon/src/runtime.ts
@@ -101,7 +101,8 @@ export async function startDaemon(input: {
         lifecycle.record({ event: "process_exit", outcome });
         await settleTeardownStep(() => transport!.stop());
         await settleTeardownStep(() => connLog.settle());
-        rmSync(pidPath, { force: true });
+        // Same shape for the pid file: an unremovable pid file must not strand the lock behind it.
+        await settleTeardownStep(async () => rmSync(pidPath, { force: true }));
         singleton.release();
       }
     })();

--- a/packages/daemon/test/daemon-build-drain.integration.test.ts
+++ b/packages/daemon/test/daemon-build-drain.integration.test.ts
@@ -9,7 +9,7 @@ import { ensureLocalDaemonRunning, type DaemonLaunchSpec } from "../src/client/d
 import { requestDaemonJsonRpcAt } from "../src/client/local-json-rpc-client.ts";
 import { readDaemonLifecycleRecords, type DaemonLifecycleRecorder } from "../src/lifecycle-log.ts";
 import { daemonSingletonLockPath } from "../src/daemon-singleton.ts";
-import { readDaemonPid, startDaemon, type RunningDaemon } from "../src/runtime.ts";
+import { daemonPidPath, readDaemonPid, startDaemon, type RunningDaemon } from "../src/runtime.ts";
 import { openBootstrappedRepoCell, registerBootstrappedDaemonRepo } from "./repo-settings.fixture.ts";
 
 test("the daemon binds and serves status and queued commands before repository attachment settles", async () => {
@@ -307,6 +307,36 @@ test("a drain that rejects still releases the pid file and the singleton lock", 
   } finally {
     await daemon?.stop().catch(() => undefined);
     await realCell?.close().catch(() => undefined);
+    rmSync(parent, { recursive: true, force: true });
+  }
+});
+
+test("a pid file that cannot be removed still releases the singleton lock", async () => {
+  // Pid removal sits between the socket teardown and the lock release. If it throws, the lock must
+  // still go: a held lock with no live daemon behind it is exactly the state stop exists to prevent.
+  const parent = mkdtempSync(path.join(tmpdir(), "ha-daemon-stop-pid-stuck-")),
+    rootDir = path.join(parent, "repo"),
+    userRoot = path.join(parent, "user"),
+    repoId = "stop-pid-stuck",
+    lockPath = daemonSingletonLockPath(userRoot, repoId),
+    pidPath = daemonPidPath(userRoot, repoId);
+  let daemon: RunningDaemon | undefined;
+  rosterRepo(rootDir, repoId);
+  registerBootstrappedDaemonRepo({ canonicalRoot: rootDir, repoId, userRoot, createConvenienceLinks: false });
+  try {
+    daemon = runningDaemon(await startDaemon({ daemonId: repoId, userRoot, endpoint: testEndpoint(repoId) }));
+    assert.equal(existsSync(lockPath), true, "the running daemon holds the singleton lock");
+    // A non-empty directory in the pid file's place makes the non-recursive rmSync throw.
+    rmSync(pidPath, { force: true });
+    mkdirSync(path.join(pidPath, "stuck"), { recursive: true });
+
+    await daemon.stop();
+
+    assert.equal(existsSync(lockPath), false, "stop exit must release the singleton lock");
+    assert.equal(existsSync(testEndpoint(repoId)), false, "stop exit must remove the socket");
+    daemon = undefined;
+  } finally {
+    await daemon?.stop().catch(() => undefined);
     rmSync(parent, { recursive: true, force: true });
   }
 });


### PR DESCRIPTION
Production-Delta: +22/-13

# English

## Problem

Follow-up to #2251. Independent review of the merged fix (`rev_2251_indep`) found the last teardown gap: `rmSync(pidPath)` sat unguarded between the socket teardown and `singleton.release()`. An unremovable pid file (permission error, a directory left in its place) would throw and strand the singleton lock behind a daemon that was already gone, which is exactly the state `stop()` exists to prevent. A second read-only review (gemini-3.8-flash) independently flagged the same line and one more: `host.close()` ran the fleet center / edge runtime / proxy closes before the cell closes with no guard, so a failure there skipped the cell closes that own the worker threads the stop sequence releases the lock on top of.

## Fix

- `packages/daemon/src/runtime.ts`: pid removal uses the same per-step `settleTeardownStep` shape as the other teardown steps; `singleton.release()` is now unconditionally reachable.
- `packages/daemon/src/daemon-host-lifecycle-api.ts`: the pre-cell steps are settled with `Promise.allSettled` alongside the cell closes; the first rejection from either group still propagates, so nothing is swallowed and the cells always close.

No new mechanism, no retry, no flag. Production +22/-13; nothing retained for later deletion.

## Negative control

New integration test `a pid file that cannot be removed still releases the singleton lock` replaces the pid file with a non-empty directory (non-recursive `rmSync` throws), stops the daemon and asserts the lock and socket are gone. It fails on `origin/main` (lock left behind) and passes here.

## Verification

```
npm test -- --tier integration --file packages/daemon/test/daemon-build-drain.integration.test.ts
ℹ tests 6 / pass 6 / fail 0   (file exits in ~10s)
npx eslint packages/daemon/src/runtime.ts packages/daemon/src/daemon-host-lifecycle-api.ts packages/daemon/test/daemon-build-drain.integration.test.ts   # clean
```

Full matrix is GitHub CI's job.

## Review evidence

- `rev_2251_indep` (Sol, changes_requested) — requested exactly this correction plus a focused negative test.
- gemini-3.8-flash read-only review — same finding on `runtime.ts` plus the `host.close()` preamble gap fixed here; its third finding (`context.openings` not awaited on close) is filed as a follow-up, not fixed here.

## Residual risk

`context.openings` (in-flight cell opens) are still not awaited by `host.close()`; a stop racing a slow open can release the lock under a thread that is still attaching. Tracked separately.

# 中文

## 问题

#2251 的补修。合入后的独立复核(`rev_2251_indep`)指出最后一处拆除缺口:`rmSync(pidPath)` 夹在 socket 拆除与 `singleton.release()` 之间且无守护,pid 文件删不掉(权限错误、原位被目录占住)就会抛错,把单例锁留在一个已经不在的 daemon 身后——这正是 `stop()` 要防的状态。另一路只读复核(gemini-3.8-flash)独立指出同一行,并多指出一处:`host.close()` 在关 cell 之前跑 fleet center / edge runtime / proxy 的关闭且无守护,那里一失败就跳过了拥有 worker 线程的 cell 关闭,而停机序列正是在这些线程之上释放锁的。

## 修法

- `packages/daemon/src/runtime.ts`:pid 移除改用与其他拆除步骤相同的 `settleTeardownStep` 形状;`singleton.release()` 无条件可达。
- `packages/daemon/src/daemon-host-lifecycle-api.ts`:cell 之前的步骤与 cell 关闭一起用 `Promise.allSettled` 结算;任一组的首个拒绝仍然传播,不吞错,cell 一定关。

不加机制、不加重试、不加开关。production +22/-13,无保留待删路径。

## 阴性对照

新增集成用例「a pid file that cannot be removed still releases the singleton lock」:把 pid 文件换成非空目录(非递归 `rmSync` 必抛),停 daemon,断言锁与 socket 已释放。该用例在 `origin/main` 上红(锁残留),本分支绿。

## 验证

同上英文段;完整矩阵由 GitHub CI 跑。

## 复核证据

- `rev_2251_indep`(Sol,changes_requested)——要求的正是这一处修正加一条聚焦的负向测试。
- gemini-3.8-flash 只读复核——同一 `runtime.ts` 发现 + 本 PR 修掉的 `host.close()` 前置缺口;其第三条(`context.openings` 关闭时未等待)另立后续任务,本 PR 不修。

## 残余风险

`host.close()` 仍不等待在飞的 cell open;stop 与一次很慢的 open 竞争时可能在仍在 attach 的线程之上释放锁。另行跟踪。
