### PR TITLE
fix(cli): agent and squad delete reach the daemon with reason and expected version

### DIFF
--- a/packages/cli/src/cli/thin-command-preset.ts
+++ b/packages/cli/src/cli/thin-command-preset.ts
@@ -1,5 +1,6 @@
 import type { SafePath } from "../../../daemon/src/protocol/daemon-protocol.contract.ts";
 import { accepted, nonEmpty, promptInput, readFlags, rejectInput, rejected } from "./thin-command-flags.ts";
+import { projectFlags } from "./thin-command-projection.ts";
 import { parseTaskCreate } from "./thin-command-task-create.ts";
 import type { ProtocolCommand, ThinCliInput, ThinCliInputDirectory, ThinParseResult } from "./thin-command-types.ts";
 
@@ -67,22 +68,14 @@ export function parsePreset(
       positionalFields ? "Use preset:<id>/<entrypoint>." : `Invalid ${positionalField}.`,
       json,
     );
-  let payload: Record<string, unknown>;
-  const declared = route.inputs as readonly (ThinCliInput & {
-    readonly field: string;
-    readonly codec?: "json";
-  })[];
-  try {
-    payload = Object.fromEntries(
-      declared.flatMap((input) => {
-        if (input.kind === "boolean") return f.booleans.has(input.name) ? [[input.field, true]] : [];
-        const value = f.one.get(input.name);
-        return value ? [[input.field, input.codec === "json" ? JSON.parse(value) : value]] : [];
-      }),
-    );
-  } catch {
-    return rejectInput(inputs, route.id, "--inputs", json);
-  }
+  const payload: Record<string, unknown> = { ...projectFlags(route.id, f, inputs) };
+  for (const input of route.inputs as readonly (ThinCliInput & { readonly field: string; readonly codec?: "json" })[])
+    if (input.codec === "json" && typeof payload[input.field] === "string")
+      try {
+        payload[input.field] = JSON.parse(payload[input.field] as string);
+      } catch {
+        return rejectInput(inputs, route.id, input.name, json);
+      }
   const position =
       matched && positionalFields
         ? {

--- a/packages/cli/test/agent-create.integration.test.ts
+++ b/packages/cli/test/agent-create.integration.test.ts
@@ -125,6 +125,17 @@ test("agent create runs and ontology-squad reinstall stays on the canonical Enti
     );
     assert.equal(entityGet.entity.value.id, "meta-designer");
     assert.deepEqual(ontologyGet.entity.value, ontologySquad);
+    const version = String((ontologyGet.entity as unknown as { currentVersion: number }).currentVersion),
+      deleted = run(root, env, [
+        "squad",
+        "delete",
+        ontologySquad.id,
+        "--reason",
+        "retired",
+        "--expected-version",
+        version,
+      ]);
+    assert.equal(deleted.outcome, "applied", JSON.stringify(deleted));
     const inventory = run(root, env, ["runtime", "instance", "list"]),
       installation = (inventory.installations as Array<Record<string, unknown>>).find(
         (row) => row.version === "codex agent-create-fixture",

--- a/packages/cli/test/thin-command.test.ts
+++ b/packages/cli/test/thin-command.test.ts
@@ -114,6 +114,23 @@ test("entity import and update carry declared attributes as one typed JSON objec
   assert.deepEqual((updated.command.action as { readonly attributes: unknown }).attributes, { region: "south" });
 });
 
+test("agent and squad delete project their reason and expected version into the daemon Action", () => {
+  for (const [noun, idField] of [
+    ["agent", "agentId"],
+    ["squad", "squadId"],
+  ] as const) {
+    const parsed = parseThinCommand([noun, "delete", "worker-a", "--reason", "retired", "--expected-version", "3"]);
+    assert.equal(parsed.ok, true);
+    if (!parsed.ok) return;
+    assert.deepEqual(parsed.command.action, {
+      kind: `${noun}-delete`,
+      [idField]: "worker-a",
+      reason: "retired",
+      expectedVersion: 3,
+    });
+  }
+});
+
 test("entity import projects its concurrency and dry-run flags into one daemon Action", () => {
   const parsed = parseThinCommand([
     "entity",


### PR DESCRIPTION
# English

## Summary

`ha agent delete` and `ha squad delete` could never succeed from the CLI (Bench F3: 5/5 `invalid_command` at every scale). agent and squad commands build their payload in `parsePreset`, which keyed each value by `input.field`; the two delete commands declare `--reason` and `--expected-version` without a `field`, so both values landed under the key `"undefined"` and the daemon saw no expectedVersion. The shared `projectFlags` already derives the field from the flag name and applies the number projection; `parsePreset` now uses it and keeps only the `codec: "json"` parsing that preset `--inputs` needs. Repeated flags, previously dropped by `parsePreset`, now reach the payload as well.

## What Changed

- `thin-command-preset.ts`: payload from `projectFlags`, plus JSON parsing for `codec: "json"` inputs.
- `thin-command.test.ts`: agent and squad delete parse into `{ reason, expectedVersion: <number> }`.
- `agent-create.integration.test.ts`: a real `ha squad delete` through the CLI and daemon is applied.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: +9/-16 (net -7), from `node tools/gates/production-delta.mjs --base origin/main`.

## Machine-Readable Declarations

## Task And Scope

- Harness task: task_4d193efe99d208339995e505f9
- Branch: `codex/agent-squad-delete-fields`
- Public scope: CLI payload projection for preset, agent and squad commands
- Private planning/evidence updated: yes (task plan and worker report)
- Out of scope: folding `codec: "json"` into `projection` (it also shapes the RPC field type)

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: not applicable
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `e623fd932`
- Branch merge-base with `origin/main`: `e623fd932`
- Last `git fetch origin` time: 2026-09-10 20:25 UTC
- Sync method: rebased onto origin/main
- Public diff command: `git diff origin/main...codex/agent-squad-delete-fields`
- Private evidence commit/path: task_4d193efe99d208339995e505f9 task package report
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- CLI thin-command suites (thin-command*, daemon-thin-client-cli, squad-cancel-command, task-action-help): 53/53.
- `agent-create.integration.test.ts` passes; negative control: with `thin-command-preset.ts` from main the new `squad delete` step is `op_rejected`.
- `npx tsc -b packages/cli`, eslint, line-density, `run-manifest-gates --changed origin/main` pass.
- Not run: the full `npm run check` / `npm test` locally. Local agents must not run the full matrix, so CI is the full authority.

## Review Evidence

- Lead-authored; the first attempt replaced the builder with `projectFlags` alone and two preset tests caught the lost `--inputs` JSON parsing, which is restored as the codec overlay.
- Reviewer subagent: not used
- Human review: pending
- Blocking findings: none

## Residual Risk

- An empty flag value now reaches the payload as an empty string instead of being dropped; the daemon validators reject empty required fields.

## References

- Task: task_4d193efe99d208339995e505f9
- Bench report: task_34935988e63cb55291ca3c5ada (F3)

---

# 中文

## 概要

`ha agent delete` 与 `ha squad delete` 从 CLI 永远无法成功（Bench F3：每档 5/5 次 `invalid_command`）。agent 与 squad 命令在 `parsePreset` 里组装 payload，按 `input.field` 取键；这两个 delete 命令声明 `--reason` 和 `--expected-version` 时没有写 `field`，两个值都落在键 `"undefined"` 下，daemon 因此看不到 expectedVersion。通用的 `projectFlags` 本来就按参数名推导字段并处理数字投影；`parsePreset` 现在直接复用它，只保留 preset `--inputs` 需要的 `codec: "json"` 解析。以前被 `parsePreset` 丢掉的可重复参数，现在也会进入 payload。

## 改动内容

- `thin-command-preset.ts`：payload 由 `projectFlags` 生成，再对 `codec: "json"` 的输入做 JSON 解析。
- `thin-command.test.ts`：agent 与 squad delete 解析为 `{ reason, expectedVersion: <数字> }`。
- `agent-create.integration.test.ts`：经 CLI 与 daemon 真实执行一次 `ha squad delete`，结果为 applied。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 删除的门或 fixture：none
- 生产净行数：+9/-16 (net -7)，由 `node tools/gates/production-delta.mjs --base origin/main` 计算。

## 机读声明说明

- 本 PR 不涉及依赖变化和事件迁移，没有机读声明。

## 任务与范围

- Harness 任务：task_4d193efe99d208339995e505f9
- 分支：`codex/agent-squad-delete-fields`
- 公开范围：preset、agent、squad 命令的 CLI payload 投影
- 私有计划 / 证据是否已更新：yes（任务计划与 worker 报告）
- 范围外：把 `codec: "json"` 并入 `projection`（它同时决定 RPC 字段类型）

## 版本影响

- 版本：不改版本
- 发布影响：不发布

## 治理声明

- 是否触碰 protected surface：no
- protected surface 范围：不适用
- 依据：不适用
- 机器检查边界：本 PR 只声明该段存在；声明是否真实、充分，由 reviewer 判断。
- Break-glass：no
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- `origin/main` 基准 SHA：`e623fd932`
- 当前分支与 `origin/main` 的 merge-base：`e623fd932`
- 最近一次 `git fetch origin` 时间：2026-09-10 20:25 UTC
- 同步方式：rebase 到 origin/main
- 公开 diff 命令：`git diff origin/main...codex/agent-squad-delete-fields`
- 私有证据 commit/path：task_4d193efe99d208339995e505f9 任务包报告
- Reviewer 证据路径：见本 PR 的「审查证据」一节
- GitHub Actions `rewrite-ci` run URL：本 PR 的 CI 还在跑
- [ ] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- CLI thin-command 测试集（thin-command*、daemon-thin-client-cli、squad-cancel-command、task-action-help）：53/53。
- `agent-create.integration.test.ts` 通过；阴性对照：换回 main 的 `thin-command-preset.ts`，新增的 `squad delete` 步骤被 `op_rejected`。
- `npx tsc -b packages/cli`、eslint、line-density、`run-manifest-gates --changed origin/main` 通过。
- 未运行：本地整套 `npm run check` / `npm test`。规定禁止本地 agent 跑全量矩阵，全量以 CI 为准。

## 审查证据

- 主控编写；第一版只用 `projectFlags` 替换，两个 preset 测试拦下了丢失的 `--inputs` JSON 解析，已作为 codec 覆盖层恢复。
- Reviewer subagent：未使用
- 人工审查：待进行
- 阻塞发现：无

## 残余风险

- 空参数值现在以空字符串进入 payload，而不是被丢弃；daemon 校验器会拒绝空的必填字段。

## 关联材料

- Task: task_4d193efe99d208339995e505f9
- Bench report: task_34935988e63cb55291ca3c5ada (F3)

---

## PR Gate Checklist / PR 门禁清单

- [x] Branch is based on latest `origin/main`. / 分支基于最新 `origin/main`。
- [x] PR body uses this full template structure. / PR 描述使用本模板完整结构。
- [x] PR body uses two complete language blocks: `# English` first, then `# 中文`. / PR 正文使用两块完整正文：`# English` 在上，`# 中文` 在下。
- [x] PR body passes `tools/check-pr-body-bilingual.mjs`. / PR 正文通过 `tools/check-pr-body-bilingual.mjs`。
- [x] If the PR touches a manifest-derived protected surface, Governance Declaration is filled with ADR/decision/task evidence or break-glass fields. / 若 PR 触碰 manifest 派生的 protected surface，Governance Declaration 已填写 ADR/decision/task 依据或 break-glass 字段。
- [x] No private harness files are included. / 不包含私有 harness 文件。
- [x] No ignored local agent entry files are included. / 不包含被忽略的本地 agent 入口文件。
- [x] No absolute local filesystem paths are included in this public PR body. / 本公开 PR 描述不包含本机绝对路径。
- [x] Public diff is limited to the stated task scope. / 公开 diff 限于声明的任务范围。
- [x] Private planning/evidence updates are recorded when applicable. / 适用时已记录私有计划 / 证据更新。
- [x] Version and publish impact are stated. / 已说明版本与发布影响。
- [x] Local verification commands are recorded honestly. / 已如实记录本地验证命令。
- [ ] CI results are linked or explained. / CI 结果已链接或说明。
- [x] Review evidence is recorded. / 已记录审查证据。
- [x] Open P0/P1/P2 findings are closed, deferred with owner, or explicitly blocked. / open P0/P1/P2 findings 已关闭、带 owner 延后，或明确阻塞。
- [x] Merge method and post-merge branch cleanup plan are clear. / 合并方式和合并后分支清理计划清楚。
- [x] No admin bypass is planned unless explicitly approved and recorded. / 除非明确批准并记录，否则不计划 admin bypass。
