### PR TITLE
feat(gates): add G1 write-path scale-invariant cost gate

### DIFF
--- a/packages/daemon/test/fixtures/g1-cost-probe.mjs
+++ b/packages/daemon/test/fixtures/g1-cost-probe.mjs
@@ -1,0 +1,83 @@
+// G1 write-cost-scaling gate: deterministic-cost instrumentation shared by the writer-worker
+// `--import` preload (g1-writer-probe-import.mjs) and the gate's own host-side read measurements.
+// Patches built-in prototypes only (node:sqlite StatementSync, node:crypto Hash, node:fs
+// readFileSync); production source carries none of this. Git subprocess count reuses the
+// existing production counter (localGitObjectRefStore.processCount) instead of patching
+// child_process, so it stays accurate across every call shape the kernel already uses.
+import { syncBuiltinESMExports } from "node:module";
+import { StatementSync } from "node:sqlite";
+import crypto from "node:crypto";
+import fs from "node:fs";
+import { localGitObjectRefStore } from "../../../kernel/src/store/local-version-control-system.ts";
+
+const counters = { sqlRowsRead: 0, sha256Calls: 0, sha256Bytes: 0, fileReadBytes: 0 };
+let gitBaseline = 0;
+let installed = false;
+
+function rowCount(result) {
+  if (Array.isArray(result)) return result.length;
+  return result === undefined ? 0 : 1;
+}
+
+function byteLength(chunk, encoding) {
+  if (typeof chunk === "string") return Buffer.byteLength(chunk, encoding ?? "utf8");
+  if (ArrayBuffer.isView(chunk)) return chunk.byteLength;
+  return Buffer.byteLength(String(chunk));
+}
+
+export function installCostProbe() {
+  if (installed) return;
+  installed = true;
+
+  const statementProto = StatementSync.prototype,
+    originalAll = statementProto.all,
+    originalGet = statementProto.get;
+  statementProto.all = function all(...args) {
+    const result = originalAll.apply(this, args);
+    counters.sqlRowsRead += rowCount(result);
+    return result;
+  };
+  statementProto.get = function get(...args) {
+    const result = originalGet.apply(this, args);
+    counters.sqlRowsRead += rowCount(result);
+    return result;
+  };
+
+  const hashProto = crypto.Hash.prototype,
+    originalUpdate = hashProto.update,
+    originalDigest = hashProto.digest;
+  hashProto.update = function update(chunk, encoding) {
+    counters.sha256Bytes += byteLength(chunk, encoding);
+    return originalUpdate.call(this, chunk, encoding);
+  };
+  hashProto.digest = function digest(...args) {
+    counters.sha256Calls += 1;
+    return originalDigest.apply(this, args);
+  };
+
+  const originalReadFileSync = fs.readFileSync;
+  fs.readFileSync = function readFileSync(...args) {
+    const result = originalReadFileSync.apply(this, args);
+    counters.fileReadBytes += typeof result === "string" ? Buffer.byteLength(result, "utf8") : result.byteLength;
+    return result;
+  };
+  syncBuiltinESMExports();
+}
+
+export function resetCostProbe() {
+  counters.sqlRowsRead = 0;
+  counters.sha256Calls = 0;
+  counters.sha256Bytes = 0;
+  counters.fileReadBytes = 0;
+  gitBaseline = localGitObjectRefStore.processCount();
+}
+
+export function snapshotCostProbe() {
+  return {
+    sqlRowsRead: counters.sqlRowsRead,
+    sha256Calls: counters.sha256Calls,
+    sha256Bytes: counters.sha256Bytes,
+    gitProcesses: localGitObjectRefStore.processCount() - gitBaseline,
+    fileReadBytes: counters.fileReadBytes,
+  };
+}

--- a/packages/daemon/test/fixtures/g1-cost-probe.mjs
+++ b/packages/daemon/test/fixtures/g1-cost-probe.mjs
@@ -8,7 +8,7 @@ import { syncBuiltinESMExports } from "node:module";
 import { StatementSync } from "node:sqlite";
 import crypto from "node:crypto";
 import fs from "node:fs";
-import { localGitObjectRefStore } from "../../../kernel/src/store/local-version-control-system.ts";
+import { localGitObjectRefStore } from "../../../kernel/src/index.ts";
 
 const counters = { sqlRowsRead: 0, sha256Calls: 0, sha256Bytes: 0, fileReadBytes: 0 };
 let gitBaseline = 0;

