### PR TITLE
feat(kernel,daemon): W1-min stage 1 — generation-1 SQLite ledger store with shadow sink

### DIFF
--- a/packages/cli/src/cli/thin-command-router.ts
+++ b/packages/cli/src/cli/thin-command-router.ts
@@ -72,17 +72,7 @@ export function parseRouted(
         })
       : rejected(f.code, f.nextAction, json);
   }
-  if (route.id === "ledger-migrate") {
-    const f = readFlags(route.id, args.slice(2), inputs);
-    if (!f.ok) return rejected(f.code, f.nextAction, json);
-    const generation = f.one.get("--generation");
-    if (generation !== undefined && generation !== "1")
-      return rejected("invalid_field", "--generation currently requires 1.", json);
-    return accepted(rootDir, repoId, json, {
-      kind: "ledger-migrate",
-      ...(generation ? { generation: Number(generation) } : {}),
-    });
-  }
+  if (route.id === "ledger-migrate") return parseLedgerMigrateRouted(route, args, rootDir, repoId, json, inputs);
   if (route.id === "explain") return parseExplain(args, rootDir, repoId, json, route.method);
   if (rootCommand === "runtime" && route.path[1] === "instance")
     return parseRuntimeInstance(route, args, rootDir, repoId, json, inputs);
@@ -117,6 +107,25 @@ export function parseRouted(
   if (route.phase.startsWith("Preset-") || rootCommand === "agent" || rootCommand === "squad")
     return parsePreset(route, args, rootDir, repoId, json, inputs);
   return undefined;
+}
+
+function parseLedgerMigrateRouted(
+  route: ProtocolCommand,
+  args: readonly string[],
+  rootDir: SafePath,
+  repoId: string | undefined,
+  json: boolean,
+  inputs: ThinCliInputDirectory,
+): ThinParseResult {
+  const f = readFlags(route.id, args.slice(2), inputs);
+  if (!f.ok) return rejected(f.code, f.nextAction, json);
+  const generation = f.one.get("--generation");
+  if (generation !== undefined && generation !== "1")
+    return rejected("invalid_field", "--generation currently requires 1.", json);
+  return accepted(rootDir, repoId, json, {
+    kind: "ledger-migrate",
+    ...(generation ? { generation: Number(generation) } : {}),
+  });
 }
 
 function parseVerticalKindRouted(

--- a/packages/cli/src/cli/thin-command-router.ts
+++ b/packages/cli/src/cli/thin-command-router.ts
@@ -72,10 +72,17 @@ export function parseRouted(
         })
       : rejected(f.code, f.nextAction, json);
   }
-  if (route.id === "ledger-migrate")
-    return args.length === 2
-      ? accepted(rootDir, repoId, json, { kind: "ledger-migrate" })
-      : rejected("unknown_field", "ha ledger migrate takes no options.", json);
+  if (route.id === "ledger-migrate") {
+    const f = readFlags(route.id, args.slice(2), inputs);
+    if (!f.ok) return rejected(f.code, f.nextAction, json);
+    const generation = f.one.get("--generation");
+    if (generation !== undefined && generation !== "1")
+      return rejected("invalid_field", "--generation currently requires 1.", json);
+    return accepted(rootDir, repoId, json, {
+      kind: "ledger-migrate",
+      ...(generation ? { generation: Number(generation) } : {}),
+    });
+  }
   if (route.id === "explain") return parseExplain(args, rootDir, repoId, json, route.method);
   if (rootCommand === "runtime" && route.path[1] === "instance")
     return parseRuntimeInstance(route, args, rootDir, repoId, json, inputs);

--- a/packages/cli/test/thin-command-contract-parity.test.ts
+++ b/packages/cli/test/thin-command-contract-parity.test.ts
@@ -64,12 +64,17 @@ test("all public commands expose the canonical structured input facet", () => {
     "receipt-show",
     "doc-materialize",
     "preset-upgrade",
-    "ledger-migrate",
     "daemon-projection-rebuild",
     "daemon-start",
     "daemon-status",
   ])
     assert.deepEqual(daemonProtocolCommands.find((command) => command.id === id)?.inputs, [], id);
+  const ledgerMigrate = daemonProtocolCommands.find((command) => command.id === "ledger-migrate");
+  assert.deepEqual(
+    ledgerMigrate?.inputs.map((input) => [input.name, input.kind, input.required]),
+    [["--generation", "single", false]],
+    "ledger-migrate",
+  );
   // daemon-stop is the one daemon control with a flag: --force is the supported escalation when
   // a cooperative stop times out, and the usage line is derived from this declaration.
   const daemonStop = daemonProtocolCommands.find((command) => command.id === "daemon-stop");

--- a/packages/cli/test/thin-command-identity-migration.test.ts
+++ b/packages/cli/test/thin-command-identity-migration.test.ts
@@ -243,8 +243,7 @@ test("runtime instance auth commands parse into repo-scoped interactive sign-in 
       "sign-in-once",
     ]),
     logout = parseThinCommand(["runtime", "instance", "logout", "worker"]);
-  for (const parsed of [login, logout])
-    assert.equal(parsed.ok, true, JSON.stringify(parsed));
+  for (const parsed of [login, logout]) assert.equal(parsed.ok, true, JSON.stringify(parsed));
   if (login.ok)
     assert.deepEqual(
       {
@@ -271,30 +270,9 @@ test("runtime instance auth commands parse into repo-scoped interactive sign-in 
       },
     );
   assert.equal(parseThinCommand(["runtime", "instance", "login"]).ok, false);
-  assert.equal(
-    parseThinCommand([
-      "runtime",
-      "instance",
-      "login",
-      "worker",
-      "--prompt",
-      "x",
-    ]).ok,
-    false,
-  );
-  assert.equal(
-    parseThinCommand(["runtime", "instance", "reauth", "worker"]).ok,
-    false,
-  );
-  const shown = parseThinCommand([
-    "runtime",
-    "instance",
-    "show",
-    "worker",
-    "--repo",
-    "alpha",
-    "--probe",
-  ]);
+  assert.equal(parseThinCommand(["runtime", "instance", "login", "worker", "--prompt", "x"]).ok, false);
+  assert.equal(parseThinCommand(["runtime", "instance", "reauth", "worker"]).ok, false);
+  const shown = parseThinCommand(["runtime", "instance", "show", "worker", "--repo", "alpha", "--probe"]);
   assert.equal(shown.ok === true && shown.command.repoId, undefined);
   if (shown.ok) assert.equal(shown.command.action.probe, true);
 });
@@ -319,35 +297,26 @@ test("migration import parser accepts ordered sources and repeated explicit conf
     assert.deepEqual(parsed.command.action, {
       kind: "migrate-import",
       sourceRoots: ["../alice", "../bob"],
-      resolutions: [
-        "harness/people.yaml=source",
-        "harness/AGENTS.md=destination",
-      ],
+      resolutions: ["harness/people.yaml=source", "harness/AGENTS.md=destination"],
       dryRun: true,
     });
   assert.equal(parseThinCommand(["migrate", "import"]).ok, false);
   assert.equal(
-    parseThinCommand([
-      "migrate",
-      "import",
-      "--source",
-      "a",
-      "--resolve",
-      "harness/people.yaml=automatic",
-    ]).ok,
+    parseThinCommand(["migrate", "import", "--source", "a", "--resolve", "harness/people.yaml=automatic"]).ok,
     false,
   );
-  assert.equal(
-    parseThinCommand(["migrate", "import", "--source", "a", "--force"]).ok,
-    false,
-  );
+  assert.equal(parseThinCommand(["migrate", "import", "--source", "a", "--force"]).ok, false);
 });
 
