### PR TITLE
fix(doc-sync): sync HTML documents outside task packages through one textual file-type table

### DIFF
--- a/packages/daemon/src/doc-sync-reads.ts
+++ b/packages/daemon/src/doc-sync-reads.ts
@@ -6,6 +6,7 @@ import {
   documentPath,
   resolveDocRoute,
   resolveHarnessLayout,
+  worktreeDocumentMediaType,
   sha256Bytes,
   stableStringify,
   type DocEventV1,
@@ -258,8 +259,7 @@ export function listProjectedTaskDocuments(
 }
 
 const worktreeDocumentMaxBytes = 2 * 1024 * 1024,
-  worktreeDocumentMaxEntries = 2000,
-  worktreeDocumentExtensions = new Set([".md", ".json", ".yaml", ".yml", ".txt", ".html", ".htm"]);
+  worktreeDocumentMaxEntries = 2000;
 
 type WorktreeDocumentRow = {
   readonly path: string;
@@ -287,19 +287,6 @@ function resolveWorktreeDocumentPath(packageRoot: string | null, relative: strin
     if (statLinkSync(cursor)?.isSymbolicLink()) return null;
   }
   return target;
-}
-
-function worktreeDocumentMediaType(relative: string): string {
-  const extension = path.extname(relative).toLowerCase();
-  return extension === ".json"
-    ? "application/json"
-    : extension === ".html" || extension === ".htm"
-      ? "text/html"
-      : extension === ".yaml" || extension === ".yml"
-        ? "application/yaml"
-        : extension === ".md"
-          ? "text/markdown"
-          : "text/plain";
 }
 
 /** One live file from the task package's working copy, or null when it is absent. */
@@ -341,7 +328,8 @@ function worktreeDocumentIndex(packageRoot: string | null): readonly WorktreeDoc
         queue.push(target);
         continue;
       }
-      if (!entry.isFile() || !worktreeDocumentExtensions.has(path.extname(entry.name).toLowerCase())) continue;
+      const mediaType = worktreeDocumentMediaType(entry.name);
+      if (!entry.isFile() || mediaType === null) continue;
       const stat = statFileSync(target);
       if (stat === null || stat.size > worktreeDocumentMaxBytes) continue;
       const bytes = readFileSync(target);
@@ -349,7 +337,7 @@ function worktreeDocumentIndex(packageRoot: string | null): readonly WorktreeDoc
         path: path.relative(root, target).split(path.sep).join("/"),
         blobSha256: sha256Bytes(bytes),
         size: stat.size,
-        mediaType: worktreeDocumentMediaType(entry.name),
+        mediaType,
         uncommitted: true,
       });
     }

--- a/packages/daemon/test/doc-sync-slice-a.fixtures.ts
+++ b/packages/daemon/test/doc-sync-slice-a.fixtures.ts
@@ -71,11 +71,13 @@ export function standardMigration(revision: number, target: string, body: string
     ],
   };
 }
