### PR TITLE
fix: let ci observe pull import named runs

### DIFF
--- a/packages/cli/test/thin-command.test.ts
+++ b/packages/cli/test/thin-command.test.ts
@@ -713,6 +713,11 @@ test("thin parser routes CI observation pulls through the repo task command", ()
     assert.deepEqual(parsed.command.action, { kind: "ci-observe-pull", limit: 20 });
   }
   assert.equal(parseThinCommand(["ci", "observe", "pull", "--limit", "0"]).ok, false);
+  const named = parseThinCommand(["ci", "observe", "pull", "--run", "34091151001", "--run", "33890867571"]);
+  assert.equal(named.ok, true, JSON.stringify(named));
+  if (named.ok)
+    assert.deepEqual(named.command.action, { kind: "ci-observe-pull", runs: ["34091151001", "33890867571"] });
+  assert.equal(parseThinCommand(["ci", "observe", "pull", "--run", "abc"]).ok, false);
 });
 
 test("thin parser validates only the selected command descriptor", () => {

--- a/packages/daemon/src/ci-observation-actions.ts
+++ b/packages/daemon/src/ci-observation-actions.ts
@@ -25,43 +25,49 @@ export async function pullAndIngestCiObservations(
   binding: RepoCellBinding,
   runGh: RunGh = (command, args, options) => runProcessTextAsync(command, args, options.cwd),
 ): Promise<WriteReceipt> {
-  const limit = Number(action.limit ?? 20);
+  const limit = Number(action.limit ?? 20),
+    namedRuns = Array.isArray(action.runs) ? action.runs.map(Number) : null;
   if (!Number.isSafeInteger(limit) || limit < 1 || limit > 100)
     throw cell.cellCodedError("invalid_command", "CI observation pull limit must be 1..100.");
+  if (namedRuns && action.limit !== undefined)
+    throw cell.cellCodedError("invalid_command", "Use --run <run-id> or --limit <count>, not both.");
+  if (namedRuns && (namedRuns.length > 100 || namedRuns.some((id) => !Number.isSafeInteger(id) || id < 1)))
+    throw cell.cellCodedError("invalid_command", "CI observation pull accepts 1..100 positive --run ids.");
   const temporaryRoot = mkdtempSync(path.join(tmpdir(), "ha-ci-observe-"));
   try {
-    const runs = selectCiObservationRuns(
-      (
-        await Promise.all(
-          ["rewrite-ci.yml", "rebuild-gates.yml"].map(
-            async (workflow) =>
-              JSON.parse(
-                await runGh(
-                  "gh",
-                  [
-                    "run",
-                    "list",
-                    "--workflow",
-                    workflow,
-                    "--limit",
-                    String(limit),
-                    "--json",
-                    "databaseId,headBranch,createdAt",
-                  ],
-                  { cwd: cell.rootDir },
-                ),
-              ) as readonly CiWorkflowRun[],
-          ),
-        )
-      ).flat(),
-      limit,
-    );
+    const runs: readonly Pick<CiWorkflowRun, "databaseId">[] =
+      namedRuns?.map((databaseId) => ({ databaseId })) ??
+      selectCiObservationRuns(
+        (
+          await Promise.all(
+            ["rewrite-ci.yml", "rebuild-gates.yml"].map(
+              async (workflow) =>
+                JSON.parse(
+                  await runGh(
+                    "gh",
+                    [
+                      "run",
+                      "list",
+                      "--workflow",
+                      workflow,
+                      "--limit",
+                      String(limit),
+                      "--json",
+                      "databaseId,headBranch,createdAt",
+                    ],
+                    { cwd: cell.rootDir },
+                  ),
+                ) as readonly CiWorkflowRun[],
+            ),
+          )
+        ).flat(),
+        limit,
+      );
     const eventRefs: string[] = [];
     let imported = 0,
       duplicate = 0,
       lastRevision = cell.store.readHead()?.revision ?? 0;
     for (const run of runs) {
-      if (run.headBranch !== "main") continue;
       const summary = JSON.parse(
         await runGh(
           "gh",
@@ -83,8 +89,8 @@ export async function pullAndIngestCiObservations(
         attempt: number;
       };
       const { status: runLifecycleState } = summary;
-      // Publish immutable observations only once the run has a final conclusion.
-      if (runLifecycleState !== "completed") continue;
+      // Publish immutable observations only for main runs that have a final conclusion.
+      if (summary.headBranch !== "main" || runLifecycleState !== "completed") continue;
       const runRoot = path.join(temporaryRoot, String(run.databaseId));
       try {
         await runGh(
@@ -154,7 +160,13 @@ export async function pullAndIngestCiObservations(
       outcome: visible ? "applied" : "pending",
       opId: `ci-observe-pull-${Date.now()}`,
       revision: lastRevision,
-      evidence: JSON.stringify({ schema: "ci-observe-pull/v1", imported, duplicate, requestedRuns: limit, eventRefs }),
+      evidence: JSON.stringify({
+        schema: "ci-observe-pull/v1",
+        imported,
+        duplicate,
+        requestedRuns: namedRuns?.length ?? limit,
+        eventRefs,
+      }),
       visibility: "center",
       proof: {
         committedRevision: lastRevision,

--- a/packages/daemon/src/protocol/daemon-protocol-commands-ci.ts
+++ b/packages/daemon/src/protocol/daemon-protocol-commands-ci.ts
@@ -16,9 +16,10 @@ export const ciObservationProtocolCommands = Object.freeze([
     actionKind: "ci-observe-pull",
     phase: "PLT-TestEng-W1",
     path: ["ci", "observe", "pull"],
-    summary: "Pull structured GitHub Actions observations and append canonical CI events.",
+    summary: "Pull GitHub Actions CI observations; --run imports named runs instead of the latest --limit runs.",
     method: "repo.task.run",
     inputs: [
+      cliInput("--run", "repeated", false, { code: "invalid_field" }, { field: "runs", regex: "^[1-9][0-9]{0,19}$" }),
       cliInput(
         "--limit",
         "single",

--- a/packages/daemon/test/ci-observatory-read.test.ts
+++ b/packages/daemon/test/ci-observatory-read.test.ts
@@ -331,6 +331,82 @@ test("CI observation pull writes canonical events once per run and job", async (
   }
 });
 
+test("CI observation pull imports named main runs without listing recent runs", async () => {
+  const rootDir = mkdtempSync(path.join(process.cwd(), ".tmp-ci-observation-named-")),
+    events: CiRunObservationEventV2[] = [],
+    calls: string[] = [];
+  const cell = {
+    rootDir,
+    now: () => "2026-09-10T00:00:00.000Z",
+    cellCodedError: (_code: string, message: string) => new Error(message),
+    store: {
+      readHead: () => (events.length ? { revision: events.length } : null),
+      readEvent: (opId: string) => events.find((event) => event.opId === opId),
+      append: ({ event }: { event: CiRunObservationEventV2 }) => {
+        events.push(event);
+        return { revision: events.length };
+      },
+    },
+    projection: { apply: () => undefined, readCiRunObservations: () => ({ watermark: events.length }) },
+  };
+  const runGh = async (_command: string, args: readonly string[]) => {
+    calls.push(`${args[1]}:${args[2]}`);
+    if (args[1] === "view")
+      return JSON.stringify({
+        workflowName: "rewrite-ci",
+        headSha: `sha-${args[2]}`,
+        headBranch: args[2] === "700" ? "main" : "codex/feature",
+        status: "completed",
+        conclusion: "success",
+        attempt: 1,
+      });
+    assert.equal(args[1], "download");
+    const output = String(args[args.indexOf("--dir") + 1]);
+    mkdirSync(output, { recursive: true });
+    writeFileSync(
+      path.join(output, "observation.json"),
+      JSON.stringify({
+        schema: "ci-run-artifact/v1",
+        run: {
+          runId: `${args[2]}.1`,
+          sha: `sha-${args[2]}`,
+          branch: "main",
+          prNumber: null,
+          job: "full-check (24)",
+          wallclockMs: 20,
+          runner: "ubuntu",
+        },
+        tests: [],
+        gates: [],
+      }),
+    );
+    return "";
+  };
+  try {
+    const receipt = await pullAndIngestCiObservations(
+      cell as never,
+      { kind: "ci-observe-pull", runs: ["700", "701"] },
+      { actor, source: "local" },
+      runGh,
+    );
+    assert.deepEqual(calls, ["view:700", "download:700", "view:701"]);
+    assert.equal(events.length, 1);
+    assert.equal(events[0]?.payload.verification?.headSha, "sha-700");
+    assert.equal(JSON.parse(receipt.evidence).requestedRuns, 2);
+    await assert.rejects(
+      pullAndIngestCiObservations(
+        cell as never,
+        { kind: "ci-observe-pull", runs: ["700"], limit: 5 },
+        { actor, source: "local" },
+        runGh,
+      ),
+      /not both/u,
+    );
+  } finally {
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});
+
 test("CI completion verdict comes from the completed matching workflow run, not artifact labels", async () => {
   const cases = [
     {


### PR DESCRIPTION
# English

## Summary

`ha task complete` accepts only a verified `ci_run_observed` event whose SHA equals the submission commit. `ha ci observe pull` could reach only the newest `--limit` runs, and PR runs count toward that limit, so the reach is about 30 main runs. A submission anchored at an older main commit could therefore never be evidenced, even though its green `rewrite-ci` run and observation artifacts were still retained on GitHub. `--run <id>` (repeatable) imports named runs directly.

## Architectural Justification

- Not required (churn 78, net +14).

## What Changed

- `ci observe pull --run <run-id>` (repeatable, 1..100) imports exactly the named runs and does not list recent runs. `--run` and `--limit` cannot be used together.
- The main-branch filter now reads the authoritative `gh run view` summary. One check covers both the listed path and the named path, and the listing path still pre-filters main runs as before.
- The evidence reports `requestedRuns` as the number of named runs when `--run` is used.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: see the computed production-delta job summary (+46/-32 locally).

## Machine-Readable Declarations

## Task And Scope

- Harness task: task_009013282c373a19e297bc39ae (completion evidence judgment: `--ci` accepts only receipt references; this makes such receipts obtainable for older submissions)
- Branch: `codex/ci-observe-run`
- Public scope: `packages/daemon/src/ci-observation-actions.ts`, the CI protocol command declaration, and two test files
- Private planning/evidence updated: yes
- Out of scope: verification semantics are unchanged. Only completed `rewrite-ci` runs on `main` whose artifact SHA and attempt match are still marked verified.

## Version Impact

- Version: no version change because this is an additive CLI input on an unreleased command surface
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none
- Authority: not applicable
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `1f85019afd376384f8153d739e412e3b8c1e5933`
- Branch merge-base with `origin/main`: `1f85019afd376384f8153d739e412e3b8c1e5933`
- Last `git fetch origin` time: 2026-09-10 09:30 UTC
- Sync method: rebase onto origin/main after PR #2403 merged
- Public diff command: `git diff origin/main...codex/ci-observe-run`
- Private evidence commit/path: task package of task_009013282c373a19e297bc39ae
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [x] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Red before fix (Docker-isolated, source files reverted to `origin/main`): `packages/daemon/test/ci-observatory-read.test.ts` 7 pass / 1 fail (new named-run case); `packages/cli/test/thin-command.test.ts` 18 pass / 1 fail (new `--run` parse case).
- Green after fix (Docker-isolated): `ci-observatory-read.test.ts` 8/8; `thin-command.test.ts` 19/19; `json-rpc-protocol.test.ts` 50/50.
- Not run: the full `npm run check` / `npm test` locally. Local agents must not run the full matrix, so CI is the full authority. `check-file-complexity` currently fails on `main` for an unrelated file, and #2403 fixes it.

## Review Evidence

- Self-review: the lead wrote the change and checked it against the verification rule in `ci-observation-actions.ts`. `verification` is still derived from the workflow run summary and artifact identity, never from the caller.
- Reviewer subagent: not used
- Human review: pending
- Blocking findings: none

## Residual Risk

- A named run whose observation artifacts have expired imports nothing, as before. The receipt shows `imported: 0`.

## References

- Task: task_009013282c373a19e297bc39ae
- Evidence: runs such as https://github.com/FairladyZ625/harness-anything/actions/runs/34091151001 still have non-expired `ci-observation-*` artifacts but are unreachable by `--limit 100`
- Review: this PR

---

# 中文

## 概要

`ha task complete` 只认一种 CI 证据：已验证的 `ci_run_observed` 事件，且事件的 SHA 要等于 submission 的 commit。但 `ha ci observe pull` 只能拉最新的 `--limit` 个 run，PR 的 run 也算在里面，实际只覆盖最近 30 个左右的 main run。结果是锚在较早 main 提交上的 submission 永远拿不到证据，哪怕 GitHub 上它那次绿的 `rewrite-ci` run 和观测 artifact 都还在保留期内。新增的 `--run <id>`（可重复）直接导入指定的 run。

## 架构辩护

- 不需要（churn 78，净 +14）。

## 改动内容

- `ci observe pull --run <run-id>`：可重复，1 到 100 个，只导入指定的 run，不再列最近的 run。不能和 `--limit` 同时用。
- 判断是否为 main 分支，改为读 `gh run view` 返回的权威 summary。按列表拉和按名拉走同一处检查；按列表拉时照旧先筛出 main 的 run。
- 用 `--run` 时，证据里的 `requestedRuns` 记为指定 run 的个数。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 同 commit 删除的门 / fixture：none
- 生产净行数：以 production-delta job summary 为准（本地算出 +46/-32）。

## 机读声明说明

- 不涉及依赖变化、事件迁移和保留旧路径，没有机读声明。

## 任务与范围

- Harness 任务：task_009013282c373a19e297bc39ae（完成证据判定：`--ci` 只收 receipt 引用；本 PR 让较早的 submission 也能拿到这样的 receipt）
- 分支：`codex/ci-observe-run`
- 公开范围：`packages/daemon/src/ci-observation-actions.ts`、CI 协议命令声明、两个测试文件
- 私有计划 / 证据是否已更新：yes
- 范围外：验证语义不变，仍然只有 main 上已完成、且 artifact 的 SHA 和 attempt 都对得上的 `rewrite-ci` run 才标为已验证。

## 版本影响

- 版本：不改版本，因为只是在未发布的命令面上新增一个 CLI 输入
- 发布影响：不发布

## 治理声明

- 是否触碰 protected surface：no
- protected surface 范围：无
- 依据：不适用
- 机器检查边界：本 PR 只声明该段存在；声明是否真实、充分，由 reviewer 判断。
- Break-glass：no
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- `origin/main` 基准 SHA：`1f85019afd376384f8153d739e412e3b8c1e5933`
- 当前分支与 `origin/main` 的 merge-base：`1f85019afd376384f8153d739e412e3b8c1e5933`
- 最近一次 `git fetch origin` 时间：2026-09-10 09:30 UTC
- 同步方式：PR #2403 合入后 rebase 到 origin/main
- 公开 diff 命令：`git diff origin/main...codex/ci-observe-run`
- 私有证据 commit/path：task_009013282c373a19e297bc39ae 任务包
- Reviewer 证据路径：见本 PR 的「审查证据」一节
- GitHub Actions `rewrite-ci` run URL：本 PR 的 CI 还在跑
- [ ] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [x] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- 修复前（Docker 隔离，两个源文件退回 `origin/main` 版本）是红的：`packages/daemon/test/ci-observatory-read.test.ts` 7 过 1 失败，失败的是新加的按名导入用例；`packages/cli/test/thin-command.test.ts` 18 过 1 失败，失败的是新加的 `--run` 解析用例。
- 修复后（Docker 隔离）全绿：`ci-observatory-read.test.ts` 8/8，`thin-command.test.ts` 19/19，`json-rpc-protocol.test.ts` 50/50。
- 未运行：本地整套 `npm run check` / `npm test`。规定禁止本地 agent 跑全量矩阵，全量以 CI 为准。main 上 `check-file-complexity` 目前因一个无关文件而红，由 #2403 修复。

## 审查证据

- 自查：改动由主控编写，并对照了 `ci-observation-actions.ts` 里的验证规则：`verification` 仍然只由 workflow run 的 summary 和 artifact 的身份推出，调用方无法指定。
- Reviewer subagent：未使用
- 人工审查：待进行
- 阻塞发现：无

## 残余风险

- 如果指定 run 的观测 artifact 已过期，和以前一样什么都导入不了，回执里显示 `imported: 0`。

## 关联材料

- 任务：task_009013282c373a19e297bc39ae
- 证据：例如 https://github.com/FairladyZ625/harness-anything/actions/runs/34091151001 ，它的 `ci-observation-*` artifact 还没过期，但 `--limit 100` 已经够不到
- 审查：本 PR

---

## PR Gate Checklist / PR 门禁清单

- [x] Branch is based on latest `origin/main`. / 分支基于最新 `origin/main`。
- [x] PR body uses this full template structure. / PR 描述使用本模板完整结构。
- [x] PR body uses two complete language blocks: `# English` first, then `# 中文`. / PR 正文使用两块完整正文：`# English` 在上，`# 中文` 在下。
- [ ] PR body passes `tools/check-pr-body-bilingual.mjs`. / PR 正文通过 `tools/check-pr-body-bilingual.mjs`。
- [x] If the PR touches a manifest-derived protected surface, Governance Declaration is filled with ADR/decision/task evidence or break-glass fields. / 若 PR 触碰 manifest 派生的 protected surface，Governance Declaration 已填写 ADR/decision/task 依据或 break-glass 字段。
- [x] No private harness files are included. / 不包含私有 harness 文件。
- [x] No ignored local agent entry files are included. / 不包含被忽略的本地 agent 入口文件。
- [x] No absolute local filesystem paths are included in this public PR body. / 本公开 PR 描述不包含本机绝对路径。
- [x] Public diff is limited to the stated task scope. / 公开 diff 限于声明的任务范围。
- [x] Private planning/evidence updates are recorded when applicable. / 适用时已记录私有计划 / 证据更新。
- [x] Version and publish impact are stated. / 已说明版本与发布影响。
- [x] Local verification commands are recorded honestly. / 已如实记录本地验证命令。
- [ ] CI results are linked or explained. / CI 结果已链接或说明。
- [x] Review evidence is recorded. / 已记录审查证据。
- [x] Open P0/P1/P2 findings are closed, deferred with owner, or explicitly blocked. / open P0/P1/P2 findings 已关闭、带 owner 延后，或明确阻塞。
- [x] Merge method and post-merge branch cleanup plan are clear. / 合并方式和合并后分支清理计划清楚。
- [x] No admin bypass is planned unless explicitly approved and recorded. / 除非明确批准并记录，否则不计划 admin bypass。
