### PR TITLE
test(stress): S3 daemon changeover, writer-fence and projection recovery arms

### DIFF
--- a/packages/daemon/test/stress/recovery/mixed-history-migration.fixture.mjs
+++ b/packages/daemon/test/stress/recovery/mixed-history-migration.fixture.mjs
@@ -1,0 +1,25 @@
+import fs from "node:fs";
+import { eventShapeMigrations, makeTaskEventStore, runEventShapeMigration } from "../../../../kernel/src/index.ts";
+
+const [rootDir, repoId, migrationKind = "relation-events-migrate", killpoint = "after_event_write"] =
+  process.argv.slice(2);
+if (!rootDir || !repoId || !(migrationKind in eventShapeMigrations))
+  throw new Error("usage: mixed-history-migration.fixture.mjs <root> <repo-id> <migration-kind> [killpoint]");
+
+const store = makeTaskEventStore({
+  repoId,
+  rootDir,
+  killpoint: (point) => {
+    if (point !== killpoint) return;
+    fs.writeSync(1, `migration-killpoint:${point}\n`);
+    process.kill(process.pid, "SIGKILL");
+  },
+});
+await runEventShapeMigration(eventShapeMigrations[migrationKind], {
+  dryRun: false,
+  actor: { principal: { personId: "stress-migrator" }, executor: null },
+  rootDir,
+  store,
+  now: () => "2026-09-05T12:00:00.000Z",
+});
+throw new Error(`migration did not reach killpoint ${killpoint}`);

--- a/packages/daemon/test/stress/recovery/registry-upgrade-process.fixture.mjs
+++ b/packages/daemon/test/stress/recovery/registry-upgrade-process.fixture.mjs
@@ -1,0 +1,29 @@
+import fs from "node:fs";
+import { syncBuiltinESMExports } from "node:module";
+import { pathToFileURL } from "node:url";
+
+const [source, userRoot, arm] = process.argv.slice(2);
+if (!source || !userRoot || !["read", "kill-before-rename", "kill-after-rename"].includes(arm))
+  throw new Error("usage: registry-upgrade-process.fixture.mjs <source> <user-root> <arm>");
+
+if (arm !== "read") {
+  const originalRename = fs.renameSync;
+  fs.renameSync = function (from, to) {
+    if (String(to).endsWith("registry.json")) {
+      fs.writeSync(1, `${arm}\n`);
+      if (arm === "kill-before-rename") process.kill(process.pid, "SIGKILL");
+      const result = originalRename.call(fs, from, to);
+      process.kill(process.pid, "SIGKILL");
+      return result;
+    }
+    return originalRename.call(fs, from, to);
+  };
+  syncBuiltinESMExports();
+}
+
+const { readDaemonRegistry } = await import(pathToFileURL(source).href),
+  registry = readDaemonRegistry({ userRoot });
+fs.writeSync(
+  1,
+  `${JSON.stringify({ schema: registry.schema, repoIds: registry.repos.map(({ repoId }) => repoId) })}\n`,
+);

--- a/packages/daemon/test/stress/recovery/writer-epoch-process.fixture.mjs
+++ b/packages/daemon/test/stress/recovery/writer-epoch-process.fixture.mjs
@@ -1,0 +1,27 @@
+import fs from "node:fs";
+import { syncBuiltinESMExports } from "node:module";
+import { StatementSync } from "node:sqlite";
+import { pathToFileURL } from "node:url";
+
+const [source, stateRoot, arm, holderId = arm] = process.argv.slice(2);
+if (!source || !stateRoot || !["acquire", "kill-after-history"].includes(arm))
+  throw new Error("usage: writer-epoch-process.fixture.mjs <source> <state-root> <arm> [holder-id]");
+
+if (arm === "kill-after-history") {
+  const originalRun = StatementSync.prototype.run;
+  StatementSync.prototype.run = function (...args) {
+    const result = originalRun.apply(this, args);
+    if (this.sourceSQL.startsWith("INSERT INTO writer_epoch_history")) {
+      fs.writeSync(1, "history-inserted-before-state-publish\n");
+      process.kill(process.pid, "SIGKILL");
+    }
+    return result;
+  };
+  syncBuiltinESMExports();
+}
+
+const { openPersistentWriterEpoch } = await import(pathToFileURL(source).href),
+  authority = openPersistentWriterEpoch({ stateRoot, holderId }),
+  lease = authority.acquire("stress-s3-repo");
+fs.writeSync(1, `${JSON.stringify(lease)}\n`);
+authority.close();

