### PR TITLE
test(scale): CLI and entity scale bench with correctness oracles

### DIFF
--- a/tools/scale/README.md
+++ b/tools/scale/README.md
@@ -76,7 +76,9 @@ node tools/scale/cli-entity-bench.mjs --compare a.json,b.json   # p50 ratio per 
 `--docker` copies the working tree into the container, runs `npm ci` and the hermetic preflight,
 runs the bench against a fixture daemon under a per-run user root, and copies
 `bench-results-<sha>-<tasks>.{json,md}` plus `host-load.json` back to `--out`. Other options:
-`--samples` (CLI samples per command, default 5), `--clients` (concurrent clients, default 8).
+`--samples` (CLI samples per command, default 5), `--clients` (concurrent clients, default 8),
+`--populate-budget-s` (stop issuing population writes after this many seconds and measure at the
+reached counts, which the results record).
 
 * Population: `tasks` Tasks, then 0.45 Facts, 0.48 Decisions, 0.5 Relations and 0.1 imports of
   each vertical artifact kind per Task, written through the CLI's own parser and daemon client with

--- a/tools/scale/README.md
+++ b/tools/scale/README.md
@@ -59,3 +59,35 @@ conditions, both rounds, a human table, and numeric repair priorities.
 The harness records load average and free memory before/after each round. The
 machine currently runs other workers, so values are suitable for same-host
 comparisons and trend/extrapolation, not cross-host SLO claims.
+
+## CLI and entity scale bench
+
+`cli-entity-bench.mjs` measures data correctness and latency for every `ha` CLI command and every
+entity read/write path on a real daemon at a declared Task count. It runs in the local Docker test
+image (`plt-center-testbed/source:latest`) in a fresh `harness-test-isolation-*` container:
+
+```sh
+node tools/scale/cli-entity-bench.mjs --docker --tasks 1000 --out <dir>
+node tools/scale/cli-entity-bench.mjs --docker --tasks 10000 --out <dir>
+node tools/scale/cli-entity-bench.mjs --matrix                  # coverage matrix, no daemon
+node tools/scale/cli-entity-bench.mjs --compare a.json,b.json   # p50 ratio per metric
+```
+
+`--docker` copies the working tree into the container, runs `npm ci` and the hermetic preflight,
+runs the bench against a fixture daemon under a per-run user root, and copies
+`bench-results-<sha>-<tasks>.{json,md}` plus `host-load.json` back to `--out`. Other options:
+`--samples` (CLI samples per command, default 5), `--clients` (concurrent clients, default 8).
+
+* Population: `tasks` Tasks, then 0.45 Facts, 0.48 Decisions, 0.5 Relations and 0.1 imports of
+  each vertical artifact kind per Task, written through the CLI's own parser and daemon client with
+  `--clients` concurrent requests (the `rpc` arm). No SQL is written.
+* Every mapped registry command runs `--samples` times as a real `ha` process (the `cli` arm, with
+  `HA_CLI_TIMING` phases); reads are also sampled on the `rpc` arm. `cli-entity-bench.commands.mjs`
+  maps each registry id to a sample builder or to the reason it is not measured; unmapped ids are
+  reported, never dropped.
+* Throughput: 100 Fact writes on 1 and on `--clients` clients; three rounds of `--clients`
+  concurrent CLI processes. Cold reads: `daemon stop` -> `daemon start --service` -> first read.
+* Oracles (`cli-entity-bench.oracles.mjs`): receipt vs. durable outcome both ways (B1), written
+  values and file bytes found by opId (B2), list visibility including deletes (B3), reads equal
+  before and after `daemon projection rebuild` (B4), ledger revision/outcome structure (B5, the
+  stress O2 oracle). Each run also feeds every oracle a corrupted input and records that it fails.

