### PR TITLE
fix(kernel): closeout blocker names the missing or template sections

### DIFF
--- a/packages/application/test/task-lifecycle-transition-service.test.ts
+++ b/packages/application/test/task-lifecycle-transition-service.test.ts
@@ -87,6 +87,21 @@ test("completion blocker matrix returns one canonical next for every substantive
       assert.equal((blockers[0]?.next.command.length ?? 0) > 0, true, code);
       assert.equal((blockers[0]?.next.reason.length ?? 0) > 0, true, code);
     }
+    const missingSections = completionBlockers(consented.snapshot, "execution-1", {
+      ...ready,
+      closeout: "placeholder",
+      closeoutMissingSections: [
+        { section: "Summary", reason: "empty" },
+        { section: "Verification", reason: "empty" },
+      ],
+    })[0]!;
+    assert.match(missingSections.next.reason, /missing sections: Summary, Verification/);
+    const templateSection = completionBlockers(consented.snapshot, "execution-1", {
+      ...ready,
+      closeout: "placeholder",
+      closeoutMissingSections: [{ section: "Residual Risk", reason: "scaffold" }],
+    })[0]!;
+    assert.match(templateSection.next.reason, /still template: Residual Risk/);
     // The lineage blocker names the missing edge with the exact command that writes it.
     const lineage = completionBlockers(orphanMilestone, "execution-1", ready)[0]!;
     assert.equal(

--- a/packages/daemon/src/repo-cell-task-progress.ts
+++ b/packages/daemon/src/repo-cell-task-progress.ts
@@ -562,6 +562,10 @@ export function completionContext(
     }),
     closeoutPath = closeoutDocument.path,
     projected = cell.projection.readDocument(closeoutPath),
