### PR TITLE
test: quarantine the fleet dual-sync mirror-propagation window assertion

### DIFF
--- a/tools/test-quarantine.json
+++ b/tools/test-quarantine.json
@@ -15,6 +15,11 @@
       "test": "attached task runtime settlement releases its execution lease before publishing the terminal outcome",
       "ownerTask": "task_f9443002d6d995489ebf082911",
       "quarantinedAt": "2026-09-05"
+    },
+    {
+      "test": "class A: a task command carries local task documents, and the effect lands in both mirrors",
+      "ownerTask": "task_f9443002d6d995489ebf082911",
+      "quarantinedAt": "2026-09-05"
     }
   ]
 }


### PR DESCRIPTION
# English

## Summary

`main` run 33930751342 (after #2273 merged) went red on both `full-check (24)` and `full-check (26)` with one wall-clock assertion: `fleet-dual-sync.integration.test.ts:291` "the second edge must see the carried document through its mirror" — the second edge's mirror still showed the initial template when the 3 s window expired. The same test passes locally in an isolated environment, #2273 does not touch the fleet mirror path, and the same job ran the Fleet TLS soak for 338 s, so the runner was saturated. Per the standing flake policy this entry is quarantined and attributed to the flaky-test owner task instead of being rerun to green.

## What Changed

- `tools/test-quarantine.json`: one entry, `ownerTask: task_f9443002d6d995489ebf082911`, `quarantinedAt: 2026-09-05` (4 entries total).

## Verification

- Local: `node --test --test-name-pattern='class A: a task command carries local task documents' packages/daemon/test/fleet-dual-sync.integration.test.ts` → 1/1 pass.
- Fact F-EFCE60BC records the CI log evidence.

## Review Evidence

- CEO triage against the CI log and the #2273 diff surface.

## Residual Risk

- The mirror-propagation window (3 s) stays load-sensitive until task_f9443002 reshapes it around an observable condition.

Production-Delta: +0/-0
Deleted-Production-Paths: none

---

# 中文

## 摘要

`main` run 33930751342(#2273 合入后)在 `full-check (24)` 与 `(26)` 同时红,只有一条墙钟断言:`fleet-dual-sync.integration.test.ts:291`「第二个 edge 必须经镜像看到携带的文档」——3 s 窗口到期时第二个 edge 的镜像仍是初始模板。该用例本地隔离环境 1/1 绿,#2273 不触碰 fleet 镜像路径,且同一 job 里 Fleet TLS 压测跑了 338 s,runner 明显饱和。按常设假红政策隔离并归属 flaky 线任务,不 rerun 到绿。

## 改动

- `tools/test-quarantine.json`:新增一条,`ownerTask: task_f9443002d6d995489ebf082911`,`quarantinedAt: 2026-09-05`(共 4 条)。

## 验证

- 本地按用例名复跑 1/1 绿。
- Fact F-EFCE60BC 记录 CI 日志证据。

## 复核证据

- CEO 对照 CI 日志与 #2273 的 diff 面分诊。

## 残余风险

- 镜像传播窗口(3 s)在 task_f9443002 改成可观察条件之前仍对负载敏感。
