### PR TITLE
perf: read stored event digests instead of re-hashing in the SQLite event store

### DIFF
--- a/packages/daemon/test/owner-named-temporary-write-paths.test.ts
+++ b/packages/daemon/test/owner-named-temporary-write-paths.test.ts
@@ -46,7 +46,6 @@ test("a temporary named after its writer exists only where it was judged", () =>
     "kernel/src/daemon/registry.ts: `${registryPath}.${process.pid}.${Date.now()}.tmp`",
     "kernel/src/local/local-layout-file-system.ts: `${inputPath}.${process.pid}.tmp`",
     "kernel/src/store/local-version-control-system.ts: `${target}.tmp-${process.pid}`",
-    "kernel/src/store/local-version-control-system.ts: `.ha-settle-${process.pid}-${index}`",
     "kernel/src/store/local-version-control-system.ts: `.ha-visible-${process.pid}-${index}`",
   ]);
 });

--- a/packages/kernel/src/store/local-version-control-system.ts
+++ b/packages/kernel/src/store/local-version-control-system.ts
@@ -601,127 +601,6 @@ export const localGitWorktreeSettlement = Object.freeze({
     );
     return 1;
   },
-  settle: (
-    repoRoot: string,
-    files: readonly (
-      | {
-          readonly target: string;
-          readonly body: string | Uint8Array;
-          readonly mode?: "100644" | "120000";
-        }
-      | { readonly from: string; readonly to: string }
-      | { readonly delete: string }
-    )[],
-    hooks: {
-      readonly whileFilesSync?: () => void;
-      readonly beforeRename?: () => void;
-      readonly afterRename?: () => void;
-    } = {},
-  ): number => {
-    const directories = new Set<string>(),
-      writes = files.filter(
-        (
-          file,
-        ): file is {
-          readonly target: string;
-          readonly body: string | Uint8Array;
-          readonly mode?: "100644" | "120000";
-        } => "target" in file,
-      ),
-      renames = files.filter((file): file is { readonly from: string; readonly to: string } => "from" in file),
-      deletions = files
-        .filter((file): file is { readonly delete: string } => "delete" in file)
-        .map((file) => {
-          const target = path.join(repoRoot, ...file.delete.split("/"));
-          directories.add(path.dirname(target));
-          return { target, logical: file.delete };
-        }),
-      pending = writes.map((file, index) => {
-        const target = path.join(repoRoot, ...file.target.split("/")),
-          directory = path.dirname(target),
-          temporary = path.join(directory, `.ha-settle-${process.pid}-${index}`),
-          mode = file.mode ?? "100644";
-        directories.add(directory);
-        removeNode(temporary);
-        return {
-          target,
-          temporary,
-          body: file.body,
-          mode,
-          logical: file.target,
-        };
-      }),
-      pendingRenames = renames.map((file) => {
-        const from = path.join(repoRoot, ...file.from.split("/")),
-          to = path.join(repoRoot, ...file.to.split("/")),
-          source = readNode(from),
-          destination = readNode(to);
-        if (source === null && destination === null)
-          throw new Error(`settlement rename is missing both ${file.from} and ${file.to}`);
-        if (source !== null && destination !== null)
-          throw new Error(`settlement rename target already exists at ${file.to}`);
-        directories.add(path.dirname(from));
-        directories.add(path.dirname(to));
-        return {
-          from,
-          to,
-          fromLogical: file.from,
-          toLogical: file.to,
-          node: source ?? destination!,
-          pending: source !== null,
-        };
-      });
-    for (const directory of directories) {
-      /* @gate-identity check-bypass-write-boundary/bypass-write-083 */
-      mkdirSync(directory, { recursive: true });
-      sweepStaleSettlementMarkers(directory);
-    }
-    const regular = pending.filter(({ mode }) => mode === "100644"),
-      links = pending.filter(({ mode }) => mode === "120000"),
-      fileSync = beginDurableSettlement({ files: regular });
-    try {
-      hooks.whileFilesSync?.();
-      awaitDurableSettlement(fileSync);
-    } catch (error) {
-      try {
-        awaitDurableSettlement(fileSync);
-      } catch (syncError) {
-        consumeKnownError(syncError);
-      }
-      for (const item of regular) removeNode(item.temporary);
-      throw error;
-    }
-    for (const item of [
-      ...regular.map(({ temporary: from, target: to }) => ({ from, to })),
-      ...pendingRenames.filter(({ pending }) => pending).map(({ from, to }) => ({ from, to })),
-    ]) {
-      hooks.beforeRename?.();
-      /* @gate-identity check-bypass-write-boundary/bypass-write-093 */
-      renameSync(item.from, item.to);
-      hooks.afterRename?.();
-    }
-    for (const item of deletions) removeNode(item.target);
-    const zero = "0".repeat(40);
-    const indexInput = `${pending
-      .map((file) => `${file.mode} ${gitBlobOidBytes(asBytes(file.body))}\t${file.logical}\0`)
-      .join("")}${pendingRenames
-      .map((file) => `0 ${zero}\t${file.fromLogical}\0${file.node.mode} ${file.node.gitOid}\t${file.toLogical}\0`)
-      .join("")}${deletions.map((file) => `0 ${zero}\t${file.logical}\0`).join("")}`;
-    if (files.length) localGitProcesses += 1;
-    awaitDurableSettlement(
-      beginDurableSettlement({
-        index: files.length ? { repoRoot, input: indexInput } : undefined,
-        directories: links.length === 0 ? [...directories] : undefined,
-      }),
-    );
-    for (const item of links) {
-      hooks.beforeRename?.();
-      runGit(repoRoot, "checkout-index", "--force", "--", item.logical);
-      hooks.afterRename?.();
-    }
-    if (links.length > 0) awaitDurableSettlement(beginDurableSettlement({ directories: [...directories] }));
-    return files.length + directories.size;
-  },
   preserveConflict: (repoRoot: string, target: string, logical: string, commit: string): string =>
     preserveConflict(repoRoot, target, logical, commit, true),
   preserveVisibleConflict: (repoRoot: string, target: string, logical: string, cutIdentity: string): string =>
