### PR TITLE
fix(kernel): migrate legacy task-embedded relations and review submission digests in generation-1 conversion

### DIFF
--- a/packages/daemon/test/legacy-generation-conversion.integration.test.ts
+++ b/packages/daemon/test/legacy-generation-conversion.integration.test.ts
@@ -16,26 +16,34 @@ import {
   validateScheduleV1,
   convertLegacyGeneration,
   createImmutableLegacyGenerationSnapshot,
+  currentTaskForWrite,
   deriveRelationId,
   makeTaskProjection,
   openSqliteEventStore,
   preflightCanonicalGeneration,
   reconcileSqliteEvents,
   readSettingsFacet,
+  reviewDigest,
   serializeEventHead,
   sha256Bytes,
   sha256Text,
   stableStringify,
+  submissionDigest,
   validateCurrentCanonicalEvent,
   type CanonicalEventV1,
   type CanonicalEventStore,
+  type TaskEventV1,
 } from "../../kernel/src/index.ts";
-import { assertNoPendingHistoricalRewrites } from "../../kernel/test/store/canonical-generation.fixtures.ts";
+import {
+  assertNoPendingHistoricalRewrites,
+  planLegacyGenerationConversion,
+} from "../../kernel/test/store/canonical-generation.fixtures.ts";
 import {
   createImmutableLegacyGenerationSnapshotFromStoppedRepository,
   preflightConvertedGenerationActivation,
 } from "../../kernel/test/store/canonical-generation.fixtures.ts";
 import { sqliteContentObjectPath } from "../../kernel/test/store/canonical-generation.fixtures.ts";
