### PR TITLE
fix(kernel): normalize legacy import event shapes in the generation-1 conversion

### DIFF
--- a/packages/daemon/test/legacy-generation-conversion.integration.test.ts
+++ b/packages/daemon/test/legacy-generation-conversion.integration.test.ts
@@ -352,6 +352,7 @@ test("immutable generation-0 conversion retries into inactive generation-1 witho
       })),
       [
         { name: "task-v2-snapshots", count: 0, firstRevision: null, lastRevision: null },
+        { name: "legacy-import-normalization", count: 0, firstRevision: null, lastRevision: null },
         { name: "relation-events", count: 0, firstRevision: null, lastRevision: null },
         { name: "review-submission-pins", count: 0, firstRevision: null, lastRevision: null },
         { name: "decision-digests", count: 0, firstRevision: null, lastRevision: null },

--- a/packages/kernel/src/store/event-shape-migration.ts
+++ b/packages/kernel/src/store/event-shape-migration.ts
@@ -28,6 +28,7 @@ import { isRelationEvent } from "../domain/relation-event.ts";
 import { isTaskBootstrapEvent } from "../domain/task-bootstrap-event.ts";
 import { isTaskEvent } from "../domain/doc-sync-canonical-events.ts";
 import { validateTaskV2, type TaskV2 } from "../domain/task.ts";
+import { normalizePersistedTimestamp } from "../domain/timestamp.ts";
 import { sha256Text } from "../integrity/stable-hash.ts";
 import { localRuntimeStateFileSystem } from "../local/local-layout-file-system.ts";
 import { makeTaskProjection } from "../projection/rebuildable-task-projection-factory.ts";
@@ -42,6 +43,7 @@ import type { CanonicalContentBlob, CanonicalEventStore } from "./task-event-sto
 // active store. Conversion validates the complete plan before seeding an inactive destination.
 export type EventShapeMigrationName =
   | "task-v2-snapshots"
+  | "legacy-import-normalization"
   | "relation-events"
   | "review-submission-pins"
   | "decision-digests"
@@ -49,6 +51,7 @@ export type EventShapeMigrationName =
   | "settings-wal-flush";
 export type EventShapeMigrationKind =
   | "task-v2-snapshots-migrate"
+  | "legacy-import-normalization-migrate"
   | "relation-events-migrate"
   | "review-submission-pins-migrate"
   | "decision-digests-migrate"
@@ -163,6 +166,67 @@ const taskV2SnapshotsMigration: EventShapeMigrationSpec = {
       category: "retired Task.relations dropped after canonical relation event",
       before: legacy.task,
       after: task,
+    };
+  },
+};
+
+function normalizeEmbeddedTaskToCurrentTaskV2(task: TaskV2): TaskV2 | null {
+  const current = task as TaskV2 & { readonly pinned?: unknown };
+  let normalized: TaskV2 = Object.hasOwn(current, "pinned") ? current : { ...current, pinned: false };
+  if (normalized.metadata !== undefined) {
+    const { longRunning: _retiredLongRunning, ...metadata } = normalized.metadata as TaskV2["metadata"] & {
+      readonly longRunning?: unknown;
+    };
+    normalized = {
+      ...normalized,
+      metadata: {
+        ...metadata,
+        workKind: metadata.workKind ?? null,
+        urgency: metadata.urgency ?? null,
+        verticalId: metadata.verticalId ?? "software/coding",
+        surfaces: metadata.surfaces ?? [],
+      },
+    };
+  }
+  return canonicalJson(normalized) === canonicalJson(task) ? null : normalized;
+}
+
+const legacyImportNormalizationMigration: EventShapeMigrationSpec = {
+  name: "legacy-import-normalization",
+  matches: () => false,
+  rewrite: (event) => {
+    const carrier = asTaskBootstrapEvent(event);
+    if (carrier !== null) {
+      const task = normalizeEmbeddedTaskToCurrentTaskV2(carrier.payload.task as TaskV2);
+      return task === null
+        ? null
+        : {
+            event: { ...event, payload: { ...event.payload, task } } as CanonicalEventV1,
+            category: "embedded task normalized to current Task/v2",
+            before: carrier.payload.task,
+            after: task,
+          };
+    }
+    if (!isMigrationImportEvent(event)) return null;
+    const entity = event.payload.entity,
+      task = entity.kind === "task" ? normalizeEmbeddedTaskToCurrentTaskV2(entity.task) : null,
+      occurredAt = event.occurredAt.endsWith("Z") ? null : normalizePersistedTimestamp(event.occurredAt);
+    if (task === null && occurredAt === null) return null;
+    const normalizedEntity = task === null ? entity : { ...entity, task };
+    return {
+      event: {
+        ...event,
+        occurredAt: occurredAt ?? event.occurredAt,
+        payload: { ...event.payload, entity: normalizedEntity },
+      } as CanonicalEventV1,
+      category: [
+        task === null ? null : "embedded task normalized to current Task/v2",
+        occurredAt ? "occurredAt normalized to Z" : null,
+      ]
+        .filter(Boolean)
+        .join(", "),
+      before: { occurredAt: event.occurredAt, entity },
+      after: { occurredAt: occurredAt ?? event.occurredAt, entity: normalizedEntity },
     };
   },
 };
