### PR TITLE
fix(daemon): validate lifecycle ids at admission with the replay identity contracts

### DIFF
--- a/packages/daemon/src/repo-cell-action-dispatch.ts
+++ b/packages/daemon/src/repo-cell-action-dispatch.ts
@@ -6,6 +6,7 @@ import {
   executionExecutorDeclarationCandidates,
   getExecutableEntityAction,
   lifecycleDocumentPaths,
+  requireEntityTypeContract,
   type WriteReceiptDraft as WriteReceipt,
 } from "../../kernel/src/index.ts";
 import { runPresetAction } from "../../preset/src/index.ts";
@@ -29,6 +30,7 @@ export async function executeAction(
   action: RepoTaskAction,
   binding: RepoCellBinding,
 ): Promise<WriteReceipt> {
+  validateCanonicalIdentityInputs(cell, action);
   if (
     [
       "vertical-declaration-migrate",
@@ -341,6 +343,22 @@ export async function executeAction(
   if (action.kind === "task-declare-executor") return cell.declareExecutionExecutor(action, binding);
   if (action.kind === "task-closeout") return cell.closeoutTask(action, binding);
   return cell.lifecycleAction(action, binding);
+}
+
+export function validateCanonicalIdentityInputs(cell: RepoCellOperationalContext, action: RepoTaskAction): void {
+  const fields = [
+    ["taskId", "task"],
+    ["executionId", "execution"],
+    ["reviewId", "review"],
+  ] as const;
+  for (const [field, kind] of fields) {
+    const value = action[field];
+    if (typeof value !== "string" || value.length === 0) continue;
+    const identity = requireEntityTypeContract(kind).id,
+      pattern = identity.refPattern ?? identity.pattern;
+    if (!new RegExp(`(?:${pattern})`, "u").test(value))
+      throw cell.cellCodedError("invalid_field", `${field} must match the canonical ${kind} identifier pattern.`);
+  }
 }
 
 export function declareExecutionExecutor(

--- a/packages/daemon/src/repo-cell-task-create.ts
+++ b/packages/daemon/src/repo-cell-task-create.ts
@@ -1,6 +1,5 @@
 import { createHash } from "node:crypto";
 import {
-  parseEntityRef,
   sessionProvenance,
   taskBootstrapWritePlan,
   type WriteReceiptDraft as WriteReceipt,
@@ -146,11 +145,6 @@ export function prepareTaskCreateAt(
     canonicalOpId = cell.operationId(canonicalAction, binding, cell.input.repoId, 0),
     opId = dryRun ? `preview:${createHash("sha256").update(canonicalOpId).digest("hex")}` : canonicalOpId,
     existing = dryRun ? null : cell.store.readEvent(opId);
-  if (typeof canonicalAction.taskId === "string" && parseEntityRef(`task/${canonicalAction.taskId}`)?.kind !== "task")
-    throw cell.cellCodedError(
-      "invalid_task_id",
-      `Task id ${canonicalAction.taskId} cannot be parsed as a task entity reference.`,
-    );
   if (existing) {
     return cell.receiptForOperation(opId, binding);
   }

--- a/packages/daemon/test/task-action-catalog-executor.test.ts
+++ b/packages/daemon/test/task-action-catalog-executor.test.ts
@@ -6,6 +6,31 @@ import { makeEntityActionCatalogExecutor, deriveActionResult } from "../src/enti
 import { rejectExecutionSelection } from "../src/repo-cell-execution-selection.ts";
 import { cellCriterionError } from "../src/repo-cell-errors.ts";
 import { failed } from "../src/repo-cell-settlement.ts";
+import { validateCanonicalIdentityInputs } from "../src/repo-cell-action-dispatch.ts";
+
+test("shared action admission rejects replay-invalid lifecycle identities", () => {
+  const cell = {
+    cellCodedError: (code: string, message: string) => Object.assign(new Error(message), { code }),
+  } as never;
+  for (const [field, value] of [
+    ["taskId", "t0"],
+    ["executionId", "exec.1"],
+    ["reviewId", "review.1"],
+  ] as const) {
+    assert.throws(
+      () => validateCanonicalIdentityInputs(cell, { kind: "test", [field]: value }),
+      (error: unknown) => (error as { code?: string }).code === "invalid_field",
+    );
+  }
+  assert.doesNotThrow(() =>
+    validateCanonicalIdentityInputs(cell, {
+      kind: "task-start",
+      taskId: "task_valid",
+      executionId: "exec-valid",
+      reviewId: "review-valid",
+    }),
+  );
+});
 
 test("the catalog executor directly invokes Task execution metadata and derives ActionResult", async () => {
   const executor = makeEntityActionCatalogExecutor({

--- a/packages/daemon/test/task-surface.integration.test.ts
+++ b/packages/daemon/test/task-surface.integration.test.ts
@@ -26,12 +26,43 @@ test("task create rejects ids that cannot form task entity references", async (t
     { actor, source: "local" },
   );
   assert.equal(rejected.outcome, "op_rejected");
-  assert.equal(rejected.code, "invalid_task_id");
+  assert.equal(rejected.code, "invalid_field");
   const accepted = await cell.run(
     { kind: "task-create", taskId: "task-t0", title: "Valid id" },
     { actor, source: "local" },
   );
   assert.equal(accepted.outcome, "applied");
+  // Bench F7: the same admission guard covers every lifecycle identity, not only task create.
+  const proposed = await cell.run(
+      {
+        kind: "decision-propose",
+        jsonInput: JSON.stringify({
+          title: "Reckon target",
+          question: "Which task delivers it?",
+          riskTier: "low",
+          urgency: "low",
+          vertical: "software/coding",
+          preset: "standard-task",
+          decisionClass: "ordinary",
+          appliesTo: { modules: ["daemon"], productLines: ["harness-anything"] },
+          chosen: [{ id: "CH1", text: "Deliver it" }],
+          rejected: [{ id: "RJ1", text: "Skip it", whyNot: "It is needed" }],
+          claims: [{ id: "C1", text: "It is needed", loadBearing: false }],
+        }),
+      },
+      { actor, source: "local" },
+    ),
+    decisionId = (JSON.parse(String(proposed.evidence)) as { readonly decisionId: string }).decisionId;
+  for (const action of [
+    { kind: "decision-reckon", decisionId, taskId: "t0" },
+    { kind: "task-start", commandType: "StartExecution", taskId: "task-t0", executionId: "exec.1" },
+    { kind: "task-review-execution", commandType: "RecordReview", taskId: "task-t0", reviewId: "review.1" },
+  ]) {
+    const refused = await cell.run(action, { actor, source: "local" });
+    assert.deepEqual([refused.outcome, refused.code], ["op_rejected", "invalid_field"], JSON.stringify(refused));
+  }
+  const listed = await cell.run({ kind: "task-list" }, { actor, source: "local" });
+  assert.match(String(listed.evidence), /task-t0/u);
 });
 
 test("task create publishes complete metadata and first-class relations survive cold rebuild", async () => {


### PR DESCRIPTION
# English

## Summary

Bench F7: two more entry points accepted input that the projection cannot replay, and one of them takes a repository offline for good. `decision reckon --task t0` is accepted (`publication_indeterminate`), after which every read and write of that repository returns `repo_unavailable`, also after a restart; `task start --execution-id exec.1` is accepted and then leaves writes stuck on `projection_pending`. The mechanism is the one F1 (#2430) fixed for `task create --id` only: admission checked that the value was non-empty, replay checks the entity identity pattern. Action admission now checks `taskId`, `executionId` and `reviewId` against the same entity identity contracts that replay uses, for every action, so the F1 check in task create is deleted.

## Architectural Justification

-

## What Changed

- `repo-cell-action-dispatch.ts`: `executeAction` first validates `taskId` against the task `refPattern`, and `executionId` and `reviewId` against their entity `pattern`, rejecting with `invalid_field`.
- `repo-cell-task-create.ts`: the task-create specific `invalid_task_id` check is deleted; the shared guard covers it.
- `task-surface.integration.test.ts`: the F1 test now also drives `decision reckon` (against a real proposed decision), `task start` and `task review-execution` with replay-invalid ids through the real cell, and checks the ledger stays readable. `task-action-catalog-executor.test.ts` covers the guard directly.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: +18/-6 (net +12), from `node tools/gates/production-delta.mjs --base origin/main`.

## Machine-Readable Declarations

## Task And Scope

- Harness task: task_605ad4c02dbc76453881c6cfa9
- Branch: `codex/f7-accept-replay-parity`
- Public scope: identity validation at action admission
- Private planning/evidence updated: yes (task plan, worker report, fact F-27DD2D89)
- Out of scope: malformed data already written to a ledger; create-time ids of schedules, agents and squads

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: not applicable
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `dbf396c92`
- Branch merge-base with `origin/main`: `dbf396c92`
- Last `git fetch origin` time: 2026-09-11 UTC (at branch creation)
- Sync method: branched from origin/main
- Public diff command: `git diff origin/main...codex/f7-accept-replay-parity`
- Private evidence commit/path: task_605ad4c02dbc76453881c6cfa9 task package report
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [x] `npm run typecheck` (as `npx tsc -b packages/kernel packages/daemon`, exit 0)
- [ ] `npm test`
- [x] `npm run harness:check-import-boundaries` (via `run-manifest-gates --changed origin/main`)
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts` (via `run-manifest-gates --changed origin/main`)
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- `task-surface.integration.test.ts`, `task-action-catalog-executor.test.ts`, `json-rpc-protocol.test.ts`: 62/62.
- Negative control: with main's two production files, the reckon step against a real decision with task `t0` returns `pending` / `publication_indeterminate` instead of `op_rejected` / `invalid_field`, which is the Bench F7 signature.
- The CLI maps `decision reckon --task`, `task start --execution-id` and `task review-execution --review-id` to `taskId`, `executionId` and `reviewId` (checked with `parseThinCommand`).
- G33, G36 and `run-manifest-gates --changed origin/main` pass.
- Not run: the full `npm run check` / `npm test` locally. Local agents must not run the full matrix, so CI is the full authority.

## Review Evidence

- Worker (Codex Sol) wrote the guard; the lead deleted the now duplicate task-create check, added the real-path assertions and the negative control.
- Reviewer subagent: not used
- Human review: pending
- Blocking findings: none

## Residual Risk

- Ledgers that already contain such ids stay unreadable; this change only prevents new ones.
- The error code for a bad task id in `task create` changes from `invalid_task_id` to `invalid_field`; no other consumer of the old code exists in the repository.

## References

- Task: task_605ad4c02dbc76453881c6cfa9
- Bench F7 (task_34935988e63cb55291ca3c5ada), F1 fix #2430
- Fact: F-27DD2D89

---

# 中文

## 概要

Bench F7：另有两个入口会受理投影无法回放的输入，其中一个会让仓库永久下线。`decision reckon --task t0` 被受理（`publication_indeterminate`），之后该仓库所有读写都返回 `repo_unavailable`，重启也不恢复；`task start --execution-id exec.1` 被受理后，写入一直卡在 `projection_pending`。机制与 F1（#2430）相同，而 F1 只修了 `task create --id`：受理只检查非空，回放按实体身份 pattern 校验。现在所有 action 在受理时都按回放使用的同一份实体身份契约检查 `taskId`、`executionId` 与 `reviewId`，task create 里 F1 的专项检查随之删除。

## 架构辩护

-

## 改动内容

- `repo-cell-action-dispatch.ts`：`executeAction` 先按 task 的 `refPattern` 校验 `taskId`，按各自实体的 `pattern` 校验 `executionId` 与 `reviewId`，不符即以 `invalid_field` 拒绝。
- `repo-cell-task-create.ts`：删掉 task create 专用的 `invalid_task_id` 检查，由共用检查覆盖。
- `task-surface.integration.test.ts`：F1 的测试现在还经真实 cell 用回放非法的 id 调 `decision reckon`（针对一个真实提出的 decision）、`task start` 与 `task review-execution`，并确认台账仍可读。`task-action-catalog-executor.test.ts` 直接覆盖该检查。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 删除的门或 fixture：none
- 生产净行数：+18/-6 (net +12)，由 `node tools/gates/production-delta.mjs --base origin/main` 计算。

## 机读声明说明

- 本 PR 不涉及依赖变化和事件迁移，没有机读声明。

## 任务与范围

- Harness 任务：task_605ad4c02dbc76453881c6cfa9
- 分支：`codex/f7-accept-replay-parity`
- 公开范围：action 受理时的身份校验
- 私有计划 / 证据是否已更新：yes（任务计划、worker 报告、fact F-27DD2D89）
- 范围外：已经写进台账的坏数据；schedule、agent、squad 创建时的 id

## 版本影响

- 版本：不改版本
- 发布影响：不发布

## 治理声明

- 是否触碰 protected surface：no
- protected surface 范围：不适用
- 依据：不适用
- 机器检查边界：本 PR 只声明该段存在；声明是否真实、充分，由 reviewer 判断。
- Break-glass：no
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- `origin/main` 基准 SHA：`dbf396c92`
- 当前分支与 `origin/main` 的 merge-base：`dbf396c92`
- 最近一次 `git fetch origin` 时间：2026-09-11 UTC（开分支时）
- 同步方式：从 origin/main 开分支
- 公开 diff 命令：`git diff origin/main...codex/f7-accept-replay-parity`
- 私有证据 commit/path：task_605ad4c02dbc76453881c6cfa9 任务包报告
- Reviewer 证据路径：见本 PR 的「审查证据」一节
- GitHub Actions `rewrite-ci` run URL：本 PR 的 CI 还在跑
- [ ] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [x] `npm run typecheck`（以 `npx tsc -b packages/kernel packages/daemon` 运行，exit 0）
- [ ] `npm test`
- [x] `npm run harness:check-import-boundaries`（经 `run-manifest-gates --changed origin/main`）
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts`（经 `run-manifest-gates --changed origin/main`）
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- `task-surface.integration.test.ts`、`task-action-catalog-executor.test.ts`、`json-rpc-protocol.test.ts`：62/62。
- 阴性对照：用 main 的两个生产文件，对真实 decision 以 task `t0` 做 reckon，返回 `pending` / `publication_indeterminate`，而不是 `op_rejected` / `invalid_field`，正是 Bench F7 的症状。
- CLI 把 `decision reckon --task`、`task start --execution-id`、`task review-execution --review-id` 分别映射为 `taskId`、`executionId`、`reviewId`（用 `parseThinCommand` 核对过）。
- G33、G36 与 `run-manifest-gates --changed origin/main` 通过。
- 未运行：本地整套 `npm run check` / `npm test`。规定禁止本地 agent 跑全量矩阵，全量以 CI 为准。

## 审查证据

- worker（Codex Sol）写了共用检查；主控删掉因此重复的 task create 检查，补了真实路径断言与阴性对照。
- Reviewer subagent：未使用
- 人工审查：待进行
- 阻塞发现：无

## 残余风险

- 已经含有这类 id 的台账仍然不可读；本改动只阻止新增。
- task create 遇到非法 task id 的错误码从 `invalid_task_id` 变为 `invalid_field`；仓库里没有旧错误码的其他使用方。

## 关联材料

- Task: task_605ad4c02dbc76453881c6cfa9
- Bench F7（task_34935988e63cb55291ca3c5ada）、F1 修复 #2430
- Fact: F-27DD2D89

---

## PR Gate Checklist / PR 门禁清单

- [x] Branch is based on latest `origin/main`. / 分支基于最新 `origin/main`。
- [x] PR body uses this full template structure. / PR 描述使用本模板完整结构。
- [x] PR body uses two complete language blocks: `# English` first, then `# 中文`. / PR 正文使用两块完整正文：`# English` 在上，`# 中文` 在下。
- [x] PR body passes `tools/check-pr-body-bilingual.mjs`. / PR 正文通过 `tools/check-pr-body-bilingual.mjs`。
- [x] If the PR touches a manifest-derived protected surface, Governance Declaration is filled with ADR/decision/task evidence or break-glass fields. / 若 PR 触碰 manifest 派生的 protected surface，Governance Declaration 已填写 ADR/decision/task 依据或 break-glass 字段。
- [x] No private harness files are included. / 不包含私有 harness 文件。
- [x] No ignored local agent entry files are included. / 不包含被忽略的本地 agent 入口文件。
- [x] No absolute local filesystem paths are included in this public PR body. / 本公开 PR 描述不包含本机绝对路径。
- [x] Public diff is limited to the stated task scope. / 公开 diff 限于声明的任务范围。
- [x] Private planning/evidence updates are recorded when applicable. / 适用时已记录私有计划 / 证据更新。
- [x] Version and publish impact are stated. / 已说明版本与发布影响。
- [x] Local verification commands are recorded honestly. / 已如实记录本地验证命令。
- [ ] CI results are linked or explained. / CI 结果已链接或说明。
- [x] Review evidence is recorded. / 已记录审查证据。
- [x] Open P0/P1/P2 findings are closed, deferred with owner, or explicitly blocked. / open P0/P1/P2 findings 已关闭、带 owner 延后，或明确阻塞。
- [x] Merge method and post-merge branch cleanup plan are clear. / 合并方式和合并后分支清理计划清楚。
- [x] No admin bypass is planned unless explicitly approved and recorded. / 除非明确批准并记录，否则不计划 admin bypass。