-export function rows(evidence: string | undefined): readonly { readonly path: string; readonly state: string }[] {
+export function rows(
+  evidence: string | undefined,
+): readonly { readonly path: string; readonly state: string; readonly mediaType: string | null }[] {
   assert.match(evidence ?? "", /^doc-scan:/u);
   return (
     JSON.parse((evidence ?? "").slice("doc-scan:".length)) as {
-      rows: readonly { path: string; state: string }[];
+      rows: readonly { path: string; state: string; mediaType: string | null }[];
     }
   ).rows;
 }

--- a/packages/daemon/test/doc-sync-slice-a.test.ts
+++ b/packages/daemon/test/doc-sync-slice-a.test.ts
@@ -1,16 +1,68 @@
 // harness-test-tier: integration
 import assert from "node:assert/strict";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
-import { DOC_POLICY_ID, makeTaskEventStore, parseDocWriteIntent, sha256Text } from "../../kernel/src/index.ts";
+import {
+  DOC_POLICY_ID,
+  makeTaskEventStore,
+  OPAQUE_TEXTUAL_POLICY_ID,
+  parseDocWriteIntent,
+  sha256Text,
+} from "../../kernel/src/index.ts";
 import { detail, touch } from "../src/doc-sync-details.ts";
 import { canonicalRoot, workspaceId } from "../src/protocol/daemon-protocol.contract.ts";
 import { blockedAuthoredCandidateReason } from "../src/repo-cell.ts";
 import { openBootstrappedRepoCell as openRepoCell } from "./repo-settings.fixture.ts";
 
 import { actor, git, initRepo, opaqueTextualMediaType, rows, write } from "./doc-sync-slice-a.fixtures.ts";
+
+test("HTML research documents are eligible, submit as opaque text, and become clean", async () => {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-doc-a-html-research-"));
+  initRepo(rootDir);
+  const logical = "context/research/2026-09-05-foundation-audit/index.html",
+    body = "<!doctype html>\n<title>Foundation audit</title>\n<p>canonical HTML</p>\n",
+    repoId = workspaceId("html-research"),
+    cell = await openRepoCell({
+      repoId,
+      rootDir: canonicalRoot(rootDir),
+      ownerId: "html-research-daemon",
+    }),
+    binding = { actor, source: "local" as const };
+  try {
+    write(rootDir, logical, body);
+    const dryRun = await cell.run({ kind: "doc-dry-run", paths: [logical] }, binding);
+    assert.equal(dryRun.outcome, "pending", JSON.stringify(dryRun));
+    assert.deepEqual(
+      rows(dryRun.evidence).map((row) => [row.path, row.state, row.mediaType]),
+      [[logical, "eligible", "text/html"]],
+    );
+    const submitted = await cell.run({ kind: "doc-submit", paths: [logical] }, binding);
+    assert.equal(submitted.outcome, "applied", JSON.stringify(submitted));
+    const event = makeTaskEventStore({ repoId, rootDir }).readEvent(submitted.opId);
+    assert.equal(event?.schema, "doc-event/v1");
+    if (event?.schema === "doc-event/v1") {
+      const change = event.payload.changes[0]!;
+      assert.equal(change.policyId, OPAQUE_TEXTUAL_POLICY_ID);
+      assert.deepEqual(change.candidate, {
+        sha256: sha256Text(body),
+        size: Buffer.byteLength(body),
+        mediaType: "text/html",
+      });
+    }
+    assert.equal(readFileSync(path.join(rootDir, "harness", logical), "utf8"), body);
+    const status = await cell.run({ kind: "doc-status", paths: [logical] }, binding);
+    assert.deepEqual(
+      rows(status.evidence).map((row) => [row.path, row.state]),
+      [[logical, "clean"]],
+    );
+  } finally {
+    await cell.close();
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});
+
 test("status, dry-run, and submit share the repeatable-path scanner and automatic base", async () => {
   const rootDir = mkdtempSync(path.join(tmpdir(), "ha-doc-a-scanner-"));
   initRepo(rootDir);

--- a/packages/kernel/src/domain/artifact-text-classification.ts
+++ b/packages/kernel/src/domain/artifact-text-classification.ts
@@ -17,20 +17,38 @@ export type TextualArtifactClassification = Readonly<{
   policyId: "markdown-body-replaceable/v1" | typeof OPAQUE_TEXTUAL_POLICY_ID;
 }>;
 
+const textualFileTypes: readonly {
+  readonly extensions: readonly string[];
+  readonly mediaType: OpaqueTextualMediaType;
+  readonly docSyncCandidate: boolean;
+  readonly worktreeDocument: boolean;
+}[] = [
+  { extensions: [".md"], mediaType: "text/markdown", docSyncCandidate: true, worktreeDocument: true },
+  { extensions: [".txt"], mediaType: "text/plain", docSyncCandidate: true, worktreeDocument: true },
+  { extensions: [".html", ".htm"], mediaType: "text/html", docSyncCandidate: true, worktreeDocument: true },
+  { extensions: [".json"], mediaType: "application/json", docSyncCandidate: false, worktreeDocument: true },
+  { extensions: [".yaml", ".yml"], mediaType: "application/yaml", docSyncCandidate: false, worktreeDocument: true },
+  { extensions: [".mjs", ".js"], mediaType: "text/javascript", docSyncCandidate: false, worktreeDocument: false },
+  { extensions: [".css"], mediaType: "text/css", docSyncCandidate: false, worktreeDocument: false },
+  { extensions: [".csv"], mediaType: "text/csv", docSyncCandidate: false, worktreeDocument: false },
+];
+
 /**
  * Classifies authored document paths that doc-sync may process. Task artifact
  * directories and authored architecture model files are opaque regardless of
  * their content type; prose semantics apply everywhere else only to Markdown
- * and plain-text documents.
+ * and plain-text documents. Other supported textual formats are whole-file
+ * documents.
  */
 export function classifyTextualArtifactPath(value: string): TextualArtifactClassification | null {
   if (artifactPath(value) || architectureModelPath(value))
     return { kind: "opaque-textual", mediaType: opaqueTextualMediaType(value), policyId: OPAQUE_TEXTUAL_POLICY_ID };
-  if (value.endsWith(".md"))
-    return { kind: "canonical-prose", mediaType: "text/markdown", policyId: "markdown-body-replaceable/v1" };
-  if (value.endsWith(".txt"))
-    return { kind: "canonical-prose", mediaType: "text/plain", policyId: "markdown-body-replaceable/v1" };
-  return null;
+  const fileType = textualFileType(value);
+  if (fileType === null || !fileType.docSyncCandidate) return null;
+  const { mediaType } = fileType;
+  return mediaType === "text/markdown" || mediaType === "text/plain"
+    ? { kind: "canonical-prose", mediaType, policyId: "markdown-body-replaceable/v1" }
+    : { kind: "opaque-textual", mediaType, policyId: OPAQUE_TEXTUAL_POLICY_ID };
 }
 
 export function isOpaqueTextualMediaType(value: unknown): value is OpaqueTextualMediaType {
@@ -47,6 +65,11 @@ export function isOpaqueTextualMediaType(value: unknown): value is OpaqueTextual
   );
 }
 
+export function worktreeDocumentMediaType(value: string): OpaqueTextualMediaType | null {
+  const fileType = textualFileType(value);
+  return fileType?.worktreeDocument ? fileType.mediaType : null;
+}
+
 function artifactPath(value: string): boolean {
   return value.startsWith("artifacts/") || /^tasks\/[^/]+\/artifacts(?:\/|$)/u.test(value);
 }
@@ -58,13 +81,14 @@ function architectureModelPath(value: string): boolean {
 }
 
 function opaqueTextualMediaType(value: string): OpaqueTextualMediaType {
-  if (value.endsWith(".md")) return "text/markdown";
-  if (value.endsWith(".txt")) return "text/plain";
-  if (value.endsWith(".html") || value.endsWith(".htm")) return "text/html";
-  if (value.endsWith(".mjs") || value.endsWith(".js")) return "text/javascript";
-  if (value.endsWith(".json")) return "application/json";
-  if (value.endsWith(".css")) return "text/css";
-  if (value.endsWith(".yaml") || value.endsWith(".yml")) return "application/yaml";
-  if (value.endsWith(".csv")) return "text/csv";
-  return OPAQUE_TEXTUAL_MEDIA_TYPE;
+  return textualFileType(value)?.mediaType ?? OPAQUE_TEXTUAL_MEDIA_TYPE;
+}
+
+function textualFileType(value: string): (typeof textualFileTypes)[number] | null {
+  const extension = extensionOf(value);
+  return textualFileTypes.find((fileType) => fileType.extensions.includes(extension)) ?? null;
+}
+
+function extensionOf(value: string): string {
+  return value.slice(value.lastIndexOf(".")).toLowerCase();
 }

--- a/packages/kernel/src/index.ts
+++ b/packages/kernel/src/index.ts
@@ -152,6 +152,7 @@ export {
   classifyTextualArtifactPath,
   OPAQUE_TEXTUAL_POLICY_ID,
   type OpaqueTextualMediaType,
+  worktreeDocumentMediaType,
 } from "./domain/artifact-text-classification.ts";
 export {
   parseCanonicalEvent,

--- a/packages/kernel/test/contracts/doc-sync.test.ts
+++ b/packages/kernel/test/contracts/doc-sync.test.ts
@@ -254,7 +254,16 @@ test("opaque textual paths preserve their media type", () => {
     mediaType: "text/plain",
     policyId: DOC_POLICY_ID,
   });
-  assert.equal(classifyTextualArtifactPath("context/report.html"), null);
+  assert.deepEqual(classifyTextualArtifactPath("context/report.html"), {
+    kind: "opaque-textual",
+    mediaType: "text/html",
+    policyId: OPAQUE_TEXTUAL_POLICY_ID,
+  });
+  assert.deepEqual(classifyTextualArtifactPath("context/report.htm"), {
+    kind: "opaque-textual",
+    mediaType: "text/html",
+    policyId: OPAQUE_TEXTUAL_POLICY_ID,
+  });
   assert.equal(classifyTextualArtifactPath("context/architecture/notes.json"), null);
   assert.equal(classifyTextualArtifactPath("context/architecture/views/write-path.c4"), null);
 });


### PR DESCRIPTION
# English

## Summary

HTML documents outside task packages (research packages, architecture visualizations) could not enter the canonical ledger: the doc-sync candidate scanner classified `.html/.htm` as "not a supported textual document" while the worktree reader and `ha task artifact add` already accepted them. This PR replaces three duplicated extension lists (candidate classifier, opaque media-type mapper, worktree document reader) with one table in the kernel classification module. `.html/.htm` now sync as opaque whole-file documents (`text/html`); markdown and plain text keep prose semantics; JSON/YAML stay readable in worktree listings but are not doc-sync candidates, exactly as before.

## Architectural Justification

- Not required: production delta is +45/-32 (below both thresholds).

## What Changed

- `packages/kernel/src/domain/artifact-text-classification.ts`: single `textualFileTypes` table (extensions, media type, doc-sync candidate flag, worktree document flag); `classifyTextualArtifactPath` and `opaqueTextualMediaType` read it; new exported `worktreeDocumentMediaType`.
- `packages/daemon/src/doc-sync-reads.ts`: deletes its private extension set and media-type mapper, uses the kernel table (no file removed, so Gate Harvest lists none).
- `packages/kernel/src/index.ts`: exports `worktreeDocumentMediaType`.
- Tests: kernel contract replaces the old `context/report.html` → null expectation with HTML classification; daemon slice A adds a research-package HTML dry-run → submit → clean integration case; fixtures updated.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: use the single CI-backed `Production-Delta` declaration below; do not enter a second metric.

## Machine-Readable Declarations

Production-Delta: +45/-32

## Task And Scope

- Harness task: task_4feaaee3f1b92b3d68539b6c3c
- Branch: `codex/doc-sync-html`
- Public scope: kernel text classification, daemon doc-sync worktree reads, directed tests
- Private planning/evidence updated: yes
- Out of scope: retiring the interim copy of a research HTML that was published through `ha task artifact add` into a task package; the WAL-flush sweep vs doc-sync deletion road (task_3b58c4540ede0890bdc24909a3)

## Version Impact

- Version: package versions unchanged
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none
- Authority: not applicable
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: a68e51e19cd241013572521a97132dc20a1cd6d5
- Branch merge-base with `origin/main`: a68e51e19cd241013572521a97132dc20a1cd6d5
- Last `git fetch origin` time: 2026-09-05T05:40Z
- Sync method: rebase (head 250c33c15fc9a5e802027b681968a4304df24646)
- Public diff command: `git diff --stat origin/main...codex/doc-sync-html`
- Private evidence commit/path: private task package `task_4feaaee3f1b92b3d68539b6c3c` artifacts/reports/implementation.md
- Reviewer evidence path: same task package, artifacts/reports
- GitHub Actions `rewrite-ci` run URL: pending (filled after the run)
- [ ] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Not run: full `npm run check` / `npm test` locally by policy (worker stop point is directed tests). Run on the isolated Ubuntu target via `node tools/dispatch-isolated-test.mjs`: `packages/daemon/test/doc-sync-slice-a.test.ts` (11/11), `packages/kernel/test/contracts/doc-sync.test.ts` (7/7); `node tools/gates/line-density.mjs --base origin/main` pass; `node tools/check-file-complexity.mjs` pass. CI is the authority.

## Review Evidence

- Self-review: worker report in the task package; CEO read the full production diff.
- Reviewer subagent: none
- Human review: CEO semantic acceptance against the task plan (one table replaces three lists; HTML becomes an opaque whole-file candidate outside task packages; prose semantics unchanged for markdown/text).
- Blocking findings: none

## Residual Risk

- The shared canonical workspace's existing untracked research HTML files were not submitted in this PR (isolation policy forbids testing against the default daemon); the operator submits them after the daemon is rebuilt on this change.
- `.json`/`.yaml` remain non-candidates by design; any authored JSON outside task packages still needs its own road.

## References

- Task: task_4feaaee3f1b92b3d68539b6c3c
- Evidence: task package artifacts/reports/implementation.md, fact F-7AADF267
- Review: task package artifacts/reports/dispatch_adcd1c9bd80a2c1798c9716c.md

---

# 中文

## 概要

任务包之外的 HTML 文档(研究包、架构可视化)进不了 canonical 台账:doc-sync 候选扫描器把 `.html/.htm` 判为「不支持的文本文档」,而 worktree 读路与 `ha task artifact add` 早已接受它们。本 PR 用 kernel 分类模块里的一张表取代三份重复的扩展名清单(候选分类器、opaque 媒体类型映射、worktree 文档读取器)。`.html/.htm` 现在作为 opaque 整文件文档(`text/html`)同步;markdown 与纯文本保留 prose 语义;JSON/YAML 仍可在 worktree 列表中读到但不是 doc-sync 候选,与之前一致。

## 架构辩护

- 不需要:生产增删 +45/-32,低于两个阈值。

## 改动内容

- `packages/kernel/src/domain/artifact-text-classification.ts`:单一 `textualFileTypes` 表(扩展名、媒体类型、是否 doc-sync 候选、是否 worktree 文档);`classifyTextualArtifactPath` 与 `opaqueTextualMediaType` 读该表;新增导出 `worktreeDocumentMediaType`。
- `packages/daemon/src/doc-sync-reads.ts`:删除私有扩展名集合与媒体类型映射,改用 kernel 表。
- `packages/kernel/src/index.ts`:导出 `worktreeDocumentMediaType`。
- 测试:kernel contract 覆盖 HTML 分类;daemon slice A 新增研究包 HTML dry-run → submit → clean 的集成用例;fixtures 更新。

## 门收割 / Gate Harvest

- 删除的生产路径:none(没有删除文件;被替代的是同文件内的重复扩展名表与映射函数,见改动内容)
- 同 commit 删除的门 / fixture:none
- 生产净行数:引用英文块中的 `Production-Delta`。

## 机读声明说明

- 机读声明只在英文块出现一次;本 PR 不改任何 `package.json` / `package-lock.json`,故不含 Dependency-Change 行。

## 任务与范围

- Harness 任务:task_4feaaee3f1b92b3d68539b6c3c
- 分支:`codex/doc-sync-html`
- 公开范围:kernel 文本分类、daemon doc-sync worktree 读路、定向测试
- 私有计划 / 证据是否已更新:yes
- 范围外:退役此前经 `ha task artifact add` 复制进任务包的研究 HTML 临时副本;WAL flush 扫描与 doc-sync 删除写路(task_3b58c4540ede0890bdc24909a3)

## 版本影响

- 版本:包版本不变
- 发布影响:不发布

## 治理声明

- 是否触碰 protected surface:no
- protected surface 范围:无
- 依据:不适用
- 机器检查边界:本 PR 只声明该段存在;声明是否真实、充分,由 reviewer 判断。
- Break-glass:no
- Break-glass 原因:不适用
- Break-glass 范围:不适用
- 后续治理任务:不适用

## 验证

- `origin/main` 基准 SHA:a68e51e19cd241013572521a97132dc20a1cd6d5
- 当前分支与 `origin/main` 的 merge-base:a68e51e19cd241013572521a97132dc20a1cd6d5
- 最近一次 `git fetch origin` 时间:2026-09-05T05:40Z
- 同步方式:rebase(head 250c33c15fc9a5e802027b681968a4304df24646)
- 公开 diff 命令:`git diff --stat origin/main...codex/doc-sync-html`
- 私有证据 commit/path:私有任务包 `task_4feaaee3f1b92b3d68539b6c3c` artifacts/reports/implementation.md
- Reviewer 证据路径:同任务包 artifacts/reports
- GitHub Actions `rewrite-ci` run URL:待 CI 运行后回填
- [ ] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- 未运行:按纪律本地不跑整套 `npm run check` / `npm test`(worker 停止点是定向测试);在隔离 Ubuntu 目标机经 `node tools/dispatch-isolated-test.mjs` 跑了 `packages/daemon/test/doc-sync-slice-a.test.ts`(11/11)与 `packages/kernel/test/contracts/doc-sync.test.ts`(7/7);`line-density`、`check-file-complexity` 通过。CI 是权威。

## 审查证据

- 自查:worker 报告在任务包;CEO 通读了全部生产 diff。
- Reviewer subagent:无
- 人工审查:CEO 按任务计划做语义验收(一张表取代三份清单;任务包外 HTML 成为 opaque 整文件候选;markdown/text 的 prose 语义不变)。
- 阻塞发现:无

## 残余风险

- 共享 canonical 工作区里已有的 untracked 研究 HTML 未在本 PR 内提交(隔离纪律禁止对 default daemon 测试);daemon 按本改动重建后由操作者提交。
- `.json`/`.yaml` 按设计仍非候选;任务包外的 authored JSON 仍需自己的写路。

## 关联材料

- 任务:task_4feaaee3f1b92b3d68539b6c3c
- 证据:任务包 artifacts/reports/implementation.md,fact F-7AADF267
- 审查:任务包 artifacts/reports/dispatch_adcd1c9bd80a2c1798c9716c.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)
