### PR TITLE
fix(entity): key artifact mutation opIds on the presented fence so retries replay

### DIFF
--- a/packages/daemon/src/artifact-entity-action.ts
+++ b/packages/daemon/src/artifact-entity-action.ts
@@ -11,7 +11,7 @@ import {
 import {
   compiledRelationDirections,
   artifactEntityContractSnapshot,
-  artifactUpdateOperationId,
+  artifactMutationOperationId,
   canonicalArtifactLocator,
   compileEntityArchived,
   compileEntityUpdated,
@@ -155,7 +155,16 @@ export function executeArtifactEntityMutation(input: {
     expectedVersion = Number(input.action.expectedVersion);
   if (!current?.descriptor)
     throw Object.assign(new Error(`Entity ${kind}/${entityId} does not exist.`), { code: "entity_not_found" });
-  if (!Number.isSafeInteger(expectedVersion) || expectedVersion !== current.revision)
+  if (!Number.isSafeInteger(expectedVersion))
+    throw Object.assign(new Error(`Entity ${entityId} expected revision ${String(expectedVersion)} is invalid.`), {
+      code: "revision_conflict",
+    });
+  const mutation = input.action.kind === "entity-update" ? "update" : "archive",
+    opId = artifactMutationOperationId({ mutation, entityId, expectedVersion }),
+    replayed = readEntityOperation(input.store, opId);
+  // A retry presenting the same fence replays the operation it already applied instead of tripping the CAS below.
+  if (replayed) return { action: input.action, contract, receipt: mutationReplayReceipt(replayed, input) };
+  if (expectedVersion !== current.revision)
     throw Object.assign(
       new Error(
         `Entity ${entityId} expected revision ${String(expectedVersion)}, current revision is ${current.revision}.`,
@@ -172,11 +181,11 @@ export function executeArtifactEntityMutation(input: {
     },
     bundle =
       input.action.kind === "entity-update"
-        ? updatedBundle(input.action, current.descriptor, compiled, contractSnapshot, envelope)
+        ? updatedBundle(input.action, current.descriptor, compiled, contractSnapshot, { ...envelope, opId })
         : compileEntityArchived({
             ...envelope,
-            eventId: `event-entity-archive-${workspaceRevision}`,
-            opId: `entity-archive-${entityId}-${workspaceRevision}`,
+            eventId: `event-${opId}`,
+            opId,
             contractSnapshot,
             entityId,
             reason: requiredArtifactText(input.action.reason, "reason"),
@@ -213,6 +222,7 @@ function updatedBundle(
   compiled: CompiledArtifactKindContract,
   contractSnapshot: ReturnType<typeof artifactEntityContractSnapshot>,
   envelope: {
+    readonly opId: string;
     readonly workspaceRevision: number;
     readonly actor: RepoCellBinding["actor"];
     readonly source: RepoCellBinding["source"];
@@ -223,12 +233,10 @@ function updatedBundle(
       typeof action.locator === "string"
         ? canonicalArtifactLocator({ kind: current.locator.kind, value: action.locator })
         : current.locator,
-    contentVersion = typeof action.contentVersion === "string" ? action.contentVersion.trim() : current.contentVersion,
-    opId = artifactUpdateOperationId({ entityId: current.entityId, workspaceRevision: envelope.workspaceRevision });
+    contentVersion = typeof action.contentVersion === "string" ? action.contentVersion.trim() : current.contentVersion;
   return compileEntityUpdated({
     ...envelope,
-    eventId: `event-${opId}`,
-    opId,
+    eventId: `event-${envelope.opId}`,
     contract: compiled.entityKindContract as Parameters<typeof compileEntityUpdated>[0]["contract"],
     contractSnapshot,
     descriptor: {
@@ -468,6 +476,33 @@ function previewReceipt(
     authorizationDecision: input.authorizationDecision,
     effects: [],
     updatedProjection: null,
+  };
+}
+
+function mutationReplayReceipt(
+  event: EntityEventV1,
+  input: { readonly authorizationDecision: AuthorizationDecision },
+): ArtifactImportReceipt {
+  return {
+    outcome: "no_changes",
+    opId: event.opId,
+    revision: event.workspaceRevision,
+    entityId: event.payload.entityId,
+    evidence: JSON.stringify({
+      schema: "artifact-entity-mutation-result/v1",
+      eventType: event.type,
+      idempotent: true,
+      sameResult: true,
+    }),
+    visibility: "center",
+    proof: {
+      committedRevision: event.workspaceRevision,
+      appliedCut: event.workspaceRevision,
+      durable: true,
+      canonicalVisible: true,
+      worktreeVisible: event.type === "entity_updated",
+    },
+    authorizationDecision: input.authorizationDecision,
   };
 }
 

--- a/packages/daemon/test/artifact-entity-action.integration.test.ts
+++ b/packages/daemon/test/artifact-entity-action.integration.test.ts
@@ -185,6 +185,20 @@ test("Artifact import is dry-run safe, edge-idempotent, fenced, and cold-rebuild
     assert.equal(titleOnlyUpdate.outcome, "applied", JSON.stringify(titleOnlyUpdate));
     assert.notEqual(titleOnlyUpdate.opId, descriptorUpdate.opId);
     assert.match(String(titleOnlyUpdate.opId), /^entity-update-/u);
+    // A retry that presents the same fence replays the applied update instead of revision_conflict.
+    const titleOnlyRetry = await cell.run(
+      {
+        kind: "entity-update",
+        entityKind: kind,
+        entityId: preview.entityId,
+        expectedVersion: descriptorUpdate.revision,
+        title: "Revised title again",
+      },
+      binding,
+    );
+    assert.equal(titleOnlyRetry.outcome, "no_changes", JSON.stringify(titleOnlyRetry));
+    assert.equal(titleOnlyRetry.opId, titleOnlyUpdate.opId);
+    assert.equal(titleOnlyRetry.revision, titleOnlyUpdate.revision);
     const archived = await cell.run(
       {
         kind: "entity-archive",
@@ -196,6 +210,18 @@ test("Artifact import is dry-run safe, edge-idempotent, fenced, and cold-rebuild
       binding,
     );
     assert.equal(archived.outcome, "applied", JSON.stringify(archived));
+    const archiveRetry = await cell.run(
+      {
+        kind: "entity-archive",
+        entityKind: kind,
+        entityId: preview.entityId,
+        expectedVersion: titleOnlyUpdate.revision,
+        reason: "Superseded by ADR-0002",
+      },
+      binding,
+    );
+    assert.equal(archiveRetry.outcome, "no_changes", JSON.stringify(archiveRetry));
+    assert.equal(archiveRetry.opId, archived.opId);
     const artifactEvents = makeTaskEventReader({ repoId, rootDir })
       .read()
       .events.filter((event) => event.schema === "entity-event/v1" && event.payload.entityKind === kind);

--- a/packages/kernel/src/domain/artifact-entity.ts
+++ b/packages/kernel/src/domain/artifact-entity.ts
@@ -310,14 +310,21 @@ export function artifactImportOperationId(input: {
   return `entity-import-${sha256(identity).slice(0, 32)}`;
 }
 
-/** `entity_updated` carries its own operation identity: the same entity at the same revision fence is one
- * operation (retries replay), while an update that leaves contentVersion untouched must never collide with the
- * `entity-import-*` event that first observed that content. */
-export function artifactUpdateOperationId(input: {
+/** Mutations (`entity_updated` / `entity_archived`) key their operation identity on the revision fence the caller
+ * presented, not on the store revision the event lands at: a retry that presents the same fence recomputes the same
+ * opId and replays the applied operation instead of surfacing `revision_conflict`, while an update that leaves
+ * contentVersion untouched never collides with the `entity-import-*` event that first observed that content. */
+export function artifactMutationOperationId(input: {
+  readonly mutation: "update" | "archive";
   readonly entityId: string;
-  readonly workspaceRevision: number;
+  readonly expectedVersion: number;
 }): string {
-  return `entity-update-${input.entityId}-${input.workspaceRevision}`;
+  return `entity-${input.mutation}-${input.entityId}-${input.expectedVersion}`;
+}
+
+export function isArtifactMutationOperationId(mutation: "update" | "archive", entityId: string, opId: string): boolean {
+  const prefix = `entity-${mutation}-${entityId}-`;
+  return opId.startsWith(prefix) && /^(?:0|[1-9][0-9]*)$/u.test(opId.slice(prefix.length));
 }
 
 function isArtifactDescriptor(value: unknown): value is ArtifactDescriptor {

--- a/packages/kernel/src/domain/entity-event.ts
+++ b/packages/kernel/src/domain/entity-event.ts
@@ -4,7 +4,7 @@ import { sha256Text, stableStringify } from "../integrity/stable-hash.ts";
 import {
   artifactEntityContractFromSnapshot,
   artifactImportOperationId,
-  artifactUpdateOperationId,
+  isArtifactMutationOperationId,
   artifactObservationId,
   canonicalArtifactLocator,
   canonicalArtifactSourceIdentity,
@@ -350,17 +350,12 @@ function validateEntityEventFields(value: unknown, allowUnknownFields: boolean):
   if (validateEventEnvelopeIdentity(value, allowUnknownFields).length) return ["entity event identity is invalid"];
   if (value.type === "entity_content_observed")
     return validateObservedPayload(value.payload, hasFields, String(value.opId), allowUnknownFields);
-  if (value.type === "entity_updated")
-    return validateObservedPayload(
-      value.payload,
-      hasFields,
-      String(value.opId),
-      allowUnknownFields,
-      artifactUpdateOperationId({
-        entityId: String(value.payload.entityId),
-        workspaceRevision: Number(value.workspaceRevision),
-      }),
+  if (value.type === "entity_updated") {
+    const updatedEntityId = String(value.payload.entityId);
+    return validateObservedPayload(value.payload, hasFields, String(value.opId), allowUnknownFields, (opId) =>
+      isArtifactMutationOperationId("update", updatedEntityId, opId),
     );
+  }
   if (value.type === "entity_archived") {
     const payload = value.payload;
     try {
@@ -523,7 +518,7 @@ function validateObservedPayload(
   hasFields: typeof hasOnlyFields | typeof hasRequiredFields,
   opId: string,
   allowUnknownFields: boolean,
-  expectedOperation?: string,
+  acceptsOperation?: (opId: string) => boolean,
 ): readonly string[] {
   const fields = [
     "entityKind",
@@ -541,7 +536,7 @@ function validateObservedPayload(
   if (common.length) return common;
   if (typeof payload.observedContentVersion !== "string" || !payload.observedContentVersion)
     return ["entity observed content version is invalid"];
-  if (!validObservationIdentity(payload, payload.observedContentVersion, opId, expectedOperation))
+  if (!validObservationIdentity(payload, payload.observedContentVersion, opId, acceptsOperation))
     return ["entity observed idempotency identity is invalid"];
   let contract: EntityStoreKindContract;
   try {
@@ -643,12 +638,15 @@ function validObservationIdentity(
   payload: Record<string, unknown>,
   resolution: string,
   opId: string,
-  expectedOperation?: string,
+  acceptsOperation?: (opId: string) => boolean,
 ): boolean {
   const locator = payload.locator as unknown as ArtifactLocator,
-    expected = artifactObservationId({ entityId: String(payload.entityId), locator, resolution });
-  expectedOperation ??= artifactImportOperationId({ entityId: String(payload.entityId), locator, resolution });
-  return payload.observationId === expected && opId === expectedOperation;
+    entityId = String(payload.entityId),
+    expected = artifactObservationId({ entityId, locator, resolution }),
+    accepts =
+      acceptsOperation ??
+      ((candidate: string) => candidate === artifactImportOperationId({ entityId, locator, resolution }));
+  return payload.observationId === expected && accepts(opId);
 }
 
 function validateClaim(

--- a/packages/kernel/src/domain/index.ts
+++ b/packages/kernel/src/domain/index.ts
@@ -336,7 +336,7 @@ export {
   artifactEntityContractSnapshot,
   artifactImportOperationId,
   artifactObservationId,
-  artifactUpdateOperationId,
+  artifactMutationOperationId,
   canonicalArtifactLocator,
   canonicalSourceIdentity,
   decodeArtifactDescriptor,


### PR DESCRIPTION
# English

## Summary

Follow-up to #2295 from the independent Terra review of task_d7058b77 (rev_d7058b77_terra_1, changes_requested): a retried `entity-update` / `entity-archive` that presents the same `expectedVersion` returned `revision_conflict` instead of replaying the operation it had already applied, because the opId embedded the store revision the event landed at, which a retry cannot recompute. Mutation opIds are now keyed on the presented fence, `entity-<update|archive>-<entityId>-<expectedVersion>`; the mutation path looks the opId up before the CAS and replays it (`no_changes`, original opId/revision), and the kernel validates `entity_updated` by that shape.

## Architectural Justification

- Not applicable (focused fix). The temporary `artifactUpdateOperationId` from #2295 is replaced, not kept alongside.

## What Changed

- kernel `artifact-entity.ts`: `artifactMutationOperationId` (+ internal `isArtifactMutationOperationId`); `entity-event.ts`: `entity_updated` validation accepts that shape via a predicate, observed/missing keep the import identity.
- daemon `artifact-entity-action.ts`: compute the mutation opId from `expectedVersion`, replay via `readEntityOperation` before the CAS (`mutationReplayReceipt`), archive uses the same identity.
- integration test: same-fence retry of the title-only update and of the archive both return `no_changes` with the original opId.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates: none

## Verification

- `node --test packages/daemon/test/artifact-entity-action.integration.test.ts packages/kernel/test/contracts/artifact-entity.test.ts` → 5 passed (retry cases fail on origin/main with `revision_conflict`).
- `tsc -b packages/kernel packages/application packages/daemon` exit 0; eslint, line-density, file-complexity, kernel dead-exports, duplicate-definitions pass. `check:local` not run.

## Review Evidence

- Terra review report: `harness/tasks/task_d7058b77…/artifacts/reports/review-terra-2026-09-05.md` assertion 3 (blocking) — addressed here; assertions 1, 2, 4, 5 passed.

## Residual Risk

- `fatalCellError` latch policy for `op_conflict` unchanged (separate decision).

Production-Delta: +73/-33

---

# 中文

## 摘要

#2295 的后续,来自 task_d7058b77 的 Terra 独立复核(rev_d7058b77_terra_1,changes_requested):同 fence 重试 `entity-update` / `entity-archive` 会得到 `revision_conflict` 而不是回放已应用的操作,因为 opId 里嵌的是事件落盘时的 store revision,重试方算不出来。现在 mutation 的 opId 以调用方提交的 fence 为键:`entity-<update|archive>-<entityId>-<expectedVersion>`;mutation 路径在 CAS 之前按 opId 查找并回放(`no_changes`、原 opId/revision),kernel 按该形状校验 `entity_updated`。

## 架构辩护

- 不适用(聚焦修复)。#2295 引入的 `artifactUpdateOperationId` 被替换而非并存。

## 变更内容

- kernel:`artifactMutationOperationId`(+ 内部 `isArtifactMutationOperationId`);`entity_updated` 校验改为谓词接受该形状,observed/missing 仍用 import 身份。
- daemon:mutation opId 由 `expectedVersion` 派生,CAS 前经 `readEntityOperation` 回放(`mutationReplayReceipt`);archive 同一身份。
- 集成测试:title-only update 与 archive 的同 fence 重试均返回 `no_changes` 且 opId 不变。

## 门收割

Deleted-Production-Paths: none
Deleted-Gates: none

## 验证

- 定向测试 5 passed(重试用例在 origin/main 上 `revision_conflict` 红);tsc、eslint、line-density、file-complexity、kernel dead-exports、duplicate-definitions 通过;未跑 `check:local`。

## 评审证据

- Terra 报告断言 3(阻塞)在此处置;断言 1/2/4/5 已通过。

## 残余风险

- `op_conflict` 的 latch 分类不变(另立 decision)。
