### PR TITLE
test(cli): make the missing-agent batch row independent of task lease ordering

### DIFF
--- a/packages/cli/test/runtime-cli.integration.test.ts
+++ b/packages/cli/test/runtime-cli.integration.test.ts
@@ -1044,7 +1044,7 @@ test("real CLI runs, archives task-bound dispatches, resumes, waits through stat
           schema: "runtime-batch/v1",
           maxConcurrency: 2,
           dispatches: [
-            { instance: "cli-worker", agent: "fable", to: "missing-agent", prompt: "must reject", task: taskId },
+            { instance: "cli-worker", agent: "fable", to: "missing-agent", prompt: "must reject" },
             {
               instance: "cli-worker",
               agent: "fable",


### PR DESCRIPTION
# English

## Summary
main d19b29c09 went red in `runtime-cli.integration.test.ts` (full-check 26): the first `runtime batch` row (`to: missing-agent`, task-bound) expected `squad_member_not_found` but received `runtime_task_lease_required`.

Root cause: `runtime-spawner.ts` checks the task lease before it resolves squad membership. With `maxConcurrency: 2` the batch admits row 0 and row 1 concurrently, so whenever row 1 wins admission and takes the lease, row 0 is rejected by the lease gate instead of the squad gate. The assertion depended on admission order that the test never controlled. Same family as F-BC03A6F5.

Fix: row 0 no longer carries `task`, so its rejection reason is independent of lease state. The task-bound rows and their assertions (one success, three `runtime_task_lease_required`) are unchanged.

## Verification
- `packages/cli/test/runtime-cli.integration.test.ts` locally: 1/1 pass after the change (isolated env, TMPDIR=/tmp).
- Fact F-CB461325 records the CI log evidence and mechanism under task_f9443002.

## Review Evidence
- Test-only change, reviewed by the CEO session against the spawner check order (`runtime-spawner.ts` lease gate precedes squad resolution).

## Residual Risk
- Rows 1–4 still race for the single lease under concurrency 2; the assertions already tolerate any winner, so no further order dependence remains in this block.

Production-Delta: +0/-0
Deleted-Production-Paths: none

---

# 中文

## 摘要
main d19b29c09 在 `runtime-cli.integration.test.ts`(full-check 26)变红:`runtime batch` 第 0 行(`to: missing-agent`,绑定 task)期望 `squad_member_not_found`,实得 `runtime_task_lease_required`。

根因:`runtime-spawner.ts` 先做任务租约检查,后解析 squad 成员。`maxConcurrency: 2` 让第 0 行与第 1 行并发入队,只要第 1 行先被接纳并持有租约,第 0 行就被租约门而非 squad 门拒绝。断言依赖了测试从未控制的入队顺序。与 F-BC03A6F5 同族。

修法:第 0 行不再带 `task`,其拒绝原因与租约状态无关。任务绑定行及其断言(一成功、三 `runtime_task_lease_required`)不变。

## 验证
- 本地整文件 `packages/cli/test/runtime-cli.integration.test.ts` 改后 1/1 绿(隔离 env,TMPDIR=/tmp)。
- Fact F-CB461325 在 task_f9443002 下记录 CI 日志证据与机制。

## 复核证据
- 仅测试改动,CEO session 对照 spawner 检查顺序(租约门先于 squad 解析)亲验。

## 残余风险
- 第 1–4 行在并发度 2 下仍竞争同一租约;断言已容忍任一胜者,该块不再有顺序依赖。
