### PR TITLE
feat(entity): update and archive declared entity instances from CLI and GUI

### DIFF
--- a/packages/cli/src/cli/thin-command-router.ts
+++ b/packages/cli/src/cli/thin-command-router.ts
@@ -100,27 +100,7 @@ export function parseRouted(
       route.id === "distill-promote" ? { confidence: "medium", memoryClass: "semantic" } : {},
     );
   if (rootCommand === "relation") return parseRelationRouted(route, args, rootDir, repoId, json, inputs);
-  if (rootCommand === "entity") {
-    if (route.id === "entity-import") return parseEntityImportRouted(route, args, rootDir, repoId, json, inputs);
-    if (route.id === "entity-update" || route.id === "entity-archive") {
-      const entityKind = args[2],
-        projected = parseProjected(route.id, args.slice(3), rootDir, repoId, json, inputs, {}, {}, route.method);
-      if (!nonEmpty(entityKind))
-        return rejected("missing_field", `Use ha entity ${route.id.slice("entity-".length)} <kind>.`, json);
-      if (!projected.ok) return projected;
-      return accepted(rootDir, repoId, json, { ...projected.command.action, entityKind });
-    }
-    const entityKind = args[2],
-      f = readFlags(route.id, args.slice(3), inputs);
-    if (!nonEmpty(entityKind))
-      return rejected("missing_field", `Use ha entity ${route.id.slice("entity-".length)} <kind>.`, json);
-    if (!f.ok) return rejected(f.code, f.nextAction, json);
-    return accepted(rootDir, repoId, json, {
-      kind: route.id,
-      entityKind,
-      ...(route.id === "entity-get" ? { entityId: f.one.get("--id") } : {}),
-    });
-  }
+  if (rootCommand === "entity") return parseEntityRouted(route, args, rootDir, repoId, json, inputs);
   if (route.phase.startsWith("Preset-") || rootCommand === "agent" || rootCommand === "squad")
     return parsePreset(route, args, rootDir, repoId, json, inputs);
   return undefined;
@@ -134,6 +114,35 @@ const peopleRequiredInputs: Readonly<Record<string, readonly string[]>> = Object
   "people-revoke-delegation": ["--token-id"],
   "people-remove": ["--person-id"],
 });
