### PR TITLE
fix(daemon): make squad run receipts truthful, refuse a second run per task, settle the squad on leader cancel

### DIFF
--- a/packages/application/src/squad-action-explanation-service.ts
+++ b/packages/application/src/squad-action-explanation-service.ts
@@ -187,6 +187,7 @@ function evaluateCriterion(
     };
   if (
     criterionRef === "squad/task-mission-ready" ||
+    criterionRef === "squad/task-run-available" ||
     criterionRef === "squad/execution-lease-holder" ||
     criterionRef === "squad/execution-lease-reacquisition" ||
     criterionRef === "squad/leader-dispatch"

--- a/packages/cli/src/cli/guidance-plane.ts
+++ b/packages/cli/src/cli/guidance-plane.ts
@@ -168,6 +168,13 @@ export function humanError(receipt: Record<string, unknown>): { readonly code: s
     leader = record(receipt.leader) ? humanError(receipt.leader) : null;
   if (code === "squad_leader_failed" && leader && leader.code !== "unknown")
     return { code, hint: renderTemplate("failure", "squad-leader", leader) };
+  if (code === "write_rejected" && typeof receipt.rejectionExplanation === "string")
+    return {
+      code,
+      hint:
+        `${receipt.rejectionExplanation} ` +
+        `Inner receipt: ${typeof receipt.summary === "string" ? receipt.summary : "summary unavailable"}`,
+    };
   if (code === "daemon_stopping") return { code, hint: renderTemplate("failure", "daemon-stopping", {}) };
   if (code === "daemon_restarting" && typeof outer.hint === "string") return { code, hint: outer.hint };
   const diagnostic = record(receipt.diagnostic) ? receipt.diagnostic : null,

--- a/packages/cli/test/guidance-plane.test.ts
+++ b/packages/cli/test/guidance-plane.test.ts
@@ -97,6 +97,27 @@ test("failure guidance renders structured missing-section, validator, and worksp
   );
 });
 
