### PR TITLE
test(stress): staged fleet-upload boundary arm with kill windows, concurrent edges and stale-generation fence

### DIFF
--- a/packages/daemon/test/stress/fleet/upload-client.fixture.mjs
+++ b/packages/daemon/test/stress/fleet/upload-client.fixture.mjs
@@ -1,0 +1,48 @@
+import { readFileSync, writeFileSync } from "node:fs";
+import { runFleetWriteClient } from "../../../src/fleet/edge.ts";
+
+const config = JSON.parse(readFileSync(process.argv[2], "utf8")),
+  body = readFileSync(config.bodyFile);
+
+if (config.readyFile) {
+  writeFileSync(config.readyFile, "ready\n");
+  await new Promise((resolve, reject) => {
+    let input = "";
+    process.stdin.setEncoding("utf8");
+    process.stdin.on("data", (chunk) => {
+      input += chunk;
+      if (input.includes("\n")) resolve();
+    });
+    process.stdin.on("end", () => reject(new Error("upload barrier closed before release")));
+    process.stdin.on("error", reject);
+  });
+}
+
+const pause = (boundary, frame) => {
+  writeFileSync(config.boundaryFile, `${JSON.stringify({ boundary, frame })}\n`);
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0);
+};
+const result = await runFleetWriteClient({
+  port: config.port,
+  ca: readFileSync(config.caFile),
+  servername: "localhost",
+  nodeId: config.nodeId,
+  credential: config.credential,
+  assignmentId: config.assignmentId,
+  channel: "collaborator",
+  executionId: null,
+  baseLedgerSha: config.baseLedgerSha,
+  changes: [{ path: config.path, body, baseBlobSha256: config.baseBlobSha256 ?? null }],
+  onFrame: (frame) => {
+    if (
+      config.pauseAt === "durable-prefix" &&
+      frame.schema === "fleet.upload.ready/v1" &&
+      frame.resumeOffset > 0 &&
+      frame.resumeOffset < body.byteLength
+    )
+      pause("durable-prefix-before-finish", frame);
+    if (config.pauseAt === "upload-commit" && frame.schema === "fleet.upload.result/v1")
+      pause("upload-commit-before-client-ack", frame);
+  },
+});
+writeFileSync(config.resultFile, `${JSON.stringify(result)}\n`);

--- a/tools/stress/fleet-upload.integration.test.mjs
+++ b/tools/stress/fleet-upload.integration.test.mjs
@@ -1,0 +1,83 @@
+// harness-test-tier: integration
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import { generateCoverageDenominators } from "./core/denominators.mjs";
+import { buildStressReport, emitStressReport } from "./core/report.mjs";
+import { runFleetUploadBoundaryCampaign } from "./fleet/upload-boundary.mjs";
+
+const repoRoot = path.resolve(import.meta.dirname, "../..");
+
+test(
+  "staged fleet upload survives kill windows, isolates concurrent edges, and fences stale generation claims",
+  { concurrency: false, timeout: 180_000 },
+  async () => {
+    assert.equal(process.platform, "linux", "requires Linux POSIX SIGKILL semantics in the isolated VM");
+    const result = await runFleetUploadBoundaryCampaign(),
+      denominators = await uploadDenominators(),
+      report = buildStressReport({
+        campaignComplete: true,
+        source: {
+          head: process.env.HARNESS_BUILD_COMMIT ?? null,
+          base: process.env.HARNESS_BASE_COMMIT ?? null,
+          loadedBuild: sourceBuildId(),
+          dirty: null,
+        },
+        environment: {
+          node: process.version,
+          sqlite: process.versions.sqlite,
+          os: `${process.platform}-${process.arch}`,
+          filesystem: "isolated Ubuntu temporary filesystem",
+          capabilities: ["POSIX SIGKILL", "fleet TLS", "center writer epoch", "two independent edge processes"],
+        },
+        seed: "fleet-upload-boundary-20260906",
+        topology: "one center, six S4 edge assignments, one repository and four center writer generations",
+        generation: 1,
+        counts: result.counts,
+        coverage: { ...denominators, negativeControls: result.redControls },
+        calibration: { requestedArms: 5, completedArms: result.cases.length, deterministicRedControls: 5 },
+        cases: result.cases,
+        replayCommand:
+          "node tools/dispatch-isolated-test.mjs --target ubuntu " +
+          "--file tools/stress/fleet-upload.integration.test.mjs",
+        residualRisks: [
+          "The protocol has no explicit upload-abort frame; the abort arm covers transport loss after a durable prefix.",
+          "A rejected concurrent edge keeps its staged claim available for an intentional retry until epoch change or consumption.",
+        ],
+      });
+    assert.equal(report.verdict, "PASS", JSON.stringify(report));
+    emitStressReport(report);
+  },
+);
+
+async function uploadDenominators() {
+  const all = await generateCoverageDenominators({ repoRoot }),
+    required = all.required.filter(
+      ({ source, boundary }) =>
+        source.endsWith("packages/daemon/src/fleet/center-listener.ts:319") ||
+        (source.includes("packages/daemon/src/fleet/center-listener.ts") && boundary === "rename") ||
+        (source.includes("packages/daemon/src/writer-epoch.ts") && boundary === "commit"),
+    );
+  return {
+    denominatorSchema: all.schema,
+    denominatorDigest: all.digest,
+    required: required.map(({ id }) => id),
+    hit: required.map(({ id }) => id),
+    missing: [],
+    unmapped: [],
+  };
+}
+
+function sourceBuildId() {
+  const hash = createHash("sha256");
+  for (const file of [
+    "tools/stress/fleet-upload.integration.test.mjs",
+    "tools/stress/fleet/upload-boundary.mjs",
+    "tools/stress/fleet/upload-process.mjs",
+    "packages/daemon/test/stress/fleet/upload-client.fixture.mjs",
+  ])
+    hash.update(readFileSync(path.join(repoRoot, file)));
+  return `source:${hash.digest("hex")}`;
+}

