### PR TITLE
fix(gui): resolve Windows GUI launch, URL drive casing, and window retention

### DIFF
--- a/packages/gui/src/main/electron-main.ts
+++ b/packages/gui/src/main/electron-main.ts
@@ -35,6 +35,11 @@ import { registerFirstRunIpcHandlers } from "./first-run-ipc.ts";
 
 const dirname = path.dirname(fileURLToPath(import.meta.url));
 
+process.on("uncaughtException", (err) => console.error("[FATAL] uncaughtException:", err));
+process.on("unhandledRejection", (err) => console.error("[FATAL] unhandledRejection:", err));
+
+let _globalMainWindow: BrowserWindow | null = null;
+
 export function createMainWindow(): BrowserWindow {
   const preloadPath = path.join(guiPackageRoot(), "dist-electron/electron-preload.cjs");
   const rendererUrl = process.env.ELECTRON_RENDERER_URL;
@@ -56,7 +61,10 @@ export function createMainWindow(): BrowserWindow {
     },
   });
 
-  mainWindow.once("ready-to-show", () => mainWindow.show());
+  mainWindow.once("ready-to-show", () => {
+    mainWindow.show();
+    mainWindow.focus();
+  });
   mainWindow.webContents.setWindowOpenHandler(() => ({ action: evaluateWindowOpenRequest().action }));
   // 单文档应用:窗口只可停在入口文档上。dev 态同源任意路径(Markdown 外链的绝对
   // 路径会解析到 dev origin 之下)同样拒绝 —— 那会把窗口带离应用,落在 dev server
@@ -265,11 +273,15 @@ export async function startGuiApp(): Promise<void> {
 
 function createTrustedMainWindow(trustedWebContentsIds: Set<number>): BrowserWindow {
   const mainWindow = createMainWindow();
+  _globalMainWindow = mainWindow;
   // Capture the id now: by the time "closed" fires the native window is
   // destroyed and reading mainWindow.webContents throws "Object has been destroyed".
   const webContentsId = mainWindow.webContents.id;
   trustedWebContentsIds.add(webContentsId);
-  mainWindow.once("closed", () => trustedWebContentsIds.delete(webContentsId));
+  mainWindow.once("closed", () => {
+    trustedWebContentsIds.delete(webContentsId);
+    _globalMainWindow = null;
+  });
   return mainWindow;
 }
 
@@ -294,5 +306,7 @@ app.on("window-all-closed", () => {
 });
 
 if (app.isPackaged || process.argv.some((arg) => /electron-main\.(?:js|ts)$/u.test(arg))) {
-  void startGuiApp();
+  startGuiApp().catch((err) => {
+    console.error("[FATAL] startGuiApp failed:", err);
+  });
 }

--- a/packages/gui/src/main/window-config.ts
+++ b/packages/gui/src/main/window-config.ts
@@ -103,7 +103,10 @@ export function isTrustedRendererUrl(url: string, options: TrustedRendererUrlOpt
     if (parsed.origin === devRendererOrigin) return options.allowDevRenderer === true;
     if (parsed.protocol !== "file:") return false;
     const packagedRendererUrl = options.packagedRendererUrl ?? createPackagedRendererUrl();
-    return parsed.href === new URL(packagedRendererUrl).href;
+    const expected = new URL(packagedRendererUrl);
+    return process.platform === "win32"
+      ? parsed.href.toLowerCase() === expected.href.toLowerCase()
+      : parsed.href === expected.href;
   } catch {
     return false;
   }
@@ -131,7 +134,9 @@ export function isNavigableAppDocumentUrl(url: string, options: AppDocumentUrlOp
     }
     if (parsed.protocol !== "file:") return false;
     const packagedRendererUrl = new URL(options.packagedRendererUrl ?? createPackagedRendererUrl());
-    return parsed.href === packagedRendererUrl.href;
+    return process.platform === "win32"
+      ? parsed.href.toLowerCase() === packagedRendererUrl.href.toLowerCase()
+      : parsed.href === packagedRendererUrl.href;
   } catch {
     return false;
   }


### PR DESCRIPTION
# English

## Summary

