### PR TITLE
fix(daemon): derive the artifact-add source prefix from the repository root

### DIFF
--- a/packages/daemon/src/doc-sync-candidate-scanner.ts
+++ b/packages/daemon/src/doc-sync-candidate-scanner.ts
@@ -87,6 +87,9 @@ export function scanDocCandidates(input: {
 }): DocCandidateScan {
   const layout = resolveHarnessLayout(input.rootDir),
     ledger = resolveLedgerGitLayout(input.rootDir),
+    // artifactSource resolves --source against the product repository root, which is not
+    // the ledger Git top level when the authored root is its own nested repository.
+    sourcePrefix = relative(input.rootDir, layout.authoredRoot),
     task = input.taskId === undefined ? null : input.projection.read(input.taskId),
     taskPrefix =
       input.taskId === undefined
@@ -219,15 +222,13 @@ export function scanDocCandidates(input: {
         "add",
         claimingTaskId,
         "--source",
-        `${ledger.authoredPrefix ? `${ledger.authoredPrefix}/` : ""}${logical}`,
+        `${sourcePrefix ? `${sourcePrefix}/` : ""}${logical}`,
         "--destination",
         logical.slice(`tasks/${taskDirectory}/`.length),
       ]);
       return scannedCandidateRow(
         "inapplicable",
-        rawClassification === null || (candidate === null && fileSize !== null && fileSize > DOC_SYNC_INLINE_MAX_BYTES)
-          ? `task artifact is outside doc sync; publish it with ${nextAction}`
-          : "non-textual artifact is outside doc sync; publish it with ha task artifact add",
+        `task artifact is outside doc sync; publish it with ${nextAction}`,
         bytes,
         base,
         candidate,

--- a/packages/daemon/test/doc-sync-artifact-raw-bytes.test.ts
+++ b/packages/daemon/test/doc-sync-artifact-raw-bytes.test.ts
@@ -374,6 +374,62 @@ test("doc status uses the configured authored root and quotes artifact source pa
   }
 });
 
