### PR TITLE
fix(daemon,cli): show why a command was rejected

### DIFF
--- a/packages/cli/src/cli/guidance-plane.ts
+++ b/packages/cli/src/cli/guidance-plane.ts
@@ -186,22 +186,29 @@ export function humanError(receipt: Record<string, unknown>): { readonly code: s
   if (code === "daemon_stopping") return { code, hint: renderTemplate("failure", "daemon-stopping", {}) };
   if (code === "fact_type_unregistered") return { code, hint: renderTemplate("failure", "fact-type-unregistered", {}) };
   if (code === "daemon_restarting" && typeof outer.hint === "string") return { code, hint: outer.hint };
-  const diagnostic = record(receipt.diagnostic) ? receipt.diagnostic : null,
+  const rawDiagnostic = record(receipt.diagnostic) ? receipt.diagnostic : null,
+    // A bare {kind:"failure"} diagnostic is the code-only placeholder `rejected()` always attaches;
+    // it renders to the same generic sentence as the final fallback, so treat it as no diagnostic
+    // and let a specific rejectionExplanation or unmet-criteria detail take priority instead.
+    diagnostic = rawDiagnostic && rawDiagnostic.kind !== "failure" ? rawDiagnostic : null,
     diagnosticHint = diagnostic ? renderDiagnostic(diagnostic) : null,
+    explanationHint = typeof receipt.rejectionExplanation === "string" ? receipt.rejectionExplanation : null,
     declaredGuidance = renderReceiptGuidance(receipt),
     baseHint =
       diagnosticHint ??
+      explanationHint ??
       (declaredGuidance.length > 0 ? declaredGuidance.join(" ") : null) ??
       renderTemplate("failure", "failure", { code }),
-    criteria = diagnosticHint
-      ? []
-      : Array.isArray(receipt.unmetCriteria)
-        ? receipt.unmetCriteria.flatMap((entry) =>
-            record(entry) && typeof entry.ref === "string" && typeof entry.explain === "string"
-              ? [{ ref: entry.ref, explain: entry.explain }]
-              : [],
-          )
-        : [],
+    criteria =
+      diagnosticHint || explanationHint
+        ? []
+        : Array.isArray(receipt.unmetCriteria)
+          ? receipt.unmetCriteria.flatMap((entry) =>
+              record(entry) && typeof entry.ref === "string" && typeof entry.explain === "string"
+                ? [{ ref: entry.ref, explain: entry.explain }]
+                : [],
+            )
+          : [],
     hint =
       criteria.length === 0 ? baseHint : `${baseHint} ${renderTemplate("failure", "unmet-criteria", { criteria })}`;
   return { code, hint };

--- a/packages/cli/test/guidance-plane.test.ts
+++ b/packages/cli/test/guidance-plane.test.ts
@@ -100,6 +100,41 @@ test("failure guidance renders structured missing-section, validator, and worksp
   );
 });
 