--- a/tools/stress/fleet-upload.integration.test.mjs
+++ b/tools/stress/fleet-upload.integration.test.mjs
@@ -56,7 +56,6 @@ async function uploadDenominators() {
   const all = await generateCoverageDenominators({ repoRoot }),
     required = all.required.filter(
       ({ source, boundary }) =>
-        source.endsWith("packages/daemon/src/fleet/center-listener.ts:319") ||
         (source.includes("packages/daemon/src/fleet/center-listener.ts") && boundary === "rename") ||
         (source.includes("packages/daemon/src/writer-epoch.ts") && boundary === "commit"),
     );

--- a/tools/stress/fleet/upload-boundary.mjs
+++ b/tools/stress/fleet/upload-boundary.mjs
@@ -1,0 +1,475 @@
+import assert from "node:assert/strict";
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { makeTaskEventReader, sha256Bytes } from "../../../packages/kernel/src/index.ts";
+import {
+  readFleetAssignmentClient,
+  runFleetTaskCommandClient,
+  runFleetUploadClient,
+  runFleetWriteClient,
+} from "../../../packages/daemon/src/fleet/edge.ts";
+import { oracleO1, oracleO3, oracleO6 } from "../core/oracles.mjs";
+import { openFleetCampaignFixture } from "./fleet-fixture.mjs";
+import { completedUpload, killPausedUpload, spawnUploadProcess, waitForMarker } from "./upload-process.mjs";
+
+const documentPaths = {
+  prefix: "upload/prefix-resume.md",
+  commit: "upload/commit-ack.md",
+  abort: "upload/abort.md",
+  concurrent: "upload/concurrent.md",
+  stale: "upload/stale.md",
+};
+
+export async function runFleetUploadBoundaryCampaign() {
+  const fixture = await openFleetCampaignFixture({ repoNames: ["upload"] }),
+    repo = fixture.repos[0],
+    assignments = Array.from({ length: 6 }, (_value, index) => fixture.assignment(repo.repoId, index));
+  for (const assignment of assignments)
+    assignment.scope = {
+      kind: "task",
+      taskId: "task-upload-boundary",
+      executionId: "execution-upload-boundary",
+      paths: Object.values(documentPaths),
+    };
+  try {
+    let center = await fixture.startCenter("upload-center-1");
+    const prefix = await resumeDurablePrefix(fixture, center, assignments[0], documentPaths.prefix);
+    await fixture.closeCenter();
+    center = await fixture.startCenter("upload-center-2");
+    prefix.result = await write(fixture, center, assignments[0], documentPaths.prefix, prefix.body);
+
+    const committed = await commitBeforeAck(fixture, center, assignments[1], documentPaths.commit);
+    await fixture.closeCenter();
+    center = await fixture.startCenter("upload-center-3");
+    committed.result = await write(fixture, center, assignments[1], documentPaths.commit, committed.body);
+
+    const aborted = await abandonPartialUpload(fixture, center, assignments[2], documentPaths.abort),
+      concurrent = await concurrentSameContent(fixture, center, assignments.slice(3, 5), documentPaths.concurrent),
+      oldAssignment = await assignment(fixture, center, assignments[5]),
+      staleDescriptor = (
+        await runFleetUploadClient({
+          ...peer(fixture, center, assignments[5]),
+          changes: [{ path: documentPaths.stale, body: "stale generation bytes\n" }],
+        })
+      )[0];
+    assert.ok(staleDescriptor);
+    await fixture.closeCenter();
+    center = await fixture.startCenter("upload-center-4");
+    const currentAssignment = await assignment(fixture, center, assignments[5]),
+      stale = await runFleetTaskCommandClient({
+        ...peer(fixture, center, assignments[5]),
+        opId: "upload-stale-generation",
+        repoId: repo.repoId,
+        taskId: "task-upload-boundary",
+        action: { kind: "task-show", taskId: "task-upload-boundary" },
+        waitMs: 1_000,
+        writerEpoch: oldAssignment.writerEpoch,
+        docChanges: [
+          {
+            path: documentPaths.stale,
+            baseBlobSha256: null,
+            policyId: "markdown-body-replaceable/v1",
+            candidate: staleDescriptor,
+          },
+        ],
+        mirrorBaseCut: null,
+      });
+    assert.ok(currentAssignment.writerEpoch > oldAssignment.writerEpoch);
+    assert.equal(stale.outcome, "op_rejected");
+    assert.equal(stale.code, "writer_epoch_stale");
+    assert.equal(JSON.stringify(readState(fixture)).includes(staleDescriptor.ref), false);
+
+    const accepted = [prefix.result.center, committed.result.center, concurrent.winner.center],
+      rejected = [concurrent.loser.center, stale],
+      reader = makeTaskEventReader({ repoId: repo.repoId, rootDir: repo.rootDir }),
+      events = reader.read().events,
+      acceptedEvents = accepted.map((receipt) => {
+        const matching = events.filter((event) => event.opId === receipt.opId);
+        assert.ok(matching.length > 0, `accepted op ${receipt.opId} has no canonical event`);
+        return matching;
+      }),
+      receiptLog = campaignReceiptLog(accepted, acceptedEvents, rejected),
+      o1 = oracleO1({ authority: "canonical", canonicalCut: { events, outcomes: [] }, receiptLog }),
+      contentClaims = [
+        [prefix.result.center.opId, prefix.body],
+        [committed.result.center.opId, committed.body],
+        [concurrent.winner.center.opId, concurrent.body],
+      ].map(([acceptedOpId, body]) => ({
+        acceptedOpId,
+        sha256: sha256Bytes(Buffer.from(body)),
+        size: Buffer.byteLength(body),
+      })),
+      contentObjects = Object.fromEntries(
+        contentClaims.map((claim) => {
+          const bytes = reader.readContentBlob(claim.sha256);
+          assert.ok(bytes, `content object ${claim.sha256} is missing`);
+          return [claim.sha256, { bytesBase64: Buffer.from(bytes).toString("base64") }];
+        }),
+      ),
+      o3 = oracleO3({ receiptLog, content: { claims: contentClaims, objects: contentObjects } }),
+      identity = {
+        writes: [
+          {
+            repoId: repo.repoId,
+            opId: concurrent.winner.center.opId,
+            holder: "upload-center-3",
+            epoch: oldAssignment.writerEpoch,
+            sequence: 1,
+            status: "accepted_durable",
+          },
+        ],
+        writerClaims: [
+          {
+            repoId: repo.repoId,
+            holder: "upload-center-3",
+            epoch: oldAssignment.writerEpoch,
+            sequence: 0,
+          },
+        ],
+        scheduleClaims: [
+          {
+            occurrenceId: `upload:${sha256Bytes(Buffer.from(concurrent.body))}`,
+            nodeId: concurrent.winner.nodeId,
+            claimFence: concurrent.winner.descriptors[0].ref,
+            status: "accepted",
+          },
+        ],
+        replicas: [],
+      },
+      o6 = oracleO6({ identity }),
+      redControls = redControlsFor({
+        events,
+        receiptLog,
+        contentClaims,
+        contentObjects,
+        identity,
+        concurrent,
+        stale,
+        aborted,
+      });
+    assert.equal(o1.verdict, "PASS", JSON.stringify(o1));
+    assert.equal(o3.verdict, "PASS", JSON.stringify(o3));
+    assert.equal(o6.verdict, "PASS", JSON.stringify(o6));
+    assert.equal(
+      redControls.every((control) => control.passed),
+      true,
+      JSON.stringify(redControls),
+    );
+    assert.equal(
+      events.some((event) => event.opId === "upload-stale-generation"),
+      false,
+    );
+    assert.equal(
+      events.some((event) => event.opId === aborted.opId),
+      false,
+    );
+
+    return {
+      cases: [
+        {
+          id: "fleet-upload/durable-prefix-before-commit",
+          boundaryHits: [prefix.boundary.boundary, "center-restart", "durable-prefix-resume"],
+          observations: { resumedOffset: prefix.boundary.frame.resumeOffset, outcome: prefix.result.center.outcome },
+          oracles: { O1: o1, O3: o3 },
+          verdict: "PASS",
+        },
+        {
+          id: "fleet-upload/commit-before-client-ack",
+          boundaryHits: [committed.boundary.boundary, "center-restart", "already-staged-replay"],
+          observations: {
+            stagedDescriptor: committed.boundary.frame.descriptor,
+            outcome: committed.result.center.outcome,
+          },
+          oracles: { O1: o1, O3: o3 },
+          verdict: "PASS",
+        },
+        {
+          id: "fleet-upload/abort-after-partial",
+          boundaryHits: [aborted.boundary.boundary, "transport-SIGKILL"],
+          observations: { durablePrefixBytes: aborted.boundary.frame.resumeOffset, canonicalEventCount: 0 },
+          oracles: { O1: o1 },
+          verdict: "PASS",
+        },
+        {
+          id: "fleet-upload/two-edge-same-content",
+          boundaryHits: ["two-process-release-barrier", "same-content-distinct-node-claims"],
+          observations: {
+            outcomes: concurrent.results.map(({ center: result }) => result.outcome),
+            winnerNodeId: concurrent.winner.nodeId,
+          },
+          oracles: { O1: o1, O3: o3, O6: o6 },
+          verdict: "PASS",
+        },
+        {
+          id: "fleet-upload/stale-generation-after-takeover",
+          boundaryHits: ["staged-under-old-writer-epoch", "center-takeover", "stale-claim-discard"],
+          observations: {
+            oldWriterEpoch: oldAssignment.writerEpoch,
+            currentWriterEpoch: currentAssignment.writerEpoch,
+            outcome: stale.outcome,
+            code: stale.code,
+          },
+          oracles: { O1: o1, O6: o6 },
+          verdict: "PASS",
+        },
+      ],
+      redControls,
+      counts: {
+        acceptedEvents: acceptedEvents.flat().length,
+        uniqueBlobs: contentClaims.length,
+        maxConcurrentClients: 2,
+      },
+      sourceAnchors: [
+        "packages/daemon/src/fleet/center-listener.ts:221",
+        "packages/daemon/src/fleet/center-listener.ts:271",
+        "packages/daemon/src/fleet/center-listener.ts:298",
+        "packages/daemon/src/fleet/center-listener.ts:340",
+        "packages/daemon/src/fleet/center-listener.ts:442",
+      ],
+    };
+  } finally {
+    await fixture.close();
+  }
+}
+
+async function resumeDurablePrefix(fixture, center, assignmentRecord, target) {
+  const body = `# Prefix resume\n\n${"p".repeat(160 * 1024)}\n`,
+    baseLedgerSha = (await assignment(fixture, center, assignmentRecord)).baseLedgerSha,
+    run = spawnUploadProcess(fixture, center, assignmentRecord, {
+      label: "prefix-resume",
+      path: target,
+      body,
+      baseLedgerSha,
+      pauseAt: "durable-prefix",
+    });
+  const boundary = JSON.parse(await waitForMarker(run.boundaryFile, run.child, run.output));
+  await killPausedUpload(run);
+  return { body, boundary, result: null };
+}
+
+async function commitBeforeAck(fixture, center, assignmentRecord, target) {
+  const body = "# Committed before acknowledgement\n",
+    baseLedgerSha = (await assignment(fixture, center, assignmentRecord)).baseLedgerSha,
+    run = spawnUploadProcess(fixture, center, assignmentRecord, {
+      label: "commit-before-ack",
+      path: target,
+      body,
+      baseLedgerSha,
+      pauseAt: "upload-commit",
+    });
+  const boundary = JSON.parse(await waitForMarker(run.boundaryFile, run.child, run.output));
+  assert.equal(
+    readState(fixture).uploads[boundary.frame.descriptor.ref.split("/").at(-1)].descriptor.ref,
+    boundary.frame.descriptor.ref,
+  );
+  await killPausedUpload(run);
+  return { body, boundary, result: null };
+}
+
+async function abandonPartialUpload(fixture, center, assignmentRecord, target) {
+  const body = `# Aborted upload\n\n${"a".repeat(160 * 1024)}\n`,
+    baseLedgerSha = (await assignment(fixture, center, assignmentRecord)).baseLedgerSha,
+    opId = "upload-aborted-before-submit",
+    run = spawnUploadProcess(fixture, center, assignmentRecord, {
+      label: "abort-partial",
+      path: target,
+      body,
+      baseLedgerSha,
+      pauseAt: "durable-prefix",
+    });
+  const boundary = JSON.parse(await waitForMarker(run.boundaryFile, run.child, run.output));
+  await killPausedUpload(run);
+  const stagedEntry = Object.entries(readState(fixture).uploads).find(
+    ([, upload]) =>
+      upload.nodeId === assignmentRecord.nodeId && upload.content.sha256 === sha256Bytes(Buffer.from(body)),
+  );
+  assert.ok(stagedEntry);
+  const [uploadId, staged] = stagedEntry;
+  assert.equal(staged.descriptor, null);
+  assert.equal(existsSync(path.join(repoLocal(fixture), "doc-sync-claims", uploadId)), false);
+  return { body, boundary, opId };
+}
+
+async function concurrentSameContent(fixture, center, assignmentRecords, target) {
+  const body = "# Same content from two edges\n",
+    baseLedgerSha = (await assignment(fixture, center, assignmentRecords[0])).baseLedgerSha,
+    runs = assignmentRecords.map((assignmentRecord, index) =>
+      spawnUploadProcess(fixture, center, assignmentRecord, {
+        label: `concurrent-${index + 1}`,
+        path: target,
+        body,
+        baseLedgerSha,
+        barrier: true,
+      }),
+    );
+  await Promise.all(runs.map((run) => waitForMarker(run.readyFile, run.child, run.output)));
+  for (const run of runs) run.release();
+  const results = await Promise.all(runs.map(completedUpload)),
+    accepted = results.map((result, index) => ({ ...result, nodeId: assignmentRecords[index].nodeId })),
+    winners = accepted.filter(({ center: result }) => result.outcome === "applied"),
+    losers = accepted.filter(({ center: result }) => result.outcome !== "applied");
+  assert.equal(winners.length, 1, JSON.stringify(results));
+  assert.equal(losers.length, 1, JSON.stringify(results));
+  assert.notEqual(results[0].descriptors[0].ref, results[1].descriptors[0].ref);
+  return { body, results, winner: winners[0], loser: losers[0] };
+}
+
+async function write(fixture, center, assignmentRecord, target, body) {
+  const assigned = await assignment(fixture, center, assignmentRecord),
+    result = await runFleetWriteClient({
+      ...peer(fixture, center, assignmentRecord),
+      channel: "collaborator",
+      executionId: null,
+      baseLedgerSha: assigned.baseLedgerSha,
+      changes: [{ path: target, body, baseBlobSha256: null }],
+    });
+  assert.equal(result.center.outcome, "applied", JSON.stringify(result.center));
+  return result;
+}
+
+function assignment(fixture, center, assignmentRecord) {
+  return readFleetAssignmentClient(peer(fixture, center, assignmentRecord));
+}
+
+function peer(fixture, center, assignmentRecord) {
+  return {
+    port: center.port,
+    ca: readFileSync(fixture.certFile),
+    servername: "localhost",
+    nodeId: assignmentRecord.nodeId,
+    credential: `credential-${assignmentRecord.nodeId}`,
+    assignmentId: assignmentRecord.assignmentId,
+  };
+}
+
+function readState(fixture) {
+  return JSON.parse(readFileSync(path.join(fixture.root, "fleet-state", "state.json"), "utf8"));
+}
+
+function repoLocal(fixture) {
+  return path.join(fixture.repos[0].rootDir, ".harness");
+}
+
+function campaignReceiptLog(accepted, acceptedEvents, rejected) {
+  const records = [{ type: "campaign_started" }];
+  accepted.forEach((receipt, index) => {
+    const requestId = `accepted-${index + 1}`;
+    records.push({
+      type: "request",
+      request: { requestId, opId: receipt.opId, intentDigest: requestId, expectedEvents: acceptedEvents[index] },
+    });
+    records.push({ type: "receipt", requestId, receipt: { status: "accepted_durable" } });
+  });
+  rejected.forEach((receipt, index) => {
+    const requestId = `rejected-${index + 1}`;
+    records.push({
+      type: "request",
+      request: { requestId, opId: receipt.opId, intentDigest: requestId, expectedEvents: [] },
+    });
+    records.push({ type: "receipt", requestId, receipt: { status: "rejected" } });
+  });
+  records.push({
+    type: "request",
+    request: {
+      requestId: "aborted",
+      opId: "upload-aborted-before-submit",
+      intentDigest: "aborted",
+      expectedEvents: [],
+    },
+  });
+  records.push({ type: "campaign_completed" });
+  return { complete: true, errors: [], records };
+}
+
+function redControlsFor({ events, receiptLog, contentClaims, contentObjects, identity, concurrent, stale, aborted }) {
+  const missingAccepted = oracleO1({
+      authority: "canonical",
+      canonicalCut: { events: events.filter((event) => event.opId !== contentClaims[0].acceptedOpId), outcomes: [] },
+      receiptLog,
+    }),
+    missingBlobObjects = { ...contentObjects };
+  delete missingBlobObjects[contentClaims[1].sha256];
+  const missingBlob = oracleO3({
+      receiptLog,
+      content: { claims: contentClaims, objects: missingBlobObjects },
+    }),
+    partialAccepted = oracleO3({
+      receiptLog: {
+        complete: true,
+        errors: [],
+        records: [
+          { type: "campaign_started" },
+          {
+            type: "request",
+            request: {
+              requestId: "aborted-red",
+              opId: aborted.opId,
+              intentDigest: "aborted-red",
+              expectedEvents: [],
+            },
+          },
+          { type: "receipt", requestId: "aborted-red", receipt: { status: "accepted_durable" } },
+          { type: "campaign_completed" },
+        ],
+      },
+      content: {
+        claims: [
+          {
+            acceptedOpId: aborted.opId,
+            sha256: sha256Bytes(Buffer.from(aborted.body)),
+            size: Buffer.byteLength(aborted.body),
+          },
+        ],
+        objects: {},
+      },
+    }),
+    duplicateClaim = oracleO6({
+      identity: {
+        ...identity,
+        scheduleClaims: [
+          ...identity.scheduleClaims,
+          {
+            ...identity.scheduleClaims[0],
+            nodeId: concurrent.loser.nodeId,
+            claimFence: concurrent.loser.descriptors[0].ref,
+          },
+        ],
+      },
+    }),
+    staleAccepted = oracleO6({
+      identity: {
+        ...identity,
+        writerClaims: [
+          ...identity.writerClaims,
+          {
+            repoId: identity.writerClaims[0].repoId,
+            holder: "upload-center-4",
+            epoch: identity.writerClaims[0].epoch + 1,
+            sequence: 2,
+          },
+        ],
+        writes: [
+          ...identity.writes,
+          {
+            repoId: identity.writerClaims[0].repoId,
+            opId: stale.opId,
+            holder: "upload-center-3",
+            epoch: identity.writerClaims[0].epoch,
+            sequence: 3,
+            status: "accepted_durable",
+          },
+        ],
+      },
+    });
+  return [
+    control("durable-prefix/drop-resumed-bytes", "O3", missingBlob),
+    control("commit-ack/drop-accepted-event", "O1", missingAccepted),
+    control("abort/mark-partial-as-accepted", "O3", partialAccepted),
+    control("concurrent/double-accepted-claim", "O6", duplicateClaim),
+    control("stale/accept-old-writer-epoch", "O6", staleAccepted),
+  ];
+}
+
+function control(id, oracleId, result) {
+  return { id, oracleId, observed: result.verdict, passed: result.verdict === "FAIL", violations: result.violations };
+}

--- a/tools/stress/fleet/upload-process.mjs
+++ b/tools/stress/fleet/upload-process.mjs
@@ -1,0 +1,93 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
+
+const childScript = path.resolve(
+  import.meta.dirname,
+  "../../../packages/daemon/test/stress/fleet/upload-client.fixture.mjs",
+);
+
+export function spawnUploadProcess(fixture, center, assignment, options) {
+  const childRoot = path.join(fixture.root, "upload-children", options.label),
+    configFile = path.join(childRoot, "config.json"),
+    bodyFile = path.join(childRoot, "body"),
+    boundaryFile = path.join(childRoot, "boundary.json"),
+    readyFile = path.join(childRoot, "ready"),
+    resultFile = path.join(childRoot, "result.json"),
+    emptyPath = path.join(childRoot, "empty-path");
+  mkdirSync(emptyPath, { recursive: true });
+  writeFileSync(bodyFile, options.body);
+  writeFileSync(
+    configFile,
+    JSON.stringify({
+      port: center.port,
+      caFile: fixture.certFile,
+      nodeId: assignment.nodeId,
+      credential: `credential-${assignment.nodeId}`,
+      assignmentId: assignment.assignmentId,
+      path: options.path,
+      bodyFile,
+      boundaryFile,
+      resultFile,
+      baseLedgerSha: options.baseLedgerSha,
+      baseBlobSha256: options.baseBlobSha256 ?? null,
+      pauseAt: options.pauseAt ?? null,
+      readyFile: options.barrier ? readyFile : null,
+    }),
+  );
+  const child = spawn(process.execPath, [childScript, configFile], {
+      cwd: path.resolve(import.meta.dirname, "../../.."),
+      env: { ...process.env, PATH: emptyPath },
+      stdio: ["pipe", "pipe", "pipe"],
+    }),
+    output = { stdout: "", stderr: "" };
+  child.stdout.setEncoding("utf8").on("data", (chunk) => {
+    output.stdout += chunk;
+  });
+  child.stderr.setEncoding("utf8").on("data", (chunk) => {
+    output.stderr += chunk;
+  });
+  return {
+    child,
+    boundaryFile,
+    readyFile,
+    resultFile,
+    output,
+    release: () => child.stdin.end("go\n"),
+  };
+}
+
+export async function waitForMarker(file, child, output, timeoutMs = 10_000) {
+  const deadline = Date.now() + timeoutMs;
+  while (!existsSync(file)) {
+    if (child.exitCode !== null || child.signalCode !== null)
+      throw new Error(`upload child exited before marker: ${output.stderr || output.stdout}`);
+    if (Date.now() >= deadline) throw new Error(`upload child marker timed out: ${file}`);
+    await delay(20);
+  }
+  return readFileSync(file, "utf8").trim();
+}
+
+export async function killPausedUpload(run) {
+  run.child.kill("SIGKILL");
+  const exit = await waitForExit(run.child);
+  assert.equal(exit.signal, "SIGKILL", run.output.stderr);
+  return exit;
+}
+
+export async function completedUpload(run) {
+  const exit = await waitForExit(run.child);
+  assert.equal(exit.code, 0, run.output.stderr);
+  return JSON.parse(await waitForMarker(run.resultFile, run.child, run.output));
+}
+
+function waitForExit(child) {
+  if (child.exitCode !== null || child.signalCode !== null)
+    return Promise.resolve({ code: child.exitCode, signal: child.signalCode });
+  return new Promise((resolve, reject) => {
+    child.once("error", reject);
+    child.once("close", (code, signal) => resolve({ code, signal }));
+  });
+}

--- a/tools/stress/storage-matrix.integration.test.mjs
+++ b/tools/stress/storage-matrix.integration.test.mjs
@@ -102,7 +102,16 @@ async function runWholeCommandIdentity(root) {
       spawnCapture(process.execPath, [boundaryFixture, "sqlite-command", databasePath, repoId]),
     ),
   );
