### PR TITLE
fix(kernel,cli): explain invalid relation inputs — direction, target kind and missing fields get their own codes and hints

### DIFF
--- a/packages/cli/src/cli/thin-command-router.ts
+++ b/packages/cli/src/cli/thin-command-router.ts
@@ -200,16 +200,19 @@ function parseRelationRouted(
 ): ThinParseResult | undefined {
   if (route.id === "relation-list") return parseProjected(route.id, args.slice(2), rootDir, repoId, json, inputs);
   if (route.id === "relation-relate")
-    return parseProjected(
-      route.id,
-      args.slice(2),
-      rootDir,
-      repoId,
+    return normalizeRelationRelateFailure(
+      parseProjected(
+        route.id,
+        args.slice(2),
+        rootDir,
+        repoId,
+        json,
+        inputs,
+        {},
+        { direction: "directed", origin: "declared" },
+        route.method,
+      ),
       json,
-      inputs,
-      {},
-      { direction: "directed", origin: "declared" },
-      route.method,
     );
   if (route.id === "relation-unrelate") {
     const relationId = args[2];
@@ -232,4 +235,17 @@ function parseRelationRouted(
         );
   }
   return undefined;
+}
+
+function normalizeRelationRelateFailure(result: ThinParseResult, json: boolean): ThinParseResult {
+  if (result.ok || result.code !== "invalid_field") return result;
+  if (result.nextAction.startsWith("--expected-version is required."))
+    return rejected(
+      "missing_field",
+      "Add --expected-version 0 when creating a new Relation, then rerun the command.",
+      json,
+    );
+  return result.nextAction.startsWith("--rationale is required.")
+    ? rejected("missing_field", "Add --rationale <why>, then rerun the command.", json)
+    : result;
 }

--- a/packages/cli/test/thin-command-preset-fact-decision.test.ts
+++ b/packages/cli/test/thin-command-preset-fact-decision.test.ts
@@ -177,6 +177,33 @@ test("Relation commands replace hosted Task and Decision relation ingress", () =
   assert.equal(parseThinCommand(["decision", "relate", "dec_a"]).ok, false);
 });
 
