### PR TITLE
test(kernel): prove a warm projection writer handle cannot starve or corrupt a same-path rebuild

### DIFF
--- a/packages/kernel/test/store/projection-reader-close-contention.fixture.ts
+++ b/packages/kernel/test/store/projection-reader-close-contention.fixture.ts
@@ -1,9 +1,16 @@
+import { renameSync } from "node:fs";
+import path from "node:path";
+import type { DatabaseSync } from "node:sqlite";
 import { parentPort, workerData } from "node:worker_threads";
-import { makeTaskProjectionReader } from "../../src/projection/rebuildable-task-projection.ts";
+import { serializeCanonicalEvent } from "../../src/domain/doc-sync.contract.ts";
+import { sha256Text } from "../../src/integrity/stable-hash.ts";
+import { makeTaskProjection, makeTaskProjectionReader } from "../../src/projection/rebuildable-task-projection.ts";
 import { closeDatabase, withDatabase } from "../../src/projection/rebuildable-task-projection-database.ts";
+import type { EventStreamPort } from "../../src/projection/rebuildable-task-projection-types.ts";
+import { lifecycleFixture } from "./task-lifecycle-fixture.ts";
 
 interface WorkerInput {
-  readonly role: "reader" | "writer";
+  readonly role: "reader" | "rebuilder" | "writer";
   readonly rootDir: string;
   readonly projectionPath: string;
   readonly start: SharedArrayBuffer;
@@ -25,7 +32,8 @@ const input = workerData as WorkerInput,
 
 try {
   if (input.role === "writer") runWriter();
-  else runReader();
+  else if (input.role === "reader") runReader();
+  else runRebuilder();
 } catch (error) {
   parentPort!.postMessage({ ok: false, role: input.role, error: sqliteFailure(error) });
 }
@@ -72,6 +80,90 @@ function runReader(): void {
     parentPort!.postMessage({ ok: false, role: "reader", samples, error: sqliteFailure(error) });
   } finally {
     reader.close();
+  }
+}
+
+function runRebuilder(): void {
+  const ownerAStore = fixtureEventStore(),
+    ownerA = makeTaskProjection({
+      rootDir: input.rootDir,
+      projectionPath: input.projectionPath,
+      eventStore: ownerAStore,
+    });
+  ownerA.catchUp();
+  let warmHandle: DatabaseSync | null = null;
+  withDatabase(input.projectionPath, ownerAStore.readHead, (db) => {
+    warmHandle = db;
+    db.exec("CREATE TABLE warm_owner_marker(value TEXT NOT NULL)");
+  });
+
+  const ownerB = makeTaskProjection({
+      rootDir: input.rootDir,
+      projectionPath: input.projectionPath,
+      eventStore: fixtureEventStore(),
+    }),
+    rebuilt = ownerB.rebuild(),
+    staleHandleClosed = databaseIsClosed(warmHandle!),
+    cold = makeTaskProjection({
+      rootDir: input.rootDir,
+      projectionPath: path.join(input.rootDir, ".harness/cache/cold-task.sqlite"),
+      eventStore: fixtureEventStore(),
+    }),
+    coldRebuilt = cold.rebuild();
+  cold.close();
+  ownerB.close();
+
+  let replacedHandle: typeof warmHandle = null;
+  withDatabase(input.projectionPath, ownerAStore.readHead, (db) => {
+    replacedHandle = db;
+    db.exec("CREATE TABLE warm_owner_marker(value TEXT NOT NULL); PRAGMA wal_checkpoint(TRUNCATE)");
+  });
+  renameSync(cold.path, input.projectionPath);
+  const reopened = withDatabase(input.projectionPath, ownerAStore.readHead, (db) => {
+    const marker = db
+        .prepare("SELECT count(*) AS count FROM sqlite_master WHERE type = 'table' AND name = 'warm_owner_marker'")
+        .get() as { readonly count: number },
+      digest = db.prepare("SELECT state_digest FROM projection_meta WHERE singleton = 1").get() as {
+        readonly state_digest: string | null;
+      };
+    return { sameHandle: db === replacedHandle, markerPresent: marker.count > 0, stateDigest: digest.state_digest };
+  });
+  ownerA.close();
+  parentPort!.postMessage({
+    ok: true,
+    role: "rebuilder",
+    staleHandleClosed,
+    rebuiltDigest: rebuilt.stateDigest,
+    coldDigest: coldRebuilt.stateDigest,
+    reopenedSameHandle: reopened.sameHandle,
+    markerPresent: reopened.markerPresent,
+    reopenedDigest: reopened.stateDigest,
+  });
+}
+
+function fixtureEventStore(): EventStreamPort {
+  const event = lifecycleFixture().events[0]!,
+    eventDigest = `sha256:${sha256Text(serializeCanonicalEvent(event))}` as const;
+  return {
+    readHead: () => ({ revision: event.workspaceRevision, eventDigest }),
+    readBatch: () => ({
+      sourceRevision: event.workspaceRevision,
+      events: [event],
+      cursor: null,
+      done: true,
+      accessedItems: 1,
+      prefetchContent: () => new Map(),
+    }),
+    readContentBlob: () => null,
+  };
+}
+
+function databaseIsClosed(db: DatabaseSync): boolean {
+  try {
+    db.exec("SELECT 1");
+    return false;
+  } catch {
+    return true;
   }
 }
 