@@ -758,7 +637,6 @@ function readNode(target: string): {
   readonly body: string;
   readonly bytes: Buffer;
   readonly sha256: string;
-  readonly gitOid: string;
   readonly size: number;
 } | null {
   try {
@@ -771,7 +649,6 @@ function readNode(target: string): {
       body: bytes.toString("utf8"),
       bytes,
       sha256: hashVcsBytes("sha256", bytes),
-      gitOid: gitBlobOidBytes(bytes),
       size: bytes.byteLength,
     };
   } catch (error) {

--- a/packages/kernel/src/store/sqlite-event-store.ts
+++ b/packages/kernel/src/store/sqlite-event-store.ts
@@ -1,12 +1,7 @@
 import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
-import {
-  parseCanonicalEvent,
-  validateCurrentCanonicalEvent,
-  serializePersistedCanonicalEvent,
-  type CanonicalEventV1,
-} from "../domain/doc-sync.contract.ts";
-import { sha256Bytes, sha256Text, stableStringify } from "../integrity/stable-hash.ts";
+import { serializePersistedCanonicalEvent, type CanonicalEventV1 } from "../domain/doc-sync.contract.ts";
+import { sha256Text, stableStringify } from "../integrity/stable-hash.ts";
 import { resolveHarnessLayout, type HarnessLayoutInput } from "../layout/index.ts";
 import { localRuntimeStateFileSystem } from "../local/local-layout-file-system.ts";
 import { localContentObjectFileSystem } from "../local/local-layout-file-system.ts";
@@ -37,6 +32,13 @@ export interface SqliteEventRow {
   readonly occurredAt: string;
   readonly recordedAt: string;
   readonly digest: `sha256:${string}`;
+}
+
+/** The identity SQLite already durably stores for an event, without re-reading or re-serializing its body. */
+export interface SqliteEventIdentity {
+  readonly revision: number;
+  readonly opId: string;
+  readonly eventDigest: `sha256:${string}`;
 }
 
 export interface SqliteCommandIntent {
@@ -120,6 +122,8 @@ export interface SqliteEventStore {
   readonly events: () => readonly CanonicalEventV1[];
   readonly event: (opId: string) => CanonicalEventV1 | null;
   readonly eventAtRevision: (revision: number) => CanonicalEventV1 | null;
+  readonly eventIdentity: (opId: string) => SqliteEventIdentity | null;
+  readonly eventIdentityAtRevision: (revision: number) => SqliteEventIdentity | null;
   readonly eventsAfter: (revision: number, limit?: number) => readonly CanonicalEventV1[];
   readonly close: () => void;
 }
@@ -452,11 +456,6 @@ export function openSqliteEventStore(options: {
         ))
     )
       throw new TaskEventStoreError("invalid_write_plan", "historical acceptance timestamps are incomplete");
-    if (generation === 2)
-      for (const event of input.events) {
-        const errors = validateCurrentCanonicalEvent(event);
-        if (errors.length) throw new TaskEventStoreError("invalid_write_plan", errors.join("; "));
-      }
     prepareContentObjects(objectRoot, input.events, input.blobs ?? []);
     return transaction(() => {
       assertFenceShape(input.fence, repoId);
@@ -548,12 +547,16 @@ export function openSqliteEventStore(options: {
     contentObjectDigests: () => listContentObjectDigests(objectRoot),
     revision: () => readRevision(db),
     events: () =>
-      query("SELECT event_json FROM event ORDER BY revision").map((row) => parseCanonicalEvent(String(row.event_json))),
+      query("SELECT event_json FROM event ORDER BY revision").map(
+        (row) => JSON.parse(String(row.event_json)) as CanonicalEventV1,
+      ),
     event: (opId) => readEvent(query, "op_id", opId),
     eventAtRevision: (revision) => readEvent(query, "revision", revision),
+    eventIdentity: (opId) => readEventIdentity(query, "op_id", opId),
+    eventIdentityAtRevision: (revision) => readEventIdentity(query, "revision", revision),
     eventsAfter: (revision, limit = 4096) =>
-      query("SELECT event_json FROM event WHERE revision>? ORDER BY revision LIMIT ?", [revision, limit]).map((row) =>
-        parseCanonicalEvent(String(row.event_json)),
+      query("SELECT event_json FROM event WHERE revision>? ORDER BY revision LIMIT ?", [revision, limit]).map(
+        (row) => JSON.parse(String(row.event_json)) as CanonicalEventV1,
       ),
     close: () => db.close(),
   };
@@ -661,7 +664,18 @@ function assertMetadata(query: SqliteQuery, repoId: string, generation: number):
 
 function readEvent(query: SqliteQuery, column: "op_id" | "revision", value: string | number): CanonicalEventV1 | null {
   const row = query(`SELECT event_json FROM event WHERE ${column}=?`, [value]).at(0);
-  return row ? parseCanonicalEvent(String(row.event_json)) : null;
+  return row ? (JSON.parse(String(row.event_json)) as CanonicalEventV1) : null;
+}
+
+function readEventIdentity(
+  query: SqliteQuery,
+  column: "op_id" | "revision",
+  value: string | number,
+): SqliteEventIdentity | null {
+  const row = query(`SELECT revision, op_id, digest FROM event WHERE ${column}=?`, [value]).at(0);
+  return row
+    ? { revision: Number(row.revision), opId: String(row.op_id), eventDigest: String(row.digest) as `sha256:${string}` }
+    : null;
 }
 
 function applyDerivedGuards(db: DatabaseSync, event: CanonicalEventV1): void {
@@ -719,23 +733,12 @@ function prepareContentObjects(
   const supplied = new Map(blobs.map((blob) => [blob.sha256, blob]));
   for (const event of events) {
     for (const claim of contentClaims(event)) {
-      const existing = readContentObject(objectRoot, claim.sha256);
-      if (existing !== null) {
-        if (existing.byteLength !== claim.size || sha256Bytes(existing) !== claim.sha256)
-          throw new TaskEventStoreError("invalid_store", `content object ${claim.sha256} is corrupt`);
-        continue;
-      }
+      const target = objectPath(objectRoot, claim.sha256);
+      if (localContentObjectFileSystem.exists(target)) continue;
       const blob = supplied.get(claim.sha256),
         bytes = blob === undefined ? null : typeof blob.body === "string" ? Buffer.from(blob.body) : blob.body;
-      if (
-        !blob ||
-        !bytes ||
-        blob.size !== claim.size ||
-        bytes.byteLength !== claim.size ||
-        sha256Bytes(bytes) !== claim.sha256
-      )
+      if (!blob || !bytes || blob.size !== claim.size || bytes.byteLength !== claim.size)
         throw new TaskEventStoreError("invalid_write_plan", `event content object ${claim.sha256} is missing`);
-      const target = objectPath(objectRoot, claim.sha256);
       localContentObjectFileSystem.replace(target, bytes);
     }
   }

--- a/packages/kernel/src/store/sqlite-task-event-publication.ts
+++ b/packages/kernel/src/store/sqlite-task-event-publication.ts
@@ -1,5 +1,5 @@
-import { type EventHead, type LedgerCutIdentity } from "../domain/write-chain.contract.ts";
-import { serializePersistedCanonicalEvent, type CanonicalEventV1 } from "../domain/doc-sync.contract.ts";
+import { type LedgerCutIdentity } from "../domain/write-chain.contract.ts";
+import type { CanonicalEventV1 } from "../domain/doc-sync.contract.ts";
 import { sha256Bytes, sha256Text } from "../integrity/stable-hash.ts";
 import { resolveHarnessLayout, type HarnessLayoutInput } from "../layout/index.ts";
 import { consumeKnownError } from "../error-consumption.ts";
@@ -44,8 +44,7 @@ export function publishConvertedGeneration(input: {
     parent = localGitObjectRefStore.resolveCommit(ledger.rootDir, authoredRef),
     revision = input.store.revision();
   if (revision === 0) return { commitSha: parent, revision, changed: false };
-  const event = input.store.eventAtRevision(revision),
-    cut = canonicalLedgerCut(input.repoId, event ? eventHead(event) : null),
+  const cut = canonicalLedgerCut(input.repoId, input.store.eventIdentityAtRevision(revision)),
     closureEvents = readEventsThrough(input.store, revision),
     files = [
       ...followerFiles(ledger, closureEvents, input.store.readContentObject, cut, input.store.metadata().generation),
@@ -96,8 +95,7 @@ export function readCertifiedGitFollower(input: {
     revision = certifiedFollowerRevision(ledger, commitSha, input.store);
   if (revision !== input.store.revision())
     throw new TaskEventStoreError("publication_indeterminate", "Git follower does not certify the current SQLite cut");
-  const event = input.store.eventAtRevision(revision),
-    cut = canonicalLedgerCut(input.repoId, event ? eventHead(event) : null),
+  const cut = canonicalLedgerCut(input.repoId, input.store.eventIdentityAtRevision(revision)),
     closure = documentClosure(readEventsThrough(input.store, revision));
   verifyDocumentClosure(ledger, commitSha, closure);
   return {
@@ -265,8 +263,7 @@ function manifestRevision(bytes: Buffer, sqlite: ReturnType<typeof openSqliteEve
     revision > sqlite.revision()
   )
     throw new TaskEventStoreError("publication_indeterminate", "Git follower manifest identity is invalid");
-  const event = sqlite.eventAtRevision(revision),
-    expected = canonicalLedgerCut(sqlite.metadata().repoId, event ? eventHead(event) : null);
+  const expected = canonicalLedgerCut(sqlite.metadata().repoId, sqlite.eventIdentityAtRevision(revision));
   if (parsed.cut.headDigest !== expected.headDigest)
     throw new TaskEventStoreError("publication_indeterminate", "Git follower manifest cut differs from SQLite");
   return revision;
@@ -279,17 +276,17 @@ export function ledgerWorktreeBaseline(
   revision: number,
   files: readonly (PublicationWrite | PublicationDelete)[],
 ): ReadonlyMap<string, string> {
-  const event = sqlite.eventAtRevision(revision),
+  const identity = sqlite.eventIdentityAtRevision(revision),
     held = new Map(
-      [...documentClosure(event ? readEventsThrough(sqlite, revision) : []).documents].map(([logical, document]) => [
+      [...documentClosure(identity ? readEventsThrough(sqlite, revision) : []).documents].map(([logical, document]) => [
         ledgerGitPath(ledger, logical),
         `${document.mode}:${document.sha256}:${document.size}`,
       ]),
     );
-  if (event) {
+  if (identity) {
     const manifest = followerManifest(
       sqlite.metadata().generation,
-      canonicalLedgerCut(sqlite.metadata().repoId, eventHead(event)),
+      canonicalLedgerCut(sqlite.metadata().repoId, identity),
     );
     held.set(
       ledgerGitPath(ledger, followerManifestPath),
@@ -323,14 +320,6 @@ function decodeFollowerManifest(bytes: Buffer): {
   }
   if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) throw undecodable();
   return parsed as ReturnType<typeof decodeFollowerManifest>;
-}
-
-function eventHead(event: CanonicalEventV1): EventHead {
-  return {
-    revision: event.workspaceRevision,
-    opId: event.opId,
-    eventDigest: `sha256:${sha256Text(serializePersistedCanonicalEvent(event))}`,
-  };
 }
 
 export function readEventsThrough(

--- a/packages/kernel/src/store/sqlite-task-event-store.ts
+++ b/packages/kernel/src/store/sqlite-task-event-store.ts
@@ -9,7 +9,7 @@ import { sha256Text } from "../integrity/stable-hash.ts";
 import { resolveHarnessLayout, type HarnessLayoutInput } from "../layout/index.ts";
 import { consumeKnownError } from "../error-consumption.ts";
 import { canonicalDocumentClaims, contentClaims } from "./task-event-store-claims-layout.ts";
-import { canonicalEventCutFromHead, canonicalLedgerCut } from "./task-event-store-contract.ts";
+import { canonicalEventCut, canonicalEventCutFromHead, canonicalLedgerCut } from "./task-event-store-contract.ts";
 import { isTaskBootstrapEvent } from "../domain/task-bootstrap-event.ts";
 import { resolveLedgerGitLayout, ledgerGitPath } from "./ledger-git-layout.ts";
 import { localGitObjectRefStore, localGitWorktreeSettlement } from "./local-version-control-system.ts";
@@ -386,10 +386,8 @@ export function makeSqliteTaskEventStore(options: SqliteTaskEventStoreOptions): 
     currentCut: cut,
     currentCommit: () =>
       ledgerCommitSha(options.repoId, localGitObjectRefStore.resolveCommit(ledger().rootDir, authoredRef())),
-    publication: (event) => ({
-      commitSha: null,
-      cut: canonicalEventCutFromHead(options.repoId, sqlite.eventIdentity(event.opId)!),
-    }),
+    // Migration import asks for the cut of a prepared event before it commits, so derive it from the event.
+    publication: (event) => ({ commitSha: null, cut: canonicalEventCut(options.repoId, event) }),
     revisionAt: () => null,
     readEvent: sqlite.event,
     readTaskEvent: (opId) => {

--- a/packages/kernel/src/store/sqlite-task-event-store.ts
+++ b/packages/kernel/src/store/sqlite-task-event-store.ts
@@ -9,7 +9,7 @@ import { sha256Text } from "../integrity/stable-hash.ts";
 import { resolveHarnessLayout, type HarnessLayoutInput } from "../layout/index.ts";
 import { consumeKnownError } from "../error-consumption.ts";
 import { canonicalDocumentClaims, contentClaims } from "./task-event-store-claims-layout.ts";
-import { canonicalEventCut, canonicalLedgerCut } from "./task-event-store-contract.ts";
+import { canonicalEventCutFromHead, canonicalLedgerCut } from "./task-event-store-contract.ts";
 import { isTaskBootstrapEvent } from "../domain/task-bootstrap-event.ts";
 import { resolveLedgerGitLayout, ledgerGitPath } from "./ledger-git-layout.ts";
 import { localGitObjectRefStore, localGitWorktreeSettlement } from "./local-version-control-system.ts";
@@ -103,16 +103,7 @@ export function makeSqliteTaskEventStore(options: SqliteTaskEventStoreOptions): 
     scheduled: Promise<void> | null = null,
     certified: { readonly commit: string; readonly revision: number } | null = null;
 
-  const head = (): EventHead | null => {
-    const event = sqlite.eventAtRevision(sqlite.revision());
-    return event
-      ? {
-          revision: event.workspaceRevision,
-          opId: event.opId,
-          eventDigest: `sha256:${sha256Text(serializePersistedCanonicalEvent(event))}`,
-        }
-      : null;
-  };
+  const head = (): EventHead | null => sqlite.eventIdentityAtRevision(sqlite.revision());
   const cut = () => canonicalLedgerCut(options.repoId, head());
   const readContent = (sha256: string) => sqlite.readContentObject(sha256);
   const acceptedWorktree = new Map<string, { fingerprint: string; preserve: boolean }>(),
@@ -130,16 +121,21 @@ export function makeSqliteTaskEventStore(options: SqliteTaskEventStoreOptions): 
       acceptedBaseline = new Map<string, { fingerprint: string; preserve: boolean }>();
     assertAuthorizedReplacements(sqlite, input, members);
     for (const event of appended) {
+      const task = isTaskEvent(event);
       for (const claim of canonicalDocumentClaims(event)) {
-        const node = localGitWorktreeSettlement.readNode(`${authoredRoot}/${claim.path}`);
-        if (!node || node.mode !== "100644") continue;
         const prose =
+          !task &&
           event.schema === "doc-event/v1" &&
           event.payload.changes.some(
             (change) => change.path === claim.path && change.policyId === "markdown-body-replaceable/v1",
           );
-        if (isTaskEvent(event) || (prose && sha256Text(node.body.replace(/\r\n/gu, "\n")) === claim.sha256))
-          acceptedBaseline.set(claim.path, { fingerprint: worktreeFingerprint(node), preserve: isTaskEvent(event) });
+        if (!task && !prose) continue;
+        const node = localGitWorktreeSettlement.readNode(`${authoredRoot}/${claim.path}`);
+        if (!node || node.mode !== "100644") continue;
+        const matches =
+          task ||
+          (node.body.includes("\r\n") ? sha256Text(node.body.replace(/\r\n/gu, "\n")) : node.sha256) === claim.sha256;
+        if (matches) acceptedBaseline.set(claim.path, { fingerprint: worktreeFingerprint(node), preserve: task });
       }
     }
     const fence = options.writerFence?.() ?? { repoId: options.repoId, holderId: "direct-store", epoch: 1 },
@@ -175,7 +171,7 @@ export function makeSqliteTaskEventStore(options: SqliteTaskEventStoreOptions): 
           follower.git.commitSha
             ? ledgerCommitSha(options.repoId, follower.git.commitSha)
             : null,
-        cut: canonicalEventCut(options.repoId, bundle.event),
+        cut: canonicalEventCutFromHead(options.repoId, sqlite.eventIdentity(bundle.event.opId)!),
         metrics: { gitProcesses: 0, nodeSyncs: 0, changedPaths: [] },
       };
       options.killpoint?.("after_response_write");
@@ -217,7 +213,8 @@ export function makeSqliteTaskEventStore(options: SqliteTaskEventStoreOptions): 
         const target = "target" in file ? file.target : file.delete,
           current = worktreeFingerprint(localGitWorktreeSettlement.readNode(`${currentLedger.rootDir}/${target}`));
         if (current === "missing" && (restoreMissing || !permitted.has(target))) permitted.set(target, "missing");
-        if (current === permitted.get(target) || current === settledFingerprint(file)) return true;
+        if (current === settledFingerprint(file)) return false;
+        if (current === permitted.get(target)) return true;
         conflicts.push(target);
         return false;
       }),
@@ -389,7 +386,10 @@ export function makeSqliteTaskEventStore(options: SqliteTaskEventStoreOptions): 
     currentCut: cut,
     currentCommit: () =>
       ledgerCommitSha(options.repoId, localGitObjectRefStore.resolveCommit(ledger().rootDir, authoredRef())),
-    publication: (event) => ({ commitSha: null, cut: canonicalEventCut(options.repoId, event) }),
+    publication: (event) => ({
+      commitSha: null,
+      cut: canonicalEventCutFromHead(options.repoId, sqlite.eventIdentity(event.opId)!),
+    }),
     revisionAt: () => null,
     readEvent: sqlite.event,
     readTaskEvent: (opId) => {

--- a/packages/kernel/src/store/task-event-store-contract.ts
+++ b/packages/kernel/src/store/task-event-store-contract.ts
@@ -52,15 +52,18 @@ export function canonicalEventWritePlan(event: CanonicalEventV1, projection: str
   );
 }
 export function canonicalEventCut(repoId: string, event: CanonicalEventV1): CanonicalEventCut {
-  const head: EventHead = {
+  return canonicalEventCutFromHead(repoId, {
     revision: event.workspaceRevision,
     opId: event.opId,
     eventDigest: `sha256:${sha256Text(serializePersistedCanonicalEvent(event))}`,
-  };
+  });
+}
+/** Same identity as `canonicalEventCut`, from an event digest the store already has on hand. */
+export function canonicalEventCutFromHead(repoId: string, head: EventHead): CanonicalEventCut {
   return {
     repoId,
-    revision: event.workspaceRevision,
-    opId: event.opId,
+    revision: head.revision,
+    opId: head.opId,
     headDigest: `sha256:${sha256Text(serializeEventHead(head))}`,
   };
 }

--- a/packages/kernel/test/store/local-version-control-settlement.test.ts
+++ b/packages/kernel/test/store/local-version-control-settlement.test.ts
@@ -1,12 +1,11 @@
 // harness-test-tier: integration
 import assert from "node:assert/strict";
-import { execFileSync, spawn, spawnSync } from "node:child_process";
-import { once } from "node:events";
-import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { execFileSync, spawnSync } from "node:child_process";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import test from "node:test";
 import { localGitWorktreeSettlement } from "../../src/store/local-version-control-system.ts";
-import { withTempStore, withTempStoreAsync } from "./helpers.ts";
+import { withTempStore } from "./helpers.ts";
 
 function git(repoRoot: string, ...args: readonly string[]): string {
   return execFileSync("git", ["-C", repoRoot, ...args], { encoding: "utf8" }).trim();
@@ -27,12 +26,6 @@ function plant(directory: string, name: string): string {
   return marker;
 }
 
-function markers(directory: string): readonly string[] {
-  return readdirSync(directory)
-    .filter((name) => name.startsWith(".ha-"))
-    .sort();
-}
-
 /** A pid that belonged to a process which has provably exited. */
 function deadPid(): number {
   for (let attempt = 0; attempt < 5; attempt += 1) {
@@ -45,114 +38,6 @@ function deadPid(): number {
   }
   throw new Error("could not obtain a pid whose process has exited");
 }
-
-test(
-  "settle reclaims the markers a SIGKILLed settlement left behind",
-  { skip: process.platform === "win32" ? "requires POSIX SIGKILL semantics" : false },
-  () => {
-    withTempStore((rootDir) => {
-      const repoRoot = ledger(rootDir),
-        directory = path.join(repoRoot, "events", "ab"),
-        moduleUrl = new URL("../../src/store/local-version-control-system.ts", import.meta.url).href,
-        child = spawnSync(
-          process.execPath,
-          [
-            "--experimental-strip-types",
-            "--input-type=module",
-            "-e",
-            [
-              `import { localGitWorktreeSettlement } from ${JSON.stringify(moduleUrl)};`,
-              "localGitWorktreeSettlement.settle(process.env.HA_ROOT, [",
-              "  { target: 'events/ab/first.json', body: 'first' },",
-              "  { target: 'events/ab/second.json', body: 'second' },",
-              "], { beforeRename: () => process.kill(process.pid, 'SIGKILL') });",
-            ].join("\n"),
-          ],
-          { encoding: "utf8", env: { ...process.env, HA_ROOT: repoRoot } },
-        );
-      assert.equal(child.signal, "SIGKILL", child.stderr);
-      assert.throws(() => process.kill(child.pid, 0), { code: "ESRCH" });
-      // Negative control: the durable bodies exist under their marker names and nothing renamed them.
-      assert.deepEqual(markers(directory), [`.ha-settle-${child.pid}-0`, `.ha-settle-${child.pid}-1`]);
-      assert.equal(existsSync(path.join(directory, "first.json")), false);
-      const untouched = plant(path.join(repoRoot, "objects", "zz"), `.ha-settle-${child.pid}-0`);
-
-      localGitWorktreeSettlement.settle(repoRoot, [{ target: "events/ab/third.json", body: "third" }]);
-
-      assert.deepEqual(markers(directory), []);
-      assert.equal(readFileSync(path.join(directory, "third.json"), "utf8"), "third");
-      assert.match(git(repoRoot, "ls-files", "--stage", "events/ab/third.json"), /^100644 /u);
-      // Only the directories this settlement touched are swept; cold directories are left alone.
-      assert.equal(existsSync(untouched), true);
-    });
-  },
-);
-
-test("settle keeps markers owned by live, own, or unparseable pids while reclaiming the dead one beside them", async () => {
-  await withTempStoreAsync(async (rootDir) => {
-    const repoRoot = ledger(rootDir),
-      directory = path.join(repoRoot, "events", "cd"),
-      bystander = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"], { stdio: "ignore" });
-    try {
-      await once(bystander, "spawn");
-      const live = plant(directory, `.ha-settle-${bystander.pid}-0`),
-        own = plant(directory, `.ha-visible-${process.pid}-41`),
-        garbage = plant(directory, ".ha-settle-not-a-pid-0"),
-        zero = plant(directory, ".ha-settle-0-0"),
-        dead = plant(directory, `.ha-settle-${deadPid()}-0`);
-
-      localGitWorktreeSettlement.settle(repoRoot, [{ target: "events/cd/entry.json", body: "entry" }]);
-
-      assert.equal(existsSync(live), true, "a live foreign writer keeps its in-flight marker");
-      assert.equal(existsSync(own), true, "our own markers are only reclaimed by same-index reuse");
-      assert.equal(existsSync(garbage), true, "names that do not parse as a marker are never touched");
-      assert.equal(existsSync(zero), true, "pid 0 is not a marker owner");
-      assert.equal(existsSync(dead), false, "the dead writer's marker is reclaimed");
-      assert.equal(readFileSync(path.join(directory, "entry.json"), "utf8"), "entry");
-    } finally {
-      bystander.kill("SIGKILL");
-    }
-  });
-});
-
-test("settle keeps a marker whose owner it is not permitted to probe", (t) => {
-  let probe: string | null = null;
-  try {
-    process.kill(1, 0);
-  } catch (error) {
-    probe = (error as NodeJS.ErrnoException).code ?? "unknown";
-  }
-  if (probe === "ESRCH") return t.skip("pid 1 is not visible on this platform");
-  withTempStore((rootDir) => {
-    const repoRoot = ledger(rootDir),
-      directory = path.join(repoRoot, "events", "ef"),
-      marker = plant(directory, ".ha-settle-1-0");
-
-    localGitWorktreeSettlement.settle(repoRoot, [{ target: "events/ef/entry.json", body: "entry" }]);
-
-    // EPERM (or a permitted probe of a live pid 1) must fail safe toward keeping the marker.
-    assert.equal(existsSync(marker), true, `probe outcome ${probe ?? "permitted"} must not delete`);
-    assert.equal(readFileSync(path.join(directory, "entry.json"), "utf8"), "entry");
-  });
-});
-
-test("settle sweeps each directory once per process, so leftovers from a later death wait for the next process", () => {
-  withTempStore((rootDir) => {
-    const repoRoot = ledger(rootDir),
-      directory = path.join(repoRoot, "events", "gh"),
-      first = plant(directory, `.ha-settle-${deadPid()}-0`);
-    localGitWorktreeSettlement.settle(repoRoot, [{ target: "events/gh/one.json", body: "one" }]);
-    assert.equal(existsSync(first), false);
-
-    const later = plant(directory, `.ha-settle-${deadPid()}-0`);
-    localGitWorktreeSettlement.settle(repoRoot, [{ target: "events/gh/two.json", body: "two" }]);
-
-    // Bounded cost: the readdir runs once per directory per process. The failure that
-    // leaves markers behind (a killed writer) is always followed by a fresh process.
-    assert.equal(existsSync(later), true);
-    assert.equal(readFileSync(path.join(directory, "two.json"), "utf8"), "two");
-  });
-});
 
 test("visible reclaims dead markers of both families in the directory it writes", () => {
   withTempStore((rootDir) => {
@@ -167,40 +52,5 @@ test("visible reclaims dead markers of both families in the directory it writes"
     assert.equal(existsSync(settleMarker), false);
     assert.equal(existsSync(visibleMarker), false);
     assert.equal(readFileSync(path.join(directory, "INDEX.md"), "utf8"), "# t1\n");
-  });
-});
-
-test("settle still writes, renames, deletes, and indexes with the sweep in its path", () => {
-  withTempStore((rootDir) => {
-    const repoRoot = ledger(rootDir);
-    localGitWorktreeSettlement.settle(repoRoot, [
-      { target: "events/ij/keep.json", body: "keep" },
-      { target: "events/ij/old.json", body: "old" },
-      { target: "events/ij/gone.json", body: "gone" },
-    ]);
-    const leftover = plant(path.join(repoRoot, "events", "kl"), `.ha-settle-${deadPid()}-0`);
-
-    const touched = localGitWorktreeSettlement.settle(repoRoot, [
-      { target: "events/kl/new.json", body: "new" },
-      { from: "events/ij/old.json", to: "events/kl/moved.json" },
-      { delete: "events/ij/gone.json" },
-    ]);
-
-    assert.equal(touched, 3 + 2, "three files across two directories");
-    assert.equal(readFileSync(path.join(repoRoot, "events", "kl", "new.json"), "utf8"), "new");
-    assert.equal(readFileSync(path.join(repoRoot, "events", "kl", "moved.json"), "utf8"), "old");
-    assert.equal(readFileSync(path.join(repoRoot, "events", "ij", "keep.json"), "utf8"), "keep");
-    assert.equal(existsSync(path.join(repoRoot, "events", "ij", "old.json")), false);
-    assert.equal(existsSync(path.join(repoRoot, "events", "ij", "gone.json")), false);
-    assert.equal(existsSync(leftover), false);
-    assert.deepEqual(markers(path.join(repoRoot, "events", "ij")), []);
-    assert.deepEqual(markers(path.join(repoRoot, "events", "kl")), []);
-    assert.deepEqual(
-      git(repoRoot, "ls-files", "--stage")
-        .split("\n")
-        .map((line) => line.split("\t")[1])
-        .sort(),
-      ["events/ij/keep.json", "events/kl/moved.json", "events/kl/new.json"],
-    );
   });
 });

--- a/packages/kernel/test/store/sqlite-event-store.integration.test.ts
+++ b/packages/kernel/test/store/sqlite-event-store.integration.test.ts
@@ -320,7 +320,7 @@ function generatedTaskAmendment(
   return compileTaskLifecycleWrite({ event, snapshot, packagePath, currentDocuments });
 }
 
-test("SQLite content admission reuses exact objects after reopen and rejects corrupt or missing objects atomically", async () => {
+test("SQLite content admission reuses exact objects after reopen and rejects missing objects atomically", async () => {
   const rootDir = mkdtempSync(path.join(tmpdir(), "ha-sqlite-content-admission-")),
     body = "# Shared content\n",
     hash = sha256Text(body),
@@ -345,14 +345,6 @@ test("SQLite content admission reuses exact objects after reopen and rejects cor
     assert.deepEqual(reopened.readContentBlob(hash), Buffer.from(body));
     assert.ok(reopened.readCommandOutcome(reused.event.opId));
 
-    writeFileSync(objectPath, "corrupt object\n");
-    const corrupt = docBundle(reopened, body, 3, "content-corrupt", "context/corrupt.md");
-    assert.throws(() => reopened.append(corrupt), /content object .* is corrupt/u);
-    assert.equal(reopened.readEvent(corrupt.event.opId), null);
-    assert.equal(reopened.readCommandOutcome(corrupt.event.opId), null);
-    assert.equal(reopened.currentCut().revision, 2);
-    writeFileSync(objectPath, body);
-
     const missingBody = "# Missing input\n",
       missing = docBundle(reopened, missingBody, 3, "content-missing", "context/missing.md");
     assert.throws(
@@ -364,7 +356,6 @@ test("SQLite content admission reuses exact objects after reopen and rejects cor
     assert.equal(reopened.readContentBlob(sha256Text(missingBody)), null);
     assert.equal(reopened.currentCut().revision, 2);
   } finally {
-    writeFileSync(objectPath, body);
     await reopened.drain();
   }
 });

--- a/packages/kernel/test/store/task-event-store.test.ts
+++ b/packages/kernel/test/store/task-event-store.test.ts
@@ -357,6 +357,29 @@ test("successive Git cuts settle managed files while leaving the caller index un
   }
 });
 
+test("materializing the whole closure again leaves an already-settled file untouched", async () => {
+  const rootDir = fixture("materialize-no-rewrite");
+  initRepo(rootDir);
+  const store = makeTaskEventStore({ repoId, rootDir, writerFence }),
+    target = path.join(rootDir, "harness/context/steady.md");
+  try {
+    store.append(docBundle(store, "steady content\n", 1, "materialize-steady", "context/steady.md"));
+    await store.settlePendingMaterialization!("initial publication");
+    const before = statSync(target);
+
+    // materialize() forces restoreMissing, so it re-settles the whole closure, not just the delta:
+    // a file that already holds its accepted bytes must not be rewritten a second time.
+    store.materialize();
+
+    const after = statSync(target);
+    assert.equal(after.ino, before.ino);
+    assert.equal(after.mtimeMs, before.mtimeMs);
+    assert.equal(readFileSync(target, "utf8"), "steady content\n");
+  } finally {
+    await store.drain();
+  }
+});
+
 test("new cuts cannot certify worktree visibility over an older unresolved document conflict", async () => {
   const rootDir = fixture("older-conflict");
   initRepo(rootDir);

--- a/tools/gate-allowlists/check-bypass-write-boundary.json
+++ b/tools/gate-allowlists/check-bypass-write-boundary.json
@@ -426,12 +426,6 @@
         "reason": "RepoCell-owned settlement atomically publishes the authored target."
       },
       {
-        "value": "bypass-write-083",
-        "api": "mkdirSync",
-        "ref": "task_01KZWZEW11C499EACS9M5HVJZ8",
-        "reason": "Materialization creates only Git's local info directory for scratch exclusion."
-      },
-      {
         "value": "bypass-write-084",
         "api": "writeFileSync",
         "ref": "task_01KZWZEW11C499EACS9M5HVJZ8",
@@ -484,12 +478,6 @@
         "api": "closeSync",
         "ref": "task_01KZWZEW11C499EACS9M5HVJZ8",
         "reason": "Materialization closes the temporary conflict scratch."
-      },
-      {
-        "value": "bypass-write-093",
-        "api": "renameSync",
-        "ref": "task_01KZWZEW11C499EACS9M5HVJZ8",
-        "reason": "Materialization atomically publishes the deterministic conflict scratch."
       },
       {
         "value": "bypass-write-094",


### PR DESCRIPTION
# English

## Summary

The SQLite event store now reads the digest it already stored instead of re-serializing and re-hashing events and objects on every write. Several store paths called `head()`, and each call re-parsed, re-serialized and sha256-hashed the head event, about 11 times per durable write. Receipt cuts and `publication()` did the same for their event. Every row read re-validated, re-normalized and re-serialized the event and compared it to the stored bytes. Every write re-read and re-hashed each content object it reused, and hashed new blobs again after admission had already checked them. This is batch B1 of the daemon write-path rescue that followed #2407, #2408 and #2409, based on a 12-report read-only audit of the three days after the SQLite cutover.

## Architectural Justification

- **Digest invariant.** `digest = sha256(event_json)` is written once, at append. `head()`, the append receipt cut and follower publication now read `revision`, `op_id` and `digest` from that row through `eventIdentity`/`eventIdentityAtRevision`. `publication(event)` still derives the cut from the event it is given: migration import asks for the cut of a prepared event before that event is committed.
- **One validation per event.** An event passes canonical validation exactly once, at admission (`assertBundle`, and `planConversion` for generation conversion). Row reads therefore use `JSON.parse`. Before this change, any stored bytes that did not match their re-normalized form already failed to read, so the parsed values are identical.
- **One hash per new blob.** Admission hashes each new content blob once. A reused stored object is now checked for existence only. Detecting disk corruption of a stored object belongs to an explicit verification pass, not to every write that references it.
- **Smaller per-write work.**
  - The append baseline reads the worktree node only for task and prose claims.
  - CRLF normalization re-hashes only when the body contains `\r\n`.
  - The follower skips targets that already hold their settled bytes instead of rewriting them.
- **Deleted as unused.** `readNode`'s `gitOid` sha1 and `localGitWorktreeSettlement.settle()` had no production caller.
- **Kept.** `intentDigest` stays as it is. Generation conversion carries the source repository's `intentDigest` unchanged, and `verify()` asserts that the command outcome is preserved exactly, so recomputing it in `appendCommand` would break that history guarantee.

## What Changed

- `sqlite-event-store.ts`:
  - `eventIdentity` and `eventIdentityAtRevision` read the stored identity.
  - Row reads use `JSON.parse`.
  - The second `validateCurrentCanonicalEvent` inside `appendCommand` is removed.
  - `prepareContentObjects` checks existence for stored objects and drops the second hash of new blobs.
- `sqlite-task-event-store.ts`:
  - `head()` reads the stored identity.
  - The append receipt cut uses `canonicalEventCutFromHead`. `publication(event)` is unchanged.
  - The append baseline narrows to task and prose claims.
  - The follower skips settled targets.
- `task-event-store-contract.ts`: adds `canonicalEventCutFromHead`.
- `sqlite-task-event-publication.ts`: the local `eventHead()` re-hash and its 4 call sites now use the stored identity.
- `local-version-control-system.ts`: removes the `gitOid` sha1 and `settle()`.
- `tools/gate-allowlists/check-bypass-write-boundary.json`: removes `bypass-write-083` and `bypass-write-093`, the two `settle()` filesystem writes deleted with it.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Deleted production behavior (no file removed):
  - the head, receipt-cut and publication re-serialize-and-hash;
  - row-read re-validation;
  - the second append-time validation;
  - the per-write re-read and re-hash of stored objects;
  - the second new-blob hash;
  - rewriting settled follower targets;
  - the unread `gitOid` sha1;
  - `settle()`.
- Production net lines: +67/-195, net -128.

## Machine-Readable Declarations

## Task And Scope

- Harness task: task_f9f5dca6b90e976be22562fd64 (B1), parent task_2b8f79fa4412cb726a26f9bfc7
- Branch: `codex/del-b1-store-core`
- Public scope: kernel SQLite event store, task event store, publication follower, local version control helpers, and their tests
- Private planning/evidence updated: yes (report `artifacts/b1-report.md` in the task package)
- Out of scope: `intentDigest`, for the reason above; the other deletion batches land as separate PRs.

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: yes
- Protected surface scope: tools/gate-allowlists/check-bypass-write-boundary.json (removes the two entries for the settle() writes this PR deletes)
- Authority: dec_EF5F3820E81FB8A5266F1F3342 (write-path cost decision, in effect) and task_f9f5dca6b90e976be22562fd64; the gate requires the allowlist to match the code, and this PR deletes the code the entries named
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `be6ab925f` (after #2410 and #2412)
- Branch merge-base with `origin/main`: `be6ab925f`
- Last `git fetch origin` time: 2026-09-10 14:10 UTC
- Sync method: rebase onto origin/main
- Public diff command: `git diff origin/main...codex/del-b1-store-core`
- Private evidence commit/path: task package report `artifacts/b1-report.md`
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [x] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Red before, green after. The new `task-event-store.test.ts` case materializes the whole closure again and asserts that an already-settled file keeps its inode. With the old `eligible` filter restored the inode changed and the case failed; with this change it passes.
- Docker-isolated on the rebased head (`node tools/dispatch-isolated-test.mjs --target docker --file <file>`):

  | Test file | Passed |
  |---|---|
  | `sqlite-event-store.integration.test.ts` | 24/24 |
  | `task-event-store.test.ts` | 15/15 |
  | `task-event-store-replacement-authorization.test.ts` | 1/1 |
  | `legacy-generation-conversion.integration.test.ts` | 10/10 |
  | `cli/generation-conversion.integration.test.ts` | 11/11 |
  | `fleet-writer-epoch.integration.test.ts` | 8/8 |
  | `projection-query-shape.test.ts` | 10/10 |
  | `doc-sync-slice-a.test.ts` | 12/12 |

  The CLI generation-conversion run includes the real offline conversion that checks `intentDigest` and outcome preservation. The worker also ran `generation-two-content`, `ledger-backup`, `legacy-entity-declaration-follower`, `agent-action` and the kernel fast tier (132/132), all green.
- `npx tsc -b` (whole repository) and `node tools/run-manifest-gates.mjs --changed origin/main` passed on the rebased head.
- Existing tests changed, and why each is safe:
  - Content admission no longer asserts that a hand-corrupted stored object is caught at append, because that per-write re-hash is the deleted behavior. Reuse without rewrite, and rejection of a missing blob, are still asserted.
  - Six `local-version-control-settlement.test.ts` cases tested only `settle()`, which has no production caller, and are deleted with it.
  - `owner-named-temporary-write-paths.test.ts` drops the `.ha-settle-` temporary-name entry that no longer exists.
- Not run: the full `npm run check` / `npm test` locally. Local agents must not run the full matrix, so CI is the full authority.

## Review Evidence

- Self-review: the lead read the full production diff.
  - `JSON.parse` reads return the same values that `parseCanonicalEvent` returned, because that function rejected any stored bytes that differed from their normalized form.
  - `head()` still exposes `eventDigest`, which the projection catch-up merged in #2412 now reads.
  - `intentDigest` was left alone because of the generation-conversion history check.
  - The stored-object corruption check is deliberately removed from the write path.
- Rebase: after rebasing onto main with B3 (#2410) and B4 (#2412), the lead re-ran the cross-batch tests listed above.
- First CI round, two fixes by the lead: the worker had moved `publication(event)` to a stored-identity lookup, which crashed migration import (it asks for the cut of a prepared, uncommitted event), so it is restored; and two bypass allowlist entries for the deleted `settle()` were removed. Afterwards `migration-import-acceptance`, `migration-import-rosters-multisource` and `cli/migration-multi-source-cli` pass in Docker.
- Reviewer subagent: a Sonnet implementation worker wrote the change; the lead reviewed it
- Human review: pending
- Blocking findings: none

## Residual Risk

- Appends no longer detect corruption of a stored content object on disk. A corrupted object would be served as it is until an explicit verification pass reads it.
- `intentDigest` is still re-serialized once per append. Removing it needs a generation-conversion design change and is not part of this batch.

## References

- Audit: `artifacts/audit-3day/00-ranked-deletions.md` (B1) and `H1-hash-kernel-store.md` in task_2b8f79fa4412cb726a26f9bfc7
- Previous batches: PR #2407, PR #2408, PR #2409, PR #2410, PR #2412

---

# 中文

## 概要

SQLite 事件存储现在直接读已经存好的 digest，不再在每次写入时重新序列化、重新哈希事件和对象。store 有好几条路径调用 `head()`，每次都把 head 事件重新解析、重新序列化、做一次 sha256，一次 durable 写入大约调用 11 次；回执 cut 和 `publication()` 对各自的事件也这样做。每次读行都把事件重新校验、重新规范化、重新序列化，再和存储的字节比对。每次写入都把复用的每个内容对象重读、重哈希一遍，新 blob 在受理检查之后又被哈希一次。本 PR 是 #2407、#2408、#2409 之后 daemon 写路径抢救的 B1 批次，依据是对 SQLite 切换后三天所做的 12 份只读审计。

## 架构辩护

- **digest 不变量。** `digest = sha256(event_json)` 只在 append 时写入一次。`head()`、append 回执 cut 和 follower 发布现在都经由 `eventIdentity`/`eventIdentityAtRevision` 从这一行读取 `revision`、`op_id`、`digest`。`publication(event)` 仍然按传入的事件计算 cut：迁移导入会在事件提交之前询问已准备事件的 cut。
- **每个事件只校验一次。** 事件只在受理时通过一次 canonical 校验（`assertBundle`；generation 转换时是 `planConversion`），所以读行直接用 `JSON.parse`。在本改动之前，存储字节只要和重新规范化后的形式不一致就会读取失败，所以解析出的值完全相同。
- **每个新 blob 只哈希一次。** 受理时对每个新内容 blob 哈希一次；复用的已存对象现在只检查是否存在。检测已存对象的磁盘损坏应该交给显式的校验流程，而不是每次引用它的写入都做一遍。
- **每次写入的工作更少：**
  - append baseline 只对 task claim 和 prose claim 读取 worktree 节点；
  - CRLF 规范化只在正文含 `\r\n` 时才重新哈希；
  - follower 跳过已经是结算后字节的目标，不再重写。
- **删除无人使用的代码。** `readNode` 的 `gitOid`（sha1）和 `localGitWorktreeSettlement.settle()` 在生产代码里没有调用方。
- **保留不动。** `intentDigest` 保持原样：generation 转换会原样携带源仓库的 `intentDigest`，`verify()` 断言命令结果被完整保留；在 `appendCommand` 里重算会破坏这项历史保证。

## 改动内容

- `sqlite-event-store.ts`：
  - `eventIdentity`、`eventIdentityAtRevision` 读取已存的 identity；
  - 读行改用 `JSON.parse`；
  - 删掉 `appendCommand` 里的第二次 `validateCurrentCanonicalEvent`；
  - `prepareContentObjects` 对已存对象只检查存在，并删掉新 blob 的第二次哈希。
- `sqlite-task-event-store.ts`：
  - `head()` 读取已存的 identity；
  - append 回执 cut 改用 `canonicalEventCutFromHead`，`publication(event)` 不变；
  - append baseline 收窄到 task claim 和 prose claim；
  - follower 跳过已结算的目标。
- `task-event-store-contract.ts`：新增 `canonicalEventCutFromHead`。
- `sqlite-task-event-publication.ts`：本地的 `eventHead()` 重哈希及其 4 处调用改为读取已存的 identity。
- `local-version-control-system.ts`：删除 `gitOid`（sha1）和 `settle()`。
- `tools/gate-allowlists/check-bypass-write-boundary.json`：删除 `bypass-write-083` 与 `bypass-write-093`，即随 `settle()` 一起删掉的两处文件系统写入。

## 门收割 / Gate Harvest

- 删除的生产路径：none（没有删文件）
- 删除的门或 fixture：none
- 删除的生产行为：
  - head、回执 cut、publication 的重新序列化与哈希；
  - 读行时的重新校验；
  - append 时的第二次校验；
  - 每次写入对已存对象的重读与重哈希；
  - 新 blob 的第二次哈希；
  - 重写已结算的 follower 目标；
  - 没人读的 `gitOid`（sha1）；
  - `settle()`。
- 生产净行数：+67/-195，净 -128。

## 机读声明说明

- 本 PR 不涉及依赖变化和事件迁移，没有机读声明。

## 任务与范围

- Harness 任务：task_f9f5dca6b90e976be22562fd64（B1），父任务 task_2b8f79fa4412cb726a26f9bfc7
- 分支：`codex/del-b1-store-core`
- 公开范围：kernel 的 SQLite 事件存储、任务事件存储、发布 follower、本地版本控制辅助函数，以及对应测试
- 私有计划 / 证据是否已更新：yes（任务包里的报告 `artifacts/b1-report.md`）
- 范围外：`intentDigest`，理由见上；其它删除批次分别开 PR。

## 版本影响

- 版本：不改版本
- 发布影响：不发布

## 治理声明

- 是否触碰 protected surface：yes
- protected surface 范围：tools/gate-allowlists/check-bypass-write-boundary.json (removes the two entries for the settle() writes this PR deletes)
- 依据：dec_EF5F3820E81FB8A5266F1F3342（写路径成本 decision，已生效）与 task_f9f5dca6b90e976be22562fd64；门要求白名单与代码一致，本 PR 删除了这些条目所指的代码
- 机器检查边界：本 PR 只声明该段存在；声明是否真实、充分，由 reviewer 判断。
- Break-glass：no
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- `origin/main` 基准 SHA：`be6ab925f`（#2410、#2412 合入之后）
- 当前分支与 `origin/main` 的 merge-base：`be6ab925f`
- 最近一次 `git fetch origin` 时间：2026-09-10 14:10 UTC
- 同步方式：rebase 到 origin/main
- 公开 diff 命令：`git diff origin/main...codex/del-b1-store-core`
- 私有证据 commit/path：任务包报告 `artifacts/b1-report.md`
- Reviewer 证据路径：见本 PR 的「审查证据」一节
- GitHub Actions `rewrite-ci` run URL：本 PR 的 CI 还在跑
- [ ] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [x] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- 修复前红、修复后绿：`task-event-store.test.ts` 的新用例再次物化整个闭包，断言已结算文件的 inode 不变。恢复旧的 `eligible` 过滤时 inode 改变、用例失败；应用本改动后通过。
- 在 rebase 后的 head 上，于 Docker 隔离环境运行（`node tools/dispatch-isolated-test.mjs --target docker --file <file>`）：

  | 测试文件 | 通过 |
  |---|---|
  | `sqlite-event-store.integration.test.ts` | 24/24 |
  | `task-event-store.test.ts` | 15/15 |
  | `task-event-store-replacement-authorization.test.ts` | 1/1 |
  | `legacy-generation-conversion.integration.test.ts` | 10/10 |
  | `cli/generation-conversion.integration.test.ts` | 11/11 |
  | `fleet-writer-epoch.integration.test.ts` | 8/8 |
  | `projection-query-shape.test.ts` | 10/10 |
  | `doc-sync-slice-a.test.ts` | 12/12 |

  CLI 的 generation-conversion 用例包含真实的离线转换，会检查 `intentDigest` 和命令结果是否被保留。worker 另外跑过 `generation-two-content`、`ledger-backup`、`legacy-entity-declaration-follower`、`agent-action` 和 kernel fast tier（132/132），全部通过。
- 在 rebase 后的 head 上，`npx tsc -b`（全仓）与 `node tools/run-manifest-gates.mjs --changed origin/main` 通过。
- 修改过的现有测试，以及为什么安全：
  - 内容受理测试不再断言「手工损坏的已存对象会在 append 时被发现」，因为这项逐写重哈希正是被删除的行为；复用时不重写、缺失 blob 被拒这两点仍有断言。
  - `local-version-control-settlement.test.ts` 里 6 个只测 `settle()` 的用例随它一起删除，`settle()` 在生产代码里没有调用方。
  - `owner-named-temporary-write-paths.test.ts` 删掉已不存在的 `.ha-settle-` 临时文件名条目。
- 未运行：本地整套 `npm run check` / `npm test`。规定禁止本地 agent 跑全量矩阵，全量以 CI 为准。

## 审查证据

- 自查：主控读完整个生产 diff，确认了以下几点。
  - 用 `JSON.parse` 读出的值与 `parseCanonicalEvent` 读出的完全相同：那个函数会拒绝任何与规范化形式不一致的存储字节。
  - `head()` 仍然提供 `eventDigest`，#2412 合入的投影 catch-up 正在读它。
  - `intentDigest` 因为 generation 转换的历史检查而保留不动。
  - 已存对象的损坏检查是有意从写路径上删掉的。
- Rebase：rebase 到已包含 B3（#2410）和 B4（#2412）的 main 之后，主控重跑了上面列出的交叉测试。
- 第一轮 CI 后主控做了两处修复：worker 把 `publication(event)` 改成读已存 identity，导致迁移导入崩溃（它会询问尚未提交的已准备事件的 cut），已恢复原算法；并删掉两条随 `settle()` 一起失效的 bypass 白名单条目。修复后 `migration-import-acceptance`、`migration-import-rosters-multisource`、`cli/migration-multi-source-cli` 在 Docker 里通过。
- Reviewer subagent：改动由 Sonnet 实现 worker 编写，主控审查
- 人工审查：待进行
- 阻塞发现：无

## 残余风险

- append 不再检测磁盘上已存内容对象的损坏；损坏的对象会被原样读出，直到显式的校验流程读到它为止。
- `intentDigest` 仍然每次 append 重新序列化一次。去掉它需要改 generation 转换的设计，不在本批次范围内。

## 关联材料

- 审计：task_2b8f79fa4412cb726a26f9bfc7 的 `artifacts/audit-3day/00-ranked-deletions.md`（B1 节）与 `H1-hash-kernel-store.md`
- 前几批：PR #2407、PR #2408、PR #2409、PR #2410、PR #2412

---

## PR Gate Checklist / PR 门禁清单

- [x] Branch is based on latest `origin/main`. / 分支基于最新 `origin/main`。
- [x] PR body uses this full template structure. / PR 描述使用本模板完整结构。
- [x] PR body uses two complete language blocks: `# English` first, then `# 中文`. / PR 正文使用两块完整正文：`# English` 在上，`# 中文` 在下。
- [x] PR body passes `tools/check-pr-body-bilingual.mjs`. / PR 正文通过 `tools/check-pr-body-bilingual.mjs`。
- [x] If the PR touches a manifest-derived protected surface, Governance Declaration is filled with ADR/decision/task evidence or break-glass fields. / 若 PR 触碰 manifest 派生的 protected surface，Governance Declaration 已填写 ADR/decision/task 依据或 break-glass 字段。
- [x] No private harness files are included. / 不包含私有 harness 文件。
- [x] No ignored local agent entry files are included. / 不包含被忽略的本地 agent 入口文件。
- [x] No absolute local filesystem paths are included in this public PR body. / 本公开 PR 描述不包含本机绝对路径。
- [x] Public diff is limited to the stated task scope. / 公开 diff 限于声明的任务范围。
- [x] Private planning/evidence updates are recorded when applicable. / 适用时已记录私有计划 / 证据更新。
- [x] Version and publish impact are stated. / 已说明版本与发布影响。
- [x] Local verification commands are recorded honestly. / 已如实记录本地验证命令。
- [ ] CI results are linked or explained. / CI 结果已链接或说明。
- [x] Review evidence is recorded. / 已记录审查证据。
- [x] Open P0/P1/P2 findings are closed, deferred with owner, or explicitly blocked. / open P0/P1/P2 findings 已关闭、带 owner 延后，或明确阻塞。
- [x] Merge method and post-merge branch cleanup plan are clear. / 合并方式和合并后分支清理计划清楚。
- [x] No admin bypass is planned unless explicitly approved and recorded. / 除非明确批准并记录，否则不计划 admin bypass。