+test("write_rejected renders the inner receipt reason and summary without suggesting a retry", () => {
+  assert.deepEqual(
+    renderCliReceipt({
+      ok: false,
+      command: "squad-run",
+      code: "write_rejected",
+      rejectionExplanation:
+        'The inner receipt outcome "running" is not a declared write outcome; inspect the producing action instead of retrying it.',
+      summary: "squad-run debug-squad: squad_0123456789abcdef01234567",
+      error: { code: "write_rejected" },
+    }),
+    {
+      stream: "stderr",
+      text:
+        'error code=write_rejected hint=The inner receipt outcome "running" is not a declared write outcome; ' +
+        "inspect the producing action instead of retrying it. Inner receipt: " +
+        "squad-run debug-squad: squad_0123456789abcdef01234567",
+    },
+  );
+});
+
 test("receipt registry preserves migrated family goldens", () => {
   assert.deepEqual(renderCliReceipt({ command: "runtime-batch", dispatches: [] }), {
     stream: "stdout",

--- a/packages/cli/test/squad-resident-leader.integration.test.ts
+++ b/packages/cli/test/squad-resident-leader.integration.test.ts
@@ -90,19 +90,29 @@ test("each worker outcome calls back into a new leader turn and a failed worker 
     run(root, env, ["doc", "sync", "--submit", "--path", `${residentPackage}/task_plan.md`]);
     mkdirSync(path.join(root, "squadwork"));
 
-    const started = run(root, env, [
-      "squad",
-      "run",
-      "core-squad",
-      "--instance",
-      "resident-worker",
-      "--cwd",
-      "squadwork",
-      "--task",
-      "resident-task",
-    ]);
-    assert.equal(started.outcome, "running", JSON.stringify(started));
+    const runArgs = [
+        "squad",
+        "run",
+        "core-squad",
+        "--instance",
+        "resident-worker",
+        "--cwd",
+        "squadwork",
+        "--task",
+        "resident-task",
+      ] as const,
+      started = run(root, env, runArgs);
+    assert.equal(started.ok, true, JSON.stringify(started));
+    assert.equal(started.outcome, "applied", JSON.stringify(started));
+    assert.equal(started.status, "leader_running", JSON.stringify(started));
     assert.match(String(started.squadRunId), /^squad_[a-f0-9]{24}$/u);
+    const duplicate = runMaybe(root, env, runArgs);
+    assert.equal(duplicate.status, 1, JSON.stringify(duplicate));
+    assert.equal(duplicate.receipt.code, "squad_run_active", JSON.stringify(duplicate));
+    assert.ok(
+      (duplicate.receipt.nextActions as unknown[]).some((next) => String(next).includes(String(started.squadRunId))),
+      JSON.stringify(duplicate),
+    );
 
     const current = pollSquadStatus(root, env, String(started.squadRunId));
     assert.equal(current.status, "converged", JSON.stringify(current));
@@ -521,7 +531,9 @@ test(
         "--task",
         "squad-api-task",
       ]);
-      assert.equal(started.outcome, "running", JSON.stringify(started));
+      assert.equal(started.ok, true, JSON.stringify(started));
+      assert.equal(started.outcome, "applied", JSON.stringify(started));
+      assert.equal(started.status, "leader_running", JSON.stringify(started));
       const current = pollSquadStatus(root, env, String(started.squadRunId));
       assert.equal(current.status, "converged", JSON.stringify(current));
       const workers = current.workers as Array<Record<string, unknown>>;

--- a/packages/daemon/src/protocol/daemon-protocol-validate-results.ts
+++ b/packages/daemon/src/protocol/daemon-protocol-validate-results.ts
@@ -95,7 +95,27 @@ export function makeDaemonCommandReceipt(command: string, receipt: object): Json
       ...declared
     } = receipt as Readonly<Record<string, unknown>>,
     fields = Object.fromEntries(Object.entries(declared).filter(([, value]) => value !== undefined)),
+    knownOutcome = statusWord(receiptOutcomeWords, fields.outcome),
     ok = fields.outcome === "applied" || fields.outcome === "pending" || fields.outcome === "no_changes";
+  if (!knownOutcome) {
+    const wrappedSummary = nonEmpty(fields.summary)
+      ? String(fields.summary)
+      : `outcome=${String(fields.outcome ?? "missing")} code=${String(fields.code ?? "missing")}`;
+    return {
+      schema: "command-receipt/v2",
+      ok: false,
+      command,
+      ...fields,
+      outcome: "op_rejected",
+      code: "write_rejected",
+      origin: "daemon",
+      rejectionExplanation:
+        `The inner receipt outcome ${JSON.stringify(fields.outcome)} is not a declared write outcome; ` +
+        "inspect the producing action instead of retrying it.",
+      summary: wrappedSummary,
+      error: { code: "write_rejected" },
+    } as JsonObject;
+  }
   return {
     schema: "command-receipt/v2",
     ok,

--- a/packages/daemon/src/squad-action-runtime.ts
+++ b/packages/daemon/src/squad-action-runtime.ts
@@ -132,11 +132,10 @@ function coordinatorReceipt(
   revision: number,
   effects: readonly string[],
 ): WriteReceipt {
-  const cut = cell.projection.list(),
-    outcome = raw.outcome === "running" ? "running" : "applied";
+  const cut = cell.projection.list();
   return {
     ...raw,
-    outcome,
+    outcome: "applied",
     opId,
     revision,
     evidence: JSON.stringify(raw),

--- a/packages/daemon/src/squad-coordinator.ts
+++ b/packages/daemon/src/squad-coordinator.ts
@@ -102,9 +102,18 @@ export function makeSquadCoordinator(input: {
   };
 }) {
   const start = async (action: JsonObject, binding: RuntimeBinding): Promise<JsonObject> => {
+    const taskId = requiredSquadText(action.taskId, "taskId"),
+      activeRun = readStates().find((state) => state.taskId === taskId && !terminal(state));
+    if (activeRun)
+      throw cellCriterionError(
+        "squad_run_active",
+        `Task ${taskId} already has active Squad run ${activeRun.squadRunId}.`,
+        "run",
+        "squad/task-run-available",
+        [`Run ha squad status ${activeRun.squadRunId}; cancel it before starting another Squad run for this Task.`],
+      );
     const squadId = requiredSquadText(action.squadId, "squadId"),
       runtimeInstanceId = requiredSquadText(action.runtimeInstanceId, "runtimeInstanceId"),
-      taskId = requiredSquadText(action.taskId, "taskId"),
       cwd = resolveCwd(input.rootDir, action.cwd),
       squad = squadForRun(squadId);
     let mission: string;
@@ -157,15 +166,10 @@ export function makeSquadCoordinator(input: {
     try {
       const running = await spawnLeader(state, { kind: "initial" });
       return {
-        schema: "command-receipt/v2",
-        ok: true,
-        command: "squad-run",
-        outcome: "running",
         squadRunId,
         leaderRuntimeSessionId: running.currentLeaderRuntimeSessionId,
-
+        status: "leader_running",
         summary: `squad-run ${squadId}: ${squadRunId}`,
-        exitCode: 0,
       };
     } catch (error) {
       const failed = revise(state, {
@@ -197,26 +201,17 @@ export function makeSquadCoordinator(input: {
       );
     if ("projectionState" in state)
       return {
-        schema: "command-receipt/v2",
-        ok: true,
-        command: "squad-status",
-        outcome: "applied",
         ...state,
         status: "invalid",
         summary: state.projectionError.hint,
         nextAction: state.projectionError.hint,
-        exitCode: 0,
       };
-    const detail = statusDto(state);
+    const detail = statusDto(state),
+      phase = visiblePhase(state);
     return {
-      schema: "command-receipt/v2",
-      ok: true,
-      command: "squad-status",
-      outcome: "applied",
       ...detail,
-      status: state.phase,
-      summary: `squad-run ${state.squadId}: ${state.phase}`,
-      exitCode: 0,
+      status: phase,
+      summary: `squad-run ${state.squadId}: ${phase}`,
     };
   };
 
@@ -274,15 +269,9 @@ export function makeSquadCoordinator(input: {
         [`Retry ha squad cancel ${squadRunId}; already-cancelled runtimes are idempotent.`],
       );
     return {
-      schema: "command-receipt/v2",
-      ok: true,
-      command: "squad-cancel",
-      outcome: "applied",
       squadRunId,
       status: "cancelled",
       summary: `squad-run ${state.squadId}: cancelled`,
-
-      exitCode: 0,
     };
   };
 
@@ -423,6 +412,10 @@ export function makeSquadCoordinator(input: {
     const row = dispatchRows(state).find((dispatch) => dispatch.runtimeSessionId === runtimeSessionId),
       turn = state.leaderTurns.find((candidate) => candidate.runtimeSessionId === runtimeSessionId);
     if (!turn) return;
+    if (row?.outcome === "cancelled") {
+      await cancel(state.squadRunId, state.binding);
+      return;
+    }
     if (!row || row.outcome !== "succeeded") {
       await retryLeader(
         state,
@@ -897,7 +890,7 @@ export function makeSquadCoordinator(input: {
         squadId: state.squadId,
         taskId: state.taskId,
         mission: state.mission,
-        phase: state.phase,
+        phase: visiblePhase(state),
         error: state.error,
         currentLeaderRuntimeSessionId: state.currentLeaderRuntimeSessionId,
         leaderTurns: state.leaderTurns.map((turn) => {
@@ -958,7 +951,7 @@ export function makeSquadCoordinator(input: {
       squadId: state.squadId,
       taskId: state.taskId,
       mission: state.mission,
-      phase: state.phase,
+      phase: visiblePhase(state),
       leaderTurnCount: state.leaderTurns.length,
       workerAttemptCount: state.workerAttempts.length,
       runningCount: sessions.filter((session) => runtimeSessionSemanticState(session) === "running").length,
@@ -969,6 +962,12 @@ export function makeSquadCoordinator(input: {
         ...sessions.map((session) => session.lastObservedAt),
       ]),
     };
+  }
+
+  function visiblePhase(state: SquadState): SquadRunPhase {
+    if (terminal(state) || state.currentLeaderRuntimeSessionId === null) return state.phase;
+    const leader = input.projection().readRuntimeSession(state.currentLeaderRuntimeSessionId);
+    return leader && runtimeSessionSemanticState(leader) === "cancelled" ? "cancelled" : state.phase;
   }
 
   return { start, status, cancel, list, read, observeOutcome, reconcile };

--- a/packages/daemon/test/squad-coordinator-recovery.test.ts
+++ b/packages/daemon/test/squad-coordinator-recovery.test.ts
@@ -346,6 +346,57 @@ test("a malformed leader result re-asks the same leader session instead of faili
   });
 });
 
+test("a second Squad run for the same Task points to the active run without dispatching", async () => {
+  await withRootDir(async (rootDir) => {
+    const fixture = makeRecoveryFixture(rootDir, { leaderOutcome: null, leaderTurnBudget: 3 });
+    await assert.rejects(
+      fixture.coordinator.start(
+        {
+          squadId: "core-squad",
+          runtimeInstanceId: INSTANCE_ID,
+          taskId: TASK_ID,
+          cwd: { scope: "repo-root" },
+        },
+        { actor: { principal: { personId: "person-squad" }, executor: null }, source: "local" },
+      ),
+      (error: unknown) =>
+        error instanceof Error &&
+        "code" in error &&
+        error.code === "squad_run_active" &&
+        error.message.includes(SQUAD_RUN_ID),
+    );
+    assert.equal(fixture.spawns.length, 0);
+    assert.equal(fixture.reacquired(), 0);
+  });
+});
+
+test("a cancelled leader is immediately visible and settles cancellation for the whole Squad run", async () => {
+  await withRootDir(async (rootDir) => {
+    const fixture = makeRecoveryFixture(rootDir, {
+      leaderOutcome: "cancelled",
+      leaderTurnBudget: 3,
+      workers: [
+        {
+          workerId: "sol",
+          dispatchId: "dispatch_000000000000000000000002",
+          runtimeSessionId: "runtime-worker-sol",
+          outcome: null,
+        },
+      ],
+    });
+    assert.equal(fixture.coordinator.status(SQUAD_RUN_ID).status, "cancelled");
+
+    await fixture.coordinator.observeOutcome(outcomeEvent(LEADER_SESSION_ID));
+
+    assert.equal(fixture.state().phase, "cancelled");
+    assert.deepEqual(
+      fixture.cancellations.map((payload) => payload.runtimeSessionId),
+      [LEADER_SESSION_ID, "runtime-worker-sol"],
+    );
+    assert.equal(fixture.spawns.length, 0, "leader cancellation must not enter the retry loop");
+  });
+});
+
 test("a failed leader runtime turn is recorded and re-asked instead of terminating the run", async () => {
   await withRootDir(async (rootDir) => {
     const fixture = makeRecoveryFixture(rootDir, { leaderOutcome: "failed", leaderTurnBudget: 3 });
@@ -546,7 +597,6 @@ test("squad cancel persists a terminal phase before stopping every member and re
       source: "local",
     });
 
-    assert.equal(receipt.ok, true);
     assert.equal(receipt.status, "cancelled");
     assert.equal(fixture.state().phase, "cancelled");
     assert.deepEqual(

--- a/packages/daemon/test/validator-diagnostic-contract.test.ts
+++ b/packages/daemon/test/validator-diagnostic-contract.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { validateDaemonSettingsRead } from "../src/protocol/gui-result-validation.ts";
 import {
+  makeDaemonCommandReceipt,
   daemonProtocolError,
   validateDaemonAgenda,
   validateDaemonDecisionList,
@@ -80,6 +81,20 @@ test("Squad migration wire input is limited to legacy source paths and dry-run",
     } as JsonObject).join("\n"),
     /action\.declaration.*not declared/u,
   );
+});
+
+test("an undeclared inner write outcome becomes a diagnostic rejection with its summary intact", () => {
+  const receipt = makeDaemonCommandReceipt("squad-run", {
+    outcome: "running",
+    opId: "op-squad-run",
+    summary: "squad-run debug-squad: squad_0123456789abcdef01234567",
+  });
+  assert.equal(receipt.ok, false);
+  assert.equal(receipt.outcome, "op_rejected");
+  assert.equal(receipt.code, "write_rejected");
+  assert.equal(receipt.origin, "daemon");
+  assert.match(String(receipt.rejectionExplanation), /not a declared write outcome.*instead of retrying/iu);
+  assert.equal(receipt.summary, "squad-run debug-squad: squad_0123456789abcdef01234567");
 });
 
 const relationGraph = {

--- a/packages/kernel/src/domain/squad-action-contract.ts
+++ b/packages/kernel/src/domain/squad-action-contract.ts
@@ -233,6 +233,7 @@ const declarations: readonly SquadActionDeclaration[] = Object.freeze([
         "squad_task_unavailable",
         "The requested Task has a mission that can be dispatched.",
       ),
+      criterion("squad/task-run-available", "squad_run_active", "The requested Task has no active Squad run."),
       criterion(
         "squad/execution-lease-holder",
         "lease_conflict",


### PR DESCRIPTION
# English

## Summary

`ha squad run` returned `write_rejected` while the daemon had already started the squad leader: the coordinator handed back an internal lifecycle DTO shaped like a `command-receipt/v2` with `outcome: "running"`, the result validator correctly refused that undeclared write outcome, and the CLI rendered a rejection for a run that was live. Retrying the command started a second leader on the same task, and cancelling a leader only ended that turn while the squad re-dispatched a new leader and kept its workers. This PR removes the pseudo-receipt, wraps coordinator results as ordinary `applied` write receipts, refuses a second non-terminal run for the same task inside the existing serialized write queue (`squad_run_active`, naming the active `squadRunId`), settles the whole squad when its leader is cancelled, and makes `squad status` report the leader's cancelled state from the runtime projection. A malformed inner outcome now yields a self-explaining rejection instead of a bare `write_rejected`.

## Architectural Justification

- Not required: production delta is +58/-31 (below both thresholds).

## What Changed

- `packages/daemon/src/squad-coordinator.ts`: `start` rejects when a non-terminal run already exists for the task; start/status/cancel return plain DTOs (no `schema`/`ok`/`command`/`outcome`/`exitCode` fields); `observeOutcome` cancels the whole run when the leader runtime is cancelled instead of retrying a leader; `visiblePhase` reads the leader runtime's semantic state for status/list/read.
- `packages/daemon/src/squad-action-runtime.ts`: coordinator results always wrap as `outcome: "applied"`; the `running` passthrough is deleted.
- `packages/daemon/src/protocol/daemon-protocol-validate-results.ts`: an inner receipt with an undeclared outcome becomes an explicit `op_rejected`/`write_rejected` receipt carrying `rejectionExplanation` and the inner summary.
- `packages/kernel/src/domain/squad-action-contract.ts`: declares criterion `squad/task-run-available` with code `squad_run_active`.
- `packages/application/src/squad-action-explanation-service.ts`, `packages/cli/src/cli/guidance-plane.ts`: explanation classification and human rendering for the new code and for wrapped rejections.
- Tests: CLI resident-leader integration replays the same argv and expects `squad_run_active` with no second spawn; coordinator recovery covers cancelled-leader settlement; validator diagnostic contract covers the malformed inner outcome; guidance-plane rendering.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: use the single CI-backed `Production-Delta` declaration below; do not enter a second metric.

## Machine-Readable Declarations

Production-Delta: +58/-31

## Task And Scope

- Harness task: task_0996007ac5919c2d0c000e5441
- Branch: `codex/squad-run-receipt`
- Public scope: daemon squad coordinator and action runtime, daemon result validator, kernel squad action contract, application explanation service, CLI guidance rendering, directed tests
- Private planning/evidence updated: yes
- Out of scope: a dedicated `ha squad cancel` CLI verb (cancelling the leader runtime now settles the run); the rejection-code diagnostics family tracked by task_89cc19f9a8a70b8e1c075b1de9 beyond the validator case fixed here

## Version Impact

- Version: package versions unchanged
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none
- Authority: not applicable
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: a68e51e19cd241013572521a97132dc20a1cd6d5
- Branch merge-base with `origin/main`: a68e51e19cd241013572521a97132dc20a1cd6d5
- Last `git fetch origin` time: 2026-09-05T05:55Z
- Sync method: rebase (head 669389f34efba74348a1c49fac62281b5f283ec7)
- Public diff command: `git diff --stat origin/main...codex/squad-run-receipt`
- Private evidence commit/path: private task package `task_0996007ac5919c2d0c000e5441` artifacts/reports/implementation.md
- Reviewer evidence path: same task package, artifacts/reports
- GitHub Actions `rewrite-ci` run URL: pending (filled after the run)
- [ ] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [x] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Not run: full `npm run check` / `npm test` locally by policy (worker stop point is directed tests). Run on the isolated Ubuntu target via `node tools/dispatch-isolated-test.mjs`: `packages/cli/test/squad-resident-leader.integration.test.ts` (3/3, rerun after rebase 3/3), `packages/daemon/test/squad-action.integration.test.ts` (3/3), `packages/daemon/test/squad-coordinator-recovery.test.ts` (3/3), `packages/daemon/test/validator-diagnostic-contract.test.ts` (6/6), `packages/daemon/test/squad-run-list-window.test.ts` + `squad-run-detail-read.test.ts` (4/4); local fast batch 33/33; `npm run lint` and `npm run typecheck` pass; `node tools/gates/line-density.mjs --base origin/main` pass. CI is the authority.

## Review Evidence

- Self-review: worker report in the task package; CEO read the full production diff.
- Reviewer subagent: none
- Human review: CEO semantic acceptance against the task plan (root cause in the daemon wrapper, not the CLI; no new claim entity, mutual exclusion via the existing serialized write queue; cancel cascades; status reads the runtime projection; rejection is self-explaining).
- Blocking findings: none
- Field evidence: on 2026-09-05 two identical `ha squad run debug-squad` invocations both printed `write_rejected` while the daemon connection log recorded two inner receipts `ok:true outcome:running` with distinct squad run ids; both squads ran to completion in the same worktree.

## Residual Risk

- Existing squad runs that are already in a non-terminal state when this ships keep their stored phase; only the leader-cancelled case is re-read from the runtime projection.
- The validator's explicit rejection for undeclared inner outcomes applies to every daemon action; any other action that still returns a lifecycle word as `outcome` will now be rejected with an explanation rather than silently wrapped, which is the intended fail-closed behavior.

## References

- Task: task_0996007ac5919c2d0c000e5441
- Evidence: task package artifacts/reports/implementation.md, fact F-A519C3E6
- Review: task package artifacts/reports/dispatch_4546acc23b963e515e06870b.md

---

# 中文

## 概要

`ha squad run` 在 daemon 已经起了 squad leader 的情况下返回 `write_rejected`:coordinator 把一个内部生命周期 DTO 伪装成 `command-receipt/v2` 且 `outcome: "running"`,结果校验器正确地拒绝了这个未声明的写结果,CLI 就把一个正在跑的 run 渲染成了拒绝。重试会在同一任务上再起一个 leader;取消 leader 只结束当前 turn,squad 会重派新 leader 并保留 worker。本 PR 删除伪回执,把 coordinator 结果按普通 `applied` 写回执包装;在既有的序列化写队列里拒绝同一任务的第二个非终态 run(`squad_run_active`,并指出正在跑的 `squadRunId`);leader 被取消时结算整个 squad;`squad status` 从 runtime 投影读出 leader 的 cancelled 状态。内层 outcome 形状非法时给出带解释的拒绝,而不是裸的 `write_rejected`。

## 架构辩护

- 不需要:生产增删 +58/-31,低于两个阈值。

## 改动内容

- `packages/daemon/src/squad-coordinator.ts`:`start` 在该任务已有非终态 run 时拒绝;start/status/cancel 返回纯 DTO(去掉 `schema`/`ok`/`command`/`outcome`/`exitCode` 字段);`observeOutcome` 在 leader runtime 被取消时取消整个 run 而不是重派 leader;`visiblePhase` 为 status/list/read 读 leader runtime 的语义状态。
- `packages/daemon/src/squad-action-runtime.ts`:coordinator 结果一律包装为 `outcome: "applied"`;删除 `running` 透传。
- `packages/daemon/src/protocol/daemon-protocol-validate-results.ts`:内层回执 outcome 未声明时,产出带 `rejectionExplanation` 与内层 summary 的显式 `op_rejected`/`write_rejected` 回执。
- `packages/kernel/src/domain/squad-action-contract.ts`:声明判据 `squad/task-run-available`,代码 `squad_run_active`。
- `packages/application/src/squad-action-explanation-service.ts`、`packages/cli/src/cli/guidance-plane.ts`:新代码与包装拒绝的解释分类与人读渲染。
- 测试:CLI resident-leader 集成用例重放同一 argv,期望 `squad_run_active` 且不二次 spawn;coordinator recovery 覆盖 leader 被取消后的整体结算;validator diagnostic contract 覆盖非法内层 outcome;guidance-plane 渲染。

## 门收割 / Gate Harvest

- 删除的生产路径:none(没有删除文件;被删的是同文件内的伪回执字段与 `running` 透传)
- 同 commit 删除的门 / fixture:none
- 生产净行数:引用英文块中的 `Production-Delta`。

## 机读声明说明

- 机读声明只在英文块出现一次;本 PR 不改任何 `package.json` / `package-lock.json`,故不含 Dependency-Change 行。

## 任务与范围

- Harness 任务:task_0996007ac5919c2d0c000e5441
- 分支:`codex/squad-run-receipt`
- 公开范围:daemon squad coordinator 与 action runtime、daemon 结果校验器、kernel squad action 契约、application 解释服务、CLI 引导渲染、定向测试
- 私有计划 / 证据是否已更新:yes
- 范围外:独立的 `ha squad cancel` CLI 动词(取消 leader runtime 现已结算整个 run);task_89cc19f9a8a70b8e1c075b1de9 跟踪的拒绝码诊断族中本 PR 未涉及的其它情形

## 版本影响

- 版本:包版本不变
- 发布影响:不发布

## 治理声明

- 是否触碰 protected surface:no
- protected surface 范围:无
- 依据:不适用
- 机器检查边界:本 PR 只声明该段存在;声明是否真实、充分,由 reviewer 判断。
- Break-glass:no
- Break-glass 原因:不适用
- Break-glass 范围:不适用
- 后续治理任务:不适用

## 验证

- `origin/main` 基准 SHA:a68e51e19cd241013572521a97132dc20a1cd6d5
- 当前分支与 `origin/main` 的 merge-base:a68e51e19cd241013572521a97132dc20a1cd6d5
- 最近一次 `git fetch origin` 时间:2026-09-05T05:55Z
- 同步方式:rebase(head 669389f34efba74348a1c49fac62281b5f283ec7)
- 公开 diff 命令:`git diff --stat origin/main...codex/squad-run-receipt`
- 私有证据 commit/path:私有任务包 `task_0996007ac5919c2d0c000e5441` artifacts/reports/implementation.md
- Reviewer 证据路径:同任务包 artifacts/reports
- GitHub Actions `rewrite-ci` run URL:待 CI 运行后回填
- [ ] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [x] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- 未运行:按纪律本地不跑整套 `npm run check` / `npm test`(worker 停止点是定向测试);在隔离 Ubuntu 目标机经 `node tools/dispatch-isolated-test.mjs` 跑了 `squad-resident-leader.integration`(3/3,rebase 后复跑 3/3)、`squad-action.integration`(3/3)、`squad-coordinator-recovery`(3/3)、`validator-diagnostic-contract`(6/6)、`squad-run-list-window` + `squad-run-detail-read`(4/4);本地快速批 33/33;`npm run lint`、`npm run typecheck`、`line-density` 通过。CI 是权威。

## 审查证据

- 自查:worker 报告在任务包;CEO 通读了全部生产 diff。
- Reviewer subagent:无
- 人工审查:CEO 按任务计划做语义验收(根因在 daemon 包装层而非 CLI;不新增 claim 实体,互斥复用序列化写队列;cancel 级联;status 回读 runtime 投影;拒绝自解释)。
- 阻塞发现:无
- 现场证据:2026-09-05 两次相同的 `ha squad run debug-squad` 都打印 `write_rejected`,daemon 连接日志却记录了两条 `ok:true outcome:running` 的内层回执与两个不同的 squad run id;两个 squad 在同一 worktree 各自跑完。

## 残余风险

- 本改动上线时已处于非终态的既有 squad run 保留其存储的 phase;只有 leader 被取消这一情形改为从 runtime 投影回读。
- 校验器对未声明内层 outcome 的显式拒绝作用于所有 daemon action;任何仍把生命周期词当 `outcome` 返回的 action 现在会被带解释地拒绝而不是静默包装,这是预期的 fail-closed 行为。

## 关联材料

- 任务:task_0996007ac5919c2d0c000e5441
- 证据:任务包 artifacts/reports/implementation.md,fact F-A519C3E6
- 审查:任务包 artifacts/reports/dispatch_4546acc23b963e515e06870b.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)
