### PR TITLE
fix(cli): recover the daemon restart window with one bounded replay

### DIFF
--- a/packages/cli/src/cli/guidance-plane.ts
+++ b/packages/cli/src/cli/guidance-plane.ts
@@ -164,6 +164,7 @@ export function humanError(receipt: Record<string, unknown>): { readonly code: s
   if (code === "squad_leader_failed" && leader && leader.code !== "unknown")
     return { code, hint: renderTemplate("failure", "squad-leader", leader) };
   if (code === "daemon_stopping") return { code, hint: renderTemplate("failure", "daemon-stopping", {}) };
+  if (code === "daemon_restarting" && typeof outer.hint === "string") return { code, hint: outer.hint };
   const diagnostic = record(receipt.diagnostic) ? receipt.diagnostic : null,
     diagnosticHint = diagnostic ? renderDiagnostic(diagnostic) : null,
     declaredGuidance = renderReceiptGuidance(receipt),

--- a/packages/cli/src/cli/guidance-plane.ts
+++ b/packages/cli/src/cli/guidance-plane.ts
@@ -102,6 +102,11 @@ const guidanceTemplates = new Map<string, GuidanceTemplate>([
   ["cli:daemon-connection-failure", (args) => `Local daemon request failed. Cause: ${textArg(args, "message")}`],
   ["cli:daemon-build-stale", () => "Restart the local daemon so its build matches this CLI, then retry the command."],
   [
+    "cli:daemon-restarting",
+    (args) =>
+      `daemon is restarting (old build -> new build); waited ${numberArg(args, "waitedSeconds")}s but it is not ready`,
+  ],
+  [
     "cli:daemon-target-conflict",
     (args) =>
       `Daemon target conflict: injected target endpoint=${JSON.stringify(textArg(args, "endpoint"))} ` +

--- a/packages/cli/src/cli/thin-command.ts
+++ b/packages/cli/src/cli/thin-command.ts
@@ -2,6 +2,7 @@ export const thinCliLocalErrorCodes = Object.freeze([
   "daemon_start_runtime_forbidden",
   "daemon_disconnect",
   "daemon_gone",
+  "daemon_restarting",
   "daemon_target_conflict",
   "duplicate_field",
   "invalid_field",

--- a/packages/cli/src/daemon/client.ts
+++ b/packages/cli/src/daemon/client.ts
@@ -160,7 +160,7 @@ export async function runCommandThroughDaemon(
         ),
       () => cliDaemonServeLaunch(userRoot, daemonId),
       socketPath,
-      { autostart, env, invokingRoot: command.rootDir, userRoot, daemonId, commandCategory: "operation" },
+      daemonAutostartOptions(command, autostart, env, userRoot, daemonId, "operation"),
     );
   }
   if (command.method.startsWith("daemon.runtimeInstance.")) {
@@ -178,14 +178,7 @@ export async function runCommandThroughDaemon(
         ),
       () => cliDaemonServeLaunch(userRoot, daemonId),
       socketPath,
-      {
-        autostart,
-        env,
-        invokingRoot: command.rootDir,
-        userRoot,
-        daemonId,
-        commandCategory: daemonCommandCategory(command.method),
-      },
+      daemonAutostartOptions(command, autostart, env, userRoot, daemonId),
     );
   }
   const fleetSchedule = await fleetScheduleRoute(command, env);
@@ -203,7 +196,7 @@ export async function runCommandThroughDaemon(
         ),
       () => cliDaemonServeLaunch(userRoot, daemonId),
       socketPath,
-      { autostart, env, invokingRoot: command.rootDir, userRoot, daemonId, commandCategory: "operation" },
+      daemonAutostartOptions(command, autostart, env, userRoot, daemonId, "operation"),
     );
   }
   const fleetRuntime = await fleetRuntimeRoute(command, env);
@@ -221,7 +214,7 @@ export async function runCommandThroughDaemon(
         ),
       () => cliDaemonServeLaunch(userRoot, daemonId),
       socketPath,
-      { autostart, env, invokingRoot: command.rootDir, userRoot, daemonId, commandCategory: "operation" },
+      daemonAutostartOptions(command, autostart, env, userRoot, daemonId, "operation"),
     );
   }
   const fleetTask = await fleetTaskRoute(command, env);
@@ -239,7 +232,7 @@ export async function runCommandThroughDaemon(
         ),
       () => cliDaemonServeLaunch(userRoot, daemonId),
       socketPath,
