### PR TITLE
perf(gui): settle writes from receipts instead of whole-repo rereads

### DIFF
--- a/packages/gui/src/renderer/api-client.ts
+++ b/packages/gui/src/renderer/api-client.ts
@@ -291,7 +291,6 @@ export interface CatalogSnapshotSuccess {
   readonly status: "ready" | "pending";
   readonly repoId: string;
   readonly observedAt: string;
-  readonly catalogDigest: string;
   readonly defaults: {
     readonly verticalId: string;
     readonly presetId: string;
@@ -338,8 +337,6 @@ export interface CatalogRereadReceipt {
   readonly outcome: "applied" | "op_rejected";
   readonly operationId: string;
   readonly repoId: string;
-  readonly beforeDigest: string;
-  readonly afterDigest: string;
   readonly observedAt: string;
   readonly error: BridgeError | null;
 }
@@ -507,7 +504,7 @@ export const harnessClient = {
   ): Promise<CatalogPresetSuccess> {
     return readCatalogPreset(await invoke("repo.gui.catalog.preset.read", payload, "getCatalogPreset"));
   },
-  async rereadCatalog(payload: RepoScope & { readonly expectedDigest?: string }): Promise<CatalogRereadReceipt> {
+  async rereadCatalog(payload: RepoScope): Promise<CatalogRereadReceipt> {
     return readCatalogRereadReceipt(await invoke("repo.gui.catalog.reread", payload, "rereadCatalog"));
   },
 };

--- a/packages/gui/src/renderer/catalog-data.ts
+++ b/packages/gui/src/renderer/catalog-data.ts
@@ -26,10 +26,11 @@ export function useCatalogPreset(repoId: string, presetId: string | null, locale
   });
 }
 
