### PR TITLE
feat(gui): default the assoc axis and its relation kinds on

### DIFF
--- a/packages/gui/src/renderer/graph/EgoNeighborhood.tsx
+++ b/packages/gui/src/renderer/graph/EgoNeighborhood.tsx
@@ -28,7 +28,7 @@ import {
   type EgoFlowNode,
   type EgoHopBudget,
 } from "./egoCanvas";
-import { defaultKindFilter, edgePassesKindFilter, type FlowAnimMode } from "./relationVisual";
+import { defaultAxisFilter, defaultKindFilter, edgePassesKindFilter, type FlowAnimMode } from "./relationVisual";
 import {
   defaultEntityStatusFilter,
   isEntityStatusFilterNarrowed,
@@ -63,7 +63,7 @@ export interface EgoNeighborhoodFilters {
 
 export function defaultNeighborhoodFilters(): EgoNeighborhoodFilters {
   return {
-    axes: { authority: true, evidence: true, execution: true, assoc: false },
+    axes: defaultAxisFilter(),
     kinds: defaultKindFilter(),
     types: null,
     flowMode: "focus",

--- a/packages/gui/src/renderer/graph/relationVisual.ts
+++ b/packages/gui/src/renderer/graph/relationVisual.ts
@@ -69,14 +69,15 @@ export function visualForKind(kind: RelationKind): RelationVisual {
   return RELATION_VISUAL[kind] ?? RELATION_VISUAL.relates;
 }
 
-/** 默认关系类型筛选:assoc 轴(relates/implements)默认关,降噪。 */
+/** 默认关系类型筛选:全开。assoc 轴曾默认关降噪,但 decision↔task 的 `relates` 边
+ * 落在该轴上,关掉会让聚光灯/领地里 decision 邻居整块不可见(2026-09-08 泽宇裁决改默认)。 */
 export function defaultKindFilter(): Set<RelationKind> {
-  return new Set(RELATION_KIND_ORDER.filter((k) => KIND_AXIS[k] !== "assoc"));
+  return new Set(RELATION_KIND_ORDER);
 }
 
-/** 默认语义轴筛选:assoc 默认关。 */
+/** 默认语义轴筛选:全开(理由同 defaultKindFilter)。 */
 export function defaultAxisFilter(): Record<SemanticAxis, boolean> {
-  return { authority: true, evidence: true, execution: true, assoc: false };
+  return { authority: true, evidence: true, execution: true, assoc: true };
 }
 
 /** 边是否通过关系类型筛选。kinds 空集 = 全部隐藏。 */


### PR DESCRIPTION
# English

## Summary

The graph's assoc axis (relates/implements/owns) defaulted to hidden for noise reduction. Decisions attached to a task through a `relates` edge live on that axis, so they were invisible in the spotlight and territory graphs no matter which entity types were selected — decisions appeared to vanish while the data was intact. Defaults now enable every axis and every relation kind; the filter panel still narrows them per session (nothing is persisted).

## Architectural Justification

-

## What Changed

- `defaultAxisFilter()` returns assoc on; `defaultKindFilter()` no longer filters out assoc-axis kinds.
- `EgoNeighborhood`'s standalone default now derives from `defaultAxisFilter()` instead of its own inline literal, so the graph page and the detail-page canvases share one default source.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: see the computed production-delta job summary.

## Machine-Readable Declarations

Dependency-Change: none

## Task And Scope

- Harness task: task_259285bf6e5472341857ae95c3 (recorded after PR creation)
- Branch: codex/assoc-axis-default
- Public scope: GUI graph default filters (two functions, one call site)
- Private planning/evidence updated: yes
- Out of scope: per-user filter persistence (never existed); GUI decision-pool visibility (investigated on request, confirmed working)

## Version Impact

- Version: no version change because no package manifest or published surface changed
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope:
- Authority: not applicable
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason:
- Break-glass scope:
- Follow-up governance task:

## Verification

- Base `origin/main` SHA: f31c93a8aafacb8153377ad061f7e16a2c15bec3
- Branch merge-base with `origin/main`: f31c93a8aafacb8153377ad061f7e16a2c15bec3
- Last `git fetch origin` time: 2026-09-08T08:30+08:00
- Sync method: none needed
- Public diff command: `git diff origin/main...HEAD`
- Private evidence commit/path: task ledger (task_259285bf6e5472341857ae95c3)
- Reviewer evidence path: this PR's review section
- GitHub Actions `rewrite-ci` run URL: pending — will link after the run starts
- [ ] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [x] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts` (via `node tools/run-manifest-gates.mjs --changed origin/main`, all green)
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Not run: full `npm run check` / `npm test` — per the local stop rule the full matrix is GitHub CI's job; locally ran the changed-surface manifest gates (green), repo-wide typecheck (clean), eslint on changed files (clean), and the two graph test files (`ego-canvas.vitest.ts` 12 pass, `graph-view.vitest.ts` 4 pass).

## Review Evidence

- Self-review: diff is three spots; the ego fixture tests already exercise claim-anchored decision edges through the defaults.
- Reviewer subagent: none
- Human review: owner requested this default change directly (2026-09-08)
- Blocking findings: none known

## Residual Risk

- Graphs get busier by default (owns/relates/implements edges now draw); users who want the old view narrow the axis in the filter panel per session.

## References

- Task: task_259285bf6e5472341857ae95c3
- Evidence: root-cause analysis in the 2026-09-07 session (decisions reachable only via `relates` edges on the hidden assoc axis)
- Review:

---

# 中文

## 概要

关系图的关联轴(relates/implements/owns)此前默认关闭降噪,而 decision↔task 之间的 `relates` 边正落在这条轴上——聚光灯/领地里这类 decision 邻居整块不可见,选满实体类型也救不回来,表现为「decision 莫名消失」而数据完好。现在默认全部轴、全部关系类型开启;筛选面板仍可按会话收窄(筛选不落盘)。

## 架构辩护

-

## 改动内容

- `defaultAxisFilter()` 返回 assoc 开;`defaultKindFilter()` 不再剔除关联轴关系类型。
- `EgoNeighborhood` 的独立默认从内联字面量改为引用 `defaultAxisFilter()`,图页与详情页画布共用同一默认源。

## 门收割 / Gate Harvest

- 删除的生产路径:none
- 同 commit 删除的门 / fixture:none
- 生产净行数:见 production-delta job summary 的机器计算结果。

## 机读声明说明

- 依赖变化:未修改任何 `package.json` / `package-lock.json`。
- 保留旧路径:不适用。
- Evidence claim:本次不声明。

## 任务与范围

- Harness 任务:task_259285bf6e5472341857ae95c3(PR 创建后补记)
- 分支:codex/assoc-axis-default
- 公开范围:GUI 图默认筛选(两个函数、一个调用点)
- 私有计划 / 证据是否已更新:yes
- 范围外:筛选的按用户持久化(从未存在);决策池可见性(应邀排查,确认正常)

## 版本影响

- 版本:不改版本,原因是未修改任何 package manifest 或发布面
- 发布影响:不发布

## 治理声明

- 是否触碰 protected surface:no
- protected surface 范围:
- 依据:不适用
- 机器检查边界:本 PR 只声明该段存在;声明是否真实、充分,由 reviewer 判断。
- Break-glass:no
- Break-glass 原因:
- Break-glass 范围:
- 后续治理任务:

## 验证

- `origin/main` 基准 SHA:f31c93a8aafacb8153377ad061f7e16a2c15bec3
- 当前分支与 `origin/main` 的 merge-base:f31c93a8aafacb8153377ad061f7e16a2c15bec3
- 最近一次 `git fetch origin` 时间:2026-09-08T08:30+08:00
- 同步方式:不需要
- 公开 diff 命令:`git diff origin/main...HEAD`
- 私有证据 commit/path:任务台账(task_259285bf6e5472341857ae95c3)
- Reviewer 证据路径:本 PR review 区
- GitHub Actions `rewrite-ci` run URL:待 run 启动后补
- [ ] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [x] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts`(经 `node tools/run-manifest-gates.mjs --changed origin/main`,全绿)
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- 未运行:完整 `npm run check` / `npm test`——按本机停止点纪律完整矩阵归 GitHub CI;本机已跑:改动面 manifest 门(绿)、全仓 typecheck(净)、改动文件 eslint(净)、两个图测试文件(`ego-canvas.vitest.ts` 12 过、`graph-view.vitest.ts` 4 过)。

## 审查证据

- 自查:diff 共三处;ego fixture 测试本就用默认筛选跑 claim 锚定的 decision 边。
- Reviewer subagent:无
- 人工审查:owner 于 2026-09-08 直接拍板该默认变更
- 阻塞发现:无已知

## 残余风险

- 默认图更热闹(owns/relates/implements 边现在画出来);想要旧观感的用户在筛选面板按会话收窄该轴。

## 关联材料

- 任务:task_259285bf6e5472341857ae95c3
- 证据:2026-09-07 会话的根因分析(decision 仅经隐藏关联轴上的 `relates` 边可达)
- 审查:
