### PR TITLE
fix(daemon): admit implementer and reviewer redispatch after changes_requested

### DIFF
--- a/packages/daemon/src/repo-cell-authorization.ts
+++ b/packages/daemon/src/repo-cell-authorization.ts
@@ -455,10 +455,20 @@ function invalidExecutorBindingFor(
         : "malformed executor descriptor",
     expected = lease?.actor.executor ? `agent:${lease.actor.executor.id}` : null,
     retry = executorRetryCommand(input.action, taskId, executionId),
-    expectation = expected
-      ? `Expected ${expected} from the held execution lease; run from that executor, then retry ${retry}`
-      : "Expected a task-bound executor with a matching held execution lease; run ha task start " +
-        `${taskId ?? "<task-id>"}, then retry ${retry}`,
+    reviewerRedispatch =
+      input.action.kind === "task-review-execution" &&
+      taskId !== null &&
+      isExecutorDescriptorRecord(raw) &&
+      raw.kind === "agent" &&
+      typeof raw.id === "string" &&
+      raw.id.startsWith("runtime-session:"),
+    expectation = reviewerRedispatch
+      ? `Expected a reviewer RuntimeSession bound to execution ${executionId ?? "<execution-id>"}; run ` +
+        `ha runtime run <runtime-instance-id> --role reviewer --task ${taskId}, then retry ${retry}`
+      : expected
+        ? `Expected ${expected} from the held execution lease; run from that executor, then retry ${retry}`
+        : "Expected a task-bound executor with a matching held execution lease; run ha task start " +
+          `${taskId ?? "<task-id>"}, then retry ${retry}`,
     diagnostic: ReceiptDiagnostic = {
       kind: "validation",
       entity: [taskId ? `task ${taskId}` : "repository", executionId ? `execution ${executionId}` : ""]

--- a/packages/daemon/src/repo-cell-open.ts
+++ b/packages/daemon/src/repo-cell-open.ts
@@ -749,7 +749,13 @@ export async function openRepoWriterCell(
     const runtimeExecutor = { kind: "agent" as const, id: `runtime-session:${runtimeSessionId}` },
       runtimeBinding = { ...binding, actor: { principal: binding.actor.principal, executor: runtimeExecutor } };
     let lease = projection.currentLease(taskId, now());
-    const executionId = lease?.executionId;
+    const snapshot = projection.read(taskId).snapshot,
+      executionId = snapshot.executions.find(
+        (execution) =>
+          execution.executionId === lease?.executionId &&
+          execution.iteration === snapshot.task?.iteration &&
+          execution.state === "active",
+      )?.executionId;
     if (lease?.phase === "held" && !isSameExecution(lease.actor, runtimeBinding.actor)) {
       const heldRuntimeSessionId =
           lease.actor.executor?.kind === "agent" && lease.actor.executor.id.startsWith("runtime-session:")

--- a/packages/daemon/test/repo-cell-executor-binding-cut.test.ts
+++ b/packages/daemon/test/repo-cell-executor-binding-cut.test.ts
@@ -107,6 +107,44 @@ test("executor binding rejection names the claimed and held executors", async (t
   assert.equal(context.observedActor, null);
 });
 
+test("a reviewer bound to an earlier execution receives a reviewer redispatch command", async () => {
+  const nextExecutionId = "exec-runtime-second-round",
+    nextRuntimeActor = {
+      principal: runtimeActor.principal,
+      executor: { kind: "agent" as const, id: "runtime-session:second-round-runtime" },
+    },
+    context = contextFor(
+      Promise.resolve(),
+      () => runtimeSession,
+      () => ({ ...lease, executionId: nextExecutionId, actor: nextRuntimeActor }),
+    ),
+    receipt = await createRepoCellApi(context).run(
+      {
+        kind: "task-review-execution",
+        taskId,
+        executionId: nextExecutionId,
+        reviewId: "review-second-round",
+        fromFile: "review.json",
+        executor: runtimeActor.executor,
+      },
+      binding,
+    );
+
+  assert.equal(receipt.outcome, "op_rejected");
+  assert.equal(receipt.code, "executor_binding_invalid");
+  assert.deepEqual(receipt.diagnostic, {
+    kind: "validation",
+    entity: `task ${taskId} execution ${nextExecutionId}`,
+    field: "executor",
+    actual: `agent:${runtimeActor.executor.id}`,
+    expectation:
+      `Expected a reviewer RuntimeSession bound to execution ${nextExecutionId}; run ` +
+      `ha runtime run <runtime-instance-id> --role reviewer --task ${taskId}, then retry ` +
+      `the ha task review execution command`,
+  });
+  assert.equal(context.observedActor, null);
+});
+
 test("executor-free actions reach the publication queue synchronously", async () => {
   const context = contextFor(
       Promise.resolve(),

--- a/packages/daemon/test/runtime-spawn-ingress.integration.test.ts
+++ b/packages/daemon/test/runtime-spawn-ingress.integration.test.ts
@@ -17,11 +17,7 @@ import {
   installation,
   initIngressRepo,
   rpc,
-  rpcAttach,
-  eventually,
   eventuallyValue,
-  writeProviderStub,
-  installationFixture,
   spawnCli,
 } from "./fixtures/runtime-ingress.ts";
 
@@ -435,6 +431,175 @@ test("daemon ingress preserves executor-scoped task-bound runtime spawn", async 
           kind: "agent",
           id: `runtime-session:${receipt.runtimeSessionId}`,
         });
+    });
+    await t.test("changes requested admits implementation and reviewer redispatch", async () => {
+      const taskId = "task-runtime-redispatch",
+        firstExecutionId = "exec-runtime-redispatch-r1";
+      await createReadyTask(taskId, "Runtime changes-requested redispatch");
+      assert.equal(
+        (await host.run(repoId, { kind: "task-start", taskId, executionId: firstExecutionId }, auth)).outcome,
+        "applied",
+      );
+      assert.equal(
+        (
+          await host.run(
+            repoId,
+            {
+              kind: "task-submit",
+              taskId,
+              executionId: firstExecutionId,
+              submission: {
+                completionClaim: "First round is ready for review.",
+                deliverables: ["redispatch fixture"],
+                outputs: ["runtime receipt"],
+                verificationNotes: ["integration"],
+                knownGaps: [],
+                residualRisks: [],
+                commitSha: "a".repeat(40),
+              },
+            },
+            auth,
+          )
+        ).outcome,
+        "applied",
+      );
+      writeFileSync(
+        path.join(root, "redispatch-changes.json"),
+        JSON.stringify({
+          verdict: "changes_requested",
+          reason: "Exercise a second implementation round.",
+          evidenceChecked: ["first-round receipt"],
+        }),
+      );
+      const firstReviewer = await rpc(host, auth, "repo.agentRuntime.spawn", {
+        repo: { repoId },
+        payload: {
+          runtimeInstanceId: ingressDefinition.instanceId,
+          cwd: { scope: "repo-root" },
+          prompt: "Review the first round.",
+          role: "reviewer",
+          taskId,
+          idempotencyKey: "runtime-changes-requested-first-reviewer",
+        },
+      });
+      assert.equal(firstReviewer.outcome, "applied", JSON.stringify(firstReviewer));
+      await eventuallyValue(
+        async () =>
+          makeTaskEventReader({ repoId, rootDir: root })
+            .read()
+            .events.find(
+              (event) =>
+                event.type === "runtime_session_task_bound" &&
+                event.payload.runtimeSessionId === firstReviewer.runtimeSessionId,
+            ) ?? null,
+      );
+      assert.equal(
+        (
+          await host.run(
+            repoId,
+            {
+              kind: "task-review-execution",
+              taskId,
+              executionId: firstExecutionId,
+              reviewId: "redispatch-changes",
+              fromFile: "redispatch-changes.json",
+              executor: {
+                kind: "agent",
+                id: `runtime-session:${String(firstReviewer.runtimeSessionId)}`,
+              },
+            },
+            auth,
+          )
+        ).outcome,
+        "applied",
+      );
+
+      const implementation = await rpc(host, auth, "repo.agentRuntime.spawn", {
+        repo: { repoId },
+        payload: {
+          runtimeInstanceId: ingressDefinition.instanceId,
+          cwd: { scope: "repo-root" },
+          prompt: "Continue implementation.",
+          taskId,
+          idempotencyKey: "runtime-changes-requested-implementation",
+        },
+      });
+      assert.equal(implementation.outcome, "applied", JSON.stringify(implementation));
+
+      const implementationBinding = await eventuallyValue(
+        async () =>
+          makeTaskEventReader({ repoId, rootDir: root })
+            .read()
+            .events.find(
+              (event) =>
+                event.type === "runtime_session_task_bound" &&
+                event.payload.runtimeSessionId === implementation.runtimeSessionId,
+            ) ?? null,
+      );
+      assert.equal(implementationBinding?.type, "runtime_session_task_bound");
+      if (implementationBinding?.type !== "runtime_session_task_bound") throw new Error("missing task binding");
+      const secondExecutionId = implementationBinding.payload.executionId,
+        secondSubmission = await host.run(
+          repoId,
+          {
+            kind: "task-submit",
+            taskId,
+            executionId: secondExecutionId,
+            submission: {
+              completionClaim: "Second round is ready for review.",
+              deliverables: ["redispatch fixture"],
+              outputs: ["runtime receipt"],
+              verificationNotes: ["integration"],
+              knownGaps: [],
+              residualRisks: [],
+              commitSha: "b".repeat(40),
+            },
+            executor: {
+              kind: "agent",
+              id: `runtime-session:${String(implementation.runtimeSessionId)}`,
+            },
+          },
+          auth,
+        );
+      assert.equal(secondSubmission.outcome, "applied", JSON.stringify(secondSubmission));
+      writeFileSync(
+        path.join(root, "redispatch-review.json"),
+        JSON.stringify({ verdict: "approved", reason: "Second round reviewed.", evidenceChecked: ["second round"] }),
+      );
+      const staleReviewer = await host.run(
+        repoId,
+        {
+          kind: "task-review-execution",
+          taskId,
+          executionId: secondExecutionId,
+          reviewId: "redispatch-stale-reviewer",
+          fromFile: "redispatch-review.json",
+          executor: {
+            kind: "agent",
+            id: `runtime-session:${String(firstReviewer.runtimeSessionId)}`,
+          },
+        },
+        auth,
+      );
+      assert.equal(staleReviewer.outcome, "op_rejected", JSON.stringify(staleReviewer));
+      assert.equal(staleReviewer.code, "executor_binding_invalid", JSON.stringify(staleReviewer));
+      assert.match(
+        String((staleReviewer.diagnostic as { expectation?: unknown } | undefined)?.expectation),
+        new RegExp(`ha runtime run <runtime-instance-id> --role reviewer --task ${taskId}`, "u"),
+      );
+
+      const independentReview = await rpc(host, auth, "repo.agentRuntime.spawn", {
+        repo: { repoId },
+        payload: {
+          runtimeInstanceId: ingressDefinition.instanceId,
+          cwd: { scope: "repo-root" },
+          prompt: "Review the continuation.",
+          role: "reviewer",
+          taskId,
+          idempotencyKey: "runtime-changes-requested-reviewer",
+        },
+      });
+      assert.equal(independentReview.outcome, "applied", JSON.stringify(independentReview));
     });
     await t.test("an in-review task dispatches a closeout continuation without reopening execution", async () => {
       const taskId = "task-runtime-review-continuation",
@@ -994,809 +1159,6 @@ test("daemon ingress preserves executor-scoped task-bound runtime spawn", async 
     );
   } finally {
     await transport.stop();
-    await host.close();
-    rmSync(parent, { recursive: true, force: true });
-  }
-});
-
-test("daemon ingress persists scrubbed provider JSONL while returning canonical results for both runtime kinds", async (t) => {
-  const parent = mkdtempSync(path.join(tmpdir(), "ha-runtime-provider-events-")),
-    root = path.join(parent, "repo"),
-    userRoot = path.join(parent, "user"),
-    repoId = "runtime-provider-events",
-    uid = 4302;
-  initIngressRepo(root, uid);
-  registerDaemonRepo({
-    canonicalRoot: root,
-    repoId,
-    userRoot,
-    createConvenienceLinks: false,
-  });
-  const installations = (["claude", "codex"] as const).map((kindId) => {
-    const executablePath = writeProviderStub(
-      path.join(parent, `${kindId}-stub.mjs`),
-      kindId,
-      undefined,
-      kindId === "claude" ? 1_000 : 40,
-    );
-    return {
-      installationId: `installation-${kindId}`,
-      kindId,
-      executablePath,
-      version: "1.0.0",
-      observedAt: "2026-08-19T00:00:00.000Z",
-    } as const;
-  });
-  const auth = {
-      transportKind: "unix-socket",
-      unixSocketOwnerBoundary: {
-        ownerUid: uid,
-        source: "unix-socket-filesystem-owner-boundary",
-      },
-    } as const,
-    host = await openDaemonHost({
-      daemonId: "runtime-provider-events",
-      userRoot,
-      runtimeDiscover: () => installations,
-    });
-  await host.attachmentsSettled();
-  try {
-    for (const kindId of ["claude", "codex"] as const)
-      host.runtimeInstance(
-        "daemon.runtimeInstance.create",
-        {
-          instanceId: `${kindId}-provider`,
-          name: `${kindId} provider`,
-          kindId,
-          installationId: `installation-${kindId}`,
-          providerId: kindId === "claude" ? "anthropic" : "openai",
-          models: [`${kindId}-model`],
-          authMode: "subscription",
-        },
-        auth,
-      );
-    host.runtimeInstance(
-      "daemon.runtimeInstance.create",
-      {
-        instanceId: "codex-read-only",
-        name: "codex read only",
-        kindId: "codex",
-        installationId: "installation-codex",
-        providerId: "openai",
-        models: ["codex-model"],
-        permissionMode: "read-only",
-        authMode: "subscription",
-      },
-      auth,
-    );
-    for (const kindId of ["claude", "codex"] as const)
-      await t.test(kindId, async () => {
-        const receipt = await rpc(host, auth, "repo.agentRuntime.spawn", {
-          repo: { repoId },
-          payload: {
-            runtimeInstanceId: `${kindId}-provider`,
-            cwd: { scope: "repo-root" },
-            prompt: `Run ${kindId}`,
-            taskId: null,
-            idempotencyKey: `${kindId}-provider-events`,
-          },
-        });
-        assert.equal(receipt.outcome, "applied", JSON.stringify(receipt));
-        // Keep Claude active while its first message is already buffered so it covers the attach
-        // response's replay path; Codex continues to cover live notifications after attachment.
-        if (kindId === "claude") await new Promise((resolve) => setTimeout(resolve, 2_000));
-        const frames: Record<string, unknown>[] = [],
-          attached = await rpcAttach(host, auth, repoId, String(receipt.runtimeSessionId), frames);
-        try {
-          await eventually(async () =>
-            frames.some(
-              (frame) =>
-                frame.type === "activity" && frame.activity === "message" && frame.content === `${kindId} live content`,
-            ),
-          );
-          const read = await eventuallyValue(async () => {
-            const value = await rpc(host, auth, "repo.agentRuntime.sessions.read", {
-              repo: { repoId },
-              payload: { runtimeSessionId: receipt.runtimeSessionId },
-            });
-            return value.result ? value : null;
-          });
-          assert.equal((read.session as Record<string, unknown>).providerSessionId, `${kindId}-provider-session`);
-          assert.deepEqual((read.session as { activity: unknown }).activity, {
-            lastObservedAt: (read.session as { activity: { lastObservedAt: string } }).activity.lastObservedAt,
-            outcome: "succeeded",
-            exitCode: 0,
-            resultRef: (read.result as Record<string, unknown>).ref,
-            missingEvidence: null,
-          });
-          assert.deepEqual(read.result, {
-            ref: (read.result as Record<string, unknown>).ref,
-            text: `${kindId} final result`,
-          });
-          assert.match(
-            String((read.result as Record<string, unknown>).ref),
-            /^artifact:runtime-result\/sha256\/[0-9a-f]{64}$/u,
-          );
-          const streamPath = path.join(root, ".harness", "runtime", "dispatches", `${receipt.dispatchId}.jsonl`),
-            stream = await eventuallyValue(() => {
-              try {
-                return readFileSync(streamPath, "utf8");
-              } catch {
-                return null;
-              }
-            });
-          assert.match(stream, /"kind":"provider_event"/u);
-          if (kindId === "codex") {
-            assert.doesNotMatch(
-              stream,
-              /credentialRef|executablePath|apiToken|sk-provider-secret|\/provider\/private/u,
-            );
-          }
-          const outcome = makeTaskEventReader({ repoId, rootDir: root })
-            .read()
-            .events.find(
-              (event) =>
-                event.type === "runtime_session_outcome_observed" &&
-                event.payload.runtimeSessionId === receipt.runtimeSessionId,
-            );
-          assert.equal(outcome?.type, "runtime_session_outcome_observed");
-          if (outcome?.type === "runtime_session_outcome_observed")
-            assert.equal(
-              Buffer.from(
-                makeTaskEventReader({ repoId, rootDir: root }).readContentBlob(outcome.payload.result!.sha256)!,
-              ).toString("utf8"),
-              `${kindId} final result`,
-            );
-        } finally {
-          attached.close();
-        }
-      });
-    const readOnly = await rpc(host, auth, "repo.agentRuntime.spawn", {
-        repo: { repoId },
-        payload: {
-          runtimeInstanceId: "codex-read-only",
-          cwd: { scope: "repo-root" },
-          prompt: "read-only",
-          taskId: null,
-          idempotencyKey: "codex-read-only",
-        },
-      }),
-      readOnlyRead = await eventuallyValue(async () => {
-        const value = await rpc(host, auth, "repo.agentRuntime.sessions.read", {
-          repo: { repoId },
-          payload: { runtimeSessionId: readOnly.runtimeSessionId },
-        });
-        // A read racing the writer's projection catch-up can observe the session before it is
-        // projected (runtime_session_not_found), which returns a receipt with no `session` at
-        // all -- keep polling rather than crashing on that transient shape.
-        return (value.session as { activity?: { outcome: unknown } } | undefined)?.activity?.outcome ? value : null;
-      });
-    assert.deepEqual(
-      (
-        readOnlyRead.session as {
-          activity: { outcome: unknown; exitCode: unknown };
-        }
-      ).activity && {
-        outcome: (readOnlyRead.session as { activity: { outcome: unknown } }).activity.outcome,
-        exitCode: (readOnlyRead.session as { activity: { exitCode: unknown } }).activity.exitCode,
-      },
-      { outcome: "succeeded", exitCode: 0 },
-    );
-    const noAction = await rpc(host, auth, "repo.agentRuntime.spawn", {
-        repo: { repoId },
-        payload: {
-          runtimeInstanceId: "codex-provider",
-          cwd: { scope: "repo-root" },
-          prompt: "no-action",
-          taskId: null,
-          idempotencyKey: "codex-no-action",
-        },
-      }),
-      noActionRead = await eventuallyValue(async () => {
-        const value = await rpc(host, auth, "repo.agentRuntime.sessions.read", {
-          repo: { repoId },
-          payload: { runtimeSessionId: noAction.runtimeSessionId },
-        });
-        // A read racing the writer's projection catch-up can observe the session before it is
-        // projected (runtime_session_not_found), which returns a receipt with no `session` at
-        // all -- keep polling rather than crashing on that transient shape.
-        return (value.session as { activity?: { outcome: unknown } } | undefined)?.activity?.outcome ? value : null;
-      });
-    assert.deepEqual(
-      (
-        noActionRead.session as {
-          activity: { outcome: unknown; exitCode: unknown };
-        }
-      ).activity && {
-        outcome: (noActionRead.session as { activity: { outcome: unknown } }).activity.outcome,
-        exitCode: (noActionRead.session as { activity: { exitCode: unknown } }).activity.exitCode,
-      },
-      { outcome: "succeeded", exitCode: 0 },
-    );
-    const noWrite = await rpc(host, auth, "repo.agentRuntime.spawn", {
-        repo: { repoId },
-        payload: {
-          runtimeInstanceId: "codex-provider",
-          cwd: { scope: "repo-root" },
-          prompt: "no-write",
-          taskId: null,
-          idempotencyKey: "codex-no-write",
-        },
-      }),
-      noWriteRead = await eventuallyValue(async () => {
-        const value = await rpc(host, auth, "repo.agentRuntime.sessions.read", {
-          repo: { repoId },
-          payload: { runtimeSessionId: noWrite.runtimeSessionId },
-        });
-        // A read racing the writer's projection catch-up can observe the session before it is
-        // projected (runtime_session_not_found), which returns a receipt with no `session` at
-        // all -- keep polling rather than crashing on that transient shape.
-        return (value.session as { activity?: { outcome: unknown } } | undefined)?.activity?.outcome ? value : null;
-      });
-    assert.deepEqual(
-      (
-        noWriteRead.session as {
-          activity: { outcome: unknown; exitCode: unknown };
-        }
-      ).activity && {
-        outcome: (noWriteRead.session as { activity: { outcome: unknown } }).activity.outcome,
-        exitCode: (noWriteRead.session as { activity: { exitCode: unknown } }).activity.exitCode,
-      },
-      { outcome: "succeeded", exitCode: 0 },
-    );
-    const denied = await rpc(host, auth, "repo.agentRuntime.spawn", {
-        repo: { repoId },
-        payload: {
-          runtimeInstanceId: "claude-provider",
-          cwd: { scope: "repo-root" },
-          prompt: "permission-denied",
-          taskId: null,
-          idempotencyKey: "claude-permission-denied",
-        },
-      }),
-      deniedRead = await eventuallyValue(async () => {
-        const value = await rpc(host, auth, "repo.agentRuntime.sessions.read", {
-          repo: { repoId },
-          payload: { runtimeSessionId: denied.runtimeSessionId },
-        });
-        // A read racing the writer's projection catch-up can observe the session before it is
-        // projected (runtime_session_not_found), which returns a receipt with no `session` at
-        // all -- keep polling rather than crashing on that transient shape.
-        return (value.session as { activity?: { outcome: unknown } } | undefined)?.activity?.outcome ? value : null;
-      });
-    assert.deepEqual(
-      (
-        deniedRead.session as {
-          activity: { outcome: unknown; exitCode: unknown };
-        }
-      ).activity && {
-        outcome: (deniedRead.session as { activity: { outcome: unknown } }).activity.outcome,
-        exitCode: (deniedRead.session as { activity: { exitCode: unknown } }).activity.exitCode,
-      },
-      { outcome: "succeeded", exitCode: 0 },
-    );
-    const empty = await rpc(host, auth, "repo.agentRuntime.spawn", {
-      repo: { repoId },
-      payload: {
-        runtimeInstanceId: "codex-provider",
-        cwd: { scope: "repo-root" },
-        prompt: "failure:empty",
-        taskId: null,
-        idempotencyKey: "codex-empty-failure",
-      },
-    });
-    const emptyRead = await eventuallyValue(async () => {
-      const value = await rpc(host, auth, "repo.agentRuntime.sessions.read", {
-        repo: { repoId },
-        payload: { runtimeSessionId: empty.runtimeSessionId },
-      });
-      // See the comment above the first occurrence of this guard: a read racing the writer's
-      // projection catch-up can return a receipt with no `session` yet.
-      return (value.session as { activity?: { outcome: unknown } } | undefined)?.activity?.outcome ? value : null;
-    });
-    assert.deepEqual(
-      (
-        emptyRead.session as {
-          activity: { outcome: unknown; exitCode: unknown };
-        }
-      ).activity && {
-        outcome: (emptyRead.session as { activity: { outcome: unknown } }).activity.outcome,
-        exitCode: (emptyRead.session as { activity: { exitCode: unknown } }).activity.exitCode,
-      },
-      { outcome: "failed", exitCode: 1 },
-    );
-    assert.equal(
-      (emptyRead.result as Record<string, unknown>).text,
-      "Provider exited with code 1 and produced no output.",
-    );
-    const secret = "sk-runtime-secret-1234567890",
-      stderrFailure = await rpc(host, auth, "repo.agentRuntime.spawn", {
-        repo: { repoId },
-        payload: {
-          runtimeInstanceId: "codex-provider",
-          cwd: { scope: "repo-root" },
-          prompt: "failure:secret",
-          taskId: null,
-          idempotencyKey: "codex-stderr-failure",
-        },
-      });
-    const stderrRead = await eventuallyValue(async () => {
-      const value = await rpc(host, auth, "repo.agentRuntime.sessions.read", {
-        repo: { repoId },
-        payload: { runtimeSessionId: stderrFailure.runtimeSessionId },
-      });
-      // See the comment above the first occurrence of this guard: a read racing the writer's
-      // projection catch-up can return a receipt with no `session` yet.
-      return (value.session as { activity?: { outcome: unknown } } | undefined)?.activity?.outcome ? value : null;
-    });
-    assert.match(
-      String((stderrRead.result as Record<string, unknown>).text),
-      /Provider exited with code 1.*OPENAI_API_KEY=\[REDACTED\]/u,
-    );
-    assert.doesNotMatch(JSON.stringify(stderrRead), new RegExp(secret, "u"));
-    assert.doesNotMatch(
-      readFileSync(path.join(root, ".harness", "runtime", "dispatches", `${stderrFailure.dispatchId}.jsonl`), "utf8"),
-      new RegExp(secret, "u"),
-    );
-    const structured = await rpc(host, auth, "repo.agentRuntime.spawn", {
-      repo: { repoId },
-      payload: {
-        runtimeInstanceId: "codex-provider",
-        cwd: { scope: "repo-root" },
-        prompt: "failure:structured",
-        taskId: null,
-        idempotencyKey: "codex-structured-failure",
-      },
-    });
-    const structuredRead = await eventuallyValue(async () => {
-      const value = await rpc(host, auth, "repo.agentRuntime.sessions.read", {
-        repo: { repoId },
-        payload: { runtimeSessionId: structured.runtimeSessionId },
-      });
-      // See the comment above the first occurrence of this guard: a read racing the writer's
-      // projection catch-up can return a receipt with no `session` yet.
-      return (value.session as { activity?: { outcome: unknown } } | undefined)?.activity?.outcome ? value : null;
-    });
-    assert.match(String((structuredRead.result as Record<string, unknown>).text), /structured provider failure/u);
-    assert.doesNotMatch(JSON.stringify(structuredRead), new RegExp(secret, "u"));
-  } finally {
-    await host.close();
-    rmSync(parent, { recursive: true, force: true });
-  }
-});
-
-test("daemon ingress resumes the same provider session for Claude and Codex", async (t) => {
-  const parent = mkdtempSync(path.join(tmpdir(), "ha-runtime-resume-")),
-    root = path.join(parent, "repo"),
-    userRoot = path.join(parent, "user"),
-    repoId = "runtime-resume",
-    uid = 4303;
-  initIngressRepo(root, uid);
-  registerDaemonRepo({
-    canonicalRoot: root,
-    repoId,
-    userRoot,
-    createConvenienceLinks: false,
-  });
-  const launches: {
-      readonly kindId: string;
-      readonly args: readonly string[];
-    }[] = [],
-    installations = (["claude", "codex"] as const).map((kindId) => {
-      const executablePath = writeProviderStub(path.join(parent, `${kindId}-resume-stub.mjs`), kindId);
-      return {
-        installationId: `installation-${kindId}`,
-        kindId,
-        executablePath,
-        version: "1.0.0",
-        observedAt: "2026-08-19T00:00:00.000Z",
-      } as const;
-    });
-  const auth = {
-      transportKind: "unix-socket",
-      unixSocketOwnerBoundary: {
-        ownerUid: uid,
-        source: "unix-socket-filesystem-owner-boundary",
-      },
-    } as const,
-    host = await openDaemonHost({
-      daemonId: "runtime-resume",
-      userRoot,
-      runtimeDiscover: () => installations,
-      runtimeLaunch: (prepared) => {
-        const kindId = prepared.definition.kindId,
-          resumed = prepared.args.includes("--resume") || prepared.args.includes("resume"),
-          providerSessionId = kindId === "claude" ? "claude-resume-session" : "codex-resume-session";
-        launches.push({ kindId, args: prepared.args });
-        const output =
-          kindId === "claude"
-            ? [
-                {
-                  type: "system",
-                  subtype: "init",
-                  session_id: providerSessionId,
-                },
-                {
-                  type: "assistant",
-                  session_id: providerSessionId,
-                  message: {
-                    content: [
-                      {
-                        type: "text",
-                        text: resumed ? "claude second turn" : "claude first turn",
-                      },
-                    ],
-                  },
-                },
-                {
-                  type: "result",
-                  subtype: "success",
-                  is_error: false,
-                  session_id: providerSessionId,
-                  result: resumed ? "claude second result" : "claude first result",
-                },
-              ]
-            : [
-                { type: "thread.started", thread_id: providerSessionId },
-                {
-                  type: "item.completed",
-                  item: {
-                    id: "resume-item",
-                    type: "agent_message",
-                    text: resumed ? "codex second turn" : "codex first turn",
-                  },
-                },
-                {
-                  type: "turn.completed",
-                  usage: { input_tokens: 1, output_tokens: 1 },
-                },
-              ];
-        return {
-          pid: 4400 + launches.length,
-          onOutput: (listener) => {
-            queueMicrotask(() => output.forEach((frame) => listener(`${JSON.stringify(frame)}\n`)));
-          },
-          onErrorOutput: () => undefined,
-          onExit: (listener) => {
-            queueMicrotask(() => listener(0));
-          },
-          terminate: () => undefined,
-        };
-      },
-    });
-  try {
-    for (const kindId of ["claude", "codex"] as const)
-      await t.test(kindId, async () => {
-        const definition = {
-          instanceId: `${kindId}-resume`,
-          name: `${kindId} resume`,
-          kindId,
-          installationId: `installation-${kindId}`,
-          providerId: kindId === "claude" ? "anthropic" : "openai",
-          models: [`${kindId}-model`],
-          authMode: "subscription",
-        };
-        host.runtimeInstance("daemon.runtimeInstance.create", definition, auth);
-        const first = await rpc(host, auth, "repo.agentRuntime.spawn", {
-          repo: { repoId },
-          payload: {
-            runtimeInstanceId: definition.instanceId,
-            cwd: { scope: "repo-root" },
-            prompt: "First turn",
-            taskId: null,
-            idempotencyKey: `${kindId}-resume-first`,
-          },
-        });
-        assert.equal(first.outcome, "applied", JSON.stringify(first));
-        await eventually(async () =>
-          makeTaskEventReader({ repoId, rootDir: root })
-            .read()
-            .events.some(
-              (event) =>
-                event.type === "runtime_session_outcome_observed" &&
-                event.payload.runtimeSessionId === first.runtimeSessionId,
-            ),
-        );
-        const providerSessionId = kindId === "claude" ? "claude-resume-session" : "codex-resume-session",
-          second = await rpc(host, auth, "repo.agentRuntime.spawn", {
-            repo: { repoId },
-            payload: {
-              runtimeInstanceId: definition.instanceId,
-              cwd: { scope: "repo-root" },
-              prompt: "Second turn",
-              providerSessionId,
-              taskId: null,
-              idempotencyKey: `${kindId}-resume-second`,
-            },
-          });
-        await eventually(async () =>
-          makeTaskEventReader({ repoId, rootDir: root })
-            .read()
-            .events.some(
-              (event) =>
-                event.type === "runtime_session_outcome_observed" &&
-                event.payload.runtimeSessionId === second.runtimeSessionId,
-            ),
-        );
-        const read = await eventuallyValue(async () => {
-          const value = await rpc(host, auth, "repo.agentRuntime.sessions.read", {
-            repo: { repoId },
-            payload: { runtimeSessionId: second.runtimeSessionId },
-          });
-          return value.result ? value : null;
-        });
-        assert.equal((read.session as Record<string, unknown>).providerSessionId, providerSessionId);
-        assert.equal(
-          (read.result as Record<string, unknown>).text,
-          kindId === "claude" ? "claude second result" : "codex second turn",
-        );
-        const secondLaunch = launches.findLast((launch) => launch.kindId === kindId)!;
-        if (kindId === "claude") assert.deepEqual(secondLaunch.args.slice(-2), ["--resume", providerSessionId]);
-        else {
-          assert.deepEqual(secondLaunch.args.slice(0, 2), ["exec", "resume"]);
-          assert.equal(secondLaunch.args.at(-2), providerSessionId);
-        }
-      });
-  } finally {
-    await host.close();
-    rmSync(parent, { recursive: true, force: true });
-  }
-});
-
-test("daemon ingress cancellation is explicit and idempotent for an active runtime", async () => {
-  const parent = mkdtempSync(path.join(tmpdir(), "ha-runtime-cancel-")),
-    root = path.join(parent, "repo"),
-    userRoot = path.join(parent, "user"),
-    executablePath = path.join(parent, "cancel-stub.mjs"),
-    repoId = "runtime-cancel",
-    uid = 4304;
-  initIngressRepo(root, uid);
-  registerDaemonRepo({
-    canonicalRoot: root,
-    repoId,
-    userRoot,
-    createConvenienceLinks: false,
-  });
-  const installation = installationFixture("codex", writeProviderStub(executablePath, "codex"));
-  const auth = {
-      transportKind: "unix-socket",
-      unixSocketOwnerBoundary: {
-        ownerUid: uid,
-        source: "unix-socket-filesystem-owner-boundary",
-      },
-    } as const,
-    host = await openDaemonHost({
-      daemonId: "runtime-cancel",
-      userRoot,
-      runtimeDiscover: () => [installation],
-      runtimeLaunch: () => ({
-        pid: 4501,
-        onOutput: () => undefined,
-        onErrorOutput: () => undefined,
-        onExit: () => undefined,
-        terminate: () => undefined,
-      }),
-    });
-  try {
-    const definition = {
-      instanceId: "codex-cancel",
-      name: "codex cancel",
-      kindId: "codex" as const,
-      installationId: installation.installationId,
-      providerId: "openai",
-      models: ["codex-model"],
-      authMode: "subscription" as const,
-    };
-    host.runtimeInstance("daemon.runtimeInstance.create", definition, auth);
-    const spawned = await rpc(host, auth, "repo.agentRuntime.spawn", {
-      repo: { repoId },
-      payload: {
-        runtimeInstanceId: definition.instanceId,
-        cwd: { scope: "repo-root" },
-        prompt: "Keep running",
-        taskId: null,
-        idempotencyKey: "cancel-active",
-      },
-    });
-    assert.equal(spawned.outcome, "applied", JSON.stringify(spawned));
-    const frames: Record<string, unknown>[] = [],
-      attached = await rpcAttach(host, auth, repoId, String(spawned.runtimeSessionId), frames);
-    try {
-      const cancelled = await rpc(host, auth, "repo.agentRuntime.cancel", {
-        repo: { repoId },
-        payload: { runtimeSessionId: spawned.runtimeSessionId },
-      });
-      assert.equal(cancelled.outcome, "applied");
-      assert.equal(cancelled.command, "runtime-cancel");
-      const read = await eventuallyValue(async () => {
-        const value = await rpc(host, auth, "repo.agentRuntime.sessions.read", {
-          repo: { repoId },
-          payload: { runtimeSessionId: spawned.runtimeSessionId },
-        });
-        // See the comment above the `.activity` polling guards: a read racing the writer's
-        // projection catch-up can return a receipt with no `session` yet.
-        return (value.session as Record<string, unknown> | undefined)?.liveness === "exited" ? value : null;
-      });
-      assert.equal(
-        (read.session as Record<string, unknown>).activity &&
-          ((read.session as Record<string, unknown>).activity as Record<string, unknown>).outcome,
-        "cancelled",
-      );
-      await eventually(() => frames.some((frame) => frame.type === "exit" && frame.outcome === "cancelled"));
-      const events = makeTaskEventReader({ repoId, rootDir: root })
-        .read()
-        .events.filter(
-          (event) => "runtimeSessionId" in event.payload && event.payload.runtimeSessionId === spawned.runtimeSessionId,
-        );
-      assert.equal(
-        events.some((event) => event.type === "runtime_session_cancelled"),
-        true,
-      );
-      const repeat = await rpc(host, auth, "repo.agentRuntime.cancel", {
-        repo: { repoId },
-        payload: { runtimeSessionId: spawned.runtimeSessionId },
-      });
-      assert.equal(repeat.outcome, "applied");
-      assert.equal(repeat.detail, "already-exited");
-      const missing = await rpc(host, auth, "repo.agentRuntime.cancel", {
-        repo: { repoId },
-        payload: { runtimeSessionId: "runtime_missing" },
-      });
-      assert.equal(missing.outcome, "pending");
-      assert.equal((missing.proof as Record<string, unknown>).canonicalVisible, false);
-    } finally {
-      attached.close();
-    }
-  } finally {
-    await host.close();
-    rmSync(parent, { recursive: true, force: true });
-  }
-});
-
-test("agy consumes only its closed stream-json event protocol", async () => {
-  const parent = mkdtempSync(path.join(tmpdir(), "ha-runtime-agy-events-")),
-    root = path.join(parent, "repo"),
-    userRoot = path.join(parent, "user"),
-    repoId = "runtime-agy-events",
-    uid = 4305;
-  let installation = {
-    installationId: "installation-agy",
-    kindId: "agy" as const,
-    executablePath: "/opt/witnessed/agy",
-    version: "1.1.15",
-    observedAt: "2026-08-19T00:00:00.000Z",
-  };
-  initIngressRepo(root, uid);
-  registerDaemonRepo({
-    canonicalRoot: root,
-    repoId,
-    userRoot,
-    createConvenienceLinks: false,
-  });
-  const agyStub = writeProviderExecutable(path.join(parent, "agy-stub"), "process.exit(0)\n");
-  installation = { ...installation, executablePath: agyStub };
-  let unknown = false;
-  const auth = {
-      transportKind: "unix-socket",
-      unixSocketOwnerBoundary: {
-        ownerUid: uid,
-        source: "unix-socket-filesystem-owner-boundary",
-      },
-    } as const,
-    host = await openDaemonHost({
-      daemonId: "runtime-agy-events",
-      userRoot,
-      runtimeDiscover: () => [installation],
-      runtimeLaunch: (prepared) => {
-        assert.deepEqual(prepared.args, [
-          "-p",
-          unknown ? "Unknown event" : "Structured result",
-          "--output-format",
-          "stream-json",
-          "--model",
-          "gemini-3.1-pro-low",
-          "--dangerously-skip-permissions",
-          "--effort",
-          "low",
-        ]);
-        const output = unknown
-          ? [{ event: "future_event", text: "must not become a result" }]
-          : [
-              { event: "init", conversation_id: "agy-conversation" },
-              {
-                event: "step_update",
-                step_update: {
-                  conversation_id: "agy-conversation",
-                  step_index: 1,
-                  state: "ACTIVE",
-                  step_type: "agent_response",
-                  text_delta: "live",
-                },
-              },
-              {
-                event: "result",
-                result: {
-                  conversation_id: "agy-conversation",
-                  status: "SUCCESS",
-                  response: "AGY-OK",
-                },
-              },
-            ];
-        return {
-          pid: 4601,
-          onOutput: (listener) => {
-            queueMicrotask(() => output.forEach((frame) => listener(`${JSON.stringify(frame)}\n`)));
-          },
-          onErrorOutput: () => undefined,
-          onExit: (listener) => {
-            queueMicrotask(() => listener(0));
-          },
-          terminate: () => undefined,
-        };
-      },
-    });
-  try {
-    host.runtimeInstance(
-      "daemon.runtimeInstance.create",
-      {
-        instanceId: "agy-provider",
-        name: "agy provider",
-        kindId: "agy",
-        installationId: installation.installationId,
-        providerId: "google",
-        models: ["gemini-3.1-pro-low"],
-        agy: { effort: "low" },
-        authMode: "subscription",
-      },
-      auth,
-    );
-    const succeeded = await rpc(host, auth, "repo.agentRuntime.spawn", {
-      repo: { repoId },
-      payload: {
-        runtimeInstanceId: "agy-provider",
-        cwd: { scope: "repo-root" },
-        prompt: "Structured result",
-        effort: "low",
-        taskId: null,
-        idempotencyKey: "agy-structured",
-      },
-    });
-    assert.equal(succeeded.outcome, "applied", JSON.stringify(succeeded));
-    const read = await eventuallyValue(async () => {
-      const value = await rpc(host, auth, "repo.agentRuntime.sessions.read", {
-        repo: { repoId },
-        payload: { runtimeSessionId: succeeded.runtimeSessionId },
-      });
-      return value.result ? value : null;
-    });
-    assert.equal((read.session as Record<string, unknown>).providerSessionId, "agy-conversation");
-    assert.equal((read.result as Record<string, unknown>).text, "AGY-OK");
-    assert.equal((read.session as { activity: { outcome: string } }).activity.outcome, "succeeded");
-    unknown = true;
-    const rejected = await rpc(host, auth, "repo.agentRuntime.spawn", {
-      repo: { repoId },
-      payload: {
-        runtimeInstanceId: "agy-provider",
-        cwd: { scope: "repo-root" },
-        prompt: "Unknown event",
-        effort: "low",
-        taskId: null,
-        idempotencyKey: "agy-unknown",
-      },
-    });
-    assert.equal(rejected.outcome, "applied", JSON.stringify(rejected));
-    const rejectedRead = await eventuallyValue(async () => {
-      const value = await rpc(host, auth, "repo.agentRuntime.sessions.read", {
-        repo: { repoId },
-        payload: { runtimeSessionId: rejected.runtimeSessionId },
-      });
-      // See the comment above the first occurrence of this guard: a read racing the writer's
-      // projection catch-up can return a receipt with no `session` yet.
-      return (value.session as { activity?: { outcome: unknown } } | undefined)?.activity?.outcome ? value : null;
-    });
-    assert.equal((rejectedRead.session as { activity: { outcome: string } }).activity.outcome, "succeeded");
-    assert.equal((rejectedRead.result as Record<string, unknown>).text, "");
-  } finally {
     await host.close();
     rmSync(parent, { recursive: true, force: true });
   }

--- a/packages/daemon/test/runtime-spawn-ingress.integration.test.ts
+++ b/packages/daemon/test/runtime-spawn-ingress.integration.test.ts
@@ -191,8 +191,15 @@ test("daemon ingress preserves executor-scoped task-bound runtime spawn", async 
       } finally {
         claimed.close();
       }
-      const overview = await host.read(repoId, "repo.agentRuntime.overview", {}, auth),
-        session = overview.sessions.find((candidate) => candidate.runtimeSessionId === receipt.runtimeSessionId);
+      const session = await eventuallyValue(async () => {
+        const overview = await host.read(repoId, "repo.agentRuntime.overview", {}, auth),
+          projected = overview.sessions.find((candidate) => candidate.runtimeSessionId === receipt.runtimeSessionId);
+        return projected?.associations.some(
+          (association) => association.taskId === taskId && association.executionId === executionId,
+        )
+          ? projected
+          : null;
+      });
       assert.equal(
         session?.associations.some(
           (association) => association.taskId === taskId && association.executionId === executionId,

--- a/packages/daemon/test/runtime-spawn-provider-ingress.integration.test.ts
+++ b/packages/daemon/test/runtime-spawn-provider-ingress.integration.test.ts
@@ -1,0 +1,822 @@
+// harness-test-tier: integration
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { makeTaskEventReader } from "../../kernel/src/index.ts";
+import { openDaemonHost } from "../src/daemon-host.ts";
+import { writeProviderExecutable } from "./fixtures/runtime-stub.ts";
+import { registerBootstrappedDaemonRepo as registerDaemonRepo } from "./repo-settings.fixture.ts";
+import {
+  initIngressRepo,
+  rpc,
+  rpcAttach,
+  eventually,
+  eventuallyValue,
+  writeProviderStub,
+  installationFixture,
+} from "./fixtures/runtime-ingress.ts";
+
+test("daemon ingress persists scrubbed provider JSONL while returning canonical results for both runtime kinds", async (t) => {
+  const parent = mkdtempSync(path.join(tmpdir(), "ha-runtime-provider-events-")),
+    root = path.join(parent, "repo"),
+    userRoot = path.join(parent, "user"),
+    repoId = "runtime-provider-events",
+    uid = 4302;
+  initIngressRepo(root, uid);
+  registerDaemonRepo({
+    canonicalRoot: root,
+    repoId,
+    userRoot,
+    createConvenienceLinks: false,
+  });
+  const installations = (["claude", "codex"] as const).map((kindId) => {
+    const executablePath = writeProviderStub(
+      path.join(parent, `${kindId}-stub.mjs`),
+      kindId,
+      undefined,
+      kindId === "claude" ? 1_000 : 40,
+    );
+    return {
+      installationId: `installation-${kindId}`,
+      kindId,
+      executablePath,
+      version: "1.0.0",
+      observedAt: "2026-08-19T00:00:00.000Z",
+    } as const;
+  });
+  const auth = {
+      transportKind: "unix-socket",
+      unixSocketOwnerBoundary: {
+        ownerUid: uid,
+        source: "unix-socket-filesystem-owner-boundary",
+      },
+    } as const,
+    host = await openDaemonHost({
+      daemonId: "runtime-provider-events",
+      userRoot,
+      runtimeDiscover: () => installations,
+    });
+  await host.attachmentsSettled();
+  try {
+    for (const kindId of ["claude", "codex"] as const)
+      host.runtimeInstance(
+        "daemon.runtimeInstance.create",
+        {
+          instanceId: `${kindId}-provider`,
+          name: `${kindId} provider`,
+          kindId,
+          installationId: `installation-${kindId}`,
+          providerId: kindId === "claude" ? "anthropic" : "openai",
+          models: [`${kindId}-model`],
+          authMode: "subscription",
+        },
+        auth,
+      );
+    host.runtimeInstance(
+      "daemon.runtimeInstance.create",
+      {
+        instanceId: "codex-read-only",
+        name: "codex read only",
+        kindId: "codex",
+        installationId: "installation-codex",
+        providerId: "openai",
+        models: ["codex-model"],
+        permissionMode: "read-only",
+        authMode: "subscription",
+      },
+      auth,
+    );
+    for (const kindId of ["claude", "codex"] as const)
+      await t.test(kindId, async () => {
+        const receipt = await rpc(host, auth, "repo.agentRuntime.spawn", {
+          repo: { repoId },
+          payload: {
+            runtimeInstanceId: `${kindId}-provider`,
+            cwd: { scope: "repo-root" },
+            prompt: `Run ${kindId}`,
+            taskId: null,
+            idempotencyKey: `${kindId}-provider-events`,
+          },
+        });
+        assert.equal(receipt.outcome, "applied", JSON.stringify(receipt));
+        // Keep Claude active while its first message is already buffered so it covers the attach
+        // response's replay path; Codex continues to cover live notifications after attachment.
+        if (kindId === "claude") await new Promise((resolve) => setTimeout(resolve, 2_000));
+        const frames: Record<string, unknown>[] = [],
+          attached = await rpcAttach(host, auth, repoId, String(receipt.runtimeSessionId), frames);
+        try {
+          await eventually(async () =>
+            frames.some(
+              (frame) =>
+                frame.type === "activity" && frame.activity === "message" && frame.content === `${kindId} live content`,
+            ),
+          );
+          const read = await eventuallyValue(async () => {
+            const value = await rpc(host, auth, "repo.agentRuntime.sessions.read", {
+              repo: { repoId },
+              payload: { runtimeSessionId: receipt.runtimeSessionId },
+            });
+            return value.result ? value : null;
+          });
+          assert.equal((read.session as Record<string, unknown>).providerSessionId, `${kindId}-provider-session`);
+          assert.deepEqual((read.session as { activity: unknown }).activity, {
+            lastObservedAt: (read.session as { activity: { lastObservedAt: string } }).activity.lastObservedAt,
+            outcome: "succeeded",
+            exitCode: 0,
+            resultRef: (read.result as Record<string, unknown>).ref,
+            missingEvidence: null,
+          });
+          assert.deepEqual(read.result, {
+            ref: (read.result as Record<string, unknown>).ref,
+            text: `${kindId} final result`,
+          });
+          assert.match(
+            String((read.result as Record<string, unknown>).ref),
+            /^artifact:runtime-result\/sha256\/[0-9a-f]{64}$/u,
+          );
+          const streamPath = path.join(root, ".harness", "runtime", "dispatches", `${receipt.dispatchId}.jsonl`),
+            stream = await eventuallyValue(() => {
+              try {
+                return readFileSync(streamPath, "utf8");
+              } catch {
+                return null;
+              }
+            });
+          assert.match(stream, /"kind":"provider_event"/u);
+          if (kindId === "codex") {
+            assert.doesNotMatch(
+              stream,
+              /credentialRef|executablePath|apiToken|sk-provider-secret|\/provider\/private/u,
+            );
+          }
+          const outcome = makeTaskEventReader({ repoId, rootDir: root })
+            .read()
+            .events.find(
+              (event) =>
+                event.type === "runtime_session_outcome_observed" &&
+                event.payload.runtimeSessionId === receipt.runtimeSessionId,
+            );
+          assert.equal(outcome?.type, "runtime_session_outcome_observed");
+          if (outcome?.type === "runtime_session_outcome_observed")
+            assert.equal(
+              Buffer.from(
+                makeTaskEventReader({ repoId, rootDir: root }).readContentBlob(outcome.payload.result!.sha256)!,
+              ).toString("utf8"),
+              `${kindId} final result`,
+            );
+        } finally {
+          attached.close();
+        }
+      });
+    const readOnly = await rpc(host, auth, "repo.agentRuntime.spawn", {
+        repo: { repoId },
+        payload: {
+          runtimeInstanceId: "codex-read-only",
+          cwd: { scope: "repo-root" },
+          prompt: "read-only",
+          taskId: null,
+          idempotencyKey: "codex-read-only",
+        },
+      }),
+      readOnlyRead = await eventuallyValue(async () => {
+        const value = await rpc(host, auth, "repo.agentRuntime.sessions.read", {
+          repo: { repoId },
+          payload: { runtimeSessionId: readOnly.runtimeSessionId },
+        });
+        // A read racing the writer's projection catch-up can observe the session before it is
+        // projected (runtime_session_not_found), which returns a receipt with no `session` at
+        // all -- keep polling rather than crashing on that transient shape.
+        return (value.session as { activity?: { outcome: unknown } } | undefined)?.activity?.outcome ? value : null;
+      });
+    assert.deepEqual(
+      (
+        readOnlyRead.session as {
+          activity: { outcome: unknown; exitCode: unknown };
+        }
+      ).activity && {
+        outcome: (readOnlyRead.session as { activity: { outcome: unknown } }).activity.outcome,
+        exitCode: (readOnlyRead.session as { activity: { exitCode: unknown } }).activity.exitCode,
+      },
+      { outcome: "succeeded", exitCode: 0 },
+    );
+    const noAction = await rpc(host, auth, "repo.agentRuntime.spawn", {
+        repo: { repoId },
+        payload: {
+          runtimeInstanceId: "codex-provider",
+          cwd: { scope: "repo-root" },
+          prompt: "no-action",
+          taskId: null,
+          idempotencyKey: "codex-no-action",
+        },
+      }),
+      noActionRead = await eventuallyValue(async () => {
+        const value = await rpc(host, auth, "repo.agentRuntime.sessions.read", {
+          repo: { repoId },
+          payload: { runtimeSessionId: noAction.runtimeSessionId },
+        });
+        // A read racing the writer's projection catch-up can observe the session before it is
+        // projected (runtime_session_not_found), which returns a receipt with no `session` at
+        // all -- keep polling rather than crashing on that transient shape.
+        return (value.session as { activity?: { outcome: unknown } } | undefined)?.activity?.outcome ? value : null;
+      });
+    assert.deepEqual(
+      (
+        noActionRead.session as {
+          activity: { outcome: unknown; exitCode: unknown };
+        }
+      ).activity && {
+        outcome: (noActionRead.session as { activity: { outcome: unknown } }).activity.outcome,
+        exitCode: (noActionRead.session as { activity: { exitCode: unknown } }).activity.exitCode,
+      },
+      { outcome: "succeeded", exitCode: 0 },
+    );
+    const noWrite = await rpc(host, auth, "repo.agentRuntime.spawn", {
+        repo: { repoId },
+        payload: {
+          runtimeInstanceId: "codex-provider",
+          cwd: { scope: "repo-root" },
+          prompt: "no-write",
+          taskId: null,
+          idempotencyKey: "codex-no-write",
+        },
+      }),
+      noWriteRead = await eventuallyValue(async () => {
+        const value = await rpc(host, auth, "repo.agentRuntime.sessions.read", {
+          repo: { repoId },
+          payload: { runtimeSessionId: noWrite.runtimeSessionId },
+        });
+        // A read racing the writer's projection catch-up can observe the session before it is
+        // projected (runtime_session_not_found), which returns a receipt with no `session` at
+        // all -- keep polling rather than crashing on that transient shape.
+        return (value.session as { activity?: { outcome: unknown } } | undefined)?.activity?.outcome ? value : null;
+      });
+    assert.deepEqual(
+      (
+        noWriteRead.session as {
+          activity: { outcome: unknown; exitCode: unknown };
+        }
+      ).activity && {
+        outcome: (noWriteRead.session as { activity: { outcome: unknown } }).activity.outcome,
+        exitCode: (noWriteRead.session as { activity: { exitCode: unknown } }).activity.exitCode,
+      },
+      { outcome: "succeeded", exitCode: 0 },
+    );
+    const denied = await rpc(host, auth, "repo.agentRuntime.spawn", {
+        repo: { repoId },
+        payload: {
+          runtimeInstanceId: "claude-provider",
+          cwd: { scope: "repo-root" },
+          prompt: "permission-denied",
+          taskId: null,
+          idempotencyKey: "claude-permission-denied",
+        },
+      }),
+      deniedRead = await eventuallyValue(async () => {
+        const value = await rpc(host, auth, "repo.agentRuntime.sessions.read", {
+          repo: { repoId },
+          payload: { runtimeSessionId: denied.runtimeSessionId },
+        });
+        // A read racing the writer's projection catch-up can observe the session before it is
+        // projected (runtime_session_not_found), which returns a receipt with no `session` at
+        // all -- keep polling rather than crashing on that transient shape.
+        return (value.session as { activity?: { outcome: unknown } } | undefined)?.activity?.outcome ? value : null;
+      });
+    assert.deepEqual(
+      (
+        deniedRead.session as {
+          activity: { outcome: unknown; exitCode: unknown };
+        }
+      ).activity && {
+        outcome: (deniedRead.session as { activity: { outcome: unknown } }).activity.outcome,
+        exitCode: (deniedRead.session as { activity: { exitCode: unknown } }).activity.exitCode,
+      },
+      { outcome: "succeeded", exitCode: 0 },
+    );
+    const empty = await rpc(host, auth, "repo.agentRuntime.spawn", {
+      repo: { repoId },
+      payload: {
+        runtimeInstanceId: "codex-provider",
+        cwd: { scope: "repo-root" },
+        prompt: "failure:empty",
+        taskId: null,
+        idempotencyKey: "codex-empty-failure",
+      },
+    });
+    const emptyRead = await eventuallyValue(async () => {
+      const value = await rpc(host, auth, "repo.agentRuntime.sessions.read", {
+        repo: { repoId },
+        payload: { runtimeSessionId: empty.runtimeSessionId },
+      });
+      // See the comment above the first occurrence of this guard: a read racing the writer's
+      // projection catch-up can return a receipt with no `session` yet.
+      return (value.session as { activity?: { outcome: unknown } } | undefined)?.activity?.outcome ? value : null;
+    });
+    assert.deepEqual(
+      (
+        emptyRead.session as {
+          activity: { outcome: unknown; exitCode: unknown };
+        }
+      ).activity && {
+        outcome: (emptyRead.session as { activity: { outcome: unknown } }).activity.outcome,
+        exitCode: (emptyRead.session as { activity: { exitCode: unknown } }).activity.exitCode,
+      },
+      { outcome: "failed", exitCode: 1 },
+    );
+    assert.equal(
+      (emptyRead.result as Record<string, unknown>).text,
+      "Provider exited with code 1 and produced no output.",
+    );
+    const secret = "sk-runtime-secret-1234567890",
+      stderrFailure = await rpc(host, auth, "repo.agentRuntime.spawn", {
+        repo: { repoId },
+        payload: {
+          runtimeInstanceId: "codex-provider",
+          cwd: { scope: "repo-root" },
+          prompt: "failure:secret",
+          taskId: null,
+          idempotencyKey: "codex-stderr-failure",
+        },
+      });
+    const stderrRead = await eventuallyValue(async () => {
+      const value = await rpc(host, auth, "repo.agentRuntime.sessions.read", {
+        repo: { repoId },
+        payload: { runtimeSessionId: stderrFailure.runtimeSessionId },
+      });
+      // See the comment above the first occurrence of this guard: a read racing the writer's
+      // projection catch-up can return a receipt with no `session` yet.
+      return (value.session as { activity?: { outcome: unknown } } | undefined)?.activity?.outcome ? value : null;
+    });
+    assert.match(
+      String((stderrRead.result as Record<string, unknown>).text),
+      /Provider exited with code 1.*OPENAI_API_KEY=\[REDACTED\]/u,
+    );
+    assert.doesNotMatch(JSON.stringify(stderrRead), new RegExp(secret, "u"));
+    assert.doesNotMatch(
+      readFileSync(path.join(root, ".harness", "runtime", "dispatches", `${stderrFailure.dispatchId}.jsonl`), "utf8"),
+      new RegExp(secret, "u"),
+    );
+    const structured = await rpc(host, auth, "repo.agentRuntime.spawn", {
+      repo: { repoId },
+      payload: {
+        runtimeInstanceId: "codex-provider",
+        cwd: { scope: "repo-root" },
+        prompt: "failure:structured",
+        taskId: null,
+        idempotencyKey: "codex-structured-failure",
+      },
+    });
+    const structuredRead = await eventuallyValue(async () => {
+      const value = await rpc(host, auth, "repo.agentRuntime.sessions.read", {
+        repo: { repoId },
+        payload: { runtimeSessionId: structured.runtimeSessionId },
+      });
+      // See the comment above the first occurrence of this guard: a read racing the writer's
+      // projection catch-up can return a receipt with no `session` yet.
+      return (value.session as { activity?: { outcome: unknown } } | undefined)?.activity?.outcome ? value : null;
+    });
+    assert.match(String((structuredRead.result as Record<string, unknown>).text), /structured provider failure/u);
+    assert.doesNotMatch(JSON.stringify(structuredRead), new RegExp(secret, "u"));
+  } finally {
+    await host.close();
+    rmSync(parent, { recursive: true, force: true });
+  }
+});
+
+test("daemon ingress resumes the same provider session for Claude and Codex", async (t) => {
+  const parent = mkdtempSync(path.join(tmpdir(), "ha-runtime-resume-")),
+    root = path.join(parent, "repo"),
+    userRoot = path.join(parent, "user"),
+    repoId = "runtime-resume",
+    uid = 4303;
+  initIngressRepo(root, uid);
+  registerDaemonRepo({
+    canonicalRoot: root,
+    repoId,
+    userRoot,
+    createConvenienceLinks: false,
+  });
+  const launches: {
+      readonly kindId: string;
+      readonly args: readonly string[];
+    }[] = [],
+    installations = (["claude", "codex"] as const).map((kindId) => {
+      const executablePath = writeProviderStub(path.join(parent, `${kindId}-resume-stub.mjs`), kindId);
+      return {
+        installationId: `installation-${kindId}`,
+        kindId,
+        executablePath,
+        version: "1.0.0",
+        observedAt: "2026-08-19T00:00:00.000Z",
+      } as const;
+    });
+  const auth = {
+      transportKind: "unix-socket",
+      unixSocketOwnerBoundary: {
+        ownerUid: uid,
+        source: "unix-socket-filesystem-owner-boundary",
+      },
+    } as const,
+    host = await openDaemonHost({
+      daemonId: "runtime-resume",
+      userRoot,
+      runtimeDiscover: () => installations,
+      runtimeLaunch: (prepared) => {
+        const kindId = prepared.definition.kindId,
+          resumed = prepared.args.includes("--resume") || prepared.args.includes("resume"),
+          providerSessionId = kindId === "claude" ? "claude-resume-session" : "codex-resume-session";
+        launches.push({ kindId, args: prepared.args });
+        const output =
+          kindId === "claude"
+            ? [
+                {
+                  type: "system",
+                  subtype: "init",
+                  session_id: providerSessionId,
+                },
+                {
+                  type: "assistant",
+                  session_id: providerSessionId,
+                  message: {
+                    content: [
+                      {
+                        type: "text",
+                        text: resumed ? "claude second turn" : "claude first turn",
+                      },
+                    ],
+                  },
+                },
+                {
+                  type: "result",
+                  subtype: "success",
+                  is_error: false,
+                  session_id: providerSessionId,
+                  result: resumed ? "claude second result" : "claude first result",
+                },
+              ]
+            : [
+                { type: "thread.started", thread_id: providerSessionId },
+                {
+                  type: "item.completed",
+                  item: {
+                    id: "resume-item",
+                    type: "agent_message",
+                    text: resumed ? "codex second turn" : "codex first turn",
+                  },
+                },
+                {
+                  type: "turn.completed",
+                  usage: { input_tokens: 1, output_tokens: 1 },
+                },
+              ];
+        return {
+          pid: 4400 + launches.length,
+          onOutput: (listener) => {
+            queueMicrotask(() => output.forEach((frame) => listener(`${JSON.stringify(frame)}\n`)));
+          },
+          onErrorOutput: () => undefined,
+          onExit: (listener) => {
+            queueMicrotask(() => listener(0));
+          },
+          terminate: () => undefined,
+        };
+      },
+    });
+  try {
+    for (const kindId of ["claude", "codex"] as const)
+      await t.test(kindId, async () => {
+        const definition = {
+          instanceId: `${kindId}-resume`,
+          name: `${kindId} resume`,
+          kindId,
+          installationId: `installation-${kindId}`,
+          providerId: kindId === "claude" ? "anthropic" : "openai",
+          models: [`${kindId}-model`],
+          authMode: "subscription",
+        };
+        host.runtimeInstance("daemon.runtimeInstance.create", definition, auth);
+        const first = await rpc(host, auth, "repo.agentRuntime.spawn", {
+          repo: { repoId },
+          payload: {
+            runtimeInstanceId: definition.instanceId,
+            cwd: { scope: "repo-root" },
+            prompt: "First turn",
+            taskId: null,
+            idempotencyKey: `${kindId}-resume-first`,
+          },
+        });
+        assert.equal(first.outcome, "applied", JSON.stringify(first));
+        await eventually(async () =>
+          makeTaskEventReader({ repoId, rootDir: root })
+            .read()
+            .events.some(
+              (event) =>
+                event.type === "runtime_session_outcome_observed" &&
+                event.payload.runtimeSessionId === first.runtimeSessionId,
+            ),
+        );
+        const providerSessionId = kindId === "claude" ? "claude-resume-session" : "codex-resume-session",
+          second = await rpc(host, auth, "repo.agentRuntime.spawn", {
+            repo: { repoId },
+            payload: {
+              runtimeInstanceId: definition.instanceId,
+              cwd: { scope: "repo-root" },
+              prompt: "Second turn",
+              providerSessionId,
+              taskId: null,
+              idempotencyKey: `${kindId}-resume-second`,
+            },
+          });
+        await eventually(async () =>
+          makeTaskEventReader({ repoId, rootDir: root })
+            .read()
+            .events.some(
+              (event) =>
+                event.type === "runtime_session_outcome_observed" &&
+                event.payload.runtimeSessionId === second.runtimeSessionId,
+            ),
+        );
+        const read = await eventuallyValue(async () => {
+          const value = await rpc(host, auth, "repo.agentRuntime.sessions.read", {
+            repo: { repoId },
+            payload: { runtimeSessionId: second.runtimeSessionId },
+          });
+          return value.result ? value : null;
+        });
+        assert.equal((read.session as Record<string, unknown>).providerSessionId, providerSessionId);
+        assert.equal(
+          (read.result as Record<string, unknown>).text,
+          kindId === "claude" ? "claude second result" : "codex second turn",
+        );
+        const secondLaunch = launches.findLast((launch) => launch.kindId === kindId)!;
+        if (kindId === "claude") assert.deepEqual(secondLaunch.args.slice(-2), ["--resume", providerSessionId]);
+        else {
+          assert.deepEqual(secondLaunch.args.slice(0, 2), ["exec", "resume"]);
+          assert.equal(secondLaunch.args.at(-2), providerSessionId);
+        }
+      });
+  } finally {
+    await host.close();
+    rmSync(parent, { recursive: true, force: true });
+  }
+});
+
+test("daemon ingress cancellation is explicit and idempotent for an active runtime", async () => {
+  const parent = mkdtempSync(path.join(tmpdir(), "ha-runtime-cancel-")),
+    root = path.join(parent, "repo"),
+    userRoot = path.join(parent, "user"),
+    executablePath = path.join(parent, "cancel-stub.mjs"),
+    repoId = "runtime-cancel",
+    uid = 4304;
+  initIngressRepo(root, uid);
+  registerDaemonRepo({
+    canonicalRoot: root,
+    repoId,
+    userRoot,
+    createConvenienceLinks: false,
+  });
+  const installation = installationFixture("codex", writeProviderStub(executablePath, "codex"));
+  const auth = {
+      transportKind: "unix-socket",
+      unixSocketOwnerBoundary: {
+        ownerUid: uid,
+        source: "unix-socket-filesystem-owner-boundary",
+      },
+    } as const,
+    host = await openDaemonHost({
+      daemonId: "runtime-cancel",
+      userRoot,
+      runtimeDiscover: () => [installation],
+      runtimeLaunch: () => ({
+        pid: 4501,
+        onOutput: () => undefined,
+        onErrorOutput: () => undefined,
+        onExit: () => undefined,
+        terminate: () => undefined,
+      }),
+    });
+  try {
+    const definition = {
+      instanceId: "codex-cancel",
+      name: "codex cancel",
+      kindId: "codex" as const,
+      installationId: installation.installationId,
+      providerId: "openai",
+      models: ["codex-model"],
+      authMode: "subscription" as const,
+    };
+    host.runtimeInstance("daemon.runtimeInstance.create", definition, auth);
+    const spawned = await rpc(host, auth, "repo.agentRuntime.spawn", {
+      repo: { repoId },
+      payload: {
+        runtimeInstanceId: definition.instanceId,
+        cwd: { scope: "repo-root" },
+        prompt: "Keep running",
+        taskId: null,
+        idempotencyKey: "cancel-active",
+      },
+    });
+    assert.equal(spawned.outcome, "applied", JSON.stringify(spawned));
+    const frames: Record<string, unknown>[] = [],
+      attached = await rpcAttach(host, auth, repoId, String(spawned.runtimeSessionId), frames);
+    try {
+      const cancelled = await rpc(host, auth, "repo.agentRuntime.cancel", {
+        repo: { repoId },
+        payload: { runtimeSessionId: spawned.runtimeSessionId },
+      });
+      assert.equal(cancelled.outcome, "applied");
+      assert.equal(cancelled.command, "runtime-cancel");
+      const read = await eventuallyValue(async () => {
+        const value = await rpc(host, auth, "repo.agentRuntime.sessions.read", {
+          repo: { repoId },
+          payload: { runtimeSessionId: spawned.runtimeSessionId },
+        });
+        // See the comment above the `.activity` polling guards: a read racing the writer's
+        // projection catch-up can return a receipt with no `session` yet.
+        return (value.session as Record<string, unknown> | undefined)?.liveness === "exited" ? value : null;
+      });
+      assert.equal(
+        (read.session as Record<string, unknown>).activity &&
+          ((read.session as Record<string, unknown>).activity as Record<string, unknown>).outcome,
+        "cancelled",
+      );
+      await eventually(() => frames.some((frame) => frame.type === "exit" && frame.outcome === "cancelled"));
+      const events = makeTaskEventReader({ repoId, rootDir: root })
+        .read()
+        .events.filter(
+          (event) => "runtimeSessionId" in event.payload && event.payload.runtimeSessionId === spawned.runtimeSessionId,
+        );
+      assert.equal(
+        events.some((event) => event.type === "runtime_session_cancelled"),
+        true,
+      );
+      const repeat = await rpc(host, auth, "repo.agentRuntime.cancel", {
+        repo: { repoId },
+        payload: { runtimeSessionId: spawned.runtimeSessionId },
+      });
+      assert.equal(repeat.outcome, "applied");
+      assert.equal(repeat.detail, "already-exited");
+      const missing = await rpc(host, auth, "repo.agentRuntime.cancel", {
+        repo: { repoId },
+        payload: { runtimeSessionId: "runtime_missing" },
+      });
+      assert.equal(missing.outcome, "pending");
+      assert.equal((missing.proof as Record<string, unknown>).canonicalVisible, false);
+    } finally {
+      attached.close();
+    }
+  } finally {
+    await host.close();
+    rmSync(parent, { recursive: true, force: true });
+  }
+});
+
+test("agy consumes only its closed stream-json event protocol", async () => {
+  const parent = mkdtempSync(path.join(tmpdir(), "ha-runtime-agy-events-")),
+    root = path.join(parent, "repo"),
+    userRoot = path.join(parent, "user"),
+    repoId = "runtime-agy-events",
+    uid = 4305;
+  let installation = {
+    installationId: "installation-agy",
+    kindId: "agy" as const,
+    executablePath: "/opt/witnessed/agy",
+    version: "1.1.15",
+    observedAt: "2026-08-19T00:00:00.000Z",
+  };
+  initIngressRepo(root, uid);
+  registerDaemonRepo({
+    canonicalRoot: root,
+    repoId,
+    userRoot,
+    createConvenienceLinks: false,
+  });
+  const agyStub = writeProviderExecutable(path.join(parent, "agy-stub"), "process.exit(0)\n");
+  installation = { ...installation, executablePath: agyStub };
+  let unknown = false;
+  const auth = {
+      transportKind: "unix-socket",
+      unixSocketOwnerBoundary: {
+        ownerUid: uid,
+        source: "unix-socket-filesystem-owner-boundary",
+      },
+    } as const,
+    host = await openDaemonHost({
+      daemonId: "runtime-agy-events",
+      userRoot,
+      runtimeDiscover: () => [installation],
+      runtimeLaunch: (prepared) => {
+        assert.deepEqual(prepared.args, [
+          "-p",
+          unknown ? "Unknown event" : "Structured result",
+          "--output-format",
+          "stream-json",
+          "--model",
+          "gemini-3.1-pro-low",
+          "--dangerously-skip-permissions",
+          "--effort",
+          "low",
+        ]);
+        const output = unknown
+          ? [{ event: "future_event", text: "must not become a result" }]
+          : [
+              { event: "init", conversation_id: "agy-conversation" },
+              {
+                event: "step_update",
+                step_update: {
+                  conversation_id: "agy-conversation",
+                  step_index: 1,
+                  state: "ACTIVE",
+                  step_type: "agent_response",
+                  text_delta: "live",
+                },
+              },
+              {
+                event: "result",
+                result: {
+                  conversation_id: "agy-conversation",
+                  status: "SUCCESS",
+                  response: "AGY-OK",
+                },
+              },
+            ];
+        return {
+          pid: 4601,
+          onOutput: (listener) => {
+            queueMicrotask(() => output.forEach((frame) => listener(`${JSON.stringify(frame)}\n`)));
+          },
+          onErrorOutput: () => undefined,
+          onExit: (listener) => {
+            queueMicrotask(() => listener(0));
+          },
+          terminate: () => undefined,
+        };
+      },
+    });
+  try {
+    host.runtimeInstance(
+      "daemon.runtimeInstance.create",
+      {
+        instanceId: "agy-provider",
+        name: "agy provider",
+        kindId: "agy",
+        installationId: installation.installationId,
+        providerId: "google",
+        models: ["gemini-3.1-pro-low"],
+        agy: { effort: "low" },
+        authMode: "subscription",
+      },
+      auth,
+    );
+    const succeeded = await rpc(host, auth, "repo.agentRuntime.spawn", {
+      repo: { repoId },
+      payload: {
+        runtimeInstanceId: "agy-provider",
+        cwd: { scope: "repo-root" },
+        prompt: "Structured result",
+        effort: "low",
+        taskId: null,
+        idempotencyKey: "agy-structured",
+      },
+    });
+    assert.equal(succeeded.outcome, "applied", JSON.stringify(succeeded));
+    const read = await eventuallyValue(async () => {
+      const value = await rpc(host, auth, "repo.agentRuntime.sessions.read", {
+        repo: { repoId },
+        payload: { runtimeSessionId: succeeded.runtimeSessionId },
+      });
+      return value.result ? value : null;
+    });
+    assert.equal((read.session as Record<string, unknown>).providerSessionId, "agy-conversation");
+    assert.equal((read.result as Record<string, unknown>).text, "AGY-OK");
+    assert.equal((read.session as { activity: { outcome: string } }).activity.outcome, "succeeded");
+    unknown = true;
+    const rejected = await rpc(host, auth, "repo.agentRuntime.spawn", {
+      repo: { repoId },
+      payload: {
+        runtimeInstanceId: "agy-provider",
+        cwd: { scope: "repo-root" },
+        prompt: "Unknown event",
+        effort: "low",
+        taskId: null,
+        idempotencyKey: "agy-unknown",
+      },
+    });
+    assert.equal(rejected.outcome, "applied", JSON.stringify(rejected));
+    const rejectedRead = await eventuallyValue(async () => {
+      const value = await rpc(host, auth, "repo.agentRuntime.sessions.read", {
+        repo: { repoId },
+        payload: { runtimeSessionId: rejected.runtimeSessionId },
+      });
+      // See the comment above the first occurrence of this guard: a read racing the writer's
+      // projection catch-up can return a receipt with no `session` yet.
+      return (value.session as { activity?: { outcome: unknown } } | undefined)?.activity?.outcome ? value : null;
+    });
+    assert.equal((rejectedRead.session as { activity: { outcome: string } }).activity.outcome, "succeeded");
+    assert.equal((rejectedRead.result as Record<string, unknown>).text, "");
+  } finally {
+    await host.close();
+    rmSync(parent, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
# English

## Summary

After a `changes_requested` review, the task could not be redispatched: `ha runtime run --task <T>` for the implementer answered `invalid_transition`, and a reviewer runtime dispatched before the CEO's next `submit` got `executor_binding_invalid` with no way forward. Tonight three lines (provider, #2251, observe) each hit it once or twice and fell back to bare dispatches. Root cause: the handoff reused the previous round's *released* lease as if it were the new round's execution. It now reuses only an execution that is still `active` in the current iteration, and a stale reviewer binding is rejected with the exact redispatch command.

## What Changed

- `packages/daemon/src/repo-cell-open.ts`: handoff reuses only the current iteration's `active` execution; the released lease from the `changes_requested` round is no longer treated as the new execution (5 lines deleted, narrower condition added).
- `packages/daemon/src/repo-cell-authorization.ts`: when an old reviewer RuntimeSession points at a superseded execution, `executor_binding_invalid` carries `ha runtime run <runtime-instance-id> --role reviewer --task <task-id>`.
- Tests: contract for the stale-reviewer hint (`repo-cell-executor-binding-cut.test.ts`); integration for submit → reviewer dispatch → changes_requested → implementer redispatch → new submit → stale reviewer rejected with hint → reviewer redispatch (`runtime-spawn-ingress.integration.test.ts`). The ingress file had crossed 1900 lines, so its provider/resume/cancel scenarios move mechanically to `runtime-spawn-provider-ingress.integration.test.ts` (no assertion removed).

## Architectural Justification

- The state machine stays authoritative and reviewer independence is untouched: the fix narrows which execution a redispatch may attach to, it does not add a retry, a fallback path, or a second write road. The only addition is a hint on an existing rejection code.
- The file split is the line-ceiling rule applied as written (structural decomposition, assertions preserved) rather than an ignore entry.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: use the single CI-backed `Production-Delta` declaration below; do not enter a second metric.

## Machine-Readable Declarations

Production-Delta: +21/-5

## Task And Scope

- Harness task: task_944a077286f0a893500c004995 (filed from tonight's dispatch friction; evidence F-595C4D1B and the rejected receipts in task_af62c7ee / task_643b8b46 review reports)
- Branch: codex/redispatch
- Public scope: two daemon files, three test files (one new by split)
- Private planning/evidence updated: yes — `artifacts/reports/redispatch.md` (before/after isolated receipts)
- Out of scope: a CLI verb that opens a new round explicitly (not needed once the handoff condition is right)

## Version Impact

- Version: no version change because no command shape changed; a rejection gained a hint
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Authority: task_944a077286f0a893500c004995; lifecycle flow defects take priority by standing ruling

## Verification

- Isolated repo (own HOME/userRoot, `TMPDIR=/tmp`, `env -u HARNESS_*`): before — implementer redispatch `invalid_transition`; after — `running`; stale reviewer gets the redispatch hint; new reviewer dispatch keeps independence.
- `npm test -- --file …executor-binding-cut… --file …runtime-spawn-ingress… --file …runtime-spawn-provider-ingress…` green (8/8 in the split file); full matrix is CI's job.

## Review Evidence

- Independent review `rev_redispatch_indep` (Sol) in flight; recorded on the task before merge.

## Residual Risk

- Reviewer redispatch was already partly working on main; this PR completes the implementer side and the stale-binding hint. Any remaining round-transition gap will show up first in the black-box acceptance runs (task_f449e24f).

---

# 中文

## 摘要

`changes_requested` 之后任务派不出去:实现者 `ha runtime run --task` 报 `invalid_transition`,CEO 重新 submit 之前派出的 reviewer runtime 得到 `executor_binding_invalid` 且无路可走;今晚三条线各撞一两次只能裸派。根因:handoff 把上一轮**已释放**的 lease 当成新轮 execution 复用。现在只复用当前 iteration 仍 `active` 的 execution;过期 reviewer 绑定被拒时给出确切的重派命令。

## 改动

- `repo-cell-open.ts`:handoff 只复用当前 iteration 的 active execution(删 5 行,换更窄条件)。
- `repo-cell-authorization.ts`:stale reviewer 绑定的 `executor_binding_invalid` 带 `ha runtime run <instance> --role reviewer --task <task>`。
- 测试:contract + 多轮生命周期 integration;超 1900 行的 ingress 文件机械拆出 provider/resume/cancel 场景(断言未删)。

## 架构辩护

状态机仍是权威,reviewer 独立性未动:只收窄续派可挂接的 execution,不加重试、不加兜底、不加第二条写路;唯一新增是既有拒绝码上的 hint。拆文件是行数规则的照章执行,不是 ignore 条目。

## 验证

隔离仓改前/改后原样回执在任务包报告;三文件测试绿。

## 残余风险

reviewer 续派在 main 上已部分可用;本 PR 补实现者侧与 stale 绑定提示;剩余轮次切换缺口会先在黑盒验收(task_f449e24f)暴露。
