### PR TITLE
fix(projection): keep the projection writer open across operations and surface SQLite error detail

### DIFF
--- a/packages/daemon/src/protocol/daemon-protocol-gui-types.ts
+++ b/packages/daemon/src/protocol/daemon-protocol-gui-types.ts
@@ -843,7 +843,11 @@ export interface DaemonProtocolErrorResult {
   readonly origin: "daemon";
   readonly code: string;
   readonly evidence: string;
-  readonly error: { readonly code: string };
+  readonly error: {
+    readonly code: string;
+    readonly errcode?: number;
+    readonly errstr?: string;
+  };
   readonly diagnostic?: ReceiptDiagnostic;
 }
 

--- a/packages/daemon/src/protocol/daemon-protocol-validate-results.ts
+++ b/packages/daemon/src/protocol/daemon-protocol-validate-results.ts
@@ -364,13 +364,17 @@ export function validateDaemonProtocolError(value: unknown): readonly string[] {
     ["evidence", value.evidence, nonEmpty(value.evidence), "must be a non-empty string"],
   ] as const)
     if (!valid) return [validationError(entityId, field, actual, expectation)];
-  const errorShapeError = recordShapeError(entityId, value.error, ["code"], undefined, "error");
+  const errorShapeError = recordShapeError(entityId, value.error, ["code"], ["code", "errcode", "errstr"], "error");
   if (errorShapeError) return [errorShapeError];
   if (!isJsonObject(value.error)) return [];
   if (!nonEmpty(value.error.code))
     return [validationError(entityId, "error.code", value.error.code, "must be a non-empty string")];
   if (value.code !== value.error.code)
     return [validationError(entityId, "error.code", value.error.code, "must equal code")];
+  if (value.error.errcode !== undefined && (!integer(value.error.errcode) || Number(value.error.errcode) < 0))
+    return [validationError(entityId, "error.errcode", value.error.errcode, "must be a non-negative integer")];
+  if (value.error.errstr !== undefined && !nonEmpty(value.error.errstr))
+    return [validationError(entityId, "error.errstr", value.error.errstr, "must be a non-empty string")];
   if (value.diagnostic !== undefined && !isStructuredDiagnostic(value.diagnostic))
     return [validationError(entityId, "diagnostic", value.diagnostic, "must be a structured receipt diagnostic")];
   return [];
