### PR TITLE
fix(runtime): preserve provider 429 fault details

### DIFF
--- a/packages/cli/src/cli-runtime-wait.ts
+++ b/packages/cli/src/cli-runtime-wait.ts
@@ -79,8 +79,15 @@ export async function waitForRuntime(
     statusReader?.close();
     detach?.();
   }
-  const result = current as unknown as AgentRuntimeSessionResult,
-    text = result.result?.text ?? "",
+  return runtimeResultReceipt(current as unknown as AgentRuntimeSessionResult, runtimeSessionId, spawned);
+}
+
+function runtimeResultReceipt(
+  result: AgentRuntimeSessionResult,
+  runtimeSessionId: string,
+  spawned: JsonObject | undefined,
+): JsonObject {
+  const text = result.result?.text ?? "",
     outcome = result.session.activity.outcome ?? "unknown",
     settlementFailed =
       result.session.activity.outcome === null ||
@@ -110,7 +117,7 @@ export async function waitForRuntime(
                 ? `Provider exited with code ${String(result.session.activity.exitCode)} without a diagnostic.`
                 : `${commandName}: ${outcome}`);
   return {
-    ...current,
+    ...result,
     command: commandName,
     outcome,
     runtimeSessionId,

--- a/packages/cli/src/cli-runtime-wait.ts
+++ b/packages/cli/src/cli-runtime-wait.ts
@@ -87,16 +87,28 @@ export async function waitForRuntime(
       (outcome === "unknown" && result.session.activity.reasonCode !== undefined),
     commandName = spawned ? "runtime-run" : "runtime-status",
     providerExit = Number.isInteger(result.session.activity.exitCode),
-    failureCode = settlementFailed ? "runtime_settlement_failed" : providerExit ? "provider_exit" : "runtime_failed",
+    attempt = result.session.attemptChain?.attempts.find(
+      (candidate) => candidate.runtimeSessionId === runtimeSessionId,
+    ),
+    providerFaultClass = attempt?.classification === "provider_fault" ? attempt.faultClass : undefined,
+    failureCode = settlementFailed
+      ? "runtime_settlement_failed"
+      : providerFaultClass
+        ? providerFaultClass
+        : providerExit
+          ? "provider_exit"
+          : "runtime_failed",
     reason =
       outcome === "succeeded"
         ? null
-        : text ||
-          (settlementFailed
-            ? "runtime_settlement_failed: daemon reported the runtime exited but no terminal outcome became visible."
-            : providerExit
-              ? `Provider exited with code ${String(result.session.activity.exitCode)} without a diagnostic.`
-              : `${commandName}: ${outcome}`);
+        : providerFaultClass
+          ? providerFaultReason(providerFaultClass, attempt?.resetAt, attempt?.reason ?? text)
+          : text ||
+            (settlementFailed
+              ? "runtime_settlement_failed: daemon reported the runtime exited but no terminal outcome became visible."
+              : providerExit
+                ? `Provider exited with code ${String(result.session.activity.exitCode)} without a diagnostic.`
+                : `${commandName}: ${outcome}`);
   return {
     ...current,
     command: commandName,
@@ -107,6 +119,12 @@ export async function waitForRuntime(
     summary: text || reason || `${commandName}: ${outcome}`,
     exitCode: outcome === "succeeded" ? 0 : 1,
   };
+}
+
+function providerFaultReason(faultClass: string, resetAt: string | undefined, diagnostic: string): string {
+  return [`faultClass=${faultClass}`, resetAt ? `resetAt=${resetAt}` : null, diagnostic]
+    .filter((value): value is string => Boolean(value))
+    .join("; ");
 }
 
 async function waitForStreamedRuntime(

--- a/packages/cli/src/cli-runtime-wait.ts
+++ b/packages/cli/src/cli-runtime-wait.ts
@@ -117,7 +117,7 @@ function runtimeResultReceipt(
                 ? `Provider exited with code ${String(result.session.activity.exitCode)} without a diagnostic.`
                 : `${commandName}: ${outcome}`);
   return {
-    ...result,
+    ...(result as unknown as JsonObject),
     command: commandName,
     outcome,
     runtimeSessionId,

--- a/packages/cli/test/runtime-cli.integration.test.ts
+++ b/packages/cli/test/runtime-cli.integration.test.ts
@@ -1177,6 +1177,20 @@ test("real CLI runs, archives task-bound dispatches, resumes, waits through stat
     assert.equal(structuredFailure.status, 1);
     assert.match(String(structuredFailure.receipt.reason), /structured provider failure/u);
     assert.doesNotMatch(JSON.stringify(structuredFailure.receipt), new RegExp(secret, "u"));
+    const quotaFailure = runMaybe(root, env, [
+      "runtime",
+      "run",
+      "cli-worker",
+      "--prompt",
+      "failure:429",
+      "--no-stream",
+    ]);
+    assert.equal(quotaFailure.status, 1);
+    assert.equal(quotaFailure.receipt.code, "quota_exhausted");
+    assert.match(
+      String(quotaFailure.receipt.reason),
+      /faultClass=quota_exhausted; resetAt=2026-09-06T05:06:07\.000Z;.*credit balance exhausted/u,
+    );
     writeFileSync(
       path.join(root, "failure-batch.json"),
       JSON.stringify({
@@ -1627,13 +1641,19 @@ function writeProgressProvider(target: string, version: string): void {
     batchMarker =
       'const batch = mission.includes("batch hold"), mark = (event) => { if (batch) fs.appendFileSync(".batch-tracker", event + "\\n"); };\n',
     threadMarker = 'console.log(JSON.stringify({ type: "thread.started", thread_id: session })); if (readOnly)',
+    quotaMarker = "else { const resumed",
+    quotaFailure =
+      'else if (mission === "failure:429") process.stdout.write([JSON.stringify({ type: "thread.started", thread_id: "provider-cli-session" }), JSON.stringify({ type: "turn.failed", error: { http_status: 429, code: "insufficient_quota", message: "credit balance exhausted", reset_at: "2026-09-06T05:06:07Z" } })].join("\\n") + "\\n", () => process.exit(1));\nelse { const resumed',
     progressSetup =
       `${batchMarker}const progressTask = mission.startsWith("progress-middle:") ? mission.slice("progress-middle:".length) : null;\n` +
       'const submitTask = mission.startsWith("submit-before-exit:") ? mission.slice("submit-before-exit:".length) : null;\n',
     progressWrite =
       `console.log(JSON.stringify({ type: "thread.started", thread_id: session })); if (progressTask) { for (const text of ["Provider checkpoint one.", "Provider checkpoint two."]) { let result; for (let attempt = 0; attempt < 20; attempt += 1) { result = require("node:child_process").spawnSync(process.execPath, [${JSON.stringify(cli)}, "--root", process.cwd(), "--json", "task", "progress", "append", progressTask, "--text", text, "--evidence", "test:reports/runtime-progress.txt:provider checkpoint"], { encoding: "utf8", env: process.env }); if (result.status === 0) break; Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 50); } if (result.status !== 0) { process.stderr.write("progress append failed: " + result.stdout + result.stderr); process.exit(8); } } } ` +
       `if (submitTask) { const submission = JSON.stringify({ completionClaim: "Runtime worker submitted before exit.", deliverables: ["runtime archive"], outputs: ["runtime archive"], verificationNotes: ["integration"], knownGaps: [], residualRisks: [], commitSha: "a".repeat(40) }); const result = require("node:child_process").spawnSync(process.execPath, [${JSON.stringify(cli)}, "--root", process.cwd(), "--json", "task", "submit", submitTask, "--json-input", submission], { encoding: "utf8", env: process.env }); if (result.status !== 0) { process.stderr.write("task submit failed: " + result.stdout + result.stderr); process.exit(8); } } if (readOnly)`,
-    next = source.replace(batchMarker, progressSetup).replace(threadMarker, progressWrite);
+    next = source
+      .replace(batchMarker, progressSetup)
+      .replace(threadMarker, progressWrite)
+      .replace(quotaMarker, quotaFailure);
   if (next === source) throw new Error("runtime progress provider marker changed");
   writeFileSync(target, next);
 }

--- a/packages/daemon/src/agent-runtime-contract.ts
+++ b/packages/daemon/src/agent-runtime-contract.ts
@@ -52,6 +52,8 @@ export interface AgentRuntimeAttemptChainDto {
     readonly provider: { readonly instance: string; readonly model: string | null };
     readonly classification: "provider_fault" | "worker_stop" | "gate_red" | null;
     readonly reason: string | null;
+    readonly faultClass?: "quota_exhausted" | "rate_limited";
+    readonly resetAt?: string;
     readonly fallbackState: "scheduled" | "dispatched" | "exhausted" | null;
     readonly nextDispatchId: string | null;
   }[];
@@ -465,16 +467,20 @@ function validAttemptChain(value: unknown): value is AgentRuntimeAttemptChainDto
     value.attempts.every(
       (attempt) =>
         isAgentRuntimeContractRecord(attempt) &&
-        hasExactAgentRuntimeContractFields(attempt, [
-          "dispatchId",
-          "runtimeSessionId",
-          "attemptIndex",
-          "provider",
-          "classification",
-          "reason",
-          "fallbackState",
-          "nextDispatchId",
-        ]) &&
+        hasAgentRuntimeContractFields(
+          attempt,
+          [
+            "dispatchId",
+            "runtimeSessionId",
+            "attemptIndex",
+            "provider",
+            "classification",
+            "reason",
+            "fallbackState",
+            "nextDispatchId",
+          ],
+          ["faultClass", "resetAt"],
+        ) &&
         typeof attempt.dispatchId === "string" &&
         typeof attempt.runtimeSessionId === "string" &&
         Number.isInteger(attempt.attemptIndex) &&
@@ -486,6 +492,10 @@ function validAttemptChain(value: unknown): value is AgentRuntimeAttemptChainDto
         (attempt.classification === null ||
           ["provider_fault", "worker_stop", "gate_red"].includes(String(attempt.classification))) &&
         (attempt.reason === null || typeof attempt.reason === "string") &&
+        (attempt.faultClass === undefined ||
+          ["quota_exhausted", "rate_limited"].includes(String(attempt.faultClass))) &&
+        (attempt.resetAt === undefined ||
+          (!Number.isNaN(Date.parse(String(attempt.resetAt))) && typeof attempt.resetAt === "string")) &&
         (attempt.fallbackState === null ||
           ["scheduled", "dispatched", "exhausted"].includes(String(attempt.fallbackState))) &&
         (attempt.nextDispatchId === null || typeof attempt.nextDispatchId === "string"),

--- a/packages/daemon/src/dispatch-read.ts
+++ b/packages/daemon/src/dispatch-read.ts
@@ -224,6 +224,8 @@ export function readRuntimeAttemptChain(
         },
         classification: stream.attemptOutcome?.classification ?? null,
         reason: stream.attemptOutcome?.reason ?? null,
+        ...(stream.attemptOutcome?.faultClass ? { faultClass: stream.attemptOutcome.faultClass } : {}),
+        ...(stream.attemptOutcome?.resetAt ? { resetAt: stream.attemptOutcome.resetAt } : {}),
         fallbackState: stream.fallbackState,
         nextDispatchId: stream.nextDispatchId,
       }))

--- a/packages/daemon/src/runtime-fallback-contract.ts
+++ b/packages/daemon/src/runtime-fallback-contract.ts
@@ -12,6 +12,8 @@ export type RuntimeProviderFault = {
     | "provider_disconnected"
     | "pre_tool_exit";
   readonly reason: string;
+  readonly faultClass?: "quota_exhausted" | "rate_limited";
+  readonly resetAt?: string;
 };
 
 export type RuntimeFallbackCandidate = { readonly instance: string; readonly model?: string };
@@ -31,4 +33,6 @@ export type RuntimeAttemptOutcome = {
   readonly provider: { readonly instance: string; readonly model: string; readonly kind: RuntimeInstanceKind };
   readonly attemptGroupId: string;
   readonly attemptIndex: number;
+  readonly faultClass?: RuntimeProviderFault["faultClass"];
+  readonly resetAt?: string;
 };

--- a/packages/daemon/src/runtime-provider-fault.ts
+++ b/packages/daemon/src/runtime-provider-fault.ts
@@ -15,21 +15,30 @@ export function providerFaultFromFrame(
     const responseCode = integer(value.api_error_status) ?? integer(value.error_status),
       error = diagnosticText(value.error),
       diagnostic = diagnosticText(value.result) ?? error;
-    return providerFaultFromDiagnostic(responseCode, error, diagnostic);
+    return providerFaultFromDiagnostic(responseCode, error, diagnostic, resetAtFrom(value));
   }
   if (kindId === "codex" && value.type === "turn.failed") {
     const detail = diagnosticRecord(value.error),
       responseCode = integer(detail?.http_status) ?? integer(detail?.status),
       code = diagnosticText(detail?.code),
       diagnostic = diagnosticText(detail?.message) ?? (detail ? JSON.stringify(detail) : null);
-    return providerFaultFromDiagnostic(responseCode, code, diagnostic);
+    return providerFaultFromDiagnostic(responseCode, code, diagnostic, resetAtFrom(detail ?? value));
   }
   if (kindId === "agy" && value.event === "result") {
     const result = diagnosticRecord(value.result),
       diagnostic = diagnosticText(result?.error),
       responseCode = integer(result?.status_code),
       code = diagnosticText(result?.code);
-    return providerFaultFromDiagnostic(responseCode, code, diagnostic);
+    return providerFaultFromDiagnostic(responseCode, code, diagnostic, resetAtFrom(result ?? value));
+  }
+  if (kindId === "zcode" && value.type === "turn.failed") {
+    const payload = diagnosticRecord(value.payload),
+      detail = diagnosticRecord(payload?.error) ?? payload,
+      attribution = diagnosticRecord(detail?.attribution) ?? diagnosticRecord(payload?.attribution),
+      responseCode = integer(attribution?.statusCode) ?? integer(detail?.statusCode) ?? integer(detail?.status),
+      code = diagnosticText(detail?.code),
+      diagnostic = diagnosticText(detail?.message) ?? (detail ? JSON.stringify(detail) : null);
+    return providerFaultFromDiagnostic(responseCode, code, diagnostic, resetAtFrom(attribution ?? detail ?? value));
   }
   return null;
 }
@@ -71,7 +80,12 @@ export function classifyRuntimeExit(
         ? "Worker stop was requested."
         : `Worker process stopped before settlement: ${active.lossReason}`,
     );
-  if (attemptFailed && providerFault) return classified("provider_fault", providerFault.reason);
+  if (attemptFailed && providerFault)
+    return {
+      ...classified("provider_fault", providerFault.reason),
+      ...(providerFault.faultClass ? { faultClass: providerFault.faultClass } : {}),
+      ...(providerFault.resetAt ? { resetAt: providerFault.resetAt } : {}),
+    };
   if (exitCode === null)
     return classified("provider_fault", "Provider process disconnected before completing the attempt.");
   if (attemptFailed && !active.toolCallObserved) {
@@ -121,13 +135,20 @@ function providerFaultFromDiagnostic(
   responseCode: number | null,
   code: string | null,
   diagnostic: string | null,
+  resetAt: string | undefined,
 ): RuntimeProviderFault | null {
   const joined = [code, diagnostic].filter((value): value is string => value !== null).join(" ");
+  if (quota.test(joined))
+    return fault("quota_exhausted", `Provider quota exhausted: ${joined}`, "quota_exhausted", resetAt);
   if (responseCode === 429 || /rate[_ -]?limit|too many requests/iu.test(joined))
-    return fault("rate_limited", providerDiagnostic("Provider rate limited the attempt", responseCode ?? 429, joined));
+    return fault(
+      "rate_limited",
+      providerDiagnostic("Provider rate limited the attempt", responseCode ?? 429, joined),
+      "rate_limited",
+      resetAt,
+    );
   if (responseCode !== null && responseCode >= 500 && responseCode <= 599)
     return fault("server_error", providerDiagnostic("Provider server error", responseCode, joined));
-  if (quota.test(joined)) return fault("quota_exhausted", `Provider quota exhausted: ${joined}`);
   if (model.test(joined)) return fault("unrecognized_model", `Provider rejected the model: ${joined}`);
   if (responseCode === 401 || responseCode === 403 || auth.test(joined))
     return fault("auth_failed", providerDiagnostic("Provider authentication failed", responseCode, joined));
@@ -139,8 +160,54 @@ function providerDiagnostic(label: string, responseCode: number | null, diagnost
   return `${label}${status}${diagnostic ? `: ${diagnostic}` : "."}`;
 }
 
-function fault(code: RuntimeProviderFault["code"], reason: string): RuntimeProviderFault {
-  return { code, reason: reason.trim().slice(0, 1024) || code };
+function fault(
+  code: RuntimeProviderFault["code"],
+  reason: string,
+  faultClass?: RuntimeProviderFault["faultClass"],
+  resetAt?: string,
+): RuntimeProviderFault {
+  return {
+    code,
+    reason: reason.trim().slice(0, 1024) || code,
+    ...(faultClass ? { faultClass } : {}),
+    ...(resetAt ? { resetAt } : {}),
+  };
+}
+
+function resetAtFrom(value: Record<string, unknown>): string | undefined {
+  const direct = ["resetAt", "reset_at", "resetTime", "reset_time", "x-ratelimit-reset"].flatMap((key) =>
+      value[key] === undefined ? [] : [value[key]],
+    ),
+    headers = diagnosticRecord(value.headers) ?? diagnosticRecord(value.response_headers),
+    headerReset = headers
+      ? (headers["x-ratelimit-reset"] ?? headers["ratelimit-reset"] ?? headers["retry-after"])
+      : undefined,
+    retryAfter = value.retry_after ?? value.retryAfter;
+  for (const candidate of [...direct, headerReset]) {
+    const absolute = absoluteResetAt(candidate);
+    if (absolute) return absolute;
+  }
+  return retryAfterAt(retryAfter);
+}
+
+function absoluteResetAt(value: unknown): string | undefined {
+  if (typeof value === "string" && value.trim()) {
+    const milliseconds = Date.parse(value);
+    if (Number.isFinite(milliseconds)) return new Date(milliseconds).toISOString();
+    if (/^\d+(?:\.\d+)?$/u.test(value.trim())) return epochResetAt(Number(value));
+  }
+  return typeof value === "number" && Number.isFinite(value) ? epochResetAt(value) : undefined;
+}
+
+function epochResetAt(value: number): string | undefined {
+  const milliseconds = value < 10_000_000_000 ? value * 1_000 : value;
+  return Number.isFinite(milliseconds) ? new Date(milliseconds).toISOString() : undefined;
+}
+
+function retryAfterAt(value: unknown): string | undefined {
+  if (typeof value === "string" && !/^\d+(?:\.\d+)?$/u.test(value.trim())) return absoluteResetAt(value);
+  const seconds = typeof value === "number" ? value : typeof value === "string" ? Number(value) : NaN;
+  return Number.isFinite(seconds) && seconds >= 0 ? new Date(Date.now() + seconds * 1_000).toISOString() : undefined;
 }
 function integer(value: unknown): number | null {
   return Number.isInteger(value) ? Number(value) : null;

--- a/packages/daemon/src/runtime-provider-fault.ts
+++ b/packages/daemon/src/runtime-provider-fault.ts
@@ -137,27 +137,20 @@ function providerFaultFromDiagnostic(
   diagnostic: string | null,
   resetAt: string | undefined,
 ): RuntimeProviderFault | null {
-  const joined = [code, diagnostic].filter((value): value is string => value !== null).join(" ");
-  if (quota.test(joined))
-    return fault("quota_exhausted", `Provider quota exhausted: ${joined}`, "quota_exhausted", resetAt);
+  const joined = [code, diagnostic].filter((value): value is string => value !== null).join(" "),
+    reason = providerReason(responseCode, joined);
+  if (quota.test(joined)) return fault("quota_exhausted", reason, "quota_exhausted", resetAt);
   if (responseCode === 429 || /rate[_ -]?limit|too many requests/iu.test(joined))
-    return fault(
-      "rate_limited",
-      providerDiagnostic("Provider rate limited the attempt", responseCode ?? 429, joined),
-      "rate_limited",
-      resetAt,
-    );
-  if (responseCode !== null && responseCode >= 500 && responseCode <= 599)
-    return fault("server_error", providerDiagnostic("Provider server error", responseCode, joined));
-  if (model.test(joined)) return fault("unrecognized_model", `Provider rejected the model: ${joined}`);
-  if (responseCode === 401 || responseCode === 403 || auth.test(joined))
-    return fault("auth_failed", providerDiagnostic("Provider authentication failed", responseCode, joined));
+    return fault("rate_limited", reason, "rate_limited", resetAt);
+  if (responseCode !== null && responseCode >= 500 && responseCode <= 599) return fault("server_error", reason);
+  if (model.test(joined)) return fault("unrecognized_model", reason);
+  if (responseCode === 401 || responseCode === 403 || auth.test(joined)) return fault("auth_failed", reason);
   return null;
 }
 
-function providerDiagnostic(label: string, responseCode: number | null, diagnostic: string): string {
-  const status = responseCode === null ? "" : ` (HTTP ${String(responseCode)})`;
-  return `${label}${status}${diagnostic ? `: ${diagnostic}` : "."}`;
+function providerReason(responseCode: number | null, diagnostic: string): string {
+  const status = responseCode === null ? "" : `HTTP ${String(responseCode)}`;
+  return [status, diagnostic].filter(Boolean).join(": ");
 }
 
 function fault(

--- a/packages/daemon/test/runtime-provider-fault.test.ts
+++ b/packages/daemon/test/runtime-provider-fault.test.ts
@@ -51,6 +51,7 @@ test("claude api_error 429 preserves quota classification and reset header", () 
     headers: { "x-ratelimit-reset": "2026-09-06T01:02:03Z" },
   });
   assert.equal(fault?.faultClass, "quota_exhausted");
+  assert.equal(fault?.reason, "HTTP 429: insufficient_quota Your credit balance is exhausted");
   assert.equal(fault?.resetAt, "2026-09-06T01:02:03.000Z");
 });
 
@@ -65,6 +66,7 @@ test("codex rate_limit_exceeded preserves reset_at", () => {
     },
   });
   assert.equal(fault?.faultClass, "rate_limited");
+  assert.equal(fault?.reason, "HTTP 429: rate_limit_exceeded Too many requests");
   assert.equal(fault?.resetAt, "2026-09-06T02:03:04.000Z");
 });
 
@@ -81,6 +83,7 @@ test("agy RESOURCE_EXHAUSTED preserves epoch reset_time", () => {
     },
   });
   assert.equal(fault?.faultClass, "quota_exhausted");
+  assert.equal(fault?.reason, "HTTP 429: RESOURCE_EXHAUSTED quota exhausted");
   assert.equal(fault?.resetAt, "2026-09-06T01:43:05.000Z");
 });
 
@@ -96,6 +99,7 @@ test("zcode turn.failed attribution 429 preserves retry reset", () => {
     },
   });
   assert.equal(fault?.faultClass, "rate_limited");
+  assert.equal(fault?.reason, "HTTP 429: rate_limit_exceeded rate limit reached");
   assert.equal(fault?.resetAt, "2026-09-06T04:05:06.000Z");
 });
 

