### PR TITLE
perf(daemon): stop dispatch polling at process exit and drop the exit re-read

### DIFF
--- a/packages/daemon/src/dispatch-stream.ts
+++ b/packages/daemon/src/dispatch-stream.ts
@@ -392,16 +392,16 @@ export function appendRuntimeWorkerRecord(
   dispatchId: string,
   value: Readonly<Record<string, unknown>>,
 ): void {
-  appendJsonl(dispatchStreamPath(rootDir, dispatchId), { schema: streamSchema, ...value });
+  appendDispatchStreamRecord(dispatchStreamPath(rootDir, dispatchId), value);
 }
 
-export function readRuntimeWorkerChunk(
-  rootDir: string,
-  dispatchId: string,
-  offset: number,
-  limit = 1024 * 1024,
-): Buffer {
-  const descriptor = openSync(dispatchStreamPath(rootDir, dispatchId), fsConstants.O_RDONLY);
+/** Append to a dispatch stream whose path the caller resolved once for the dispatch's lifetime. */
+export function appendDispatchStreamRecord(target: string, value: Readonly<Record<string, unknown>>): void {
+  appendJsonl(target, { schema: streamSchema, ...value });
+}
+
+export function readRuntimeWorkerChunk(target: string, offset: number, limit = 1024 * 1024): Buffer {
+  const descriptor = openSync(target, fsConstants.O_RDONLY);
   try {
     const size = fstatSync(descriptor).size;
     if (size <= offset) return Buffer.alloc(0);

--- a/packages/daemon/src/runtime-spawn-adoption.ts
+++ b/packages/daemon/src/runtime-spawn-adoption.ts
@@ -9,7 +9,11 @@ import {
 import { removeRuntimeCallbackRelay } from "./runtime-callback-relay.ts";
 import { createActiveRuntime, attachActiveRuntime } from "./runtime-spawn-active.ts";
 import { adoptNativeProcess, runtimePidIsAlive } from "./runtime-spawn-process.ts";
-import { durableOutputRecordCount, restoreDurableOutputRecords } from "./runtime-spawn-provider-stream.ts";
+import {
+  consumeDurableOutput,
+  durableOutputRecordCount,
+  restoreDurableOutputRecords,
+} from "./runtime-spawn-provider-stream.ts";
 import { runtimeBindingForDispatch, type RuntimeBinding } from "./runtime-spawn-types.ts";
 import type { RuntimePermissionMode } from "./runtime-permissions.ts";
 import type { RuntimeSpawnerContext } from "./runtime-spawn-context.ts";
@@ -130,7 +134,11 @@ export async function adoptRuntimes(context: RuntimeSpawnerContext): Promise<voi
             exitCode: active.lossExitCode,
             signal: active.lossSignal,
           });
-          context.input.schedule(() => context.publishExit(active, active.lossExitCode), active.binding);
+          // No process_exit orders this settlement after the drain's last line. Settle from the stream.
+          context.input.schedule(async () => {
+            await consumeDurableOutput(context, active);
+            await context.publishExit(active, active.lossExitCode);
+          }, active.binding);
         }
       }, 50);
       timer.unref();

--- a/packages/daemon/src/runtime-spawn-control.ts
+++ b/packages/daemon/src/runtime-spawn-control.ts
@@ -27,6 +27,9 @@ export async function cancelRuntime(
     await consumeDurableOutput(context, active, cancelDurableDrainTimeoutMs);
     if (active.process.terminateTree) await active.process.terminateTree();
     else active.process.terminate();
+    // Cancel holds the write queue: lines flushed during termination drain into work queued behind
+    // it, which is dropped once settlement retires the runtime. Settle them from the stream.
+    await consumeDurableOutput(context, active);
     await context.publishExit(active, null);
     return context.controlReceipt(opId, runtimeSessionId);
   }

