### PR TITLE
fix(gui): clarify card hover and close preview on backdrop click

### DIFF
--- a/packages/gui/src/renderer/components/TaskPreviewDrawer.tsx
+++ b/packages/gui/src/renderer/components/TaskPreviewDrawer.tsx
@@ -63,7 +63,13 @@ export function TaskPreviewDrawer({
   const orderedEvents = [...(task.events ?? [])].sort((a, b) => b.at.localeCompare(a.at));
 
   return (
-    <div className="fixed inset-0 z-40 flex justify-end bg-bg/45">
+    <div
+      data-testid="task-preview-backdrop"
+      className="fixed inset-0 z-40 flex justify-end bg-bg/45"
+      onClick={(event) => {
+        if (event.target === event.currentTarget) onClose();
+      }}
+    >
       <aside className="flex h-full w-full max-w-[520px] flex-col border-l border-border-strong bg-surface shadow-2xl shadow-black/40">
         <header className="border-b border-border px-4 py-3">
           <div className="flex items-start gap-3">

--- a/packages/gui/src/renderer/views/BoardView.tsx
+++ b/packages/gui/src/renderer/views/BoardView.tsx
@@ -91,7 +91,7 @@ const Card = memo(function Card({
       title={taskControlHint(task)}
       className={`group relative cursor-pointer rounded-lg bg-surface-raised p-2.5 ${freshnessBorder(
         task.freshness,
-      )} ${archived ? "opacity-50" : ""} ${dragging ? "shadow-lg" : "hover:border-border-strong"} ${isFavorite ? "ring-1 ring-accent/40" : ""}`}
+      )} ${archived ? "opacity-50" : ""} ${dragging ? "shadow-lg" : "hover:border-accent hover:ring-1 hover:ring-accent/50"} ${isFavorite ? "ring-1 ring-accent/40" : ""}`}
     >
       <div className="flex items-center gap-2">
         <EngineBadge engine={task.engine} locked={external} />

--- a/packages/gui/test/taskFilters.vitest.ts
+++ b/packages/gui/test/taskFilters.vitest.ts
@@ -5,6 +5,7 @@ import { createRoot, type Root } from "react-dom/client";
 import { renderToStaticMarkup } from "react-dom/server";
 import type { RelationEdge, SnapshotStatus, TaskRow } from "../src/renderer/model/types.ts";
 import { BOARD_COLUMNS } from "../src/renderer/model/types.ts";
+import { TaskPreviewDrawer } from "../src/renderer/components/TaskPreviewDrawer.tsx";
 import { BoardView } from "../src/renderer/views/BoardView.tsx";
 import { SwimlaneBoard } from "../src/renderer/views/SwimlaneBoard.tsx";
 import {
@@ -924,7 +925,13 @@ describe("draggable narrowing (W9)", () => {
     act(() => {
       doneCard!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
     });
-    expect(selected).toEqual(["t_done"]); // 点击行为不变。
+    expect(selected).toEqual(["t_done"]);
+    act(() => {
+      doneCard!.querySelector("p")!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      doneCard!.firstElementChild!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      doneCard!.lastElementChild!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    expect(selected).toEqual(["t_done", "t_done", "t_done", "t_done"]);
     act(() => {
       root.unmount();
     });
@@ -1515,5 +1522,44 @@ describe("swimlane column resize (W11)", () => {
       root.unmount();
     });
     container.remove();
+  });
+});
+
+describe("task preview dismissal", () => {
+  it("closes on backdrop click but keeps drawer contents and pin independent", async () => {
+    const onClose = vi.fn(),
+      onSetPin = vi.fn();
+    const task = makeTask();
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    try {
+      await act(async () =>
+        root.render(
+          createElement(TaskPreviewDrawer, {
+            task,
+            tasks: [task],
+            relations: [],
+            onClose,
+            onOpenDetail: noop,
+            onPreviewTask: noop,
+            onSetPin,
+          }),
+        ),
+      );
+      const backdrop = container.firstElementChild as HTMLElement;
+      act(() => (container.querySelector("aside h2") as HTMLElement).click());
+      expect(onClose).not.toHaveBeenCalled();
+      act(() => (container.querySelector('[data-testid="task-preview-pin-toggle"]') as HTMLElement).click());
+      expect(onSetPin).toHaveBeenCalledWith(task, true);
+      expect(onClose).not.toHaveBeenCalled();
+      act(() => backdrop.click());
+      expect(onClose).toHaveBeenCalledTimes(1);
+      act(() => window.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" })));
+      expect(onClose).toHaveBeenCalledTimes(2);
+    } finally {
+      act(() => root.unmount());
+      container.remove();
+    }
   });
 });


### PR DESCRIPTION
# English

## Summary
Make board card clicks easier to understand: show an accent edge on hover and dismiss task previews when clicking the backdrop. Keep clicks inside the drawer open.

## Architectural Justification
Use the existing card CSS and drawer event boundary. No new state, request, cache, dependency or event-routing layer is needed.

## What Changed
Card hover now uses an accent border and a one-pixel ring without changing layout. The existing full-card click handler remains the single preview entry; pin and favorite keep their independent actions. Backdrop clicks close the drawer only when the clicked target is the backdrop itself. Existing Escape dismissal remains available.

## Gate Harvest / 门收割
Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
Production +8/-2. Replace the weak hover color and previously inert backdrop in place; no retained alternative path.

## Task And Scope
- Harness task: task_fb6938c88cd483ab2af9ed06fe.
- Branch: codex/gui-drawer-interaction.
- Scope: BoardView, TaskPreviewDrawer and existing taskFilters tests.
- Private planning and verification evidence updated.
- Out of scope: proving or fixing the separately reported latency across different cards.

## Version Impact
No version change or publication.

## Governance Declaration
- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: not applicable
- Machine-check boundary: declarations do not replace behavior verification.
- Break-glass: no

## Verification
Based on main 8d52691f747f80a0aad7322663af5ba1b4e992bb, which includes W10 windowing. Actual Ubuntu taskFilters regression first failed backdrop dismissal (57 passed, one failed); the changed implementation passes all 58. Typecheck, scoped ESLint and diff check pass. Renderer and preload builds pass after installing the declared dependencies in the isolated checkout. Root inspected a real Electron hover screenshot and exercised edge/title clicks, inside-drawer clicks and outside-backdrop dismissal. Existing pin/favorite and keyboard tests pass. GitHub CI is pending. No broad performance improvement is claimed.

## Review Evidence
Root inspected the actual rendered accent edge and verified that inside clicks do not trigger dismissal. Tests cover card title/header/badge propagation and independent controls. The performance investigation found expensive automation locator resolution; those seconds are excluded from product latency claims. No external human review claimed.

## Residual Risk
Perceived latency during different-card navigation remains under investigation. The screenshot was taken during initial pagination and is visual interaction evidence only. This change preserves existing drag handling; exhaustive drag permutations were not rerun.

## References
Task task_fb6938c88cd483ab2af9ed06fe; prerequisite PR #2382.

---

# 中文

## 概要
明确看板卡片的可点击反馈：悬停时高亮边缘，点击预览抽屉外的遮罩关闭抽屉；抽屉内部点击保持打开。

## 架构辩护
直接修改现有卡片样式和抽屉事件边界，不新增状态、请求、缓存、依赖或事件转发层。

## 改动内容
卡片悬停改为强调色边框和一像素光圈，不改变尺寸。现有整卡点击仍是打开预览的入口，pin和收藏保持独立动作。遮罩仅在点击目标等于自身时关闭，内部内容不会误关；保留Escape关闭。

## 门收割 / Gate Harvest
生产代码新增8行、删除2行，原地替换弱悬停颜色与无响应遮罩，不保留另一条生产路径。

## 任务与范围
任务task_fb6938c88cd483ab2af9ed06fe，分支codex/gui-drawer-interaction。范围为BoardView、TaskPreviewDrawer和已有taskFilters测试；私有计划与验收证据已更新。不同卡片切换时的卡顿另行调查，不在本PR中冒称修复。

## 版本影响
不改版本，不发布。

## 治理声明
不触碰保护面，不使用break-glass。声明不能替代行为验收。

## 验证
基于已包含W10的main 8d52691f747f80a0aad7322663af5ba1b4e992bb。实际Ubuntu回归先得到57通过、遮罩关闭1失败，修复后58项全部通过。类型检查、定向ESLint和差异检查通过；隔离目录安装声明依赖后，前端和preload构建通过。主控查看真实Electron的悬停截图，验证卡片边缘与标题点击、抽屉内部不关闭、外部遮罩关闭。现有pin、收藏和键盘测试通过，GitHub CI待运行。不宣称全面性能改善。

## 审查证据
主控查看实际强调色边缘，验证内部点击不会触发关闭。测试覆盖标题、头部和徽章区域点击冒泡，以及独立按钮行为。性能调查发现自动化定位器解析耗时较大，该时间不计为产品延迟。不冒称外部人工评审。

## 残余风险
切换不同卡片时的主观延迟继续调查。截图发生在初始分页期间，仅证明视觉与交互，不作为性能基准。保留现有拖拽处理，未重跑所有拖拽排列。

## 关联材料
任务task_fb6938c88cd483ab2af9ed06fe；前置PR #2382。
