### PR TITLE
fix(kernel): publish follower commits with one fast-import over a file-descriptor stdin

### DIFF
--- a/packages/kernel/src/local/local-layout-file-system.ts
+++ b/packages/kernel/src/local/local-layout-file-system.ts
@@ -99,6 +99,34 @@ export const localRuntimeStateFileSystem = {
     /* @gate-identity check-bypass-write-boundary/bypass-write-058 */
     rmSync(inputPath, { force: true }),
   syncDirectory: (inputPath: string) => syncDirectories([inputPath]),
+  withReadDescriptor: <T>(inputPath: string, use: (descriptor: number) => T): T => {
+    const descriptor =
+      /* @gate-identity check-bypass-write-boundary/bypass-write-129 */
+      openSync(inputPath, "r");
+    try {
+      return use(descriptor);
+    } finally {
+      /* @gate-identity check-bypass-write-boundary/bypass-write-130 */
+      closeSync(descriptor);
+    }
+  },
+  writeExclusiveStream: (inputPath: string, chunks: Iterable<string | Uint8Array>): void => {
+    const descriptor =
+      /* @gate-identity check-bypass-write-boundary/bypass-write-131 */
+      openSync(inputPath, "wx");
+    try {
+      for (const chunk of chunks) {
+        const bytes = typeof chunk === "string" ? Buffer.from(chunk) : chunk;
+        for (let offset = 0; offset < bytes.byteLength; )
+          offset +=
+            /* @gate-identity check-bypass-write-boundary/bypass-write-132 */
+            writeSync(descriptor, bytes, offset);
+      }
+    } finally {
+      /* @gate-identity check-bypass-write-boundary/bypass-write-133 */
+      closeSync(descriptor);
+    }
+  },
   writeText: (inputPath: string, value: string) =>
     /* @gate-identity check-bypass-write-boundary/bypass-write-059 */
     writeFileSync(inputPath, value, "utf8"),

--- a/packages/kernel/src/store/local-version-control-system.ts
+++ b/packages/kernel/src/store/local-version-control-system.ts
@@ -18,13 +18,13 @@ import {
   statSync,
   symlinkSync,
   unlinkSync,
-  writeSync,
   writeFileSync,
 } from "node:fs";
 import { open as openAsync } from "node:fs/promises";
 import path from "node:path";
 import { isMainThread, parentPort, Worker, workerData } from "node:worker_threads";
 import { consumeKnownError } from "../error-consumption.ts";
+import { localRuntimeStateFileSystem } from "../local/local-layout-file-system.ts";
 import type { VcsCommitAuthor, VersionControlSystem } from "../ports/version-control-system.ts";
 import { VcsCommandError } from "../ports/version-control-system.ts";
 import { makeLocalVersionControlCommands } from "./local-version-control-commands.ts";
@@ -347,34 +347,22 @@ export const localGitObjectRefStore = Object.freeze({
       });
   },
   importCommit: (repoRoot: string, input: Iterable<string | Uint8Array>) => {
+    // The fast-import stream is handed to git as a regular-file descriptor: a socketpair stdin
+    // wedges intermittently on macOS (task_fc929174), and the whole publication is one spawn.
     const temporaryRoot = path.join(repoRoot, ".harness"),
       temporaryPath = path.join(temporaryRoot, `.ha-fast-import-${process.pid}-${randomUUID()}`);
-    mkdirSync(temporaryRoot, { recursive: true });
-    let inputFd: number | null = null,
-      temporaryCreated = false;
+    localRuntimeStateFileSystem.mkdirp(temporaryRoot);
     try {
-      const outputFd = openSync(temporaryPath, "wx");
-      temporaryCreated = true;
-      try {
-        for (const chunk of input) {
-          const bytes = typeof chunk === "string" ? Buffer.from(chunk) : chunk;
-          for (let offset = 0; offset < bytes.byteLength; ) offset += writeSync(outputFd, bytes, offset);
-        }
-      } finally {
-        closeSync(outputFd);
-      }
-      inputFd = openSync(temporaryPath, "r");
-      return localGitBytes(
-        repoRoot,
-        ["-c", "core.fsync=committed,reference", "-c", "core.fsyncMethod=fsync", "fast-import", "--quiet", "--force"],
-        inputFd,
+      localRuntimeStateFileSystem.writeExclusiveStream(temporaryPath, input);
+      return localRuntimeStateFileSystem.withReadDescriptor(temporaryPath, (inputFd) =>
+        localGitBytes(
+          repoRoot,
+          ["-c", "core.fsync=committed,reference", "-c", "core.fsyncMethod=fsync", "fast-import", "--quiet", "--force"],
+          inputFd,
+        ),
       );
     } finally {
-      try {
-        if (inputFd !== null) closeSync(inputFd);
-      } finally {
-        if (temporaryCreated) unlinkSync(temporaryPath);
-      }
+      localRuntimeStateFileSystem.remove(temporaryPath);
     }
   },
   listRefs: (repoRoot: string, refs: readonly string[]) =>

--- a/packages/kernel/src/store/local-version-control-system.ts
+++ b/packages/kernel/src/store/local-version-control-system.ts
@@ -2,7 +2,7 @@ import {
   /* @gate-identity check-sync-subprocess/sync-subprocess-014 */
   execFileSync,
 } from "node:child_process";
-import { createHash } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import {
   closeSync,
   existsSync,
@@ -18,6 +18,7 @@ import {
   statSync,
   symlinkSync,
   unlinkSync,
+  writeSync,
   writeFileSync,
 } from "node:fs";
 import { open as openAsync } from "node:fs/promises";
@@ -204,17 +205,17 @@ function gitInvocation(
 function quoteWindowsCommandArgument(value: string): string {
   return /^[^\s"&|<>^()]+$/u.test(value) ? value : `"${value.replaceAll('"', '\\"')}"`;
 }
-function localGitBytes(repoRoot: string, args: readonly string[], input?: Uint8Array): Buffer {
+function localGitBytes(repoRoot: string, args: readonly string[], input?: Uint8Array | number): Buffer {
   localGitProcesses += 1;
   const invocation = gitInvocation(repoRoot, args);
   try {
     return (
       /* @gate-identity check-sync-subprocess/sync-subprocess-016 */
       execFileSync(invocation.command, invocation.args, {
-        input,
+        ...(typeof input === "number" ? {} : { input }),
         encoding: "buffer",
         maxBuffer: gitMaxBuffer,
-        stdio: [input ? "pipe" : "ignore", "pipe", "pipe"],
+        stdio: [typeof input === "number" ? input : input ? "pipe" : "ignore", "pipe", "pipe"],
         windowsHide: true,
         ...(process.platform === "win32" ? { windowsVerbatimArguments: true } : {}),
       })
@@ -316,11 +317,6 @@ export const localGitObjectRefStore = Object.freeze({
     flush();
     return bytesByTarget;
   },
-  writeBlob: (repoRoot: string, body: string) => {
-    const oid = localGitBytes(repoRoot, ["hash-object", "-w", "--stdin"], Buffer.from(body)).toString("utf8").trim();
-    if (!/^[0-9a-f]{40}$/u.test(oid)) throw new Error("Git hash-object returned no blob object id");
-    return oid;
-  },
   listTree: (
     repoRoot: string,
     commit: string,
@@ -350,12 +346,37 @@ export const localGitObjectRefStore = Object.freeze({
           : [];
       });
   },
-  importCommit: (repoRoot: string, input: string) =>
-    localGitBytes(
-      repoRoot,
-      ["-c", "core.fsync=committed,reference", "-c", "core.fsyncMethod=fsync", "fast-import", "--quiet", "--force"],
-      Buffer.from(input),
-    ),
+  importCommit: (repoRoot: string, input: Iterable<string | Uint8Array>) => {
+    const temporaryRoot = path.join(repoRoot, ".harness"),
+      temporaryPath = path.join(temporaryRoot, `.ha-fast-import-${process.pid}-${randomUUID()}`);
+    mkdirSync(temporaryRoot, { recursive: true });
+    let inputFd: number | null = null,
+      temporaryCreated = false;
+    try {
+      const outputFd = openSync(temporaryPath, "wx");
+      temporaryCreated = true;
+      try {
+        for (const chunk of input) {
+          const bytes = typeof chunk === "string" ? Buffer.from(chunk) : chunk;
+          for (let offset = 0; offset < bytes.byteLength; ) offset += writeSync(outputFd, bytes, offset);
+        }
+      } finally {
+        closeSync(outputFd);
+      }
+      inputFd = openSync(temporaryPath, "r");
+      return localGitBytes(
+        repoRoot,
+        ["-c", "core.fsync=committed,reference", "-c", "core.fsyncMethod=fsync", "fast-import", "--quiet", "--force"],
+        inputFd,
+      );
+    } finally {
+      try {
+        if (inputFd !== null) closeSync(inputFd);
+      } finally {
+        if (temporaryCreated) unlinkSync(temporaryPath);
+      }
+    }
+  },
   listRefs: (repoRoot: string, refs: readonly string[]) =>
     runGit(repoRoot, "for-each-ref", "--format=%(refname) %(objectname)", ...refs),
   updateRef: (repoRoot: string, ref: string, sha: string, previous?: string) => {

--- a/packages/kernel/src/store/task-event-store-git-refs.ts
+++ b/packages/kernel/src/store/task-event-store-git-refs.ts
@@ -11,21 +11,27 @@ export function prepareCommit(
 ): string {
   const message = `harness sqlite outbox ${opId}`,
     timestamp = Math.floor(Date.parse(occurredAt) / 1_000);
-  let input = [
-    `commit ${ref}\n`,
-    "mark :1\n",
-    `committer Harness SQLite Outbox <harness-sqlite-outbox@local.invalid> ${timestamp} +0000\n`,
-    `data ${Buffer.byteLength(message)}\n`,
-    `${message}\n`,
-    `from ${parent}\n`,
-  ].join("");
-  for (const file of files) {
-    if ("from" in file) input += `R ${file.from} ${file.to}\n`;
-    else if ("delete" in file) input += `D ${file.delete}\n`;
-    else input += `M ${file.mode} ${gitObjects.writeBlob(repoRoot, file.body)} ${file.target}\n`;
+  function* fastImportInput(): Generator<string> {
+    yield [
+      `commit ${ref}\n`,
+      "mark :1\n",
+      `committer Harness SQLite Outbox <harness-sqlite-outbox@local.invalid> ${timestamp} +0000\n`,
+      `data ${Buffer.byteLength(message)}\n`,
+      `${message}\n`,
+      `from ${parent}\n`,
+    ].join("");
+    for (const file of files) {
+      if ("from" in file) yield `R ${file.from} ${file.to}\n`;
+      else if ("delete" in file) yield `D ${file.delete}\n`;
+      else {
+        yield `M ${file.mode} inline ${file.target}\ndata ${Buffer.byteLength(file.body)}\n`;
+        yield file.body;
+        yield "\n";
+      }
+    }
+    yield "\nget-mark :1\ndone\n";
   }
-  input += "\nget-mark :1\ndone\n";
-  const sha = gitObjects.importCommit(repoRoot, input).toString("utf8").trim().split("\n").at(-1) ?? "";
+  const sha = gitObjects.importCommit(repoRoot, fastImportInput()).toString("utf8").trim().split("\n").at(-1) ?? "";
   if (!/^[0-9a-f]{40}$/u.test(sha)) throw new Error("Git outbox import returned no commit");
   return sha;
 }

--- a/packages/kernel/test/store/task-event-store-large-outbox.integration.test.ts
+++ b/packages/kernel/test/store/task-event-store-large-outbox.integration.test.ts
@@ -2,11 +2,11 @@
 import assert from "node:assert/strict";
 import { constants as bufferConstants } from "node:buffer";
 import { createHash } from "node:crypto";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, readdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
-import { localGitObjectRefStore } from "../../src/store/local-version-control-system.ts";
+import { localGitObjectRefStore, localGitProcessCount } from "../../src/store/local-version-control-system.ts";
 import { prepareCommit } from "../../src/store/task-event-store-git-refs.ts";
 import { git, initRepo } from "./task-event-store.fixtures.ts";
 
@@ -30,14 +30,17 @@ test(
       const aggregateBytes = files.reduce((total, file) => total + Buffer.byteLength(file.body), 0);
       assert.ok(aggregateBytes > 600 * 1024 * 1024);
       assert.ok(aggregateBytes > bufferConstants.MAX_STRING_LENGTH);
-      const commit = prepareCommit(
-        rootDir,
-        "refs/ha/tmp/large-outbox",
-        parent,
-        files,
-        "large-outbox",
-        "2026-09-06T00:00:00.000Z",
-      );
+      const beforePublicationProcesses = localGitProcessCount(),
+        commit = prepareCommit(
+          rootDir,
+          "refs/ha/tmp/large-outbox",
+          parent,
+          files,
+          "large-outbox",
+          "2026-09-06T00:00:00.000Z",
+        );
+      assert.equal(localGitProcessCount() - beforePublicationProcesses, 1);
+      assert.deepEqual(readdirSync(path.join(rootDir, ".harness")), []);
       assert.match(commit, /^[0-9a-f]{40}$/u);
       for (const file of files) {
         const readback = localGitObjectRefStore.readPath(rootDir, commit, file.target);
@@ -54,3 +57,23 @@ test(
     }
   },
 );
+
+test("Git outbox removes its fast-import file when publication fails", () => {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "harness-failed-outbox-"));
+  try {
+    initRepo(rootDir);
+    assert.throws(() =>
+      prepareCommit(
+        rootDir,
+        "refs/ha/tmp/failed-outbox",
+        "missing-parent",
+        [{ mode: "100644", target: "harness/failed.txt", body: "not published\n" }],
+        "failed-outbox",
+        "2026-09-06T00:00:00.000Z",
+      ),
+    );
+    assert.deepEqual(readdirSync(path.join(rootDir, ".harness")), []);
+  } finally {
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});

--- a/tools/gate-allowlists/check-bypass-write-boundary.json
+++ b/tools/gate-allowlists/check-bypass-write-boundary.json
@@ -628,6 +628,36 @@
         "api": "DatabaseSync",
         "ref": "dec_B1F5FF7648436C985F38F14226",
         "reason": "Opens the generation-scoped SQLite ledger store beneath the coordinated repo cell."
+      },
+      {
+        "value": "bypass-write-129",
+        "api": "openSync",
+        "ref": "dec_FC8D4B2DE22E97774073A0BBF9",
+        "reason": "Git follower fast-import stream is read back through a regular-file descriptor (no socketpair stdin)."
+      },
+      {
+        "value": "bypass-write-130",
+        "api": "closeSync",
+        "ref": "dec_FC8D4B2DE22E97774073A0BBF9",
+        "reason": "Git follower fast-import read descriptor is closed after the single git spawn."
+      },
+      {
+        "value": "bypass-write-131",
+        "api": "openSync",
+        "ref": "dec_FC8D4B2DE22E97774073A0BBF9",
+        "reason": "Git follower fast-import stream is created exclusively under the ledger .harness/ directory."
+      },
+      {
+        "value": "bypass-write-132",
+        "api": "writeSync",
+        "ref": "dec_FC8D4B2DE22E97774073A0BBF9",
+        "reason": "Git follower fast-import stream is written to the temporary file chunk by chunk."
+      },
+      {
+        "value": "bypass-write-133",
+        "api": "closeSync",
+        "ref": "dec_FC8D4B2DE22E97774073A0BBF9",
+        "reason": "Git follower fast-import stream file is closed before git reads it."
       }
     ],
     "exemptHumanOrBootstrap": [],


### PR DESCRIPTION
# English

## Summary

The Git follower published a commit by spawning `git hash-object -w --stdin` once per file (44k spawns for a canonical first publication) and then `git fast-import` once, all synchronously on the writer thread with `execFileSync` `input` over socketpair stdin. On macOS that stdin path wedges intermittently per spawn: the child sits in `read(0)` at 0 % CPU while the worker thread waits in `kevent`, and the process can no longer exit (`process.exit` blocks in `Worker::JoinThread`). Changeover attempt 4 (2026-09-07) died there, and the same host reproduces it without the daemon at spawn #285 of a small-blob storm. This PR publishes each commit with exactly one `git fast-import` whose blobs are inline data and whose stdin is a regular-file descriptor, and deletes `writeBlob`.

## Architectural Justification

- Not required (churn 85, net +27).

## What Changed

- `local-version-control-system.ts`: `importCommit` takes an iterable stream, writes it to a temporary file under the repository's `.harness/` through `localRuntimeStateFileSystem` (`writeExclusiveStream` / `withReadDescriptor` / `remove`) and runs `git fast-import` with that file's fd as stdin (no socketpair for stdin); no raw fs call in this module. `writeBlob` deleted. `localGitBytes` accepts an fd for stdin.
- `local-layout-file-system.ts`: the two new port methods; their five descriptor calls carry gate identities bypass-write-129..133 registered in the check-bypass-write-boundary allowlist (coordinatedCore).
- `task-event-store-git-refs.ts`: `prepareCommit` yields the fast-import stream as a generator with `M <mode> inline <path>` + `data <len>` blocks instead of pre-hashing blobs.
- `task-event-store-large-outbox.integration.test.ts`: asserts exactly one git spawn per publication (`localGitProcessCount` delta === 1), a > 600 MB batch publishes, and the temporary file is cleaned up on failure.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: use the single CI-backed `Production-Delta` declaration below; do not enter a second metric.

## Machine-Readable Declarations

Production-Delta: +72/-29

## Task And Scope

- Harness task: task_fc9291742da1c3a3a7555b85b9 (parent task_d1b1a445f32ffa19b5264ba950)
- Branch: codex/follower-hash-object
- Public scope: packages/kernel store git helpers and follower commit preparation; one kernel integration test
- Private planning/evidence updated: yes (task plan, facts F-1D4EE341 / F-DB8624CF, evidence dir macos-repro-20260907)
- Out of scope: stdout/stderr remain pipes (41-byte outputs; 8000-spawn control showed no issue); daemon rebuild and changeover attempt 5

## Version Impact

- Version: no version change because the change is internal to the kernel git publication path
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: yes
- Protected surface scope: tools/gate-allowlists/check-bypass-write-boundary.json (five new coordinatedCore entries bypass-write-129..133 for the fast-import stream file handled by localRuntimeStateFileSystem; no gate logic change, no other exemption)
- Authority: dec_FC8D4B2DE22E97774073A0BBF9
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: a014c58c7120b0e23c912674c7bad7777c4a9bdb
- Branch merge-base with `origin/main`: a014c58c7120b0e23c912674c7bad7777c4a9bdb
- Last `git fetch origin` time: 2026-09-07 14:38 CST
- Sync method: none needed
- Public diff command: `git diff a014c58c7...371c55137`
- Private evidence commit/path: harness/tasks/task_fc9291742da1c3a3a7555b85b9-*/artifacts/evidence/macos-repro-20260907/summary.md
- Reviewer evidence path: peer CEO macOS run of task-event-store-large-outbox.integration.test.ts (2/2, >600 MB batch in 8.6 s, single-spawn assertion)
- GitHub Actions `rewrite-ci` run URL: pending
- [x] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [x] `npm test` (targeted: large-outbox integration + fast/contract tiers by the worker; full matrix in CI)
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Not run: full local gate matrix (CI is the authority)

## Review Evidence

- Self-review: worker (Sol) targeted tests; CEO read of production hunks
- Reviewer subagent: peer CEO ground-truth on macOS (test re-run, semantic acceptance: single spawn, file-fd stdin, writeBlob removed)
- Human review: pending
- Blocking findings: none

## Residual Risk

- failing-before is a same-host reproduction outside the daemon (socketpair storm wedges at spawn #285; file-fd variant 8000/8000), not a CI-runnable test: the wedge is intermittent and macOS-specific, so the regression guard is structural (exactly one spawn, stdin from a file) rather than a timing test.
- The temporary fast-import file lives under the ledger repository's `.harness/`; a crash between write and unlink leaves a `.ha-fast-import-*` file behind (harmless, ignored by the follower).

## References

- Task: task_fc9291742da1c3a3a7555b85b9
- Evidence: F-1D4EE341, F-DB8624CF; harness/tasks/task_d1b1a445…/artifacts/ops/run4/evidence/wedge-summary.txt
- Review: peer CEO ground-truth message 2026-09-07 14:3x

---

# 中文

## 概要

Git follower 发布一个提交要逐文件 spawn `git hash-object -w --stdin`(canonical 首发布 44k 次)再 spawn 一次 `git fast-import`,全部在 writer 线程用 `execFileSync` 的 `input` 经 socketpair stdin 同步执行。macOS 上这条 stdin 路径每次 spawn 都有小概率挂死:子进程 0% CPU 卡在 `read(0)`,worker 线程卡在 `kevent`,进程随之无法退出(`process.exit` 卡在 `Worker::JoinThread`)。第四次换代(2026-09-07)死在这里,同一台机器不经 daemon 在小 blob 风暴第 285 次 spawn 复现。本 PR 改为每个提交只 spawn 一次 `git fast-import`,blob 走 inline data,stdin 是普通文件的 fd,并删除 `writeBlob`。

## 变更内容

- `local-version-control-system.ts`:`importCommit` 接收可迭代流,流式写到仓库 `.harness/` 下临时文件,再以该文件 fd 作 stdin 运行 `git fast-import`(stdin 不经 socketpair);所有退出路径都删临时文件。删除 `writeBlob`。`localGitBytes` 接受 fd 作 stdin。
- `task-event-store-git-refs.ts`:`prepareCommit` 用生成器产出 fast-import 流,`M <mode> inline <path>` + `data <len>`,不再预先 hash blob。
- `task-event-store-large-outbox.integration.test.ts`:断言每次发布恰好一次 git spawn(`localGitProcessCount` 差值 === 1)、>600 MB 批次可发布、失败时临时文件被清理。

## 任务与范围

- Harness 任务:task_fc9291742da1c3a3a7555b85b9(父 task_d1b1a445f32ffa19b5264ba950)
- 分支:codex/follower-hash-object
- 公开范围:packages/kernel store 的 git 辅助函数与 follower 提交组装;一个 kernel 集成测试
- 私有计划/证据已更新:是
- 不在范围:stdout/stderr 仍是 pipe;daemon 重建与第五次换代

## 版本影响

- 版本:无变更
- 发布影响:不发布

## 治理声明

- 触碰保护面:是
- 保护面范围:tools/gate-allowlists/check-bypass-write-boundary.json(新增 coordinatedCore 登记 bypass-write-129..133,对应 localRuntimeStateFileSystem 处理的 fast-import 流文件;不改门逻辑、不加其它豁免)
- 授权:dec_FC8D4B2DE22E97774073A0BBF9
- Break-glass:否

## 验证

- 定向测试:large-outbox 集成测试 2/2(macOS,>600 MB 批次 8.6 s,单 spawn 断言通过);fast/contract 层由 worker 跑;完整门矩阵以 GitHub CI 为准。

## 评审证据

- 自审:worker 定向测试;CEO 读生产 hunks
- 评审:peer CEO macOS ground-truth + 语义验收(单 spawn、文件 fd stdin、writeBlob 已删)
- 阻塞发现:无

## 残余风险

- failing-before 是同机 daemon 外复现(socketpair 风暴第 285 次挂;文件 fd 版 8000/8000),不是 CI 可跑的测试:挂死是间歇且 macOS 特有,所以回归护栏是结构断言(恰好一次 spawn、stdin 来自文件)而非计时测试。
- fast-import 临时文件在台账仓 `.harness/` 下;写入与删除之间崩溃会留下 `.ha-fast-import-*` 文件(无害,follower 忽略)。

## 参考

- 任务:task_fc9291742da1c3a3a7555b85b9
- 证据:F-1D4EE341、F-DB8624CF

🤖 Generated with [Claude Code](https://claude.com/claude-code)