+    closeoutAssessment = assessTransitionDocument(
+      requireTransitionDocumentKind("task.complete"),
+      projected.document?.body ?? "",
+    ),
     scan = scanDocCandidates({
       rootDir: cell.rootDir,
       workspaceId: cell.input.repoId,
@@ -577,7 +581,7 @@ export function completionContext(
       ? "dirty_eligible"
       : projected.document === null
         ? "missing"
-        : !assessTransitionDocument(requireTransitionDocumentKind("task.complete"), projected.document.body).ready
+        : !closeoutAssessment.ready
           ? "placeholder"
           : "ready";
   const producesFactCount = cell.projection
@@ -594,5 +598,11 @@ export function completionContext(
         row.state === "active" &&
         row.targetRef.startsWith("fact/"),
     ).length;
-  return { closeout, closeoutPath, eligibleDirtyPaths, producesFactCount };
+  return {
+    closeout,
+    closeoutPath,
+    closeoutMissingSections: closeoutAssessment.missingSections,
+    eligibleDirtyPaths,
+    producesFactCount,
+  };
 }

--- a/packages/kernel/src/domain/completion-readiness.ts
+++ b/packages/kernel/src/domain/completion-readiness.ts
@@ -1,6 +1,7 @@
 import type { TaskLifecycleSnapshot } from "./task-lifecycle.contract.ts";
 import { closeoutReadiness } from "./closeout-readiness.ts";
 import { approvedReviewHistoryForExecution } from "./review.ts";
+import type { TransitionDocumentMissingSection } from "./transition-document-readiness.ts";
 
 export type CompletionBlockerCode =
   | "not_in_review"
@@ -29,6 +30,7 @@ export interface CompletionBlocker {
 export interface CompletionReadinessContext {
   readonly closeout: "ready" | "placeholder" | "dirty_eligible" | "missing";
   readonly closeoutPath: string;
+  readonly closeoutMissingSections?: readonly TransitionDocumentMissingSection[];
   readonly eligibleDirtyPaths: readonly string[];
   readonly producesFactCount: number;
 }
@@ -142,11 +144,19 @@ export function completionBlockers(
       "Publish eligible closeout and artifact edits through doc-sync.",
     );
   if (context.closeout !== "ready")
-    return one(
-      "closeout_placeholder",
-      "closeout",
-      `edit harness/${context.closeoutPath}`,
-      "Replace the canonical closeout placeholder before completion.",
-    );
+    return one("closeout_placeholder", "closeout", `edit harness/${context.closeoutPath}`, closeoutReason(context));
   return [];
+}
+
+function closeoutReason(context: CompletionReadinessContext): string {
+  const sections = context.closeoutMissingSections ?? [],
+    missing = sections.filter(({ reason }) => reason === "empty").map(({ section }) => section),
+    scaffold = sections.filter(({ reason }) => reason === "scaffold").map(({ section }) => section),
+    details = [
+      missing.length ? `missing sections: ${missing.join(", ")}` : "",
+      scaffold.length ? `still template: ${scaffold.join(", ")}` : "",
+    ].filter(Boolean);
+  return details.length
+    ? `closeout.md ${details.join("; ")}.`
+    : "Replace the canonical closeout placeholder before completion.";
 }

--- a/packages/kernel/test/transition-document-readiness.test.ts
+++ b/packages/kernel/test/transition-document-readiness.test.ts
@@ -127,6 +127,14 @@ test("closeout uses the same required-section and scaffold rules", () => {
     ).ready,
     true,
   );
+  assert.deepEqual(
+    assessTransitionDocument(
+      "task.closeout",
+      "# Closeout\n\n## Summary（交付了什么）\n\nDone.\n\n## Verification\n\nTests passed.\n\n" +
+        "## Residual Risk\n\nNone.\n\n## Same Mechanism Elsewhere\n\nNot applicable.",
+    ).missingSections.map(({ section }) => section),
+    ["Summary"],
+  );
 });
 
 test("decision and declaration documents reject their canonical blank scaffolds", () => {


### PR DESCRIPTION
# English

## Summary

`ha task complete` rejected an incomplete closeout with `closeout_placeholder` and "Replace the canonical closeout placeholder before completion.", without saying which section. On 2026-09-11 a complete closeout for task_0cc28139 was rejected only because its headings read `## Summary（交付了什么）`; the message sent two rounds of investigation in the wrong direction. The readiness check already knew the missing and still-template sections; the completion blocker now names them, e.g. `closeout.md missing sections: Summary; still template: Residual Risk.` Heading matching is unchanged.

## What Changed

- `completion-readiness.ts`: the closeout blocker's reason lists missing and still-template sections; the generic sentence remains when none are known.
- `repo-cell-task-progress.ts`: pass the closeout assessment's sections into the readiness context.
- Tests: blocker reasons for missing and template sections; a suffixed `## Summary（…）` heading counts as missing.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: +28/-8 (net +20), from `node tools/gates/production-delta.mjs --base origin/main`.

## Machine-Readable Declarations

## Task And Scope

- Harness task: task_24321def74569024e4d5bba0b3
- Branch: `codex/closeout-section-diagnostic`
- Public scope: closeout blocker message
- Private planning/evidence updated: yes (task plan and worker report)
- Out of scope: accepting suffixed headings

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: not applicable
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `40e79162e`
- Branch merge-base with `origin/main`: `40e79162e`
- Last `git fetch origin` time: 2026-09-10 21:55 UTC
- Sync method: rebased onto origin/main
- Public diff command: `git diff origin/main...codex/closeout-section-diagnostic`
- Private evidence commit/path: task_24321def74569024e4d5bba0b3 task package report
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- `transition-document-readiness.test.ts` and `task-lifecycle-transition-service.test.ts`: 19/19; negative control: with main's `completion-readiness.ts` the new service test fails.
- `tsc -b packages/kernel packages/daemon`, line-density, `run-manifest-gates --changed origin/main`, G4 fallback boundaries pass.
- Not run: the full `npm run check` / `npm test` locally. Local agents must not run the full matrix, so CI is the full authority.

## Review Evidence

- Lead review of the Terra worker's commit; the reason reaches the CLI through the rejection explanation (see PR #2437 for criterion-bearing rejections).
- Reviewer subagent: not used
- Human review: pending
- Blocking findings: none

## Residual Risk

- A suffixed heading is reported as a missing section; the message does not suggest renaming the heading.

## References

- Task: task_24321def74569024e4d5bba0b3

---

# 中文

## 概要

`ha task complete` 遇到不完整的 closeout 时返回 `closeout_placeholder` 和 "Replace the canonical closeout placeholder before completion."，不说是哪一节。2026-09-11 task_0cc28139 的 closeout 内容完整，只因标题写成 `## Summary（交付了什么）` 被拒，这句提示把两轮排查都引到了错误方向。readiness 检查本来就知道缺哪几节、哪几节还是模板；现在完成阻塞会点名，例如 `closeout.md missing sections: Summary; still template: Residual Risk.`。标题匹配规则不变。

## 改动内容

- `completion-readiness.ts`：closeout 阻塞的原因列出缺失与仍为模板的小节；两者都未知时保留通用句。
- `repo-cell-task-progress.ts`：把 closeout 评估出的小节传入 readiness 上下文。
- 测试：缺节与模板小节的阻塞原因；带后缀的 `## Summary（…）` 标题算作缺失。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 删除的门或 fixture：none
- 生产净行数：+28/-8 (net +20)，由 `node tools/gates/production-delta.mjs --base origin/main` 计算。

## 机读声明说明

- 本 PR 不涉及依赖变化和事件迁移，没有机读声明。

## 任务与范围

- Harness 任务：task_24321def74569024e4d5bba0b3
- 分支：`codex/closeout-section-diagnostic`
- 公开范围：closeout 阻塞提示
- 私有计划 / 证据是否已更新：yes（任务计划与 worker 报告）
- 范围外：接受带后缀的标题

## 版本影响

- 版本：不改版本
- 发布影响：不发布

## 治理声明

- 是否触碰 protected surface：no
- protected surface 范围：不适用
- 依据：不适用
- 机器检查边界：本 PR 只声明该段存在；声明是否真实、充分，由 reviewer 判断。
- Break-glass：no
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- `origin/main` 基准 SHA：`40e79162e`
- 当前分支与 `origin/main` 的 merge-base：`40e79162e`
- 最近一次 `git fetch origin` 时间：2026-09-10 21:55 UTC
- 同步方式：rebase 到 origin/main
- 公开 diff 命令：`git diff origin/main...codex/closeout-section-diagnostic`
- 私有证据 commit/path：task_24321def74569024e4d5bba0b3 任务包报告
- Reviewer 证据路径：见本 PR 的「审查证据」一节
- GitHub Actions `rewrite-ci` run URL：本 PR 的 CI 还在跑
- [ ] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- `transition-document-readiness.test.ts` 与 `task-lifecycle-transition-service.test.ts`：19/19；阴性对照：换回 main 的 `completion-readiness.ts`，新的服务测试失败。
- `tsc -b packages/kernel packages/daemon`、line-density、`run-manifest-gates --changed origin/main`、G4 fallback 边界通过。
- 未运行：本地整套 `npm run check` / `npm test`。规定禁止本地 agent 跑全量矩阵，全量以 CI 为准。

## 审查证据

- 主控审查 Terra worker 的提交；原因经拒绝说明到达 CLI（带 criterion 的拒绝见 PR #2437）。
- Reviewer subagent：未使用
- 人工审查：待进行
- 阻塞发现：无

## 残余风险

- 带后缀的标题会被报告为缺失小节；提示不会建议改标题。

## 关联材料

- Task: task_24321def74569024e4d5bba0b3

---

## PR Gate Checklist / PR 门禁清单

- [x] Branch is based on latest `origin/main`. / 分支基于最新 `origin/main`。
- [x] PR body uses this full template structure. / PR 描述使用本模板完整结构。
- [x] PR body uses two complete language blocks: `# English` first, then `# 中文`. / PR 正文使用两块完整正文：`# English` 在上，`# 中文` 在下。
- [x] PR body passes `tools/check-pr-body-bilingual.mjs`. / PR 正文通过 `tools/check-pr-body-bilingual.mjs`。
- [x] If the PR touches a manifest-derived protected surface, Governance Declaration is filled with ADR/decision/task evidence or break-glass fields. / 若 PR 触碰 manifest 派生的 protected surface，Governance Declaration 已填写 ADR/decision/task 依据或 break-glass 字段。
- [x] No private harness files are included. / 不包含私有 harness 文件。
- [x] No ignored local agent entry files are included. / 不包含被忽略的本地 agent 入口文件。
- [x] No absolute local filesystem paths are included in this public PR body. / 本公开 PR 描述不包含本机绝对路径。
- [x] Public diff is limited to the stated task scope. / 公开 diff 限于声明的任务范围。
- [x] Private planning/evidence updates are recorded when applicable. / 适用时已记录私有计划 / 证据更新。
- [x] Version and publish impact are stated. / 已说明版本与发布影响。
- [x] Local verification commands are recorded honestly. / 已如实记录本地验证命令。
- [ ] CI results are linked or explained. / CI 结果已链接或说明。
- [x] Review evidence is recorded. / 已记录审查证据。
- [x] Open P0/P1/P2 findings are closed, deferred with owner, or explicitly blocked. / open P0/P1/P2 findings 已关闭、带 owner 延后，或明确阻塞。
- [x] Merge method and post-merge branch cleanup plan are clear. / 合并方式和合并后分支清理计划清楚。
- [x] No admin bypass is planned unless explicitly approved and recorded. / 除非明确批准并记录，否则不计划 admin bypass。
