### PR TITLE
fix(daemon): settle a failed canonical task-id scan to stop the single-writer hot loop

### DIFF
--- a/packages/daemon/src/repo-cell-receipts.ts
+++ b/packages/daemon/src/repo-cell-receipts.ts
@@ -3,6 +3,7 @@ import {
   isTaskEvent,
   isTaskProgressEvent,
   contractForDeclarationEvent,
+  consumeKnownError,
   type CanonicalEventV1,
   type TaskProgressEventV1,
   type WriteReceiptDraft as WriteReceipt,
@@ -199,16 +200,23 @@ export function projectedTaskIds(cell: ProjectedTaskIdsContext): Set<string> {
   }
   const taskIds = new Set<string>();
   let cursor: string | null = null;
-  for (;;) {
-    const batch = cell.store.readBatch(cursor, 4096) as {
-      readonly events: readonly CanonicalEventV1[];
-      readonly cursor: string | null;
-      readonly done: boolean;
-    };
-    for (const event of batch.events) if (isTaskEvent(event)) taskIds.add(event.taskId);
-    if (batch.done) break;
-    if (batch.cursor === cursor) throw new Error("canonical task event scan did not advance");
-    cursor = batch.cursor;
+  try {
+    for (;;) {
+      const batch = cell.store.readBatch(cursor, 4096) as {
+        readonly events: readonly CanonicalEventV1[];
+        readonly cursor: string | null;
+        readonly done: boolean;
+      };
+      for (const event of batch.events) if (isTaskEvent(event)) taskIds.add(event.taskId);
+      if (batch.done) break;
+      if (batch.cursor === cursor) throw new Error("canonical task event scan did not advance");
+      cursor = batch.cursor;
+    }
+  } catch (error) {
+    // A failed canonical scan must settle this cell's lookup rather than trigger
+    // an unbounded internal retry loop. An empty set is fail-closed for writes.
+    consumeKnownError(error);
+    taskIds.clear();
   }
   cell.knownTaskIds = taskIds;
   return cell.knownTaskIds;

--- a/packages/daemon/test/repo-cell-latch-recovery.test.ts
+++ b/packages/daemon/test/repo-cell-latch-recovery.test.ts
@@ -36,24 +36,43 @@ test("task identity lookup remains available while the projection catches up", (
   assert.deepEqual([...projectedTaskIds(cell)], ["task-existing"]);
 });
 
-test("task identity lookup preserves a canonical scan failure while the projection catches up", () => {
+test("task identity lookup settles a canonical scan failure and caches fail-closed", () => {
   const scanFailure = Object.assign(new Error("canonical event object is unavailable"), { code: "invalid_store" }),
+    reads = { count: 0 },
     cell = {
       knownTaskIds: null,
       projection: { list: () => ({ watermark: 2, sourceRevision: 4, rows: [] }) },
       store: {
         readBatch: () => {
+          reads.count += 1;
           throw scanFailure;
         },
       },
       cellCodedError,
     };
 
-  assert.throws(
-    () => projectedTaskIds(cell),
-    (error: unknown) => error === scanFailure,
-  );
-  assert.equal(cell.knownTaskIds, null);
+  assert.deepEqual([...projectedTaskIds(cell)], []);
+  assert.deepEqual([...projectedTaskIds(cell)], []);
+  assert.equal(reads.count, 1);
+  assert.notEqual(cell.knownTaskIds, null);
+});
+
+test("task identity lookup settles a non-advancing canonical scan", () => {
+  let reads = 0;
+  const cell = {
+    knownTaskIds: null,
+    projection: { list: () => ({ watermark: 0, sourceRevision: 1, rows: [] }) },
+    store: {
+      readBatch: () => {
+        reads += 1;
+        return { events: [], cursor: null, done: false };
+      },
+    },
+    cellCodedError,
+  };
+  assert.deepEqual([...projectedTaskIds(cell)], []);
+  assert.deepEqual([...projectedTaskIds(cell)], []);
+  assert.equal(reads, 1);
 });
 
 test("projection recovery names and carries the reachable rebuild command", () => {


### PR DESCRIPTION
# English

## Summary

Stops the single-writer hot loop (pinned defect task_9a5f18a9) that pinned the canonical daemon near 100% CPU and starved every other write. The fix is at the source: `projectedTaskIds` now settles a failed canonical task-id scan (caches the result once) instead of letting the failure propagate into the single-writer retry, which re-scanned and re-threw without bound.

This supersedes the earlier round-1/2 approach on this branch (an early `lease_conflict` admission rejection in `task-action-catalog-runtime.ts`). That approach broke legitimate execution-reuse admission semantics and went RED in CI; it has been dropped entirely. The correct fix removes the loop's engine (the unbounded re-scan) rather than adding a new admission gate in front of it.

## Root Cause

While the projection watermark lags the source revision, `projectedTaskIds` falls back to a full canonical `readBatch` scan. On a scan failure — a store read error, or a cursor that stops advancing — the throw propagated out, `knownTaskIds` was never cached, the single-writer retry re-issued the command, and it re-scanned and re-threw forever (call stack: sqlite3Prepare / ObjectFromEntries / ArrayMap / unixShmLock). Durability was intact throughout; only the writer's forward progress was starved. This is an availability/liveness defect, not a data defect.

## What Changed

- `packages/daemon/src/repo-cell-receipts.ts`: wrap the `projectedTaskIds` fallback scan. On failure, `consumeKnownError(error)` (kernel no-op marker, the sanctioned way to consume a caught failure under `ha/no-swallowed-failure`) and cache an empty task set on the cell. The lookup settles once; later calls hit the cache instead of re-scanning, which breaks the retry loop.
- `packages/daemon/test/repo-cell-latch-recovery.test.ts`: two reproduction tests. "settles a canonical scan failure and caches fail-closed" and "settles a non-advancing canonical scan" both call `projectedTaskIds` twice and assert `reads === 1` — i.e. the second call hits the cache and does NOT re-scan. That is the direct positive control for the anti-loop guarantee (without caching the second call would re-scan → `reads === 2` → test fails).

## Design Note (fail-closed tradeoff)

An empty task set is fail-closed for writes: task/parent existence checks reject (`parent_not_found`, mutation "not found"). It only arises in the anomalous watermark-lagging + scan-failure window and clears when the cell is recreated (daemon restart / cell eviction). Normal operation is untouched: when the watermark equals the source revision the fast path runs and never enters the try/catch.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none

## Machine-Readable Declarations

Production-Delta: +18/-10
Dependency-Change: none

## Task And Scope

- Harness task: defect task_9a5f18a94206a170d973d6168a; round-3 carrier task_4e35b641 (supersedes round-1/2 carrier task_5a330de6).
- Branch: codex/runtime-hotloop-fix; base origin/main 327dfbbdc.
- Out of scope: the migration/canonical write path, WAL/SQLite durability, CI/branch-protection, the admission/lease semantics (deliberately not touched — that was the reverted approach).

## Version Impact

- Version: no change (internal daemon correctness fix). Publish impact: none.

## Governance Declaration

- Protected surface touched: no.
- Break-glass: no.

## Verification

- Base `origin/main` SHA: 327dfbbdc.
- `npx eslint` on both touched files: pass (exit 0) — `ha/no-swallowed-failure` satisfied.
- `npx tsc -b packages/daemon --pretty false`: pass (exit 0).
- `node tools/run-node-tests.mjs --tier integration --file packages/daemon/test/repo-cell-latch-recovery.test.ts`: 8 pass / 0 fail, including the two anti-loop reproduction tests.
- Full local gate matrix: not run locally (CI is the authority).

## Review Evidence

- CEO ground-truth: read the full `projectedTaskIds` function and both call sites in `repo-cell-task-create.ts`. The create duplicate-check (`taskIds.has(taskId)`) could fail-open on an empty set, but is practically unreachable: `createTaskId` is deterministic in (action, binding, repoId), so a colliding id implies an idempotent request (caught upstream by idempotency-key reuse), and the event append layer dedups by opId. Mutation and parent checks fail-closed on empty.
- Peer CEO session (harness-anything-fe) independently endorsed the source-level fail-closed approach over the reverted admission gate.
- Blocking findings: none.

## Residual Risk

- After a genuine scan failure the cell stays fail-closed (empty) for its lifetime until recreation, even if the underlying store condition later resolves; recovery is a daemon restart / cell eviction. Chosen deliberately over re-enabling the unbounded re-scan.
- The upstream single-writer retry mechanism itself is not rewritten; it is defused by removing the re-scan that fed it.

---

# 中文

## 摘要

修复被 pin 的恶性缺陷 task_9a5f18a9：canonical daemon 单写线程被顶到近 100% CPU、饿死其余所有写。修在源头——`projectedTaskIds` 现在把「canonical task-id 扫描失败」settle 掉（一次性缓存结果），不再让失败向上抛、被单写重试反复重扫重抛、无限打转。

本次取代了同分支上 round-1/2 的做法（在 `task-action-catalog-runtime.ts` 里加早期 `lease_conflict` admission 拦截）。那个做法破坏了合法的 execution-reuse admission 语义、CI 已红，已整体删除。正解是拆掉循环的引擎（无界重扫），而不是在它前面再加一道门。

## 根因

当 projection watermark 落后 source revision 时，`projectedTaskIds` 回退到全量 canonical `readBatch` 扫描。扫描失败（store 读错，或游标不前进）时异常上抛、`knownTaskIds` 从未缓存，单写重试重发命令→再扫→再抛，永不收敛。全程持久性无损，只是写进度被饿死——这是可用性/活性缺陷，不是数据缺陷。

## 改了什么

- `repo-cell-receipts.ts`：给回退扫描套 try/catch。失败时 `consumeKnownError(error)`（kernel 的 no-op 标记，`ha/no-swallowed-failure` 规则下消费捕获失败的合规写法）+ 在 cell 上缓存空集。lookup 一次性 settle，后续调用命中缓存、不再重扫，循环被掐断。
- `repo-cell-latch-recovery.test.ts`：两个复现测试。均调用 `projectedTaskIds` 两次并断言 `reads === 1`——第二次命中缓存、不重扫。这是反循环保证的阳性对照（没缓存则第二次重扫 → `reads === 2` → 测试失败）。

## fail-closed 取舍

空集对写是 fail-closed：task/parent 存在性检查会拒（`parent_not_found` 等）。只在 watermark 落后 + 扫描失败的异常窗口出现，cell 重建（daemon 重启/驱逐）即恢复。正常路径不受影响：watermark == source revision 走 fast path，根本不进 try/catch。

## 验证

- base origin/main：327dfbbdc。
- 两个改动文件 `eslint`：exit 0（`ha/no-swallowed-failure` 满足）。
- `tsc -b packages/daemon`：exit 0。
- latch-recovery 定向测试：8 pass / 0 fail，含两个反循环复现测试。
- 全量门矩阵：本地不跑，CI 权威。

## 残余风险

- 真扫描失败后 cell 在其生命周期内保持 fail-closed（空），即使底层条件后来恢复；恢复靠 daemon 重启/cell 驱逐。刻意选它，而非重新放开无界重扫。
- 单写重试机制本身未重写，靠移除喂给它的重扫来解除。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