+test("doc status nextAction round-trips when the authored root is its own nested Git repository", async () => {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-artifact-nested-ledger-"));
+  initRepo(rootDir);
+  // Canonical layout: the authored root is an independent Git repository nested inside the
+  // product repository. The prefix relative to the ledger Git top level is then empty, so the
+  // artifact add source must be derived from the product root, not from the ledger prefix.
+  const ledgerRoot = path.join(rootDir, "harness");
+  mkdirSync(ledgerRoot, { recursive: true });
+  git(ledgerRoot, "init", "-q");
+  git(ledgerRoot, "config", "user.name", "Doc Raw Test");
+  git(ledgerRoot, "config", "user.email", "doc-raw@example.invalid");
+  git(ledgerRoot, "config", "gc.auto", "0");
+  writeFileSync(path.join(ledgerRoot, ".gitkeep"), "");
+  git(ledgerRoot, "add", ".gitkeep");
+  git(ledgerRoot, "commit", "-qm", "ledger base");
+  const repoId = workspaceId("artifact-nested-ledger"),
+    cell = await openRepoCell({ repoId, rootDir: canonicalRoot(rootDir), ownerId: "artifact-nested-ledger" }),
+    binding = { actor, source: "local" as const };
+  try {
+    const created = (await cell.run(
+      { kind: "task-create", taskId: "task-nested", title: "Nested Ledger" },
+      binding,
+    )) as { readonly outcome: string; readonly packagePath: string };
+    assert.equal(created.outcome, "applied", JSON.stringify(created));
+    const logical = `${created.packagePath}/artifacts/report.json`,
+      target = path.join(ledgerRoot, ...logical.split("/")),
+      bytes = Buffer.from('{"schema":"report/v1","nested":true}\n');
+    mkdirSync(path.dirname(target), { recursive: true });
+    writeFileSync(target, bytes);
+    const status = (await cell.run({ kind: "doc-status", paths: [logical] }, binding)) as Record<string, unknown>,
+      nextAction = String((status.detail as { readonly nextAction?: string }).nextAction),
+      routed = /^ha task artifact add (\S+) --source ('[^']*'|\S+) --destination ('[^']*'|\S+)$/u.exec(nextAction),
+      unquote = (token: string): string => token.replace(/^'(.*)'$/u, "$1");
+    assert.ok(routed, nextAction);
+    assert.equal(unquote(routed[2]!), `harness/${logical}`, nextAction);
+    assert.equal(unquote(routed[3]!), "artifacts/report.json", nextAction);
+    const added = (await cell.run(
+      {
+        kind: "task-artifact-add",
+        taskId: routed[1]!,
+        source: unquote(routed[2]!),
+        destination: unquote(routed[3]!),
+      },
+      binding,
+    )) as Record<string, unknown>;
+    assert.equal(added.outcome, "applied", JSON.stringify(added));
+    assert.equal(added.source, `harness/${logical}`);
+    assert.deepEqual(readFileSync(target), bytes, "same-path takeover preserves the original bytes");
+    await waitForFixturePublication(cell, String(added.opId), binding);
+    assert.deepEqual(gitBytes(ledgerRoot, logical), bytes, "the nested ledger Git cut holds the same bytes");
+  } finally {
+    await cell.close();
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});
+
 function gitBytes(rootDir: string, target: string): Buffer {
   return execFileSync("git", ["-C", rootDir, "show", `HEAD:${target}`], { maxBuffer: 64 * 1024 * 1024 });
 }


### PR DESCRIPTION
# English

## Summary

`ha doc status` suggests an `ha task artifact add --source <path>` command for raw-byte task files. The scanner built `--source` from the ledger Git prefix, but `artifact add` resolves `--source` against the product repository root. When the authored root is its own nested Git repository (as `harness/` is), the ledger prefix is empty, so the suggested command dropped the `harness/` segment and failed with `artifact_source_missing`. The prefix now comes from the root directory, and the unreachable generic non-textual reason left from the pre-gating route is removed.

## What Changed

- `doc-sync-candidate-scanner.ts`: the `--source` prefix derives from the repository root.
- `doc-sync-artifact-raw-bytes.test.ts`: the emitted command round-trips through `task artifact add` on a nested-repository fixture.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: +5/-4 (net +1), from `node tools/gates/production-delta.mjs --base origin/main`.

## Machine-Readable Declarations

## Task And Scope

- Harness task: task_f4377627de1b284dab59ba5550
- Branch: `codex/raw-source-prefix`
- Public scope: the doc status next action for raw-byte task files
- Private planning/evidence updated: yes (task plan and worker report)
- Out of scope: artifact add itself

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: not applicable
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `b28d80603`
- Branch merge-base with `origin/main`: `b28d80603`
- Last `git fetch origin` time: 2026-09-10 18:20 UTC
- Sync method: rebased onto origin/main
- Public diff command: `git diff origin/main...codex/raw-source-prefix`
- Private evidence commit/path: task_f4377627de1b284dab59ba5550 task package report
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- `npx tsc -b packages/daemon` passes.
- `node --test packages/daemon/test/doc-sync-artifact-raw-bytes.test.ts`: 6/6.
- `node tools/run-manifest-gates.mjs --changed origin/main` passes.
- Not run: the full `npm run check` / `npm test` locally. Local agents must not run the full matrix, so CI is the full authority.

## Review Evidence

- This fixes the only blocking finding (item 2) of the task's earlier independent review.
- Reviewer subagent: not used
- Human review: pending
- Blocking findings: none

## Residual Risk

- None known.

## References

- Task: task_f4377627de1b284dab59ba5550
- PR #2393

---

# 中文

## 概要

`ha doc status` 会为原字节的任务文件给出一条 `ha task artifact add --source <path>` 建议命令。扫描器用 ledger 的 Git 前缀拼 `--source`，但 `artifact add` 是相对产品仓库根目录解析 `--source` 的。当 authored root 本身是一个嵌套 Git 仓库时（`harness/` 就是），ledger 前缀为空，建议命令丢了 `harness/` 这一段，执行时报 `artifact_source_missing`。现在前缀从根目录派生；同时删掉旧路由遗留的、已经走不到的通用非文本原因。

## 改动内容

- `doc-sync-candidate-scanner.ts`：`--source` 前缀从仓库根目录派生。
- `doc-sync-artifact-raw-bytes.test.ts`：在嵌套仓库 fixture 上，扫描器给出的命令能通过 `task artifact add` 完整执行。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 删除的门或 fixture：none
- 生产净行数：+5/-4 (net +1)，由 `node tools/gates/production-delta.mjs --base origin/main` 计算。

## 机读声明说明

- 本 PR 不涉及依赖变化和事件迁移，没有机读声明。

## 任务与范围

- Harness 任务：task_f4377627de1b284dab59ba5550
- 分支：`codex/raw-source-prefix`
- 公开范围：原字节任务文件的 doc status 建议命令
- 私有计划 / 证据是否已更新：yes（任务计划与 worker 报告）
- 范围外：artifact add 本身

## 版本影响

- 版本：不改版本
- 发布影响：不发布

## 治理声明

- 是否触碰 protected surface：no
- protected surface 范围：不适用
- 依据：不适用
- 机器检查边界：本 PR 只声明该段存在；声明是否真实、充分，由 reviewer 判断。
- Break-glass：no
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- `origin/main` 基准 SHA：`b28d80603`
- 当前分支与 `origin/main` 的 merge-base：`b28d80603`
- 最近一次 `git fetch origin` 时间：2026-09-10 18:20 UTC
- 同步方式：rebase 到 origin/main
- 公开 diff 命令：`git diff origin/main...codex/raw-source-prefix`
- 私有证据 commit/path：task_f4377627de1b284dab59ba5550 任务包报告
- Reviewer 证据路径：见本 PR 的「审查证据」一节
- GitHub Actions `rewrite-ci` run URL：本 PR 的 CI 还在跑
- [ ] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- `npx tsc -b packages/daemon` 通过。
- `node --test packages/daemon/test/doc-sync-artifact-raw-bytes.test.ts`：6/6。
- `node tools/run-manifest-gates.mjs --changed origin/main` 通过。
- 未运行：本地整套 `npm run check` / `npm test`。规定禁止本地 agent 跑全量矩阵，全量以 CI 为准。

## 审查证据

- 修的是该任务上一轮独立评审里唯一的阻塞项（第 2 项）。
- Reviewer subagent：未使用
- 人工审查：待进行
- 阻塞发现：无

## 残余风险

- 未知。

## 关联材料

- Task: task_f4377627de1b284dab59ba5550
- PR #2393

---

## PR Gate Checklist / PR 门禁清单

- [x] Branch is based on latest `origin/main`. / 分支基于最新 `origin/main`。
- [x] PR body uses this full template structure. / PR 描述使用本模板完整结构。
- [x] PR body uses two complete language blocks: `# English` first, then `# 中文`. / PR 正文使用两块完整正文：`# English` 在上，`# 中文` 在下。
- [x] PR body passes `tools/check-pr-body-bilingual.mjs`. / PR 正文通过 `tools/check-pr-body-bilingual.mjs`。
- [x] If the PR touches a manifest-derived protected surface, Governance Declaration is filled with ADR/decision/task evidence or break-glass fields. / 若 PR 触碰 manifest 派生的 protected surface，Governance Declaration 已填写 ADR/decision/task 依据或 break-glass 字段。
- [x] No private harness files are included. / 不包含私有 harness 文件。
- [x] No ignored local agent entry files are included. / 不包含被忽略的本地 agent 入口文件。
- [x] No absolute local filesystem paths are included in this public PR body. / 本公开 PR 描述不包含本机绝对路径。
- [x] Public diff is limited to the stated task scope. / 公开 diff 限于声明的任务范围。
- [x] Private planning/evidence updates are recorded when applicable. / 适用时已记录私有计划 / 证据更新。
- [x] Version and publish impact are stated. / 已说明版本与发布影响。
- [x] Local verification commands are recorded honestly. / 已如实记录本地验证命令。
- [ ] CI results are linked or explained. / CI 结果已链接或说明。
- [x] Review evidence is recorded. / 已记录审查证据。
- [x] Open P0/P1/P2 findings are closed, deferred with owner, or explicitly blocked. / open P0/P1/P2 findings 已关闭、带 owner 延后，或明确阻塞。
- [x] Merge method and post-merge branch cleanup plan are clear. / 合并方式和合并后分支清理计划清楚。
- [x] No admin bypass is planned unless explicitly approved and recorded. / 除非明确批准并记录，否则不计划 admin bypass。
