### PR TITLE
feat(settings): configure review independence by repository

### DIFF
--- a/packages/cli/test/settings-command.test.ts
+++ b/packages/cli/test/settings-command.test.ts
@@ -18,6 +18,8 @@ test("Settings CLI projects read and owned update flags to the closed daemon act
     "update",
     "--default-preset",
     "strict-task",
+    "--review-independence",
+    "principal",
     "--locale",
     "zh-CN",
     "--task-scaffold",
@@ -32,6 +34,7 @@ test("Settings CLI projects read and owned update flags to the closed daemon act
     assert.deepEqual(update.command.action, {
       kind: "settings-update",
       defaultPreset: "strict-task",
+      reviewIndependence: "principal",
       locale: "zh-CN",
       taskScaffold: "governance/task-scaffold.json",
       expectedVersion: 42,

--- a/packages/daemon/src/protocol/daemon-protocol-commands.ts
+++ b/packages/daemon/src/protocol/daemon-protocol-commands.ts
@@ -62,6 +62,15 @@ const settingsWriteTopology = {
         settingValueInput("--default-preset"),
         settingValueInput("--default-profile"),
         cliInput(
+          "--review-independence",
+          "single",
+          false,
+          { code: "invalid_field" },
+          {
+            enum: ["execution", "principal"],
+          },
+        ),
+        cliInput(
           "--locale",
           "single",
           false,

--- a/packages/daemon/src/protocol/daemon-protocol-gui-actions.ts
+++ b/packages/daemon/src/protocol/daemon-protocol-gui-actions.ts
@@ -188,6 +188,7 @@ export const daemonGuiActionMethods = Object.freeze([
       defaultVertical: "string?",
       defaultPreset: "string?",
       defaultProfile: "string?",
+      reviewIndependence: "string?",
       locale: "string?",
       taskScaffold: "string?",
       repositoryScaffold: "string?",

--- a/packages/daemon/src/protocol/daemon-protocol-rpc-validation.ts
+++ b/packages/daemon/src/protocol/daemon-protocol-rpc-validation.ts
@@ -283,18 +283,10 @@ export function validateGuiActionPayload(method: DaemonGuiActionMethod, value: u
       Object.keys(item).every((field) => required.includes(field) || optional.includes(field));
   if (method === "repo.task.submit") errors.push(...validateGuiSubmission(value.submission));
   if (method === "repo.settings.update") {
-    const settingFields = [
-        "defaultVertical",
-        "defaultPreset",
-        "defaultProfile",
-        "locale",
-        "taskScaffold",
-        "repositoryScaffold",
-        "walFlushAdaptive",
-        "walFlushEvents",
-        "walFlushBytes",
-        "walFlushMilliseconds",
-      ],
+    const settingFields = (
+        "defaultVertical defaultPreset defaultProfile reviewIndependence locale taskScaffold repositoryScaffold " +
+        "walFlushAdaptive walFlushEvents walFlushBytes walFlushMilliseconds"
+      ).split(" "),
       changed = settingFields.filter((field) => value[field] !== undefined),
       identifier = /^[A-Za-z0-9][A-Za-z0-9/_.@-]*$/u;
     if (
@@ -306,7 +298,8 @@ export function validateGuiActionPayload(method: DaemonGuiActionMethod, value: u
       [value.walFlushEvents, value.walFlushBytes, value.walFlushMilliseconds].some(
         (item) => item !== undefined && (!Number.isSafeInteger(item) || Number(item) < 1),
       ) ||
-      (value.locale !== undefined && !["en-US", "zh-CN"].includes(String(value.locale)))
+      (value.locale !== undefined && !["en-US", "zh-CN"].includes(String(value.locale))) ||
+      (value.reviewIndependence !== undefined && !["execution", "principal"].includes(String(value.reviewIndependence)))
     )
       errors.push("settings update is invalid");
   }

--- a/packages/daemon/src/repo-cell-action-context.ts
+++ b/packages/daemon/src/repo-cell-action-context.ts
@@ -318,7 +318,7 @@ export function createRepoCellActionContext(bindings: {
       snapshot: Parameters<typeof proofFor>[1],
       binding: Parameters<typeof proofFor>[2],
       projection: Parameters<typeof proofFor>[3],
-    ) => proofFor(command, snapshot, binding, projection, bindings.rootDir, bindings.getSettings()),
+    ) => proofFor(command, snapshot, binding, projection, bindings.rootDir, bindings.getSettings),
     lifecycleReceipt,
     publicPublication: bindings.publicPublication,
     explicitExecutionId,

--- a/packages/daemon/src/repo-cell-action-context.ts
+++ b/packages/daemon/src/repo-cell-action-context.ts
@@ -233,6 +233,7 @@ export function createRepoCellActionContext(bindings: {
   readonly getEntityActionExecutor: () => ReturnType<typeof makeEntityActionCatalogExecutor>;
   readonly getEntityActionRuntimes: () => EntityActionCatalogRuntimes;
   readonly getService: () => ReturnType<typeof makeTaskLifecycleService>;
+  readonly getSettings: () => SettingsV1;
   readonly getRecovery: () => ReturnType<CanonicalEventStore["recover"]>;
   readonly getRecoveryUncertain: () => boolean;
   readonly setRecoveryUncertain: (value: boolean) => void;
@@ -317,7 +318,7 @@ export function createRepoCellActionContext(bindings: {
       snapshot: Parameters<typeof proofFor>[1],
       binding: Parameters<typeof proofFor>[2],
       projection: Parameters<typeof proofFor>[3],
-    ) => proofFor(command, snapshot, binding, projection, bindings.rootDir),
+    ) => proofFor(command, snapshot, binding, projection, bindings.rootDir, bindings.getSettings()),
     lifecycleReceipt,
     publicPublication: bindings.publicPublication,
     explicitExecutionId,

--- a/packages/daemon/src/repo-cell-errors.ts
+++ b/packages/daemon/src/repo-cell-errors.ts
@@ -28,8 +28,9 @@ export function cellCriterionError(
   actionId: string,
   criterionRef: string,
   nextActions: readonly string[] = [],
+  diagnostic?: ReceiptDiagnostic,
 ): Error {
-  return attributeCellCriterion(cellCodedError(code, text), actionId, criterionRef, nextActions);
+  return attributeCellCriterion(cellCodedError(code, text, diagnostic), actionId, criterionRef, nextActions);
 }
 
 export function attributeCellCriterion(

--- a/packages/daemon/src/repo-cell-open.ts
+++ b/packages/daemon/src/repo-cell-open.ts
@@ -681,6 +681,7 @@ export async function openRepoWriterCell(
     getEntityActionExecutor: () => entityActionExecutor,
     getEntityActionRuntimes: () => entityActionRuntimes,
     getService: () => service,
+    getSettings: () => readSettings(),
     getRecovery: () => recovery,
     getRecoveryUncertain: () => recoveryUncertain,
     setRecoveryUncertain: (value) => {

--- a/packages/daemon/src/repo-cell-proof.ts
+++ b/packages/daemon/src/repo-cell-proof.ts
@@ -21,6 +21,7 @@ import {
   type AuthorizationDecision,
   type CompleteTaskCommand,
   type ProofFor,
+  type SettingsV1,
   type TaskLifecycleCommand,
   type WriteReceipt,
 } from "../../kernel/src/index.ts";
@@ -41,6 +42,7 @@ export async function proofFor(
   binding: RepoCellBinding,
   projection: ReturnType<typeof makeTaskProjection>,
   rootDir: string,
+  settings: SettingsV1,
 ): Promise<TaskLifecycleServiceProof<typeof command> & { readonly authorizationDecision?: AuthorizationDecision }> {
   if (command.type === "CreateReplayTask") return { taskIdUnique: true, actorBinding: command.actor };
   const transition = TASK_LIFECYCLE_TRANSITIONS.find((candidate) => candidate.matches(command, snapshot)),
@@ -147,18 +149,49 @@ export async function proofFor(
         REVIEW_PROOF_CRITERION,
         reviewCriterion.nextActions,
       );
-    const independentActor = execution !== undefined && isIndependentFrom(execution.actor, command.actor),
+    const independentActor =
+        execution !== undefined &&
+        (settings.reviewIndependence === "execution"
+          ? isIndependentFrom(execution.actor, command.actor)
+          : !isSamePerson(execution.actor, command.actor)),
       externalCompletionEvidence = independentActor
         ? false
         : validExternalCompletionEvidence(command, projection, rootDir),
       explicitlyUnreviewed = independentActor ? false : validNoIndependentReview(command, projection, rootDir);
     if (!independentActor && !externalCompletionEvidence && !explicitlyUnreviewed) {
+      const principalSettingGuidance =
+        settings.reviewIndependence === "principal" &&
+        execution !== undefined &&
+        isSamePerson(execution.actor, command.actor)
+          ? [
+              "Repository setting reviewIndependence currently equals principal, so the reviewer and execution " +
+                "actor must have different principals.",
+              "ha settings update --review-independence execution",
+            ]
+          : reviewCriterion.nextActions;
       throw cellCriterionError(
         "actor_unauthorized",
-        "Task review actor independence proof was not satisfied.",
+        settings.reviewIndependence === "principal" &&
+          execution !== undefined &&
+          isSamePerson(execution.actor, command.actor)
+          ? "Repository setting reviewIndependence is principal; the reviewer and execution actor have the same " +
+              "principal. Change it with `ha settings update --review-independence execution`."
+          : "Task review actor independence proof was not satisfied.",
         "review",
         REVIEW_PROOF_CRITERION,
-        reviewCriterion.nextActions,
+        principalSettingGuidance,
+        settings.reviewIndependence === "principal" &&
+          execution !== undefined &&
+          isSamePerson(execution.actor, command.actor)
+          ? {
+              kind: "validation",
+              entity: "repository setting",
+              field: "reviewIndependence",
+              actual: "principal",
+              expectation:
+                "Use a reviewer with a different principal, or run ha settings update --review-independence execution",
+            }
+          : undefined,
       );
     }
     return {

--- a/packages/daemon/src/repo-cell-proof.ts
+++ b/packages/daemon/src/repo-cell-proof.ts
@@ -42,7 +42,7 @@ export async function proofFor(
   binding: RepoCellBinding,
   projection: ReturnType<typeof makeTaskProjection>,
   rootDir: string,
-  settings: SettingsV1,
+  getSettings: () => SettingsV1,
 ): Promise<TaskLifecycleServiceProof<typeof command> & { readonly authorizationDecision?: AuthorizationDecision }> {
   if (command.type === "CreateReplayTask") return { taskIdUnique: true, actorBinding: command.actor };
   const transition = TASK_LIFECYCLE_TRANSITIONS.find((candidate) => candidate.matches(command, snapshot)),
@@ -107,6 +107,7 @@ export async function proofFor(
     };
   }
   if (command.type === "RecordReview") {
+    const settings = getSettings();
     const runtimeSessionId = runtimeSessionIdFromActor(command.actor),
       runtimeSession = runtimeSessionId === null ? null : projection.readRuntimeSession(runtimeSessionId),
       runtimeBinding = runtimeSession?.taskBindings.some(

--- a/packages/daemon/test/gui-s3-contract.test.ts
+++ b/packages/daemon/test/gui-s3-contract.test.ts
@@ -25,6 +25,7 @@ test("daemon Settings reads use the exact canonical Settings shape", () => {
     defaultVertical: "software/coding",
     defaultPreset: "standard-task",
     defaultProfile: "baseline",
+    reviewIndependence: "execution",
     locale: "en-US",
     scaffolds: {
       task: "governance/task-scaffold.json",

--- a/packages/daemon/test/review-independence-diagnostics.integration.test.ts
+++ b/packages/daemon/test/review-independence-diagnostics.integration.test.ts
@@ -1,7 +1,7 @@
 // harness-test-tier: integration
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -32,6 +32,7 @@ test("#1541: each Execution Review refusal names its own cause and its own repai
   let cell: Awaited<ReturnType<typeof openRepoCell>> | undefined;
   try {
     initRepo(rootDir);
+    writeSettingsFixture(rootDir);
     cell = await openRepoCell({
       repoId: workspaceId("review-independence"),
       rootDir: canonicalRoot(rootDir),
@@ -115,6 +116,104 @@ test("#1541: each Execution Review refusal names its own cause and its own repai
     rmSync(rootDir, { recursive: true, force: true });
   }
 });
+
+test("principal review independence rejects a different executor owned by the submitting principal", async () => {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-review-principal-"));
+  let cell: Awaited<ReturnType<typeof openRepoCell>> | undefined;
+  try {
+    initRepo(rootDir);
+    writeSettingsFixture(rootDir);
+    cell = await openRepoCell({
+      repoId: workspaceId("review-principal"),
+      rootDir: canonicalRoot(rootDir),
+      ownerId: "daemon-test",
+    });
+    const principal = { personId: "person-review-principal" } as const,
+      agent = withRoleBinding(
+        { actor: { principal, executor: { kind: "agent" as const, id: "worker" } }, source: "local" as const },
+        "arbiter",
+      ),
+      reviewer = withRoleBinding(
+        { actor: { principal, executor: { kind: "agent" as const, id: "reviewer" } }, source: "local" as const },
+        "arbiter",
+      );
+    const updated = await cell.run(
+      { kind: "settings-update", reviewIndependence: "principal", idempotencyKey: "strict-review-independence" },
+      agent,
+    );
+    assert.equal(updated.outcome, "applied", JSON.stringify(updated));
+    const settingsRead = (await cell.read("repo.settings.read")) as {
+      readonly settings: { readonly reviewIndependence?: string };
+    };
+    assert.equal(settingsRead.settings.reviewIndependence, "principal");
+
+    const taskId = "task-principal-review",
+      executionId = "exec-principal-review";
+    const created = await cell.run({ kind: "task-create", taskId, title: "Principal review" }, agent);
+    assert.equal(created.outcome, "applied");
+    await realizeTaskPlanFixture(rootDir, String((created as Record<string, unknown>).packagePath), (planPath) =>
+      cell!.run({ kind: "doc-submit", paths: [planPath] }, agent),
+    );
+    assert.equal((await cell.run({ kind: "task-start", taskId, executionId }, agent)).outcome, "applied");
+    const commitSha = git(rootDir, "rev-parse", "HEAD");
+    writeFileSync(
+      path.join(rootDir, "submission.json"),
+      JSON.stringify({
+        completionClaim: "Ready.",
+        deliverables: ["d"],
+        outputs: ["o"],
+        verificationNotes: ["v"],
+        knownGaps: [],
+        residualRisks: [],
+        commitSha,
+      }),
+    );
+    assert.equal(
+      (await cell.run({ kind: "task-submit", taskId, executionId, fromFile: "submission.json" }, agent)).outcome,
+      "applied",
+    );
+    writeFileSync(
+      path.join(rootDir, "review.json"),
+      JSON.stringify({ verdict: "approved", reason: "Reviewed independently.", evidenceChecked: ["tests"] }),
+    );
+
+    const refused = await cell.run(
+      { kind: "task-review-execution", taskId, executionId, reviewId: "strict-review", fromFile: "review.json" },
+      reviewer,
+    );
+    assert.equal(refused.code, "actor_unauthorized", JSON.stringify(refused));
+    assert.match(
+      JSON.stringify(refused),
+      /reviewIndependence.*principal.*ha settings update --review-independence execution/u,
+    );
+  } finally {
+    await cell?.close();
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});
+
+function writeSettingsFixture(rootDir: string): void {
+  mkdirSync(path.join(rootDir, "harness"), { recursive: true });
+  writeFileSync(
+    path.join(rootDir, "harness/harness.yaml"),
+    [
+      "schema: harness-anything/v1",
+      "layout:",
+      "  authoredRoot: harness",
+      "  localRoot: .harness",
+      "settings:",
+      "  defaultVertical: software/coding",
+      "  defaultPreset: standard-task",
+      "  defaultProfile: baseline",
+      "  scaffolds:",
+      "    task: governance/task-scaffold.json",
+      "    repository: governance/repository-scaffold.json",
+      "",
+    ].join("\n"),
+  );
+  git(rootDir, "add", "harness/harness.yaml");
+  git(rootDir, "commit", "--quiet", "-m", "settings fixture");
+}
 
 // The complementary half: when the execution declared no executor, the same principal genuinely cannot
 // review it until an agent executor accepts that attribution through its own audited lifecycle event.

--- a/packages/gui/test/service-bridge.test.ts
+++ b/packages/gui/test/service-bridge.test.ts
@@ -250,6 +250,7 @@ test("GUI client reaches every shipped read through a real resident daemon", asy
       defaultVertical: "software/coding",
       defaultPreset: "standard-task",
       defaultProfile: "baseline",
+      reviewIndependence: "execution",
       locale: "en-US",
       scaffolds: {
         task: "governance/task-scaffold.json",

--- a/packages/gui/test/settings-repository-selectors.vitest.ts
+++ b/packages/gui/test/settings-repository-selectors.vitest.ts
@@ -21,6 +21,7 @@ const SETTINGS = {
   defaultVertical: "software/coding",
   defaultPreset: "standard-task",
   defaultProfile: "baseline",
+  reviewIndependence: "execution" as const,
   locale: "zh-CN" as const,
   scaffolds: { task: "governance/task-scaffold.json", repository: "governance/repository-scaffold.json" },
   walFlush: { adaptive: true, events: 256, bytes: 8_388_608, milliseconds: 3_600_000 },

--- a/packages/gui/test/system-group-widescreen.vitest.ts
+++ b/packages/gui/test/system-group-widescreen.vitest.ts
@@ -45,6 +45,7 @@ function seedQueries(client: QueryClient): void {
       defaultVertical: "software/coding",
       defaultPreset: "standard-task",
       defaultProfile: "baseline",
+      reviewIndependence: "execution",
       locale: "zh-CN",
       scaffolds: { task: "governance/task-scaffold.json", repository: "governance/repository-scaffold.json" },
       walFlush: { adaptive: true, events: 256, bytes: 8_388_608, milliseconds: 3_600_000 },

--- a/packages/kernel/src/domain/index.ts
+++ b/packages/kernel/src/domain/index.ts
@@ -256,13 +256,14 @@ export {
   SETTINGS_LOCAL_PATH,
   parseLocalSettings,
   readSettingsFacet,
+  reviewIndependenceLevels,
   repositorySettings,
   serializeLocalSettings,
   validateRepositorySettings,
   validateSettingsV1,
   writeRepositorySettingsFacet,
 } from "./settings.ts";
-export type { RepositorySettingsV1, SettingsLocale, SettingsV1 } from "./settings.ts";
+export type { RepositorySettingsV1, ReviewIndependence, SettingsLocale, SettingsV1 } from "./settings.ts";
 export { compileSettingsChangedEvent, isSettingsEvent } from "./settings-event.ts";
 export { settingsActionLocale } from "./settings-action-contract.ts";
 export type { SettingsActionDraft } from "./settings-action-contract.ts";

--- a/packages/kernel/src/domain/index.ts
+++ b/packages/kernel/src/domain/index.ts
@@ -256,14 +256,13 @@ export {
   SETTINGS_LOCAL_PATH,
   parseLocalSettings,
   readSettingsFacet,
-  reviewIndependenceLevels,
   repositorySettings,
   serializeLocalSettings,
   validateRepositorySettings,
   validateSettingsV1,
   writeRepositorySettingsFacet,
 } from "./settings.ts";
-export type { RepositorySettingsV1, ReviewIndependence, SettingsLocale, SettingsV1 } from "./settings.ts";
+export type { RepositorySettingsV1, SettingsLocale, SettingsV1 } from "./settings.ts";
 export { compileSettingsChangedEvent, isSettingsEvent } from "./settings-event.ts";
 export { settingsActionLocale } from "./settings-action-contract.ts";
 export type { SettingsActionDraft } from "./settings-action-contract.ts";

--- a/packages/kernel/src/domain/settings-action-contract.ts
+++ b/packages/kernel/src/domain/settings-action-contract.ts
@@ -13,6 +13,7 @@ import { compileSettingsChangedEvent, type SettingsEventBundle } from "./setting
 import {
   SETTINGS_ID,
   repositorySettings,
+  reviewIndependenceLevels,
   settingsLocales,
   validateRepositorySettings,
   writeRepositorySettingsFacet,
@@ -38,6 +39,7 @@ const repositoryFieldNames = Object.freeze([
   "defaultVertical",
   "defaultPreset",
   "defaultProfile",
+  "reviewIndependence",
   "taskScaffold",
   "repositoryScaffold",
   "walFlushAdaptive",
@@ -120,6 +122,7 @@ export function createSettingsActionCatalog(
           field("defaultVertical"),
           field("defaultPreset"),
           field("defaultProfile"),
+          field("reviewIndependence", "string", false, reviewIndependenceLevels),
           field("locale", "string", false, settingsLocales),
           field("taskScaffold"),
           field("repositoryScaffold"),
@@ -194,6 +197,7 @@ export function compileSettingsUpdate(input: EntityActionCompileInput): Settings
       defaultVertical: updatedText(input.action, "defaultVertical", current.defaultVertical),
       defaultPreset: updatedText(input.action, "defaultPreset", current.defaultPreset),
       defaultProfile: updatedText(input.action, "defaultProfile", current.defaultProfile),
+      reviewIndependence: updatedReviewIndependence(input.action.reviewIndependence, current.reviewIndependence),
       scaffolds: {
         task: updatedText(input.action, "taskScaffold", current.scaffolds.task),
         repository: updatedText(input.action, "repositoryScaffold", current.scaffolds.repository),
@@ -236,10 +240,10 @@ export function settingsActionLocale(value: unknown): SettingsLocale | undefined
 }
 
 function currentSettings(input: EntityActionCompileInput): RepositorySettingsV1 {
-  const current = input.currentEntity;
+  const current = repositorySettings(input.currentEntity as RepositorySettingsV1);
   if (validateRepositorySettings(current).length)
     rejectSettings("content_not_ready", `Settings ${SETTINGS_ID} has no valid canonical projection.`);
-  return repositorySettings(current as RepositorySettingsV1);
+  return current;
 }
 
 function updatedText(action: Readonly<Record<string, unknown>>, name: string, current: string): string {
@@ -247,6 +251,16 @@ function updatedText(action: Readonly<Record<string, unknown>>, name: string, cu
   const value = action[name];
   if (typeof value === "string" && value.trim()) return value.trim();
   rejectSettings("invalid_command", `${name} must be a non-empty string.`);
+}
+
+function updatedReviewIndependence(
+  value: unknown,
+  current: RepositorySettingsV1["reviewIndependence"],
+): RepositorySettingsV1["reviewIndependence"] {
+  if (value === undefined) return current;
+  if (reviewIndependenceLevels.includes(value as RepositorySettingsV1["reviewIndependence"]))
+    return value as RepositorySettingsV1["reviewIndependence"];
+  rejectSettings("invalid_command", `reviewIndependence must be one of ${reviewIndependenceLevels.join(", ")}.`);
 }
 
 function updatedBoolean(action: Readonly<Record<string, unknown>>, name: string, current: boolean): boolean {

--- a/packages/kernel/src/domain/settings-event.ts
+++ b/packages/kernel/src/domain/settings-event.ts
@@ -138,6 +138,7 @@ function validSettingsSnapshot(value: unknown, allowUnknownFields: boolean): boo
       defaultVertical: value.defaultVertical,
       defaultPreset: value.defaultPreset,
       defaultProfile: value.defaultProfile,
+      reviewIndependence: value.reviewIndependence ?? "execution",
       scaffolds: {
         task: value.scaffolds.task,
         repository: value.scaffolds.repository,
@@ -164,6 +165,7 @@ function validSettingsSnapshot(value: unknown, allowUnknownFields: boolean): boo
           "defaultVertical",
           "defaultPreset",
           "defaultProfile",
+          "reviewIndependence",
           "scaffolds",
           "walFlush",
         ].includes(field),

--- a/packages/kernel/src/domain/settings.ts
+++ b/packages/kernel/src/domain/settings.ts
@@ -6,6 +6,8 @@ export const SETTINGS_ID = "repository";
 export const SETTINGS_LOCAL_PATH = ".harness/settings.local.json";
 export const settingsLocales = ["en-US", "zh-CN"] as const;
 export type SettingsLocale = (typeof settingsLocales)[number];
+export const reviewIndependenceLevels = ["execution", "principal"] as const;
+export type ReviewIndependence = (typeof reviewIndependenceLevels)[number];
 
 export interface WalFlushSettingsV1 {
   readonly adaptive: boolean;
@@ -29,6 +31,7 @@ export const SETTINGS_FIELD_OWNERSHIP = Object.freeze({
   defaultVertical: "repository",
   defaultPreset: "repository",
   defaultProfile: "repository",
+  reviewIndependence: "repository",
   locale: "local",
   scaffolds: "repository",
   walFlush: "repository",
@@ -49,6 +52,7 @@ export interface RepositorySettingsV1 {
   readonly defaultVertical: string;
   readonly defaultPreset: string;
   readonly defaultProfile: string;
+  readonly reviewIndependence: ReviewIndependence;
   readonly scaffolds: {
     readonly task: string;
     readonly repository: string;
@@ -67,6 +71,7 @@ export interface SettingsV1 {
   readonly defaultVertical: string;
   readonly defaultPreset: string;
   readonly defaultProfile: string;
+  readonly reviewIndependence: ReviewIndependence;
   readonly locale: SettingsLocale;
   readonly scaffolds: {
     readonly task: string;
@@ -93,6 +98,7 @@ export const INITIAL_SETTINGS_V1: SettingsV1 = Object.freeze({
   defaultVertical: "software/coding",
   defaultPreset: "standard-task",
   defaultProfile: "baseline",
+  reviewIndependence: "execution",
   locale: "en-US",
   scaffolds: Object.freeze({
     task: "governance/task-scaffold.json",
@@ -128,6 +134,10 @@ export const SETTINGS_V1_SCHEMA: EntityDocumentJsonSchema<SettingsV1> = {
       minLength: 1,
       ...ownedSchema("defaultProfile", {}),
     },
+    reviewIndependence: ownedSchema("reviewIndependence", {
+      type: "string",
+      enum: reviewIndependenceLevels,
+    }),
     locale: ownedSchema("locale", { type: "string", enum: settingsLocales }),
     scaffolds: {
       ...ownedSchema("scaffolds", {}),
@@ -157,6 +167,7 @@ export const SETTINGS_V1_SCHEMA: EntityDocumentJsonSchema<SettingsV1> = {
     "defaultVertical",
     "defaultPreset",
     "defaultProfile",
+    "reviewIndependence",
     "locale",
     "scaffolds",
     "walFlush",
@@ -185,6 +196,10 @@ export const SETTINGS_REPOSITORY_V1_SCHEMA: EntityDocumentJsonSchema<RepositoryS
       minLength: 1,
       ...ownedSchema("defaultProfile", {}),
     },
+    reviewIndependence: ownedSchema("reviewIndependence", {
+      type: "string",
+      enum: reviewIndependenceLevels,
+    }),
     scaffolds: {
       ...ownedSchema("scaffolds", {}),
       type: "object",
@@ -202,7 +217,16 @@ export const SETTINGS_REPOSITORY_V1_SCHEMA: EntityDocumentJsonSchema<RepositoryS
     },
     walFlush: walFlushSchema(),
   },
-  required: ["schema", "settingsId", "defaultVertical", "defaultPreset", "defaultProfile", "scaffolds", "walFlush"],
+  required: [
+    "schema",
+    "settingsId",
+    "defaultVertical",
+    "defaultPreset",
+    "defaultProfile",
+    "reviewIndependence",
+    "scaffolds",
+    "walFlush",
+  ],
   additionalProperties: false,
 };
 
@@ -217,6 +241,7 @@ export function repositorySettings(settings: SettingsV1 | RepositorySettingsV1):
     defaultVertical: settings.defaultVertical,
     defaultPreset: settings.defaultPreset,
     defaultProfile: settings.defaultProfile,
+    reviewIndependence: settings.reviewIndependence ?? INITIAL_SETTINGS_V1.reviewIndependence,
     scaffolds: { task: settings.scaffolds.task, repository: settings.scaffolds.repository },
     walFlush: settings.walFlush ?? DEFAULT_WAL_FLUSH_SETTINGS,
   };
@@ -244,6 +269,8 @@ export function readSettingsFacet(body: string): SettingsV1 {
     defaultVertical: setting(body, "defaultVertical") ?? INITIAL_SETTINGS_V1.defaultVertical,
     defaultPreset: setting(body, "defaultPreset") ?? INITIAL_SETTINGS_V1.defaultPreset,
     defaultProfile: setting(body, "defaultProfile") ?? INITIAL_SETTINGS_V1.defaultProfile,
+    reviewIndependence: (setting(body, "reviewIndependence") ??
+      INITIAL_SETTINGS_V1.reviewIndependence) as ReviewIndependence,
     locale: (setting(body, "locale") ?? INITIAL_SETTINGS_V1.locale) as SettingsLocale,
     scaffolds: {
       task: settingBlockValue(body, "scaffolds", "task") ?? INITIAL_SETTINGS_V1.scaffolds.task,
@@ -282,6 +309,13 @@ export function writeRepositorySettingsFacet(body: string, settings: RepositoryS
     "defaultProfile",
     repository.defaultProfile,
     INITIAL_SETTINGS_V1.defaultProfile,
+  );
+  next = replaceOptionalDefaultedScalar(
+    next,
+    "  ",
+    "reviewIndependence",
+    repository.reviewIndependence,
+    INITIAL_SETTINGS_V1.reviewIndependence,
   );
   next = replaceDefaultedBlockScalar(
     next,
@@ -381,6 +415,20 @@ function replaceScalar(body: string, indent: string, key: string, value: string)
 function replaceDefaultedScalar(body: string, indent: string, key: string, value: string, fallback: string): string {
   if (setting(body, key) === undefined && value === fallback) return body;
   return replaceScalar(body, indent, key, value);
+}
+
+function replaceOptionalDefaultedScalar(
+  body: string,
+  indent: string,
+  key: string,
+  value: string,
+  fallback: string,
+): string {
+  if (setting(body, key) !== undefined) return replaceScalar(body, indent, key, value);
+  if (value === fallback) return body;
+  const header = /^settings:[^\r\n]*(?:\r?\n|$)/mu;
+  if (!header.test(body)) throw new Error("Missing settings block in harness.yaml.");
+  return body.replace(header, (match) => `${match}${indent}${key}: ${value}\n`);
 }
 
 function replaceBlockScalar(body: string, block: string, key: string, value: string): string {

--- a/packages/kernel/src/schemas/registry.ts
+++ b/packages/kernel/src/schemas/registry.ts
@@ -78,6 +78,7 @@ export const HarnessConfigSchema = Schema.Struct({
       defaultVertical: Schema.optional(ConfigIdentifierSchema),
       defaultPreset: Schema.optional(ConfigIdentifierSchema),
       defaultProfile: Schema.optional(ConfigIdentifierSchema),
+      reviewIndependence: Schema.optional(Schema.Literal("execution", "principal")),
       tasks: Schema.optional(
         Schema.Struct({
           wipLimit: Schema.optional(TaskWipLimitSchema),

--- a/packages/kernel/test/contracts/settings-action.test.ts
+++ b/packages/kernel/test/contracts/settings-action.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { explainEntityKind, getExecutableEntityAction } from "../../src/domain/entity-kind-registry.ts";
 import { SettingsActionError } from "../../src/domain/settings-action-contract.ts";
+import { assertSettingsEventInputs } from "../../src/domain/settings-event.ts";
 import { readSettingsFacet, repositorySettings } from "../../src/domain/settings.ts";
 
 const documentBody = [
@@ -49,6 +50,23 @@ test("Settings update compiles the existing audit event with actor and parent do
   assert.match(draft.result.bundle.blobs[0].body, /defaultPreset: docs-task/u);
 });
 
+test("Settings update persists principal review independence through the existing event", () => {
+  const draft = compile({ reviewIndependence: "principal" });
+  assert.equal(draft.kind, "settings");
+  if (draft.kind !== "settings" || draft.result.kind !== "event") return;
+  assert.equal(draft.result.bundle.event.payload.settings.reviewIndependence, "principal");
+  assert.match(draft.result.bundle.blobs[0].body, /reviewIndependence: principal/u);
+  assertSettingsEventInputs(draft.result.bundle.event, draft.result.bundle.plan, draft.result.bundle.blobs);
+});
+
+test("Settings update hydrates the default when the projected event predates review independence", () => {
+  const { reviewIndependence: _legacyMissing, ...legacyCurrent } = current;
+  const draft = compile({ reviewIndependence: "principal" }, legacyCurrent);
+  assert.equal(draft.kind, "settings");
+  if (draft.kind !== "settings" || draft.result.kind !== "event") return;
+  assert.equal(draft.result.bundle.event.payload.settings.reviewIndependence, "principal");
+});
+
 test("Settings expectedVersion rejects a stale edge update with a typed error", () => {
   assert.throws(
     () => compile({ walFlushEvents: 512, expectedVersion: 6 }),
@@ -67,7 +85,7 @@ test("Settings locale remains outside the canonical event compiler", () => {
   assert.deepEqual(draft.result, { kind: "no-changes", settings: current, revision: 7 });
 });
 
-function compile(action: Readonly<Record<string, unknown>>) {
+function compile(action: Readonly<Record<string, unknown>>, currentEntity: unknown = current) {
   const compiler = getExecutableEntityAction("settings-update")?.execution?.compile;
   assert.ok(compiler);
   return compiler({
@@ -81,7 +99,7 @@ function compile(action: Readonly<Record<string, unknown>>) {
     opId: "settings-action-contract",
     occurredAt: "2026-09-01T00:00:00.000Z",
     workspaceRevision: 8,
-    currentEntity: current,
+    currentEntity,
     entityRevision: 7,
     currentDocumentBody: documentBody,
   });

--- a/packages/kernel/test/contracts/settings-event.test.ts
+++ b/packages/kernel/test/contracts/settings-event.test.ts
@@ -45,6 +45,11 @@ test("every Settings business field declares repository or local ownership", () 
     );
 });
 
+test("Settings defaults review independence to the execution axis when omitted", () => {
+  assert.equal(readSettingsFacet(original).reviewIndependence, "execution");
+  assert.equal(repositorySettings(readSettingsFacet(original)).reviewIndependence, "execution");
+});
+
 test("Settings facet codec changes owned fields and preserves every unowned byte", () => {
   const settings: SettingsV1 = {
       ...readSettingsFacet(original),

--- a/packages/kernel/test/store/settings-projection.test.ts
+++ b/packages/kernel/test/store/settings-projection.test.ts
@@ -24,7 +24,12 @@ test(rebuildTitle, async () => {
     const original = initRepo(rootDir),
       eventStore = makeTaskEventStore({ repoId: "settings-projection", rootDir }),
       projection = makeTaskProjection({ rootDir, eventStore }),
-      settings = { ...readSettingsFacet(original), defaultPreset: "strict-task", locale: "zh-CN" } as SettingsV1,
+      settings = {
+        ...readSettingsFacet(original),
+        defaultPreset: "strict-task",
+        reviewIndependence: "principal" as const,
+        locale: "zh-CN" as const,
+      },
       candidate = writeRepositorySettingsFacet(original, settings),
       bundle = compileSettingsChangedEvent({
         settings,


### PR DESCRIPTION
# English

## Summary
Makes the self-review independence criterion a repository setting (task_9c8006b7, ruled by 泽宇 2026-09-04/05). `reviewIndependence` accepts `execution` (default, current behaviour after #2250: reviewer must be a different execution) or `principal` (strict: reviewer must be a different person).

- `packages/kernel/src/domain/settings*.ts`, `schemas/registry.ts`: new repository-owned field with default `execution`; ownership is `repository` because review policy must read the same for every daemon and worker on the repo, unlike `locale`.
- `ha settings read` shows it; `ha settings update --review-independence <execution|principal>` persists it through the existing settings event path (no second read path, no new storage).
- `packages/daemon/src/repo-cell-proof.ts`: the review proof consumes the setting. Under `principal`, a same-person reviewer is rejected with a diagnostic that names the setting, its current value, and the command to change it.
- Tests: kernel settings contracts/projection, CLI settings command, and an isolated daemon integration test covering both levels and the strict-mode rejection diagnostic.

## Architectural Justification
This parameterises an existing comparison; it does not add a bypass. The switch changes how strict the independence check is, never whether review happens. Existing settings without the field read as `execution` through the same defaulting path already used for `walFlush`, so no migration and no compatibility layer. The setting is the durable record of a security trade-off that previously lived only in a PR description.

## Verification
- Kernel contract tests (settings-event, settings-action): 11/11; CLI settings command: 2/2.
- Isolated (Ubuntu VM) runs: settings-projection 2/2; `review-independence-diagnostics.integration.test.ts` 5/5.
- typecheck, lint, line-density, canonical-event-compat, file-complexity, test-selection gates: pass locally (see task report artifacts/reports/dispatch_runtime_ee8f81376f3c9668c99e6d09.md).
- Fact F-479B14D6.

## Review Evidence
- Implemented by Sol (gpt-5.6-sol) from the task plan; CEO read the proof and settings diffs against the ruling: default unchanged, ownership rationale stated, strict rejection carries setting/value/remedy.

## Residual Risk
- The strict-mode diagnostic is asserted in an isolated integration test only; a user-visible `ha task review-execution` run under `principal` has not been exercised on the canonical repo yet.

Production-Delta: +126/-21
Deleted-Production-Paths: none

---

# 中文

## 摘要
把自审独立性判据做成 repository 设置项(task_9c8006b7,泽宇 2026-09-04/05 裁定)。`reviewIndependence` 取 `execution`(默认,即 #2250 之后的现行为:复核者须是不同 execution)或 `principal`(严格:复核者须是不同的人)。

- `packages/kernel/src/domain/settings*.ts`、`schemas/registry.ts`:新增 repository 归属字段,默认 `execution`;归 `repository` 是因为复核策略必须对同一仓库的所有 daemon 与 worker 一致,不像 `locale` 是每台机器的选择。
- `ha settings read` 可见;`ha settings update --review-independence <execution|principal>` 经现有 settings 事件路径持久化(不新增第二套读取路径与存储)。
- `packages/daemon/src/repo-cell-proof.ts`:复核证明读取该设置。`principal` 下同一人复核被拒,诊断里点名设置项、当前值与修改命令。
- 测试:kernel settings 契约/投影、CLI settings 命令、隔离 daemon 集成测试覆盖两档与严格模式拒绝诊断。

## 架构辩护
这是把已有比较参数化,不是加逃生口:开关只改独立性判据的严格程度,不改「要不要复核」。旧 settings 缺该字段时沿用 `walFlush` 已有的默认化读取路径读成 `execution`,没有迁移、没有兼容层。这个设置项是原本只存在于 PR 描述里的安全取舍的持久记录。

## 验证
- kernel 契约测试(settings-event、settings-action)11/11;CLI settings 命令 2/2。
- 隔离机(Ubuntu VM):settings-projection 2/2;`review-independence-diagnostics.integration.test.ts` 5/5。
- typecheck、lint、line-density、canonical-event-compat、file-complexity、test-selection 本地全过(见任务报告 artifacts/reports/dispatch_runtime_ee8f81376f3c9668c99e6d09.md)。
- Fact F-479B14D6。

## 复核证据
- Sol(gpt-5.6-sol)按任务 plan 实现;CEO 对照裁决读了 proof 与 settings diff:默认值未变、归属理由成立、严格拒绝带设置/当前值/修法。

## 残余风险
- 严格模式诊断只在隔离集成测试里断言;canonical 仓上尚未用 `principal` 真跑一次 `ha task review-execution`。