--- a/tools/scale/cli-entity-bench.commands.mjs
+++ b/tools/scale/cli-entity-bench.commands.mjs
@@ -1,0 +1,480 @@
+// Coverage table for tools/scale/cli-entity-bench.mjs. An entry is either a sample builder
+// `(c, s) => argv` or a string naming why the command is not measured. Entries run in table
+// order once per sample s, so a chain command reads what its producer returned for the same s
+// through c.got(id, s). Registry ids missing from this table are reported as unmapped.
+
+const worker = { actor: "agent:scale-bench-worker" },
+  offline = { offline: true };
+const J = JSON.stringify;
+const runtime = "spawns a real agent runtime process";
+const artifactKinds = ["research", "architecture-decision-record", "external-issue"];
+
+export const benchKinds = artifactKinds;
+
+export const decisionPacket = (title, text) =>
+  J({
+    title,
+    question: `Should ${title} hold?`,
+    riskTier: "medium",
+    urgency: "medium",
+    vertical: "default",
+    preset: "default",
+    decisionClass: "ordinary",
+    appliesTo: { modules: ["kernel"], productLines: [] },
+    chosen: [{ id: "CH1", text }],
+    rejected: [{ id: "RJ1", text: "Keep the old path", whyNot: "Not canonical" }],
+    claims: [],
+    fulfillments: [],
+  });
+
+// A fresh package reaches the worktree asynchronously; wait for it before writing into it.
+const visible = (metric) => (c, s) => {
+  const opId = c.got.get(`${metric}#${s}`)?.opId ?? "none";
+  return ["receipt", "show", opId, "--wait", "worktree_visible", "--timeout-ms", "60000"];
+};
+const chain = (s) => `bench-chain-${s}`,
+  chain2 = (s) => `bench-chain2-${s}`,
+  chain3 = (s) => `bench-chain3-${s}`;
+
+const entityEntries = artifactKinds.flatMap((kind) => [
+  [`entity-import~${kind}`, (c, s) => c.importArgs(kind, `probe-${s}`)],
+  [`entity-get~${kind}`, (c, s) => ["entity", "get", kind, "--id", c.id(`entity-import~${kind}`, s)]],
+  [`entity-list~${kind}`, () => ["entity", "list", kind]],
+  [
+    `entity-update~${kind}`,
+    (c, s) => [
+      ...["entity", "update", kind, "--id", c.id(`entity-import~${kind}`, s), "--title", c.text(`upd ${kind} ${s}`)],
+      ...["--expected-version", c.rev(`entity-import~${kind}`, s)],
+    ],
+  ],
+  [
+    `entity-archive~${kind}`,
+    (c, s) => [
+      ...["entity", "archive", kind, "--id", c.id(`entity-import~${kind}`, s), "--reason", "bench"],
+      ...["--expected-version", c.rev(`entity-update~${kind}`, s)],
+    ],
+  ],
+  [`entity-import~delete-${kind}`, (c, s) => c.importArgs(kind, `del-${s}`)],
+  [
+    `entity-delete~${kind}`,
+    (c, s) => [
+      ...["entity", "delete", kind, "--id", c.id(`entity-import~delete-${kind}`, s), "--reason", "bench"],
+      ...["--expected-version", c.rev(`entity-import~delete-${kind}`, s)],
+    ],
+  ],
+  [`entity-get~deleted-${kind}`, (c, s) => ["entity", "get", kind, "--id", c.id(`entity-import~delete-${kind}`, s)]],
+]);
+
+export const commandTable = [
+  // Task lifecycle, one chain Task per sample.
+  [
+    "task-create",
+    (c, s) => ["task", "create", "--id", chain(s), "--admin", "--title", `Chain ${s}`, "--preset", "docs-task"],
+  ],
+  ["task-show", (c, s) => ["task", "show", chain(s)]],
+  ["task-read-set", (c, s) => ["task", "read-set", chain(s)]],
+  ["task-dispatches", (c, s) => ["task", "dispatches", chain(s)]],
+  ["task-amend", (c, s) => ["task", "amend", chain(s), "--set", `title:Chain ${s} amended`]],
+  ["task-pin", (c, s) => ["task", "pin", chain(s)]],
+  ["task-unpin", (c, s) => ["task", "unpin", chain(s)]],
+  ["receipt-show~visible", visible("task-create")],
+  ["doc-sync-submit~plan", (c, s) => ["doc", "sync", "--submit", "--path", c.realizePlan(s)]],
+  ["task-start", (c, s) => ["task", "start", chain(s), "--execution-id", `exe-chain-${s}`], worker],
+  ["task-progress-append", (c, s) => ["task", "progress", "append", chain(s), "--text", c.text("progress")], worker],
+  [
+    "task-artifact-add",
+    (c, s) => [
+      ...["task", "artifact", "add", chain(s), "--source", c.repoFile(`src-${s}.md`, `# a ${s}\n`)],
+      ...["--destination", `artifacts/bench-${s}.md`],
+    ],
+    worker,
+  ],
+  ["doc-status", (c, s) => ["doc", "status", "--task", chain(s)]],
+  ["doc-sync-dry-run", (c, s) => (c.writeCloseout(s), ["doc", "sync", "--dry-run", "--task", chain(s)])],
+  ["doc-sync-submit", (c, s) => ["doc", "sync", "--submit", "--task", chain(s)], worker],
+  ["doc-show", (c, s) => ["doc", "show", "--path", `${c.packagePath(s)}/closeout.md`]],
+  [
+    "fact-record~chain",
+    (c, s) => ["fact", "record", chain(s), "--statement", c.text(`chain fact ${s}`), "--source", "bench"],
+  ],
+  ["task-submit", (c, s) => ["task", "submit", chain(s), "--json-input", J(c.submission(s))], worker],
+  ["task-code-doc-reconcile", (c, s) => ["task", "code-doc", "reconcile", chain(s), "--path", "README.md"]],
+  ["task-show~witness", (c, s) => ["task", "show", chain(s)]],
+  ["task-review", (c, s) => ["task", "review", chain(s)]],
+  [
+    "task-review-execution",
+    (c, s) => ["task", "review-execution", chain(s), "--review-id", `rev-${s}`, "--json-input", J(c.review(s))],
+  ],
+  [
+    "task-review-consent",
+    (c, s) => ["task", "review-consent", chain(s), "--consent-id", `con-${s}`, "--json-input", J(c.consent(s))],
+  ],
+  ["task-complete", (c, s) => ["task", "complete", chain(s)]],
+  [
+    "task-code-doc-repoint",
+    (c, s) => [
+      "task",
+      "code-doc",
+      "repoint",
+      chain(s),
+      "--record",
+      c.field("task-show~witness", s, "witnessId"),
+      "--reason",
+      "b",
+    ],
+  ],
+  // Chain 2 closes out through the composite command; chain 3 walks the non-happy transitions.
+  [
+    "task-create~chain2",
+    (c, s) => ["task", "create", "--id", chain2(s), "--admin", "--title", `Chain2 ${s}`, "--preset", "docs-task"],
+  ],
+  ["receipt-show~visible2", visible("task-create~chain2")],
+  ["doc-sync-submit~plan2", (c, s) => ["doc", "sync", "--submit", "--path", c.realizePlan(s, "~chain2")]],
+  ["task-start~chain2", (c, s) => ["task", "start", chain2(s), "--execution-id", `exe-chain2-${s}`], worker],
+  [
+    "doc-sync-submit~chain2",
+    (c, s) => (c.writeCloseout(s, "~chain2"), ["doc", "sync", "--submit", "--task", chain2(s)]),
+    worker,
+  ],
+  [
+    "fact-record~chain2",
+    (c, s) => ["fact", "record", chain2(s), "--statement", c.text(`chain2 fact ${s}`), "--source", "bench"],
+  ],
+  [
+    "task-submit~chain2",
+    (c, s) => ["task", "submit", chain2(s), "--json-input", J(c.submission(s, "~chain2"))],
+    worker,
+  ],
+  [
+    "task-closeout",
+    (c, s) => [
+      ...["task", "closeout", chain2(s), "--json-input"],
+      J({
+        review: c.review(s, "~chain2"),
+        consent: { approved: true },
+        completion: { ci: "not_applicable", codeDocPaths: [] },
+      }),
+    ],
+  ],
+  ["task-create~chain3", (c, s) => ["task", "create", "--id", chain3(s), "--admin", "--title", `Chain3 ${s}`]],
+  ["receipt-show~visible3", visible("task-create~chain3")],
+  ["doc-sync-submit~plan3", (c, s) => ["doc", "sync", "--submit", "--path", c.realizePlan(s, "~chain3")]],
+  ["task-start~chain3", (c, s) => ["task", "start", chain3(s), "--execution-id", `exe-chain3-${s}`], worker],
+  ["task-release", (c, s) => ["task", "release", chain3(s), "--reason", "bench"], worker],
+  ["task-transition", (c, s) => ["task", "transition", chain3(s), "blocked", "--reason", "bench"]],
+  ["task-declare-executor", (c, s) => ["task", "declare-executor", chain3(s), "--reason", "bench"]],
+  ["task-archive", (c, s) => ["task", "archive", chain3(s), "--reason", "bench"]],
+  ["task-reopen", (c, s) => ["task", "reopen", chain3(s), "--reason", "bench reopen"]],
+  [
+    "task-supersede",
+    (c, s) => ["task", "supersede", c.task(s + 1), "--title", `Replacement ${s}`, "--reason", "bench"],
+  ],
+  ["task-delete", (c, s) => ["task", "delete", "--soft", c.task(s + 20), "--confirm", c.task(s + 20), "--reason", "b"]],
+  ["task-contract-migrate", () => ["task", "contract", "migrate", "--dry-run"]],
+  ["task-list", () => ["task", "list"]],
+  ["task-list~status", () => ["task", "list", "--status", "planned"]],
+  ["task-list~search", (c) => ["task", "list", "--search", c.task(7)]],
+  ["task-list~kind", () => ["task", "list", "--kind", "docs"]],
+  ["agenda", () => ["agenda"]],
+  ["agenda~page", () => ["agenda", "--limit", "20"]],
+  // Facts.
+  ["fact-record", (c, s) => ["fact", "record", c.task(s), "--statement", c.text(`fact ${s}`), "--source", "bench"]],
+  ["fact-show", (c, s) => ["fact", "show", "--id", c.id("fact-record", s)]],
+  ["fact-search", () => ["fact", "search", "bench"]],
+  ["fact-search~task", (c, s) => ["fact", "search", "--task", c.task(s)]],
+  ["fact-type-register", (c, s) => ["fact", "type", "register", `bench-type-${s}`, "--source", "bench"]],
+  ["fact-type-list", () => ["fact", "type", "list"]],
+  [
+    "fact-reclassify",
+    (c, s) => ["fact", "reclassify", c.id("fact-record", s), "--type", `bench-type-${s}`, "--rationale", "bench"],
+  ],
+  [
+    "distill-candidate",
+    (c, s) => [
+      "distill",
+      "candidate",
+      "--task",
+      c.task(s),
+      "--input",
+      c.repoFile(`distill-${s}.md`, `# Distill ${s}\n\n- ${c.text("claim")}\n`),
+    ],
+  ],
+  [
+    "distill-promote",
+    (c, s) => [
+      ...["distill", "promote", "--task", c.task(s), "--candidate", c.field("distill-candidate", s, "candidatePath")],
+      ...["--claim", c.text("distilled")],
+    ],
+  ],
+  // Decisions.
+  [
+    "decision-propose",
+    (c, s) => [
+      "decision",
+      "propose",
+      "--json-input",
+      decisionPacket(`Probe ${s}`, c.text("d")),
+      "--body",
+      c.decisionBody(s),
+    ],
+  ],
+  ["decision-show", (c, s) => ["decision", "show", c.id("decision-propose", s)]],
+  ["decision-list", () => ["decision", "list"]],
+  ["decision-list~state", () => ["decision", "list", "--state", "proposed"]],
+  ["decision-validate", (c, s) => ["decision", "validate", c.id("decision-propose", s)]],
+  ["decision-verify", (c, s) => ["decision", "verify", c.id("decision-propose", s)]],
+  ["decision-amend", (c, s) => ["decision", "amend", c.id("decision-propose", s), "--title", `Probe ${s} v2`]],
+  [
+    "decision-claim-add",
+    (c, s) => ["decision", "claim", "add", c.id("decision-propose", s), "--id", "C1", "--text", c.text("claim")],
+  ],
+  ["decision-reckon", (c, s) => ["decision", "reckon", c.id("decision-propose", s), "--task", c.task(s)]],
+  [
+    "relation-relate~evidence",
+    (c, s) => [
+      ...["relation", "relate", "--source-ref", `decision/${c.id("decision-propose", s)}/C1`],
+      ...[
+        "--target-ref",
+        `fact/${c.id("fact-record", s)}`,
+        "--type",
+        "evidenced-by",
+        "--rationale",
+        "b",
+        "--expected-version",
+        "0",
+      ],
+    ],
+  ],
+  ["decision-accept", (c, s) => ["decision", "accept", c.id("decision-propose", s), "--rationale", "bench"]],
+  [
+    "decision-claim-fulfill",
+    (c, s) => ["decision", "claim", "fulfill", c.id("decision-propose", s), "--id", "C1", "--mode", "delivered"],
+  ],
+  ["decision-transition", (c, s) => ["decision", "transition", "deferred", c.decision(s), "--dry-run"]],
+  ["decision-defer", (c, s) => ["decision", "defer", c.decision(s + 10), "--rationale", "bench"]],
+  ["decision-reject", (c, s) => ["decision", "reject", c.decision(s + 20), "--rationale", "bench"]],
+  [
+    "decision-propose~b",
+    (c, s) => [
+      "decision",
+      "propose",
+      "--json-input",
+      decisionPacket(`Probe b ${s}`, c.text("d")),
+      "--body",
+      c.decisionBody(s),
+    ],
+  ],
+  [
+    "decision-accept~b",
+    (c, s) => [
+      "decision",
+      "accept",
+      c.id("decision-propose~b", s),
+      "--rationale",
+      "b",
+      "--judgment-only",
+      "bench judgment",
+    ],
+  ],
+  ["decision-supersede", (c, s) => ["decision", "supersede", c.id("decision-propose~b", s), "--reason", "bench"]],
+  ["decision-retire", (c, s) => ["decision", "retire", c.id("decision-propose", s), "--reason", "bench"]],
+  [
+    "decision-repin",
+    (c, s) => ["decision", "repin", c.decision(s), "--migration-evidence", `task/${c.task(s)}/task_plan.md`],
+  ],
+  // Relations.
+  [
+    "relation-relate",
+    (c, s) => [
+      ...["relation", "relate", "--source-ref", `task/${c.task(s + 3)}`, "--target-ref", `task/${c.task(s + 5)}`],
+      ...["--type", "relates", "--rationale", c.text("rel"), "--expected-version", "0"],
+    ],
+  ],
+  ["relation-list", () => ["relation", "list"]],
+  ["relation-list~entity", (c, s) => ["relation", "list", "--entity", `task/${c.task(s + 3)}`]],
+  [
+    "relation-reconfirm",
+    (c, s) => [
+      ...["relation", "reconfirm", c.id("relation-relate", s), "--rationale", "bench"],
+      ...["--expected-version", c.rev("relation-relate", s)],
+    ],
+  ],
+  [
+    "relation-unrelate",
+    (c, s) => [
+      ...["relation", "unrelate", c.id("relation-relate", s), "--reason", "bench"],
+      ...["--expected-version", c.rev("relation-reconfirm", s)],
+    ],
+  ],
+  // Generic entity store kinds, plus reads of the projected built-in kinds.
+  ...entityEntries,
+  ...["agent", "squad", "relation", "execution", "review", "schedule", "runtime-session", "settings"].map((kind) => [
+    `entity-list~${kind}`,
+    () => ["entity", "list", kind],
+  ]),
+  ["explain", () => ["explain", "task"]],
+  ["explain~entity", (c, s) => ["explain", `task/${c.task(s)}`]],
+  // Agents, squads, schedules, runtime instances (fixture user root only).
+  ["agent-validate", (c, s) => ["agent", "validate", "--source", c.agentSource(s)]],
+  ["agent-install", (c, s) => ["agent", "install", "--source", c.agentSource(s)]],
+  ["agent-list", () => ["agent", "list"]],
+  ["agent-inspect", (c, s) => ["agent", "inspect", `bench-agent-${s}`]],
+  ["squad-validate", (c, s) => ["squad", "validate", "--source", c.squadSource(s)]],
+  ["squad-install", (c, s) => ["squad", "install", "--source", c.squadSource(s)]],
+  ["squad-list", () => ["squad", "list"]],
+  ["squad-inspect", (c, s) => ["squad", "inspect", `bench-squad-${s}`]],
+  [
+    "runtime-instance-create",
+    (c, s) => [
+      ...["runtime", "instance", "create", "--id", `bench-rt-${s}`, "--name", `Bench ${s}`, "--kind", "codex"],
+      ...["--provider", "openai", "--model", "bench-model", "--auth", "subscription"],
+    ],
+  ],
+  ["runtime-instance-list", () => ["runtime", "instance", "list"]],
+  ["runtime-instance-show", (c, s) => ["runtime", "instance", "show", `bench-rt-${s}`]],
+  ["runtime-instance-update", (c, s) => ["runtime", "instance", "update", `bench-rt-${s}`, "--name", `B ${s}`]],
+  ["runtime-status", () => ["runtime", "status"]],
+  [
+    "schedule-create",
+    (c, s) => [
+      ...["schedule", "create", `bench-sched-${s}`, "--name", `Sched ${s}`, "--mode", "detect", "--every", "24h"],
+      ...["--agent", `bench-agent-${s}`, "--instance", `bench-rt-${s}`, "--mission", "bench", "--disabled"],
+    ],
+  ],
+  ["schedule-list", () => ["schedule", "list"]],
+  ["schedule-show", (c, s) => ["schedule", "show", `bench-sched-${s}`]],
+  ["schedule-runs", (c, s) => ["schedule", "runs", `bench-sched-${s}`]],
+  ["schedule-update", (c, s) => ["schedule", "update", `bench-sched-${s}`, "--name", `Sched ${s} v2`]],
+  ["schedule-disable", (c, s) => ["schedule", "disable", `bench-sched-${s}`]],
+  ["schedule-delete", (c, s) => ["schedule", "delete", `bench-sched-${s}`, "--reason", "bench"]],
+  ["runtime-instance-delete", (c, s) => ["runtime", "instance", "delete", `bench-rt-${s}`]],
+  [
+    "agent-delete",
+    (c, s) => ["agent", "delete", `bench-agent-${s}`, "--reason", "b", "--expected-version", c.rev("agent-install", s)],
+  ],
+  [
+    "squad-delete",
+    (c, s) => ["squad", "delete", `bench-squad-${s}`, "--reason", "b", "--expected-version", c.rev("squad-install", s)],
+  ],
+  // Settings, people, vertical, presets, templates, scripts.
+  ["settings-read", () => ["settings", "read"]],
+  ["settings-update", (c, s) => ["settings", "update", "--locale", s % 2 ? "zh-CN" : "en-US"]],
+  [
+    "people-add",
+    (c, s) => [
+      "people",
+      "add",
+      "--person-id",
+      `bench-p-${s}`,
+      "--display-name",
+      `P ${s}`,
+      "--role",
+      "member",
+      "--command-class",
+      "repo-write",
+    ],
+  ],
+  [
+    "people-set-role",
+    (c, s) => [
+      "people",
+      "set-role",
+      "--person-id",
+      `bench-p-${s}`,
+      "--role",
+      "reviewer",
+      "--command-class",
+      "repo-read",
+    ],
+  ],
+  [
+    "people-bind",
+    (c, s) => [
+      "people",
+      "bind",
+      "--actor",
+      `person:bench-p-${s}`,
+      "--role",
+      "member",
+      "--target",
+      `person/bench-p-${s}`,
+    ],
+  ],
+  ["people-remove", (c, s) => ["people", "remove", "--person-id", `bench-p-${s}`]],
+  ["vertical-validate", () => ["vertical", "validate"]],
+  ["vertical-kind-upsert-cli", (c, s) => ["vertical", "entity-kind", "upsert", "--from-file", c.kindFile(s)]],
+  [
+    "vertical-kind-publish-schema-cli",
+    (c, s) => ["vertical", "entity-kind", "publish-schema", `bench-kind-${s}`, "--from-file", c.schemaFile(s)],
+  ],
+  ["vertical-kind-retire-cli", (c, s) => ["vertical", "entity-kind", "retire", `bench-kind-${s}`, "--reason", "bench"]],
+  ["vertical-declaration-migrate", () => ["migrate", "vertical-declaration"]],
+  ["preset-list", () => ["preset", "list"]],
+  ["preset-inspect", () => ["preset", "inspect", "standard-task"]],
+  ["preset-check", () => ["preset", "check", "standard-task"]],
+  ["preset-audit", () => ["preset", "audit"]],
+  ["preset-validate", (c) => ["preset", "validate", "--source", c.presetSource()]],
+  ["preset-install", (c) => ["preset", "install", "--source", c.presetSource(), "--dry-run"]],
+  ["preset-seed", () => ["preset", "seed", "--dry-run"]],
+  ["preset-uninstall", () => ["preset", "uninstall", "docs-task", "--dry-run"]],
+  ["preset-upgrade", (c, s) => ["preset", "upgrade", c.task(s + 40)]],
+  ["template-list", () => ["template", "list"]],
+  ["template-render", () => ["template", "render", "template://planning/task-plan@1"]],
+  ["script-list", () => ["script", "list"]],
+  ["script-inspect", (c) => ["script", "inspect", c.scriptId()]],
+  // Ledger and daemon reads; receipts.
+  ["receipt-show", (c, s) => ["receipt", "show", c.opId(s)]],
+  ["ledger-reconcile", () => ["ledger", "reconcile", "--generation", "1"]],
+  ["daemon-status", () => ["daemon", "status"]],
+  ["doc-materialize", () => ["doc", "materialize"]],
+  ["doc-retire", (c, s) => ["doc", "retire", "--path", `${c.packagePath(s)}/artifacts/bench-${s}.md`, "--reason", "b"]],
+  // Client-local and offline commands (not daemon routes).
+  ["capabilities", () => ["capabilities"]],
+  ["version", () => ["--version"]],
+  ["help", () => ["--help"]],
+  ["events-tail", () => ["events", "tail"], offline],
+  ["backup", (c, s) => ["backup", c.backupDir(s)], offline],
+  ["restore-drill", (c, s) => ["restore", "--drill", c.backupDir(s)], offline],
+  // Measured in the cold-read and rebuild phases, not here.
+  ["daemon-stop", "measured in the cold-read phase (each cold sample is stop -> start -> first read)"],
+  ["daemon-start", "measured in the cold-read phase"],
+  ["daemon-projection-rebuild", "measured once in the rebuild-oracle phase (heavy full rebuild)"],
+  ["repo-bootstrap", "measured once as `ha init` during fixture setup"],
+  // Excluded, with the reason.
+  ["gui", "launches the Electron GUI"],
+  ["agent-create", runtime],
+  ["squad-run", runtime],
+  ["squad-status", "needs a squad run, which spawns runtimes"],
+  ["squad-cancel", "needs a squad run, which spawns runtimes"],
+  ["runtime-run", runtime],
+  ["runtime-batch", runtime],
+  ["runtime-cancel", "needs a live runtime session"],
+  ["schedule-enable", "arms the schedule to dispatch a runtime"],
+  ["schedule-run-now", runtime],
+  ["script-run", "executes a vertical script process"],
+  ["preset-run-start", "executes a preset script process"],
+  ["runtime-instance-login", "interactive provider authentication"],
+  ["runtime-instance-logout", "provider authentication state"],
+  ["runtime-instance-github-credential-set", "writes a GitHub credential reference"],
+  ["runtime-instance-github-credential-unset", "writes a GitHub credential reference"],
+  ["people-delegate", "needs a live runtime session token"],
+  ["people-revoke-delegation", "needs a live runtime session token"],
+  ["ci-observe-pull", "network: shells out to gh against GitHub"],
+  ["daemon-fleet-center-start", "network: opens a TLS fleet listener"],
+  ["daemon-fleet-edge-sync", "network: syncs against a fleet center"],
+  ["daemon-connection-add", "remote daemon connection topology"],
+  ["daemon-connection-update", "remote daemon connection topology"],
+  ["daemon-connection-remove", "remote daemon connection topology"],
+  ["daemon-connection-probe", "network probe of a remote endpoint"],
+  ["daemon-repo-register", "rewrites the daemon registry the fixture itself depends on"],
+  ["daemon-repo-update", "rewrites the daemon registry the fixture itself depends on"],
+  ["daemon-repo-unregister", "rewrites the daemon registry the fixture itself depends on"],
+  ["doc-conflict-resolve", "needs a fleet edge/center content conflict"],
+  ["doc-conflict-discard-local", "needs a fleet edge/center content conflict"],
+  ["doc-conflict-overwrite-center", "needs a fleet edge/center content conflict"],
+  ["migrate-import", "needs a legacy (pre-canonical) ledger source"],
+  ["migrate-ledger", "needs a generation-1 backup; covered by generation-activation.integration.test.ts"],
+];
+
+// A metric id is `<registry command id>` or `<registry command id>~<variant>`.
+export const registryId = (metric) => metric.split("~")[0];

