### PR TITLE
perf: read Git closure blobs by their listed object ids

### DIFF
--- a/packages/kernel/src/store/local-version-control-system.ts
+++ b/packages/kernel/src/store/local-version-control-system.ts
@@ -323,28 +323,31 @@ export const localGitObjectRefStore = Object.freeze({
   readPaths: (
     repoRoot: string,
     commit: string,
-    entries: readonly { readonly target: string; readonly size: number }[],
+    entries: readonly { readonly target: string; readonly size: number; readonly oid: string }[],
   ): ReadonlyMap<string, Buffer> => {
     // One `cat-file --batch` per bounded chunk instead of one `git show` per path: the
     // canonical ledger holds ~10^5 event and content blobs, and per-path processes turned
-    // a stopped-generation read into hours.
+    // a stopped-generation read into hours. Each blob is addressed by the id the caller's
+    // `ls-tree` of this same commit returned: `<commit>:<path>` makes git walk every tree
+    // on the path and scan it entry by entry, so a directory of N files costs O(N) per
+    // lookup and a whole-closure read turns quadratic.
     const bytesByTarget = new Map<string, Buffer>();
-    let chunk: { readonly target: string; readonly size: number }[] = [],
+    let chunk: { readonly target: string; readonly size: number; readonly oid: string }[] = [],
       chunkBytes = 0;
     const flush = () => {
       if (chunk.length === 0) return;
       const output = withStdinFile(
         repoRoot,
         ".ha-cat-file-batch-",
-        [chunk.map(({ target }) => `${commit}:${target}\n`).join("")],
+        [chunk.map(({ oid }) => `${oid}\n`).join("")],
         (inputFd) => localGitBytes(repoRoot, ["cat-file", "--batch"], inputFd),
       );
       let offset = 0;
-      for (const { target } of chunk) {
+      for (const { target, oid } of chunk) {
         const newline = output.indexOf(0x0a, offset);
         if (newline < 0) throw new Error(`Git cat-file --batch output ended before ${target}`);
         const header = output.subarray(offset, newline).toString("utf8"),
-          size = /^[0-9a-f]{40} blob ([0-9]+)$/u.exec(header)?.[1];
+          size = header.startsWith(`${oid} blob `) ? /^[0-9a-f]{40} blob ([0-9]+)$/u.exec(header)?.[1] : undefined;
         if (size === undefined) throw new Error(`Git cat-file --batch could not read ${commit}:${target}: ${header}`);
         const start = newline + 1,
           end = start + Number(size);

--- a/packages/kernel/src/store/sqlite-task-event-publication.ts
+++ b/packages/kernel/src/store/sqlite-task-event-publication.ts
@@ -356,7 +356,7 @@ function verifyDocumentClosure(
       commit,
       [...closure.documents.keys()].flatMap((logical) => {
         const entry = tree.get(ledgerGitPath(ledger, logical));
-        return entry ? [{ target: entry.target, size: entry.size }] : [];
+        return entry ? [{ target: entry.target, size: entry.size, oid: entry.oid }] : [];
       }),
     );
   for (const [logical, expected] of closure.documents) {
@@ -393,7 +393,7 @@ export function verifyGitFiles(repoRoot: string, commit: string, files: readonly
       commit,
       files.flatMap((file) => {
         const entry = "target" in file ? tree.get(file.target) : undefined;
-        return entry ? [{ target: entry.target, size: entry.size }] : [];
+        return entry ? [{ target: entry.target, size: entry.size, oid: entry.oid }] : [];
       }),
     );
   for (const file of files) {
@@ -552,7 +552,7 @@ export function captureGitBaseline(
       commit,
       targets.flatMap((target) => {
         const entry = tree.get(target);
-        return entry ? [{ target, size: entry.size }] : [];
+        return entry ? [{ target, size: entry.size, oid: entry.oid }] : [];
       }),
     );
   return new Map(


### PR DESCRIPTION
# English

## Summary

Read batched Git blobs by the object ids already returned by the same commit tree. This avoids repeated path-to-object resolution while retaining full byte comparisons and validating returned object identity.

## Architectural Justification
Use the existing product entrypoints and lifecycle, without introducing another writer or compatibility path.

## What Changed
Scope is the public diff on codex/v2-cold-oid. No private data is included.

## Gate Harvest / 门收割
Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
Production delta is measured by the CI production-delta job.

## Task And Scope
Task: task_efba1f39d9eaa52a2766595737. Private task evidence updated. No unrelated production repository changes.

## Version Impact
No version change; no npm publication.

## Governance Declaration
- Protected surface touched: no
- Protected surface scope: none
- Authority: not applicable
- Break-glass: no

## Verification
Original worker reports six Docker files and controlled cold-start experiments. Root replayed the patch onto main468faa6e5 and ran local-version-control-settlement and sqlite-event-store in Docker plus CLI typecheck, all passed. Real Ubuntu 1k/2690/10k follow-up remains incomplete; no complete release-scale claim. Rebased onto 2d3a670d1 (the PR #2403 merge, which moved verifyDocumentClosure, verifyGitFiles and captureGitBaseline into sqlite-task-event-publication.ts); the three one-line `oid` additions were carried over to that module unchanged, and local-version-control-settlement (6/6) and sqlite-event-store (24/24) passed again in Docker on the rebased head. Current-head GitHub CI and final Root review pending.

## Review Evidence
Initial Root source review performed; full integration review pending. No human approval is claimed.

## Residual Risk
Original worker reports six Docker files and controlled cold-start experiments. Root replayed the patch onto main468faa6e5 and ran local-version-control-settlement and sqlite-event-store in Docker plus CLI typecheck, all passed. Real Ubuntu 1k/2690/10k follow-up remains incomplete; no complete release-scale claim. Normal merge after required checks and review; no npm publish.

## References
Task task_efba1f39d9eaa52a2766595737; public source/test diff; private evidence is excluded from this public body.

---

# 中文

## 概要

批量Git内容读取改用同一commit树已经返回的对象id，避免重复路径查找；完整字节比较与返回对象身份核验保留。

## 架构辩护
复用现有入口与生命周期，不新增第二writer或兼容路径。

## 改动内容
公开范围见codex/v2-cold-oid diff，不含私有数据。

## 门收割 / Gate Harvest
未删除完整生产路径或门禁；生产增删以CI计算为准。

## 任务与范围
任务task_efba1f39d9eaa52a2766595737。私有证据已更新，不操作无关生产仓库。

## 版本影响
不改版本，不发布npm。

## 治理声明
- 是否触碰protected surface：no
- 范围：无
- 依据：不适用
- Break-glass：no

## 验证
原worker报告六个Docker文件与受控冷启动实验。Root将补丁移至main468faa6e5，Docker定向运行settlement与sqlite-event-store并通过CLI类型检查。真实Ubuntu 1k/2690/10k后续仍待验，不声明完整规模通过。 已rebase到2d3a670d1（PR #2403的合并；它把verifyDocumentClosure、verifyGitFiles和captureGitBaseline挪进了sqlite-task-event-publication.ts），三处单行`oid`改动原样迁到该模块；rebase后的head上，Docker重跑local-version-control-settlement（6/6）与sqlite-event-store（24/24）均通过。当前head完整CI与Root终审待完成。

## 审查证据
Root已做初步源码审查，集成审查待完成，不宣称人工批准。

## 残余风险
原worker报告六个Docker文件与受控冷启动实验。Root将补丁移至main468faa6e5，Docker定向运行settlement与sqlite-event-store并通过CLI类型检查。真实Ubuntu 1k/2690/10k后续仍待验，不声明完整规模通过。 检查与评审通过后普通merge，不发布npm。

## 关联材料
任务task_efba1f39d9eaa52a2766595737，源码/测试见公开diff，私有材料不放公开描述。

## PR Gate Checklist / PR 门禁清单
- [x] Two complete language blocks and scoped public changes. / 双语正文与限定公开范围。
- [x] No private ledger or local absolute paths included. / 不含私有台账或本机绝对路径。
- [ ] Current head CI and integration review passed. / 本head CI与集成评审通过。

