### PR TITLE
fix(daemon): closeout complete leaf reuses the allowed center authorization decision

### DIFF
--- a/packages/daemon/src/repo-cell-closeout.ts
+++ b/packages/daemon/src/repo-cell-closeout.ts
@@ -6,6 +6,27 @@ import { readPacketSource } from "./repo-cell-packets.ts";
 import type { RepoCellOperationalContext } from "./repo-cell-action-context.ts";
 import type { RepoCellBinding, RepoTaskAction, Snapshot } from "./repo-cell-types.ts";
 
+export function authorizeCloseoutLeaf(input: {
+  readonly stage: string;
+  readonly binding: RepoCellBinding;
+  readonly actor: RepoCellBinding["actor"];
+  readonly action: RepoTaskAction;
+  readonly actionId: string;
+  readonly revision: number;
+  readonly now: string;
+}) {
+  const unqualifiedBinding = { ...input.binding, actor: input.actor, authorizationDecision: undefined };
+  return input.stage === "complete" && input.binding.authorizationDecision?.outcome === "allowed"
+    ? input.binding.authorizationDecision
+    : authorizeRepoCellAction({
+        action: input.action,
+        binding: unqualifiedBinding,
+        actionId: input.actionId,
+        revision: input.revision,
+        now: input.now,
+      });
+}
+
 export async function closeoutTask(
   cell: RepoCellOperationalContext,
   action: RepoTaskAction,
@@ -50,9 +71,11 @@ export async function closeoutTask(
         revision = cell.store.readHead()?.revision ?? 0,
         unqualifiedBinding = { ...binding, actor, authorizationDecision: undefined },
         actionId = cell.operationId(leafAction, unqualifiedBinding, cell.input.repoId, revision),
-        authorizationDecision = authorizeRepoCellAction({
+        authorizationDecision = authorizeCloseoutLeaf({
+          stage,
+          binding,
+          actor,
           action: leafAction,
-          binding: unqualifiedBinding,
           actionId,
           revision,
           now: cell.now(),

--- a/packages/daemon/test/task-closeout-action.test.ts
+++ b/packages/daemon/test/task-closeout-action.test.ts
@@ -8,6 +8,7 @@ import type { ActorIdentity, AuthorizationDecision, WriteReceipt } from "../../k
 import { runTaskCloseoutAction, type CloseoutStep } from "../../application/src/task-closeout-action.ts";
 import { gateChecks } from "../src/repo-cell-proof.ts";
 import { readWorkspaceText } from "../src/workspace-text-port.ts";
+import { authorizeCloseoutLeaf } from "../src/repo-cell-closeout.ts";
 
 const taskId = "task-closeout",
   executionId = "execution-closeout",
@@ -194,6 +195,43 @@ test("closeout runs four canonical leaf commands without impersonating the creat
   } finally {
     rmSync(value.rootDir, { recursive: true, force: true });
   }
+});
+
+test("complete leaf reuses an allowed center decision, while non-allowed remains denied", () => {
+  const action = { kind: "task-complete", taskId } as const,
+    actorValue = actor("worker-agent"),
+    allowed = { ...authorizationDecision, actor: actorValue },
+    binding = { actor: actorValue, source: "local", authorizationDecision: allowed } as const;
+  assert.equal(
+    authorizeCloseoutLeaf({
+      stage: "complete",
+      binding,
+      actor: actorValue,
+      action,
+      actionId: "a",
+      revision: 1,
+      now: "2026-01-01T00:00:00Z",
+    }).outcome,
+    "allowed",
+  );
+  const deniedBinding = {
+    ...binding,
+    source: "declared",
+    authorizationBindingMode: "declared",
+    authorizationDecision: undefined,
+  } as const;
+  assert.equal(
+    authorizeCloseoutLeaf({
+      stage: "complete",
+      binding: deniedBinding,
+      actor: actorValue,
+      action,
+      actionId: "a",
+      revision: 1,
+      now: "2026-01-01T00:00:00Z",
+    }).outcome,
+    "denied",
+  );
 });
 test("closeout upgrades a stale preset snapshot before the first lifecycle mutation", async () => {
   const value = setup(snapshot(), undefined, caller, undefined, false);


### PR DESCRIPTION
# English

## Summary

Fixes `task_733cbfdf` (flow defect): the one-shot `ha task closeout <task>` command returned `authorization_denied` at its **complete** sub-step, while the same person running the standalone `ha task complete <task> --ci passed` was `allowed`. A caller authorized to close out a task could not complete it via the one-shot command (workaround: run closeout, then complete standalone).

## Architectural Justification

`closeoutTask`'s per-leaf `invoke` re-derived a fresh authorization for each stage with the center AuthorizationPort decision dropped (`unqualifiedBinding = { ...binding, authorizationDecision: undefined }`). For `complete` this re-derivation denied a caller that the standalone `ha task complete` path (which carries the binding as-is) authorizes. The closeout's outer center decision — required, and already `allowed` for the closeout as a whole — was ignored for the complete leaf. A closeout is the umbrella that runs submit→review→consent→complete, so authorizing the closeout authorizes its complete sub-step; `task-complete` and the closeout path resolve through the same generic role-binding check. Reusing the already-`allowed` center decision for the complete leaf is therefore an alignment, not a relaxation. The change is the minimal source-level correction (no new bypass branch); other stages are untouched.

## What Changed

- `packages/daemon/src/repo-cell-closeout.ts`: extract the leaf authorization into an exported `authorizeCloseoutLeaf(...)`. For the `complete` stage, reuse the center `binding.authorizationDecision` when it is already `allowed`; otherwise fall back to the per-leaf `authorizeRepoCellAction` re-derivation. submit / review-execution / review-consent are unchanged.
- `packages/daemon/test/task-closeout-action.test.ts`: regression test with a positive control (complete + allowed center decision → `allowed`, i.e. reuse) and a negative control (complete + non-allowed/absent center decision → `denied`, i.e. re-derive and fail-closed).

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none

## Machine-Readable Declarations

Production-Delta: +25/-2
Dependency-Change: none
Event-Migration: none — pure authorization-evaluation fix; no event shape or replay change.

## Task And Scope

- Harness task: task_733cbfdf3ace649a8a5aaab0ff (flow-defect fix).
- Branch: codex/closeout-authz; base origin/main 830e5ec1.
- Out of scope: canonical migration/write path, WAL/SQLite, CI/branch protection, the other closeout stages' authorization.

## Version Impact

- Version: no change (internal daemon authorization-parity fix). Publish impact: none.

## Governance Declaration

- Protected surface touched: no.
- Break-glass: no.

## Verification

- Base `origin/main` SHA: 830e5ec1.
- `npx eslint` on both touched files: pass (exit 0).
- `npx tsc -b packages/daemon`: pass (exit 0).
- `node tools/run-node-tests.mjs --tier fast --file packages/daemon/test/task-closeout-action.test.ts`: 17 pass / 0 fail (new positive/negative regression test + all pre-existing closeout tests, no regression).
- Full matrix: CI is the authority (in particular broader authorization-invariant tests).

## Review Evidence

- Implemented by Sol (codex-api) over two rounds; round-1 delivered the fix without a test, CEO returned it for a real-authz regression test + negative control before acceptance; round-2 added the exported `authorizeCloseoutLeaf` + positive/negative test.
- CEO ground-truth: read the fix + test, confirmed the negative control re-derives and denies; ran the file (17/0).

## Residual Risk

- The exact root cause of the per-leaf denial (why re-deriving with `authorizationDecision: undefined` denies `complete` specifically) was not pinned in a written report; the fix corrects the observable behavior by reusing the already-`allowed` center decision rather than by changing the generic authorization. If a reviewer knows a `complete`-specific check that the closeout authorization does not subsume, this reuse could bypass it — please flag. The negative control guards the no-blanket-allow direction; CI's broader authorization tests are the safety net for the subsumption assumption.

  Update: the peer CEO session independently ground-truthed this during three real closeouts — standalone `ha task complete` authorizes with the same generic check (`bindingsUsed: hasRoleBinding repo-write`, `reasonCodes: authorization_allowed`), and complete's extra requirements (fact_missing, code_doc_missing, fact-retirement) are completion-READINESS gates evaluated AFTER authorization with distinct error codes — not authorization gates. So the subsumption is empirically confirmed: complete has no authorization check beyond what closeout already covers.

## References

- Reported by the peer CEO session during task_477321af closeout.

---

# 中文

## 概要

修复 `task_733cbfdf`(流转缺陷):一次性 `ha task closeout <task>` 跑到 **complete 子步**返回 `authorization_denied`,但同一 person 直接跑独立 `ha task complete <task> --ci passed` 却 `allowed`。即有权 closeout 的操作者无法经一次性命令 complete(workaround:closeout 后再独立 complete)。

## 架构辩护

`closeoutTask` 的 per-leaf `invoke` 对每个阶段丢弃中心 AuthorizationPort 决策(`authorizationDecision: undefined`)重新求授权。complete 阶段这次重推拒了独立 `ha task complete`(原样携带 binding)本会放行的操作者。closeout 外层中心决策(必需、且对整个 closeout 已 `allowed`)在 complete leaf 被忽略。closeout 是跑 submit→review→consent→complete 的总伞,授权 closeout 即授权其 complete 子步;`task-complete` 与 closeout 走同一通用 role-binding 检查。故对 complete leaf 复用已 `allowed` 的中心决策是**对齐而非放宽**。改动是最小源头修正(不加旁路分支),其它阶段不动。

## 改动内容

- `packages/daemon/src/repo-cell-closeout.ts`:把 leaf 授权抽成导出的 `authorizeCloseoutLeaf(...)`。complete 阶段在中心 `binding.authorizationDecision` 已 `allowed` 时复用它,否则回落 per-leaf `authorizeRepoCellAction` 重推。submit/review-execution/review-consent 不变。
- `packages/daemon/test/task-closeout-action.test.ts`:回归测试,阳性(complete+allowed 中心决策→`allowed` 复用)+ 阴性(complete+非-allowed/缺失中心决策→`denied` 重推、fail-closed)对照。

## 门收割 / Gate Harvest

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none

## 机读声明说明

机读声明只在英文块给出(Production-Delta +25/-2、Dependency-Change none、Event-Migration none)。

## 任务与范围

- Harness 任务:task_733cbfdf3ace649a8a5aaab0ff(流转缺陷修复)。
- 分支:codex/closeout-authz;base origin/main 830e5ec1。
- 范围外:canonical 迁移/写路径、WAL/SQLite、CI/分支保护、其它 closeout 阶段的授权。

## 版本影响

- 版本:不变(daemon 内部授权一致性修复)。发布影响:无。

## 治理声明

- 触碰 protected surface:否。
- Break-glass:否。

## 验证

- base origin/main:830e5ec1。
- 两文件 `eslint`:exit 0;`tsc -b packages/daemon`:exit 0。
- `task-closeout-action.test.ts` 定向:17 pass / 0 fail(新阳性/阴性回归测试 + 既有 closeout 测试无回归)。
- 完整矩阵以 CI 为权威(尤其更广的授权不变量测试)。

## 审查证据

- Sol(codex-api)两轮实现:round-1 给 fix 无测试,CEO 退回要真实授权路径的回归测试 + 阴性对照;round-2 补导出 `authorizeCloseoutLeaf` + 阳性/阴性测试。
- CEO ground-truth:读 fix+测试、确认阴性对照重推且拒、跑文件 17/0。

## 残余风险

- per-leaf 拒 complete 的确切根因未落书面报告;fix 以复用已 `allowed` 的中心决策修正可观察行为,而非改通用授权。若复核者知道 complete 有 closeout 不 subsume 的合法额外检查,此复用可能绕过它——请拍。阴性对照守住「不 blanket-allow」方向;CI 更广授权测试是 subsume 假设的安全网。

  补充:对面 CEO 在三个真实 closeout 上独立 ground-truth——独立 `ha task complete` 以同一通用检查放行(`bindingsUsed: hasRoleBinding repo-write`),而 complete 的额外要求(fact_missing、code_doc_missing、fact-retirement)是**授权通过之后**评估的 completion-READINESS 门、错误码各不相同,不是授权门。故 subsume 已实证:complete 没有 closeout 未覆盖的授权检查。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
