### PR TITLE
perf: verify content inputs once at the store boundary

### DIFF
--- a/packages/daemon/src/artifact-entity-action.ts
+++ b/packages/daemon/src/artifact-entity-action.ts
@@ -233,7 +233,7 @@ export function executeArtifactEntityMutation(input: {
             compiled,
             contractSnapshot,
             { ...envelope, opId },
-            carriedContent(input.store, pinned, entityId, current.ownedContent),
+            carriedContent(pinned, entityId, current.ownedContent),
             carriedDirectories(pinned, entityId, current.ownedContent),
             entityDirectoryFootprint(entityContentRoot(pinned, entityId), current.ownedContent),
           )
@@ -303,7 +303,7 @@ function updatedBundle(
     readonly source: RepoCellBinding["source"];
     readonly occurredAt: string;
   },
-  carried: readonly EntityContentBlob[],
+  carried: readonly Omit<EntityContentBlob, "body">[],
   carriedDirectories: readonly string[],
   heldDirectories: readonly string[],
 ) {
@@ -731,21 +731,19 @@ export function resolveSourceBinding(
   return { entityId: null, generation };
 }
 
-/** The content objects an entity already owns, restated from the ledger so an update carries them forward. */
+/** The content objects an entity already owns, restated as manifest metadata so an update carries them forward. */
 function carriedContent(
-  store: CanonicalEventStore,
   contract: EntityStoreKindContract,
   entityId: string,
   ownedContent: EntityOwnedContentV1 | null,
-): readonly EntityContentBlob[] {
+): readonly Omit<EntityContentBlob, "body">[] {
   if (!ownedContent) return [];
   const root = `${entityContentRoot(contract, entityId)}/`,
-    sizes = new Map(ownedContent.content.map((entry) => [entry.sha256, entry]));
+    objects = new Map(ownedContent.content.map((entry) => [entry.sha256, entry]));
   return ownedContent.bindings.flatMap(({ path: bound, contentSha256, policyId }) => {
     if (!bound.startsWith(root)) return [];
-    const bytes = store.readContentBlob(contentSha256),
-      object = sizes.get(contentSha256);
-    if (!bytes || !object) throw new Error(`Entity content object ${contentSha256} is unavailable.`);
+    const object = objects.get(contentSha256);
+    if (!object) throw new Error(`Entity content object ${contentSha256} is unavailable.`);
     return [
       {
         relativePath: bound.slice(root.length),
@@ -753,7 +751,6 @@ function carriedContent(
         size: object.byteLength,
         mediaType: object.mediaType,
         policyId,
-        body: bytes,
       },
     ];
   });

--- a/packages/daemon/test/entity-content-lifecycle.integration.test.ts
+++ b/packages/daemon/test/entity-content-lifecycle.integration.test.ts
@@ -523,6 +523,13 @@ test("Deleting an entity is refused for a caller with no repository write role",
       ),
       entityId = (JSON.parse(String(imported.evidence)) as { preview: { entityId: string } }).preview.entityId;
     assert.equal(imported.outcome, "applied", JSON.stringify(imported));
+    // Writes return at acceptance; the worktree follower settles afterwards, so wait before checking the file.
+    const visible = await cell.run(
+      { kind: "receipt-show", opId: imported.opId, waitFor: ["worktree_visible"], timeoutMs: 5_000 },
+      binding,
+    );
+    assert.equal((visible as { wait?: { state?: string } }).wait?.state, "satisfied", JSON.stringify(visible));
+    assert.equal(existsSync(path.join(rootDir, "harness", `entities/research/${entityId}.json`)), true);
 
     const request = {
         kind: "entity-delete",

--- a/packages/kernel/src/domain/entity-event-compile.ts
+++ b/packages/kernel/src/domain/entity-event-compile.ts
@@ -189,7 +189,11 @@ export function compileEntityUpdated(
     readonly contract: EntityStoreKindContract;
     readonly contractSnapshot: ArtifactEntityContractSnapshot;
     readonly descriptor: ArtifactDescriptor;
-    readonly sourceContent?: readonly EntityContentBlob[];
+    /**
+     * Owned content restated as manifest metadata; the store already holds those bytes, so only
+     * new content is carried.
+     */
+    readonly sourceContent?: readonly Omit<EntityContentBlob, "body">[];
     readonly sourceDirectories?: readonly string[];
     readonly retirements?: readonly EntityContentRetirement[];
     readonly heldDirectories?: readonly string[];
@@ -228,7 +232,7 @@ export function compileEntityUpdated(
   return {
     event,
     plan: declarationWritePlan("EntityUpdated", event, "entity/v1"),
-    blobs: [blob(claim, body), ...sourceContent],
+    blobs: [blob(claim, body)],
   };
 }
 

--- a/packages/kernel/src/domain/entity-event.ts
+++ b/packages/kernel/src/domain/entity-event.ts
@@ -342,13 +342,7 @@ export function assertEntityEventInputs(
   const claim = event.payload.declarationDocumentClaim,
     declarationBlob = blobs.find((candidate) => candidate.sha256 === claim.sha256),
     contract = contractForDeclarationEvent(event);
-  if (
-    !declarationBlob ||
-    declarationBlob.size !== claim.size ||
-    declarationBlob.mediaType !== claim.mediaType ||
-    typeof declarationBlob.body !== "string" ||
-    sha256Text(declarationBlob.body) !== claim.sha256
-  )
+  if (!declarationBlob || typeof declarationBlob.body !== "string")
     throw new Error("entity declaration blob must be exact");
   let value: unknown;
   try {
@@ -696,7 +690,7 @@ export function declarationOwnedContent(
   contract: EntityStoreKindContract,
   entityId: string,
   claim: EntityDeclarationClaim,
-  sourceContent: readonly EntityContentBlob[] = [],
+  sourceContent: readonly Omit<EntityContentBlob, "body">[] = [],
   owned: {
     readonly directories?: readonly string[];
     readonly retirements?: readonly EntityContentRetirement[];

--- a/packages/kernel/src/domain/people-event.ts
+++ b/packages/kernel/src/domain/people-event.ts
@@ -277,8 +277,7 @@ export function assertPeopleEventInputs(
   assertPeopleEventWritePlan(event, plan);
   const claim = event.payload.peopleDocumentClaim,
     blob = blobs.find((candidate) => candidate.sha256 === claim.sha256);
-  if (!blob || blob.size !== claim.size || blob.mediaType !== claim.mediaType || sha256Text(blob.body) !== claim.sha256)
-    throw new Error("people.yaml blob must be exact");
+  if (!blob) throw new Error("people.yaml blob must be exact");
   const roster = parsePeopleRosterDocument(blob.body);
   if (stableStringify(roster) !== stableStringify(event.payload.roster))
     throw new Error("people.yaml blob must contain the exact roster snapshot");

--- a/packages/kernel/src/domain/schedule-event.ts
+++ b/packages/kernel/src/domain/schedule-event.ts
@@ -339,8 +339,7 @@ export function assertScheduleEventInputs(
   }
   const claim = event.payload.declarationDocumentClaim,
     blob = blobs.find((candidate) => candidate.sha256 === claim.sha256);
-  if (!blob || blob.size !== claim.size || blob.mediaType !== claim.mediaType || sha256Text(blob.body) !== claim.sha256)
-    throw new Error("schedule definition blob must be exact");
+  if (!blob) throw new Error("schedule definition blob must be exact");
   let value: unknown;
   try {
     value = JSON.parse(blob.body);

--- a/packages/kernel/src/domain/settings-event.ts
+++ b/packages/kernel/src/domain/settings-event.ts
@@ -217,8 +217,7 @@ export function assertSettingsEventInputs(
   assertSettingsEventWritePlan(event, plan);
   const claim = event.payload.harnessDocumentClaim,
     blob = blobs.find((candidate) => candidate.sha256 === claim.sha256);
-  if (!blob || blob.size !== claim.size || blob.mediaType !== claim.mediaType || sha256Text(blob.body) !== claim.sha256)
-    throw new Error("settings harness.yaml blob must be exact");
+  if (!blob) throw new Error("settings harness.yaml blob must be exact");
   if (
     stableStringify(repositorySettings(readSettingsFacet(blob.body))) !==
     stableStringify(repositorySettings(event.payload.settings))

--- a/packages/kernel/src/domain/task-snapshot-upgrade-store-seam.ts
+++ b/packages/kernel/src/domain/task-snapshot-upgrade-store-seam.ts
@@ -24,18 +24,6 @@ export function assertSnapshotUpgradeInputs(
   blobs: readonly SnapshotUpgradeBlob[],
 ): void {
   assertPresetSnapshotUpgradeWritePlan(event, plan as FrozenWritePlan<"PresetSnapshotUpgrade">);
-  const claims = presetSnapshotUpgradeClaims(event),
-    shape = (items: readonly { readonly sha256: string; readonly size: number; readonly mediaType: string }[]) =>
-      stableStringify(
-        items
-          .map(({ sha256, size, mediaType }) => ({ sha256, size, mediaType }))
-          .sort((a, b) => a.sha256.localeCompare(b.sha256)),
-      );
-  if (
-    shape(blobs) !== shape(claims) ||
-    blobs.some((blob) => Buffer.byteLength(blob.body) !== blob.size || sha256Text(blob.body) !== blob.sha256)
-  )
-    throw new Error("snapshot upgrade content inputs must exactly match the frozen write plan");
   const snapshot = blobs.find((blob) => blob.sha256 === event.payload.presetSnapshotClaim.sha256),
     contract = blobs.find((blob) => blob.sha256 === event.payload.taskContractClaim.sha256);
   let value: Record<string, unknown>, contractValue: Record<string, unknown>;

--- a/packages/kernel/src/domain/vertical-declaration.ts
+++ b/packages/kernel/src/domain/vertical-declaration.ts
@@ -505,8 +505,7 @@ export function assertVerticalDeclarationEventInputs(
     throw new Error("vertical declaration write plan is not exact");
   const claim = event.payload.declarationDocumentClaim,
     blob = blobs.find((candidate) => candidate.sha256 === claim.sha256);
-  if (!blob || blob.size !== claim.size || blob.mediaType !== claim.mediaType || sha256Text(blob.body) !== claim.sha256)
-    throw new Error("vertical declaration blob must be exact");
+  if (!blob) throw new Error("vertical declaration blob must be exact");
   const parsed = parseVerticalDeclarationDocument(JSON.parse(blob.body));
   if (stableStringify(parsed) !== stableStringify(event.payload.declaration))
     throw new Error("vertical declaration blob does not match event snapshot");

--- a/packages/kernel/src/domain/write-chain.contract.ts
+++ b/packages/kernel/src/domain/write-chain.contract.ts
@@ -418,7 +418,9 @@ export function normalizeContentAddressedInputs<T extends ContentAddressedInput>
     const prior = bySha256.get(input.sha256);
     if (
       prior !== undefined &&
-      (prior.size !== input.size || prior.mediaType !== input.mediaType || !sameContentBody(prior.body, input.body))
+      (prior.size !== input.size ||
+        prior.mediaType !== input.mediaType ||
+        (typeof prior.body === "string" && typeof input.body === "string" && prior.body !== input.body))
     )
       throw new WriteChainContractError(
         "invalid_write_plan",
@@ -427,13 +429,6 @@ export function normalizeContentAddressedInputs<T extends ContentAddressedInput>
     if (prior === undefined) bySha256.set(input.sha256, input);
   }
   return [...bySha256.values()];
-}
-
-function sameContentBody(left: string | Uint8Array | undefined, right: string | Uint8Array | undefined): boolean {
-  if (typeof left === "string" || typeof right === "string" || left === undefined || right === undefined)
-    return left === right;
-  if (left.byteLength !== right.byteLength) return false;
-  return left.every((byte, index) => byte === right[index]);
 }
 
 const LEDGER_DATABASE_PATH = ".harness/store/generations/2/ledger.sqlite";

--- a/packages/kernel/src/store/task-event-store-validation.ts
+++ b/packages/kernel/src/store/task-event-store-validation.ts
@@ -22,7 +22,6 @@ import { assertTaskLifecycleWritePlan } from "../domain/task-lifecycle-publicati
 import {
   assertTaskBootstrapWritePlan,
   isTaskBootstrapEvent,
-  taskBootstrapClaims,
   type TaskBootstrapEventV1,
 } from "../domain/task-bootstrap-event.ts";
 import { assertTaskProgressWritePlan, isTaskProgressEvent } from "../domain/task-progress-event.ts";
@@ -38,7 +37,7 @@ import {
   type FrozenWritePlan,
   type WriteTarget,
 } from "../domain/write-chain.contract.ts";
-import { sha256Bytes, sha256Text, stableStringify } from "../integrity/stable-hash.ts";
+import { sha256Bytes, stableStringify } from "../integrity/stable-hash.ts";
 import { assertPublishableOpId, eventObjectTarget } from "../layout/ledger-object-layout.ts";
 import type { CanonicalContentBlob, CanonicalEventWriteBundle } from "./task-event-store-types.ts";
 import { TaskEventStoreError } from "./task-event-store-types.ts";
@@ -54,7 +53,7 @@ export function assertBundle(bundle: CanonicalEventWriteBundle): void {
     const docErrors = validateCurrentDocEvent(event);
     if (docErrors.length)
       throw new TaskEventStoreError("invalid_write_plan", "doc event write requires the current cut identity");
-    assertDocWritePlan(event, plan, blobs);
+    assertDocWritePlan(event, plan);
   }
   const currentErrors = validateCurrentCanonicalEvent(event);
   if (currentErrors.length)
@@ -116,7 +115,7 @@ export function assertBundle(bundle: CanonicalEventWriteBundle): void {
         "lifecycle write plan must exactly declare event, documents, blobs, lease, and projections",
       );
     }
-  if (isTaskBootstrapEvent(event)) assertBootstrapInputs(event, plan, blobs);
+  if (isTaskBootstrapEvent(event)) assertBootstrapInputs(event, plan);
   if (isSnapshotUpgradeEvent(event))
     try {
       assertSnapshotUpgradeInputs(event, plan, requireTextBlobs(blobs));
@@ -227,11 +226,7 @@ function requireTextBlobs(blobs: readonly CanonicalContentBlob[]): readonly (Can
     throw new TaskEventStoreError("invalid_write_plan", "this canonical event accepts text content only");
   return blobs as readonly (CanonicalContentBlob & { readonly body: string })[];
 }
-export function assertDocWritePlan(
-  event: DocEventV1,
-  plan: FrozenWritePlan,
-  blobs: readonly CanonicalContentBlob[],
-): void {
+export function assertDocWritePlan(event: DocEventV1, plan: FrozenWritePlan): void {
   try {
     assertDocSyncWritePlan(event, plan as FrozenWritePlan<"DocSyncSubmit">);
   } catch {
@@ -240,17 +235,8 @@ export function assertDocWritePlan(
       "doc write plan must exactly declare event, head, projection, and content targets",
     );
   }
-  assertContentInputs(
-    event.payload.changes.flatMap(({ candidate }) => (candidate === null ? [] : [candidate])),
-    blobs,
-    "doc",
-  );
 }
-export function assertBootstrapInputs(
-  event: TaskBootstrapEventV1,
-  plan: FrozenWritePlan,
-  blobs: readonly CanonicalContentBlob[],
-): void {
+export function assertBootstrapInputs(event: TaskBootstrapEventV1, plan: FrozenWritePlan): void {
   try {
     assertTaskBootstrapWritePlan(event, plan as FrozenWritePlan<"TaskBootstrap">);
   } catch {
@@ -259,24 +245,6 @@ export function assertBootstrapInputs(
       "task bootstrap write plan must exactly declare event, task, snapshot, documents, and blobs",
     );
   }
-  const claims = taskBootstrapClaims(event);
-  assertContentInputs(claims, blobs, "task bootstrap");
-  const claim = claims[0];
-  if (!claim || !("digest" in claim))
-    throw new TaskEventStoreError("invalid_write_plan", "task bootstrap snapshot claim is missing");
-  const blob = blobs.find((candidate) => candidate.sha256 === claim.sha256);
-  let value: Record<string, unknown>;
-  try {
-    value = JSON.parse(typeof blob?.body === "string" ? blob.body : "") as Record<string, unknown>;
-  } catch {
-    throw new TaskEventStoreError("invalid_write_plan", "task bootstrap snapshot claim must be JSON");
-  }
-  const { digest, ...snapshot } = value;
-  if (digest !== claim.digest || claim.digest !== `sha256:${sha256Text(stableStringify(snapshot))}`)
-    throw new TaskEventStoreError(
-      "invalid_write_plan",
-      "task bootstrap snapshot claim digest must match its canonical bytes",
-    );
 }
 export function assertContentInputs(
   claims: readonly {
@@ -301,23 +269,21 @@ export function assertContentInputs(
     if (!(error instanceof WriteChainContractError)) throw error;
     throw new TaskEventStoreError("invalid_write_plan", `${label} content inputs conflict for one SHA`);
   }
-  const shape = (
-    items: readonly {
-      readonly sha256: string;
-      readonly size: number;
-      readonly mediaType: string;
-    }[],
-  ) =>
-    stableStringify(
-      items
-        .map(({ sha256, size, mediaType }) => ({ sha256, size, mediaType }))
-        .sort((a, b) => a.sha256.localeCompare(b.sha256)),
-    );
+  // Blobs may cover a subset of the claims: an object the store already holds needs no bytes resupplied, and
+  // prepareContentObjects rejects a claim with neither a blob nor a stored object. Every supplied blob is
+  // hashed here — the one place content bytes are verified — and must match the claim it stands for.
+  const claimsBySha = new Map(normalizedClaims.map((claim) => [claim.sha256, claim]));
   if (
-    shape(normalizedBlobs) !== shape(normalizedClaims) ||
     normalizedBlobs.some((blob) => {
-      const bytes = typeof blob.body === "string" ? Buffer.from(blob.body) : blob.body;
-      return bytes.byteLength !== blob.size || sha256Bytes(bytes) !== blob.sha256;
+      const claim = claimsBySha.get(blob.sha256),
+        bytes = typeof blob.body === "string" ? Buffer.from(blob.body) : blob.body;
+      return (
+        claim === undefined ||
+        claim.size !== blob.size ||
+        claim.mediaType !== blob.mediaType ||
+        bytes.byteLength !== blob.size ||
+        sha256Bytes(bytes) !== blob.sha256
+      );
     })
   )
     throw new TaskEventStoreError(

--- a/packages/kernel/test/contracts/artifact-entity.test.ts
+++ b/packages/kernel/test/contracts/artifact-entity.test.ts
@@ -21,6 +21,7 @@ import {
 } from "../../src/index.ts";
 import {
   artifactEntityContractFromSnapshot,
+  artifactMutationOperationId,
   canonicalArtifactUrl,
   decodeArtifactEntityContractSnapshot,
   encodeArtifactDescriptor,
@@ -30,6 +31,8 @@ import {
   validateCurrentEntityEvent,
   validateEntityEvent,
 } from "../../src/domain/entity-event.ts";
+import { compileEntityUpdated } from "../../src/domain/entity-event-compile.ts";
+import { assertContentInputs } from "../../src/store/task-event-store-validation.ts";
 
 const vertical = JSON.parse(
   readFileSync(new URL("../../fixtures/schemas/vertical-definition/valid.json", import.meta.url), "utf8"),
@@ -192,9 +195,11 @@ test("observed and missing artifact events are self-validating generic entity ev
     "the generic store must rebuild a compiled kind from the event snapshot without a kind-specific store",
   );
   assert.throws(() =>
-    assertEntityEventInputs(compiledObserved.event, compiledObserved.plan, [
-      { ...compiledObserved.blobs[0], body: `${compiledObserved.blobs[0].body} ` },
-    ]),
+    assertContentInputs(
+      [compiledObserved.event.payload.declarationDocumentClaim],
+      [{ ...compiledObserved.blobs[0], body: `${compiledObserved.blobs[0].body} ` }],
+      "entity observed",
+    ),
   );
 
   const missingResolution = "missing:ENOENT",
@@ -221,6 +226,52 @@ test("observed and missing artifact events are self-validating generic entity ev
     missing.plan.targets.some(({ kind }) => kind === "authored_file"),
     false,
   );
+});
+
+test("an entity update restates owned content as manifest metadata without carrying its bytes", () => {
+  const artifact = compiledArtifact(),
+    source = canonicalSourceIdentity({ kind: "repository-path", repositoryId: "canonical", path: "docs/adr.md" }),
+    descriptor = makeDescriptor(artifact, source),
+    opId = artifactMutationOperationId({
+      mutation: "update",
+      entityId: descriptor.entityId,
+      expectedVersion: 1,
+      request: { entityKind: descriptor.typeIdentity, title: "ADR One revised" },
+    }),
+    carried = {
+      relativePath: "notes/keep.md",
+      sha256: "b".repeat(64),
+      size: 5,
+      mediaType: "text/markdown",
+      policyId: "markdown-body-replaceable/v1",
+    },
+    updated = compileEntityUpdated({
+      contract: artifact.entityKindContract as EntityStoreKindContract,
+      contractSnapshot: artifactEntityContractSnapshot({ ...artifact, kindVersion: 1 }),
+      descriptor,
+      sourceContent: [carried],
+      eventId: `event-${opId}`,
+      opId,
+      workspaceRevision: 2,
+      actor,
+      source: "local",
+      occurredAt: "2026-09-10T00:00:00.000Z",
+    });
+  // The manifest still binds what the entity owns, restated from metadata alone …
+  const binding = updated.event.payload.ownedContent.bindings.find(({ path }) => path.endsWith("notes/keep.md"));
+  assert.equal(binding?.contentSha256, carried.sha256);
+  assert.deepEqual(
+    updated.event.payload.ownedContent.content.find(({ sha256 }) => sha256 === carried.sha256),
+    {
+      sha256: carried.sha256,
+      byteLength: carried.size,
+      mediaType: carried.mediaType,
+    },
+  );
+  // … but the bundle carries only the declaration's bytes: the store already holds the carried object,
+  // and a claim with neither a blob nor a stored object is rejected at the store boundary.
+  assert.equal(updated.blobs.length, 1);
+  assert.equal(updated.blobs[0].sha256, updated.event.payload.declarationDocumentClaim.sha256);
 });
 
 const adrKindId = "KND-1f5c0a7e9b3d4c6a8e2f0b1d3c5a7e94";

--- a/packages/kernel/test/contracts/entity-store.test.ts
+++ b/packages/kernel/test/contracts/entity-store.test.ts
@@ -6,7 +6,8 @@ import test from "node:test";
 import { createEntityStore } from "../../src/index.ts";
 import { validateAgentDeclarationV1 } from "../../src/domain/agent-squad-schema.ts";
 import { explainEntityKind } from "../../src/domain/entity-kind-registry.ts";
-import { assertEntityUpsertInputs, type EntityEventV1 } from "../../src/domain/entity-event.ts";
+import { type EntityEventV1 } from "../../src/domain/entity-event.ts";
+import { assertContentInputs } from "../../src/store/task-event-store-validation.ts";
 import type { EntityUpsertBundle } from "../../src/domain/entity-event-compile.ts";
 import { validateWriteReceipt } from "../../src/domain/write-chain.contract.ts";
 import { createEntityOwnedContent, MAX_ENTITY_CONTENT_OBJECT_BYTES } from "../../src/domain/entity-owned-content.ts";
@@ -264,7 +265,12 @@ test("Entity upsert rejects schema-invalid declarations and tampered declaration
   );
   const bundle = upsert(store, "agent", agent, 1),
     tampered = [{ ...bundle.blobs[0], body: `${bundle.blobs[0].body} ` }];
-  assert.throws(() => assertEntityUpsertInputs(bundle.event, bundle.plan, tampered), /declaration blob must be exact/u);
+  // Blob bytes are verified once, at the store boundary; a body that disagrees with its claim's SHA is
+  // rejected there rather than by a second hash inside the domain assertion.
+  assert.throws(
+    () => assertContentInputs([bundle.event.payload.declarationDocumentClaim], tampered, "entity upsert"),
+    /content inputs must exactly match/u,
+  );
 });
 
 test("entity_upsert receipt detail is closed and registered", () => {

--- a/packages/kernel/test/contracts/people-event.test.ts
+++ b/packages/kernel/test/contracts/people-event.test.ts
@@ -6,6 +6,7 @@ import {
   compilePeopleRosterActionEvent,
   validatePeopleEvent,
 } from "../../src/domain/people-event.ts";
+import { assertContentInputs } from "../../src/store/task-event-store-validation.ts";
 
 test("people_changed carries the Action result, parent CAS, exact blob, and frozen write plan", () => {
   const compiled = compilePeopleRosterActionEvent({
@@ -33,14 +34,20 @@ test("people_changed carries the Action result, parent CAS, exact blob, and froz
   assert.doesNotThrow(() =>
     assertPeopleEventInputs(compiled.bundle!.event, compiled.bundle!.plan, compiled.bundle!.blobs),
   );
+  // Blob bytes are verified once, at the store boundary: a body that disagrees with its claim's SHA is
+  // rejected there (assertContentInputs), not by a second hash inside the domain assertion.
   assert.throws(
     () =>
-      assertPeopleEventInputs(compiled.bundle!.event, compiled.bundle!.plan, [
-        {
-          ...compiled.bundle!.blobs[0],
-          body: `${compiled.bundle!.blobs[0].body} `,
-        },
-      ]),
-    /must be exact/u,
+      assertContentInputs(
+        [compiled.bundle!.event.payload.peopleDocumentClaim],
+        [
+          {
+            ...compiled.bundle!.blobs[0],
+            body: `${compiled.bundle!.blobs[0].body} `,
+          },
+        ],
+        "people",
+      ),
+    /content inputs must exactly match/u,
   );
 });

--- a/packages/kernel/test/store/sqlite-event-store.integration.test.ts
+++ b/packages/kernel/test/store/sqlite-event-store.integration.test.ts
@@ -347,10 +347,9 @@ test("SQLite content admission reuses exact objects after reopen and rejects mis
 
     const missingBody = "# Missing input\n",
       missing = docBundle(reopened, missingBody, 3, "content-missing", "context/missing.md");
-    assert.throws(
-      () => reopened.append({ ...missing, blobs: [] }),
-      /doc content inputs must exactly match the frozen write plan/u,
-    );
+    // Content is verified once at the store boundary: a claim with neither a blob nor a stored object is
+    // refused by the object store, not by a second blob/claim shape check in bundle validation.
+    assert.throws(() => reopened.append({ ...missing, blobs: [] }), /event content object .* is missing/u);
     assert.equal(reopened.readEvent(missing.event.opId), null);
     assert.equal(reopened.readCommandOutcome(missing.event.opId), null);
     assert.equal(reopened.readContentBlob(sha256Text(missingBody)), null);

--- a/packages/kernel/test/store/task-bootstrap-store.test.ts
+++ b/packages/kernel/test/store/task-bootstrap-store.test.ts
@@ -80,31 +80,8 @@ test("task bootstrap publishes and rebuilds one exact Task, snapshot, and docume
       store = makeTaskEventStore({ repoId: "bootstrap", rootDir });
     projection = makeTaskProjection({ rootDir, eventStore: store });
     const before = store.currentCommit();
-    const tamperedBody = `${stableStringify({ ...snapshotValue, id: "tampered", digest })}\n`,
-      tamperedSha = sha256Text(tamperedBody),
-      tampered = {
-        ...event,
-        payload: {
-          ...event.payload,
-          presetSnapshotClaim: {
-            ...event.payload.presetSnapshotClaim,
-            sha256: tamperedSha,
-            size: Buffer.byteLength(tamperedBody),
-          },
-        },
-      },
-      tamperedBlobs = [{ ...tampered.payload.presetSnapshotClaim, body: tamperedBody }, blobs[1]!] as const;
-    assert.throws(
-      () =>
-        store.append({
-          event: tampered,
-          plan: taskBootstrapWritePlan(tampered),
-          blobs: tamperedBlobs,
-        }),
-      /snapshot.*digest/iu,
-    );
-    assert.deepEqual(store.currentCommit(), before);
-    assert.equal(store.read().revision, 0);
+    // A claim with neither a blob nor a stored object is still refused; since content is verified once at the
+    // store boundary, the rejection now comes from the object store rather than the bundle's blob/claim shape.
     assert.throws(
       () =>
         store.append({
@@ -112,7 +89,7 @@ test("task bootstrap publishes and rebuilds one exact Task, snapshot, and docume
           plan: taskBootstrapWritePlan(event),
           blobs: blobs.slice(1),
         }),
-      /content inputs/u,
+      /event content object .* is missing/u,
     );
     assert.deepEqual(store.currentCommit(), before);
     assert.equal(store.read().revision, 0);

--- a/packages/preset/test/preset-bootstrap.test.ts
+++ b/packages/preset/test/preset-bootstrap.test.ts
@@ -101,7 +101,7 @@ test("standard and milestone bootstrap compile one exact canonical birth and reb
           plan: standard.plan,
           blobs: standard.blobs.slice(1),
         }),
-      /content inputs/u,
+      /event content object .* is missing/u,
     );
     assert.deepEqual(store.currentCommit(), before);
     const receipt = store.append({


### PR DESCRIPTION
# English

## Summary

Content inputs are now verified once, at the store boundary. Before this change, a content blob carried by a write was hashed in the domain `assert*Inputs` guard of its event type (settings, people, schedule, vertical, entity, the task-snapshot seam), again in the doc and bootstrap paths of store validation, and once more by the store's general check. A bootstrap snapshot also re-derived the digest embedded in its own body and compared it with the claim, and both sides are compiled by the same process. An entity update re-supplied and re-hashed the bytes of every owned blob it kept, even when that blob was already in the object store. This is batch B2 of the daemon write-path rescue that followed #2407, #2408 and #2409, based on a 12-report read-only audit of the three days after the SQLite cutover.

## Architectural Justification

- **Where the one check lives.** `assertContentInputs` in `task-event-store-validation.ts` is the single place a supplied blob's bytes are hashed and matched against its claim's sha256, size and media type. Every other layer now checks only that a needed blob is present.
- **Blobs a subset of claims.** Supplied blobs must now be a subset of the claims instead of an exact match. A claim with neither a supplied blob nor a stored object is still rejected, by `prepareContentObjects` when it prepares objects. So an entity update can restate the owned content it keeps as manifest metadata without carrying the bytes again.
- **Bootstrap digest.** The self-comparison between the bootstrap snapshot's embedded digest and its claim is deleted.
- **Left for governance.** `sameContentBody` is reduced to one string comparison for two inputs that share a sha256. The gate test G03 in `tools/gates/test/write-chain-contract.test.mjs` locks that behavior, and changing it is protected surface. It is left for the governance task that also removes the unused `ledger_file` write-plan targets (task_f351132392fa541d28459a68ce).

## What Changed

- `task-event-store-validation.ts`:
  - Accepts blobs ⊆ claims.
  - Removes the doc-plan and bootstrap re-checks and the embedded-digest self-comparison.
- The settings, people, schedule, vertical and entity event guards check presence only; the entity guard also keeps its string-type check before parsing.
- `task-snapshot-upgrade-store-seam.ts`: removes the per-blob sha check and the claim-shape comparison.
- `write-chain.contract.ts`: removes `sameContentBody` and its byte-wise comparison.
- `artifact-entity-action.ts`: narrows `carriedContent` to manifest metadata. A kept owned blob is restated from the owned-content bindings; no stored bytes are read or carried. (Corrected after merge: an earlier version of this description said the function was dropped.)

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: packages/kernel/test/store/task-bootstrap-store.test.ts embedded-digest tamper case
- Deleted production behavior (no file removed): the domain-level blob re-hashes, the doc and bootstrap re-checks, the bootstrap embedded-digest self-comparison, the byte-wise `sameContentBody` comparison, and the re-supply and re-hash of kept entity blobs.
- Production net lines: +40/-100, net -60.

## Machine-Readable Declarations

## Task And Scope

- Harness task: task_5a7a8a092efead62c45c9af832 (B2), parent task_2b8f79fa4412cb726a26f9bfc7
- Branch: `codex/del-b2-content-once`
- Public scope: kernel content validation, domain event guards, the write-chain content normalization, the entity update action in the daemon, and their tests
- Private planning/evidence updated: yes (fact F-D91D1498, report `artifacts/b2-report.md` in the task package)
- Out of scope: `ledger_file` targets and the last `sameContentBody` string check (governance task task_f351132392fa541d28459a68ce)

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none
- Authority: not applicable
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: task_f351132392fa541d28459a68ce

## Verification

- Base `origin/main` SHA: `6d67e6b90` (after B1 #2413 and B5 #2414)
- Branch merge-base with `origin/main`: `6d67e6b90`
- Last `git fetch origin` time: 2026-09-10 15:00 UTC
- Sync method: rebase onto origin/main
- Public diff command: `git diff origin/main...codex/del-b2-content-once`
- Private evidence commit/path: fact F-D91D1498
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [x] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- New positive test: an entity update restates kept owned content as manifest metadata and carries exactly one blob. On the base, `assertBundle` rejected that shape (blobs ⊂ claims).
- Docker-isolated on main with B1 merged (`node tools/dispatch-isolated-test.mjs --target docker --file <file>`):

  | Test file | Passed |
  |---|---|
  | `sqlite-event-store.integration.test.ts` | 24/24 |
  | `task-event-store.test.ts` | 15/15 |
  | `generation-two-content.integration.test.ts` | 1/1 |
  | `artifact-entity-action.integration.test.ts` | 4/4 |
  | `repo-cell-settings.integration.test.ts` | 1/1 |
  | `migration-import-acceptance.integration.test.ts` | 1/1 |

  The worker also ran the kernel contract tests for people events, entity store and artifact entity, and the task bootstrap store tests.
- `npx tsc -b` (whole repository) and `node tools/run-manifest-gates.mjs --changed origin/main` passed on the rebased head.
- Existing tests changed, and why each is safe:
  - The people-event, entity-store and artifact-entity tamper tests now call `assertContentInputs` directly. Tampering is still rejected, at the one remaining check.
  - The task-bootstrap embedded-digest tamper case is deleted with the self-comparison it tested. Its blob bytes hash correctly, so only that self-comparison could reject it.
  - The missing-blob negatives now match the `prepareContentObjects` message. The rejection is still atomic, and the revision and commit are unchanged.
- Not run: the full `npm run check` / `npm test` locally. Local agents must not run the full matrix, so CI is the full authority.

## Review Evidence

- Self-review: the lead read the full production diff and confirmed three things:
  - every supplied blob is still hashed exactly once, in `assertContentInputs`;
  - a claim with no blob and no stored object is still rejected (after B1, `prepareContentObjects` checks stored objects for existence and still rejects a missing one);
  - the remaining `sameContentBody` string check stays for the reason above.
- Rebase: the batch was rebased onto main with B1 and B5 and re-tested there. B1 and B2 both touch content admission.
- Reviewer subagent: a GLM-5.3 implementation worker wrote the change; the lead reviewed it
- Human review: pending
- Blocking findings: none

## Residual Risk

- Domain guards now assume the store boundary runs before any event reaches the projection. That holds for every write path in the repository.
- The last `sameContentBody` string check stays until the governance task lands.

## References

- Audit: `artifacts/audit-3day/00-ranked-deletions.md` (B2), `H2-hash-kernel-domain.md` and `S6-2391-entity.md` in task_2b8f79fa4412cb726a26f9bfc7
- Previous batches: PR #2407 to PR #2414

---

# 中文

## 概要

内容输入现在只在 store 边界校验一次。本改动之前，写入携带的内容 blob 会被多次哈希：先在所属事件类型的 domain `assert*Inputs` 守卫里（settings、people、schedule、vertical、entity、task-snapshot seam），再在 store 校验的 doc 与 bootstrap 路径里，最后在 store 的通用检查里再算一次。bootstrap 快照还会重新推导正文里内嵌的 digest，再和 claim 比对，而这两边都是同一个进程编译出来的。entity 更新会把它保留的每个自有 blob 的字节重新携带、重新哈希一遍，即使对象库里早已有这份内容。本 PR 是 #2407、#2408、#2409 之后 daemon 写路径抢救的 B2 批次，依据是对 SQLite 切换后三天所做的 12 份只读审计。

## 架构辩护

- **唯一的校验点。** `task-event-store-validation.ts` 里的 `assertContentInputs`，是唯一对供应 blob 的字节做哈希、并与 claim 的 sha256、大小、媒体类型比对的地方。其他各层现在只检查需要的 blob 是否存在。
- **blob 是 claim 的子集。** 供应的 blob 现在只需是 claim 的子集，不必一一对应。既没有供应 blob、又没有已存对象的 claim，仍会在 `prepareContentObjects` 准备对象时被拒绝。因此 entity 更新可以把保留的自有内容写成 manifest 元数据，不必重新携带字节。
- **bootstrap digest。** bootstrap 快照内嵌 digest 与 claim 之间的自比对已删除。
- **留给治理。** `sameContentBody` 收窄为一行：两份输入 sha256 相同时比较字符串。`tools/gates/test/write-chain-contract.test.mjs` 里的门测试 G03 锁住了这个行为，改它属于受保护面，留给同时删除无人使用的 `ledger_file` 写计划目标的治理任务（task_f351132392fa541d28459a68ce）。

## 改动内容

- `task-event-store-validation.ts`：
  - 接受 blob ⊆ claim；
  - 删掉 doc-plan 与 bootstrap 的重复检查，以及内嵌 digest 的自比对。
- settings、people、schedule、vertical、entity 事件守卫只检查存在性；entity 守卫另外保留解析之前的字符串类型检查。
- `task-snapshot-upgrade-store-seam.ts`：删掉逐 blob 的 sha 检查和 claim 形状比较。
- `write-chain.contract.ts`：删掉 `sameContentBody` 及其逐字节比较。
- `artifact-entity-action.ts`：`carriedContent` 收窄为只写 manifest 元数据：保留的自有 blob 从自有内容绑定写成元数据，不再读取或携带已存字节。（合并后更正：此前的描述误写为删掉了这个函数。）

## 门收割 / Gate Harvest

- 删除的生产路径：none（没有删文件）
- 删除的门或 fixture：`packages/kernel/test/store/task-bootstrap-store.test.ts` 中内嵌 digest 篡改用例
- 删除的生产行为：domain 层的 blob 重哈希、doc 与 bootstrap 的重复检查、bootstrap 内嵌 digest 的自比对、`sameContentBody` 的逐字节比较，以及 entity 更新时重新携带并重新哈希保留的 blob。
- 生产净行数：+40/-100，净 -60。

## 机读声明说明

- 本 PR 不涉及依赖变化和事件迁移，没有机读声明。

## 任务与范围

- Harness 任务：task_5a7a8a092efead62c45c9af832（B2），父任务 task_2b8f79fa4412cb726a26f9bfc7
- 分支：`codex/del-b2-content-once`
- 公开范围：kernel 的内容校验、domain 事件守卫、write-chain 的内容规范化、daemon 的 entity 更新 action，以及对应测试
- 私有计划 / 证据是否已更新：yes（fact F-D91D1498，任务包里的报告 `artifacts/b2-report.md`）
- 范围外：`ledger_file` 目标，以及最后那一行 `sameContentBody` 字符串比较（治理任务 task_f351132392fa541d28459a68ce）

## 版本影响

- 版本：不改版本
- 发布影响：不发布

## 治理声明

- 是否触碰 protected surface：no
- protected surface 范围：无
- 依据：不适用
- 机器检查边界：本 PR 只声明该段存在；声明是否真实、充分，由 reviewer 判断。
- Break-glass：no
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：task_f351132392fa541d28459a68ce

## 验证

- `origin/main` 基准 SHA：`6d67e6b90`（B1 #2413、B5 #2414 合入之后）
- 当前分支与 `origin/main` 的 merge-base：`6d67e6b90`
- 最近一次 `git fetch origin` 时间：2026-09-10 15:00 UTC
- 同步方式：rebase 到 origin/main
- 公开 diff 命令：`git diff origin/main...codex/del-b2-content-once`
- 私有证据 commit/path：fact F-D91D1498
- Reviewer 证据路径：见本 PR 的「审查证据」一节
- GitHub Actions `rewrite-ci` run URL：本 PR 的 CI 还在跑
- [ ] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [x] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- 新增正向测试：entity 更新把保留的自有内容写成 manifest 元数据，只携带一个 blob。在基线上，`assertBundle` 会拒绝这种形态（blob ⊂ claim）。
- 在已合入 B1 的 main 上，于 Docker 隔离环境运行（`node tools/dispatch-isolated-test.mjs --target docker --file <file>`）：

  | 测试文件 | 通过 |
  |---|---|
  | `sqlite-event-store.integration.test.ts` | 24/24 |
  | `task-event-store.test.ts` | 15/15 |
  | `generation-two-content.integration.test.ts` | 1/1 |
  | `artifact-entity-action.integration.test.ts` | 4/4 |
  | `repo-cell-settings.integration.test.ts` | 1/1 |
  | `migration-import-acceptance.integration.test.ts` | 1/1 |

  worker 另外跑过 kernel 中 people 事件、entity store、artifact entity 的 contract 测试，以及 task bootstrap store 测试。
- 在 rebase 后的 head 上，`npx tsc -b`（全仓）与 `node tools/run-manifest-gates.mjs --changed origin/main` 通过。
- 修改过的现有测试，以及为什么安全：
  - people-event、entity-store、artifact-entity 的篡改测试改为直接调用 `assertContentInputs`，篡改仍然会在剩下的那一次检查中被拒绝。
  - task-bootstrap 的内嵌 digest 篡改用例随它所测的自比对一起删除：它的 blob 字节哈希是正确的，只有那项自比对能拒绝它。
  - 缺失 blob 的反例改为匹配 `prepareContentObjects` 的报错信息；拒绝仍然是原子的，revision 和 commit 都不变。
- 未运行：本地整套 `npm run check` / `npm test`。规定禁止本地 agent 跑全量矩阵，全量以 CI 为准。

## 审查证据

- 自查：主控读完整个生产 diff，确认了三点：
  - 每个供应的 blob 仍然恰好在 `assertContentInputs` 里哈希一次；
  - 既没有 blob 又没有已存对象的 claim 仍会被拒绝（B1 之后，`prepareContentObjects` 对已存对象只检查是否存在，缺失的仍会被拒绝）；
  - 剩下那一行 `sameContentBody` 字符串比较出于上文的原因保留。
- Rebase：本批次 rebase 到含 B1、B5 的 main 上并在其上重新测试；B1 与 B2 都改到了内容受理。
- Reviewer subagent：改动由 GLM-5.3 实现 worker 编写，主控审查
- 人工审查：待进行
- 阻塞发现：无

## 残余风险

- domain 守卫现在假设任何事件到达投影之前都先经过 store 边界；仓库里所有写路径都满足这一点。
- 最后那一行 `sameContentBody` 字符串比较要等治理任务合入后才能删掉。

## 关联材料

- 审计：task_2b8f79fa4412cb726a26f9bfc7 的 `artifacts/audit-3day/00-ranked-deletions.md`（B2 节）、`H2-hash-kernel-domain.md`、`S6-2391-entity.md`
- 前几批：PR #2407 至 PR #2414

---

## PR Gate Checklist / PR 门禁清单

- [x] Branch is based on latest `origin/main`. / 分支基于最新 `origin/main`。
- [x] PR body uses this full template structure. / PR 描述使用本模板完整结构。
- [x] PR body uses two complete language blocks: `# English` first, then `# 中文`. / PR 正文使用两块完整正文：`# English` 在上，`# 中文` 在下。
- [x] PR body passes `tools/check-pr-body-bilingual.mjs`. / PR 正文通过 `tools/check-pr-body-bilingual.mjs`。
- [x] If the PR touches a manifest-derived protected surface, Governance Declaration is filled with ADR/decision/task evidence or break-glass fields. / 若 PR 触碰 manifest 派生的 protected surface，Governance Declaration 已填写 ADR/decision/task 依据或 break-glass 字段。
- [x] No private harness files are included. / 不包含私有 harness 文件。
- [x] No ignored local agent entry files are included. / 不包含被忽略的本地 agent 入口文件。
- [x] No absolute local filesystem paths are included in this public PR body. / 本公开 PR 描述不包含本机绝对路径。
- [x] Public diff is limited to the stated task scope. / 公开 diff 限于声明的任务范围。
- [x] Private planning/evidence updates are recorded when applicable. / 适用时已记录私有计划 / 证据更新。
- [x] Version and publish impact are stated. / 已说明版本与发布影响。
- [x] Local verification commands are recorded honestly. / 已如实记录本地验证命令。
- [ ] CI results are linked or explained. / CI 结果已链接或说明。
- [x] Review evidence is recorded. / 已记录审查证据。
- [x] Open P0/P1/P2 findings are closed, deferred with owner, or explicitly blocked. / open P0/P1/P2 findings 已关闭、带 owner 延后，或明确阻塞。
- [x] Merge method and post-merge branch cleanup plan are clear. / 合并方式和合并后分支清理计划清楚。
- [x] No admin bypass is planned unless explicitly approved and recorded. / 除非明确批准并记录，否则不计划 admin bypass。

