### PR TITLE
fix(cli): honest fact record errors for rationale pairs and unregistered types

### DIFF
--- a/packages/application/test/fact-event-service.test.ts
+++ b/packages/application/test/fact-event-service.test.ts
@@ -116,7 +116,9 @@ test("recorded Fact is durable and immediately searchable through the canonical 
             payload: { ...draft.payload, domainTypes: ["architecture-design"] },
           }),
         ),
-      /Fact domain type architecture-design is not registered/u,
+      (error: unknown) =>
+        code(error) === "fact_type_unregistered" &&
+        /Fact domain type architecture-design is not registered/u.test((error as Error).message),
     );
     const reclassified = service.record(
       compile(projection, {

--- a/packages/cli/src/cli/guidance-plane.ts
+++ b/packages/cli/src/cli/guidance-plane.ts
@@ -80,6 +80,12 @@ const guidanceTemplates = new Map<string, GuidanceTemplate>([
   ["*:remove-dry-run", (args) => `next: remove --dry-run and rerun ${textArg(args, "command")}`],
   ["*:no-action", () => "next: no action required"],
   [
+    "failure:fact-type-unregistered",
+    () =>
+      "Fact domain types must be registered before use; run ha fact type register <type> --source <source>, " +
+      "then retry this command.",
+  ],
+  [
     "failure:daemon-stopping",
     () =>
       "The daemon is draining its write queues before it exits and admits no new work; it releases its " +
@@ -174,6 +180,7 @@ export function humanError(receipt: Record<string, unknown>): { readonly code: s
         `Inner receipt: ${typeof receipt.summary === "string" ? receipt.summary : "summary unavailable"}`,
     };
   if (code === "daemon_stopping") return { code, hint: renderTemplate("failure", "daemon-stopping", {}) };
+  if (code === "fact_type_unregistered") return { code, hint: renderTemplate("failure", "fact-type-unregistered", {}) };
   if (code === "daemon_restarting" && typeof outer.hint === "string") return { code, hint: outer.hint };
   const diagnostic = record(receipt.diagnostic) ? receipt.diagnostic : null,
     diagnosticHint = diagnostic ? renderDiagnostic(diagnostic) : null,

--- a/packages/cli/src/cli/thin-command-fact.ts
+++ b/packages/cli/src/cli/thin-command-fact.ts
@@ -100,7 +100,8 @@ export function parseFactRecord(
       "missing_field",
       supersedes
         ? "--rationale and --supersedes must be provided together; add --rationale <why>, then rerun the command."
-        : "--rationale and --supersedes must be provided together; add --supersedes <fact-ref>, then rerun the command.",
+        : "--rationale and --supersedes must be provided together; " +
+            "add --supersedes <fact-ref>, then rerun the command.",
       json,
     );
   return accepted(rootDir, repoId, json, {

--- a/packages/cli/src/cli/thin-command-fact.ts
+++ b/packages/cli/src/cli/thin-command-fact.ts
@@ -1,5 +1,5 @@
 import type { SafePath } from "../../../daemon/src/protocol/daemon-protocol.contract.ts";
-import { accepted, projectionWaitMs, readFlags, rejectInput, rejected } from "./thin-command-flags.ts";
+import { accepted, projectionWaitMs, readFlags, rejected } from "./thin-command-flags.ts";
 import { parseProjected } from "./thin-command-projection.ts";
 import type { ThinCliInputDirectory, ThinParseResult } from "./thin-command-types.ts";
 
@@ -95,7 +95,14 @@ export function parseFactRecord(
     );
   if (waitProjectionMs === null)
     return rejected("invalid_field", "Use a non-negative safe integer projection wait limit in milliseconds.", json);
-  if (Boolean(supersedes) !== Boolean(rationale)) return rejectInput(inputs, "fact-record", "--rationale", json);
+  if (Boolean(supersedes) !== Boolean(rationale))
+    return rejected(
+      "missing_field",
+      supersedes
+        ? "--rationale and --supersedes must be provided together; add --rationale <why>, then rerun the command."
+        : "--rationale and --supersedes must be provided together; add --supersedes <fact-ref>, then rerun the command.",
+      json,
+    );
   return accepted(rootDir, repoId, json, {
     kind: "fact-record",
     ...(positionalTaskId || flaggedTaskId ? { taskId: positionalTaskId ?? flaggedTaskId } : {}),

--- a/packages/cli/test/guidance-plane.test.ts
+++ b/packages/cli/test/guidance-plane.test.ts
@@ -118,6 +118,18 @@ test("write_rejected renders the inner receipt reason and summary without sugges
   );
 });
 
+test("fact_type_unregistered guides registering the domain type before retry", () => {
+  assert.deepEqual(
+    renderCliReceipt({ ok: false, code: "fact_type_unregistered", error: { code: "fact_type_unregistered" } }),
+    {
+      stream: "stderr",
+      text:
+        "error code=fact_type_unregistered hint=Fact domain types must be registered before use; " +
+        "run ha fact type register <type> --source <source>, then retry this command.",
+    },
+  );
+});
+
 test("receipt registry preserves migrated family goldens", () => {
   assert.deepEqual(renderCliReceipt({ command: "runtime-batch", dispatches: [] }), {
     stream: "stdout",

--- a/packages/cli/test/thin-command-preset-fact-decision.test.ts
+++ b/packages/cli/test/thin-command-preset-fact-decision.test.ts
@@ -326,6 +326,70 @@ test("Fact CLI exposes record, controlled types, search, and show while keeping 
     "x".repeat(200),
   ]);
   assert.equal(excessiveRationale.ok ? "ok" : excessiveRationale.code, "invalid_field");
+  const rationaleOnly = parseThinCommand([
+    "fact",
+    "record",
+    "--task",
+    "task-1",
+    "--statement",
+    "Observed",
+    "--source",
+    "test",
+    "--rationale",
+    "why",
+  ]);
+  assert.deepEqual(rationaleOnly, {
+    ok: false,
+    code: "missing_field",
+    nextAction:
+      "--rationale and --supersedes must be provided together; add --supersedes <fact-ref>, then rerun the command.",
+    json: false,
+  });
+  const supersedesOnly = parseThinCommand([
+    "fact",
+    "record",
+    "--task",
+    "task-1",
+    "--statement",
+    "Observed",
+    "--source",
+    "test",
+    "--supersedes",
+    "fact/F-ABCDEFGH",
+  ]);
+  assert.deepEqual(supersedesOnly, {
+    ok: false,
+    code: "missing_field",
+    nextAction:
+      "--rationale and --supersedes must be provided together; add --rationale <why>, then rerun the command.",
+    json: false,
+  });
+  const superseding = parseThinCommand([
+    "fact",
+    "record",
+    "--task",
+    "task-1",
+    "--statement",
+    "Observed",
+    "--source",
+    "test",
+    "--supersedes",
+    "fact/F-ABCDEFGH",
+    "--rationale",
+    "Corrects the target observation.",
+  ]);
+  assert.equal(superseding.ok, true, JSON.stringify(superseding));
+  if (superseding.ok)
+    assert.deepEqual(superseding.command.action, {
+      kind: "fact-record",
+      taskId: "task-1",
+      statement: "Observed",
+      evidenceSource: "test",
+      confidence: "medium",
+      memoryClass: "episodic",
+      memoryTags: [],
+      supersedes: { factRef: "fact/F-ABCDEFGH", rationale: "Corrects the target observation." },
+    });
   for (const retired of ["--kind", "--summary", "--detail"]) {
     const rejected = parseThinCommand(["fact", "record", "task-1", retired, "legacy"]);
     assert.equal(rejected.ok, false);

--- a/packages/kernel/src/projection/fact-event-projection.ts
+++ b/packages/kernel/src/projection/fact-event-projection.ts
@@ -77,6 +77,7 @@ export class FactProjectionError extends Error {
     | "invalid_transition"
     | "entity_not_found"
     | "anchor_not_found"
+    | "fact_type_unregistered"
     | "relation_invalid";
   constructor(code: FactProjectionError["code"], message: string) {
     super(message);
@@ -140,7 +141,7 @@ export function assertFactAdmission(db: DatabaseSync, event: FactEventV1): void 
   }
   for (const domainType of event.payload.domainTypes ?? [])
     if (!db.prepare("SELECT 1 FROM fact_domain_type WHERE domain_type = ?").get(domainType))
-      throw new FactProjectionError("relation_invalid", `Fact domain type ${domainType} is not registered.`);
+      throw new FactProjectionError("fact_type_unregistered", `Fact domain type ${domainType} is not registered.`);
   const supersedes = event.payload.supersedes;
   if (!supersedes) return;
   const target = db.prepare("SELECT ref FROM fact WHERE ref = ?").get(supersedes.factRef) as

--- a/packages/kernel/test/store/fact-admission-liveness.test.ts
+++ b/packages/kernel/test/store/fact-admission-liveness.test.ts
@@ -46,7 +46,25 @@ test("Fact admission rejects superseding an already-superseded target", () => {
   }
 });
 
-function fact(revision: number, factId: string, supersedesRef?: string): FactEventV1 {
+test("Fact admission names an unregistered domain type instead of a relation failure", () => {
+  const db = new DatabaseSync(":memory:");
+  try {
+    createRelationGraphProjectionTables(db);
+    createFactProjectionTables(db);
+    reduceFactEvent(db, fact(1, "F-ABCDEFGH"));
+    assert.throws(
+      () => reduceFactEvent(db, fact(2, "F-BCDEFGHJ", undefined, ["architecture"])),
+      (error: unknown) =>
+        error instanceof FactProjectionError &&
+        error.code === "fact_type_unregistered" &&
+        /Fact domain type architecture is not registered/u.test(error.message),
+    );
+  } finally {
+    db.close();
+  }
+});
+
+function fact(revision: number, factId: string, supersedesRef?: string, domainTypes?: string[]): FactEventV1 {
   return {
     schema: "fact-event/v1",
     eventId: `event-${revision}`,
@@ -66,6 +84,7 @@ function fact(revision: number, factId: string, supersedesRef?: string): FactEve
       memoryClass: "semantic",
       memoryTags: [],
       provenance: [],
+      ...(domainTypes ? { domainTypes } : {}),
       ...(supersedesRef
         ? { supersedes: { factRef: supersedesRef, rationale: "New observation replaces the target." } }
         : {}),


### PR DESCRIPTION
# English

## Summary

Fixes two misleading `ha fact record` errors so the CLI names the real problem instead of a false one.

- When exactly one of `--rationale` / `--supersedes` is supplied, the CLI returned a false `invalid_field` pattern error. It now returns an honest `missing_field` with a symmetric message naming the missing flag.
- When a Fact carries a domain type that is not registered, the projection threw `relation_invalid` (a wrong, confusing code). It now throws a new `fact_type_unregistered` code, and the CLI guidance plane maps that code to a hint to run `ha fact type register <type>` first. The genuine supersedes-endpoint `relation_invalid` path is unchanged.

## What Changed

- `packages/cli/src/cli/thin-command-fact.ts`: the `--rationale`/`--supersedes` pairing check returns `missing_field` with a message naming which flag to add, instead of a pattern rejection.
- `packages/kernel/src/projection/fact-event-projection.ts`: unregistered domain type throws `fact_type_unregistered` (added to the `FactProjectionError` code union); the supersedes-target `relation_invalid` at the following check is preserved.
- `packages/cli/src/cli/guidance-plane.ts`: adds the `fact-type-unregistered` guidance template and maps the `fact_type_unregistered` code to it.
- Tests: `thin-command-preset-fact-decision.test.ts`, `guidance-plane.test.ts`, `fact-admission-liveness.test.ts`, `fact-event-service.test.ts` cover both corrected errors (including "names unregistered type instead of relation failure").

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none

## Machine-Readable Declarations

Production-Delta: +19/-3
Dependency-Change: none

## Task And Scope

- Harness task: task_477321af (fact-record redo; lineage from the credential/hot-loop incident cleanup). Public scope: CLI fact-record error honesty + kernel fact projection code.
- Branch: codex/fact-record-person-fix; base origin/main.
- Out of scope: the legitimate supersedes-endpoint relation check; daemon rejection allowlist (verified it passes the new code through unchanged).

## Version Impact

- Version: no change (CLI error-message + error-code correctness). Publish impact: none.

## Governance Declaration

- Protected surface touched: no. Break-glass: no.

## Verification

- Base `origin/main` SHA: latest at open.
- Worker (GLM) targeted tests green; CEO ground-truth independently: read both production hunks (the two `relation_invalid` sites are correctly distinguished — the unregistered-type one changed, the supersedes-endpoint one preserved); `git grep fact_type_unregistered` shows source + guidance mapping + application/kernel consumer tests with no orphan; daemon rejection path passes the new code through (no allowlist swallow); `node tools/run-manifest-gates.mjs --changed origin/main` PASSED. Full matrix in CI.

## Review Evidence

- Peer CEO ground-truth (diff read, consumer coverage, targeted tests, manifest gates) and this CEO's independent hunk read. Worker report treated as assertion, not evidence.
- Blocking findings: none.

## Residual Risk

- None material; the change narrows two error codes/messages and adds their consumer mapping and tests.

---

# 中文

## 概要

修复 `ha fact record` 两处误导性错误,让 CLI 报真问题而非假问题。

- `--rationale` / `--supersedes` 缺一时,原来报假的 `invalid_field` pattern 错误;现改为诚实的 `missing_field`,对称提示缺哪个。
- Fact 带未注册 domain type 时,projection 原抛 `relation_invalid`(错码、误导);现抛新码 `fact_type_unregistered`,CLI guidance plane 映射为"先 run ha fact type register <type>"提示。合法的 supersedes 端点 `relation_invalid` 路径不动。

## 验证

- worker(GLM)定向测试绿;CEO 独立 ground-truth:读两处生产 hunk(两处 relation_invalid 正确区分——未注册类型那处改了,supersedes 端点那处保留);grep fact_type_unregistered 源码+guidance+消费者测试无孤儿;daemon 拒绝路径透传新码;run-manifest-gates --changed origin/main 亲过。完整矩阵以 CI 为准。

## 残余风险

- 无实质风险;仅收窄两个错误码/文案并补消费者映射与测试。

🤖 Generated with [Claude Code](https://claude.com/claude-code)