### PR TITLE
fix(kernel): never start a ledger open retry at or after the busy deadline even if the backoff oversleeps

### DIFF
--- a/packages/kernel/src/store/sqlite-event-store.ts
+++ b/packages/kernel/src/store/sqlite-event-store.ts
@@ -113,6 +113,8 @@ function configureLedgerConnection(db: DatabaseSync): void {
       if (!isSqliteBusy(error) || Date.now() + OPEN_BUSY_BACKOFF_MS >= deadline) throw error;
       consumeKnownError(error);
       Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, OPEN_BUSY_BACKOFF_MS);
+      // The wait can oversleep; never start an attempt at or after the deadline.
+      if (Date.now() >= deadline) throw error;
     }
   }
 }


### PR DESCRIPTION
# English

## Summary

Second follow-up to #2320/#2321 from the Terra review of record on task_8793e15671e7533ddf45df1f03 (round 2): `Atomics.wait` can oversleep, so an attempt could still start at or after the 5 s deadline. After the backoff the loop now rethrows the busy error if the deadline has passed, so no attempt ever starts outside the budget.

## Architectural Justification

- One condition in one function; no new mechanism, no new identity, allowlist delta 0.
- The regression test from #2320 still passes (11/11); its 400 ms hold is far inside the budget, so it exercises the retry path unchanged.

## Fleet / centralized-ledger view

Unchanged from #2320.

## What Changed

- `packages/kernel/src/store/sqlite-event-store.ts`: one post-backoff deadline check in `configureLedgerConnection`.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none

## Machine-Readable Declarations

Production-Delta: +2/-0

## Task And Scope

- Harness task: task_8793e15671e7533ddf45df1f03
- Branch: codex/ledger-open-oversleep
- Public scope: `packages/kernel/src/store/sqlite-event-store.ts`
- Private planning/evidence updated: yes (closeout written; review review_terra_20260906 on the task)
- Out of scope: everything else

## Version Impact

- Version: no version change because the fix is internal to the store open path
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none
- Authority: not applicable
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no

## Verification

- Base `origin/main` SHA: 84a5c0d74b83b58f4e61c9d19f72b7f2de2f5552
- `node --test packages/kernel/test/store/sqlite-event-store.integration.test.ts`: 11 pass / 0 fail.
- `node tools/check-bypass-write-boundary.mjs`: 111 governed calls, delta 0; eslint, prettier; `check:local` not run; CI is the authority.

## Review Evidence

- Source: Terra review_terra_20260906 on task_8793e156; Terra round 2 after merge.

## Residual Risk

- None new.

---

# 中文

## 概要

Terra 第二轮:`Atomics.wait` 可能超时唤醒,尝试仍可能在 deadline 之后开始。退避后若已过 deadline 直接抛出原 BUSY 错误,保证任何尝试都不在预算外开始。

## 架构辩护

单函数单条件;无新机制、无新标识、allowlist 零增长;#2320 的回归测试照常 11/11。

## 中心化仓库视角

同 #2320。

## 改动内容

`packages/kernel/src/store/sqlite-event-store.ts`:退避常量与重试守卫。

## 门收割 / Gate Harvest

无删除。

## 任务与范围

task_8793e156;分支 codex/ledger-open-oversleep。

## 版本影响

无。

## 治理声明

未触碰 protected surface。

## 验证

本地 11/11;gate delta 0;CI 为权威。

## 审查证据

来源 Terra review_terra_20260906;合并后 Terra 第二轮。

## 残余风险

无新增。
