### PR TITLE
fix(gui): replay zcode dispatch transcripts

### DIFF
--- a/packages/daemon/src/observe-tail.ts
+++ b/packages/daemon/src/observe-tail.ts
@@ -237,7 +237,8 @@ function selectDispatchReplayRecord(
 function usefulProviderEvent(event: Readonly<Record<string, unknown>>): boolean {
   const type = event.type,
     message = isJsonObject(event.message) ? event.message : null,
-    content = message && Array.isArray(message.content) ? message.content.filter(isJsonObject) : [];
+    content = message && Array.isArray(message.content) ? message.content.filter(isJsonObject) : [],
+    payload = isJsonObject(event.payload) ? event.payload : null;
   if (type === "assistant")
     return content.some((item) =>
       ["thinking", "text", "tool_use", "server_tool_use", "web_search_tool_result"].includes(String(item.type)),
@@ -260,6 +261,9 @@ function usefulProviderEvent(event: Readonly<Record<string, unknown>>): boolean 
       ].includes(String(item.type))
     );
   }
+  if (type === "model.streaming" && payload)
+    return ["reasoning_delta", "text_delta", "tool_call"].includes(String(payload.kind));
+  if (type === "tool.updated" && payload) return ["result", "error"].includes(String(payload.kind));
   return ["step_update", "result"].includes(String(event.event));
 }
 

--- a/packages/daemon/test/observe-tail.integration.test.mjs
+++ b/packages/daemon/test/observe-tail.integration.test.mjs
@@ -6,7 +6,9 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
 import { openDaemonConnLog } from "../src/conn-log.ts";
+import { openDispatchStream } from "../src/dispatch-stream.ts";
 import { daemonStdioLogPath, openDaemonLifecycleLog } from "../src/lifecycle-log.ts";
+import { readObserveTail } from "../src/observe-tail.ts";
 import { createDaemonHostRepositoryApi } from "../src/daemon-host-repository-api.ts";
 import { validateObserveTailResult } from "../src/protocol/daemon-protocol-gui-types.ts";
 import { validateDaemonRpcCall } from "../src/protocol/daemon-protocol-rpc-validation.ts";
