### PR TITLE
fix(daemon): task lifecycle rejections keep the guard's reason

### DIFF
--- a/packages/daemon/src/task-action-catalog-runtime.ts
+++ b/packages/daemon/src/task-action-catalog-runtime.ts
@@ -393,7 +393,8 @@ function taskActionRejection(
 
     evidence: `criterion:${first.ref}`,
     unmetCriteria,
-    rejectionExplanation: first.explain,
+    // The guard's own reason says what is wrong; the criterion text only states what must hold.
+    rejectionExplanation: rejected?.rejectionExplanation || first.explain,
     nextActions,
   };
 }

--- a/packages/daemon/test/task-surface.integration.test.ts
+++ b/packages/daemon/test/task-surface.integration.test.ts
@@ -517,3 +517,29 @@ test("task lifecycle mutations publish L1 events, exact documents, and replayabl
     rmSync(rootDir, { recursive: true, force: true });
   }
 });
+
+test("a lifecycle rejection bound to a declared criterion reports the guard's own reason", async (t) => {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-task-rejection-reason-"));
+  t.after(() => rmSync(rootDir, { recursive: true, force: true }));
+  initRepo(rootDir);
+  const cell = await openRepoCell({
+    repoId: workspaceId("task-rejection-reason"),
+    rootDir: canonicalRoot(rootDir),
+    ownerId: "task-rejection-reason",
+  });
+  t.after(() => cell.close());
+  await cell.run({ kind: "task-create", taskId: "task-reason", title: "Reason" }, { actor, source: "local" });
+  const refused = await cell.run(
+    {
+      kind: "task-review-execution",
+      commandType: "RecordReview",
+      taskId: "task-reason",
+      reviewId: "review-reason",
+      jsonInput: JSON.stringify({ verdict: "approved", reason: "Looks done.", evidenceChecked: ["read"] }),
+    },
+    { actor, source: "local" },
+  );
+  assert.equal(refused.unmetCriteria?.[0]?.ref, "task-lifecycle-review-transitions/review.validate");
+  assert.match(String(refused.rejectionExplanation), /Current submitted execution candidates: none/u);
+  assert.notEqual(refused.rejectionExplanation, refused.unmetCriteria?.[0]?.explain);
+});


### PR DESCRIPTION
# English

## Summary

Task lifecycle rejections still hid the guard's reason after #2437. `taskActionRejection` spreads the specific rejection built by `failed()` (which #2437 fixed) and then overwrote `rejectionExplanation` with the criterion's requirement sentence. For task lifecycle actions, #2437's fix therefore never reached the caller. Example on main: `task review-execution` for a task with no submitted execution answered "…append-only Review history requires a new review id." It now answers "Current submitted execution candidates: none. Run ha task show …; if the task is active, run ha task submit …". Found by the round-2 CLI evidence run of task_c2c9ab598622e1988a68905251.

## Architectural Justification

-

## What Changed

- `task-action-catalog-runtime.ts` `taskActionRejection`: `rejectionExplanation` prefers the specific rejection's reason and falls back to the criterion text.
- `task-surface.integration.test.ts`: a review of a task with no submitted execution, through the real cell, reports the guard's reason and not the criterion sentence.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: +2/-1 (net +1), from `node tools/gates/production-delta.mjs --base origin/main`.

## Machine-Readable Declarations

## Task And Scope

