### PR TITLE
fix(kernel): retry the ledger open pragmas on SQLITE_BUSY so concurrent openers wait instead of failing

### DIFF
--- a/packages/kernel/src/store/sqlite-event-store.ts
+++ b/packages/kernel/src/store/sqlite-event-store.ts
@@ -90,6 +90,37 @@ export function sqliteLedgerPath(input: HarnessLayoutInput, generation = SQLITE_
   return path.join(resolveHarnessLayout(input).localRoot, "store", "generations", String(generation), "ledger.sqlite");
 }
 
+const SQLITE_BUSY = 5,
+  OPEN_BUSY_BUDGET_MS = 5000;
+
+// busy_timeout goes first so every later lock wait is honoured. The WAL switch is the exception:
+// SQLite skips the busy handler when a connection holding SHARED asks for EXCLUSIVE while another
+// connection holds RESERVED (deadlock avoidance), so with several openers on one fresh ledger a
+// concurrent opener gets SQLITE_BUSY at once no matter the timeout. A bounded retry within the same
+// budget is the only remedy the engine leaves; every pragma here is idempotent.
+function configureLedgerConnection(db: DatabaseSync): void {
+  const deadline = Date.now() + OPEN_BUSY_BUDGET_MS;
+  for (;;) {
+    try {
+      /* @gate-identity check-bypass-write-boundary/bypass-write-127 */ db.exec(
+        `PRAGMA busy_timeout=${OPEN_BUSY_BUDGET_MS}; PRAGMA journal_mode=WAL; ` +
+          "PRAGMA synchronous=FULL; PRAGMA foreign_keys=ON",
+      );
+      return;
+    } catch (error) {
+      if (!isSqliteBusy(error) || Date.now() >= deadline) throw error;
+      consumeKnownError(error);
+      Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 10);
+    }
+  }
+}
+
+function isSqliteBusy(error: unknown): boolean {
+  return (
+    typeof error === "object" && error !== null && (error as { readonly errcode?: unknown }).errcode === SQLITE_BUSY
+  );
+}
+
 export function openSqliteEventStore(options: {
   readonly repoId: string;
   readonly rootInput?: HarnessLayoutInput;
@@ -100,9 +131,7 @@ export function openSqliteEventStore(options: {
     databasePath = options.databasePath ?? sqliteLedgerPath(options.rootInput ?? process.cwd(), generation);
   localRuntimeStateFileSystem.mkdirp(path.dirname(databasePath));
   const db = /* @gate-identity check-bypass-write-boundary/bypass-write-128 */ new DatabaseSync(databasePath);
-  /* @gate-identity check-bypass-write-boundary/bypass-write-127 */ db.exec(
-    "PRAGMA journal_mode=WAL; PRAGMA synchronous=FULL; " + "PRAGMA foreign_keys=ON; PRAGMA busy_timeout=5000",
-  );
+  configureLedgerConnection(db);
   createSchema(db, options.repoId, generation);
   const sqliteVersion = String(
     /* @gate-identity check-bypass-write-boundary/bypass-write-126 */ db

--- a/packages/kernel/test/store/sqlite-event-store.integration.test.ts
+++ b/packages/kernel/test/store/sqlite-event-store.integration.test.ts
@@ -1,6 +1,6 @@
 // harness-test-tier: integration
 import assert from "node:assert/strict";
-import { spawnSync } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -60,6 +60,40 @@ test("a stale holder rolls back before SQLite records an event or outcome", () =
   } finally {
     successor.close();
     stale.close();
+  }
+});
+
+test("opening waits for a concurrent writer lock instead of failing with database is locked", async () => {
+  const databasePath = scratch("open-under-lock"),
+    holdMs = 400,
+    holder = spawn(process.execPath, [
+      "--input-type=module",
+      "-e",
+      [
+        'import { DatabaseSync } from "node:sqlite";',
+        `const db = new DatabaseSync(${JSON.stringify(databasePath)});`,
+        'db.exec("BEGIN IMMEDIATE; CREATE TABLE lock_holder(x INTEGER)");',
+        'process.stdout.write("locked\\n");',
+        `Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ${holdMs});`,
+        'db.exec("COMMIT");',
+        "db.close();",
+      ].join("\n"),
+    ]);
+  try {
+    await new Promise<void>((resolve, reject) => {
+      holder.stdout.once("data", () => resolve());
+      holder.once("exit", (code) => reject(new Error(`lock holder exited early with ${code}`)));
+    });
+    const startedAt = Date.now(),
+      store = openSqliteEventStore({ repoId, databasePath });
+    try {
+      assert.ok(Date.now() - startedAt >= holdMs / 4, "open must have waited on the busy handler");
+      assert.equal(store.revision(), 0);
+    } finally {
+      store.close();
+    }
+  } finally {
+    holder.kill("SIGKILL");
   }
 });
 


### PR DESCRIPTION
# English

## Summary

task_8793e15671e7533ddf45df1f03: `openSqliteEventStore` could fail with `ERR_SQLITE_ERROR` errcode 5 `database is locked` when another connection held a write lock at open time. Found by the S2 F03 eight-client arm once its assertion named the failing client (PR #2319 shard 4, F-1D38FE5A): the open ran `PRAGMA journal_mode=WAL` before `PRAGMA busy_timeout`, and even with the order fixed SQLite skips the busy handler for this lock promotion (SHARED to EXCLUSIVE while another connection holds RESERVED, its deadlock-avoidance rule). The open pragmas now run busy_timeout first and are retried on SQLITE_BUSY within the same 5 s budget; all four pragmas are idempotent.

## Architectural Justification

- One production function changes (`configureLedgerConnection`, same `bypass-write-127` identity, no allowlist growth). The retry is bounded by the existing busy budget and is the only remedy SQLite leaves for this case; it does not wrap any statement other than the connection pragmas.
- Regression test: a child process holds `BEGIN IMMEDIATE` on a fresh ledger for 400 ms while the parent opens the store. Red on main (`database is locked` at the first exec), red after a pragma reorder alone, green with the retry.
- Same mechanism elsewhere: `packages/daemon/src/writer-epoch.ts` already sets busy_timeout first and is opened by one daemon per state root (no concurrent openers); replica ack/cut stores are single-process DELETE-mode stores. No change there.

## Fleet / centralized-ledger view

The ledger is opened by the daemon and by CLI clients on the same machine; eight concurrent CLI openers are the F03 model of that. Center/edge have their own stores.

## What Changed

- `packages/kernel/src/store/sqlite-event-store.ts`: `configureLedgerConnection` (busy_timeout first, bounded SQLITE_BUSY retry), `isSqliteBusy`.
- `packages/kernel/test/store/sqlite-event-store.integration.test.ts`: "opening waits for a concurrent writer lock instead of failing with database is locked".

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none

## Machine-Readable Declarations

Production-Delta: +32/-3

## Task And Scope

- Harness task: task_8793e15671e7533ddf45df1f03
- Branch: codex/sqlite-open-busy-timeout
- Public scope: `packages/kernel/src/store/sqlite-event-store.ts`, `packages/kernel/test/store/sqlite-event-store.integration.test.ts`
- Private planning/evidence updated: yes (F-1D38FE5A, run ids below)
- Out of scope: shard layout (task_7f9c1a3e), writer-epoch store

## Version Impact

- Version: no version change because the fix is internal to the store open path
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none
- Authority: not applicable
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no

## Verification

- Base `origin/main` SHA: 0fc51a1e9488ef9ad80071a50757c609fc79bfcd
- `node --test packages/kernel/test/store/sqlite-event-store.integration.test.ts`: 11 pass / 0 fail (new case red on unfixed code with `database is locked`).
- Isolated Ubuntu `node tools/dispatch-isolated-test.mjs --target ubuntu --file tools/stress/storage-matrix.integration.test.mjs`: run `harness-test-isolation-18349-582fc651-8f0a-40f2-b560-d53d1051…` 1/1 PASS (F03 included).
- `node tools/check-bypass-write-boundary.mjs`: 111 governed calls, delta 0. eslint, prettier; `check:local` not run; CI is the authority (shard 4 carries F03 on the current layout).

## Review Evidence

- CEO-authored; Terra reviewer of record after merge; peer CEO assertion-level read requested (production ledger path).

## Residual Risk

- The retry covers the open pragmas only; a lock held longer than 5 s at open still surfaces `database is locked`, which is the existing busy budget.

---

# 中文

## 概要

task_8793e156:`openSqliteEventStore` 在另一连接持写锁时会以 `database is locked` 失败。S2 F03 八客户端臂把失败客户端具名后暴露(#2319 shard 4,F-1D38FE5A):打开时 `journal_mode=WAL` 排在 `busy_timeout` 之前;且即使调顺序,SQLite 对这类锁升级(持 SHARED 求 EXCLUSIVE、他连接持 RESERVED)按死锁规避规则不调 busy handler。现在 busy_timeout 先行,连接 pragma 在同一 5 s 预算内遇 SQLITE_BUSY 有界重试;四条 pragma 都幂等。

## 架构辩护

单个生产函数、同一 gate 标识(127)、allowlist 无增长;重试只包连接 pragma。回归测试:子进程持 `BEGIN IMMEDIATE` 400 ms,主进程打开必须等待——main 上红、仅调顺序仍红、加重试绿。同机制:writer-epoch 单 daemon 打开、replica 存储单进程 DELETE 模式,不改。

## 中心化仓库视角

daemon 与同机 CLI 客户端共同打开台账;F03 的八并发即其模型。

## 改动内容

见英文。

## 门收割 / Gate Harvest

无删除。

## 任务与范围

task_8793e156;分支 codex/sqlite-open-busy-timeout;范围外:分片布局(task_7f9c1a3e)。

## 版本影响

无。

## 治理声明

未触碰 protected surface;allowlist delta 0。

## 验证

本地 11/11;VM storage-matrix run 18349 PASS;gate 111/delta 0;CI 为权威。

## 审查证据

CEO 亲写;合并后 Terra;请对等 CEO 做断言级细读(生产台账路径)。

## 残余风险

重试仅覆盖打开 pragma;超过 5 s 的锁仍报 database is locked(既有预算)。
