### PR TITLE
fix(entity): give entity_updated its own operation id and fold updates into the current descriptor

### DIFF
--- a/packages/daemon/src/artifact-entity-action.ts
+++ b/packages/daemon/src/artifact-entity-action.ts
@@ -11,7 +11,7 @@ import {
 import {
   compiledRelationDirections,
   artifactEntityContractSnapshot,
-  artifactImportOperationId,
+  artifactUpdateOperationId,
   canonicalArtifactLocator,
   compileEntityArchived,
   compileEntityUpdated,
@@ -224,7 +224,7 @@ function updatedBundle(
         ? canonicalArtifactLocator({ kind: current.locator.kind, value: action.locator })
         : current.locator,
     contentVersion = typeof action.contentVersion === "string" ? action.contentVersion.trim() : current.contentVersion,
-    opId = artifactImportOperationId({ entityId: current.entityId, locator, resolution: contentVersion });
+    opId = artifactUpdateOperationId({ entityId: current.entityId, workspaceRevision: envelope.workspaceRevision });
   return compileEntityUpdated({
     ...envelope,
     eventId: `event-${opId}`,
@@ -423,7 +423,13 @@ function readCurrentArtifact(
   for (const event of store.read().events) {
     if (!isEntityEvent(event) || event.payload.entityKind !== kind || event.payload.entityId !== entityId) continue;
     revision = Math.max(revision, event.workspaceRevision);
-    if (!isEntityDeclarationEvent(event) || event.type !== "entity_content_observed") continue;
+    // Both observations and descriptor updates carry the full descriptor blob; folding only observations would make
+    // every later update start from a stale descriptor and silently drop the previous update.
+    if (
+      !isEntityDeclarationEvent(event) ||
+      (event.type !== "entity_content_observed" && event.type !== "entity_updated")
+    )
+      continue;
     const claim = event.payload.declarationDocumentClaim,
       bytes = store.readContentBlob(claim.sha256);
     if (!bytes) throw new Error(`Artifact descriptor blob ${claim.sha256} is unavailable.`);

--- a/packages/daemon/test/artifact-entity-action.integration.test.ts
+++ b/packages/daemon/test/artifact-entity-action.integration.test.ts
@@ -170,12 +170,27 @@ test("Artifact import is dry-run safe, edge-idempotent, fenced, and cold-rebuild
       secondaryNodeBinding,
     );
     assert.equal(descriptorUpdate.outcome, "applied", JSON.stringify(descriptorUpdate));
+    // Regression (task_d7058b77): an update that leaves contentVersion untouched must not collide with the
+    // entity-import-* operation that first observed that content.
+    const titleOnlyUpdate = await cell.run(
+      {
+        kind: "entity-update",
+        entityKind: kind,
+        entityId: preview.entityId,
+        expectedVersion: descriptorUpdate.revision,
+        title: "Revised title again",
+      },
+      binding,
+    );
+    assert.equal(titleOnlyUpdate.outcome, "applied", JSON.stringify(titleOnlyUpdate));
+    assert.notEqual(titleOnlyUpdate.opId, descriptorUpdate.opId);
+    assert.match(String(titleOnlyUpdate.opId), /^entity-update-/u);
     const archived = await cell.run(
       {
         kind: "entity-archive",
         entityKind: kind,
         entityId: preview.entityId,
-        expectedVersion: descriptorUpdate.revision,
+        expectedVersion: titleOnlyUpdate.revision,
         reason: "Superseded by ADR-0002",
       },
       binding,
@@ -190,6 +205,7 @@ test("Artifact import is dry-run safe, edge-idempotent, fenced, and cold-rebuild
         "entity_content_observed",
         "entity_content_observed",
         "entity_target_missing",
+        "entity_updated",
         "entity_updated",
         "entity_archived",
       ],
@@ -219,7 +235,7 @@ test("Artifact import is dry-run safe, edge-idempotent, fenced, and cold-rebuild
       assert.equal(row?.id, preview.entityId);
       assert.equal(row?.workspaceRevision, archived.revision);
       assert.equal(row?.value.contentVersion, "revision:manual-2");
-      assert.equal(row?.value.title, "Revised title");
+      assert.equal(row?.value.title, "Revised title again");
       assert.equal(row?.freshness, "orphaned");
       assert.equal(row?.currentVersion, null);
     } finally {

--- a/packages/kernel/src/domain/artifact-entity.ts
+++ b/packages/kernel/src/domain/artifact-entity.ts
@@ -310,6 +310,16 @@ export function artifactImportOperationId(input: {
   return `entity-import-${sha256(identity).slice(0, 32)}`;
 }
 
+/** `entity_updated` carries its own operation identity: the same entity at the same revision fence is one
+ * operation (retries replay), while an update that leaves contentVersion untouched must never collide with the
+ * `entity-import-*` event that first observed that content. */
+export function artifactUpdateOperationId(input: {
+  readonly entityId: string;
+  readonly workspaceRevision: number;
+}): string {
+  return `entity-update-${input.entityId}-${input.workspaceRevision}`;
+}
+
 function isArtifactDescriptor(value: unknown): value is ArtifactDescriptor {
   return (
     isRecord(value) &&

--- a/packages/kernel/src/domain/entity-event.ts
+++ b/packages/kernel/src/domain/entity-event.ts
@@ -4,6 +4,7 @@ import { sha256Text, stableStringify } from "../integrity/stable-hash.ts";
 import {
   artifactEntityContractFromSnapshot,
   artifactImportOperationId,
+  artifactUpdateOperationId,
   artifactObservationId,
   canonicalArtifactLocator,
   canonicalArtifactSourceIdentity,
@@ -350,7 +351,16 @@ function validateEntityEventFields(value: unknown, allowUnknownFields: boolean):
   if (value.type === "entity_content_observed")
     return validateObservedPayload(value.payload, hasFields, String(value.opId), allowUnknownFields);
   if (value.type === "entity_updated")
-    return validateObservedPayload(value.payload, hasFields, String(value.opId), allowUnknownFields);
+    return validateObservedPayload(
+      value.payload,
+      hasFields,
+      String(value.opId),
+      allowUnknownFields,
+      artifactUpdateOperationId({
+        entityId: String(value.payload.entityId),
+        workspaceRevision: Number(value.workspaceRevision),
+      }),
+    );
   if (value.type === "entity_archived") {
     const payload = value.payload;
     try {
@@ -513,6 +523,7 @@ function validateObservedPayload(
   hasFields: typeof hasOnlyFields | typeof hasRequiredFields,
   opId: string,
   allowUnknownFields: boolean,
+  expectedOperation?: string,
 ): readonly string[] {
   const fields = [
     "entityKind",
@@ -530,7 +541,7 @@ function validateObservedPayload(
   if (common.length) return common;
   if (typeof payload.observedContentVersion !== "string" || !payload.observedContentVersion)
     return ["entity observed content version is invalid"];
-  if (!validObservationIdentity(payload, payload.observedContentVersion, opId))
+  if (!validObservationIdentity(payload, payload.observedContentVersion, opId, expectedOperation))
     return ["entity observed idempotency identity is invalid"];
   let contract: EntityStoreKindContract;
   try {
@@ -628,10 +639,15 @@ function validateUpsertPayload(
   return validateClaim(payload, contract, hasFields, schema);
 }
 
-function validObservationIdentity(payload: Record<string, unknown>, resolution: string, opId: string): boolean {
+function validObservationIdentity(
+  payload: Record<string, unknown>,
+  resolution: string,
+  opId: string,
+  expectedOperation?: string,
+): boolean {
   const locator = payload.locator as unknown as ArtifactLocator,
-    expected = artifactObservationId({ entityId: String(payload.entityId), locator, resolution }),
-    expectedOperation = artifactImportOperationId({ entityId: String(payload.entityId), locator, resolution });
+    expected = artifactObservationId({ entityId: String(payload.entityId), locator, resolution });
+  expectedOperation ??= artifactImportOperationId({ entityId: String(payload.entityId), locator, resolution });
   return payload.observationId === expected && opId === expectedOperation;
 }
 

--- a/packages/kernel/src/domain/index.ts
+++ b/packages/kernel/src/domain/index.ts
@@ -336,6 +336,7 @@ export {
   artifactEntityContractSnapshot,
   artifactImportOperationId,
   artifactObservationId,
+  artifactUpdateOperationId,
   canonicalArtifactLocator,
   canonicalSourceIdentity,
   decodeArtifactDescriptor,


### PR DESCRIPTION
# English

## Summary

`entity-update` on an imported artifact entity whose contentVersion did not change derived the same opId as the original `entity-import-*` event (different bytes), so the WAL store threw `op_conflict` and the RepoCell latched canonical **unavailable** (seen on the GUI System page 2026-09-05 14:09, fact F-7158660F, task_d7058b77). `entity_updated` now carries its own operation identity `entity-update-<entityId>-<workspaceRevision>` (same shape as `entity_archived`), and the kernel validator checks that identity instead of the import one.

The same path had a second defect: `readCurrentArtifact` folded only `entity_content_observed` events, so a second update started from a stale descriptor and silently dropped the previous update's title/locator/contentVersion. It now folds `entity_updated` too.

## Architectural Justification

- Not applicable (small fix, no new module). Removed: the import-opId coupling for updates in the kernel validator and the observation-only fold in the daemon.

## What Changed

- kernel `artifact-entity.ts`: `artifactUpdateOperationId`; `entity-event.ts`: `entity_updated` validation expects that identity (observationId still checked against contentVersion).
- daemon `artifact-entity-action.ts`: `updatedBundle` uses the new identity; `readCurrentArtifact` folds `entity_updated`.
- daemon integration test: title-only update after a descriptor update is applied (was `op_conflict`) and keeps `revision:manual-2`; event sequence now has two `entity_updated`.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates: none

## Verification

- `node --test packages/daemon/test/artifact-entity-action.integration.test.ts packages/kernel/test/contracts/artifact-entity.test.ts` → 5 passed (the new case fails on origin/main with `op_conflict`, then with the stale contentVersion once the opId is fixed).
- `tsc -b packages/kernel packages/application packages/daemon` exit 0; eslint on touched files; line-density, file-complexity, kernel dead-exports pass.
- Not run: `check:local` (CI is the authority).

## Review Evidence

- CEO ground-truth: `.harness/requests/requests.jsonl` 2026-09-05T06:07:34Z `repo.entity.update` → `op_conflict`; conflicting opId is the applied import event `harness/events/6a/entity-import-413b58c1….json`.

## Residual Risk

- `fatalCellError` still classifies `op_conflict` as fatal and latches the whole cell; whether a caller-side identity collision should ever latch is a separate decision (recorded in task_d7058b77 residual risk), not changed here.
- No historical `entity_updated` event exists with the old identity that succeeded (every collision was rejected), so no migration is needed.

Production-Delta: +41/-8

---

# 中文

## 摘要

对已 import 的 artifact 实体做 `entity-update` 而 contentVersion 未变时,daemon 派生出与原 `entity-import-*` 事件相同的 opId(字节不同),WAL store 抛 `op_conflict`,RepoCell 把 canonical 整仓 latch 成**不可用**(GUI 系统页 2026-09-05 14:09 可见;F-7158660F,task_d7058b77)。现在 `entity_updated` 拥有自己的操作身份 `entity-update-<entityId>-<workspaceRevision>`(与 `entity_archived` 同形),kernel 校验器按该身份校验,不再要求等于 import opId。

同一路径的第二个缺陷一并修:`readCurrentArtifact` 只折叠 `entity_content_observed`,第二次 update 从过期描述符起算、静默丢掉前一次 update 的 title/locator/contentVersion;现在也折叠 `entity_updated`。

## 架构辩护

- 不适用(小修,无新模块)。删除:kernel 校验器里 update 与 import opId 的耦合;daemon 只折叠观测事件的读法。

## 变更内容

- kernel `artifact-entity.ts` 新增 `artifactUpdateOperationId`;`entity-event.ts` 的 `entity_updated` 校验改用该身份(observationId 仍按 contentVersion 校验)。
- daemon `artifact-entity-action.ts`:`updatedBundle` 用新身份;`readCurrentArtifact` 折叠 `entity_updated`。
- daemon 集成测试:descriptor update 之后的 title-only update 为 applied(此前 `op_conflict`)且保持 `revision:manual-2`;事件序列含两个 `entity_updated`。

## 门收割

Deleted-Production-Paths: none
Deleted-Gates: none

## 验证

- 定向测试 5 passed(新用例在 origin/main 上先因 `op_conflict` 失败,修 opId 后再因 contentVersion 回退失败,两处都修后通过);tsc、eslint、line-density、file-complexity、kernel dead-exports 通过。未跑 `check:local`。

## 评审证据

- CEO 亲自取证:requests.jsonl 06:07:34Z 的 `repo.entity.update` → `op_conflict`;冲突 opId 即已 applied 的 import 事件。

## 残余风险

- `fatalCellError` 仍把 `op_conflict` 列为 fatal 并 latch 整仓;调用方身份撞车是否该 latch 是另一个裁决,本 PR 不改。
- 历史上不存在以旧身份成功写入的 `entity_updated`(冲突全被拒),无需迁移。
