### PR TITLE
fix(daemon): a vertical script runs against a commit that includes every accepted write

### DIFF
--- a/packages/daemon/src/repo-cell-api.ts
+++ b/packages/daemon/src/repo-cell-api.ts
@@ -393,7 +393,8 @@ export function createRepoCellApi(context: RepoCellApiContext): RepoCell & RepoC
         });
     };
     if (action.kind === "script-run")
-      return Promise.resolve()
+      // The script reads the published commit, so it waits for every accepted write to be published first.
+      return Promise.resolve(context.store.settlePendingMaterialization?.("vertical script"))
         .then(() =>
           executeVerticalScriptAction({
             action,


### PR DESCRIPTION
# English

## Summary

Main `cb4d238ca` is red: `vertical-script-actions.test.ts` "RepoCell runs only declared vertical scripts and dry-run publishes the same plan without side effects" fails with `task_not_found` right after `task-create` returned `applied`. Locally it fails 4 of 5 runs on `cb4d238ca`.

Cause: `script-run` executes the script before it enters the write queue, against `store.currentCommit()`. The ledger commit for an accepted write is published afterwards by the store's follower, scheduled with `setImmediate`. So a script issued right after a write can run against a commit that does not yet contain that write. The race predates #2444: this test flaked occasionally tonight before it. #2444 made it frequent, because the write chain now yields one event-loop turn and the follower no longer always runs before the next action. `script-run` now waits for the follower to publish every accepted write (`settlePendingMaterialization`, the same wait `receipt-show` uses) before it reads the commit.

## Architectural Justification

-

## What Changed

- `repo-cell-api.ts`: the `script-run` path awaits `store.settlePendingMaterialization("vertical script")` before `executeVerticalScriptAction` reads `currentCommit()`. The script still runs outside the write queue.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: +2/-1 (net +1), from `node tools/gates/production-delta.mjs --base origin/main`.

## Machine-Readable Declarations

## Task And Scope

- Harness task: task_c4cb53aaee10608ce8f6ac6c09 (F6; this fixes the regression its #2444 exposed)
- Branch: `codex/vertical-script-settle`
- Public scope: the `script-run` path in `repo-cell-api.ts`
- Private planning/evidence updated: yes (F6 task closeout and a fact)
- Out of scope: the unrelated CI-load flakes seen on #2445 (`doc-sync-slice-a-artifacts-upgrades`, `review-independence-diagnostics`), which pass locally 5/5 and 3/3 on `cb4d238ca`

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: not applicable
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `cb4d238ca`
- Branch merge-base with `origin/main`: `cb4d238ca`
- Last `git fetch origin` time: 2026-09-11 UTC
- Sync method: branched from origin/main
- Public diff command: `git diff origin/main...codex/vertical-script-settle`
- Private evidence commit/path: task_c4cb53aaee10608ce8f6ac6c09 task package
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [x] `npm run typecheck` (as `npx tsc -b packages/kernel packages/daemon`, exit 0)
- [ ] `npm test`
- [x] `npm run harness:check-import-boundaries` (via `run-manifest-gates --changed origin/main`)
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts` (via `run-manifest-gates --changed origin/main`)
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- The failing test, run alone: 8/8 pass with this change; 1/5 pass on `cb4d238ca` without it. With `repo-cell.ts` reverted to its pre-#2444 chain and no other change, 5/5 pass, which is how the regression was traced to the yield.
- Every test file that mentions `script-run` or vertical scripts (`vertical-script-actions`, `json-rpc-protocol`, `thin-command`, `thin-command-preset-fact-decision`, `daemon-autostart-cli`): 97/98. The one failure, "semantic sources and agent execution cross the daemon…", also fails on `cb4d238ca` in this shell because the session's executor identity leaks into the test's environment; it is not related.

## Review Evidence

- Lead diagnosis and fix. The only other `currentCommit()` read in `packages/daemon/src` is this one, so no other call site needs the wait.
- Reviewer subagent: not used
- Human review: pending
- Blocking findings: none

## Residual Risk

- A `script-run` issued while the follower cannot publish (for example concurrent authored edits) still runs against the last published commit, as before.

## References

- Task: task_c4cb53aaee10608ce8f6ac6c09
- Regression source: #2444

---

# 中文

## 概要

main `cb4d238ca` 红：`vertical-script-actions.test.ts` 的「RepoCell runs only declared vertical scripts and dry-run publishes the same plan without side effects」在 `task-create` 返回 `applied` 后立刻报 `task_not_found`。在 `cb4d238ca` 上本地 5 次失败 4 次。

原因：`script-run` 在进入写队列之前执行脚本，读的是 `store.currentCommit()`；而已受理写入的 ledger 提交由 store 的 follower 随后发布，follower 用 `setImmediate` 调度。所以紧跟在写入之后的脚本，可能读到还不包含这次写入的提交。这个竞态早于 #2444 就存在，今晚在它之前这个测试就偶发失败过。#2444 让写入链每次让出一个事件循环轮次之后，follower 不再总是抢在下一个动作之前运行，于是变得高频。现在 `script-run` 在读提交之前，先等 follower 发布完全部已受理的写入。用的是 `settlePendingMaterialization`，与 `receipt-show` 用的等待相同。

## 架构辩护

-

## 改动内容

- `repo-cell-api.ts`：`script-run` 路径在 `executeVerticalScriptAction` 读 `currentCommit()` 之前，先 await `store.settlePendingMaterialization("vertical script")`。脚本仍在写队列之外运行。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 删除的门或 fixture：none
- 生产净行数：+2/-1 (net +1)，由 `node tools/gates/production-delta.mjs --base origin/main` 计算。

## 机读声明说明

- 本 PR 不涉及依赖变化和事件迁移，没有机读声明。

## 任务与范围

- Harness 任务：task_c4cb53aaee10608ce8f6ac6c09（F6；本 PR 修它的 #2444 暴露出的回归）
- 分支：`codex/vertical-script-settle`
- 公开范围：`repo-cell-api.ts` 的 `script-run` 路径
- 私有计划 / 证据是否已更新：yes（F6 任务 closeout 与一条 fact）
- 范围外：#2445 上看到的两个 CI 负载下的偶发失败（`doc-sync-slice-a-artifacts-upgrades`、`review-independence-diagnostics`），在 `cb4d238ca` 上本地分别 5/5、3/3 通过

## 版本影响

- 版本：不改版本
- 发布影响：不发布

## 治理声明

- 是否触碰 protected surface：no
- protected surface 范围：不适用
- 依据：不适用
- 机器检查边界：本 PR 只声明该段存在；声明是否真实、充分，由 reviewer 判断。
- Break-glass：no
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- `origin/main` 基准 SHA：`cb4d238ca`
- 当前分支与 `origin/main` 的 merge-base：`cb4d238ca`
- 最近一次 `git fetch origin` 时间：2026-09-11 UTC
- 同步方式：从 origin/main 建分支
- 公开 diff 命令：`git diff origin/main...codex/vertical-script-settle`
- 私有证据 commit/path：task_c4cb53aaee10608ce8f6ac6c09 任务包
- Reviewer 证据路径：见本 PR 的「审查证据」一节
- GitHub Actions `rewrite-ci` run URL：本 PR 的 CI 还在跑
- [ ] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [x] `npm run typecheck`（以 `npx tsc -b packages/kernel packages/daemon` 运行，exit 0）
- [ ] `npm test`
- [x] `npm run harness:check-import-boundaries`（经 `run-manifest-gates --changed origin/main`）
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts`（经 `run-manifest-gates --changed origin/main`）
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- 单独跑失败的测试：带本改动 8/8 通过；不带时在 `cb4d238ca` 上 5 次只过 1 次。只把 `repo-cell.ts` 换回 #2444 之前的写入链、别的不动，5/5 通过，由此定位到让出。
- 所有提到 `script-run` 或 vertical script 的测试文件（`vertical-script-actions`、`json-rpc-protocol`、`thin-command`、`thin-command-preset-fact-decision`、`daemon-autostart-cli`）：97/98。唯一的失败「semantic sources and agent execution cross the daemon…」在这个 shell 里对 `cb4d238ca` 同样失败，原因是会话的执行者身份泄漏进测试环境，与本改动无关。

## 审查证据

- 主控诊断并修复。`packages/daemon/src` 里读 `currentCommit()` 的只有这一处，别处不需要等待。
- Reviewer subagent：未使用
- 人工审查：待进行
- 阻塞发现：无

## 残余风险

- follower 无法发布时（例如 authored 树有并发编辑），`script-run` 仍按最后一次已发布的提交运行，与以前相同。

## 关联材料

- Task: task_c4cb53aaee10608ce8f6ac6c09
- 回归来源：#2444

---

## PR Gate Checklist / PR 门禁清单

- [x] Branch is based on latest `origin/main`. / 分支基于最新 `origin/main`。
- [x] PR body uses this full template structure. / PR 描述使用本模板完整结构。
- [x] PR body uses two complete language blocks: `# English` first, then `# 中文`. / PR 正文使用两块完整正文：`# English` 在上，`# 中文` 在下。
- [x] PR body passes `tools/check-pr-body-bilingual.mjs`. / PR 正文通过 `tools/check-pr-body-bilingual.mjs`。
- [x] If the PR touches a manifest-derived protected surface, Governance Declaration is filled with ADR/decision/task evidence or break-glass fields. / 若 PR 触碰 manifest 派生的 protected surface，Governance Declaration 已填写 ADR/decision/task 依据或 break-glass 字段。
- [x] No private harness files are included. / 不包含私有 harness 文件。
- [x] No ignored local agent entry files are included. / 不包含被忽略的本地 agent 入口文件。
- [x] No absolute local filesystem paths are included in this public PR body. / 本公开 PR 描述不包含本机绝对路径。
- [x] Public diff is limited to the stated task scope. / 公开 diff 限于声明的任务范围。
- [x] Private planning/evidence updates are recorded when applicable. / 适用时已记录私有计划 / 证据更新。
- [x] Version and publish impact are stated. / 已说明版本与发布影响。
- [x] Local verification commands are recorded honestly. / 已如实记录本地验证命令。
- [ ] CI results are linked or explained. / CI 结果已链接或说明。
- [x] Review evidence is recorded. / 已记录审查证据。
- [x] Open P0/P1/P2 findings are closed, deferred with owner, or explicitly blocked. / open P0/P1/P2 findings 已关闭、带 owner 延后，或明确阻塞。
- [x] Merge method and post-merge branch cleanup plan are clear. / 合并方式和合并后分支清理计划清楚。
- [x] No admin bypass is planned unless explicitly approved and recorded. / 除非明确批准并记录，否则不计划 admin bypass。