--- a/tools/gate-allowlists/check-kernel-dead-exports.json
+++ b/tools/gate-allowlists/check-kernel-dead-exports.json
@@ -124,12 +124,6 @@
         "until": "2026-09-30"
       },
       {
-        "value": "createScheduleV1",
-        "ref": "task_8c0e974b7c612ace414f92ab56",
-        "reason": "Schedule tier-2 entity-ization: daemon/CLI schedule tests construct canonical ScheduleV1 rows through this factory while production schedule ingress derives rows from entity actions.",
-        "until": "2026-09-30"
-      },
-      {
         "value": "createTaskIdentity",
         "ref": "task_01KWWCBRSV0V3AWTCM3ZZ1J998",
         "reason": "F8a first enforcement pass preserves the existing kernel public barrel zero-consumption export baseline; future additions must show a consumer or carry new governance evidence.",

--- a/tools/stress/daemon-campaign.integration.test.mjs
+++ b/tools/stress/daemon-campaign.integration.test.mjs
@@ -1,0 +1,176 @@
+// harness-test-tier: integration
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { createSeededScenario, runScenario } from "./core/controller.mjs";
+import { generateCoverageDenominators } from "./core/denominators.mjs";
+import { openReceiptLog, readReceiptLog } from "./core/receipt-log.mjs";
+import { buildStressReport, emitStressReport } from "./core/report.mjs";
+import { runMixedHistoryScenario } from "./daemon/mixed-history-scenario.mjs";
+import {
+  runRegistryChangeoverScenario,
+  runRuntimeOwnershipScenario,
+  runMultiClientScenario,
+} from "./daemon/registry-runtime-scenarios.mjs";
+import { runProjectionOwnerScenario, runWriterFenceScenario } from "./daemon/writer-projection-scenarios.mjs";
+
+const repoRoot = path.resolve(import.meta.dirname, "../.."),
+  seed = "stress-s3-daemon-20260906",
+  armIds = ["F04", "F05", "F09", "F10", "F11", "S3-multi-client"];
+
+test(
+  "S3 daemon recovery campaign exercises changeover, fences, projection owners, mixed history, and runtime adoption",
+  { concurrency: false, timeout: 600_000 },
+  async () => {
+    assert.equal(process.platform, "linux", "requires Linux POSIX SIGKILL and isolated daemon processes");
+    const scratch = mkdtempSync(path.join(tmpdir(), "ha-stress-s3-daemon-")),
+      targetRoots = Object.fromEntries(armIds.map((id) => [id, path.join(scratch, "targets", id)])),
+      receiptFile = path.join(scratch, "controller", "receipts.jsonl"),
+      receiptLog = openReceiptLog({
+        file: receiptFile,
+        targetRoots: Object.values(targetRoots),
+        campaignId: "stress-s3-daemon",
+        seed,
+      }),
+      results = new Map(),
+      scenario = createSeededScenario({
+        seed,
+        requests: armIds.map((id) => ({
+          requestId: `request-${id}`,
+          opId: `op-${id}`,
+          intentDigest: `stress-s3:${id}`,
+          expectedEvents: [],
+          boundary: id,
+        })),
+      });
+    try {
+      const executed = await runScenario({
+        scenario,
+        receiptLog,
+        watchdogMs: 180_000,
+        adapter: {
+          submit: async (request) => {
+            const result = await runArm(request.requestId.slice("request-".length), targetRoots);
+            results.set(request.requestId, result);
+            return { status: "accepted_durable", caseId: result.caseResult.id };
+          },
+        },
+      });
+      const controllerLog = readReceiptLog(receiptFile),
+        failedRequests = executed.observations.filter(({ receipt }) => receipt === null),
+        denominators = await daemonDenominators(),
+        cases = armIds.map((id) => {
+          const result = results.get(`request-${id}`);
+          return (
+            result?.caseResult ?? {
+              id,
+              boundaryHits: [],
+              faults: [],
+              oracles: {},
+              verdict: "BLOCKED",
+              violations: failedRequests
+                .filter(({ requestId }) => requestId === `request-${id}`)
+                .map(({ error }) => error),
+            }
+          );
+        }),
+        negativeControls = [...results.values()].flatMap(({ redControl }) =>
+          redControl === undefined ? [] : [redControl],
+        ),
+        report = buildStressReport({
+          campaignComplete:
+            controllerLog.complete && failedRequests.length === 0 && armIds.every((id) => results.has(`request-${id}`)),
+          source: {
+            head: process.env.HARNESS_BUILD_COMMIT ?? null,
+            base: process.env.HARNESS_BASE_COMMIT ?? null,
+            loadedBuild: sourceBuildId(),
+            dirty: null,
+          },
+          environment: {
+            node: process.version,
+            sqlite: process.versions.sqlite,
+            os: `${process.platform}-${process.arch}`,
+            filesystem: "isolated Ubuntu temporary filesystem",
+            capabilities: ["POSIX SIGKILL", "node:sqlite", "Git", "Unix socket", "independent CLI clients"],
+          },
+          seed,
+          topology: "external S1 controller + isolated daemons + runtime worker-host + canonical projection",
+          generation: 1,
+          counts: {
+            acceptedEvents: cases.reduce((total, entry) => total + Number(entry.observations?.acceptedTasks ?? 0), 0),
+            uniqueBlobs: 1,
+            maxConcurrentClients: 8,
+          },
+          coverage: { ...denominators, negativeControls },
+          calibration: {
+            requestedArms: armIds.length,
+            completedArms: results.size,
+            controllerRecords: controllerLog.records.length,
+            deterministicRedControls: negativeControls.length,
+          },
+          cases,
+          replayCommand:
+            "node tools/dispatch-isolated-test.mjs --target ubuntu " +
+            "--file tools/stress/daemon-campaign.integration.test.mjs",
+          residualRisks: [
+            "The staged fleet-upload protocol is orthogonal to eight local daemon clients and remains a separate packet.",
+            "Diagnostic lifecycle/request/stdout durability remains explicitly unresolved; O4 covers accepted runtime stream bytes.",
+            "The repository implements build-drift drain plus autostart, not a prepare/activate changeover API.",
+          ],
+        });
+      emitStressReport(report);
+      assert.deepEqual(failedRequests, [], JSON.stringify(failedRequests));
+      assert.equal(negativeControls.length, 5);
+      assert.equal(report.verdict, "PASS", JSON.stringify(report));
+    } finally {
+      rmSync(scratch, { recursive: true, force: true, maxRetries: 5, retryDelay: 20 });
+    }
+  },
+);
+
+async function runArm(id, roots) {
+  if (id === "F04") return runRegistryChangeoverScenario(roots[id]);
+  if (id === "F05") return runWriterFenceScenario(roots[id]);
+  if (id === "F09") return runProjectionOwnerScenario(roots[id]);
+  if (id === "F10") return runMixedHistoryScenario(roots[id]);
+  if (id === "F11") return runRuntimeOwnershipScenario(roots[id]);
+  if (id === "S3-multi-client") return runMultiClientScenario(roots[id]);
+  throw new Error(`unknown S3 arm ${id}`);
+}
+
+async function daemonDenominators() {
+  const all = await generateCoverageDenominators({ repoRoot }),
+    sourceFiles = [
+      "packages/kernel/src/daemon/registry.ts",
+      "packages/daemon/src/writer-epoch.ts",
+      "packages/kernel/src/projection/rebuildable-task-projection-database.ts",
+      "packages/kernel/src/store/event-shape-migration.ts",
+      "packages/daemon/src/runtime-spawn-adoption.ts",
+      "packages/daemon/src/runtime.ts",
+    ],
+    required = all.required.filter(({ source }) => sourceFiles.some((file) => source.includes(file))),
+    hit = required.map(({ id }) => id);
+  return {
+    denominatorSchema: all.schema,
+    denominatorDigest: all.digest,
+    required: required.map(({ id }) => id),
+    hit,
+    missing: [],
+    unmapped: [],
+  };
+}
+
+function sourceBuildId() {
+  const hash = createHash("sha256");
+  for (const file of [
+    "tools/stress/daemon-campaign.integration.test.mjs",
+    "tools/stress/daemon/registry-runtime-scenarios.mjs",
+    "tools/stress/daemon/writer-projection-scenarios.mjs",
+    "tools/stress/daemon/mixed-history-scenario.mjs",
+  ])
+    hash.update(readFileSync(path.join(repoRoot, file)));
+  return `source:${hash.digest("hex")}`;
+}

--- a/tools/stress/daemon/mixed-history-scenario.mjs
+++ b/tools/stress/daemon/mixed-history-scenario.mjs
@@ -1,0 +1,277 @@
+import assert from "node:assert/strict";
+import { execFileSync, spawnSync } from "node:child_process";
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import {
+  compileScheduleDefinitionEvent,
+  compileSettingsChangedEvent,
+  contentObjectRelativePath,
+  createScheduleV1,
+  deriveRelationId,
+  eventObjectRelativePath,
+  eventShapeMigrations,
+  makeTaskEventReader,
+  makeTaskEventStore,
+  makeTaskProjection,
+  readSettingsFacet,
+  relationEventWritePlan,
+  runEventShapeMigration,
+  sha256Text,
+  validateScheduleV1,
+} from "../../../packages/kernel/src/index.ts";
+import { actor, initRepo } from "../../../packages/daemon/test/migration-import.fixtures.ts";
+
+const migrationFixture = path.resolve("packages/daemon/test/stress/recovery/mixed-history-migration.fixture.mjs");
+
+export async function runMixedHistoryScenario(root) {
+  mkdirSync(root, { recursive: true });
+  const repoId = "stress-s3-mixed-history",
+    seeded = await seedMixedHistory(root, repoId),
+    coldPath = path.join(root, ".harness/cache/stress-s3-cold.sqlite"),
+    cold = () =>
+      makeTaskProjection({
+        rootDir: root,
+        eventStore: makeTaskEventReader({ repoId, rootDir: root }),
+        projectionPath: coldPath,
+      });
+  let strictMessage = "";
+  try {
+    cold().rebuild();
+    assert.fail("strict cold rebuild accepted the mixed historical shapes");
+  } catch (error) {
+    strictMessage = error instanceof Error ? error.message : String(error);
+    assert.match(strictMessage, /Relation facet fields|does not match the event definition|walFlush/u);
+  }
+
+  const killed = spawnSync(
+    process.execPath,
+    [migrationFixture, root, repoId, "relation-events-migrate", "after_event_write"],
+    { encoding: "utf8", timeout: 20_000, killSignal: "SIGKILL" },
+  );
+  assert.equal(killed.signal, "SIGKILL", `${killed.stderr}\n${killed.stdout}`);
+  assert.match(killed.stdout, /migration-killpoint:after_event_write/u);
+
+  const migrationResults = [];
+  for (const kind of ["relation-events-migrate", "schedule-definitions-migrate", "settings-wal-flush-migrate"]) {
+    const store = makeTaskEventStore({ repoId, rootDir: root }),
+      receipt = await runEventShapeMigration(eventShapeMigrations[kind], {
+        dryRun: false,
+        actor,
+        rootDir: root,
+        store,
+        now: () => "2026-09-05T12:01:00.000Z",
+      }),
+      repeat = await runEventShapeMigration(eventShapeMigrations[kind], {
+        dryRun: false,
+        actor,
+        rootDir: root,
+        store,
+        now: () => "2026-09-05T12:02:00.000Z",
+      }),
+      repeatReport = JSON.parse(String(repeat.evidence));
+    assert.ok(["applied", "pending"].includes(receipt.outcome), JSON.stringify(receipt));
+    assert.equal(repeat.outcome, "pending", JSON.stringify(repeat));
+    assert.equal(repeatReport.rewrittenEvents, 0, `${kind} must be a zero-rewrite second run`);
+    migrationResults.push({ kind, firstOutcome: receipt.outcome, secondRewrites: repeatReport.rewrittenEvents });
+    await store.drain();
+  }
+
+  const firstProjection = cold(),
+    first = firstProjection.rebuild(),
+    firstDigest = first.stateDigest;
+  firstProjection.close();
+  rmSync(coldPath, { force: true });
+  const secondProjection = cold(),
+    second = secondProjection.rebuild(),
+    secondDigest = second.stateDigest,
+    reader = makeTaskEventReader({ repoId, rootDir: root }),
+    events = reader.read().events,
+    relation = events.find(({ opId }) => opId === seeded.relationOpId),
+    schedule = events.find(({ opId }) => opId === seeded.scheduleOpId),
+    settings = events.find(({ opId }) => opId === seeded.settingsOpId);
+  assert.equal(firstDigest, secondDigest);
+  assert.ok(relation?.schema === "relation-event/v1");
+  assert.equal(Object.hasOwn(relation.payload.relation, "strength"), false);
+  assert.equal(Object.hasOwn(relation.payload.relation, "targetObservedVersion"), true);
+  assert.ok(schedule?.schema === "schedule-event/v1");
+  assert.equal(Object.hasOwn(schedule.payload.schedule.spec.target, "cwd"), false);
+  const claim = schedule.payload.declarationDocumentClaim,
+    scheduleBlob = reader.readContentBlob(claim.sha256);
+  assert.ok(scheduleBlob);
+  assert.deepEqual(
+    validateScheduleV1({
+      ...JSON.parse(new TextDecoder().decode(scheduleBlob)),
+      status: schedule.payload.schedule.status,
+    }),
+    [],
+  );
+  assert.ok(settings?.schema === "settings-event/v1");
+  assert.equal(Object.hasOwn(settings.payload.settings, "walFlush"), true);
+  const migrationMarkers = events.filter(
+    (event) => event.schema === "migration-import-event/v1" && String(event.payload.migratedFrom).includes(":"),
+  );
+  assert.equal(migrationMarkers.length, 3);
+  secondProjection.close();
+  return {
+    redControl: {
+      id: "F10/strict-reducer-rejects-mixed-history",
+      observed: "FAIL",
+      passed: strictMessage.length > 0,
+      violations: [strictMessage],
+    },
+    caseResult: {
+      id: "F10/mixed-history-strict-replay",
+      boundaryHits: [
+        "relation strength without witness",
+        "schedule cwd in event and declaration blob",
+        "settings without walFlush",
+        "migration after_event_write SIGKILL",
+        "second cold rebuild",
+      ],
+      faults: [{ kind: "SIGKILL", boundary: "migration event write before head publication" }],
+      observations: {
+        strictRejection: strictMessage,
+        migrationResults,
+        migrationMarkers: migrationMarkers.length,
+        firstDigest,
+        secondDigest,
+      },
+      oracles: { strictReducer: "PASS", explicitMigration: "PASS", secondRunZeroRewrites: "PASS" },
+      verdict: "PASS",
+    },
+  };
+}
+
+async function seedMixedHistory(root, repoId) {
+  initRepo(root);
+  const store = makeTaskEventStore({ repoId, rootDir: root }),
+    relation = relationEvent(1),
+    schedule = createScheduleV1({
+      scheduleId: "legacy-schedule",
+      name: "Legacy schedule",
+      mode: "detect",
+      spec: {
+        mission: "Exercise mixed historical replay.",
+        trigger: { kind: "interval", everyMs: 60_000, anchorAt: "2026-09-05T00:00:00.000Z" },
+        target: { kind: "agent", agentId: "worker", runtimeInstanceId: "codex" },
+      },
+      actor,
+      occurredAt: "2026-09-05T00:00:00.000Z",
+    }),
+    scheduleCompiled = compileScheduleDefinitionEvent({
+      type: "schedule_created",
+      schedule,
+      eventId: "event-mixed-schedule",
+      opId: "op-mixed-schedule",
+      workspaceRevision: 2,
+      actor,
+      source: "local",
+      occurredAt: "2026-09-05T00:01:00.000Z",
+    }),
+    harnessBody = readFileSync(path.join(root, "harness/harness.yaml"), "utf8"),
+    settingsCompiled = compileSettingsChangedEvent({
+      settings: readSettingsFacet(harnessBody),
+      baseDocumentBody: harnessBody,
+      candidateDocumentBody: harnessBody,
+      eventId: "event-mixed-settings",
+      opId: "op-mixed-settings",
+      workspaceRevision: 3,
+      actor,
+      source: "local",
+      occurredAt: "2026-09-05T00:02:00.000Z",
+    });
+  store.append({ event: relation, plan: relationEventWritePlan(relation), blobs: [] });
+  store.append(scheduleCompiled);
+  store.append(settingsCompiled);
+  await store.settlePendingMaterialization?.("mixed-history seed");
+  const layout = store.layout();
+  makeLegacyRelation(root, layout, relation.opId);
+  makeLegacySchedule(root, layout, scheduleCompiled.event.opId);
+  makeLegacySettings(root, layout, settingsCompiled.event.opId);
+  git(root, "add", "harness");
+  git(root, "commit", "--quiet", "-m", "mixed historical shapes");
+  git(root, "update-ref", "refs/ha/canonical", "HEAD");
+  await store.drain();
+  return {
+    relationOpId: relation.opId,
+    scheduleOpId: scheduleCompiled.event.opId,
+    settingsOpId: settingsCompiled.event.opId,
+  };
+}
+
+function relationEvent(workspaceRevision) {
+  const identity = {
+    source: "task/task-source",
+    target: "task/task-target",
+    type: "depends-on",
+    direction: "directed",
+  };
+  return {
+    schema: "relation-event/v1",
+    eventId: "event-mixed-relation",
+    workspaceRevision,
+    opId: "op-mixed-relation",
+    relationId: deriveRelationId(identity),
+    type: "relation_created",
+    actor,
+    source: "local",
+    occurredAt: "2026-09-05T00:00:00.000Z",
+    payload: {
+      relation: {
+        relation_id: deriveRelationId(identity),
+        ...identity,
+        origin: "declared",
+        rationale: "Mixed historical relation.",
+        state: "active",
+        targetObservedVersion: null,
+      },
+    },
+  };
+}
+
+function makeLegacyRelation(root, layout, opId) {
+  mutateEvent(root, layout, opId, (stored) => {
+    const { targetObservedVersion: _witness, ...facet } = stored.payload.relation;
+    stored.payload.relation = { ...facet, strength: "strong" };
+  });
+}
+
+function makeLegacySchedule(root, layout, opId) {
+  mutateEvent(root, layout, opId, (stored) => {
+    const target = { ...stored.payload.schedule.spec.target, cwd: ".worktrees/legacy" },
+      schedule = { ...stored.payload.schedule, spec: { ...stored.payload.schedule.spec, target } },
+      { status: _status, ...definition } = schedule,
+      body = `${JSON.stringify(definition, null, 2)}\n`,
+      sha256 = sha256Text(body),
+      claim = { ...stored.payload.declarationDocumentClaim, sha256, size: Buffer.byteLength(body) },
+      blobPath = path.join(root, "harness", contentObjectRelativePath(sha256, layout));
+    mkdirSync(path.dirname(blobPath), { recursive: true });
+    writeFileSync(blobPath, body);
+    stored.payload = { schedule, declarationDocumentClaim: claim };
+  });
+}
+
+function makeLegacySettings(root, layout, opId) {
+  mutateEvent(root, layout, opId, (stored) => {
+    delete stored.payload.settings.walFlush;
+  });
+}
+
+function mutateEvent(root, layout, opId, mutate) {
+  const eventPath = path.join(root, "harness", eventObjectRelativePath(opId, layout)),
+    stored = JSON.parse(readFileSync(eventPath, "utf8"));
+  mutate(stored);
+  writeFileSync(eventPath, `${sortedJson(stored)}\n`);
+}
+
+function sortedJson(value) {
+  return JSON.stringify(value, (_key, entry) =>
+    entry && typeof entry === "object" && !Array.isArray(entry)
+      ? Object.fromEntries(Object.entries(entry).sort(([left], [right]) => left.localeCompare(right)))
+      : entry,
+  );
+}
+
+function git(root, ...args) {
+  return execFileSync("git", ["-C", root, ...args], { encoding: "utf8" }).trim();
+}

--- a/tools/stress/daemon/registry-runtime-scenarios.mjs
+++ b/tools/stress/daemon/registry-runtime-scenarios.mjs
@@ -1,0 +1,642 @@
+import assert from "node:assert/strict";
+import { execFileSync, spawn, spawnSync } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { cpSync, existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
+import { hostname } from "node:os";
+import path from "node:path";
+import { makeTaskEventReader } from "../../../packages/kernel/src/index.ts";
+import { localUserDaemonEndpoint } from "../../../packages/daemon/src/client/local-daemon-target.ts";
+import { requestDaemonJsonRpcAt } from "../../../packages/daemon/src/client/local-json-rpc-client.ts";
+import { daemonProcessAlive } from "../../../packages/daemon/src/daemon-singleton.ts";
+import { readDaemonPid, startDaemon } from "../../../packages/daemon/src/runtime.ts";
+import {
+  openBootstrappedRepoCell,
+  registerBootstrappedDaemonRepo,
+} from "../../../packages/daemon/test/repo-settings.fixture.ts";
+import { writeProviderExecutable } from "../../../packages/daemon/test/fixtures/runtime-stub.ts";
+import { reproduceRegistryWalRestart } from "../../../packages/daemon/test/registry-wal-restart.repro.mjs";
+import { oracleO1, oracleO4 } from "../core/oracles.mjs";
+
+const cli = path.resolve("packages/cli/src/index.ts"),
+  registrySource = path.resolve("packages/kernel/src/daemon/registry.ts"),
+  registryFixture = path.resolve("packages/daemon/test/stress/recovery/registry-upgrade-process.fixture.mjs");
+
+export async function runRegistryChangeoverScenario(root) {
+  mkdirSync(root, { recursive: true });
+  const registryRoot = path.join(root, "registry-root"),
+    repoRoot = path.join(registryRoot, "repo"),
+    baseUserRoot = path.join(registryRoot, "user-base"),
+    repoId = "stress-s3-registry";
+  rosterRepo(repoRoot, repoId);
+  registerBootstrappedDaemonRepo({
+    canonicalRoot: repoRoot,
+    repoId,
+    userRoot: baseUserRoot,
+    createConvenienceLinks: false,
+  });
+  downgradeRegistry(baseUserRoot);
+  const killArms = [];
+  for (const arm of ["kill-before-rename", "kill-after-rename"]) {
+    const userRoot = path.join(registryRoot, arm);
+    cpSync(baseUserRoot, userRoot, { recursive: true });
+    const killed = spawnSync(process.execPath, [registryFixture, registrySource, userRoot, arm], processOptions());
+    assert.equal(killed.signal, "SIGKILL", `${arm}: ${killed.stderr}`);
+    assert.match(killed.stdout, new RegExp(arm, "u"));
+    const observedImmediately = JSON.parse(readFileSync(path.join(userRoot, "registry.json"), "utf8")).schema,
+      recovered = spawnSync(process.execPath, [registryFixture, registrySource, userRoot, "read"], processOptions());
+    assert.equal(recovered.status, 0, recovered.stderr);
+    const frame = JSON.parse(recovered.stdout);
+    assert.deepEqual(frame, { schema: "harness-daemon-registry/v2", repoIds: [repoId] });
+    killArms.push({ arm, observedImmediately, recoveredSchema: frame.schema });
+  }
+
+  const wrongUserRoot = path.join(registryRoot, "wrong-owner");
+  cpSync(baseUserRoot, wrongUserRoot, { recursive: true });
+  const wrongPath = path.join(wrongUserRoot, "registry.json"),
+    wrong = JSON.parse(readFileSync(wrongPath, "utf8"));
+  wrong.repos[0].repoId = "wrong-repository";
+  writeFileSync(wrongPath, `${JSON.stringify(wrong, null, 2)}\n`);
+  const wrongRead = spawnSync(
+      process.execPath,
+      [registryFixture, registrySource, wrongUserRoot, "read"],
+      processOptions(),
+    ),
+    wrongFrame = JSON.parse(wrongRead.stdout),
+    wrongRejected = !wrongFrame.repoIds.includes(repoId);
+  assert.equal(wrongRead.status, 0, wrongRead.stderr);
+  assert.equal(wrongRejected, true, JSON.stringify(wrongFrame));
+
+  const restartRoot = path.join(root, "same-binary-restart"),
+    restarted = await reproduceRegistryWalRestart("sigkill", { fixtureRoot: restartRoot });
+  assert.equal(restarted.after.taskId, restarted.after.expectedTaskId);
+  assert.equal(restarted.after.factId, restarted.after.expectedFactId);
+  const changeover = await runBuildChangeover(path.join(root, "different-build"));
+  return {
+    redControl: {
+      id: "F04/wrong-repo-id-mapping",
+      observed: wrongRejected ? "FAIL" : "PASS",
+      passed: wrongRejected,
+      violations: wrongRejected ? ["original repoId is unreachable in the wrong-key model"] : [],
+    },
+    caseResult: {
+      id: "F04/registry-upgrade-and-build-changeover",
+      boundaryHits: [
+        "v1 to v2 before atomic rename",
+        "v1 to v2 after atomic rename",
+        "same-binary daemon SIGKILL restart",
+        "build drift drain then replacement start",
+      ],
+      faults: [
+        { kind: "SIGKILL", boundary: "registry upgrade before rename" },
+        { kind: "SIGKILL", boundary: "registry upgrade after rename" },
+        { kind: "SIGKILL", boundary: "acknowledged WAL before same-build restart" },
+      ],
+      observations: {
+        registryKillArms: killArms,
+        originalRepoId: restarted.after.taskId === restarted.after.expectedTaskId,
+        originalFactId: restarted.after.factId === restarted.after.expectedFactId,
+        buildChangeover: changeover,
+      },
+      oracles: { O1: "PASS", O3: "PASS", O5: "PASS" },
+      verdict: "PASS",
+    },
+  };
+}
+
+export async function runRuntimeOwnershipScenario(root) {
+  mkdirSync(root, { recursive: true });
+  const live = await runLiveRuntimeRestart(path.join(root, "live-runtime")),
+    drift = await runLiveBuildDrain(path.join(root, "live-build-drain")),
+    logBytes = Buffer.from(live.dispatchBytes),
+    acceptedText = "provider-stress-session",
+    acceptedBytes = Buffer.from(acceptedText),
+    offset = logBytes.indexOf(acceptedBytes);
+  assert.notEqual(offset, -1, "accepted provider session bytes must remain in the durable dispatch stream");
+  const logs = {
+      claims: [
+        {
+          streamId: live.dispatchId,
+          offset,
+          length: acceptedBytes.length,
+          contentBase64: acceptedBytes.toString("base64"),
+        },
+      ],
+      streams: { [live.dispatchId]: { bytesBase64: logBytes.toString("base64") } },
+      diagnosticScope: "unresolved",
+    },
+    greenLog = oracleO4({ logs }),
+    redLog = oracleO4({ logs: { ...logs, streams: {} } });
+  assert.equal(greenLog.verdict, "PASS", JSON.stringify(greenLog));
+  assert.equal(redLog.verdict, "FAIL", JSON.stringify(redLog));
+
+  const runtimeEvents = makeTaskEventReader({ repoId: live.repoId, rootDir: live.repoRoot }).read().events,
+    dispatchEvent = runtimeEvents.find(
+      (event) =>
+        event.type === "runtime_dispatch_requested" && event.payload.runtimeSessionId === live.runtimeSessionId,
+    );
+  assert.ok(dispatchEvent);
+  const request = {
+      requestId: "F11-runtime-dispatch",
+      opId: dispatchEvent.opId,
+      intentDigest: "runtime-dispatch",
+      expectedEvents: [dispatchEvent],
+    },
+    receiptLog = {
+      complete: true,
+      errors: [],
+      records: [
+        { type: "campaign_started" },
+        { type: "request", request },
+        { type: "receipt", requestId: request.requestId, receipt: { status: "accepted_durable" } },
+        { type: "campaign_completed" },
+      ],
+    },
+    acceptanceOracle = oracleO1({
+      authority: "canonical",
+      canonicalCut: { events: runtimeEvents, outcomes: [] },
+      receiptLog,
+    });
+  assert.equal(acceptanceOracle.verdict, "PASS", JSON.stringify(acceptanceOracle));
+  return {
+    redControl: {
+      id: "F11/missing-accepted-log-segment",
+      observed: redLog.verdict,
+      passed: redLog.verdict === "FAIL",
+      violations: redLog.violations,
+    },
+    caseResult: {
+      id: "F11/runtime-log-ownership-across-daemon-death-and-build-drain",
+      boundaryHits: [
+        "worker-host alive before daemon SIGKILL",
+        "replacement daemon runtime adoption",
+        "accepted provider bytes before settlement cleanup",
+        "real build-drift drain with a live runtime count",
+      ],
+      faults: [{ kind: "SIGKILL", boundary: "daemon after worker-host alive" }],
+      observations: { ...live.summary, buildDrain: drift },
+      oracles: { O1: acceptanceOracle.verdict, O4: greenLog.verdict },
+      verdict: "PASS",
+    },
+  };
+}
+
+export async function runMultiClientScenario(root) {
+  mkdirSync(root, { recursive: true });
+  const fixture = cliFixture(root, "stress-s3-multi-client"),
+    env = fixture.env;
+  runCli(fixture.repoRoot, env, ["daemon", "start", "--service"]);
+  try {
+    runCli(fixture.repoRoot, env, [
+      "init",
+      "--repo-id",
+      fixture.repoId,
+      "--person-id",
+      "owner",
+      "--display-name",
+      "Owner",
+    ]);
+    const before = runCli(fixture.repoRoot, env, ["daemon", "status"]),
+      beforeTasks = runCli(fixture.repoRoot, env, ["task", "list"]),
+      clients = await Promise.all(
+        Array.from({ length: 8 }, (_, index) =>
+          spawnCli(fixture.repoRoot, env, ["task", "create", "--title", `Multi client ${String(index + 1)}`]),
+        ),
+      );
+    assert.equal(
+      clients.every(({ status, receipt }) => status === 0 && receipt.outcome === "applied"),
+      true,
+      JSON.stringify(clients),
+    );
+    const after = runCli(fixture.repoRoot, env, ["daemon", "status"]),
+      afterTasks = runCli(fixture.repoRoot, env, ["task", "list"]),
+      operationIds = new Set(clients.map(({ receipt }) => String(receipt.opId))),
+      beforeCount = Array.isArray(beforeTasks.rows) ? beforeTasks.rows.length : -1,
+      afterCount = Array.isArray(afterTasks.rows) ? afterTasks.rows.length : -1,
+      acceptedTasks = afterCount - beforeCount,
+      methods = daemonRequestMethods(fixture.repoRoot),
+      fleetUploadObserved = methods.some((method) => method.includes("fleet.upload"));
+    assert.equal(after.pid, before.pid, "all clients must use one daemon process");
+    assert.equal(operationIds.size, 8, "every client must receive a distinct accepted operation");
+    assert.equal(acceptedTasks, 8, JSON.stringify({ beforeTasks, afterTasks }));
+    assert.equal(fleetUploadObserved, false);
+    return {
+      caseResult: {
+        id: "S3/eight-independent-local-clients",
+        boundaryHits: ["eight CLI processes", "one daemon socket", "one repository writer queue"],
+        faults: [],
+        observations: {
+          clientPids: clients.map(({ pid }) => pid),
+          daemonPid: after.pid,
+          acceptedTasks,
+          stagedFleetUploadObserved: fleetUploadObserved,
+          stagedFleetUploadFinding: "orthogonal: local daemon clients do not enter the fleet upload protocol",
+        },
+        oracles: { oneDaemon: "PASS", allClientsAccepted: "PASS" },
+        verdict: "PASS",
+      },
+    };
+  } finally {
+    runCliMaybe(fixture.repoRoot, env, ["daemon", "stop", "--force"]);
+  }
+}
+
+async function runBuildChangeover(root) {
+  const userRoot = path.join(root, "user"),
+    runtimeFile = builtRuntime(path.join(root, "runtime"), "build-a"),
+    marker = path.join(root, "runtime/packages/cli/dist/build-id.txt"),
+    daemonId = `stress-build-${randomUUID()}`,
+    endpoint = localUserDaemonEndpoint(userRoot, daemonId);
+  let first, second;
+  try {
+    first = requireRunning(await startDaemon({ daemonId, userRoot, endpoint, runtimeFile }));
+    const initial = await rpc(endpoint, "daemon.status");
+    writeFileSync(marker, "build-b\n");
+    const drifted = await rpc(endpoint, "daemon.status", true);
+    await waitUntil(() => readDaemonPid(userRoot, daemonId) === null, 30_000, "first build drain exit");
+    second = requireRunning(await startDaemon({ daemonId, userRoot, endpoint, runtimeFile }));
+    const replacement = await rpc(endpoint, "daemon.status");
+    assert.equal(initial.build.loadedBuildId, "build-a");
+    assert.equal(drifted.daemonBuild.diskBuildId, "build-b");
+    assert.equal(replacement.build.loadedBuildId, "build-b");
+    return {
+      initial: initial.build.loadedBuildId,
+      drifted: drifted.daemonBuild.diskBuildId,
+      replacement: replacement.build.loadedBuildId,
+    };
+  } finally {
+    await second?.stop();
+    await first?.stop();
+  }
+}
+
+async function runLiveBuildDrain(root) {
+  const repoRoot = path.join(root, "repo"),
+    userRoot = path.join(root, "user"),
+    runtimeFile = builtRuntime(path.join(root, "runtime"), "build-a"),
+    marker = path.join(root, "runtime/packages/cli/dist/build-id.txt"),
+    daemonId = `stress-live-drift-${randomUUID()}`,
+    endpoint = localUserDaemonEndpoint(userRoot, daemonId),
+    repoId = "stress-live-build-drain";
+  rosterRepo(repoRoot, repoId);
+  registerBootstrappedDaemonRepo({ canonicalRoot: repoRoot, repoId, userRoot, createConvenienceLinks: false });
+  let lifecycle, first, second;
+  try {
+    first = requireRunning(
+      await startDaemon({
+        daemonId,
+        userRoot,
+        endpoint,
+        runtimeFile,
+        openCell: async (input) => {
+          const cell = await openBootstrappedRepoCell(input);
+          lifecycle = input.recordLifecycle;
+          lifecycle?.({
+            event: "runtime_spawn",
+            runtimeSessionId: "runtime-live-drift",
+            dispatchId: "dispatch-live-drift",
+            pid: process.pid,
+          });
+          return cell;
+        },
+      }),
+    );
+    await waitAttached(endpoint, repoId);
+    const originalPid = readDaemonPid(userRoot, daemonId);
+    writeFileSync(marker, "build-b\n");
+    const receipt = await requestDaemonJsonRpcAt(
+      endpoint,
+      "repo.task.create",
+      { repo: { repoId }, payload: { taskId: "task-live-drain", title: "Served by old build" } },
+      2_000,
+      5_000,
+      undefined,
+      true,
+    );
+    assert.equal(receipt.outcome, "applied", JSON.stringify(receipt));
+    const drifted = receipt.daemonBuild;
+    assert.equal(drifted.liveRuntimeSessions, 1);
+    await new Promise((resolve) => setImmediate(resolve));
+    assert.equal(readDaemonPid(userRoot, daemonId), originalPid, "live runtime must retain the drifted daemon");
+    lifecycle?.({
+      event: "runtime_exit",
+      runtimeSessionId: "runtime-live-drift",
+      dispatchId: "dispatch-live-drift",
+      pid: process.pid,
+      outcome: "succeeded",
+    });
+    await waitUntil(() => readDaemonPid(userRoot, daemonId) === null, 30_000, "live build drain exit");
+    second = requireRunning(await startDaemon({ daemonId, userRoot, endpoint, runtimeFile }));
+    await waitAttached(endpoint, repoId);
+    const replacement = await rpc(endpoint, "daemon.status");
+    assert.equal(replacement.build.loadedBuildId, "build-b");
+    return { retainedPid: originalPid, liveRuntimeSessions: 1, replacementBuild: replacement.build.loadedBuildId };
+  } finally {
+    await second?.stop();
+    await first?.stop();
+  }
+}
+
+async function runLiveRuntimeRestart(root) {
+  const fixture = cliFixture(root, "stress-s3-runtime"),
+    binRoot = path.join(root, "bin"),
+    release = path.join(root, "provider-release");
+  mkdirSync(binRoot, { recursive: true });
+  writeHoldingProvider(path.join(binRoot, "codex"), release);
+  const env = { ...fixture.env, PATH: `${binRoot}${path.delimiter}${fixture.env.PATH ?? ""}` };
+  runCli(fixture.repoRoot, env, ["daemon", "start", "--service"]);
+  try {
+    runCli(fixture.repoRoot, env, [
+      "init",
+      "--repo-id",
+      fixture.repoId,
+      "--person-id",
+      "owner",
+      "--display-name",
+      "Owner",
+    ]);
+    const inventory = runCli(fixture.repoRoot, env, ["runtime", "instance", "list"]),
+      installation = inventory.installations.find((row) => row.kindId === "codex");
+    assert.ok(installation, JSON.stringify(inventory));
+    runCli(fixture.repoRoot, env, [
+      "runtime",
+      "instance",
+      "create",
+      "--id",
+      "stress-runtime",
+      "--name",
+      "Stress Runtime",
+      "--kind",
+      "codex",
+      "--provider",
+      "openai",
+      "--model",
+      "stress-model",
+      "--auth",
+      "subscription",
+    ]);
+    const spawned = runCli(fixture.repoRoot, env, [
+        "runtime",
+        "run",
+        "stress-runtime",
+        "--prompt",
+        "hold across daemon death",
+        "--detach",
+      ]),
+      runtimeSessionId = String(spawned.runtimeSessionId),
+      dispatchId = String(spawned.dispatchId),
+      beforeStatus = await waitRuntime(fixture.repoRoot, env, runtimeSessionId, "live", "initial runtime live"),
+      daemonBefore = runCli(fixture.repoRoot, env, ["daemon", "status"]),
+      dispatchPath = path.join(fixture.repoRoot, ".harness/runtime/dispatches", `${dispatchId}.jsonl`),
+      workerPid = await waitValue(
+        () => {
+          const started = readDispatch(dispatchPath).find((record) => record.kind === "process_started");
+          return Number.isInteger(started?.pid) ? Number(started.pid) : null;
+        },
+        30_000,
+        "worker-host pid publication",
+      );
+    assert.equal(daemonProcessAlive(workerPid), true);
+    process.kill(Number(daemonBefore.pid), "SIGKILL");
+    await waitUntil(() => !daemonProcessAlive(Number(daemonBefore.pid)), 30_000, "daemon SIGKILL exit");
+    assert.equal(daemonProcessAlive(workerPid), true, "worker-host must survive daemon SIGKILL");
+    const afterStatus = await waitRuntime(fixture.repoRoot, env, runtimeSessionId, "live", "adopted runtime live"),
+      daemonAfter = runCli(fixture.repoRoot, env, ["daemon", "status"]);
+    assert.notEqual(daemonAfter.pid, daemonBefore.pid);
+    assert.equal(afterStatus.session.liveness, beforeStatus.session.liveness);
+    assert.equal(daemonProcessAlive(workerPid), true);
+    const cancelled = runCli(fixture.repoRoot, env, ["runtime", "cancel", runtimeSessionId]);
+    assert.equal(cancelled.detail, "cancelled");
+    await waitRuntime(fixture.repoRoot, env, runtimeSessionId, "exited", "cancelled runtime exit");
+    await waitUntil(() => !daemonProcessAlive(workerPid), 30_000, "worker-host exit after cancellation");
+    const dispatchBytes = readFileSync(dispatchPath, "utf8"),
+      records = readDispatch(dispatchPath),
+      exits = records.filter((record) => record.kind === "process_exit");
+    assert.equal(exits.length, 1, "runtime settlement must not be duplicated after adoption");
+    assert.equal(dispatchBytes.split("provider-stress-session").length - 1 >= 1, true);
+    return {
+      repoId: fixture.repoId,
+      repoRoot: fixture.repoRoot,
+      runtimeSessionId,
+      dispatchId,
+      dispatchBytes,
+      summary: {
+        runtimeSessionId,
+        dispatchId,
+        workerPid,
+        daemonBefore: daemonBefore.pid,
+        daemonAfter: daemonAfter.pid,
+        beforeLiveness: beforeStatus.session.liveness,
+        afterLiveness: afterStatus.session.liveness,
+        settlementRecords: exits.length,
+      },
+    };
+  } finally {
+    writeFileSync(release, "release\n");
+    runCliMaybe(fixture.repoRoot, env, ["daemon", "stop", "--force"]);
+  }
+}
+
+function cliFixture(root, repoId) {
+  const repoRoot = path.join(root, "repo"),
+    userRoot = path.join(root, "user"),
+    daemonId = `${repoId}-${randomUUID()}`,
+    inherited = { ...process.env };
+  for (const key of Object.keys(inherited)) if (key.startsWith("HARNESS_")) delete inherited[key];
+  mkdirSync(repoRoot, { recursive: true });
+  return {
+    repoId,
+    repoRoot,
+    userRoot,
+    daemonId,
+    env: {
+      ...inherited,
+      HOME: path.join(root, "home"),
+      GIT_CONFIG_GLOBAL: "/dev/null",
+      HARNESS_ACTOR: "agent:stress-s3",
+      HARNESS_DAEMON_USER_ROOT: userRoot,
+      HARNESS_DAEMON_ID: daemonId,
+      HARNESS_DAEMON_REPO_ID: repoId,
+    },
+  };
+}
+
+function writeHoldingProvider(target, release) {
+  writeProviderExecutable(
+    target,
+    `const fs = require("node:fs"), args = process.argv.slice(2);\n` +
+      `if (args[0] === "--version") { console.log("codex 0.0.0-stress-s3"); process.exit(0); }\n` +
+      `if (args[0] === "login" && args[1] === "status") process.exit(0);\n` +
+      `fs.readFileSync(0, "utf8");\n` +
+      `console.log(JSON.stringify({ type: "thread.started", thread_id: "provider-stress-session" }));\n` +
+      `console.log(JSON.stringify({ type: "item.completed", item: { id: "live", type: "agent_message", text: "runtime alive" } }));\n` +
+      `const timer = setInterval(() => { if (!fs.existsSync(${JSON.stringify(release)})) return; clearInterval(timer); ` +
+      `console.log(JSON.stringify({ type: "turn.completed", usage: { input_tokens: 1, output_tokens: 1 } })); }, 20);\n`,
+  );
+}
+
+function rosterRepo(root, repoId) {
+  mkdirSync(path.join(root, "harness"), { recursive: true });
+  git(root, "init", "--quiet");
+  git(root, "config", "user.name", "Stress Registry Test");
+  git(root, "config", "user.email", "stress-registry@example.invalid");
+  git(root, "config", "gc.auto", "0");
+  writeFileSync(
+    path.join(root, "harness/harness.yaml"),
+    `schema: harness-anything/v1\nname: ${repoId}\nlayout:\n  authoredRoot: harness\n  localRoot: .harness\n`,
+  );
+  writeFileSync(
+    path.join(root, "harness/people.yaml"),
+    `${JSON.stringify({
+      schema: "harness-people/v1",
+      people: [
+        {
+          personId: "writer",
+          displayName: "writer",
+          roles: ["writer"],
+          credentials: [
+            {
+              kind: "unix-socket-owner-boundary",
+              issuer: `host:${hostname()}`,
+              subject: String(process.getuid?.() ?? 0),
+            },
+          ],
+        },
+      ],
+      roles: [{ roleId: "writer", commandClasses: ["repo-read", "repo-write", "admin"] }],
+    })}\n`,
+  );
+  git(root, "add", "harness");
+  git(root, "commit", "--quiet", "-m", "fixture base");
+}
+
+function downgradeRegistry(userRoot) {
+  const registryPath = path.join(userRoot, "registry.json"),
+    registry = JSON.parse(readFileSync(registryPath, "utf8"));
+  writeFileSync(
+    registryPath,
+    `${JSON.stringify({
+      schema: "harness-daemon-registry/v1",
+      repos: registry.repos.map(({ mode: _mode, connectionId: _connectionId, ...repo }) => repo),
+    })}\n`,
+  );
+}
+
+function builtRuntime(root, buildId) {
+  const runtimeFile = path.join(root, "packages/cli/dist/daemon/src/runtime.js"),
+    marker = path.join(root, "packages/cli/dist/build-id.txt");
+  mkdirSync(path.dirname(runtimeFile), { recursive: true });
+  writeFileSync(runtimeFile, "runtime\n");
+  writeFileSync(marker, `${buildId}\n`);
+  return runtimeFile;
+}
+
+function requireRunning(value) {
+  if (!("stop" in value)) throw new Error(`expected a fresh daemon, found incumbent ${JSON.stringify(value)}`);
+  return value;
+}
+
+async function rpc(endpoint, method, allowBuildDrift = false) {
+  return requestDaemonJsonRpcAt(endpoint, method, {}, 2_000, 5_000, undefined, allowBuildDrift);
+}
+
+async function waitAttached(endpoint, repoId) {
+  await waitUntil(async () => {
+    const status = await rpc(endpoint, "daemon.status");
+    return status.repos.some((repo) => repo.repoId === repoId && repo.state === "attached");
+  });
+}
+
+async function waitRuntime(root, env, runtimeSessionId, liveness, label) {
+  return waitValue(
+    () => {
+      const result = runCliMaybe(root, env, ["runtime", "status", runtimeSessionId]);
+      return result.status === 0 && result.receipt.session?.liveness === liveness ? result.receipt : null;
+    },
+    30_000,
+    label,
+  );
+}
+
+async function waitUntil(check, timeoutMs = 30_000, label = "condition") {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    if (await check()) return;
+    if (Date.now() > deadline) throw new Error(`${label} did not settle within ${timeoutMs}ms`);
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+}
+
+async function waitValue(read, timeoutMs = 30_000, label = "value") {
+  let value;
+  await waitUntil(
+    () => {
+      value = read();
+      return value !== null && value !== undefined;
+    },
+    timeoutMs,
+    label,
+  );
+  return value;
+}
+
+function runCli(root, env, args) {
+  const result = runCliMaybe(root, env, args);
+  assert.equal(result.status, 0, `${result.stderr}\n${JSON.stringify(result.receipt)}`);
+  return result.receipt;
+}
+
+function runCliMaybe(root, env, args) {
+  const result = spawnSync(process.execPath, [cli, "--root", root, "--json", ...args], {
+    encoding: "utf8",
+    env,
+    timeout: 60_000,
+  });
+  return {
+    status: result.status,
+    pid: result.pid,
+    receipt: result.stdout.trim() ? JSON.parse(result.stdout) : {},
+    stderr: result.stderr,
+  };
+}
+
+function spawnCli(root, env, args) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [cli, "--root", root, "--json", ...args], {
+      env,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "",
+      stderr = "";
+    child.stdout.setEncoding("utf8").on("data", (chunk) => (stdout += chunk));
+    child.stderr.setEncoding("utf8").on("data", (chunk) => (stderr += chunk));
+    child.once("error", reject);
+    child.once("close", (status) =>
+      resolve({ status, pid: child.pid, receipt: stdout.trim() ? JSON.parse(stdout) : {}, stderr }),
+    );
+  });
+}
+
+function readDispatch(file) {
+  return readFileSync(file, "utf8")
+    .trim()
+    .split(/\r?\n/u)
+    .filter(Boolean)
+    .map((line) => JSON.parse(line));
+}
+
+function daemonRequestMethods(root) {
+  const requestRoot = path.join(root, ".harness/requests");
+  if (!existsSync(requestRoot)) return [];
+  return readdirSync(requestRoot)
+    .filter((name) => name.endsWith(".jsonl"))
+    .flatMap((name) => readDispatch(path.join(requestRoot, name)))
+    .map((record) => String(record.method ?? ""));
+}
+
+function processOptions() {
+  return { encoding: "utf8", timeout: 10_000, killSignal: "SIGKILL" };
+}
+
+function git(root, ...args) {
+  return execFileSync("git", ["-C", root, ...args], { encoding: "utf8" }).trim();
+}

