### PR TITLE
feat(gui): resize columns across board, swimlane and list layouts

### DIFF
--- a/packages/gui/src/renderer/board-column-preferences.ts
+++ b/packages/gui/src/renderer/board-column-preferences.ts
@@ -1,0 +1,99 @@
+import { consumeKnownError } from "../api/error-consumption.ts";
+import { isRendererRecord } from "./result-validation.ts";
+
+/**
+ * 看板列宽的本地持久化(W11):三种布局(列/泳道/列表)各一份「列 key → px 宽度」
+ * 映射,存 renderer localStorage(同 favorites/graph-density,不进台账、不进 URL)。
+ * 模型刻意保持「每列一个数字」:未设置的列走各视图的 CSS 默认(列模式等分、
+ * 泳道 180/230、列表 table-fixed 自动分配),设置了才输出显式宽度。
+ */
+const storageKey = "harness:gui:board-column-widths";
+
+export type BoardLayoutId = "column" | "swimlane" | "list";
+export type BoardColumnWidthMap = Record<string, number>;
+
+export interface BoardColumnWidths {
+  readonly column: BoardColumnWidthMap;
+  readonly swimlane: BoardColumnWidthMap;
+  readonly list: BoardColumnWidthMap;
+}
+
+export const emptyBoardColumnWidths: BoardColumnWidths = { column: {}, swimlane: {}, list: {} };
+
+/** 存储层的全局 sanity 区间;各视图在交互时再按自己的列做更紧的 clamp。 */
+const storedWidthRange = { min: 40, max: 1200 } as const;
+
+/** renderer 的 localStorage;非 DOM 环境(如 SSR 渲染)返回 null,宽度回落默认。 */
+export function boardColumnPreferenceStorage(): {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+} | null {
+  return typeof window === "undefined" ? null : window.localStorage;
+}
+
+export function clampBoardColumnWidth(px: number): number {
+  return Math.min(storedWidthRange.max, Math.max(storedWidthRange.min, Math.round(px)));
+}
+
+function widthMap(value: unknown): BoardColumnWidthMap {
+  if (!isRendererRecord(value)) return {};
+  const map: BoardColumnWidthMap = {};
+  for (const [key, raw] of Object.entries(value)) {
+    // 有限数字一律收下并 clamp(存量偏好即使超出新区间也只是被夹回,不丢)。
+    if (typeof raw === "number" && Number.isFinite(raw)) map[key] = clampBoardColumnWidth(raw);
+  }
+  return map;
+}
+
+export function readBoardColumnWidths(
+  storage: { getItem(key: string): string | null } | null | undefined,
+): BoardColumnWidths {
+  if (!storage) return emptyBoardColumnWidths;
+  try {
+    const parsed: unknown = JSON.parse(storage.getItem(storageKey) ?? "null");
+    if (!isRendererRecord(parsed)) return emptyBoardColumnWidths;
+    return {
+      column: widthMap(parsed.column),
+      swimlane: widthMap(parsed.swimlane),
+      list: widthMap(parsed.list),
+    };
+  } catch (cause) {
+    consumeKnownError(cause);
+    return emptyBoardColumnWidths;
+  }
+}
+
+export function writeBoardColumnWidths(
+  storage: { setItem(key: string, value: string): void } | null | undefined,
+  widths: BoardColumnWidths,
+): void {
+  if (!storage) return;
+  try {
+    storage.setItem(storageKey, JSON.stringify(widths));
+  } catch (cause) {
+    // 隐私模式/quota 满:本会话宽度仍生效,只是不跨会话记忆(显式消费,不静默吞)。
+    consumeKnownError(cause);
+  }
+}
+
+/** 设置一列宽度(clamp + 取整);返回新对象,不改入参。 */
+export function setBoardColumnWidth(
+  widths: BoardColumnWidths,
+  layout: BoardLayoutId,
+  key: string,
+  px: number,
+): BoardColumnWidths {
+  return { ...widths, [layout]: { ...widths[layout], [key]: clampBoardColumnWidth(px) } };
+}
+
+/** 清除一列宽度(双击手柄恢复默认布局);key 不存在时原样返回。 */
+export function clearBoardColumnWidth(
+  widths: BoardColumnWidths,
+  layout: BoardLayoutId,
+  key: string,
+): BoardColumnWidths {
+  if (!(key in widths[layout])) return widths;
+  const next = { ...widths[layout] };
+  delete next[key];
+  return { ...widths, [layout]: next };
+}

--- a/packages/gui/src/renderer/components/ColumnResizeHandle.tsx
+++ b/packages/gui/src/renderer/components/ColumnResizeHandle.tsx
@@ -1,0 +1,83 @@
+import type { KeyboardEvent, PointerEvent as ReactPointerEvent } from "react";
+
+const KEYBOARD_STEP = 16;
+
+/**
+ * 看板列宽手柄(W11,三布局共用):TerminalChrome 侧栏的 pointer 拖拽模式
+ * (按下后在 window 上跟指针,松手收听)加上键盘可达——可 Tab 聚焦,←/→ 微调。
+ *
+ * 摆放不变量:手柄必须是「列容器」的直接子元素。未定宽的列(width 未传)在
+ * 拖拽/键盘起点用父元素的实测宽度作基准,已定宽列直接用状态值。宽度状态与
+ * 持久化都由调用方(各看板视图)持有,本组件只汇报目标宽度。
+ */
+export function ColumnResizeHandle({
+  label,
+  width,
+  min,
+  max,
+  onChange,
+  onReset,
+  className = "",
+  testId,
+}: {
+  /** 无障碍名,如「调整「Active」列宽」。 */
+  label: string;
+  /** 当前持久化宽度;undefined = 该列仍走默认布局。 */
+  width: number | undefined;
+  min: number;
+  max: number;
+  onChange: (px: number) => void;
+  /** 双击恢复默认布局;不传则双击无操作。 */
+  onReset?: () => void;
+  /** 定位类(如 absolute inset-y-0 -right-1.5);光标/触摸/焦点样式已内置。 */
+  className?: string;
+  testId?: string;
+}) {
+  const clamp = (px: number) => Math.min(max, Math.max(min, Math.round(px)));
+  // 未定宽列的基准 = 父元素(列容器)的实测宽度;测不到(SSR)时退 min。
+  const baseWidth = (element: HTMLElement) =>
+    width ?? Math.round(element.parentElement?.getBoundingClientRect().width ?? min);
+
+  const startDrag = (event: ReactPointerEvent<HTMLDivElement>) => {
+    if (event.button !== 0) return;
+    event.preventDefault();
+    const origin = event.clientX;
+    const base = baseWidth(event.currentTarget);
+    const onMove = (move: PointerEvent) => onChange(clamp(base + move.clientX - origin));
+    const onUp = () => {
+      window.removeEventListener("pointermove", onMove);
+      window.removeEventListener("pointerup", onUp);
+    };
+    window.addEventListener("pointermove", onMove);
+    window.addEventListener("pointerup", onUp);
+  };
+
+  const onKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (event.key !== "ArrowLeft" && event.key !== "ArrowRight") return;
+    event.preventDefault();
+    const step = event.key === "ArrowLeft" ? -KEYBOARD_STEP : KEYBOARD_STEP;
+    onChange(clamp(baseWidth(event.currentTarget) + step));
+  };
+
+  return (
+    <div
+      role="separator"
+      aria-orientation="vertical"
+      aria-label={label}
+      aria-valuenow={width}
+      aria-valuemin={min}
+      aria-valuemax={max}
+      tabIndex={0}
+      data-testid={testId}
+      title={`${label}(拖拽调宽 · ←/→ 微调${onReset ? " · 双击恢复默认" : ""})`}
+      onPointerDown={startDrag}
+      onKeyDown={onKeyDown}
+      onDoubleClick={onReset}
+      className={[
+        "z-10 w-3 cursor-col-resize touch-none select-none",
+        "hover:bg-accent/30 focus-visible:bg-accent/50 focus-visible:outline-none",
+        className,
+      ].join(" ")}
+    />
+  );
+}

--- a/packages/gui/src/renderer/components/ColumnResizeHandle.tsx
+++ b/packages/gui/src/renderer/components/ColumnResizeHandle.tsx
@@ -6,7 +6,8 @@ const KEYBOARD_STEP = 16;
  * 看板列宽手柄(W11,三布局共用):TerminalChrome 侧栏的 pointer 拖拽模式
  * (按下后在 window 上跟指针,松手收听)加上键盘可达——可 Tab 聚焦,←/→ 微调。
  *
- * 摆放不变量:手柄必须是「列容器」的直接子元素。未定宽的列(width 未传)在
+ * 摆放不变量:手柄必须是「列容器」的直接子元素,基类自带 position:absolute,
+ * 列容器须为 relative,消费方只补 inset 偏移类。未定宽的列(width 未传)在
  * 拖拽/键盘起点用父元素的实测宽度作基准,已定宽列直接用状态值。宽度状态与
  * 持久化都由调用方(各看板视图)持有,本组件只汇报目标宽度。
  */
