### PR TITLE
fix(kernel): stop retrying the ledger open pragmas once no further attempt can start inside the busy budget

### DIFF
--- a/packages/kernel/src/store/sqlite-event-store.ts
+++ b/packages/kernel/src/store/sqlite-event-store.ts
@@ -91,7 +91,8 @@ export function sqliteLedgerPath(input: HarnessLayoutInput, generation = SQLITE_
 }
 
 const SQLITE_BUSY = 5,
-  OPEN_BUSY_BUDGET_MS = 5000;
+  OPEN_BUSY_BUDGET_MS = 5000,
+  OPEN_BUSY_BACKOFF_MS = 10;
 
 // busy_timeout goes first so every later lock wait is honoured. The WAL switch is the exception:
 // SQLite skips the busy handler when a connection holding SHARED asks for EXCLUSIVE while another
@@ -108,9 +109,10 @@ function configureLedgerConnection(db: DatabaseSync): void {
       );
       return;
     } catch (error) {
-      if (!isSqliteBusy(error) || Date.now() >= deadline) throw error;
+      // Retry only while a further attempt can still start inside the budget.
+      if (!isSqliteBusy(error) || Date.now() + OPEN_BUSY_BACKOFF_MS >= deadline) throw error;
       consumeKnownError(error);
-      Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 10);
+      Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, OPEN_BUSY_BACKOFF_MS);
     }
   }
 }


### PR DESCRIPTION
# English

## Summary

Follow-up to #2320 from the Terra review of record on task_8793e15671e7533ddf45df1f03 (changes_requested): the SQLITE_BUSY retry in `configureLedgerConnection` checked the deadline only after a failed attempt, so a busy error caught just before the deadline could sleep and start one more attempt past the 5 s budget. The retry now continues only while a further attempt can still start inside the budget (`Date.now() + backoff >= deadline` rethrows). The same review also found the task closeout unfilled; that is fixed in the private ledger.

## Architectural Justification

- One condition in one function; no new mechanism, no new identity, allowlist delta 0.
- The regression test from #2320 still passes (11/11); its 400 ms hold is far inside the budget, so it exercises the retry path unchanged.

## Fleet / centralized-ledger view

Unchanged from #2320.

## What Changed

- `packages/kernel/src/store/sqlite-event-store.ts`: `OPEN_BUSY_BACKOFF_MS` constant; the retry guard rethrows when the next attempt could not start before the deadline.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none

## Machine-Readable Declarations

Production-Delta: +5/-3

## Task And Scope

- Harness task: task_8793e15671e7533ddf45df1f03
- Branch: codex/ledger-open-deadline
- Public scope: `packages/kernel/src/store/sqlite-event-store.ts`
- Private planning/evidence updated: yes (closeout written; review review_terra_20260906 on the task)
- Out of scope: everything else

## Version Impact

- Version: no version change because the fix is internal to the store open path
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none
- Authority: not applicable
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no

## Verification

- Base `origin/main` SHA: 2ef3c8a204f4a5a7504340ed7606aa7fa97fac92
- `node --test packages/kernel/test/store/sqlite-event-store.integration.test.ts`: 11 pass / 0 fail.
- `node tools/check-bypass-write-boundary.mjs`: 111 governed calls, delta 0; eslint, prettier; `check:local` not run; CI is the authority.

## Review Evidence

- Source: Terra review_terra_20260906 on task_8793e156; Terra round 2 after merge.

## Residual Risk

- None new.

---

# 中文

## 概要

#2320 的 Terra 复核意见:重试只在失败后检查 deadline,临近 deadline 抓到 BUSY 后仍会退避并再跑一次,越过 5 s 预算。现在只有下一次尝试仍能在预算内开始才重试。复核同时指出任务 closeout 未填,已在私有台账补齐。

## 架构辩护

单函数单条件;无新机制、无新标识、allowlist 零增长;#2320 的回归测试照常 11/11。

## 中心化仓库视角

同 #2320。

## 改动内容

`packages/kernel/src/store/sqlite-event-store.ts`:退避常量与重试守卫。

## 门收割 / Gate Harvest

无删除。

## 任务与范围

task_8793e156;分支 codex/ledger-open-deadline。

## 版本影响

无。

## 治理声明

未触碰 protected surface。

## 验证

本地 11/11;gate delta 0;CI 为权威。

## 审查证据

来源 Terra review_terra_20260906;合并后 Terra 第二轮。

## 残余风险

无新增。
