### PR TITLE
perf: fact liveness and completion reads do only per-fact and per-task work

### DIFF
--- a/packages/daemon/src/doc-sync-candidate-scanner.ts
+++ b/packages/daemon/src/doc-sync-candidate-scanner.ts
@@ -109,7 +109,10 @@ export function scanDocCandidates(input: {
     candidates = selected?.length
       ? [...new Set(selected)]
       : [
-          ...new Set(input.inventory?.rows.map((row) => row.path) ?? dirtyPaths(ledger.rootDir, ledger.authoredPrefix)),
+          ...new Set(
+            input.inventory?.rows.map((row) => row.path) ??
+              dirtyPaths(ledger.rootDir, ledger.authoredPrefix, taskPrefix ?? ""),
+          ),
         ].filter((value) => value.startsWith(enumerationScope)),
     paths = candidates.sort(),
     baseLedgerSha = input.inventory?.baseLedgerSha ?? input.store.currentCut(),
@@ -579,8 +582,9 @@ export function resolveDocExecutionBinding(
   return { id: lease?.executionId ?? null, candidates: [], lease, runtimeDelegatedTaskId: null };
 }
 
-function dirtyPaths(repoRoot: string, authoredPrefix: string): string[] {
-  const scope = authoredPrefix || ".",
+function dirtyPaths(repoRoot: string, authoredPrefix: string, logicalScope = ""): string[] {
+  const scopePath = [authoredPrefix, logicalScope.replace(/\/$/u, "")].filter(Boolean).join("/"),
+    scope = scopePath || ".",
     changed = gitNames(repoRoot, ["diff", "--name-only", "-z", "HEAD", "--", scope]),
     untracked = gitNames(repoRoot, ["ls-files", "--others", "--exclude-standard", "-z", "--", scope]),
     prefix = authoredPrefix ? `${authoredPrefix}/` : "";
@@ -594,7 +598,9 @@ function dirtyPaths(repoRoot: string, authoredPrefix: string): string[] {
             !/\/\.ha-(?:visible|settle)-/u.test(`/${value}`),
         )
         .map((value) => value.slice(prefix.length))
-        .concat(conflictLogicalPaths(path.join(repoRoot, authoredPrefix))),
+        .concat(
+          conflictLogicalPaths(path.join(repoRoot, scopePath || authoredPrefix), logicalScope.replace(/\/$/u, "")),
+        ),
     ),
   ];
 }
@@ -614,15 +620,17 @@ function candidateConflicts(rootDir: string, authoredRoot: string, logical: stri
     .map((name) => relative(rootDir, path.join(directory, name)))
     .sort();
 }
-function conflictLogicalPaths(authoredRoot: string): string[] {
+function conflictLogicalPaths(authoredRoot: string, logicalScope = ""): string[] {
   const found: string[] = [];
   const visit = (directory: string) => {
     if (!existsSync(directory)) return;
     for (const entry of readdirSync(directory, { withFileTypes: true })) {
       const target = path.join(directory, entry.name);
       if (entry.isDirectory()) visit(target);
-      else if (entry.isFile() && /\.conflict-[0-9a-f]{8}\.(?:md|txt)$/u.test(entry.name))
-        found.push(relative(authoredRoot, target).replace(/\.conflict-[0-9a-f]{8}(?=\.(?:md|txt)$)/u, ""));
+      else if (entry.isFile() && /\.conflict-[0-9a-f]{8}\.(?:md|txt)$/u.test(entry.name)) {
+        const logical = relative(authoredRoot, target).replace(/\.conflict-[0-9a-f]{8}(?=\.(?:md|txt)$)/u, "");
+        found.push(logicalScope ? `${logicalScope}/${logical}` : logical);
+      }
     }
   };
   visit(authoredRoot);

--- a/packages/daemon/src/repo-cell-task-progress.ts
+++ b/packages/daemon/src/repo-cell-task-progress.ts
@@ -585,19 +585,8 @@ export function completionContext(
           ? "placeholder"
           : "ready";
   const producesFactCount = cell.projection
-    .readFactGraph()
-    .edges.filter(
-      (row: {
-        readonly sourceRef: string;
-        readonly targetRef: string;
-        readonly relationType: string;
-        readonly state: string;
-      }) =>
-        row.sourceRef === `task/${taskId}` &&
-        row.relationType === "produces" &&
-        row.state === "active" &&
-        row.targetRef.startsWith("fact/"),
-    ).length;
+    .readRelationQuery({ source: `task/${taskId}`, relationType: "produces", state: "active" })
+    .rows.filter((row) => row.targetRef.startsWith("fact/")).length;
   return {
     closeout,
     closeoutPath,

--- a/packages/kernel/src/projection/fact-event-projection.ts
+++ b/packages/kernel/src/projection/fact-event-projection.ts
@@ -237,16 +237,17 @@ function livenessRelations(
   targetRefs?: readonly string[],
 ): readonly { readonly targetRef: string; readonly relationType: string; readonly state: string }[] {
   if (targetRefs !== undefined && targetRefs.length === 0) return [];
-  const scoped = targetRefs !== undefined && targetRefs.length <= 900;
-  const where = scoped ? ` WHERE target_ref IN (${targetRefs.map(() => "?").join(",")})` : "";
   return queryRows<{
     readonly targetRef: string;
     readonly relationType: string;
     readonly state: string;
   }>(
     db,
-    `SELECT target_ref AS targetRef, relation_type AS relationType, state FROM relation_edge${where} ORDER BY relation_id`,
-    ...(scoped ? targetRefs : []),
+    "SELECT target_ref AS targetRef, relation_type AS relationType, state FROM relation_edge " +
+      "WHERE state = 'active' AND relation_type = 'supersedes-fact' " +
+      "AND (? IS NULL OR target_ref IN (SELECT value FROM json_each(?))) ORDER BY relation_id",
+    targetRefs === undefined ? null : JSON.stringify(targetRefs),
+    targetRefs === undefined ? null : JSON.stringify(targetRefs),
   );
 }
 function decodeFactRows(db: DatabaseSync, records: readonly FactRecord[]): readonly FactProjectionRow[] {

--- a/packages/kernel/test/store/task-query-projection.test.ts
+++ b/packages/kernel/test/store/task-query-projection.test.ts
@@ -593,3 +593,93 @@ test("fact search pages concatenate to the full result, honor windows, and keep 
     db.close();
   }
 });
+
+test("fact search liveness reads stay bounded by supersedes edges", () => {
+  const db = new DatabaseSync(":memory:");
+  try {
+    createRelationGraphProjectionTables(db);
+    createFactProjectionTables(db);
+    const insertFact = db.prepare(
+        "INSERT INTO fact(task_id, fact_id, ref, statement, evidence_source, observed_at, confidence, memory_class, op_id, workspace_revision, row_json) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+      ),
+      insertFts = db.prepare("INSERT INTO fact_fts(fact_id, statement, evidence_source) VALUES (?, ?, ?)");
+    db.exec("BEGIN");
+    for (let index = 0; index < 2000; index += 1) {
+      const factId = `F-${String(index).padStart(8, "0")}`,
+        ref = `fact/${factId}`,
+        row = {
+          schema: "fact-row/v1",
+          ref,
+          taskId: "task-scale",
+          factId,
+          statement: `scale observation ${index}`,
+          evidenceSource: "scale",
+          observedAt: "2026-08-18T00:00:00.000Z",
+          confidence: "high",
+          memoryClass: "semantic",
+          memoryTags: [],
+          provenance: [],
+          actor: { principal: { personId: "scale" }, executor: null },
+          source: "local",
+          occurredAt: "2026-08-18T00:00:00.000Z",
+          workspaceRevision: index + 1,
+        };
+      insertFact.run(
+        "task-scale",
+        factId,
+        ref,
+        row.statement,
+        row.evidenceSource,
+        row.observedAt,
+        row.confidence,
+        row.memoryClass,
+        `op-${index}`,
+        index + 1,
+        JSON.stringify(row),
+      );
+      insertFts.run(factId, row.statement, row.evidenceSource);
+    }
+    db.prepare("INSERT INTO relation_edge VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)").run(
+      "rel-scale",
+      "fact/F-00000001",
+      "fact/F-00000000",
+      "supersedes-fact",
+      "active",
+      null,
+      "fact/F-00000001",
+      2001,
+      JSON.stringify({
+        relationId: "rel-scale",
+        sourceRef: "fact/F-00000001",
+        targetRef: "fact/F-00000000",
+        relationType: "supersedes-fact",
+        state: "active",
+      }),
+    );
+    db.exec("COMMIT");
+    const original = db.prepare;
+    let rowsRead = 0;
+    db.prepare = ((...args: Parameters<typeof original>) => {
+      const statement = original.apply(db, args);
+      const all = statement.all.bind(statement),
+        get = statement.get.bind(statement);
+      statement.all = (...values: unknown[]) => {
+        const result = all(...values);
+        rowsRead += Array.isArray(result) ? result.length : 0;
+        return result;
+      };
+      statement.get = (...values: unknown[]) => {
+        const result = get(...values);
+        rowsRead += result === undefined ? 0 : 1;
+        return result;
+      };
+      return statement;
+    }) as typeof db.prepare;
+    const result = searchFactRowsPage(db, { query: "scale", limit: 500 });
+    assert.equal(result.rows?.length, 500);
+    console.log(JSON.stringify({ factCount: 2000, sqlRowsRead: rowsRead }));
+    assert.ok(rowsRead < 5000, `narrow liveness read ${rowsRead} rows`);
+  } finally {
+    db.close();
+  }
+});

--- a/packages/kernel/test/store/task-query-projection.test.ts
+++ b/packages/kernel/test/store/task-query-projection.test.ts
@@ -594,7 +594,7 @@ test("fact search pages concatenate to the full result, honor windows, and keep 
   }
 });
 
-test("fact search liveness reads stay bounded by supersedes edges", () => {
+test("fact search liveness reads only supersedes edges, however many facts and edges exist", () => {
   const db = new DatabaseSync(":memory:");
   try {
     createRelationGraphProjectionTables(db);
@@ -656,6 +656,20 @@ test("fact search liveness reads stay bounded by supersedes edges", () => {
         state: "active",
       }),
     );
+    // Unrelated active edges: a liveness read that scans the edge table pays for every one of them.
+    const insertEdge = db.prepare("INSERT INTO relation_edge VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)");
+    for (let index = 0; index < 3000; index += 1)
+      insertEdge.run(
+        `rel-unrelated-${index}`,
+        "task/task-scale",
+        `fact/F-${String(index % 2000).padStart(8, "0")}`,
+        "produces",
+        "active",
+        null,
+        `fact/F-${String(index % 2000).padStart(8, "0")}`,
+        3000 + index,
+        JSON.stringify({ relationId: `rel-unrelated-${index}`, relationType: "produces", state: "active" }),
+      );
     db.exec("COMMIT");
     const original = db.prepare;
     let rowsRead = 0;
@@ -675,10 +689,14 @@ test("fact search liveness reads stay bounded by supersedes edges", () => {
       };
       return statement;
     }) as typeof db.prepare;
-    const result = searchFactRowsPage(db, { query: "scale", limit: 500 });
-    assert.equal(result.rows?.length, 500);
-    console.log(JSON.stringify({ factCount: 2000, sqlRowsRead: rowsRead }));
-    assert.ok(rowsRead < 5000, `narrow liveness read ${rowsRead} rows`);
+    // Unpaged: every fact is decoded, which is past the old 900-target cut-off.
+    const rows = searchFactRows(db, {});
+    assert.equal(rows.length, 2000);
+    assert.equal(rows.find((row) => row.factId === "F-00000000")?.invalidated, true);
+    assert.equal(rows.find((row) => row.factId === "F-00000001")?.invalidated, false);
+    console.log(JSON.stringify({ factCount: 2000, unrelatedEdges: 3000, sqlRowsRead: rowsRead }));
+    // 2,000 fact rows plus the one supersedes edge; reading the 3,000 unrelated edges would exceed this.
+    assert.ok(rowsRead <= 2000 + 50, `liveness read ${rowsRead} rows`);
   } finally {
     db.close();
   }


### PR DESCRIPTION
# English

## Summary

Two hot reads did repository-wide work to answer a question about one fact or one task (Bench section 4.4):
- Fact liveness: once a read decoded more than 900 facts, it read the whole `relation_edge` table and then ran `some()` over every edge for every fact. That is O(facts × edges). `fact search` jumped from 30 ms to 377 ms at the 901st fact.
- `task complete` / `task closeout`: every call ran `git diff`, `git ls-files --others` and a conflict-file walk over the whole authored tree, then filtered to the task. It also read the whole fact graph to count one task's `produces` edges.

Now:
- Liveness reads only active `supersedes-fact` edges, filtered by target in SQL. The 900-target branch is gone.
- The task-scoped scan enumerates only the task package.
- The produces count uses the narrow relation query.

## Architectural Justification

-

## What Changed

- `fact-event-projection.ts` `livenessRelations`: `WHERE state = 'active' AND relation_type = 'supersedes-fact'`, plus target membership through `json_each`.
- `doc-sync-candidate-scanner.ts`: `dirtyPaths` and `conflictLogicalPaths` take the task's logical scope, and git and readdir run under it. The result set is unchanged, because the old code enumerated everything and then filtered to the same scope.
- `repo-cell-task-progress.ts`: `producesFactCount` uses `readRelationQuery({ source, relationType: "produces", state: "active" })`.
- `task-query-projection.test.ts`: an unpaged search over 2,000 facts with 3,000 unrelated edges reads at most the fact rows plus the supersedes edge.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: +22/-24 (net -2), from `node tools/gates/production-delta.mjs --base origin/main`.

## Machine-Readable Declarations

## Task And Scope

- Harness task: task_3d544f598841881061d54556c8
- Branch: `codex/f8-hot-read-full-scans`
- Public scope: the fact liveness read, the task-scoped dirty scan, and the completion produces count
- Private planning/evidence updated: yes (task report with the CEO acceptance section, fact F-E58944FE)
- Out of scope: a default limit for `fact search` (a product choice)

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: not applicable
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `25340de52`
- Branch merge-base with `origin/main`: `25340de52`
- Last `git fetch origin` time: 2026-09-11 UTC (before rebase)
- Sync method: rebased onto origin/main
- Public diff command: `git diff origin/main...codex/f8-hot-read-full-scans`
- Private evidence commit/path: task_3d544f598841881061d54556c8 task package report
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [x] `npm run typecheck` (as `npx tsc -b packages/kernel packages/daemon`, exit 0)
- [ ] `npm test`
- [x] `npm run harness:check-import-boundaries` (via `run-manifest-gates --changed origin/main`)
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts` (via `run-manifest-gates --changed origin/main`)
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Real data, on a read-only copy of a projection with 3,357 facts and 108 active supersedes edges: an unpaged fact search takes 3,949 ms before and 37 ms after (median of 3). All 3,357 rows, including the 98 superseded ones, are identical.
- On a real authored tree: the whole-tree scan costs git diff 292 ms + ls-files 416 ms + a walk of 45,397 files. One task package costs 40 ms + 39 ms + 30 files.
- Negative control: with `fact-event-projection.ts` from main, the new test reads 5,001 rows (723 ms) and fails; with this change it reads 2,001 rows (28 ms) and passes.
- No `produces` edge to a fact exists only in `task_relation`, so the completion fact count is unchanged on that data.
- Targeted tests 27/27: `task-query-projection`, `fact-admission-liveness`, `fact-retirement-completion`, `task-surface`, `rejection-next-actions`. `run-manifest-gates --changed origin/main` passes.

## Review Evidence

- Worker (Codex Terra) wrote the production change. Its scale test was paged and read 502 rows before and after the fix. The lead rewrote the test to go past the old cut-off, added the negative control, and measured real data.
- Reviewer subagent: not used
- Human review: pending
- Blocking findings: none

## Residual Risk

- The liveness query reaches `relation_edge` through the state index and filters by type inside SQLite; that is milliseconds at 10k edges.
- `fact search` still has no default limit.

## References

- Task: task_3d544f598841881061d54556c8
- Bench task_34935988e63cb55291ca3c5ada section 4.4 (fact F-92500FD4); fact F-E58944FE

---

# 中文

## 概要

两个热读为了回答关于一条 fact 或一个任务的问题，做了全仓规模的工作（Bench 第 4.4 节）：
- fact liveness：一次读取解码的 fact 超过 900 条后，会读出整张 `relation_edge` 表，再对每条 fact 在全部边上跑一次 `some()`，即 O(facts × edges)。`fact search` 在第 901 条 fact 处从 30 ms 跳到 377 ms。
- `task complete` / `task closeout`：每次调用都对整个 authored 树跑 `git diff`、`git ls-files --others` 和冲突文件遍历，然后才按任务过滤；还为了数一个任务的 `produces` 边读出全量 fact 图。

现在：
- liveness 只读 active 的 `supersedes-fact` 边，在 SQL 里按 target 过滤，删除了 900 条分支。
- 限定任务的扫描只枚举该任务包。
- produces 计数改用窄关系查询。

## 架构辩护

-

## 改动内容

- `fact-event-projection.ts` 的 `livenessRelations`：条件为 `WHERE state = 'active' AND relation_type = 'supersedes-fact'`，target 过滤经 `json_each`。
- `doc-sync-candidate-scanner.ts`：`dirtyPaths` 与 `conflictLogicalPaths` 接收任务的逻辑范围，git 与 readdir 只在其下运行。旧代码是先枚举全部再过滤到同一范围，所以结果集不变。
- `repo-cell-task-progress.ts`：`producesFactCount` 改用 `readRelationQuery({ source, relationType: "produces", state: "active" })`。
- `task-query-projection.test.ts`：2,000 条 fact 加 3,000 条无关边时，不分页搜索读取的行数不超过 fact 行数加 supersedes 边。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 删除的门或 fixture：none
- 生产净行数：+22/-24 (net -2)，由 `node tools/gates/production-delta.mjs --base origin/main` 计算。

## 机读声明说明

- 本 PR 不涉及依赖变化和事件迁移，没有机读声明。

## 任务与范围

- Harness 任务：task_3d544f598841881061d54556c8
- 分支：`codex/f8-hot-read-full-scans`
- 公开范围：fact liveness 读取、限定任务的 dirty 扫描、完成门的 produces 计数
- 私有计划 / 证据是否已更新：yes（任务报告的 CEO 验收节，fact F-E58944FE）
- 范围外：`fact search` 的默认 limit（属于产品取舍）

## 版本影响

- 版本：不改版本
- 发布影响：不发布

## 治理声明

- 是否触碰 protected surface：no
- protected surface 范围：不适用
- 依据：不适用
- 机器检查边界：本 PR 只声明该段存在；声明是否真实、充分，由 reviewer 判断。
- Break-glass：no
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- `origin/main` 基准 SHA：`25340de52`
- 当前分支与 `origin/main` 的 merge-base：`25340de52`
- 最近一次 `git fetch origin` 时间：2026-09-11 UTC（rebase 前）
- 同步方式：rebase 到 origin/main
- 公开 diff 命令：`git diff origin/main...codex/f8-hot-read-full-scans`
- 私有证据 commit/path：task_3d544f598841881061d54556c8 任务包报告
- Reviewer 证据路径：见本 PR 的「审查证据」一节
- GitHub Actions `rewrite-ci` run URL：本 PR 的 CI 还在跑
- [ ] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [x] `npm run typecheck`（以 `npx tsc -b packages/kernel packages/daemon` 运行，exit 0）
- [ ] `npm test`
- [x] `npm run harness:check-import-boundaries`（经 `run-manifest-gates --changed origin/main`）
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts`（经 `run-manifest-gates --changed origin/main`）
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- 真实数据：在一份含 3,357 条 fact、108 条 active supersedes 边的投影只读副本上，不分页 fact search 改前 3,949 ms、改后 37 ms（3 次取中位）。3,357 行逐条一致，包括 98 条已被取代的。
- 在一棵真实 authored 树上：全树扫描是 git diff 292 ms + ls-files 416 ms + 遍历 45,397 个文件；单个任务包是 40 ms + 39 ms + 30 个文件。
- 阴性对照：换回 main 的 `fact-event-projection.ts`，新测试读 5,001 行（723 ms）并失败；带本改动读 2,001 行（28 ms）并通过。
- 没有只存在于 `task_relation` 的指向 fact 的 `produces` 边，所以在这份数据上完成门的 fact 计数不变。
- 定向测试 27/27：`task-query-projection`、`fact-admission-liveness`、`fact-retirement-completion`、`task-surface`、`rejection-next-actions`。`run-manifest-gates --changed origin/main` 通过。

## 审查证据

- worker（Codex Terra）写了生产改动。它加的规模测试是分页的，修复前后都只读 502 行。主控改写了测试使其越过旧的截断点，补了阴性对照，并测了真实数据。
- Reviewer subagent：未使用
- 人工审查：待进行
- 阻塞发现：无

## 残余风险

- liveness 查询经 state 索引访问 `relation_edge`，在 SQLite 内按类型过滤；1 万条边时只有几毫秒。
- `fact search` 仍然没有默认 limit。

## 关联材料

- Task: task_3d544f598841881061d54556c8
- Bench task_34935988e63cb55291ca3c5ada 第 4.4 节（fact F-92500FD4）；fact F-E58944FE

---

## PR Gate Checklist / PR 门禁清单

- [x] Branch is based on latest `origin/main`. / 分支基于最新 `origin/main`。
- [x] PR body uses this full template structure. / PR 描述使用本模板完整结构。
- [x] PR body uses two complete language blocks: `# English` first, then `# 中文`. / PR 正文使用两块完整正文：`# English` 在上，`# 中文` 在下。
- [x] PR body passes `tools/check-pr-body-bilingual.mjs`. / PR 正文通过 `tools/check-pr-body-bilingual.mjs`。
- [x] If the PR touches a manifest-derived protected surface, Governance Declaration is filled with ADR/decision/task evidence or break-glass fields. / 若 PR 触碰 manifest 派生的 protected surface，Governance Declaration 已填写 ADR/decision/task 依据或 break-glass 字段。
- [x] No private harness files are included. / 不包含私有 harness 文件。
- [x] No ignored local agent entry files are included. / 不包含被忽略的本地 agent 入口文件。
- [x] No absolute local filesystem paths are included in this public PR body. / 本公开 PR 描述不包含本机绝对路径。
- [x] Public diff is limited to the stated task scope. / 公开 diff 限于声明的任务范围。
- [x] Private planning/evidence updates are recorded when applicable. / 适用时已记录私有计划 / 证据更新。
- [x] Version and publish impact are stated. / 已说明版本与发布影响。
- [x] Local verification commands are recorded honestly. / 已如实记录本地验证命令。
- [ ] CI results are linked or explained. / CI 结果已链接或说明。
- [x] Review evidence is recorded. / 已记录审查证据。
- [x] Open P0/P1/P2 findings are closed, deferred with owner, or explicitly blocked. / open P0/P1/P2 findings 已关闭、带 owner 延后，或明确阻塞。
- [x] Merge method and post-merge branch cleanup plan are clear. / 合并方式和合并后分支清理计划清楚。
- [x] No admin bypass is planned unless explicitly approved and recorded. / 除非明确批准并记录，否则不计划 admin bypass。
