### PR TITLE
fix: reject explicit doc conflicts before partial publication

### DIFF
--- a/packages/cli/test/cli-lifecycle-user-journey-stress.integration.test.ts
+++ b/packages/cli/test/cli-lifecycle-user-journey-stress.integration.test.ts
@@ -479,6 +479,21 @@ test("a locally edited task plan becomes a CLI doc conflict that the conflict co
     assert.equal(unresolved[0]?.requiredRoute, "local-conflict-resolution", blockedSync.stdout);
     assert.match(unresolved[0]?.reason ?? "", /local conflict scratch requires resolution/u, blockedSync.stdout);
     assert.match(String(blockedReceipt.summary ?? ""), /\tconflict\t/u, blockedSync.stdout);
+    const siblingPath = path.join(packageRoot, "closeout.md"),
+      siblingLogical = packagePathFor(packagePath, "closeout.md"),
+      siblingBefore = readFileSync(siblingPath, "utf8");
+    writeFileSync(siblingPath, `${siblingBefore}\nLocal sibling change must not hide a selected conflict.\n`);
+    const mixed = await runResult(
+      fixture,
+      ["doc", "sync", "--submit", "--path", planLogical, "--path", siblingLogical],
+      environment,
+    );
+    const mixedReceipt = JSON.parse(mixed.stdout) as Record<string, unknown>;
+    assert.notEqual(mixed.status, 0, mixed.stdout);
+    assert.equal(mixedReceipt.outcome, "op_rejected", mixed.stdout);
+    const siblingCanonical = await expectApplied(fixture, ["doc", "show", "--path", siblingLogical], environment);
+    assert.equal(siblingCanonical.evidence, siblingBefore);
+    writeFileSync(siblingPath, siblingBefore);
     // Recovery: merge the preserved prose onto the retitled base, then close the conflict by hand.
     writeFileSync(planPath, `${readFileSync(planPath, "utf8")}\n${drift}`);
     const resolved = await expectApplied(fixture, ["doc", "conflict", "resolve", conflictId], environment);

--- a/packages/cli/test/cli-lifecycle-user-journey-stress.integration.test.ts
+++ b/packages/cli/test/cli-lifecycle-user-journey-stress.integration.test.ts
@@ -463,8 +463,7 @@ test("a locally edited task plan becomes a CLI doc conflict that the conflict co
     assert.match(readFileSync(planPath, "utf8"), new RegExp(`^# ${renamed}$`, "mu"));
     const conflicted = await expectApplied(fixture, ["doc", "status", "--path", planLogical], environment);
     assert.equal(docScanRows(conflicted.evidence)[0]?.state, "conflict", String(conflicted.evidence));
-    // An explicit --path submit of the conflicted document is skipped, not rejected: exit 0 and no_changes,
-    // with the required recovery route carried only in detail.unresolvedTouches and the summary.
+    // An explicit --path submit of the conflicted document is rejected with a recovery route.
     const blockedSync = await runResult(fixture, ["doc", "sync", "--submit", "--path", planLogical], environment),
       blockedReceipt = JSON.parse(blockedSync.stdout) as Record<string, unknown>,
       unresolved =
@@ -473,9 +472,9 @@ test("a locally edited task plan becomes a CLI doc conflict that the conflict co
             | { readonly unresolvedTouches?: readonly { readonly reason?: string; readonly requiredRoute?: string }[] }
             | undefined
         )?.unresolvedTouches ?? [];
-    assert.equal(blockedSync.status, 0, blockedSync.stdout);
-    assert.equal(blockedReceipt.outcome, "no_changes", blockedSync.stdout);
-    assert.equal(blockedReceipt.status, "rejected", blockedSync.stdout);
+    assert.notEqual(blockedSync.status, 0, blockedSync.stdout);
+    assert.equal(blockedReceipt.outcome, "op_rejected", blockedSync.stdout);
+    assert.match(String(blockedReceipt.nextActions ?? ""), /ha doc conflict resolve [0-9a-f]{8}/u, blockedSync.stdout);
     assert.equal(unresolved.length, 1, blockedSync.stdout);
     assert.equal(unresolved[0]?.requiredRoute, "local-conflict-resolution", blockedSync.stdout);
     assert.match(unresolved[0]?.reason ?? "", /local conflict scratch requires resolution/u, blockedSync.stdout);

--- a/packages/daemon/src/doc-sync-command-actions.ts
+++ b/packages/daemon/src/doc-sync-command-actions.ts
@@ -142,6 +142,31 @@ export async function runDocAction(input: Input): Promise<WriteReceipt> {
     });
   }
   if (scan && !scan.rows.some((row) => row.state === "eligible")) {
+    const explicitSelection =
+      !Object.hasOwn(input.action, "taskId") && Array.isArray(input.action.paths) && input.action.paths.length > 0;
+    if (explicitSelection && scan.rows.some((row) => row.state === "conflict")) {
+      const rejection = rejectDocSyncAction(
+        `scan:${scan.baseLedgerSha.headDigest}`,
+        "preview_blocked",
+        scanDetail(input, scan, "preview_blocked"),
+      );
+      const conflictIds = scan.rows
+        .filter((row) => row.state === "conflict")
+        .flatMap((row) => row.conflicts)
+        .map((value) => /\.conflict-([0-9a-f]{8})\.(?:md|txt)$/u.exec(value)?.[1] ?? null)
+        .filter((value): value is string => value !== null);
+      return {
+        ...rejection,
+        nextActions: conflictIds.map((id) => `ha doc conflict resolve ${id}`),
+        summary: [
+          "doc-submit: op_rejected",
+          "skipped:",
+          ...scan.rows
+            .filter((row) => row.state === "conflict")
+            .map((row) => `${row.path}\t${row.state}\t${row.reason ?? "candidate is not eligible"}`),
+        ].join("\n"),
+      };
+    }
     const code = scanRejectionCode(scan),
       blocked = scanDetail(input, scan, code ?? "preview_blocked");
     return scan.rows.some((row) => row.state === "blocked" || row.state === "deletion")

--- a/packages/daemon/src/doc-sync-command-actions.ts
+++ b/packages/daemon/src/doc-sync-command-actions.ts
@@ -91,7 +91,7 @@ export function isDocAction(kind: string): boolean {
   );
 }
 
