### PR TITLE
fix(daemon): reject task ids that cannot form task entity references

### DIFF
--- a/packages/daemon/src/repo-cell-task-create.ts
+++ b/packages/daemon/src/repo-cell-task-create.ts
@@ -1,5 +1,6 @@
 import { createHash } from "node:crypto";
 import {
+  parseEntityRef,
   sessionProvenance,
   taskBootstrapWritePlan,
   type WriteReceiptDraft as WriteReceipt,
@@ -145,6 +146,11 @@ export function prepareTaskCreateAt(
     canonicalOpId = cell.operationId(canonicalAction, binding, cell.input.repoId, 0),
     opId = dryRun ? `preview:${createHash("sha256").update(canonicalOpId).digest("hex")}` : canonicalOpId,
     existing = dryRun ? null : cell.store.readEvent(opId);
+  if (typeof canonicalAction.taskId === "string" && parseEntityRef(`task/${canonicalAction.taskId}`)?.kind !== "task")
+    throw cell.cellCodedError(
+      "invalid_task_id",
+      `Task id ${canonicalAction.taskId} cannot be parsed as a task entity reference.`,
+    );
   if (existing) {
     return cell.receiptForOperation(opId, binding);
   }

--- a/packages/daemon/test/task-surface.integration.test.ts
+++ b/packages/daemon/test/task-surface.integration.test.ts
@@ -10,6 +10,30 @@ import { openBootstrappedRepoCell as openRepoCell, waitForFixturePublication } f
 import { realizeTaskPlanFixture } from "../../../tools/fixtures/task-plan.mjs";
 
 import { actor, git, initRepo } from "./task-surface.fixtures.ts";
+
+test("task create rejects ids that cannot form task entity references", async (t) => {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-task-id-ref-"));
+  t.after(() => rmSync(rootDir, { recursive: true, force: true }));
+  initRepo(rootDir);
+  const cell = await openRepoCell({
+    repoId: workspaceId("task-id-ref"),
+    rootDir: canonicalRoot(rootDir),
+    ownerId: "task-id-ref-create",
+  });
+  t.after(() => cell.close());
+  const rejected = await cell.run(
+    { kind: "task-create", taskId: "t0", title: "Invalid id" },
+    { actor, source: "local" },
+  );
+  assert.equal(rejected.outcome, "op_rejected");
+  assert.equal(rejected.code, "invalid_task_id");
+  const accepted = await cell.run(
+    { kind: "task-create", taskId: "task-t0", title: "Valid id" },
+    { actor, source: "local" },
+  );
+  assert.equal(accepted.outcome, "applied");
+});
+
 test("task create publishes complete metadata and first-class relations survive cold rebuild", async () => {
   const rootDir = mkdtempSync(path.join(tmpdir(), "ha-task-surface-"));
   let cell: Awaited<ReturnType<typeof openRepoCell>> | undefined;


### PR DESCRIPTION
# English

## Summary

A task id that cannot form a `task/<id>` entity reference could make a whole repository permanently unavailable. The 2026-09-11 scale bench reproduced it in Docker: `ha task create --id t0 --admin` was accepted, and the first `ha fact record t0` wrote an automatic `task/t0 --produces--> fact/F-…` relation. The store accepted that relation, but projection replay rejected it, so the repository cell went `unavailable` with `Relation endpoints must be canonical registered Entity refs`, and every restart replayed into the same failure. Task create now applies the same `parseEntityRef` grammar that replay uses and rejects such ids with `invalid_task_id` before anything is written.

## What Changed

- `repo-cell-task-create.ts`: reject an explicit task id that `parseEntityRef` cannot read as a task reference.
- `task-surface.integration.test.ts`: `t0` is rejected and the repository stays available; the test fails without the fix.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: +6/-0 (net +6), from `node tools/gates/production-delta.mjs --base origin/main`.

## Machine-Readable Declarations

## Task And Scope

- Harness task: task_da9eb7b39633d63348b33ebb7c
- Branch: `codex/f1-task-id-ref`
- Public scope: task create admission
- Private planning/evidence updated: yes (task plan and worker report)
- Out of scope: repairing a repository that already holds such an event; no canonical ledger does

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: not applicable
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `779c723f8`
- Branch merge-base with `origin/main`: `779c723f8`
- Last `git fetch origin` time: 2026-09-10 18:55 UTC
- Sync method: rebased onto origin/main
- Public diff command: `git diff origin/main...codex/f1-task-id-ref`
- Private evidence commit/path: task_da9eb7b39633d63348b33ebb7c task package report
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- The new integration test passes with the fix and fails without it (lead ran both).
- `npx tsc -b packages/daemon` and `node tools/run-manifest-gates.mjs --changed origin/main` pass.
- Not run: the full `npm run check` / `npm test` locally. Local agents must not run the full matrix, so CI is the full authority.

## Review Evidence

- Lead review: acceptance and replay now share one grammar; ids starting with `task_` or containing `-` are unaffected.
- Reviewer subagent: not used
- Human review: pending
- Blocking findings: none

## Residual Risk

- Scripts that created tasks with bare ids such as `t0` now get `invalid_task_id`.

## References

- Task: task_da9eb7b39633d63348b33ebb7c
- Bench report: task_34935988e63cb55291ca3c5ada (F1)

---

# 中文

## 概要

一个无法组成 `task/<id>` 实体引用的 Task id，会让整个仓库永久不可用。2026-09-11 的规模 Bench 在 Docker 里复现了这个问题：`ha task create --id t0 --admin` 被受理；第一次 `ha fact record t0` 会自动写一条 `task/t0 --produces--> fact/F-…` 关系。store 受理了这条关系，投影回放却拒绝它，于是仓库 cell 变成 `unavailable`，报错 `Relation endpoints must be canonical registered Entity refs`，此后每次重启回放都会再次失败。现在 task create 使用与回放相同的 `parseEntityRef` 语法，在写入任何东西之前就以 `invalid_task_id` 拒绝这类 id。

## 改动内容

- `repo-cell-task-create.ts`：显式 task id 如果不能被 `parseEntityRef` 解析成 task 引用，就拒绝。
- `task-surface.integration.test.ts`：`t0` 被拒绝，仓库保持可用；去掉修复后该测试失败。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 删除的门或 fixture：none
- 生产净行数：+6/-0 (net +6)，由 `node tools/gates/production-delta.mjs --base origin/main` 计算。

## 机读声明说明

- 本 PR 不涉及依赖变化和事件迁移，没有机读声明。

## 任务与范围

- Harness 任务：task_da9eb7b39633d63348b33ebb7c
- 分支：`codex/f1-task-id-ref`
- 公开范围：task create 的受理校验
- 私有计划 / 证据是否已更新：yes（任务计划与 worker 报告）
- 范围外：修复已经含有这类事件的仓库；目前没有任何 canonical 台账含有

## 版本影响

- 版本：不改版本
- 发布影响：不发布

## 治理声明

- 是否触碰 protected surface：no
- protected surface 范围：不适用
- 依据：不适用
- 机器检查边界：本 PR 只声明该段存在；声明是否真实、充分，由 reviewer 判断。
- Break-glass：no
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- `origin/main` 基准 SHA：`779c723f8`
- 当前分支与 `origin/main` 的 merge-base：`779c723f8`
- 最近一次 `git fetch origin` 时间：2026-09-10 18:55 UTC
- 同步方式：rebase 到 origin/main
- 公开 diff 命令：`git diff origin/main...codex/f1-task-id-ref`
- 私有证据 commit/path：task_da9eb7b39633d63348b33ebb7c 任务包报告
- Reviewer 证据路径：见本 PR 的「审查证据」一节
- GitHub Actions `rewrite-ci` run URL：本 PR 的 CI 还在跑
- [ ] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- 新集成测试在有修复时通过、去掉修复时失败（主控两边都跑过）。
- `npx tsc -b packages/daemon` 与 `node tools/run-manifest-gates.mjs --changed origin/main` 通过。
- 未运行：本地整套 `npm run check` / `npm test`。规定禁止本地 agent 跑全量矩阵，全量以 CI 为准。

## 审查证据

- 主控审查：受理与回放现在共用同一套语法；以 `task_` 开头或含 `-` 的 id 不受影响。
- Reviewer subagent：未使用
- 人工审查：待进行
- 阻塞发现：无

## 残余风险

- 用 `t0` 这类裸 id 创建任务的脚本，现在会收到 `invalid_task_id`。

## 关联材料

- Task: task_da9eb7b39633d63348b33ebb7c
- Bench report: task_34935988e63cb55291ca3c5ada (F1)

---

## PR Gate Checklist / PR 门禁清单

- [x] Branch is based on latest `origin/main`. / 分支基于最新 `origin/main`。
- [x] PR body uses this full template structure. / PR 描述使用本模板完整结构。
- [x] PR body uses two complete language blocks: `# English` first, then `# 中文`. / PR 正文使用两块完整正文：`# English` 在上，`# 中文` 在下。
- [x] PR body passes `tools/check-pr-body-bilingual.mjs`. / PR 正文通过 `tools/check-pr-body-bilingual.mjs`。
- [x] If the PR touches a manifest-derived protected surface, Governance Declaration is filled with ADR/decision/task evidence or break-glass fields. / 若 PR 触碰 manifest 派生的 protected surface，Governance Declaration 已填写 ADR/decision/task 依据或 break-glass 字段。
- [x] No private harness files are included. / 不包含私有 harness 文件。
- [x] No ignored local agent entry files are included. / 不包含被忽略的本地 agent 入口文件。
- [x] No absolute local filesystem paths are included in this public PR body. / 本公开 PR 描述不包含本机绝对路径。
- [x] Public diff is limited to the stated task scope. / 公开 diff 限于声明的任务范围。
- [x] Private planning/evidence updates are recorded when applicable. / 适用时已记录私有计划 / 证据更新。
- [x] Version and publish impact are stated. / 已说明版本与发布影响。
- [x] Local verification commands are recorded honestly. / 已如实记录本地验证命令。
- [ ] CI results are linked or explained. / CI 结果已链接或说明。
- [x] Review evidence is recorded. / 已记录审查证据。
- [x] Open P0/P1/P2 findings are closed, deferred with owner, or explicitly blocked. / open P0/P1/P2 findings 已关闭、带 owner 延后，或明确阻塞。
- [x] Merge method and post-merge branch cleanup plan are clear. / 合并方式和合并后分支清理计划清楚。
- [x] No admin bypass is planned unless explicitly approved and recorded. / 除非明确批准并记录，否则不计划 admin bypass。
