### PR TITLE
test: allow sequential lease reacquisition in runtime batches

### DIFF
--- a/packages/cli/test/runtime-cli.integration.test.ts
+++ b/packages/cli/test/runtime-cli.integration.test.ts
@@ -1122,8 +1122,12 @@ test("real CLI runs, archives task-bound dispatches, resumes, waits through stat
     const taskBatchRows = batchRows.slice(1),
       successfulBatchRows = taskBatchRows.filter((row) => row.status === "succeeded"),
       rejectedTaskBatchRows = taskBatchRows.filter((row) => row.status === "rejected");
-    assert.equal(successfulBatchRows.length, 1, JSON.stringify(batch.receipt));
-    assert.equal(rejectedTaskBatchRows.length, 3, JSON.stringify(batch.receipt));
+    assert.ok(successfulBatchRows.length >= 1, JSON.stringify(batch.receipt));
+    assert.equal(
+      successfulBatchRows.length + rejectedTaskBatchRows.length,
+      taskBatchRows.length,
+      JSON.stringify(batch.receipt),
+    );
     assert.equal(
       rejectedTaskBatchRows.every((row) => row.code === "runtime_task_lease_required"),
       true,
@@ -1140,7 +1144,7 @@ test("real CLI runs, archives task-bound dispatches, resumes, waits through stat
       batchDispatches = (
         run(root, env, ["task", "dispatches", taskId]).dispatches as Array<Record<string, unknown>>
       ).filter((row) => batchDispatchIds.has(String(row.dispatchId)));
-    assert.equal(batchDispatches.length, 1);
+    assert.equal(batchDispatches.length, successfulBatchRows.length);
     assert.equal(
       batchDispatches.every(
         (row) => row.agentId === "terra" && row.delegatedByAgentId === "fable" && row.squadId === "core-squad",


### PR DESCRIPTION
# English

## Summary
The CLI batch integration test expects exactly one successful task-bound dispatch over the entire batch. A task lease can legitimately be released and acquired by a later queued request, so main failed when two sequential requests succeeded. Check exclusive concurrent ownership and complete accounting instead of a fixed lifetime success count.

## Architectural Justification
No production implementation change. Preserve the existing peak-holder assertion and all receipt/archive checks.

## What Changed
- Require at least one success and account for every task-bound row as succeeded or rejected.
- Match stored dispatch count to actual successful rows.
- Preserve peak active holders <=1, typed lease rejections, missing-agent rejection, attribution and archive checks.

## Gate Harvest / 门收割
Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production code delta: zero.

## Machine-Readable Declarations
No dependency, event format, workflow, timeout or gate-policy changes.

### Optional Evidence Claims
No performance claim or assertion that the independent Fleet failure is repaired.

## Task And Scope
- Maintainer-authorized main CI repair.
- Branch: codex/runtime-batch-lease-oracle.
- Public scope: packages/cli/test/runtime-cli.integration.test.ts only.
- Private planning/evidence updated: yes, excluded from public branch.
- Out of scope: Fleet SQLite lock and runtime production changes.

## Version Impact
No version change; test-only repair. No publish.

## Governance Declaration
- Protected surface touched: no
- Protected surface scope: none
- Authority: not applicable
- Machine-check boundary: reviewers assess this declaration.
- Break-glass: no

## Verification
- Baseline/merge-base: 3979487ffdc47badeb9fefd91f0e5dd1f571b714.
- Original failure: run34331181328, full-check26, runtime-cli.integration.test.ts:1125 reported actual2 expected1. Raw job assertion obtained directly from Actions job102399878511.
- Exact Ubuntu dispatcher runtime-cli.integration.test.ts passed (exit0); the CLI lifecycle test ran about77s. git diff --check passed.
- No full local suite, typecheck or production performance run claimed.
- Public PR CI pending.

## Review Evidence
Root inspected the complete scoped diff and confirmed the peak-holder, reason, attribution and archive assertions remain. No native subagents. The test must still fail if task-bound workers overlap; no retries or longer sleeps added.

## Residual Risk
The Fleet scale SQLite lock from the same main run remains independently investigated. A passing test here does not establish overall main health.

## References
- https://github.com/FairladyZ625/harness-anything/actions/runs/34331181328/job/102399878511
- packages/cli/test/runtime-cli.integration.test.ts

---

# 中文

## 概要
CLI 批派测试把整批成功数写死为1。Task租约释放后，后续排队请求可以合法取得租约，因此main出现实际成功2项、预期1项的失败。改为验证并发独占与完整结果记账。

## 架构辩护
不改生产实现；保留原有峰值持有者检查及全部回执和归档验证。

## 改动内容
- 至少一项成功，所有Task条目必须有成功或拒绝结果。
- 存储的dispatch数量与实际成功条目一致。
- 保留峰值持有者<=1、租约拒绝类型、不存在Agent拒绝、归属和归档检查。

## 门收割 / Gate Harvest
无生产路径、门禁或fixture删除；生产代码零改动。

## 机读声明说明
不改依赖、事件格式、workflow、超时或门禁策略，不声称修好了独立Fleet锁问题。

## 任务与范围
维护者已授权main修复。分支codex/runtime-batch-lease-oracle，仅修改既有CLI集成测试。私有计划和证据保留在私有工作区；Fleet与runtime生产改动不在本PR。

## 版本影响
仅测试，不改版本、不发布。

## 治理声明
未触碰protected surface，不使用break-glass，声明由reviewer核实。

## 验证
基线3979487ffdc47badeb9fefd91f0e5dd1f571b714。原始Actions job102399878511末尾断言明确actual2/expected1。Ubuntu隔离入口的runtime-cli.integration.test.ts通过、exit0，CLI生命周期测试约77秒；git diff --check通过。未跑完整本地套件，不声称类型或性能验证。公共CI待运行。

## 审查证据
Root核对完整diff，确认峰值、拒绝原因、归属及归档断言均保留；未使用原生子代理，未添加重试或延长等待。

## 残余风险
同一main run的Fleet SQLite锁仍独立处理，本测试通过不能代替main整体恢复。

## 关联材料
上述Actions原始job及packages/cli/test/runtime-cli.integration.test.ts。

## PR Gate Checklist / PR 门禁清单
- [x] Isolated worktree, scoped public diff, no private files or host paths.
- [x] Full bilingual sections and honest evidence boundaries.
- [x] No gate bypass, workflow or timeout changes.
- [ ] Required public CI green.
- [ ] Normal merge and branch/worktree cleanup after review and required checks.