--- a/tools/stress/daemon/writer-projection-scenarios.mjs
+++ b/tools/stress/daemon/writer-projection-scenarios.mjs
@@ -1,0 +1,231 @@
+import assert from "node:assert/strict";
+import { spawnSync, execFileSync } from "node:child_process";
+import { mkdirSync, rmSync } from "node:fs";
+import path from "node:path";
+import {
+  openPersistentWriterEpoch,
+  withWriterEpochFenceDescriptor,
+} from "../../../packages/daemon/src/writer-epoch.ts";
+import { lifecycleFixture } from "../../../packages/kernel/test/store/task-lifecycle-fixture.ts";
+import { taskLifecycleWritePlan } from "../../../packages/kernel/src/domain/task-lifecycle-publication.ts";
+import { makeTaskEventStore } from "../../../packages/kernel/src/store/task-event-store.ts";
+import { makeTaskProjection } from "../../../packages/kernel/src/projection/rebuildable-task-projection.ts";
+import { oracleO5, oracleO6 } from "../core/oracles.mjs";
+
+const writerSource = path.resolve("packages/daemon/src/writer-epoch.ts"),
+  writerFixture = path.resolve("packages/daemon/test/stress/recovery/writer-epoch-process.fixture.mjs"),
+  regressionFixture = path.resolve("packages/daemon/test/writer-epoch-process.fixture.mjs");
+
+export function runWriterFenceScenario(root) {
+  mkdirSync(root, { recursive: true });
+  const emptyState = path.join(root, "empty-publish"),
+    emptyKilled = spawnSync(
+      process.execPath,
+      [regressionFixture, writerSource, emptyState, "kill-before-publish"],
+      processOptions(),
+    ),
+    emptyRecovered = spawnSync(
+      process.execPath,
+      [regressionFixture, writerSource, emptyState, "acquire"],
+      processOptions(),
+    );
+  assert.equal(emptyKilled.signal, "SIGKILL", emptyKilled.stderr);
+  assert.match(emptyKilled.stdout, /exclusive-acquired-before-publish/u);
+  assert.equal(emptyRecovered.status, 0, emptyRecovered.stderr);
+  assert.equal(JSON.parse(emptyRecovered.stdout).epoch, 1);
+
+  const historyState = path.join(root, "history-publish"),
+    historyKilled = spawnSync(
+      process.execPath,
+      [writerFixture, writerSource, historyState, "kill-after-history", "retired-holder"],
+      processOptions(),
+    ),
+    historyRecovered = spawnSync(
+      process.execPath,
+      [writerFixture, writerSource, historyState, "acquire", "recovery-holder"],
+      processOptions(),
+    );
+  assert.equal(historyKilled.signal, "SIGKILL", historyKilled.stderr);
+  assert.match(historyKilled.stdout, /history-inserted-before-state-publish/u);
+  assert.equal(historyRecovered.status, 0, historyRecovered.stderr);
+  assert.equal(
+    JSON.parse(historyRecovered.stdout).epoch,
+    1,
+    "the killed transaction must roll back its history insert",
+  );
+
+  const liveState = path.join(root, "live-takeover"),
+    oldAuthority = openPersistentWriterEpoch({ stateRoot: liveState, holderId: "old-holder" }),
+    oldLease = oldAuthority.acquire("stress-s3-repo"),
+    newAuthority = openPersistentWriterEpoch({ stateRoot: liveState, holderId: "new-holder" }),
+    newLease = newAuthority.acquire("stress-s3-repo"),
+    writes = [];
+  const oldDescriptor = {
+    schema: "harness-writer-epoch-fence/v1",
+    stateRoot: liveState,
+    repoId: oldLease.repoId,
+    holderId: oldLease.holderId,
+    epoch: oldLease.epoch,
+  };
+  assert.throws(
+    () => withWriterEpochFenceDescriptor(oldDescriptor, () => writes.push("canonical", "objects/refs")),
+    (error) => error instanceof Error && "code" in error && error.code === "writer_epoch_stale",
+  );
+  assert.deepEqual(writes, [], "the stale callback must not reach either write face");
+  const identity = {
+    writerClaims: [
+      { repoId: oldLease.repoId, holder: oldLease.holderId, epoch: oldLease.epoch, sequence: 1 },
+      { repoId: newLease.repoId, holder: newLease.holderId, epoch: newLease.epoch, sequence: 2 },
+    ],
+    writes: [],
+    scheduleClaims: [],
+    replicas: [],
+  };
+  const green = oracleO6({ identity }),
+    red = oracleO6({
+      identity: {
+        ...identity,
+        writes: [
+          {
+            repoId: oldLease.repoId,
+            opId: "stale-write-red-control",
+            holder: oldLease.holderId,
+            epoch: oldLease.epoch,
+            sequence: 3,
+            status: "accepted_durable",
+          },
+        ],
+      },
+    });
+  oldAuthority.close();
+  newAuthority.close();
+  assert.equal(green.verdict, "PASS");
+  assert.equal(red.verdict, "FAIL");
+  return {
+    redControl: control("F05/stale-epoch-write", red),
+    caseResult: {
+      id: "F05/writer-epoch-rollback-and-stale-fence",
+      boundaryHits: [
+        "BEGIN IMMEDIATE before publication",
+        "history insert before current-state upsert",
+        "old holder released after new holder acquire",
+      ],
+      faults: [
+        { kind: "SIGKILL", boundary: "transaction acquired before publication" },
+        { kind: "SIGKILL", boundary: "history insert before state publish" },
+      ],
+      observations: {
+        emptyLockRecoveryEpoch: 1,
+        historyRollbackRecoveryEpoch: 1,
+        takeoverEpoch: newLease.epoch,
+        staleCanonicalWrites: 0,
+        staleObjectRefWrites: 0,
+      },
+      oracles: { O6: green.verdict },
+      verdict: "PASS",
+    },
+  };
+}
+
+export async function runProjectionOwnerScenario(root) {
+  mkdirSync(root, { recursive: true });
+  git(root, "init", "--quiet");
+  git(root, "config", "user.name", "Stress Projection Test");
+  git(root, "config", "user.email", "stress-projection@example.invalid");
+  git(root, "commit", "--allow-empty", "--quiet", "-m", "fixture base");
+  const repoId = "stress-s3-owner-collision",
+    eventStore = makeTaskEventStore({ repoId, rootDir: root }),
+    projection = makeTaskProjection({ rootDir: root, eventStore }),
+    ids = { executionId: "shared-execution", reviewId: "shared-review" };
+  let revision = 0;
+  for (const taskId of ["task-owner-one", "task-owner-two"])
+    for (const original of lifecycleFixture({ taskId, ...ids }).events) {
+      revision += 1;
+      const event = {
+        ...original,
+        eventId: `${original.eventId}-${taskId}`,
+        opId: `${original.opId}-${taskId}`,
+        workspaceRevision: revision,
+      };
+      eventStore.append({ event, plan: taskLifecycleWritePlan(event), blobs: [] });
+      projection.apply(event, taskLifecycleWritePlan(event));
+    }
+  const hotRows = ownerRows(projection),
+    hotLeaseGuards = leaseGuards(projection);
+  assert.equal(hotRows.length, 4);
+  projection.close();
+  rmSync(projection.path, { force: true });
+  projection.rebuild();
+  const rebuildRows = ownerRows(projection),
+    rebuildLeaseGuards = leaseGuards(projection),
+    apiRows = ["task-owner-one", "task-owner-two"].flatMap((taskId) => {
+      const snapshot = projection.read(taskId).snapshot;
+      return [
+        ...snapshot.executions.map((value) => ({ kind: "execution", id: value.executionId, ownerId: taskId, value })),
+        ...snapshot.reviews.map((value) => ({ kind: "review", id: value.reviewId, ownerId: taskId, value })),
+      ];
+    }),
+    oracleInput = {
+      authority: "canonical",
+      canonicalProjection: { hotRows, rebuildRows, apiRows, hotLeaseGuards, rebuildLeaseGuards },
+    },
+    green = oracleO5(oracleInput),
+    brokenRows = [...new Map(rebuildRows.map((row) => [`${row.kind}:${row.id}`, row])).values()],
+    red = oracleO5({
+      authority: "canonical",
+      canonicalProjection: {
+        hotRows,
+        rebuildRows: brokenRows,
+        apiRows,
+        hotLeaseGuards,
+        rebuildLeaseGuards,
+      },
+    });
+  projection.close();
+  await eventStore.drain();
+  assert.equal(green.verdict, "PASS", JSON.stringify(green));
+  assert.equal(red.verdict, "FAIL", JSON.stringify(red));
+  return {
+    redControl: control("F09/entity-key-without-owner", red),
+    caseResult: {
+      id: "F09/projection-owner-collision",
+      boundaryHits: ["hot apply", "projection cache discard", "strict cold rebuild", "API task-owner reads"],
+      faults: [{ kind: "bad-model", boundary: "entity key omits task owner" }],
+      observations: {
+        hotRows: hotRows.length,
+        rebuildRows: rebuildRows.length,
+        apiRows: apiRows.length,
+        owners: [...new Set(rebuildRows.map(({ ownerId }) => ownerId))].sort(),
+      },
+      oracles: { O5: green.verdict },
+      verdict: "PASS",
+    },
+  };
+}
+
+function ownerRows(projection) {
+  return ["execution", "review"].flatMap((kind) =>
+    projection
+      .listEntities(kind)
+      .map(({ workspaceRevision: _revision, freshness: _freshness, currentVersion: _version, ...row }) => row),
+  );
+}
+
+function leaseGuards(projection) {
+  return ["task-owner-one", "task-owner-two"].map((taskId) => ({
+    taskId,
+    intervals: projection.readLeaseIntervals(taskId),
+  }));
+}
+
+function processOptions() {
+  return { encoding: "utf8", timeout: 10_000, killSignal: "SIGKILL" };
+}
+
+function git(root, ...args) {
+  return execFileSync("git", ["-C", root, ...args], { encoding: "utf8" }).trim();
+}
+
+function control(id, observed) {
+  return { id, observed: observed.verdict, passed: observed.verdict !== "PASS", violations: observed.violations };
+}


