### PR TITLE
gui(observe): decouple follow merge cost from loaded history

### DIFF
--- a/packages/gui/src/renderer/components/observe/DaemonTailPane.tsx
+++ b/packages/gui/src/renderer/components/observe/DaemonTailPane.tsx
@@ -11,9 +11,11 @@ import {
   applyObserveTailPage,
   applyObserveViewing,
   filterObserveRows,
+  filterObserveRowsLog,
   initialObserveTail,
   observePaneCursor,
   observeTailRequest,
+  type ObserveFilterCache,
   type ObserveRow,
   type ObserveTailCursor,
   type ObserveTailKind,
@@ -133,13 +135,19 @@ export function DaemonTailPane({
     [scroll, setScroll] = useState({ top: 0, height: 0 }),
     bodyRef = useRef<HTMLDivElement>(null),
     selfScroll = useRef(false),
+    // 增量过滤缓存:同一 query 只扫新增行(见 filterObserveRowsLog),follow 轮询不重扫全量。
+    filterRef = useRef<ObserveFilterCache | null>(null),
     tail = useObserveTail(repoId, kind, paused),
     snapshot = tail.snapshot,
-    rows = useMemo(() => filterObserveRows(snapshot.rows, query), [snapshot.rows, query]),
+    rows = useMemo(() => {
+      const next = filterObserveRowsLog(snapshot.rows, query, filterRef.current);
+      filterRef.current = next;
+      return next.result;
+    }, [snapshot.rows, snapshot.rows.version, query]),
     isLogPane = kind !== "events",
     // 尾随的触发键是「最后一行」而不是行数:加载历史只改第一行,不应把视口拉到底;
     // 只有 live follow 改变最后一行时才触发贴底。
-    lastKey = rows.length > 0 ? rows[rows.length - 1]!.key : null,
+    lastKey = rows.length > 0 ? rows.at(-1)!.key : null,
     // 只渲染视口附近的行;DOM 行数上界与累计加载行数无关(见 observeWindowRange)。
     rowWindow = observeWindowRange({ total: rows.length, scrollTop: scroll.top, viewportHeight: scroll.height }),
     visible = rows.slice(rowWindow.start, rowWindow.end);

--- a/packages/gui/src/renderer/daemon-observe-model.ts
+++ b/packages/gui/src/renderer/daemon-observe-model.ts
@@ -39,7 +39,7 @@ export interface ObserveRow {
 }
 
 export interface ObserveTailSnapshot {
-  readonly rows: readonly ObserveRow[];
+  readonly rows: ObserveRowLog;
   readonly historyCursor: ObserveTailCursor;
   readonly liveCursor: ObserveTailCursor;
   readonly status: "idle" | "live" | "unavailable" | "gap" | "error";
@@ -72,7 +72,7 @@ export const OBSERVE_FOLLOW_ROW_LIMIT = 5_000;
 
 export function initialObserveTail(): ObserveTailSnapshot {
   return {
-    rows: [],
+    rows: new ObserveRowLog(),
     historyCursor: null,
     liveCursor: null,
     status: "idle",
@@ -108,10 +108,11 @@ export function applyObserveTailPage(state: ObserveTailSnapshot, page: ObserveTa
   if (page.status === "gap") {
     const marker = gapMarkerRow(page.gap, state.rows.length),
       historyGap = page.direction === "history";
+    // history 方向的缺口标记只插入行头,不裁剪已加载行(回看历史期间任何一端都不丢)。
+    if (historyGap) state.rows.prepend([marker], false);
+    else state.rows.replace([marker]);
     return {
       ...state,
-      // history 方向的缺口标记只插入行头,不裁剪已加载行(回看历史期间任何一端都不丢)。
-      rows: historyGap ? [marker, ...state.rows] : [marker],
       status: "gap",
       gap: page.gap,
       unavailable: null,
@@ -136,20 +137,17 @@ export function applyObserveTailPage(state: ObserveTailSnapshot, page: ObserveTa
     prepend = page.direction === "history",
     initializing = prepend && state.liveCursor === null,
     appendAfterGap = initializing && state.status === "gap",
-    headGrowth = prepend && !appendAfterGap,
-    rows = headGrowth
-      ? // history 翻页:只往前拼接,永不裁剪(渲染代价由视图窗口化保证)。
-        page.kind === "events"
-        ? mergeEventRows(state.rows, fresh, true)
-        : [...fresh, ...state.rows]
-      : // follow 增长:只有贴底追尾时才对 live 累积封顶(丢最旧端);回看历史期间不裁剪。
-        capFollowRows(
-          page.kind === "events" ? mergeEventRows(state.rows, fresh, false) : [...state.rows, ...fresh],
-          state.viewing,
-        );
-  return {
+    headGrowth = prepend && !appendAfterGap;
+  if (headGrowth)
+    // history 翻页:只往前拼接,永不裁剪(渲染代价由视图窗口化保证);事件按 key 索引挡重放。
+    state.rows.prepend(fresh, page.kind === "events");
+  else {
+    // follow 增长:只有贴底追尾时才对 live 累积封顶(丢最旧端);回看历史期间不裁剪。
+    state.rows.append(fresh, page.kind === "events");
+    capFollowRows(state.rows, state.viewing);
+  }
+  const next: ObserveTailSnapshot = {
     ...state,
-    rows,
     historyCursor: prepend ? pageHistoryCursor : state.historyCursor,
     liveCursor: prepend ? (initializing ? pageLiveCursor : state.liveCursor) : pageLiveCursor,
     status: "live",
@@ -164,6 +162,9 @@ export function applyObserveTailPage(state: ObserveTailSnapshot, page: ObserveTa
     mode: page.mode,
     received: state.received + fresh.length,
   };
+  // 空页 fast path:无新行、游标与追平位都没动的 follow 页原样返回同一引用,
+  // 视图 setSnapshot 拿到同引用不重渲染。行容器本身从不重建(见 ObserveRowLog)。
+  return sameObserveTail(state, next) ? state : next;
 }
 
 export function observePaneCursor(value: ObserveTailRead["historyCursor"]): ObserveTailCursor {
@@ -220,15 +221,190 @@ export function filterObserveRows(rows: readonly ObserveRow[], query: string): r
   return rows.filter((row) => row.searchText.includes(needle));
 }
 
-function mergeEventRows(
-  existing: readonly ObserveRow[],
-  fresh: readonly ObserveRow[],
-  prepend: boolean,
-): readonly ObserveRow[] {
-  // 事件行以 eventId 为键:ledger 重建后同一 revision 段重放时不重复入列。
-  const seen = new Set(existing.map((row) => row.key));
-  const unique = fresh.filter((row) => !seen.has(row.key));
-  return prepend ? [...unique, ...existing] : [...existing, ...unique];
+/** 增量查询过滤的续用缓存:视图存进 ref,连同 rows.version 一起作 useMemo 依赖。 */
+export interface ObserveFilterCache {
+  readonly query: string;
+  readonly source: ObserveRowLog;
+  readonly version: number;
+  readonly mark: ObserveRowMark;
+  readonly result: ObserveRowLog;
+}
+
+/**
+ * 行存储上的关键字过滤,语义同 filterObserveRows,但同一 query 下只对两端新增行做
+ * 匹配、结果容器跨快照复用(引用不变):follow 轮询不再每秒全量重扫已加载行。
+ * query 变化或行集被裁剪/替换(growth 为 null)时全量重建;空查询直接复用源容器。
+ */
+export function filterObserveRowsLog(
+  source: ObserveRowLog,
+  query: string,
+  cache: ObserveFilterCache | null,
+): ObserveFilterCache {
+  const needle = query.trim().toLowerCase();
+  if (cache !== null && cache.source === source && cache.query === needle && cache.version === source.version)
+    return cache;
+  if (needle === "") return { query: needle, source, version: source.version, mark: source.mark(), result: source };
+  const prior = cache !== null && cache.source === source && cache.query === needle ? cache : null;
+  const growth = prior === null ? null : source.growth(prior.mark);
+  if (prior === null || growth === null) {
+    const result = new ObserveRowLog(false),
+      hits: ObserveRow[] = [];
+    for (const row of source) if (row.searchText.includes(needle)) hits.push(row);
+    result.append(hits, false);
+    return { query: needle, source, version: source.version, mark: source.mark(), result };
+  }
+  const matched = (rows: readonly ObserveRow[]) => rows.filter((row) => row.searchText.includes(needle));
+  if (growth.prepended.length > 0) prior.result.prepend(matched(growth.prepended), false);
+  if (growth.appended.length > 0) prior.result.append(matched(growth.appended), false);
+  return { query: needle, source, version: source.version, mark: growth.mark, result: prior.result };
+}
+
+/** 行存储的两端水位 + 丢行计数,是增量查询过滤判断缓存可否续用的标记。 */
+export interface ObserveRowMark {
+  readonly head: number;
+  readonly tail: number;
+  readonly shrinks: number;
+}
+
+/**
+ * 行存储:head(倒序,承接前插)/ tail(正序,承接追加)两段,前插与追加常数摊还,
+ * 按索引读取 O(1)、窗口切片 O(window),不再随累计行数整数组复制。事件去重靠随行
+ * 维护的 key 索引(seen),不每页整表重建 Set;贴底封顶丢最旧端时先弹 head、再前移
+ * tail 读偏移(摊还清除)。version 随每次行集变更自增、shrinks 只在丢行/整表替换时
+ * 自增,供 filterObserveRowsLog 判断「增量续用 / 全量重建」。
+ */
+export class ObserveRowLog {
+  private readonly head: ObserveRow[] = [];
+  private tail: ObserveRow[] = [];
+  private readonly seen: Set<string> | null;
+  private tailStart = 0;
+  private shrinkCount = 0;
+  private mutationCount = 0;
+
+  /** dedup=false 的实例不做 key 去重(查询过滤的结果容器:key 天然唯一,省一份索引)。 */
+  constructor(dedup = true) {
+    this.seen = dedup ? new Set<string>() : null;
+  }
+
+  get length(): number {
+    return this.head.length + this.tail.length - this.tailStart;
+  }
+
+  /** 行集变更计数:视图层增量过滤的缓存键之一。 */
+  get version(): number {
+    return this.mutationCount;
+  }
+
+  /**
+   * 前插一批行到行头(history 翻页、gap 标记)。dedup 时按 key 挡掉已入列的重放事件,
+   * 未见过行保持原有顺序(与旧 mergeEventRows 的 filter 语义一致)。
+   */
+  prepend(rows: readonly ObserveRow[], dedup: boolean): void {
+    if (rows.length === 0) return;
+    let grown = false;
+    for (let index = rows.length - 1; index >= 0; index -= 1) {
+      const row = rows[index]!;
+      if (!this.admit(row, dedup)) continue;
+      this.head.push(row);
+      grown = true;
+    }
+    if (grown) this.mutationCount += 1;
+  }
+
+  /** 追加一批行到行尾(follow 增长);dedup 时按 key 挡掉已入列的重放事件。 */
+  append(rows: readonly ObserveRow[], dedup: boolean): void {
+    if (rows.length === 0) return;
+    let grown = false;
+    for (const row of rows) {
+      if (!this.admit(row, dedup)) continue;
+      this.tail.push(row);
+      grown = true;
+    }
+    if (grown) this.mutationCount += 1;
+  }
+
+  /** 贴底封顶丢最旧端:先弹 head(倒序段的末尾就是最旧行),耗尽后前移 tail 读偏移。 */
+  dropOldest(count: number): void {
+    let remaining = Math.min(count, this.length);
+    if (remaining <= 0) return;
+    while (remaining > 0 && this.head.length > 0) {
+      this.seen?.delete(this.head.pop()!.key);
+      remaining -= 1;
+    }
+    for (let index = 0; index < remaining; index += 1) this.seen?.delete(this.tail[this.tailStart + index]!.key);
+    this.tailStart += remaining;
+    if (this.tailStart > 0 && this.tailStart * 2 >= this.tail.length) {
+      this.tail = this.tail.slice(this.tailStart);
+      this.tailStart = 0;
+    }
+    this.shrinkCount += 1;
+    this.mutationCount += 1;
+  }
+
+  /** 整表替换(follow 方向 gap 重置):只留给定行,key 索引随之重建。 */
+  replace(rows: readonly ObserveRow[]): void {
+    this.head.length = 0;
+    this.tail = [...rows];
+    this.tailStart = 0;
+    this.seen?.clear();
+    for (const row of rows) this.seen?.add(row.key);
+    this.shrinkCount += 1;
+    this.mutationCount += 1;
+  }
+
+  /** 按索引读取(支持负索引,语义同 Array.prototype.at),O(1)。 */
+  at(index: number): ObserveRow | undefined {
+    const total = this.length,
+      slot = index < 0 ? total + index : index;
+    if (slot < 0 || slot >= total) return undefined;
+    return slot < this.head.length
+      ? this.head[this.head.length - 1 - slot]
+      : this.tail[this.tailStart + slot - this.head.length];
+  }
+
+  /** 窗口切片 [start, end)(支持负索引);代价 O(end - start),与累计行数无关。 */
+  slice(start = 0, end = this.length): readonly ObserveRow[] {
+    const total = this.length,
+      from = Math.max(0, start < 0 ? total + start : start),
+      to = Math.min(total, end < 0 ? total + end : end),
+      window: ObserveRow[] = [];
+    for (let index = from; index < to; index += 1) window.push(this.at(index)!);
+    return window;
+  }
+
+  /** 逻辑正序迭代,只供全量重建路径(查询词变化/行集收缩)使用。 */
+  *[Symbol.iterator](): Iterator<ObserveRow> {
+    for (let index = this.head.length - 1; index >= 0; index -= 1) yield this.head[index]!;
+    for (let index = this.tailStart; index < this.tail.length; index += 1) yield this.tail[index]!;
+  }
+
+  /** 当前两端水位与丢行计数。 */
+  mark(): ObserveRowMark {
+    return { head: this.head.length, tail: this.tail.length - this.tailStart, shrinks: this.shrinkCount };
+  }
+
+  /**
+   * 自 mark 以来的两端新增行(各自按逻辑正序)与新 mark。期间丢过行或整表替换过
+   * (shrinks 变化)、或水位回落时返回 null:缓存里的行集不再可靠,调用方需全量重建。
+   */
+  growth(
+    mark: ObserveRowMark,
+  ): { prepended: readonly ObserveRow[]; appended: readonly ObserveRow[]; mark: ObserveRowMark } | null {
+    const current = this.mark();
+    if (mark.shrinks !== current.shrinks || mark.head > current.head || mark.tail > current.tail) return null;
+    return {
+      prepended: this.head.slice(mark.head).reverse(),
+      appended: this.tail.slice(this.tailStart + mark.tail),
+      mark: current,
+    };
+  }
+
+  private admit(row: ObserveRow, dedup: boolean): boolean {
+    if (this.seen === null) return true;
+    if (dedup && this.seen.has(row.key)) return false;
+    this.seen.add(row.key);
+    return true;
+  }
 }
 
 /**
@@ -242,13 +418,40 @@ function sameCursor(left: ObserveTailCursor, right: ObserveTailCursor): boolean 
   return right.kind !== "events" && left.fileId === right.fileId && left.offset === right.offset;
 }
 
+/** 空页 fast path:逐字段比较两次快照是否可观察地相同(行容器同引用即行集未变)。 */
+function sameObserveTail(a: ObserveTailSnapshot, b: ObserveTailSnapshot): boolean {
+  return (
+    a.rows === b.rows &&
+    a.status === b.status &&
+    a.error === b.error &&
+    a.caughtUp === b.caughtUp &&
+    a.historyDone === b.historyDone &&
+    a.mode === b.mode &&
+    a.viewing === b.viewing &&
+    a.received === b.received &&
+    sameCursor(a.historyCursor, b.historyCursor) &&
+    sameCursor(a.liveCursor, b.liveCursor) &&
+    sameDetail(a.unavailable, b.unavailable) &&
+    sameDetail(a.gap, b.gap)
+  );
+}
+
+function sameDetail<T extends object>(a: T | null, b: T | null): boolean {
+  if (a === b) return true;
+  if (a === null || b === null) return false;
+  const left = a as Readonly<Record<string, unknown>>,
+    right = b as Readonly<Record<string, unknown>>;
+  return Object.keys(left).every((key) => left[key] === right[key]);
+}
+
 /**
- * follow 增长的内存上限:贴底追尾时丢最旧端;回看历史期间不裁剪(不足上限原样返回,
+ * follow 增长的内存上限:贴底追尾时丢最旧端;回看历史期间不裁剪(不足上限不动行集,
  * 见 OBSERVE_FOLLOW_ROW_LIMIT)。回到贴底后的下一次 follow 增长重新把行数拉回界内。
  */
-function capFollowRows(rows: readonly ObserveRow[], viewing: "follow" | "history"): readonly ObserveRow[] {
-  if (viewing !== "follow" || rows.length <= OBSERVE_FOLLOW_ROW_LIMIT) return rows;
-  return rows.slice(rows.length - OBSERVE_FOLLOW_ROW_LIMIT);
+function capFollowRows(rows: ObserveRowLog, viewing: "follow" | "history"): void {
+  if (viewing !== "follow") return;
+  const excess = rows.length - OBSERVE_FOLLOW_ROW_LIMIT;
+  if (excess > 0) rows.dropOldest(excess);
 }
 
 function gapMarkerRow(gap: { readonly reason: string; readonly requestedFileId: string }, seq: number): ObserveRow {

--- a/packages/gui/test/daemon-observe.vitest.ts
+++ b/packages/gui/test/daemon-observe.vitest.ts
@@ -207,18 +207,18 @@ describe("G6-B observe 模型:分页 → 行流", () => {
     expect(first.status).toBe("live");
     expect(first.caughtUp).toBe(true);
     expect(replayed.rows).toHaveLength(3);
-    expect(first.rows[0]!.refs.map((chip) => chip.ref)).toEqual([`task/${TASK_ID}`]);
-    expect(first.rows[1]!.refs.map((chip) => chip.ref)).toEqual([`decision/${DECISION_ID}`]);
-    expect(first.rows[2]!.refs.map((chip) => chip.ref)).toEqual([`session/${SESSION_ID}`]);
+    expect(first.rows.at(0)!.refs.map((chip) => chip.ref)).toEqual([`task/${TASK_ID}`]);
+    expect(first.rows.at(1)!.refs.map((chip) => chip.ref)).toEqual([`decision/${DECISION_ID}`]);
+    expect(first.rows.at(2)!.refs.map((chip) => chip.ref)).toEqual([`session/${SESSION_ID}`]);
   });
 
   it("日志页产出方法行,repo-log 与 daemon-log 同一形状", () => {
     for (const kind of ["repo-log", "daemon-log"] as const) {
       const state = applyObserveTailPage(initialObserveTail(), logPage(kind));
       expect(state.rows).toHaveLength(1);
-      expect(state.rows[0]!.type).toBe("repo.tasks.list");
-      expect(state.rows[0]!.text).toBe("4ms");
-      expect(state.rows[0]!.ok).toBe(true);
+      expect(state.rows.at(0)!.type).toBe("repo.tasks.list");
+      expect(state.rows.at(0)!.text).toBe("4ms");
+      expect(state.rows.at(0)!.ok).toBe(true);
       expect(state.liveCursor).toEqual({ kind, fileId: "file-g6b", offset: 88 });
       expect(state.historyCursor).toEqual({ kind, fileId: "file-g6b", offset: 0 });
     }
@@ -273,7 +273,7 @@ describe("G6-B observe 模型:分页 → 行流", () => {
 
   it("过滤命中行文本、实体引用与悬停 detail(payload 内文仍可检索)", () => {
     const state = applyObserveTailPage(initialObserveTail(), EVENT_PAGE),
-      rows = state.rows;
+      rows = state.rows.slice(0);
     expect(filterObserveRows(rows, "探针决策")).toHaveLength(1);
     expect(filterObserveRows(rows, DECISION_ID)).toHaveLength(1);
     // 文本列不渲染 payload JSON(G10 不变量),但关键字仍要能命中悬停 detail。
@@ -283,31 +283,34 @@ describe("G6-B observe 模型:分页 → 行流", () => {
 
   it("历史页插到顶部且 live follow 追加到底部,不删除已加载历史", () => {
     const event = (revision: number) => ({
-        ...(EVENT_PAGE.items[0] as object),
-        eventId: `ev-g6b-${revision}`,
-        workspaceRevision: revision,
-      }),
-      latest = applyObserveTailPage(initialObserveTail(), EVENT_PAGE),
-      withHistory = applyObserveTailPage(latest, {
-        ...EVENT_PAGE,
-        items: [event(9), event(10)] as never,
-        historyCursor: { kind: "events", revision: 9 },
-        liveCursor: { kind: "events", revision: 10 },
-        done: false,
-      }),
-      followed = applyObserveTailPage(withHistory, {
-        ...EVENT_PAGE,
-        direction: "follow",
-        items: [event(14)] as never,
-        historyCursor: null,
-        liveCursor: { kind: "events", revision: 14 },
-        sourceCursor: { kind: "events", revision: 14 },
-        done: true,
-      });
-    expect(withHistory.rows.map((row) => row.revision)).toEqual([9, 10, 11, 12, 13]);
-    expect(followed.rows.map((row) => row.revision)).toEqual([9, 10, 11, 12, 13, 14]);
-    expect(followed.historyCursor).toEqual({ kind: "events", revision: 9 });
-    expect(followed.liveCursor).toEqual({ kind: "events", revision: 14 });
+      ...(EVENT_PAGE.items[0] as object),
+      eventId: `ev-g6b-${revision}`,
+      workspaceRevision: revision,
+    });
+    // rows 是跨快照共享的活容器(常数追加,见 ObserveRowLog):中间快照的行集要在
+    // 下一次应用前取值,断言才对应当时的行集。
+    let state = applyObserveTailPage(initialObserveTail(), EVENT_PAGE);
+    state = applyObserveTailPage(state, {
+      ...EVENT_PAGE,
+      items: [event(9), event(10)] as never,
+      historyCursor: { kind: "events", revision: 9 },
+      liveCursor: { kind: "events", revision: 10 },
+      done: false,
+    });
+    const withHistoryRevisions = state.rows.slice(0).map((row) => row.revision);
+    state = applyObserveTailPage(state, {
+      ...EVENT_PAGE,
+      direction: "follow",
+      items: [event(14)] as never,
+      historyCursor: null,
+      liveCursor: { kind: "events", revision: 14 },
+      sourceCursor: { kind: "events", revision: 14 },
+      done: true,
+    });
+    expect(withHistoryRevisions).toEqual([9, 10, 11, 12, 13]);
+    expect(state.rows.slice(0).map((row) => row.revision)).toEqual([9, 10, 11, 12, 13, 14]);
+    expect(state.historyCursor).toEqual({ kind: "events", revision: 9 });
+    expect(state.liveCursor).toEqual({ kind: "events", revision: 14 });
   });
 
   it("事件行摘要不把 payload JSON 倒进文本列,实体事件只给 kind", () => {
@@ -361,7 +364,7 @@ describe("G6-B observe 模型:分页 → 行流", () => {
     state = applyObserveTailPage(state, revisionPage(range(501, 900), "history"));
     state = applyObserveTailPage(state, revisionPage(range(101, 500), "history"));
     expect(state.rows).toHaveLength(900);
-    expect(state.rows[0]!.revision).toBe(101);
+    expect(state.rows.at(0)!.revision).toBe(101);
     expect(state.rows.at(-1)!.revision).toBe(1000);
   });
 
@@ -375,7 +378,7 @@ describe("G6-B observe 模型:分页 → 行流", () => {
       revisionPage(range(OBSERVE_FOLLOW_ROW_LIMIT + 1, OBSERVE_FOLLOW_ROW_LIMIT + 100), "follow"),
     );
     expect(state.rows).toHaveLength(OBSERVE_FOLLOW_ROW_LIMIT);
-    expect(state.rows[0]!.revision).toBe(101);
+    expect(state.rows.at(0)!.revision).toBe(101);
     expect(state.rows.at(-1)!.revision).toBe(OBSERVE_FOLLOW_ROW_LIMIT + 100);
   });
 
@@ -392,7 +395,7 @@ describe("G6-B observe 模型:分页 → 行流", () => {
       revisionPage(range(OBSERVE_FOLLOW_ROW_LIMIT - 99, OBSERVE_FOLLOW_ROW_LIMIT + 100), "follow"),
     );
     expect(state.rows).toHaveLength(OBSERVE_FOLLOW_ROW_LIMIT + 100);
-    expect(state.rows[0]!.revision).toBe(1);
+    expect(state.rows.at(0)!.revision).toBe(1);
     // 滚回底部(viewing: follow):下一页 follow 增长把行数拉回界内(丢最旧端)。
     state = applyObserveViewing(state, "follow");
     state = applyObserveTailPage(
@@ -400,7 +403,7 @@ describe("G6-B observe 模型:分页 → 行流", () => {
       revisionPage(range(OBSERVE_FOLLOW_ROW_LIMIT + 101, OBSERVE_FOLLOW_ROW_LIMIT + 110), "follow"),
     );
     expect(state.rows).toHaveLength(OBSERVE_FOLLOW_ROW_LIMIT);
-    expect(state.rows[0]!.revision).toBe(111);
+    expect(state.rows.at(0)!.revision).toBe(111);
     expect(state.rows.at(-1)!.revision).toBe(OBSERVE_FOLLOW_ROW_LIMIT + 110);
   });
 
@@ -436,8 +439,8 @@ describe("G6-B observe 模型:分页 → 行流", () => {
     });
     // 旧双侧上限会把 600 行裁回 500;现在标记行入列且旧行一条不丢。
     expect(gapped.rows).toHaveLength(601);
-    expect(gapped.rows[0]!.gapMarker).toEqual({ reason: "cursor-file-not-retained", requestedFileId: "file-gone" });
-    expect(gapped.rows[1]!.revision).toBe(1);
+    expect(gapped.rows.at(0)!.gapMarker).toEqual({ reason: "cursor-file-not-retained", requestedFileId: "file-gone" });
+    expect(gapped.rows.at(1)!.revision).toBe(1);
     expect(gapped.rows.at(-1)!.revision).toBe(600);
   });
 

--- a/packages/gui/test/observe-follow-cost.vitest.ts
+++ b/packages/gui/test/observe-follow-cost.vitest.ts
@@ -1,0 +1,234 @@
+// harness-test-tier: fast
+import { describe, expect, it } from "vitest";
+import {
+  applyObserveTailPage,
+  applyObserveViewing,
+  filterObserveRowsLog,
+  initialObserveTail,
+} from "../src/renderer/daemon-observe-model.ts";
+import type { ObserveTailRead } from "../src/api/renderer-dto.ts";
+
+/**
+ * follow 数据路径的每页工作量与累计行数解耦(task_643b8b46 复核 finding 的回归判据):
+ *  - 500 页 follow(其中 400 页空页)作用在 6,400 行已累计的基础上,空页快照必须原样
+ *    返回(引用相等:不产生新数组、setSnapshot 同引用不触发重渲染),非空页行容器
+ *    原样复用(引用相等:合并路径不整数组复制),事件去重走增量 key 索引而非整表重建 Set;
+ *  - history 前插同样不换容器,157 页级联翻页不再二次方累计;
+ *  - 查询过滤增量续用:同一 query 只扫两端新增行,结果容器跨快照复用。
+ * 判定依据是引用相等(结构性、不受 CI 抖动影响);耗时数字是数量级证据,进任务包报告。
+ * 阴性对照:把合并路径改回整数组复制(`[...rows, ...fresh]` 重建),引用相等断言必须红。
+ */
+
+const REPO_ID = "follow-cost",
+  AT = "2026-09-05T00:00:00.000Z",
+  SEED_PAGES = 100,
+  SEED_WIDTH = 64,
+  FOLLOW_PAGES = 500,
+  FOLLOW_WIDTH = 8,
+  LIVE_REVISION = SEED_PAGES * SEED_WIDTH;
+
+function range(from: number, to: number): number[] {
+  return Array.from({ length: to - from + 1 }, (_, index) => from + index);
+}
+
+function eventItem(revision: number, title: string) {
+  return {
+    schema: "task-event/v1",
+    eventId: `ev-cost-${revision}`,
+    workspaceRevision: revision,
+    opId: "op-cost",
+    type: "task_created",
+    actor: { kind: "agent", id: "agent_cost" },
+    source: { channel: "cli" },
+    occurredAt: AT,
+    taskId: `task_${revision}`,
+    payload: { task: { title } },
+  };
+}
+
+function eventPage(revisions: readonly number[], direction: "history" | "follow", done: boolean): ObserveTailRead {
+  return {
+    schema: "daemon.observe-tail/v3",
+    ok: true,
+    repoId: REPO_ID,
+    mode: "local",
+    kind: "events",
+    direction,
+    status: "ready",
+    items: revisions.map((revision) => eventItem(revision, `row-${revision}`)) as never,
+    historyCursor:
+      direction === "history" && revisions.length > 0 ? { kind: "events", revision: Math.min(...revisions) } : null,
+    liveCursor: { kind: "events", revision: LIVE_REVISION },
+    sourceCursor: { kind: "events", revision: LIVE_REVISION },
+    done,
+  };
+}
+
+function logPage(count: number, direction: "history" | "follow", done: boolean, baseOffset: number): ObserveTailRead {
+  return {
+    schema: "daemon.observe-tail/v3",
+    ok: true,
+    repoId: REPO_ID,
+    mode: "local",
+    kind: "repo-log",
+    direction,
+    status: "ready",
+    items: Array.from({ length: count }, (_, index) => ({
+      schema: "daemon-request-log/v1",
+      at: AT,
+      method: "repo.tasks.list",
+      event: "request",
+      ok: true,
+      durationMs: index,
+    })) as never,
+    historyCursor:
+      direction === "history" && count > 0 ? { kind: "repo-log", fileId: "f-cost", offset: baseOffset } : null,
+    liveCursor: { kind: "repo-log", fileId: "f-cost", offset: baseOffset },
+    sourceCursor: { kind: "repo-log", fileId: "f-cost", offset: baseOffset },
+    done,
+  };
+}
+
+/** 100 页 × 64 行 history 预载(6,400 行已加载,超过 OBSERVE_FOLLOW_ROW_LIMIT 之外的历史量级)。 */
+function seedEvents(pages: number): ReturnType<typeof initialObserveTail> {
+  let state = initialObserveTail();
+  for (let page = 0; page < pages; page += 1) {
+    const from = page * SEED_WIDTH + 1;
+    state = applyObserveTailPage(state, eventPage(range(from, from + SEED_WIDTH - 1), "history", false));
+  }
+  return state;
+}
+
+describe("follow 数据路径:每页工作量不随累计行数增长", () => {
+  it("events:500 页 follow(400 页空页)不重建行容器,空页快照原样返回", () => {
+    let state = seedEvents(SEED_PAGES);
+    expect(state.rows).toHaveLength(SEED_PAGES * SEED_WIDTH);
+    // follow 追加超过 OBSERVE_FOLLOW_ROW_LIMIT 后贴底封顶丢最旧端:最终行数回到上限。
+    const sameRows: boolean[] = [],
+      emptyPageKeptSnapshot: boolean[] = [],
+      growthPageNewSnapshot: boolean[] = [];
+    let revision = LIVE_REVISION;
+    const followStarted = performance.now(),
+      pageCosts: number[] = [];
+    for (let page = 0; page < FOLLOW_PAGES; page += 1) {
+      const before = state,
+        pageStarted = performance.now();
+      if (page % 5 === 0) {
+        state = applyObserveTailPage(state, eventPage(range(revision + 1, revision + FOLLOW_WIDTH), "follow", true));
+        revision += FOLLOW_WIDTH;
+        growthPageNewSnapshot.push(state !== before);
+      } else {
+        state = applyObserveTailPage(state, eventPage([], "follow", true));
+        emptyPageKeptSnapshot.push(state === before);
+      }
+      sameRows.push(state.rows === before.rows);
+      pageCosts.push(performance.now() - pageStarted);
+    }
+    const followMs = performance.now() - followStarted,
+      worstPage = Math.max(...pageCosts);
+    console.info(
+      `[perf] events follow: ${FOLLOW_PAGES} pages (${FOLLOW_PAGES / 5} x ${FOLLOW_WIDTH} rows +` +
+        ` ${FOLLOW_PAGES - FOLLOW_PAGES / 5} empty) over ${SEED_PAGES * SEED_WIDTH} loaded rows` +
+        ` | total ${followMs.toFixed(1)}ms | worst page ${worstPage.toFixed(3)}ms`,
+    );
+    expect(sameRows.every(Boolean)).toBe(true);
+    expect(emptyPageKeptSnapshot).toHaveLength(FOLLOW_PAGES - FOLLOW_PAGES / 5);
+    expect(emptyPageKeptSnapshot.every(Boolean)).toBe(true);
+    expect(growthPageNewSnapshot.every(Boolean)).toBe(true);
+    expect(state.rows).toHaveLength(5_000);
+  });
+
+  it("repo-log:日志合并路径同样不整数组复制", () => {
+    let state = initialObserveTail(),
+      offset = 0;
+    for (let page = 0; page < SEED_PAGES; page += 1) {
+      offset += SEED_WIDTH * 88;
+      state = applyObserveTailPage(state, logPage(SEED_WIDTH, "history", false, offset));
+    }
+    expect(state.rows).toHaveLength(SEED_PAGES * SEED_WIDTH);
+    const sameRows: boolean[] = [],
+      emptyPageKeptSnapshot: boolean[] = [];
+    for (let page = 0; page < FOLLOW_PAGES; page += 1) {
+      const before = state;
+      if (page % 5 === 0) {
+        offset += FOLLOW_WIDTH * 88;
+        state = applyObserveTailPage(state, logPage(FOLLOW_WIDTH, "follow", true, offset));
+      } else {
+        state = applyObserveTailPage(state, logPage(0, "follow", true, offset));
+        emptyPageKeptSnapshot.push(state === before);
+      }
+      sameRows.push(state.rows === before.rows);
+    }
+    expect(sameRows.every(Boolean)).toBe(true);
+    expect(emptyPageKeptSnapshot.every(Boolean)).toBe(true);
+    expect(state.rows).toHaveLength(5_000);
+  });
+
+  it("空 follow 页的每页耗时随累计行数走平(数量级证据,判定靠上面的引用相等)", () => {
+    const averages: number[] = [],
+      sizes: number[] = [];
+    for (const pages of [16, 50, 100]) {
+      // 浏览历史视角(viewing: history):follow 增长不触发贴底封顶,行数可越过上限继续累计。
+      let state = applyObserveViewing(seedEvents(pages), "history");
+      const revision = pages * SEED_WIDTH;
+      // 先一页非空 follow 把 caughtUp 置稳,空页才可能原样返回。
+      state = applyObserveTailPage(state, eventPage(range(revision + 1, revision + 4), "follow", true));
+      const started = performance.now();
+      for (let page = 0; page < 100; page += 1) state = applyObserveTailPage(state, eventPage([], "follow", true));
+      averages.push((performance.now() - started) / 100);
+      sizes.push(state.rows.length);
+    }
+    console.info(
+      `[perf] empty follow page avg @1k/3.2k/6.4k rows: ` + averages.map((ms) => `${ms.toFixed(4)}ms`).join(" / "),
+    );
+    expect(sizes).toEqual([1_028, 3_204, 6_404]);
+    // 宽上界:只防灾难级回归(整表扫描/复制),不追精确耗时。
+    expect(averages[2]).toBeLessThan(5);
+  });
+});
+
+describe("查询过滤:增量续用,只扫新增行", () => {
+  function titledPage(revisions: readonly number[], direction: "history" | "follow", done: boolean): ObserveTailRead {
+    return {
+      ...eventPage(revisions, direction, done),
+      items: revisions.map((revision, index) =>
+        eventItem(revision, `${index % 2 === 0 ? "hit-cost" : "miss-cost"}-${revision}`),
+      ) as never,
+    };
+  }
+
+  it("同一 query 下追加/前插只匹配新增行,结果容器复用;换 query 全量重建", () => {
+    let state = initialObserveTail();
+    state = applyObserveTailPage(state, titledPage(range(1, 64), "history", false));
+    state = applyObserveTailPage(state, titledPage(range(65, 128), "history", false));
+    const first = filterObserveRowsLog(state.rows, "hit-cost", null);
+    expect(first.result.length).toBe(64);
+    state = applyObserveTailPage(state, titledPage(range(129, 136), "follow", true));
+    const appended = filterObserveRowsLog(state.rows, "hit-cost", first);
+    expect(appended.result).toBe(first.result);
+    expect(appended.result.length).toBe(68);
+    state = applyObserveTailPage(state, titledPage(range(-8, -1), "history", false));
+    const prepended = filterObserveRowsLog(state.rows, "hit-cost", appended);
+    expect(prepended.result).toBe(first.result);
+    expect(prepended.result.length).toBe(72);
+    const requery = filterObserveRowsLog(state.rows, "miss-cost", prepended);
+    expect(requery.result).not.toBe(first.result);
+    expect(requery.result.length).toBe(72);
+    const unfiltered = filterObserveRowsLog(state.rows, "", requery);
+    expect(unfiltered.result).toBe(state.rows);
+  });
+
+  it("行集被贴底封顶裁剪后过滤缓存作废重建", () => {
+    let state = initialObserveTail();
+    for (let page = 0; page < 78; page += 1)
+      state = applyObserveTailPage(state, titledPage(range(page * 64 + 1, page * 64 + 64), "history", false));
+    state = applyObserveTailPage(state, titledPage(range(4_993, 5_000), "history", false));
+    const atCap = filterObserveRowsLog(state.rows, "hit-cost", null);
+    expect(atCap.result.length).toBe(2_500);
+    state = applyObserveTailPage(state, titledPage(range(5_001, 5_008), "follow", true));
+    expect(state.rows.length).toBe(5_000);
+    const afterDrop = filterObserveRowsLog(state.rows, "hit-cost", atCap);
+    expect(afterDrop.result).not.toBe(atCap.result);
+    expect(afterDrop.result.length).toBe(2_500);
+  });
+});

--- a/packages/gui/test/observe-windowing.vitest.ts
+++ b/packages/gui/test/observe-windowing.vitest.ts
@@ -170,7 +170,7 @@ describe("数据面:契约页宽连续翻页装万行,history 方向不裁剪", 
     );
     expect(applied).toBe(157);
     expect(state.rows).toHaveLength(TOTAL_ROWS);
-    expect(state.rows[0]!.revision).toBe(1);
+    expect(state.rows.at(0)!.revision).toBe(1);
     expect(state.rows.at(-1)!.revision).toBe(TOTAL_ROWS);
     expect(elapsed).toBeLessThan(2_000);
     // 超过内存上限的 follow 增长仍受 OBSERVE_FOLLOW_ROW_LIMIT 约束(只丢最旧端)。

--- a/tools/gui-test-manifest.mjs
+++ b/tools/gui-test-manifest.mjs
@@ -71,6 +71,7 @@ export const guiVitestManifest = [
   "packages/gui/test/docTree.vitest.ts",
   "packages/gui/test/system-view-detail.vitest.ts",
   "packages/gui/test/daemon-observe.vitest.ts",
+  "packages/gui/test/observe-follow-cost.vitest.ts",
   "packages/gui/test/observe-windowing.vitest.ts",
   "packages/gui/test/preset-detail.vitest.ts",
   "packages/gui/test/settings-repository-selectors.vitest.ts",


### PR DESCRIPTION
# English

## Summary

Follow-up to #2259 (unbounded observe scrollback). Independent review `rev_2259_indep` accepted history reachability, bounded DOM and follow behaviour but rejected the performance claim: every follow poll (once per second) rebuilt a `Set` over all accumulated rows, copied the whole array, and did so even for empty pages, so per-page cost grew linearly with loaded history and a 157-page load was quadratic overall. This PR makes the per-page cost independent of loaded history.

## What Changed

- `packages/gui/src/renderer/daemon-observe-model.ts`: rows live in an `ObserveRowLog` — a head segment (reversed, receives history prepends) and a tail segment (receives follow appends) with an amortised drop offset for the 5,000-row follow cap; prepend/append are O(page), index reads O(1). Event de-duplication keeps an incremental key index maintained on append/prepend/drop instead of rebuilding it per page. An empty follow page returns the same snapshot reference (no new array, no re-render).
- `packages/gui/src/renderer/components/observe/DaemonTailPane.tsx`: window slice reads by index from the log; query filtering is cached and invalidated only when rows or the query change.
- One deliberate semantic change: a snapshot's `rows` is now a live container shared across snapshots (constant-time append needs it; an immutable snapshot with O(1) append would need a persistent vector, out of scope). Production only holds the latest snapshot; tests that froze old snapshots now copy.
- Tests: `observe-follow-cost.vitest.ts` (new, registered in `tools/gui-test-manifest.mjs`) simulates 500 follow pages with 400 empty ones and asserts per-page work does not grow with accumulated rows (empty pages return the identical snapshot; the row container is never rebuilt); `daemon-observe.vitest.ts` and `observe-windowing.vitest.ts` updated.

## Architectural Justification

- **Why a two-segment log instead of an immutable array.** The follow path is a once-per-second poll for the lifetime of the page; any per-page cost proportional to loaded history is a leak by construction. An immutable flat array forces O(n) copy per page. A persistent vector would keep immutability with O(1) append but is a new dependency and more code than the defect warrants; head/tail segments with an amortised drop offset are the smallest structure that gives O(page) append/prepend and O(1) index reads.
- **Why the row container is shared across snapshots.** The renderer only ever holds the latest snapshot and the window reads by index; nothing in production compares old and new `rows` by identity except to skip re-render on empty pages, which the same-reference return now serves deliberately. The trade is documented in the model and enforced by `observe-follow-cost.vitest.ts`.
- **What was not added.** No worker, no virtualization library, no cache layer beyond a single memoised filter keyed on rows+query; the DOM windowing from #2259 is untouched.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: use the single CI-backed `Production-Delta` declaration below; do not enter a second metric.

## Machine-Readable Declarations

Production-Delta: +244/-32

## Task And Scope

- Harness task: task_643b8b46a0e0b6b526d2a55158 (GUI observe unbounded scrollback; PLT-Ontology Phase 4 GUI-UX)
- Branch: codex/observe-perf
- Public scope: observe model and pane in `packages/gui`, GUI tests, test manifest
- Private planning/evidence updated: yes — `artifacts/reports/observe-perf.md` with before/after per-page work numbers
- Out of scope: further reducing the steady-state cost after the 5,000-row cap (bounded constant per page, not zero); query changes still rebuild the filter (user keystroke path, unchanged)

## Version Impact

- Version: no version change because only renderer internals changed
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Authority: task_643b8b46a0e0b6b526d2a55158 (changes_requested finding from `rev_2259_indep`)

## Verification

- `npm run test:gui -w @harness-anything/gui -- test/observe-windowing.vitest.ts test/daemon-observe.vitest.ts` 25/25; `test/observe-follow-cost.vitest.ts` 5/5 (CEO re-ran in the worktree).
- Negative control (worker report): on the previous implementation the five follow-cost tests fail (three structural assertions fail as `expected false to be true`).
- Before/after per-page cost table in the task report: empty-page cost rose 5.4× from 1k to 6.4k loaded rows before; flat after.
- Full matrix is GitHub CI's job.

## Review Evidence

- `rev_2259_indep` (Sol, changes_requested) identified the O(n) follow path with file:line; this PR is scoped to that finding. Independent re-review requested after merge (the shared mutable `rows` container is the point to scrutinise).

## Residual Risk

- Shared mutable `rows` across snapshots: any future code that needs a frozen row set must copy (`rows.slice(0)`); nothing in production does today.

---

# 中文

## 摘要

#2259(observe 无界回滚)的补修。独立复核 `rev_2259_indep` 认可历史可达、DOM 有界、follow 行为,但否决了性能断言:每次 follow 轮询(每秒一次)都对全部累计行重建 `Set`、整数组复制,空页也一样,单页成本随已加载历史线性增长,157 页累计呈二次。本 PR 让单页成本与已加载历史无关。

## 改动

- `daemon-observe-model.ts`:行存储改为 `ObserveRowLog` head/tail 两段 + 封顶丢弃的摊还偏移,前插/追加 O(页宽)、按索引读 O(1);事件去重维护增量 key 索引;空 follow 页返回同一快照引用。
- `DaemonTailPane.tsx`:窗口按索引读;查询过滤缓存,只在行或查询变化时失效。
- 一处有意的语义变化:快照 `rows` 变为跨快照共享的活容器(常数追加的必要代价);生产只持有最新快照。
- 测试:新增 `observe-follow-cost.vitest.ts`(已登记 manifest)模拟 500 页 follow(400 空页)断言单页工作量不随累计行数增长;两个既有文件更新。

## 架构辩护

- **为什么是两段日志而不是不可变数组**:follow 路径是页面生命周期内每秒一次的轮询,任何与累计历史成比例的单页成本按构造就是泄漏;不可变平铺数组必然每页 O(n) 复制;持久化向量能保不可变 + O(1) 追加,但要新依赖、代码量超出缺陷所需;head/tail 两段 + 摊还丢弃偏移是给出 O(页宽) 追加/前插与 O(1) 索引读的最小结构。
- **为什么行容器跨快照共享**:渲染只持有最新快照并按索引读窗口;生产里没有按 identity 比较新旧 `rows` 的地方,唯一的"空页跳过重渲染"正是同引用返回刻意服务的;取舍写在模型注释里,由 `observe-follow-cost.vitest.ts` 钉住。
- **没有加什么**:没有 worker、没有虚拟化库、除一个按 rows+query 记忆的过滤缓存外没有缓存层;#2259 的 DOM 窗口化原样不动。

## 验证 / 复核

见英文段;改前空页成本 1k→6.4k 行涨 5.4 倍,改后走平。合入后请求独立复核(重点看共享可变 `rows`)。

## 残余风险

需要冻结旧快照行集的未来代码必须 `rows.slice(0)`;今天生产里没有这样的调用方。
