### PR TITLE
fix(daemon): only trust an inherited HARNESS_DAEMON_REPO_ID that belongs to the current root

### DIFF
--- a/packages/daemon/src/client/local-daemon-target.ts
+++ b/packages/daemon/src/client/local-daemon-target.ts
@@ -88,14 +88,21 @@ export function resolveLocalDaemonTargetFromRepos(
     );
   const requested = input.repoIdOverride ?? env.HARNESS_DAEMON_REPO_ID;
   const rootDir = bindCanonicalRoot(input.rootDir);
-  const repo = requested
+  const rootedRepos = registeredRepos
+    .filter(
+      (candidate) => candidate.canonicalRoot === rootDir || rootDir.startsWith(`${candidate.canonicalRoot}${path.sep}`),
+    )
+    .sort((left, right) => right.canonicalRoot.length - left.canonicalRoot.length);
+  const repo = input.repoIdOverride
     ? registeredRepos.find((candidate) => candidate.repoId === requested && candidate.state === "enabled")
-    : registeredRepos
-        .filter(
+    : env.HARNESS_DAEMON_REPO_ID
+      ? (registeredRepos.find(
           (candidate) =>
-            candidate.canonicalRoot === rootDir || rootDir.startsWith(`${candidate.canonicalRoot}${path.sep}`),
-        )
-        .sort((left, right) => right.canonicalRoot.length - left.canonicalRoot.length)[0];
+            candidate.repoId === requested &&
+            candidate.state === "enabled" &&
+            (candidate.canonicalRoot === rootDir || rootDir.startsWith(`${candidate.canonicalRoot}${path.sep}`)),
+        ) ?? rootedRepos[0])
+      : rootedRepos[0];
   if (!repo || repo.state !== "enabled")
     throw Object.assign(
       new Error(

--- a/packages/daemon/test/local-daemon-target.test.ts
+++ b/packages/daemon/test/local-daemon-target.test.ts
@@ -149,7 +149,7 @@ test("local daemon target honors an explicit root instead of the process working
   }
 });
 
