### PR TITLE
docs: localize installation guide and add star history charts

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ then gates *"done"* so progress compounds instead of evaporating into chat.
 </p>
 
 <p>
-  <a href="https://skills.sh/FairladyZ625/harness-anything"><img alt="Skills 安装" src="https://skills.sh/b/FairladyZ625/harness-anything"></a>
+  <a href="https://skills.sh/FairladyZ625/harness-anything"><img alt="Skills installs" src="https://skills.sh/b/FairladyZ625/harness-anything"></a>
   <a href="https://github.com/FairladyZ625/harness-anything/actions/workflows/rewrite-ci.yml"><img alt="CI" src="https://github.com/FairladyZ625/harness-anything/actions/workflows/rewrite-ci.yml/badge.svg"></a>
   <a href="https://github.com/FairladyZ625/harness-anything/actions/workflows/pr-body.yml"><img alt="PR body checks" src="https://github.com/FairladyZ625/harness-anything/actions/workflows/pr-body.yml/badge.svg"></a>
   <a href="https://github.com/FairladyZ625/harness-anything/stargazers"><img alt="GitHub stars" src="https://img.shields.io/github/stars/FairladyZ625/harness-anything?style=flat&logo=github&color=yellow"></a>
@@ -124,46 +124,69 @@ contributor hot-reload tool.
 Ready to use it on a project? Continue with the
 [Start guide](./docs-release/start/en/00-what-is-this.md).
 
-### 通过 Skills 生态一段话完成安装
+### Install through the Skills ecosystem
 
-先把引导技能装到你使用的 Agent。下面以 Codex 和 Claude Code 为例；可以删掉不用的 Agent 参数，或交互选择其他受支持的 Agent：
+Install the onboarding skill for the agents you use. This example selects Codex
+and Claude Code; omit an agent you do not use, or choose other supported agents
+interactively:
 
 ```bash
 bunx skills add FairladyZ625/harness-anything --skill harness-download -g -a codex claude-code
 ```
 
-没有 Bun 时，把 `bunx` 换成 `npx` 即可。Bun 运行的是 Skills 安装器；Harness 当前仍使用 Node 24+ 和持久源码运行。
+Without Bun, replace `bunx` with `npx`. Bun runs the Skills installer; Harness
+itself currently runs on Node 24+ from a persistent source checkout.
 
-然后在目标项目里给 Agent 这一段话：
+Then give your agent this prompt from the target project:
 
-> 使用 harness-download 带我完成 Harness Anything 首次接入：检查环境，把源码放到持久目录，将整套技能软链接到我选定的 Agent 用户目录，然后继续初始化当前仓库、建立主控知识入口，并用 harness-ceo 带完一个真实任务。能从项目和环境查到的信息请直接读取；需要我选择或批准时，给出具体方案后再问，已确认内容不要重复确认。
+> Use harness-download to guide me through first-time Harness Anything setup:
+> check the environment, download the source to a persistent directory, symlink
+> the full skill set into my selected agents' user directories, then initialize
+> this repository, set up the CEO knowledge locations, and complete one real
+> task with harness-ceo. Read information available in the project and environment
+> directly. When a choice or approval is needed, show me the concrete proposal
+> first, and do not ask again about something I have already confirmed.
 
-整个流程连续完成：
+The agent continues through each stage:
 
-| 技能 | 负责什么 |
+| Skill | Responsibility |
 | --- | --- |
-| [harness-download](./skills/harness-download/SKILL.md) | 准备环境、下载持久源码、链接整套技能，并协调后续引导 |
-| [harness-install](./skills/harness-install/SKILL.md) | 把可用的 Harness 接入指定仓库，保留既有指令与身份审批 |
-| [harness-ceo](./skills/harness-ceo/SKILL.md) | 初始化用户知识位置、选择模型、开展真实工作并验证交付 |
+| [harness-download](./skills/harness-download/SKILL.md) | Prepare the environment and persistent source checkout, link the skills, and coordinate the remaining setup |
+| [harness-install](./skills/harness-install/SKILL.md) | Adopt the available Harness installation in a target repository, preserving existing instructions and identity approvals |
+| [harness-ceo](./skills/harness-ceo/SKILL.md) | Initialize user-owned knowledge locations, select models, carry out real work, and verify delivery |
 
-下载工具只做一次；接入另一个仓库时直接使用 `harness-install`，日常工作使用 `harness-ceo`。用户矩阵、问题记录和反馈保留在工作区，升级公共技能不覆盖。
+Download the tools once. Use `harness-install` for another repository and
+`harness-ceo` for daily work. User model matrices, issue records, and feedback
+stay in the workspace; public skill updates do not overwrite them.
 
