### PR TITLE
fix(daemon): stop the task start receipt from directing executors to declare before submission

### DIFF
--- a/packages/daemon/src/repo-cell-packets.ts
+++ b/packages/daemon/src/repo-cell-packets.ts
@@ -191,7 +191,7 @@ export function lifecycleReceipt(
       event.type === "review_recorded" || event.type === "review_consent_recorded" ? event.payload.review : undefined,
     receiptReview = eventReview ?? selected?.review ?? (reviews.length === 1 ? reviews[0] : undefined),
     reviewId = receiptReview?.reviewId ?? null,
-    declarationNeeded = undeclared && reviews.length === 0,
+    declarationNeeded = snapshot.task?.status === "in_review" && undeclared && reviews.length === 0,
     consentCandidates = approved.length ? approved : approvedHistory,
     consentReviewId = consentCandidates.length === 1 ? consentCandidates[0]!.reviewId : "<review-id>",
     from =
@@ -260,12 +260,7 @@ export function lifecycleReceipt(
     summary =
       event.type === "execution_submitted" && event.payload.supersedesSubmissionId !== undefined
         ? "Submission amended; prior Review and consent pins are stale until reviewed or explicitly consented again."
-        : event.type === "execution_started" && undeclared
-          ? [
-              "Execution declared no executor; a same-person review will require an ",
-              "audited agent executor declaration before review.",
-            ].join("")
-          : undefined;
+        : undefined;
   return {
     outcome: "applied",
     opId: event.opId,

--- a/packages/daemon/test/review-independence-diagnostics.integration.test.ts
+++ b/packages/daemon/test/review-independence-diagnostics.integration.test.ts
@@ -197,7 +197,13 @@ test("a child bare-invocation execution can recover from its parent Task dispatc
       unknown
     >;
     assert.equal(started.outcome, "applied");
-    assert.match(String(started.summary), /declared no executor/u);
+    assert.deepEqual(started.next, [
+      {
+        command: `ha task submit ${taskId} --json-input '<submission-json>'`,
+        reason: "Run the canonical next command for this lifecycle state.",
+      },
+    ]);
+    assert.doesNotMatch(JSON.stringify(started), /declare-executor/u);
     const worker = await cell.spawnRuntime(
       {
         runtimeInstanceId: "review-runtime",
@@ -237,15 +243,12 @@ test("a child bare-invocation execution can recover from its parent Task dispatc
         commitSha,
       }),
     );
-    assert.equal(
-      (
-        await cell.run(
-          { kind: "task-submit", taskId, executionId: priorExecutionId, fromFile: "submission.json" },
-          bare,
-        )
-      ).outcome,
-      "applied",
+    const submitted = await cell.run(
+      { kind: "task-submit", taskId, executionId: priorExecutionId, fromFile: "submission.json" },
+      bare,
     );
+    assert.equal(submitted.outcome, "applied");
+    assert.match(JSON.stringify(submitted.next), /ha task declare-executor/u);
     writeFileSync(
       path.join(rootDir, "changes-requested.json"),
       JSON.stringify({


### PR DESCRIPTION
# English

## Summary

Lifecycle flow defect found by the Phase 5.3 black-box run (F-226B3495): a Consumer worker that only reads `--help` was told by the `ha task start` receipt to record its executor declaration next, while `ha task declare-executor` is a post-submission repair operation and rejects with `invalid_proof` until `status=submitted`. The worker stalled. The state machine is authoritative; the receipt guidance was computed too early.

## What Changed

- `packages/daemon/src/repo-cell-packets.ts`: `declarationNeeded` is true only at the submitted review node; the start receipt's lifecycle `next` reason and summary no longer mention `declare-executor`. Net −5 production lines; no precondition was relaxed.
- `packages/daemon/test/review-independence-diagnostics.integration.test.ts`: asserts the start receipt carries no executor-declaration guidance and the post-submit receipt does.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: use the single CI-backed `Production-Delta` declaration below; do not enter a second metric.

## Machine-Readable Declarations

Production-Delta: +2/-7

## Task And Scope

- Harness task: task_2331829ba142f64df9e198d76a (flow defect; unblocks task_f449e24f's third black-box run)
- Branch: codex/declare-order
- Public scope: one receipt-guidance condition in the daemon, one integration test
- Private planning/evidence updated: yes — `artifacts/reports/declare-order.md` (before/after raw receipts from an isolated repository), fact F-5A849F2A
- Out of scope: allowing pre-submission executor declaration for CEO-proxied submissions (would relax the state machine; not done)

## Version Impact

- Version: no version change because only receipt guidance text/conditions changed
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Authority: task_2331829ba142f64df9e198d76a under PLT-Ontology root task_5fc5080044fcfdbf548008f2f5; flow defects take priority by standing ruling

## Verification

- Isolated repository (`ha init` in mktemp, `env -u HARNESS_*`): before — start receipt `next.reason` directs to `declare-executor` and `declare-executor` rejects `invalid_proof`; after — start receipt carries no such guidance, `submit` then `declare-executor` works.
- `npm test -- --tier integration --file packages/daemon/test/review-independence-diagnostics.integration.test.ts` green; full matrix is CI's job.

## Review Evidence

- Independent review `rev_declare_order_indep` (Sol) in flight at PR time; result recorded on the task before merge.

## Residual Risk

- Guidance only; the state machine precondition is untouched, so a CEO proxying a worker's submission still declares the executor after `submit`.

---

# 中文

## 摘要

Phase 5.3 黑盒验收发现的流转缺陷(F-226B3495):只读 `--help` 的 Consumer worker 被 `ha task start` 回执引导去 declare-executor,而 `declare-executor` 是提交后的修复操作,`submitted` 之前一律 `invalid_proof`,worker 卡死。以状态机为权威,回执引导算早了。

## 改动

- `repo-cell-packets.ts`:`declarationNeeded` 只在 submitted 节点为真;start 回执的 lifecycle next reason 与 summary 不再提 declare-executor。净 −5 生产行,未放宽任何前置。
- 集成测试断言 start 回执无该引导、submit 后有。

## 验证

隔离仓改前/改后原样回执在任务包报告;集成测试绿。

## 残余风险

只改引导不改前置;CEO 代提 worker 提交时仍需 submit 后再 declare-executor。