+test("a rejected receipt's own explanation replaces the generic code-only hint", () => {
+  assert.equal(
+    humanError({
+      code: "preset_snapshot_mismatch",
+      diagnostic: { kind: "failure", code: "preset_snapshot_mismatch" },
+      rejectionExplanation: "Run ha preset upgrade task-a before completion.",
+    }).hint,
+    "Run ha preset upgrade task-a before completion.",
+  );
+  assert.deepEqual(
+    renderCliReceipt({
+      ok: false,
+      code: "invalid_proof",
+      diagnostic: { kind: "failure", code: "invalid_proof" },
+      rejectionExplanation:
+        "CI run 34491684357 tested a1b2c3; this execution submitted d4e5f6. Use an observation for the submitted commit.",
+    }),
+    {
+      stream: "stderr",
+      text:
+        "error code=invalid_proof hint=CI run 34491684357 tested a1b2c3; this execution submitted d4e5f6. " +
+        "Use an observation for the submitted commit.",
+    },
+  );
+  // A richer structured diagnostic still wins over a plain rejectionExplanation string.
+  assert.equal(
+    humanError({
+      code: "invalid_result",
+      diagnostic: { kind: "validation", entity: "task-a", field: "status", actual: "weird", expectation: "planned" },
+      rejectionExplanation: "generic wrapper text",
+    }).hint,
+    "Validation failed for entity=task-a field=status; actual=weird; planned.",
+  );
+});
+
 test("write_rejected renders the inner receipt reason and summary without suggesting a retry", () => {
   assert.deepEqual(
     renderCliReceipt({

--- a/packages/daemon/src/ci-observation-actions.ts
+++ b/packages/daemon/src/ci-observation-actions.ts
@@ -90,7 +90,14 @@ export async function pullAndIngestCiObservations(
       };
       const { status: runLifecycleState } = summary;
       // Publish immutable observations only for main runs that have a final conclusion.
-      if (summary.headBranch !== "main" || runLifecycleState !== "completed") continue;
+      if (summary.headBranch !== "main" || runLifecycleState !== "completed") {
+        if (namedRuns)
+          throw cell.cellCodedError(
+            "invalid_command",
+            `CI run ${run.databaseId} is ${runLifecycleState} on ${summary.headBranch}; only completed main runs can be imported.`,
+          );
+        continue;
+      }
       const runRoot = path.join(temporaryRoot, String(run.databaseId));
       try {
         await runGh(

--- a/packages/daemon/src/ci-observation-actions.ts
+++ b/packages/daemon/src/ci-observation-actions.ts
@@ -94,7 +94,8 @@ export async function pullAndIngestCiObservations(
         if (namedRuns)
           throw cell.cellCodedError(
             "invalid_command",
-            `CI run ${run.databaseId} is ${runLifecycleState} on ${summary.headBranch}; only completed main runs can be imported.`,
+            `CI run ${run.databaseId} is ${runLifecycleState} on ${summary.headBranch}; ` +
+              "only completed main runs can be imported.",
           );
         continue;
       }

--- a/packages/daemon/src/entity-action-catalog-executor.ts
+++ b/packages/daemon/src/entity-action-catalog-executor.ts
@@ -456,7 +456,9 @@ export function deriveActionResult(
         ? criterionRefs.map((criterionRef) => resolveActionCriterion(contract, criterionRef))
         : [],
     explanation = rejected
-      ? (unmetCriteria[0]?.explain ?? `Action ${contract.target.kind}.${contract.id} was rejected.`)
+      ? (unmetCriteria[0]?.explain ??
+        receipt.rejectionExplanation ??
+        `Action ${contract.target.kind}.${contract.id} was rejected.`)
       : null;
   return {
     ...receipt,

--- a/packages/daemon/src/repo-cell-api.ts
+++ b/packages/daemon/src/repo-cell-api.ts
@@ -980,6 +980,10 @@ export function createRepoCellApi(context: RepoCellApiContext): RepoCell & RepoC
       if (
         action.kind === "projection-rebuild" ||
         action.kind === "doc-materialize" ||
+        // ci-observe-pull mints a synthetic opId over a batch of separately-opId'd imports; that
+        // opId is never itself an accepted command outcome, so acceptance lookup would mislabel
+        // its own already-correct applied/pending outcome as acceptance_unknown.
+        action.kind === "ci-observe-pull" ||
         (!(durablePolicyActions as readonly string[]).includes(action.kind) && action.kind !== "receipt-show")
       )
         return receipt;

--- a/packages/daemon/src/repo-cell-settlement.ts
+++ b/packages/daemon/src/repo-cell-settlement.ts
@@ -6,7 +6,13 @@ import {
   type TaskProgressEvidence,
   type WriteReceiptDraft as WriteReceipt,
 } from "../../kernel/src/index.ts";
-import { actionCriterionFailure, cellCodedError, cellCriterionError, cellErrorCode } from "./repo-cell-errors.ts";
+import {
+  actionCriterionFailure,
+  cellCodedError,
+  cellCriterionError,
+  cellErrorCode,
+  cellErrorMessage,
+} from "./repo-cell-errors.ts";
 import { gateChecks, selectedReviewId } from "./repo-cell-proof.ts";
 import type { Snapshot } from "./repo-cell-types.ts";
 import { diagnosticForError } from "./receipt-guidance.ts";
@@ -125,8 +131,13 @@ export function failed(
       : rejected(opId, code);
   const diagnostic = diagnosticForError(error),
     diagnosed = diagnostic ? { ...receipt, diagnostic } : receipt,
+    // A rejected guard's thrown message is its own explanation; forward it so the receipt is
+    // self-describing instead of falling back to a code-only sentence downstream. Indeterminate
+    // outcomes keep their retry guidance untouched — they were never a guard rejection.
+    message = receipt.outcome === "op_rejected" ? cellErrorMessage(error) : "",
+    explained = message ? { ...diagnosed, rejectionExplanation: message } : diagnosed,
     criterionFailure = actionCriterionFailure(error);
-  if (criterionFailure === null) return diagnosed;
+  if (criterionFailure === null) return explained;
   if (!contract || !action)
     throw cellCodedError(
       "invalid_store",
@@ -145,7 +156,7 @@ export function failed(
       `Action ${contract.target.kind}.${contract.id} does not declare criterion ${criterionFailure.criterionRef}.`,
     );
   return {
-    ...diagnosed,
+    ...explained,
     evidence: `criterion:${criterion.ref}`,
     unmetCriteria: [criterion],
     rejectionExplanation: criterion.explain,

--- a/packages/daemon/test/ci-observatory-read.test.ts
+++ b/packages/daemon/test/ci-observatory-read.test.ts
@@ -385,14 +385,24 @@ test("CI observation pull imports named main runs without listing recent runs", 
   try {
     const receipt = await pullAndIngestCiObservations(
       cell as never,
-      { kind: "ci-observe-pull", runs: ["700", "701"] },
+      { kind: "ci-observe-pull", runs: ["700"] },
       { actor, source: "local" },
       runGh,
     );
-    assert.deepEqual(calls, ["view:700", "download:700", "view:701"]);
+    assert.deepEqual(calls, ["view:700", "download:700"]);
     assert.equal(events.length, 1);
     assert.equal(events[0]?.payload.verification?.headSha, "sha-700");
-    assert.equal(JSON.parse(receipt.evidence).requestedRuns, 2);
+    assert.equal(JSON.parse(receipt.evidence).requestedRuns, 1);
+    await assert.rejects(
+      pullAndIngestCiObservations(
+        cell as never,
+        { kind: "ci-observe-pull", runs: ["701"] },
+        { actor, source: "local" },
+        runGh,
+      ),
+      /CI run 701 is completed on codex\/feature; only completed main runs can be imported\./u,
+    );
+    assert.equal(events.length, 1);
     await assert.rejects(
       pullAndIngestCiObservations(
         cell as never,

--- a/packages/daemon/test/rejection-next-actions.integration.test.ts
+++ b/packages/daemon/test/rejection-next-actions.integration.test.ts
@@ -263,6 +263,111 @@ test("executor declaration and completion context refusals name projection rebui
   }
 });
 
+test("symptom task_5df51336056c76d54946b231a7: decision propose packet issues name the field instead of a bare invalid_command", async () => {
+  const rootDir = workspace("decision-packet-issues"),
+    repoId = workspaceId("decision-packet-issues");
+  let cell: Awaited<ReturnType<typeof openRepoCell>> | undefined;
+  try {
+    cell = await openRepoCell({ repoId, rootDir: canonicalRoot(rootDir), ownerId: "decision-packet-issues" });
+    const rejected = await cell.run(
+      {
+        kind: "decision-propose",
+        body: "# Over-length whyNot\n",
+        jsonInput: JSON.stringify({
+          title: "Over-length whyNot",
+          question: "Does the packet validator name the problem?",
+          riskTier: "medium",
+          urgency: "medium",
+          vertical: "default",
+          preset: "default",
+          decisionClass: "ordinary",
+          appliesTo: { modules: ["daemon"], productLines: [] },
+          chosen: [{ id: "CH1", text: "Use events" }],
+          rejected: [{ id: "RJ1", text: "Use files", whyNot: "x".repeat(200) }],
+          claims: [],
+          fulfillments: [],
+        }),
+      },
+      binding("decision-packet-issues"),
+    );
+    assert.equal(rejected.outcome, "op_rejected", JSON.stringify(rejected));
+    assert.equal(rejected.code, "invalid_command");
+    assert.match(String(rejected.rejectionExplanation), /whyNot/u);
+  } finally {
+    await cell?.close();
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});
+
+test("symptom task_6edcc0d990dae7e42f4bc93ff9 (review-execution before submit): review before submission names the required state instead of a bare invalid_command", async () => {
+  const rootDir = workspace("review-before-submit"),
+    taskId = "task-review-before-submit",
+    executionId = "exec-review-before-submit",
+    owner = binding("review-before-submit-owner"),
+    reviewer = withRoleBinding(binding("review-before-submit-reviewer"), "arbiter");
+  let cell: Awaited<ReturnType<typeof openRepoCell>> | undefined;
+  try {
+    cell = await openRepoCell({
+      repoId: workspaceId("review-before-submit"),
+      rootDir: canonicalRoot(rootDir),
+      ownerId: "review-before-submit",
+    });
+    const created = await cell.run({ kind: "task-create", taskId, title: "Review before submit" }, owner);
+    assert.equal(created.outcome, "applied");
+    await waitForFixturePublication(cell, created.opId, owner);
+    await realizeTaskPlanFixture(rootDir, String((created as Record<string, unknown>).packagePath), (planPath) =>
+      cell!.run({ kind: "doc-submit", paths: [planPath] }, owner),
+    );
+    assert.equal((await cell.run({ kind: "task-start", taskId, executionId }, owner)).outcome, "applied");
+    writeFileSync(
+      path.join(rootDir, "review.json"),
+      JSON.stringify({ verdict: "approved", reason: "Independent review.", evidenceChecked: ["integration"] }),
+    );
+    const rejected = await cell.run(
+      { kind: "task-review-execution", taskId, executionId, reviewId: "review-early", fromFile: "review.json" },
+      reviewer,
+    );
+    assert.equal(rejected.outcome, "op_rejected", JSON.stringify(rejected));
+    assert.equal(rejected.code, "invalid_transition", JSON.stringify(rejected));
+    assert.match(String(rejected.rejectionExplanation), /submitted execution/u);
+    assert.deepEqual(rejected.diagnostic, {
+      kind: "validation",
+      entity: `execution ${executionId}`,
+      field: "status",
+      actual: "active",
+      expectation: "Execution status must be submitted on the current task iteration before review",
+    });
+  } finally {
+    await cell?.close();
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});
+
+test("symptom task_356fe6c7a05cb987d93a807b46: relation relate against a nonexistent entity names the missing ref instead of a bare entity_not_found", async () => {
+  const rootDir = workspace("relation-entity-not-found"),
+    repoId = workspaceId("relation-entity-not-found");
+  let cell: Awaited<ReturnType<typeof openRepoCell>> | undefined;
+  try {
+    cell = await openRepoCell({ repoId, rootDir: canonicalRoot(rootDir), ownerId: "relation-entity-not-found" });
+    const rejected = await cell.run(
+      {
+        kind: "relation-relate",
+        sourceRef: "task/task-does-not-exist-1",
+        targetRef: "task/task-does-not-exist-2",
+        relationType: "depends-on",
+        expectedVersion: 0,
+      },
+      binding("relation-entity-not-found"),
+    );
+    assert.equal(rejected.outcome, "op_rejected", JSON.stringify(rejected));
+    assert.equal(rejected.code, "entity_not_found", JSON.stringify(rejected));
+    assert.match(String(rejected.rejectionExplanation), /task-does-not-exist-1 does not exist/u);
+  } finally {
+    await cell?.close();
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});
+
 function binding(executorId: string) {
   return {
     actor: { principal: { personId: "person-owner" }, executor: { kind: "agent" as const, id: executorId } },

--- a/packages/daemon/test/task-action-catalog-executor.test.ts
+++ b/packages/daemon/test/task-action-catalog-executor.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { getExecutableEntityAction } from "../../kernel/src/index.ts";
 import { makeEntityActionCatalogExecutor, deriveActionResult } from "../src/entity-action-catalog-executor.ts";
+import { rejectExecutionSelection } from "../src/repo-cell-execution-selection.ts";
 import { cellCriterionError } from "../src/repo-cell-errors.ts";
 import { failed } from "../src/repo-cell-settlement.ts";
 
@@ -128,4 +129,49 @@ test("criterion-bearing failures resolve descriptors by action plus ref even whe
     );
     assert.deepEqual(receipt.unmetCriteria, [descriptor]);
   }
+});
+
+test("a plain coded-error rejection forwards the guard's own message instead of the generic sentence", () => {
+  const contract = getExecutableEntityAction("task-complete");
+  assert.ok(contract);
+  const receipt = deriveActionResult(
+    contract,
+    { kind: "task-complete", taskId: "task_contract" },
+    failed(
+      "op-preset-mismatch",
+      Object.assign(new Error("Run ha preset upgrade task_contract before completion."), {
+        code: "preset_snapshot_mismatch",
+      }),
+    ),
+  );
+  assert.equal(receipt.code, "preset_snapshot_mismatch");
+  assert.equal(receipt.rejectionExplanation, "Run ha preset upgrade task_contract before completion.");
+});
+
+test("symptom task_4ba380067767eb1d0744ba7844: ambiguous execution selection names its candidates instead of a bare invalid_command", () => {
+  const contract = getExecutableEntityAction("task-review-execution");
+  assert.ok(contract);
+  let thrown: unknown;
+  try {
+    rejectExecutionSelection(
+      [{ executionId: "exec-changes-requested" }, { executionId: "exec-submitted" }],
+      "Current submitted execution",
+      "Run ha task show task_contract; if the task is active, run ha task submit task_contract " +
+        "--json-input '<submission-json>'.",
+      (candidate) =>
+        `ha task review-execution task_contract --execution-id ${candidate} ` +
+        "--review-id <review-id> --from-file <review.json>",
+    );
+  } catch (error) {
+    thrown = error;
+  }
+  assert.ok(thrown, "rejectExecutionSelection must throw for multiple candidates");
+  const receipt = deriveActionResult(
+    contract,
+    { kind: "task-review-execution", taskId: "task_contract" },
+    failed("op-ambiguous-review", thrown),
+  );
+  assert.equal(receipt.code, "invalid_command");
+  assert.match(String(receipt.rejectionExplanation), /candidates: exec-changes-requested, exec-submitted/u);
+  assert.match(String(receipt.rejectionExplanation), /Choose one explicitly/u);
 });


### PR DESCRIPTION
# English

## Summary

A rejected command now tells the operator why it was rejected.

- When a guard throws, the daemon forwards the thrown message as the receipt's `rejectionExplanation`. Before, most guards (for example `preset_snapshot_mismatch`, `invalid_proof`, `lease_required`) reached the CLI only as a code plus the generic sentence "Inspect error code …, correct the command input, and retry".
- The CLI prints a specific explanation ahead of declared guidance; the code-only placeholder diagnostic no longer hides it.
- `ha ci observe pull` returned `acceptance_unknown` when every run was already imported, because the generic acceptance lookup ran on its synthetic batch opId. It is now excluded from that wrap.
- `ha ci observe pull --run <id>` silently skipped a run that is not a completed main run and reported "imported 0, 0 already existed". It now rejects with the run's branch and state.

## Architectural Justification

Every change removes a place where the reason was already known and then dropped: the thrown message, the explanation behind a placeholder diagnostic, the correct outcome under a synthetic opId, and the branch of a skipped run. No new receipt field or schema is added; `rejectionExplanation` already exists.

## What Changed

- `repo-cell-settlement.ts`: `failed()` forwards the thrown message for `op_rejected`.
- `entity-action-catalog-executor.ts`: the rejection explanation falls back to the receipt's explanation before a generic sentence.
- `guidance-plane.ts`: the CLI prefers a specific explanation over the placeholder diagnostic.
- `repo-cell-api.ts`: `ci-observe-pull` is excluded from the acceptance wrap.
- `ci-observation-actions.ts`: a named non-main or unfinished run is rejected with its branch and state.
- Tests: guidance plane, catalog executor, CI observation pull, and one integration test covering five rejection families.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: +46/-15 (net +31), from `node tools/gates/production-delta.mjs --base origin/main`.

## Machine-Readable Declarations

## Task And Scope

- Harness task: task_c2c9ab598622e1988a68905251
- Branch: `codex/cli-rejection-reasons`
- Public scope: rejection receipts and the CI observation pull
- Private planning/evidence updated: yes (task plan and worker report)
- Out of scope: receipt schema; the exact-sha CI completion rule

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: not applicable
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `b28d80603`
- Branch merge-base with `origin/main`: `b28d80603`
- Last `git fetch origin` time: 2026-09-10 18:05 UTC
- Sync method: rebased onto origin/main
- Public diff command: `git diff origin/main...codex/cli-rejection-reasons`
- Private evidence commit/path: task_c2c9ab598622e1988a68905251 task package report
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- `npx tsc -b packages/daemon packages/cli` passes.
- ci-observatory-read, guidance-plane and task-action-catalog-executor tests: 21/21.
- `node tools/run-manifest-gates.mjs --changed origin/main` passes.
- Not run: the full `npm run check` / `npm test` locally. Local agents must not run the full matrix, so CI is the full authority.

## Review Evidence

- Lead review: the forwarded message is the guard's own text, used only for `op_rejected`; indeterminate outcomes keep their retry guidance.
- Reviewer subagent: not used
- Human review: pending
- Blocking findings: none

## Residual Risk

- A guard message written for developers now reaches operators verbatim.

## References

- Task: task_c2c9ab598622e1988a68905251
- Parent: task_2b8f79fa4412cb726a26f9bfc7

---

# 中文

## 概要

被拒绝的命令现在会告诉操作者被拒的原因。

- 守卫抛错时，daemon 把抛出的信息作为回执的 `rejectionExplanation` 转发。之前大多数守卫（例如 `preset_snapshot_mismatch`、`invalid_proof`、`lease_required`）到 CLI 只剩一个错误码，外加一句通用的「Inspect error code …, correct the command input, and retry」。
- CLI 优先打印具体的拒绝说明，排在声明式指引之前；只有错误码的占位 diagnostic 不再把它盖掉。
- `ha ci observe pull` 在所有 run 都已导入过时返回 `acceptance_unknown`，原因是通用的受理查询作用在它合成的批次 opId 上。现在把它排除在这层包装之外。
- `ha ci observe pull --run <id>` 遇到不是已完成 main run 的 run 会静默跳过，只报「导入 0，已存在 0」。现在直接拒绝，并说明该 run 的分支和状态。

## 架构辩护

每一处改动都是删掉一个「原因本来已知、却被丢掉」的地方：抛出的信息、被占位 diagnostic 盖住的说明、合成 opId 下本来正确的 outcome，以及被跳过的 run 的分支。没有新增回执字段或 schema，`rejectionExplanation` 本来就存在。

## 改动内容

- `repo-cell-settlement.ts`：`failed()` 对 `op_rejected` 转发抛出的信息。
- `entity-action-catalog-executor.ts`：拒绝说明在退回通用句之前，先取回执已有的说明。
- `guidance-plane.ts`：CLI 优先显示具体说明，不再被占位 diagnostic 盖掉。
- `repo-cell-api.ts`：`ci-observe-pull` 不再经过受理包装。
- `ci-observation-actions.ts`：显式指定的非 main 或未完成 run 会被拒绝，并说明分支与状态。
- 测试：guidance plane、catalog executor、CI observation pull，以及一个覆盖五类拒绝的集成测试。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 删除的门或 fixture：none
- 生产净行数：+46/-15 (net +31)，由 `node tools/gates/production-delta.mjs --base origin/main` 计算。

## 机读声明说明

- 本 PR 不涉及依赖变化和事件迁移，没有机读声明。

## 任务与范围

- Harness 任务：task_c2c9ab598622e1988a68905251
- 分支：`codex/cli-rejection-reasons`
- 公开范围：拒绝回执与 CI observation pull
- 私有计划 / 证据是否已更新：yes（任务计划与 worker 报告）
- 范围外：回执 schema；completion 的 exact-sha CI 规则

## 版本影响

- 版本：不改版本
- 发布影响：不发布

## 治理声明

- 是否触碰 protected surface：no
- protected surface 范围：不适用
- 依据：不适用
- 机器检查边界：本 PR 只声明该段存在；声明是否真实、充分，由 reviewer 判断。
- Break-glass：no
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- `origin/main` 基准 SHA：`b28d80603`
- 当前分支与 `origin/main` 的 merge-base：`b28d80603`
- 最近一次 `git fetch origin` 时间：2026-09-10 18:05 UTC
- 同步方式：rebase 到 origin/main
- 公开 diff 命令：`git diff origin/main...codex/cli-rejection-reasons`
- 私有证据 commit/path：task_c2c9ab598622e1988a68905251 任务包报告
- Reviewer 证据路径：见本 PR 的「审查证据」一节
- GitHub Actions `rewrite-ci` run URL：本 PR 的 CI 还在跑
- [ ] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- `npx tsc -b packages/daemon packages/cli` 通过。
- ci-observatory-read、guidance-plane、task-action-catalog-executor 测试：21/21。
- `node tools/run-manifest-gates.mjs --changed origin/main` 通过。
- 未运行：本地整套 `npm run check` / `npm test`。规定禁止本地 agent 跑全量矩阵，全量以 CI 为准。

## 审查证据

- 主控审查：转发的是守卫自己的文本，只用于 `op_rejected`；不确定结果保留原有的重试指引。
- Reviewer subagent：未使用
- 人工审查：待进行
- 阻塞发现：无

## 残余风险

- 原本写给开发者的守卫信息，现在会原样出现在操作者面前。

## 关联材料

- Task: task_c2c9ab598622e1988a68905251
- Parent: task_2b8f79fa4412cb726a26f9bfc7

---

## PR Gate Checklist / PR 门禁清单

- [x] Branch is based on latest `origin/main`. / 分支基于最新 `origin/main`。
- [x] PR body uses this full template structure. / PR 描述使用本模板完整结构。
- [x] PR body uses two complete language blocks: `# English` first, then `# 中文`. / PR 正文使用两块完整正文：`# English` 在上，`# 中文` 在下。
- [x] PR body passes `tools/check-pr-body-bilingual.mjs`. / PR 正文通过 `tools/check-pr-body-bilingual.mjs`。
- [x] If the PR touches a manifest-derived protected surface, Governance Declaration is filled with ADR/decision/task evidence or break-glass fields. / 若 PR 触碰 manifest 派生的 protected surface，Governance Declaration 已填写 ADR/decision/task 依据或 break-glass 字段。
- [x] No private harness files are included. / 不包含私有 harness 文件。
- [x] No ignored local agent entry files are included. / 不包含被忽略的本地 agent 入口文件。
- [x] No absolute local filesystem paths are included in this public PR body. / 本公开 PR 描述不包含本机绝对路径。
- [x] Public diff is limited to the stated task scope. / 公开 diff 限于声明的任务范围。
- [x] Private planning/evidence updates are recorded when applicable. / 适用时已记录私有计划 / 证据更新。
- [x] Version and publish impact are stated. / 已说明版本与发布影响。
- [x] Local verification commands are recorded honestly. / 已如实记录本地验证命令。
- [ ] CI results are linked or explained. / CI 结果已链接或说明。
- [x] Review evidence is recorded. / 已记录审查证据。
- [x] Open P0/P1/P2 findings are closed, deferred with owner, or explicitly blocked. / open P0/P1/P2 findings 已关闭、带 owner 延后，或明确阻塞。
- [x] Merge method and post-merge branch cleanup plan are clear. / 合并方式和合并后分支清理计划清楚。
- [x] No admin bypass is planned unless explicitly approved and recorded. / 除非明确批准并记录，否则不计划 admin bypass。
