### PR TITLE
test: pin the pull_request event in the manifest gate runner fixture

### DIFF
--- a/tools/run-manifest-gates.test.mjs
+++ b/tools/run-manifest-gates.test.mjs
@@ -267,6 +267,9 @@ function fixtureCiEnv(root) {
   const observationRoot = path.join(root, "tmp/ci-observation");
   return {
     GITHUB_ACTIONS: "true",
+    // The fixture manifest only declares pullRequestJobs; pin the event so the ambient
+    // GITHUB_EVENT_NAME of a push or schedule run cannot empty the selected gate set.
+    GITHUB_EVENT_NAME: "pull_request",
     GITHUB_JOB: "fast-contract",
     HARNESS_CI_NODE_TEST_RESULTS: path.join(observationRoot, "node-tests.json"),
     HARNESS_CI_VITEST_RESULTS: path.join(observationRoot, "vitest.json"),


### PR DESCRIPTION
# English

## Summary

Fix-forward for the main push lane after #2331: the manifest gate runner resume test pins `GITHUB_EVENT_NAME=pull_request` in its fixture environment. Its fixture manifest only declares `pullRequestJobs`, so once the runner selected gates from the ambient event name, every push and schedule lane (crlf-checkout, node26-compatibility, full-check 24/26 on f3e1d4210) ran the test with an empty plan and failed the `status === 1` assertion. Pull-request lanes were unaffected, which is why #2331 was green.

## Architectural Justification

- Not required: test-only change, 3 production lines of churn or fewer.

## What Changed

- `tools/run-manifest-gates.test.mjs`: `fixtureCiEnv` sets `GITHUB_EVENT_NAME: "pull_request"` with a comment explaining why; verified locally under `push`, `schedule`, `pull_request` and unset (11/11 each). Negative control: main at a01c65904 (before #2331) passes the same test under `push`, so the regression is #2331's event-aware selection meeting an event-agnostic fixture.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: see the computed production-delta job summary.

## Machine-Readable Declarations

## Task And Scope

- Harness task: task_d8cb00406ff6a6b839092822fb (follow-up to CI cut 2)
- Branch: codex/ci-cut2-fix
- Public scope: tools/run-manifest-gates.test.mjs
- Private planning/evidence updated: yes
- Out of scope: runner behaviour, manifest, workflow

## Version Impact

- Version: no version change because this changes one test fixture only
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none
- Authority: not applicable
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no

---

# 中文

## 摘要

#2331 合入后 main 的 push lane 红,本 PR 前向修复:manifest gate runner 的 resume 测试在夹具环境里钉住 `GITHUB_EVENT_NAME=pull_request`。夹具 manifest 只声明了 `pullRequestJobs`,runner 改为按环境事件名选门后,所有 push / schedule lane(f3e1d4210 上的 crlf-checkout、node26-compatibility、full-check 24/26)跑该测试时门集为空,`status === 1` 断言失败;PR lane 不受影响,所以 #2331 本身是绿的。

## 架构说明

- 不需要:纯测试改动。

## 变更内容

- `tools/run-manifest-gates.test.mjs`:`fixtureCiEnv` 设置 `GITHUB_EVENT_NAME: "pull_request"` 并注释原因;本地在 `push`、`schedule`、`pull_request` 与未设置四种情况下各 11/11 通过。阴性对照:#2331 之前的 main(a01c65904)在 `push` 下同一测试通过,回归来自 #2331 的事件感知选门遇上不感知事件的夹具。

## 门收割

- 无删除的生产路径。

## 任务与范围

- Harness 任务:task_d8cb00406ff6a6b839092822fb(CI 第二刀的后续修复)
- 分支:codex/ci-cut2-fix
- 公开范围:tools/run-manifest-gates.test.mjs
- 私有规划/证据已更新:是
- 不在范围:runner 行为、manifest、workflow

## 版本影响

- 版本:不变,只改一个测试夹具
- 发布影响:不发布

## 治理声明

- 触碰 protected surface:否
- 范围:无
- 授权:不适用
- 机器检查边界:本 PR 只断言声明存在;是否成立与充分由评审判断。
- Break-glass:否