-      { autostart, env, invokingRoot: command.rootDir, userRoot, daemonId, commandCategory: "operation" },
+      daemonAutostartOptions(command, autostart, env, userRoot, daemonId, "operation"),
     );
   }
   const fleetDoc = await fleetDocRoute(command, env);
@@ -257,14 +250,7 @@ export async function runCommandThroughDaemon(
         ),
       () => cliDaemonServeLaunch(userRoot, daemonId),
       socketPath,
-      {
-        autostart,
-        env,
-        invokingRoot: command.rootDir,
-        userRoot,
-        daemonId,
-        commandCategory: daemonCommandCategory(fleetDoc.method),
-      },
+      daemonAutostartOptions(command, autostart, env, userRoot, daemonId, daemonCommandCategory(fleetDoc.method)),
     );
   }
   const target = {
@@ -287,14 +273,7 @@ export async function runCommandThroughDaemon(
     request,
     () => cliDaemonServeLaunch(target.userRoot, target.daemonId),
     target.socketPath,
-    {
-      autostart,
-      env,
-      invokingRoot: command.rootDir,
-      userRoot: target.userRoot,
-      daemonId: target.daemonId,
-      commandCategory: daemonCommandCategory(command.method),
-    },
+    daemonAutostartOptions(command, autostart, env, target.userRoot, target.daemonId),
   );
   result = await settleRepoWarming(result, request, target.userRoot, target.daemonId);
   if (command.action.kind !== "preset-run-start") return result;
@@ -351,6 +330,17 @@ export async function runCommandThroughDaemon(
 
 function daemonCommandCategory(method: string): "operation" | "daemon-lifecycle" {
   return method === "daemon.stop" || method === "daemon.status" ? "daemon-lifecycle" : "operation";
+}
+
+function daemonAutostartOptions(
+  command: ThinCommand,
+  autostart: boolean,
+  env: NodeJS.ProcessEnv,
+  userRoot: string,
+  daemonId: string,
+  commandCategory = daemonCommandCategory(command.method),
+): Parameters<typeof withAutostart>[3] {
+  return { autostart, env, invokingRoot: command.rootDir, userRoot, daemonId, commandCategory };
 }
 
 function daemonRequestPayload(command: ThinCommand, env: NodeJS.ProcessEnv): Readonly<Record<string, unknown>> {

--- a/packages/cli/src/daemon/client.ts
+++ b/packages/cli/src/daemon/client.ts
@@ -160,7 +160,7 @@ export async function runCommandThroughDaemon(
         ),
       () => cliDaemonServeLaunch(userRoot, daemonId),
       socketPath,
-      { autostart, env, invokingRoot: command.rootDir, userRoot, daemonId },
+      { autostart, env, invokingRoot: command.rootDir, userRoot, daemonId, commandCategory: "operation" },
     );
   }
   if (command.method.startsWith("daemon.runtimeInstance.")) {
@@ -178,7 +178,14 @@ export async function runCommandThroughDaemon(
         ),
       () => cliDaemonServeLaunch(userRoot, daemonId),
       socketPath,
-      { autostart, env, invokingRoot: command.rootDir, userRoot, daemonId },
+      {
+        autostart,
+        env,
+        invokingRoot: command.rootDir,
+        userRoot,
+        daemonId,
+        commandCategory: daemonCommandCategory(command.method),
+      },
     );
   }
   const fleetSchedule = await fleetScheduleRoute(command, env);
@@ -196,7 +203,7 @@ export async function runCommandThroughDaemon(
         ),
       () => cliDaemonServeLaunch(userRoot, daemonId),
       socketPath,
-      { autostart, env, invokingRoot: command.rootDir, userRoot, daemonId },
+      { autostart, env, invokingRoot: command.rootDir, userRoot, daemonId, commandCategory: "operation" },
     );
   }
   const fleetRuntime = await fleetRuntimeRoute(command, env);
@@ -214,7 +221,7 @@ export async function runCommandThroughDaemon(
         ),
       () => cliDaemonServeLaunch(userRoot, daemonId),
       socketPath,
-      { autostart, env, invokingRoot: command.rootDir, userRoot, daemonId },
+      { autostart, env, invokingRoot: command.rootDir, userRoot, daemonId, commandCategory: "operation" },
     );
   }
   const fleetTask = await fleetTaskRoute(command, env);
@@ -232,7 +239,7 @@ export async function runCommandThroughDaemon(
         ),
       () => cliDaemonServeLaunch(userRoot, daemonId),
       socketPath,