-也可以查看或直接安装仓库里的整组技能：
+You can also inspect or install the complete skill set:
 
 ```bash
 bunx skills add FairladyZ625/harness-anything --list
 bunx skills add FairladyZ625/harness-anything --skill '*' -g -a codex claude-code
 ```
 
-Skills CLI 的安装副本与源码安装不是同一回事。下载引导随后会把所选 Agent 的技能接到持久源码；已有同名定制内容先检查冲突，不自动覆盖。源码目录移走会使链接失效，因此不放临时目录。
+The Skills CLI's installed copy is separate from the source installation. The
+onboarding flow then links the selected agents to the persistent source checkout.
+Existing customized skills with the same name are checked for conflicts, not
+automatically overwritten. Moving the source directory breaks those links, so do
+not keep it in a temporary location.
 
-如果没有安装 Skills CLI，也可直接把这句话发给 Agent：
+You can also start without installing the Skills CLI by sending this prompt:
 
-> 读取 https://github.com/FairladyZ625/harness-anything 中的 `skills/harness-download/SKILL.md`，按它完成上述首次引导，并在各阶段继续执行。
+> Read `skills/harness-download/SKILL.md` from
+> https://github.com/FairladyZ625/harness-anything and follow it through the
+> first-time setup described above, continuing from one stage to the next.
 
-已有当前可用台账会直接复用；明确属于旧代时才走 [harness-migration](./skills/harness-migration/SKILL.md)，不会因目录已存在就覆盖或自动迁移。
+An existing, usable current-generation ledger is reused. Only an identified older
+generation is routed to [harness-migration](./skills/harness-migration/SKILL.md);
+an existing directory alone does not authorize overwriting or migration.
 
