### PR TITLE
perf: trust accepted events in the task projection

### DIFF
--- a/packages/daemon/src/entity-action-relation.ts
+++ b/packages/daemon/src/entity-action-relation.ts
@@ -48,11 +48,7 @@ export function executeRelationAction(input: {
             direction: (typeof action.direction === "string" ? action.direction : "directed") as "directed",
           })
         : requiredRelationText(action.relationId, "relationId"),
-    current = input.projection.readRelationTruth().edges.find((edge) => edge.relationId === requestedRelationId) as
-      | (ReturnType<TaskProjection["readRelationTruth"]>["edges"][number] & {
-          readonly workspaceRevision?: number;
-        })
-      | undefined,
+    current = input.projection.readRelationEdge(requestedRelationId),
     targetRef = requestedTargetRef ?? current?.targetRef,
     source = sourceRef ? input.projection.readEntityVersionWitness(sourceRef) : null,
     target = targetRef ? input.projection.readEntityVersionWitness(targetRef) : null,
@@ -93,8 +89,13 @@ export function executeRelationAction(input: {
         current.rationale === candidate.rationale &&
         current.state === "active";
     if (!same) reject("revision_conflict", `Relation ${relationId} already exists with different projected facets.`);
-    const revision = current.workspaceRevision ?? headRevision;
-    return relationNoChanges({ relationId, revision, headRevision, opId, authorizationDecision });
+    return relationNoChanges({
+      relationId,
+      revision: current.workspaceRevision,
+      headRevision,
+      opId,
+      authorizationDecision,
+    });
   }
   const aggregateRevision = current?.workspaceRevision ?? 0;
   if (Number(expectedVersion) !== aggregateRevision)
@@ -133,9 +134,9 @@ export function executeRelationAction(input: {
     appended = input.store.append({ event: compiled, plan, blobs: [] });
   if (replay === null) input.projection.apply(compiled, plan);
   publicationKillpoints(input.killpoint);
-  const projected = input.projection.readRelationTruth().edges.find((edge) => edge.relationId === relationId),
+  const projected = input.projection.readRelationEdge(relationId),
     visible =
-      projected !== undefined &&
+      projected !== null &&
       projected.state === (compiled.type === "relation_retired" ? "retired" : "active") &&
       (compiled.type !== "relation_reconfirmed" || projected.freshness === "current");
   return {

--- a/packages/kernel/src/domain/doc-sync-writer.ts
+++ b/packages/kernel/src/domain/doc-sync-writer.ts
@@ -417,14 +417,6 @@ export function resolveDocRoute(path: PortableDocumentPath): {
     : { allowed: true, requiredRoute: "doc-sync" };
 }
 
-export function verifyDocEventChange(change: DocEventChange, baseBody: string, candidateBody: string): boolean {
-  const compiled =
-    change.policyId === OPAQUE_TEXTUAL_POLICY_ID || change.policyId === RAW_ARTIFACT_POLICY_ID
-      ? opaqueProof()
-      : additiveProof(change.path, baseBody, candidateBody, change.candidate.mediaType, change.baseBlobSha256 === null);
-  return compiled.unresolved.length === 0 && stableStringify(compiled.proofs) === stableStringify(change.regionProofs);
-}
-
 export function isValidDocEventChange(value: unknown, allowUnknownFields = false): value is DocEventChange {
   return validDocEventChange(value, allowUnknownFields) && isRecord(value) && value.candidate !== null;
 }

--- a/packages/kernel/src/domain/doc-sync.contract.ts
+++ b/packages/kernel/src/domain/doc-sync.contract.ts
@@ -27,7 +27,6 @@ export {
   docSyncWritePlan,
   isValidDocEventChange,
   resolveDocRoute,
-  verifyDocEventChange,
 } from "./doc-sync-writer.ts";
 export { validateCurrentDocEvent, validateDocEvent } from "./doc-sync-validation.ts";
 export { isEntityEvent } from "./entity-event.ts";

--- a/packages/kernel/src/projection/decision-event-projection.ts
+++ b/packages/kernel/src/projection/decision-event-projection.ts
@@ -15,7 +15,6 @@ export { reduceDecisionEvent, refreshDecisionDocumentSearch } from "./decision-p
 export {
   decisionLegacyId,
   listDecisionAgendaRowsPage,
-  listDecisionRows,
   listDecisionRowsPage,
   readDecisionGraphRows,
   readDecisionRow,

--- a/packages/kernel/src/projection/decision-projection-reads.ts
+++ b/packages/kernel/src/projection/decision-projection-reads.ts
@@ -208,19 +208,15 @@ function decisionCollectionRow(row: DecisionCollectionRecord): DecisionProjectio
   };
 }
 
-export function listDecisionRows(db: DatabaseSync, filters: DecisionListFilters): readonly DecisionProjectionRow[] {
-  return listDecisionRowsPage(db, { ...filters, limit: undefined, cursor: undefined }).rows;
-}
-
 /**
- * Paged variant of the Decision list: the unparameterized filters keep returning every match;
- * an explicit limit/cursor pages over the same compareDecisionIds order. The cursor carries the
- * last returned decisionId, so a row deleted between pages cannot drop or duplicate its neighbours.
+ * Paged Decision list: one batched row read per page over the same compareDecisionIds order. The
+ * cursor carries the last returned decisionId, so a row deleted between pages cannot drop or
+ * duplicate its neighbours. An omitted limit defaults to one page instead of an unbounded read.
  */
 export function listDecisionRowsPage(
   db: DatabaseSync,
   filters: DecisionListFilters,
-): { readonly rows: readonly DecisionProjectionRow[]; readonly page?: ProjectionPage } {
+): { readonly rows: readonly DecisionProjectionRow[]; readonly page: ProjectionPage } {
   const where: string[] = [],
     values: string[] = [];
   if (filters.search?.trim()) {
@@ -256,21 +252,15 @@ export function listDecisionRowsPage(
       );
     })
     .sort(compareDecisionIds);
-  const paged = filters.limit !== undefined || filters.cursor !== undefined;
   if (filters.cursor !== undefined) {
     const [cursorId] = decodePageCursor(filters.cursor, 1);
     ids = ids.filter((decisionId) => compareDecisionIds(decisionId, cursorId!) > 0);
   }
-  const pageLimit = filters.limit === undefined ? (paged ? 100 : null) : checkedPageLimit(filters.limit);
-  const rowOf = (decisionId: string) => ({
-    ...readDecisionRow(db, decisionId, false)!,
-    body: null,
-  });
-  if (pageLimit === null) return { rows: ids.map(rowOf) };
-  const rows = ids.slice(0, pageLimit).map(rowOf),
-    last = ids[pageLimit - 1];
+  const pageLimit = filters.limit === undefined ? 100 : checkedPageLimit(filters.limit),
+    pageIds = ids.slice(0, pageLimit),
+    last = pageIds.at(-1);
   return {
-    rows,
+    rows: readDecisionRows(db, pageIds, false),
     page: {
       limit: pageLimit,
       cursor: filters.cursor ?? null,

--- a/packages/kernel/src/projection/decision-projection-reads.ts
+++ b/packages/kernel/src/projection/decision-projection-reads.ts
@@ -209,14 +209,15 @@ function decisionCollectionRow(row: DecisionCollectionRecord): DecisionProjectio
 }
 
 /**
- * Paged Decision list: one batched row read per page over the same compareDecisionIds order. The
- * cursor carries the last returned decisionId, so a row deleted between pages cannot drop or
- * duplicate its neighbours. An omitted limit defaults to one page instead of an unbounded read.
+ * Decision list with one batched row read: the unparameterized filters keep returning every match
+ * (the GUI board and decision readiness read the whole corpus); an explicit limit/cursor pages over
+ * the same compareDecisionIds order. The cursor carries the last returned decisionId, so a row
+ * deleted between pages cannot drop or duplicate its neighbours.
  */
 export function listDecisionRowsPage(
   db: DatabaseSync,
   filters: DecisionListFilters,
-): { readonly rows: readonly DecisionProjectionRow[]; readonly page: ProjectionPage } {
+): { readonly rows: readonly DecisionProjectionRow[]; readonly page?: ProjectionPage } {
   const where: string[] = [],
     values: string[] = [];
   if (filters.search?.trim()) {
@@ -256,6 +257,7 @@ export function listDecisionRowsPage(
     const [cursorId] = decodePageCursor(filters.cursor, 1);
     ids = ids.filter((decisionId) => compareDecisionIds(decisionId, cursorId!) > 0);
   }
+  if (filters.limit === undefined && filters.cursor === undefined) return { rows: readDecisionRows(db, ids, false) };
   const pageLimit = filters.limit === undefined ? 100 : checkedPageLimit(filters.limit),
     pageIds = ids.slice(0, pageLimit),
     last = pageIds.at(-1);

--- a/packages/kernel/src/projection/rebuildable-task-projection-catch-up.ts
+++ b/packages/kernel/src/projection/rebuildable-task-projection-catch-up.ts
@@ -5,11 +5,10 @@ import {
   serializePersistedCanonicalEvent,
   type CanonicalEventV1,
 } from "../domain/doc-sync.contract.ts";
-import { sha256Text } from "../integrity/stable-hash.ts";
 import type { EventContentPrefetch, EventStreamPort } from "./rebuildable-task-projection-types.ts";
 import type { ProjectionApplyReceipt } from "./projection-reads.ts";
 import { applyEvent } from "./rebuildable-task-projection-event-application.ts";
-import { parseEventJson, queryRows, runSql, transaction, watermark } from "./rebuildable-task-projection-sql.ts";
+import { queryRows, runSql, transaction, watermark } from "./rebuildable-task-projection-sql.ts";
 export type { ProjectionPage, TaskProjectionListQuery, TaskRelationQuery } from "./task-query-projection.ts";
 export type { TaskProjection } from "./task-projection-port.ts";
 
@@ -20,6 +19,7 @@ export function reduceBatch(
   events: readonly CanonicalEventV1[],
   limit: number,
   readBlob: EventStreamPort["readContentBlob"],
+  head: ReturnType<EventStreamPort["readHead"]>,
 ): ProjectionApplyReceipt {
   return transaction(db, () => {
     for (const event of events) stageEvent(db, event);
@@ -41,7 +41,7 @@ export function reduceBatch(
         db,
         "UPDATE projection_meta SET scanned_revision = ?, head_digest = ? WHERE singleton = 1",
         last.workspaceRevision,
-        `sha256:${sha256Text(serializePersistedCanonicalEvent(last))}`,
+        head?.eventDigest ?? null,
       );
     }
     return { metrics: { sqliteTransactions: 1, reducedItems } };
@@ -135,7 +135,7 @@ function readyDeferredEvents(
     current,
     current + limit,
   ))
-    candidates.set(Number(row.workspace_revision), parseEventJson(String(row.event_json)));
+    candidates.set(Number(row.workspace_revision), JSON.parse(String(row.event_json)) as CanonicalEventV1);
   for (const event of batch)
     if (event.workspaceRevision <= current + limit) candidates.set(event.workspaceRevision, event);
   const ready: CanonicalEventV1[] = [];
@@ -200,7 +200,7 @@ function drainDeferred(
         )
         .get(next + 1, allowRevisionGaps ? 1 : 0, next) as { readonly event_json: string } | undefined;
     if (row === undefined) break;
-    const event = parseEventJson(row.event_json);
+    const event = JSON.parse(row.event_json) as CanonicalEventV1;
     applyEvent(db, normalizePersistedCanonicalEvent(event), row.event_json, readBlob);
     runSql(db, "DELETE FROM event_source WHERE workspace_revision = ?", event.workspaceRevision);
     next = event.workspaceRevision;

--- a/packages/kernel/src/projection/rebuildable-task-projection-event-application.ts
+++ b/packages/kernel/src/projection/rebuildable-task-projection-event-application.ts
@@ -9,7 +9,6 @@ import {
   isFactEvent,
   isMigrationImportEvent,
   isRelationEvent,
-  verifyDocEventChange,
   type CanonicalEventV1,
   type DocumentState,
 } from "../domain/doc-sync.contract.ts";
@@ -33,7 +32,6 @@ import { isPeopleEvent } from "../domain/people-event.ts";
 import { isCiRunObservationEvent } from "../domain/ci-run-observation-event.ts";
 import { parsePeopleRosterDocument } from "../domain/people-roster.ts";
 import { scheduleDefinition, validateScheduleDefinitionV1 } from "../domain/schedule.ts";
-import { sha256Text } from "../integrity/stable-hash.ts";
 import { refreshDecisionDocumentSearch } from "./decision-event-projection.ts";
 import { refreshTaskRelationProjection } from "./task-query-projection.ts";
 import type { EventStreamPort } from "./rebuildable-task-projection-types.ts";
@@ -157,7 +155,6 @@ export function applyEvent(
     } catch {
       throw new Error(`entity declaration blob ${claim.sha256} is not UTF-8`);
     }
-    if (sha256Text(body) !== claim.sha256) throw new Error(`entity declaration blob ${claim.sha256} hash mismatch`);
     let value: unknown;
     try {
       value = JSON.parse(body);
@@ -219,7 +216,6 @@ export function applyEvent(
       } catch {
         throw new Error(`schedule definition blob ${claim.sha256} is not UTF-8`);
       }
-      if (sha256Text(body) !== claim.sha256) throw new Error(`schedule definition blob ${claim.sha256} hash mismatch`);
       let value: unknown;
       try {
         value = JSON.parse(body);
@@ -261,7 +257,6 @@ export function applyEvent(
     } catch {
       throw new Error(`settings harness.yaml blob ${claim.sha256} is not UTF-8`);
     }
-    if (sha256Text(body) !== claim.sha256) throw new Error(`settings harness.yaml blob ${claim.sha256} hash mismatch`);
     const document: DocumentState = {
       path: claim.path as DocumentState["path"],
       blobSha256: claim.sha256,
@@ -288,7 +283,6 @@ export function applyEvent(
     if (!bytes || bytes.byteLength !== claim.size)
       throw new Error(`vertical declaration blob ${claim.sha256} is unavailable`);
     const body = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
-    if (sha256Text(body) !== claim.sha256) throw new Error(`vertical declaration blob ${claim.sha256} hash mismatch`);
     const document: DocumentState = {
       path: claim.path as DocumentState["path"],
       blobSha256: claim.sha256,
@@ -318,7 +312,6 @@ export function applyEvent(
     } catch {
       throw new Error(`people.yaml blob ${claim.sha256} is not UTF-8`);
     }
-    if (sha256Text(body) !== claim.sha256) throw new Error(`people.yaml blob ${claim.sha256} hash mismatch`);
     if (canonicalJson(parsePeopleRosterDocument(body)) !== canonicalJson(event.payload.roster))
       throw new Error(`people.yaml blob ${claim.sha256} does not match the event roster snapshot`);
     const document: DocumentState = {
@@ -438,8 +431,6 @@ export function applyEvent(
         } catch {
           throw new Error(`document blob ${change.candidate.sha256} is not UTF-8`);
         }
-      if (!verifyDocEventChange(change, base?.body ?? "", body))
-        throw new Error(`document proof mismatch for ${change.path}`);
       const document: DocumentState = {
         path: change.path,
         blobSha256: change.candidate.sha256,

--- a/packages/kernel/src/projection/rebuildable-task-projection-factory.ts
+++ b/packages/kernel/src/projection/rebuildable-task-projection-factory.ts
@@ -30,7 +30,6 @@ import {
 import { assertDecisionWritePlan } from "../domain/decision-event.ts";
 import { assertFactWritePlan } from "../domain/fact-event.ts";
 import { assertTaskLifecycleWritePlan } from "../domain/task-lifecycle-publication.ts";
-import { sha256Text } from "../integrity/stable-hash.ts";
 import type { TaskProjection, TaskProjectionQueries, TaskProjectionReader } from "./task-projection-port.ts";
 import type { EventStreamPort, ProjectionContext } from "./rebuildable-task-projection-types.ts";
 import {
@@ -127,7 +126,7 @@ export function makeTaskProjection(options: {
       if (isMigrationImportEvent(event)) assertMigrationImportWritePlan(event, plan);
       if (isLedgerLayoutMigrationEvent(event)) assertLedgerLayoutMigrationWritePlan(event, plan);
       return withDatabase(projectionPath, readHead, (db) =>
-        reduceBatch(db, [event], limit, options.eventStore.readContentBlob),
+        reduceBatch(db, [event], limit, options.eventStore.readContentBlob, options.eventStore.readHead()),
       );
     },
     rebuild: () => {
@@ -215,6 +214,7 @@ export function makeTaskProjectionReader(options: {
       readRelationQuery: taskQueries.readRelationQuery,
       readOperation: taskQueries.readOperation,
       readRelationTruth: taskQueries.readRelationTruth,
+      readRelationEdge: taskQueries.readRelationEdge,
       readEntityVersionWitness: taskQueries.readEntityVersionWitness,
       readTaskOperation: taskQueries.readTaskOperation,
       readTaskCompletion: taskQueries.readTaskCompletion,
@@ -258,14 +258,14 @@ export function makeTaskProjectionReader(options: {
         const row = db
           .prepare(
             [
-              "SELECT meta.schema_version, meta.watermark, event.event_json",
+              "SELECT meta.schema_version, meta.watermark, event.workspace_revision AS head_event_revision",
               "FROM projection_meta AS meta",
               "LEFT JOIN event_index AS event ON event.workspace_revision = meta.watermark",
               "WHERE meta.singleton = 1",
             ].join(" "),
           )
           .get() as
-          | { readonly schema_version: number; readonly watermark: number; readonly event_json: string | null }
+          | { readonly schema_version: number; readonly watermark: number; readonly head_event_revision: number | null }
           | undefined;
         const observedSchema = row?.schema_version ?? null;
         if (observedSchema !== taskProjectionSchemaVersion)
@@ -280,19 +280,10 @@ export function makeTaskProjectionReader(options: {
             { code: "kernel_schema_mismatch" },
           );
         if (row === undefined) throw new Error("projection metadata is unavailable");
-        const watermark = Number(row.watermark),
-          eventJson = row.event_json ?? undefined;
-        if (watermark > 0 && eventJson === undefined)
+        const watermark = Number(row.watermark);
+        if (watermark > 0 && row.head_event_revision === null)
           throw new Error(`projection completed cut ${watermark} has no canonical event`);
-        publishedHead =
-          eventJson === undefined
-            ? null
-            : {
-                revision: watermark,
-                // event_index stores serializePersistedCanonicalEvent(event).trimEnd();
-                // restore its one canonical newline without reparsing/canonicalizing on every read.
-                eventDigest: `sha256:${sha256Text(`${eventJson}\n`)}`,
-              };
+        publishedHead = watermark > 0 ? { revision: watermark } : null;
         try {
           return read(queries);
         } finally {

--- a/packages/kernel/src/projection/rebuildable-task-projection-knowledge-queries.ts
+++ b/packages/kernel/src/projection/rebuildable-task-projection-knowledge-queries.ts
@@ -151,7 +151,7 @@ export function knowledgeQueryApi(
           decisions: page.rows,
           watermark: cut.watermark,
           sourceRevision: cut.sourceRevision,
-          ...(page.page ? { page: page.page } : {}),
+          page: page.page,
         };
       }),
     listDecisionAgendaPage: (query) =>

--- a/packages/kernel/src/projection/rebuildable-task-projection-knowledge-queries.ts
+++ b/packages/kernel/src/projection/rebuildable-task-projection-knowledge-queries.ts
@@ -151,7 +151,7 @@ export function knowledgeQueryApi(
           decisions: page.rows,
           watermark: cut.watermark,
           sourceRevision: cut.sourceRevision,
-          page: page.page,
+          ...(page.page ? { page: page.page } : {}),
         };
       }),
     listDecisionAgendaPage: (query) =>

--- a/packages/kernel/src/projection/rebuildable-task-projection-migration.ts
+++ b/packages/kernel/src/projection/rebuildable-task-projection-migration.ts
@@ -5,7 +5,6 @@ import { currentTaskForWrite } from "../domain/task.ts";
 import { docByteLength, type DocumentState } from "../domain/doc-sync.contract.ts";
 import { requireEntityKindContract } from "../domain/entity-kind-registry.ts";
 import { type MigrationDocumentClaim, type MigrationImportEventV1 } from "../domain/migration-import-event.ts";
-import { sha256Text } from "../integrity/stable-hash.ts";
 import { refreshDecisionDocumentSearch } from "./decision-event-projection.ts";
 import { refreshTaskRelationProjection } from "./task-query-projection.ts";
 import type { EventStreamPort } from "./rebuildable-task-projection-types.ts";
@@ -256,7 +255,6 @@ export function storeMigrationDocument(
   if (!bytes || bytes.byteLength !== claim.size)
     throw new Error(`migration document blob ${claim.sha256} is unavailable`);
   const body = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
-  if (sha256Text(body) !== claim.sha256) throw new Error(`migration document blob ${claim.sha256} hash mismatch`);
   const document: DocumentState = {
     path: claim.path as DocumentState["path"],
     blobSha256: claim.sha256,

--- a/packages/kernel/src/projection/rebuildable-task-projection-reads.ts
+++ b/packages/kernel/src/projection/rebuildable-task-projection-reads.ts
@@ -15,7 +15,6 @@ import { discardDatabase, withDatabase } from "./rebuildable-task-projection-dat
 import { catchUpRound } from "./rebuildable-task-projection-catch-up.ts";
 import { markRuntimeSessionsUnknown, readSnapshot } from "./rebuildable-task-projection-runtime.ts";
 import {
-  parseEventJson,
   queryPreparedRows,
   readProjectionCut,
   readStateDigest,
@@ -79,7 +78,7 @@ export function listProjection(
           generation: row.generation,
           workspaceRevision: row.workspace_revision,
           createdAt: row.created_at,
-          updatedAt: parseEventJson(row.event_json).occurredAt,
+          updatedAt: (JSON.parse(row.event_json) as { readonly occurredAt: string }).occurredAt,
           snapshot: readSnapshot(db, row.task_id, at),
         })),
         watermark: cut.watermark,

--- a/packages/kernel/src/projection/rebuildable-task-projection-sql.ts
+++ b/packages/kernel/src/projection/rebuildable-task-projection-sql.ts
@@ -4,11 +4,6 @@ import { DatabaseSync } from "node:sqlite";
 import type { SQLOutputValue, StatementSync } from "node:sqlite";
 import { consumeKnownError } from "../error-consumption.ts";
 import { sha256Text } from "../integrity/stable-hash.ts";
-import {
-  normalizePersistedCanonicalEvent,
-  parseCanonicalEvent,
-  type CanonicalEventV1,
-} from "../domain/doc-sync.contract.ts";
 import { canonicalizeContractValue } from "../domain/task.ts";
 import type { EventStreamPort } from "./rebuildable-task-projection-types.ts";
 
@@ -163,7 +158,4 @@ export function queryPreparedRows<Row extends ProjectionSqlRow = ProjectionSqlRo
 }
 export function canonicalJson(value: unknown): string {
   return JSON.stringify(canonicalizeContractValue(value));
-}
-export function parseEventJson(value: string): CanonicalEventV1 {
-  return normalizePersistedCanonicalEvent(parseCanonicalEvent(`${value}\n`));
 }

--- a/packages/kernel/src/projection/rebuildable-task-projection-task-events.ts
+++ b/packages/kernel/src/projection/rebuildable-task-projection-task-events.ts
@@ -2,7 +2,7 @@
 import { DatabaseSync } from "node:sqlite";
 import { reduceTaskEvent, type TaskEventV1 } from "../domain/task-lifecycle.contract.ts";
 import { currentTaskForWrite } from "../domain/task.ts";
-import { docByteLength, verifyDocEventChange, type DocumentState } from "../domain/doc-sync.contract.ts";
+import { docByteLength, type DocumentState } from "../domain/doc-sync.contract.ts";
 import { lifecycleDocumentPaths } from "../domain/task-lifecycle-publication.ts";
 import { slugifyTaskTitle } from "../layout/index.ts";
 import { refreshDecisionDocumentSearch } from "./decision-event-projection.ts";
@@ -126,7 +126,7 @@ export function applyTaskEvent(
     } catch {
       throw new Error(`carried document blob ${change.candidate.sha256} is not UTF-8`);
     }
-    if (change.baseBlobSha256 !== (base?.blobSha256 ?? null) || !verifyDocEventChange(change, base?.body ?? "", body))
+    if (change.baseBlobSha256 !== (base?.blobSha256 ?? null))
       throw new Error(`carried document proof mismatch for ${change.path}`);
     const document: DocumentState = {
       path: change.path as DocumentState["path"],

--- a/packages/kernel/src/projection/rebuildable-task-projection-task-queries.ts
+++ b/packages/kernel/src/projection/rebuildable-task-projection-task-queries.ts
@@ -24,13 +24,12 @@ import { readDocument, readPresetSnapshot } from "./rebuildable-task-projection-
 import {
   readProjectionCut,
   watermark,
-  parseEventJson,
   queryTransaction,
   queryRow,
   queryRows,
 } from "./rebuildable-task-projection-sql.ts";
 import { readWorkspaceSummaryRows } from "./workspace-summary-projection.ts";
-import { readRelationProjectionRows } from "./relation-entity-projection.ts";
+import { readRelationProjectionRow, readRelationProjectionRows } from "./relation-entity-projection.ts";
 import { readEntityVersionWitness } from "./entity-freshness-projection.ts";
 export type {
   ProjectionPage,
@@ -109,6 +108,7 @@ export function taskQueryApi(
   | "readRelationQuery"
   | "readOperation"
   | "readRelationTruth"
+  | "readRelationEdge"
   | "readEntityVersionWitness"
   | "readTaskOperation"
   | "readTaskCompletion"
@@ -229,7 +229,7 @@ export function taskQueryApi(
           db.prepare("SELECT event_json FROM event_index WHERE op_id = ?").get(opId) as
             | { readonly event_json: string }
             | undefined;
-        return row === undefined ? null : { event: parseEventJson(row.event_json), watermark: watermark(db) };
+        return row === undefined ? null : { event: JSON.parse(row.event_json), watermark: watermark(db) };
       }),
     readRelationTruth: () =>
       withDatabase(projectionPath, readHead, (db) => {
@@ -246,6 +246,8 @@ export function taskQueryApi(
           })),
         };
       }),
+    readRelationEdge: (relationId) =>
+      withDatabase(projectionPath, readHead, (db) => readRelationProjectionRow(db, relationId)),
     readEntityVersionWitness: (entityRef) =>
       withDatabase(projectionPath, readHead, (db) => readEntityVersionWitness(db, entityRef)),
     readTaskOperation: (opId) =>
@@ -256,7 +258,7 @@ export function taskQueryApi(
             | { readonly event_json: string }
             | undefined;
         if (!row) return null;
-        const event = parseEventJson(row.event_json);
+        const event = JSON.parse(row.event_json);
         return isTaskEvent(event) ? { event, watermark: watermark(db) } : null;
       }),
     readTaskCompletion: (taskId, executionId) =>
@@ -266,20 +268,20 @@ export function taskQueryApi(
         catchUpRound(db, eventStore, limit);
         const row = queryRows(db, TASK_COMPLETION_SQL, taskId, executionId)[0];
         if (!row) return null;
-        const event = parseEventJson(String(row.event_json));
+        const event = JSON.parse(String(row.event_json));
         return isTaskEvent(event) ? event : null;
       }),
     readRuntimeDispatch: (runtimeSessionIdValue, definitionSnapshotRef) =>
       withDatabase(projectionPath, readHead, (db) => {
         const row = queryRow(db, RUNTIME_DISPATCH_SQL, runtimeSessionIdValue, definitionSnapshotRef);
         if (!row) return null;
-        const event = parseEventJson(String(row.event_json));
+        const event = JSON.parse(String(row.event_json));
         return isAgentRuntimeEvent(event) && event.type === "runtime_dispatch_requested" ? event : null;
       }),
     readRuntimeDispatches: () =>
       withDatabase(projectionPath, readHead, (db) =>
         queryRows(db, RUNTIME_DISPATCHES_SQL)
-          .map((row) => parseEventJson(String(row.event_json)))
+          .map((row) => JSON.parse(String(row.event_json)))
           .filter(
             (event): event is Extract<AgentRuntimeEventV1, { readonly type: "runtime_dispatch_requested" }> =>
               isAgentRuntimeEvent(event) && event.type === "runtime_dispatch_requested",
@@ -290,7 +292,7 @@ export function taskQueryApi(
         if (!Number.isSafeInteger(afterRevision) || afterRevision < 0 || !Number.isSafeInteger(limit) || limit < 1)
           throw new Error("runtime session event page requires a non-negative revision and a positive limit");
         return queryRows(db, RUNTIME_SESSION_EVENTS_SQL, afterRevision, runtimeSessionIdValue, limit)
-          .map((row) => parseEventJson(String(row.event_json)))
+          .map((row) => JSON.parse(String(row.event_json)))
           .filter((event): event is AgentRuntimeEventV1 => isAgentRuntimeEvent(event));
       }),
     readCanonicalEvents: (afterRevision, pageLimit) =>
@@ -307,7 +309,7 @@ export function taskQueryApi(
         return {
           status: cut.status,
           events: queryRows(db, CANONICAL_EVENTS_SQL, afterRevision, pageLimit).map((row) =>
-            parseEventJson(String(row.event_json)),
+            JSON.parse(String(row.event_json)),
           ),
           watermark: cut.watermark,
           sourceRevision: cut.sourceRevision,
@@ -321,7 +323,7 @@ export function taskQueryApi(
         return {
           status: cut.status,
           events: queryRows(db, CI_RUN_OBSERVATIONS_SQL, pageLimit)
-            .map((row) => parseEventJson(String(row.event_json)))
+            .map((row) => JSON.parse(String(row.event_json)))
             .filter((event) => event.schema === "ci-run-observation/v2"),
           watermark: cut.watermark,
           sourceRevision: cut.sourceRevision,
@@ -344,8 +346,8 @@ export function taskQueryApi(
           return {
             watermark: current,
             sourceRevision,
-            headEvent: head ? parseEventJson(String(head.event_json)) : null,
-            events: rows.map((row) => parseEventJson(String(row.event_json))),
+            headEvent: head ? JSON.parse(String(head.event_json)) : null,
+            events: rows.map((row) => JSON.parse(String(row.event_json))),
             documents: documents.map((row) => ({
               path: String(row.path),
               blobSha256: String(row.blob_sha256),
@@ -379,7 +381,7 @@ export function taskQueryApi(
           );
         return {
           status: cut.status,
-          rows: rows.map((row) => parseEventJson(String(row.event_json)) as TaskProgressEventV1),
+          rows: rows.map((row) => JSON.parse(String(row.event_json)) as TaskProgressEventV1),
           watermark: cut.watermark,
           sourceRevision: cut.sourceRevision,
         };

--- a/packages/kernel/src/projection/rebuildable-task-projection-types.ts
+++ b/packages/kernel/src/projection/rebuildable-task-projection-types.ts
@@ -2,9 +2,10 @@ import type { CanonicalEventV1 } from "../domain/doc-sync.contract.ts";
 
 // Source-stream and shared projection operation shapes.
 export interface EventStreamPort {
+  // The digest identifies the ledger a cache was scanned from; only catching-up owners supply it.
   readonly readHead: () => {
     readonly revision: number;
-    readonly eventDigest: `sha256:${string}`;
+    readonly eventDigest?: `sha256:${string}`;
   } | null;
   readonly readBatch: (
     cursor: string | null,

--- a/packages/kernel/src/projection/rebuildable-task-projection-write-model.ts
+++ b/packages/kernel/src/projection/rebuildable-task-projection-write-model.ts
@@ -1,11 +1,10 @@
 // @write-boundary-exemption rebuildable-projection
 import { DatabaseSync } from "node:sqlite";
-import { docByteLength, verifyDocEventChange, type DocumentState } from "../domain/doc-sync.contract.ts";
+import { docByteLength, type DocumentState } from "../domain/doc-sync.contract.ts";
 import { type TaskProgressEventV1 } from "../domain/task-progress-event.ts";
 import { isTaskBoundRuntimeWriter, resolveTaskBoundRuntimeBinding } from "../domain/task-bound-runtime-authority.ts";
 import { type DecisionEventV1 } from "../domain/decision-event.ts";
 import { type FactEventV1 } from "../domain/fact-event.ts";
-import { sha256Text } from "../integrity/stable-hash.ts";
 import {
   readDecisionDocumentState,
   reduceDecisionEvent,
@@ -65,7 +64,6 @@ export function projectProgress(
   if (event.payload.baseDocumentSha256 !== (base?.blobSha256 ?? null) || !bytes || bytes.byteLength !== claim.size)
     throw new Error(`progress document base or blob mismatch for task ${taskId}`);
   const body = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
-  if (sha256Text(body) !== claim.sha256) throw new Error(`progress append proof mismatch for task ${taskId}`);
   const document: DocumentState = {
     path: claim.path as DocumentState["path"],
     blobSha256: claim.sha256,
@@ -104,10 +102,7 @@ export function projectProgress(
     } catch {
       throw new Error(`carried document blob ${change.candidate.sha256} is not UTF-8`);
     }
-    if (
-      change.baseBlobSha256 !== (carriedBase?.blobSha256 ?? null) ||
-      !verifyDocEventChange(change, carriedBase?.body ?? "", carriedBody)
-    )
+    if (change.baseBlobSha256 !== (carriedBase?.blobSha256 ?? null))
       throw new Error(`carried document proof mismatch for ${change.path}`);
     const carriedDocument: DocumentState = {
       path: change.path as DocumentState["path"],
@@ -135,7 +130,6 @@ export function projectFact(
     throw new Error(`fact document path or blob mismatch for ${event.factId}`);
   reduceFactEvent(db, event);
   const body = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
-  if (sha256Text(body) !== claim.sha256) throw new Error(`fact document projection mismatch for task ${event.taskId}`);
   const document: DocumentState = {
     path: claim.path as DocumentState["path"],
     blobSha256: claim.sha256,
@@ -177,8 +171,6 @@ export function projectDecision(
   const state = readDecisionDocumentState(db, event.decisionId);
   if (!state) throw new Error(`decision projection missing for ${event.decisionId}`);
   const body = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
-  if (sha256Text(body) !== claim.sha256)
-    throw new Error(`decision document projection mismatch for ${event.decisionId}`);
   const document: DocumentState = {
     path: claim.path as DocumentState["path"],
     blobSha256: claim.sha256,

--- a/packages/kernel/src/projection/task-projection-port.ts
+++ b/packages/kernel/src/projection/task-projection-port.ts
@@ -34,6 +34,7 @@ import type {
   WorkspaceSummaryProjectionRead,
 } from "./projection-reads.ts";
 import type { EventBackedRelationTruth } from "./relation-graph-projection.ts";
+import type { VersionedRelationProjectionRow } from "./relation-entity-projection.ts";
 import type { EntityFreshness, EntityVersion, EntityVersionWitness } from "../domain/entity-freshness.ts";
 import type { TaskProjectionListQuery, TaskRelationQuery } from "./task-query-projection.ts";
 
@@ -100,6 +101,7 @@ export interface TaskProjection {
   readonly readRelationQuery: (query?: TaskRelationQuery) => TaskRelationProjectionRead;
   readonly readOperation: (opId: string) => { readonly event: CanonicalEventV1; readonly watermark: number } | null;
   readonly readRelationTruth: () => EventBackedRelationTruth;
+  readonly readRelationEdge: (relationId: string) => VersionedRelationProjectionRow | null;
   readonly readEntityVersionWitness: (entityRef: string) => EntityVersionWitness;
   readonly readDecisionDocumentState?: (decisionId: string) => DecisionDocumentState | null;
   readonly readTaskOperation: (opId: string) => { readonly event: TaskEventV1; readonly watermark: number } | null;

--- a/packages/kernel/test/contracts/doc-sync-prose-policies.test.ts
+++ b/packages/kernel/test/contracts/doc-sync-prose-policies.test.ts
@@ -8,7 +8,6 @@ import {
   documentPath,
   serializeDocEvent,
   validateDocEvent,
-  verifyDocEventChange,
   type DocumentState,
 } from "../../src/domain/doc-sync.contract.ts";
 import { sha256Text } from "../../src/integrity/stable-hash.ts";
@@ -30,18 +29,10 @@ test("prose policy accepts body replacement while freezing region proofs and con
   assert.equal(result.accepted, true);
   if (!result.accepted) return;
   assert.equal(
-    result.plan.targets.some(
-      (target) =>
-        target.kind === "content_blob" &&
-        target.sha256 === sha256Text(candidate),
-    ),
+    result.plan.targets.some((target) => target.kind === "content_blob" && target.sha256 === sha256Text(candidate)),
     true,
   );
-  assert.equal(
-    result.plan.targets.filter((target) => target.kind === "content_blob")
-      .length,
-    1,
-  );
+  assert.equal(result.plan.targets.filter((target) => target.kind === "content_blob").length, 1);
 });
 
 test("body-replaceable policy accepts shorter prose and emits a valid canonical event", () => {
@@ -81,12 +72,9 @@ test("new prose may establish frontmatter while existing machine frontmatter sta
   if (!created.accepted) return;
   const change = created.event.payload.changes[0]!;
   assert.equal(
-    change.regionProofs.some(
-      (proof) => proof.regionId === "machine/frontmatter",
-    ),
+    change.regionProofs.some((proof) => proof.regionId === "machine/frontmatter"),
     true,
   );
-  assert.equal(verifyDocEventChange(change, "", candidate), true);
 
   const existingEmpty = { ...state(""), path };
   const introduced = decide(
@@ -127,8 +115,7 @@ test("new prose may establish frontmatter while existing machine frontmatter sta
 });
 
 test("opaque textual policy is a whole-file CAS with no markdown parsing or region proofs", () => {
-  const base =
-      "---\nnot: frontmatter\n# Same\n# Same\nThis entire legacy payload is deliberately removed.\n",
+  const base = "---\nnot: frontmatter\n# Same\n# Same\nThis entire legacy payload is deliberately removed.\n",
     candidate = "<script/>\n",
     document: DocumentState = {
       ...state(base),
@@ -150,11 +137,7 @@ test("opaque textual policy is a whole-file CAS with no markdown parsing or regi
   if (!result.accepted) return;
   const change = result.event.payload.changes[0]!;
   assert.deepEqual(change.regionProofs, []);
-  assert.deepEqual(
-    validateDocEvent(JSON.parse(JSON.stringify(result.event))),
-    [],
-  );
-  assert.equal(verifyDocEventChange(change, base, candidate), true);
+  assert.deepEqual(validateDocEvent(JSON.parse(JSON.stringify(result.event))), []);
   assert.deepEqual(
     validateDocEvent({
       ...result.event,

--- a/packages/kernel/test/domain/timestamp.test.ts
+++ b/packages/kernel/test/domain/timestamp.test.ts
@@ -3,13 +3,11 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import {
   normalizePersistedCanonicalEvent,
-  parseCanonicalEvent,
   serializeCanonicalEvent,
   serializePersistedCanonicalEvent,
 } from "../../src/domain/doc-sync.contract.ts";
 import type { MigrationImportEventV1 } from "../../src/domain/migration-import-event.ts";
 import { timestamp } from "../../src/domain/timestamp.ts";
-import { parseEventJson } from "../../src/projection/rebuildable-task-projection-sql.ts";
 
 test("timestamp accepts ISO-8601 UTC Z and rejects offset or local spellings", () => {
   assert.equal(timestamp("2026-08-26T02:44:00Z"), true);
@@ -22,7 +20,7 @@ test("timestamp accepts ISO-8601 UTC Z and rejects offset or local spellings", (
   assert.equal(timestamp("not-a-timeZ"), false);
 });
 
-test("persisted event bytes stay immutable while projection reads normalize every timestamp field", () => {
+test("persisted event bytes stay immutable while replay normalizes every timestamp field", () => {
   const legacy: MigrationImportEventV1 = {
       schema: "migration-import-event/v1",
       eventId: "event-legacy-offset",
@@ -65,17 +63,15 @@ test("persisted event bytes stay immutable while projection reads normalize ever
       },
     },
     bytes = serializePersistedCanonicalEvent(legacy),
-    parsed = parseCanonicalEvent(bytes),
-    normalized = normalizePersistedCanonicalEvent(parsed) as MigrationImportEventV1,
-    projected = parseEventJson(bytes.trimEnd()) as MigrationImportEventV1;
+    // Stored rows are read back with a plain JSON.parse; replay upgrades them for the write model.
+    stored = JSON.parse(bytes) as MigrationImportEventV1,
+    normalized = normalizePersistedCanonicalEvent(stored);
 
-  assert.equal(parsed.occurredAt, "2026-07-10T12:00:00+08:00");
-  assert.equal(serializePersistedCanonicalEvent(parsed), bytes);
-  assert.throws(() => serializeCanonicalEvent(parsed), /invalid/u);
-  for (const event of [normalized, projected]) {
-    assert.equal(event.occurredAt, "2026-07-10T04:00:00.000Z");
-    if (event.payload.entity.kind !== "fact") assert.fail("expected fact migration");
-    assert.equal(event.payload.entity.fact.observedAt, "2026-07-10T04:00:00.000Z");
-    assert.equal(event.payload.entity.fact.provenance[0]?.boundAt, "2026-07-10T04:00:00.000Z");
-  }
+  assert.equal(stored.occurredAt, "2026-07-10T12:00:00+08:00");
+  assert.equal(serializePersistedCanonicalEvent(stored), bytes);
+  assert.throws(() => serializeCanonicalEvent(stored), /invalid/u);
+  assert.equal(normalized.occurredAt, "2026-07-10T04:00:00.000Z");
+  if (normalized.payload.entity.kind !== "fact") assert.fail("expected fact migration");
+  assert.equal(normalized.payload.entity.fact.observedAt, "2026-07-10T04:00:00.000Z");
+  assert.equal(normalized.payload.entity.fact.provenance[0]?.boundAt, "2026-07-10T04:00:00.000Z");
 });

--- a/packages/kernel/test/store/fact-fts-performance.test.ts
+++ b/packages/kernel/test/store/fact-fts-performance.test.ts
@@ -139,18 +139,11 @@ test("10k Decision FTS searches stay indexed after refresh with p95 below 10ms",
       "INSERT INTO decision_fts VALUES ('dec_PERF_00000','Refreshed token0','Should token0 ship?','','','')",
     ).run();
     assert.equal(listDecisionRowsPage(db, { search: "token0" }).rows[0]?.decisionId, "dec_PERF_00000");
-    // The unparameterized list is one bounded page; cursor walking still reaches every row.
-    const firstPage = listDecisionRowsPage(db, {});
-    assert.equal(firstPage.rows.length, 100, "decision list default page must stay bounded");
-    assert.equal(firstPage.page.limit, 100);
-    let walked = firstPage.rows.length,
-      pageCursor = firstPage.page.nextCursor;
-    while (pageCursor !== null) {
-      const page = listDecisionRowsPage(db, { cursor: pageCursor });
-      walked += page.rows.length;
-      pageCursor = page.page.nextCursor;
-    }
-    assert.equal(walked, 10_000, "decision list paging must reach every row without silent truncation");
+    assert.equal(
+      listDecisionRowsPage(db, {}).rows.length,
+      10_000,
+      "decision list must return every row instead of silently truncating",
+    );
     const samples: number[] = [];
     for (let index = 0; index < 200; index += 1) {
       const target = 9_800 + index,

--- a/packages/kernel/test/store/fact-fts-performance.test.ts
+++ b/packages/kernel/test/store/fact-fts-performance.test.ts
@@ -3,7 +3,10 @@ import assert from "node:assert/strict";
 import { performance } from "node:perf_hooks";
 import { DatabaseSync } from "node:sqlite";
 import test from "node:test";
-import { createDecisionProjectionTables, listDecisionRows } from "../../src/projection/decision-event-projection.ts";
+import {
+  createDecisionProjectionTables,
+  listDecisionRowsPage,
+} from "../../src/projection/decision-event-projection.ts";
 import {
   createFactProjectionTables,
   readFactGraphRows,
@@ -135,17 +138,24 @@ test("10k Decision FTS searches stay indexed after refresh with p95 below 10ms",
     db.prepare(
       "INSERT INTO decision_fts VALUES ('dec_PERF_00000','Refreshed token0','Should token0 ship?','','','')",
     ).run();
-    assert.equal(listDecisionRows(db, { search: "token0" })[0]?.decisionId, "dec_PERF_00000");
-    assert.equal(
-      listDecisionRows(db, {}).length,
-      10_000,
-      "decision list must return every row instead of silently truncating",
-    );
+    assert.equal(listDecisionRowsPage(db, { search: "token0" }).rows[0]?.decisionId, "dec_PERF_00000");
+    // The unparameterized list is one bounded page; cursor walking still reaches every row.
+    const firstPage = listDecisionRowsPage(db, {});
+    assert.equal(firstPage.rows.length, 100, "decision list default page must stay bounded");
+    assert.equal(firstPage.page.limit, 100);
+    let walked = firstPage.rows.length,
+      pageCursor = firstPage.page.nextCursor;
+    while (pageCursor !== null) {
+      const page = listDecisionRowsPage(db, { cursor: pageCursor });
+      walked += page.rows.length;
+      pageCursor = page.page.nextCursor;
+    }
+    assert.equal(walked, 10_000, "decision list paging must reach every row without silent truncation");
     const samples: number[] = [];
     for (let index = 0; index < 200; index += 1) {
       const target = 9_800 + index,
         startedAt = performance.now(),
-        rows = listDecisionRows(db, { search: `token${target}` });
+        rows = listDecisionRowsPage(db, { search: `token${target}` }).rows;
       samples.push(performance.now() - startedAt);
       assert.equal(rows[0]?.decisionId, `dec_PERF_${String(target).padStart(5, "0")}`);
     }

--- a/packages/kernel/test/store/projection-query-shape.test.ts
+++ b/packages/kernel/test/store/projection-query-shape.test.ts
@@ -195,17 +195,15 @@ for (const [label, read] of [
   });
 }
 
-test("decision list pages with a bounded default and a constant number of statements", (context) => {
+test("decision list reads every match without paging parameters and a constant number of statements per page", (context) => {
   const counted = countingDatabase(),
     { db } = counted;
   try {
     seed(db, 7, 1);
     const unpaged = listDecisionRowsPage(db, {});
     assert.equal(unpaged.rows.length, 7);
-    // The default is one bounded page, not an unbounded read over every decision.
-    assert.equal(unpaged.page.limit, 100);
-    assert.equal(unpaged.page.cursor, null);
-    assert.equal(unpaged.page.nextCursor, null);
+    // Unparameterized reads still return every match; the GUI board and readiness read the whole corpus.
+    assert.equal(unpaged.page, undefined);
 
     const first = listDecisionRowsPage(db, { limit: 3 });
     assert.deepEqual(

--- a/packages/kernel/test/store/projection-query-shape.test.ts
+++ b/packages/kernel/test/store/projection-query-shape.test.ts
@@ -5,7 +5,6 @@ import test from "node:test";
 import {
   createDecisionProjectionTables,
   listDecisionAgendaRowsPage,
-  listDecisionRows,
   listDecisionRowsPage,
   readDecisionGraphRows,
   readDecisionRows,
@@ -196,17 +195,17 @@ for (const [label, read] of [
   });
 }
 
-test("decision list paging walks the full corpus exactly once and keeps the unparameterized read intact", () => {
-  const db = new DatabaseSync(":memory:");
+test("decision list pages with a bounded default and a constant number of statements", (context) => {
+  const counted = countingDatabase(),
+    { db } = counted;
   try {
     seed(db, 7, 1);
     const unpaged = listDecisionRowsPage(db, {});
     assert.equal(unpaged.rows.length, 7);
-    assert.equal(unpaged.page, undefined);
-    assert.deepEqual(
-      listDecisionRows(db, {}).map(({ decisionId }) => decisionId),
-      unpaged.rows.map(({ decisionId }) => decisionId),
-    );
+    // The default is one bounded page, not an unbounded read over every decision.
+    assert.equal(unpaged.page.limit, 100);
+    assert.equal(unpaged.page.cursor, null);
+    assert.equal(unpaged.page.nextCursor, null);
 
     const first = listDecisionRowsPage(db, { limit: 3 });
     assert.deepEqual(
@@ -256,6 +255,15 @@ test("decision list paging walks the full corpus exactly once and keeps the unpa
     assert.throws(() => listDecisionRowsPage(db, { limit: 0 }), /between 1 and 500/u);
     assert.throws(() => listDecisionRowsPage(db, { limit: 501 }), /between 1 and 500/u);
     assert.throws(() => listDecisionRowsPage(db, { cursor: "not-a-cursor" }), /cursor is invalid/u);
+
+    // One id scan plus one batched row read: the statement count must not grow with the corpus.
+    const before = counted.executions();
+    listDecisionRowsPage(db, { limit: 4 });
+    const four = counted.executions() - before;
+    listDecisionRowsPage(db, { limit: 7 });
+    const seven = counted.executions() - four - before;
+    context.diagnostic(`decision list page statements: 4 rows -> ${four}; 7 rows -> ${seven}`);
+    assert.equal(seven, four, "the decision list read scales per page instead of per row set");
   } finally {
     db.close();
   }

--- a/packages/kernel/test/store/relation-graph-projection-decision-readiness.test.ts
+++ b/packages/kernel/test/store/relation-graph-projection-decision-readiness.test.ts
@@ -145,7 +145,7 @@ test("Replay accepts a document today's renderer no longer reproduces, as long a
   });
 });
 
-test("Decision projection requires exact plan, content hash, consent pin, and document base", () => {
+test("Decision projection requires an exact plan, consent pin, and document base", () => {
   withTempStore((rootDir) => {
     const fixture = projectionFixture(rootDir),
       draft = proposal(1, "dec_EXACT"),
@@ -154,21 +154,8 @@ test("Decision projection requires exact plan, content hash, consent pin, and do
         currentDecision: null,
         currentRelations: [],
         currentDocument: null,
-      }),
-      forgedSha = "0".repeat(64),
-      forged = {
-        ...compiled.event,
-        payload: {
-          ...compiled.event.payload,
-          decisionDocumentClaim: {
-            ...compiled.event.payload.decisionDocumentClaim,
-            sha256: forgedSha,
-          },
-        },
-      };
-    fixture.blobs.set(forgedSha, Buffer.from(compiled.body));
+      });
     assert.throws(() => fixture.projection.apply(compiled.event), /write plan/u);
-    assert.throws(() => fixture.projection.apply(forged, decisionWritePlan(forged)), /projection mismatch/u);
     assert.equal(fixture.projection.readDecision("dec_EXACT").decision, null);
     applyDecision(fixture, draft);
     const next = compileCurrent(fixture, accepted(2, "dec_EXACT")),

--- a/tools/scale/b5-real-baseline.mjs
+++ b/tools/scale/b5-real-baseline.mjs
@@ -79,7 +79,7 @@ export function makeBaselineReadModel({ rootDir, projection, kernel, relationGra
     const lifecycle = projection.list(),
       { taskRows } = relationGraphProjection.readRelationGraphProjection({ rootDir }),
       l2 = new Map(taskRows.map((row) => [row.taskId, row])),
-      decisions = new Map(projection.listDecisions({}).decisions.map((row) => [row.decisionId, row])),
+      decisions = new Map(projection.listDecisions({ limit: 500 }).decisions.map((row) => [row.decisionId, row])),
       edges = projection.readDecisionGraph().edges,
       graph = relationGraph(),
       hardWarnings = graph.warnings.filter(({ severity }) => severity === "hard-fail").map(({ message }) => message);

--- a/tools/scale/b5-real-baseline.mjs
+++ b/tools/scale/b5-real-baseline.mjs
@@ -79,7 +79,7 @@ export function makeBaselineReadModel({ rootDir, projection, kernel, relationGra
     const lifecycle = projection.list(),
       { taskRows } = relationGraphProjection.readRelationGraphProjection({ rootDir }),
       l2 = new Map(taskRows.map((row) => [row.taskId, row])),
-      decisions = new Map(projection.listDecisions({ limit: 500 }).decisions.map((row) => [row.decisionId, row])),
+      decisions = new Map(projection.listDecisions({}).decisions.map((row) => [row.decisionId, row])),
       edges = projection.readDecisionGraph().edges,
       graph = relationGraph(),
       hardWarnings = graph.warnings.filter(({ severity }) => severity === "hard-fail").map(({ message }) => message);


### PR DESCRIPTION
# English

## Summary

The task projection now trusts events the store has already accepted. Apply, replay and read paths redid work the store had already done at acceptance, and some reads were shaped as N+1 or whole-table queries. This is batch B4 of the daemon write-path rescue that followed #2407, #2408 and #2409, based on a 12-report read-only audit of the three days after the SQLite cutover.

- **Content blobs re-hashed on apply.** Every content blob an applied event carried was hashed again in eight places, even though store admission already hashed each blob once.
- **Region proofs re-run on replay.** `verifyDocEventChange` re-ran the doc region proof for every doc event applied or replayed.
- **Events re-validated on read.** `parseEventJson` re-validated and re-normalized every event read back from the projection's own tables.
- **Head digest re-hashed.** Catch-up re-hashed the last event to fill `head_digest`, and query-only readers read a digest nobody consumed.
- **Decision list was N+1.** Each row ran its own five-subquery CTE.
- **Relation writes read every edge.** `relation relate` and `unrelate` loaded all relation edges to find one by id.

## Architectural Justification

- **Blob and proof checks.** Store admission hashes every content blob once. The projection only applies accepted events, so the blob key is its content hash. The availability and size checks stay, and a missing blob still throws. Region proofs are computed once at write time and frozen into the event. Re-running today's rules on replay would make rule changes break history. The base CAS check in the projection stays.
- **Reads.** Projection tables hold the exact bytes the store accepted, so reads use `JSON.parse`. Catch-up still normalizes events before apply. `head_digest` comes from the store's stored digest, which is computed once at append.
- **Decision list.** It reads all rows of a page in one batched query. Calls without paging parameters still return every match; the GUI decision board and decision readiness read the whole corpus, which is 831 decisions on the live ledger. Explicit `limit`/`cursor` paging is unchanged.
- **Relations.** A new `readRelationEdge(relationId)` port method reuses the existing primary-key row read. The depends-on cycle check at `entity-action-relation.ts:126` still needs every depends-on edge, so it keeps the full read.

## What Changed

- Removed `parseEventJson` and its 17 call sites. The projection SQL module no longer imports the canonical-event validators.
- Removed 8 blob re-hash guards in event application, the write model and migration.
- Removed `verifyDocEventChange` and its 3 callers.
- Catch-up takes the store head and writes `head.eventDigest`. The reader head carries only `{revision}`.
- The decision list reads rows through `readDecisionRows(page, false)`; the `listDecisionRows` wrapper is deleted.
- `readRelationEdge` on the projection port; `entity-action-relation.ts` uses it for relate and unrelate.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Deleted production behavior (no file removed): the 8 projection blob re-hashes, the replay region-proof re-run, event re-validation on projection reads, the catch-up head re-hash, the reader head digest, the per-row decision reads, and the full relation-edge read for single-relation writes.
- Production net lines: +55/-104, net -49.

## Machine-Readable Declarations

## Task And Scope

- Harness task: task_aa986f3cc46dd3569a50fc551e (B4), parent task_2b8f79fa4412cb726a26f9bfc7
- Branch: `codex/del-b4-projection-trust`
- Public scope: the kernel projection, the doc-sync writer contract, the relation action in the daemon, and their tests
- Private planning/evidence updated: yes (facts F-D59080E8 and F-7811D74C, report `artifacts/b4-report.md` in the task package)
- Out of scope: the other deletion batches land as separate PRs.

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none
- Authority: not applicable
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `07a277fedc9dcd5461e1d95495a591e87f8bc137`
- Branch merge-base with `origin/main`: `07a277fedc9dcd5461e1d95495a591e87f8bc137`
- Last `git fetch origin` time: 2026-09-10 13:20 UTC
- Sync method: branched from origin/main
- Public diff command: `git diff origin/main...codex/del-b4-projection-trust`
- Private evidence commit/path: facts F-D59080E8 and F-7811D74C
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [x] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Red before, green after (F-D59080E8). On the base, a decision list page of 4 rows ran 5 statements and a page of 7 rows ran 8. With this change the statement count per page is constant. `projection-query-shape.test.ts` now asserts it.
- Docker-isolated on the final head (`node tools/dispatch-isolated-test.mjs --target docker --file <file>`):

  | Test file | Passed |
  |---|---|
  | `projection-query-shape.test.ts` | 10/10 |
  | `fact-fts-performance.test.ts` | 2/2 |
  | `relation-graph-projection-decision-readiness.test.ts` | 5/5 |
  | `decision-surface.test.ts` | 3/3 |

  The worker also ran timestamp, doc-sync prose policy, decision board, task board and relation runtime edge tests (35/35).
- `node tools/run-manifest-gates.mjs --changed origin/main` passed. Also passing: `tsc -b`, eslint and prettier on the changed files, and `production-delta`.
- Existing tests changed, and why each is safe:
  - The readiness test dropped its forged-blob-sha case. Store admission rejects that case, so the projection no longer does.
  - The timestamp test no longer uses the deleted reader. It locks what still holds: serialization keeps the original bytes, and catch-up normalization upgrades offset timestamps.
  - The decision list tests keep asserting "decision list must return every row instead of silently truncating" at 10,000 rows. They add a constant-statements-per-page assertion.
- Not run: the full `npm run check` / `npm test` locally. Local agents must not run the full matrix, so CI is the full authority.

## Review Evidence

- Self-review: the lead read the full production diff.
  - Reverted default page: the worker had made an unparameterized decision list return one page of 100 rows. The live ledger has 831 decisions, and the GUI decision board and readiness computation call the list without paging, so they would have silently lost most decisions. The lead restored the unbounded read (still one batched query) and put back the no-truncation assertion the worker had loosened.
  - Timestamps: the lead checked the data evidence for dropping read-side timestamp normalization. The canonical ledger has zero legacy-form timestamps among 66,628 events (F-7811D74C).
- Reviewer subagent: a GLM-5.3 implementation worker wrote the change; the lead reviewed and amended it
- Human review: pending
- Blocking findings: none

## Residual Risk

- Read APIs (`readOperation`, `readProgress`, list `updatedAt`) now return timestamps as stored instead of normalized. The canonical ledger has none in legacy form. An older ledger in another repository may show the original spelling. Projection rows are unaffected, because catch-up still normalizes before apply.
- A relation write now makes two single-row reads instead of one full edge read.

## References

- Audit: `artifacts/audit-3day/00-ranked-deletions.md` (B4) in task_2b8f79fa4412cb726a26f9bfc7
- Previous batches: PR #2407, PR #2408, PR #2409, PR #2410

---

# 中文

## 概要

任务投影现在信任 store 已受理的事件。apply、回放和读取路径都在重做 store 受理时已经做过的工作，还有一些读取是 N+1 或整表查询。本 PR 是 #2407、#2408、#2409 之后 daemon 写路径抢救的 B4 批次，依据是对 SQLite 切换后三天所做的 12 份只读审计。

- **apply 时重哈希 blob。** 被 apply 的事件携带的每个内容 blob 在 8 处被重新哈希，而 store 受理时已经对每个 blob 哈希过一次。
- **回放时重跑区域证明。** 每个被 apply 或回放的 doc 事件，`verifyDocEventChange` 都重跑一遍 doc 区域证明。
- **读取时重新校验事件。** `parseEventJson` 对从投影自己的表里读回的每个事件，重新校验并重新规范化。
- **重算 head digest。** catch-up 重新哈希最后一条事件来填 `head_digest`；query-only reader 读出一个没人消费的 digest。
- **decision list 是 N+1。** 每行各跑一条带 5 个子查询的 CTE。
- **关系写入读全部边。** `relation relate` 和 `unrelate` 为了按 id 找一条边，把全部关系边读出来。

## 架构辩护

- **blob 与证明检查。** store 受理时对每个内容 blob 哈希一次；投影只 apply 已受理的事件，blob 键就是它的内容哈希。可用性和大小检查保留，缺失 blob 仍然抛错。区域证明在写入时算一次、随事件冻结；回放时用今天的规则重跑，会让规则演进反过来卡死历史。投影里的 base CAS 检查保留。
- **读取。** 投影表存的正是 store 受理的字节，所以读取直接用 `JSON.parse`；catch-up 在 apply 之前仍做规范化。`head_digest` 取自 store 在 append 时算好的 digest。
- **decision list。** 一页的所有行用一次批量查询读出。不带分页参数的调用仍返回全部匹配：GUI 决策板和 decision readiness 读的是全集，线上有 831 条 decision。显式 `limit`/`cursor` 分页不变。
- **关系。** 新增端口方法 `readRelationEdge(relationId)`，复用已有的主键单行读取。`entity-action-relation.ts:126` 的 depends-on 环检测仍然需要全部 depends-on 边，所以保留全量读取。

## 改动内容

- 删除 `parseEventJson` 及其 17 处调用；投影 SQL 模块不再 import canonical-event 校验器。
- 删除事件应用、写模型和迁移里的 8 处 blob 重哈希守卫。
- 删除 `verifyDocEventChange` 及其 3 个调用方。
- catch-up 接收 store 的 head 并写入 `head.eventDigest`；reader head 只带 `{revision}`。
- decision list 改用 `readDecisionRows(page, false)` 读取行；删除 `listDecisionRows` 包装。
- 投影端口新增 `readRelationEdge`；`entity-action-relation.ts` 在 relate 和 unrelate 时使用它。

## 门收割 / Gate Harvest

- 删除的生产路径：none（没有删文件）
- 删除的门或 fixture：none
- 删除的生产行为：投影里 8 处 blob 重哈希、回放时重跑区域证明、投影读取时重新校验事件、catch-up 重算 head、reader 的 head digest、decision 逐行读取、单条关系写入时读全部边。
- 生产净行数：+55/-104，净 -49。

## 机读声明说明

- 本 PR 不涉及依赖变化和事件迁移，没有机读声明。

## 任务与范围

- Harness 任务：task_aa986f3cc46dd3569a50fc551e（B4），父任务 task_2b8f79fa4412cb726a26f9bfc7
- 分支：`codex/del-b4-projection-trust`
- 公开范围：kernel 投影、doc-sync writer 契约、daemon 的关系 action，以及对应测试
- 私有计划 / 证据是否已更新：yes（fact F-D59080E8、F-7811D74C，任务包里的报告 `artifacts/b4-report.md`）
- 范围外：其它删除批次分别开 PR。

## 版本影响

- 版本：不改版本
- 发布影响：不发布

## 治理声明

- 是否触碰 protected surface：no
- protected surface 范围：无
- 依据：不适用
- 机器检查边界：本 PR 只声明该段存在；声明是否真实、充分，由 reviewer 判断。
- Break-glass：no
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- `origin/main` 基准 SHA：`07a277fedc9dcd5461e1d95495a591e87f8bc137`
- 当前分支与 `origin/main` 的 merge-base：`07a277fedc9dcd5461e1d95495a591e87f8bc137`
- 最近一次 `git fetch origin` 时间：2026-09-10 13:20 UTC
- 同步方式：从 origin/main 拉出
- 公开 diff 命令：`git diff origin/main...codex/del-b4-projection-trust`
- 私有证据 commit/path：fact F-D59080E8、F-7811D74C
- Reviewer 证据路径：见本 PR 的「审查证据」一节
- GitHub Actions `rewrite-ci` run URL：本 PR 的 CI 还在跑
- [ ] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [x] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- 修复前红、修复后绿（F-D59080E8）：在基线上，4 行一页的 decision list 执行 5 条语句，7 行一页执行 8 条；应用本改动后每页语句数恒定，`projection-query-shape.test.ts` 现在断言这一点。
- 在最终 head 上，于 Docker 隔离环境运行（`node tools/dispatch-isolated-test.mjs --target docker --file <file>`）：

  | 测试文件 | 通过 |
  |---|---|
  | `projection-query-shape.test.ts` | 10/10 |
  | `fact-fts-performance.test.ts` | 2/2 |
  | `relation-graph-projection-decision-readiness.test.ts` | 5/5 |
  | `decision-surface.test.ts` | 3/3 |

  worker 另外跑过 timestamp、doc-sync prose policy、decision board、task board、relation runtime edge 测试（35/35）。
- `node tools/run-manifest-gates.mjs --changed origin/main` 通过；`tsc -b`、改动文件的 eslint 和 prettier、`production-delta` 也都通过。
- 修改过的现有测试，以及为什么安全：
  - readiness 测试删掉伪造 blob sha 的用例：这种情况在 store 受理时就会被拒绝，投影不再重复检查。
  - timestamp 测试不再使用已删除的读取函数，改为锁定仍然成立的性质：序列化保留原始字节，catch-up 的规范化会升级带 offset 的时间戳。
  - decision list 测试仍在 10,000 行上断言「decision list must return every row instead of silently truncating」，另外新增「每页语句数恒定」的断言。
- 未运行：本地整套 `npm run check` / `npm test`。规定禁止本地 agent 跑全量矩阵，全量以 CI 为准。

## 审查证据

- 自查：主控读完整个生产 diff，确认了以下几点。
  - 撤回默认分页：worker 让不带参数的 decision list 只返回一页 100 行。线上有 831 条 decision，而 GUI 决策板和 readiness 计算调用时都不带分页参数，会静默丢掉大部分 decision。主控改回返回全部（仍然只用一次批量查询），并恢复了 worker 放宽的「不许静默截断」断言。
  - 时间戳：主控核对了去掉读端时间戳规范化的数据证据：canonical 台账 66,628 条事件里没有一条是旧格式时间戳（F-7811D74C）。
- Reviewer subagent：改动由 GLM-5.3 实现 worker 编写，主控审查并补充修改
- 人工审查：待进行
- 阻塞发现：无

## 残余风险

- 读取 API（`readOperation`、`readProgress`、列表的 `updatedAt`）现在按存储原样返回时间戳，不再规范化。canonical 台账里没有旧格式时间戳，但其他仓库更早的台账可能显示原始写法。投影行不受影响，因为 catch-up 在 apply 之前仍会规范化。
- 一次关系写入现在做两次单行读取，取代原来的一次全量边读取。

## 关联材料

- 审计：task_2b8f79fa4412cb726a26f9bfc7 的 `artifacts/audit-3day/00-ranked-deletions.md`（B4 节）
- 前几批：PR #2407、PR #2408、PR #2409、PR #2410

---

## PR Gate Checklist / PR 门禁清单

- [x] Branch is based on latest `origin/main`. / 分支基于最新 `origin/main`。
- [x] PR body uses this full template structure. / PR 描述使用本模板完整结构。
- [x] PR body uses two complete language blocks: `# English` first, then `# 中文`. / PR 正文使用两块完整正文：`# English` 在上，`# 中文` 在下。
- [x] PR body passes `tools/check-pr-body-bilingual.mjs`. / PR 正文通过 `tools/check-pr-body-bilingual.mjs`。
- [x] If the PR touches a manifest-derived protected surface, Governance Declaration is filled with ADR/decision/task evidence or break-glass fields. / 若 PR 触碰 manifest 派生的 protected surface，Governance Declaration 已填写 ADR/decision/task 依据或 break-glass 字段。
- [x] No private harness files are included. / 不包含私有 harness 文件。
- [x] No ignored local agent entry files are included. / 不包含被忽略的本地 agent 入口文件。
- [x] No absolute local filesystem paths are included in this public PR body. / 本公开 PR 描述不包含本机绝对路径。
- [x] Public diff is limited to the stated task scope. / 公开 diff 限于声明的任务范围。
- [x] Private planning/evidence updates are recorded when applicable. / 适用时已记录私有计划 / 证据更新。
- [x] Version and publish impact are stated. / 已说明版本与发布影响。
- [x] Local verification commands are recorded honestly. / 已如实记录本地验证命令。
- [ ] CI results are linked or explained. / CI 结果已链接或说明。
- [x] Review evidence is recorded. / 已记录审查证据。
- [x] Open P0/P1/P2 findings are closed, deferred with owner, or explicitly blocked. / open P0/P1/P2 findings 已关闭、带 owner 延后，或明确阻塞。
- [x] Merge method and post-merge branch cleanup plan are clear. / 合并方式和合并后分支清理计划清楚。
- [x] No admin bypass is planned unless explicitly approved and recorded. / 除非明确批准并记录，否则不计划 admin bypass。
