### PR TITLE
test(daemon): cover registry migration WAL recovery (task_fa0ffafa)

### DIFF
--- a/packages/daemon/test/registry-wal-restart.integration.test.ts
+++ b/packages/daemon/test/registry-wal-restart.integration.test.ts
@@ -1,0 +1,40 @@
+// harness-test-tier: integration
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { reproduceRegistryWalRestart } from "./registry-wal-restart.repro.mjs";
+
+for (const arm of ["migrate-v1", "restart-v2"] as const) {
+  test(`acknowledged task and fact survive the ${arm} daemon replacement sequence`, async () => {
+    const fixtureRoot = mkdtempSync(path.join(tmpdir(), `ha-registry-wal-test-${arm}-`));
+    try {
+      const result = await reproduceRegistryWalRestart(arm, { fixtureRoot });
+      assert.equal(result.before.gitEventHead, 0);
+      assert.equal(result.before.walLines, 2);
+      assert.equal(result.before.receipts.taskReceipt.commitSha, null);
+      assert.equal(result.before.receipts.factReceipt.commitSha, null);
+      assert.equal(result.after.registrySchema, "harness-daemon-registry/v2");
+      assert.equal(result.after.eventHead, 2);
+      assert.deepEqual(result.after.schemas, ["task-event/v1", "fact-event/v1"]);
+      assert.deepEqual(result.after.walRevisions, []);
+      assert.equal(result.after.taskPackageExists, true);
+      assert.equal(result.after.factDocumentExists, true);
+    } finally {
+      rmSync(fixtureRoot, { recursive: true, force: true, maxRetries: 5, retryDelay: 20 });
+    }
+  });
+}
+
+test("the reproduction fails closed when migration drops the v1 repository mapping", async () => {
+  const fixtureRoot = mkdtempSync(path.join(tmpdir(), "ha-registry-wal-test-drop-"));
+  try {
+    await assert.rejects(
+      reproduceRegistryWalRestart("drop-v1-mapping", { fixtureRoot }),
+      /restart cannot attach repro-repo because its registry mapping is absent/u,
+    );
+  } finally {
+    rmSync(fixtureRoot, { recursive: true, force: true, maxRetries: 5, retryDelay: 20 });
+  }
+});

--- a/packages/daemon/test/registry-wal-restart.integration.test.ts
+++ b/packages/daemon/test/registry-wal-restart.integration.test.ts
@@ -6,35 +6,25 @@ import path from "node:path";
 import test from "node:test";
 import { reproduceRegistryWalRestart } from "./registry-wal-restart.repro.mjs";
 
