### PR TITLE
fix: route and adopt raw Task artifact files

### DIFF
--- a/packages/daemon/src/doc-sync-candidate-scanner.ts
+++ b/packages/daemon/src/doc-sync-candidate-scanner.ts
@@ -151,11 +151,16 @@ export function scanDocCandidates(input: {
       conflicts = inventoried?.conflicts ?? candidateConflicts(input.rootDir, layout.authoredRoot, logical),
       safe = inventoried?.safe ?? directFile(layout.authoredRoot, logical),
       classification = classifyDocSyncCandidatePath(logical),
+      taskArtifactCandidate =
+        claimingTaskId !== null &&
+        classification === null &&
+        /^tasks\/[^/]+\/artifacts\//u.test(document) &&
+        baseDocumentIsNew(projected),
       existingMediaType = classifyTextualArtifactPath(logical)?.mediaType ?? null,
       fileSize = inventoried ? inventoried.size : safe && existsSync(target) ? lstatSync(target).size : null,
       rawBytes = inventoried
         ? inventoried.bytes
-        : (classification !== null || !route.allowed || projected.document !== null) &&
+        : (classification !== null || taskArtifactCandidate || !route.allowed || projected.document !== null) &&
             fileSize !== null &&
             fileSize <= DOC_SYNC_INLINE_MAX_BYTES &&
             safe &&
@@ -201,6 +206,16 @@ export function scanDocCandidates(input: {
         classification?.mediaType ?? null,
         "task_package_unregistered",
         "ha task artifact add",
+      );
+    if (taskArtifactCandidate && candidate !== null)
+      return scannedCandidateRow(
+        "inapplicable",
+        `task artifact is outside doc sync; publish it with ha task artifact add ${claimingTaskId} ` +
+          `--source harness/${logical} --destination ${logical.slice(`tasks/${taskDirectory}/`.length)}`,
+        bytes,
+        base,
+        candidate,
+        classification?.mediaType ?? null,
       );
     if (classification === null && candidate !== null && candidate === base)
       return scannedCandidateRow("clean", null, bytes, base, candidate, existingMediaType);
@@ -359,6 +374,10 @@ export function scanDocCandidates(input: {
   }
 }
 
+function baseDocumentIsNew(projected: ReturnType<TaskProjection["readDocument"]>): boolean {
+  return projected.document === null;
+}
+
 export function scanAuthoredCandidateInventory(input: {
   readonly rootDir: string;
   readonly store: CanonicalEventStore;
@@ -378,7 +397,9 @@ export function scanAuthoredCandidateInventory(input: {
         target = path.join(layout.authoredRoot, ...logical.split("/")),
         size = safe && existsSync(target) ? lstatSync(target).size : null,
         rawBytes =
-          (classification !== null || !route.allowed) && size !== null && size <= DOC_SYNC_INLINE_MAX_BYTES
+          (classification !== null || !route.allowed || /^tasks\/[^/]+\/artifacts\//u.test(logical)) &&
+          size !== null &&
+          size <= DOC_SYNC_INLINE_MAX_BYTES
             ? readCandidate(target)
             : null,
         bytes = rawBytes === null ? null : canonicalProseBytes(rawBytes, classification?.policyId);

--- a/packages/daemon/src/doc-sync-candidate-scanner.ts
+++ b/packages/daemon/src/doc-sync-candidate-scanner.ts
@@ -6,6 +6,7 @@ import { existsSync, lstatSync, readdirSync, readFileSync } from "node:fs";
 import path from "node:path";
 import {
   classifyDocSyncCandidatePath,
+  classifyRawArtifactPath,
   classifyTextualArtifactPath,
   decideDocWriteCriteria,
   DOC_SYNC_INLINE_MAX_BYTES,
@@ -30,7 +31,7 @@ import {
   type TaskProjection,
   type WriteSource,
 } from "../../kernel/src/index.ts";
-import { blockedCandidateNextAction } from "./doc-sync-details.ts";
+import { blockedCandidateNextAction, formatShellCommand } from "./doc-sync-details.ts";
 import { docSyncError } from "./doc-sync-files.ts";
 
 export type DocCandidateState = "clean" | "eligible" | "inapplicable" | "blocked" | "deletion" | "conflict";
@@ -150,14 +151,18 @@ export function scanDocCandidates(input: {
       projected = input.projection.readDocument(document),
       conflicts = inventoried?.conflicts ?? candidateConflicts(input.rootDir, layout.authoredRoot, logical),
       safe = inventoried?.safe ?? directFile(layout.authoredRoot, logical),
+      fileSize = inventoried ? inventoried.size : safe && existsSync(target) ? lstatSync(target).size : null,
       classification = classifyDocSyncCandidatePath(logical),
+      rawClassification = classifyRawArtifactPath(document),
+      rawTaskArtifactCandidate = rawClassification !== null && !/\.(?:jsonl|log)$/u.test(document),
       taskArtifactCandidate =
         claimingTaskId !== null &&
-        classification === null &&
+        (classification === null
+          ? !/\.(?:jsonl|log)$/u.test(document)
+          : rawTaskArtifactCandidate && fileSize !== null && fileSize > DOC_SYNC_INLINE_MAX_BYTES) &&
         /^tasks\/[^/]+\/artifacts\//u.test(document) &&
         baseDocumentIsNew(projected),
       existingMediaType = classifyTextualArtifactPath(logical)?.mediaType ?? null,
-      fileSize = inventoried ? inventoried.size : safe && existsSync(target) ? lstatSync(target).size : null,
       rawBytes = inventoried
         ? inventoried.bytes
         : (classification !== null || taskArtifactCandidate || !route.allowed || projected.document !== null) &&
@@ -207,16 +212,32 @@ export function scanDocCandidates(input: {
         "task_package_unregistered",
         "ha task artifact add",
       );
-    if (taskArtifactCandidate && candidate !== null)
+    if (taskArtifactCandidate) {
+      const nextAction = formatShellCommand("ha", [
+        "task",
+        "artifact",
+        "add",
+        claimingTaskId,
+        "--source",
+        `${ledger.authoredPrefix ? `${ledger.authoredPrefix}/` : ""}${logical}`,
+        "--destination",
+        logical.slice(`tasks/${taskDirectory}/`.length),
+      ]);
       return scannedCandidateRow(
         "inapplicable",
-        `task artifact is outside doc sync; publish it with ha task artifact add ${claimingTaskId} ` +
-          `--source harness/${logical} --destination ${logical.slice(`tasks/${taskDirectory}/`.length)}`,
+        rawClassification === null || (candidate === null && fileSize !== null && fileSize > DOC_SYNC_INLINE_MAX_BYTES)
+          ? `task artifact is outside doc sync; publish it with ${nextAction}`
+          : "non-textual artifact is outside doc sync; publish it with ha task artifact add",
         bytes,
         base,
         candidate,
         classification?.mediaType ?? null,
+        null,
+        null,
+        null,
+        fileSize,
       );
+    }
     if (classification === null && candidate !== null && candidate === base)
       return scannedCandidateRow("clean", null, bytes, base, candidate, existingMediaType);
     if (classification === null)

--- a/packages/daemon/src/doc-sync-command-actions.ts
+++ b/packages/daemon/src/doc-sync-command-actions.ts
@@ -339,8 +339,8 @@ export function runArtifactAdd(input: Input): ArtifactAddReceipt {
     destinationValue = requiredDocSyncText(input.action.destination, "destination");
   if (!hasExactDocSyncActionFields(input.action, ["kind", "taskId", "source", "destination"]))
     throw docSyncError("invalid_command", "task artifact add requires taskId, source, and destination");
-  const target = taskArtifactTarget(input, taskId, destinationValue),
-    source = artifactSource(input, sourceValue);
+  const source = artifactSource(input, sourceValue),
+    target = taskArtifactTarget(input, taskId, destinationValue, source.absolute);
   // Size is settled from the file, not from a buffer: a source past the blob contract is refused
   // without first reading 50 MB of it into the daemon.
   if (lstatSync(source.absolute).size > RAW_ARTIFACT_MAX_BYTES)
@@ -370,7 +370,7 @@ export function publishTaskArtifact(
   return publishTaskArtifactBytes(publicationInput, target, artifact.bytes);
 }
 
-function taskArtifactTarget(input: Input, taskId: string, destinationValue: string) {
+function taskArtifactTarget(input: Input, taskId: string, destinationValue: string, sourceAbsolute?: string) {
   const task = input.projection.read(taskId);
   if (task.watermark !== task.sourceRevision || !task.packagePath || !task.snapshot.task)
     throw docSyncError("content_not_ready", `Task ${taskId} is not ready for artifact add`);
@@ -390,7 +390,7 @@ function taskArtifactTarget(input: Input, taskId: string, destinationValue: stri
     rawClassification = classifyRawArtifactPath(destination);
   if (
     !destination.startsWith(`${task.packagePath}/artifacts/`) ||
-    classification === null ||
+    (classification === null && rawClassification === null) ||
     !directPaths(input.rootDir, [destination])
   )
     throw docSyncError(
@@ -402,7 +402,8 @@ function taskArtifactTarget(input: Input, taskId: string, destinationValue: stri
     authoredTarget = path.join(layout.authoredRoot, ...destination.split("/")),
     gitTarget = ledgerGitPath(ledger, destination),
     projected = input.projection.readDocument(destination),
-    tracked = gitTracked(ledger.rootDir, gitTarget);
+    tracked = gitTracked(ledger.rootDir, gitTarget),
+    sameUntrackedSource = sourceAbsolute === authoredTarget && !tracked && projected.document === null;
   return {
     taskId,
     destination,
@@ -413,6 +414,7 @@ function taskArtifactTarget(input: Input, taskId: string, destinationValue: stri
     ledgerRootDir: ledger.rootDir,
     projected,
     tracked,
+    sameUntrackedSource,
   };
 }
 
@@ -431,6 +433,7 @@ function publishTaskArtifactBytes(
     ledgerRootDir,
     projected,
     tracked,
+    sameUntrackedSource,
   } = target;
   const projectedEdit =
     projected.document !== null &&
@@ -441,7 +444,7 @@ function publishTaskArtifactBytes(
       "artifact_tracked_edit",
       `destination is a tracked edit; use ha doc sync --submit --path ${destination}`,
     );
-  if (tracked || existsSync(authoredTarget) || projected.document !== null) {
+  if (tracked || (existsSync(authoredTarget) && !sameUntrackedSource) || projected.document !== null) {
     const sha = sha256Bytes(bytes),
       replay =
         existsSync(authoredTarget) &&

--- a/packages/daemon/src/doc-sync-details.ts
+++ b/packages/daemon/src/doc-sync-details.ts
@@ -34,6 +34,16 @@ export function blockedCandidateNextAction(
   return `resolve ${candidate.path} through ${route}: ${candidate.reason ?? "candidate is blocked"}; then ${nextStep}`;
 }
 
+export function formatShellCommand(command: string, args: readonly string[]): string {
+  return [command, ...args].map(shellQuoteArgument).join(" ");
+}
+
+function shellQuoteArgument(value: string): string {
+  if (/^[A-Za-z0-9_./:@%+=,-]+$/u.test(value)) return value;
+  const quote = "'";
+  return `${quote}${value.replaceAll(quote, `${quote}"${quote}"${quote}`)}${quote}`;
+}
+
 export function readDetail(
   input: Input,
   paths: readonly string[],

--- a/packages/daemon/src/doc-sync-settlement.ts
+++ b/packages/daemon/src/doc-sync-settlement.ts
@@ -68,6 +68,9 @@ function statusSummary(scan: DocCandidateScan): string {
 }
 
 export function scanDetail(input: Input, scan: DocCandidateScan, code: string): DocSyncReceiptDetail {
+  const nextAction = scan.rows
+    .filter((row) => row.state === "inapplicable" && row.reason?.includes("ha task artifact add"))
+    .map((row) => row.reason!.slice(row.reason!.indexOf("ha task artifact add")))[0];
   return {
     kind: "doc_sync",
     code,
@@ -101,6 +104,7 @@ export function scanDetail(input: Input, scan: DocCandidateScan, code: string): 
         baseBlobSha256: row.baseBlobSha256!,
         source: "intent" as const,
       })),
+    ...(nextAction === undefined ? {} : { nextAction }),
   };
 }
 

--- a/packages/daemon/src/protocol/daemon-protocol-commands-task.ts
+++ b/packages/daemon/src/protocol/daemon-protocol-commands-task.ts
@@ -115,7 +115,7 @@ export const taskExecutionProtocolCommands = Object.freeze([
     id: "task-artifact-add",
     phase: "W3",
     path: ["task", "artifact", "add", "<task-id>"],
-    summary: "Publish an untracked UTF-8 artifact through canonical doc sync.",
+    summary: "Publish an untracked task artifact through canonical doc sync.",
     method: "repo.task.run",
     inputs: [
       cliInput("--source", "single", true, {

--- a/packages/daemon/test/doc-sync-artifact-raw-bytes.test.ts
+++ b/packages/daemon/test/doc-sync-artifact-raw-bytes.test.ts
@@ -1,7 +1,7 @@
 // harness-test-tier: integration
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { existsSync, mkdtempSync, readFileSync, rmSync, truncateSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, truncateSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -269,6 +269,56 @@ test("a raw publication that fails leaves no accepted artifact and no raw claim 
     assert.equal(decision.detail.unresolvedTouches[0]?.requiredRoute, "task-artifact-add");
   } finally {
     rmSync(confinementRoot, { recursive: true, force: true });
+  }
+});
+
+test("doc status routes a new JSON task artifact to artifact add and accepts same-path takeover", async () => {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-artifact-json-route-"));
+  initRepo(rootDir);
+  const repoId = workspaceId("artifact-json-route"),
+    cell = await openRepoCell({ repoId, rootDir: canonicalRoot(rootDir), ownerId: "artifact-json-route" }),
+    binding = { actor, source: "local" as const };
+  try {
+    const created = (await cell.run({ kind: "task-create", taskId: "task-json", title: "JSON Artifact" }, binding)) as {
+      readonly outcome: string;
+      readonly packagePath: string;
+    };
+    assert.equal(created.outcome, "applied", JSON.stringify(created));
+    const logical = `${created.packagePath}/artifacts/report.json`,
+      target = path.join(rootDir, "harness", ...logical.split("/")),
+      bytes = Buffer.from('{"schema":"report/v1","ok":true}\n');
+    mkdirSync(path.dirname(target), { recursive: true });
+    writeFileSync(target, bytes);
+    const status = (await cell.run({ kind: "doc-status", paths: [logical] }, binding)) as Record<string, unknown>,
+      rows = JSON.parse(String(status.evidence).slice("doc-scan:".length)) as {
+        readonly rows: readonly { readonly state: string; readonly reason: string | null }[];
+      };
+    assert.deepEqual(
+      [rows.rows[0]?.state, rows.rows[0]?.reason],
+      [
+        "inapplicable",
+        `task artifact is outside doc sync; publish it with ha task artifact add task-json ` +
+          `--source harness/${logical} --destination artifacts/report.json`,
+      ],
+    );
+    assert.match(
+      String((status.detail as { readonly nextAction?: string }).nextAction),
+      /^ha task artifact add task-json/u,
+    );
+    const added = (await cell.run(
+      {
+        kind: "task-artifact-add",
+        taskId: "task-json",
+        source: `harness/${logical}`,
+        destination: "artifacts/report.json",
+      },
+      binding,
+    )) as Record<string, unknown>;
+    assert.equal(added.outcome, "applied", JSON.stringify(added));
+    assert.deepEqual(readFileSync(target), bytes, "same-path takeover preserves the original bytes");
+  } finally {
+    await cell.close();
+    rmSync(rootDir, { recursive: true, force: true });
   }
 });
 

--- a/packages/daemon/test/doc-sync-artifact-raw-bytes.test.ts
+++ b/packages/daemon/test/doc-sync-artifact-raw-bytes.test.ts
@@ -10,6 +10,7 @@ import {
   documentPath,
   makeTaskEventReader,
   makeTaskEventStore,
+  DOC_SYNC_INLINE_MAX_BYTES,
   parseDocWriteIntent,
   RAW_ARTIFACT_MAX_BYTES,
   RAW_ARTIFACT_POLICY_ID,
@@ -316,6 +317,57 @@ test("doc status routes a new JSON task artifact to artifact add and accepts sam
     )) as Record<string, unknown>;
     assert.equal(added.outcome, "applied", JSON.stringify(added));
     assert.deepEqual(readFileSync(target), bytes, "same-path takeover preserves the original bytes");
+  } finally {
+    await cell.close();
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});
+
+test("doc status uses the configured authored root and quotes artifact source paths", async () => {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-artifact-configured-root-"));
+  initRepo(rootDir);
+  mkdirSync(path.join(rootDir, "harness"), { recursive: true });
+  writeFileSync(
+    path.join(rootDir, "harness", "harness.yaml"),
+    "schema: harness-anything/v1\nlayout:\n  authoredRoot: ledger\n  localRoot: .harness\n",
+  );
+  const repoId = workspaceId("artifact-configured-root"),
+    cell = await openRepoCell({ repoId, rootDir: canonicalRoot(rootDir), ownerId: "artifact-configured-root" }),
+    binding = { actor, source: "local" as const };
+  try {
+    const created = (await cell.run(
+      { kind: "task-create", taskId: "task-configured", title: "Configured Root" },
+      binding,
+    )) as { readonly outcome: string; readonly packagePath: string };
+    assert.equal(created.outcome, "applied", JSON.stringify(created));
+    const logical = `${created.packagePath}/artifacts/report (final).pdf`,
+      target = path.join(rootDir, "ledger", ...logical.split("/")),
+      bytes = Buffer.concat([Buffer.from("%PDF-1.7\n"), Buffer.alloc(DOC_SYNC_INLINE_MAX_BYTES + 1, 0xff)]);
+    mkdirSync(path.dirname(target), { recursive: true });
+    writeFileSync(target, bytes);
+    const status = (await cell.run({ kind: "doc-status", paths: [logical] }, binding)) as Record<string, unknown>;
+    const rows = JSON.parse(String(status.evidence).slice("doc-scan:".length)) as {
+      readonly rows: readonly {
+        readonly state: string;
+        readonly reason: string | null;
+        readonly size: number | null;
+        readonly candidateBlobSha256: string | null;
+      }[];
+    };
+    assert.deepEqual(
+      [rows.rows[0]?.state, rows.rows[0]?.size, rows.rows[0]?.candidateBlobSha256],
+      ["inapplicable", bytes.byteLength, null],
+      JSON.stringify(rows),
+    );
+    assert.match(
+      rows.rows[0]?.reason ?? "",
+      /'ledger\/tasks\/task-configured-configured-root\/artifacts\/report \(final\)\.pdf'/u,
+    );
+    assert.equal(
+      (status.detail as { readonly nextAction?: string }).nextAction,
+      "ha task artifact add task-configured --source 'ledger/tasks/task-configured-configured-root/artifacts/report (final).pdf' " +
+        "--destination 'artifacts/report (final).pdf'",
+    );
   } finally {
     await cell.close();
     rmSync(rootDir, { recursive: true, force: true });


### PR DESCRIPTION
# English

## Summary

New raw files inside registered Task artifacts were rejected by doc sync, while importing the same file with artifact add failed on an existing destination. This change reports the artifact import route and lets that route adopt its own untracked source without changing bytes. The reviewed follow-up also handles shell quoting, configured authored roots, and oversized raw files.

## Architectural Justification

The existing artifact publisher remains the single writer. The scanner explains which command owns the raw file; no second content store, compatibility layer or retry path is introduced.

## What Changed

- Route unregistered Task raw artifacts to artifact add and expose next-action guidance.
- Admit an identical source/destination when it is untracked and has no canonical document.
- Preserve collision protection for tracked and different destinations, and correct the obsolete UTF-8 help description.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
Production-Delta: +71/-11

## Machine-Readable Declarations

No dependency or accepted event fixture changes.

### Optional Evidence Claims

No formal performance claim.

## Task And Scope

- Task: task_f4377627de1b284dab59ba5550.
- Branch: codex/raw-artifact-docsync.
- Scope: daemon document scanning, artifact admission, guidance and direct tests.
- Private planning/evidence updated: yes.
- Out of scope: generation conversion and repository attach lifecycle.

## Version Impact

No version change and no npm publication.

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none
- Authority: not applicable
- Machine-check boundary: reviewers assess sufficiency.
- Break-glass: no

## Verification

Base and merge-base: a94d5b5e782d8ebf03b433c13904c3694cdfbf88. Public diff: git diff origin/main...HEAD. The worker reports typecheck, scoped lint and 40 cases across five Docker-isolated test files passing; those reports are not a substitute for the forthcoming GitHub checks. Full local suites were not run. Follow-up Docker checks passed 26 cases. Current head aa4bba690 passed rewrite-ci run https://github.com/FairladyZ625/harness-anything/actions/runs/34433297999 and rebuild gates run 34433297988.

## Review Evidence

Root reviewed both commits, including aa4bba690. All three prior findings are addressed with a configured-root, spaced filename, oversized PDF regression. No native subagent or human GitHub approval is claimed.

## Residual Risk

Current behavior still uses explicit artifact import rather than making every repository file a document candidate. Merge will use a normal merge commit after required CI and review pass, followed by owned branch cleanup.

## References

Source and tests are in this diff. Private plans and machine-local evidence are excluded from this public body. CI links will come from this PR's actual runs.

---

# 中文

## 概要

已登记 Task 的 artifacts 目录里新写 JSON/PDF/二进制时，doc sync 原来拒绝；再对同路径调用 artifact add 又会遇到目标已存在。本变更给出原字节文件的正确导入路径，并允许该路径接管自己的未跟踪源文件，保留原字节。增量修复覆盖参数引用、自定义目录和超限原字节文件。

## 架构辩护

继续使用既有 artifact 发布器作为唯一写入实现，scanner 只说明路由。不新建存储、兼容层或重试机制，不把所有仓库文件都认作 Task 内容。

## 改动内容

- 为 Task 未登记原字节文件给出 artifact add 与 nextAction。
- source 与 destination 相同且未跟踪、没有canonical文档时允许接管。
- 保留已跟踪/不同目标冲突保护，修正过期的仅UTF-8帮助。

## 门收割 / Gate Harvest

没有删除完整生产文件、门禁或fixture；生产变化为新增71行、删除11行。

## 机读声明说明

没有依赖或accepted事件fixture变化；正式机读字段仅在英文块出现。

## 任务与范围

任务task_f4377627de1b284dab59ba5550，分支codex/raw-artifact-docsync。范围仅daemon文档扫描、artifact接管、指引与直接测试。私有计划/证据已更新，不包含世代转换和仓库挂载生命周期。

## 版本影响

不改版本，不发布npm。

## 治理声明

- 是否触碰protected surface：no
- 范围：无
- 依据：不适用
- 机器检查不代替评审判断。
- Break-glass：no

## 验证

基准与merge-base均为a94d5b5e782d8ebf03b433c13904c3694cdfbf88；diff使用git diff origin/main...HEAD。worker报告typecheck、定向lint及五个Docker隔离测试文件共40例通过，报告不能代替随后真实GitHub检查。没有跑全量本地套件，增量Docker验证26例通过。当前head aa4bba690 的 rewrite-ci run https://github.com/FairladyZ625/harness-anything/actions/runs/34433297999 和 rebuild gates 34433297988 均通过。

## 审查证据

Root已审查两个提交，aa4bba690修复三项发现；定向回归覆盖配置目录、带空格文件名和超inline上限PDF。不宣称原生subagent或GitHub人工批准。

## 残余风险

发布仍走显式artifact导入，不能误读为任意文件自动接管。CI/评审通过后普通merge并清理自有分支。

## 关联材料

源码和测试见diff；私有计划与本机证据不放公开描述，检查结果以本PR实际run为准。

## PR Gate Checklist / PR 门禁清单

- [ ] Branch is based on latest `origin/main`. / 分支基于最新 `origin/main`。
- [ ] PR body uses this full template structure. / PR 描述使用本模板完整结构。
- [ ] PR body uses two complete language blocks: `# English` first, then `# 中文`. / PR 正文使用两块完整正文：`# English` 在上，`# 中文` 在下。
- [ ] PR body passes `tools/check-pr-body-bilingual.mjs`. / PR 正文通过 `tools/check-pr-body-bilingual.mjs`。
- [ ] If the PR touches a manifest-derived protected surface, Governance Declaration is filled with ADR/decision/task evidence or break-glass fields. / 若 PR 触碰 manifest 派生的 protected surface，Governance Declaration 已填写 ADR/decision/task 依据或 break-glass 字段。
- [ ] No private harness files are included. / 不包含私有 harness 文件。
- [ ] No ignored local agent entry files are included. / 不包含被忽略的本地 agent 入口文件。
- [ ] No absolute local filesystem paths are included in this public PR body. / 本公开 PR 描述不包含本机绝对路径。
- [ ] Public diff is limited to the stated task scope. / 公开 diff 限于声明的任务范围。
- [ ] Private planning/evidence updates are recorded when applicable. / 适用时已记录私有计划 / 证据更新。
- [ ] Version and publish impact are stated. / 已说明版本与发布影响。
- [ ] Local verification commands are recorded honestly. / 已如实记录本地验证命令。
- [ ] CI results are linked or explained. / CI 结果已链接或说明。
- [ ] Review evidence is recorded. / 已记录审查证据。
- [ ] Open P0/P1/P2 findings are closed, deferred with owner, or explicitly blocked. / open P0/P1/P2 findings 已关闭、带 owner 延后，或明确阻塞。
- [ ] Merge method and post-merge branch cleanup plan are clear. / 合并方式和合并后分支清理计划清楚。
- [ ] No admin bypass is planned unless explicitly approved and recorded. / 除非明确批准并记录，否则不计划 admin bypass。
