### PR TITLE
fix(store): keep the original error when ROLLBACK fails after SQLite already rolled back

### DIFF
--- a/packages/daemon/src/writer-epoch.ts
+++ b/packages/daemon/src/writer-epoch.ts
@@ -2,7 +2,7 @@ import { randomUUID } from "node:crypto";
 import { mkdirSync } from "node:fs";
 import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
-import type { WalMaterializationFenceV1 } from "../../kernel/src/index.ts";
+import { consumeKnownError, type WalMaterializationFenceV1 } from "../../kernel/src/index.ts";
 
 export interface WriterEpochLease {
   readonly repoId: string;
@@ -90,7 +90,11 @@ export function openPersistentWriterEpoch(options: {
       database.exec("COMMIT");
       return result;
     } catch (error) {
-      database.exec("ROLLBACK");
+      try {
+        database.exec("ROLLBACK");
+      } catch (rollbackError) {
+        consumeKnownError(rollbackError);
+      }
       throw error;
     }
   };

--- a/packages/kernel/src/store/sqlite-event-store.ts
+++ b/packages/kernel/src/store/sqlite-event-store.ts
@@ -10,6 +10,7 @@ import { resolveHarnessLayout, type HarnessLayoutInput } from "../layout/index.t
 import { localRuntimeStateFileSystem } from "../local/local-layout-file-system.ts";
 import { replayClaim, replayRelease, replayRenew } from "../projection/rebuildable-task-projection-runtime.ts";
 import { TaskEventStoreError } from "./task-event-store-types.ts";
+import { consumeKnownError } from "../error-consumption.ts";
 
 export const SQLITE_LEDGER_GENERATION = 1;
 
@@ -116,7 +117,13 @@ export function openSqliteEventStore(options: {
       /* @gate-identity check-bypass-write-boundary/bypass-write-124 */ db.exec("COMMIT");
       return result;
     } catch (error) {
-      /* @gate-identity check-bypass-write-boundary/bypass-write-123 */ db.exec("ROLLBACK");
+      // SQLite may already have rolled back on its own (I/O error, disk full); a failing ROLLBACK
+      // must not replace the original error, which is the only record of the root cause.
+      try {
+        /* @gate-identity check-bypass-write-boundary/bypass-write-123 */ db.exec("ROLLBACK");
+      } catch (rollbackError) {
+        consumeKnownError(rollbackError);
+      }
       throw error;
     }
   };


### PR DESCRIPTION
# English

## Summary

When a SQLite write fails with an I/O error (EIO, ENOSPC, short write) SQLite rolls the transaction back on its own. The transaction wrapper in `packages/kernel/src/store/sqlite-event-store.ts` then executed `ROLLBACK` inside its `catch`, which throws `cannot rollback - no transaction is active`, and that message replaced the original error. The stress campaign's first storage arm (task_92f597d5, fact F-01423378) injected one EIO into the shadow WAL with strace and the only RepoCell log line was the rollback message, so the failure cause could not be classified. This PR swallows a failing `ROLLBACK` and rethrows the original error, in the event store and in the SQLite-backed writer epoch authority (`packages/daemon/src/writer-epoch.ts`, same pattern). Task task_cdbe3567c1f3960beae5d421c8.

## Architectural Justification

- The original error is the only record of the root cause; a rollback failure after an automatic rollback carries no information. Preserving it is a precondition for the stress campaign's `shadowFailureCause` classification (physical-io vs fence-unavailable vs unknown) and for the structured shadow-failure record (task_473cd4ac).
- No behaviour change on the success path or on ordinary failures where `ROLLBACK` succeeds.

## Fleet / centralized-ledger view

Error propagation only; no change to what is written or when.

## What Changed

- `sqlite-event-store.ts` `transaction()`: `try { ROLLBACK } catch { consumeKnownError } ; throw error`.
- `writer-epoch.ts` `withImmediateTransaction()`: same.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none

## Machine-Readable Declarations

Production-Delta: +14/-3

## Task And Scope

- Harness task: task_cdbe3567c1f3960beae5d421c8
- Branch: codex/store-rollback-mask
- Public scope: two transaction wrappers
- Private planning/evidence updated: yes (fact F-01423378 from the S2 arm; S2 round 3 re-runs the arm on top of this fix)
- Out of scope: structured shadow-failure records (task_473cd4ac), receipt errcode/errstr (task_eb87096f)

## Version Impact

- Version: no version change because error propagation only
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none
- Authority: not applicable
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no

## Verification

- Base `origin/main` SHA: 84b3094408c5c3cb65934c3ccd5ccd0b08437206
- Negative control: the S2 strace arm on the previous code logged only `cannot rollback - no transaction is active` for an injected `pwrite64 = -1 EIO` (F-01423378); S2 round 3 re-runs the same arm on this branch and must log the SQLite I/O error (reported in the task).
- tsc kernel+daemon 0; bypass-write 111/111 (the ROLLBACK marker kept); Ubuntu VM: `sqlite-event-store.integration.test.ts`, `fleet-writer-epoch.integration.test.ts`, `writer-epoch-sigkill.integration.test.ts` 10/10, 7/7, 1/1. `check:local` not run.

## Review Evidence

- S2 round-2 report and F-01423378; CEO-authored fix (known diff, no worker).

## Residual Risk

- If node:sqlite places the I/O detail only in `errcode`/`errstr` rather than the message, the log line will still need those fields (task_eb87096f covers receipts).

---

# 中文

## 概要

SQLite 写失败(EIO/ENOSPC/短写)时会自行回滚;`sqlite-event-store.ts` 的 `transaction()` 在 catch 里再执行 ROLLBACK,抛出 `cannot rollback - no transaction is active`,把原始错误盖掉。压测 S2 第一条存储臂用 strace 注入一次 EIO,RepoCell 日志只剩这条回滚信息,无法归因(F-01423378)。本 PR 让 ROLLBACK 失败被吞、原始错误原样上抛;`writer-epoch.ts` 同写法同修。task_cdbe3567。

## 架构辩护

- 原始错误是根因唯一记录;自动回滚后的回滚失败不含信息。保留它是 shadowFailureCause 分类与影子失败结构化记录(task_473cd4ac)的前提。成功路径与普通失败路径行为不变。

## 中心化仓库视角

只改错误传播,不改写入内容与时机。

## 改动内容

两个事务包装器的 catch 分支。

## 门收割 / Gate Harvest

无删除。

## 任务与范围

- task_cdbe3567;分支 codex/store-rollback-mask;范围两处包装器;结构化记录与回执 errcode 另有任务。

## 版本影响

- 无版本变化;不发布。

## 治理声明

- 未触碰 protected surface。

## 验证

- 阴性对照:S2 臂在旧代码上仅记录回滚信息(F-01423378),第三轮在本分支重跑须记录 SQLite I/O 错误;tsc 0、bypass-write 111/111、VM store 10/10、writer-epoch 7/7、SIGKILL 1/1;未跑 `check:local`。

## 审查证据

- S2 第二轮报告与 F-01423378;CEO 亲写的已知 diff。

## 残余风险

- 若 node:sqlite 只把 I/O 细节放在 errcode/errstr 而不在 message,日志仍需这些字段(task_eb87096f 覆盖回执侧)。