-      { autostart, env, invokingRoot: command.rootDir, userRoot, daemonId },
+      { autostart, env, invokingRoot: command.rootDir, userRoot, daemonId, commandCategory: "operation" },
     );
   }
   const fleetDoc = await fleetDocRoute(command, env);
@@ -250,7 +257,14 @@ export async function runCommandThroughDaemon(
         ),
       () => cliDaemonServeLaunch(userRoot, daemonId),
       socketPath,
-      { autostart, env, invokingRoot: command.rootDir, userRoot, daemonId },
+      {
+        autostart,
+        env,
+        invokingRoot: command.rootDir,
+        userRoot,
+        daemonId,
+        commandCategory: daemonCommandCategory(fleetDoc.method),
+      },
     );
   }
   const target = {
@@ -279,6 +293,7 @@ export async function runCommandThroughDaemon(
       invokingRoot: command.rootDir,
       userRoot: target.userRoot,
       daemonId: target.daemonId,
+      commandCategory: daemonCommandCategory(command.method),
     },
   );
   result = await settleRepoWarming(result, request, target.userRoot, target.daemonId);
@@ -332,6 +347,10 @@ export async function runCommandThroughDaemon(
       };
     }
   }
+}
+
+function daemonCommandCategory(method: string): "operation" | "daemon-lifecycle" {
+  return method === "daemon.stop" || method === "daemon.status" ? "daemon-lifecycle" : "operation";
 }
 
 function daemonRequestPayload(command: ThinCommand, env: NodeJS.ProcessEnv): Readonly<Record<string, unknown>> {

--- a/packages/cli/src/daemon/client.ts
+++ b/packages/cli/src/daemon/client.ts
@@ -160,7 +160,7 @@ export async function runCommandThroughDaemon(
         ),
       () => cliDaemonServeLaunch(userRoot, daemonId),
       socketPath,
-      { autostart, env, invokingRoot: command.rootDir },
+      { autostart, env, invokingRoot: command.rootDir, userRoot, daemonId },
     );
   }
   if (command.method.startsWith("daemon.runtimeInstance.")) {
@@ -178,7 +178,7 @@ export async function runCommandThroughDaemon(
         ),
       () => cliDaemonServeLaunch(userRoot, daemonId),
       socketPath,
-      { autostart, env, invokingRoot: command.rootDir },
+      { autostart, env, invokingRoot: command.rootDir, userRoot, daemonId },
     );
   }
   const fleetSchedule = await fleetScheduleRoute(command, env);
@@ -196,7 +196,7 @@ export async function runCommandThroughDaemon(
         ),
       () => cliDaemonServeLaunch(userRoot, daemonId),
       socketPath,
-      { autostart, env, invokingRoot: command.rootDir },
+      { autostart, env, invokingRoot: command.rootDir, userRoot, daemonId },
     );
   }
   const fleetRuntime = await fleetRuntimeRoute(command, env);
@@ -214,7 +214,7 @@ export async function runCommandThroughDaemon(
         ),
       () => cliDaemonServeLaunch(userRoot, daemonId),
       socketPath,
-      { autostart, env, invokingRoot: command.rootDir },
+      { autostart, env, invokingRoot: command.rootDir, userRoot, daemonId },
     );
   }
   const fleetTask = await fleetTaskRoute(command, env);
@@ -232,7 +232,7 @@ export async function runCommandThroughDaemon(
         ),
       () => cliDaemonServeLaunch(userRoot, daemonId),
       socketPath,
-      { autostart, env, invokingRoot: command.rootDir },
+      { autostart, env, invokingRoot: command.rootDir, userRoot, daemonId },
     );
   }
   const fleetDoc = await fleetDocRoute(command, env);
@@ -250,7 +250,7 @@ export async function runCommandThroughDaemon(
         ),
       () => cliDaemonServeLaunch(userRoot, daemonId),
       socketPath,
