### PR TITLE
perf(preset): trust installed digests and cache bundled assets

### DIFF
--- a/packages/cli/src/daemon/client.ts
+++ b/packages/cli/src/daemon/client.ts
@@ -280,7 +280,7 @@ export async function runCommandThroughDaemon(
           : {}),
       };
     }
-    await new Promise((resolve) => setTimeout(resolve, 20));
+    await new Promise((resolve) => setTimeout(resolve, 250));
     try {
       result = await requestLocalDaemonJsonRpcForTarget(
         target,

--- a/packages/preset/src/preset-assets.ts
+++ b/packages/preset/src/preset-assets.ts
@@ -7,15 +7,31 @@ import { compileVerticalContract, TemplateCatalogSchema } from "../../kernel/src
 import type { CompiledVerticalContract, TemplateCatalog } from "../../kernel/src/index.ts";
 import { requiredRegularFile, safeTemplatePath } from "./preset-materialization.ts";
 import { parsePresetJson } from "./preset-package.ts";
-import { isPresetResolutionRecord, presetFailure, resolverContentHash } from "./preset-resolver-common.ts";
+import {
+  defaultAssets,
+  isPresetResolutionRecord,
+  presetFailure,
+  resolverContentHash,
+} from "./preset-resolver-common.ts";
 import type { CanonicalAssets, CatalogSource, DecodedPresetPackageV3, Provider } from "./preset-resolver-types.ts";
 import { Schema } from "effect";
 import { existsSync, lstatSync } from "node:fs";
 import path from "node:path";
 
+const canonicalAssetsCache = new Map<string, CanonicalAssets>();
+
 export function loadCanonicalAssets(source: string): CanonicalAssets {
   const resolvedSource = path.resolve(source),
-    sourceIsFile = existsSync(resolvedSource) && lstatSync(resolvedSource).isFile(),
+    cached = canonicalAssetsCache.get(resolvedSource);
+  if (cached) return cached;
+  const assets = loadCanonicalAssetsUncached(resolvedSource);
+  if (resolvedSource !== path.resolve(defaultAssets)) return assets;
+  canonicalAssetsCache.set(resolvedSource, assets);
+  return assets;
+}
+
+function loadCanonicalAssetsUncached(resolvedSource: string): CanonicalAssets {
+  const sourceIsFile = existsSync(resolvedSource) && lstatSync(resolvedSource).isFile(),
     root = sourceIsFile ? path.dirname(resolvedSource) : resolvedSource,
     verticalPath = sourceIsFile ? resolvedSource : path.join(root, "vertical.json"),
     verticalBody = requiredRegularFile(verticalPath, "missing_vertical"),

--- a/packages/preset/src/preset-catalog.ts
+++ b/packages/preset/src/preset-catalog.ts
@@ -125,7 +125,11 @@ export function decodeCandidate(
   pointerDigest?: unknown,
 ): Candidate {
   try {
-    const decoded = decodePackage(root, layer === "user");
+    const decoded = decodePackage(
+      root,
+      layer === "user",
+      typeof pointerDigest === "string" ? pointerDigest : undefined,
+    );
     if (decoded.manifest.id !== directoryId)
       throw presetFailure(
         "path_id_mismatch",
@@ -133,8 +137,6 @@ export function decodeCandidate(
       );
     if (pointerVertical !== undefined && decoded.manifest.vertical !== pointerVertical)
       throw presetFailure("invalid_pointer", `Pointer vertical does not match package ${directoryId}.`);
-    if (pointerDigest !== undefined && decoded.packageDigest !== pointerDigest)
-      throw presetFailure("digest_mismatch", `Pointer digest does not match package ${directoryId}.`);
     return {
       id: decoded.manifest.id,
       verticalId: decoded.manifest.vertical,

--- a/packages/preset/src/preset-package.ts
+++ b/packages/preset/src/preset-package.ts
@@ -1,18 +1,8 @@
 import { decodeCatalog } from "./preset-assets.ts";
-import {
-  presetFailure,
-  resolverContentHash,
-} from "./preset-resolver-common.ts";
-import type {
-  DecodedPresetPackageV3,
-  PresetPackageScript,
-} from "./preset-resolver-types.ts";
+import { presetFailure, resolverContentHash } from "./preset-resolver-common.ts";
+import type { DecodedPresetPackageV3, PresetPackageScript } from "./preset-resolver-types.ts";
 import { validatePackagePolicy } from "./preset-validation.ts";
-import {
-  canonicalPresetBytes,
-  parsePresetManifestV3,
-  validatePresetDocumentV1,
-} from "./preset.contract.ts";
+import { canonicalPresetBytes, parsePresetManifestV3, validatePresetDocumentV1 } from "./preset.contract.ts";
 import type { PresetDocumentV1 } from "./preset.contract.ts";
 import { createHash } from "node:crypto";
 import { existsSync, lstatSync, readFileSync, readdirSync } from "node:fs";
@@ -25,67 +15,53 @@ export function decodePresetPackageV3(root: string): DecodedPresetPackageV3 {
 export function decodePackage(
   root: string,
   requireLocalCatalog = false,
+  trustedDigest?: string,
 ): DecodedPresetPackageV3 {
   const files = scan(root),
     manifestBody = file(files, "preset.json", "missing_manifest"),
     presetBody = file(files, "PRESET.md", "missing_preset_document"),
-    manifest = parsePresetManifestV3(
-      parsePresetJson(manifestBody, "invalid_manifest"),
-    ),
+    manifest = parsePresetManifestV3(parsePresetJson(manifestBody, "invalid_manifest")),
     document = parseDocument(presetBody),
     task = manifest;
   for (const [name, entrypoint] of Object.entries(task?.entrypoints ?? {}))
     if (!files.has(entrypoint.command))
-      throw presetFailure(
-        "missing_script",
-        `Entrypoint ${name} command ${entrypoint.command} is missing.`,
-      );
-  if (task?.policyPath)
-    validatePackagePolicy(file(files, task.policyPath, "missing_policy"));
+      throw presetFailure("missing_script", `Entrypoint ${name} command ${entrypoint.command} is missing.`);
+  if (task?.policyPath) validatePackagePolicy(file(files, task.policyPath, "missing_policy"));
   const catalogBody = files.get("template-catalog.json"),
-    hasSelections =
-      task?.profiles.some((profile) => profile.templateSelections.length > 0) ??
-      false;
+    hasSelections = task?.profiles.some((profile) => profile.templateSelections.length > 0) ?? false;
   if (requireLocalCatalog && hasSelections && catalogBody === undefined)
     throw presetFailure(
       "missing_template_catalog",
       `User preset ${manifest.id} must provide template-catalog.json for its template selections.`,
     );
   if (catalogBody !== undefined) decodeCatalog(catalogBody, root);
-  const digest = createHash("sha256");
-  for (const [name, body] of [...files].sort(([left], [right]) =>
-    left.localeCompare(right),
-  ))
-    digest.update(`${name}\0${Buffer.byteLength(body)}\0`).update(body);
+  const packageDigest =
+    trustedDigest ??
+    (() => {
+      const digest = createHash("sha256");
+      for (const [name, body] of [...files].sort(([left], [right]) => left.localeCompare(right)))
+        digest.update(`${name}\0${Buffer.byteLength(body)}\0`).update(body);
+      return digest.digest("hex");
+    })();
   return {
     manifest,
     document,
     root,
-    packageDigest: digest.digest("hex"),
+    packageDigest,
     manifestSha256: resolverContentHash(canonicalPresetBytes(manifest)),
   } as DecodedPresetPackageV3;
 }
 
 export function scan(root: string): Map<string, string> {
-  if (
-    !existsSync(root) ||
-    !lstatSync(root).isDirectory() ||
-    lstatSync(root).isSymbolicLink()
-  )
-    throw presetFailure(
-      "invalid_package",
-      `Preset package ${root} is not a regular directory.`,
-    );
+  if (!existsSync(root) || !lstatSync(root).isDirectory() || lstatSync(root).isSymbolicLink())
+    throw presetFailure("invalid_package", `Preset package ${root} is not a regular directory.`);
   const files = new Map<string, string>(),
     visit = (directory: string) => {
       for (const entry of readdirSync(directory, { withFileTypes: true })) {
         const absolute = path.join(directory, entry.name),
           relative = path.relative(root, absolute).split(path.sep).join("/");
         if (entry.isSymbolicLink() || (!entry.isDirectory() && !entry.isFile()))
-          throw presetFailure(
-            "symlink_forbidden",
-            `Preset package entry ${relative} is not regular.`,
-          );
+          throw presetFailure("symlink_forbidden", `Preset package entry ${relative} is not regular.`);
         if (entry.isDirectory()) visit(absolute);
         else files.set(relative, readFileSync(absolute, "utf8"));
       }
@@ -94,19 +70,11 @@ export function scan(root: string): Map<string, string> {
   return files;
 }
 
-export function presetPackageScripts(
-  root: string,
-): readonly PresetPackageScript[] {
+export function presetPackageScripts(root: string): readonly PresetPackageScript[] {
   const directory = path.join(root, "scripts");
   if (!existsSync(directory)) return [];
-  if (
-    !lstatSync(directory).isDirectory() ||
-    lstatSync(directory).isSymbolicLink()
-  )
-    throw presetFailure(
-      "invalid_preset_scripts",
-      `Preset package ${root} ships scripts as a non-directory node.`,
-    );
+  if (!lstatSync(directory).isDirectory() || lstatSync(directory).isSymbolicLink())
+    throw presetFailure("invalid_preset_scripts", `Preset package ${root} ships scripts as a non-directory node.`);
   return readdirSync(directory, { withFileTypes: true })
     .sort((left, right) => left.name.localeCompare(right.name))
     .map((entry) => {
@@ -126,13 +94,8 @@ export function presetPackageScripts(
 export function parseDocument(body: string): PresetDocumentV1 {
   const value = presetDocumentValue(body),
     errors = validatePresetDocumentV1(value);
-  if (errors.length)
-    throw presetFailure("invalid_preset_document", errors.join("; "));
-  if (!isPresetDocumentV1(value))
-    throw presetFailure(
-      "invalid_preset_document",
-      "PRESET.md document is invalid.",
-    );
+  if (errors.length) throw presetFailure("invalid_preset_document", errors.join("; "));
+  if (!isPresetDocumentV1(value)) throw presetFailure("invalid_preset_document", "PRESET.md document is invalid.");
   return value;
 }
 
@@ -148,9 +111,7 @@ export function isPresetDocumentV1(value: unknown): value is PresetDocumentV1 {
   );
 }
 
-export function presetDocumentValue(
-  body: string,
-): Record<string, unknown> | null {
+export function presetDocumentValue(body: string): Record<string, unknown> | null {
   const match = /^---\r?\n([\s\S]*?)\r?\n---\r?\n([\s\S]*)$/u.exec(body);
   if (!match) return null;
   return {
@@ -164,14 +125,9 @@ export function presetDocumentValue(
   };
 }
 
-export function file(
-  files: Map<string, string>,
-  name: string,
-  code: string,
-): string {
+export function file(files: Map<string, string>, name: string, code: string): string {
   const body = files.get(name);
-  if (body === undefined)
-    throw presetFailure(code, `Preset package is missing ${name}.`);
+  if (body === undefined) throw presetFailure(code, `Preset package is missing ${name}.`);
   return body;
 }
 

--- a/packages/preset/src/preset-resolver-api.ts
+++ b/packages/preset/src/preset-resolver-api.ts
@@ -1,39 +1,7 @@
-import { effectiveCatalog } from "./preset-catalog.ts";
-import {
-  defaultBundled,
-  key,
-  presetFailure,
-} from "./preset-resolver-common.ts";
 import type { PresetResolverOptions } from "./preset-resolver-types.ts";
 import { createRuntime } from "./preset-runtime.ts";
-import type {
-  CanonicalPresetResolver,
-  PresetManifestV3,
-} from "./preset.contract.ts";
-import path from "node:path";
+import type { CanonicalPresetResolver } from "./preset.contract.ts";
 
-export function createCanonicalPresetResolver(
-  options: PresetResolverOptions,
-): CanonicalPresetResolver {
+export function createCanonicalPresetResolver(options: PresetResolverOptions): CanonicalPresetResolver {
   return createRuntime(options).resolver;
-}
-
-export function readInstalledPresetManifest(input: {
-  readonly userRoot: string;
-  readonly presetId: string;
-  readonly verticalId: string;
-}): PresetManifestV3 {
-  const selected = effectiveCatalog(
-    defaultBundled,
-    path.resolve(input.userRoot),
-  ).get(key(input.verticalId, input.presetId));
-  if (!selected?.decoded)
-    throw (
-      selected?.error ??
-      presetFailure(
-        "preset_not_found",
-        `Preset ${input.presetId} is not installed.`,
-      )
-    );
-  return selected.decoded.manifest;
 }

--- a/packages/preset/src/preset-resolver.ts
+++ b/packages/preset/src/preset-resolver.ts
@@ -1,5 +1,4 @@
 export { createCanonicalPresetResolver } from "./preset-resolver-api.ts";
-export { readInstalledPresetManifest } from "./preset-resolver-api.ts";
 export { compileRepositoryScaffold } from "./preset-repository-scaffold.ts";
 export { assertRepositoryScaffoldPlanCurrent } from "./preset-repository-scaffold.ts";
 export { validatePresetPackage } from "./preset-validation.ts";

--- a/packages/preset/src/preset-runtime.ts
+++ b/packages/preset/src/preset-runtime.ts
@@ -1,6 +1,6 @@
 import { assertCanonicalVertical, loadCanonicalAssets, packageCatalog } from "./preset-assets.ts";
 import { effectiveCatalog } from "./preset-catalog.ts";
-import { catalogRecovery, listCatalog } from "./preset-discovery.ts";
+import { listCatalog } from "./preset-discovery.ts";
 import {
   catalogAnchors,
   materializeSelections,
@@ -21,7 +21,6 @@ import {
 } from "./preset-resolver-common.ts";
 import type {
   Candidate,
-  CanonicalAssets,
   InternalPresetResolution,
   OwnedEntrypoint,
   PresetResolverOptions,
@@ -47,9 +46,8 @@ export function createRuntime(options: PresetResolverOptions): {
     userRoot = path.resolve(options.userRoot),
     assetsRoot = path.resolve(options.assetsRoot ?? defaultAssets),
     kernelVersion = options.kernelVersion ?? "1.0.0";
-  let cachedAssets: CanonicalAssets | undefined;
   const resolveInternal = (request: ResolvePresetRequestV1): InternalPresetResolution => {
-    const assets = (cachedAssets ??= loadCanonicalAssets(assetsRoot)),
+    const assets = loadCanonicalAssets(assetsRoot),
       inventory = effectiveCatalog(bundledRoot, userRoot),
       selected = inventory.get(key(request.verticalId, request.presetId));
     if (selected && !selected.decoded)
@@ -297,29 +295,41 @@ export function createRuntime(options: PresetResolverOptions): {
     };
   };
   const resolver: CanonicalPresetResolver = {
-    list: async ({ verticalId }) =>
-      listCatalog(effectiveCatalog(bundledRoot, userRoot), verticalId).map((entry) => {
+    list: async ({ verticalId }) => {
+      const catalog = effectiveCatalog(bundledRoot, userRoot),
+        assets = loadCanonicalAssets(assetsRoot),
+        providers = new Map(assets.providers.map((item) => [item.id, item]));
+      return listCatalog(catalog, verticalId).map((entry) => {
         if (entry.validity !== "valid") return entry;
-        try {
-          resolveInternal({
-            presetId: entry.id,
-            verticalId,
-            locale: "en-US",
-            purpose: "inspect",
-          });
-          return entry;
-        } catch (error) {
-          const known = asFailure(error);
-          return {
-            ...entry,
-            validity: known.code === "missing_provider" ? ("unavailable" as const) : ("blocked" as const),
-            errorCode: known.code,
-            issues: [{ code: known.code, message: known.message }],
-            issueCount: 1,
-            ...catalogRecovery(entry, known),
-          };
-        }
-      }),
+        const candidate = catalog.get(key(verticalId, entry.id)),
+          imports = candidate?.decoded?.manifest.capabilityImports ?? [],
+          missingProviderIds = imports
+            .filter((item) => {
+              const provider = providers.get(item.id);
+              return (
+                (!provider || provider.kind !== item.kind || provider.version !== item.version) &&
+                (!("required" in item) || item.required)
+              );
+            })
+            .map(({ id }) => id)
+            .sort();
+        if (!missingProviderIds.length) return entry;
+        const failure = presetFailure(
+          "missing_provider",
+          `Capability providers ${missingProviderIds.join(", ")} are unavailable.`,
+          missingProviderIds,
+        );
+        return {
+          ...entry,
+          validity: "unavailable" as const,
+          errorCode: failure.code,
+          issues: [{ code: failure.code, message: failure.message }],
+          issueCount: 1,
+          nextAction: `Use a Harness build that provides ${missingProviderIds.join(", ")}, then rerun ha preset list.`,
+          missingProviderIds,
+        };
+      });
+    },
     resolve: async (request): Promise<PresetResolveResultV1> => {
       try {
         const resolved = resolveInternal(request);


### PR DESCRIPTION
# English

## Summary

Preset resolution stops re-reading and re-hashing installed packages on every request.

- An active install pointer carries the digest of its content-addressed directory, which was verified at install time. Resolve now uses it instead of rebuilding the digest from the file tree.
- Built-in assets are cached per process; custom roots still load live.
- `resolver.list` reads manifest fields and provider availability without a full resolve per entry.
- The CLI preset run status poll moves from 20 ms to 250 ms; it waits on daemon-owned run status, which has no push event.

This is batch R5 of the 2026-09-10 rescan.

## Architectural Justification

The churn is mostly deletion (−139). The one new parameter carries the install-time digest, so the hot path skips a hash it already has. The one new map caches only immutable built-in assets.

## What Changed

- `preset-package.ts`, `preset-catalog.ts`: an optional trusted digest for active pointers.
- `preset-assets.ts`, `preset-runtime.ts`: per-process cache for bundled assets.
- `preset-resolver.ts`, `preset-resolver-api.ts`: list without full resolve.
- `packages/cli/src/daemon/client.ts`: status poll interval is 250 ms.
- Deleted the zero-consumer `readInstalledPresetManifest`.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: +90/-139 (net -49), from `node tools/gates/production-delta.mjs --base origin/main`.

## Machine-Readable Declarations

## Task And Scope

- Harness task: task_710cb65de4674eb81fa9b7dbb0
- Branch: `codex/r5-preset-cli`
- Public scope: preset resolution and the CLI preset run status poll
- Private planning/evidence updated: yes (task plan and worker report)
- Out of scope: install-time verification, which remains the integrity entry point

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: not applicable
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `8ba0c5978`
- Branch merge-base with `origin/main`: `8ba0c5978`
- Last `git fetch origin` time: 2026-09-10 16:45 UTC
- Sync method: rebased onto origin/main
- Public diff command: `git diff origin/main...codex/r5-preset-cli`
- Private evidence commit/path: task_710cb65de4674eb81fa9b7dbb0 task package report
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- `npx tsc -b packages/preset packages/cli` passes.
- All non-integration `packages/preset/test` files pass, along with targeted resolver, bundled catalog, discovery shadowing and capability tests.
- prettier, eslint and `node tools/run-manifest-gates.mjs --changed origin/main` pass.
- Not run: the full `npm run check` / `npm test` locally. Local agents must not run the full matrix, so CI is the full authority.

## Review Evidence

- Self-review: the lead confirmed that install-time copy and object verification are unchanged.
- Reviewer subagent: not used
- Human review: pending
- Blocking findings: none

## Residual Risk

- A package tampered with after install is no longer detected at resolve time, only by install or verification commands.

## References

- Task: task_710cb65de4674eb81fa9b7dbb0
- Parent: task_2b8f79fa4412cb726a26f9bfc7

---

# 中文

## 概要

preset 解析不再在每次请求时重读、重哈希已安装的包。

- 活动的安装指针带着其内容寻址目录的 digest，这个 digest 在安装时已经校验过。resolve 现在直接使用它，不再从文件树重算。
- 内置资产按进程缓存；自定义根目录仍然实时读取。
- `resolver.list` 只读清单字段和 provider 可用性，不再对每个条目做完整 resolve。
- CLI 的 preset run 状态轮询间隔从 20ms 调到 250ms。它等的是 daemon 拥有的 run 状态，没有推送事件可等。

这是 2026-09-10 复扫后的 R5 批次。

## 架构辩护

改动行数大部分是删除（−139）。唯一新增的参数用来携带安装时的 digest，让热路径跳过它本来就有的那次哈希；唯一新增的 Map 只缓存不可变的内置资产。

## 改动内容

- `preset-package.ts`、`preset-catalog.ts`：为活动指针增加可选的受信 digest。
- `preset-assets.ts`、`preset-runtime.ts`：内置资产按进程缓存。
- `preset-resolver.ts`、`preset-resolver-api.ts`：列表不再做完整 resolve。
- `packages/cli/src/daemon/client.ts`：状态轮询间隔改为 250ms。
- 删除零消费者的 `readInstalledPresetManifest`。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 删除的门或 fixture：none
- 生产净行数：+90/-139 (net -49)，由 `node tools/gates/production-delta.mjs --base origin/main` 计算。

## 机读声明说明

- 本 PR 不涉及依赖变化和事件迁移，没有机读声明。

## 任务与范围

- Harness 任务：task_710cb65de4674eb81fa9b7dbb0
- 分支：`codex/r5-preset-cli`
- 公开范围：preset 解析与 CLI 的 preset run 状态轮询
- 私有计划 / 证据是否已更新：yes（任务计划与 worker 报告）
- 范围外：安装时的校验，它仍然是完整性的入口

## 版本影响

- 版本：不改版本
- 发布影响：不发布

## 治理声明

- 是否触碰 protected surface：no
- protected surface 范围：不适用
- 依据：不适用
- 机器检查边界：本 PR 只声明该段存在；声明是否真实、充分，由 reviewer 判断。
- Break-glass：no
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- `origin/main` 基准 SHA：`8ba0c5978`
- 当前分支与 `origin/main` 的 merge-base：`8ba0c5978`
- 最近一次 `git fetch origin` 时间：2026-09-10 16:45 UTC
- 同步方式：rebase 到 origin/main
- 公开 diff 命令：`git diff origin/main...codex/r5-preset-cli`
- 私有证据 commit/path：task_710cb65de4674eb81fa9b7dbb0 任务包报告
- Reviewer 证据路径：见本 PR 的「审查证据」一节
- GitHub Actions `rewrite-ci` run URL：本 PR 的 CI 还在跑
- [ ] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- `npx tsc -b packages/preset packages/cli` 通过。
- `packages/preset/test` 的全部非集成测试通过，定向的 resolver、bundled catalog、discovery shadowing、capability 测试也通过。
- prettier、eslint、`node tools/run-manifest-gates.mjs --changed origin/main` 通过。
- 未运行：本地整套 `npm run check` / `npm test`。规定禁止本地 agent 跑全量矩阵，全量以 CI 为准。

## 审查证据

- 自查：主控确认安装时的复制与对象校验保持不变。
- Reviewer subagent：未使用
- 人工审查：待进行
- 阻塞发现：无

## 残余风险

- 安装之后被篡改的包，不再能在 resolve 时发现，只能由安装或校验命令发现。

## 关联材料

- Task: task_710cb65de4674eb81fa9b7dbb0
- Parent: task_2b8f79fa4412cb726a26f9bfc7

---

## PR Gate Checklist / PR 门禁清单

- [x] Branch is based on latest `origin/main`. / 分支基于最新 `origin/main`。
- [x] PR body uses this full template structure. / PR 描述使用本模板完整结构。
- [x] PR body uses two complete language blocks: `# English` first, then `# 中文`. / PR 正文使用两块完整正文：`# English` 在上，`# 中文` 在下。
- [x] PR body passes `tools/check-pr-body-bilingual.mjs`. / PR 正文通过 `tools/check-pr-body-bilingual.mjs`。
- [x] If the PR touches a manifest-derived protected surface, Governance Declaration is filled with ADR/decision/task evidence or break-glass fields. / 若 PR 触碰 manifest 派生的 protected surface，Governance Declaration 已填写 ADR/decision/task 依据或 break-glass 字段。
- [x] No private harness files are included. / 不包含私有 harness 文件。
- [x] No ignored local agent entry files are included. / 不包含被忽略的本地 agent 入口文件。
- [x] No absolute local filesystem paths are included in this public PR body. / 本公开 PR 描述不包含本机绝对路径。
- [x] Public diff is limited to the stated task scope. / 公开 diff 限于声明的任务范围。
- [x] Private planning/evidence updates are recorded when applicable. / 适用时已记录私有计划 / 证据更新。
- [x] Version and publish impact are stated. / 已说明版本与发布影响。
- [x] Local verification commands are recorded honestly. / 已如实记录本地验证命令。
- [ ] CI results are linked or explained. / CI 结果已链接或说明。
- [x] Review evidence is recorded. / 已记录审查证据。
- [x] Open P0/P1/P2 findings are closed, deferred with owner, or explicitly blocked. / open P0/P1/P2 findings 已关闭、带 owner 延后，或明确阻塞。
- [x] Merge method and post-merge branch cleanup plan are clear. / 合并方式和合并后分支清理计划清楚。
- [x] No admin bypass is planned unless explicitly approved and recorded. / 除非明确批准并记录，否则不计划 admin bypass。