--- a/packages/kernel/test/store/projection-reader-close-contention.integration.test.ts
+++ b/packages/kernel/test/store/projection-reader-close-contention.integration.test.ts
@@ -1,5 +1,6 @@
 // harness-test-tier: integration
 import assert from "node:assert/strict";
+import path from "node:path";
 import { Worker } from "node:worker_threads";
 import test from "node:test";
 import { makeTaskProjection } from "../../src/projection/rebuildable-task-projection.ts";
@@ -7,8 +8,14 @@ import { withTempStoreAsync } from "./helpers.ts";
 
 interface WorkerResult {
   readonly ok: boolean;
-  readonly role: "reader" | "writer";
+  readonly role: "reader" | "rebuilder" | "writer";
   readonly samples?: number;
+  readonly staleHandleClosed?: boolean;
+  readonly rebuiltDigest?: string;
+  readonly coldDigest?: string;
+  readonly reopenedSameHandle?: boolean;
+  readonly markerPresent?: boolean;
+  readonly reopenedDigest?: string | null;
   readonly error?: {
     readonly code: string | null;
     readonly errcode: number | null;
@@ -65,6 +72,26 @@ test("a persistent writer owner keeps query-only readers on the completed cut af
       [],
       `query-only reader failures: ${JSON.stringify(readerResults)}`,
     );
+  });
+});
+
+test("a warm writer owner cannot starve rebuild and reopens after the database identity changes", async () => {
+  await withTempStoreAsync(async (rootDir) => {
+    const result = await startWorker({
+      role: "rebuilder",
+      rootDir,
+      projectionPath: path.join(rootDir, ".harness/cache/task.sqlite"),
+      start: new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT),
+      stop: new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT),
+      rows: 0,
+      payloadBytes: 0,
+    }).result;
+    assert.equal(result.ok, true, JSON.stringify(result));
+    assert.equal(result.staleHandleClosed, true, "rebuild must close every warm owner before discard");
+    assert.equal(result.rebuiltDigest, result.coldDigest, "warm-owner rebuild must match a cold rebuild");
+    assert.equal(result.reopenedSameHandle, false, "file replacement must initialize a new DatabaseSync handle");
+    assert.equal(result.markerPresent, false, "the reopened owner must not read the unlinked database");
+    assert.equal(result.reopenedDigest, result.rebuiltDigest);
   });
 });
 


### PR DESCRIPTION
# English

## Summary

task_fbae9df07c47d318c6748c61bb: one integration scenario proving that the warm projection writer handle introduced by #2310 cannot starve or corrupt a same-path rebuild. Owner A keeps its `DatabaseSync` warm; owner B rebuilds the same projection; the test asserts A is closed before discard, no SQLite error escapes, the rebuilt state digest equals an independent cold rebuild, and after the file is replaced A's next `use()` opens a new handle that reads the rebuilt database, not the unlinked one.

## Architectural Justification

