### PR TITLE
fix(daemon): relay enforced read-only runtime callbacks

### DIFF
--- a/packages/daemon/src/runtime-spawner.ts
+++ b/packages/daemon/src/runtime-spawner.ts
@@ -475,7 +475,7 @@ export function makeRuntimeSpawner(input: RuntimeSpawnerInput) {
         isSealedRuntimeDaemonRoute(daemonRoute) &&
         runtimeInstance?.kindId === "codex" &&
         runtimeInstance.isolationState === "enforced" &&
-        effectivePermissionMode === "workspace-write"
+        (effectivePermissionMode === "workspace-write" || effectivePermissionMode === "read-only")
           ? runtimeCallbackRelaySpec(input.rootDir, newDispatchId, daemonRoute)
           : undefined,
       missionDaemonRoute =

--- a/packages/daemon/test/runtime-spawn-ingress.integration.test.ts
+++ b/packages/daemon/test/runtime-spawn-ingress.integration.test.ts
@@ -284,7 +284,7 @@ test("daemon ingress preserves executor-scoped task-bound runtime spawn", async 
         /^# Agent Identity: Sol Reviewer \(sol-reviewer\)[\s\S]*AGENT_CLI_INGRESS_WITNESS[\s\S]*# Mission\n\nReview through the declared identity\.[\s\S]*# Read-only Dispatch Contract[\s\S]*final stdout/u,
       );
     });
