### PR TITLE
fix: close late repository attaches rejected by registry

### DIFF
--- a/packages/daemon/src/daemon-host-errors.ts
+++ b/packages/daemon/src/daemon-host-errors.ts
@@ -88,6 +88,19 @@ export function attachBudgetError(repoId: string, timeoutMs: number): Error {
   return error;
 }
 
+export function revokedAttachError(repoId: string): Error {
+  const error = new Error(
+    [
+      "Repository ",
+      `${repoId}`,
+      " changed registration while it was attaching; the daemon discarded that attach and keeps ",
+      "the repo unavailable until the next probe reopens it under the current registry row.",
+    ].join(""),
+  ) as Error & { code: string };
+  error.code = "repo_attach_revoked";
+  return error;
+}
+
 export function failedConfigureVerify(
   receipt: RepoBootstrapReceipt,
   repoId: string,

--- a/packages/daemon/src/daemon-host-open.ts
+++ b/packages/daemon/src/daemon-host-open.ts
@@ -399,8 +399,14 @@ export async function openDaemonHost(input: DaemonHostOpenInput): Promise<Daemon
     });
     const loaded = cells.get(repoId);
     if (loaded && loaded.status().mode !== registered.repo.mode) await closeCell(repoId);
-    if (registered.repo.authoredBranch === null)
-      throw hostCodedError("registry_repo_invalid", `Workspace repository ${repoId} has no authored branch.`);
+    if (registered.repo.authoredBranch === null || registered.repo.canonicalRoot === null)
+      throw hostCodedError(
+        "registry_repo_invalid",
+        `Workspace repository ${repoId} has no authored branch or canonical root.`,
+      );
+    // The registry row, not the caller's path, is what the attach is opened against: registering a
+    // subdirectory records the enclosing harness root, and publication re-reads that same row.
+    const registeredRoot = canonicalRoot(registered.repo.canonicalRoot);
     if (!cells.has(repoId))
       try {
         markWarming(
@@ -408,18 +414,18 @@ export async function openDaemonHost(input: DaemonHostOpenInput): Promise<Daemon
           warmingStatus({
             ...registered.repo,
             repoId: id,
-            canonicalRoot: root,
+            canonicalRoot: registeredRoot,
           }),
         );
         await openRegistered({
           ...registered.repo,
           repoId: id,
-          canonicalRoot: root,
+          canonicalRoot: registeredRoot,
           authoredBranch: registered.repo.authoredBranch,
         });
       } catch (error) {
         consumeKnownError(error);
-        latchUnavailable(repoId, unavailableStatus(repoId, root, registered.repo.mode, error));
+        latchUnavailable(repoId, unavailableStatus(repoId, registeredRoot, registered.repo.mode, error));
       }
     return registered;
   };

--- a/packages/daemon/src/daemon-host-registry.ts
+++ b/packages/daemon/src/daemon-host-registry.ts
@@ -5,7 +5,9 @@ import {
   unregisterDaemonRepo,
   type DaemonRepoMode,
 } from "../../kernel/src/index.ts";
+import { revokedAttachError } from "./daemon-host-errors.ts";
 import { canonicalRoot, workspaceId } from "./protocol/daemon-protocol.contract.ts";
+import type { RepoCell } from "./repo-cell-types.ts";
 import type { RuntimeAttemptTerminal } from "./runtime-spawn.ts";
 import type { DaemonHostRegistryContext } from "./daemon-host-context.ts";
 
@@ -112,6 +114,23 @@ export function raceAttachBudget(
   });
 }
 
