### PR TITLE
fix(sqlite): keep the original error when ROLLBACK fails in the replica stores and projection transaction

### DIFF
--- a/packages/daemon/src/fleet/replica-ack-store.ts
+++ b/packages/daemon/src/fleet/replica-ack-store.ts
@@ -1,6 +1,7 @@
 import { existsSync, mkdirSync, readdirSync } from "node:fs";
 import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
+import { consumeKnownError } from "../../../kernel/src/index.ts";
 import type { FleetCut } from "./contract.ts";
 
 export interface ReplicaDeliveryKey {
@@ -195,7 +196,11 @@ export function openReplicaAckStore(rootDir: string): ReplicaAckStore {
       store.prepare("DELETE FROM active_offer WHERE node_id=? AND view_id=?").run(key.nodeId, key.viewId);
       store.exec("COMMIT");
     } catch (error) {
-      store.exec("ROLLBACK");
+      try {
+        store.exec("ROLLBACK");
+      } catch (rollbackError) {
+        consumeKnownError(rollbackError);
+      }
       throw error;
     }
     return { outcome: "applied" as const, cursor: cursor(key) };

--- a/packages/daemon/src/fleet/replica-cut-store.ts
+++ b/packages/daemon/src/fleet/replica-cut-store.ts
@@ -218,7 +218,11 @@ export function openReplicaCutSource(options: ReplicaCutSourceOptions): ReplicaC
       pruned = prune(store);
       store.exec("COMMIT");
     } catch (error) {
-      store.exec("ROLLBACK");
+      try {
+        store.exec("ROLLBACK");
+      } catch (rollbackError) {
+        consumeKnownError(rollbackError);
+      }
       throw error;
     }
     for (const orphan of pruned)

--- a/packages/kernel/src/projection/rebuildable-task-projection-sql.ts
+++ b/packages/kernel/src/projection/rebuildable-task-projection-sql.ts
@@ -112,8 +112,12 @@ export function transaction<A>(db: DatabaseSync, run: () => A): A {
     db.exec("COMMIT");
     return value;
   } catch (error) {
-    /* @gate-identity check-bypass-write-boundary/bypass-write-030 */
-    db.exec("ROLLBACK");
+    try {
+      /* @gate-identity check-bypass-write-boundary/bypass-write-030 */
+      db.exec("ROLLBACK");
+    } catch (rollbackError) {
+      consumeKnownError(rollbackError);
+    }
     throw error;
   }
 }


### PR DESCRIPTION
# English

## Summary

When a SQLite write fails with an I/O error SQLite rolls the transaction back on its own; a `ROLLBACK` issued afterwards throws `cannot rollback - no transaction is active` and, in a bare `catch { ROLLBACK; throw }`, that message replaces the original error. PR #2309 fixed the event store and the writer epoch authority. The reviewer of task_cdbe3567 (Terra, runtime_72431d75) found that the closeout's claim "no other SQLite transaction wrappers exist" was false: three more bare wrappers remained. This PR converges them on the same `consumeKnownError` form. Task task_cdbe3567c1f3960beae5d421c8.

## Architectural Justification

- The original error is the only record of the root cause; a rollback failure after an automatic rollback carries no information. Preserving it is a precondition for the stress campaign's `shadowFailureCause` classification (physical-io vs fence-unavailable vs unknown) and for the structured shadow-failure record (task_473cd4ac).
- No behaviour change on the success path or on ordinary failures where `ROLLBACK` succeeds.

## Fleet / centralized-ledger view

Error propagation only; no change to what is written or when.

## What Changed

- `packages/daemon/src/fleet/replica-ack-store.ts` ack transaction: `try { ROLLBACK } catch { consumeKnownError }; throw error` (adds the kernel import).
- `packages/daemon/src/fleet/replica-cut-store.ts` cut transaction: same.
- `packages/kernel/src/projection/rebuildable-task-projection-sql.ts` `transaction()`: same; `@gate-identity bypass-write-030` marker kept. `queryTransaction()` already had the guarded form.
- After this PR every `ROLLBACK` in `packages/*/src` (7 sites) is guarded.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none

## Machine-Readable Declarations

Production-Delta: +17/-4

## Task And Scope

- Harness task: task_cdbe3567c1f3960beae5d421c8
- Branch: codex/rollback-mask-2
- Public scope: three transaction wrappers
- Private planning/evidence updated: yes (fact F-01423378 from the S2 arm; Terra review changes_requested on task_cdbe3567 for the false closeout claim)
- Out of scope: structured shadow-failure records (task_473cd4ac), receipt errcode/errstr (task_eb87096f)

## Version Impact

- Version: no version change because error propagation only
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none
- Authority: not applicable
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no

## Verification

- Base `origin/main` SHA: 84b3094408c5c3cb65934c3ccd5ccd0b08437206
- Negative control: the S2 strace arm on the previous code logged only `cannot rollback - no transaction is active` for an injected `pwrite64 = -1 EIO` (F-01423378); S2 round 3 re-runs the same arm on this branch and must log the SQLite I/O error (reported in the task).
- `npx tsc -b --pretty false` clean; `node tools/check-bypass-write-boundary.mjs` 111/111 (bypass-write-030 marker kept); local `node --test packages/daemon/test/replica-ack-store.integration.test.ts packages/daemon/test/replica-cut-store.integration.test.ts` 10/10. `check:local` not run; CI is the authority.

## Review Evidence

- S2 round-2 report and F-01423378; CEO-authored fix (known diff, no worker).

## Residual Risk

- If node:sqlite places the I/O detail only in `errcode`/`errstr` rather than the message, the log line will still need those fields (task_eb87096f covers receipts).

---

# 中文

## 概要

SQLite 写失败时会自行回滚,随后再执行 ROLLBACK 会抛 `cannot rollback - no transaction is active`,裸 `catch { ROLLBACK; throw }` 会把原始错误盖掉。#2309 修了事件表与 writer epoch 两处;task_cdbe3567 的复核者(Terra,runtime_72431d75)指出 closeout「没有其它 SQLite 事务包装」为假,还剩三处:replica-ack-store、replica-cut-store、rebuildable-task-projection-sql 的 `transaction()`。本 PR 用同一 `consumeKnownError` 写法补齐,此后 `packages/*/src` 里 7 处 ROLLBACK 全部有保护。task_cdbe3567。

## 架构辩护

- 原始错误是根因唯一记录;自动回滚后的回滚失败不含信息。保留它是 shadowFailureCause 分类与影子失败结构化记录(task_473cd4ac)的前提。成功路径与普通失败路径行为不变。

## 中心化仓库视角

只改错误传播,不改写入内容与时机。

## 改动内容

两个事务包装器的 catch 分支。

## 门收割 / Gate Harvest

无删除。

## 任务与范围

- task_cdbe3567;分支 codex/rollback-mask-2;范围两处包装器;结构化记录与回执 errcode 另有任务。

## 版本影响

- 无版本变化;不发布。

## 治理声明

- 未触碰 protected surface。

## 验证

- 阴性对照:S2 臂在旧代码上仅记录回滚信息(F-01423378),第三轮在本分支重跑须记录 SQLite I/O 错误;tsc 0、bypass-write 111/111、VM store 10/10、writer-epoch 7/7、SIGKILL 1/1;未跑 `check:local`。

## 审查证据

- S2 第二轮报告与 F-01423378;CEO 亲写的已知 diff。

## 残余风险

- 若 node:sqlite 只把 I/O 细节放在 errcode/errstr 而不在 message,日志仍需这些字段(task_eb87096f 覆盖回执侧)。
