### PR TITLE
feat(kernel,daemon,cli): ha migrate settings-wal-flush — fill the required walFlush into stored Settings history

### DIFF
--- a/packages/cli/src/cli/thin-command-router.ts
+++ b/packages/cli/src/cli/thin-command-router.ts
@@ -63,6 +63,7 @@ export function parseRouted(
     route.id === "relation-events-migrate" ||
     route.id === "decision-digests-migrate" ||
     route.id === "schedule-definitions-migrate" ||
+    route.id === "settings-wal-flush-migrate" ||
     route.id === "dispatch-records-migrate"
   ) {
     const f = readFlags(route.id, args.slice(2), inputs);

--- a/packages/cli/test/thin-command.test.ts
+++ b/packages/cli/test/thin-command.test.ts
@@ -191,6 +191,14 @@ test("dispatch record migration projects its dry-run flag into the daemon Action
   assert.deepEqual(parsed.command.action, { kind: "dispatch-records-migrate", dryRun: true });
 });
 
+test("settings WAL flush migration projects its dry-run flag into the daemon Action", () => {
+  const parsed = parseThinCommand(["migrate", "settings-wal-flush", "--dry-run"]);
+  assert.equal(parsed.ok, true);
+  if (!parsed.ok) return;
+  assert.equal(parsed.command.method, "repo.task.run");
+  assert.deepEqual(parsed.command.action, { kind: "settings-wal-flush-migrate", dryRun: true });
+});
+
 test("Squad migration projects legacy sources and dry-run into one center Action", () => {
   const parsed = parseThinCommand([
     "migrate",
@@ -276,6 +284,7 @@ test("capabilities is an exact-set projection of the command contract", () => {
       "migrate-import",
       "relation-events-migrate",
       "schedule-definitions-migrate",
+      "settings-wal-flush-migrate",
       "vertical-declaration-migrate",
     ],
     preset: [

--- a/packages/daemon/src/protocol/daemon-protocol-commands-agent.ts
+++ b/packages/daemon/src/protocol/daemon-protocol-commands-agent.ts
@@ -162,6 +162,16 @@ export const agentProtocolCommands = Object.freeze([
     inputs: [cliInput("--dry-run", "boolean", false, { code: "invalid_field" }, { field: "dryRun" })],
   }),
   defineLedgerWriteCommand({
+    id: "settings-wal-flush-migrate",
+    phase: "Migration-A",
+    path: ["migrate", "settings-wal-flush"],
+    summary:
+      "Fill the historical repository Settings walFlush snapshot with its declared default. " +
+      "Stop daemon writers first; --dry-run reports the rewrites.",
+    method: "repo.task.run",
+    inputs: [cliInput("--dry-run", "boolean", false, { code: "invalid_field" }, { field: "dryRun" })],
+  }),
+  defineLedgerWriteCommand({
     id: "dispatch-records-migrate",
     phase: "Migration-A",
     path: ["migrate", "dispatch-records"],

--- a/packages/daemon/src/recovery-state.ts
+++ b/packages/daemon/src/recovery-state.ts
@@ -16,6 +16,10 @@ const recoveryCommands: Readonly<Record<string, RecoveryCommandPolicy>> = Object
     causes: Object.freeze(["data-shape"] as const),
     settlesLatch: true,
   }),
+  "settings-wal-flush-migrate": Object.freeze({
+    causes: Object.freeze(["data-shape"] as const),
+    settlesLatch: true,
+  }),
   "receipt-show": Object.freeze({
     causes: Object.freeze(["data-shape", "infrastructure"] as const),
     settlesLatch: false,

--- a/packages/daemon/src/repo-cell-authorization.ts
+++ b/packages/daemon/src/repo-cell-authorization.ts
@@ -161,6 +161,8 @@ export function authorizeDurableRepoCellAction(
       return authorizeRepoCellAction(input);
     case "schedule-definitions-migrate":
       return authorizeRepoCellAction(input);
+    case "settings-wal-flush-migrate":
+      return authorizeRepoCellAction(input);
     case "fact-type-register":
       return authorizeRepoCellAction(input);
     case "ledger-migrate":

--- a/packages/daemon/test/event-shape-migration.integration.test.ts
+++ b/packages/daemon/test/event-shape-migration.integration.test.ts
@@ -9,13 +9,16 @@ import test from "node:test";
 import {
   canonicalEventWritePlan,
   compileScheduleDefinitionEvent,
+  compileSettingsChangedEvent,
   contentObjectRelativePath,
   createScheduleV1,
   deriveRelationId,
+  eventShapeMigrations,
   eventObjectRelativePath,
   makeTaskEventReader,
   makeTaskEventStore,
   makeTaskProjection,
+  readSettingsFacet,
   relationEventWritePlan,
   runDispatchRecordMigration,
   runtimeArchiveText,
@@ -92,6 +95,35 @@ function sortedJson(value: unknown): string {
 function definitionOf(schedule: ReturnType<typeof createScheduleV1>) {
   const { status: _status, ...definition } = schedule;
   return definition;
+}
+
+async function seedHistoricalSettingsEvent(rootDir: string, repoId: string, walFlush?: unknown) {
+  const body = readFileSync(path.join(rootDir, "harness/harness.yaml"), "utf8"),
+    store = makeTaskEventStore({ repoId, rootDir }),
+    compiled = compileSettingsChangedEvent({
+      settings: readSettingsFacet(body),
+      baseDocumentBody: body,
+      candidateDocumentBody: body,
+      eventId: "event-legacy-settings",
+      opId: "op-legacy-settings",
+      workspaceRevision: 1,
+      actor,
+      source,
+      occurredAt: "2026-09-01T00:00:00.000Z",
+    });
+  store.append(compiled);
+  await store.settlePendingMaterialization?.("fixture");
+  const eventPath = path.join(rootDir, "harness", eventObjectRelativePath(compiled.event.opId, store.layout())),
+    stored = JSON.parse(readFileSync(eventPath, "utf8")) as Record<string, unknown> & {
+      readonly payload: Record<string, unknown> & { readonly settings: Record<string, unknown> };
+    };
+  if (walFlush === undefined) delete stored.payload.settings.walFlush;
+  else stored.payload.settings.walFlush = walFlush;
+  writeFileSync(eventPath, `${sortedJson(stored)}\n`);
+  execFileSync("git", ["-C", rootDir, "commit", "-qam", "legacy settings shape"]);
+  execFileSync("git", ["-C", rootDir, "update-ref", "refs/ha/canonical", "HEAD"]);
+  await store.drain();
+  return { eventPath, stored };
 }
 
 test("relation_created history in the pre-derived-strength shape cold-rebuilds only after `migrate relation-events`", async () => {
@@ -187,6 +219,132 @@ test("relation_created history in the pre-derived-strength shape cold-rebuilds o
     const repeat = (await cell.run({ kind: "relation-events-migrate" }, binding)) as Record<string, unknown>;
     assert.equal(repeat.outcome, "pending");
     assert.equal((JSON.parse(String(repeat.evidence)) as { rewrittenEvents: number }).rewrittenEvents, 0);
+  } finally {
+    await cell?.close?.();
+    rmSync(scratch, { recursive: true, force: true });
+  }
+});
+
+test("historical Settings without walFlush cold-rebuild only after `migrate settings-wal-flush`", async () => {
+  const scratch = mkdtempSync(path.join(tmpdir(), "ha-settings-wal-flush-")),
+    repoId = "settings-wal-flush-fixture";
+  let cell: Awaited<ReturnType<typeof openRepoCell>> | undefined;
+  try {
+    initRepo(scratch);
+    const { stored: legacy } = await seedHistoricalSettingsEvent(scratch, repoId),
+      coldPath = path.join(scratch, ".harness/cache/cold-settings.sqlite"),
+      cold = () =>
+        makeTaskProjection({
+          rootDir: scratch,
+          eventStore: makeTaskEventReader({ repoId, rootDir: scratch }),
+          projectionPath: coldPath,
+        });
+    assert.throws(() => cold().rebuild(), /settings declaration is missing required field "walFlush"/u);
+
+    cell = await openRepoCell({
+      repoId: workspaceId(repoId),
+      rootDir: canonicalRoot(scratch),
+      ownerId: "event-shape-test",
+      now: () => "2026-09-02T12:00:00.000Z",
+    });
+    assert.equal(cell.status().causeClass, "data-shape");
+    const binding = { actor, source },
+      beforeHead = makeTaskEventReader({ repoId, rootDir: scratch }).readHead(),
+      preview = (await cell.run({ kind: "settings-wal-flush-migrate", dryRun: true }, binding)) as Record<
+        string,
+        unknown
+      >,
+      previewReport = JSON.parse(String(preview.evidence)) as {
+        readonly rewrittenEvents: number;
+        readonly categories: Record<string, number>;
+        readonly samples: readonly {
+          readonly before: Record<string, unknown>;
+          readonly after: Record<string, unknown>;
+        }[];
+      };
+    assert.equal(preview.outcome, "pending", JSON.stringify(preview));
+    assert.equal(previewReport.rewrittenEvents, 1);
+    assert.deepEqual(previewReport.categories, { "walFlush filled from declared/default settings": 1 });
+    assert.equal(previewReport.samples[0]?.before.walFlushPresent, false);
+    assert.deepEqual(previewReport.samples[0]?.after.walFlush, {
+      adaptive: true,
+      events: 256,
+      bytes: 8_388_608,
+      milliseconds: 3_600_000,
+    });
+    assert.deepEqual(makeTaskEventReader({ repoId, rootDir: scratch }).readHead(), beforeHead);
+
+    const applied = (await cell.run({ kind: "settings-wal-flush-migrate" }, binding)) as Record<string, unknown>;
+    assert.equal(applied.outcome, "applied", JSON.stringify(applied));
+    assert.equal(applied.revision, 2);
+    assert.equal(cell.status().state, "attached");
+    const projection = cold(),
+      rebuilt = projection.rebuild();
+    assert.equal(rebuilt.watermark, 2);
+    assert.deepEqual(projection.getEntity("settings", "repository")?.value.walFlush, {
+      adaptive: true,
+      events: 256,
+      bytes: 8_388_608,
+      milliseconds: 3_600_000,
+    });
+    projection.close();
+    assert.deepEqual(readSettingsFacet(readFileSync(path.join(scratch, "harness/harness.yaml"), "utf8")).walFlush, {
+      adaptive: true,
+      events: 256,
+      bytes: 8_388_608,
+      milliseconds: 3_600_000,
+    });
+    const migrated = makeTaskEventReader({ repoId, rootDir: scratch })
+        .read()
+        .events.find((event) => event.opId === "op-legacy-settings")! as unknown as typeof legacy,
+      { payload: legacyPayload, ...legacyEnvelope } = legacy,
+      { payload: migratedPayload, ...migratedEnvelope } = migrated,
+      { settings: legacySettings, ...legacyPayloadRest } = legacyPayload,
+      { settings: migratedSettings, ...migratedPayloadRest } = migratedPayload as typeof legacyPayload,
+      { walFlush: migratedWalFlush, ...migratedSettingsRest } = migratedSettings;
+    assert.deepEqual(migratedEnvelope, legacyEnvelope);
+    assert.deepEqual(migratedPayloadRest, legacyPayloadRest);
+    assert.deepEqual(migratedSettingsRest, legacySettings);
+    assert.deepEqual(migratedWalFlush, previewReport.samples[0]?.after.walFlush);
+
+    const repeat = (await cell.run({ kind: "settings-wal-flush-migrate" }, binding)) as Record<string, unknown>;
+    assert.equal(repeat.outcome, "pending");
+    assert.equal((JSON.parse(String(repeat.evidence)) as { rewrittenEvents: number }).rewrittenEvents, 0);
+    assert.equal(repeat.revision, 2);
+  } finally {
+    await cell?.close?.();
+    rmSync(scratch, { recursive: true, force: true });
+  }
+});
+
+test("settings WAL flush migration rejects a present malformed snapshot without overwriting it", async () => {
+  const scratch = mkdtempSync(path.join(tmpdir(), "ha-settings-wal-flush-invalid-")),
+    repoId = "settings-wal-flush-invalid";
+  let cell: Awaited<ReturnType<typeof openRepoCell>> | undefined;
+  try {
+    initRepo(scratch);
+    const { eventPath, stored: invalid } = await seedHistoricalSettingsEvent(scratch, repoId, { adaptive: true });
+    assert.throws(
+      () => eventShapeMigrations["settings-wal-flush-migrate"].rewrite(invalid as never, {} as never),
+      /walFlush is missing required field "events"/u,
+    );
+    cell = await openRepoCell({
+      repoId: workspaceId(repoId),
+      rootDir: canonicalRoot(scratch),
+      ownerId: "event-shape-test",
+      now: () => "2026-09-02T12:00:00.000Z",
+    });
+    assert.equal(cell.status().causeClass, "data-shape");
+    const rejected = await cell.run({ kind: "settings-wal-flush-migrate" }, { actor, source });
+    assert.equal(rejected.outcome, "op_rejected", JSON.stringify(rejected));
+    assert.match(JSON.stringify(rejected), /settings event envelope or payload is invalid/u);
+    const persisted = JSON.parse(readFileSync(eventPath, "utf8")) as typeof invalid,
+      head = JSON.parse(readFileSync(path.join(scratch, "harness/events/head.json"), "utf8")) as {
+        readonly revision: number;
+      },
+      settings = persisted.payload.settings;
+    assert.equal(head.revision, 1);
+    assert.deepEqual(settings.walFlush, { adaptive: true });
   } finally {
     await cell?.close?.();
     rmSync(scratch, { recursive: true, force: true });

--- a/packages/kernel/src/domain/default-policy.ts
+++ b/packages/kernel/src/domain/default-policy.ts
@@ -44,6 +44,7 @@ const repositoryWriteActions = Object.freeze([
   "projection-rebuild",
   "relation-events-migrate",
   "schedule-definitions-migrate",
+  "settings-wal-flush-migrate",
   "runtime-batch",
   "runtime-cancel",
   "runtime-instance-login",

--- a/packages/kernel/src/store/event-shape-migration.ts
+++ b/packages/kernel/src/store/event-shape-migration.ts
@@ -9,13 +9,19 @@ import {
 import type { DecisionEventV1 } from "../domain/decision-event-types.ts";
 import { serializePersistedCanonicalEvent } from "../domain/doc-sync-canonical-events.ts";
 import type { CanonicalEventV1 } from "../domain/doc-sync-types.ts";
+import { isSettingsEvent } from "../domain/settings-event.ts";
+import { SETTINGS_REPOSITORY_V1_SCHEMA, type WalFlushSettingsV1 } from "../domain/settings.ts";
 import {
   isMigrationImportEvent,
   migrationImportWritePlan,
   type MigrationImportEventV1,
 } from "../domain/migration-import-event.ts";
 import { normalizeLegacyRelationState } from "../domain/entity-relation.ts";
-import { serializeEntityJsonSchema, type EntityJsonObjectSchema } from "../domain/entity-json-schema.ts";
+import {
+  serializeEntityJsonSchema,
+  validateEntityJsonSchema,
+  type EntityJsonObjectSchema,
+} from "../domain/entity-json-schema.ts";
 import {
   SCHEDULE_DEFINITION_V1_SCHEMA,
   scheduleDefinition,
@@ -42,11 +48,16 @@ import type { CanonicalContentBlob, CanonicalEventStore, PublicationFile } from 
 // shape `fact-rekey` uses, so the ledger head and commit are produced by the store. The live
 // projection is left alone: every rewrite is, by construction, what the projection already
 // derived, so it only has to catch up the marker. Cold rebuilds are proved separately.
-export type EventShapeMigrationName = "relation-events" | "decision-digests" | "schedule-definitions";
+export type EventShapeMigrationName =
+  | "relation-events"
+  | "decision-digests"
+  | "schedule-definitions"
+  | "settings-wal-flush";
 export type EventShapeMigrationKind =
   | "relation-events-migrate"
   | "decision-digests-migrate"
-  | "schedule-definitions-migrate";
+  | "schedule-definitions-migrate"
+  | "settings-wal-flush-migrate";
 export interface EventShapeRewrite {
   readonly event: CanonicalEventV1;
   readonly blobs?: readonly CanonicalContentBlob[];
@@ -167,6 +178,57 @@ const decisionDigestsMigration: EventShapeMigrationSpec = {
   },
 };
 
+const SETTINGS_WAL_FLUSH_MIGRATION_VALUE: WalFlushSettingsV1 = Object.freeze({
+  adaptive: true,
+  events: 256,
+  bytes: 8_388_608,
+  milliseconds: 3_600_000,
+});
+
+function validateHistoricalWalFlush(value: unknown, opId: string): void {
+  const schema = SETTINGS_REPOSITORY_V1_SCHEMA.properties.walFlush as EntityJsonObjectSchema,
+    errors = validateEntityJsonSchema(
+      {
+        $schema: "https://json-schema.org/draft/2020-12/schema",
+        $id: "SettingsWalFlushMigration/v1",
+        ...schema,
+      },
+      value,
+      `settings event ${opId} walFlush`,
+    );
+  if (errors.length > 0) throw new Error(errors.join("; "));
+}
+
+export const settingsWalFlushMigration: EventShapeMigrationSpec = {
+  name: "settings-wal-flush",
+  // The rewrite never reads the cut, so every settings event stays in bulk rounds.
+  matches: () => false,
+  rewrite: (event) => {
+    if (!isSettingsEvent(event) || event.type !== "settings_changed") return null;
+    const settings = event.payload.settings as unknown;
+    if (settings === null || typeof settings !== "object" || Array.isArray(settings))
+      throw new Error(`settings event ${event.opId} settings must be a JSON object`);
+    const historical = settings as Readonly<Record<string, unknown>>;
+    if (Object.hasOwn(historical, "walFlush")) {
+      validateHistoricalWalFlush(historical.walFlush, event.opId);
+      return null;
+    }
+    const migrated = { ...historical, walFlush: SETTINGS_WAL_FLUSH_MIGRATION_VALUE };
+    return {
+      event: { ...event, payload: { ...event.payload, settings: migrated } } as CanonicalEventV1,
+      category: "walFlush filled from declared/default settings",
+      before: {
+        walFlushPresent: false,
+        harnessDocumentClaim: event.payload.harnessDocumentClaim,
+      },
+      after: {
+        walFlush: SETTINGS_WAL_FLUSH_MIGRATION_VALUE,
+        harnessDocumentClaim: event.payload.harnessDocumentClaim,
+      },
+    };
+  },
+};
+
 // This migration owns exactly one historical break: `spec.target.cwd` (removed in 272de6d16).
 // Any other field the current target schema does not declare is a new break that needs its own
 // migration, so it is reported instead of being silently absorbed here.
@@ -255,6 +317,7 @@ export const eventShapeMigrations: Readonly<Record<EventShapeMigrationKind, Even
   "relation-events-migrate": relationEventsMigration,
   "decision-digests-migrate": decisionDigestsMigration,
   "schedule-definitions-migrate": scheduleDefinitionsMigration,
+  "settings-wal-flush-migrate": settingsWalFlushMigration,
 };
 
 export async function runEventShapeMigration(

--- a/packages/kernel/test/contracts/authorization-port.test.ts
+++ b/packages/kernel/test/contracts/authorization-port.test.ts
@@ -50,7 +50,8 @@ test("the default Policy covers the frozen durable inventory exactly once", () =
   // 2026-09-05:声明实体 update / archive 进入 durable inventory(CEO 已确认),111 → 113。
   // 2026-09-05:vertical declaration migrate / kind upsert / kind retire 进入 durable inventory,113 → 116。
   // 2026-09-05:schedule-definitions-migrate 修复存量 schedule 声明形状,116 → 117。
-  assert.equal(durablePolicyActions.length, 117);
+  // 2026-09-05:settings-wal-flush-migrate 补齐存量 Settings WAL 快照,117 → 118。
+  assert.equal(durablePolicyActions.length, 118);
   // 其余两条是自洽不变量,不需要第二个硬编码数字:清单内无重复(三个角色分段互不重叠),
   // 且每个 durable Action 恰好被一条 rule 覆盖。
   assert.equal(new Set(durablePolicyActions).size, durablePolicyActions.length);


### PR DESCRIPTION
# English

## Summary

`ha migrate settings-wal-flush [--dry-run]`: a one-shot history migration that fills the required `walFlush` object into stored `settings-event/v1` `settings_changed` payloads that predate the field, so a cold projection rebuild of such ledgers passes the current strict Settings schema. It unlatches the self-representation ledger (`settings declaration is missing required field "walFlush"`) under dec_558977E9: history migrates; `walFlush` stays required; no replay tolerance. Task: task_f1db655ebacd847417a78cb5a7.

## Architectural Justification

- Same shape as `schedule-definitions` (#2302): one spec in `event-shape-migration.ts`, registered in `eventShapeMigrations`, plus the five assembly points (CLI route, Migration-A descriptor with `--dry-run`, recovery-state `data-shape`/settlesLatch, generic `authorizeRepoCellAction`, default repo-write policy). No dispatcher change (table lookup already).
- The rewrite owns exactly one break: a missing `walFlush`. The value is frozen inside the migration (`{adaptive:true, events:256, bytes:8388608, milliseconds:3600000}`, the semantics `readSettingsFacet` already assigns to an omitted field) and does not follow `DEFAULT_WAL_FLUSH_SETTINGS`. A present-but-invalid `walFlush` is reported field by field and never overwritten; a present valid one returns `null`.
- `matches: () => false` (the rewrite never reads the cut). opId, revision, actor, time, the YAML document claim and every other settings field are untouched, so the doc-proof chain is not rewritten.

## Fleet / centralized-ledger view

The migration is a center-only single-writer command under the repo's writer epoch fence and is idempotent (second run rewrites nothing, no second marker). Edges never migrate history.

## What Changed

kernel `event-shape-migration.ts` (+ types); daemon descriptor / recovery-state / authorization; kernel default-policy; cli route; tests: `event-shape-migration.integration.test.ts` (missing walFlush → rebuild red; dry-run 1; apply → rebuild green and facet shows the frozen value; second run 0; data-shape latch → attached; invalid walFlush rejected at spec and end to end), thin-command, authorization-port (durable inventory 117→118).

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates: none

## Verification

- Ubuntu VM isolated: `event-shape-migration.integration.test.ts` 8/8; `authorization-port.test.ts` 7/7 (worker, commit e9d9ef2a0). Local: thin-command 19/19; tsc (kernel/daemon/cli) 0; durable-action authorization 0/123 missing; G0-5 (all deltas negative), G36, duplicate-definitions, canonical-event-compat, import-boundaries pass. `check:local` not run.
- self-representation ledger copy (132 events), worker and CEO runs independently: offline rebuild FAILED (`walFlush`) → dry-run 1 rewrite → apply revision 133 → second run 0 → offline rebuild `ok head=133 watermark=133`; `git diff <pristine cut>..refs/ha/canonical -- events` = the single Settings event + marker + head.

## Review Evidence

- Worker report: task packet `artifacts/reports/implementation.md`.
- Peer CEO semantic acceptance: passed on seven points (frozen value, sub-schema validation of a present walFlush, null when valid, `matches: () => false`, only `payload.settings` touched, five assembly points identical to the schedule precedent, reader and projection untouched).
- Why filling only the payload snapshot is self-consistent: the settings replay validates the `harness.yaml` blob by hash and UTF-8 only (`rebuildable-task-projection-event-application.ts:249-259`); unlike the schedule facet there is no byte-level blob-vs-payload equality check, so leaving the YAML claim untouched cannot desynchronise anything.

## Residual Risk

- A ledger whose YAML explicitly declares a non-default WAL is not covered by this rewrite (none among the known ledgers); such a ledger would need its declared value, not the frozen default.
- The engine gaps tracked in task_96788bcc (applied settles the latch without rebuilding the live projection; scratch replay runs every spec but publishes one) still apply; rollout runs an offline rebuild and a daemon restart after the migration, as for #2302.

---

# 中文

## 摘要

`ha migrate settings-wal-flush [--dry-run]`:一次性历史迁移,给早于该字段的 `settings-event/v1` `settings_changed` 载荷补上 required 的 `walFlush`,使此类台账的冷重建通过当前严格 Settings schema;解锁 self-representation 台账。依据 dec_558977E9:历史走迁移、`walFlush` 保持 required、不做重放容忍。任务 task_f1db655ebacd847417a78cb5a7。

## 架构辩护

- 与 #2302 同形:一个 spec + 五处装配点,dispatcher 不动。
- 只拥有一个断裂(缺 `walFlush`);值冻结在迁移内(即 `readSettingsFacet` 对省略字段已赋的语义),不跟随 `DEFAULT_WAL_FLUSH_SETTINGS`;存在但非法 → 字段级报错不覆写;存在且合法 → null。
- `matches: () => false`;opId/revision/actor/时间/YAML claim/其它 settings 字段一律不动,doc-proof 链不被改写。

## 中心化仓库视角

中心单写、writer epoch fence 内、幂等(二跑零改写无第二个 marker);边缘不迁移历史。

## 门收割

Deleted-Production-Paths: none
Deleted-Gates: none

## 验证

- VM 隔离 8/8、7/7;本地 thin-command 19/19、tsc 0、durable-action 0/123 缺失、G0-5/G36/duplicate/canonical-event-compat/import-boundaries 过;未跑 `check:local`。
- self-representation 副本(132 事件)worker 与 CEO 各跑一遍:重建 FAILED → dry-run 1 → apply 133 → 二跑 0 → 重建 ok;git diff 改动恰为那 1 条 Settings 事件 + marker + head。

## 评审证据

- 对面 CEO 语义验收七项通过(冻结值、存在则子 schema 校验、合法返回 null、matches 为 false、只动 payload.settings、五处装配点同形、reader/投影未动)。
- 只填 payload 快照而不动 YAML claim 为何自洽:settings 回放对 `harness.yaml` blob 只做 hash 与 UTF-8 校验(event-application.ts:249-259),没有 schedule 那道 blob 与 payload 逐字节互证,因此不会失配。

## 残余风险

- YAML 显式声明非默认 WAL 的台账不在本改写范围(已知台账中不存在),此类需取其声明值。
- 引擎缺口(task_96788bcc)仍在;上线同 #2302 在迁移后做离线重建与 daemon 重启。

Production-Delta: +84/-3
