### PR TITLE
fix(preset): spell out roles, allowed edits and the decoded-payload criterion in the black-box acceptance scenario

### DIFF
--- a/packages/preset/assets/software-coding/presets/lifecycle-blackbox-acceptance/PRESET.md
+++ b/packages/preset/assets/software-coding/presets/lifecycle-blackbox-acceptance/PRESET.md
@@ -1,10 +1,12 @@
 ---
 schema: preset-document/v1
-description: Materialize a source-blind black-box acceptance script for the complete Task lifecycle and the hooks negative case.
-whenToUse: Use when validating that a Consumer can discover and complete the Task lifecycle through the public ha CLI alone.
+description: Materialize a source-blind, dual-principal black-box acceptance script for the complete Task lifecycle and the hooks negative case.
+whenToUse: Use when validating that a Consumer owner/executor and a distinct independent reviewer can complete the Task lifecycle through the public ha CLI alone.
 ---
 
 # Lifecycle Black-box Acceptance
 
-Adds `lifecycle-blackbox-acceptance.md`, a reproducible Consumer-mode script for
-the hooks negative case and the start, progress, review, and completion path.
+Adds `lifecycle-blackbox-acceptance.md`, a reproducible dual-principal script for
+the hooks negative case and the start, progress, review, and completion path. It
+keeps repository source paths blind while permitting normal editing of the
+disposable Task's own harness documents and artifacts.

--- a/packages/preset/assets/software-coding/presets/lifecycle-blackbox-acceptance/templates/task.lifecycle.blackbox.acceptance/en-US.md
+++ b/packages/preset/assets/software-coding/presets/lifecycle-blackbox-acceptance/templates/task.lifecycle.blackbox.acceptance/en-US.md
@@ -2,11 +2,19 @@
 
 ## Consumer Contract
 
-Act as a source-blind Consumer. Discover the CLI only with `ha --help`,
-`ha <command> --help`, and `ha explain`. You may execute lifecycle commands
-that you discover through those surfaces. Do not read, search, list, or inspect
-`packages/` or any Harness Anything source file. Do not use prior source-level
-knowledge to invent commands or payload fields.
+Act as a source-blind Consumer owner/executor. A different principal must act as
+the independent reviewer: the Consumer/owner/executor must not author that
+review, and the reviewer must not provide owner consent or complete the Task.
+Discover the CLI only with `ha --help`, `ha <command> --help`, and `ha explain`.
+You may execute lifecycle commands that you discover through those surfaces.
+
+Source blindness means do not read, search, list, or inspect repository source
+paths, including `packages/`, `tools/`, and `docs-release/`, or any other
+Harness Anything source path. Do not use prior source-level knowledge to invent
+commands or payload fields. You may use any editor to read or edit only the
+disposable Task's own harness documents (`task_plan.md`, `closeout.md`, and
+files under that Task's `artifacts/` directory), then use the documented CLI
+sync flow where required.
 
 ## Isolated Setup
 
@@ -27,10 +35,11 @@ not edit configuration or source to manufacture a bridge.
 ## Lifecycle Scenario
 
 Create one disposable Task, start its execution, append progress with evidence,
-submit a complete typed result, record an independent approved review, provide
-the required owner consent, and complete the Task. Follow command receipts and
-their next-step guidance. Use `ha task show` between transitions and finish only
-when the canonical Task status is `done`.
+and submit a complete typed result as the Consumer owner/executor. A distinct
+independent reviewer must record the approved review. The Consumer/owner then
+provides the required owner consent and completes the Task. Follow command
+receipts and their next-step guidance. Use `ha task show` between transitions
+and finish only when the canonical Task status is `done`.
 
 If the public CLI is undiscoverable, a receipt omits the next required step, or
 field names disagree between help, schema, and receipts, stop at that first CLI
@@ -41,5 +50,8 @@ storage, or runtime defect, stop immediately without a workaround.
 
 Return a chronological transcript of every command and its unedited output, the
 created Task and Execution ids, the first failure classification if any, and the
-final Task projection. Also return a tool-call inventory sufficient to prove
-that no `packages/` path was read.
+final Task projection. Decode every tool-call payload and provide an inventory
+showing that none contains a repository source path (including `packages/`,
+`tools/`, or `docs-release/`). Do not use a raw JSONL text grep as the criterion:
+constraint prose and Task-owned document contents may legitimately name those
+paths while stating the boundary.

--- a/packages/preset/assets/software-coding/presets/lifecycle-blackbox-acceptance/templates/task.lifecycle.blackbox.acceptance/zh-CN.md
+++ b/packages/preset/assets/software-coding/presets/lifecycle-blackbox-acceptance/templates/task.lifecycle.blackbox.acceptance/zh-CN.md
@@ -2,10 +2,16 @@
 
 ## Consumer Contract
 
-你是未读源码的 Consumer。只允许通过 `ha --help`、`ha <command> --help` 与
-`ha explain` 发现 CLI；可以执行从这些公开表面发现的生命周期命令。禁止读取、
-搜索、列举或检查 `packages/` 及任何 Harness Anything 源文件；禁止用源码级先验
-知识猜测命令或 payload 字段。
+你是未读源码的 Consumer owner/executor。必须由另一个不同 principal 担任独立
+reviewer：Consumer/owner/executor 不得撰写该 review，reviewer 也不得提供 owner
+consent 或完成 Task。只允许通过 `ha --help`、`ha <command> --help` 与 `ha explain`
+发现 CLI；可以执行从这些公开表面发现的生命周期命令。
+
+源码盲的含义是禁止读取、搜索、列举或检查仓库源码路径，包括 `packages/`、
+`tools/`、`docs-release/` 和任何其他 Harness Anything 源码路径；禁止用源码级先验
+知识猜测命令或 payload 字段。可以使用任意编辑器读取或编辑仅属于该一次性 Task 的
+harness 文档（`task_plan.md`、`closeout.md` 与该 Task `artifacts/` 目录中的文件），
+之后在需要时走文档化的 CLI sync 流程。
 
 ## Isolated Setup
 