-export function useCatalogReread(repoId: string, expectedDigest: string | undefined) {
+/** 手动重读是「读最新」:不带 CAS 期望值,daemon 端 reread 即取当前快照。 */
+export function useCatalogReread(repoId: string) {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: () => harnessClient.rereadCatalog({ repoId, ...(expectedDigest ? { expectedDigest } : {}) }),
+    mutationFn: () => harnessClient.rereadCatalog({ repoId }),
     onSuccess: async (receipt) => {
       if (receipt.ok && receipt.outcome === "applied")
         await queryClient.invalidateQueries({ queryKey: catalogQueryKeys.all(repoId) });

--- a/packages/gui/src/renderer/components/runtime/useRuntimeWorkspace.ts
+++ b/packages/gui/src/renderer/components/runtime/useRuntimeWorkspace.ts
@@ -368,12 +368,11 @@ export function useAgentSquadWorkspace(
         );
         return null;
       }
-      await client.fetchQuery({
-        queryKey: ["agents", repoId],
-        queryFn: () => agentEntityClient.listAgents(repoId),
-        staleTime: 0,
-      });
-      await client.invalidateQueries({ queryKey: ["agent-detail", repoId], refetchType: "active" });
+      // 回执已证 applied + canonicalVisible;只失效,由挂载面的正常 refetch 带新列表。
+      await Promise.all([
+        client.invalidateQueries({ queryKey: ["agents", repoId], refetchType: "active" }),
+        client.invalidateQueries({ queryKey: ["agent-detail", repoId], refetchType: "active" }),
+      ]);
       return settled;
     },
     saveSquad: async (declaration: SquadDeclarationV1): Promise<EntitySaveResult | null> => {
@@ -399,12 +398,10 @@ export function useAgentSquadWorkspace(
         );
         return null;
       }
-      await client.fetchQuery({
-        queryKey: ["squads", repoId],
-        queryFn: () => agentEntityClient.listSquads(repoId),
-        staleTime: 0,
-      });
-      await client.invalidateQueries({ queryKey: ["squad-detail", repoId], refetchType: "active" });
+      await Promise.all([
+        client.invalidateQueries({ queryKey: ["squads", repoId], refetchType: "active" }),
+        client.invalidateQueries({ queryKey: ["squad-detail", repoId], refetchType: "active" }),
+      ]);
       return settled;
     },
     dispatch: async (request: DispatchRequest) => {
@@ -415,19 +412,9 @@ export function useAgentSquadWorkspace(
       if (settled?.runtimeSessionId && request.taskId !== null) {
         for (let attempt = 0; attempt < 40; attempt += 1) {
           try {
-            const [session, groups] = await Promise.all([
-              agentRuntimeClient.session(repoId, settled.runtimeSessionId),
-              agentRuntimeClient.sessionGroups(repoId, {
-                groupBy: "task",
-                since: "1970-01-01T00:00:00.000Z",
-                limit: SESSION_GROUPS_PAGE_LIMIT,
-              }),
-            ]);
-            if (
-              session.session.associations.some((association) => association.taskId === request.taskId) &&
-              groups.groups.some((group) => group.taskId === request.taskId)
-            )
-              break;
+            // 绑定等待只读这一个 session 的 associations,不随全仓 session-group 历史增长。
+            const session = await agentRuntimeClient.session(repoId, settled.runtimeSessionId);
+            if (session.session.associations.some((association) => association.taskId === request.taskId)) break;
           } catch (error) {
             consumeKnownError(error);
           }

--- a/packages/gui/src/renderer/decision-actions.ts
+++ b/packages/gui/src/renderer/decision-actions.ts
@@ -2,7 +2,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { useRef, useState } from "react";
 import type { GuiActionResult } from "../api/renderer-dto.ts";
 import { consumeKnownError } from "../api/error-consumption.ts";
-import { harnessClient, type DecisionListSuccess, type DecisionProposalInput } from "./api-client.ts";
+import { harnessClient, type DecisionProposalInput } from "./api-client.ts";
 import type { DecisionRow, RelationEdge } from "./model/types.ts";
 import { triadicQueryKeys } from "./triadic-data.ts";
 import { workspaceSummaryQueryKeys } from "./workspace-summary-data.ts";
@@ -103,12 +103,6 @@ export interface DecisionMutationFeedback {
   readonly receipt?: Pick<ReceiptRecord, "consentId" | "path" | "commitSha" | "documentSha256" | "worktreeVisible">;
 }
 
-const terminalState: Record<DecisionAction, DecisionRow["state"]> = {
-  accept: "in_effect",
-  reject: "rejected",
-  defer: "deferred",
-};
-
 export function useDecisionActions(repoId: string) {
   const queryClient = useQueryClient();
   const locks = useRef(new Map<string, Promise<DecisionMutationFeedback>>());
@@ -137,19 +131,13 @@ export function useDecisionActions(repoId: string) {
     documentSha256: receipt.documentSha256,
     worktreeVisible: receipt.worktreeVisible,
   });
-  const refresh = async (): Promise<{ decisions: DecisionListSuccess }> => {
+  const refresh = async (): Promise<void> => {
+    // 一次失效覆盖全部三元切面(derives/摘要/事实/完整投影):挂载中的查询按
+    // react-query 默认 refetchType:"active" 重取,没挂载的只标记 stale。
     await Promise.all([
-      // 一次失效覆盖全部三元切面(derives/摘要/事实/完整投影):挂载中的查询按
-      // react-query 默认 refetchType:"active" 重取,没挂载的只标记 stale。
       queryClient.invalidateQueries({ queryKey: triadicQueryKeys.all(repoId) }),
       queryClient.invalidateQueries({ queryKey: workspaceSummaryQueryKeys.read(repoId) }),
     ]);
-    const decisions = await queryClient.fetchQuery({
-      queryKey: triadicQueryKeys.decisions(repoId),
-      queryFn: () => harnessClient.getDecisions({ repoId }),
-      staleTime: 0,
-    });
-    return { decisions };
   };
   const failure = (key: string, kind: DecisionMutationFeedback["kind"], settlement: DecisionSettlement) =>
     publish(key, {
@@ -206,31 +194,16 @@ export function useDecisionActions(repoId: string) {
             code: "projection_key_missing",
             hint: "receipt 已 applied 但未返回 decisionId；用 opId 查询，勿重放 mutation。",
           });
-        const reread = await refresh(),
-          // 可见 = 新提案出现在 canonical 投影且仍待裁:裁决能力的 lifecycle 前置
-          // (kernel decisionCapabilities)由投影逐行给出,renderer 不再比较状态词。
-          visible = reread.decisions.decisions.some(
-            (decision) =>
-              decision.decisionId === decisionId &&
-              decision.capabilities.some((capability) => capability.id === "accept" && capability.available),
-          );
-        if (visible) {
-          pendingResolvers.current.delete(operationKey("proposal"));
-          return publish("proposal", {
-            state: "success",
-            kind: "propose",
-            opId: settlement.opId,
-            hint: `${decisionId} 已从 canonical projection 重读。`,
-            receipt: visibleReceipt(settlement.receipt),
-          });
-        }
-        pendingResolvers.current.set(operationKey("proposal"), (receipt) => finish(settleDecisionReceipt(receipt)));
+        // 回执已证 durable + canonicalVisible + committedRevision===appliedCut:失效后交给
+        // 正常 refetch,不再强制整表重读并逐条扫描确认。
+        await refresh();
+        pendingResolvers.current.delete(operationKey("proposal"));
         return publish("proposal", {
-          state: "pending",
+          state: "success",
           kind: "propose",
           opId: settlement.opId,
-          code: "projection_not_visible",
-          hint: `${decisionId} 尚未出现在 canonical projection；勿重放 mutation。`,
+          hint: `${decisionId} 已由 durable 回执确认落定。`,
+          receipt: visibleReceipt(settlement.receipt),
         });
       };
       return finish(settleDecisionReceipt(await harnessClient.proposeDecision({ repoId, ...input })));
@@ -266,32 +239,15 @@ export function useDecisionActions(repoId: string) {
             );
           return failure(decision.decisionId, action, settlement);
         }
-        const consentId = settlement.receipt.consentId,
-          reread = await refresh(),
-          canonical = reread.decisions.decisions.find((row) => row.decisionId === decision.decisionId);
-        const visible =
-          canonical?.state === terminalState[action] &&
-          typeof consentId === "string" &&
-          canonical.judgmentConsents.some((consent) => consent.consentId === consentId && consent.action === action);
-        if (visible) {
-          pendingResolvers.current.delete(operationKey(decision.decisionId));
-          return publish(decision.decisionId, {
-            state: "success",
-            kind: action,
-            opId: settlement.opId,
-            hint: "canonical decision + judgment consent 已重读确认。",
-            receipt: visibleReceipt(settlement.receipt),
-          });
-        }
-        pendingResolvers.current.set(operationKey(decision.decisionId), (receipt) =>
-          finish(settleDecisionReceipt(receipt)),
-        );
+        // 与 propose 同一条落定判据:回执三件套已证 canonical 落定,失效后交给正常 refetch。
+        await refresh();
+        pendingResolvers.current.delete(operationKey(decision.decisionId));
         return publish(decision.decisionId, {
-          state: "pending",
+          state: "success",
           kind: action,
           opId: settlement.opId,
-          code: "projection_not_visible",
-          hint: "receipt 已 applied，但 canonical decision/consent 尚不可见；勿重放 mutation。",
+          hint: "canonical decision + judgment consent 已由回执确认。",
+          receipt: visibleReceipt(settlement.receipt),
         });
       };
       return finish(settleDecisionReceipt(initial));

--- a/packages/gui/src/renderer/task-actions.ts
+++ b/packages/gui/src/renderer/task-actions.ts
@@ -2,16 +2,9 @@ import { useQueryClient } from "@tanstack/react-query";
 import { useCallback, useRef, useState } from "react";
 import type { GuiActionResult } from "../api/renderer-dto.ts";
 import type { GuiSubmissionV1 } from "../api/renderer-dto.ts";
-import { harnessClient, type TaskListSuccess } from "./api-client.ts";
-import type { TaskCapabilityId, TaskRow } from "./model/types.ts";
-import { readTaskList, taskQueryKeys } from "./task-data.ts";
-
-/**
- * 写后重读的落定判据:读重读行自己的能力投影(dec_5B135F46 CH4 第二层),
- * 而不是在 renderer 里再比一次状态词——落定与否是 daemon 已经判完的事。
- */
-const rowCan = (row: TaskListSuccess["rows"][number], id: TaskCapabilityId): boolean =>
-  row.capabilities.some((capability) => capability.id === id && capability.available);
+import { harnessClient } from "./api-client.ts";
+import type { TaskRow } from "./model/types.ts";
+import { taskQueryKeys } from "./task-data.ts";
 
 type ReceiptRecord = GuiActionResult & {
   readonly revision?: number;
@@ -31,7 +24,6 @@ export interface TaskSettlement {
   readonly opId: string;
   readonly code?: string;
   readonly hint?: string;
-  readonly revision?: number;
   readonly receipt: GuiActionResult;
 }
 
@@ -49,7 +41,6 @@ export function settleTaskReceipt(initial: GuiActionResult): TaskSettlement {
     return {
       state: "applied",
       opId: receipt.opId,
-      ...(Number.isInteger(receipt.revision) ? { revision: receipt.revision } : {}),
       receipt,
     };
   }
@@ -59,7 +50,6 @@ export function settleTaskReceipt(initial: GuiActionResult): TaskSettlement {
       opId: receipt.opId,
       code: receipt.outcome === "applied" ? "canonical_not_visible" : (receipt.code ?? receipt.outcome),
       hint: receipt.nextAction ?? "用 opId 查询 canonical receipt；不要重放 mutation。",
-      ...(Number.isInteger(receipt.revision) ? { revision: receipt.revision } : {}),
       receipt,
     };
   }
@@ -85,10 +75,10 @@ export interface TaskMutationFeedback {
 }
 
 /**
- * 回执已 applied、只是「canonical 可见」或「task projection 追平」还没到位。这两种落定里
- * 写入已经不在飞,in-flight 锁必须放开;它们与 pending/indeterminate(归属未知)不是一回事。
+ * 回执已 applied、只是「canonical 可见」还没到位。这种落定里写入已经不在飞,
+ * in-flight 锁必须放开;它与 pending/indeterminate(归属未知)不是一回事。
  */
-const settledButInvisible: ReadonlySet<string> = new Set(["canonical_not_visible", "projection_not_visible"]);
+const settledButInvisible: ReadonlySet<string> = new Set(["canonical_not_visible"]);
 
 export function useTaskActions(repoId: string) {
   const queryClient = useQueryClient(),
@@ -119,7 +109,6 @@ export function useTaskActions(repoId: string) {
       taskId: string,
       kind: TaskMutationFeedback["kind"],
       settlement: TaskSettlement,
-      visible: (data: TaskListSuccess) => boolean,
     ): Promise<TaskMutationFeedback> => {
       if (settlement.state !== "applied")
         return publish(taskId, {
@@ -129,28 +118,15 @@ export function useTaskActions(repoId: string) {
           code: settlement.code,
           hint: settlement.hint ?? "canonical receipt 尚未 settled；不要重放 mutation。",
         });
-      const queryKey = taskQueryKeys.list(repoId),
-        previous = queryClient.getQueryData<TaskListSuccess>(queryKey);
-      const data = await queryClient.fetchQuery({
-        queryKey,
-        queryFn: () => readTaskList(repoId, previous),
-        staleTime: 0,
+      // 回执本身就是落定证明(durable + canonicalVisible + committedRevision===appliedCut):
+      // 只失效任务切面,新行状态由挂载中的台账探针正常 refetch 带上来,不强制整表重读。
+      await queryClient.invalidateQueries({ queryKey: taskQueryKeys.all(repoId), refetchType: "active" });
+      return publish(taskId, {
+        state: "success",
+        kind,
+        opId: settlement.opId,
+        hint: "canonical receipt 已确认落定。",
       });
-      const revisionVisible = settlement.revision === undefined || data.watermark >= settlement.revision;
-      return revisionVisible && visible(data)
-        ? publish(taskId, {
-            state: "success",
-            kind,
-            opId: settlement.opId,
-            hint: "canonical projection 已重读并确认。",
-          })
-        : publish(taskId, {
-            state: "pending",
-            kind,
-            opId: settlement.opId,
-            code: "projection_not_visible",
-            hint: "receipt 已 applied，但 task projection 尚未显示目标 cut；用 opId 继续查询，勿重放 mutation。",
-          });
     },
     [repoId, queryClient, publish],
   );
@@ -198,12 +174,7 @@ export function useTaskActions(repoId: string) {
         const settlement = settleTaskReceipt(
           await harnessClient.startTask({ repoId, taskId: task.taskId, executionId }),
         );
-        return reread(task.taskId, "start", settlement, (data) =>
-          data.rows.some(
-            (row) =>
-              row.taskId === task.taskId && rowCan(row, "progress") && row.snapshot.lease?.executionId === executionId,
-          ),
-        );
+        return reread(task.taskId, "start", settlement);
       }),
     [once, reread],
   );
@@ -230,14 +201,7 @@ export function useTaskActions(repoId: string) {
             ...input,
           }),
         );
-        return reread(task.taskId, "progress", settlement, (data) =>
-          data.rows.some(
-            (row) =>
-              row.taskId === task.taskId &&
-              rowCan(row, "progress") &&
-              row.snapshot.lease?.executionId === task.activeExecutionId,
-          ),
-        );
+        return reread(task.taskId, "progress", settlement);
       }),
     [once, reread],
   );
