### PR TITLE
fix(kernel): projection replay tolerates declarations accepted under an older schema

### DIFF
--- a/packages/kernel/src/domain/entity-json-schema.ts
+++ b/packages/kernel/src/domain/entity-json-schema.ts
@@ -62,18 +62,29 @@ export class EntitySchemaContractError extends Error {
   }
 }
 
+export interface EntityJsonSchemaValidationOptions {
+  /** Replay of already-accepted declarations: fields the current schema no longer declares are tolerated. */
+  readonly allowUnknownFields?: boolean;
+}
+
 export function validateEntityJsonSchema(
   schema: EntityDocumentJsonSchema,
   value: unknown,
   label = "entity declaration",
+  options: EntityJsonSchemaValidationOptions = {},
 ): readonly string[] {
   const errors: string[] = [];
-  validateNode(schema, value, label, errors);
+  validateNode(schema, value, label, errors, options.allowUnknownFields === true);
   return errors;
 }
 
-export function parseEntityJsonSchema<T>(schema: EntityDocumentJsonSchema<T>, value: unknown, label?: string): T {
-  const errors = validateEntityJsonSchema(schema, value, label);
+export function parseEntityJsonSchema<T>(
+  schema: EntityDocumentJsonSchema<T>,
+  value: unknown,
+  label?: string,
+  options: EntityJsonSchemaValidationOptions = {},
+): T {
+  const errors = validateEntityJsonSchema(schema, value, label, options);
   if (errors.length) throw new EntitySchemaContractError(errors.join("; "));
   return value as T;
 }
@@ -95,15 +106,27 @@ export function explainEntityJsonSchema(schema: EntityDocumentJsonSchema): reado
   }));
 }
 
