### PR TITLE
fix(daemon): write each request log line to its own repository file

### DIFF
--- a/packages/daemon/src/request-log.ts
+++ b/packages/daemon/src/request-log.ts
@@ -1,5 +1,4 @@
-import { mkdir, open, rename, rm } from "node:fs/promises";
-import type { FileHandle } from "node:fs/promises";
+import { appendFile, mkdir, rename, rm, stat } from "node:fs/promises";
 import path from "node:path";
 import { consumeKnownError, resolveHarnessLayout } from "../../kernel/src/index.ts";
 // Classification lives here rather than at the dispatch point: the schema registry names the
@@ -83,7 +82,6 @@ export function openDaemonRequestLog(options: DaemonRequestLogOptions): DaemonRe
   const logPaths = new Map<string, string>();
   let reportedFailure = false;
   let chain: Promise<void> = Promise.resolve();
-  let handle: FileHandle | null = null;
 
   return {
     record: (entry) => {
@@ -91,24 +89,14 @@ export function openDaemonRequestLog(options: DaemonRequestLogOptions): DaemonRe
       if (!logPath) return;
       chain = chain.then(() => writeRequestLogLine(logPath, `${JSON.stringify(buildRecord(entry, now()))}\n`));
     },
-    settle: async () => {
-      await chain;
-      if (handle) await handle.close();
-      handle = null;
-    },
+    settle: () => chain,
   };
 
   async function writeRequestLogLine(logPath: string, line: string): Promise<void> {
     try {
       await mkdir(path.dirname(logPath), { recursive: true });
-      if (!handle) handle = await open(logPath, "a");
-      if ((await handle.stat()).size >= maxBytes) {
-        await handle.close();
-        handle = null;
-        await rotate(logPath, keptFiles);
-        handle = await open(logPath, "a");
-      }
-      await handle.write(line, null, "utf8");
+      if ((await fileSize(logPath)) >= maxBytes) await rotate(logPath, keptFiles);
+      await appendFile(logPath, line, "utf8");
     } catch (error) {
       consumeKnownError(error);
       if (!reportedFailure) {
@@ -181,6 +169,15 @@ async function rotate(logPath: string, keptFiles: number): Promise<void> {
     }
   }
   await rename(logPath, `${logPath}.1`);
+}
+
+async function fileSize(filePath: string): Promise<number> {
+  try {
+    return (await stat(filePath)).size;
+  } catch (error) {
+    if (isMissingFile(error)) return 0;
+    throw error;
+  }
 }
 
 function isMissingFile(error: unknown): boolean {

--- a/packages/daemon/test/request-log.test.ts
+++ b/packages/daemon/test/request-log.test.ts
@@ -222,6 +222,27 @@ test("rotation holds the log to a bounded number of files", async () => {
   assert.equal(live.at(-1)?.opId, "op_399");
 });
 
+test("each repository's requests land in that repository's own log, and a record after settle is still written", async () => {
+  const first = tempRoot(),
+    second = tempRoot(),
+    roots: Record<string, string> = { first, second };
+  const log = openDaemonRequestLog({ resolveRootDir: (repoId) => roots[repoId] });
+  log.record(entry({ repoId: "first", opId: "op_first" }));
+  log.record(entry({ repoId: "second", opId: "op_second" }));
+  await log.settle();
+  log.record(entry({ repoId: "second", opId: "op_late" }));
+  await log.settle();
+
+  assert.deepEqual(
+    readRecords(first).map(({ opId }) => opId),
+    ["op_first"],
+  );
+  assert.deepEqual(
+    readRecords(second).map(({ opId }) => opId),
+    ["op_second", "op_late"],
+  );
+});
+
 test("a sink that cannot write neither throws nor keeps reporting", async () => {
   const rootDir = tempRoot();
   // A file where the log directory must be: mkdir fails for every record.


### PR DESCRIPTION
# English

## Summary

Main is red at b28d80603: `observe-tail.integration.test.mjs` fails on Node 26 because a `FileHandle` for `.harness/requests/requests.jsonl` was closed by garbage collection (run 34506505657). The cause is in the async request log from #2421:

- The daemon kept one `FileHandle` for the whole process. It was opened for the first repository that logged a request, and every later record, for any repository, was written into that file.
- `settle()` closed the handle, but a record that arrived after `settle()` reopened it, and nothing closed it again.

Each line is now appended with `appendFile`, which opens and closes the file for that write, so records go to their own repository's log and no handle outlives a write. Writes stay serialized and off the reply path.

## What Changed

- `request-log.ts`: `appendFile` per line; size check by `stat`; `settle()` waits for the chain; the shared handle is deleted.
- `request-log.test.ts`: two repositories each get only their own records, and a record after `settle()` is still written. The test fails on the previous code.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: +13/-16 (net -3), from `node tools/gates/production-delta.mjs --base origin/main`.

## Machine-Readable Declarations

## Task And Scope

- Harness task: task_566316a5c3e85ef4a588e466bb
- Branch: `codex/request-log-handle`
- Public scope: the daemon request log sink
- Private planning/evidence updated: yes (task plan and worker report)
- Out of scope: the connection log

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: not applicable
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `85970d403`
- Branch merge-base with `origin/main`: `85970d403`
- Last `git fetch origin` time: 2026-09-10 18:30 UTC
- Sync method: rebased onto origin/main
- Public diff command: `git diff origin/main...codex/request-log-handle`
- Private evidence commit/path: task_566316a5c3e85ef4a588e466bb task package report
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- `node --test packages/daemon/test/request-log.test.ts`: 10/10; the new test fails with the previous `request-log.ts` (negative control).
- `node --test packages/daemon/test/observe-tail.integration.test.mjs`: 5/5, twice.
- `npx tsc -b packages/daemon`, write-road registry check and `node tools/run-manifest-gates.mjs --changed origin/main` pass.
- Not run: the full `npm run check` / `npm test` locally. Local agents must not run the full matrix, so CI is the full authority.

## Review Evidence

- Lead review; this repairs a regression from #2421 that the lead merged.
- Reviewer subagent: not used
- Human review: pending
- Blocking findings: none

## Residual Risk

- One open and close per request log line, off the reply path.

## References

- Main run: https://github.com/FairladyZ625/harness-anything/actions/runs/34506505657
- PR #2421
- Task: task_566316a5c3e85ef4a588e466bb

---

# 中文

## 概要

main 在 b28d80603 上是红的：Node 26 下 `observe-tail.integration.test.mjs` 失败，原因是 `.harness/requests/requests.jsonl` 的一个 `FileHandle` 被垃圾回收关闭（run 34506505657）。根因在 #2421 引入的异步请求日志：

- daemon 整个进程只持有一个 `FileHandle`。它按第一个写请求日志的仓库打开，之后任何仓库的记录都写进了这一个文件。
- `settle()` 会关掉句柄，但 `settle()` 之后到达的记录会重新打开它，之后再也没人关闭。

现在每一行都用 `appendFile` 追加，由这次写入自己打开、关闭文件，所以记录落在各自仓库的日志里，没有句柄活得比一次写入更久。写入仍然串行，并且不在回复路径上。

## 改动内容

- `request-log.ts`：每行用 `appendFile`；用 `stat` 判断大小；`settle()` 等待写链完成；删掉共享句柄。
- `request-log.test.ts`：两个仓库各自只收到自己的记录，`settle()` 之后的记录仍然会写入。该测试在旧代码上失败。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 删除的门或 fixture：none
- 生产净行数：+13/-16 (net -3)，由 `node tools/gates/production-delta.mjs --base origin/main` 计算。

## 机读声明说明

- 本 PR 不涉及依赖变化和事件迁移，没有机读声明。

## 任务与范围

- Harness 任务：task_566316a5c3e85ef4a588e466bb
- 分支：`codex/request-log-handle`
- 公开范围：daemon 请求日志的写入端
- 私有计划 / 证据是否已更新：yes（任务计划与 worker 报告）
- 范围外：连接日志

## 版本影响

- 版本：不改版本
- 发布影响：不发布

## 治理声明

- 是否触碰 protected surface：no
- protected surface 范围：不适用
- 依据：不适用
- 机器检查边界：本 PR 只声明该段存在；声明是否真实、充分，由 reviewer 判断。
- Break-glass：no
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- `origin/main` 基准 SHA：`85970d403`
- 当前分支与 `origin/main` 的 merge-base：`85970d403`
- 最近一次 `git fetch origin` 时间：2026-09-10 18:30 UTC
- 同步方式：rebase 到 origin/main
- 公开 diff 命令：`git diff origin/main...codex/request-log-handle`
- 私有证据 commit/path：task_566316a5c3e85ef4a588e466bb 任务包报告
- Reviewer 证据路径：见本 PR 的「审查证据」一节
- GitHub Actions `rewrite-ci` run URL：本 PR 的 CI 还在跑
- [ ] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- `node --test packages/daemon/test/request-log.test.ts`：10/10；新测试在旧的 `request-log.ts` 上失败（阴性对照）。
- `node --test packages/daemon/test/observe-tail.integration.test.mjs`：5/5，跑了两次。
- `npx tsc -b packages/daemon`、write-road 登记检查、`node tools/run-manifest-gates.mjs --changed origin/main` 通过。
- 未运行：本地整套 `npm run check` / `npm test`。规定禁止本地 agent 跑全量矩阵，全量以 CI 为准。

## 审查证据

- 主控审查；修复的是主控合入的 #2421 引入的回归。
- Reviewer subagent：未使用
- 人工审查：待进行
- 阻塞发现：无

## 残余风险

- 每行请求日志多一次打开与关闭，不在回复路径上。

## 关联材料

- Main run: https://github.com/FairladyZ625/harness-anything/actions/runs/34506505657
- PR #2421
- Task: task_566316a5c3e85ef4a588e466bb

---

## PR Gate Checklist / PR 门禁清单

- [x] Branch is based on latest `origin/main`. / 分支基于最新 `origin/main`。
- [x] PR body uses this full template structure. / PR 描述使用本模板完整结构。
- [x] PR body uses two complete language blocks: `# English` first, then `# 中文`. / PR 正文使用两块完整正文：`# English` 在上，`# 中文` 在下。
- [x] PR body passes `tools/check-pr-body-bilingual.mjs`. / PR 正文通过 `tools/check-pr-body-bilingual.mjs`。
- [x] If the PR touches a manifest-derived protected surface, Governance Declaration is filled with ADR/decision/task evidence or break-glass fields. / 若 PR 触碰 manifest 派生的 protected surface，Governance Declaration 已填写 ADR/decision/task 依据或 break-glass 字段。
- [x] No private harness files are included. / 不包含私有 harness 文件。
- [x] No ignored local agent entry files are included. / 不包含被忽略的本地 agent 入口文件。
- [x] No absolute local filesystem paths are included in this public PR body. / 本公开 PR 描述不包含本机绝对路径。
- [x] Public diff is limited to the stated task scope. / 公开 diff 限于声明的任务范围。
- [x] Private planning/evidence updates are recorded when applicable. / 适用时已记录私有计划 / 证据更新。
- [x] Version and publish impact are stated. / 已说明版本与发布影响。
- [x] Local verification commands are recorded honestly. / 已如实记录本地验证命令。
- [ ] CI results are linked or explained. / CI 结果已链接或说明。
- [x] Review evidence is recorded. / 已记录审查证据。
- [x] Open P0/P1/P2 findings are closed, deferred with owner, or explicitly blocked. / open P0/P1/P2 findings 已关闭、带 owner 延后，或明确阻塞。
- [x] Merge method and post-merge branch cleanup plan are clear. / 合并方式和合并后分支清理计划清楚。
- [x] No admin bypass is planned unless explicitly approved and recorded. / 除非明确批准并记录，否则不计划 admin bypass。
