### PR TITLE
test(daemon): settle the seeded settings publication before the registry WAL restart fixture starts its daemon

### DIFF
--- a/packages/daemon/test/registry-wal-restart.repro.mjs
+++ b/packages/daemon/test/registry-wal-restart.repro.mjs
@@ -9,7 +9,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { daemonProcessAlive } from "../src/daemon-singleton.ts";
 import { readDaemonPid } from "../src/runtime.ts";
-import { registerBootstrappedDaemonRepo } from "./repo-settings.fixture.ts";
+import { registerSettledBootstrappedDaemonRepo } from "./repo-settings.fixture.ts";
 
 const repositoryRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../.."),
   cli = path.join(repositoryRoot, "packages/cli/src/index.ts");
@@ -23,7 +23,12 @@ export async function reproduceRegistrySqliteRestart(arm, options = {}) {
     daemonId = `registry-wal-${arm}`,
     fixture = { fixtureRoot, rootDir, userRoot, repoId, daemonId };
   rosterRepo(rootDir, repoId);
-  registerBootstrappedDaemonRepo({ canonicalRoot: rootDir, repoId, userRoot, createConvenienceLinks: false });
+  await registerSettledBootstrappedDaemonRepo({
+    canonicalRoot: rootDir,
+    repoId,
+    userRoot,
+    createConvenienceLinks: false,
+  });
   downgradeRegistryToV1(userRoot);
   startDaemon(fixture);
   await waitForAttached(fixture);

--- a/packages/daemon/test/repo-settings.fixture.ts
+++ b/packages/daemon/test/repo-settings.fixture.ts
@@ -51,11 +51,11 @@ export function seedSettingsEvent(input: {
   readonly rootDir: string;
   readonly authoredBranch?: string;
   readonly writerEpochFence?: WriterEpochFenceDescriptor;
-}): void {
+}): ReturnType<typeof makeTaskEventStore> | undefined {
   const repoId = workspaceId(input.repoId),
     rootDir = canonicalRoot(input.rootDir),
     fixtureKey = `${rootDir}\0${repoId}`;
-  if (seededSettings.has(fixtureKey)) return;
+  if (seededSettings.has(fixtureKey)) return undefined;
   const store = makeTaskEventStore({
       repoId,
       rootDir,
@@ -66,7 +66,7 @@ export function seedSettingsEvent(input: {
     stream = store.read();
   if (stream.events.some((event) => event.schema === "settings-event/v1")) {
     seededSettings.add(fixtureKey);
-    return;
+    return store;
   }
   const documentBody = settingsBase(rootDir),
     digest = createHash("sha256").update(`${repoId}\0${documentBody}`).digest("hex");
@@ -84,6 +84,25 @@ export function seedSettingsEvent(input: {
     }),
   );
   seededSettings.add(fixtureKey);
+  return store;
+}
+
+export async function registerSettledBootstrappedDaemonRepo(
+  input: Parameters<typeof registerProductDaemonRepo>[0],
+): Promise<ReturnType<typeof registerProductDaemonRepo>> {
+  if (input.mode !== "remote-edge" && input.repoId && input.canonicalRoot) {
+    const writerEpochFence = fixtureFence(
+        input.repoId,
+        input.canonicalRoot,
+        path.join(daemonRegistryPaths(input).userRoot, "fleet"),
+      ),
+      store = seedSettingsEvent({ repoId: input.repoId, rootDir: input.canonicalRoot, writerEpochFence });
+    if (store) {
+      store.materialize();
+      await store.drain();
+    }
+  }
+  return registerProductDaemonRepo(input);
 }
 
 export const openFencedRepoCell: typeof openProductRepoCell = async (input) => {


### PR DESCRIPTION
# English

## Summary

`registry-wal-restart.integration.test.ts` (both the graceful-stop and the sigkill arm) failed intermittently on `rewrite-ci` with `daemon did not attach` / `materialization_failed … cannot lock ref 'refs/heads/master': is at X but expected Y` — five occurrences in one day, twice on `main` after PR #2339. Diagnosis (fact F-595A10CC): the failure happens during the fixture's **initial** attach, not after the restart. `seedSettingsEvent` opens a kernel store to seed the settings event and leaves its Git follower publication pending (a `setImmediate` follower); when the daemon then attaches and publishes, the two writers race for `refs/heads/master`. Production's compare-and-swap is correct — it rejects the stale expected ref — so this is a test-fixture lifecycle defect, and the fix is test-only.

## Architectural Justification

- Not required (production delta 0). No retry, timeout change or gate relaxation was added; the fixture is made to finish its own publication before the daemon starts.

## What Changed

- `packages/daemon/test/repo-settings.fixture.ts`: `seedSettingsEvent` returns the store it opened; new `registerSettledBootstrappedDaemonRepo` seeds, then `materialize()` + `await drain()` on that store, and only then registers the repository.
- `packages/daemon/test/registry-wal-restart.repro.mjs`: uses `registerSettledBootstrappedDaemonRepo` so no fixture follower is still publishing when the daemon under test attaches.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: see the computed production-delta job summary (0 production lines; test files only).

## Machine-Readable Declarations

Event-Migration: none — test fixture change only.

## Task And Scope

- Harness task: task_3a0f383098069f690b074cf171
- Branch: `codex/wal-materialization-reflock-race`
- Public scope: `packages/daemon/test/repo-settings.fixture.ts`, `packages/daemon/test/registry-wal-restart.repro.mjs`
- Private planning/evidence updated: yes
- Out of scope: any change to `sqlite-task-event-store.ts` / `task-event-store-git-refs.ts` (production CAS verified correct and left untouched).

## Version Impact

- Version: no version change because only test fixtures change.
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none
- Authority: task_3a0f383098069f690b074cf171
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: c4d5eca64da7b2dcb892ad511e08844a7c9edbf8
- Branch merge-base with `origin/main`: c4d5eca64da7b2dcb892ad511e08844a7c9edbf8
- Last `git fetch origin` time: 2026-09-07T05:20Z
- Sync method: none needed (branch is on top of the first `main` commit that contains activate-on-open)
- Public diff command: `git diff origin/main...codex/wal-materialization-reflock-race`
- Private evidence commit/path: task_3a0f3830 dispatch reports; facts F-CDCF58A1, F-FDD768B6, F-60A5CD5E, F-07347219, F-B2674ACE (occurrences), F-595A10CC (diagnosis)
- Reviewer evidence path: peer CEO ground-truth review on task_3a0f3830 (negative control on `c4d5eca64`)
- GitHub Actions `rewrite-ci` run URL: pending (this PR's checks)
- [ ] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [x] `npm run typecheck` (targeted tsc)
- [x] `npm test` — targeted: `packages/daemon/test/registry-wal-restart.integration.test.ts` both arms, looped as negative control (before: red within a few iterations; after: 20 invocations × both arms = 40/40 arm-runs green on c4d5eca64+aea4e7a0d, zero did-not-attach / cannot-lock-ref), plus the fixture's other consumers
- [x] `npm run harness:check-import-boundaries` (manifest gates on the changed files)
- [x] `npm run harness:scan-forbidden-symbols` (same)
- [x] `npm run harness:check-private-boundary` (same)
- [x] `npm run harness:check-package-policy` (same)
- [x] `npm run harness:check-implementation-contracts` (same)
- [x] `npm run harness:check-schema-contracts` (same)
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Not run: `npm ci`, `npm run check`, full tiers, smoke/release lanes — not run on worker machines by policy; GitHub `rewrite-ci` is the authority.

## Review Evidence

- Self-review: CEO read the diff (seed store is drained before registration; production untouched).
- Reviewer subagent: peer CEO session ground-truth review — ran the wide-window negative control on this branch (20 invocations, both arms, 40/40 green), confirmed test-only diff with production 0 and no retry added to the production CAS; APPROVE recorded as F-A2BCC9E8
- Human review: pending on this PR
- Blocking findings: none

## Residual Risk

- Other tests that call `registerBootstrappedDaemonRepo` directly keep the old ordering; if they show the same symptom they should switch to `registerSettledBootstrappedDaemonRepo`.

## References

- Task: task_3a0f383098069f690b074cf171
- Evidence: facts F-595A10CC, F-B2674ACE and the occurrence facts above
- Review: peer CEO review on task_3a0f3830

---

# 中文

## 概要

`registry-wal-restart.integration.test.ts`(graceful-stop 与 sigkill 两臂)在 `rewrite-ci` 上间歇失败:`daemon did not attach` / `materialization_failed … cannot lock ref 'refs/heads/master': is at X but expected Y`,一天内 5 次、PR #2339 合入后在 `main` 上两次。定因(fact F-595A10CC):失败发生在 fixture 的**初次** attach,不是重启之后。`seedSettingsEvent` 为了写入 settings 事件打开了一个 kernel store,其 Git follower 发布仍挂在 `setImmediate` 里;daemon 随后 attach 并发布时,两个 writer 抢 `refs/heads/master`。生产侧的 compare-and-swap 行为正确(拒绝陈旧的 expected ref),所以这是测试 fixture 生命周期缺陷,修复只动测试。

## 架构辩护

- 不适用(生产 delta 为 0)。没有加重试、改超时或放宽门禁;只是让 fixture 在 daemon 启动前把自己的发布做完。

## 改动内容

- `packages/daemon/test/repo-settings.fixture.ts`:`seedSettingsEvent` 返回它打开的 store;新增 `registerSettledBootstrappedDaemonRepo`,先 seed,再对该 store `materialize()` + `await drain()`,然后才注册仓库。
- `packages/daemon/test/registry-wal-restart.repro.mjs`:改用 `registerSettledBootstrappedDaemonRepo`,被测 daemon attach 时不再有 fixture follower 在发布。

## 门收割 / Gate Harvest

- 删除的生产路径:none
- 同 commit 删除的门 / fixture:none
- 生产净行数:见 production-delta job summary(生产 0 行,只改测试)。

## 机读声明说明

- 机读声明只在英文块出现一次。
- 依赖变化:无 `package.json`/`package-lock.json` 改动,已删除该行。
- Event-Migration:仅测试 fixture 改动。

## 任务与范围

- Harness 任务:task_3a0f383098069f690b074cf171
- 分支:`codex/wal-materialization-reflock-race`
- 公开范围:`packages/daemon/test/repo-settings.fixture.ts`、`packages/daemon/test/registry-wal-restart.repro.mjs`
- 私有计划 / 证据是否已更新:yes
- 范围外:`sqlite-task-event-store.ts` / `task-event-store-git-refs.ts` 的任何改动(生产 CAS 已验证正确、保持不动)。

## 版本影响

- 版本:不改版本,原因是只改测试 fixture。
- 发布影响:不发布

## 治理声明

- 是否触碰 protected surface:no
- protected surface 范围:无
- 依据:task_3a0f383098069f690b074cf171
- 机器检查边界:本 PR 只声明该段存在;声明是否真实、充分,由 reviewer 判断。
- Break-glass:no
- Break-glass 原因:不适用
- Break-glass 范围:不适用
- 后续治理任务:不适用

## 验证

- `origin/main` 基准 SHA:c4d5eca64da7b2dcb892ad511e08844a7c9edbf8
- 当前分支与 `origin/main` 的 merge-base:c4d5eca64da7b2dcb892ad511e08844a7c9edbf8
- 最近一次 `git fetch origin` 时间:2026-09-07T05:20Z
- 同步方式:不需要(分支基于首个含 activate-on-open 的 `main` commit)
- 公开 diff 命令:`git diff origin/main...codex/wal-materialization-reflock-race`
- 私有证据 commit/path:task_3a0f3830 dispatch 报告;fact F-CDCF58A1、F-FDD768B6、F-60A5CD5E、F-07347219、F-B2674ACE(发生记录)、F-595A10CC(定因)
- Reviewer 证据路径:对面 CEO 在 task_3a0f3830 上的 ground-truth 复核(基于 `c4d5eca64` 的阴性对照)
- GitHub Actions `rewrite-ci` run URL:待本 PR 的 checks
- [ ] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [x] `npm run typecheck`(定向 tsc)
- [x] `npm test`——定向:`packages/daemon/test/registry-wal-restart.integration.test.ts` 两臂循环阴性对照(改前几轮内即红;改后在 c4d5eca64+aea4e7a0d 上 20 次调用 × 两臂 = 40/40 全绿,零 did-not-attach / cannot-lock-ref),以及该 fixture 的其他消费者
- [x] `npm run harness:check-import-boundaries`(变更文件的 manifest 门)
- [x] `npm run harness:scan-forbidden-symbols`(同上)
- [x] `npm run harness:check-private-boundary`(同上)
- [x] `npm run harness:check-package-policy`(同上)
- [x] `npm run harness:check-implementation-contracts`(同上)
- [x] `npm run harness:check-schema-contracts`(同上)
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- 未运行:`npm ci`、`npm run check`、完整 tier、smoke/release——按纪律 worker 机不跑全量;GitHub `rewrite-ci` 是权威。

## 审查证据

- 自查:CEO 亲读 diff(seed store 在注册前 drain 完;生产未动)。
- Reviewer subagent:对面 CEO session 的 ground-truth 复核——在本分支亲跑宽窗口阴性对照(20 次调用、两臂,40/40 全绿),确认纯测试改动、生产 0、未给生产 CAS 加重试;APPROVE 记录 F-A2BCC9E8
- 人工审查:待本 PR
- 阻塞发现:无

## 残余风险

- 直接调用 `registerBootstrappedDaemonRepo` 的其他测试仍是旧顺序;若出现同类症状应改用 `registerSettledBootstrappedDaemonRepo`。

## 关联材料

- 任务:task_3a0f383098069f690b074cf171
- 证据:fact F-595A10CC、F-B2674ACE 及上述发生记录
- 审查:task_3a0f3830 上对面 CEO 的复核

---

## PR Gate Checklist / PR 门禁清单

- [x] Branch is based on latest `origin/main`. / 分支基于最新 `origin/main`。
- [x] PR body uses this full template structure. / PR 描述使用本模板完整结构。
- [x] PR body uses two complete language blocks: `# English` first, then `# 中文`. / PR 正文使用两块完整正文:`# English` 在上,`# 中文` 在下。
- [x] PR body passes `tools/check-pr-body-bilingual.mjs`. / PR 正文通过 `tools/check-pr-body-bilingual.mjs`。
- [x] If the PR touches a manifest-derived protected surface, Governance Declaration is filled with ADR/decision/task evidence or break-glass fields. / 若 PR 触碰 manifest 派生的 protected surface,Governance Declaration 已填写 ADR/decision/task 依据或 break-glass 字段。
- [x] No private harness files are included. / 不包含私有 harness 文件。
- [x] No ignored local agent entry files are included. / 不包含被忽略的本地 agent 入口文件。
- [x] No absolute local filesystem paths are included in this public PR body. / 本公开 PR 描述不包含本机绝对路径。
- [x] Public diff is limited to the stated task scope. / 公开 diff 限于声明的任务范围。
- [x] Private planning/evidence updates are recorded when applicable. / 适用时已记录私有计划 / 证据更新。
- [x] Version and publish impact are stated. / 已说明版本与发布影响。
- [x] Local verification commands are recorded honestly. / 已如实记录本地验证命令。
- [x] CI results are linked or explained. / CI 结果已链接或说明。
- [x] Review evidence is recorded. / 已记录审查证据。
- [x] Open P0/P1/P2 findings are closed, deferred with owner, or explicitly blocked. / open P0/P1/P2 findings 已关闭、带 owner 延后,或明确阻塞。
- [x] Merge method and post-merge branch cleanup plan are clear. / 合并方式和合并后分支清理计划清楚。
- [x] No admin bypass is planned unless explicitly approved and recorded. / 除非明确批准并记录,否则不计划 admin bypass。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