@@ -22,10 +28,11 @@ dispatch 并在运行时到达。原样记录发现命令与输出。预期观�
 
 ## Lifecycle Scenario
 
-创建一个一次性 Task，启动 Execution，追加带 evidence 的 progress，提交完整的
-typed result，记录独立的 approved review，提供所需的 owner consent，最后完成
-Task。跟随命令回执及其 next-step 指引，在转换之间执行 `ha task show`；只有规范
-Task status 为 `done` 才算完成。
+以 Consumer owner/executor 身份创建一个一次性 Task，启动 Execution，追加带
+evidence 的 progress，并提交完整的 typed result。必须由不同身份的独立 reviewer
+记录 approved review；Consumer/owner 随后提供所需的 owner consent 并完成 Task。
+跟随命令回执及其 next-step 指引，在转换之间执行 `ha task show`；只有规范 Task
+status 为 `done` 才算完成。
 
 若公开 CLI 无法发现、回执缺少下一必需步骤、或 help/schema/receipt 的字段名不一致，
 在第一个 CLI 表面缺陷处停止并原样报告。若失败属于 lifecycle、authority、storage
@@ -34,5 +41,7 @@ Task status 为 `done` 才算完成。
 ## Evidence
 
 返回每条命令及其未编辑输出的时间顺序记录、创建的 Task 与 Execution id、首个失败
-分类（如有）和最终 Task projection；另给出足以证明从未读取 `packages/` 路径的
-tool-call 清单。
+分类（如有）和最终 Task projection；解码每个 tool-call payload，并给出清单证明其中
+不含任何仓库源码路径（包括 `packages/`、`tools/`、`docs-release/`）。不得把原始
+JSONL 文本 grep 当作判据：约束文本和 Task 自有文档的内容可以为说明边界而合法提及
+这些路径。


### PR DESCRIPTION
# English

## Summary

Follow-up to #2264 from the independent review of the black-box acceptance run (`rev_blackbox53_indep`): the scenario's literal criteria did not match how a source-blind Consumer actually works. Three clarifications, text only: the run needs two distinct principals (Consumer as owner/executor, an independent reviewer); source blindness forbids reading, searching, listing or inspecting repository source paths (`packages/`, `tools/`, `docs-release/`, …) but explicitly allows any editor on the disposable task's own `task_plan.md`, `closeout.md` and `artifacts/`; and the transparency check is on decoded tool-call payloads, not a raw `grep` over the JSONL (which also contains the constraint prose itself — Run 5's 15 raw hits decode to two `apply_patch` inputs that quote the prohibition while authoring the task plan).

## What Changed

- `packages/preset/assets/software-coding/presets/lifecycle-blackbox-acceptance/PRESET.md` and `templates/task.lifecycle.blackbox.acceptance/{en-US,zh-CN}.md`: roles, allowed edits, and the decoded-payload criterion spelled out.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: use the single CI-backed `Production-Delta` declaration below; do not enter a second metric.

## Machine-Readable Declarations

Production-Delta: +0/-0

## Task And Scope

- Harness task: task_f449e24f89c97057cd81747bef (Ontology 5.3)
- Branch: codex/blackbox-scenario
- Public scope: preset scenario text
- Private planning/evidence updated: yes — `artifacts/reports/blackbox-acceptance.md` (## Scenario revision after review, with the two decoded payload contexts)
- Out of scope: any change to the Consumer behaviour or to lifecycle code

## Version Impact

- Version: no version change because only preset prose changed
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Authority: task_f449e24f89c97057cd81747bef; correction requested by `rev_blackbox53_indep`

## Verification

- `node --test packages/preset/test/preset-resolver-bundled-catalog.test.ts packages/preset/test/preset-resolver-snapshot-templates.test.ts` green; full matrix is CI's job.

## Review Evidence

- Independent re-review `rev_blackbox53_indep_r2` requested against the revised criteria and the Run 5 decoded payloads.

## Residual Risk

- None beyond prose; a future run under the revised scenario is the authoritative proof.

---

# 中文

## 摘要

#2264 的后续,来自黑盒验收独立复核 `rev_blackbox53_indep`:剧本的字面判据与源码盲 Consumer 的真实工作方式不一致。三处澄清,只改文字:必须两个不同 principal(Consumer=owner/executor,独立 reviewer 另一身份);源码盲禁止读取/搜索/列出/检视仓库源码路径(`packages/`、`tools/`、`docs-release/`…),但明确允许用任何编辑器编辑一次性任务自己的 `task_plan.md`/`closeout.md`/`artifacts/`;透明判据针对解码后的 tool-call payload,不是对含约束文本的原始 JSONL 数 grep(Run 5 的 15 处原始命中解码后只有两处,都是 `apply_patch` 写 task plan 时引用的禁令原文)。

## 改动

三个 preset 文本文件。

## 验证

preset 定向测试绿;复核 `rev_blackbox53_indep_r2` 按修订判据重做。