-      { autostart, env, invokingRoot: command.rootDir },
+      { autostart, env, invokingRoot: command.rootDir, userRoot, daemonId },
     );
   }
   const target = {
@@ -273,7 +273,13 @@ export async function runCommandThroughDaemon(
     request,
     () => cliDaemonServeLaunch(target.userRoot, target.daemonId),
     target.socketPath,
-    { autostart, env, invokingRoot: command.rootDir },
+    {
+      autostart,
+      env,
+      invokingRoot: command.rootDir,
+      userRoot: target.userRoot,
+      daemonId: target.daemonId,
+    },
   );
   result = await settleRepoWarming(result, request, target.userRoot, target.daemonId);
   if (command.action.kind !== "preset-run-start") return result;

--- a/packages/cli/src/daemon/with-autostart.ts
+++ b/packages/cli/src/daemon/with-autostart.ts
@@ -7,10 +7,61 @@ export async function withAutostart(
   request: () => Promise<JsonObject>,
   launch: () => DaemonLaunchSpec,
   socketPath: string,
-  options: { readonly autostart: boolean; readonly env: NodeJS.ProcessEnv; readonly invokingRoot: string },
+  options: {
+    readonly autostart: boolean;
+    readonly env: NodeJS.ProcessEnv;
+    readonly invokingRoot: string;
+    readonly userRoot?: string;
+    readonly daemonId?: string;
+    readonly restartBudgetMs?: number;
+  },
 ): Promise<JsonObject> {
+  const startedAt = Date.now();
   try {
-    return await request();
+    const result = await request();
+    if (!isDaemonStopping(result) || !options.userRoot || !options.daemonId) return result;
+    const { readDaemonPid } = await import("../../../daemon/src/daemon-singleton.ts"),
+      { DaemonAutostartError, ensureLocalDaemonRunning, waitForDaemonGenerationChange } = await import(
+        "../../../daemon/src/client/daemon-autostart.ts"
+      ),
+      outgoingPid = readDaemonPid(options.userRoot, options.daemonId),
+      budgetMs = options.restartBudgetMs ?? 30_000,
+      changed = await waitForDaemonGenerationChange({
+        previousPid: outgoingPid,
+        readPid: () => readDaemonPid(options.userRoot!, options.daemonId!),
+        timeoutMs: Math.max(0, budgetMs - (Date.now() - startedAt)),
+      });
+    if (!changed.ok) return daemonRestartingReceipt(Date.now() - startedAt, 0);
+    // Leave room for autostart's two bounded socket probes so the whole
+    // recovery path, including an unreachable Unix socket, stays inside the
+    // caller-visible budget.
+    const probeReserveMs = 550,
+      remainingMs = budgetMs - (Date.now() - startedAt) - probeReserveMs;
+    if (remainingMs <= 0) return daemonRestartingReceipt(Date.now() - startedAt, 0);
+    const started = await ensureLocalDaemonRunning({
+      socketPath,
+      invokingRoot: options.invokingRoot,
+      launch,
+      readyTimeoutMs: remainingMs,
+      extendTimeoutWhileProgressing: false,
+      onProgress: (progress) => process.stderr.write(`${progress.message}\n`),
+    });
+    if (!started.ok) {
+      // A runtime or worktree caller is allowed to wait for a supervisor-owned
+      // replacement, but it must never inherit authority to spawn that daemon.
+      if (started.code === "daemon_start_runtime_forbidden" || started.code === "daemon_start_noncanonical_checkout")
+        return daemonRestartingReceipt(Date.now() - startedAt, 0);
+      throw new DaemonAutostartError(started);
+    }
+    try {
+      const retried = await request();
+      if (isDaemonStopping(retried)) return daemonRestartingReceipt(Date.now() - startedAt, 1);
+      return { ...retried, daemonRestart: { waitedMs: Date.now() - startedAt, retries: 1 } };
+    } catch (error) {
+      const { isDaemonUnreachable } = await import("../../../daemon/src/client/daemon-autostart.ts");
+      if (isDaemonUnreachable(error)) return daemonRestartingReceipt(Date.now() - startedAt, 1);
+      throw error;
+    }
   } catch (error) {
     if (!options.autostart) throw error;
     const { DaemonAutostartError, ensureLocalDaemonRunning, isDaemonUnreachable, runtimeDaemonStartRefusal } =
@@ -29,4 +80,24 @@ export async function withAutostart(
     if (!started.ok) throw new DaemonAutostartError(started);
     return await request();
   }
+}
+
+function isDaemonStopping(result: JsonObject): boolean {
+  const error =
+    result.error && typeof result.error === "object" && !Array.isArray(result.error)
+      ? (result.error as JsonObject)
+      : null;
+  return result.code === "daemon_stopping" || error?.code === "daemon_stopping";
+}
+
+function daemonRestartingReceipt(waitedMs: number, retries: number): JsonObject {
+  const waitedSeconds = Math.ceil(waitedMs / 1_000),
+    hint = `daemon is restarting (old build -> new build); waited ${waitedSeconds}s but it is not ready`;
+  return {
+    ok: false,
+    code: "daemon_restarting",
+    error: { code: "daemon_restarting", hint },
+    hint,
+    daemonRestart: { waitedMs, retries },
+  };
 }

--- a/packages/cli/src/daemon/with-autostart.ts
+++ b/packages/cli/src/daemon/with-autostart.ts
@@ -15,12 +15,19 @@ export async function withAutostart(
     readonly userRoot?: string;
     readonly daemonId?: string;
     readonly restartBudgetMs?: number;
+    readonly commandCategory: "operation" | "daemon-lifecycle";
   },
 ): Promise<JsonObject> {
   const startedAt = Date.now();
   try {
     const result = await request();
-    if (!isDaemonStopping(result) || !options.userRoot || !options.daemonId) return result;
+    if (
+      !isDaemonStopping(result) ||
+      options.commandCategory === "daemon-lifecycle" ||
+      !options.userRoot ||
+      !options.daemonId
+    )
+      return result;
     const { readDaemonPid } = await import("../../../daemon/src/daemon-singleton.ts"),
       { DaemonAutostartError, ensureLocalDaemonRunning, waitForDaemonGenerationChange } = await import(
         "../../../daemon/src/client/daemon-autostart.ts"

--- a/packages/cli/src/daemon/with-autostart.ts
+++ b/packages/cli/src/daemon/with-autostart.ts
@@ -1,5 +1,6 @@
 import type { DaemonLaunchSpec } from "../../../daemon/src/client/daemon-autostart.ts";
 import type { JsonObject } from "../../../daemon/src/protocol/json-rpc-types.ts";
+import { renderCliGuidance } from "../cli/guidance-plane.ts";
 
 // The autostart seam is imported lazily so the thin dist static import graph stays
 // entry/parser/transport-only; it is only reachable on a connection-level failure.
@@ -92,7 +93,7 @@ function isDaemonStopping(result: JsonObject): boolean {
 
 function daemonRestartingReceipt(waitedMs: number, retries: number): JsonObject {
   const waitedSeconds = Math.ceil(waitedMs / 1_000),
-    hint = `daemon is restarting (old build -> new build); waited ${waitedSeconds}s but it is not ready`;
+    hint = renderCliGuidance("daemon-restarting", { waitedSeconds });
   return {
     ok: false,
     code: "daemon_restarting",

--- a/packages/cli/test/daemon-restart-window.test.ts
+++ b/packages/cli/test/daemon-restart-window.test.ts
@@ -1,0 +1,84 @@
+// harness-test-tier: fast
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { createServer } from "node:net";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { daemonPidPath } from "../../daemon/src/daemon-singleton.ts";
+import type { DaemonLaunchSpec } from "../../daemon/src/client/daemon-autostart.ts";
+import { withAutostart } from "../src/daemon/with-autostart.ts";
+
+const unusedLaunch = (): DaemonLaunchSpec => ({ command: process.execPath, args: [], env: {} });
+
+test("daemon_stopping waits for the replacement generation and resends exactly once", async () => {
+  const parent = mkdtempSync(path.join(tmpdir(), "ha-restart-ready-")),
+    socketPath = path.join(parent, "daemon.sock"),
+    daemonId = "restart-ready",
+    pidPath = daemonPidPath(parent, daemonId),
+    server = createServer(),
+    receipts = [
+      { ok: false, code: "daemon_stopping" },
+      { ok: true, outcome: "applied" },
+    ],
+    request = async () => receipts.shift()!;
+  writeFileSync(pidPath, "111\n");
+  const replace = setTimeout(() => {
+    writeFileSync(pidPath, "222\n");
+    server.listen(socketPath);
+  }, 20);
+  try {
+    const result = await withAutostart(request, unusedLaunch, socketPath, {
+      autostart: true,
+      env: {},
+      invokingRoot: process.cwd(),
+      userRoot: parent,
+      daemonId,
+      restartBudgetMs: 1_000,
+    });
+    assert.equal(result.outcome, "applied");
+    assert.deepEqual(result.daemonRestart, {
+      waitedMs: (result.daemonRestart as { waitedMs: number }).waitedMs,
+      retries: 1,
+    });
+    assert.equal(receipts.length, 0, "the original request is resent exactly once");
+  } finally {
+    clearTimeout(replace);
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+    rmSync(parent, { recursive: true, force: true });
+  }
+});
+
+test("restart budget exhaustion returns daemon_restarting without resending", async () => {
+  const parent = mkdtempSync(path.join(tmpdir(), "ha-restart-timeout-")),
+    daemonId = "restart-timeout",
+    calls: number[] = [];
+  writeFileSync(daemonPidPath(parent, daemonId), "111\n");
+  try {
+    const result = await withAutostart(
+      async () => {
+        calls.push(Date.now());
+        return { ok: false, code: "daemon_stopping" };
+      },
+      unusedLaunch,
+      path.join(parent, "missing.sock"),
+      {
+        autostart: true,
+        env: {},
+        invokingRoot: process.cwd(),
+        userRoot: parent,
+        daemonId,
+        restartBudgetMs: 25,
+      },
+    );
+    assert.equal(result.code, "daemon_restarting");
+    assert.match(String((result.error as { hint: string }).hint), /old build -> new build.*waited 1s/u);
+    assert.deepEqual(result.daemonRestart, {
+      waitedMs: (result.daemonRestart as { waitedMs: number }).waitedMs,
+      retries: 0,
+    });
+    assert.equal(calls.length, 1);
+  } finally {
+    rmSync(parent, { recursive: true, force: true });
+  }
+});

--- a/packages/cli/test/daemon-restart-window.test.ts
+++ b/packages/cli/test/daemon-restart-window.test.ts
@@ -35,6 +35,7 @@ test("daemon_stopping waits for the replacement generation and resends exactly o
       userRoot: parent,
       daemonId,
       restartBudgetMs: 1_000,
+      commandCategory: "operation",
     });
     assert.equal(result.outcome, "applied");
     assert.deepEqual(result.daemonRestart, {
@@ -69,6 +70,7 @@ test("restart budget exhaustion returns daemon_restarting without resending", as
         userRoot: parent,
         daemonId,
         restartBudgetMs: 25,
+        commandCategory: "operation",
       },
     );
     assert.equal(result.code, "daemon_restarting");
@@ -78,6 +80,36 @@ test("restart budget exhaustion returns daemon_restarting without resending", as
       retries: 0,
     });
     assert.equal(calls.length, 1);
+  } finally {
+    rmSync(parent, { recursive: true, force: true });
+  }
+});
+
+test("daemon lifecycle commands preserve daemon_stopping without waiting or resending", async () => {
+  const parent = mkdtempSync(path.join(tmpdir(), "ha-restart-lifecycle-")),
+    daemonId = "restart-lifecycle";
+  writeFileSync(daemonPidPath(parent, daemonId), "111\n");
+  let calls = 0;
+  try {
+    const result = await withAutostart(
+      async () => {
+        calls += 1;
+        return { ok: false, code: "daemon_stopping" };
+      },
+      unusedLaunch,
+      path.join(parent, "daemon.sock"),
+      {
+        autostart: true,
+        env: {},
+        invokingRoot: process.cwd(),
+        userRoot: parent,
+        daemonId,
+        restartBudgetMs: 1_000,
+        commandCategory: "daemon-lifecycle",
+      },
+    );
+    assert.equal(result.code, "daemon_stopping");
+    assert.equal(calls, 1);
   } finally {
     rmSync(parent, { recursive: true, force: true });
   }

--- a/packages/cli/test/daemon-stop-drain-window.test.ts
+++ b/packages/cli/test/daemon-stop-drain-window.test.ts
@@ -29,8 +29,8 @@ test("a drain longer than the stop budget is reported as draining, not as a time
   try {
     const stopStartedAt = Date.now(),
       stop = runCli(fixture, ["daemon", "stop", "--json"]);
-    // The refusal is what marks the drain as begun, so every observation below is inside the window.
-    const refused = await waitForStoppingRefusal(fixture),
+    // The lifecycle observation marks the drain as begun, so everything below is inside the window.
+    const stopping = await waitForStoppingObservation(fixture),
       inWindow = await snapshot(fixture),
       status = await runCli(fixture, ["daemon", "status", "--json"]);
     const stopped = JSON.parse((await stop).stdout) as Record<string, unknown>;
@@ -48,8 +48,8 @@ test("a drain longer than the stop budget is reported as draining, not as a time
     assert.equal(reported.ok, true, JSON.stringify(reported));
     assert.match(String(reported.summary), /Stopping: draining \d+ live runtime session\(s\)/u);
     assert.ok(
-      refused.elapsedMs < drainMs,
-      `a draining daemon must answer at once, not be waited out: ${refused.elapsedMs}ms`,
+      stopping.elapsedMs < drainMs,
+      `a draining daemon must answer at once, not be waited out: ${stopping.elapsedMs}ms`,
     );
 
     await waitForRelease(fixture);
@@ -207,14 +207,17 @@ async function snapshot(
 }
 
 // Before the stop request lands the daemon still serves normally, so the fixture waits for the first
-// refusal rather than assuming a freshly spawned `daemon stop` has already reached it.
-async function waitForStoppingRefusal(fixture: Fixture): Promise<CliRun> {
+// lifecycle observation rather than assuming a freshly spawned `daemon stop` has already reached it.
+async function waitForStoppingObservation(fixture: Fixture): Promise<CliRun> {
   const deadline = Date.now() + drainMs;
   for (;;) {
-    const run = await runCli(fixture, ["task", "list", "--json"], "env"),
-      receipt = JSON.parse(run.stdout) as { readonly code?: string };
-    if (receipt.code === "daemon_stopping") return run;
-    if (Date.now() > deadline) throw new Error(`daemon ${fixture.daemonId} never refused new work: ${run.stdout}`);
+    // A normal repository command intentionally waits for a replacement generation during
+    // daemon_stopping. Probe through the daemon lifecycle surface instead: lifecycle commands
+    // must report the active drain immediately and must never trigger restart-window recovery.
+    const run = await runCli(fixture, ["daemon", "status", "--json"]),
+      receipt = JSON.parse(run.stdout) as { readonly summary?: string };
+    if (/Stopping: draining/u.test(receipt.summary ?? "")) return run;
+    if (Date.now() > deadline) throw new Error(`daemon ${fixture.daemonId} never reported its drain: ${run.stdout}`);
     await delay(50);
   }
 }

--- a/packages/daemon/src/client/daemon-autostart.ts
+++ b/packages/daemon/src/client/daemon-autostart.ts
@@ -35,6 +35,10 @@ export interface DaemonStartProgress {
   readonly fingerprint: string;
   readonly message: string;
 }
+export interface DaemonGenerationWaitResult {
+  readonly ok: boolean;
+  readonly waitedMs: number;
+}
 export class DaemonAutostartError extends Error {
   readonly code: DaemonAutostartFailureCode;
   readonly attempts: number;
@@ -95,6 +99,7 @@ export async function ensureLocalDaemonRunning(input: {
   readonly probe?: (socketPath: string) => Promise<boolean>;
   readonly spawnDetached?: (launch: DaemonLaunchSpec) => Promise<void>;
   readonly onProgress?: (progress: DaemonStartProgress) => void;
+  readonly extendTimeoutWhileProgressing?: boolean;
 }): Promise<DaemonAutostartResult> {
   const readyTimeoutMs = input.readyTimeoutMs ?? 10_000,
     probeIntervalMs = input.probeIntervalMs ?? 50;
@@ -142,7 +147,7 @@ export async function ensureLocalDaemonRunning(input: {
     }
     const startedAt = Date.now(),
       quietDeadline = startedAt + readyTimeoutMs,
-      progressDeadline = startedAt + readyTimeoutMs * 6;
+      progressDeadline = startedAt + readyTimeoutMs * (input.extendTimeoutWhileProgressing === false ? 1 : 6);
     for (;;) {
       if (await ready()) return { ok: true, hint: "daemon is reachable", attempts: spawned ? 1 : 0 };
       const progress = readDaemonStartProgress(launched, Date.now() - startedAt);
@@ -182,6 +187,21 @@ export async function ensureLocalDaemonRunning(input: {
       launched ? daemonLaunchOutputPath(launched) : "the daemon lifecycle log"
     }.`,
   };
+}
+export async function waitForDaemonGenerationChange(input: {
+  readonly previousPid: number | null;
+  readonly readPid: () => number | null;
+  readonly timeoutMs: number;
+  readonly pollIntervalMs?: number;
+}): Promise<DaemonGenerationWaitResult> {
+  const startedAt = Date.now(),
+    deadline = startedAt + input.timeoutMs,
+    pollIntervalMs = input.pollIntervalMs ?? 50;
+  for (;;) {
+    if (input.readPid() !== input.previousPid) return { ok: true, waitedMs: Date.now() - startedAt };
+    if (Date.now() >= deadline) return { ok: false, waitedMs: Date.now() - startedAt };
+    await delay(pollIntervalMs);
+  }
 }
 /** Where a launched daemon's fatal stdout/stderr lands; the hint the user is told to inspect. */
 export function daemonLaunchOutputPath(launch: DaemonLaunchSpec): string | undefined {


### PR DESCRIPTION
# English

## Summary
A canonical-root `git pull` rebuilds the CLI and makes the resident daemon restart itself. Requests that land in that window were rejected outright with `daemon_stopping` (seen again today while dispatching workers) or, earlier, answered by a half-ready replacement with semantic false errors (task_9d539e4b). The CLI now treats an explicit `daemon_stopping` receipt as a bounded generation transition.

- `with-autostart.ts`: on `daemon_stopping`, wait for the outgoing pid generation to change, reuse the existing autostart readiness probe for the replacement, and resend the identical request exactly once. Total budget 30 s; on exhaustion the receipt is `daemon_restarting` with the wait time in the hint and `daemonRestart.retries` in evidence.
- Callers that may not spawn a daemon (runtime-bound, non-canonical checkout) still wait for a supervisor-owned replacement but never inherit spawn authority.
- `daemon-autostart.ts`: `waitForDaemonGenerationChange` helper; `client.ts` passes userRoot/daemonId through; `guidance-plane.ts` renders the new code.
- Daemon side confirmed, not changed: it binds before repository attachment and queues accepted repository commands until attachment settles, so the replacement cannot answer from an uninitialized projection.

## Architectural Justification
One replay on one explicit signal, riding the autostart path that already exists; no generic retry layer, no change to drain semantics or to when `daemon_stopping` is produced. Plain ENOENT/ECONNREFUSED stay with the existing connection-level autostart.

## Verification
- `packages/cli/test/daemon-restart-window.test.ts`: 2/2 (drain → replacement ready → one replay succeeds; budget exhausted → `daemon_restarting`).
- `daemon-build-drain.integration.test.ts`: 6/6; typecheck, targeted eslint, `git diff --check`: pass. No canonical-daemon restart experiment was run.

## Review Evidence
- Implemented by Sol from the task plan; CEO read the full `with-autostart.ts` diff against the plan's constraints (one replay, explicit signal only, budget visible in the receipt).

## Residual Risk
- The wait is keyed on the pid-file generation; a supervisor that restarts without touching the pid file would exhaust the budget and surface `daemon_restarting` rather than hang.

Production-Delta: +131/-10
Deleted-Production-Paths: none

---

# 中文

## 摘要
canonical 根 `git pull` 会重建 CLI 并让常驻 daemon 自愈重启。落在这个窗口里的请求要么被 `daemon_stopping` 直接拒绝(今天派工时再次实测),要么此前被半就绪的新进程答成语义假错(task_9d539e4b)。CLI 现在把显式的 `daemon_stopping` 回执当作有界的代际切换处理。

- `with-autostart.ts`:收到 `daemon_stopping` 后等待旧 pid 代际变化,复用现有 autostart 就绪探测等新进程,然后把同一请求**只重发一次**。总预算 30 s;耗尽则回执 `daemon_restarting`,hint 写明等待时长,evidence 带 `daemonRestart.retries`。
- 不允许拉起 daemon 的调用方(runtime 绑定、非 canonical checkout)仍可等待由 supervisor 拉起的新进程,但不会因此获得拉起权限。
- `daemon-autostart.ts` 新增 `waitForDaemonGenerationChange`;`client.ts` 透传 userRoot/daemonId;`guidance-plane.ts` 渲染新码。
- daemon 侧只确认未改:它先绑定再挂仓库,已接受的仓库命令排队到挂载完成,新进程不会用未初始化的投影应答。

## 架构辩护
一个显式信号、一次重发,搭在已有的 autostart 路径上;没有通用重试层,不改 drain 语义,不改 `daemon_stopping` 的产生条件。普通 ENOENT/ECONNREFUSED 仍归现有连接级 autostart。

## 验证
- `packages/cli/test/daemon-restart-window.test.ts`:2/2(drain → 新进程就绪 → 一次重发成功;预算耗尽 → `daemon_restarting`)。
- `daemon-build-drain.integration.test.ts`:6/6;typecheck、定向 eslint、`git diff --check` 通过。未对 canonical daemon 做重启实验。

## 复核证据
- Sol 按任务 plan 实现;CEO 对照 plan 约束(只重发一次、只认显式信号、预算在回执可见)读了 `with-autostart.ts` 全部 diff。

## 残余风险
- 等待以 pid 文件代际为键;若某 supervisor 重启时不动 pid 文件,会耗尽预算返回 `daemon_restarting` 而不是挂住。
