### PR TITLE
perf(kernel): read stopped legacy generations with chunked cat-file --batch

### DIFF
--- a/packages/kernel/src/store/legacy-generation-source.ts
+++ b/packages/kernel/src/store/legacy-generation-source.ts
@@ -30,15 +30,15 @@ export function readStoppedLegacyGeneration(input: { readonly rootInput: Harness
     eventsRoot = ledgerGitPath(ledger, "events"),
     gitHeadBytes = localGitObjectRefStore.readPath(ledger.rootDir, commit, `${eventsRoot}/head.json`),
     gitHead = gitHeadBytes === null ? null : parseLegacyHead(gitHeadBytes.toString("utf8"), "Git"),
-    gitEvents = localGitObjectRefStore
+    eventTree = localGitObjectRefStore
       .listTree(ledger.rootDir, commit, eventsRoot)
-      .filter(({ target }) => target !== `${eventsRoot}/head.json` && target.endsWith(".json"))
+      .filter(({ target }) => target !== `${eventsRoot}/head.json` && target.endsWith(".json")),
+    eventBytes = localGitObjectRefStore.readPaths(ledger.rootDir, commit, eventTree),
+    gitEvents = eventTree
       .map(({ mode, target }) => {
         if (mode !== "100644")
           throw new TaskEventStoreError("invalid_store", `legacy Git event ${target} has invalid mode ${mode}`);
-        const bytes = localGitObjectRefStore.readPath(ledger.rootDir, commit, target);
-        if (bytes === null) throw new TaskEventStoreError("invalid_store", `legacy Git event ${target} disappeared`);
-        const entry = decodeLegacyEventBytes(bytes.toString("utf8"), target),
+        const entry = decodeLegacyEventBytes(eventBytes.get(target)!.toString("utf8"), target),
           fileOpId = path.posix.basename(target).slice(0, -5);
         if (entry.event.opId !== fileOpId)
           throw new TaskEventStoreError("invalid_store", `legacy Git event ${target} does not match its opId`);
@@ -235,11 +235,13 @@ function readStoppedObjects(
   rootDir: string,
 ): readonly { readonly sha256: string; readonly size: number; readonly bytesBase64: string }[] {
   const objects = new Map<string, Buffer>(),
-    prefix = ledgerGitPath(ledger, "objects/sha256");
-  for (const { mode, target } of localGitObjectRefStore.listTree(ledger.rootDir, commit, prefix)) {
+    prefix = ledgerGitPath(ledger, "objects/sha256"),
+    objectTree = localGitObjectRefStore.listTree(ledger.rootDir, commit, prefix),
+    objectBytes = localGitObjectRefStore.readPaths(ledger.rootDir, commit, objectTree);
+  for (const { mode, target } of objectTree) {
     const sha256 = target.slice(prefix.length + 1).replace("/", ""),
-      bytes = localGitObjectRefStore.readPath(ledger.rootDir, commit, target);
-    if (mode !== "100644" || !/^[0-9a-f]{64}$/u.test(sha256) || bytes === null || sha256Bytes(bytes) !== sha256)
+      bytes = objectBytes.get(target)!;
+    if (mode !== "100644" || !/^[0-9a-f]{64}$/u.test(sha256) || sha256Bytes(bytes) !== sha256)
       throw new TaskEventStoreError("invalid_store", `legacy Git content object ${target} is invalid`);
     objects.set(sha256, bytes);
   }

--- a/packages/kernel/src/store/local-version-control-system.ts
+++ b/packages/kernel/src/store/local-version-control-system.ts
@@ -28,7 +28,9 @@ import type { VcsCommitAuthor, VersionControlSystem } from "../ports/version-con
 import { VcsCommandError } from "../ports/version-control-system.ts";
 import { makeLocalVersionControlCommands } from "./local-version-control-commands.ts";
 
-const gitMaxBuffer = 256 * 1024 * 1024;
+const gitMaxBuffer = 256 * 1024 * 1024,
+  gitBatchChunkBytes = 64 * 1024 * 1024,
+  gitBatchChunkEntries = 4_096;
 
 export function makeLocalVersionControlSystem(): VersionControlSystem {
   return makeLocalVersionControlCommands({
@@ -272,7 +274,48 @@ export const localGitObjectRefStore = Object.freeze({
       return false;
     }
   },
-  batch: (repoRoot: string, input: string) => localGitBytes(repoRoot, ["cat-file", "--batch"], Buffer.from(input)),
+  readPaths: (
+    repoRoot: string,
+    commit: string,
+    entries: readonly { readonly target: string; readonly size: number }[],
+  ): ReadonlyMap<string, Buffer> => {
+    // One `cat-file --batch` per bounded chunk instead of one `git show` per path: the
+    // canonical ledger holds ~10^5 event and content blobs, and per-path processes turned
+    // a stopped-generation read into hours.
+    const bytesByTarget = new Map<string, Buffer>();
+    let chunk: { readonly target: string; readonly size: number }[] = [],
+      chunkBytes = 0;
+    const flush = () => {
+      if (chunk.length === 0) return;
+      const output = localGitBytes(
+        repoRoot,
+        ["cat-file", "--batch"],
+        Buffer.from(chunk.map(({ target }) => `${commit}:${target}\n`).join("")),
+      );
+      let offset = 0;
+      for (const { target } of chunk) {
+        const newline = output.indexOf(0x0a, offset);
+        if (newline < 0) throw new Error(`Git cat-file --batch output ended before ${target}`);
+        const header = output.subarray(offset, newline).toString("utf8"),
+          size = /^[0-9a-f]{40} blob ([0-9]+)$/u.exec(header)?.[1];
+        if (size === undefined) throw new Error(`Git cat-file --batch could not read ${commit}:${target}: ${header}`);
+        const start = newline + 1,
+          end = start + Number(size);
+        bytesByTarget.set(target, Buffer.from(output.subarray(start, end)));
+        offset = end + 1;
+      }
+      chunk = [];
+      chunkBytes = 0;
+    };
+    for (const entry of entries) {
+      if (chunk.length > 0 && (chunkBytes + entry.size > gitBatchChunkBytes || chunk.length >= gitBatchChunkEntries))
+        flush();
+      chunk.push(entry);
+      chunkBytes += entry.size;
+    }
+    flush();
+    return bytesByTarget;
+  },
   writeBlob: (repoRoot: string, body: string) => {
     const oid = localGitBytes(repoRoot, ["hash-object", "-w", "--stdin"], Buffer.from(body)).toString("utf8").trim();
     if (!/^[0-9a-f]{40}$/u.test(oid)) throw new Error("Git hash-object returned no blob object id");
@@ -282,8 +325,13 @@ export const localGitObjectRefStore = Object.freeze({
     repoRoot: string,
     commit: string,
     target?: string,
-  ): readonly { readonly mode: "100644" | "120000"; readonly oid: string; readonly target: string }[] => {
-    const output = localGitBytes(repoRoot, ["ls-tree", "-r", "-z", commit, ...(target ? ["--", target] : [])]);
+  ): readonly {
+    readonly mode: "100644" | "120000";
+    readonly oid: string;
+    readonly size: number;
+    readonly target: string;
+  }[] => {
+    const output = localGitBytes(repoRoot, ["ls-tree", "-r", "-l", "-z", commit, ...(target ? ["--", target] : [])]);
     return output
       .toString("utf8")
       .split("\0")
@@ -292,12 +340,13 @@ export const localGitObjectRefStore = Object.freeze({
         const tab = record.indexOf("\t"),
           header = tab < 0 ? "" : record.slice(0, tab),
           logical = tab < 0 ? "" : record.slice(tab + 1);
-        const [mode, type, oid] = header.split(" ");
+        const [mode, type, oid, size] = header.trim().split(/\s+/u);
         return (mode === "100644" || mode === "120000") &&
           type === "blob" &&
           /^[0-9a-f]{40}$/u.test(oid ?? "") &&
+          /^[0-9]+$/u.test(size ?? "") &&
           logical
-          ? [{ mode, oid: oid!, target: logical }]
+          ? [{ mode, oid: oid!, size: Number(size), target: logical }]
           : [];
       });
   },


### PR DESCRIPTION
> Fill this PR body as two complete language blocks: English first, then `---`, then Chinese.

# English

## Summary

`readStoppedLegacyGeneration` spawned one `git show` per legacy event and per content object. On the canonical ledger (61,570 event blobs plus 43,802 content blobs) that is roughly 105k processes; the first canonical backup rehearsal ran for 20 minutes at about 1.8 spawns per second and projected to 16 hours before it was stopped. The stopped-generation read now lists blob sizes once (`ls-tree -l`) and reads the listed blobs through `cat-file --batch` in bounded chunks. The same canonical read completes in 20 seconds with 33 git processes and returns the same 61,569 events, 43,802 objects and head revision.

## Architectural Justification

- Not required: production churn is under 200 lines. The batch reader replaces the unused `batch` primitive on `localGitObjectRefStore` rather than adding a parallel read path.

## What Changed

- `packages/kernel/src/store/local-version-control-system.ts`: `listTree` runs `ls-tree -r -l -z` and returns each blob's `size`; new `readPaths(repoRoot, commit, entries)` reads listed blobs with `cat-file --batch` in chunks bounded by 64 MB / 4,096 entries and fails closed on a missing or non-blob record; the never-called `batch` primitive is deleted.
- `packages/kernel/src/store/legacy-generation-source.ts`: event and content-object reads go through `readPaths` instead of one `readPath` per file; mode, opId, sha256 and canonical-bytes checks are unchanged.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: use the single CI-backed `Production-Delta` declaration below; do not enter a second metric.

## Machine-Readable Declarations

Production-Delta: +0/-0

## Task And Scope

- Harness task: task_fefeeeecfb8f1b7a69c0d18e6c
- Branch: `codex/legacy-batch-read`
- Public scope: kernel store legacy-generation read path only
- Private planning/evidence updated: yes
- Out of scope: backup/restore CLI surface, generation-1 conversion semantics, the unexplained per-spawn overhead observed inside the backup process (batching removes the dependency on it)

## Version Impact

- Version: no version change because this is an internal read-path performance fix
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none
- Authority: not applicable
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: 403deddb7716e524ca4ed954dce29da05743a9c4
- Branch merge-base with `origin/main`: 403deddb7716e524ca4ed954dce29da05743a9c4
- Last `git fetch origin` time: 2026-09-06T13:31Z
- Sync method: none needed
- Public diff command: `git diff origin/main...codex/legacy-batch-read`
- Private evidence commit/path: harness task package (see Task And Scope)
- Reviewer evidence path: CEO self-review in the task package
- GitHub Actions `rewrite-ci` run URL: pending
- [x] `node tools/run-node-tests.mjs --file packages/kernel/test/store/ledger-backup.integration.test.ts --file packages/daemon/test/legacy-generation-conversion.integration.test.ts --file packages/kernel/test/store/local-version-control-settlement.test.ts` (13 pass)
- [x] `node tools/run-manifest-gates.mjs --changed origin/main` (passed)
- [x] Canonical-scale read of the stopped legacy generation through the new path: 61,569 events, 43,802 objects, 20 s, 33 git processes (was projected 16 h)
- [ ] GitHub Actions `rewrite-ci` passed
- Not run: full `npm test` / `npm run check` locally; GitHub CI is the authority.

## Review Evidence

- Self-review: CEO read of both diffs; batch parsing verified against canonical output (size header regex, trailing newline per record).
- Reviewer subagent: none
- Human review: pending
- Blocking findings: none

## Residual Risk

- Chunk bounds (64 MB / 4,096 entries) are constants; the largest canonical blob is 20 MB, well under the 256 MB git buffer.

## References

- Task: task_fefeeeecfb8f1b7a69c0d18e6c
- Evidence: canonical-scale timing in the task package
- Review: this PR

---

# 中文

## 概要

`readStoppedLegacyGeneration` 对每个 legacy 事件和每个内容对象各起一个 `git show`。canonical 台账有 61,570 个事件 blob 和 43,802 个内容 blob,约 10.5 万个进程;首次 canonical 备份演练跑了 20 分钟、每秒约 1.8 次 spawn,折算 16 小时,已停掉。现在停机代读取先用 `ls-tree -l` 一次列出 blob 尺寸,再按有界分块用 `cat-file --batch` 读取。同一份 canonical 读取 20 秒完成、33 个 git 进程,返回同样的 61,569 个事件、43,802 个对象与 head revision。

## 架构辩护

- 不需要:生产 churn 低于 200 行。batch 读取替换了 `localGitObjectRefStore` 上从未被调用的 `batch` 原语,不是新增并行读路径。

## 改动内容

- `packages/kernel/src/store/local-version-control-system.ts`:`listTree` 改跑 `ls-tree -r -l -z` 并返回每个 blob 的 `size`;新增 `readPaths(repoRoot, commit, entries)`,按 64 MB / 4,096 条分块用 `cat-file --batch` 读取,缺失或非 blob 记录直接失败;删除从未被调用的 `batch` 原语。
- `packages/kernel/src/store/legacy-generation-source.ts`:事件与内容对象读取改走 `readPaths`,不再逐文件 `readPath`;mode、opId、sha256 与 canonical 字节校验不变。

## 门收割 / Gate Harvest

- 删除的生产路径:none
- 同 commit 删除的门 / fixture:none
- 生产净行数:引用英文块中的 `Production-Delta`。

## 机读声明说明

- 机读声明只在英文块出现一次。

## 任务与范围

- Harness 任务:task_fefeeeecfb8f1b7a69c0d18e6c
- 分支:`codex/legacy-batch-read`
- 公开范围:仅 kernel store 的 legacy 代读取路径
- 私有计划 / 证据是否已更新:yes
- 范围外:backup/restore CLI 面、generation-1 转换语义、备份进程内未查明的单次 spawn 开销(分块后不再依赖它)

## 版本影响

- 版本:不改版本,原因是内部读路径性能修复
- 发布影响:不发布

## 治理声明

- 是否触碰 protected surface:no
- protected surface 范围:无
- 依据:不适用
- 机器检查边界:本 PR 只声明该段存在;是否真实、充分由 reviewer 判断。
- Break-glass:no
- Break-glass 原因:不适用
- Break-glass 范围:不适用
- 后续治理任务:不适用

## 验证

- `origin/main` 基准 SHA:403deddb7716e524ca4ed954dce29da05743a9c4
- 当前分支与 `origin/main` 的 merge-base:403deddb7716e524ca4ed954dce29da05743a9c4
- 最近一次 `git fetch origin` 时间:2026-09-06T13:31Z
- 同步方式:不需要
- 公开 diff 命令:`git diff origin/main...codex/legacy-batch-read`
- 私有证据 commit/path:harness 任务包
- Reviewer 证据路径:任务包内 CEO 自查
- GitHub Actions `rewrite-ci` run URL:待补
- [x] 三份定向测试(13 pass)
- [x] `node tools/run-manifest-gates.mjs --changed origin/main` 通过
- [x] canonical 规模读取:61,569 事件、43,802 对象、20 秒、33 个 git 进程
- [ ] GitHub Actions `rewrite-ci` passed
- 未运行:本地全量 `npm test` / `npm run check`;GitHub CI 是权威。

## 审查证据

- 自查:CEO 通读两处 diff,batch 输出解析已对 canonical 输出核对。
- Reviewer subagent:无
- 人工审查:待定
- 阻塞发现:无

## 残余风险

- 分块上限为常量;canonical 最大 blob 20 MB,远低于 256 MB 的 git 缓冲上限。

## 关联材料

- 任务:task_fefeeeecfb8f1b7a69c0d18e6c
- 证据:任务包内 canonical 规模计时
- 审查:本 PR
