### PR TITLE
test(stress): concurrent fleet-upload loser must be op_rejected with base_ledger_changed

### DIFF
--- a/tools/stress/fleet/upload-boundary.mjs
+++ b/tools/stress/fleet/upload-boundary.mjs
@@ -196,6 +196,7 @@ export async function runFleetUploadBoundaryCampaign() {
           observations: {
             outcomes: concurrent.results.map(({ center: result }) => result.outcome),
             winnerNodeId: concurrent.winner.nodeId,
+            loserCode: concurrent.loser.center.code,
           },
           oracles: { O1: o1, O3: o3, O6: o6 },
           verdict: "PASS",
@@ -307,9 +308,10 @@ async function concurrentSameContent(fixture, center, assignmentRecords, target)
   const results = await Promise.all(runs.map(completedUpload)),
     accepted = results.map((result, index) => ({ ...result, nodeId: assignmentRecords[index].nodeId })),
     winners = accepted.filter(({ center: result }) => result.outcome === "applied"),
-    losers = accepted.filter(({ center: result }) => result.outcome !== "applied");
+    losers = accepted.filter(({ center: result }) => result.outcome === "op_rejected");
   assert.equal(winners.length, 1, JSON.stringify(results));
   assert.equal(losers.length, 1, JSON.stringify(results));
+  assert.equal(losers[0].center.code, "base_ledger_changed", JSON.stringify(losers[0].center));
   assert.notEqual(results[0].descriptors[0].ref, results[1].descriptors[0].ref);
   return { body, results, winner: winners[0], loser: losers[0] };
 }


### PR DESCRIPTION
# English

## Summary

Follow-up to #2318 from the Terra review of record on task_394f4954b81c50805131fcd5dc (changes_requested): the two-edge concurrent upload arm filtered the loser as `outcome !== "applied"`, so a `pending`/`no_changes`/indeterminate loser would have passed. The loser is now required to be `op_rejected` with code `base_ledger_changed` (observed on isolated Ubuntu runs 52088 and 53647), and the case report records `loserCode`.

## Architectural Justification

- Test-only, one file, narrowing an assertion; Production-Delta counts the stress driver as tooling lines.
- Nothing removed.

## Fleet / centralized-ledger view

The concurrent arm is the multi-edge question; this change makes its rejection explicit instead of "not applied".

## What Changed

- `tools/stress/fleet/upload-boundary.mjs`: `concurrentSameContent` asserts exactly one `applied` and exactly one `op_rejected` with `base_ledger_changed`; the `fleet-upload/two-edge-same-content` case carries `loserCode`.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none

## Machine-Readable Declarations

Production-Delta: +3/-1

## Task And Scope

- Harness task: task_394f4954b81c50805131fcd5dc
- Branch: codex/fleet-upload-loser-code
- Public scope: `tools/stress/fleet/upload-boundary.mjs`
- Private planning/evidence updated: yes (review review_terra_20260906, fact on the observed code)
- Out of scope: everything else in #2318

## Version Impact

- Version: no version change because only a test assertion is narrowed
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none
- Authority: not applicable
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no

## Verification

- Base `origin/main` SHA: 2ef3c8a204f4a5a7504340ed7606aa7fa97fac92 (rebased after #2320 fixed the ledger-open defect that F03 exposed on this PR's shard 4; head is now 3c983bc8a)
- Isolated Ubuntu `node tools/dispatch-isolated-test.mjs --target ubuntu --file tools/stress/fleet-upload.integration.test.mjs`: run `harness-test-isolation-52088-4990bb9f-f432-4c59-ad91-67ec791a315b` (loser code observed `base_ledger_changed`), run `harness-test-isolation-53647-51245c0e-1bfc-497f-9f68-8207d215ab` with the pinned assertion, 1/1 PASS.
- prettier, eslint, `node --check`; `check:local` not run; CI is the authority.

## Review Evidence

- Terra review_terra_20260906 (changes_requested) is the source of this change; Terra round 2 after merge.

## Residual Risk

- None beyond #2318's stated gaps.

---

# 中文

## 概要

#2318 的 Terra 复核意见:并发臂把败方按「非 applied」过滤,pending/no_changes 也能过。现在败方必须是 `op_rejected` 且码为 `base_ledger_changed`(VM run 52088/53647 实测),case 报告带 `loserCode`。

## 架构辩护

纯测试、单文件、收窄断言。

## 中心化仓库视角

并发臂即多边缘问题;本改动让拒绝显式化。

## 改动内容

`tools/stress/fleet/upload-boundary.mjs` 的 `concurrentSameContent`。

## 门收割 / Gate Harvest

无删除。

## 任务与范围

task_394f4954;分支 codex/fleet-upload-loser-code。

## 版本影响

无。

## 治理声明

未触碰 protected surface。

## 验证

VM run 52088、53647(1/1 PASS);CI 为权威。

## 审查证据

来源 Terra review_terra_20260906;合并后 Terra 第二轮。

## 残余风险

无新增。
