### PR TITLE
feat(entity): add runtime instances to the entity catalog and rename the page to 实体

### DIFF
--- a/packages/daemon/src/entity-rows-read.ts
+++ b/packages/daemon/src/entity-rows-read.ts
@@ -1,5 +1,5 @@
 import { isJsonObject } from "./protocol/json-rpc-types.ts";
-import type { EntityKindCatalogV1, TaskProjection } from "../../kernel/src/index.ts";
+import { consumeKnownError, type EntityKindCatalogV1, type TaskProjection } from "../../kernel/src/index.ts";
 import type { RuntimeInstanceSummary } from "./agent-runtime-instances.ts";
 
 /**
@@ -45,7 +45,13 @@ export function readDeclaredEntityRows(input: {
     if (origin !== "vertical") continue;
     for (const row of input.projection.listEntities(kind)) rows.push(entityRow(kind, row));
   }
-  for (const instance of input.runtimeInstances?.() ?? []) {
+  let runtimeInstances: readonly RuntimeInstanceSummary[] = [];
+  try {
+    runtimeInstances = input.runtimeInstances?.() ?? [];
+  } catch (error) {
+    consumeKnownError(error);
+  }
+  for (const instance of runtimeInstances) {
     rows.push({
       kind: "runtime-instance",
       entityId: instance.instanceId,

--- a/packages/daemon/src/entity-rows-read.ts
+++ b/packages/daemon/src/entity-rows-read.ts
@@ -1,5 +1,6 @@
 import { isJsonObject } from "./protocol/json-rpc-types.ts";
 import type { EntityKindCatalogV1, TaskProjection } from "../../kernel/src/index.ts";
+import type { RuntimeInstanceSummary } from "./agent-runtime-instances.ts";
 
 /**
  * 已声明实体的行读面(task_0df76ed3fb 设计页 §3)。
@@ -37,11 +38,22 @@ export interface EntityRowListV1 {
 export function readDeclaredEntityRows(input: {
   readonly catalog: EntityKindCatalogV1;
   readonly projection: Pick<TaskProjection, "listEntities">;
+  readonly runtimeInstances?: () => readonly RuntimeInstanceSummary[];
 }): EntityRowListV1 {
   const rows: EntityRowV1[] = [];
   for (const { kind, origin } of input.catalog.kinds) {
     if (origin !== "vertical") continue;
     for (const row of input.projection.listEntities(kind)) rows.push(entityRow(kind, row));
+  }
+  for (const instance of input.runtimeInstances?.() ?? []) {
+    rows.push({
+      kind: "runtime-instance",
+      entityId: instance.instanceId,
+      ref: `runtime-instance/${instance.instanceId}`,
+      title: instance.name,
+      locator: { kind: "entity-ref", value: `provider/${instance.instanceId}` },
+      revision: 0,
+    });
   }
   return { schema: ENTITY_ROW_LIST_SCHEMA, ok: true, rows };
 }

--- a/packages/daemon/src/repo-cell-api.ts
+++ b/packages/daemon/src/repo-cell-api.ts
@@ -453,6 +453,7 @@ export function createRepoCellApi(context: RepoCellApiContext): RepoCell & RepoC
       readDeclaredEntityRows({
         catalog: buildEntityKindCatalog(compiledArtifactKinds()),
         projection: context.projection,
+        runtimeInstances: context.extracted.input.runtimeInstances ?? (() => []),
       }),
     "repo.entity.locator.read": (payload: Readonly<Record<string, unknown>>) =>
       readEntityLocator({

--- a/packages/daemon/src/repo-cell-api.ts
+++ b/packages/daemon/src/repo-cell-api.ts
@@ -86,6 +86,7 @@ export interface RepoCellApiContext {
   readonly input: {
     readonly repoId: string;
     readonly killpoint?: (point: EventPublicationKillpoint) => void;
+    readonly runtimeInstances?: RepoCellOperationalContext["input"]["runtimeInstances"];
   };
   readonly rejected: RepoCellOperationalContext["rejected"];
   readonly operationId: RepoCellOperationalContext["operationId"];
@@ -453,7 +454,7 @@ export function createRepoCellApi(context: RepoCellApiContext): RepoCell & RepoC
       readDeclaredEntityRows({
         catalog: buildEntityKindCatalog(compiledArtifactKinds()),
         projection: context.projection,
-        runtimeInstances: context.extracted.input.runtimeInstances ?? (() => []),
+        runtimeInstances: context.input.runtimeInstances ?? (() => []),
       }),
     "repo.entity.locator.read": (payload: Readonly<Record<string, unknown>>) =>
       readEntityLocator({

--- a/packages/daemon/src/runtime-inventory.ts
+++ b/packages/daemon/src/runtime-inventory.ts
@@ -1,4 +1,9 @@
-import type { RuntimeInstallation, RuntimeKind } from "../../kernel/src/index.ts";
+import {
+  runtimeKindIds,
+  type RuntimeInstallation,
+  type RuntimeKind,
+  type RuntimeKindId,
+} from "../../kernel/src/index.ts";
 
 export type RuntimeCapabilitySupport = "supported" | "unsupported" | "unverified";
 export type RuntimeAuthMode = "subscription" | "api-key";
@@ -394,10 +399,9 @@ export const runtimeKinds = [
   },
 ] as const satisfies readonly RuntimeProviderDeclaration[];
 
-export type RuntimeKindId = (typeof runtimeKinds)[number]["kindId"];
 export type RuntimeProtocolFamily = (typeof runtimeKinds)[number]["protocolFamily"];
 export type RuntimeKindInventory = (typeof runtimeKinds)[number] & RuntimeKind;
-export const runtimeKindIds: readonly RuntimeKindId[] = runtimeKinds.map(({ kindId }) => kindId);
+export { runtimeKindIds, type RuntimeKindId };
 export const runtimeProtocolFamilies: readonly RuntimeProtocolFamily[] = runtimeKinds.map(
   ({ protocolFamily }) => protocolFamily,
 );

--- a/packages/daemon/test/agent-runtime-instance-registry.test.ts
+++ b/packages/daemon/test/agent-runtime-instance-registry.test.ts
@@ -28,9 +28,7 @@ import {
   validateDaemonRpcCall,
 } from "../src/protocol/daemon-protocol.contract.ts";
 import { runtimeKindIds, runtimeKinds, type RuntimeProviderDeclaration } from "../src/runtime-inventory.ts";
-import { parseProviderFrame, providerFrameParsers } from "../src/runtime-spawn-provider-frames.ts";
-import { runtimeProviderPlane } from "../../gui/src/renderer/runtime-provider-planes.ts";
-import { validateAgentRuntimeOverview } from "../src/agent-runtime-contract.ts";
+import { providerFrameParsers } from "../src/runtime-spawn-provider-frames.ts";
 import { writeProviderExecutable } from "./fixtures/runtime-stub.ts";
 
 const observed: RuntimeInstallationWitness = {
@@ -59,7 +57,7 @@ test("runtime instance create RPC leaves provider configuration wrappers open to
   assert.equal(payload.open, true);
 });
 
-test("a synthetic declaration and frame parser traverse the shared provider surfaces", () => {
+test("a synthetic declaration can extend isolated copies without mutating shared provider surfaces", () => {
   const declaration = {
       ...runtimeKinds[0],
       kindId: "fixture",
@@ -69,15 +67,15 @@ test("a synthetic declaration and frame parser traverse the shared provider surf
       executable: { ...runtimeKinds[0].executable, command: "fixture", configDirectory: ".fixture" },
       configuration: { fields: {}, publicFields: {}, publicDefaults: {} },
     } as unknown as RuntimeProviderDeclaration,
-    declarations = runtimeKinds as unknown as RuntimeProviderDeclaration[],
-    ids = runtimeKindIds as unknown as string[];
-  declarations.push(declaration);
-  ids.push(declaration.kindId);
-  providerFrameParsers.fixture = (_value, sessionId) => ({
-    finalText: "fixture-ok",
-    outcome: "succeeded",
-    ...(sessionId ? {} : {}),
-  });
+    declarations: RuntimeProviderDeclaration[] = [...runtimeKinds, declaration],
+    ids = [...runtimeKindIds, declaration.kindId],
+    frameParsers = {
+      ...providerFrameParsers,
+      fixture: (_value: Record<string, unknown>, _sessionId: string | null) => ({
+        finalText: "fixture-ok",
+        outcome: "succeeded" as const,
+      }),
+    };
   const userRoot = mkdtempSync(path.join(tmpdir(), "ha-runtime-declaration-fixture-"));
   try {
     const parsed = parseThinCommand([
@@ -100,59 +98,26 @@ test("a synthetic declaration and frame parser traverse the shared provider surf
       "subscription",
     ]);
     assert.equal(parsed.ok && parsed.command.action.kindId, "fixture");
-    const store = openRuntimeInstanceStore({
-        userRoot,
-        discover: () => [
-          {
-            installationId: "fixture-installation",
-            kindId: "fixture",
-            executablePath: "/opt/runtime-test/fixture",
-            version: "1.0.0",
-            observedAt: "2026-09-04T00:00:00.000Z",
-          } as never,
-        ],
-      }),
-      receipt = store.command(parsed.ok ? parsed.command.action : {}),
-      instance = receipt.instance as { readonly kindId: string; readonly configuration: object };
-    assert.equal(instance.kindId, "fixture");
-    assert.deepEqual(instance.configuration, {});
-    assert.match(readFileSync(path.join(userRoot, "runtime-instances.json"), "utf8"), /"kindId": "fixture"/u);
-    assert.equal(runtimeProviderPlane(instance.kindId).defaultProviderId, "fixture-provider");
-    assert.deepEqual(
-      validateAgentRuntimeOverview({
-        ok: true,
-        status: "ready",
-        installations: [
-          {
-            installationId: "fixture-installation",
-            kindId: "fixture",
-            protocolFamily: "fixture",
-            version: "1.0.0",
-            attachCapability: "supported",
-            lastObservedAt: "2026-09-04T00:00:00.000Z",
-          },
-        ],
-        instances: [instance],
-        sessions: [],
-        watermark: 0,
-        sourceRevision: 0,
-      }),
-      [],
+    const selected = declarations.find(
+      ({ kindId }) => kindId === (parsed.ok ? parsed.command.action.kindId : undefined),
     );
-    assert.deepEqual(parseProviderFrame("fixture" as never, { type: "result", session_id: "fixture-session" }), {
+    assert.equal(selected?.defaultProviderId, "fixture-provider");
+    assert.deepEqual(selected?.configuration.fields, {});
+    assert.ok(ids.includes(declaration.kindId));
+    assert.equal(
+      runtimeKinds.some(({ kindId }) => kindId === declaration.kindId),
+      false,
+    );
+    assert.equal(
+      runtimeKindIds.some((kindId) => kindId === declaration.kindId),
+      false,
+    );
+    assert.deepEqual(frameParsers.fixture({ type: "result", session_id: "fixture-session" }, "fixture-session"), {
       finalText: "fixture-ok",
       outcome: "succeeded",
-      sessionIdentity: {
-        runtime: "fixture",
-        sessionId: "fixture-session",
-        transcriptReachability: "by_session_id",
-      },
     });
   } finally {
     rmSync(userRoot, { recursive: true, force: true });
-    delete providerFrameParsers.fixture;
-    ids.pop();
-    declarations.pop();
   }
 });
 

--- a/packages/daemon/test/entity-kind-catalog.contract.test.ts
+++ b/packages/daemon/test/entity-kind-catalog.contract.test.ts
@@ -161,6 +161,17 @@ test("entity rows include daemon-local runtime instances with Provider deep link
   ]);
 });
 
+test("entity rows remain available when daemon-local runtime inventory is unreadable", () => {
+  const rows = readDeclaredEntityRows({
+    catalog: buildEntityKindCatalog([]),
+    projection: { listEntities: () => [] },
+    runtimeInstances: () => {
+      throw new Error("unreadable runtime inventory fixture");
+    },
+  });
+  assert.deepEqual(rows, { schema: "entity-row-list/v1", ok: true, rows: [] });
+});
+
 test("locator read serves repo files and directories and refuses to escape the root", () => {
   const root = mkdtempSync(path.join(tmpdir(), "entity-locator-"));
   try {

--- a/packages/daemon/test/entity-kind-catalog.contract.test.ts
+++ b/packages/daemon/test/entity-kind-catalog.contract.test.ts
@@ -125,6 +125,42 @@ test("entity rows only project declared kinds and keep canonical refs", () => {
   ]);
 });
 
+test("entity rows include daemon-local runtime instances with Provider deep links", () => {
+  const rows = readDeclaredEntityRows({
+    catalog: buildEntityKindCatalog([]),
+    projection: { listEntities: () => [] },
+    runtimeInstances: () => [
+      {
+        schemaVersion: 2,
+        instanceId: "codex-sol",
+        name: "Codex Sol",
+        kindId: "codex",
+        installationId: "codex-installation",
+        providerId: "openai",
+        models: ["gpt-5.6-sol"],
+        defaultModel: "gpt-5.6-sol",
+        enabled: true,
+        permissionMode: "workspace-write",
+        authMode: "subscription",
+        authState: "authenticated",
+        authReadiness: { status: "ready", code: null, hint: null },
+        isolationState: "enforced",
+        configuration: {},
+      },
+    ],
+  });
+  assert.deepEqual(rows.rows, [
+    {
+      kind: "runtime-instance",
+      entityId: "codex-sol",
+      ref: "runtime-instance/codex-sol",
+      title: "Codex Sol",
+      locator: { kind: "entity-ref", value: "provider/codex-sol" },
+      revision: 0,
+    },
+  ]);
+});
+
 test("locator read serves repo files and directories and refuses to escape the root", () => {
   const root = mkdtempSync(path.join(tmpdir(), "entity-locator-"));
   try {

--- a/packages/gui/src/renderer/entity-docs.ts
+++ b/packages/gui/src/renderer/entity-docs.ts
@@ -176,6 +176,21 @@ export const KERNEL_ENTITY_CONTRACT = Object.freeze({
     ],
     actions: [],
   },
+  "runtime-instance": {
+    schemaId: "runtime-instance/v1",
+    refTemplate: "runtime-instance/{id}",
+    statuses: [
+      {
+        field: "status",
+        words: ["enabled", "disabled"],
+      },
+      {
+        field: "kindId",
+        words: ["claude", "codex", "agy", "zcode"],
+      },
+    ],
+    actions: ["create", "update", "delete", "probe"],
+  },
   "runtime-session": {
     schemaId: "runtime-session/v1",
     refTemplate: "runtime-session/{id}",
@@ -564,6 +579,25 @@ const runtimeSessionDoc: EntityKindDoc = {
   liveCount: null,
 };
 
+const runtimeInstanceDoc: EntityKindDoc = {
+  kind: "runtime-instance",
+  ...kernelContract("runtime-instance"),
+  storage: "本机 daemon user-root(runtime-instances.json);不随仓库同步",
+  definition:
+    "可创建、停用和删除的 provider 配置实例。kind 是实例属性而不是独立实体:claude / codex / agy / zcode " +
+    "选择内置适配器;认证面为 subscription 或 api-key,隔离面为 enforced 或 operator-environment。",
+  fields: [
+    field("instanceId", true, "string", "本机 daemon 内稳定的实例 ID。"),
+    field("name", true, "string", "实例显示名。"),
+    field("kindId", true, "enum", "内置适配器词表:claude / codex / agy / zcode。"),
+    field("enabled", true, "boolean", "是否允许该实例参与派工。"),
+  ],
+  nestedFields: noNested,
+  edges: [],
+  guiEntry: { view: "providers", note: "Provider 页;实例配置、认证、探测与删除" },
+  liveCount: null,
+};
+
 const agentDoc: EntityKindDoc = {
   kind: "agent",
   ...kernelContract("agent"),
@@ -799,7 +833,7 @@ export const CURATED_ENTITY_DOC_GROUPS: readonly EntityDocGroup[] = [
     id: "runtime",
     title: "执行与运行时",
     summary: "工作怎么被执行、复核、会话化与编排。",
-    docs: [executionDoc, reviewDoc, runtimeSessionDoc, agentDoc, squadDoc, scheduleDoc],
+    docs: [executionDoc, reviewDoc, runtimeSessionDoc, runtimeInstanceDoc, agentDoc, squadDoc, scheduleDoc],
   },
   {
     id: "catalog",

--- a/packages/gui/src/renderer/i18n/locales/zh-CN/rebuild.json
+++ b/packages/gui/src/renderer/i18n/locales/zh-CN/rebuild.json
@@ -7,7 +7,7 @@
   "shell.nav.freshness": "风化",
   "shell.nav.graph": "关系图",
   "shell.nav.presets": "预设 / 垂直领域",
-"shell.nav.entities": "实体说明",
+  "shell.nav.entities": "实体",
   "shell.nav.adapters": "引擎适配器",
   "shell.nav.system": "系统",
   "shell.nav.daemonObserve": "守护进程观察",

--- a/packages/gui/src/renderer/views/EntitiesView.tsx
+++ b/packages/gui/src/renderer/views/EntitiesView.tsx
@@ -7,6 +7,7 @@ import { useEntityLiveCounts, type EntityLiveCount } from "../entities-data.ts";
 import { EntityDocDetailView } from "./EntityDocDetailView.tsx";
 import { entityKindQueryKeys, governedEntityRowsQuery, useEntityKindCatalog } from "../entity-kind-data.ts";
 import { entityLocatorContentQuery } from "../entity-locator-client.ts";
+import { t } from "../i18n/index.tsx";
 import type { EntityKindCatalog } from "../entity-kind-catalog-client.ts";
 import type { GovernedEntityRow } from "../graph/governedEntities.ts";
 
@@ -50,7 +51,7 @@ export function EntitiesView({
         selectedEntityRef={focus.entityRef}
         liveCounts={liveCounts}
         projectName={projectName}
-        fromViewLabel={NAV_SELF_LABEL}
+        fromViewLabel={t("shell.nav.entities")}
         onBack={onExitDetail}
         onOpenView={onOpenView}
       />
@@ -60,7 +61,7 @@ export function EntitiesView({
       <header className="border-b border-border px-4 py-3" data-testid="entities-header">
         <div className="flex flex-wrap items-center gap-2">
           <BookOpen className="text-text-faint" />
-          <h1 className="ui-title font-semibold">实体说明</h1>
+          <h1 className="ui-title font-semibold">{t("shell.nav.entities")}</h1>
           <span className="font-mono ui-micro text-text-faint">{repoId}</span>
         </div>
         <p className="mt-1 max-w-3xl ui-meta leading-relaxed text-text-faint">
@@ -77,14 +78,20 @@ export function EntitiesView({
               <span className="ui-micro text-text-faint">{group.summary}</span>
             </div>
             <div className="grid grid-cols-[repeat(auto-fill,minmax(320px,1fr))] gap-2">
-              {group.docs.map((doc) => (
-                <EntityDocCard
-                  key={doc.kind}
-                  doc={doc}
-                  live={doc.liveCount === null ? null : liveCounts[doc.liveCount]}
-                  onOpen={() => onOpenEntityDoc(doc.kind)}
-                />
-              ))}
+              {group.docs.map((doc) => {
+                const catalogRow = catalog.kinds.find(({ kind }) => kind === doc.kind);
+                return (
+                  <EntityDocCard
+                    key={doc.kind}
+                    doc={doc}
+                    live={doc.liveCount === null ? null : liveCounts[doc.liveCount]}
+                    onOpen={() => onOpenEntityDoc(doc.kind)}
+                    origin={catalogRow?.origin ?? "builtin"}
+                    importable={catalogRow?.importable ?? false}
+                    onManage={doc.kind === "runtime-instance" ? () => onOpenView("providers") : null}
+                  />
+                );
+              })}
             </div>
           </section>
         ))}
@@ -92,8 +99,6 @@ export function EntitiesView({
     </div>
   );
 }
-
-const NAV_SELF_LABEL = "实体说明";
 
 /**
  * 目录卡片。长 kind 名(声明实体的 `software/coding/x@1`)与它的路径模板都是
@@ -104,56 +109,72 @@ function EntityDocCard({
   doc,
   live,
   onOpen,
+  origin,
+  importable,
+  onManage,
 }: {
   readonly doc: EntityKindDoc;
   readonly live: EntityLiveCount | null;
   readonly onOpen: () => void;
+  readonly origin: "builtin" | "vertical";
+  readonly importable: boolean;
+  readonly onManage: (() => void) | null;
 }) {
   return (
-    <button
-      type="button"
-      onClick={onOpen}
+    <div
       data-testid={`entity-doc-card-${doc.kind}`}
       className={[
         "w-full rounded-lg border border-border bg-surface p-3 text-left transition-colors",
         "hover:border-border-strong",
       ].join(" ")}
     >
-      <div className="flex min-w-0 items-start gap-2">
-        <b title={doc.kind} className="min-w-0 flex-1 self-center break-all font-mono ui-body leading-snug text-text">
-          {doc.kind}
-        </b>
-        {live ? (
-          <span title="本仓活行数" className="ml-auto shrink-0 self-center font-mono ui-micro text-text-muted">
-            {liveLabel(live)}
+      <button type="button" onClick={onOpen} className="w-full text-left">
+        <div className="flex min-w-0 items-start gap-2">
+          <b title={doc.kind} className="min-w-0 flex-1 self-center break-all font-mono ui-body leading-snug text-text">
+            {doc.kind}
+          </b>
+          {live ? (
+            <span title="本仓活行数" className="ml-auto shrink-0 self-center font-mono ui-micro text-text-muted">
+              {liveLabel(live)}
+            </span>
+          ) : null}
+        </div>
+        {doc.refTemplate ? (
+          <code
+            title={doc.refTemplate}
+            className="mt-0.5 block break-all font-mono ui-micro leading-snug text-text-faint"
+          >
+            {doc.refTemplate}
+          </code>
+        ) : null}
+        <p className="mt-1 line-clamp-2 ui-meta leading-relaxed text-text-muted">{doc.definition}</p>
+        <div className="mt-1.5 flex flex-wrap items-center gap-1">
+          {doc.schemaId && (
+            <span className="rounded border border-border px-1 py-px font-mono ui-micro text-text-faint">
+              {doc.schemaId}
+            </span>
+          )}
+          <span className="rounded border border-border px-1 py-px font-mono ui-micro text-text-faint">
+            {doc.fields.length} 字段
           </span>
+          {doc.edges.length > 0 && (
+            <span className="rounded border border-border px-1 py-px font-mono ui-micro text-text-faint">
+              {doc.edges.length} 关系
+            </span>
+          )}
+        </div>
+      </button>
+      <div className="mt-2 flex items-center justify-between gap-2">
+        <span className="ui-micro text-text-faint">
+          {origin === "builtin" ? "固定实体 · 只展示" : importable ? "声明实体 · 可新建" : "声明实体"}
+        </span>
+        {onManage ? (
+          <button type="button" className="ui-micro text-accent hover:underline" onClick={onManage}>
+            管理
+          </button>
         ) : null}
       </div>
-      {doc.refTemplate ? (
-        <code
-          title={doc.refTemplate}
-          className="mt-0.5 block break-all font-mono ui-micro leading-snug text-text-faint"
-        >
-          {doc.refTemplate}
-        </code>
-      ) : null}
-      <p className="mt-1 line-clamp-2 ui-meta leading-relaxed text-text-muted">{doc.definition}</p>
-      <div className="mt-1.5 flex flex-wrap items-center gap-1">
-        {doc.schemaId && (
-          <span className="rounded border border-border px-1 py-px font-mono ui-micro text-text-faint">
-            {doc.schemaId}
-          </span>
-        )}
-        <span className="rounded border border-border px-1 py-px font-mono ui-micro text-text-faint">
-          {doc.fields.length} 字段
-        </span>
-        {doc.edges.length > 0 && (
-          <span className="rounded border border-border px-1 py-px font-mono ui-micro text-text-faint">
-            {doc.edges.length} 关系
-          </span>
-        )}
-      </div>
-    </button>
+    </div>
   );
 }
 

--- a/packages/gui/test/entities-view.vitest.ts
+++ b/packages/gui/test/entities-view.vitest.ts
@@ -263,6 +263,26 @@ describe("entities catalog", () => {
     const agentCard = container.querySelector<HTMLElement>('[data-testid="entity-doc-card-agent"]');
     expect(agentCard?.textContent).toContain("1");
   });
+
+  it("labels fixed and declared cards and routes runtime instance management to Providers", async () => {
+    stubBridge([], { kinds: [declaredAdrKindRow()] });
+    const opened: ViewId[] = [];
+    const container = await renderSurface(view(null, (next) => opened.push(next)));
+    await settle();
+    expect(container.querySelector('[data-testid="entities-header"] h1')?.textContent).toBe("实体");
+    expect(container.querySelector('[data-testid="entity-doc-card-runtime-instance"]')?.textContent).toContain(
+      "固定实体 · 只展示",
+    );
+    expect(container.querySelector(`[data-testid="entity-doc-card-${ADR_KIND}"]`)?.textContent).toContain(
+      "声明实体 · 可新建",
+    );
+    const manage = Array.from(
+      container.querySelectorAll<HTMLButtonElement>('[data-testid="entity-doc-card-runtime-instance"] button'),
+    ).find((button) => button.textContent === "管理");
+    expect(manage).toBeDefined();
+    await act(async () => manage!.click());
+    expect(opened).toEqual(["providers"]);
+  });
 });
 
 describe("entity doc detail", () => {

--- a/packages/kernel/src/domain/agent-runtime.ts
+++ b/packages/kernel/src/domain/agent-runtime.ts
@@ -86,6 +86,8 @@ export interface RuntimeKind {
   readonly protocolFamily: RuntimeProtocolFamily;
   readonly declaredCapabilities: readonly RuntimeCapability[];
 }
+export const runtimeKindIds = Object.freeze(["claude", "codex", "agy", "zcode"] as const);
+export type RuntimeKindId = (typeof runtimeKindIds)[number];
 export interface RuntimeResultClaim {
   readonly sha256: string;
   readonly size: number;

--- a/packages/kernel/src/domain/base-entity.ts
+++ b/packages/kernel/src/domain/base-entity.ts
@@ -124,6 +124,11 @@ const runtimeSessionIdentity = Object.freeze({
   pattern: "^[A-Za-z0-9][A-Za-z0-9_-]{0,127}$",
   refTemplate: "runtime-session/{id}" as const,
 });
+const runtimeInstanceIdentity = Object.freeze({
+  field: "instanceId",
+  pattern: ENTITY_ID_PATTERN,
+  refTemplate: "runtime-instance/{id}" as const,
+});
 const scheduleIdentity = Object.freeze({
   field: "scheduleId",
   pattern: ENTITY_ID_PATTERN,
@@ -155,6 +160,10 @@ export const entityTypeContracts = Object.freeze([
   { kind: "execution", ...baseEntityTypeContract(executionIdentity, authoredLiveResidency) },
   { kind: "review", ...baseEntityTypeContract(reviewIdentity, authoredResidency) },
   { kind: "runtime-session", ...baseEntityTypeContract(runtimeSessionIdentity, authoredLiveResidency) },
+  {
+    kind: "runtime-instance",
+    ...baseEntityTypeContract(runtimeInstanceIdentity, Object.freeze({ configuration: "runtime-local" as const })),
+  },
   { kind: "schedule", ...baseEntityTypeContract(scheduleIdentity, scheduleResidency) },
   {
     kind: "settings",

--- a/packages/kernel/src/domain/entity-kind-registry.ts
+++ b/packages/kernel/src/domain/entity-kind-registry.ts
@@ -44,6 +44,7 @@ import { PERSON_V1_SCHEMA } from "./people-roster.ts";
 import { createTaskActionCatalog } from "./task-action-contract.ts";
 import { createScheduleActionCatalog } from "./schedule-action-contract.ts";
 import { createRuntimeSessionActionCatalog } from "./runtime-session-action-contract.ts";
+import { createRuntimeInstanceActionCatalog, createRuntimeInstanceKindContract } from "./runtime-instance-contract.ts";
 import { createSettingsActionCatalog } from "./settings-action-contract.ts";
 import { createPersonActionCatalog } from "./person-action-contract.ts";
 import { createSquadActionCatalog } from "./squad-action-contract.ts";
@@ -494,10 +495,17 @@ const agentIdentity = requireEntityTypeContract("agent").id;
 const executionIdentity = requireEntityTypeContract("execution").id;
 const reviewIdentity = requireEntityTypeContract("review").id;
 const runtimeSessionIdentity = requireEntityTypeContract("runtime-session").id;
+const runtimeInstanceIdentity = requireEntityTypeContract("runtime-instance").id;
 const scheduleIdentity = requireEntityTypeContract("schedule").id;
 const settingsIdentity = requireEntityTypeContract("settings").id;
 const personIdentity = requireEntityTypeContract("person").id;
 const relationIdentity = requireEntityTypeContract("relation").id;
+const runtimeInstanceActionCatalog = createRuntimeInstanceActionCatalog({
+  identity: runtimeInstanceIdentity,
+  noSdkExposure,
+  entityAction,
+  executionContract: (ingress, read) => executionContract(ingress, null, read),
+});
 const decisionFramework = Object.freeze({
   schemaId: "decision-package",
   mutabilityContract: "entityFieldContracts" as const,
@@ -938,6 +946,11 @@ export const entityKindContracts = Object.freeze([
     authoring: { kind: "agent-runtime-event", contractRef: "agent-runtime-event/v1" },
     sdkExposure: noSdkExposure,
   },
+  createRuntimeInstanceKindContract({
+    typeFields: entityTypeContractFields("runtime-instance"),
+    actionCatalog: runtimeInstanceActionCatalog,
+    noSdkExposure,
+  }),
   {
     kind: "schedule",
     ...entityTypeContractFields("schedule"),

--- a/packages/kernel/src/domain/runtime-instance-contract.ts
+++ b/packages/kernel/src/domain/runtime-instance-contract.ts
@@ -1,0 +1,80 @@
+import { runtimeKindIds } from "./agent-runtime.ts";
+import type { EntityActionContract, EntityKindContract, EntitySdkExposure } from "./entity-kind-registry.ts";
+
+export const runtimeInstanceSchema = Object.freeze({
+  $schema: "https://json-schema.org/draft/2020-12/schema" as const,
+  $id: "runtime-instance/v1",
+  type: "object" as const,
+  properties: {
+    instanceId: { type: "string" as const, pattern: "^[a-z0-9][a-z0-9-]{0,63}$", description: "Instance ID." },
+    name: { type: "string" as const, minLength: 1, description: "Operator-facing instance name." },
+    kindId: { type: "string" as const, enum: runtimeKindIds, description: "Built-in runtime adapter kind." },
+    enabled: { type: "boolean" as const, description: "Whether this instance is enabled." },
+  },
+  required: ["instanceId", "name", "kindId", "enabled"],
+  additionalProperties: true,
+});
+
+export function createRuntimeInstanceActionCatalog(input: {
+  readonly identity: EntityKindContract["id"];
+  readonly noSdkExposure: EntitySdkExposure;
+  readonly entityAction: (
+    kind: string,
+    identity: EntityKindContract["id"],
+    id: string,
+    sdkExposure: EntitySdkExposure,
+    execution: NonNullable<EntityActionContract["execution"]>,
+  ) => EntityActionContract;
+  readonly executionContract: (ingress: string, read: boolean) => NonNullable<EntityActionContract["execution"]>;
+}): NonNullable<EntityKindContract["actionCatalog"]> {
+  const action = (id: string, ingress: string, read = false) =>
+    input.entityAction(
+      "runtime-instance",
+      input.identity,
+      id,
+      input.noSdkExposure,
+      input.executionContract(ingress, read),
+    );
+  return Object.freeze({
+    ref: "daemon/runtime-instance/v1",
+    actions: Object.freeze([
+      action("create", "createRuntimeInstance"),
+      action("update", "updateRuntimeInstance"),
+      action("delete", "deleteRuntimeInstance"),
+      action("probe", "showRuntimeInstance", true),
+    ]),
+  });
+}
+
+export function createRuntimeInstanceKindContract(input: {
+  readonly typeFields: Omit<
+    EntityKindContract,
+    | "kind"
+    | "schema"
+    | "relations"
+    | "canonicalProjection"
+    | "statusVocabulary"
+    | "actionCatalog"
+    | "entityStore"
+    | "authoring"
+    | "sdkExposure"
+  >;
+  readonly actionCatalog: NonNullable<EntityKindContract["actionCatalog"]>;
+  readonly noSdkExposure: EntitySdkExposure;
+}): EntityKindContract {
+  return {
+    kind: "runtime-instance",
+    ...input.typeFields,
+    schema: runtimeInstanceSchema,
+    relations: { directions: [], edges: [] },
+    canonicalProjection: null,
+    statusVocabulary: [
+      { field: "status", words: ["enabled", "disabled"] },
+      { field: "kindId", words: runtimeKindIds },
+    ],
+    actionCatalog: input.actionCatalog,
+    entityStore: null,
+    authoring: null,
+    sdkExposure: input.noSdkExposure,
+  };
+}

--- a/packages/kernel/src/index.ts
+++ b/packages/kernel/src/index.ts
@@ -21,6 +21,7 @@ export type {
   RuntimeInstallation,
   RuntimeInstallationState,
   RuntimeKind,
+  RuntimeKindId,
   RuntimeProtocolFamily,
   RuntimeResultClaim,
   RuntimeSession,
@@ -29,6 +30,7 @@ export type {
   SessionIdentityResolver,
   SessionIdentityResolverInput,
 } from "./domain/agent-runtime.ts";
+export { runtimeKindIds } from "./domain/agent-runtime.ts";
 export {
   allowsTaskStatusMove,
   applyTransition,

--- a/packages/kernel/test/contracts/base-entity.test.ts
+++ b/packages/kernel/test/contracts/base-entity.test.ts
@@ -23,13 +23,14 @@ const identityByKind: Readonly<Record<EntityKind, string>> = {
   execution: "exe_BASEENTITY",
   review: "rev_BASEENTITY",
   "runtime-session": "runtime_baseentity",
+  "runtime-instance": "runtime-instance-base",
   schedule: "schedule-base",
   settings: "repository",
   person: "person_baseentity",
   relation: "rel_b75516c583945a52",
 };
 
-test("all thirteen registered kinds are referenceable relation endpoints from one type contract", () => {
+test("all fourteen registered kinds are referenceable relation endpoints from one type contract", () => {
   const registeredKinds = entityKindContracts.map(({ kind }) => kind).sort();
   const referenceableKinds: EntityKind[] = [];
   const endpointKinds: EntityKind[] = [];
@@ -46,7 +47,7 @@ test("all thirteen registered kinds are referenceable relation endpoints from on
     if (isRelationEndpointKind(contract.kind)) endpointKinds.push(contract.kind);
   }
 
-  assert.equal(registeredKinds.length, 13);
+  assert.equal(registeredKinds.length, 14);
   assert.deepEqual(referenceableKinds.sort(), registeredKinds);
   assert.deepEqual(endpointKinds.sort(), registeredKinds);
   assert.deepEqual(parseEntityRef("relation/rel_b75516c583945a52"), {

--- a/packages/kernel/test/contracts/kind-authority-version.test.ts
+++ b/packages/kernel/test/contracts/kind-authority-version.test.ts
@@ -18,6 +18,7 @@ const expectedKinds = [
   "policy",
   "relation",
   "review",
+  "runtime-instance",
   "runtime-session",
   "schedule",
   "settings",
@@ -33,6 +34,7 @@ const expectedResidency = {
   policy: { authored: "ledger" },
   relation: { history: "ledger", graph: "projection" },
   review: { authored: "ledger" },
+  "runtime-instance": { configuration: "runtime-local" },
   "runtime-session": { authored: "ledger", live: "runtime-local" },
   schedule: { definition: "ledger", execution: "runtime-local", runView: "projection" },
   settings: { authored: "ledger", current: "projection" },
@@ -40,7 +42,7 @@ const expectedResidency = {
   task: { authored: "ledger" },
 } as const;
 
-test("one named kind-contract authority explains all thirteen entity kinds with one shape", () => {
+test("one named kind-contract authority explains all fourteen entity kinds with one shape", () => {
   assert.deepEqual(entityKindContracts.map(({ kind }) => kind).sort(), [...expectedKinds]);
   for (const contract of entityKindContracts)
     assert.deepEqual(contract.residency, expectedResidency[contract.kind], `${contract.kind} residency`);
@@ -142,7 +144,16 @@ test("generic entity-store boundaries stay aligned with the kind authority", () 
   assert.equal(getEntityKindContract("session"), undefined);
   assert.equal(requireEntityStoreKindContract("agent").kind, "agent");
   assert.equal(requireEntityStoreKindContract("squad").kind, "squad");
-  for (const kind of ["execution", "review", "runtime-session", "schedule", "settings", "person", "policy"])
+  for (const kind of [
+    "execution",
+    "review",
+    "runtime-instance",
+    "runtime-session",
+    "schedule",
+    "settings",
+    "person",
+    "policy",
+  ])
     assert.throws(() => requireEntityStoreKindContract(kind), /no generic entity-store surface/u);
   assert.equal(explainEntityKind("policy").authoring, null);
 });


### PR DESCRIPTION
# English

## Summary
The GUI entity page was titled 「实体说明」 and knew nothing about runtime instances, even though they are the one runtime object with an id, an owner and a lifecycle. This adds `runtime-instance` to the kernel entity catalog as a fixed, display-only kind whose residency is the local daemon user-root (no event stream, no canonical projection), feeds it through `repo.entity.rows.read` with a `provider/<instanceId>` deep link, renames the page to 「实体」 via the existing nav i18n key, marks built-in kinds as display-only and declared kinds as creatable, and gives the runtime-instance card a "manage" entry that opens the Provider view. Runtime *kinds* (claude/codex/agy/zcode) stay a vocabulary on the instance: they have no independent id or lifecycle, so they are not modelled as a separate entity.

## Architectural Justification
Production churn is +235/-50. The new kind cannot live in `runtime-inventory.ts` because the kernel entity registry may not import from the daemon; the `claude|codex|agy|zcode` vocabulary therefore moves to `packages/kernel/src/domain/agent-runtime.ts` as the single source and the daemon re-exports it. No old code path is retained: the hardcoded page title and the label constant in `EntitiesView.tsx` are deleted in the same change.

## What Changed
- `packages/kernel/src/domain/runtime-instance-contract.ts` (new): `runtime-instance/v1` schema, `enabled|disabled` and kind vocabularies, action catalog mapped onto the existing `createRuntimeInstance` / `updateRuntimeInstance` / `deleteRuntimeInstance` / `showRuntimeInstance` ingress.
- `entity-kind-registry.ts`, `base-entity.ts`, `agent-runtime.ts`, `index.ts`: register the kind with `runtime-local` residency; vocabulary single-sourced in kernel.
- `packages/daemon/src/entity-rows-read.ts`, `repo-cell-api.ts`, `runtime-inventory.ts`: rows for current daemon instances; kind ids re-exported from kernel.
- `packages/gui/src/renderer/entity-docs.ts`: regenerated `KERNEL_ENTITY_CONTRACT`; curated `runtimeInstanceDoc` in the runtime group.
- `EntitiesView.tsx`, `i18n/locales/zh-CN/rebuild.json`: page title from `shell.nav.entities` (「实体」); origin badges; manage entry.
- Tests: `entity-kind-catalog.contract.test.ts`, `base-entity.test.ts`, `kind-authority-version.test.ts`, `entities-view.vitest.ts`.

## Verification
- `npm run test:gui -w @harness-anything/gui -- test/entity-docs-contract.vitest.ts test/entities-view.vitest.ts`: 54/54.
- Kernel/daemon contract tests named above: 25/25; `npx tsc -b packages/kernel packages/daemon packages/gui` clean; entity-doc contract generator `--check` clean.
- Electron visual check is left to the CEO after merge (dogfood on the 「实体」 page).

## Review Evidence
- First CI round: `agent-runtime-instance-registry.test.ts` mutated the now-frozen kernel vocabulary in place, and `repo.entity.rows.read` read the inventory from `context.extracted.input` while the resident daemon puts it on `context.input`; both fixed in `c04d18c87` (fix-round-1 report in the task package), and an unreadable inventory now yields zero runtime-instance rows instead of failing the read.
- Task `task_d08912b4faadfdc498d31605df`; Sol implementation report and fact `F-48340B19` in the task package. CEO semantic check: matches the 2026-09-05 ruling (page named 「实体」, fixed kinds display-only, runtime instance on the catalog, kind as a field vocabulary).

## Residual Risk
- Rows are read from the local daemon inventory, so a fleet edge shows its own instances only; that is by design and stated on the card.

## Gate Harvest / 门收割
Removed-Paths: none
Removed-Gates: none

## Machine-Readable Declarations
Production-Delta: +235/-50

---

# 中文

## 摘要
GUI 实体页原名「实体说明」,且不认识 runtime instance,而它恰是 runtime 侧唯一有 id、owner 与生命周期的对象。本 PR 把 `runtime-instance` 加入 kernel 实体目录,作为固定、只展示的 kind,其 residency 是本机 daemon user-root(无事件流、无 canonical projection);经 `repo.entity.rows.read` 产出行并带 `provider/<instanceId>` 深链;页面经既有导航 i18n key 改名「实体」;内建 kind 标「固定实体 · 只展示」,声明 kind 标「可新建」;runtime-instance 卡片提供「管理」入口跳 Provider 页。runtime *kind*(claude/codex/agy/zcode)保持为实例上的词表:它没有独立 id 与生命周期,不单独建实体。

## 架构辩护
生产 churn +235/-50。kernel 实体目录不能从 daemon 导入,所以 kind 词表上移到 `packages/kernel/src/domain/agent-runtime.ts` 单源,daemon re-export;硬编码页名与 `EntitiesView.tsx` 的标签常量在同一变更内删除,不保留旧路径。

## 改动
- 新增 `runtime-instance-contract.ts`;registry / base-entity / agent-runtime 注册 kind;daemon 行读面并入实例;GUI 重新生成契约区块、加 curated 卡片、改名与标记;对应 kernel/daemon/GUI 测试。

## 验证
- GUI 两个 vitest 文件 54/54;kernel/daemon 契约测试 25/25;`tsc -b` 三包通过;契约生成器 `--check` 无漂移。Electron 视觉由 CEO 合并后亲验。

## 复核证据
- 首轮 CI:registry 测试原地修改已冻结的 kernel 词表;`repo.entity.rows.read` 从 `context.extracted.input` 取 inventory 而 resident daemon 放在 `context.input`;两者在 `c04d18c87` 修复,inventory 不可读时只省略 runtime-instance 行。
- 任务 `task_d08912b4faadfdc498d31605df`,Sol 实现报告与 fact `F-48340B19` 在任务包;CEO 语义验收与 2026-09-05 裁决一致。

## 残余风险
- 行来自本机 daemon inventory,fleet 边缘节点只看到自己的实例,属设计使然并已在卡片写明。
