### PR TITLE
fix(daemon): admit WIP on every task-start path and read only the occupying worktable

### DIFF
--- a/packages/daemon/src/repo-cell-action-dispatch.ts
+++ b/packages/daemon/src/repo-cell-action-dispatch.ts
@@ -159,13 +159,8 @@ export async function executeAction(
       targetRevision = targetId
         ? cell.projection.read(targetId).snapshot.revision
         : (cell.store.readHead()?.revision ?? 0),
-      lifecycle = actionContract.execution.lifecycle,
-      leasedStart =
-        lifecycle?.coordination === "reserve" &&
-        targetId !== null &&
-        ["held", "reserving"].includes(cell.projection.currentLease(targetId, cell.now())?.phase ?? "");
-    if (lifecycle?.coordination === "reserve" && targetId && !leasedStart)
-      cell.assertTaskWipCapacity(targetId, "active");
+      lifecycle = actionContract.execution.lifecycle;
+    if (lifecycle?.coordination === "reserve" && targetId) cell.assertTaskWipCapacity(targetId, "active");
     return cell.entityActionExecutor.run(
       action,
       binding,

--- a/packages/daemon/src/repo-cell-open.ts
+++ b/packages/daemon/src/repo-cell-open.ts
@@ -566,6 +566,7 @@ export async function openRepoWriterCell(
         binding,
         snapshot: projection.read(taskId).snapshot as Snapshot,
         start: (executionId) => {
+          extracted.assertTaskWipCapacity(taskId, "active");
           const action = { kind: "task-start", taskId, ...(executionId ? { executionId } : {}) },
             revision = store.readHead()?.revision ?? 0,
             authorizationDecision = authorizeRepoCellAction({
@@ -830,6 +831,7 @@ export async function openRepoWriterCell(
       if (lease?.phase === "held" || lease?.phase === "reserving")
         throw cellCodedError("lease_conflict", `Task ${taskId} lease remained active after dispatch handoff release.`);
     }
+    operationalContext.assertTaskWipCapacity(taskId, "active");
     const startAction = { kind: "task-start", taskId, ...(executionId ? { executionId } : {}) },
       startBinding = authorizeRuntimeAction(
         startAction,

--- a/packages/daemon/src/repo-cell-task-query.ts
+++ b/packages/daemon/src/repo-cell-task-query.ts
@@ -43,7 +43,7 @@ export interface TaskQueryCell {
   ) => WriteReceipt;
   readonly cellCodedError: (code: string, message: string, diagnostic?: ReceiptDiagnostic) => Error;
   readonly requiredCellText: (value: unknown, name: string) => string;
-  readonly wipSnapshotEntries: () => readonly TaskWipSnapshotEntryV1[];
+  readonly wipSnapshotEntries: (activatingTaskId: string) => readonly TaskWipSnapshotEntryV1[];
   readonly legacyReviewLint: typeof import("./repo-cell-review-lint.ts").legacyReviewLint;
   readonly projectionReady: (value: { readonly status: string }) => boolean;
   readonly now: () => string;
@@ -195,7 +195,7 @@ export function taskWipEnteringAction(
 }
 
 export function assertTaskWipCapacity(cell: TaskQueryCell, taskId: string, nextStatus: DomainStatus): void {
-  const tasks = cell.wipSnapshotEntries(),
+  const tasks = cell.wipSnapshotEntries(taskId),
     activating = tasks.find((task: TaskWipSnapshotEntryV1) => task.taskId === taskId);
   if (!activating) return;
   const allowed =
@@ -219,21 +219,28 @@ export function assertTaskWipCapacity(cell: TaskQueryCell, taskId: string, nextS
     );
 }
 
-export function wipSnapshotEntries(cell: TaskQueryCell): readonly TaskWipSnapshotEntryV1[] {
-  const rows = cell.projection.list().rows,
-    childCounts = directChildCountsFrom(rows);
-  return rows.map((row) => {
-    const task = row.snapshot.task;
-    return {
-      taskId: row.taskId,
-      title: task?.title ?? "",
-      status: task?.status ?? "planned",
-      taskClass: task?.taskClass ?? "standard",
-      packageDisposition: requiredPackageDisposition(row.taskId, task?.packageDisposition),
-      hasCloseoutEvidence: hasCloseoutEvidence(row.snapshot.executions),
-      directChildCount: childCounts.get(row.taskId) ?? 0,
-    };
-  });
+// Only WIP-occupying task rows (plus the activating task itself, which may still be
+// planned) are read: one SQL-status-filtered list() call per occupying status, so the row
+// count stays bounded by the worktable rather than the whole task ledger. Each row's
+// directChildCount comes from a parentTaskId-filtered index read, which is bounded by that
+// task's actual child count instead of a full-table scan.
+export function wipSnapshotEntries(cell: TaskQueryCell, activatingTaskId: string): readonly TaskWipSnapshotEntryV1[] {
+  const occupying = taskWipOccupyingStatuses.flatMap((status) => cell.projection.list({ status }).rows),
+    activating = occupying.some((row) => row.taskId === activatingTaskId)
+      ? null
+      : cell.projection.read(activatingTaskId),
+    rows = activating?.snapshot.task
+      ? [...occupying, { taskId: activatingTaskId, snapshot: activating.snapshot }]
+      : occupying;
+  return rows.map((row) => ({
+    taskId: row.taskId,
+    title: row.snapshot.task?.title ?? "",
+    status: row.snapshot.task?.status ?? "planned",
+    taskClass: row.snapshot.task?.taskClass ?? "standard",
+    packageDisposition: requiredPackageDisposition(row.taskId, row.snapshot.task?.packageDisposition),
+    hasCloseoutEvidence: hasCloseoutEvidence(row.snapshot.executions),
+    directChildCount: cell.projection.readTaskIndex({ parentTaskId: row.taskId }).rows.length,
+  }));
 }
 
 export function directChildCounts(cell: TaskQueryCell): Map<string, number> {

--- a/packages/daemon/test/runtime-spawn-lifecycle.integration.test.ts
+++ b/packages/daemon/test/runtime-spawn-lifecycle.integration.test.ts
@@ -24,6 +24,7 @@ import {
 import { launchExitNotification } from "../src/runtime-spawn.ts";
 import { writeProviderExecutable } from "./fixtures/runtime-stub.ts";
 import { realizeTaskPlanFixture } from "../../../tools/fixtures/task-plan.mjs";
+import { TASK_WIP_LIMIT_ENV } from "../src/task-wip-settings.ts";
 
 const definition: AgentDefinitionSnapshot = {
   schema: "agent-definition-snapshot/v1",
@@ -1707,6 +1708,123 @@ test("runtime exit notification records a bounded timeout", async () => {
     );
     assert.equal(finished.occurredAt, "2026-08-23T00:00:00.000Z");
   } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("runtime dispatch of a planned task is rejected at a full worktable", async () => {
+  const root = mkdtempSync(path.join(tmpdir(), "ha-runtime-wip-full-"));
+  const previousLimit = process.env[TASK_WIP_LIMIT_ENV];
+  process.env[TASK_WIP_LIMIT_ENV] = "1";
+  let launchCount = 0;
+  try {
+    initIngressRepo(root, 4312);
+    const cell = await openRepoCell({
+      repoId: workspaceId("runtime-wip-full"),
+      rootDir: canonicalRoot(root),
+      ownerId: "runtime-wip-full-test",
+      runtimeDaemonRoute: {
+        userRoot: path.join(root, ".daemon-user"),
+        daemonId: "runtime-wip-full-test",
+        endpoint: path.join(root, ".daemon-user", "daemon.sock"),
+      },
+      runtimeInstances: () => [
+        {
+          schemaVersion: 2,
+          instanceId: definition.instanceId,
+          name: "Codex WIP Full",
+          kindId: definition.kindId,
+          installationId: definition.installationId,
+          providerId: definition.providerId,
+          models: [definition.model],
+          defaultModel: definition.model,
+          enabled: true,
+          permissionMode: "workspace-write",
+          codex: {},
+          authMode: definition.authMode,
+          authState: "configured",
+          authReadiness: { status: "ready", code: null, hint: null },
+          isolationState: "enforced",
+        },
+      ],
+      prepareRuntimeLaunch: async (_instanceId, request) => ({
+        definition,
+        installation,
+        executablePath: installation.executablePath,
+        args: ["exec", "--json", "-"],
+        env: process.env,
+        cwd: request.cwd,
+        prompt: request.prompt,
+      }),
+      runtimeLaunch: () => {
+        launchCount += 1;
+        return {
+          pid: process.pid,
+          onOutput: () => undefined,
+          onErrorOutput: () => undefined,
+          onExit: () => undefined,
+          terminate: () => undefined,
+        };
+      },
+    });
+    try {
+      const binding = {
+        actor: { principal: { personId: "person-wip-full" }, executor: null },
+        source: "local" as const,
+      };
+      const occupant = await cell.run(
+        { kind: "task-create", taskId: "task-wip-full-occupant", title: "Occupant" },
+        binding,
+      );
+      assert.equal(occupant.outcome, "applied");
+      await waitForFixturePublication(cell, occupant.opId, binding);
+      await realizeTaskPlanFixture(
+        root,
+        String((occupant as Record<string, unknown>).packagePath),
+        (planPath) => cell.run({ kind: "doc-submit", paths: [planPath] }, binding),
+        "Occupant",
+      );
+      assert.equal(
+        (
+          await cell.run(
+            { kind: "task-start", taskId: "task-wip-full-occupant", executionId: "execution-wip-full-occupant" },
+            binding,
+          )
+        ).outcome,
+        "applied",
+      );
+      const planned = await cell.run(
+        { kind: "task-create", taskId: "task-wip-full-planned", title: "Planned dispatch target" },
+        binding,
+      );
+      assert.equal(planned.outcome, "applied");
+      await waitForFixturePublication(cell, planned.opId, binding);
+      await realizeTaskPlanFixture(
+        root,
+        String((planned as Record<string, unknown>).packagePath),
+        (planPath) => cell.run({ kind: "doc-submit", paths: [planPath] }, binding),
+        "Planned dispatch target",
+      );
+      await assert.rejects(
+        cell.spawnRuntime(
+          {
+            runtimeInstanceId: definition.instanceId,
+            cwd: { scope: "repo-root" },
+            prompt: "Dispatch a planned task while the worktable is full",
+            taskId: "task-wip-full-planned",
+            idempotencyKey: "wip-full-dispatch",
+          },
+          binding,
+        ),
+        (error: unknown) => error instanceof Error && "code" in error && error.code === "task_wip_limit_reached",
+      );
+      assert.equal(launchCount, 0, "the rejected dispatch must not launch a provider");
+    } finally {
+      await cell.close();
+    }
+  } finally {
+    if (previousLimit === undefined) delete process.env[TASK_WIP_LIMIT_ENV];
+    else process.env[TASK_WIP_LIMIT_ENV] = previousLimit;
     rmSync(root, { recursive: true, force: true });
   }
 });

--- a/packages/daemon/test/task-query-read.test.ts
+++ b/packages/daemon/test/task-query-read.test.ts
@@ -205,7 +205,7 @@ test("task reads fail closed when event truth has no packageDisposition", () => 
     cell = { projection } as unknown as TaskQueryCell;
 
   assert.throws(() => read.guiTasks(), /missing packageDisposition for task_missing/u);
-  assert.throws(() => wipSnapshotEntries(cell), /missing packageDisposition for task_missing/u);
+  assert.throws(() => wipSnapshotEntries(cell, "task_missing"), /missing packageDisposition for task_missing/u);
 });
 
 test("relation graph validator accepts the canonical cut and rejects invented fields", () => {

--- a/tools/gates/cost-budget.json
+++ b/tools/gates/cost-budget.json
@@ -203,13 +203,6 @@
     },
     "knownScaling": [
       {
-        "operation": "task-start",
-        "metric": "sqlRowsRead",
-        "reason": "task-start admits WIP through assertTaskWipCapacity -> wipSnapshotEntries (daemon repo-cell-task-query.ts), and projection.list() (kernel projection/rebuildable-task-projection-reads.ts listProjection) reads the whole task index (SELECT task_snapshot.task_id AS task_id, task_package.package_path ... FROM task_snapshot LEFT JOIN task_package LEFT JOIN task_generation ORDER BY task_snapshot.task_id) and then one readSnapshot per task (SELECT snapshot_json FROM task_snapshot WHERE task_id = ?, plus relation_edge/entity-freshness reads that list sqlite_master for every task carrying a relation); about 3 rows per task.",
-        "deletionTaskId": "task_2b8f79fa4412cb726a26f9bfc7",
-        "expiresAt": "2026-09-24T00:00:00.000Z"
-      },
-      {
         "operation": "decision-propose",
         "metric": "sqlRowsRead",
         "reason": "entity-action-catalog-executor.ts compileDraft calls projection.readDecisionGraph() only to keep the edges owned by this one decision; readDecisionGraphRows builds the whole graph including decisionCoverage (kernel projection/decision-projection-coverage.ts), which reads every task (SELECT task_id,json_extract(snapshot_json,'$.task.status') AS status FROM task_snapshot ORDER BY task_id), every fact (SELECT ref FROM fact ORDER BY ref), and every decision, claim, option and relation edge. The replacement-authorization backward scan named in the task plan is now a per-process cache (#2410) and shows only in the first call.",


### PR DESCRIPTION
# English

## Summary

The WIP limit (30) was bypassed: the ledger showed 42 occupying tasks. Runtime dispatch reserves the task lease and then starts the task through `handoffTaskLease`, which calls the lifecycle action directly and never passes through `executeAction`'s admission check; squad first-round dispatch does the same. On top of that, `executeAction` skipped admission whenever the task already had a held or reserving lease. Revision 65139 is the causal anchor: a runtime dispatch took occupancy from 30 to 31. All three paths now run `assertTaskWipCapacity`; for a task that is already active the check is idempotent. WIP admission also no longer reads the whole task ledger: it reads only the rows in occupying statuses plus the task being activated.

## What Changed

- `repo-cell-action-dispatch.ts`: delete the `leasedStart` exemption.
- `repo-cell-open.ts`: admission before the start in `handoffTaskLease` and in the squad `reacquireTaskLease` start.
- `repo-cell-task-query.ts` `wipSnapshotEntries`: per-status SQL-filtered lists plus the activating task; child counts from a parent-filtered index read.
- `tools/gates/cost-budget.json`: delete the `task-start` knownScaling exemption that G38 now reports as stale.
- Test: runtime dispatch of a planned task is rejected at a full worktable and no runtime is launched.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: +28/-24 (net +4), from `node tools/gates/production-delta.mjs --base origin/main`.

## Machine-Readable Declarations

## Task And Scope

- Harness task: task_6f9c8cf341c6ae4160d13b95bb
- Branch: `codex/wip-admission-fix`
- Public scope: WIP admission on every path that starts a task
- Private planning/evidence updated: yes (task plan and worker report)
- Out of scope: lowering the deployed limit back to 30 (done by the lead after deploy)

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: yes
- Protected surface scope: `tools/gates/cost-budget.json`: one knownScaling entry (`task-start`/`sqlRowsRead`) is deleted because the G38 gate reports it stale after this change; no gate logic changes.
- Authority: The user authorized tonight's governance fixes (2026-09-10 night-mode message); the exemption's own deletionTaskId is task_2b8f79fa4412cb726a26f9bfc7.
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `c153c7327`
- Branch merge-base with `origin/main`: `c153c7327`
- Last `git fetch origin` time: 2026-09-10 19:45 UTC
- Sync method: rebased onto origin/main
- Public diff command: `git diff origin/main...codex/wip-admission-fix`
- Private evidence commit/path: task_6f9c8cf341c6ae4160d13b95bb task package report
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- G1: `task-start.sqlRowsRead` 549 at 200 tasks and 549 at 2000 tasks (the exemption recorded 937 growing); `node tools/gates/cost-budget.mjs` passes after deleting the exemption.
- Negative control: with the `handoffTaskLease` check reverted, the new test fails (`Missing expected rejection`).
- Isolated runs: runtime-spawn-lifecycle 7/7, task-wip 6/6, squad-action 4/4, fleet-lease-broker 16/16, lease-reservation, milestone-lineage, hitrate-task-lifecycle green; task-query-read 9/9; squad fast/contract 45/45.
- Lead re-ran the new test and the cost gate after rebasing on main.
- Not run: the full `npm run check` / `npm test` locally. Local agents must not run the full matrix, so CI is the full authority.

## Review Evidence

- Lead review: the squad path is the same class of bypass and is included; the orphaned-lease reclaim in #2431 edits the release branch of the same function and does not overlap.
- Reviewer subagent: not used
- Human review: pending
- Blocking findings: none

## Residual Risk

- While occupancy stays above the limit, dispatching a planned task is refused until tasks close; this is the intended behavior.

## References

- Task: task_6f9c8cf341c6ae4160d13b95bb
- Fact: F-6BF6CB03
- Causal anchor: task_dfbe44e31bd5811ba720c1b1c7 (revision 65139)

---

# 中文

## 概要

WIP 上限（30）被绕过：台账上占位任务达到 42。runtime 派发先预留任务租约，再经 `handoffTaskLease` 启动任务；这一步直接调生命周期动作，根本不经过 `executeAction` 的准入检查；squad 首轮派发也一样。另外，只要任务已有 held 或 reserving 租约，`executeAction` 就跳过准入。因果锚是 revision 65139：一次 runtime 派发让占位从 30 变成 31。现在三条路径都调用 `assertTaskWipCapacity`；对已经 active 的任务，这个检查是幂等的。WIP 准入也不再读整本任务台账，只读占位状态的行和正在激活的那个任务。

## 改动内容

- `repo-cell-action-dispatch.ts`：删掉 `leasedStart` 豁免。
- `repo-cell-open.ts`：`handoffTaskLease` 与 squad `reacquireTaskLease` 的 start 之前做准入。
- `repo-cell-task-query.ts` 的 `wipSnapshotEntries`：按占位状态分别用 SQL 过滤读取，再加上正在激活的任务；子任务数改用按父任务过滤的索引读。
- `tools/gates/cost-budget.json`：删掉 G38 判为 stale 的 `task-start` knownScaling 豁免。
- 测试：工作台满时，对 planned 任务的 runtime 派发被拒，且没有启动任何 runtime。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 删除的门或 fixture：none
- 生产净行数：+28/-24 (net +4)，由 `node tools/gates/production-delta.mjs --base origin/main` 计算。

## 机读声明说明

- 本 PR 不涉及依赖变化和事件迁移，没有机读声明。

## 任务与范围

- Harness 任务：task_6f9c8cf341c6ae4160d13b95bb
- 分支：`codex/wip-admission-fix`
- 公开范围：所有启动任务的路径上的 WIP 准入
- 私有计划 / 证据是否已更新：yes（任务计划与 worker 报告）
- 范围外：把部署中的上限压回 30（部署后由主控执行）

## 版本影响

- 版本：不改版本
- 发布影响：不发布

## 治理声明

- 是否触碰 protected surface：yes
- protected surface 范围：`tools/gates/cost-budget.json`：删掉一条 knownScaling 条目（`task-start`/`sqlRowsRead`），因为本改动后 G38 判它为 stale；门逻辑不变。
- 依据：用户授权了今晚的治理修复（2026-09-10 夜间消息）；该豁免自身登记的 deletionTaskId 是 task_2b8f79fa4412cb726a26f9bfc7。
- 机器检查边界：本 PR 只声明该段存在；声明是否真实、充分，由 reviewer 判断。
- Break-glass：no
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- `origin/main` 基准 SHA：`c153c7327`
- 当前分支与 `origin/main` 的 merge-base：`c153c7327`
- 最近一次 `git fetch origin` 时间：2026-09-10 19:45 UTC
- 同步方式：rebase 到 origin/main
- 公开 diff 命令：`git diff origin/main...codex/wip-admission-fix`
- 私有证据 commit/path：task_6f9c8cf341c6ae4160d13b95bb 任务包报告
- Reviewer 证据路径：见本 PR 的「审查证据」一节
- GitHub Actions `rewrite-ci` run URL：本 PR 的 CI 还在跑
- [ ] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- G1：`task-start.sqlRowsRead` 在 200 与 2000 个任务时都是 549（豁免登记时是 937 且随规模增长）；删掉豁免后 `node tools/gates/cost-budget.mjs` 通过。
- 阴性对照：撤掉 `handoffTaskLease` 里的检查，新测试失败（`Missing expected rejection`）。
- 隔离运行：runtime-spawn-lifecycle 7/7、task-wip 6/6、squad-action 4/4、fleet-lease-broker 16/16，lease-reservation、milestone-lineage、hitrate-task-lifecycle 全绿；task-query-read 9/9；squad fast/contract 45/45。
- 主控在 rebase 到 main 后重跑了新测试与成本门。
- 未运行：本地整套 `npm run check` / `npm test`。规定禁止本地 agent 跑全量矩阵，全量以 CI 为准。

## 审查证据

- 主控审查：squad 路径是同一类绕过，一并修复；#2431 的孤儿租约回收改的是同一函数的释放分支，与本改动不重叠。
- Reviewer subagent：未使用
- 人工审查：待进行
- 阻塞发现：无

## 残余风险

- 占位高于上限期间，派发 planned 任务会被拒，直到有任务收口；这正是预期行为。

## 关联材料

- Task: task_6f9c8cf341c6ae4160d13b95bb
- Fact: F-6BF6CB03
- Causal anchor: task_dfbe44e31bd5811ba720c1b1c7 (revision 65139)

---

## PR Gate Checklist / PR 门禁清单

- [x] Branch is based on latest `origin/main`. / 分支基于最新 `origin/main`。
- [x] PR body uses this full template structure. / PR 描述使用本模板完整结构。
- [x] PR body uses two complete language blocks: `# English` first, then `# 中文`. / PR 正文使用两块完整正文：`# English` 在上，`# 中文` 在下。
- [x] PR body passes `tools/check-pr-body-bilingual.mjs`. / PR 正文通过 `tools/check-pr-body-bilingual.mjs`。
- [x] If the PR touches a manifest-derived protected surface, Governance Declaration is filled with ADR/decision/task evidence or break-glass fields. / 若 PR 触碰 manifest 派生的 protected surface，Governance Declaration 已填写 ADR/decision/task 依据或 break-glass 字段。
- [x] No private harness files are included. / 不包含私有 harness 文件。
- [x] No ignored local agent entry files are included. / 不包含被忽略的本地 agent 入口文件。
- [x] No absolute local filesystem paths are included in this public PR body. / 本公开 PR 描述不包含本机绝对路径。
- [x] Public diff is limited to the stated task scope. / 公开 diff 限于声明的任务范围。
- [x] Private planning/evidence updates are recorded when applicable. / 适用时已记录私有计划 / 证据更新。
- [x] Version and publish impact are stated. / 已说明版本与发布影响。
- [x] Local verification commands are recorded honestly. / 已如实记录本地验证命令。
- [ ] CI results are linked or explained. / CI 结果已链接或说明。
- [x] Review evidence is recorded. / 已记录审查证据。
- [x] Open P0/P1/P2 findings are closed, deferred with owner, or explicitly blocked. / open P0/P1/P2 findings 已关闭、带 owner 延后，或明确阻塞。
- [x] Merge method and post-merge branch cleanup plan are clear. / 合并方式和合并后分支清理计划清楚。
- [x] No admin bypass is planned unless explicitly approved and recorded. / 除非明确批准并记录，否则不计划 admin bypass。