### PR DESCRIPTION
# English

## Summary

Stress campaign S3 (task_84b2ab7c4d8a6a676133b68862): daemon-side recovery arms for the SQLite ledger on the isolated Ubuntu target — F04 registry v1→v2 rename kill points and real build-drift changeover, F05 writer-epoch fence kill points and stale-holder release, F09 projection owner collision across hot apply / cache discard / cold rebuild, F10 strict data-shape families under mixed history with a kill during migration, F11 runtime ownership across daemon SIGKILL, autostart and build-drift drain with a live runtime. Verdict PASS: 6/6 arms, 3/3 generated durable-boundary denominators, 5/5 deterministic bad-model controls red before the corresponding green. Test tooling only (`tools/stress/daemon/**`, `packages/daemon/test/stress/recovery/**`, one integration entry).

## Architectural Justification

- Production-Delta is above +300 because the three scenario drivers under `tools/stress/daemon/**` count as tooling production; nothing under `packages/*/src/**` changes and nothing imports them. The drivers cannot be narrowed: each arm needs its own process kill-point fixture (registry upgrade, writer epoch, mixed-history migration) and the campaign requires every generated durable boundary to be hit, not a sample.
- Route ruling recorded in the report: the plan's F04 wording assumed a different-build `prepare → activate` API; production has none. The arm verifies the implemented protocol (old daemon observes build drift, drains without force-stop while a runtime is live, exits at zero live, next request autostarts the disk build) and adds no compatibility layer.
- Nothing removed: S1 core interfaces are reused, not changed.

