### PR TITLE
perf: publish the Git and worktree followers incrementally

### DIFF
--- a/docs-release/architecture/en/00-overview.md
+++ b/docs-release/architecture/en/00-overview.md
@@ -14,9 +14,10 @@ complete event interval and command outcome. A Git commit is not an acceptance b
 `packages/kernel/src/store/sqlite-event-store.ts` implements that transaction.
 `sqlite-task-event-store.ts` adapts the canonical event-store port and publishes
 accepted events' authored documents and `events/segments/manifest.json` to Git.
-The publisher reads back the manifest and document bodies, modes, and retirements
-before certifying the Git cut. Worktree visibility is checked separately and may
-remain pending when authored files have concurrent edits.
+Each run publishes only the events accepted since the cut Git's manifest names, on
+top of that commit, and the authored worktree settles the same events. A file with a
+concurrent edit keeps the user's bytes and is reported as a conflict; the worktree
+facet stays pending until a later event or `ha doc materialize` settles that file.
 
 The old segment WAL, merged shadow reader, publication pointer family, and
 materializer worker are retired. SQLite's own transaction journal remains an

--- a/docs-release/architecture/zh/00-overview.md
+++ b/docs-release/architecture/zh/00-overview.md
@@ -11,8 +11,9 @@ Git 和读取投影从这份记录派生。
 
 `packages/kernel/src/store/sqlite-event-store.ts` 实现接受事务；
 `sqlite-task-event-store.ts` 实现 canonical store 端口，并把已接受事件派生的文档和
-`events/segments/manifest.json` 发布到 Git。只有独立回读 manifest、文档内容、文件模式及
-退役路径后才认证 Git cut。Worktree 可见性单独检查；并发撰写修改可以让该 facet 保持 pending。
+`events/segments/manifest.json` 发布到 Git。每次只把 Git manifest 所指 cut 之后新接受的事件
+提交在该 commit 之上，撰写 worktree 结算同一批事件。有并发修改的文件保留用户字节并报告为冲突；
+worktree facet 保持 pending，直到后续事件或 `ha doc materialize` 结算该文件。
 
 旧 segment WAL、合并 shadow reader、publication pointer 家族和 materializer worker 已退役。
 SQLite 自身的事务日志仍是数据库实现细节。

