### PR TITLE
fix(kernel): stop requiring reviewIndependence in the stored Settings declaration

### DIFF
--- a/packages/kernel/src/domain/settings.ts
+++ b/packages/kernel/src/domain/settings.ts
@@ -167,7 +167,6 @@ export const SETTINGS_V1_SCHEMA: EntityDocumentJsonSchema<SettingsV1> = {
     "defaultVertical",
     "defaultPreset",
     "defaultProfile",
-    "reviewIndependence",
     "locale",
     "scaffolds",
     "walFlush",
@@ -217,16 +216,7 @@ export const SETTINGS_REPOSITORY_V1_SCHEMA: EntityDocumentJsonSchema<RepositoryS
     },
     walFlush: walFlushSchema(),
   },
-  required: [
-    "schema",
-    "settingsId",
-    "defaultVertical",
-    "defaultPreset",
-    "defaultProfile",
-    "reviewIndependence",
-    "scaffolds",
-    "walFlush",
-  ],
+  required: ["schema", "settingsId", "defaultVertical", "defaultPreset", "defaultProfile", "scaffolds", "walFlush"],
   additionalProperties: false,
 };
 

--- a/packages/kernel/test/contracts/settings-event.test.ts
+++ b/packages/kernel/test/contracts/settings-event.test.ts
@@ -3,9 +3,13 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { sha256Text } from "../../src/integrity/stable-hash.ts";
 import { compileSettingsChangedEvent, validateSettingsEvent } from "../../src/domain/settings-event.ts";
