### PR TITLE
fix(daemon): resolve vertical kind ids for entity reads

### DIFF
--- a/packages/daemon/src/artifact-entity-action.ts
+++ b/packages/daemon/src/artifact-entity-action.ts
@@ -68,6 +68,10 @@ export function compiledArtifactKinds(rootDir: string, repositoryId: string): re
   return canonicalVertical(rootDir, repositoryId).contract.artifactKinds;
 }
 
+export function resolveEntityReadKind(kind: string, contracts: readonly CompiledArtifactKindContract[]): string {
+  return contracts.find(({ declaration }) => declaration.id === kind)?.typeIdentity ?? kind;
+}
+
 /**
  * The registry relation writes are admitted against: kernel rows plus the governed rows the canonical
  * vertical compiled, so a kind-declared triple is writable through the same authority as a code row.

--- a/packages/daemon/src/repo-cell-action-dispatch.ts
+++ b/packages/daemon/src/repo-cell-action-dispatch.ts
@@ -11,6 +11,7 @@ import {
 } from "../../kernel/src/index.ts";
 import { runPresetAction } from "../../preset/src/index.ts";
 import { runAgentEntityAction } from "./agent-entities.ts";
+import { compiledArtifactKinds, resolveEntityReadKind } from "./artifact-entity-action.ts";
 import { distillPromotionAction, prepareDistillCandidate, readDistillEntity } from "./distill-actions.ts";
 import { isDocAction, runArtifactAdd, runDocAction } from "./doc-sync-actions.ts";
 import { runMigrationImport } from "./migration-import.ts";
@@ -243,7 +244,8 @@ export async function executeAction(
   if (action.kind === "preset-upgrade") return cell.upgradePresetSnapshot(action, binding);
   if (/^entity-(?:get|list)$/u.test(action.kind)) {
     const revision = cell.store.readHead()?.revision ?? 0,
-      kind = cell.requiredCellText(action.entityKind, "entityKind");
+      requestedKind = cell.requiredCellText(action.entityKind, "entityKind"),
+      kind = resolveEntityReadKind(requestedKind, compiledArtifactKinds(cell.rootDir, cell.input.repoId));
     if (action.kind === "entity-list")
       return cell.readResult(
         cell.operationId(action, binding, cell.input.repoId, revision),

--- a/packages/daemon/test/artifact-entity-action.integration.test.ts
+++ b/packages/daemon/test/artifact-entity-action.integration.test.ts
@@ -238,11 +238,30 @@ test("Artifact import is dry-run safe, edge-idempotent, fenced, and cold-rebuild
     );
 
     const listed = await cell.run({ kind: "entity-list", entityKind: kind }, binding),
+      shortListed = await cell.run({ kind: "entity-list", entityKind: "architecture-decision-record" }, binding),
+      shortGet = await cell.run(
+        { kind: "entity-get", entityKind: "architecture-decision-record", entityId: preview.entityId },
+        binding,
+      ),
       listedEntities = (
         JSON.parse(String(listed.evidence)) as {
           entities: readonly { id: string; freshness: string; currentVersion: string | number | null }[];
         }
-      ).entities;
+      ).entities,
+      shortListEvidence = JSON.parse(String(shortListed.evidence)) as {
+        kind: string;
+        entities: readonly { id: string; freshness: string; currentVersion: string | number | null }[];
+      },
+      shortGetEvidence = JSON.parse(String(shortGet.evidence)) as {
+        kind: string;
+        entity: { id: string };
+      };
+    assert.equal(shortListed.outcome, "applied", JSON.stringify(shortListed));
+    assert.equal(shortGet.outcome, "applied", JSON.stringify(shortGet));
+    assert.equal(shortListEvidence.kind, kind);
+    assert.equal(shortGetEvidence.kind, kind);
+    assert.deepEqual(shortListEvidence.entities, listedEntities);
+    assert.equal(shortGetEvidence.entity.id, preview.entityId);
     assert.deepEqual(
       listedEntities.map(({ id }) => id),
       [preview.entityId],
@@ -320,15 +339,31 @@ test("Directory artifact import fingerprints files, replays unchanged content, a
       deriveArtifactContentVersion({ kind: "content", content: manifest }),
     );
     const listed = await cell.run({ kind: "entity-list", entityKind: researchKind }, binding),
-      entity = (
-        JSON.parse(String(listed.evidence)) as {
-          entities: readonly {
-            id: string;
-            value: { title: string };
-            currentVersion: string | number | null;
-          }[];
-        }
-      ).entities[0];
+      shortListed = await cell.run({ kind: "entity-list", entityKind: "research" }, binding),
+      shortGet = await cell.run(
+        { kind: "entity-get", entityKind: "research", entityId: firstPreview.entityId },
+        binding,
+      ),
+      listedEvidence = JSON.parse(String(listed.evidence)) as {
+        kind: string;
+        entities: readonly {
+          id: string;
+          value: { title: string };
+          currentVersion: string | number | null;
+        }[];
+      },
+      shortListEvidence = JSON.parse(String(shortListed.evidence)) as typeof listedEvidence,
+      shortGetEvidence = JSON.parse(String(shortGet.evidence)) as {
+        kind: string;
+        entity: { id: string };
+      },
+      entity = listedEvidence.entities[0];
+    assert.equal(shortListed.outcome, "applied", JSON.stringify(shortListed));
+    assert.equal(shortGet.outcome, "applied", JSON.stringify(shortGet));
+    assert.equal(shortListEvidence.kind, researchKind);
+    assert.equal(shortGetEvidence.kind, researchKind);
+    assert.deepEqual(shortListEvidence.entities, listedEvidence.entities);
+    assert.equal(shortGetEvidence.entity.id, firstPreview.entityId);
     assert.equal(entity?.value.title, "Directory artifacts");
     assert.equal(entity?.currentVersion, firstPreview.candidateContentVersion);
 

--- a/packages/daemon/test/entity-kind-catalog.contract.test.ts
+++ b/packages/daemon/test/entity-kind-catalog.contract.test.ts
@@ -5,7 +5,11 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
 import { buildEntityKindCatalog, validateEntityKindCatalog } from "../../kernel/src/index.ts";
-import { compiledArtifactKinds, relationDirectionRegistry } from "../src/artifact-entity-action.ts";
+import {
+  compiledArtifactKinds,
+  relationDirectionRegistry,
+  resolveEntityReadKind,
+} from "../src/artifact-entity-action.ts";
 import { readDeclaredEntityRows, validateEntityRowList } from "../src/entity-rows-read.ts";
 import { readEntityLocator, validateEntityLocatorRead } from "../src/entity-locator-read.ts";
 import { daemonGuiReadMethods, validateDaemonRpcCall } from "../src/protocol/daemon-protocol.contract.ts";
@@ -92,6 +96,15 @@ test("the declared research kind is importable and carries both governed relatio
       { type: "relates", sourceKind: RESEARCH_KIND, targetKind: "task" },
     ],
   );
+});
+
+test("entity projection reads resolve vertical declaration ids to canonical kind identities", () => {
+  const kinds = repositoryKinds();
+  assert.equal(resolveEntityReadKind("architecture-decision-record", kinds), ADR_KIND);
+  assert.equal(resolveEntityReadKind("external-issue", kinds), "software/coding/external-issue@1");
+  assert.equal(resolveEntityReadKind("research", kinds), RESEARCH_KIND);
+  assert.equal(resolveEntityReadKind(RESEARCH_KIND, kinds), RESEARCH_KIND);
+  assert.equal(resolveEntityReadKind("agent", kinds), "agent");
 });
 
 test("builtin rows carry no declaration and declared rows always do", () => {


### PR DESCRIPTION
# English

## Summary

`ha entity list <kind>` / `ha entity get` with a short vertical kind id (for example `research`) returned nothing after 6db8d86ba (vertical contract compiles fully-qualified kinds) and f92a6abf8 (import writer stores the fully-qualified `entity_kind`): the projection rows are keyed by `software/coding/research@1` while the read path queried `entity_kind = 'research'` verbatim. This PR adds one read-side resolver, `resolveEntityReadKind`, that maps a declared vertical kind id to its compiled `typeIdentity` before the projection query; canonical, built-in and unknown kinds pass through unchanged. Writers and stored keys are untouched, so no migration is needed (task_a01e319ec, fact F-F313ED18).

## Architectural Justification

- The compiled vertical contract is already the single authority that turns a declaration id into a type identity; the read path now asks it instead of guessing. No second kind table, no alias map, no fallback query.
- Passthrough for unknown ids keeps the existing `entity_kind_unknown` behaviour and keeps relation refs (which use the canonical prefix) working.

## Fleet / centralized-ledger view

Read-only change; every node resolves the same contract from the same repo, so two edges listing the same kind read the same rows.

## What Changed

- `packages/daemon/src/artifact-entity-action.ts`: `resolveEntityReadKind(kind, contracts)`.
- `packages/daemon/src/repo-cell-action-dispatch.ts`: entity-get/list resolve the requested kind through the compiled artifact kinds before the projection read.
- Tests: `artifact-entity-action.integration.test.ts` (short kind list/get across an isolated RepoCell, red before / green after), `entity-kind-catalog.contract.test.ts` (canonical and agent kinds pass through).

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none

## Machine-Readable Declarations

Production-Delta: +7/-1

## Task And Scope

- Harness task: task_a01e319ec
- Branch: codex/entity-kind-key
- Public scope: daemon entity read path + two tests
- Private planning/evidence updated: yes (fact F-F313ED18 acceptance, F-185EBB89 implementation)
- Out of scope: writer / stored kind keys, GUI entity page, thin-command-router

## Version Impact

- Version: no version change because this is a read-path fix inside an unreleased slice
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none
- Authority: not applicable
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no

## Verification

- Base `origin/main` SHA: 3fd68e21fb1416d03d5f450114e4cb03105c6187
- Isolated RepoCell: short-kind list 0 → 2 rows and get resolves after the fix; the two new cases were red on 3fd68e21f and are green on 34ab4c0d9 (negative control).
- Contract test: three vertical artifact kinds resolve, canonical / agent kinds pass through.
- `check:local` not run; CI is the authority.

## Review Evidence

- Peer CEO semantic acceptance: fact F-F313ED18 (root cause = compile-side key change, not #2292; option A read-side resolver chosen over writer change).
- Worker report: fact F-185EBB89.

## Residual Risk

- Not re-tested against the live default daemon with this commit installed (that daemon is held at 3fd68e21f); the generation change after merge picks it up.

---

# 中文

## 概要

6db8d86ba(vertical contract 编译全限定 kind)与 f92a6abf8(import writer 落全限定 `entity_kind`)之后,`ha entity list/get` 用短 kind(如 `research`)查投影恒为空:行键是 `software/coding/research@1`,读侧却按原样 `entity_kind = 'research'` 查。本 PR 只加一个读侧 resolver `resolveEntityReadKind`,查投影前把声明 id 解析成编译后的 `typeIdentity`;canonical/内建/未知 kind 原样透传。不改 writer 与已存键,不需要迁移(task_a01e319ec,F-F313ED18)。

## 架构辩护

- 编译后的 vertical contract 本来就是「声明 id → 类型身份」的唯一权威,读侧改为问它而不是猜;不加第二张 kind 表、别名表或回退查询。
- 未知 id 透传保住既有 `entity_kind_unknown` 行为,relation ref(用 canonical 前缀)不受影响。

## 中心化仓库视角

纯读侧改动;每个节点从同一仓解析同一 contract,两个边缘节点 list 同一 kind 读到同一批行。

## 改动内容

- `artifact-entity-action.ts` 新增 `resolveEntityReadKind`;`repo-cell-action-dispatch.ts` entity-get/list 先解析再查投影;两处测试。

## 门收割 / Gate Harvest

无删除。

## 任务与范围

- 任务 task_a01e319ec;分支 codex/entity-kind-key;范围 daemon 实体读路 + 两测试;不含 writer/存储键、GUI 实体页、thin-command-router。

## 版本影响

- 无版本变化;不发布。

## 治理声明

- 未触碰 protected surface。

## 验证

- 基线 3fd68e21f;隔离 RepoCell 短 kind list 0 → 2 行、get 可解析;新增两用例在基线上红、在 34ab4c0d9 上绿(阴性对照);contract 三 artifact kind 可解析、canonical/agent 透传;未跑 `check:local`。

## 审查证据

- 对面 CEO 语义验收 F-F313ED18;worker 报告 F-185EBB89。

## 残余风险

- 未在装有本 commit 的真实 default daemon 上复测生产 32/30/1 行;合并后 daemon 换代自然生效。