--- a/packages/kernel/src/store/local-version-control-system.ts
+++ b/packages/kernel/src/store/local-version-control-system.ts
@@ -284,7 +284,6 @@ export const localGitObjectRefStore = Object.freeze({
     const timestamp = new Date(Number(seconds) * 1_000);
     return Number.isNaN(timestamp.valueOf()) ? null : timestamp.toISOString();
   },
-  blobOid: (body: string | Uint8Array) => gitBlobOidBytes(typeof body === "string" ? Buffer.from(body) : body),
   resolveCommit: (repoRoot: string, revision: string) => runGit(repoRoot, "rev-parse", revision).trim(),
   currentBranch: (repoRoot: string): string | null => {
     try {

--- a/packages/kernel/src/store/sqlite-task-event-publication.ts
+++ b/packages/kernel/src/store/sqlite-task-event-publication.ts
@@ -47,16 +47,12 @@ export function publishConvertedGeneration(input: {
   const event = input.store.eventAtRevision(revision),
     cut = canonicalLedgerCut(input.repoId, event ? eventHead(event) : null),
     closureEvents = readEventsThrough(input.store, revision),
-    files = followerFiles(
-      ledger,
-      parent,
-      closureEvents,
-      input.store.readContentObject,
-      cut,
-      input.store.metadata().generation,
-    ),
+    files = [
+      ...followerFiles(ledger, closureEvents, input.store.readContentObject, cut, input.store.metadata().generation),
+      ...legacyRetirements(ledger, parent),
+    ],
     directories = followerDirectories(ledger, closureEvents),
-    manifestTarget = ledgerGitPath(ledger, "events/segments/manifest.json"),
+    manifestTarget = ledgerGitPath(ledger, followerManifestPath),
     alreadyCertified =
       localGitObjectRefStore.readPath(ledger.rootDir, parent, manifestTarget) !== null &&
       JSON.parse(localGitObjectRefStore.readPath(ledger.rootDir, parent, manifestTarget)!.toString("utf8"))
@@ -65,9 +61,11 @@ export function publishConvertedGeneration(input: {
   if (alreadyCertified) {
     const baseline = captureConversionBaseline(input.rootInput, ledger.rootDir, parent, files);
     localGitWorktreeSettlement.index(ledger.rootDir, files);
-    if (!worktreeMatchesBaseline(ledger.rootDir, baseline, files) || !settleWorktree(ledger.rootDir, files, baseline))
+    if (
+      !worktreeMatchesBaseline(ledger.rootDir, baseline, files) ||
+      settleWorktree(ledger.rootDir, files, baseline).length > 0
+    )
       throw new TaskEventStoreError("publication_indeterminate", "authored worktree has concurrent edits");
-    verifyWorktreeFiles(ledger.rootDir, files);
     settleWorktreeDirectories(ledger.rootDir, directories);
     return { commitSha: parent, revision, changed: false };
   }
@@ -75,12 +73,12 @@ export function publishConvertedGeneration(input: {
     commit = prepareCommit(ledger.rootDir, tempRef, parent, files, `conversion-${revision}`, new Date().toISOString()),
     baseline = captureConversionBaseline(input.rootInput, ledger.rootDir, parent, files);
   finalizeRefs(ledger.rootDir, authoredRef, commit, parent, tempRef);
-  verifyGitFiles(ledger.rootDir, commit, files);
-  verifyAuthoredRef(ledger.rootDir, authoredRef, commit);
   localGitWorktreeSettlement.index(ledger.rootDir, files);
-  if (!worktreeMatchesBaseline(ledger.rootDir, baseline, files) || !settleWorktree(ledger.rootDir, files, baseline))
+  if (
+    !worktreeMatchesBaseline(ledger.rootDir, baseline, files) ||
+    settleWorktree(ledger.rootDir, files, baseline).length > 0
+  )
     throw new TaskEventStoreError("publication_indeterminate", "authored worktree has concurrent edits");
-  verifyWorktreeFiles(ledger.rootDir, files);
   settleWorktreeDirectories(ledger.rootDir, directories);
   return { commitSha: commit, revision, changed: true };
 }
@@ -112,9 +110,11 @@ export function readCertifiedGitFollower(input: {
   };
 }
 
+const followerManifestPath = "events/segments/manifest.json";
+
+/** The publication of `events`: their documents' latest bytes, their retirements, and last the cut's manifest. */
 export function followerFiles(
   ledger: ReturnType<typeof resolveLedgerGitLayout>,
-  parent: string,
   events: readonly CanonicalEventV1[],
   readContent: (sha256: string) => Uint8Array | null,
   cut: LedgerCutIdentity,
@@ -138,26 +138,28 @@ export function followerFiles(
       retired.delete(claim.path);
     }
   }
-  const manifest = `${JSON.stringify({ schema: "sqlite-ledger-segment-manifest/v1", generation, cut })}\n`;
-  const eventsPrefix = ledgerGitPath(ledger, "events/"),
-    objectsPrefix = ledgerGitPath(ledger, "objects/sha256/");
-  for (const entry of localGitObjectRefStore.listTree(ledger.rootDir, parent, [eventsPrefix, objectsPrefix])) {
-    if (
-      (entry.target.startsWith(eventsPrefix) && !entry.target.endsWith("events/segments/manifest.json")) ||
-      entry.target.startsWith(objectsPrefix)
-    )
-      retired.add(entry.target);
-  }
-  for (const target of localGitWorktreeSettlement.indexedPaths(ledger.rootDir, [eventsPrefix, objectsPrefix])) {
-    if (target !== `${eventsPrefix}segments/manifest.json`) retired.add(target);
-  }
   return [
     ...[...latest].map(([target, value]) => ({ target: ledgerGitPath(ledger, target), ...value })),
-    ...[...retired].map((target) => ({
-      delete: target.startsWith(ledger.authoredPrefix) ? target : ledgerGitPath(ledger, target),
-    })),
-    { target: ledgerGitPath(ledger, "events/segments/manifest.json"), body: manifest, mode: "100644" },
+    ...[...retired].map((target) => ({ delete: ledgerGitPath(ledger, target) })),
+    { target: ledgerGitPath(ledger, followerManifestPath), body: followerManifest(generation, cut), mode: "100644" },
   ];
+}
+
+function followerManifest(generation: number, cut: LedgerCutIdentity): string {
+  return `${JSON.stringify({ schema: "sqlite-ledger-segment-manifest/v1", generation, cut })}\n`;
+}
+
+/** Pre-SQLite paths the index tracks, and with a `parent`, its tree holds: conversion retires both. */
+export function legacyRetirements(
+  ledger: ReturnType<typeof resolveLedgerGitLayout>,
+  parent: string | null,
+): PublicationDelete[] {
+  const scopes = [ledgerGitPath(ledger, "events/"), ledgerGitPath(ledger, "objects/sha256/")],
+    retired = new Set(localGitWorktreeSettlement.indexedPaths(ledger.rootDir, scopes));
+  if (parent !== null)
+    for (const entry of localGitObjectRefStore.listTree(ledger.rootDir, parent, scopes)) retired.add(entry.target);
+  retired.delete(ledgerGitPath(ledger, followerManifestPath));
+  return [...retired].map((target) => ({ delete: target }));
 }
 
 export interface FollowerDirectorySettlement {
@@ -224,14 +226,35 @@ export function settleWorktreeDirectories(repoRoot: string, settlement: Follower
       );
 }
 
+/**
+ * The revision whose cut `commit`'s manifest binds by head digest. Content addressing binds the rest of the tree to
+ * that commit, so it is not re-rendered here; `readCertifiedGitFollower` is the full read-back.
+ */
 export function certifiedFollowerRevision(
   ledger: ReturnType<typeof resolveLedgerGitLayout>,
   commit: string,
   sqlite: ReturnType<typeof openSqliteEventStore>,
 ): number {
-  const target = ledgerGitPath(ledger, "events/segments/manifest.json"),
-    bytes = localGitObjectRefStore.readPath(ledger.rootDir, commit, target);
-  if (!bytes) return 0;
+  const bytes = localGitObjectRefStore.readPath(ledger.rootDir, commit, ledgerGitPath(ledger, followerManifestPath));
+  return bytes ? manifestRevision(bytes, sqlite) : 0;
+}
+
+/** The revision the worktree's own manifest names, or 0 (settle the whole closure) when it names no SQLite cut. */
+export function physicalWorktreeRevision(
+  ledger: ReturnType<typeof resolveLedgerGitLayout>,
+  sqlite: ReturnType<typeof openSqliteEventStore>,
+): number {
+  const node = localGitWorktreeSettlement.readNode(`${ledger.rootDir}/${ledgerGitPath(ledger, followerManifestPath)}`);
+  if (node?.mode !== "100644") return 0;
+  try {
+    return manifestRevision(node.bytes, sqlite);
+  } catch (error) {
+    consumeKnownError(error);
+    return 0;
+  }
+}
+
+function manifestRevision(bytes: Buffer, sqlite: ReturnType<typeof openSqliteEventStore>): number {
   const parsed = decodeFollowerManifest(bytes),
     revision = Number(parsed.cut?.revision);
   if (
@@ -246,22 +269,44 @@ export function certifiedFollowerRevision(
     expected = canonicalLedgerCut(sqlite.metadata().repoId, event ? eventHead(event) : null);
   if (parsed.cut.headDigest !== expected.headDigest)
     throw new TaskEventStoreError("publication_indeterminate", "Git follower manifest cut differs from SQLite");
-  const closure = followerFiles(
-    ledger,
-    commit,
-    readEventsThrough(sqlite, revision),
-    sqlite.readContentObject,
-    expected,
-    sqlite.metadata().generation,
-  );
-  verifyGitFiles(ledger.rootDir, commit, closure);
   return revision;
 }
 
+/** What the ledger held at `revision` for each target: what a worktree settled there holds until settled again. */
+export function ledgerWorktreeBaseline(
+  ledger: ReturnType<typeof resolveLedgerGitLayout>,
+  sqlite: ReturnType<typeof openSqliteEventStore>,
+  revision: number,
+  files: readonly (PublicationWrite | PublicationDelete)[],
+): ReadonlyMap<string, string> {
+  const event = sqlite.eventAtRevision(revision),
+    held = new Map(
+      [...documentClosure(event ? readEventsThrough(sqlite, revision) : []).documents].map(([logical, document]) => [
+        ledgerGitPath(ledger, logical),
+        `${document.mode}:${document.sha256}:${document.size}`,
+      ]),
+    );
+  if (event) {
+    const manifest = followerManifest(
+      sqlite.metadata().generation,
+      canonicalLedgerCut(sqlite.metadata().repoId, eventHead(event)),
+    );
+    held.set(
+      ledgerGitPath(ledger, followerManifestPath),
+      `100644:${publicationDigest(manifest)}:${Buffer.byteLength(manifest)}`,
+    );
+  }
+  return new Map(
+    files.map((file) => {
+      const target = "target" in file ? file.target : file.delete;
+      return [target, held.get(target) ?? "missing"];
+    }),
+  );
+}
+
 /**
- * Only a manifest that is not JSON is undecodable. Everything the certification does afterwards reads the
- * ledger, not the manifest, and `publishFollower` runs the same reads outside this function — so folding their
- * failures into a decode verdict would name the wrong file and hide the failure that actually happened.
+ * Only a manifest that is not JSON is undecodable; one that decodes but names no cut SQLite holds is reported as
+ * that, so a decode verdict never hides the identity failure that actually happened.
  */
 function decodeFollowerManifest(bytes: Buffer): {
   readonly generation?: unknown;
@@ -375,55 +420,7 @@ function verifyDocumentClosure(
       throw new TaskEventStoreError("publication_indeterminate", `Git follower retirement differs at ${logical}`);
 }
 
-/** Every Git path a publication entry names, whether it publishes bytes, moves them or retires them. */
-function publicationTargets(file: PublicationFile): readonly string[] {
-  if ("target" in file) return [file.target];
-  if ("delete" in file) return [file.delete];
-  return [file.from, file.to];
-}
-
-export function verifyGitFiles(repoRoot: string, commit: string, files: readonly PublicationFile[]): void {
-  const tree = new Map(
-      localGitObjectRefStore
-        .listTree(repoRoot, commit, files.flatMap(publicationTargets))
-        .map((entry) => [entry.target, entry] as const),
-    ),
-    bodies = localGitObjectRefStore.readPaths(
-      repoRoot,
-      commit,
-      files.flatMap((file) => {
-        const entry = "target" in file ? tree.get(file.target) : undefined;
-        return entry ? [{ target: entry.target, size: entry.size, oid: entry.oid }] : [];
-      }),
-    );
-  for (const file of files) {
-    if ("target" in file) {
-      const body = bodies.get(file.target) ?? null;
-      if (body === null || !body.equals(publicationBytes(file.body)) || tree.get(file.target)?.mode !== file.mode)
-        throw new TaskEventStoreError("publication_indeterminate", `Git follower read-back differs at ${file.target}`);
-    } else if ("delete" in file && tree.has(file.delete)) {
-      throw new TaskEventStoreError("publication_indeterminate", `Git follower did not retire ${file.delete}`);
-    }
-  }
-}
-
-export function verifyAuthoredRef(repoRoot: string, authoredRef: string, commit: string): void {
-  if (localGitObjectRefStore.resolveCommit(repoRoot, authoredRef) !== commit)
-    throw new TaskEventStoreError("publication_indeterminate", "authored ref moved before Git follower read-back");
-}
-
-export function verifyWorktreeFiles(repoRoot: string, files: readonly PublicationFile[]): void {
-  for (const file of files) {
-    if ("target" in file) {
-      const node = localGitWorktreeSettlement.readNode(`${repoRoot}/${file.target}`);
-      if (node?.sha256 !== publicationDigest(file.body) || node.mode !== file.mode)
-        throw new Error(`worktree follower read-back differs at ${file.target}`);
-    } else if ("delete" in file && localGitWorktreeSettlement.readNode(`${repoRoot}/${file.delete}`) !== null) {
-      throw new Error(`worktree follower did not retire ${file.delete}`);
-    }
-  }
-}
-
+/** Returns the targets a caller changed before their rename: they keep the caller's bytes, the rest still settle. */
 export function settleWorktree(
   repoRoot: string,
   files: readonly PublicationFile[],
@@ -431,16 +428,17 @@ export function settleWorktree(
   killpoint?: (point: import("./task-event-store-types.ts").EventPublicationKillpoint) => void,
   preserve: ReadonlySet<string> = new Set(),
   commit = "",
-): boolean {
+): readonly string[] {
   const deletes = files.flatMap((file) => ("delete" in file ? [file.delete] : [])),
-    writes = files.flatMap((file) => ("target" in file ? [file] : []));
+    writes = files.flatMap((file) => ("target" in file ? [file] : [])),
+    conflicts: string[] = [];
   for (const target of deletes)
     if (
       !settleVisibleChange(repoRoot, target, "missing", baseline, killpoint, (hooks) =>
         localGitWorktreeSettlement.deleteVisible(repoRoot, [target], hooks),
       )
     )
-      return false;
+      conflicts.push(target);
   for (const file of writes)
     if (
       !settleVisibleChange(
@@ -465,8 +463,8 @@ export function settleWorktree(
         },
       )
     )
-      return false;
-  return true;
+      conflicts.push(file.target);
+  return conflicts;
 }
 
 function settleVisibleChange(

--- a/packages/kernel/src/store/sqlite-task-event-store.ts
+++ b/packages/kernel/src/store/sqlite-task-event-store.ts
@@ -71,7 +71,6 @@ export interface SqliteTaskEventStoreOptions {
   readonly authoredBranch?: string;
   readonly writerFence?: () => DaemonWriterFence;
   readonly activationPreflight?: (input: { readonly rootInput: HarnessLayoutInput; readonly repoId: string }) => void;
-  readonly beforeAppend?: () => void;
   readonly withAppendFence?: <T>(operation: () => T) => T;
   readonly onMaterializationHealthChange?: (health: MaterializationHealth) => void;
   readonly mutable?: boolean;
@@ -122,7 +121,6 @@ export function makeSqliteTaskEventStore(options: SqliteTaskEventStoreOptions): 
   const append = (bundle: CanonicalWriteBundle): CanonicalEventAppendReceipt => {
     if (options.mutable === false) throw new TaskEventStoreError("invalid_write_plan", "event reader is read-only");
     validateCanonicalWriteBundle(bundle);
-    options.beforeAppend?.();
     options.killpoint?.("before_event_write");
     const members = [...(bundle.preceding ?? []), bundle],
       appended = members.map((member) => member.event),
@@ -434,7 +432,10 @@ export function makeSqliteTaskEventStore(options: SqliteTaskEventStoreOptions): 
   }
 }
 
-/** A machine-written file the window restates may still hold any earlier snapshot of it that an interrupted pass left. */
+/**
+ * A machine-written file the window restates may still hold any earlier snapshot of it that an interrupted pass
+ * left.
+ */
 function recoverGeneratedWorktreeBaseline(
   ledger: ReturnType<typeof resolveLedgerGitLayout>,
   events: readonly CanonicalEventV1[],

--- a/packages/kernel/src/store/sqlite-task-event-store.ts
+++ b/packages/kernel/src/store/sqlite-task-event-store.ts
@@ -12,7 +12,7 @@ import { canonicalDocumentClaims, contentClaims } from "./task-event-store-claim
 import { canonicalEventCut, canonicalLedgerCut } from "./task-event-store-contract.ts";
 import { isTaskBootstrapEvent } from "../domain/task-bootstrap-event.ts";
 import { resolveLedgerGitLayout, ledgerGitPath } from "./ledger-git-layout.ts";
-import { localGitObjectRefStore, localGitText, localGitWorktreeSettlement } from "./local-version-control-system.ts";
+import { localGitObjectRefStore, localGitWorktreeSettlement } from "./local-version-control-system.ts";
 import { openSqliteEventStore, type SqliteCommandOutcome } from "./sqlite-event-store.ts";
 import { validateCanonicalWriteBundle } from "./task-event-store-contract.ts";
 import type {
@@ -21,6 +21,7 @@ import type {
   CanonicalWriteBundle,
   EventFileBatch,
   MaterializationHealth,
+  MaterializationReceipt,
   PublicationWrite,
   PublicationDelete,
 } from "./task-event-store-types.ts";
@@ -32,12 +33,11 @@ import {
   captureGitBaseline,
   followerDirectories,
   followerFiles,
-  readEventsThrough,
+  legacyRetirements,
+  ledgerWorktreeBaseline,
+  physicalWorktreeRevision,
   settleWorktree,
   settleWorktreeDirectories,
-  verifyAuthoredRef,
-  verifyGitFiles,
-  verifyWorktreeFiles,
   worktreeFingerprint,
   publicationDigest,
   readPendingEvents,
@@ -97,12 +97,12 @@ export function makeSqliteTaskEventStore(options: SqliteTaskEventStoreOptions): 
     if (!branch) throw new TaskEventStoreError("publication_indeterminate", "authored branch is detached");
     return `refs/heads/${branch}`;
   };
-  let settledWorktreeRevision = 0,
+  // Null until a settlement pass completes in this process; until then the worktree's manifest says where it stands.
+  let settledWorktreeRevision: number | null = null,
     closed = false,
     follower = pendingFollower("Git follower has not published this ledger cut"),
     scheduled: Promise<void> | null = null,
-    certified: { readonly commit: string; readonly revision: number } | null = null,
-    pendingWorktreeBaseline: ReadonlyMap<string, string> | null = null;
+    certified: { readonly commit: string; readonly revision: number } | null = null;
 
   const head = (): EventHead | null => {
     const event = sqlite.eventAtRevision(sqlite.revision());
@@ -116,7 +116,9 @@ export function makeSqliteTaskEventStore(options: SqliteTaskEventStoreOptions): 
   };
   const cut = () => canonicalLedgerCut(options.repoId, head());
   const readContent = (sha256: string) => sqlite.readContentObject(sha256);
-  const acceptedWorktree = new Map<string, { fingerprint: string; preserve: boolean }>();
+  const acceptedWorktree = new Map<string, { fingerprint: string; preserve: boolean }>(),
+    // Each target a settlement left alone, with the bytes it would have settled there.
+    worktreeConflicts = new Map<string, string>();
   const append = (bundle: CanonicalWriteBundle): CanonicalEventAppendReceipt => {
     if (options.mutable === false) throw new TaskEventStoreError("invalid_write_plan", "event reader is read-only");
     validateCanonicalWriteBundle(bundle);
@@ -189,16 +191,18 @@ export function makeSqliteTaskEventStore(options: SqliteTaskEventStoreOptions): 
     }
   };
 
+  /** Returns the targets left alone: bytes that are neither baseline nor settled are a concurrent edit, and win. */
   const settleFollowerWorktree = (
     currentLedger: ReturnType<typeof ledger>,
     files: readonly (PublicationWrite | PublicationDelete)[],
     baseline: ReadonlyMap<string, string>,
     commit: string,
     directories: FollowerDirectorySettlement,
-    restoreMissing = false,
-  ): boolean => {
+    restoreMissing: boolean,
+  ): readonly string[] => {
     const permitted = new Map(baseline),
-      preserve = new Set<string>();
+      preserve = new Set<string>(),
+      conflicts: string[] = [];
     for (const [logical, accepted] of acceptedWorktree) {
       const target = ledgerGitPath(currentLedger, logical);
       if (
@@ -210,103 +214,87 @@ export function makeSqliteTaskEventStore(options: SqliteTaskEventStoreOptions): 
       permitted.set(target, accepted.fingerprint);
       if (accepted.preserve && baseline.get(target) !== accepted.fingerprint) preserve.add(target);
     }
-    let eligible = files.filter((file) => {
-      const target = "target" in file ? file.target : file.delete,
-        current = worktreeFingerprint(localGitWorktreeSettlement.readNode(`${currentLedger.rootDir}/${target}`)),
-        settled =
-          "target" in file ? `${file.mode}:${publicationDigest(file.body)}:${Buffer.byteLength(file.body)}` : "missing";
-      if (current === "missing" && (restoreMissing || !permitted.has(target))) permitted.set(target, "missing");
-      return current === permitted.get(target) || current === settled;
-    });
-    if (eligible.length < files.length) {
-      const manifest = ledgerGitPath(currentLedger, "events/segments/manifest.json");
-      eligible = eligible.filter((file) => ("target" in file ? file.target : file.delete) !== manifest);
-    }
-    if (!settleWorktree(currentLedger.rootDir, eligible, permitted, options.killpoint, preserve, commit)) return false;
-    verifyWorktreeFiles(currentLedger.rootDir, eligible);
+    const manifest = ledgerGitPath(currentLedger, "events/segments/manifest.json"),
+      eligible = files.filter((file) => {
+        const target = "target" in file ? file.target : file.delete,
+          current = worktreeFingerprint(localGitWorktreeSettlement.readNode(`${currentLedger.rootDir}/${target}`));
+        if (current === "missing" && (restoreMissing || !permitted.has(target))) permitted.set(target, "missing");
+        if (current === permitted.get(target) || current === settledFingerprint(file)) return true;
+        conflicts.push(target);
+        return false;
+      }),
+      isManifest = (file: PublicationWrite | PublicationDelete) => "target" in file && file.target === manifest;
+    conflicts.push(
+      ...settleWorktree(
+        currentLedger.rootDir,
+        eligible.filter((file) => !isManifest(file)),
+        permitted,
+        options.killpoint,
+        preserve,
+        commit,
+      ),
+    );
     // Creating an owned directory is additive and idempotent, so it runs even when a concurrent edit made part
     // of this settlement ineligible: a partial pass must not be the reason a directory stays missing. Retiring
     // one is equally safe under a partial pass, because a directory whose files have not been removed yet is
     // still occupied and is therefore left standing.
     settleWorktreeDirectories(currentLedger.rootDir, directories);
-    if (eligible.length < files.length) return false;
+    // A restart resumes from this manifest, so it lands only after everything it vouches for.
+    conflicts.push(...settleWorktree(currentLedger.rootDir, eligible.filter(isManifest), permitted, options.killpoint));
     acceptedWorktree.clear();
-    return true;
+    return conflicts;
   };
 
-  const publishFollower = (restoreMissing = false) => {
+  /**
+   * Publishes only what SQLite accepted since the followers last settled: Git on top of its certified parent, the
+   * worktree against what it last held. `restoreMissing` (materialize) settles the whole closure instead.
+   */
+  const publishFollower = (restoreMissing = false): MaterializationReceipt => {
     const accepted = cut(),
       currentLedger = ledger(),
       currentRef = authoredRef(),
       parent = localGitObjectRefStore.resolveCommit(currentLedger.rootDir, currentRef);
     if (accepted.revision === 0) {
       follower = pendingFollower("No accepted ledger cut exists to publish");
-      return {
-        status: "visible" as const,
-        commitSha: ledgerCommitSha(options.repoId, parent),
-        changed: [],
-        conflicts: [],
-      };
+      return { status: "visible", commitSha: ledgerCommitSha(options.repoId, parent), changed: [], conflicts: [] };
     }
     const verifiedRevision =
         certified?.commit === parent ? certified.revision : certifiedFollowerRevision(currentLedger, parent, sqlite),
-      pendingEvents = readPendingEvents(sqlite, Math.min(verifiedRevision, settledWorktreeRevision)),
-      files = followerFiles(currentLedger, parent, pendingEvents, readContent, accepted, sqlite.metadata().generation);
+      worktreeRevision = settledWorktreeRevision ?? physicalWorktreeRevision(currentLedger, sqlite),
+      // A generation converted before the index followed Git can still index pre-SQLite paths; an open repairs it.
+      legacy = settledWorktreeRevision === null ? legacyRetirements(currentLedger, null) : [],
+      from = restoreMissing ? 0 : Math.min(verifiedRevision, worktreeRevision);
     certified = { commit: parent, revision: verifiedRevision };
-    if (verifiedRevision === accepted.revision) {
-      const closureEvents = readEventsThrough(sqlite, accepted.revision),
-        closureFiles = followerFiles(
-          currentLedger,
-          parent,
-          closureEvents,
-          readContent,
-          accepted,
-          sqlite.metadata().generation,
-        ),
-        physicalCommit = pendingWorktreeBaseline ? null : recoverPhysicalWorktreeCommit(currentLedger, parent, sqlite),
-        baseline = pendingWorktreeBaseline
-          ? new Map(pendingWorktreeBaseline)
-          : physicalCommit
-            ? new Map([
-                ...captureGitBaseline(currentLedger.rootDir, physicalCommit, closureFiles),
-                ...recoverGeneratedWorktreeBaseline(currentLedger, closureEvents),
-              ])
-            : new Map<string, string>();
-      follower = {
-        git: { status: "verified", cut: accepted, commitSha: parent },
-        worktree: pendingFollower("worktree settlement has not verified the Git cut").worktree,
-      };
-      localGitWorktreeSettlement.index(currentLedger.rootDir, closureFiles);
-      pendingWorktreeBaseline = baseline;
-      if (
-        settleFollowerWorktree(
-          currentLedger,
-          closureFiles,
-          baseline,
-          parent,
-          followerDirectories(currentLedger, closureEvents),
-          restoreMissing,
-        )
-      ) {
-        pendingWorktreeBaseline = null;
-        settledWorktreeRevision = accepted.revision;
-      }
-      verifyAuthoredRef(currentLedger.rootDir, currentRef, parent);
+    if (from === accepted.revision && legacy.length === 0) {
+      settledWorktreeRevision = accepted.revision;
       follower = {
         git: { status: "verified", cut: accepted, commitSha: parent },
         worktree:
-          settledWorktreeRevision < accepted.revision
-            ? pendingFollower("authored worktree has concurrent edits").worktree
+          follower.worktree.cut?.revision === accepted.revision
+            ? follower.worktree
             : { status: "verified", cut: accepted, commitSha: parent, conflicts: [] },
       };
-      return {
-        status: "visible" as const,
-        commitSha: ledgerCommitSha(options.repoId, parent),
-        changed: [],
-        conflicts: [],
-      };
+      return { status: "visible", commitSha: ledgerCommitSha(options.repoId, parent), changed: [], conflicts: [] };
     }
-    const tempRef = `refs/ha-sqlite-outbox/${sha256Text(`${accepted.revision}:${accepted.headDigest}`)}`,
+    const events = readPendingEvents(sqlite, from),
+      files = [...followerFiles(currentLedger, events, readContent, accepted, sqlite.metadata().generation), ...legacy],
+      baseline = new Map(captureGitBaseline(currentLedger.rootDir, parent, files));
+    if (restoreMissing || worktreeRevision !== verifiedRevision) {
+      // The worktree last settled at another cut than Git's parent, so it may still hold what the ledger held then.
+      const held = new Map([
+        ...ledgerWorktreeBaseline(currentLedger, sqlite, worktreeRevision, files),
+        ...recoverGeneratedWorktreeBaseline(currentLedger, events),
+      ]);
+      for (const [target, previous] of held)
+        if (
+          worktreeFingerprint(localGitWorktreeSettlement.readNode(`${currentLedger.rootDir}/${target}`)) !==
+          baseline.get(target)
+        )
+          baseline.set(target, previous);
+    }
+    let commit = parent;
+    if (verifiedRevision < accepted.revision) {
+      const tempRef = `refs/ha-sqlite-outbox/${sha256Text(`${accepted.revision}:${accepted.headDigest}`)}`;
       commit = prepareCommit(
         currentLedger.rootDir,
         tempRef,
@@ -315,59 +303,52 @@ export function makeSqliteTaskEventStore(options: SqliteTaskEventStoreOptions): 
         `outbox-${accepted.revision}`,
         new Date().toISOString(),
       );
-    options.killpoint?.("after_git_commit");
-    const baseline = new Map(captureGitBaseline(currentLedger.rootDir, parent, files));
-    for (const [target, previous] of pendingWorktreeBaseline ?? []) {
-      const current = worktreeFingerprint(localGitWorktreeSettlement.readNode(`${currentLedger.rootDir}/${target}`));
-      // Exact bytes from the latest certified Git cut can advance an older pending baseline.
-      if (current !== baseline.get(target)) baseline.set(target, previous);
+      options.killpoint?.("after_git_commit");
+      finalizeRefs(currentLedger.rootDir, currentRef, commit, parent, tempRef);
+      options.killpoint?.("after_git_ref_update");
+      certified = { commit, revision: accepted.revision };
     }
-    pendingWorktreeBaseline = baseline;
-    finalizeRefs(currentLedger.rootDir, currentRef, commit, parent, tempRef);
-    options.killpoint?.("after_git_ref_update");
-    verifyGitFiles(currentLedger.rootDir, commit, files);
-    verifyAuthoredRef(currentLedger.rootDir, currentRef, commit);
-    certified = { commit, revision: accepted.revision };
     follower = {
       git: { status: "verified", cut: accepted, commitSha: commit },
       worktree: pendingFollower("worktree settlement has not verified the Git cut").worktree,
     };
     localGitWorktreeSettlement.index(currentLedger.rootDir, files);
-    if (
+    const skipped = new Set(
       settleFollowerWorktree(
         currentLedger,
         files,
         baseline,
         commit,
-        followerDirectories(currentLedger, pendingEvents),
+        followerDirectories(currentLedger, events),
         restoreMissing,
-      )
-    ) {
-      pendingWorktreeBaseline = null;
-      settledWorktreeRevision = accepted.revision;
+      ),
+    );
+    // A skipped target is never retried on its own: it stays reported until settled or its settled bytes appear.
+    for (const [target, settled] of worktreeConflicts)
+      if (worktreeFingerprint(localGitWorktreeSettlement.readNode(`${currentLedger.rootDir}/${target}`)) === settled)
+        worktreeConflicts.delete(target);
+    for (const file of files) {
+      const target = "target" in file ? file.target : file.delete;
+      if (skipped.has(target)) worktreeConflicts.set(target, settledFingerprint(file));
+      else worktreeConflicts.delete(target);
     }
-    const manifest = files.find((file) => "target" in file && file.target.endsWith("events/segments/manifest.json"));
-    if (!manifest || !("target" in manifest)) throw new Error("outbox manifest is absent");
-    const gitReadback =
-      localGitObjectRefStore.readPath(currentLedger.rootDir, commit, manifest.target)?.toString("utf8") ?? null;
-    const worktreeReadback =
-      localGitWorktreeSettlement.readNode(`${currentLedger.rootDir}/${manifest.target}`)?.body ?? null;
-    if (gitReadback !== manifest.body) throw new Error("Git follower manifest read-back did not match");
-    verifyAuthoredRef(currentLedger.rootDir, currentRef, commit);
+    settledWorktreeRevision = accepted.revision;
+    const conflicts = [...worktreeConflicts.keys()].sort();
     follower = {
-      git: { status: "verified", cut: accepted, commitSha: commit },
+      git: follower.git,
       worktree:
-        settledWorktreeRevision >= accepted.revision && worktreeReadback === manifest.body
-          ? { status: "verified", cut: accepted, commitSha: commit, conflicts: [] }
-          : { status: "pending", cut: null, commitSha: commit, reason: "authored worktree has concurrent edits" },
+        conflicts.length === 0
+          ? { status: "verified", cut: accepted, commitSha: commit, conflicts }
+          : {
+              status: "pending",
+              cut: accepted,
+              commitSha: commit,
+              reason: "authored worktree has concurrent edits",
+              conflicts,
+            },
     };
     options.onMaterializationHealthChange?.(health("ok"));
-    return {
-      status: "visible" as const,
-      commitSha: ledgerCommitSha(options.repoId, commit),
-      changed: [],
-      conflicts: [],
-    };
+    return { status: "visible", commitSha: ledgerCommitSha(options.repoId, commit), changed: [], conflicts };
   };
 
   const scheduleFollower = (): Promise<void> => {
@@ -453,34 +434,7 @@ export function makeSqliteTaskEventStore(options: SqliteTaskEventStoreOptions): 
   }
 }
 
-function recoverPhysicalWorktreeCommit(
-  ledger: ReturnType<typeof resolveLedgerGitLayout>,
-  parent: string,
-  sqlite: ReturnType<typeof openSqliteEventStore>,
-): string | null {
-  const target = ledgerGitPath(ledger, "events/segments/manifest.json"),
-    physical = localGitWorktreeSettlement.readNode(`${ledger.rootDir}/${target}`)?.body ?? null;
-  if (physical === null) return null;
-  const commits = localGitText(
-    ledger.rootDir,
-    "log",
-    "--first-parent",
-    "--format=%H",
-    `--find-object=${localGitObjectRefStore.blobOid(physical)}`,
-    parent,
-    "--",
-    target,
-  )
-    .split("\n")
-    .filter(Boolean);
-  const commit = commits.find(
-    (candidate) => localGitObjectRefStore.readPath(ledger.rootDir, candidate, target)?.toString("utf8") === physical,
-  );
-  if (!commit) return null;
-  certifiedFollowerRevision(ledger, commit, sqlite);
-  return commit;
-}
-
+/** A machine-written file the window restates may still hold any earlier snapshot of it that an interrupted pass left. */
 function recoverGeneratedWorktreeBaseline(
   ledger: ReturnType<typeof resolveLedgerGitLayout>,
   events: readonly CanonicalEventV1[],
@@ -503,6 +457,10 @@ function recoverGeneratedWorktreeBaseline(
     }
   }
   return recovered;
+}
+
+function settledFingerprint(file: PublicationWrite | PublicationDelete): string {
+  return "target" in file ? `${file.mode}:${publicationDigest(file.body)}:${Buffer.byteLength(file.body)}` : "missing";
 }
 
 function pendingFollower(reason: string): { readonly git: FollowerFacet; readonly worktree: FollowerFacet } {

--- a/packages/kernel/test/store/sqlite-event-store.integration.test.ts
+++ b/packages/kernel/test/store/sqlite-event-store.integration.test.ts
@@ -128,15 +128,17 @@ test("Git can verify an accepted document while a concurrently edited worktree r
       git(rootDir, "status", "--short", "--", "harness/context/published.md"),
       "M harness/context/published.md",
     );
+    assert.deepEqual(store.followerStatus().worktree.conflicts, ["harness/context/published.md"]);
     unlinkSync(path.join(rootDir, "harness/context/published.md"));
-    await store.settlePendingMaterialization?.("test recovery");
+    store.materialize();
     assert.equal(store.followerStatus().worktree.status, "verified");
+    assert.equal(readFileSync(path.join(rootDir, "harness/context/published.md"), "utf8"), "# Published\n");
   } finally {
     await store.drain();
   }
 });
 
-test("certified reopen resumes from the last physical cut without overwriting later user edits", async () => {
+test("certified reopen resumes from the worktree's own manifest without overwriting later user edits", async () => {
   const rootDir = mkdtempSync(path.join(tmpdir(), "ha-sqlite-worktree-reopen-"));
   initRepo(rootDir);
   const collision = path.join(rootDir, "harness/context/collision.md"),
@@ -153,15 +155,20 @@ test("certified reopen resumes from the last physical cut without overwriting la
   first.append(docBundle(first, "# Canonical later\n", 3, "reopen-later", "context/later.md"));
   await first.settlePendingMaterialization?.("blocked second cut");
   assert.equal(first.followerStatus().worktree.status, "pending");
+  assert.deepEqual(first.followerStatus().worktree.conflicts, ["harness/context/collision.md"]);
+  assert.equal(readFileSync(collision, "utf8"), "local collision\n");
   await first.drain();
 
   unlinkSync(collision);
   const reopened = makeTaskEventStore({ repoId, rootDir });
   try {
+    // The reported path is not retried on its own: the reopen resumes at the settled cut, and materializing restores.
     await reopened.settlePendingMaterialization?.("resume physical cut");
+    assert.throws(() => readFileSync(collision), { code: "ENOENT" });
+    assert.equal(readFileSync(later, "utf8"), "# Canonical later\n");
+    reopened.materialize();
     assert.equal(reopened.followerStatus().worktree.status, "verified");
     assert.equal(readFileSync(collision, "utf8"), "# Canonical collision\n");
-    assert.equal(readFileSync(later, "utf8"), "# Canonical later\n");
   } finally {
     await reopened.drain();
   }
@@ -171,7 +178,6 @@ test("certified reopen resumes from the last physical cut without overwriting la
   try {
     await editedReopen.settlePendingMaterialization?.("preserve edit after reopen");
     assert.equal(readFileSync(later, "utf8"), "real user edit\n");
-    assert.equal(editedReopen.followerStatus().worktree.status, "pending");
   } finally {
     await editedReopen.drain();
   }
@@ -179,7 +185,6 @@ test("certified reopen resumes from the last physical cut without overwriting la
   const deletedReopen = makeTaskEventStore({ repoId, rootDir });
   try {
     await deletedReopen.settlePendingMaterialization?.("preserve local deletion");
-    assert.equal(deletedReopen.followerStatus().worktree.status, "pending");
     assert.throws(() => readFileSync(later), { code: "ENOENT" });
     const acceptedRevision = deletedReopen.currentCut().revision;
     deletedReopen.materialize();
@@ -383,7 +388,7 @@ test("certified Git follower rejects document tampering even when its manifest i
     try {
       assert.throws(
         () => readCertifiedGitFollower({ rootInput: rootDir, repoId, store: sqlite }),
-        /read-back differs/u,
+        /Git follower document differs at context\/canonical\.md/u,
       );
     } finally {
       sqlite.close();

--- a/packages/kernel/test/store/task-event-store.test.ts
+++ b/packages/kernel/test/store/task-event-store.test.ts
@@ -1,11 +1,12 @@
 // harness-test-tier: integration
 import assert from "node:assert/strict";
-import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
 import { attachReceiptAcceptance } from "../../src/composition/receipt-acceptance.ts";
 import { taskLifecycleWritePlan } from "../../src/domain/task-lifecycle-publication.ts";
+import { localContentObjectFileSystem } from "../../src/local/local-layout-file-system.ts";
 import { localGitObjectRefStore } from "../../src/store/local-version-control-system.ts";
 import { openSqliteEventStore, sqliteContentObjectPath } from "../../src/store/sqlite-event-store.ts";
 import { makeTaskEventStore, readCertifiedGitFollower } from "../../src/store/task-event-store.ts";
@@ -151,7 +152,67 @@ test("acceptance subprocess cost is independent of 100 versus 10,000-event histo
   }
 });
 
-test("repeated settlement preserves concurrent edits to a claimed document and resumes after resolution", async () => {
+test("each settlement renders and settles only its own events while a concurrent edit keeps its bytes", async (t) => {
+  const rootDir = fixture("incremental-follower"),
+    edited = path.join(rootDir, "harness/context/edited.md");
+  initRepo(rootDir);
+  mkdirSync(path.dirname(edited), { recursive: true });
+  writeFileSync(edited, "user edit\n");
+  let settledFiles = 0;
+  const contentReads = t.mock.method(localContentObjectFileSystem, "readBytes"),
+    options = {
+      repoId,
+      rootDir,
+      writerFence,
+      killpoint: (point: string) => {
+        if (point === "before_worktree_rename") settledFiles += 1;
+      },
+    },
+    measure = async (store: ReturnType<typeof makeTaskEventStore>, context: string) => {
+      contentReads.mock.resetCalls();
+      settledFiles = 0;
+      await store.settlePendingMaterialization!(context);
+      return { contentReads: contentReads.mock.callCount(), settledFiles };
+    };
+  const store = makeTaskEventStore(options),
+    perCut: Awaited<ReturnType<typeof measure>>[] = [];
+  try {
+    store.append(docBundle(store, "accepted\n", 1, "incremental-edited", "context/edited.md"));
+    await store.settlePendingMaterialization!("cut claiming the edited document");
+    for (let revision = 2; revision <= 6; revision += 1) {
+      const logical = `context/later-${revision}.md`;
+      store.append(docBundle(store, `accepted ${revision}\n`, revision, `incremental-${revision}`, logical));
+      perCut.push(await measure(store, `cut ${revision}`));
+      assert.equal(readFileSync(path.join(rootDir, "harness", logical), "utf8"), `accepted ${revision}\n`);
+    }
+    // One content object, and its document plus the manifest, per cut: never the history behind it.
+    assert.deepEqual(
+      perCut,
+      perCut.map(() => ({ contentReads: 1, settledFiles: 2 })),
+    );
+    assert.equal(readFileSync(edited, "utf8"), "user edit\n");
+    const head = store.currentCut(),
+      physical = JSON.parse(readFileSync(path.join(rootDir, "harness/events/segments/manifest.json"), "utf8"));
+    assert.deepEqual(store.followerStatus().git.cut, head);
+    assert.deepEqual(store.followerStatus().worktree.cut, head);
+    assert.deepEqual(physical.cut, head);
+    assert.equal(store.followerStatus().worktree.status, "pending");
+    assert.deepEqual(store.followerStatus().worktree.conflicts, ["harness/context/edited.md"]);
+  } finally {
+    await store.drain();
+  }
+  // The worktree's own manifest says where it stands, so a reopen settles nothing and leaves the edit alone.
+  const reopened = makeTaskEventStore(options);
+  try {
+    assert.deepEqual(await measure(reopened, "reopen at the settled cut"), { contentReads: 0, settledFiles: 0 });
+    assert.equal(reopened.followerStatus().git.status, "verified");
+    assert.equal(readFileSync(edited, "utf8"), "user edit\n");
+  } finally {
+    await reopened.drain();
+  }
+});
+
+test("repeated settlement preserves concurrent edits to a claimed document until materialization restores it", async () => {
   const rootDir = fixture("claimed-edit"),
     target = path.join(rootDir, "harness/context/owned.md");
   initRepo(rootDir);
@@ -163,12 +224,15 @@ test("repeated settlement preserves concurrent edits to a claimed document and r
   await store.settlePendingMaterialization!("retry must not bless user bytes");
   assert.equal(store.followerStatus().git.status, "verified");
   assert.equal(store.followerStatus().worktree.status, "pending");
+  assert.deepEqual(store.followerStatus().worktree.conflicts, ["harness/context/owned.md"]);
   assert.equal(readFileSync(target, "utf8"), "user edit\n");
   await store.drain();
   assert.equal(readFileSync(target, "utf8"), "user edit\n");
   rmSync(target);
   store = makeTaskEventStore({ repoId, rootDir, writerFence });
-  await store.settlePendingMaterialization!("user restored pre-publication state");
+  await store.settlePendingMaterialization!("a reported path is not retried on its own");
+  assert.equal(existsSync(target), false);
+  store.materialize();
   assert.equal(store.followerStatus().worktree.status, "verified");
   assert.equal(readFileSync(target, "utf8"), "accepted content\n");
   await store.drain();
@@ -198,9 +262,10 @@ test("a caller edit at the rename boundary is preserved as a pending worktree co
     await store.settlePendingMaterialization!("inject boundary edit");
     assert.equal(store.followerStatus().git.status, "verified");
     assert.equal(store.followerStatus().worktree.status, "pending");
+    assert.deepEqual(store.followerStatus().worktree.conflicts, ["harness/context/boundary.md"]);
     assert.equal(readFileSync(target, "utf8"), "caller edit at settlement boundary\n");
     rmSync(target);
-    await store.settlePendingMaterialization!("caller resolved boundary edit");
+    store.materialize();
     assert.equal(store.followerStatus().worktree.status, "verified");
     assert.equal(readFileSync(target, "utf8"), "accepted content\n");
   } finally {
@@ -208,7 +273,7 @@ test("a caller edit at the rename boundary is preserved as a pending worktree co
   }
 });
 
-test("Git verification fails when the authored ref moves after its atomic update", async () => {
+test("an authored ref moved after the follower's atomic update is followed, not fought, by the next run", async () => {
   const rootDir = fixture("authored-ref-readback");
   initRepo(rootDir);
   const branch = git(rootDir, "symbolic-ref", "--short", "HEAD"),
@@ -229,10 +294,13 @@ test("Git verification fails when the authored ref moves after its atomic update
     store.append(docBundle(store, "accepted content\n", 1, "ref-moved", "context/ref-moved.md"));
     await store.settlePendingMaterialization!("move authored ref after update");
     assert.equal(git(rootDir, "rev-parse", "HEAD"), parent);
-    assert.equal(store.followerStatus().git.status, "pending");
-    assert.match(store.followerStatus().git.reason!, /authored ref moved/u);
-    await store.settlePendingMaterialization!("publish after ref stabilizes");
+    await store.settlePendingMaterialization!("publish on top of the moved ref");
+    const head = git(rootDir, "rev-parse", "HEAD");
+    assert.notEqual(head, parent);
+    assert.equal(git(rootDir, "rev-parse", "HEAD^"), parent);
+    assert.equal(git(rootDir, "show", "HEAD:harness/context/ref-moved.md"), "accepted content");
     assert.equal(store.followerStatus().git.status, "verified");
+    assert.equal(store.followerStatus().git.commitSha, head);
   } finally {
     await store.drain();
   }
@@ -303,11 +371,15 @@ test("new cuts cannot certify worktree visibility over an older unresolved docum
     await store.settlePendingMaterialization!("new cut with prior conflict");
     assert.equal(store.followerStatus().git.status, "verified");
     assert.equal(store.followerStatus().worktree.status, "pending");
+    assert.deepEqual(store.followerStatus().worktree.conflicts, ["harness/context/conflicted.md"]);
     assert.equal(readFileSync(target, "utf8"), "user edit\n");
-    rmSync(target);
-    await store.settlePendingMaterialization!("resolved both cuts");
+    assert.equal(readFileSync(path.join(rootDir, "harness/context/next.md"), "utf8"), "next document\n");
+    // Once the worktree holds the accepted bytes the conflict is gone, so a later cut can certify visibility.
+    writeFileSync(target, "accepted\n");
+    store.append(docBundle(store, "third document\n", 3, "third-cut", "context/third.md"));
+    await store.settlePendingMaterialization!("conflict resolved to the accepted bytes");
     assert.equal(store.followerStatus().worktree.status, "verified");
-    assert.equal(readFileSync(target, "utf8"), "accepted\n");
+    assert.deepEqual(store.followerStatus().worktree.conflicts, []);
   } finally {
     await store.drain();
   }

--- a/packages/preset/test/preset-bootstrap.test.ts
+++ b/packages/preset/test/preset-bootstrap.test.ts
@@ -255,7 +255,12 @@ test("reopen recovers bootstrap machine views while preserving bootstrap prose a
     assert.equal(readFileSync(draftPath, "utf8"), "A real unsubmitted draft\n");
     assert.equal(reopened.currentCut().revision, 3);
     assert.equal(reopened.followerStatus().worktree.status, "pending");
-    assert.equal(readFileSync(manifestPath, "utf8"), physicalManifest);
+    assert.deepEqual(reopened.followerStatus().worktree.conflicts, [
+      `harness/${born.packagePath}/closeout.md`,
+      `harness/${plan.path}`,
+    ]);
+    // The draft is reported, not a reason to hold the worktree back: its manifest records the settled cut.
+    assert.equal(JSON.parse(readFileSync(manifestPath, "utf8")).cut.revision, 3);
   } finally {
     await reopened.drain();
     rmSync(rootDir, { recursive: true, force: true });


### PR DESCRIPTION
# English

## Summary

Make the Git and worktree followers do work proportional to the events since their last run, not to the whole history. SQLite is canonical, and the followers publish accepted events to the authored Git branch and the authored worktree on the single per-repository writer thread. The follower rendered `readPendingEvents(sqlite, min(verifiedRevision, settledWorktreeRevision))`, but `settledWorktreeRevision` started at 0 on every daemon start and advanced only when the whole window settled. The real authored worktree always holds some unsynced edits from agents, so settlement never completed. Every write then re-rendered the full history: it read and re-hashed every content blob and re-checked every file. After PR #2407 was deployed, a single write took 1.0 s, but the next one waited 32.9 s behind that follower pass (fact F-7198CB74). This is the third batch of the daemon write-path rescue.

## Architectural Justification

- Git is a follower. When the worktree holds a concurrent edit, the user's bytes win and the file is reported; the follower does not retry forever. With that rule, the settled revision can advance on every run, and the window stays incremental.
- Deletion first: production net is -47 lines (+207/-254, `node tools/gates/production-delta.mjs --base origin/main`). The full-closure pass stays only where it is explicit and rare: `materialize()`, and one pass at open when the worktree's own manifest names no SQLite cut.
- Verification kept:
  - the manifest identity, generation, repoId and headDigest checks;
  - the sha256 check on each rendered content object;
  - the rename-time concurrent-edit check;
  - the full `readCertifiedGitFollower` read-back, which conversion, activation and reconcile use.
- Verification deleted: the per-run read-backs, for three reasons.
  - Git's content addressing means a commit's tree cannot differ from the objects written into it.
  - `finalizeRefs` updates the ref by compare-and-swap, so a moved ref fails that update. It is not caught by a later read.
  - The manifest's headDigest already binds a Git cut to SQLite.

## What Changed

- `sqlite-task-event-store.ts`, `publishFollower`:
  - Each run renders only the events after `min(verifiedRevision, worktreeRevision)`, and Git commits only when it is behind.
  - A settlement returns the targets it left alone. Those are kept in `follower.worktree.conflicts` until a later event settles them or the file holds its settled bytes again.
  - `settledWorktreeRevision` advances to the head on every run, and the worktree manifest is written last.
- Startup: the worktree's settled revision comes from its own `events/segments/manifest.json`, checked against SQLite by headDigest (`physicalWorktreeRevision`). This replaces `recoverPhysicalWorktreeCommit`, which ran `git log --find-object` plus a full certification.
- A worktree that settled at a different cut than Git's parent may still hold the ledger's bytes from that cut. `ledgerWorktreeBaseline` computes those bytes from SQLite, and only in that case.
- `certifiedFollowerRevision`: the closure re-render and `verifyGitFiles` are gone; the manifest identity and headDigest checks stay.
- The per-write `ls-tree`/`ls-files` scan of the pre-SQLite `events/` and `objects/sha256/` paths runs in two places only: generation conversion, and once at store open (`legacyRetirements`). An open still has to repair stale legacy index entries (commit `d7896bb96`, test "certified reopen retires stale legacy index entries").
- Deleted:
  - the read-backs `verifyGitFiles`, both `verifyAuthoredRef` calls, the manifest read-back and `verifyWorktreeFiles`, including in `publishConvertedGeneration`;
  - `pendingWorktreeBaseline`;
  - the now-unused `blobOid`;
  - the kernel store's unused `beforeAppend` option.
- `docs-release/architecture/{en,zh}/00-overview.md` no longer says Git is certified by reading every file back.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Deleted production behavior (no file removed): the whole-history follower window, the full-closure pass when Git is already at the head, `recoverPhysicalWorktreeCommit`, the closure re-render inside `certifiedFollowerRevision`, the per-run read-backs, the per-write legacy path scan, and the unused `beforeAppend` hook.
- Production net lines: +207/-254, net -47.

## Machine-Readable Declarations

## Task And Scope

- Harness task: task_2b8f79fa4412cb726a26f9bfc7 (daemon write-path performance rescue)
- Branch: `codex/incremental-git-follower`
- Public scope: `packages/kernel/src/store/` follower and publication, their tests, one preset test, and the architecture overview in `docs-release/`
- Private planning/evidence updated: yes (fact F-7198CB74)
- Out of scope: the remaining per-write serialization and hashing in the store (`readHead()`, repeated event validation) is a follow-up.

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none
- Authority: not applicable
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `0176f68806b0ec3bab57df6e1e7a3c79c6fdb72d`
- Branch merge-base with `origin/main`: `0176f68806b0ec3bab57df6e1e7a3c79c6fdb72d`
- Last `git fetch origin` time: 2026-09-10 12:40 UTC
- Sync method: rebase onto origin/main
- Public diff command: `git diff origin/main...codex/incremental-git-follower`
- Private evidence commit/path: fact F-7198CB74
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [x] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Red before, green after. The new case in `task-event-store.test.ts` edits one file as the user would, then settles five more appends. It counts content-object reads and settled files for each settle.
  - On the base, both grow with history: reads 2→6, settled files 1→5.
  - On this branch, every settle costs exactly 1 read and 2 settled files, whatever the history length.
  - The edited file keeps the user's bytes and is reported as a conflict. The Git cut, worktree cut and on-disk manifest all reach the head, and a reopen does no work.
- Docker-isolated on the rebased head (`node tools/dispatch-isolated-test.mjs --target docker --file <file>`):

  | Test file | Passed |
  |---|---|
  | `task-event-store.test.ts` | 14/14 |
  | `sqlite-event-store.integration.test.ts` | 24/24 |
  | `legacy-entity-declaration-follower.integration.test.ts` | 1/1 |
  | `local-version-control-settlement.test.ts` | 6/6 |
  | `daemon/test/legacy-generation-conversion.integration.test.ts` | 10/10 |
  | `preset/test/preset-bootstrap.test.ts` | 2/2 |
  | `gui/test/service-bridge.test.ts` | 3/3 |
  | `cli/test/daemon-receipt-cli.test.ts` | 1/1 |
  | `task-projection.test.ts` | 26/26 |

  The implementation worker also ran about 75 targeted files on Docker before the rebase, all green.
- Existing tests changed, and why each is safe:
  - Tamper test: only the expected message changed. `readCertifiedGitFollower` still catches the tamper, now through `verifyDocumentClosure`.
  - Ref-moved test: it asserted `verifyAuthoredRef`. It now checks that the follower does not fight an external move and publishes on top of it on the next run.
  - Five tests expected deleting a conflicted file and then settling or reopening to restore it, which was the retry-forever behavior. They now restore through `materialize()` or by writing the accepted bytes back. Every assertion about user bytes is unchanged, and conflict-list assertions were added.
  - `preset-bootstrap` asserted that the manifest stays at the old cut while a conflict exists. It now asserts that the manifest reaches the head and both skipped files are reported.
- Also run on the final head: `tsc -b`, eslint and prettier on changed files, `check-file-complexity`, `check-cli-structure`, `check-bypass-write-boundary`, `line-density`, `production-delta`, `git diff --check` (all pass).
- Not run: the full `npm run check` / `npm test` locally. Local agents must not run the full matrix, so CI is the full authority.

## Review Evidence

- Self-review: the lead read the full production diff.
  - Steady state: after each run, `settledWorktreeRevision` and the certified revision both equal the accepted head, so the next window starts at the head and `ledgerWorktreeBaseline` does not run.
  - External ref moves: they fail the `finalizeRefs` compare-and-swap or are published on top of.
  - Conflicts: a conflict never overwrites user bytes.
  - Manifest: it is written after everything it vouches for.
- Reviewer subagent: an isolated implementation worker wrote the change; the lead reviewed it, resolved the rebase against PR #2402 (the deleted `verifyGitFiles` carried that PR's `oid` edit), and removed the unused `beforeAppend` hook
- Human review: pending
- Blocking findings: none

## Residual Risk

- Conflict reports live in memory. A restart forgets them, and a run with no new events does not re-check them. `ha doc status` still shows the dirty file.
- If a crash interrupts a settlement, a prose file left at an intermediate cut is reported as a conflict, not overwritten. The old code behaved the same way.
- A worktree manifest that is corrupt or edited by hand triggers the full pass on every open until it is rewritten.
- An external commit that changes canonical files but keeps the manifest intact is no longer noticed by the per-run follower. Only `readCertifiedGitFollower` catches it.
- On the live ledger, the first start after deployment makes one larger pass from wherever the old code last left the worktree manifest.

## References

- Evidence: fact F-7198CB74
- Previous batches: PR #2407, PR #2408
- Review: this PR

---

# 中文

## 概要

让 Git follower 和 worktree follower 的工作量只和上次运行之后的新事件成正比，不再和整段历史成正比。SQLite 是 canonical；follower 在每个仓库唯一的 writer 线程上，把已接受的事件发布到 authored Git 分支和 authored worktree。原来 follower 渲染的是 `readPendingEvents(sqlite, min(verifiedRevision, settledWorktreeRevision))`，而 `settledWorktreeRevision` 每次 daemon 启动都从 0 开始，并且只有整个窗口全部结算成功才会前进。真实的 authored worktree 里总有 agent 还没同步的改动，所以结算永远完不成，每次写入都要重渲染全历史：重读并重新哈希所有内容对象，逐个文件重新检查。PR #2407 上线后，单次写入 1.0 秒，紧接着的下一次写入却要在这一轮 follower 后面等 32.9 秒（fact F-7198CB74）。这是 daemon 写路径抢救的第三批。

## 架构辩护

- Git 是 follower。worktree 里有并发编辑时，用户的字节优先，这个文件被上报，而不是无限重试。有了这条规则，每次运行都能推进已结算 revision，窗口保持增量。
- 以删除为主：生产代码净减 47 行（+207/-254，`node tools/gates/production-delta.mjs --base origin/main`）。全闭包处理只保留在显式且罕见的地方：`materialize()`，以及打开时 worktree 自己的 manifest 对不上任何 SQLite cut 的那一次。
- 保留的校验：
  - manifest 的 identity、generation、repoId、headDigest 检查；
  - 每个渲染出的内容对象的 sha256 检查；
  - rename 时的并发编辑检查；
  - 完整的 `readCertifiedGitFollower` 读回，供转换、激活和 reconcile 使用。
- 删除的校验：每次运行的读回。理由有三：
  - Git 的内容寻址保证了 commit 的树不可能和写进去的对象不一致；
  - `finalizeRefs` 用 compare-and-swap 更新 ref，ref 被移动时这一步就会失败，不是靠事后读回发现；
  - manifest 的 headDigest 已经把 Git cut 和 SQLite 绑在一起。

## 改动内容

- `sqlite-task-event-store.ts` 的 `publishFollower`：
  - 每次运行只渲染 `min(verifiedRevision, worktreeRevision)` 之后的事件，Git 只在落后时才提交。
  - 结算返回它跳过的目标，这些目标记在 `follower.worktree.conflicts` 里，直到后续事件把它们结算掉，或者文件重新变回应结算的字节。
  - 每次运行都把 `settledWorktreeRevision` 推进到 head；worktree manifest 最后写。
- 启动：worktree 的已结算 revision 从它自己的 `events/segments/manifest.json` 读出，并用 headDigest 与 SQLite 核对（`physicalWorktreeRevision`）。它取代了 `recoverPhysicalWorktreeCommit`（`git log --find-object` 加一次完整认证）。
- worktree 停在与 Git parent 不同的 cut 时，可能仍然保留着台账在那个 cut 的字节。`ledgerWorktreeBaseline` 从 SQLite 算出这些字节，而且只在这种情况下运行。
- `certifiedFollowerRevision`：去掉闭包重渲染和 `verifyGitFiles`，保留 manifest 的 identity 和 headDigest 检查。
- 对 SQLite 之前的 `events/`、`objects/sha256/` 路径的 `ls-tree`/`ls-files` 扫描，原来每次写入都跑，现在只在两处运行：generation 转换时，以及打开 store 时跑一次（`legacyRetirements`）。打开时仍然需要修复过期的旧索引条目（commit `d7896bb96`，测试 "certified reopen retires stale legacy index entries"）。
- 删除：
  - 读回校验 `verifyGitFiles`、两处 `verifyAuthoredRef`、manifest 读回和 `verifyWorktreeFiles`，`publishConvertedGeneration` 里的也一并删除；
  - `pendingWorktreeBaseline`；
  - 已无用处的 `blobOid`；
  - kernel store 里没有调用方的 `beforeAppend` 选项。
- `docs-release/architecture/{en,zh}/00-overview.md` 不再说 Git 是靠逐文件读回来认证的。

## 门收割 / Gate Harvest

- 删除的生产路径：none（没有删文件）
- 删除的生产行为：全历史 follower 窗口、Git 已在 head 时的全闭包处理、`recoverPhysicalWorktreeCommit`、`certifiedFollowerRevision` 里的闭包重渲染、每次运行的读回、每次写入的旧路径扫描，以及没有调用方的 `beforeAppend` 钩子
- 生产净行数：+207/-254，净 -47。

## 机读声明说明

- 本 PR 不涉及依赖变化、事件迁移和保留旧路径，没有机读声明。

## 任务与范围

- Harness 任务：task_2b8f79fa4412cb726a26f9bfc7（daemon 写路径性能抢救）
- 分支：`codex/incremental-git-follower`
- 公开范围：`packages/kernel/src/store/` 里的 follower 与发布逻辑、对应测试、一个 preset 测试，以及 `docs-release/` 里的架构概览
- 私有计划 / 证据是否已更新：yes（fact F-7198CB74）
- 范围外：store 里剩下的每次写入的序列化和哈希（`readHead()`、重复的事件校验）另开后续 PR。

## 版本影响

- 版本：不改版本
- 发布影响：不发布

## 治理声明

- 是否触碰 protected surface：no
- protected surface 范围：无
- 依据：不适用
- 机器检查边界：本 PR 只声明该段存在；声明是否真实、充分，由 reviewer 判断。
- Break-glass：no
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- `origin/main` 基准 SHA：`0176f68806b0ec3bab57df6e1e7a3c79c6fdb72d`
- 当前分支与 `origin/main` 的 merge-base：`0176f68806b0ec3bab57df6e1e7a3c79c6fdb72d`
- 最近一次 `git fetch origin` 时间：2026-09-10 12:40 UTC
- 同步方式：rebase 到 origin/main
- 公开 diff 命令：`git diff origin/main...codex/incremental-git-follower`
- 私有证据 commit/path：fact F-7198CB74
- Reviewer 证据路径：见本 PR 的「审查证据」一节
- GitHub Actions `rewrite-ci` run URL：本 PR 的 CI 还在跑
- [ ] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [x] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- 修复前红、修复后绿。`task-event-store.test.ts` 的新用例先像用户那样改一个文件，再结算后续 5 次 append，统计每次结算的内容对象读取数和结算文件数：
  - 在基线上，两个数都随历史增长：读取 2→6，结算文件 1→5；
  - 本分支上，无论历史多长，每次结算都恰好 1 次读取、2 个文件；
  - 被改的文件保留用户的字节并被上报为冲突；Git cut、worktree cut 和磁盘上的 manifest 都到达 head；重新打开不做任何工作。
- 在 rebase 后的 head 上，于 Docker 隔离环境运行（`node tools/dispatch-isolated-test.mjs --target docker --file <file>`）：

  | 测试文件 | 通过 |
  |---|---|
  | `task-event-store.test.ts` | 14/14 |
  | `sqlite-event-store.integration.test.ts` | 24/24 |
  | `legacy-entity-declaration-follower.integration.test.ts` | 1/1 |
  | `local-version-control-settlement.test.ts` | 6/6 |
  | `daemon/test/legacy-generation-conversion.integration.test.ts` | 10/10 |
  | `preset/test/preset-bootstrap.test.ts` | 2/2 |
  | `gui/test/service-bridge.test.ts` | 3/3 |
  | `cli/test/daemon-receipt-cli.test.ts` | 1/1 |
  | `task-projection.test.ts` | 26/26 |

  实现 worker 在 rebase 之前还在 Docker 里跑了约 75 个定向测试文件，全绿。
- 修改过的现有测试，以及为什么安全：
  - 篡改测试：只改了期望的报错信息。`readCertifiedGitFollower` 仍能抓到篡改，现在经由 `verifyDocumentClosure`。
  - ref 被移动的测试：原来断言 `verifyAuthoredRef`，现在检查 follower 不和外部移动较劲，而是在下一轮运行时发布在它之上。
  - 5 个测试原先期望「删掉冲突文件、再结算或重开就会恢复它」，也就是无限重试的行为。现在改为通过 `materialize()` 恢复，或把已接受的字节写回。所有关于用户字节的断言都不变，另外补了冲突列表的断言。
  - `preset-bootstrap` 原先断言有冲突时 manifest 停在旧 cut，现在断言 manifest 到达 head，并上报两个被跳过的文件。
- 在最终 head 上另外跑过：`tsc -b`、改动文件的 eslint 和 prettier、`check-file-complexity`、`check-cli-structure`、`check-bypass-write-boundary`、`line-density`、`production-delta`、`git diff --check`，全部通过。
- 未运行：本地整套 `npm run check` / `npm test`。规定禁止本地 agent 跑全量矩阵，全量以 CI 为准。

## 审查证据

- 自查：主控读完整个生产 diff，确认了以下几点。
  - 稳态：每次运行后，`settledWorktreeRevision` 和已认证 revision 都等于已接受的 head，所以下一个窗口从 head 开始，`ledgerWorktreeBaseline` 不会运行。
  - 外部移动 ref：要么让 `finalizeRefs` 的 compare-and-swap 失败，要么在它之上继续发布。
  - 冲突：冲突永远不会覆盖用户的字节。
  - manifest：在它所担保的一切之后才写入。
- Reviewer subagent：改动由隔离的实现 worker 编写。主控负责审查；解决了与 PR #2402 的 rebase 冲突（被删掉的 `verifyGitFiles` 里带着那个 PR 的 `oid` 改动）；并删掉了没有调用方的 `beforeAppend` 钩子
- 人工审查：待进行
- 阻塞发现：无

## 残余风险

- 冲突记录只在内存里：重启后会忘掉，没有新事件的运行也不会重新检查。`ha doc status` 仍然能看到那个脏文件。
- 如果结算中途崩溃，停在中间 cut 的 prose 文件会被上报为冲突，而不是被覆盖；旧代码也是如此。
- worktree manifest 损坏或被手改时，每次打开都会走一次全量处理，直到它被重写。
- 外部提交改了 canonical 文件但没动 manifest 时，每次运行的 follower 不再察觉，只有 `readCertifiedGitFollower` 能抓到。
- 在线上台账上，部署后的第一次启动会从旧代码最后留下的 worktree manifest 位置开始，做一轮较大的处理。

## 关联材料

- 证据：fact F-7198CB74
- 前两批：PR #2407、PR #2408
- 审查：本 PR

---

## PR Gate Checklist / PR 门禁清单

- [x] Branch is based on latest `origin/main`. / 分支基于最新 `origin/main`。
- [x] PR body uses this full template structure. / PR 描述使用本模板完整结构。
- [x] PR body uses two complete language blocks: `# English` first, then `# 中文`. / PR 正文使用两块完整正文：`# English` 在上，`# 中文` 在下。
- [x] PR body passes `tools/check-pr-body-bilingual.mjs`. / PR 正文通过 `tools/check-pr-body-bilingual.mjs`。
- [x] If the PR touches a manifest-derived protected surface, Governance Declaration is filled with ADR/decision/task evidence or break-glass fields. / 若 PR 触碰 manifest 派生的 protected surface，Governance Declaration 已填写 ADR/decision/task 依据或 break-glass 字段。
- [x] No private harness files are included. / 不包含私有 harness 文件。
- [x] No ignored local agent entry files are included. / 不包含被忽略的本地 agent 入口文件。
- [x] No absolute local filesystem paths are included in this public PR body. / 本公开 PR 描述不包含本机绝对路径。
- [x] Public diff is limited to the stated task scope. / 公开 diff 限于声明的任务范围。
- [x] Private planning/evidence updates are recorded when applicable. / 适用时已记录私有计划 / 证据更新。
- [x] Version and publish impact are stated. / 已说明版本与发布影响。
- [x] Local verification commands are recorded honestly. / 已如实记录本地验证命令。
- [ ] CI results are linked or explained. / CI 结果已链接或说明。
- [x] Review evidence is recorded. / 已记录审查证据。
- [x] Open P0/P1/P2 findings are closed, deferred with owner, or explicitly blocked. / open P0/P1/P2 findings 已关闭、带 owner 延后，或明确阻塞。
- [x] Merge method and post-merge branch cleanup plan are clear. / 合并方式和合并后分支清理计划清楚。
- [x] No admin bypass is planned unless explicitly approved and recorded. / 除非明确批准并记录，否则不计划 admin bypass。