--- a/tools/scale/cli-entity-bench.mjs
+++ b/tools/scale/cli-entity-bench.mjs
@@ -126,7 +126,12 @@ async function main() {
     phases = {},
     snapshots = [],
     errors = [],
-    log = (message) => console.log(`[scale-bench ${((Date.now() - started) / 1000).toFixed(0)}s] ${message}`);
+    log = (message) => console.log(`[scale-bench ${((Date.now() - started) / 1000).toFixed(0)}s] ${message}`),
+    // Phase boundaries after the CLI arm, in seconds since start, so a slow phase is attributable.
+    mark = (label) => {
+      (phases.marks ??= {})[label] = Math.round((Date.now() - started) / 1000);
+      log(label);
+    };
   // runtime instance create probes the provider CLI; a version-only stub stands in for it.
   const bin = path.join(f.parent, "bin");
   mkdirSync(bin, { recursive: true });
@@ -246,6 +251,7 @@ async function main() {
       ([metric, build]) => typeof build === "function" && reads.has(registryId(metric)),
     ))
       for (let s = 0; s < args.samples; s++) await rpc(`read:${metric}`, build(context, s));
+    mark("rpc-reads");
     // 8 concurrent CLI processes, write then read, three rounds.
     for (let round = 0; round < 3; round++) {
       await concurrentCli(
@@ -261,6 +267,7 @@ async function main() {
       );
     }
     snap("measured");
+    mark("cli-concurrent");
     // Cold reads: stop -> start -> first read, per read shape.
     for (const [metric, argv] of coldReads()) {
       await stopDaemon(f);
@@ -268,6 +275,7 @@ async function main() {
       f.invoke(`cold:${metric}`, argv, { requireSuccess: false, timeoutMs: 600_000 });
       f.invoke(`warm:${metric}`, argv, { requireSuccess: false, timeoutMs: 600_000 });
     }
+    mark("cold-reads");
     // Rebuild oracle input: the same reads before and after a full projection rebuild.
     const listed = async () =>
       Object.fromEntries(
@@ -287,6 +295,7 @@ async function main() {
     for (const [metric, argv] of listReads())
       lists[metric] = await rpcFull(parseThinCommand, runCommandThroughDaemon, f, argv);
     snap("end");
+    mark("rebuild-and-lists");
     phases.done = true;
   } catch (error) {
     errors.push({ phase: "measure", message: error.stack ?? String(error) });
@@ -313,6 +322,7 @@ async function main() {
     oracles = runOracles(oracleInput);
     negativeControls = runNegativeControls(oracleInput);
     store.close();
+    mark("oracles");
   } catch (error) {
     errors.push({ phase: "oracles", message: error.stack ?? String(error) });
   }

--- a/tools/scale/cli-entity-bench.mjs
+++ b/tools/scale/cli-entity-bench.mjs
@@ -26,7 +26,7 @@ import * as report from "./cli-entity-bench.report.mjs";
 import { benchContext, brief, factOp, issueServer, population, taskId } from "./cli-entity-bench.workload.mjs";
 
 function parseArgs(argv) {
-  const options = { tasks: 1000, samples: 5, clients: 8, seed: 20260911, out: null };
+  const options = { tasks: 1000, samples: 5, clients: 8, seed: 20260911, out: null, populateBudgetS: Infinity };
   for (let index = 0; index < argv.length; index++) {
     const key = argv[index];
     if (["--matrix", "--docker"].includes(key)) options[key.slice(2)] = true;
@@ -34,6 +34,7 @@ function parseArgs(argv) {
     else if (["--tasks", "--samples", "--clients", "--seed"].includes(key))
       options[key.slice(2)] = Number(argv[++index]);
     else if (key === "--out") options.out = path.resolve(argv[++index]);
+    else if (key === "--populate-budget-s") options.populateBudgetS = Number(argv[++index]);
     else throw new Error(`unknown option ${key}`);
   }
   return options;
@@ -156,13 +157,14 @@ async function main() {
     rpcRows.push(row);
     return row;
   };
-  const pool = async (items, clients, work) => {
+  const pool = async (items, clients, work, deadline = Infinity) => {
     let next = 0;
     await Promise.all(
       Array.from({ length: clients }, async () => {
-        while (next < items.length) await work(items[next++]);
+        while (next < items.length && performance.now() < deadline) await work(items[next++]);
       }),
     );
+    return next;
   };
   const issues = await issueServer();
   let initRevision = 0,
@@ -178,18 +180,26 @@ async function main() {
     );
     initRevision = readHead(openSqliteEventStore, f.root);
     // Population: Tasks first (the other kinds point at them), then every other kind interleaved.
-    const ops = population(f, n);
+    const ops = population(f, n),
+      deadline = performance.now() + args.populateBudgetS * 1000;
     for (const [label, group] of [
       ["tasks", ops.filter((op) => op.kind === "task")],
       ["others", ops.filter((op) => op.kind !== "task")],
     ]) {
       const at = performance.now();
-      await pool(group, args.clients, async (op) => {
-        const row = await rpc(`populate:${op.kind}`, op.argv, { clients: args.clients });
-        writes.push({ ...op, ...row, argv: undefined });
-        if (writes.length % 1000 === 0) log(`populated ${writes.length}/${ops.length}`);
-      });
-      phases[`populate-${label}`] = { ops: group.length, wallMs: performance.now() - at };
+      const issued = await pool(
+        group,
+        args.clients,
+        async (op) => {
+          const row = await rpc(`populate:${op.kind}`, op.argv, { clients: args.clients });
+          writes.push({ ...op, ...row, argv: undefined });
+          if (writes.length % 1000 === 0) log(`populated ${writes.length}/${ops.length}`);
+        },
+        deadline,
+      );
+      // A budget stop is a result: the reached counts are what every later number was measured at.
+      phases[`populate-${label}`] = { ops: issued, planned: group.length, wallMs: performance.now() - at };
+      if (issued < group.length) log(`population budget exhausted at ${issued}/${group.length} ${label}`);
     }
     snap("populated");
     log(`population done: ${writes.filter((w) => w.status === "accepted_durable").length}/${ops.length} accepted`);

--- a/tools/scale/cli-entity-bench.mjs
+++ b/tools/scale/cli-entity-bench.mjs
@@ -1,0 +1,449 @@
+#!/usr/bin/env node
+/**
+ * Scale bench: every `ha` CLI command and every entity read/write path at 1k-10k Tasks, for data
+ * correctness and latency. Run from the repository root; see tools/scale/README.md.
+ *
+ *   node tools/scale/cli-entity-bench.mjs --docker --tasks 1000 --out <host-dir>   # one-shot container
+ *   node tools/scale/cli-entity-bench.mjs --tasks 1000 --out <dir>                  # inside the container
+ *   node tools/scale/cli-entity-bench.mjs --matrix                                  # coverage matrix only
+ *   node tools/scale/cli-entity-bench.mjs --compare a.json,b.json                   # latency ratios
+ *
+ * Population goes through the CLI's own parser and daemon client in one resident process with
+ * --clients concurrent requests (the RPC arm). Every registry command is then measured as real
+ * `ha` child processes (the CLI arm, with HA_CLI_TIMING phases); reads are also sampled on the
+ * RPC arm. No SQL is written; the ledger is only opened read-only for the oracles.
+ */
+import { spawn, spawnSync } from "node:child_process";
+import { randomUUID, createHash } from "node:crypto";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { loadavg } from "node:os";
+import path from "node:path";
+import { fixture, resourceSnapshot } from "../stress/entity-cli-calibration.fixture.mjs";
+import { cli } from "../../packages/cli/test/daemon-multi-repo-lifecycle-cli.fixtures.ts";
+import { benchKinds, commandTable, registryId } from "./cli-entity-bench.commands.mjs";
+import { runOracles, runNegativeControls } from "./cli-entity-bench.oracles.mjs";
+import * as report from "./cli-entity-bench.report.mjs";
+import { benchContext, brief, factOp, issueServer, population, taskId } from "./cli-entity-bench.workload.mjs";
+
+function parseArgs(argv) {
+  const options = { tasks: 1000, samples: 5, clients: 8, seed: 20260911, out: null };
+  for (let index = 0; index < argv.length; index++) {
+    const key = argv[index];
+    if (["--matrix", "--docker"].includes(key)) options[key.slice(2)] = true;
+    else if (key === "--compare") options.compare = argv[++index].split(",");
+    else if (["--tasks", "--samples", "--clients", "--seed"].includes(key))
+      options[key.slice(2)] = Number(argv[++index]);
+    else if (key === "--out") options.out = path.resolve(argv[++index]);
+    else throw new Error(`unknown option ${key}`);
+  }
+  return options;
+}
+
+async function runDocker() {
+  const hostSamples = [];
+  const name = `harness-test-isolation-scale-bench-${randomUUID().slice(0, 8)}`,
+    inner = process.argv
+      .slice(2)
+      .filter((value, index, all) => value !== "--docker" && value !== "--out" && all[index - 1] !== "--out");
+  const script = [
+    "set -eu",
+    "cd /workspace",
+    "npm ci --no-audit --no-fund >/dev/null 2>&1",
+    `node tools/test-hermetic-preflight.mjs --user-root /tmp/${name}`,
+    `node tools/scale/cli-entity-bench.mjs ${inner.join(" ")} --out /out`,
+  ].join("\n");
+  const host = () => ({
+    at: new Date().toISOString(),
+    load: loadavg(),
+    ncpu: spawnSync("sysctl", ["-n", "hw.ncpu"], { encoding: "utf8" }).stdout.trim(),
+  });
+  const hostBefore = host();
+  const step = (command, commandArgs, options = {}) =>
+    spawnSync(command, commandArgs, { stdio: "inherit", ...options }).status;
+  let status = step("docker", [
+    "create",
+    "--init",
+    "--name",
+    name,
+    "--workdir",
+    "/workspace",
+    "--entrypoint",
+    "sh",
+    "-e",
+    `CLI_ENTITY_BENCH_SOURCE=${JSON.stringify(report.sourceIdentity())}`,
+    "plt-center-testbed/source:latest",
+    "-lc",
+    script,
+  ]);
+  if (status !== 0) return status;
+  try {
+    const files = spawnSync("git", ["ls-files", "--cached", "--others", "--exclude-standard", "-z"], {
+      encoding: "buffer",
+    }).stdout;
+    const tar = spawnSync("tar", ["--no-xattrs", "-cf", "-", "--null", "-T", "-"], {
+      input: files,
+      maxBuffer: 2 ** 31,
+      env: { ...process.env, COPYFILE_DISABLE: "1" },
+    });
+    status =
+      tar.status === 0
+        ? step("docker", ["cp", "-", `${name}:/workspace`], {
+            input: tar.stdout,
+            stdio: ["pipe", "inherit", "inherit"],
+          })
+        : tar.status;
+    const samples = [],
+      sampler = setInterval(() => samples.push(host()), 15_000);
+    if (status === 0)
+      status = await new Promise((resolve) =>
+        spawn("docker", ["start", "-a", name], { stdio: "inherit" }).on("close", resolve),
+      );
+    clearInterval(sampler);
+    hostSamples.push(...samples);
+    mkdirSync(args.out, { recursive: true });
+    step("docker", ["cp", `${name}:/out/.`, args.out]);
+    writeFileSync(
+      path.join(args.out, "host-load.json"),
+      JSON.stringify({ container: name, before: hostBefore, during: hostSamples, after: host() }, null, 2),
+    );
+  } finally {
+    step("docker", ["rm", "-f", name], { stdio: "ignore" });
+  }
+  return status;
+}
+
+async function main() {
+  const { parseThinCommand } = await import("../../packages/cli/src/cli/thin-command.ts");
+  const { runCommandThroughDaemon } = await import("../../packages/cli/src/daemon/client.ts");
+  const { openSqliteEventStore } = await import("../../packages/kernel/src/store/sqlite-event-store.ts");
+  mkdirSync(args.out, { recursive: true });
+  const started = Date.now(),
+    f = fixture(args.seed, { daemonId: "scale-bench", frames: false }),
+    n = args.tasks,
+    writes = [],
+    rpcRows = [],
+    phases = {},
+    snapshots = [],
+    errors = [],
+    log = (message) => console.log(`[scale-bench ${((Date.now() - started) / 1000).toFixed(0)}s] ${message}`);
+  // runtime instance create probes the provider CLI; a version-only stub stands in for it.
+  const bin = path.join(f.parent, "bin");
+  mkdirSync(bin, { recursive: true });
+  writeFileSync(path.join(bin, "codex"), '#!/bin/sh\necho "codex-cli 0.0.0-scale-bench"\n', { mode: 0o755 });
+  f.env.PATH = `${bin}${path.delimiter}${f.env.PATH}`;
+  Object.assign(process.env, f.env);
+  const snap = (label) => snapshots.push({ label, ...resourceSnapshot(f.root), cpuAndRss: undefined });
+  const rpc = async (metric, argv, record = {}) => {
+    const parsed = parseThinCommand(["--root", f.root, "--json", ...argv]),
+      at = performance.now();
+    let receipt = null,
+      error = parsed.ok ? null : parsed.code;
+    if (parsed.ok)
+      try {
+        receipt = await runCommandThroughDaemon(parsed.command, undefined, { env: f.env });
+      } catch (thrown) {
+        error = thrown.message;
+      }
+    const row = {
+      metric,
+      arm: "rpc",
+      atMs: Math.round(at),
+      wallMs: performance.now() - at,
+      ...brief(receipt),
+      error,
+      ...record,
+    };
+    rpcRows.push(row);
+    return row;
+  };
+  const pool = async (items, clients, work) => {
+    let next = 0;
+    await Promise.all(
+      Array.from({ length: clients }, async () => {
+        while (next < items.length) await work(items[next++]);
+      }),
+    );
+  };
+  const issues = await issueServer();
+  let initRevision = 0,
+    beforeRebuild = {},
+    afterRebuild = {};
+  const lists = {};
+  try {
+    snap("start");
+    f.invoke(
+      "repo-bootstrap",
+      ["init", "--repo-id", "scale-bench", "--person-id", "owner", "--display-name", "Owner"],
+      { timeoutMs: 120_000 },
+    );
+    initRevision = readHead(openSqliteEventStore, f.root);
+    // Population: Tasks first (the other kinds point at them), then every other kind interleaved.
+    const ops = population(f, n);
+    for (const [label, group] of [
+      ["tasks", ops.filter((op) => op.kind === "task")],
+      ["others", ops.filter((op) => op.kind !== "task")],
+    ]) {
+      const at = performance.now();
+      await pool(group, args.clients, async (op) => {
+        const row = await rpc(`populate:${op.kind}`, op.argv, { clients: args.clients });
+        writes.push({ ...op, ...row, argv: undefined });
+        if (writes.length % 1000 === 0) log(`populated ${writes.length}/${ops.length}`);
+      });
+      phases[`populate-${label}`] = { ops: group.length, wallMs: performance.now() - at };
+    }
+    snap("populated");
+    log(`population done: ${writes.filter((w) => w.status === "accepted_durable").length}/${ops.length} accepted`);
+    // Throughput: the same write shape on 1 client and on --clients clients.
+    for (const clients of [1, args.clients]) {
+      const batch = Array.from({ length: 100 }, (_, index) => factOp(f, n, `tput-${clients}-${index}`)),
+        at = performance.now();
+      await pool(batch, clients, async (op) =>
+        writes.push({
+          ...op,
+          ...(await rpc(`throughput:fact-record:${clients}`, op.argv, { clients })),
+          argv: undefined,
+        }),
+      );
+      phases[`throughput-${clients}`] = {
+        ops: batch.length,
+        wallMs: performance.now() - at,
+        opsPerSecond: batch.length / ((performance.now() - at) / 1000),
+      };
+    }
+    const context = benchContext(f, n, writes, args.samples);
+    // CLI arm: every mapped registry command, --samples real processes each, in table order.
+    const cliStart = f.rows.length;
+    for (const [metric, build, options = {}] of commandTable) {
+      if (typeof build === "string") continue;
+      for (let s = 0; s < args.samples; s++) {
+        let argv;
+        try {
+          argv = build(context, s);
+        } catch (error) {
+          f.rows.push({ metric, s, arm: "cli", buildError: error.message, wallMs: null });
+          continue;
+        }
+        const receipt = f.invoke(metric, argv, { requireSuccess: false, timeoutMs: 600_000, ...options });
+        Object.assign(f.rows.at(-1), { s, arm: "cli", expect: context.takeExpect() });
+        context.got.set(`${metric}#${s}`, receipt);
+      }
+      log(`cli ${metric}`);
+    }
+    phases.cli = { rows: f.rows.length - cliStart };
+    // RPC arm for every read command (no process start, same request path).
+    const reads = await readMetrics();
+    for (const [metric, build] of commandTable.filter(
+      ([metric, build]) => typeof build === "function" && reads.has(registryId(metric)),
+    ))
+      for (let s = 0; s < args.samples; s++) await rpc(`read:${metric}`, build(context, s));
+    // 8 concurrent CLI processes, write then read, three rounds.
+    for (let round = 0; round < 3; round++) {
+      await concurrentCli(
+        f,
+        "cli8:fact-record",
+        Array.from({ length: args.clients }, (_, client) => factOp(f, n, `cli8-${round}-${client}`)),
+        writes,
+      );
+      await concurrentCli(
+        f,
+        "cli8:task-show",
+        Array.from({ length: args.clients }, (_, client) => ({ argv: ["task", "show", taskId(client % n)] })),
+      );
+    }
+    snap("measured");
+    // Cold reads: stop -> start -> first read, per read shape.
+    for (const [metric, argv] of coldReads()) {
+      await stopDaemon(f);
+      f.invoke("daemon-start", ["daemon", "start", "--service"], { requireSuccess: false, timeoutMs: 600_000 });
+      f.invoke(`cold:${metric}`, argv, { requireSuccess: false, timeoutMs: 600_000 });
+      f.invoke(`warm:${metric}`, argv, { requireSuccess: false, timeoutMs: 600_000 });
+    }
+    // Rebuild oracle input: the same reads before and after a full projection rebuild.
+    const listed = async () =>
+      Object.fromEntries(
+        await Promise.all(
+          coldReads().map(async ([metric, argv]) => [
+            metric,
+            digestRows(await rpcFull(parseThinCommand, runCommandThroughDaemon, f, argv)),
+          ]),
+        ),
+      );
+    beforeRebuild = await listed();
+    f.invoke("daemon-projection-rebuild", ["daemon", "projection", "rebuild"], {
+      requireSuccess: false,
+      timeoutMs: 1_800_000,
+    });
+    afterRebuild = await listed();
+    for (const [metric, argv] of listReads())
+      lists[metric] = await rpcFull(parseThinCommand, runCommandThroughDaemon, f, argv);
+    snap("end");
+    phases.done = true;
+  } catch (error) {
+    errors.push({ phase: "measure", message: error.stack ?? String(error) });
+    log(`phase failed: ${error.message}`);
+  }
+  let oracles = {},
+    negativeControls = [];
+  const cliRows = f.rows.map(report.compactRow);
+  try {
+    const store = openSqliteEventStore({ rootInput: f.root, repoId: "scale-bench", readOnly: true }),
+      classes = new Map((await report.coverage()).map(({ id, commandClass }) => [id, commandClass]));
+    const cliWrites = f.rows
+      .filter((row) => row.receipt && ["repo-write", "arbiter", "admin"].includes(classes.get(registryId(row.metric))))
+      .map((row) => ({ metric: row.metric, ...brief(row.receipt), receipt: row.receipt, expect: row.expect }));
+    const oracleInput = {
+      store,
+      initRevision,
+      writes: [...writes, ...cliWrites],
+      lists,
+      cliRows,
+      beforeRebuild,
+      afterRebuild,
+    };
+    oracles = runOracles(oracleInput);
+    negativeControls = runNegativeControls(oracleInput);
+    store.close();
+  } catch (error) {
+    errors.push({ phase: "oracles", message: error.stack ?? String(error) });
+  }
+  try {
+    const result = {
+      schema: "cli-entity-bench/v1",
+      source: report.sourceIdentity(),
+      params: { ...args, out: undefined },
+      counts: report.countBy(writes, (w) => `${w.kind}:${w.status ?? w.code ?? w.error}`),
+      phases,
+      oracles,
+      negativeControls,
+      coverage: await report.coverage(),
+      summary: report.summarize([...cliRows, ...rpcRows]),
+      snapshots,
+      samples: {
+        cli: cliRows,
+        rpc: rpcRows,
+        writes: writes.map(({ values: _values, blobs: _blobs, ...rest }) => rest),
+      },
+      errors,
+      elapsedMs: Date.now() - started,
+    };
+    const file = path.join(args.out, `bench-results-${result.source.sha.slice(0, 12)}-${n}.json`);
+    writeFileSync(file, JSON.stringify(result));
+    writeFileSync(file.replace(/\.json$/u, ".md"), report.summaryMarkdown(result));
+    log(
+      `wrote ${file}; oracles ${Object.values(oracles)
+        .map((o) => `${o.id}=${o.verdict}`)
+        .join(" ")}`,
+    );
+  } finally {
+    issues.close();
+    await f.close().catch((error) => console.error(`cleanup: ${error.message}`));
+  }
+}
+
+async function rpcFull(parseThinCommand, runCommandThroughDaemon, f, argv) {
+  const parsed = parseThinCommand(["--root", f.root, "--json", ...argv]);
+  return runCommandThroughDaemon(parsed.command, undefined, { env: f.env }).catch((error) => ({
+    ok: false,
+    error: error.message,
+  }));
+}
+
+function digestRows(receipt) {
+  let evidence = receipt?.evidence;
+  if (typeof evidence === "string")
+    try {
+      evidence = JSON.parse(evidence);
+    } catch {
+      /* keep the raw string */
+    }
+  return {
+    ok: receipt?.ok ?? null,
+    code: receipt?.code ?? null,
+    sha256: createHash("sha256")
+      .update(JSON.stringify(evidence ?? null))
+      .digest("hex"),
+  };
+}
+
+const coldReads = () => [
+  ["task-list", ["task", "list"]],
+  ["decision-list", ["decision", "list"]],
+  ["fact-search", ["fact", "search", "bench"]],
+  ["relation-list", ["relation", "list"]],
+  ["agenda", ["agenda"]],
+  ...benchKinds.map((kind) => [`entity-list~${kind}`, ["entity", "list", kind]]),
+];
+const listReads = () => [
+  ["task", ["task", "list"]],
+  ...benchKinds.map((kind) => [`entity:${kind}`, ["entity", "list", kind]]),
+];
+
+async function readMetrics() {
+  const { thinCliCommands } = await import("../../packages/daemon/src/protocol/daemon-protocol.contract.ts");
+  return new Set(thinCliCommands.filter(({ commandClass }) => commandClass === "repo-read").map(({ id }) => id));
+}
+
+// Same exit test as the calibration fixture's close(): an empty cmdline is a zombie, a foreign one a reused pid.
+async function stopDaemon(f) {
+  const stopped = f.invoke("daemon-stop", ["daemon", "stop"], { requireSuccess: false, timeoutMs: 600_000 }),
+    alive = () => {
+      try {
+        return readFileSync(`/proc/${stopped.pid}/cmdline`, "utf8").includes(f.userRoot);
+      } catch {
+        return false;
+      }
+    };
+  for (const deadline = Date.now() + 120_000; Number.isSafeInteger(stopped?.pid) && alive() && Date.now() < deadline; )
+    await new Promise((resolve) => setTimeout(resolve, 50));
+}
+
+function concurrentCli(f, metric, ops, writes) {
+  return Promise.all(
+    ops.map(
+      (op, client) =>
+        new Promise((resolve) => {
+          const at = performance.now(),
+            child = spawn(process.execPath, [cli, "--root", f.root, "--json", ...op.argv], { env: f.env });
+          let stdout = "";
+          child.stdout.on("data", (chunk) => (stdout += chunk));
+          child.stderr.resume();
+          child.on("close", (exit) => {
+            let receipt = null;
+            try {
+              receipt = JSON.parse(stdout);
+            } catch {
+              /* parse failures are evidence */
+            }
+            const row = {
+              metric,
+              arm: "cli-concurrent",
+              client,
+              wallMs: performance.now() - at,
+              exit,
+              ...brief(receipt),
+            };
+            f.rows.push({ ...row, receipt: null });
+            if (writes) writes.push({ ...op, ...row, argv: undefined });
+            resolve(row);
+          });
+        }),
+    ),
+  );
+}
+
+function readHead(openSqliteEventStore, root) {
+  const store = openSqliteEventStore({ rootInput: root, repoId: "scale-bench", readOnly: true });
+  try {
+    return store.revision();
+  } finally {
+    store.close();
+  }
+}
+
+// Dispatch last: the module-level helpers above must be initialized before main() runs.
+const args = parseArgs(process.argv.slice(2));
+if (args.matrix) console.log(report.matrixMarkdown(await report.coverage()));
+else if (args.compare)
+  console.log(report.compareMarkdown(...args.compare.map((file) => JSON.parse(readFileSync(file, "utf8")))));
+else if (args.docker) process.exitCode = await runDocker();
+else await main();

--- a/tools/scale/cli-entity-bench.oracles.mjs
+++ b/tools/scale/cli-entity-bench.oracles.mjs
@@ -1,0 +1,271 @@
+/**
+ * Correctness oracles for tools/scale/cli-entity-bench.mjs over one frozen run. Every oracle is a
+ * pure function of the recorded receipts, the read results and a read-only ledger store, so the
+ * negative controls can feed each one a deliberately corrupted copy and require it to fail.
+ */
+import { createHash } from "node:crypto";
+import { oracleO2 } from "../stress/core/oracles.mjs";
+
+const verdict = (id, violations) => ({
+  id,
+  verdict: violations.length ? "FAIL" : "PASS",
+  violations: violations.slice(0, 50),
+  violationCount: violations.length,
+});
+const accepted = (write) => write.status === "accepted_durable";
+const label = (write) => write.key ?? write.metric;
+
+// B1: an acknowledged write is durable, a rejected one is not, and nothing durable is unacknowledged.
+export function receiptOracle({ store, initRevision, writes }) {
+  const violations = [],
+    acknowledged = new Map();
+  for (const write of writes.filter(accepted)) {
+    if (store.readCommandOutcome(write.opId)?.status !== "accepted_durable")
+      violations.push(`${label(write)}: accepted receipt ${write.opId} has no accepted outcome`);
+    acknowledged.set(write.opId, (acknowledged.get(write.opId) ?? 0) + 1);
+  }
+  for (const [opId, count] of acknowledged) if (count > 1) violations.push(`opId ${opId} acknowledged ${count} times`);
+  for (const write of writes.filter((write) => !accepted(write) && write.opId))
+    if (store.readCommandOutcome(write.opId)?.status === "accepted_durable")
+      violations.push(`${label(write)}: non-accepted receipt ${write.opId} has an accepted outcome`);
+  const claimed = new Set(writes.flatMap((write) => (write.receipt ? collect(write.receipt, "opId") : [write.opId])));
+  for (const outcome of store.outcomes())
+    if (outcome.status === "accepted_durable" && outcome.firstRevision > initRevision && !claimed.has(outcome.opId))
+      violations.push(`accepted outcome ${outcome.opId} (${outcome.summary}) has no acknowledged receipt`);
+  return verdict("B1-receipt-durable", violations);
+}
+
+// B2: every value and file the bench wrote is in the accepted events or content objects, byte for byte.
+export function readbackOracle({ store, writes }) {
+  const violations = [];
+  for (const write of writes.filter(
+    (write) => accepted(write) && (write.values?.length || write.blobs?.length || write.expect),
+  )) {
+    const expect = write.expect ?? { values: write.values, blobs: write.blobs },
+      outcome = store.readCommandOutcome(write.opId),
+      strings = new Set();
+    for (let revision = outcome?.firstRevision ?? 1; revision <= (outcome?.lastRevision ?? 0); revision++)
+      collect(store.eventAtRevision(revision), null).forEach((value) => strings.add(value));
+    const digests = [...strings]
+        .map((value) => value.replace(/^sha256:/u, ""))
+        .filter((value) => /^[0-9a-f]{64}$/u.test(value)),
+      objects = digests
+        .map((digest) => store.readContentObject(digest))
+        .filter(Boolean)
+        .map((bytes) => Buffer.from(bytes));
+    for (const value of expect.values ?? [])
+      if (!strings.has(value) && !objects.some((bytes) => bytes.includes(Buffer.from(value))))
+        violations.push(`${label(write)}: ${JSON.stringify(value)} is not in accepted op ${write.opId}`);
+    for (const blob of expect.blobs ?? []) {
+      const digest = createHash("sha256").update(blob).digest("hex"),
+        stored = digests.includes(digest) ? store.readContentObject(digest) : null;
+      if (!stored || !Buffer.from(stored).equals(blob))
+        violations.push(`${label(write)}: content ${digest} is not byte-exact in ${write.opId}`);
+    }
+  }
+  return verdict("B2-readback-bytes", violations);
+}
+
+// B3: the read API shows every populated Task and entity with its exact title, and no deleted entity.
+export function listOracle({ writes, lists, cliRows }) {
+  const violations = [];
+  const check = (listName, expected) => {
+    const index = fieldIndex(lists[listName]);
+    if (lists[listName]?.ok !== true)
+      violations.push(`${listName}: list read failed (${lists[listName]?.code ?? lists[listName]?.error})`);
+    for (const [id, title] of expected) {
+      const holders = index.get(id) ?? [];
+      if (!holders.length) violations.push(`${listName}: ${id} is not visible`);
+      else if (!holders.some((holder) => Object.values(holder).includes(title)))
+        violations.push(`${listName}: ${id} title differs from ${JSON.stringify(title)}`);
+    }
+  };
+  const populated = writes.filter(
+    (write) => accepted(write) && !write.metric?.startsWith("throughput") && write.values,
+  );
+  // Tasks the CLI arm superseded or soft-deleted must leave the default list; every other one stays.
+  const retired = new Set(
+    cliRows
+      .filter((row) => ["task-supersede", "task-delete"].includes(row.metric) && row.ok === true)
+      .map((row) => row.args[row.args.indexOf(row.metric === "task-delete" ? "--soft" : "supersede") + 1]),
+  );
+  check(
+    "task",
+    populated
+      .filter((write) => write.kind === "task" && !retired.has(write.key))
+      .map((write) => [write.key, write.values[0]]),
+  );
+  const taskIndex = fieldIndex(lists.task);
+  for (const id of retired) if (taskIndex.has(id)) violations.push(`task: retired ${id} is still listed`);
+  for (const listName of Object.keys(lists).filter((name) => name.startsWith("entity:"))) {
+    const kind = listName.slice("entity:".length);
+    check(
+      listName,
+      populated.filter((write) => write.kind === listName).map((write) => [write.entityId, write.values[0]]),
+    );
+    const index = fieldIndex(lists[listName]);
+    for (const row of cliRows.filter((row) => row.metric === `entity-delete~${kind}` && row.ok === true))
+      if (index.has(row.entityId)) violations.push(`${listName}: deleted ${row.entityId} is still listed`);
+  }
+  for (const row of cliRows.filter((row) => row.metric.startsWith("entity-get~deleted-")))
+    if (row.ok === true) violations.push(`${row.metric}: deleted entity is still readable`);
+  return verdict("B3-read-visibility", violations);
+}
+
+// B4: a full projection rebuild from the event store reproduces every incremental read exactly.
+export function rebuildOracle({ beforeRebuild, afterRebuild }) {
+  const violations = Object.keys(beforeRebuild).length ? [] : ["no rebuild evidence was recorded"];
+  for (const [metric, before] of Object.entries(beforeRebuild)) {
+    const after = afterRebuild[metric];
+    if (before.ok !== true || after?.ok !== true)
+      violations.push(`${metric}: read failed around rebuild (${before.code} / ${after?.code})`);
+    else if (before.sha256 !== after.sha256) violations.push(`${metric}: rows differ after rebuild`);
+  }
+  return verdict("B4-rebuild-equivalence", violations);
+}
+
+// B5: the ledger itself is gap-free and duplicate-free (the stress O2 oracle, structural part).
+export function structureOracle({ store, cut }) {
+  const frozen = cut ?? ledgerCut(store),
+    log = { complete: true, errors: [], records: [{ type: "campaign_started" }, { type: "campaign_completed" }] },
+    observed = oracleO2({ authority: "sqlite", sqliteCut: frozen, receiptLog: log });
+  return verdict("B5-ledger-structure", observed.violations);
+}
+
+export const ledgerCut = (store) => {
+  const events = [];
+  for (let revision = 1; revision <= store.revision(); revision++) {
+    const identity = store.eventIdentityAtRevision(revision);
+    if (identity) events.push({ workspaceRevision: revision, opId: identity.opId });
+  }
+  return { revision: store.revision(), events, outcomes: store.outcomes() };
+};
+
+export function runOracles(input) {
+  input.cut ??= ledgerCut(input.store);
+  return Object.fromEntries(
+    [receiptOracle, readbackOracle, listOracle, rebuildOracle, structureOracle].map((oracle) => {
+      const observed = oracle(input);
+      return [observed.id, observed];
+    }),
+  );
+}
+
+// Each control corrupts one input the way a real defect would and requires its oracle to FAIL.
+export function runNegativeControls(input) {
+  const acceptedWrites = input.writes.filter((write) => accepted(write) && write.values && !write.receipt),
+    sample = acceptedWrites.slice(0, 20),
+    blobWrite = acceptedWrites.find((write) => write.blobs?.length),
+    rejected = input.writes.find((write) => !accepted(write));
+  const controls = [
+    [
+      "dropped-acknowledgement",
+      receiptOracle,
+      { ...input, writes: input.writes.filter((write) => write !== acceptedWrites[0]) },
+    ],
+    [
+      "phantom-acceptance",
+      receiptOracle,
+      {
+        ...input,
+        writes: [
+          ...sample,
+          { ...(rejected ?? {}), key: "phantom", status: "accepted_durable", opId: "op-never-written" },
+        ],
+      },
+    ],
+    [
+      "tampered-value",
+      readbackOracle,
+      { ...input, writes: [{ ...acceptedWrites[0], values: [`${acceptedWrites[0].values[0]}·`] }] },
+    ],
+    [
+      "tampered-file-byte",
+      readbackOracle,
+      { ...input, writes: [{ ...blobWrite, blobs: [Buffer.concat([blobWrite.blobs[0], Buffer.from([0])])] }] },
+    ],
+    [
+      "invisible-task",
+      listOracle,
+      {
+        ...input,
+        writes: [{ kind: "task", key: "bench-task-never-created", status: "accepted_durable", values: ["x"] }],
+        cliRows: [],
+      },
+    ],
+    [
+      "rebuild-divergence",
+      rebuildOracle,
+      {
+        ...input,
+        afterRebuild: {
+          ...input.afterRebuild,
+          "task-list": { ...input.afterRebuild["task-list"], sha256: "0".repeat(64) },
+        },
+      },
+    ],
+    [
+      "duplicate-revision",
+      structureOracle,
+      { ...input, cut: { ...input.cut, events: [...input.cut.events, input.cut.events[0]] } },
+    ],
+  ];
+  return controls.map(([id, oracle, corrupted]) => {
+    const observed = oracle(corrupted);
+    return {
+      id,
+      oracle: observed.id,
+      observed: observed.verdict,
+      passed: observed.verdict === "FAIL",
+      violations: observed.violations.slice(0, 3),
+    };
+  });
+}
+
+// Every string in a value, or every value of one key, walking JSON-string fields too.
+function collect(root, key) {
+  const found = [],
+    stack = [root];
+  while (stack.length) {
+    let value = stack.pop();
+    if (typeof value === "string" && /^[[{]/u.test(value))
+      try {
+        value = JSON.parse(value);
+      } catch {
+        if (key === null) found.push(value);
+        continue;
+      }
+    if (typeof value === "string") {
+      if (key === null) found.push(value);
+      continue;
+    }
+    if (!value || typeof value !== "object") continue;
+    for (const [field, child] of Object.entries(value)) {
+      if (key !== null && field === key && typeof child === "string") found.push(child);
+      stack.push(child);
+    }
+  }
+  return found;
+}
+
+// Map from every string field value to the objects that hold it directly.
+function fieldIndex(receipt) {
+  const index = new Map(),
+    stack = [receipt?.evidence ?? receipt];
+  while (stack.length) {
+    let value = stack.pop();
+    if (typeof value === "string" && /^[[{]/u.test(value))
+      try {
+        value = JSON.parse(value);
+      } catch {
+        continue;
+      }
+    if (!value || typeof value !== "object") continue;
+    for (const child of Object.values(value)) {
+      if (typeof child !== "string") stack.push(child);
+      else if (index.has(child)) index.get(child).push(value);
+      else index.set(child, [value]);
+    }
+  }
+  return index;
+}

--- a/tools/scale/cli-entity-bench.report.mjs
+++ b/tools/scale/cli-entity-bench.report.mjs
@@ -1,0 +1,170 @@
+/**
+ * Coverage and result shaping for tools/scale/cli-entity-bench.mjs: the registry-derived coverage
+ * matrix, compact result rows, per-metric percentiles and the Markdown renderings.
+ */
+import { spawnSync } from "node:child_process";
+import { percentile } from "../measure-cli-command-timing.mjs";
+import { commandTable, registryId } from "./cli-entity-bench.commands.mjs";
+import { brief } from "./cli-entity-bench.workload.mjs";
+
+export async function coverage() {
+  const { thinCliCommands } = await import("../../packages/daemon/src/protocol/daemon-protocol.contract.ts");
+  const { clientLocalCommands } = await import("../../packages/cli/src/cli/thin-command-help.ts");
+  const registry = [
+    ...thinCliCommands.map(({ id, path: words, method, commandClass }) => ({
+      id,
+      path: words.join(" "),
+      method,
+      commandClass,
+    })),
+    ...clientLocalCommands.map(({ usage }) => ({
+      id: usage
+        .split(" ")
+        .slice(1)
+        .filter(
+          (word, index, words) =>
+            !/^[-[<]/u.test(word) && words.slice(0, index).every((prior) => !/^[-[<]/u.test(prior)),
+        )
+        .join("-"),
+      path: usage,
+      method: "client-local",
+    })),
+    ...["capabilities", "version", "help", "events-tail", "backup", "restore-drill"].map((id) => ({
+      id,
+      method: "client-local",
+    })),
+  ];
+  const measured = new Map();
+  for (const [metric, build] of commandTable) {
+    const row = measured.get(registryId(metric)) ?? { metrics: [], reason: null };
+    if (typeof build === "string") row.reason = build;
+    else row.metrics.push(metric);
+    measured.set(registryId(metric), row);
+  }
+  return registry.map((command) => ({
+    ...command,
+    ...(measured.get(command.id) ?? { metrics: [], reason: "UNMAPPED" }),
+  }));
+}
+
+export function matrixMarkdown(rows) {
+  const lines = [
+    "| command id | path | method | class | measured metrics | not measured because |",
+    "| --- | --- | --- | --- | --- | --- |",
+  ];
+  for (const row of rows)
+    lines.push(
+      `| ${row.id} | ${row.path ?? ""} | ${row.method} | ${row.commandClass ?? ""} | ${row.metrics.join(", ")} | ${row.reason ?? ""} |`,
+    );
+  const counted = (test) => rows.filter(test).length;
+  lines.push(
+    "",
+    `${rows.length} commands: ${counted((row) => row.metrics.length)} measured, ` +
+      `${counted((row) => !row.metrics.length && row.reason !== "UNMAPPED")} excluded, ${counted((row) => row.reason === "UNMAPPED")} unmapped.`,
+  );
+  return lines.join("\n");
+}
+
+export const countBy = (rows, key) =>
+  rows.reduce((counts, row) => ({ ...counts, [key(row)]: (counts[key(row)] ?? 0) + 1 }), {});
+
+// Rows keep the receipt identity and CLI phases; full stdout stays out of the results file.
+export function compactRow(row) {
+  const { stdout, stderr, receipt, timing, startedAt: _at, seed: _seed, expect: _expect, ...rest } = row;
+  // A CLI process succeeded when it exited 0 (explain, help and capabilities carry no `ok` field).
+  return {
+    ...rest,
+    arm: row.arm ?? "cli",
+    ...(receipt ? brief(receipt) : {}),
+    ...(row.exit === undefined ? {} : { ok: row.exit === 0 }),
+    stdoutBytes: stdout?.length,
+    stderrTail: row.exit === 0 ? undefined : stderr?.slice(-400),
+    timing: timing
+      ? { totalMs: timing.totalMs, phases: timing.phases, daemonRequests: timing.daemonRequests }
+      : undefined,
+  };
+}
+
+export function summarize(rows) {
+  const groups = new Map();
+  for (const row of rows)
+    if (row.wallMs !== null)
+      groups.set(`${row.arm}|${row.metric}`, [...(groups.get(`${row.arm}|${row.metric}`) ?? []), row]);
+  return [...groups].map(([key, group]) => {
+    const [arm, metric] = key.split("|"),
+      wall = group.map((row) => row.wallMs),
+      rpcMs = group.map((row) => row.timing?.phases?.daemonRoundTrip).filter(Number.isFinite);
+    return {
+      arm,
+      metric,
+      n: group.length,
+      ok: group.filter((row) => row.ok === true).length,
+      codes: countBy(
+        group.filter((row) => row.ok !== true),
+        (row) => row.code ?? row.error ?? `exit ${row.exit}`,
+      ),
+      p50: percentile(wall, 0.5),
+      p95: percentile(wall, 0.95),
+      p99: percentile(wall, 0.99),
+      max: Math.max(...wall),
+      ...(rpcMs.length
+        ? { daemonRoundTripP50: percentile(rpcMs, 0.5), daemonRoundTripP95: percentile(rpcMs, 0.95) }
+        : {}),
+    };
+  });
+}
+
+export function summaryMarkdown(result) {
+  const cell = (value) => (Number.isFinite(value) ? value.toFixed(1) : "");
+  return [
+    `# cli-entity-bench ${result.params.tasks} tasks @ ${result.source.sha.slice(0, 12)}`,
+    "",
+    `elapsed ${(result.elapsedMs / 1000).toFixed(0)} s; oracles: ${Object.values(result.oracles)
+      .map((o) => `${o.id} ${o.verdict}`)
+      .join(", ")}; ` +
+      `negative controls: ${result.negativeControls.filter((c) => c.passed).length}/${result.negativeControls.length} detected`,
+    "",
+    "```json",
+    JSON.stringify({ phases: result.phases, counts: result.counts }, null, 1),
+    "```",
+    "",
+    "| arm | metric | n | ok | p50 ms | p95 ms | p99 ms | max ms | daemon RPC p50 | failures |",
+    "| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |",
+    ...result.summary.map(
+      (row) =>
+        `| ${row.arm} | ${row.metric} | ${row.n} | ${row.ok} | ${cell(row.p50)} | ${cell(row.p95)} | ${cell(row.p99)} | ${cell(row.max)} | ` +
+        `${cell(row.daemonRoundTripP50)} | ${Object.entries(row.codes)
+          .map(([code, count]) => `${code}×${count}`)
+          .join(" ")} |`,
+    ),
+  ].join("\n");
+}
+
+export function compareMarkdown(small, large) {
+  const index = new Map(small.summary.map((row) => [`${row.arm}|${row.metric}`, row]));
+  const rows = large.summary
+    .flatMap((row) => {
+      const base = index.get(`${row.arm}|${row.metric}`);
+      return base && base.p50 > 0 ? [{ ...row, base, ratio: row.p50 / base.p50 }] : [];
+    })
+    .sort((left, right) => right.ratio - left.ratio);
+  return [
+    `| arm | metric | p50 @${small.params.tasks} | p50 @${large.params.tasks} | ratio | p95 @${small.params.tasks} | p95 @${large.params.tasks} |`,
+    "| --- | --- | ---: | ---: | ---: | ---: | ---: |",
+    ...rows.map(
+      (row) =>
+        `| ${row.arm} | ${row.metric} | ${row.base.p50.toFixed(1)} | ${row.p50.toFixed(1)} | ${row.ratio.toFixed(2)} | ${row.base.p95.toFixed(1)} | ${row.p95.toFixed(1)} |`,
+    ),
+  ].join("\n");
+}
+
+// Inside the container there is no .git, so --docker passes the host's identity in the environment.
+export function sourceIdentity() {
+  if (process.env.CLI_ENTITY_BENCH_SOURCE) return JSON.parse(process.env.CLI_ENTITY_BENCH_SOURCE);
+  const read = (...gitArgs) => spawnSync("git", gitArgs, { encoding: "utf8" }).stdout?.trim() || null;
+  return {
+    sha: read("rev-parse", "HEAD") ?? "unverified",
+    base: read("merge-base", "HEAD", "origin/main"),
+    dirty: Boolean(read("status", "--porcelain")),
+  };
+}

--- a/tools/scale/cli-entity-bench.report.mjs
+++ b/tools/scale/cli-entity-bench.report.mjs
@@ -65,8 +65,11 @@ export function matrixMarkdown(rows) {
   return lines.join("\n");
 }
 
-export const countBy = (rows, key) =>
-  rows.reduce((counts, row) => ({ ...counts, [key(row)]: (counts[key(row)] ?? 0) + 1 }), {});
+export const countBy = (rows, key) => {
+  const counts = {};
+  for (const row of rows) counts[key(row)] = (counts[key(row)] ?? 0) + 1;
+  return counts;
+};
 
 // Rows keep the receipt identity and CLI phases; full stdout stays out of the results file.
 export function compactRow(row) {
@@ -88,8 +91,11 @@ export function compactRow(row) {
 export function summarize(rows) {
   const groups = new Map();
   for (const row of rows)
-    if (row.wallMs !== null)
-      groups.set(`${row.arm}|${row.metric}`, [...(groups.get(`${row.arm}|${row.metric}`) ?? []), row]);
+    if (row.wallMs !== null) {
+      const key = `${row.arm}|${row.metric}`;
+      if (groups.has(key)) groups.get(key).push(row);
+      else groups.set(key, [row]);
+    }
   return [...groups].map(([key, group]) => {
     const [arm, metric] = key.split("|"),
       wall = group.map((row) => row.wallMs),

--- a/tools/scale/cli-entity-bench.workload.mjs
+++ b/tools/scale/cli-entity-bench.workload.mjs
@@ -285,12 +285,13 @@ export function brief(receipt) {
   };
 }
 
-// First value per key, breadth-first over the receipt and its JSON-string evidence.
+// First value per key, breadth-first over the receipt and its JSON-string evidence. A read cursor,
+// not queue.shift(): list receipts at 10k Tasks hold ~10^5 nodes and shift() makes the walk quadratic.
 export function deepFind(root, keys) {
   const found = {},
     queue = [root];
-  while (queue.length && Object.keys(found).length < keys.length) {
-    let value = queue.shift();
+  for (let next = 0; next < queue.length && Object.keys(found).length < keys.length; next++) {
+    let value = queue[next];
     if (typeof value === "string" && /^[[{]/u.test(value))
       try {
         value = JSON.parse(value);

--- a/tools/scale/cli-entity-bench.workload.mjs
+++ b/tools/scale/cli-entity-bench.workload.mjs
@@ -83,8 +83,9 @@ export function population(f, n) {
         "relate",
         "--source-ref",
         `task/${taskId((index + 1) % n)}`,
+        // A random earlier Task: a shallow dependency forest, not one N/2-deep chain.
         "--target-ref",
-        `task/${taskId(index % n)}`,
+        `task/${taskId(hashIndex(`r${index}`, (index % n) + 1))}`,
         "--type",
         "depends-on",
         "--rationale",

--- a/tools/scale/cli-entity-bench.workload.mjs
+++ b/tools/scale/cli-entity-bench.workload.mjs
@@ -1,0 +1,310 @@
+/**
+ * Workload for tools/scale/cli-entity-bench.mjs: the population it writes and the context the
+ * coverage table reads (ids from earlier receipts, fixture files, lifecycle packets).
+ */
+import { spawn } from "node:child_process";
+import { createHash, randomUUID } from "node:crypto";
+import { mkdirSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { git } from "../../packages/cli/test/daemon-multi-repo-lifecycle-cli.fixtures.ts";
+import { realizedDecisionBody, realizedTaskPlan } from "../fixtures/task-plan.mjs";
+import { benchKinds, decisionPacket } from "./cli-entity-bench.commands.mjs";
+
+export const taskId = (index) => `bench-task-${index}`;
+export const nonce = (label) => `${label} ✓ 测试 é ${createHash("sha256").update(label).digest("hex").slice(0, 12)}`;
+const kinds = ["feat", "fix", "docs"],
+  tiers = ["low", "medium", "high"];
+
+export function factOp(f, n, label) {
+  const statement = nonce(`fact ${label}`);
+  return {
+    kind: "fact",
+    key: label,
+    argv: [
+      "fact",
+      "record",
+      taskId(hashIndex(label, n)),
+      "--statement",
+      statement,
+      "--source",
+      "bench",
+      "--confidence",
+      "high",
+    ],
+    values: [statement],
+  };
+}
+
+export function population(f, n) {
+  const ops = [];
+  for (let index = 0; index < n; index++) {
+    const title = `Bench task ${index} ${nonce(`t${index}`).slice(-12)}`;
+    ops.push({
+      kind: "task",
+      key: taskId(index),
+      values: [title],
+      argv: [
+        "task",
+        "create",
+        "--id",
+        taskId(index),
+        "--admin",
+        "--title",
+        title,
+        "--kind",
+        kinds[index % 3],
+        "--risk-tier",
+        tiers[index % 3],
+        "--urgency",
+        tiers[(index + 1) % 3],
+      ],
+    });
+  }
+  const others = [];
+  for (let index = 0; index < Math.round(0.45 * n); index++) others.push(factOp(f, n, `f${index}`));
+  for (let index = 0; index < Math.round(0.48 * n); index++) {
+    const title = `Bench decision ${index}`,
+      text = nonce(`d${index}`);
+    others.push({
+      kind: "decision",
+      key: `d${index}`,
+      values: [title, text],
+      argv: ["decision", "propose", "--json-input", decisionPacket(title, text)],
+    });
+  }
+  for (let index = 0; index < Math.round(0.5 * n); index++) {
+    const rationale = nonce(`r${index}`);
+    others.push({
+      kind: "relation",
+      key: `r${index}`,
+      values: [rationale],
+      argv: [
+        "relation",
+        "relate",
+        "--source-ref",
+        `task/${taskId((index + 1) % n)}`,
+        "--target-ref",
+        `task/${taskId(index % n)}`,
+        "--type",
+        "depends-on",
+        "--rationale",
+        rationale,
+        "--expected-version",
+        "0",
+      ],
+    });
+  }
+  for (const kind of benchKinds)
+    for (let index = 0; index < Math.round(0.1 * n); index++) others.push(importOp(f, kind, `p${index}`));
+  // Deterministic interleave so every kind is written under the same concurrent load.
+  return [
+    ...ops,
+    ...others.sort((left, right) => hashIndex(left.key + left.kind, 1e9) - hashIndex(right.key + right.kind, 1e9)),
+  ];
+}
+
+let issueOrigin = "http://127.0.0.1:0";
+const issueBody = (urlPath) => Buffer.from(`# Issue ${urlPath}\n${nonce(urlPath)}\n`);
+// A child process, because the CLI arm's spawnSync blocks this process while the daemon fetches.
+export async function issueServer() {
+  // Same bytes as issueBody(): "# Issue <path>\n" + nonce(<path>) + "\n".
+  const script = [
+    'const { createHash } = require("node:crypto");',
+    'const tag = (p) => createHash("sha256").update(p).digest("hex").slice(0, 12);',
+    'const body = (p) => "# Issue " + p + "\\n" + p + " \\u2713 \\u6d4b\\u8bd5 \\u00e9 " + tag(p) + "\\n";',
+    'require("node:http").createServer((q, r) => r.end(body(q.url)))',
+    '  .listen(0, "127.0.0.1", function () { console.log(this.address().port); });',
+  ].join("\n");
+  const server = spawn(process.execPath, ["-e", script], { stdio: ["ignore", "pipe", "inherit"] });
+  const port = await new Promise((resolve) => server.stdout.once("data", (chunk) => resolve(String(chunk).trim())));
+  issueOrigin = `http://127.0.0.1:${port}`;
+  return { close: () => server.kill() };
+}
+
+function importOp(f, kind, tag) {
+  const title = `Bench ${kind} ${tag}`;
+  if (kind === "external-issue") {
+    // URL locators are fetched by the daemon; the bench serves them locally (see issueServer).
+    const locator = `${issueOrigin}/bench/${encodeURIComponent(tag)}`;
+    return {
+      kind: `entity:${kind}`,
+      key: locator,
+      values: [title],
+      blobs: [issueBody(`/bench/${encodeURIComponent(tag)}`)],
+      argv: ["entity", "import", "--kind", kind, "--locator", locator, "--expected-version", "0", "--title", title],
+    };
+  }
+  const locator = `inputs/${kind}/${tag}`,
+    text = Buffer.from(`# ${nonce(`${kind} ${tag}`)}\n${"canonical content\n".repeat(16)}`),
+    binary = Buffer.alloc(2048);
+  let state = hashIndex(locator, 2 ** 31) + 1;
+  for (let offset = 0; offset < binary.length; offset++)
+    binary[offset] = (state = (Math.imul(state, 1664525) + 1013904223) >>> 0) & 255;
+  mkdirSync(path.join(f.root, locator), { recursive: true });
+  writeFileSync(path.join(f.root, locator, "README.md"), text);
+  writeFileSync(path.join(f.root, locator, "sample.bin"), binary);
+  return {
+    kind: `entity:${kind}`,
+    key: locator,
+    values: [title],
+    blobs: [text, binary],
+    argv: ["entity", "import", "--kind", kind, "--locator", locator, "--expected-version", "0", "--title", title],
+  };
+}
+
+export function benchContext(f, n, writes, samples) {
+  const got = new Map(),
+    accepted = writes.filter((w) => w.status === "accepted_durable");
+  let expect = null;
+  const receiptOf = (metric, s) => got.get(`${metric}#${s}`);
+  const decisions = accepted.filter((w) => w.kind === "decision").map((w) => w.entityId);
+  const dir = (name) => {
+    const target = path.join(f.parent, "bench-inputs", name);
+    mkdirSync(target, { recursive: true });
+    return target;
+  };
+  const writeJson = (target, value) => (writeFileSync(target, JSON.stringify(value)), target);
+  return {
+    got,
+    takeExpect: () => [expect, (expect = null)][0],
+    task: (index) => taskId(index % n),
+    decision: (index) => decisions[index % decisions.length],
+    id: (metric, s) => brief(receiptOf(metric, s)).entityId,
+    rev: (metric, s) => String(receiptOf(metric, s)?.revision ?? 0),
+    opId: (s) => accepted[s % accepted.length].opId,
+    text: (label) => {
+      const value = nonce(`${label} ${randomUUID()}`);
+      (expect ??= { values: [] }).values.push(value);
+      return value;
+    },
+    // Artifact and distill sources must be untracked regular files inside the repository.
+    repoFile: (name, text) => {
+      mkdirSync(path.join(f.root, "bench-src"), { recursive: true });
+      writeFileSync(path.join(f.root, "bench-src", name), text);
+      return `bench-src/${name}`;
+    },
+    field: (metric, s, key) => deepFind(receiptOf(metric, s), [key])[key] ?? "missing",
+    packagePath: (s, chain = "") => receiptOf(`task-create${chain}`, s)?.packagePath,
+    realizePlan: (s, chain = "") => {
+      const plan = `${receiptOf(`task-create${chain}`, s)?.packagePath}/task_plan.md`;
+      writeFileSync(path.join(f.root, "harness", plan), realizedTaskPlan(`Chain${chain} ${s}`));
+      return plan;
+    },
+    decisionBody: (s) => realizedDecisionBody(`Probe ${s}`),
+    writeCloseout: (s, chain = "") => {
+      const root = path.join(f.root, "harness", receiptOf(`task-create${chain}`, s)?.packagePath ?? "missing");
+      mkdirSync(path.join(root, "artifacts"), { recursive: true });
+      writeFileSync(path.join(root, "artifacts", "report.md"), `# Report ${s}\n`);
+      writeFileSync(
+        path.join(root, "closeout.md"),
+        "# Closeout\n\n## Summary\n\nBench.\n\n## Verification\n\nBench.\n\n" +
+          "## Residual Risk\n\nBench.\n\n## Same Mechanism Elsewhere\n\nBench.\n",
+      );
+    },
+    submission: (s, chain = "") => ({
+      completionClaim: "Bench chain complete.",
+      deliverables: [`${receiptOf(`task-create${chain}`, s)?.packagePath}/artifacts/report.md`],
+      outputs: ["bench"],
+      verificationNotes: ["bench"],
+      knownGaps: [],
+      residualRisks: [],
+      commitSha: git(f.root, "rev-parse", "HEAD"),
+    }),
+    review: (s, chain = "") => ({
+      verdict: "approved",
+      reason: "Bench review.",
+      evidenceChecked: [`${receiptOf(`task-create${chain}`, s)?.packagePath}/artifacts/report.md`],
+    }),
+    consent: (s) => {
+      const found = deepFind(receiptOf("task-review-execution", s), ["reviewDigest", "contentDigest"]);
+      return { reviewDigest: found.reviewDigest, contentDigest: found.contentDigest };
+    },
+    importArgs: (kind, tag) => {
+      const op = importOp(f, kind, `${tag}-${randomUUID().slice(0, 8)}`);
+      expect = { values: op.values, blobs: op.blobs };
+      return op.argv;
+    },
+    agentSource: (s) =>
+      path.dirname(
+        writeJson(path.join(dir(`agent-${s}`), "agent.json"), {
+          schema: "agent-declaration/v1",
+          id: `bench-agent-${s}`,
+          name: `Bench ${s}`,
+          instructions: "Bench agent.",
+          runtime_type: "codex",
+          skills: [],
+          prompts: [],
+          preset: "standard-task",
+        }),
+      ),
+    squadSource: (s) =>
+      path.dirname(
+        writeJson(path.join(dir(`squad-${s}`), "squad.json"), {
+          schema: "squad-declaration/v1",
+          id: `bench-squad-${s}`,
+          name: `Bench squad ${s}`,
+          leader: `bench-agent-${s}`,
+          workers: [`bench-agent-${(s + 1) % samples}`],
+          leaderTurnBudget: 8,
+          roster: `bench-agent-${(s + 1) % samples} -> work`,
+        }),
+      ),
+    kindFile: (s) =>
+      writeJson(path.join(dir("kinds"), `kind-${s}.json`), {
+        id: `bench-kind-${s}`,
+        entityType: "artifact",
+        idPrefix: `BK${s}`,
+        display: { singular: `Bench kind ${s}`, plural: `Bench kinds ${s}` },
+        descriptorSchemaRef: "schema://artifact-descriptor",
+        store: { pathTemplate: `entities/bench-kind-${s}/{id}.json` },
+        locatorKinds: ["repository-path"],
+        attributes: {},
+      }),
+    schemaFile: (s) => writeJson(path.join(dir("kinds"), `schema-${s}.json`), { owner: { type: "string" } }),
+    presetSource: () => path.resolve("packages/preset/assets/software-coding/presets/docs-task"),
+    scriptId: () => deepFind(receiptOf("script-list", 0), ["id"]).id,
+    backupDir: (s) => path.join(f.parent, "backups", `backup-${s}`),
+  };
+}
+
+export function brief(receipt) {
+  if (!receipt) return {};
+  const found = deepFind(receipt, ["entityId", "factId", "decisionId", "relationId", "candidateId"]);
+  return {
+    ok: receipt.ok ?? null,
+    status: receipt.status ?? null,
+    outcome: receipt.outcome ?? null,
+    code: receipt.code ?? receipt.error?.code ?? null,
+    ...(receipt.ok === false
+      ? { diagnostic: JSON.stringify(receipt.diagnostic ?? receipt.nextAction ?? null).slice(0, 400) }
+      : {}),
+    opId: receipt.opId ?? null,
+    revision: receipt.revision ?? null,
+    entityId: found.entityId ?? found.factId ?? found.decisionId ?? found.relationId ?? found.candidateId ?? null,
+  };
+}
+
+// First value per key, breadth-first over the receipt and its JSON-string evidence.
+export function deepFind(root, keys) {
+  const found = {},
+    queue = [root];
+  while (queue.length && Object.keys(found).length < keys.length) {
+    let value = queue.shift();
+    if (typeof value === "string" && /^[[{]/u.test(value))
+      try {
+        value = JSON.parse(value);
+      } catch {
+        continue;
+      }
+    if (!value || typeof value !== "object") continue;
+    for (const [key, child] of Object.entries(value)) {
+      if (keys.includes(key) && found[key] === undefined && typeof child === "string") found[key] = child;
+      queue.push(child);
+    }
+  }
+  return found;
+}
+
+export function hashIndex(text, modulo) {
+  return createHash("sha256").update(String(text)).digest().readUInt32BE(0) % modulo;
+}

--- a/tools/stress/entity-cli-calibration.fixture.mjs
+++ b/tools/stress/entity-cli-calibration.fixture.mjs
@@ -11,7 +11,7 @@ import { lastTimingRecord, percentile } from "../measure-cli-command-timing.mjs"
 export const workload = Object.freeze({ seeds: [1103, 2207, 3301], tasks: 3, entities: 3, binaryBytes: 4096 });
 export const frame = (type, value) => console.log(`ENTITY_CLI_CALIBRATION\t${JSON.stringify({ type, ...value })}`);
 
-export function fixture(seed) {
+export function fixture(seed, { daemonId = "entity-cli-calibration", frames = true } = {}) {
   const parent = mkdtempSync(path.join(tmpdir(), "ha-entity-cli-calibration-"));
   const root = path.join(parent, "repo"),
     userRoot = path.join(parent, "user");
@@ -26,7 +26,7 @@ export function fixture(seed) {
   }
   Object.assign(env, {
     HARNESS_DAEMON_USER_ROOT: userRoot,
-    HARNESS_DAEMON_ID: "entity-cli-calibration",
+    HARNESS_DAEMON_ID: daemonId,
     HARNESS_GIT_AUTHOR_NAME: "Calibration Fixture",
     HARNESS_GIT_AUTHOR_EMAIL: "calibration@example.test",
     GIT_CONFIG_GLOBAL: "/dev/null",
@@ -34,14 +34,16 @@ export function fixture(seed) {
   });
   const rows = [],
     checks = [];
-  const invoke = (metric, args, { actor, input, requireSuccess = true } = {}) => {
+  const invoke = (metric, args, { actor, input, requireSuccess = true, timeoutMs = 30_000, offline = false } = {}) => {
     const startedAt = new Date().toISOString(),
       started = performance.now();
-    const result = spawnSync(process.execPath, [cli, "--root", root, "--json", ...args], {
+    // Offline storage commands (backup, restore, events, migrate ledger) are recognised by argv[0].
+    const argv = offline ? [...args, "--root", root, "--json"] : ["--root", root, "--json", ...args];
+    const result = spawnSync(process.execPath, [cli, ...argv], {
       env: { ...env, ...(actor ? { HARNESS_ACTOR: actor } : {}) },
       encoding: "utf8",
-      timeout: 30_000,
-      maxBuffer: 8 * 1024 * 1024,
+      timeout: timeoutMs,
+      maxBuffer: 512 * 1024 * 1024,
       ...(input === undefined ? {} : { input: JSON.stringify(input) }),
     });
     let receipt = null;
@@ -65,7 +67,7 @@ export function fixture(seed) {
       timing: lastTimingRecord(result.stderr ?? ""),
     };
     rows.push(row);
-    frame("command", row);
+    if (frames) frame("command", row);
     if (requireSuccess) {
       assert.equal(result.status, 0, `${metric}: ${result.stdout}\n${result.stderr}`);
       assert.equal(receipt?.ok, true, `${metric}: ${result.stdout}`);
@@ -122,7 +124,7 @@ export function fixture(seed) {
       rmSync(parent, { recursive: true, force: true, maxRetries: 5 });
     }
   };
-  return { seed, parent, root, userRoot, rows, checks, invoke, check, publish, close };
+  return { seed, parent, root, userRoot, env, rows, checks, invoke, check, publish, close };
 }
 
 export function resourceSnapshot(root) {


### PR DESCRIPTION
# English

## Summary

Adds a repeatable scale bench for every `ha` CLI command and every entity read/write path on a real daemon. One command runs a tier in a fresh container from the local Docker test image: `node tools/scale/cli-entity-bench.mjs --docker --tasks 1000|10000 --out <dir>`. It populates Tasks, Facts, Decisions, Relations and artifact imports through the CLI's own parser and daemon client with 8 concurrent clients. It then measures each mapped command as a real `ha` process (CLI arm, with `HA_CLI_TIMING` phases) and reads on the RPC arm, and records cold/hot reads and 1- and 8-client throughput. Five correctness oracles check the result, each paired with a corrupted-input control that must fail:
- B1: receipt vs. durable outcome in both directions.
- B2: byte-for-byte readback by opId.
- B3: list visibility, including deletes.
- B4: reads are equal before and after a full projection rebuild.
- B5: ledger revision structure (the stress O2 oracle).

Eight runs of this bench (1k and 10k, before and after the R batch) found seven defects outside the bench: F1 #2430, F2 #2435, F3 #2434, F4 #2439, F6 #2444 and F7 #2442 are fixed. F5 (entity-action write cost grows with repository size) is open. No product code changes.

## Architectural Justification

- Churn is 1,726 lines, all under `tools/`; production packages are untouched.
- Why not extend `tools/scale/measure.mjs`: it measures file-scan, replay and hash primitives on synthetic fixture trees. It never drives a daemon or the CLI, so it cannot measure command latency or check receipts against durable state.
- Why not extend `tools/stress`: its campaigns inject failures under a controller that writes a receipt log. This bench runs the full command registry at 1k–10k scale.
- What it reuses:
  - the stress O2 oracle (B5);
  - the entity CLI calibration fixture, parameterized with a daemon id, frame output, offline argv order and a timeout;
  - `percentile` from `tools/measure-cli-command-timing.mjs`;
  - the CLI test fixture helpers.
- B1 does not reuse stress O1: O1 consumes the controller's receipt log and a frozen authority cut, while the bench checks CLI receipts against the live store. Converting 17k bench writes into the controller log format would add code rather than remove it.
- `cli-entity-bench.commands.mjs` maps each registry id to a sample builder or to the reason it is not measured. Unmapped ids are reported, never dropped. On current main: 162 commands, 125 measured, 37 excluded, 0 unmapped.

## What Changed

- `tools/scale/cli-entity-bench.mjs`: entry point, Docker orchestration, population, measurement, throughput and cold reads.
- `tools/scale/cli-entity-bench.commands.mjs`: command registry mapping and sample builders.
- `tools/scale/cli-entity-bench.workload.mjs`: population shapes and payload builders.
- `tools/scale/cli-entity-bench.oracles.mjs`: oracles B1–B5 and their negative controls.
- `tools/scale/cli-entity-bench.report.mjs`: JSON and Markdown results, and `--compare` ratios.
- `tools/scale/README.md`: usage.
- `tools/stress/entity-cli-calibration.fixture.mjs`: optional daemon id, frame output, offline argv order and timeout. The output buffer grows to 512 MiB for 10k-row reads. Defaults are unchanged.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: +1718/-8 (net +1710), from `node tools/gates/production-delta.mjs --base origin/main`; all lines are under `tools/`.

## Machine-Readable Declarations

## Task And Scope

- Harness task: task_34935988e63cb55291ca3c5ada
- Branch: `codex/scale-bench-cli-entity`
- Public scope: `tools/scale` bench tooling and the calibration fixture's options
- Private planning/evidence updated: yes (bench report, raw results and facts in the task package)
- Out of scope: fixing F5; product code

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: not applicable
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `cb4d238ca`
- Branch merge-base with `origin/main`: `cb4d238ca`
- Last `git fetch origin` time: 2026-09-11 UTC (before rebase)
- Sync method: rebased onto origin/main
- Public diff command: `git diff origin/main...codex/scale-bench-cli-entity`
- Private evidence commit/path: task_34935988e63cb55291ca3c5ada task package bench report
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [x] `npm run harness:check-import-boundaries` (via `run-manifest-gates --changed origin/main`)
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts` (via `run-manifest-gates --changed origin/main`)
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- `node tools/scale/cli-entity-bench.mjs --matrix` on this branch after rebase: 162 commands, 125 measured, 37 excluded, 0 unmapped.
- Eight bench runs in Docker: pre-R 1k ×3 and 10k ×1, post-R 1k ×2 and 10k ×1, latest main 1k ×1. Every oracle passed in every run, and every negative control made its oracle fail.
- `run-manifest-gates --changed origin/main` passes (lint, test-tier manifest, CLI structure, import boundaries, duplicate definitions, implementation contracts).
- `tools/stress/entity-cli-calibration.integration.test.mjs` needs Linux; after the fixture change it passes 1/1 through `tools/dispatch-isolated-test.mjs --target docker` (47 s).

## Review Evidence

- Worker (Claude Opus) built the bench and ran it.
- The lead checked the bench for overlap with `tools/scale` and `tools/stress`, confirmed B5 reuses O2, accepted B1's separate implementation for the reason above, and re-ran the coverage matrix on current main.
- Reviewer subagent: not used
- Human review: pending
- Blocking findings: none

## Residual Risk

- Numbers are same-host comparisons on a loaded development machine, not SLOs.
- The 10k tier needs a population budget (1,500 s used in the report). The bench records the reached counts when the budget cuts population short.

## References

- Task: task_34935988e63cb55291ca3c5ada
- Fixes it led to: #2430, #2434, #2435, #2439, #2442, #2444

---

# 中文

## 概要

新增一个可重复运行的规模 Bench，覆盖每一条 `ha` CLI 命令和每一条 entity 读写路径，跑在真实 daemon 上。一条命令就能在本地 Docker 测试镜像的新容器里跑完一档：`node tools/scale/cli-entity-bench.mjs --docker --tasks 1000|10000 --out <dir>`。

- 填充：经 CLI 自己的解析器和 daemon client，用 8 个并发 client 写入 Task、Fact、Decision、Relation 与工件 import。
- 测量：每条映射到的命令以真实 `ha` 进程执行（CLI 臂，带 `HA_CLI_TIMING` 相位），读取同时走 RPC 臂测量；另记录冷读、热读，以及 1 client 与 8 client 的吞吐。
- 正确性判据共五条，每条都配一个损坏输入的对照，对照必须让判据失败：
  - B1：回执与持久结果双向一致。
  - B2：按 opId 逐字节读回。
  - B3：列表可见性，包括删除。
  - B4：投影全量重建前后读结果相等。
  - B5：ledger revision 结构（即 stress 的 O2 判据）。

这个 Bench 跑了 8 轮（1k 与 10k，R 批次前后），找到 Bench 之外的 7 个缺陷：F1 #2430、F2 #2435、F3 #2434、F4 #2439、F6 #2444、F7 #2442 已修；F5（entity-action 写入成本随仓库规模增长）未修。不改产品代码。

## 架构辩护

- 改动 1,726 行，全部在 `tools/` 下，不碰生产包。
- 为什么不扩展 `tools/scale/measure.mjs`：它测的是合成 fixture 树上的文件扫描、回放与 hash 原语，不驱动 daemon 或 CLI，测不了命令时延，也没法拿回执和持久状态对照。
- 为什么不扩展 `tools/stress`：它的 campaign 在一个写 receipt log 的 controller 下做故障注入；本 Bench 要在 1k–10k 规模上跑完整个命令注册表。
- 复用的部分：
  - stress 的 O2 判据（B5）；
  - entity CLI calibration fixture，新增 daemon id、帧输出、离线命令参数顺序与超时四个可选参数；
  - `tools/measure-cli-command-timing.mjs` 的 `percentile`；
  - CLI 测试 fixture 的辅助函数。
- B1 没有复用 stress 的 O1：O1 读的是 controller 的 receipt log 和冻结的权威切面，Bench 是拿 CLI 回执对照活的 store。把 1.7 万次 Bench 写入转换成 controller 日志格式，只会增加代码，而不是减少。
- `cli-entity-bench.commands.mjs` 把每个注册表 id 映射到采样构造器，或写明不测的原因；未映射的 id 会报告出来，不会被丢掉。当前 main 上：162 条命令，125 条测量，37 条排除，0 条未映射。

## 改动内容

- `tools/scale/cli-entity-bench.mjs`：入口、Docker 编排、填充、测量、吞吐与冷读。
- `tools/scale/cli-entity-bench.commands.mjs`：命令注册表映射与采样构造器。
- `tools/scale/cli-entity-bench.workload.mjs`：填充形状与载荷构造。
- `tools/scale/cli-entity-bench.oracles.mjs`：判据 B1–B5 及其阴性对照。
- `tools/scale/cli-entity-bench.report.mjs`：JSON 与 Markdown 结果，以及 `--compare` 比值。
- `tools/scale/README.md`：用法。
- `tools/stress/entity-cli-calibration.fixture.mjs`：新增可选的 daemon id、帧输出、离线命令参数顺序与超时；为 1 万行的读取把输出缓冲放大到 512 MiB。默认行为不变。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 删除的门或 fixture：none
- 生产净行数：+1718/-8 (net +1710)，由 `node tools/gates/production-delta.mjs --base origin/main` 计算；全部在 `tools/` 下。

## 机读声明说明

- 本 PR 不涉及依赖变化和事件迁移，没有机读声明。

## 任务与范围

- Harness 任务：task_34935988e63cb55291ca3c5ada
- 分支：`codex/scale-bench-cli-entity`
- 公开范围：`tools/scale` 的 Bench 工具，以及 calibration fixture 的可选参数
- 私有计划 / 证据是否已更新：yes（任务包里的 Bench 报告、原始结果与 fact）
- 范围外：修 F5；产品代码

## 版本影响

- 版本：不改版本
- 发布影响：不发布

## 治理声明

- 是否触碰 protected surface：no
- protected surface 范围：不适用
- 依据：不适用
- 机器检查边界：本 PR 只声明该段存在；声明是否真实、充分，由 reviewer 判断。
- Break-glass：no
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- `origin/main` 基准 SHA：`cb4d238ca`
- 当前分支与 `origin/main` 的 merge-base：`cb4d238ca`
- 最近一次 `git fetch origin` 时间：2026-09-11 UTC（rebase 前）
- 同步方式：rebase 到 origin/main
- 公开 diff 命令：`git diff origin/main...codex/scale-bench-cli-entity`
- 私有证据 commit/path：task_34935988e63cb55291ca3c5ada 任务包 Bench 报告
- Reviewer 证据路径：见本 PR 的「审查证据」一节
- GitHub Actions `rewrite-ci` run URL：本 PR 的 CI 还在跑
- [ ] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [x] `npm run harness:check-import-boundaries`（经 `run-manifest-gates --changed origin/main`）
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts`（经 `run-manifest-gates --changed origin/main`）
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- rebase 后在本分支跑 `node tools/scale/cli-entity-bench.mjs --matrix`：162 条命令，125 条测量，37 条排除，0 条未映射。
- Docker 里跑了 8 轮：pre-R 1k ×3、10k ×1，post-R 1k ×2、10k ×1，最新 main 1k ×1。每轮判据全部通过，每个阴性对照都让对应判据失败。
- `run-manifest-gates --changed origin/main` 通过（lint、test-tier manifest、CLI 结构、import 边界、重复定义、实现契约）。
- `tools/stress/entity-cli-calibration.integration.test.mjs` 需要 Linux；fixture 改动后经 `tools/dispatch-isolated-test.mjs --target docker` 运行，1/1 通过（47 秒）。

## 审查证据

- worker（Claude Opus）写了 Bench 并完成运行。
- 主控核查了与 `tools/scale`、`tools/stress` 的重叠：确认 B5 复用了 O2；B1 单独实现的理由见上文，予以接受；并在当前 main 上重跑了覆盖矩阵。
- Reviewer subagent：未使用
- 人工审查：待进行
- 阻塞发现：无

## 残余风险

- 数字是负载中的开发机上的同机对比，不是 SLO。
- 10k 档需要填充预算（报告用 1,500 秒）；预算截断时，Bench 记录实际达到的数量。

## 关联材料

- Task: task_34935988e63cb55291ca3c5ada
- 它促成的修复：#2430、#2434、#2435、#2439、#2442、#2444

---

## PR Gate Checklist / PR 门禁清单

- [x] Branch is based on latest `origin/main`. / 分支基于最新 `origin/main`。
- [x] PR body uses this full template structure. / PR 描述使用本模板完整结构。
- [x] PR body uses two complete language blocks: `# English` first, then `# 中文`. / PR 正文使用两块完整正文：`# English` 在上，`# 中文` 在下。
- [x] PR body passes `tools/check-pr-body-bilingual.mjs`. / PR 正文通过 `tools/check-pr-body-bilingual.mjs`。
- [x] If the PR touches a manifest-derived protected surface, Governance Declaration is filled with ADR/decision/task evidence or break-glass fields. / 若 PR 触碰 manifest 派生的 protected surface，Governance Declaration 已填写 ADR/decision/task 依据或 break-glass 字段。
- [x] No private harness files are included. / 不包含私有 harness 文件。
- [x] No ignored local agent entry files are included. / 不包含被忽略的本地 agent 入口文件。
- [x] No absolute local filesystem paths are included in this public PR body. / 本公开 PR 描述不包含本机绝对路径。
- [x] Public diff is limited to the stated task scope. / 公开 diff 限于声明的任务范围。
- [x] Private planning/evidence updates are recorded when applicable. / 适用时已记录私有计划 / 证据更新。
- [x] Version and publish impact are stated. / 已说明版本与发布影响。
- [x] Local verification commands are recorded honestly. / 已如实记录本地验证命令。
- [ ] CI results are linked or explained. / CI 结果已链接或说明。
- [x] Review evidence is recorded. / 已记录审查证据。
- [x] Open P0/P1/P2 findings are closed, deferred with owner, or explicitly blocked. / open P0/P1/P2 findings 已关闭、带 owner 延后，或明确阻塞。
- [x] Merge method and post-merge branch cleanup plan are clear. / 合并方式和合并后分支清理计划清楚。
- [x] No admin bypass is planned unless explicitly approved and recorded. / 除非明确批准并记录，否则不计划 admin bypass。