- Test-only: `packages/kernel/test/store/projection-reader-close-contention.{fixture,integration.test}.ts`; Production-Delta +0/-0.
- Negative control: with `closeProjectionHandlesAt` temporarily made a no-op the new case fails with `ERR_SQLITE_ERROR` errcode 522 `disk I/O error` (isolated run 96323); the temporary edit was reverted before commit.
- Nothing removed; the fixture's existing reader-contention case is unchanged and still passes.

## Fleet / centralized-ledger view

Single-node projection cache. Multiple edge nodes each own their own projection file; the shared state is the canonical ledger, which this test does not touch.

## What Changed

- `projection-reader-close-contention.fixture.ts`: a `rebuilder` role that runs owner A warm, owner B rebuild, a cold rebuild for the digest oracle, then a file-identity change with a marker table and checkpoint.
- `projection-reader-close-contention.integration.test.ts`: the warm-owner rebuild scenario and its five assertions.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none

## Machine-Readable Declarations

Production-Delta: +0/-0

## Task And Scope

- Harness task: task_fbae9df07c47d318c6748c61bb
- Branch: codex/warm-handle-race
- Public scope: `packages/kernel/test/store/projection-reader-close-contention.*`
- Private planning/evidence updated: yes (fact F-2659C05D, worker report dispatch_4cfd5dfaa495b22be0244e88, closeout)
- Out of scope: any production change; bare external replacement of a projection file with a live WAL sidecar is not claimed supported

## Version Impact

- Version: no version change because only tests are added
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none
- Authority: not applicable
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no

## Verification

- Base `origin/main` SHA: a1761ea17883443b1476014a66f5a658e9af8bb8
- Isolated Ubuntu `node tools/dispatch-isolated-test.mjs --target ubuntu --file packages/kernel/test/store/projection-reader-close-contention.integration.test.ts`: run `harness-test-isolation-3105-df0d31be-5055-43be-8f6d-ebb7759cc533`, 2 passed / 0 failed, new case 209.7 ms.
- Negative control run `harness-test-isolation-96323-69c67e02-3c09-4c84-8f7c-54fd669dffb7`: new case red as intended, existing case green.
- Worker: typecheck, lint, G36 line-density, production-delta, file-complexity, test-selection pass; `check:local` not run; CI is the authority.

## Review Evidence

- CEO semantic read against the task plan goal (warm owner + rebuild/discard from another owner: no BUSY escape, cold-digest equality, stale-handle behaviour); Terra reviewer of record after merge.

## Residual Risk

- The identity-change phase checkpoints the marker before replacing the file so that fingerprint/reopen behaviour is tested in isolation; replacing a projection file under a live WAL sidecar is not claimed supported.

---

# 中文

## 概要

task_fbae9df0:一条集成场景,证明 #2310 引入的投影写者暖句柄不会饿死或污染同路径重建。owner A 保持暖句柄,owner B 重建同一投影;断言 A 在 discard 前被关闭、无 SQLite 错误外泄、重建 digest 等于独立冷重建,文件替换后 A 的下一次 `use()` 打开新句柄并读到重建后的库而非已 unlink 的旧库。

## 架构辩护

纯测试,Production-Delta +0/-0;负对照(临时把 `closeProjectionHandlesAt` 变 no-op)按预期红,已在提交前恢复。

## 中心化仓库视角

单节点投影缓存;多边缘各自持有投影文件,共享态是 canonical 台账,本测试不触碰。

## 改动内容

fixture 新增 `rebuilder` 角色与文件身份变更阶段;测试新增一个场景五条断言。

## 门收割 / Gate Harvest

无删除。

## 任务与范围

task_fbae9df0;分支 codex/warm-handle-race;范围仅两个测试文件。

## 版本影响

无版本变化,不发布。

## 治理声明

未触碰 protected surface。

## 验证

隔离 Ubuntu run 3105(2 passed)与负对照 run 96323;worker 未跑 check:local,CI 为权威。

## 审查证据

CEO 按 plan 目标语义复核;合并后 Terra 复核。

## 残余风险

带 live WAL sidecar 的裸外部文件替换不在声明支持范围内。