-for (const arm of ["migrate-v1", "restart-v2"] as const) {
-  test(`acknowledged task and fact survive the ${arm} daemon replacement sequence`, async () => {
+for (const arm of ["graceful-stop", "sigkill"] as const) {
+  test(`daemon preserves acknowledged WAL writes after ${arm}`, async () => {
     const fixtureRoot = mkdtempSync(path.join(tmpdir(), `ha-registry-wal-test-${arm}-`));
     try {
       const result = await reproduceRegistryWalRestart(arm, { fixtureRoot });
-      assert.equal(result.before.gitEventHead, 0);
-      assert.equal(result.before.walLines, 2);
+      process.stdout.write(`[registry-wal-restart:${arm}] ${JSON.stringify(result)}\n`);
+      assert.equal(result.before.registrySchema, "harness-daemon-registry/v2");
+      assert.equal(result.before.receipts.taskReceipt.outcome, "applied");
       assert.equal(result.before.receipts.taskReceipt.commitSha, null);
+      assert.equal(result.before.receipts.factReceipt.outcome, "applied");
       assert.equal(result.before.receipts.factReceipt.commitSha, null);
       assert.equal(result.after.registrySchema, "harness-daemon-registry/v2");
-      assert.equal(result.after.eventHead, 2);
-      assert.deepEqual(result.after.schemas, ["task-event/v1", "fact-event/v1"]);
-      assert.deepEqual(result.after.walRevisions, []);
+      assert.ok(result.after.canonicalEventHead > result.before.canonicalEventHead);
+      assert.equal(result.after.walLines, 0);
       assert.equal(result.after.taskPackageExists, true);
-      assert.equal(result.after.factDocumentExists, true);
+      assert.equal(result.after.taskId, result.after.expectedTaskId);
+      assert.equal(result.after.factId, result.after.expectedFactId);
     } finally {
       rmSync(fixtureRoot, { recursive: true, force: true, maxRetries: 5, retryDelay: 20 });
     }
   });
 }
-
-test("the reproduction fails closed when migration drops the v1 repository mapping", async () => {
-  const fixtureRoot = mkdtempSync(path.join(tmpdir(), "ha-registry-wal-test-drop-"));
-  try {
-    await assert.rejects(
-      reproduceRegistryWalRestart("drop-v1-mapping", { fixtureRoot }),
-      /restart cannot attach repro-repo because its registry mapping is absent/u,
-    );
-  } finally {
-    rmSync(fixtureRoot, { recursive: true, force: true, maxRetries: 5, retryDelay: 20 });
-  }
-});

--- a/packages/daemon/test/registry-wal-restart.repro.mjs
+++ b/packages/daemon/test/registry-wal-restart.repro.mjs
@@ -1,0 +1,211 @@
+#!/usr/bin/env node
+
+import { execFileSync, spawnSync } from "node:child_process";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const repositoryRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../..");
+const kernelUrl = pathToFileURL(path.join(repositoryRoot, "packages/kernel/src/index.ts")).href;
+const walUrl = pathToFileURL(path.join(repositoryRoot, "packages/kernel/src/store/wal-event-log.ts")).href;
+
+export async function reproduceRegistryWalRestart(arm, options = {}) {
+  if (arm !== "migrate-v1" && arm !== "restart-v2" && arm !== "drop-v1-mapping")
+    throw new Error(`unknown reproduction arm: ${arm}`);
+  const fixtureRoot = options.fixtureRoot ?? mkdtempSync(path.join(tmpdir(), `ha-registry-wal-${arm}-`));
+  const rootDir = path.join(fixtureRoot, "repository");
+  const userRoot = path.join(fixtureRoot, "user-root");
+  mkdirSync(rootDir, { recursive: true });
+  mkdirSync(userRoot, { recursive: true });
+  initRepo(rootDir);
+  writeRegistry(userRoot, rootDir, arm === "restart-v2" ? "v2" : "v1");
+
+  const child = spawnSync(
+    process.execPath,
+    ["--experimental-strip-types", fileURLToPath(import.meta.url), "--child", rootDir],
+    { encoding: "utf8", env: { ...process.env, HA_REPRO_KERNEL_URL: kernelUrl } },
+  );
+  if (child.status !== 0) throw new Error(`writer process failed (${child.status}): ${child.stderr || child.stdout}`);
+  const before = observe(rootDir, userRoot, child.stdout.trim());
+
+  const { makeTaskEventStore, readDaemonRegistry } = await import(kernelUrl);
+  const { openWalEventLog } = await import(walUrl);
+  const registry =
+    arm === "drop-v1-mapping" ? { schema: "harness-daemon-registry/v2", repos: [] } : readDaemonRegistry({ userRoot });
+  const registered = registry.repos.find((repo) => repo.repoId === "repro-repo");
+  if (!registered?.canonicalRoot)
+    throw new Error("restart cannot attach repro-repo because its registry mapping is absent");
+
+  const store = makeTaskEventStore({ repoId: "repro-repo", rootDir: registered.canonicalRoot });
+  const recovery = store.recover();
+  await store.settleRecoveryMaterialization?.();
+  await store.drain();
+  const stream = store.read();
+  const after = {
+    registrySchema: readDaemonRegistry({ userRoot }).schema,
+    eventHead: stream.revision,
+    schemas: stream.events.map((event) => event.schema),
+    walRevisions: openWalEventLog(rootDir, { mutable: false })
+      .records()
+      .map((record) => record.revision),
+    taskPackageExists: existsSync(path.join(rootDir, "harness/tasks/task-repro/task.md")),
+    factDocumentExists: existsSync(path.join(rootDir, "harness/facts/F-REPR0002.md")),
+    canonicalCommit: git(rootDir, "rev-parse", "refs/ha/canonical"),
+    recovery,
+  };
+  return { arm, fixtureRoot, before, after };
+}
+
+async function childWrite(rootDir) {
+  const { REPLAY_TASK_GRAPH, compileFactWrite, makeTaskEventStore, sha256Text, taskLifecycleWritePlan } = await import(
+    process.env.HA_REPRO_KERNEL_URL ?? kernelUrl
+  );
+  const store = makeTaskEventStore({
+    repoId: "repro-repo",
+    rootDir,
+    walFlushEvents: 64,
+    walFlushMs: 60_000,
+  });
+  const taskBody = "# Reproduction task\n",
+    taskClaim = {
+      path: "tasks/task-repro/task.md",
+      sha256: sha256Text(taskBody),
+      size: Buffer.byteLength(taskBody),
+      mediaType: "text/markdown",
+      policyId: "typed-machine-writer/v1",
+    },
+    taskEvent = {
+      schema: "task-event/v1",
+      eventId: "event-repro-task",
+      workspaceRevision: 1,
+      opId: "op-repro-task",
+      taskId: "task-repro",
+      type: "task_created",
+      actor: { principal: { personId: "person-repro" }, executor: { kind: "agent", id: "codex" } },
+      source: "local",
+      occurredAt: "2026-09-05T00:00:00.000Z",
+      payload: {
+        task: {
+          schema: "task/v2",
+          taskId: "task-repro",
+          title: "Registry WAL restart reproduction",
+          taskClass: "standard",
+          status: "planned",
+          graph: REPLAY_TASK_GRAPH,
+          currentNode: "implementation",
+          iteration: 0,
+          createdBy: {
+            principal: { personId: "person-repro" },
+            executor: { kind: "agent", id: "codex" },
+          },
+          completionGateIds: [],
+          presetSnapshotDigest: null,
+          pinned: false,
+        },
+        documentClaims: [taskClaim],
+      },
+    };
+  const taskReceipt = store.append({
+    event: taskEvent,
+    plan: taskLifecycleWritePlan(taskEvent),
+    blobs: [{ ...taskClaim, body: taskBody }],
+  });
+  const factWrite = compileFactWrite({
+    event: {
+      schema: "fact-event/v1",
+      eventId: "event-repro-fact",
+      workspaceRevision: 2,
+      opId: "op-repro-fact",
+      taskId: "task-repro",
+      factId: "F-REPR0002",
+      type: "fact_recorded",
+      actor: { principal: { personId: "person-repro" }, executor: { kind: "agent", id: "codex" } },
+      source: "local",
+      occurredAt: "2026-09-05T00:00:01.000Z",
+      payload: {
+        statement: "The reproduction fact reached the durable WAL.",
+        evidenceSource: "scripts/repro-registry-wal-restart.mjs",
+        observedAt: "2026-09-05T00:00:01.000Z",
+        confidence: "high",
+        memoryClass: "episodic",
+        memoryTags: ["episode"],
+        provenance: [
+          {
+            runtime: "unavailable",
+            sessionId: null,
+            transcriptReachability: "unavailable",
+            boundAt: "2026-09-05T00:00:01.000Z",
+          },
+        ],
+      },
+    },
+  });
+  const factReceipt = store.append(factWrite);
+  process.stdout.write(`${JSON.stringify({ taskReceipt, factReceipt })}\n`);
+  process.exit(0);
+}
+
+function observe(rootDir, userRoot, receipts) {
+  const segmentPath = path.join(rootDir, ".harness/wal/seg-000000.log");
+  return {
+    registrySchema: JSON.parse(readFileSync(path.join(userRoot, "registry.json"), "utf8")).schema,
+    gitEventHead: readGitEventHead(rootDir),
+    walLines: existsSync(segmentPath) ? readFileSync(segmentPath, "utf8").trim().split("\n").filter(Boolean).length : 0,
+    taskPackageExists: existsSync(path.join(rootDir, "harness/tasks/task-repro/task.md")),
+    factDocumentExists: existsSync(path.join(rootDir, "harness/facts/F-REPR0002.md")),
+    receipts: JSON.parse(receipts),
+  };
+}
+
+function readGitEventHead(rootDir) {
+  try {
+    return JSON.parse(git(rootDir, "show", "refs/ha/canonical:harness/events/head.json")).revision;
+  } catch {
+    return 0;
+  }
+}
+
+function writeRegistry(userRoot, rootDir, version) {
+  const repo = {
+    repoId: "repro-repo",
+    canonicalRoot: realpathSync.native(rootDir),
+    displayName: "WAL reproduction",
+    authoredBranch: "master",
+    ...(version === "v2" ? { mode: "local", connectionId: "local" } : {}),
+    state: "enabled",
+    registeredAt: "2026-09-05T00:00:00.000Z",
+  };
+  const registry =
+    version === "v2"
+      ? {
+          schema: "harness-daemon-registry/v2",
+          connections: [{ id: "local", kind: "local", displayName: "This device", state: "enabled" }],
+          repos: [repo],
+        }
+      : { schema: "harness-daemon-registry/v1", repos: [repo] };
+  writeFileSync(path.join(userRoot, "registry.json"), `${JSON.stringify(registry)}\n`);
+}
+
+function initRepo(rootDir) {
+  git(rootDir, "init", "--quiet");
+  git(rootDir, "config", "user.name", "Registry WAL Reproduction");
+  git(rootDir, "config", "user.email", "registry-wal-repro@example.invalid");
+  git(rootDir, "config", "gc.auto", "0");
+  git(rootDir, "commit", "--allow-empty", "--quiet", "-m", "fixture base");
+}
+
+function git(rootDir, ...args) {
+  return execFileSync("git", ["-C", rootDir, ...args], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  }).trim();
+}
+
+if (process.argv[2] === "--child") {
+  await childWrite(process.argv[3]);
+} else if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  const requestedArm = process.argv[2];
+  const arms = requestedArm ? [requestedArm] : ["migrate-v1", "restart-v2"];
+  for (const arm of arms) process.stdout.write(`${JSON.stringify(await reproduceRegistryWalRestart(arm), null, 2)}\n`);
+}

--- a/packages/daemon/test/registry-wal-restart.repro.mjs
+++ b/packages/daemon/test/registry-wal-restart.repro.mjs
@@ -1,211 +1,229 @@
 #!/usr/bin/env node
-
+import assert from "node:assert/strict";
 import { execFileSync, spawnSync } from "node:child_process";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { hostname, tmpdir } from "node:os";
 import path from "node:path";
-import { fileURLToPath, pathToFileURL } from "node:url";
+import { fileURLToPath } from "node:url";
+import { daemonProcessAlive } from "../src/daemon-singleton.ts";
+import { readDaemonPid } from "../src/runtime.ts";
+import { registerBootstrappedDaemonRepo } from "./repo-settings.fixture.ts";
 
-const repositoryRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../..");
-const kernelUrl = pathToFileURL(path.join(repositoryRoot, "packages/kernel/src/index.ts")).href;
-const walUrl = pathToFileURL(path.join(repositoryRoot, "packages/kernel/src/store/wal-event-log.ts")).href;
+const repositoryRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../.."),
+  cli = path.join(repositoryRoot, "packages/cli/src/index.ts");
 
 export async function reproduceRegistryWalRestart(arm, options = {}) {
-  if (arm !== "migrate-v1" && arm !== "restart-v2" && arm !== "drop-v1-mapping")
-    throw new Error(`unknown reproduction arm: ${arm}`);
-  const fixtureRoot = options.fixtureRoot ?? mkdtempSync(path.join(tmpdir(), `ha-registry-wal-${arm}-`));
-  const rootDir = path.join(fixtureRoot, "repository");
-  const userRoot = path.join(fixtureRoot, "user-root");
-  mkdirSync(rootDir, { recursive: true });
-  mkdirSync(userRoot, { recursive: true });
-  initRepo(rootDir);
-  writeRegistry(userRoot, rootDir, arm === "restart-v2" ? "v2" : "v1");
-
-  const child = spawnSync(
-    process.execPath,
-    ["--experimental-strip-types", fileURLToPath(import.meta.url), "--child", rootDir],
-    { encoding: "utf8", env: { ...process.env, HA_REPRO_KERNEL_URL: kernelUrl } },
-  );
-  if (child.status !== 0) throw new Error(`writer process failed (${child.status}): ${child.stderr || child.stdout}`);
-  const before = observe(rootDir, userRoot, child.stdout.trim());
-
-  const { makeTaskEventStore, readDaemonRegistry } = await import(kernelUrl);
-  const { openWalEventLog } = await import(walUrl);
-  const registry =
-    arm === "drop-v1-mapping" ? { schema: "harness-daemon-registry/v2", repos: [] } : readDaemonRegistry({ userRoot });
-  const registered = registry.repos.find((repo) => repo.repoId === "repro-repo");
-  if (!registered?.canonicalRoot)
-    throw new Error("restart cannot attach repro-repo because its registry mapping is absent");
-
-  const store = makeTaskEventStore({ repoId: "repro-repo", rootDir: registered.canonicalRoot });
-  const recovery = store.recover();
-  await store.settleRecoveryMaterialization?.();
-  await store.drain();
-  const stream = store.read();
-  const after = {
-    registrySchema: readDaemonRegistry({ userRoot }).schema,
-    eventHead: stream.revision,
-    schemas: stream.events.map((event) => event.schema),
-    walRevisions: openWalEventLog(rootDir, { mutable: false })
-      .records()
-      .map((record) => record.revision),
-    taskPackageExists: existsSync(path.join(rootDir, "harness/tasks/task-repro/task.md")),
-    factDocumentExists: existsSync(path.join(rootDir, "harness/facts/F-REPR0002.md")),
-    canonicalCommit: git(rootDir, "rev-parse", "refs/ha/canonical"),
-    recovery,
-  };
+  if (arm !== "graceful-stop" && arm !== "sigkill") throw new Error(`unknown reproduction arm: ${arm}`);
+  const fixtureRoot = options.fixtureRoot ?? mkdtempSync(path.join(tmpdir(), `ha-daemon-wal-${arm}-`)),
+    rootDir = path.join(fixtureRoot, "repository"),
+    userRoot = path.join(fixtureRoot, "user-root"),
+    repoId = `registry-wal-${arm}`,
+    daemonId = `registry-wal-${arm}`,
+    fixture = { fixtureRoot, rootDir, userRoot, repoId, daemonId };
+  rosterRepo(rootDir, repoId);
+  registerBootstrappedDaemonRepo({ canonicalRoot: rootDir, repoId, userRoot, createConvenienceLinks: false });
+  downgradeRegistryToV1(userRoot);
+  startDaemon(fixture);
+  await waitForAttached(fixture);
+  const taskReceipt = runCli(fixture, ["task", "create", "--title", `Daemon WAL ${arm}`]),
+    taskId = String(taskReceipt.taskId),
+    factReceipt = runCli(fixture, [
+      "fact",
+      "record",
+      taskId,
+      "--statement",
+      `Daemon WAL ${arm} fact`,
+      "--source",
+      `test:registry-wal-${arm}`,
+      "--confidence",
+      "high",
+    ]),
+    before = observeBefore(fixture, taskReceipt, factReceipt);
+  assert.equal(taskReceipt.commitSha, null, JSON.stringify(taskReceipt));
+  assert.equal(factReceipt.commitSha, null, JSON.stringify(factReceipt));
+  assert.ok(before.walLines >= 2, JSON.stringify(before));
+  if (arm === "graceful-stop") runCli(fixture, ["daemon", "stop"]);
+  else killDaemon(fixture);
+  await waitForStopped(fixture);
+  startDaemon(fixture);
+  await waitForAttached(fixture);
+  const task = runCli(fixture, ["task", "show", taskId]),
+    fact = runCli(fixture, ["fact", "show", "--id", String(factReceipt.factId)]),
+    after = observeAfter(fixture, taskId, String(factReceipt.factId), String(taskReceipt.packagePath), task, fact);
+  runCli(fixture, ["daemon", "stop"]);
+  await waitForStopped(fixture);
   return { arm, fixtureRoot, before, after };
 }
 
-async function childWrite(rootDir) {
-  const { REPLAY_TASK_GRAPH, compileFactWrite, makeTaskEventStore, sha256Text, taskLifecycleWritePlan } = await import(
-    process.env.HA_REPRO_KERNEL_URL ?? kernelUrl
-  );
-  const store = makeTaskEventStore({
-    repoId: "repro-repo",
-    rootDir,
-    walFlushEvents: 64,
-    walFlushMs: 60_000,
-  });
-  const taskBody = "# Reproduction task\n",
-    taskClaim = {
-      path: "tasks/task-repro/task.md",
-      sha256: sha256Text(taskBody),
-      size: Buffer.byteLength(taskBody),
-      mediaType: "text/markdown",
-      policyId: "typed-machine-writer/v1",
-    },
-    taskEvent = {
-      schema: "task-event/v1",
-      eventId: "event-repro-task",
-      workspaceRevision: 1,
-      opId: "op-repro-task",
-      taskId: "task-repro",
-      type: "task_created",
-      actor: { principal: { personId: "person-repro" }, executor: { kind: "agent", id: "codex" } },
-      source: "local",
-      occurredAt: "2026-09-05T00:00:00.000Z",
-      payload: {
-        task: {
-          schema: "task/v2",
-          taskId: "task-repro",
-          title: "Registry WAL restart reproduction",
-          taskClass: "standard",
-          status: "planned",
-          graph: REPLAY_TASK_GRAPH,
-          currentNode: "implementation",
-          iteration: 0,
-          createdBy: {
-            principal: { personId: "person-repro" },
-            executor: { kind: "agent", id: "codex" },
-          },
-          completionGateIds: [],
-          presetSnapshotDigest: null,
-          pinned: false,
-        },
-        documentClaims: [taskClaim],
-      },
-    };
-  const taskReceipt = store.append({
-    event: taskEvent,
-    plan: taskLifecycleWritePlan(taskEvent),
-    blobs: [{ ...taskClaim, body: taskBody }],
-  });
-  const factWrite = compileFactWrite({
-    event: {
-      schema: "fact-event/v1",
-      eventId: "event-repro-fact",
-      workspaceRevision: 2,
-      opId: "op-repro-fact",
-      taskId: "task-repro",
-      factId: "F-REPR0002",
-      type: "fact_recorded",
-      actor: { principal: { personId: "person-repro" }, executor: { kind: "agent", id: "codex" } },
-      source: "local",
-      occurredAt: "2026-09-05T00:00:01.000Z",
-      payload: {
-        statement: "The reproduction fact reached the durable WAL.",
-        evidenceSource: "scripts/repro-registry-wal-restart.mjs",
-        observedAt: "2026-09-05T00:00:01.000Z",
-        confidence: "high",
-        memoryClass: "episodic",
-        memoryTags: ["episode"],
-        provenance: [
-          {
-            runtime: "unavailable",
-            sessionId: null,
-            transcriptReachability: "unavailable",
-            boundAt: "2026-09-05T00:00:01.000Z",
-          },
-        ],
-      },
-    },
-  });
-  const factReceipt = store.append(factWrite);
-  process.stdout.write(`${JSON.stringify({ taskReceipt, factReceipt })}\n`);
-  process.exit(0);
-}
-
-function observe(rootDir, userRoot, receipts) {
-  const segmentPath = path.join(rootDir, ".harness/wal/seg-000000.log");
+function observeBefore(fixture, taskReceipt, factReceipt) {
   return {
-    registrySchema: JSON.parse(readFileSync(path.join(userRoot, "registry.json"), "utf8")).schema,
-    gitEventHead: readGitEventHead(rootDir),
-    walLines: existsSync(segmentPath) ? readFileSync(segmentPath, "utf8").trim().split("\n").filter(Boolean).length : 0,
-    taskPackageExists: existsSync(path.join(rootDir, "harness/tasks/task-repro/task.md")),
-    factDocumentExists: existsSync(path.join(rootDir, "harness/facts/F-REPR0002.md")),
-    receipts: JSON.parse(receipts),
+    registrySchema: registrySchema(fixture),
+    canonicalEventHead: canonicalHead(fixture.rootDir),
+    walLines: walLines(fixture.rootDir),
+    taskPackageExists: packageExists(fixture.rootDir, String(taskReceipt.packagePath)),
+    receipts: { taskReceipt, factReceipt },
   };
 }
-
-function readGitEventHead(rootDir) {
+function observeAfter(fixture, taskId, factId, packagePath, task, fact) {
+  const taskEvidence = JSON.parse(String(task.evidence)),
+    factEvidence = JSON.parse(String(fact.evidence));
+  return {
+    registrySchema: registrySchema(fixture),
+    canonicalEventHead: canonicalHead(fixture.rootDir),
+    walLines: walLines(fixture.rootDir),
+    taskPackageExists: packageExists(fixture.rootDir, packagePath),
+    taskId: taskEvidence.task.taskId,
+    factId: factEvidence.fact.factId,
+    expectedTaskId: taskId,
+    expectedFactId: factId,
+  };
+}
+function startDaemon(fixture) {
+  const result = runCliResult(fixture, ["daemon", "start", "--service"]);
+  assert.equal(result.status, 0, `${result.stderr}\n${result.stdout}\n${daemonLog(fixture)}`);
+}
+function killDaemon(fixture) {
+  const pid = readDaemonPid(fixture.userRoot, fixture.daemonId);
+  assert.notEqual(pid, null, "isolated daemon must publish its pid before SIGKILL");
+  process.kill(pid, "SIGKILL");
+}
+async function waitForAttached(fixture) {
+  const deadline = Date.now() + 60_000;
+  for (;;) {
+    const result = runCliResult(fixture, ["daemon", "status"]);
+    if (
+      result.status === 0 &&
+      JSON.parse(result.stdout).repos?.some((repo) => repo.repoId === fixture.repoId && repo.state === "attached")
+    )
+      return;
+    if (Date.now() > deadline)
+      throw new Error(`daemon did not attach: ${result.stderr}\n${result.stdout}\n${daemonLog(fixture)}`);
+    await delay(50);
+  }
+}
+async function waitForStopped(fixture) {
+  const deadline = Date.now() + 30_000;
+  for (;;) {
+    const pid = readDaemonPid(fixture.userRoot, fixture.daemonId);
+    if (pid === null || !daemonProcessAlive(pid)) return;
+    if (Date.now() > deadline) throw new Error(`daemon ${fixture.daemonId} did not stop`);
+    await delay(50);
+  }
+}
+function runCli(fixture, args) {
+  const result = runCliResult(fixture, args);
+  assert.equal(result.status, 0, `${result.stderr}\n${result.stdout}\n${daemonLog(fixture)}`);
+  return JSON.parse(result.stdout);
+}
+function runCliResult(fixture, args) {
+  return spawnSync(process.execPath, [cli, "--root", fixture.rootDir, "--json", ...args], {
+    encoding: "utf8",
+    env: isolatedEnvironment(fixture),
+    timeout: 60_000,
+  });
+}
+function isolatedEnvironment(fixture) {
+  const env = { ...process.env };
+  for (const key of Object.keys(env)) if (key.startsWith("HARNESS_")) delete env[key];
+  return {
+    ...env,
+    GIT_CONFIG_GLOBAL: "/dev/null",
+    HARNESS_ACTOR: "agent:harness-test",
+    HARNESS_DAEMON_ID: fixture.daemonId,
+    HARNESS_DAEMON_REPO_ID: fixture.repoId,
+    HARNESS_DAEMON_USER_ROOT: fixture.userRoot,
+  };
+}
+function daemonLog(fixture) {
+  const log = path.join(fixture.userRoot, "logs", `daemon-${fixture.daemonId}.log`);
+  return existsSync(log) ? readFileSync(log, "utf8") : "daemon log absent";
+}
+function downgradeRegistryToV1(userRoot) {
+  const registryPath = path.join(userRoot, "registry.json"),
+    registry = JSON.parse(readFileSync(registryPath, "utf8"));
+  writeFileSync(
+    registryPath,
+    `${JSON.stringify({
+      schema: "harness-daemon-registry/v1",
+      repos: registry.repos.map(({ mode: _mode, connectionId: _connectionId, ...repo }) => repo),
+    })}\n`,
+  );
+}
+function registrySchema(fixture) {
+  return JSON.parse(readFileSync(path.join(fixture.userRoot, "registry.json"), "utf8")).schema;
+}
+function packageExists(rootDir, packagePath) {
+  return existsSync(path.join(rootDir, packagePath)) || existsSync(path.join(rootDir, "harness", packagePath));
+}
+function walLines(rootDir) {
+  const segment = path.join(rootDir, ".harness/wal/seg-000000.log");
+  return existsSync(segment) ? readFileSync(segment, "utf8").trim().split("\n").filter(Boolean).length : 0;
+}
+function canonicalHead(rootDir) {
   try {
     return JSON.parse(git(rootDir, "show", "refs/ha/canonical:harness/events/head.json")).revision;
   } catch {
     return 0;
   }
 }
-
-function writeRegistry(userRoot, rootDir, version) {
-  const repo = {
-    repoId: "repro-repo",
-    canonicalRoot: realpathSync.native(rootDir),
-    displayName: "WAL reproduction",
-    authoredBranch: "master",
-    ...(version === "v2" ? { mode: "local", connectionId: "local" } : {}),
-    state: "enabled",
-    registeredAt: "2026-09-05T00:00:00.000Z",
-  };
-  const registry =
-    version === "v2"
-      ? {
-          schema: "harness-daemon-registry/v2",
-          connections: [{ id: "local", kind: "local", displayName: "This device", state: "enabled" }],
-          repos: [repo],
-        }
-      : { schema: "harness-daemon-registry/v1", repos: [repo] };
-  writeFileSync(path.join(userRoot, "registry.json"), `${JSON.stringify(registry)}\n`);
-}
-
-function initRepo(rootDir) {
+function rosterRepo(rootDir, repoId) {
+  mkdirSync(path.join(rootDir, "harness"), { recursive: true });
   git(rootDir, "init", "--quiet");
-  git(rootDir, "config", "user.name", "Registry WAL Reproduction");
-  git(rootDir, "config", "user.email", "registry-wal-repro@example.invalid");
+  git(rootDir, "config", "user.name", "Registry WAL Daemon Test");
+  git(rootDir, "config", "user.email", "registry-wal-daemon@example.invalid");
   git(rootDir, "config", "gc.auto", "0");
-  git(rootDir, "commit", "--allow-empty", "--quiet", "-m", "fixture base");
+  writeFileSync(
+    path.join(rootDir, "harness/harness.yaml"),
+    [
+      "schema: harness-anything/v1",
+      `name: ${repoId}`,
+      "layout:",
+      "  authoredRoot: harness",
+      "  localRoot: .harness",
+      "settings:",
+      "  walFlush:",
+      "    adaptive: false",
+      "    events: 256",
+      "    bytes: 8388608",
+      "    milliseconds: 3600000",
+      "",
+    ].join("\n"),
+  );
+  writeFileSync(
+    path.join(rootDir, "harness/people.yaml"),
+    `${JSON.stringify({
+      schema: "harness-people/v1",
+      people: [
+        {
+          personId: "writer",
+          displayName: "writer",
+          roles: ["writer"],
+          credentials: [
+            {
+              kind: "unix-socket-owner-boundary",
+              issuer: `host:${hostname()}`,
+              subject: String(process.getuid?.() ?? 0),
+            },
+          ],
+        },
+      ],
+      roles: [{ roleId: "writer", commandClasses: ["repo-read", "repo-write", "admin"] }],
+    })}\n`,
+  );
+  git(rootDir, "add", "harness");
+  git(rootDir, "commit", "--quiet", "-m", "fixture base");
 }
-
 function git(rootDir, ...args) {
   return execFileSync("git", ["-C", rootDir, ...args], {
     encoding: "utf8",
     stdio: ["ignore", "pipe", "pipe"],
   }).trim();
 }
-
-if (process.argv[2] === "--child") {
-  await childWrite(process.argv[3]);
-} else if (process.argv[1] === fileURLToPath(import.meta.url)) {
-  const requestedArm = process.argv[2];
-  const arms = requestedArm ? [requestedArm] : ["migrate-v1", "restart-v2"];
+function delay(milliseconds) {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  const requestedArm = process.argv[2],
+    arms = requestedArm ? [requestedArm] : ["graceful-stop", "sigkill"];
   for (const arm of arms) process.stdout.write(`${JSON.stringify(await reproduceRegistryWalRestart(arm), null, 2)}\n`);
 }


### PR DESCRIPTION
# English

## Summary

Debug line for task_fa0ffafa (acknowledged task/fact writes lost across the 2026-09-02 registry v1→v2 hard cut + daemon replacement, fact F-466163BF). On current main the loss does **not** reproduce in either arm: PR #2171 replaced the v1 rejection with an atomic v1→v2 upgrade that preserves each row's repoId/canonicalRoot mapping, so the restarted writer re-attaches the same repository-local WAL and recovery materializes the acknowledged suffix. The explicit negative arm (drop the v1 mapping) fails before attach, which is the discontinuity #2155 had opened. Round 2 (after CEO semantic review) replaced the direct kernel-store fixture with a real resident-daemon fixture: a dedicated user root/registry/socket, `ha task create` + `ha fact record` acknowledged `applied` with `commitSha=null`, then daemon replacement by graceful `ha daemon stop` and by SIGKILL; in both arms the new daemon attaches, canonical head 1→3, WAL 2→0, and the task/fact remain readable. The first-round kernel arm and dropped-mapping arm were deleted (kernel reopen is already covered by existing WAL recovery tests and that fixture bypassed RepoCell materialization/fence). No production change.

## Architectural Justification

- Not applicable: tests only (`+0/-0` production).

## What Changed

- `packages/daemon/test/registry-wal-restart.repro.mjs`: resident-daemon reproduction fixture (v1 registry → real daemon attach/upgrade → acknowledged unmaterialized writes → graceful-stop or SIGKILL replacement → new daemon attach → CLI reads).
- `packages/daemon/test/registry-wal-restart.integration.test.ts` (`harness-test-tier: integration`): graceful-stop and SIGKILL replacement through the CLI/daemon attach path.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates: none

## Verification

- `node tools/dispatch-isolated-test.mjs --file packages/daemon/test/registry-wal-restart.integration.test.ts` on the Ubuntu VM (round 2, daemon arms) passed; raw logs `artifacts/raw/daemon-graceful-stop-2026-09-05.log`, `daemon-sigkill-2026-09-05.log` in the task packet.
- eslint on both files; `git diff --check`. `check:local` not run.

## Review Evidence

- Worker report: `harness/tasks/task_fa0ffafa…/artifacts/reports/implementation.md` §2 challenges the plan's suspected chain (v1 rejection blocking re-attach) with `git show 2f4bfa3cc -- packages/kernel/src/daemon/registry.ts`.
- CEO: moved the fixture out of `scripts/` (it is test tooling, imported by the test), no other change.

## Residual Risk

- The daemon arms replace the resident daemon process (graceful and SIGKILL) but run the same `dist` bytes before and after; the exact operator sequence of 2026-09-02 is not recoverable. Receipt semantics (`applied` before materialization) stay owned by W1-min / gen-2.

Production-Delta: +0/-0

---

# 中文

## 摘要

task_fa0ffafa 的 debug 线(2026-09-02 registry v1→v2 硬切 + daemon 换代后,已回执 applied 的 task/fact 丢失,F-466163BF)。在当前 main 上两臂都**复现不出**:PR #2171 把 v1 拒绝改成了保留 repoId/canonicalRoot 映射的原子 v1→v2 升级,重启后的 writer 重新挂上同一个仓内 WAL,恢复把已回执的后缀物化。阴性臂(抹掉 v1 映射)在 attach 前失败——那正是 #2155 当时打开的断点。第二轮(CEO 语义验收后)把直接开 kernel store 的 fixture 换成真实常驻 daemon:独立 user root/registry/socket,`ha task create` + `ha fact record` 拿到 applied 且 commitSha=null,再分别用 `ha daemon stop` 与 SIGKILL 换代;两臂新 daemon attach 后 canonical head 1→3、WAL 2→0,task/fact 都可读。第一轮的 kernel 臂与映射丢失臂已删(kernel reopen 已有 WAL 恢复测试覆盖,且该 fixture 绕过 RepoCell 物化/fence)。无生产改动。

## 架构辩护

- 不适用:仅测试(`+0/-0`)。

## 变更内容

- `packages/daemon/test/registry-wal-restart.repro.mjs`:常驻 daemon 复现 fixture(v1 registry → 真实 daemon attach/升级 → 已回执未物化写入 → 优雅停或 SIGKILL 换代 → 新 daemon attach → CLI 读)。
- `packages/daemon/test/registry-wal-restart.integration.test.ts`(integration tier):优雅停与 SIGKILL 两种换代经 CLI/daemon attach 路径。

## 门收割

Deleted-Production-Paths: none
Deleted-Gates: none

## 验证

- Ubuntu VM 隔离跑集成测试(第二轮 daemon 臂)通过,原始日志在任务包 `artifacts/raw/daemon-*.log`;eslint、`git diff --check` 通过;未跑 `check:local`。

## 评审证据

- worker 报告 §2 用 `git show 2f4bfa3cc` 证伪了 plan 的疑似因果链;CEO 只把 fixture 从 `scripts/` 移进测试目录。

## 残余风险

- daemon 臂真实换代常驻进程(优雅停与 SIGKILL),但前后 `dist` 字节相同;09-02 的精确人工序列不可还原。回执语义归 W1-min / gen-2。
