### PR TITLE
fix(kernel): scope task-owned entity projections by owner so reused review ids no longer overwrite each other

### DIFF
--- a/packages/kernel/src/projection/projection-schema.ts
+++ b/packages/kernel/src/projection/projection-schema.ts
@@ -1,3 +1,3 @@
-// Version 18 adds event-derived entity freshness/version witnesses and the Relation
-// target-observation witness. A mismatch discards and replays the rebuildable cache.
-export const taskProjectionSchemaVersion = 18;
+// Version 19 scopes task-owned Entity rows by owner so equal local Execution/Review ids
+// replay independently. A mismatch discards and replays the rebuildable cache.
+export const taskProjectionSchemaVersion = 19;

--- a/packages/kernel/src/projection/rebuildable-task-projection-database.ts
+++ b/packages/kernel/src/projection/rebuildable-task-projection-database.ts
@@ -440,12 +440,12 @@ function createTables(db: DatabaseSync): void {
     CREATE TABLE IF NOT EXISTS entity_projection (
       entity_kind TEXT NOT NULL,
       entity_id TEXT NOT NULL,
-      task_id TEXT,
+      task_id TEXT NOT NULL,
       workspace_revision INTEGER NOT NULL,
       freshness TEXT NOT NULL,
       current_version,
       value_json TEXT NOT NULL,
-      PRIMARY KEY(entity_kind, entity_id)
+      PRIMARY KEY(entity_kind, task_id, entity_id)
     );
     CREATE INDEX IF NOT EXISTS entity_projection_task
       ON entity_projection(entity_kind, task_id, workspace_revision, entity_id);

--- a/packages/kernel/src/projection/rebuildable-task-projection-entities.ts
+++ b/packages/kernel/src/projection/rebuildable-task-projection-entities.ts
@@ -17,20 +17,20 @@ import type { EntityFreshness, EntityVersion } from "../domain/entity-freshness.
 const UPSERT_ENTITY_SQL = [
   "INSERT INTO entity_projection(entity_kind, entity_id, task_id, workspace_revision,",
   "freshness, current_version, value_json)",
-  "VALUES (?, ?, ?, ?, ?, ?, ?) ON CONFLICT(entity_kind, entity_id) DO UPDATE SET",
-  "task_id=excluded.task_id, workspace_revision=excluded.workspace_revision, freshness=excluded.freshness,",
+  "VALUES (?, ?, ?, ?, ?, ?, ?) ON CONFLICT(entity_kind, task_id, entity_id) DO UPDATE SET",
+  "workspace_revision=excluded.workspace_revision, freshness=excluded.freshness,",
   "current_version=excluded.current_version, value_json=excluded.value_json",
   "WHERE entity_projection.workspace_revision <= excluded.workspace_revision",
 ].join(" ");
 const LIST_ENTITY_SQL = [
   "SELECT entity_kind, entity_id, task_id, workspace_revision, freshness, current_version, value_json",
   "FROM entity_projection",
-  "WHERE entity_kind = ? ORDER BY entity_id",
+  "WHERE entity_kind = ? ORDER BY entity_id, task_id",
 ].join(" ");
 const GET_ENTITY_SQL = [
   "SELECT entity_kind, entity_id, task_id, workspace_revision, freshness, current_version, value_json",
   "FROM entity_projection",
-  "WHERE entity_kind = ? AND entity_id = ? LIMIT 1",
+  "WHERE entity_kind = ? AND entity_id = ? ORDER BY workspace_revision DESC LIMIT 1",
 ].join(" ");
 
 export function projectEmbeddedCanonicalEntities(db: DatabaseSync, event: CanonicalEventV1): void {
@@ -81,7 +81,7 @@ function writeEntityProjection(
     UPSERT_ENTITY_SQL,
     projection.kind,
     projection.id,
-    projection.ownerId,
+    projection.ownerId ?? "",
     projection.workspaceRevision,
     freshness,
     currentVersion,
@@ -103,7 +103,12 @@ export function getEntityProjectionRow(
 }
 
 export function deleteEntityProjectionRow(db: DatabaseSync, entityKind: string, entityId: string): void {
-  runSql(db, "DELETE FROM entity_projection WHERE entity_kind = ? AND entity_id = ?", entityKind, entityId);
+  runSql(
+    db,
+    "DELETE FROM entity_projection WHERE entity_kind = ? AND entity_id = ? AND task_id = ''",
+    entityKind,
+    entityId,
+  );
 }
 
 export function markEntityProjectionMissing(
@@ -115,7 +120,7 @@ export function markEntityProjectionMissing(
   runSql(
     db,
     "UPDATE entity_projection SET workspace_revision = ?, freshness = 'orphaned', current_version = NULL " +
-      "WHERE entity_kind = ? AND entity_id = ? AND workspace_revision <= ?",
+      "WHERE entity_kind = ? AND entity_id = ? AND task_id = '' AND workspace_revision <= ?",
     workspaceRevision,
     entityKind,
     entityId,
@@ -130,7 +135,7 @@ function entityProjectionRow(row: Readonly<Record<string, unknown>>): EntityProj
   return {
     kind: String(row.entity_kind),
     id: String(row.entity_id),
-    ownerId: row.task_id === null ? null : String(row.task_id),
+    ownerId: row.task_id === null || row.task_id === "" ? null : String(row.task_id),
     workspaceRevision: Number(row.workspace_revision),
     freshness: String(row.freshness) as EntityFreshness,
     currentVersion:

--- a/packages/kernel/src/projection/rebuildable-task-projection-sql.ts
+++ b/packages/kernel/src/projection/rebuildable-task-projection-sql.ts
@@ -24,7 +24,7 @@ const stateDigestTables = [
   ["task_generation", "task_id"],
   ["task_relation", "relation_id"],
   ["task_progress", "workspace_revision"],
-  ["entity_projection", "entity_kind, entity_id"],
+  ["entity_projection", "entity_kind, task_id, entity_id"],
   ["archived_entity", "entity_kind, entity_id"],
   ["edge", "task_id, edge_id, iteration"],
   ["lease_cas", "task_id"],

--- a/packages/kernel/test/contracts/relation-entity.test.ts
+++ b/packages/kernel/test/contracts/relation-entity.test.ts
@@ -347,11 +347,11 @@ test("an entity_target_missing projection makes every inbound Relation orphaned 
   const db = new DatabaseSync(":memory:");
   createRelationGraphProjectionTables(db);
   db.exec(
-    "CREATE TABLE entity_projection (entity_kind TEXT NOT NULL, entity_id TEXT NOT NULL, task_id TEXT, " +
+    "CREATE TABLE entity_projection (entity_kind TEXT NOT NULL, entity_id TEXT NOT NULL, task_id TEXT NOT NULL, " +
       "workspace_revision INTEGER NOT NULL, freshness TEXT NOT NULL, current_version, value_json TEXT NOT NULL, " +
-      "PRIMARY KEY(entity_kind, entity_id))",
+      "PRIMARY KEY(entity_kind, task_id, entity_id))",
   );
-  db.prepare("INSERT INTO entity_projection VALUES ('runtime-session', 'target', NULL, 4, 'current', 4, '{}')").run();
+  db.prepare("INSERT INTO entity_projection VALUES ('runtime-session', 'target', '', 4, 'current', 4, '{}')").run();
   const created = ["source-a", "source-b"].map((sourceId, index) => {
     const identity = {
       source: `agent/${sourceId}`,

--- a/packages/kernel/test/store/schedule-projection.test.ts
+++ b/packages/kernel/test/store/schedule-projection.test.ts
@@ -18,7 +18,7 @@ const actor = { principal: { personId: "person-schedule" }, executor: null } as 
 test("Schedule definition and run view share one canonical stream and rebuild exactly", async () => {
   await withTempStoreAsync(async (rootDir) => {
     initRepo(rootDir);
-    assert.equal(taskProjectionSchemaVersion, 18);
+    assert.equal(taskProjectionSchemaVersion, 19);
     const eventStore = makeTaskEventStore({ repoId: "schedule-projection", rootDir }),
       projection = makeTaskProjection({ rootDir, eventStore }),
       schedule = baseSchedule(),

--- a/packages/kernel/test/store/task-lifecycle-fixture.ts
+++ b/packages/kernel/test/store/task-lifecycle-fixture.ts
@@ -43,10 +43,19 @@ function command<C extends Parameters<typeof normalizeTaskLifecycleCommand>[1]>(
   };
 }
 
-export function lifecycleFixture(): {
+export function lifecycleFixture(
+  options: {
+    readonly taskId?: string;
+    readonly executionId?: string;
+    readonly reviewId?: string;
+  } = {},
+): {
   readonly events: readonly TaskEventV1[];
   readonly snapshot: TaskLifecycleSnapshot;
 } {
+  const taskId = options.taskId ?? "task-1",
+    executionId = options.executionId ?? "execution-1",
+    reviewId = options.reviewId ?? "review-execution";
   const events: TaskEventV1[] = [];
   let snapshot = emptyTaskLifecycleSnapshot();
   const run = (
@@ -60,7 +69,7 @@ export function lifecycleFixture(): {
   run(
     command(implementer, 1, {
       type: "CreateReplayTask",
-      taskId: "task-1",
+      taskId,
       title: "Fixture",
       taskClass: "standard",
       graph: REPLAY_TASK_GRAPH,
@@ -72,14 +81,14 @@ export function lifecycleFixture(): {
   run(
     command(implementer, 2, {
       type: "StartExecution",
-      taskId: "task-1",
-      executionId: "execution-1",
+      taskId,
+      executionId,
     }),
     {
       actorBinding: implementer,
       reservation: {
-        taskId: "task-1",
-        executionId: "execution-1",
+        taskId,
+        executionId,
         expiresAt: "2026-08-11T01:00:00.000Z",
         ttlMs: 1_800_000,
         previousHolder: null,
@@ -91,8 +100,8 @@ export function lifecycleFixture(): {
   run(
     command(implementer, 3, {
       type: "SubmitExecution",
-      taskId: "task-1",
-      executionId: "execution-1",
+      taskId,
+      executionId,
       submission: {
         completionClaim: "implemented",
         deliverables: [],
@@ -105,7 +114,7 @@ export function lifecycleFixture(): {
     }),
     { actorBinding: implementer, leaseVersion: 0, sessionDisposition: "complete" },
   );
-  run(reviewCommand(4, "approved", "review-execution"), {
+  run(reviewCommand(4, taskId, executionId, "approved", reviewId), {
     actorBinding: reviewer,
     capability: "execution-review@v1",
     capabilityRef: "cap-review",
@@ -114,8 +123,8 @@ export function lifecycleFixture(): {
   run(
     command(implementer, 5, {
       type: "RecordReviewConsent",
-      taskId: "task-1",
-      executionId: "execution-1",
+      taskId,
+      executionId,
       reviewId: review.reviewId,
       consentId: "consent-1",
       reviewDigest: reviewDigest(review),
@@ -123,7 +132,7 @@ export function lifecycleFixture(): {
     }),
     { actorBinding: implementer, capability: "execution-consent@v1", capabilityRef: "cap-consent" } as never,
   );
-  run(command(implementer, 6, { type: "CompleteTask", taskId: "task-1", executionId: "execution-1" }), {
+  run(command(implementer, 6, { type: "CompleteTask", taskId, executionId }), {
     capability: "task-complete@v1",
     capabilityRef: "cap-complete",
     actorRole: "owner",
@@ -133,7 +142,13 @@ export function lifecycleFixture(): {
   return { events, snapshot };
 }
 
-function reviewCommand(revision: number, verdict: "approved", reviewId: string): RecordReviewCommand {
+function reviewCommand(
+  revision: number,
+  taskId: string,
+  executionId: string,
+  verdict: "approved",
+  reviewId: string,
+): RecordReviewCommand {
   const submission = {
     completionClaim: "implemented",
     deliverables: [],
@@ -145,8 +160,8 @@ function reviewCommand(revision: number, verdict: "approved", reviewId: string):
   };
   return command(reviewer, revision, {
     type: "RecordReview",
-    taskId: "task-1",
-    executionId: "execution-1",
+    taskId,
+    executionId,
     reviewId,
     verdict,
     reason: "execution approved",

--- a/packages/kernel/test/store/task-owned-entity-projection-control.integration.test.ts
+++ b/packages/kernel/test/store/task-owned-entity-projection-control.integration.test.ts
@@ -1,0 +1,24 @@
+// harness-test-tier: integration
+import assert from "node:assert/strict";
+import test from "node:test";
+import { makeTaskProjection } from "../../src/projection/rebuildable-task-projection.ts";
+import { withTempStoreAsync } from "./helpers.ts";
+import { memoryEventStore, reviewEvents } from "./task-owned-entity-projection.fixtures.ts";
+
+test("reviews with distinct ids retain the existing projection behavior", async () => {
+  await withTempStoreAsync(async (rootDir) => {
+    const events = reviewEvents("review-second"),
+      projection = makeTaskProjection({ rootDir, eventStore: memoryEventStore(events) });
+    projection.catchUp();
+
+    assert.deepEqual(
+      projection.read("task-first").snapshot.reviews.map(({ reviewId }) => reviewId),
+      ["review-shared"],
+    );
+    assert.deepEqual(
+      projection.read("task-second").snapshot.reviews.map(({ reviewId }) => reviewId),
+      ["review-second"],
+    );
+    projection.close();
+  });
+});

--- a/packages/kernel/test/store/task-owned-entity-projection.fixtures.ts
+++ b/packages/kernel/test/store/task-owned-entity-projection.fixtures.ts
@@ -1,0 +1,50 @@
+import type { CanonicalEventV1 } from "../../src/domain/doc-sync.contract.ts";
+import { serializeCanonicalEvent } from "../../src/domain/doc-sync.contract.ts";
+import { sha256Text } from "../../src/integrity/stable-hash.ts";
+import { lifecycleFixture } from "./task-lifecycle-fixture.ts";
+
+export function memoryEventStore(events: readonly CanonicalEventV1[]) {
+  return {
+    readHead: () => ({
+      revision: events.at(-1)?.workspaceRevision ?? 0,
+      eventDigest: events.length === 0 ? null : `sha256:${sha256Text(serializeCanonicalEvent(events.at(-1)!))}`,
+    }),
+    readBatch: (cursor: string | null, maxItems: number) => {
+      const start = cursor === null ? 0 : Number(cursor),
+        slice = events.slice(start, start + maxItems);
+      return {
+        sourceRevision: events.at(-1)?.workspaceRevision ?? 0,
+        events: slice,
+        cursor: start + slice.length >= events.length ? null : String(start + slice.length),
+        done: start + slice.length >= events.length,
+        accessedItems: slice.length,
+        prefetchContent: () => new Map<string, Uint8Array | null>(),
+      };
+    },
+    readContentBlob: () => null,
+  };
+}
+
+export function reviewEvents(
+  secondReviewId: string,
+  secondExecutionId = "execution-second",
+): readonly CanonicalEventV1[] {
+  const first = lifecycleFixture({
+      taskId: "task-first",
+      executionId: "execution-shared",
+      reviewId: "review-shared",
+    }).events.slice(0, 4),
+    second = lifecycleFixture({
+      taskId: "task-second",
+      executionId: secondExecutionId,
+      reviewId: secondReviewId,
+    })
+      .events.slice(0, 4)
+      .map((event, index) => ({
+        ...event,
+        eventId: `event-second-${index + 5}`,
+        opId: `op-second-${event.type}-${index + 5}`,
+        workspaceRevision: index + 5,
+      }));
+  return [...first, ...second] as readonly CanonicalEventV1[];
+}

--- a/packages/kernel/test/store/task-owned-entity-projection.integration.test.ts
+++ b/packages/kernel/test/store/task-owned-entity-projection.integration.test.ts
@@ -1,0 +1,63 @@
+// harness-test-tier: integration
+import assert from "node:assert/strict";
+import { DatabaseSync } from "node:sqlite";
+import test from "node:test";
+import { makeTaskProjection } from "../../src/projection/rebuildable-task-projection.ts";
+import { taskProjectionSchemaVersion } from "../../src/projection/projection-schema.ts";
+import { withTempStoreAsync } from "./helpers.ts";
+import { memoryEventStore, reviewEvents } from "./task-owned-entity-projection.fixtures.ts";
+
+test("task-owned reviews with the same local id remain visible in both task snapshots", async () => {
+  await withTempStoreAsync(async (rootDir) => {
+    const events = reviewEvents("review-shared", "execution-shared"),
+      projection = makeTaskProjection({ rootDir, eventStore: memoryEventStore(events) });
+    projection.catchUp();
+
+    assert.equal(projection.readTaskOperation(events[3]!.opId)?.event.type, "review_recorded");
+    assert.equal(projection.readTaskOperation(events[7]!.opId)?.event.type, "review_recorded");
+    assert.deepEqual(
+      projection.read("task-first").snapshot.reviews.map(({ reviewId }) => reviewId),
+      ["review-shared"],
+    );
+    assert.deepEqual(
+      projection.read("task-second").snapshot.reviews.map(({ reviewId }) => reviewId),
+      ["review-shared"],
+    );
+    assert.deepEqual(
+      projection
+        .listEntities("review")
+        .filter(({ id }) => id === "review-shared")
+        .map(({ ownerId }) => ownerId)
+        .sort(),
+      ["task-first", "task-second"],
+    );
+    assert.deepEqual(
+      projection
+        .listEntities("execution")
+        .filter(({ id }) => id === "execution-shared")
+        .map(({ ownerId }) => ownerId)
+        .sort(),
+      ["task-first", "task-second"],
+    );
+    projection.close();
+
+    const stale = new DatabaseSync(projection.path);
+    stale.prepare("DELETE FROM entity_projection WHERE entity_kind = 'review' AND task_id = ?").run("task-first");
+    stale
+      .prepare("UPDATE projection_meta SET schema_version = ? WHERE singleton = 1")
+      .run(taskProjectionSchemaVersion - 1);
+    stale.close();
+
+    const rebuilt = makeTaskProjection({ rootDir, eventStore: memoryEventStore(events) });
+    rebuilt.catchUp();
+    assert.deepEqual(
+      rebuilt.read("task-first").snapshot.reviews.map(({ reviewId }) => reviewId),
+      ["review-shared"],
+    );
+    assert.deepEqual(
+      rebuilt.read("task-second").snapshot.reviews.map(({ reviewId }) => reviewId),
+      ["review-shared"],
+    );
+    rebuilt.close();
+  });
+});


### PR DESCRIPTION
# English

## Summary

An accepted `review_recorded` event could be present in the canonical stream and in `event_index` while the task snapshot showed no review, and the projection watermark had already advanced past it. Root cause: the rebuildable `entity_projection` table keyed task-owned `review` and `execution` rows by `(entity_kind, entity_id)` only, so a later task reusing the same owner-local id (for example `review-ceo-1`) overwrote the earlier task's row. A read-only census of the preserved canonical cache showed 233 review events but 229 review rows, and the three repeated review ids account exactly for the four lost rows. The fix keys rows by `(entity_kind, task_id, entity_id)`, uses an empty owner sentinel for unowned entities, and bumps the projection schema from 18 to 19 so the existing mismatch path discards the cache and replays the ledger, restoring the collided rows without a compatibility or retry layer. The earlier "daemon restart window" hypothesis was disproved (the first incident happened nine minutes after the replacement daemon attached) and its probe commits were dropped from the branch.

## Architectural Justification

- Not required: production delta is +19/-14 (below both thresholds).

## What Changed

- `packages/kernel/src/projection/projection-schema.ts`: `taskProjectionSchemaVersion` 18 → 19 with the reason.
- `packages/kernel/src/projection/rebuildable-task-projection-database.ts`: `entity_projection.task_id` is `NOT NULL`; primary key becomes `(entity_kind, task_id, entity_id)`; the schema closure list is updated.
- `packages/kernel/src/projection/rebuildable-task-projection-entities.ts`: upsert conflicts on the owner-scoped key; unowned entities store an empty owner sentinel; delete and read-back for unowned entities are scoped to `task_id = ''`; row-to-entity mapping treats the sentinel as no owner.
- `packages/kernel/src/projection/rebuildable-task-projection-sql.ts`: point lookup orders by newest `workspace_revision`; list ordering adds `task_id`.
- Tests: new collision regression and distinct-id control integration tests (isolated), shared fixtures; relation-entity, schedule-projection and lifecycle fixtures adjusted for the owner dimension.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: use the single CI-backed `Production-Delta` declaration below; do not enter a second metric.

## Machine-Readable Declarations

Production-Delta: +19/-14

## Task And Scope

- Harness task: task_2fe095aee124235f4405f2043a
- Branch: `codex/projection-miss-review`
- Public scope: kernel rebuildable task projection schema, entity upsert/read SQL, directed tests
- Private planning/evidence updated: yes
- Out of scope: making the public `getEntity(kind, id)` point lookup owner-aware (it returns the newest matching row when an owner-local id is reused; snapshot hydration and `listEntities` are owner-correct)

## Version Impact

- Version: package versions unchanged; task projection schema 18 → 19 (rebuildable cache, discarded and replayed on mismatch)
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none
- Authority: not applicable
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: 93c4c511fd10e06ac1aa0a986c64402d511bd802
- Branch merge-base with `origin/main`: 93c4c511fd10e06ac1aa0a986c64402d511bd802
- Last `git fetch origin` time: 2026-09-05T06:40Z
- Sync method: rebase (head 2f65deaf2d41a6857a20061d4e509da8f45ff8ae)
- Public diff command: `git diff --stat origin/main...codex/projection-miss-review`
- Private evidence commit/path: private task package `task_2fe095aee124235f4405f2043a` artifacts/reports/implementation.md
- Reviewer evidence path: same task package, artifacts/reports
- GitHub Actions `rewrite-ci` run URL: pending (filled after the run)
- [ ] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [x] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [x] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Not run: full `npm run check` / `npm test` locally by policy. Run: isolated Ubuntu dispatcher for the collision regression (1/1; the same fixture failed 1/2 before the fix, the control passed), the distinct-id control (1/1) and `projection-ddl-rebuild` (2/2); local fast tier 627/627 with `TMPDIR=/private/tmp`; `task-projection.test.ts` 26/26; lint, typecheck, file-complexity, schema-closure, line-density and production-delta gates pass. CI is the authority.

## Review Evidence

- Self-review: worker report in the task package; CEO read the full production diff.
- Reviewer subagent: none
- Human review: CEO semantic acceptance against the task plan (root cause is an identity collision, not a restart window; fix adds the owner dimension to the key and relies on the existing schema-mismatch rebuild instead of a retry or compatibility layer; negative control present).
- Blocking findings: none
- Field evidence: fact F-59C8839D (first instance, revision 58779), F-2534BA68 (second instance under a stable daemon, revision 59235), F-EEE85AA8 (census: 233 review events vs 229 rows, three repeated review ids).

## Residual Risk

- Every node rebuilds its task projection cache once on upgrade (schema 19); on this repository the rebuild is tens of seconds.
- `getEntity(kind, id)` without an owner returns the newest matching row when an owner-local id is reused; callers that need a specific task's entity read it through the task snapshot.

## References

- Task: task_2fe095aee124235f4405f2043a
- Evidence: task package artifacts/reports/implementation.md, facts F-59C8839D, F-2534BA68, F-EEE85AA8
- Review: task package artifacts/reports/dispatch_c9a5e810fe5b5d16cd2a5f7e.md

---

# 中文

## 概要

一条已接受的 `review_recorded` 事件在 canonical 事件流与 `event_index` 里都在,任务快照却没有这条 review,而投影水位已经推进越过它。根因:可重建的 `entity_projection` 表把任务拥有的 `review` / `execution` 行只按 `(entity_kind, entity_id)` 作主键,后一个任务复用同一个局部 id(如 `review-ceo-1`)时就覆盖了前一个任务的行。对保留下来的 canonical 缓存做只读统计:233 条 review 事件对 229 行 review 行,三个重复的 review id 恰好解释丢失的四行。修法:主键改为 `(entity_kind, task_id, entity_id)`,无 owner 的实体用空 owner 哨兵,投影 schema 18 → 19,由既有的 schema 不匹配路径丢弃缓存并重放台账,恢复被覆盖的行,不加兼容层或重试层。此前「daemon 换代窗口」假说已被证伪(第一次实例发生在新 daemon attach 完成 9 分钟后),相应探针提交已从分支移除。

## 架构辩护

- 不需要:生产增删 +19/-14,低于两个阈值。

## 改动内容

- `packages/kernel/src/projection/projection-schema.ts`:`taskProjectionSchemaVersion` 18 → 19 并注明原因。
- `packages/kernel/src/projection/rebuildable-task-projection-database.ts`:`entity_projection.task_id` 改为 `NOT NULL`;主键改为 `(entity_kind, task_id, entity_id)`;schema closure 清单同步。
- `packages/kernel/src/projection/rebuildable-task-projection-entities.ts`:upsert 按 owner 维度冲突;无 owner 实体存空 owner 哨兵;无 owner 实体的删除与回读限定 `task_id = ''`;行到实体的映射把哨兵视为无 owner。
- `packages/kernel/src/projection/rebuildable-task-projection-sql.ts`:点查按最新 `workspace_revision` 排序;列表排序加 `task_id`。
- 测试:新增碰撞回归与不同 id 对照两个隔离集成用例及共享 fixtures;relation-entity、schedule-projection 与生命周期 fixture 适配 owner 维度。

## 门收割 / Gate Harvest

- 删除的生产路径:none
- 同 commit 删除的门 / fixture:none
- 生产净行数:引用英文块中的 `Production-Delta`。

## 机读声明说明

- 机读声明只在英文块出现一次;本 PR 不改任何 `package.json` / `package-lock.json`,故不含 Dependency-Change 行。

## 任务与范围

- Harness 任务:task_2fe095aee124235f4405f2043a
- 分支:`codex/projection-miss-review`
- 公开范围:kernel 可重建任务投影的 schema、实体 upsert/读 SQL、定向测试
- 私有计划 / 证据是否已更新:yes
- 范围外:公开的 `getEntity(kind, id)` 点查改为 owner 感知(复用局部 id 时它返回最新一行;快照水合与 `listEntities` 已按 owner 正确)

## 版本影响

- 版本:包版本不变;任务投影 schema 18 → 19(可重建缓存,不匹配即丢弃重放)
- 发布影响:不发布

## 治理声明

- 是否触碰 protected surface:no
- protected surface 范围:无
- 依据:不适用
- 机器检查边界:本 PR 只声明该段存在;声明是否真实、充分,由 reviewer 判断。
- Break-glass:no
- Break-glass 原因:不适用
- Break-glass 范围:不适用
- 后续治理任务:不适用

## 验证

- `origin/main` 基准 SHA:93c4c511fd10e06ac1aa0a986c64402d511bd802
- 当前分支与 `origin/main` 的 merge-base:93c4c511fd10e06ac1aa0a986c64402d511bd802
- 最近一次 `git fetch origin` 时间:2026-09-05T06:40Z
- 同步方式:rebase(head 2f65deaf2d41a6857a20061d4e509da8f45ff8ae)
- 公开 diff 命令:`git diff --stat origin/main...codex/projection-miss-review`
- 私有证据 commit/path:私有任务包 `task_2fe095aee124235f4405f2043a` artifacts/reports/implementation.md
- Reviewer 证据路径:同任务包 artifacts/reports
- GitHub Actions `rewrite-ci` run URL:待 CI 运行后回填
- [ ] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [x] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [x] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- 未运行:按纪律本地不跑整套 `npm run check` / `npm test`。已跑:隔离 Ubuntu 目标机上的碰撞回归(1/1;修复前同一 fixture 1/2 失败、对照通过)、不同 id 对照(1/1)、`projection-ddl-rebuild`(2/2);本地 fast tier 627/627(`TMPDIR=/private/tmp`);`task-projection.test.ts` 26/26;lint、typecheck、file-complexity、schema-closure、line-density、production-delta 通过。CI 是权威。

## 审查证据

- 自查:worker 报告在任务包;CEO 通读了全部生产 diff。
- Reviewer subagent:无
- 人工审查:CEO 按任务计划做语义验收(根因是身份碰撞而非换代窗口;修法给主键加 owner 维度并复用既有 schema 不匹配重建,不加重试/兼容层;有阴性对照)。
- 阻塞发现:无
- 现场证据:fact F-59C8839D(第一次实例,rev 58779)、F-2534BA68(稳态 daemon 下第二次实例,rev 59235)、F-EEE85AA8(统计:233 条事件对 229 行,三个重复 review id)。

## 残余风险

- 升级后每个节点重建一次任务投影缓存(schema 19);本仓重建为数十秒。
- 不带 owner 的 `getEntity(kind, id)` 在局部 id 复用时返回最新一行;需要特定任务实体的调用方经任务快照读取。

## 关联材料

- 任务:task_2fe095aee124235f4405f2043a
- 证据:任务包 artifacts/reports/implementation.md,fact F-59C8839D、F-2534BA68、F-EEE85AA8
- 审查:任务包 artifacts/reports/dispatch_c9a5e810fe5b5d16cd2a5f7e.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)