-test("migrate ledger is one closed no-option command", () => {
+test("migrate ledger accepts only the declared SQLite generation option", () => {
   const parsed = parseThinCommand(["migrate", "ledger"]);
   assert.equal(parsed.ok, true);
-  if (parsed.ok)
-    assert.deepEqual(parsed.command.action, { kind: "ledger-migrate" });
+  if (parsed.ok) assert.deepEqual(parsed.command.action, { kind: "ledger-migrate" });
+
+  const generation = parseThinCommand(["migrate", "ledger", "--generation", "1"]);
+  assert.equal(generation.ok, true);
+  if (generation.ok) assert.deepEqual(generation.command.action, { kind: "ledger-migrate", generation: 1 });
+  assert.equal(parseThinCommand(["migrate", "ledger", "--generation", "2"]).ok, false);
   assert.equal(parseThinCommand(["migrate", "ledger", "--dry-run"]).ok, false);
 });
 

--- a/packages/daemon/src/protocol/daemon-protocol-commands-agent.ts
+++ b/packages/daemon/src/protocol/daemon-protocol-commands-agent.ts
@@ -272,9 +272,9 @@ export const agentProtocolCommands = Object.freeze([
     id: "ledger-migrate",
     phase: "Migration-A",
     path: ["migrate", "ledger"],
-    summary: "Migrate the canonical ledger from flat/v1 to sharded-sha256-2/v1.",
+    summary: "Migrate the ledger layout or seed a declared SQLite generation.",
     method: "repo.task.run",
-    inputs: [],
+    inputs: [cliInput("--generation", "single", false, { code: "missing_field" })],
   }),
   defineRepoReadCommand({
     id: "explain",

--- a/packages/daemon/src/repo-cell-action-dispatch.ts
+++ b/packages/daemon/src/repo-cell-action-dispatch.ts
@@ -111,10 +111,14 @@ export async function executeAction(
         };
   }
   if (action.kind === "ledger-migrate") {
-    if (action.generation !== undefined) {
+    if (typeof action.generation === "number") {
       const fence = binding.writerEpochFence;
       if (!fence) throw cell.cellCodedError("invalid_command", "SQLite generation migration requires a writer fence.");
-      const sqlite = openSqliteEventStore({ repoId: cell.input.repoId, rootInput: cell.rootDir });
+      const sqlite = openSqliteEventStore({
+        repoId: cell.input.repoId,
+        rootInput: cell.rootDir,
+        generation: action.generation,
+      });
       try {
         const migration = migrateEventsToSqlite({
           store: sqlite,

--- a/packages/daemon/src/repo-cell-action-dispatch.ts
+++ b/packages/daemon/src/repo-cell-action-dispatch.ts
@@ -6,10 +6,7 @@ import {
   eventShapeMigrations,
   executionExecutorDeclarationCandidates,
   getExecutableEntityAction,
-  isLedgerLayoutMigrationEvent,
   lifecycleDocumentPaths,
-  migrateEventsToSqlite,
-  openSqliteEventStore,
   type WriteReceiptDraft as WriteReceipt,
 } from "../../kernel/src/index.ts";
 import { runPresetAction } from "../../preset/src/index.ts";
@@ -19,7 +16,11 @@ import { isDocAction, runArtifactAdd, runDocAction } from "./doc-sync-actions.ts
 import { runMigrationImport } from "./migration-import.ts";
 import { runFactRekey } from "./fact-rekey.ts";
 import { assertExecutionExecutorDeclarationEligible } from "./repo-cell-execution-selection.ts";
-import { runDispatchRecordMigrationAction, runEventShapeMigrationAction } from "./repo-cell-migration-actions.ts";
+import {
+  runDispatchRecordMigrationAction,
+  runEventShapeMigrationAction,
+  runLedgerMigrateAction,
+} from "./repo-cell-migration-actions.ts";
 import { runSquadEntityMigration } from "./squad-entity-migration.ts";
 import { type RepoCellBinding, type RepoTaskAction, type Snapshot } from "./repo-cell-types.ts";
 import { pullAndIngestCiObservations } from "./ci-observation-actions.ts";
@@ -110,76 +111,7 @@ export async function executeAction(
           proof,
         };
   }
-  if (action.kind === "ledger-migrate") {
-    if (typeof action.generation === "number") {
-      const fence = binding.writerEpochFence;
-      if (!fence) throw cell.cellCodedError("invalid_command", "SQLite generation migration requires a writer fence.");
-      const sqlite = openSqliteEventStore({
-        repoId: cell.input.repoId,
-        rootInput: cell.rootDir,
-        generation: action.generation,
-      });
-      try {
-        const migration = migrateEventsToSqlite({
-          store: sqlite,
-          repoId: cell.input.repoId,
-          events: cell.store.read().events,
-          holder: fence.holderId,
-          epoch: fence.epoch,
-        });
-        return cell.readResult(
-          cell.operationId(action, binding, cell.input.repoId, migration.revision),
-          migration,
-          migration.revision,
-          null,
-        );
-      } finally {
-        sqlite.close();
-      }
-    }
-    await cell.store.settlePendingMaterialization?.("layout migration");
-    const appended = cell.store.migrateLayout({
-      actor: binding.actor,
-      source: binding.source,
-      occurredAt: cell.now(),
-    });
-    if (!isLedgerLayoutMigrationEvent(appended.event))
-      throw cell.cellCodedError("invalid_store", "Ledger migration returned the wrong event type.");
-    cell.projection.catchUp?.();
-    const projected = cell.projection.list(),
-      visible = projected.watermark === appended.revision && projected.sourceRevision === appended.revision,
-      proof = {
-        committedRevision: appended.revision,
-        appliedCut: projected.watermark,
-        durable: true,
-        canonicalVisible: visible,
-        worktreeVisible: true,
-      },
-      receipt = {
-        opId: appended.event.opId,
-        revision: appended.revision,
-        evidence: JSON.stringify({
-          ...appended.event.payload,
-          commitSha: appended.commitSha?.sha ?? null,
-          projection: {
-            status: projected.status,
-            watermark: projected.watermark,
-            sourceRevision: projected.sourceRevision,
-          },
-        }),
-        visibility: "center" as const,
-        proof,
-        commitSha: appended.commitSha?.sha ?? null,
-        cut: appended.cut,
-        worktreeVisible: true,
-      };
-    return visible
-      ? ({ outcome: "applied", ...receipt } as WriteReceipt)
-      : ({
-          outcome: "pending",
-          ...receipt,
-        } as WriteReceipt);
-  }
+  if (action.kind === "ledger-migrate") return runLedgerMigrateAction(cell, action, binding);
   if (action.kind === "receipt-show") {
     const opId = String(action.opId ?? "");
     // A provably absent operation can be answered from the durable read model.

--- a/packages/daemon/src/repo-cell-action-dispatch.ts
+++ b/packages/daemon/src/repo-cell-action-dispatch.ts
@@ -8,6 +8,8 @@ import {
   getExecutableEntityAction,
   isLedgerLayoutMigrationEvent,
   lifecycleDocumentPaths,
+  migrateEventsToSqlite,
+  openSqliteEventStore,
   type WriteReceiptDraft as WriteReceipt,
 } from "../../kernel/src/index.ts";
 import { runPresetAction } from "../../preset/src/index.ts";
@@ -109,6 +111,28 @@ export async function executeAction(
         };
   }
   if (action.kind === "ledger-migrate") {
+    if (action.generation !== undefined) {
+      const fence = binding.writerEpochFence;
+      if (!fence) throw cell.cellCodedError("invalid_command", "SQLite generation migration requires a writer fence.");
+      const sqlite = openSqliteEventStore({ repoId: cell.input.repoId, rootInput: cell.rootDir });
+      try {
+        const migration = migrateEventsToSqlite({
+          store: sqlite,
+          repoId: cell.input.repoId,
+          events: cell.store.read().events,
+          holder: fence.holderId,
+          epoch: fence.epoch,
+        });
+        return cell.readResult(
+          cell.operationId(action, binding, cell.input.repoId, migration.revision),
+          migration,
+          migration.revision,
+          null,
+        );
+      } finally {
+        sqlite.close();
+      }
+    }
     await cell.store.settlePendingMaterialization?.("layout migration");
     const appended = cell.store.migrateLayout({
       actor: binding.actor,

--- a/packages/daemon/src/repo-cell-migration-actions.ts
+++ b/packages/daemon/src/repo-cell-migration-actions.ts
@@ -1,4 +1,11 @@
-import { runDispatchRecordMigration, runEventShapeMigration } from "../../kernel/src/index.ts";
+import {
+  isLedgerLayoutMigrationEvent,
+  migrateEventsToSqlite,
+  openSqliteEventStore,
+  runDispatchRecordMigration,
+  runEventShapeMigration,
+  type WriteReceiptDraft as WriteReceipt,
+} from "../../kernel/src/index.ts";
 import type { RepoCellOperationalContext } from "./repo-cell-action-context.ts";
 import type { RepoCellBinding, RepoTaskAction } from "./repo-cell-types.ts";
 
@@ -34,4 +41,83 @@ export function runDispatchRecordMigrationAction(
     now: cell.now,
     settleLease: (settlement) => cell.settleRuntimeExecutionLease(settlement, binding),
   });
+}
+
+function runSqliteGenerationMigrationAction(
+  cell: RepoCellOperationalContext,
+  action: RepoTaskAction,
+  binding: RepoCellBinding,
+  generation: number,
+) {
+  const fence = binding.writerEpochFence;
+  if (!fence) throw cell.cellCodedError("invalid_command", "SQLite generation migration requires a writer fence.");
+  const sqlite = openSqliteEventStore({ repoId: cell.input.repoId, rootInput: cell.rootDir, generation });
+  try {
+    const migration = migrateEventsToSqlite({
+      store: sqlite,
+      repoId: cell.input.repoId,
+      events: cell.store.read().events,
+      holder: fence.holderId,
+      epoch: fence.epoch,
+    });
+    return cell.readResult(
+      cell.operationId(action, binding, cell.input.repoId, migration.revision),
+      migration,
+      migration.revision,
+      null,
+    );
+  } finally {
+    sqlite.close();
+  }
+}
+
+export async function runLedgerMigrateAction(
+  cell: RepoCellOperationalContext,
+  action: RepoTaskAction,
+  binding: RepoCellBinding,
+) {
+  if (typeof action.generation === "number")
+    return runSqliteGenerationMigrationAction(cell, action, binding, action.generation);
+  await cell.store.settlePendingMaterialization?.("layout migration");
+  const appended = cell.store.migrateLayout({
+    actor: binding.actor,
+    source: binding.source,
+    occurredAt: cell.now(),
+  });
+  if (!isLedgerLayoutMigrationEvent(appended.event))
+    throw cell.cellCodedError("invalid_store", "Ledger migration returned the wrong event type.");
+  cell.projection.catchUp?.();
+  const projected = cell.projection.list(),
+    visible = projected.watermark === appended.revision && projected.sourceRevision === appended.revision,
+    proof = {
+      committedRevision: appended.revision,
+      appliedCut: projected.watermark,
+      durable: true,
+      canonicalVisible: visible,
+      worktreeVisible: true,
+    },
+    receipt = {
+      opId: appended.event.opId,
+      revision: appended.revision,
+      evidence: JSON.stringify({
+        ...appended.event.payload,
+        commitSha: appended.commitSha?.sha ?? null,
+        projection: {
+          status: projected.status,
+          watermark: projected.watermark,
+          sourceRevision: projected.sourceRevision,
+        },
+      }),
+      visibility: "center" as const,
+      proof,
+      commitSha: appended.commitSha?.sha ?? null,
+      cut: appended.cut,
+      worktreeVisible: true,
+    };
+  return visible
+    ? ({ outcome: "applied", ...receipt } as WriteReceipt)
+    : ({
+        outcome: "pending",
+        ...receipt,
+      } as WriteReceipt);
 }

--- a/packages/daemon/src/repo-cell.ts
+++ b/packages/daemon/src/repo-cell.ts
@@ -150,7 +150,7 @@ export async function initializeRepoCell(context: RepoCellCoreInput): Promise<Re
   configureLedgerMaintenance(context.rootDir);
   const sqliteShadow = openSqliteEventStore({ repoId: context.input.repoId, rootInput: context.rootDir });
   let store: ReturnType<typeof makeTaskEventStore>,
-    sqliteShadowUnseeded = false;
+    sqliteShadowGapWarned = false;
   store = makeTaskEventStore({
     repoId: context.input.repoId,
     rootDir: context.rootDir,
@@ -208,15 +208,17 @@ export async function initializeRepoCell(context: RepoCellCoreInput): Promise<Re
   });
   const appendWalStore = store.append,
     shadowAccepted = (bundle: Parameters<typeof appendWalStore>[0]): void => {
-      if (sqliteShadowUnseeded) return;
       const events = [...(bundle.preceding ?? []).map((preceding) => preceding.event), bundle.event],
         nextRevision = sqliteShadow.revision() + 1;
       if (nextRevision !== events[0]!.workspaceRevision) {
-        sqliteShadowUnseeded = true;
-        console.warn(
-          `[sqlite-shadow] append skipped: generation 1 is unseeded at revision ${nextRevision - 1}; ` +
-            `next WAL bundle begins at revision ${events[0]!.workspaceRevision}`,
-        );
+        // Not seeded (or behind): skip this bundle only. Seeding is the explicit
+        // `ha migrate ledger --generation 1`; the next write after it follows again.
+        if (!sqliteShadowGapWarned)
+          console.warn(
+            `[sqlite-shadow] append skipped: generation 1 is unseeded at revision ${nextRevision - 1}; ` +
+              `next WAL bundle begins at revision ${events[0]!.workspaceRevision}`,
+          );
+        sqliteShadowGapWarned = true;
         return;
       }
       const fence = context.activeWriterEpochFenceDescriptor;

--- a/packages/daemon/src/repo-cell.ts
+++ b/packages/daemon/src/repo-cell.ts
@@ -6,14 +6,18 @@ import {
   closeoutReadiness,
   configureLedgerMaintenance,
   consumeKnownError,
+  migrateEventsToSqlite,
   makeTaskEventStore,
   makeGitEventStore,
   makeTaskProjection,
+  openSqliteEventStore,
   localGitWorktreeSettlement,
   readSettingsFacet,
   resolveLedgerGitLayout,
   resolveHarnessLayout,
   runWalMaterializationRequest,
+  serializePersistedCanonicalEvent,
+  sha256Text,
   type ActorIdentity,
   type DaemonRepoMode,
   type DocSyncReceiptDetail,
@@ -145,7 +149,10 @@ export async function initializeRepoCell(context: RepoCellCoreInput): Promise<Re
   };
   const configPath = path.join(resolveHarnessLayout(context.rootDir).authoredRoot, "harness.yaml");
   configureLedgerMaintenance(context.rootDir);
-  const store = makeTaskEventStore({
+  const sqliteShadow = openSqliteEventStore({ repoId: context.input.repoId, rootInput: context.rootDir });
+  let store: ReturnType<typeof makeTaskEventStore>,
+    sqliteShadowBootstrapped = false;
+  store = makeTaskEventStore({
     repoId: context.input.repoId,
     rootDir: context.rootDir,
     authoredBranch: context.authoredBranch,
@@ -200,6 +207,55 @@ export async function initializeRepoCell(context: RepoCellCoreInput): Promise<Re
     rejectPreparedRecovery: context.mode === "remote-center",
     walFlushPolicy: () => readSettingsFacet(existsSync(configPath) ? readFileSync(configPath, "utf8") : "").walFlush,
   });
+  const appendWalStore = store.append,
+    shadowAccepted = (bundle: Parameters<typeof appendWalStore>[0], full: boolean): void => {
+      const fence = context.activeWriterEpochFenceDescriptor;
+      if (!fence) throw new Error("writer epoch fence is unavailable for SQLite shadow append");
+      const sqliteFence = { repoId: fence.repoId, holder: fence.holderId, epoch: fence.epoch };
+      if (!sqliteShadowBootstrapped || full) {
+        migrateEventsToSqlite({
+          store: sqliteShadow,
+          repoId: fence.repoId,
+          events: store.read().events,
+          holder: fence.holderId,
+          epoch: fence.epoch,
+        });
+        sqliteShadowBootstrapped = true;
+        return;
+      }
+      sqliteShadow.claimWriter(sqliteFence);
+      const eventJson = serializePersistedCanonicalEvent(bundle.event);
+      sqliteShadow.appendCommand({
+        fence: sqliteFence,
+        intent: {
+          opId: bundle.event.opId,
+          intentDigest: `sha256:${sha256Text(eventJson)}`,
+          summary: bundle.event.type,
+        },
+        events: [bundle.event],
+      });
+    };
+  const drainWalStore = store.drain;
+  store = {
+    ...store,
+    append: (bundle, additionalFiles) => {
+      const receipt = appendWalStore(bundle, additionalFiles);
+      try {
+        shadowAccepted(bundle, additionalFiles !== undefined || (bundle.preceding?.length ?? 0) > 0);
+      } catch (error) {
+        console.warn(`[sqlite-shadow] append failed: ${error instanceof Error ? error.message : String(error)}`);
+        consumeKnownError(error);
+      }
+      return receipt;
+    },
+    drain: async () => {
+      try {
+        await drainWalStore();
+      } finally {
+        sqliteShadow.close();
+      }
+    },
+  };
   try {
     context.input.onStoreOpened?.(store);
     context.input.onOpenProgress?.({

--- a/packages/daemon/src/repo-cell.ts
+++ b/packages/daemon/src/repo-cell.ts
@@ -6,7 +6,6 @@ import {
   closeoutReadiness,
   configureLedgerMaintenance,
   consumeKnownError,
-  migrateEventsToSqlite,
   makeTaskEventStore,
   makeGitEventStore,
   makeTaskProjection,
@@ -151,7 +150,7 @@ export async function initializeRepoCell(context: RepoCellCoreInput): Promise<Re
   configureLedgerMaintenance(context.rootDir);
   const sqliteShadow = openSqliteEventStore({ repoId: context.input.repoId, rootInput: context.rootDir });
   let store: ReturnType<typeof makeTaskEventStore>,
-    sqliteShadowBootstrapped = false;
+    sqliteShadowUnseeded = false;
   store = makeTaskEventStore({
     repoId: context.input.repoId,
     rootDir: context.rootDir,
@@ -208,25 +207,21 @@ export async function initializeRepoCell(context: RepoCellCoreInput): Promise<Re
     walFlushPolicy: () => readSettingsFacet(existsSync(configPath) ? readFileSync(configPath, "utf8") : "").walFlush,
   });
   const appendWalStore = store.append,
-    bootstrapSqliteShadow = (): void => {
-      const fence = context.activeWriterEpochFenceDescriptor;
-      if (!fence) throw new Error("writer epoch fence is unavailable for SQLite shadow bootstrap");
-      migrateEventsToSqlite({
-        store: sqliteShadow,
-        repoId: fence.repoId,
-        events: store.read().events,
-        holder: fence.holderId,
-        epoch: fence.epoch,
-        verifyExact: false,
-      });
-      sqliteShadowBootstrapped = true;
-    },
     shadowAccepted = (bundle: Parameters<typeof appendWalStore>[0]): void => {
+      if (sqliteShadowUnseeded) return;
+      const events = [...(bundle.preceding ?? []).map((preceding) => preceding.event), bundle.event],
+        nextRevision = sqliteShadow.revision() + 1;
+      if (nextRevision !== events[0]!.workspaceRevision) {
+        sqliteShadowUnseeded = true;
+        console.warn(
+          `[sqlite-shadow] append skipped: generation 1 is unseeded at revision ${nextRevision - 1}; ` +
+            `next WAL bundle begins at revision ${events[0]!.workspaceRevision}`,
+        );
+        return;
+      }
       const fence = context.activeWriterEpochFenceDescriptor;
       if (!fence) throw new Error("writer epoch fence is unavailable for SQLite shadow append");
-      if (!sqliteShadowBootstrapped) bootstrapSqliteShadow();
       const sqliteFence = { repoId: fence.repoId, holder: fence.holderId, epoch: fence.epoch },
-        events = [...(bundle.preceding ?? []).map((preceding) => preceding.event), bundle.event],
         eventBytes = events.map(serializePersistedCanonicalEvent);
       sqliteShadow.appendCommand({
         fence: sqliteFence,
@@ -268,12 +263,6 @@ export async function initializeRepoCell(context: RepoCellCoreInput): Promise<Re
       watermark: null,
     });
     let recovery = store.recover();
-    try {
-      bootstrapSqliteShadow();
-    } catch (error) {
-      console.warn(`[sqlite-shadow] bootstrap failed: ${error instanceof Error ? error.message : String(error)}`);
-      consumeKnownError(error);
-    }
     projection = makeTaskProjection({
       rootDir: context.rootDir,
       eventStore: store,

--- a/packages/daemon/src/repo-cell.ts
+++ b/packages/daemon/src/repo-cell.ts
@@ -208,31 +208,34 @@ export async function initializeRepoCell(context: RepoCellCoreInput): Promise<Re
     walFlushPolicy: () => readSettingsFacet(existsSync(configPath) ? readFileSync(configPath, "utf8") : "").walFlush,
   });
   const appendWalStore = store.append,
-    shadowAccepted = (bundle: Parameters<typeof appendWalStore>[0], full: boolean): void => {
+    bootstrapSqliteShadow = (): void => {
+      const fence = context.activeWriterEpochFenceDescriptor;
+      if (!fence) throw new Error("writer epoch fence is unavailable for SQLite shadow bootstrap");
+      migrateEventsToSqlite({
+        store: sqliteShadow,
+        repoId: fence.repoId,
+        events: store.read().events,
+        holder: fence.holderId,
+        epoch: fence.epoch,
+        verifyExact: false,
+      });
+      sqliteShadowBootstrapped = true;
+    },
+    shadowAccepted = (bundle: Parameters<typeof appendWalStore>[0]): void => {
       const fence = context.activeWriterEpochFenceDescriptor;
       if (!fence) throw new Error("writer epoch fence is unavailable for SQLite shadow append");
-      const sqliteFence = { repoId: fence.repoId, holder: fence.holderId, epoch: fence.epoch };
-      if (!sqliteShadowBootstrapped || full) {
-        migrateEventsToSqlite({
-          store: sqliteShadow,
-          repoId: fence.repoId,
-          events: store.read().events,
-          holder: fence.holderId,
-          epoch: fence.epoch,
-        });
-        sqliteShadowBootstrapped = true;
-        return;
-      }
-      sqliteShadow.claimWriter(sqliteFence);
-      const eventJson = serializePersistedCanonicalEvent(bundle.event);
+      if (!sqliteShadowBootstrapped) bootstrapSqliteShadow();
+      const sqliteFence = { repoId: fence.repoId, holder: fence.holderId, epoch: fence.epoch },
+        events = [...(bundle.preceding ?? []).map((preceding) => preceding.event), bundle.event],
+        eventBytes = events.map(serializePersistedCanonicalEvent);
       sqliteShadow.appendCommand({
         fence: sqliteFence,
         intent: {
           opId: bundle.event.opId,
-          intentDigest: `sha256:${sha256Text(eventJson)}`,
+          intentDigest: `sha256:${sha256Text(JSON.stringify(eventBytes))}`,
           summary: bundle.event.type,
         },
-        events: [bundle.event],
+        events,
       });
     };
   const drainWalStore = store.drain;
@@ -241,7 +244,7 @@ export async function initializeRepoCell(context: RepoCellCoreInput): Promise<Re
     append: (bundle, additionalFiles) => {
       const receipt = appendWalStore(bundle, additionalFiles);
       try {
-        shadowAccepted(bundle, additionalFiles !== undefined || (bundle.preceding?.length ?? 0) > 0);
+        shadowAccepted(bundle);
       } catch (error) {
         console.warn(`[sqlite-shadow] append failed: ${error instanceof Error ? error.message : String(error)}`);
         consumeKnownError(error);
@@ -265,6 +268,12 @@ export async function initializeRepoCell(context: RepoCellCoreInput): Promise<Re
       watermark: null,
     });
     let recovery = store.recover();
+    try {
+      bootstrapSqliteShadow();
+    } catch (error) {
+      console.warn(`[sqlite-shadow] bootstrap failed: ${error instanceof Error ? error.message : String(error)}`);
+      consumeKnownError(error);
+    }
     projection = makeTaskProjection({
       rootDir: context.rootDir,
       eventStore: store,

--- a/packages/daemon/test/sqlite-shadow.integration.test.ts
+++ b/packages/daemon/test/sqlite-shadow.integration.test.ts
@@ -1,0 +1,71 @@
+// harness-test-tier: integration
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { makeTaskEventStore, openSqliteEventStore } from "../../kernel/src/index.ts";
+import { bundle, eventAt, initRepo } from "../../kernel/test/store/task-event-store.fixtures.ts";
+import { canonicalRoot, workspaceId } from "../src/protocol/daemon-protocol.contract.ts";
+import { openPersistentWriterEpoch } from "../src/writer-epoch.ts";
+import { openBootstrappedRepoCell as openRepoCell } from "./repo-settings.fixture.ts";
+
+test("first RepoCell write does not import an unseeded 1k-event history into the SQLite shadow", async () => {
+  const parent = mkdtempSync(path.join(tmpdir(), "ha-sqlite-shadow-repo-cell-")),
+    rootDir = path.join(parent, "repo"),
+    repoId = workspaceId("sqlite-shadow-repo-cell"),
+    events = Array.from({ length: 1_000 }, (_, index) => eventAt(index + 1)),
+    terminal = bundle(events.at(-1)!);
+  let cell: Awaited<ReturnType<typeof openRepoCell>> | undefined,
+    seed: ReturnType<typeof makeTaskEventStore> | undefined;
+  mkdirSync(rootDir);
+  initRepo(rootDir);
+  try {
+    seed = makeTaskEventStore({ repoId, rootDir });
+    seed.append({ ...terminal, preceding: events.slice(0, -1).map(bundle) });
+    await seed.drain();
+    const stateRoot = path.join(parent, "writer-epoch"),
+      holderId = "sqlite-shadow-writer",
+      authority = openPersistentWriterEpoch({ stateRoot, holderId }),
+      lease = authority.acquire(repoId),
+      binding = {
+        actor: { principal: { personId: "sqlite-shadow-owner" }, executor: null },
+        source: "local" as const,
+        writerEpochFence: {
+          schema: "harness-writer-epoch-fence/v1" as const,
+          stateRoot,
+          repoId,
+          epoch: lease.epoch,
+          holderId,
+        },
+      };
+    authority.close();
+
+    cell = await openRepoCell({ repoId, rootDir: canonicalRoot(rootDir), ownerId: holderId });
+    const shadow = openSqliteEventStore({ repoId, rootInput: rootDir });
+    try {
+      assert.equal(shadow.revision(), 0);
+      const first = await cell.run(
+        { kind: "task-create", taskId: "task-after-history", title: "After history" },
+        binding,
+      );
+      assert.equal(first.outcome, "applied", JSON.stringify(first));
+      assert.equal(first.revision, 1_003, JSON.stringify(first));
+      assert.equal(first.cut?.revision, 1_003, JSON.stringify(first));
+      assert.equal(shadow.revision(), 0, "the first write must not import pre-existing history");
+
+      const second = await cell.run(
+        { kind: "task-create", taskId: "task-after-skip", title: "After skipped shadow" },
+        binding,
+      );
+      assert.equal(second.outcome, "applied", JSON.stringify(second));
+      assert.equal(shadow.revision(), 0, "an unseeded shadow stays disabled for later writes in the cell");
+    } finally {
+      shadow.close();
+    }
+  } finally {
+    await seed?.drain();
+    await cell?.close();
+    rmSync(parent, { recursive: true, force: true });
+  }
+});

--- a/packages/kernel/src/composition/index.ts
+++ b/packages/kernel/src/composition/index.ts
@@ -13,6 +13,7 @@ export {
 export type { WalRecoveryProgress } from "../store/wal-shadow-event-store.ts";
 export { ledgerGitPath, resolveLedgerGitLayout } from "../store/ledger-git-layout.ts";
 export { eventShapeMigrations, runEventShapeMigration } from "../store/event-shape-migration.ts";
+export { migrateEventsToSqlite, openSqliteEventStore } from "../store/sqlite-event-store.ts";
 export { runDispatchRecordMigration } from "../store/dispatch-record-migration.ts";
 export type { DispatchRecordLeaseSettlement } from "../store/dispatch-record-migration.ts";
 export { resolveRetirableDocument } from "../store/ledger-document.ts";

--- a/packages/kernel/src/index.ts
+++ b/packages/kernel/src/index.ts
@@ -1,5 +1,13 @@
 export { consumeKnownError } from "./error-consumption.ts";
-export * from "./store/sqlite-event-store.ts";
+export {
+  SQLITE_LEDGER_GENERATION,
+  migrateEventsToSqlite,
+  openSqliteEventStore,
+  sqliteLedgerPath,
+  type SqliteCommandIntent,
+  type SqliteCommandOutcome,
+  type SqliteEventStore,
+} from "./store/sqlite-event-store.ts";
 export * from "./domain/index.ts";
 export {
   compareRuntimeActivity,

--- a/packages/kernel/src/index.ts
+++ b/packages/kernel/src/index.ts
@@ -1,5 +1,4 @@
 export { consumeKnownError } from "./error-consumption.ts";
-export { migrateEventsToSqlite, openSqliteEventStore } from "./store/sqlite-event-store.ts";
 export * from "./domain/index.ts";
 export {
   compareRuntimeActivity,
@@ -297,6 +296,8 @@ export {
   makeTaskEventStore,
   makeTaskProjection,
   runEventShapeMigration,
+  migrateEventsToSqlite,
+  openSqliteEventStore,
   makeTaskProjectionReader,
   runWalMaterializationRequest,
 } from "./composition/index.ts";

--- a/packages/kernel/src/index.ts
+++ b/packages/kernel/src/index.ts
@@ -1,4 +1,5 @@
 export { consumeKnownError } from "./error-consumption.ts";
+export * from "./store/sqlite-event-store.ts";
 export * from "./domain/index.ts";
 export {
   compareRuntimeActivity,

--- a/packages/kernel/src/index.ts
+++ b/packages/kernel/src/index.ts
@@ -1,13 +1,5 @@
 export { consumeKnownError } from "./error-consumption.ts";
-export {
-  SQLITE_LEDGER_GENERATION,
-  migrateEventsToSqlite,
-  openSqliteEventStore,
-  sqliteLedgerPath,
-  type SqliteCommandIntent,
-  type SqliteCommandOutcome,
-  type SqliteEventStore,
-} from "./store/sqlite-event-store.ts";
+export { migrateEventsToSqlite, openSqliteEventStore } from "./store/sqlite-event-store.ts";
 export * from "./domain/index.ts";
 export {
   compareRuntimeActivity,

--- a/packages/kernel/src/store/index.ts
+++ b/packages/kernel/src/store/index.ts
@@ -1,5 +1,13 @@
 export * from "../integrity/stable-hash.ts";
 export * from "./entity-store.ts";
 export * from "./local-version-control-system.ts";
-export * from "./sqlite-event-store.ts";
+export {
+  SQLITE_LEDGER_GENERATION,
+  migrateEventsToSqlite,
+  openSqliteEventStore,
+  sqliteLedgerPath,
+  type SqliteCommandIntent,
+  type SqliteCommandOutcome,
+  type SqliteEventStore,
+} from "./sqlite-event-store.ts";
 export * from "./task-event-store.ts";

--- a/packages/kernel/src/store/index.ts
+++ b/packages/kernel/src/store/index.ts
@@ -1,4 +1,5 @@
 export * from "../integrity/stable-hash.ts";
 export * from "./entity-store.ts";
 export * from "./local-version-control-system.ts";
+export * from "./sqlite-event-store.ts";
 export * from "./task-event-store.ts";

--- a/packages/kernel/src/store/index.ts
+++ b/packages/kernel/src/store/index.ts
@@ -1,13 +1,5 @@
 export * from "../integrity/stable-hash.ts";
 export * from "./entity-store.ts";
 export * from "./local-version-control-system.ts";
-export {
-  SQLITE_LEDGER_GENERATION,
-  migrateEventsToSqlite,
-  openSqliteEventStore,
-  sqliteLedgerPath,
-  type SqliteCommandIntent,
-  type SqliteCommandOutcome,
-  type SqliteEventStore,
-} from "./sqlite-event-store.ts";
+export { migrateEventsToSqlite, openSqliteEventStore } from "./sqlite-event-store.ts";
 export * from "./task-event-store.ts";

--- a/packages/kernel/src/store/sqlite-event-store.ts
+++ b/packages/kernel/src/store/sqlite-event-store.ts
@@ -65,19 +65,25 @@ export function openSqliteEventStore(options: {
   const generation = options.generation ?? SQLITE_LEDGER_GENERATION,
     databasePath = options.databasePath ?? sqliteLedgerPath(options.rootInput ?? process.cwd(), generation);
   localRuntimeStateFileSystem.mkdirp(path.dirname(databasePath));
-  const db = new DatabaseSync(databasePath);
-  db.exec("PRAGMA journal_mode=WAL; PRAGMA synchronous=FULL; " + "PRAGMA foreign_keys=ON; PRAGMA busy_timeout=5000");
+  const db = /* @gate-identity check-bypass-write-boundary/bypass-write-128 */ new DatabaseSync(databasePath);
+  /* @gate-identity check-bypass-write-boundary/bypass-write-127 */ db.exec(
+    "PRAGMA journal_mode=WAL; PRAGMA synchronous=FULL; " + "PRAGMA foreign_keys=ON; PRAGMA busy_timeout=5000",
+  );
   createSchema(db, options.repoId, generation);
-  const sqliteVersion = String(db.prepare("SELECT sqlite_version() AS version").get()!.version);
+  const sqliteVersion = String(
+    /* @gate-identity check-bypass-write-boundary/bypass-write-126 */ db
+      .prepare("SELECT sqlite_version() AS version")
+      .get()!.version,
+  );
 
   const transaction = <A>(run: () => A): A => {
-    db.exec("BEGIN IMMEDIATE");
+    /* @gate-identity check-bypass-write-boundary/bypass-write-125 */ db.exec("BEGIN IMMEDIATE");
     try {
       const result = run();
-      db.exec("COMMIT");
+      /* @gate-identity check-bypass-write-boundary/bypass-write-124 */ db.exec("COMMIT");
       return result;
     } catch (error) {
-      db.exec("ROLLBACK");
+      /* @gate-identity check-bypass-write-boundary/bypass-write-123 */ db.exec("ROLLBACK");
       throw error;
     }
   };
@@ -92,7 +98,7 @@ export function openSqliteEventStore(options: {
         );
       if (current && fence.epoch === current.epoch && fence.holder !== current.holder)
         throw new TaskEventStoreError("revision_conflict", `writer epoch ${fence.epoch} belongs to another holder`);
-      db.prepare(
+      /* @gate-identity check-bypass-write-boundary/bypass-write-122 */ db.prepare(
         "INSERT INTO writer_lease(repo_id, holder, epoch) VALUES (?, ?, ?) " +
           "ON CONFLICT(repo_id) DO UPDATE SET holder=excluded.holder, epoch=excluded.epoch",
       ).run(fence.repoId, fence.holder, fence.epoch);
@@ -119,7 +125,7 @@ export function openSqliteEventStore(options: {
           "revision_conflict",
           `writer epoch ${input.fence.epoch} belongs to another holder`,
         );
-      db.prepare(
+      /* @gate-identity check-bypass-write-boundary/bypass-write-121 */ db.prepare(
         "INSERT INTO writer_lease(repo_id, holder, epoch) VALUES (?, ?, ?) " +
           "ON CONFLICT(repo_id) DO UPDATE SET holder=excluded.holder, epoch=excluded.epoch",
       ).run(input.fence.repoId, input.fence.holder, input.fence.epoch);
@@ -135,7 +141,7 @@ export function openSqliteEventStore(options: {
           );
         const eventJson = serializePersistedCanonicalEvent(event),
           digest = `sha256:${sha256Text(eventJson)}`;
-        db.prepare(
+        /* @gate-identity check-bypass-write-boundary/bypass-write-120 */ db.prepare(
           "INSERT INTO event(revision, op_id, event_json, digest, occurred_at) " + "VALUES (?, ?, ?, ?, ?)",
         ).run(revision, event.opId, eventJson, digest, event.occurredAt);
         applyDerivedGuards(db, event);
@@ -143,9 +149,12 @@ export function openSqliteEventStore(options: {
       const firstRevision = input.events.length ? head + 1 : null,
         lastRevision = input.events.length ? head + input.events.length : null,
         status = input.rejectionCode ? "rejected" : "accepted_durable";
-      if (lastRevision !== null) db.prepare("UPDATE ledger_meta SET revision=? WHERE singleton=1").run(lastRevision);
+      if (lastRevision !== null)
+        /* @gate-identity check-bypass-write-boundary/bypass-write-119 */ db.prepare(
+          "UPDATE ledger_meta SET revision=? WHERE singleton=1",
+        ).run(lastRevision);
       input.beforeOutcome?.();
-      db.prepare(
+      /* @gate-identity check-bypass-write-boundary/bypass-write-118 */ db.prepare(
         "INSERT INTO command_outcome(" +
           "op_id, status, first_revision, last_revision, intent_digest, " +
           "intent_summary, rejection_code" +
@@ -169,7 +178,7 @@ export function openSqliteEventStore(options: {
     outcome,
     revision: () => readRevision(db),
     events: () =>
-      db
+      /* @gate-identity check-bypass-write-boundary/bypass-write-117 */ db
         .prepare("SELECT event_json FROM event ORDER BY revision")
         .all()
         .map((row) => parseCanonicalEvent(String(row.event_json))),
@@ -218,7 +227,7 @@ export function migrateEventsToSqlite(input: {
 }
 
 function createSchema(db: DatabaseSync, repoId: string, generation: number): void {
-  db.exec(`
+  /* @gate-identity check-bypass-write-boundary/bypass-write-116 */ db.exec(`
     CREATE TABLE IF NOT EXISTS ledger_meta (
       singleton INTEGER PRIMARY KEY CHECK(singleton=1), repo_id TEXT NOT NULL UNIQUE,
       generation INTEGER NOT NULL, revision INTEGER NOT NULL CHECK(revision>=0)
@@ -251,10 +260,12 @@ function createSchema(db: DatabaseSync, repoId: string, generation: number): voi
       PRIMARY KEY(task_id, execution_id, acquired_revision)
     ) STRICT;
   `);
-  db.prepare(
+  /* @gate-identity check-bypass-write-boundary/bypass-write-115 */ db.prepare(
     "INSERT OR IGNORE INTO ledger_meta(singleton, repo_id, generation, revision) " + "VALUES (1, ?, ?, 0)",
   ).run(repoId, generation);
-  const meta = db.prepare("SELECT repo_id, generation FROM ledger_meta WHERE singleton=1").get()!;
+  const meta = /* @gate-identity check-bypass-write-boundary/bypass-write-114 */ db
+    .prepare("SELECT repo_id, generation FROM ledger_meta WHERE singleton=1")
+    .get()!;
   if (meta.repo_id !== repoId || Number(meta.generation) !== generation)
     throw new TaskEventStoreError(
       "repo_mismatch",
@@ -279,12 +290,14 @@ function assertFenceShape(fence: SqliteWriterFence, repoId: string): void {
 }
 
 function readWriter(db: DatabaseSync, repoId: string): { readonly holder: string; readonly epoch: number } | null {
-  const row = db.prepare("SELECT holder, epoch FROM writer_lease WHERE repo_id=?").get(repoId);
+  const row = /* @gate-identity check-bypass-write-boundary/bypass-write-113 */ db
+    .prepare("SELECT holder, epoch FROM writer_lease WHERE repo_id=?")
+    .get(repoId);
   return row ? { holder: String(row.holder), epoch: Number(row.epoch) } : null;
 }
 
 function readOutcome(db: DatabaseSync, opId: string): SqliteCommandOutcome | null {
-  const row = db
+  const row = /* @gate-identity check-bypass-write-boundary/bypass-write-112 */ db
     .prepare(
       "SELECT op_id, status, first_revision, last_revision, intent_digest, " +
         "intent_summary, rejection_code " +
@@ -304,5 +317,9 @@ function readOutcome(db: DatabaseSync, opId: string): SqliteCommandOutcome | nul
 }
 
 function readRevision(db: DatabaseSync): number {
-  return Number(db.prepare("SELECT revision FROM ledger_meta WHERE singleton=1").get()!.revision);
+  return Number(
+    /* @gate-identity check-bypass-write-boundary/bypass-write-111 */ db
+      .prepare("SELECT revision FROM ledger_meta WHERE singleton=1")
+      .get()!.revision,
+  );
 }

--- a/packages/kernel/src/store/sqlite-event-store.ts
+++ b/packages/kernel/src/store/sqlite-event-store.ts
@@ -1,0 +1,289 @@
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import {
+  parseCanonicalEvent,
+  serializePersistedCanonicalEvent,
+  type CanonicalEventV1,
+} from "../domain/doc-sync.contract.ts";
+import { sha256Text } from "../integrity/stable-hash.ts";
+import { resolveHarnessLayout, type HarnessLayoutInput } from "../layout/index.ts";
+import { localRuntimeStateFileSystem } from "../local/local-layout-file-system.ts";
+import { replayClaim, replayRelease, replayRenew } from "../projection/rebuildable-task-projection-runtime.ts";
+import { TaskEventStoreError } from "./task-event-store-types.ts";
+
+export const SQLITE_LEDGER_GENERATION = 1;
+
+export interface SqliteWriterFence {
+  readonly repoId: string;
+  readonly holder: string;
+  readonly epoch: number;
+}
+
+export interface SqliteCommandIntent {
+  readonly opId: string;
+  readonly intentDigest: `sha256:${string}`;
+  readonly summary: string;
+}
+
+export interface SqliteCommandOutcome {
+  readonly opId: string;
+  readonly status: "accepted_durable" | "rejected";
+  readonly firstRevision: number | null;
+  readonly lastRevision: number | null;
+  readonly intentDigest: `sha256:${string}`;
+  readonly summary: string;
+  readonly rejectionCode: string | null;
+}
+
+export interface SqliteEventStore {
+  readonly databasePath: string;
+  readonly sqliteVersion: string;
+  readonly claimWriter: (fence: SqliteWriterFence) => void;
+  readonly appendCommand: (input: {
+    readonly fence: SqliteWriterFence;
+    readonly intent: SqliteCommandIntent;
+    readonly events: readonly CanonicalEventV1[];
+    readonly rejectionCode?: string;
+    readonly beforeOutcome?: () => void;
+  }) => SqliteCommandOutcome;
+  readonly outcome: (opId: string) => SqliteCommandOutcome | null;
+  readonly events: () => readonly CanonicalEventV1[];
+  readonly close: () => void;
+}
+
+export function sqliteLedgerPath(input: HarnessLayoutInput): string {
+  return path.join(resolveHarnessLayout(input).localRoot, "ledger.sqlite");
+}
+
+export function openSqliteEventStore(options: {
+  readonly repoId: string;
+  readonly rootInput?: HarnessLayoutInput;
+  readonly databasePath?: string;
+  readonly generation?: number;
+}): SqliteEventStore {
+  const databasePath = options.databasePath ?? sqliteLedgerPath(options.rootInput ?? process.cwd());
+  localRuntimeStateFileSystem.mkdirp(path.dirname(databasePath));
+  const db = new DatabaseSync(databasePath);
+  db.exec("PRAGMA journal_mode=WAL; PRAGMA synchronous=FULL; PRAGMA foreign_keys=ON; PRAGMA busy_timeout=5000");
+  createSchema(db, options.repoId, options.generation ?? SQLITE_LEDGER_GENERATION);
+  const sqliteVersion = String(db.prepare("SELECT sqlite_version() AS version").get()!.version);
+
+  const transaction = <A>(run: () => A): A => {
+    db.exec("BEGIN IMMEDIATE");
+    try {
+      const result = run();
+      db.exec("COMMIT");
+      return result;
+    } catch (error) {
+      db.exec("ROLLBACK");
+      throw error;
+    }
+  };
+  const claimWriter = (fence: SqliteWriterFence): void =>
+    transaction(() => {
+      assertFenceShape(fence, options.repoId);
+      const current = readWriter(db, options.repoId);
+      if (current && fence.epoch < current.epoch)
+        throw new TaskEventStoreError(
+          "revision_conflict",
+          `writer epoch ${fence.epoch} is stale; current is ${current.epoch}`,
+        );
+      if (current && fence.epoch === current.epoch && fence.holder !== current.holder)
+        throw new TaskEventStoreError("revision_conflict", `writer epoch ${fence.epoch} belongs to another holder`);
+      db.prepare(
+        "INSERT INTO writer_lease(repo_id, holder, epoch) VALUES (?, ?, ?) " +
+          "ON CONFLICT(repo_id) DO UPDATE SET holder=excluded.holder, epoch=excluded.epoch",
+      ).run(fence.repoId, fence.holder, fence.epoch);
+    });
+
+  const outcome = (opId: string): SqliteCommandOutcome | null => readOutcome(db, opId);
+  const appendCommand: SqliteEventStore["appendCommand"] = (input) =>
+    transaction(() => {
+      assertFenceShape(input.fence, options.repoId);
+      const prior = readOutcome(db, input.intent.opId);
+      if (prior) {
+        if (prior.intentDigest !== input.intent.intentDigest)
+          throw new TaskEventStoreError(
+            "op_conflict",
+            `opId ${input.intent.opId} already names another command intent`,
+          );
+        return prior;
+      }
+      const writer = readWriter(db, options.repoId);
+      if (writer && input.fence.epoch < writer.epoch)
+        throw new TaskEventStoreError("revision_conflict", `writer epoch ${input.fence.epoch} is stale`);
+      if (writer && input.fence.epoch === writer.epoch && input.fence.holder !== writer.holder)
+        throw new TaskEventStoreError(
+          "revision_conflict",
+          `writer epoch ${input.fence.epoch} belongs to another holder`,
+        );
+      db.prepare(
+        "INSERT INTO writer_lease(repo_id, holder, epoch) VALUES (?, ?, ?) " +
+          "ON CONFLICT(repo_id) DO UPDATE SET holder=excluded.holder, epoch=excluded.epoch",
+      ).run(input.fence.repoId, input.fence.holder, input.fence.epoch);
+      if (input.rejectionCode && input.events.length)
+        throw new TaskEventStoreError("invalid_write_plan", "a rejected command cannot append events");
+      const head = Number(db.prepare("SELECT revision FROM ledger_meta WHERE singleton=1").get()!.revision);
+      for (const [offset, event] of input.events.entries()) {
+        const revision = head + offset + 1;
+        if (event.workspaceRevision !== revision)
+          throw new TaskEventStoreError(
+            "revision_conflict",
+            `workspace revision ${event.workspaceRevision} must equal allocated revision ${revision}`,
+          );
+        const eventJson = serializePersistedCanonicalEvent(event),
+          digest = `sha256:${sha256Text(eventJson)}`;
+        db.prepare("INSERT INTO event(revision, op_id, event_json, digest, occurred_at) VALUES (?, ?, ?, ?, ?)").run(
+          revision,
+          event.opId,
+          eventJson,
+          digest,
+          event.occurredAt,
+        );
+        applyDerivedGuards(db, event);
+      }
+      const firstRevision = input.events.length ? head + 1 : null,
+        lastRevision = input.events.length ? head + input.events.length : null,
+        status = input.rejectionCode ? "rejected" : "accepted_durable";
+      if (lastRevision !== null) db.prepare("UPDATE ledger_meta SET revision=? WHERE singleton=1").run(lastRevision);
+      input.beforeOutcome?.();
+      db.prepare(
+        "INSERT INTO command_outcome(" +
+          "op_id, status, first_revision, last_revision, intent_digest, intent_summary, rejection_code" +
+          ") VALUES (?, ?, ?, ?, ?, ?, ?)",
+      ).run(
+        input.intent.opId,
+        status,
+        firstRevision,
+        lastRevision,
+        input.intent.intentDigest,
+        input.intent.summary,
+        input.rejectionCode ?? null,
+      );
+      return readOutcome(db, input.intent.opId)!;
+    });
+  return {
+    databasePath,
+    sqliteVersion,
+    claimWriter,
+    appendCommand,
+    outcome,
+    events: () =>
+      db
+        .prepare("SELECT event_json FROM event ORDER BY revision")
+        .all()
+        .map((row) => parseCanonicalEvent(String(row.event_json))),
+    close: () => db.close(),
+  };
+}
+
+export function migrateEventsToSqlite(input: {
+  readonly store: SqliteEventStore;
+  readonly repoId: string;
+  readonly events: readonly CanonicalEventV1[];
+  readonly holder?: string;
+  readonly epoch?: number;
+}): { readonly migrated: number; readonly revision: number } {
+  const fence = { repoId: input.repoId, holder: input.holder ?? "generation-migrator", epoch: input.epoch ?? 1 };
+  input.store.claimWriter(fence);
+  let migrated = 0;
+  for (const event of input.events) {
+    const eventJson = serializePersistedCanonicalEvent(event),
+      intentDigest = `sha256:${sha256Text(eventJson)}` as const;
+    const before = input.store.outcome(event.opId);
+    input.store.appendCommand({
+      fence,
+      intent: { opId: event.opId, intentDigest, summary: event.type },
+      events: [event],
+    });
+    if (!before) migrated += 1;
+  }
+  const stored = input.store.events();
+  if (stored.length !== input.events.length || stored.at(-1)?.workspaceRevision !== stored.length)
+    throw new TaskEventStoreError("invalid_store", "SQLite migration count and maximum revision differ");
+  for (const [index, event] of input.events.entries())
+    if (serializePersistedCanonicalEvent(stored[index]!) !== serializePersistedCanonicalEvent(event))
+      throw new TaskEventStoreError("invalid_store", `SQLite migration digest differs at revision ${index + 1}`);
+  return { migrated, revision: stored.length };
+}
+
+function createSchema(db: DatabaseSync, repoId: string, generation: number): void {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS ledger_meta (
+      singleton INTEGER PRIMARY KEY CHECK(singleton=1), repo_id TEXT NOT NULL UNIQUE,
+      generation INTEGER NOT NULL, revision INTEGER NOT NULL CHECK(revision>=0)
+    ) STRICT;
+    CREATE TABLE IF NOT EXISTS event (
+      revision INTEGER PRIMARY KEY, op_id TEXT NOT NULL UNIQUE, event_json TEXT NOT NULL,
+      digest TEXT NOT NULL, occurred_at TEXT NOT NULL,
+      recorded_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
+    ) STRICT;
+    CREATE TABLE IF NOT EXISTS command_outcome (
+      op_id TEXT PRIMARY KEY, status TEXT NOT NULL CHECK(status IN ('accepted_durable','rejected')),
+      first_revision INTEGER, last_revision INTEGER, intent_digest TEXT NOT NULL,
+      intent_summary TEXT NOT NULL, rejection_code TEXT,
+      recorded_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+      CHECK((status='accepted_durable' AND rejection_code IS NULL) OR (status='rejected' AND rejection_code IS NOT NULL))
+    ) STRICT;
+    CREATE TABLE IF NOT EXISTS writer_lease (
+      repo_id TEXT PRIMARY KEY, holder TEXT NOT NULL, epoch INTEGER NOT NULL CHECK(epoch>0)
+    ) STRICT;
+    CREATE TABLE IF NOT EXISTS lease_cas (task_id TEXT PRIMARY KEY, lease_json TEXT NOT NULL) STRICT;
+    CREATE TABLE IF NOT EXISTS lease_interval (
+      task_id TEXT NOT NULL, execution_id TEXT NOT NULL, acquired_revision INTEGER NOT NULL,
+      released_revision INTEGER, holder_json TEXT NOT NULL, previous_holder_json TEXT,
+      lease_expires_at TEXT NOT NULL, reason TEXT NOT NULL,
+      PRIMARY KEY(task_id, execution_id, acquired_revision)
+    ) STRICT;
+  `);
+  db.prepare("INSERT OR IGNORE INTO ledger_meta(singleton, repo_id, generation, revision) VALUES (1, ?, ?, 0)").run(
+    repoId,
+    generation,
+  );
+  const meta = db.prepare("SELECT repo_id, generation FROM ledger_meta WHERE singleton=1").get()!;
+  if (meta.repo_id !== repoId || Number(meta.generation) !== generation)
+    throw new TaskEventStoreError(
+      "repo_mismatch",
+      "SQLite ledger metadata belongs to another repository or generation",
+    );
+}
+
+function applyDerivedGuards(db: DatabaseSync, event: CanonicalEventV1): void {
+  if (event.schema !== "task-event/v1") return;
+  if (event.type === "execution_started") replayClaim(db, event);
+  if (event.type === "lease_renewed") replayRenew(db, event);
+  if (
+    (event.type === "execution_submitted" && event.payload.supersedesSubmissionId === undefined) ||
+    event.type === "lease_released"
+  )
+    replayRelease(db, event.taskId, event.payload.execution.executionId, event.workspaceRevision);
+}
+
+function assertFenceShape(fence: SqliteWriterFence, repoId: string): void {
+  if (fence.repoId !== repoId || !fence.holder || !Number.isSafeInteger(fence.epoch) || fence.epoch < 1)
+    throw new TaskEventStoreError("invalid_write_plan", "SQLite writer fence is invalid");
+}
+
+function readWriter(db: DatabaseSync, repoId: string): { readonly holder: string; readonly epoch: number } | null {
+  const row = db.prepare("SELECT holder, epoch FROM writer_lease WHERE repo_id=?").get(repoId);
+  return row ? { holder: String(row.holder), epoch: Number(row.epoch) } : null;
+}
+
+function readOutcome(db: DatabaseSync, opId: string): SqliteCommandOutcome | null {
+  const row = db
+    .prepare(
+      "SELECT op_id, status, first_revision, last_revision, intent_digest, intent_summary, rejection_code " +
+        "FROM command_outcome WHERE op_id=?",
+    )
+    .get(opId);
+  if (!row) return null;
+  return {
+    opId: String(row.op_id),
+    status: row.status as SqliteCommandOutcome["status"],
+    firstRevision: row.first_revision === null ? null : Number(row.first_revision),
+    lastRevision: row.last_revision === null ? null : Number(row.last_revision),
+    intentDigest: String(row.intent_digest) as `sha256:${string}`,
+    summary: String(row.intent_summary),
+    rejectionCode: row.rejection_code === null ? null : String(row.rejection_code),
+  };
+}

--- a/packages/kernel/src/store/sqlite-event-store.ts
+++ b/packages/kernel/src/store/sqlite-event-store.ts
@@ -47,12 +47,13 @@ export interface SqliteEventStore {
     readonly beforeOutcome?: () => void;
   }) => SqliteCommandOutcome;
   readonly outcome: (opId: string) => SqliteCommandOutcome | null;
+  readonly revision: () => number;
   readonly events: () => readonly CanonicalEventV1[];
   readonly close: () => void;
 }
 
-export function sqliteLedgerPath(input: HarnessLayoutInput): string {
-  return path.join(resolveHarnessLayout(input).localRoot, "ledger.sqlite");
+export function sqliteLedgerPath(input: HarnessLayoutInput, generation = SQLITE_LEDGER_GENERATION): string {
+  return path.join(resolveHarnessLayout(input).localRoot, "store", "generations", String(generation), "ledger.sqlite");
 }
 
 export function openSqliteEventStore(options: {
@@ -61,11 +62,12 @@ export function openSqliteEventStore(options: {
   readonly databasePath?: string;
   readonly generation?: number;
 }): SqliteEventStore {
-  const databasePath = options.databasePath ?? sqliteLedgerPath(options.rootInput ?? process.cwd());
+  const generation = options.generation ?? SQLITE_LEDGER_GENERATION,
+    databasePath = options.databasePath ?? sqliteLedgerPath(options.rootInput ?? process.cwd(), generation);
   localRuntimeStateFileSystem.mkdirp(path.dirname(databasePath));
   const db = new DatabaseSync(databasePath);
-  db.exec("PRAGMA journal_mode=WAL; PRAGMA synchronous=FULL; PRAGMA foreign_keys=ON; PRAGMA busy_timeout=5000");
-  createSchema(db, options.repoId, options.generation ?? SQLITE_LEDGER_GENERATION);
+  db.exec("PRAGMA journal_mode=WAL; PRAGMA synchronous=FULL; " + "PRAGMA foreign_keys=ON; PRAGMA busy_timeout=5000");
+  createSchema(db, options.repoId, generation);
   const sqliteVersion = String(db.prepare("SELECT sqlite_version() AS version").get()!.version);
 
   const transaction = <A>(run: () => A): A => {
@@ -123,23 +125,19 @@ export function openSqliteEventStore(options: {
       ).run(input.fence.repoId, input.fence.holder, input.fence.epoch);
       if (input.rejectionCode && input.events.length)
         throw new TaskEventStoreError("invalid_write_plan", "a rejected command cannot append events");
-      const head = Number(db.prepare("SELECT revision FROM ledger_meta WHERE singleton=1").get()!.revision);
+      const head = readRevision(db);
       for (const [offset, event] of input.events.entries()) {
         const revision = head + offset + 1;
         if (event.workspaceRevision !== revision)
           throw new TaskEventStoreError(
             "revision_conflict",
-            `workspace revision ${event.workspaceRevision} must equal allocated revision ${revision}`,
+            `workspace revision ${event.workspaceRevision} must equal ` + `allocated revision ${revision}`,
           );
         const eventJson = serializePersistedCanonicalEvent(event),
           digest = `sha256:${sha256Text(eventJson)}`;
-        db.prepare("INSERT INTO event(revision, op_id, event_json, digest, occurred_at) VALUES (?, ?, ?, ?, ?)").run(
-          revision,
-          event.opId,
-          eventJson,
-          digest,
-          event.occurredAt,
-        );
+        db.prepare(
+          "INSERT INTO event(revision, op_id, event_json, digest, occurred_at) " + "VALUES (?, ?, ?, ?, ?)",
+        ).run(revision, event.opId, eventJson, digest, event.occurredAt);
         applyDerivedGuards(db, event);
       }
       const firstRevision = input.events.length ? head + 1 : null,
@@ -149,7 +147,8 @@ export function openSqliteEventStore(options: {
       input.beforeOutcome?.();
       db.prepare(
         "INSERT INTO command_outcome(" +
-          "op_id, status, first_revision, last_revision, intent_digest, intent_summary, rejection_code" +
+          "op_id, status, first_revision, last_revision, intent_digest, " +
+          "intent_summary, rejection_code" +
           ") VALUES (?, ?, ?, ?, ?, ?, ?)",
       ).run(
         input.intent.opId,
@@ -168,6 +167,7 @@ export function openSqliteEventStore(options: {
     claimWriter,
     appendCommand,
     outcome,
+    revision: () => readRevision(db),
     events: () =>
       db
         .prepare("SELECT event_json FROM event ORDER BY revision")
@@ -183,28 +183,38 @@ export function migrateEventsToSqlite(input: {
   readonly events: readonly CanonicalEventV1[];
   readonly holder?: string;
   readonly epoch?: number;
+  readonly verifyExact?: boolean;
 }): { readonly migrated: number; readonly revision: number } {
-  const fence = { repoId: input.repoId, holder: input.holder ?? "generation-migrator", epoch: input.epoch ?? 1 };
+  const fence = {
+    repoId: input.repoId,
+    holder: input.holder ?? "generation-migrator",
+    epoch: input.epoch ?? 1,
+  };
   input.store.claimWriter(fence);
-  let migrated = 0;
-  for (const event of input.events) {
+  const existingRevision = input.store.revision();
+  if (existingRevision > input.events.length)
+    throw new TaskEventStoreError("invalid_store", "SQLite migration revision exceeds the source stream");
+  for (const event of input.events.slice(existingRevision)) {
     const eventJson = serializePersistedCanonicalEvent(event),
       intentDigest = `sha256:${sha256Text(eventJson)}` as const;
-    const before = input.store.outcome(event.opId);
     input.store.appendCommand({
       fence,
       intent: { opId: event.opId, intentDigest, summary: event.type },
       events: [event],
     });
-    if (!before) migrated += 1;
   }
+  const revision = input.store.revision();
+  if (input.verifyExact === false) return { migrated: revision - existingRevision, revision };
   const stored = input.store.events();
   if (stored.length !== input.events.length || stored.at(-1)?.workspaceRevision !== stored.length)
     throw new TaskEventStoreError("invalid_store", "SQLite migration count and maximum revision differ");
-  for (const [index, event] of input.events.entries())
-    if (serializePersistedCanonicalEvent(stored[index]!) !== serializePersistedCanonicalEvent(event))
+  for (const [index, event] of input.events.entries()) {
+    const storedBytes = serializePersistedCanonicalEvent(stored[index]!),
+      sourceBytes = serializePersistedCanonicalEvent(event);
+    if (storedBytes !== sourceBytes)
       throw new TaskEventStoreError("invalid_store", `SQLite migration digest differs at revision ${index + 1}`);
-  return { migrated, revision: stored.length };
+  }
+  return { migrated: revision - existingRevision, revision };
 }
 
 function createSchema(db: DatabaseSync, repoId: string, generation: number): void {
@@ -223,12 +233,17 @@ function createSchema(db: DatabaseSync, repoId: string, generation: number): voi
       first_revision INTEGER, last_revision INTEGER, intent_digest TEXT NOT NULL,
       intent_summary TEXT NOT NULL, rejection_code TEXT,
       recorded_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
-      CHECK((status='accepted_durable' AND rejection_code IS NULL) OR (status='rejected' AND rejection_code IS NOT NULL))
+      CHECK(
+        (status='accepted_durable' AND rejection_code IS NULL)
+        OR (status='rejected' AND rejection_code IS NOT NULL)
+      )
     ) STRICT;
     CREATE TABLE IF NOT EXISTS writer_lease (
       repo_id TEXT PRIMARY KEY, holder TEXT NOT NULL, epoch INTEGER NOT NULL CHECK(epoch>0)
     ) STRICT;
-    CREATE TABLE IF NOT EXISTS lease_cas (task_id TEXT PRIMARY KEY, lease_json TEXT NOT NULL) STRICT;
+    CREATE TABLE IF NOT EXISTS lease_cas (
+      task_id TEXT PRIMARY KEY, lease_json TEXT NOT NULL
+    ) STRICT;
     CREATE TABLE IF NOT EXISTS lease_interval (
       task_id TEXT NOT NULL, execution_id TEXT NOT NULL, acquired_revision INTEGER NOT NULL,
       released_revision INTEGER, holder_json TEXT NOT NULL, previous_holder_json TEXT,
@@ -236,10 +251,9 @@ function createSchema(db: DatabaseSync, repoId: string, generation: number): voi
       PRIMARY KEY(task_id, execution_id, acquired_revision)
     ) STRICT;
   `);
-  db.prepare("INSERT OR IGNORE INTO ledger_meta(singleton, repo_id, generation, revision) VALUES (1, ?, ?, 0)").run(
-    repoId,
-    generation,
-  );
+  db.prepare(
+    "INSERT OR IGNORE INTO ledger_meta(singleton, repo_id, generation, revision) " + "VALUES (1, ?, ?, 0)",
+  ).run(repoId, generation);
   const meta = db.prepare("SELECT repo_id, generation FROM ledger_meta WHERE singleton=1").get()!;
   if (meta.repo_id !== repoId || Number(meta.generation) !== generation)
     throw new TaskEventStoreError(
@@ -272,7 +286,8 @@ function readWriter(db: DatabaseSync, repoId: string): { readonly holder: string
 function readOutcome(db: DatabaseSync, opId: string): SqliteCommandOutcome | null {
   const row = db
     .prepare(
-      "SELECT op_id, status, first_revision, last_revision, intent_digest, intent_summary, rejection_code " +
+      "SELECT op_id, status, first_revision, last_revision, intent_digest, " +
+        "intent_summary, rejection_code " +
         "FROM command_outcome WHERE op_id=?",
     )
     .get(opId);
@@ -286,4 +301,8 @@ function readOutcome(db: DatabaseSync, opId: string): SqliteCommandOutcome | nul
     summary: String(row.intent_summary),
     rejectionCode: row.rejection_code === null ? null : String(row.rejection_code),
   };
+}
+
+function readRevision(db: DatabaseSync): number {
+  return Number(db.prepare("SELECT revision FROM ledger_meta WHERE singleton=1").get()!.revision);
 }

--- a/packages/kernel/test/store/sqlite-event-store-kill.fixture.mjs
+++ b/packages/kernel/test/store/sqlite-event-store-kill.fixture.mjs
@@ -1,0 +1,19 @@
+import { serializePersistedCanonicalEvent } from "../../src/domain/doc-sync.contract.ts";
+import { sha256Text } from "../../src/integrity/stable-hash.ts";
+import { openSqliteEventStore } from "../../src/store/sqlite-event-store.ts";
+import { eventAt } from "./task-event-store.fixtures.ts";
+
+const [databasePath, repoId] = process.argv.slice(2),
+  store = openSqliteEventStore({ databasePath, repoId }),
+  event = eventAt(1),
+  eventJson = serializePersistedCanonicalEvent(event);
+store.appendCommand({
+  fence: { repoId, holder: "replacement-writer", epoch: 2 },
+  intent: {
+    opId: event.opId,
+    intentDigest: `sha256:${sha256Text(eventJson)}`,
+    summary: event.type,
+  },
+  events: [event],
+  beforeOutcome: () => process.kill(process.pid, "SIGKILL"),
+});

--- a/packages/kernel/test/store/sqlite-event-store.integration.test.ts
+++ b/packages/kernel/test/store/sqlite-event-store.integration.test.ts
@@ -11,6 +11,7 @@ import { sha256Text } from "../../src/integrity/stable-hash.ts";
 import {
   migrateEventsToSqlite,
   openSqliteEventStore,
+  sqliteLedgerPath,
   type SqliteCommandIntent,
   type SqliteEventStore,
   type SqliteWriterFence,
@@ -85,6 +86,30 @@ test("event, writer takeover, ledger head, and outcome roll back atomically", ()
   }
 });
 
+test("one shadow bundle appends preceding events and its terminal event in one command", () => {
+  const store = openSqliteEventStore({ repoId, databasePath: scratch("bundle") }),
+    events = [eventAt(1), eventAt(2), eventAt(3)],
+    eventBytes = events.map(serializePersistedCanonicalEvent),
+    outcome = store.appendCommand({
+      fence,
+      intent: {
+        opId: events.at(-1)!.opId,
+        intentDigest: `sha256:${sha256Text(JSON.stringify(eventBytes))}`,
+        summary: events.at(-1)!.type,
+      },
+      events,
+    });
+  try {
+    assert.deepEqual(
+      { firstRevision: outcome.firstRevision, lastRevision: outcome.lastRevision },
+      { firstRevision: 1, lastRevision: 3 },
+    );
+    assert.deepEqual(store.events(), events);
+  } finally {
+    store.close();
+  }
+});
+
 test("SIGKILL recovery discards an uncommitted event and writer takeover", () => {
   const databasePath = scratch("sigkill"),
     store = openSqliteEventStore({ repoId, databasePath });
@@ -125,6 +150,62 @@ test("generation migration is byte-exact, idempotent, and reports a bounded thro
   }
 });
 
+test("generation paths coexist beneath the local store root", () => {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-sqlite-path-"));
+  assert.equal(sqliteLedgerPath(rootDir, 1), path.join(rootDir, ".harness/store/generations/1/ledger.sqlite"));
+  assert.equal(sqliteLedgerPath(rootDir, 2), path.join(rootDir, ".harness/store/generations/2/ledger.sqlite"));
+});
+
+test("50k bootstrap is incremental and subsequent shadow bundles stay millisecond-scale", (context) => {
+  const store = openSqliteEventStore({ repoId, databasePath: scratch("shadow-cost") }),
+    sourceEvents = Array.from({ length: 50_000 }, (_, index) => eventAt(index + 1)),
+    bootstrapStarted = performance.now();
+  try {
+    const bootstrapped = migrateEventsToSqlite({
+        store,
+        repoId,
+        events: sourceEvents,
+        holder: fence.holder,
+        epoch: fence.epoch,
+        verifyExact: false,
+      }),
+      bootstrapMs = performance.now() - bootstrapStarted,
+      incremental = migrateEventsToSqlite({
+        store,
+        repoId,
+        events: sourceEvents,
+        holder: fence.holder,
+        epoch: fence.epoch,
+        verifyExact: false,
+      }),
+      samplesMs: number[] = [];
+    assert.deepEqual(bootstrapped, { migrated: 50_000, revision: 50_000 });
+    assert.deepEqual(incremental, { migrated: 0, revision: 50_000 });
+    for (let revision = 50_001; revision <= 50_100; revision += 1) {
+      const event = eventAt(revision),
+        eventBytes = [serializePersistedCanonicalEvent(event)],
+        started = performance.now();
+      store.appendCommand({
+        fence,
+        intent: {
+          opId: event.opId,
+          intentDigest: `sha256:${sha256Text(JSON.stringify(eventBytes))}`,
+          summary: event.type,
+        },
+        events: [event],
+      });
+      samplesMs.push(performance.now() - started);
+    }
+    samplesMs.sort((left, right) => left - right);
+    const p50Ms = percentile(samplesMs, 0.5),
+      p99Ms = percentile(samplesMs, 0.99);
+    assert.ok(p99Ms < 100, `expected p99 shadow append below 100ms, received ${p99Ms}ms`);
+    context.diagnostic(JSON.stringify({ sourceEvents: sourceEvents.length, bootstrapMs, p50Ms, p99Ms }));
+  } finally {
+    store.close();
+  }
+});
+
 function command(_store: SqliteEventStore, revision: number, opId = eventAt(revision).opId) {
   const event = { ...eventAt(revision), opId };
   return { fence, intent: intentFor(event), events: [event] } as const;
@@ -144,4 +225,8 @@ function intentFor(event: ReturnType<typeof eventAt>): SqliteCommandIntent {
 
 function scratch(name: string): string {
   return path.join(mkdtempSync(path.join(tmpdir(), `ha-sqlite-${name}-`)), "ledger.sqlite");
+}
+
+function percentile(sorted: readonly number[], quantile: number): number {
+  return sorted[Math.ceil(sorted.length * quantile) - 1]!;
 }

--- a/packages/kernel/test/store/sqlite-event-store.integration.test.ts
+++ b/packages/kernel/test/store/sqlite-event-store.integration.test.ts
@@ -178,7 +178,8 @@ test("50k bootstrap is incremental and subsequent shadow bundles append one comm
         epoch: fence.epoch,
         verifyExact: false,
       }),
-      samplesMs: number[] = [];
+      samplesMs: number[] = [],
+      appended: ReturnType<typeof eventAt>[] = [];
     assert.deepEqual(bootstrapped, { migrated: 50_000, revision: 50_000 });
     assert.deepEqual(incremental, { migrated: 0, revision: 50_000 });
     for (let revision = 50_001; revision <= 50_100; revision += 1) {
@@ -195,6 +196,7 @@ test("50k bootstrap is incremental and subsequent shadow bundles append one comm
         events: [event],
       });
       samplesMs.push(performance.now() - started);
+      appended.push(event);
     }
     samplesMs.sort((left, right) => left - right);
     const p50Ms = percentile(samplesMs, 0.5),
@@ -202,7 +204,7 @@ test("50k bootstrap is incremental and subsequent shadow bundles append one comm
       afterAppends = migrateEventsToSqlite({
         store,
         repoId,
-        events: sourceEvents,
+        events: [...sourceEvents, ...appended],
         holder: fence.holder,
         epoch: fence.epoch,
         verifyExact: false,

--- a/packages/kernel/test/store/sqlite-event-store.integration.test.ts
+++ b/packages/kernel/test/store/sqlite-event-store.integration.test.ts
@@ -156,7 +156,7 @@ test("generation paths coexist beneath the local store root", () => {
   assert.equal(sqliteLedgerPath(rootDir, 2), path.join(rootDir, ".harness/store/generations/2/ledger.sqlite"));
 });
 
-test("50k bootstrap is incremental and subsequent shadow bundles stay millisecond-scale", (context) => {
+test("50k bootstrap is incremental and subsequent shadow bundles append one command each", (context) => {
   const store = openSqliteEventStore({ repoId, databasePath: scratch("shadow-cost") }),
     sourceEvents = Array.from({ length: 50_000 }, (_, index) => eventAt(index + 1)),
     bootstrapStarted = performance.now();
@@ -198,8 +198,19 @@ test("50k bootstrap is incremental and subsequent shadow bundles stay millisecon
     }
     samplesMs.sort((left, right) => left - right);
     const p50Ms = percentile(samplesMs, 0.5),
-      p99Ms = percentile(samplesMs, 0.99);
-    assert.ok(p99Ms < 100, `expected p99 shadow append below 100ms, received ${p99Ms}ms`);
+      p99Ms = percentile(samplesMs, 0.99),
+      afterAppends = migrateEventsToSqlite({
+        store,
+        repoId,
+        events: sourceEvents,
+        holder: fence.holder,
+        epoch: fence.epoch,
+        verifyExact: false,
+      });
+    // Each shadow bundle advances the store by exactly its own events and never re-imports the
+    // history; the timings are reported, not asserted (CI runners have no wall-clock budget).
+    assert.equal(store.revision(), 50_100);
+    assert.deepEqual(afterAppends, { migrated: 0, revision: 50_100 });
     context.diagnostic(JSON.stringify({ sourceEvents: sourceEvents.length, bootstrapMs, p50Ms, p99Ms }));
   } finally {
     store.close();

--- a/packages/kernel/test/store/sqlite-event-store.integration.test.ts
+++ b/packages/kernel/test/store/sqlite-event-store.integration.test.ts
@@ -1,0 +1,147 @@
+// harness-test-tier: integration
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { serializePersistedCanonicalEvent } from "../../src/domain/doc-sync.contract.ts";
+import { sha256Text } from "../../src/integrity/stable-hash.ts";
+import {
+  migrateEventsToSqlite,
+  openSqliteEventStore,
+  type SqliteCommandIntent,
+  type SqliteEventStore,
+  type SqliteWriterFence,
+} from "../../src/store/sqlite-event-store.ts";
+import { eventAt } from "./task-event-store.fixtures.ts";
+
+const repoId = "sqlite-generation-test";
+const fence: SqliteWriterFence = { repoId, holder: "writer-a", epoch: 1 };
+
+test("single writer serializes revision allocation and rejects a competing revision", () => {
+  const databasePath = scratch("concurrent"),
+    first = openSqliteEventStore({ repoId, databasePath }),
+    second = openSqliteEventStore({ repoId, databasePath });
+  try {
+    first.claimWriter(fence);
+    assert.equal(first.appendCommand(command(first, 1)).lastRevision, 1);
+    assert.throws(() => second.appendCommand(command(second, 1, "second-op")), /allocated revision 2/u);
+    assert.equal(second.appendCommand(command(second, 2, "second-op")).lastRevision, 2);
+    assert.deepEqual(
+      second.events().map((event) => event.workspaceRevision),
+      [1, 2],
+    );
+  } finally {
+    first.close();
+    second.close();
+  }
+});
+
+test("kill-reopen returns the durable command outcome for the same op_id", () => {
+  const databasePath = scratch("reopen");
+  let store = openSqliteEventStore({ repoId, databasePath });
+  store.claimWriter(fence);
+  const accepted = store.appendCommand(command(store, 1));
+  store.close();
+  store = openSqliteEventStore({ repoId, databasePath });
+  try {
+    assert.deepEqual(store.appendCommand(command(store, 1)), accepted);
+    assert.throws(
+      () =>
+        store.appendCommand({
+          ...command(store, 1),
+          intent: { ...intent(1), intentDigest: `sha256:${"f".repeat(64)}` },
+        }),
+      /another command intent/u,
+    );
+  } finally {
+    store.close();
+  }
+});
+
+test("event, writer takeover, ledger head, and outcome roll back atomically", () => {
+  const databasePath = scratch("rollback"),
+    store = openSqliteEventStore({ repoId, databasePath });
+  try {
+    store.claimWriter(fence);
+    assert.throws(
+      () =>
+        store.appendCommand({
+          ...command(store, 1),
+          fence: { repoId, holder: "writer-b", epoch: 2 },
+          beforeOutcome: () => {
+            throw new Error("transaction killpoint");
+          },
+        }),
+      /transaction killpoint/u,
+    );
+    assert.equal(store.events().length, 0);
+    assert.equal(store.outcome(eventAt(1).opId), null);
+    assert.equal(store.appendCommand(command(store, 1)).lastRevision, 1);
+  } finally {
+    store.close();
+  }
+});
+
+test("SIGKILL recovery discards an uncommitted event and writer takeover", () => {
+  const databasePath = scratch("sigkill"),
+    store = openSqliteEventStore({ repoId, databasePath });
+  store.claimWriter(fence);
+  store.close();
+  const fixture = fileURLToPath(new URL("./sqlite-event-store-kill.fixture.mjs", import.meta.url)),
+    killed = spawnSync(process.execPath, [fixture, databasePath, repoId], { encoding: "utf8" });
+  assert.equal(killed.signal, "SIGKILL", killed.stderr);
+  const reopened = openSqliteEventStore({ repoId, databasePath });
+  try {
+    assert.equal(reopened.events().length, 0);
+    assert.equal(reopened.appendCommand(command(reopened, 1)).lastRevision, 1);
+  } finally {
+    reopened.close();
+  }
+});
+
+test("generation migration is byte-exact, idempotent, and reports a bounded throughput sample", (context) => {
+  const databasePath = scratch("migration"),
+    store = openSqliteEventStore({ repoId, databasePath }),
+    events = Array.from({ length: 1_000 }, (_, index) => eventAt(index + 1)),
+    started = performance.now();
+  try {
+    const first = migrateEventsToSqlite({ store, repoId, events, holder: fence.holder, epoch: fence.epoch }),
+      elapsedMs = performance.now() - started,
+      second = migrateEventsToSqlite({ store, repoId, events, holder: fence.holder, epoch: fence.epoch });
+    assert.deepEqual(first, { migrated: 1_000, revision: 1_000 });
+    assert.deepEqual(second, { migrated: 0, revision: 1_000 });
+    context.diagnostic(
+      JSON.stringify({
+        events: events.length,
+        elapsedMs,
+        eventsPerSecond: Math.round(events.length / (elapsedMs / 1_000)),
+      }),
+    );
+  } finally {
+    store.close();
+  }
+});
+
+function command(_store: SqliteEventStore, revision: number, opId = eventAt(revision).opId) {
+  const event = { ...eventAt(revision), opId };
+  return { fence, intent: intentFor(event), events: [event] } as const;
+}
+
+function intent(revision: number): SqliteCommandIntent {
+  return intentFor(eventAt(revision));
+}
+
+function intentFor(event: ReturnType<typeof eventAt>): SqliteCommandIntent {
+  return {
+    opId: event.opId,
+    intentDigest: `sha256:${sha256Text(serializePersistedCanonicalEvent(event))}`,
+    summary: event.type,
+  };
+}
+
+function scratch(name: string): string {
+  return path.join(mkdtempSync(path.join(tmpdir(), `ha-sqlite-${name}-`)), "ledger.sqlite");
+}

--- a/tools/gate-allowlists/check-bypass-write-boundary.json
+++ b/tools/gate-allowlists/check-bypass-write-boundary.json
@@ -567,31 +567,31 @@
         "value": "bypass-write-111",
         "api": "sqlite.prepare",
         "ref": "dec_B1F5FF7648436C985F38F14226",
-        "reason": "SQLite ledger statement run inside the coordinated command transaction or its bootstrap."
+        "reason": "SQLite ledger statement run inside the coordinated command transaction, or the explicit `ha migrate ledger --generation 1` command."
       },
       {
         "value": "bypass-write-112",
         "api": "sqlite.prepare",
         "ref": "dec_B1F5FF7648436C985F38F14226",
-        "reason": "SQLite ledger statement run inside the coordinated command transaction or its bootstrap."
+        "reason": "SQLite ledger statement run inside the coordinated command transaction, or the explicit `ha migrate ledger --generation 1` command."
       },
       {
         "value": "bypass-write-113",
         "api": "sqlite.prepare",
         "ref": "dec_B1F5FF7648436C985F38F14226",
-        "reason": "SQLite ledger statement run inside the coordinated command transaction or its bootstrap."
+        "reason": "SQLite ledger statement run inside the coordinated command transaction, or the explicit `ha migrate ledger --generation 1` command."
       },
       {
         "value": "bypass-write-114",
         "api": "sqlite.prepare",
         "ref": "dec_B1F5FF7648436C985F38F14226",
-        "reason": "SQLite ledger statement run inside the coordinated command transaction or its bootstrap."
+        "reason": "SQLite ledger statement run inside the coordinated command transaction, or the explicit `ha migrate ledger --generation 1` command."
       },
       {
         "value": "bypass-write-115",
         "api": "sqlite.prepare",
         "ref": "dec_B1F5FF7648436C985F38F14226",
-        "reason": "SQLite ledger statement run inside the coordinated command transaction or its bootstrap."
+        "reason": "SQLite ledger statement run inside the coordinated command transaction, or the explicit `ha migrate ledger --generation 1` command."
       },
       {
         "value": "bypass-write-116",
@@ -603,37 +603,37 @@
         "value": "bypass-write-117",
         "api": "sqlite.prepare",
         "ref": "dec_B1F5FF7648436C985F38F14226",
-        "reason": "SQLite ledger statement run inside the coordinated command transaction or its bootstrap."
+        "reason": "SQLite ledger statement run inside the coordinated command transaction, or the explicit `ha migrate ledger --generation 1` command."
       },
       {
         "value": "bypass-write-118",
         "api": "sqlite.prepare",
         "ref": "dec_B1F5FF7648436C985F38F14226",
-        "reason": "SQLite ledger statement run inside the coordinated command transaction or its bootstrap."
+        "reason": "SQLite ledger statement run inside the coordinated command transaction, or the explicit `ha migrate ledger --generation 1` command."
       },
       {
         "value": "bypass-write-119",
         "api": "sqlite.prepare",
         "ref": "dec_B1F5FF7648436C985F38F14226",
-        "reason": "SQLite ledger statement run inside the coordinated command transaction or its bootstrap."
+        "reason": "SQLite ledger statement run inside the coordinated command transaction, or the explicit `ha migrate ledger --generation 1` command."
       },
       {
         "value": "bypass-write-120",
         "api": "sqlite.prepare",
         "ref": "dec_B1F5FF7648436C985F38F14226",
-        "reason": "SQLite ledger statement run inside the coordinated command transaction or its bootstrap."
+        "reason": "SQLite ledger statement run inside the coordinated command transaction, or the explicit `ha migrate ledger --generation 1` command."
       },
       {
         "value": "bypass-write-121",
         "api": "sqlite.prepare",
         "ref": "dec_B1F5FF7648436C985F38F14226",
-        "reason": "SQLite ledger statement run inside the coordinated command transaction or its bootstrap."
+        "reason": "SQLite ledger statement run inside the coordinated command transaction, or the explicit `ha migrate ledger --generation 1` command."
       },
       {
         "value": "bypass-write-122",
         "api": "sqlite.prepare",
         "ref": "dec_B1F5FF7648436C985F38F14226",
-        "reason": "SQLite ledger statement run inside the coordinated command transaction or its bootstrap."
+        "reason": "SQLite ledger statement run inside the coordinated command transaction, or the explicit `ha migrate ledger --generation 1` command."
       },
       {
         "value": "bypass-write-123",
@@ -657,7 +657,7 @@
         "value": "bypass-write-126",
         "api": "sqlite.prepare",
         "ref": "dec_B1F5FF7648436C985F38F14226",
-        "reason": "SQLite ledger statement run inside the coordinated command transaction or its bootstrap."
+        "reason": "SQLite ledger statement run inside the coordinated command transaction, or the explicit `ha migrate ledger --generation 1` command."
       },
       {
         "value": "bypass-write-127",

--- a/tools/gate-allowlists/check-bypass-write-boundary.json
+++ b/tools/gate-allowlists/check-bypass-write-boundary.json
@@ -3,101 +3,674 @@
   "gateId": "check-bypass-write-boundary",
   "entries": {
     "rebuildable-projection": [
-      { "value": "bypass-write-001", "api": "sqlite.prepare", "ref": "task_6e3a253ed79c2c458543c7d3d7", "reason": "Reads disposable scan state after a projection reduction batch." },
-      { "value": "bypass-write-002", "api": "sqlite.prepare", "ref": "task_6e3a253ed79c2c458543c7d3d7", "reason": "Reads disposable scan state before a projection catch-up batch." },
-      { "value": "bypass-write-003", "api": "sqlite.prepare", "ref": "task_6e3a253ed79c2c458543c7d3d7", "reason": "Checks for the next deferred canonical event in the disposable source table." },
-      { "value": "bypass-write-004", "api": "sqlite.prepare", "ref": "task_6e3a253ed79c2c458543c7d3d7", "reason": "Checks whether a canonical event was already applied to the disposable index." },
-      { "value": "bypass-write-005", "api": "sqlite.prepare", "ref": "task_6e3a253ed79c2c458543c7d3d7", "reason": "Checks the disposable event source for an opId or revision collision." },
-      { "value": "bypass-write-006", "api": "sqlite.prepare", "ref": "task_6e3a253ed79c2c458543c7d3d7", "reason": "Reads the next deferred canonical event for ordered projection reduction." },
-      { "value": "bypass-write-007", "api": "DatabaseSync", "ref": "task_01KZQ944F7RH6E0153Q3Q86Y63", "reason": "Disposable SQLite view rebuilt from the authoritative task event stream." },
-      { "value": "bypass-write-008", "api": "sqlite.exec", "ref": "task_01KZQ944F7RH6E0153Q3Q86Y63", "reason": "Configures journal and foreign-key behavior for the disposable SQLite view." },
-      { "value": "bypass-write-009", "api": "sqlite.exec", "ref": "task_01KZQ944F7RH6E0153Q3Q86Y63", "reason": "Creates only the disposable projection schema and derived tables." },
-      { "value": "bypass-write-010", "api": "sqlite.prepare", "ref": "task_1de89b0fd52d2c7a67617d1a2a", "reason": "Reads the disposable projection identity before deciding whether to rebuild it." },
-      { "value": "bypass-write-011", "api": "sqlite.prepare", "ref": "task_01KZRMKPA7XGF0NGBE961MCGET", "reason": "Reads the prior disposable document row while reducing a canonical doc event." },
-      { "value": "bypass-write-012", "api": "sqlite.prepare", "ref": "task_01KZRMM35JQWZP5SCMW8GD366E", "reason": "Reads the disposable task snapshot list for the GUI read surface." },
-      { "value": "bypass-write-013", "api": "sqlite.prepare", "ref": "task_01KZRMKPA7XGF0NGBE961MCGET", "reason": "Reads one disposable document projection row for document status." },
-      { "value": "bypass-write-014", "api": "sqlite.prepare", "ref": "task_01KZQ944F7RH6E0153Q3Q86Y63", "reason": "Reads one disposable preset snapshot row." },
-      { "value": "bypass-write-015", "api": "sqlite.prepare", "ref": "task_01KZXGJWVCKCA6B0MKB220PKFB", "reason": "Reads the projected package path for task delivery surfaces." },
-      { "value": "bypass-write-016", "api": "sqlite.prepare", "ref": "task_01KZRMKPA7XGF0NGBE961MCGET", "reason": "Resolves a disposable lease row by execution for writer authorization." },
-      { "value": "bypass-write-017", "api": "sqlite.prepare", "ref": "task_01KZQ944F7RH6E0153Q3Q86Y63", "reason": "Projects the reserving lease into the disposable CAS row." },
-      { "value": "bypass-write-018", "api": "sqlite.prepare", "ref": "task_01KZQ944F7RH6E0153Q3Q86Y63", "reason": "Activates the held lease in the disposable CAS row." },
-      { "value": "bypass-write-019", "api": "sqlite.prepare", "ref": "task_01KZQ944F7RH6E0153Q3Q86Y63", "reason": "Records a rebuildable lease interval." },
-      { "value": "bypass-write-020", "api": "sqlite.prepare", "ref": "task_01KZQ944F7RH6E0153Q3Q86Y63", "reason": "Projects a renewed lease into the disposable CAS row." },
-      { "value": "bypass-write-021", "api": "sqlite.prepare", "ref": "task_01KZQ944F7RH6E0153Q3Q86Y63", "reason": "Updates the rebuildable lease interval expiry." },
-      { "value": "bypass-write-022", "api": "sqlite.prepare", "ref": "task_01KZQ944F7RH6E0153Q3Q86Y63", "reason": "Releases a disposable lease CAS row." },
-      { "value": "bypass-write-023", "api": "sqlite.prepare", "ref": "task_01KZQ944F7RH6E0153Q3Q86Y63", "reason": "Closes the rebuildable lease interval." },
-      { "value": "bypass-write-024", "api": "sqlite.prepare", "ref": "task_01KZQ944F7RH6E0153Q3Q86Y63", "reason": "Reads the disposable task lifecycle snapshot." },
-      { "value": "bypass-write-025", "api": "sqlite.prepare", "ref": "task_01KZQ944F7RH6E0153Q3Q86Y63", "reason": "Reads rebuildable lease intervals." },
-      { "value": "bypass-write-026", "api": "sqlite.prepare", "ref": "task_01KZQ944F7RH6E0153Q3Q86Y63", "reason": "Checks active lease capacity in the disposable CAS view." },
-      { "value": "bypass-write-027", "api": "sqlite.prepare", "ref": "task_01KZQ944F7RH6E0153Q3Q86Y63", "reason": "Reserves a disposable lease CAS row." },
-      { "value": "bypass-write-028", "api": "sqlite.exec", "ref": "task_01KZQ944F7RH6E0153Q3Q86Y63", "reason": "Begins an atomic transaction against the disposable view." },
-      { "value": "bypass-write-029", "api": "sqlite.exec", "ref": "task_01KZQ944F7RH6E0153Q3Q86Y63", "reason": "Commits an atomic transaction against the disposable view." },
-      { "value": "bypass-write-030", "api": "sqlite.exec", "ref": "task_01KZQ944F7RH6E0153Q3Q86Y63", "reason": "Rolls back an atomic transaction against the disposable view." },
-      { "value": "bypass-write-031", "api": "sqlite.prepare", "ref": "task_01KZQ944F7RH6E0153Q3Q86Y63", "reason": "Reads the disposable projection watermark." },
-      { "value": "bypass-write-032", "api": "sqlite.prepare", "ref": "task_1de89b0fd52d2c7a67617d1a2a", "reason": "Reads the disposable projection state digest." },
-      { "value": "bypass-write-033", "api": "sqlite.prepare", "ref": "task_6e3a253ed79c2c458543c7d3d7", "reason": "Reads scan state when checking the authoritative source cut." },
-      { "value": "bypass-write-034", "api": "sqlite.prepare", "ref": "task_6e3a253ed79c2c458543c7d3d7", "reason": "Checks the deferred event source before the projection source cut so history regression can self-heal safely." },
-      { "value": "bypass-write-035", "api": "sqlite.prepare", "ref": "task_01KZQ944F7RH6E0153Q3Q86Y63", "reason": "Prepares a mutation against the disposable projection." },
-      { "value": "bypass-write-036", "api": "sqlite.prepare", "ref": "task_01KZQ944F7RH6E0153Q3Q86Y63", "reason": "Prepares a query against the disposable projection." },
-      { "value": "bypass-write-037", "api": "sqlite.prepare", "ref": "task_01KZQ944F7RH6E0153Q3Q86Y63", "reason": "Reads a disposable canonical operation row." },
-      { "value": "bypass-write-038", "api": "sqlite.prepare", "ref": "task_01KZRMKPA7XGF0NGBE961MCGET", "reason": "Reads a disposable canonical operation row before typed task dispatch." },
-      { "value": "bypass-write-039", "api": "sqlite.prepare", "ref": "task_01KZXGJWVCKCA6B0MKB220PKFB", "reason": "Resolves the projected package owner for document routing." },
-      { "value": "bypass-write-098", "api": "sqlite.prepare", "ref": "task_6d847ff57bf88357cfd7c64f8e", "reason": "Checks that a migration task-document owner snapshot exists without loading the whole task snapshot and relation graph." },
-      { "value": "bypass-write-104", "api": "sqlite.exec", "ref": "task_01KZQ944F7RH6E0153Q3Q86Y63", "reason": "Begins a read-only transaction over the disposable projection cache." },
-      { "value": "bypass-write-105", "api": "sqlite.exec", "ref": "task_01KZQ944F7RH6E0153Q3Q86Y63", "reason": "Commits the read-only transaction over the disposable projection cache." },
-      { "value": "bypass-write-106", "api": "sqlite.exec", "ref": "task_01KZQ944F7RH6E0153Q3Q86Y63", "reason": "Rolls back the read-only transaction over the disposable projection cache." },
-      { "value": "bypass-write-107", "api": "sqlite.exec", "ref": "task_01KZQ944F7RH6E0153Q3Q86Y63", "reason": "Begins a query transaction over the disposable projection cache." },
-      { "value": "bypass-write-108", "api": "sqlite.exec", "ref": "task_01KZQ944F7RH6E0153Q3Q86Y63", "reason": "Commits a query transaction over the disposable projection cache." },
-      { "value": "bypass-write-109", "api": "sqlite.exec", "ref": "task_01KZQ944F7RH6E0153Q3Q86Y63", "reason": "Rolls back a query transaction over the disposable projection cache." }
+      {
+        "value": "bypass-write-001",
+        "api": "sqlite.prepare",
+        "ref": "task_6e3a253ed79c2c458543c7d3d7",
+        "reason": "Reads disposable scan state after a projection reduction batch."
+      },
+      {
+        "value": "bypass-write-002",
+        "api": "sqlite.prepare",
+        "ref": "task_6e3a253ed79c2c458543c7d3d7",
+        "reason": "Reads disposable scan state before a projection catch-up batch."
+      },
+      {
+        "value": "bypass-write-003",
+        "api": "sqlite.prepare",
+        "ref": "task_6e3a253ed79c2c458543c7d3d7",
+        "reason": "Checks for the next deferred canonical event in the disposable source table."
+      },
+      {
+        "value": "bypass-write-004",
+        "api": "sqlite.prepare",
+        "ref": "task_6e3a253ed79c2c458543c7d3d7",
+        "reason": "Checks whether a canonical event was already applied to the disposable index."
+      },
+      {
+        "value": "bypass-write-005",
+        "api": "sqlite.prepare",
+        "ref": "task_6e3a253ed79c2c458543c7d3d7",
+        "reason": "Checks the disposable event source for an opId or revision collision."
+      },
+      {
+        "value": "bypass-write-006",
+        "api": "sqlite.prepare",
+        "ref": "task_6e3a253ed79c2c458543c7d3d7",
+        "reason": "Reads the next deferred canonical event for ordered projection reduction."
+      },
+      {
+        "value": "bypass-write-007",
+        "api": "DatabaseSync",
+        "ref": "task_01KZQ944F7RH6E0153Q3Q86Y63",
+        "reason": "Disposable SQLite view rebuilt from the authoritative task event stream."
+      },
+      {
+        "value": "bypass-write-008",
+        "api": "sqlite.exec",
+        "ref": "task_01KZQ944F7RH6E0153Q3Q86Y63",
+        "reason": "Configures journal and foreign-key behavior for the disposable SQLite view."
+      },
+      {
+        "value": "bypass-write-009",
+        "api": "sqlite.exec",
+        "ref": "task_01KZQ944F7RH6E0153Q3Q86Y63",
+        "reason": "Creates only the disposable projection schema and derived tables."
+      },
+      {
+        "value": "bypass-write-010",
+        "api": "sqlite.prepare",
+        "ref": "task_1de89b0fd52d2c7a67617d1a2a",
+        "reason": "Reads the disposable projection identity before deciding whether to rebuild it."
+      },
+      {
+        "value": "bypass-write-011",
+        "api": "sqlite.prepare",
+        "ref": "task_01KZRMKPA7XGF0NGBE961MCGET",
+        "reason": "Reads the prior disposable document row while reducing a canonical doc event."
+      },
+      {
+        "value": "bypass-write-012",
+        "api": "sqlite.prepare",
+        "ref": "task_01KZRMM35JQWZP5SCMW8GD366E",
+        "reason": "Reads the disposable task snapshot list for the GUI read surface."
+      },
+      {
+        "value": "bypass-write-013",
+        "api": "sqlite.prepare",
+        "ref": "task_01KZRMKPA7XGF0NGBE961MCGET",
+        "reason": "Reads one disposable document projection row for document status."
+      },
+      {
+        "value": "bypass-write-014",
+        "api": "sqlite.prepare",
+        "ref": "task_01KZQ944F7RH6E0153Q3Q86Y63",
+        "reason": "Reads one disposable preset snapshot row."
+      },
+      {
+        "value": "bypass-write-015",
+        "api": "sqlite.prepare",
+        "ref": "task_01KZXGJWVCKCA6B0MKB220PKFB",
+        "reason": "Reads the projected package path for task delivery surfaces."
+      },
+      {
+        "value": "bypass-write-016",
+        "api": "sqlite.prepare",
+        "ref": "task_01KZRMKPA7XGF0NGBE961MCGET",
+        "reason": "Resolves a disposable lease row by execution for writer authorization."
+      },
+      {
+        "value": "bypass-write-017",
+        "api": "sqlite.prepare",
+        "ref": "task_01KZQ944F7RH6E0153Q3Q86Y63",
+        "reason": "Projects the reserving lease into the disposable CAS row."
+      },
+      {
+        "value": "bypass-write-018",
+        "api": "sqlite.prepare",
+        "ref": "task_01KZQ944F7RH6E0153Q3Q86Y63",
+        "reason": "Activates the held lease in the disposable CAS row."
+      },
+      {
+        "value": "bypass-write-019",
+        "api": "sqlite.prepare",
+        "ref": "task_01KZQ944F7RH6E0153Q3Q86Y63",
+        "reason": "Records a rebuildable lease interval."
+      },
+      {
+        "value": "bypass-write-020",
+        "api": "sqlite.prepare",
+        "ref": "task_01KZQ944F7RH6E0153Q3Q86Y63",
+        "reason": "Projects a renewed lease into the disposable CAS row."
+      },
+      {
+        "value": "bypass-write-021",
+        "api": "sqlite.prepare",
+        "ref": "task_01KZQ944F7RH6E0153Q3Q86Y63",
+        "reason": "Updates the rebuildable lease interval expiry."
+      },
+      {
+        "value": "bypass-write-022",
+        "api": "sqlite.prepare",
+        "ref": "task_01KZQ944F7RH6E0153Q3Q86Y63",
+        "reason": "Releases a disposable lease CAS row."
+      },
+      {
+        "value": "bypass-write-023",
+        "api": "sqlite.prepare",
+        "ref": "task_01KZQ944F7RH6E0153Q3Q86Y63",
+        "reason": "Closes the rebuildable lease interval."
+      },
+      {
+        "value": "bypass-write-024",
+        "api": "sqlite.prepare",
+        "ref": "task_01KZQ944F7RH6E0153Q3Q86Y63",
+        "reason": "Reads the disposable task lifecycle snapshot."
+      },
+      {
+        "value": "bypass-write-025",
+        "api": "sqlite.prepare",
+        "ref": "task_01KZQ944F7RH6E0153Q3Q86Y63",
+        "reason": "Reads rebuildable lease intervals."
+      },
+      {
+        "value": "bypass-write-026",
+        "api": "sqlite.prepare",
+        "ref": "task_01KZQ944F7RH6E0153Q3Q86Y63",
+        "reason": "Checks active lease capacity in the disposable CAS view."
+      },
+      {
+        "value": "bypass-write-027",
+        "api": "sqlite.prepare",
+        "ref": "task_01KZQ944F7RH6E0153Q3Q86Y63",
+        "reason": "Reserves a disposable lease CAS row."
+      },
+      {
+        "value": "bypass-write-028",
+        "api": "sqlite.exec",
+        "ref": "task_01KZQ944F7RH6E0153Q3Q86Y63",
+        "reason": "Begins an atomic transaction against the disposable view."
+      },
+      {
+        "value": "bypass-write-029",
+        "api": "sqlite.exec",
+        "ref": "task_01KZQ944F7RH6E0153Q3Q86Y63",
+        "reason": "Commits an atomic transaction against the disposable view."
+      },
+      {
+        "value": "bypass-write-030",
+        "api": "sqlite.exec",
+        "ref": "task_01KZQ944F7RH6E0153Q3Q86Y63",
+        "reason": "Rolls back an atomic transaction against the disposable view."
+      },
+      {
+        "value": "bypass-write-031",
+        "api": "sqlite.prepare",
+        "ref": "task_01KZQ944F7RH6E0153Q3Q86Y63",
+        "reason": "Reads the disposable projection watermark."
+      },
+      {
+        "value": "bypass-write-032",
+        "api": "sqlite.prepare",
+        "ref": "task_1de89b0fd52d2c7a67617d1a2a",
+        "reason": "Reads the disposable projection state digest."
+      },
+      {
+        "value": "bypass-write-033",
+        "api": "sqlite.prepare",
+        "ref": "task_6e3a253ed79c2c458543c7d3d7",
+        "reason": "Reads scan state when checking the authoritative source cut."
+      },
+      {
+        "value": "bypass-write-034",
+        "api": "sqlite.prepare",
+        "ref": "task_6e3a253ed79c2c458543c7d3d7",
+        "reason": "Checks the deferred event source before the projection source cut so history regression can self-heal safely."
+      },
+      {
+        "value": "bypass-write-035",
+        "api": "sqlite.prepare",
+        "ref": "task_01KZQ944F7RH6E0153Q3Q86Y63",
+        "reason": "Prepares a mutation against the disposable projection."
+      },
+      {
+        "value": "bypass-write-036",
+        "api": "sqlite.prepare",
+        "ref": "task_01KZQ944F7RH6E0153Q3Q86Y63",
+        "reason": "Prepares a query against the disposable projection."
+      },
+      {
+        "value": "bypass-write-037",
+        "api": "sqlite.prepare",
+        "ref": "task_01KZQ944F7RH6E0153Q3Q86Y63",
+        "reason": "Reads a disposable canonical operation row."
+      },
+      {
+        "value": "bypass-write-038",
+        "api": "sqlite.prepare",
+        "ref": "task_01KZRMKPA7XGF0NGBE961MCGET",
+        "reason": "Reads a disposable canonical operation row before typed task dispatch."
+      },
+      {
+        "value": "bypass-write-039",
+        "api": "sqlite.prepare",
+        "ref": "task_01KZXGJWVCKCA6B0MKB220PKFB",
+        "reason": "Resolves the projected package owner for document routing."
+      },
+      {
+        "value": "bypass-write-098",
+        "api": "sqlite.prepare",
+        "ref": "task_6d847ff57bf88357cfd7c64f8e",
+        "reason": "Checks that a migration task-document owner snapshot exists without loading the whole task snapshot and relation graph."
+      },
+      {
+        "value": "bypass-write-104",
+        "api": "sqlite.exec",
+        "ref": "task_01KZQ944F7RH6E0153Q3Q86Y63",
+        "reason": "Begins a read-only transaction over the disposable projection cache."
+      },
+      {
+        "value": "bypass-write-105",
+        "api": "sqlite.exec",
+        "ref": "task_01KZQ944F7RH6E0153Q3Q86Y63",
+        "reason": "Commits the read-only transaction over the disposable projection cache."
+      },
+      {
+        "value": "bypass-write-106",
+        "api": "sqlite.exec",
+        "ref": "task_01KZQ944F7RH6E0153Q3Q86Y63",
+        "reason": "Rolls back the read-only transaction over the disposable projection cache."
+      },
+      {
+        "value": "bypass-write-107",
+        "api": "sqlite.exec",
+        "ref": "task_01KZQ944F7RH6E0153Q3Q86Y63",
+        "reason": "Begins a query transaction over the disposable projection cache."
+      },
+      {
+        "value": "bypass-write-108",
+        "api": "sqlite.exec",
+        "ref": "task_01KZQ944F7RH6E0153Q3Q86Y63",
+        "reason": "Commits a query transaction over the disposable projection cache."
+      },
+      {
+        "value": "bypass-write-109",
+        "api": "sqlite.exec",
+        "ref": "task_01KZQ944F7RH6E0153Q3Q86Y63",
+        "reason": "Rolls back a query transaction over the disposable projection cache."
+      }
     ],
     "coordinatedCore": [
-      { "value": "bypass-write-043", "api": "rmSync", "ref": "task_01KZRMKJT7YKQ2TNXA8WR1W5DN", "reason": "RepoCell-owned recovery removes only an abandoned prepared artifact." },
-      { "value": "bypass-write-053", "api": "openSync", "ref": "task_01KZRMKJT7YKQ2TNXA8WR1W5DN", "reason": "RepoCell-owned per-repository lock uses exclusive OS creation." },
-      { "value": "bypass-write-054", "api": "writeFileSync", "ref": "task_01KZRMKJT7YKQ2TNXA8WR1W5DN", "reason": "RepoCell-owned per-repository lock records its generation." },
-      { "value": "bypass-write-055", "api": "closeSync", "ref": "task_01KZRMKJT7YKQ2TNXA8WR1W5DN", "reason": "RepoCell-owned per-repository lock closes its descriptor." },
-      { "value": "bypass-write-056", "api": "mkdirSync", "ref": "task_01KZRMKJT7YKQ2TNXA8WR1W5DN", "reason": "RepoCell-owned writer creates only its exact event or pending directory." },
-      { "value": "bypass-write-057", "api": "renameSync", "ref": "task_01KZRMKJT7YKQ2TNXA8WR1W5DN", "reason": "RepoCell-owned writer atomically publishes exact event or head bytes." },
-      { "value": "bypass-write-058", "api": "rmSync", "ref": "task_01KZRMKJT7YKQ2TNXA8WR1W5DN", "reason": "RepoCell-owned writer removes only its pending or prepared recovery artifact." },
-      { "value": "bypass-write-059", "api": "writeFileSync", "ref": "task_01KZRMKJT7YKQ2TNXA8WR1W5DN", "reason": "RepoCell-owned writer updates only its exact local runtime state." },
-      { "value": "bypass-write-060", "api": "mkdirSync", "ref": "task_6e3a253ed79c2c458543c7d3d7", "reason": "Local-only WAL creates its exact private buffer directory." },
-      { "value": "bypass-write-061", "api": "rmSync", "ref": "dec_F906FA4E1BE047B6F591CF4316; task_32e553b6c0ff5f31a6d914e5cb", "reason": "S4 checkpoint GC removes only a local-only WAL object after the materialized Git cut no longer references it." },
-      { "value": "bypass-write-062", "api": "mkdirSync", "ref": "task_6e3a253ed79c2c458543c7d3d7", "reason": "Local-only WAL creates the parent of its exact append target." },
-      { "value": "bypass-write-063", "api": "openSync", "ref": "task_6e3a253ed79c2c458543c7d3d7", "reason": "Git-first local-only WAL opens its exact shadow append target." },
-      { "value": "bypass-write-064", "api": "writeSync", "ref": "task_6e3a253ed79c2c458543c7d3d7", "reason": "Local-only WAL appends canonical record bytes." },
-      { "value": "bypass-write-065", "api": "fsyncSync", "ref": "dec_F906FA4E1BE047B6F591CF4316; task_32e553b6c0ff5f31a6d914e5cb", "reason": "S4 acknowledgment hardens the exact appended WAL segment before the write receipt returns." },
-      { "value": "bypass-write-066", "api": "closeSync", "ref": "task_6e3a253ed79c2c458543c7d3d7", "reason": "Local-only WAL closes its append descriptor." },
-      { "value": "bypass-write-067", "api": "mkdirSync", "ref": "task_6e3a253ed79c2c458543c7d3d7", "reason": "Local-only WAL creates the parent of its replacement target." },
-      { "value": "bypass-write-068", "api": "openSync", "ref": "task_6e3a253ed79c2c458543c7d3d7", "reason": "Local-only WAL opens its exact temporary replacement." },
-      { "value": "bypass-write-069", "api": "writeSync", "ref": "task_6e3a253ed79c2c458543c7d3d7", "reason": "Local-only WAL writes canonical head or object bytes." },
-      { "value": "bypass-write-070", "api": "fsyncSync", "ref": "dec_F906FA4E1BE047B6F591CF4316; task_32e553b6c0ff5f31a6d914e5cb", "reason": "S4 acknowledgment hardens the exact replacement WAL head or object bytes before publication." },
-      { "value": "bypass-write-071", "api": "closeSync", "ref": "task_6e3a253ed79c2c458543c7d3d7", "reason": "Local-only WAL closes its temporary replacement." },
-      { "value": "bypass-write-072", "api": "renameSync", "ref": "task_6e3a253ed79c2c458543c7d3d7", "reason": "Local-only WAL atomically publishes head or object bytes." },
-      { "value": "bypass-write-073", "api": "openSync", "ref": "dec_F906FA4E1BE047B6F591CF4316; task_32e553b6c0ff5f31a6d914e5cb", "reason": "S4 WAL replacement opens only its containing directory to harden the atomic rename." },
-      { "value": "bypass-write-074", "api": "fsyncSync", "ref": "dec_F906FA4E1BE047B6F591CF4316; task_32e553b6c0ff5f31a6d914e5cb", "reason": "S4 acknowledgment hardens the WAL replacement directory after its atomic rename." },
-      { "value": "bypass-write-110", "api": "rmSync", "ref": "task_38bc061c5a6c7fb1946e9b5cc6; task_f821cb831f535a13d8cc857c3c", "reason": "Local-only WAL removes only its own pid-named temporary replacement when the write or rename throws." },
-      { "value": "bypass-write-075", "api": "closeSync", "ref": "dec_F906FA4E1BE047B6F591CF4316; task_32e553b6c0ff5f31a6d914e5cb", "reason": "S4 WAL replacement closes only the containing-directory durability descriptor." },
-      { "value": "bypass-write-076", "api": "mkdirSync", "ref": "task_01KZWZEW11C499EACS9M5HVJZ8", "reason": "RepoCell-owned settlement creates only an authored target directory." },
-      { "value": "bypass-write-077", "api": "symlinkSync", "ref": "dec_F906FA4E1BE047B6F591CF4316; task_32e553b6c0ff5f31a6d914e5cb", "reason": "S4 return-path visibility creates only an exact temporary authored symlink before atomic worktree publication." },
-      { "value": "bypass-write-078", "api": "symlinkSync", "ref": "dec_F906FA4E1BE047B6F591CF4316; task_32e553b6c0ff5f31a6d914e5cb", "reason": "S4 return-path conflict preservation copies only the divergent authored symlink into deterministic scratch." },
-      { "value": "bypass-write-079", "api": "open", "ref": "task_01KZXGJWVCKCA6B0MKB220PKFB", "reason": "The durable settlement worker opens each exact temporary target before writing and syncing frozen bytes." },
-      { "value": "bypass-write-080", "api": "open", "ref": "task_01KZXGJWVCKCA6B0MKB220PKFB", "reason": "The durable settlement worker opens every changed parent directory for fsync before acknowledgment." },
-      { "value": "bypass-write-081", "api": "unlinkSync", "ref": "task_01KZXGJWVCKCA6B0MKB220PKFB", "reason": "RepoCell-owned settlement removes only its exact unpublished temporary targets after publication callback failure." },
-      { "value": "bypass-write-082", "api": "renameSync", "ref": "task_01KZWZEW11C499EACS9M5HVJZ8", "reason": "RepoCell-owned settlement atomically publishes the authored target." },
-      { "value": "bypass-write-083", "api": "mkdirSync", "ref": "task_01KZWZEW11C499EACS9M5HVJZ8", "reason": "Materialization creates only Git's local info directory for scratch exclusion." },
-      { "value": "bypass-write-084", "api": "writeFileSync", "ref": "task_01KZWZEW11C499EACS9M5HVJZ8", "reason": "Materialization registers only the deterministic conflict-scratch ignore rule." },
-      { "value": "bypass-write-085", "api": "mkdirSync", "ref": "task_01KZWZEW11C499EACS9M5HVJZ8", "reason": "Materialization creates only a deterministic conflict-scratch parent." },
-      { "value": "bypass-write-086", "api": "writeFileSync", "ref": "dec_F906FA4E1BE047B6F591CF4316; task_32e553b6c0ff5f31a6d914e5cb", "reason": "S4 return-path conflict preservation registers only the deterministic conflict-scratch ignore rule." },
-      { "value": "bypass-write-087", "api": "mkdirSync", "ref": "dec_F906FA4E1BE047B6F591CF4316; task_32e553b6c0ff5f31a6d914e5cb", "reason": "S4 conflict materialization creates only the exact parent for its deterministic durable scratch file." },
-      { "value": "bypass-write-088", "api": "openSync", "ref": "task_01KZWZEW11C499EACS9M5HVJZ8", "reason": "Materialization opens only the exact temporary conflict scratch." },
-      { "value": "bypass-write-089", "api": "writeFileSync", "ref": "task_01KZWZEW11C499EACS9M5HVJZ8", "reason": "Materialization preserves only divergent local bytes in scratch." },
-      { "value": "bypass-write-090", "api": "writeFileSync", "ref": "dec_F906FA4E1BE047B6F591CF4316; task_32e553b6c0ff5f31a6d914e5cb", "reason": "S4 conflict materialization writes only divergent authored bytes to its exact durable temporary scratch." },
-      { "value": "bypass-write-091", "api": "fsyncSync", "ref": "task_01KZWZEW11C499EACS9M5HVJZ8", "reason": "Materialization hardens the temporary conflict scratch." },
-      { "value": "bypass-write-092", "api": "closeSync", "ref": "task_01KZWZEW11C499EACS9M5HVJZ8", "reason": "Materialization closes the temporary conflict scratch." },
-      { "value": "bypass-write-093", "api": "renameSync", "ref": "task_01KZWZEW11C499EACS9M5HVJZ8", "reason": "Materialization atomically publishes the deterministic conflict scratch." },
-      { "value": "bypass-write-094", "api": "renameSync", "ref": "dec_F906FA4E1BE047B6F591CF4316; task_32e553b6c0ff5f31a6d914e5cb", "reason": "S4 conflict materialization atomically publishes only its exact deterministic durable scratch file." },
-      { "value": "bypass-write-095", "api": "openSync", "ref": "task_01KZWZEW11C499EACS9M5HVJZ8", "reason": "Materialization opens the conflict-scratch parent for durability." },
-      { "value": "bypass-write-096", "api": "fsyncSync", "ref": "task_01KZWZEW11C499EACS9M5HVJZ8", "reason": "Materialization hardens the conflict-scratch parent directory." },
-      { "value": "bypass-write-097", "api": "closeSync", "ref": "task_01KZWZEW11C499EACS9M5HVJZ8", "reason": "Materialization closes the conflict-scratch parent directory." }
+      {
+        "value": "bypass-write-043",
+        "api": "rmSync",
+        "ref": "task_01KZRMKJT7YKQ2TNXA8WR1W5DN",
+        "reason": "RepoCell-owned recovery removes only an abandoned prepared artifact."
+      },
+      {
+        "value": "bypass-write-053",
+        "api": "openSync",
+        "ref": "task_01KZRMKJT7YKQ2TNXA8WR1W5DN",
+        "reason": "RepoCell-owned per-repository lock uses exclusive OS creation."
+      },
+      {
+        "value": "bypass-write-054",
+        "api": "writeFileSync",
+        "ref": "task_01KZRMKJT7YKQ2TNXA8WR1W5DN",
+        "reason": "RepoCell-owned per-repository lock records its generation."
+      },
+      {
+        "value": "bypass-write-055",
+        "api": "closeSync",
+        "ref": "task_01KZRMKJT7YKQ2TNXA8WR1W5DN",
+        "reason": "RepoCell-owned per-repository lock closes its descriptor."
+      },
+      {
+        "value": "bypass-write-056",
+        "api": "mkdirSync",
+        "ref": "task_01KZRMKJT7YKQ2TNXA8WR1W5DN",
+        "reason": "RepoCell-owned writer creates only its exact event or pending directory."
+      },
+      {
+        "value": "bypass-write-057",
+        "api": "renameSync",
+        "ref": "task_01KZRMKJT7YKQ2TNXA8WR1W5DN",
+        "reason": "RepoCell-owned writer atomically publishes exact event or head bytes."
+      },
+      {
+        "value": "bypass-write-058",
+        "api": "rmSync",
+        "ref": "task_01KZRMKJT7YKQ2TNXA8WR1W5DN",
+        "reason": "RepoCell-owned writer removes only its pending or prepared recovery artifact."
+      },
+      {
+        "value": "bypass-write-059",
+        "api": "writeFileSync",
+        "ref": "task_01KZRMKJT7YKQ2TNXA8WR1W5DN",
+        "reason": "RepoCell-owned writer updates only its exact local runtime state."
+      },
+      {
+        "value": "bypass-write-060",
+        "api": "mkdirSync",
+        "ref": "task_6e3a253ed79c2c458543c7d3d7",
+        "reason": "Local-only WAL creates its exact private buffer directory."
+      },
+      {
+        "value": "bypass-write-061",
+        "api": "rmSync",
+        "ref": "dec_F906FA4E1BE047B6F591CF4316; task_32e553b6c0ff5f31a6d914e5cb",
+        "reason": "S4 checkpoint GC removes only a local-only WAL object after the materialized Git cut no longer references it."
+      },
+      {
+        "value": "bypass-write-062",
+        "api": "mkdirSync",
+        "ref": "task_6e3a253ed79c2c458543c7d3d7",
+        "reason": "Local-only WAL creates the parent of its exact append target."
+      },
+      {
+        "value": "bypass-write-063",
+        "api": "openSync",
+        "ref": "task_6e3a253ed79c2c458543c7d3d7",
+        "reason": "Git-first local-only WAL opens its exact shadow append target."
+      },
+      {
+        "value": "bypass-write-064",
+        "api": "writeSync",
+        "ref": "task_6e3a253ed79c2c458543c7d3d7",
+        "reason": "Local-only WAL appends canonical record bytes."
+      },
+      {
+        "value": "bypass-write-065",
+        "api": "fsyncSync",
+        "ref": "dec_F906FA4E1BE047B6F591CF4316; task_32e553b6c0ff5f31a6d914e5cb",
+        "reason": "S4 acknowledgment hardens the exact appended WAL segment before the write receipt returns."
+      },
+      {
+        "value": "bypass-write-066",
+        "api": "closeSync",
+        "ref": "task_6e3a253ed79c2c458543c7d3d7",
+        "reason": "Local-only WAL closes its append descriptor."
+      },
+      {
+        "value": "bypass-write-067",
+        "api": "mkdirSync",
+        "ref": "task_6e3a253ed79c2c458543c7d3d7",
+        "reason": "Local-only WAL creates the parent of its replacement target."
+      },
+      {
+        "value": "bypass-write-068",
+        "api": "openSync",
+        "ref": "task_6e3a253ed79c2c458543c7d3d7",
+        "reason": "Local-only WAL opens its exact temporary replacement."
+      },
+      {
+        "value": "bypass-write-069",
+        "api": "writeSync",
+        "ref": "task_6e3a253ed79c2c458543c7d3d7",
+        "reason": "Local-only WAL writes canonical head or object bytes."
+      },
+      {
+        "value": "bypass-write-070",
+        "api": "fsyncSync",
+        "ref": "dec_F906FA4E1BE047B6F591CF4316; task_32e553b6c0ff5f31a6d914e5cb",
+        "reason": "S4 acknowledgment hardens the exact replacement WAL head or object bytes before publication."
+      },
+      {
+        "value": "bypass-write-071",
+        "api": "closeSync",
+        "ref": "task_6e3a253ed79c2c458543c7d3d7",
+        "reason": "Local-only WAL closes its temporary replacement."
+      },
+      {
+        "value": "bypass-write-072",
+        "api": "renameSync",
+        "ref": "task_6e3a253ed79c2c458543c7d3d7",
+        "reason": "Local-only WAL atomically publishes head or object bytes."
+      },
+      {
+        "value": "bypass-write-073",
+        "api": "openSync",
+        "ref": "dec_F906FA4E1BE047B6F591CF4316; task_32e553b6c0ff5f31a6d914e5cb",
+        "reason": "S4 WAL replacement opens only its containing directory to harden the atomic rename."
+      },
+      {
+        "value": "bypass-write-074",
+        "api": "fsyncSync",
+        "ref": "dec_F906FA4E1BE047B6F591CF4316; task_32e553b6c0ff5f31a6d914e5cb",
+        "reason": "S4 acknowledgment hardens the WAL replacement directory after its atomic rename."
+      },
+      {
+        "value": "bypass-write-110",
+        "api": "rmSync",
+        "ref": "task_38bc061c5a6c7fb1946e9b5cc6; task_f821cb831f535a13d8cc857c3c",
+        "reason": "Local-only WAL removes only its own pid-named temporary replacement when the write or rename throws."
+      },
+      {
+        "value": "bypass-write-075",
+        "api": "closeSync",
+        "ref": "dec_F906FA4E1BE047B6F591CF4316; task_32e553b6c0ff5f31a6d914e5cb",
+        "reason": "S4 WAL replacement closes only the containing-directory durability descriptor."
+      },
+      {
+        "value": "bypass-write-076",
+        "api": "mkdirSync",
+        "ref": "task_01KZWZEW11C499EACS9M5HVJZ8",
+        "reason": "RepoCell-owned settlement creates only an authored target directory."
+      },
+      {
+        "value": "bypass-write-077",
+        "api": "symlinkSync",
+        "ref": "dec_F906FA4E1BE047B6F591CF4316; task_32e553b6c0ff5f31a6d914e5cb",
+        "reason": "S4 return-path visibility creates only an exact temporary authored symlink before atomic worktree publication."
+      },
+      {
+        "value": "bypass-write-078",
+        "api": "symlinkSync",
+        "ref": "dec_F906FA4E1BE047B6F591CF4316; task_32e553b6c0ff5f31a6d914e5cb",
+        "reason": "S4 return-path conflict preservation copies only the divergent authored symlink into deterministic scratch."
+      },
+      {
+        "value": "bypass-write-079",
+        "api": "open",
+        "ref": "task_01KZXGJWVCKCA6B0MKB220PKFB",
+        "reason": "The durable settlement worker opens each exact temporary target before writing and syncing frozen bytes."
+      },
+      {
+        "value": "bypass-write-080",
+        "api": "open",
+        "ref": "task_01KZXGJWVCKCA6B0MKB220PKFB",
+        "reason": "The durable settlement worker opens every changed parent directory for fsync before acknowledgment."
+      },
+      {
+        "value": "bypass-write-081",
+        "api": "unlinkSync",
+        "ref": "task_01KZXGJWVCKCA6B0MKB220PKFB",
+        "reason": "RepoCell-owned settlement removes only its exact unpublished temporary targets after publication callback failure."
+      },
+      {
+        "value": "bypass-write-082",
+        "api": "renameSync",
+        "ref": "task_01KZWZEW11C499EACS9M5HVJZ8",
+        "reason": "RepoCell-owned settlement atomically publishes the authored target."
+      },
+      {
+        "value": "bypass-write-083",
+        "api": "mkdirSync",
+        "ref": "task_01KZWZEW11C499EACS9M5HVJZ8",
+        "reason": "Materialization creates only Git's local info directory for scratch exclusion."
+      },
+      {
+        "value": "bypass-write-084",
+        "api": "writeFileSync",
+        "ref": "task_01KZWZEW11C499EACS9M5HVJZ8",
+        "reason": "Materialization registers only the deterministic conflict-scratch ignore rule."
+      },
+      {
+        "value": "bypass-write-085",
+        "api": "mkdirSync",
+        "ref": "task_01KZWZEW11C499EACS9M5HVJZ8",
+        "reason": "Materialization creates only a deterministic conflict-scratch parent."
+      },
+      {
+        "value": "bypass-write-086",
+        "api": "writeFileSync",
+        "ref": "dec_F906FA4E1BE047B6F591CF4316; task_32e553b6c0ff5f31a6d914e5cb",
+        "reason": "S4 return-path conflict preservation registers only the deterministic conflict-scratch ignore rule."
+      },
+      {
+        "value": "bypass-write-087",
+        "api": "mkdirSync",
+        "ref": "dec_F906FA4E1BE047B6F591CF4316; task_32e553b6c0ff5f31a6d914e5cb",
+        "reason": "S4 conflict materialization creates only the exact parent for its deterministic durable scratch file."
+      },
+      {
+        "value": "bypass-write-088",
+        "api": "openSync",
+        "ref": "task_01KZWZEW11C499EACS9M5HVJZ8",
+        "reason": "Materialization opens only the exact temporary conflict scratch."
+      },
+      {
+        "value": "bypass-write-089",
+        "api": "writeFileSync",
+        "ref": "task_01KZWZEW11C499EACS9M5HVJZ8",
+        "reason": "Materialization preserves only divergent local bytes in scratch."
+      },
+      {
+        "value": "bypass-write-090",
+        "api": "writeFileSync",
+        "ref": "dec_F906FA4E1BE047B6F591CF4316; task_32e553b6c0ff5f31a6d914e5cb",
+        "reason": "S4 conflict materialization writes only divergent authored bytes to its exact durable temporary scratch."
+      },
+      {
+        "value": "bypass-write-091",
+        "api": "fsyncSync",
+        "ref": "task_01KZWZEW11C499EACS9M5HVJZ8",
+        "reason": "Materialization hardens the temporary conflict scratch."
+      },
+      {
+        "value": "bypass-write-092",
+        "api": "closeSync",
+        "ref": "task_01KZWZEW11C499EACS9M5HVJZ8",
+        "reason": "Materialization closes the temporary conflict scratch."
+      },
+      {
+        "value": "bypass-write-093",
+        "api": "renameSync",
+        "ref": "task_01KZWZEW11C499EACS9M5HVJZ8",
+        "reason": "Materialization atomically publishes the deterministic conflict scratch."
+      },
+      {
+        "value": "bypass-write-094",
+        "api": "renameSync",
+        "ref": "dec_F906FA4E1BE047B6F591CF4316; task_32e553b6c0ff5f31a6d914e5cb",
+        "reason": "S4 conflict materialization atomically publishes only its exact deterministic durable scratch file."
+      },
+      {
+        "value": "bypass-write-095",
+        "api": "openSync",
+        "ref": "task_01KZWZEW11C499EACS9M5HVJZ8",
+        "reason": "Materialization opens the conflict-scratch parent for durability."
+      },
+      {
+        "value": "bypass-write-096",
+        "api": "fsyncSync",
+        "ref": "task_01KZWZEW11C499EACS9M5HVJZ8",
+        "reason": "Materialization hardens the conflict-scratch parent directory."
+      },
+      {
+        "value": "bypass-write-097",
+        "api": "closeSync",
+        "ref": "task_01KZWZEW11C499EACS9M5HVJZ8",
+        "reason": "Materialization closes the conflict-scratch parent directory."
+      },
+      {
+        "value": "bypass-write-111",
+        "api": "sqlite.prepare",
+        "ref": "dec_B1F5FF7648436C985F38F14226",
+        "reason": "SQLite ledger statement run inside the coordinated command transaction or its bootstrap."
+      },
+      {
+        "value": "bypass-write-112",
+        "api": "sqlite.prepare",
+        "ref": "dec_B1F5FF7648436C985F38F14226",
+        "reason": "SQLite ledger statement run inside the coordinated command transaction or its bootstrap."
+      },
+      {
+        "value": "bypass-write-113",
+        "api": "sqlite.prepare",
+        "ref": "dec_B1F5FF7648436C985F38F14226",
+        "reason": "SQLite ledger statement run inside the coordinated command transaction or its bootstrap."
+      },
+      {
+        "value": "bypass-write-114",
+        "api": "sqlite.prepare",
+        "ref": "dec_B1F5FF7648436C985F38F14226",
+        "reason": "SQLite ledger statement run inside the coordinated command transaction or its bootstrap."
+      },
+      {
+        "value": "bypass-write-115",
+        "api": "sqlite.prepare",
+        "ref": "dec_B1F5FF7648436C985F38F14226",
+        "reason": "SQLite ledger statement run inside the coordinated command transaction or its bootstrap."
+      },
+      {
+        "value": "bypass-write-116",
+        "api": "sqlite.exec",
+        "ref": "dec_B1F5FF7648436C985F38F14226",
+        "reason": "Creates or configures the SQLite ledger schema inside the coordinated store open."
+      },
+      {
+        "value": "bypass-write-117",
+        "api": "sqlite.prepare",
+        "ref": "dec_B1F5FF7648436C985F38F14226",
+        "reason": "SQLite ledger statement run inside the coordinated command transaction or its bootstrap."
+      },
+      {
+        "value": "bypass-write-118",
+        "api": "sqlite.prepare",
+        "ref": "dec_B1F5FF7648436C985F38F14226",
+        "reason": "SQLite ledger statement run inside the coordinated command transaction or its bootstrap."
+      },
+      {
+        "value": "bypass-write-119",
+        "api": "sqlite.prepare",
+        "ref": "dec_B1F5FF7648436C985F38F14226",
+        "reason": "SQLite ledger statement run inside the coordinated command transaction or its bootstrap."
+      },
+      {
+        "value": "bypass-write-120",
+        "api": "sqlite.prepare",
+        "ref": "dec_B1F5FF7648436C985F38F14226",
+        "reason": "SQLite ledger statement run inside the coordinated command transaction or its bootstrap."
+      },
+      {
+        "value": "bypass-write-121",
+        "api": "sqlite.prepare",
+        "ref": "dec_B1F5FF7648436C985F38F14226",
+        "reason": "SQLite ledger statement run inside the coordinated command transaction or its bootstrap."
+      },
+      {
+        "value": "bypass-write-122",
+        "api": "sqlite.prepare",
+        "ref": "dec_B1F5FF7648436C985F38F14226",
+        "reason": "SQLite ledger statement run inside the coordinated command transaction or its bootstrap."
+      },
+      {
+        "value": "bypass-write-123",
+        "api": "sqlite.exec",
+        "ref": "dec_B1F5FF7648436C985F38F14226",
+        "reason": "Creates or configures the SQLite ledger schema inside the coordinated store open."
+      },
+      {
+        "value": "bypass-write-124",
+        "api": "sqlite.exec",
+        "ref": "dec_B1F5FF7648436C985F38F14226",
+        "reason": "Creates or configures the SQLite ledger schema inside the coordinated store open."
+      },
+      {
+        "value": "bypass-write-125",
+        "api": "sqlite.exec",
+        "ref": "dec_B1F5FF7648436C985F38F14226",
+        "reason": "Creates or configures the SQLite ledger schema inside the coordinated store open."
+      },
+      {
+        "value": "bypass-write-126",
+        "api": "sqlite.prepare",
+        "ref": "dec_B1F5FF7648436C985F38F14226",
+        "reason": "SQLite ledger statement run inside the coordinated command transaction or its bootstrap."
+      },
+      {
+        "value": "bypass-write-127",
+        "api": "sqlite.exec",
+        "ref": "dec_B1F5FF7648436C985F38F14226",
+        "reason": "Creates or configures the SQLite ledger schema inside the coordinated store open."
+      },
+      {
+        "value": "bypass-write-128",
+        "api": "DatabaseSync",
+        "ref": "dec_B1F5FF7648436C985F38F14226",
+        "reason": "Opens the generation-scoped SQLite ledger store beneath the coordinated repo cell."
+      }
     ],
     "exemptHumanOrBootstrap": [],
     "legacyArchive": [],

--- a/tools/write-road-registry.json
+++ b/tools/write-road-registry.json
@@ -66,8 +66,8 @@
     "packages/daemon/src/repo-cell-errors.ts",
     "packages/daemon/src/repo-cell-lock.ts",
     "packages/daemon/src/request-log.ts",
-    "packages/daemon/src/runtime.ts",
     "packages/daemon/src/runtime-callback-relay.ts",
+    "packages/daemon/src/runtime.ts",
     "packages/daemon/src/schedule-occurrence-workspace.ts",
     "packages/daemon/src/transport/unix-socket.ts",
     "packages/daemon/src/writer-epoch.ts",
@@ -76,6 +76,7 @@
     "packages/kernel/src/local/local-layout-file-system.ts",
     "packages/kernel/src/projection/rebuildable-task-projection-database.ts",
     "packages/kernel/src/store/local-version-control-system.ts",
+    "packages/kernel/src/store/sqlite-event-store.ts",
     "packages/preset/src/preset-installation.ts",
     "packages/preset/src/preset-process-service.ts"
   ]


### PR DESCRIPTION
# English

## Summary

W1-min stage ① (task_a93f6a2e, contract per dec_B1F5FF76): a generation-1 SQLite ledger store, its migrator, and a best-effort shadow sink behind the existing WAL/Git accept point. Nothing switches yet: the old accept point, receipts, and canonical reads are untouched, and no old path is deleted (the net-deletion gate applies to the stage ③ switch PR by ruling). This lands the shadow so stage ② can reconcile production writes against it.

## Architectural Justification

- One new module `packages/kernel/src/store/sqlite-event-store.ts` (production +426 net): `ledger_meta` / `event` / `command_outcome` / `writer_lease` plus derived `lease_cas` / `lease_interval` reducers, all under one `BEGIN IMMEDIATE` command transaction (writer generation fence `{repoId, holder, epoch}` checked in-transaction; `command_outcome` keyed by op_id records the whole-command terminal outcome; same op_id + same intent replays, different intent is `op_conflict`). `synchronous=FULL`, `sqlite_version()` check, `recorded_at` from the database clock.
- **Operational semantics: the write path never imports history.** `shadowAccepted` appends only when `ledger_meta.revision + 1` equals the bundle's first event revision; otherwise it warns once per cell and skips that bundle. Seeding is the explicit `ha migrate ledger --generation 1`, and **the shadow follows again from the next write after seeding**, with no daemon re-attach. Stage ② reconciliation relies on this.
- Composition lives in `RepoCell` (`packages/daemon/src/repo-cell.ts`): shadow appends happen after the WAL append is durable, one `appendCommand` per bundle (`events=[...preceding, event]`), bootstrap only once in the recovering phase, incremental from `ledger_meta.revision`. Shadow failure logs `[sqlite-shadow]` and never withdraws the WAL receipt.
- Byte-exact full-stream verification exists only in the explicit `ha migrate ledger --generation 1`.
- Store path `.harness/store/generations/<generation>/ledger.sqlite`; the generation is written to both the path and `ledger_meta` so gen-2 can coexist read-only later.

## What Changed

- kernel: `sqlite-event-store.ts` (new), named exports `openSqliteEventStore` / `migrateEventsToSqlite`.
- daemon: `repo-cell.ts` shadow composition; `repo-cell-action-dispatch.ts` passes the generation to path and metadata.
- cli: `ha migrate ledger --generation 1` (no flag keeps the existing Git layout migration; other generations fail closed), routed through `parseLedgerMigrateRouted`.
- tests: `packages/kernel/test/store/sqlite-event-store.integration.test.ts` (+ SIGKILL fixture): concurrent revision allocation, close/reopen same op_id persistent outcome + different-intent rejection, atomic rollback, in-transaction SIGKILL, 1,000-event byte-exact migration + idempotent second run, generation-path coexistence, 50k bootstrap + per-command shadow cost.

## Governance Declaration

- Protected surface touched: `tools/gate-allowlists/check-bypass-write-boundary.json` (+18 `coordinatedCore` entries, bypass-write-111…128) and `tools/write-road-registry.json` (+1 physical write sink). Both register the new generation-1 SQLite ledger store's DatabaseSync / exec / prepare calls, which run only inside the coordinated RepoCell command path.
- Authorizing decision: dec_B1F5FF7648436C985F38F14226 (W1-min contract, stage ①). Task: task_a93f6a2eecfe93e57a0a1e6830.
- No gate was weakened or removed; no break-glass used.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates: none

## Verification

- Ubuntu VM isolated: `sqlite-event-store.integration.test.ts` 8/8 (run `harness-test-isolation-68471-…`); 50,000-event bootstrap once 13,628 ms; 100 subsequent one-event shadow command transactions p50 0.209 ms / p99 0.728 ms. Regression on the VM: `wal-shadow-event-store.test.ts` 28/28, `json-rpc-protocol.test.ts` 55/55.
- Locally after rebase onto `989bb83e`: tsc (kernel/application/daemon/cli) exit 0; kernel dead-exports, cli-structure, line-density, file-complexity, duplicate-definitions, derived-contracts, schema-closure pass; thin-command / contract-parity / identity-migration / sqlite store tests 38 passed.
- Production +501/-54 (the +/- includes the ledger-migrate executor moved out of the dispatcher; < the ruled 1,100×1.5 stop line). `check:local` not run.

## Review Evidence

- Two rounds of CEO semantic review (peer CEO session) against dec_B1F5FF76: round 1 accepted the contract layer and required (a) one transaction per bundle, (b) no history import on the write path, (c) byte-exact only in the explicit migration, (d) ≥50k measurement, and the generation path; rounds 2 and 3 are recorded at the end of `task_plan.md`; round 3 accepted (b) after `bootstrapSqliteShadow` and its lazy fallback were deleted.
- Worker reports: `harness/tasks/task_a93f6a2e…/artifacts/reports/implementation.md` (§0 and §第二轮).

## Correction (2026-09-05, after merge)

- In local mode the shadow is inert: `writerEpochFence` is only injected by the fleet center-listener transport auth, so local CLI/GUI commands carry no fence — `ha migrate ledger --generation 1` is rejected (`invalid_command`) and `shadowAccepted` would skip every local write. "Stage ① merged" therefore does not mean "the shadow is following" on any current (local-mode) ledger. Tracked as item 0 of stage ② (task_4e02f9e60f708dd1c76933b658, fact F-CADDBB1D).

## Residual Risk

- The accept point is still WAL/Git; ownership items 1 and 5 of the seven (single copy not subject to cache deletion; content retention independent of WAL/Git) are proven only inside the SQLite store and remain stage ③ work.
- Shadow warnings go to daemon stderr only; the structured stage ② reconciliation table is not built yet.
- Benchmark is a single-VM 1,000/50,000 small-event sample.

Production-Delta: +501/-54

---

# 中文

## 摘要

W1-min 第①段(task_a93f6a2e,契约按 dec_B1F5FF76):generation-1 SQLite 台账库、迁移器、挂在既有 WAL/Git accept point 后面的 best-effort shadow sink。本 PR **不切换**:旧 accept point、receipt、canonical 读都不动,不删旧路(净删门按裁决只在第③段切换 PR 上算)。落下 shadow,第②段才能拿生产写入逐条对账。

## 架构辩护

- 一个新模块 `sqlite-event-store.ts`(production 净 +426):`ledger_meta` / `event` / `command_outcome` / `writer_lease` + 派生 `lease_cas` / `lease_interval` reducer,全部在一个 `BEGIN IMMEDIATE` 命令事务内(写者 generation fence 事务内核对;`command_outcome` 以 op_id 记整命令终态,同键同意图回放、异意图 `op_conflict`)。`synchronous=FULL`、`sqlite_version()` 校验、`recorded_at` 库墙钟。
- **运维语义:写路永不导入历史。** `shadowAccepted` 只在 `ledger_meta.revision + 1` 等于 bundle 首事件 revision 时 append,否则每 cell 只 warn 一次并跳过该 bundle;播种只由显式 `ha migrate ledger --generation 1` 完成,**播种后 shadow 从下一次写开始跟随**,不需要 daemon 重新 attach。第②段对账据此。
- 组合职责在 `RepoCell`:WAL durable 之后再 shadow,每 bundle 一个 `appendCommand`(`events=[...preceding, event]`),引导只在 recovering 阶段做一次、按 `ledger_meta.revision` 增量;shadow 失败只打 `[sqlite-shadow]` 日志,不撤 WAL receipt。
- 全流 byte-exact 校验只在显式 `ha migrate ledger --generation 1`。
- 库路径 `.harness/store/generations/<generation>/ledger.sqlite`,generation 同时写路径与 `ledger_meta`,gen-2 可只读并存。

## 变更内容

- kernel 新库模块与两个具名导出;daemon `repo-cell.ts` shadow 组合、`repo-cell-action-dispatch.ts` 传 generation;cli `ha migrate ledger --generation 1`(无参保持原行为,其他 generation fail-closed);集成测试覆盖并发 revision、close/reopen 幂等与异意图拒绝、原子回滚、事务内 SIGKILL、1,000 事件 byte-exact 迁移与幂等、两代路径并存、50k 引导与单次写开销。

## 治理声明

- 触碰的受保护面:`tools/gate-allowlists/check-bypass-write-boundary.json`(新增 18 条 `coordinatedCore`,bypass-write-111…128)与 `tools/write-road-registry.json`(新增 1 个物理写 sink)。两者登记的都是 generation-1 SQLite 台账库的 DatabaseSync / exec / prepare 调用,只在受协调的 RepoCell 命令路径内执行。
- 授权决策:dec_B1F5FF7648436C985F38F14226(W1-min 契约,第①段)。任务:task_a93f6a2eecfe93e57a0a1e6830。
- 未削弱或删除任何门;未使用 break-glass。

## 门收割

Deleted-Production-Paths: none
Deleted-Gates: none

## 验证

- Ubuntu VM 隔离 8/8;50,000 事件引导一次 13,628 ms;其后 100 次单事件 shadow 事务 p50 0.209 ms / p99 0.728 ms;回归 wal-shadow 28/28、json-rpc 55/55。
- rebase 到 `989bb83e` 后本地:tsc、七个门、38 tests 通过;production +501/-54(含把 ledger-migrate 执行体搬出 dispatcher 的两边计行;低于 1,100×1.5 停止线);未跑 `check:local`。

## 评审证据

- 对面 CEO session 两轮语义验收(dec_B1F5FF76 逐条):第一轮提出 (a)–(d) 与路径必修,第二轮驳回 (b)(attach 期无 fence、全流导入落在首写),第三轮删除 bootstrapSqliteShadow 与懒回退后通过,记录在 task_plan.md 末尾;worker 报告 `implementation.md` §0 与 §第二轮。

## 更正(2026-09-05,合并后)

- 本地模式下 shadow 空转:`writerEpochFence` 只由 fleet center-listener 的 transport auth 注入,本地 CLI/GUI 命令无 fence——`ha migrate ledger --generation 1` 被拒(`invalid_command`),`shadowAccepted` 也会跳过每一条本地写。因此「第①段已合入」不等于「影子已在跟随」(当前所有台账都是本地模式)。归第②段第 0 项(task_4e02f9e60f708dd1c76933b658,fact F-CADDBB1D)。

## 残余风险

- accept point 仍是 WAL/Git;所有权七项的 1、5 只在 SQLite 侧证明,归第③段。
- shadow warning 只进 daemon stderr,第②段结构化对账表未建。
- 基准是单 VM 小事件样本。
