### PR TITLE
fix(runtime): restore sub2api compatibility on current CLI

### DIFF
--- a/packages/cli/src/cli/thin-command-runtime-instance-create.ts
+++ b/packages/cli/src/cli/thin-command-runtime-instance-create.ts
@@ -16,6 +16,7 @@ export function parseRuntimeInstanceCreate(
   const authMode = flags.one.get("--auth"),
     credentialRef = flags.one.get("--credential-ref"),
     kindId = flags.one.get("--kind"),
+    credentialHeader = flags.one.get("--credential-header"),
     header = runtimeHttpHeaderFlags(flags.many.get("--http-header") ?? []);
   if (!kindId) return rejected("missing_field", "Runtime instances require --kind <runtime-kind>.", json);
   if (authMode === "api-key" && !credentialRef)
@@ -32,7 +33,14 @@ export function parseRuntimeInstanceCreate(
   if (declaration && hasForeignAdapterOptions(declaration.fields, flags, header.value))
     return rejected("invalid_field", "This runtime kind does not accept options for another adapter.", json);
   const baseUrl = flags.one.get("--base-url"),
-    kindConfig = runtimeInstanceKindConfig(kindId, flags.one, flags.booleans, baseUrl, header.value);
+    kindConfig = runtimeInstanceKindConfig(
+      kindId,
+      flags.one,
+      flags.booleans,
+      baseUrl,
+      header.value,
+      credentialHeader,
+    );
   return accepted(
     rootDir,
     undefined,
@@ -63,9 +71,11 @@ function hasForeignAdapterOptions(
 ): boolean {
   return (
     (flags.one.has("--base-url") && !fields.includes("baseUrl")) ||
+    (flags.booleans.has("--allow-insecure-http") && !fields.includes("allowInsecureHttp")) ||
     (flags.one.has("--wire-api") && !fields.includes("wireApi")) ||
     (flags.booleans.has("--requires-openai-auth") && !fields.includes("requiresOpenAiAuth")) ||
-    (headers !== undefined && !fields.includes("httpHeaders"))
+    (headers !== undefined && !fields.includes("httpHeaders")) ||
+    (flags.one.has("--credential-header") && !fields.includes("credentialHeader"))
   );
 }
 
@@ -75,6 +85,7 @@ function runtimeInstanceKindConfig(
   booleans: Set<string>,
   baseUrl: string | undefined,
   headers: Readonly<Record<string, string>> | undefined,
+  credentialHeader: string | undefined,
 ) {
   if (!kindId) return {};
   const declaration =
@@ -84,9 +95,11 @@ function runtimeInstanceKindConfig(
       ...(one.get("--effort") ? { [effortField]: one.get("--effort") } : {}),
       ...(booleans.has("--fast") ? { fast: true } : {}),
       ...(baseUrl ? { baseUrl } : {}),
+      ...(booleans.has("--allow-insecure-http") ? { allowInsecureHttp: true } : {}),
       ...(one.get("--wire-api") ? { wireApi: one.get("--wire-api") } : {}),
       ...(booleans.has("--requires-openai-auth") ? { requiresOpenAiAuth: true } : {}),
       ...(headers ? { httpHeaders: headers } : {}),
+      ...(credentialHeader ? { credentialHeader } : {}),
     };
   return { [kindId]: configuration };
 }
@@ -97,7 +110,7 @@ function runtimeHttpHeaderFlags(
   | { readonly ok: true; readonly value?: Readonly<Record<string, string>> }
   | { readonly ok: false; readonly hint: string } {
   if (values.length === 0) return { ok: true };
-  const headers: Record<string, string> = {};
+  const headers: Record<string, string> = {}, normalizedNames = new Set<string>();
   for (const value of values) {
     const separator = value.indexOf("=");
     if (separator < 1 || separator === value.length - 1)
@@ -106,12 +119,14 @@ function runtimeHttpHeaderFlags(
         hint: "Use --http-header Name=Value with a non-secret static header.",
       };
     const name = value.slice(0, separator),
-      item = value.slice(separator + 1);
-    if (Object.hasOwn(headers, name))
+      item = value.slice(separator + 1),
+      normalizedName = name.toLowerCase();
+    if (normalizedNames.has(normalizedName))
       return {
         ok: false,
         hint: `HTTP header ${name} was provided more than once.`,
       };
+    normalizedNames.add(normalizedName);
     headers[name] = item;
   }
   return { ok: true, value: headers };

--- a/packages/cli/test/thin-command.test.ts
+++ b/packages/cli/test/thin-command.test.ts
@@ -535,6 +535,57 @@ test("thin parser derives closed preset and task-create payloads from descriptor
     });
 });
 
+test("runtime instance parser rejects repeated static headers regardless of spelling", () => {
+  const base = [
+    "runtime",
+    "instance",
+    "create",
+    "--id",
+    "codex-headers",
+    "--name",
+    "Codex Headers",
+    "--kind",
+    "codex",
+    "--provider",
+    "sidecar",
+    "--model",
+    "gpt-5.6-sol",
+    "--auth",
+    "api-key",
+    "--credential-ref",
+    "credential:v1:codex-headers",
+  ];
+  const accepted = parseThinCommand([...base, "--http-header", "X-Custom=static"]);
+  assert.equal(accepted.ok, true, JSON.stringify(accepted));
+  if (accepted.ok) assert.deepEqual(accepted.command.action.codex, { httpHeaders: { "X-Custom": "static" } });
+  const compatibility = parseThinCommand([
+    ...base,
+    "--base-url",
+    "http://192.168.1.20:8080/v1",
+    "--allow-insecure-http",
+    "--credential-header",
+    "x-api-key",
+  ]);
+  assert.equal(compatibility.ok, true, JSON.stringify(compatibility));
+  if (compatibility.ok)
+    assert.deepEqual(compatibility.command.action.codex, {
+      baseUrl: "http://192.168.1.20:8080/v1",
+      allowInsecureHttp: true,
+      credentialHeader: "x-api-key",
+    });
+  for (const duplicate of [
+    ["X-Custom=first", "X-Custom=second"],
+    ["X-Custom=first", "x-custom=second"],
+  ]) {
+    const rejected = parseThinCommand([...base, ...duplicate.flatMap((value) => ["--http-header", value])]);
+    assert.equal(rejected.ok, false, JSON.stringify(rejected));
+    if (!rejected.ok) {
+      assert.equal(rejected.code, "invalid_field");
+      assert.match(rejected.nextAction, /HTTP header .* was provided more than once\./u);
+    }
+  }
+});
+
 test("thin parser routes CI observation pulls through the repo task command", () => {
   const parsed = parseThinCommand(["ci", "observe", "pull", "--limit", "20"]);
   assert.equal(parsed.ok, true, JSON.stringify(parsed));

--- a/packages/daemon/src/agent-runtime-instance-config.ts
+++ b/packages/daemon/src/agent-runtime-instance-config.ts
@@ -150,16 +150,36 @@ export function runtimeInstanceConfig(value: unknown): RuntimeInstanceConfig {
     flatConfiguration = {
       ...(value.reasoningEffort === undefined ? {} : { [effortField]: value.reasoningEffort }),
       ...(value.baseUrl === undefined ? {} : { baseUrl: value.baseUrl }),
+      ...(value.allowInsecureHttp === undefined ? {} : { allowInsecureHttp: value.allowInsecureHttp }),
     },
     configuration = runtimeKindConfig(
       flat ? flatConfiguration : normalizeRuntimeInputAliases(value[value.kindId], declaration.configuration.fields),
       declaration.configuration.fields,
     );
+  const credentialHeader = configuration.credentialHeader;
+  if (credentialHeader !== undefined && auth.mode !== "api-key")
+    throw runtimeInstanceError(
+      "invalid_runtime_credential_header",
+      "credentialHeader is available only for API-key runtime instances.",
+    );
+  if (
+    typeof credentialHeader === "string" &&
+    configuration.httpHeaders !== undefined &&
+    Object.keys(configuration.httpHeaders as Readonly<Record<string, string>>).some(
+      (header) => header.toLowerCase() === credentialHeader.toLowerCase(),
+    )
+  )
+    throw runtimeInstanceError(
+      "invalid_runtime_credential_header",
+      "credentialHeader must not overlap a static HTTP header.",
+    );
   if (
     common.providerId === "openai" &&
-    (configuration.wireApi !== undefined ||
+    (configuration.allowInsecureHttp !== undefined ||
+      configuration.wireApi !== undefined ||
       configuration.requiresOpenAiAuth !== undefined ||
-      configuration.httpHeaders !== undefined)
+      configuration.httpHeaders !== undefined ||
+      configuration.credentialHeader !== undefined)
   )
     throw runtimeInstanceError(
       "invalid_runtime_kind_config",
@@ -182,7 +202,7 @@ function normalizeRuntimeInputAliases(
 
 function runtimeKindConfig(
   value: unknown,
-  fields: Readonly<Record<string, "identifier" | "url" | "effort" | "boolean" | "headers" | "agy-effort">>,
+  fields: RuntimeProviderDeclaration["configuration"]["fields"],
 ): Readonly<Record<string, unknown>> {
   if (value === undefined) return {};
   if (!isRuntimeInstanceRecord(value) || Object.keys(value).some((key) => !Object.hasOwn(fields, key)))
@@ -197,8 +217,10 @@ function runtimeKindConfig(
         const shape = fields[key]!;
         if (shape === "boolean") return [key, requireBoolean(item, key)];
         if (shape === "headers") return [key, runtimeHttpHeaders(item)];
+        if (shape === "header-name") return [key, runtimeCredentialHeader(item)];
         if (shape === "agy-effort") return [key, agyEffort(item)];
-        if (shape === "url") return [key, secureRuntimeBaseUrl(item)];
+        if (shape === "url")
+          return [key, secureRuntimeBaseUrl(item, { allowInsecureHttp: value.allowInsecureHttp === true })];
         if (shape === "identifier") return [key, identifier(item, key)];
         return [key, runtimeEffort(item)];
       }),
@@ -261,22 +283,36 @@ export function runtimeHttpHeaders(value: unknown): Readonly<Record<string, stri
       "invalid_runtime_http_headers",
       "httpHeaders must be a non-empty object of non-secret HTTP headers.",
     );
-  const result: Record<string, string> = {};
+  const result: Record<string, string> = {},
+    normalizedNames = new Set<string>();
   for (const [name, item] of Object.entries(value)) {
+    const normalizedName = name.toLowerCase();
     if (
       !/^[!#$%&'*+.^_`|~0-9A-Za-z-]+$/u.test(name) ||
       /(?:authorization|api[-_]?key|cookie|credential|password|secret|token)/iu.test(name) ||
       typeof item !== "string" ||
       !item ||
-      /[\r\n]/u.test(item)
+      /[\r\n]/u.test(item) ||
+      normalizedNames.has(normalizedName)
     )
       throw runtimeInstanceError(
         "invalid_runtime_http_headers",
         "httpHeaders must contain valid non-secret header names and single-line values.",
       );
+    normalizedNames.add(normalizedName);
     result[name] = item;
   }
   return result;
+}
+
+export function runtimeCredentialHeader(value: unknown): string {
+  const name = typeof value === "string" ? value.trim() : "";
+  if (!/^[!#$%&'*+.^_`|~0-9A-Za-z-]+$/u.test(name))
+    throw runtimeInstanceError(
+      "invalid_runtime_credential_header",
+      "credentialHeader must be a valid HTTP header name.",
+    );
+  return name;
 }
 
 export function needsRuntimeInstanceNormalization(value: unknown): boolean {

--- a/packages/daemon/src/agent-runtime-instance-storage.ts
+++ b/packages/daemon/src/agent-runtime-instance-storage.ts
@@ -244,6 +244,10 @@ export function runtimeBaseUrl(config: RuntimeInstanceConfig): string | undefine
 
 export function writeCodexConfig(target: string, config: RuntimeInstanceConfig, bearerToken?: string): void {
   const provider = runtimeProviderConfig(config),
+    headers =
+      bearerToken && provider.credentialHeader
+        ? { ...(provider.httpHeaders ?? {}), [provider.credentialHeader]: bearerToken }
+        : provider.httpHeaders,
     lines = [
       `model_provider = ${tomlString(config.providerId)}`,
       ...(provider.reasoningEffort ? [`model_reasoning_effort = ${tomlString(provider.reasoningEffort)}`] : []),
@@ -255,12 +259,16 @@ export function writeCodexConfig(target: string, config: RuntimeInstanceConfig, 
       `name = ${tomlString(config.providerId)}`,
       ...(provider.baseUrl ? [`base_url = ${tomlString(provider.baseUrl)}`] : []),
       ...(provider.wireApi ? [`wire_api = ${tomlString(provider.wireApi)}`] : []),
-      ...(provider.requiresOpenAiAuth === undefined ? [] : [`requires_openai_auth = ${provider.requiresOpenAiAuth}`]),
-      ...(provider.httpHeaders
+      ...(provider.requiresOpenAiAuth === undefined && config.providerId !== "openai"
+        ? ["requires_openai_auth = false"]
+        : provider.requiresOpenAiAuth === undefined
+          ? []
+          : [`requires_openai_auth = ${provider.requiresOpenAiAuth}`]),
+      ...(headers
         ? [
             [
               "http_headers = { ",
-              `${Object.entries(provider.httpHeaders)
+              `${Object.entries(headers)
                 .sort(([a], [b]) => a.localeCompare(b))
                 .map(([key, value]) => `${tomlString(key)} = ${tomlString(value)}`)
                 .join(", ")}`,
@@ -268,7 +276,9 @@ export function writeCodexConfig(target: string, config: RuntimeInstanceConfig, 
             ].join(""),
           ]
         : []),
-      ...(bearerToken ? [`experimental_bearer_token = ${tomlString(bearerToken)}`] : []),
+      ...(bearerToken && !provider.credentialHeader
+        ? [`experimental_bearer_token = ${tomlString(bearerToken)}`]
+        : []),
     );
   const temp = `${target}.${process.pid}.tmp`;
   // The leftover of a failed write here is a 0600 config carrying the broker bearer token,

--- a/packages/daemon/src/agent-runtime-instance-store.ts
+++ b/packages/daemon/src/agent-runtime-instance-store.ts
@@ -292,8 +292,10 @@ export function openRuntimeInstanceStore(input: {
       throw runtimeInstanceError("runtime_credential_unavailable", credentialUnavailableHint);
     }
     if (config.kindId === "codex") {
-      const configPath = path.join(env.CODEX_HOME!, "config.toml");
-      if (!codexConfigHasBearer(configPath)) writeCodexConfig(configPath, config, secret);
+      const configPath = path.join(env.CODEX_HOME!, "config.toml"),
+        provider = runtimeProviderConfig(config);
+      if (!codexConfigHasBearer(configPath) || provider.credentialHeader !== undefined)
+        writeCodexConfig(configPath, config, secret);
     } else env.ANTHROPIC_API_KEY = secret;
     rememberAuthReadiness(config.instanceId, available());
     return {

--- a/packages/daemon/src/agent-runtime-instance-types.ts
+++ b/packages/daemon/src/agent-runtime-instance-types.ts
@@ -34,9 +34,12 @@ export interface CodexRuntimeInstanceConfig {
   readonly reasoningEffort?: string;
   readonly fast?: boolean;
   readonly baseUrl?: string;
+  readonly allowInsecureHttp?: boolean;
   readonly wireApi?: string;
   readonly requiresOpenAiAuth?: boolean;
   readonly httpHeaders?: Readonly<Record<string, string>>;
+  /** Header name receiving the resolved API-key credential at launch time. */
+  readonly credentialHeader?: string;
 }
 
 export interface AgyRuntimeInstanceConfig {
@@ -54,9 +57,11 @@ export interface RuntimeProviderInstanceConfig {
   readonly reasoningEffort?: string;
   readonly fast?: boolean;
   readonly baseUrl?: string;
+  readonly allowInsecureHttp?: boolean;
   readonly wireApi?: string;
   readonly requiresOpenAiAuth?: boolean;
   readonly httpHeaders?: Readonly<Record<string, string>>;
+  readonly credentialHeader?: string;
 }
 
 export function runtimeProviderConfig(config: RuntimeInstanceConfig): RuntimeProviderInstanceConfig {

--- a/packages/daemon/src/agent-runtime-launch-config.ts
+++ b/packages/daemon/src/agent-runtime-launch-config.ts
@@ -128,7 +128,10 @@ export function credentialHint(error: unknown): string {
     : credentialUnavailableHint;
 }
 
-export function secureRuntimeBaseUrl(value: unknown): string {
+export function secureRuntimeBaseUrl(
+  value: unknown,
+  options: { readonly allowInsecureHttp?: boolean } = {},
+): string {
   const text = requiredRuntimeInstanceText(value, "baseUrl");
   let parsed: URL;
   try {
@@ -142,11 +145,30 @@ export function secureRuntimeBaseUrl(value: unknown): string {
     parsed.search ||
     parsed.hash ||
     (parsed.protocol !== "https:" &&
-      !(parsed.protocol === "http:" && ["127.0.0.1", "::1", "localhost"].includes(parsed.hostname)))
+      !(parsed.protocol === "http:" && ["127.0.0.1", "::1", "localhost"].includes(parsed.hostname)) &&
+      !(
+        parsed.protocol === "http:" &&
+        options.allowInsecureHttp === true &&
+        isPrivateIpv4(parsed.hostname)
+      ))
   )
     throw runtimeInstanceError(
       "invalid_base_url",
-      "baseUrl must use HTTPS or loopback HTTP and cannot contain credentials, query, or fragment.",
+      [
+        "baseUrl must use HTTPS or loopback HTTP; private HTTP requires explicit ",
+        "allowInsecureHttp, and credentials, query, and fragments are forbidden.",
+      ].join(""),
     );
   return parsed.toString();
+}
+
+function isPrivateIpv4(hostname: string): boolean {
+  const octets = hostname.split(".").map(Number);
+  if (
+    octets.length !== 4 ||
+    octets.some((octet) => !Number.isInteger(octet) || octet < 0 || octet > 255)
+  )
+    return false;
+  const [first, second] = octets;
+  return first === 10 || (first === 192 && second === 168) || (first === 172 && second >= 16 && second <= 31);
 }

--- a/packages/daemon/src/protocol/daemon-protocol-commands-runtime-config.ts
+++ b/packages/daemon/src/protocol/daemon-protocol-commands-runtime-config.ts
@@ -256,6 +256,9 @@ export const runtimeConfigProtocolCommands = Object.freeze([
       cliInput("--base-url", "single", false, {
         code: "invalid_field",
       }),
+      cliInput("--allow-insecure-http", "boolean", false, {
+        code: "invalid_field",
+      }),
       cliInput("--wire-api", "single", false, {
         code: "invalid_field",
       }),
@@ -263,6 +266,9 @@ export const runtimeConfigProtocolCommands = Object.freeze([
         code: "invalid_field",
       }),
       cliInput("--http-header", "repeated", false, {
+        code: "invalid_field",
+      }),
+      cliInput("--credential-header", "single", false, {
         code: "invalid_field",
       }),
       cliInput(

--- a/packages/daemon/src/protocol/daemon-protocol.contract.ts
+++ b/packages/daemon/src/protocol/daemon-protocol.contract.ts
@@ -48,7 +48,16 @@ export const builtInRuntimeProviderInputDeclaration = Object.freeze({
   }),
   codex: Object.freeze({
     authModes: ["subscription", "api-key"] as const,
-    fields: ["reasoningEffort", "fast", "baseUrl", "wireApi", "requiresOpenAiAuth", "httpHeaders"] as const,
+    fields: [
+      "reasoningEffort",
+      "fast",
+      "baseUrl",
+      "allowInsecureHttp",
+      "wireApi",
+      "requiresOpenAiAuth",
+      "httpHeaders",
+      "credentialHeader",
+    ] as const,
     effortField: "reasoningEffort",
     fast: true,
   }),

--- a/packages/daemon/src/runtime-inventory.ts
+++ b/packages/daemon/src/runtime-inventory.ts
@@ -18,7 +18,9 @@ export interface RuntimeProviderDeclaration {
   };
   readonly declaredCapabilities: RuntimeInstallation["effectiveCapabilities"];
   readonly configuration: {
-    readonly fields: Readonly<Record<string, "identifier" | "url" | "effort" | "boolean" | "headers" | "agy-effort">>;
+    readonly fields: Readonly<
+      Record<string, "identifier" | "url" | "effort" | "boolean" | "headers" | "header-name" | "agy-effort">
+    >;
     readonly publicFields: Readonly<Record<string, string>>;
     readonly publicDefaults: Readonly<Record<string, unknown>>;
   };
@@ -159,18 +161,22 @@ export const runtimeKinds = [
         reasoningEffort: "effort",
         fast: "boolean",
         baseUrl: "url",
+        allowInsecureHttp: "boolean",
         wireApi: "identifier",
         requiresOpenAiAuth: "boolean",
         httpHeaders: "headers",
+        credentialHeader: "header-name",
       },
       publicFields: {
         reasoningEffort: "reasoningEffort",
         fast: "fast",
         baseUrl: "baseUrl",
         baseUrlConfigured: "baseUrlConfigured",
+        allowInsecureHttp: "allow_insecure_http",
         wireApi: "wire_api",
         requiresOpenAiAuth: "requires_openai_auth",
         httpHeaders: "http_headers",
+        credentialHeader: "credential_header",
       },
       publicDefaults: {
         reasoningEffort: null,

--- a/packages/daemon/test/agent-runtime-sub2api.test.ts
+++ b/packages/daemon/test/agent-runtime-sub2api.test.ts
@@ -1,0 +1,107 @@
+// harness-test-tier: contract
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { runtimeHttpHeaders } from "../src/agent-runtime-instance-config.ts";
+import { openRuntimeInstanceStore, type RuntimeInstallationWitness } from "../src/agent-runtime-instances.ts";
+
+const observed: RuntimeInstallationWitness = {
+  installationId: "codex-installation-test",
+  kindId: "codex",
+  executablePath: "/opt/runtime-test/codex",
+  version: "0.146.1",
+  observedAt: "2026-08-15T00:00:00.000Z",
+};
+
+test("Codex private HTTP API-key launch writes the credential only to its contracted header", async () => {
+  const userRoot = mkdtempSync(path.join(tmpdir(), "ha-runtime-secret-header-"));
+  try {
+    const store = openRuntimeInstanceStore({
+      userRoot,
+      discover: () => [observed],
+      resolveCredential: () => "instance-secret",
+    });
+    store.create({
+      schemaVersion: 2,
+      instanceId: "codex-sub2api",
+      name: "Codex sub2api",
+      kindId: "codex",
+      installationId: observed.installationId,
+      providerId: "sub2api",
+      models: ["gpt-5.6-sol"],
+      defaultModel: "gpt-5.6-sol",
+      enabled: true,
+      permissionMode: "read-only",
+      isolationState: "enforced",
+      codex: {
+        baseUrl: "http://192.168.1.20:8080/v1",
+        allowInsecureHttp: true,
+        wireApi: "responses",
+        credentialHeader: "x-api-key",
+      },
+      auth: { mode: "api-key", credentialRef: "credential:v1:codex-sub2api" },
+    });
+    const launch = await store.prepareLaunch("codex-sub2api", { cwd: "/workspace/repo", prompt: "Inspect" });
+    const configText = readFileSync(path.join(launch.env.CODEX_HOME!, "config.toml"), "utf8");
+    assert.match(configText, /http_headers = \{ "x-api-key" = "instance-secret" \}/u);
+    assert.match(configText, /requires_openai_auth = false/u);
+    assert.doesNotMatch(configText, /experimental_bearer_token/u);
+    assert.doesNotMatch(JSON.stringify(launch), /instance-secret/u);
+  } finally {
+    rmSync(userRoot, { recursive: true, force: true });
+  }
+});
+
+test("Codex private HTTP and credential-header configuration preserves its trust boundaries", () => {
+  const userRoot = mkdtempSync(path.join(tmpdir(), "ha-runtime-private-http-"));
+  try {
+    const store = openRuntimeInstanceStore({ userRoot, discover: () => [observed] });
+    const common = {
+      schemaVersion: 2 as const,
+      name: "Codex private",
+      kindId: "codex",
+      installationId: observed.installationId,
+      providerId: "sub2api",
+      models: ["gpt-5.6-sol"],
+      defaultModel: "gpt-5.6-sol",
+      enabled: true,
+      isolationState: "enforced" as const,
+      auth: { mode: "api-key" as const, credentialRef: "credential:v1:codex-private" },
+    };
+    assert.throws(
+      () => store.create({ ...common, instanceId: "without-flag", codex: { baseUrl: "http://10.0.0.2/v1" } }),
+      (error: unknown) => codedAs(error, "invalid_base_url"),
+    );
+    assert.throws(
+      () =>
+        store.create({
+          ...common,
+          instanceId: "public-http",
+          codex: { baseUrl: "http://8.8.8.8/v1", allowInsecureHttp: true },
+        }),
+      (error: unknown) => codedAs(error, "invalid_base_url"),
+    );
+    assert.throws(
+      () =>
+        store.create({
+          ...common,
+          instanceId: "header-collision",
+          codex: { httpHeaders: { "X-Custom": "static" }, credentialHeader: "x-custom" },
+        }),
+      (error: unknown) => codedAs(error, "invalid_runtime_credential_header"),
+    );
+    assert.deepEqual(runtimeHttpHeaders({ "X-Custom": "static" }), { "X-Custom": "static" });
+    assert.throws(
+      () => runtimeHttpHeaders({ "X-Custom": "first", "x-custom": "second" }),
+      (error: unknown) => codedAs(error, "invalid_runtime_http_headers"),
+    );
+  } finally {
+    rmSync(userRoot, { recursive: true, force: true });
+  }
+});
+
+function codedAs(error: unknown, code: string): boolean {
+  return error instanceof Error && "code" in error && error.code === code;
+}


### PR DESCRIPTION
# English

> Supersedes #2238 (fork PR by @cyrneutron): rebased onto main `c2e9a4610` after the provider-declaration refactor (#2262) — the sub2api fields now live in the `runtime-inventory.ts` declaration and `agent-runtime-instance-config.ts` validation, tests moved to `agent-runtime-sub2api.test.ts`; semantics unchanged (`--credential-header`, `--allow-insecure-http` limited to explicit flag + loopback/RFC1918 IPv4, credential value only in the 0600 isolated config).

## Summary

Carry the runtime compatibility fix onto the latest upstream main so API-key credentials can use a provider-specific header for private HTTP sub2api endpoints. Credential references remain opaque and runtime validation stays fail-closed.

## Architectural Justification

The current runtime contract could not represent custom credential headers or explicitly permitted private HTTP. This change extends the existing Codex runtime configuration and storage paths only; it introduces no provider checkout changes and no arbitrary shell path.

## What Changed
- CLI accepts `--credential-header` and `--allow-insecure-http`.
- Runtime validates custom credential headers, private IPv4 HTTP, and case-insensitive static header collisions.
- Isolated config writes the resolved key to the configured header and avoids bearer fallback.
- CLI and daemon coverage was added for the compatibility behavior.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
Production-Delta: +133/-22
Dependency-Change: none

## Task And Scope
- Harness task: provider compatibility migration for MI HA runtime
- Branch: `codex/mi-runtime-compat-stable-20260904`
- Public scope: Codex runtime CLI and daemon compatibility for custom API-key providers
- Private planning/evidence updated: yes
- Out of scope: upstream provider behavior, HA target source, automatic merge

## Version Impact

No version change; publish impact none.

## Governance Declaration
- Protected surface touched: no
- Protected surface scope: none
- Authority: not applicable
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification
- Base `origin/main` SHA: `9140cd98a52725ec1d1dfafe5b1464c2063fc4ee`
- Branch merge-base with `origin/main`: `9140cd98a52725ec1d1dfafe5b1464c2063fc4ee`
- Sync method: rebase
- Public diff command: `git diff origin/main...HEAD`
- Private evidence commit/path: `302b0ecb37091fa1d8a97b571b5f542425824263`
- Reviewer evidence path: local build, 71 targeted tests, daemon status, runtime probe, and exact sub2api response
- GitHub Actions `rewrite-ci` run URL: https://github.com/FairladyZ625/harness-anything/actions/runs/33887490904
- [x] CLI build
- [x] Targeted runtime and CLI tests
- [x] `git diff --check`
- [ ] `npm run check`
- [x] Full GitHub Actions CI
- Not run: full check is delegated to GitHub Actions for this PR

## Review Evidence

Self-review: the diff is limited to the existing runtime configuration, storage, launch validation, protocol input, and focused tests. The daemon was restarted from the resulting stable build and returned the expected sub2api response.

## Residual Risk

The provider remains an external sub2api endpoint; this change only makes its authentication and private HTTP transport explicit and bounded.

## References
- Task: provider compatibility migration for MI HA runtime
- Evidence: commit `302b0ecb37091fa1d8a97b571b5f542425824263` and local daemon receipts
- Review: latest CI rerun `33887490904` is green; prior run `33886058151` exposed one unrelated load-sensitive daemon performance flake, with no changed test or production path implicated.

---

# 中文

> 取代 #2238(@cyrneutron 的 fork PR):在 provider 声明化(#2262)之后 rebase 到 main `c2e9a4610`——sub2api 字段落到 `runtime-inventory.ts` 声明与 `agent-runtime-instance-config.ts` 校验,测试迁到 `agent-runtime-sub2api.test.ts`;语义不变(`--credential-header`,`--allow-insecure-http` 仅显式 flag + 回环/RFC1918 IPv4,凭证值只进 0600 隔离配置)。

## 概要

将 runtime 兼容修复整理到最新 upstream main，使 API key 能通过 provider 专用 header 发送到内网 HTTP sub2api。凭据引用继续保持 opaque，运行时校验继续 fail-closed。

## 架构辩护

旧 runtime 契约无法表达自定义凭据 header 与显式允许的私有 HTTP。本改动只扩展既有 Codex runtime 配置、存储和启动校验路径，不修改 provider checkout，也不引入任意 shell 路径。

## 改动内容

CLI 新增 `--credential-header` 与 `--allow-insecure-http`；runtime 校验自定义凭据 header、私有 IPv4 HTTP 和大小写不敏感的静态 header 冲突；隔离配置把解析后的 key 写入指定 header，避免 bearer 回退；同时补充 CLI 与 daemon 定向测试。

## 任务与范围

任务是 MI HA runtime provider 兼容迁移；分支为 `codex/mi-runtime-compat-stable-20260904`；公开范围仅限 Codex runtime CLI 与 daemon 兼容；不涉及 upstream provider 行为、HA target 源码或自动合并。

## 版本影响

不改版本，不发布。

## 治理声明
- 触碰 protected surface：否
- protected surface 范围：无
- 依据：不适用
- Break-glass：否

## 验证

稳定目录已快进到 `origin/main` 最新提交并重放兼容修复；CLI 构建通过，定向测试 71/71 通过，daemon status 正常，runtime readiness 为 ready，实际请求返回 `HA_STABLE_PROVIDER_OK`。最新 GitHub CI run `33887490904` 已全部通过；此前 `33886058151` 的单个失败确认是与本改动无关的负载敏感 daemon 性能波动。

## 审阅证据

自查确认改动集中在既有 runtime 配置、存储、启动校验、协议输入和测试；daemon 已从稳定构建重启并完成 sub2api 验证。等待 CI 与 upstream reviewer。

## 残余风险

provider 仍是外部 sub2api endpoint；本改动只把认证 header 与私有 HTTP 传输显式化并限制在受控配置内。
