### PR TITLE
perf: stop hashing the whole projection on every write

### DIFF
--- a/packages/kernel/src/projection/projection-reads.ts
+++ b/packages/kernel/src/projection/projection-reads.ts
@@ -102,9 +102,11 @@ export interface TaskRelationProjectionRead {
 export interface ProjectionApplyReceipt {
   readonly metrics: { readonly sqliteTransactions: 1; readonly reducedItems: number };
 }
-export interface ProjectionRebuildReceipt {
-  readonly watermark: number;
+export interface ProjectionRebuildReceipt extends ProjectionCatchUpReceipt {
   readonly stateDigest: `sha256:${string}`;
+}
+export interface ProjectionCatchUpReceipt {
+  readonly watermark: number;
   readonly metrics: {
     readonly sqliteTransactions: number;
     readonly reducedItems: number;

--- a/packages/kernel/src/projection/rebuildable-task-projection-catch-up.ts
+++ b/packages/kernel/src/projection/rebuildable-task-projection-catch-up.ts
@@ -9,16 +9,7 @@ import { sha256Text } from "../integrity/stable-hash.ts";
 import type { EventContentPrefetch, EventStreamPort } from "./rebuildable-task-projection-types.ts";
 import type { ProjectionApplyReceipt } from "./projection-reads.ts";
 import { applyEvent } from "./rebuildable-task-projection-event-application.ts";
-import {
-  isAtSourceCut,
-  parseEventJson,
-  queryRows,
-  readStateDigest,
-  refreshStateDigestAtSourceCut,
-  runSql,
-  transaction,
-  watermark,
-} from "./rebuildable-task-projection-sql.ts";
+import { parseEventJson, queryRows, runSql, transaction, watermark } from "./rebuildable-task-projection-sql.ts";
 export type { ProjectionPage, TaskProjectionListQuery, TaskRelationQuery } from "./task-query-projection.ts";
 export type { TaskProjection } from "./task-projection-port.ts";
 
@@ -29,7 +20,6 @@ export function reduceBatch(
   events: readonly CanonicalEventV1[],
   limit: number,
   readBlob: EventStreamPort["readContentBlob"],
-  sourceRevision: number,
 ): ProjectionApplyReceipt {
   return transaction(db, () => {
     for (const event of events) stageEvent(db, event);
@@ -54,10 +44,6 @@ export function reduceBatch(
         `sha256:${sha256Text(serializePersistedCanonicalEvent(last))}`,
       );
     }
-    runSql(db, "UPDATE projection_meta SET state_digest = NULL WHERE singleton = 1");
-    // A successful writer apply owns this complete cut. Persist its digest in the same SQLite
-    // transaction so a subsequent serving read never has to perform a catch-up write.
-    if (isAtSourceCut(db, sourceRevision)) refreshStateDigestAtSourceCut(db, sourceRevision);
     return { metrics: { sqliteTransactions: 1, reducedItems } };
   });
 }
@@ -88,26 +74,14 @@ export function catchUpRound(
     /* @gate-identity check-bypass-write-boundary/bypass-write-003 */
     db.prepare("SELECT 1 AS present FROM event_source WHERE workspace_revision > ? LIMIT 1").get(watermark(db)) !==
     undefined;
-  if (batch === null && !hasDeferred) {
-    const current = watermark(db);
-    if (readStateDigest(db) !== null || !isAtSourceCut(db, sourceRevision))
-      return {
-        sourceRevision,
-        watermark: current,
-        reducedItems: 0,
-        accessedItems: 0,
-        sqliteTransactions: 0,
-      };
-    const digest = transaction(db, () => refreshStateDigestAtSourceCut(db, sourceRevision));
-    if (digest === null) throw new Error("projection digest refresh lost its source-complete cut");
+  if (batch === null && !hasDeferred)
     return {
       sourceRevision,
-      watermark: current,
+      watermark: watermark(db),
       reducedItems: 0,
       accessedItems: 0,
-      sqliteTransactions: 1,
+      sqliteTransactions: 0,
     };
-  }
   // A complete source scan proves that an absent revision is a permanent hole in this
   // ledger. Before that point, keep strict continuity so a later batch can still supply it.
   const allowRevisionGaps = batch === null || batch.done;
@@ -132,9 +106,7 @@ export function catchUpRound(
         );
       else runSql(db, "UPDATE projection_meta SET scan_cursor = ? WHERE singleton = 1", batch.cursor);
     }
-    const reduced = drainDeferred(db, limit, (sha256) => prefetchedContent.get(sha256) ?? null, allowRevisionGaps);
-    runSql(db, "UPDATE projection_meta SET state_digest = NULL WHERE singleton = 1");
-    return reduced;
+    return drainDeferred(db, limit, (sha256) => prefetchedContent.get(sha256) ?? null, allowRevisionGaps);
   });
   return {
     sourceRevision,

--- a/packages/kernel/src/projection/rebuildable-task-projection-factory.ts
+++ b/packages/kernel/src/projection/rebuildable-task-projection-factory.ts
@@ -49,13 +49,7 @@ import { entityQueryApi } from "./rebuildable-task-projection-entity-api.ts";
 import { runtimeLeaseApi } from "./rebuildable-task-projection-runtime-api.ts";
 import { taskQueryApi } from "./rebuildable-task-projection-task-queries.ts";
 import { markRuntimeSessionsUnknown } from "./rebuildable-task-projection-runtime.ts";
-import {
-  readStateDigest,
-  readProjectionCut,
-  refreshStateDigestAtSourceCut,
-  transaction,
-  watermark,
-} from "./rebuildable-task-projection-sql.ts";
+import { readStateDigest, readProjectionCut, transaction, watermark } from "./rebuildable-task-projection-sql.ts";
 export type { ProjectionPage, TaskProjectionListQuery, TaskRelationQuery } from "./task-query-projection.ts";
 export type { TaskProjection } from "./task-projection-port.ts";
 
@@ -86,11 +80,7 @@ export function makeTaskProjection(options: {
     throw new Error("task projection catch-up limit must be between 1 and 4096");
   if (localRuntimeStateFileSystem.exists(projectionPath)) {
     try {
-      withDatabase(projectionPath, readHead, (db) =>
-        transaction(db, () => {
-          if (markRuntimeSessionsUnknown(db) > 0) refreshStateDigestAtSourceCut(db, readHead()?.revision ?? 0);
-        }),
-      );
+      withDatabase(projectionPath, readHead, (db) => transaction(db, () => markRuntimeSessionsUnknown(db)));
     } catch (error) {
       if (error instanceof ProjectionSchemaMismatchError && error.observed < taskProjectionSchemaVersion) {
         consumeKnownError(error);
@@ -136,10 +126,9 @@ export function makeTaskProjection(options: {
       if (isDecisionEvent(event)) assertDecisionWritePlan(event, plan);
       if (isMigrationImportEvent(event)) assertMigrationImportWritePlan(event, plan);
       if (isLedgerLayoutMigrationEvent(event)) assertLedgerLayoutMigrationWritePlan(event, plan);
-      const receipt = withDatabase(projectionPath, readHead, (db) =>
-        reduceBatch(db, [event], limit, options.eventStore.readContentBlob, readHead()?.revision ?? 0),
+      return withDatabase(projectionPath, readHead, (db) =>
+        reduceBatch(db, [event], limit, options.eventStore.readContentBlob),
       );
-      return receipt;
     },
     rebuild: () => {
       closeDatabase(projectionPath, readHead);
@@ -166,21 +155,11 @@ export function makeTaskProjection(options: {
           reportedWatermark = round.watermark;
         }
         if (round.watermark !== round.sourceRevision) continue;
-        const settled = withDatabase(projectionPath, readHead, (db) =>
-          transaction(db, () => ({
-            watermark: watermark(db),
-            stateDigest: refreshStateDigestAtSourceCut(db, readHead()?.revision ?? 0),
-          })),
-        );
-        if (settled.stateDigest === null) throw new Error("projection catch-up did not reach the source cut");
-        return {
-          watermark: settled.watermark,
-          stateDigest: settled.stateDigest,
-          metrics: { sqliteTransactions: sqliteTransactions + 1, reducedItems, maxBatchItems },
-        };
+        return { watermark: round.watermark, metrics: { sqliteTransactions, reducedItems, maxBatchItems } };
       }
     },
-    readStateDigest: () => withDatabase(projectionPath, readHead, readStateDigest),
+    readStateDigest: () =>
+      withDatabase(projectionPath, readHead, (db) => readStateDigest(db, readHead()?.revision ?? 0)),
     readCut: () => withDatabase(projectionPath, readHead, (db) => readProjectionCut(db, readHead)),
     read: (taskId) => readProjection(projectionPath, readHead, options.eventStore, taskId, limit, now),
     list: (query) => listProjection(projectionPath, readHead, options.eventStore, limit, now, query),
@@ -219,7 +198,8 @@ export function makeTaskProjectionReader(options: {
     runtimeQueries = runtimeLeaseApi(context),
     queries: TaskProjectionQueries = {
       path: projectionPath,
-      readStateDigest: () => withDatabase(projectionPath, readHead, readStateDigest),
+      readStateDigest: () =>
+        withDatabase(projectionPath, readHead, (db) => readStateDigest(db, readHead()?.revision ?? 0)),
       readCut: () => withDatabase(projectionPath, readHead, (db) => readProjectionCut(db, readHead)),
       read: (taskId) => readProjection(projectionPath, readHead, unavailableSource, taskId, 4096, now),
       list: (query) => listProjection(projectionPath, readHead, unavailableSource, 4096, now, query),

--- a/packages/kernel/src/projection/rebuildable-task-projection-reads.ts
+++ b/packages/kernel/src/projection/rebuildable-task-projection-reads.ts
@@ -18,7 +18,7 @@ import {
   parseEventJson,
   queryPreparedRows,
   readProjectionCut,
-  refreshStateDigestAtSourceCut,
+  readStateDigest,
   transaction,
   watermark,
 } from "./rebuildable-task-projection-sql.ts";
@@ -209,7 +209,7 @@ export function rebuildProjection(
     transaction(db, () => {
       markRuntimeSessionsUnknown(db);
       const current = watermark(db),
-        digest = refreshStateDigestAtSourceCut(db, readHead()?.revision ?? 0);
+        digest = readStateDigest(db, readHead()?.revision ?? 0);
       if (digest === null) throw new Error("projection rebuild did not reach a source-complete state digest");
       return { current, digest };
     }),

--- a/packages/kernel/src/projection/rebuildable-task-projection-runtime-api.ts
+++ b/packages/kernel/src/projection/rebuildable-task-projection-runtime-api.ts
@@ -23,7 +23,7 @@ import {
   squadRunProjectionReady,
   upsertSquadRun,
 } from "./rebuildable-task-projection-squad-runs.ts";
-import { refreshStateDigestAtSourceCut, transaction } from "./rebuildable-task-projection-sql.ts";
+import { transaction } from "./rebuildable-task-projection-sql.ts";
 export type { ProjectionPage, TaskProjectionListQuery, TaskRelationQuery } from "./task-query-projection.ts";
 export type { TaskProjection } from "./task-projection-port.ts";
 
@@ -86,36 +86,18 @@ export function runtimeLeaseApi(
         return row ? effectiveLease(db, row.task_id, at ?? now()) : null;
       }),
     reserveLease: (lease, now) =>
-      withDatabase(projectionPath, readHead, (db) =>
-        transaction(db, () => {
-          const reserved = reserve(db, lease, now);
-          refreshStateDigestAtSourceCut(db, readHead()?.revision ?? 0);
-          return reserved;
-        }),
-      ),
+      withDatabase(projectionPath, readHead, (db) => transaction(db, () => reserve(db, lease, now))),
     activateLease: (lease) =>
       withDatabase(projectionPath, readHead, (db) =>
-        transaction(db, () => {
-          const active = changeLease(db, lease, "held", lease.expiresAt, now());
-          refreshStateDigestAtSourceCut(db, readHead()?.revision ?? 0);
-          return active;
-        }),
+        transaction(db, () => changeLease(db, lease, "held", lease.expiresAt, now())),
       ),
     renewLease: (lease, expiresAt) =>
       withDatabase(projectionPath, readHead, (db) =>
-        transaction(db, () => {
-          const renewed = changeLease(db, lease, "held", expiresAt, now());
-          refreshStateDigestAtSourceCut(db, readHead()?.revision ?? 0);
-          return renewed;
-        }),
+        transaction(db, () => changeLease(db, lease, "held", expiresAt, now())),
       ),
     releaseLease: (lease) =>
       withDatabase(projectionPath, readHead, (db) =>
-        transaction(db, () => {
-          const released = changeLease(db, lease, "released", lease.expiresAt, now());
-          refreshStateDigestAtSourceCut(db, readHead()?.revision ?? 0);
-          return released;
-        }),
+        transaction(db, () => changeLease(db, lease, "released", lease.expiresAt, now())),
       ),
   };
 }

--- a/packages/kernel/src/projection/rebuildable-task-projection-sql.ts
+++ b/packages/kernel/src/projection/rebuildable-task-projection-sql.ts
@@ -65,15 +65,6 @@ export function readProjectionCut(
   };
 }
 
-export function readStateDigest(db: DatabaseSync): `sha256:${string}` | null {
-  const row =
-    /* @gate-identity check-bypass-write-boundary/bypass-write-032 */
-    db.prepare("SELECT state_digest FROM projection_meta WHERE singleton = 1").get() as {
-      readonly state_digest: string | null;
-    };
-  return row.state_digest === null ? null : (row.state_digest as `sha256:${string}`);
-}
-
 export function isAtSourceCut(db: DatabaseSync, sourceRevision: number): boolean {
   const state =
     /* @gate-identity check-bypass-write-boundary/bypass-write-033 */
@@ -91,17 +82,18 @@ export function isAtSourceCut(db: DatabaseSync, sourceRevision: number): boolean
   );
 }
 
-export function refreshStateDigestAtSourceCut(db: DatabaseSync, sourceRevision: number): `sha256:${string}` | null {
-  if (!isAtSourceCut(db, sourceRevision)) return null;
-  let digest = sha256Text("task-projection-state/v1");
-  for (const [table, order] of stateDigestTables) {
-    digest = sha256Text(`${digest}\n${table}`);
-    for (const row of prepareQuery(db, `SELECT * FROM ${table} ORDER BY ${order}`).iterate())
-      digest = sha256Text(`${digest}\n${canonicalJson(row as ProjectionSqlRow)}`);
-  }
-  const value = `sha256:${digest}` as `sha256:${string}`;
-  runSql(db, "UPDATE projection_meta SET state_digest = ? WHERE singleton = 1", value);
-  return value;
+// Hashes every projection row, so only explicit rebuilds and read-side checks call it; writes never do.
+export function readStateDigest(db: DatabaseSync, sourceRevision: number): `sha256:${string}` | null {
+  return queryTransaction(db, () => {
+    if (!isAtSourceCut(db, sourceRevision)) return null;
+    let digest = sha256Text("task-projection-state/v1");
+    for (const [table, order] of stateDigestTables) {
+      digest = sha256Text(`${digest}\n${table}`);
+      for (const row of prepareQuery(db, `SELECT * FROM ${table} ORDER BY ${order}`).iterate())
+        digest = sha256Text(`${digest}\n${canonicalJson(row as ProjectionSqlRow)}`);
+    }
+    return `sha256:${digest}` as const;
+  });
 }
 export function transaction<A>(db: DatabaseSync, run: () => A): A {
   /* @gate-identity check-bypass-write-boundary/bypass-write-028 */

--- a/packages/kernel/src/projection/task-projection-port.ts
+++ b/packages/kernel/src/projection/task-projection-port.ts
@@ -22,6 +22,7 @@ import type {
   LeaseInterval,
   PresetSnapshotProjectionRead,
   ProjectionApplyReceipt,
+  ProjectionCatchUpReceipt,
   ProjectionRebuildReceipt,
   ReplicaProjectionBasis,
   TaskProgressProjectionRead,
@@ -67,7 +68,7 @@ export interface TaskProjection {
   readonly close: () => void;
   readonly apply: (event: CanonicalEventV1, plan?: FrozenWritePlan) => ProjectionApplyReceipt;
   readonly rebuild: () => ProjectionRebuildReceipt;
-  readonly catchUp?: () => ProjectionRebuildReceipt;
+  readonly catchUp?: () => ProjectionCatchUpReceipt;
   readonly readStateDigest: () => `sha256:${string}` | null;
   readonly readCut: () => {
     readonly status: "ready" | "pending";

--- a/packages/kernel/test/store/projection-reader-close-contention.fixture.ts
+++ b/packages/kernel/test/store/projection-reader-close-contention.fixture.ts
@@ -6,6 +6,7 @@ import { serializeCanonicalEvent } from "../../src/domain/doc-sync.contract.ts";
 import { sha256Text } from "../../src/integrity/stable-hash.ts";
 import { makeTaskProjection, makeTaskProjectionReader } from "../../src/projection/rebuildable-task-projection.ts";
 import { closeDatabase, withDatabase } from "../../src/projection/rebuildable-task-projection-database.ts";
+import { readStateDigest } from "../../src/projection/rebuildable-task-projection-sql.ts";
 import type { EventStreamPort } from "../../src/projection/rebuildable-task-projection-types.ts";
 import { lifecycleFixture } from "./task-lifecycle-fixture.ts";
 
@@ -123,10 +124,8 @@ function runRebuilder(): void {
     const marker = db
         .prepare("SELECT count(*) AS count FROM sqlite_master WHERE type = 'table' AND name = 'warm_owner_marker'")
         .get() as { readonly count: number },
-      digest = db.prepare("SELECT state_digest FROM projection_meta WHERE singleton = 1").get() as {
-        readonly state_digest: string | null;
-      };
-    return { sameHandle: db === replacedHandle, markerPresent: marker.count > 0, stateDigest: digest.state_digest };
+      stateDigest = readStateDigest(db, ownerAStore.readHead()?.revision ?? 0);
+    return { sameHandle: db === replacedHandle, markerPresent: marker.count > 0, stateDigest };
   });
   ownerA.close();
   parentPort!.postMessage({

--- a/packages/kernel/test/store/task-projection.test.ts
+++ b/packages/kernel/test/store/task-projection.test.ts
@@ -433,7 +433,7 @@ test("migration-sized catch-up reduces 5k events in bounded projection transacti
       projection = makeTaskProjection({ rootDir, eventStore });
     const receipt = projection.catchUp!();
     assert.equal(receipt.watermark, count);
-    assert.deepEqual(receipt.metrics, { sqliteTransactions: 3, reducedItems: count, maxBatchItems: 4_096 });
+    assert.deepEqual(receipt.metrics, { sqliteTransactions: 2, reducedItems: count, maxBatchItems: 4_096 });
     projection.close();
   });
 });
@@ -677,6 +677,27 @@ test("migration truth-gap archives remain queryable after a cold projection rebu
   });
 });
 
+test("steady apply reads only the projection rows its event touches", async () => {
+  await withTempStoreAsync(async (rootDir) => {
+    initRepo(rootDir);
+    const eventStore = makeTaskEventStore({ repoId: "test-repo", rootDir });
+    const projection = makeTaskProjection({ rootDir, eventStore, now: () => "2026-08-11T00:30:00.000Z" });
+    const [first, ...rest] = lifecycleFixture().events;
+    eventStore.append(taskBundle(first!));
+    projection.apply(first!);
+    // Task lifecycle events never write decision content pins; any whole-state scan would still read the table.
+    const db = new DatabaseSync(projection.path);
+    db.exec("DROP TABLE decision_content_pin");
+    db.close();
+    for (const event of rest) {
+      eventStore.append(taskBundle(event));
+      assert.deepEqual(projection.apply(event).metrics, { sqliteTransactions: 1, reducedItems: 1 });
+    }
+    assert.equal(projection.read("task-1").snapshot.task?.status, "done");
+    projection.close();
+  });
+});
+
 test("steady apply and rebuild use the same reducer and reproduce watermark, op index, lease intervals", async () => {
   await withTempStoreAsync(async (rootDir) => {
     initRepo(rootDir);
@@ -721,7 +742,7 @@ test("steady apply and rebuild use the same reducer and reproduce watermark, op 
     ]);
     const incrementalStateDigest = projection.readStateDigest();
     if (incrementalStateDigest === null)
-      assert.fail("a source-complete incremental projection must persist its state digest");
+      assert.fail("a source-complete incremental projection must report its state digest");
 
     projection.close();
     rmSync(projection.path, { force: true });

--- a/tools/gate-allowlists/check-bypass-write-boundary.json
+++ b/tools/gate-allowlists/check-bypass-write-boundary.json
@@ -190,12 +190,6 @@
         "reason": "Reads the disposable projection watermark."
       },
       {
-        "value": "bypass-write-032",
-        "api": "sqlite.prepare",
-        "ref": "task_1de89b0fd52d2c7a67617d1a2a",
-        "reason": "Reads the disposable projection state digest."
-      },
-      {
         "value": "bypass-write-033",
         "api": "sqlite.prepare",
         "ref": "task_6e3a253ed79c2c458543c7d3d7",


### PR DESCRIPTION
# English

## Summary

Stop recomputing a whole-projection SHA-256 digest on every write. Each projection `apply`, each lease reserve/activate/renew/release, and each idle catch-up round hashed every row of 23 projection tables and stored the result in `projection_meta.state_digest`. No production code reads the stored value. On the real 66,494-event ledger (761 MB projection) one digest takes 3.4–6.7 s, and it runs on the single per-repository writer thread, so every write paid it before the next write could start. It went into the write transaction in `d53b08bbe5` (2026-09-01), which moved it off read paths.

## Architectural Justification

- Deletion, not a new mechanism: production net is -71 lines. The digest stays available where it has a caller: at the end of an explicit `projection rebuild` (its receipt reports it, and offline double-rebuild comparisons use it) and through `readStateDigest()` for read-side checks in tests and stress tools.
- `readStateDigest(db, sourceRevision)` now computes on demand inside one read transaction and returns `null` when the projection is not at the source cut. That matches what the stored column meant before.
- Catch-up returns a new `ProjectionCatchUpReceipt` without a digest. Its callers (repo-cell open, migration import, event-shape migration) already ignored it or read only `watermark`.

## What Changed

- `rebuildable-task-projection-sql.ts`: delete `refreshStateDigestAtSourceCut` (compute plus column write); `readStateDigest` becomes the single on-demand computation.
- `rebuildable-task-projection-catch-up.ts`: `reduceBatch` (every apply) and `catchUpRound` no longer clear or refresh the digest; the idle round no longer opens a write transaction just to hash; `reduceBatch` drops its now-unused `sourceRevision` parameter.
- `rebuildable-task-projection-runtime-api.ts`: the four lease writes no longer hash the projection.
- `rebuildable-task-projection-factory.ts`: startup runtime-session marking and `catchUp()` no longer hash; `catchUp()` drops its trailing digest transaction.
- `rebuildable-task-projection-reads.ts`: `rebuildProjection` computes the digest once at the end.
- Tests: a new regression proves a steady apply never reads tables its event does not touch; the catch-up transaction count drops by the removed digest transaction; one fixture reads the digest on demand instead of from the column.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Deleted production behavior (no file removed): the per-write, per-lease and idle catch-up projection state digest refresh (`refreshStateDigestAtSourceCut` and its nine call sites).
- Production net lines: +39/-110, net -71 (`node tools/gates/production-delta.mjs --base origin/main`).
- Retained old path with deletion date: the unused `projection_meta.state_digest` column stays in the DDL until the next projection schema bump; dropping it now would force every existing projection through a full rebuild.

## Machine-Readable Declarations

## Task And Scope

- Harness task: not registered yet. This is the user-directed daemon write-path rescue, done outside the ledger while the writer is saturated; it will be registered once writes recover.
- Branch: `codex/drop-write-state-digest`
- Public scope: `packages/kernel/src/projection/` and its tests
- Private planning/evidence updated: no (see Task above)
- Out of scope: Git follower full-closure recomputation, runtime output polling, post-write visibility waits, and writer-queue spin waits are separate changes.

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none
- Authority: not applicable
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `2d3a670d16fe8b300cd0889adc39d1effa23d3da`
- Branch merge-base with `origin/main`: `2d3a670d16fe8b300cd0889adc39d1effa23d3da`
- Last `git fetch origin` time: 2026-09-10 11:05 UTC
- Sync method: rebase onto origin/main after PR #2403 merged
- Public diff command: `git diff origin/main...codex/drop-write-state-digest`
- Private evidence commit/path: not applicable
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR (rebased onto the PR #2403 merge, which restored the file-complexity gate on `main`).
- [ ] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [x] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Red before the fix: with only the new test applied to `origin/main`, `task-projection.test.ts` fails at `reduceBatch → refreshStateDigestAtSourceCut` with `no such table: decision_content_pin`, and the catch-up count reports 3 transactions instead of 2.
- Green after the fix, Docker-isolated (`node tools/dispatch-isolated-test.mjs --target docker --file <file>`): `packages/kernel/test/store/task-projection.test.ts` (26/26), `schedule-projection.test.ts` (1/1), `agent-runtime.test.ts` (10/10), `projection-ddl-rebuild.test.ts` (2/2), `projection-reader-close-contention.integration.test.ts` (2/2); `packages/daemon/test/task-action-explanation-read.integration.test.ts` (2/2), `projection-readiness-wait.integration.test.ts` (3/3), `legacy-generation-conversion.integration.test.ts` (10 pass, 0 fail); `packages/cli/test/daemon-receipt-cli.test.ts` (1/1).
- Real-data measurement: re-applying the last event to a copy of the live 761 MB projection (so staging and reduction are no-ops and only the fixed per-write work remains) took 6694/3415/3453 ms on `main` and 0/0/0 ms on this branch.
- Also run: eslint and prettier on changed files (clean); `node tools/gates/production-delta.mjs --base origin/main` (pass).
- Not run: the full `npm run check` / `npm test` locally. Local agents must not run the full matrix, so CI is the full authority.

## Review Evidence

- Self-review: the lead traced every reader of `state_digest` / `readStateDigest` / `stateDigest`. Production readers are the rebuild receipt and the offline generation-two double-rebuild comparison, and both still get the digest from `rebuild()`. `readStateDigest()` is called only by tests, stress tools and one gate fixture that uses it to open the database.
- Reviewer subagent: not used
- Human review: pending
- Blocking findings: none

## Residual Risk

- A projection that was already at the source cut keeps a stale value in the unused column; nothing reads it.
- `readStateDigest()` now hashes on each call instead of reading a stored value. Only tests and tools call it.

## References

- Origin of the per-write digest: `d53b08bbe5` (2026-09-01)
- Related: PR #2403 (restores green `main`)
- Review: this PR

---

# 中文

## 概要

不再在每次写入时对整个 projection 重算 SHA-256。原来每次 projection `apply`、每次 lease 预留/激活/续期/释放、每个空闲 catch-up 轮次，都会把 23 张 projection 表的每一行哈希一遍，结果存进 `projection_meta.state_digest`，而生产代码没有任何地方读这个值。在真实台账上（66,494 个事件，projection 761MB），算一次要 3.4–6.7 秒，而且跑在每个仓库唯一的 writer 线程上，每次写入都要先付完这笔才能轮到下一次写入。它是在 `d53b08bbe5`（2026-09-01）被放进写事务的，当时是为了让读路径不用算。

## 架构辩护

- 这是删除，不是新机制：生产代码净减 71 行。有调用方的地方仍然能拿到 digest：显式 `projection rebuild` 结束时算一次（回执里报告它，离线双重重建比较也用它），以及测试和压测工具通过 `readStateDigest()` 做读侧检查。
- `readStateDigest(db, sourceRevision)` 改为在一个读事务里按需计算；projection 没到 source cut 时返回 `null`，和原来那个列的含义一致。
- catch-up 改为返回新的 `ProjectionCatchUpReceipt`，不带 digest。它的调用方（repo-cell 打开、migration import、event-shape migration）原本就不看它，或者只读 `watermark`。

## 改动内容

- `rebuildable-task-projection-sql.ts`：删除 `refreshStateDigestAtSourceCut`（计算加写列）；`readStateDigest` 成为唯一的按需计算。
- `rebuildable-task-projection-catch-up.ts`：`reduceBatch`（每次 apply 都走）和 `catchUpRound` 不再清空或刷新 digest；空闲轮次不再为了算哈希开写事务；`reduceBatch` 去掉不再使用的 `sourceRevision` 参数。
- `rebuildable-task-projection-runtime-api.ts`：四个 lease 写入不再哈希 projection。
- `rebuildable-task-projection-factory.ts`：启动时标记 runtime session、以及 `catchUp()` 都不再算哈希；`catchUp()` 去掉末尾那次只为算 digest 的事务。
- `rebuildable-task-projection-reads.ts`：`rebuildProjection` 结束时算一次 digest。
- 测试：新增回归测试，证明一次普通 apply 不会读它的事件没碰到的表；catch-up 的事务数少了被删掉的那次 digest 事务；一个 fixture 改为按需读取 digest，不再读列。

## 门收割 / Gate Harvest

- 删除的生产路径：none（没有删文件）
- 删除的生产行为：每次写入、每次 lease 变更、以及空闲 catch-up 时的 projection state digest 刷新（`refreshStateDigestAtSourceCut` 及其 9 个调用点）
- 同 commit 删除的门 / fixture：none
- 生产净行数：+39/-110，净 -71（`node tools/gates/production-delta.mjs --base origin/main`）。
- 保留的旧路径及删除时间：不再使用的 `projection_meta.state_digest` 列留在 DDL 里，到下一次 projection schema 升级时删。现在删会逼所有现存 projection 全量重建。

## 机读声明说明

- 本 PR 不涉及依赖变化和事件迁移，没有机读声明。保留的旧列见上一节。

## 任务与范围

- Harness 任务：暂未登记。这是用户指示的 daemon 写路径抢救，writer 饱和期间在台账外进行，写入恢复后补登记。
- 分支：`codex/drop-write-state-digest`
- 公开范围：`packages/kernel/src/projection/` 及其测试
- 私有计划 / 证据是否已更新：no（见上面「任务」一条）
- 范围外：Git follower 全闭包重算、runtime 输出轮询、写后可见性等待、写队列自旋等待，各自单独成 PR。

## 版本影响

- 版本：不改版本
- 发布影响：不发布

## 治理声明

- 是否触碰 protected surface：no
- protected surface 范围：无
- 依据：不适用
- 机器检查边界：本 PR 只声明该段存在；声明是否真实、充分，由 reviewer 判断。
- Break-glass：no
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- `origin/main` 基准 SHA：`2d3a670d16fe8b300cd0889adc39d1effa23d3da`
- 当前分支与 `origin/main` 的 merge-base：`2d3a670d16fe8b300cd0889adc39d1effa23d3da`
- 最近一次 `git fetch origin` 时间：2026-09-10 11:05 UTC
- 同步方式：PR #2403 合入后 rebase 到 origin/main
- 公开 diff 命令：`git diff origin/main...codex/drop-write-state-digest`
- 私有证据 commit/path：不适用
- Reviewer 证据路径：见本 PR 的「审查证据」一节
- GitHub Actions `rewrite-ci` run URL：本 PR 的 CI 还在跑（已 rebase 到 PR #2403 的合并提交上，该合并修好了 `main` 的文件复杂度门）。
- [ ] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [x] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- 修复前为红：只把新测试放到 `origin/main` 上，`task-projection.test.ts` 在 `reduceBatch → refreshStateDigestAtSourceCut` 处失败，报 `no such table: decision_content_pin`；catch-up 的事务数是 3 而不是 2。
- 修复后为绿，在 Docker 隔离环境里跑（`node tools/dispatch-isolated-test.mjs --target docker --file <file>`）：`packages/kernel/test/store/task-projection.test.ts`（26/26）、`schedule-projection.test.ts`（1/1）、`agent-runtime.test.ts`（10/10）、`projection-ddl-rebuild.test.ts`（2/2）、`projection-reader-close-contention.integration.test.ts`（2/2）；`packages/daemon/test/task-action-explanation-read.integration.test.ts`（2/2）、`projection-readiness-wait.integration.test.ts`（3/3）、`legacy-generation-conversion.integration.test.ts`（10 过、0 失败）；`packages/cli/test/daemon-receipt-cli.test.ts`（1/1）。
- 真实数据实测：在线上 761MB projection 的副本上重放最后一个事件（staging 和 reduce 都是空操作，只剩每次写入的固定开销），`main` 上耗时 6694/3415/3453 毫秒，本分支 0/0/0 毫秒。
- 另外跑过：改动文件的 eslint 和 prettier（干净）；`node tools/gates/production-delta.mjs --base origin/main`（通过）。
- 未运行：本地整套 `npm run check` / `npm test`。规定禁止本地 agent 跑全量矩阵，全量以 CI 为准。

## 审查证据

- 自查：主控追了 `state_digest` / `readStateDigest` / `stateDigest` 的每一个读者。生产读者只有 rebuild 回执和离线 generation-two 双重重建比较，两者仍从 `rebuild()` 拿到 digest。`readStateDigest()` 只被测试、压测工具，以及一个用它来打开数据库的门 fixture 调用。
- Reviewer subagent：未使用
- 人工审查：待进行
- 阻塞发现：无

## 残余风险

- 已经处在 source cut 的 projection，那个不再使用的列里会留着旧值，没有人读它。
- `readStateDigest()` 现在每次调用都现算，不再读存储值；只有测试和工具调用它。

## 关联材料

- 每次写入都算 digest 的来源：`d53b08bbe5`（2026-09-01）
- 相关：PR #2403（恢复 main 绿）
- 审查：本 PR

---

## PR Gate Checklist / PR 门禁清单

- [x] Branch is based on latest `origin/main`. / 分支基于最新 `origin/main`。
- [x] PR body uses this full template structure. / PR 描述使用本模板完整结构。
- [x] PR body uses two complete language blocks: `# English` first, then `# 中文`. / PR 正文使用两块完整正文：`# English` 在上，`# 中文` 在下。
- [ ] PR body passes `tools/check-pr-body-bilingual.mjs`. / PR 正文通过 `tools/check-pr-body-bilingual.mjs`。
- [x] If the PR touches a manifest-derived protected surface, Governance Declaration is filled with ADR/decision/task evidence or break-glass fields. / 若 PR 触碰 manifest 派生的 protected surface，Governance Declaration 已填写 ADR/decision/task 依据或 break-glass 字段。
- [x] No private harness files are included. / 不包含私有 harness 文件。
- [x] No ignored local agent entry files are included. / 不包含被忽略的本地 agent 入口文件。
- [x] No absolute local filesystem paths are included in this public PR body. / 本公开 PR 描述不包含本机绝对路径。
- [x] Public diff is limited to the stated task scope. / 公开 diff 限于声明的任务范围。
- [x] Private planning/evidence updates are recorded when applicable. / 适用时已记录私有计划 / 证据更新。
- [x] Version and publish impact are stated. / 已说明版本与发布影响。
- [x] Local verification commands are recorded honestly. / 已如实记录本地验证命令。
- [ ] CI results are linked or explained. / CI 结果已链接或说明。
- [x] Review evidence is recorded. / 已记录审查证据。
- [x] Open P0/P1/P2 findings are closed, deferred with owner, or explicitly blocked. / open P0/P1/P2 findings 已关闭、带 owner 延后，或明确阻塞。
- [x] Merge method and post-merge branch cleanup plan are clear. / 合并方式和合并后分支清理计划清楚。
- [x] No admin bypass is planned unless explicitly approved and recorded. / 除非明确批准并记录，否则不计划 admin bypass。
