### PR TITLE
feat(preset,cli): lifecycle black-box acceptance preset; repo bootstrap honours the injected daemon endpoint (Ontology 5.3)

### DIFF
--- a/packages/cli/src/daemon/client.ts
+++ b/packages/cli/src/daemon/client.ts
@@ -125,7 +125,13 @@ export async function runCommandThroughDaemon(
     const userRoot = daemonUserRoot(env),
       daemonId = daemonIdFromEnv(env),
       { kind: _kind, ...params } = command.action,
-      socketPath = localUserDaemonEndpoint(userRoot, daemonId);
+      socketPath = resolveLocalDaemonEndpoint({
+        userRoot,
+        daemonId,
+        env,
+        repoId: env.HARNESS_DAEMON_REPO_ID,
+        canonicalRoot: command.rootDir,
+      });
     return withAutostart(
       () =>
         requestLocalDaemonJsonRpcForTarget(

--- a/packages/cli/src/daemon/client.ts
+++ b/packages/cli/src/daemon/client.ts
@@ -96,6 +96,24 @@ export function daemonTargetFailureCode(error: unknown): "daemon_target_conflict
     ? "daemon_target_conflict"
     : null;
 }
+// Repo bootstrap and runtime-instance commands must reach the daemon an isolated runtime injected
+// through HARNESS_DAEMON_ENDPOINT, not the implicit user socket: the resolver honours the injected
+// endpoint and the repo scope.
+function repoScopedDaemonEndpoint(
+  env: NodeJS.ProcessEnv,
+  command: ThinCommand,
+  userRoot: string,
+  daemonId: string,
+): string {
+  return resolveLocalDaemonEndpoint({
+    userRoot,
+    daemonId,
+    env,
+    repoId: env.HARNESS_DAEMON_REPO_ID,
+    canonicalRoot: command.rootDir,
+  });
+}
+
 export async function runCommandThroughDaemon(
   command: ThinCommand,
   onPhase: (receipt: JsonObject) => void = () => undefined,
@@ -125,13 +143,7 @@ export async function runCommandThroughDaemon(
     const userRoot = daemonUserRoot(env),
       daemonId = daemonIdFromEnv(env),
       { kind: _kind, ...params } = command.action,
-      socketPath = resolveLocalDaemonEndpoint({
-        userRoot,
-        daemonId,
-        env,
-        repoId: env.HARNESS_DAEMON_REPO_ID,
-        canonicalRoot: command.rootDir,
-      });
+      socketPath = repoScopedDaemonEndpoint(env, command, userRoot, daemonId);
     return withAutostart(
       () =>
         requestLocalDaemonJsonRpcForTarget(
@@ -155,13 +167,7 @@ export async function runCommandThroughDaemon(
     const userRoot = daemonUserRoot(env),
       daemonId = daemonIdFromEnv(env),
       { kind: _kind, ...payload } = command.action,
-      socketPath = resolveLocalDaemonEndpoint({
-        userRoot,
-        daemonId,
-        env,
-        repoId: env.HARNESS_DAEMON_REPO_ID,
-        canonicalRoot: command.rootDir,
-      });
+      socketPath = repoScopedDaemonEndpoint(env, command, userRoot, daemonId);
     return withAutostart(
       () =>
         requestLocalDaemonJsonRpcForTarget(

--- a/packages/cli/test/daemon-autostart-cli.test.ts
+++ b/packages/cli/test/daemon-autostart-cli.test.ts
@@ -219,6 +219,52 @@ test("task-bound runtime identity cannot autostart the shared daemon", (context)
   }
 });
 
+test("repo bootstrap reaches an injected daemon endpoint across an isolated runtime temp directory", () => {
+  const previousTemp = process.env.TMPDIR;
+  process.env.TMPDIR = "/tmp";
+  const fixture = setup(),
+    bootstrapRoot = setupRepository(fixture.parent, "bootstrap-repo"),
+    endpoint = localUserDaemonEndpoint(fixture.userRoot, "default"),
+    runtimeTemp = path.join(fixture.parent, "runtime", "isolated", "tmp");
+  try {
+    mkdirSync(runtimeTemp, { recursive: true });
+    assert.equal(run(fixture.root, fixture.userRoot, ["daemon", "start", "--service"]).ok, true);
+    const result = spawnSync(
+      process.execPath,
+      [
+        cli,
+        "--root",
+        bootstrapRoot,
+        "--json",
+        "init",
+        "--repo-id",
+        "runtime-bootstrap",
+        "--person-id",
+        "owner",
+        "--display-name",
+        "Owner",
+      ],
+      {
+        encoding: "utf8",
+        env: {
+          ...cliEnv(bootstrapRoot, fixture.userRoot),
+          HARNESS_DAEMON_ENDPOINT: endpoint,
+          TMPDIR: runtimeTemp,
+        },
+      },
+    );
+    assert.equal(result.status, 0, `${result.stderr}\n${result.stdout}`);
+    const receipt = JSON.parse(result.stdout) as { readonly ok?: boolean; readonly repoId?: string };
+    assert.equal(receipt.ok, true);
+    assert.equal(receipt.repoId, "runtime-bootstrap");
+  } finally {
+    stop(fixture.root, fixture.userRoot);
+    rmSync(fixture.parent, { recursive: true, force: true });
+    if (previousTemp === undefined) delete process.env.TMPDIR;
+    else process.env.TMPDIR = previousTemp;
+  }
+});
+
 test("a blocked vertical script keeps handshakes, snapshots, and same-repo writes live", async (context) => {
   const fixture = setup(),
     repoId = "vertical-wedge",

--- a/packages/daemon/test/gui-catalog.integration.test.ts
+++ b/packages/daemon/test/gui-catalog.integration.test.ts
@@ -20,7 +20,7 @@ test("GUI catalog projection uses canonical inventory without source paths or pl
   const catalog = openCatalog();
   const snapshot = await catalog.snapshot();
   assert.deepEqual(validateCatalogSnapshot(snapshot), []);
-  assert.equal(snapshot.presets.length, 12);
+  assert.equal(snapshot.presets.length, 13);
   assert.equal(
     snapshot.presets.every((row) => !("source" in row)),
     true,

--- a/packages/daemon/test/gui-s3-resident.integration.test.ts
+++ b/packages/daemon/test/gui-s3-resident.integration.test.ts
@@ -175,7 +175,7 @@ test("GUI S3 resident daemon bridge serves two RepoCells, catalog/runtime/contro
 
     const catalog = await rpc("repo.gui.catalog.snapshot", { repo: { repoId: "alpha" } });
     assert.equal(catalog.schema, "gui-catalog-snapshot/v1");
-    assert.equal((catalog.presets as unknown[]).length, 12);
+    assert.equal((catalog.presets as unknown[]).length, 13);
     const reread = await rpc("repo.gui.catalog.reread", {
       repo: { repoId: "alpha" },
       payload: { expectedDigest: catalog.catalogDigest },

--- a/packages/preset/assets/software-coding/presets/lifecycle-blackbox-acceptance/PRESET.md
+++ b/packages/preset/assets/software-coding/presets/lifecycle-blackbox-acceptance/PRESET.md
@@ -1,0 +1,10 @@
+---
+schema: preset-document/v1
+description: Materialize a source-blind black-box acceptance script for the complete Task lifecycle and the hooks negative case.
+whenToUse: Use when validating that a Consumer can discover and complete the Task lifecycle through the public ha CLI alone.
+---
+
+# Lifecycle Black-box Acceptance
+
+Adds `lifecycle-blackbox-acceptance.md`, a reproducible Consumer-mode script for
+the hooks negative case and the start, progress, review, and completion path.

--- a/packages/preset/assets/software-coding/presets/lifecycle-blackbox-acceptance/preset.json
+++ b/packages/preset/assets/software-coding/presets/lifecycle-blackbox-acceptance/preset.json
@@ -1,0 +1,28 @@
+{
+  "schema": "preset-manifest/v3",
+  "id": "lifecycle-blackbox-acceptance",
+  "title": "Lifecycle Black-box Acceptance",
+  "vertical": "software/coding",
+  "version": "3.0.0",
+  "kind": "template-content",
+  "outputShape": "task-package-artifact",
+  "kernelVersionRange": { "min": "1.0.0", "maxExclusive": "2.0.0" },
+  "capabilityImports": [],
+  "profiles": [
+    {
+      "id": "baseline",
+      "title": "Baseline",
+      "checkerProfile": "standard",
+      "completionGates": [],
+      "templateSelections": [
+        {
+          "slot": "task.lifecycle.blackbox.acceptance",
+          "templateRef": "template://acceptance/lifecycle-blackbox@1",
+          "materializeAs": "lifecycle-blackbox-acceptance.md",
+          "localePolicy": { "prefer": "project", "fallback": "en-US" }
+        }
+      ]
+    }
+  ],
+  "defaultProfile": "baseline"
+}

--- a/packages/preset/assets/software-coding/presets/lifecycle-blackbox-acceptance/template-catalog.json
+++ b/packages/preset/assets/software-coding/presets/lifecycle-blackbox-acceptance/template-catalog.json
@@ -1,0 +1,52 @@
+{
+  "schema": "template-catalog/v2",
+  "package": {
+    "id": "preset-lifecycle-blackbox-acceptance",
+    "title": "lifecycle-blackbox-acceptance",
+    "version": "3.0.0",
+    "owner": "preset",
+    "locales": ["zh-CN", "en-US"]
+  },
+  "documents": [
+    {
+      "id": "acceptance/lifecycle-blackbox",
+      "version": "1",
+      "documentKind": "acceptance-script",
+      "slot": "task.lifecycle.blackbox.acceptance",
+      "materializeAs": "lifecycle-blackbox-acceptance.md",
+      "frontmatterSchema": "task-package/v2",
+      "requiredAnchors": [
+        "## Consumer Contract",
+        "## Isolated Setup",
+        "## Hooks Negative Case",
+        "## Lifecycle Scenario",
+        "## Evidence"
+      ],
+      "fallbackLocale": "en-US",
+      "locales": [
+        {
+          "locale": "zh-CN",
+          "anchors": [
+            "## Consumer Contract",
+            "## Isolated Setup",
+            "## Hooks Negative Case",
+            "## Lifecycle Scenario",
+            "## Evidence"
+          ],
+          "bodyPath": "templates/task.lifecycle.blackbox.acceptance/zh-CN.md"
+        },
+        {
+          "locale": "en-US",
+          "anchors": [
+            "## Consumer Contract",
+            "## Isolated Setup",
+            "## Hooks Negative Case",
+            "## Lifecycle Scenario",
+            "## Evidence"
+          ],
+          "bodyPath": "templates/task.lifecycle.blackbox.acceptance/en-US.md"
+        }
+      ]
+    }
+  ]
+}

--- a/packages/preset/assets/software-coding/presets/lifecycle-blackbox-acceptance/templates/task.lifecycle.blackbox.acceptance/en-US.md
+++ b/packages/preset/assets/software-coding/presets/lifecycle-blackbox-acceptance/templates/task.lifecycle.blackbox.acceptance/en-US.md
@@ -1,0 +1,45 @@
+# {{title}} — Lifecycle Black-box Acceptance
+
+## Consumer Contract
+
+Act as a source-blind Consumer. Discover the CLI only with `ha --help`,
+`ha <command> --help`, and `ha explain`. You may execute lifecycle commands
+that you discover through those surfaces. Do not read, search, list, or inspect
+`packages/` or any Harness Anything source file. Do not use prior source-level
+knowledge to invent commands or payload fields.
+
+## Isolated Setup
+
+Work only in the disposable repository supplied by the dispatcher. Confirm it
+is the current directory, run `ha init` there, and do not access or mutate any
+other repository ledger. Use a no-gate task preset so local CI is not part of
+this CLI acceptance scenario.
+
+## Hooks Negative Case
+
+Before the happy path, use only the allowed discovery surfaces to determine
+whether a declared hook can be attached to and reached by a runtime dispatch.
+Record the exact discovery commands and outputs. The expected observation is
+that hooks may exist on a declaration surface but the public runtime workflow
+does not expose a reachable hook bridge. Do not work around that absence and do
+not edit configuration or source to manufacture a bridge.
+
+## Lifecycle Scenario
+
+Create one disposable Task, start its execution, append progress with evidence,
+submit a complete typed result, record an independent approved review, provide
+the required owner consent, and complete the Task. Follow command receipts and
+their next-step guidance. Use `ha task show` between transitions and finish only
+when the canonical Task status is `done`.
+
+If the public CLI is undiscoverable, a receipt omits the next required step, or
+field names disagree between help, schema, and receipts, stop at that first CLI
+surface defect and report it verbatim. If the failure is a lifecycle, authority,
+storage, or runtime defect, stop immediately without a workaround.
+
+## Evidence
+
+Return a chronological transcript of every command and its unedited output, the
+created Task and Execution ids, the first failure classification if any, and the
+final Task projection. Also return a tool-call inventory sufficient to prove
+that no `packages/` path was read.

--- a/packages/preset/assets/software-coding/presets/lifecycle-blackbox-acceptance/templates/task.lifecycle.blackbox.acceptance/zh-CN.md
+++ b/packages/preset/assets/software-coding/presets/lifecycle-blackbox-acceptance/templates/task.lifecycle.blackbox.acceptance/zh-CN.md
@@ -1,0 +1,38 @@
+# {{title}} — 生命周期黑盒验收
+
+## Consumer Contract
+
+你是未读源码的 Consumer。只允许通过 `ha --help`、`ha <command> --help` 与
+`ha explain` 发现 CLI；可以执行从这些公开表面发现的生命周期命令。禁止读取、
+搜索、列举或检查 `packages/` 及任何 Harness Anything 源文件；禁止用源码级先验
+知识猜测命令或 payload 字段。
+
+## Isolated Setup
+
+只在派工方提供的一次性仓库中工作。先确认当前目录，在该目录执行 `ha init`，
+不得访问或修改其他仓库的台账。创建任务时选用无 gate 的 preset，避免把本地 CI
+混入本次 CLI 验收。
+
+## Hooks Negative Case
+
+在 happy path 前，只用获准的发现表面判断：已声明的 hook 是否能挂接到 runtime
+dispatch 并在运行时到达。原样记录发现命令与输出。预期观察是：hook 可以存在于
+声明面，但公开 runtime 工作流没有可到达的 hook 桥。不得绕过这一缺口，也不得
+通过修改配置或源码制造桥。
+
+## Lifecycle Scenario
+
+创建一个一次性 Task，启动 Execution，追加带 evidence 的 progress，提交完整的
+typed result，记录独立的 approved review，提供所需的 owner consent，最后完成
+Task。跟随命令回执及其 next-step 指引，在转换之间执行 `ha task show`；只有规范
+Task status 为 `done` 才算完成。
+
+若公开 CLI 无法发现、回执缺少下一必需步骤、或 help/schema/receipt 的字段名不一致，
+在第一个 CLI 表面缺陷处停止并原样报告。若失败属于 lifecycle、authority、storage
+或 runtime 缺陷，立即停止且不得绕过。
+
+## Evidence
+
+返回每条命令及其未编辑输出的时间顺序记录、创建的 Task 与 Execution id、首个失败
+分类（如有）和最终 Task projection；另给出足以证明从未读取 `packages/` 路径的
+tool-call 清单。

--- a/packages/preset/test/preset-resolver-bundled-catalog.test.ts
+++ b/packages/preset/test/preset-resolver-bundled-catalog.test.ts
@@ -9,7 +9,7 @@ import { compileTaskBootstrap } from "../src/index.ts";
 import { createRuntime } from "../src/preset-resolver.ts";
 
 import { git } from "./preset-resolver.fixtures.ts";
-test("all twelve bundled packages resolve through one valid catalog", async () => {
+test("all thirteen bundled packages resolve through one valid catalog", async () => {
   const root = mkdtempSync(path.join(tmpdir(), "ha-preset-builtins-"));
   try {
     const runtime = createRuntime({ userRoot: root }),
@@ -39,6 +39,11 @@ test("all twelve bundled packages resolve through one valid catalog", async () =
         { id: "docs-task", validity: "valid", errorCode: undefined },
         { id: "github-issue-repair", validity: "valid", errorCode: undefined },
         { id: "legacy-migration", validity: "valid", errorCode: undefined },
+        {
+          id: "lifecycle-blackbox-acceptance",
+          validity: "valid",
+          errorCode: undefined,
+        },
         { id: "milestone-closeout", validity: "valid", errorCode: undefined },
         { id: "module", validity: "valid", errorCode: undefined },
         { id: "standard-task", validity: "valid", errorCode: undefined },
@@ -135,6 +140,12 @@ test("all twelve bundled packages resolve through one valid catalog", async () =
         ["task.plan", "task.closeout", "task.artifacts.keep"],
       ],
       ["docs-task", "task-package-artifact", [], ["task.plan", "task.closeout", "task.artifacts.keep"]],
+      [
+        "lifecycle-blackbox-acceptance",
+        "task-package-artifact",
+        [],
+        ["task.plan", "task.closeout", "task.artifacts.keep", "task.lifecycle.blackbox.acceptance"],
+      ],
       [
         "code-impact-analysis",
         "task-package-artifact",

--- a/packages/preset/test/preset-resolver-snapshot-templates.test.ts
+++ b/packages/preset/test/preset-resolver-snapshot-templates.test.ts
@@ -509,8 +509,8 @@ test("seed and audit dry-runs report the two-layer inventory without mutation", 
       },
       {
         schema: "preset-audit-report/v1",
-        total: 12,
-        valid: 12,
+        total: 13,
+        valid: 13,
         unavailable: 0,
         blocked: 0,
         issues: [],
@@ -527,7 +527,7 @@ test("seed and audit dry-runs report the two-layer inventory without mutation", 
     };
     assert.equal(drySeed.schema, "preset-seed-report/v1");
     assert.equal(drySeed.mode, "dry-run");
-    assert.equal(drySeed.packageCount, 12);
+    assert.equal(drySeed.packageCount, 13);
     assert.deepEqual(
       drySeed.packages.map(({ presetId }) => presetId),
       [
@@ -538,6 +538,7 @@ test("seed and audit dry-runs report the two-layer inventory without mutation", 
         "docs-task",
         "github-issue-repair",
         "legacy-migration",
+        "lifecycle-blackbox-acceptance",
         "milestone-closeout",
         "module",
         "standard-task",
@@ -550,8 +551,8 @@ test("seed and audit dry-runs report the two-layer inventory without mutation", 
       rootDir,
       action: { kind: "preset-seed" },
     })) as { mode: string; packageCount: number };
-    assert.deepEqual({ mode: seeded.mode, packageCount: seeded.packageCount }, { mode: "apply", packageCount: 12 });
-    assert.equal(readdirSync(path.join(userRoot, "active")).length, 12);
+    assert.deepEqual({ mode: seeded.mode, packageCount: seeded.packageCount }, { mode: "apply", packageCount: 13 });
+    assert.equal(readdirSync(path.join(userRoot, "active")).length, 13);
   } finally {
     rmSync(rootDir, { recursive: true, force: true });
   }

--- a/packages/preset/test/preset-resolver-vertical-scripts.test.ts
+++ b/packages/preset/test/preset-resolver-vertical-scripts.test.ts
@@ -38,7 +38,7 @@ test("generic list, inspect, check, install, and uninstall actions share the can
       issues: unknown[];
       issueCount?: number;
     }>;
-    assert.equal(listed.length, 12);
+    assert.equal(listed.length, 13);
     const standardRow = listed.find(({ id }) => id === "standard-task")!,
       // The golden row pins the display projection; profile entries come from
       // the same bundled manifest the catalog derives from, so a manifest


### PR DESCRIPTION
# English

## Summary

Ontology Phase 5.3: a black-box acceptance preset (`lifecycle-blackbox-acceptance/baseline`) whose script makes a source-blind Consumer worker — allowed only `ha --help`, `ha <cmd> --help` and `ha explain` — walk a disposable repository through hooks negative case → task create → start → progress → submit → review → consent → complete. Running it for real (Terra, two runs) surfaced one CLI defect fixed here and one lifecycle contract defect filed separately.

## What Changed

- `packages/preset/assets/software-coding/presets/lifecycle-blackbox-acceptance/` (`PRESET.md`, `preset.json`, template `task.lifecycle.blackbox.acceptance/{en-US,zh-CN}.md`) and the bundled `template-catalog.json` entry — the acceptance script as a preset, discoverable through `ha preset list`.
- `packages/cli/src/daemon/client.ts`: repo bootstrap derived its socket with `localUserDaemonEndpoint` and ignored an injected `HARNESS_DAEMON_ENDPOINT`; it now goes through the same validated `resolveLocalDaemonEndpoint` path as every other runtime-facing command (Run 1 failed on exactly this: `daemon_unavailable … connect EINVAL` against the wrong socket). Test added in `daemon-autostart-cli.test.ts`.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: use the single CI-backed `Production-Delta` declaration below; do not enter a second metric.

## Machine-Readable Declarations

Production-Delta: +20/-8

## Task And Scope

- Harness task: task_f449e24f89c97057cd81747bef (PLT-Ontology Phase 5.3; root task_5fc5080044fcfdbf548008f2f5)
- Branch: codex/blackbox-53
- Public scope: one preset, one CLI endpoint-resolution fix, tests
- Private planning/evidence updated: yes — `artifacts/reports/blackbox-acceptance.md` (both runs verbatim, tool-call inventory, facts F-9EA71C2C / F-6799DECD / F-0A4FF979 / F-226B3495)
- Out of scope: the lifecycle defect the second run stopped on (`task start` receipt suggests `declare-executor` before submission while `declare-executor` requires `submitted`) — task_2331829ba142f64df9e198d76a, dispatched; the third, fully green run happens after it lands

## Version Impact

- Version: no version change because a preset was added and an endpoint-resolution bug fixed; no command shape changed
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Authority: task_f449e24f89c97057cd81747bef under PLT-Ontology (dec_5B135F46 CH7)

## Verification

- `node --test packages/cli/test/daemon-autostart-cli.test.ts` 12/12; `packages/preset/test/preset-resolver-bundled-catalog.test.ts` 11/11 (CEO re-ran in the worktree).
- Real runs: Run 1 (`runtime_b9e21efc047e75420c3b4176`) stopped at the endpoint defect before task creation; Run 2 (`runtime_c6656350eff7035dc0c0ee98`) after the fix reached init → discovery → hooks negative case → preset → task create → plan sync → start → show → progress → fact, and stopped at the lifecycle defect as the script's checkpoint requires. Tool-call inventory shows no `packages/` read.
- Full matrix is GitHub CI's job.

## Review Evidence

- CEO ground-truth of the report and directed tests; independent review pending closeout (the task stays active until the third run is green).

## Residual Risk

- The preset's Consumer script is only as discoverable as `ha --help`/`ha explain`; the runs already produced three surface-discoverability facts for follow-up.

---

# 中文

## 摘要

Ontology Phase 5.3:黑盒验收 preset(`lifecycle-blackbox-acceptance/baseline`),让一个只许用 `ha --help`/`ha <cmd> --help`/`ha explain`、禁读源码的 Consumer worker 在一次性仓库里走 hooks 反例 → create → start → progress → submit → review → consent → complete。真实跑两次(Terra)暴露一个 CLI 缺陷(本 PR 修)和一个生命周期契约缺陷(另立任务)。

## 改动

- preset 资产与模板目录条目(见英文段)。
- `packages/cli/src/daemon/client.ts`:repo bootstrap 之前用 `localUserDaemonEndpoint` 推导 socket、忽略注入的 `HARNESS_DAEMON_ENDPOINT`;改走与其他 runtime 命令相同的 `resolveLocalDaemonEndpoint`(Run 1 正是死在这里)。加测试。

## 范围外

第二次跑停在的流转缺陷(`task start` 回执建议先 `declare-executor`,而它要求 `submitted`)——task_2331829ba142f64df9e198d76a 已派工;修好后跑第三次到全绿。

## 验证

定向测试 12/12、11/11;两次真实跑的原样记录与 tool-call 清单在任务包报告。