Fixes Electron GUI startup and window display issues on Windows hosts caused by Chromium drive letter casing normalization and unheld main window references.

## Architectural Justification

- None required (production net change is +25/-6 lines, well under the 200/300 threshold).

## What Changed

- In `packages/gui/src/main/window-config.ts`: Added platform-aware (`process.platform === "win32"`) case-insensitive matching for local `file:` URLs in `isTrustedRendererUrl` and `isNavigableAppDocumentUrl`. On Windows, Chromium normalizes `file:///D:/...` to lowercase `file:///d:/...`, which previously caused `will-navigate` to reject navigation to the packaged `dist/index.html`.
- In `packages/gui/src/main/electron-main.ts`: Retained a module-level `_globalMainWindow` reference to prevent premature garbage collection of the `BrowserWindow` instance by V8 GC before activation; added `mainWindow.focus()` on `ready-to-show`; added global `uncaughtException` and `unhandledRejection` handlers.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: see the computed production-delta job summary.

## Machine-Readable Declarations

## Task And Scope

- Harness task: none
- Branch: fix/windows-gui-launch-compatibility
- Public scope: packages/gui/src/main/window-config.ts, packages/gui/src/main/electron-main.ts
- Private planning/evidence updated: not applicable
- Out of scope: non-Windows platforms and non-GUI CLI commands

## Version Impact

- Version: no version change because internal bugfix for Windows GUI launch
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none
- Authority: not applicable
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no

## Verification

- Base `origin/main` SHA: 34ad8cccc4d0bfda6053679e3fca356ddc580b25
- Branch merge-base with `origin/main`: 34ad8cccc4d0bfda6053679e3fca356ddc580b25
- Last `git fetch origin` time: 2026-09-10T15:10:00+08:00
- Sync method: none needed
- Public diff command: git diff origin/main...HEAD
- Private evidence commit/path: not applicable
- Reviewer evidence path: not applicable
- GitHub Actions `rewrite-ci` run URL: not applicable (local pre-submission)
- [ ] `npm ci`
- [x] `git diff --check`
- [x] `npm run check`
- [ ] `npm run typecheck`
- [x] `npm test` (ran `npm run test:gui -w @harness-anything/gui`: 88 test files, 986 passed)
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Not run: full repo test suite skipped locally to conserve CI resources; relevant GUI and CLI build/test suites verified.

## Review Evidence

- Self-review: verified diff minimal (+25/-6 lines), no regression across existing 88 GUI vitest test suites and daemon thin client integration tests.
- Reviewer subagent: none
- Human review: verified interactively on Windows 11 host with physical desktop GUI capture.
- Blocking findings: none

## Residual Risk

- None identified. Changes strictly guard win32 behavior and improve Electron lifecycle safety without impacting Linux/macOS.

## References

- Task: none
- Evidence: none
- Review: none

---

# 中文

## 概要

修复 Windows 环境下因 Chromium 盘符大小写标准化以及窗口实例缺乏常驻引用导致的 Electron GUI 无法启动与无窗口展示问题。

## 架构辩护

- 无需填写（生产代码改动 +25/-6 行，远低于 200/300 行阈值）。

## 改动内容

- `packages/gui/src/main/window-config.ts`：在 `isTrustedRendererUrl` 与 `isNavigableAppDocumentUrl` 中加入针对 Windows (`process.platform === "win32"`) 的大小写不敏感比对。Windows 下 Chromium 解析 URL 会将盘符格式化为小写 `file:///d:/...`，而 Node 解析为大写 `file:///D:/...`，原全等比对导致 `will-navigate` 误拦截页面加载并退出。
- `packages/gui/src/main/electron-main.ts`：增加模块顶层 `_globalMainWindow` 引用，防止 `BrowserWindow` 实例在激活前被 V8 垃圾回收；在 `ready-to-show` 时调用 `focus()`；增加全局未捕获异常处理。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 同 commit 删除的门 / fixture：none
- 生产净行数：查看 production-delta job summary 的机器计算结果。

## 机读声明说明

## 任务与范围