--- a/packages/daemon/test/runtime-provider-fault.test.ts
+++ b/packages/daemon/test/runtime-provider-fault.test.ts
@@ -42,6 +42,63 @@ test("structured provider errors classify rate limits, server faults, quota, mod
   );
 });
 
+test("claude api_error 429 preserves quota classification and reset header", () => {
+  const fault = providerFaultFromFrame("claude", {
+    type: "result",
+    api_error_status: 429,
+    error: "insufficient_quota",
+    result: "Your credit balance is exhausted",
+    headers: { "x-ratelimit-reset": "2026-09-06T01:02:03Z" },
+  });
+  assert.equal(fault?.faultClass, "quota_exhausted");
+  assert.equal(fault?.resetAt, "2026-09-06T01:02:03.000Z");
+});
+
+test("codex rate_limit_exceeded preserves reset_at", () => {
+  const fault = providerFaultFromFrame("codex", {
+    type: "turn.failed",
+    error: {
+      http_status: 429,
+      code: "rate_limit_exceeded",
+      message: "Too many requests",
+      reset_at: "2026-09-06T02:03:04Z",
+    },
+  });
+  assert.equal(fault?.faultClass, "rate_limited");
+  assert.equal(fault?.resetAt, "2026-09-06T02:03:04.000Z");
+});
+
+test("agy RESOURCE_EXHAUSTED preserves epoch reset_time", () => {
+  const fault = providerFaultFromFrame("agy", {
+    event: "result",
+    result: {
+      status: "ERROR",
+      response: "",
+      status_code: 429,
+      code: "RESOURCE_EXHAUSTED",
+      error: "quota exhausted",
+      reset_time: 1_788_658_985,
+    },
+  });
+  assert.equal(fault?.faultClass, "quota_exhausted");
+  assert.equal(fault?.resetAt, "2026-09-06T01:43:05.000Z");
+});
+
+test("zcode turn.failed attribution 429 preserves retry reset", () => {
+  const fault = providerFaultFromFrame("zcode", {
+    type: "turn.failed",
+    payload: {
+      error: {
+        code: "rate_limit_exceeded",
+        message: "rate limit reached",
+        attribution: { statusCode: 429, resetAt: "2026-09-06T04:05:06Z" },
+      },
+    },
+  });
+  assert.equal(fault?.faultClass, "rate_limited");
+  assert.equal(fault?.resetAt, "2026-09-06T04:05:06.000Z");
+});
+
 test("attempt-bound classification falls back only before tools or for recognized provider faults", () => {
   assert.deepEqual(pick(classifyRuntimeExit(active({ toolCallObserved: false }), 1)), {
     outcome: "failed",


### PR DESCRIPTION
# English

## Summary
Provider 429 (quota exhausted / rate limited) was settled as a generic stream loss: the attempt read as `daemon_stream_unavailable` and the CLI exited with `daemon_gone`, hiding the provider's own error class and reset time (task_7c0adfe6, confirmed still present on 2026-09-05).

- `runtime-fallback-contract.ts`, `runtime-provider-fault.ts`: `RuntimeProviderFault` gains `faultClass` (`quota_exhausted` | `rate_limited`) and an optional normalized ISO `resetAt`; the parser recognises the 429 shapes of all four kinds (claude `api_error` + `x-ratelimit-reset`, codex `rate_limit_exceeded` + `reset_at`, agy `RESOURCE_EXHAUSTED` + epoch `reset_time`, zcode `turn.failed` attribution 429) plus `retry-after`.
- `agent-runtime-contract.ts`, `dispatch-read.ts`: the fields survive dispatch-stream storage and the attempt-chain projection.
- Settlement: a recognised provider fault takes precedence over the pre-tool / stream-loss classification; genuine daemon subscription loss still reports `daemon_gone`.
- `cli-runtime-wait.ts`: `ha runtime run --no-stream` and `ha runtime status --wait` render the fault class and reset time instead of a daemon-gone message.

## Architectural Justification
This is classification, not a new mechanism: two optional fields on an existing contract, one precedence rule in settlement, no retry layer. 429 handling stays with the existing fallback chain, which already accepts `provider_fault`. Old events without the fields read as undefined; no migration.

## Verification
- `runtime-provider-fault.test.ts`: 6/6 (one 429 fixture per kind, all synthetic and minimal — derived from the documented shapes, not captured live traffic).
- `runtime-cli.integration.test.ts`: fake Codex provider exits with 429 → CLI receipt carries `quota_exhausted` and the rendered reset.
- settlement / session-group / fallback-render tests: 17/17; typecheck, targeted eslint, canonical-event-compat (171 samples), `git diff --check`: pass.

## Review Evidence
- Implemented by Sol from the task plan; CEO read the report and the contract/settlement diff surface.

## Residual Risk
- The per-kind 429 fixtures are synthetic; if a provider's live 429 shape differs, classification degrades to the previous generic path (never to a wrong success).

Production-Delta: +138/-37
Deleted-Production-Paths: none

---

# 中文

## 摘要
provider 429(配额耗尽 / 限流)此前被结算成泛化的流失联:attempt 记为 `daemon_stream_unavailable`,CLI 以 `daemon_gone` 退出,provider 自己的错误类别与 reset 时间全部丢失(task_7c0adfe6,2026-09-05 存在性分析确认仍在)。

- `runtime-fallback-contract.ts`、`runtime-provider-fault.ts`:`RuntimeProviderFault` 新增 `faultClass`(`quota_exhausted` | `rate_limited`)与可选的归一化 ISO `resetAt`;解析器识别四个 kind 的 429 形态(claude `api_error` + `x-ratelimit-reset`、codex `rate_limit_exceeded` + `reset_at`、agy `RESOURCE_EXHAUSTED` + epoch `reset_time`、zcode `turn.failed` attribution 429)以及 `retry-after`。
- `agent-runtime-contract.ts`、`dispatch-read.ts`:字段贯通派工流存储与 attempt 链投影。
- 结算:已识别的 provider fault 优先于 pre-tool / 流失联分类;真正的 daemon 订阅丢失仍报 `daemon_gone`。
- `cli-runtime-wait.ts`:`ha runtime run --no-stream` 与 `ha runtime status --wait` 显示 fault 类别与 reset 时间,不再显示 daemon 失联。

## 架构辩护
这是分类修正,不是新机制:现有契约上两个可选字段、结算里一条优先级规则,没有重试层。429 的处置仍交给现有 fallback 链(它本来就接受 `provider_fault`)。旧事件缺字段读成 undefined,无迁移。

## 验证
- `runtime-provider-fault.test.ts`:6/6(每个 kind 一条 429 fixture,均为按文档形态构造的最小合成样本,不是实抓流量)。
- `runtime-cli.integration.test.ts`:假 Codex provider 以 429 退出 → CLI 回执带 `quota_exhausted` 与 reset 渲染。
- 结算 / session-group / fallback 渲染测试 17/17;typecheck、定向 eslint、canonical-event-compat(171 样本)、`git diff --check` 通过。

## 复核证据
- Sol 按任务 plan 实现;CEO 读了报告与契约/结算 diff 面。

## 残余风险
- 各 kind 的 429 fixture 为合成样本;若某 provider 线上 429 形态不同,分类退化到原先的泛化路径(不会误判成功)。