+import { lifecycleFixture } from "../../kernel/test/store/task-lifecycle-fixture.ts";
 import { actor, initRepo } from "./migration-import.fixtures.ts";
 
 test("stopped legacy Git plus accepted WAL suffix converts without a strict reader", () => {
@@ -257,6 +265,22 @@ test("immutable generation-0 conversion retries into inactive generation-1 witho
     assert.equal(seeded.eventBytes, originalBytes);
     const first = convertLegacyGeneration({ rootDir: root, snapshotPath, databasePath });
     assert.equal(first.rewrittenEvents, 1);
+    assert.deepEqual(
+      first.migrationFamilies.map(({ name, count, firstRevision, lastRevision }) => ({
+        name,
+        count,
+        firstRevision,
+        lastRevision,
+      })),
+      [
+        { name: "task-v2-snapshots", count: 0, firstRevision: null, lastRevision: null },
+        { name: "relation-events", count: 0, firstRevision: null, lastRevision: null },
+        { name: "review-submission-pins", count: 0, firstRevision: null, lastRevision: null },
+        { name: "decision-digests", count: 0, firstRevision: null, lastRevision: null },
+        { name: "schedule-definitions", count: 0, firstRevision: null, lastRevision: null },
+        { name: "settings-wal-flush", count: 1, firstRevision: 1, lastRevision: 1 },
+      ],
+    );
     assert.equal(first.migratedEvents, 1);
     assert.equal(first.active, false);
     const second = convertLegacyGeneration({ rootDir: root, snapshotPath, databasePath });
@@ -658,6 +682,177 @@ test("inactive generation conversion witnesses separated legacy relations at the
     rmSync(scratch, { recursive: true, force: true });
   }
 });
+
+test("Task/v2 snapshot migration preserves lifecycle and relation final state", () => {
+  const root = mkdtempSync(path.join(tmpdir(), "ha-generation-task-v2-")),
+    relationIdentity = {
+      source: "task/task-1",
+      target: "task/task-1",
+      type: "depends-on",
+      direction: "directed",
+    } as const,
+    relationId = deriveRelationId(relationIdentity),
+    relation = {
+      relation_id: relationId,
+      ...relationIdentity,
+      strength: "strong",
+      origin: "declared",
+      state: "active",
+      rationale: "Historical hosted relation.",
+    } as const,
+    fixture = lifecycleFixture(),
+    finalTask = fixture.events.at(-1)!.payload.task,
+    legacyRelation = {
+      ...fixture.events.at(-1),
+      eventId: "event-legacy-task-relation",
+      workspaceRevision: 7,
+      opId: "op_legacy_task_relation",
+      type: "task_relation_added",
+      payload: {
+        task: { ...finalTask, relations: [relation] },
+        mutation: { command: "relate", reason: "Historical relation creation.", fields: [relationId] },
+        documentClaims: [],
+      },
+    } as unknown as TaskEventV1,
+    redundantSnapshot = {
+      ...legacyRelation,
+      eventId: "event-legacy-task-snapshot",
+      workspaceRevision: 8,
+      opId: "op_legacy_task_snapshot",
+      type: "task_amended",
+      payload: {
+        task: { ...finalTask, relations: [relation] },
+        mutation: { command: "amend", reason: "Historical redundant snapshot.", fields: [] },
+        documentClaims: [],
+      },
+    } as unknown as TaskEventV1,
+    legacyEvents = [...fixture.events, legacyRelation, redundantSnapshot],
+    plan = planLegacyGenerationConversion({ rootDir: root, store: arrayStore(legacyEvents, () => null) });
+  try {
+    const convertedRelation = plan.events[6]!,
+      convertedSnapshot = plan.events[7]!;
+    assert.equal(convertedRelation.schema, "relation-event/v1");
+    assert.equal(convertedRelation.type, "relation_created");
+    assert.equal(convertedRelation.eventId, legacyRelation.eventId);
+    assert.equal(convertedRelation.opId, legacyRelation.opId);
+    assert.equal(convertedRelation.workspaceRevision, legacyRelation.workspaceRevision);
+    assert.equal(convertedRelation.payload.relation.targetObservedVersion, 6);
+    assert.equal(Object.hasOwn(convertedRelation.payload.relation, "strength"), false);
+    assert.equal(Object.hasOwn(convertedSnapshot.payload.task, "relations"), false);
+    assert.ok(plan.events.every((event) => validateCurrentCanonicalEvent(event).length === 0));
+    assert.deepEqual(migrationFamily(plan, "task-v2-snapshots"), {
+      name: "task-v2-snapshots",
+      count: 2,
+      firstRevision: 7,
+      lastRevision: 8,
+    });
+    assert.deepEqual(migrationFamily(plan, "relation-events"), {
+      name: "relation-events",
+      count: 1,
+      firstRevision: 7,
+      lastRevision: 7,
+    });
+
+    const legacyProjection = makeTaskProjection({
+        rootDir: root,
+        eventStore: arrayStore(legacyEvents, () => null),
+        projectionPath: path.join(root, "legacy.sqlite"),
+      }),
+      convertedProjection = makeTaskProjection({
+        rootDir: root,
+        eventStore: arrayStore(plan.events, () => null),
+        projectionPath: path.join(root, "converted.sqlite"),
+      });
+    try {
+      legacyProjection.rebuild();
+      convertedProjection.rebuild();
+      const legacyLifecycle = legacyProjection.read("task-1").snapshot,
+        convertedLifecycle = convertedProjection.read("task-1").snapshot;
+      assert.deepEqual(
+        {
+          ...convertedLifecycle,
+          task: convertedLifecycle.task === null ? null : currentTaskForWrite(convertedLifecycle.task),
+        },
+        {
+          ...legacyLifecycle,
+          task: legacyLifecycle.task === null ? null : currentTaskForWrite(legacyLifecycle.task),
+        },
+      );
+      assert.deepEqual(
+        convertedProjection.getEntity("relation", relationId),
+        legacyProjection.getEntity("relation", relationId),
+      );
+    } finally {
+      legacyProjection.close();
+      convertedProjection.close();
+    }
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("review submission migration pins only reviews missing the field", () => {
+  const root = mkdtempSync(path.join(tmpdir(), "ha-generation-review-pins-")),
+    fixture = lifecycleFixture(),
+    legacyEvents = fixture.events.map((event) => {
+      if (event.type === "review_recorded") {
+        const { submissionDigest: _legacyPin, ...review } = event.payload.review;
+        return { ...event, payload: { ...event.payload, review } } as unknown as CanonicalEventV1;
+      }
+      if (event.type !== "review_consent_recorded") return event;
+      const { submissionDigest: _legacyReviewPin, ...review } = event.payload.review,
+        { submissionDigest: _legacyConsentPin, ...consent } = event.payload.consent;
+      return {
+        ...event,
+        payload: { ...event.payload, review, consent: { ...consent, reviewDigest: reviewDigest(review as never) } },
+      } as unknown as CanonicalEventV1;
+    }),
+    plan = planLegacyGenerationConversion({ rootDir: root, store: arrayStore(legacyEvents, () => null) });
+  try {
+    const reviewEvent = plan.events.find((event) => event.type === "review_recorded")!,
+      consentEvent = plan.events.find((event) => event.type === "review_consent_recorded")!,
+      expectedPin = submissionDigest(reviewEvent.payload.execution.submission);
+    assert.equal(reviewEvent.payload.review.submissionDigest, expectedPin);
+    assert.equal(consentEvent.payload.review.submissionDigest, expectedPin);
+    assert.equal(consentEvent.payload.consent.submissionDigest, expectedPin);
+    assert.equal(consentEvent.payload.consent.reviewDigest, reviewDigest(consentEvent.payload.review));
+    assert.ok(plan.events.every((event) => validateCurrentCanonicalEvent(event).length === 0));
+    assert.deepEqual(migrationFamily(plan, "review-submission-pins"), {
+      name: "review-submission-pins",
+      count: 2,
+      firstRevision: 4,
+      lastRevision: 5,
+    });
+
+    const amendedPin = `sha256:${"c".repeat(64)}`,
+      currentEvents = fixture.events.map((event) => {
+        if (event.type !== "review_consent_recorded") return event;
+        const review = { ...event.payload.review, submissionDigest: amendedPin };
+        return {
+          ...event,
+          payload: {
+            ...event.payload,
+            review,
+            consent: { ...event.payload.consent, reviewDigest: reviewDigest(review) },
+          },
+        } as CanonicalEventV1;
+      }),
+      currentPlan = planLegacyGenerationConversion({ rootDir: root, store: arrayStore(currentEvents, () => null) }),
+      preserved = currentPlan.events.find((event) => event.type === "review_consent_recorded")!;
+    assert.equal(preserved.payload.review.submissionDigest, amendedPin);
+    assert.equal(preserved.payload.consent.submissionDigest, expectedPin);
+    assert.equal(migrationFamily(currentPlan, "review-submission-pins").count, 0);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+function migrationFamily(
+  plan: ReturnType<typeof planLegacyGenerationConversion>,
+  name: ReturnType<typeof planLegacyGenerationConversion>["migrationFamilies"][number]["name"],
+) {
+  return plan.migrationFamilies.find((family) => family.name === name)!;
+}
 
 function seedLegacySettings(root: string, legacy = true) {
   const body = readFileSync(path.join(root, "harness/harness.yaml"), "utf8"),

--- a/packages/kernel/src/store/event-shape-migration.ts
+++ b/packages/kernel/src/store/event-shape-migration.ts
@@ -7,6 +7,8 @@ import {
 } from "../domain/decision-event-document.ts";
 import type { DecisionEventV1 } from "../domain/decision-event-types.ts";
 import type { CanonicalEventV1 } from "../domain/doc-sync-types.ts";
+import { submissionDigest, type SubmissionV1 } from "../domain/execution.ts";
+import { reviewDigest, type ReviewConsentV1, type ReviewV1 } from "../domain/review.ts";
 import { isSettingsEvent } from "../domain/settings-event.ts";
 import { SETTINGS_REPOSITORY_V1_SCHEMA, type WalFlushSettingsV1 } from "../domain/settings.ts";
 import { isMigrationImportEvent } from "../domain/migration-import-event.ts";
@@ -23,6 +25,9 @@ import {
   type ScheduleV1,
 } from "../domain/schedule.ts";
 import { isRelationEvent } from "../domain/relation-event.ts";
+import { isTaskBootstrapEvent } from "../domain/task-bootstrap-event.ts";
+import { isTaskEvent } from "../domain/doc-sync-canonical-events.ts";
+import { validateTaskV2, type TaskV2 } from "../domain/task.ts";
 import { sha256Text } from "../integrity/stable-hash.ts";
 import { localRuntimeStateFileSystem } from "../local/local-layout-file-system.ts";
 import { makeTaskProjection } from "../projection/rebuildable-task-projection-factory.ts";
@@ -36,12 +41,16 @@ import type { CanonicalContentBlob, CanonicalEventStore } from "./task-event-sto
 // replayed at their historical cuts; the planner neither mutates the source nor publishes into an
 // active store. Conversion validates the complete plan before seeding an inactive destination.
 export type EventShapeMigrationName =
+  | "task-v2-snapshots"
   | "relation-events"
+  | "review-submission-pins"
   | "decision-digests"
   | "schedule-definitions"
   | "settings-wal-flush";
 export type EventShapeMigrationKind =
+  | "task-v2-snapshots-migrate"
   | "relation-events-migrate"
+  | "review-submission-pins-migrate"
   | "decision-digests-migrate"
   | "schedule-definitions-migrate"
   | "settings-wal-flush-migrate";
@@ -70,7 +79,142 @@ export interface LegacyGenerationConversionPlan {
     readonly revision: number;
     readonly category: string;
   }[];
+  readonly migrationFamilies: readonly EventShapeMigrationFamilyReport[];
 }
+
+export interface EventShapeMigrationFamilyReport {
+  readonly name: EventShapeMigrationName;
+  readonly count: number;
+  readonly firstRevision: number | null;
+  readonly lastRevision: number | null;
+}
+
+function asTaskBootstrapEvent(event: CanonicalEventV1) {
+  return isTaskBootstrapEvent(event) ? event : null;
+}
+
+function taskWithRetiredRelations(event: CanonicalEventV1): {
+  readonly task: TaskV2;
+  readonly relations: readonly Readonly<Record<string, unknown>>[];
+} | null {
+  const carrier = isTaskEvent(event) ? event : asTaskBootstrapEvent(event);
+  if (carrier === null) return null;
+  const task = carrier.payload.task as TaskV2 & { readonly relations?: unknown };
+  if (!Object.hasOwn(task, "relations")) return null;
+  const { relations, ...current } = task;
+  if (!Array.isArray(relations) || validateTaskV2(current).length > 0) return null;
+  return {
+    task,
+    relations: relations as readonly Readonly<Record<string, unknown>>[],
+  };
+}
+
+const taskV2SnapshotsMigration: EventShapeMigrationSpec = {
+  name: "task-v2-snapshots",
+  // A non-empty carrier reads the relation aggregate at the pre-event cut. In particular,
+  // task_relation_added becomes the canonical relation event before later snapshots drop the
+  // retired hosted field.
+  matches: (event) => (taskWithRetiredRelations(event)?.relations.length ?? 0) > 0,
+  rewrite: (event, cut) => {
+    const legacy = taskWithRetiredRelations(event);
+    if (legacy === null) return null;
+    const { relations: _retiredRelations, ...task } = legacy.task as TaskV2 & {
+      readonly relations: readonly Readonly<Record<string, unknown>>[];
+    };
+    if (legacy.relations.length === 0)
+      return {
+        event: { ...event, payload: { ...event.payload, task } } as CanonicalEventV1,
+        category: "retired empty Task.relations dropped",
+        before: legacy.task,
+        after: task,
+      };
+    if (!isTaskEvent(event))
+      throw new Error(`task snapshot ${event.opId} carries non-empty relations without a task lifecycle mutation`);
+    if (event.type === "task_relation_added") {
+      const addedIds = new Set(event.payload.mutation.fields),
+        added = legacy.relations.filter((relation) => addedIds.has(String(relation.relation_id))),
+        carried = legacy.relations.filter((relation) => !addedIds.has(String(relation.relation_id)));
+      if (added.length !== 1)
+        throw new Error(`task relation event ${event.opId} must identify exactly one added relation`);
+      assertRelationsExistAtCut(carried, cut, event.opId);
+      const relation = added[0]!,
+        relationId = String(relation.relation_id);
+      return {
+        event: {
+          schema: "relation-event/v1",
+          eventId: event.eventId,
+          workspaceRevision: event.workspaceRevision,
+          opId: event.opId,
+          relationId,
+          type: "relation_created",
+          actor: event.actor,
+          source: event.source,
+          occurredAt: event.occurredAt,
+          payload: { relation },
+        } as CanonicalEventV1,
+        category: "embedded task relation promoted to canonical relation_created",
+        before: event,
+        after: { relationId, relation },
+      };
+    }
+    assertRelationsExistAtCut(legacy.relations, cut, event.opId);
+    return {
+      event: { ...event, payload: { ...event.payload, task } } as CanonicalEventV1,
+      category: "retired Task.relations dropped after canonical relation event",
+      before: legacy.task,
+      after: task,
+    };
+  },
+};
+
+function assertRelationsExistAtCut(
+  relations: readonly Readonly<Record<string, unknown>>[],
+  cut: EventShapeCut,
+  opId: string,
+): void {
+  const missing = relations
+    .map((relation) => String(relation.relation_id))
+    .filter((relationId) => cut.readEntityVersionWitness(`relation/${relationId}`).currentVersion === null);
+  if (missing.length > 0)
+    throw new Error(`task snapshot ${opId} carries relations not present at its historical cut: ${missing.join(", ")}`);
+}
+
+const reviewSubmissionPinsMigration: EventShapeMigrationSpec = {
+  name: "review-submission-pins",
+  matches: () => false,
+  rewrite: (event) => {
+    if (!isTaskEvent(event) || (event.type !== "review_recorded" && event.type !== "review_consent_recorded"))
+      return null;
+    const review = event.payload.review as ReviewV1;
+    if (Object.hasOwn(review, "submissionDigest")) return null;
+    const submission = event.payload.execution.submission as SubmissionV1 | null;
+    if (submission === null) throw new Error(`review event ${event.opId} has no submitted execution to pin`);
+    const pin = submissionDigest(submission),
+      pinnedReview = { ...review, submissionDigest: pin };
+    if (event.type === "review_recorded")
+      return {
+        event: { ...event, payload: { ...event.payload, review: pinnedReview } } as CanonicalEventV1,
+        category: "review submission digest pinned",
+        before: review,
+        after: pinnedReview,
+      };
+    const consent = event.payload.consent as ReviewConsentV1,
+      pinnedConsent = {
+        ...consent,
+        reviewDigest: reviewDigest(pinnedReview),
+        ...(Object.hasOwn(consent, "submissionDigest") ? {} : { submissionDigest: pin }),
+      };
+    return {
+      event: {
+        ...event,
+        payload: { ...event.payload, review: pinnedReview, consent: pinnedConsent },
+      } as CanonicalEventV1,
+      category: "review and consent submission digests pinned",
+      before: { review, consent },
+      after: { review: pinnedReview, consent: pinnedConsent },
+    };
+  },
+};
 
 const relationEventsMigration: EventShapeMigrationSpec = {
   name: "relation-events",
@@ -304,7 +448,9 @@ const scheduleDefinitionsMigration: EventShapeMigrationSpec = {
 };
 
 export const eventShapeMigrations: Readonly<Record<EventShapeMigrationKind, EventShapeMigrationSpec>> = {
+  "task-v2-snapshots-migrate": taskV2SnapshotsMigration,
   "relation-events-migrate": relationEventsMigration,
+  "review-submission-pins-migrate": reviewSubmissionPinsMigration,
   "decision-digests-migrate": decisionDigestsMigration,
   "schedule-definitions-migrate": scheduleDefinitionsMigration,
   "settings-wal-flush-migrate": settingsWalFlushMigration,
@@ -321,27 +467,8 @@ export function planLegacyGenerationConversion(input: {
 }): LegacyGenerationConversionPlan {
   const head = input.store.readHead(),
     headRevision = head?.revision ?? 0,
-    byOpId = new Map(input.store.read().events.map((event) => [event.opId, event])),
-    blobs = new Map<string, CanonicalContentBlob>(),
-    rewrites: LegacyGenerationConversionPlan["rewrites"][number][] = [];
-  for (const spec of Object.values(eventShapeMigrations)) {
-    const planned = replayRewrites(spec, input, headRevision, head);
-    for (const rewrite of planned) {
-      byOpId.set(rewrite.event.opId, rewrite.event);
-      for (const blob of rewrite.blobs ?? []) blobs.set(blob.sha256, blob);
-      rewrites.push({
-        migration: spec.name,
-        opId: rewrite.event.opId,
-        revision: rewrite.event.workspaceRevision,
-        category: rewrite.category,
-      });
-    }
-  }
-  return {
-    events: [...byOpId.values()].sort((left, right) => left.workspaceRevision - right.workspaceRevision),
-    blobs: [...blobs.values()],
-    rewrites,
-  };
+    replayed = replayRewrites(input, headRevision, head);
+  return { ...replayed, migrationFamilies: summarizeMigrationFamilies(replayed.rewrites) };
 }
 
 export function assertNoPendingHistoricalRewrites(input: {
@@ -360,17 +487,16 @@ export function assertNoPendingHistoricalRewrites(input: {
 const BULK_ROUND_LIMIT = 4096;
 
 function replayRewrites(
-  spec: EventShapeMigrationSpec,
   input: { readonly rootDir: string; readonly store: CanonicalEventStore },
   headRevision: number,
   head: ReturnType<CanonicalEventStore["readHead"]>,
-): readonly EventShapeRewrite[] {
-  const rewrites: EventShapeRewrite[] = [],
-    scratchPath = path.join(tmpdir(), `ha-${spec.name}-${process.pid}-${Date.now()}.sqlite`),
-    pending: CanonicalEventV1[] = [],
-    syntheticBlobs = new Map<string, Uint8Array>();
-  let cap = 0,
-    cursor: string | null = null,
+): Pick<LegacyGenerationConversionPlan, "events" | "blobs" | "rewrites"> {
+  const events: CanonicalEventV1[] = [],
+    blobs = new Map<string, CanonicalContentBlob>(),
+    rewrites: LegacyGenerationConversionPlan["rewrites"][number][] = [],
+    scratchPath = path.join(tmpdir(), `ha-event-shapes-${process.pid}-${Date.now()}.sqlite`),
+    pending: CanonicalEventV1[] = [];
+  let cursor: string | null = null,
     exhausted = false,
     prefetchContent: ReturnType<CanonicalEventStore["readBatch"]>["prefetchContent"],
     projection: TaskProjection | null = null;
@@ -384,55 +510,43 @@ function replayRewrites(
       if (batch.prefetchContent) prefetchContent = batch.prefetchContent;
     }
   };
-  // Every migration's rewrite is applied to the scratch projection so it stays valid past shapes
-  // the other migrations own (a decision digest is derived over rewritten relations, and the
-  // strict reducer rejects both legacy shapes); only the requested migration's rewrites are
-  // reported and published.
   const migrations = Object.values(eventShapeMigrations);
-  // A round ends at the next candidate when it is the next event (so its rewrite sees the
-  // projection at revision-1), otherwise right before it or after a full bulk round; with no
-  // events left it ends at the head.
-  const nextCap = (): number => {
+  // Each cut-dependent candidate is the first and only event in its batch. TaskProjection applies
+  // the previous batch before requesting the next one, so rewrite sees the exact pre-event cut.
+  // The stream head remains the real final head, which makes one catchUp settle one state digest.
+  const nextBatch = () => {
     fill();
-    if (pending.length === 0) return headRevision;
+    if (pending.length === 0) return [];
     const candidate = pending.findIndex((event) => migrations.some((migration) => migration.matches(event))),
       count = candidate === 0 ? 1 : Math.min(candidate === -1 ? pending.length : candidate, BULK_ROUND_LIMIT);
-    return pending[count - 1]!.workspaceRevision;
+    return pending
+      .splice(0, count)
+      .map((event) => rewriteToFixedPoint(event, projection!, migrations, blobs, rewrites));
   };
   const stream = {
-    readHead: () =>
-      cap >= headRevision
-        ? head
-        : { revision: cap, eventDigest: `sha256:${sha256Text(`event-shape-migration:${cap}`)}` as `sha256:${string}` },
+    readHead: () => head,
     readBatch: () => {
-      const beyond = pending.findIndex((event) => event.workspaceRevision > cap),
-        events = pending.splice(0, beyond === -1 ? pending.length : beyond).map((event) => {
-          let current = event;
-          for (const migration of migrations) {
-            const rewrite = migration.rewrite(current, projection!);
-            if (rewrite === null) continue;
-            if (migration === spec) rewrites.push(rewrite);
-            for (const blob of rewrite.blobs ?? []) syntheticBlobs.set(blob.sha256, Buffer.from(blob.body));
-            current = rewrite.event;
-          }
-          return current;
-        });
+      const batch = nextBatch(),
+        done = exhausted && pending.length === 0;
+      events.push(...batch);
       return {
-        sourceRevision: cap,
-        events,
-        cursor: null,
-        done: true,
-        accessedItems: events.length,
+        sourceRevision: headRevision,
+        events: batch,
+        cursor: done ? null : String(batch.at(-1)?.workspaceRevision ?? events.length),
+        done,
+        accessedItems: batch.length,
         prefetchContent: (replay: readonly CanonicalEventV1[]) => {
-          const persisted = replay.filter((event) =>
-              contentClaims(event).every((claim) => !syntheticBlobs.has(claim.sha256)),
-            ),
-            content = new Map([...(prefetchContent?.(persisted) ?? []), ...syntheticBlobs]);
+          const persisted = replay.filter((event) => contentClaims(event).every((claim) => !blobs.has(claim.sha256))),
+            generated = [...blobs].map(([sha256, blob]) => [sha256, Buffer.from(blob.body)] as const),
+            content = new Map([...(prefetchContent?.(persisted) ?? []), ...generated]);
           return content;
         },
       };
     },
-    readContentBlob: (sha256: string) => syntheticBlobs.get(sha256) ?? input.store.readContentBlob(sha256),
+    readContentBlob: (sha256: string) => {
+      const generated = blobs.get(sha256);
+      return generated ? Buffer.from(generated.body) : input.store.readContentBlob(sha256);
+    },
   };
   projection = makeTaskProjection({
     rootDir: input.rootDir,
@@ -441,17 +555,61 @@ function replayRewrites(
     catchUpLimit: BULK_ROUND_LIMIT,
   });
   try {
-    let watermark = 0;
-    while (watermark < headRevision) {
-      cap = nextCap();
-      const round = projection.catchUp!();
-      if (round.watermark !== cap)
-        throw new Error(`${spec.name} migrating replay stalled at revision ${round.watermark} before ${cap}`);
-      watermark = cap;
-    }
+    const round = projection.catchUp!();
+    if (round.watermark !== headRevision)
+      throw new Error(`event-shape migration replay stalled at revision ${round.watermark} before ${headRevision}`);
   } finally {
     projection.close();
     for (const suffix of ["", "-wal", "-shm"]) localRuntimeStateFileSystem.remove(`${scratchPath}${suffix}`);
   }
-  return rewrites;
+  return { events, blobs: [...blobs.values()], rewrites };
+}
+
+function rewriteToFixedPoint(
+  event: CanonicalEventV1,
+  cut: EventShapeCut,
+  migrations: readonly EventShapeMigrationSpec[],
+  blobs: Map<string, CanonicalContentBlob>,
+  rewrites: LegacyGenerationConversionPlan["rewrites"][number][],
+): CanonicalEventV1 {
+  let current = event;
+  const applied = new Set<EventShapeMigrationName>(),
+    seen = new Set([canonicalJson(event)]);
+  for (let pass = 0; pass <= migrations.length; pass += 1) {
+    let changed = false;
+    for (const migration of migrations) {
+      const rewrite = migration.rewrite(current, cut);
+      if (rewrite === null) continue;
+      if (applied.has(migration.name)) throw new Error(`${migration.name} is not idempotent for event ${event.opId}`);
+      applied.add(migration.name);
+      changed = true;
+      current = rewrite.event;
+      for (const blob of rewrite.blobs ?? []) blobs.set(blob.sha256, blob);
+      rewrites.push({
+        migration: migration.name,
+        opId: event.opId,
+        revision: event.workspaceRevision,
+        category: rewrite.category,
+      });
+    }
+    if (!changed) return current;
+    const state = canonicalJson(current);
+    if (seen.has(state)) throw new Error(`event-shape migration cycle for event ${event.opId}`);
+    seen.add(state);
+  }
+  throw new Error(`event-shape migrations did not reach a fixed point for event ${event.opId}`);
+}
+
+function summarizeMigrationFamilies(
+  rewrites: LegacyGenerationConversionPlan["rewrites"],
+): readonly EventShapeMigrationFamilyReport[] {
+  return Object.values(eventShapeMigrations).map(({ name }) => {
+    const revisions = rewrites.filter((rewrite) => rewrite.migration === name).map((rewrite) => rewrite.revision);
+    return {
+      name,
+      count: revisions.length,
+      firstRevision: revisions.length === 0 ? null : Math.min(...revisions),
+      lastRevision: revisions.length === 0 ? null : Math.max(...revisions),
+    };
+  });
 }

--- a/packages/kernel/src/store/legacy-generation-conversion.ts
+++ b/packages/kernel/src/store/legacy-generation-conversion.ts
@@ -43,6 +43,7 @@ export interface LegacyGenerationConversionReport {
   readonly sourceEvents: number;
   readonly convertedEvents: number;
   readonly rewrittenEvents: number;
+  readonly migrationFamilies: ReturnType<typeof planLegacyGenerationConversion>["migrationFamilies"];
   readonly copiedObjects: number;
   readonly migratedEvents: number;
   readonly destinationRevision: number;
@@ -240,6 +241,7 @@ export function convertLegacyGeneration(input: {
       sourceEvents: snapshot.eventBytes.length,
       convertedEvents: plan.events.length,
       rewrittenEvents: plan.rewrites.length,
+      migrationFamilies: plan.migrationFamilies,
       copiedObjects: store.contentObjectDigests().length,
       migratedEvents: plan.events.length - existingRevision,
       destinationRevision: store.revision(),
@@ -335,10 +337,6 @@ function validatedConversionPlan(snapshot: ImmutableLegacySnapshotV2, rootDir: s
         `converted event ${event.opId} is not current: ${issues.join("; ")}`,
       );
   }
-  assertNoPendingHistoricalRewrites({
-    rootDir,
-    store: convertedPlanStore(snapshot, snapshotPath, plan.events, plan.blobs),
-  });
   return plan;
 }
 
@@ -413,22 +411,6 @@ function writeRawSnapshot(input: {
 
 function sqliteSnapshotStore(store: ReturnType<typeof openSqliteEventStore>): CanonicalEventStore {
   return arraySnapshotStore(store.events(), (sha256) => store.readContentObject(sha256));
-}
-
-function convertedPlanStore(
-  snapshot: ImmutableLegacySnapshotV2,
-  snapshotPath: string,
-  events: readonly CanonicalEventV1[],
-  generatedBlobs: readonly CanonicalContentBlob[],
-): CanonicalEventStore {
-  const generated = new Map(generatedBlobs.map((blob) => [blob.sha256, Buffer.from(blob.body)])),
-    objects = new Map(snapshot.objects.map((object) => [object.sha256, object]));
-  return arraySnapshotStore(events, (sha256) => {
-    const blob = generated.get(sha256);
-    if (blob) return blob;
-    const object = objects.get(sha256);
-    return object ? readSnapshotObject(snapshotPath, sha256, object.size) : null;
-  });
 }
 
 function snapshotSourceDigest(

--- a/packages/kernel/test/store/canonical-generation.fixtures.ts
+++ b/packages/kernel/test/store/canonical-generation.fixtures.ts
@@ -1,6 +1,9 @@
 // Internal test access for daemon conversion, receipt and admission scenarios.
 export { OPAQUE_TEXTUAL_POLICY_ID } from "../../src/domain/artifact-text-classification.ts";
-export { assertNoPendingHistoricalRewrites } from "../../src/store/event-shape-migration.ts";
+export {
+  assertNoPendingHistoricalRewrites,
+  planLegacyGenerationConversion,
+} from "../../src/store/event-shape-migration.ts";
 export {
   createImmutableLegacyGenerationSnapshotFromStoppedRepository,
   preflightConvertedGenerationActivation,


### PR DESCRIPTION
# English

## Summary

Generation-1 conversion of the real canonical history (61,685 events) failed at revision 40000 with `converted event op_91639a93… is not current: Task/v2 fields are incomplete or unknown`, and the conversion plan took ~31 minutes before failing. This PR adds the two missing offline event-shape migration families and collapses the planner to a single replay.

Root cause (measured on the authoritative backup copy): 346 of 61,685 events are not current under the strict Task/v2 and Review validators — 74 Task snapshots still carry the retired embedded `relations` field, and 283 review pins lack `submissionDigest` (11 overlap). The failing event was rejected for the unknown `relations` field, not for a missing required field.

## Architectural Justification

- Computed production churn is 328 lines (+234/-94, net +140), above the 200-line threshold. The churn is concentrated in `packages/kernel/src/store/event-shape-migration.ts`, which is the single offline migration registry that already owns the existing families; the two new families cannot live anywhere else without creating a second migration path.
- No compatibility layer was added: the validators are not relaxed. Legacy events are rewritten into the current canonical shapes (`relation-event/v1` `relation_created`, review pins with `submissionDigest`), consistent with the relation-first-class model introduced in a2c4dd6ce.
- Obsolete code removed: the duplicate `planLegacyGenerationConversion` call inside `validatedConversionPlan` (via `assertNoPendingHistoricalRewrites`) and the `convertedPlanStore` helper that only existed to feed it; per-family replay loops are replaced by one unified replay with a single state digest at the real head. Strict current-shape validation of every converted event remains as the backstop.
- Scope cannot be narrowed: the two families must ship together, otherwise conversion still fails at revision 40190 on the review family.

## What Changed

- `event-shape-migration.ts`: new family `task-embedded-relations` — the legacy `task_relation_added` event (revision 42127) is rewritten to a canonical `relation_created` event preserving eventId/opId/workspaceRevision/actor/source/occurredAt and adding `targetObservedVersion`; later Task snapshots drop `relations` only after `assertRelationsExistAtCut` proves every embedded relation already exists as a first-class relation at that cut.
- `event-shape-migration.ts`: new family `review-submission-digest` — review pins without `submissionDigest` get it computed from the referenced submission (`Object.hasOwn` guard leaves already-pinned reviews such as revision 57404 untouched); dependent consents recompute `reviewDigest`.
- `event-shape-migration.ts`: unified single replay across families, one state digest at the real head; `planLegacyGenerationConversion` now reports `migrationFamilies` (name, matched count, category).
- `legacy-generation-conversion.ts`: conversion report carries `migrationFamilies`; the duplicate plan computation and `convertedPlanStore` are deleted.
- Tests: `legacy-generation-conversion.integration.test.ts` adds three equivalence checks (lifecycle final state, relation final state, current-shape validation of every converted event) for both families plus positive controls; the fixtures barrel exports `planLegacyGenerationConversion`.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: see the computed production-delta job summary (+234/-94 computed locally with `tools/gates/production-delta.mjs`).

## Machine-Readable Declarations

Event-Migration: none — no `packages/kernel/fixtures/canonical-events/**/accepted*.json` fixture changes; the new families are registered in the offline conversion planner only, and the retired live `ha migrate` command is intentionally not revived (verified by the CLI thin-command test).

## Task And Scope

- Harness task: task_7f051276554a3ec2283a294c83
- Branch: `codex/gen1-task-v2-migration`
- Public scope: `packages/kernel/src/store/event-shape-migration.ts`, `packages/kernel/src/store/legacy-generation-conversion.ts`, `packages/kernel/test/store/canonical-generation.fixtures.ts`, `packages/daemon/test/legacy-generation-conversion.integration.test.ts`
- Private planning/evidence updated: yes
- Out of scope: the third canonical changeover itself (runbook in task_d1b1a445, scheduled after this merge); reviving a live `ha migrate` user-facing command (deferred to the CEO/owner decision).

## Version Impact

- Version: no version change because this fixes the offline conversion planner ahead of the database-version cut; the release task owns the bump.
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none
- Authority: task_7f051276554a3ec2283a294c83
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: 9dc34398ea1a4d0385dd4054969d4c2eaf7b246a
- Branch merge-base with `origin/main`: 9dc34398ea1a4d0385dd4054969d4c2eaf7b246a
- Last `git fetch origin` time: 2026-09-06T20:32Z
- Sync method: none needed (rebased onto latest `origin/main` before the final test run)
- Public diff command: `git diff origin/main...codex/gen1-task-v2-migration`
- Private evidence commit/path: `harness/tasks/task_7f051276554a3ec2283a294c83-…/artifacts/reports/{dispatch_9d58c67246e1ae69565631b2.md,implementation.md}`, fact F-EF5E1147
- Reviewer evidence path: peer CEO ground-truth review recorded on the same task package
- GitHub Actions `rewrite-ci` run URL: pending (this PR's checks)
- [ ] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [x] `npm run typecheck` (`npx tsc -b packages/kernel packages/daemon --pretty false`)
- [x] `npm test` — targeted: `packages/daemon/test/legacy-generation-conversion.integration.test.ts` 7 pass / 0 fail / 1 opt-in canonical-scale skip, run under the isolated Ubuntu test user; gate tests 192 pass; CLI thin-command 18 pass
- [x] `npm run harness:check-import-boundaries` (via `node tools/run-manifest-gates.mjs --changed origin/main`, 7/7)
- [x] `npm run harness:scan-forbidden-symbols` (same manifest run)
- [x] `npm run harness:check-private-boundary` (same manifest run)
- [x] `npm run harness:check-package-policy` (same manifest run)
- [x] `npm run harness:check-implementation-contracts` (same manifest run)
- [x] `npm run harness:check-schema-contracts` (same manifest run)
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Not run: `npm ci`, `npm run check`, full fast/contract tiers, `check-legacy-intake-readiness`, `smoke-cli-package` — full suites are not run on the worker machine by policy; GitHub `rewrite-ci` is the authority.
- Offline full chain on a copy of the authoritative canonical backup (never the backup itself): snapshot 61,685 events / 43,911 objects; convert #1 61,685 migrated events with 358 rewrites; convert #2 `migratedEvents == 0`; verify-import `matches == true`, 61,685/61,685 rows, source digest round-trips; planner + validation ≈ 35 s (previously ≈ 31 min).

## Review Evidence

- Self-review: CEO read the diff hunks for both families, the `assertRelationsExistAtCut` guard, the `Object.hasOwn` pin guard, and the removed duplicate plan path.
- Reviewer subagent: peer CEO session ground-truth review — read code and tests, verified that `rel_f9831dd0bd9d4d94` exists only inside two Task snapshots (so dropping the field without the relation event would lose the relation), confirmed the three equivalence tests and positive control, confirmed no live `ha migrate` revival; verdict APPROVE.
- Human review: pending on this PR
- Blocking findings: none

## Residual Risk

- Conversion correctness is proven offline against a copy of the current canonical backup; the live changeover (stop → backup → snapshot → convert → verify-import → rebuild → preflight → restart → reconcile) still has to be executed and gated separately.
- If canonical history gains a new non-current shape family before the changeover, conversion will fail-closed again with the same class of error; the registry makes adding a family a contained change.

## References

- Task: task_7f051276554a3ec2283a294c83
- Evidence: dispatch dispatch_9d58c67246e1ae69565631b2 report and `implementation.md` on the task package; fact F-EF5E1147
- Review: peer CEO ground-truth review on the task package

---

# 中文

## 概要

对真实 canonical 历史(61,685 事件)做 generation-1 转换时,在 revision 40000 失败:`converted event op_91639a93… is not current: Task/v2 fields are incomplete or unknown`,且失败前 plan 阶段耗时约 31 分钟。本 PR 补上缺失的两条离线事件形状迁移族,并把 planner 收敛为单次回放。

根因(在权威备份副本上实测):61,685 事件中 346 个在严格 Task/v2 与 Review 校验下不 current——74 个 Task 快照仍带已退役的内嵌 `relations` 字段,283 个 review pin 缺 `submissionDigest`(11 个重叠)。失败事件是因为未知字段 `relations` 被拒,不是缺必填字段。

## 架构辩护

- 机器计算生产 churn 328 行(+234/-94,净 +140),超过 200 行门槛。churn 集中在 `packages/kernel/src/store/event-shape-migration.ts`——它是唯一的离线迁移 registry,已承载既有迁移族;两条新族放到别处就会出现第二条迁移路径。
- 没有加兼容层:校验器没有放宽。旧事件被重写成当前 canonical 形状(`relation-event/v1` 的 `relation_created`、带 `submissionDigest` 的 review pin),与 a2c4dd6ce 引入的 relation 一等公民模型一致。
- 删除的废弃代码:`validatedConversionPlan` 里经 `assertNoPendingHistoricalRewrites` 触发的重复 `planLegacyGenerationConversion` 计算,以及只为喂它而存在的 `convertedPlanStore`;逐族回放循环被统一单次回放取代,只在真实 head 做一次 state digest。每个转换后事件的严格 current 校验仍作为兜底保留。
- 范围不能收窄:两族必须同批,否则转换会在 revision 40190 继续在 review 族上失败。

## 改动内容

- `event-shape-migration.ts`:新族 `task-embedded-relations`——旧 `task_relation_added` 事件(revision 42127)重写为 canonical `relation_created`,保留 eventId/opId/workspaceRevision/actor/source/occurredAt 并补 `targetObservedVersion`;后续 Task 快照只有在 `assertRelationsExistAtCut` 证明该 cut 上每条内嵌关系都已作为一等 relation 存在后才删 `relations`。
- `event-shape-migration.ts`:新族 `review-submission-digest`——缺 `submissionDigest` 的 review pin 从所引用的 submission 重算得到(`Object.hasOwn` 守卫,已有 pin 的 review 如 revision 57404 不动);依赖它的 consent 重算 `reviewDigest`。
- `event-shape-migration.ts`:跨族统一单次回放、真实 head 单次 state digest;`planLegacyGenerationConversion` 输出 `migrationFamilies`(族名、匹配数、类别)。
- `legacy-generation-conversion.ts`:转换报告带 `migrationFamilies`;删除重复 plan 计算与 `convertedPlanStore`。
- 测试:`legacy-generation-conversion.integration.test.ts` 为两族新增三项等价断言(lifecycle 终态、relation 终态、每个转换后事件的 current 校验)及正控;fixtures barrel 导出 `planLegacyGenerationConversion`。

## 门收割 / Gate Harvest

- 删除的生产路径:none
- 同 commit 删除的门 / fixture:none
- 生产净行数:见 production-delta job summary(本地 `tools/gates/production-delta.mjs` 计算为 +234/-94)。

## 机读声明说明

- 机读声明只在英文块出现一次。
- 依赖变化:无 `package.json`/`package-lock.json` 改动,已删除该行。
- Event-Migration:无 accepted fixture 改动;新族只登记在离线 conversion planner,已退役的 live `ha migrate` 命令有意不复活(CLI thin-command 测试确认)。

## 任务与范围

- Harness 任务:task_7f051276554a3ec2283a294c83
- 分支:`codex/gen1-task-v2-migration`
- 公开范围:`packages/kernel/src/store/event-shape-migration.ts`、`packages/kernel/src/store/legacy-generation-conversion.ts`、`packages/kernel/test/store/canonical-generation.fixtures.ts`、`packages/daemon/test/legacy-generation-conversion.integration.test.ts`
- 私有计划 / 证据是否已更新:yes
- 范围外:第三次 canonical 换代本身(runbook 在 task_d1b1a445,合入后排);复活 live `ha migrate` 用户面命令(留待 CEO/owner 裁决)。

## 版本影响

- 版本:不改版本,原因是本 PR 修复的是数据库版本切割之前的离线转换 planner,版本号由 release task 负责。
- 发布影响:不发布

## 治理声明

- 是否触碰 protected surface:no
- protected surface 范围:无
- 依据:task_7f051276554a3ec2283a294c83
- 机器检查边界:本 PR 只声明该段存在;声明是否真实、充分,由 reviewer 判断。
- Break-glass:no
- Break-glass 原因:不适用
- Break-glass 范围:不适用
- 后续治理任务:不适用

## 验证

- `origin/main` 基准 SHA:9dc34398ea1a4d0385dd4054969d4c2eaf7b246a
- 当前分支与 `origin/main` 的 merge-base:9dc34398ea1a4d0385dd4054969d4c2eaf7b246a
- 最近一次 `git fetch origin` 时间:2026-09-06T20:32Z
- 同步方式:不需要(最终测试前已 rebase 到最新 `origin/main`)
- 公开 diff 命令:`git diff origin/main...codex/gen1-task-v2-migration`
- 私有证据 commit/path:`harness/tasks/task_7f051276554a3ec2283a294c83-…/artifacts/reports/{dispatch_9d58c67246e1ae69565631b2.md,implementation.md}`,fact F-EF5E1147
- Reviewer 证据路径:对面 CEO 的 ground-truth 复核记录在同一任务包
- GitHub Actions `rewrite-ci` run URL:待本 PR 的 checks
- [ ] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [x] `npm run typecheck`(`npx tsc -b packages/kernel packages/daemon --pretty false`)
- [x] `npm test`——定向:`packages/daemon/test/legacy-generation-conversion.integration.test.ts` 7 pass / 0 fail / 1 个按需 canonical-scale skip,在隔离 Ubuntu 测试用户下运行;gate tests 192 pass;CLI thin-command 18 pass
- [x] `npm run harness:check-import-boundaries`(经 `node tools/run-manifest-gates.mjs --changed origin/main`,7/7)
- [x] `npm run harness:scan-forbidden-symbols`(同一 manifest 运行)
- [x] `npm run harness:check-private-boundary`(同上)
- [x] `npm run harness:check-package-policy`(同上)
- [x] `npm run harness:check-implementation-contracts`(同上)
- [x] `npm run harness:check-schema-contracts`(同上)
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- 未运行:`npm ci`、`npm run check`、完整 fast/contract tier、`check-legacy-intake-readiness`、`smoke-cli-package`——按纪律 worker 机不跑全量;GitHub `rewrite-ci` 是权威。
- 在权威 canonical 备份的副本上(不是备份本身)跑离线全链:snapshot 61,685 事件 / 43,911 对象;convert #1 迁移 61,685 事件、358 次重写;convert #2 `migratedEvents == 0`;verify-import `matches == true`,61,685/61,685 行,source digest 回连一致;planner + 校验约 35 秒(此前约 31 分钟)。

## 审查证据

- 自查:CEO 亲读两族 diff、`assertRelationsExistAtCut` 守卫、`Object.hasOwn` pin 守卫与被删的重复 plan 路径。
- Reviewer subagent:对面 CEO session 的 ground-truth 复核——亲读代码与测试,核实 `rel_f9831dd0bd9d4d94` 全 canonical 只存在于两个 Task 快照内(直接删字段而不补 relation 事件必丢关系),确认三项等价测试与正控,确认没有复活 live `ha migrate`;结论 APPROVE。
- 人工审查:待本 PR
- 阻塞发现:无

## 残余风险

- 转换正确性只在当前 canonical 备份副本上离线证明;真实换代(stop → backup → snapshot → convert → verify-import → rebuild → preflight → restart → reconcile)仍需单独执行并逐门验收。
- 若换代前 canonical 历史再出现新的非 current 形状族,转换会以同类错误 fail-closed;registry 让新增一族成为局部改动。

## 关联材料

- 任务:task_7f051276554a3ec2283a294c83
- 证据:任务包上的 dispatch_9d58c67246e1ae69565631b2 报告与 `implementation.md`;fact F-EF5E1147
- 审查:任务包上对面 CEO 的 ground-truth 复核

---

## PR Gate Checklist / PR 门禁清单

- [x] Branch is based on latest `origin/main`. / 分支基于最新 `origin/main`。
- [x] PR body uses this full template structure. / PR 描述使用本模板完整结构。
- [x] PR body uses two complete language blocks: `# English` first, then `# 中文`. / PR 正文使用两块完整正文:`# English` 在上,`# 中文` 在下。
- [x] PR body passes `tools/check-pr-body-bilingual.mjs`. / PR 正文通过 `tools/check-pr-body-bilingual.mjs`。
- [x] If the PR touches a manifest-derived protected surface, Governance Declaration is filled with ADR/decision/task evidence or break-glass fields. / 若 PR 触碰 manifest 派生的 protected surface,Governance Declaration 已填写 ADR/decision/task 依据或 break-glass 字段。
- [x] No private harness files are included. / 不包含私有 harness 文件。
- [x] No ignored local agent entry files are included. / 不包含被忽略的本地 agent 入口文件。
- [x] No absolute local filesystem paths are included in this public PR body. / 本公开 PR 描述不包含本机绝对路径。
- [x] Public diff is limited to the stated task scope. / 公开 diff 限于声明的任务范围。
- [x] Private planning/evidence updates are recorded when applicable. / 适用时已记录私有计划 / 证据更新。
- [x] Version and publish impact are stated. / 已说明版本与发布影响。
- [x] Local verification commands are recorded honestly. / 已如实记录本地验证命令。
- [x] CI results are linked or explained. / CI 结果已链接或说明。
- [x] Review evidence is recorded. / 已记录审查证据。
- [x] Open P0/P1/P2 findings are closed, deferred with owner, or explicitly blocked. / open P0/P1/P2 findings 已关闭、带 owner 延后,或明确阻塞。
- [x] Merge method and post-merge branch cleanup plan are clear. / 合并方式和合并后分支清理计划清楚。
- [x] No admin bypass is planned unless explicitly approved and recorded. / 除非明确批准并记录,否则不计划 admin bypass。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