+// A cold attach can outlive the registry decision that asked for it: `daemon repo update
+// --state disabled` returns as soon as the on-disk row flips, while an open started earlier is
+// still inside openCell. The registry row is therefore re-read at publication time and is the
+// only authority on whether that Cell may be published. This is a publication check, not a
+// synchronous write barrier: a Cell that was already published, or one still opening, can be
+// writing right up until it is closed, so a migration must still see the repo fully attached
+// before it disables it.
+function stillRegistered(
+  context: DaemonHostRegistryContext,
+  repoId: string,
+): { readonly mode: DaemonRepoMode; readonly canonicalRoot: string } | null {
+  const row = readDaemonRegistry({ userRoot: context.input.userRoot }).repos.find((repo) => repo.repoId === repoId);
+  return row?.state === "enabled" && row.mode !== "remote-proxy" && row.canonicalRoot !== null
+    ? { mode: row.mode, canonicalRoot: row.canonicalRoot }
+    : null;
+}
+
 export async function performOpenRegistered(
   context: DaemonHostRegistryContext,
   repo: {
@@ -132,8 +151,9 @@ export async function performOpenRegistered(
       ...(progress ?? {}),
     };
   context.input.recordLifecycle?.({ event: "repo_attach_started", ...lifecycle });
+  let opened: RepoCell | undefined;
   try {
-    const cell = await context.openCell({
+    opened = await context.openCell({
       repoId: workspaceId(repo.repoId),
       rootDir: canonicalRoot(repo.canonicalRoot),
       mode: repo.mode,
@@ -154,11 +174,25 @@ export async function performOpenRegistered(
       ...context.runtimePorts,
       ...(context.input.runtimeLaunch ? { runtimeLaunch: context.input.runtimeLaunch } : {}),
     });
-    if (context.closing) {
-      await cell.close();
-      context.settleWarming(repo.repoId);
+    const wanted = context.closing ? null : stillRegistered(context, repo.repoId);
+    if (wanted?.mode !== repo.mode || wanted.canonicalRoot !== repo.canonicalRoot) {
+      await opened.close();
+      opened = undefined;
+      context.input.recordLifecycle?.({
+        event: "repo_attach_discarded",
+        ...lifecycle,
+        durationMs: performance.now() - started,
+      });
+      if (wanted === null) context.settleWarming(repo.repoId);
+      else
+        context.latchUnavailable(
+          repo.repoId,
+          context.unavailableStatus(repo.repoId, repo.canonicalRoot, repo.mode, revokedAttachError(repo.repoId)),
+        );
       return;
     }
+    const cell = opened;
+    opened = undefined;
     context.cells.set(repo.repoId, cell);
     await context.scheduleScheduler.refresh();
     context.settleWarming(repo.repoId);
@@ -169,6 +203,10 @@ export async function performOpenRegistered(
       durationMs: performance.now() - started,
     });
   } catch (error) {
+    // The publication re-read and the discard close are new throw sites downstream of a live
+    // Cell, so an open that never reaches `cells` still gets torn down instead of leaking its
+    // writer worker and workspace lock.
+    if (opened) await opened.close();
     context.input.recordLifecycle?.({
       event: "repo_attach_failed",
       ...lifecycle,

--- a/packages/daemon/src/lifecycle-log.ts
+++ b/packages/daemon/src/lifecycle-log.ts
@@ -25,6 +25,7 @@ export type DaemonLifecycleEvent =
   | "repo_attach_completed"
   | "repo_attach_failed"
   | "repo_attach_timed_out"
+  | "repo_attach_discarded"
   | "repo_registry_pruned"
   | "attachments_settled"
   | "runtime_spawn"

--- a/packages/daemon/src/repo-cell-lock.ts
+++ b/packages/daemon/src/repo-cell-lock.ts
@@ -13,7 +13,7 @@ const projectionFailurePatterns = [
  * Git/lock failures (publication CAS, writer lock) point it at the workspace infrastructure. */
 export function causeClassOf(error: unknown): "data-shape" | "infrastructure" | "projection" {
   return error instanceof VcsCommandError ||
-    ["writer_rejected", "publication_indeterminate"].includes(cellErrorCode(error))
+    ["writer_rejected", "publication_indeterminate", "repo_attach_revoked"].includes(cellErrorCode(error))
     ? "infrastructure"
     : error instanceof Error && projectionFailurePatterns.some((pattern) => pattern.test(error.message))
       ? "projection"

--- a/packages/daemon/test/daemon-host-recovery.test.ts
+++ b/packages/daemon/test/daemon-host-recovery.test.ts
@@ -1,7 +1,7 @@
 // harness-test-tier: integration
 import assert from "node:assert/strict";
 import { execFileSync, spawnSync } from "node:child_process";
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { DatabaseSync } from "node:sqlite";
 import { hostname, tmpdir } from "node:os";
 import path from "node:path";
@@ -437,6 +437,174 @@ test("a repository whose open never settles is bounded by an attach budget while
       "attached",
       "a late open completion must heal the timed-out latch",
     );
+  } finally {
+    await host.close();
+    rmSync(parent, { recursive: true, force: true });
+  }
+});
+
+// The registry row is the only authority at publication time. Both cases below hang the very
+// first openCell so the registry can be changed while the attach is genuinely in flight, then
+// hand the host a real Cell (holding the workspace writer lock) as the late completion.
+function gateFirstOpen(repoId: string): {
+  readonly openCell: typeof openRepoCell;
+  readonly release: (cell: Awaited<ReturnType<typeof openRepoCell>>) => Promise<void>;
+} {
+  type Resolve = (cell: Awaited<ReturnType<typeof openRepoCell>>) => void;
+  let gated = false,
+    announce!: (resolve: Resolve) => void;
+  const arrived = new Promise<Resolve>((resolve) => {
+    announce = resolve;
+  });
+  return {
+    openCell: async (cellInput) => {
+      if (cellInput.repoId !== workspaceId(repoId) || gated) return openRepoCell(cellInput);
+      gated = true;
+      return new Promise((resolve) => {
+        announce(resolve);
+      });
+    },
+    release: async (cell) => {
+      (await arrived)(cell);
+    },
+  };
+}
+
+test("a disabled repository is not resurrected by its in-flight attach landing late", async () => {
+  const parent = mkdtempSync(path.join(tmpdir(), "ha-host-disable-attach-")),
+    userRoot = path.join(parent, "user"),
+    rootDir = path.join(parent, "repo"),
+    records: Record<string, unknown>[] = [];
+  rosterRepo(rootDir, "disable-attach");
+  registerDaemonRepo({ canonicalRoot: rootDir, repoId: "disable-attach", userRoot, createConvenienceLinks: false });
+  const root = canonicalRoot(rootDir),
+    lockPath = `${root}.harness-anything-writer.lock`,
+    gate = gateFirstOpen("disable-attach"),
+    host = await openDaemonHost({
+      daemonId: "disable-attach",
+      userRoot,
+      attachTimeoutMs: 2_000,
+      openCell: gate.openCell,
+      recordLifecycle: (record) => records.push(record),
+    });
+  try {
+    await host.attachmentsSettled(); // the attach budget expires; the underlying open is still hung
+    const started = performance.now(),
+      disabled = await host.admin({ kind: "update", repoId: "disable-attach", state: "disabled" }, auth),
+      elapsedMs = performance.now() - started;
+    assert.equal(disabled.outcome, "applied");
+    assert.ok(elapsedMs < 1_000, `disable must not wait for the in-flight attach: ${elapsedMs.toFixed(1)}ms`);
+    // The late completion is a real Cell: it owns a writer worker and the workspace lock.
+    const late = await openRepoCell({
+      repoId: workspaceId("disable-attach"),
+      rootDir: root,
+      ownerId: "disable-attach",
+    });
+    assert.equal(existsSync(lockPath), true, "the late Cell must really hold the workspace writer lock");
+    await gate.release(late);
+    for (
+      let attempt = 0;
+      attempt < 500 && !records.some((record) => record.event === "repo_attach_discarded");
+      attempt += 1
+    )
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    assert.equal(
+      records.some((record) => record.event === "repo_attach_discarded" && record.repoId === "disable-attach"),
+      true,
+      "a disabled repo's late attach must record a discard terminal",
+    );
+    assert.equal(
+      records.some((record) => record.event === "repo_attach_completed" && record.repoId === "disable-attach"),
+      false,
+      "a disabled repo must never publish an attach",
+    );
+    assert.equal(late.status().state, "closed", "the discarded Cell must be closed, not just dropped from the map");
+    assert.equal(existsSync(lockPath), false, "the discarded attach must release the workspace writer lock");
+    assert.equal(
+      host.status().repos.some((repo) => repo.repoId === "disable-attach"),
+      false,
+    );
+    // Re-enabling is unaffected: the next registry refresh opens a fresh Cell and serves writes.
+    assert.equal(
+      (await host.admin({ kind: "update", repoId: "disable-attach", state: "enabled" }, auth)).outcome,
+      "applied",
+    );
+    assert.equal(host.status().repos.find((repo) => repo.repoId === "disable-attach")?.state, "attached");
+    assert.equal(
+      (
+        await host.run(
+          "disable-attach",
+          { kind: "task-create", taskId: "task_disable_attach", title: "Disable attach" },
+          auth,
+        )
+      ).outcome,
+      "applied",
+    );
+  } finally {
+    await host.close();
+    rmSync(parent, { recursive: true, force: true });
+  }
+});
+
+test("an attach that lands after its registration changed mode is discarded and reopens in the new mode", async () => {
+  const parent = mkdtempSync(path.join(tmpdir(), "ha-host-mode-attach-")),
+    userRoot = path.join(parent, "user"),
+    rootDir = path.join(parent, "repo"),
+    records: Record<string, unknown>[] = [];
+  let clock = "2026-09-10T00:00:00.000Z";
+  rosterRepo(rootDir, "mode-attach");
+  registerDaemonRepo({
+    canonicalRoot: rootDir,
+    repoId: "mode-attach",
+    mode: "local",
+    userRoot,
+    createConvenienceLinks: false,
+  });
+  const root = canonicalRoot(rootDir),
+    lockPath = `${root}.harness-anything-writer.lock`,
+    gate = gateFirstOpen("mode-attach"),
+    host = await openDaemonHost({
+      daemonId: "mode-attach",
+      userRoot,
+      attachTimeoutMs: 2_000,
+      openCell: gate.openCell,
+      now: () => clock,
+      recordLifecycle: (record) => records.push(record),
+    });
+  try {
+    await host.attachmentsSettled();
+    assert.equal(
+      (await host.admin({ kind: "update", repoId: "mode-attach", mode: "remote-edge" }, auth)).outcome,
+      "applied",
+    );
+    const late = await openRepoCell({ repoId: workspaceId("mode-attach"), rootDir: root, ownerId: "mode-attach" });
+    assert.equal(existsSync(lockPath), true);
+    await gate.release(late);
+    for (
+      let attempt = 0;
+      attempt < 500 && !records.some((record) => record.event === "repo_attach_discarded");
+      attempt += 1
+    )
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    assert.equal(
+      records.some((record) => record.event === "repo_attach_discarded" && record.repoId === "mode-attach"),
+      true,
+    );
+    assert.equal(
+      records.some((record) => record.event === "repo_attach_completed" && record.repoId === "mode-attach"),
+      false,
+      "a stale-mode attach must not publish",
+    );
+    assert.equal(late.status().state, "closed");
+    assert.equal(existsSync(lockPath), false);
+    const latched = host.status().repos.find((repo) => repo.repoId === "mode-attach")!;
+    assert.equal(latched.state, "unavailable");
+    assert.match(String(latched.lastError), /changed registration while it was attaching/u);
+    assert.equal(latched.causeClass, "infrastructure");
+    // Past the reprobe throttle the still-enabled repo reopens under the registry's current mode.
+    clock = "2026-09-10T00:00:30.000Z";
+    assert.equal((await host.run("mode-attach", { kind: "task-list" }, auth)).outcome, "applied");
+    assert.equal(host.status().repos.find((repo) => repo.repoId === "mode-attach")?.mode, "remote-edge");
   } finally {
     await host.close();
     rmSync(parent, { recursive: true, force: true });


### PR DESCRIPTION
# English

## Summary
A cold repository attach could publish after its registry row was disabled. Recheck current registry authority before publishing and close discarded cells through the existing writer shutdown path.

## Architectural Justification
Use the existing product entrypoints and lifecycle, without introducing another writer or compatibility path.

## What Changed
Scope is the public diff on codex/disable-warming-attach. No private data is included.

## Gate Harvest / 门收割
Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
Production delta is measured by the CI production-delta job.

## Task And Scope
Task: task_004faca337f4efd8c7838d0481. Private task evidence updated. No unrelated production repository changes.

## Version Impact
No version change; no npm publication.

## Governance Declaration
- Protected surface touched: no
- Protected surface scope: none
- Authority: not applicable
- Break-glass: no

## Verification
Base d9c4c2aa5 for release acceptance; warming fix base a94d5b5e7. Worker reports Docker recovery regressions 17/17 and neighbor 8/8, plus typecheck and lint. Root inspected registry/open diff. This is not a synchronous stop-write barrier. No complete local check:local was requested. GitHub current-head CI has not yet been verified.

## Review Evidence
Initial Root source review performed; full integration review pending. No human approval is claimed.

## Residual Risk
Worker reports Docker recovery regressions 17/17 and neighbor 8/8, plus typecheck and lint. Root inspected registry/open diff. This is not a synchronous stop-write barrier. Cross-scope findings remain tracked in the private task report. Merge only after required CI and review; ordinary merge commit and owned branch cleanup.

## References
Task task_004faca337f4efd8c7838d0481; public source/test diff; private evidence is excluded from this public body.

---

# 中文

## 概要
冷挂载可能在仓库停用后迟到发布；发布前重读注册权威，通过既有关闭路径关闭被丢弃的cell。

## 架构辩护
复用现有入口与生命周期，不新增第二writer或兼容路径。

## 改动内容
公开范围见codex/disable-warming-attach diff，不含私有数据。

## 门收割 / Gate Harvest
未删除完整生产路径或门禁；生产增删以CI计算为准。

## 任务与范围
任务task_004faca337f4efd8c7838d0481。私有证据已更新，不操作无关生产仓库。

## 版本影响
不改版本，不发布npm。

## 治理声明
- 是否触碰protected surface：no
- 范围：无
- 依据：不适用
- Break-glass：no

## 验证
worker报告Docker回归17/17与邻测8/8以及类型检查和lint，Root已审查registry/open改动。这不构成同步停写屏障。 未要求完整本地check:local；尚未核实本head完整GitHub CI。

## 审查证据
Root已做初步源码审查，集成审查待完成，不宣称人工批准。

## 残余风险
worker报告Docker回归17/17与邻测8/8以及类型检查和lint，Root已审查registry/open改动。这不构成同步停写屏障。 跨范围发现见私有任务报告。真实CI和评审通过后普通merge并清理自有分支。

## 关联材料
任务task_004faca337f4efd8c7838d0481，源码/测试见公开diff，私有材料不放公开描述。

## PR Gate Checklist / PR 门禁清单
- [x] Two complete language blocks and scoped public changes. / 双语正文与限定公开范围。
- [x] No private ledger or local absolute paths included. / 不含私有台账或本机绝对路径。
- [ ] Current head CI and integration review passed. / 本head CI与集成评审通过。
