### PR TITLE
fix(daemon): preserve provider fault classification on runtime loss

### DIFF
--- a/packages/daemon/src/runtime-provider-fault.ts
+++ b/packages/daemon/src/runtime-provider-fault.ts
@@ -73,19 +73,15 @@ export function classifyRuntimeExit(
       attemptGroupId,
       attemptIndex,
     });
-  if (active.cancelRequested || active.lossReason)
-    return classified(
-      "worker_stop",
-      active.cancelRequested
-        ? "Worker stop was requested."
-        : `Worker process stopped before settlement: ${active.lossReason}`,
-    );
+  if (active.cancelRequested) return classified("worker_stop", "Worker stop was requested.");
   if (attemptFailed && providerFault)
     return {
       ...classified("provider_fault", providerFault.reason),
       ...(providerFault.faultClass ? { faultClass: providerFault.faultClass } : {}),
       ...(providerFault.resetAt ? { resetAt: providerFault.resetAt } : {}),
     };
+  if (active.lossReason)
+    return classified("worker_stop", `Worker process stopped before settlement: ${active.lossReason}`);
   if (exitCode === null)
     return classified("provider_fault", "Provider process disconnected before completing the attempt.");
   if (attemptFailed && !active.toolCallObserved) {

--- a/packages/daemon/test/runtime-provider-fault.test.ts
+++ b/packages/daemon/test/runtime-provider-fault.test.ts
@@ -163,6 +163,27 @@ test("attempt-bound classification falls back only before tools or for recognize
   assert.equal(classifyRuntimeExit(recovered, 1).classification, "gate_red");
 });
 
+test("observed provider fault takes precedence over a later runtime loss", () => {
+  const result = classifyRuntimeExit(
+    active({
+      lossReason: "runtime process disappeared",
+      providerFault: {
+        code: "quota_exhausted",
+        faultClass: "quota_exhausted",
+        reason: "HTTP 429: insufficient_quota credit balance exhausted",
+        resetAt: "2026-09-06T05:06:07.000Z",
+      },
+    }),
+    null,
+  );
+
+  assert.equal(result.outcome, "unknown");
+  assert.equal(result.classification, "provider_fault");
+  assert.equal(result.faultClass, "quota_exhausted");
+  assert.equal(result.resetAt, "2026-09-06T05:06:07.000Z");
+  assert.equal(result.reason, "HTTP 429: insufficient_quota credit balance exhausted");
+});
+
 function active(overrides: Partial<ActiveRuntime>): ActiveRuntime {
   return {
     dispatchId: "dispatch_0123456789abcdef01234567",


### PR DESCRIPTION
# English

## Summary
Follow-up to #2280 from its independent review (rev_fault429_r1, task_7c0adfe6): `classifyRuntimeExit` checked `cancelRequested || lossReason` before `providerFault`, so a run that produced a structured 429 fault and then lost its stream settled as `worker_stop` and dropped `faultClass` / `resetAt`. Priority is now explicit cancel → observed provider fault → loss reason.

## Verification
- New regression in `runtime-provider-fault.test.ts`: fault + lossReason → `provider_fault` with class and reset preserved (red before the fix, 7/7 after).
- typecheck, eslint, prettier, `git diff --check`: pass.

## Review Evidence
- Fix by Sol from the reviewer's finding; CEO read the 10-line priority change.

## Residual Risk
- None new. Genuine reconnect exhaustion still reports through the daemon-gone path.

Production-Delta: +3/-7
Deleted-Production-Paths: none

---

# 中文

## 摘要
#2280 独立复核(rev_fault429_r1,task_7c0adfe6)的跟进:`classifyRuntimeExit` 先查 `cancelRequested || lossReason` 再查 `providerFault`,于是先产出结构化 429 fault、随后流失联的运行被结算成 `worker_stop`,`faultClass` / `resetAt` 丢失。现在优先级明确为:显式取消 → 已观测到的 provider fault → 失联原因。

## 验证
- `runtime-provider-fault.test.ts` 新增回归:fault + lossReason → `provider_fault` 且类别与 reset 保留(修复前红,修复后 7/7)。
- typecheck、eslint、prettier、`git diff --check` 通过。

## 复核证据
- Sol 按复核 finding 修复;CEO 读了这 10 行优先级改动。

## 残余风险
- 无新增。真正的重连耗尽仍走 daemon-gone 路径。
