### PR TITLE
fix(daemon): dispatch reclaims orphaned leases; order executions by iteration

### DIFF
--- a/packages/daemon/src/repo-cell-open.ts
+++ b/packages/daemon/src/repo-cell-open.ts
@@ -804,9 +804,7 @@ export async function openRepoWriterCell(
           heldRuntimeSessionId !== null &&
           heldRuntimeSessionId === fromRuntimeSessionId &&
           isSamePerson(lease.actor, binding.actor);
-      // An orphaned lease's holder session has already ended (it is definitionally past
-      // expiresAt), so any dispatcher may reclaim it; the ownership check below only
-      // guards a still-live held lease against being stolen from its active holder.
+      // An orphaned lease is past expiresAt; the release rule decides who may reclaim it.
       if (lease.phase === "held" && !dispatcherOwnsLease && !trustedRuntimeHandoff)
         throw cellCodedError(
           "lease_conflict",
@@ -819,7 +817,7 @@ export async function openRepoWriterCell(
         },
         releaseBinding = authorizeRuntimeAction(
           releaseAction,
-          { ...binding, actor: lease.actor },
+          lease.phase === "orphaned" ? binding : { ...binding, actor: lease.actor },
           `runtime-task-handoff-release:${taskId}:${runtimeSessionId}:${String(lease.version)}`,
         ),
         released = await operationalContext.taskSurfaceWrite(releaseAction, releaseBinding);

--- a/packages/daemon/src/repo-cell-open.ts
+++ b/packages/daemon/src/repo-cell-open.ts
@@ -791,7 +791,10 @@ export async function openRepoWriterCell(
           execution.iteration === snapshot.task?.iteration &&
           execution.state === "active",
       )?.executionId;
-    if (lease?.phase === "held" && !isSameExecution(lease.actor, runtimeBinding.actor)) {
+    if (
+      (lease?.phase === "held" || lease?.phase === "orphaned") &&
+      !isSameExecution(lease.actor, runtimeBinding.actor)
+    ) {
       const heldRuntimeSessionId =
           lease.actor.executor?.kind === "agent" && lease.actor.executor.id.startsWith("runtime-session:")
             ? lease.actor.executor.id.slice("runtime-session:".length)
@@ -801,7 +804,10 @@ export async function openRepoWriterCell(
           heldRuntimeSessionId !== null &&
           heldRuntimeSessionId === fromRuntimeSessionId &&
           isSamePerson(lease.actor, binding.actor);
-      if (!dispatcherOwnsLease && !trustedRuntimeHandoff)
+      // An orphaned lease's holder session has already ended (it is definitionally past
+      // expiresAt), so any dispatcher may reclaim it; the ownership check below only
+      // guards a still-live held lease against being stolen from its active holder.
+      if (lease.phase === "held" && !dispatcherOwnsLease && !trustedRuntimeHandoff)
         throw cellCodedError(
           "lease_conflict",
           `Task ${taskId} is held by another RuntimeSession; wait for it to settle before dispatching again.`,

--- a/packages/daemon/src/runtime-spawner.ts
+++ b/packages/daemon/src/runtime-spawner.ts
@@ -258,7 +258,7 @@ export function makeRuntimeSpawner(input: RuntimeSpawnerInput) {
         dispatchLeaseExecutor = `runtime-session:${runtimeSessionId}`,
         trustedSourceExecutor = trustedHandoffSource ? `runtime-session:${trustedHandoffSource}` : null;
       const leaseQualifies =
-        leaseAtAdmission === null || leaseAtAdmission.phase === "released"
+        leaseAtAdmission === null || leaseAtAdmission.phase === "released" || leaseAtAdmission.phase === "orphaned"
           ? input.handoffTaskLease !== undefined
           : leaseAtAdmission.phase === "held" &&
             isSamePerson(leaseAtAdmission.actor, binding.actor) &&

--- a/packages/daemon/test/runtime-spawn-lifecycle.integration.test.ts
+++ b/packages/daemon/test/runtime-spawn-lifecycle.integration.test.ts
@@ -1529,6 +1529,131 @@ test(
   },
 );
 
+test("dispatch reclaims an orphaned task lease instead of requiring a manual release", async () => {
+  const root = mkdtempSync(path.join(tmpdir(), "ha-runtime-orphan-lease-"));
+  let clock = "2026-09-11T00:00:00.000Z";
+  try {
+    initIngressRepo(root, 4313);
+    const cell = await openRepoCell({
+      repoId: workspaceId("runtime-orphan-lease"),
+      rootDir: canonicalRoot(root),
+      ownerId: "orphan-lease-test",
+      now: () => clock,
+      runtimeDaemonRoute: {
+        userRoot: path.join(root, ".daemon-user"),
+        daemonId: "orphan-lease-test",
+        endpoint: path.join(root, ".daemon-user", "daemon.sock"),
+      },
+      runtimeInstances: () => [
+        {
+          schemaVersion: 2,
+          instanceId: definition.instanceId,
+          name: "Codex Orphan Lease",
+          kindId: definition.kindId,
+          installationId: definition.installationId,
+          providerId: definition.providerId,
+          models: [definition.model],
+          defaultModel: definition.model,
+          enabled: true,
+          permissionMode: "workspace-write",
+          codex: {},
+          authMode: definition.authMode,
+          authState: "configured",
+          authReadiness: { status: "ready", code: null, hint: null },
+          isolationState: "enforced",
+        },
+      ],
+      prepareRuntimeLaunch: async (_instanceId, request) => ({
+        definition,
+        installation,
+        executablePath: installation.executablePath,
+        args: ["exec", "--json", "-"],
+        env: process.env,
+        cwd: request.cwd,
+        prompt: request.prompt,
+      }),
+      runtimeLaunch: () => ({
+        pid: process.pid,
+        onOutput: () => undefined,
+        onErrorOutput: () => undefined,
+        onExit: () => undefined,
+        terminate: () => undefined,
+      }),
+    });
+    try {
+      const taskId = "task-runtime-orphan-lease",
+        executionId = "execution-runtime-orphan-lease",
+        binding = {
+          actor: { principal: { personId: "person-orphan-lease" }, executor: null },
+          source: "local" as const,
+        };
+      const created = await cell.run({ kind: "task-create", taskId, title: "Orphan lease dispatch" }, binding);
+      assert.equal(created.outcome, "applied");
+      await waitForFixturePublication(cell, created.opId, binding);
+      await realizeTaskPlanFixture(
+        root,
+        String((created as Record<string, unknown>).packagePath),
+        (planPath) => cell.run({ kind: "doc-submit", paths: [planPath] }, binding),
+        "Orphan lease dispatch",
+      );
+      assert.equal(
+        (
+          await cell.run(
+            {
+              kind: "task-start",
+              taskId,
+              executionId,
+              executor: { kind: "agent", id: "orphan-lease-worker" },
+              ttlMs: 60_000,
+            },
+            binding,
+          )
+        ).outcome,
+        "applied",
+      );
+      const held = String(
+        ((await cell.run({ kind: "task-show", taskId }, binding)) as Record<string, unknown>).summary,
+      );
+      assert.match(held, /\nlease: [^\n]*phase=held/u, held);
+      // Past the 60s TTL the lease projects as orphaned with no manual `ha task release`.
+      clock = "2026-09-11T00:01:01.000Z";
+      const lapsed = String(
+        ((await cell.run({ kind: "task-show", taskId }, binding)) as Record<string, unknown>).summary,
+      );
+      assert.match(lapsed, /\nlease: [^\n]*phase=orphaned/u, lapsed);
+      const receipt = await cell.spawnRuntime(
+        {
+          runtimeInstanceId: definition.instanceId,
+          cwd: { scope: "repo-root" },
+          prompt: "Reclaim the orphaned lease and continue the task.",
+          taskId,
+          idempotencyKey: "orphan-lease-reclaim",
+        },
+        binding,
+      );
+      assert.equal(receipt.outcome, "applied", JSON.stringify(receipt));
+      const projection = makeTaskProjection({
+        rootDir: root,
+        eventStore: makeTaskEventReader({ repoId: "runtime-orphan-lease", rootDir: root }),
+      });
+      try {
+        const snapshot = projection.read(taskId).snapshot;
+        assert.equal(snapshot.lease?.phase, "held");
+        assert.deepEqual(snapshot.lease?.actor.executor, {
+          kind: "agent",
+          id: `runtime-session:${receipt.runtimeSessionId}`,
+        });
+      } finally {
+        projection.close();
+      }
+    } finally {
+      await cell.close();
+    }
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test("runtime exit notification records a bounded timeout", async () => {
   const root = mkdtempSync(path.join(tmpdir(), "ha-runtime-exit-notification-")),
     executablePath = writeProviderExecutable(

--- a/packages/daemon/test/runtime-spawn-lifecycle.integration.test.ts
+++ b/packages/daemon/test/runtime-spawn-lifecycle.integration.test.ts
@@ -1621,6 +1621,20 @@ test("dispatch reclaims an orphaned task lease instead of requiring a manual rel
         ((await cell.run({ kind: "task-show", taskId }, binding)) as Record<string, unknown>).summary,
       );
       assert.match(lapsed, /\nlease: [^\n]*phase=orphaned/u, lapsed);
+      // Only the same principal or the task owner may reclaim it; another person is refused.
+      await assert.rejects(
+        cell.spawnRuntime(
+          {
+            runtimeInstanceId: definition.instanceId,
+            cwd: { scope: "repo-root" },
+            prompt: "Reclaim another person's orphaned lease.",
+            taskId,
+            idempotencyKey: "orphan-lease-stranger",
+          },
+          { ...binding, actor: { principal: { personId: "person-orphan-stranger" }, executor: null } },
+        ),
+        /same principal reclaiming an orphaned lease/u,
+      );
       const receipt = await cell.spawnRuntime(
         {
           runtimeInstanceId: definition.instanceId,

--- a/packages/kernel/src/projection/rebuildable-task-projection-runtime.ts
+++ b/packages/kernel/src/projection/rebuildable-task-projection-runtime.ts
@@ -123,7 +123,7 @@ export function readSnapshot(db: DatabaseSync, taskId: string, now?: string): Ta
       db,
       [
         "SELECT value_json FROM entity_projection WHERE entity_kind = 'execution' AND task_id = ?",
-        "ORDER BY json_extract(value_json, '$.iteration'), json_extract(value_json, '$.claimedAt')",
+        "ORDER BY json_extract(value_json, '$.iteration'), json_extract(value_json, '$.claimedAt'), entity_id",
       ].join(" "),
       taskId,
     ).map((value) => JSON.parse(String(value.value_json)) as TaskLifecycleSnapshot["executions"][number]),

--- a/packages/kernel/src/projection/rebuildable-task-projection-runtime.ts
+++ b/packages/kernel/src/projection/rebuildable-task-projection-runtime.ts
@@ -121,7 +121,10 @@ export function readSnapshot(db: DatabaseSync, taskId: string, now?: string): Ta
     throw new Error(`projection snapshot mismatch for task ${taskId}`);
   const executions = queryRows(
       db,
-      "SELECT value_json FROM entity_projection WHERE entity_kind = 'execution' AND task_id = ? ORDER BY entity_id",
+      [
+        "SELECT value_json FROM entity_projection WHERE entity_kind = 'execution' AND task_id = ?",
+        "ORDER BY json_extract(value_json, '$.iteration'), json_extract(value_json, '$.claimedAt')",
+      ].join(" "),
       taskId,
     ).map((value) => JSON.parse(String(value.value_json)) as TaskLifecycleSnapshot["executions"][number]),
     reviews = queryRows(

--- a/packages/kernel/test/store/task-lifecycle-fixture.ts
+++ b/packages/kernel/test/store/task-lifecycle-fixture.ts
@@ -142,11 +142,109 @@ export function lifecycleFixture(
   return { events, snapshot };
 }
 
+export function twoRoundLifecycleEvents(
+  options: {
+    readonly taskId?: string;
+    readonly firstExecutionId?: string;
+    readonly secondExecutionId?: string;
+  } = {},
+): {
+  readonly events: readonly TaskEventV1[];
+  readonly snapshot: TaskLifecycleSnapshot;
+} {
+  const taskId = options.taskId ?? "task-two-round",
+    firstExecutionId = options.firstExecutionId ?? "execution-round-one",
+    secondExecutionId = options.secondExecutionId ?? "execution-round-two";
+  const events: TaskEventV1[] = [];
+  let snapshot = emptyTaskLifecycleSnapshot();
+  const run = (
+    command: TaskLifecycleCommand,
+    proof: CreateReplayTaskProof | StartExecutionProof | SubmitExecutionProof | ReviewProof,
+  ) => {
+    const result = applyTransition(snapshot, command, proof as never);
+    snapshot = result.snapshot;
+    events.push(result.event);
+  };
+  run(
+    command(implementer, 1, {
+      type: "CreateReplayTask",
+      taskId,
+      title: "Two-round fixture",
+      taskClass: "standard",
+      graph: REPLAY_TASK_GRAPH,
+      completionGateIds: [],
+      presetSnapshotDigest: null,
+    }),
+    { taskIdUnique: true, actorBinding: implementer },
+  );
+  run(
+    command(implementer, 2, {
+      type: "StartExecution",
+      taskId,
+      executionId: firstExecutionId,
+    }),
+    {
+      actorBinding: implementer,
+      reservation: {
+        taskId,
+        executionId: firstExecutionId,
+        expiresAt: "2026-08-11T01:00:00.000Z",
+        ttlMs: 1_800_000,
+        previousHolder: null,
+        reason: "initial_claim",
+        version: 0,
+      },
+    },
+  );
+  run(
+    command(implementer, 3, {
+      type: "SubmitExecution",
+      taskId,
+      executionId: firstExecutionId,
+      submission: {
+        completionClaim: "implemented",
+        deliverables: [],
+        outputs: [],
+        verificationNotes: ["tests"],
+        knownGaps: [],
+        residualRisks: [],
+        commitSha,
+      },
+    }),
+    { actorBinding: implementer, leaseVersion: 0, sessionDisposition: "complete" },
+  );
+  run(reviewCommand(4, taskId, firstExecutionId, "changes_requested", "review-round-one"), {
+    actorBinding: reviewer,
+    capability: "execution-review@v1",
+    capabilityRef: "cap-review",
+  });
+  run(
+    command(implementer, 5, {
+      type: "StartExecution",
+      taskId,
+      executionId: secondExecutionId,
+    }),
+    {
+      actorBinding: implementer,
+      reservation: {
+        taskId,
+        executionId: secondExecutionId,
+        expiresAt: "2026-08-11T01:05:00.000Z",
+        ttlMs: 1_800_000,
+        previousHolder: null,
+        reason: "initial_claim",
+        version: 0,
+      },
+    },
+  );
+  return { events, snapshot };
+}
+
 function reviewCommand(
   revision: number,
   taskId: string,
   executionId: string,
-  verdict: "approved",
+  verdict: "approved" | "changes_requested",
   reviewId: string,
 ): RecordReviewCommand {
   const submission = {

--- a/packages/kernel/test/store/task-projection.test.ts
+++ b/packages/kernel/test/store/task-projection.test.ts
@@ -34,7 +34,7 @@ import {
 } from "../../src/domain/migration-import-event.ts";
 import { OPAQUE_TEXTUAL_POLICY_ID } from "../../src/domain/artifact-text-classification.ts";
 import { sha256Text } from "../../src/integrity/stable-hash.ts";
-import { lifecycleFixture } from "./task-lifecycle-fixture.ts";
+import { lifecycleFixture, twoRoundLifecycleEvents } from "./task-lifecycle-fixture.ts";
 import { withTempStoreAsync } from "./helpers.ts";
 
 test("task/doc reducers share one SQLite transaction and L2 rebuild restores exact document bytes", async () => {
@@ -769,6 +769,35 @@ test("steady apply and rebuild use the same reducer and reproduce watermark, op 
     assert.equal(projection.read("task-1").snapshot.task?.title, "Fixture");
     projection.rebuild();
     assert.equal(projection.read("task-1").snapshot.executions[0]?.state, "accepted");
+  });
+});
+
+test("executions project in iteration order regardless of internal entity id ordering", async () => {
+  await withTempStoreAsync(async (rootDir) => {
+    initRepo(rootDir);
+    const eventStore = makeTaskEventStore({ repoId: "test-repo", rootDir }),
+      projection = makeTaskProjection({ rootDir, eventStore }),
+      { events } = twoRoundLifecycleEvents({
+        taskId: "task-execution-order",
+        // Alphabetically reversed against arrival order: a naive `ORDER BY entity_id`
+        // would list the second round before the first.
+        firstExecutionId: "execution-zz-round-one",
+        secondExecutionId: "execution-aa-round-two",
+      });
+    for (const event of events) {
+      eventStore.append(taskBundle(event));
+      projection.apply(event);
+    }
+    assert.deepEqual(
+      projection.read("task-execution-order").snapshot.executions.map((execution) => ({
+        executionId: execution.executionId,
+        iteration: execution.iteration,
+      })),
+      [
+        { executionId: "execution-zz-round-one", iteration: 0 },
+        { executionId: "execution-aa-round-two", iteration: 1 },
+      ],
+    );
   });
 });
 


### PR DESCRIPTION
# English

## Summary

Two lifecycle defects hit tonight's closeout work. First, when a runtime lease expired (projected as `orphaned`), `ha runtime run --task` refused to dispatch until a human ran `ha task release`; runtime admission only accepted `null`/`released`/`held`. Dispatch now releases an orphaned lease and starts the new session. The release is written with the dispatcher's own identity, so the existing release rule decides who may reclaim it: the same principal or the task owner; anyone else is refused. Second, `ha task show --json` listed `evidence.executions` in entity-id hash order, so "last element = current execution" was wrong for multi-round tasks. Executions are now ordered by iteration and claim time.

## What Changed

- `repo-cell-open.ts` handoff: an orphaned lease is released and restarted; a held lease still requires ownership or a trusted runtime handoff.
- `runtime-spawner.ts`: runtime admission treats an orphaned lease like a released one.
- `rebuildable-task-projection-runtime.ts`: executions ordered by `iteration`, then `claimedAt`.
- Tests: orphaned-lease dispatch succeeds for the same person and is refused for another person; two-round execution order.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: +12/-5 (net +7), from `node tools/gates/production-delta.mjs --base origin/main`.

## Machine-Readable Declarations

## Task And Scope

- Harness task: task_c4c1b2963802e3be7825ef1bda
- Branch: `codex/orphan-lease-dispatch`
- Public scope: runtime dispatch over expired leases; execution ordering in task reads
- Private planning/evidence updated: yes (task plan and worker report)
- Out of scope: lease TTL policy; the WIP admission bypass (separate PR)

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: not applicable
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `779c723f8`
- Branch merge-base with `origin/main`: `779c723f8`
- Last `git fetch origin` time: 2026-09-10 19:20 UTC
- Sync method: rebased onto origin/main
- Public diff command: `git diff origin/main...codex/orphan-lease-dispatch`
- Private evidence commit/path: task_c4c1b2963802e3be7825ef1bda task package report
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- `node --test packages/daemon/test/runtime-spawn-lifecycle.integration.test.ts packages/kernel/test/store/task-projection.test.ts`: 34/34.
- Negative control: with the worker's first version, which released as the lease holder, the other-person dispatch succeeded and the new assertion failed (`Missing expected rejection`).
- `npx tsc -b packages/daemon`, line-density, production-delta pass.
- Not run: the full `npm run check` / `npm test` locally. Local agents must not run the full matrix, so CI is the full authority.

## Review Evidence

- Lead review found the first version impersonated the lease holder on release, bypassing the release rule for orphaned leases; fixed in the third commit.
- Independent Sol review (one round, report in the task package): no reachable path to steal a live lease or reclaim another person's orphaned lease; it found that the new execution order had no final unique key when iteration and `claimedAt` tie or are missing. Fixed by keeping `entity_id` as the last sort key (fourth commit).
- Reviewer subagent: not used
- Human review: pending
- Blocking findings: none

## Residual Risk

- An orphaned lease held by a different person still needs that person, the task owner, or an admin release.

## References

- Task: task_c4c1b2963802e3be7825ef1bda

---

# 中文

## 概要

今晚的收口工作撞上两个生命周期缺陷。其一，runtime 租约过期（投影为 `orphaned`）后，`ha runtime run --task` 拒绝派工，必须有人手动 `ha task release`；原因是 runtime 受理只认 `null`/`released`/`held`。现在派工会先释放孤儿租约，再启动新 session。释放以派工者自己的身份写入，由既有 release 规则裁决谁能回收：同一 principal 或任务 owner 可以，其他人被拒。其二，`ha task show --json` 的 `evidence.executions` 按实体 id 的哈希排序，多轮任务里「最后一个就是当前 execution」不成立。现在按 iteration 与认领时间排序。

## 改动内容

- `repo-cell-open.ts` 的 handoff：孤儿租约先释放再启动；held 租约仍要求所有权或可信的 runtime 交接。
- `runtime-spawner.ts`：runtime 受理把孤儿租约当作已释放处理。
- `rebuildable-task-projection-runtime.ts`：executions 按 `iteration`、再按 `claimedAt` 排序。
- 测试：同一人对孤儿租约派工成功、另一人被拒；两轮 execution 的顺序。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 删除的门或 fixture：none
- 生产净行数：+12/-5 (net +7)，由 `node tools/gates/production-delta.mjs --base origin/main` 计算。

## 机读声明说明

- 本 PR 不涉及依赖变化和事件迁移，没有机读声明。

## 任务与范围

- Harness 任务：task_c4c1b2963802e3be7825ef1bda
- 分支：`codex/orphan-lease-dispatch`
- 公开范围：过期租约上的 runtime 派工；task 读取中的 execution 排序
- 私有计划 / 证据是否已更新：yes（任务计划与 worker 报告）
- 范围外：租约 TTL 策略；WIP 受理旁路（另一个 PR）

## 版本影响

- 版本：不改版本
- 发布影响：不发布

## 治理声明

- 是否触碰 protected surface：no
- protected surface 范围：不适用
- 依据：不适用
- 机器检查边界：本 PR 只声明该段存在；声明是否真实、充分，由 reviewer 判断。
- Break-glass：no
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- `origin/main` 基准 SHA：`779c723f8`
- 当前分支与 `origin/main` 的 merge-base：`779c723f8`
- 最近一次 `git fetch origin` 时间：2026-09-10 19:20 UTC
- 同步方式：rebase 到 origin/main
- 公开 diff 命令：`git diff origin/main...codex/orphan-lease-dispatch`
- 私有证据 commit/path：task_c4c1b2963802e3be7825ef1bda 任务包报告
- Reviewer 证据路径：见本 PR 的「审查证据」一节
- GitHub Actions `rewrite-ci` run URL：本 PR 的 CI 还在跑
- [ ] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- `node --test packages/daemon/test/runtime-spawn-lifecycle.integration.test.ts packages/kernel/test/store/task-projection.test.ts`：34/34。
- 阴性对照：换回 worker 第一版（以租约持有人身份释放），另一人的派工会成功，新断言失败（`Missing expected rejection`）。
- `npx tsc -b packages/daemon`、line-density、production-delta 通过。
- 未运行：本地整套 `npm run check` / `npm test`。规定禁止本地 agent 跑全量矩阵，全量以 CI 为准。

## 审查证据

- 主控审查发现第一版在释放时冒用租约持有人身份，绕过了孤儿租约的 release 规则；第三个提交已修正。
- Sol 独立评审一轮（报告在任务包）：没有可达路径能抢走活租约或回收别人的孤儿租约；指出新的 execution 排序在 iteration 与 `claimedAt` 相同或缺失时没有最终唯一键。已把 `entity_id` 保留为最后一个排序键（第四个提交）。
- Reviewer subagent：未使用
- 人工审查：待进行
- 阻塞发现：无

## 残余风险

- 别人持有的孤儿租约，仍需要持有人、任务 owner 或管理员来释放。

## 关联材料

- Task: task_c4c1b2963802e3be7825ef1bda

---

## PR Gate Checklist / PR 门禁清单

- [x] Branch is based on latest `origin/main`. / 分支基于最新 `origin/main`。
- [x] PR body uses this full template structure. / PR 描述使用本模板完整结构。
- [x] PR body uses two complete language blocks: `# English` first, then `# 中文`. / PR 正文使用两块完整正文：`# English` 在上，`# 中文` 在下。
- [x] PR body passes `tools/check-pr-body-bilingual.mjs`. / PR 正文通过 `tools/check-pr-body-bilingual.mjs`。
- [x] If the PR touches a manifest-derived protected surface, Governance Declaration is filled with ADR/decision/task evidence or break-glass fields. / 若 PR 触碰 manifest 派生的 protected surface，Governance Declaration 已填写 ADR/decision/task 依据或 break-glass 字段。
- [x] No private harness files are included. / 不包含私有 harness 文件。
- [x] No ignored local agent entry files are included. / 不包含被忽略的本地 agent 入口文件。
- [x] No absolute local filesystem paths are included in this public PR body. / 本公开 PR 描述不包含本机绝对路径。
- [x] Public diff is limited to the stated task scope. / 公开 diff 限于声明的任务范围。
- [x] Private planning/evidence updates are recorded when applicable. / 适用时已记录私有计划 / 证据更新。
- [x] Version and publish impact are stated. / 已说明版本与发布影响。
- [x] Local verification commands are recorded honestly. / 已如实记录本地验证命令。
- [ ] CI results are linked or explained. / CI 结果已链接或说明。
- [x] Review evidence is recorded. / 已记录审查证据。
- [x] Open P0/P1/P2 findings are closed, deferred with owner, or explicitly blocked. / open P0/P1/P2 findings 已关闭、带 owner 延后，或明确阻塞。
- [x] Merge method and post-merge branch cleanup plan are clear. / 合并方式和合并后分支清理计划清楚。
- [x] No admin bypass is planned unless explicitly approved and recorded. / 除非明确批准并记录，否则不计划 admin bypass。

