### PR TITLE
fix(test): route registered GUI files through the isolated dispatcher

### DIFF
--- a/tools/dispatch-isolated-test.mjs
+++ b/tools/dispatch-isolated-test.mjs
@@ -12,8 +12,17 @@ import {
   toolOption,
   toolValue,
 } from "./tool-command-contract.mjs";
+import { guiVitestManifest } from "./gui-test-manifest.mjs";
 
 const repoRoot = path.resolve(import.meta.dirname, "..");
+const dispatchCommand = Object.freeze({
+  ...dispatchIsolatedTestCommand,
+  options: Object.freeze(
+    dispatchIsolatedTestCommand.options.map((option) =>
+      option.name === "--file" ? { ...option, validate: validateDispatchTestFile } : option,
+    ),
+  ),
+});
 export const sourceRootAllowlist = Object.freeze([
   ".github",
   ".gitignore",
@@ -30,22 +39,52 @@ export const sourceRootAllowlist = Object.freeze([
 ]);
 
 export function parseDispatchArgs(argv) {
-  const parsed = parseToolOptions(dispatchIsolatedTestCommand, argv);
+  const parsed = parseToolOptions(dispatchCommand, argv);
   if (parsed.help) return { help: true };
   const options = {
     target: toolValue(parsed, "--target") ?? toolOption(dispatchIsolatedTestCommand, "--target").defaultValue,
     tier: toolValue(parsed, "--tier"),
     file: toolValue(parsed, "--file"),
   };
+  validateFileSelection(options.file);
   return options;
 }
 
 export function testRunnerArgs(options) {
+  validateFileSelection(options.file);
+  if (guiVitestManifest.includes(options.file)) {
+    return [
+      "npm",
+      "run",
+      "test:gui",
+      "--workspace",
+      "@harness-anything/gui",
+      "--",
+      options.file.slice("packages/gui/".length),
+    ];
+  }
   return [
     "node",
     "tools/run-node-tests.mjs",
     ...(options.tier === undefined ? ["--file", options.file] : ["--tier", options.tier]),
   ];
+}
+
+function validateFileSelection(file) {
+  if (file?.startsWith("packages/gui/test/") && !guiVitestManifest.includes(file)) {
+    throw new Error(`unknown GUI test file: ${file}`);
+  }
+}
+
+function validateDispatchTestFile(value) {
+  if (
+    value.startsWith("/") ||
+    value.split("/").includes("..") ||
+    value.includes("\\") ||
+    !/\.(?:(?:test|spec)\.(?:mjs|js|ts)|vitest\.(?:mjs|js|ts))$/u.test(value)
+  ) {
+    throw new Error(`--file must be a POSIX repository-relative test file; received ${JSON.stringify(value)}`);
+  }
 }
 
 export function sourceArchiveArgs(platform = process.platform, sourceRoot = repoRoot) {

--- a/tools/dispatch-isolated-test.mjs
+++ b/tools/dispatch-isolated-test.mjs
@@ -46,12 +46,11 @@ export function parseDispatchArgs(argv) {
     tier: toolValue(parsed, "--tier"),
     file: toolValue(parsed, "--file"),
   };
-  validateFileSelection(options.file);
   return options;
 }
 
 export function testRunnerArgs(options) {
-  validateFileSelection(options.file);
+  if (options.file !== undefined) validateDispatchTestFile(options.file);
   if (guiVitestManifest.includes(options.file)) {
     return [
       "npm",
@@ -70,21 +69,10 @@ export function testRunnerArgs(options) {
   ];
 }
 
-function validateFileSelection(file) {
-  if (file?.startsWith("packages/gui/test/") && !guiVitestManifest.includes(file)) {
-    throw new Error(`unknown GUI test file: ${file}`);
-  }
-}
-
 function validateDispatchTestFile(value) {
-  if (
-    value.startsWith("/") ||
-    value.split("/").includes("..") ||
-    value.includes("\\") ||
-    !/\.(?:(?:test|spec)\.(?:mjs|js|ts)|vitest\.(?:mjs|js|ts))$/u.test(value)
-  ) {
-    throw new Error(`--file must be a POSIX repository-relative test file; received ${JSON.stringify(value)}`);
-  }
+  if (guiVitestManifest.includes(value)) return;
+  if (value.includes(".vitest.")) throw new Error(`unknown GUI test file: ${value}`);
+  toolOption(dispatchIsolatedTestCommand, "--file").validate(value);
 }
 
 export function sourceArchiveArgs(platform = process.platform, sourceRoot = repoRoot) {

--- a/tools/dispatch-isolated-test.test.mjs
+++ b/tools/dispatch-isolated-test.test.mjs
@@ -48,7 +48,7 @@ test("dispatcher accepts all isolated targets and validates exact file paths", (
   assert.throws(() => parseDispatchArgs(["--file", "../outside.test.mjs"]), /repository-relative/u);
 });
 
-test("dispatcher builds runner commands for either supported selector", () => {
+test("dispatcher builds runner commands for Node selectors and registered GUI files", () => {
   assert.deepEqual(testRunnerArgs({ tier: "integration", file: undefined }), [
     "node",
     "tools/run-node-tests.mjs",
@@ -61,6 +61,26 @@ test("dispatcher builds runner commands for either supported selector", () => {
     "--file",
     "tools/a.test.mjs",
   ]);
+  assert.deepEqual(testRunnerArgs({ tier: undefined, file: "packages/gui/test/task-pin-actions.vitest.ts" }), [
+    "npm",
+    "run",
+    "test:gui",
+    "--workspace",
+    "@harness-anything/gui",
+    "--",
+    "test/task-pin-actions.vitest.ts",
+  ]);
+});
+
+test("dispatcher rejects unregistered GUI files", () => {
+  assert.throws(
+    () => parseDispatchArgs(["--file", "packages/gui/test/unregistered.vitest.ts"]),
+    /unknown GUI test file: packages\/gui\/test\/unregistered\.vitest\.ts/u,
+  );
+  assert.throws(
+    () => testRunnerArgs({ tier: undefined, file: "packages/gui/test/unregistered.vitest.ts" }),
+    /unknown GUI test file/u,
+  );
 });
 
 test("source root allowlist contains only current test inputs", () => {
@@ -160,6 +180,16 @@ test("remote scripts preflight before executing tests with a dedicated root and 
   assert.match(powerShell, /\$ProgressPreference = 'SilentlyContinue'/u);
   assert.match(powerShell, /test-hermetic-preflight\.mjs --user-root 'C:\\Temp\\run\\\.test-isolation-state'/u);
   assert.match(powerShell, /\$env:HARNESS_DAEMON_USER_ROOT = 'C:\\Temp\\run\\\.test-isolation-state'/u);
+});
+
+test("remote scripts preserve the GUI workspace-relative file argument", () => {
+  const options = { tier: undefined, file: "packages/gui/test/task-pin-actions.vitest.ts" };
+  const posix = posixTestScript("/tmp/run", "/tmp/run/.test-isolation-state", options);
+  const powerShell = powerShellTestScript("C:\\Temp\\run", "C:\\Temp\\run\\.test-isolation-state", options);
+  assert.match(posix, /'test\/task-pin-actions\.vitest\.ts'/u);
+  assert.match(powerShell, /'test\/task-pin-actions\.vitest\.ts'/u);
+  assert.doesNotMatch(posix, /'packages\/gui\/test\/task-pin-actions\.vitest\.ts'/u);
+  assert.doesNotMatch(powerShell, /'packages\/gui\/test\/task-pin-actions\.vitest\.ts'/u);
 });
 
 function withFixture(run) {

--- a/tools/dispatch-isolated-test.test.mjs
+++ b/tools/dispatch-isolated-test.test.mjs
@@ -83,6 +83,23 @@ test("dispatcher rejects unregistered GUI files", () => {
   );
 });
 
+test("GUI routing preserves native tests and accepts registered TSX", () => {
+  const native = "packages/gui/test/local-doc-ipc.test.ts";
+  assert.equal(parseDispatchArgs(["--file", native]).file, native);
+  assert.deepEqual(testRunnerArgs({ file: native }), ["node", "tools/run-node-tests.mjs", "--file", native]);
+  const tsx = "packages/gui/test/first-run-guide.vitest.tsx";
+  assert.equal(parseDispatchArgs(["--file", tsx]).file, tsx);
+  assert.deepEqual(testRunnerArgs({ file: tsx }), [
+    "npm",
+    "run",
+    "test:gui",
+    "--workspace",
+    "@harness-anything/gui",
+    "--",
+    "test/first-run-guide.vitest.tsx",
+  ]);
+});
+
 test("source root allowlist contains only current test inputs", () => {
   assert.deepEqual(sourceRootAllowlist, [
     ".github",


### PR DESCRIPTION
# English

## Summary
Allow the existing isolated test dispatcher to run a registered GUI Vitest file on Ubuntu, Docker or Windows targets. Previously every --file selection went to the Node runner, so GUI files could not use the required isolation entry.

## Architectural Justification
Reuse the existing GUI manifest, npm workspace script and original Node path validator. No second test entry, duplicate file allowlist, new selector or CI policy.

## What Changed
Route registered GUI files to workspace-relative Vitest arguments; preserve native Node tests even under packages/gui/test. Accept registered TSX and reject unknown Vitest paths. Reuse the existing path validator for all non-GUI selections.

## Gate Harvest / 门收割
Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
Production +28/-1. Existing dispatch selection is extended; no parallel isolation mechanism.

## Machine-Readable Declarations
No dependencies, version, event fixtures or CI/gate changes.

## Task And Scope
- Harness task: task_5846b1b6b4bdd2c7f9468b902b.
- Branch: codex/gui-isolated-runner.
- Public scope: tools/dispatch-isolated-test.mjs and its existing test.
- Private planning/evidence updated: yes.
- Out of scope: new GUI tests, GUI implementation, runner policy, source allowlist, workflows and quarantine.

## Version Impact
No version change or publish.

## Governance Declaration
- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: not applicable
- Machine-check boundary: source scope and semantics still require review.
- Break-glass: no

## Verification
Base c4330a85d06ed3a650965b26cb86d0aad49edc48. Ubuntu exact dispatcher contract file15/15 passed; actual first-run-guide.vitest.tsx selected exactly one file and one test and passed. Earlier worker also ran a registered .vitest.ts file successfully. New regression failed the first candidate on an existing native GUI Node test; corrected route preserves it and accepts registered TSX. POSIX/PowerShell command construction is covered. Changed-source ESLint and git diff --check passed. No full check:local or real Windows execution claim. GitHub CI pending.

## Review Evidence
Root found the initial candidate rejected native GUI tests and omitted TSX; fixed both and removed duplicated validator logic. Root reviewed the final routing and observed the named Ubuntu runs. Worker counts alone were not accepted as final proof.

## Residual Risk
Windows command construction is tested, but no Windows host execution was run for this change. GUI manifest membership remains the execution authority; this does not change repository naming conventions or add new test files.

## References
Task reports retain worker evidence and CEO red/green correction. No private data in public diff.

---

# 中文

## 概要
让现有隔离测试入口支持已登记的 GUI Vitest 单文件。此前所有 --file 都交给 Node runner，GUI 文件无法走规定的隔离入口。

## 架构辩护
复用现有 GUI manifest、npm workspace 测试脚本和 Node 路径校验器。不新增测试入口、名单、选项或 CI 规则。

## 改动内容
已登记 GUI 文件转成 workspace 相对参数；GUI 目录里的原生 Node 测试仍走原 runner；支持已登记 TSX、拒绝未知 Vitest 路径；其余路径沿用原校验。

## 门收割 / Gate Harvest
生产 +28/-1，扩展既有选择逻辑，无第二套隔离机制。机读声明仅在英文块出现。

## 机读声明说明
不改依赖、版本、事件 fixture 或 CI/gate。

## 任务与范围
Task task_5846b1b6b4bdd2c7f9468b902b；分支 codex/gui-isolated-runner；只改 dispatcher 和已有测试。私有证据已更新，不含新 GUI 测试文件、实现、源同步名单或工作流。

## 版本影响
不改版本，不发布。

## 治理声明
不触碰保护面，无 break-glass；语义仍需评审。

## 验证
基准 c4330a85。Ubuntu dispatcher 契约15/15通过；实际 first-run-guide.vitest.tsx 只选中1文件/1测试并通过。worker此前也验证了现有.vitest.ts文件。新增负控使初稿因错误拒绝原生GUI Node测试而失败；修正后原路保留且TSX通过。POSIX/PowerShell参数构造已测，改动面ESLint和差异检查通过；未跑全量check:local或Windows实机，GitHub CI待跑。

## 审查证据
主控发现初稿误拒绝原生GUI测试、漏TSX，修正并删除重复路径校验。最终路由和Ubuntu输出已亲核，不把worker计数直接当最终证据。

## 残余风险
Windows仅验证参数构造，未实机执行。GUI manifest仍为登记权威，不改变现有测试命名规则，也不新增测试文件。

## 关联材料
任务报告保留worker结果和主控红绿修正，公共diff无私有数据。