-test("local daemon target keeps the environment repo id override authoritative", async () => {
+test("local daemon target ignores an environment repo id from another registered workspace", async () => {
   const fixtureRoot = mkdtempSync(path.join(tmpdir(), "ha-local-daemon-target-"));
   const firstRoot = path.join(fixtureRoot, "first"),
     secondRoot = path.join(fixtureRoot, "second"),
@@ -170,6 +170,57 @@ test("local daemon target keeps the environment repo id override authoritative",
       userRoot,
       env: { HARNESS_DAEMON_REPO_ID: "second" },
     });
+
+    assert.equal(target.repoId, "first");
+    assert.equal(target.canonicalRoot, canonicalFirstRoot);
+  } finally {
+    rmSync(fixtureRoot, { recursive: true, force: true });
+  }
+});
+
+test("local daemon target keeps a matching injected repo id", async () => {
+  const fixtureRoot = mkdtempSync(path.join(tmpdir(), "ha-local-daemon-target-"));
+  const workspaceRoot = path.join(fixtureRoot, "workspace"),
+    userRoot = path.join(fixtureRoot, "user");
+  try {
+    mkdirSync(workspaceRoot, { recursive: true });
+    mkdirSync(userRoot);
+    const canonicalWorkspaceRoot = realpathSync.native(workspaceRoot);
+    writeFileSync(
+      path.join(userRoot, "registry.json"),
+      `${JSON.stringify(registry([repo("runtime-worker", canonicalWorkspaceRoot)]), null, 2)}\n`,
+    );
+
+    const target = await resolveLocalDaemonTarget({
+      rootDir: workspaceRoot,
+      userRoot,
+      env: { HARNESS_DAEMON_REPO_ID: "runtime-worker" },
+    });
+
+    assert.equal(target.repoId, "runtime-worker");
+    assert.equal(target.canonicalRoot, canonicalWorkspaceRoot);
+  } finally {
+    rmSync(fixtureRoot, { recursive: true, force: true });
+  }
+});
+
+test("local daemon target keeps an explicit repo id override authoritative", async () => {
+  const fixtureRoot = mkdtempSync(path.join(tmpdir(), "ha-local-daemon-target-"));
+  const firstRoot = path.join(fixtureRoot, "first"),
+    secondRoot = path.join(fixtureRoot, "second"),
+    userRoot = path.join(fixtureRoot, "user");
+  try {
+    mkdirSync(firstRoot, { recursive: true });
+    mkdirSync(secondRoot);
+    mkdirSync(userRoot);
+    const canonicalFirstRoot = realpathSync.native(firstRoot),
+      canonicalSecondRoot = realpathSync.native(secondRoot);
+    writeFileSync(
+      path.join(userRoot, "registry.json"),
+      `${JSON.stringify(registry([repo("first", canonicalFirstRoot), repo("second", canonicalSecondRoot)]), null, 2)}\n`,
+    );
+
+    const target = await resolveLocalDaemonTarget({ rootDir: firstRoot, repoIdOverride: "second", userRoot, env: {} });
 
     assert.equal(target.repoId, "second");
     assert.equal(target.canonicalRoot, canonicalSecondRoot);


### PR DESCRIPTION
# English

## Summary

The CLI trusted an inherited `HARNESS_DAEMON_REPO_ID` unconditionally. Any isolated CLI (own HOME, own daemon) launched from a shell that had the variable set — a runtime worker's shell, a verifier's shell — got routed to a repo the isolated daemon had never registered and answered `workspace is not registered`. That single leak produced the entire round-2 "real dispatch fails" verdict on the provider PR before round 3 traced it. The inherited id is now honoured only when it names an enabled registry entry under the current root; otherwise the deepest registered entry for the root is used, exactly as when the variable is absent. Daemon-injected task-bound ids and explicit overrides are unchanged.

## What Changed

- `packages/daemon/src/client/local-daemon-target.ts`: the unconditional environment-id branch (6 lines) is deleted; selection is rooted and the inherited id must match a registry entry under `rootDir`.
- `packages/daemon/test/local-daemon-target.test.ts`: the old cross-root override test becomes a fallback test; two contract tests added — a matching task-bound injection is kept, an explicit override is kept.

## Gate Harvest / 门收割

Deleted-Production-Paths: unconditional `HARNESS_DAEMON_REPO_ID` selection branch in `local-daemon-target.ts`
Deleted-Gates-Fixtures: the cross-root override assertion in `local-daemon-target.test.ts` (replaced by the fallback contract)
- Production net lines: use the single CI-backed `Production-Delta` declaration below; do not enter a second metric.

## Machine-Readable Declarations

Production-Delta: +13/-6

## Task And Scope

- Harness task: task_3ef9f59fce2946dffa1d43d3ae (filed from the provider verification round 2/3 evidence)
- Branch: codex/repoid-guard
- Public scope: one daemon client target resolver, its test
- Private planning/evidence updated: yes — `artifacts/reports/repoid-guard.md` (Round-3 recipe re-run with the leaked variable kept)
- Out of scope: a diagnostic code for the mismatch (silent fallback matches the variable-absent behaviour; add a code only if a real caller needs it)

## Version Impact

- Version: no version change because only endpoint selection tightened; no command shape changed
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Authority: task_3ef9f59fce2946dffa1d43d3ae; evidence in task_f53452ed reports `provider-verification-round2.md` (symptom) and `provider-round3.md` (three-way reproduction)

## Verification

- `node --test packages/daemon/test/local-daemon-target.test.ts` 12/12; eslint, typecheck, line-density, file-complexity pass locally.
- Isolated Round-3 recipe with `HARNESS_DAEMON_REPO_ID=stale-parent-repo` left in the environment: `init`, `runtime instance create`, `show --probe`, `runtime run` all succeed (before: `workspace is not registered`).
- Full matrix is GitHub CI's job.

## Review Evidence

- Independent review `rev_repoid_indep` (Sol) in flight; result recorded on the task before merge.

## Residual Risk

- A mismatched inherited id now falls back silently; if that ever hides a misconfiguration, add a diagnostic code rather than re-trusting the variable.

---

# 中文

## 摘要

CLI 过去无条件采信继承来的 `HARNESS_DAEMON_REPO_ID`:任何在设置了该变量的 shell(runtime worker 的 shell、验收者的 shell)里启动的隔离 CLI(独立 HOME/daemon)都会被路由到隔离 daemon 从未注册的 repo,报 `workspace is not registered`——Provider PR 第二轮「真实派工失败」整个判定都来自这一处泄漏。现在只有当继承的 id 对应当前 root 下已启用的注册表项时才采信,否则与变量不存在时一样回到该 root 最深的注册项;daemon 注入的 task-bound id 与显式 override 不变。

## 改动

- `local-daemon-target.ts`:删除无条件采信分支,选择按 root 归属校验。
- 测试:跨 root 覆盖用例改为回退用例;新增匹配注入保留、显式 override 保留两项契约。

## 验证

12/12;隔离 Round 3 配方保留泄漏变量仍全链路成功(改前 workspace is not registered)。

## 残余风险

不匹配时静默回退;若将来掩盖了配置错误,加诊断码而不是重新采信变量。
