### PR TITLE
test(gui): cover the zcode provider plane in the runtime kind adjudication

### DIFF
--- a/packages/gui/test/runtime-provider-planes.vitest.ts
+++ b/packages/gui/test/runtime-provider-planes.vitest.ts
@@ -131,8 +131,16 @@ describe("provider planes (2026-08-20 adjudication)", () => {
     expect(planeAllowsEffort("codex")).toBe(true);
     expect(planeAllowsPermissions("codex")).toBe(true);
   });
+  it("gives zcode a login-only plane whose model is pinned by its own config, not by an API override", () => {
+    expect(planeAuthModes("zcode")).toEqual(["subscription"]);
+    expect(planeUsesApiOverride("zcode")).toBe(false);
+    expect(planeAllowsBaseUrl("zcode", "subscription")).toBe(false);
+    expect(planeAllowsApiKey("zcode", "api-key")).toBe(false);
+    expect(planeAllowsEffort("zcode")).toBe(false);
+    expect(planeAllowsPermissions("zcode")).toBe(true);
+  });
   it("covers every runtime kind the contract accepts", () => {
-    expect([...RUNTIME_KIND_IDS].sort()).toEqual(["agy", "claude", "codex"]);
+    expect([...RUNTIME_KIND_IDS].sort()).toEqual(["agy", "claude", "codex", "zcode"]);
   });
   it("clears every field the new plane cannot express when the provider changes", () => {
     const configured = applyRuntimeAuthMode(


### PR DESCRIPTION
# English

## Summary
#2273 added `zcode` as the fourth runtime kind but left the GUI provider-plane adjudication test asserting the old three-kind list, so `runtime-provider-planes.vitest.ts` fails on main (and on every PR's merge commit, first seen on #2274's gui-build). This adds the zcode plane expectation derived from its declaration — login-only auth, no API override, no base URL or API key, no effort, permissions available — and extends the kind list.

## Verification
- `npx vitest run test/runtime-provider-planes.vitest.ts` in `packages/gui`: 18/18 (was 1 failed / 16 passed on main c2e9a4610).

## Review Evidence
- CEO change; expectations read directly from the `zcode` declaration in `runtime-inventory.ts`.

## Residual Risk
- None beyond the test itself; no production code changes.

Production-Delta: +0/-0
Deleted-Production-Paths: none

---

# 中文

## 摘要
#2273 加入第四个 runtime kind `zcode`,但 GUI 的 provider 平面裁定测试仍断言旧的三种 kind,导致 `runtime-provider-planes.vitest.ts` 在 main 上失败(每个 PR 的 merge commit 也会红,首次出现在 #2274 的 gui-build)。本 PR 按 zcode 声明补上其平面期望——仅登录认证、无 API 覆盖、无 base URL / API key、无 effort、有权限模式——并把 kind 清单扩为四个。

## 验证
- `packages/gui` 下 `npx vitest run test/runtime-provider-planes.vitest.ts`:18/18(main c2e9a4610 上为 1 失败 / 16 通过)。

## 复核证据
- CEO 改动;期望值直接取自 `runtime-inventory.ts` 的 zcode 声明。

## 残余风险
- 仅测试改动,无生产代码变化。