-function validateNode(schema: EntityJsonSchemaNode, value: unknown, path: string, errors: string[]): void {
+function validateNode(
+  schema: EntityJsonSchemaNode,
+  value: unknown,
+  path: string,
+  errors: string[],
+  allowUnknown = false,
+): void {
   if (value === null && schema["x-nullable"] === true) return;
   const errorStart = errors.length;
-  validateNodeValue(schema, value, path, errors);
+  validateNodeValue(schema, value, path, errors, allowUnknown);
   if (errors.length > errorStart && schema["x-error"] !== undefined)
     errors.splice(errorStart, errors.length - errorStart, `${path} ${schema["x-error"]}`);
 }
 
-function validateNodeValue(schema: EntityJsonSchemaNode, value: unknown, path: string, errors: string[]): void {
+function validateNodeValue(
+  schema: EntityJsonSchemaNode,
+  value: unknown,
+  path: string,
+  errors: string[],
+  allowUnknown = false,
+): void {
   if (Array.isArray(schema.type)) {
     const valid = schema.type.some((type) =>
       type === "null"
@@ -166,7 +189,7 @@ function validateNodeValue(schema: EntityJsonSchemaNode, value: unknown, path: s
     }
     if (schema.minItems !== undefined && value.length < schema.minItems)
       errors.push(`${path} must contain at least ${schema.minItems} item(s).`);
-    value.forEach((item, index) => validateNode(schema.items, item, `${path}[${index}]`, errors));
+    value.forEach((item, index) => validateNode(schema.items, item, `${path}[${index}]`, errors, allowUnknown));
     if (schema.uniqueItems && new Set(value.map(stableJson)).size !== value.length)
       errors.push(`${path} entries must be unique.`);
     const uniqueBy = schema["x-unique-by"];
@@ -184,13 +207,13 @@ function validateNodeValue(schema: EntityJsonSchemaNode, value: unknown, path: s
   for (const field of schema.required)
     if (!Object.hasOwn(value, field) || value[field] === undefined)
       errors.push(`${path} is missing required field ${JSON.stringify(field)}.`);
-  if (!schema.additionalProperties)
+  if (!schema.additionalProperties && !allowUnknown)
     for (const field of Object.keys(value))
       if (!Object.hasOwn(schema.properties, field))
         errors.push(`${path} field ${JSON.stringify(field)} is unknown; remove it.`);
   for (const [field, fieldSchema] of Object.entries(schema.properties))
     if (Object.hasOwn(value, field) && value[field] !== undefined)
-      validateNode(fieldSchema, value[field], `${path} field ${JSON.stringify(field)}`, errors);
+      validateNode(fieldSchema, value[field], `${path} field ${JSON.stringify(field)}`, errors, allowUnknown);
 }
 
 function stableJson(value: unknown): string {

--- a/packages/kernel/src/domain/entity-kind-projection.ts
+++ b/packages/kernel/src/domain/entity-kind-projection.ts
@@ -1,5 +1,5 @@
 import { deriveRelationId } from "./entity-relation.ts";
-import { parseEntityJsonSchema } from "./entity-json-schema.ts";
+import { parseEntityJsonSchema, type EntityJsonSchemaValidationOptions } from "./entity-json-schema.ts";
 import type { EntityKindContract } from "./entity-kind-registry.ts";
 
 export type EntityProjectionContract = Pick<
@@ -28,6 +28,9 @@ export interface InterpretedEntityRelation {
   readonly recordIndex: number;
 }
 
+/** Projection replay re-reads declarations the writer already accepted under the schema of their day. */
+const REPLAY_VALIDATION: EntityJsonSchemaValidationOptions = { allowUnknownFields: true };
+
 export interface InterpretedEntityProjection extends InterpretedEntityValue {
   readonly ownerId: string | null;
   readonly workspaceRevision: number;
@@ -46,8 +49,9 @@ export function interpretEntityValue(
   contract: Pick<EntityKindContract, "kind" | "schema" | "id">,
   value: unknown,
   label = `${contract.kind} declaration`,
+  options: EntityJsonSchemaValidationOptions = {},
 ): InterpretedEntityValue {
-  const parsed = parseEntityJsonSchema(contract.schema, value, label);
+  const parsed = parseEntityJsonSchema(contract.schema, value, label, options);
   if (!isEntityRecord(parsed)) throw new Error(`${label} must be an object`);
   const id = parsed[contract.id.field];
   if (typeof id !== "string") throw new Error(`${label} has no string identity`);
@@ -60,7 +64,12 @@ export function interpretEntityProjection(
   workspaceRevision: number,
   sourcePath: string,
 ): InterpretedEntityProjection | null {
-  return deriveEntityProjection(contract, interpretEntityValue(contract, value), workspaceRevision, sourcePath);
+  return deriveEntityProjection(
+    contract,
+    interpretEntityValue(contract, value, undefined, REPLAY_VALIDATION),
+    workspaceRevision,
+    sourcePath,
+  );
 }
 
 export function deriveEntityProjection(

--- a/packages/kernel/src/domain/relation-event.ts
+++ b/packages/kernel/src/domain/relation-event.ts
@@ -163,7 +163,9 @@ export function reduceRelationEntity(
     });
   }
   if (relation === null) throw new Error(`Relation ${id} has no facet payload`);
-  assertRelationEventRecord(relation, false, migrated?.kind === "relation" ? migrated.registry : undefined);
+  // The reducer replays facets the writer already accepted under the schema of their day (validateCurrentRelationEvent
+  // stays strict at accept time): fields since removed are ignored and targetObservedVersion may be absent.
+  assertRelationEventRecord(relation, true, migrated?.kind === "relation" ? migrated.registry : undefined);
   return Object.freeze({
     ...base,
     source: relation.source,

--- a/packages/kernel/src/domain/settings.ts
+++ b/packages/kernel/src/domain/settings.ts
@@ -161,16 +161,7 @@ export const SETTINGS_V1_SCHEMA: EntityDocumentJsonSchema<SettingsV1> = {
     },
     walFlush: walFlushSchema(),
   },
-  required: [
-    "schema",
-    "settingsId",
-    "defaultVertical",
-    "defaultPreset",
-    "defaultProfile",
-    "locale",
-    "scaffolds",
-    "walFlush",
-  ],
+  required: ["schema", "settingsId", "defaultVertical", "defaultPreset", "defaultProfile", "locale", "scaffolds"],
   additionalProperties: false,
 };
 
@@ -216,7 +207,7 @@ export const SETTINGS_REPOSITORY_V1_SCHEMA: EntityDocumentJsonSchema<RepositoryS
     },
     walFlush: walFlushSchema(),
   },
-  required: ["schema", "settingsId", "defaultVertical", "defaultPreset", "defaultProfile", "scaffolds", "walFlush"],
+  required: ["schema", "settingsId", "defaultVertical", "defaultPreset", "defaultProfile", "scaffolds"],
   additionalProperties: false,
 };
 

--- a/packages/kernel/src/projection/rebuildable-task-projection-event-application.ts
+++ b/packages/kernel/src/projection/rebuildable-task-projection-event-application.ts
@@ -31,7 +31,7 @@ import { isVerticalDeclarationEvent } from "../domain/vertical-declaration.ts";
 import { isPeopleEvent } from "../domain/people-event.ts";
 import { isCiRunObservationEvent } from "../domain/ci-run-observation-event.ts";
 import { parsePeopleRosterDocument } from "../domain/people-roster.ts";
-import { scheduleDefinition, validateScheduleDefinitionV1 } from "../domain/schedule.ts";
+import { validateScheduleDefinitionV1 } from "../domain/schedule.ts";
 import { sha256Text } from "../integrity/stable-hash.ts";
 import { refreshDecisionDocumentSearch } from "./decision-event-projection.ts";
 import { refreshTaskRelationProjection } from "./task-query-projection.ts";
@@ -160,7 +160,7 @@ export function applyEvent(
       throw new Error(`entity declaration blob ${claim.sha256} is not JSON`);
     }
     const contract = contractForDeclarationEvent(event),
-      entity = interpretEntityValue(contract, value),
+      entity = interpretEntityValue(contract, value, undefined, { allowUnknownFields: true }),
       contractErrors = contract.entityStore.validate?.(entity.value) ?? [];
     if (contractErrors.length) throw new Error(contractErrors.join("; "));
     if (entity.id !== event.payload.entityId)
@@ -221,11 +221,12 @@ export function applyEvent(
       } catch {
         throw new Error(`schedule definition blob ${claim.sha256} is not JSON`);
       }
-      if (
-        validateScheduleDefinitionV1(value).length > 0 ||
-        canonicalJson(value) !== canonicalJson(scheduleDefinition(event.payload.schedule))
-      )
-        throw new Error(`schedule definition blob ${claim.sha256} does not match the event definition facet`);
+      // Replay re-reads a declaration the writer already accepted under the schema of its day: hash and size
+      // prove integrity, and fields the current schema no longer declares are tolerated. Re-deriving the facet
+      // from the event and demanding byte equality was a second implementation of the same truth; it latched
+      // every repository whose history predates a schema change.
+      if (validateScheduleDefinitionV1(value, true).length > 0)
+        throw new Error(`schedule definition blob ${claim.sha256} is not a schedule definition`);
       const document: DocumentState = {
         path: claim.path as DocumentState["path"],
         blobSha256: claim.sha256,

--- a/packages/kernel/test/contracts/replay-tolerance.test.ts
+++ b/packages/kernel/test/contracts/replay-tolerance.test.ts
@@ -1,0 +1,119 @@
+// harness-test-tier: contract
+import assert from "node:assert/strict";
+import test from "node:test";
+import { deriveRelationId } from "../../src/domain/entity-relation.ts";
+import { parseEntityJsonSchema, validateEntityJsonSchema } from "../../src/domain/entity-json-schema.ts";
+import { interpretEntityProjection } from "../../src/domain/entity-kind-projection.ts";
+import { requireEntityKindContract } from "../../src/domain/entity-kind-registry.ts";
+import {
+  compileRelationCreatedEvent,
+  reduceRelationEntity,
+  validateCurrentRelationEvent,
+  validateRelationEvent,
+} from "../../src/domain/relation-event.ts";
+import { createScheduleV1, validateScheduleDefinitionV1, scheduleDefinition } from "../../src/domain/schedule.ts";
+import { validateRepositorySettings, repositorySettings } from "../../src/domain/settings.ts";
+
+// Projection replay re-reads declarations the writer already accepted under the schema of their day. Each case
+// below is a real stored shape that latched a repository on the 2026-09-05 rebuild (data-shape), paired with the
+// writer-side check that must stay strict so tolerance never leaks onto the accept path.
+
+const actor = { principal: { personId: "person-replay" }, executor: null } as const;
+
+test("replay: a 2026-08-31 Settings declaration (no reviewIndependence, no walFlush) still projects", () => {
+  const legacy = {
+    schema: "settings/v1",
+    settingsId: "repository",
+    defaultVertical: "software/coding",
+    defaultPreset: "standard-task",
+    defaultProfile: "baseline",
+    scaffolds: { task: "governance/task-scaffold.json", repository: "governance/repository-scaffold.json" },
+  };
+  assert.deepEqual(validateRepositorySettings(legacy), []);
+  const projected = interpretEntityProjection(requireEntityKindContract("settings"), legacy, 3, "events/x.json");
+  assert.equal(projected?.id, "repository");
+  const read = repositorySettings(legacy as never);
+  assert.equal(read.reviewIndependence, "execution");
+  assert.equal(read.walFlush.adaptive, true);
+});
+
+test("replay: a 2026-08-29 Schedule declaration whose target still carries cwd projects; the writer rejects it", () => {
+  const schedule = createScheduleV1({
+      scheduleId: "antientropy-sweep",
+      name: "反熵周期轻扫",
+      mode: "detect",
+      spec: {
+        trigger: { kind: "interval", everyMs: 43_200_000, anchorAt: "2026-08-29T02:34:18.719Z" },
+        target: { kind: "agent", agentId: "ae-discrimination", runtimeInstanceId: "test-codex-sol" },
+        mission: "周期反熵轻扫。",
+      },
+      actor,
+      occurredAt: "2026-08-29T02:34:18.719Z",
+    }),
+    legacyBlob = {
+      ...scheduleDefinition(schedule),
+      spec: { ...schedule.spec, target: { ...schedule.spec.target, cwd: ".worktrees/antientropy-0829b" } },
+    },
+    legacyRow = { ...schedule, spec: legacyBlob.spec },
+    contract = requireEntityKindContract("schedule");
+  // replay tolerates the removed field
+  assert.deepEqual(validateScheduleDefinitionV1(legacyBlob, true), []);
+  assert.equal(interpretEntityProjection(contract, legacyRow, 42_614, "events/c7/x.json")?.id, "antientropy-sweep");
+  // the writer does not
+  assert.match(validateScheduleDefinitionV1(legacyBlob).join("; "), /"cwd" is unknown/u);
+  assert.throws(() => parseEntityJsonSchema(contract.schema, legacyRow), /"cwd" is unknown/u);
+});
+
+test("replay: a relation_created facet with strength and no targetObservedVersion reduces; the writer rejects it", () => {
+  const identity = {
+      source: "relation/rel_1111111111111111",
+      target: "decision/dec_RELATION_TARGET",
+      type: "relates" as const,
+      direction: "directed" as const,
+    },
+    created = compileRelationCreatedEvent({
+      record: {
+        relation_id: deriveRelationId(identity),
+        ...identity,
+        origin: "declared",
+        state: "active",
+        rationale: "Replay tolerance contract.",
+        targetObservedVersion: 1,
+      },
+      actor,
+      source: "local",
+      opId: "relation-replay-legacy",
+      occurredAt: "2026-08-20T00:00:00.000Z",
+      workspaceRevision: 21,
+    }),
+    { targetObservedVersion: _dropped, ...facet } = created.payload.relation,
+    legacy = { ...created, payload: { ...created.payload, relation: { ...facet, strength: "weak" } } } as never;
+  assert.deepEqual(validateRelationEvent(legacy), []);
+  const entity = reduceRelationEntity(null, legacy);
+  assert.equal(entity.source, identity.source);
+  assert.ok(validateCurrentRelationEvent(legacy).length > 0);
+});
+
+test("replay: unknown fields are tolerated inside arrays too, and only when asked", () => {
+  const schema = {
+    $schema: "https://json-schema.org/draft/2020-12/schema",
+    $id: "ReplayArray/v1",
+    type: "object",
+    properties: {
+      items: {
+        type: "array",
+        items: {
+          type: "object",
+          properties: { id: { type: "string" } },
+          required: ["id"],
+          additionalProperties: false,
+        },
+      },
+    },
+    required: ["items"],
+    additionalProperties: false,
+  } as const;
+  const value = { items: [{ id: "a", legacy: true }] };
+  assert.equal(validateEntityJsonSchema(schema as never, value, "fixture", { allowUnknownFields: true }).length, 0);
+  assert.match(validateEntityJsonSchema(schema as never, value, "fixture").join("; "), /"legacy" is unknown/u);
+});

--- a/tools/offline-projection-rebuild.mjs
+++ b/tools/offline-projection-rebuild.mjs
@@ -1,0 +1,31 @@
+#!/usr/bin/env node
+// Rebuild a repository's task projection offline, from its ledger only, without any daemon.
+// Run it against a COPY of the repository before a daemon generation change: a rebuild that throws here
+// is exactly the data-shape latch the new daemon would raise on attach.
+//   node --experimental-strip-types tools/offline-projection-rebuild.mjs <repo-root> [repo-id]
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+const [, , repoRootArg, repoId = "canonical"] = process.argv;
+if (!repoRootArg) {
+  console.error("usage: node --experimental-strip-types tools/offline-projection-rebuild.mjs <repo-root> [repo-id]");
+  process.exit(2);
+}
+const repoRoot = path.resolve(repoRootArg),
+  kernelRoot = path.resolve(path.dirname(new URL(import.meta.url).pathname), ".."),
+  kernel = await import(pathToFileURL(path.join(kernelRoot, "packages/kernel/src/index.ts")).href),
+  eventStore = kernel.makeTaskEventReader({ repoId, rootDir: repoRoot }),
+  head = eventStore.readHead(),
+  projection = kernel.makeTaskProjection({ rootDir: repoRoot, eventStore });
+try {
+  const receipt = projection.rebuild();
+  console.log(
+    `offline-projection-rebuild: ok repo=${repoId} head=${head?.revision ?? 0} watermark=${receipt.watermark}`,
+  );
+} catch (error) {
+  console.error(`offline-projection-rebuild: FAILED repo=${repoId} head=${head?.revision ?? 0}`);
+  console.error(String(error instanceof Error ? error.message : error));
+  process.exitCode = 1;
+} finally {
+  projection.close();
+}


### PR DESCRIPTION
# English

## Summary

Second layer of the 2026-09-05 daemon-generation latch (first layer: #2299). With main `989bb83e` the daemon attached 11/15 repositories; canonical still latched `data-shape` on projection rebuild because a 2026-08-29 schedule declaration carries `spec.target.cwd`, a field the current schema no longer declares. Two more repositories latched the same way (settings without `walFlush`; relation facets that still carry `strength` and predate `targetObservedVersion`).

Invariant adopted (agreed by both CEO sessions, standing_policy decision to follow once the ledger is writable): **replay is never stricter than the writer that accepted the event.** Replay validates structure only — hash, size, JSON, required fields — and tolerates fields the current schema no longer knows; the schedule facet byte-equality re-derivation (a second implementation of the same truth) is deleted; `walFlush` follows `reviewIndependence` out of the Settings `required` list because every reader already defaults it. Writers stay strict: `validateCurrentRelationEvent`, `validateScheduleDefinitionV1` without the flag, and `parseEntityJsonSchema` without options still reject those shapes (negative controls). No stored data changes, no migration, no fallback branch.

## Architectural Justification

- Production churn is small (+88/-31); no new module. Removed: the schedule facet equality re-derivation in replay and two `required` entries whose defaults already lived in readers.

## What Changed

- `entity-json-schema.ts`: `EntityJsonSchemaValidationOptions.allowUnknownFields` threaded through `validateEntityJsonSchema` / `parseEntityJsonSchema` (objects and array items).
- `entity-kind-projection.ts`: projection replay (`interpretEntityProjection`) interprets declarations with `allowUnknownFields`; `interpretEntityValue` accepts options (writers keep the strict default).
- `rebuildable-task-projection-event-application.ts`: entity declaration replay uses the option; schedule blob replay validates with `allowUnknownFields` and no longer re-derives the facet for byte equality.
- `relation-event.ts`: the reducer accepts historical facets (`allowHistoricalFields`) — `validateCurrentRelationEvent` stays strict at accept time.
- `settings.ts`: `walFlush` removed from both `required` lists (readers default it, as with `reviewIndependence` in #2299).
- `tools/offline-projection-rebuild.mjs` (new): rebuild a repository's projection from a ledger copy without a daemon — run it before a daemon generation change instead of finding the latch in production.
- `packages/kernel/test/contracts/replay-tolerance.test.ts` (new, contract tier): three positive controls with the real stored shapes (Settings 2026-08-31, Schedule with `cwd`, relation with `strength`/no `targetObservedVersion`) plus writer-side negative controls and an array-items case.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates: none

## Verification

- Offline rebuild on ledger copies with this branch: canonical head 59504 → watermark 59504 OK; self-representation 132 OK; zeyu-ai-brain 353 OK. All three fail on origin/main (`schedule definition blob … does not match`, `settings declaration is missing required field "walFlush"`, `Relation facet fields are invalid`).
- `node --test` over replay-tolerance + settings/relation/entity/schedule contract tests + schedule/settings/task-owned-entity projection tests → 42 passed.
- `tsc -b kernel/application/daemon/cli` exit 0; kernel dead-exports, duplicate-definitions, line-density, file-complexity, derived-contracts, schema-closure pass; new test file is discovered by `discoverTestFiles`. `check:local` not run.

## Review Evidence

- CEO ground truth on the rebuilt daemon (pid 91910): `ha daemon status --json` canonical `unavailable` / `causeClass: data-shape` with the schedule message; the blob at `objects/sha256/6f/68c223…` fails only `spec.target.cwd is unknown` under `validateScheduleDefinitionV1`; the relation shapes were enumerated from the zeyu-ai-brain ledger (2 `relation_created` events with `strength`, without `targetObservedVersion`).
- Peer CEO session reviewed and agreed the invariant and the deletion of the facet equality check before this PR was opened.

## Residual Risk

- Replayed rows may carry fields the current model ignores (e.g. `cwd` on a schedule target); readers reduce with the current model, blobs stay byte-exact. This is the intended asymmetry.
- Ledger writes were blocked while this was built, so the task/fact/decision for the invariant are filed right after merge; the offline rebuild tool should become the mandatory pre-step of a daemon generation change (follow-up).

Production-Delta: +88/-31

---

# 中文

## 摘要

2026-09-05 daemon 换代 latch 的第二层(第一层 #2299)。main `989bb83e` 起来后 11/15 仓 attached,canonical 在投影重建时仍 `data-shape` latch:2026-08-29 的 schedule 声明 spec.target 带 `cwd`,当前 schema 已不认识。另两个仓同族(settings 缺 `walFlush`;relation facet 仍带 `strength`、早于 `targetObservedVersion`)。

采用的不变量(两个 CEO session 已一致,台账可写后立 standing_policy decision):**回放不得比当初接受该事件的 writer 更严。** 回放只做结构校验——hash、size、JSON、required 字段——并容忍当前 schema 不再声明的字段;删掉 schedule facet 的字节相等再派生(同一真相的第二份实现);`walFlush` 跟着 `reviewIndependence` 一起从 Settings required 里出来(读侧本来就默认)。写路保持严格:`validateCurrentRelationEvent`、不带开关的 `validateScheduleDefinitionV1`、不带 options 的 `parseEntityJsonSchema` 仍拒绝这些形状(阴性对照)。不改存量数据、不迁移、不加兜底分支。

## 架构辩护

- production 净变化小(+88/-31),无新模块。删除:回放期 schedule facet 相等再派生;两个 required 项(默认值早已在读侧)。

## 变更内容

- `entity-json-schema.ts`:`allowUnknownFields` 选项贯穿对象与数组项。
- `entity-kind-projection.ts`:回放解释用该选项;写路默认严格。
- `rebuildable-task-projection-event-application.ts`:实体声明与 schedule blob 回放用该选项;不再重派生 facet 比字节。
- `relation-event.ts`:reducer 接受历史 facet;`validateCurrentRelationEvent` 在 accept 时仍严格。
- `settings.ts`:两处 required 去掉 `walFlush`。
- `tools/offline-projection-rebuild.mjs`(新):不起 daemon、从台账副本重建投影——换代前先跑它,不拿生产撞。
- `replay-tolerance.test.ts`(新,contract):三组真实存量形状阳性对照 + 写路阴性对照 + 数组项用例。

## 门收割

Deleted-Production-Paths: none
Deleted-Gates: none

## 验证

- 台账副本离线重建:canonical 59504 / self-representation 132 / zeyu-ai-brain 353 全部 OK;origin/main 上三者分别以上述三种错误失败。
- 相关 contract + projection 测试 42 passed;tsc、六个门通过;新测试文件被 `discoverTestFiles` 发现;未跑 `check:local`。

## 评审证据

- CEO 亲自取证(新 daemon pid 91910 的 `ha daemon status --json`、blob 用 `validateScheduleDefinitionV1` 单独判定只败在 `cwd`、zeyu-ai-brain 台账枚举出 2 条带 `strength` 的 relation_created);对面 CEO session 开 PR 前已对不变量与删相等断言表示同意。

## 残余风险

- 回放出的行可能带当前模型忽略的字段(如 schedule target 的 `cwd`),读侧按当前模型 reduce、blob 保持原字节,这是预期的不对称。
- 台账在本 PR 期间不可写,task/fact/decision 合入后补;离线重建工具应成为 daemon 换代的强制前置步骤(后续)。