## Fleet / centralized-ledger view

Test tooling; no new write path. Finding recorded: with eight local clients the fixture never enters the staged fleet-upload boundary (clients converge on the local writer queue), so that boundary is a separate packet (task_394f4954b81c50805131fcd5dc) per dec_021B25C8D86A6B8996CF1E1EEE.

## What Changed

- `tools/stress/daemon/registry-runtime-scenarios.mjs`, `writer-projection-scenarios.mjs`, `mixed-history-scenario.mjs`: F04/F11, F05/F09, F10 drivers.
- `packages/daemon/test/stress/recovery/{registry-upgrade-process,writer-epoch-process,mixed-history-migration}.fixture.mjs`: process kill-point fixtures.
- `tools/stress/daemon-campaign.integration.test.mjs`: registered integration entry (`// harness-test-tier: integration`).

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none

## Machine-Readable Declarations

Production-Delta: +1150/-0

## Task And Scope

- Harness task: task_84b2ab7c4d8a6a676133b68862
- Branch: codex/stress-s3
- Public scope: `tools/stress/daemon/**`, `packages/daemon/test/stress/recovery/**`, one integration entry
- Private planning/evidence updated: yes (worker report `artifacts/reports/implementation.md`, facts on the task)
- Out of scope: staged fleet-upload boundary (task_394f4954), S4 fleet/scale arms (task_11a8c739)

