### PR TITLE
fix(runtime): identify canonical task ids in missions and diagnostics

### DIFF
--- a/packages/cli/test/runtime-cli.integration.test.ts
+++ b/packages/cli/test/runtime-cli.integration.test.ts
@@ -419,6 +419,7 @@ test("real CLI runs, archives task-bound dispatches, resumes, waits through stat
     assert.match(assembledPrompt, /# Worker Role/u);
     assertTaskMissionPrompt(assembledPrompt, {
       repoId: "runtime-cli",
+      taskId,
       canonicalRoot: realpathSync(root),
       workerRoot: realpathSync(root),
       taskPackageRoot: path.join(realpathSync(root), "harness", packagePath),
@@ -605,6 +606,7 @@ test("real CLI runs, archives task-bound dispatches, resumes, waits through stat
     assert.equal(reusedReport, `final:${reusedMission}`);
     assertTaskMissionPrompt(reusedMission, {
       repoId: "runtime-cli",
+      taskId,
       canonicalRoot: realpathSync(root),
       workerRoot: realpathSync(root),
       taskPackageRoot: path.join(realpathSync(root), "harness", packagePath),
@@ -638,6 +640,7 @@ test("real CLI runs, archives task-bound dispatches, resumes, waits through stat
     );
     assertTaskMissionPrompt(derivedText.slice("final:".length), {
       repoId: "runtime-cli",
+      taskId,
       canonicalRoot: realpathSync(root),
       workerRoot: realpathSync(root),
       taskPackageRoot: taskPackage,
@@ -1323,6 +1326,7 @@ test("real CLI runs, archives task-bound dispatches, resumes, waits through stat
     const cancelledReport = readFileSync(path.join(artifactRoot, "reports", `${detachedDispatchId}.md`), "utf8");
     assertTaskMissionPrompt(cancelledReport.slice("live:".length), {
       repoId: "runtime-cli",
+      taskId,
       canonicalRoot: realpathSync(root),
       workerRoot: realpathSync(root),
       taskPackageRoot: path.join(realpathSync(root), "harness", packagePath),
@@ -1382,6 +1386,7 @@ test("real CLI runs, archives task-bound dispatches, resumes, waits through stat
     assert.ok(resumedText.startsWith("resumed:provider-cli-session:"), resumedText);
     assertTaskMissionPrompt(resumedText.slice("resumed:provider-cli-session:".length), {
       repoId: "runtime-cli",
+      taskId,
       canonicalRoot: realpathSync(root),
       workerRoot: realpathSync(root),
       taskPackageRoot: path.join(realpathSync(root), "harness", packagePath),
@@ -1631,6 +1636,7 @@ function assertTaskMissionPrompt(
   prompt: string,
   expected: {
     readonly repoId: string;
+    readonly taskId: string;
     readonly canonicalRoot: string;
     readonly workerRoot: string;
     readonly taskPackageRoot: string;
@@ -1642,7 +1648,7 @@ function assertTaskMissionPrompt(
 ): void {
   assert.ok(
     prompt.includes(
-      `# Dispatch Preconditions\nRepository id: ${expected.repoId}\nRepository registration: enabled\nCanonical repository root: ${expected.canonicalRoot}\nWorker repository root: ${expected.workerRoot}\nTask package root: ${expected.taskPackageRoot}\nDaemon user root: ${expected.daemonUserRoot}\nDaemon id: ${expected.daemonId}\nDaemon endpoint: `,
+      `# Dispatch Preconditions\nRepository id: ${expected.repoId}\nRepository registration: enabled\nCanonical repository root: ${expected.canonicalRoot}\nWorker repository root: ${expected.workerRoot}\nCanonical Task ID: ${expected.taskId}\nTask package root: ${expected.taskPackageRoot}\nDaemon user root: ${expected.daemonUserRoot}\nDaemon id: ${expected.daemonId}\nDaemon endpoint: `,
     ),
     prompt,
   );

--- a/packages/daemon/src/repo-cell-authorization.ts
+++ b/packages/daemon/src/repo-cell-authorization.ts
@@ -1,4 +1,5 @@
 import { composeDurableActionEnvelope } from "../../application/src/durable-action-envelope.ts";
+import path from "node:path";
 import {
   durablePolicyActions,
   isSameExecution,
@@ -456,6 +457,22 @@ function invalidExecutorBindingFor(
         : "malformed executor descriptor",
     expected = lease?.actor.executor ? `agent:${lease.actor.executor.id}` : null,
     retry = executorRetryCommand(input.action, taskId, executionId),
+    runtimeSessionId =
+      isExecutorDescriptorRecord(raw) &&
+      raw.kind === "agent" &&
+      typeof raw.id === "string" &&
+      raw.id.startsWith("runtime-session:")
+        ? raw.id.slice("runtime-session:".length)
+        : null,
+    runtimeSession = runtimeSessionId === null ? null : input.projection.readRuntimeSession(runtimeSessionId),
+    canonicalTaskId =
+      taskId === null || runtimeSession === null
+        ? null
+        : (runtimeSession.taskBindings.find((candidate) => {
+            if (candidate.taskId === taskId) return false;
+            const packagePath = input.projection.read(candidate.taskId).packagePath;
+            return packagePath !== null && path.posix.basename(packagePath) === taskId;
+          })?.taskId ?? null),
     reviewerRedispatch =
       input.action.kind === "task-review-execution" &&
       taskId !== null &&
@@ -463,20 +480,23 @@ function invalidExecutorBindingFor(
       raw.kind === "agent" &&
       typeof raw.id === "string" &&
       raw.id.startsWith("runtime-session:"),
-    expectation = reviewerRedispatch
-      ? `Expected a reviewer RuntimeSession bound to execution ${executionId ?? "<execution-id>"}; run ` +
-        `ha runtime run <runtime-instance-id> --role reviewer --task ${taskId}, then retry ${retry}`
-      : expected
-        ? `Expected ${expected} from the held execution lease; run from that executor, then retry ${retry}`
-        : "Expected a task-bound executor with a matching held execution lease; run ha task start " +
-          `${taskId ?? "<task-id>"}, then retry ${retry}`,
+    expectation = canonicalTaskId
+      ? `The supplied taskId matches the bound package basename; use canonical taskId ${canonicalTaskId}, then retry ` +
+        executorRetryCommand(input.action, canonicalTaskId, executionId)
+      : reviewerRedispatch
+        ? `Expected a reviewer RuntimeSession bound to execution ${executionId ?? "<execution-id>"}; run ` +
+          `ha runtime run <runtime-instance-id> --role reviewer --task ${taskId}, then retry ${retry}`
+        : expected
+          ? `Expected ${expected} from the held execution lease; run from that executor, then retry ${retry}`
+          : "Expected a task-bound executor with a matching held execution lease; run ha task start " +
+            `${taskId ?? "<task-id>"}, then retry ${retry}`,
     diagnostic: ReceiptDiagnostic = {
       kind: "validation",
       entity: [taskId ? `task ${taskId}` : "repository", executionId ? `execution ${executionId}` : ""]
         .filter(Boolean)
         .join(" "),
-      field: "executor",
-      actual,
+      field: canonicalTaskId ? "taskId" : "executor",
+      actual: canonicalTaskId ? taskId! : actual,
       expectation,
     };
   return Object.assign(new Error(message), { code: "executor_binding_invalid" as const, diagnostic });

--- a/packages/daemon/src/runtime-spawn-mission.ts
+++ b/packages/daemon/src/runtime-spawn-mission.ts
@@ -240,6 +240,7 @@ export function assembleTaskMission(input: {
   readonly repoId: string;
   readonly canonicalRoot: string;
   readonly workerRoot: string;
+  readonly taskId: string;
   readonly taskPackageRoot: string;
   readonly daemonRoute: RuntimeDaemonRoute;
   readonly runtimeActor: string;
@@ -250,6 +251,7 @@ export function assembleTaskMission(input: {
     "Repository registration: enabled",
     `Canonical repository root: ${input.canonicalRoot}`,
     `Worker repository root: ${input.workerRoot}`,
+    `Canonical Task ID: ${input.taskId}`,
     `Task package root: ${input.taskPackageRoot}`,
     ...(input.daemonRoute.userRoot
       ? [`Daemon user root: ${input.daemonRoute.userRoot}`, `Daemon id: ${input.daemonRoute.daemonId}`]

--- a/packages/daemon/src/runtime-spawner.ts
+++ b/packages/daemon/src/runtime-spawner.ts
@@ -496,6 +496,7 @@ export function makeRuntimeSpawner(input: RuntimeSpawnerInput) {
               repoId: input.repoId,
               canonicalRoot: input.rootDir,
               workerRoot: cwd,
+              taskId: taskId!,
               taskPackageRoot: taskMission.packageRoot,
               daemonRoute: missionDaemonRoute!,
               runtimeActor,

--- a/packages/daemon/test/repo-cell-executor-binding-cut.test.ts
+++ b/packages/daemon/test/repo-cell-executor-binding-cut.test.ts
@@ -135,6 +135,9 @@ test("package basename diagnostics name the canonical task id and retry command"
       `ha task artifact add ${taskId} --source <path> --destination <artifact-path>`,
   });
   assert.equal(context.observedActor, null);
+  const retried = await createRepoCellApi(context).run(action, binding);
+  assert.equal(retried.outcome, "applied", JSON.stringify(retried));
+  assert.deepEqual(context.observedActor, runtimeActor);
 });
 
 test("a reviewer bound to an earlier execution receives a reviewer redispatch command", async () => {

--- a/packages/daemon/test/repo-cell-executor-binding-cut.test.ts
+++ b/packages/daemon/test/repo-cell-executor-binding-cut.test.ts
@@ -107,6 +107,36 @@ test("executor binding rejection names the claimed and held executors", async (t
   assert.equal(context.observedActor, null);
 });
 
+test("package basename diagnostics name the canonical task id and retry command", async () => {
+  const packageBasename = `${taskId}-runtime-first-write`,
+    context = contextFor(
+      Promise.resolve(),
+      () => runtimeSession,
+      () => lease,
+    ),
+    receipt = await createRepoCellApi(context).run(
+      {
+        ...action,
+        taskId: packageBasename,
+        executor: runtimeActor.executor,
+      },
+      binding,
+    );
+
+  assert.equal(receipt.outcome, "op_rejected");
+  assert.equal(receipt.code, "executor_binding_invalid");
+  assert.deepEqual(receipt.diagnostic, {
+    kind: "validation",
+    entity: `task ${packageBasename} execution ${executionId}`,
+    field: "taskId",
+    actual: packageBasename,
+    expectation:
+      `The supplied taskId matches the bound package basename; use canonical taskId ${taskId}, then retry ` +
+      `ha task artifact add ${taskId} --source <path> --destination <artifact-path>`,
+  });
+  assert.equal(context.observedActor, null);
+});
+
 test("a reviewer bound to an earlier execution receives a reviewer redispatch command", async () => {
   const nextExecutionId = "exec-runtime-second-round",
     nextRuntimeActor = {
@@ -251,6 +281,9 @@ function contextFor(
         }),
       },
       projection: {
+        read: (candidateTaskId: string) => ({
+          packagePath: candidateTaskId === taskId ? `tasks/${packageBasenameFor(taskId)}` : null,
+        }),
         readRuntimeSession,
         currentLease,
         readCut: () => ({ status: "ready", watermark: 3, sourceRevision: 3 }),
@@ -279,4 +312,8 @@ function contextFor(
     readonly observedActor: RepoCellBinding["actor"] | null;
     readonly tailAssignments: number;
   };
+}
+
+function packageBasenameFor(candidateTaskId: string): string {
+  return `${candidateTaskId}-runtime-first-write`;
 }

--- a/packages/daemon/test/runtime-spawn-ingress.integration.test.ts
+++ b/packages/daemon/test/runtime-spawn-ingress.integration.test.ts
@@ -180,6 +180,7 @@ test("daemon ingress preserves executor-scoped task-bound runtime spawn", async 
           `Task package root: ${path.join(realpathSync(root), "harness", "tasks", "task-runtime-agent-agent-runtime")}`,
         ),
       );
+      assert.ok(launchedPrompt.includes(`Canonical Task ID: ${taskId}`));
       assert.match(launchedPrompt, new RegExp(`Runtime actor: agent:runtime-session:${receipt.runtimeSessionId}`, "u"));
       assert.equal(launchedPrompt.includes(userRoot), false);
       assert.equal(launchedPrompt.includes("Daemon id: runtime-spawn-ingress"), false);


### PR DESCRIPTION
# English

## Summary

Distinguish canonical Task IDs from package directory names in task-bound runtime missions. When the exact bound package basename is supplied as taskId, keep the rejection and explain the correct ID and retry command.

## Architectural Justification

Use the existing mission builder and executor diagnostics. No alias, path normalization, second authorization route or lease recovery.

## What Changed

Pass Task ID into the generated mission separately from package root. Resolve diagnostic hints from the bound RuntimeSession and projected Task package path; preserve all admission checks.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
Production +32/-9; replace ambiguous diagnostics in place.

## Machine-Readable Declarations

No dependency, event fixture, version or CI/gate changes.

## Task And Scope

- Harness task: task_f9a4e367fabc027a004fad2cb4.
- Branch: codex/runtime-task-id-context.
- Public scope: daemon mission/diagnostic fields and focused tests.
- Private planning/evidence updated: yes.
- Out of scope: alias support, lease recovery, GUI and release.

## Version Impact

No version change or publish.

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: not applicable
- Machine-check boundary: declaration requires semantic review.
- Break-glass: no

## Verification

Base main6ec1d9a8dcb546cde73fb6feacaa74b6006308b9; ordinary merge head354b178d4. Public diff: git diff origin/main...HEAD. Ubuntu executor-binding contract6/6 and runtime ingress17/17; maintainer added a same-context canonical-ID retry after basename rejection and reran contract6/6. The same projected lease/session admits the corrected request without reacquisition; this fixture proves admission, not an actual second artifact publication. Source runtime ingress checks the generated mission. New-head public CI required. Worker ran unauthorized full check:local; that is excluded from acceptance evidence.

## Review Evidence

Maintainer read mission/call site and diagnostic resolution. Wrong or unrelated runtime remains rejected; exact package matching only improves the message. Confirmed source failure used a package basename as taskId. Actual runtime observation is retained in private evidence. GitHub bot findings will be triaged before merge.

## Residual Risk

Not a blanket solution for missing leases or wrong execution identity. Full new-head CI and live deployment pending. Ordinary merge and branch/worktree cleanup after acceptance; no admin bypass planned.

## References

Private Task report and Fact F-B13B5DAF; existing RuntimeSession binding and Task package projection.

---

# 中文

## 概要

区分runtime任务的canonical Task ID与任务包目录名。误传绑定目录basename时仍拒绝，但明确指出正确ID与重试命令。

## 架构辩护

复用既有mission生成与executor诊断，不增加别名、路径归一化、第二授权路或租约救场。

## 改动内容

生成mission分别标注Task ID和package root；诊断根据绑定RuntimeSession与投影包路径给提示，原接纳校验保持。

## 门收割 / Gate Harvest

生产+32/-9，在原入口替换含混提示，无旧路径保留、无整文件或门删除。

## 机读声明说明

不改依赖、事件样本、版本或CI/gate。

## 任务与范围

Task task_f9a4e367fabc027a004fad2cb4；分支codex/runtime-task-id-context。只改daemon mission/诊断与定向测试，私有证据已更新；不增加别名，不做租约恢复、GUI或发版。

## 版本影响

不改版本、不发布。

## 治理声明

未触碰protected surface，授权不适用；声明需语义核对。Break-glass：no。

## 验证

基准main6ec1d9a8d，普通merge后354b178d4。Ubuntu executor-binding6/6和runtime ingress17/17；主控新增basename拒绝后同context正确ID重试并跑6/6。同一投影lease/session无需重领即接纳纠正请求；此fixture证明接纳，不冒称第二次artifact实际发布。runtime ingress检查真实生成mission。新head公共CI仍必需。worker越界跑的全check:local不纳入验收。

## 审查证据

主控核对mission调用点及诊断解析；无关或错误runtime仍拒绝，准确package匹配只改善提示。原事故命令确实把目录basename作为taskId，私有证据保留。合并前处理GitHub bot意见。

## 残余风险

不解决真正缺失租约或execution身份错误。完整新headCI及部署待验证。验收后普通merge并清分支/worktree，不计划admin绕门。

## 关联材料

私有Task报告、Fact F-B13B5DAF及现有RuntimeSession绑定/Task包投影。

---

## PR Gate Checklist / PR 门禁清单

- [x] Latest main integrated, bilingual scope/review/evidence recorded.
- [x] No private files, local paths, dependency changes or gate changes.
- [x] Version/publish impact and merge cleanup stated.
- [ ] New-head required CI green and bot triage completed.
- [ ] Ordinary merge and cleanup completed.
