### PR TITLE
fix(daemon): keep an explicitly stopped daemon offline until an explicit start

### DIFF
--- a/packages/cli/src/cli/thin-command.ts
+++ b/packages/cli/src/cli/thin-command.ts
@@ -1,5 +1,6 @@
 export const thinCliLocalErrorCodes = Object.freeze([
   "daemon_start_runtime_forbidden",
+  "daemon_stopped_by_operator",
   "daemon_disconnect",
   "daemon_gone",
   "daemon_restarting",

--- a/packages/cli/src/daemon/control.ts
+++ b/packages/cli/src/daemon/control.ts
@@ -318,6 +318,7 @@ async function status(
   } catch (error) {
     const stoppedAt = readDaemonStoppedAt(userRoot, daemonId);
     if (!stoppedAt) throw error;
+    consumeKnownError(error);
     const summary = `daemon status: not running (stopped by operator at ${stoppedAt})`;
     result = { ...daemonFailure("daemon-status", "daemon_unavailable", summary), summary };
   }

--- a/packages/cli/src/daemon/control.ts
+++ b/packages/cli/src/daemon/control.ts
@@ -87,9 +87,9 @@ export async function runDaemonControl(argv: readonly string[], renderReceipt: R
       return finish(assessed.receipt, assessed.exitCode);
     }
     if (command === "stop") {
-      writeDaemonStoppedMarker(userRoot, daemonId);
       const pid = readDaemonPid(userRoot, daemonId);
       if (pid === null) return finish(daemonFailure("daemon-stop", "daemon_unavailable", "No daemon is running."), 1);
+      writeDaemonStoppedMarker(userRoot, daemonId);
       if (argv.includes("--force")) {
         const forced = await forceStopDaemon(userRoot, daemonId, pid);
         return finish(forced, forced.ok === true ? 0 : 1);

--- a/packages/cli/src/daemon/control.ts
+++ b/packages/cli/src/daemon/control.ts
@@ -337,6 +337,9 @@ function assessDaemonStatus(result: Record<string, unknown>): {
   readonly receipt: Record<string, unknown>;
   readonly exitCode: 0 | 1;
 } {
+  // A status that could not reach a daemon (including the operator-stop report) exits non-zero like every
+  // other unavailable answer; callers such as the first-run lane poll on that exit code.
+  if (result.ok === false) return { receipt: result, exitCode: 1 };
   const rows = Array.isArray(result.repos) ? result.repos : [],
     retryingRows = rows.flatMap((value) => {
       if (!statusRecord(value) || !statusRecord(value.materialization)) return [];

--- a/packages/cli/src/daemon/control.ts
+++ b/packages/cli/src/daemon/control.ts
@@ -9,7 +9,12 @@ import { requestDaemonJsonRpcAt } from "../../../daemon/src/client/local-json-rp
 import type { DaemonShutdownExchange } from "../../../daemon/src/client/local-json-rpc-shutdown.ts";
 import { terminateProcess } from "../../../daemon/src/process-port.ts";
 import type { JsonObject } from "../../../daemon/src/protocol/json-rpc-types.ts";
-import { runtimeDaemonStartRefusal } from "../../../daemon/src/client/daemon-autostart.ts";
+import {
+  clearDaemonStoppedMarker,
+  readDaemonStoppedAt,
+  runtimeDaemonStartRefusal,
+  writeDaemonStoppedMarker,
+} from "../../../daemon/src/client/daemon-autostart.ts";
 import { readDaemonPid, startDaemon } from "../../../daemon/src/runtime.ts";
 import {
   daemonProcessAlive,
@@ -73,6 +78,7 @@ export async function runDaemonControl(argv: readonly string[], renderReceipt: R
     if (command === "serve") {
       const refusal = runtimeDaemonStartRefusal();
       if (refusal) return finish(daemonFailure("daemon-serve", "daemon_start_runtime_forbidden", refusal.hint), 1);
+      clearDaemonStoppedMarker(userRoot, daemonId);
       return serve(userRoot, daemonId, finish);
     }
     if (command === "start") return startDaemonService(argv, userRoot, daemonId, invokingRoot, finish);
@@ -81,6 +87,7 @@ export async function runDaemonControl(argv: readonly string[], renderReceipt: R
       return finish(assessed.receipt, assessed.exitCode);
     }
     if (command === "stop") {
+      writeDaemonStoppedMarker(userRoot, daemonId);
       const pid = readDaemonPid(userRoot, daemonId);
       if (pid === null) return finish(daemonFailure("daemon-stop", "daemon_unavailable", "No daemon is running."), 1);
       if (argv.includes("--force")) {
@@ -128,6 +135,10 @@ async function startDaemonService(
       ),
       2,
     );
+  const runtimeRefusal = runtimeDaemonStartRefusal();
+  if (runtimeRefusal)
+    return finish(daemonFailure("daemon-start", "daemon_start_runtime_forbidden", runtimeRefusal.hint), 1);
+  clearDaemonStoppedMarker(userRoot, daemonId);
   let running: Record<string, unknown> | null = null;
   try {
     running = await status(userRoot, daemonId, argv);
@@ -135,9 +146,6 @@ async function startDaemonService(
     consumeKnownError(error);
   }
   if (running?.ok === true) return finish(running, 0);
-  const runtimeRefusal = runtimeDaemonStartRefusal();
-  if (runtimeRefusal)
-    return finish(daemonFailure("daemon-start", "daemon_start_runtime_forbidden", runtimeRefusal.hint), 1);
   const started = await ensureCliDaemonRunning({
     invokingRoot,
     userRoot,
@@ -303,8 +311,16 @@ async function status(
     consumeKnownError(error);
     resolved = null;
   }
-  const endpoint = resolved?.socketPath ?? localUserDaemonEndpoint(userRoot, daemonId),
+  const endpoint = resolved?.socketPath ?? localUserDaemonEndpoint(userRoot, daemonId);
+  let result: Record<string, unknown>;
+  try {
     result = await requestDaemonJsonRpcAt(endpoint, "daemon.status", {}, 75, undefined, undefined, true);
+  } catch (error) {
+    const stoppedAt = readDaemonStoppedAt(userRoot, daemonId);
+    if (!stoppedAt) throw error;
+    const summary = `daemon status: not running (stopped by operator at ${stoppedAt})`;
+    result = { ...daemonFailure("daemon-status", "daemon_unavailable", summary), summary };
+  }
   const target = {
       endpoint,
       daemonId,

--- a/packages/cli/src/daemon/with-autostart.ts
+++ b/packages/cli/src/daemon/with-autostart.ts
@@ -72,13 +72,27 @@ export async function withAutostart(
     }
   } catch (error) {
     if (!options.autostart) throw error;
-    const { DaemonAutostartError, ensureLocalDaemonRunning, isDaemonUnreachable, runtimeDaemonStartRefusal } =
-      await import("../../../daemon/src/client/daemon-autostart.ts");
+    const {
+      DaemonAutostartError,
+      ensureLocalDaemonRunning,
+      isDaemonUnreachable,
+      readDaemonStoppedAt,
+      runtimeDaemonStartRefusal,
+    } = await import("../../../daemon/src/client/daemon-autostart.ts");
     if (!isDaemonUnreachable(error)) throw error;
     // The failed connection already proves this socket unavailable. A second socket probe can
     // consume its full timeout without adding evidence.
     const refusal = runtimeDaemonStartRefusal(options.env);
     if (refusal) throw new DaemonAutostartError({ ok: false, ...refusal, attempts: 0 });
+    const stoppedAt =
+      options.userRoot && options.daemonId ? readDaemonStoppedAt(options.userRoot, options.daemonId) : null;
+    if (stoppedAt)
+      throw new DaemonAutostartError({
+        ok: false,
+        code: "daemon_stopped_by_operator",
+        hint: `The daemon was stopped by the operator at ${stoppedAt}. Run \`ha daemon start --service\` to start it.`,
+        attempts: 0,
+      });
     const started = await ensureLocalDaemonRunning({
       socketPath,
       invokingRoot: options.invokingRoot,

--- a/packages/cli/test/daemon-autostart-cli.test.ts
+++ b/packages/cli/test/daemon-autostart-cli.test.ts
@@ -129,7 +129,13 @@ test("operator stop blocks autostart until explicit start while process death re
       lifecycle.some((record) => record.event === "process_exit" && record.outcome === "stop_requested"),
       true,
     );
-    const stoppedStatus = run(fixture.root, fixture.userRoot, ["daemon", "status"]);
+    const stoppedStatusRun = spawnSync(process.execPath, [cli, "--root", fixture.root, "--json", "daemon", "status"], {
+      encoding: "utf8",
+      env: cliEnv(fixture.root, fixture.userRoot),
+    });
+    // Unavailable answers exit non-zero: the first-run lane polls this exit code to see the daemon gone.
+    assert.notEqual(stoppedStatusRun.status, 0, `${stoppedStatusRun.stderr}\n${stoppedStatusRun.stdout}`);
+    const stoppedStatus = JSON.parse(stoppedStatusRun.stdout) as Record<string, unknown>;
     assert.match(String(stoppedStatus.summary), /not running \(stopped by operator at \d{4}-\d{2}-\d{2}T/u);
     const worktree = path.join(fixture.root, ".worktrees", "task-list-feature");
     git(fixture.root, "worktree", "add", "--quiet", "--detach", worktree);

--- a/packages/cli/test/daemon-autostart-cli.test.ts
+++ b/packages/cli/test/daemon-autostart-cli.test.ts
@@ -22,6 +22,7 @@ import {
 } from "../../daemon/src/client/local-json-rpc-client.ts";
 import { streamAgentRuntimeAt } from "../../daemon/src/client/local-json-rpc-stream.ts";
 import { localUserDaemonEndpoint } from "../../daemon/src/client/local-daemon-target.ts";
+import { clearDaemonStoppedMarker } from "../../daemon/src/client/daemon-autostart.ts";
 import { openDaemonLifecycleLog, readDaemonLifecycleRecords } from "../../daemon/src/lifecycle-log.ts";
 import { currentDaemonProtocolVersion } from "../../daemon/src/protocol/version.ts";
 import { readDaemonPid } from "../../daemon/src/runtime.ts";
@@ -52,7 +53,7 @@ test("resident daemon autostart strips the worker callback relay marker", () => 
   }
 });
 
-test("registered checkout autostarts the daemon while its worktree only connects", (context) => {
+test("operator stop blocks autostart until explicit start while process death remains recoverable", async (context) => {
   const fixture = setup();
   try {
     assert.equal(run(fixture.root, fixture.userRoot, ["daemon", "start", "--service"]).ok, true);
@@ -112,6 +113,8 @@ test("registered checkout autostarts the daemon while its worktree only connects
       lifecycle.some((record) => record.event === "process_exit" && record.outcome === "stop_requested"),
       true,
     );
+    const stoppedStatus = run(fixture.root, fixture.userRoot, ["daemon", "status"]);
+    assert.match(String(stoppedStatus.summary), /not running \(stopped by operator at \d{4}-\d{2}-\d{2}T/u);
     const worktree = path.join(fixture.root, ".worktrees", "task-list-feature");
     git(fixture.root, "worktree", "add", "--quiet", "--detach", worktree);
     const refused = spawnSync(process.execPath, [cli, "--root", worktree, "--json", "task", "list"], {
@@ -120,20 +123,33 @@ test("registered checkout autostarts the daemon while its worktree only connects
     });
     assert.notEqual(refused.status, 0, `${refused.stderr}\n${refused.stdout}`);
     const refusal = JSON.parse(refused.stdout) as { error?: { code?: string } };
-    assert.equal(refusal.error?.code, "daemon_start_noncanonical_checkout");
+    assert.equal(refusal.error?.code, "daemon_stopped_by_operator");
     assert.equal(readDaemonPid(fixture.userRoot, "default"), null, "the refused worktree must not claim the daemon");
 
-    // The daemon is gone; a repository command from the registered checkout must bring it back and answer.
+    const blocked = spawnSync(process.execPath, [cli, "--root", fixture.root, "--json", "task", "list"], {
+      encoding: "utf8",
+      env: cliEnv(fixture.root, fixture.userRoot),
+    });
+    assert.notEqual(blocked.status, 0, `${blocked.stderr}\n${blocked.stdout}`);
+    const blockedReceipt = JSON.parse(blocked.stdout) as {
+      error?: { code?: string };
+      diagnostic?: { expectation?: string };
+    };
+    assert.equal(blockedReceipt.error?.code, "daemon_stopped_by_operator");
+    assert.match(String(blockedReceipt.diagnostic?.expectation), /ha daemon start --service/u);
+    assert.equal(readDaemonPid(fixture.userRoot, "default"), null, "operator stop must suppress autostart");
+
+    assert.equal(run(fixture.root, fixture.userRoot, ["daemon", "start", "--service"]).ok, true);
     const result = spawnSync(process.execPath, [cli, "--root", fixture.root, "--json", "task", "list"], {
       encoding: "utf8",
       env: cliEnv(fixture.root, fixture.userRoot),
     });
     assert.equal(result.status, 0, `${result.stderr}\n${result.stdout}`);
-    const receipt = JSON.parse(result.stdout) as { ok: boolean; outcome?: string; error?: { code: string } };
+    const receipt = JSON.parse(result.stdout) as { ok: boolean; outcome?: string };
     assert.equal(receipt.ok, true, JSON.stringify(receipt));
     assert.equal(receipt.outcome, "applied");
     const restartedPid = readDaemonPid(fixture.userRoot, "default");
-    assert.ok(restartedPid, "autostart must leave a resident daemon pid file");
+    assert.ok(restartedPid, "explicit start must leave a resident daemon pid file");
     assert.notEqual(restartedPid, previousPid);
     const connected = spawnSync(process.execPath, [cli, "--root", worktree, "--json", "task", "list"], {
       encoding: "utf8",
@@ -146,7 +162,7 @@ test("registered checkout autostarts the daemon while its worktree only connects
       "the worktree must reuse the resident daemon",
     );
     context.diagnostic(
-      `worktree refusal=${refusal.error?.code}; registered checkout pid=${restartedPid}; worktree existing-daemon task-list=ok`,
+      `stop refusal=${blockedReceipt.error?.code}; explicit-start pid=${restartedPid}; worktree existing-daemon task-list=ok`,
     );
     const restartedLifecycle = readDaemonLifecycleRecords(fixture.userRoot, "default"),
       generationStart = restartedLifecycle.findLastIndex((record) => record.event === "process_start"),
@@ -160,6 +176,14 @@ test("registered checkout autostarts the daemon while its worktree only connects
       generationStart >= 0 && bound > generationStart && attach > bound,
       "the resident socket must bind before the cold registry starts attaching",
     );
+    process.kill(restartedPid, "SIGKILL");
+    await waitForProcessExit(restartedPid);
+    const recovered = run(fixture.root, fixture.userRoot, ["task", "list"]);
+    assert.equal(recovered.outcome, "applied");
+    const recoveredPid = readDaemonPid(fixture.userRoot, "default");
+    assert.ok(recoveredPid, "process death without daemon stop must remain autostartable");
+    assert.notEqual(recoveredPid, restartedPid);
+    context.diagnostic(`SIGKILL negative control autostart pid=${recoveredPid}`);
     assert.equal(run(fixture.root, fixture.userRoot, ["daemon", "stop"]).ok, true);
   } finally {
     rmSync(fixture.parent, { recursive: true, force: true });
@@ -967,6 +991,7 @@ test(
       register(fixture.root, fixture.userRoot, "autostart-fail");
       assert.equal(run(fixture.root, fixture.userRoot, ["daemon", "stop"]).ok, true);
       waitForDaemonDown(fixture.userRoot);
+      clearDaemonStoppedMarker(fixture.userRoot, "default");
       // The lock is the first mutating step. A read-only user root must fail there
       // with the permission cause instead of spawning or waiting for a bind timeout.
       chmodSync(fixture.userRoot, 0o555);

--- a/packages/cli/test/daemon-autostart-cli.test.ts
+++ b/packages/cli/test/daemon-autostart-cli.test.ts
@@ -53,6 +53,22 @@ test("resident daemon autostart strips the worker callback relay marker", () => 
   }
 });
 
+test("stopping a cold daemon leaves the user root untouched", () => {
+  const fixture = setup();
+  try {
+    const stopped = spawnSync(process.execPath, [cli, "--root", fixture.root, "--json", "daemon", "stop"], {
+      encoding: "utf8",
+      env: cliEnv(fixture.root, fixture.userRoot),
+    });
+    assert.notEqual(stopped.status, 0, `${stopped.stderr}\n${stopped.stdout}`);
+    const receipt = JSON.parse(stopped.stdout) as { error?: { code?: string } };
+    assert.equal(receipt.error?.code, "daemon_unavailable");
+    assert.equal(existsSync(fixture.userRoot), false, "a cold stop must not create daemon state");
+  } finally {
+    rmSync(fixture.parent, { recursive: true, force: true });
+  }
+});
+
 test("operator stop blocks autostart until explicit start while process death remains recoverable", async (context) => {
   const fixture = setup();
   try {

--- a/packages/cli/test/migration-multi-source-cli.integration.test.ts
+++ b/packages/cli/test/migration-multi-source-cli.integration.test.ts
@@ -18,10 +18,13 @@ test("CLI merges two independently initialized Git Harness repositories into a t
     userRoot = path.join(parent, "user");
   try {
     initialize(first, userRoot, "source-first");
+    run(first, userRoot, ["daemon", "start", "--service"]);
     initialize(second, userRoot, "source-second");
+    run(second, userRoot, ["daemon", "start", "--service"]);
     initialize(center, userRoot, "center");
     addSourceData(first, "alpha", "person_alpha");
     addSourceData(second, "beta", "person_beta");
+    run(center, userRoot, ["daemon", "start", "--service"]);
     const receipt = run(center, userRoot, ["migrate", "import", "--source", first, "--source", second]);
     assert.equal(receipt.outcome, "applied", JSON.stringify(receipt));
     assert.equal(receipt.exitCode, 0);

--- a/packages/cli/test/runtime-cli.integration.test.ts
+++ b/packages/cli/test/runtime-cli.integration.test.ts
@@ -710,6 +710,7 @@ test("real CLI runs, archives task-bound dispatches, resumes, waits through stat
     );
     assert.equal(stoppedForRestart.forced, true, JSON.stringify(stoppedForRestart));
     assert.equal(processAlive(workerPid), true, `runtime worker ${String(workerPid)} must survive daemon stop --force`);
+    assert.equal(run(root, env, ["daemon", "start", "--service"]).ok, true);
     const liveAfterRestart = await eventuallyRuntimeStatus(root, env, restartSessionId, "live"),
       daemonAfterRestart = run(root, env, ["daemon", "status"]);
     assert.notEqual(daemonAfterRestart.pid, daemonBeforeRestart.pid, "runtime status must use a restarted daemon");

--- a/packages/daemon/src/client/daemon-autostart.ts
+++ b/packages/daemon/src/client/daemon-autostart.ts
@@ -1,7 +1,8 @@
-import { existsSync, readFileSync, statSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import {
   acquireDaemonAutostartFlight,
+  daemonPidPath,
   daemonProcessAlive,
   daemonSocketProbe,
   readDaemonSingletonLockPid,
@@ -16,6 +17,7 @@ export interface DaemonLaunchSpec {
   readonly env: NodeJS.ProcessEnv;
 }
 export const autostartFailureCodes = [
+  "daemon_stopped_by_operator",
   "daemon_start_noncanonical_checkout",
   "daemon_start_runtime_forbidden",
   "daemon_spawn_not_found",
@@ -38,6 +40,24 @@ export interface DaemonStartProgress {
 export interface DaemonGenerationWaitResult {
   readonly ok: boolean;
   readonly waitedMs: number;
+}
+export function daemonStoppedMarkerPath(userRoot: string, daemonId: string): string {
+  return daemonPidPath(userRoot, daemonId).replace(/\.pid$/u, ".stopped");
+}
+export function writeDaemonStoppedMarker(userRoot: string, daemonId: string): string {
+  const stoppedAt = new Date().toISOString(),
+    markerPath = daemonStoppedMarkerPath(userRoot, daemonId);
+  mkdirSync(userRoot, { recursive: true });
+  writeFileSync(markerPath, `${stoppedAt}\n${process.pid}\n`, { mode: 0o600 });
+  return stoppedAt;
+}
+export function readDaemonStoppedAt(userRoot: string, daemonId: string): string | null {
+  const markerPath = daemonStoppedMarkerPath(userRoot, daemonId);
+  if (!existsSync(markerPath)) return null;
+  return readFileSync(markerPath, "utf8").split("\n", 1)[0] || null;
+}
+export function clearDaemonStoppedMarker(userRoot: string, daemonId: string): void {
+  rmSync(daemonStoppedMarkerPath(userRoot, daemonId), { force: true });
 }
 export class DaemonAutostartError extends Error {
   readonly code: DaemonAutostartFailureCode;
@@ -103,6 +123,17 @@ export async function ensureLocalDaemonRunning(input: {
 }): Promise<DaemonAutostartResult> {
   const readyTimeoutMs = input.readyTimeoutMs ?? 10_000,
     probeIntervalMs = input.probeIntervalMs ?? 50;
+  const launched = input.launch(),
+    target = daemonLaunchTarget(launched);
+  if (!target) throw new Error("daemon launch spec does not declare its --user-root and --daemon-id");
+  const stoppedAt = readDaemonStoppedAt(target.userRoot, target.daemonId);
+  if (stoppedAt)
+    return {
+      ok: false,
+      code: "daemon_stopped_by_operator",
+      hint: `The daemon was stopped by the operator at ${stoppedAt}. Run \`ha daemon start --service\` to start it.`,
+      attempts: 0,
+    };
   const probe = input.probe ?? daemonSocketProbe,
     spawnDetached =
       input.spawnDetached ??
@@ -122,15 +153,11 @@ export async function ensureLocalDaemonRunning(input: {
     return probe(input.socketPath);
   };
   if (await ready()) return { ok: true, hint: "daemon is reachable", attempts: 0 };
-  let launched: DaemonLaunchSpec | null = null,
-    flight: Awaited<ReturnType<typeof acquireDaemonAutostartFlight>> | null = null,
+  let flight: Awaited<ReturnType<typeof acquireDaemonAutostartFlight>> | null = null,
     spawned = false,
     latestProgress: DaemonStartProgress | null = null,
     reported = "";
   try {
-    launched = input.launch();
-    const target = daemonLaunchTarget(launched);
-    if (!target) throw new Error("daemon launch spec does not declare its --user-root and --daemon-id");
     const refusal = await daemonHostStartRefusal({ invokingRoot: input.invokingRoot, userRoot: target.userRoot });
     if (refusal) return { ok: false, ...refusal, attempts: 0 };
     flight = await acquireDaemonAutostartFlight(target);

--- a/packages/daemon/src/client/daemon-autostart.ts
+++ b/packages/daemon/src/client/daemon-autostart.ts
@@ -123,17 +123,6 @@ export async function ensureLocalDaemonRunning(input: {
 }): Promise<DaemonAutostartResult> {
   const readyTimeoutMs = input.readyTimeoutMs ?? 10_000,
     probeIntervalMs = input.probeIntervalMs ?? 50;
-  const launched = input.launch(),
-    target = daemonLaunchTarget(launched);
-  if (!target) throw new Error("daemon launch spec does not declare its --user-root and --daemon-id");
-  const stoppedAt = readDaemonStoppedAt(target.userRoot, target.daemonId);
-  if (stoppedAt)
-    return {
-      ok: false,
-      code: "daemon_stopped_by_operator",
-      hint: `The daemon was stopped by the operator at ${stoppedAt}. Run \`ha daemon start --service\` to start it.`,
-      attempts: 0,
-    };
   const probe = input.probe ?? daemonSocketProbe,
     spawnDetached =
       input.spawnDetached ??
@@ -153,13 +142,25 @@ export async function ensureLocalDaemonRunning(input: {
     return probe(input.socketPath);
   };
   if (await ready()) return { ok: true, hint: "daemon is reachable", attempts: 0 };
-  let flight: Awaited<ReturnType<typeof acquireDaemonAutostartFlight>> | null = null,
+  let launched: DaemonLaunchSpec | null = null,
+    flight: Awaited<ReturnType<typeof acquireDaemonAutostartFlight>> | null = null,
     spawned = false,
     latestProgress: DaemonStartProgress | null = null,
     reported = "";
   try {
+    launched = input.launch();
+    const target = daemonLaunchTarget(launched);
+    if (!target) throw new Error("daemon launch spec does not declare its --user-root and --daemon-id");
     const refusal = await daemonHostStartRefusal({ invokingRoot: input.invokingRoot, userRoot: target.userRoot });
     if (refusal) return { ok: false, ...refusal, attempts: 0 };
+    const stoppedAt = readDaemonStoppedAt(target.userRoot, target.daemonId);
+    if (stoppedAt)
+      return {
+        ok: false,
+        code: "daemon_stopped_by_operator",
+        hint: `The daemon was stopped by the operator at ${stoppedAt}. Run \`ha daemon start --service\` to start it.`,
+        attempts: 0,
+      };
     flight = await acquireDaemonAutostartFlight(target);
     // The probe belongs inside the claim: another caller may have bound the
     // socket between this process's initial probe and atomic lock creation.

--- a/tools/smoke-cli-package.mjs
+++ b/tools/smoke-cli-package.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import { execFileSync, spawnSync } from "node:child_process";
-import { chmodSync, existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -59,11 +59,19 @@ export function runCliPackageSmoke(root = process.cwd()) {
     expectOk(runJson(binPath, ["--root", projectDir, "--json", "task", "submit", "task-smoke", "--execution-id", "execution-smoke", "--from-file", "submission.json"], projectDir, env(userRoot, home)), "task submit");
     expectOk(runJson(binPath, ["--root", projectDir, "--json", "daemon", "status"], projectDir, env(userRoot, home)), "daemon status");
     expectOk(runJson(binPath, ["--root", projectDir, "--json", "daemon", "stop"], projectDir, env(userRoot, home)), "daemon stop"); started = false;
-    // Bounded autostart is the headline behavior: with no explicit daemon left
-    // running, a plain repository command must bring it back and still answer.
+    // An explicit operator stop sticks: a plain repository command is refused by name
+    // instead of resurrecting the daemon (the cold-migration single-writer window).
+    const refused = runJson(binPath, ["--root", projectDir, "--json", "task", "list"], projectDir, env(userRoot, home));
+    if (refused.status === 0 || refused.receipt?.ok !== false || refused.receipt?.code !== "daemon_stopped_by_operator") throw new Error(`task list after an explicit stop must be refused with daemon_stopped_by_operator: ${JSON.stringify(refused)}`);
+    if (existsSync(path.join(userRoot, "daemon-default.pid"))) throw new Error("explicit stop was not sticky: a daemon pid appeared after the refused command");
+    expectOk(runJson(binPath, ["--root", projectDir, "--json", "daemon", "start", "--service"], projectDir, env(userRoot, home)), "daemon start after operator stop"); started = true;
+    // Bounded autostart is the headline behavior for a daemon that died without an operator
+    // stop: kill it outright, then a plain repository command must bring it back and still answer.
+    const killedPid = Number(readFileSync(path.join(userRoot, "daemon-default.pid"), "utf8").trim()); process.kill(killedPid, "SIGKILL");
+    for (const deadline = Date.now() + 10_000; ; ) { try { process.kill(killedPid, 0); } catch { break; } if (Date.now() > deadline) throw new Error(`daemon ${killedPid} survived SIGKILL for 10s`); Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 100); }
     expectOk(runJson(binPath, ["--root", projectDir, "--json", "task", "list"], projectDir, env(userRoot, home)), "task list after auto-start"); started = true;
     expectOk(runJson(binPath, ["--root", projectDir, "--json", "daemon", "stop"], projectDir, env(userRoot, home)), "daemon stop after auto-start"); started = false;
-    console.log(`CLI package smoke passed: npm-pack consumer bootstrap + lifecycle + auto-start; unstartable-daemon rejection=${unstartableMs === null ? "skipped" : `${unstartableMs.toFixed(3)}ms`}.`);
+    console.log(`CLI package smoke passed: npm-pack consumer bootstrap + lifecycle + sticky operator stop + auto-start after kill; unstartable-daemon rejection=${unstartableMs === null ? "skipped" : `${unstartableMs.toFixed(3)}ms`}.`);
   } finally {
     if (started && binPath) run(binPath, ["--root", projectDir, "--json", "daemon", "stop"], projectDir, env(userRoot, home));
     rmSync(tempRoot, { recursive: true, force: true });

--- a/tools/write-road-registry.json
+++ b/tools/write-road-registry.json
@@ -48,6 +48,7 @@
     "packages/daemon/src/agent-runtime-instance-storage.ts",
     "packages/daemon/src/agent-runtime-instance-store.ts",
     "packages/daemon/src/ci-observation-actions.ts",
+    "packages/daemon/src/client/daemon-autostart.ts",
     "packages/daemon/src/daemon-singleton.ts",
     "packages/daemon/src/dispatch-stream.ts",
     "packages/daemon/src/doc-sync-candidate-scanner.ts",


### PR DESCRIPTION
# English

## Summary

After an operator runs `ha daemon stop` (cooperative or `--force`), no client autostart may bring the daemon back until an explicit `ha daemon start --service` or `ha daemon serve`. The stop writes a marker beside the daemon pid file; the autostart client refuses with the named code `daemon_stopped_by_operator` before probing or spawning; explicit start clears the marker. A daemon that exits on its own (build-drift drain, crash, SIGKILL) leaves no marker, so the existing replacement-on-next-command behaviour is unchanged.

This is a correctness precondition of the cold-migration ruling dec_E8C80116F3E38A128B87785C23 (backup, stop, offline conversion, reconciliation, cold restart): during conversion and reconciliation the migration tool must be the only writer, and a concurrent client request must not resurrect the daemon through `withAutostart`. The 2026-09-06 maintenance window showed the daemon reappearing 0.4 s, 5 s and 14 min after three explicit stops.

## Architectural Justification

-

## What Changed

- `packages/daemon/src/client/daemon-autostart.ts`: `daemon_stopped_by_operator` failure code; marker path/read/write/clear helpers next to the pid file; `ensureLocalDaemonRunning` refuses before any socket probe or spawn when the marker exists.
- `packages/cli/src/daemon/control.ts`: `stop` writes the marker before requesting cooperative or forced shutdown; `start --service` and `serve` clear it; `status` on an unavailable daemon reports `not running (stopped by operator at <ISO time>)`.
- `packages/cli/test/daemon-autostart-cli.test.ts`: stop refusal, status wording, explicit-start recovery, and a SIGKILL negative control proving autostart still works when the daemon dies without an operator stop.
- `tools/smoke-cli-package.mjs` (protected gate script): the packaged-CLI smoke encoded the old headline "a plain command resurrects the daemon after `daemon stop`", which is exactly the behaviour this change removes. It now asserts the `daemon_stopped_by_operator` refusal with no pid file appearing, starts the daemon explicitly, then proves bounded autostart after a SIGKILL. The status fallback also calls `consumeKnownError` (lint `ha/no-swallowed-failure`).
- Round 2: `stop` writes the marker only after a daemon pid exists, so a cold `daemon stop` creates no state (G20 platform-smoke; new CLI test); the autostart client keeps its original order (socket probe, then launch-target and canonical/worktree refusals, then the marker check right before spawn); `with-autostart.ts` returns `daemon_stopped_by_operator` fast after a connection failure when it already knows userRoot/daemonId; `tools/write-road-registry.json` declares the marker file as the physical write sink of `daemon-autostart.ts`.
- Round 3: `ha daemon status` exits non-zero for the operator-stop report like every other unavailable answer (G34 first-run lane polls that exit code); `daemon_stopped_by_operator` is registered in `thinCliLocalErrorCodes` (check-cli-error-codes).

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: use the single CI-backed `Production-Delta` declaration below; do not enter a second metric.

## Machine-Readable Declarations

Production-Delta: +83/-12

## Task And Scope

- Harness task: task_66a88bdfcd85616d28d799c8ce (derives from dec_E8C80116F3E38A128B87785C23)
- Branch: `codex/daemon-stop-sticky`
- Public scope: daemon autostart client, CLI daemon stop/start/status, their CLI contract test
- Private planning/evidence updated: yes
- Out of scope: GUI presentation of the stopped state; fleet center state

## Version Impact

- Version: no version change because the release version is set by the release task
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: yes
- Protected surface scope: `tools/smoke-cli-package.mjs` (smoke-cli-package gate script); the gate's intent (packaged CLI bootstrap + lifecycle + bounded autostart) is kept, only the precondition for autostart moves from "after an explicit stop" to "after the daemon died without an operator stop"
- Authority: dec_E8C80116F3E38A128B87785C23 (cold-migration ruling; the sticky stop is its single-writer guard, relation rel_de987bd0d672a440), task_66a88bdfcd85616d28d799c8ce
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: e0859e09929099b89e0d277967344b0f236aee3e
- Branch merge-base with `origin/main`: e0859e09929099b89e0d277967344b0f236aee3e
- Last `git fetch origin` time: 2026-09-06T05:54Z
- Sync method: none needed
- Public diff command: `git diff --stat origin/main...codex/daemon-stop-sticky`
- Private evidence commit/path: task package `artifacts/reports/worker-report.md`, fact F-BC8FEC66, F-98F69299
- Reviewer evidence path: task package `artifacts/missions/review-terra-*.md` after CI
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Not run: full `npm test` / `check:local` by policy (GitHub CI is the complete authority). Targeted: `packages/daemon/test/daemon-autostart.test.ts` 15/15 locally; `packages/cli/test/daemon-autostart-cli.test.ts` 14/14 on the isolated Ubuntu target (round 3 rerun); `tools/gates/line-density.mjs` and `production-delta.mjs` pass; `npm run harness:smoke-cli-package` PASS locally after the smoke change.

## Review Evidence

- Self-review: CEO read of the marker placement (refusal sits in the same seam as `daemon_start_runtime_forbidden`), the stop-before-request ordering and the SIGKILL negative control
- Reviewer subagent: Terra reviewer round after CI (recorded in the task package)
- Human review: peer CEO ruled the sticky stop is part of the cold-migration single-writer closure
- Blocking findings: none open

## Residual Risk

- A malformed or unreadable marker surfaces as a filesystem error rather than being ignored (intentional fail-closed).
- The GUI shows the daemon as unavailable while the marker exists; it has no start button yet, so recovery is `ha daemon start --service` from a shell.

## References

- Task: task_66a88bdfcd85616d28d799c8ce
- Evidence: task package `artifacts/reports/worker-report.md`; facts F-98F69299 (premise correction), F-BC8FEC66 (before/after)
- Review: dec_E8C80116F3E38A128B87785C23 cold-migration ruling

---

# 中文

## 概要

操作者显式执行 `ha daemon stop`(协作停或 `--force`)之后,任何客户端的 autostart 都不得把 daemon 拉起来,直到显式 `ha daemon start --service` 或 `ha daemon serve`。stop 在 pid 文件旁写一个标记;autostart 客户端在探测或 spawn 之前以具名码 `daemon_stopped_by_operator` 拒绝;显式 start 清除标记。daemon 自行退出(build-drift 排空自退、崩溃、SIGKILL)不留标记,现有「下一条命令自动起替代」的行为不变。

这是冷迁移裁决 dec_E8C80116F3E38A128B87785C23(备份 → 停机 → 离线转换 → 对账 → 冷启动)的正确性前置:转换与对账窗口内迁移工具必须是唯一 writer,并发客户端请求不得经 `withAutostart` 复活 daemon。2026-09-06 维护窗口三次显式 stop 之后 daemon 分别在 0.4 s、5 s、14 min 内重新出现。

## 架构辩护

-

## 改动内容

- `packages/daemon/src/client/daemon-autostart.ts`:新增 `daemon_stopped_by_operator` 失败码;pid 文件旁的标记路径/读/写/清除;`ensureLocalDaemonRunning` 在任何 socket 探测或 spawn 之前遇标记即拒绝。
- `packages/cli/src/daemon/control.ts`:`stop` 在发出协作或强制停止之前写标记;`start --service` 与 `serve` 清除;daemon 不可用时 `status` 报 `not running (stopped by operator at <ISO 时刻>)`。
- `packages/cli/test/daemon-autostart-cli.test.ts`:stop 拒绝、status 文案、显式 start 恢复,以及 SIGKILL 负对照(无操作者 stop 时 autostart 仍工作)。
- `tools/smoke-cli-package.mjs`(protected 门脚本):打包 CLI 的 smoke 把「`daemon stop` 之后一条普通命令把 daemon 拉回来」当作 headline 行为,而这正是本变更移除的行为。现改为断言 `daemon_stopped_by_operator` 拒绝且不出现 pid 文件、显式 start,再用 SIGKILL 证明有界 autostart 仍工作。status 回退分支补 `consumeKnownError`(lint `ha/no-swallowed-failure`)。
- 第二轮:`stop` 只在存在 daemon pid 时才写标记,冷 `daemon stop` 不创建任何状态(G20 platform-smoke;新增 CLI 测试);autostart 客户端恢复原顺序(先探测 socket,再解析 launch target 与 canonical/worktree 拒绝,标记检查紧贴 spawn 之前);`with-autostart.ts` 在连接失败且已知 userRoot/daemonId 时快速返回 `daemon_stopped_by_operator`;`tools/write-road-registry.json` 把标记文件登记为 `daemon-autostart.ts` 的物理写。
- 第三轮:操作者停机报告下 `ha daemon status` 与其它不可用回答一样非零退出(G34 first-run 门轮询该退出码);`daemon_stopped_by_operator` 登记进 `thinCliLocalErrorCodes`(check-cli-error-codes)。

## 门收割 / Gate Harvest

- 删除的生产路径:none
- 同 commit 删除的门 / fixture:none
- 生产净行数:引用英文块中的 `Production-Delta`。

## 机读声明说明

- 机读声明只在英文块出现一次,顶格书写。

## 任务与范围

- Harness 任务:task_66a88bdfcd85616d28d799c8ce(derives 于 dec_E8C80116F3E38A128B87785C23)
- 分支:`codex/daemon-stop-sticky`
- 公开范围:daemon autostart 客户端、CLI daemon stop/start/status 及其 CLI 契约测试
- 私有计划 / 证据是否已更新:yes
- 范围外:GUI 对停机态的展示;fleet center 状态

## 版本影响

- 版本:不改版本,原因是发版版本号由 release task 统一设定
- 发布影响:不发布

## 治理声明

- 是否触碰 protected surface:yes
- protected surface 范围:`tools/smoke-cli-package.mjs`(smoke-cli-package 门脚本);门的意图(打包 CLI 引导 + 生命周期 + 有界 autostart)不变,只把 autostart 的前置从「显式 stop 之后」改为「daemon 非操作者停机死亡之后」
- 依据:dec_E8C80116F3E38A128B87785C23(冷迁移裁决;粘性 stop 是其单写守卫,关系 rel_de987bd0d672a440)、task_66a88bdfcd85616d28d799c8ce
- 机器检查边界:本 PR 只声明该段存在;是否真实、充分由 reviewer 判断。
- Break-glass:no
- Break-glass 原因:不适用
- Break-glass 范围:不适用
- 后续治理任务:不适用

## 验证

- `origin/main` 基准 SHA:e0859e09929099b89e0d277967344b0f236aee3e
- 当前分支与 `origin/main` 的 merge-base:e0859e09929099b89e0d277967344b0f236aee3e
- 最近一次 `git fetch origin` 时间:2026-09-06T05:54Z
- 同步方式:不需要
- 公开 diff 命令:`git diff --stat origin/main...codex/daemon-stop-sticky`
- 私有证据 commit/path:任务包 `artifacts/reports/worker-report.md`、fact F-BC8FEC66、F-98F69299
- Reviewer 证据路径:同一任务包 `artifacts/missions/review-terra-*.md`(CI 后)
- GitHub Actions `rewrite-ci` run URL:待本 PR 运行
- [ ] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- 未运行:按纪律不跑全量 `npm test` / `check:local`(GitHub CI 是完整权威)。定向:`packages/daemon/test/daemon-autostart.test.ts` 本地 15/15;`packages/cli/test/daemon-autostart-cli.test.ts` 隔离 Ubuntu 14/14(第三轮复跑);`tools/gates/line-density.mjs` 与 `production-delta.mjs` 通过;smoke 改动后本地 `npm run harness:smoke-cli-package` PASS。

## 审查证据

- 自查:CEO 细读标记落点(与 `daemon_start_runtime_forbidden` 同一拒绝缝)、stop 先写标记再发请求的顺序、SIGKILL 负对照
- Reviewer subagent:CI 后 Terra 复核一轮(记录在任务包)
- 人工审查:对等 CEO 裁定粘性 stop 属于冷迁移单写闭包
- 阻塞发现:无

## 残余风险

- 标记损坏或不可读时按文件系统错误暴露而不是忽略(有意 fail-closed)。
- 标记存在期间 GUI 只显示 daemon 不可用、尚无启动按钮,恢复靠 shell 里 `ha daemon start --service`。

## 关联材料

- 任务:task_66a88bdfcd85616d28d799c8ce
- 证据:任务包 `artifacts/reports/worker-report.md`;fact F-98F69299(前提修正)、F-BC8FEC66(修复前后对照)
- 审查:dec_E8C80116F3E38A128B87785C23 冷迁移裁决

---

## PR Gate Checklist / PR 门禁清单

- [x] Branch is based on latest `origin/main`. / 分支基于最新 `origin/main`。
- [x] PR body uses this full template structure. / PR 描述使用本模板完整结构。
- [x] PR body uses two complete language blocks: `# English` first, then `# 中文`. / PR 正文使用两块完整正文:`# English` 在上,`# 中文` 在下。
- [x] PR body passes `tools/check-pr-body-bilingual.mjs`. / PR 正文通过 `tools/check-pr-body-bilingual.mjs`。
- [x] If the PR touches a manifest-derived protected surface, Governance Declaration is filled with ADR/decision/task evidence or break-glass fields. / 若 PR 触碰 manifest 派生的 protected surface,Governance Declaration 已填写 ADR/decision/task 依据或 break-glass 字段。
- [x] No private harness files are included. / 不包含私有 harness 文件。
- [x] No ignored local agent entry files are included. / 不包含被忽略的本地 agent 入口文件。
- [x] No absolute local filesystem paths are included in this public PR body. / 本公开 PR 描述不包含本机绝对路径。
- [x] Public diff is limited to the stated task scope. / 公开 diff 限于声明的任务范围。
- [x] Private planning/evidence updates are recorded when applicable. / 适用时已记录私有计划 / 证据更新。
- [x] Version and publish impact are stated. / 已说明版本与发布影响。
- [x] Local verification commands are recorded honestly. / 已如实记录本地验证命令。
- [ ] CI results are linked or explained. / CI 结果已链接或说明。
- [x] Review evidence is recorded. / 已记录审查证据。
- [x] Open P0/P1/P2 findings are closed, deferred with owner, or explicitly blocked. / open P0/P1/P2 findings 已关闭、带 owner 延后,或明确阻塞。
- [x] Merge method and post-merge branch cleanup plan are clear. / 合并方式和合并后分支清理计划清楚。
- [x] No admin bypass is planned unless explicitly approved and recorded. / 除非明确批准并记录,否则不计划 admin bypass。