+test("Relation relate names missing concurrency and rationale fields with executable hints", () => {
+  const base = [
+      "relation",
+      "relate",
+      "--source-ref",
+      "decision/dec_a",
+      "--target-ref",
+      "task/task_a",
+      "--type",
+      "derives",
+    ],
+    missingVersion = parseThinCommand([...base, "--rationale", "Decision derives task."]),
+    missingRationale = parseThinCommand([...base, "--expected-version", "0"]);
+  assert.deepEqual(missingVersion, {
+    ok: false,
+    code: "missing_field",
+    nextAction: "Add --expected-version 0 when creating a new Relation, then rerun the command.",
+    json: false,
+  });
+  assert.deepEqual(missingRationale, {
+    ok: false,
+    code: "missing_field",
+    nextAction: "Add --rationale <why>, then rerun the command.",
+    json: false,
+  });
+});
+
 test("Fact CLI exposes record, controlled types, search, and show while keeping local errors closed", () => {
   const record = parseThinCommand([
     "fact",

--- a/packages/daemon/test/artifact-relation-endpoint.integration.test.ts
+++ b/packages/daemon/test/artifact-relation-endpoint.integration.test.ts
@@ -62,6 +62,34 @@ test("A vertical artifact entity is a relation endpoint for its declared triple 
     );
     assert.equal(declared.outcome, "applied", JSON.stringify(declared));
 
+    const reversed = await cell.run(
+      {
+        kind: "relation-relate",
+        sourceRef: `decision/${decisionId}`,
+        targetRef: entityRef,
+        relationType: "relates",
+        rationale: "The declared artifact direction must be discoverable.",
+        expectedVersion: 0,
+      },
+      binding,
+    );
+    assert.equal(reversed.code, "relation_direction_invalid", JSON.stringify(reversed));
+    assert.match(JSON.stringify(reversed.diagnostic), /next: ha relation relate --source-ref/u);
+
+    const invalidTarget = await cell.run(
+      {
+        kind: "relation-relate",
+        sourceRef: `decision/${decisionId}`,
+        targetRef: entityRef,
+        relationType: "refines",
+        rationale: "Decision refines accepts a Decision target only.",
+        expectedVersion: 0,
+      },
+      binding,
+    );
+    assert.equal(invalidTarget.code, "relation_target_kind_invalid", JSON.stringify(invalidTarget));
+    assert.match(JSON.stringify(invalidTarget.diagnostic), /decision --refines-->.*decision/u);
+
     const undeclared = await cell.run(
       {
         kind: "relation-relate",

--- a/packages/kernel/src/domain/relation-event.ts
+++ b/packages/kernel/src/domain/relation-event.ts
@@ -490,14 +490,60 @@ export function assertRelationAdmission(
   directions: readonly CanonicalRelationDirection[] = canonicalRelationDirections,
 ): void {
   const kinds = relationEndpointKinds(record);
-  if (!isAllowedRelationKindTriple(kinds.source, record.type, kinds.target, directions))
-    throw Object.assign(
-      new Error(
-        `Relation triple ${kinds.source} --${record.type}--> ${kinds.target} is not declared ` +
-          "in the canonical direction registry",
-      ),
-      { code: "relation_triple_undeclared" },
+  if (isAllowedRelationKindTriple(kinds.source, record.type, kinds.target, directions)) return;
+  const writable = directions.filter(({ registration }) => registration !== "derived"),
+    reversed = writable.find(
+      ({ sourceKind, type, targetKind }) =>
+        sourceKind === kinds.target && type === record.type && targetKind === kinds.source,
+    ),
+    acceptedTargets = writable.filter(({ sourceKind, type }) => sourceKind === kinds.source && type === record.type);
+  if (reversed)
+    relationAdmissionError(
+      "relation_direction_invalid",
+      record,
+      kinds,
+      `Use canonical direction ${reversed.sourceKind} --${reversed.type}--> ${reversed.targetKind}; ` +
+        `next: ha relation relate --source-ref ${record.target} --target-ref ${record.source} ` +
+        `--type ${record.type} --rationale <why> --expected-version 0`,
     );
+  if (acceptedTargets.length > 0)
+    relationAdmissionError(
+      "relation_target_kind_invalid",
+      record,
+      kinds,
+      `Allowed target ${acceptedTargets.map(({ targetKind }) => targetKind).join(" or ")} for ` +
+        `${kinds.source} --${record.type}-->; replace --target-ref with a matching canonical Entity ref`,
+    );
+  relationAdmissionError(
+    "relation_triple_undeclared",
+    record,
+    kinds,
+    "Choose a declared source --type--> target triple from ha relation relate --help",
+  );
+}
+
+function relationAdmissionError(
+  code: string,
+  record: Pick<EntityRelationRecord, "type">,
+  kinds: { readonly source: string; readonly target: string },
+  expectation: string,
+): never {
+  throw Object.assign(
+    new Error(
+      `Relation triple ${kinds.source} --${record.type}--> ${kinds.target} is not declared ` +
+        "in the canonical direction registry",
+    ),
+    {
+      code,
+      diagnostic: {
+        kind: "validation",
+        entity: "relation",
+        field: "source-ref/type/target-ref",
+        actual: `${kinds.source} --${record.type}--> ${kinds.target}`,
+        expectation,
+      },
+    },
+  );
 }
 
 function relationEndpointKinds(record: Pick<EntityRelationRecord, "source" | "target">): {

--- a/packages/kernel/test/contracts/relation-entity.test.ts
+++ b/packages/kernel/test/contracts/relation-entity.test.ts
@@ -71,6 +71,39 @@ test("Relation kind and actions expose the BaseEntity and G1 concurrency contrac
   assert.equal(getExecutableEntityAction("decision-relate"), undefined);
 });
 
+test("Relation admission distinguishes reversed direction from an invalid target kind", () => {
+  const compile = (sourceRef: string, targetRef: string, type: "implements" | "refines") => {
+    const identity = { source: sourceRef, target: targetRef, type, direction: "directed" as const };
+    return compileRelationCreatedEvent({
+      record: {
+        relation_id: deriveRelationId(identity),
+        ...identity,
+        origin: "declared",
+        state: "active",
+        rationale: "Negative admission contract.",
+        targetObservedVersion: 1,
+      },
+      actor,
+      source,
+      opId: `relation-invalid-${type}`,
+      occurredAt: "2026-09-04T00:00:00.000Z",
+      workspaceRevision: 1,
+    });
+  };
+  assert.throws(
+    () => compile("decision/dec_RELATION_TARGET", "task/task_RELATION_TARGET", "implements"),
+    (error: unknown) =>
+      (error as { code?: string }).code === "relation_direction_invalid" &&
+      /task --implements--> decision/u.test(JSON.stringify((error as { diagnostic?: unknown }).diagnostic)),
+  );
+  assert.throws(
+    () => compile("decision/dec_RELATION_TARGET", "task/task_RELATION_TARGET", "refines"),
+    (error: unknown) =>
+      (error as { code?: string }).code === "relation_target_kind_invalid" &&
+      /decision --refines-->.*decision/u.test(JSON.stringify((error as { diagnostic?: unknown }).diagnostic)),
+  );
+});
+
 test("native Relation history reduces and projects one versioned aggregate row", () => {
   const relation = record(),
     created = compileRelationCreatedEvent({


### PR DESCRIPTION
# English

## Summary

`ha relation relate` used to answer every illegal input with one code, `relation_invalid`, and the caller had to guess which of three different things went wrong. On 08-23 that produced a burst of 7 rejections in 20 seconds from one agent retrying blind. The kernel admission now classifies the three cases it can name, and the CLI renders an actionable hint for each. Legal relations are untouched.

## What Changed

- `packages/kernel/src/domain/relation-event.ts`: two narrow classification branches ahead of the existing undeclared-triple rejection, plus one diagnostic helper:
  - exact reverse of a registered triple → `relation_direction_invalid`, hint carries the legal canonical triple and the complete swapped-ref `ha relation relate` command;
  - legal source/type but illegal target kind → `relation_target_kind_invalid`, hint lists every legal target kind from the canonical registry;
  - missing `--expected-version` / `--rationale` → `missing_field`, hint names the flag and says to retry.
  - anything else keeps `relation_triple_undeclared`. decision→task stays `derives`/`relates` only; `refines` stays decision→decision; claim anchors stay `C<n>`.
- `packages/cli/src/cli/thin-command-router.ts`: one normalization helper so the hint reaches the text and `--json` receipts identically.
- Tests: kernel contract (+3 cases), CLI fast (+1), repo-cell integration (+1: new codes and the pre-existing legal write plus cold rebuild).

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: use the single CI-backed `Production-Delta` declaration below; do not enter a second metric.

## Machine-Readable Declarations

Production-Delta: +78/-16

## Task And Scope

- Harness task: task_b5bc08c0567c9cff99d3633f6e (PLT-Ontology Phase 0 friction line)
- Branch: codex/relation-discoverability
- Public scope: kernel relation admission diagnostics, CLI receipt rendering, tests
- Private planning/evidence updated: yes (report with before/after receipts, independent review `rev_b5bc_indep`)
- Out of scope: daemon protocol schema (unchanged); other single-code-many-causes admissions (`decision_invalid`, tracked on task_ed3596218 / task_9c0dda92)

## Version Impact

- Version: no version change because receipts gained codes and hints; no command shape changed
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Authority: task_b5bc08c0567c9cff99d3633f6e under PLT-Ontology root task_5fc5080044fcfdbf548008f2f5

## Verification

- `node --test packages/kernel/test/contracts/relation-entity.test.ts` 7/7; `packages/cli/test/thin-command-preset-fact-decision.test.ts` 9/9; `npm test -- --tier integration --file packages/daemon/test/artifact-relation-endpoint.integration.test.ts` 1/1.
- Negative control (independent reviewer): production change stashed, tests only → the three new assertions fail; restored → green.
- Manual: three illegal inputs on an isolated `ha init` repo return the three codes and hints verbatim as in the report.
- typecheck, lint, line-density, file-complexity, production-delta pass locally; full matrix is CI's job.

## Review Evidence

- Independent review `rev_b5bc_indep` (Sol): approved — "narrowed classification plus diagnostics, not a new table or compatibility layer".

## Residual Risk

- The direction-fix command template uses `--expected-version 0` (correct for creating the swapped relation); retrying an already-existing swapped relation gets the normal revision conflict.

# 中文

## 摘要

`ha relation relate` 过去对所有非法输入只回一个 `relation_invalid`,调用方只能猜三种原因里是哪一种;08-23 一个 agent 盲重试 20 秒内产生 7 次拒绝。现在 kernel admission 把能叫出名字的三类分开,CLI 对每类给可执行 hint;合法 relation 不受影响。

## 改动

- `relation-event.ts`:在既有「未声明三元组」拒绝之前加两条收窄分支 + 一个诊断 helper:反向 → `relation_direction_invalid`(给合法三元组与交换后的完整命令);target kind 不合法 → `relation_target_kind_invalid`(列全部合法 target kind);缺 `--expected-version`/`--rationale` → `missing_field`(给要加的 flag)。其余保持 `relation_triple_undeclared`;decision→task 仍只允许 derives/relates,refines 仅 decision→decision,claim 锚仍是 `C<n>`。
- `thin-command-router.ts`:一个归一化 helper,文本与 `--json` 回执一致。
- 测试三层各加用例。

## 验证 / 复核

同上英文段;独立复核 `rev_b5bc_indep` approved,含阴性对照。

## 残余风险

方向修正命令模板用 `--expected-version 0`;重试已存在的交换关系会得到常规 revision 冲突。