- Harness task: task_c2c9ab598622e1988a68905251
- Branch: `codex/task-rejection-reason`
- Public scope: the explanation of task lifecycle rejections
- Private planning/evidence updated: yes (round-2 CLI evidence in the task package)
- Out of scope: rejections without a more specific reason (for example `lease_required`) keep the criterion text

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: not applicable
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `5f1bb2b7b`
- Branch merge-base with `origin/main`: `5f1bb2b7b`
- Last `git fetch origin` time: 2026-09-11 UTC (before rebase)
- Sync method: rebased onto origin/main
- Public diff command: `git diff origin/main...codex/task-rejection-reason`
- Private evidence commit/path: task_c2c9ab598622e1988a68905251 `artifacts/cli-evidence.md`
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [x] `npm run typecheck` (as `npx tsc -b packages/daemon`, exit 0)
- [ ] `npm test`
- [x] `npm run harness:check-import-boundaries` (via `run-manifest-gates --changed origin/main`)
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts` (via `run-manifest-gates --changed origin/main`)
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- New test passes; negative control with main's `task-action-catalog-runtime.ts`: it fails. `task-surface.integration.test.ts` and `task-action-catalog-executor.test.ts`: 12/12 after rebase.
- The test files that assert on `rejectionExplanation`: 88/89; the one failure is `sqlite-ledger-reconcile.integration.test.ts` waiting for a real daemon to start while the machine's load average was 104 (Docker benchmark running); it does not touch this code path.
- Not run: the full `npm run check` / `npm test` locally. Local agents must not run the full matrix, so CI is the full authority.

## Review Evidence

- Lead-authored one-line fix with a real-path test and negative control; root cause identified by the round-2 CLI evidence worker.
- Reviewer subagent: not used
- Human review: pending
- Blocking findings: none

## Residual Risk

- None known.

## References

- Task: task_c2c9ab598622e1988a68905251
- Related: PR #2425, PR #2437

---

# 中文

## 概要

#2437 之后，task 生命周期动作的拒绝仍然看不到守卫给出的原因。`taskActionRejection` 先展开 `failed()`（#2437 修的那处）构造的具体拒绝，随后又用 criterion 的要求句覆盖了 `rejectionExplanation`，所以对 task 生命周期动作而言，#2437 的修复从未到达调用方。main 上的例子：对一个没有已提交执行的任务做 `task review-execution`，回答是「…append-only Review history requires a new review id.」；现在回答「Current submitted execution candidates: none. Run ha task show …; if the task is active, run ha task submit …」。这是 task_c2c9ab598622e1988a68905251 第 2 轮 CLI 取证发现的。

## 架构辩护

-

## 改动内容

- `task-action-catalog-runtime.ts` 的 `taskActionRejection`：`rejectionExplanation` 优先取具体拒绝里的原因，没有时才退回 criterion 文案。
- `task-surface.integration.test.ts`：经真实 cell 对没有已提交执行的任务做评审，回执给出守卫的原因，而不是 criterion 句子。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 删除的门或 fixture：none
- 生产净行数：+2/-1 (net +1)，由 `node tools/gates/production-delta.mjs --base origin/main` 计算。

## 机读声明说明

- 本 PR 不涉及依赖变化和事件迁移，没有机读声明。

## 任务与范围

- Harness 任务：task_c2c9ab598622e1988a68905251
- 分支：`codex/task-rejection-reason`
- 公开范围：task 生命周期拒绝的说明文本
- 私有计划 / 证据是否已更新：yes（任务包里的第 2 轮 CLI 取证）
- 范围外：没有更具体原因的拒绝（例如 `lease_required`）仍用 criterion 文案

## 版本影响

- 版本：不改版本
- 发布影响：不发布

## 治理声明

- 是否触碰 protected surface：no
- protected surface 范围：不适用
- 依据：不适用
- 机器检查边界：本 PR 只声明该段存在；声明是否真实、充分，由 reviewer 判断。
- Break-glass：no
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- `origin/main` 基准 SHA：`5f1bb2b7b`
- 当前分支与 `origin/main` 的 merge-base：`5f1bb2b7b`
- 最近一次 `git fetch origin` 时间：2026-09-11 UTC（rebase 前）
- 同步方式：rebase 到 origin/main
- 公开 diff 命令：`git diff origin/main...codex/task-rejection-reason`
- 私有证据 commit/path：task_c2c9ab598622e1988a68905251 的 `artifacts/cli-evidence.md`
- Reviewer 证据路径：见本 PR 的「审查证据」一节
- GitHub Actions `rewrite-ci` run URL：本 PR 的 CI 还在跑
- [ ] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [x] `npm run typecheck`（以 `npx tsc -b packages/daemon` 运行，exit 0）
- [ ] `npm test`
- [x] `npm run harness:check-import-boundaries`（经 `run-manifest-gates --changed origin/main`）
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts`（经 `run-manifest-gates --changed origin/main`）
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- 新测试通过；阴性对照：换回 main 的 `task-action-catalog-runtime.ts`，该测试失败。rebase 后 `task-surface.integration.test.ts` 与 `task-action-catalog-executor.test.ts`：12/12。
- 所有断言 `rejectionExplanation` 的测试文件：88/89；唯一失败的是 `sqlite-ledger-reconcile.integration.test.ts`，它在等待真实 daemon 启动时超时，当时本机 load average 为 104（Docker Bench 在跑），与本改动的代码路径无关。
- 未运行：本地整套 `npm run check` / `npm test`。规定禁止本地 agent 跑全量矩阵，全量以 CI 为准。

## 审查证据

- 主控编写的一行修复，附真实路径测试与阴性对照；根因由第 2 轮 CLI 取证 worker 找到。
- Reviewer subagent：未使用
- 人工审查：待进行
- 阻塞发现：无

## 残余风险

- 无已知风险。

## 关联材料

- Task: task_c2c9ab598622e1988a68905251
- 相关：PR #2425、PR #2437

---

## PR Gate Checklist / PR 门禁清单

- [x] Branch is based on latest `origin/main`. / 分支基于最新 `origin/main`。
- [x] PR body uses this full template structure. / PR 描述使用本模板完整结构。
- [x] PR body uses two complete language blocks: `# English` first, then `# 中文`. / PR 正文使用两块完整正文：`# English` 在上，`# 中文` 在下。
- [x] PR body passes `tools/check-pr-body-bilingual.mjs`. / PR 正文通过 `tools/check-pr-body-bilingual.mjs`。
- [x] If the PR touches a manifest-derived protected surface, Governance Declaration is filled with ADR/decision/task evidence or break-glass fields. / 若 PR 触碰 manifest 派生的 protected surface，Governance Declaration 已填写 ADR/decision/task 依据或 break-glass 字段。
- [x] No private harness files are included. / 不包含私有 harness 文件。
- [x] No ignored local agent entry files are included. / 不包含被忽略的本地 agent 入口文件。
- [x] No absolute local filesystem paths are included in this public PR body. / 本公开 PR 描述不包含本机绝对路径。
- [x] Public diff is limited to the stated task scope. / 公开 diff 限于声明的任务范围。
- [x] Private planning/evidence updates are recorded when applicable. / 适用时已记录私有计划 / 证据更新。
- [x] Version and publish impact are stated. / 已说明版本与发布影响。
- [x] Local verification commands are recorded honestly. / 已如实记录本地验证命令。
- [ ] CI results are linked or explained. / CI 结果已链接或说明。
- [x] Review evidence is recorded. / 已记录审查证据。
- [x] Open P0/P1/P2 findings are closed, deferred with owner, or explicitly blocked. / open P0/P1/P2 findings 已关闭、带 owner 延后，或明确阻塞。
- [x] Merge method and post-merge branch cleanup plan are clear. / 合并方式和合并后分支清理计划清楚。
- [x] No admin bypass is planned unless explicitly approved and recorded. / 除非明确批准并记录，否则不计划 admin bypass。