--- a/packages/daemon/src/runtime-spawn-process.ts
+++ b/packages/daemon/src/runtime-spawn-process.ts
@@ -11,6 +11,7 @@ import { consumeKnownError } from "../../kernel/src/index.ts";
 import type { PreparedRuntimeLaunch, RuntimeInstanceKind } from "./agent-runtime-instances.ts";
 import {
   appendRuntimeWorkerRecord,
+  dispatchStreamPath,
   readRuntimeWorkerChunk,
   scrubProviderValue,
   type DispatchStreamWriter,
@@ -242,18 +243,12 @@ function signalRuntimeTargets(
     }
 }
 
-async function survivingRuntimePids(pids: readonly number[]): Promise<readonly number[]> {
-  const wanted = new Set(pids),
-    rows = await readPosixProcessRows();
-  return rows.filter(({ pid }) => wanted.has(pid)).map(({ pid }) => pid);
-}
-
 async function awaitRuntimeProcessExit(pids: readonly number[], timeoutMs: number): Promise<readonly number[]> {
   const deadline = Date.now() + timeoutMs;
-  let survivors = await survivingRuntimePids(pids);
+  let survivors = pids.filter(runtimePidIsAlive);
   while (survivors.length > 0 && Date.now() < deadline) {
     await delay(Math.min(25, Math.max(1, deadline - Date.now())));
-    survivors = await survivingRuntimePids(pids);
+    survivors = survivors.filter(runtimePidIsAlive);
   }
   return survivors;
 }
@@ -501,6 +496,7 @@ function observeDispatchProcess(
   pid: number,
   skipPersistedOutputRecords = 0,
 ): RuntimeProcess {
+  const stream = dispatchStreamPath(rootDir, dispatchId);
   const outputs: Array<{ readonly chunk: string; readonly persisted: boolean }> = [];
   const errors: string[] = [];
   const decoder = new StringDecoder("utf8");
@@ -525,12 +521,15 @@ function observeDispatchProcess(
     if (exited) return;
     exited = true;
     exitCode = code;
+    // process_exit follows the host's last provider line. Stop here, not in release(), which settlement
+    // skips on its early return, on a throw, and behind the writer-thread proxy.
+    clearInterval(timer);
     if (exitListener) exitListener(code);
   };
   const drain = (): void => {
     if (released) return;
     try {
-      const bytes = readRuntimeWorkerChunk(rootDir, dispatchId, offset);
+      const bytes = readRuntimeWorkerChunk(stream, offset);
       if (bytes.length === 0) return;
       offset += bytes.length;
       buffer += decoder.write(bytes);
@@ -547,13 +546,14 @@ function observeDispatchProcess(
         } else if (record?.kind === "provider_stderr") emitError(String(record.chunk));
         else if (record?.kind === "process_exit") {
           emitExit(Number.isInteger(record.exitCode) ? Number(record.exitCode) : null);
+          return;
         }
       }
     } catch (error) {
       consumeKnownError(error);
     }
   };