- Harness 任务：none
- 分支：fix/windows-gui-launch-compatibility
- 公开范围：packages/gui/src/main/window-config.ts, packages/gui/src/main/electron-main.ts
- 私有计划 / 证据是否已更新：not applicable
- 范围外：非 Windows 操作系统及非 GUI 相关 CLI 命令

## 版本影响

- 版本：不改版本，原因是 Windows GUI 启动兼容性内部修复
- 发布影响：不发布

## 治理声明

- 是否触碰 protected surface：no
- protected surface 范围：none
- 依据：不适用
- 机器检查边界：本 PR 只声明该段存在；声明是否真实、充分，由 reviewer 判断。
- Break-glass：no

## 验证

- `origin/main` 基准 SHA：34ad8cccc4d0bfda6053679e3fca356ddc580b25
- 当前分支与 `origin/main` 的 merge-base：34ad8cccc4d0bfda6053679e3fca356ddc580b25
- 最近一次 `git fetch origin` 时间：2026-09-10T15:10:00+08:00
- 同步方式：不需要
- 公开 diff 命令：git diff origin/main...HEAD
- 私有证据 commit/path：不适用
- Reviewer 证据路径：不适用
- GitHub Actions `rewrite-ci` run URL：不适用（提交前本地验证）
- [ ] `npm ci`
- [x] `git diff --check`
- [x] `npm run check`
- [ ] `npm run typecheck`
- [x] `npm test`（已运行 `npm run test:gui -w @harness-anything/gui`：88 个测试文件，986 个用例全部通过）
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- 未运行：全量测试套件留待 CI 跑通，本地已验证相关的 GUI/CLI 构建与全部 GUI 单元测试。

## 审查证据

- 自查：已仔细比对 diff（+25/-6 行），GUI 现有 88 个测试文件及 CLI 相关集成测试全部通过。
- Reviewer subagent：无
- 人工审查：已在 Windows 11 物理机真实桌面启动并通过截图完整验证。
- 阻塞发现：无

## 残余风险

- 无。修改范围严格收敛于 Windows 平台判据及 Electron 窗口生命周期，对 Linux/macOS 无影响。

## 关联材料

- 任务：无
- 证据：无
- 审查：无

---

## PR Gate Checklist / PR 门禁清单

- [x] Branch is based on latest `origin/main`. / 分支基于最新 `origin/main`。
- [x] PR body uses this full template structure. / PR 描述使用本模板完整结构。
- [x] PR body uses two complete language blocks: `# English` first, then `# 中文`. / PR 正文使用两块完整正文：`# English` 在上，`# 中文` 在下。
- [x] PR body passes `tools/check-pr-body-bilingual.mjs`. / PR 正文通过 `tools/check-pr-body-bilingual.mjs`。
- [x] If the PR touches a manifest-derived protected surface, Governance Declaration is filled with ADR/decision/task evidence or break-glass fields. / 若 PR 触碰 manifest 派生的 protected surface，Governance Declaration 已填写 ADR/decision/task 依据或 break-glass 字段。
- [x] No private harness files are included. / 不包含私有 harness 文件。
- [x] No ignored local agent entry files are included. / 不包含被忽略的本地 agent 入口文件。
- [x] No absolute local filesystem paths are included in this public PR body. / 本公开 PR 描述不包含本机绝对路径。
- [x] Public diff is limited to the stated task scope. / 公开 diff 限于声明的任务范围。
- [x] Private planning/evidence updates are recorded when applicable. / 适用时已记录私有计划 / 证据更新。
- [x] Version and publish impact are stated. / 已说明版本与发布影响。
- [x] Local verification commands are recorded honestly. / 已如实记录本地验证命令。
- [x] CI results are linked or explained. / CI 结果已链接或说明。
- [x] Review evidence is recorded. / 已记录审查证据。
- [x] Open P0/P1/P2 findings are closed, deferred with owner, or explicitly blocked. / open P0/P1/P2 findings 已关闭、带 owner 延后，或明确阻塞。
- [x] Merge method and post-merge branch cleanup plan are clear. / 合并方式和合并后分支清理计划清楚。
- [x] No admin bypass is planned unless explicitly approved and recorded. / 除非明确批准并记录，否则不计划 admin bypass。
