### PR TITLE
fix(daemon): yield between serialized writes so URL imports are not starved; one deadline for URL body

### DIFF
--- a/packages/daemon/src/artifact-entity-action.ts
+++ b/packages/daemon/src/artifact-entity-action.ts
@@ -54,8 +54,7 @@ import { requireCanonicalVerticalDeclaration, type VerticalDeclarationReader } f
 const compiledVerticals = new Map<string, CompiledVerticalContract>(),
   compiledDirections = new Map<string, readonly CanonicalRelationDirection[]>();
 export const artifactImportSourceResolution = Symbol("artifactImportSourceResolution");
-const ARTIFACT_SOURCE_FETCH_TIMEOUT_MS = 10_000,
-  ARTIFACT_SOURCE_BODY_MAX_BYTES = 10 * 1024 * 1024;
+const ARTIFACT_SOURCE_FETCH_TIMEOUT_MS = 10_000;
 /** `entityId` is null only for a dry run of material the center has never accepted; nothing is minted then. */
 type ArtifactImportReceipt = WriteReceipt & { readonly entityId: string | null };
 
@@ -513,29 +512,14 @@ async function resolveArtifactSource(input: {
   if (locator.kind === "url") {
     const controller = new AbortController(),
       timeout = setTimeout(() => controller.abort(), ARTIFACT_SOURCE_FETCH_TIMEOUT_MS);
-    let response: Response;
+    // One deadline covers the response headers and the body: a response that stalls after its headers times out.
     try {
-      response = await fetch(locator.value, { redirect: "follow", signal: controller.signal });
-    } catch (error) {
-      if (controller.signal.aborted)
-        throw new ArtifactEntityServiceError(
-          "source_resolution_timeout",
-          `URL resolver timed out after ${ARTIFACT_SOURCE_FETCH_TIMEOUT_MS} ms.`,
-        );
-      throw error;
-    }
-    const source = { kind: "url" as const, url: locator.value };
-    const code = response.status;
-    if (code === 404 || code === 410) {
-      clearTimeout(timeout);
-      return { status: "missing", source, reason: `HTTP ${code}`, resolver: "http" };
-    }
-    if (!response.ok) {
-      clearTimeout(timeout);
-      throw new Error(`URL resolver returned HTTP ${response.status}.`);
-    }
-    try {
-      const content = await readResponseBody(response, controller),
+      const response = await fetch(locator.value, { redirect: "follow", signal: controller.signal }),
+        source = { kind: "url" as const, url: locator.value },
+        code = response.status;
+      if (code === 404 || code === 410) return { status: "missing", source, reason: `HTTP ${code}`, resolver: "http" };
+      if (!response.ok) throw new Error(`URL resolver returned HTTP ${response.status}.`);
+      const content = new Uint8Array(await response.arrayBuffer()),
         name = path.basename(new URL(locator.value).pathname) || new URL(locator.value).hostname;
       return {
         status: "observed",
@@ -559,37 +543,6 @@ async function resolveArtifactSource(input: {
   throw new ArtifactEntityServiceError(
     "source_resolution_failed",
     `No external-key resolver is installed for ${input.contract.typeIdentity}.`,
-  );
-}
-
-async function readResponseBody(response: Response, _controller: AbortController): Promise<Uint8Array> {
-  const declaredLength = Number(response.headers.get("content-length"));
-  if (Number.isFinite(declaredLength) && declaredLength > ARTIFACT_SOURCE_BODY_MAX_BYTES) throw sourceBodyTooLarge();
-  if (!response.body) {
-    const content = new Uint8Array(await response.arrayBuffer());
-    if (content.byteLength > ARTIFACT_SOURCE_BODY_MAX_BYTES) throw sourceBodyTooLarge();
-    return content;
-  }
-  const chunks: Uint8Array[] = [];
-  let size = 0;
-  for await (const value of response.body as AsyncIterable<Uint8Array>) {
-    size += value.byteLength;
-    if (size > ARTIFACT_SOURCE_BODY_MAX_BYTES) throw sourceBodyTooLarge();
-    chunks.push(value);
-  }
-  const content = new Uint8Array(size);
-  let offset = 0;
-  for (const chunk of chunks) {
-    content.set(chunk, offset);
-    offset += chunk.byteLength;
-  }
-  return content;
-}
-
-function sourceBodyTooLarge(): ArtifactEntityServiceError {
-  return new ArtifactEntityServiceError(
-    "source_resolution_failed",
-    `URL resolver response exceeds ${ARTIFACT_SOURCE_BODY_MAX_BYTES} bytes.`,
   );
 }
 

--- a/packages/daemon/src/artifact-entity-action.ts
+++ b/packages/daemon/src/artifact-entity-action.ts
@@ -54,7 +54,8 @@ import { requireCanonicalVerticalDeclaration, type VerticalDeclarationReader } f
 const compiledVerticals = new Map<string, CompiledVerticalContract>(),
   compiledDirections = new Map<string, readonly CanonicalRelationDirection[]>();
 export const artifactImportSourceResolution = Symbol("artifactImportSourceResolution");
-const ARTIFACT_SOURCE_FETCH_TIMEOUT_MS = 10_000;
+const ARTIFACT_SOURCE_FETCH_TIMEOUT_MS = 10_000,
+  ARTIFACT_SOURCE_BODY_MAX_BYTES = 10 * 1024 * 1024;
 /** `entityId` is null only for a dry run of material the center has never accepted; nothing is minted then. */
 type ArtifactImportReceipt = WriteReceipt & { readonly entityId: string | null };
 
@@ -522,27 +523,73 @@ async function resolveArtifactSource(input: {
           `URL resolver timed out after ${ARTIFACT_SOURCE_FETCH_TIMEOUT_MS} ms.`,
         );
       throw error;
-    } finally {
-      clearTimeout(timeout);
     }
     const source = { kind: "url" as const, url: locator.value };
     const code = response.status;
-    if (code === 404 || code === 410) return { status: "missing", source, reason: `HTTP ${code}`, resolver: "http" };
-    if (!response.ok) throw new Error(`URL resolver returned HTTP ${response.status}.`);
-    const content = new Uint8Array(await response.arrayBuffer()),
-      name = path.basename(new URL(locator.value).pathname) || new URL(locator.value).hostname;
-    return {
-      status: "observed",
-      source,
-      witness: { kind: "content", content },
-      content: [sourceObject(name, content)],
-      title: name,
-      resolver: "http",
-    };
+    if (code === 404 || code === 410) {
+      clearTimeout(timeout);
+      return { status: "missing", source, reason: `HTTP ${code}`, resolver: "http" };
+    }
+    if (!response.ok) {
+      clearTimeout(timeout);
+      throw new Error(`URL resolver returned HTTP ${response.status}.`);
+    }
+    try {
+      const content = await readResponseBody(response, controller),
+        name = path.basename(new URL(locator.value).pathname) || new URL(locator.value).hostname;
+      return {
+        status: "observed",
+        source,
+        witness: { kind: "content", content },
+        content: [sourceObject(name, content)],
+        title: name,
+        resolver: "http",
+      };
+    } catch (error) {
+      if (controller.signal.aborted)
+        throw new ArtifactEntityServiceError(
+          "source_resolution_timeout",
+          `URL resolver timed out after ${ARTIFACT_SOURCE_FETCH_TIMEOUT_MS} ms.`,
+        );
+      throw error;
+    } finally {
+      clearTimeout(timeout);
+    }
   }
   throw new ArtifactEntityServiceError(
     "source_resolution_failed",
     `No external-key resolver is installed for ${input.contract.typeIdentity}.`,
+  );
+}
+
+async function readResponseBody(response: Response, _controller: AbortController): Promise<Uint8Array> {
+  const declaredLength = Number(response.headers.get("content-length"));
+  if (Number.isFinite(declaredLength) && declaredLength > ARTIFACT_SOURCE_BODY_MAX_BYTES) throw sourceBodyTooLarge();
+  if (!response.body) {
+    const content = new Uint8Array(await response.arrayBuffer());
+    if (content.byteLength > ARTIFACT_SOURCE_BODY_MAX_BYTES) throw sourceBodyTooLarge();
+    return content;
+  }
+  const chunks: Uint8Array[] = [];
+  let size = 0;
+  for await (const value of response.body as AsyncIterable<Uint8Array>) {
+    size += value.byteLength;
+    if (size > ARTIFACT_SOURCE_BODY_MAX_BYTES) throw sourceBodyTooLarge();
+    chunks.push(value);
+  }
+  const content = new Uint8Array(size);
+  let offset = 0;
+  for (const chunk of chunks) {
+    content.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return content;
+}
+
+function sourceBodyTooLarge(): ArtifactEntityServiceError {
+  return new ArtifactEntityServiceError(
+    "source_resolution_failed",
+    `URL resolver response exceeds ${ARTIFACT_SOURCE_BODY_MAX_BYTES} bytes.`,
   );
 }
 

--- a/packages/daemon/src/repo-cell.ts
+++ b/packages/daemon/src/repo-cell.ts
@@ -197,7 +197,6 @@ export async function initializeRepoCell(context: RepoCellCoreInput): Promise<Re
 }
 
 export function chainRepoCellWrite<T>(tail: Promise<void>, work: () => T | PromiseLike<T>): Promise<T> {
-  return tail.then(
-    () => new Promise<T>((resolve, reject) => setImmediate(() => Promise.resolve(work()).then(resolve, reject))),
-  );
+  // One event-loop turn between serialized writes, so timers and I/O are not starved by a write backlog.
+  return tail.then(() => new Promise<void>((resolve) => setImmediate(resolve))).then(work);
 }

--- a/packages/daemon/src/repo-cell.ts
+++ b/packages/daemon/src/repo-cell.ts
@@ -197,5 +197,7 @@ export async function initializeRepoCell(context: RepoCellCoreInput): Promise<Re
 }
 
 export function chainRepoCellWrite<T>(tail: Promise<void>, work: () => T | PromiseLike<T>): Promise<T> {
-  return tail.then(work);
+  return tail.then(
+    () => new Promise<T>((resolve, reject) => setImmediate(() => Promise.resolve(work()).then(resolve, reject))),
+  );
 }

--- a/packages/daemon/test/artifact-entity-action.integration.test.ts
+++ b/packages/daemon/test/artifact-entity-action.integration.test.ts
@@ -364,6 +364,67 @@ test("URL source resolution does not block a concurrent repository write", async
   }
 });
 
+test("URL source resolution times out when response body never completes", async () => {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-url-body-timeout-")),
+    repoId = workspaceId("url-body-timeout");
+  let cell: Awaited<ReturnType<typeof openRepoCell>> | undefined;
+  const server = createServer((_request, response) => {
+    response.writeHead(200, { "content-type": "text/plain" });
+    response.write("partial");
+  });
+  try {
+    initRepo(rootDir);
+    cell = await openRepoCell({
+      repoId,
+      rootDir: canonicalRoot(rootDir),
+      ownerId: "url-body-timeout-center",
+      now: () => "2026-09-11T02:00:00.000Z",
+    });
+    const created = await cell.run(
+      {
+        kind: "vertical-kind-upsert",
+        kindId: "remote-note",
+        expectedVersion: 0,
+        declaration: {
+          id: "remote-note",
+          entityType: "artifact",
+          idPrefix: "RN",
+          display: { singular: "Remote Note", plural: "Remote Notes" },
+          descriptorSchemaRef: "schema://artifact-descriptor",
+          store: { pathTemplate: "entities/remote-notes/{id}.json" },
+          locatorKinds: ["url"],
+        },
+      },
+      binding,
+    );
+    const kindRef = (JSON.parse(String(created.evidence)) as { kindRef: string }).kindRef;
+    await new Promise<void>((resolve, reject) => {
+      server.once("error", reject);
+      server.listen(0, "127.0.0.1", () => resolve());
+    });
+    const address = server.address();
+    assert.ok(address && typeof address === "object");
+    const started = Date.now(),
+      imported = await cell.run(
+        {
+          kind: "entity-import",
+          entityKind: kindRef,
+          locator: `http://127.0.0.1:${String(address.port)}/partial.md`,
+          expectedVersion: 0,
+        },
+        binding,
+      );
+    assert.equal(imported.outcome, "op_rejected", JSON.stringify(imported));
+    assert.equal(imported.code, "source_resolution_timeout", JSON.stringify(imported));
+    assert.ok(Date.now() - started >= 9_000);
+    assert.ok(Date.now() - started < 12_000);
+  } finally {
+    await cell?.close();
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});
+
 test("Directory artifact import fingerprints files, replays unchanged content, and records missing", async () => {
   const rootDir = mkdtempSync(path.join(tmpdir(), "ha-directory-artifact-import-")),
     sourcePath = "research/2026-09-05-directory-artifacts",

--- a/packages/daemon/test/artifact-entity-action.integration.test.ts
+++ b/packages/daemon/test/artifact-entity-action.integration.test.ts
@@ -425,6 +425,92 @@ test("URL source resolution times out when response body never completes", async
   }
 });
 
+test("URL source resolution completes while seven writers keep the repository queue busy", async () => {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-url-import-load-")),
+    repoId = workspaceId("url-import-load");
+  let cell: Awaited<ReturnType<typeof openRepoCell>> | undefined,
+    writing = true;
+  const server = createServer((_request, response) => response.end("# Remote note\n"));
+  const writers: Promise<number>[] = [];
+  try {
+    initRepo(rootDir);
+    cell = await openRepoCell({
+      repoId,
+      rootDir: canonicalRoot(rootDir),
+      ownerId: "url-import-load-center",
+      now: () => "2026-09-11T02:00:00.000Z",
+    });
+    const created = await cell.run(
+      {
+        kind: "vertical-kind-upsert",
+        kindId: "remote-note",
+        expectedVersion: 0,
+        declaration: {
+          id: "remote-note",
+          entityType: "artifact",
+          idPrefix: "RN",
+          display: { singular: "Remote Note", plural: "Remote Notes" },
+          descriptorSchemaRef: "schema://artifact-descriptor",
+          store: { pathTemplate: "entities/remote-notes/{id}.json" },
+          locatorKinds: ["url"],
+        },
+      },
+      binding,
+    );
+    const kindRef = (JSON.parse(String(created.evidence)) as { kindRef: string }).kindRef;
+    await new Promise<void>((resolve, reject) => {
+      server.once("error", reject);
+      server.listen(0, "127.0.0.1", () => resolve());
+    });
+    const address = server.address();
+    assert.ok(address && typeof address === "object");
+    const openCell = cell;
+    for (let writer = 0; writer < 7; writer += 1)
+      writers.push(
+        (async () => {
+          let written = 0;
+          while (writing) {
+            await openCell.run(
+              {
+                kind: "fact-record",
+                statement: `Load writer ${String(writer)} observation ${String(written)}.`,
+                evidenceSource: "test:url-import-load",
+                confidence: "high",
+                memoryClass: "episodic",
+                memoryTags: [],
+              },
+              binding,
+            );
+            written += 1;
+          }
+          return written;
+        })(),
+      );
+    const started = Date.now(),
+      imported = await cell.run(
+        {
+          kind: "entity-import",
+          entityKind: kindRef,
+          locator: `http://127.0.0.1:${String(address.port)}/note.md`,
+          expectedVersion: 0,
+        },
+        binding,
+      ),
+      elapsed = Date.now() - started;
+    writing = false;
+    const written = (await Promise.all(writers)).reduce((sum, count) => sum + count, 0);
+    assert.equal(imported.outcome, "applied", JSON.stringify(imported));
+    assert.ok(elapsed < 5_000, `URL import took ${String(elapsed)} ms under load`);
+    assert.ok(written > 0, "the writers kept the queue busy");
+  } finally {
+    writing = false;
+    await Promise.allSettled(writers);
+    await cell?.close();
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});
+
 test("Directory artifact import fingerprints files, replays unchanged content, and records missing", async () => {
   const rootDir = mkdtempSync(path.join(tmpdir(), "ha-directory-artifact-import-")),
     sourcePath = "research/2026-09-05-directory-artifacts",


### PR DESCRIPTION
# English

## Summary

Bench F6: after F2 (#2435) moved URL fetching out of the write queue, a URL entity import starved under sustained writes. Its 10 s timeout fired 13–25 s late, and in a 600 s run no import finished. Cause: the repository's serialized writes were chained as back-to-back promise microtasks, so while a write backlog existed the event loop never reached its timer and I/O phases, and the fetch made no progress. The write chain now yields one event-loop turn (`setImmediate`) between writes; writes stay strictly serialized. Separately, the fetch deadline was cleared once headers arrived, so a response that stalled after its headers hung forever. One abort deadline now covers the headers and the body.

## Architectural Justification

-

## What Changed

- `repo-cell.ts` `chainRepoCellWrite`: waits one `setImmediate` turn before each serialized write. The yield runs before the write inside the promise chain, so a write that throws synchronously still rejects its caller.
- `artifact-entity-action.ts`: one try/finally keeps the abort timer armed through `response.arrayBuffer()` and maps an abort to `source_resolution_timeout`.
- `artifact-entity-action.integration.test.ts`: a response that stalls after its headers times out; with seven writers keeping the queue busy, a URL import to a fast local endpoint applies within 5 s.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: +18/-17 (net +1), from `node tools/gates/production-delta.mjs --base origin/main`.

## Machine-Readable Declarations

## Task And Scope

- Harness task: task_c4cb53aaee10608ce8f6ac6c09
- Branch: `codex/f6-url-import-starvation`
- Public scope: the repository write chain and URL source resolution
- Private planning/evidence updated: yes (task plan, worker report, facts F-6C619565 and F-0F91FF23)
- Out of scope: a size limit for URL bodies beyond the existing entity content ceiling

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: not applicable
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `5f1bb2b7b`
- Branch merge-base with `origin/main`: `5f1bb2b7b`
- Last `git fetch origin` time: 2026-09-11 UTC (before rebase)
- Sync method: rebased onto origin/main
- Public diff command: `git diff origin/main...codex/f6-url-import-starvation`
- Private evidence commit/path: task_c4cb53aaee10608ce8f6ac6c09 task package report
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [x] `npm run typecheck` (as `npx tsc -b packages/kernel packages/daemon`, exit 0)
- [ ] `npm test`
- [x] `npm run harness:check-import-boundaries` (via `run-manifest-gates --changed origin/main`)
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts` (via `run-manifest-gates --changed origin/main`)
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- `artifact-entity-action.integration.test.ts` 7/7, including the F2 test "URL source resolution does not block a concurrent repository write".
- Negative controls: with main's `repo-cell.ts`, the load test's import returns `source_resolution_timeout` after about 16 s; with main's `artifact-entity-action.ts`, the stalled-body test hangs until the 40 s test timeout (F-0F91FF23).
- Wider write-path tests: `json-rpc-protocol`, `task-surface`, `fact-retirement-completion` 63/63; `writer-request-cost`, `local-writer-fence`, `writer-watchdog-feed`, `writer-supervisor-liveness` 9/9. G38, G33, G36 and `run-manifest-gates --changed origin/main` pass.
- Not run: the Bench's 600 s seven-client benchmark, and the full `npm run check` / `npm test` locally; CI is the full authority.

## Review Evidence

- Worker (Codex Terra) found the cause and wrote the first version; the lead fixed the synchronous-throw regression in the chain, removed the streaming size cap (+49 → +1 net), and added the load test and both negative controls.
- Reviewer subagent: not used
- Human review: pending
- Blocking findings: none

## Residual Risk

- Each serialized write now waits one event-loop turn; under a backlog this adds well under a millisecond per write in exchange for timers and I/O making progress.
- A very large URL body is buffered in full before the existing content ceiling refuses it.

## References

- Task: task_c4cb53aaee10608ce8f6ac6c09
- Bench F6 (task_34935988e63cb55291ca3c5ada), F2 #2435
- Facts: F-6C619565, F-0F91FF23

---

# 中文

## 概要

Bench F6：F2（#2435）把 URL 取数移出写队列后，URL entity import 在持续写入下被饿死：10 秒超时晚触发 13–25 秒，600 秒负载下一条 import 都没完成。原因：仓库的串行写入被串成一条接一条的 promise 微任务，只要有写入积压，事件循环就进不了定时器和 I/O 阶段，取数没有进展。现在写入链在两次写入之间让出一个事件循环轮次（`setImmediate`），写入仍严格串行。另外，取数的截止计时器在响应头到达后就被清除，响应头之后停住的 body 会永远挂住；现在一个中止截止时间同时覆盖响应头和 body。

## 架构辩护

-

## 改动内容

- `repo-cell.ts` 的 `chainRepoCellWrite`：每次串行写入前等待一个 `setImmediate` 轮次。让出发生在 promise 链内、写入之前，所以同步抛错的写入仍然让调用方拿到 reject。
- `artifact-entity-action.ts`：用一个 try/finally 让中止计时器一直持续到 `response.arrayBuffer()` 结束，中止映射为 `source_resolution_timeout`。
- `artifact-entity-action.integration.test.ts`：响应头之后停住的响应会超时；7 个写入者让队列持续忙碌时，指向快速本地端点的 URL import 在 5 秒内受理。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 删除的门或 fixture：none
- 生产净行数：+18/-17 (net +1)，由 `node tools/gates/production-delta.mjs --base origin/main` 计算。

## 机读声明说明

- 本 PR 不涉及依赖变化和事件迁移，没有机读声明。

## 任务与范围

- Harness 任务：task_c4cb53aaee10608ce8f6ac6c09
- 分支：`codex/f6-url-import-starvation`
- 公开范围：仓库写入链与 URL 来源解析
- 私有计划 / 证据是否已更新：yes（任务计划、worker 报告、fact F-6C619565 与 F-0F91FF23）
- 范围外：在现有 entity 内容上限之外再给 URL body 加大小限制

## 版本影响

- 版本：不改版本
- 发布影响：不发布

## 治理声明

- 是否触碰 protected surface：no
- protected surface 范围：不适用
- 依据：不适用
- 机器检查边界：本 PR 只声明该段存在；声明是否真实、充分，由 reviewer 判断。
- Break-glass：no
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- `origin/main` 基准 SHA：`5f1bb2b7b`
- 当前分支与 `origin/main` 的 merge-base：`5f1bb2b7b`
- 最近一次 `git fetch origin` 时间：2026-09-11 UTC（rebase 前）
- 同步方式：rebase 到 origin/main
- 公开 diff 命令：`git diff origin/main...codex/f6-url-import-starvation`
- 私有证据 commit/path：task_c4cb53aaee10608ce8f6ac6c09 任务包报告
- Reviewer 证据路径：见本 PR 的「审查证据」一节
- GitHub Actions `rewrite-ci` run URL：本 PR 的 CI 还在跑
- [ ] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [x] `npm run typecheck`（以 `npx tsc -b packages/kernel packages/daemon` 运行，exit 0）
- [ ] `npm test`
- [x] `npm run harness:check-import-boundaries`（经 `run-manifest-gates --changed origin/main`）
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts`（经 `run-manifest-gates --changed origin/main`）
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- `artifact-entity-action.integration.test.ts` 7/7，含 F2 的测试「URL source resolution does not block a concurrent repository write」。
- 阴性对照：换回 main 的 `repo-cell.ts`，负载测试里的 import 约 16 秒后返回 `source_resolution_timeout`；换回 main 的 `artifact-entity-action.ts`，停住的 body 一直挂到 40 秒测试超时（F-0F91FF23）。
- 更广的写路径测试：`json-rpc-protocol`、`task-surface`、`fact-retirement-completion` 63/63；`writer-request-cost`、`local-writer-fence`、`writer-watchdog-feed`、`writer-supervisor-liveness` 9/9。G38、G33、G36 与 `run-manifest-gates --changed origin/main` 通过。
- 未运行：Bench 的 600 秒 7 client 基准，以及本地整套 `npm run check` / `npm test`；全量以 CI 为准。

## 审查证据

- worker（Codex Terra）找到原因并写了第一版；主控修正了写入链里同步抛错的回归，删掉流式大小上限（净增 +49 → +1），补了负载测试与两个阴性对照。
- Reviewer subagent：未使用
- 人工审查：待进行
- 阻塞发现：无

## 残余风险

- 每次串行写入多等一个事件循环轮次；积压时每次写入增加远小于 1 毫秒，换来定时器与 I/O 能推进。
- 很大的 URL body 会先完整缓冲，再被现有内容上限拒绝。

## 关联材料

- Task: task_c4cb53aaee10608ce8f6ac6c09
- Bench F6（task_34935988e63cb55291ca3c5ada）、F2 #2435
- Facts: F-6C619565、F-0F91FF23

---

## PR Gate Checklist / PR 门禁清单

- [x] Branch is based on latest `origin/main`. / 分支基于最新 `origin/main`。
- [x] PR body uses this full template structure. / PR 描述使用本模板完整结构。
- [x] PR body uses two complete language blocks: `# English` first, then `# 中文`. / PR 正文使用两块完整正文：`# English` 在上，`# 中文` 在下。
- [x] PR body passes `tools/check-pr-body-bilingual.mjs`. / PR 正文通过 `tools/check-pr-body-bilingual.mjs`。
- [x] If the PR touches a manifest-derived protected surface, Governance Declaration is filled with ADR/decision/task evidence or break-glass fields. / 若 PR 触碰 manifest 派生的 protected surface，Governance Declaration 已填写 ADR/decision/task 依据或 break-glass 字段。
- [x] No private harness files are included. / 不包含私有 harness 文件。
- [x] No ignored local agent entry files are included. / 不包含被忽略的本地 agent 入口文件。
- [x] No absolute local filesystem paths are included in this public PR body. / 本公开 PR 描述不包含本机绝对路径。
- [x] Public diff is limited to the stated task scope. / 公开 diff 限于声明的任务范围。
- [x] Private planning/evidence updates are recorded when applicable. / 适用时已记录私有计划 / 证据更新。
- [x] Version and publish impact are stated. / 已说明版本与发布影响。
- [x] Local verification commands are recorded honestly. / 已如实记录本地验证命令。
- [ ] CI results are linked or explained. / CI 结果已链接或说明。
- [x] Review evidence is recorded. / 已记录审查证据。
- [x] Open P0/P1/P2 findings are closed, deferred with owner, or explicitly blocked. / open P0/P1/P2 findings 已关闭、带 owner 延后，或明确阻塞。
- [x] Merge method and post-merge branch cleanup plan are clear. / 合并方式和合并后分支清理计划清楚。
- [x] No admin bypass is planned unless explicitly approved and recorded. / 除非明确批准并记录，否则不计划 admin bypass。
