### PR TITLE
fix(daemon): resolve URL entity import sources outside the write queue

### DIFF
--- a/packages/application/src/artifact-entity-service.ts
+++ b/packages/application/src/artifact-entity-service.ts
@@ -102,7 +102,12 @@ export interface PreparedArtifactEntityImport {
 }
 
 export class ArtifactEntityServiceError extends Error {
-  readonly code: "entity_kind_not_found" | "invalid_command" | "revision_conflict" | "source_resolution_failed";
+  readonly code:
+    | "entity_kind_not_found"
+    | "invalid_command"
+    | "revision_conflict"
+    | "source_resolution_failed"
+    | "source_resolution_timeout";
 
   constructor(code: ArtifactEntityServiceError["code"], message: string) {
     super(message);
@@ -145,7 +150,7 @@ export function makeArtifactEntityService(options: {
       throw new ArtifactEntityServiceError("entity_kind_not_found", `Artifact kind ${request.kind} is not compiled.`);
     if (!Number.isSafeInteger(request.expectedVersion) || request.expectedVersion < 0)
       throw new ArtifactEntityServiceError("invalid_command", "expectedVersion must be a non-negative integer.");
-    const locator = resolveLocator(request.locator, contract),
+    const locator = resolveArtifactLocator(request.locator, contract),
       resolution = await resolveAuthoritatively(options.resolveSource, locator, contract),
       resolvedSourceIdentity = canonicalSourceIdentity(resolution.source),
       sourceIdentity = request.sourceIdentity ?? resolvedSourceIdentity;
@@ -302,7 +307,7 @@ function mintedBytes(bytes: Uint8Array): Uint8Array {
   return bytes;
 }
 
-function resolveLocator(value: string, contract: CompiledArtifactKindContract): ArtifactLocator {
+export function resolveArtifactLocator(value: string, contract: CompiledArtifactKindContract): ArtifactLocator {
   const allowed = contract.declaration.locatorKinds,
     inferred = /^https?:\/\//iu.test(value)
       ? "url"

--- a/packages/application/src/index.ts
+++ b/packages/application/src/index.ts
@@ -16,6 +16,7 @@ export {
   ArtifactEntityServiceError,
   makeArtifactEntityService,
   readArtifactDescriptor,
+  resolveArtifactLocator,
 } from "./artifact-entity-service.ts";
 export type {
   ArtifactEntityCurrent,

--- a/packages/daemon/src/artifact-entity-action.ts
+++ b/packages/daemon/src/artifact-entity-action.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import {
   ArtifactEntityServiceError,
   makeArtifactEntityService,
+  resolveArtifactLocator,
   readArtifactDescriptor,
   type ArtifactEntityCurrent,
   type ArtifactSourceResolution,
@@ -52,6 +53,8 @@ import { requireCanonicalVerticalDeclaration, type VerticalDeclarationReader } f
 
 const compiledVerticals = new Map<string, CompiledVerticalContract>(),
   compiledDirections = new Map<string, readonly CanonicalRelationDirection[]>();
+export const artifactImportSourceResolution = Symbol("artifactImportSourceResolution");
+const ARTIFACT_SOURCE_FETCH_TIMEOUT_MS = 10_000;
 /** `entityId` is null only for a dry run of material the center has never accepted; nothing is minted then. */
 type ArtifactImportReceipt = WriteReceipt & { readonly entityId: string | null };
 
@@ -131,6 +134,25 @@ export function resolveArtifactImportAction(
   return contract?.entityKindContract.actionCatalog?.actions.find(({ id }) => id === "import") ?? null;
 }
 
+export async function prepareArtifactEntityImportSource(input: {
+  readonly rootDir: string;
+  readonly repositoryId: string;
+  readonly action: RepoTaskAction;
+  readonly projection: VerticalDeclarationReader;
+}): Promise<ArtifactSourceResolution> {
+  const contract = findArtifactKindContract(
+    requiredArtifactText(input.action.entityKind, "entityKind"),
+    compiledArtifactKinds(input.projection, input.repositoryId),
+  );
+  if (!contract)
+    throw new ArtifactEntityServiceError(
+      "entity_kind_not_found",
+      `Artifact kind ${String(input.action.entityKind)} is not declared.`,
+    );
+  const locator = resolveArtifactLocator(requiredArtifactText(input.action.locator, "locator"), contract);
+  return resolveArtifactSource({ rootDir: input.rootDir, repositoryId: input.repositoryId, locator, contract });
+}
+
 export async function executeArtifactEntityImport(input: {
   readonly rootDir: string;
   readonly repositoryId: string;
@@ -140,6 +162,7 @@ export async function executeArtifactEntityImport(input: {
   readonly projection: TaskProjection;
   readonly now: () => string;
   readonly authorizationDecision: AuthorizationDecision;
+  readonly sourceResolution?: ArtifactSourceResolution;
 }): Promise<{
   readonly action: RepoTaskAction;
   readonly contract: EntityActionContract;
@@ -351,10 +374,12 @@ export async function runArtifactEntityImport(input: {
   readonly projection: TaskProjection;
   readonly now: () => string;
   readonly authorizationDecision: AuthorizationDecision;
+  readonly sourceResolution?: ArtifactSourceResolution;
 }): Promise<ArtifactImportReceipt> {
   const service = makeArtifactEntityService({
       contracts: input.contracts,
       resolveSource: (locator, contract) =>
+        input.sourceResolution ??
         resolveArtifactSource({
           rootDir: input.rootDir,
           repositoryId: input.repositoryId,
@@ -477,8 +502,22 @@ async function resolveArtifactSource(input: {
     };
   }
   if (locator.kind === "url") {
-    const response = await fetch(locator.value, { redirect: "follow" }),
-      source = { kind: "url" as const, url: locator.value };
+    const controller = new AbortController(),
+      timeout = setTimeout(() => controller.abort(), ARTIFACT_SOURCE_FETCH_TIMEOUT_MS);
+    let response: Response;
+    try {
+      response = await fetch(locator.value, { redirect: "follow", signal: controller.signal });
+    } catch (error) {
+      if (controller.signal.aborted)
+        throw new ArtifactEntityServiceError(
+          "source_resolution_timeout",
+          `URL resolver timed out after ${ARTIFACT_SOURCE_FETCH_TIMEOUT_MS} ms.`,
+        );
+      throw error;
+    } finally {
+      clearTimeout(timeout);
+    }
+    const source = { kind: "url" as const, url: locator.value };
     const code = response.status;
     if (code === 404 || code === 410) return { status: "missing", source, reason: `HTTP ${code}`, resolver: "http" };
     if (!response.ok) throw new Error(`URL resolver returned HTTP ${response.status}.`);

--- a/packages/daemon/src/artifact-entity-action.ts
+++ b/packages/daemon/src/artifact-entity-action.ts
@@ -379,13 +379,21 @@ export async function runArtifactEntityImport(input: {
   const service = makeArtifactEntityService({
       contracts: input.contracts,
       resolveSource: (locator, contract) =>
-        input.sourceResolution ??
-        resolveArtifactSource({
-          rootDir: input.rootDir,
-          repositoryId: input.repositoryId,
-          locator,
-          contract,
-        }),
+        input.sourceResolution
+          ? Promise.resolve(input.sourceResolution)
+          : locator.kind === "url"
+            ? Promise.reject(
+                new ArtifactEntityServiceError(
+                  "source_resolution_failed",
+                  "URL source resolution must complete before the import enters the write queue.",
+                ),
+              )
+            : resolveArtifactSource({
+                rootDir: input.rootDir,
+                repositoryId: input.repositoryId,
+                locator,
+                contract,
+              }),
       readCurrent: (kind, entityId) => readCurrentArtifact(input.store, input.contracts, kind, entityId),
       resolveSourceBinding: (kind, sourceIdentity) => resolveSourceBinding(input.store, kind, sourceIdentity),
       randomEntityIdBytes: () => randomBytes(ARTIFACT_ENTITY_ID_BYTES),

--- a/packages/daemon/src/entity-action-catalog-executor.ts
+++ b/packages/daemon/src/entity-action-catalog-executor.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { makeDecisionService, makeFactService } from "../../application/src/index.ts";
+import { makeDecisionService, makeFactService, type ArtifactSourceResolution } from "../../application/src/index.ts";
 import {
   compileEntityUpsert,
   compileEntityDeleted,
@@ -50,7 +50,6 @@ import {
   executeArtifactEntityImport,
   executeArtifactEntityMutation,
   artifactImportSourceResolution,
-  type ArtifactSourceResolution,
 } from "./artifact-entity-action.ts";
 import { executeRelationAction, publicationKillpoints, reject } from "./entity-action-relation.ts";
 
@@ -75,7 +74,6 @@ export interface EntityActionCatalogRuntimes {
   readonly entity?: Readonly<Record<string, EntityActionCatalogRunner>>;
   readonly task?: EntityActionCatalogRunner;
   readonly prepare?: Readonly<Record<string, EntityActionCatalogPreparer>>;
-  readonly artifactImportSourceResolution?: ArtifactSourceResolution;
 }
 
 export function makeEntityActionCatalogExecutor(input: {
@@ -135,11 +133,11 @@ export function makeEntityActionCatalogExecutor(input: {
         projection: input.projection,
         now: input.now,
         authorizationDecision,
-        sourceResolution:
-          runtimes.artifactImportSourceResolution ??
-          (action as RepoTaskAction & { readonly [artifactImportSourceResolution]?: ArtifactSourceResolution })[
-            artifactImportSourceResolution
-          ],
+        sourceResolution: (
+          action as RepoTaskAction & {
+            readonly [artifactImportSourceResolution]?: ArtifactSourceResolution;
+          }
+        )[artifactImportSourceResolution],
       }).then((result) => deriveActionResult(result.contract, result.action, result.receipt));
     }
     if (action.kind === "entity-update" || action.kind === "entity-archive" || action.kind === "entity-delete") {

--- a/packages/daemon/src/entity-action-catalog-executor.ts
+++ b/packages/daemon/src/entity-action-catalog-executor.ts
@@ -46,7 +46,12 @@ import {
   matchingRuntimeSessionReplayBundle,
   type RuntimeSessionBundle,
 } from "./entity-action-runtime-session.ts";
-import { executeArtifactEntityImport, executeArtifactEntityMutation } from "./artifact-entity-action.ts";
+import {
+  executeArtifactEntityImport,
+  executeArtifactEntityMutation,
+  artifactImportSourceResolution,
+  type ArtifactSourceResolution,
+} from "./artifact-entity-action.ts";
 import { executeRelationAction, publicationKillpoints, reject } from "./entity-action-relation.ts";
 
 type ExecutableAction = EntityActionContract & { readonly execution: EntityActionExecutionContract };
@@ -70,6 +75,7 @@ export interface EntityActionCatalogRuntimes {
   readonly entity?: Readonly<Record<string, EntityActionCatalogRunner>>;
   readonly task?: EntityActionCatalogRunner;
   readonly prepare?: Readonly<Record<string, EntityActionCatalogPreparer>>;
+  readonly artifactImportSourceResolution?: ArtifactSourceResolution;
 }
 
 export function makeEntityActionCatalogExecutor(input: {
@@ -129,6 +135,11 @@ export function makeEntityActionCatalogExecutor(input: {
         projection: input.projection,
         now: input.now,
         authorizationDecision,
+        sourceResolution:
+          runtimes.artifactImportSourceResolution ??
+          (action as RepoTaskAction & { readonly [artifactImportSourceResolution]?: ArtifactSourceResolution })[
+            artifactImportSourceResolution
+          ],
       }).then((result) => deriveActionResult(result.contract, result.action, result.receipt));
     }
     if (action.kind === "entity-update" || action.kind === "entity-archive" || action.kind === "entity-delete") {

--- a/packages/daemon/src/repo-cell-api.ts
+++ b/packages/daemon/src/repo-cell-api.ts
@@ -41,6 +41,8 @@ import { readAgentEntityGuiProjection } from "./agent-entities.ts";
 import {
   canonicalVertical,
   compiledArtifactKinds,
+  prepareArtifactEntityImportSource,
+  artifactImportSourceResolution,
   readCurrentArtifact,
   resolveEntityReadKind,
 } from "./artifact-entity-action.ts";
@@ -418,6 +420,25 @@ export function createRepoCellApi(context: RepoCellApiContext): RepoCell & RepoC
             ),
           (error) => failAction(error, durable ? authorizeAtCurrentCut()! : undefined),
         );
+    if (action.kind === "entity-import")
+      return Promise.resolve()
+        .then(() =>
+          prepareArtifactEntityImportSource({
+            rootDir: context.rootDir,
+            repositoryId: context.input.repoId,
+            action,
+            projection: context.projection,
+          }),
+        )
+        .then((sourceResolution) =>
+          enqueuePublication((authorizationDecision) =>
+            context.executeAction(
+              { ...action, [artifactImportSourceResolution]: sourceResolution },
+              authorizationDecision ? { ...binding, authorizationDecision } : binding,
+            ),
+          ),
+        )
+        .catch((error) => failAction(error, durable ? authorizeAtCurrentCut()! : undefined));
     return enqueuePublication((authorizationDecision) =>
       context.executeAction(action, authorizationDecision ? { ...binding, authorizationDecision } : binding),
     );

--- a/packages/daemon/src/repo-cell-errors.ts
+++ b/packages/daemon/src/repo-cell-errors.ts
@@ -59,6 +59,7 @@ export function errorOperationId(error: unknown): string | null {
 }
 
 export function cellErrorCode(error: unknown): string {
+  if (error instanceof ArtifactEntityServiceError) return error.code;
   const normalized = normalizeDomainError(error);
   switch (normalized._tag) {
     case "LeaseConflictError":

--- a/packages/daemon/test/artifact-entity-action.integration.test.ts
+++ b/packages/daemon/test/artifact-entity-action.integration.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { createServer } from "node:http";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -297,6 +298,68 @@ test("Artifact import is dry-run safe, edge-idempotent, fenced, and cold-rebuild
     }
   } finally {
     await cell?.close();
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});
+
+test("URL source resolution does not block a concurrent repository write", async () => {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-url-artifact-import-")),
+    repoId = workspaceId("url-artifact-import");
+  let cell: Awaited<ReturnType<typeof openRepoCell>> | undefined;
+  const server = createServer(() => {});
+  try {
+    initRepo(rootDir);
+    cell = await openRepoCell({
+      repoId,
+      rootDir: canonicalRoot(rootDir),
+      ownerId: "url-artifact-import-center",
+      now: () => "2026-09-11T02:00:00.000Z",
+    });
+    const created = await cell.run(
+      {
+        kind: "vertical-kind-upsert",
+        kindId: "remote-note",
+        expectedVersion: 0,
+        declaration: {
+          id: "remote-note",
+          entityType: "artifact",
+          idPrefix: "RN",
+          display: { singular: "Remote Note", plural: "Remote Notes" },
+          descriptorSchemaRef: "schema://artifact-descriptor",
+          store: { pathTemplate: "entities/remote-notes/{id}.json" },
+          locatorKinds: ["url"],
+        },
+      },
+      binding,
+    );
+    assert.equal(created.outcome, "applied", JSON.stringify(created));
+    const kindRef = (JSON.parse(String(created.evidence)) as { kindRef: string }).kindRef;
+    await new Promise<void>((resolve, reject) => {
+      server.once("error", reject);
+      server.listen(0, "127.0.0.1", () => resolve());
+    });
+    const address = server.address();
+    assert.ok(address && typeof address === "object");
+    const url = `http://127.0.0.1:${String(address.port)}/hanging.md`;
+    const importing = cell.run(
+      { kind: "entity-import", entityKind: kindRef, locator: url, expectedVersion: 0 },
+      binding,
+    );
+    const started = Date.now();
+    const write = await Promise.race([
+      cell.run({ kind: "task-create", taskId: "url-import-concurrent-write", title: "Concurrent write" }, binding),
+      new Promise<never>((_, reject) =>
+        setTimeout(() => reject(new Error("concurrent write exceeded 2 seconds")), 2_000),
+      ),
+    ]);
+    assert.equal(write.outcome, "applied", JSON.stringify(write));
+    assert.ok(Date.now() - started < 2_000);
+    const imported = await importing;
+    assert.equal(imported.outcome, "op_rejected", JSON.stringify(imported));
+    assert.equal(imported.code, "source_resolution_timeout", JSON.stringify(imported));
+  } finally {
+    await cell?.close();
+    await new Promise<void>((resolve) => server.close(() => resolve()));
     rmSync(rootDir, { recursive: true, force: true });
   }
 });


### PR DESCRIPTION
# English

## Summary

An `entity import` with a URL locator fetched the URL inside the repository's serialized write path, so every other write to that repository waited for the network (Bench F2). With a URL that accepts connections but never answers, a concurrent `fact record` waited the full 120 s, and nothing bounded the fetch. The import now resolves its source before it enters the write queue and hands the result to the queued write; inside the queue a URL locator without a pre-resolved source is an explicit error, not a second fetch. The fetch has a 10 s timeout that ends as `source_resolution_timeout`.

## Architectural Justification

The network wait has to leave the serialized write, so the source must be resolved before enqueueing; that needs the locator parsing the service already had (now exported), a pre-enqueue step in `repo-cell-api.ts`, and a way to hand the result to the queued write. The executor API takes only action and binding, so the result rides on a module-private Symbol on the action, which is never serialized into the event. The rest is the bounded fetch and one error code. A timeout alone would still block every write for up to 10 s per hanging URL, so it is not a substitute.

## What Changed

- `repo-cell-api.ts`: resolve the import source, then enqueue the write with the result.
- `artifact-entity-action.ts`: `prepareArtifactEntityImportSource`; queued URL imports require the pre-resolved source; the fetch has a 10 s abort.
- `entity-action-catalog-executor.ts`: pass the pre-resolved source to the import.
- `artifact-entity-service.ts`, `repo-cell-errors.ts`: `source_resolution_timeout` reaches the receipt.
- Test: a hanging local HTTP port as the URL; a concurrent `task-create` completes within 2 s; the import ends with `source_resolution_timeout`.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: +97/-13 (net +84), from `node tools/gates/production-delta.mjs --base origin/main`.

## Machine-Readable Declarations

## Task And Scope

- Harness task: task_2c15b7bf82ab72310661bbd23d
- Branch: `codex/f2-url-import-fetch`
- Public scope: URL entity import and the repository write queue
- Private planning/evidence updated: yes (task plan and worker report)
- Out of scope: repository-path locators (local reads stay in the queue)

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: not applicable
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `ac1e3cb0f`
- Branch merge-base with `origin/main`: `ac1e3cb0f`
- Last `git fetch origin` time: 2026-09-10 20:50 UTC
- Sync method: rebased onto origin/main
- Public diff command: `git diff origin/main...codex/f2-url-import-fetch`
- Private evidence commit/path: task_2c15b7bf82ab72310661bbd23d task package report
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- `artifact-entity-action.integration.test.ts` via the isolated dispatcher: 5/5; the new test takes about 10.7 s (production timeout).
- Negative control (lead): with the production files from main, the new test fails with `concurrent write exceeded 2 seconds`.
- `npx tsc -b packages/application packages/daemon` and `run-manifest-gates --changed origin/main` pass.
- Not run: the full `npm run check` / `npm test` locally. Local agents must not run the full matrix, so CI is the full authority.

## Review Evidence

- Lead review of round 1 removed an unused runtimes field and a silent fallback that would fetch inside the queue whenever the Symbol was lost; round 2 made the queued URL path an explicit error and added the regression test.
- Reviewer subagent: not used
- Human review: pending
- Blocking findings: none

## Residual Risk

- The source is resolved before authorization, so a rejected import may still have fetched its URL.
- A retried import with the same idempotency key fetches again before the queue recognizes the replay.

## References

- Task: task_2c15b7bf82ab72310661bbd23d
- Fact: F-CF5BCF46
- Bench report: task_34935988e63cb55291ca3c5ada (F2)

---

# 中文

## 概要

URL 定位的 `entity import` 在仓库的串行写路径里做 fetch，于是这个仓库的其他写入都得等网络（Bench F2）。URL 只接受连接、永不应答时，同时进行的 `fact record` 等满了 120 秒，而 fetch 本身没有任何上限。现在 import 在进入写队列之前解析来源，把结果交给排队的写入；队列内拿不到预解析结果的 URL locator 直接报错，不会再 fetch 一次。fetch 带 10 秒超时，超时以 `source_resolution_timeout` 结束。

## 架构辩护

网络等待必须离开串行写，所以来源要在入队前解析：这需要服务里已有的 locator 解析（现在导出）、`repo-cell-api.ts` 里的入队前步骤，以及把结果交给排队写入的办法。执行器 API 只接收 action 与 binding，结果通过 action 上一个模块私有的 Symbol 传递，它不会被序列化进事件。其余是有上限的 fetch 和一个错误码。只加超时的话，每个挂起的 URL 仍会让所有写入阻塞最多 10 秒，替代不了。

## 改动内容

- `repo-cell-api.ts`：先解析 import 来源，再带着结果入队。
- `artifact-entity-action.ts`：`prepareArtifactEntityImportSource`；排队的 URL import 必须带预解析结果；fetch 10 秒中止。
- `entity-action-catalog-executor.ts`：把预解析结果传给 import。
- `artifact-entity-service.ts`、`repo-cell-errors.ts`：`source_resolution_timeout` 进入回执。
- 测试：以挂起的本地 HTTP 端口为 URL，同时进行的 `task-create` 在 2 秒内完成，import 以 `source_resolution_timeout` 结束。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 删除的门或 fixture：none
- 生产净行数：+97/-13 (net +84)，由 `node tools/gates/production-delta.mjs --base origin/main` 计算。

## 机读声明说明

- 本 PR 不涉及依赖变化和事件迁移，没有机读声明。

## 任务与范围

- Harness 任务：task_2c15b7bf82ab72310661bbd23d
- 分支：`codex/f2-url-import-fetch`
- 公开范围：URL entity import 与仓库写队列
- 私有计划 / 证据是否已更新：yes（任务计划与 worker 报告）
- 范围外：仓库路径 locator（本地读取仍在队列内）

## 版本影响

- 版本：不改版本
- 发布影响：不发布

## 治理声明

- 是否触碰 protected surface：no
- protected surface 范围：不适用
- 依据：不适用
- 机器检查边界：本 PR 只声明该段存在；声明是否真实、充分，由 reviewer 判断。
- Break-glass：no
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- `origin/main` 基准 SHA：`ac1e3cb0f`
- 当前分支与 `origin/main` 的 merge-base：`ac1e3cb0f`
- 最近一次 `git fetch origin` 时间：2026-09-10 20:50 UTC
- 同步方式：rebase 到 origin/main
- 公开 diff 命令：`git diff origin/main...codex/f2-url-import-fetch`
- 私有证据 commit/path：task_2c15b7bf82ab72310661bbd23d 任务包报告
- Reviewer 证据路径：见本 PR 的「审查证据」一节
- GitHub Actions `rewrite-ci` run URL：本 PR 的 CI 还在跑
- [ ] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- 经隔离派测跑 `artifact-entity-action.integration.test.ts`：5/5；新测试约 10.7 秒（生产超时值）。
- 阴性对照（主控）：换回 main 的生产文件，新测试以 `concurrent write exceeded 2 seconds` 失败。
- `npx tsc -b packages/application packages/daemon` 与 `run-manifest-gates --changed origin/main` 通过。
- 未运行：本地整套 `npm run check` / `npm test`。规定禁止本地 agent 跑全量矩阵，全量以 CI 为准。

## 审查证据

- 主控审查第 1 轮后删掉了一个无人写入的 runtimes 字段，以及一个静默回退：只要 Symbol 丢失就会在队列内 fetch；第 2 轮把队列内的 URL 路径改为明确报错，并补了回归测试。
- Reviewer subagent：未使用
- 人工审查：待进行
- 阻塞发现：无

## 残余风险

- 来源在授权之前解析，被拒的 import 也可能已经 fetch 过它的 URL。
- 同一幂等键的重试 import 会在队列识别重放之前再 fetch 一次。

## 关联材料

- Task: task_2c15b7bf82ab72310661bbd23d
- Fact: F-CF5BCF46
- Bench report: task_34935988e63cb55291ca3c5ada (F2)

---

## PR Gate Checklist / PR 门禁清单

- [x] Branch is based on latest `origin/main`. / 分支基于最新 `origin/main`。
- [x] PR body uses this full template structure. / PR 描述使用本模板完整结构。
- [x] PR body uses two complete language blocks: `# English` first, then `# 中文`. / PR 正文使用两块完整正文：`# English` 在上，`# 中文` 在下。
- [x] PR body passes `tools/check-pr-body-bilingual.mjs`. / PR 正文通过 `tools/check-pr-body-bilingual.mjs`。
- [x] If the PR touches a manifest-derived protected surface, Governance Declaration is filled with ADR/decision/task evidence or break-glass fields. / 若 PR 触碰 manifest 派生的 protected surface，Governance Declaration 已填写 ADR/decision/task 依据或 break-glass 字段。
- [x] No private harness files are included. / 不包含私有 harness 文件。
- [x] No ignored local agent entry files are included. / 不包含被忽略的本地 agent 入口文件。
- [x] No absolute local filesystem paths are included in this public PR body. / 本公开 PR 描述不包含本机绝对路径。
- [x] Public diff is limited to the stated task scope. / 公开 diff 限于声明的任务范围。
- [x] Private planning/evidence updates are recorded when applicable. / 适用时已记录私有计划 / 证据更新。
- [x] Version and publish impact are stated. / 已说明版本与发布影响。
- [x] Local verification commands are recorded honestly. / 已如实记录本地验证命令。
- [ ] CI results are linked or explained. / CI 结果已链接或说明。
- [x] Review evidence is recorded. / 已记录审查证据。
- [x] Open P0/P1/P2 findings are closed, deferred with owner, or explicitly blocked. / open P0/P1/P2 findings 已关闭、带 owner 延后，或明确阻塞。
- [x] Merge method and post-merge branch cleanup plan are clear. / 合并方式和合并后分支清理计划清楚。
- [x] No admin bypass is planned unless explicitly approved and recorded. / 除非明确批准并记录，否则不计划 admin bypass。
