### PR TITLE
fix: make board card switching and pin actions respond reliably

### DIFF
--- a/packages/gui/src/main/electron-main.ts
+++ b/packages/gui/src/main/electron-main.ts
@@ -2,7 +2,7 @@ import { app, BrowserWindow, dialog, ipcMain, Menu, session, shell, type MenuIte
 import { homedir } from "node:os";
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
-import { readDaemonRegistry, type HarnessLayoutOverrides } from "../../../kernel/src/index.ts";
+import { readDaemonRegistry } from "../../../kernel/src/index.ts";
 import { registerHarnessIpcHandlers } from "./ipc-handlers.ts";
 import { registerArtifactOpenIpc } from "./artifact-open-ipc.ts";
 import { registerLocalDocIpc } from "./local-doc-ipc.ts";
@@ -176,7 +176,7 @@ export async function startGuiApp(): Promise<void> {
   installContentSecurityPolicy();
   const trustedWebContentsIds = new Set<number>();
   const rootDir = resolveGuiProjectRoot(),
-    bridge = createLocalGuiServiceBridge(rootDir, resolveGuiLayoutOverrides()),
+    bridge = createLocalGuiServiceBridge(rootDir),
     controlled = addLocalMainControls({
       bridge,
       target: async (repoId) => resolveLocalDaemonTarget({ rootDir, ...(repoId ? { repoIdOverride: repoId } : {}) }),
@@ -275,11 +275,6 @@ function createTrustedMainWindow(trustedWebContentsIds: Set<number>): BrowserWin
 
 export function resolveGuiProjectRoot(): string {
   return path.resolve(process.env.HARNESS_GUI_ROOT ?? process.cwd());
-}
-
-export function resolveGuiLayoutOverrides(): HarnessLayoutOverrides | undefined {
-  const authoredRoot = process.env.HARNESS_AUTHORED_ROOT;
-  return authoredRoot && authoredRoot.length > 0 ? { authoredRoot } : undefined;
 }
 
 function guiPackageRoot(): string {

--- a/packages/gui/src/main/local-composition-root.ts
+++ b/packages/gui/src/main/local-composition-root.ts
@@ -44,10 +44,10 @@ interface DaemonClient {
   ) => Promise<JsonObject>;
 }
 let client: Promise<DaemonClient> | undefined;
-export function createLocalGuiServiceBridge(
-  rootDir: string,
-  _layoutOverrides?: { readonly authoredRoot?: string },
-): GuiServiceBridge {
+// 没有 layout 覆写入口:GUI 的每一次读写都走 daemon JSON-RPC,authored root 由 daemon 按
+// 目标仓库自己的 harness.yaml 解析(非默认 authoredRoot 也因此照常可读)。GUI 侧再开一个
+// 覆写参数只会让人以为它能改别人的 authored root。
+export function createLocalGuiServiceBridge(rootDir: string): GuiServiceBridge {
   const root = path.resolve(rootDir);
   validateProjectPath(root, ".");
   return createGuiServiceBridgeForDaemon(

--- a/packages/gui/src/renderer/components/TaskPreviewDrawer.tsx
+++ b/packages/gui/src/renderer/components/TaskPreviewDrawer.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { ArrowSquareOut, CheckCircle, Lock, PushPin, X, XCircle } from "@phosphor-icons/react";
 import type { RelationEdge, TaskRow } from "../model/types";
 import { isExternal } from "../model/types";
@@ -36,13 +36,25 @@ export function TaskPreviewDrawer({
   onPreviewTask: (id: string) => void;
   onSetPin?: (task: TaskRow, pinned: boolean) => void;
 }) {
+  const panelRef = useRef<HTMLElement | null>(null);
+  // 抽屉是非模态的:压暗层不接指针事件,点在它下面的看板卡上那一次点击就直接换卡
+  // (实测:遮罩接事件时换一张卡要点两次,第一次只关抽屉、看起来「什么都没发生」)。
+  // 「点外面关掉」仍然成立,判据从「点中了遮罩」换成「按下的位置不在抽屉里」。
   useEffect(() => {
     if (!task) return;
     const onKeyDown = (event: KeyboardEvent) => {
       if (event.key === "Escape") onClose();
     };
+    const onPointerDown = (event: MouseEvent) => {
+      if (event.target instanceof Node && panelRef.current?.contains(event.target) === true) return;
+      onClose();
+    };
     window.addEventListener("keydown", onKeyDown);
-    return () => window.removeEventListener("keydown", onKeyDown);
+    window.addEventListener("mousedown", onPointerDown);
+    return () => {
+      window.removeEventListener("keydown", onKeyDown);
+      window.removeEventListener("mousedown", onPointerDown);
+    };
   }, [onClose, task]);
   if (!task) return null;
 
@@ -65,12 +77,12 @@ export function TaskPreviewDrawer({
   return (
     <div
       data-testid="task-preview-backdrop"
-      className="fixed inset-0 z-40 flex justify-end bg-bg/45"
-      onClick={(event) => {
-        if (event.target === event.currentTarget) onClose();
-      }}
+      className="pointer-events-none fixed inset-0 z-40 flex justify-end bg-bg/45"
     >
-      <aside className="flex h-full w-full max-w-[520px] flex-col border-l border-border-strong bg-surface shadow-2xl shadow-black/40">
+      <aside
+        ref={panelRef}
+        className="pointer-events-auto flex h-full w-full max-w-[520px] flex-col border-l border-border-strong bg-surface shadow-2xl shadow-black/40"
+      >
         <header className="border-b border-border px-4 py-3">
           <div className="flex items-start gap-3">
             <div className="min-w-0 flex-1">

--- a/packages/gui/src/renderer/components/TaskPreviewDrawer.tsx
+++ b/packages/gui/src/renderer/components/TaskPreviewDrawer.tsx
@@ -81,7 +81,10 @@ export function TaskPreviewDrawer({
     >
       <aside
         ref={panelRef}
-        className="pointer-events-auto flex h-full w-full max-w-[520px] flex-col border-l border-border-strong bg-surface shadow-2xl shadow-black/40"
+        className={[
+          "pointer-events-auto flex h-full w-full max-w-[520px] flex-col",
+          "border-l border-border-strong bg-surface shadow-2xl shadow-black/40",
+        ].join(" ")}
       >
         <header className="border-b border-border px-4 py-3">
           <div className="flex items-start gap-3">

--- a/packages/gui/src/renderer/task-actions.ts
+++ b/packages/gui/src/renderer/task-actions.ts
@@ -90,6 +90,12 @@ export interface TaskMutationFeedback {
   readonly hint: string;
 }
 
+/**
+ * 回执已 applied、只是「canonical 可见」或「task projection 追平」还没到位。这两种落定里
+ * 写入已经不在飞,in-flight 锁必须放开;它们与 pending/indeterminate(归属未知)不是一回事。
+ */
+const settledButInvisible: ReadonlySet<string> = new Set(["canonical_not_visible", "projection_not_visible"]);
+
 export function useTaskActions(repoId: string) {
   const queryClient = useQueryClient(),
     locks = useRef(new Map<string, Promise<TaskMutationFeedback>>());
@@ -161,7 +167,12 @@ export function useTaskActions(repoId: string) {
       if (held) return held;
       const promise = run().then(
         (result) => {
-          if (result.state !== "pending") locks.current.delete(lockKey);
+          // 锁只挡「这次写入还在飞」。回执本身已 applied、只差可见性追平的那两种落定
+          // 不是在飞写入:继续挡住会把控件永久锁死——实测 pin 一次(回执
+          // canonical_not_visible)之后 unpin 再也发不出去。真正归属未知的回执
+          // (pending/indeterminate)照旧挡住,start 那条会另铸 executionId,不得重放。
+          if (result.state !== "pending" || (result.code !== undefined && settledButInvisible.has(result.code)))
+            locks.current.delete(lockKey);
           return result;
         },
         (error) => {

--- a/packages/gui/src/renderer/views/BoardView.tsx
+++ b/packages/gui/src/renderer/views/BoardView.tsx
@@ -466,6 +466,18 @@ export const BoardView = memo(function BoardView({
   // 关系刷新(增量页换 relations 数组)不再打穿全板卡片 memo。
   const spawningDecisions = useMemo(() => buildSpawningDecisionIndex(allTasks, relations), [allTasks, relations]);
 
+  // pin 也是一次台账写入:回执落定与投影追平之间有真实延迟(实测约 2s),那段时间
+  // 按钮看起来「点了没反应」。写入报告面与拖拽 start 共用同一条,pin 也挂进去。
+  const reportedSetPin = useCallback(
+    (task: TaskRow, pinned: boolean) => {
+      setDragMessage(null);
+      setLastMutationTaskId(task.taskId);
+      onSetPin?.(task, pinned);
+    },
+    [onSetPin],
+  );
+  const setPin = onSetPin ? reportedSetPin : undefined;
+
   const onDragStart = (e: DragStartEvent) => setActiveTask(boardTasks.find((t) => t.taskId === e.active.id) ?? null);
 
   const onDragEnd = (event: DragEndEvent) => {
@@ -579,7 +591,7 @@ export const BoardView = memo(function BoardView({
           spawningDecisions={spawningDecisions}
           favorites={favorites}
           onToggleFavorite={onToggleFavorite}
-          onSetPin={onSetPin}
+          onSetPin={setPin}
           embedded
         />
       ) : layout === "swimlane" ? (
@@ -592,7 +604,7 @@ export const BoardView = memo(function BoardView({
           spawningDecisions={spawningDecisions}
           favorites={favorites}
           onToggleFavorite={onToggleFavorite}
-          onSetPin={onSetPin}
+          onSetPin={setPin}
         />
       ) : (
         <DndContext sensors={sensors} onDragStart={onDragStart} onDragEnd={onDragEnd}>
@@ -607,7 +619,7 @@ export const BoardView = memo(function BoardView({
                 spawningDecisions={spawningDecisions}
                 favorites={favorites}
                 onToggleFavorite={onToggleFavorite}
-                onSetPin={onSetPin}
+                onSetPin={setPin}
                 width={columnWidths.column[status]}
                 onResize={resizeColumn}
                 onReset={resetColumn}

--- a/packages/gui/test/task-pin-actions.vitest.ts
+++ b/packages/gui/test/task-pin-actions.vitest.ts
@@ -122,4 +122,149 @@ describe("useTaskActions pin write channel", () => {
       vi.restoreAllMocks();
     }
   });
+
+  // 回执 applied 但重读还没看到目标 cut(实测 canonical 追平要约 2s)时,写入**不是**在飞:
+  // 旧实现把这条也留在 in-flight 锁里,于是 pin 一次之后 unpin 再也发不出去——控件永久死掉,
+  // 而且界面一句话都不说。这一条守住「投影滞后不锁控件」,同时不放开真正归属未知的回执。
+  it("keeps the pin control usable after a receipt whose projection has not caught up", async () => {
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const task = (pinned: boolean): TaskRow => ({
+      taskId: "task-pin",
+      title: "Pin me",
+      projectId: "repo-a",
+      coordinationStatus: "planned",
+      canonicalStatus: "planned",
+      rawStatus: "planned/implementation",
+      freshness: "fresh",
+      packageDisposition: "active",
+      closeoutReadiness: "not_required",
+      engine: "local",
+      source: "local-document",
+      module: "core",
+      lastKnownAt: "2026-08-30T00:00:00.000Z",
+      gates: [],
+      docs: [],
+      ...(pinned ? { pinned: true } : {}),
+    });
+    const list = (pinned: boolean): TaskListSuccess => ({
+      ok: true,
+      status: "ready",
+      rows: [
+        {
+          taskId: "task-pin",
+          createdAt: null,
+          updatedAt: "2026-08-30T00:00:00.000Z",
+          generation: "v1",
+          snapshot: {
+            revision: 9,
+            task: { schema: "task/v2", taskId: "task-pin", title: "Pin me", pinned },
+            executions: [],
+            reviews: [],
+            consents: [],
+            codeDocWitnesses: [],
+            gateWitnesses: [],
+            lease: null,
+          },
+        } as never,
+      ],
+      invalidRows: [],
+      watermark: 9,
+      sourceRevision: 9,
+      warnings: [],
+    });
+    const pin = vi.fn(async () => receipt()),
+      unpin = vi.fn(async () => receipt()),
+      // 第一次重读还停在 pin 之前的那一版 → 落定成 projection_not_visible。
+      reads = vi.fn().mockResolvedValueOnce(list(false)).mockResolvedValueOnce(list(false));
+    vi.spyOn(harnessClient, "pinTask").mockImplementation(pin);
+    vi.spyOn(harnessClient, "unpinTask").mockImplementation(unpin);
+    vi.spyOn(harnessClient, "getTasks").mockImplementation(reads);
+
+    let actions: ReturnType<typeof useTaskActions> | undefined;
+    try {
+      await act(async () => {
+        root.render(
+          createElement(QueryClientProvider, {
+            client,
+            children: createElement(function Probe() {
+              actions = useTaskActions("repo-a");
+              return null;
+            }),
+          }),
+        );
+      });
+      client.setQueryData(taskQueryKeys.list("repo-a"), list(false));
+
+      const lagging = await actions!.setTaskPin(task(false), true);
+      expect(lagging).toMatchObject({ state: "pending", kind: "pin", code: "projection_not_visible" });
+      expect(pin).toHaveBeenCalledTimes(1);
+
+      // 同一条任务的下一次 pin 意图必须真的发出去,而不是拿回上一次那个 promise。
+      const again = await actions!.setTaskPin(task(true), false);
+      expect(unpin).toHaveBeenCalledTimes(1);
+      expect(again).toMatchObject({ kind: "pin" });
+
+      // 实测真机落在另一条同类落定上:回执 outcome=applied,但 proof 还没断言
+      // canonical 可见(code=canonical_not_visible)。它同样不得锁死控件。
+      vi.mocked(harnessClient.pinTask).mockClear();
+      const unproven = receipt({
+        proof: { committedRevision: 9, appliedCut: 9, durable: true, canonicalVisible: false, worktreeVisible: true },
+      });
+      vi.spyOn(harnessClient, "pinTask").mockImplementation(async () => unproven);
+      vi.spyOn(harnessClient, "showReceipt").mockImplementation(async () => unproven as never);
+      const invisible = await actions!.setTaskPin(task(false), true);
+      expect(invisible).toMatchObject({ state: "pending", kind: "pin", code: "canonical_not_visible" });
+      await actions!.setTaskPin(task(false), true);
+      expect(harnessClient.pinTask).toHaveBeenCalledTimes(2);
+    } finally {
+      await act(async () => {
+        root.unmount();
+      });
+      container.remove();
+      vi.restoreAllMocks();
+    }
+  });
+
+  // 归属真正未知的回执(pending/indeterminate)照旧挡住重放:锁只在「回执已 applied」时放开。
+  it("still blocks a replay while the receipt's own fate is unknown", async () => {
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const task = { taskId: "task-pin" };
+    const pin = vi.fn(async () => receipt({ outcome: "pending", opId: "op-pin-pending" }));
+    vi.spyOn(harnessClient, "pinTask").mockImplementation(pin);
+    vi.spyOn(harnessClient, "showReceipt").mockImplementation(
+      async () => receipt({ outcome: "pending", opId: "op-pin-pending" }) as never,
+    );
+
+    let actions: ReturnType<typeof useTaskActions> | undefined;
+    try {
+      await act(async () => {
+        root.render(
+          createElement(QueryClientProvider, {
+            client,
+            children: createElement(function Probe() {
+              actions = useTaskActions("repo-a");
+              return null;
+            }),
+          }),
+        );
+      });
+      const first = await actions!.setTaskPin(task, true);
+      expect(first).toMatchObject({ state: "pending", kind: "pin" });
+      expect(first.code).not.toBe("projection_not_visible");
+      await actions!.setTaskPin(task, true);
+      expect(pin).toHaveBeenCalledTimes(1);
+    } finally {
+      await act(async () => {
+        root.unmount();
+      });
+      container.remove();
+      vi.restoreAllMocks();
+    }
+  });
 });

--- a/packages/gui/test/taskFilters.vitest.ts
+++ b/packages/gui/test/taskFilters.vitest.ts
@@ -1526,7 +1526,7 @@ describe("swimlane column resize (W11)", () => {
 });
 
 describe("task preview dismissal", () => {
-  it("closes on backdrop click but keeps drawer contents and pin independent", async () => {
+  it("closes on an outside press, lets the dimmed board keep its clicks, and keeps pin independent", async () => {
     const onClose = vi.fn(),
       onSetPin = vi.fn();
     const task = makeTask();
@@ -1547,14 +1547,29 @@ describe("task preview dismissal", () => {
           }),
         ),
       );
-      const backdrop = container.firstElementChild as HTMLElement;
-      act(() => (container.querySelector("aside h2") as HTMLElement).click());
+      const backdrop = container.querySelector('[data-testid="task-preview-backdrop"]') as HTMLElement;
+      // 压暗层不接指针事件:它下面的看板卡照常收到那一次点击,换卡才只需点一次。
+      expect(backdrop.className).toContain("pointer-events-none");
+      expect((container.querySelector("aside") as HTMLElement).className).toContain("pointer-events-auto");
+      const inside = container.querySelector("aside h2") as HTMLElement;
+      act(() => {
+        inside.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
+        inside.click();
+      });
       expect(onClose).not.toHaveBeenCalled();
-      act(() => (container.querySelector('[data-testid="task-preview-pin-toggle"]') as HTMLElement).click());
+      const pinToggle = container.querySelector('[data-testid="task-preview-pin-toggle"]') as HTMLElement;
+      act(() => {
+        pinToggle.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
+        pinToggle.click();
+      });
       expect(onSetPin).toHaveBeenCalledWith(task, true);
       expect(onClose).not.toHaveBeenCalled();
-      act(() => backdrop.click());
+      // 抽屉外按下 = 关闭(原来的「点中遮罩」判据换成「按下位置不在抽屉里」)。
+      const outside = document.createElement("div");
+      document.body.append(outside);
+      act(() => outside.dispatchEvent(new MouseEvent("mousedown", { bubbles: true })));
       expect(onClose).toHaveBeenCalledTimes(1);
+      outside.remove();
       act(() => window.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" })));
       expect(onClose).toHaveBeenCalledTimes(2);
     } finally {


### PR DESCRIPTION
# English

## Summary
Board drawer overlays consumed the first click on another card; applied but not visible pin receipts left controls locked. Restore one-click switching and unlock settled writes, with visible pin feedback.

## Architectural Justification
Use the existing product entrypoints and lifecycle, without introducing another writer or compatibility path.

## What Changed
Scope is the public diff on codex/release-gui-acceptance. No private data is included.

## Gate Harvest / 门收割
Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
Production delta is measured by the CI production-delta job.

## Task And Scope
Task: task_d47e53b897c8868f1a01555357. Private task evidence updated. No unrelated production repository changes.

## Version Impact
No version change; no npm publication.

## Governance Declaration
- Protected surface touched: no
- Protected surface scope: none
- Authority: not applicable
- Break-glass: no

## Verification
Base d9c4c2aa5 for release acceptance; warming fix base a94d5b5e7. Worker reports Electron isolated scenarios, non-default root and PDF coverage; GUI vitest 986 tests passed. Root inspected drawer and action-lock diff. Real headed subjective acceptance remains outstanding. No complete local check:local was requested. GitHub current-head CI has not yet been verified.

## Review Evidence
Initial Root source review performed; full integration review pending. No human approval is claimed.

## Residual Risk
Worker reports Electron isolated scenarios, non-default root and PDF coverage; GUI vitest 986 tests passed. Root inspected drawer and action-lock diff. Real headed subjective acceptance remains outstanding. Cross-scope findings remain tracked in the private task report. Merge only after required CI and review; ordinary merge commit and owned branch cleanup.

## References
Task task_d47e53b897c8868f1a01555357; public source/test diff; private evidence is excluded from this public body.

---

# 中文

## 概要
看板抽屉吞掉换卡的第一次点击，已接受但尚未可见的pin回执使控件永久锁住；修复换卡、落定后的解锁与反馈。

## 架构辩护
复用现有入口与生命周期，不新增第二writer或兼容路径。

## 改动内容
公开范围见codex/release-gui-acceptance diff，不含私有数据。

## 门收割 / Gate Harvest
未删除完整生产路径或门禁；生产增删以CI计算为准。

## 任务与范围
任务task_d47e53b897c8868f1a01555357。私有证据已更新，不操作无关生产仓库。

## 版本影响
不改版本，不发布npm。

## 治理声明
- 是否触碰protected surface：no
- 范围：无
- 依据：不适用
- Break-glass：no

## 验证
worker报告Electron隔离场景、非默认目录/PDF及986项GUI测试通过；Root已看抽屉与锁改动。真实有头窗口主观验收尚未完成。 未要求完整本地check:local；尚未核实本head完整GitHub CI。

## 审查证据
Root已做初步源码审查，集成审查待完成，不宣称人工批准。

## 残余风险
worker报告Electron隔离场景、非默认目录/PDF及986项GUI测试通过；Root已看抽屉与锁改动。真实有头窗口主观验收尚未完成。 跨范围发现见私有任务报告。真实CI和评审通过后普通merge并清理自有分支。

## 关联材料
任务task_d47e53b897c8868f1a01555357，源码/测试见公开diff，私有材料不放公开描述。

## PR Gate Checklist / PR 门禁清单
- [x] Two complete language blocks and scoped public changes. / 双语正文与限定公开范围。
- [x] No private ledger or local absolute paths included. / 不含私有台账或本机绝对路径。
- [ ] Current head CI and integration review passed. / 本head CI与集成评审通过。
