### PR TITLE
fix(daemon): explain dispatch-less review recovery

### DIFF
--- a/packages/daemon/src/repo-cell-proof.ts
+++ b/packages/daemon/src/repo-cell-proof.ts
@@ -155,7 +155,10 @@ export async function proofFor(
         (settings.reviewIndependence === "execution"
           ? isIndependentFrom(execution.actor, command.actor)
           : !isSamePerson(execution.actor, command.actor)),
-      dispatchlessExecution = execution?.actor.executor === null && command.actor.executor === null,
+      dispatchlessExecution =
+        execution?.actor.executor === null &&
+        command.actor.executor === null &&
+        readTaskLineageDispatches({ projection, rootDir, taskId: command.taskId }).length === 0,
       principalIndependenceRequired =
         settings.reviewIndependence === "principal" &&
         execution !== undefined &&

--- a/packages/daemon/src/repo-cell-proof.ts
+++ b/packages/daemon/src/repo-cell-proof.ts
@@ -204,7 +204,17 @@ export async function proofFor(
               expectation:
                 "Use a reviewer with a different principal, or run ha settings update --review-independence execution",
             }
-          : undefined,
+          : dispatchlessExecution
+            ? {
+                kind: "validation",
+                entity: "task review",
+                field: "actor",
+                actual: "dispatch-less execution and reviewer",
+                expectation:
+                  "Use a different person, or run the review with HARNESS_ACTOR=agent:<id>; " +
+                  "declare-executor requires an existing dispatch record",
+              }
+            : undefined,
       );
     }
     return {

--- a/packages/daemon/src/repo-cell-proof.ts
+++ b/packages/daemon/src/repo-cell-proof.ts
@@ -155,35 +155,44 @@ export async function proofFor(
         (settings.reviewIndependence === "execution"
           ? isIndependentFrom(execution.actor, command.actor)
           : !isSamePerson(execution.actor, command.actor)),
+      dispatchlessExecution = execution?.actor.executor === null && command.actor.executor === null,
+      principalIndependenceRequired =
+        settings.reviewIndependence === "principal" &&
+        execution !== undefined &&
+        isSamePerson(execution.actor, command.actor),
       externalCompletionEvidence = independentActor
         ? false
         : validExternalCompletionEvidence(command, projection, rootDir),
       explicitlyUnreviewed = independentActor ? false : validNoIndependentReview(command, projection, rootDir);
     if (!independentActor && !externalCompletionEvidence && !explicitlyUnreviewed) {
       const principalSettingGuidance =
-        settings.reviewIndependence === "principal" &&
-        execution !== undefined &&
-        isSamePerson(execution.actor, command.actor)
+        principalIndependenceRequired
           ? [
               "Repository setting reviewIndependence currently equals principal, so the reviewer and execution " +
                 "actor must have different principals.",
               "ha settings update --review-independence execution",
             ]
-          : reviewCriterion.nextActions;
+          : dispatchlessExecution
+            ? [
+                "Have a different person run the review, or use HARNESS_ACTOR=agent:<id> for an auditable " +
+                  "same-principal review; ha task declare-executor requires an existing dispatch record and is " +
+                  "unavailable for this execution.",
+              ]
+            : reviewCriterion.nextActions;
       throw cellCriterionError(
         "actor_unauthorized",
-        settings.reviewIndependence === "principal" &&
-          execution !== undefined &&
-          isSamePerson(execution.actor, command.actor)
+        principalIndependenceRequired
           ? "Repository setting reviewIndependence is principal; the reviewer and execution actor have the same " +
               "principal. Change it with `ha settings update --review-independence execution`."
-          : "Task review actor independence proof was not satisfied.",
+          : dispatchlessExecution
+            ? "Task review actor independence proof was not satisfied: the submitted execution has no executor " +
+              "and the current reviewer has no executor. Use a different person, or run the review with " +
+              "HARNESS_ACTOR=agent:<id>; declare-executor requires an existing dispatch record."
+            : "Task review actor independence proof was not satisfied.",
         "review",
         REVIEW_PROOF_CRITERION,
         principalSettingGuidance,
-        settings.reviewIndependence === "principal" &&
-          execution !== undefined &&
-          isSamePerson(execution.actor, command.actor)
+        principalIndependenceRequired
           ? {
               kind: "validation",
               entity: "repository setting",

--- a/packages/daemon/src/task-action-catalog-runtime.ts
+++ b/packages/daemon/src/task-action-catalog-runtime.ts
@@ -380,10 +380,9 @@ function taskActionRejection(
       if (!criterion) throw new Error(`Task Action ${contract.id} criterion ${criterionRef} is not declared.`);
       return criterion;
     }),
-    nextActions =
-      rejected?.diagnostic && rejected.diagnostic.kind !== "failure"
-        ? Object.freeze([])
-        : Object.freeze([...new Set([...unmet.flatMap(({ nextActions: next }) => next)])]),
+    nextActions = rejected?.diagnostic
+      ? Object.freeze([])
+      : Object.freeze([...new Set([...unmet.flatMap(({ nextActions: next }) => next)])]),
     first = unmetCriteria[0]!;
   return {
     ...(rejected ??

--- a/packages/daemon/src/task-action-catalog-runtime.ts
+++ b/packages/daemon/src/task-action-catalog-runtime.ts
@@ -380,9 +380,10 @@ function taskActionRejection(
       if (!criterion) throw new Error(`Task Action ${contract.id} criterion ${criterionRef} is not declared.`);
       return criterion;
     }),
-    nextActions = rejected?.diagnostic
-      ? Object.freeze([])
-      : Object.freeze([...new Set([...unmet.flatMap(({ nextActions: next }) => next)])]),
+    nextActions =
+      rejected?.diagnostic && rejected.diagnostic.kind !== "failure"
+        ? Object.freeze([])
+        : Object.freeze([...new Set([...unmet.flatMap(({ nextActions: next }) => next)])]),
     first = unmetCriteria[0]!;
   return {
     ...(rejected ??

--- a/packages/daemon/test/review-independence-diagnostics.integration.test.ts
+++ b/packages/daemon/test/review-independence-diagnostics.integration.test.ts
@@ -426,8 +426,6 @@ test("a child bare-invocation execution can recover from its parent Task dispatc
       bare,
     );
     assert.equal(dispatchCannotBeSkipped.code, "actor_unauthorized", JSON.stringify(dispatchCannotBeSkipped));
-    assert.match(JSON.stringify(dispatchCannotBeSkipped), /HARNESS_ACTOR=agent:<id>/u);
-    assert.match(JSON.stringify(dispatchCannotBeSkipped), /declare-executor requires an existing dispatch record/u);
     writeFileSync(
       path.join(rootDir, "no-independent-review.json"),
       JSON.stringify({
@@ -638,6 +636,8 @@ test("a reviewed child execution cannot declare an executor when neither it nor 
       bare,
     );
     assert.equal(unmarked.code, "actor_unauthorized", JSON.stringify(unmarked));
+    assert.match(JSON.stringify(unmarked), /HARNESS_ACTOR=agent:<id>/u);
+    assert.match(JSON.stringify(unmarked), /declare-executor requires an existing dispatch record/u);
     writeFileSync(
       path.join(rootDir, "no-independent-review.json"),
       JSON.stringify({

--- a/packages/daemon/test/review-independence-diagnostics.integration.test.ts
+++ b/packages/daemon/test/review-independence-diagnostics.integration.test.ts
@@ -426,6 +426,8 @@ test("a child bare-invocation execution can recover from its parent Task dispatc
       bare,
     );
     assert.equal(dispatchCannotBeSkipped.code, "actor_unauthorized", JSON.stringify(dispatchCannotBeSkipped));
+    assert.match(JSON.stringify(dispatchCannotBeSkipped), /HARNESS_ACTOR=agent:<id>/u);
+    assert.match(JSON.stringify(dispatchCannotBeSkipped), /declare-executor requires an existing dispatch record/u);
     writeFileSync(
       path.join(rootDir, "no-independent-review.json"),
       JSON.stringify({


### PR DESCRIPTION
# English

## Summary

Fix the dispatch-less `review-execution` deadlock from #2052. When the submitted execution and reviewer both have no executor, and neither the task nor its parent lineage has a runtime dispatch, the rejection now exposes a reachable `HARNESS_ACTOR=agent:<id>` recovery path instead of recommending `ha task declare-executor`, which requires an existing dispatch record.

## What Changed

- Scope the dispatch-less branch to an empty task-lineage dispatch set.
- Preserve the existing parent-dispatch recovery behavior.
- Include the reachable recovery path in a structured validation diagnostic.
- Add regression assertions for the true dispatch-less case.

## Verification

- `npm run typecheck`
- `npm run lint`
- `git diff --check`
- `npm test -- --file packages/daemon/test/review-independence-diagnostics.integration.test.ts`

All five target tests reached their business assertions successfully. The three test processes then hit Windows `EPERM` while removing temporary daemon directories; no business-assertion failure was observed. Source GitHub CI is the acceptance authority.

## Scope

- Harness task: task_a78feb26d0bcfe1599e3494ca2-upstream-enforced-callback-and-squad-permission-follow-ups
- Branch: codex/upstream-dispatchless-review-20260907
- Issue: #2052
- No dependency, version, provider, CI-policy, or target-checkout changes.

## Review Status

Maintainer review pending. No admin bypass planned.

---

# 中文

## 概要

修复 #2052 所述的 dispatch-less `review-execution` 死循环。当提交执行和审核者都没有 executor，且 task 及其父链都没有 runtime dispatch 时，拒绝结果现在提供可达的 `HARNESS_ACTOR=agent:<id>` 恢复路径，而不是建议需要已有 dispatch record 的 `ha task declare-executor`。

## 改动内容

- 仅当 task lineage 没有 dispatch 时进入 dispatch-less 分支。
- 保持已有父 dispatch 恢复流程不变。
- 通过 structured validation diagnostic 携带可达恢复路径。
- 为真正的 dispatch-less 场景增加回归断言。

## 验证

- `npm run typecheck`
- `npm run lint`
- `git diff --check`
- `npm test -- --file packages/daemon/test/review-independence-diagnostics.integration.test.ts`

五个目标测试均成功执行到业务断言。随后三个测试进程在 Windows 删除临时 daemon 目录时遇到 `EPERM`；未观察到业务断言失败。最终以源库 GitHub CI 作为验收依据。

## 范围

- Harness 任务：task_a78feb26d0bcfe1599e3494ca2-upstream-enforced-callback-and-squad-permission-follow-ups
- 分支：codex/upstream-dispatchless-review-20260907
- Issue：#2052
- 不涉及依赖、版本、provider、CI 策略或 target checkout 变更。

## 审查状态

等待 maintainer review，不使用 admin bypass。

## PR Gate Checklist / PR 门禁清单

- [x] Two complete language blocks with `# English` first and `# 中文` second. / 使用两块完整双语正文，`# English` 在前、`# 中文` 在后。
- [x] No private harness files or local absolute paths. / 不包含私有 harness 文件或本机绝对路径。
- [x] Local verification is stated honestly. / 已如实说明本地验证。
- [ ] GitHub Actions checks passed. / GitHub Actions 检查等待完成。
- [ ] Maintainer review completed. / Maintainer review 等待完成。
- [x] No admin bypass is planned. / 不使用 admin bypass。

Closes #2052