+
+function parseEntityRouted(
+  route: ProtocolCommand,
+  args: readonly string[],
+  rootDir: SafePath,
+  repoId: string | undefined,
+  json: boolean,
+  inputs: ThinCliInputDirectory,
+): ThinParseResult {
+  if (route.id === "entity-import") return parseEntityImportRouted(route, args, rootDir, repoId, json, inputs);
+  if (route.id === "entity-update" || route.id === "entity-archive") {
+    const entityKind = args[2],
+      projected = parseProjected(route.id, args.slice(3), rootDir, repoId, json, inputs, {}, {}, route.method);
+    if (!nonEmpty(entityKind))
+      return rejected("missing_field", `Use ha entity ${route.id.slice("entity-".length)} <kind>.`, json);
+    if (!projected.ok) return projected;
+    return accepted(rootDir, repoId, json, { ...projected.command.action, entityKind });
+  }
+  const entityKind = args[2],
+    f = readFlags(route.id, args.slice(3), inputs);
+  if (!nonEmpty(entityKind))
+    return rejected("missing_field", `Use ha entity ${route.id.slice("entity-".length)} <kind>.`, json);
+  if (!f.ok) return rejected(f.code, f.nextAction, json);
+  return accepted(rootDir, repoId, json, {
+    kind: route.id,
+    entityKind,
+    ...(route.id === "entity-get" ? { entityId: f.one.get("--id") } : {}),
+  });
+}
 
 function parseEntityImportRouted(
   route: ProtocolCommand,

--- a/packages/cli/src/cli/thin-command-router.ts
+++ b/packages/cli/src/cli/thin-command-router.ts
@@ -102,6 +102,14 @@ export function parseRouted(
   if (rootCommand === "relation") return parseRelationRouted(route, args, rootDir, repoId, json, inputs);
   if (rootCommand === "entity") {
     if (route.id === "entity-import") return parseEntityImportRouted(route, args, rootDir, repoId, json, inputs);
+    if (route.id === "entity-update" || route.id === "entity-archive") {
+      const entityKind = args[2],
+        projected = parseProjected(route.id, args.slice(3), rootDir, repoId, json, inputs, {}, {}, route.method);
+      if (!nonEmpty(entityKind))
+        return rejected("missing_field", `Use ha entity ${route.id.slice("entity-".length)} <kind>.`, json);
+      if (!projected.ok) return projected;
+      return accepted(rootDir, repoId, json, { ...projected.command.action, entityKind });
+    }
     const entityKind = args[2],
       f = readFlags(route.id, args.slice(3), inputs);
     if (!nonEmpty(entityKind))

--- a/packages/cli/test/thin-command.test.ts
+++ b/packages/cli/test/thin-command.test.ts
@@ -112,6 +112,55 @@ test("entity import projects its concurrency and dry-run flags into one daemon A
   );
 });
 
+test("entity update and archive preserve the entity revision fence", () => {
+  const update = parseThinCommand([
+    "entity",
+    "update",
+    "software/coding/architecture-decision-record@1",
+    "--id",
+    "ADR-abc",
+    "--title",
+    "Revised",
+    "--locator",
+    "docs/revised.md",
+    "--content-version",
+    "git:abc",
+    "--expected-version",
+    "7",
+  ]);
+  assert.equal(update.ok, true);
+  if (update.ok)
+    assert.deepEqual(update.command.action, {
+      kind: "entity-update",
+      entityKind: "software/coding/architecture-decision-record@1",
+      entityId: "ADR-abc",
+      title: "Revised",
+      locator: "docs/revised.md",
+      contentVersion: "git:abc",
+      expectedVersion: 7,
+    });
+  const archive = parseThinCommand([
+    "entity",
+    "archive",
+    "software/coding/architecture-decision-record@1",
+    "--id",
+    "ADR-abc",
+    "--reason",
+    "Superseded",
+    "--expected-version",
+    "8",
+  ]);
+  assert.equal(archive.ok, true);
+  if (archive.ok)
+    assert.deepEqual(archive.command.action, {
+      kind: "entity-archive",
+      entityKind: "software/coding/architecture-decision-record@1",
+      entityId: "ADR-abc",
+      reason: "Superseded",
+      expectedVersion: 8,
+    });
+});
+
 test("dispatch record migration projects its dry-run flag into the daemon Action", () => {
   const parsed = parseThinCommand(["migrate", "dispatch-records", "--dry-run"]);
   assert.equal(parsed.ok, true);
@@ -191,7 +240,7 @@ test("capabilities is an exact-set projection of the command contract", () => {
       "doc-sync-dry-run",
       "doc-sync-submit",
     ],
-    entity: ["entity-get", "entity-import", "entity-list"],
+    entity: ["entity-archive", "entity-get", "entity-import", "entity-list", "entity-update"],
     explain: ["explain"],
     fact: ["fact-reclassify", "fact-record", "fact-search", "fact-show", "fact-type-list", "fact-type-register"],
     gui: ["gui"],

--- a/packages/daemon/src/artifact-entity-action.ts
+++ b/packages/daemon/src/artifact-entity-action.ts
@@ -9,6 +9,11 @@ import {
 } from "../../application/src/index.ts";
 import {
   compiledRelationDirections,
+  artifactEntityContractSnapshot,
+  artifactImportOperationId,
+  canonicalArtifactLocator,
+  compileEntityArchived,
+  compileEntityUpdated,
   compileVerticalContract,
   composeCanonicalRelationDirections,
   isEntityDeclarationEvent,
@@ -88,6 +93,118 @@ export async function executeArtifactEntityImport(input: {
     );
   const receipt = await runArtifactEntityImport({ ...input, contracts });
   return { action: { ...input.action, entityId: receipt.entityId }, contract, receipt };
+}
+
+export function executeArtifactEntityMutation(input: {
+  readonly rootDir: string;
+  readonly repositoryId: string;
+  readonly action: RepoTaskAction;
+  readonly binding: RepoCellBinding;
+  readonly store: CanonicalEventStore;
+  readonly projection: TaskProjection;
+  readonly now: () => string;
+  readonly authorizationDecision: AuthorizationDecision;
+}): {
+  readonly action: RepoTaskAction;
+  readonly contract: EntityActionContract;
+  readonly receipt: ArtifactImportReceipt;
+} {
+  const contracts = compiledArtifactKinds(),
+    kind = requiredArtifactText(input.action.entityKind, "entityKind"),
+    entityId = requiredArtifactText(input.action.entityId, "entityId"),
+    compiled = contracts.find(({ typeIdentity }) => typeIdentity === kind),
+    contract = compiled?.entityKindContract.actionCatalog?.actions.find(({ id }) => id === input.action.kind.slice(7));
+  if (!compiled || !contract?.execution)
+    throw Object.assign(new Error(`Artifact kind ${kind} has no executable ${input.action.kind} action.`), {
+      code: "unsupported_command",
+    });
+  const current = readCurrentArtifact(input.store, contracts, kind, entityId),
+    expectedVersion = Number(input.action.expectedVersion);
+  if (!current?.descriptor)
+    throw Object.assign(new Error(`Entity ${kind}/${entityId} does not exist.`), { code: "entity_not_found" });
+  if (!Number.isSafeInteger(expectedVersion) || expectedVersion !== current.revision)
+    throw Object.assign(
+      new Error(
+        `Entity ${entityId} expected revision ${String(expectedVersion)}, current revision is ${current.revision}.`,
+      ),
+      { code: "revision_conflict" },
+    );
+  const contractSnapshot = artifactEntityContractSnapshot(compiled),
+    workspaceRevision = (input.store.readHead()?.revision ?? 0) + 1,
+    envelope = {
+      workspaceRevision,
+      actor: input.binding.actor,
+      source: input.binding.source,
+      occurredAt: input.now(),
+    },
+    bundle =
+      input.action.kind === "entity-update"
+        ? updatedBundle(input.action, current.descriptor, compiled, contractSnapshot, envelope)
+        : compileEntityArchived({
+            ...envelope,
+            eventId: `event-entity-archive-${workspaceRevision}`,
+            opId: `entity-archive-${entityId}-${workspaceRevision}`,
+            contractSnapshot,
+            entityId,
+            reason: requiredArtifactText(input.action.reason, "reason"),
+          }),
+    appended = input.store.append(bundle),
+    _applied = input.projection.apply(bundle.event, bundle.plan),
+    applied = input.projection.readOperation(bundle.event.opId),
+    visible = !!applied && applied.watermark >= bundle.event.workspaceRevision,
+    receipt: ArtifactImportReceipt = {
+      outcome: visible ? "applied" : "pending",
+      opId: bundle.event.opId,
+      revision: appended.revision,
+      entityId,
+      evidence: JSON.stringify({ schema: "artifact-entity-mutation-result/v1", eventType: bundle.event.type }),
+      visibility: "center",
+      proof: {
+        committedRevision: appended.revision,
+        appliedCut: applied?.watermark ?? 0,
+        durable: true,
+        canonicalVisible: visible,
+        worktreeVisible: bundle.event.type === "entity_updated",
+      },
+      authorizationDecision: input.authorizationDecision,
+      commitSha: appended.commitSha?.sha ?? null,
+      cut: appended.cut,
+      ...(visible ? {} : { guidance: [{ kind: "retry-receipt", args: { opId: bundle.event.opId } }] }),
+    };
+  return { action: input.action, contract, receipt };
+}
+
+function updatedBundle(
+  action: RepoTaskAction,
+  current: NonNullable<ArtifactEntityCurrent["descriptor"]>,
+  compiled: CompiledArtifactKindContract,
+  contractSnapshot: ReturnType<typeof artifactEntityContractSnapshot>,
+  envelope: {
+    readonly workspaceRevision: number;
+    readonly actor: RepoCellBinding["actor"];
+    readonly source: RepoCellBinding["source"];
+    readonly occurredAt: string;
+  },
+) {
+  const locator =
+      typeof action.locator === "string"
+        ? canonicalArtifactLocator({ kind: current.locator.kind, value: action.locator })
+        : current.locator,
+    contentVersion = typeof action.contentVersion === "string" ? action.contentVersion.trim() : current.contentVersion,
+    opId = artifactImportOperationId({ entityId: current.entityId, locator, resolution: contentVersion });
+  return compileEntityUpdated({
+    ...envelope,
+    eventId: `event-${opId}`,
+    opId,
+    contract: compiled.entityKindContract as Parameters<typeof compileEntityUpdated>[0]["contract"],
+    contractSnapshot,
+    descriptor: {
+      ...current,
+      locator,
+      contentVersion,
+      ...(typeof action.title === "string" ? { title: action.title.trim() } : {}),
+    },
+  });
 }
 
 export async function runArtifactEntityImport(input: {

--- a/packages/daemon/src/entity-action-catalog-executor.ts
+++ b/packages/daemon/src/entity-action-catalog-executor.ts
@@ -42,7 +42,7 @@ import {
   matchingRuntimeSessionReplayBundle,
   type RuntimeSessionBundle,
 } from "./entity-action-runtime-session.ts";
-import { executeArtifactEntityImport } from "./artifact-entity-action.ts";
+import { executeArtifactEntityImport, executeArtifactEntityMutation } from "./artifact-entity-action.ts";
 import { executeRelationAction, publicationKillpoints, reject } from "./entity-action-relation.ts";
 
 type ExecutableAction = EntityActionContract & { readonly execution: EntityActionExecutionContract };
@@ -125,6 +125,20 @@ export function makeEntityActionCatalogExecutor(input: {
         now: input.now,
         authorizationDecision,
       }).then((result) => deriveActionResult(result.contract, result.action, result.receipt));
+    }
+    if (action.kind === "entity-update" || action.kind === "entity-archive") {
+      const authorizationDecision = decisionAuthorization(action, binding, opId, input),
+        result = executeArtifactEntityMutation({
+          rootDir: input.rootDir ?? process.cwd(),
+          repositoryId: input.repositoryId ?? "repository",
+          action,
+          binding,
+          store: input.store,
+          projection: input.projection,
+          now: input.now,
+          authorizationDecision,
+        });
+      return deriveActionResult(result.contract, result.action, result.receipt);
     }
     const contract = executableAction(action.kind),
       prepare = runtimes.prepare?.[contract.target.kind],

--- a/packages/daemon/src/entity-rows-read.ts
+++ b/packages/daemon/src/entity-rows-read.ts
@@ -27,6 +27,7 @@ export interface EntityRowV1 {
   readonly title: string | null;
   readonly locator: { readonly kind: string; readonly value: string } | null;
   readonly revision: number;
+  readonly archived: boolean;
 }
 
 export interface EntityRowListV1 {
@@ -59,6 +60,7 @@ export function readDeclaredEntityRows(input: {
       title: instance.name,
       locator: { kind: "entity-ref", value: `provider/${instance.instanceId}` },
       revision: 0,
+      archived: false,
     });
   }
   return { schema: ENTITY_ROW_LIST_SCHEMA, ok: true, rows };
@@ -66,7 +68,12 @@ export function readDeclaredEntityRows(input: {
 
 function entityRow(
   kind: string,
-  row: { readonly id: string; readonly workspaceRevision: number; readonly value: unknown },
+  row: {
+    readonly id: string;
+    readonly workspaceRevision: number;
+    readonly freshness: string;
+    readonly value: unknown;
+  },
 ): EntityRowV1 {
   const descriptor = isJsonObject(row.value) ? row.value : {};
   const locator = descriptor.locator;
@@ -80,6 +87,7 @@ function entityRow(
         ? { kind: locator.kind, value: locator.value }
         : null,
     revision: row.workspaceRevision,
+    archived: row.freshness === "orphaned",
   };
 }
 
@@ -112,6 +120,7 @@ function validateRow(value: unknown): readonly string[] {
     errors.push("locator must carry kind and value");
   if (!Number.isSafeInteger(value.revision) || Number(value.revision) < 0)
     errors.push("revision must be a non-negative integer");
+  if (typeof value.archived !== "boolean") errors.push("archived must be a boolean");
   return errors;
 }
 

--- a/packages/daemon/src/protocol/daemon-protocol-commands-agent.ts
+++ b/packages/daemon/src/protocol/daemon-protocol-commands-agent.ts
@@ -264,6 +264,52 @@ export const agentProtocolCommands = Object.freeze([
       cliInput("--dry-run", "boolean", false, { code: "invalid_field" }, { field: "dryRun" }),
     ],
   }),
+  defineCenterForwardWriteCommand({
+    id: "entity-update",
+    phase: "Governed-Entity-W2",
+    path: ["entity", "update", "<kind>"],
+    summary: "Update mutable fields of one compiled vertical Artifact Entity.",
+    method: "repo.task.run",
+    positional: "entityKind",
+    inputs: [
+      cliInput("--id", "single", true, { code: "missing_field" }, { field: "entityId" }),
+      cliInput(
+        "--expected-version",
+        "single",
+        true,
+        { code: "missing_field" },
+        {
+          regex: "^(?:0|[1-9][0-9]*)$",
+          projection: "number",
+        },
+      ),
+      cliInput("--title", "single", false, { code: "invalid_field" }),
+      cliInput("--locator", "single", false, { code: "invalid_field" }),
+      cliInput("--content-version", "single", false, { code: "invalid_field" }, { field: "contentVersion" }),
+    ],
+  }),
+  defineCenterForwardWriteCommand({
+    id: "entity-archive",
+    phase: "Governed-Entity-W2",
+    path: ["entity", "archive", "<kind>"],
+    summary: "Archive one compiled vertical Artifact Entity without deleting its descriptor.",
+    method: "repo.task.run",
+    positional: "entityKind",
+    inputs: [
+      cliInput("--id", "single", true, { code: "missing_field" }, { field: "entityId" }),
+      cliInput("--reason", "single", true, { code: "missing_field" }),
+      cliInput(
+        "--expected-version",
+        "single",
+        true,
+        { code: "missing_field" },
+        {
+          regex: "^(?:0|[1-9][0-9]*)$",
+          projection: "number",
+        },
+      ),
+    ],
+  }),
   defineRepoReadCommand({
     id: "entity-get",
     phase: "Runtime-B",

--- a/packages/daemon/src/protocol/daemon-protocol-gui-actions-entity.ts
+++ b/packages/daemon/src/protocol/daemon-protocol-gui-actions-entity.ts
@@ -21,6 +21,31 @@ export const entityImportGuiActions = Object.freeze([
     "/api/entities/import",
     "repo-write",
   ),
+  guiAction(
+    "entity.update",
+    "repo.entity.update",
+    "entity-update",
+    shape({
+      entityKind: "string",
+      entityId: "string",
+      expectedVersion: "number",
+      title: "string?",
+      locator: "string?",
+      contentVersion: "string?",
+    }),
+    "updateEntity",
+    "/api/entities/update",
+    "repo-write",
+  ),
+  guiAction(
+    "entity.archive",
+    "repo.entity.archive",
+    "entity-archive",
+    shape({ entityKind: "string", entityId: "string", expectedVersion: "number", reason: "string" }),
+    "archiveEntity",
+    "/api/entities/archive",
+    "repo-write",
+  ),
 ] as const);
 
 /** Agent/Squad 声明文档的写入面;两者共用 generic entity store 的同一条写路。 */

--- a/packages/daemon/src/protocol/daemon-protocol.contract.ts
+++ b/packages/daemon/src/protocol/daemon-protocol.contract.ts
@@ -749,6 +749,7 @@ export default Object.freeze({
     "Governed-Entity-W1-F",
     "Governed-Entity-W2-0",
     "Governed-Entity-W2-B",
+    "Governed-Entity-W2",
   ]),
   commands: daemonOwnedProtocolCommands,
   methods: Object.freeze([

--- a/packages/daemon/src/repo-cell-action-dispatch.ts
+++ b/packages/daemon/src/repo-cell-action-dispatch.ts
@@ -183,7 +183,7 @@ export async function executeAction(
       ),
     );
   }
-  if (action.kind === "entity-import")
+  if (["entity-import", "entity-update", "entity-archive"].includes(action.kind))
     return cell.entityActionExecutor.run(
       action,
       binding,

--- a/packages/daemon/src/repo-cell-authorization.ts
+++ b/packages/daemon/src/repo-cell-authorization.ts
@@ -140,7 +140,9 @@ export function authorizeDurableRepoCellAction(
     case "doc-submit":
       return authorizeRepoCellAction(input);
     case "entity-import":
+      return authorizeRepoCellAction(input);
     case "entity-update":
+      return authorizeRepoCellAction(input);
     case "entity-archive":
       return authorizeRepoCellAction(input);
     case "entity-migrate-squads":

--- a/packages/daemon/src/repo-cell-authorization.ts
+++ b/packages/daemon/src/repo-cell-authorization.ts
@@ -140,6 +140,8 @@ export function authorizeDurableRepoCellAction(
     case "doc-submit":
       return authorizeRepoCellAction(input);
     case "entity-import":
+    case "entity-update":
+    case "entity-archive":
       return authorizeRepoCellAction(input);
     case "entity-migrate-squads":
       return authorizeRepoCellAction(input);

--- a/packages/daemon/test/artifact-entity-action.integration.test.ts
+++ b/packages/daemon/test/artifact-entity-action.integration.test.ts
@@ -58,7 +58,7 @@ test("Artifact import is dry-run safe, edge-idempotent, fenced, and cold-rebuild
     );
     assert.deepEqual(
       explained.subjects[0]?.actions.map(({ action }) => action.id),
-      ["import", "distill-candidate"],
+      ["import", "update", "archive", "distill-candidate"],
     );
     assert.equal(explained.subjects[0]?.actions[0]?.available, null);
 
@@ -175,12 +175,42 @@ test("Artifact import is dry-run safe, edge-idempotent, fenced, and cold-rebuild
       "entity_target_missing",
     );
     assert.equal(missingReplay.proof?.worktreeVisible, false);
+    const descriptorUpdate = await cell.run(
+      {
+        kind: "entity-update",
+        entityKind: kind,
+        entityId: preview.entityId,
+        expectedVersion: missing.revision,
+        title: "Revised title",
+        locator: sourcePath,
+        contentVersion: "revision:manual-2",
+      },
+      secondaryNodeBinding,
+    );
+    assert.equal(descriptorUpdate.outcome, "applied", JSON.stringify(descriptorUpdate));
+    const archived = await cell.run(
+      {
+        kind: "entity-archive",
+        entityKind: kind,
+        entityId: preview.entityId,
+        expectedVersion: descriptorUpdate.revision,
+        reason: "Superseded by ADR-0002",
+      },
+      binding,
+    );
+    assert.equal(archived.outcome, "applied", JSON.stringify(archived));
     const artifactEvents = makeTaskEventReader({ repoId, rootDir })
       .read()
       .events.filter((event) => event.schema === "entity-event/v1" && event.payload.entityKind === kind);
     assert.deepEqual(
       artifactEvents.map(({ type }) => type),
-      ["entity_content_observed", "entity_content_observed", "entity_target_missing"],
+      [
+        "entity_content_observed",
+        "entity_content_observed",
+        "entity_target_missing",
+        "entity_updated",
+        "entity_archived",
+      ],
     );
 
     const listed = await cell.run({ kind: "entity-list", entityKind: kind }, binding),
@@ -205,8 +235,9 @@ test("Artifact import is dry-run safe, edge-idempotent, fenced, and cold-rebuild
         row = rebuilt.getEntity(kind, preview.entityId);
       assert.equal(receipt.watermark, rebuildStore.readHead()?.revision);
       assert.equal(row?.id, preview.entityId);
-      assert.equal(row?.workspaceRevision, missing.revision);
-      assert.equal(row?.value.contentVersion, updatedEvidence.preview.candidateContentVersion);
+      assert.equal(row?.workspaceRevision, archived.revision);
+      assert.equal(row?.value.contentVersion, "revision:manual-2");
+      assert.equal(row?.value.title, "Revised title");
       assert.equal(row?.freshness, "orphaned");
       assert.equal(row?.currentVersion, null);
     } finally {

--- a/packages/daemon/test/entity-kind-catalog.contract.test.ts
+++ b/packages/daemon/test/entity-kind-catalog.contract.test.ts
@@ -121,6 +121,7 @@ test("entity rows only project declared kinds and keep canonical refs", () => {
       title: "ADR-0020 · Decision 与 ADR 边界",
       locator: { kind: "repository-path", value: "harness/adr/ADR-0020.md" },
       revision: 42,
+      archived: false,
     },
   ]);
 });
@@ -157,6 +158,7 @@ test("entity rows include daemon-local runtime instances with Provider deep link
       title: "Codex Sol",
       locator: { kind: "entity-ref", value: "provider/codex-sol" },
       revision: 0,
+      archived: false,
     },
   ]);
 });

--- a/packages/daemon/test/json-rpc-protocol.test.ts
+++ b/packages/daemon/test/json-rpc-protocol.test.ts
@@ -316,6 +316,8 @@ test("GUI action facets are exact, typed, and exclude the generic runner", () =>
     ["repo.decision.reject", { decisionId: "dec_A", reason: "Rejected" }],
     ["repo.decision.defer", { decisionId: "dec_A", reason: "Deferred" }],
     ["repo.entity.import", { entityKind: "software/coding/architecture-decision-record@1", locator: "harness/adr/ADR-0001-example.md", expectedVersion: 0, title: "Example ADR" }],
+    ["repo.entity.update", { entityKind: "software/coding/architecture-decision-record@1", entityId: "ADR-abc", expectedVersion: 7, title: "Updated", locator: "harness/adr/ADR-0002.md", contentVersion: "git:abc" }],
+    ["repo.entity.archive", { entityKind: "software/coding/architecture-decision-record@1", entityId: "ADR-abc", expectedVersion: 8, reason: "Superseded" }],
     ["repo.receipt.show", { opId: "op_A" }],
     ["repo.settings.update", { defaultPreset: "strict-task", locale: "zh-CN", idempotencyKey: "settings-once" }],
     ["repo.gui.catalog.reread", {}],

--- a/packages/gui/src/renderer/App.tsx
+++ b/packages/gui/src/renderer/App.tsx
@@ -94,7 +94,7 @@ function AppShell() {
     if (next !== activeRepoId) setActiveRepoId(next);
   }, [activeRepoId, systemQuery.data?.repos]);
   const projectId = activeRepoId ?? "unselected";
-  // 已注册 kind 清单(内核内建 + 本仓 vertical 声明):图筛选、命令面板与实体说明面同源于此。
+  // 已注册 kind 清单(内核内建 + 本仓 vertical 声明):图筛选、命令面板与实体页同源于此。
   const entityKinds = useEntityKindOptions(projectId);
   const governedEntities = useGovernedEntityRows(projectId);
   const declaredKinds = useMemo(() => entityKinds.map(({ kind }) => kind), [entityKinds]);
@@ -614,7 +614,7 @@ function AppShell() {
               ) : view === "entities" ? (
                 <EntitiesView
                   repoId={projectId}
-                  // 实体说明深链接 entitydoc/<kind>:落目录页内详情(与 preset/<id> 同构,
+                  // 实体页深链接 entitydoc/<kind>:落目录页内详情(与 preset/<id> 同构,
                   // 推栈回撤原路返回)。声明实体的 <kind>/<id> 也落这里(见 entityRoutes)。
                   focusedRef={focusedEntityRef}
                   onOpenEntityDoc={(kind) =>

--- a/packages/gui/src/renderer/components/entityDoc/GovernedEntityPanel.tsx
+++ b/packages/gui/src/renderer/components/entityDoc/GovernedEntityPanel.tsx
@@ -4,7 +4,7 @@ import { Plus } from "@phosphor-icons/react";
 import type { EntityKindRow } from "../../entity-kind-catalog-client.ts";
 import type { GovernedEntityRow } from "../../graph/governedEntities.ts";
 import { entityKindQueryKeys } from "../../entity-kind-data.ts";
-import { importEntity } from "../../entity-locator-client.ts";
+import { archiveEntity, importEntity, updateEntity } from "../../entity-locator-client.ts";
 import { NewGovernedEntityForm, type NewGovernedEntityInput } from "./NewGovernedEntityForm.tsx";
 
 /**
@@ -29,11 +29,13 @@ export function GovernedEntityPanel({
   readonly onSelect: (ref: string) => void;
 }) {
   const [query, setQuery] = useState("");
+  const [showArchived, setShowArchived] = useState(false);
   const needle = query.trim().toLowerCase();
+  const activeRows = showArchived ? rows : rows.filter((entity) => !entity.archived);
   const visible =
     needle === ""
-      ? rows
-      : rows.filter((entity) =>
+      ? activeRows
+      : activeRows.filter((entity) =>
           [entity.title ?? "", entity.entityId, entity.locator?.value ?? ""].some((text) =>
             text.toLowerCase().includes(needle),
           ),
@@ -44,6 +46,10 @@ export function GovernedEntityPanel({
         <h2 className="ui-body font-semibold">本仓实体</h2>
         <span className="ui-micro text-text-faint">{rows.length} 条</span>
         {row.importable && <NewEntityControl repoId={repoId} row={row} />}
+        <label className="ml-auto ui-micro text-text-faint">
+          <input type="checkbox" checked={showArchived} onChange={(event) => setShowArchived(event.target.checked)} />
+          显示已归档
+        </label>
       </header>
       {rows.length === 0 ? (
         <p data-testid="governed-entity-empty" className="mt-2 ui-meta text-text-faint">
@@ -70,22 +76,28 @@ export function GovernedEntityPanel({
             <ul data-testid="governed-entity-list" className="mt-2 flex flex-col gap-1">
               {visible.map((entity) => (
                 <li key={entity.ref}>
-                  <button
-                    type="button"
-                    data-testid={`governed-entity-row-${entity.entityId}`}
-                    onClick={() => onSelect(entity.ref)}
+                  <div
                     className={[
                       "w-full rounded-md border px-2 py-1.5 text-left",
+                      entity.archived ? "opacity-50" : "",
                       entity.ref === selectedRef
                         ? "border-border-strong bg-surface-raised"
                         : "border-border hover:bg-surface-raised",
                     ].join(" ")}
                   >
-                    <span className="block truncate ui-meta text-text">{entity.title ?? entity.entityId}</span>
-                    <span className="block truncate font-mono ui-micro text-text-faint">
-                      {entity.locator?.value ?? entity.entityId}
-                    </span>
-                  </button>
+                    <button
+                      type="button"
+                      data-testid={`governed-entity-row-${entity.entityId}`}
+                      onClick={() => onSelect(entity.ref)}
+                      className="w-full text-left"
+                    >
+                      <span className="block truncate ui-meta text-text">{entity.title ?? entity.entityId}</span>
+                      <span className="block truncate font-mono ui-micro text-text-faint">
+                        {entity.locator?.value ?? entity.entityId}
+                      </span>
+                    </button>
+                    {!entity.archived && <EntityMutationControls repoId={repoId} entity={entity} />}
+                  </div>
                 </li>
               ))}
             </ul>
@@ -93,6 +105,93 @@ export function GovernedEntityPanel({
         </>
       )}
     </section>
+  );
+}
+
+function EntityMutationControls({ repoId, entity }: { readonly repoId: string; readonly entity: GovernedEntityRow }) {
+  const queryClient = useQueryClient();
+  const [mode, setMode] = useState<"edit" | "archive" | null>(null);
+  const [title, setTitle] = useState(entity.title ?? "");
+  const [locator, setLocator] = useState(entity.locator?.value ?? "");
+  const [contentVersion, setContentVersion] = useState("");
+  const [reason, setReason] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const finish = (receipt: { readonly outcome: string; readonly [key: string]: unknown }) => {
+    if (receipt.outcome !== "applied" && receipt.outcome !== "no_changes") return setError(importFailureText(receipt));
+    setMode(null);
+    void queryClient.invalidateQueries({ queryKey: entityKindQueryKeys.rows(repoId) });
+  };
+  return (
+    <div className="mt-1 flex flex-wrap gap-1 ui-micro">
+      <button type="button" onClick={() => setMode("edit")}>
+        编辑
+      </button>
+      <button type="button" onClick={() => setMode("archive")}>
+        归档
+      </button>
+      {mode === "edit" && (
+        <form
+          className="flex w-full flex-col gap-1"
+          onSubmit={(event) => {
+            event.preventDefault();
+            setError(null);
+            void updateEntity({
+              repoId,
+              entityKind: entity.kind,
+              entityId: entity.entityId,
+              expectedVersion: entity.revision,
+              title,
+              locator,
+              ...(contentVersion ? { contentVersion } : {}),
+            })
+              .then(finish)
+              .catch((cause: unknown) => setError(cause instanceof Error ? cause.message : String(cause)));
+          }}
+        >
+          <input aria-label="title" value={title} onChange={(event) => setTitle(event.target.value)} />
+          <input
+            aria-label={`${entity.locator?.kind ?? "locator"} locator`}
+            value={locator}
+            onChange={(event) => setLocator(event.target.value)}
+          />
+          <input
+            aria-label="content version"
+            value={contentVersion}
+            onChange={(event) => setContentVersion(event.target.value)}
+          />
+          {entity.locator?.kind === "repository-path" && <span>保存后右侧 Markdown 预览会刷新。</span>}
+          {entity.locator?.kind === "url" && <span>URL 可达性由导入/预览读面提示。</span>}
+          <button type="submit">保存</button>
+        </form>
+      )}
+      {mode === "archive" && (
+        <form
+          className="flex w-full gap-1"
+          onSubmit={(event) => {
+            event.preventDefault();
+            setError(null);
+            void archiveEntity({
+              repoId,
+              entityKind: entity.kind,
+              entityId: entity.entityId,
+              expectedVersion: entity.revision,
+              reason,
+            })
+              .then(finish)
+              .catch((cause: unknown) => setError(cause instanceof Error ? cause.message : String(cause)));
+          }}
+        >
+          <input
+            aria-label="archive reason"
+            required
+            value={reason}
+            onChange={(event) => setReason(event.target.value)}
+          />
+          <button type="submit">确认归档</button>
+        </form>
+      )}
+      {error && <span className="w-full text-status-blocked">{error}</span>}
+    </div>
   );
 }
 

--- a/packages/gui/src/renderer/entities-data.ts
+++ b/packages/gui/src/renderer/entities-data.ts
@@ -9,7 +9,7 @@ import { triadicQueryKeys } from "./triadic-data.ts";
 import type { RelationFactSummaryRow } from "./api-client.ts";
 
 /**
- * 实体说明面的活行数读面:全部复用既有读与既有 queryKey(共享缓存、共享
+ * 实体页的活行数读面:全部复用既有读与既有 queryKey(共享缓存、共享
  * ledger 失效),本模块不新造任何读方法。hook 只在说明面挂载时被调用——
  * 没人看这个面就不请求(与 triadic 读面同一纪律)。
  */

--- a/packages/gui/src/renderer/entity-docs.ts
+++ b/packages/gui/src/renderer/entity-docs.ts
@@ -2,7 +2,7 @@ import type { ViewId } from "./navigation/viewHistory.ts";
 import type { EntityKindCatalog, EntityKindRow } from "./entity-kind-catalog-client.ts";
 
 /**
- * 实体说明面(dec_2935057783CD5D56E9F287AE4D CH4)的说明内容目录。
+ * 实体页(dec_2935057783CD5D56E9F287AE4D CH4)的说明内容目录。
  *
  * 这是一个**静态策展目录**:renderer 不能在浏览器里 import kernel(kernel 带
  * node 内置模块),所以说明内容在这里以数据形式落地。它与代码实况的一致性

--- a/packages/gui/src/renderer/entity-kind-data.ts
+++ b/packages/gui/src/renderer/entity-kind-data.ts
@@ -10,7 +10,7 @@ import type { GovernedEntityRow } from "./graph/governedEntities.ts";
 import type { EntityTypeOption } from "./components/GraphFilterPanel.tsx";
 
 /**
- * 已注册 kind 清单的读 hook。GUI 的四个消费面(实体说明分组、领地节点类型、
+ * 已注册 kind 清单的读 hook。GUI 的四个消费面(实体页分组、领地节点类型、
  * 筛选面板、命令面板)都从这一个 query 派生,不各留一份清单。
  */
 export const entityKindQueryKeys = {

--- a/packages/gui/src/renderer/entity-locator-client.ts
+++ b/packages/gui/src/renderer/entity-locator-client.ts
@@ -32,6 +32,22 @@ type LocatorBridge = {
     readonly expectedVersion: number;
     readonly title?: string;
   }) => Promise<unknown>;
+  readonly updateEntity: (payload: {
+    readonly repoId: string;
+    readonly entityKind: string;
+    readonly entityId: string;
+    readonly expectedVersion: number;
+    readonly title?: string;
+    readonly locator?: string;
+    readonly contentVersion?: string;
+  }) => Promise<unknown>;
+  readonly archiveEntity: (payload: {
+    readonly repoId: string;
+    readonly entityKind: string;
+    readonly entityId: string;
+    readonly expectedVersion: number;
+    readonly reason: string;
+  }) => Promise<unknown>;
 };
 
 const bridge = (): Partial<LocatorBridge> => (window.harness as unknown as Partial<LocatorBridge> | undefined) ?? {};
@@ -85,4 +101,34 @@ export async function importEntity(input: EntityImportInput): Promise<GuiActionR
   if (!isRendererRecord(value) || value.schema !== "command-receipt/v2" || typeof value.outcome !== "string")
     throw new Error(rendererErrorHint(value, "Entity import bridge returned an invalid result."));
   return value as unknown as GuiActionResult;
+}
+
+async function mutationResult(channel: ((payload: never) => Promise<unknown>) | undefined, payload: object) {
+  if (!channel) throw new Error("Entity mutation bridge is unavailable.");
+  const value = await channel(payload as never);
+  if (!isRendererRecord(value) || value.schema !== "command-receipt/v2" || typeof value.outcome !== "string")
+    throw new Error(rendererErrorHint(value, "Entity mutation bridge returned an invalid result."));
+  return value as unknown as GuiActionResult;
+}
+
+export function updateEntity(input: {
+  readonly repoId: string;
+  readonly entityKind: string;
+  readonly entityId: string;
+  readonly expectedVersion: number;
+  readonly title?: string;
+  readonly locator?: string;
+  readonly contentVersion?: string;
+}): Promise<GuiActionResult> {
+  return mutationResult(bridge().updateEntity as ((payload: never) => Promise<unknown>) | undefined, input);
+}
+
+export function archiveEntity(input: {
+  readonly repoId: string;
+  readonly entityKind: string;
+  readonly entityId: string;
+  readonly expectedVersion: number;
+  readonly reason: string;
+}): Promise<GuiActionResult> {
+  return mutationResult(bridge().archiveEntity as ((payload: never) => Promise<unknown>) | undefined, input);
 }

--- a/packages/gui/src/renderer/graph/governedEntities.ts
+++ b/packages/gui/src/renderer/graph/governedEntities.ts
@@ -13,6 +13,7 @@ export interface GovernedEntityRow {
   readonly title: string | null;
   readonly locator: { readonly kind: string; readonly value: string } | null;
   readonly revision: number;
+  readonly archived: boolean;
 }
 
 /** 没有标题就显示 entityId——不编造一个好看的名字。 */

--- a/packages/gui/src/renderer/navigation/entityRoutes.ts
+++ b/packages/gui/src/renderer/navigation/entityRoutes.ts
@@ -23,7 +23,7 @@ export interface EntityDetailTarget {
  * decision/<id> → 决策详情页;fact/<anchor> → 事实详情页;其余 → null。
  *
  * `declaredKinds` 是已注册 kind 读面上的 kind 清单:声明出来的实体没有专页,统一落
- * 实体说明面的该 kind 详情(与 entitydoc/<kind> 同一落点),整条 ref 原样下发,由那一页
+ * 实体页的该 kind 详情(与 entitydoc/<kind> 同一落点),整条 ref 原样下发,由那一页
  * 选中对应实体。本函数不持有 kind 清单——不传就只认代码里有专页的那些。
  */
 export function entityDetailTargetOf(ref: string, declaredKinds: readonly string[] = []): EntityDetailTarget | null {
@@ -59,7 +59,7 @@ export function entityDetailTargetOf(ref: string, declaredKinds: readonly string
     if (!presetId) return null;
     return { view: "presets", focusedEntityRef: `preset/${presetId}` };
   }
-  // entitydoc/<kind> → 实体说明面内的实体详情(dec_2935057783CD5D56E9F287AE4D CH4):
+  // entitydoc/<kind> → 实体页内的实体详情(dec_2935057783CD5D56E9F287AE4D CH4):
   // 与 preset/<id> 同一条「目录页内详情」路径——落 entities 视图,focusedEntityRef
   // 区分目录/详情,推栈回撤原路返回。
   if (ref.startsWith("entitydoc/")) {

--- a/packages/gui/src/renderer/views/EntitiesView.tsx
+++ b/packages/gui/src/renderer/views/EntitiesView.tsx
@@ -12,7 +12,7 @@ import type { EntityKindCatalog } from "../entity-kind-catalog-client.ts";
 import type { GovernedEntityRow } from "../graph/governedEntities.ts";
 
 /**
- * 实体说明面(dec_2935057783CD5D56E9F287AE4D CH4):三元语与扩展实体集中在一
+ * 实体目录面(dec_2935057783CD5D56E9F287AE4D CH4):三元语与扩展实体集中在一
  * 个目录上「看见它们是什么」。双重身份:对内是限制面(受控词表与合法动作在这
  * 里可见,不允许随手自由文本),对外是产品展示面(陌生人第一次看懂三元语内核
  * 的入口)。目录 + 详情沿用 PresetsView 的范式(entitydoc/<kind> 深链接,推栈
@@ -28,7 +28,7 @@ export function EntitiesView({
 }: {
   readonly repoId: string;
   /**
-   * 详情落点。两种形态:`entitydoc/<kind>`(打开某 kind 的说明)与声明实体的
+   * 详情落点。两种形态:`entitydoc/<kind>`(打开某 kind 的详情)与声明实体的
    * `<kind>/<entityId>`(打开该 kind 并选中这一个实体)。null = 目录页。
    */
   readonly focusedRef: string | null;

--- a/packages/gui/src/renderer/views/EntityDocDetailView.tsx
+++ b/packages/gui/src/renderer/views/EntityDocDetailView.tsx
@@ -14,7 +14,7 @@ import type { GovernedEntityRow } from "../graph/governedEntities.ts";
 const LEFT_COLUMN_CLASS = "w-[400px] shrink-0 overflow-y-auto border-r border-border px-4 py-4";
 
 /**
- * 实体说明面·详情:两栏骨架——左列(固定宽,内部自滚动)承载说明本体:描述、存放、
+ * 实体页·详情:两栏骨架——左列(固定宽,内部自滚动)承载说明本体:描述、存放、
  * GUI 入口、核心字段(含合法写入动作)、状态词表、关系,以及声明实体的「本仓实体」
  * 清单(含搜索与新建);右栏是选中实体的自适应渲染器(`entity-locator-renderer.ts`
  * 按 locator 类型选),占满剩余宽度与全高,未选中时呈真实空态。内核实体(task /

--- a/packages/gui/test/preload-allowlist.test.ts
+++ b/packages/gui/test/preload-allowlist.test.ts
@@ -149,7 +149,8 @@ test("preload exposes only the approved API methods", () => {
   assert.throws(() => assertPreloadPayload("getTasks", { repoId: "repo-a", staleRepoId: "repo-b" }), /not allowed/u);
   assert.throws(() => assertPreloadPayload("getSystemStatus", { repoId: "repo-a" }), /not allowed/u);
   assert.equal(getPreloadApiCapability("getTasks").status, "shipped");
-  assert.equal(daemonGuiActionMethods.length, 31);
+  // entity.update / entity.archive add the updateEntity and archiveEntity GUI methods.
+  assert.equal(daemonGuiActionMethods.length, 33);
   assert.equal(
     daemonGuiActionMethods.some(({ method }) => method === "repo.task.run"),
     false,

--- a/packages/kernel/src/domain/artifact-entity-actions.ts
+++ b/packages/kernel/src/domain/artifact-entity-actions.ts
@@ -1,0 +1,81 @@
+import {
+  noSdkExposure,
+  entityAction,
+  type EntityActionContract,
+  type EntityActionInputContract,
+  type EntityKindContract,
+} from "./entity-kind-registry.ts";
+
+const execution = (ingress: string) =>
+  Object.freeze({
+    ingress,
+    compile: null,
+    read: false,
+    implementation: "catalog-runtime" as const,
+    topology: "center-forward-write" as const,
+    targetIdField: "entityId",
+  });
+
+const input = (fields: EntityActionInputContract["fields"]): EntityActionInputContract =>
+  Object.freeze({ schema: "entity-action-input/v1", fields: Object.freeze(fields), exactlyOneOf: Object.freeze([]) });
+
+export const artifactEntityImportActionInput = input([
+  { field: "entityKind", type: "string", required: true },
+  { field: "locator", type: "string", required: true },
+  { field: "expectedVersion", type: "number", required: true },
+  { field: "title", type: "string", required: false },
+  { field: "entityId", type: "string", required: false },
+  { field: "sourceIdentity", type: "string", required: false },
+  { field: "idempotencyKey", type: "string", required: false },
+  { field: "dryRun", type: "boolean", required: false },
+]);
+
+const action = (kind: string, identity: EntityKindContract["id"], id: string, ingress: string): EntityActionContract =>
+  Object.freeze({
+    ...entityAction(kind, identity, id, noSdkExposure, execution(ingress)),
+    concurrency: Object.freeze({
+      expectedVersion: Object.freeze({ authority: "entity-aggregate-revision", required: true }),
+      leasePolicy: Object.freeze({ authority: "center-repo-cell-single-writer" }),
+      occurrenceClaim: Object.freeze({ authority: "not-applicable" }),
+      idempotency: Object.freeze({ authority: "operation-id" }),
+      artifactOwnership: Object.freeze({ owner: "entity", refTemplate: `${kind}/{entityId}` }),
+    }),
+    explain: `${kind}.${id} runs through the canonical entity revision fence.`,
+  });
+
+export function artifactEntityActionCatalog(
+  kind: string,
+  identity: EntityKindContract["id"],
+): NonNullable<EntityKindContract["actionCatalog"]> {
+  const imported = action(kind, identity, "import", "entity-import");
+  return Object.freeze({
+    ref: "kernel/entity-event/v1",
+    actions: Object.freeze([
+      Object.freeze({ ...imported, input: artifactEntityImportActionInput }),
+      Object.freeze({
+        ...action(kind, identity, "update", "entity-update"),
+        input: input([
+          { field: "entityKind", type: "string", required: true },
+          { field: "entityId", type: "string", required: true },
+          { field: "expectedVersion", type: "number", required: true },
+          { field: "title", type: "string", required: false },
+          { field: "locator", type: "string", required: false },
+          { field: "contentVersion", type: "string", required: false },
+        ]),
+      }),
+      Object.freeze({
+        ...action(kind, identity, "archive", "entity-archive"),
+        input: input([
+          { field: "entityKind", type: "string", required: true },
+          { field: "entityId", type: "string", required: true },
+          { field: "reason", type: "string", required: true },
+          { field: "expectedVersion", type: "number", required: true },
+        ]),
+      }),
+      Object.freeze({
+        ...entityAction(kind, identity, "distill-candidate", noSdkExposure, execution("distill-candidate")),
+        explain: `${kind}.distill-candidate creates a generated candidate artifact without canonical writes.`,
+      }),
+    ]),
+  });
+}

--- a/packages/kernel/src/domain/artifact-entity.ts
+++ b/packages/kernel/src/domain/artifact-entity.ts
@@ -246,7 +246,7 @@ export function artifactEntityContractFromSnapshot(
     id: identity,
     residency: { authored: "ledger" as const },
     relationEndpoint: { eligible: true as const },
-    baseActions: ["pin", "unpin", "relate", "unrelate", "archive", "explain"],
+    baseActions: ["pin", "unpin", "relate", "unrelate", "update", "archive", "explain"],
     schema: artifactDescriptorSchema(
       {
         descriptorSchemaRef: decoded.descriptorSchemaRef,

--- a/packages/kernel/src/domain/base-entity.ts
+++ b/packages/kernel/src/domain/base-entity.ts
@@ -10,7 +10,15 @@ export type EntityDisposition = PackageDisposition;
 export type EntityResidency = "ledger" | "runtime-local" | "projection";
 export type EntityResidencyFacets = Readonly<Record<string, EntityResidency>>;
 
-export const baseEntityActionIds = Object.freeze(["pin", "unpin", "relate", "unrelate", "archive", "explain"] as const);
+export const baseEntityActionIds = Object.freeze([
+  "pin",
+  "unpin",
+  "relate",
+  "unrelate",
+  "update",
+  "archive",
+  "explain",
+] as const);
 export type BaseEntityActionId = (typeof baseEntityActionIds)[number];
 
 export interface RelationEndpointEligibility {

--- a/packages/kernel/src/domain/default-policy.ts
+++ b/packages/kernel/src/domain/default-policy.ts
@@ -27,6 +27,8 @@ const repositoryWriteActions = Object.freeze([
   "doc-retire",
   "doc-submit",
   "entity-import",
+  "entity-update",
+  "entity-archive",
   "entity-migrate-squads",
   "fact-reclassify",
   "fact-record",

--- a/packages/kernel/src/domain/entity-action-explanation.ts
+++ b/packages/kernel/src/domain/entity-action-explanation.ts
@@ -1,11 +1,11 @@
 import { validateActorIdentity } from "./actor-identity.ts";
 import { parseEntityRef, type EntityRef } from "./entity-ref.ts";
 import {
-  artifactEntityActionCatalog,
   getEntityKindContract,
   type EntityActionContract,
   type EntityActionInputField,
 } from "./entity-kind-registry.ts";
+import { artifactEntityActionCatalog } from "./artifact-entity-actions.ts";
 import { isEntityActionUnmetCriterion, type EntityActionUnmetCriterionV1 } from "./receipt-domain-registry.ts";
 import type { AuthorizationDecision } from "./receipt-frame.ts";
 

--- a/packages/kernel/src/domain/entity-event.ts
+++ b/packages/kernel/src/domain/entity-event.ts
@@ -68,6 +68,13 @@ export interface ArtifactTargetMissingPayload {
   readonly artifactContract: ArtifactEntityContractSnapshot;
 }
 
+export interface ArtifactEntityArchivedPayload {
+  readonly entityKind: string;
+  readonly entityId: string;
+  readonly reason: string;
+  readonly artifactContract: ArtifactEntityContractSnapshot;
+}
+
 export type EntityUpsertEventV1 = EventEnvelope<
   "entity-event/v1",
   "entity_upserted",
@@ -86,7 +93,24 @@ export type EntityTargetMissingEventV1 = EventEnvelope<
   ActorIdentity,
   ArtifactTargetMissingPayload
 >;
-export type EntityEventV1 = EntityUpsertEventV1 | EntityContentObservedEventV1 | EntityTargetMissingEventV1;
+export type EntityUpdatedEventV1 = EventEnvelope<
+  "entity-event/v1",
+  "entity_updated",
+  ActorIdentity,
+  ArtifactContentObservedPayload
+>;
+export type EntityArchivedEventV1 = EventEnvelope<
+  "entity-event/v1",
+  "entity_archived",
+  ActorIdentity,
+  ArtifactEntityArchivedPayload
+>;
+export type EntityEventV1 =
+  | EntityUpsertEventV1
+  | EntityContentObservedEventV1
+  | EntityTargetMissingEventV1
+  | EntityUpdatedEventV1
+  | EntityArchivedEventV1;
 
 // Append-only history predating the generic store carries the upsert payload under this retired envelope.
 export type LegacyAgentEntityEventV1 = EventEnvelope<
@@ -96,12 +120,18 @@ export type LegacyAgentEntityEventV1 = EventEnvelope<
   EntityUpsertPayload
 >;
 export type StoredEntityEventV1 = EntityEventV1 | LegacyAgentEntityEventV1;
-export type EntityDeclarationEventV1 = EntityUpsertEventV1 | EntityContentObservedEventV1 | LegacyAgentEntityEventV1;
+export type EntityDeclarationEventV1 =
+  | EntityUpsertEventV1
+  | EntityContentObservedEventV1
+  | EntityUpdatedEventV1
+  | LegacyAgentEntityEventV1;
 
 const entityEventEnvelopes: ReadonlyArray<readonly [schema: string, type: string]> = [
   ["entity-event/v1", "entity_upserted"],
   ["entity-event/v1", "entity_content_observed"],
   ["entity-event/v1", "entity_target_missing"],
+  ["entity-event/v1", "entity_updated"],
+  ["entity-event/v1", "entity_archived"],
   ["agent-entity-event/v1", "agent_entity_written"],
 ];
 const LEGACY_AGENT_ENTITY_POLICY_ID = "typed-agent-entity/v1";
@@ -128,6 +158,18 @@ export interface EntityContentObservedBundle {
 export interface EntityTargetMissingBundle {
   readonly event: EntityTargetMissingEventV1;
   readonly plan: FrozenWritePlan<"EntityTargetMissing">;
+  readonly blobs: readonly [];
+}
+
+export interface EntityUpdatedBundle {
+  readonly event: EntityUpdatedEventV1;
+  readonly plan: FrozenWritePlan<"EntityUpdated">;
+  readonly blobs: readonly [EntityDeclarationBlob];
+}
+
+export interface EntityArchivedBundle {
+  readonly event: EntityArchivedEventV1;
+  readonly plan: FrozenWritePlan<"EntityArchived">;
   readonly blobs: readonly [];
 }
 
@@ -221,6 +263,60 @@ export function compileEntityTargetMissing(
   return { event, plan: entityTargetMissingWritePlan(event), blobs: [] };
 }
 
+export function compileEntityUpdated(
+  input: EntityEventEnvelopeInput & {
+    readonly contract: EntityStoreKindContract;
+    readonly contractSnapshot: ArtifactEntityContractSnapshot;
+    readonly descriptor: ArtifactDescriptor;
+  },
+): EntityUpdatedBundle {
+  const descriptor = decodeArtifactDescriptor(input.contract, input.descriptor),
+    { body, claim } = declarationContent(input.contract, descriptor.entityId, descriptor),
+    observationId = artifactObservationId({
+      entityId: descriptor.entityId,
+      locator: descriptor.locator,
+      resolution: descriptor.contentVersion,
+    }),
+    event: EntityUpdatedEventV1 = {
+      ...eventEnvelope(input),
+      type: "entity_updated",
+      payload: {
+        entityKind: input.contract.kind,
+        entityId: descriptor.entityId,
+        declarationDocumentClaim: claim,
+        locator: descriptor.locator,
+        sourceIdentity: descriptor.source,
+        observedContentVersion: descriptor.contentVersion,
+        resolver: "descriptor-update",
+        observationId,
+        artifactContract: input.contractSnapshot,
+      },
+    };
+  assertValidCurrent(event);
+  return { event, plan: declarationWritePlan("EntityUpdated", event, "entity/v1"), blobs: [blob(claim, body)] };
+}
+
+export function compileEntityArchived(
+  input: EntityEventEnvelopeInput & {
+    readonly contractSnapshot: ArtifactEntityContractSnapshot;
+    readonly entityId: string;
+    readonly reason: string;
+  },
+): EntityArchivedBundle {
+  const event: EntityArchivedEventV1 = {
+    ...eventEnvelope(input),
+    type: "entity_archived",
+    payload: {
+      entityKind: input.contractSnapshot.typeIdentity,
+      entityId: input.entityId,
+      reason: input.reason.trim(),
+      artifactContract: input.contractSnapshot,
+    },
+  };
+  assertValidCurrent(event);
+  return { event, plan: entityArchivedWritePlan(event), blobs: [] };
+}
+
 export function validateEntityEvent(value: unknown): readonly string[] {
   return validateEntityEventFields(value, true);
 }
@@ -253,6 +349,22 @@ function validateEntityEventFields(value: unknown, allowUnknownFields: boolean):
   if (validateEventEnvelopeIdentity(value, allowUnknownFields).length) return ["entity event identity is invalid"];
   if (value.type === "entity_content_observed")
     return validateObservedPayload(value.payload, hasFields, String(value.opId), allowUnknownFields);
+  if (value.type === "entity_updated")
+    return validateObservedPayload(value.payload, hasFields, String(value.opId), allowUnknownFields);
+  if (value.type === "entity_archived") {
+    const payload = value.payload;
+    try {
+      artifactEntityContractFromSnapshot(payload.artifactContract, allowUnknownFields);
+    } catch {
+      return ["entity archive artifact contract is invalid"];
+    }
+    return typeof payload.entityKind === "string" &&
+      typeof payload.entityId === "string" &&
+      typeof payload.reason === "string" &&
+      payload.reason.length > 0
+      ? []
+      : ["entity archive payload is invalid"];
+  }
   if (value.type === "entity_target_missing")
     return validateMissingPayload(value.payload, hasFields, String(value.opId), allowUnknownFields);
   return validateUpsertPayload(value.schema, value.payload, hasFields);
@@ -263,7 +375,7 @@ export function isEntityEvent(event: { readonly schema: string; readonly type: s
 }
 
 export function isEntityDeclarationEvent(event: StoredEntityEventV1): event is EntityDeclarationEventV1 {
-  return event.type !== "entity_target_missing";
+  return event.type !== "entity_target_missing" && event.type !== "entity_archived";
 }
 
 export function entityUpsertWritePlan(event: EntityUpsertEventV1): FrozenWritePlan<"EntityUpsert"> {
@@ -292,6 +404,20 @@ export function entityTargetMissingWritePlan(
   );
 }
 
+export function entityArchivedWritePlan(event: EntityArchivedEventV1): FrozenWritePlan<"EntityArchived"> {
+  return freezeDeclaredWritePlan(
+    {
+      commandType: "EntityArchived",
+      targets: [
+        { kind: "event_file", path: eventObjectTarget(event.opId), operation: "create" },
+        { kind: "event_head", path: "harness/events/head.json", operation: "replace" },
+        { kind: "projection_invalidation", projection: "entity/v1", key: event.payload.entityId },
+      ],
+    },
+    ["EntityArchived"],
+  );
+}
+
 export function assertEntityEventInputs(
   event: EntityEventV1,
   plan: FrozenWritePlan | undefined,
@@ -302,13 +428,20 @@ export function assertEntityEventInputs(
     readonly body: string;
   }[],
 ): void {
-  if (event.type === "entity_target_missing") {
-    assertExactWritePlan(plan, entityTargetMissingWritePlan(event));
+  if (event.type === "entity_target_missing" || event.type === "entity_archived") {
+    assertExactWritePlan(
+      plan,
+      event.type === "entity_archived" ? entityArchivedWritePlan(event) : entityTargetMissingWritePlan(event),
+    );
     if (blobs.length) throw new Error("entity target-missing event must not carry content blobs");
     return;
   }
   const expected =
-    event.type === "entity_content_observed" ? entityContentObservedWritePlan(event) : entityUpsertWritePlan(event);
+    event.type === "entity_content_observed"
+      ? entityContentObservedWritePlan(event)
+      : event.type === "entity_updated"
+        ? declarationWritePlan("EntityUpdated", event, "entity/v1")
+        : entityUpsertWritePlan(event);
   assertExactWritePlan(plan, expected);
   const claim = event.payload.declarationDocumentClaim,
     declarationBlob = blobs.find((candidate) => candidate.sha256 === claim.sha256),
@@ -327,7 +460,7 @@ export function assertEntityEventInputs(
     throw new Error("entity declaration blob must be JSON");
   }
   const entity =
-    event.type === "entity_content_observed"
+    event.type === "entity_content_observed" || event.type === "entity_updated"
       ? decodeArtifactDescriptor(contract, value)
       : parseEntityJsonSchema(contract.schema, value, `${contract.kind} declaration`);
   if (!isRecord(entity) || entity[contract.id.field] !== event.payload.entityId)
@@ -359,14 +492,18 @@ export function assertEntityUpsertWritePlan(event: EntityEventV1, plan: FrozenWr
   const expected =
     event.type === "entity_target_missing"
       ? entityTargetMissingWritePlan(event)
-      : event.type === "entity_content_observed"
-        ? entityContentObservedWritePlan(event)
-        : entityUpsertWritePlan(event);
+      : event.type === "entity_archived"
+        ? entityArchivedWritePlan(event)
+        : event.type === "entity_content_observed"
+          ? entityContentObservedWritePlan(event)
+          : event.type === "entity_updated"
+            ? declarationWritePlan("EntityUpdated", event, "entity/v1")
+            : entityUpsertWritePlan(event);
   assertExactWritePlan(plan, expected);
 }
 
 export function contractForDeclarationEvent(event: EntityDeclarationEventV1): EntityStoreKindContract {
-  return event.type === "entity_content_observed"
+  return event.type === "entity_content_observed" || event.type === "entity_updated"
     ? artifactEntityContractFromSnapshot(event.payload.artifactContract)
     : requireEntityStoreKindContract(event.payload.entityKind);
 }
@@ -531,7 +668,7 @@ function declarationContent(contract: EntityStoreKindContract, entityId: string,
   return { body, claim };
 }
 
-function declarationWritePlan<Command extends "EntityUpsert" | "EntityContentObserved">(
+function declarationWritePlan<Command extends "EntityUpsert" | "EntityContentObserved" | "EntityUpdated">(
   commandType: Command,
   event: EntityDeclarationEventV1,
   projection: string,

--- a/packages/kernel/src/domain/entity-kind-registry.ts
+++ b/packages/kernel/src/domain/entity-kind-registry.ts
@@ -316,7 +316,7 @@ const capabilityExposure = (target: string, schemaId: string): EntitySdkExposure
     sdk: Object.freeze({ target: `${target[0]!.toUpperCase()}${target.slice(1)}Capability`, schemaId }),
     agentCapability: Object.freeze({ target, schemaId }),
   });
-const entityAction = (
+export const entityAction = (
   kind: string,
   identity: EntityKindContract["id"],
   id: string,
@@ -374,106 +374,6 @@ export const genericAuthoring = Object.freeze({
 });
 export const genericEntityStore = (pathTemplate: string, validate?: (value: unknown) => readonly string[]) =>
   Object.freeze({ document: declarationDocument(pathTemplate), ...(validate ? { validate } : {}) });
-
-export const artifactEntityImportActionInput = Object.freeze({
-  schema: "entity-action-input/v1" as const,
-  fields: Object.freeze([
-    { field: "entityKind", type: "string" as const, required: true },
-    { field: "locator", type: "string" as const, required: true },
-    { field: "expectedVersion", type: "number" as const, required: true },
-    { field: "title", type: "string" as const, required: false },
-    { field: "entityId", type: "string" as const, required: false },
-    { field: "sourceIdentity", type: "string" as const, required: false },
-    { field: "idempotencyKey", type: "string" as const, required: false },
-    { field: "dryRun", type: "boolean" as const, required: false },
-  ]),
-  exactlyOneOf: Object.freeze([]),
-} as const satisfies EntityActionInputContract);
-
-export function artifactEntityActionCatalog(
-  kind: string,
-  identity: EntityKindContract["id"],
-): NonNullable<EntityKindContract["actionCatalog"]> {
-  const declared = entityAction(
-    kind,
-    identity,
-    "import",
-    noSdkExposure,
-    Object.freeze({
-      ingress: "entity-import",
-      compile: null,
-      read: false,
-      implementation: "catalog-runtime" as const,
-      topology: "center-forward-write" as const,
-      targetIdField: "entityId",
-    }),
-  );
-  return Object.freeze({
-    ref: "kernel/entity-event/v1",
-    actions: Object.freeze([
-      Object.freeze({
-        ...declared,
-        input: artifactEntityImportActionInput,
-        criteria: Object.freeze([
-          Object.freeze({
-            ref: "entity/aggregate-revision",
-            failureCode: "revision_conflict",
-            explain: "The expected Entity revision must equal the latest canonical observation revision.",
-          }),
-          Object.freeze({
-            ref: "entity/source-resolution",
-            failureCode: "source_resolution_failed",
-            explain:
-              "The declared resolver must return either authoritative content or an authoritative missing result.",
-          }),
-        ]),
-        concurrency: Object.freeze({
-          expectedVersion: Object.freeze({ authority: "entity-aggregate-revision", required: true }),
-          leasePolicy: Object.freeze({ authority: "center-repo-cell-single-writer" }),
-          occurrenceClaim: Object.freeze({ authority: "entity-observation-id" }),
-          idempotency: Object.freeze({ authority: "entity-source-resolution-operation-id" }),
-          artifactOwnership: Object.freeze({
-            owner: "entity-revision",
-            refTemplate: "entity/{entityId}/revision/{revision}",
-          }),
-        }),
-        effects: Object.freeze([
-          Object.freeze({ ref: "entity-event/entity_content_observed", projection: "entity/v1" }),
-          Object.freeze({ ref: "entity-event/entity_target_missing", projection: "entity/v1" }),
-        ]),
-        explain:
-          `${kind}.import resolves one artifact source and appends entity-event/v1 under the ` +
-          "entity aggregate revision fence; dry-run performs no write.",
-      }),
-      Object.freeze({
-        ...entityAction(kind, identity, "distill-candidate", noSdkExposure, {
-          ingress: "distill-candidate",
-          compile: null,
-          read: false,
-          implementation: "catalog-runtime",
-          topology: "center-forward-write",
-          targetIdField: "entityRef",
-        }),
-        criteria: Object.freeze([
-          Object.freeze({
-            ref: "artifact/distill-candidate.validate",
-            failureCode: "invalid_command",
-            explain: "The distill candidate input must identify a valid workspace file or governed artifact entity.",
-          }),
-        ]),
-        failureCodes: Object.freeze([
-          Object.freeze({
-            code: "invalid_command",
-            source: "criterion",
-            explain: "distill-candidate may reject with invalid_command.",
-            nextCapabilityRef: null,
-          }),
-        ]),
-        explain: `${kind}.distill-candidate creates a generated candidate artifact without canonical writes.`,
-      }),
-    ]),
-  });
-}
 
 const taskExposure = capabilityExposure("task", "task-frontmatter");
 const factExposure = capabilityExposure("fact", "fact-event");

--- a/packages/kernel/src/domain/index.ts
+++ b/packages/kernel/src/domain/index.ts
@@ -167,7 +167,6 @@ export type { ContractVersion } from "./contract-version.ts";
 export { normalizePersistedTimestamp, timestamp } from "./timestamp.ts";
 
 export {
-  artifactEntityImportActionInput,
   getExecutableEntityAction,
   getEntityKindContract,
   getTaskActionForTransition,
@@ -306,9 +305,12 @@ export type {
   SquadDeclarationV1,
 } from "./agent-squad-schema.ts";
 export { EntitySchemaContractError } from "./entity-json-schema.ts";
+export { artifactEntityActionCatalog, artifactEntityImportActionInput } from "./artifact-entity-actions.ts";
 
 export {
   compileEntityContentObserved,
+  compileEntityArchived,
+  compileEntityUpdated,
   compileEntityTargetMissing,
   compileEntityUpsert,
   contractForDeclarationEvent,
@@ -318,6 +320,8 @@ export {
 } from "./entity-event.ts";
 export type {
   EntityContentObservedBundle,
+  EntityArchivedBundle,
+  EntityUpdatedBundle,
   EntityEventV1,
   EntityTargetMissingBundle,
   EntityUpsertBundle,

--- a/packages/kernel/src/domain/index.ts
+++ b/packages/kernel/src/domain/index.ts
@@ -305,7 +305,7 @@ export type {
   SquadDeclarationV1,
 } from "./agent-squad-schema.ts";
 export { EntitySchemaContractError } from "./entity-json-schema.ts";
-export { artifactEntityActionCatalog, artifactEntityImportActionInput } from "./artifact-entity-actions.ts";
+export { artifactEntityImportActionInput } from "./artifact-entity-actions.ts";
 
 export {
   compileEntityContentObserved,
@@ -320,8 +320,6 @@ export {
 } from "./entity-event.ts";
 export type {
   EntityContentObservedBundle,
-  EntityArchivedBundle,
-  EntityUpdatedBundle,
   EntityEventV1,
   EntityTargetMissingBundle,
   EntityUpsertBundle,

--- a/packages/kernel/src/domain/vertical-contract.ts
+++ b/packages/kernel/src/domain/vertical-contract.ts
@@ -9,13 +9,13 @@ import { baseEntityTypeContract, entityTypeContracts, type EntityTypeContract } 
 import { artifactEntityIdPattern } from "./entity-ref.ts";
 import { artifactDescriptorSchema, deepFreeze } from "./artifact-entity.ts";
 import {
-  artifactEntityActionCatalog,
   entityKindContracts,
   genericAuthoring,
   genericEntityStore,
   noSdkExposure,
   type EntityKindContract,
 } from "./entity-kind-registry.ts";
+import { artifactEntityActionCatalog } from "./artifact-entity-actions.ts";
 import {
   compileGovernedRelationDirections,
   type GovernedRelationCompilationAuthority,

--- a/packages/kernel/src/projection/rebuildable-task-projection-event-application.ts
+++ b/packages/kernel/src/projection/rebuildable-task-projection-event-application.ts
@@ -188,7 +188,9 @@ export function applyEvent(
       event.workspaceRevision,
       `event:${event.opId}`,
       "current",
-      event.type === "entity_content_observed" ? event.payload.observedContentVersion : event.workspaceRevision,
+      event.type === "entity_content_observed" || event.type === "entity_updated"
+        ? event.payload.observedContentVersion
+        : event.workspaceRevision,
     );
     return;
   }

--- a/packages/kernel/test/contracts/authorization-port.test.ts
+++ b/packages/kernel/test/contracts/authorization-port.test.ts
@@ -47,7 +47,8 @@ test("the default Policy covers the frozen durable inventory exactly once", () =
   // Action 进入 durable inventory(CEO 确认,与 rekey-facts 同角色),107 → 109。
   // task_046460a29d5a147d3c9ecf7f92:dispatch-records-migrate 从 canonical 派工副本恢复事件,109 → 110。
   // 2026-09-03 W1-F:center-only Squad migration 进入 durable inventory(CEO 已裁 cutover),110 → 111。
-  assert.equal(durablePolicyActions.length, 111);
+  // 2026-09-05:声明实体 update / archive 进入 durable inventory(CEO 已确认),111 → 113。
+  assert.equal(durablePolicyActions.length, 113);
   // 其余两条是自洽不变量,不需要第二个硬编码数字:清单内无重复(三个角色分段互不重叠),
   // 且每个 durable Action 恰好被一条 rule 覆盖。
   assert.equal(new Set(durablePolicyActions).size, durablePolicyActions.length);

--- a/tools/gui-e2e/scenarios/declared-entity-kinds.mjs
+++ b/tools/gui-e2e/scenarios/declared-entity-kinds.mjs
@@ -48,7 +48,7 @@ export default {
     try {
       const issueUrl = `http://127.0.0.1:${served.address().port}/issues/2224`;
 
-      await page.getByRole("button", { name: /实体说明|Entities/u }).click();
+      await page.getByRole("button", { name: /^实体$|Entities/u }).click();
       await page.getByTestId("entities-content").waitFor();
 
       // 1. 说明面按声明长出「声明实体」一组——GUI 没有这份清单,它来自读面。

--- a/tools/gui-e2e/scenarios/declared-entity-kinds.mjs
+++ b/tools/gui-e2e/scenarios/declared-entity-kinds.mjs
@@ -80,7 +80,21 @@ export default {
       await markdown.waitFor();
       assert.match(await markdown.innerText(), /声明实体探针/u);
 
-      // 6. 第二种声明 kind:external-issue(url locator)不改 GUI 就出现在同一目录里。
+      // 6. 同一行完成 descriptor update → archive。写后列表由失效查询重新读取;
+      //    archive 默认隐藏,打开「显示已归档」后以灰显行保留审计可见性。
+      await list.getByRole("button", { name: "编辑" }).click();
+      await list.getByLabel("title").fill("ADR-0001 · 已更新");
+      await list.getByLabel("repository-path locator").fill(LOCATOR);
+      await list.getByLabel("content version").fill("revision:gui-e2e-2");
+      await list.getByRole("button", { name: "保存" }).click();
+      await list.getByText("ADR-0001 · 已更新").waitFor();
+      await list.getByRole("button", { name: "归档" }).click();
+      await list.getByLabel("archive reason").fill("E2E lifecycle complete");
+      await list.getByRole("button", { name: "确认归档" }).click();
+      await page.getByLabel("显示已归档").check();
+      await list.getByText("ADR-0001 · 已更新").waitFor();
+
+      // 7. 第二种声明 kind:external-issue(url locator)不改 GUI 就出现在同一目录里。
       await page
         .getByRole("button", { name: /返回上一级|Back to previous/u })
         .first()
@@ -93,7 +107,7 @@ export default {
       await page.getByTestId("entity-declaration-facets").waitFor();
       await page.getByTestId("governed-entity-empty").waitFor();
 
-      // 7. url locator 的新建:表单出现 locator 类型选择(声明给了 url/external-key),
+      // 8. url locator 的新建:表单出现 locator 类型选择(声明给了 url/external-key),
       //    locator 字符串按 http(s) 前缀推断为 url kind,daemon 真实 GET 一次性 HTTP 服务。
       await page.getByTestId("governed-entity-new").click();
       await page.getByTestId("new-governed-entity-form").waitFor();
@@ -106,7 +120,7 @@ export default {
       const issueRowText = await issueRows.first().innerText();
       assert.match(issueRowText, /issues\/2224/u, "the external-issue row must show its url locator");
 
-      // 8. 领地筛选按 kind 生效:两个声明 kind 的类型 chip 都由读面派生,标签取声明显示名;
+      // 9. 领地筛选按 kind 生效:两个声明 kind 的类型 chip 都由读面派生,标签取声明显示名;
       //    图节点层:每种声明 kind 一块领地,chip 的 navRef 是 <kind>/<entityId>。
       await page
         .getByRole("button", { name: /关系图|Relation Graph/u })


### PR DESCRIPTION
# English

## Summary
Declared entity instances (architecture-decision-record, external-issue) could only be created; `archive` existed as an action id with no write road and there was no `update` at all. This adds both as first-class kernel events on the canonical event stream, exposes them through the daemon single-write queue (JSON-RPC facets, HTTP, CLI) and gives the GUI governed-entity panel edit and archive affordances with locator-kind-specific inputs. `source` stays immutable because entity identity derives from it; archive is a separate `entity_archived` event carrying a reason, not a field smuggled into the seven-field descriptor. Rebased onto main after #2288 merged.

## Architectural Justification
Production churn is +686/-161 against main. The write road follows the existing route CLI/GUI → daemon protocol → RepoCell → entity action executor → kernel entity/store/projection; nothing new is invented. The artifact action catalog moved out of `entity-kind-registry.ts` into `artifact-entity-actions.ts` to keep the registry under the complexity ceiling; the registry no longer carries a second copy. Concurrent writers from several edges serialize in the RepoCell write and the stale one gets `revision_conflict` from `expectedVersion`; no locks were added.

## What Changed
- Kernel: `entity_updated` (unchanged `sourceIdentity`, replacement descriptor claim, locator, content version) and `entity_archived` (`entityKind`, `entityId`, `reason`) in `entity-event.ts`; reducer/projection support; `artifact-entity-actions.ts` split out of the registry; base-entity and default policy extended.
- Daemon: `repo.entity.update` / `repo.entity.archive` facets (`repo-write`), `/api/entities/update|archive`, authorization, `artifact-entity-action.ts` executor; `entity-rows-read.ts` carries archive metadata so the GUI can filter and dim.
- CLI: `ha entity update <kind> --id … [--title|--locator|--content-version] --expected-version` and `ha entity archive <kind> --id … --reason --expected-version`.
- GUI: `GovernedEntityPanel.tsx` edit + archive (reason + confirm), archived rows hidden by default with a 「显示已归档」 toggle; locator inputs per `repository-path` / `url` / `external-key`; `entity-locator-client.ts` clients.
- E2E scenario `declared-entity-kinds.mjs` extended to create → update → archive.

## Verification
- `npx tsc -b packages/kernel packages/daemon packages/cli packages/gui` clean; `npm run lint` clean; `check-cli-error-codes`, line-density, file-complexity gates pass locally.
- Focused node tests 31/31; GUI `entities-view` 15/15; JSON-RPC facet contract 1/1; isolated Ubuntu `artifact-entity-action.integration.test.ts` 1/1 including durable event sequence and cold rebuild.
- Full Electron E2E not executed in this round; CEO dogfoods the panel after merge.

## Review Evidence
- Second CI round (`5ae40b0ec`): durable-policy authorization ratchet advanced 111 → 113 for `entity-update` / `entity-archive` with explicit per-action authorization returns; the `declared-entity-kinds` GUI e2e scenario now follows the page rename (CEO isolated-lane run had caught the stale selector).
- First CI round (`a0accb89a`): GUI facet count pinned at 33 naming the two additions; entity routing extracted from `parseRouted`; three zero-consumer kernel barrel exports removed instead of allowlisted; `Governed-Entity-W2` declared as a protocol phase (derived-contracts / schema-closure); two stale 「实体说明」 comments in `EntitiesView.tsx` reworded.
- Task `task_5987fb3b4b410c041e17ede1aa`; Sol first round stopped with a challenge (descriptor cannot hold archived, source is identity, blocked files); CEO adopted the alternative design recorded in the task plan before the second round. Implementation report in the task package.

## Residual Risk
- Locator-specific editing is field-level (path / URL / key inputs with the existing Markdown preview); editing the Markdown body of a `repository-path` artifact is out of scope and tracked separately.

## Gate Harvest / 门收割
Removed-Paths: none
Removed-Gates: none

## Machine-Readable Declarations
Production-Delta: +686/-161

---

# 中文

## 摘要
声明实体实例(architecture-decision-record、external-issue)此前只能新建;`archive` 只是一个没有写路的动作 id,`update` 完全没有。本 PR 把两者做成 canonical 事件流上的一等 kernel 事件,经 daemon 单写队列暴露(JSON-RPC facet、HTTP、CLI),GUI 的 governed-entity 面板获得编辑与归档入口,并按 locator 类型给出对应输入。`source` 保持不可变(实体身份由它派生);归档是独立的 `entity_archived` 事件并带 reason,不塞进七字段 descriptor。#2288 合入后已 rebase 到 main。

## 架构辩护
相对 main 的生产 churn 为 +686/-161。写路沿既有链 CLI/GUI → daemon protocol → RepoCell → entity action executor → kernel entity/store/projection,没有新发明。artifact 动作目录从 `entity-kind-registry.ts` 拆到 `artifact-entity-actions.ts` 以过复杂度门,registry 不再保留第二份。多边缘节点并发写在 RepoCell 内串行,过期写者由 `expectedVersion` 得到 `revision_conflict`,不加锁。

## 改动
- kernel 两个事件与 reducer/projection;daemon 两个 facet、HTTP、授权与执行器,行读面带归档元数据;CLI `ha entity update/archive`;GUI 面板编辑/归档/归档过滤与按 locator 输入;E2E 场景扩到 create → update → archive。

## 验证
- 四包 `tsc -b`、lint、CLI 错误码门、密度门、复杂度门本地通过;定向 node 31/31、GUI 15/15、facet 契约 1/1、Ubuntu 隔离集成 1/1(含冷重建)。完整 Electron E2E 未跑,CEO 合并后亲验面板。

## 复核证据
- 第二轮 CI(`5ae40b0ec`):durable action 授权 ratchet 111 → 113,两动作各自显式授权返回;`declared-entity-kinds` e2e 场景跟随页面改名(CEO 隔离 lane 实跑抓到旧选择器)。
- 首轮 CI(`a0accb89a`):facet 计数钉在 33 并点名两个新增;entity 路由从 `parseRouted` 抽出;三个零消费者 kernel barrel 导出直接删除而非加白名单;声明 `Governed-Entity-W2` phase;`EntitiesView.tsx` 两处旧页名注释改写。
- 任务 `task_5987fb3b4b410c041e17ede1aa`;Sol 首轮带证据停手(descriptor 不收 archived、source 即身份、禁区阻塞),CEO 采纳替代设计写回 plan 后第二轮实现;实现报告在任务包。

## 残余风险
- locator 编辑是字段级(路径/URL/键 + 既有 Markdown 预览);`repository-path` 工件的 Markdown 正文编辑不在本 PR 范围,另行跟踪。
