### PR TITLE
fix: attribute command usage through unique RPC ownership

### DIFF
--- a/tools/logs/cli-usage-audit.mjs
+++ b/tools/logs/cli-usage-audit.mjs
@@ -105,20 +105,20 @@ export function auditCliUsage({
   const firstObservedAt = sorted[0]?.atMs ?? null;
   const lastObservedAt = sorted.at(-1)?.atMs ?? null;
   const windows = [7, 30].map((days) => buildWindow(days, sorted, nowMs));
-  const usageByCommand = new Map();
-  for (const record of sorted) {
-    const command = record.command ?? "<unknown>";
-    usageByCommand.set(command, (usageByCommand.get(command) ?? 0) + 1);
-  }
+  const attribution = attributeRequests(sorted, commands);
   const failures = buildFailureFamilies(sorted, commands, slowMs, receipts, events);
   const slowCalls = summarizeSlowCalls(sorted, slowMs);
-  const observedIds = new Set([...usageByCommand.keys()]);
+  const observedIds = new Set(attribution.observedIds);
   const denominator = commands.map((command) => {
-    const count = usageByCommand.get(command.id) ?? usageByCommand.get(command.actionKind) ?? 0;
+    const counts = attribution.byCommand.get(command.id) ?? { direct: 0, uniqueMethod: 0, shared: 0 };
+    const count = counts.direct + counts.uniqueMethod;
     return {
       ...command,
       observedRequests: count,
-      status: count > 0 ? "observed" : "unobserved-needs-review",
+      directObservedRequests: counts.direct,
+      uniqueMethodObservedRequests: counts.uniqueMethod,
+      sharedMethodObservedRequests: counts.shared,
+      status: count > 0 ? "observed" : counts.shared > 0 ? "unattributed-shared-method" : "unobserved-needs-review",
       retirementDisposition: count > 0 ? "retain-observed" : "needs-human-review",
     };
   });
@@ -140,6 +140,12 @@ export function auditCliUsage({
       requestCount: sorted.length,
       uniqueCommands: observedIds.size,
       sourceAttribution,
+      methodAttribution: {
+        uniqueMethodRequests: attribution.uniqueMethodRequests,
+        sharedMethodRequests: attribution.sharedMethodRequests,
+        unattributedMethodRequests: attribution.sharedMethodRequests,
+        note: "shared RPC methods are evidence of traffic but cannot be assigned to a command descriptor",
+      },
       retentionWindowMs: firstObservedAt === null ? 0 : Math.max(0, lastObservedAt - firstObservedAt),
       retentionWindowDays:
         firstObservedAt === null ? 0 : Math.round(((lastObservedAt - firstObservedAt) / DAY_MS) * 100) / 100,
@@ -162,7 +168,7 @@ export function auditCliUsage({
     denominator,
     failures,
     zeroObservation: denominator
-      .filter((row) => row.observedRequests === 0)
+      .filter((row) => row.observedRequests === 0 && row.sharedMethodObservedRequests === 0)
       .map((row) => ({
         id: row.id,
         usage: row.usage,
@@ -177,6 +183,57 @@ export function auditCliUsage({
     },
     slowCalls,
   };
+}
+
+function attributeRequests(records, commands) {
+  const byCommand = new Map();
+  const ownersByMethod = new Map();
+  for (const command of commands) {
+    const identities = new Set([command.id, command.actionKind].filter(Boolean));
+    for (const identity of identities) {
+      const counts = byCommand.get(identity) ?? { direct: 0, uniqueMethod: 0, shared: 0 };
+      byCommand.set(identity, counts);
+    }
+    if (command.method) {
+      const owners = ownersByMethod.get(command.method) ?? [];
+      owners.push(command);
+      ownersByMethod.set(command.method, owners);
+    }
+  }
+  const observedIds = new Set();
+  let uniqueMethodRequests = 0;
+  let sharedMethodRequests = 0;
+  for (const record of records) {
+    const directMatches = commands.filter((command) =>
+      [command.id, command.actionKind].filter(Boolean).includes(record.command),
+    );
+    if (directMatches.length) {
+      for (const command of directMatches) {
+        const counts = byCommand.get(command.id) ?? { direct: 0, uniqueMethod: 0, shared: 0 };
+        counts.direct += 1;
+        byCommand.set(command.id, counts);
+        observedIds.add(command.id);
+      }
+      continue;
+    }
+    const owners = record.method ? (ownersByMethod.get(record.method) ?? []) : [];
+    if (owners.length === 1) {
+      const command = owners[0];
+      const counts = byCommand.get(command.id) ?? { direct: 0, uniqueMethod: 0, shared: 0 };
+      counts.uniqueMethod += 1;
+      byCommand.set(command.id, counts);
+      observedIds.add(command.id);
+      uniqueMethodRequests += 1;
+    } else if (owners.length > 1) {
+      sharedMethodRequests += 1;
+      for (const command of owners) {
+        const counts = byCommand.get(command.id) ?? { direct: 0, uniqueMethod: 0, shared: 0 };
+        counts.shared += 1;
+        byCommand.set(command.id, counts);
+      }
+    }
+  }
+  return { byCommand, observedIds, uniqueMethodRequests, sharedMethodRequests };
 }
 
 function buildWindow(days, records, nowMs) {

--- a/tools/logs/cli-usage-audit.test.mjs
+++ b/tools/logs/cli-usage-audit.test.mjs
@@ -28,6 +28,8 @@ const row = (at, commandName, overrides = {}) => ({
   ...overrides,
 });
 
+const descriptor = (id, method) => ({ id, actionKind: id, method, usage: `ha ${id}`, testCoverage: "unmeasured" });
+
 test("audit keeps the descriptor denominator and refuses to call mixed request logs CLI usage", () => {
   const now = Date.parse("2026-09-08T00:00:00.000Z");
   const report = auditCliUsage({
@@ -43,6 +45,76 @@ test("audit keeps the descriptor denominator and refuses to call mixed request l
   assert.equal(report.denominator.find((item) => item.id === "write").status, "unobserved-needs-review");
   assert.equal(report.windows[0].requestCount, 1);
   assert.equal(report.windows[1].requestCount, 1);
+});
+
+test("a uniquely owned RPC method observes its command descriptor", () => {
+  const report = auditCliUsage({
+    commands: [descriptor("agenda", "repo.agenda.read")],
+    requestRecords: [row("2026-09-07T00:00:00.000Z", undefined, { method: "repo.agenda.read" })],
+    nowMs: Date.parse("2026-09-08T00:00:00.000Z"),
+  });
+  assert.equal(report.denominator[0].observedRequests, 1);
+  assert.equal(report.denominator[0].directObservedRequests, 0);
+  assert.equal(report.denominator[0].uniqueMethodObservedRequests, 1);
+  assert.equal(report.observation.methodAttribution.uniqueMethodRequests, 1);
+});
+
+test("shared RPC traffic remains unattributed instead of observing every alias", () => {
+  const report = auditCliUsage({
+    commands: [
+      descriptor("runtime-batch", "repo.agentRuntime.spawn"),
+      descriptor("runtime-run", "repo.agentRuntime.spawn"),
+    ],
+    requestRecords: [row("2026-09-07T00:00:00.000Z", undefined, { method: "repo.agentRuntime.spawn" })],
+    nowMs: Date.parse("2026-09-08T00:00:00.000Z"),
+  });
+  assert.deepEqual(
+    report.denominator.map((item) => item.observedRequests),
+    [0, 0],
+  );
+  assert.deepEqual(
+    report.denominator.map((item) => item.sharedMethodObservedRequests),
+    [1, 1],
+  );
+  assert.equal(report.observation.methodAttribution.sharedMethodRequests, 1);
+  assert.deepEqual(
+    report.denominator.map((item) => item.status),
+    ["unattributed-shared-method", "unattributed-shared-method"],
+  );
+  assert.equal(report.zeroObservation.length, 0);
+});
+
+test("a direct identity and its matching unique method count one request once", () => {
+  const report = auditCliUsage({
+    commands: [descriptor("agenda", "repo.agenda.read")],
+    requestRecords: [row("2026-09-07T00:00:00.000Z", "agenda", { method: "repo.agenda.read" })],
+    nowMs: Date.parse("2026-09-08T00:00:00.000Z"),
+  });
+  assert.equal(report.denominator[0].observedRequests, 1);
+  assert.equal(report.denominator[0].directObservedRequests, 1);
+  assert.equal(report.denominator[0].uniqueMethodObservedRequests, 0);
+});
+
+test("distinct direct and unique-method records both count", () => {
+  const report = auditCliUsage({
+    commands: [descriptor("agenda", "repo.agenda.read")],
+    requestRecords: [
+      row("2026-09-07T00:00:00.000Z", "agenda"),
+      row("2026-09-07T00:00:01.000Z", undefined, { method: "repo.agenda.read" }),
+    ],
+    nowMs: Date.parse("2026-09-08T00:00:00.000Z"),
+  });
+  assert.equal(report.denominator[0].observedRequests, 2);
+});
+
+test("a genuinely unobserved descriptor remains a zero-observation candidate", () => {
+  const report = auditCliUsage({
+    commands: [descriptor("never-used", "repo.never.used")],
+    requestRecords: [],
+    nowMs: Date.parse("2026-09-08T00:00:00.000Z"),
+  });
+  assert.equal(report.denominator[0].observedRequests, 0);
+  assert.equal(report.zeroObservation[0].id, "never-used");
 });
 
 test("failure families only deduplicate repeated non-null opIds", () => {


### PR DESCRIPTION
# English

## Summary
Count requests with a uniquely owned RPC method toward the owning command descriptor. Shared RPC methods remain explicitly unattributed instead of being mislabeled as zero usage.

## Architectural Justification
Keep the existing audit and request logs. Resolve ownership from the current command descriptor catalog; no new telemetry, command registry or data source.

## What Changed
Prefer direct command identity when present. Otherwise attribute unique RPC ownership once; record shared-method traffic separately for each possible owner and exclude those descriptors from zero-observation recommendations. Distinct direct and method-only records both count. Preserve unknown CLI/GUI source attribution and existing failure-family behavior.

## Gate Harvest / 门收割
Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
Production +66/-9. Replace the old id/action-only usage lookup in place.

## Task And Scope
- Task: task_84144d0b202214575f3cf1f39c.
- Branch: codex/cli-usage-mapping.
- Scope: tools/logs/cli-usage-audit.mjs and its existing test.
- Private evidence updated; historical daily report remains unchanged.

## Version Impact
No version or publish changes.

## Governance Declaration
- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: not applicable
- Machine-check boundary: declarations do not replace behavior review.
- Break-glass: no

## Verification
Worker reported actual Ubuntu isolated 11/11. Root read the attribution implementation and ran the same 11 tests, then merged current main and reran them successfully. Tests distinguish unique RPC ownership, shared-method ambiguity, single-request double counting, distinct records, true zero observations and mixed-source logs. Diff check passes. Required GitHub CI pending.

## Review Evidence
Root checked caller fields against request loading and confirmed that source provenance is still unknown unless explicitly logged. No command was removed based on this report. This fixes the audit instrument before it is used for retirement decisions; current consumers and recovery value still need separate assessment.

## Residual Risk
Shared RPC traffic cannot identify the specific command, and request logs do not reliably distinguish CLI from GUI. Neither ambiguity is treated as proof of disuse. Existing daily snapshot was not regenerated or overwritten.

## References
Task task_84144d0b202214575f3cf1f39c and parent usage audit task_0cc28139cf6f29f0ad6b962b3a.

---

# 中文

## 概要
把唯一归属于某个命令的RPC请求计入该命令。共享RPC的调用明确标为无法归属，避免误判为零使用。

## 架构辩护
复用现有审计、请求日志和命令声明目录，不新增遥测、注册表或数据源。

## 改动内容
请求有直接命令身份时优先按身份归属；否则唯一RPC归属只计一次。共享RPC流量单独记录，不进入零观察候选。同一请求同时具备命令身份和method不重复计算，不同记录则分别累计。保留CLI/GUI来源未知的事实和现有失败分组行为。

## 门收割 / Gate Harvest
生产新增66行、删除9行，原地替换只匹配id/action的旧统计，没有保留第二套实现。

## 任务与范围
任务task_84144d0b202214575f3cf1f39c，分支codex/cli-usage-mapping。修改审计工具及已有测试，私有证据已更新；保留既有每日快照。

## 版本影响
不改版本，不发布。

## 治理声明
不触碰保护面，无break-glass；声明不能替代行为验证。

## 验证
Worker实际Ubuntu隔离测试11/11。主控阅读实现并跑同一组11项测试，合并当前main后再次通过。测试区分唯一RPC、共享RPC歧义、单次请求重复计数、不同记录累计、真正零观察和混合来源。差异检查通过，GitHub CI待运行。

## 审查证据
主控核对日志读取保留的字段和归属路径，确认没有日志来源就不能自称纯CLI使用量。没有根据本次结果删除命令。先修审计工具，再结合实际消费者和恢复场景评估退役。

## 残余风险
共享RPC不能还原具体命令，日志也不能可靠区分CLI和GUI；这些歧义均不当作无用的证据。没有重复运行、覆盖既有每日快照。

## 关联材料
子任务task_84144d0b202214575f3cf1f39c；父审计任务task_0cc28139cf6f29f0ad6b962b3a。