-    await t.test("only enforced Codex workspace-write receives a callback relay", async () => {
+    await t.test("enforced Codex runtimes receive a callback relay without opening operator routes", async () => {
       const directEndpoint = localUserDaemonEndpoint(userRoot, "runtime-spawn-ingress"),
         cases = [
           {
@@ -351,10 +351,20 @@ test("daemon ingress preserves executor-scoped task-bound runtime spawn", async 
           },
         });
         assert.equal(receipt.outcome, "applied", JSON.stringify(receipt));
-        assert.equal(launchedEnv?.HARNESS_DAEMON_ENDPOINT, directEndpoint);
-        assert.equal(launchedEnv?.HARNESS_DAEMON_RELAY, undefined);
-        assert.equal(launchedPersistence?.callbackRelay, undefined);
-        assert.ok(launchedPrompt.includes(`Daemon endpoint: ${directEndpoint}`));
+        const receivesRelay = runtime.kindId === "codex" && runtime.isolationState === "enforced";
+        if (receivesRelay) {
+          assert.match(String(launchedEnv?.HARNESS_DAEMON_ENDPOINT), /[\\/]\.harness[\\/]r-[a-f0-9]{24}\.sock$/u);
+          assert.equal(launchedEnv?.HARNESS_DAEMON_RELAY, "1");
+          assert.doesNotMatch(String(launchedEnv?.HARNESS_DAEMON_ENDPOINT), /harness-anything/u);
+          assert.equal(launchedPersistence?.callbackRelay?.path, launchedEnv?.HARNESS_DAEMON_ENDPOINT);
+          assert.equal(launchedPersistence?.callbackRelay?.endpoint, directEndpoint);
+          assert.ok(launchedPrompt.includes(`Daemon endpoint: ${launchedEnv?.HARNESS_DAEMON_ENDPOINT}`));
+        } else {
+          assert.equal(launchedEnv?.HARNESS_DAEMON_ENDPOINT, directEndpoint);
+          assert.equal(launchedEnv?.HARNESS_DAEMON_RELAY, undefined);
+          assert.equal(launchedPersistence?.callbackRelay, undefined);
+          assert.ok(launchedPrompt.includes(`Daemon endpoint: ${directEndpoint}`));
+        }
       }
     });
     await t.test("the first dispatch holds the task lease and a concurrent second dispatch is rejected", async () => {


### PR DESCRIPTION
# English

## Summary

Extend the existing sealed callback relay to enforced Codex runtimes in `read-only` mode. This keeps governed task callbacks on the per-dispatch relay instead of exposing the private daemon endpoint.

## Architectural Justification

- The existing relay implementation already owns endpoint validation and lifecycle cleanup; this change widens only the admission condition and updates the ingress regression matrix.

## What Changed

- Enforced Codex runtimes using either `workspace-write` or `read-only` now receive a callback relay.
- Ordinary runtimes and non-enforced routes retain direct daemon routing.
- Regression coverage verifies relay use without opening operator routes.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none

## Machine-Readable Declarations

Dependency-Change: none

## Task And Scope

- Harness task: task_a78feb26d0bcfe1599e3494ca2-upstream-enforced-callback-and-squad-permission-follow-ups
- Branch: codex/upstream-readonly-relay-20260907
- Public scope: enforced Codex read-only callback relay admission and focused ingress regression coverage
- Private planning/evidence updated: yes
- Out of scope: provider configuration, target checkout changes, CI policy, publication automation, merge authority, and the separate Squad permission follow-up

## Version Impact

- Version: no version change because this is an internal daemon routing correctness fix
- Publish impact: no publish; publish readiness only

## Governance Declaration

- Protected surface touched: yes
- Protected surface scope: daemon runtime spawn routing and ingress integration test
- Authority: task_a78feb26d0bcfe1599e3494ca2
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no

## Verification

- Base `origin/main` SHA: dc1836afd499c36f9da5f68b09f8002e405c5ccb
- Branch merge-base with `origin/main`: dc1836afd499c36f9da5f68b09f8002e405c5ccb
- Last `git fetch origin` time: 2026-09-07
- Sync method: none needed
- Public diff command: `git diff --no-renames origin/main...HEAD`
- Private evidence commit/path: `F-590D1821`; `task_a78feb26d0bcfe1599e3494ca2-upstream-enforced-callback-and-squad-permission-follow-ups/artifacts/reports/upstream-callback-followups-verification.md`
- Reviewer evidence path: pending upstream review
- GitHub Actions `rewrite-ci` run URL: pending
- [ ] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [x] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Not run: `npm test -- --file packages/daemon/test/runtime-spawn-ingress.integration.test.ts` as a passing claim; the current host is Windows while this relay assertion is POSIX-only, and the run also hit a pre-existing Windows temporary-directory cleanup `EPERM`. Source Linux CI is the acceptance authority.

## Review Evidence

- Self-review: candidate cherry-picked cleanly onto the latest source `main`; diff is limited to two files and preserves non-enforced/direct-route behavior.
- Reviewer subagent: pending
- Human review: pending source maintainer
- Blocking findings: none known; platform-specific local test limitation is disclosed above.

## Residual Risk

The callback relay remains POSIX-only by design; Windows continues to use the existing direct route. Full source CI and maintainer review are required before merge.

## References

- Task: task_a78feb26d0bcfe1599e3494ca2-upstream-enforced-callback-and-squad-permission-follow-ups
- Evidence: F-590D1821 and the task verification report
- Review: pending

---

# 中文

## 概要

将现有受封装 callback relay 扩展到 enforced 且 `read-only` 的 Codex runtime，确保受治理的 task callback 继续使用按 dispatch 隔离的 relay，而不是暴露私有 daemon endpoint。

## 架构辩护

- 现有 relay 实现已经负责 endpoint 校验和生命周期清理；本变更只扩大准入条件，并更新 ingress 回归矩阵。

## 改动内容

- enforced Codex runtime 在 `workspace-write` 或 `read-only` 模式下均使用 callback relay。
- 普通 runtime 与非 enforced route 保持 direct daemon route。
- 回归测试验证 relay 路由不会开放 operator route。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 同 commit 删除的门 / fixture：none
- 生产净行数：由机器 gate 计算。

## 任务与范围

- Harness 任务：task_a78feb26d0bcfe1599e3494ca2-upstream-enforced-callback-and-squad-permission-follow-ups
- 分支：codex/upstream-readonly-relay-20260907
- 公开范围：enforced Codex read-only callback relay 准入与 ingress 定向回归覆盖
- 私有计划 / 证据是否已更新：yes
- 范围外：provider 配置、target checkout、CI 策略、发布自动化、合并权限，以及独立的 Squad permission follow-up

## 版本影响

- 版本：不变更，这是内部 daemon 路由正确性修复
- 发布影响：不发布；仅做发布准备

## 治理声明

- 是否触碰 protected surface：yes
- protected surface 范围：daemon runtime spawn 路由与 ingress 集成测试
- 依据：task_a78feb26d0bcfe1599e3494ca2
- 机器检查边界：本 PR 只声明该段存在；声明是否真实、充分，由 reviewer 判断。
- Break-glass：no

## 验证

- `origin/main` 基准 SHA：dc1836afd499c36f9da5f68b09f8002e405c5ccb
- 当前分支与 `origin/main` 的 merge-base：dc1836afd499c36f9da5f68b09f8002e405c5ccb
- 最近一次 `git fetch origin` 时间：2026-09-07
- 同步方式：不需要
- 公开 diff 命令：`git diff --no-renames origin/main...HEAD`
- 私有证据 commit/path：`F-590D1821`；`task_a78feb26d0bcfe1599e3494ca2-upstream-enforced-callback-and-squad-permission-follow-ups/artifacts/reports/upstream-callback-followups-verification.md`
- Reviewer 证据路径：等待 upstream review
- GitHub Actions `rewrite-ci` run URL：等待 CI
- [ ] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [x] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- 未运行：不把 `npm test -- --file packages/daemon/test/runtime-spawn-ingress.integration.test.ts` 计为通过；当前主机为 Windows，而该 relay 断言是 POSIX-only，且运行中还遇到既有的 Windows 临时目录清理 `EPERM`。最终以源库 Linux CI 为验收依据。

## 审查证据

- 自查：候选已干净 cherry-pick 到最新源库 `main`；diff 只涉及两个文件，并保留非 enforced/direct route 行为。
- Reviewer subagent：等待
- 人工审查：等待源库 maintainer
- 阻塞发现：暂无；本地平台测试限制已如实披露。

## 残余风险

callback relay 按设计仅支持 POSIX；Windows 继续使用现有 direct route。合并前仍需完整源库 CI 与 maintainer review。

## 关联材料

- 任务：task_a78feb26d0bcfe1599e3494ca2-upstream-enforced-callback-and-squad-permission-follow-ups
- 证据：F-590D1821 与任务验证报告
- Review：等待

## PR Gate Checklist / PR 门禁清单

- [x] Branch is based on latest `origin/main`. / 分支基于最新 `origin/main`。
- [x] PR body uses this full template structure. / PR 描述使用本模板完整结构。
- [x] PR body uses two complete language blocks: `# English` first, then `# 中文`. / PR 正文使用两块完整正文：`# English` 在上，`# 中文` 在下。
- [ ] PR body passes `tools/check-pr-body-bilingual.mjs`. / PR 正文等待 CI 校验。
- [x] If the PR touches a manifest-derived protected surface, Governance Declaration is filled with task evidence. / 已填写 task 依据。
- [x] No private harness files are included. / 不包含私有 harness 文件。
- [x] No ignored local agent entry files are included. / 不包含被忽略的本地 agent 入口文件。
- [x] No absolute local filesystem paths are included in this public PR body. / 不包含本机绝对路径。
- [x] Public diff is limited to the stated task scope. / 公开 diff 限于声明范围。
- [x] Version and publish impact are stated. / 已说明版本与发布影响。
- [x] Local verification commands are stated honestly. / 已如实说明本地验证。
- [ ] CI results are linked or explained. / CI 结果等待。
- [ ] Review evidence is recorded. / 审查证据等待。
- [x] Open P0/P1/P2 findings are explicitly blocked by maintainer review. / 当前无已知 P0/P1/P2；合并需 maintainer review。
- [x] Merge method and post-merge branch cleanup plan are clear. / 采用普通 PR 合并，合并后删除候选分支。
- [x] No admin bypass is planned. / 不使用 admin bypass。