### PR TITLE
fix(gui): prevent a missing i18n key from crashing the renderer; add plane_zcode

### DIFF
--- a/packages/gui/src/renderer/i18n/core.ts
+++ b/packages/gui/src/renderer/i18n/core.ts
@@ -73,7 +73,7 @@ export function setActiveLocale(locale: Locale): void {
 }
 
 export function messageFor(key: MessageKey): string {
-  return catalogs[activeLocale][key] ?? catalogs["en-US"][key];
+  return catalogs[activeLocale][key] ?? catalogs["en-US"][key] ?? key;
 }
 
 function interpolate(message: string, params: MessageParams = {}): string {

--- a/packages/gui/src/renderer/i18n/locales/en-US/agentRuntime.json
+++ b/packages/gui/src/renderer/i18n/locales/en-US/agentRuntime.json
@@ -208,6 +208,7 @@
   "agentRuntime.plane_claude": "Subscription plus API on one instance: override the base URL and model to adapt a third party such as GLM.",
   "agentRuntime.plane_codex": "Codex-family models only; subscription and API are two separate call paths, each its own instance.",
   "agentRuntime.plane_agy": "Subscription login only; there is no API mode.",
+  "agentRuntime.plane_zcode": "Subscription and API are two separate call paths, each its own instance; defaults to zai.",
   "agentRuntime.witnessedInstallations": "Installations witnessed on this machine",
   "agentRuntime.witnessed": "Witnessed {kind} {version}",
   "agentRuntime.noWitnessedInstallation": "No {kind} installation witnessed — install it on this machine and put it on PATH.",

--- a/packages/gui/src/renderer/i18n/locales/zh-CN/agentRuntime.json
+++ b/packages/gui/src/renderer/i18n/locales/zh-CN/agentRuntime.json
@@ -208,6 +208,7 @@
   "agentRuntime.plane_claude": "登录态 + API 双模式:同一实例覆盖 base URL 与模型即可适配第三方(如 GLM)。",
   "agentRuntime.plane_codex": "只有 Codex 系模型;登录态与 API 是两条独立的调用方式,各建各的实例。",
   "agentRuntime.plane_agy": "只有登录态,没有 API 模式。",
+  "agentRuntime.plane_zcode": "登录态与 API 是两条独立的调用方式,各建各的实例;默认接 zai。",
   "agentRuntime.witnessedInstallations": "这台机器上探测到的安装",
   "agentRuntime.witnessed": "探测到 {kind} {version}",
   "agentRuntime.noWitnessedInstallation": "没有探测到 {kind} 的安装 —— 先在这台机器上装好并确保它在 PATH 里。",

--- a/packages/gui/test/i18n-locale-parity.vitest.ts
+++ b/packages/gui/test/i18n-locale-parity.vitest.ts
@@ -2,6 +2,7 @@
 import { readdirSync, readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 import { t, setActiveLocale, initialLocale } from "../src/renderer/i18n/core.ts";
+import { RUNTIME_KIND_IDS } from "../src/renderer/runtime-provider-planes.ts";
 
 function catalogKeys(locale: "en-US" | "zh-CN"): string[] {
   const directory = new URL(`../src/renderer/i18n/locales/${locale}/`, import.meta.url);
@@ -19,5 +20,18 @@ describe("i18n bilingual catalogs (REQ-GUI-09 language switch)", () => {
     setActiveLocale("en-US");
     expect(t("shell.nav.overview")).not.toMatch(/\{/u);
     expect(typeof initialLocale()).toBe("string");
+  });
+
+  it("has a plane_<kind> caption for every runtime kind (guards the ZCODE black-screen)", () => {
+    const keys = new Set(catalogKeys("zh-CN"));
+    for (const kindId of RUNTIME_KIND_IDS)
+      expect(keys.has(`agentRuntime.plane_${kindId}`), `missing agentRuntime.plane_${kindId}`).toBe(true);
+  });
+
+  it("returns the key itself for a missing message instead of throwing", () => {
+    setActiveLocale("zh-CN");
+    const missing = "agentRuntime.plane_does_not_exist" as never;
+    expect(() => t(missing)).not.toThrow();
+    expect(t(missing)).toBe("agentRuntime.plane_does_not_exist");
   });
 });


### PR DESCRIPTION
# English

## Summary

Selecting ZCODE in the Agent Runtime Provider "new" dialog crashed the whole renderer to a black screen. The dialog renders `t("agentRuntime.plane_<kind>")`; `plane_zcode` is absent from both locales, `messageFor` returned `undefined`, and `interpolate`'s `undefined.replace(...)` threw a `TypeError` that unmounted the React tree. Two fixes: (root) `messageFor` now falls back to the key itself so any missing key degrades to a visible key instead of crashing; (data) the `plane_zcode` caption is added to zh-CN and en-US.

## What Changed

- `packages/gui/src/renderer/i18n/core.ts`: `messageFor` returns `... ?? key` — a missing message can no longer reach `interpolate` as `undefined`.
- `packages/gui/src/renderer/i18n/locales/{zh-CN,en-US}/agentRuntime.json`: add `agentRuntime.plane_zcode`.
- `packages/gui/test/i18n-locale-parity.vitest.ts`: assert every runtime kind has a `plane_<kind>` caption (the existing parity test only compared the two locales to each other, so a key missing from both passed), and that a missing key does not throw.

## Gate Harvest

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none

## Machine-Readable Declarations

Production-Delta: +1/-1

(The two locale JSON additions are i18n data, which the production-delta gate does not count as production; the computed production delta is core.ts only, +1/-1.)

## Governance Declaration

- Protected surface touched: no
- Break-glass: no

## Verification

- `npx vitest run test/i18n-locale-parity.vitest.ts` in `packages/gui`: 4/4 pass after the fix.
- Negative control: stashing only the production changes (keeping the tests) reruns red on both new tests — `missing agentRuntime.plane_zcode`, and `TypeError: Cannot read properties of undefined` (the exact black-screen root cause). Restored and green.
- Not run: full suite by policy (worker stop point is the directed test). CI is the authority.

## Review Evidence

- Self-review: CEO located the root cause in source (fact F-38552FA4) and wrote the fix and the two guard tests; the negative control reproduces the black-screen `TypeError` and proves the fix.

## Residual Risk

- The renderer has no error boundary around dialog rendering; this PR removes the specific crash and the whole missing-key family, but an unrelated render throw would still unmount the tree. Tracked separately if desired.

## References

- Harness task: task_2cd183384754cc485c19822697; fact F-38552FA4

---

# 中文

## 概要

Agent Runtime Provider 新建对话框里点 ZCODE 导致整个 renderer 崩成黑屏。对话框渲染 `t("agentRuntime.plane_<kind>")`;`plane_zcode` 两个 locale 都没有,`messageFor` 返回 `undefined`,`interpolate` 的 `undefined.replace(...)` 抛 `TypeError` 卸载了 React 树。两处修复:(根本)`messageFor` fallback 到 key 本身,任何缺失 key 降级为显示 key 而非崩溃;(数据)补 zh-CN/en-US 的 `plane_zcode` 文案。

## 改动内容

- `core.ts`:`messageFor` 返回 `... ?? key`,缺失消息不再以 `undefined` 进入 `interpolate`。
- 两个 `agentRuntime.json`:新增 `agentRuntime.plane_zcode`。
- 测试:断言每个 runtime kind 都有 `plane_<kind>` 文案(原 parity 测试只比对两 locale 互相一致,两者都缺就漏过),并断言缺失 key 不抛。

## 验证

- `packages/gui` 内 `npx vitest run test/i18n-locale-parity.vitest.ts`:修复后 4/4。
- 阴性对照:只 stash 生产改动(留测试)复跑,两个新测试红——`missing agentRuntime.plane_zcode` 与 `TypeError: Cannot read properties of undefined`(正是黑屏根因),恢复后转绿。
- 未跑整套(按纪律,停止点是定向测试);CI 是权威。

## 残余风险

- renderer 对话框渲染没有 error boundary;本 PR 消掉了这个具体崩溃与整个 missing-key 族,但无关的渲染抛错仍会卸载树,需要另行跟踪。