@@ -264,6 +266,119 @@ test("observe.tail opens a 5000-line JSONL source at the latest page and pages b
     console.info(`observe.tail 5000-line first page: ${elapsedMs.toFixed(1)}ms`);
   } finally {
     await cell?.close();
+    rmSync(rootDir, { recursive: true, force: true });
+    rmSync(userRoot, { recursive: true, force: true });
+  }
+});
+
+test("observe.tail replays persisted ZCode transcript records", async () => {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-observe-zcode-"));
+  const userRoot = mkdtempSync(path.join(tmpdir(), "ha-observe-zcode-user-"));
+  const dispatchId = "dispatch_0123456789abcdef01234567";
+  try {
+    initRepo(rootDir);
+    const stream = openDispatchStream(rootDir, {
+      dispatchId,
+      taskId: "task-zcode-transcript",
+      executionId: "execution-zcode-transcript",
+      runtimeSessionId: "runtime-zcode-transcript",
+      instanceId: "zcode-glm",
+      kindId: "zcode",
+      startedAt: "2026-09-05T00:00:00.000Z",
+    });
+    stream.appendProviderEvent(
+      {
+        type: "turn.started",
+        sessionId: "session-zcode",
+        turnId: "turn-zcode",
+      },
+      "2026-09-05T00:00:00.001Z",
+    );
+    stream.appendProviderEvent(
+      {
+        type: "model.streaming",
+        sessionId: "session-zcode",
+        turnId: "turn-zcode",
+        payload: { kind: "reasoning_delta", delta: "Inspect " },
+      },
+      "2026-09-05T00:00:00.002Z",
+    );
+    stream.appendProviderEvent(
+      {
+        type: "model.streaming",
+        sessionId: "session-zcode",
+        turnId: "turn-zcode",
+        payload: { kind: "reasoning_delta", delta: "persisted state." },
+      },
+      "2026-09-05T00:00:00.002Z",
+    );
+    stream.appendProviderEvent(
+      {
+        type: "model.streaming",
+        sessionId: "session-zcode",
+        turnId: "turn-zcode",
+        payload: {
+          kind: "tool_call",
+          toolCallId: "call-zcode",
+          toolName: "Read",
+          input: { file_path: "task_plan.md" },
+        },
+      },
+      "2026-09-05T00:00:00.003Z",
+    );
+    stream.appendProviderEvent(
+      {
+        type: "tool.updated",
+        sessionId: "session-zcode",
+        turnId: "turn-zcode",
+        payload: { kind: "result", toolCallId: "call-zcode", result: "Task contract." },
+      },
+      "2026-09-05T00:00:00.004Z",
+    );
+    stream.appendProviderEvent(
+      {
+        type: "model.streaming",
+        sessionId: "session-zcode",
+        turnId: "turn-zcode",
+        payload: { kind: "text_delta", delta: "bounded fix." },
+      },
+      "2026-09-05T00:00:00.004Z",
+    );
+    stream.appendProviderEvent(
+      {
+        type: "result",
+        sessionId: "session-zcode",
+        turnId: "turn-zcode",
+        response: "Implemented the bounded fix.",
+        usage: { totalTokens: 42 },
+      },
+      "2026-09-05T00:00:00.005Z",
+    );
+
+    const page = await readObserveTail({
+      repoId: workspaceId("observe-zcode"),
+      rootDir,
+      mode: "local",
+      projection: {},
+      userRoot,
+      daemonId: "observe-zcode-daemon",
+      payload: { kind: "dispatch", dispatchId, direction: "history" },
+    });
+
+    assertAvailable(page, "local", "dispatch");
+    assert.deepEqual(
+      page.items.map((record) => [record.kind, record.event?.type]),
+      [
+        ["provider_event", "turn.started"],
+        ["provider_event", "model.streaming"],
+        ["provider_event", "model.streaming"],
+        ["provider_event", "model.streaming"],
+        ["provider_event", "tool.updated"],
+        ["provider_event", "model.streaming"],
+        ["provider_event", "result"],
+      ],
+    );
+  } finally {
     rmSync(rootDir, { recursive: true, force: true });
     rmSync(userRoot, { recursive: true, force: true });
   }

--- a/packages/gui/src/renderer/session-transcript-model.ts
+++ b/packages/gui/src/renderer/session-transcript-model.ts
@@ -49,15 +49,23 @@ export function sessionTranscriptTurns(
       turns.push(created);
       return created;
     },
-    add = (target: MutableTurn, type: SessionTranscriptItemType, label: string, detail: string, at: string | null) => {
-      const normalized = clip(detail.trim(), DETAIL_LIMIT),
+    add = (
+      target: MutableTurn,
+      type: SessionTranscriptItemType,
+      label: string,
+      detail: string,
+      at: string | null,
+      appendDelta = false,
+    ) => {
+      const normalized = clip(appendDelta ? detail : detail.trim(), DETAIL_LIMIT),
         prior = target.items.at(-1);
       if (!normalized) return;
       if (prior && prior.type === type && (type === "thinking" || type === "text")) {
+        const combined = `${prior.detail}${appendDelta ? "" : "\n\n"}${normalized}`;
         target.items[target.items.length - 1] = {
           ...prior,
-          summary: summaryOf(`${prior.detail}\n\n${normalized}`),
-          detail: clip(`${prior.detail}\n\n${normalized}`, DETAIL_LIMIT),
+          summary: summaryOf(combined),
+          detail: clip(combined, DETAIL_LIMIT),
           occurredAt: at ?? prior.occurredAt,
         };
         return;
@@ -150,10 +158,48 @@ export function sessionTranscriptTurns(
         else if (itemType === "error") add(current, "error", "error", contentOf(item), at);
         continue;
       }
+      if (type === "model.streaming") {
+        current ??= turn(`zcode:${stringOf(event.turnId) ?? turns.length + 1}`, at);
+        if (current.status === "unknown") current.status = "running";
+        const payload = recordOf(event.payload),
+          kind = stringOf(payload?.kind),
+          delta = stringOf(payload?.delta) ?? "";
+        if (kind === "reasoning_delta") add(current, "thinking", "thinking", delta, at, true);
+        else if (kind === "text_delta") add(current, "text", "text", delta, at, true);
+        else if (kind === "tool_call" && payload) {
+          const toolId = stringOf(payload.toolCallId),
+            label = stringOf(payload.toolName) ?? "tool";
+          add(current, "tool_call", label, contentOf(payload.input ?? payload), at);
+          if (toolId) toolTurns.set(toolId, { turn: current, label });
+        }
+        continue;
+      }
+      if (type === "tool.updated") {
+        const payload = recordOf(event.payload),
+          kind = stringOf(payload?.kind),
+          toolId = stringOf(payload?.toolCallId),
+          known = toolId ? toolTurns.get(toolId) : null,
+          target = known?.turn ?? current ?? turn(`zcode:${stringOf(event.turnId) ?? turns.length + 1}`, at),
+          label = known?.label ?? (toolId ? `tool ${toolId}` : "tool");
+        current = target;
+        if (kind === "result" && payload) add(target, "tool_result", label, contentOf(payload.result), at);
+        else if (kind === "error" && payload) add(target, "error", label, contentOf(payload.error), at);
+        continue;
+      }
       if (type === "result") {
         current ??= turn(`provider:${turns.length + 1}`, at);
-        const result = stringOf(event.result);
-        if (result && current.items.at(-1)?.detail !== result) add(current, "text", "result", result, at);
+        const response = stringOf(event.response),
+          result = stringOf(event.result) ?? response,
+          prior = current.items.at(-1);
+        if (response && prior?.type === "text" && prior.label === "text")
+          current.items[current.items.length - 1] = {
+            ...prior,
+            label: "result",
+            summary: summaryOf(response),
+            detail: clip(response, DETAIL_LIMIT),
+            occurredAt: at ?? prior.occurredAt,
+          };
+        else if (result && prior?.detail !== result) add(current, "text", "result", result, at);
         current.status = event.is_error === true ? "failed" : "completed";
         current.endedAt = at;
         continue;

--- a/packages/gui/test/agent-runtime-sessions.vitest.ts
+++ b/packages/gui/test/agent-runtime-sessions.vitest.ts
@@ -302,6 +302,91 @@ describe("session transcript replay", () => {
     ]);
   });
 
+  it("maps persisted ZCode reasoning, tools, and response into one transcript turn", () => {
+    const turns = sessionTranscriptTurns([
+      {
+        kind: "provider_event",
+        occurredAt: "2026-09-05T00:00:00.001Z",
+        event: { type: "turn.started", sessionId: "session-zcode", turnId: "turn-zcode" },
+      },
+      {
+        kind: "provider_event",
+        occurredAt: "2026-09-05T00:00:00.002Z",
+        event: {
+          type: "model.streaming",
+          sessionId: "session-zcode",
+          turnId: "turn-zcode",
+          payload: { kind: "reasoning_delta", delta: "Inspect " },
+        },
+      },
+      {
+        kind: "provider_event",
+        occurredAt: "2026-09-05T00:00:00.002Z",
+        event: {
+          type: "model.streaming",
+          sessionId: "session-zcode",
+          turnId: "turn-zcode",
+          payload: { kind: "reasoning_delta", delta: "persisted state." },
+        },
+      },
+      {
+        kind: "provider_event",
+        occurredAt: "2026-09-05T00:00:00.003Z",
+        event: {
+          type: "model.streaming",
+          sessionId: "session-zcode",
+          turnId: "turn-zcode",
+          payload: {
+            kind: "tool_call",
+            toolCallId: "call-zcode",
+            toolName: "Read",
+            input: { file_path: "task_plan.md" },
+          },
+        },
+      },
+      {
+        kind: "provider_event",
+        occurredAt: "2026-09-05T00:00:00.004Z",
+        event: {
+          type: "tool.updated",
+          sessionId: "session-zcode",
+          turnId: "turn-zcode",
+          payload: { kind: "result", toolCallId: "call-zcode", result: "Task contract." },
+        },
+      },
+      {
+        kind: "provider_event",
+        occurredAt: "2026-09-05T00:00:00.004Z",
+        event: {
+          type: "model.streaming",
+          sessionId: "session-zcode",
+          turnId: "turn-zcode",
+          payload: { kind: "text_delta", delta: "bounded fix." },
+        },
+      },
+      {
+        kind: "provider_event",
+        occurredAt: "2026-09-05T00:00:00.005Z",
+        event: {
+          type: "result",
+          sessionId: "session-zcode",
+          turnId: "turn-zcode",
+          response: "Implemented the bounded fix.",
+          usage: { totalTokens: 42 },
+        },
+      },
+    ]);
+
+    expect(turns).toHaveLength(1);
+    expect(turns[0]?.status).toBe("completed");
+    expect(turns[0]?.items.map(({ type, label, detail }) => ({ type, label, detail }))).toEqual([
+      { type: "thinking", label: "thinking", detail: "Inspect persisted state." },
+      { type: "tool_call", label: "Read", detail: '{\n  "file_path": "task_plan.md"\n}' },
+      { type: "tool_result", label: "Read", detail: "Task contract." },
+      { type: "text", label: "result", detail: "Implemented the bounded fix." },
+    ]);
+  });
+
   it("states explicitly that a session without a dispatch has no replay record", () => {
     const markup = renderToStaticMarkup(
       createElement(SessionTranscript, {


### PR DESCRIPTION
# English

## Summary

GUI session pages showed "no dispatch record" for zcode (GLM) runtimes even though their dispatch stream on disk holds tens of thousands of provider events. The only transcript read path (`observe.tail(kind=dispatch)`) filtered out zcode's `model.streaming` / `tool.updated` events and the renderer did not recognise the final `result.response`, so the record existed but rendered zero turns. This PR lets the existing filter pass zcode content events and teaches the single transcript model to merge stream deltas, tool results and the final response.

## Architectural Justification

- One read source stays the read source: no second transcript channel, no fallback, no protocol change. The worker's evidence-backed challenge rejected the task plan's original hypothesis (a `stream:` vs `file:` ref mismatch) — the `file:` dispatch stream is still the sole producer and consumer; facts F-2E0E3FD0 / F-34FF40C6.
- The codex / claude / agy transcript behaviour is untouched (session-identity contract 8/8 and existing renderer tests unchanged).

## Fleet / centralized-ledger view

Read-only replay of a per-dispatch stream; no new writer, no concurrency subject.

## What Changed

- `packages/daemon/src/observe-tail.ts`: `usefulProviderEvent` passes zcode `model.streaming` (reasoning/text delta, tool_call) and `tool.updated` (result/error).
- `packages/gui/src/renderer/session-transcript-model.ts`: lossless delta concatenation, zcode reasoning/text/tool/result mapping, final `result.response` converges the streamed tail.
- Tests: `packages/daemon/test/observe-tail.integration.test.mjs` (zcode replay through an isolated daemon read), `packages/gui/test/agent-runtime-sessions.vitest.ts` (zcode fixture now yields turns; red on main).

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none

## Machine-Readable Declarations

Production-Delta: +57/-7

## Task And Scope

- Harness task: task_68d2a1cc4178f862024c4b7f78 (parent PLT-Provider task_6787fa1c)
- Branch: codex/transcript-stream-ref
- Public scope: the four files above
- Private planning/evidence updated: yes (worker report, facts F-2E0E3FD0 / F-34FF40C6)
- Out of scope: a CLI transcript surface for `ha runtime status` (does not exist today; separate task if wanted)

## Version Impact

- Version: no version change (renderer + daemon read filter)
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none
- Authority: not applicable
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no

## Verification

- Base `origin/main` SHA: faecce39a5865e1cc8749e0caac7a32cced39ae7
- Negative control before the fix: GUI vitest 1 failed / 26 passed (zcode fixture 0 turns); isolated Ubuntu `observe-tail.integration` 1 failed / 4 passed.
- After: `npm run test:gui -w @harness-anything/gui -- agent-runtime-sessions.vitest.ts` 27/27 (re-run by the CEO); isolated Ubuntu `observe-tail.integration` 5/5; `session-identity.contract` 8/8; typecheck, eslint, line-density, production-delta, file-complexity all PASS.
- Real instance read-only check: `dispatch_89e1e06e9b5402e88c6f298a` now replays 64 events → 1 turn with text.
- `check:local` not run; CI is the authority.

## Review Evidence

- CEO semantic read of the diff against the task goal (single read source, no compat layer); Terra review to follow on the task after merge.

## Residual Risk

- Electron GUI walk-through on a live GLM session is pending the CEO's next daemon changeover (daemon read filter is in the daemon build).

---

# 中文

## 概要

GUI 会话页对 zcode(GLM)runtime 显示「该会话没有可用的派工记录」,但盘上的派工流里有几万条 provider 事件。唯一的 transcript 读路径 `observe.tail(kind=dispatch)` 把 zcode 的 `model.streaming` / `tool.updated` 过滤掉了,renderer 也不认最终的 `result.response`,于是记录存在但渲染 0 个 turn。本 PR 让现有筛选放行 zcode 内容事件,并让同一份 transcript 模型合并流式增量、工具结果与最终回复。

## 架构辩护

单一读源不变:不加第二条 transcript 通道、不加 fallback、不改协议。worker 以证据推翻了任务计划原先的 `stream:`/`file:` ref 假设(`file:` 派工流仍是唯一生产者与消费者,fact F-2E0E3FD0 / F-34FF40C6)。codex/claude/agy 的行为不变。

## 中心化仓库视角

只读回放每个 dispatch 自己的流;无新写者、无并发主体。

## 改动内容

`observe-tail.ts` 筛选放行;`session-transcript-model.ts` 增量拼接与 zcode 映射;两处测试(daemon 隔离集成 + GUI vitest,main 上为红)。

## 门收割 / Gate Harvest

无删除。

## 任务与范围

task_68d2a1cc(父 PLT-Provider);分支 codex/transcript-stream-ref;不含 CLI transcript 面。

## 版本影响

无。

## 治理声明

未触碰 protected surface。

## 验证

修复前阴性对照红;修复后 GUI vitest 27/27(CEO 复跑)、Ubuntu 隔离集成 5/5、session-identity 8/8;各 gate PASS;未跑 check:local,CI 为权威。

## 审查证据

CEO 语义细读;合并后 Terra 在任务上复核。

## 残余风险

Electron 上真实 GLM 会话的人工走查待下次 daemon 换代后由 CEO 做。
