### PR TITLE
fix(gui): add modelHint_zcode caption and guard both per-kind i18n prefixes

### DIFF
--- a/packages/gui/src/renderer/i18n/locales/en-US/agentRuntime.json
+++ b/packages/gui/src/renderer/i18n/locales/en-US/agentRuntime.json
@@ -229,6 +229,7 @@
   "agentRuntime.modelHint_claude": "Any claude-compatible model; for a third-party API use that provider's model name.",
   "agentRuntime.modelHint_codex": "Codex-family models only.",
   "agentRuntime.modelHint_agy": "Gemini-family models only.",
+  "agentRuntime.modelHint_zcode": "Open, free-form model names configured per instance (no catalog probe); defaults to zai.",
   "agentRuntime.baseUrl": "Base URL",
   "agentRuntime.baseUrlHint": "Point at a third-party endpoint here; leave empty for the official one.",
   "agentRuntime.apiKey": "API key",

--- a/packages/gui/src/renderer/i18n/locales/zh-CN/agentRuntime.json
+++ b/packages/gui/src/renderer/i18n/locales/zh-CN/agentRuntime.json
@@ -229,6 +229,7 @@
   "agentRuntime.modelHint_claude": "任意 claude 兼容模型;第三方 API 填对方的模型名。",
   "agentRuntime.modelHint_codex": "只接受 codex 系模型。",
   "agentRuntime.modelHint_agy": "只接受 gemini 系模型。",
+  "agentRuntime.modelHint_zcode": "开放模型名,按实例自填(无目录探测);默认接 zai。",
   "agentRuntime.baseUrl": "Base URL",
   "agentRuntime.baseUrlHint": "第三方端点填这里;留空走官方端点。",
   "agentRuntime.apiKey": "API Key",

--- a/packages/gui/test/i18n-locale-parity.vitest.ts
+++ b/packages/gui/test/i18n-locale-parity.vitest.ts
@@ -22,10 +22,13 @@ describe("i18n bilingual catalogs (REQ-GUI-09 language switch)", () => {
     expect(typeof initialLocale()).toBe("string");
   });
 
