### PR TITLE
fix: preserve accepted receipt and Person state during publication

### DIFF
--- a/packages/daemon/src/person-action-runtime.ts
+++ b/packages/daemon/src/person-action-runtime.ts
@@ -47,8 +47,12 @@ export function makePersonActionRuntime(cell: RepoCellRuntimeContext): EntityAct
         throw cell.cellCodedError("revision_conflict", `Operation ${opId} belongs to a non-People event.`);
       return personReplayReceipt(cell.receiptForOperation(opId, binding), existing.payload.targetPersonId);
     }
+    const document = cell.projection.readDocument("people.yaml");
+    if (document.watermark !== document.sourceRevision)
+      throw cell.cellCodedError("content_not_ready", "People document projection is pending.");
     const peoplePath = path.join(resolveHarnessLayout(cell.rootDir).authoredRoot, "people.yaml"),
-      currentBody = existsSync(peoplePath) ? readFileSync(peoplePath, "utf8") : null,
+      // The authored seed is used only before the first canonical People document exists.
+      currentBody = document.document?.body ?? (existsSync(peoplePath) ? readFileSync(peoplePath, "utf8") : null),
       compile = contract.execution.compile;
     if (!compile) throw cell.cellCodedError("invalid_command", `${action.kind} has no Person event compiler.`);
     const compiled = compile({

--- a/packages/daemon/test/person-action.integration.test.ts
+++ b/packages/daemon/test/person-action.integration.test.ts
@@ -1,13 +1,13 @@
 // harness-test-tier: integration
 import assert from "node:assert/strict";
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
 import { makeTaskEventReader } from "../../kernel/src/index.ts";
 import { canonicalRoot, workspaceId } from "../src/protocol/daemon-protocol.contract.ts";
 import { parseDaemonGuiReadResult } from "../src/protocol/gui-result-validation.ts";
-import { openBootstrappedRepoCell as openRepoCell } from "./repo-settings.fixture.ts";
+import { openBootstrappedRepoCell as openRepoCell, waitForFixturePublication } from "./repo-settings.fixture.ts";
 import { initRepo } from "./migration-import.fixtures.ts";
 
 const explainMethod = "repo.entity.actions.explain" as const,
@@ -17,6 +17,7 @@ const explainMethod = "repo.entity.actions.explain" as const,
 test("Person Actions share catalog execution, exact refusal attribution, and explain parity", async () => {
   const root = mkdtempSync(path.join(tmpdir(), "ha-person-action-"));
   let cell: Awaited<ReturnType<typeof openRepoCell>> | undefined;
+  let holdMirror = false;
   try {
     initRepo(root);
     let now = "2026-09-01T01:00:00.000Z";
@@ -25,6 +26,10 @@ test("Person Actions share catalog execution, exact refusal attribution, and exp
       rootDir: canonicalRoot(root),
       ownerId: "person-action-test",
       now: () => now,
+      killpoint: (point) => {
+        if (holdMirror && point === "before_worktree_rename")
+          throw new Error("fixture holds the authored mirror behind acceptance");
+      },
     });
     const ownerBinding = { actor: ownerActor, source: "local" as const },
       added = await cell.run(
@@ -95,6 +100,10 @@ test("Person Actions share catalog execution, exact refusal attribution, and exp
     assert.match(ownerRemoval.nextActions?.[0] ?? "", /bootstrap creator person_zeyu cannot be removed/u);
     assert.equal(peopleEventCount(root), beforeOwnerRefusal);
 
+    await waitForFixturePublication(cell, added.opId, ownerBinding);
+    const peoplePath = path.join(root, "harness", "people.yaml");
+    const beforeDelegationBody = readFileSync(peoplePath, "utf8");
+    holdMirror = true;
     const delegated = await cell.run(
       {
         kind: "people-delegate",
@@ -107,6 +116,8 @@ test("Person Actions share catalog execution, exact refusal attribution, and exp
       ownerBinding,
     );
     assert.equal(delegated.outcome, "applied", JSON.stringify(delegated));
+    // A lagging physical mirror must not erase an already accepted delegation from command validation.
+    writeFileSync(peoplePath, beforeDelegationBody);
     now = "2026-09-01T01:30:00.000Z";
     const beforeRevokeRefusal = peopleEventCount(root),
       aliceBinding = {
@@ -133,6 +144,7 @@ test("Person Actions share catalog execution, exact refusal attribution, and exp
     assert.match(foreignRevoke.nextActions?.[0] ?? "", /Only DelegatedExecutionToken issuer person_zeyu/u);
     assert.equal(peopleEventCount(root), beforeRevokeRefusal);
   } finally {
+    holdMirror = false;
     await cell?.close();
     rmSync(root, { recursive: true, force: true });
   }

--- a/packages/kernel/src/composition/receipt-acceptance.ts
+++ b/packages/kernel/src/composition/receipt-acceptance.ts
@@ -62,9 +62,9 @@ export function attachReceiptAcceptance<R extends WriteReceiptDraft>(
   const { repoId, revision, headDigest } = store.publication(event).cut;
   const acceptedCut: ReceiptConsumerCut = { repoId, revision, headDigest, generation: 1 };
   const follower = store.followerStatus();
-  const facet = (value: typeof follower.worktree): ReceiptFacet => ({
-    state: value.status,
-    cut: value.cut ? { ...value.cut, generation: 1 } : null,
+  const facet = (value: typeof follower.worktree, coversAcceptance: boolean): ReceiptFacet => ({
+    state: value.status === "verified" && !coversAcceptance ? "pending" : value.status,
+    cut: coversAcceptance && value.cut ? { ...value.cut, generation: 1 } : null,
     ...(value.reason ? { reason: value.reason } : {}),
   });
   const gitCoversAcceptance =
@@ -95,8 +95,11 @@ export function attachReceiptAcceptance<R extends WriteReceiptDraft>(
       cut: acceptedCut,
     },
     projection: { state: visible ? "verified" : "pending", cut: visible ? acceptedCut : null },
-    git: { ...facet(follower.git), commitSha: follower.git.commitSha },
-    worktree: facet(follower.worktree),
+    git: {
+      ...facet(follower.git, gitCoversAcceptance),
+      commitSha: gitCoversAcceptance ? follower.git.commitSha : null,
+    },
+    worktree: facet(follower.worktree, worktreeCoversAcceptance),
     replica: empty.replica,
     outcome: receipt.outcome === "no_changes" ? "no_changes" : visible ? "applied" : "pending",
     revision: outcome.lastRevision,

--- a/packages/kernel/src/store/sqlite-task-event-store.ts
+++ b/packages/kernel/src/store/sqlite-task-event-store.ts
@@ -230,14 +230,20 @@ export function makeSqliteTaskEventStore(options: SqliteTaskEventStoreOptions): 
       for (const [logical, baseline] of acceptedBaseline) acceptedWorktree.set(logical, baseline);
     try {
       options.killpoint?.("after_sqlite_commit");
-      follower = pendingFollower("Git follower has not verified the accepted ledger cut");
+      // Acceptance advances the ledger head, not the already verified follower prefix.
       scheduleFollower();
       options.killpoint?.("before_response_write");
       const receipt: CanonicalEventAppendReceipt = {
         status: "applied",
         event: bundle.event,
         revision: bundle.event.workspaceRevision,
-        commitSha: follower.git.commitSha ? ledgerCommitSha(options.repoId, follower.git.commitSha) : null,
+        commitSha:
+          follower.git.status === "verified" &&
+          follower.git.cut !== null &&
+          follower.git.cut.revision >= bundle.event.workspaceRevision &&
+          follower.git.commitSha
+            ? ledgerCommitSha(options.repoId, follower.git.commitSha)
+            : null,
         cut: canonicalEventCut(options.repoId, bundle.event),
         metrics: { gitProcesses: 0, nodeSyncs: 0, changedPaths: [] },
       };
@@ -455,7 +461,14 @@ export function makeSqliteTaskEventStore(options: SqliteTaskEventStoreOptions): 
     append,
     materialize: () => publishFollower(true),
     materializationHealth: () =>
-      health(follower.git.status === "verified" ? "ok" : scheduled ? "retrying" : "failed", follower.git.reason),
+      health(
+        follower.git.status === "verified" && follower.git.cut?.revision === sqlite.revision()
+          ? "ok"
+          : scheduled
+            ? "retrying"
+            : "failed",
+        follower.git.reason,
+      ),
     drain: async () => {
       await scheduled;
       if (!closed) sqlite.close();

--- a/packages/kernel/test/store/task-event-store.test.ts
+++ b/packages/kernel/test/store/task-event-store.test.ts
@@ -4,6 +4,7 @@ import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, writ
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
+import { attachReceiptAcceptance } from "../../src/composition/receipt-acceptance.ts";
 import { taskLifecycleWritePlan } from "../../src/domain/task-lifecycle-publication.ts";
 import { localGitObjectRefStore } from "../../src/store/local-version-control-system.ts";
 import { openSqliteEventStore, sqliteContentObjectPath } from "../../src/store/sqlite-event-store.ts";
@@ -332,3 +333,33 @@ test("corrupt accepted content cannot be certified by publishing the same corrup
 function fixture(name: string): string {
   return mkdtempSync(path.join(tmpdir(), `ha-sqlite-${name}-`));
 }
+
+test("later acceptance retains the verified prefix without certifying the newer receipt", async () => {
+  const rootDir = fixture("verified-prefix");
+  initRepo(rootDir);
+  const store = makeTaskEventStore({ repoId, rootDir, writerFence });
+  const first = eventAt(1),
+    second = eventAt(2);
+  const projection = { readCut: () => ({ watermark: store.currentCut().revision }) } as never;
+  const receipt = (opId: string) => attachReceiptAcceptance({ outcome: "applied", opId }, store, projection);
+  try {
+    store.append({ event: first, plan: taskLifecycleWritePlan(first), blobs: [] });
+    store.materialize();
+    assert.equal(receipt(first.opId).git.state, "verified");
+    const appended = store.append({ event: second, plan: taskLifecycleWritePlan(second), blobs: [] });
+    assert.equal(receipt(first.opId).git.state, "verified", "new acceptance must not erase verified history");
+    assert.equal(receipt(first.opId).worktree.state, "verified");
+    assert.equal(receipt(second.opId).git.state, "pending");
+    assert.equal(receipt(second.opId).worktree.state, "pending");
+    assert.equal(receipt(second.opId).git.commitSha, null);
+    assert.equal(appended.commitSha, null);
+    assert.equal(store.materializationHealth().lastCheckpointRevision, 1);
+    assert.equal(store.materializationHealth().pendingWalEvents, 1);
+    assert.equal(store.materializationHealth().state, "retrying");
+    store.materialize();
+    assert.equal(receipt(second.opId).git.state, "verified");
+    assert.equal(receipt(second.opId).worktree.state, "verified");
+  } finally {
+    await store.drain();
+  }
+});


### PR DESCRIPTION
# English

## Summary
Accepting a newer command erased the follower's verified prefix. An older Decision receipt therefore regressed from verified to pending, and health reported checkpoint zero with the entire ledger pending. Retain the actual certified prefix and evaluate each receipt against its own accepted revision. Person actions also read the accepted roster projection instead of a potentially lagging physical mirror; only an unclaimed bootstrap seed uses authored bytes.

## Architectural Justification
Reuse existing follower progress and cut comparisons. No new cache, durable schema or writer is introduced.

## What Changed
- Preserve follower progress when acceptance advances the ledger head.
- Keep newer receipt facets and commit SHA pending until the retained cut covers them.
- Report backlog from the retained checkpoint while the new cut is settling.
- Add a deterministic real-store regression covering old and new receipts before and after publication.
- Validate Person commands against the same-cut canonical roster, retaining issuer authorization while the physical mirror is held behind.

## Gate Harvest / 门收割
Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Replaced destructive progress reset and unscoped receipt facet projection; no parallel path retained.

## Machine-Readable Declarations
No dependencies, event format, gate, workflow, retry or timeout changes.

### Optional Evidence Claims
No performance or complete Fleet recovery claim.

## Task And Scope
- Maintainer-authorized main receipt regression repair.
- Branch: codex/follower-receipt-monotonic.
- Public scope: sqlite-task-event-store, receipt-acceptance composition, Person action runtime and their existing tests.
- Private evidence updated: yes, excluded from public branch.
- Out of scope: Fleet lock, initial cold recertification and live format migration.

## Version Impact
No version change or publish.

## Governance Declaration
- Protected surface touched: no
- Protected surface scope: none (manifest classifier returned no protected matches)
- Authority: not applicable
- Machine-check boundary: reviewers assess the declaration.
- Break-glass: no

## Verification
- Base169daf2c1712efe021f4da98e995b2dea08caabb.
- New real-store test fails on unchanged source with old receipt pending instead of verified.
- Node26.8.1 isolated Ubuntu: store13/13, receipt contracts7/7, original JSON-RPC file49/49 passed. ARM64 target differs from CIx64.
- Held-mirror Person regression fails on unchanged main with token-not-found rather than issuer refusal; fixed Person1/1 and People6/6 pass on Node26.8.1. The original authorization assertions remain.
- Typecheck, diff check and CLI post-commit build passed. No full local suite run.
- Public CI pending.

## Review Evidence
Root inspected all facets and append commitSha: a revision1 certificate cannot verify revision2. The test asserts checkpoint1/backlog1, old verified, new pending, and new verified only after materialization. Genuine follower failure/divergence handling remains unchanged.

## Residual Risk
Cold recertification costs and independent SQLite locks remain open. Retaining the prefix on ordinary acceptance does not suppress publication errors or certify later work.

## References
- https://github.com/FairladyZ625/harness-anything/actions/runs/34341017391/job/102431688939
- packages/kernel/test/store/task-event-store.test.ts

---

# 中文

## 概要
接受新命令时把已经验证的follower进度清空，导致旧Decision回执从verified回退到pending，健康状态也显示检查点0和全部积压。本次保留真实已验证前缀，并按每份回执自己的接受版本判断覆盖。Person命令改读同cut的canonical roster，仅未登记的bootstrap种子读取物理正文，防止已接受令牌被落后的物理副本漏掉。

## 架构辩护
复用已有follower和cut比较，不新增缓存、持久schema或writer。

## 改动内容
接受推进head时保留检查点；新回执未被旧cut覆盖时仍为pending且无commitSHA；健康状态计算真实剩余积压；增加真实store的确定性回归。

## 门收割 / Gate Harvest
替换清空进度和不区分请求版本的回执投影，没有保留并行旧路径，不删门禁或fixture。

## 机读声明说明
不改依赖、事件格式、gate、workflow、重试或超时，不声明性能或Fleet整体修复。

## 任务与范围
维护者已授权main修复，分支codex/follower-receipt-monotonic，范围为follower、receipt组合、Person运行时及既有测试。私有证据不公开。冷启动重认证、Fleet锁和在线格式切换不在本次范围。

## 版本影响
不改版本、不发布。

## 治理声明
manifest分类未命中protected surface，不使用break-glass，声明真实性由reviewer核实。

## 验证
基线169daf2c1712efe021f4da98e995b2dea08caabb。新增用例在旧源码上明确失败：旧回执pending而非verified。Node26.8.1 Ubuntu隔离验证store13/13、receipt7/7、原JSON-RPC49/49通过；ARM64与CIx64仍有平台差异。另以冻结物理副本的用例证明未修改main也会漏读已接受令牌；修复后Person1/1和People6/6在Node26通过，原授权断言保留。typecheck、diff检查和提交后CLI构建通过，未跑本地全套。公共CI待运行。

## 审查证据
Root检查新回执不能借用旧证明：测试验证checkpoint1/backlog1、旧verified、新pending，物化完成后新回执才verified。原失败及分歧处理保持。

## 残余风险
冷启动重认证成本与独立SQLite锁仍未解决。普通接受保留前缀，不代表忽略发布错误或认证未来版本。

## 关联材料
上述Actions原始job和store回归测试。

## PR Gate Checklist / PR 门禁清单
- [x] Isolated scoped diff; no private files or local host paths.
- [x] Bilingual body and actual red/green evidence.
- [x] No bypass, retries or weakened assertions.
- [ ] Required public checks passed.
- [ ] Normal merge and cleanup after checks and review.
