### PR TITLE
fix(daemon): task list keeps child tasks without --parent and counts children across the ledger

### DIFF
--- a/packages/daemon/src/repo-cell-task-query.ts
+++ b/packages/daemon/src/repo-cell-task-query.ts
@@ -77,7 +77,7 @@ export function listTasks(cell: TaskQueryCell, action: RepoTaskAction, binding: 
       flat
         ? {
             ...filters,
-            parentTaskId: typeof action.parentTaskId === "string" ? action.parentTaskId : null,
+            ...(typeof action.parentTaskId === "string" ? { parentTaskId: action.parentTaskId } : {}),
             ...(query.limit === undefined ? {} : { limit: query.limit }),
             ...(query.cursor === undefined ? {} : { cursor: query.cursor }),
             activePackagesOnly: true,
@@ -105,7 +105,10 @@ export function listTasks(cell: TaskQueryCell, action: RepoTaskAction, binding: 
       throw cell.cellCodedError("invalid_command", "Task list cursor is invalid; restart the filtered query.");
     throw error;
   }
-  const rootSetting = resolveTaskRootThreshold(cell.rootDir),
+  // Filters and pages narrow the rows; a row's children are still counted across the whole ledger.
+  const childCounts =
+      selected.mode === "flat" ? cell.projection.readTaskChildCounts(selected.rows.map((row) => row.taskId)) : {},
+    rootSetting = resolveTaskRootThreshold(cell.rootDir),
     value =
       selected.mode === "tree"
         ? {
@@ -122,7 +125,7 @@ export function listTasks(cell: TaskQueryCell, action: RepoTaskAction, binding: 
             schema: "task-list/v2" as const,
             mode: "flat" as const,
             rows: selected.rows.map((row) => {
-              const directChildCount = selected.childCounts.get(row.taskId) ?? 0;
+              const directChildCount = childCounts[row.taskId] ?? 0;
               return {
                 taskId: row.taskId,
                 status: row.status,

--- a/packages/daemon/test/task-surface-reads-leases.integration.test.ts
+++ b/packages/daemon/test/task-surface-reads-leases.integration.test.ts
@@ -246,6 +246,20 @@ test("task read surfaces, dry-runs, idempotency, structured input, and supersede
       (listed.rows as { taskId: string }[]).map((row) => row.taskId),
       ["task_source"],
     );
+    assert.equal(
+      (listed.rows as { rootAssessment: { directChildCount: number } }[])[0]?.rootAssessment.directChildCount,
+      2,
+      "a filtered list still counts each row's children across the whole ledger",
+    );
+    const everything = evidence(await cell.run({ kind: "task-list" }, binding));
+    assert.deepEqual(
+      (everything.rows as { taskId: string }[])
+        .map((row) => row.taskId)
+        .filter((taskId) => taskId.startsWith("task_child") || taskId === "task_grandchild")
+        .sort(),
+      ["task_child_alpha", "task_child_beta", "task_grandchild"],
+      "a list without --parent includes child tasks",
+    );
     assert.equal(tree.schema, "task-list/v2");
     assert.equal((treeReceipt as Record<string, unknown>).schema, "task-list/v2");
     assert.deepEqual((treeReceipt as Record<string, unknown>).rows, tree.rows);

--- a/packages/kernel/src/projection/rebuildable-task-projection-factory.ts
+++ b/packages/kernel/src/projection/rebuildable-task-projection-factory.ts
@@ -204,6 +204,7 @@ export function makeTaskProjectionReader(options: {
       list: (query) => listProjection(projectionPath, readHead, unavailableSource, 4096, now, query),
       ...entityQueryApi(context),
       readTaskIndex: taskQueries.readTaskIndex,
+      readTaskChildCounts: taskQueries.readTaskChildCounts,
       readWorkspaceSummary: taskQueries.readWorkspaceSummary,
       readTaskRelations: taskQueries.readTaskRelations,
       readTaskRelationNeighborhood: taskQueries.readTaskRelationNeighborhood,

--- a/packages/kernel/src/projection/rebuildable-task-projection-task-queries.ts
+++ b/packages/kernel/src/projection/rebuildable-task-projection-task-queries.ts
@@ -9,6 +9,7 @@ import { readFactGraphRows } from "./fact-event-projection.ts";
 import {
   readTaskDependencyClosureRows,
   readTaskRelationNeighborhoodRows,
+  readTaskChildCounts,
   readTaskIndexRows,
   readTaskRelationPage,
   readTaskRelationRows,
@@ -100,6 +101,7 @@ export function taskQueryApi(
   | "readTaskRelations"
   | "readTaskRelationNeighborhood"
   | "readTaskIndex"
+  | "readTaskChildCounts"
   | "readWorkspaceSummary"
   | "readTaskDependencyClosure"
   | "readTaskRelationsByTargets"
@@ -139,6 +141,8 @@ export function taskQueryApi(
         };
       });
     },
+    readTaskChildCounts: (parentTaskIds) =>
+      withDatabase(projectionPath, readHead, (db) => readTaskChildCounts(db, parentTaskIds)),
     readWorkspaceSummary: () =>
       withDatabase(projectionPath, readHead, (db) => {
         const cut = readProjectionCut(db, readHead);

--- a/packages/kernel/src/projection/task-projection-port.ts
+++ b/packages/kernel/src/projection/task-projection-port.ts
@@ -83,6 +83,7 @@ export interface TaskProjection {
   readonly readTaskIndex: (
     query?: TaskProjectionListQuery,
   ) => import("./projection-reads.ts").TaskIndexProjectionRead & { readonly page: ProjectionPage | null };
+  readonly readTaskChildCounts: (parentTaskIds: readonly string[]) => Readonly<Record<string, number>>;
   readonly readWorkspaceSummary: () => WorkspaceSummaryProjectionRead;
   readonly readTaskRelations: () => TaskRelationProjectionRead;
   readonly readTaskRelationNeighborhood: (

--- a/packages/kernel/src/projection/task-query-projection.ts
+++ b/packages/kernel/src/projection/task-query-projection.ts
@@ -88,6 +88,26 @@ export interface NarrowTaskRow {
 /** One projection scan for the CLI task index. The row is intentionally limited
  * to list/tree fields, so callers do not hydrate executions, reviews, leases, or
  * relation graphs only to discard them after a metadata filter. */
+/** Direct children with an active package, counted across the whole ledger for the given parents. */
+export function readTaskChildCounts(
+  db: DatabaseSync,
+  parentTaskIds: readonly string[],
+): Readonly<Record<string, number>> {
+  if (parentTaskIds.length === 0) return {};
+  const parent = "json_extract(snapshot_json, '$.task.metadata.parentTaskId')";
+  return Object.fromEntries(
+    queryRows<{ readonly parent_task_id: string; readonly child_count: number }>(
+      db,
+      [
+        `SELECT ${parent} AS parent_task_id, COUNT(*) AS child_count FROM task_snapshot`,
+        "WHERE COALESCE(json_extract(snapshot_json, '$.task.packageDisposition'), 'active') = 'active'",
+        `AND ${parent} IN (SELECT value FROM json_each(?)) GROUP BY parent_task_id`,
+      ].join(" "),
+      JSON.stringify(parentTaskIds),
+    ).map((row) => [row.parent_task_id, Number(row.child_count)]),
+  );
+}
+
 export function readTaskIndexRows(
   db: DatabaseSync,
   query: TaskProjectionListQuery = {},


### PR DESCRIPTION
# English

## Summary

Regression from R3 (#2424), found right after deploying ac1e3cb0f: `ha task list` without `--parent` returned only top-level tasks. The canonical daemon listed 989 rows (active 10, in_review 3) while the projection holds 2117 active-package tasks (active 20, in_review 11); the GUI board reads the same list. The SQL pushdown turned an absent `--parent` into `parentTaskId IS NULL`. A second defect from the same change: each row's `directChildCount` (and so its root assessment) was counted from the returned rows only, so any filtered or paged list showed milestone roots with 0 children. Now the parent filter applies only when `--parent` is given, and child counts come from one grouped SQL read over the whole ledger for the returned rows.

## What Changed

- `repo-cell-task-query.ts`: no parent filter unless `--parent` is given; flat rows take child counts from `readTaskChildCounts`.
- `task-query-projection.ts` + port + rebuildable implementation: `readTaskChildCounts(parentTaskIds)`, one grouped query over active-package tasks.
- `task-surface-reads-leases.integration.test.ts`: a filtered list reports the source task's 2 children; an unfiltered list includes the children and grandchild.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: +32/-3 (net +29), from `node tools/gates/production-delta.mjs --base origin/main`.

## Machine-Readable Declarations

## Task And Scope

- Harness task: task_f8456626b923534705b547de3e
- Branch: `codex/task-list-children`
- Public scope: flat task list rows and child counts
- Private planning/evidence updated: yes (task plan and worker report)
- Out of scope: tree mode (it still reads the full active set, unchanged by R3)

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: not applicable
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `40e79162e`
- Branch merge-base with `origin/main`: `40e79162e`
- Last `git fetch origin` time: 2026-09-10 21:15 UTC
- Sync method: rebased onto origin/main
- Public diff command: `git diff origin/main...codex/task-list-children`
- Private evidence commit/path: task_f8456626b923534705b547de3e task package report
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Negative controls, each isolated: with main's list code the filtered-count assertion fails; with only the parent line reverted, the `includes child tasks` assertion fails.
- `task-surface-reads-leases`, `task-query-read`, `task-index-query`, `projection-query-shape`, `task-query-projection`: 35/35.
- G1 `task-list.sqlRowsRead` 6 at 200 and 6 at 2000; G38, line-density, production-delta, `run-manifest-gates --changed origin/main` pass.
- F-EB1964E0 records the deployed symptom.
- Not run: the full `npm run check` / `npm test` locally. Local agents must not run the full matrix, so CI is the full authority.

## Review Evidence

- Lead-authored hotfix; the R3 review accepted the SQL pushdown without a test for an unfiltered list with children, which is added here.
- Reviewer subagent: not used
- Human review: pending
- Blocking findings: none

## Residual Risk

- The grouped count evaluates `json_extract` over every task row in SQLite for each list call; it returns only one row per parent.

## References

- Task: task_f8456626b923534705b547de3e
- Regression source: PR #2424 (task_bfbf7a1daa6a50d9984706e3a5)
- Fact: F-EB1964E0

---

# 中文

## 概要

R3（#2424）引入的回归，部署 ac1e3cb0f 之后立即发现：不带 `--parent` 的 `ha task list` 只返回顶层任务。canonical daemon 列出 989 行（active 10、in_review 3），而投影里有 2117 个 active 包任务（active 20、in_review 11）；GUI 看板读的是同一份列表。SQL 下推把「没传 `--parent`」变成了 `parentTaskId IS NULL`。同一改动还有第二个缺陷：每行的 `directChildCount`（进而根任务判定）只按返回的行计算，筛选或分页后的列表里里程碑根任务一律显示 0 个子任务。现在只有传了 `--parent` 才加父任务过滤；子任务数由一条分组 SQL 在全部台账上为返回的行统计。

## 改动内容

- `repo-cell-task-query.ts`：只有传 `--parent` 才加父任务过滤；flat 行的子任务数取自 `readTaskChildCounts`。
- `task-query-projection.ts`、端口与 rebuildable 实现：`readTaskChildCounts(parentTaskIds)`，对 active 包任务做一次分组查询。
- `task-surface-reads-leases.integration.test.ts`：筛选后的列表报告源任务有 2 个子任务；不筛选的列表包含子任务与孙任务。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 删除的门或 fixture：none
- 生产净行数：+32/-3 (net +29)，由 `node tools/gates/production-delta.mjs --base origin/main` 计算。

## 机读声明说明

- 本 PR 不涉及依赖变化和事件迁移，没有机读声明。

## 任务与范围

- Harness 任务：task_f8456626b923534705b547de3e
- 分支：`codex/task-list-children`
- 公开范围：flat 任务列表的行与子任务数
- 私有计划 / 证据是否已更新：yes（任务计划与 worker 报告）
- 范围外：tree 模式（仍读取完整 active 集合，R3 未改）

## 版本影响

- 版本：不改版本
- 发布影响：不发布

## 治理声明

- 是否触碰 protected surface：no
- protected surface 范围：不适用
- 依据：不适用
- 机器检查边界：本 PR 只声明该段存在；声明是否真实、充分，由 reviewer 判断。
- Break-glass：no
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- `origin/main` 基准 SHA：`40e79162e`
- 当前分支与 `origin/main` 的 merge-base：`40e79162e`
- 最近一次 `git fetch origin` 时间：2026-09-10 21:15 UTC
- 同步方式：rebase 到 origin/main
- 公开 diff 命令：`git diff origin/main...codex/task-list-children`
- 私有证据 commit/path：task_f8456626b923534705b547de3e 任务包报告
- Reviewer 证据路径：见本 PR 的「审查证据」一节
- GitHub Actions `rewrite-ci` run URL：本 PR 的 CI 还在跑
- [ ] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- 阴性对照各自独立：用 main 的 list 代码，筛选后子任务数的断言失败；只撤回 parent 那一行，「包含子任务」的断言失败。
- `task-surface-reads-leases`、`task-query-read`、`task-index-query`、`projection-query-shape`、`task-query-projection`：35/35。
- G1 `task-list.sqlRowsRead` 在 200 与 2000 档都是 6；G38、line-density、production-delta、`run-manifest-gates --changed origin/main` 通过。
- F-EB1964E0 记录了部署后的症状。
- 未运行：本地整套 `npm run check` / `npm test`。规定禁止本地 agent 跑全量矩阵，全量以 CI 为准。

## 审查证据

- 主控编写的热修；R3 评审接受了 SQL 下推，但没有「带子任务的不筛选列表」这一测试，这里补上。
- Reviewer subagent：未使用
- 人工审查：待进行
- 阻塞发现：无

## 残余风险

- 分组计数在每次列表调用时对每一行任务求一次 `json_extract`；每个父任务只返回一行。

## 关联材料

- Task: task_f8456626b923534705b547de3e
- Regression source: PR #2424 (task_bfbf7a1daa6a50d9984706e3a5)
- Fact: F-EB1964E0

---

## PR Gate Checklist / PR 门禁清单

- [x] Branch is based on latest `origin/main`. / 分支基于最新 `origin/main`。
- [x] PR body uses this full template structure. / PR 描述使用本模板完整结构。
- [x] PR body uses two complete language blocks: `# English` first, then `# 中文`. / PR 正文使用两块完整正文：`# English` 在上，`# 中文` 在下。
- [x] PR body passes `tools/check-pr-body-bilingual.mjs`. / PR 正文通过 `tools/check-pr-body-bilingual.mjs`。
- [x] If the PR touches a manifest-derived protected surface, Governance Declaration is filled with ADR/decision/task evidence or break-glass fields. / 若 PR 触碰 manifest 派生的 protected surface，Governance Declaration 已填写 ADR/decision/task 依据或 break-glass 字段。
- [x] No private harness files are included. / 不包含私有 harness 文件。
- [x] No ignored local agent entry files are included. / 不包含被忽略的本地 agent 入口文件。
- [x] No absolute local filesystem paths are included in this public PR body. / 本公开 PR 描述不包含本机绝对路径。
- [x] Public diff is limited to the stated task scope. / 公开 diff 限于声明的任务范围。
- [x] Private planning/evidence updates are recorded when applicable. / 适用时已记录私有计划 / 证据更新。
- [x] Version and publish impact are stated. / 已说明版本与发布影响。
- [x] Local verification commands are recorded honestly. / 已如实记录本地验证命令。
- [ ] CI results are linked or explained. / CI 结果已链接或说明。
- [x] Review evidence is recorded. / 已记录审查证据。
- [x] Open P0/P1/P2 findings are closed, deferred with owner, or explicitly blocked. / open P0/P1/P2 findings 已关闭、带 owner 延后，或明确阻塞。
- [x] Merge method and post-merge branch cleanup plan are clear. / 合并方式和合并后分支清理计划清楚。
- [x] No admin bypass is planned unless explicitly approved and recorded. / 除非明确批准并记录，否则不计划 admin bypass。
