### PR TITLE
fix(daemon): forward the host clock when a registered repo cell is opened

### DIFF
--- a/packages/daemon/src/daemon-host-registry.ts
+++ b/packages/daemon/src/daemon-host-registry.ts
@@ -139,6 +139,7 @@ export async function performOpenRegistered(
       mode: repo.mode,
       ownerId: context.input.daemonId,
       defaultWriterEpochFence: context.writerEpochFence(repo.repoId),
+      now: context.now,
       runtimeDaemonRoute: context.runtimeDaemonRoute,
       authoredBranch: repo.authoredBranch,
       ...(context.input.shutdownRequested ? { shouldStop: context.input.shutdownRequested } : {}),


### PR DESCRIPTION
# English

## Summary

`openDaemonHost` accepts an injectable clock (`now`), and the host uses it for warming, scheduling and fleet runtimes, but `performOpenRegistered` opened repo cells without forwarding it, so every RepoCell stamped `occurredAt` from the wall clock. The S4 stress campaign's F14 arm (injected ±24 h around commit barriers, task_11a8c739) reproduced it: with the host clock moved, written events still carried wall-clock `occurredAt` (F-39E0C921, isolated run `harness-test-isolation-85807`). One line: pass `now: context.now` to `openCell`. Task task_11a8c73912c285e5eafc4b046b (checkpoint fix, CEO-owned).

## Architectural Justification

- Restores the single clock the host already owns; no new seam, no new option. Production behaviour is unchanged because the default `now` is the wall clock.
- Behavioural proof is the campaign arm (red on main, green after) rather than a second bespoke unit test; the daemon host recovery suite (14 tests, several of which inject `now`) stays green.

## Fleet / centralized-ledger view

Clock plumbing only; no write-path change. It makes the F14 invariant testable: revision/epoch order must be independent of `occurredAt`.

## What Changed

- `packages/daemon/src/daemon-host-registry.ts`: `performOpenRegistered` forwards `now: context.now` to `context.openCell`.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none

## Machine-Readable Declarations

Production-Delta: +1/-0

## Task And Scope

- Harness task: task_11a8c73912c285e5eafc4b046b
- Branch: codex/fix-clock-forward
- Public scope: one call site
- Private planning/evidence updated: yes (F-39E0C921; S4 round 3 re-runs F14 on this fix)
- Out of scope: F13 generation field in the fleet cut contract (decision pending)

## Version Impact

- Version: no version change because default behaviour is unchanged
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none
- Authority: not applicable
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no

## Verification

- Base `origin/main` SHA: 64fbe9ba0120ad71f3f8b26ca8cf14053f9bd02a
- `npx tsc -b --pretty false` clean; `node --test packages/daemon/test/daemon-host-recovery.test.ts` 14/14.
- Negative control: S4 F14 arm on main (F-39E0C921); positive: S4 round 3 on this fix (pending). `check:local` not run.

## Review Evidence

- CEO-authored one-line fix; peer CEO read-only check; the campaign arm is the behavioural evidence.

## Residual Risk

- None beyond the pending round-3 confirmation.

---

# 中文

## 概要

`openDaemonHost` 接受可注入时钟 `now`,host 自己的 warming/调度/fleet runtime 都用它,但 `performOpenRegistered` 打开 RepoCell 时没有透传,所有 RepoCell 的 `occurredAt` 都用墙钟。S4 压测 F14 臂(commit 屏障前后注入 ±24h,task_11a8c739)复现:host 时钟移动后事件仍带墙钟时间(F-39E0C921,隔离 run 85807)。修复一行:`openCell` 传 `now: context.now`。

## 架构辩护

恢复 host 已拥有的单一时钟,不加新接缝、不加新选项;默认 `now` 仍是墙钟,生产行为不变。行为证据是战役臂(main 上红、修后绿),不另写第二个专用单测;daemon host recovery 套件 14/14 绿。

## 中心化仓库视角

仅时钟接线,不改写路;让 F14 不变量(revision/epoch 顺序独立于 occurredAt)可测。

## 改动内容

`daemon-host-registry.ts` 一处调用透传 `now`。

## 门收割 / Gate Harvest

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none

## 任务与范围

task_11a8c739 的 checkpoint 修复;分支 codex/fix-clock-forward;范围外:F13 fleet cut 的 generation 字段(待 decision)。

## 版本影响

无版本变化,不发布。

## 治理声明

未触碰 protected surface;无 break-glass。

## 验证

tsc -b 干净;daemon-host-recovery 14/14;阴性对照 F-39E0C921,阳性由 S4 第三轮确认;未跑 check:local。

## 审查证据

CEO 一行修复;peer CEO 只读核;战役臂为行为证据。

## 残余风险

仅待第三轮确认。