-安装语法与目录选择见 [Skills CLI 官方说明](https://github.com/vercel-labs/skills)。技能可以直接从 GitHub 发现；[skills.sh](https://skills.sh/docs) 的展示与收录由其服务处理，不以仓库内新增文档作为已收录证明。
+See the [official Skills CLI documentation](https://github.com/vercel-labs/skills)
+for installation syntax and agent directory selection. Skills can be discovered
+directly from GitHub. Listing and indexing on [skills.sh](https://skills.sh/docs)
+are controlled by that service; adding repository documentation does not prove
+that the service has indexed it.
 
 ## Breaking change: existing repositories must migrate
 
@@ -216,7 +239,7 @@ The result is a repository that remembers more than its code:
 - [Learn](./docs-release/learn/en/00-overview.md) — understand the memory model, gates, and compounding loop. ([中文](./docs-release/learn/zh/00-overview.md))
 - [Architecture](./docs-release/architecture/en/00-overview.md) — explore the kernel, storage model, write path, and projections. ([中文](./docs-release/architecture/zh/00-overview.md))
 - [Release posture](./docs-release/release-posture.md) — see what is shipped, foundational, or planned.
-- [Harness 主控编排](./skills/harness-ceo/SKILL.md) — 模型无关的派工、证据验收，以及用户自有模型矩阵的接入与迭代方法。
+- [Harness CEO](./skills/harness-ceo/SKILL.md) — model-neutral delegation, evidence-based acceptance, and onboarding and improvement methods for user-owned model matrices.
 - [Migration](./docs-release/migration-genesis-replay.md) — replay an older-generation ledger into the current format. ([agent skill](./skills/harness-migration/SKILL.md))
 - [Ledger recovery](./docs-release/migration-legacy-ledger-recovery.md) — repair a repository whose legacy ledger the current daemon refuses to attach. ([中文](./docs-release/migration-legacy-ledger-recovery.zh-CN.md))
 - [Minimal example](./examples/minimal-project/) — inspect the smallest working project.

--- a/README.md
+++ b/README.md
@@ -254,3 +254,7 @@ documentation fixes are especially useful right now. See
 
 [AGPL-3.0-or-later](./LICENSE). Harness Anything stays open, including when it
 is offered as a service.
+
+## Star History
+
+[![Star History Chart](https://api.star-history.com/svg?repos=FairladyZ625/harness-anything&type=Date)](https://star-history.com/#FairladyZ625/harness-anything&Date)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -201,3 +201,7 @@ Harness Anything 用三个长期存在的原语承载 agent 工作：
 ## License
 
 [AGPL-3.0-or-later](./LICENSE)。Harness Anything 保持开源，包括有人把它作为服务提供时。
+
+## Star 趋势
+
+[![GitHub Star 增长趋势图](https://api.star-history.com/svg?repos=FairladyZ625/harness-anything&type=Date)](https://star-history.com/#FairladyZ625/harness-anything&Date)


### PR DESCRIPTION
# English

## Summary

Use English for the Skills installation section in the English README, and add a Star History chart to both READMEs. Keep skill content Chinese and existing Chinese installation prose unchanged.

## Architectural Justification

Documentation wording only; no architecture change.

## What Changed

Translate the new onboarding heading, instructions, prompts, table, badge text, and CEO documentation link into English. Add linked Star History charts with localized headings to both READMEs. Preserve every bash command verbatim.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none

## Machine-Readable Declarations

Production-Delta: +0/-0

### Optional Evidence Claims

No runtime or performance claim.

## Task And Scope

- Harness task: maintainer language correction; no ledger completion claimed.
- Branch: codex/readme-install-language.
- Public scope: README.md and README.zh-CN.md.
- Private planning/evidence updated: not applicable.
- Out of scope: skill content, installation commands, runtime behavior.

## Version Impact

- No version change: documentation wording only.
- Publish impact: GitHub README update; no package publication.

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none
- Authority: not applicable
- Machine-check boundary: the declaration does not replace diff review.
- Break-glass: no

## Verification

- Base and merge-base: f1f6e0a2aa3d994b5d8ce16974826408f9c4ee02.
- Last fetch: 2026-09-05, following PR #2278 integration.
- Sync method: branch from origin/main.
- Public diff: git diff origin/main...HEAD.
- Private evidence: not applicable.
- Reviewer evidence: direct before/after comparison.
- GitHub Actions run: pending push checks.
- git diff --check passed.
- Verified all bash code blocks match the prior version exactly.
- Verified the installation section contains English prose and only the two README files changed.
- Not run: runtime tests, because commands and behavior are unchanged.

## Review Evidence

- Self-review: compared language and preserved commands.
- Reviewer subagent: not needed for this wording-only correction.
- Human review: maintainer explicitly requested the locale correction.
- Blocking findings: none from scoped inspection.

## Residual Risk

No runtime behavior changed. The chart is served by Star History, so image availability depends on that service. The skill instructions remain Chinese by design.

## References

- Task: maintainer follow-up to PR #2278.
- Evidence: direct diff and command-block comparison.
- Review: scoped self-review above.

---

# 中文

## 概要

英文 README 的安装引导改为英文；中英文 README 都增加 Star 趋势图，标题各用对应语言。技能正文仍保留中文。

## 架构辩护

只修改文案，没有架构变化。

## 改动内容

翻译新增安装区段的标题、说明、提示词、表格、徽章文字与主控文档链接。同时给两份 README 增加带链接的 Star 趋势图。所有 bash 命令原样保留。

## 门收割 / Gate Harvest

没有删除生产路径或门；机读声明仅在英文块出现。

## 机读声明说明

生产增删均为零，没有运行时或性能声明。

## 任务与范围

- Harness 任务：维护者要求的语言修正，不宣称台账任务完成。
- 分支：codex/readme-install-language。
- 公开范围：README.md 和 README.zh-CN.md。
- 私有证据：不适用。
- 范围外：技能内容、安装命令和运行时行为。

## 版本影响

不改版本，只更新 GitHub README，不发布包。

## 治理声明

- 是否触碰 protected surface：no。
- 范围：无。
- 依据：不适用。
- 机器检查不替代差异审阅。
- Break-glass：no。

## 验证

基准及 merge-base 为 f1f6e0a2aa3d994b5d8ce16974826408f9c4ee02；2026-09-05 随前一个 PR 集成同步。从 origin/main 建分支，差异命令为 git diff origin/main...HEAD。

git diff --check 通过。逐段确认 bash 命令与修改前一致，安装区段为英文且只有两份 README 变更。没有重跑运行时测试，因为命令与行为未改；CI 待推送后检查。

## 审查证据

已做文案与命令对照。维护者明确要求了本次语言边界。简单文字修正未另派代理；定向检查没有阻断发现。

## 残余风险

不改变运行时行为；技能说明按要求继续使用中文。趋势图由 Star History 提供，图片可用性依赖其服务。

## 关联材料

PR #2278 的维护者后续修正；证据为本次直接差异与命令对照。

---

## PR Gate Checklist / PR 门禁清单

- [x] Scoped documentation change only. / 仅限定文档变更。
- [x] Bilingual PR body and no private files. / 双语 PR 正文，不含私有文件。
- [x] Commands unchanged and diff checked. / 命令不变，已核对差异。
- [ ] Required checks passed before merge. / 必需检查通过后合并。
- [ ] Merge commit and cleanup of owned branch. / 普通合并并清理本分支。
- [x] No bypass planned. / 不计划绕过。
