### PR TITLE
fix: derive runtime liveness from dispatch activity

### DIFF
--- a/packages/daemon/src/agent-runtime-read.ts
+++ b/packages/daemon/src/agent-runtime-read.ts
@@ -1,5 +1,6 @@
 import {
   runtimeDefinitionSnapshotArtifact,
+  latestRuntimeActivityAt,
   runtimeSessionInActivityWindow,
   runtimeSessionMissingOutcomeEvidence,
   runtimeSessionOutcomeFromEvidence,
@@ -30,6 +31,7 @@ import { runtimeKindForInstallation } from "./runtime-inventory.ts";
 import { isRuntimeKindId } from "./runtime-inventory.ts";
 import type { RuntimeInstanceSummary } from "./agent-runtime-instances.ts";
 import type { TaskDispatchRow } from "./protocol/daemon-protocol.contract.ts";
+import type { RuntimeSessionActivityEvidence } from "./dispatch-read.ts";
 
 export function makeAgentRuntimeReadModel(input: {
   readonly readDispatch?: (taskId: string, dispatchId: string) => { readonly runtimeSessionId: string } | null;
@@ -38,12 +40,18 @@ export function makeAgentRuntimeReadModel(input: {
     readonly events: readonly Extract<AgentRuntimeEventV1, { readonly type: "runtime_dispatch_requested" }>[];
   }) => readonly TaskDispatchRow[];
   readonly readAttemptChain?: (runtimeSessionId: string) => AgentRuntimeAttemptChainDto | undefined;
+  readonly readActivityEvidence?: (dispatchId: string) => RuntimeSessionActivityEvidence | undefined;
   readonly projection: TaskProjection;
   readonly store: CanonicalEventStore;
   readonly stream: AgentRuntimeStreamHub;
   readonly runtimeInstances?: () => readonly RuntimeInstanceSummary[];
   readonly now?: () => string;
 }) {
+  const activityEvidenceFor = (session: RuntimeSession): RuntimeSessionActivityEvidence | undefined => {
+    if (!input.readActivityEvidence) return undefined;
+    const dispatch = input.projection.readRuntimeDispatch(session.runtimeSessionId, session.definitionSnapshotRef);
+    return dispatch ? input.readActivityEvidence(dispatch.payload.dispatchId) : undefined;
+  };
   const installationDto = (installation: RuntimeInstallation): AgentRuntimeInstallationDto => ({
     installationId: installation.installationId,
     kindId: runtimeKindForInstallation(installation).kindId,
@@ -56,9 +64,11 @@ export function makeAgentRuntimeReadModel(input: {
     session: RuntimeSession,
     installation: RuntimeInstallation | null | undefined,
     definition: { readonly snapshot: AgentDefinitionSnapshot | null; readonly persisted: boolean },
+    evidence: RuntimeSessionActivityEvidence | undefined,
     includeAttemptChain = false,
   ): AgentRuntimeSessionDto => {
-    const attemptChain = includeAttemptChain ? input.readAttemptChain?.(session.runtimeSessionId) : undefined,
+    const observedSession = sessionWithActivityEvidence(session, evidence),
+      attemptChain = includeAttemptChain ? input.readAttemptChain?.(session.runtimeSessionId) : undefined,
       installationError = installation
         ? null
         : {
@@ -77,10 +87,12 @@ export function makeAgentRuntimeReadModel(input: {
       definitionSnapshotRef: session.definitionSnapshotRef,
       definitionSnapshot: definition.snapshot,
       definitionSnapshotPersisted: definition.persisted,
-      liveness: session.liveness,
-      semanticState: runtimeSessionSemanticState(session),
+      liveness: observedSession.liveness,
+      semanticState: runtimeSessionSemanticState(observedSession),
       attachCapability:
-        session.attachable && installation?.effectiveCapabilities.includes("attach") ? "supported" : "unsupported",
+        observedSession.attachable && installation?.effectiveCapabilities.includes("attach")
+          ? "supported"
+          : "unsupported",
       streamCursor: input.stream.latestCursor(session.runtimeSessionId),
       associations: session.taskBindings.map((binding) => {
         const lease = input.projection.currentLease(binding.taskId),
@@ -94,12 +106,12 @@ export function makeAgentRuntimeReadModel(input: {
       }),
       ...(attemptChain ? { attemptChain } : {}),
       activity: {
-        lastObservedAt: session.lastObservedAt,
-        outcome: runtimeSessionOutcomeFromEvidence(session),
-        exitCode: session.exitCode,
-        resultRef: session.resultRef,
-        missingEvidence: runtimeSessionMissingOutcomeEvidence(session),
-        ...(session.reasonCode ? { reasonCode: session.reasonCode } : {}),
+        lastObservedAt: observedSession.lastObservedAt,
+        outcome: runtimeSessionOutcomeFromEvidence(observedSession),
+        exitCode: observedSession.exitCode,
+        resultRef: observedSession.resultRef,
+        missingEvidence: runtimeSessionMissingOutcomeEvidence(observedSession),
+        ...(observedSession.reasonCode ? { reasonCode: observedSession.reasonCode } : {}),
       },
     };
   };
@@ -174,6 +186,7 @@ export function makeAgentRuntimeReadModel(input: {
             session,
             installations.find(({ installationId }) => installationId === session.installationId),
             definitionFor(session),
+            activityEvidenceFor(session),
           ),
         ),
         ...(paged === null
@@ -196,6 +209,7 @@ export function makeAgentRuntimeReadModel(input: {
         cut = input.projection.readCut(),
         sessions = input.projection
           .readRuntimeSessions()
+          .map((session) => sessionWithActivityEvidence(session, activityEvidenceFor(session)))
           .filter((session) => runtimeSessionInActivityWindow(session, query.since)),
         sessionIds = new Set(sessions.map(({ runtimeSessionId }) => runtimeSessionId)),
         dispatchEvents = input.projection
@@ -246,6 +260,7 @@ export function makeAgentRuntimeReadModel(input: {
           session,
           input.projection.readRuntimeInstallation(session.installationId),
           definitionFor(session),
+          activityEvidenceFor(session),
           true,
         ),
         result: resultFor(session),
@@ -292,6 +307,23 @@ export function makeAgentRuntimeReadModel(input: {
     }
     return { ref: session.resultRef, text };
   }
+}
+
+function sessionWithActivityEvidence(
+  session: RuntimeSession,
+  evidence: RuntimeSessionActivityEvidence | undefined,
+): RuntimeSession {
+  if (!evidence) return session;
+  const lastObservedAt = latestRuntimeActivityAt([session.lastObservedAt, evidence.lastObservedAt]);
+  if (session.liveness === "exited" || session.liveness === "live" || session.outcome !== null)
+    return { ...session, lastObservedAt };
+  if (!evidence.workerHostAlive) return { ...session, lastObservedAt };
+  return {
+    ...session,
+    liveness: "live",
+    attachable: true,
+    lastObservedAt,
+  };
 }
 
 function historicalRuntimeKindId(

--- a/packages/daemon/src/dispatch-read.ts
+++ b/packages/daemon/src/dispatch-read.ts
@@ -42,6 +42,7 @@ export function readRuntimeSessionActivityEvidence(
   rootDir: string,
   dispatchId: string,
 ): RuntimeSessionActivityEvidence | undefined {
+  if (!/^dispatch_[a-f0-9]{24}$/u.test(dispatchId)) return undefined;
   const stream = readDispatchStreamSummary(rootDir, dispatchId);
   if (!stream) return undefined;
   return {

--- a/packages/daemon/src/dispatch-read.ts
+++ b/packages/daemon/src/dispatch-read.ts
@@ -23,6 +23,7 @@ import type {
   TaskDispatchRow,
 } from "./protocol/daemon-protocol.contract.ts";
 import type { AgentRuntimeAttemptChainDto } from "./agent-runtime-contract.ts";
+import { runtimePidIsAlive } from "./runtime-spawn-process.ts";
 
 type DispatchLiveIndexRow = ReturnType<typeof readDispatchLiveIndex>["entries"][number];
 
@@ -31,6 +32,23 @@ type DispatchCandidate = {
   readonly taskPackages: readonly { readonly taskId: string; readonly packagePath: string }[];
   readonly indexed: boolean;
 };
+
+export interface RuntimeSessionActivityEvidence {
+  readonly lastObservedAt: string;
+  readonly workerHostAlive: boolean;
+}
+
+export function readRuntimeSessionActivityEvidence(
+  rootDir: string,
+  dispatchId: string,
+): RuntimeSessionActivityEvidence | undefined {
+  const stream = readDispatchStreamSummary(rootDir, dispatchId);
+  if (!stream) return undefined;
+  return {
+    lastObservedAt: stream.lastObservedAt,
+    workerHostAlive: stream.process?.exited === false && runtimePidIsAlive(stream.process.pid),
+  };
+}
 
 export function readTaskDispatches(
   input: { readonly rootDir: string; readonly projection: TaskProjection } & DaemonTaskDispatchesPayload,

--- a/packages/daemon/src/dispatch-stream.ts
+++ b/packages/daemon/src/dispatch-stream.ts
@@ -126,6 +126,7 @@ export interface DispatchLiveIndex {
 
 /** Metadata needed by daemon hot paths without retaining provider event bodies. */
 export type DispatchStreamSummary = Omit<NonNullable<ReturnType<typeof readDispatchStream>>, "records"> & {
+  readonly lastObservedAt: string;
   readonly records: readonly DispatchStreamRecord[];
 };
 
@@ -316,7 +317,7 @@ export function readDispatchStreamSummary(rootDir: string, dispatchId: string): 
       if (record) records.push(record);
     }
   }
-  const value = summarizeDispatch(header, records);
+  const value = summarizeDispatch(header, records, stat.mtimeMs);
   summaryCache.set(target, { mtimeMs: stat.mtimeMs, size: stat.size, value });
   return value;
 }
@@ -341,6 +342,7 @@ export function readDispatchStream(
   dispatchId: string,
 ): {
   readonly header: DispatchStreamHeader;
+  readonly lastObservedAt: string;
   readonly providerSessionId: string | null;
   readonly process: DispatchProcessState | null;
   readonly attemptOutcome: RuntimeAttemptOutcome | null;
@@ -367,7 +369,7 @@ export function readDispatchStream(
     .slice(1)
     .map(parseRecord)
     .filter((record): record is DispatchStreamRecord => record !== null);
-  const summary = summarizeDispatch(first, records);
+  const summary = summarizeDispatch(first, records, stat.mtimeMs);
   return {
     ...summary,
     records,
@@ -526,6 +528,7 @@ function warnOnce(warnings: Set<string>, target: string, detail: string): void {
 function summarizeDispatch(
   header: DispatchStreamHeader,
   records: readonly DispatchStreamRecord[],
+  modifiedAtMs: number,
 ): DispatchStreamSummary {
   let providerSessionId: string | null = null,
     processState: DispatchProcessState | null = null,
@@ -559,6 +562,7 @@ function summarizeDispatch(
   }
   return {
     header,
+    lastObservedAt: dispatchLastObservedAt(header, records, modifiedAtMs),
     providerSessionId,
     process: processState,
     attemptOutcome,
@@ -567,6 +571,18 @@ function summarizeDispatch(
     nextDispatchId,
     records,
   };
+}
+
+function dispatchLastObservedAt(
+  header: DispatchStreamHeader,
+  records: readonly DispatchStreamRecord[],
+  modifiedAtMs: number,
+): string {
+  const observed = [header.startedAt, new Date(modifiedAtMs).toISOString()];
+  for (const record of records) if (typeof record.occurredAt === "string") observed.push(record.occurredAt);
+  return observed.reduce((latest, candidate) =>
+    Number.isFinite(Date.parse(candidate)) && Date.parse(candidate) > Date.parse(latest) ? candidate : latest,
+  );
 }
 
 function readBoundedStreamWindows(

--- a/packages/daemon/src/repo-cell-open.ts
+++ b/packages/daemon/src/repo-cell-open.ts
@@ -27,6 +27,7 @@ import {
   type AgentRuntimeNativeSignal,
   type AgentRuntimeStreamHub,
 } from "./agent-runtime-stream.ts";
+import { readRuntimeSessionActivityEvidence } from "./dispatch-read.ts";
 import { openGuiCatalog } from "./gui-catalog.ts";
 import type { FleetRoster } from "./fleet-center-admission.ts";
 import { type CanonicalRoot, type WorkspaceId } from "./protocol/daemon-protocol.contract.ts";
@@ -220,7 +221,13 @@ export async function openRepoWriterCell(
   const workerRuntimeStream = makeAgentRuntimeStreamHub({
       readSession: (runtimeSessionId) => projection.readRuntimeSession(runtimeSessionId),
       canAttach: (session) =>
-        session.attachable &&
+        (session.attachable ||
+          (() => {
+            const dispatch = projection.readRuntimeDispatch(session.runtimeSessionId, session.definitionSnapshotRef);
+            return dispatch
+              ? readRuntimeSessionActivityEvidence(rootDir, dispatch.payload.dispatchId)?.workerHostAlive === true
+              : false;
+          })()) &&
         Boolean(projection.readRuntimeInstallation(session.installationId)?.effectiveCapabilities.includes("attach")),
       now: () => new Date(now()),
     }),

--- a/packages/daemon/src/repo-cell-proxy.ts
+++ b/packages/daemon/src/repo-cell-proxy.ts
@@ -11,7 +11,12 @@ import {
 import { ledgerWriteCommandTopology } from "../../preset/src/preset-command-contract.ts";
 import { makeAgentRuntimeReadModel } from "./agent-runtime-read.ts";
 import { makeAgentRuntimeStreamHub } from "./agent-runtime-stream.ts";
-import { readRuntimeAttemptChain, readSessionGroupDispatches, readTaskDispatches } from "./dispatch-read.ts";
+import {
+  readRuntimeAttemptChain,
+  readRuntimeSessionActivityEvidence,
+  readSessionGroupDispatches,
+  readTaskDispatches,
+} from "./dispatch-read.ts";
 import { openReplicaCutSource } from "./fleet/replica-cut-store.ts";
 import { readObserveEventTail, readObserveTail } from "./observe-tail.ts";
 import { openTerminalHost } from "./terminal-host.ts";
@@ -93,7 +98,13 @@ export async function openRepoCellProxy(
       readSession: (runtimeSessionId) =>
         reader.withSession((projection) => projection.readRuntimeSession(runtimeSessionId)),
       canAttach: (session) =>
-        session.attachable &&
+        (session.attachable ||
+          reader.withSession((projection) => {
+            const dispatch = projection.readRuntimeDispatch(session.runtimeSessionId, session.definitionSnapshotRef);
+            return dispatch
+              ? readRuntimeSessionActivityEvidence(input.rootDir, dispatch.payload.dispatchId)?.workerHostAlive === true
+              : false;
+          })) &&
         reader.withSession((projection) =>
           Boolean(projection.readRuntimeInstallation(session.installationId)?.effectiveCapabilities.includes("attach")),
         ),
@@ -171,6 +182,7 @@ export async function openRepoCellProxy(
         runtimeSpawner: () => ({ spawn: unsupportedWrite, cancel: unsupportedWrite }),
       }),
       runtimeReads = makeAgentRuntimeReadModel({
+        readActivityEvidence: (dispatchId) => readRuntimeSessionActivityEvidence(input.rootDir, dispatchId),
         readAttemptChain: (runtimeSessionId) => readRuntimeAttemptChain(input.rootDir, runtimeSessionId),
         readDispatch: (taskId, dispatchId) =>
           readTaskDispatches({ rootDir: input.rootDir, projection: writableProjection, taskId }).dispatches.find(

--- a/packages/daemon/src/repo-cell.ts
+++ b/packages/daemon/src/repo-cell.ts
@@ -23,7 +23,12 @@ import {
   type WalRecoveryProgress,
 } from "../../kernel/src/index.ts";
 import { makeAgentRuntimeReadModel } from "./agent-runtime-read.ts";
-import { readRuntimeAttemptChain, readSessionGroupDispatches, readTaskDispatches } from "./dispatch-read.ts";
+import {
+  readRuntimeAttemptChain,
+  readRuntimeSessionActivityEvidence,
+  readSessionGroupDispatches,
+  readTaskDispatches,
+} from "./dispatch-read.ts";
 import { runDocAction } from "./doc-sync-actions.ts";
 import { blockedCandidateNextAction } from "./doc-sync-details.ts";
 import { scanAuthoredCandidateInventory, type AuthoredCandidateInventoryV1 } from "./doc-sync-candidate-scanner.ts";
@@ -315,6 +320,7 @@ export async function initializeRepoCell(context: RepoCellCoreInput): Promise<Re
       killpoint: context.input.killpoint,
     });
     const runtimeReads = makeAgentRuntimeReadModel({
+        readActivityEvidence: (dispatchId) => readRuntimeSessionActivityEvidence(context.rootDir, dispatchId),
         readAttemptChain: (runtimeSessionId) => readRuntimeAttemptChain(context.rootDir, runtimeSessionId),
         readDispatch: (taskId, dispatchId) =>
           readTaskDispatches({ rootDir: context.rootDir, projection: projection!, taskId }).dispatches.find(

--- a/packages/daemon/test/agent-runtime-read-missing-installation.test.ts
+++ b/packages/daemon/test/agent-runtime-read-missing-installation.test.ts
@@ -71,9 +71,54 @@ test("an installation-backed session DTO remains byte-for-byte unchanged", () =>
     assert.equal(Object.hasOwn(session, "installationError"), false);
   }));
 
+test("live dispatch evidence repairs an unknown session and advances its observed time", () =>
+  withRuntime(true, ({ store, projection, stream }) => {
+    const unknownProjection = new Proxy(projection, {
+        get: (target, property, receiver) => {
+          if (property === "readRuntimeSessions")
+            return () =>
+              target.readRuntimeSessions().map((session) => ({
+                ...session,
+                liveness: "unknown" as const,
+                attachable: false,
+              }));
+          if (property === "readRuntimeSession")
+            return (runtimeSessionId: string) => {
+              const session = target.readRuntimeSession(runtimeSessionId);
+              return session ? { ...session, liveness: "unknown" as const, attachable: false } : null;
+            };
+          const value = Reflect.get(target, property, receiver);
+          return typeof value === "function" ? value.bind(target) : value;
+        },
+      }),
+      reads = makeAgentRuntimeReadModel({
+        readActivityEvidence: () => ({
+          lastObservedAt: "2026-09-06T01:45:42.460Z",
+          workerHostAlive: true,
+        }),
+        store,
+        projection: unknownProjection,
+        stream,
+      });
+    for (const session of [
+      reads.overview({}).sessions[0]!,
+      reads.session({ runtimeSessionId: "runtime-historical" }).session,
+    ]) {
+      assert.equal(session.liveness, "live");
+      assert.equal(session.semanticState, "running");
+      assert.equal(session.attachCapability, "supported");
+      assert.equal(session.activity.lastObservedAt, "2026-09-06T01:45:42.460Z");
+    }
+  }));
+
 function withRuntime(
   installationPresent: boolean,
-  use: (fixture: { readonly reads: ReturnType<typeof makeAgentRuntimeReadModel> }) => void,
+  use: (fixture: {
+    readonly reads: ReturnType<typeof makeAgentRuntimeReadModel>;
+    readonly store: ReturnType<typeof makeTaskEventStore>;
+    readonly projection: ReturnType<typeof makeTaskProjection>;
+    readonly stream: ReturnType<typeof makeAgentRuntimeStreamHub>;
+  }) => void,
 ): void {
   const rootDir = mkdtempSync(path.join(tmpdir(), "ha-runtime-missing-installation-"));
   let projection: ReturnType<typeof makeTaskProjection> | undefined;
@@ -93,7 +138,7 @@ function withRuntime(
       readSession: (runtimeSessionId) => projection!.readRuntimeSession(runtimeSessionId),
       canAttach: () => true,
     });
-    use({ reads: makeAgentRuntimeReadModel({ store, projection, stream }) });
+    use({ reads: makeAgentRuntimeReadModel({ store, projection, stream }), store, projection, stream });
   } finally {
     projection?.close();
     rmSync(rootDir, { recursive: true, force: true });

--- a/packages/daemon/test/agent-runtime-read-missing-installation.test.ts
+++ b/packages/daemon/test/agent-runtime-read-missing-installation.test.ts
@@ -16,6 +16,7 @@ import {
 import { validateAgentRuntimeOverview, validateAgentRuntimeSession } from "../src/agent-runtime-contract.ts";
 import { makeAgentRuntimeReadModel } from "../src/agent-runtime-read.ts";
 import { makeAgentRuntimeStreamHub } from "../src/agent-runtime-stream.ts";
+import { readRuntimeSessionActivityEvidence } from "../src/dispatch-read.ts";
 
 const actor = { principal: { personId: "person-runtime" }, executor: null } as const;
 
@@ -111,6 +112,19 @@ test("live dispatch evidence repairs an unknown session and advances its observe
     }
   }));
 
+test("runtime overview remains available without a local dispatch stream", () =>
+  withRuntime(true, ({ rootDir, store, projection, stream }) => {
+    const reads = makeAgentRuntimeReadModel({
+      readActivityEvidence: (dispatchId) => readRuntimeSessionActivityEvidence(rootDir, dispatchId),
+      store,
+      projection,
+      stream,
+    });
+    const overview = reads.overview({});
+    assert.equal(overview.ok, true);
+    assert.equal(overview.sessions[0]?.runtimeSessionId, "runtime-historical");
+  }));
+
 function withRuntime(
   installationPresent: boolean,
   use: (fixture: {
@@ -118,6 +132,7 @@ function withRuntime(
     readonly store: ReturnType<typeof makeTaskEventStore>;
     readonly projection: ReturnType<typeof makeTaskProjection>;
     readonly stream: ReturnType<typeof makeAgentRuntimeStreamHub>;
+    readonly rootDir: string;
   }) => void,
 ): void {
   const rootDir = mkdtempSync(path.join(tmpdir(), "ha-runtime-missing-installation-"));
@@ -138,7 +153,7 @@ function withRuntime(
       readSession: (runtimeSessionId) => projection!.readRuntimeSession(runtimeSessionId),
       canAttach: () => true,
     });
-    use({ reads: makeAgentRuntimeReadModel({ store, projection, stream }), store, projection, stream });
+    use({ reads: makeAgentRuntimeReadModel({ store, projection, stream }), store, projection, stream, rootDir });
   } finally {
     projection?.close();
     rmSync(rootDir, { recursive: true, force: true });

--- a/packages/daemon/test/dispatch-stream.test.ts
+++ b/packages/daemon/test/dispatch-stream.test.ts
@@ -156,6 +156,16 @@ test("ZCode provider writes and its live worker host form current session activi
   }
 });
 
+test("runtime activity evidence is absent when no local dispatch stream exists", () => {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-dispatch-missing-activity-"));
+  try {
+    assert.equal(readRuntimeSessionActivityEvidence(rootDir, "dispatch_666666666666666666666666"), undefined);
+    assert.equal(readRuntimeSessionActivityEvidence(path.join(rootDir, "remote-root"), "dispatch-gui"), undefined);
+  } finally {
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});
+
 test("adoption skips a stream above Node's string limit while runtime cancel still stops the process", async () => {
   const rootDir = mkdtempSync(path.join(tmpdir(), "ha-dispatch-oversized-read-"));
   const warning = console.warn,

--- a/packages/daemon/test/dispatch-stream.test.ts
+++ b/packages/daemon/test/dispatch-stream.test.ts
@@ -1,6 +1,6 @@
 // harness-test-tier: fast
 import assert from "node:assert/strict";
-import { appendFileSync, mkdtempSync, rmSync, statSync, truncateSync } from "node:fs";
+import { appendFileSync, mkdtempSync, rmSync, statSync, truncateSync, utimesSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -15,6 +15,7 @@ import {
 } from "../src/dispatch-stream.ts";
 import { adoptRuntimes } from "../src/runtime-spawn-adoption.ts";
 import { cancelRuntime } from "../src/runtime-spawn-control.ts";
+import { readRuntimeSessionActivityEvidence } from "../src/dispatch-read.ts";
 
 test("the live index rebuilds exactly from dispatch stream headers", () => {
   const rootDir = mkdtempSync(path.join(tmpdir(), "ha-dispatch-live-index-"));
@@ -104,6 +105,52 @@ test("dispatch summaries skip provider bodies and refresh when lifecycle records
       exited?.records.map((record) => record.kind),
       ["process_started", "process_exit"],
     );
+  } finally {
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});
+
+test("ZCode provider writes and its live worker host form current session activity evidence", () => {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-dispatch-zcode-activity-"));
+  try {
+    const dispatchId = "dispatch_555555555555555555555555",
+      runtimeSessionId = "runtime_555555555555555555555555",
+      target = dispatchStreamPath(rootDir, dispatchId);
+    openDispatchStream(rootDir, {
+      dispatchId,
+      taskId: "task-zcode",
+      executionId: "execution-zcode",
+      runtimeSessionId,
+      instanceId: "zcode-glm",
+      startedAt: "2026-09-06T00:00:00.000Z",
+    });
+    appendRuntimeWorkerRecord(rootDir, dispatchId, {
+      kind: "process_started",
+      occurredAt: "2026-09-06T00:00:01.000Z",
+      pid: process.pid,
+    });
+    const frames = [
+      { type: "session.updated", payload: { type: "model_request_started" } },
+      { type: "model.streaming", payload: { kind: "text_delta", delta: "working" } },
+      { type: "tool.updated", payload: { kind: "result", result: { success: true } } },
+      { type: "result", response: "done", usage: { modelRequestCount: 1 } },
+    ];
+    for (const [index, event] of frames.entries())
+      appendRuntimeWorkerRecord(rootDir, dispatchId, {
+        kind: "provider_event",
+        occurredAt: `2026-09-06T00:00:0${String(index + 2)}.000Z`,
+        event,
+      });
+    utimesSync(target, new Date("2026-09-06T00:00:05.000Z"), new Date("2026-09-06T00:00:05.000Z"));
+
+    const summary = readDispatchStreamSummary(rootDir, dispatchId),
+      evidence = readRuntimeSessionActivityEvidence(rootDir, dispatchId);
+    assert.equal(summary?.lastObservedAt, "2026-09-06T00:00:05.000Z");
+    assert.deepEqual(
+      summary?.records.map((record) => record.kind),
+      ["process_started"],
+    );
+    assert.deepEqual(evidence, { lastObservedAt: "2026-09-06T00:00:05.000Z", workerHostAlive: true });
   } finally {
     rmSync(rootDir, { recursive: true, force: true });
   }


### PR DESCRIPTION
# English

## Summary

`ha runtime status` and the GUI session page reported `liveness=unknown` and a `lastObservedAt` more than an hour stale for a zcode (GLM) runtime whose dispatch stream was still being appended to every few seconds and whose worker-host process was alive (fact F-20923DF2). The projection's `lastObservedAt` only advances on sparse canonical lifecycle events and deliberately does not retain provider payloads, so it cannot see ongoing provider activity. This PR derives read-time activity from the evidence that already exists: the dispatch stream's last record / file mtime plus the recorded worker-host PID, for every runtime kind.

## Architectural Justification

- No second probe and no retained provider payloads: the dispatch JSONL is already the durable authority for a dispatch; its mtime and the recorded PID are read where the session DTO is built.
- Evidence can only promote a non-terminal `unknown`/`stale` session to `live` when its worker process is alive; it never downgrades canonical `live` and never overrides terminal state or outcome (a broader overlay was tried and rejected because it downgraded live fixtures with dead PIDs).
- The worker rejected the task plan's first hypothesis (parser dropping frames) with evidence: every frame was already persisted; the gap was read-side.

## Fleet / centralized-ledger view

Read-only per-dispatch evidence on the node that owns the dispatch stream; no new writer, no concurrency subject.

## What Changed

- `packages/daemon/src/dispatch-stream.ts`: compact summary carries `lastObservedAt` = max(start, retained record times, JSONL mtime).
- `packages/daemon/src/dispatch-read.ts`: `readRuntimeSessionActivityEvidence(rootDir, dispatchId)` → `{lastObservedAt, workerHostAlive}` using the existing PID-liveness primitive.
- `packages/daemon/src/agent-runtime-read.ts`: overlay into overview / session / group reads via `sessionWithActivityEvidence`.
- `packages/daemon/src/repo-cell.ts`, `repo-cell-open.ts`, `repo-cell-proxy.ts`: wire the reader into the standard read path and attach admission.
- Tests: `dispatch-stream.test.ts` (persisted zcode writes, summary freshness, PID liveness, no payload retention), `agent-runtime-read-missing-installation.test.ts` (unknown→live repair, monotonic observed time).

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none

## Machine-Readable Declarations

Production-Delta: +108/-16

## Task And Scope

- Harness task: task_92cb596dc28352ccc5126d7609 (parent PLT-Provider task_6787fa1c)
- Branch: codex/zcode-liveness
- Public scope: six daemon source files + two daemon test files
- Private planning/evidence updated: yes (worker report, facts F-20923DF2 / F-4CBE74A8)
- Out of scope: GUI (already consumes the corrected DTO)

## Version Impact

- Version: no version change (daemon read model)
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none
- Authority: not applicable
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no

## Verification

- Base `origin/main` SHA: 5356849a253443331c48278f5abf2cfc76202d28
- Fast: `dispatch-stream`, `dispatch-read`, `runtime-spawn-provider-frames-zcode` 23/23 (re-run by the CEO for the first two); contract 9/9.
- Isolated Ubuntu: `agent-runtime-read-missing-installation` 3/3, `runtime-spawn-lifecycle.integration` 6/6, `agent-runtime-slice-b` 13/13 (hermetic preflight PASS).
- lint, canonical-event-compat, gates tests 187/187, file-complexity, line-density, production-delta PASS.
- `check:local` not run; CI is the authority.

## Review Evidence

- Round 2 (CI): integration-shard (4) caught two regressions — the evidence overlay passed projected dispatch ids that have no local stream to the strict JSONL reader (`dispatch id is invalid` → `bootstrap_failed` / `op_rejected`). Fixed by returning `undefined` before filesystem access when the id cannot name a local stream; DTOs unchanged; two tests added (`worker-report-r2.md`).
- CEO semantic read against the task goal (single evidence chain, promote-only overlay, all kinds); Terra review to follow on the task after merge.

## Residual Risk

- Dispatch mtime is local write evidence (manual touch/copy can move it); PID reuse is the existing OS limitation. Both are bounded because the overlay only promotes non-terminal unknown/stale sessions.
- Electron GUI check on a live GLM session pending the next daemon changeover.

---

# 中文

## 概要

zcode(GLM)runtime 的派工流每隔几秒仍在追加、worker-host 进程活着,但 `ha runtime status` 与 GUI 会话页却报 liveness=unknown、lastObservedAt 落后一个多小时(fact F-20923DF2)。投影里的 lastObservedAt 只在稀疏的 canonical 生命周期事件上前进、且刻意不保留 provider 载荷,看不见持续的 provider 活动。本 PR 在读侧用已有证据推导活性:派工流最后记录/文件 mtime + 记录在案的 worker-host PID,对所有 runtime kind 一致。

## 架构辩护

不加第二套探测、不在内存保留 provider 载荷;证据只能把非终态的 unknown/stale 提升为 live(且要求进程存活),不降级 canonical live、不覆盖终态与 outcome。worker 以证据否定了计划里「解析器丢帧」的第一假设(帧早已持久化,缺口在读侧)。

## 中心化仓库视角

只在持有派工流的节点上做只读证据推导;无新写者、无并发主体。

## 改动内容

`dispatch-stream.ts` 摘要带 lastObservedAt;`dispatch-read.ts` 新增按 dispatch 的活性证据读取;`agent-runtime-read.ts` 叠加到 overview/session/group 读;三处 repo-cell 接线到标准读路径与 attach 准入;两处测试。

## 门收割 / Gate Harvest

无删除。

## 任务与范围

task_92cb596d(父 PLT-Provider);分支 codex/zcode-liveness;不含 GUI。

## 版本影响

无。

## 治理声明

未触碰 protected surface。

## 验证

fast 23/23(CEO 复跑前两组)、contract 9/9、Ubuntu 隔离 3/3 + 6/6 + 13/13;各 gate PASS;未跑 check:local,CI 为权威。

## 审查证据

CEO 语义细读;合并后 Terra 在任务上复核。

## 残余风险

mtime 可被手工 touch/复制改变、PID 复用是既有 OS 限制,均因「只提升非终态 unknown/stale」而有界;Electron 上真实 GLM 会话待下次换代后 CEO 亲验。
