### PR TITLE
fix(daemon): reuse caller binding for task artifacts

### DIFF
--- a/packages/daemon/src/doc-sync-candidate-scanner.ts
+++ b/packages/daemon/src/doc-sync-candidate-scanner.ts
@@ -115,7 +115,7 @@ export function scanDocCandidates(input: {
       )
       .sort(),
     baseLedgerSha = input.inventory?.baseLedgerSha ?? input.store.currentCut(),
-    execution = executionBinding(
+    execution = resolveDocExecutionBinding(
       paths,
       input.executionId,
       input.projection,
@@ -457,7 +457,7 @@ export function publicScan(scan: DocCandidateScan): {
   };
 }
 
-function executionBinding(
+export function resolveDocExecutionBinding(
   paths: readonly string[],
   explicit: string | undefined,
   projection: TaskProjection,

--- a/packages/daemon/src/doc-sync-command-actions.ts
+++ b/packages/daemon/src/doc-sync-command-actions.ts
@@ -22,7 +22,7 @@ import {
   type WriteSource,
 } from "../../kernel/src/index.ts";
 import { assignmentIntent, scannerSubmit } from "./doc-sync-adjudication.ts";
-import { intentFromScan } from "./doc-sync-candidate-scanner.ts";
+import { intentFromScan, resolveDocExecutionBinding } from "./doc-sync-candidate-scanner.ts";
 import type { AuthoredCandidateInventoryV1, DocCandidateScan } from "./doc-sync-candidate-scanner.ts";
 import { claimBytes, directPaths, settleConflictScratch } from "./doc-sync-details.ts";
 import {
@@ -427,7 +427,16 @@ function publishTaskArtifactBytes(
   }
   const sha = sha256Bytes(bytes),
     base = input.store.currentCut(),
-    lease = input.projection.currentLease(taskId, input.now()),
+    execution = resolveDocExecutionBinding(
+      [destination],
+      undefined,
+      input.projection,
+      input.binding.actor,
+      input.binding.source,
+      input.now(),
+      taskId,
+    ),
+    lease = execution.lease,
     intent = parseDocWriteIntent(
       {
         schema: "doc-write-intent/v1",

--- a/packages/daemon/test/doc-sync-slice-a-implicit-lease.test.ts
+++ b/packages/daemon/test/doc-sync-slice-a-implicit-lease.test.ts
@@ -1,6 +1,6 @@
 // harness-test-tier: integration
 import assert from "node:assert/strict";
-import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -278,6 +278,40 @@ test("path and confirmed full submits ride the repository prose channel when ano
     assert.equal(
       (await cell.run({ kind: "task-start", taskId, executionId: "exec-path-prose" }, holder)).outcome,
       "applied",
+    );
+    const artifactBody = '{"verified":true}\n';
+    writeFileSync(path.join(rootDir, ".harness", "incoming.json"), artifactBody);
+    const artifact = await cell.run(
+      {
+        kind: "task-artifact-add",
+        taskId,
+        source: ".harness/incoming.json",
+        destination: "reports/imported.json",
+      },
+      person,
+    );
+    assert.equal(artifact.outcome, "applied", JSON.stringify(artifact));
+    await waitForWorktree(cell, artifact, person);
+    const artifactEvent = makeTaskEventReader({ repoId, rootDir }).readEvent(artifact.opId);
+    assert.equal(artifactEvent?.schema, "doc-event/v1");
+    if (artifactEvent?.schema === "doc-event/v1") assert.equal(artifactEvent.payload.executionId, null);
+    assert.equal(
+      readFileSync(path.join(rootDir, "harness", packagePath, "artifacts/reports/imported.json"), "utf8"),
+      artifactBody,
+    );
+    const unboundRuntime = await cell.run(
+      {
+        kind: "task-artifact-add",
+        taskId,
+        source: ".harness/incoming.json",
+        destination: "reports/unbound-runtime.json",
+      },
+      holder,
+    );
+    assert.equal(unboundRuntime.code, "lease_conflict", JSON.stringify(unboundRuntime));
+    assert.equal(
+      existsSync(path.join(rootDir, "harness", packagePath, "artifacts/reports/unbound-runtime.json")),
+      false,
     );
     write(rootDir, `${packagePath}/artifacts/reports/leased.md`, "# Leased task report\n");
     write(rootDir, "context/shared.md", "# Shared\n");


### PR DESCRIPTION
# English

## Summary

Fix task artifact publication for a repository caller when another executor holds the task lease. Artifact publication now uses the same caller-aware execution binding as doc submission, preserving runtime task scope and byte ownership checks.

## Architectural Justification

Reuse the existing selector in the same module. Remove unconditional currentLease binding rather than adding another authorization path. No new event, schema, permission exception or store.

## What Changed

- Export the existing caller binding selector and reuse it in artifact publication.
- Reproduce the non-holder rejection through the real artifact action; assert null execution binding and exact published bytes after the fix.
- Verify an unbound runtime still rejects and creates no destination.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
Production +13/-4 lines. The unconditional lease-selection expression is replaced in the same change; no obsolete path is retained.

## Machine-Readable Declarations

No dependency, version, or accepted-event fixture changes.

## Task And Scope

- Harness task: task_ca527730a1d31cf2f5165e5499.
- Branch: codex/artifact-caller-channel.
- Public scope: daemon doc-sync action/scanner and existing implicit-lease regression.
- Private planning/evidence updated: yes.
- Out of scope: new Entity storage formats, backlog ingestion and actual release.

## Version Impact

No version change; focused repair. No publish.

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: not applicable
- Machine-check boundary: declarations do not replace semantic review.
- Break-glass: no

## Verification

- Base origin/main: 934da262eccdcb0e79ed830667c697cb8884b361, fetched 2026-09-08 UTC and merged without conflicting source changes. Public diff: git diff origin/main...HEAD.
- Ubuntu isolated dispatcher: implicit-lease 7/7, artifacts-upgrades 3/3, opaque-artifact 7/7; runtime-spawn-ingress 17/17, including real bound-runtime artifact publication and cross-task rejection.
- The added non-holder test failed with lease_conflict before the fix and passed after it.
- Scoped ESLint, Prettier and git diff --check passed. Local typecheck hook could not find worktree tsc; no local typecheck claim. PR CI supplies typecheck and required checks.
- No full check:local or unrelated matrix reruns. All 17 required checks passed on run34250287487 attempt2: https://github.com/FairladyZ625/harness-anything/actions/runs/34250287487. Attempt1 failed an unrelated Fleet fixture doc-submit with database is locked; preserved as fact F-60D0708F under the existing Fleet stability task. No source or gate change was made for the rerun.

## Review Evidence

Independent HA Sol and GLM reviews inspected the full authorization and data path. No confirmed P0-P2 defects. GLM noted missing recorded bound-runtime test evidence; the existing ingress suite was subsequently run and all 17 tests passed. The intended refusal of a runtime lacking a session task binding is preserved. Private reports: sol-review.md and glm-review.md. No human review claim.

## Residual Risk

Not deployed and the original live backlog ingestion has not yet been replayed. Git publication and materialization remain asynchronous, with existing separate receipt facets. Required CI must pass before normal merge and branch cleanup; no bypass planned.

## References

Existing doc-sync-writer and task-bound-runtime-authority contracts; private fact F-2F6BF6E7 records the scoped regression evidence.

---

# 中文

## 概要

修复其他执行者持有Task租约时，合法仓库调用者补录附件被lease_conflict拒绝的问题。附件提交复用doc提交已有的调用者执行绑定选择，保持runtime任务范围与原字节保护。

## 架构辩护

复用现有模块函数，删除无条件currentLease绑定，不增加第二权限通道、事件格式、例外或存储。

## 改动内容

导出已有通道选择函数供附件入口调用；现有测试通过真实artifact动作复现非持有人拒绝，并验证修复后空execution绑定和精确字节。同时验证未绑定runtime仍拒绝且目标文件不存在。

## 门收割 / Gate Harvest

生产+13/-4行，无文件删除；错误租约选择表达式同次替换，无保留旧生产路径。机读声明只在英文块出现。

## 机读声明说明

不改依赖、版本或已接受事件fixture。

## 任务与范围

Task task_ca527730a1d31cf2f5165e5499；分支codex/artifact-caller-channel。仅daemon两个doc-sync模块和已有回归文件，私有证据已更新；不含新Entity格式、历史库存入账或正式发布。

## 版本影响

局部修复，不改版本、不发布。

## 治理声明

未触碰protected surface，不改CI/gate，无break-glass；声明不替代语义审查。

## 验证

基准934da262eccdcb0e79ed830667c697cb8884b361，2026-09-08 UTC fetch并merge，无源码冲突。Ubuntu隔离测试7+3+7+17全部通过，最后17项包含真实runtime附件写入和跨Task拒绝。新增回归旧代码lease_conflict失败、修复后通过。范围ESLint、Prettier和diff检查通过；worktree提交hook缺本地tsc，不冒称本地typecheck，交真实PR CI验证。未跑完整check:local或无关矩阵；CI run34250287487第二次运行17项必需检查全绿。第一次Fleet夹具doc-submit报database is locked，已保留为F-60D0708F并归既有Fleet稳定性任务；重跑未改源码或门禁。

## 审查证据

独立HA Sol与GLM完整核对权限和数据链，零确认P0-P2缺陷。GLM提出真实绑定runtime测试证据缺口，随后补跑现有ingress套件17/17通过。缺session绑定的runtime继续拒绝是既有doc通道语义。私有报告sol-review.md/glm-review.md，不冒称人工评审。

## 残余风险

尚未部署和重放真实库存入账。Git发布与物化沿用既有异步回执；必需CI通过后普通merge并清理，无绕过。

## 关联材料

现有doc-sync-writer、task-bound-runtime-authority契约及私有Fact F-2F6BF6E7。

## PR Gate Checklist / PR 门禁清单

- [x] Scoped change and full bilingual structure / 范围与完整双语结构
- [x] Targeted Ubuntu evidence and independent reviews / 定向Ubuntu证据与独立评审
- [x] Required CI and final comment triage / 必需CI及最终评论分诊
- [x] Normal merge and cleanup after checks, no publish / 通过后普通merge清理，不发布