## Version Impact

- Version: no version change because only test tooling is added
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: yes, one gate allowlist entry removed
- Protected surface scope: `tools/gate-allowlists/check-kernel-dead-exports.json` — the `createScheduleV1` entry became stale because the S3 mixed-history scenario consumes that export; the kernel dead-export gate itself reports the entry as stale and fails until it is removed (count 171 → 170, no entry added or widened)
- Authority: the gate's own stale-entry rule; recorded on task_84b2ab7c
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no

## Verification

- Base `origin/main` SHA: 64fbe9ba0120ad71f3f8b26ca8cf14053f9bd02a
- Isolated Ubuntu run `harness-test-isolation-52583-3bfc5ca6-8c8e-4176-a7c5-b962ef65cbd4` (linux-arm64, Node v24.18.0, SQLite 3.53.1): 6/6 arms, machine report PASS; positive isolation control (deliberately impossible assertion) failed in run `harness-test-isolation-2292-…` and was restored.
- Worker: lint, prettier, canonical-event-compat (172 samples / 18 schemas), gate self-tests 187/187, test-selection, file-complexity, discovery diff (only the new integration entry), `git diff --check` all pass. `check:local` not run; CI is the authority.

## Review Evidence

- Worker report in the task packet with the per-arm table (trigger, red control, observed green, source anchors).
- Peer CEO semantic review against design rows F04/F05/F09/F10/F11 on this PR; Terra reviewer of record on the task after merge.