+import { requireEntityKindContract } from "../../src/domain/entity-kind-registry.ts";
+import { interpretEntityValue } from "../../src/domain/entity-kind-projection.ts";
 import {
   SETTINGS_FIELD_OWNERSHIP,
+  SETTINGS_REPOSITORY_V1_SCHEMA,
   SETTINGS_V1_SCHEMA,
+  validateRepositorySettings,
   readSettingsFacet,
   repositorySettings,
   writeRepositorySettingsFacet,
@@ -43,6 +47,27 @@ test("every Settings business field declares repository or local ownership", () 
       SETTINGS_FIELD_OWNERSHIP[field as keyof typeof SETTINGS_FIELD_OWNERSHIP],
       field,
     );
+});
+
+test("a repository Settings declaration recorded before reviewIndependence existed still projects", () => {
+  // Positive control: the exact shape `settings-initialize` wrote on 2026-08-31, before the field was added.
+  // Projection rebuilds (schema bumps) re-validate every stored declaration against the registry schema, so a
+  // field that has a read-side default must not be required here or every older repository latches on rebuild.
+  const legacy = {
+    schema: "settings/v1",
+    settingsId: "repository",
+    defaultVertical: "software/coding",
+    defaultPreset: "standard-task",
+    defaultProfile: "baseline",
+    scaffolds: { task: "governance/task-scaffold.json", repository: "governance/repository-scaffold.json" },
+    walFlush: { adaptive: true, events: 256, bytes: 8388608, milliseconds: 2000 },
+  };
+  assert.deepEqual(validateRepositorySettings(legacy), []);
+  assert.equal(SETTINGS_REPOSITORY_V1_SCHEMA.required.includes("reviewIndependence"), false);
+  assert.equal(SETTINGS_V1_SCHEMA.required.includes("reviewIndependence"), false);
+  const interpreted = interpretEntityValue(requireEntityKindContract("settings"), legacy);
+  assert.equal(interpreted.id, "repository");
+  assert.equal(repositorySettings(legacy as never).reviewIndependence, "execution");
 });
 
 test("Settings defaults review independence to the execution axis when omitted", () => {


### PR DESCRIPTION
# English

## Summary

After the canonical daemon was rebuilt onto main `9e4a7cea`, 11 of 15 attached repositories (canonical included) latched unavailable with data-shape `settings declaration is missing required field "reviewIndependence"`. Root cause: #2296 bumped the projection schema (18→19), forcing a rebuild that re-validates every stored declaration against the registry schema; the repository Settings declaration written by `settings-initialize` on 2026-08-31 predates `reviewIndependence`, and while every read site already defaults it to `"execution"` (`settings-event.ts`, `settings.ts`), the JSON schema still listed it as required. This PR removes the field from the `required` lists so the schema says what the readers do. No stored data changes, no migration, no fallback layer.

## Architectural Justification

- Not applicable (2-line schema narrowing + a positive-control test).

## What Changed

- `packages/kernel/src/domain/settings.ts`: `reviewIndependence` removed from `required` in `SETTINGS_V1_SCHEMA` and `SETTINGS_REPOSITORY_V1_SCHEMA` (it stays typed, enumerated, and defaulted on read).
- `packages/kernel/test/contracts/settings-event.test.ts`: positive control with the exact 2026-08-31 declaration shape — validates, projects through `interpretEntityValue(requireEntityKindContract("settings"))`, and reads back `reviewIndependence === "execution"`.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates: none

## Verification

- `node --test packages/kernel/test/contracts/settings-event.test.ts packages/kernel/test/contracts/settings-action.test.ts packages/kernel/test/store/settings-projection.test.ts` → 14 passed (the new test fails on origin/main).
- `tsc -b packages/kernel packages/application packages/daemon` exit 0; eslint; derived-contracts, schema-closure, duplicate-definitions, line-density, file-complexity, kernel dead-exports pass. `check:local` not run.

## Review Evidence

- CEO ground truth: `ha daemon status --json` on the rebuilt daemon (pid 42570) shows 11 repos `unavailable` with `causeClass: data-shape` and that message; `git log a68e51e1..9e4a7cea -- settings*.ts` is empty (the schema did not change; the rebuild did).

## Residual Risk

- Same mechanism elsewhere: any other kind whose registry schema gained a required field after repositories were initialized would latch the same way on the next rebuild. The 11-repository rebuild surfaced only Settings, but a cell latches on its first error, so a follow-up task will validate every stored declaration of every kind against the current registry schemas offline (ledger writes are blocked until this PR lands, so the task is filed after merge).

Production-Delta: +1/-11

---

# 中文

## 摘要

canonical daemon 换代到 main `9e4a7cea` 后,15 个已挂仓里 11 个(含 canonical)立刻 data-shape latch:`settings declaration is missing required field "reviewIndependence"`。根因:#2296 把投影 schema 18→19,触发重建,重建逐条用 registry schema 校验存量实体声明;`settings-initialize` 在 2026-08-31 写下的仓级 Settings 声明早于 `reviewIndependence` 字段,而读侧(`settings-event.ts`、`settings.ts`)本来就默认 `"execution"`,JSON schema 却把它列为 required——同一个默认值在两处实现且互相矛盾。本 PR 把该字段从两处 `required` 去掉,让 schema 说读侧已经在做的事。不改存量数据、不迁移、不加兜底层。

## 架构辩护

- 不适用(两行 schema 收窄 + 一个阳性对照测试)。

## 变更内容

- `settings.ts`:两处 schema 的 `required` 去掉 `reviewIndependence`(类型、枚举、读侧默认不变)。
- `settings-event.test.ts`:用 2026-08-31 的原始声明形状做阳性对照——通过校验、经 `interpretEntityValue` 投影、读回 `"execution"`。

## 门收割

Deleted-Production-Paths: none
Deleted-Gates: none

## 验证

- settings 三个测试文件 14 passed(新测试在 origin/main 上红);tsc、eslint、derived-contracts、schema-closure、duplicate-definitions、line-density、file-complexity、kernel dead-exports 通过;未跑 `check:local`。

## 评审证据

- CEO 亲自取证:新 daemon(pid 42570)`ha daemon status --json` 11 仓 `unavailable` / `causeClass: data-shape`;`git log a68e51e1..9e4a7cea -- settings*.ts` 为空(schema 没变,是重建把存量暴露出来)。

## 残余风险

- 同机制别处:任何 kind 的 registry schema 在仓初始化之后新增 required 字段,下次重建都会同样炸。这轮 11 仓只报了 Settings,但 cell 在第一个错就 latch,所以合入后另立任务离线把所有 kind 的存量声明对当前 schema 全量校验一遍(台账在本 PR 合入前不可写,任务合入后立)。