-  it("has a plane_<kind> caption for every runtime kind (guards the ZCODE black-screen)", () => {
+  it("has plane_<kind> and modelHint_<kind> captions for every runtime kind (guards the ZCODE black-screen)", () => {
     const keys = new Set(catalogKeys("zh-CN"));
-    for (const kindId of RUNTIME_KIND_IDS)
-      expect(keys.has(`agentRuntime.plane_${kindId}`), `missing agentRuntime.plane_${kindId}`).toBe(true);
+    // NewRuntimeDialog renders both t(`agentRuntime.plane_${kindId}`) and t(`agentRuntime.modelHint_${kindId}`);
+    // a missing key on either used to crash the renderer, so both prefixes must exist for every kind.
+    for (const prefix of ["plane", "modelHint"] as const)
+      for (const kindId of RUNTIME_KIND_IDS)
+        expect(keys.has(`agentRuntime.${prefix}_${kindId}`), `missing agentRuntime.${prefix}_${kindId}`).toBe(true);
   });
 
   it("returns the key itself for a missing message instead of throwing", () => {


### PR DESCRIPTION
# English

## Summary

Add the missing `agentRuntime.modelHint_zcode` caption (zh-CN/en-US) and extend the runtime-kind i18n guard test to require both `plane_<kind>` and `modelHint_<kind>` for every runtime kind. This is the follow-up caught by the mechanism search when closing the ZCODE black-screen fix (#2308): `NewRuntimeDialog.tsx:221` renders `t(`agentRuntime.modelHint_${form.kindId}`)` alongside `:125`'s `plane_`, and `modelHint_zcode` was missing exactly like `plane_zcode` was — only `agy`/`claude`/`codex` existed. #2308's `?? key` fallback already removed the crash, but ZCODE's model hint showed the raw key text; this PR supplies the caption and the guard test now blocks either prefix from silently missing for any kind.

## Architectural Justification

- Not required: Production-Delta is +0/-0 (locale JSON and tests are not production).

## What Changed

- `packages/gui/src/renderer/i18n/locales/{zh-CN,en-US}/agentRuntime.json`: add `agentRuntime.modelHint_zcode` (ZCODE takes open, free-form model names configured per instance — no catalog probe — defaulting to zai, per `runtime-inventory.ts` zcode kind).
- `packages/gui/test/i18n-locale-parity.vitest.ts`: the existing per-kind guard checked only `plane_<kind>`; it now iterates both `["plane","modelHint"]` prefixes over `RUNTIME_KIND_IDS`, so a missing caption on either prefix for any kind fails the test.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: use the single CI-backed `Production-Delta` declaration below; do not enter a second metric.

## Machine-Readable Declarations

Production-Delta: +0/-0

Dependency-Change: none

## Task And Scope

- Harness task: task_198ef8d9877f6dec6fbef9ac35
- Branch: `codex/gui-modelhint-zcode`
- Public scope: GUI renderer i18n data (two locale captions) + one vitest guard extension
- Private planning/evidence updated: yes (task package plan + fact F-DB623328)
- Out of scope: any renderer logic change (the crash-proofing `?? key` fallback in core.ts already landed in #2308); other dynamic i18n lookups (graph.axis / SystemView / FreshnessView) are already covered by the same core.ts fallback

## Version Impact

- Version: no package version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none
- Authority: not applicable
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: f9f26b385
- Branch merge-base with `origin/main`: f9f26b385 (rebased)
- Public diff command: `git diff --stat origin/main...codex/gui-modelhint-zcode`
- Private evidence: task package artifacts, fact F-DB623328
- GitHub Actions `rewrite-ci` run URL: pending (filled after the run)
- [ ] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Directed test run in the branch worktree: `packages/gui` `npx vitest run test/i18n-locale-parity.vitest.ts` → 4/4 passed; `node tools/gates/production-delta.mjs --base <merge-base>` → +0/-0 pass. Full `check:local`/matrix not run locally by policy; CI is the authority.

## Review Evidence

- Self-review: CEO wrote the change directly (exact 3-file diff), verified against `runtime-inventory.ts` zcode kind for the caption content.
- Reviewer subagent: none (production-delta +0/-0, data + test only)
- Human review: CEO
- Blocking findings: none

## Residual Risk

- None functional: the caption is data; the crash was already prevented by #2308. If a future runtime kind is added, the extended guard now fails until both `plane_` and `modelHint_` captions exist for it — intended.

## References

- Task: task_198ef8d9877f6dec6fbef9ac35
- Origin finding: task_2cd183384754cc485c19822697 closeout "Same Mechanism Elsewhere" (the mechanism search that surfaced modelHint_zcode)
- Evidence: fact F-DB623328

---

# 中文

## 概要

补上缺失的 `agentRuntime.modelHint_zcode` 文案(zh-CN/en-US),并把 runtime-kind 的 i18n 守护测试从只查 `plane_<kind>` 扩到同时要求每个 kind 都有 `plane_<kind>` 与 `modelHint_<kind>`。这是收口 ZCODE 黑屏修复(#2308)时机制搜索捞出的跟进:`NewRuntimeDialog.tsx:221` 与 `:125` 的 `plane_` 并列渲染 `t(`agentRuntime.modelHint_${form.kindId}`)`,而 `modelHint_zcode` 和当时的 `plane_zcode` 一样缺失——只有 `agy`/`claude`/`codex`。#2308 的 `?? key` 兜底已消除崩溃,但 ZCODE 的 model 提示显示原始 key 文本;本 PR 补文案,守护测试现在会挡下任一前缀对任一 kind 的静默缺失。

## 架构辩护

- 不需要:Production-Delta 为 +0/-0(locale JSON 与测试不计生产)。

## 改动内容

- `packages/gui/src/renderer/i18n/locales/{zh-CN,en-US}/agentRuntime.json`:新增 `agentRuntime.modelHint_zcode`(依 `runtime-inventory.ts` 的 zcode kind:开放、按实例自填的自由模型名,无目录探测,默认接 zai)。
- `packages/gui/test/i18n-locale-parity.vitest.ts`:既有 per-kind 守护只查 `plane_<kind>`,现改为对 `["plane","modelHint"]` 两个前缀遍历 `RUNTIME_KIND_IDS`,任一前缀对任一 kind 缺文案即测试失败。

## 门收割 / Gate Harvest

- 删除的生产路径:none
- 同 commit 删除的门 / fixture:none
- 生产净行数:引用英文块中的 `Production-Delta`。

## 机读声明说明

- 机读声明只在英文块出现一次;本 PR 不改任何 `package.json` / `package-lock.json`,故不含 Dependency-Change 变更。

## 任务与范围

- Harness 任务:task_198ef8d9877f6dec6fbef9ac35
- 分支:`codex/gui-modelhint-zcode`
- 公开范围:GUI 渲染层 i18n 数据(两条 locale 文案)+ 一处 vitest 守护扩展
- 私有计划 / 证据是否已更新:yes(任务包 plan + fact F-DB623328)
- 范围外:任何渲染逻辑改动(防崩溃的 `?? key` 兜底已在 #2308 落地);其它动态 i18n 查表(graph.axis / SystemView / FreshnessView)已被同一 core.ts 兜底覆盖

## 版本影响

- 版本:无包版本变更
- 发布影响:不发布

## 治理声明

- 是否触碰 protected surface:no
- protected surface 范围:无
- 依据:不适用
- 机器检查边界:本 PR 只声明该段存在;是否真实充分由 reviewer 判断。
- Break-glass:no
- Break-glass 原因:不适用
- Break-glass 范围:不适用
- 后续治理任务:不适用

## 验证

- `origin/main` 基准 SHA:f9f26b385
- 与 `origin/main` 的 merge-base:f9f26b385(已 rebase)
- 公开 diff 命令:`git diff --stat origin/main...codex/gui-modelhint-zcode`
- 私有证据:任务包 artifacts,fact F-DB623328
- GitHub Actions `rewrite-ci` run URL:待 CI 运行后回填
- 定向测试(分支 worktree):`packages/gui` `npx vitest run test/i18n-locale-parity.vitest.ts` → 4/4 通过;`node tools/gates/production-delta.mjs --base <merge-base>` → +0/-0 通过。按纪律本地不跑整套 `check:local`/矩阵;CI 是权威。

## 审查证据

- 自查:CEO 直接写(确切三文件 diff),文案内容对照 `runtime-inventory.ts` 的 zcode kind 核过。
- Reviewer subagent:无(production-delta +0/-0,仅数据 + 测试)
- 人工审查:CEO
- 阻塞发现:无

## 残余风险

- 功能上无:文案是数据,崩溃已由 #2308 防住。未来新增 runtime kind 时,扩展后的守护测试会在其 `plane_` 与 `modelHint_` 文案齐备前失败——符合预期。

## 关联材料

- 任务:task_198ef8d9877f6dec6fbef9ac35
- 起源发现:task_2cd183384754cc485c19822697 closeout「Same Mechanism Elsewhere」节(捞出 modelHint_zcode 的机制搜索)
- 证据:fact F-DB623328