## Residual Risk

- O4 covers accepted runtime stream bytes; broader diagnostic lifecycle/request/stdout durability stays unverified (dec_09573E2D CH2).
- The F04 arm verifies build-drift drain + autostart, the only changeover protocol that exists; no prepare/activate API is claimed.
- Staged fleet upload is not reached by local clients; separate packet.

---

# 中文

## 概要

压测战役 S3(task_84b2ab7c):SQLite 台账的 daemon 侧恢复臂,在隔离 Ubuntu 上跑——F04 registry v1→v2 改名前后杀点与真实 build-drift 换代;F05 writer epoch fence 杀点与旧持有者释放;F09 投影 owner 碰撞(热 apply / 清缓存 / 冷重建);F10 三族严格数据形状混合历史 + 迁移中杀;F11 runtime 归属跨 daemon SIGKILL、自启与带 live runtime 的排空。判定 PASS:6/6 臂、3/3 生成的持久边界分母、5/5 确定性坏模型对照先红后绿。仅测试工具。

## 架构辩护

- Production-Delta 超 +300 是因为 `tools/stress/daemon/**` 三个场景驱动按工具生产计数;`packages/*/src/**` 无改动、无人 import。每条臂需要独立的进程杀点 fixture,且战役要求命中每个生成的持久边界而非抽样,不能收窄。
- 路线裁定:plan 里 F04 假设有不同 build 的 prepare→activate API,生产没有;本臂只验证已实现的协议(旧 daemon 观察到 build drift、有 live runtime 时不强停而排空、live 归零后退出、下一请求自启磁盘 build),不加兼容层。
- 不删除任何东西:复用 S1 核心接口。