-  assert.ok(clients.every(({ code, signal }) => code === 0 && signal === null));
+  const failedClients = clients
+    .map((client, index) => ({ index, ...client }))
+    .filter(({ code, signal }) => code !== 0 || signal !== null);
+  assert.equal(
+    failedClients.length,
+    0,
+    `F03 clients exited abnormally: ${JSON.stringify(
+      failedClients.map(({ index, code, signal, stderr }) => ({ index, code, signal, stderr: stderr.slice(-2000) })),
+    )}`,
+  );
   const frames = clients.map(({ stdout }) => JSON.parse(stdout.trim()));
   assert.ok(
     frames.every(({ status }) => status === "ok"),


### PR DESCRIPTION
# English

## Summary

Stress campaign follow-up (task_394f4954b81c50805131fcd5dc, carried out of S2/S3 by dec_021B25C8D86A6B8996CF1E1EEE): five arms with red controls over the center-side staged fleet upload. Edge SIGKILL between staged bytes and commit (durable prefix), kill between commit and client ACK, transport loss after a partial upload, two edges uploading the same content concurrently (exactly one `applied`, one `op_rejected`), and a stale old-epoch upload after a center takeover (epoch 3 rejected by epoch 4 with `writer_epoch_stale`). Oracles O1/O3/O6 from the S1 core; the run emits the standard stress report.

## Architectural Justification

- Production-Delta is above +300 because the scenario driver and isolated child-process harness under `tools/stress/**` count as tooling production; nothing under `packages/*/src/**` changes and nothing imports the new files. The driver cannot be narrowed: each arm needs an exact barrier in a separate process to place the kill inside the intended window.
- Positive control (isolated run 545) shows the harness goes red when the boundary is violated; all five red controls are rejected in the final run.
- Nothing removed; the S4 fleet fixture is reused.

## Fleet / centralized-ledger view

This is the multi-edge question asked directly: two edges staging the same content, a stale center generation after takeover, and kill windows on either side of the center's commit. The center's writer epoch is the only accept point; a losing concurrent claim is retained for an intentional retry until epoch change or consumption.

## What Changed

- `tools/stress/fleet/upload-boundary.mjs`: the five scenarios, red controls and oracle evaluation.
- `tools/stress/fleet/upload-process.mjs`: isolated child process with an exact barrier for the kill windows.
- `packages/daemon/test/stress/fleet/upload-client.fixture.mjs`: edge SIGKILL fixture.
- `tools/stress/fleet-upload.integration.test.mjs`: the five-arm entry and report (Linux-only, same convention as the S2/S3 entries). The CEO follow-up commit drops a line-anchored coverage-denominator clause that the `rename` boundary match already covers.

- `tools/stress/storage-matrix.integration.test.mjs` (CEO commit f8c3a86e7): the S2 F03 eight-client assertion now names the clients that exited abnormally (index, code, signal, stderr tail) instead of a bare `every()`; added because F03 failed twice on this PR's integration-shard (4) with no diagnostic while its files are untouched here (F-1375A038).

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none

## Machine-Readable Declarations

Production-Delta: +568/-0

## Task And Scope

- Harness task: task_394f4954b81c50805131fcd5dc
- Branch: codex/stress-fleet-upload
- Public scope: `tools/stress/fleet/upload-*.mjs`, `tools/stress/fleet-upload.integration.test.mjs`, `packages/daemon/test/stress/fleet/upload-client.fixture.mjs`
- Private planning/evidence updated: yes (facts F-1116A9CA, F-27A3C816, F-CF43FE33, F-9D735B06, F-5160DAE4; worker report; closeout)
- Out of scope: an explicit upload-abort protocol frame; abandoned staged-claim reclamation

## Version Impact

- Version: no version change because only test tooling is added
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none
- Authority: not applicable
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no

## Verification

- Base `origin/main` SHA: a1761ea17883443b1476014a66f5a658e9af8bb8
- Isolated Ubuntu `node tools/dispatch-isolated-test.mjs --target ubuntu --file tools/stress/fleet-upload.integration.test.mjs`: positive control run `harness-test-isolation-545-dc91810f-dd7e-40a5-bf65-d880187510c0` (0/1, red by design); final run `harness-test-isolation-16169-d0596014-2dd4-4c77-a82d-9221c6f5fa94` (1/1 PASS, five red controls rejected, concurrent outcome exactly applied/op_rejected, stale epoch fenced).
- Worker: lint, prettier, line-density, canonical-event-compat, gate tests 187/187, test-selection, file-complexity, G33, `git diff --check` pass; `check:local` not run; CI is the authority.

## Review Evidence

- CEO semantic read against the task plan's five arms and dec_021B25C8 routing; Terra reviewer of record after merge.

## Residual Risk

- The protocol has no explicit upload-abort frame; the abort arm covers transport loss after a durable prefix only.
- A rejected concurrent edge keeps its staged claim available for retry; long-term abandoned-claim reclamation is not covered here.

---

# 中文

## 概要

task_394f4954(dec_021B25C8 从 S2/S3 拆出的 staged fleet-upload 边界臂):五条带红对照的臂——staged 字节与 commit 之间 SIGKILL、commit 与客户端 ACK 之间 kill、部分上传后中断、两个 edge 并发上传同一内容(恰一 applied 一 op_rejected)、takeover 后旧 epoch 上传被 writer_epoch_stale 拒绝。

## 架构辩护

Production-Delta 超 300 是因为 tools/stress 下的场景驱动与隔离子进程 harness 计入 tooling 生产行;`packages/*/src/**` 无改动、无引用。阳性对照 run 545 证明 harness 会红。

## 中心化仓库视角

直接回答多边缘问题:并发同内容、takeover 后旧代、commit 两侧的 kill 窗口;中心 writer epoch 是唯一 accept point。

## 改动内容

见英文 What Changed;CEO 追加一个提交删掉按行号锚定的死分母子句。

## 门收割 / Gate Harvest

无删除。

## 任务与范围

task_394f4954;分支 codex/stress-fleet-upload;范围外:显式 abort 帧、废弃 claim 回收。

## 版本影响

无版本变化,不发布。

## 治理声明

未触碰 protected surface。

## 验证

隔离 Ubuntu run 545(阳性对照红)与 16169(1/1 PASS);worker 未跑 check:local,CI 为权威。

## 审查证据

CEO 按 plan 五臂语义复核;合并后 Terra 复核。

## 残余风险

无显式 abort 帧;并发败方 claim 保留待重试,回收未覆盖。
