### PR TITLE
perf(daemon): relation, import and decision writes read only the rows they need

### DIFF
--- a/packages/daemon/src/artifact-entity-action.ts
+++ b/packages/daemon/src/artifact-entity-action.ts
@@ -399,12 +399,7 @@ export async function runArtifactEntityImport(input: {
       randomEntityIdBytes: () => randomBytes(ARTIFACT_ENTITY_ID_BYTES),
       readOperation: (opId) => readEntityOperation(input.store, opId),
       countRelationChanges: (entityRef) =>
-        input.projection
-          .readRelationTruth()
-          .edges.filter(
-            ({ sourceRef, targetRef, state }) =>
-              state === "active" && (sourceRef === entityRef || targetRef === entityRef),
-          ).length,
+        input.projection.readRelationQuery({ entity: entityRef, state: "active" }).rows.length,
     }),
     prepared = await service.prepare(
       {

--- a/packages/daemon/src/entity-action-catalog-executor.ts
+++ b/packages/daemon/src/entity-action-catalog-executor.ts
@@ -569,9 +569,8 @@ function compileDraft(
   if (document.watermark !== document.sourceRevision)
     reject("content_not_ready", `Decision document ${path} is pending.`);
   const relations = projection
-    .readDecisionGraph()
-    .edges.filter((edge) => edge.ownerRef === `decision/${draft.event.decisionId}`)
-    .map((edge) => ({
+    .readRelationQuery({ ownerRef: `decision/${draft.event.decisionId}` })
+    .rows.map((edge) => ({
       relation_id: edge.relationId,
       source: edge.sourceRef,
       target: edge.targetRef,

--- a/packages/daemon/src/entity-action-relation.ts
+++ b/packages/daemon/src/entity-action-relation.ts
@@ -123,11 +123,7 @@ export function executeRelationAction(input: {
   if (
     compiled.type === "relation_created" &&
     compiled.payload.relation.type === "depends-on" &&
-    hasRelationPath(
-      input.projection.readRelationTruth().edges,
-      compiled.payload.relation.target,
-      compiled.payload.relation.source,
-    )
+    hasRelationPath(input.projection, compiled.payload.relation.target, compiled.payload.relation.source)
   )
     reject("relation_cycle", "The requested depends-on Relation would create a blocking cycle.");
   const plan = relationEventWritePlan(compiled),
@@ -192,15 +188,7 @@ function requiredRelationText(value: unknown, field: string): string {
   reject("invalid_command", `${field} is required.`);
 }
 
-function hasRelationPath(
-  edges: ReturnType<TaskProjection["readRelationTruth"]>["edges"],
-  start: string,
-  goal: string,
-): boolean {
-  const graph = new Map<string, string[]>();
-  for (const edge of edges)
-    if (edge.state === "active" && edge.relationType === "depends-on")
-      graph.set(edge.sourceRef, [...(graph.get(edge.sourceRef) ?? []), edge.targetRef]);
+function hasRelationPath(projection: TaskProjection, start: string, goal: string): boolean {
   const queue = [start],
     seen = new Set<string>();
   while (queue.length) {
@@ -208,7 +196,11 @@ function hasRelationPath(
     if (current === goal) return true;
     if (seen.has(current)) continue;
     seen.add(current);
-    queue.push(...(graph.get(current) ?? []));
+    queue.push(
+      ...projection
+        .readRelationQuery({ source: current, relationType: "depends-on", state: "active" })
+        .rows.map((edge) => edge.targetRef),
+    );
   }
   return false;
 }

--- a/packages/daemon/test/relation-action.integration.test.ts
+++ b/packages/daemon/test/relation-action.integration.test.ts
@@ -258,6 +258,52 @@ test("Relation actions serialize aggregate revisions and reject cycles and stale
   }
 });
 
+test("a depends-on cycle through several hops is rejected and converging paths are not a cycle", async () => {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-relation-cycle-"));
+  initRepo(rootDir);
+  const cell = await openRepoCell({
+    repoId: workspaceId("relation-cycle"),
+    rootDir: canonicalRoot(rootDir),
+    ownerId: "relation-cycle-test",
+  });
+  const dependsOn = (source: string, target: string) =>
+    cell.run(
+      {
+        kind: "relation-relate",
+        sourceRef: `task/task_cycle_${source}`,
+        targetRef: `task/task_cycle_${target}`,
+        relationType: "depends-on",
+        rationale: `${source} waits for ${target}.`,
+        expectedVersion: 0,
+      },
+      binding,
+    );
+  try {
+    for (const name of ["a", "b", "c", "d"])
+      assert.equal(
+        (await cell.run({ kind: "task-create", taskId: `task_cycle_${name}`, title: name }, binding)).outcome,
+        "applied",
+      );
+    // a -> b -> c, and a -> d -> c: two paths converge on c.
+    for (const [source, target] of [
+      ["a", "b"],
+      ["b", "c"],
+      ["a", "d"],
+      ["d", "c"],
+    ])
+      assert.equal((await dependsOn(source, target)).outcome, "applied", `${source} -> ${target}`);
+    // d -> b closes no loop: b cannot reach d.
+    assert.equal((await dependsOn("d", "b")).outcome, "applied");
+    // c -> a closes a loop through either path.
+    const cycle = await dependsOn("c", "a");
+    assert.equal(cycle.outcome, "op_rejected", JSON.stringify(cycle));
+    assert.equal(cycle.code, "relation_cycle");
+  } finally {
+    await cell.close();
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});
+
 function relationRows(receipt: { readonly evidence?: unknown }): readonly {
   readonly relationId: string;
   readonly strength: string;

--- a/packages/kernel/src/projection/task-query-projection.ts
+++ b/packages/kernel/src/projection/task-query-projection.ts
@@ -44,6 +44,7 @@ export interface TaskRelationQuery {
   readonly target?: string;
   readonly relationType?: string;
   readonly state?: string;
+  readonly ownerRef?: string;
   readonly freshness?: RelationFreshness;
   readonly updatedAfter?: string;
   readonly updatedBefore?: string;
@@ -680,6 +681,10 @@ export function readTaskRelationPage(
   if (query.state !== undefined) {
     where.push("state = ?");
     values.push(query.state);
+  }
+  if (query.ownerRef !== undefined) {
+    where.push("owner_ref = ?");
+    values.push(query.ownerRef);
   }
   if (query.updatedAfter !== undefined) {
     where.push("updated_at >= ?");

--- a/tools/gates/cost-budget.json
+++ b/tools/gates/cost-budget.json
@@ -203,20 +203,6 @@
     },
     "knownScaling": [
       {
-        "operation": "decision-propose",
-        "metric": "sqlRowsRead",
-        "reason": "entity-action-catalog-executor.ts compileDraft calls projection.readDecisionGraph() only to keep the edges owned by this one decision; readDecisionGraphRows builds the whole graph including decisionCoverage (kernel projection/decision-projection-coverage.ts), which reads every task (SELECT task_id,json_extract(snapshot_json,'$.task.status') AS status FROM task_snapshot ORDER BY task_id), every fact (SELECT ref FROM fact ORDER BY ref), and every decision, claim, option and relation edge. The replacement-authorization backward scan named in the task plan is now a per-process cache (#2410) and shows only in the first call.",
-        "deletionTaskId": "task_2b8f79fa4412cb726a26f9bfc7",
-        "expiresAt": "2026-09-24T00:00:00.000Z"
-      },
-      {
-        "operation": "decision-reject",
-        "metric": "sqlRowsRead",
-        "reason": "Same path as decision-propose: entity-action-catalog-executor.ts compileDraft calls projection.readDecisionGraph() only to keep the edges owned by this one decision; readDecisionGraphRows builds the whole graph including decisionCoverage (kernel projection/decision-projection-coverage.ts), which reads every task (SELECT task_id,json_extract(snapshot_json,'$.task.status') AS status FROM task_snapshot ORDER BY task_id), every fact (SELECT ref FROM fact ORDER BY ref), and every decision, claim, option and relation edge.",
-        "deletionTaskId": "task_2b8f79fa4412cb726a26f9bfc7",
-        "expiresAt": "2026-09-24T00:00:00.000Z"
-      },
-      {
         "operation": "runtime-overview",
         "metric": "sqlRowsRead",
         "reason": "workspaceSummaryFromProjection -> projection.readWorkspaceSummary() -> readWorkspaceSummaryRows (kernel projection/workspace-summary-projection.ts) reads every task (SELECT task_id, status, COALESCE(json_extract(snapshot_json, '$.task.packageDisposition'), 'active') AS package_disposition FROM task_snapshot ORDER BY task_id) and every decision (SELECT decision_id, state FROM decision ORDER BY decision_id) to count them in memory.",


### PR DESCRIPTION
# English

## Summary

Bench F5: relation relate, entity import and decision propose/reject got slower as the repository grew, because each of those writes read the whole repository's relation or decision graph to answer a question about one entity. They now read only the rows they need:
- The depends-on cycle check walks depends-on edges from the target, one indexed query per node, instead of loading every edge.
- Entity import counts active relations touching the one entity.
- Decision compilation reads only the edges the decision owns (a new `ownerRef` filter on the existing relation query) instead of building the whole decision graph, which also computed coverage over every task.

The two G1 `knownScaling` exemptions for decision-propose/reject named exactly this path; they are now stale and are removed.

## Architectural Justification

-

## What Changed

- `entity-action-relation.ts`: `hasRelationPath` takes the projection and queries active depends-on edges per visited node; the traversal stays complete (no depth or node cap).
- `artifact-entity-action.ts`: `countRelationChanges` uses `readRelationQuery({ entity, state: "active" })`.
- `entity-action-catalog-executor.ts`: `compileDraft` uses `readRelationQuery({ ownerRef })`.
- `task-query-projection.ts`: `TaskRelationQuery.ownerRef` filter.
- `relation-action.integration.test.ts`: a multi-hop cycle is rejected and converging paths are not a cycle.
- `tools/gates/cost-budget.json`: remove the decision-propose and decision-reject `knownScaling` entries.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: +15/-24 (net -9), from `node tools/gates/production-delta.mjs --base origin/main`.
- Gate data: two expired-by-fix exemptions removed from `tools/gates/cost-budget.json`; no budget or margin changed.

## Machine-Readable Declarations

## Task And Scope

- Harness task: task_644341526c2540f75649959928
- Branch: `codex/f5-per-write-full-graph-reads`
- Public scope: three per-write reads, one relation query filter, one test, two G1 exemptions
- Private planning/evidence updated: yes (task report with the CEO acceptance section, fact F-143244DE)
- Out of scope: an `owner_ref` index or rewriting the entity OR condition (projection schema changes)

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: yes
- Protected surface scope: `tools/gates/cost-budget.json`, removal of the decision-propose and decision-reject `writeCostScaling.knownScaling` entries only
- Authority: the entries' own `deletionTaskId` is task_2b8f79fa4412cb726a26f9bfc7 (the R batch this task belongs to), and G38 on this branch reports both as stale ("measured 156->156 is already within the margin; remove the exemption"). The repository owner authorized governance fixes for tonight's run.
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `46eebdc86`
- Branch merge-base with `origin/main`: `46eebdc86`
- Last `git fetch origin` time: 2026-09-11 UTC (before rebase)
- Sync method: rebased onto origin/main
- Public diff command: `git diff origin/main...codex/f5-per-write-full-graph-reads`
- Private evidence commit/path: task_644341526c2540f75649959928 task package report
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [x] `npm run typecheck` (as `npx tsc -b packages/kernel packages/daemon`, exit 0)
- [ ] `npm test`
- [x] `npm run harness:check-import-boundaries` (via `run-manifest-gates --changed origin/main`)
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts` (via `run-manifest-gates --changed origin/main`)
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- G1 at 200 → 2000 events (`node tools/gates/cost-budget.mjs`), sqlRowsRead: decision-propose main 410 → 2138, this branch 156 → 156; decision-reject 442 → 2170 vs 181 → 181; relation-relate 299 → 299 on both. G38 passes after the exemptions are removed.
- On a read-only copy of a real 10,617-edge projection: the old per-write reads took 4,876 ms (`readRelationTruth`-equivalent) and 434 ms (`readDecisionGraph`); the new owner read averages 5.2 ms. For all 762 decisions, the relations handed to `compileDecisionWrite` are field-for-field identical old vs new. Import counts for the 20 most-connected refs are identical. No depends-on edge exists only in `task_relation`, so the cycle check sees the same edge set.
- `EXPLAIN QUERY PLAN`: the cycle-check query uses `task_relation_type` and `relation_edge_source` in both UNION ALL arms. The owner and entity queries still scan `relation_edge` inside SQLite (5.5 ms and 10.7 ms on that copy).
- Mutation check: limiting the traversal to one hop makes the new multi-hop test fail; restored, it passes.
- Targeted tests 15/15: `relation-action`, `decision-surface`, `decision-review-independence`, `artifact-entity-action`, `g1-write-cost-scaling`. `run-manifest-gates --changed origin/main` passes.

## Review Evidence

- Worker (Codex Sol) wrote the production change. The lead measured G1 and the real-data comparisons, checked query plans and decision equivalence, added the multi-hop test with a mutation check, and removed the stale exemptions.
- Reviewer subagent: not used
- Human review: pending
- Blocking findings: none

## Residual Risk

- The decision owner read and the entity import count still scan `relation_edge` in SQLite, linear in edge count but a few milliseconds at 10k edges. An `owner_ref` index is the next step if it matters.
- Decision equivalence was verified on real data, not proven for every possible row shape. `taskRelationRow` turns a missing `rationale` into `""`, and no real decision edge lacks one.

## References

- Task: task_644341526c2540f75649959928
- Bench F5 (task_34935988e63cb55291ca3c5ada); fact F-143244DE

---

# 中文

## 概要

Bench F5：relation relate、entity import、decision propose/reject 随仓库变大而变慢。原因是这几种写入每次都读出整个仓库的关系图或决策图，只为回答关于一个 entity 的问题。现在它们只读需要的行：
- depends-on 环检测从 target 出发沿 depends-on 边走，每个节点一次走索引的查询，不再加载全部边。
- entity import 只数与这一个 entity 相连的活跃关系。
- decision 编译只读该 decision 自己拥有的边：在现有关系查询上新增 `ownerRef` 条件，不再构建整个 decision graph（后者还会对每个 task 计算 coverage）。

G1 里 decision-propose/reject 的两条 `knownScaling` 豁免指的正是这条路径，现已过期，一并删除。

## 架构辩护

-

## 改动内容

- `entity-action-relation.ts`：`hasRelationPath` 改为接收 projection，对访问到的每个节点查询活跃的 depends-on 边；遍历仍然完整，没有深度或节点上限。
- `artifact-entity-action.ts`：`countRelationChanges` 改用 `readRelationQuery({ entity, state: "active" })`。
- `entity-action-catalog-executor.ts`：`compileDraft` 改用 `readRelationQuery({ ownerRef })`。
- `task-query-projection.ts`：`TaskRelationQuery` 新增 `ownerRef` 条件。
- `relation-action.integration.test.ts`：多跳环被拒绝，路径汇合不算环。
- `tools/gates/cost-budget.json`：删除 decision-propose 与 decision-reject 的 `knownScaling` 条目。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 删除的门或 fixture：none
- 生产净行数：+15/-24 (net -9)，由 `node tools/gates/production-delta.mjs --base origin/main` 计算。
- 门数据：从 `tools/gates/cost-budget.json` 删除两条因本修复而过期的豁免；预算与容差都不变。

## 机读声明说明

- 本 PR 不涉及依赖变化和事件迁移，没有机读声明。

## 任务与范围

- Harness 任务：task_644341526c2540f75649959928
- 分支：`codex/f5-per-write-full-graph-reads`
- 公开范围：三处每次写入的读取、一个关系查询条件、一个测试、两条 G1 豁免
- 私有计划 / 证据是否已更新：yes（任务报告的 CEO 验收节，fact F-143244DE）
- 范围外：给 `owner_ref` 加索引，或改写 entity 的 OR 条件（都属于投影 schema 变化）

## 版本影响

- 版本：不改版本
- 发布影响：不发布

## 治理声明

- 是否触碰 protected surface：yes
- protected surface 范围：`tools/gates/cost-budget.json`，只删除 decision-propose 与 decision-reject 两条 `writeCostScaling.knownScaling`
- 依据：
  - 这两条豁免自身登记的 `deletionTaskId` 是 task_2b8f79fa4412cb726a26f9bfc7，也就是本任务所属的 R 批次；
  - 本分支上 G38 报两条都已过期（"measured 156->156 is already within the margin; remove the exemption"）；
  - 仓库所有者授权了今晚的治理修复。
- 机器检查边界：本 PR 只声明该段存在；声明是否真实、充分，由 reviewer 判断。
- Break-glass：no
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- `origin/main` 基准 SHA：`46eebdc86`
- 当前分支与 `origin/main` 的 merge-base：`46eebdc86`
- 最近一次 `git fetch origin` 时间：2026-09-11 UTC（rebase 前）
- 同步方式：rebase 到 origin/main
- 公开 diff 命令：`git diff origin/main...codex/f5-per-write-full-graph-reads`
- 私有证据 commit/path：task_644341526c2540f75649959928 任务包报告
- Reviewer 证据路径：见本 PR 的「审查证据」一节
- GitHub Actions `rewrite-ci` run URL：本 PR 的 CI 还在跑
- [ ] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [x] `npm run typecheck`（以 `npx tsc -b packages/kernel packages/daemon` 运行，exit 0）
- [ ] `npm test`
- [x] `npm run harness:check-import-boundaries`（经 `run-manifest-gates --changed origin/main`）
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts`（经 `run-manifest-gates --changed origin/main`）
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- G1 在 200 与 2000 事件两档（`node tools/gates/cost-budget.mjs`）的 sqlRowsRead：
  - decision-propose：main 410 → 2138，本分支 156 → 156；
  - decision-reject：main 442 → 2170，本分支 181 → 181；
  - relation-relate：两边都是 299 → 299。
  删除豁免后 G38 通过。
- 在一份真实投影（10,617 条边）的只读副本上：
  - 旧的每次写入读取分别耗时 4,876 ms（`readRelationTruth` 等价）和 434 ms（`readDecisionGraph`）；新的按 owner 读取平均 5.2 ms。
  - 全部 762 个 decision 交给 `compileDecisionWrite` 的关系，新旧逐字段相同。
  - 连接最多的 20 个 ref 的 import 计数相同。
  - 没有只存在于 `task_relation` 的 depends-on 边，环检测看到的边集不变。
- `EXPLAIN QUERY PLAN`：环检测查询在 UNION ALL 两臂分别用 `task_relation_type` 和 `relation_edge_source`。owner 与 entity 查询在 SQLite 内仍扫描 `relation_edge`（该副本上分别 5.5 ms、10.7 ms）。
- 变异检查：把遍历限制为一跳后，新的多跳测试失败；还原后通过。
- 定向测试 15/15：`relation-action`、`decision-surface`、`decision-review-independence`、`artifact-entity-action`、`g1-write-cost-scaling`。`run-manifest-gates --changed origin/main` 通过。

## 审查证据

- worker（Codex Sol）写了生产改动。主控做了以下工作：
  - 测了 G1 和真实数据对照；
  - 核对了查询计划与 decision 等价；
  - 补了多跳测试并做变异检查；
  - 删除了过期豁免。
- Reviewer subagent：未使用
- 人工审查：待进行
- 阻塞发现：无

## 残余风险

- decision 按 owner 读取与 entity import 计数在 SQLite 内仍扫描 `relation_edge`，随边数线性增长，但在 1 万条边时只有几毫秒。若成为瓶颈，下一步是给 `owner_ref` 加索引。
- decision 等价是在真实数据上验证的，没有对所有可能的行形状做证明。`taskRelationRow` 会把缺失的 `rationale` 变成 `""`，而真实数据里没有缺 rationale 的 decision 边。

## 关联材料

- Task: task_644341526c2540f75649959928
- Bench F5（task_34935988e63cb55291ca3c5ada）；fact F-143244DE

---

## PR Gate Checklist / PR 门禁清单

- [x] Branch is based on latest `origin/main`. / 分支基于最新 `origin/main`。
- [x] PR body uses this full template structure. / PR 描述使用本模板完整结构。
- [x] PR body uses two complete language blocks: `# English` first, then `# 中文`. / PR 正文使用两块完整正文：`# English` 在上，`# 中文` 在下。
- [x] PR body passes `tools/check-pr-body-bilingual.mjs`. / PR 正文通过 `tools/check-pr-body-bilingual.mjs`。
- [x] If the PR touches a manifest-derived protected surface, Governance Declaration is filled with ADR/decision/task evidence or break-glass fields. / 若 PR 触碰 manifest 派生的 protected surface，Governance Declaration 已填写 ADR/decision/task 依据或 break-glass 字段。
- [x] No private harness files are included. / 不包含私有 harness 文件。
- [x] No ignored local agent entry files are included. / 不包含被忽略的本地 agent 入口文件。
- [x] No absolute local filesystem paths are included in this public PR body. / 本公开 PR 描述不包含本机绝对路径。
- [x] Public diff is limited to the stated task scope. / 公开 diff 限于声明的任务范围。
- [x] Private planning/evidence updates are recorded when applicable. / 适用时已记录私有计划 / 证据更新。
- [x] Version and publish impact are stated. / 已说明版本与发布影响。
- [x] Local verification commands are recorded honestly. / 已如实记录本地验证命令。
- [ ] CI results are linked or explained. / CI 结果已链接或说明。
- [x] Review evidence is recorded. / 已记录审查证据。
- [x] Open P0/P1/P2 findings are closed, deferred with owner, or explicitly blocked. / open P0/P1/P2 findings 已关闭、带 owner 延后，或明确阻塞。
- [x] Merge method and post-merge branch cleanup plan are clear. / 合并方式和合并后分支清理计划清楚。
- [x] No admin bypass is planned unless explicitly approved and recorded. / 除非明确批准并记录，否则不计划 admin bypass。
