### PR TITLE
fix(daemon): move the writer epoch authority to SQLite

### DIFF
--- a/packages/daemon/src/writer-epoch.ts
+++ b/packages/daemon/src/writer-epoch.ts
@@ -1,17 +1,8 @@
 import { randomUUID } from "node:crypto";
-import {
-  closeSync,
-  existsSync,
-  fsyncSync,
-  mkdirSync,
-  openSync,
-  readFileSync,
-  unlinkSync,
-  writeFileSync,
-} from "node:fs";
+import { mkdirSync } from "node:fs";
 import path from "node:path";
-import { consumeKnownError, type WalMaterializationFenceV1 } from "../../kernel/src/index.ts";
-import { writeFileDurably } from "./durable-file.ts";
+import { DatabaseSync } from "node:sqlite";
+import type { WalMaterializationFenceV1 } from "../../kernel/src/index.ts";
 
 export interface WriterEpochLease {
   readonly repoId: string;
@@ -37,8 +28,14 @@ export class WriterEpochError extends Error {
     this.code = code;
   }
 }
-type EpochState = { readonly schema: "fleet-writer-epoch/v1"; readonly repos: Record<string, WriterEpochLease> };
-const schema = "fleet-writer-epoch/v1" as const;
+
+type EpochRow = {
+  readonly repo_id: string;
+  readonly holder_id: string;
+  readonly epoch: number;
+  readonly version: number;
+  readonly issued_at: string;
+};
 
 export function openPersistentWriterEpoch(options: {
   readonly stateRoot: string;
@@ -46,59 +43,110 @@ export function openPersistentWriterEpoch(options: {
   readonly now?: () => string;
 }): PersistentWriterEpoch {
   mkdirSync(options.stateRoot, { recursive: true });
-  const stateFile = path.join(options.stateRoot, "writer-epochs.json"),
-    historyFile = path.join(options.stateRoot, "writer-epochs.history"),
-    lockFile = path.join(options.stateRoot, "writer-epochs.lock"),
+  const database = new DatabaseSync(path.join(options.stateRoot, "writer-epochs.sqlite")),
     holderId = options.holderId ?? `center-${process.pid}-${randomUUID()}`,
     now = options.now ?? (() => new Date().toISOString());
+  database.exec("PRAGMA busy_timeout=5000; PRAGMA journal_mode=WAL; PRAGMA synchronous=FULL; PRAGMA foreign_keys=ON");
+  database.exec(`
+    CREATE TABLE IF NOT EXISTS writer_epoch_history (
+      repo_id TEXT NOT NULL,
+      epoch INTEGER NOT NULL CHECK(epoch > 0),
+      PRIMARY KEY(repo_id, epoch)
+    ) STRICT;
+    CREATE TABLE IF NOT EXISTS writer_epochs (
+      repo_id TEXT PRIMARY KEY,
+      holder_id TEXT NOT NULL CHECK(length(holder_id) > 0),
+      epoch INTEGER NOT NULL CHECK(epoch > 0),
+      version INTEGER NOT NULL CHECK(version > 0),
+      issued_at TEXT NOT NULL
+    ) STRICT;
+  `);
+  const selectCurrent = database.prepare(
+      "SELECT repo_id, holder_id, epoch, version, issued_at FROM writer_epochs WHERE repo_id=?",
+    ),
+    selectStatus = database.prepare(
+      "SELECT repo_id, holder_id, epoch, version, issued_at FROM writer_epochs ORDER BY repo_id",
+    ),
+    selectFloor = database.prepare("SELECT MAX(epoch) AS floor FROM writer_epoch_history WHERE repo_id=?"),
+    insertHistory = database.prepare("INSERT INTO writer_epoch_history(repo_id, epoch) VALUES (?, ?)"),
+    upsertCurrent = database.prepare(
+      "INSERT INTO writer_epochs(repo_id, holder_id, epoch, version, issued_at) VALUES (?, ?, ?, ?, ?) " +
+        "ON CONFLICT(repo_id) DO UPDATE SET holder_id=excluded.holder_id, epoch=excluded.epoch, " +
+        "version=excluded.version, issued_at=excluded.issued_at",
+    );
   let closed = false;
-  const read = (): EpochState => readState(stateFile);
-  const write = (state: EpochState): void => writeWriterEpochState(stateFile, state);
-  const acquire = (repoId: string): WriterEpochLease => {
+  const ensureOpen = (): void => {
     if (closed) throw new WriterEpochError("writer_epoch_invalid", "writer epoch authority is closed");
-    if (!repoId) throw new WriterEpochError("writer_epoch_invalid", "repoId is required for writer epoch allocation");
-    return withLock(lockFile, () => {
-      const state = read(),
-        previous = state.repos[repoId],
-        floor = historyFloor(historyFile, repoId),
-        lease: WriterEpochLease = {
-          repoId,
-          holderId,
-          epoch: Math.max(previous?.epoch ?? 0, floor) + 1,
-          version: Math.max(previous?.version ?? 0, floor) + 1,
-          issuedAt: now(),
-        };
-      appendHistory(historyFile, lease);
-      write({ schema, repos: { ...state.repos, [repoId]: lease } });
-      return lease;
-    });
   };
-  const current = (repoId: string): WriterEpochLease | null => read().repos[repoId] ?? null;
-  const assertState = (state: EpochState, repoId: string, epoch: number, expectedHolderId: string): void => {
-    const observed = state.repos[repoId];
+  const readCurrent = (repoId: string): WriterEpochLease | null => {
+    const row = selectCurrent.get(repoId) as EpochRow | undefined;
+    return row ? leaseFromRow(row) : null;
+  };
+  const withImmediateTransaction = <T>(operation: () => T): T => {
+    ensureOpen();
+    database.exec("BEGIN IMMEDIATE");
+    try {
+      const result = operation();
+      database.exec("COMMIT");
+      return result;
+    } catch (error) {
+      database.exec("ROLLBACK");
+      throw error;
+    }
+  };
+  const assertState = (repoId: string, epoch: number, expectedHolderId: string): void => {
+    const observed = readCurrent(repoId);
     if (!observed || observed.epoch !== epoch || observed.holderId !== expectedHolderId)
       throw new WriterEpochError(
         "writer_epoch_stale",
-        `writer epoch ${epoch} for ${repoId} is stale; current epoch is ${observed?.epoch ?? "missing"}. Query the receipt or reacquire the writer epoch before retrying.`,
+        `writer epoch ${epoch} for ${repoId} is stale; current epoch is ${observed?.epoch ?? "missing"}. ` +
+          "Query the receipt or reacquire the writer epoch before retrying.",
       );
   };
-  const assert = (repoId: string, epoch: number, expectedHolderId = holderId): void =>
-    assertState(read(), repoId, epoch, expectedHolderId);
-  const withAppendFence = <T>(repoId: string, epoch: number, expectedHolderId: string, operation: () => T): T =>
-    withLock(lockFile, () => {
-      assertState(read(), repoId, epoch, expectedHolderId);
-      return operation();
+  const acquire = (repoId: string): WriterEpochLease => {
+    ensureOpen();
+    if (!repoId) throw new WriterEpochError("writer_epoch_invalid", "repoId is required for writer epoch allocation");
+    return withImmediateTransaction(() => {
+      const previous = readCurrent(repoId),
+        floor = Number((selectFloor.get(repoId) as { readonly floor: number | null }).floor ?? 0),
+        epoch = Math.max(previous?.epoch ?? 0, floor) + 1,
+        lease: WriterEpochLease = {
+          repoId,
+          holderId,
+          epoch,
+          version: Math.max(previous?.version ?? 0, floor) + 1,
+          issuedAt: now(),
+        };
+      if (!Number.isSafeInteger(epoch))
+        throw new WriterEpochError("writer_epoch_invalid", `writer epoch for ${repoId} exceeds the safe integer range`);
+      insertHistory.run(repoId, lease.epoch);
+      upsertCurrent.run(repoId, lease.holderId, lease.epoch, lease.version, lease.issuedAt);
+      return lease;
     });
-  const status = (): readonly WriterEpochLease[] =>
-    Object.values(read().repos).sort((left, right) => left.repoId.localeCompare(right.repoId));
+  };
   return {
     acquire,
-    current,
-    assert,
-    withAppendFence,
-    status,
+    current: (repoId) => {
+      ensureOpen();
+      return readCurrent(repoId);
+    },
+    assert: (repoId, epoch, expectedHolderId = holderId) => {
+      ensureOpen();
+      assertState(repoId, epoch, expectedHolderId);
+    },
+    withAppendFence: (repoId, epoch, expectedHolderId, operation) =>
+      withImmediateTransaction(() => {
+        assertState(repoId, epoch, expectedHolderId);
+        return operation();
+      }),
+    status: () => {
+      ensureOpen();
+      return (selectStatus.all() as unknown as readonly EpochRow[]).map(leaseFromRow);
+    },
     close: () => {
+      if (closed) return;
       closed = true;
+      database.close();
     },
   };
 }
@@ -123,6 +171,16 @@ export function assertWriterEpochFenceDescriptor(descriptor: WriterEpochFenceDes
   }
 }
 
+function leaseFromRow(row: EpochRow): WriterEpochLease {
+  return {
+    repoId: row.repo_id,
+    holderId: row.holder_id,
+    epoch: row.epoch,
+    version: row.version,
+    issuedAt: row.issued_at,
+  };
+}
+
 function validateWriterEpochFenceDescriptor(descriptor: WriterEpochFenceDescriptor): void {
   if (
     descriptor.schema !== "harness-writer-epoch-fence/v1" ||
@@ -133,130 +191,4 @@ function validateWriterEpochFenceDescriptor(descriptor: WriterEpochFenceDescript
     descriptor.epoch < 1
   )
     throw new WriterEpochError("writer_epoch_invalid", "writer epoch fence descriptor is invalid");
-}
-
-function readState(file: string): EpochState {
-  if (!existsSync(file)) return { schema, repos: {} };
-  let value: unknown;
-  try {
-    value = JSON.parse(readFileSync(file, "utf8"));
-  } catch (error) {
-    throw new WriterEpochError(
-      "writer_epoch_invalid",
-      `writer epoch state is unreadable: ${error instanceof Error ? error.message : String(error)}`,
-    );
-  }
-  if (
-    !value ||
-    typeof value !== "object" ||
-    Array.isArray(value) ||
-    (value as { schema?: unknown }).schema !== schema ||
-    !isEpochRecord((value as { repos?: unknown }).repos)
-  )
-    throw new WriterEpochError("writer_epoch_invalid", "writer epoch state has an invalid durable shape");
-  const repos: Record<string, WriterEpochLease> = {};
-  for (const [repoId, raw] of Object.entries((value as { repos: Record<string, unknown> }).repos)) {
-    if (!raw || typeof raw !== "object" || Array.isArray(raw))
-      throw new WriterEpochError("writer_epoch_invalid", `writer epoch row ${repoId} is invalid`);
-    const row = raw as Record<string, unknown>;
-    if (
-      row.repoId !== repoId ||
-      typeof row.holderId !== "string" ||
-      !row.holderId ||
-      !Number.isSafeInteger(row.epoch) ||
-      Number(row.epoch) <= 0 ||
-      !Number.isSafeInteger(row.version) ||
-      Number(row.version) <= 0 ||
-      typeof row.issuedAt !== "string"
-    )
-      throw new WriterEpochError("writer_epoch_invalid", `writer epoch row ${repoId} is invalid`);
-    repos[repoId] = row as unknown as WriterEpochLease;
-  }
-  return { schema, repos };
-}
-function isEpochRecord(value: unknown): value is Record<string, unknown> {
-  return value !== null && typeof value === "object" && !Array.isArray(value);
-}
-function withLock<T>(file: string, operation: () => T): T {
-  mkdirSync(path.dirname(file), { recursive: true });
-  let fd: number;
-  for (;;) {
-    try {
-      fd = openSync(file, "wx", 0o600);
-      break;
-    } catch (error) {
-      if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
-      let ownerText: string;
-      try {
-        ownerText = readFileSync(file, "utf8").trim();
-      } catch (error) {
-        if ((error as NodeJS.ErrnoException).code === "ENOENT") continue;
-        throw error;
-      }
-      if (!ownerText) {
-        Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 2);
-        continue;
-      }
-      const owner = Number.parseInt(ownerText, 10);
-      let alive = false;
-      if (Number.isSafeInteger(owner) && owner > 0) {
-        try {
-          process.kill(owner, 0);
-          alive = true;
-        } catch (error) {
-          consumeKnownError(error);
-          alive = false;
-        }
-      }
-      if (!alive) {
-        try {
-          unlinkSync(file);
-        } catch (retryError) {
-          consumeKnownError(retryError);
-          if ((retryError as NodeJS.ErrnoException).code !== "ENOENT") throw retryError;
-        }
-        continue;
-      }
-      Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 2);
-    }
-  }
-  try {
-    writeFileSync(fd, `${process.pid}\n`);
-    fsyncSync(fd);
-    return operation();
-  } finally {
-    closeSync(fd);
-    try {
-      unlinkSync(file);
-    } catch (error) {
-      consumeKnownError(error);
-    }
-  }
-}
-function appendHistory(file: string, lease: WriterEpochLease): void {
-  const fd = openSync(file, "a", 0o600);
-  try {
-    writeFileSync(fd, `${JSON.stringify(lease)}\n`);
-    fsyncSync(fd);
-  } finally {
-    closeSync(fd);
-  }
-}
-function historyFloor(file: string, repoId: string): number {
-  if (!existsSync(file)) return 0;
-  const rows = readFileSync(file, "utf8").split(/\r?\n/u).filter(Boolean);
-  let floor = 0;
-  for (const line of rows) {
-    try {
-      const row = JSON.parse(line) as Partial<WriterEpochLease>;
-      if (row.repoId === repoId && typeof row.epoch === "number" && Number.isSafeInteger(row.epoch))
-        floor = Math.max(floor, row.epoch);
-    } catch (error) {
-      consumeKnownError(error);
-    }
-  }
-  return floor;
-}
-function writeWriterEpochState(file: string, value: unknown): void {
-  writeFileDurably(file, `${JSON.stringify(value)}\n`, 0o600);
 }

--- a/packages/daemon/test/fleet-lease-broker.integration.test.ts
+++ b/packages/daemon/test/fleet-lease-broker.integration.test.ts
@@ -344,11 +344,11 @@ test(
     const created = await fixture.command("node-one", { kind: "task-create", title: "Epoch fence" });
     const taskId = String((created.receipt as Record<string, unknown>).taskId);
     assert.equal((await fixture.command("node-one", { kind: "task-start", taskId })).outcome, "applied");
-    const oldEpoch = (
-      JSON.parse(readFileSync(path.join(fixture.stateRoot, "writer-epochs.json"), "utf8")) as {
-        repos: Record<string, { epoch: number }>;
-      }
-    ).repos["lease-repo"]!.epoch;
+    const epochObserver = openPersistentWriterEpoch({ stateRoot: fixture.stateRoot, holderId: "epoch-observer" }),
+      oldLease = epochObserver.current("lease-repo");
+    epochObserver.close();
+    assert.ok(oldLease);
+    const oldEpoch = oldLease.epoch;
     const replacement = await fixture.openCenter(fixture.host);
     const before = fixture.commitCount();
     // The stale endpoint must not adopt the replacement's epoch merely because
@@ -405,12 +405,10 @@ test("stale task rejection disposes carried document claims", { timeout: 30_000 
     ...peer,
     changes: [{ path: pathValue, body: "stale candidate\n" }],
   });
-  const oldEpoch = (
-    JSON.parse(readFileSync(path.join(fixture.stateRoot, "writer-epochs.json"), "utf8")) as {
-      repos: Record<string, { epoch: number }>;
-    }
-  ).repos["lease-repo"]!.epoch;
-  const authority = openPersistentWriterEpoch({ stateRoot: fixture.stateRoot, holderId: "claim-successor" });
+  const authority = openPersistentWriterEpoch({ stateRoot: fixture.stateRoot, holderId: "claim-successor" }),
+    oldLease = authority.current("lease-repo");
+  assert.ok(oldLease);
+  const oldEpoch = oldLease.epoch;
   authority.acquire("lease-repo");
   const result = await runFleetTaskCommandClient({
     ...peer,

--- a/packages/daemon/test/fleet-transport.integration.test.ts
+++ b/packages/daemon/test/fleet-transport.integration.test.ts
@@ -916,16 +916,18 @@ test("fleet runtime waits over five seconds for every configured overview page",
       };
     },
   };
-  const center = await listenFleetTls({
-    host: slowHost,
-    stateRoot: path.join(fixture.root, "slow-runtime-center"),
-    key: fixture.key,
-    cert: fixture.cert,
-    replicaDiskQuotaBytes: replicaQuota,
-    authenticate: (nodeId, credential) => nodeId === fixture.assignment.nodeId && credential === "machine-secret",
-    resolveAssignment: (assignmentId) => (assignmentId === fixture.assignment.assignmentId ? fixture.assignment : null),
-  });
-  t.after(() => center.close());
+  const center = await fixture.hold(
+    listenFleetTls({
+      host: slowHost,
+      stateRoot: path.join(fixture.root, "slow-runtime-center"),
+      key: fixture.key,
+      cert: fixture.cert,
+      replicaDiskQuotaBytes: replicaQuota,
+      authenticate: (nodeId, credential) => nodeId === fixture.assignment.nodeId && credential === "machine-secret",
+      resolveAssignment: (assignmentId) =>
+        assignmentId === fixture.assignment.assignmentId ? fixture.assignment : null,
+    }),
+  );
   const workspaceRoot = path.join(fixture.root, "slow-runtime-edge"),
     viewRoot = path.join(fixture.root, "slow-runtime-view");
   mkdirSync(path.join(workspaceRoot, "harness"), { recursive: true });
@@ -978,7 +980,7 @@ test("fleet runtime waits over five seconds for every configured overview page",
       },
     },
   });
-  t.after(() => runtime.close());
+  fixture.track(() => void runtime.close());
   const overview = await runtime.run("repo.agentRuntime.overview", { limit: 1 });
   assert.equal((overview.sessions as readonly unknown[]).length, 1);
   assert.deepEqual(pagePayloads.slice(0, 2), [{ limit: 16 }, { limit: 16, cursor: "slow-page:16" }]);
@@ -1338,6 +1340,7 @@ async function fleetFixture(paths: readonly string[] = ["tasks/task-fleet-fleet/
     certFile,
     emptyPath,
     track: owned.track,
+    hold: owned.hold,
     setActive: (value: boolean) => {
       nodeActive = value;
     },
@@ -1515,6 +1518,7 @@ async function crossRepoFixture() {
     assignments,
     path: pathValue,
     track: owned.track,
+    hold: owned.hold,
     center: () =>
       owned.hold(
         listenFleetTls({

--- a/packages/daemon/test/fleet-writer-epoch.integration.test.ts
+++ b/packages/daemon/test/fleet-writer-epoch.integration.test.ts
@@ -1,9 +1,10 @@
 // harness-test-tier: integration
 import assert from "node:assert/strict";
 import { execFileSync, spawn } from "node:child_process";
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
 import test from "node:test";
 import { pathToFileURL } from "node:url";
 import {
@@ -61,13 +62,14 @@ function childEpoch(
   root: string,
   holderId: string,
   readyFile = "",
+  repoId = "repo",
 ): Promise<{
   readonly code: number | null;
   readonly lease: { readonly epoch: number; readonly holderId: string } | null;
 }> {
-  const code = `import { writeFileSync } from "node:fs"; import { openPersistentWriterEpoch } from ${JSON.stringify(pathToFileURL(source).href)}; const [root, holder, ready] = process.argv.slice(1); const authority = openPersistentWriterEpoch({ stateRoot: root, holderId: holder }); if (ready) writeFileSync(ready, "ready\\n"); console.log(JSON.stringify(authority.acquire("repo")));`;
+  const code = `import { writeFileSync } from "node:fs"; import { openPersistentWriterEpoch } from ${JSON.stringify(pathToFileURL(source).href)}; const [root, holder, ready, repo] = process.argv.slice(1); const authority = openPersistentWriterEpoch({ stateRoot: root, holderId: holder }); if (ready) writeFileSync(ready, "ready\\n"); console.log(JSON.stringify(authority.acquire(repo))); authority.close();`;
   return new Promise((resolve, reject) => {
-    const child = spawn(process.execPath, ["--input-type=module", "-e", code, root, holderId, readyFile], {
+    const child = spawn(process.execPath, ["--input-type=module", "-e", code, root, holderId, readyFile, repoId], {
       stdio: ["ignore", "pipe", "pipe"],
     });
     let stdout = "",
@@ -84,34 +86,6 @@ function childEpoch(
       resolve({ code: exitCode, lease: JSON.parse(stdout.trim()) });
     });
   });
-}
-
-async function holdEpochLock(root: string, readyFile: string, holdMs: number): Promise<() => Promise<void>> {
-  const file = path.join(root, "writer-epochs.lock");
-  const code = `import { closeSync, existsSync, fsyncSync, openSync, unlinkSync, writeFileSync } from "node:fs"; const [file, ready, hold] = process.argv.slice(1); const fd = openSync(file, "wx", 0o600); writeFileSync(fd, process.pid + "\\n"); fsyncSync(fd); console.log("locked"); const deadline = Date.now() + 10_000; while (!existsSync(ready)) { if (Date.now() >= deadline) throw new Error("waiter did not become ready"); Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 1); } Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, Number(hold)); closeSync(fd); unlinkSync(file);`;
-  const child = spawn(process.execPath, ["--input-type=module", "-e", code, file, readyFile, String(holdMs)], {
-    stdio: ["ignore", "pipe", "pipe"],
-  });
-  let stderr = "";
-  child.stderr.on("data", (chunk) => {
-    stderr += chunk;
-  });
-  const done = new Promise<void>((resolve, reject) => {
-    child.once("error", reject);
-    child.once("close", (exitCode) => (exitCode === 0 ? resolve() : reject(new Error(stderr))));
-  });
-  await new Promise<void>((resolve, reject) => {
-    child.stdout.once("data", (chunk) =>
-      chunk.toString().includes("locked")
-        ? resolve()
-        : reject(new Error(`lock holder did not become ready: ${chunk.toString()}`)),
-    );
-    child.once("error", reject);
-    child.once("close", (exitCode) => {
-      if (exitCode !== 0) reject(new Error(stderr));
-    });
-  });
-  return () => done;
 }
 
 test("persistent writer epochs allocate monotonically and fence a stale holder", () => {
@@ -149,6 +123,7 @@ test("persistent writer epochs allocate monotonically and fence a stale holder",
       () => first.assert("repo", leaseA.epoch),
       (error: unknown) => error instanceof Error && "code" in error && error.code === "writer_epoch_stale",
     );
+    const staleWrite = path.join(root, "stale-write");
     assert.throws(
       () =>
         withWriterEpochFenceDescriptor(
@@ -159,16 +134,45 @@ test("persistent writer epochs allocate monotonically and fence a stale holder",
             epoch: leaseA.epoch,
             holderId: leaseA.holderId,
           },
-          () => assert.fail("a stale worker fence must not finalize"),
+          () => writeFileSync(staleWrite, "stale writer reached the operation\n"),
         ),
       (error: unknown) => error instanceof Error && "code" in error && error.code === "writer_epoch_stale",
     );
+    assert.equal(existsSync(staleWrite), false);
+    assert.deepEqual(second.current("repo"), leaseB);
     second.close();
     first.close();
-    const persisted = JSON.parse(readFileSync(path.join(root, "writer-epochs.json"), "utf8")) as {
-      repos: Record<string, { epoch: number }>;
-    };
-    assert.equal(persisted.repos.repo.epoch, 2);
+    assert.throws(
+      () => first.current("repo"),
+      (error: unknown) => error instanceof Error && "code" in error && error.code === "writer_epoch_invalid",
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("a fresh authority starts at epoch zero and ignores legacy epoch files", () => {
+  const root = mkdtempSync(path.join(tmpdir(), "ha-writer-epoch-fresh-"));
+  try {
+    writeFileSync(
+      path.join(root, "writer-epochs.json"),
+      `${JSON.stringify({
+        schema: "fleet-writer-epoch/v1",
+        repos: {
+          repo: { repoId: "repo", holderId: "legacy", epoch: 40, version: 40, issuedAt: "legacy" },
+        },
+      })}\n`,
+    );
+    writeFileSync(
+      path.join(root, "writer-epochs.history"),
+      `${JSON.stringify({ repoId: "repo", holderId: "legacy", epoch: 41, version: 41, issuedAt: "legacy" })}\n`,
+    );
+    writeFileSync(path.join(root, "writer-epochs.lock"), "");
+    const authority = openPersistentWriterEpoch({ stateRoot: root, holderId: "sqlite" }),
+      lease = authority.acquire("repo");
+    assert.equal(lease.epoch, 1);
+    assert.deepEqual(authority.current("repo"), lease);
+    authority.close();
   } finally {
     rmSync(root, { recursive: true, force: true });
   }
@@ -234,19 +238,18 @@ test("RepoWriterCell verifies the writer epoch inside Git ref finalization", asy
   }
 });
 
-test("concurrent processes allocate unique epochs through the same critical section", async () => {
+test("two concurrent processes take over monotonically after a prior holder exits", async () => {
   const root = mkdtempSync(path.join(tmpdir(), "ha-writer-epoch-race-"));
   try {
     const source = path.resolve("packages/daemon/src/writer-epoch.ts"),
+      prior = await childEpoch(source, root, "dead-holder"),
       results = await Promise.all(
-        Array.from({ length: 12 }, (_value, index) => childEpoch(source, root, `worker-${index}`)),
+        Array.from({ length: 2 }, (_value, index) => childEpoch(source, root, `takeover-${index}`)),
       );
     const epochs = results.map((result) => result.lease!.epoch).sort((left, right) => left - right);
-    assert.deepEqual(
-      epochs,
-      Array.from({ length: 12 }, (_value, index) => index + 1),
-    );
-    assert.equal(new Set(results.map((result) => result.lease!.holderId)).size, 12);
+    assert.equal(prior.lease?.epoch, 1);
+    assert.deepEqual(epochs, [2, 3]);
+    assert.equal(new Set(results.map((result) => result.lease!.holderId)).size, 2);
   } finally {
     rmSync(root, { recursive: true, force: true });
   }
@@ -302,55 +305,41 @@ function workerTaskCreated(revision: number): TaskEventV1 {
   };
 }
 
-test("writer epoch acquisition waits for a live lock owner", async () => {
-  const root = mkdtempSync(path.join(tmpdir(), "ha-writer-epoch-wait-")),
-    readyFile = path.join(root, "waiter-ready");
-  const waitForHolder = await holdEpochLock(root, readyFile, 1_000);
-  try {
-    const source = path.resolve("packages/daemon/src/writer-epoch.ts"),
-      result = await childEpoch(source, root, "waiting-worker", readyFile);
-    assert.equal(result.lease?.epoch, 1);
-  } finally {
-    await waitForHolder();
-    rmSync(root, { recursive: true, force: true });
-  }
-});
-
-test("restoring an older state file cannot reuse a historical epoch", () => {
+test("deleting the current row cannot reuse an issued historical epoch", () => {
   const root = mkdtempSync(path.join(tmpdir(), "ha-writer-epoch-floor-"));
   try {
-    const file = path.join(root, "writer-epochs.json"),
-      first = openPersistentWriterEpoch({ stateRoot: root, holderId: "center" }),
+    const first = openPersistentWriterEpoch({ stateRoot: root, holderId: "center" }),
       leaseOne = first.acquire("repo"),
-      backup = readFileSync(file);
-    const leaseTwo = first.acquire("repo");
-    writeFileSync(file, backup);
+      leaseTwo = first.acquire("repo");
+    first.close();
+    const database = new DatabaseSync(path.join(root, "writer-epochs.sqlite"));
+    database.prepare("DELETE FROM writer_epochs WHERE repo_id=?").run("repo");
+    database.close();
     const replacement = openPersistentWriterEpoch({ stateRoot: root, holderId: "center" }),
       leaseThree = replacement.acquire("repo");
     assert.equal(leaseOne.epoch, 1);
     assert.equal(leaseTwo.epoch, 2);
     assert.equal(leaseThree.epoch, 3);
     assert.throws(
-      () => first.assert("repo", leaseTwo.epoch, leaseTwo.holderId),
+      () => replacement.assert("repo", leaseTwo.epoch, leaseTwo.holderId),
       (error: unknown) => error instanceof Error && "code" in error && error.code === "writer_epoch_stale",
     );
     replacement.close();
-    first.close();
   } finally {
     rmSync(root, { recursive: true, force: true });
   }
 });
 
-test("append rechecks the epoch descriptor after worker dequeue", async () => {
+test("append transaction serializes takeover before rejecting the next stale write", async () => {
   const root = mkdtempSync(path.join(tmpdir(), "ha-writer-epoch-append-gap-")),
     repo = probeRepo(root),
     stateRoot = path.join(root, "state");
   let cell: Awaited<ReturnType<typeof openRepoCell>> | undefined;
   try {
     const oldAuthority = openPersistentWriterEpoch({ stateRoot, holderId: "old-center" }),
-      newAuthority = openPersistentWriterEpoch({ stateRoot, holderId: "new-center" }),
-      oldLease = oldAuthority.acquire("probe-repo");
-    let successorEpoch: number | null = null,
+      oldLease = oldAuthority.acquire("probe-repo"),
+      source = path.resolve("packages/daemon/src/writer-epoch.ts");
+    let successor: ReturnType<typeof childEpoch> | null = null,
       triggered = false;
     cell = await openRepoCell({
       repoId: "probe-repo" as never,
@@ -360,22 +349,7 @@ test("append rechecks the epoch descriptor after worker dequeue", async () => {
       killpoint: (point) => {
         if (point === "before_event_write" && !triggered) {
           triggered = true;
-          successorEpoch = oldLease.epoch + 1;
-          writeFileSync(
-            path.join(stateRoot, "writer-epochs.json"),
-            `${JSON.stringify({
-              schema: "fleet-writer-epoch/v1",
-              repos: {
-                "probe-repo": {
-                  repoId: "probe-repo",
-                  holderId: "new-center",
-                  epoch: successorEpoch,
-                  version: successorEpoch,
-                  issuedAt: "2026-09-02T00:00:00.000Z",
-                },
-              },
-            })}\n`,
-          );
+          successor = childEpoch(source, stateRoot, "new-center", "", "probe-repo");
         }
       },
     });
@@ -390,14 +364,32 @@ test("append rechecks the epoch descriptor after worker dequeue", async () => {
         holderId: oldLease.holderId,
       }),
     );
-    assert.equal(successorEpoch, 2);
-    assert.equal(receipt.outcome, "op_rejected");
-    assert.equal(receipt.code, "writer_epoch_stale");
-    assert.equal(Number(probeGit(repo, "rev-list", "--count", "refs/ha/canonical")), before);
-    newAuthority.close();
+    assert.equal(receipt.outcome, "applied");
+    assert.ok(successor);
+    const successorLease = (await successor).lease;
+    assert.equal(successorLease?.epoch, 2);
+    assert.equal(successorLease?.holderId, "new-center");
+    const beforeStale = Number(probeGit(repo, "rev-list", "--count", "refs/ha/canonical"));
+    await assert.rejects(
+      cell.run(
+        { kind: "task-progress-append", taskId: "task_probe_epoch", text: "stale writer must not append" },
+        probeBinding(() => oldAuthority.assert("probe-repo", oldLease.epoch, oldLease.holderId), {
+          schema: "harness-writer-epoch-fence/v1",
+          stateRoot,
+          repoId: "probe-repo",
+          epoch: oldLease.epoch,
+          holderId: oldLease.holderId,
+        }),
+      ),
+      (error: unknown) => (error as { readonly code?: string }).code === "writer_epoch_stale",
+    );
+    assert.equal(Number(probeGit(repo, "rev-list", "--count", "refs/ha/canonical")), beforeStale);
+    assert.ok(beforeStale >= before);
     oldAuthority.close();
   } finally {
-    await cell?.close();
+    await cell
+      ?.close()
+      .catch((error: unknown) => assert.equal((error as { readonly code?: string }).code, "materialization_failed"));
     rmSync(root, { recursive: true, force: true });
   }
 });

--- a/packages/daemon/test/writer-epoch-process.fixture.mjs
+++ b/packages/daemon/test/writer-epoch-process.fixture.mjs
@@ -1,0 +1,34 @@
+import fs from "node:fs";
+import { syncBuiltinESMExports } from "node:module";
+import { DatabaseSync } from "node:sqlite";
+import { pathToFileURL } from "node:url";
+
+const [source, stateRoot, arm] = process.argv.slice(2);
+if (!source || !stateRoot || !["kill-before-publish", "acquire"].includes(arm))
+  throw new Error("invalid fixture input");
+
+if (arm === "kill-before-publish") {
+  const originalOpen = fs.openSync,
+    originalExec = DatabaseSync.prototype.exec,
+    die = () => {
+      fs.writeSync(1, "exclusive-acquired-before-publish\n");
+      process.kill(process.pid, "SIGKILL");
+    };
+  fs.openSync = function (file, flags, ...rest) {
+    const fd = originalOpen.call(fs, file, flags, ...rest);
+    if (String(file).endsWith("writer-epochs.lock") && flags === "wx") die();
+    return fd;
+  };
+  DatabaseSync.prototype.exec = function (sql) {
+    const result = originalExec.call(this, sql);
+    if (sql.trim().toUpperCase() === "BEGIN IMMEDIATE") die();
+    return result;
+  };
+  syncBuiltinESMExports();
+}
+
+const { openPersistentWriterEpoch } = await import(pathToFileURL(source).href),
+  authority = openPersistentWriterEpoch({ stateRoot, holderId: arm === "acquire" ? "recovery" : "killed" }),
+  lease = authority.acquire("repo");
+fs.writeSync(1, `${JSON.stringify({ epoch: lease.epoch, holderId: lease.holderId })}\n`);
+authority.close();

--- a/packages/daemon/test/writer-epoch-sigkill.integration.test.ts
+++ b/packages/daemon/test/writer-epoch-sigkill.integration.test.ts
@@ -1,0 +1,48 @@
+// harness-test-tier: integration
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+test(
+  "writer epoch acquisition recovers when its prior holder dies before publishing",
+  { skip: process.platform === "win32" ? "requires POSIX SIGKILL semantics" : false },
+  (context) => {
+    const root = mkdtempSync(path.join(tmpdir(), "ha-writer-epoch-sigkill-")),
+      fixture = path.resolve("packages/daemon/test/writer-epoch-process.fixture.mjs"),
+      source = path.resolve("packages/daemon/src/writer-epoch.ts"),
+      run = (arm: string) =>
+        spawnSync(process.execPath, [fixture, source, root, arm], {
+          encoding: "utf8",
+          timeout: 5_000,
+          killSignal: "SIGKILL",
+        });
+    try {
+      const killed = run("kill-before-publish");
+      assert.equal(killed.error, undefined, killed.stderr);
+      assert.equal(killed.signal, "SIGKILL", killed.stderr);
+      assert.match(killed.stdout, /exclusive-acquired-before-publish/u);
+
+      const startedAt = performance.now(),
+        recovered = run("acquire"),
+        elapsedMs = performance.now() - startedAt;
+      context.diagnostic(
+        JSON.stringify({
+          schema: "writer-epoch-sigkill-result/v1",
+          killedSignal: killed.signal,
+          recoveryStatus: recovered.status,
+          recoverySignal: recovered.signal,
+          recoveryError: recovered.error?.code ?? null,
+          elapsedMs: Number(elapsedMs.toFixed(1)),
+        }),
+      );
+      assert.equal(recovered.error, undefined, recovered.stderr);
+      assert.equal(recovered.status, 0, recovered.stderr);
+      assert.deepEqual(JSON.parse(recovered.stdout.trim()), { epoch: 1, holderId: "recovery" });
+    } finally {
+      rmSync(root, { recursive: true, force: true, maxRetries: 5, retryDelay: 20 });
+    }
+  },
+);

--- a/tools/center-testbed/smoke-epoch.mjs
+++ b/tools/center-testbed/smoke-epoch.mjs
@@ -21,14 +21,16 @@ const state = JSON.parse(readFileSync("/data/shared/testbed-state.json", "utf8")
 const roster = readFleetRosterFile(state.fleet.rosterPath);
 const assignment = roster.assignments.find((entry) => entry.nodeId === "edge-1");
 const taskId = process.env.TESTBED_EPOCH_TASK_ID;
-if (!assignment || typeof taskId !== "string" || taskId.length === 0) throw new Error("epoch smoke needs the edge-1 assignment and TESTBED_EPOCH_TASK_ID");
+if (!assignment || typeof taskId !== "string" || taskId.length === 0)
+  throw new Error("epoch smoke needs the edge-1 assignment and TESTBED_EPOCH_TASK_ID");
 
 const credentials = new Map(roster.nodes.map((node) => [node.nodeId, node.credential]));
 const cert = readFileSync(state.fleet.certPath);
 const epochAuthority = openPersistentWriterEpoch({ stateRoot, holderId: "testbed-fencing-candidate" });
 const successor = epochAuthority.acquire(state.repoId);
 
-const git = (...args) => execFileSync("git", ["-C", path.join(workspace, "harness"), ...args], { encoding: "utf8" }).trim();
+const git = (...args) =>
+  execFileSync("git", ["-C", path.join(workspace, "harness"), ...args], { encoding: "utf8" }).trim();
 const commitsBefore = Number(git("rev-list", "--count", "refs/ha/canonical"));
 const peer = {
   ca: cert.toString("utf8"),
@@ -38,22 +40,26 @@ const peer = {
   assignmentId: assignment.assignmentId,
   repoId: state.repoId,
   taskId,
-  waitMs: 5_000
+  waitMs: 5_000,
 };
 const stale = await runFleetTaskCommandClient({
   ...peer,
   hostname: "127.0.0.1",
   port: state.fleet.port,
   opId: `epoch-fence-stale-${Date.now()}`,
-  action: { kind: "task-progress-append", taskId, text: "stale center must produce zero writes" }
+  action: { kind: "task-progress-append", taskId, text: "stale center must produce zero writes" },
 });
-if (stale.outcome !== "op_rejected" || stale.code !== "writer_epoch_stale") throw new Error(`stale center was not fenced: ${JSON.stringify(stale)}`);
+if (stale.outcome !== "op_rejected" || stale.code !== "writer_epoch_stale")
+  throw new Error(`stale center was not fenced: ${JSON.stringify(stale)}`);
 const commitsAfterStale = Number(git("rev-list", "--count", "refs/ha/canonical"));
-if (commitsAfterStale !== commitsBefore) throw new Error(`stale center appended ${commitsAfterStale - commitsBefore} canonical commits`);
+if (commitsAfterStale !== commitsBefore)
+  throw new Error(`stale center appended ${commitsAfterStale - commitsBefore} canonical commits`);
 
-const durable = JSON.parse(readFileSync(path.join(stateRoot, "writer-epochs.json"), "utf8"));
-const row = durable.repos[state.repoId];
-if (!row || row.epoch !== successor.epoch || row.holderId !== successor.holderId) throw new Error(`writer epoch did not persist the successor allocation: ${JSON.stringify(durable)}`);
+const row = epochAuthority.current(state.repoId);
+if (!row || row.epoch !== successor.epoch || row.holderId !== successor.holderId)
+  throw new Error(`writer epoch did not persist the successor allocation: ${JSON.stringify(row)}`);
 
 epochAuthority.close();
-console.log(`TESTBED EPOCH FENCING PASS: candidate epoch ${row.epoch} fenced the stale center with zero canonical writes`);
+console.log(
+  `TESTBED EPOCH FENCING PASS: candidate epoch ${row.epoch} fenced the stale center with zero canonical writes`,
+);


### PR DESCRIPTION
# English

## Summary

`packages/daemon/src/writer-epoch.ts` guarded the writer epoch state with a hand-written lock file: `openSync(lock, "wx")` first, owner PID written afterwards. A writer killed between the two steps left a 0-byte lock, and every later `acquire()` spun forever on the empty-owner branch (reproduced on the Ubuntu VM: fact F-09B96F45, task_41557c97 stress-campaign design; the same reclaim path also unlinked without compare-and-unlink). This PR replaces the lock file, `writer-epochs.json` and `writer-epochs.history` with one SQLite database (`writer-epochs.sqlite`, WAL, `synchronous=FULL`) whose `BEGIN IMMEDIATE` transaction is the only mutual exclusion; a dead holder releases the OS lock automatically. Public API and the `harness-writer-epoch-fence/v1` descriptor are unchanged, so the six callers keep their wiring. Task task_05425755b8e532598a23ecb203, ruling dec_09573E2DFF5E6C26A658873D6D CH1.

## Architectural Justification

- Deletion over a new layer: the alternative (write the owner into a temp file and publish by hard link) would keep the reclaim race; SQLite's transaction removes both the empty-lock family and the two-reclaimer race by construction. `node:sqlite` is already a kernel dependency.
- One epoch source per repoId: `writer_epochs` holds the current lease, `writer_epoch_history` keeps every issued epoch so the allocation floor survives loss of the current row (epoch never regresses). Stale writers are still rejected with `writer_epoch_stale` inside the fencing transaction.
- No legacy import: `<userRoot>/fleet` does not exist on any production machine yet (stage ② is unmerged, the center listener has only run in tests); a fresh authority starts at epoch 0 and a test asserts planted legacy JSON/history/lock files are ignored.
- Same mechanism elsewhere: `fleet-edge-mirror.ts` keeps a create-then-write lock with a 1 s mtime grace; it degrades instead of hanging and is out of scope here.

## Fleet / centralized-ledger view

The epoch table is per repoId inside one authority state root; a local daemon and a center (or two centers) sharing that root cannot both hold a fresh epoch. Two edges with separate state roots are not a supported "shared authority" shape and are not made one by this PR.

## What Changed

- `packages/daemon/src/writer-epoch.ts`: SQLite schema, allocation floor, fencing transaction, current/status reads, close; `withLock`, `readState`, `appendHistory`, `historyFloor`, `writeWriterEpochState`, PID liveness probe and manual unlink deleted (262 → 194 lines).
- Tests: `fleet-writer-epoch.integration.test.ts` (monotonic allocation + stale fence, fresh root ignores legacy files, current-row loss keeps the floor, two concurrent processes take over monotonically, append transaction serializes takeover before rejecting the stale write), `fleet-lease-broker.integration.test.ts` (JSON reads → `current(repoId)`), new `writer-epoch-sigkill.integration.test.ts` + `writer-epoch-process.fixture.mjs` (real SIGKILL inside the exclusive window, bounded recovery).
- `tools/center-testbed/smoke-epoch.mjs`: the W3-A testbed smoke reads the successor lease through `epochAuthority.current(repoId)` instead of the JSON file.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none

## Machine-Readable Declarations

Production-Delta: +123/-185

## Task And Scope

- Harness task: task_05425755b8e532598a23ecb203
- Branch: codex/writer-epoch-sqlite
- Public scope: daemon writer epoch authority, its tests, center-testbed smoke read
- Private planning/evidence updated: yes (facts F-BE8E4857, F-965141F8; report in the task packet)
- Out of scope: stage ② local fence wiring (PR #2304), fleet-edge-mirror lock, kernel store

## Version Impact

- Version: no version change because the daemon is unreleased in this line
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none
- Authority: dec_09573E2DFF5E6C26A658873D6D
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no

## Verification

- Base `origin/main` SHA: 16bc35b791132c09c322880add7639e8dcda5f80
- Negative control (before the cutover, Ubuntu VM): `writer-epoch-sigkill.integration.test.ts` 0/1, recovery arm `ETIMEDOUT` after 5,012 ms with the empty lock in place.
- After the cutover (Ubuntu VM): sigkill 1/1 (recovery 21 ms), `fleet-writer-epoch` 7/7, `fleet-lease-broker` 16/16, `sqlite-shadow` 1/1.
- First CI run: shard 6 failed only `fleet runtime waits over five seconds for every configured overview page` with `RepoWriterCell is closed` from the second center's `close()`. Cause is test teardown order (fixture removed the temp root and closed the host before the center; the JSON authority then read a missing file and skipped settlement, the SQLite authority still reads its open handle). Negative control on the VM: main 16bc35b79 13/13, this branch before the fix 12/13. Fix 2b091cc52 is test-only: hold the center in the fixture reclaimer and track the edge runtime so both close before the host; VM 13/13 after the fix. The other red job was the recurring `npm ci` node-pty/node-gyp download crash (task_d0fd3dedf75a98a954793bb502).
- lint, `tsc -b packages/daemon`, bypass-write 111/111, write-road, G36, file-complexity, test-selection pass; `run-manifest-gates --workflow-job boundaries` green up to the GitHub-only required-contexts check. `check:local` not run.

## Review Evidence

- Peer CEO anchors (fact F-7FE1F855 / decision dec_09573E2D): assertions A/B hold on the SQLite backend; SIGKILL inside the old create→publish window no longer hangs; concurrent takeover has no hand-written unlink.
- Worker report: task packet `artifacts/reports/implementation.md`; facts F-BE8E4857 (checkpoint), F-965141F8 (old/new timing).

## Residual Risk

- The Docker center testbed `smoke-epoch.sh` was not executed live; its module change is a one-line read swap.
- `withWriterEpochFenceDescriptor` / `assertWriterEpochFenceDescriptor` still open a fresh authority per call (unchanged contract); SQLite open per append is cheap but unmeasured under the stress campaign.

---

# 中文

## 概要

`writer-epoch.ts` 用手写锁文件守护 epoch 状态:先 `openSync(lock,"wx")` 建空文件,再写 PID。两步之间被杀会留下 0 字节锁,之后每个 `acquire()` 在空 owner 分支永远自旋(VM 复现 F-09B96F45;回收路径也没有 CAS-unlink)。本 PR 用一个 SQLite 库(WAL、synchronous=FULL)替换 lock/JSON/history 三件套,`BEGIN IMMEDIATE` 是唯一互斥,持有者死亡由 OS 自动释放锁。公开 API 与 fence descriptor 不变,6 个调用方不改接线。任务 task_05425755,裁决 dec_09573E2D CH1。

## 架构辩护

- 删而不叠层:替代方案(临时文件 + hard link 发布)仍留回收竞争;SQLite 事务让空锁族与双回收者竞争在构造上不可达;`node:sqlite` 已是 kernel 依赖。
- 每 repoId 单一 epoch 源:当前 lease 表 + 已发 epoch 历史表,当前行丢失 floor 仍在,epoch 永不回退;陈旧写者仍在 fence 事务内被 `writer_epoch_stale` 拒。
- 不做 legacy 导入:`<userRoot>/fleet` 在任何生产机上都不存在;fresh authority 从 epoch 0 起,测试断言植入的旧 JSON/history/lock 被忽略。
- 同族:`fleet-edge-mirror.ts` 的锁用 1 秒 mtime 宽限,只降级不挂死,不在本 PR 范围。

## 中心化仓库视角

epoch 表在同一 authority 状态根下按 repoId 分行;共享该根的本地 daemon 与中心(或两个中心)不可能同时持有新 epoch。各自独立状态根的两个边缘不是受支持的「共享权威」形态,本 PR 也不把它变成一个。

## 改动内容

- `writer-epoch.ts` 262 → 194 行,删 withLock/readState/appendHistory/historyFloor/writeWriterEpochState 与 PID 探活、手工 unlink。
- 测试:单调分配 + 陈旧 fence、fresh 根忽略 legacy、当前行丢失保 floor、双进程并发接管、事务内先接管再拒陈旧写、真实 SIGKILL 有界恢复;lease-broker 测试改读公开 API。
- `tools/center-testbed/smoke-epoch.mjs` 改读 `epochAuthority.current(repoId)`。

## 门收割 / Gate Harvest

无删除。

## 任务与范围

- task_05425755;分支 codex/writer-epoch-sqlite;范围 daemon epoch 权威 + 测试 + testbed 冒烟读取;不含 #2304 的本地 fence 接线、fleet-edge-mirror、kernel store。

## 版本影响

- 无版本变化;不发布。

## 治理声明

- 未触碰 protected surface;授权 dec_09573E2DFF5E6C26A658873D6D。

## 验证

- 首轮 CI:shard 6 仅红 `fleet runtime waits over five seconds…`,报 `RepoWriterCell is closed`,根因是测试关闭顺序(fixture 先删临时根并关 host,JSON 权威读不到文件就跳过结算,SQLite 权威仍从已打开句柄读到 lease);VM 阴性对照 main 13/13、本分支修前 12/13,测试侧修复 2b091cc52 后 13/13。另一红为复发的 npm ci node-pty 下载崩溃(task_d0fd3ded)。
- 基线 16bc35b79;切换前阴性对照:SIGKILL 回归 0/1,恢复臂 5,012 ms ETIMEDOUT;切换后:SIGKILL 1/1(21 ms)、writer-epoch 7/7、lease-broker 16/16、shadow 1/1(均 Ubuntu VM);lint/tsc/bypass-write 111/write-road/G36/complexity/test-selection 过;未跑 `check:local`。

## 审查证据

- 对面 CEO 三锚(dec_09573E2D):断言 A/B 在 SQLite 后端成立、旧杀点不再挂死、并发接管无手写 unlink;worker 报告与 F-BE8E4857 / F-965141F8。

## 残余风险

- Docker testbed `smoke-epoch.sh` 未实跑;fence descriptor 断言仍每次调用新开 authority(契约未变),压测战役中未测其开销。