@@ -449,6 +513,7 @@ const scheduleDefinitionsMigration: EventShapeMigrationSpec = {
 
 export const eventShapeMigrations: Readonly<Record<EventShapeMigrationKind, EventShapeMigrationSpec>> = {
   "task-v2-snapshots-migrate": taskV2SnapshotsMigration,
+  "legacy-import-normalization-migrate": legacyImportNormalizationMigration,
   "relation-events-migrate": relationEventsMigration,
   "review-submission-pins-migrate": reviewSubmissionPinsMigration,
   "decision-digests-migrate": decisionDigestsMigration,

--- a/packages/kernel/src/store/event-shape-migration.ts
+++ b/packages/kernel/src/store/event-shape-migration.ts
@@ -11,7 +11,7 @@ import { submissionDigest, type SubmissionV1 } from "../domain/execution.ts";
 import { reviewDigest, type ReviewConsentV1, type ReviewV1 } from "../domain/review.ts";
 import { isSettingsEvent } from "../domain/settings-event.ts";
 import { SETTINGS_REPOSITORY_V1_SCHEMA, type WalFlushSettingsV1 } from "../domain/settings.ts";
-import { isMigrationImportEvent } from "../domain/migration-import-event.ts";
+import { canonicalMigrationProvenance, isMigrationImportEvent } from "../domain/migration-import-event.ts";
 import { normalizeLegacyRelationState } from "../domain/entity-relation.ts";
 import {
   serializeEntityJsonSchema,
@@ -26,15 +26,17 @@ import {
 } from "../domain/schedule.ts";
 import { isRelationEvent } from "../domain/relation-event.ts";
 import { isTaskBootstrapEvent } from "../domain/task-bootstrap-event.ts";
-import { isTaskEvent } from "../domain/doc-sync-canonical-events.ts";
+import { isTaskEvent, serializePersistedCanonicalEvent } from "../domain/doc-sync-canonical-events.ts";
 import { validateTaskV2, type TaskV2 } from "../domain/task.ts";
 import { normalizePersistedTimestamp } from "../domain/timestamp.ts";
+import { isRecord } from "../domain/write-chain.contract.ts";
 import { sha256Text } from "../integrity/stable-hash.ts";
 import { localRuntimeStateFileSystem } from "../local/local-layout-file-system.ts";
 import { makeTaskProjection } from "../projection/rebuildable-task-projection-factory.ts";
 import { canonicalJson } from "../projection/rebuildable-task-projection-sql.ts";
 import type { TaskProjection } from "../projection/task-projection-port.ts";
 import { contentClaims } from "./task-event-store-claims-layout.ts";
+import { canonicalLedgerCut } from "./task-event-store-contract.ts";
 import type { CanonicalContentBlob, CanonicalEventStore } from "./task-event-store-types.ts";
 
 // Pure offline generation planner. It replays an immutable generation-0 snapshot into a scratch
@@ -64,7 +66,10 @@ export interface EventShapeRewrite {
   readonly before: unknown;
   readonly after: unknown;
 }
-export type EventShapeCut = Pick<TaskProjection, "readEntityVersionWitness" | "readDecisionDocumentState">;
+export type EventShapeCut = Pick<
+  TaskProjection,
+  "readEntityVersionWitness" | "readDecisionDocumentState" | "readReplicaBasis"
+>;
 export interface EventShapeMigrationSpec {
   readonly name: EventShapeMigrationName;
   // Pure on the event: true for every event whose `rewrite` reads the cut. Only these are replayed
@@ -172,7 +177,11 @@ const taskV2SnapshotsMigration: EventShapeMigrationSpec = {
 
 function normalizeEmbeddedTaskToCurrentTaskV2(task: TaskV2): TaskV2 | null {
   const current = task as TaskV2 & { readonly pinned?: unknown };
-  let normalized: TaskV2 = Object.hasOwn(current, "pinned") ? current : { ...current, pinned: false };
+  let normalized: TaskV2 = {
+    ...current,
+    schema: "task/v2",
+    ...(Object.hasOwn(current, "pinned") ? {} : { pinned: false }),
+  };
   if (normalized.metadata !== undefined) {
     const { longRunning: _retiredLongRunning, ...metadata } = normalized.metadata as TaskV2["metadata"] & {
       readonly longRunning?: unknown;
@@ -188,31 +197,123 @@ function normalizeEmbeddedTaskToCurrentTaskV2(task: TaskV2): TaskV2 | null {
       },
     };
   }
+  if (
+    Array.isArray(normalized.provenance) &&
+    normalized.provenance.some((entry) => !Object.hasOwn(entry, "transcriptReachability"))
+  )
+    normalized = { ...normalized, provenance: canonicalMigrationProvenance(normalized.provenance) };
   return canonicalJson(normalized) === canonicalJson(task) ? null : normalized;
+}
+
+function taskCarrier(event: CanonicalEventV1): { readonly task: TaskV2 } | null {
+  const payload = event.payload as unknown;
+  if (!isRecord(payload) || !isRecord(payload.task)) return null;
+  return { task: payload.task as unknown as TaskV2 };
+}
+
+function legacyDocLedgerIdentity(event: CanonicalEventV1): { readonly repoId: string } | null {
+  if (event.schema !== "doc-event/v1" || event.type !== "documents_written" || !isRecord(event.payload)) return null;
+  const payload = event.payload as unknown as Readonly<Record<string, unknown>>,
+    base = payload.baseLedgerSha;
+  return isRecord(base) && typeof base.repoId === "string" && typeof base.sha === "string"
+    ? { repoId: base.repoId }
+    : null;
+}
+
+function canonicalProvenance(entries: readonly unknown[]): ReturnType<typeof canonicalMigrationProvenance> {
+  return canonicalMigrationProvenance(
+    entries.map((entry) =>
+      isRecord(entry) ? { ...entry, boundAt: normalizePersistedTimestamp(entry.boundAt) ?? entry.boundAt } : entry,
+    ),
+  );
 }
 
 const legacyImportNormalizationMigration: EventShapeMigrationSpec = {
   name: "legacy-import-normalization",
-  matches: () => false,
-  rewrite: (event) => {
-    const carrier = asTaskBootstrapEvent(event);
+  matches: (event) => legacyDocLedgerIdentity(event) !== null,
+  rewrite: (event, cut) => {
+    const carrier = taskCarrier(event);
     if (carrier !== null) {
-      const task = normalizeEmbeddedTaskToCurrentTaskV2(carrier.payload.task as TaskV2);
+      const task = normalizeEmbeddedTaskToCurrentTaskV2(carrier.task);
       return task === null
         ? null
         : {
             event: { ...event, payload: { ...event.payload, task } } as CanonicalEventV1,
             category: "embedded task normalized to current Task/v2",
-            before: carrier.payload.task,
+            before: carrier.task,
             after: task,
           };
+    }
+    const legacyLedger = legacyDocLedgerIdentity(event);
+    if (legacyLedger !== null) {
+      const headEvent = cut.readReplicaBasis(null).headEvent,
+        head =
+          headEvent === null
+            ? null
+            : {
+                revision: headEvent.workspaceRevision,
+                opId: headEvent.opId,
+                eventDigest: `sha256:${sha256Text(serializePersistedCanonicalEvent(headEvent))}` as const,
+              },
+        baseLedgerSha = canonicalLedgerCut(legacyLedger.repoId, head);
+      return {
+        event: {
+          ...event,
+          source: isRecord(event.source) && event.source.kind === "watch_session" ? "local" : event.source,
+          payload: { ...event.payload, baseLedgerSha },
+        } as CanonicalEventV1,
+        category: "legacy commit ledger identity normalized to pre-event canonical cut",
+        before: (event.payload as unknown as Readonly<Record<string, unknown>>).baseLedgerSha,
+        after: baseLedgerSha,
+      };
+    }
+    if (event.schema === "decision-event/v1" && event.type === "decision_proposed" && isRecord(event.payload)) {
+      if (Object.hasOwn(event.payload, "provenance")) return null;
+      const payload = {
+        ...event.payload,
+        provenance: canonicalProvenance([{ runtime: "unavailable", sessionId: null, boundAt: event.occurredAt }]),
+      };
+      return {
+        event: { ...event, payload } as CanonicalEventV1,
+        category: "legacy decision proposal normalized to current payload",
+        before: event.payload,
+        after: payload,
+      };
     }
     if (!isMigrationImportEvent(event)) return null;
     const entity = event.payload.entity,
       task = entity.kind === "task" ? normalizeEmbeddedTaskToCurrentTaskV2(entity.task) : null,
+      fact =
+        entity.kind === "fact"
+          ? {
+              ...entity.fact,
+              observedAt: normalizePersistedTimestamp(entity.fact.observedAt) ?? entity.fact.observedAt,
+              provenance: canonicalProvenance(entity.fact.provenance),
+            }
+          : null,
+      decision =
+        entity.kind === "decision"
+          ? {
+              ...entity.decision,
+              proposedAt: normalizePersistedTimestamp(entity.decision.proposedAt) ?? entity.decision.proposedAt,
+              decidedAt:
+                entity.decision.decidedAt === null
+                  ? null
+                  : (normalizePersistedTimestamp(entity.decision.decidedAt) ?? entity.decision.decidedAt),
+            }
+          : null,
       occurredAt = event.occurredAt.endsWith("Z") ? null : normalizePersistedTimestamp(event.occurredAt);
-    if (task === null && occurredAt === null) return null;
-    const normalizedEntity = task === null ? entity : { ...entity, task };
+    const normalizedEntity =
+      task !== null
+        ? { ...entity, task }
+        : fact !== null && entity.kind === "fact" && canonicalJson(fact) !== canonicalJson(entity.fact)
+          ? { ...entity, fact }
+          : decision !== null &&
+              entity.kind === "decision" &&
+              canonicalJson(decision) !== canonicalJson(entity.decision)
+            ? { ...entity, decision }
+            : entity;
+    if (normalizedEntity === entity && occurredAt === null) return null;
     return {
       event: {
         ...event,
@@ -221,6 +322,8 @@ const legacyImportNormalizationMigration: EventShapeMigrationSpec = {
       } as CanonicalEventV1,
       category: [
         task === null ? null : "embedded task normalized to current Task/v2",
+        fact === null ? null : "fact provenance normalized",
+        normalizedEntity !== entity && entity.kind === "decision" ? "decision timestamps normalized" : null,
         occurredAt ? "occurredAt normalized to Z" : null,
       ]
         .filter(Boolean)

--- a/packages/kernel/test/store/legacy-import-normalization.test.ts
+++ b/packages/kernel/test/store/legacy-import-normalization.test.ts
@@ -1,0 +1,239 @@
+// harness-test-tier: contract
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  MIGRATION_DOCUMENT_POLICY_ID,
+  REPLAY_TASK_GRAPH,
+  sha256Text,
+  validateCurrentCanonicalEvent,
+  validateTaskV2,
+  type CanonicalEventV1,
+  type TaskV2,
+} from "../../src/index.ts";
+import { eventShapeMigrations, type EventShapeCut } from "../../src/store/event-shape-migration.ts";
+
+const actor = { principal: { personId: "person_synthetic" }, executor: null } as const,
+  snapshotDigest = `sha256:${"b".repeat(64)}` as const,
+  claim = {
+    path: "tasks/task_synthetic-synthetic/INDEX.md",
+    sha256: "a".repeat(64),
+    size: 1,
+    mediaType: "text/markdown" as const,
+    policyId: MIGRATION_DOCUMENT_POLICY_ID,
+  },
+  currentMetadata = {
+    idempotencyKey: null,
+    parentTaskId: null,
+    workKind: null,
+    riskTier: null,
+    urgency: null,
+    verticalId: "software/coding",
+    presetId: "create-milestone",
+    profileId: "baseline",
+    moduleKey: null,
+    slug: "synthetic",
+    surfaces: [],
+    fromLegacyId: null,
+  } as const;
+
+test("legacy import normalization rewrites all three persisted event classes to current shape", () => {
+  const direct = taskBootstrapEvent(false),
+    directRewrite = migration().rewrite(direct, cut());
+  assert.deepEqual(validateCurrentCanonicalEvent(direct), ["Task/v2 fields are incomplete or unknown"]);
+  assert.ok(directRewrite);
+  assert.equal((directRewrite.event.payload.task as TaskV2).pinned, false);
+  assert.deepEqual(validateCurrentCanonicalEvent(directRewrite.event), []);
+
+  const importedTask = migrationTaskEvent(),
+    legacyTask = importedTask.payload.entity.task;
+  assert.deepEqual(validateTaskV2(legacyTask), [
+    {
+      code: "invalid_task",
+      message: "task metadata is missing required fields: workKind, urgency, verticalId, surfaces",
+    },
+  ]);
+  assert.deepEqual(validateCurrentCanonicalEvent(importedTask), ["migration task entity is invalid"]);
+  const taskRewrite = migration().rewrite(importedTask, cut());
+  assert.ok(taskRewrite);
+  assert.deepEqual(taskRewrite.event.payload.entity.task.metadata, currentMetadata);
+  assert.deepEqual(validateCurrentCanonicalEvent(taskRewrite.event), []);
+
+  const importedDecision = migrationDecisionEvent(),
+    originalIdentity = { eventId: importedDecision.eventId, opId: importedDecision.opId };
+  assert.deepEqual(validateCurrentCanonicalEvent(importedDecision), ["migration import event identity is invalid"]);
+  const decisionRewrite = migration().rewrite(importedDecision, cut());
+  assert.ok(decisionRewrite);
+  assert.deepEqual({ eventId: decisionRewrite.event.eventId, opId: decisionRewrite.event.opId }, originalIdentity);
+  assert.equal(decisionRewrite.event.occurredAt, "2026-06-02T16:00:00.000Z");
+  assert.equal(Date.parse(decisionRewrite.event.occurredAt), Date.parse(importedDecision.occurredAt));
+  assert.deepEqual(validateCurrentCanonicalEvent(decisionRewrite.event), []);
+});
+
+test("legacy import normalization is idempotent and converges with task snapshot normalization", () => {
+  const currentImport = migrationTaskEvent(currentMetadata);
+  assert.equal(migration().rewrite(currentImport, cut()), null);
+
+  let event = taskBootstrapEvent(false, []),
+    rewrites = 0;
+  for (let round = 0; round < 3; round += 1) {
+    let changed = false;
+    for (const family of Object.values(eventShapeMigrations)) {
+      const rewrite = family.rewrite(event, cut());
+      if (rewrite === null) continue;
+      event = rewrite.event;
+      rewrites += 1;
+      changed = true;
+    }
+    if (!changed) break;
+  }
+  assert.equal(rewrites, 2);
+  assert.equal(Object.hasOwn(event.payload.task, "relations"), false);
+  assert.equal(event.payload.task.pinned, false);
+  assert.deepEqual(validateCurrentCanonicalEvent(event), []);
+  assert.equal(
+    Object.values(eventShapeMigrations).every((family) => family.rewrite(event, cut()) === null),
+    true,
+  );
+});
+
+function migration() {
+  return eventShapeMigrations["legacy-import-normalization-migrate"];
+}
+
+function cut(): EventShapeCut {
+  return {
+    readEntityVersionWitness: () => ({ currentVersion: null, observedRevision: 0 }),
+    readDecisionDocumentState: () => null,
+  };
+}
+
+function task(pinned = true, metadata: Readonly<Record<string, unknown>> | undefined = undefined): TaskV2 {
+  return {
+    schema: "task/v2",
+    taskId: "task_synthetic",
+    title: "Synthetic task",
+    taskClass: "standard",
+    status: "planned",
+    graph: REPLAY_TASK_GRAPH,
+    currentNode: "implementation",
+    iteration: 0,
+    createdBy: actor,
+    completionGateIds: [],
+    presetSnapshotDigest: snapshotDigest,
+    pinned,
+    ...(metadata === undefined ? {} : { metadata }),
+  } as TaskV2;
+}
+
+function taskBootstrapEvent(pinned: boolean, relations?: readonly unknown[]): CanonicalEventV1 {
+  const embedded = task(pinned) as TaskV2 & { pinned?: boolean; relations?: readonly unknown[] };
+  if (!pinned) delete embedded.pinned;
+  if (relations !== undefined) embedded.relations = relations;
+  return {
+    schema: "task-bootstrap-event/v1",
+    eventId: "event-bootstrap-synthetic",
+    workspaceRevision: 1,
+    opId: "op-bootstrap-synthetic",
+    taskId: embedded.taskId,
+    type: "task_bootstrapped",
+    actor,
+    source: "local",
+    occurredAt: "2026-08-13T00:00:00.000Z",
+    payload: {
+      task: embedded,
+      presetSnapshotClaim: {
+        digest: snapshotDigest,
+        sha256: "c".repeat(64),
+        size: 1,
+        mediaType: "application/json",
+      },
+      initialDocumentClaims: [
+        {
+          path: "tasks/task_synthetic-synthetic/task_plan.md",
+          sha256: "d".repeat(64),
+          size: 1,
+          mediaType: "text/markdown",
+          owner: "doc-sync",
+          policyId: "markdown-body-replaceable/v1",
+        },
+      ],
+    },
+  } as CanonicalEventV1;
+}
+
+function migrationTaskEvent(metadata: Readonly<Record<string, unknown>> = legacyMetadata()): CanonicalEventV1 & {
+  readonly payload: { readonly entity: { readonly task: TaskV2 } };
+} {
+  const opId = "migration-task-synthetic";
+  return {
+    schema: "migration-import-event/v1",
+    eventId: `event-${sha256Text(opId)}`,
+    workspaceRevision: 1,
+    opId,
+    type: "entity_migrated",
+    actor,
+    source: "migration-import/v1",
+    occurredAt: "2026-06-03T00:00:00.000Z",
+    payload: {
+      migratedFrom: "task_synthetic",
+      generation: "v0",
+      entity: {
+        kind: "task",
+        provenance: "imported_snapshot",
+        task: task(true, metadata),
+        originalStatus: "planned",
+        packagePath: "tasks/task_synthetic-synthetic",
+        documentClaim: claim,
+      },
+    },
+  } as CanonicalEventV1 & { readonly payload: { readonly entity: { readonly task: TaskV2 } } };
+}
+
+function legacyMetadata() {
+  const {
+    workKind: _workKind,
+    urgency: _urgency,
+    verticalId: _verticalId,
+    surfaces: _surfaces,
+    ...legacy
+  } = currentMetadata;
+  return { ...legacy, longRunning: false };
+}
+
+function migrationDecisionEvent(): CanonicalEventV1 {
+  const opId = "migration-decision-synthetic",
+    decisionId = "dec_SYNTHETIC";
+  return {
+    schema: "migration-import-event/v1",
+    eventId: `event-${sha256Text(opId)}`,
+    workspaceRevision: 2,
+    opId,
+    type: "entity_migrated",
+    actor,
+    source: "migration-import/v1",
+    occurredAt: "2026-06-03T00:00:00+08:00",
+    payload: {
+      migratedFrom: decisionId,
+      generation: "v0",
+      entity: {
+        kind: "decision",
+        decision: {
+          decisionId,
+          state: "in_effect",
+          title: "Synthetic decision",
+          proposedAt: "2026-06-02T15:00:00.000Z",
+          decidedAt: "2026-06-02T16:00:00.000Z",
+          chosen: [],
+          rejected: [],
+          claims: [],
+          relations: [],
+          judgmentConsents: [],
+        },
+        documentClaim: {
+          ...claim,
+          path: `decisions/decision-${decisionId}/decision.md`,
+        },
+      },
+    },
+  } as CanonicalEventV1;
+}

--- a/packages/kernel/test/store/legacy-import-normalization.test.ts
+++ b/packages/kernel/test/store/legacy-import-normalization.test.ts
@@ -10,6 +10,8 @@ import {
   type CanonicalEventV1,
   type TaskV2,
 } from "../../src/index.ts";
+import { OPAQUE_TEXTUAL_POLICY_ID } from "../../src/domain/artifact-text-classification.ts";
+import { DECISION_DOCUMENT_POLICY_ID } from "../../src/domain/decision-event-types.ts";
 import { eventShapeMigrations, type EventShapeCut } from "../../src/store/event-shape-migration.ts";
 
 const actor = { principal: { personId: "person_synthetic" }, executor: null } as const,
@@ -96,14 +98,63 @@ test("legacy import normalization is idempotent and converges with task snapshot
   );
 });
 
+test("legacy import normalization covers every inventory shape", () => {
+  const taskEvent = {
+      ...taskBootstrapEvent(true),
+      schema: "task-event/v1",
+      type: "execution_started",
+      payload: { task: legacyTaskWithProvenance() },
+    } as CanonicalEventV1,
+    taskRewrite = migration().rewrite(taskEvent, cut());
+  assert.ok(taskRewrite);
+  assert.equal(taskRewrite.event.payload.task.schema, "task/v2");
+  assert.equal(taskRewrite.event.payload.task.pinned, false);
+  assert.equal(taskRewrite.event.payload.task.provenance[0].transcriptReachability, "by_session_id");
+
+  const factEvent = migrationFactEvent(),
+    factRewrite = migration().rewrite(factEvent, cut());
+  assert.deepEqual(validateCurrentCanonicalEvent(factEvent), ["migration fact entity is invalid"]);
+  assert.ok(factRewrite);
+  assert.equal(factRewrite.event.payload.entity.fact.observedAt, "2026-08-01T12:25:14.000Z");
+  assert.equal(factRewrite.event.payload.entity.fact.provenance[0].boundAt, "2026-08-01T12:25:14.000Z");
+  assert.deepEqual(validateCurrentCanonicalEvent(factRewrite.event), []);
+
+  const decisionEvent = migrationDecisionEventWithLegacyDecisionTimestamp(),
+    decisionRewrite = migration().rewrite(decisionEvent, cut());
+  assert.deepEqual(validateCurrentCanonicalEvent(decisionEvent), ["migration decision entity is invalid"]);
+  assert.ok(decisionRewrite);
+  assert.equal(decisionRewrite.event.payload.entity.decision.decidedAt, "2026-06-02T16:00:00.000Z");
+  assert.deepEqual(validateCurrentCanonicalEvent(decisionRewrite.event), []);
+
+  const proposal = legacyDecisionProposal(),
+    proposalRewrite = migration().rewrite(proposal, cut());
+  assert.ok(proposalRewrite);
+  assert.equal(Object.keys(proposalRewrite.event.payload).length, 17);
+  assert.deepEqual(validateCurrentCanonicalEvent(proposalRewrite.event), []);
+
+  const doc = legacyDocEvent(),
+    docRewrite = migration().rewrite(doc, cut(taskBootstrapEvent(true)));
+  assert.ok(docRewrite);
+  assert.equal(docRewrite.event.source, "local");
+  assert.deepEqual(Object.keys(docRewrite.event.payload.baseLedgerSha).sort(), ["headDigest", "repoId", "revision"]);
+  assert.deepEqual(validateCurrentCanonicalEvent(docRewrite.event), []);
+});
+
 function migration() {
   return eventShapeMigrations["legacy-import-normalization-migrate"];
 }
 
-function cut(): EventShapeCut {
+function cut(headEvent: CanonicalEventV1 | null = null): EventShapeCut {
   return {
     readEntityVersionWitness: () => ({ currentVersion: null, observedRevision: 0 }),
     readDecisionDocumentState: () => null,
+    readReplicaBasis: () => ({
+      watermark: headEvent?.workspaceRevision ?? 0,
+      sourceRevision: headEvent?.workspaceRevision ?? 0,
+      headEvent,
+      events: [],
+      documents: [],
+    }),
   };
 }
 
@@ -234,6 +285,122 @@ function migrationDecisionEvent(): CanonicalEventV1 {
           path: `decisions/decision-${decisionId}/decision.md`,
         },
       },
+    },
+  } as CanonicalEventV1;
+}
+
+function legacyTaskWithProvenance(): TaskV2 {
+  const value = task(true, legacyMetadata()) as TaskV2 & { schema: string; pinned?: boolean };
+  value.schema = "task/v1";
+  delete value.pinned;
+  return {
+    ...value,
+    provenance: [{ runtime: "codex", sessionId: "session-synthetic", boundAt: "2026-08-01T00:00:00.000Z" }],
+  } as TaskV2;
+}
+
+function migrationFactEvent(): CanonicalEventV1 {
+  const opId = "migration-fact-synthetic";
+  return {
+    schema: "migration-import-event/v1",
+    eventId: `event-${sha256Text(opId)}`,
+    workspaceRevision: 3,
+    opId,
+    type: "entity_migrated",
+    actor,
+    source: "migration-import/v1",
+    occurredAt: "2026-08-01T12:25:14.000Z",
+    payload: {
+      migratedFrom: "F-ABCDEFGH",
+      generation: "v0",
+      entity: {
+        kind: "fact",
+        fact: {
+          factId: "F-ABCDEFGH",
+          statement: "Synthetic fact",
+          evidenceSource: "synthetic",
+          observedAt: "2026-08-01T20:25:14+08:00",
+          confidence: "high",
+          memoryClass: "episodic",
+          memoryTags: [],
+          provenance: [{ runtime: "codex", sessionId: "session-synthetic", boundAt: "2026-08-01T20:25:14+08:00" }],
+        },
+        documentClaim: { ...claim, path: "facts/F-ABCDEFGH.md" },
+      },
+    },
+  } as CanonicalEventV1;
+}
+
+function migrationDecisionEventWithLegacyDecisionTimestamp(): CanonicalEventV1 {
+  const event = migrationDecisionEvent() as CanonicalEventV1 & {
+    payload: { entity: { decision: { decidedAt: string } } };
+  };
+  event.occurredAt = "2026-06-03T00:00:00.000Z";
+  event.payload.entity.decision.decidedAt = "2026-06-03T00:00:00+08:00";
+  return event;
+}
+
+function legacyDecisionProposal(): CanonicalEventV1 {
+  const decisionId = "dec_SYNTHETIC_PROPOSAL";
+  return {
+    schema: "decision-event/v1",
+    eventId: "event-proposal-synthetic",
+    workspaceRevision: 4,
+    opId: "op-proposal-synthetic",
+    decisionId,
+    type: "decision_proposed",
+    actor,
+    source: "local",
+    occurredAt: "2026-08-14T00:00:00.000Z",
+    payload: {
+      title: "Synthetic proposal",
+      question: "Use the current shape?",
+      riskTier: "medium",
+      urgency: "medium",
+      vertical: "software/coding",
+      preset: "standard-task",
+      appliesTo: { modules: ["kernel"], productLines: [] },
+      decisionClass: "ordinary",
+      chosen: [{ id: "CH1", text: "Yes" }],
+      rejected: [{ id: "RJ1", text: "No", whyNot: "Invalid" }],
+      body: "Synthetic body",
+      claims: [],
+      fulfillments: [],
+      relations: [],
+      baseDocumentSha256: null,
+      decisionDocumentClaim: {
+        path: `decisions/decision-${decisionId}/decision.md`,
+        sha256: "e".repeat(64),
+        size: 1,
+        mediaType: "text/markdown",
+        policyId: DECISION_DOCUMENT_POLICY_ID,
+      },
+    },
+  } as CanonicalEventV1;
+}
+
+function legacyDocEvent(): CanonicalEventV1 {
+  return {
+    schema: "doc-event/v1",
+    eventId: "event-doc-synthetic",
+    workspaceRevision: 2,
+    opId: "op-doc-synthetic",
+    type: "documents_written",
+    actor,
+    source: { kind: "watch_session", sessionId: "watch-synthetic", path: "notes.json", fingerprint: "f".repeat(64) },
+    occurredAt: "2026-08-14T00:00:00.000Z",
+    payload: {
+      executionId: null,
+      baseLedgerSha: { repoId: "synthetic", sha: "a".repeat(40) },
+      changes: [
+        {
+          path: "notes.json",
+          baseBlobSha256: null,
+          candidate: { sha256: "a".repeat(64), size: 1, mediaType: "application/json" },
+          policyId: OPAQUE_TEXTUAL_POLICY_ID,
+          regionProofs: [],
+        },
+      ],
     },
   } as CanonicalEventV1;
 }


### PR DESCRIPTION
# English

## Summary

Adds the `legacy-import-normalization` event-shape migration family so generation-1 offline conversion accepts every legacy shape that blocked five real repositories in changeover run 5. Round 1 (f94545188) covered the first layer: (a) `task_bootstrapped` payloads written before `pinned` became a required Task/v2 field; (b) `migration-import-event/v1` embedded tasks carrying pre-current metadata (missing `workKind`/`urgency`/`verticalId`/`surfaces`, retired `longRunning`); (c) `occurredAt` with a UTC offset instead of `Z`. Round 2 (ba850e56) covers the remaining layers found by a full inventory of the five repository copies: (d) task schema v1 → v2 for every event type that carries a `payload.task`, with top-level provenance from `canonicalMigrationProvenance`; (e) fact events missing `observedAt`/`provenance` (transcript reachability); (f) decision events with embedded `proposedAt`/`decidedAt` offsets; (g) `documents_written` doc events whose `baseLedgerSha` is rebuilt as the converted canonical cut and whose source `watch_session` becomes `local`; (h) `decision_proposed` events missing provenance (`baseDocumentSha256`/`decisionDocumentClaim` are kept because the validator requires them). History is rewritten offline by the family per dec_558977E9; no compatibility layer, no daemon change.

## Architectural Justification

- Not required (net +168; one migration family module and its tests, no new module or layer).

## What Changed

- `packages/kernel/src/store/event-shape-migration.ts` (+125/-3 across the two commits): task-carrier coverage for every `payload.task` event type, fact/decision/doc-event/decision_proposed normalisers reusing the existing normalizers, plus round-1 `normalizeEmbeddedTaskToCurrentTaskV2` (adds `pinned:false` when absent; fills the four metadata fields with the importer's canonical defaults `null`/`null`/`"software/coding"`/`[]`; drops the retired `longRunning` key) applied to direct `task_bootstrapped` events and to `entity.kind === "task"` import events; `occurredAt` normalised to `Z` via `normalizePersistedTimestamp` for import events. `eventId`/`opId` are untouched (eventId derives from opId only). Registered as `legacy-import-normalization` / `-migrate`.
- `packages/kernel/test/store/legacy-import-normalization.test.ts`: synthetic events for each shape (no private repository data), asserting the rewritten events pass `validateCurrentCanonicalEvent`, identity is preserved, and a current-shape event is left untouched; a mutation control (dropping one required `decision_proposed` key trips the assertion) shows the test exercises the validator.
- `legacy-generation-conversion.integration.test.ts`: family listed in the conversion family set.
- Forward path: the daemon importer already normalises timestamps and writes `pinned`; no change needed (worker report).

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: use the single CI-backed `Production-Delta` declaration below; do not enter a second metric.

## Machine-Readable Declarations

Production-Delta: +171/-3

## Task And Scope

- Harness task: task_6bc39b77ae49f72c3a11baa030 (parent task_d1b1a445f32ffa19b5264ba950; ruling dec_19C89C028C357418EFF71E5121)
- Branch: codex/migration-family-import-norm
- Public scope: kernel event-shape migration families and their tests
- Private planning/evidence updated: yes (task plan, worker reports, facts F-12C29216 and follow-ups)
- Out of scope: daemon importer changes (verified unnecessary); the per-repository conversions themselves (operator run after merge)

## Version Impact

- Version: no version change because the change is internal to offline conversion
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: not applicable
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: 7cc577d14d841876d4dcda6bf8441a6a1ee79c79
- Branch merge-base with `origin/main`: 7cc577d14d841876d4dcda6bf8441a6a1ee79c79
- Last `git fetch origin` time: 2026-09-07 19:1x CST
- Sync method: none needed
- Public diff command: `git diff 7cc577d14...ba850e56`
- Private evidence commit/path: harness/tasks/task_6bc39b77ae49f72c3a11baa030-*/artifacts/reports/
- Reviewer evidence path: two independent CEO dry-runs of `diagnose-plan-events.mjs` (task_6bc39b77 artifacts/diagnosis) against copies of the five blocked repositories at ba850e56: hud-ipad 0/29, self-representation 0/133, brain-os-frontend 0/720, kty-web 0/4051, drg-grouper-dingwen 0/1283 failing plan events (facts F-1829CA72 / F-91666399 / F-DA5C93DC); worker convert×2 idempotent (second pass migratedEvents=0), verify-import matches, rebuild stateDigest stable, preflight passed
- GitHub Actions `rewrite-ci` run URL: pending
- [x] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [x] `npm test` (worker: legacy-import-normalization + migration-import-event suites and legacy-generation-conversion integration green on the isolated runner; full matrix in CI)
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Not run: full local gate matrix (CI is the authority)

## Review Evidence

- Self-review: worker (Sol, three rounds; round 1 stopped at the multi-field checkpoint, ruling recorded in dec_19C89C02 lineage; round 3 rejected one mission instruction with evidence — the validator requires `baseDocumentSha256`/`decisionDocumentClaim` on `decision_proposed`, so they are kept)
- Reviewer subagent: peer CEO ground-truth (independent re-run of the five-copy dry-run, failing=0) and this CEO's independent re-run (same result); CEO read of production hunks
- Human review: pending
- Blocking findings: none

## Residual Risk

- Defaults for the four metadata fields are the importer's canonical defaults, chosen by ruling rather than recovered from history; `longRunning` was `false` in every affected event (checked across the five repositories), so dropping it loses no information.
- `documents_written.baseLedgerSha` is rebuilt as the converted cut rather than the pre-conversion sha; the original sha does not exist in the converted generation, so it cannot be preserved verbatim.

## References

- Task: task_6bc39b77ae49f72c3a11baa030
- Evidence: F-12C29216, F-1829CA72, F-91666399, F-DA5C93DC; run-5 per-repository errors under task_d1b1a445…/artifacts/ops/run5/repos/<id>/
- Review: pending

---

# 中文

## 概要

新增 `legacy-import-normalization` 事件形状迁移族,使 generation-1 离线转换接受第五次换代中挡住 5 个真实仓的全部旧形状。第一轮(f94545188)覆盖第一层:(a) `pinned` 成为 Task/v2 必需字段之前写入的 `task_bootstrapped`;(b) `migration-import-event/v1` 内嵌 task 带旧 metadata(缺 `workKind`/`urgency`/`verticalId`/`surfaces`,含退役键 `longRunning`);(c) `occurredAt` 带时区偏移而非 `Z`。第二轮(ba850e56)按 5 仓副本全量清点覆盖其余层:(d) 所有携带 `payload.task` 的事件类型 task schema v1→v2,顶层 provenance 用 `canonicalMigrationProvenance`;(e) fact 缺 `observedAt`/`provenance`;(f) decision 内嵌 `proposedAt`/`decidedAt` 带偏移;(g) `documents_written` 的 `baseLedgerSha` 重建为转换后 canonical cut、source `watch_session`→`local`;(h) `decision_proposed` 补 provenance(validator 强制 `baseDocumentSha256`/`decisionDocumentClaim`,予以保留)。按 dec_558977E9 离线重写历史,不加兼容层、不改 daemon。

## 变更内容

- `event-shape-migration.ts`:`normalizeEmbeddedTaskToCurrentTaskV2`(缺 `pinned` 补 false;四个 metadata 字段填 importer 现行默认值 `null`/`null`/`"software/coding"`/`[]`;删除退役键 `longRunning`),作用于直接的 `task_bootstrapped` 与 `entity.kind === "task"` 的 import 事件;import 事件 `occurredAt` 经 `normalizePersistedTimestamp` 归一到 `Z`。`eventId`/`opId` 不动。
- 新测试 `legacy-import-normalization.test.ts`:三类形状的合成事件(不含私有仓数据),断言重写后通过 `validateCurrentCanonicalEvent`、身份不变、现行形状不被触碰。
- 前向路径:daemon importer 已归一时间戳并写 `pinned`,无需改动。

## 任务与范围

- Harness 任务:task_6bc39b77ae49f72c3a11baa030(父 task_d1b1a445;裁决 dec_19C89C028C357418EFF71E5121)
- 分支:codex/migration-family-import-norm
- 不在范围:importer 改动(已验证不需要);各仓实际转换(合入后由 operator 执行)

## 版本影响

- 版本:无变更;发布影响:不发布

## 治理声明

- 触碰保护面:否;Break-glass:否

## 验证

- worker:定向测试与 legacy-generation-conversion 集成在隔离 runner 绿;两位 CEO 各自独立用 diagnose-plan-events.mjs 对 5 仓副本干跑 ba850e56:hud-ipad 0/29、self-representation 0/133、brain-os-frontend 0/720、kty-web 0/4051、drg-grouper-dingwen 0/1283 失败(facts F-1829CA72/F-91666399/F-DA5C93DC);convert×2 幂等、verify-import 一致、rebuild stateDigest 稳定、preflight 通过;完整门矩阵以 CI 为准。

## 评审证据

- peer CEO 独立复跑 5 仓干跑 failing=0;本 CEO 独立复跑同结果;CEO 读生产 hunks;Sol 第三轮带证据驳回 mission 一处错误指令(见英文 Review Evidence)。

## 残余风险

- 四个 metadata 字段的值是裁决选定的 importer 默认值而非从历史恢复;`longRunning` 在 5 个仓的受影响事件中全为 false,删除不丢信息。
- `documents_written.baseLedgerSha` 重建为转换后的 cut,原 sha 在转换后 generation 中不存在,无法原样保留。

## 参考

- 任务:task_6bc39b77ae49f72c3a11baa030

🤖 Generated with [Claude Code](https://claude.com/claude-code)