-  const timer = setInterval(drain, 20);
+  const timer = setInterval(drain, 250);
   timer.unref();
   queueMicrotask(drain);
   return {

--- a/packages/daemon/src/runtime-spawn-settlement.ts
+++ b/packages/daemon/src/runtime-spawn-settlement.ts
@@ -3,7 +3,6 @@ import type { AgentRuntimeEventV1, CanonicalEventStore, RuntimeResultClaim } fro
 import { consumeKnownError } from "../../kernel/src/index.ts";
 import { scrubProviderValue } from "./dispatch-stream.ts";
 import { archiveRuntimeDispatch, type RuntimeDispatchArchive } from "./doc-sync-actions.ts";
-import { consumeDurableOutput } from "./runtime-spawn-provider-stream.ts";
 import { runtimeDescendantsAlive } from "./runtime-spawn-process.ts";
 import type { ActiveRuntime } from "./runtime-spawn-types.ts";
 import { pushWorkerBranch, workerWorktreeDirty } from "./runtime-worker-push.ts";
@@ -27,7 +26,6 @@ export async function publishExit(
     cancelBinding = cancelled && active.cancelBinding ? active.cancelBinding : active.binding,
     terminalBinding = runtimeSessionBinding(active.binding, active.runtimeSessionId);
   try {
-    await consumeDurableOutput(context, active);
     if (!cancelled && code === null)
       context.input.stream.publish(active.runtimeSessionId, {
         type: "error",

--- a/packages/daemon/src/runtime-spawn-types.ts
+++ b/packages/daemon/src/runtime-spawn-types.ts
@@ -26,6 +26,7 @@ export interface RuntimeProcess {
   readonly pid: number;
   readonly onOutput: (listener: (chunk: string, persisted?: boolean) => void) => void;
   readonly onErrorOutput: (listener: (chunk: string) => void) => void;
+  /** Fires only after onOutput delivered every provider line; exit settlement does not re-read the stream. */
   readonly onExit: (listener: (code: number | null) => void) => void;
   readonly terminate: () => void;
   readonly terminateTree?: () => Promise<void>;

--- a/packages/daemon/src/runtime-worker-host.ts
+++ b/packages/daemon/src/runtime-worker-host.ts
@@ -1,6 +1,6 @@
 import { spawn } from "node:child_process";
 import { consumeKnownError } from "../../kernel/src/index.ts";
-import { appendRuntimeWorkerRecord, scrubProviderValue } from "./dispatch-stream.ts";
+import { appendDispatchStreamRecord, dispatchStreamPath, scrubProviderValue } from "./dispatch-stream.ts";
 import { createRuntimeCallbackRelay } from "./runtime-callback-relay.ts";
 import type { RuntimeCallbackRelay } from "./runtime-spawn-types.ts";
 
@@ -18,8 +18,9 @@ type RuntimeWorkerManifest = {
 
 async function runRuntimeWorkerHost(): Promise<void> {
   const manifest = parseManifest(await readStandardInput());
+  const stream = dispatchStreamPath(manifest.rootDir, manifest.dispatchId);
   const append = (value: Readonly<Record<string, unknown>>): void =>
-    appendRuntimeWorkerRecord(manifest.rootDir, manifest.dispatchId, {
+    appendDispatchStreamRecord(stream, {
       occurredAt: new Date().toISOString(),
       ...value,
     });

--- a/packages/daemon/test/dispatch-stream.test.ts
+++ b/packages/daemon/test/dispatch-stream.test.ts
@@ -15,6 +15,7 @@ import {
 } from "../src/dispatch-stream.ts";
 import { adoptRuntimes } from "../src/runtime-spawn-adoption.ts";
 import { cancelRuntime } from "../src/runtime-spawn-control.ts";
+import { adoptNativeProcess } from "../src/runtime-spawn-process.ts";
 import { readRuntimeSessionActivityEvidence } from "../src/dispatch-read.ts";
 import { runtimeBindingForDispatch } from "../src/runtime-spawn-types.ts";
 import { runtimeSessionActionPreparer } from "../src/runtime-session-action-runtime.ts";
@@ -262,6 +263,101 @@ test("adoption skips a stream above Node's string limit while runtime cancel sti
     assert.equal(published, true);
   } finally {
     console.warn = warning;
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});
+
+test("a dispatch observer delivers each pre-exit line once and stops polling at process_exit without a release", async (t) => {
+  t.mock.timers.enable({ apis: ["setInterval"] });
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-dispatch-observer-exit-"));
+  try {
+    const dispatchId = "dispatch_aaaaaaaaaaaaaaaaaaaaaaaa",
+      pid = 2_147_483_647;
+    openDispatchStream(rootDir, {
+      dispatchId,
+      taskId: null,
+      executionId: null,
+      runtimeSessionId: "runtime_aaaaaaaaaaaaaaaaaaaaaaaa",
+      instanceId: "instance-1",
+      startedAt: "2026-09-10T00:00:00.000Z",
+    });
+    appendRuntimeWorkerRecord(rootDir, dispatchId, { kind: "process_started", pid });
+    appendRuntimeWorkerRecord(rootDir, dispatchId, { kind: "provider_event", event: { seq: 1 } });
+    // Nothing below calls release(): settlement skips it on its early return, on a throw, and
+    // across the writer-thread proxy, so the observer itself must stop at process_exit.
+    const observed = adoptNativeProcess(rootDir, dispatchId, pid),
+      outputs: string[] = [],
+      exits: Array<number | null> = [];
+    observed.onOutput((chunk) => outputs.push(chunk));
+    observed.onExit((code) => exits.push(code));
+    await Promise.resolve();
+    appendRuntimeWorkerRecord(rootDir, dispatchId, { kind: "provider_event", event: { seq: 2 } });
+    appendRuntimeWorkerRecord(rootDir, dispatchId, { kind: "provider_output_invalid", output: "not json" });
+    t.mock.timers.tick(250);
+    appendRuntimeWorkerRecord(rootDir, dispatchId, { kind: "provider_event", event: { seq: 3 } });
+    appendRuntimeWorkerRecord(rootDir, dispatchId, { kind: "process_exit", exitCode: 0, signal: null });
+    t.mock.timers.tick(250);
+    const delivered = ['{"seq":1}\n', '{"seq":2}\n', "not json\n", '{"seq":3}\n'];
+    assert.deepEqual(outputs, delivered);
+    assert.deepEqual(exits, [0]);
+
+    appendRuntimeWorkerRecord(rootDir, dispatchId, { kind: "provider_event", event: { seq: "after-exit" } });
+    t.mock.timers.tick(60_000);
+    assert.deepEqual(outputs, delivered, "no drain tick may read the stream after process_exit");
+    assert.deepEqual(exits, [0]);
+  } finally {
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});
+
+test("runtime cancel settles provider lines flushed while the provider is terminated", async () => {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-dispatch-cancel-tail-"));
+  try {
+    const dispatchId = "dispatch_bbbbbbbbbbbbbbbbbbbbbbbb",
+      runtimeSessionId = "runtime_bbbbbbbbbbbbbbbbbbbbbbbb";
+    openDispatchStream(rootDir, {
+      dispatchId,
+      taskId: null,
+      executionId: null,
+      runtimeSessionId,
+      instanceId: "instance-1",
+      startedAt: "2026-09-10T00:00:00.000Z",
+    });
+    appendRuntimeWorkerRecord(rootDir, dispatchId, { kind: "process_started", pid: 2_147_483_647 });
+    appendRuntimeWorkerRecord(rootDir, dispatchId, { kind: "provider_event", event: { seq: 1 } });
+    const consumed: string[] = [],
+      settledAfter: number[] = [],
+      active = {
+        dispatchId,
+        durableOutputCount: 0,
+        process: {
+          // Cancel holds the write queue, so these lines cannot reach settlement through the drain.
+          terminateTree: async () => {
+            appendRuntimeWorkerRecord(rootDir, dispatchId, { kind: "provider_event", event: { seq: 2 } });
+            appendRuntimeWorkerRecord(rootDir, dispatchId, { kind: "process_exit", exitCode: null, signal: "SIGTERM" });
+          },
+        },
+      };
+    const receipt = await cancelRuntime(
+      {
+        input: { rootDir, repoId: "cancel-tail" },
+        processes: new Map([[runtimeSessionId, active]]),
+        consumeLine: async (runtime: typeof active, line: string) => {
+          runtime.durableOutputCount += 1;
+          consumed.push(line);
+        },
+        publishExit: async () => {
+          settledAfter.push(consumed.length);
+        },
+        controlReceipt: () => ({ ok: true, detail: "cancelled" }),
+      } as never,
+      { runtimeSessionId },
+      { actor: { principal: { personId: "operator" }, executor: null }, source: "local" },
+    );
+    assert.equal(receipt.detail, "cancelled");
+    assert.deepEqual(consumed, ['{"seq":1}', '{"seq":2}']);
+    assert.deepEqual(settledAfter, [2]);
+  } finally {
     rmSync(rootDir, { recursive: true, force: true });
   }
 });


### PR DESCRIPTION
# English

## Summary

Stop the daemon main thread from polling runtime dispatch streams forever. Every observed dispatch ran `setInterval(drain, 20)`, and every tick re-resolved the harness layout from disk (`existsSync` plus a `harness.yaml` parse) to find a stream path that never changes. The interval was cleared only by settlement's `release()`. Settlement skips that call on its early return or after a throw, and in the production writer-worker setup `release()` clears only the worker thread's listener map. So each dispatch kept polling at 50 ticks/s until the daemon restarted. A 60 s CPU profile of the live daemon put 17–23% of main-thread time in this drain path. Every exit also re-read and re-parsed the whole stream file (up to 200 MB).

## Architectural Justification

- The stream path is resolved once per observer and once per worker host, instead of on every tick or provider line.
- The observer stops at the record that ends the stream. The interval is cleared when the drain delivers `process_exit`, so no settlement outcome can leave a poller behind. The tick is 250 ms instead of 20 ms.
- A normal exit no longer re-reads the stream: the drain queues every provider line ahead of the exit on the same ordered queue. The re-read stays on the two paths where that ordering does not hold. Cancel holds the write queue, so lines drained during termination would otherwise be dropped. The adoption lost path is settled by a timer, not by `process_exit`.
- Cancel checks for surviving processes with `kill(pid, 0)` (the existing `runtimePidIsAlive`) instead of spawning `ps` every 25 ms.

## What Changed

- `dispatch-stream.ts`: `readRuntimeWorkerChunk` takes the resolved stream path; new `appendDispatchStreamRecord(target, value)` for writers that resolve the path once.
- `runtime-spawn-process.ts`: the observer resolves the path once, clears its interval in `emitExit`, stops reading at `process_exit`, and ticks every 250 ms. `survivingRuntimePids` is deleted.
- `runtime-worker-host.ts`: resolves the stream path once per host.
- `runtime-spawn-settlement.ts`: `publishExit` no longer calls `consumeDurableOutput`.
- `runtime-spawn-control.ts` / `runtime-spawn-adoption.ts`: the stream re-read moves to the two paths that still need it.
- Tests: two new cases in `packages/daemon/test/dispatch-stream.test.ts`. One proves each pre-exit line is delivered exactly once and nothing is read after `process_exit`, even when `release()` never runs. The other proves cancel still settles a line the provider flushes during termination. Both fail on the old source.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Deleted production behavior (no file removed): the per-tick layout re-resolve, post-exit polling, the per-exit full stream re-read, and the 25 ms `ps` survivor loop (`survivingRuntimePids`).
- Production net lines: +35/-24, net +11 (`node tools/gates/production-delta.mjs --base origin/main`). The additions are the path-taking append helper, the re-read moved into the two paths that keep it, and comments that state the ordering each path relies on.

## Machine-Readable Declarations

## Task And Scope

- Harness task: not registered yet. This is the user-directed daemon rescue, done outside the ledger while the writer is saturated; it will be registered once writes recover.
- Branch: `codex/runtime-drain-once`
- Public scope: `packages/daemon/src/` runtime dispatch observation and settlement, plus its tests
- Private planning/evidence updated: no (see Task above)
- Out of scope: writer-queue spin waits, post-write visibility waits, and the Git follower are separate changes.

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none
- Authority: not applicable
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `2d3a670d16fe8b300cd0889adc39d1effa23d3da`
- Branch merge-base with `origin/main`: `2d3a670d16fe8b300cd0889adc39d1effa23d3da`
- Last `git fetch origin` time: 2026-09-10 11:50 UTC
- Sync method: rebase onto origin/main
- Public diff command: `git diff origin/main...codex/runtime-drain-once`
- Private evidence commit/path: not applicable
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [x] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Red before the fix: on the old source the new observer test saw a record after `process_exit`, and the cancel test settled only the first line.
- Green after the fix, Docker-isolated (`node tools/dispatch-isolated-test.mjs --target docker --file <file>`), all in `packages/daemon/test/` unless noted:

  | Test file | Passed |
  |---|---|
  | `dispatch-stream.test.ts` | 13/13 |
  | `runtime-spawn-lifecycle.integration.test.ts` | 6/6 |
  | `runtime-spawn-settlement.test.ts` | 8/8 |
  | `runtime-callback-relay.integration.test.ts` | 5/5 |
  | `runtime-spawn.integration.test.ts` | 5/5 |
  | `runtime-spawn-ingress.integration.test.ts` | 17/17 |
  | `runtime-spawn-provider-ingress.integration.test.ts` | 8/8 |
  | `runtime-orphan-settlement.integration.test.ts` | 1/1 |
  | `squad-coordinator-recovery.test.ts` | 15/15 |
  | `packages/cli/test/daemon-stop-identity` | 4/4 |
  | `packages/cli/test/runtime-cli.integration` | 1/1 |

  `runtime-cli.integration` asserts the final result text from a real provider stub, so it checks end to end that settlement still sees every line.
- Also run: `tsc -b`, eslint, prettier, `production-delta`, `git diff --check` (all pass).
- Not run: the full `npm run check` / `npm test` locally. Local agents must not run the full matrix, so CI is the full authority.

## Review Evidence

- Self-review: the lead read the full production diff and checked each ordering claim against the code: the observer's output and exit listeners feed the same ordered queue; cancel runs inside the publication queue; the adoption lost path settles from a 50 ms timer. `runtimePidIsAlive` takes a single argument, so `filter(runtimePidIsAlive)` is safe.
- Reviewer subagent: an isolated implementation worker wrote the change; the lead reviewed it
- Human review: pending
- Blocking findings: none

## Residual Risk

- Streamed output reaches the GUI up to 250 ms later.
- Re-reading a large adopted stream after a daemon restart now catches up at about 4 MB/s instead of 50 MB/s (1 MB per tick).
- A worker host that dies without writing `process_exit` and is never adopted still polls, now at 4 ticks/s instead of 50.
- On a fleet edge, cancel does not go through the queue, so a drained line could be consumed twice. The same race exists on `main`; this change does not touch it.

## References

- Related: PR #2405 (per-write projection digest), PR #2403 (restored green `main`)
- Review: this PR

---

# 中文

## 概要

让 daemon 主线程不再无休止地轮询 runtime 派工输出流。原来每个被观察的派工都挂一个 `setInterval(drain, 20)`，每次 tick 都从磁盘重新解析 harness 布局（`existsSync` 加解析一遍 `harness.yaml`），为的只是找到一个根本不会变的流文件路径。这个定时器只由结算里的 `release()` 清除：结算提前返回或抛错时会跳过它；生产环境走 writer-worker 代理时，`release()` 只清 worker 线程里的监听表。结果每个派工都以每秒 50 次的频率一直轮询，直到 daemon 重启。线上 daemon 60 秒的 CPU profile 显示，主线程 17–23% 的时间花在这条 drain 路径上。另外每次退出还要把整个流文件（最大 200MB）重读、重解析一遍。

## 架构辩护

- 流文件路径每个观察者只解析一次，每个 worker host 也只解析一次，不再每个 tick、每行 provider 输出都解析。
- 观察者读到流的结束记录就停：drain 交付 `process_exit` 时清掉定时器，所以无论结算结果如何都不会留下轮询器；tick 间隔从 20ms 改为 250ms。
- 正常退出不再重读整个流：drain 已经把每一行 provider 输出排在 exit 之前，进的是同一个有序队列。只有两条路径不满足这个顺序，因此保留重读：一是 cancel 持有写队列，终止期间 drain 出来的行否则会被丢掉；二是 adoption 丢失路径，它由定时器触发结算，而不是由 `process_exit` 触发。
- cancel 检查残留进程改用 `kill(pid, 0)`（已有的 `runtimePidIsAlive`），不再每 25ms 起一个 `ps`。

## 改动内容

- `dispatch-stream.ts`：`readRuntimeWorkerChunk` 改为接收已解析好的流文件路径；新增 `appendDispatchStreamRecord(target, value)`，供只解析一次路径的写入方使用。
- `runtime-spawn-process.ts`：观察者只解析一次路径，在 `emitExit` 里清掉定时器，读到 `process_exit` 即停，tick 改为 250ms；删除 `survivingRuntimePids`。
- `runtime-worker-host.ts`：每个 host 只解析一次流文件路径。
- `runtime-spawn-settlement.ts`：`publishExit` 不再调用 `consumeDurableOutput`。
- `runtime-spawn-control.ts` / `runtime-spawn-adoption.ts`：重读挪到仍然需要它的两条路径上。
- 测试：`packages/daemon/test/dispatch-stream.test.ts` 新增两个用例。一个证明即使 `release()` 从未执行，退出前的每一行都恰好交付一次，`process_exit` 之后不再读取；另一个证明 cancel 仍能结算 provider 在终止期间刷出的行。两个用例在旧代码上都失败。

## 门收割 / Gate Harvest

- 删除的生产路径：none（没有删文件）
- 删除的生产行为：每个 tick 重新解析布局、退出后的持续轮询、每次退出时对整个流的重读，以及每 25ms 一次的 `ps` 残留进程检查（`survivingRuntimePids`）
- 生产净行数：+35/-24，净 +11（`node tools/gates/production-delta.mjs --base origin/main`）。增加的是接收路径参数的 append helper、挪到两条保留路径里的重读，以及说明每条路径所依赖顺序的注释。

## 机读声明说明

- 本 PR 不涉及依赖变化、事件迁移和保留旧路径，没有机读声明。

## 任务与范围

- Harness 任务：暂未登记。这是用户指示的 daemon 抢救，writer 饱和期间在台账外进行，写入恢复后补登记。
- 分支：`codex/runtime-drain-once`
- 公开范围：`packages/daemon/src/` 里的 runtime 派工观察与结算，以及对应测试
- 私有计划 / 证据是否已更新：no（见上面「任务」一条）
- 范围外：写队列自旋等待、写后可见性等待、Git follower，各自单独成 PR。

## 版本影响

- 版本：不改版本
- 发布影响：不发布

## 治理声明

- 是否触碰 protected surface：no
- protected surface 范围：无
- 依据：不适用
- 机器检查边界：本 PR 只声明该段存在；声明是否真实、充分，由 reviewer 判断。
- Break-glass：no
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- `origin/main` 基准 SHA：`2d3a670d16fe8b300cd0889adc39d1effa23d3da`
- 当前分支与 `origin/main` 的 merge-base：`2d3a670d16fe8b300cd0889adc39d1effa23d3da`
- 最近一次 `git fetch origin` 时间：2026-09-10 11:50 UTC
- 同步方式：rebase 到 origin/main
- 公开 diff 命令：`git diff origin/main...codex/runtime-drain-once`
- 私有证据 commit/path：不适用
- Reviewer 证据路径：见本 PR 的「审查证据」一节
- GitHub Actions `rewrite-ci` run URL：本 PR 的 CI 还在跑
- [ ] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [x] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- 修复前为红：在旧代码上，新的观察者测试在 `process_exit` 之后还读到了记录，cancel 测试只结算了第一行。
- 修复后为绿，在 Docker 隔离环境里跑（`node tools/dispatch-isolated-test.mjs --target docker --file <file>`），除注明外都在 `packages/daemon/test/` 下：

  | 测试文件 | 通过 |
  |---|---|
  | `dispatch-stream.test.ts` | 13/13 |
  | `runtime-spawn-lifecycle.integration.test.ts` | 6/6 |
  | `runtime-spawn-settlement.test.ts` | 8/8 |
  | `runtime-callback-relay.integration.test.ts` | 5/5 |
  | `runtime-spawn.integration.test.ts` | 5/5 |
  | `runtime-spawn-ingress.integration.test.ts` | 17/17 |
  | `runtime-spawn-provider-ingress.integration.test.ts` | 8/8 |
  | `runtime-orphan-settlement.integration.test.ts` | 1/1 |
  | `squad-coordinator-recovery.test.ts` | 15/15 |
  | `packages/cli/test/daemon-stop-identity` | 4/4 |
  | `packages/cli/test/runtime-cli.integration` | 1/1 |

  `runtime-cli.integration` 会校验真实 provider stub 输出的最终结果文本，用端到端的方式确认结算仍能看到每一行。
- 另外跑过：`tsc -b`、eslint、prettier、`production-delta`、`git diff --check`，全部通过。
- 未运行：本地整套 `npm run check` / `npm test`。规定禁止本地 agent 跑全量矩阵，全量以 CI 为准。

## 审查证据

- 自查：主控读完整个生产 diff，并逐条对照代码核实顺序依据：观察者的输出监听和退出监听进的是同一个有序队列；cancel 在发布队列里执行；adoption 丢失路径由 50ms 定时器触发结算。`runtimePidIsAlive` 只接收一个参数，所以 `filter(runtimePidIsAlive)` 是安全的。
- Reviewer subagent：改动由隔离的实现 worker 编写，主控审查
- 人工审查：待进行
- 阻塞发现：无

## 残余风险

- 流式输出到达 GUI 最多晚 250ms。
- daemon 重启后，重读一个很大的已收养输出流，追赶速度从约 50MB/s 降到约 4MB/s（每个 tick 读 1MB）。
- worker host 没写 `process_exit` 就死掉、又一直没被收养时，仍会轮询，但频率从每秒 50 次降到 4 次。
- 在 fleet 边缘节点上，cancel 不经过队列，同一行可能被消费两次。这个竞态在 `main` 上本来就有，本改动没有触及。

## 关联材料

- 相关：PR #2405（每次写入的 projection digest）、PR #2403（恢复 main 绿）
- 审查：本 PR

---

## PR Gate Checklist / PR 门禁清单

- [x] Branch is based on latest `origin/main`. / 分支基于最新 `origin/main`。
- [x] PR body uses this full template structure. / PR 描述使用本模板完整结构。
- [x] PR body uses two complete language blocks: `# English` first, then `# 中文`. / PR 正文使用两块完整正文：`# English` 在上，`# 中文` 在下。
- [x] PR body passes `tools/check-pr-body-bilingual.mjs`. / PR 正文通过 `tools/check-pr-body-bilingual.mjs`。
- [x] If the PR touches a manifest-derived protected surface, Governance Declaration is filled with ADR/decision/task evidence or break-glass fields. / 若 PR 触碰 manifest 派生的 protected surface，Governance Declaration 已填写 ADR/decision/task 依据或 break-glass 字段。
- [x] No private harness files are included. / 不包含私有 harness 文件。
- [x] No ignored local agent entry files are included. / 不包含被忽略的本地 agent 入口文件。
- [x] No absolute local filesystem paths are included in this public PR body. / 本公开 PR 描述不包含本机绝对路径。
- [x] Public diff is limited to the stated task scope. / 公开 diff 限于声明的任务范围。
- [x] Private planning/evidence updates are recorded when applicable. / 适用时已记录私有计划 / 证据更新。
- [x] Version and publish impact are stated. / 已说明版本与发布影响。
- [x] Local verification commands are recorded honestly. / 已如实记录本地验证命令。
- [ ] CI results are linked or explained. / CI 结果已链接或说明。
- [x] Review evidence is recorded. / 已记录审查证据。
- [x] Open P0/P1/P2 findings are closed, deferred with owner, or explicitly blocked. / open P0/P1/P2 findings 已关闭、带 owner 延后，或明确阻塞。
- [x] Merge method and post-merge branch cleanup plan are clear. / 合并方式和合并后分支清理计划清楚。
- [x] No admin bypass is planned unless explicitly approved and recorded. / 除非明确批准并记录，否则不计划 admin bypass。