-export async function runDocAction(input: Input): Promise<WriteReceipt> {
+export async function runDocAction(input: Input): Promise<DocSettlementReceipt> {
   if (Buffer.byteLength(JSON.stringify(input.action)) > DOC_COMMAND_FRAME_MAX_BYTES)
     throw docSyncError("invalid_command", "doc command frame exceeds the descriptor-only limit");
   if (input.action.kind.startsWith("doc-conflict-")) return runLocalDocConflictExit(input);
@@ -141,9 +141,8 @@ export async function runDocAction(input: Input): Promise<WriteReceipt> {
       ].join("\n"),
     });
   }
-  if (scan && !scan.rows.some((row) => row.state === "eligible")) {
-    const explicitSelection =
-      !Object.hasOwn(input.action, "taskId") && Array.isArray(input.action.paths) && input.action.paths.length > 0;
+  if (scan) {
+    const explicitSelection = Array.isArray(input.action.paths) && input.action.paths.length > 0;
     if (explicitSelection && scan.rows.some((row) => row.state === "conflict")) {
       const rejection = rejectDocSyncAction(
         `scan:${scan.baseLedgerSha.headDigest}`,
@@ -167,6 +166,8 @@ export async function runDocAction(input: Input): Promise<WriteReceipt> {
         ].join("\n"),
       };
     }
+  }
+  if (scan && !scan.rows.some((row) => row.state === "eligible")) {
     const code = scanRejectionCode(scan),
       blocked = scanDetail(input, scan, code ?? "preview_blocked");
     return scan.rows.some((row) => row.state === "blocked" || row.state === "deletion")


### PR DESCRIPTION
# English

## Summary
Explicit document selections now reject unresolved conflicts before publication, including a selection containing both conflicted and eligible documents. The CLI exits nonzero and prints conflict-resolution commands.

## Architectural Justification
Use the existing scanner and rejected receipt. Evaluate the explicit-selection conflict before choosing the eligible subset, rather than adding rollback, retries or a second publication path.

## What Changed
Reject explicit paths containing a conflict and preserve their unresolved-touch details. Return the existing conflict IDs as actionable next steps. Keep normal unchanged selections idempotent and allow a resolved conflict to submit successfully. Use the existing document settlement receipt type for its summary metadata.

## Gate Harvest / 门收割
Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
Production +27/-1. The check now happens before publication selection; no retained alternative write path.

## Task And Scope
- Task: task_c45875d54c80e675eab3793200.
- Branch: codex/doc-sync-conflict-result.
- Scope: daemon doc-sync-command-actions and the existing CLI lifecycle journey test.
- Private evidence updated. No change to Entity formats or canonical history.

## Version Impact
No version change or publish.

## Governance Declaration
- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: not applicable
- Machine-check boundary: declarations do not replace behavior verification.
- Break-glass: no

## Verification
Worker exact Ubuntu CLI journey 6/6 passed for the initial single-conflict fix. Root added a mixed-selection counterexample: the old candidate exited zero and failed the assertion. After moving conflict rejection ahead of eligible selection, all six actual Ubuntu lifecycle/recovery scenarios pass, including canonical readback showing the eligible sibling was not partly published. Scoped ESLint, full project typecheck and diff check pass. Latest main was merged normally; only the independent usage audit changed in that merge. GitHub CI pending.

## Review Evidence
Root found and corrected the initial candidate's guard, which only ran when no eligible document existed. Root also corrected the receipt return annotation after the actual project typecheck rejected summary metadata. This is an explicit-path conflict fix, not a claim that every ineligible candidate in a broad scan is an error.

## Residual Risk
Cross-platform and additional concurrency permutations were not rerun. The existing conflict scratch format and resolver remain authoritative; this change does not expand which document formats participate in conflict tracking.

## References
Task task_c45875d54c80e675eab3793200; original CLI recovery delivery PR #2379.

---

# 中文

## 概要
显式选择的文档包含未解决冲突时，在发布之前拒绝请求；同时选择冲突文件和可提交文件也不能误报成功。CLI以非零退出，并给出解决冲突的命令。

## 架构辩护
复用既有扫描器和拒绝回执，在筛选可提交子集之前检查显式选择的冲突，不新增回滚、重试或第二条发布路径。

## 改动内容
保留冲突详情并把已有冲突ID转换为下一步命令。未变更路径保持幂等，解决冲突后仍可成功提交。返回类型使用既有文档结算回执，准确容纳摘要字段。

## 门收割 / Gate Harvest
生产新增27行、删除1行，检查提前到发布选择前，没有保留另一条写路。

## 任务与范围
任务task_c45875d54c80e675eab3793200，分支codex/doc-sync-conflict-result。只修改daemon文档同步动作和已有CLI生命周期旅程测试；私有证据已更新，不改变Entity格式或历史事件。

## 版本影响
不改版本，不发布。

## 治理声明
不触碰保护面，无break-glass；声明不能替代行为验证。

## 验证
Worker初版单冲突修复的Ubuntu旅程6/6通过。主控补充混选反例，旧候选退出0导致断言失败；修复后六个真实CLI生命周期/恢复场景全部通过，独立读取canonical文档也证明可提交的旁项没有被部分发布。定向ESLint、完整项目类型检查和差异检查通过。普通merge同步最新main，该次合并仅含独立使用审计改动。GitHub CI待跑。

## 审查证据
主控发现初版只在不存在可提交文件时检查冲突，已修正；实际项目类型检查还暴露摘要字段与返回类型不一致，也已修正。本PR只针对明确选择路径的冲突，不把广域扫描里所有不可提交项一律当作错误。

## 残余风险
未重跑其他平台和额外并发排列。沿用既有冲突草稿格式与解决器，不扩展参与冲突跟踪的文档类型。

## 关联材料
任务task_c45875d54c80e675eab3793200；原CLI恢复交付PR #2379。