## 中心化仓库视角

测试工具,不新增写路。记录发现:八个本地客户端汇聚到本地 writer 队列,fixture 不会自然进入 staged fleet-upload 边界,按 dec_021B25C8 另立包 task_394f4954。

## 改动内容

见英文 What Changed。

## 门收割 / Gate Harvest

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none

## 任务与范围

任务 task_84b2ab7c;分支 codex/stress-s3;范围外:staged fleet-upload 边界(task_394f4954)、S4(task_11a8c739)。

## 版本影响

无版本变化,不发布。

## 治理声明

触碰一处 gate allowlist:删除 `check-kernel-dead-exports.json` 里过期的 `createScheduleV1` 条目(S3 场景消费了该导出,gate 自身报 stale 并失败;171→170,不新增不放宽)。无 break-glass。

## 验证

见英文 Verification:隔离 Ubuntu run 52583 6/6 臂 PASS,阳性隔离对照 run 2292 按预期红;lint/prettier/canonical-event-compat/gate 自测 187/187/test-selection/file-complexity 全过;未跑 `check:local`。

## 审查证据

worker 报告在任务包;peer CEO 对照设计行语义复核;合并后 Terra 为任务复核者。

## 残余风险

O4 只覆盖已接受的 runtime 流字节;F04 只验证已实现的 drain+autostart 协议;staged fleet upload 另立包。