--- a/packages/daemon/test/fixtures/g1-cost-probe.mjs
+++ b/packages/daemon/test/fixtures/g1-cost-probe.mjs
@@ -31,7 +31,8 @@ export function installCostProbe() {
 
   const statementProto = StatementSync.prototype,
     originalAll = statementProto.all,
-    originalGet = statementProto.get;
+    originalGet = statementProto.get,
+    originalIterate = statementProto.iterate;
   statementProto.all = function all(...args) {
     const result = originalAll.apply(this, args);
     counters.sqlRowsRead += rowCount(result);
@@ -41,6 +42,18 @@ export function installCostProbe() {
     const result = originalGet.apply(this, args);
     counters.sqlRowsRead += rowCount(result);
     return result;
+  };
+  // Streaming reads (the projection state digest walks every table this way) return their rows
+  // one step at a time, so each step the caller takes is one row read.
+  statementProto.iterate = function iterate(...args) {
+    const iterator = originalIterate.apply(this, args),
+      next = iterator.next.bind(iterator);
+    iterator.next = (...nextArgs) => {
+      const step = next(...nextArgs);
+      if (!step.done) counters.sqlRowsRead += 1;
+      return step;
+    };
+    return iterator;
   };
 
   const hashProto = crypto.Hash.prototype,

--- a/packages/daemon/test/fixtures/g1-write-cost-scaling.ts
+++ b/packages/daemon/test/fixtures/g1-write-cost-scaling.ts
@@ -1,8 +1,9 @@
 // harness-test-tier: integration
 // G1 write-cost-scaling gate fixture: builds a ledger of a given size with a realistic mix of
-// event kinds, then drives every durable write kind and hot read once through the production
-// daemon request path, measuring deterministic cost (SQL rows read, sha256 calls/bytes, git
-// subprocess count, file-read bytes) at the point each operation actually executes:
+// event kinds, then drives every durable write kind and hot read twice through the production
+// daemon request path (a warm-up call, then the steady-state call the gate judges), measuring
+// deterministic cost (SQL rows read, sha256 calls/bytes, git subprocess count, file-read bytes)
+// at the point each operation actually executes:
 //   - writes and receipt-show execute inside the writer worker thread (instrumented via the
 //     `--import` preload g1-writer-probe-import.mjs, mirroring writer-request-cost.integration.test.ts);
 //   - task-list/task-show/agenda/workspace-summary are intercepted host-side by the RepoCell
@@ -11,12 +12,12 @@
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
 import { randomUUID } from "node:crypto";
 import { Worker } from "node:worker_threads";
 import {
   compileDecisionWrite,
   compileFactWrite,
+  deriveRelationId,
   docSyncWritePlan,
   DOC_POLICY_ID,
   makeTaskEventStore,
@@ -24,6 +25,7 @@ import {
   sha256Text,
   taskLifecycleWritePlan,
   type DocEventV1,
+  type TaskEventV1,
 } from "../../../kernel/src/index.ts";
 // These four are internal-only shapes with no public-barrel re-export (kernel/src/index.ts); the
 // fixture still needs their exact structural types to hand-build canonically-valid events, so it
@@ -85,6 +87,26 @@ function factIdFor(index: number): string {
   return `F-${code}`;
 }
 
+const bulkActor = { principal: { personId: "person-g1-bulk" }, executor: { kind: "agent" as const, id: "g1-bulk" } };
+
+function bulkTask(taskId: string, title: string, status: "planned" | "cancelled"): TaskCreatedEvent["payload"]["task"] {
+  return {
+    schema: "task/v2",
+    taskId,
+    title,
+    taskClass: "standard",
+    status,
+    graph: REPLAY_TASK_GRAPH,
+    currentNode: "implementation",
+    iteration: 0,
+    createdBy: bulkActor,
+    completionGateIds: [],
+    presetSnapshotDigest: null,
+    pinned: false,
+    packageDisposition: "active",
+  };
+}
+
 function taskCreatedEvent(revision: number, taskId: string, title: string): TaskCreatedEvent {
   return {
     schema: "task-event/v1",
@@ -93,25 +115,31 @@ function taskCreatedEvent(revision: number, taskId: string, title: string): Task
     opId: `op-${taskId}`,
     taskId,
     type: "task_created",
-    actor: { principal: { personId: "person-g1-bulk" }, executor: { kind: "agent", id: "g1-bulk" } },
+    actor: bulkActor,
+    source: "local",
+    occurredAt: "2026-08-11T00:00:00.000Z",
+    payload: { task: bulkTask(taskId, title, "planned") },
+  };
+}
+
+/** A lifecycle transition shaped the way the kernel's cancel transition emits it
+ * (task-lifecycle-command-transitions.ts transitionTask): the whole task at its new status. Cancelled
+ * rather than blocked: a blocked task occupies a WIP slot, and the measured task-start needs one. */
+function taskCancelledEvent(revision: number, taskId: string, title: string): TaskEventV1 {
+  return {
+    schema: "task-event/v1",
+    eventId: `event-${taskId}-cancelled`,
+    workspaceRevision: revision,
+    opId: `op-${taskId}-cancelled`,
+    taskId,
+    type: "task_transitioned",
+    actor: bulkActor,
     source: "local",
     occurredAt: "2026-08-11T00:00:00.000Z",
     payload: {
-      task: {
-        schema: "task/v2",
-        taskId,
-        title,
-        taskClass: "standard",
-        status: "planned",
-        graph: REPLAY_TASK_GRAPH,
-        currentNode: "implementation",
-        iteration: 0,
-        createdBy: { principal: { personId: "person-g1-bulk" }, executor: { kind: "agent", id: "g1-bulk" } },
-        completionGateIds: [],
-        presetSnapshotDigest: null,
-        pinned: false,
-        packageDisposition: "active",
-      },
+      task: bulkTask(taskId, title, "cancelled"),
+      mutation: { command: "transition", reason: "G1 bulk lifecycle transition.", fields: ["status"] },
+      documentClaims: [],
     },
   };
 }
@@ -172,7 +200,14 @@ function docWriteBundle(
 function decisionDraft(
   decisionId: string,
   revision: number,
+  taskId: string,
 ): Extract<DecisionEventDraftV1, { readonly type: "decision_proposed" }> {
+  const relation = {
+    source: `decision/${decisionId}/CH1`,
+    target: `task/${taskId}`,
+    type: "derives" as const,
+    direction: "directed" as const,
+  };
   return {
     schema: "decision-event/v1",
     eventId: `event-${decisionId}`,
@@ -197,7 +232,16 @@ function decisionDraft(
       body: `\n# G1 bulk decision ${decisionId}\n\nFixture decision seeded for the G1 cost-scaling ledger.\n`,
       claims: [{ id: "C1", text: "The fixture ledger carries a real decision with a claim.", loadBearing: true }],
       fulfillments: [],
-      relations: [],
+      relations: [
+        {
+          ...relation,
+          relation_id: deriveRelationId(relation),
+          strength: "strong",
+          origin: "declared",
+          rationale: "G1 bulk decision derives one bulk task.",
+          state: "active",
+        },
+      ],
       provenance: [
         {
           runtime: "unavailable" as const,
@@ -241,28 +285,36 @@ function factDraft(index: number, revision: number): FactEventDraftV1 {
 }
 
 /** Bulk-seeds a ledger to roughly `eventCount` events via direct, canonically-validated appends
- * (no daemon round trip), then edits a settled authored file so materialization stays dirty
- * through every later write — reproducing the concurrent-edit shape #2409 fixed. */
-function seedLedger(
+ * (no daemon round trip) and waits for its follower to publish them, so the measuring writer
+ * attaches to a fully settled Git and worktree. Every seeded kind grows with the ledger, so a cost
+ * that scans tasks, lifecycle transitions, documents, facts, decisions, claims or relations shows up. */
+async function seedLedger(
   rootDir: string,
   repoId: string,
   eventCount: number,
   fence: WriterEpochFenceDescriptor,
-): { readonly editedPath: string } {
+): Promise<{ readonly editedPath: string }> {
   const store = makeTaskEventStore({
     repoId,
     rootDir,
     writerFence: () => ({ repoId: fence.repoId, holderId: fence.holderId, epoch: fence.epoch }),
   });
   try {
-    const taskCount = Math.max(1, Math.floor(eventCount * 0.85)),
+    const taskCount = Math.max(1, Math.floor(eventCount * 0.7)),
+      cancelledCount = Math.floor(eventCount * 0.1),
       docCount = Math.max(1, Math.floor(eventCount * 0.1)),
-      factCount = Math.max(1, eventCount - taskCount - docCount - 2);
+      decisionCount = Math.max(1, Math.floor(eventCount * 0.02)),
+      factCount = Math.max(1, eventCount - taskCount - cancelledCount - docCount - decisionCount),
+      bulkTaskId = (index: number) => `g1-bulk-task-${String(index).padStart(6, "0")}`;
     let revision = store.read().revision;
     for (let index = 0; index < taskCount; index += 1) {
       revision += 1;
-      const taskId = `g1-bulk-task-${String(index).padStart(6, "0")}`,
-        event = taskCreatedEvent(revision, taskId, `G1 bulk task ${index}`);
+      const event = taskCreatedEvent(revision, bulkTaskId(index), `G1 bulk task ${index}`);
+      store.append({ event, plan: taskLifecycleWritePlan(event), blobs: [] });
+    }
+    for (let index = 0; index < cancelledCount; index += 1) {
+      revision += 1;
+      const event = taskCancelledEvent(revision, bulkTaskId(index), `G1 bulk task ${index}`);
       store.append({ event, plan: taskLifecycleWritePlan(event), blobs: [] });
     }
     let editedPath = "";
@@ -283,18 +335,19 @@ function seedLedger(
       const compiled = compileFactWrite({ event: factDraft(index, revision) });
       store.append({ event: compiled.event, plan: compiled.plan, blobs: compiled.blobs });
     }
-    revision += 1;
-    const decisionId = "dec_G1BULK1",
-      compiled = compileDecisionWrite({
-        event: decisionDraft(decisionId, revision),
+    for (let index = 0; index < decisionCount; index += 1) {
+      revision += 1;
+      const compiled = compileDecisionWrite({
+        event: decisionDraft(`dec_G1BULK${String(index).padStart(6, "0")}`, revision, bulkTaskId(index)),
         currentDecision: null,
         currentRelations: [],
         currentDocument: null,
       });
-    store.append({ event: compiled.event, plan: compiled.plan, blobs: compiled.blobs });
+      store.append({ event: compiled.event, plan: compiled.plan, blobs: compiled.blobs });
+    }
     return { editedPath };
   } finally {
-    void store.drain();
+    await store.drain();
   }
 }
 
@@ -347,15 +400,26 @@ function probeControl(worker: Worker, command: "reset" | "snapshot"): Promise<Re
   });
 }
 
-async function measureWorkerOperation<T>(
-  worker: Worker,
-  run: () => Promise<T>,
-): Promise<{ readonly result: T; readonly counters: Record<string, number> }> {
-  await probeControl(worker, "reset");
-  const result = await run();
-  const counters = (await probeControl(worker, "snapshot")) as Record<string, number>;
-  return { result, counters };
+type Measure = (run: () => Promise<unknown>) => Promise<{ readonly result: unknown; readonly counters: Counters }>;
+type Counters = Record<string, number>;
+
+// The worker snapshots after the follower settlement the request queued (g1-writer-probe-import.mjs),
+// so a write's window is the request plus the Git/worktree publication it triggered.
+function writerMeasure(worker: Worker): Measure {
+  return async (run) => {
+    await probeControl(worker, "reset");
+    const result = await run();
+    const counters = (await probeControl(worker, "snapshot")) as Counters;
+    return { result, counters };
+  };
 }
+
+// Host-side reads run synchronously inside the proxy call, so the window closes with the call.
+const hostMeasure: Measure = async (run) => {
+  resetCostProbe();
+  const result = await run();
+  return { result, counters: snapshotCostProbe() };
+};
 
 function assertApplied(label: string, result: unknown): void {
   const outcome = (result as { readonly outcome?: string } | undefined)?.outcome;
@@ -363,11 +427,19 @@ function assertApplied(label: string, result: unknown): void {
     throw new Error(`G1 ${label} was not applied (outcome=${outcome}): ${JSON.stringify(result)}`);
 }
 
+interface Subject {
+  readonly taskId: string;
+  createOpId?: string;
+  packagePath?: string;
+  decisionId?: string;
+}
+
 export interface G1ScaleMeasurement {
   readonly eventCount: number;
-  readonly counts: Record<string, Record<string, number>>;
-  readonly seedMs: number;
-  readonly measureMs: number;
+  /** Steady-state cost: the second call of each operation, the one the gate judges. */
+  readonly counts: Record<string, Counters>;
+  /** The first call of each operation, including one-time per-process work; reference only. */
+  readonly firstCall: Record<string, Counters>;
 }
 
 export async function measureWriteCostScaling(eventCount: number): Promise<G1ScaleMeasurement> {
@@ -379,8 +451,23 @@ export async function measureWriteCostScaling(eventCount: number): Promise<G1Sca
   initRepo(repoDir);
   const rootDir = canonicalRoot(repoDir);
   installCostProbe();
-  const counts: Record<string, Record<string, number>> = {};
-  const seedStartedAt = Date.now();
+  const counts: Record<string, Counters> = {},
+    firstCall: Record<string, Counters> = {},
+    // Every operation runs once to warm per-process caches, then once more to be judged: G1
+    // budgets the work each call does, not a process's one-time setup.
+    subjects: Subject[] = [{ taskId: "g1-warm-task" }, { taskId: "g1-measure-task" }];
+  const each = async (
+    operation: string,
+    measure: Measure,
+    run: (subject: Subject) => Promise<unknown>,
+    check: (result: unknown, subject: Subject) => void = (result) => assertApplied(operation, result),
+  ): Promise<void> => {
+    for (const [index, subject] of subjects.entries()) {
+      const measured = await measure(() => run(subject));
+      check(measured.result, subject);
+      (index === 0 ? firstCall : counts)[operation] = measured.counters;
+    }
+  };
   try {
     const authority = openPersistentWriterEpoch({ stateRoot, holderId: "g1-cost-scaling" }),
       lease = authority.acquire(repoId);
@@ -397,154 +484,110 @@ export async function measureWriteCostScaling(eventCount: number): Promise<G1Sca
     await (
       await openBootstrappedRepoCell({ repoId, rootDir, ownerId: "g1-cost-seed", defaultWriterEpochFence: fence })
     ).close();
-    const seeded = seedLedger(repoDir, repoId, eventCount, fence);
-    const seedMs = Date.now() - seedStartedAt;
+    const seeded = await seedLedger(repoDir, repoId, eventCount, fence);
+    // A ledger-owned prose file carries an unsubmitted local edit when the writer attaches, and
+    // keeps it through warmup and every measured write: the state a daemon (re)starts into on a
+    // live ledger. The follower must leave the edit alone without replaying history around it;
+    // 944a86ced did replay it, on every write, once a settlement had met the edit.
+    writeFileSync(path.join(repoDir, "harness", seeded.editedPath), "G1 local edit kept dirty through every write.\n");
 
-    const measureStartedAt = Date.now();
-    const handle = await openProbedSupervisor(repoId, rootDir, "g1-cost-measure", fence);
+    const handle = await openProbedSupervisor(repoId, rootDir, "g1-cost-measure", fence),
+      measure = writerMeasure(handle.worker);
     try {
-      // Warm up materialization on the already-attached probed writer, then dirty the settled
-      // authored file with a local edit that must survive every later write in this same
-      // attach — the exact shape 944a86ced regressed on. Introducing the edit only after a clean
-      // attach (rather than before) matches production: the daemon attaches once and stays warm.
       await handle.supervisor.request("settlePendingMaterialization", "g1 warmup");
-      if (seeded.editedPath)
-        writeFileSync(
-          path.join(repoDir, "harness", seeded.editedPath),
-          "G1 local edit kept dirty through every write.\n",
+      const run = (action: Record<string, unknown>, binding = writeBinding) =>
+        handle.supervisor.request<{ readonly opId: string; readonly packagePath: string; readonly evidence: string }>(
+          "run",
+          { action },
+          binding,
         );
 
-      const taskId = "g1-measure-task";
-      const created = await measureWorkerOperation(handle.worker, () =>
-        handle.supervisor.request<{ readonly opId: string; readonly packagePath: string }>(
-          "run",
-          { action: { kind: "task-create", taskId, title: "G1 measured create" } },
-          writeBinding,
-        ),
+      await each(
+        "task-create",
+        measure,
+        (subject) => run({ kind: "task-create", taskId: subject.taskId, title: `G1 measured ${subject.taskId}` }),
+        (result, subject) => {
+          assertApplied("task-create", result);
+          const created = result as { readonly opId: string; readonly packagePath: string };
+          subject.createOpId = created.opId;
+          subject.packagePath = created.packagePath;
+        },
       );
-      counts["task-create"] = created.counters;
-      assertApplied("task-create", created.result);
-      const createOpId = created.result.opId,
-        packagePath = created.result.packagePath;
-
-      const planPath = `${packagePath}/task_plan.md`;
-      mkdirSync(path.dirname(path.join(repoDir, "harness", planPath)), { recursive: true });
-      writeFileSync(path.join(repoDir, "harness", planPath), realizedTaskPlan("G1 measured task"));
-      const submitted = await measureWorkerOperation(handle.worker, () =>
-        handle.supervisor.request("run", { action: { kind: "doc-submit", paths: [planPath] } }, writeBinding),
+      await each("doc-submit", measure, (subject) => {
+        const planPath = `${subject.packagePath}/task_plan.md`;
+        mkdirSync(path.dirname(path.join(repoDir, "harness", planPath)), { recursive: true });
+        writeFileSync(path.join(repoDir, "harness", planPath), realizedTaskPlan(`G1 measured ${subject.taskId}`));
+        return run({ kind: "doc-submit", paths: [planPath] });
+      });
+      await each("task-start", measure, (subject) =>
+        run({ kind: "task-start", taskId: subject.taskId, executionId: `${subject.taskId}-execution` }),
       );
-      counts["doc-submit"] = submitted.counters;
-      assertApplied("doc-submit", submitted.result);
-
-      const executionId = "g1-measure-execution";
-      const started = await measureWorkerOperation(handle.worker, () =>
-        handle.supervisor.request("run", { action: { kind: "task-start", taskId, executionId } }, writeBinding),
+      await each("task-progress-append", measure, (subject) =>
+        run({ kind: "task-progress-append", taskId: subject.taskId, text: "G1 measured progress note.", evidence: [] }),
       );
-      counts["task-start"] = started.counters;
-      assertApplied("task-start", started.result);
-
-      const progressed = await measureWorkerOperation(handle.worker, () =>
-        handle.supervisor.request(
-          "run",
-          { action: { kind: "task-progress-append", taskId, text: "G1 measured progress note.", evidence: [] } },
-          writeBinding,
-        ),
+      await each("fact-record", measure, (subject) =>
+        run({
+          kind: "fact-record",
+          taskId: subject.taskId,
+          statement: `G1 measured fact for ${subject.taskId}.`,
+          evidenceSource: "g1:measure",
+          confidence: "high",
+          memoryClass: "semantic",
+          memoryTags: [],
+        }),
       );
-      counts["task-progress-append"] = progressed.counters;
-      assertApplied("task-progress-append", progressed.result);
-
-      const recorded = await measureWorkerOperation(handle.worker, () =>
-        handle.supervisor.request(
-          "run",
+      await each(
+        "decision-propose",
+        measure,
+        (subject) =>
+          run({
+            kind: "decision-propose",
+            body: realizedDecisionBody(`G1 measured decision for ${subject.taskId}`),
+            jsonInput: JSON.stringify({
+              title: `G1 measured decision for ${subject.taskId}`,
+              question: "Does one decision propose without extra cost at scale?",
+              riskTier: "medium",
+              urgency: "medium",
+              vertical: "software/coding",
+              preset: "standard-task",
+              decisionClass: "ordinary",
+              appliesTo: { modules: ["daemon"], productLines: [] },
+              chosen: [{ id: "CH1", text: "Measure the propose action directly." }],
+              rejected: [
+                { id: "RJ1", text: "Skip decision coverage.", whyNot: "Decisions are a durable write kind too." },
+              ],
+              claims: [{ id: "C1", text: "G1 measures decision-propose and one transition.", loadBearing: true }],
+              fulfillments: [],
+            }),
+          }),
+        (result, subject) => {
+          const evidence = (result as { readonly evidence?: string }).evidence;
+          if (!evidence?.startsWith("{"))
+            throw new Error(`G1 decision-propose was not applied: ${JSON.stringify(result)}`);
+          subject.decisionId = (JSON.parse(evidence) as { readonly decisionId: string }).decisionId;
+        },
+      );
+      await each("decision-reject", measure, (subject) =>
+        run(
           {
-            action: {
-              kind: "fact-record",
-              taskId,
-              statement: "G1 measured fact for the cost-scaling gate.",
-              evidenceSource: "g1:measure",
-              confidence: "high",
-              memoryClass: "semantic",
-              memoryTags: [],
-            },
-          },
-          writeBinding,
-        ),
-      );
-      counts["fact-record"] = recorded.counters;
-      assertApplied("fact-record", recorded.result);
-
-      const decisionPacket = {
-        title: "G1 measured decision",
-        question: "Does one decision propose without extra cost at scale?",
-        riskTier: "medium",
-        urgency: "medium",
-        vertical: "software/coding",
-        preset: "standard-task",
-        decisionClass: "ordinary",
-        appliesTo: { modules: ["daemon"], productLines: [] },
-        chosen: [{ id: "CH1", text: "Measure the propose action directly." }],
-        rejected: [{ id: "RJ1", text: "Skip decision coverage.", whyNot: "Decisions are a durable write kind too." }],
-        claims: [{ id: "C1", text: "G1 measures decision-propose and one transition.", loadBearing: true }],
-        fulfillments: [],
-      };
-      const proposed = await measureWorkerOperation(handle.worker, () =>
-        handle.supervisor.request<{ readonly evidence: string }>(
-          "run",
-          {
-            action: {
-              kind: "decision-propose",
-              body: realizedDecisionBody("G1 measured decision"),
-              jsonInput: JSON.stringify(decisionPacket),
-            },
-          },
-          writeBinding,
-        ),
-      );
-      counts["decision-propose"] = proposed.counters;
-      if (!proposed.result.evidence?.startsWith("{"))
-        throw new Error(`G1 decision-propose was not applied: ${JSON.stringify(proposed.result)}`);
-      const decisionId = (JSON.parse(proposed.result.evidence) as { readonly decisionId: string }).decisionId;
-
-      const accepted = await measureWorkerOperation(handle.worker, () =>
-        handle.supervisor.request(
-          "run",
-          {
-            action: {
-              kind: "decision-reject",
-              decisionId,
-              reason: "G1 measured rejection reason for the cost-scaling gate fixture decision.",
-            },
+            kind: "decision-reject",
+            decisionId: subject.decisionId,
+            reason: "G1 measured rejection reason for the cost-scaling gate fixture decision.",
           },
           arbiterBinding,
         ),
       );
-      counts["decision-reject"] = accepted.counters;
-      assertApplied("decision-reject", accepted.result);
-
-      const related = await measureWorkerOperation(handle.worker, () =>
-        handle.supervisor.request(
-          "run",
-          {
-            action: {
-              kind: "relation-relate",
-              sourceRef: `decision/${decisionId}/CH1`,
-              targetRef: `task/${taskId}`,
-              relationType: "derives",
-              rationale: "G1 measured relation for the cost-scaling gate.",
-              expectedVersion: 0,
-            },
-          },
-          writeBinding,
-        ),
+      await each("relation-relate", measure, (subject) =>
+        run({
+          kind: "relation-relate",
+          sourceRef: `decision/${subject.decisionId}/CH1`,
+          targetRef: `task/${subject.taskId}`,
+          relationType: "derives",
+          rationale: "G1 measured relation for the cost-scaling gate.",
+          expectedVersion: 0,
+        }),
       );
-      counts["relation-relate"] = related.counters;
-      assertApplied("relation-relate", related.result);
-
-      const shown = await measureWorkerOperation(handle.worker, () =>
-        handle.supervisor.request("run", { action: { kind: "receipt-show", opId: createOpId } }, writeBinding),
-      );
-      counts["receipt-show"] = shown.counters;
-      assertApplied("receipt-show", shown.result);
+      await each("receipt-show", measure, (subject) => run({ kind: "receipt-show", opId: subject.createOpId }));
     } finally {
       await handle.supervisor.close();
     }
@@ -556,31 +599,32 @@ export async function measureWriteCostScaling(eventCount: number): Promise<G1Sca
       defaultWriterEpochFence: fence,
     });
     try {
-      resetCostProbe();
-      await readCell.read("repo.tasks.list");
-      counts["task-list"] = snapshotCostProbe();
-
-      resetCostProbe();
-      await readCell.run({ kind: "task-show", taskId: "g1-measure-task" }, writeBinding);
-      counts["task-show"] = snapshotCostProbe();
-
-      resetCostProbe();
-      await readCell.read("repo.agenda.read");
-      counts["agenda"] = snapshotCostProbe();
-
-      resetCostProbe();
-      readCell.workspaceSummary();
-      counts["runtime-overview"] = snapshotCostProbe();
+      // List reads are judged at a page the 200-event ledger already fills in every bucket (it seeds
+      // 120 planned tasks and 4 proposed decisions), so both scales return the same full page and
+      // any row growth is work outside it. An unbounded full-set read scales with its result by
+      // definition and is not what G1 budgets.
+      const limit = 3;
+      await each("task-list", hostMeasure, () => readCell.run({ kind: "task-list", limit }, writeBinding));
+      await each("task-show", hostMeasure, (subject) =>
+        readCell.run({ kind: "task-show", taskId: subject.taskId }, writeBinding),
+      );
+      await each(
+        "agenda",
+        hostMeasure,
+        () => readCell.read("repo.agenda.read", { limit }),
+        () => undefined,
+      );
+      await each(
+        "runtime-overview",
+        hostMeasure,
+        async () => readCell.workspaceSummary(),
+        () => undefined,
+      );
     } finally {
       await readCell.close();
     }
-    const measureMs = Date.now() - measureStartedAt;
-    return { eventCount, counts, seedMs, measureMs };
+    return { eventCount, counts, firstCall };
   } finally {
     rmSync(parent, { recursive: true, force: true });
   }
-}
-
-export function g1FixturesDir(): string {
-  return path.dirname(fileURLToPath(import.meta.url));
 }

--- a/packages/daemon/test/fixtures/g1-write-cost-scaling.ts
+++ b/packages/daemon/test/fixtures/g1-write-cost-scaling.ts
@@ -1,0 +1,585 @@
+// harness-test-tier: integration
+// G1 write-cost-scaling gate fixture: builds a ledger of a given size with a realistic mix of
+// event kinds, then drives every durable write kind and hot read once through the production
+// daemon request path, measuring deterministic cost (SQL rows read, sha256 calls/bytes, git
+// subprocess count, file-read bytes) at the point each operation actually executes:
+//   - writes and receipt-show execute inside the writer worker thread (instrumented via the
+//     `--import` preload g1-writer-probe-import.mjs, mirroring writer-request-cost.integration.test.ts);
+//   - task-list/task-show/agenda/workspace-summary are intercepted host-side by the RepoCell
+//     proxy (packages/daemon/src/repo-cell-proxy.ts) and are instrumented in this process directly.
+// No production hook is added anywhere; every patch lives in g1-cost-probe.mjs.
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { randomUUID } from "node:crypto";
+import { Worker } from "node:worker_threads";
+import { makeTaskEventStore, taskLifecycleWritePlan } from "../../../kernel/src/index.ts";
+import {
+  docSyncWritePlan,
+  DOC_CODEC_ID,
+  DOC_POLICY_ID,
+  type DocEventV1,
+} from "../../../kernel/src/domain/doc-sync.contract.ts";
+import { compileDecisionWrite, type DecisionEventDraftV1 } from "../../../kernel/src/domain/decision-event.ts";
+import { compileFactWrite, type FactEventDraftV1 } from "../../../kernel/src/domain/fact-event.ts";
+import { sha256Text } from "../../../kernel/src/integrity/stable-hash.ts";
+import { REPLAY_TASK_GRAPH } from "../../../kernel/src/domain/task-graph.ts";
+import type { TaskCreatedEvent } from "../../../kernel/src/domain/task-lifecycle.contract.ts";
+import { canonicalRoot, workspaceId } from "../../src/protocol/daemon-protocol.contract.ts";
+import { openPersistentWriterEpoch, type WriterEpochFenceDescriptor } from "../../src/writer-epoch.ts";
+import { openWriterSupervisor } from "../../src/writer-supervisor.ts";
+import { openRepoCell } from "../../src/repo-cell.ts";
+import { openBootstrappedRepoCell } from "../repo-settings.fixture.ts";
+import { withRoleBinding } from "../role-binding.fixtures.ts";
+import { initRepo } from "../task-surface.fixtures.ts";
+import { realizedDecisionBody, realizedTaskPlan } from "../../../../tools/fixtures/task-plan.mjs";
+import { installCostProbe, resetCostProbe, snapshotCostProbe } from "./g1-cost-probe.mjs";
+
+export const G1_METRICS = Object.freeze(["sqlRowsRead", "sha256Calls", "sha256Bytes", "gitProcesses", "fileReadBytes"]);
+export const G1_WRITE_OPERATIONS = Object.freeze([
+  "task-create",
+  "doc-submit",
+  "task-start",
+  "task-progress-append",
+  "fact-record",
+  "decision-propose",
+  "decision-reject",
+  "relation-relate",
+  "receipt-show",
+]);
+export const G1_READ_OPERATIONS = Object.freeze(["task-list", "task-show", "agenda", "runtime-overview"]);
+export const G1_OPERATIONS = Object.freeze([...G1_WRITE_OPERATIONS, ...G1_READ_OPERATIONS]);
+
+const actor = {
+  principal: { personId: "person-g1-cost" },
+  executor: { kind: "agent" as const, id: "g1-cost-scaling" },
+};
+const writeBinding = withRoleBinding({ actor, source: "local" as const }, "repo-write");
+// A decision's proposer cannot also accept it; the arbiter binding must be a distinct actor.
+const arbiterActor = {
+  principal: { personId: "person-g1-arbiter" },
+  executor: { kind: "agent" as const, id: "g1-cost-arbiter" },
+};
+const arbiterBinding = withRoleBinding({ actor: arbiterActor, source: "local" as const }, "arbiter");
+const CROCKFORD = "0123456789ABCDEFGHJKMNPQRSTVWXYZ";
+
+function factIdFor(index: number): string {
+  let value = index + 1,
+    code = "";
+  for (let position = 0; position < 8; position += 1) {
+    code = CROCKFORD[value % CROCKFORD.length] + code;
+    value = Math.floor(value / CROCKFORD.length);
+  }
+  return `F-${code}`;
+}
+
+function git(rootDir: string, ...args: readonly string[]): string {
+  return execFileSync("git", ["-C", rootDir, ...args], { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] }).trim();
+}
+
+function taskCreatedEvent(revision: number, taskId: string, title: string): TaskCreatedEvent {
+  return {
+    schema: "task-event/v1",
+    eventId: `event-${taskId}`,
+    workspaceRevision: revision,
+    opId: `op-${taskId}`,
+    taskId,
+    type: "task_created",
+    actor: { principal: { personId: "person-g1-bulk" }, executor: { kind: "agent", id: "g1-bulk" } },
+    source: "local",
+    occurredAt: "2026-08-11T00:00:00.000Z",
+    payload: {
+      task: {
+        schema: "task/v2",
+        taskId,
+        title,
+        taskClass: "standard",
+        status: "planned",
+        graph: REPLAY_TASK_GRAPH,
+        currentNode: "implementation",
+        iteration: 0,
+        createdBy: { principal: { personId: "person-g1-bulk" }, executor: { kind: "agent", id: "g1-bulk" } },
+        completionGateIds: [],
+        presetSnapshotDigest: null,
+        pinned: false,
+        packageDisposition: "active",
+      },
+    },
+  };
+}
+
+function docWriteBundle(
+  store: ReturnType<typeof makeTaskEventStore>,
+  body: string,
+  revision: number,
+  opId: string,
+  target: string,
+): {
+  readonly event: DocEventV1;
+  readonly plan: ReturnType<typeof docSyncWritePlan>;
+  readonly blobs: readonly unknown[];
+} {
+  const hash = sha256Text(body),
+    value: DocEventV1 = {
+      schema: "doc-event/v1",
+      eventId: `event-${opId}`,
+      workspaceRevision: revision,
+      opId,
+      type: "documents_written",
+      actor: { principal: { personId: "person-g1-bulk" }, executor: { kind: "agent", id: "g1-bulk" } },
+      source: "local",
+      occurredAt: "2026-08-11T00:00:00.000Z",
+      payload: {
+        executionId: "execution-g1-bulk",
+        baseLedgerSha: store.currentCut(),
+        changes: [
+          {
+            path: target,
+            baseBlobSha256: null,
+            policyId: DOC_POLICY_ID,
+            candidate: { sha256: hash, size: Buffer.byteLength(body), mediaType: "text/markdown" },
+            // additiveProof (doc-sync-regions.ts) assigns a headingless body the "prose/*" region
+            // id when there is no prior base region to match against.
+            regionProofs: [
+              {
+                regionId: "prose/*",
+                policyId: DOC_POLICY_ID,
+                codecId: DOC_CODEC_ID,
+                baseSha256: sha256Text(""),
+                candidateSha256: hash,
+                insertBytes: Buffer.byteLength(body),
+              },
+            ],
+          },
+        ],
+      },
+    };
+  return {
+    event: value,
+    plan: docSyncWritePlan(value),
+    blobs: [{ sha256: hash, size: Buffer.byteLength(body), mediaType: "text/markdown", body }],
+  };
+}
+
+function decisionDraft(
+  decisionId: string,
+  revision: number,
+): Extract<DecisionEventDraftV1, { readonly type: "decision_proposed" }> {
+  return {
+    schema: "decision-event/v1",
+    eventId: `event-${decisionId}`,
+    workspaceRevision: revision,
+    opId: `op-${decisionId}`,
+    decisionId,
+    type: "decision_proposed",
+    actor: { principal: { personId: "person-g1-bulk" }, executor: null },
+    source: "local",
+    occurredAt: "2026-08-11T00:00:00.000Z",
+    payload: {
+      title: `G1 bulk decision ${decisionId}`,
+      question: "Does the write cost stay flat as the ledger grows?",
+      riskTier: "medium",
+      urgency: "medium",
+      vertical: "software/coding",
+      preset: "standard-task",
+      appliesTo: { modules: ["daemon"], productLines: [] },
+      decisionClass: "ordinary",
+      chosen: [{ id: "CH1", text: "Measure deterministic cost at two scales." }],
+      rejected: [{ id: "RJ1", text: "Trust wall-clock alone.", whyNot: "Shared runners make it noisy." }],
+      body: `\n# G1 bulk decision ${decisionId}\n\nFixture decision seeded for the G1 cost-scaling ledger.\n`,
+      claims: [{ id: "C1", text: "The fixture ledger carries a real decision with a claim.", loadBearing: true }],
+      fulfillments: [],
+      relations: [],
+      provenance: [
+        {
+          runtime: "unavailable" as const,
+          sessionId: null,
+          transcriptReachability: "unavailable" as const,
+          boundAt: "2026-08-11T00:00:00.000Z",
+        },
+      ],
+    },
+  };
+}
+
+function factDraft(index: number, revision: number): FactEventDraftV1 {
+  return {
+    schema: "fact-event/v1",
+    eventId: `event-fact-${index}`,
+    workspaceRevision: revision,
+    opId: `op-fact-${index}`,
+    factId: factIdFor(index),
+    type: "fact_recorded",
+    actor: { principal: { personId: "person-g1-bulk" }, executor: { kind: "agent", id: "g1-bulk" } },
+    source: "local",
+    occurredAt: "2026-08-11T00:00:00.000Z",
+    payload: {
+      statement: `G1 bulk fact ${index} observed for the cost-scaling ledger.`,
+      evidenceSource: "g1:bulk-fixture",
+      observedAt: "2026-08-11T00:00:00.000Z",
+      confidence: "high",
+      memoryClass: "semantic",
+      memoryTags: [],
+      provenance: [
+        {
+          runtime: "unavailable",
+          sessionId: null,
+          transcriptReachability: "unavailable",
+          boundAt: "2026-08-11T00:00:00.000Z",
+        },
+      ],
+    },
+  } as FactEventDraftV1;
+}
+
+/** Bulk-seeds a ledger to roughly `eventCount` events via direct, canonically-validated appends
+ * (no daemon round trip), then edits a settled authored file so materialization stays dirty
+ * through every later write — reproducing the concurrent-edit shape #2409 fixed. */
+function seedLedger(
+  rootDir: string,
+  repoId: string,
+  eventCount: number,
+  fence: WriterEpochFenceDescriptor,
+): { readonly editedPath: string } {
+  const store = makeTaskEventStore({
+    repoId,
+    rootDir,
+    writerFence: () => ({ repoId: fence.repoId, holderId: fence.holderId, epoch: fence.epoch }),
+  });
+  try {
+    const taskCount = Math.max(1, Math.floor(eventCount * 0.85)),
+      docCount = Math.max(1, Math.floor(eventCount * 0.1)),
+      factCount = Math.max(1, eventCount - taskCount - docCount - 2);
+    let revision = store.read().revision;
+    for (let index = 0; index < taskCount; index += 1) {
+      revision += 1;
+      const taskId = `g1-bulk-task-${String(index).padStart(6, "0")}`,
+        event = taskCreatedEvent(revision, taskId, `G1 bulk task ${index}`);
+      store.append({ event, plan: taskLifecycleWritePlan(event), blobs: [] });
+    }
+    let editedPath = "";
+    for (let index = 0; index < docCount; index += 1) {
+      revision += 1;
+      const target = `context/g1-bulk-doc-${String(index).padStart(6, "0")}.md`,
+        // A single-line body keeps additiveProof's computed region proofs to one "heading/shared"
+        // region, matching the proven docBundle fixture shape (task-event-store.fixtures.ts) that
+        // this helper mirrors; a multi-paragraph body splits into more regions than a hand-built
+        // proof can match.
+        body = `G1 bulk document ${index} filler prose for the cost-scaling ledger.\n`,
+        { event, plan, blobs } = docWriteBundle(store, body, revision, `op-g1-bulk-doc-${index}`, target);
+      store.append({ event, plan, blobs });
+      if (index === 0) editedPath = target;
+    }
+    for (let index = 0; index < factCount; index += 1) {
+      revision += 1;
+      const compiled = compileFactWrite({ event: factDraft(index, revision) });
+      store.append({ event: compiled.event, plan: compiled.plan, blobs: compiled.blobs });
+    }
+    revision += 1;
+    const decisionId = "dec_G1BULK1",
+      compiled = compileDecisionWrite({
+        event: decisionDraft(decisionId, revision),
+        currentDecision: null,
+        currentRelations: [],
+        currentDocument: null,
+      });
+    store.append({ event: compiled.event, plan: compiled.plan, blobs: compiled.blobs });
+    return { editedPath };
+  } finally {
+    void store.drain();
+  }
+}
+
+function probedCreateWorker(execArgvExtra: readonly string[]) {
+  return (url: URL, options: { readonly execArgv: readonly string[]; readonly workerData: unknown }) =>
+    new Worker(url, { ...options, execArgv: [...options.execArgv, ...execArgvExtra] });
+}
+
+interface RequestHandle {
+  readonly supervisor: Awaited<ReturnType<typeof openWriterSupervisor>>;
+  readonly worker: Worker;
+}
+
+async function openProbedSupervisor(
+  repoId: string,
+  rootDir: string,
+  ownerId: string,
+  fence: WriterEpochFenceDescriptor,
+): Promise<RequestHandle> {
+  const probeUrl = new URL("./g1-writer-probe-import.mjs", import.meta.url).href;
+  let capturedWorker: Worker | undefined;
+  const supervisor = await openWriterSupervisor(
+    { repoId: repoId as never, rootDir: rootDir as never, ownerId, defaultWriterEpochFence: fence },
+    {
+      createWorker: (url, options) => {
+        const worker = new Worker(url, { ...options, execArgv: [...options.execArgv, "--import", probeUrl] });
+        capturedWorker = worker;
+        return worker;
+      },
+    },
+  );
+  if (!capturedWorker) throw new Error("G1 probed worker was not captured");
+  return { supervisor, worker: capturedWorker };
+}
+
+function probeControl(worker: Worker, command: "reset" | "snapshot"): Promise<Record<string, number> | void> {
+  const requestId = randomUUID();
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(`G1 probe ${command} timed out`)), 10_000);
+    const onMessage = (message: unknown) => {
+      const value = message as {
+        readonly schema?: string;
+        readonly requestId?: string;
+        readonly counters?: Record<string, number>;
+      };
+      if (value?.requestId !== requestId) return;
+      if (value.schema === "g1-cost-probe-ack/v1" || value.schema === "g1-cost-probe-result/v1") {
+        clearTimeout(timer);
+        worker.off("message", onMessage);
+        resolve(value.counters);
+      }
+    };
+    worker.on("message", onMessage);
+    worker.postMessage({ schema: "g1-cost-probe-control/v1", command, requestId });
+  });
+}
+
+async function measureWorkerOperation<T>(
+  worker: Worker,
+  run: () => Promise<T>,
+): Promise<{ readonly result: T; readonly counters: Record<string, number> }> {
+  await probeControl(worker, "reset");
+  const result = await run();
+  const counters = (await probeControl(worker, "snapshot")) as Record<string, number>;
+  return { result, counters };
+}
+
+function assertApplied(label: string, result: unknown): void {
+  const outcome = (result as { readonly outcome?: string } | undefined)?.outcome;
+  if (outcome !== "applied")
+    throw new Error(`G1 ${label} was not applied (outcome=${outcome}): ${JSON.stringify(result)}`);
+}
+
+export interface G1ScaleMeasurement {
+  readonly eventCount: number;
+  readonly counts: Record<string, Record<string, number>>;
+  readonly seedMs: number;
+  readonly measureMs: number;
+}
+
+export async function measureWriteCostScaling(eventCount: number): Promise<G1ScaleMeasurement> {
+  const parent = mkdtempSync(path.join(tmpdir(), "ha-g1-cost-")),
+    repoDir = path.join(parent, "repo"),
+    stateRoot = path.join(parent, "writer-epochs"),
+    repoId = workspaceId(`g1-cost-${eventCount}`);
+  mkdirSync(repoDir, { recursive: true });
+  initRepo(repoDir);
+  const rootDir = canonicalRoot(repoDir);
+  installCostProbe();
+  const counts: Record<string, Record<string, number>> = {};
+  const seedStartedAt = Date.now();
+  try {
+    const authority = openPersistentWriterEpoch({ stateRoot, holderId: "g1-cost-scaling" }),
+      lease = authority.acquire(repoId);
+    authority.close();
+    const fence: WriterEpochFenceDescriptor = {
+      schema: "harness-writer-epoch-fence/v1",
+      stateRoot,
+      repoId,
+      epoch: lease.epoch,
+      holderId: lease.holderId,
+    };
+    // Settings/vertical bootstrap through the real production cell, exactly like
+    // writer-request-cost.integration.test.ts; then release it before seeding events directly.
+    await (
+      await openBootstrappedRepoCell({ repoId, rootDir, ownerId: "g1-cost-seed", defaultWriterEpochFence: fence })
+    ).close();
+    const seeded = seedLedger(repoDir, repoId, eventCount, fence);
+    const seedMs = Date.now() - seedStartedAt;
+
+    const measureStartedAt = Date.now();
+    const handle = await openProbedSupervisor(repoId, rootDir, "g1-cost-measure", fence);
+    try {
+      // Warm up materialization on the already-attached probed writer, then dirty the settled
+      // authored file with a local edit that must survive every later write in this same
+      // attach — the exact shape 944a86ced regressed on. Introducing the edit only after a clean
+      // attach (rather than before) matches production: the daemon attaches once and stays warm.
+      await handle.supervisor.request("settlePendingMaterialization", "g1 warmup");
+      if (seeded.editedPath)
+        writeFileSync(
+          path.join(repoDir, "harness", seeded.editedPath),
+          "G1 local edit kept dirty through every write.\n",
+        );
+
+      const taskId = "g1-measure-task";
+      const created = await measureWorkerOperation(handle.worker, () =>
+        handle.supervisor.request<{ readonly opId: string; readonly packagePath: string }>(
+          "run",
+          { action: { kind: "task-create", taskId, title: "G1 measured create" } },
+          writeBinding,
+        ),
+      );
+      counts["task-create"] = created.counters;
+      assertApplied("task-create", created.result);
+      const createOpId = created.result.opId,
+        packagePath = created.result.packagePath;
+
+      const planPath = `${packagePath}/task_plan.md`;
+      mkdirSync(path.dirname(path.join(repoDir, "harness", planPath)), { recursive: true });
+      writeFileSync(path.join(repoDir, "harness", planPath), realizedTaskPlan("G1 measured task"));
+      const submitted = await measureWorkerOperation(handle.worker, () =>
+        handle.supervisor.request("run", { action: { kind: "doc-submit", paths: [planPath] } }, writeBinding),
+      );
+      counts["doc-submit"] = submitted.counters;
+      assertApplied("doc-submit", submitted.result);
+
+      const executionId = "g1-measure-execution";
+      const started = await measureWorkerOperation(handle.worker, () =>
+        handle.supervisor.request("run", { action: { kind: "task-start", taskId, executionId } }, writeBinding),
+      );
+      counts["task-start"] = started.counters;
+      assertApplied("task-start", started.result);
+
+      const progressed = await measureWorkerOperation(handle.worker, () =>
+        handle.supervisor.request(
+          "run",
+          { action: { kind: "task-progress-append", taskId, text: "G1 measured progress note.", evidence: [] } },
+          writeBinding,
+        ),
+      );
+      counts["task-progress-append"] = progressed.counters;
+      assertApplied("task-progress-append", progressed.result);
+
+      const recorded = await measureWorkerOperation(handle.worker, () =>
+        handle.supervisor.request(
+          "run",
+          {
+            action: {
+              kind: "fact-record",
+              taskId,
+              statement: "G1 measured fact for the cost-scaling gate.",
+              evidenceSource: "g1:measure",
+              confidence: "high",
+              memoryClass: "semantic",
+              memoryTags: [],
+            },
+          },
+          writeBinding,
+        ),
+      );
+      counts["fact-record"] = recorded.counters;
+      assertApplied("fact-record", recorded.result);
+
+      const decisionPacket = {
+        title: "G1 measured decision",
+        question: "Does one decision propose without extra cost at scale?",
+        riskTier: "medium",
+        urgency: "medium",
+        vertical: "software/coding",
+        preset: "standard-task",
+        decisionClass: "ordinary",
+        appliesTo: { modules: ["daemon"], productLines: [] },
+        chosen: [{ id: "CH1", text: "Measure the propose action directly." }],
+        rejected: [{ id: "RJ1", text: "Skip decision coverage.", whyNot: "Decisions are a durable write kind too." }],
+        claims: [{ id: "C1", text: "G1 measures decision-propose and one transition.", loadBearing: true }],
+        fulfillments: [],
+      };
+      const proposed = await measureWorkerOperation(handle.worker, () =>
+        handle.supervisor.request<{ readonly evidence: string }>(
+          "run",
+          {
+            action: {
+              kind: "decision-propose",
+              body: realizedDecisionBody("G1 measured decision"),
+              jsonInput: JSON.stringify(decisionPacket),
+            },
+          },
+          writeBinding,
+        ),
+      );
+      counts["decision-propose"] = proposed.counters;
+      if (!proposed.result.evidence?.startsWith("{"))
+        throw new Error(`G1 decision-propose was not applied: ${JSON.stringify(proposed.result)}`);
+      const decisionId = (JSON.parse(proposed.result.evidence) as { readonly decisionId: string }).decisionId;
+
+      const accepted = await measureWorkerOperation(handle.worker, () =>
+        handle.supervisor.request(
+          "run",
+          {
+            action: {
+              kind: "decision-reject",
+              decisionId,
+              reason: "G1 measured rejection reason for the cost-scaling gate fixture decision.",
+            },
+          },
+          arbiterBinding,
+        ),
+      );
+      counts["decision-reject"] = accepted.counters;
+      assertApplied("decision-reject", accepted.result);
+
+      const related = await measureWorkerOperation(handle.worker, () =>
+        handle.supervisor.request(
+          "run",
+          {
+            action: {
+              kind: "relation-relate",
+              sourceRef: `decision/${decisionId}/CH1`,
+              targetRef: `task/${taskId}`,
+              relationType: "derives",
+              rationale: "G1 measured relation for the cost-scaling gate.",
+              expectedVersion: 0,
+            },
+          },
+          writeBinding,
+        ),
+      );
+      counts["relation-relate"] = related.counters;
+      assertApplied("relation-relate", related.result);
+
+      const shown = await measureWorkerOperation(handle.worker, () =>
+        handle.supervisor.request("run", { action: { kind: "receipt-show", opId: createOpId } }, writeBinding),
+      );
+      counts["receipt-show"] = shown.counters;
+      assertApplied("receipt-show", shown.result);
+    } finally {
+      await handle.supervisor.close();
+    }
+
+    const readCell = await openRepoCell({
+      repoId: repoId as never,
+      rootDir: rootDir as never,
+      ownerId: "g1-cost-read",
+      defaultWriterEpochFence: fence,
+    });
+    try {
+      resetCostProbe();
+      await readCell.read("repo.tasks.list");
+      counts["task-list"] = snapshotCostProbe();
+
+      resetCostProbe();
+      await readCell.run({ kind: "task-show", taskId: "g1-measure-task" }, writeBinding);
+      counts["task-show"] = snapshotCostProbe();
+
+      resetCostProbe();
+      await readCell.read("repo.agenda.read");
+      counts["agenda"] = snapshotCostProbe();
+
+      resetCostProbe();
+      readCell.workspaceSummary();
+      counts["runtime-overview"] = snapshotCostProbe();
+    } finally {
+      await readCell.close();
+    }
+    const measureMs = Date.now() - measureStartedAt;
+    return { eventCount, counts, seedMs, measureMs };
+  } finally {
+    rmSync(parent, { recursive: true, force: true });
+  }
+}
+
+export function g1FixturesDir(): string {
+  return path.dirname(fileURLToPath(import.meta.url));
+}

--- a/packages/daemon/test/fixtures/g1-write-cost-scaling.ts
+++ b/packages/daemon/test/fixtures/g1-write-cost-scaling.ts
@@ -8,24 +8,34 @@
 //   - task-list/task-show/agenda/workspace-summary are intercepted host-side by the RepoCell
 //     proxy (packages/daemon/src/repo-cell-proxy.ts) and are instrumented in this process directly.
 // No production hook is added anywhere; every patch lives in g1-cost-probe.mjs.
-import { execFileSync } from "node:child_process";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { randomUUID } from "node:crypto";
 import { Worker } from "node:worker_threads";
-import { makeTaskEventStore, taskLifecycleWritePlan } from "../../../kernel/src/index.ts";
 import {
+  compileDecisionWrite,
+  compileFactWrite,
   docSyncWritePlan,
-  DOC_CODEC_ID,
   DOC_POLICY_ID,
+  makeTaskEventStore,
+  REPLAY_TASK_GRAPH,
+  sha256Text,
+  taskLifecycleWritePlan,
   type DocEventV1,
-} from "../../../kernel/src/domain/doc-sync.contract.ts";
-import { compileDecisionWrite, type DecisionEventDraftV1 } from "../../../kernel/src/domain/decision-event.ts";
-import { compileFactWrite, type FactEventDraftV1 } from "../../../kernel/src/domain/fact-event.ts";
-import { sha256Text } from "../../../kernel/src/integrity/stable-hash.ts";
-import { REPLAY_TASK_GRAPH } from "../../../kernel/src/domain/task-graph.ts";
+} from "../../../kernel/src/index.ts";
+// These four are internal-only shapes with no public-barrel re-export (kernel/src/index.ts); the
+// fixture still needs their exact structural types to hand-build canonically-valid events, so it
+// reaches past the barrel the same way packages/daemon/test/decision-surface.test.ts already does
+// for readColdRebuildSource.
+// eslint-disable-next-line no-restricted-imports
+import { DOC_CODEC_ID } from "../../../kernel/src/domain/doc-sync.contract.ts";
+// eslint-disable-next-line no-restricted-imports
+import type { DecisionEventDraftV1 } from "../../../kernel/src/domain/decision-event.ts";
+// eslint-disable-next-line no-restricted-imports
+import type { FactEventDraftV1 } from "../../../kernel/src/domain/fact-event.ts";
+// eslint-disable-next-line no-restricted-imports
 import type { TaskCreatedEvent } from "../../../kernel/src/domain/task-lifecycle.contract.ts";
 import { canonicalRoot, workspaceId } from "../../src/protocol/daemon-protocol.contract.ts";
 import { openPersistentWriterEpoch, type WriterEpochFenceDescriptor } from "../../src/writer-epoch.ts";
@@ -73,10 +83,6 @@ function factIdFor(index: number): string {
     value = Math.floor(value / CROCKFORD.length);
   }
   return `F-${code}`;
-}
-
-function git(rootDir: string, ...args: readonly string[]): string {
-  return execFileSync("git", ["-C", rootDir, ...args], { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] }).trim();
 }
 
 function taskCreatedEvent(revision: number, taskId: string, title: string): TaskCreatedEvent {
@@ -290,11 +296,6 @@ function seedLedger(
   } finally {
     void store.drain();
   }
-}
-
-function probedCreateWorker(execArgvExtra: readonly string[]) {
-  return (url: URL, options: { readonly execArgv: readonly string[]; readonly workerData: unknown }) =>
-    new Worker(url, { ...options, execArgv: [...options.execArgv, ...execArgvExtra] });
 }
 
 interface RequestHandle {

--- a/packages/daemon/test/fixtures/g1-writer-probe-import.mjs
+++ b/packages/daemon/test/fixtures/g1-writer-probe-import.mjs
@@ -1,0 +1,21 @@
+// Worker preload for the G1 write-cost-scaling gate: installs the shared cost probe inside the
+// writer worker thread (where durable writes actually execute) and answers reset/snapshot
+// control messages from the parent thread over the existing worker message channel.
+import { parentPort } from "node:worker_threads";
+import { installCostProbe, resetCostProbe, snapshotCostProbe } from "./g1-cost-probe.mjs";
+
+installCostProbe();
+
+parentPort?.on("message", (message) => {
+  if (message?.schema !== "g1-cost-probe-control/v1") return;
+  if (message.command === "reset") {
+    resetCostProbe();
+    parentPort.postMessage({ schema: "g1-cost-probe-ack/v1", requestId: message.requestId });
+  } else if (message.command === "snapshot") {
+    parentPort.postMessage({
+      schema: "g1-cost-probe-result/v1",
+      requestId: message.requestId,
+      counters: snapshotCostProbe(),
+    });
+  }
+});

--- a/packages/daemon/test/fixtures/g1-writer-probe-import.mjs
+++ b/packages/daemon/test/fixtures/g1-writer-probe-import.mjs
@@ -12,10 +12,15 @@ parentPort?.on("message", (message) => {
     resetCostProbe();
     parentPort.postMessage({ schema: "g1-cost-probe-ack/v1", requestId: message.requestId });
   } else if (message.command === "snapshot") {
-    parentPort.postMessage({
-      schema: "g1-cost-probe-result/v1",
-      requestId: message.requestId,
-      counters: snapshotCostProbe(),
-    });
+    // An append settles the Git/worktree follower from a setImmediate it queues before the
+    // response goes out (sqlite-task-event-store.ts scheduleFollower). Snapshotting one immediate
+    // turn later closes the window after that settlement without scheduling another one.
+    setImmediate(() =>
+      parentPort.postMessage({
+        schema: "g1-cost-probe-result/v1",
+        requestId: message.requestId,
+        counters: snapshotCostProbe(),
+      }),
+    );
   }
 });

--- a/packages/daemon/test/g1-write-cost-scaling.integration.test.ts
+++ b/packages/daemon/test/g1-write-cost-scaling.integration.test.ts
@@ -1,0 +1,28 @@
+// harness-test-tier: integration
+import assert from "node:assert/strict";
+import test from "node:test";
+import { G1_METRICS, G1_OPERATIONS, measureWriteCostScaling } from "./fixtures/g1-write-cost-scaling.ts";
+
+test("measureWriteCostScaling drives every G1 operation once through the production daemon request path", async () => {
+  const measured = await measureWriteCostScaling(5);
+  assert.equal(measured.eventCount, 5);
+  assert.deepEqual(Object.keys(measured.counts).sort(), [...G1_OPERATIONS].sort());
+  for (const operation of G1_OPERATIONS) {
+    const counters = measured.counts[operation];
+    assert.deepEqual(Object.keys(counters).sort(), [...G1_METRICS].sort(), operation);
+    for (const metric of G1_METRICS)
+      assert.ok(Number.isSafeInteger(counters[metric]) && counters[metric] >= 0, `${operation}.${metric}`);
+  }
+  // Writes and receipt-show execute in the writer worker; git subprocess count comes from the
+  // production counter, so a write that touches the follower spawns at least one process.
+  assert.ok(measured.counts["task-create"].gitProcesses > 0);
+  // Host-side reads never touch the writer worker or Git.
+  assert.equal(measured.counts["task-list"].gitProcesses, 0);
+});
+
+test("measureWriteCostScaling is deterministic in shape across two independent ledgers", async () => {
+  const [first, second] = await Promise.all([measureWriteCostScaling(5), measureWriteCostScaling(5)]);
+  // Same fixed-content fixture at the same scale must cost the same regardless of which temp
+  // directory or process ids the run happened to get.
+  assert.deepEqual(first.counts, second.counts);
+});

--- a/packages/daemon/test/g1-write-cost-scaling.integration.test.ts
+++ b/packages/daemon/test/g1-write-cost-scaling.integration.test.ts
@@ -3,26 +3,32 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { G1_METRICS, G1_OPERATIONS, measureWriteCostScaling } from "./fixtures/g1-write-cost-scaling.ts";
 
-test("measureWriteCostScaling drives every G1 operation once through the production daemon request path", async () => {
+test("measureWriteCostScaling drives every G1 operation through the production daemon request path", async () => {
   const measured = await measureWriteCostScaling(5);
   assert.equal(measured.eventCount, 5);
-  assert.deepEqual(Object.keys(measured.counts).sort(), [...G1_OPERATIONS].sort());
-  for (const operation of G1_OPERATIONS) {
-    const counters = measured.counts[operation];
-    assert.deepEqual(Object.keys(counters).sort(), [...G1_METRICS].sort(), operation);
-    for (const metric of G1_METRICS)
-      assert.ok(Number.isSafeInteger(counters[metric]) && counters[metric] >= 0, `${operation}.${metric}`);
+  for (const counts of [measured.counts, measured.firstCall]) {
+    assert.deepEqual(Object.keys(counts).sort(), [...G1_OPERATIONS].sort());
+    for (const operation of G1_OPERATIONS) {
+      const counters = counts[operation];
+      assert.deepEqual(Object.keys(counters).sort(), [...G1_METRICS].sort(), operation);
+      for (const metric of G1_METRICS)
+        assert.ok(Number.isSafeInteger(counters[metric]) && counters[metric] >= 0, `${operation}.${metric}`);
+    }
   }
-  // Writes and receipt-show execute in the writer worker; git subprocess count comes from the
-  // production counter, so a write that touches the follower spawns at least one process.
+  // The write window closes after the Git/worktree follower publication the write triggered, so a
+  // write counts the follower's Git subprocesses; receipt-show appends nothing and triggers none.
   assert.ok(measured.counts["task-create"].gitProcesses > 0);
+  assert.equal(measured.counts["receipt-show"].gitProcesses, 0);
   // Host-side reads never touch the writer worker or Git.
   assert.equal(measured.counts["task-list"].gitProcesses, 0);
 });
 
-test("measureWriteCostScaling is deterministic in shape across two independent ledgers", async () => {
-  const [first, second] = await Promise.all([measureWriteCostScaling(5), measureWriteCostScaling(5)]);
+test("measureWriteCostScaling costs the same on two independent ledgers of the same scale", async () => {
+  // Measured one after the other, as the gate does: host-side reads share process-wide counters.
+  const first = await measureWriteCostScaling(5),
+    second = await measureWriteCostScaling(5);
   // Same fixed-content fixture at the same scale must cost the same regardless of which temp
   // directory or process ids the run happened to get.
   assert.deepEqual(first.counts, second.counts);
+  assert.deepEqual(first.firstCall, second.firstCall);
 });

--- a/tools/gates/cost-budget.json
+++ b/tools/gates/cost-budget.json
@@ -17,56 +17,56 @@
     },
     "baseline": {
       "task-create": {
-        "sqlRowsRead": 432,
+        "sqlRowsRead": 434,
         "sha256Calls": 120,
         "sha256Bytes": 266257,
         "gitProcesses": 6,
         "fileReadBytes": 256691
       },
       "doc-submit": {
-        "sqlRowsRead": 191,
-        "sha256Calls": 165,
-        "sha256Bytes": 182035,
+        "sqlRowsRead": 193,
+        "sha256Calls": 135,
+        "sha256Bytes": 175686,
         "gitProcesses": 6,
         "fileReadBytes": 11287
       },
       "task-start": {
-        "sqlRowsRead": 775,
+        "sqlRowsRead": 777,
         "sha256Calls": 86,
         "sha256Bytes": 189039,
         "gitProcesses": 6,
         "fileReadBytes": 5711
       },
       "task-progress-append": {
-        "sqlRowsRead": 217,
-        "sha256Calls": 44,
-        "sha256Bytes": 38285,
+        "sqlRowsRead": 219,
+        "sha256Calls": 43,
+        "sha256Bytes": 38203,
         "gitProcesses": 6,
         "fileReadBytes": 659
       },
       "fact-record": {
-        "sqlRowsRead": 243,
-        "sha256Calls": 48,
-        "sha256Bytes": 21740,
+        "sqlRowsRead": 245,
+        "sha256Calls": 47,
+        "sha256Bytes": 21483,
         "gitProcesses": 6,
         "fileReadBytes": 1009
       },
       "decision-propose": {
-        "sqlRowsRead": 639,
-        "sha256Calls": 50,
-        "sha256Bytes": 41492,
+        "sqlRowsRead": 641,
+        "sha256Calls": 49,
+        "sha256Bytes": 40365,
         "gitProcesses": 6,
         "fileReadBytes": 2831
       },
       "decision-reject": {
-        "sqlRowsRead": 466,
-        "sha256Calls": 69,
-        "sha256Bytes": 70797,
+        "sqlRowsRead": 468,
+        "sha256Calls": 68,
+        "sha256Bytes": 68683,
         "gitProcesses": 6,
         "fileReadBytes": 9313
       },
       "relation-relate": {
-        "sqlRowsRead": 960,
+        "sqlRowsRead": 300,
         "sha256Calls": 59,
         "sha256Bytes": 26938,
         "gitProcesses": 6,
@@ -81,85 +81,85 @@
       },
       "task-list": {
         "sqlRowsRead": 609,
-        "sha256Calls": 1,
-        "sha256Bytes": 756,
+        "sha256Calls": 0,
+        "sha256Bytes": 0,
         "gitProcesses": 0,
         "fileReadBytes": 0
       },
       "task-show": {
         "sqlRowsRead": 441,
-        "sha256Calls": 1,
-        "sha256Bytes": 756,
+        "sha256Calls": 0,
+        "sha256Bytes": 0,
         "gitProcesses": 0,
         "fileReadBytes": 164
       },
       "agenda": {
         "sqlRowsRead": 421,
-        "sha256Calls": 1,
-        "sha256Bytes": 756,
+        "sha256Calls": 0,
+        "sha256Bytes": 0,
         "gitProcesses": 0,
         "fileReadBytes": 431
       },
       "runtime-overview": {
         "sqlRowsRead": 175,
-        "sha256Calls": 1,
-        "sha256Bytes": 756,
+        "sha256Calls": 0,
+        "sha256Bytes": 0,
         "gitProcesses": 0,
         "fileReadBytes": 0
       }
     },
     "budgets": {
       "task-create": {
-        "sqlRowsRead": 432,
+        "sqlRowsRead": 434,
         "sha256Calls": 120,
         "sha256Bytes": 266257,
         "gitProcesses": 6,
         "fileReadBytes": 256691
       },
       "doc-submit": {
-        "sqlRowsRead": 191,
-        "sha256Calls": 165,
-        "sha256Bytes": 182035,
+        "sqlRowsRead": 193,
+        "sha256Calls": 135,
+        "sha256Bytes": 175686,
         "gitProcesses": 6,
         "fileReadBytes": 11287
       },
       "task-start": {
-        "sqlRowsRead": 775,
+        "sqlRowsRead": 777,
         "sha256Calls": 86,
         "sha256Bytes": 189039,
         "gitProcesses": 6,
         "fileReadBytes": 5711
       },
       "task-progress-append": {
-        "sqlRowsRead": 217,
-        "sha256Calls": 44,
-        "sha256Bytes": 38285,
+        "sqlRowsRead": 219,
+        "sha256Calls": 43,
+        "sha256Bytes": 38203,
         "gitProcesses": 6,
         "fileReadBytes": 659
       },
       "fact-record": {
-        "sqlRowsRead": 243,
-        "sha256Calls": 48,
-        "sha256Bytes": 21740,
+        "sqlRowsRead": 245,
+        "sha256Calls": 47,
+        "sha256Bytes": 21483,
         "gitProcesses": 6,
         "fileReadBytes": 1009
       },
       "decision-propose": {
-        "sqlRowsRead": 639,
-        "sha256Calls": 50,
-        "sha256Bytes": 41492,
+        "sqlRowsRead": 641,
+        "sha256Calls": 49,
+        "sha256Bytes": 40365,
         "gitProcesses": 6,
         "fileReadBytes": 2831
       },
       "decision-reject": {
-        "sqlRowsRead": 466,
-        "sha256Calls": 69,
-        "sha256Bytes": 70797,
+        "sqlRowsRead": 468,
+        "sha256Calls": 68,
+        "sha256Bytes": 68683,
         "gitProcesses": 6,
         "fileReadBytes": 9313
       },
       "relation-relate": {
-        "sqlRowsRead": 960,
+        "sqlRowsRead": 300,
         "sha256Calls": 59,
         "sha256Bytes": 26938,
         "gitProcesses": 6,
@@ -174,41 +174,34 @@
       },
       "task-list": {
         "sqlRowsRead": 609,
-        "sha256Calls": 1,
-        "sha256Bytes": 756,
+        "sha256Calls": 0,
+        "sha256Bytes": 0,
         "gitProcesses": 0,
         "fileReadBytes": 0
       },
       "task-show": {
         "sqlRowsRead": 441,
-        "sha256Calls": 1,
-        "sha256Bytes": 756,
+        "sha256Calls": 0,
+        "sha256Bytes": 0,
         "gitProcesses": 0,
         "fileReadBytes": 164
       },
       "agenda": {
         "sqlRowsRead": 421,
-        "sha256Calls": 1,
-        "sha256Bytes": 756,
+        "sha256Calls": 0,
+        "sha256Bytes": 0,
         "gitProcesses": 0,
         "fileReadBytes": 431
       },
       "runtime-overview": {
         "sqlRowsRead": 175,
-        "sha256Calls": 1,
-        "sha256Bytes": 756,
+        "sha256Calls": 0,
+        "sha256Bytes": 0,
         "gitProcesses": 0,
         "fileReadBytes": 0
       }
     },
     "knownScaling": [
-      {
-        "operation": "relation-relate",
-        "metric": "sqlRowsRead",
-        "reason": "relation-relate calls readRelationTruth(), which loads every relation edge before the acyclic-dependency check; already known per dec_EF5F3820E81FB8A5266F1F3342 CH1 background.",
-        "deletionTaskId": "PENDING-CEO-ASSIGNMENT",
-        "expiresAt": "2026-09-24T00:00:00.000Z"
-      },
       {
         "operation": "decision-propose",
         "metric": "sqlRowsRead",

--- a/tools/gates/cost-budget.json
+++ b/tools/gates/cost-budget.json
@@ -17,91 +17,91 @@
     },
     "baseline": {
       "task-create": {
-        "sqlRowsRead": 434,
-        "sha256Calls": 120,
-        "sha256Bytes": 266257,
+        "sqlRowsRead": 79,
+        "sha256Calls": 74,
+        "sha256Bytes": 153967,
         "gitProcesses": 6,
-        "fileReadBytes": 256691
+        "fileReadBytes": 173463
       },
       "doc-submit": {
-        "sqlRowsRead": 193,
-        "sha256Calls": 135,
-        "sha256Bytes": 175686,
+        "sqlRowsRead": 194,
+        "sha256Calls": 102,
+        "sha256Bytes": 65234,
         "gitProcesses": 6,
-        "fileReadBytes": 11287
+        "fileReadBytes": 10056
       },
       "task-start": {
-        "sqlRowsRead": 777,
-        "sha256Calls": 86,
-        "sha256Bytes": 189039,
+        "sqlRowsRead": 937,
+        "sha256Calls": 47,
+        "sha256Bytes": 27132,
         "gitProcesses": 6,
-        "fileReadBytes": 5711
+        "fileReadBytes": 5883
       },
       "task-progress-append": {
-        "sqlRowsRead": 219,
-        "sha256Calls": 43,
-        "sha256Bytes": 38203,
+        "sqlRowsRead": 220,
+        "sha256Calls": 26,
+        "sha256Bytes": 5749,
         "gitProcesses": 6,
         "fileReadBytes": 659
       },
       "fact-record": {
-        "sqlRowsRead": 245,
-        "sha256Calls": 47,
-        "sha256Bytes": 21483,
+        "sqlRowsRead": 246,
+        "sha256Calls": 31,
+        "sha256Bytes": 7741,
         "gitProcesses": 6,
-        "fileReadBytes": 1009
+        "fileReadBytes": 997
       },
       "decision-propose": {
-        "sqlRowsRead": 641,
-        "sha256Calls": 49,
-        "sha256Bytes": 40365,
+        "sqlRowsRead": 469,
+        "sha256Calls": 29,
+        "sha256Bytes": 17018,
         "gitProcesses": 6,
-        "fileReadBytes": 2831
+        "fileReadBytes": 2911
       },
       "decision-reject": {
-        "sqlRowsRead": 468,
-        "sha256Calls": 68,
-        "sha256Bytes": 68683,
+        "sqlRowsRead": 501,
+        "sha256Calls": 42,
+        "sha256Bytes": 29393,
         "gitProcesses": 6,
-        "fileReadBytes": 9313
+        "fileReadBytes": 8386
       },
       "relation-relate": {
-        "sqlRowsRead": 300,
-        "sha256Calls": 59,
-        "sha256Bytes": 26938,
+        "sqlRowsRead": 301,
+        "sha256Calls": 27,
+        "sha256Bytes": 5905,
         "gitProcesses": 6,
         "fileReadBytes": 495
       },
       "receipt-show": {
         "sqlRowsRead": 38,
-        "sha256Calls": 15,
-        "sha256Bytes": 12945,
+        "sha256Calls": 6,
+        "sha256Bytes": 10380,
         "gitProcesses": 0,
         "fileReadBytes": 0
       },
       "task-list": {
-        "sqlRowsRead": 609,
-        "sha256Calls": 0,
-        "sha256Bytes": 0,
+        "sqlRowsRead": 144,
+        "sha256Calls": 1,
+        "sha256Bytes": 213,
         "gitProcesses": 0,
-        "fileReadBytes": 0
+        "fileReadBytes": 164
       },
       "task-show": {
-        "sqlRowsRead": 441,
+        "sqlRowsRead": 601,
         "sha256Calls": 0,
         "sha256Bytes": 0,
         "gitProcesses": 0,
         "fileReadBytes": 164
       },
       "agenda": {
-        "sqlRowsRead": 421,
+        "sqlRowsRead": 181,
         "sha256Calls": 0,
         "sha256Bytes": 0,
         "gitProcesses": 0,
-        "fileReadBytes": 431
+        "fileReadBytes": 0
       },
       "runtime-overview": {
-        "sqlRowsRead": 175,
+        "sqlRowsRead": 150,
         "sha256Calls": 0,
         "sha256Bytes": 0,
         "gitProcesses": 0,
@@ -110,91 +110,91 @@
     },
     "budgets": {
       "task-create": {
-        "sqlRowsRead": 434,
-        "sha256Calls": 120,
-        "sha256Bytes": 266257,
+        "sqlRowsRead": 79,
+        "sha256Calls": 74,
+        "sha256Bytes": 153967,
         "gitProcesses": 6,
-        "fileReadBytes": 256691
+        "fileReadBytes": 173463
       },
       "doc-submit": {
-        "sqlRowsRead": 193,
-        "sha256Calls": 135,
-        "sha256Bytes": 175686,
+        "sqlRowsRead": 194,
+        "sha256Calls": 102,
+        "sha256Bytes": 65234,
         "gitProcesses": 6,
-        "fileReadBytes": 11287
+        "fileReadBytes": 10056
       },
       "task-start": {
-        "sqlRowsRead": 777,
-        "sha256Calls": 86,
-        "sha256Bytes": 189039,
+        "sqlRowsRead": 937,
+        "sha256Calls": 47,
+        "sha256Bytes": 27132,
         "gitProcesses": 6,
-        "fileReadBytes": 5711
+        "fileReadBytes": 5883
       },
       "task-progress-append": {
-        "sqlRowsRead": 219,
-        "sha256Calls": 43,
-        "sha256Bytes": 38203,
+        "sqlRowsRead": 220,
+        "sha256Calls": 26,
+        "sha256Bytes": 5749,
         "gitProcesses": 6,
         "fileReadBytes": 659
       },
       "fact-record": {
-        "sqlRowsRead": 245,
-        "sha256Calls": 47,
-        "sha256Bytes": 21483,
+        "sqlRowsRead": 246,
+        "sha256Calls": 31,
+        "sha256Bytes": 7741,
         "gitProcesses": 6,
-        "fileReadBytes": 1009
+        "fileReadBytes": 997
       },
       "decision-propose": {
-        "sqlRowsRead": 641,
-        "sha256Calls": 49,
-        "sha256Bytes": 40365,
+        "sqlRowsRead": 469,
+        "sha256Calls": 29,
+        "sha256Bytes": 17018,
         "gitProcesses": 6,
-        "fileReadBytes": 2831
+        "fileReadBytes": 2911
       },
       "decision-reject": {
-        "sqlRowsRead": 468,
-        "sha256Calls": 68,
-        "sha256Bytes": 68683,
+        "sqlRowsRead": 501,
+        "sha256Calls": 42,
+        "sha256Bytes": 29393,
         "gitProcesses": 6,
-        "fileReadBytes": 9313
+        "fileReadBytes": 8386
       },
       "relation-relate": {
-        "sqlRowsRead": 300,
-        "sha256Calls": 59,
-        "sha256Bytes": 26938,
+        "sqlRowsRead": 301,
+        "sha256Calls": 27,
+        "sha256Bytes": 5905,
         "gitProcesses": 6,
         "fileReadBytes": 495
       },
       "receipt-show": {
         "sqlRowsRead": 38,
-        "sha256Calls": 15,
-        "sha256Bytes": 12945,
+        "sha256Calls": 6,
+        "sha256Bytes": 10380,
         "gitProcesses": 0,
         "fileReadBytes": 0
       },
       "task-list": {
-        "sqlRowsRead": 609,
-        "sha256Calls": 0,
-        "sha256Bytes": 0,
+        "sqlRowsRead": 144,
+        "sha256Calls": 1,
+        "sha256Bytes": 213,
         "gitProcesses": 0,
-        "fileReadBytes": 0
+        "fileReadBytes": 164
       },
       "task-show": {
-        "sqlRowsRead": 441,
+        "sqlRowsRead": 601,
         "sha256Calls": 0,
         "sha256Bytes": 0,
         "gitProcesses": 0,
         "fileReadBytes": 164
       },
       "agenda": {
-        "sqlRowsRead": 421,
+        "sqlRowsRead": 181,
         "sha256Calls": 0,
         "sha256Bytes": 0,
         "gitProcesses": 0,
-        "fileReadBytes": 431
+        "fileReadBytes": 0
       },
       "runtime-overview": {
-        "sqlRowsRead": 175,
+        "sqlRowsRead": 150,
         "sha256Calls": 0,
         "sha256Bytes": 0,
         "gitProcesses": 0,
@@ -203,52 +203,45 @@
     },
     "knownScaling": [
       {
+        "operation": "task-start",
+        "metric": "sqlRowsRead",
+        "reason": "task-start admits WIP through assertTaskWipCapacity -> wipSnapshotEntries (daemon repo-cell-task-query.ts), and projection.list() (kernel projection/rebuildable-task-projection-reads.ts listProjection) reads the whole task index (SELECT task_snapshot.task_id AS task_id, task_package.package_path ... FROM task_snapshot LEFT JOIN task_package LEFT JOIN task_generation ORDER BY task_snapshot.task_id) and then one readSnapshot per task (SELECT snapshot_json FROM task_snapshot WHERE task_id = ?, plus relation_edge/entity-freshness reads that list sqlite_master for every task carrying a relation); about 3 rows per task.",
+        "deletionTaskId": "task_2b8f79fa4412cb726a26f9bfc7",
+        "expiresAt": "2026-09-24T00:00:00.000Z"
+      },
+      {
         "operation": "decision-propose",
         "metric": "sqlRowsRead",
-        "reason": "decision-propose is a decision write; assertAuthorizedReplacements (task-event-store-replacement-authorization.ts) scans backward through the ledger for prior document claims on every decision/settings/people write; already known per dec_EF5F3820E81FB8A5266F1F3342 CH1 background.",
-        "deletionTaskId": "PENDING-CEO-ASSIGNMENT",
+        "reason": "entity-action-catalog-executor.ts compileDraft calls projection.readDecisionGraph() only to keep the edges owned by this one decision; readDecisionGraphRows builds the whole graph including decisionCoverage (kernel projection/decision-projection-coverage.ts), which reads every task (SELECT task_id,json_extract(snapshot_json,'$.task.status') AS status FROM task_snapshot ORDER BY task_id), every fact (SELECT ref FROM fact ORDER BY ref), and every decision, claim, option and relation edge. The replacement-authorization backward scan named in the task plan is now a per-process cache (#2410) and shows only in the first call.",
+        "deletionTaskId": "task_2b8f79fa4412cb726a26f9bfc7",
         "expiresAt": "2026-09-24T00:00:00.000Z"
       },
       {
         "operation": "decision-reject",
         "metric": "sqlRowsRead",
-        "reason": "decision-reject is also a decision write and hits the same assertAuthorizedReplacements backward scan as decision-propose; already known per dec_EF5F3820E81FB8A5266F1F3342 CH1 background.",
-        "deletionTaskId": "PENDING-CEO-ASSIGNMENT",
-        "expiresAt": "2026-09-24T00:00:00.000Z"
-      },
-      {
-        "operation": "task-create",
-        "metric": "sqlRowsRead",
-        "reason": "task-create's row count grows with ledger size at head (empirically 432 at 200 events, 3492 at 2000 events); newly discovered by G1, not on the pre-known list, root cause not isolated by this task (no production hooks were added to trace it further).",
-        "deletionTaskId": "PENDING-CEO-ASSIGNMENT",
-        "expiresAt": "2026-09-24T00:00:00.000Z"
-      },
-      {
-        "operation": "task-start",
-        "metric": "sqlRowsRead",
-        "reason": "task-start's row count grows with ledger size at head (empirically 775 at 200 events, 3835 at 2000 events); newly discovered by G1, not on the pre-known list, root cause not isolated by this task.",
-        "deletionTaskId": "PENDING-CEO-ASSIGNMENT",
+        "reason": "Same path as decision-propose: entity-action-catalog-executor.ts compileDraft calls projection.readDecisionGraph() only to keep the edges owned by this one decision; readDecisionGraphRows builds the whole graph including decisionCoverage (kernel projection/decision-projection-coverage.ts), which reads every task (SELECT task_id,json_extract(snapshot_json,'$.task.status') AS status FROM task_snapshot ORDER BY task_id), every fact (SELECT ref FROM fact ORDER BY ref), and every decision, claim, option and relation edge.",
+        "deletionTaskId": "task_2b8f79fa4412cb726a26f9bfc7",
         "expiresAt": "2026-09-24T00:00:00.000Z"
       },
       {
         "operation": "task-list",
         "metric": "sqlRowsRead",
-        "reason": "task-list's row count grows with total task count at head (empirically 609 at 200 events, 5199 at 2000 events); newly discovered by G1, not on the pre-known list, root cause not isolated by this task.",
-        "deletionTaskId": "PENDING-CEO-ASSIGNMENT",
+        "reason": "task-list --limit 3 still reads the whole task index: listTasks (daemon repo-cell-task-query.ts) calls projection.readTaskIndex() -> readTaskIndexRows (kernel projection/task-query-projection.ts: SELECT task_snapshot.task_id, task_package.package_path, task_snapshot.updated_at, task_snapshot.snapshot_json FROM task_snapshot LEFT JOIN task_package USING(task_id) ORDER BY task_snapshot.task_id) and selectTaskIndex applies the limit in memory; one row per task.",
+        "deletionTaskId": "task_2b8f79fa4412cb726a26f9bfc7",
         "expiresAt": "2026-09-24T00:00:00.000Z"
       },
       {
         "operation": "task-show",
         "metric": "sqlRowsRead",
-        "reason": "task-show for one task's row count grows with total task count at head (empirically 441 at 200 events, 3501 at 2000 events, suggesting a blocking/dependency scan over every task); newly discovered by G1, not on the pre-known list.",
-        "deletionTaskId": "PENDING-CEO-ASSIGNMENT",
+        "reason": "taskShowFromProjection (daemon repo-cell-completion.ts) defaults directChildCount to projection.list().rows.filter(parentTaskId === taskId) just to count one task's children, and projection.list() (kernel projection/rebuildable-task-projection-reads.ts listProjection) reads the whole task index (SELECT task_snapshot.task_id AS task_id, task_package.package_path ... FROM task_snapshot LEFT JOIN task_package LEFT JOIN task_generation ORDER BY task_snapshot.task_id) and then one readSnapshot per task (SELECT snapshot_json FROM task_snapshot WHERE task_id = ?, plus relation_edge/entity-freshness reads that list sqlite_master for every task carrying a relation); about 3 rows per task.",
+        "deletionTaskId": "task_2b8f79fa4412cb726a26f9bfc7",
         "expiresAt": "2026-09-24T00:00:00.000Z"
       },
       {
         "operation": "runtime-overview",
         "metric": "sqlRowsRead",
-        "reason": "workspace-summary row count grows with total task count at head (empirically 175 at 200 events, 1705 at 2000 events, suggesting it aggregates across every task); newly discovered by G1, not on the pre-known list.",
-        "deletionTaskId": "PENDING-CEO-ASSIGNMENT",
+        "reason": "workspaceSummaryFromProjection -> projection.readWorkspaceSummary() -> readWorkspaceSummaryRows (kernel projection/workspace-summary-projection.ts) reads every task (SELECT task_id, status, COALESCE(json_extract(snapshot_json, '$.task.packageDisposition'), 'active') AS package_disposition FROM task_snapshot ORDER BY task_id) and every decision (SELECT decision_id, state FROM decision ORDER BY decision_id) to count them in memory.",
+        "deletionTaskId": "task_2b8f79fa4412cb726a26f9bfc7",
         "expiresAt": "2026-09-24T00:00:00.000Z"
       }
     ]

--- a/tools/gates/cost-budget.json
+++ b/tools/gates/cost-budget.json
@@ -8,5 +8,256 @@
   "budgets": {
     "projectionRebuildGitProcesses": 4,
     "firstScreenReadRpcs": 7
+  },
+  "writeCostScaling": {
+    "schema": "write-cost-scaling-budget/v1",
+    "scales": {
+      "small": 200,
+      "large": 2000
+    },
+    "baseline": {
+      "task-create": {
+        "sqlRowsRead": 432,
+        "sha256Calls": 120,
+        "sha256Bytes": 266257,
+        "gitProcesses": 6,
+        "fileReadBytes": 256691
+      },
+      "doc-submit": {
+        "sqlRowsRead": 191,
+        "sha256Calls": 165,
+        "sha256Bytes": 182035,
+        "gitProcesses": 6,
+        "fileReadBytes": 11287
+      },
+      "task-start": {
+        "sqlRowsRead": 775,
+        "sha256Calls": 86,
+        "sha256Bytes": 189039,
+        "gitProcesses": 6,
+        "fileReadBytes": 5711
+      },
+      "task-progress-append": {
+        "sqlRowsRead": 217,
+        "sha256Calls": 44,
+        "sha256Bytes": 38285,
+        "gitProcesses": 6,
+        "fileReadBytes": 659
+      },
+      "fact-record": {
+        "sqlRowsRead": 243,
+        "sha256Calls": 48,
+        "sha256Bytes": 21740,
+        "gitProcesses": 6,
+        "fileReadBytes": 1009
+      },
+      "decision-propose": {
+        "sqlRowsRead": 639,
+        "sha256Calls": 50,
+        "sha256Bytes": 41492,
+        "gitProcesses": 6,
+        "fileReadBytes": 2831
+      },
+      "decision-reject": {
+        "sqlRowsRead": 672,
+        "sha256Calls": 69,
+        "sha256Bytes": 70797,
+        "gitProcesses": 6,
+        "fileReadBytes": 9313
+      },
+      "relation-relate": {
+        "sqlRowsRead": 960,
+        "sha256Calls": 59,
+        "sha256Bytes": 26938,
+        "gitProcesses": 6,
+        "fileReadBytes": 495
+      },
+      "receipt-show": {
+        "sqlRowsRead": 38,
+        "sha256Calls": 15,
+        "sha256Bytes": 12945,
+        "gitProcesses": 0,
+        "fileReadBytes": 0
+      },
+      "task-list": {
+        "sqlRowsRead": 609,
+        "sha256Calls": 1,
+        "sha256Bytes": 756,
+        "gitProcesses": 0,
+        "fileReadBytes": 0
+      },
+      "task-show": {
+        "sqlRowsRead": 441,
+        "sha256Calls": 1,
+        "sha256Bytes": 756,
+        "gitProcesses": 0,
+        "fileReadBytes": 164
+      },
+      "agenda": {
+        "sqlRowsRead": 421,
+        "sha256Calls": 1,
+        "sha256Bytes": 756,
+        "gitProcesses": 0,
+        "fileReadBytes": 431
+      },
+      "runtime-overview": {
+        "sqlRowsRead": 175,
+        "sha256Calls": 1,
+        "sha256Bytes": 756,
+        "gitProcesses": 0,
+        "fileReadBytes": 0
+      }
+    },
+    "budgets": {
+      "task-create": {
+        "sqlRowsRead": 432,
+        "sha256Calls": 120,
+        "sha256Bytes": 266257,
+        "gitProcesses": 6,
+        "fileReadBytes": 256691
+      },
+      "doc-submit": {
+        "sqlRowsRead": 191,
+        "sha256Calls": 165,
+        "sha256Bytes": 182035,
+        "gitProcesses": 6,
+        "fileReadBytes": 11287
+      },
+      "task-start": {
+        "sqlRowsRead": 775,
+        "sha256Calls": 86,
+        "sha256Bytes": 189039,
+        "gitProcesses": 6,
+        "fileReadBytes": 5711
+      },
+      "task-progress-append": {
+        "sqlRowsRead": 217,
+        "sha256Calls": 44,
+        "sha256Bytes": 38285,
+        "gitProcesses": 6,
+        "fileReadBytes": 659
+      },
+      "fact-record": {
+        "sqlRowsRead": 243,
+        "sha256Calls": 48,
+        "sha256Bytes": 21740,
+        "gitProcesses": 6,
+        "fileReadBytes": 1009
+      },
+      "decision-propose": {
+        "sqlRowsRead": 639,
+        "sha256Calls": 50,
+        "sha256Bytes": 41492,
+        "gitProcesses": 6,
+        "fileReadBytes": 2831
+      },
+      "decision-reject": {
+        "sqlRowsRead": 672,
+        "sha256Calls": 69,
+        "sha256Bytes": 70797,
+        "gitProcesses": 6,
+        "fileReadBytes": 9313
+      },
+      "relation-relate": {
+        "sqlRowsRead": 960,
+        "sha256Calls": 59,
+        "sha256Bytes": 26938,
+        "gitProcesses": 6,
+        "fileReadBytes": 495
+      },
+      "receipt-show": {
+        "sqlRowsRead": 38,
+        "sha256Calls": 15,
+        "sha256Bytes": 12945,
+        "gitProcesses": 0,
+        "fileReadBytes": 0
+      },
+      "task-list": {
+        "sqlRowsRead": 609,
+        "sha256Calls": 1,
+        "sha256Bytes": 756,
+        "gitProcesses": 0,
+        "fileReadBytes": 0
+      },
+      "task-show": {
+        "sqlRowsRead": 441,
+        "sha256Calls": 1,
+        "sha256Bytes": 756,
+        "gitProcesses": 0,
+        "fileReadBytes": 164
+      },
+      "agenda": {
+        "sqlRowsRead": 421,
+        "sha256Calls": 1,
+        "sha256Bytes": 756,
+        "gitProcesses": 0,
+        "fileReadBytes": 431
+      },
+      "runtime-overview": {
+        "sqlRowsRead": 175,
+        "sha256Calls": 1,
+        "sha256Bytes": 756,
+        "gitProcesses": 0,
+        "fileReadBytes": 0
+      }
+    },
+    "knownScaling": [
+      {
+        "operation": "relation-relate",
+        "metric": "sqlRowsRead",
+        "reason": "relation-relate calls readRelationTruth(), which loads every relation edge before the acyclic-dependency check; already known per dec_EF5F3820E81FB8A5266F1F3342 CH1 background.",
+        "deletionTaskId": "PENDING-CEO-ASSIGNMENT",
+        "expiresAt": "2026-09-24T00:00:00.000Z"
+      },
+      {
+        "operation": "decision-propose",
+        "metric": "sqlRowsRead",
+        "reason": "decision-propose is a decision write; assertAuthorizedReplacements (task-event-store-replacement-authorization.ts) scans backward through the ledger for prior document claims on every decision/settings/people write; already known per dec_EF5F3820E81FB8A5266F1F3342 CH1 background.",
+        "deletionTaskId": "PENDING-CEO-ASSIGNMENT",
+        "expiresAt": "2026-09-24T00:00:00.000Z"
+      },
+      {
+        "operation": "decision-reject",
+        "metric": "sqlRowsRead",
+        "reason": "decision-reject is also a decision write and hits the same assertAuthorizedReplacements backward scan as decision-propose; already known per dec_EF5F3820E81FB8A5266F1F3342 CH1 background.",
+        "deletionTaskId": "PENDING-CEO-ASSIGNMENT",
+        "expiresAt": "2026-09-24T00:00:00.000Z"
+      },
+      {
+        "operation": "task-create",
+        "metric": "sqlRowsRead",
+        "reason": "task-create's row count grows with ledger size at head (empirically 432 at 200 events, 3492 at 2000 events); newly discovered by G1, not on the pre-known list, root cause not isolated by this task (no production hooks were added to trace it further).",
+        "deletionTaskId": "PENDING-CEO-ASSIGNMENT",
+        "expiresAt": "2026-09-24T00:00:00.000Z"
+      },
+      {
+        "operation": "task-start",
+        "metric": "sqlRowsRead",
+        "reason": "task-start's row count grows with ledger size at head (empirically 775 at 200 events, 3835 at 2000 events); newly discovered by G1, not on the pre-known list, root cause not isolated by this task.",
+        "deletionTaskId": "PENDING-CEO-ASSIGNMENT",
+        "expiresAt": "2026-09-24T00:00:00.000Z"
+      },
+      {
+        "operation": "task-list",
+        "metric": "sqlRowsRead",
+        "reason": "task-list's row count grows with total task count at head (empirically 609 at 200 events, 5199 at 2000 events); newly discovered by G1, not on the pre-known list, root cause not isolated by this task.",
+        "deletionTaskId": "PENDING-CEO-ASSIGNMENT",
+        "expiresAt": "2026-09-24T00:00:00.000Z"
+      },
+      {
+        "operation": "task-show",
+        "metric": "sqlRowsRead",
+        "reason": "task-show for one task's row count grows with total task count at head (empirically 441 at 200 events, 3501 at 2000 events, suggesting a blocking/dependency scan over every task); newly discovered by G1, not on the pre-known list.",
+        "deletionTaskId": "PENDING-CEO-ASSIGNMENT",
+        "expiresAt": "2026-09-24T00:00:00.000Z"
+      },
+      {
+        "operation": "runtime-overview",
+        "metric": "sqlRowsRead",
+        "reason": "workspace-summary row count grows with total task count at head (empirically 175 at 200 events, 1705 at 2000 events, suggesting it aggregates across every task); newly discovered by G1, not on the pre-known list.",
+        "deletionTaskId": "PENDING-CEO-ASSIGNMENT",
+        "expiresAt": "2026-09-24T00:00:00.000Z"
+      }
+    ]
   }
 }

--- a/tools/gates/cost-budget.json
+++ b/tools/gates/cost-budget.json
@@ -59,7 +59,7 @@
         "fileReadBytes": 2831
       },
       "decision-reject": {
-        "sqlRowsRead": 672,
+        "sqlRowsRead": 466,
         "sha256Calls": 69,
         "sha256Bytes": 70797,
         "gitProcesses": 6,
@@ -152,7 +152,7 @@
         "fileReadBytes": 2831
       },
       "decision-reject": {
-        "sqlRowsRead": 672,
+        "sqlRowsRead": 466,
         "sha256Calls": 69,
         "sha256Bytes": 70797,
         "gitProcesses": 6,

--- a/tools/gates/cost-budget.json
+++ b/tools/gates/cost-budget.json
@@ -18,15 +18,15 @@
     "baseline": {
       "task-create": {
         "sqlRowsRead": 79,
-        "sha256Calls": 74,
-        "sha256Bytes": 153967,
+        "sha256Calls": 67,
+        "sha256Bytes": 138799,
         "gitProcesses": 6,
         "fileReadBytes": 173463
       },
       "doc-submit": {
         "sqlRowsRead": 194,
-        "sha256Calls": 102,
-        "sha256Bytes": 65234,
+        "sha256Calls": 101,
+        "sha256Bytes": 63915,
         "gitProcesses": 6,
         "fileReadBytes": 10056
       },
@@ -111,15 +111,15 @@
     "budgets": {
       "task-create": {
         "sqlRowsRead": 79,
-        "sha256Calls": 74,
-        "sha256Bytes": 153967,
+        "sha256Calls": 67,
+        "sha256Bytes": 138799,
         "gitProcesses": 6,
         "fileReadBytes": 173463
       },
       "doc-submit": {
         "sqlRowsRead": 194,
-        "sha256Calls": 102,
-        "sha256Bytes": 65234,
+        "sha256Calls": 101,
+        "sha256Bytes": 63915,
         "gitProcesses": 6,
         "fileReadBytes": 10056
       },

--- a/tools/gates/cost-budget.mjs
+++ b/tools/gates/cost-budget.mjs
@@ -165,16 +165,17 @@ export async function evaluateCostBudget({
 
 // --- G1 write-path scale invariant -----------------------------------------------------------
 // Extends the cost-budget gate (dec_EF5F3820E81FB8A5266F1F3342 CH1, refining dec_D507BBA7174F4BF61521CAEB61):
-// every durable write kind and hot read runs once through the production daemon request path on a
-// 200-event and a 2000-event ledger; a 10x history growth must not cost meaningfully more per call.
+// every durable write kind and hot read runs through the production daemon request path on a
+// 200-event and a 2000-event ledger, and its steady-state call (the one after a warm-up call) is
+// judged; a 10x history growth must not cost meaningfully more per call.
 export const G1_SCALES = Object.freeze({ small: 200, large: 2000 });
 
 // Fixed, per-metric absolute margins (not per operation): the measured 200-scale and 2000-scale
 // counts for an unexempted (operation, metric) pair must differ by no more than this. Values come
 // from the noise observed on flat operations at head (task_78327209a449760a74d1992de3 report):
 export const G1_MARGINS = Object.freeze({
-  // Flat operations show 0 row difference between scales; 20 tolerates incidental plan/query
-  // shape changes (e.g. an added WHERE clause) without masking a real O(N) regression.
+  // Flat operations show 0 row difference between scales. The scarcest seeded kinds (decisions and
+  // their relations) still grow by 36 rows between scales, so a scan of any one kind exceeds 20.
   sqlRowsRead: 20,
   // Every operation hashes a fixed number of times regardless of scale; 2 covers incidental
   // additions (e.g. one more content-addressed blob) without hiding a growing hash count.
@@ -258,10 +259,10 @@ function g1HasReceipt(receipts, operation, metric, limit, now) {
 export async function measureG1WriteCostScaling(rootDir, scales) {
   const moduleUrl = pathToFileURL(path.join(rootDir, "packages/daemon/test/fixtures/g1-write-cost-scaling.ts")).href;
   const { measureWriteCostScaling, G1_OPERATIONS, G1_METRICS } = await import(moduleUrl);
-  const [small, large] = await Promise.all([
-    measureWriteCostScaling(scales.small),
-    measureWriteCostScaling(scales.large),
-  ]);
+  // One scale after the other: host-side reads are counted by process-wide probe counters, which a
+  // concurrently seeding or measuring scale would add its own work to.
+  const small = await measureWriteCostScaling(scales.small),
+    large = await measureWriteCostScaling(scales.large);
   return { small, large, operations: G1_OPERATIONS, metrics: G1_METRICS };
 }
 
@@ -297,7 +298,8 @@ export async function evaluateG1WriteCostScaling({
         );
       if (measuredSmall > budget.budgets[operation][metric])
         errors.push(
-          `${operation}.${metric}: measured ${measuredSmall} at ${G1_SCALES.small} events exceeds budget ${budget.budgets[operation][metric]}`,
+          `${operation}.${metric}: measured ${measuredSmall} at ${G1_SCALES.small} events exceeds budget ` +
+            `${budget.budgets[operation][metric]}`,
         );
 
       // Scale-invariance: 2000-scale must not exceed 200-scale plus the fixed per-metric margin,
@@ -307,15 +309,18 @@ export async function evaluateG1WriteCostScaling({
       if (exemption) {
         if (Date.parse(exemption.expiresAt) <= now.getTime())
           errors.push(
-            `${operation}.${metric}: knownScaling exemption expired at ${exemption.expiresAt} (deletion task ${exemption.deletionTaskId}); renew or fix and remove it`,
+            `${operation}.${metric}: knownScaling exemption expired at ${exemption.expiresAt} ` +
+              `(deletion task ${exemption.deletionTaskId}); renew or fix and remove it`,
           );
         else if (withinMargin)
           errors.push(
-            `${operation}.${metric}: knownScaling exemption is stale (measured ${measuredSmall}->${measuredLarge} is already within the margin); remove the exemption`,
+            `${operation}.${metric}: knownScaling exemption is stale (measured ${measuredSmall}->${measuredLarge} ` +
+              `is already within the margin); remove the exemption`,
           );
       } else if (!withinMargin)
         errors.push(
-          `${operation}.${metric}: measured ${measuredSmall} at ${G1_SCALES.small} events grew to ${measuredLarge} at ${G1_SCALES.large} events, ` +
+          `${operation}.${metric}: measured ${measuredSmall} at ${G1_SCALES.small} events grew to ` +
+            `${measuredLarge} at ${G1_SCALES.large} events, ` +
             `exceeding the +${G1_MARGINS[metric]} margin with no knownScaling exemption`,
         );
     }

--- a/tools/gates/cost-budget.mjs
+++ b/tools/gates/cost-budget.mjs
@@ -163,6 +163,177 @@ export async function evaluateCostBudget({
   };
 }
 
+// --- G1 write-path scale invariant -----------------------------------------------------------
+// Extends the cost-budget gate (dec_EF5F3820E81FB8A5266F1F3342 CH1, refining dec_D507BBA7174F4BF61521CAEB61):
+// every durable write kind and hot read runs once through the production daemon request path on a
+// 200-event and a 2000-event ledger; a 10x history growth must not cost meaningfully more per call.
+export const G1_SCALES = Object.freeze({ small: 200, large: 2000 });
+
+// Fixed, per-metric absolute margins (not per operation): the measured 200-scale and 2000-scale
+// counts for an unexempted (operation, metric) pair must differ by no more than this. Values come
+// from the noise observed on flat operations at head (task_78327209a449760a74d1992de3 report):
+export const G1_MARGINS = Object.freeze({
+  // Flat operations show 0 row difference between scales; 20 tolerates incidental plan/query
+  // shape changes (e.g. an added WHERE clause) without masking a real O(N) regression.
+  sqlRowsRead: 20,
+  // Every operation hashes a fixed number of times regardless of scale; 2 covers incidental
+  // additions (e.g. one more content-addressed blob) without hiding a growing hash count.
+  sha256Calls: 2,
+  // Observed drift is only digits added to longer generated ids (single- to double-digit bytes);
+  // 512 comfortably covers that without masking a hashed-content-scales-with-history regression.
+  sha256Bytes: 512,
+  // This is the exact metric #2407/#2409 fixed (Git follower re-rendering history per write); keep
+  // it tight. 1 tolerates a single incidental extra spawn (e.g. a lazily-created ref) at most.
+  gitProcesses: 1,
+  // Observed drift is a few bytes from longer generated ids in read file content; 128 covers that
+  // without masking a file read that starts scanning history.
+  fileReadBytes: 128,
+});
+
+function isNonEmptyString(value) {
+  return typeof value === "string" && value.length > 0;
+}
+
+function validateG1OperationMap(value, label, metrics) {
+  if (value === null || typeof value !== "object" || Array.isArray(value))
+    throw new Error(`${label} must be an object`);
+  const result = {};
+  for (const [operation, metricMap] of Object.entries(value)) {
+    if (metricMap === null || typeof metricMap !== "object" || Array.isArray(metricMap))
+      throw new Error(`${label}.${operation} must be an object`);
+    const keys = Object.keys(metricMap).sort();
+    if (keys.join("\0") !== [...metrics].sort().join("\0"))
+      throw new Error(`${label}.${operation} keys must be ${metrics.join(", ")}`);
+    result[operation] = {};
+    for (const metric of metrics) {
+      if (!Number.isSafeInteger(metricMap[metric]) || metricMap[metric] < 0)
+        throw new Error(`${label}.${operation}.${metric} must be a non-negative safe integer`);
+      result[operation][metric] = metricMap[metric];
+    }
+  }
+  return result;
+}
+
+function readG1BudgetFile(filePath, operations, metrics) {
+  const budget = parseJsonFile(filePath);
+  const section = budget?.writeCostScaling;
+  if (section?.schema !== "write-cost-scaling-budget/v1")
+    throw new Error(`${filePath}.writeCostScaling must use write-cost-scaling-budget/v1`);
+  const scales = section.scales;
+  if (!Number.isSafeInteger(scales?.small) || !Number.isSafeInteger(scales?.large) || scales.small >= scales.large)
+    throw new Error(`${filePath}.writeCostScaling.scales must declare small < large`);
+  const baseline = validateG1OperationMap(section.baseline, `${filePath}.writeCostScaling.baseline`, metrics),
+    budgets = validateG1OperationMap(section.budgets, `${filePath}.writeCostScaling.budgets`, metrics);
+  for (const operation of operations) {
+    if (!baseline[operation])
+      throw new Error(`${filePath}.writeCostScaling.baseline is missing operation ${operation}`);
+    if (!budgets[operation]) throw new Error(`${filePath}.writeCostScaling.budgets is missing operation ${operation}`);
+  }
+  const knownScaling = Array.isArray(section.knownScaling) ? section.knownScaling : null;
+  if (!knownScaling) throw new Error(`${filePath}.writeCostScaling.knownScaling must be an array`);
+  for (const [index, entry] of knownScaling.entries()) {
+    const label = `${filePath}.writeCostScaling.knownScaling[${index}]`;
+    if (!operations.includes(entry?.operation)) throw new Error(`${label}.operation must be a known G1 operation`);
+    if (!metrics.includes(entry?.metric)) throw new Error(`${label}.metric must be a known G1 metric`);
+    if (!isNonEmptyString(entry?.reason)) throw new Error(`${label}.reason is required`);
+    if (!isNonEmptyString(entry?.deletionTaskId)) throw new Error(`${label}.deletionTaskId is required`);
+    if (!isNonEmptyString(entry?.expiresAt) || Number.isNaN(Date.parse(entry.expiresAt)))
+      throw new Error(`${label}.expiresAt must be an RFC 3339 timestamp`);
+  }
+  return { scales, baseline, budgets, knownScaling };
+}
+
+function g1HasReceipt(receipts, operation, metric, limit, now) {
+  return receipts.some(
+    ({ receipt }) =>
+      verifyReceipt(receipt, {
+        scope: `cost:g1:${operation}:${metric}`,
+        kind: "g1-cost-budget",
+        minimumLimit: limit,
+        now,
+      }).ok,
+  );
+}
+
+export async function measureG1WriteCostScaling(rootDir, scales) {
+  const moduleUrl = pathToFileURL(path.join(rootDir, "packages/daemon/test/fixtures/g1-write-cost-scaling.ts")).href;
+  const { measureWriteCostScaling, G1_OPERATIONS, G1_METRICS } = await import(moduleUrl);
+  const [small, large] = await Promise.all([
+    measureWriteCostScaling(scales.small),
+    measureWriteCostScaling(scales.large),
+  ]);
+  return { small, large, operations: G1_OPERATIONS, metrics: G1_METRICS };
+}
+
+export async function evaluateG1WriteCostScaling({
+  rootDir,
+  budgetPath = path.join(rootDir, "tools/gates/cost-budget.json"),
+  receiptsDir = path.join(rootDir, "tools/gates/receipts"),
+  now = new Date(),
+  measured = null,
+} = {}) {
+  const probe = measured ?? (await measureG1WriteCostScaling(rootDir, G1_SCALES));
+  const { operations, metrics } = probe;
+  const budget = readG1BudgetFile(budgetPath, operations, metrics);
+  const receipts = loadReceipts(receiptsDir);
+  const errors = [];
+  const actualSmall = {};
+  for (const operation of operations) {
+    actualSmall[operation] = probe.small.counts[operation];
+    for (const metric of metrics) {
+      const measuredSmall = probe.small.counts[operation]?.[metric],
+        measuredLarge = probe.large.counts[operation]?.[metric];
+      if (!Number.isSafeInteger(measuredSmall) || !Number.isSafeInteger(measuredLarge))
+        throw new Error(`G1 measurement is missing ${operation}.${metric}`);
+
+      // 200-scale absolute ratchet: reused from the existing G37 baseline/budget/receipt pattern.
+      if (
+        budget.budgets[operation][metric] > budget.baseline[operation][metric] &&
+        !g1HasReceipt(receipts, operation, metric, budget.budgets[operation][metric], now)
+      )
+        errors.push(
+          `${operation}.${metric}: budget rose from ${budget.baseline[operation][metric]} to ` +
+            `${budget.budgets[operation][metric]} without a valid g1-cost-budget receipt`,
+        );
+      if (measuredSmall > budget.budgets[operation][metric])
+        errors.push(
+          `${operation}.${metric}: measured ${measuredSmall} at ${G1_SCALES.small} events exceeds budget ${budget.budgets[operation][metric]}`,
+        );
+
+      // Scale-invariance: 2000-scale must not exceed 200-scale plus the fixed per-metric margin,
+      // unless a live (non-expired) knownScaling exemption names this exact pair.
+      const exemption = budget.knownScaling.find((entry) => entry.operation === operation && entry.metric === metric),
+        withinMargin = measuredLarge <= measuredSmall + G1_MARGINS[metric];
+      if (exemption) {
+        if (Date.parse(exemption.expiresAt) <= now.getTime())
+          errors.push(
+            `${operation}.${metric}: knownScaling exemption expired at ${exemption.expiresAt} (deletion task ${exemption.deletionTaskId}); renew or fix and remove it`,
+          );
+        else if (withinMargin)
+          errors.push(
+            `${operation}.${metric}: knownScaling exemption is stale (measured ${measuredSmall}->${measuredLarge} is already within the margin); remove the exemption`,
+          );
+      } else if (!withinMargin)
+        errors.push(
+          `${operation}.${metric}: measured ${measuredSmall} at ${G1_SCALES.small} events grew to ${measuredLarge} at ${G1_SCALES.large} events, ` +
+            `exceeding the +${G1_MARGINS[metric]} margin with no knownScaling exemption`,
+        );
+    }
+  }
+  return {
+    ok: errors.length === 0,
+    errors,
+    actualSmall,
+    actualLarge: probe.large.counts,
+    baseline: budget.baseline,
+    budgets: budget.budgets,
+    knownScaling: budget.knownScaling,
+    scales: G1_SCALES,
+    operations,
+    metrics,
+  };
+}
+
 function parseArgs(argv) {
   const options = {};
   for (let index = 0; index < argv.length; index += 1) {
@@ -179,10 +350,23 @@ function parseArgs(argv) {
 export async function main(argv = process.argv.slice(2), defaultRoot = repoRoot()) {
   try {
     const options = parseArgs(argv);
-    const result = await evaluateCostBudget({ rootDir: options.rootDir ?? defaultRoot, ...options });
+    const rootDir = options.rootDir ?? defaultRoot;
+    const result = await evaluateCostBudget({ rootDir, ...options });
     for (const metric of METRICS) console.log(`${metric}: ${result.actual[metric]}/${result.budgets[metric]}`);
-    if (!result.ok) {
-      for (const error of result.errors) console.error(`G38 cost-budget: ${error}`);
+    const g1 = await evaluateG1WriteCostScaling({
+      rootDir,
+      budgetPath: options.budgetPath,
+      receiptsDir: options.receiptsDir,
+    });
+    for (const operation of g1.operations)
+      for (const metric of g1.metrics)
+        console.log(
+          `G1 ${operation}.${metric}: ${g1.actualSmall[operation][metric]}/${g1.budgets[operation][metric]} ` +
+            `at ${g1.scales.small}, ${g1.actualLarge[operation][metric]} at ${g1.scales.large}`,
+        );
+    const errors = [...result.errors, ...g1.errors];
+    if (errors.length > 0) {
+      for (const error of errors) console.error(`G38 cost-budget: ${error}`);
       return 1;
     }
     console.log("G38 cost-budget: pass");

--- a/tools/gates/test/cost-budget.test.mjs
+++ b/tools/gates/test/cost-budget.test.mjs
@@ -4,7 +4,14 @@ import { mkdtempSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
-import { evaluateCostBudget, evaluateG1WriteCostScaling, measureCosts, readCostFixture } from "../cost-budget.mjs";
+import { pathToFileURL } from "node:url";
+import {
+  evaluateCostBudget,
+  evaluateG1WriteCostScaling,
+  measureCosts,
+  measureG1WriteCostScaling,
+  readCostFixture,
+} from "../cost-budget.mjs";
 import { signReceipt } from "../receipt-verify.mjs";
 
 function fixture() {
@@ -233,6 +240,32 @@ test("G1 requires a signed receipt to raise a committed budget above baseline", 
   );
   const withReceipt = await evaluateG1WriteCostScaling({ rootDir, measured });
   assert.equal(withReceipt.ok, true, JSON.stringify(withReceipt.errors));
+});
+
+test("G1 measures the two ledger scales one after the other", async () => {
+  const rootDir = mkdtempSync(path.join(os.tmpdir(), "ha-g1-sequential-")),
+    fixtureDir = path.join(rootDir, "packages/daemon/test/fixtures");
+  mkdirSync(fixtureDir, { recursive: true });
+  // Each fake measurement yields mid-flight; overlapping scales would record a second start first.
+  writeFileSync(
+    path.join(fixtureDir, "g1-write-cost-scaling.ts"),
+    [
+      "export const G1_OPERATIONS = ['op-a'];",
+      "export const G1_METRICS = ['sqlRowsRead'];",
+      "export const events = [];",
+      "export async function measureWriteCostScaling(eventCount) {",
+      "  events.push(`start:${eventCount}`);",
+      "  await new Promise((resolve) => setTimeout(resolve, 5));",
+      "  events.push(`end:${eventCount}`);",
+      "  return { eventCount, counts: { 'op-a': { sqlRowsRead: eventCount } } };",
+      "}",
+      "",
+    ].join("\n"),
+  );
+  const measured = await measureG1WriteCostScaling(rootDir, { small: 200, large: 2000 });
+  const { events } = await import(pathToFileURL(path.join(fixtureDir, "g1-write-cost-scaling.ts")).href);
+  assert.deepEqual(events, ["start:200", "end:200", "start:2000", "end:2000"]);
+  assert.deepEqual([measured.small.eventCount, measured.large.eventCount], [200, 2000]);
 });
 
 test("G1 rejects a budget file missing an operation the measurement covers", async () => {

--- a/tools/gates/test/cost-budget.test.mjs
+++ b/tools/gates/test/cost-budget.test.mjs
@@ -4,7 +4,7 @@ import { mkdtempSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
-import { evaluateCostBudget, measureCosts, readCostFixture } from "../cost-budget.mjs";
+import { evaluateCostBudget, evaluateG1WriteCostScaling, measureCosts, readCostFixture } from "../cost-budget.mjs";
 import { signReceipt } from "../receipt-verify.mjs";
 
 function fixture() {
@@ -78,4 +78,172 @@ test("G38 rejects lowering the baseline without lowering the active ceiling", as
   const result = await evaluateCostBudget({ rootDir });
   assert.equal(result.ok, false);
   assert.match(result.errors.join("\n"), /firstScreenReadRpcs: budget rose from 6 to 7/u);
+});
+
+// --- G1 write-path scale invariant ------------------------------------------------------------
+
+const G1_OPS = Object.freeze(["op-a"]);
+const G1_TEST_METRICS = Object.freeze(["sqlRowsRead", "gitProcesses"]);
+
+function g1Setup({ baseline = { "op-a": { sqlRowsRead: 100, gitProcesses: 4 } }, knownScaling = [] } = {}) {
+  const rootDir = mkdtempSync(path.join(os.tmpdir(), "ha-g1-cost-budget-"));
+  mkdirSync(path.join(rootDir, "tools/gates/receipts"), { recursive: true });
+  writeFileSync(
+    path.join(rootDir, "tools/gates/cost-budget.json"),
+    `${JSON.stringify({
+      writeCostScaling: {
+        schema: "write-cost-scaling-budget/v1",
+        scales: { small: 200, large: 2000 },
+        baseline,
+        budgets: baseline,
+        knownScaling,
+      },
+    })}\n`,
+  );
+  return rootDir;
+}
+
+function g1Measured(small, large, { operations = G1_OPS, metrics = G1_TEST_METRICS } = {}) {
+  return { small: { counts: small }, large: { counts: large }, operations, metrics };
+}
+
+test("G1 passes when the 2000-scale count stays within the fixed margin of the 200-scale count", async () => {
+  const rootDir = g1Setup();
+  const measured = g1Measured(
+    { "op-a": { sqlRowsRead: 100, gitProcesses: 4 } },
+    { "op-a": { sqlRowsRead: 105, gitProcesses: 4 } },
+  );
+  const result = await evaluateG1WriteCostScaling({ rootDir, measured });
+  assert.equal(result.ok, true, JSON.stringify(result.errors));
+});
+
+test("G1 rejects an unexempted operation whose count grows with ledger scale", async () => {
+  const rootDir = g1Setup();
+  const measured = g1Measured(
+    { "op-a": { sqlRowsRead: 100, gitProcesses: 4 } },
+    { "op-a": { sqlRowsRead: 900, gitProcesses: 4 } },
+  );
+  const result = await evaluateG1WriteCostScaling({ rootDir, measured });
+  assert.equal(result.ok, false);
+  assert.match(
+    result.errors.join("\n"),
+    /op-a\.sqlRowsRead: measured 100 at 200 events grew to 900 at 2000 events.*no knownScaling exemption/u,
+  );
+});
+
+test("G1 tolerates a growing count when a live knownScaling exemption names the exact pair", async () => {
+  const rootDir = g1Setup({
+    baseline: { "op-a": { sqlRowsRead: 100, gitProcesses: 4 } },
+    knownScaling: [
+      {
+        operation: "op-a",
+        metric: "sqlRowsRead",
+        reason: "test fixture for a pre-existing O(N) read this task did not fix",
+        deletionTaskId: "task_test_deletion_batch",
+        expiresAt: "2099-01-01T00:00:00.000Z",
+      },
+    ],
+  });
+  const measured = g1Measured(
+    { "op-a": { sqlRowsRead: 100, gitProcesses: 4 } },
+    { "op-a": { sqlRowsRead: 900, gitProcesses: 4 } },
+  );
+  const result = await evaluateG1WriteCostScaling({ rootDir, measured });
+  assert.equal(result.ok, true, JSON.stringify(result.errors));
+});
+
+test("G1 fails a growing count guarded by an expired knownScaling exemption", async () => {
+  const rootDir = g1Setup({
+    baseline: { "op-a": { sqlRowsRead: 100, gitProcesses: 4 } },
+    knownScaling: [
+      {
+        operation: "op-a",
+        metric: "sqlRowsRead",
+        reason: "test fixture for an exemption that ran out",
+        deletionTaskId: "task_test_deletion_batch",
+        expiresAt: "2000-01-01T00:00:00.000Z",
+      },
+    ],
+  });
+  const measured = g1Measured(
+    { "op-a": { sqlRowsRead: 100, gitProcesses: 4 } },
+    { "op-a": { sqlRowsRead: 900, gitProcesses: 4 } },
+  );
+  const result = await evaluateG1WriteCostScaling({ rootDir, measured });
+  assert.equal(result.ok, false);
+  assert.match(result.errors.join("\n"), /op-a\.sqlRowsRead: knownScaling exemption expired/u);
+});
+
+test("G1 fails a stale knownScaling exemption whose pair no longer grows", async () => {
+  const rootDir = g1Setup({
+    baseline: { "op-a": { sqlRowsRead: 100, gitProcesses: 4 } },
+    knownScaling: [
+      {
+        operation: "op-a",
+        metric: "sqlRowsRead",
+        reason: "test fixture for an exemption the fix already made unnecessary",
+        deletionTaskId: "task_test_deletion_batch",
+        expiresAt: "2099-01-01T00:00:00.000Z",
+      },
+    ],
+  });
+  const measured = g1Measured(
+    { "op-a": { sqlRowsRead: 100, gitProcesses: 4 } },
+    { "op-a": { sqlRowsRead: 105, gitProcesses: 4 } },
+  );
+  const result = await evaluateG1WriteCostScaling({ rootDir, measured });
+  assert.equal(result.ok, false);
+  assert.match(result.errors.join("\n"), /op-a\.sqlRowsRead: knownScaling exemption is stale/u);
+});
+
+test("G1 rejects a 200-scale measurement that exceeds the committed budget", async () => {
+  const rootDir = g1Setup();
+  const measured = g1Measured(
+    { "op-a": { sqlRowsRead: 150, gitProcesses: 4 } },
+    { "op-a": { sqlRowsRead: 155, gitProcesses: 4 } },
+  );
+  const result = await evaluateG1WriteCostScaling({ rootDir, measured });
+  assert.equal(result.ok, false);
+  assert.match(result.errors.join("\n"), /op-a\.sqlRowsRead: measured 150 at 200 events exceeds budget 100/u);
+});
+
+test("G1 requires a signed receipt to raise a committed budget above baseline", async () => {
+  const rootDir = g1Setup();
+  const budgetPath = path.join(rootDir, "tools/gates/cost-budget.json");
+  const budget = JSON.parse(readFileSync(budgetPath, "utf8"));
+  budget.writeCostScaling.budgets["op-a"].sqlRowsRead = 150;
+  writeFileSync(budgetPath, `${JSON.stringify(budget)}\n`);
+  const measured = g1Measured(
+    { "op-a": { sqlRowsRead: 140, gitProcesses: 4 } },
+    { "op-a": { sqlRowsRead: 145, gitProcesses: 4 } },
+  );
+  const withoutReceipt = await evaluateG1WriteCostScaling({ rootDir, measured });
+  assert.equal(withoutReceipt.ok, false);
+  assert.match(withoutReceipt.errors.join("\n"), /without a valid g1-cost-budget receipt/u);
+  const unsigned = {
+    decisionId: "dec_01KZQ92VEPTDRS2HS8CKDBKW2Q",
+    scope: "cost:g1:op-a:sqlRowsRead",
+    kind: "g1-cost-budget",
+    limit: 150,
+    expiry: "2099-12-31T23:59:59Z",
+  };
+  writeFileSync(
+    path.join(rootDir, "tools/gates/receipts/g1-cost.json"),
+    `${JSON.stringify({ ...unsigned, signature: signReceipt(unsigned) })}\n`,
+  );
+  const withReceipt = await evaluateG1WriteCostScaling({ rootDir, measured });
+  assert.equal(withReceipt.ok, true, JSON.stringify(withReceipt.errors));
+});
+
+test("G1 rejects a budget file missing an operation the measurement covers", async () => {
+  const rootDir = g1Setup();
+  const measured = g1Measured(
+    { "op-a": { sqlRowsRead: 100, gitProcesses: 4 }, "op-b": { sqlRowsRead: 10, gitProcesses: 0 } },
+    { "op-a": { sqlRowsRead: 105, gitProcesses: 4 }, "op-b": { sqlRowsRead: 10, gitProcesses: 0 } },
+    { operations: ["op-a", "op-b"] },
+  );
+  await assert.rejects(
+    evaluateG1WriteCostScaling({ rootDir, measured }),
+    /writeCostScaling\.baseline is missing operation op-b/u,
+  );
 });


### PR DESCRIPTION
# English

## Summary

This PR adds G1, a scale-invariant cost gate for the daemon write path. For each class of write and hot read, it seeds one ledger with about 200 events and one with about 2000, then runs the operation once to warm up and once more to measure. Inside the writer worker, a probe loaded through `--import` counts deterministic work in the measured call:

- SQL rows read
- sha256 calls and bytes
- Git processes
- file bytes read

A count that grows between the two ledgers fails the gate. So does a count above the ratcheted absolute budget. Wall-clock time is not used.

Before this gate, write p50 regressed to 80–110 s after the SQLite cutover while every existing gate stayed green, because none of them measured how per-write work grows with history (dec_EF5F3820E81FB8A5266F1F3342, CH1).

## Architectural Justification

Most of the churn is the measuring fixture and the budget file. The fixture seeds real ledgers through the production write path, with proportional tasks, cancelled migrations, prose documents, decisions with claims and relations, and facts, so a full scan of any entity kind grows by at least 36 rows between the two sizes. The probe is loaded with `--import` into the writer worker and adds no production hooks; `production-delta` counts the gate script at +192/-3 and no `packages/*/src` file changes. Six known growths are listed as exemptions. Each exemption names a deletion task and expires on 2026-09-24. The gate reports an exemption that no longer applies, so deleting the cause also removes the exemption.

## What Changed

- `tools/gates/cost-budget.mjs` / `cost-budget.json`: G1 now runs inside the existing G38 cost-budget gate and uses the same budget file, ratchet and exemption rules.
- `packages/daemon/test/fixtures/g1-*`: the seeded fixture, the worker probe and the measurement driver.
  - The two sizes are measured one after the other, because the counters are process-global; a gate test locks that order.
  - The local edit that exposes follower replay is written before the measuring writer mounts. That is the state the daemon enters after a restart.
- `packages/daemon/test/g1-write-cost-scaling.integration.test.ts`: runs the gate as an integration test.
- `tools/gates/test/cost-budget.test.mjs`: new cases for scaling violations, stale or expired exemptions, and sequential measurement.

Known scaling exemptions:

| Operation | 200 → 2000 SQL rows | Cause |
|---|---|---|
| task-start | 937 → 5005 | the WIP capacity snapshot lists the whole task projection |
| task-show | 601 → 4669 | `directChildCount` lists the whole task projection |
| decision-propose / reject | 469 → 2269 | `readDecisionGraph()` coverage reads every task, fact and edge |
| task-list (limit 3) | 144 → 1404 | the index is read in full, then limited in memory |
| runtime-overview | 150 → 1446 | the workspace summary counts every task and decision in memory |

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: +192/-3 (gate script only; no `packages/*/src` change).

## Machine-Readable Declarations

## Task And Scope

- Harness task: task_78327209a449760a74d1992de3
- Branch: `codex/g1-write-cost-scaling`
- Public scope: the G1 scaling invariant inside the G38 cost-budget gate, its fixture and tests
- Private planning/evidence updated: yes (task plan, two worker reports, facts F-FC5A93B9 and F-0F25B045)
- Out of scope: G2–G5 of the same decision, and any production code

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: yes
- Protected surface scope: `tools/gates/cost-budget.mjs`, `tools/gates/cost-budget.json`, `tools/gates/test/cost-budget.test.mjs`
- Authority: dec_EF5F3820E81FB8A5266F1F3342 CH1 (accepted by the repository owner), task_78327209a449760a74d1992de3 derived from it
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: task_559a818b48478f255b3c720a0c (G5 per-write cost section in PR bodies)

## Verification

- Base `origin/main` SHA: `62a7123ae`
- Branch merge-base with `origin/main`: `62a7123ae`
- Last `git fetch origin` time: 2026-09-10 16:40 UTC
- Sync method: rebased onto origin/main
- Public diff command: `git diff origin/main...codex/g1-write-cost-scaling`
- Private evidence commit/path: task_78327209a449760a74d1992de3 artifacts/g1-report-2.md
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Positive controls:
  - The gate and fixtures were copied into detached worktrees at two known-bad commits. The head's six exemptions were kept, so the gate could fail only on other metrics.
  - `1f85019af` (per-row projection fingerprint) fails with 29 violations.
  - `944a86ced` (follower replay from revision 0) fails with 29 violations.
  - In both runs every one of the 8 write classes fails on sha256 calls, sha256 bytes and file bytes read.
- Head: `node tools/gates/cost-budget.mjs` exits 0. Two runs print byte-identical output, and the isolated Ubuntu run prints the same output as macOS. The lead re-ran it on this head: pass, about 20 s.
- `node tools/run-manifest-gates.mjs --changed origin/main`, line-density, file-complexity, test-selection and production-delta pass.
- Not run: the full `npm run check` / `npm test` locally. Local agents must not run the full matrix, so CI is the full authority.

## Review Evidence

- Self-review: the lead reviewed the first round and sent it back with five points:
  - include follower settlement in the window;
  - measure steady state;
  - page the hot reads;
  - absorb the deletion batches;
  - trace each growth to its cause.
- The second round answered all five. It also raised one objection, with evidence: the old window already included the follower. The positive control had stayed flat because the local edit landed after warm-up. The fixture now writes that edit before the writer mounts.
- Reviewer subagent: not used
- Human review: pending
- Blocking findings: none

## Residual Risk

- G1 counts rows returned to JavaScript, not rows SQLite scans. A `COUNT(*)` over N rows returns one row, so the gate does not see it.
- Progress and execution records are not seeded proportionally.
- With only two size points, sub-linear growth can stay inside the margin.
- The absolute ratchet on bytes is sensitive to template text changes.

## References

- Decision: dec_EF5F3820E81FB8A5266F1F3342
- Task: task_78327209a449760a74d1992de3
- Facts: F-FC5A93B9, F-0F25B045

---

# 中文

## 概要

本 PR 新增 G1：daemon 写路径的规模不变量成本门。对每一类写入和热读，它分别在约 200 条和约 2000 条事件的台账上先预热一次，再测一次。writer worker 里有一个通过 `--import` 注入的探针，统计被测那次调用做的确定性工作量：

- 读取的 SQL 行数
- sha256 调用次数与字节数
- Git 进程数
- 读文件字节数

两种台账之间出现增长，门就判红；超过棘轮下来的绝对预算，也判红。门不看墙钟。

之前的背景：SQLite 切换后写入 p50 退化到 80–110 秒，而所有门都是绿的，因为没有一道门测"每次写入的工作量是否随历史增长"（dec_EF5F3820E81FB8A5266F1F3342 CH1）。

## 架构辩护

改动行数主要来自测量 fixture 和预算文件。

- **fixture**：经生产写路径灌入真实台账，按比例包含任务、cancelled 迁移、prose 文档、带 claim 与关系的 decision 以及 fact，保证对任一类实体全扫时，两种规模之间至少相差 36 行。
- **探针**：通过 `--import` 注入 writer worker，不加任何生产钩子。`production-delta` 只计入门脚本的 +192/-3，没有改 `packages/*/src`。
- **豁免**：已知的 6 项增长登记为豁免，每项都带删除任务和 2026-09-24 到期日。豁免不再适用时门会报出来，所以删掉病因的同一个变更里也会删掉对应豁免。

## 改动内容

- `tools/gates/cost-budget.mjs` / `cost-budget.json`：G1 并入现有的 G38 cost-budget 门，共用同一个预算文件、棘轮和豁免规则。
- `packages/daemon/test/fixtures/g1-*`：灌数 fixture、worker 探针和测量驱动。
  - 计数器是进程级全局的，所以两种规模顺序测量，由门测试锁住这个顺序。
  - 暴露 follower 重放的本地编辑，在测量 writer 挂载之前写入，这正是 daemon 重启后进入的状态。
- `packages/daemon/test/g1-write-cost-scaling.integration.test.ts`：以集成测试的形式运行门。
- `tools/gates/test/cost-budget.test.mjs`：新增三类用例，覆盖规模违规、豁免过期或失效，以及顺序测量。

已登记的规模豁免：

| 操作 | 200 → 2000 读取 SQL 行数 | 原因 |
|---|---|---|
| task-start | 937 → 5005 | WIP 容量快照列出整个任务投影 |
| task-show | 601 → 4669 | `directChildCount` 列出整个任务投影 |
| decision-propose / reject | 469 → 2269 | `readDecisionGraph()` 的覆盖率读取全部 task、fact 和关系边 |
| task-list（limit 3） | 144 → 1404 | 先整张读出索引，再在内存里截取 |
| runtime-overview | 150 → 1446 | 工作区总览在内存里统计全部 task 和 decision |

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 删除的门或 fixture：none
- 生产净行数：+192/-3（只有门脚本，没有改 `packages/*/src`）。

## 机读声明说明

- 本 PR 不涉及依赖变化和事件迁移，没有机读声明。

## 任务与范围

- Harness 任务：task_78327209a449760a74d1992de3
- 分支：`codex/g1-write-cost-scaling`
- 公开范围：G38 cost-budget 门里的 G1 规模不变量，以及它的 fixture 和测试
- 私有计划 / 证据是否已更新：yes（任务计划、两轮 worker 报告，fact F-FC5A93B9 与 F-0F25B045）
- 范围外：同一决策下的 G2–G5，以及任何生产代码

## 版本影响

- 版本：不改版本
- 发布影响：不发布

## 治理声明

- 是否触碰 protected surface：yes
- protected surface 范围：`tools/gates/cost-budget.mjs`、`tools/gates/cost-budget.json`、`tools/gates/test/cost-budget.test.mjs`
- 依据：dec_EF5F3820E81FB8A5266F1F3342 CH1（仓库所有者已接受），以及由它派生的 task_78327209a449760a74d1992de3
- 机器检查边界：本 PR 只声明该段存在；声明是否真实、充分，由 reviewer 判断。
- Break-glass：no
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：task_559a818b48478f255b3c720a0c（G5，PR 正文里的逐写成本段落）

## 验证

- `origin/main` 基准 SHA：`62a7123ae`
- 当前分支与 `origin/main` 的 merge-base：`62a7123ae`
- 最近一次 `git fetch origin` 时间：2026-09-10 16:40 UTC
- 同步方式：rebase 到 origin/main
- 公开 diff 命令：`git diff origin/main...codex/g1-write-cost-scaling`
- 私有证据 commit/path：task_78327209a449760a74d1992de3 artifacts/g1-report-2.md
- Reviewer 证据路径：见本 PR 的「审查证据」一节
- GitHub Actions `rewrite-ci` run URL：本 PR 的 CI 还在跑
- [ ] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- 阳性对照：
  - 在两个已知有问题的 commit 上建 detached worktree，把本分支的门和 fixture 拷过去运行，并保留 head 的 6 条豁免，这样门只能靠其他指标变红。
  - `1f85019af`（逐行投影指纹）：29 条违规。
  - `944a86ced`（follower 从 revision 0 重放）：29 条违规。
  - 两次运行中，8 类写入全部在 sha256 调用次数、sha256 字节数和读文件字节数上变红。
- head：`node tools/gates/cost-budget.mjs` 退出码 0；连续两次输出逐字节相同；隔离 Ubuntu 上的输出与 macOS 相同。主控在本 head 上又跑了一次，通过，约 20 秒。
- `node tools/run-manifest-gates.mjs --changed origin/main`、line-density、file-complexity、test-selection、production-delta 全部通过。
- 未运行：本地整套 `npm run check` / `npm test`。规定禁止本地 agent 跑全量矩阵，全量以 CI 为准。

## 审查证据

- 自查：主控审查第一轮后，带着五点意见打回：
  - 测量窗口包含 follower 结算；
  - 测稳态；
  - 热读带分页；
  - 吸收各删除批次；
  - 逐条定位增长的原因。
- 第二轮逐条答复了这五点，还带证据提出一条异议：旧窗口其实已经包含 follower，阳性对照当时持平，是因为本地编辑在预热之后才写入。现在 fixture 在 writer 挂载之前就写入这份编辑。
- Reviewer subagent：未使用
- 人工审查：待进行
- 阻塞发现：无

## 残余风险

- G1 数的是返回给 JavaScript 的行，不是 SQLite 实际扫描的行。对 N 行做 `COUNT(*)` 只返回 1 行，门看不见。
- progress 和 execution 记录没有按比例灌入。
- 只有两个规模点，次线性增长可能落在余量之内。
- 字节类的绝对棘轮对模板文字的改动很敏感。

## 关联材料

- 决策：dec_EF5F3820E81FB8A5266F1F3342
- 任务：task_78327209a449760a74d1992de3
- Fact：F-FC5A93B9、F-0F25B045

---

## PR Gate Checklist / PR 门禁清单

- [x] Branch is based on latest `origin/main`. / 分支基于最新 `origin/main`。
- [x] PR body uses this full template structure. / PR 描述使用本模板完整结构。
- [x] PR body uses two complete language blocks: `# English` first, then `# 中文`. / PR 正文使用两块完整正文：`# English` 在上，`# 中文` 在下。
- [x] PR body passes `tools/check-pr-body-bilingual.mjs`. / PR 正文通过 `tools/check-pr-body-bilingual.mjs`。
- [x] If the PR touches a manifest-derived protected surface, Governance Declaration is filled with ADR/decision/task evidence or break-glass fields. / 若 PR 触碰 manifest 派生的 protected surface，Governance Declaration 已填写 ADR/decision/task 依据或 break-glass 字段。
- [x] No private harness files are included. / 不包含私有 harness 文件。
- [x] No ignored local agent entry files are included. / 不包含被忽略的本地 agent 入口文件。
- [x] No absolute local filesystem paths are included in this public PR body. / 本公开 PR 描述不包含本机绝对路径。
- [x] Public diff is limited to the stated task scope. / 公开 diff 限于声明的任务范围。
- [x] Private planning/evidence updates are recorded when applicable. / 适用时已记录私有计划 / 证据更新。
- [x] Version and publish impact are stated. / 已说明版本与发布影响。
- [x] Local verification commands are recorded honestly. / 已如实记录本地验证命令。
- [ ] CI results are linked or explained. / CI 结果已链接或说明。
- [x] Review evidence is recorded. / 已记录审查证据。
- [x] Open P0/P1/P2 findings are closed, deferred with owner, or explicitly blocked. / open P0/P1/P2 findings 已关闭、带 owner 延后，或明确阻塞。
- [x] Merge method and post-merge branch cleanup plan are clear. / 合并方式和合并后分支清理计划清楚。
- [x] No admin bypass is planned unless explicitly approved and recorded. / 除非明确批准并记录，否则不计划 admin bypass。
