### PR TITLE
fix(daemon): rejections carry the reason the daemon already has

### DIFF
--- a/packages/daemon/src/fleet-edge-doc-sync.ts
+++ b/packages/daemon/src/fleet-edge-doc-sync.ts
@@ -191,6 +191,9 @@ export async function runFleetEdgeDocSync(input: FleetEdgeDocSyncRequest): Promi
         rideAlongTaskPaths: rideAlong,
         outOfScopePaths: outOfScope,
         guidance: "Submit named paths or rerun with --all to confirm the full eligible candidate set.",
+        rejectionExplanation:
+          "full authored-tree submission requires explicit confirmation; " +
+          "submit named paths or rerun with --all to confirm the full eligible candidate set.",
       });
     // PUSHING
     const pushed = await runFleetWriteClient({

--- a/packages/daemon/src/repo-cell-authorization.ts
+++ b/packages/daemon/src/repo-cell-authorization.ts
@@ -539,6 +539,8 @@ export function withAuthorizationDecision(
   unmetCriteria: readonly EntityActionUnmetCriterionV1[] = receipt.unmetCriteria ?? [],
   rejectionExplanation: string | undefined = receipt.rejectionExplanation ?? undefined,
 ): WriteReceipt {
+  const summary = (receipt as WriteReceipt & Readonly<{ readonly summary?: unknown }>).summary,
+    summaryExplanation = typeof summary === "string" && summary.trim() ? summary : undefined;
   return {
     acceptance: null,
     projection: { state: "pending", cut: null },
@@ -551,7 +553,9 @@ export function withAuthorizationDecision(
     unmetCriteria,
     rejectionExplanation:
       receipt.outcome === "op_rejected" || receipt.outcome === "indeterminate"
-        ? (rejectionExplanation ?? `Action rejected after ${authorizationDecision.policyRef} qualification.`)
+        ? (rejectionExplanation ??
+          summaryExplanation ??
+          `Action rejected after ${authorizationDecision.policyRef} qualification.`)
         : null,
     nextActions: Object.freeze([...new Set([...(receipt.nextActions ?? []), ...authorizationDecision.nextActions])]),
   };

--- a/packages/daemon/src/repo-cell-settlement.ts
+++ b/packages/daemon/src/repo-cell-settlement.ts
@@ -80,7 +80,8 @@ export function completionStopped(
     opId,
     cellCriterionError(
       blocker.code,
-      blocker.gate === "fact-retirement" ? blocker.next.reason : blocker.next.command,
+      // What is wrong, then what to run; every completion blocker carries both.
+      `${blocker.next.reason} Next: ${blocker.next.command}`,
       "complete",
       "closeout-readiness/closeoutReadiness",
       [blocker.next.command],

--- a/packages/daemon/src/repo-cell-settlement.ts
+++ b/packages/daemon/src/repo-cell-settlement.ts
@@ -78,9 +78,13 @@ export function completionStopped(
   if (!contract) throw cellCodedError("invalid_store", "Task complete Action contract is unavailable.");
   const receipt = failed(
     opId,
-    cellCriterionError(blocker.code, blocker.next.command, "complete", "closeout-readiness/closeoutReadiness", [
-      blocker.next.command,
-    ]),
+    cellCriterionError(
+      blocker.code,
+      blocker.gate === "fact-retirement" ? blocker.next.reason : blocker.next.command,
+      "complete",
+      "closeout-readiness/closeoutReadiness",
+      [blocker.next.command],
+    ),
     contract,
     action,
   );

--- a/packages/daemon/src/task-action-catalog-runtime.ts
+++ b/packages/daemon/src/task-action-catalog-runtime.ts
@@ -47,6 +47,7 @@ export async function runTaskActionCatalogRuntime(
           })
         : [],
     activeLease = cell.projection.currentLease(taskId, cell.now());
+  if (!current.snapshot.task) throw cell.cellCodedError("entity_not_found", `Task ${taskId} does not exist.`);
   if (
     lifecycle?.coordination === "reserve" &&
     !preview &&

--- a/packages/daemon/test/fact-retirement-completion.contract.test.ts
+++ b/packages/daemon/test/fact-retirement-completion.contract.test.ts
@@ -53,6 +53,7 @@ test("task complete rejects an undeclared upstream Fact and persists a still-hol
       String((blocked.next as readonly { readonly reason: string }[])[0]?.reason),
       new RegExp(`${factRef} via decision/${decisionId}/C1`, "u"),
     );
+    assert.match(String(blocked.rejectionExplanation), new RegExp(`${factRef} via decision/${decisionId}/C1`, "u"));
     eventReader = makeTaskEventReader({ repoId, rootDir });
     assert.equal(
       eventReader.read().events.some((event) => event.type === "task_completed"),

--- a/packages/daemon/test/fleet-doc-sync-ok-polarity.integration.test.ts
+++ b/packages/daemon/test/fleet-doc-sync-ok-polarity.integration.test.ts
@@ -241,6 +241,10 @@ test("remote-edge full submit requires explicit all confirmation", { timeout: 60
   const unconfirmed = await fixture.edgeDocSync("node-one");
   assert.equal(unconfirmed.ok, false, JSON.stringify(unconfirmed));
   assert.equal(unconfirmed.code, "doc_submit_confirmation_required");
+  assert.match(
+    String(unconfirmed.rejectionExplanation),
+    /full authored-tree submission requires explicit confirmation/u,
+  );
   assert.deepEqual(
     (unconfirmed.rows as readonly { readonly path: string }[]).map((row) => row.path),
     [shared],

--- a/packages/daemon/test/rejection-next-actions.integration.test.ts
+++ b/packages/daemon/test/rejection-next-actions.integration.test.ts
@@ -368,6 +368,25 @@ test("symptom task_356fe6c7a05cb987d93a807b46: relation relate against a nonexis
   }
 });
 
+test("review-execution against a nonexistent task names the missing task", async () => {
+  const rootDir = workspace("review-task-not-found"),
+    repoId = workspaceId("review-task-not-found");
+  let cell: Awaited<ReturnType<typeof openRepoCell>> | undefined;
+  try {
+    cell = await openRepoCell({ repoId, rootDir: canonicalRoot(rootDir), ownerId: "review-task-not-found" });
+    const rejected = await cell.run(
+      { kind: "task-review-execution", taskId: "task-does-not-exist", reviewId: "review-missing" },
+      binding("review-task-not-found"),
+    );
+    assert.equal(rejected.outcome, "op_rejected", JSON.stringify(rejected));
+    assert.equal(rejected.code, "entity_not_found", JSON.stringify(rejected));
+    assert.match(String(rejected.rejectionExplanation), /Task task-does-not-exist does not exist/u);
+  } finally {
+    await cell?.close();
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});
+
 function binding(executorId: string) {
   return {
     actor: { principal: { personId: "person-owner" }, executor: { kind: "agent" as const, id: executorId } },


### PR DESCRIPTION
# English

## Summary

Four rejections still told the operator less than the daemon knew. This follows #2425, #2437 and #2443.
- A `doc sync --submit` without a scope that needs confirmation printed "Action rejected after default@5 qualification.", although the receipt's `summary` already listed the paths and said to rerun with `--path` or `--all`.
- `task review-execution` on a task that does not exist said "Current submitted execution candidates: none".
- `task complete` blocked by a completion gate explained itself with only the command to run. For the fact-retirement gate, that command could name only the first undischarged Fact.
- The `fact record --supersedes` rejection turned out to be a correct rule (the target was already superseded) with its message intact, so it is unchanged.

## Architectural Justification

-

## What Changed

- `repo-cell-authorization.ts`: when a rejected receipt has no `rejectionExplanation`, `withAuthorizationDecision` uses the receipt's `summary` before the generic sentence. This covers every rejection whose reason lives only in its summary.
- `fleet-edge-doc-sync.ts`: the edge doc-submit confirmation rejection, which does not pass through `withAuthorizationDecision`, sets its own `rejectionExplanation`.
- `task-action-catalog-runtime.ts`: lifecycle actions on a task that does not exist fail with `entity_not_found` "Task <id> does not exist."; task creation takes another path.
- `repo-cell-settlement.ts`: every completion blocker explains `${reason} Next: ${command}`. Each blocker already carries both.
- Regression tests in `rejection-next-actions.integration.test.ts` and `fact-retirement-completion.contract.test.ts`.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: +17/-4 (net +13), from `node tools/gates/production-delta.mjs --base origin/main`.

## Machine-Readable Declarations

## Task And Scope

- Harness task: task_b92eb9a86c67f5d959557f649c
- Branch: `codex/rejection-reasons-remaining`
- Public scope: rejection explanations for summary-only rejections, missing-task lifecycle actions and completion blockers
- Private planning/evidence updated: yes (task report with CEO acceptance, fact F-4F0673E7)
- Out of scope: changing any rejection rule or error code

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: not applicable
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `46eebdc86`
- Branch merge-base with `origin/main`: `46eebdc86`
- Last `git fetch origin` time: 2026-09-11 UTC
- Sync method: rebased onto origin/main
- Public diff command: `git diff origin/main...codex/rejection-reasons-remaining`
- Private evidence commit/path: task_b92eb9a86c67f5d959557f649c task package report
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [x] `npm run typecheck` (as `npx tsc -b packages/kernel packages/daemon packages/cli`, exit 0)
- [ ] `npm test`
- [x] `npm run harness:check-import-boundaries` (via `run-manifest-gates --changed origin/main`)
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts` (via `run-manifest-gates --changed origin/main`)
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Real CLI against an isolated daemon on this branch:
  - `doc sync --submit` without a scope prints the paths awaiting confirmation and "rerun with --path for an explicit selection or --all for every eligible candidate";
  - review of a missing task prints `entity_not_found hint=Task task-missing-r4 does not exist.`;
  - a lifecycle-blocked `task complete` prints "Complete never submits or starts an execution; reach in_review first. Next: ha task start task-r4-active --execution-id exe-r4".
- Tests: `rejection-next-actions`, `fact-retirement-completion`, `fleet-doc-sync-ok-polarity`, `task-surface` and three more, 42/42. `run-manifest-gates --changed origin/main` passes.

## Review Evidence

- Worker (Codex Terra) wrote the first three changes and their tests. The lead replaced its fact-retirement-only special case with the uniform reason-then-command explanation, and captured the CLI output.
- Reviewer subagent: not used
- Human review: pending
- Blocking findings: none

## Residual Risk

- A summary used as the explanation can be several lines long (the doc-submit one lists every candidate path).
- Completion explanations are longer than before, because they now carry the reason.

## References

- Task: task_b92eb9a86c67f5d959557f649c
- Earlier: #2425, #2437, #2443 (task_c2c9ab598622e1988a68905251)

---

# 中文

## 概要

还有四种拒绝告诉操作者的，比 daemon 实际知道的少。本 PR 接着 #2425、#2437、#2443 处理：
- 不带范围、需要确认的 `doc sync --submit` 只打印 "Action rejected after default@5 qualification."。可回执 `summary` 里已经列出了路径，并说明用 `--path` 或 `--all` 重跑。
- 对不存在的任务执行 `task review-execution`，说的是 "Current submitted execution candidates: none"。
- 被完成门挡住的 `task complete` 只给出要跑的命令。对 fact-retirement 门，这条命令只能点名第一条未处置的 Fact。
- `fact record --supersedes` 的拒绝查明是正确规则（目标已被取代），说明本来就完整，不改。

## 架构辩护

-

## 改动内容

- `repo-cell-authorization.ts`：被拒回执没有 `rejectionExplanation` 时，`withAuthorizationDecision` 先用回执的 `summary`，再用通用句。原因只写在 summary 里的拒绝，都由这一处覆盖。
- `fleet-edge-doc-sync.ts`：边缘的 doc-submit 确认拒绝不经过 `withAuthorizationDecision`，因此直接设置 `rejectionExplanation`。
- `task-action-catalog-runtime.ts`：对不存在的任务执行 lifecycle 动作，报 `entity_not_found` "Task <id> does not exist."。建任务走另一条路径，不受影响。
- `repo-cell-settlement.ts`：每个完成门 blocker 的说明统一为 `${reason} Next: ${command}`，每个 blocker 本来就同时带有这两项。
- 回归测试：`rejection-next-actions.integration.test.ts`、`fact-retirement-completion.contract.test.ts`。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 删除的门或 fixture：none
- 生产净行数：+17/-4 (net +13)，由 `node tools/gates/production-delta.mjs --base origin/main` 计算。

## 机读声明说明

- 本 PR 不涉及依赖变化和事件迁移，没有机读声明。

## 任务与范围

- Harness 任务：task_b92eb9a86c67f5d959557f649c
- 分支：`codex/rejection-reasons-remaining`
- 公开范围：只写在 summary 里的拒绝原因、对不存在任务的 lifecycle 动作、完成门 blocker 的说明
- 私有计划 / 证据是否已更新：yes（任务报告的 CEO 验收节，fact F-4F0673E7）
- 范围外：修改任何拒绝规则或错误码

## 版本影响

- 版本：不改版本
- 发布影响：不发布

## 治理声明

- 是否触碰 protected surface：no
- protected surface 范围：不适用
- 依据：不适用
- 机器检查边界：本 PR 只声明该段存在；声明是否真实、充分，由 reviewer 判断。
- Break-glass：no
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- `origin/main` 基准 SHA：`46eebdc86`
- 当前分支与 `origin/main` 的 merge-base：`46eebdc86`
- 最近一次 `git fetch origin` 时间：2026-09-11 UTC
- 同步方式：rebase 到 origin/main
- 公开 diff 命令：`git diff origin/main...codex/rejection-reasons-remaining`
- 私有证据 commit/path：task_b92eb9a86c67f5d959557f649c 任务包报告
- Reviewer 证据路径：见本 PR 的「审查证据」一节
- GitHub Actions `rewrite-ci` run URL：本 PR 的 CI 还在跑
- [ ] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [x] `npm run typecheck`（以 `npx tsc -b packages/kernel packages/daemon packages/cli` 运行，exit 0）
- [ ] `npm test`
- [x] `npm run harness:check-import-boundaries`（经 `run-manifest-gates --changed origin/main`）
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts`（经 `run-manifest-gates --changed origin/main`）
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- 本分支上对隔离 daemon 跑真实 CLI：
  - 不带范围的 `doc sync --submit` 打印待确认的路径，以及 "rerun with --path for an explicit selection or --all for every eligible candidate"；
  - review 不存在的任务打印 `entity_not_found hint=Task task-missing-r4 does not exist.`；
  - 被生命周期门挡住的 `task complete` 打印 "Complete never submits or starts an execution; reach in_review first. Next: ha task start task-r4-active --execution-id exe-r4"。
- 测试：`rejection-next-actions`、`fact-retirement-completion`、`fleet-doc-sync-ok-polarity`、`task-surface` 等 7 个文件，42/42。`run-manifest-gates --changed origin/main` 通过。

## 审查证据

- worker（Codex Terra）写了前三处改动及其测试。主控把它只针对 fact-retirement 的特判，换成统一的「原因在前、命令在后」说明，并抓取了 CLI 输出。
- Reviewer subagent：未使用
- 人工审查：待进行
- 阻塞发现：无

## 残余风险

- 用 summary 当说明时可能有好几行（doc-submit 的 summary 会列出每一个候选路径）。
- 完成门的说明比以前长，因为现在带上了原因。

## 关联材料

- Task: task_b92eb9a86c67f5d959557f649c
- 前序：#2425、#2437、#2443（task_c2c9ab598622e1988a68905251）

---

## PR Gate Checklist / PR 门禁清单

- [x] Branch is based on latest `origin/main`. / 分支基于最新 `origin/main`。
- [x] PR body uses this full template structure. / PR 描述使用本模板完整结构。
- [x] PR body uses two complete language blocks: `# English` first, then `# 中文`. / PR 正文使用两块完整正文：`# English` 在上，`# 中文` 在下。
- [x] PR body passes `tools/check-pr-body-bilingual.mjs`. / PR 正文通过 `tools/check-pr-body-bilingual.mjs`。
- [x] If the PR touches a manifest-derived protected surface, Governance Declaration is filled with ADR/decision/task evidence or break-glass fields. / 若 PR 触碰 manifest 派生的 protected surface，Governance Declaration 已填写 ADR/decision/task 依据或 break-glass 字段。
- [x] No private harness files are included. / 不包含私有 harness 文件。
- [x] No ignored local agent entry files are included. / 不包含被忽略的本地 agent 入口文件。
- [x] No absolute local filesystem paths are included in this public PR body. / 本公开 PR 描述不包含本机绝对路径。
- [x] Public diff is limited to the stated task scope. / 公开 diff 限于声明的任务范围。
- [x] Private planning/evidence updates are recorded when applicable. / 适用时已记录私有计划 / 证据更新。
- [x] Version and publish impact are stated. / 已说明版本与发布影响。
- [x] Local verification commands are recorded honestly. / 已如实记录本地验证命令。
- [ ] CI results are linked or explained. / CI 结果已链接或说明。
- [x] Review evidence is recorded. / 已记录审查证据。
- [x] Open P0/P1/P2 findings are closed, deferred with owner, or explicitly blocked. / open P0/P1/P2 findings 已关闭、带 owner 延后，或明确阻塞。
- [x] Merge method and post-merge branch cleanup plan are clear. / 合并方式和合并后分支清理计划清楚。
- [x] No admin bypass is planned unless explicitly approved and recorded. / 除非明确批准并记录，否则不计划 admin bypass。
