### PR TITLE
fix(kernel): batch follower certification reads and file-back every synchronous git stdin

### DIFF
--- a/packages/kernel/src/store/local-version-control-system.ts
+++ b/packages/kernel/src/store/local-version-control-system.ts
@@ -230,6 +230,24 @@ function localGitBytes(repoRoot: string, args: readonly string[], input?: Uint8A
     });
   }
 }
+// Synchronous git input always travels through a regular-file descriptor: a socketpair stdin
+// wedges intermittently on macOS worker threads (task_fc929174), whatever the payload size.
+function withStdinFile<T>(
+  repoRoot: string,
+  prefix: string,
+  chunks: Iterable<string | Uint8Array>,
+  run: (descriptor: number) => T,
+): T {
+  const temporaryRoot = path.join(repoRoot, ".harness"),
+    temporaryPath = path.join(temporaryRoot, `${prefix}${process.pid}-${randomUUID()}`);
+  localRuntimeStateFileSystem.mkdirp(temporaryRoot);
+  try {
+    localRuntimeStateFileSystem.writeExclusiveStream(temporaryPath, chunks);
+    return localRuntimeStateFileSystem.withReadDescriptor(temporaryPath, run);
+  } finally {
+    localRuntimeStateFileSystem.remove(temporaryPath);
+  }
+}
 export const localGitObjectRefStore = Object.freeze({
   processCount: () => localGitProcesses,
   commitTimestamp: (repoRoot: string, commit: string): string | null => {
@@ -288,10 +306,11 @@ export const localGitObjectRefStore = Object.freeze({
       chunkBytes = 0;
     const flush = () => {
       if (chunk.length === 0) return;
-      const output = localGitBytes(
+      const output = withStdinFile(
         repoRoot,
-        ["cat-file", "--batch"],
-        Buffer.from(chunk.map(({ target }) => `${commit}:${target}\n`).join("")),
+        ".ha-cat-file-batch-",
+        [chunk.map(({ target }) => `${commit}:${target}\n`).join("")],
+        (inputFd) => localGitBytes(repoRoot, ["cat-file", "--batch"], inputFd),
       );
       let offset = 0;
       for (const { target } of chunk) {
@@ -346,25 +365,14 @@ export const localGitObjectRefStore = Object.freeze({
           : [];
       });
   },
-  importCommit: (repoRoot: string, input: Iterable<string | Uint8Array>) => {
-    // The fast-import stream is handed to git as a regular-file descriptor: a socketpair stdin
-    // wedges intermittently on macOS (task_fc929174), and the whole publication is one spawn.
-    const temporaryRoot = path.join(repoRoot, ".harness"),
-      temporaryPath = path.join(temporaryRoot, `.ha-fast-import-${process.pid}-${randomUUID()}`);
-    localRuntimeStateFileSystem.mkdirp(temporaryRoot);
-    try {
-      localRuntimeStateFileSystem.writeExclusiveStream(temporaryPath, input);
-      return localRuntimeStateFileSystem.withReadDescriptor(temporaryPath, (inputFd) =>
-        localGitBytes(
-          repoRoot,
-          ["-c", "core.fsync=committed,reference", "-c", "core.fsyncMethod=fsync", "fast-import", "--quiet", "--force"],
-          inputFd,
-        ),
-      );
-    } finally {
-      localRuntimeStateFileSystem.remove(temporaryPath);
-    }
-  },
+  importCommit: (repoRoot: string, input: Iterable<string | Uint8Array>) =>
+    withStdinFile(repoRoot, ".ha-fast-import-", input, (inputFd) =>
+      localGitBytes(
+        repoRoot,
+        ["-c", "core.fsync=committed,reference", "-c", "core.fsyncMethod=fsync", "fast-import", "--quiet", "--force"],
+        inputFd,
+      ),
+    ),
   listRefs: (repoRoot: string, refs: readonly string[]) =>
     runGit(repoRoot, "for-each-ref", "--format=%(refname) %(objectname)", ...refs),
   updateRef: (repoRoot: string, ref: string, sha: string, previous?: string) => {

--- a/packages/kernel/src/store/sqlite-task-event-store.ts
+++ b/packages/kernel/src/store/sqlite-task-event-store.ts
@@ -641,33 +641,47 @@ function verifyDocumentClosure(
   commit: string,
   closure: ReturnType<typeof documentClosure>,
 ): void {
-  const modes = new Map(
-    localGitObjectRefStore.listTree(ledger.rootDir, commit).map((entry) => [entry.target, entry.mode]),
-  );
+  const tree = new Map(localGitObjectRefStore.listTree(ledger.rootDir, commit).map((entry) => [entry.target, entry])),
+    bodies = localGitObjectRefStore.readPaths(
+      ledger.rootDir,
+      commit,
+      [...closure.documents.keys()].flatMap((logical) => {
+        const entry = tree.get(ledgerGitPath(ledger, logical));
+        return entry ? [{ target: entry.target, size: entry.size }] : [];
+      }),
+    );
   for (const [logical, expected] of closure.documents) {
     const target = ledgerGitPath(ledger, logical),
-      bytes = localGitObjectRefStore.readPath(ledger.rootDir, commit, target);
+      bytes = bodies.get(target) ?? null;
     if (
       bytes === null ||
       bytes.byteLength !== expected.size ||
       sha256Text(bytes.toString("utf8")) !== expected.sha256 ||
-      modes.get(target) !== expected.mode
+      tree.get(target)?.mode !== expected.mode
     )
       throw new TaskEventStoreError("publication_indeterminate", `Git follower document differs at ${logical}`);
   }
   for (const logical of closure.retirements)
-    if (localGitObjectRefStore.readPath(ledger.rootDir, commit, ledgerGitPath(ledger, logical)) !== null)
+    if (tree.has(ledgerGitPath(ledger, logical)))
       throw new TaskEventStoreError("publication_indeterminate", `Git follower retirement differs at ${logical}`);
 }
 
 function verifyGitFiles(repoRoot: string, commit: string, files: readonly PublicationFile[]): void {
-  const modes = new Map(localGitObjectRefStore.listTree(repoRoot, commit).map((entry) => [entry.target, entry.mode]));
+  const tree = new Map(localGitObjectRefStore.listTree(repoRoot, commit).map((entry) => [entry.target, entry])),
+    bodies = localGitObjectRefStore.readPaths(
+      repoRoot,
+      commit,
+      files.flatMap((file) => {
+        const entry = "target" in file ? tree.get(file.target) : undefined;
+        return entry ? [{ target: entry.target, size: entry.size }] : [];
+      }),
+    );
   for (const file of files) {
     if ("target" in file) {
-      const body = localGitObjectRefStore.readPath(repoRoot, commit, file.target)?.toString("utf8") ?? null;
-      if (body !== file.body || modes.get(file.target) !== file.mode)
+      const body = bodies.get(file.target)?.toString("utf8") ?? null;
+      if (body !== file.body || tree.get(file.target)?.mode !== file.mode)
         throw new TaskEventStoreError("publication_indeterminate", `Git follower read-back differs at ${file.target}`);
-    } else if ("delete" in file && localGitObjectRefStore.readPath(repoRoot, commit, file.delete) !== null) {
+    } else if ("delete" in file && tree.has(file.delete)) {
       throw new TaskEventStoreError("publication_indeterminate", `Git follower did not retire ${file.delete}`);
     }
   }
@@ -770,17 +784,27 @@ function captureGitBaseline(
   commit: string,
   files: readonly PublicationFile[],
 ): ReadonlyMap<string, string> {
-  const modes = new Map(localGitObjectRefStore.listTree(repoRoot, commit).map((entry) => [entry.target, entry.mode]));
-  return new Map(
-    files.flatMap((file) => {
+  const tree = new Map(localGitObjectRefStore.listTree(repoRoot, commit).map((entry) => [entry.target, entry])),
+    targets = files.flatMap((file) => {
       const target = "target" in file ? file.target : "delete" in file ? file.delete : null;
-      if (target === null) return [];
-      const bytes = localGitObjectRefStore.readPath(repoRoot, commit, target);
+      return target === null ? [] : [target];
+    }),
+    bodies = localGitObjectRefStore.readPaths(
+      repoRoot,
+      commit,
+      targets.flatMap((target) => {
+        const entry = tree.get(target);
+        return entry ? [{ target, size: entry.size }] : [];
+      }),
+    );
+  return new Map(
+    targets.map((target) => {
+      const bytes = bodies.get(target) ?? null;
       return [
-        [
-          target,
-          bytes === null ? "missing" : `${modes.get(target)}:${sha256Text(bytes.toString("utf8"))}:${bytes.byteLength}`,
-        ],
+        target,
+        bytes === null
+          ? "missing"
+          : `${tree.get(target)?.mode}:${sha256Text(bytes.toString("utf8"))}:${bytes.byteLength}`,
       ];
     }),
   );


### PR DESCRIPTION
# English

## Summary

Cold-start certification of the Git follower (`certifiedFollowerRevision → verifyGitFiles`) and the publication baseline (`captureGitBaseline`) read every closure file with its own `git show` process. At canonical scale (44k content files) that is ~44k synchronous spawns (~10 minutes) on the writer thread at every daemon start and for every converted repository, during which the repository is unreadable. The read side was batched in PR #2334; this PR batches the verify/baseline side the same way and files-backs the remaining synchronous git stdin.

## Architectural Justification

- Not required (churn under 200, net small).

## What Changed

- `sqlite-task-event-store.ts`: `verifyGitFiles`, `captureGitBaseline` and `verifyDocumentClosure` list the tree once and read bodies through the batched `readPaths` (chunked `cat-file --batch`); retirements are checked against the listed tree instead of a per-path read. Error messages and baseline fingerprints unchanged.
- `local-version-control-system.ts`: new `withStdinFile` helper (temp file under the ledger `.harness/` via the governed `localRuntimeStateFileSystem` port, read back as an fd); `importCommit` and the `readPaths` batch list both use it, so no synchronous git call feeds stdin through a socketpair (see PR #2342).

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: use the single CI-backed `Production-Delta` declaration below; do not enter a second metric.

## Machine-Readable Declarations

Production-Delta: +73/-41

## Task And Scope

- Harness task: task_452cc5b910e080cf4bce2a2cf4 (parent task_d1b1a445f32ffa19b5264ba950)
- Branch: codex/batched-certification
- Public scope: packages/kernel store git verification and baseline paths
- Private planning/evidence updated: yes (task plan; real-copy rehearsal baseline by the peer CEO)
- Out of scope: the offline publication's dirty-worktree behaviour (task_c028bbc0f78cd2c1f65f9abb4f)

## Version Impact

- Version: no version change because the change is internal to the kernel git follower
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: not applicable
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: dc1836afd499c36f9da5f68b09f8002e405c5ccb
- Branch merge-base with `origin/main`: dc1836afd499c36f9da5f68b09f8002e405c5ccb
- Last `git fetch origin` time: 2026-09-07 15:5x CST
- Sync method: none needed
- Public diff command: `git diff dc1836afd...4791170e1`
- Private evidence commit/path: harness/tasks/task_452cc5b910e080cf4bce2a2cf4-*/task_plan.md
- Reviewer evidence path: peer CEO real-copy rehearsal (failing-before: ~44k spawns / ~10 min certification; passing-after to be re-run on the same copy)
- GitHub Actions `rewrite-ci` run URL: pending
- [x] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [x] `npm run typecheck` (kernel package tsc --noEmit)
- [x] `npm test` (fast + contract tiers 1026 pass; large-outbox 2/2; sqlite-event-store integration 20/20; legacy-generation-conversion integration 9/9)
- [x] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Not run: full local gate matrix (CI is the authority)

## Review Evidence

- Self-review: CEO-authored known diff; bypass-write and dead-export gates green locally
- Reviewer subagent: peer CEO ground-truth on the real canonical copy (spawn count and wall clock before/after)
- Human review: pending
- Blocking findings: none

## Residual Risk

- `readPaths` chunking (64 MiB / 4096 entries) bounds memory per batch; a closure with a single object above 64 MiB is still read in its own batch.

## References

- Task: task_452cc5b910e080cf4bce2a2cf4
- Evidence: peer CEO rehearsal sample (captureGitBaseline hot spot `ArrayPrototypeFlatMap → SyncProcessRunner::Spawn`)
- Review: pending

---

# 中文

## 概要

Git follower 冷启动认证(`certifiedFollowerRevision → verifyGitFiles`)与发布基线(`captureGitBaseline`)对闭包每个文件各起一个 `git show` 进程。canonical 规模(44k 内容文件)下就是 writer 线程上 ~44k 次同步 spawn(约 10 分钟),每次 daemon 启动、每个已转换仓库都要付一遍,期间该仓不可读。读侧已在 #2334 批量化;本 PR 把校验/基线侧同样批量化,并把剩余的同步 git stdin 全部改走文件。

## 变更内容

- `sqlite-task-event-store.ts`:`verifyGitFiles`、`captureGitBaseline`、`verifyDocumentClosure` 只 list 一次树,经批量 `readPaths`(分块 `cat-file --batch`)读正文;退休项对照树列表而非逐路径读。错误消息与基线指纹不变。
- `local-version-control-system.ts`:新增 `withStdinFile`(经受治理端口在台账 `.harness/` 下写临时文件、以 fd 读回);`importCommit` 与 `readPaths` 的批次清单都用它,同步 git 调用不再有 socketpair stdin(见 #2342)。

## 任务与范围

- Harness 任务:task_452cc5b910e080cf4bce2a2cf4(父 task_d1b1a445f32ffa19b5264ba950)
- 分支:codex/batched-certification
- 不在范围:离线发布遇脏 worktree 的行为(task_c028bbc0f78cd2c1f65f9abb4f)

## 版本影响

- 版本:无变更;发布影响:不发布

## 治理声明

- 触碰保护面:否;Break-glass:否

## 验证

- fast+contract 1026 通过;large-outbox 2/2;sqlite-event-store 集成 20/20;legacy-generation-conversion 集成 9/9;kernel tsc 通过;完整门矩阵以 CI 为准。

## 评审证据

- peer CEO 在真实 canonical 副本上的前后对照(spawn 数与墙钟)。

## 残余风险

- `readPaths` 分块上限 64 MiB / 4096 条,单个超过 64 MiB 的对象仍单独成批。

## 参考

- 任务:task_452cc5b910e080cf4bce2a2cf4

🤖 Generated with [Claude Code](https://claude.com/claude-code)
