### PR TITLE
fix: preserve writer fences across isolated GUI fixture seeders

### DIFF
--- a/tools/gui-e2e/lanes.mjs
+++ b/tools/gui-e2e/lanes.mjs
@@ -83,8 +83,8 @@ export async function openLane({ lane, workspaceRoot, env, runRoot, startDriver 
       daemonId: "g",
       repoId: "gui-e2e-catalog",
       task: { taskId: "task-gui-smoke", title: "Render the real triadic projection" },
-      beforeRestart: async (rootDir, repoId) => {
-        await seedTriadicEvents(rootDir, repoId);
+      beforeRestart: async (rootDir, repoId, writerFence) => {
+        await seedTriadicEvents(rootDir, repoId, writerFence);
         await seedGuiE2eRuntimeSessions(rootDir, repoId);
       },
     });

--- a/tools/gui-e2e/lanes.mjs
+++ b/tools/gui-e2e/lanes.mjs
@@ -85,7 +85,7 @@ export async function openLane({ lane, workspaceRoot, env, runRoot, startDriver 
       task: { taskId: "task-gui-smoke", title: "Render the real triadic projection" },
       beforeRestart: async (rootDir, repoId, writerFence) => {
         await seedTriadicEvents(rootDir, repoId, writerFence);
-        await seedGuiE2eRuntimeSessions(rootDir, repoId);
+        await seedGuiE2eRuntimeSessions(rootDir, repoId, writerFence);
       },
     });
   } finally {

--- a/tools/gui-e2e/scenarios/sessions-grouping.mjs
+++ b/tools/gui-e2e/scenarios/sessions-grouping.mjs
@@ -45,8 +45,8 @@ const definitionSnapshot = (instanceId, installationId) => ({
 });
 
 /** 夹具种子:在 daemon 停机窗口里追加 agent-runtime 事件(lanes.mjs 的 beforeRestart 调用)。 */
-export async function seedGuiE2eRuntimeSessions(rootDir, repoId) {
-  const store = makeTaskEventStore({ rootDir, repoId }),
+export async function seedGuiE2eRuntimeSessions(rootDir, repoId, writerFence) {
+  const store = makeTaskEventStore({ rootDir, repoId, writerFence: () => writerFence }),
     projection = makeTaskProjection({ rootDir, eventStore: store }),
     actor = { principal: { personId: "person-gui" }, executor: null },
     claim = (body) => {


### PR DESCRIPTION
# English

## Summary
Restore the isolated Electron fixture by carrying its resident writer fence through both triadic-event and runtime-session seeding. Both seeders now use the holder and epoch acquired by the fixture.

## Architectural Justification
Pass the existing fence through the existing callbacks. No new authority, retry, timeout or production fence exception is needed.

## What Changed
The lane forwards the third beforeRestart argument to both seeders. Runtime-session seeding passes that fence into its existing event store instead of silently using the default direct-store epoch. The old omitted-argument paths are replaced in place.

## Gate Harvest / 门收割
Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
Production +5/-5; net zero. No parallel implementation retained.

## Task And Scope
- Task: task_b0d5c68e422cf32e94ff866cc6.
- Branch: codex/gui-fixture-fence-public.
- Scope: tools/gui-e2e/lanes.mjs and scenarios/sessions-grouping.mjs.
- Private evidence updated; no Entity candidate code is included.

## Version Impact
No version change or publish.

## Governance Declaration
- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: not applicable
- Machine-check boundary: declarations do not replace behavior verification.
- Break-glass: no

## Verification
Root ran the actual isolated Electron sessions-grouping scenario on the main-based candidate: healthy. Restoring only these two files to origin/main reproduced writer epoch 1 belongs to another holder before the lane opened; restoring the candidate removes that rejection. Syntax checks, diff check and computed production-delta pass. GitHub CI pending.

## Review Evidence
The worker fixed triadic seeding only. Root ran the real lane, found runtime seeding still using a stale default epoch, and passed the same fixture-owned fence through the second caller. A separate Entity candidate now opens Electron and creates a Kind, then reaches outdated scenario selectors; those selectors are not included in this focused fix.

## Residual Risk
The Entity declared-kind scenario and the separate service-bridge settings-update regression remain incomplete. This PR restores fixture admission and verifies the sessions scenario; it does not claim all GUI acceptance scenarios pass.

## References
Task task_b0d5c68e422cf32e94ff866cc6 and parent Entity GUI task_c4cd247f16f90938ef2d99bb67.

---

# 中文

## 概要
修复隔离Electron夹具的writer epoch冲突：把resident fixture已取得的同一个fence传给三元事件和运行时会话两个播种步骤。

## 架构辩护
沿用现有fence和回调参数，不新增权限、重试、超时或生产侧保护例外。

## 改动内容
lane将beforeRestart第三个参数传给两个播种器；运行时会话播种用该fence打开既有事件存储，不再落回默认direct-store epoch。原遗漏参数的路径直接被替换。

## 门收割 / Gate Harvest
生产新增5行、删除5行，净增零，不保留平行实现。

## 任务与范围
任务task_b0d5c68e422cf32e94ff866cc6，分支codex/gui-fixture-fence-public。只修改lane和sessions-grouping播种函数，私有证据已更新，不夹带Entity候选实现。

## 版本影响
不改版本，不发布。

## 治理声明
不触碰保护面，无break-glass；声明不能替代真实行为验证。

## 验证
主控在main基准候选上运行真实隔离Electron的sessions-grouping场景，结果healthy。仅把两个源码文件还原为origin/main，即在窗口打开前复现writer epoch属于另一holder的拒绝；候选消除该拒绝。语法检查、差异检查与机算production-delta通过，GitHub CI待运行。

## 审查证据
Worker最初只修了三元事件播种；主控实际运行发现会话播种仍用旧默认epoch，已贯穿同一个fixture持有的fence。独立Entity候选现在能打开Electron并创建Kind，后续停在过时场景选择器；该选择器不混入本次修复。

## 残余风险
Entity声明Kind的完整界面场景和独立service-bridge settings-update失败仍未完成。本PR只证明夹具准入恢复及会话场景通过，不声称所有GUI验收都绿。

## 关联材料
任务task_b0d5c68e422cf32e94ff866cc6；父Entity GUI任务task_c4cd247f16f90938ef2d99bb67。