@@ -548,8 +552,10 @@ export function daemonProtocolError(
   code: string,
   hint: string,
   explicitDiagnostic?: DaemonProtocolErrorResult["diagnostic"],
+  sourceError?: unknown,
 ): DaemonProtocolErrorResult {
-  const diagnostic = explicitDiagnostic ?? validationDiagnostic(hint);
+  const diagnostic = explicitDiagnostic ?? validationDiagnostic(hint),
+    sqliteError = sqliteErrorDetails(sourceError);
   return {
     schema: "command-receipt/v2",
     ok: false,
@@ -559,9 +565,17 @@ export function daemonProtocolError(
     origin: "daemon",
     code,
     evidence: `rejection:${code}`,
-    error: { code },
+    error: { code, ...sqliteError },
 
     ...(diagnostic ? { diagnostic } : {}),
+  };
+}
+
+function sqliteErrorDetails(error: unknown): { readonly errcode?: number; readonly errstr?: string } {
+  if (!isJsonObject(error)) return {};
+  return {
+    ...(integer(error.errcode) && Number(error.errcode) >= 0 ? { errcode: Number(error.errcode) } : {}),
+    ...(nonEmpty(error.errstr) ? { errstr: error.errstr } : {}),
   };
 }
 

--- a/packages/daemon/src/protocol/json-rpc-dispatch-support.ts
+++ b/packages/daemon/src/protocol/json-rpc-dispatch-support.ts
@@ -74,8 +74,16 @@ export function resultErrorCode(result: object): string | null {
 export function resultErrorDetail(result: object): string | null {
   if (resultOk(result)) return null;
   const diagnostic = "diagnostic" in result ? result.diagnostic : undefined,
+    error = "error" in result ? result.error : undefined,
+    sqliteError = isJsonObject(error)
+      ? {
+          ...(typeof error.errcode === "number" ? { errcode: error.errcode } : {}),
+          ...(typeof error.errstr === "string" ? { errstr: error.errstr } : {}),
+        }
+      : {},
     detail =
       (isJsonObject(diagnostic) ? JSON.stringify(diagnostic) : null) ??
+      (Object.keys(sqliteError).length > 0 ? JSON.stringify(sqliteError) : null) ??
       ("evidence" in result && typeof result.evidence === "string" ? result.evidence : null);
   return detail?.slice(0, 500) ?? "Unknown request failure.";
 }

--- a/packages/daemon/src/protocol/json-rpc-server.ts
+++ b/packages/daemon/src/protocol/json-rpc-server.ts
@@ -610,12 +610,9 @@ export function createJsonRpcProtocolServer(options: {
 }
 
 function protocolFailure(command: string, error: unknown) {
-  return daemonProtocolError(
-    command,
-    rpcServerErrorCode(error),
-    protocolErrorMessage(error),
-    diagnosticForError(error),
-  );
+  const code = rpcServerErrorCode(error),
+    message = protocolErrorMessage(error);
+  return daemonProtocolError(command, code, message, diagnosticForError(error), error);
 }
 
 function isContractedDaemonRpcMethod(method: string): method is DaemonRpcMethod {

--- a/packages/daemon/test/conn-log.test.ts
+++ b/packages/daemon/test/conn-log.test.ts
@@ -41,6 +41,16 @@ test("request failure detail records the structured diagnostic instead of prose 
   assert.equal(resultErrorDetail({ ok: true }), null);
 });
 
+test("request failure detail records native SQLite result details", () => {
+  assert.equal(
+    resultErrorDetail({
+      ok: false,
+      error: { code: "ERR_SQLITE_ERROR", errcode: 5, errstr: "database is locked" },
+    }),
+    '{"errcode":5,"errstr":"database is locked"}',
+  );
+});
+
 test("conn log records open/request/close with monotonic ids, active counts, and per-connection request totals", async () => {
   const userRoot = tempRoot(),
     log = openDaemonConnLog({ userRoot, daemonId: "test-daemon", now: at("2026-08-20T13:00:00Z") });

--- a/packages/daemon/test/json-rpc-protocol.test.ts
+++ b/packages/daemon/test/json-rpc-protocol.test.ts
@@ -990,6 +990,50 @@ test("JSON-RPC failure receipt carries formal operation identity and origin", as
   assert.ok(malformed && !Array.isArray(malformed) && "result" in malformed); if (malformed && !Array.isArray(malformed) && "result" in malformed) assert.equal((malformed.result as Record<string, unknown>).code, "invalid_request");
 });
 
+test("JSON-RPC read failures retain native SQLite result details", async (t) => {
+  const sqliteError = Object.assign(new Error("database is locked"), {
+      code: "ERR_SQLITE_ERROR",
+      errcode: 5,
+      errstr: "database is locked",
+    }),
+    host = {
+      read: async () => {
+        throw sqliteError;
+      },
+    } as never,
+    server = createJsonRpcProtocolServer({
+      host,
+      build: { commit: null },
+      authContext: { transportKind: "unix-socket" },
+      emit: async () => undefined,
+    });
+  try {
+    await server.handle({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "protocol.hello",
+      params: { protocolVersion: currentDaemonProtocolVersion },
+    });
+    const response = await server.handle({
+      jsonrpc: "2.0",
+      id: 2,
+      method: "repo.tasks.list",
+      params: { repo: { repoId: "sqlite-error" }, payload: { limit: 1 } },
+    });
+    assert.ok(response && !Array.isArray(response) && "result" in response);
+    if (response && !Array.isArray(response) && "result" in response) {
+      t.diagnostic(`SQLite rejection receipt: ${JSON.stringify(response.result)}`);
+      assert.deepEqual((response.result as { error: unknown }).error, {
+        code: "ERR_SQLITE_ERROR",
+        errcode: 5,
+        errstr: "database is locked",
+      });
+    }
+  } finally {
+    server.close();
+  }
+});
+
 // prettier-ignore
 
 test("local daemon stop acknowledges the control request and triggers shutdown", async () => {

--- a/packages/daemon/test/validator-diagnostic-contract.test.ts
+++ b/packages/daemon/test/validator-diagnostic-contract.test.ts
@@ -380,3 +380,18 @@ test("protocol validation failures preserve entity, field, and actual as structu
   });
   assert.deepEqual(validateDaemonProtocolError(receipt), []);
 });
+
+test("protocol SQLite failures preserve native result details in the error object", () => {
+  const sqliteError = Object.assign(new Error("database is locked"), {
+      code: "ERR_SQLITE_ERROR",
+      errcode: 5,
+      errstr: "database is locked",
+    }),
+    receipt = daemonProtocolError("repo.tasks.list", sqliteError.code, sqliteError.message, undefined, sqliteError);
+  assert.deepEqual(receipt.error, {
+    code: "ERR_SQLITE_ERROR",
+    errcode: 5,
+    errstr: "database is locked",
+  });
+  assert.deepEqual(validateDaemonProtocolError(receipt), []);
+});

--- a/packages/kernel/src/projection/rebuildable-task-projection-database.ts
+++ b/packages/kernel/src/projection/rebuildable-task-projection-database.ts
@@ -218,25 +218,25 @@ function projectionDatabaseOwner(
   const use = <A>(operation: (database: DatabaseSync) => A): A => {
     // A query operation can call back into this same owner while its own `operation` is still
     // running (an event-shape migration's rewrite reads the scratch projection it is replaying
-    // into, mid-round). useDepth makes that reentrant: only the outermost call opens or closes
-    // the handle, so a nested call reuses the still-open connection instead of closing it out
-    // from under the frame that is still using it.
+    // into, mid-round). useDepth makes that reentrant, so a nested call reuses the still-open
+    // connection instead of initializing a second owner.
     if (useDepth === 0) {
       if (db !== null && fingerprint !== projectionFileFingerprint(projectionPath)) close();
       if (db === null) initialize();
     }
     useDepth += 1;
+    let succeeded = false;
     try {
       const observed = projectionSchemaVersion(db!);
       if (observed !== null && observed > taskProjectionSchemaVersion)
         throw new ProjectionSchemaMismatchError(observed, projectionPath);
       assertLedgerIdentity(db!, readHead());
-      return operation(db!);
+      const value = operation(db!);
+      succeeded = true;
+      return value;
     } finally {
       useDepth -= 1;
-      // A completed writer operation publishes the main projection file, not SQLite's
-      // process-local WAL index. Query readers keep their own short-lived snapshot open.
-      if (useDepth === 0) close();
+      if (!succeeded && useDepth === 0) close();
     }
   };
   const owner = { use, close };

--- a/packages/kernel/test/store/projection-reader-close-contention.fixture.ts
+++ b/packages/kernel/test/store/projection-reader-close-contention.fixture.ts
@@ -1,0 +1,86 @@
+import { parentPort, workerData } from "node:worker_threads";
+import { makeTaskProjectionReader } from "../../src/projection/rebuildable-task-projection.ts";
+import { closeDatabase, withDatabase } from "../../src/projection/rebuildable-task-projection-database.ts";
+
+interface WorkerInput {
+  readonly role: "reader" | "writer";
+  readonly rootDir: string;
+  readonly projectionPath: string;
+  readonly start: SharedArrayBuffer;
+  readonly stop: SharedArrayBuffer;
+  readonly rows: number;
+  readonly payloadBytes: number;
+}
+
+interface SQLiteFailure {
+  readonly code: string | null;
+  readonly errcode: number | null;
+  readonly errstr: string | null;
+  readonly message: string;
+}
+
+const input = workerData as WorkerInput,
+  start = new Int32Array(input.start),
+  stop = new Int32Array(input.stop);
+
+try {
+  if (input.role === "writer") runWriter();
+  else runReader();
+} catch (error) {
+  parentPort!.postMessage({ ok: false, role: input.role, error: sqliteFailure(error) });
+}
+
+function runWriter(): void {
+  const readHead = () => null;
+  parentPort!.postMessage({ ready: true, role: "writer" });
+  withDatabase(input.projectionPath, readHead, (db) => {
+    db.exec(
+      "PRAGMA wal_autocheckpoint = 0; BEGIN; " +
+        "CREATE TABLE IF NOT EXISTS close_contention_payload(id INTEGER PRIMARY KEY, body BLOB NOT NULL); " +
+        "DELETE FROM close_contention_payload",
+    );
+    const insert = db.prepare("INSERT INTO close_contention_payload(id, body) VALUES (?, ?)");
+    const payload = Buffer.alloc(input.payloadBytes, 1);
+    for (let row = 0; row < input.rows; row += 1) insert.run(row, payload);
+    db.exec("COMMIT");
+    // The controller starts readers from this observed commit boundary. Returning now exercises
+    // the production owner's success lifetime, which used to close and clean up the WAL here.
+    parentPort!.postMessage({ closing: true, role: "writer" });
+  });
+  parentPort!.postMessage({ written: true, role: "writer" });
+  Atomics.wait(stop, 0, 0);
+  closeDatabase(input.projectionPath, readHead);
+  parentPort!.postMessage({ ok: true, role: "writer" });
+}
+
+function runReader(): void {
+  const reader = makeTaskProjectionReader({ rootDir: input.rootDir, projectionPath: input.projectionPath });
+  let samples = 0;
+  parentPort!.postMessage({ ready: true, role: "reader" });
+  try {
+    Atomics.wait(start, 0, 0);
+    while (Atomics.load(stop, 0) === 0) {
+      const cut = reader.withSession((queries) => queries.list({ limit: 1 }));
+      if (cut.watermark !== 0 || cut.sourceRevision !== 0)
+        throw new Error(`reader left the completed projection cut: ${JSON.stringify(cut)}`);
+      samples += 1;
+      if (samples === 1) parentPort!.postMessage({ sampled: true, role: "reader" });
+      Atomics.wait(stop, 0, 0, 1);
+    }
+    parentPort!.postMessage({ ok: true, role: "reader", samples });
+  } catch (error) {
+    parentPort!.postMessage({ ok: false, role: "reader", samples, error: sqliteFailure(error) });
+  } finally {
+    reader.close();
+  }
+}
+
+function sqliteFailure(error: unknown): SQLiteFailure {
+  const record = error && typeof error === "object" ? (error as Record<string, unknown>) : {};
+  return {
+    code: typeof record.code === "string" ? record.code : null,
+    errcode: typeof record.errcode === "number" ? record.errcode : null,
+    errstr: typeof record.errstr === "string" ? record.errstr : null,
+    message: error instanceof Error ? error.message : String(error),
+  };
+}

--- a/packages/kernel/test/store/projection-reader-close-contention.integration.test.ts
+++ b/packages/kernel/test/store/projection-reader-close-contention.integration.test.ts
@@ -1,0 +1,133 @@
+// harness-test-tier: integration
+import assert from "node:assert/strict";
+import { Worker } from "node:worker_threads";
+import test from "node:test";
+import { makeTaskProjection } from "../../src/projection/rebuildable-task-projection.ts";
+import { withTempStoreAsync } from "./helpers.ts";
+
+interface WorkerResult {
+  readonly ok: boolean;
+  readonly role: "reader" | "writer";
+  readonly samples?: number;
+  readonly error?: {
+    readonly code: string | null;
+    readonly errcode: number | null;
+    readonly errstr: string | null;
+    readonly message: string;
+  };
+}
+
+test("a persistent writer owner keeps query-only readers on the completed cut after a large commit", async () => {
+  await withTempStoreAsync(async (rootDir) => {
+    const eventStore = {
+        readHead: () => null,
+        readBatch: () => ({
+          sourceRevision: 0,
+          events: [],
+          cursor: null,
+          done: true,
+          accessedItems: 0,
+          prefetchContent: () => new Map(),
+        }),
+        readContentBlob: () => null,
+      },
+      projection = makeTaskProjection({ rootDir, eventStore }),
+      start = new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT),
+      stop = new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT),
+      common = {
+        rootDir,
+        projectionPath: projection.path,
+        start,
+        stop,
+        rows: 1024,
+        payloadBytes: 1024 * 1024,
+      };
+    projection.catchUp();
+    projection.close();
+
+    const readers = Array.from({ length: 3 }, () => startWorker({ ...common, role: "reader" })),
+      writer = startWorker({ ...common, role: "writer" });
+    await Promise.all([...readers.map(({ ready }) => ready), writer.ready]);
+    await writer.closing;
+    Atomics.store(new Int32Array(start), 0, 1);
+    Atomics.notify(new Int32Array(start), 0);
+    await Promise.all([writer.written, ...readers.map(({ firstSettled }) => firstSettled)]);
+    Atomics.store(new Int32Array(stop), 0, 1);
+    Atomics.notify(new Int32Array(stop), 0);
+    const [writerResult, ...readerResults] = await Promise.all([writer.result, ...readers.map(({ result }) => result)]);
+    assert.equal(writerResult.ok, true, JSON.stringify(writerResult));
+    assert.ok(
+      readerResults.every(({ samples }) => (samples ?? 0) > 0),
+      JSON.stringify(readerResults),
+    );
+    assert.deepEqual(
+      readerResults.filter(({ ok }) => !ok),
+      [],
+      `query-only reader failures: ${JSON.stringify(readerResults)}`,
+    );
+  });
+});
+
+function startWorker(input: object): {
+  readonly ready: Promise<void>;
+  readonly closing: Promise<void>;
+  readonly written: Promise<void>;
+  readonly firstSettled: Promise<void>;
+  readonly result: Promise<WorkerResult>;
+} {
+  const worker = new Worker(new URL("./projection-reader-close-contention.fixture.ts", import.meta.url), {
+    execArgv: process.execArgv.filter(
+      (argument) => argument === "--experimental-strip-types" || argument === "--enable-source-maps",
+    ),
+    workerData: input,
+  });
+  let signalReady!: () => void,
+    signalClosing!: () => void,
+    signalWritten!: () => void,
+    signalFirstSettled!: () => void,
+    accept!: (result: WorkerResult) => void,
+    reject!: (error: Error) => void;
+  const ready = new Promise<void>((resolve) => {
+      signalReady = resolve;
+    }),
+    result = new Promise<WorkerResult>((resolve, rejectResult) => {
+      accept = resolve;
+      reject = rejectResult;
+    }),
+    closing = new Promise<void>((resolve) => {
+      signalClosing = resolve;
+    }),
+    written = new Promise<void>((resolve) => {
+      signalWritten = resolve;
+    }),
+    firstSettled = new Promise<void>((resolve) => {
+      signalFirstSettled = resolve;
+    });
+  worker.on("message", (message: unknown) => {
+    if (!message || typeof message !== "object" || Array.isArray(message)) return;
+    const record = message as Record<string, unknown>;
+    if (record.ready === true) signalReady();
+    if (record.closing === true) signalClosing();
+    if (record.written === true) signalWritten();
+    if (record.sampled === true) signalFirstSettled();
+    if (typeof record.ok === "boolean") {
+      signalReady();
+      signalClosing();
+      signalWritten();
+      signalFirstSettled();
+      accept(record as unknown as WorkerResult);
+    }
+  });
+  const fail = (error: Error) => {
+    signalReady();
+    signalClosing();
+    signalWritten();
+    signalFirstSettled();
+    reject(error);
+  };
+  worker.once("error", fail);
+  worker.once("exit", (code) => {
+    if (code !== 0) fail(new Error(`projection contention worker exited ${code}`));
+  });
+  return { ready, closing, written, firstSettled, result };
+}

--- a/packages/kernel/test/store/task-projection.test.ts
+++ b/packages/kernel/test/store/task-projection.test.ts
@@ -236,6 +236,7 @@ test("headless direct apply retains its ahead cache and refuses reopen or rebuil
       });
     const live = makeTaskProjection({ rootDir, eventStore: headlessStore() });
     live.apply(event, taskLifecycleWritePlan(event));
+    live.close();
     const retained = readFileSync(live.path);
     const rejectsAheadCache = (error: unknown): boolean => {
       assert.equal(error instanceof Error, true);

--- a/tools/gates/test/publication-invariants.test.mjs
+++ b/tools/gates/test/publication-invariants.test.mjs
@@ -124,6 +124,26 @@ test("G29 matches governed WAL declarations by exact path", () => {
   );
 });
 
+test("G29 treats a declared SQLite database as its main file plus -wal and -shm, nothing wider", () => {
+  const plan = Object.freeze({
+    commandType: "LeaseTest",
+    targets: Object.freeze([Object.freeze({ kind: "lease_sqlite" })]),
+  });
+  const sidecars = new Map([
+    [".harness/cache/task.sqlite", "main"],
+    [".harness/cache/task.sqlite-wal", "wal"],
+    [".harness/cache/task.sqlite-shm", "shm"],
+  ]);
+  assert.doesNotThrow(() => assertChangedPathsDeclared(new Map(), sidecars, plan));
+  const widened = new Map([...sidecars, [".harness/cache/task.sqlite.backup", "copy"]]);
+  assert.throws(
+    () => assertChangedPathsDeclared(new Map(), widened, plan),
+    (error) =>
+      /G29 undeclared byte mutation: \.harness\/cache\/task\.sqlite\.backup$/u.test(error.message) &&
+      !/sqlite-wal|sqlite-shm/u.test(error.message),
+  );
+});
+
 test("G29 doc publication rejects extra, missing, and late targets before Git or SQLite mutation", () => {
   const rootDir = mkdtempSync(path.join(tmpdir(), "ha-g29-doc-"));
   try {
@@ -229,13 +249,18 @@ function assertChangedPathsDeclared(before, after, plan) {
   if (undeclared.length > 0) throw new Error(`G29 undeclared byte mutation: ${undeclared.join(", ")}`);
 }
 
+/** WAL-mode SQLite keeps one logical database in three files; exact suffixes, never a glob. */
+function SQLITE_DATABASE_FOOTPRINT(mainFile) {
+  return [mainFile, `${mainFile}-wal`, `${mainFile}-shm`];
+}
+
 function declaredMatchers(plan) {
   return plan.targets.flatMap((target) => {
     if (target.kind === "event_file" || target.kind === "event_head") return [exact(target.path)];
     if (target.kind === "local_wal_file") return [exact(target.path)];
     if (target.kind === "authored_file") return [exact(`harness/${target.path}`)];
     if (target.kind === "projection_invalidation" || target.kind === "lease_sqlite")
-      return [exact(".harness/cache/task.sqlite")];
+      return SQLITE_DATABASE_FOOTPRINT(".harness/cache/task.sqlite").map(exact);
     return target.kind === "content_blob" ? [exact(`harness/${contentObjectRelativePath(target.sha256)}`)] : [];
   });
 }


### PR DESCRIPTION
# English

## Summary

Under integration-shard load, projection reads failed with `ERR_SQLITE_ERROR: database is locked` (twice on 2026-09-05, facts F-660A607D and F-534FA629). Mechanism, reproduced on the Ubuntu VM against production code: the projection owner closed its writer `DatabaseSync` after every operation, so each write ended with SQLite's last-connection cleanup (checkpoint + WAL/SHM removal under an exclusive lock); a query-only reader opening in that window got SQLITE_BUSY (errcode 5) and the 250 ms reader budget was exceeded on a slow runner. Fix: the owner keeps the writer handle open across successful operations until the projection's explicit `close()`, a discard/rebuild, a file-identity change, or a failed operation; readers stay short-lived with `BEGIN … COMMIT` snapshot isolation. The daemon's protocol error result now carries SQLite's `errcode`/`errstr` so receipts and connection logs name the cause. Task task_eb87096f7c0a258e5dffe05f7d.

## Architectural Justification

- The fix removes the per-operation open/close churn that manufactured the exclusive-cleanup window; raising the reader timeout (rejected) would only lengthen the wait, and `SQLITE_FCNTL_PERSIST_WAL` is not reachable from `node:sqlite`'s public API.
- Receipt honesty: `error.errcode` / `error.errstr` are optional wire fields on `DaemonProtocolErrorResult`, validated strictly; the fixed `error: { code }` shape that dropped the detail is gone (task_89cc19f9 family).
- No retry layer, no compatibility branch.

## Fleet / centralized-ledger view

Per-repository projection cache only; each node keeps its own owner handle. No change to canonical writes or to replica cuts (which ship the ledger, not the projection).

## What Changed

- `packages/kernel/src/projection/rebuildable-task-projection-database.ts`: owner closes only on failure, identity change or explicit close.
- `packages/daemon/src/protocol/{daemon-protocol-gui-types.ts,daemon-protocol-validate-results.ts,json-rpc-dispatch-support.ts,json-rpc-server.ts}`: `errcode`/`errstr` extracted from Node SQLite errors, validated, logged.
- Tests: new `projection-reader-close-contention.integration.test.ts` (+ fixture): a 1 GiB-WAL writer commits and closes while three readers open through the real query-only path; red on main (3/3 readers errcode 5 `database is locked`, 0 samples), green on this branch; `task-projection.test.ts` now closes the live owner before comparing main-file bytes (the WAL is expected to stay open during the owner's lifetime); protocol/validator/conn-log tests for the new fields.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none

## Machine-Readable Declarations

Production-Delta: +40/-17

## Task And Scope

- Harness task: task_eb87096f7c0a258e5dffe05f7d
- Branch: codex/projection-busy
- Public scope: projection owner lifecycle, protocol error detail, tests
- Private planning/evidence updated: yes (F-9372E139 round 1, F-EF5497D1 round 2)
- Out of scope: kernel store, writer epoch, CI

## Version Impact

- Version: no version change because behaviour under contention and error detail only
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none
- Authority: not applicable
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no

## Verification

- Base `origin/main` SHA: 84b3094408c5c3cb65934c3ccd5ccd0b08437206
- Ubuntu VM: contention test red on main (errcode 5, `database is locked`, samples 0) → green on df5dc4e0c (1/1); `task-projection.test.ts` 26/26; `validator-diagnostic-contract.test.ts` 7/7; `conn-log.test.ts` 8/8; `json-rpc-protocol.test.ts` 56/56; `provider-fallback.integration.test.ts` 2/2; `runtime-cli.integration.test.ts` 1/1.
- typecheck 0, lint 0, bypass-write 111/111, write-road, G0-5 (`json-rpc-server.ts` 620 ≤ 631), G36, import-boundaries 3/3, production delta +40/-17, walls 12/0. `check:local` not run.
- Receipt before: `{"error":{"code":"ERR_SQLITE_ERROR"}}`; after: `{"error":{"code":"ERR_SQLITE_ERROR","errcode":5,"errstr":"database is locked"}}`.

## Review Evidence

- Worker report rounds 1–2 in the task packet; fact F-EF5497D1 (errcode, timing, red→green).

## Residual Risk

- The writer handle now lives until the projection's explicit close, so anything that reads or copies the main projection file directly (rather than through SQLite) sees the checkpointed state only; production readers go through SQLite, and the one test that compared file bytes now closes the owner first.

---

# 中文

## 概要

shard 负载下投影读报 `database is locked`(09-05 两次,F-660A607D / F-534FA629)。VM 上用生产代码复现机制:投影 owner 每次操作后关闭 writer 连接,触发 SQLite 最后连接的 checkpoint + 删 WAL/SHM(排他锁),此时只读会话 open 得到 BUSY(errcode 5),250 ms 读者预算在慢机器上不够。修法:owner 在成功操作后保持 writer 句柄,直到显式 close、discard/rebuild、文件身份变化或操作失败;读者仍短连接 + `BEGIN…COMMIT` 快照。协议错误结果新增 `errcode`/`errstr`,回执与连接日志说出原因。task_eb87096f。

## 架构辩护

- 消除的是每次操作开关连接造成的排他清理窗口;调大读者超时(未采用)只是延长等待;`SQLITE_FCNTL_PERSIST_WAL` 在 `node:sqlite` 公开 API 不可达。回执诚实:可选字段严格校验,丢细节的固定形状已删。无重试层、无兼容分支。

## 中心化仓库视角

只影响每仓本地投影缓存;canonical 写与 replica cut 不变。

## 改动内容

owner 生命周期一处;协议错误四文件;新增争用回归(main 红 / 本分支绿)与字段测试;`task-projection.test.ts` 比较文件字节前先关 owner。

## 门收割 / Gate Harvest

无删除。

## 任务与范围

- task_eb87096f;分支 codex/projection-busy;范围投影 owner 生命周期 + 协议错误细节;不含 store/epoch/CI。

## 版本影响

- 无版本变化;不发布。

## 治理声明

- 未触碰 protected surface。

## 验证

- VM:争用回归 main 红(errcode 5)→ 本分支绿;task-projection 26/26、validator 7/7、conn-log 8/8、json-rpc 56/56、provider-fallback 2/2、runtime-cli 1/1;typecheck/lint/bypass-write/write-road/G0-5/G36/import-boundaries 过;PD +40/-17;未跑 `check:local`。回执前后对照见英文段。

## 审查证据

- 任务包报告两轮;F-EF5497D1。

## 残余风险

- writer 句柄存活到显式 close,直接读/拷主投影文件的路径只看到已 checkpoint 状态;生产读者都经 SQLite。
