### PR TITLE
fix(store): generation-aware backup skips legacy read when SQLite present

### DIFF
--- a/packages/kernel/src/store/ledger-backup.ts
+++ b/packages/kernel/src/store/ledger-backup.ts
@@ -42,8 +42,8 @@ export function createLedgerBackup(input: {
   fileSystem.mkdir(payloadRoot, { recursive: true });
   for (const sourcePath of sourcePaths) copySource(layout.rootDir, sourcePath, payloadRoot);
   if (sqlitePresent) vacuumSqlite(layout.rootDir, sqlitePath, payloadRoot);
-  const legacy = readStoppedLegacyGeneration({ rootInput: input.rootInput }),
-    sqlite = sqlitePresent ? inspectSqlite(sqlitePath) : null,
+  const sqlite = sqlitePresent ? inspectSqlite(sqlitePath) : null,
+    legacy = sqlitePresent ? null : readStoppedLegacyGeneration({ rootInput: input.rootInput }),
     sqliteRelative = portable(path.relative(layout.rootDir, sqlitePath)),
     files = inventory(payloadRoot).map((backupFile) => {
       const relative = portable(path.relative(payloadRoot, backupFile)),
@@ -66,8 +66,8 @@ export function createLedgerBackup(input: {
     accepted: sqlite
       ? { revision: sqlite.revision, opIds: sqlite.opIds }
       : {
-          revision: legacy.eventEntries.length,
-          opIds: new Set(legacy.eventEntries.map(({ event }) => event.opId)).size,
+          revision: legacy!.eventEntries.length,
+          opIds: new Set(legacy!.eventEntries.map(({ event }) => event.opId)).size,
         },
     sqlite: { present: sqlitePresent, integrity: sqlite?.integrity ?? null },
     files,

--- a/packages/kernel/test/store/ledger-backup.integration.test.ts
+++ b/packages/kernel/test/store/ledger-backup.integration.test.ts
@@ -96,6 +96,7 @@ test("VACUUM backup survives source deletion and rejects wrong generation metada
     backupDir = path.join(os.tmpdir(), `ha-backup-sqlite-${process.pid}-${Date.now()}`),
     store = openSqliteEventStore({ repoId: "backup-test", rootInput: root });
   try {
+    execFileSync("git", ["update-ref", "-d", "refs/ha/canonical"], { cwd: root });
     store.appendCommand({
       fence: { repoId: "backup-test", holder: "test", epoch: 1 },
       intent: { opId: event.opId, intentDigest: `sha256:${sha256Text(JSON.stringify(event))}`, summary: event.type },


### PR DESCRIPTION
# English

## Summary

`ha backup` no longer unconditionally reads the stopped legacy (WAL/Git) generation. When a SQLite generation is present, backup takes its accepted revision/opId counts from the SQLite store and skips the legacy read entirely, so backup no longer fails after the SQLite cutover when `refs/ha/canonical` is absent.

## What Changed

- `packages/kernel/src/store/ledger-backup.ts`: read the stopped legacy generation only when SQLite is absent (`legacy = sqlitePresent ? null : readStoppedLegacyGeneration(...)`); when SQLite is present, `accepted` is derived from the SQLite inspection.
- `packages/kernel/test/store/ledger-backup.integration.test.ts`: add coverage that deletes `refs/ha/canonical` before the SQLite VACUUM backup, proving backup succeeds without a legacy canonical ref.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: +4 / -4 (see the computed production-delta job summary).

## Machine-Readable Declarations

Dependency-Change: none

## Task And Scope

- Harness task: task_e35f31b0 (备份/恢复闭包 — the generation-aware backup piece)
- Branch: codex/backup-r5
- Public scope: `packages/kernel` backup module and its integration test
- Private planning/evidence updated: not applicable
- Out of scope: `ha backup/restore/events` CLI wiring and the G30 offline-maintenance exception (already in main), and the canonical three-drill run (mainline runs it at cutover)

## Version Impact

- Version: no version change because this is a bugfix to existing backup logic
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none
- Authority: not applicable
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no

---

# 中文

## 摘要

`ha backup` 在 SQLite generation 存在时不再无条件读取已停用的 legacy(WAL/Git)generation:SQLite 存在则从 SQLite store 取 accepted revision/opId 计数、完全跳过 legacy 读取,避免 SQLite 换代后没有 `refs/ha/canonical` 时备份失败。

## 改了什么

- `packages/kernel/src/store/ledger-backup.ts`:仅在 SQLite 不存在时才读停用的 legacy generation(`legacy = sqlitePresent ? null : readStoppedLegacyGeneration(...)`);SQLite 存在时 `accepted` 由 SQLite 检查派生。
- `packages/kernel/test/store/ledger-backup.integration.test.ts`:新增一条在 SQLite VACUUM 备份前删除 `refs/ha/canonical` 的覆盖,证明无 legacy canonical ref 时备份仍成功。

## 任务与范围

- Harness 任务:task_e35f31b0(备份/恢复闭包 — generation-aware 备份这一块)
- 分支:codex/backup-r5
- 公开范围:`packages/kernel` 备份模块与其 integration 测试
- 私有规划/证据更新:不适用
- 范围外:`ha backup/restore/events` CLI 接线与 G30 offline-maintenance 例外(已在 main)、canonical 三演练(主线换代时跑)

## 版本影响

- 版本:无版本变更,因为这是对既有备份逻辑的 bugfix
- 发布影响:不发布

## 治理声明

- 触碰 protected surface:否
- Protected surface 范围:无
- 授权:不适用
- 机器校验边界:本 PR 仅声明该声明存在;是否为真且充分由评审判断。
- Break-glass:否

🤖 Generated with [Claude Code](https://claude.com/claude-code)
