### PR TITLE
test: retain SQLite callsite when Fleet setup fails

### DIFF
--- a/packages/daemon/test/fleet-transport-scale.integration.test.ts
+++ b/packages/daemon/test/fleet-transport-scale.integration.test.ts
@@ -4,6 +4,7 @@ import { execFileSync, spawn } from "node:child_process";
 import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { hostname, tmpdir } from "node:os";
 import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
 import test, { type TestContext } from "node:test";
 import { fleetHostWriterOptions, fleetLedgerRevision } from "./fleet-store.fixture.ts";
 import { openSqliteEventStore } from "../../kernel/src/index.ts";
@@ -34,6 +35,33 @@ function reclaimer() {
 }
 
 test("production Fleet TLS entry sustains 3/10/32 Git-less edge processes across eight repos without duplicate writes", async (t) => {
+  // Remove this probe once the CI-only lock callsite has a causal regression test.
+  const originalExec = DatabaseSync.prototype.exec;
+  DatabaseSync.prototype.exec = function (sql: string): void {
+    try {
+      return originalExec.call(this, sql);
+    } catch (error) {
+      const failure = error as Error & { code?: string; errcode?: number; errstr?: string };
+      t.diagnostic(
+        `Fleet SQLite exec failure: ${JSON.stringify({
+          node: process.version,
+          code: failure.code,
+          errcode: failure.errcode,
+          errstr: failure.errstr,
+          message: failure.message,
+          statementKinds: sql
+            .split(";")
+            .map((statement) => statement.trim().split(/\s+/u)[0])
+            .filter(Boolean),
+          stack: failure.stack,
+        })}`,
+      );
+      throw error;
+    }
+  };
+  t.after(() => {
+    DatabaseSync.prototype.exec = originalExec;
+  });
   const fixture = await scaleFixture(t);
   t.after(() => fixture.close());
   const center = await fixture.center();

--- a/packages/kernel/src/store/sqlite-event-store.ts
+++ b/packages/kernel/src/store/sqlite-event-store.ts
@@ -166,12 +166,8 @@ function configureLedgerConnection(db: DatabaseSync, readOnly = false): void {
 }
 
 function isSqliteBusy(error: unknown): boolean {
-  if (typeof error !== "object" || error === null) return false;
-  const candidate = error as { readonly errcode?: unknown; readonly message?: unknown; readonly errstr?: unknown };
   return (
-    candidate.errcode === SQLITE_BUSY ||
-    candidate.errstr === "database is locked" ||
-    candidate.message === "database is locked"
+    typeof error === "object" && error !== null && (error as { readonly errcode?: unknown }).errcode === SQLITE_BUSY
   );
 }
 

--- a/packages/kernel/src/store/sqlite-event-store.ts
+++ b/packages/kernel/src/store/sqlite-event-store.ts
@@ -166,8 +166,12 @@ function configureLedgerConnection(db: DatabaseSync, readOnly = false): void {
 }
 
 function isSqliteBusy(error: unknown): boolean {
+  if (typeof error !== "object" || error === null) return false;
+  const candidate = error as { readonly errcode?: unknown; readonly message?: unknown; readonly errstr?: unknown };
   return (
-    typeof error === "object" && error !== null && (error as { readonly errcode?: unknown }).errcode === SQLITE_BUSY
+    candidate.errcode === SQLITE_BUSY ||
+    candidate.errstr === "database is locked" ||
+    candidate.message === "database is locked"
   );
 }
 


### PR DESCRIPTION
# English

## Summary
The Fleet scale test reports a SQLite lock through a sanitized doc-submit receipt, losing the native SQL callsite needed to distinguish connection initialization from an active transaction. Add a test-only exec failure diagnostic that preserves the original exception and all acceptance assertions.

## Architectural Justification
No production behavior change. The diagnostic is scoped to one test process and removed when a causal regression test replaces it.

## What Changed
- Report Node version, native error fields, statement kinds and stack only when SQLite exec fails.
- Restore the original prototype after the test. Keep the original throw and 3/10/32 edge waves.
- Do not log statement values or change retries, busy budgets, scale, workflow or thresholds.

## Gate Harvest / 门收割
Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Final production diff: zero. An unproved production candidate was reverted in this branch.

## Machine-Readable Declarations
No dependency, event-format or gate-policy changes.

### Optional Evidence Claims
No root-cause, performance or full-main-recovery claim.

## Task And Scope
- Maintainer-authorized main failure diagnosis.
- Branch: codex/fleet-scale-task-plan-lock.
- Public scope: packages/daemon/test/fleet-transport-scale.integration.test.ts.
- Private planning/evidence updated: yes, not published.
- Out of scope: speculative lock recovery or changing the database writer.

## Version Impact
No version change and no publish; test-only diagnostics.

## Governance Declaration
- Protected surface touched: no
- Protected surface scope: none
- Authority: not applicable
- Machine-check boundary: reviewers assess the declaration.
- Break-glass: no

## Verification
- Original baseline3979487ffdc47badeb9fefd91f0e5dd1f571b714; subsequent main PR2388 changes only an independent CLI test.
- Exact isolated Ubuntu Fleet test passed1/1 on Node26.8.1 both before and after diagnostic. Remote PATH selected a temporary official Node runtime, preserving the machine default. Host arm64 differs from CI x64.
- A direct Node26 lock probe returned errcode5; the earlier missing-errcode production hypothesis was not accepted.
- git diff --check passed. No full local suite or typecheck claimed; post-commit reported absent worktree TypeScript binary.
- Existing failure is real, but was not reproduced by these two isolated runs. PR CI pending.

## Review Evidence
Root inspected the final diff: no production changes, assertion or concurrency reductions. Native error is rethrown and probe cleanup is registered before fixture setup. The probe does not observe prepare/statement execution or other processes; it narrows exec failures only.

## Residual Risk
Fleet lock remains unresolved. The next matching CI failure may identify the exec callsite; if no probe message accompanies the rejection, inspect other SQLite calls rather than declaring success. Remove the probe once a causal regression test is established.

## References
- https://github.com/FairladyZ625/harness-anything/actions/runs/34331181328/job/102399878511
- packages/daemon/test/fleet-transport-scale.integration.test.ts

---

# 中文

## 概要
Fleet压测通过doc-submit回执报告SQLite锁错误，但回执没有原生SQL调用栈。增加仅限本测试的exec失败诊断，帮助区分连接初始化和事务内失败；原错误继续抛出，验收断言保持。

## 架构辩护
不改生产行为。诊断只影响独立测试进程，在建立因果回归后删除。

## 改动内容
失败时记录Node版本、原始错误字段、语句类别和调用栈，结束恢复原型。保持3/10/32波次、全部断言、重试和预算，不记录SQL值。

## 门收割 / Gate Harvest
最终生产diff为零，未经证实的生产候选已在分支内撤回；没有门禁或fixture删除。

## 机读声明说明
不改依赖、事件格式或门禁策略，不声明根因、性能或main整体恢复。

## 任务与范围
维护者已授权main诊断。分支codex/fleet-scale-task-plan-lock，只改既有Fleet集成测试；私有证据不公开。猜测性锁恢复与数据库writer变更不在范围内。

## 版本影响
不改版本、不发布。

## 治理声明
不触碰protected surface，不使用break-glass；声明由reviewer判断。

## 验证
基线3979487ffdc47badeb9fefd91f0e5dd1f571b714，后续main的PR2388仅修改独立CLI测试。真正Node26.8.1的Ubuntu隔离Fleet测试在诊断前后均1/1通过，临时PATH选择官方运行时，没有改默认Node。目标机arm64与CIx64仍有差异。直接锁探针返回errcode5，因此此前缺少errcode的生产假设未获接受。diff检查通过，未跑全量套件或声称类型检查；PR CI待运行。

## 审查证据
Root检查最终diff，无生产改动、断言或并发削减。原错误继续抛出，fixture启动前登记清理。此探针只覆盖本进程exec，不覆盖prepare/statement执行或其他进程。

## 残余风险
锁错误尚未修好。下次匹配CI失败可定位exec栈；如果仍无诊断，检查其他SQLite调用，不能据此宣布成功。有因果回归后删除探针。

## 关联材料
上述Actions原始job及Fleet测试文件。

## PR Gate Checklist / PR 门禁清单
- [x] Isolated scoped test change; no private data or absolute host paths.
- [x] Bilingual body and honest validation boundaries.
- [x] Original assertions, scale and errors preserved; no bypass.
- [ ] Required public CI passed.
- [ ] Normal merge and branch/worktree cleanup after checks and review.
