### PR TITLE
feat(kernel,daemon,cli): ha migrate schedule-definitions — drop retired spec.target.cwd from stored schedule history

### DIFF
--- a/packages/cli/src/cli/thin-command-router.ts
+++ b/packages/cli/src/cli/thin-command-router.ts
@@ -62,6 +62,7 @@ export function parseRouted(
     route.id === "fact-rekey" ||
     route.id === "relation-events-migrate" ||
     route.id === "decision-digests-migrate" ||
+    route.id === "schedule-definitions-migrate" ||
     route.id === "dispatch-records-migrate"
   ) {
     const f = readFlags(route.id, args.slice(2), inputs);

--- a/packages/cli/test/thin-command.test.ts
+++ b/packages/cli/test/thin-command.test.ts
@@ -275,6 +275,7 @@ test("capabilities is an exact-set projection of the command contract", () => {
       "ledger-migrate",
       "migrate-import",
       "relation-events-migrate",
+      "schedule-definitions-migrate",
       "vertical-declaration-migrate",
     ],
     preset: [

--- a/packages/daemon/src/protocol/daemon-protocol-commands-agent.ts
+++ b/packages/daemon/src/protocol/daemon-protocol-commands-agent.ts
@@ -152,6 +152,16 @@ export const agentProtocolCommands = Object.freeze([
     inputs: [cliInput("--dry-run", "boolean", false, { code: "invalid_field" }, { field: "dryRun" })],
   }),
   defineLedgerWriteCommand({
+    id: "schedule-definitions-migrate",
+    phase: "Migration-A",
+    path: ["migrate", "schedule-definitions"],
+    summary:
+      "Upcast historical schedule declarations to the current target shape and restamp their content claims. " +
+      "Stop daemon writers first; --dry-run reports the rewrites.",
+    method: "repo.task.run",
+    inputs: [cliInput("--dry-run", "boolean", false, { code: "invalid_field" }, { field: "dryRun" })],
+  }),
+  defineLedgerWriteCommand({
     id: "dispatch-records-migrate",
     phase: "Migration-A",
     path: ["migrate", "dispatch-records"],

--- a/packages/daemon/src/recovery-state.ts
+++ b/packages/daemon/src/recovery-state.ts
@@ -12,6 +12,10 @@ const recoveryCommands: Readonly<Record<string, RecoveryCommandPolicy>> = Object
   "migrate-import": Object.freeze({ causes: Object.freeze(["data-shape"] as const), settlesLatch: true }),
   "projection-rebuild": Object.freeze({ causes: Object.freeze(["projection"] as const), settlesLatch: true }),
   "relation-events-migrate": Object.freeze({ causes: Object.freeze(["data-shape"] as const), settlesLatch: true }),
+  "schedule-definitions-migrate": Object.freeze({
+    causes: Object.freeze(["data-shape"] as const),
+    settlesLatch: true,
+  }),
   "receipt-show": Object.freeze({
     causes: Object.freeze(["data-shape", "infrastructure"] as const),
     settlesLatch: false,

--- a/packages/daemon/src/repo-cell-action-dispatch.ts
+++ b/packages/daemon/src/repo-cell-action-dispatch.ts
@@ -66,7 +66,11 @@ export async function executeAction(
       now: cell.now,
     });
   }
-  if (action.kind === "relation-events-migrate" || action.kind === "decision-digests-migrate")
+  if (
+    action.kind === "relation-events-migrate" ||
+    action.kind === "decision-digests-migrate" ||
+    action.kind === "schedule-definitions-migrate"
+  )
     return runEventShapeMigrationAction(cell, eventShapeMigrations[action.kind], action, binding);
   if (action.kind === "dispatch-records-migrate") return runDispatchRecordMigrationAction(cell, action, binding);
   if (action.kind === "entity-migrate-squads") return runSquadEntityMigration(cell, action, binding);

--- a/packages/daemon/src/repo-cell-action-dispatch.ts
+++ b/packages/daemon/src/repo-cell-action-dispatch.ts
@@ -66,12 +66,8 @@ export async function executeAction(
       now: cell.now,
     });
   }
-  if (
-    action.kind === "relation-events-migrate" ||
-    action.kind === "decision-digests-migrate" ||
-    action.kind === "schedule-definitions-migrate"
-  )
-    return runEventShapeMigrationAction(cell, eventShapeMigrations[action.kind], action, binding);
+  const eventShapeMigration = eventShapeMigrations[action.kind as keyof typeof eventShapeMigrations];
+  if (eventShapeMigration) return runEventShapeMigrationAction(cell, eventShapeMigration, action, binding);
   if (action.kind === "dispatch-records-migrate") return runDispatchRecordMigrationAction(cell, action, binding);
   if (action.kind === "entity-migrate-squads") return runSquadEntityMigration(cell, action, binding);
   if (action.kind === "projection-rebuild") {

--- a/packages/daemon/src/repo-cell-authorization.ts
+++ b/packages/daemon/src/repo-cell-authorization.ts
@@ -159,6 +159,8 @@ export function authorizeDurableRepoCellAction(
       return authorizeRepoCellAction(input);
     case "relation-events-migrate":
       return authorizeRepoCellAction(input);
+    case "schedule-definitions-migrate":
+      return authorizeRepoCellAction(input);
     case "fact-type-register":
       return authorizeRepoCellAction(input);
     case "ledger-migrate":

--- a/packages/daemon/src/repo-cell-open.ts
+++ b/packages/daemon/src/repo-cell-open.ts
@@ -353,7 +353,8 @@ export async function openRepoWriterCell(
         candidate = await initialize();
         // Adopt the candidate's store as soon as it opens: the quiesce above already closed
         // the prior store, so this is the only live store left, and a store-only recovery
-        // command (relation-events-migrate, decision-digests-migrate, projection-rebuild's own
+        // command (relation-events-migrate, decision-digests-migrate, schedule-definitions-migrate,
+        // projection-rebuild's own
         // store.readHead(), ...) must be able to run against it even while the probes below
         // stay indeterminate -- repairing that indeterminate state is what those commands exist
         // to do. Only `state` gates on the probes; the store is live regardless.

--- a/packages/daemon/test/event-shape-migration.integration.test.ts
+++ b/packages/daemon/test/event-shape-migration.integration.test.ts
@@ -1,13 +1,16 @@
 // harness-test-tier: integration
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
 import test from "node:test";
 import {
   canonicalEventWritePlan,
+  compileScheduleDefinitionEvent,
+  contentObjectRelativePath,
+  createScheduleV1,
   deriveRelationId,
   eventObjectRelativePath,
   makeTaskEventReader,
@@ -19,6 +22,7 @@ import {
   runtimeDefinitionSnapshotArtifact,
   runtimeEventContentClaims,
   sha256Text,
+  validateScheduleV1,
   type AgentDefinitionSnapshot,
   type AgentRuntimeEventV1,
   type RelationEventV1,
@@ -85,6 +89,11 @@ function sortedJson(value: unknown): string {
   );
 }
 
+function definitionOf(schedule: ReturnType<typeof createScheduleV1>) {
+  const { status: _status, ...definition } = schedule;
+  return definition;
+}
+
 test("relation_created history in the pre-derived-strength shape cold-rebuilds only after `migrate relation-events`", async () => {
   const scratch = mkdtempSync(path.join(tmpdir(), "ha-relation-events-"));
   let cell: Awaited<ReturnType<typeof openRepoCell>> | undefined;
@@ -128,6 +137,7 @@ test("relation_created history in the pre-derived-strength shape cold-rebuilds o
       ownerId: "event-shape-test",
       now: () => "2026-09-02T12:00:00.000Z",
     });
+    assert.equal(cell.status().causeClass, "data-shape");
     const binding = { actor, source };
     const preview = (await cell.run({ kind: "relation-events-migrate", dryRun: true }, binding)) as Record<
       string,
@@ -175,6 +185,115 @@ test("relation_created history in the pre-derived-strength shape cold-rebuilds o
     );
 
     const repeat = (await cell.run({ kind: "relation-events-migrate" }, binding)) as Record<string, unknown>;
+    assert.equal(repeat.outcome, "pending");
+    assert.equal((JSON.parse(String(repeat.evidence)) as { rewrittenEvents: number }).rewrittenEvents, 0);
+  } finally {
+    await cell?.close?.();
+    rmSync(scratch, { recursive: true, force: true });
+  }
+});
+
+test("historical schedule targets cold-rebuild only after `migrate schedule-definitions`", async () => {
+  const scratch = mkdtempSync(path.join(tmpdir(), "ha-schedule-definitions-")),
+    repoId = "schedule-definition-fixture";
+  let cell: Awaited<ReturnType<typeof openRepoCell>> | undefined;
+  try {
+    initRepo(scratch);
+    const store = makeTaskEventStore({ repoId, rootDir: scratch }),
+      schedule = createScheduleV1({
+        scheduleId: "legacy-schedule",
+        name: "Legacy schedule",
+        mode: "detect",
+        spec: {
+          mission: "Exercise the historical target shape.",
+          trigger: { kind: "interval", everyMs: 60_000, anchorAt: "2026-09-01T00:00:00.000Z" },
+          target: { kind: "agent", agentId: "worker", runtimeInstanceId: "codex" },
+        },
+        actor,
+        occurredAt: "2026-09-01T00:00:00.000Z",
+      }),
+      compiled = compileScheduleDefinitionEvent({
+        type: "schedule_created",
+        schedule,
+        eventId: "event-legacy-schedule",
+        opId: "op-legacy-schedule",
+        workspaceRevision: 1,
+        actor,
+        source,
+        occurredAt: "2026-09-01T00:00:00.000Z",
+      });
+    store.append(compiled);
+    await store.settlePendingMaterialization?.("fixture");
+    const layout = store.layout(),
+      legacyTarget = { ...schedule.spec.target, cwd: ".worktrees/legacy" },
+      legacySchedule = { ...schedule, spec: { ...schedule.spec, target: legacyTarget } },
+      legacyDefinition = { ...definitionOf(schedule), spec: { ...schedule.spec, target: legacyTarget } },
+      legacyBody = `${JSON.stringify(legacyDefinition, null, 2)}\n`,
+      legacySha = sha256Text(legacyBody),
+      legacyClaim = {
+        ...compiled.event.payload.declarationDocumentClaim,
+        sha256: legacySha,
+        size: Buffer.byteLength(legacyBody),
+      },
+      legacyEvent = {
+        ...compiled.event,
+        payload: { schedule: legacySchedule, declarationDocumentClaim: legacyClaim },
+      };
+    const legacyBlobPath = path.join(scratch, "harness", contentObjectRelativePath(legacySha, layout));
+    mkdirSync(path.dirname(legacyBlobPath), { recursive: true });
+    writeFileSync(legacyBlobPath, legacyBody);
+    writeFileSync(
+      path.join(scratch, "harness", eventObjectRelativePath(compiled.event.opId, layout)),
+      `${sortedJson(legacyEvent)}\n`,
+    );
+    execFileSync("git", ["-C", scratch, "add", "harness"]);
+    execFileSync("git", ["-C", scratch, "commit", "-qm", "legacy schedule shape"]);
+    execFileSync("git", ["-C", scratch, "update-ref", "refs/ha/canonical", "HEAD"]);
+    await store.drain();
+
+    const coldPath = path.join(scratch, ".harness/cache/cold-schedule.sqlite"),
+      cold = () =>
+        makeTaskProjection({
+          rootDir: scratch,
+          eventStore: makeTaskEventReader({ repoId, rootDir: scratch }),
+          projectionPath: coldPath,
+        });
+    assert.throws(() => cold().rebuild(), /does not match the event definition facet/u);
+
+    cell = await openRepoCell({
+      repoId: workspaceId(repoId),
+      rootDir: canonicalRoot(scratch),
+      ownerId: "event-shape-test",
+      now: () => "2026-09-02T12:00:00.000Z",
+    });
+    assert.equal(cell.status().causeClass, "data-shape");
+    const binding = { actor, source },
+      preview = (await cell.run({ kind: "schedule-definitions-migrate", dryRun: true }, binding)) as Record<
+        string,
+        unknown
+      >;
+    assert.equal(preview.outcome, "pending", JSON.stringify(preview));
+    const previewReport = JSON.parse(String(preview.evidence)) as { readonly rewrittenEvents: number };
+    assert.equal(previewReport.rewrittenEvents, 1);
+
+    const applied = (await cell.run({ kind: "schedule-definitions-migrate" }, binding)) as Record<string, unknown>;
+    assert.equal(applied.outcome, "applied", JSON.stringify(applied));
+    assert.equal(cell.status().state, "attached");
+    const rebuilt = cold().rebuild();
+    assert.equal(rebuilt.watermark, applied.revision);
+    const migratedStore = makeTaskEventReader({ repoId, rootDir: scratch }),
+      migrated = migratedStore
+        .read()
+        .events.find((event) => event.opId === compiled.event.opId)! as typeof compiled.event,
+      claim = migrated.payload.declarationDocumentClaim,
+      blob = migratedStore.readContentBlob(claim.sha256);
+    assert.ok(blob);
+    const value = JSON.parse(new TextDecoder().decode(blob));
+    assert.deepEqual(validateScheduleV1({ ...value, status: migrated.payload.schedule.status }), []);
+    assert.equal(Object.hasOwn(migrated.payload.schedule.spec.target, "cwd"), false);
+    assert.deepEqual(value, definitionOf(migrated.payload.schedule));
+
+    const repeat = (await cell.run({ kind: "schedule-definitions-migrate" }, binding)) as Record<string, unknown>;
     assert.equal(repeat.outcome, "pending");
     assert.equal((JSON.parse(String(repeat.evidence)) as { rewrittenEvents: number }).rewrittenEvents, 0);
   } finally {

--- a/packages/kernel/src/domain/default-policy.ts
+++ b/packages/kernel/src/domain/default-policy.ts
@@ -43,6 +43,7 @@ const repositoryWriteActions = Object.freeze([
   "preset-upgrade",
   "projection-rebuild",
   "relation-events-migrate",
+  "schedule-definitions-migrate",
   "runtime-batch",
   "runtime-cancel",
   "runtime-instance-login",

--- a/packages/kernel/src/projection/rebuildable-task-projection-event-application.ts
+++ b/packages/kernel/src/projection/rebuildable-task-projection-event-application.ts
@@ -31,7 +31,7 @@ import { isVerticalDeclarationEvent } from "../domain/vertical-declaration.ts";
 import { isPeopleEvent } from "../domain/people-event.ts";
 import { isCiRunObservationEvent } from "../domain/ci-run-observation-event.ts";
 import { parsePeopleRosterDocument } from "../domain/people-roster.ts";
-import { scheduleDefinition, validateScheduleDefinitionV1 } from "../domain/schedule.ts";
+import { validateScheduleDefinitionV1 } from "../domain/schedule.ts";
 import { sha256Text } from "../integrity/stable-hash.ts";
 import { refreshDecisionDocumentSearch } from "./decision-event-projection.ts";
 import { refreshTaskRelationProjection } from "./task-query-projection.ts";
@@ -221,10 +221,7 @@ export function applyEvent(
       } catch {
         throw new Error(`schedule definition blob ${claim.sha256} is not JSON`);
       }
-      if (
-        validateScheduleDefinitionV1(value).length > 0 ||
-        canonicalJson(value) !== canonicalJson(scheduleDefinition(event.payload.schedule))
-      )
+      if (validateScheduleDefinitionV1(value).length > 0)
         throw new Error(`schedule definition blob ${claim.sha256} does not match the event definition facet`);
       const document: DocumentState = {
         path: claim.path as DocumentState["path"],

--- a/packages/kernel/src/projection/rebuildable-task-projection-event-application.ts
+++ b/packages/kernel/src/projection/rebuildable-task-projection-event-application.ts
@@ -31,7 +31,7 @@ import { isVerticalDeclarationEvent } from "../domain/vertical-declaration.ts";
 import { isPeopleEvent } from "../domain/people-event.ts";
 import { isCiRunObservationEvent } from "../domain/ci-run-observation-event.ts";
 import { parsePeopleRosterDocument } from "../domain/people-roster.ts";
-import { validateScheduleDefinitionV1 } from "../domain/schedule.ts";
+import { scheduleDefinition, validateScheduleDefinitionV1 } from "../domain/schedule.ts";
 import { sha256Text } from "../integrity/stable-hash.ts";
 import { refreshDecisionDocumentSearch } from "./decision-event-projection.ts";
 import { refreshTaskRelationProjection } from "./task-query-projection.ts";
@@ -221,7 +221,10 @@ export function applyEvent(
       } catch {
         throw new Error(`schedule definition blob ${claim.sha256} is not JSON`);
       }
-      if (validateScheduleDefinitionV1(value).length > 0)
+      if (
+        validateScheduleDefinitionV1(value).length > 0 ||
+        canonicalJson(value) !== canonicalJson(scheduleDefinition(event.payload.schedule))
+      )
         throw new Error(`schedule definition blob ${claim.sha256} does not match the event definition facet`);
       const document: DocumentState = {
         path: claim.path as DocumentState["path"],

--- a/packages/kernel/src/store/event-shape-migration.ts
+++ b/packages/kernel/src/store/event-shape-migration.ts
@@ -57,11 +57,10 @@ export interface EventShapeRewrite {
 export type EventShapeCut = Pick<TaskProjection, "readEntityVersionWitness" | "readDecisionDocumentState">;
 export interface EventShapeMigrationSpec {
   readonly name: EventShapeMigrationName;
-  // Pure on the event: true for every event this migration may rewrite.
+  // Pure on the event: true for every event whose `rewrite` reads the cut. Only these are replayed
+  // one revision at a time; every other event is rewritten inside bulk rounds, so a rewrite may
+  // touch `cut` only when `matches` is true for that event.
   readonly matches: (event: CanonicalEventV1) => boolean;
-  // Override when matching rewrites do not read the projection cut and can stay in bulk rounds.
-  // Existing migrations default to `matches` so their cut semantics remain unchanged.
-  readonly requiresCut?: (event: CanonicalEventV1) => boolean;
   readonly rewrite: (event: CanonicalEventV1, cut: EventShapeCut) => EventShapeRewrite | null;
 }
 export interface EventShapeMigrationInput {
@@ -168,6 +167,10 @@ const decisionDigestsMigration: EventShapeMigrationSpec = {
   },
 };
 
+// This migration owns exactly one historical break: `spec.target.cwd` (removed in 272de6d16).
+// Any other field the current target schema does not declare is a new break that needs its own
+// migration, so it is reported instead of being silently absorbed here.
+const RETIRED_SCHEDULE_TARGET_FIELDS: ReadonlySet<string> = new Set(["cwd"]);
 const scheduleTargetFields = new Set(
   Object.keys(
     (
@@ -195,21 +198,27 @@ function legacyScheduleDefinition(event: CanonicalEventV1): {
     candidateClaim && typeof candidateClaim.sha256 === "string" && typeof candidateClaim.size === "number"
       ? (candidateClaim as { readonly sha256: string; readonly size: number })
       : null;
-  return Object.keys(target).some((field) => !scheduleTargetFields.has(field))
-    ? { schedule: schedule as never, claim }
-    : null;
+  const unknown = Object.keys(target).filter((field) => !scheduleTargetFields.has(field)),
+    foreign = unknown.filter((field) => !RETIRED_SCHEDULE_TARGET_FIELDS.has(field));
+  if (foreign.length > 0)
+    throw new Error(
+      `schedule ${schedule.scheduleId} target carries fields this migration does not own: ${foreign.join(", ")}`,
+    );
+  return unknown.length > 0 ? { schedule: schedule as never, claim } : null;
 }
 
 const scheduleDefinitionsMigration: EventShapeMigrationSpec = {
   name: "schedule-definitions",
-  matches: (event) => legacyScheduleDefinition(event) !== null,
-  requiresCut: () => false,
+  // The rewrite never reads the cut, so every schedule event stays in bulk rounds.
+  matches: () => false,
   rewrite: (event) => {
     const legacy = legacyScheduleDefinition(event);
     if (legacy === null) return null;
     const target = legacy.schedule.spec.target,
-      removed = Object.keys(target).filter((field) => !scheduleTargetFields.has(field)),
-      nextTarget = Object.fromEntries(Object.entries(target).filter(([field]) => scheduleTargetFields.has(field))),
+      removed = Object.keys(target).filter((field) => RETIRED_SCHEDULE_TARGET_FIELDS.has(field)),
+      nextTarget = Object.fromEntries(
+        Object.entries(target).filter(([field]) => !RETIRED_SCHEDULE_TARGET_FIELDS.has(field)),
+      ),
       schedule = { ...legacy.schedule, spec: { ...legacy.schedule.spec, target: nextTarget } } as unknown as ScheduleV1,
       definition = scheduleDefinition(schedule),
       body = serializeEntityJsonSchema(SCHEDULE_DEFINITION_V1_SCHEMA, definition, "schedule definition");
@@ -383,9 +392,7 @@ function replayRewrites(
   const nextCap = (): number => {
     fill();
     if (pending.length === 0) return headRevision;
-    const candidate = pending.findIndex((event) =>
-        migrations.some((migration) => (migration.requiresCut ?? migration.matches)(event)),
-      ),
+    const candidate = pending.findIndex((event) => migrations.some((migration) => migration.matches(event))),
       count = candidate === 0 ? 1 : Math.min(candidate === -1 ? pending.length : candidate, BULK_ROUND_LIMIT);
     return pending[count - 1]!.workspaceRevision;
   };

--- a/packages/kernel/src/store/event-shape-migration.ts
+++ b/packages/kernel/src/store/event-shape-migration.ts
@@ -15,15 +15,24 @@ import {
   type MigrationImportEventV1,
 } from "../domain/migration-import-event.ts";
 import { normalizeLegacyRelationState } from "../domain/entity-relation.ts";
+import { serializeEntityJsonSchema, type EntityJsonObjectSchema } from "../domain/entity-json-schema.ts";
+import {
+  SCHEDULE_DEFINITION_V1_SCHEMA,
+  scheduleDefinition,
+  validateScheduleDefinitionV1,
+  type ScheduleV1,
+} from "../domain/schedule.ts";
 import type { WriteReceiptDraft } from "../domain/receipt-domain-registry.ts";
 import { isRelationEvent } from "../domain/relation-event.ts";
 import { sha256Text } from "../integrity/stable-hash.ts";
 import { localRuntimeStateFileSystem } from "../local/local-layout-file-system.ts";
-import { eventObjectRelativePath } from "../layout/ledger-object-layout.ts";
+import { contentObjectRelativePath, eventObjectRelativePath } from "../layout/ledger-object-layout.ts";
 import { makeTaskProjection } from "../projection/rebuildable-task-projection-factory.ts";
+import { canonicalJson } from "../projection/rebuildable-task-projection-sql.ts";
 import type { TaskProjection } from "../projection/task-projection-port.ts";
 import { ledgerGitPath, resolveLedgerGitLayout } from "./ledger-git-layout.ts";
-import type { CanonicalEventStore, PublicationFile } from "./task-event-store-types.ts";
+import { contentClaims } from "./task-event-store-claims-layout.ts";
+import type { CanonicalContentBlob, CanonicalEventStore, PublicationFile } from "./task-event-store-types.ts";
 
 // One-shot history upcasts. A migrating replay walks the ledger into a scratch projection:
 // candidates (`matches`) are replayed alone so each is rewritten against the projection state at
@@ -33,10 +42,14 @@ import type { CanonicalEventStore, PublicationFile } from "./task-event-store-ty
 // shape `fact-rekey` uses, so the ledger head and commit are produced by the store. The live
 // projection is left alone: every rewrite is, by construction, what the projection already
 // derived, so it only has to catch up the marker. Cold rebuilds are proved separately.
-export type EventShapeMigrationName = "relation-events" | "decision-digests";
-export type EventShapeMigrationKind = "relation-events-migrate" | "decision-digests-migrate";
+export type EventShapeMigrationName = "relation-events" | "decision-digests" | "schedule-definitions";
+export type EventShapeMigrationKind =
+  | "relation-events-migrate"
+  | "decision-digests-migrate"
+  | "schedule-definitions-migrate";
 export interface EventShapeRewrite {
   readonly event: CanonicalEventV1;
+  readonly blobs?: readonly CanonicalContentBlob[];
   readonly category: string;
   readonly before: unknown;
   readonly after: unknown;
@@ -44,10 +57,11 @@ export interface EventShapeRewrite {
 export type EventShapeCut = Pick<TaskProjection, "readEntityVersionWitness" | "readDecisionDocumentState">;
 export interface EventShapeMigrationSpec {
   readonly name: EventShapeMigrationName;
-  // Pure on the event: true for every event whose `rewrite` reads the cut. Only these are replayed
-  // one revision at a time; every other event is rewritten inside bulk rounds, so a rewrite may
-  // touch `cut` only when `matches` is true for that event.
+  // Pure on the event: true for every event this migration may rewrite.
   readonly matches: (event: CanonicalEventV1) => boolean;
+  // Override when matching rewrites do not read the projection cut and can stay in bulk rounds.
+  // Existing migrations default to `matches` so their cut semantics remain unchanged.
+  readonly requiresCut?: (event: CanonicalEventV1) => boolean;
   readonly rewrite: (event: CanonicalEventV1, cut: EventShapeCut) => EventShapeRewrite | null;
 }
 export interface EventShapeMigrationInput {
@@ -154,9 +168,84 @@ const decisionDigestsMigration: EventShapeMigrationSpec = {
   },
 };
 
+const scheduleTargetFields = new Set(
+  Object.keys(
+    (
+      (SCHEDULE_DEFINITION_V1_SCHEMA.properties.spec as EntityJsonObjectSchema).properties
+        .target as EntityJsonObjectSchema
+    ).properties,
+  ),
+);
+
+function legacyScheduleDefinition(event: CanonicalEventV1): {
+  readonly schedule: ScheduleV1 & { readonly spec: { readonly target: Readonly<Record<string, unknown>> } };
+  readonly claim: { readonly sha256: string; readonly size: number } | null;
+} | null {
+  if (event.schema !== "schedule-event/v1") return null;
+  const payload = event.payload as unknown as Readonly<Record<string, unknown>>,
+    schedule = payload.schedule as ScheduleV1 & {
+      readonly spec?: { readonly target?: Readonly<Record<string, unknown>> };
+    },
+    candidateClaim = payload.declarationDocumentClaim as
+      | { readonly sha256?: unknown; readonly size?: unknown }
+      | undefined,
+    target = schedule?.spec?.target;
+  if (!target) return null;
+  const claim =
+    candidateClaim && typeof candidateClaim.sha256 === "string" && typeof candidateClaim.size === "number"
+      ? (candidateClaim as { readonly sha256: string; readonly size: number })
+      : null;
+  return Object.keys(target).some((field) => !scheduleTargetFields.has(field))
+    ? { schedule: schedule as never, claim }
+    : null;
+}
+
+const scheduleDefinitionsMigration: EventShapeMigrationSpec = {
+  name: "schedule-definitions",
+  matches: (event) => legacyScheduleDefinition(event) !== null,
+  requiresCut: () => false,
+  rewrite: (event) => {
+    const legacy = legacyScheduleDefinition(event);
+    if (legacy === null) return null;
+    const target = legacy.schedule.spec.target,
+      removed = Object.keys(target).filter((field) => !scheduleTargetFields.has(field)),
+      nextTarget = Object.fromEntries(Object.entries(target).filter(([field]) => scheduleTargetFields.has(field))),
+      schedule = { ...legacy.schedule, spec: { ...legacy.schedule.spec, target: nextTarget } } as unknown as ScheduleV1,
+      definition = scheduleDefinition(schedule),
+      body = serializeEntityJsonSchema(SCHEDULE_DEFINITION_V1_SCHEMA, definition, "schedule definition");
+    if (
+      validateScheduleDefinitionV1(JSON.parse(body)).length > 0 ||
+      canonicalJson(JSON.parse(body)) !== canonicalJson(definition)
+    )
+      throw new Error(`schedule ${schedule.scheduleId} migration did not produce its exact definition facet`);
+    const sha256 = sha256Text(body),
+      claim = legacy.claim
+        ? {
+            ...(event.payload as { readonly declarationDocumentClaim: Readonly<Record<string, unknown>> })
+              .declarationDocumentClaim,
+            sha256,
+            size: Buffer.byteLength(body),
+          }
+        : null,
+      payload = {
+        ...event.payload,
+        schedule,
+        ...(claim ? { declarationDocumentClaim: claim } : {}),
+      };
+    return {
+      event: { ...event, payload } as CanonicalEventV1,
+      blobs: claim ? [{ sha256, size: claim.size, mediaType: "application/json", body }] : [],
+      category: `schedule target fields dropped: ${removed.join(", ")}`,
+      before: { target, declarationDocumentClaim: legacy.claim },
+      after: { target: nextTarget, declarationDocumentClaim: claim },
+    };
+  },
+};
+
 export const eventShapeMigrations: Readonly<Record<EventShapeMigrationKind, EventShapeMigrationSpec>> = {
   "relation-events-migrate": relationEventsMigration,
   "decision-digests-migrate": decisionDigestsMigration,
+  "schedule-definitions-migrate": scheduleDefinitionsMigration,
 };
 
 export async function runEventShapeMigration(
@@ -199,6 +288,10 @@ export async function runEventShapeMigration(
   for (const rewrite of rewrites) {
     const target = ledgerGitPath(ledger, eventObjectRelativePath(rewrite.event.opId, eventLayout));
     additional.set(target, { target, body: serializePersistedCanonicalEvent(rewrite.event), mode: "100644" });
+    for (const blob of rewrite.blobs ?? []) {
+      const blobTarget = ledgerGitPath(ledger, contentObjectRelativePath(blob.sha256, eventLayout));
+      additional.set(blobTarget, { target: blobTarget, body: blob.body, mode: "100644" });
+    }
   }
   const marker: MigrationImportEventV1 = {
     schema: "migration-import-event/v1",
@@ -262,7 +355,8 @@ function replayRewrites(
 ): readonly EventShapeRewrite[] {
   const rewrites: EventShapeRewrite[] = [],
     scratchPath = path.join(tmpdir(), `ha-${spec.name}-${process.pid}-${Date.now()}.sqlite`),
-    pending: CanonicalEventV1[] = [];
+    pending: CanonicalEventV1[] = [],
+    syntheticBlobs = new Map<string, Uint8Array>();
   let cap = 0,
     cursor: string | null = null,
     exhausted = false,
@@ -289,7 +383,9 @@ function replayRewrites(
   const nextCap = (): number => {
     fill();
     if (pending.length === 0) return headRevision;
-    const candidate = pending.findIndex((event) => migrations.some((migration) => migration.matches(event))),
+    const candidate = pending.findIndex((event) =>
+        migrations.some((migration) => (migration.requiresCut ?? migration.matches)(event)),
+      ),
       count = candidate === 0 ? 1 : Math.min(candidate === -1 ? pending.length : candidate, BULK_ROUND_LIMIT);
     return pending[count - 1]!.workspaceRevision;
   };
@@ -306,6 +402,7 @@ function replayRewrites(
             const rewrite = migration.rewrite(current, projection!);
             if (rewrite === null) continue;
             if (migration === spec) rewrites.push(rewrite);
+            for (const blob of rewrite.blobs ?? []) syntheticBlobs.set(blob.sha256, Buffer.from(blob.body));
             current = rewrite.event;
           }
           return current;
@@ -316,10 +413,16 @@ function replayRewrites(
         cursor: null,
         done: true,
         accessedItems: events.length,
-        ...(prefetchContent ? { prefetchContent } : {}),
+        prefetchContent: (replay: readonly CanonicalEventV1[]) => {
+          const persisted = replay.filter((event) =>
+              contentClaims(event).every((claim) => !syntheticBlobs.has(claim.sha256)),
+            ),
+            content = new Map([...(prefetchContent?.(persisted) ?? []), ...syntheticBlobs]);
+          return content;
+        },
       };
     },
-    readContentBlob: (sha256: string) => input.store.readContentBlob(sha256),
+    readContentBlob: (sha256: string) => syntheticBlobs.get(sha256) ?? input.store.readContentBlob(sha256),
   };
   projection = makeTaskProjection({
     rootDir: input.rootDir,

--- a/packages/kernel/test/contracts/authorization-port.test.ts
+++ b/packages/kernel/test/contracts/authorization-port.test.ts
@@ -49,7 +49,8 @@ test("the default Policy covers the frozen durable inventory exactly once", () =
   // 2026-09-03 W1-F:center-only Squad migration 进入 durable inventory(CEO 已裁 cutover),110 → 111。
   // 2026-09-05:声明实体 update / archive 进入 durable inventory(CEO 已确认),111 → 113。
   // 2026-09-05:vertical declaration migrate / kind upsert / kind retire 进入 durable inventory,113 → 116。
-  assert.equal(durablePolicyActions.length, 116);
+  // 2026-09-05:schedule-definitions-migrate 修复存量 schedule 声明形状,116 → 117。
+  assert.equal(durablePolicyActions.length, 117);
   // 其余两条是自洽不变量,不需要第二个硬编码数字:清单内无重复(三个角色分段互不重叠),
   // 且每个 durable Action 恰好被一条 rule 覆盖。
   assert.equal(new Set(durablePolicyActions).size, durablePolicyActions.length);

--- a/tools/offline-projection-rebuild.mjs
+++ b/tools/offline-projection-rebuild.mjs
@@ -1,0 +1,31 @@
+#!/usr/bin/env node
+// Rebuild a repository's task projection offline, from its ledger only, without any daemon.
+// Run it against a COPY of the repository before a daemon generation change: a rebuild that throws here
+// is exactly the data-shape latch the new daemon would raise on attach.
+//   node --experimental-strip-types tools/offline-projection-rebuild.mjs <repo-root> [repo-id]
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+const [, , repoRootArg, repoId = "canonical"] = process.argv;
+if (!repoRootArg) {
+  console.error("usage: node --experimental-strip-types tools/offline-projection-rebuild.mjs <repo-root> [repo-id]");
+  process.exit(2);
+}
+const repoRoot = path.resolve(repoRootArg),
+  kernelRoot = path.resolve(path.dirname(new URL(import.meta.url).pathname), ".."),
+  kernel = await import(pathToFileURL(path.join(kernelRoot, "packages/kernel/src/index.ts")).href),
+  eventStore = kernel.makeTaskEventReader({ repoId, rootDir: repoRoot }),
+  head = eventStore.readHead(),
+  projection = kernel.makeTaskProjection({ rootDir: repoRoot, eventStore });
+try {
+  const receipt = projection.rebuild();
+  console.log(
+    `offline-projection-rebuild: ok repo=${repoId} head=${head?.revision ?? 0} watermark=${receipt.watermark}`,
+  );
+} catch (error) {
+  console.error(`offline-projection-rebuild: FAILED repo=${repoId} head=${head?.revision ?? 0}`);
+  console.error(String(error instanceof Error ? error.message : error));
+  process.exitCode = 1;
+} finally {
+  projection.close();
+}


### PR DESCRIPTION
# English

## Summary

`ha migrate schedule-definitions [--dry-run]`: a one-shot history migration that removes the retired `spec.target.cwd` field from every stored `schedule-event/v1` (definition and run snapshots) and re-serializes the six schedule definition blobs it names, so a cold projection rebuild passes the current strict `ScheduleDefinition/v1` schema again. This is the fix for the canonical ledger's data-shape latch (`schedule definition blob 6f68c223… does not match the event definition facet`) under dec_558977E9: history migrates, no replay tolerance.

## Architectural Justification

- Reuses the existing event-shape migration engine (`event-shape-migration.ts`), CLI route, Migration-A descriptor, authorization / default policy, and data-shape latch exemption; the only engine extension is `EventShapeRewrite.blobs` so a rewrite can publish regenerated content objects through the same atomic publication (and the scratch replay resolves those synthetic blobs before they are durable).
- The migration owns exactly one historical break (`cwd`, removed in 272de6d16). Any other undeclared target field is reported, not absorbed, so the next schema tightening needs its own migration name.
- `matches` keeps its original meaning (does the rewrite read the cut); this rewrite never does, so it declares `matches: () => false` and stays in bulk rounds. No new switch.
- The schedule blob-vs-facet byte equality in the projection stays: the rewritten blob is serialized from the same definition, so the invariant still holds and keeps "valid but different" blobs out.
- The dispatcher now looks migrations up in `eventShapeMigrations` instead of listing every kind (repo-cell-action-dispatch.ts 553 lines, under its shrink-only baseline).
- `tools/offline-projection-rebuild.mjs` (kernel API, no daemon) is how a ledger copy is proved red → green before the migration touches canonical.

## Fleet / centralized-ledger view

- The migration is a canonical write: it runs only through the center's single-writer queue under the repo's writer epoch fence, and is idempotent (a second run rewrites nothing and appends no marker). Edges never migrate history; concurrent requests from several edges serialize at the center and only the first one publishes.
- Rewriting history invalidates every derived cache built on the old bytes. Warm replica cuts are the proven case: Astra reproduced `replica manifest drift at revision 42615` when an existing replica cut store tried to apply the migration's marker incrementally, while an empty cut store snapshotted the same basis successfully. Rollout therefore removes canonical's derived replica store (`<localRoot>/replica/repos/<repoId>/cuts.sqlite` and its manifests) after the migration so edges take the existing `snapshot_required` path, and runs a projection rebuild + daemon restart before the repo is served again.

## What Changed

- kernel: `scheduleDefinitionsMigration` spec; `EventShapeRewrite.blobs` + synthetic blob resolution in the scratch replay; migration name/kind unions.
- daemon: command descriptor, recovery-state policy (`data-shape`, settles latch), authorization, default policy, dispatcher table lookup.
- cli: `migrate schedule-definitions` route.
- tests: `event-shape-migration.integration.test.ts` (old-cwd event + blob → rebuild red; dry-run 1; apply → rebuild green; blob strict shape; second run 0; latch → attached), thin-command, authorization-port.
- tools: `offline-projection-rebuild.mjs`.

## Governance Declaration

- Protected surface touched: `tools/gate-manifest`-governed paths under `tools/` (new `tools/offline-projection-rebuild.mjs`, a kernel-API offline rebuild runner used to prove a ledger copy red → green; no gate, allowlist, or CI configuration is changed) and the daemon authorization / default-policy registration of the new `schedule-definitions-migrate` action, which reuses the generic `authorizeRepoCellAction` path with no wider grant than the existing `relation-events-migrate`.
- Authorizing decision: dec_558977E9 (historical data migrates; no replay tolerance). Task: task_803b56b360f30e39197f57ae3b (canonical-event-compat / migration enforcement).
- No gate was weakened or removed; no break-glass used.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates: none

## Verification

- Ubuntu VM isolated: `event-shape-migration.integration.test.ts` 6/6; thin-command 18/18; authorization-port 7/7 (Sol, commit 689194277).
- Locally on HEAD: tsc (kernel/daemon/cli) 0; import-boundaries, canonical-event-compat (172 samples / 18 schemas), duplicate-definitions, durable-action-authorization (0/122 missing), G0-5, G36 pass; `event-shape-migration.integration.test.ts` 6/6 after the CEO commits.
- Canonical ledger copy (59,504 events), independent CEO run: offline rebuild before = FAILED on blob 6f68c223…; dry-run 36 rewrites (all `schedule target fields dropped: cwd`); apply → revision 59,505, 36 rewrites; second run 0; offline rebuild after = `ok head=59505 watermark=59505`. Run 1 used the worker commit; the migrated copy was then cold-rebuilt again with the HEAD kernel (equality check restored) and stayed green. Run 2 (HEAD code end-to-end, commit 7054224c4 before the rebase onto 70b633d3) reproduced it exactly: FAILED → dry-run 36 → applied 59,505 → second run 0 → `ok head=59505 watermark=59505`; `git diff <pristine cut>..refs/ha/canonical -- events` on the migrated copy touches exactly the 36 schedule events Astra enumerated (plus the marker and head), 36/36.
- Independent blind audit (Astra, gpt-6-astra) of the three affected ledger copies: 59,989 events scanned, exactly 3 latch families / 39 events, no fourth; schedule family = 36 events / 6 blobs in canonical only. Its review of the worker diff produced one blocking finding (the deleted equality check) and two simplifications; all three are applied in this PR.
- `check:local` not run.

## Review Evidence

- Worker report: scratch `report-schedule-definitions-migrate.md` (moves into the task packet once the ledger is writable).
- Blind review: Astra `report-latch-family-plan.md` §对 Sol 方案的评审 (7 items: 1/2/6 applied here; 3/4/5/7 listed below).

## Residual Risk

- Engine gaps that predate this PR and that this migration inherits: `applied` settles the latch without rebuilding the live projection, and the scratch replay runs every registered spec while publishing only the selected one. Both are harmless for the three affected ledgers (one family each) but must be closed before a mixed-family ledger is migrated; rollout therefore runs a projection rebuild and a daemon restart right after the migration.
- The migration reads the event payload, not the old blob: a ledger whose payload is already clean but whose blob still carries `cwd` would not match. No such ledger exists among the three copies.
- Historical rewrite invalidates warm replica cuts (Astra reproduced `replica manifest drift`); rollout invalidates canonical's derived cuts so edges take the snapshot path.
- self-representation (`walFlush`) needs the follow-up `settings-wal-flush` migration; zeyu-ai-brain uses the existing `relation-events` migration.


---

# 中文

## 摘要

`ha migrate schedule-definitions [--dry-run]`:一次性历史迁移,从所有已存 `schedule-event/v1`(定义与 run 快照)删除已退役字段 `spec.target.cwd`,并重新序列化它们指向的 6 个 schedule 定义 blob,使冷重建重新通过当前严格的 `ScheduleDefinition/v1` schema。这是 canonical 台账 data-shape latch(`schedule definition blob 6f68c223… does not match the event definition facet`)在 dec_558977E9 下的修法:历史走迁移,不做重放容忍。

## 架构辩护

- 复用既有 event-shape 迁移引擎、CLI 路由、Migration-A 描述符、授权/默认策略与 data-shape latch 豁免;引擎唯一扩展是 `EventShapeRewrite.blobs`,让改写能经同一原子发布落新内容对象(scratch 重放在落盘前解析这些合成 blob)。
- 迁移只拥有一个历史断裂(`cwd`,272de6d16 删除);其它未声明字段明确报错而不是被吸收,下一次收紧必须有自己的迁移名。
- `matches` 保持原义(rewrite 是否读 cut);本改写不读,声明 `matches: () => false` 留在 bulk 轮次,不加新开关。
- 投影里 schedule blob 与 facet 的字节等价检查保留:重写 blob 由同一 definition 序列化,不变量仍成立,并挡住「合法但指向另一个 definition」的 blob。
- dispatcher 改为在 `eventShapeMigrations` 表里查找,不再逐 kind 罗列(repo-cell-action-dispatch.ts 553 行,低于 shrink-only 基线)。
- `tools/offline-projection-rebuild.mjs`(kernel API,不经 daemon)是迁移碰 canonical 之前在副本上证明 红→绿 的工具。

## 中心化仓库视角

- 迁移是 canonical 写:只经中心单写队列、在该仓 writer epoch fence 内执行,且幂等(二跑零改写、不追加 marker)。边缘节点无权迁移历史;多个边缘同时请求在中心串行,只有第一次发布。
- 改写历史会使所有建立在旧字节上的派生缓存失效。warm replica cut 是实证:Astra 复现了已有 replica cut store 对本迁移 marker 做增量时报 `replica manifest drift at revision 42615`,而空 cut store 对同一 basis 生成 snapshot 成功。因此上线在迁移后删除 canonical 的派生 replica 存储(`<localRoot>/replica/repos/<repoId>/cuts.sqlite` 及其 manifests),让边缘走既有 `snapshot_required` 路径,并在重新服务前做 projection rebuild + daemon 重启。

## 变更内容

kernel 迁移 spec 与 blobs 扩展;daemon 描述符/恢复策略/授权/默认策略/表查找;cli 路由;集成测试(旧 cwd 事件+blob→重建红;dry-run 1;实跑→重建绿;blob 严格形状;二跑 0;latch→attached);离线重建工具。

## 治理声明

- 触碰的受保护面:`tools/` 下受 gate-manifest 治理的路径(新增 `tools/offline-projection-rebuild.mjs`,kernel API 离线重建器,用于在副本上证明 红→绿;不改任何门、allowlist 或 CI 配置)以及 daemon 授权/默认策略里对新动作 `schedule-definitions-migrate` 的登记,复用通用 `authorizeRepoCellAction`,授权面不比既有 `relation-events-migrate` 更宽。
- 授权决策:dec_558977E9(历史数据走迁移,不做重放容忍)。任务:task_803b56b360f30e39197f57ae3b(canonical-event-compat / 迁移执法面)。
- 未削弱或删除任何门;未使用 break-glass。

## 门收割

Deleted-Production-Paths: none
Deleted-Gates: none

## 验证

- Ubuntu VM 隔离 6/6、thin-command 18/18、authorization-port 7/7(Sol,689194277)。
- 本地 HEAD:tsc 0;import-boundaries、canonical-event-compat、duplicate-definitions、durable-action-authorization、G0-5、G36 过;CEO 三提交后集成测试 6/6。
- canonical 副本(59,504 事件)CEO 独立复跑:迁移前离线重建 FAILED(blob 6f68c223…);dry-run 36 条改写(全为 `cwd`);实跑 revision 59,505;二跑 0;迁移后重建 `ok head=59505 watermark=59505`。第一轮用 worker 提交跑;迁移后的副本再用 HEAD kernel(equality 检查在位)冷重建仍绿。第二轮(HEAD 代码端到端,rebase 前的 7054224c4)完全复现:FAILED → dry-run 36 → 实跑 59,505 → 二跑 0 → `ok head=59505 watermark=59505`;对迁移后副本做 `git diff <原始 cut>..refs/ha/canonical -- events`,改动恰为 Astra 枚举的 36 条 schedule 事件(外加 marker 与 head),36/36。
- Astra 盲审三份台账副本:59,989 事件,恰 3 家族 39 条、无第四家族;对 worker diff 一条阻断(删 equality)+ 两条简化,本 PR 全部采纳。
- 未跑 `check:local`。

## 评审证据

worker 报告 `report-schedule-definitions-migrate.md`;Astra `report-latch-family-plan.md` §对 Sol 方案的评审(7 条:1/2/6 已采纳,3/4/5/7 列入残余风险)。

## 残余风险

- 引擎既有缺口(本 PR 之前就在,本迁移继承):`applied` 直接清 latch 不重建 live projection;scratch 重放跑全部 spec 却只发布选中 spec。三个受影响台账各只一个家族所以无害,mixed-family 台账迁移前必须收口;上线因此在迁移后紧跟 projection rebuild 与 daemon 重启。
- 迁移读 payload 不读旧 blob:payload 已净、blob 仍带 cwd 的台账不会匹配;三份副本里不存在。
- 历史改写使 warm replica cut 失效(Astra 复现 `replica manifest drift`);上线时失效 canonical 派生 cuts,边缘走 snapshot 路径。
- self-representation(`walFlush`)需后续 `settings-wal-flush` 迁移;zeyu-ai-brain 用既有 `relation-events` 迁移。

Production-Delta: +170/-10