@@ -258,9 +222,7 @@ export function useTaskActions(repoId: string) {
             submission,
           }),
         );
-        return reread(task.taskId, "submit", settlement, (data) =>
-          data.rows.some((row) => row.taskId === task.taskId && rowCan(row, "review") && row.snapshot.lease === null),
-        );
+        return reread(task.taskId, "submit", settlement);
       }),
     [once, reread],
   );
@@ -279,9 +241,7 @@ export function useTaskActions(repoId: string) {
         const settlement = settleTaskReceipt(
           await (pinned ? harnessClient.pinTask : harnessClient.unpinTask)({ repoId, taskId: task.taskId }),
         );
-        return reread(task.taskId, "pin", settlement, (data) =>
-          data.rows.some((row) => row.taskId === task.taskId && (row.snapshot.task?.pinned === true) === pinned),
-        );
+        return reread(task.taskId, "pin", settlement);
       }),
     [once, reread],
   );

--- a/packages/gui/src/renderer/views/PresetsView.tsx
+++ b/packages/gui/src/renderer/views/PresetsView.tsx
@@ -25,7 +25,7 @@ export function PresetsView({
 }) {
   const snapshot = useCatalogSnapshot(repoId),
     data = snapshot.data,
-    reread = useCatalogReread(repoId, data?.catalogDigest);
+    reread = useCatalogReread(repoId);
   const [tab, setTab] = useState<Tab>("presets");
   if (snapshot.isPending) return <State text={t("views.presetsView.readingCatalogSnapshot")} />;
   if (snapshot.isError || !data)
@@ -58,7 +58,7 @@ export function PresetsView({
           <Stack className="text-text-faint" />
           <h1 className="ui-title font-semibold">{t("views.presetsView.catalogPreset")}</h1>
           <span className="font-mono ui-micro text-text-faint">
-            {repoId} · {data.status} · {data.catalogDigest.slice(0, 18)}…
+            {repoId} · {data.status}
           </span>
           <button
             disabled={reread.isPending}
@@ -85,8 +85,7 @@ export function PresetsView({
         {reread.data && (
           <p className={`mt-1 font-mono ui-micro ${reread.data.ok ? "text-status-done" : "text-status-blocked"}`}>
             {t("views.presetsView.operationId")} {reread.data.operationId} · {reread.data.outcome} ·{" "}
-            {formatTime(reread.data.observedAt, { style: "date-time-seconds" }) ?? reread.data.observedAt} ·{" "}
-            {reread.data.beforeDigest.slice(0, 14)} → {reread.data.afterDigest.slice(0, 14)}
+            {formatTime(reread.data.observedAt, { style: "date-time-seconds" }) ?? reread.data.observedAt}
             {reread.data.error ? ` · ${reread.data.error.code}: ${reread.data.error.hint}` : ""}
           </p>
         )}

--- a/packages/gui/test/decision-actions.vitest.ts
+++ b/packages/gui/test/decision-actions.vitest.ts
@@ -1,0 +1,115 @@
+// harness-test-tier: contract
+// @vitest-environment happy-dom
+import { beforeAll, describe, expect, it, vi } from "vitest";
+import { act, createElement } from "react";
+import { createRoot } from "react-dom/client";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { GuiActionResult } from "../src/api/renderer-dto.ts";
+import { useDecisionActions } from "../src/renderer/decision-actions.ts";
+import { harnessClient } from "../src/renderer/api-client.ts";
+import { setActiveLocale } from "../src/renderer/i18n/core.ts";
+
+beforeAll(() => {
+  globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+  setActiveLocale("zh-CN");
+});
+
+const receipt = (over: Partial<GuiActionResult> = {}): GuiActionResult =>
+  ({
+    schema: "command-receipt/v2",
+    ok: true,
+    command: "decision-judge",
+    outcome: "applied",
+    opId: "op-decision-1",
+    consentId: "djc_decision000000000000000",
+    path: "decisions/decision-dec_test/decision.md",
+    commitSha: "abc123",
+    documentSha256: "0000000000000000000000000000000000000000000000000000000000000000",
+    worktreeVisible: false,
+    proof: { committedRevision: 5, appliedCut: 5, durable: true, canonicalVisible: true },
+    ...over,
+  }) as unknown as GuiActionResult;
+
+describe("useDecisionActions write channel", () => {
+  // R6(F4):回执三件套(durable + canonicalVisible + committedRevision===appliedCut)加上
+  // completeDecisionReceipt 的字段校验已是落定证明:applied 分支直接发布 success,
+  // 不再强制 staleTime:0 重读整份 decisions 并逐条扫描 state/consent。
+  it("settles an accepted decision from the receipt alone without rereading the decision list", async () => {
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const accept = vi.fn(async () => receipt()),
+      reads = vi.fn();
+    vi.spyOn(harnessClient, "acceptDecision").mockImplementation(accept);
+    vi.spyOn(harnessClient, "getDecisions").mockImplementation(reads);
+
+    let actions: ReturnType<typeof useDecisionActions> | undefined;
+    try {
+      await act(async () => {
+        root.render(
+          createElement(QueryClientProvider, {
+            client,
+            children: createElement(function Probe() {
+              actions = useDecisionActions("repo-a");
+              return null;
+            }),
+          }),
+        );
+      });
+
+      const feedback = await actions!.judge({ decisionId: "dec_test" } as never, "accept", { rationale: "ok" });
+      expect(accept).toHaveBeenCalledTimes(1);
+      expect(feedback).toMatchObject({ state: "success", kind: "accept" });
+      expect(reads).not.toHaveBeenCalled();
+    } finally {
+      await act(async () => {
+        root.unmount();
+      });
+      container.remove();
+      vi.restoreAllMocks();
+    }
+  });
+
+  // 回执 applied 但 proof 未断言 canonical 可见 → 仍是不锁死控件的 pending,
+  // 与 task 通道的 canonical_not_visible 同一族落定。
+  it("keeps an unproven receipt pending without rereading the list", async () => {
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const accept = vi.fn(async () =>
+        receipt({
+          proof: { committedRevision: 5, appliedCut: 5, durable: true, canonicalVisible: false },
+        }),
+      ),
+      reads = vi.fn();
+    vi.spyOn(harnessClient, "acceptDecision").mockImplementation(accept);
+    vi.spyOn(harnessClient, "getDecisions").mockImplementation(reads);
+
+    let actions: ReturnType<typeof useDecisionActions> | undefined;
+    try {
+      await act(async () => {
+        root.render(
+          createElement(QueryClientProvider, {
+            client,
+            children: createElement(function Probe() {
+              actions = useDecisionActions("repo-a");
+              return null;
+            }),
+          }),
+        );
+      });
+
+      const feedback = await actions!.judge({ decisionId: "dec_test" } as never, "accept", { rationale: "ok" });
+      expect(feedback).toMatchObject({ state: "pending", kind: "accept", code: "canonical_not_visible" });
+      expect(reads).not.toHaveBeenCalled();
+    } finally {
+      await act(async () => {
+        root.unmount();
+      });
+      container.remove();
+      vi.restoreAllMocks();
+    }
+  });
+});

--- a/packages/gui/test/renderer-app-model.vitest.ts
+++ b/packages/gui/test/renderer-app-model.vitest.ts
@@ -47,7 +47,7 @@ describe("renderer app model", () => {
           proof: { committedRevision: 8, appliedCut: 8, durable: true, canonicalVisible: true, worktreeVisible: false },
         }),
       ),
-    ).toMatchObject({ state: "applied", opId: "op-applied", revision: 8 });
+    ).toMatchObject({ state: "applied", opId: "op-applied" });
     expect(
       settleTaskReceipt(
         receipt({

--- a/packages/gui/test/runtime-workspace-interactions.vitest.ts
+++ b/packages/gui/test/runtime-workspace-interactions.vitest.ts
@@ -9,10 +9,14 @@ import { SessionsView } from "../src/renderer/views/SessionsView.tsx";
 import { AgentSquadView } from "../src/renderer/views/AgentSquadView.tsx";
 import { agentEntityClient } from "../src/renderer/agent-entity-client.ts";
 import { ProvidersView } from "../src/renderer/views/ProvidersView.tsx";
-import { settleEntitySaveReceipt } from "../src/renderer/components/runtime/useRuntimeWorkspace.ts";
+import {
+  settleEntitySaveReceipt,
+  useAgentSquadWorkspace,
+} from "../src/renderer/components/runtime/useRuntimeWorkspace.ts";
 import { NAV_GROUPS } from "../src/renderer/navigation/navConfig.tsx";
 import { agentRuntimeClient } from "../src/renderer/agent-runtime-client.ts";
 import { harnessClient } from "../src/renderer/api-client.ts";
+import { runtimeCommandClient } from "../src/renderer/runtime-command-client.ts";
 import { runtimeInstanceClient } from "../src/renderer/runtime-instance-client.ts";
 import {
   prewarmRuntimeInstanceCatalog,
@@ -291,6 +295,105 @@ describe("runtime entry split (W6 IA)", () => {
 
     expect(showReceipt).toHaveBeenCalledWith({ repoId: "repo-a", opId: "entity-op" });
     expect(settled).toMatchObject({ outcome: "applied", opId: "entity-op" });
+  });
+
+  // R6(F1):派工绑定等待只读新 session 自己的 associations,不再拉全仓无过滤的
+  // sessionGroups(limit 1000)在内存里找 taskId——旧实现每 250ms 一整表,
+  // 读放大随全仓 session-group 历史增长,与目标任务无关。
+  it("waits for the dispatch task binding on the spawned session alone, not the whole session-group list", async () => {
+    vi.spyOn(runtimeCommandClient, "spawn").mockResolvedValue({
+      schema: "command-receipt/v2",
+      ok: true,
+      command: "runtime.spawn",
+      outcome: "applied",
+      opId: "op-dispatch-binding",
+      runtimeSessionId: "runtime-dispatch",
+      dispatchId: "dispatch_binding",
+      proof: { durable: true, canonicalVisible: true, worktreeVisible: true },
+    } as never);
+    let dispatchPromise: Promise<unknown> | undefined;
+    await mountView(
+      createElement(function Probe() {
+        const workspace = useAgentSquadWorkspace("repo-a", null);
+        return createElement(
+          "button",
+          {
+            "data-testid": "dispatch-binding-probe",
+            onClick: () => {
+              dispatchPromise = workspace.dispatch({
+                subject: { kind: "agent", agent: { agentId: "terra", agentName: "terra", runtimeType: "codex" } },
+                mission: "binding probe",
+                cwd: { scope: "repo-root" },
+                taskId: "task-bound",
+                idempotencyKey: "gui-dispatch-binding-probe",
+              });
+            },
+          },
+          "dispatch",
+        );
+      }),
+    );
+    // 收据 settle 需要 overview 里出现新 session;绑定等待只允许读该 session。
+    vi.spyOn(agentRuntimeClient, "overview").mockImplementation(
+      async () =>
+        ({
+          ok: true,
+          status: "ready",
+          installations: [],
+          instances: [],
+          sessions: [session("runtime-dispatch", "task-bound")],
+          watermark: 1,
+          sourceRevision: 1,
+        }) as never,
+    );
+    vi.mocked(agentRuntimeClient.session).mockClear();
+    vi.mocked(agentRuntimeClient.sessionGroups).mockClear();
+
+    await click("dispatch-binding-probe");
+    const settledDispatch = (await act(async () => dispatchPromise)) as { readonly state?: string };
+
+    expect(settledDispatch.state).toBe("applied");
+    expect(agentRuntimeClient.session).toHaveBeenCalledWith("repo-a", "runtime-dispatch");
+    expect(agentRuntimeClient.sessionGroups).not.toHaveBeenCalled();
+  });
+
+  // R6(F5):agent 保存的落定判据是回执(outcome applied + canonicalVisible),
+  // 保存后只失效列表查询,由挂载面的正常 refetch 带新目录——不再强制
+  // staleTime:0 同步回读整份 agents 列表。
+  it("settles a saved agent from its receipt and refreshes the list through invalidation alone", async () => {
+    const save = vi.spyOn(agentEntityClient, "saveAgent").mockResolvedValue({
+      outcome: "applied",
+      opId: "op-save-agent",
+      revision: 4,
+      proof: { durable: true, canonicalVisible: true, worktreeVisible: true },
+    });
+    const listAgents = vi.spyOn(agentEntityClient, "listAgents");
+    let savePromise: Promise<unknown> | undefined;
+    await mountView(
+      createElement(function Probe() {
+        const workspace = useAgentSquadWorkspace("repo-a", null);
+        return createElement(
+          "button",
+          {
+            "data-testid": "save-agent-probe",
+            onClick: () => {
+              savePromise = workspace.saveAgent({ id: "terra", name: "terra" } as never);
+            },
+          },
+          "save",
+        );
+      }),
+    );
+    expect(save).not.toHaveBeenCalled();
+    const readsBeforeSave = listAgents.mock.calls.length;
+
+    await click("save-agent-probe");
+    const saved = (await act(async () => savePromise)) as { readonly outcome?: string };
+
+    expect(saved).toMatchObject({ outcome: "applied" });
+    expect(save).toHaveBeenCalledTimes(1);
+    // 恰好一次失效驱动的 refetch(挂载中的 agents 查询),没有额外的强制整表重读。
+    expect(listAgents.mock.calls.length).toBe(readsBeforeSave + 1);
   });
 
   it("exposes the runtime nav entries with the terminal page, Schedules, and no aggregate agents entry", () => {

--- a/packages/gui/test/service-bridge.test.ts
+++ b/packages/gui/test/service-bridge.test.ts
@@ -127,10 +127,13 @@ test("GUI client reaches every shipped read through a real resident daemon", asy
     const catalog = (await bridge.invoke("getCatalogSnapshot", scope)) as {
       defaults: { presetId: string };
     };
-    const reread = (await bridge.invoke("rereadCatalog", {
-      ...scope,
-      expectedDigest: (catalog as { catalogDigest: string }).catalogDigest,
-    })) as { schema: string; ok: boolean; operationId: string; repoId: string };
+    // R6:手动重读是「读最新」,不带 CAS 期望值(GUI 不再回传 catalogDigest)。
+    const reread = (await bridge.invoke("rereadCatalog", scope)) as {
+      schema: string;
+      ok: boolean;
+      operationId: string;
+      repoId: string;
+    };
     assert.deepEqual(
       { schema: reread.schema, ok: reread.ok, repoId: reread.repoId },
       { schema: "catalog-reread-receipt/v1", ok: true, repoId: fixture.repoId },

--- a/packages/gui/test/task-pin-actions.vitest.ts
+++ b/packages/gui/test/task-pin-actions.vitest.ts
@@ -5,7 +5,6 @@ import { act, createElement } from "react";
 import { createRoot } from "react-dom/client";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { GuiActionResult } from "../src/api/renderer-dto.ts";
-import type { TaskListSuccess } from "../src/renderer/api-client.ts";
 import type { TaskRow } from "../src/renderer/model/types.ts";
 import { useTaskActions } from "../src/renderer/task-actions.ts";
 import { harnessClient } from "../src/renderer/api-client.ts";
@@ -30,8 +29,18 @@ const receipt = (over: Partial<GuiActionResult> = {}): GuiActionResult =>
     ...over,
   }) as unknown as GuiActionResult;
 
+const emptyList = {
+  ok: true,
+  status: "ready",
+  rows: [],
+  invalidRows: [],
+  watermark: 0,
+  sourceRevision: 0,
+  warnings: [],
+} as const;
+
 describe("useTaskActions pin write channel", () => {
-  it("pins and unpins through the daemon pin action and re-reads the projection", async () => {
+  it("pins and unpins through the daemon pin action, settling each write from its receipt alone", async () => {
     const container = document.createElement("div");
     document.body.append(container);
     const root = createRoot(container);
@@ -54,40 +63,11 @@ describe("useTaskActions pin write channel", () => {
       docs: [],
       ...(pinned ? { pinned: true } : {}),
     });
-    const list = (pinned: boolean): TaskListSuccess => ({
-      ok: true,
-      status: "ready",
-      rows: [
-        {
-          taskId: "task-pin",
-          createdAt: null,
-          updatedAt: "2026-08-30T00:00:00.000Z",
-          generation: "v1",
-          snapshot: {
-            revision: 9,
-            task: {
-              schema: "task/v2",
-              taskId: "task-pin",
-              title: "Pin me",
-              pinned,
-            },
-            executions: [],
-            reviews: [],
-            consents: [],
-            codeDocWitnesses: [],
-            gateWitnesses: [],
-            lease: null,
-          },
-        } as never,
-      ],
-      invalidRows: [],
-      watermark: 9,
-      sourceRevision: 9,
-      warnings: [],
-    });
     const pin = vi.fn(async () => receipt()),
       unpin = vi.fn(async () => receipt()),
-      reads = vi.fn().mockResolvedValueOnce(list(true)).mockResolvedValueOnce(list(false));
+      // R6:回执三件套(durable + canonicalVisible + committedRevision===appliedCut)已是
+      // 落定证明,写入通道不再强制 staleTime:0 整表重读——这里必须保持零调用。
+      reads = vi.fn(async () => emptyList);
     vi.spyOn(harnessClient, "pinTask").mockImplementation(pin);
     vi.spyOn(harnessClient, "unpinTask").mockImplementation(unpin);
     vi.spyOn(harnessClient, "getTasks").mockImplementation(reads);
@@ -105,7 +85,7 @@ describe("useTaskActions pin write channel", () => {
           }),
         );
       });
-      client.setQueryData(taskQueryKeys.list("repo-a"), list(false));
+      client.setQueryData(taskQueryKeys.list("repo-a"), { ok: true, status: "ready", rows: [] });
 
       let feedback = await actions!.setTaskPin(task(false), true);
       expect(pin).toHaveBeenCalledWith({ repoId: "repo-a", taskId: "task-pin" });
@@ -114,7 +94,7 @@ describe("useTaskActions pin write channel", () => {
       feedback = await actions!.setTaskPin(task(true), false);
       expect(unpin).toHaveBeenCalledWith({ repoId: "repo-a", taskId: "task-pin" });
       expect(feedback).toMatchObject({ state: "success", kind: "pin" });
-      expect(reads).toHaveBeenCalledTimes(2);
+      expect(reads).not.toHaveBeenCalled();
     } finally {
       await act(async () => {
         root.unmount();
@@ -124,10 +104,11 @@ describe("useTaskActions pin write channel", () => {
     }
   });
 
-  // 回执 applied 但重读还没看到目标 cut(实测 canonical 追平要约 2s)时,写入**不是**在飞:
-  // 旧实现把这条也留在 in-flight 锁里,于是 pin 一次之后 unpin 再也发不出去——控件永久死掉,
-  // 而且界面一句话都不说。这一条守住「投影滞后不锁控件」,同时不放开真正归属未知的回执。
-  it("keeps the pin control usable after a receipt whose projection has not caught up", async () => {
+  // 回执 applied 且 proof 完整时,回执本身就是落定证明:即使 GUI 列表投影还停在旧版本
+  // (实测 canonical 追平要约 2s),也直接发布 success——旧实现在这里强制 staleTime:0
+  // 重读整表并逐行扫描,列表一滞后就把已落定的写入错报成 projection_not_visible。
+  // 列表的新状态由挂载中的台账探针正常 refetch 带上来(R6 删除回读校验)。
+  it("settles an applied pin from the receipt alone while the list projection lags", async () => {
     const container = document.createElement("div");
     document.body.append(container);
     const root = createRoot(container);
@@ -150,36 +131,9 @@ describe("useTaskActions pin write channel", () => {
       docs: [],
       ...(pinned ? { pinned: true } : {}),
     });
-    const list = (pinned: boolean): TaskListSuccess => ({
-      ok: true,
-      status: "ready",
-      rows: [
-        {
-          taskId: "task-pin",
-          createdAt: null,
-          updatedAt: "2026-08-30T00:00:00.000Z",
-          generation: "v1",
-          snapshot: {
-            revision: 9,
-            task: { schema: "task/v2", taskId: "task-pin", title: "Pin me", pinned },
-            executions: [],
-            reviews: [],
-            consents: [],
-            codeDocWitnesses: [],
-            gateWitnesses: [],
-            lease: null,
-          },
-        } as never,
-      ],
-      invalidRows: [],
-      watermark: 9,
-      sourceRevision: 9,
-      warnings: [],
-    });
     const pin = vi.fn(async () => receipt()),
       unpin = vi.fn(async () => receipt()),
-      // 第一次重读还停在 pin 之前的那一版 → 落定成 projection_not_visible。
-      reads = vi.fn().mockResolvedValueOnce(list(false)).mockResolvedValueOnce(list(false));
+      reads = vi.fn(async () => emptyList);
     vi.spyOn(harnessClient, "pinTask").mockImplementation(pin);
     vi.spyOn(harnessClient, "unpinTask").mockImplementation(unpin);
     vi.spyOn(harnessClient, "getTasks").mockImplementation(reads);
@@ -197,16 +151,17 @@ describe("useTaskActions pin write channel", () => {
           }),
         );
       });
-      client.setQueryData(taskQueryKeys.list("repo-a"), list(false));
+      client.setQueryData(taskQueryKeys.list("repo-a"), { ok: true, status: "ready", rows: [] });
 
       const lagging = await actions!.setTaskPin(task(false), true);
-      expect(lagging).toMatchObject({ state: "pending", kind: "pin", code: "projection_not_visible" });
+      expect(lagging).toMatchObject({ state: "success", kind: "pin" });
       expect(pin).toHaveBeenCalledTimes(1);
+      expect(reads).not.toHaveBeenCalled();
 
-      // 同一条任务的下一次 pin 意图必须真的发出去,而不是拿回上一次那个 promise。
+      // 同一条任务的下一次 unpin 意图必须真的发出去,而不是拿回上一次那个 promise。
       const again = await actions!.setTaskPin(task(true), false);
       expect(unpin).toHaveBeenCalledTimes(1);
-      expect(again).toMatchObject({ kind: "pin" });
+      expect(again).toMatchObject({ state: "success", kind: "pin" });
 
       // 实测真机落在另一条同类落定上:回执 outcome=applied,但 proof 还没断言
       // canonical 可见(code=canonical_not_visible)。它同样不得锁死控件。

--- a/tools/gui-test-manifest.mjs
+++ b/tools/gui-test-manifest.mjs
@@ -24,6 +24,7 @@ export const guiVitestManifest = [
   "packages/gui/test/task-adapter.vitest.ts",
   "packages/gui/test/agenda-data.vitest.ts",
   "packages/gui/test/task-pin-actions.vitest.ts",
+  "packages/gui/test/decision-actions.vitest.ts",
   "packages/gui/test/triadic-read-scoping.vitest.ts",
   "packages/gui/test/triadic-graph-paging.vitest.ts",
   "packages/gui/test/terminal-renderer.vitest.ts",


### PR DESCRIPTION
# English

## Summary

GUI writes settle from their receipts instead of rereading whole repository views.

- Runtime binding waits no longer read every session group (limit 1000) to find one session.
- Saving an agent or squad invalidates its query instead of forcing a whole-table reread with `staleTime: 0`.
- Task pin and lifecycle actions publish success from an applied receipt; the forced reread and per-row capability scan are deleted.
- Decision propose and judge actions no longer rescan the decision list; refresh is a plain invalidation.
- Preset reads stop sending `expectedDigest` and stop displaying catalog and receipt digests nobody acted on.

This is batch R6 of the 2026-09-10 rescan.

## Architectural Justification

Churn is 209 lines but net is -99: every change deletes a reread whose result the action already had in its receipt, or a digest round-trip nobody consumed. The only additions are the receipt-based settlement branches that replace those rereads.

## What Changed

- `useRuntimeWorkspace.ts`: binding wait checks one session's associations; agent/squad saves invalidate.
- `task-actions.ts`: applied receipts publish success; `rowCan`, `TaskSettlement.revision` and the visibility closures are deleted.
- `decision-actions.ts`: refresh is invalidation; the per-item scan and `terminalState` table are deleted.
- `api-client.ts`, `catalog-data.ts`, `PresetsView.tsx`: digest round-trips and their display are removed.
- Tests: task-pin actions rewritten (they locked the deleted behavior); new decision-actions and runtime-workspace cases; `tools/gui-test-manifest.mjs` registers the new file.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: +55/-154 (net -99), from `node tools/gates/production-delta.mjs --base origin/main`.

## Machine-Readable Declarations

## Task And Scope

- Harness task: task_272d0338fca6e7593ef6f6d245
- Branch: `codex/r6-gui-reads`
- Public scope: GUI renderer write settlement and preset reads
- Private planning/evidence updated: yes (task plan and worker report)
- Out of scope: daemon-side reread parameters, which still accept an optional digest

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: yes
- Protected surface scope: `tools/gui-test-manifest.mjs`: registers the new `decision-actions.vitest.ts` file. No rule changes.
- Authority: task_272d0338fca6e7593ef6f6d245; the repository owner authorized tonight's governance fixes in the 2026-09-10 session
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `b28d80603`
- Branch merge-base with `origin/main`: `b28d80603`
- Last `git fetch origin` time: 2026-09-10 18:10 UTC
- Sync method: rebased onto origin/main
- Public diff command: `git diff origin/main...codex/r6-gui-reads`
- Private evidence commit/path: task_272d0338fca6e7593ef6f6d245 task package report
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Worker: new assertions red on the old code and green after; contract/fast 22 + 46 cases green; isolated runs of runtime-workspace-interactions (27), agent-runtime-renderer (31), preset-detail (8), service-bridge (3), gui-write-receipt-settlement (1) green.
- `tsc -b`, eslint, prettier, line-density, production-delta and `run-manifest-gates --changed origin/main` pass.
- Electron check by the lead (renderer from this branch, canonical workspace through the default daemon, driven over the Chrome DevTools Protocol): the presets view renders without catalog digests and its reread returns an applied receipt with no before/after digest; unpinning a task from the board shows `pin · success … canonical receipt 已确认落定` at once and the ledger reads `pinned=false` (re-pinned afterwards); the decision review queue (1/6) and the sessions view with task bindings render.
- Not run: the full `npm run check` / `npm test` locally. Local agents must not run the full matrix, so CI is the full authority.

## Review Evidence

- Lead review of the diff: every deletion removes a reread whose result the action already had in its receipt.
- Reviewer subagent: not used
- Human review: pending
- Blocking findings: none

## Residual Risk

- A list can show the previous row for one refetch cycle after an applied write, until invalidation lands.

## References

- Task: task_272d0338fca6e7593ef6f6d245
- Fact: F-A0526939
- Parent: task_2b8f79fa4412cb726a26f9bfc7

---

# 中文

## 概要

GUI 的写操作改为按回执结算，不再重读整个仓库视图。

- runtime 绑定等待不再为了找一个 session 而读取全部 session 分组（limit 1000）。
- 保存 agent 或 squad 时只失效对应查询，不再用 `staleTime: 0` 强制整表回读。
- task 的 pin 与生命周期操作，收到 applied 回执就发布成功；删掉强制回读和逐行能力扫描。
- decision 的 propose 与 judge 不再重扫 decision 列表；刷新改为普通的失效。
- preset 读取不再回传 `expectedDigest`，也不再展示没人使用的 catalog 与回执 digest。

这是 2026-09-10 复扫后的 R6 批次。

## 架构辩护

改动总量 209 行，但净删 99 行：每一处都是删掉一次回读（其结果本来就在该操作的回执里），或删掉一个没人使用的 digest 往返。新增的只有按回执结算的分支，用来替代这些回读。

## 改动内容

- `useRuntimeWorkspace.ts`：绑定等待只检查一个 session 的 associations；agent/squad 保存改为失效。
- `task-actions.ts`：applied 回执即发布成功；删掉 `rowCan`、`TaskSettlement.revision` 和可见性闭包。
- `decision-actions.ts`：刷新改为失效；删掉逐条扫描和 `terminalState` 表。
- `api-client.ts`、`catalog-data.ts`、`PresetsView.tsx`：删掉 digest 往返及其展示。
- 测试：改写 task-pin 用例（原用例锁定的正是被删行为）；新增 decision-actions 与 runtime-workspace 用例；`tools/gui-test-manifest.mjs` 登记新文件。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 删除的门或 fixture：none
- 生产净行数：+55/-154 (net -99)，由 `node tools/gates/production-delta.mjs --base origin/main` 计算。

## 机读声明说明

- 本 PR 不涉及依赖变化和事件迁移，没有机读声明。

## 任务与范围

- Harness 任务：task_272d0338fca6e7593ef6f6d245
- 分支：`codex/r6-gui-reads`
- 公开范围：GUI 渲染层的写结算与 preset 读取
- 私有计划 / 证据是否已更新：yes（任务计划与 worker 报告）
- 范围外：daemon 端的 reread 参数，仍接受可选 digest

## 版本影响

- 版本：不改版本
- 发布影响：不发布

## 治理声明

- 是否触碰 protected surface：yes
- protected surface 范围：`tools/gui-test-manifest.mjs`：登记新增的 `decision-actions.vitest.ts`，没有改任何规则。
- 依据：task_272d0338fca6e7593ef6f6d245；仓库所有者在 2026-09-10 会话中授权了今晚的治理修正
- 机器检查边界：本 PR 只声明该段存在；声明是否真实、充分，由 reviewer 判断。
- Break-glass：no
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- `origin/main` 基准 SHA：`b28d80603`
- 当前分支与 `origin/main` 的 merge-base：`b28d80603`
- 最近一次 `git fetch origin` 时间：2026-09-10 18:10 UTC
- 同步方式：rebase 到 origin/main
- 公开 diff 命令：`git diff origin/main...codex/r6-gui-reads`
- 私有证据 commit/path：task_272d0338fca6e7593ef6f6d245 任务包报告
- Reviewer 证据路径：见本 PR 的「审查证据」一节
- GitHub Actions `rewrite-ci` run URL：本 PR 的 CI 还在跑
- [ ] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- worker：新断言在旧代码上红、新代码上绿；contract/fast 共 22 + 46 个用例全绿；隔离环境运行 runtime-workspace-interactions（27）、agent-runtime-renderer（31）、preset-detail（8）、service-bridge（3）、gui-write-receipt-settlement（1）全绿。
- `tsc -b`、eslint、prettier、line-density、production-delta、`run-manifest-gates --changed origin/main` 通过。
- 主控的 Electron 点验（渲染层来自本分支，经默认 daemon 读 canonical 工作区，通过 Chrome DevTools Protocol 操作）：预设页渲染时不再显示 catalog digest，重新读取返回 applied 回执且没有 before/after digest；在看板上取消一个任务的 pin，界面立即显示「pin · success … canonical receipt 已确认落定」，台账读到 `pinned=false`（之后已恢复 pin）；决策批准队列（1/6）与带任务绑定的会话页正常渲染。
- 未运行：本地整套 `npm run check` / `npm test`。规定禁止本地 agent 跑全量矩阵，全量以 CI 为准。

## 审查证据

- 主控审查 diff：每一处删除都是删掉一次回读，而回读的结果本来就在该操作的回执里。
- Reviewer subagent：未使用
- 人工审查：待进行
- 阻塞发现：无

## 残余风险

- 写操作 applied 之后，在失效生效前的一个刷新周期内，列表可能还显示旧行。

## 关联材料

- Task: task_272d0338fca6e7593ef6f6d245
- Fact: F-A0526939
- Parent: task_2b8f79fa4412cb726a26f9bfc7

---

## PR Gate Checklist / PR 门禁清单

- [x] Branch is based on latest `origin/main`. / 分支基于最新 `origin/main`。
- [x] PR body uses this full template structure. / PR 描述使用本模板完整结构。
- [x] PR body uses two complete language blocks: `# English` first, then `# 中文`. / PR 正文使用两块完整正文：`# English` 在上，`# 中文` 在下。
- [x] PR body passes `tools/check-pr-body-bilingual.mjs`. / PR 正文通过 `tools/check-pr-body-bilingual.mjs`。
- [x] If the PR touches a manifest-derived protected surface, Governance Declaration is filled with ADR/decision/task evidence or break-glass fields. / 若 PR 触碰 manifest 派生的 protected surface，Governance Declaration 已填写 ADR/decision/task 依据或 break-glass 字段。
- [x] No private harness files are included. / 不包含私有 harness 文件。
- [x] No ignored local agent entry files are included. / 不包含被忽略的本地 agent 入口文件。
- [x] No absolute local filesystem paths are included in this public PR body. / 本公开 PR 描述不包含本机绝对路径。
- [x] Public diff is limited to the stated task scope. / 公开 diff 限于声明的任务范围。
- [x] Private planning/evidence updates are recorded when applicable. / 适用时已记录私有计划 / 证据更新。
- [x] Version and publish impact are stated. / 已说明版本与发布影响。
- [x] Local verification commands are recorded honestly. / 已如实记录本地验证命令。
- [ ] CI results are linked or explained. / CI 结果已链接或说明。
- [x] Review evidence is recorded. / 已记录审查证据。
- [x] Open P0/P1/P2 findings are closed, deferred with owner, or explicitly blocked. / open P0/P1/P2 findings 已关闭、带 owner 延后，或明确阻塞。
- [x] Merge method and post-merge branch cleanup plan are clear. / 合并方式和合并后分支清理计划清楚。
- [x] No admin bypass is planned unless explicitly approved and recorded. / 除非明确批准并记录，否则不计划 admin bypass。
