### PR TITLE
fix: guard doc sync candidate intake

### DIFF
--- a/packages/cli/src/cli/thin-command-doc.ts
+++ b/packages/cli/src/cli/thin-command-doc.ts
@@ -1,14 +1,6 @@
 import type { SafePath } from "../../../daemon/src/protocol/daemon-protocol.contract.ts";
-import {
-  accepted,
-  nonEmpty,
-  readFlags,
-  rejected,
-} from "./thin-command-flags.ts";
-import type {
-  ThinCliInputDirectory,
-  ThinParseResult,
-} from "./thin-command-types.ts";
+import { accepted, nonEmpty, readFlags, rejected } from "./thin-command-flags.ts";
+import type { ThinCliInputDirectory, ThinParseResult } from "./thin-command-types.ts";
 
 export function parseDoc(
   id: string,
@@ -37,7 +29,8 @@ export function parseDoc(
     f = readFlags(id, args.slice(sync ? 3 : 2), inputs);
   if (!f.ok) return rejected(f.code, f.nextAction, json);
   const paths = f.many.get("--path") ?? [];
-  const taskId = f.one.get("--task");
+  const taskId = f.one.get("--task"),
+    all = f.booleans.has("--all");
   if (taskId && paths.length)
     return rejected(
       "invalid_field",
@@ -67,6 +60,6 @@ export function parseDoc(
     });
   return accepted(rootDir, repoId, json, {
     kind: "doc-submit",
-    ...(taskId ? { taskId } : { paths }),
+    ...(taskId ? { taskId } : { paths, ...(all ? { all: true } : {}) }),
   });
 }

--- a/packages/cli/src/daemon/client.ts
+++ b/packages/cli/src/daemon/client.ts
@@ -663,6 +663,7 @@ export async function fleetDocRoute(
     payload.paths = Array.isArray(command.action.paths)
       ? command.action.paths.filter((value): value is string => typeof value === "string")
       : [];
+    if (command.action.all === true) payload.all = true;
   } else {
     payload.action = route.action;
     payload.conflictId = command.action.conflictId;

--- a/packages/cli/test/daemon-multi-repo-lifecycle-cli.test.ts
+++ b/packages/cli/test/daemon-multi-repo-lifecycle-cli.test.ts
@@ -326,7 +326,7 @@ test("real CLI reaches one resident multi-workspace daemon and publishes Git eve
     // implicit submit must reject without publishing an event"). Asserting one outcome raced that sweep
     // (flake). What holds either way: the blocked path is reported against its changed machine region, the
     // eligible doc reaches canonical, and the blocked edit does not.
-    const partial = runMaybe(fixture.alpha, fixture.userRoot, ["doc", "sync", "--submit"]),
+    const partial = runMaybe(fixture.alpha, fixture.userRoot, ["doc", "sync", "--submit", "--all"]),
       blockedTouch = "context/other-session.md\tmachine region changed";
     if (partial.status === 0) {
       assert.equal(partial.receipt.outcome, "applied", JSON.stringify(partial.receipt));

--- a/packages/cli/test/fleet-task-route.test.ts
+++ b/packages/cli/test/fleet-task-route.test.ts
@@ -75,6 +75,10 @@ test("fleet task routing requires both edge config and remote-edge registry mode
   assert.equal(docStatus?.method, "daemon.fleet.doc.sync");
   assert.equal(docStatus?.payload.dryRun, true);
   assert.deepEqual(docStatus?.payload.paths, ["context/notes.md"]);
+  const docSubmitAll = await fleetDocRoute(command("repo.task.run", { kind: "doc-submit", paths: [], all: true }), env);
+  assert.equal(docSubmitAll?.payload.dryRun, false);
+  assert.deepEqual(docSubmitAll?.payload.paths, []);
+  assert.equal(docSubmitAll?.payload.all, true);
   for (const [kind, action] of [
     ["doc-conflict-resolve", "resolve"],
     ["doc-conflict-discard-local", "discard-local"],

--- a/packages/cli/test/thin-command-script-doc-runtime.test.ts
+++ b/packages/cli/test/thin-command-script-doc-runtime.test.ts
@@ -54,6 +54,7 @@ test("thin doc commands derive descriptor-only actions from the protocol directo
     show = parseThinCommand(["doc", "show", "--path", "tasks/task-1/INDEX.md"]),
     retire = parseThinCommand(["doc", "retire", "--path", "context/old.md", "--reason", "superseded scratch"]),
     submit = parseThinCommand(["doc", "sync", "--submit", "--path", "context/a.md", "--path", "context/b.md"]),
+    allSubmit = parseThinCommand(["doc", "sync", "--submit", "--all"]),
     taskSubmit = parseThinCommand(["doc", "sync", "--submit", "--task", "task-1"]);
   assert.equal(status.ok, true);
   assert.equal(selectedStatus.ok, true);
@@ -62,6 +63,7 @@ test("thin doc commands derive descriptor-only actions from the protocol directo
   assert.equal(show.ok, true);
   assert.equal(retire.ok, true);
   assert.equal(submit.ok, true);
+  assert.equal(allSubmit.ok, true);
   assert.equal(taskSubmit.ok, true);
   if (status.ok) assert.deepEqual(status.command.action, { kind: "doc-status", paths: [] });
   if (selectedStatus.ok)
@@ -93,6 +95,12 @@ test("thin doc commands derive descriptor-only actions from the protocol directo
     });
     assert.deepEqual(Object.keys(submit.command.action).sort(), ["kind", "paths"]);
   }
+  if (allSubmit.ok)
+    assert.deepEqual(allSubmit.command.action, {
+      kind: "doc-submit",
+      paths: [],
+      all: true,
+    });
   if (taskSubmit.ok)
     assert.deepEqual(taskSubmit.command.action, {
       kind: "doc-submit",
@@ -102,6 +110,8 @@ test("thin doc commands derive descriptor-only actions from the protocol directo
     parseThinCommand(["doc", "sync", "--submit", "--task", "task-1", "--path", "tasks/task-1/task_plan.md"]).ok,
     false,
   );
+  assert.equal(parseThinCommand(["doc", "sync", "--submit", "--all", "--path", "context/a.md"]).ok, false);
+  assert.equal(parseThinCommand(["doc", "sync", "--submit", "--all", "--task", "task-1"]).ok, false);
   assert.equal(parseThinCommand(["doc", "sync", "--submit", "--execution-id", "exec-1"]).ok, false);
   assert.equal(parseThinCommand(["doc", "show", "--path", "INDEX.md", "--body", "inline"]).ok, false);
   assert.equal(parseThinCommand(["doc", "retire", "--path", "context/old.md"]).ok, false);

--- a/packages/daemon/src/doc-sync-adjudication.ts
+++ b/packages/daemon/src/doc-sync-adjudication.ts
@@ -200,13 +200,16 @@ export function scannerSubmit(input: Input): DocCandidateScan {
       ? ["kind", "taskId"]
       : Object.hasOwn(input.action, "executionId")
         ? ["kind", "executionId", "paths"]
-        : ["kind", "paths"];
+        : Object.hasOwn(input.action, "all")
+          ? ["kind", "paths", "all"]
+          : ["kind", "paths"];
   if (
     !hasExactDocSyncActionFields(input.action, fields) ||
     (taskScoped
       ? typeof input.action.taskId !== "string"
       : !Array.isArray(input.action.paths) || input.action.paths.some((item) => typeof item !== "string")) ||
-    (Object.hasOwn(input.action, "executionId") && typeof input.action.executionId !== "string")
+    (Object.hasOwn(input.action, "executionId") && typeof input.action.executionId !== "string") ||
+    (Object.hasOwn(input.action, "all") && input.action.all !== true)
   )
     throw docSyncError("invalid_command", "local doc submit requires scanner paths or a task id");
   const scan = scanDocCandidates({

--- a/packages/daemon/src/doc-sync-candidate-scanner.ts
+++ b/packages/daemon/src/doc-sync-candidate-scanner.ts
@@ -6,8 +6,10 @@ import { existsSync, lstatSync, readdirSync, readFileSync } from "node:fs";
 import path from "node:path";
 import {
   canonicalDocumentClaims,
+  classifyDocSyncCandidatePath,
   classifyTextualArtifactPath,
   decideDocWriteCriteria,
+  DOC_SYNC_INLINE_MAX_BYTES,
   DOC_POLICY_ID,
   documentPath,
   parseDocWriteIntent,
@@ -34,7 +36,7 @@ import { blockedCandidateNextAction } from "./doc-sync-details.ts";
 import { docSyncError } from "./doc-sync-files.ts";
 
 export type DocCandidateState = "clean" | "eligible" | "inapplicable" | "blocked" | "deletion" | "conflict";
-type TextualArtifactMediaType = NonNullable<ReturnType<typeof classifyTextualArtifactPath>>["mediaType"];
+type TextualArtifactMediaType = NonNullable<ReturnType<typeof classifyDocSyncCandidatePath>>["mediaType"];
 export interface DocCandidateRow {
   readonly path: string;
   readonly state: DocCandidateState;
@@ -65,6 +67,7 @@ export interface AuthoredCandidateInventoryV1 {
   readonly rows: readonly {
     readonly path: string;
     readonly safe: boolean;
+    readonly size: number | null;
     readonly bytes: Uint8Array | null;
     readonly conflicts: readonly string[];
     readonly legacyDocument: DocumentState | null;
@@ -120,7 +123,7 @@ export function scanDocCandidates(input: {
       .filter(
         (value) =>
           selected?.length ||
-          classifyTextualArtifactPath(value) !== null ||
+          classifyDocSyncCandidatePath(value) !== null ||
           !resolveDocRoute(documentPath(value)).allowed,
       )
       .sort(),
@@ -165,8 +168,18 @@ export function scanDocCandidates(input: {
       projected = input.projection.readDocument(document),
       conflicts = inventoried?.conflicts ?? candidateConflicts(input.rootDir, layout.authoredRoot, logical),
       safe = inventoried?.safe ?? directFile(layout.authoredRoot, logical),
-      classification = classifyTextualArtifactPath(logical),
-      rawBytes = inventoried ? inventoried.bytes : safe && existsSync(target) ? readFileSync(target) : null,
+      classification = classifyDocSyncCandidatePath(logical),
+      existingMediaType = classifyTextualArtifactPath(logical)?.mediaType ?? null,
+      fileSize = inventoried ? inventoried.size : safe && existsSync(target) ? lstatSync(target).size : null,
+      rawBytes = inventoried
+        ? inventoried.bytes
+        : (classification !== null || !route.allowed || projected.document !== null) &&
+            fileSize !== null &&
+            fileSize <= DOC_SYNC_INLINE_MAX_BYTES &&
+            safe &&
+            existsSync(target)
+          ? readFileSync(target)
+          : null,
       bytes = rawBytes === null ? null : canonicalProseBytes(rawBytes, classification?.policyId),
       retirementBase =
         bytes === null
@@ -213,6 +226,8 @@ export function scanDocCandidates(input: {
         "task_package_unregistered",
         "ha task artifact add",
       );
+    if (classification === null && candidate !== null && candidate === base)
+      return scannedCandidateRow("clean", null, bytes, base, candidate, existingMediaType);
     if (classification === null)
       return scannedCandidateRow(
         "blocked",
@@ -220,6 +235,11 @@ export function scanDocCandidates(input: {
         null,
         projected.document?.blobSha256 ?? null,
         null,
+        null,
+        null,
+        null,
+        null,
+        fileSize,
       );
     if (projected.watermark !== projected.sourceRevision)
       return scannedCandidateRow(
@@ -236,6 +256,20 @@ export function scanDocCandidates(input: {
         null,
         projected.document?.blobSha256 ?? null,
         null,
+      );
+    if (fileSize !== null && fileSize > DOC_SYNC_INLINE_MAX_BYTES)
+      return scannedCandidateRow(
+        "blocked",
+        `${logical} is ${fileSize} bytes; doc sync accepts at most ${DOC_SYNC_INLINE_MAX_BYTES} bytes; ` +
+          "send raw content through the blob content contract",
+        null,
+        projected.document?.blobSha256 ?? null,
+        null,
+        classification.mediaType,
+        "doc_candidate_too_large",
+        "blob-content",
+        null,
+        fileSize,
       );
     if (bytes === null)
       return scannedCandidateRow(
@@ -329,6 +363,7 @@ export function scanDocCandidates(input: {
       rejectionCode: string | null = null,
       requiredRoute: string | null = null,
       regionId: string | null = null,
+      reportedSize: number | null = null,
     ): ScannedDocCandidate {
       return {
         path: logical,
@@ -336,7 +371,7 @@ export function scanDocCandidates(input: {
         reason,
         baseBlobSha256: baseHash,
         candidateBlobSha256: candidateHash,
-        size: body?.byteLength ?? null,
+        size: reportedSize ?? body?.byteLength ?? null,
         mediaType: media,
         conflicts,
         bytes: body,
@@ -361,13 +396,19 @@ export function scanAuthoredCandidateInventory(input: {
     baseLedgerSha: input.store.currentCut(),
     rows: paths.map((logical) => {
       const safe = directFile(layout.authoredRoot, logical),
-        classification = classifyTextualArtifactPath(logical),
+        classification = classifyDocSyncCandidatePath(logical),
+        route = resolveDocRoute(documentPath(logical)),
         target = path.join(layout.authoredRoot, ...logical.split("/")),
-        rawBytes = safe && existsSync(target) ? readFileSync(target) : null,
+        size = safe && existsSync(target) ? lstatSync(target).size : null,
+        rawBytes =
+          (classification !== null || !route.allowed) && size !== null && size <= DOC_SYNC_INLINE_MAX_BYTES
+            ? readFileSync(target)
+            : null,
         bytes = rawBytes === null ? null : canonicalProseBytes(rawBytes, classification?.policyId);
       return {
         path: logical,
         safe,
+        size,
         bytes,
         conflicts: candidateConflicts(input.rootDir, layout.authoredRoot, logical),
         legacyDocument:
@@ -404,7 +445,7 @@ export function intentFromScan(
         executionId: scan.executionId,
         baseLedgerSha: scan.baseLedgerSha,
         changes: eligible.map((row) => {
-          const classification = classifyTextualArtifactPath(row.path);
+          const classification = classifyDocSyncCandidatePath(row.path);
           if (classification === null || row.candidateBlobSha256 === null || row.size === null)
             throw new Error(`eligible scan row is not a textual artifact: ${row.path}`);
           return {

--- a/packages/daemon/src/doc-sync-command-actions.ts
+++ b/packages/daemon/src/doc-sync-command-actions.ts
@@ -23,7 +23,7 @@ import {
 } from "../../kernel/src/index.ts";
 import { assignmentIntent, scannerSubmit } from "./doc-sync-adjudication.ts";
 import { intentFromScan } from "./doc-sync-candidate-scanner.ts";
-import type { AuthoredCandidateInventoryV1 } from "./doc-sync-candidate-scanner.ts";
+import type { AuthoredCandidateInventoryV1, DocCandidateScan } from "./doc-sync-candidate-scanner.ts";
 import { claimBytes, directPaths, settleConflictScratch } from "./doc-sync-details.ts";
 import {
   artifactSource,
@@ -118,9 +118,12 @@ export async function runDocAction(input: Input): Promise<WriteReceipt> {
     !Object.hasOwn(input.action, "taskId") &&
     Array.isArray(input.action.paths) &&
     input.action.paths.length === 0 &&
-    input.action.all !== true &&
-    scan.rows.some((row) => row.state === "eligible")
+    input.action.all !== true
   ) {
+    const code = scanRejectionCode(scan);
+    if (code !== null)
+      return rejectDocSyncAction(`scan:${scan.baseLedgerSha.headDigest}`, code, scanDetail(input, scan, code));
+    if (!scan.rows.some((row) => row.state === "eligible")) return noOp(input, scan);
     const candidates = scan.rows.filter((row) => row.state === "eligible"),
       rejection = rejectDocSyncAction(
         `scan:${scan.baseLedgerSha.headDigest}`,
@@ -137,14 +140,7 @@ export async function runDocAction(input: Input): Promise<WriteReceipt> {
     });
   }
   if (scan && !scan.rows.some((row) => row.state === "eligible")) {
-    const code = scan.rows
-        .map((row) => row.rejectionCode)
-        .find(
-          (candidate) =>
-            candidate === "lease_conflict" ||
-            candidate === "deletion_forbidden" ||
-            candidate === "doc_candidate_too_large",
-        ),
+    const code = scanRejectionCode(scan),
       blocked = scanDetail(input, scan, code ?? "preview_blocked");
     return scan.rows.some((row) => row.state === "blocked" || row.state === "deletion")
       ? rejectDocSyncAction(`scan:${scan.baseLedgerSha.headDigest}`, code ?? "preview_blocked", blocked)
@@ -165,6 +161,23 @@ export async function runDocAction(input: Input): Promise<WriteReceipt> {
   return scan && (receipt.outcome === "applied" || receipt.outcome === "pending")
     ? scannerSettlement(input, scan, receipt)
     : receipt;
+}
+
+function scanRejectionCode(scan: DocCandidateScan): string | null {
+  const blocked = scan.rows.filter(
+    (row) => row.state === "blocked" || row.state === "deletion" || row.state === "conflict",
+  );
+  return (
+    blocked
+      .map((row) => row.rejectionCode)
+      .find(
+        (candidate) =>
+          candidate === "lease_conflict" ||
+          candidate === "deletion_forbidden" ||
+          candidate === "doc_candidate_too_large" ||
+          candidate === "task_package_unregistered",
+      ) ?? (blocked.length > 0 ? "preview_blocked" : null)
+  );
 }
 
 async function runLocalDocConflictExit(input: Input): Promise<WriteReceipt> {

--- a/packages/daemon/src/doc-sync-command-actions.ts
+++ b/packages/daemon/src/doc-sync-command-actions.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import type { CanonicalEventStore, TaskProjection } from "../../kernel/src/index.ts";
 import {
   classifyTextualArtifactPath,
+  DOC_SYNC_INLINE_MAX_BYTES,
   documentPath,
   isDocEvent,
   ledgerGitPath,
@@ -40,7 +41,7 @@ import { readAction, readDocReceipt } from "./doc-sync-reads.ts";
 import { noOp, scanDetail, scannerSettlement } from "./doc-sync-settlement.ts";
 import type { FleetAssignmentScope } from "./fleet/contract.ts";
 
-export const DOC_COMMAND_FRAME_MAX_BYTES = 256 * 1024;
+export const DOC_COMMAND_FRAME_MAX_BYTES = DOC_SYNC_INLINE_MAX_BYTES;
 
 export type Action = Readonly<Record<string, unknown>> & { readonly kind: string };
 
@@ -111,10 +112,39 @@ export async function runDocAction(input: Input): Promise<WriteReceipt> {
   if (input.action.kind === "doc-retire") return runDocRetire(input);
   if (input.action.kind !== "doc-submit") return readAction(input);
   const scan = localProseSource(input.binding.source) ? scannerSubmit(input) : null;
+  if (
+    scan &&
+    !input.authoredCandidateInventory &&
+    !Object.hasOwn(input.action, "taskId") &&
+    Array.isArray(input.action.paths) &&
+    input.action.paths.length === 0 &&
+    input.action.all !== true &&
+    scan.rows.some((row) => row.state === "eligible")
+  ) {
+    const candidates = scan.rows.filter((row) => row.state === "eligible"),
+      rejection = rejectDocSyncAction(
+        `scan:${scan.baseLedgerSha.headDigest}`,
+        "doc_submit_confirmation_required",
+        scanDetail(input, scan, "doc_submit_confirmation_required"),
+      );
+    return Object.assign(rejection, {
+      summary: [
+        "doc-submit: op_rejected",
+        "full authored-tree submission requires explicit confirmation for:",
+        ...candidates.map((row) => `${row.path}\t${row.size ?? 0} bytes`),
+        "rerun with --path for an explicit selection or --all for every eligible candidate",
+      ].join("\n"),
+    });
+  }
   if (scan && !scan.rows.some((row) => row.state === "eligible")) {
     const code = scan.rows
         .map((row) => row.rejectionCode)
-        .find((candidate) => candidate === "lease_conflict" || candidate === "deletion_forbidden"),
+        .find(
+          (candidate) =>
+            candidate === "lease_conflict" ||
+            candidate === "deletion_forbidden" ||
+            candidate === "doc_candidate_too_large",
+        ),
       blocked = scanDetail(input, scan, code ?? "preview_blocked");
     return scan.rows.some((row) => row.state === "blocked" || row.state === "deletion")
       ? rejectDocSyncAction(`scan:${scan.baseLedgerSha.headDigest}`, code ?? "preview_blocked", blocked)
@@ -165,23 +195,25 @@ async function runLocalDocConflictExit(input: Input): Promise<WriteReceipt> {
         ? "local conflict scratch is not a direct regular file"
         : "merge the conflict into its canonical document before resolving it",
     );
-  const submitted = await runDocAction({
-    ...input,
-    action: { kind: "doc-submit", paths: [conflict.logical] },
-    authoredCandidateInventory: {
-      schema: "harness-authored-candidate-inventory/v1",
-      baseLedgerSha: input.store.currentCut(),
-      rows: [
-        {
-          path: conflict.logical,
-          safe: true,
-          bytes: readFileSync(source),
-          conflicts: [],
-          legacyDocument: null,
-        },
-      ],
-    },
-  });
+  const sourceBytes = readFileSync(source),
+    submitted = await runDocAction({
+      ...input,
+      action: { kind: "doc-submit", paths: [conflict.logical] },
+      authoredCandidateInventory: {
+        schema: "harness-authored-candidate-inventory/v1",
+        baseLedgerSha: input.store.currentCut(),
+        rows: [
+          {
+            path: conflict.logical,
+            safe: true,
+            size: sourceBytes.byteLength,
+            bytes: sourceBytes,
+            conflicts: [],
+            legacyDocument: null,
+          },
+        ],
+      },
+    });
   if (["applied", "pending", "no_changes"].includes(submitted.outcome)) settleConflictScratch(conflict.scratch);
   return submitted;
 }

--- a/packages/daemon/src/fleet-edge-doc-sync.ts
+++ b/packages/daemon/src/fleet-edge-doc-sync.ts
@@ -49,6 +49,7 @@ export interface FleetEdgeChannelPayload {
 }
 export interface FleetEdgeDocSyncRequest {
   readonly payload: FleetEdgeChannelPayload & {
+    readonly all?: true;
     readonly dryRun?: boolean;
     readonly paths?: readonly string[];
     readonly timeoutMs?: number;
@@ -178,6 +179,18 @@ export async function runFleetEdgeDocSync(input: FleetEdgeDocSyncRequest): Promi
         blocked: scan.blocked,
         rideAlongTaskPaths: rideAlong,
         outOfScopePaths: outOfScope,
+      });
+    if (selection === undefined && payload.all !== true)
+      return fleetDocSyncReceipt(false, "doc_submit_confirmation_required", {
+        syncState: "LOCAL_DIRTY",
+        canonicalOutcome: "applied",
+        mirrorOutcome: settle.outcome,
+        ...cutOf(pulled.current.cut.revision),
+        rows,
+        blocked: scan.blocked,
+        rideAlongTaskPaths: rideAlong,
+        outOfScopePaths: outOfScope,
+        guidance: "Submit named paths or rerun with --all to confirm the full eligible candidate set.",
       });
     // PUSHING
     const pushed = await runFleetWriteClient({

--- a/packages/daemon/src/fleet-edge-mirror.ts
+++ b/packages/daemon/src/fleet-edge-mirror.ts
@@ -23,6 +23,7 @@ import { randomBytes } from "node:crypto";
 import path from "node:path";
 import {
   consumeKnownError,
+  DOC_SYNC_INLINE_MAX_BYTES,
   documentPath,
   resolveDocRoute,
   resolveHarnessLayout,
@@ -53,7 +54,14 @@ export interface FleetMirrorDirtyFile {
 export interface FleetMirrorScan {
   readonly changes: readonly FleetMirrorDirtyFile[];
   readonly cleanCount: number;
-  readonly blocked: readonly { readonly path: string; readonly reason: string }[];
+  readonly blocked: readonly {
+    readonly path: string;
+    readonly reason: string;
+    readonly size?: number;
+    readonly maxInlineBytes?: number;
+    readonly code?: "doc_candidate_too_large";
+    readonly requiredRoute?: "blob-content";
+  }[];
 }
 export type FleetConflictTrigger = "pull" | "push-rejected" | "command-rejected";
 export interface FleetConflictPathRow {
@@ -258,7 +266,7 @@ export function scanFleetMirrorWorktree(
   if (!existsSync(materializedRoot)) return { changes: [], cleanCount: 0, blocked: [] };
   const wanted = selection === undefined ? null : new Set(selection),
     changes: FleetMirrorDirtyFile[] = [],
-    blocked: { readonly path: string; readonly reason: string }[] = [];
+    blocked: FleetMirrorScan["blocked"][number][] = [];
   let cleanCount = 0;
   for (const logical of fleetMirrorMaterializedPaths(materializedRoot)) {
     if (!fleetMirrorProsePath(logical) || (wanted !== null && !wanted.has(logical))) continue;
@@ -274,7 +282,22 @@ export function scanFleetMirrorWorktree(
       });
       continue;
     }
-    const bytes = readFileSync(path.join(materializedRoot, ...logical.split("/"))),
+    const target = path.join(materializedRoot, ...logical.split("/")),
+      size = statSync(target).size;
+    if (size > DOC_SYNC_INLINE_MAX_BYTES) {
+      blocked.push({
+        path: logical,
+        size,
+        maxInlineBytes: DOC_SYNC_INLINE_MAX_BYTES,
+        code: "doc_candidate_too_large",
+        requiredRoute: "blob-content",
+        reason:
+          `${logical} is ${size} bytes; doc sync accepts at most ${DOC_SYNC_INLINE_MAX_BYTES} bytes; ` +
+          "send raw content through the blob content contract",
+      });
+      continue;
+    }
+    const bytes = readFileSync(target),
       base = view.entries.get(logical) ?? null;
     if (base !== null && base.sha256 === sha256Bytes(bytes)) {
       cleanCount += 1;

--- a/packages/daemon/src/protocol/daemon-protocol-commands-doc-fact.ts
+++ b/packages/daemon/src/protocol/daemon-protocol-commands-doc-fact.ts
@@ -52,6 +52,15 @@ export const docFactProtocolCommands = Object.freeze([
       cliInput("--path", "repeated", false, {
         code: "invalid_field",
       }),
+      cliInput(
+        "--all",
+        "boolean",
+        false,
+        {
+          code: "invalid_field",
+        },
+        { conflictsWith: ["--task", "--path"] },
+      ),
     ],
   }),
   defineLedgerWriteCommand({

--- a/packages/daemon/test/doc-sync-ghost-task-package.integration.test.ts
+++ b/packages/daemon/test/doc-sync-ghost-task-package.integration.test.ts
@@ -52,9 +52,22 @@ test("repo prose channel blocks artifacts under an unregistered tasks/ package d
     assert.match(ghostRow?.reason ?? "", /tasks\/task-ghost-wrong-slug is not the package path of any projected task/u);
     assert.match(ghostRow?.reason ?? "", /ha task artifact add/u);
     assert.equal(ghostRow?.mediaType, "text/markdown");
+    const unconfirmed = (await cell.run({ kind: "doc-submit", paths: [] }, binding)) as {
+      readonly outcome: string;
+      readonly code: string;
+      readonly detail: {
+        readonly unresolvedTouches: readonly { readonly path: string; readonly requiredRoute: string }[];
+      };
+    };
+    assert.equal(unconfirmed.outcome, "op_rejected", JSON.stringify(unconfirmed));
+    assert.equal(unconfirmed.code, "task_package_unregistered");
+    assert.deepEqual(
+      unconfirmed.detail.unresolvedTouches.map((touch) => [touch.path, touch.requiredRoute]),
+      [[ghost, "ha task artifact add"]],
+    );
     // Misfire control: the eligible sibling in the registered package still
     // publishes, and the blocked ghost must not ride along in that submit.
-    const submitted = (await cell.run({ kind: "doc-submit", paths: [] }, binding)) as {
+    const submitted = (await cell.run({ kind: "doc-submit", paths: [], all: true }, binding)) as {
       readonly outcome: string;
       readonly opId: string;
       readonly summary: string | null;
@@ -82,7 +95,7 @@ test("repo prose channel blocks artifacts under an unregistered tasks/ package d
       };
     };
     assert.equal(rejected.outcome, "op_rejected", JSON.stringify(rejected));
-    assert.equal(rejected.code, "preview_blocked");
+    assert.equal(rejected.code, "task_package_unregistered");
     assert.deepEqual(
       rejected.detail.unresolvedTouches.map((touch) => [touch.path, touch.requiredRoute]),
       [

--- a/packages/daemon/test/doc-sync-slice-a-implicit-lease.test.ts
+++ b/packages/daemon/test/doc-sync-slice-a-implicit-lease.test.ts
@@ -13,7 +13,7 @@ import { realizeTaskPlanFixture } from "../../../tools/fixtures/task-plan.mjs";
 import { withRoleBinding } from "./role-binding.fixtures.ts";
 
 import { initRepo, ownerBinding, rows, write } from "./doc-sync-slice-a.fixtures.ts";
-test("implicit submit accepts two authored paths with identical content", async () => {
+test("confirmed full submit accepts two authored paths with identical content", async () => {
   const rootDir = mkdtempSync(path.join(tmpdir(), "ha-doc-a-identical-content-"));
   initRepo(rootDir);
   const repoId = workspaceId("identical-content"),
@@ -27,7 +27,10 @@ test("implicit submit accepts two authored paths with identical content", async 
   try {
     write(rootDir, "context/one.md", body);
     write(rootDir, "context/two.md", body);
-    const submitted = (await cell.run({ kind: "doc-submit", paths: [] }, binding)) as Record<string, unknown>;
+    const submitted = (await cell.run({ kind: "doc-submit", paths: [], all: true }, binding)) as Record<
+      string,
+      unknown
+    >;
     assert.equal(submitted.outcome, "applied", JSON.stringify(submitted));
     assert.doesNotMatch(JSON.stringify(submitted), /duplicate write target/u);
     const event = makeTaskEventStore({ repoId, rootDir }).readEvent(String(submitted.opId));
@@ -45,7 +48,7 @@ test("implicit submit accepts two authored paths with identical content", async 
   }
 });
 
-test("implicit submit applies prose after its heading is rewritten", async () => {
+test("confirmed full submit applies prose after its heading is rewritten", async () => {
   const rootDir = mkdtempSync(path.join(tmpdir(), "ha-doc-a-partial-blocked-"));
   initRepo(rootDir);
   const repoId = workspaceId("partial-blocked"),
@@ -60,7 +63,10 @@ test("implicit submit applies prose after its heading is rewritten", async () =>
     assert.equal((await cell.run({ kind: "doc-submit", paths: ["context/blocked.md"] }, binding)).outcome, "applied");
     write(rootDir, "context/blocked.md", "# Renamed\n\nbase\n");
     write(rootDir, "context/eligible.md", "# Eligible\n\nship me\n");
-    const submitted = (await cell.run({ kind: "doc-submit", paths: [] }, binding)) as Record<string, unknown>;
+    const submitted = (await cell.run({ kind: "doc-submit", paths: [], all: true }, binding)) as Record<
+      string,
+      unknown
+    >;
     assert.equal(submitted.outcome, "applied", JSON.stringify(submitted));
     assert.match(String(submitted.summary), /skipped:\n\(none\)/u);
     const event = makeTaskEventStore({ repoId, rootDir }).readEvent(String(submitted.opId));
@@ -80,7 +86,7 @@ test("implicit submit applies prose after its heading is rewritten", async () =>
   }
 });
 
-test("implicit submit applies eligible prose and reports an unrelated deletion as skipped", async () => {
+test("confirmed full submit applies eligible prose and reports an unrelated deletion as skipped", async () => {
   const rootDir = mkdtempSync(path.join(tmpdir(), "ha-doc-a-partial-deletion-"));
   initRepo(rootDir);
   const repoId = workspaceId("partial-deletion"),
@@ -95,7 +101,10 @@ test("implicit submit applies eligible prose and reports an unrelated deletion a
     assert.equal((await cell.run({ kind: "doc-submit", paths: ["context/deleted.md"] }, binding)).outcome, "applied");
     rmSync(path.join(rootDir, "harness/context/deleted.md"));
     write(rootDir, "context/eligible.md", "# Eligible\n");
-    const submitted = (await cell.run({ kind: "doc-submit", paths: [] }, binding)) as Record<string, unknown>;
+    const submitted = (await cell.run({ kind: "doc-submit", paths: [], all: true }, binding)) as Record<
+      string,
+      unknown
+    >;
     assert.equal(submitted.outcome, "applied", JSON.stringify(submitted));
     assert.match(
       String(submitted.summary),
@@ -203,10 +212,10 @@ test("a runtime session with multiple matching held executions rejects with exac
 // The scanner used to pin a single-task selection to that task's CURRENT lease
 // regardless of who held it, so `ha doc sync --submit --path <p>` reported
 // lease_conflict for a legal repository-prose write whenever the task was
-// leased by a dispatched runtime — while an implicit submit escaped only when
+// leased by a dispatched runtime — while a full submit escaped only when
 // the dirty set happened to span two task packages. Both shapes must now ride
 // the prose channel for a non-holder.
-test("path and implicit submits ride the repository prose channel when the task lease is held by another executor", async () => {
+test("path and confirmed full submits ride the repository prose channel when another executor holds the lease", async () => {
   const rootDir = mkdtempSync(path.join(tmpdir(), "ha-doc-a-path-prose-"));
   initRepo(rootDir);
   const repoId = workspaceId("path-prose"),
@@ -295,9 +304,15 @@ test("path and implicit submits ride the repository prose channel when the task 
     write(rootDir, "context/shared.md", "# Shared\nsynced\n");
     assert.equal((await cell.run({ kind: "doc-submit", paths: ["context/shared.md"] }, person)).outcome, "applied");
     write(rootDir, `${packagePath}/artifacts/reports/second.md`, "# Second\n");
-    const implicit = (await cell.run({ kind: "doc-submit", paths: [] }, person)) as Record<string, unknown>;
-    assert.equal(implicit.outcome, "applied", JSON.stringify(implicit));
-    assert.match(String(implicit.summary), new RegExp(`applied:\\n${packagePath}/artifacts/reports/second\\.md`, "u"));
+    const fullSubmit = (await cell.run({ kind: "doc-submit", paths: [], all: true }, person)) as Record<
+      string,
+      unknown
+    >;
+    assert.equal(fullSubmit.outcome, "applied", JSON.stringify(fullSubmit));
+    assert.match(
+      String(fullSubmit.summary),
+      new RegExp(`applied:\\n${packagePath}/artifacts/reports/second\\.md`, "u"),
+    );
     // Naming the foreign execution explicitly still refuses — and the receipt names the exit that works.
     write(rootDir, `${packagePath}/artifacts/reports/third.md`, "# Third\n");
     const explicit = (await cell.run(

--- a/packages/daemon/test/doc-sync-slice-a.test.ts
+++ b/packages/daemon/test/doc-sync-slice-a.test.ts
@@ -182,6 +182,7 @@ test("scanner refuses multi-megabyte JSONL without reading it and names oversize
   }
   assert.equal(inventoryByPath.get(oversized)?.bytes, null, "oversized prose must not enter inventory bytes");
   assert.equal(inventoryByPath.get(prose)?.bytes?.byteLength, Buffer.byteLength("# Notes\n"));
+  rmSync(path.join(rootDir, "harness", oversized));
 
   const cell = await openRepoCell({ repoId, rootDir: canonicalRoot(rootDir), ownerId: "size-type-daemon" }),
     binding = { actor, source: "local" as const };
@@ -191,8 +192,8 @@ test("scanner refuses multi-megabyte JSONL without reading it and names oversize
       rows(status.evidence)
         .filter((row) => row.state !== "clean")
         .map((row) => row.path),
-      [prose, oversized],
-      "non-prose JSONL must not enter the authored candidate set",
+      [prose],
+      "non-prose JSONL must not enter the authored candidate set before oversized prose is restored",
     );
     const unconfirmed = await cell.run({ kind: "doc-submit", paths: [] }, binding);
     assert.equal(unconfirmed.outcome, "op_rejected", JSON.stringify(unconfirmed));
@@ -216,6 +217,7 @@ test("scanner refuses multi-megabyte JSONL without reading it and names oversize
       assert.deepEqual([row?.path, row?.state, row?.size], [logical, "blocked", Buffer.byteLength(jsonl)]);
       assert.match(row?.reason ?? "", /not a supported textual document/u);
     }
+    write(rootDir, oversized, `# Oversized\n${"x".repeat(DOC_SYNC_INLINE_MAX_BYTES)}`);
     const rejected = await cell.run({ kind: "doc-submit", paths: [oversized] }, binding);
     assert.equal(rejected.outcome, "op_rejected", JSON.stringify(rejected));
     assert.equal(rejected.code, "doc_candidate_too_large");

--- a/packages/daemon/test/doc-sync-slice-a.test.ts
+++ b/packages/daemon/test/doc-sync-slice-a.test.ts
@@ -5,6 +5,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
 import {
+  DOC_SYNC_INLINE_MAX_BYTES,
   DOC_POLICY_ID,
   makeTaskEventStore,
   OPAQUE_TEXTUAL_POLICY_ID,
@@ -12,11 +13,12 @@ import {
   sha256Text,
 } from "../../kernel/src/index.ts";
 import { detail, touch } from "../src/doc-sync-details.ts";
+import { scanAuthoredCandidateInventory } from "../src/doc-sync-candidate-scanner.ts";
 import { canonicalRoot, workspaceId } from "../src/protocol/daemon-protocol.contract.ts";
 import { blockedAuthoredCandidateReason } from "../src/repo-cell.ts";
 import { openBootstrappedRepoCell as openRepoCell } from "./repo-settings.fixture.ts";
 
-import { actor, git, initRepo, opaqueTextualMediaType, rows, write } from "./doc-sync-slice-a.fixtures.ts";
+import { actor, git, initRepo, rows, write } from "./doc-sync-slice-a.fixtures.ts";
 
 test("HTML research documents are eligible, submit as opaque text, and become clean", async () => {
   const rootDir = mkdtempSync(path.join(tmpdir(), "ha-doc-a-html-research-"));
@@ -86,25 +88,18 @@ test("status, dry-run, and submit share the repeatable-path scanner and automati
       [
         ["context/a.md", "eligible"],
         ["context/b.md", "eligible"],
-        ["tasks/task-one/artifacts/data.json", "blocked"],
         ["tasks/task-one/progress.md", "blocked"],
       ],
     );
-    // tasks/task-one is not a projected package path: the repo prose channel
-    // must refuse its artifacts directory instead of admitting the ghost.
-    assert.match(
-      statusRows.find((row) => row.path === "tasks/task-one/artifacts/data.json")?.reason ?? "",
-      /tasks\/task-one is not the package path of any projected task/u,
-    );
-    assert.equal(statusRows.find((row) => row.path.endsWith("artifacts/data.json"))?.mediaType, opaqueTextualMediaType);
     assert.equal(git(rootDir, "rev-parse", "HEAD"), before);
     const dry = await cell.run({ kind: "doc-dry-run", paths: ["context/a.md", "context/b.md"] }, binding);
     assert.equal(dry.outcome, "pending");
     assert.equal(dry.proof?.canonicalVisible, false);
     assert.deepEqual(rows(dry.evidence), statusRows.slice(0, 2));
     assert.equal(git(rootDir, "rev-parse", "HEAD"), before);
-    const submitted = await cell.run({ kind: "doc-submit", paths: ["context/a.md"] }, binding);
+    const submitted = await cell.run({ kind: "doc-submit", paths: ["context/a.md", "context/b.md"] }, binding);
     assert.equal(submitted.outcome, "applied", JSON.stringify(submitted));
+    assert.match(String((submitted as Record<string, unknown>).summary), /applied count: 2/u);
     assert.equal(submitted.commitSha, null);
     const event = makeTaskEventStore({ repoId: "scanner", rootDir }).readEvent(submitted.opId);
     assert.equal(event?.schema, "doc-event/v1");
@@ -120,7 +115,7 @@ test("status, dry-run, and submit share the repeatable-path scanner and automati
       assert.equal(event.payload.executionId, null);
       assert.deepEqual(
         event.payload.changes.map((change) => change.path),
-        ["context/a.md"],
+        ["context/a.md", "context/b.md"],
       );
     }
     assert.deepEqual(
@@ -141,6 +136,92 @@ test("status, dry-run, and submit share the repeatable-path scanner and automati
     assert.equal(rows(renamed.evidence)[0]?.state, "eligible");
     const accepted = await cell.run({ kind: "doc-submit", paths: ["context/a.md"] }, binding);
     assert.equal(accepted.outcome, "applied", JSON.stringify(accepted));
+  } finally {
+    await cell.close();
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});
+
+test("scanner refuses multi-megabyte JSONL without reading it and names oversized prose", async () => {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-doc-a-size-type-"));
+  initRepo(rootDir);
+  const repoId = workspaceId("size-type"),
+    line = '{"event":"load"}\n',
+    jsonl = line.repeat(Math.ceil((2 * 1024 * 1024) / Buffer.byteLength(line))),
+    prose = "context/notes.md",
+    oversized = "context/oversized.md";
+  const seed = await openRepoCell({ repoId, rootDir: canonicalRoot(rootDir), ownerId: "size-type-seed" });
+  const packagePath = await (async () => {
+    try {
+      const created = await seed.run(
+        { kind: "task-create", taskId: "task-size-type", title: "Size Type" },
+        {
+          actor,
+          source: "local",
+        },
+      );
+      assert.equal(created.outcome, "applied", JSON.stringify(created));
+      return String((created as Record<string, unknown>).packagePath);
+    } finally {
+      await seed.close();
+    }
+  })();
+  const firstLog = `${packagePath}/artifacts/evidence/controller.jsonl`,
+    secondLog = `${packagePath}/artifacts/evidence/commands-client-1.jsonl`;
+  write(rootDir, firstLog, jsonl);
+  write(rootDir, secondLog, jsonl);
+  write(rootDir, prose, "# Notes\n");
+  write(rootDir, oversized, `# Oversized\n${"x".repeat(DOC_SYNC_INLINE_MAX_BYTES)}`);
+  const store = makeTaskEventStore({ repoId, rootDir }),
+    inventory = scanAuthoredCandidateInventory({ rootDir, store }),
+    inventoryByPath = new Map(inventory.rows.map((row) => [row.path, row]));
+  await store.drain();
+  for (const logical of [firstLog, secondLog]) {
+    assert.equal(inventoryByPath.get(logical)?.size, Buffer.byteLength(jsonl));
+    assert.equal(inventoryByPath.get(logical)?.bytes, null, `${logical} must not enter inventory bytes`);
+  }
+  assert.equal(inventoryByPath.get(oversized)?.bytes, null, "oversized prose must not enter inventory bytes");
+  assert.equal(inventoryByPath.get(prose)?.bytes?.byteLength, Buffer.byteLength("# Notes\n"));
+
+  const cell = await openRepoCell({ repoId, rootDir: canonicalRoot(rootDir), ownerId: "size-type-daemon" }),
+    binding = { actor, source: "local" as const };
+  try {
+    const status = await cell.run({ kind: "doc-status", paths: [] }, binding);
+    assert.deepEqual(
+      rows(status.evidence)
+        .filter((row) => row.state !== "clean")
+        .map((row) => row.path),
+      [prose, oversized],
+      "non-prose JSONL must not enter the authored candidate set",
+    );
+    const unconfirmed = await cell.run({ kind: "doc-submit", paths: [] }, binding);
+    assert.equal(unconfirmed.outcome, "op_rejected", JSON.stringify(unconfirmed));
+    assert.equal(unconfirmed.code, "doc_submit_confirmation_required");
+    assert.match(String((unconfirmed as Record<string, unknown>).summary), new RegExp(prose, "u"));
+    assert.match(String((unconfirmed as Record<string, unknown>).summary), /--path.*--all/u);
+
+    const confirmed = await cell.run({ kind: "doc-submit", paths: [], all: true }, binding);
+    assert.equal(confirmed.outcome, "applied", JSON.stringify(confirmed));
+    const event = makeTaskEventStore({ repoId, rootDir }).readEvent(confirmed.opId);
+    assert.equal(event?.schema, "doc-event/v1");
+    if (event?.schema === "doc-event/v1")
+      assert.deepEqual(
+        event.payload.changes.map((change) => change.path),
+        [prose],
+      );
+
+    for (const logical of [firstLog, secondLog]) {
+      const selected = await cell.run({ kind: "doc-status", paths: [logical] }, binding),
+        row = rows(selected.evidence)[0];
+      assert.deepEqual([row?.path, row?.state, row?.size], [logical, "blocked", Buffer.byteLength(jsonl)]);
+      assert.match(row?.reason ?? "", /not a supported textual document/u);
+    }
+    const rejected = await cell.run({ kind: "doc-submit", paths: [oversized] }, binding);
+    assert.equal(rejected.outcome, "op_rejected", JSON.stringify(rejected));
+    assert.equal(rejected.code, "doc_candidate_too_large");
+    const oversizedRow = rows((await cell.run({ kind: "doc-status", paths: [oversized] }, binding)).evidence)[0];
+    assert.equal(oversizedRow?.size, Buffer.byteLength(`# Oversized\n${"x".repeat(DOC_SYNC_INLINE_MAX_BYTES)}`));
+    assert.match(oversizedRow?.reason ?? "", new RegExp(`${oversized}.*${DOC_SYNC_INLINE_MAX_BYTES}.*blob`, "u"));
   } finally {
     await cell.close();
     rmSync(rootDir, { recursive: true, force: true });

--- a/packages/daemon/test/doc-sync-slice-b.test.ts
+++ b/packages/daemon/test/doc-sync-slice-b.test.ts
@@ -339,9 +339,10 @@ test("claim-check keeps large bodies out of commands and recycles missing, hash,
   try {
     await startLease(local.cell, local.rootDir, "local");
     const relativePath = "tasks/task-doc-docs/large.md",
-      body = `# Large\n${"x".repeat(DOC_COMMAND_FRAME_MAX_BYTES + 1)}\n`;
+      body = `# Large\n${"x".repeat(DOC_COMMAND_FRAME_MAX_BYTES - 1024)}\n`;
     writeAuthored(local.rootDir, relativePath, body);
     const action = { kind: "doc-submit", executionId: "execution-doc", paths: [relativePath] } as const;
+    assert.equal(Buffer.byteLength(body) > DOC_COMMAND_FRAME_MAX_BYTES / 2, true);
     assert.equal(Buffer.byteLength(JSON.stringify(action)) < DOC_COMMAND_FRAME_MAX_BYTES, true);
     assert.equal(JSON.stringify(action).includes(body), false);
     const result = await local.cell.run(action, localBinding);

--- a/packages/daemon/test/fleet-doc-sync-ok-polarity.integration.test.ts
+++ b/packages/daemon/test/fleet-doc-sync-ok-polarity.integration.test.ts
@@ -162,8 +162,8 @@ async function pushRejectionFixture() {
       channel: "collaborator",
       changes,
     });
-  const edgeDocSync = (nodeId: NodeId, paths: readonly string[]) =>
-    runFleetEdgeDocSync({ payload: { ...channel(nodeId), paths } });
+  const edgeDocSync = (nodeId: NodeId, options: { readonly all?: true; readonly paths?: readonly string[] } = {}) =>
+    runFleetEdgeDocSync({ payload: { ...channel(nodeId), ...options } });
   const writeWorktree = (nodeId: NodeId, logicalPath: string, body: string): void => {
     const view = locateFleetMirrorView(edgeRoot(nodeId), "fleet-doc-sync-repo");
     assert.ok(view, "mirror view must exist before its registered harness is changed");
@@ -213,11 +213,11 @@ test("push-rejected base_blob_changed staging is rejected instead of applied", {
   const shared = "context/shared-notes.md";
   const base = "# Shared\n\nbaseline.\n";
   assert.equal((await fixture.rawWrite("node-one", [{ path: shared, body: base }])).center.outcome, "applied");
-  assert.equal((await fixture.edgeDocSync("node-one", [shared])).ok, true);
+  assert.equal((await fixture.edgeDocSync("node-one", { paths: [shared] })).ok, true);
   fixture.writeWorktree("node-one", shared, `${base}\nedge-local change.\n`);
   fixture.armBaseBlobRace(shared, base, `${base}\npeer-center change.\n`);
 
-  const receipt = await fixture.edgeDocSync("node-one", [shared]);
+  const receipt = await fixture.edgeDocSync("node-one", { paths: [shared] });
 
   assert.equal(fixture.raceInjected(), true, "the peer must move the shared path after compare and before submit");
   assert.equal(receipt.ok, false, JSON.stringify(receipt));
@@ -227,4 +227,25 @@ test("push-rejected base_blob_changed staging is rejected instead of applied", {
   assert.equal(receipt.canonicalOutcome, "op_rejected");
   assert.equal(receipt.mirrorOutcome, "pull_blocked");
   assert.equal(fixture.conflicts().length, 1, "the losing local bytes must be staged for an explicit exit");
+});
+
+test("remote-edge full submit requires explicit all confirmation", { timeout: 60_000 }, async (t) => {
+  const fixture = await pushRejectionFixture();
+  t.after(() => fixture.close());
+  const shared = "context/shared-notes.md",
+    base = "# Shared\n\nbaseline.\n";
+  assert.equal((await fixture.rawWrite("node-one", [{ path: shared, body: base }])).center.outcome, "applied");
+  assert.equal((await fixture.edgeDocSync("node-one", { paths: [shared] })).ok, true);
+  fixture.writeWorktree("node-one", shared, `${base}\nedge-local change.\n`);
+
+  const unconfirmed = await fixture.edgeDocSync("node-one");
+  assert.equal(unconfirmed.ok, false, JSON.stringify(unconfirmed));
+  assert.equal(unconfirmed.code, "doc_submit_confirmation_required");
+  assert.deepEqual(
+    (unconfirmed.rows as readonly { readonly path: string }[]).map((row) => row.path),
+    [shared],
+  );
+
+  const confirmed = await fixture.edgeDocSync("node-one", { all: true });
+  assert.equal(confirmed.ok, true, JSON.stringify(confirmed));
 });

--- a/packages/daemon/test/fleet-dual-sync-hardening.test.ts
+++ b/packages/daemon/test/fleet-dual-sync-hardening.test.ts
@@ -16,9 +16,15 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
 import { createHash } from "node:crypto";
+import { DOC_SYNC_INLINE_MAX_BYTES } from "../../kernel/src/index.ts";
 import { openBootstrappedRepoCell as openRepoCell } from "./repo-settings.fixture.ts";
 import { canonicalRoot, workspaceId } from "../src/protocol/daemon-protocol.contract.ts";
-import { applyFleetMirrorCut, readFleetUnresolvedConflicts, withFleetMirrorLock } from "../src/fleet-edge-mirror.ts";
+import {
+  applyFleetMirrorCut,
+  readFleetUnresolvedConflicts,
+  scanFleetMirrorWorktree,
+  withFleetMirrorLock,
+} from "../src/fleet-edge-mirror.ts";
 import { fleetDocPathInTaskPackage } from "../src/fleet-edge-task.ts";
 import { realizedTaskPlan } from "../../../tools/fixtures/task-plan.mjs";
 import { withRoleBinding } from "./role-binding.fixtures.ts";
@@ -72,6 +78,41 @@ const mirrorCut = (value: unknown): { revision: number; headDigest: string } => 
   const cut = ledgerCut(value);
   return { revision: cut.revision, headDigest: cut.headDigest };
 };
+
+test("fleet mirror candidate scan names oversized prose without reading it into a change", (t) => {
+  const root = mkdtempSync(path.join(tmpdir(), "w3c-h-large-doc-"));
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  initRepo(root);
+  const logical = "context/oversized.md",
+    body = `# Oversized\n${"x".repeat(DOC_SYNC_INLINE_MAX_BYTES)}`,
+    size = Buffer.byteLength(body);
+  writeBytes(path.join(root, "harness", logical), body);
+  const scan = scanFleetMirrorWorktree(
+    {
+      repoId: "large-doc",
+      viewId: "view-one",
+      viewDir: path.join(root, "view"),
+      revision: 1,
+      headDigest: "head",
+      manifestDigest: "manifest",
+      entries: new Map(),
+    },
+    root,
+  );
+  assert.deepEqual(scan.changes, []);
+  assert.deepEqual(scan.blocked, [
+    {
+      path: logical,
+      size,
+      maxInlineBytes: DOC_SYNC_INLINE_MAX_BYTES,
+      code: "doc_candidate_too_large",
+      requiredRoute: "blob-content",
+      reason:
+        `${logical} is ${size} bytes; doc sync accepts at most ${DOC_SYNC_INLINE_MAX_BYTES} bytes; ` +
+        "send raw content through the blob content contract",
+    },
+  ]);
+});
 
 test("F1: the fleet doc-submit channel cannot write task documents without the held execution", async (t) => {
   const root = mkdtempSync(path.join(tmpdir(), "w3c-h-f1-"));

--- a/packages/kernel/src/domain/artifact-text-classification.ts
+++ b/packages/kernel/src/domain/artifact-text-classification.ts
@@ -1,5 +1,8 @@
 export const OPAQUE_TEXTUAL_POLICY_ID = "opaque-textual-whole-file/v1";
 export const OPAQUE_TEXTUAL_MEDIA_TYPE = "text/x-harness-opaque";
+// Doc sync is an inline prose channel capped by its 256 KiB descriptor frame.
+// Larger raw content belongs to the <=50,000,000 byte blob contract in dec_776B4D61DF711D9F31126D375D.
+export const DOC_SYNC_INLINE_MAX_BYTES = 256 * 1024;
 export type OpaqueTextualMediaType =
   | "application/json"
   | "application/yaml"
@@ -49,6 +52,16 @@ export function classifyTextualArtifactPath(value: string): TextualArtifactClass
   return mediaType === "text/markdown" || mediaType === "text/plain"
     ? { kind: "canonical-prose", mediaType, policyId: "markdown-body-replaceable/v1" }
     : { kind: "opaque-textual", mediaType, policyId: OPAQUE_TEXTUAL_POLICY_ID };
+}
+
+export function classifyDocSyncCandidatePath(value: string): TextualArtifactClassification | null {
+  const classification = classifyTextualArtifactPath(value),
+    extension = extensionOf(value);
+  return (artifactPath(value) && classification?.mediaType === "application/json") ||
+    extension === ".jsonl" ||
+    extension === ".log"
+    ? null
+    : classification;
 }
 
 export function isOpaqueTextualMediaType(value: unknown): value is OpaqueTextualMediaType {

--- a/packages/kernel/src/index.ts
+++ b/packages/kernel/src/index.ts
@@ -149,7 +149,9 @@ export {
   resolveDocRoute,
 } from "./domain/doc-sync.contract.ts";
 export {
+  classifyDocSyncCandidatePath,
   classifyTextualArtifactPath,
+  DOC_SYNC_INLINE_MAX_BYTES,
   OPAQUE_TEXTUAL_POLICY_ID,
   type OpaqueTextualMediaType,
   worktreeDocumentMediaType,

--- a/packages/kernel/test/contracts/doc-sync.test.ts
+++ b/packages/kernel/test/contracts/doc-sync.test.ts
@@ -2,6 +2,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import {
+  classifyDocSyncCandidatePath,
   OPAQUE_TEXTUAL_MEDIA_TYPE,
   OPAQUE_TEXTUAL_POLICY_ID,
   classifyTextualArtifactPath,
@@ -266,6 +267,19 @@ test("opaque textual paths preserve their media type", () => {
   });
   assert.equal(classifyTextualArtifactPath("context/architecture/notes.json"), null);
   assert.equal(classifyTextualArtifactPath("context/architecture/views/write-path.c4"), null);
+  assert.equal(classifyDocSyncCandidatePath("tasks/task-owner/artifacts/data.json"), null);
+  assert.equal(classifyDocSyncCandidatePath("tasks/task-owner/artifacts/run.jsonl"), null);
+  assert.equal(classifyDocSyncCandidatePath("tasks/task-owner/artifacts/run.log"), null);
+  assert.deepEqual(classifyDocSyncCandidatePath("context/architecture/architecture-manifest.json"), {
+    kind: "opaque-textual",
+    mediaType: "application/json",
+    policyId: OPAQUE_TEXTUAL_POLICY_ID,
+  });
+  assert.deepEqual(classifyDocSyncCandidatePath("tasks/task-owner/artifacts/report.md"), {
+    kind: "opaque-textual",
+    mediaType: "text/markdown",
+    policyId: OPAQUE_TEXTUAL_POLICY_ID,
+  });
 });
 
 test("doc content claims accept only the supported opaque textual media types", () => {


### PR DESCRIPTION
# English

## Summary

Two production incidents today (facts F-B56275D2, F-94BEF394) stopped every ledger write for ~45 minutes each: raw stress logs (8 × 46 MB `.jsonl`) copied into a task packet were classified as JSON text artifacts and swept into a single `documents_written` record (370 MB of blobs), once by a full `ha doc sync --submit` and once by the daemon's own after-flush candidate settlement. The WAL→Git materializer then failed deterministically on a >512 MB in-memory string and latched. This PR makes the doc channel refuse what it was never meant to carry, at the scanner layer, on both the local and the remote-edge routes.

## Architectural Justification

- One threshold: `DOC_SYNC_INLINE_MAX_BYTES = 256 KiB` (the existing command-frame ceiling) is now also the inline candidate ceiling; larger content is refused with `doc_candidate_too_large` naming path, size and limit and pointing at the blob content contract of dec_776B4D61 (≤ 50 MB content-addressed). No new storage path is implemented here.
- Scanner-level invariant, not an external stopgap: `scanAuthoredCandidateInventory` and the fleet mirror scanner `stat` before reading; artifact JSON, `.jsonl` and `.log` are no longer automatic prose candidates (architecture manifest JSON and typed machine JSON routes are preserved). The after-flush settlement and a human submit go through the same admission.
- Bare full-tree submit is no longer a write: without `--path`, `doc-submit` returns `doc_submit_confirmation_required` with the candidate list; `--all` is the explicit opt-in and is propagated to the remote-edge route so an edge cannot re-widen it.
- Multi-`--path` receipts now report what was actually written (the incident showed `no_changes` while 179 changes were recorded).

## Fleet / centralized-ledger view

Edge routes get the same size guard and confirmation; a bare full submit does not push to center, `all:true` does (fleet-doc-sync-ok-polarity 3/3).

## What Changed

- `packages/kernel/src/domain/artifact-text-classification.ts`, `packages/kernel/src/index.ts`: `classifyDocSyncCandidatePath`, `DOC_SYNC_INLINE_MAX_BYTES`.
- `packages/daemon/src/doc-sync-candidate-scanner.ts`, `doc-sync-command-actions.ts`, `doc-sync-adjudication.ts`: stat-before-read, structured oversized refusal, confirmation gate, receipt fidelity.
- `packages/daemon/src/protocol/daemon-protocol-commands-doc-fact.ts`, `packages/cli/src/cli/thin-command-doc.ts`, `packages/cli/src/daemon/client.ts`: closed `--all` contract end to end.
- `packages/daemon/src/fleet-edge-doc-sync.ts`, `fleet-edge-mirror.ts`: same guard on the edge.
- Tests: doc-sync-slice-a (multi-MB JSONL fixtures, oversized Markdown), kernel doc-sync contract, thin-command doc runtime, fleet-task-route, fleet-dual-sync-hardening, fleet-doc-sync-ok-polarity.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none

## Machine-Readable Declarations

Production-Delta: +190/-47

## Task And Scope

- Harness task: task_effc7b8318907fbf14a8ff744d
- Branch: codex/doc-channel-guard
- Public scope: the files above
- Private planning/evidence updated: yes (worker report; facts F-D36CEC24, F-3C13CF15)
- Out of scope: the blob content write path itself (dec_776B4D61 / gen-2); the materializer's whole-batch string assembly (deleted by the stage-③ cold migration, task_d1b1a445)

## Version Impact

- Version: no version change (daemon/CLI behaviour; CLI gains `--all`)
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none
- Authority: not applicable
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no

## Verification

- Base `origin/main` SHA: 9d287f46eabf4bbf8b7b8a06bf7106fe12b40e56
- Isolated Ubuntu: doc-sync-slice-a 12/12, kernel doc-sync contract 7/7, doc-sync-artifact-opaque 7/7, fleet-doc-sync-ok-polarity 3/3 (a deliberately wrong assertion was dispatched first and failed on the Ubuntu side, then reverted).
- Local: thin-command-script-doc-runtime 6/6 (re-run by the CEO), fleet-task-route 1/1, fleet-dual-sync-hardening 9/9; tsc for kernel/daemon/cli, lint, line-density, canonical-event-compat, test-selection, file-complexity, gates tests 187/187, production-delta PASS.
- `check:local` not run; CI is the authority.

## Review Evidence

- Round 2 (CI run 34010676510): three deterministic regressions — a repository-wide sweep test still used a bare submit (now `--all`), a claim-check fixture sat 10 bytes over the new 256 KiB ceiling (fixture resized, assertions kept), and an unregistered-package test received the confirmation gate before the named `task_package_unregistered` rejection. Admission now resolves blocked/deletion/conflict scan codes before the unscoped-confirmation gate (`scanRejectionCode`), with an exact-order test (`worker-report-r2.md`).
- CEO semantic read against the incident mechanism and the peer-CEO steer (refusal must live in the scanner, not in `.gitignore`); Terra review to follow on the task after merge.

## Residual Risk

- Evidence `.log` files in task packets are no longer synced as prose; they wait for the blob content contract. `.gitignore` entries added during the incident stay as defence in depth until then.

---

# 中文

## 概要

今天两起生产事故(F-B56275D2、F-94BEF394)各让全台账写入停摆约 45 分钟:拷进任务包的 8 个 46 MB 原始压测 `.jsonl` 被归为 JSON 文本工件,先后被一次全量 `ha doc sync --submit` 和 daemon 自己的 flush 后自动清算扫成单条 documents_written(370 MB blob),WAL→Git 物化器在 >512 MB 的内存字符串上确定性失败并停机。本 PR 让 doc 通道在扫描层就拒收它不该承载的东西,本地与远端边缘同路。

## 架构辩护

单一阈值 `DOC_SYNC_INLINE_MAX_BYTES = 256 KiB`(即现有命令帧上限);超限具名拒收 `doc_candidate_too_large` 并指向 dec_776B4D61 的 blob 内容契约(≤50 MB 内容寻址),不在此实现新写路。扫描器先 `stat` 再读;工件 JSON/`.jsonl`/`.log` 不再是自动 prose 候选(架构清单 JSON 与类型化机器 JSON 路由保留);自动清算与人手提交同一道门。不带 `--path` 的全量提交不再是写,而是 `doc_submit_confirmation_required` 加候选清单,`--all` 为显式确认并传到边缘。多 `--path` 回执如实报告实际写入。

## 中心化仓库视角

边缘同样受大小守卫与确认门;裸全量提交不推中心,`all:true` 才推(3/3)。

## 改动内容

见英文段;16 个文件,无新增/删除文件。

## 门收割 / Gate Harvest

无删除。

## 任务与范围

task_effc7b83;分支 codex/doc-channel-guard;不含 blob 写路本身与物化器整批拼串(后者随第③段冷迁移删除)。

## 版本影响

无(CLI 新增 `--all`)。

## 治理声明

未触碰 protected surface。

## 验证

Ubuntu 隔离 12/12、7/7、7/7、3/3(含先故意写错断言验证派测确实跑在本 worktree);本地 6/6(CEO 复跑)、1/1、9/9;各 gate PASS;未跑 check:local,CI 为权威。

## 审查证据

CEO 按事故机制与对等 CEO 的「拒收在扫描层」判断细读;合并后 Terra 在任务上复核。

## 残余风险

任务包里的证据 `.log` 暂不再作为 prose 入库,等 blob 内容契约;事故期间加的 `.gitignore` 条目作为纵深保留。