@@ -29,7 +30,7 @@ export function ColumnResizeHandle({
   onChange: (px: number) => void;
   /** 双击恢复默认布局;不传则双击无操作。 */
   onReset?: () => void;
-  /** 定位类(如 absolute inset-y-0 -right-1.5);光标/触摸/焦点样式已内置。 */
+  /** 定位偏移类(如 inset-y-0 -right-1.5);position:absolute 与光标/触摸/焦点样式已内置。 */
   className?: string;
   testId?: string;
 }) {
@@ -95,7 +96,9 @@ export function ColumnResizeHandle({
       onKeyDown={onKeyDown}
       onDoubleClick={onReset}
       className={[
-        "z-10 w-3 cursor-col-resize touch-none select-none",
+        // absolute 必须在共享基类:手柄自身无内容,静态流里高度恒为 0,inset-* 全部
+        // 失效,鼠标无命中区(2026-09-09 真机验收实证);父容器按不变量已是 relative。
+        "absolute z-10 w-3 cursor-col-resize touch-none select-none",
         "hover:bg-accent/30 focus-visible:bg-accent/50 focus-visible:outline-none",
         className,
       ].join(" ")}

--- a/packages/gui/src/renderer/components/ColumnResizeHandle.tsx
+++ b/packages/gui/src/renderer/components/ColumnResizeHandle.tsx
@@ -1,4 +1,4 @@
-import type { KeyboardEvent, PointerEvent as ReactPointerEvent } from "react";
+import { useEffect, useRef, useState, type KeyboardEvent, type PointerEvent as ReactPointerEvent } from "react";
 
 const KEYBOARD_STEP = 16;
 
@@ -38,19 +38,39 @@ export function ColumnResizeHandle({
   const baseWidth = (element: HTMLElement) =>
     width ?? Math.round(element.parentElement?.getBoundingClientRect().width ?? min);
 
+  // 拖拽监听的唯一 owner:ref 持当前收尾函数,pointerup/pointercancel、开始新拖拽
+  // 前与组件卸载都走它——取消或中途卸载后不再有 stale onChange 继续写宽度。
+  const stopDragRef = useRef<(() => void) | null>(null);
+  useEffect(() => () => stopDragRef.current?.(), []);
+
   const startDrag = (event: ReactPointerEvent<HTMLDivElement>) => {
     if (event.button !== 0) return;
     event.preventDefault();
+    stopDragRef.current?.();
     const origin = event.clientX;
     const base = baseWidth(event.currentTarget);
     const onMove = (move: PointerEvent) => onChange(clamp(base + move.clientX - origin));
-    const onUp = () => {
+    const stop = () => {
       window.removeEventListener("pointermove", onMove);
-      window.removeEventListener("pointerup", onUp);
+      window.removeEventListener("pointerup", stop);
+      window.removeEventListener("pointercancel", stop);
+      stopDragRef.current = null;
     };
+    stopDragRef.current = stop;
     window.addEventListener("pointermove", onMove);
-    window.addEventListener("pointerup", onUp);
+    window.addEventListener("pointerup", stop);
+    window.addEventListener("pointercancel", stop);
   };
+
+  // 未定宽列也要向辅助技术报现值:挂载(及宽度回落 undefined 时)量一次父元素
+  // 实际宽度作 aria-valuenow;量不出正宽度(无布局引擎的环境)保持省略。
+  const handleRef = useRef<HTMLDivElement>(null);
+  const [measuredWidth, setMeasuredWidth] = useState<number>();
+  useEffect(() => {
+    if (width !== undefined) return;
+    const px = Math.round(handleRef.current?.parentElement?.getBoundingClientRect().width ?? 0);
+    if (px > 0) setMeasuredWidth(px);
+  }, [width]);
 
   const onKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
     if (event.key !== "ArrowLeft" && event.key !== "ArrowRight") return;
@@ -61,10 +81,11 @@ export function ColumnResizeHandle({
 
   return (
     <div
+      ref={handleRef}
       role="separator"
       aria-orientation="vertical"
       aria-label={label}
-      aria-valuenow={width}
+      aria-valuenow={width ?? measuredWidth}
       aria-valuemin={min}
       aria-valuemax={max}
       tabIndex={0}

--- a/packages/gui/src/renderer/i18n/locales/en-US/views.json
+++ b/packages/gui/src/renderer/i18n/locales/en-US/views.json
@@ -74,6 +74,7 @@
   "views.listView.cancelFavorites": "Cancel favorites",
   "views.listView.closeout": "closeout",
   "views.listView.collection": "Favorites",
+  "views.listView.columnResize": "Resize the \"{column}\" column",
   "views.listView.currentResults": "Current results",
   "views.listView.engine": "engine",
   "views.listView.externalReadOnly": "External read only",

--- a/packages/gui/src/renderer/i18n/locales/zh-CN/views.json
+++ b/packages/gui/src/renderer/i18n/locales/zh-CN/views.json
@@ -74,6 +74,7 @@
   "views.listView.cancelFavorites": "取消收藏",
   "views.listView.closeout": "收口",
   "views.listView.collection": "收藏",
+  "views.listView.columnResize": "调整「{column}」列宽",
   "views.listView.currentResults": "当前结果",
   "views.listView.engine": "引擎",
   "views.listView.externalReadOnly": "外部只读",

--- a/packages/gui/src/renderer/views/BoardView.tsx
+++ b/packages/gui/src/renderer/views/BoardView.tsx
@@ -1,4 +1,4 @@
-import { memo, useEffect, useMemo, useState } from "react";
+import { memo, useCallback, useEffect, useMemo, useState } from "react";
 import {
   DndContext,
   PointerSensor,
@@ -21,6 +21,14 @@ import {
   FreshnessTag,
   freshnessBorder,
 } from "../components/badges";
+import { ColumnResizeHandle } from "../components/ColumnResizeHandle.tsx";
+import {
+  boardColumnPreferenceStorage,
+  clearBoardColumnWidth,
+  readBoardColumnWidths,
+  setBoardColumnWidth,
+  writeBoardColumnWidths,
+} from "../board-column-preferences.ts";
 import { SwimlaneBoard, type LaneGroupBy } from "./SwimlaneBoard";
 import { TaskFilterBar } from "../components/TaskFilterBar";
 import type { TaskFilters } from "../model/taskFilters";
@@ -255,6 +263,9 @@ function DndCard({
   );
 }
 
+/** 列宽交互区间(W11):未定宽列走 basis-1/4 等分默认,一旦拖/微调就固定 px。 */
+const COLUMN_WIDTH_RANGE = { min: 220, max: 720 } as const;
+
 function Column({
   status,
   tasks,
@@ -264,6 +275,9 @@ function Column({
   favorites,
   onToggleFavorite,
   onSetPin,
+  width,
+  onResize,
+  onReset,
 }: {
   status: SnapshotStatus;
   tasks: readonly TaskRow[];
@@ -273,6 +287,10 @@ function Column({
   favorites: ReadonlySet<string>;
   onToggleFavorite: (id: string) => void;
   onSetPin?: (task: TaskRow, pinned: boolean) => void;
+  /** 持久化列宽;undefined = 默认等分布局。 */
+  width: number | undefined;
+  onResize: (status: SnapshotStatus, px: number) => void;
+  onReset: (status: SnapshotStatus) => void;
 }) {
   const { setNodeRef, isOver } = useDroppable({ id: status });
   const meta = STATUS_META[status];
@@ -280,10 +298,14 @@ function Column({
   // 每张卡外层的拖拽容器带 content-visibility:auto,离屏卡的布局与绘制由渲染器跳过。
   // 列内默认序(W8):lastKnownAt 倒序打底,pin → 收藏稳定置顶。
   const ordered = sortByRecentThenPinAndFavoritesFirst(tasks, favorites);
+  // 未定宽列保持 basis-1/4 等分默认;定宽后固定 px(两态都 shrink-0,越界走横向滚动)。
+  const sizing = width === undefined ? "basis-1/4" : "";
   return (
     <div
       ref={setNodeRef}
-      className={`flex basis-1/4 shrink-0 flex-col rounded-xl p-2 transition-colors ${
+      data-testid={`board-column-${status}`}
+      style={width === undefined ? undefined : { width }}
+      className={`relative flex shrink-0 ${sizing} flex-col rounded-xl p-2 transition-colors ${
         isOver && rejecting
           ? "bg-danger/5 outline outline-1 outline-dashed outline-danger/40"
           : isOver
@@ -291,6 +313,16 @@ function Column({
             : "bg-surface"
       }`}
     >
+      <ColumnResizeHandle
+        label={`调整「${meta.label}」列宽`}
+        width={width}
+        min={COLUMN_WIDTH_RANGE.min}
+        max={COLUMN_WIDTH_RANGE.max}
+        onChange={(px) => onResize(status, px)}
+        onReset={() => onReset(status)}
+        testId={`board-column-resize-${status}`}
+        className="inset-y-0 -right-1.5"
+      />
       <div className="flex items-center gap-2 px-1.5 pb-2 pt-1">
         <span style={{ color: meta.color }} className="text-base">
           {meta.icon}
@@ -378,6 +410,26 @@ export const BoardView = memo(function BoardView({
   const [activeTask, setActiveTask] = useState<TaskRow | null>(null);
   const [dragMessage, setDragMessage] = useState<string | null>(null);
   const [lastMutationTaskId, setLastMutationTaskId] = useState<string | null>(null);
+
+  // 列宽偏好(W11):GUI 本地态,读写同 graph-density 模式;只在挂载时读一次,
+  // 之后写穿透(每次调整都落 localStorage,重启/重载后保留)。
+  const [columnWidths, setColumnWidths] = useState(() => readBoardColumnWidths(boardColumnPreferenceStorage()));
+  const resizeColumn = useCallback(
+    (status: SnapshotStatus, px: number) => {
+      const next = setBoardColumnWidth(columnWidths, "column", status, px);
+      setColumnWidths(next);
+      writeBoardColumnWidths(boardColumnPreferenceStorage(), next);
+    },
+    [columnWidths],
+  );
+  const resetColumn = useCallback(
+    (status: SnapshotStatus) => {
+      const next = clearBoardColumnWidth(columnWidths, "column", status);
+      setColumnWidths(next);
+      writeBoardColumnWidths(boardColumnPreferenceStorage(), next);
+    },
+    [columnWidths],
+  );
 
   // 看板默认降噪(W8):冷终态(终态且非重点种子,判定复用 isTaskGraphFocusSeed 的
   // 14 天窗口)默认折叠为可见计数,TaskFilterBar 提供展开开关;pinned 恒可见。
@@ -539,6 +591,9 @@ export const BoardView = memo(function BoardView({
                 favorites={favorites}
                 onToggleFavorite={onToggleFavorite}
                 onSetPin={onSetPin}
+                width={columnWidths.column[status]}
+                onResize={resizeColumn}
+                onReset={resetColumn}
               />
             ))}
           </div>

--- a/packages/gui/src/renderer/views/ListView.tsx
+++ b/packages/gui/src/renderer/views/ListView.tsx
@@ -1,9 +1,18 @@
-import { memo, useEffect, useMemo, useState } from "react";
+import { memo, useCallback, useEffect, useMemo, useState, type ReactNode } from "react";
 import { CaretLeft, CaretRight, Lock, PushPin, Star } from "@phosphor-icons/react";
 import type { TaskRow } from "../model/types";
 import { isExternal } from "../model/types";
 import { CloseoutBadge, DecisionSourceBadge, EngineBadge, FreshnessTag, StatusBadge } from "../components/badges";
 import { TaskFilterBar } from "../components/TaskFilterBar";
+import { ColumnResizeHandle } from "../components/ColumnResizeHandle.tsx";
+import {
+  boardColumnPreferenceStorage,
+  clearBoardColumnWidth,
+  readBoardColumnWidths,
+  setBoardColumnWidth,
+  writeBoardColumnWidths,
+  type BoardColumnWidths,
+} from "../board-column-preferences.ts";
 import type { TaskFilters } from "../model/taskFilters";
 import { sortByRecentThenPinAndFavoritesFirst } from "../model/taskFilters";
 import type { SpawningDecisionIndex } from "../model/triadic";
@@ -13,6 +22,51 @@ import { formatTime } from "../model/time.ts";
 const PAGE_SIZE_OPTIONS = [8, 15, 30, 60] as const;
 type PageSize = (typeof PAGE_SIZE_OPTIONS)[number];
 const DEFAULT_PAGE_SIZE: PageSize = 15;
+
+/** 列宽交互区间(W11):table-fixed 下 th 的显式宽度即列宽,未设置的列自动分配剩余。 */
+const LIST_WIDTH_RANGE = { min: 56, max: 720 } as const;
+
+function ListHeaderCell({
+  columnKey,
+  label,
+  children,
+  width,
+  onResize,
+  onReset,
+  title,
+  className = "px-3 py-2",
+}: {
+  columnKey: string;
+  /** 列的口语名(供 resize 手柄的无障碍标签),如「标题 / 模块」。 */
+  label: string;
+  children: ReactNode;
+  width: number | undefined;
+  onResize: (key: string, px: number) => void;
+  onReset: (key: string) => void;
+  title?: string;
+  className?: string;
+}) {
+  return (
+    <th
+      className={`relative font-medium ${className}`}
+      style={width === undefined ? undefined : { width }}
+      data-testid={`list-column-${columnKey}`}
+      title={title}
+    >
+      {children}
+      <ColumnResizeHandle
+        label={t("views.listView.columnResize", { column: label })}
+        width={width}
+        min={LIST_WIDTH_RANGE.min}
+        max={LIST_WIDTH_RANGE.max}
+        onChange={(px) => onResize(columnKey, px)}
+        onReset={() => onReset(columnKey)}
+        testId={`list-column-resize-${columnKey}`}
+        className="inset-y-0 -right-1"
+      />
+    </th>
+  );
+}
 
 const dateLabel = (iso: string) => formatTime(iso, { style: "month-day-time" }) ?? "—";
 
@@ -177,6 +231,25 @@ export function ListView({
 }) {
   const [page, setPage] = useState(0);
   const [pageSize, setPageSize] = useState<PageSize>(DEFAULT_PAGE_SIZE);
+  // 列宽偏好(W11):GUI 本地态,与看板另两布局共用一个存储键;未设置的列保持
+  // table-fixed 自动分配,设置后 th 的显式宽度即列宽(总宽超出容器走横向滚动)。
+  const [widths, setWidths] = useState<BoardColumnWidths>(() => readBoardColumnWidths(boardColumnPreferenceStorage()));
+  const resizeColumn = useCallback(
+    (key: string, px: number) => {
+      const next = setBoardColumnWidth(widths, "list", key, px);
+      setWidths(next);
+      writeBoardColumnWidths(boardColumnPreferenceStorage(), next);
+    },
+    [widths],
+  );
+  const resetColumn = useCallback(
+    (key: string) => {
+      const next = clearBoardColumnWidth(widths, "list", key);
+      setWidths(next);
+      writeBoardColumnWidths(boardColumnPreferenceStorage(), next);
+    },
+    [widths],
+  );
 
   useEffect(() => {
     setPage(0);
@@ -253,16 +326,80 @@ export function ListView({
           <table className="w-full table-fixed border-collapse text-left">
             <thead className="sticky top-0 z-10 bg-surface">
               <tr className="border-b border-border font-mono ui-meta uppercase tracking-wide text-text-faint">
-                <th className="w-14 px-2 py-2 font-medium" title={t("views.listView.collection")}>
+                <ListHeaderCell
+                  columnKey="pins"
+                  label={t("views.listView.collection")}
+                  width={widths.list.pins}
+                  onResize={resizeColumn}
+                  onReset={resetColumn}
+                  title={t("views.listView.collection")}
+                  className="w-14 px-2 py-2"
+                >
                   📌 ★
-                </th>
-                <th className="px-3 py-2 font-medium">{t("views.listView.task")}</th>
-                <th className="px-3 py-2 font-medium">{t("views.listView.titleModule")}</th>
-                <th className="px-3 py-2 font-medium">{t("views.listView.statusNodeHolder")}</th>
-                <th className="px-3 py-2 font-medium">{t("views.listView.closeout")}</th>
-                <th className="px-3 py-2 font-medium">{t("views.listView.engine")}</th>
-                <th className="px-3 py-2 font-medium">{t("views.listView.freshness")}</th>
-                <th className="px-3 py-2 font-medium">{t("views.listView.package")}</th>
+                </ListHeaderCell>
+                <ListHeaderCell
+                  columnKey="task"
+                  label={t("views.listView.task")}
+                  width={widths.list.task}
+                  onResize={resizeColumn}
+                  onReset={resetColumn}
+                >
+                  {t("views.listView.task")}
+                </ListHeaderCell>
+                <ListHeaderCell
+                  columnKey="title"
+                  label={t("views.listView.titleModule")}
+                  width={widths.list.title}
+                  onResize={resizeColumn}
+                  onReset={resetColumn}
+                >
+                  {t("views.listView.titleModule")}
+                </ListHeaderCell>
+                <ListHeaderCell
+                  columnKey="status"
+                  label={t("views.listView.statusNodeHolder")}
+                  width={widths.list.status}
+                  onResize={resizeColumn}
+                  onReset={resetColumn}
+                >
+                  {t("views.listView.statusNodeHolder")}
+                </ListHeaderCell>
+                <ListHeaderCell
+                  columnKey="closeout"
+                  label={t("views.listView.closeout")}
+                  width={widths.list.closeout}
+                  onResize={resizeColumn}
+                  onReset={resetColumn}
+                >
+                  {t("views.listView.closeout")}
+                </ListHeaderCell>
+                <ListHeaderCell
+                  columnKey="engine"
+                  label={t("views.listView.engine")}
+                  width={widths.list.engine}
+                  onResize={resizeColumn}
+                  onReset={resetColumn}
+                >
+                  {t("views.listView.engine")}
+                </ListHeaderCell>
+                <ListHeaderCell
+                  columnKey="freshness"
+                  label={t("views.listView.freshness")}
+                  width={widths.list.freshness}
+                  onResize={resizeColumn}
+                  onReset={resetColumn}
+                >
+                  {t("views.listView.freshness")}
+                </ListHeaderCell>
+                <ListHeaderCell
+                  columnKey="package"
+                  label={t("views.listView.package")}
+                  width={widths.list.package}
+                  onResize={resizeColumn}
+                  onReset={resetColumn}
+                >
+                  {t("views.listView.package")}
+                </ListHeaderCell>
               </tr>
             </thead>
             <tbody>

--- a/packages/gui/src/renderer/views/ListView.tsx
+++ b/packages/gui/src/renderer/views/ListView.tsx
@@ -131,8 +131,11 @@ const AuditRow = memo(function AuditRow({
         </button>
       </td>
       <td className="px-3 py-2 align-top">
-        <div className="font-mono ui-body text-text">{task.taskId}</div>
-        <div className="mt-1 font-mono ui-meta text-text-faint">{dateLabel(task.lastKnownAt)}</div>
+        {/* table-fixed(W11)下窄列裁不裁由单元格自己负责:截断 + title 悬停保整串可读可抄。 */}
+        <div title={task.taskId} className="truncate font-mono ui-body text-text">
+          {task.taskId}
+        </div>
+        <div className="mt-1 truncate font-mono ui-meta text-text-faint">{dateLabel(task.lastKnownAt)}</div>
       </td>
       <td className="min-w-[260px] px-3 py-2 align-top">
         <div className="flex items-start gap-1.5">
@@ -151,7 +154,9 @@ const AuditRow = memo(function AuditRow({
           <div className="line-clamp-2 ui-prose font-medium leading-snug text-text">{task.title}</div>
         </div>
         <div className="mt-1 flex flex-wrap items-center gap-2 font-mono ui-meta text-text-faint">
-          <span>{task.module === "unassigned" || !task.module ? t("views.listView.notProjected") : task.module}</span>
+          <span className="min-w-0 truncate">
+            {task.module === "unassigned" || !task.module ? t("views.listView.notProjected") : task.module}
+          </span>
           {task.blocking === "unknown" && <span className="text-stale">{t("views.listView.blockingUnknown")}</span>}
           {spawningDecision && <DecisionSourceBadge decisionId={spawningDecision} compact />}
           {isExternal(task) && (
@@ -166,9 +171,9 @@ const AuditRow = memo(function AuditRow({
         <div className="flex flex-col items-start gap-1">
           <StatusBadge status={task.canonicalStatus ?? task.coordinationStatus} />
           {task.canonicalStatus && task.canonicalStatus !== task.coordinationStatus && (
-            <span className="font-mono ui-micro text-text-faint">coordination={task.coordinationStatus}</span>
+            <span className="truncate font-mono ui-micro text-text-faint">coordination={task.coordinationStatus}</span>
           )}
-          <span className="font-mono ui-micro text-text-faint">
+          <span className="truncate font-mono ui-micro text-text-faint">
             {t("views.listView.nodeLabel")}
             {task.currentNode ?? "—"}
           </span>
@@ -196,7 +201,12 @@ const AuditRow = memo(function AuditRow({
         <FreshnessTag freshness={task.freshness} lastKnownAt={task.lastKnownAt} />
       </td>
       <td className="px-3 py-2 align-top">
-        <span className="rounded border border-border px-1.5 py-px font-mono ui-meta text-text-muted">
+        <span
+          className={[
+            "inline-block max-w-full truncate rounded border border-border",
+            "px-1.5 py-px font-mono ui-meta text-text-muted",
+          ].join(" ")}
+        >
           {task.packageDisposition}
         </span>
       </td>

--- a/packages/gui/src/renderer/views/ListView.tsx
+++ b/packages/gui/src/renderer/views/ListView.tsx
@@ -144,7 +144,7 @@ const AuditRow = memo(function AuditRow({
               title={t("views.listView.pinnedToday")}
               data-testid={`task-pinned-marker-${task.taskId}`}
               className={[
-                "mt-0.5 inline-flex shrink-0 items-center gap-0.5 rounded",
+                "mt-0.5 inline-flex max-w-full shrink-0 items-center gap-0.5 truncate rounded",
                 "border border-accent/40 px-1 font-mono ui-micro text-accent",
               ].join(" ")}
             >
@@ -157,10 +157,18 @@ const AuditRow = memo(function AuditRow({
           <span className="min-w-0 truncate">
             {task.module === "unassigned" || !task.module ? t("views.listView.notProjected") : task.module}
           </span>
-          {task.blocking === "unknown" && <span className="text-stale">{t("views.listView.blockingUnknown")}</span>}
-          {spawningDecision && <DecisionSourceBadge decisionId={spawningDecision} compact />}
+          {task.blocking === "unknown" && (
+            <span className="min-w-0 truncate text-stale">{t("views.listView.blockingUnknown")}</span>
+          )}
+          {/* 长 decision 徽章自身 max-w-full 只封盒不裁内容(flex 项 min-content=整串),会画进相邻列;
+              外包一层可收缩截断项收敛,整串 ID 仍由徽章自己的 title 悬停与 DOM 文本保住。 */}
+          {spawningDecision && (
+            <span className="min-w-0 truncate">
+              <DecisionSourceBadge decisionId={spawningDecision} compact />
+            </span>
+          )}
           {isExternal(task) && (
-            <span className="inline-flex items-center gap-1">
+            <span className="inline-flex min-w-0 items-center gap-1 truncate">
               <Lock weight="bold" />
               外部只读
             </span>
@@ -168,19 +176,23 @@ const AuditRow = memo(function AuditRow({
         </div>
       </td>
       <td className="px-3 py-2 align-top" data-testid={`task-inline-state-${task.taskId}`}>
+        {/* flex 列 cross 轴上的 truncate 没有盒宽可裁(2026-09-09 二次 Electron 验收:
+            节点/lease 行画进相邻列),必须配 max-w-full 让列宽成为截断上限。 */}
         <div className="flex flex-col items-start gap-1">
           <StatusBadge status={task.canonicalStatus ?? task.coordinationStatus} />
           {task.canonicalStatus && task.canonicalStatus !== task.coordinationStatus && (
-            <span className="truncate font-mono ui-micro text-text-faint">coordination={task.coordinationStatus}</span>
+            <span className="max-w-full truncate font-mono ui-micro text-text-faint">
+              coordination={task.coordinationStatus}
+            </span>
           )}
-          <span className="truncate font-mono ui-micro text-text-faint">
+          <span className="max-w-full truncate font-mono ui-micro text-text-faint">
             {t("views.listView.nodeLabel")}
             {task.currentNode ?? "—"}
           </span>
           {task.activeExecutionId ? (
             <span
               title={t("views.listView.leaseTitle")}
-              className="max-w-[16rem] truncate font-mono ui-micro text-text-muted"
+              className="max-w-full truncate font-mono ui-micro text-text-muted"
             >
               {task.activeExecutionId}
               {task.leaseHolder ? ` · ${task.leaseHolder}` : ""}
@@ -195,7 +207,11 @@ const AuditRow = memo(function AuditRow({
         <CloseoutBadge value={task.closeoutReadiness} />
       </td>
       <td className="px-3 py-2 align-top">
-        <EngineBadge engine={task.engine} locked={isExternal(task)} />
+        {/* engine 是 inline-flex 整串不可断行(验收实测 kernel/task-lifecycle/v1 距列界 1px),
+            外包收缩截断项防更窄列越界。 */}
+        <span className="inline-block max-w-full truncate">
+          <EngineBadge engine={task.engine} locked={isExternal(task)} />
+        </span>
       </td>
       <td className="px-3 py-2 align-top">
         <FreshnessTag freshness={task.freshness} lastKnownAt={task.lastKnownAt} />

--- a/packages/gui/src/renderer/views/SwimlaneBoard.tsx
+++ b/packages/gui/src/renderer/views/SwimlaneBoard.tsx
@@ -1,14 +1,28 @@
-import { memo, useEffect, useMemo, useState } from "react";
+import { memo, useCallback, useEffect, useMemo, useState } from "react";
 import { CaretRight, Lock, PushPin, Star } from "@phosphor-icons/react";
 import type { TaskRow, SnapshotStatus } from "../model/types";
 import { BOARD_COLUMNS, isExternal } from "../model/types";
 import { STATUS_META, CloseoutBadge, DecisionSourceBadge, FreshnessTag, freshnessBorder } from "../components/badges";
+import { ColumnResizeHandle } from "../components/ColumnResizeHandle.tsx";
+import {
+  boardColumnPreferenceStorage,
+  clearBoardColumnWidth,
+  readBoardColumnWidths,
+  setBoardColumnWidth,
+  writeBoardColumnWidths,
+  type BoardColumnWidths,
+} from "../board-column-preferences.ts";
 import type { SpawningDecisionIndex } from "../model/triadic";
 import { sortByRecentThenPinAndFavoritesFirst } from "../model/taskFilters";
 
 export type LaneGroupBy = "module" | "engine" | "root" | "productLine";
 
-const GRID_COLS = "grid-cols-[180px_repeat(7,230px)]";
+/** 泳道列宽默认值 = 原 GRID_COLS(180px 泳道标签 + 7×230px 状态列);可调区间各自独立。 */
+const LANE_COLUMN_KEY = "lane";
+const LANE_WIDTH_DEFAULT = 180;
+const LANE_WIDTH_RANGE = { min: 120, max: 480 } as const;
+const STATUS_WIDTH_DEFAULT = 230;
+const STATUS_WIDTH_RANGE = { min: 160, max: 640 } as const;
 
 const cellKey = (lane: string, status: SnapshotStatus) => `${lane}::${status}`;
 
@@ -326,6 +340,32 @@ export function SwimlaneBoard({
   const model = useMemo(() => buildSwimlaneModel(tasks, groupBy), [groupBy, tasks]);
   const lanes = model.lanes;
 
+  // 泳道列宽偏好(W11):泳道标签列 + 7 个状态列各一个数字,默认 180/230 等宽;
+  // 表头是唯一手柄面(sticky,滚动时仍可达),行模板跟着表头走。
+  const [widths, setWidths] = useState<BoardColumnWidths>(() => readBoardColumnWidths(boardColumnPreferenceStorage()));
+  const resizeColumn = useCallback(
+    (key: string, px: number) => {
+      const next = setBoardColumnWidth(widths, "swimlane", key, px);
+      setWidths(next);
+      writeBoardColumnWidths(boardColumnPreferenceStorage(), next);
+    },
+    [widths],
+  );
+  const resetColumn = useCallback(
+    (key: string) => {
+      const next = clearBoardColumnWidth(widths, "swimlane", key);
+      setWidths(next);
+      writeBoardColumnWidths(boardColumnPreferenceStorage(), next);
+    },
+    [widths],
+  );
+  const laneWidth = widths.swimlane[LANE_COLUMN_KEY] ?? LANE_WIDTH_DEFAULT;
+  const gridStyle = {
+    gridTemplateColumns: [laneWidth, ...BOARD_COLUMNS.map((status) => widths.swimlane[status] ?? STATUS_WIDTH_DEFAULT)]
+      .map((px) => `${Math.round(px)}px`)
+      .join(" "),
+  };
+
   useEffect(() => {
     if (activeCell && !lanes.includes(activeCell.lane)) setActiveCell(null);
   }, [activeCell, lanes]);
@@ -341,14 +381,34 @@ export function SwimlaneBoard({
     <div className="flex min-h-0 flex-1 flex-col">
       <div className="max-h-[48vh] overflow-auto border-b border-border">
         <div className="min-w-max px-4 pb-4">
-          <div className={`sticky top-0 z-10 grid ${GRID_COLS} gap-2 border-b border-border bg-bg py-2`}>
-            <div className="self-center px-1.5 font-mono ui-meta uppercase tracking-wide text-text-faint">
+          <div className="sticky top-0 z-10 grid gap-2 border-b border-border bg-bg py-2" style={gridStyle}>
+            <div className="relative self-center px-1.5 font-mono ui-meta uppercase tracking-wide text-text-faint">
               {groupBy}
+              <ColumnResizeHandle
+                label="调整泳道标签列宽"
+                width={laneWidth}
+                min={LANE_WIDTH_RANGE.min}
+                max={LANE_WIDTH_RANGE.max}
+                onChange={(px) => resizeColumn(LANE_COLUMN_KEY, px)}
+                onReset={() => resetColumn(LANE_COLUMN_KEY)}
+                testId="swimlane-lane-resize"
+                className="inset-y-0 -right-1"
+              />
             </div>
             {BOARD_COLUMNS.map((status) => {
               const meta = STATUS_META[status];
               return (
-                <div key={status} className="flex items-center gap-1.5 px-1.5">
+                <div key={status} className="relative flex items-center gap-1.5 px-1.5">
+                  <ColumnResizeHandle
+                    label={`调整「${meta.label}」列宽`}
+                    width={widths.swimlane[status] ?? STATUS_WIDTH_DEFAULT}
+                    min={STATUS_WIDTH_RANGE.min}
+                    max={STATUS_WIDTH_RANGE.max}
+                    onChange={(px) => resizeColumn(status, px)}
+                    onReset={() => resetColumn(status)}
+                    testId={`swimlane-column-resize-${status}`}
+                    className="inset-y-0 -right-1"
+                  />
                   <span style={{ color: meta.color }} className="text-base">
                     {meta.icon}
                   </span>
@@ -364,7 +424,8 @@ export function SwimlaneBoard({
             <div
               key={lane}
               data-testid="swimlane-row"
-              className={`grid ${GRID_COLS} gap-2 border-b border-border py-2.5 cv-auto-4-5r`}
+              className="grid gap-2 border-b border-border py-2.5 cv-auto-4-5r"
+              style={gridStyle}
             >
               <div className="flex items-baseline gap-2 self-start px-1.5 pt-1.5">
                 <span

--- a/packages/gui/test/list-view.vitest.ts
+++ b/packages/gui/test/list-view.vitest.ts
@@ -211,10 +211,18 @@ describe("list view column resize (W11)", () => {
   it("renders one keyboard-reachable handle per header column with no explicit widths by default", () => {
     const markup = listMarkup();
     expect(markup.split('data-testid="list-column-resize-').length - 1).toBe(8);
+    const headerCell = markup.match(/<th[^>]*data-testid="list-column-title"[^>]*>/u)![0];
     const handle = markup.match(/<div[^>]*data-testid="list-column-resize-title"[^>]*>/u)![0];
     expect(handle).toContain('role="separator"');
     expect(handle).toContain('tabindex="0"');
     expect(handle).toContain("Resize the &quot;title / module&quot; column");
+    // 回归:真实 Electron 验收发现共享基类缺 position:absolute,静态流里手柄高度
+    // 恒 0、鼠标无命中区、拖拽无效(2026-09-09);定位链 = relative th + 基类内置
+    // absolute + 消费方 inset 偏移。命中区像素高度由 Electron 走查复核,类名断言
+    // 不证明像素行为。
+    expect(headerCell).toContain("relative");
+    expect(handle).toContain("absolute");
+    expect(handle).toContain("inset-y-0");
     // 未定宽列走 table-fixed 自动分配:th 不输出显式宽度。
     expect(markup).not.toContain('style="width');
   });

--- a/packages/gui/test/list-view.vitest.ts
+++ b/packages/gui/test/list-view.vitest.ts
@@ -229,6 +229,44 @@ describe("list view column resize (W11)", () => {
     expect(handle).toContain('aria-valuenow="420"');
   });
 
+  // 回归:真实 Electron 验收发现 table-fixed 窄列里未收敛的 font-mono 长 taskId
+  // 直接画进 Title 列(2026-09-09)。此处只断言收敛原语(截断类 + title 悬停)在
+  // 标记里就位;像素级不越列由 Electron 走查复核,类名断言不证明像素行为。
+  it("contains unbreakable cell values inside their fixed columns and keeps the full id on hover", () => {
+    const task = makeTask({
+      taskId: "task_eeb3b5f08c093e63622b24392c",
+      title: "Overflow regression",
+      module: "packages/daemon",
+      canonicalStatus: "done",
+      coordinationStatus: "in_review",
+      currentNode: "review",
+    });
+    const markup = renderToStaticMarkup(
+      createElement(ListView, {
+        tasks: [task],
+        allTasks: [task],
+        filters: DEFAULT_TASK_FILTERS,
+        onFiltersChange: () => undefined,
+        onSelect: () => undefined,
+        spawningDecisions: new Map(),
+        favorites: new Set<string>(),
+        onToggleFavorite: () => undefined,
+        embedded: true,
+      }),
+    );
+    const idLine = markup.match(/<div[^>]*>task_eeb3b5f08c093e63622b24392c<\/div>/u)![0];
+    expect(idLine).toContain("truncate");
+    expect(idLine).toContain('title="task_eeb3b5f08c093e63622b24392c"'); // 悬停可见整串。
+    const dateLine = markup.match(/<div[^>]*class="mt-1 truncate[^"]*"[^>]*>[^<]+<\/div>/u)![0];
+    expect(dateLine).toBeTruthy();
+    // 同一 fixed 布局下其余不可断行值同样收敛在本列:coordination 键值串、节点行、
+    // 模块名、包处置枚举 chip。
+    expect(markup.match(/<span[^>]*>coordination=in_review<\/span>/u)![0]).toContain("truncate");
+    expect(markup.match(/<span[^>]*>graph cursor:review<\/span>/u)![0]).toContain("truncate");
+    expect(markup.match(/<span[^>]*>packages\/daemon<\/span>/u)![0]).toContain("truncate");
+    expect(markup.match(/<span[^>]*>active<\/span>/u)![0]).toContain("max-w-full");
+  });
+
   it("drags, fine-tunes with arrow keys, resets by double-click, and persists across remount", async () => {
     localStorage.setItem(WIDTH_KEY, JSON.stringify({ list: { title: 420 } }));
     const view = await mountList();

--- a/packages/gui/test/list-view.vitest.ts
+++ b/packages/gui/test/list-view.vitest.ts
@@ -1,6 +1,8 @@
 // harness-test-tier: contract
-import { beforeAll, describe, expect, it } from "vitest";
-import { createElement } from "react";
+// @vitest-environment happy-dom
+import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { act, createElement } from "react";
+import { createRoot } from "react-dom/client";
 import { renderToStaticMarkup } from "react-dom/server";
 import type { TaskRow } from "../src/renderer/model/types.ts";
 import { ListView } from "../src/renderer/views/ListView.tsx";
@@ -148,5 +150,125 @@ describe("list view", () => {
     expect(markup).not.toContain('type="checkbox"');
     for (const gone of ["Batch operations", "Batch run Check", "Batch mark Ready", "Batch archiving", "Deselect"])
       expect(markup).not.toContain(gone);
+  });
+});
+
+/**
+ * 列表列宽 resize(W11):table-fixed 下 th 的显式宽度即列宽,未设置的列自动分配
+ * 剩余宽度;手柄键盘可达,双击恢复默认,与看板另两布局共用同一 localStorage 键。
+ */
+const WIDTH_KEY = "harness:gui:board-column-widths";
+
+const listMarkup = (widthsJson?: string): string => {
+  if (widthsJson === undefined) localStorage.removeItem(WIDTH_KEY);
+  else localStorage.setItem(WIDTH_KEY, widthsJson);
+  const tasks = [makeTask()];
+  return renderToStaticMarkup(
+    createElement(ListView, {
+      tasks,
+      allTasks: tasks,
+      filters: DEFAULT_TASK_FILTERS,
+      onFiltersChange: () => undefined,
+      onSelect: () => undefined,
+      spawningDecisions: new Map(),
+      favorites: new Set(),
+      onToggleFavorite: () => undefined,
+      embedded: true,
+    }),
+  );
+};
+
+async function mountList() {
+  const container = document.createElement("div");
+  document.body.append(container);
+  const root = createRoot(container);
+  const tasks = [makeTask()];
+  await act(async () => {
+    root.render(
+      createElement(ListView, {
+        tasks,
+        allTasks: tasks,
+        filters: DEFAULT_TASK_FILTERS,
+        onFiltersChange: () => undefined,
+        onSelect: () => undefined,
+        spawningDecisions: new Map(),
+        favorites: new Set(),
+        onToggleFavorite: () => undefined,
+        embedded: true,
+      }),
+    );
+  });
+  return { container, root };
+}
+
+const storedListWidths = (): Record<string, number> => JSON.parse(localStorage.getItem(WIDTH_KEY) ?? "{}").list ?? {};
+
+describe("list view column resize (W11)", () => {
+  beforeEach(() => {
+    localStorage.removeItem(WIDTH_KEY);
+  });
+
+  it("renders one keyboard-reachable handle per header column with no explicit widths by default", () => {
+    const markup = listMarkup();
+    expect(markup.split('data-testid="list-column-resize-').length - 1).toBe(8);
+    const handle = markup.match(/<div[^>]*data-testid="list-column-resize-title"[^>]*>/u)![0];
+    expect(handle).toContain('role="separator"');
+    expect(handle).toContain('tabindex="0"');
+    expect(handle).toContain("Resize the &quot;title / module&quot; column");
+    // 未定宽列走 table-fixed 自动分配:th 不输出显式宽度。
+    expect(markup).not.toContain('style="width');
+  });
+
+  it("applies a persisted width to its header cell", () => {
+    const markup = listMarkup(JSON.stringify({ list: { title: 420, pins: 64 } }));
+    const title = markup.match(/<th[^>]*data-testid="list-column-title"[^>]*>/u)![0];
+    expect(title).toContain('style="width:420px"');
+    const pins = markup.match(/<th[^>]*data-testid="list-column-pins"[^>]*>/u)![0];
+    expect(pins).toContain('style="width:64px"');
+    const handle = markup.match(/<div[^>]*data-testid="list-column-resize-title"[^>]*>/u)![0];
+    expect(handle).toContain('aria-valuenow="420"');
+  });
+
+  it("drags, fine-tunes with arrow keys, resets by double-click, and persists across remount", async () => {
+    localStorage.setItem(WIDTH_KEY, JSON.stringify({ list: { title: 420 } }));
+    const view = await mountList();
+    const handle = view.container.querySelector<HTMLElement>('[data-testid="list-column-resize-title"]')!;
+    const cell = view.container.querySelector<HTMLElement>('[data-testid="list-column-title"]')!;
+
+    act(() => {
+      handle.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true, clientX: 100, pointerId: 1 }));
+      window.dispatchEvent(new PointerEvent("pointermove", { clientX: 40, pointerId: 1 }));
+      window.dispatchEvent(new PointerEvent("pointerup", { clientX: 40, pointerId: 1 }));
+    });
+    expect(cell.style.width).toBe("360px"); // 420 - 60。
+    expect(storedListWidths().title).toBe(360);
+
+    act(() => {
+      handle.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true }));
+    });
+    expect(cell.style.width).toBe("376px"); // +16 微调。
+    expect(storedListWidths().title).toBe(376);
+
+    act(() => {
+      view.root.unmount();
+    });
+    view.container.remove();
+
+    // 重挂载(窗口重载等价):宽度从 localStorage 恢复。
+    const reloaded = await mountList();
+    const reloadedCell = reloaded.container.querySelector<HTMLElement>('[data-testid="list-column-title"]')!;
+    expect(reloadedCell.style.width).toBe("376px");
+
+    const reloadedHandle = reloaded.container.querySelector<HTMLElement>('[data-testid="list-column-resize-title"]')!;
+    act(() => {
+      reloadedHandle.dispatchEvent(new MouseEvent("dblclick", { bubbles: true }));
+    });
+    expect(reloadedCell.style.width).toBe("");
+    expect(storedListWidths().title).toBeUndefined();
+
+    act(() => {
+      reloaded.root.unmount();
+    });
+    reloaded.container.remove();
   });
 });

--- a/packages/gui/test/list-view.vitest.ts
+++ b/packages/gui/test/list-view.vitest.ts
@@ -1,6 +1,6 @@
 // harness-test-tier: contract
 // @vitest-environment happy-dom
-import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { act, createElement } from "react";
 import { createRoot } from "react-dom/client";
 import { renderToStaticMarkup } from "react-dom/server";
@@ -270,5 +270,91 @@ describe("list view column resize (W11)", () => {
       reloaded.root.unmount();
     });
     reloaded.container.remove();
+  });
+
+  it("stops tracking on pointercancel: later moves neither resize nor persist, and a fresh drag recovers", async () => {
+    localStorage.setItem(WIDTH_KEY, JSON.stringify({ list: { title: 420 } }));
+    const view = await mountList();
+    const handle = view.container.querySelector<HTMLElement>('[data-testid="list-column-resize-title"]')!;
+    const cell = view.container.querySelector<HTMLElement>('[data-testid="list-column-title"]')!;
+
+    act(() => {
+      handle.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true, clientX: 100, pointerId: 1 }));
+      window.dispatchEvent(new PointerEvent("pointercancel", { pointerId: 1 }));
+    });
+    act(() => {
+      window.dispatchEvent(new PointerEvent("pointermove", { clientX: 220, pointerId: 1 }));
+    });
+    // 取消后的移动不得落到列宽或 localStorage(stale 监听会写出 540)。
+    expect(cell.style.width).toBe("420px");
+    expect(storedListWidths().title).toBe(420);
+
+    act(() => {
+      handle.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true, clientX: 100, pointerId: 2 }));
+      window.dispatchEvent(new PointerEvent("pointermove", { clientX: 140, pointerId: 2 }));
+      window.dispatchEvent(new PointerEvent("pointerup", { clientX: 140, pointerId: 2 }));
+    });
+    expect(cell.style.width).toBe("460px"); // 新拖拽不受取消残留影响。
+    expect(storedListWidths().title).toBe(460);
+
+    act(() => {
+      view.root.unmount();
+    });
+    view.container.remove();
+  });
+
+  it("releases window listeners when unmounted mid-drag, so stray moves never write storage", async () => {
+    localStorage.setItem(WIDTH_KEY, JSON.stringify({ list: { title: 420 } }));
+    const view = await mountList();
+    const handle = view.container.querySelector<HTMLElement>('[data-testid="list-column-resize-title"]')!;
+
+    act(() => {
+      handle.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true, clientX: 100, pointerId: 1 }));
+    });
+    act(() => {
+      view.root.unmount();
+    });
+    view.container.remove();
+    act(() => {
+      window.dispatchEvent(new PointerEvent("pointermove", { clientX: 220, pointerId: 1 }));
+    });
+    // 中途卸载后 stale 监听会同步写 localStorage(不依赖 React 挂载状态)。
+    expect(storedListWidths().title).toBe(420);
+  });
+
+  it("announces the measured default width when no width is persisted, and re-measures after reset", async () => {
+    // happy-dom 无布局引擎:以 stub 提供「父元素实测宽度」,真实浏览器由布局给出。
+    const rectOf = (width: number) =>
+      ({ x: 0, y: 0, top: 0, left: 0, right: width, bottom: 20, width, height: 20 }) as DOMRect;
+    const measure = vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockReturnValue(rectOf(300));
+    try {
+      const view = await mountList();
+      const handle = view.container.querySelector<HTMLElement>('[data-testid="list-column-resize-title"]')!;
+      const cell = view.container.querySelector<HTMLElement>('[data-testid="list-column-title"]')!;
+      // 默认(未定宽)手柄也必须报数字现值,而不是省略 aria-valuenow。
+      expect(handle.getAttribute("aria-valuenow")).toBe("300");
+      expect(cell.style.width).toBe(""); // 报数不等于写假宽度:th 仍走默认布局。
+
+      act(() => {
+        handle.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true, clientX: 100, pointerId: 1 }));
+        window.dispatchEvent(new PointerEvent("pointermove", { clientX: 160, pointerId: 1 }));
+        window.dispatchEvent(new PointerEvent("pointerup", { clientX: 160, pointerId: 1 }));
+      });
+      expect(handle.getAttribute("aria-valuenow")).toBe("360"); // 定宽后报持久化值。
+
+      measure.mockReturnValue(rectOf(320)); // 布局变了:恢复默认须重新量,不吐旧缓存。
+      act(() => {
+        handle.dispatchEvent(new MouseEvent("dblclick", { bubbles: true }));
+      });
+      expect(handle.getAttribute("aria-valuenow")).toBe("320");
+      expect(cell.style.width).toBe("");
+
+      act(() => {
+        view.root.unmount();
+      });
+      view.container.remove();
+    } finally {
+      measure.mockRestore();
+    }
   });
 });

--- a/packages/gui/test/list-view.vitest.ts
+++ b/packages/gui/test/list-view.vitest.ts
@@ -233,13 +233,17 @@ describe("list view column resize (W11)", () => {
   // 直接画进 Title 列(2026-09-09)。此处只断言收敛原语(截断类 + title 悬停)在
   // 标记里就位;像素级不越列由 Electron 走查复核,类名断言不证明像素行为。
   it("contains unbreakable cell values inside their fixed columns and keeps the full id on hover", () => {
+    const longDecisionId = "dec_01KZWTAPXF24FR62Q53Y42JGMV";
     const task = makeTask({
       taskId: "task_eeb3b5f08c093e63622b24392c",
       title: "Overflow regression",
       module: "packages/daemon",
       canonicalStatus: "done",
       coordinationStatus: "in_review",
-      currentNode: "review",
+      currentNode: "implementation",
+      activeExecutionId: "execution_eeb3b5f08c093e63622b24392c",
+      leaseHolder: "person-zeyu · codex-sol",
+      leasePhase: "held",
     });
     const markup = renderToStaticMarkup(
       createElement(ListView, {
@@ -248,7 +252,7 @@ describe("list view column resize (W11)", () => {
         filters: DEFAULT_TASK_FILTERS,
         onFiltersChange: () => undefined,
         onSelect: () => undefined,
-        spawningDecisions: new Map(),
+        spawningDecisions: new Map([["task_eeb3b5f08c093e63622b24392c", longDecisionId]]),
         favorites: new Set<string>(),
         onToggleFavorite: () => undefined,
         embedded: true,
@@ -262,9 +266,28 @@ describe("list view column resize (W11)", () => {
     // 同一 fixed 布局下其余不可断行值同样收敛在本列:coordination 键值串、节点行、
     // 模块名、包处置枚举 chip。
     expect(markup.match(/<span[^>]*>coordination=in_review<\/span>/u)![0]).toContain("truncate");
-    expect(markup.match(/<span[^>]*>graph cursor:review<\/span>/u)![0]).toContain("truncate");
+    expect(markup.match(/<span[^>]*>graph cursor:implementation<\/span>/u)![0]).toContain("truncate");
     expect(markup.match(/<span[^>]*>packages\/daemon<\/span>/u)![0]).toContain("truncate");
     expect(markup.match(/<span[^>]*>active<\/span>/u)![0]).toContain("max-w-full");
+    // 二次验收(2026-09-09):长 decision 徽章与状态列各行在 136px 窄列画进相邻列。
+    // 徽章外包可收缩截断项,整串 decision id 保留在徽章自身 title(悬停)与 DOM 文本。
+    const badge = markup.match(
+      new RegExp(`<span class="min-w-0 truncate"><span[^>]*title="[^"]*${longDecisionId}[^"]*"`, "u"),
+    );
+    expect(badge).not.toBeNull();
+    expect(markup).toContain(longDecisionId); // 截断只是绘制层,屏幕阅读器仍读整串。
+    // flex 列 cross 轴的 truncate 必须配 max-w-full 才有盒宽可裁;lease 原来的
+    // max-w-[16rem] 上限大于任何窄列,等于没封。
+    for (const line of [
+      /<span[^>]*>coordination=in_review<\/span>/u,
+      /<span[^>]*>graph cursor:implementation<\/span>/u,
+      /<span[^>]*>execution_eeb3b5f08c093e63622b24392c[^<]*<\/span>/u,
+    ]) {
+      const span = markup.match(line)![0];
+      expect(span).toContain("max-w-full");
+      expect(span).toContain("truncate");
+      expect(span).not.toContain("16rem");
+    }
   });
 
   it("drags, fine-tunes with arrow keys, resets by double-click, and persists across remount", async () => {

--- a/packages/gui/test/taskFilters.vitest.ts
+++ b/packages/gui/test/taskFilters.vitest.ts
@@ -1,9 +1,10 @@
 // @vitest-environment happy-dom
-import { beforeAll, describe, expect, it } from "vitest";
+import { beforeAll, beforeEach, describe, expect, it } from "vitest";
 import { act, createElement } from "react";
 import { createRoot } from "react-dom/client";
 import { renderToStaticMarkup } from "react-dom/server";
 import type { RelationEdge, SnapshotStatus, TaskRow } from "../src/renderer/model/types.ts";
+import { BOARD_COLUMNS } from "../src/renderer/model/types.ts";
 import { BoardView } from "../src/renderer/views/BoardView.tsx";
 import { SwimlaneBoard } from "../src/renderer/views/SwimlaneBoard.tsx";
 import {
@@ -20,6 +21,14 @@ import {
   type TaskFilters,
 } from "../src/renderer/model/taskFilters.ts";
 import { setActiveLocale } from "../src/renderer/i18n/core.ts";
+import {
+  boardColumnPreferenceStorage,
+  clearBoardColumnWidth,
+  emptyBoardColumnWidths,
+  readBoardColumnWidths,
+  setBoardColumnWidth,
+  writeBoardColumnWidths,
+} from "../src/renderer/board-column-preferences.ts";
 import { projectedTaskFields } from "./task-projection-fields.ts";
 
 function makeTask(overrides: Partial<TaskRow> = {}): TaskRow {
@@ -811,8 +820,11 @@ describe("draggable narrowing (W9)", () => {
     expect(markup.split('data-testid="board-task-card"').length - 1).toBe(2); // 两张卡都在。
     expect(markup.split('aria-roledescription="draggable"').length - 1).toBe(1); // 只有可拖卡挂 dnd。
     // 两张卡的包装层都可聚焦(可拖卡经 dnd attributes,不可拖卡显式声明),焦点不随收窄丢失。
+    // W11 起列头 resize 手柄也可聚焦(role="separator"),tabindex 计数只看卡包装层标签自身。
     expect(markup.split('role="button"').length - 1).toBe(2);
-    expect(markup.split('tabindex="0"').length - 1).toBe(2);
+    const wrappers = markup.match(/<div[^>]*role="button"[^>]*>/gu) ?? [];
+    expect(wrappers).toHaveLength(2);
+    expect(wrappers.every((tag) => tag.includes('tabindex="0"'))).toBe(true);
   });
 
   it("keeps hover hint and click behavior on non-draggable cards", async () => {
@@ -989,5 +1001,265 @@ describe("swimlane single-pass grouping (W9)", () => {
     expect(markup).toContain("lane-card-p2");
     const drilldown = markup.slice(markup.indexOf("下钻结果"));
     expect(drilldown).not.toContain("lane-card-b1");
+  });
+});
+
+/**
+ * 看板列宽偏好与 resize(W11):三种布局共用一份「每列一个数字 + 默认值」的
+ * localStorage 记忆(不进台账、不进 URL);未设置的列走各视图默认——列模式
+ * basis-1/4 等分、泳道 180+7×230、列表 table-fixed 自动分配。手柄键盘可达
+ * (Tab 聚焦 + ←/→ 微调),双击恢复默认;拖拽/微调即时落盘,重挂载后保留。
+ */
+const WIDTH_KEY = "harness:gui:board-column-widths";
+
+const widthMemory = () => {
+  const store = new Map<string, string>();
+  return {
+    getItem: (key: string) => store.get(key) ?? null,
+    setItem: (key: string, value: string) => void store.set(key, value),
+  };
+};
+
+const storedWidths = (layout: "column" | "swimlane" | "list"): Record<string, number> =>
+  JSON.parse(localStorage.getItem(WIDTH_KEY) ?? "{}")[layout] ?? {};
+
+async function mountBoardView(tasks: TaskRow[]) {
+  const container = document.createElement("div");
+  document.body.append(container);
+  const root = createRoot(container);
+  await act(async () => {
+    root.render(
+      createElement(BoardView, {
+        tasks,
+        allTasks: tasks,
+        filters: { ...DEFAULT_TASK_FILTERS },
+        onFiltersChange: noop,
+        onSelect: noop,
+        relations: [],
+        favorites: new Set<string>(),
+        onToggleFavorite: noop,
+        onSetPin: noop,
+      }),
+    );
+  });
+  return { container, root };
+}
+
+describe("board column width preferences (W11)", () => {
+  it("round-trips per-layout width maps and leaves unset layouts empty", () => {
+    const storage = widthMemory();
+    expect(readBoardColumnWidths(storage)).toEqual(emptyBoardColumnWidths);
+    let widths = setBoardColumnWidth(emptyBoardColumnWidths, "column", "planned", 360);
+    widths = setBoardColumnWidth(widths, "swimlane", "lane", 200);
+    widths = setBoardColumnWidth(widths, "list", "title", 420);
+    writeBoardColumnWidths(storage, widths);
+    expect(readBoardColumnWidths(storage)).toEqual(widths);
+  });
+
+  it("clamps and rounds widths into the sanity range on write", () => {
+    expect(setBoardColumnWidth(emptyBoardColumnWidths, "column", "planned", 3).column.planned).toBe(40);
+    expect(setBoardColumnWidth(emptyBoardColumnWidths, "column", "planned", 9999).column.planned).toBe(1200);
+    expect(setBoardColumnWidth(emptyBoardColumnWidths, "column", "planned", 300.6).column.planned).toBe(301);
+  });
+
+  it("falls back to defaults on bad JSON or non-numeric entries", () => {
+    const storage = widthMemory();
+    storage.setItem(WIDTH_KEY, "{not json");
+    expect(readBoardColumnWidths(storage)).toEqual(emptyBoardColumnWidths);
+    storage.setItem(WIDTH_KEY, JSON.stringify({ column: { planned: "wide" }, swimlane: 7 }));
+    expect(readBoardColumnWidths(storage)).toEqual(emptyBoardColumnWidths);
+  });
+
+  it("clear removes one key and is a no-op for absent keys", () => {
+    const widths = setBoardColumnWidth(emptyBoardColumnWidths, "swimlane", "lane", 200);
+    expect(clearBoardColumnWidth(widths, "swimlane", "lane").swimlane).toEqual({});
+    expect(clearBoardColumnWidth(widths, "swimlane", "missing")).toBe(widths);
+  });
+
+  it("missing storage (SSR) and failing writes never block the view", () => {
+    expect(readBoardColumnWidths(null)).toEqual(emptyBoardColumnWidths);
+    expect(() => writeBoardColumnWidths(null, emptyBoardColumnWidths)).not.toThrow();
+    expect(() => writeBoardColumnWidths(boardColumnPreferenceStorage(), emptyBoardColumnWidths)).not.toThrow();
+  });
+});
+
+describe("board column resize: column mode (W11)", () => {
+  beforeEach(() => {
+    localStorage.removeItem(WIDTH_KEY);
+  });
+
+  it("renders equal-quarter columns by default with one keyboard-reachable handle per column", () => {
+    const markup = boardMarkup([makeTask({ coordinationStatus: "planned" })]);
+    expect(markup.split('data-testid="board-column-resize-').length - 1).toBe(BOARD_COLUMNS.length);
+    const handle = markup.match(/<div[^>]*data-testid="board-column-resize-planned"[^>]*>/u)![0];
+    expect(handle).toContain('role="separator"');
+    expect(handle).toContain('tabindex="0"');
+    // 未定宽列保持等分默认:不输出显式宽度。
+    expect(markup).not.toContain('style="width');
+  });
+
+  it("applies a persisted width as an explicit column width", () => {
+    localStorage.setItem(WIDTH_KEY, JSON.stringify({ column: { planned: 360 } }));
+    const markup = boardMarkup([makeTask({ coordinationStatus: "planned" })]);
+    const column = markup.match(/<div[^>]*data-testid="board-column-planned"[^>]*>/u)![0];
+    expect(column).toContain('style="width:360px"');
+    expect(column).not.toContain("basis-1/4");
+    const handle = markup.match(/<div[^>]*data-testid="board-column-resize-planned"[^>]*>/u)![0];
+    expect(handle).toContain('aria-valuenow="360"');
+  });
+
+  it("drags the handle to widen a column, fine-tunes with arrow keys, and persists", async () => {
+    localStorage.setItem(WIDTH_KEY, JSON.stringify({ column: { planned: 300 } }));
+    const board = await mountBoardView([makeTask({ coordinationStatus: "planned" })]);
+    const handle = board.container.querySelector<HTMLElement>('[data-testid="board-column-resize-planned"]')!;
+    const column = board.container.querySelector<HTMLElement>('[data-testid="board-column-planned"]')!;
+
+    act(() => {
+      handle.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true, clientX: 100, pointerId: 1 }));
+      window.dispatchEvent(new PointerEvent("pointermove", { clientX: 160, pointerId: 1 }));
+      window.dispatchEvent(new PointerEvent("pointerup", { clientX: 160, pointerId: 1 }));
+    });
+    expect(column.style.width).toBe("360px");
+    expect(storedWidths("column").planned).toBe(360);
+
+    act(() => {
+      handle.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true }));
+    });
+    expect(column.style.width).toBe("376px");
+    act(() => {
+      handle.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowLeft", bubbles: true }));
+    });
+    expect(column.style.width).toBe("360px");
+    expect(storedWidths("column").planned).toBe(360);
+
+    act(() => {
+      board.root.unmount();
+    });
+    board.container.remove();
+  });
+
+  it("keeps the resized width across a remount (window reload equivalent)", async () => {
+    localStorage.setItem(WIDTH_KEY, JSON.stringify({ column: { planned: 300 } }));
+    const first = await mountBoardView([makeTask({ coordinationStatus: "planned" })]);
+    const handle = first.container.querySelector<HTMLElement>('[data-testid="board-column-resize-planned"]')!;
+    act(() => {
+      handle.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true }));
+    });
+    act(() => {
+      first.root.unmount();
+    });
+    first.container.remove();
+
+    const second = await mountBoardView([makeTask({ coordinationStatus: "planned" })]);
+    const column = second.container.querySelector<HTMLElement>('[data-testid="board-column-planned"]')!;
+    expect(column.style.width).toBe("316px");
+    act(() => {
+      second.root.unmount();
+    });
+    second.container.remove();
+  });
+
+  it("double-click resets the column to the default equal-quarter layout", async () => {
+    localStorage.setItem(WIDTH_KEY, JSON.stringify({ column: { planned: 300 } }));
+    const board = await mountBoardView([makeTask({ coordinationStatus: "planned" })]);
+    const handle = board.container.querySelector<HTMLElement>('[data-testid="board-column-resize-planned"]')!;
+    act(() => {
+      handle.dispatchEvent(new MouseEvent("dblclick", { bubbles: true }));
+    });
+    const column = board.container.querySelector<HTMLElement>('[data-testid="board-column-planned"]')!;
+    expect(column.style.width).toBe("");
+    expect(column.className).toContain("basis-1/4");
+    expect(storedWidths("column").planned).toBeUndefined();
+    act(() => {
+      board.root.unmount();
+    });
+    board.container.remove();
+  });
+});
+
+describe("swimlane column resize (W11)", () => {
+  beforeEach(() => {
+    localStorage.removeItem(WIDTH_KEY);
+  });
+
+  const laneResizeFixture = (): TaskRow[] => [
+    makeTask({ taskId: "t_p1", rootTaskId: "root-a", rootTitle: "Lane A", coordinationStatus: "planned" }),
+  ];
+
+  it("renders the default 180px lane + 7×230px status template on header and rows", () => {
+    const markup = renderToStaticMarkup(
+      createElement(SwimlaneBoard, {
+        tasks: laneResizeFixture(),
+        groupBy: "root",
+        onSelect: noop,
+        drill: null,
+        relations: [],
+        favorites: new Set<string>(),
+        onToggleFavorite: noop,
+        onSetPin: noop,
+      }),
+    );
+    const template = `grid-template-columns:${["180px", ...Array(7).fill("230px")].join(" ")}`;
+    expect(markup.split(template).length - 1).toBeGreaterThanOrEqual(2); // sticky 表头 + 每泳道行。
+    expect(markup.split('data-testid="swimlane-column-resize-').length - 1).toBe(BOARD_COLUMNS.length);
+    expect(markup).toContain('data-testid="swimlane-lane-resize"');
+  });
+
+  it("derives the template from persisted lane and status widths", () => {
+    localStorage.setItem(WIDTH_KEY, JSON.stringify({ swimlane: { lane: 200, planned: 320 } }));
+    const markup = renderToStaticMarkup(
+      createElement(SwimlaneBoard, {
+        tasks: laneResizeFixture(),
+        groupBy: "root",
+        onSelect: noop,
+        drill: null,
+        relations: [],
+        favorites: new Set<string>(),
+        onToggleFavorite: noop,
+        onSetPin: noop,
+      }),
+    );
+    expect(markup).toContain("grid-template-columns:200px 320px 230px");
+  });
+
+  it("drags a status column wider and fine-tunes the lane column with arrow keys", async () => {
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    await act(async () => {
+      root.render(
+        createElement(SwimlaneBoard, {
+          tasks: laneResizeFixture(),
+          groupBy: "root",
+          onSelect: noop,
+          drill: null,
+          relations: [],
+          favorites: new Set<string>(),
+          onToggleFavorite: noop,
+          onSetPin: noop,
+        }),
+      );
+    });
+    const statusHandle = container.querySelector<HTMLElement>('[data-testid="swimlane-column-resize-planned"]')!;
+    act(() => {
+      statusHandle.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true, clientX: 80, pointerId: 1 }));
+      window.dispatchEvent(new PointerEvent("pointermove", { clientX: 140, pointerId: 1 }));
+      window.dispatchEvent(new PointerEvent("pointerup", { clientX: 140, pointerId: 1 }));
+    });
+    expect(storedWidths("swimlane").planned).toBe(290);
+    // 活 DOM 的 style 序列化在冒号后带空格,断言不带冒号的模板子串。
+    expect(container.innerHTML).toContain("180px 290px 230px");
+
+    const laneHandle = container.querySelector<HTMLElement>('[data-testid="swimlane-lane-resize"]')!;
+    act(() => {
+      laneHandle.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowLeft", bubbles: true }));
+    });
+    expect(storedWidths("swimlane").lane).toBe(164); // 180 - 16。
+    expect(container.innerHTML).toContain("164px 290px 230px");
+
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
   });
 });


### PR DESCRIPTION
# English

## Summary

Add persistent numeric column widths to column, swimlane and list layouts, with pointer resizing, keyboard adjustment and reset.

## Architectural Justification

Reuse one small local preference map and one shared resize handle across the three existing layouts. Keep existing CSS defaults until a width is explicitly set. No new layout engine, ledger state, dependency or server API. Listener ownership stays in the handle; cancellation and unmount dispose the same active listener set.

## What Changed

Store widths per layout/column in renderer localStorage. Add focusable resize handles and reset controls. Preserve the W9 stable badge/card props during integration. Measure default accessible widths without persisting invented values.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
Production +515/-30 against main. Replace fixed swimlane grid tracks and unconditional board sizing with the existing preference-driven views; no parallel implementation.

## Machine-Readable Declarations

No dependency, version, accepted-event fixture or CI/gate change.

## Task And Scope

- Harness task: task_eeb3b5f08c093e63622b24392c.
- Branch: codex/kanban-w11; base main.
- Public scope: three board layouts, shared handle/preferences, locale labels and existing tests.
- Private planning/evidence updated: yes.
- Out of scope: W10 virtualization, cross-window live sync, storage and release.

## Version Impact

No version change or publish.

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: not applicable
- Machine-check boundary: declarations do not replace semantic review.
- Break-glass: no

## Verification

Base main e42c2149abd32845953401778d7d82fa55bcfa5b; final candidate ac81192ef36f1bf01acd9c650cbb7b77e3252625. Existing scoped GUI105 tests passed, final list-view11/11, old positioning path fails its new assertion. Actual visible Electron on canonical data: task/decision IDs stay within list cells; list keyboard152→168, pointer168→228, reset136, keyboard152 and reload restores152; swimlane label244→260. Prior column keyboard244→276 persisted across restart. Old handle had height0 and failed real pointer dragging; corrected handle is hit-testable and moves exactly60px. Root inspected screenshots and the current code. No whole check:local or production frame-time claim. Final-head GitHub CI pending; prior dd90f03d8 CI was green.

## Review Evidence

Independent Sol found pointercancel/unmount cleanup and default aria gaps; GLM corrected with positive/negative tests. Root Electron acceptance additionally found fixed-cell overflow and zero-height handles, both corrected by GLM and rechecked through actual rendered geometry and interaction. The shared positioning fix replaces the unusable static handle. No external human review claimed.

## Residual Risk

Screen-reader behavior, every board-column pointer permutation and production-scale frame timings remain unverified. Default accessible width is measured at mount/reset rather than continuously observing viewport changes. Cross-window live preference synchronization is outside scope. An earlier CI head failed a vertical-script materialization test while same-head Ubuntu4/4 passed; cause remains tracked separately, not declared fixed by this GUI change. Merge requires current required CI, normal merge only.

## References

Private W11 artifacts retain independent review, correction and integration reports. The W9 parent provides memo/reference behavior; its nested keyboard guard is preserved.

---

# 中文

## 概要

列、泳道、列表三种布局支持数值列宽偏好，提供指针拖动、键盘微调和恢复默认。

## 架构辩护

三个既有布局共用小型本地偏好映射和一个调整手柄；未显式设置时保留原CSS默认。不引入布局引擎、台账状态、依赖或服务端API。监听器由手柄持有，取消与卸载都清理同一组活动监听器。

## 改动内容

按布局/列存localStorage；提供可聚焦手柄和重置。集成时保留W9稳定徽章/卡片属性；默认可访问宽度来自测量，不伪造持久化数值。

## 门收割 / Gate Harvest

对main基准生产+515/-30。固定泳道轨道和无条件列宽改为偏好驱动；无平行实现，机读声明仅在英文块出现。

## 机读声明说明

不改依赖、版本、已接受事件fixture或CI/gate。

## 任务与范围

Task task_eeb3b5f08c093e63622b24392c；分支codex/kanban-w11，基于main。范围为三个布局、共享手柄/偏好、文案及既有测试。私有证据已更新；不含W10虚拟滚动、跨窗口实时同步、存储或发版。

## 版本影响

不改版本，不发布。

## 治理声明

不触碰protected surface，无break-glass；声明不替代语义评审。

## 验证

main基准e42c2149，最终候选ac81192ef36f1bf01acd9c650cbb7b77e3252625。定向GUI105项通过，最终list-view11/11，旧定位实现的新增负控失败。主控真实Electron验证长Task/Decision ID不越列；列表键盘152到168、鼠标拖到228、重置136，再键盘调到152并重载保持152；泳道标签244到260。此前列模式244到276并重启保持已验。旧手柄高度0、鼠标无效，新手柄有真实命中区且移动60px准确生效。截图与源码已亲验；不声称全量check:local或生产帧耗时。最终提交CI待跑，前一dd90f03d8提交CI已绿。

## 审查证据

Sol独立评审发现取消/卸载清理与默认aria问题，GLM以正负例修复。主控实机又发现固定表格文本溢出和手柄零高度，GLM已修，主控复验真实几何和交互。不冒称外部人工评审。

## 残余风险

未覆盖读屏、每列指针排列和生产帧耗时。默认aria仅挂载/重置测量，未持续跟踪视口变化；跨窗口实时同步不在范围。早先CI出现vertical-script物化测试失败，同提交Ubuntu4/4通过，根因仍另项跟踪，不由此GUI修正宣称解决。合并须最终必需CI通过，普通merge。

## 关联材料

私有W11任务包保留独立评审、修正和集成报告；W9父层提供memo/引用行为，嵌套键盘守卫已保留。

## PR Gate Checklist / PR 门禁清单

- [x] Bilingual scoped evidence / 双语范围证据
- [ ] Required CI, parent integration and desktop acceptance / CI、父层集成和桌面验收
- [x] Normal merge only, no publish / 普通merge，不发布
