### PR TITLE
fix(daemon): keep external calls from holding the repository write queue

### DIFF
--- a/packages/daemon/src/agent-runtime-credential-port.ts
+++ b/packages/daemon/src/agent-runtime-credential-port.ts
@@ -12,7 +12,7 @@ import { runProcessTextAsync } from "./process-port.ts";
 // existed; other platforms reject it closed. The darwin store writes the
 // secret twice because `security add-generic-password -w` reads entry plus
 // retype from stdin; a single line exits 0 without storing anything.
-export type CredentialRunner = (command: CredentialCommand) => Promise<string>;
+export type CredentialRunner = (command: CredentialCommand, timeoutMs?: number) => Promise<string>;
 export interface CredentialCommand {
   readonly file: string;
   readonly args: readonly string[];
@@ -23,6 +23,11 @@ export interface CredentialPort {
   readonly store: (reference: string, secret: string) => Promise<void>;
   readonly resolve: (reference: string) => Promise<string>;
 }
+// Runtime spawns resolve credentials inside the repository write queue, so a vault that waits on a
+// person (a locked keychain's unlock dialog) must fail the lookup rather than hold every write. A
+// readable secret answers in well under a second; PowerShell's Add-Type compile takes a few. Stores
+// stay unbounded: a person storing a secret is there to answer the dialog.
+const credentialLookupTimeoutMs = 10_000;
 const namespace = "com.harness-anything.runtime-instance",
   neutralPattern = /^credential:v1:([a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])?)$/u,
   legacyPattern = /^keychain:([A-Za-z0-9._-]+)\/([A-Za-z0-9._-]+)$/u;
@@ -34,6 +39,7 @@ export function isCredentialReferenceText(text: string): boolean {
 export function credentialPort(
   platform: NodeJS.Platform = process.platform,
   run: CredentialRunner = runCredentialCommand,
+  lookupTimeoutMs = credentialLookupTimeoutMs,
 ): CredentialPort {
   const backend = credentialBackend(platform);
   return {
@@ -45,15 +51,16 @@ export function credentialPort(
     },
     resolve: async (reference) => {
       const command = backend.resolve(reference);
-      return (await attempt(backend.hint, () => run(command))) || throwCredentialUnavailable(backend.hint);
+      return (
+        (await attempt(backend.hint, () => run(command, lookupTimeoutMs))) || throwCredentialUnavailable(backend.hint)
+      );
     },
   };
 }
-export async function runCredentialCommand(command: CredentialCommand): Promise<string> {
-  return (await runProcessTextAsync(command.file, command.args, undefined, undefined, command.stdin)).replace(
-    /[\r\n]+$/u,
-    "",
-  );
+export async function runCredentialCommand(command: CredentialCommand, timeoutMs?: number): Promise<string> {
+  return (
+    await runProcessTextAsync(command.file, command.args, undefined, undefined, command.stdin, undefined, { timeoutMs })
+  ).replace(/[\r\n]+$/u, "");
 }
 // The underlying error (exit status, stderr, ENOENT) is discarded on purpose:
 // it can echo command output, so only the fixed per-backend hint ever surfaces.

--- a/packages/daemon/src/ci-observation-actions.ts
+++ b/packages/daemon/src/ci-observation-actions.ts
@@ -17,14 +17,29 @@ type CiRunArtifact = Omit<CiRunObservationEventV2["payload"], "verification"> & 
   readonly schema: "ci-run-artifact/v1";
 };
 type CiWorkflowRun = { readonly databaseId: number; readonly headBranch: string; readonly createdAt: string };
+type CiRunSummary = {
+  readonly workflowName: string;
+  readonly headSha: string;
+  readonly headBranch: string;
+  readonly status: string;
+  readonly conclusion: string;
+  readonly attempt: number;
+};
 type RunGh = (command: string, args: readonly string[], options: { readonly cwd: string }) => Promise<string>;
+type FetchedCiRun = {
+  readonly databaseId: number;
+  readonly summary: CiRunSummary;
+  readonly artifacts: readonly CiRunArtifact[];
+};
+type CiObservationFetch = { readonly requestedRuns: number; readonly runs: readonly FetchedCiRun[] };
 
-export async function pullAndIngestCiObservations(
-  cell: RepoCellActionContext,
+// Every gh call finishes before the pull enters the repository write queue: GitHub can stall
+// without bound, and the queue waits only on the event appends in ingestCiObservations.
+export async function fetchCiObservations(
+  cell: Pick<RepoCellActionContext, "rootDir" | "cellCodedError">,
   action: RepoTaskAction,
-  binding: RepoCellBinding,
   runGh: RunGh = (command, args, options) => runProcessTextAsync(command, args, options.cwd),
-): Promise<WriteReceipt> {
+): Promise<CiObservationFetch> {
   const limit = Number(action.limit ?? 20),
     namedRuns = Array.isArray(action.runs) ? action.runs.map(Number) : null;
   if (!Number.isSafeInteger(limit) || limit < 1 || limit > 100)
@@ -63,10 +78,7 @@ export async function pullAndIngestCiObservations(
         ).flat(),
         limit,
       );
-    const eventRefs: string[] = [];
-    let imported = 0,
-      duplicate = 0,
-      lastRevision = cell.store.readHead()?.revision ?? 0;
+    const fetched: FetchedCiRun[] = [];
     for (const run of runs) {
       const summary = JSON.parse(
         await runGh(
@@ -80,14 +92,7 @@ export async function pullAndIngestCiObservations(
           ],
           { cwd: cell.rootDir },
         ),
-      ) as {
-        workflowName: string;
-        headSha: string;
-        headBranch: string;
-        status: string;
-        conclusion: string;
-        attempt: number;
-      };
+      ) as CiRunSummary;
       const { status: runLifecycleState } = summary;
       // Publish immutable observations only for main runs that have a final conclusion.
       if (summary.headBranch !== "main" || runLifecycleState !== "completed") {
@@ -112,83 +117,96 @@ export async function pullAndIngestCiObservations(
         consumeKnownError(error);
         continue;
       }
-      for (const artifact of readArtifacts(runRoot)) {
-        const digest = createHash("sha256")
-            .update(`verified-v2\u0000${artifact.run.runId}\u0000${artifact.run.job}`)
-            .digest("hex"),
-          opId = `ci-observation-${digest}`;
-        if (cell.store.readEvent(opId)) {
-          duplicate += 1;
-          eventRefs.push(`event:${opId}`);
-          continue;
-        }
-        const event: CiRunObservationEventV2 = {
-            schema: "ci-run-observation/v2",
-            eventId: `event-${digest}`,
-            workspaceRevision: (cell.store.readHead()?.revision ?? 0) + 1,
-            opId,
-            type: "ci_run_observed",
-            actor: binding.actor,
-            source: binding.source,
-            occurredAt: cell.now(),
-            payload: {
-              run: artifact.run,
-              tests: artifact.tests,
-              gates: artifact.gates,
-              verification:
-                summary.workflowName === "rewrite-ci" &&
-                summary.headBranch === "main" &&
-                artifact.run.branch === "main" &&
-                artifact.run.sha === summary.headSha &&
-                artifact.run.runId === `${run.databaseId}.${summary.attempt}`
-                  ? {
-                      source: "github-actions",
-                      workflow: "rewrite-ci",
-                      runId: String(run.databaseId),
-                      attempt: summary.attempt,
-                      headSha: summary.headSha,
-                      conclusion: summary.conclusion,
-                    }
-                  : null,
-            },
-          },
-          errors = validateCurrentCiRunObservationEvent(event);
-        if (errors.length) throw cell.cellCodedError("invalid_command", errors.join("; "));
-        const plan = ciRunObservationWritePlan(event),
-          appended = cell.store.append({ event, plan, blobs: [] });
-        cell.projection.apply(event, plan);
-        lastRevision = appended.revision;
-        imported += 1;
-        eventRefs.push(`event:${opId}`);
-      }
+      fetched.push({ databaseId: run.databaseId, summary, artifacts: readArtifacts(runRoot) });
     }
-    const appliedCut = cell.projection.readCiRunObservations(1).watermark,
-      visible = appliedCut >= lastRevision;
-    return {
-      outcome: visible ? "applied" : "pending",
-      opId: `ci-observe-pull-${Date.now()}`,
-      revision: lastRevision,
-      evidence: JSON.stringify({
-        schema: "ci-observe-pull/v1",
-        imported,
-        duplicate,
-        requestedRuns: namedRuns?.length ?? limit,
-        eventRefs,
-      }),
-      visibility: "center",
-      proof: {
-        committedRevision: lastRevision,
-        appliedCut,
-        durable: true,
-        canonicalVisible: visible,
-        worktreeVisible: false,
-      },
-      summary:
-        `Imported ${imported} CI observation artifact(s); ${duplicate} already existed.\n` + eventRefs.join("\n"),
-    } as WriteReceipt;
+    return { requestedRuns: namedRuns?.length ?? limit, runs: fetched };
   } finally {
     rmSync(temporaryRoot, { recursive: true, force: true });
   }
+}
+
+export function ingestCiObservations(
+  cell: RepoCellActionContext,
+  binding: RepoCellBinding,
+  fetched: CiObservationFetch,
+): WriteReceipt {
+  const eventRefs: string[] = [];
+  let imported = 0,
+    duplicate = 0,
+    lastRevision = cell.store.readHead()?.revision ?? 0;
+  for (const { databaseId, summary, artifacts } of fetched.runs)
+    for (const artifact of artifacts) {
+      const digest = createHash("sha256")
+          .update(`verified-v2\u0000${artifact.run.runId}\u0000${artifact.run.job}`)
+          .digest("hex"),
+        opId = `ci-observation-${digest}`;
+      if (cell.store.readEvent(opId)) {
+        duplicate += 1;
+        eventRefs.push(`event:${opId}`);
+        continue;
+      }
+      const event: CiRunObservationEventV2 = {
+          schema: "ci-run-observation/v2",
+          eventId: `event-${digest}`,
+          workspaceRevision: (cell.store.readHead()?.revision ?? 0) + 1,
+          opId,
+          type: "ci_run_observed",
+          actor: binding.actor,
+          source: binding.source,
+          occurredAt: cell.now(),
+          payload: {
+            run: artifact.run,
+            tests: artifact.tests,
+            gates: artifact.gates,
+            verification:
+              summary.workflowName === "rewrite-ci" &&
+              summary.headBranch === "main" &&
+              artifact.run.branch === "main" &&
+              artifact.run.sha === summary.headSha &&
+              artifact.run.runId === `${databaseId}.${summary.attempt}`
+                ? {
+                    source: "github-actions",
+                    workflow: "rewrite-ci",
+                    runId: String(databaseId),
+                    attempt: summary.attempt,
+                    headSha: summary.headSha,
+                    conclusion: summary.conclusion,
+                  }
+                : null,
+          },
+        },
+        errors = validateCurrentCiRunObservationEvent(event);
+      if (errors.length) throw cell.cellCodedError("invalid_command", errors.join("; "));
+      const plan = ciRunObservationWritePlan(event),
+        appended = cell.store.append({ event, plan, blobs: [] });
+      cell.projection.apply(event, plan);
+      lastRevision = appended.revision;
+      imported += 1;
+      eventRefs.push(`event:${opId}`);
+    }
+  const appliedCut = cell.projection.readCiRunObservations(1).watermark,
+    visible = appliedCut >= lastRevision;
+  return {
+    outcome: visible ? "applied" : "pending",
+    opId: `ci-observe-pull-${Date.now()}`,
+    revision: lastRevision,
+    evidence: JSON.stringify({
+      schema: "ci-observe-pull/v1",
+      imported,
+      duplicate,
+      requestedRuns: fetched.requestedRuns,
+      eventRefs,
+    }),
+    visibility: "center",
+    proof: {
+      committedRevision: lastRevision,
+      appliedCut,
+      durable: true,
+      canonicalVisible: visible,
+      worktreeVisible: false,
+    },
+    summary: `Imported ${imported} CI observation artifact(s); ${duplicate} already existed.\n` + eventRefs.join("\n"),
+  } as WriteReceipt;
 }
 
 export function selectCiObservationRuns(runs: readonly CiWorkflowRun[], limit: number): readonly CiWorkflowRun[] {

--- a/packages/daemon/src/repo-cell-action-dispatch.ts
+++ b/packages/daemon/src/repo-cell-action-dispatch.ts
@@ -18,7 +18,6 @@ import { runMigrationImport } from "./migration-import.ts";
 import { assertExecutionExecutorDeclarationEligible } from "./repo-cell-execution-selection.ts";
 import { runLedgerReconcileAction } from "./repo-cell-migration-actions.ts";
 import { type RepoCellBinding, type RepoTaskAction, type Snapshot } from "./repo-cell-types.ts";
-import { pullAndIngestCiObservations } from "./ci-observation-actions.ts";
 import { readTaskLineageDispatches } from "./dispatch-read.ts";
 import type { RepoCellOperationalContext } from "./repo-cell-action-context.ts";
 import { runFactAction } from "./repo-cell-fact-action.ts";
@@ -46,7 +45,6 @@ export async function executeAction(
       projection: cell.projection,
       now: cell.now,
     });
-  if (action.kind === "ci-observe-pull") return pullAndIngestCiObservations(cell, action, binding);
   if (action.kind === "migrate-import")
     return runMigrationImport({
       action,

--- a/packages/daemon/src/repo-cell-api.ts
+++ b/packages/daemon/src/repo-cell-api.ts
@@ -41,12 +41,11 @@ import { readAgentEntityGuiProjection } from "./agent-entities.ts";
 import {
   canonicalVertical,
   compiledArtifactKinds,
-  prepareArtifactEntityImportSource,
-  artifactImportSourceResolution,
   readCurrentArtifact,
   resolveEntityReadKind,
 } from "./artifact-entity-action.ts";
 import { requireCanonicalVerticalDeclaration } from "./vertical-declaration-action.ts";
+import { readBeforeWriteQueue } from "./write-queue-external-reads.ts";
 import { readDeclaredEntityRows } from "./entity-rows-read.ts";
 import { readEntityContent, type EntityContentSource } from "./entity-content-read.ts";
 import { readEntityLocator } from "./entity-locator-read.ts";
@@ -421,24 +420,10 @@ export function createRepoCellApi(context: RepoCellApiContext): RepoCell & RepoC
             ),
           (error) => failAction(error, durable ? authorizeAtCurrentCut()! : undefined),
         );
-    if (action.kind === "entity-import")
-      return Promise.resolve()
-        .then(() =>
-          prepareArtifactEntityImportSource({
-            rootDir: context.rootDir,
-            repositoryId: context.input.repoId,
-            action,
-            projection: context.projection,
-          }),
-        )
-        .then((sourceResolution) =>
-          enqueuePublication((authorizationDecision) =>
-            context.executeAction(
-              { ...action, [artifactImportSourceResolution]: sourceResolution },
-              authorizationDecision ? { ...binding, authorizationDecision } : binding,
-            ),
-          ),
-        )
+    const externalRead = readBeforeWriteQueue(context, action, binding);
+    if (externalRead)
+      return externalRead
+        .then((publish) => enqueuePublication(publish))
         .catch((error) => failAction(error, durable ? authorizeAtCurrentCut()! : undefined));
     return enqueuePublication((authorizationDecision) =>
       context.executeAction(action, authorizationDecision ? { ...binding, authorizationDecision } : binding),

--- a/packages/daemon/src/runtime-worker-push.ts
+++ b/packages/daemon/src/runtime-worker-push.ts
@@ -9,7 +9,11 @@ const execFileAsync = promisify(execFile),
   detailLimit = 512,
   // Porcelain output grows with the worktree, and the dirty worktrees this answers about are the
   // large ones. Anything past this bound is still an answer: a worktree that says that much is dirty.
-  worktreeStatusLimit = 1 << 20;
+  worktreeStatusLimit = 1 << 20,
+  // Settlement pushes inside the repository write queue, so a stalled remote or a credential dialog
+  // nobody answers holds every write to the repo. A code-only worker branch pushes in seconds; this
+  // is the bound the fleet edge gives its own network transfers.
+  workerPushTimeoutMs = 60_000;
 
 export type WorkerPushResult =
   | { readonly attempted: false; readonly reason: "not-a-worker-worktree" | "not-codex-branch" | "detached" }
@@ -45,6 +49,7 @@ export async function pushWorkerBranch(input: {
   readonly cwd: string;
   readonly canonicalRoot: string;
   readonly env?: NodeJS.ProcessEnv;
+  readonly timeoutMs?: number;
 }): Promise<WorkerPushResult> {
   if (samePath(input.cwd, input.canonicalRoot)) return { attempted: false, reason: "not-a-worker-worktree" };
 
@@ -65,18 +70,27 @@ export async function pushWorkerBranch(input: {
   if (!branch) return { attempted: false, reason: "detached" };
   if (!workerBranchPattern.test(branch)) return { attempted: false, reason: "not-codex-branch" };
 
+  const timeoutMs = input.timeoutMs ?? workerPushTimeoutMs;
   try {
     const env = { ...process.env, ...input.env, GIT_TERMINAL_PROMPT: "0" },
       invocation = gitInvocation(input.cwd, ["push", "--force-with-lease", "origin", `HEAD:${branch}`], env);
     await execFileAsync(invocation.command, invocation.args, {
       env,
       maxBuffer: detailLimit * 2,
+      timeout: timeoutMs,
       windowsHide: true,
       ...(invocation.windowsVerbatimArguments ? { windowsVerbatimArguments: true } : {}),
     });
     return { attempted: true, ok: true, branch };
   } catch (error) {
-    return { attempted: true, ok: false, branch, detail: errorDetail(error) };
+    // execFile marks the child killed only when it enforced the timeout itself.
+    const timedOut = typeof error === "object" && error !== null && "killed" in error && error.killed === true;
+    return {
+      attempted: true,
+      ok: false,
+      branch,
+      detail: timedOut ? `git push timed out after ${timeoutMs} ms` : errorDetail(error),
+    };
   }
 }
 

--- a/packages/daemon/src/write-queue-external-reads.ts
+++ b/packages/daemon/src/write-queue-external-reads.ts
@@ -1,0 +1,37 @@
+import type { AuthorizationDecision, WriteReceiptDraft } from "../../kernel/src/index.ts";
+import { artifactImportSourceResolution, prepareArtifactEntityImportSource } from "./artifact-entity-action.ts";
+import { fetchCiObservations, ingestCiObservations } from "./ci-observation-actions.ts";
+import type { RepoCellApiContext } from "./repo-cell-api.ts";
+import type { RepoCellBinding, RepoTaskAction } from "./repo-cell-types.ts";
+
+type QueuedPublication = (
+  authorizationDecision?: AuthorizationDecision,
+) => WriteReceiptDraft | Promise<WriteReceiptDraft>;
+
+// A URL artifact source or GitHub can stall without bound, and every other write to the repository
+// would wait behind it in the write queue. These reads finish first; only the returned publication
+// of what they read runs inside the queue.
+export function readBeforeWriteQueue(
+  context: RepoCellApiContext,
+  action: RepoTaskAction,
+  binding: RepoCellBinding,
+): Promise<QueuedPublication> | null {
+  if (action.kind === "entity-import")
+    return prepareArtifactEntityImportSource({
+      rootDir: context.rootDir,
+      repositoryId: context.input.repoId,
+      action,
+      projection: context.projection,
+    }).then(
+      (sourceResolution) => (authorizationDecision) =>
+        context.executeAction(
+          { ...action, [artifactImportSourceResolution]: sourceResolution },
+          authorizationDecision ? { ...binding, authorizationDecision } : binding,
+        ),
+    );
+  if (action.kind === "ci-observe-pull")
+    return fetchCiObservations(context.extracted, action).then(
+      (fetched) => () => ingestCiObservations(context.extracted, binding, fetched),
+    );
+  return null;
+}

--- a/packages/daemon/test/ci-observatory-read.test.ts
+++ b/packages/daemon/test/ci-observatory-read.test.ts
@@ -4,10 +4,20 @@ import path from "node:path";
 import test from "node:test";
 import assert from "node:assert/strict";
 import { readCiObservatory } from "../src/ci-observatory-read.ts";
-import { pullAndIngestCiObservations, selectCiObservationRuns } from "../src/ci-observation-actions.ts";
+import { fetchCiObservations, ingestCiObservations, selectCiObservationRuns } from "../src/ci-observation-actions.ts";
 import type { CiRunObservationEventV2 } from "../../kernel/src/index.ts";
 
 const actor = { principal: { personId: "person-observatory" }, executor: null } as const;
+
+// The daemon runs the gh reads before the write queue and the appends inside it; these cases run both halves back to back.
+async function pullAndIngestCiObservations(
+  cell: Parameters<typeof ingestCiObservations>[0],
+  action: Parameters<typeof fetchCiObservations>[1],
+  binding: Parameters<typeof ingestCiObservations>[1],
+  runGh: Parameters<typeof fetchCiObservations>[2],
+) {
+  return ingestCiObservations(cell, binding, await fetchCiObservations(cell, action, runGh));
+}
 
 function event(
   revision: number,

--- a/packages/daemon/test/doc-sync-slice-a-artifacts-upgrades.test.ts
+++ b/packages/daemon/test/doc-sync-slice-a-artifacts-upgrades.test.ts
@@ -295,6 +295,8 @@ test("an authored edit of a migrated governance standard upgrades its policy in 
     const native = makeTaskEventReader({ repoId, rootDir }).readEvent(second.opId);
     if (native?.schema === "doc-event/v1") assert.equal("policyUpgrade" in native.payload.changes[0]!, false);
 
+    // The receipt reports git pending; the hand commit must land on top of the second submit's publication.
+    await waitForFixturePublication(cell, String(second.opId), binding);
     write(rootDir, standard, `${secondBody}hand edit outside doc sync\n`);
     git(rootDir, "add", "harness");
     git(rootDir, "commit", "-qm", "manual ledger advance");

--- a/packages/daemon/test/json-rpc-protocol.test.ts
+++ b/packages/daemon/test/json-rpc-protocol.test.ts
@@ -17,7 +17,7 @@ import path from "node:path";
 import test from "node:test";
 import { openDaemonHost } from "../src/daemon-host.ts";
 import { openPersistentWriterEpoch } from "../src/writer-epoch.ts";
-import { pullAndIngestCiObservations } from "../src/ci-observation-actions.ts";
+import { fetchCiObservations, ingestCiObservations } from "../src/ci-observation-actions.ts";
 import {
   canonicalEventWritePlan,
   makeTaskEventReader,
@@ -1669,51 +1669,48 @@ async function publishCiObservation(
     databaseId = Number.parseInt(createHash("sha256").update(runId).digest("hex").slice(0, 8), 16) + 1,
     observedRunId = `${databaseId}.1`;
   try {
-    const receipt = await pullAndIngestCiObservations(
-      {
-        rootDir,
-        store,
-        projection,
-        now: () => "2026-09-09T00:00:00.000Z",
-        cellCodedError: (code: string, message: string) => Object.assign(new Error(message), { code }),
-      } as unknown as Parameters<typeof pullAndIngestCiObservations>[0],
-      { kind: "ci-observe-pull", limit: 1 },
-      repoWriteBinding,
-      async (_command, args) => {
-        if (args[1] === "list")
-          return JSON.stringify([{ databaseId, headBranch: "main", createdAt: "2026-09-09T00:00:00.000Z" }]);
-        if (args[1] === "view")
-          return JSON.stringify({
-            workflowName: verified ? "rewrite-ci" : "rebuild-gates",
-            headSha: commitSha,
-            headBranch: "main",
-            status: "completed",
-            conclusion: "success",
-            attempt: 1,
-          });
-        assert.equal(args[1], "download");
-        const output = String(args[args.indexOf("--dir") + 1]);
-        mkdirSync(output, { recursive: true });
-        writeFileSync(
-          path.join(output, "observation.json"),
-          JSON.stringify({
-            schema: "ci-run-artifact/v1",
-            run: {
-              runId: observedRunId,
-              sha: commitSha,
-              branch: "main",
-              prNumber: null,
-              job: "full-check (24)",
-              wallclockMs: 25,
-              runner: "fixture-runner",
-            },
-            tests: [],
-            gates: [{ gate: "ci", pass: true, metrics: { runAttempt: 1 } }],
-          }),
-        );
-        return "";
-      },
-    );
+    const cell = {
+      rootDir,
+      store,
+      projection,
+      now: () => "2026-09-09T00:00:00.000Z",
+      cellCodedError: (code: string, message: string) => Object.assign(new Error(message), { code }),
+    } as unknown as Parameters<typeof ingestCiObservations>[0];
+    const fetched = await fetchCiObservations(cell, { kind: "ci-observe-pull", limit: 1 }, async (_command, args) => {
+      if (args[1] === "list")
+        return JSON.stringify([{ databaseId, headBranch: "main", createdAt: "2026-09-09T00:00:00.000Z" }]);
+      if (args[1] === "view")
+        return JSON.stringify({
+          workflowName: verified ? "rewrite-ci" : "rebuild-gates",
+          headSha: commitSha,
+          headBranch: "main",
+          status: "completed",
+          conclusion: "success",
+          attempt: 1,
+        });
+      assert.equal(args[1], "download");
+      const output = String(args[args.indexOf("--dir") + 1]);
+      mkdirSync(output, { recursive: true });
+      writeFileSync(
+        path.join(output, "observation.json"),
+        JSON.stringify({
+          schema: "ci-run-artifact/v1",
+          run: {
+            runId: observedRunId,
+            sha: commitSha,
+            branch: "main",
+            prNumber: null,
+            job: "full-check (24)",
+            wallclockMs: 25,
+            runner: "fixture-runner",
+          },
+          tests: [],
+          gates: [{ gate: "ci", pass: true, metrics: { runAttempt: 1 } }],
+        }),
+      );
+      return "";
+    });
+    const receipt = ingestCiObservations(cell, repoWriteBinding, fetched);
     assert.equal(JSON.parse(receipt.evidence).imported, 1);
     const event = store
       .read()

--- a/packages/daemon/test/runtime-worker-push.test.ts
+++ b/packages/daemon/test/runtime-worker-push.test.ts
@@ -1,7 +1,7 @@
 // harness-test-tier: fast
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -49,6 +49,47 @@ test("worker push records a single failure without retrying", async (context) =>
   assert.equal(result.ok, false);
   assert.equal(result.branch, "codex/push-failure");
   assert.match(result.detail, /does not appear to be a git repository|No such file|not found/iu);
+});
+
+test("a worker push that never answers ends as a timed-out push failure", async (context) => {
+  const root = mkdtempSync(path.join(tmpdir(), "ha-worker-push-hang-")),
+    bare = path.join(root, "remote.git"),
+    canonical = path.join(root, "project"),
+    worker = path.join(root, "worker"),
+    hooks = path.join(root, "hooks"),
+    release = path.join(root, "release");
+  context.after(() => {
+    writeFileSync(release, "");
+    rmSync(root, { recursive: true, force: true });
+  });
+  git(root, "init", "--bare", bare);
+  git(root, "init", "-q", "project");
+  git(canonical, "config", "user.email", "push-test@example.invalid");
+  git(canonical, "config", "user.name", "Push Test");
+  git(canonical, "commit", "--allow-empty", "--quiet", "-m", "fixture");
+  git(canonical, "remote", "add", "origin", bare);
+  git(canonical, "worktree", "add", "--quiet", worker, "-b", "codex/push-hang");
+  // Stands in for a stalled remote or a credential dialog nobody answers.
+  mkdirSync(hooks);
+  writeFileSync(
+    path.join(hooks, "pre-push"),
+    `#!/bin/sh\nwhile [ -d '${root}' ] && [ ! -f '${release}' ]; do sleep 0.05; done\n`,
+    { mode: 0o755 },
+  );
+  git(canonical, "config", "core.hooksPath", hooks);
+
+  const result = await Promise.race([
+    pushWorkerBranch({ cwd: worker, canonicalRoot: canonical, timeoutMs: 300 }),
+    new Promise<never>((_, reject) => {
+      setTimeout(() => reject(new Error("the hanging push never settled")), 10_000).unref();
+    }),
+  ]);
+  assert.deepEqual(result, {
+    attempted: true,
+    ok: false,
+    branch: "codex/push-hang",
+    detail: "git push timed out after 300 ms",
+  });
 });
 
 test("canonical roots never trigger worker push", async () => {

--- a/packages/daemon/test/write-queue-external-calls.integration.test.ts
+++ b/packages/daemon/test/write-queue-external-calls.integration.test.ts
@@ -1,0 +1,189 @@
+// harness-test-tier: integration
+import assert from "node:assert/strict";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { credentialPort, runCredentialCommand } from "../src/agent-runtime-credential-port.ts";
+import { openRuntimeInstanceStore, type RuntimeInstallationWitness } from "../src/agent-runtime-instances.ts";
+import { canonicalRoot, workspaceId } from "../src/protocol/daemon-protocol.contract.ts";
+import { withRoleBinding } from "./role-binding.fixtures.ts";
+import { openBootstrappedRepoCell as openRepoCell } from "./repo-settings.fixture.ts";
+import { initRepo } from "./task-surface.fixtures.ts";
+
+// Each test injects one external command that never answers until the test releases it (or deletes its
+// directory), then proves an unrelated write to the same repository is still accepted.
+const binding = withRoleBinding(
+  { actor: { principal: { personId: "person-write-queue" }, executor: null }, source: "local" as const },
+  "repo-write",
+);
+
+async function waitForFile(file: string): Promise<void> {
+  const deadline = Date.now() + 10_000;
+  while (!existsSync(file)) {
+    assert.ok(Date.now() < deadline, `${path.basename(file)} never appeared`);
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+}
+
+async function settlesWithin<T>(pending: Promise<T>, ms: number, message: string): Promise<T> {
+  let timer: NodeJS.Timeout | undefined;
+  try {
+    return await Promise.race([
+      pending,
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(() => reject(new Error(message)), ms);
+      }),
+    ]);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+test(
+  "ci observe pull does not hold the repository write queue while gh hangs",
+  { skip: process.platform === "win32" ? "requires POSIX shell-script executables resolved through PATH" : false },
+  async () => {
+    const parent = mkdtempSync(path.join(tmpdir(), "ha-ci-pull-queue-")),
+      rootDir = path.join(parent, "repo"),
+      stubDir = path.join(parent, "bin"),
+      started = path.join(parent, "gh.started"),
+      release = path.join(parent, "gh.release"),
+      originalPath = process.env.PATH;
+    let cell: Awaited<ReturnType<typeof openRepoCell>> | undefined;
+    try {
+      mkdirSync(rootDir);
+      mkdirSync(stubDir);
+      writeFileSync(
+        path.join(stubDir, "gh"),
+        `#!/bin/sh\n: > '${started}'\nwhile [ -d '${parent}' ] && [ ! -f '${release}' ]; do sleep 0.05; done\nexit 1\n`,
+        { mode: 0o755 },
+      );
+      initRepo(rootDir);
+      // The writer thread copies the environment when it starts, so the stub goes on PATH first.
+      process.env.PATH = `${stubDir}${path.delimiter}${originalPath ?? ""}`;
+      cell = await openRepoCell({
+        repoId: workspaceId("ci-pull-queue"),
+        rootDir: canonicalRoot(rootDir),
+        ownerId: "ci-pull-queue-center",
+        now: () => "2026-09-11T02:00:00.000Z",
+      });
+      const pulling = cell.run({ kind: "ci-observe-pull", limit: 1 }, binding);
+      await waitForFile(started);
+      const write = await settlesWithin(
+        cell.run({ kind: "task-create", taskId: "ci-pull-concurrent-write", title: "Concurrent write" }, binding),
+        5_000,
+        "a concurrent write waited on the hanging gh",
+      );
+      assert.equal(write.outcome, "applied", JSON.stringify(write));
+      writeFileSync(release, "");
+      const pulled = await pulling;
+      assert.equal(pulled.outcome, "op_rejected", JSON.stringify(pulled));
+    } finally {
+      writeFileSync(release, "");
+      process.env.PATH = originalPath;
+      await cell?.close();
+      rmSync(parent, { recursive: true, force: true });
+    }
+  },
+);
+
+test("a credential lookup nobody answers fails the spawn and releases the repository write queue", async () => {
+  const parent = mkdtempSync(path.join(tmpdir(), "ha-credential-queue-")),
+    rootDir = path.join(parent, "repo"),
+    started = path.join(parent, "vault.started"),
+    release = path.join(parent, "vault.release"),
+    installation: RuntimeInstallationWitness = {
+      installationId: "codex-credential-queue-installation",
+      kindId: "codex",
+      executablePath: "/opt/witnessed/codex-credential-queue",
+      version: "1.0.0",
+      observedAt: "2026-09-11T00:00:00.000Z",
+    },
+    // The native vault command is replaced by a process that never answers, like a keychain unlock dialog.
+    vault = credentialPort(
+      process.platform,
+      (command, timeoutMs) =>
+        runCredentialCommand(
+          {
+            ...command,
+            file: process.execPath,
+            args: [
+              "-e",
+              `const fs = require("node:fs"); fs.writeFileSync(${JSON.stringify(started)}, "");` +
+                `setInterval(() => { if (fs.existsSync(${JSON.stringify(release)})) process.exit(1); }, 50);`,
+            ],
+          },
+          timeoutMs,
+        ),
+      300,
+    ),
+    instances = openRuntimeInstanceStore({
+      userRoot: path.join(parent, "user"),
+      discover: () => [installation],
+      resolveCredential: vault.resolve,
+    });
+  let cell: Awaited<ReturnType<typeof openRepoCell>> | undefined;
+  try {
+    mkdirSync(rootDir);
+    initRepo(rootDir);
+    instances.create({
+      schemaVersion: 2,
+      instanceId: "codex-credential-queue",
+      name: "Codex Credential Queue",
+      kindId: "codex",
+      installationId: installation.installationId,
+      providerId: "openai",
+      models: ["gpt-5.6-sol"],
+      defaultModel: "gpt-5.6-sol",
+      enabled: true,
+      permissionMode: "read-only",
+      codex: {},
+      auth: { mode: "api-key", credentialRef: "credential:v1:credential-queue" },
+    });
+    cell = await openRepoCell({
+      repoId: workspaceId("credential-queue"),
+      rootDir: canonicalRoot(rootDir),
+      ownerId: "credential-queue-center",
+      now: () => "2026-09-11T02:00:00.000Z",
+      runtimeDaemonRoute: {
+        userRoot: path.join(parent, "daemon-user"),
+        daemonId: "credential-queue",
+        endpoint: path.join(parent, "daemon.sock"),
+      },
+      runtimeInstances: instances.listPublic,
+      prepareRuntimeLaunch: instances.prepareLaunch,
+      runtimeLaunch: () => {
+        throw new Error("a runtime must not launch without its credential");
+      },
+    });
+    const spawning = cell.spawnRuntime(
+      {
+        runtimeInstanceId: "codex-credential-queue",
+        cwd: { scope: "repo-root" },
+        prompt: "Needs the unanswered credential",
+        taskId: null,
+        idempotencyKey: "credential-queue-spawn",
+      },
+      binding,
+    );
+    const spawned = spawning.then(
+      (receipt) => ({ receipt }),
+      (error: unknown) => ({ error }),
+    );
+    await waitForFile(started);
+    const write = await settlesWithin(
+      cell.run({ kind: "task-create", taskId: "credential-concurrent-write", title: "Concurrent write" }, binding),
+      5_000,
+      "a concurrent write waited on the unanswered credential lookup",
+    );
+    assert.equal(write.outcome, "applied", JSON.stringify(write));
+    const settled = await spawned;
+    assert.ok("error" in settled, JSON.stringify(settled));
+    assert.equal((settled.error as { readonly code?: unknown }).code, "runtime_credential_unavailable");
+  } finally {
+    writeFileSync(release, "");
+    await cell?.close();
+    rmSync(parent, { recursive: true, force: true });
+  }
+});

--- a/tools/gate-allowlists/check-fallback-boundaries.json
+++ b/tools/gate-allowlists/check-fallback-boundaries.json
@@ -38,7 +38,7 @@
       "packages/daemon/src/artifacts-gui-read.ts#walkAllTaskArtifacts",
       "packages/daemon/src/artifacts-gui-read.ts#walkArtifactTree",
       "packages/daemon/src/build-identity.ts#resolveStamp",
-      "packages/daemon/src/ci-observation-actions.ts#pullAndIngestCiObservations",
+      "packages/daemon/src/ci-observation-actions.ts#fetchCiObservations",
       "packages/daemon/src/client/local-json-rpc-client.ts#onLine",
       "packages/daemon/src/client/local-json-rpc-shutdown.ts#requestDaemonShutdownAt",
       "packages/daemon/src/client/local-json-rpc-stream.ts#connect",


### PR DESCRIPTION
# English

## Summary

Every write to a repository runs through one serial write queue (`chainRepoCellWrite`). Three places awaited an external process inside that queue with no time limit, so a stalled GitHub, a remote that never answers, or a keychain unlock dialog nobody answers froze every write to the repository:

- `ci observe pull`: every `gh run list` / `gh run view` / `gh run download` ran inside the queue.
- Runtime exit: the settlement's `git push --force-with-lease` of the worker branch had no timeout.
- Runtime spawn: the credential lookup (`security` / `secret-tool` / PowerShell) had no timeout.

Now:
- `ci observe pull` finishes all gh reads before it enters the queue; only the event appends run inside.
- The worker push is bounded at 60 s and the credential lookup at 10 s. A timeout ends as the existing push-failure record or `runtime_credential_unavailable`.

## Architectural Justification

- The push and the lookup stay in the queue on purpose. The push result is part of the settlement write (it goes into the result body, hash and ref, in the same append as the archive and outcome). The credential depends on which instance the queued spawn selects. Moving either out changes settlement semantics, so this PR bounds them instead.

## What Changed

- `ci-observation-actions.ts`: split into `fetchCiObservations` (all gh calls and artifact reads, before the queue) and `ingestCiObservations` (dedupe, `store.append`, receipt, inside the queue). Event content, opId and the verification decision are unchanged.
- `write-queue-external-reads.ts` (new): `readBeforeWriteQueue` routes both external reads that finish before the queue, the URL entity import (moved from `repo-cell-api.ts`) and the ci pull. `repo-cell-api.ts` drops 15 lines net and stays under the file-complexity limit.
- `repo-cell-action-dispatch.ts`: the in-queue ci pull branch is deleted.
- `runtime-worker-push.ts`: `timeout: 60_000`; a timeout is reported as `git push timed out after N ms`.
- `agent-runtime-credential-port.ts`: `resolve` passes a 10 s timeout to the runner; `store` stays unbounded (a person is there to answer the dialog).
- Side effect: a gh failure midway through a pull no longer leaves a partial import, because appends start only after every read has finished.
- `doc-sync-slice-a-artifacts-upgrades.test.ts`: before its hand-made ledger commit, the governance-standard test now waits for the second doc submit to publish (`waitForFixturePublication`, the helper the first test in the file already uses). The new test file in this PR moved heavier I/O tests into integration shard 6, and there this test failed twice at line 302 with `no_changes`: the hand commit had landed before the follower published the previous submit.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Deleted code (no whole file): the in-queue ci-observe-pull dispatch branch; `pullAndIngestCiObservations`; the entity-import route inside `repo-cell-api.ts` `run()`.
- The fallback-boundaries allowlist entry moves from `pullAndIngestCiObservations` to `fetchCiObservations`, which now holds the same `consumeKnownError` path. Entry count unchanged.
- Production net lines: +179/-120 (net +59), from `node tools/gates/production-delta.mjs --base origin/main`.

## Machine-Readable Declarations

- No dependency change or event migration; no machine-readable declarations.

## Task And Scope

- Harness task: task_31a5ff133c117a556eec3cc803
- Branch: `codex/serial-slot-external-calls`
- Public scope: external calls awaited inside the repository write queue
- Private planning/evidence updated: yes (task report, facts F-D634C4D1, F-F83E363E, F-96EA589B)
- Out of scope: moving the worker push out of the queue (changes settlement atomicity); local commands in the same settlement turn (`ps`, `git status`)

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: yes
- Protected surface scope: `tools/gate-allowlists/check-fallback-boundaries.json`, one entry renamed from `ci-observation-actions.ts#pullAndIngestCiObservations` to `ci-observation-actions.ts#fetchCiObservations`. Entry count unchanged; nothing is loosened.
- Authority: task_31a5ff133c117a556eec3cc803 (this change). The gate's exact-sync check requires the entry to follow the function that holds the `consumeKnownError` path, and the split in this PR moved that path. The repository owner authorized governance fixes for tonight's run.
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `8a0213695`
- Branch merge-base with `origin/main`: `8a0213695`
- Last `git fetch origin` time: 2026-09-11 UTC
- Sync method: rebased onto origin/main
- Public diff command: `git diff origin/main...codex/serial-slot-external-calls`
- Private evidence commit/path: task_31a5ff133c117a556eec3cc803 task package report and evidence
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [x] `npm run typecheck` (as `npx tsc -b packages/kernel packages/daemon`, exit 0)
- [ ] `npm test`
- [x] `npm run harness:check-import-boundaries` (via `run-manifest-gates --changed origin/main`)
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts` (via `run-manifest-gates --changed origin/main`)
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Three hang-injection tests, each with a negative control (same test, production files reverted to base):
  - ci pull (integration, a PATH gh stub that never returns): passes in 1.2 s; reverted, a concurrent `task-create` is still waiting after 6 s and the test fails.
  - credential lookup (integration, a vault command that never returns): passes in 1.2 s; reverted, fails after 5.6 s.
  - worker push (fast, real git, real bare remote, a pre-push hook that never returns, 300 ms bound): passes in 0.8 s; reverted, the push never settles.
- An out-of-tree experiment with the full repo cell and a task-bound runtime: with a hanging pre-push hook, a concurrent `task-create` was still queued after 75 s before the fix, and applied after 60.1 s with the fix (outcome still `succeeded`, push failure recorded). It needs 60 s of wall clock, so it is not checked in.
- Shard 6 failure, before the test fix: the raw job log shows `doc-sync-slice-a-artifacts-upgrades.test.ts:302` expected `applied`, got `no_changes`. On the Ubuntu VM the whole shard passes (10 and 4 CPUs); running the test next to the 600 MB outbox test on 2 CPUs failed it 2 times in 22. After the fix the file passes on the VM.
- Touched-surface tests green: `runtime-worker-push`, `agent-runtime-credential-port`, `ci-observatory-read`, `agent-runtime-instance-registry`, `json-rpc-protocol`, `artifact-entity-action.integration` (including the F2/F6 URL tests), `runtime-worker-github-credentials.integration`. `run-manifest-gates --changed origin/main`, `check-file-complexity` and `production-delta` pass.

## Review Evidence

- Worker (Claude Opus) wrote the change, the tests and the negative controls. The lead read the production diff and checked that the ci ingest never used the authorization decision it no longer receives (the old function read only `actor` and `source` from the binding).
- Reviewer subagent: not used
- Human review: pending
- Blocking findings: none

## Residual Risk

- A hanging gh now holds only its own pull request, with no timeout; other writes proceed.
- gh reads now happen before admission and authorization, the same as the URL entity import. A caller that would be rejected still triggers gh first.
- A single runtime exit can hold the queue for up to about 60 s (plus up to 10 s for the GitHub credential lookup). A legitimate but slow push is reported as timed out and the branch is not published.
- On macOS, someone who cannot type the keychain unlock password within 10 s gets `runtime_credential_unavailable` and has to unlock and retry.
- Windows not run: the ci queue test skips on win32 with a named capability reason.

## References

- Task: task_31a5ff133c117a556eec3cc803
- Facts: F-D634C4D1, F-F83E363E, F-96EA589B

---

# 中文

## 概要

对一个仓库的所有写入都经过同一条串行写队列（`chainRepoCellWrite`）。有三处在队内 await 外部进程且没有时间上限，GitHub 卡住、远端不应答、或者 keychain 解锁对话框没人处理时，这个仓库的所有写入都会被冻结：

- `ci observe pull`：所有 `gh run list` / `gh run view` / `gh run download` 都在队内执行。
- runtime 退出：结算时推送 worker 分支的 `git push --force-with-lease` 没有超时。
- runtime 启动：凭据查询（`security` / `secret-tool` / PowerShell）没有超时。

现在：
- `ci observe pull` 在入队前完成全部 gh 读取，队内只做事件追加。
- worker 推送上限 60 秒，凭据查询上限 10 秒。超时后分别记为已有的推送失败记录和 `runtime_credential_unavailable`。

## 架构辩护

- 推送和凭据查询是有意留在队内的。推送结果属于结算写入的一部分（进入结果正文、hash 和 ref，与归档、outcome 同一次追加）；凭据取决于队内的启动流程选中了哪个实例。把任何一个移出队列都会改变结算语义，所以本 PR 改为给它们加上限。

## 改动内容

- `ci-observation-actions.ts`：拆成 `fetchCiObservations`（所有 gh 调用和 artifact 读取，在入队前）和 `ingestCiObservations`（去重、`store.append`、回执，在队内）。事件内容、opId、verification 判定不变。
- `write-queue-external-reads.ts`（新）：`readBeforeWriteQueue` 统一承接两条在入队前完成的外部读取：URL entity import（从 `repo-cell-api.ts` 挪来）和 ci pull。`repo-cell-api.ts` 净减 15 行，保持在文件复杂度上限以内。
- `repo-cell-action-dispatch.ts`：删掉队内的 ci pull 分支。
- `runtime-worker-push.ts`：`timeout: 60_000`；超时记为 `git push timed out after N ms`。
- `agent-runtime-credential-port.ts`：`resolve` 给 runner 传 10 秒超时；`store` 不限时（存凭据时人在场）。
- 附带效果：pull 中途 gh 失败不再留下部分导入，因为所有读取完成后才开始追加。
- `doc-sync-slice-a-artifacts-upgrades.test.ts`：governance standard 那条测试在手工提交账本前，先等第二次 doc submit 发布完成（`waitForFixturePublication`，同文件第一条测试已经在用）。本 PR 新增的测试文件让更重的 I/O 测试换进 integration shard 6，这条测试在那里两次于第 302 行失败，实际值 `no_changes`：手工提交落在了 follower 发布上一次提交之前。

## 门收割 / Gate Harvest

- 删除的生产路径：none（没有删除整个文件）
- 删除的门或 fixture：none
- 删除的代码：队内的 ci-observe-pull 分支；`pullAndIngestCiObservations`；`repo-cell-api.ts` `run()` 里的 entity-import 路由。
- fallback-boundaries allowlist 的登记项从 `pullAndIngestCiObservations` 改为 `fetchCiObservations`，同一条 `consumeKnownError` 路径现在在这个函数里。登记数量不变。
- 生产净行数：+179/-120（net +59），由 `node tools/gates/production-delta.mjs --base origin/main` 计算。

## 机读声明说明

- 本 PR 不涉及依赖变化和事件迁移，没有机读声明。

## 任务与范围

- Harness 任务：task_31a5ff133c117a556eec3cc803
- 分支：`codex/serial-slot-external-calls`
- 公开范围：在仓库写队列内被 await 的外部调用
- 私有计划 / 证据是否已更新：yes（任务报告，fact F-D634C4D1、F-F83E363E、F-96EA589B）
- 范围外：把 worker 推送移出队列（会改变结算原子性）；同一结算回合里的本地命令（`ps`、`git status`）

## 版本影响

- 版本：不改版本
- 发布影响：不发布

## 治理声明

- 是否触碰 protected surface：yes
- protected surface 范围：`tools/gate-allowlists/check-fallback-boundaries.json`，一条登记项从 `ci-observation-actions.ts#pullAndIngestCiObservations` 改名为 `ci-observation-actions.ts#fetchCiObservations`。登记数量不变，没有放宽任何约束。
- 依据：
  - task_31a5ff133c117a556eec3cc803（本改动）；
  - 该门的精确同步检查要求登记项跟随持有 `consumeKnownError` 路径的函数，本 PR 的拆分移动了这条路径；
  - 仓库所有者授权了今晚的治理修复。
- 机器检查边界：本 PR 只声明该段存在；声明是否真实、充分，由 reviewer 判断。
- Break-glass：no
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- `origin/main` 基准 SHA：`8a0213695`
- 当前分支与 `origin/main` 的 merge-base：`8a0213695`
- 最近一次 `git fetch origin` 时间：2026-09-11 UTC
- 同步方式：rebase 到 origin/main
- 公开 diff 命令：`git diff origin/main...codex/serial-slot-external-calls`
- 私有证据 commit/path：task_31a5ff133c117a556eec3cc803 任务包报告与 evidence
- Reviewer 证据路径：见本 PR 的「审查证据」一节
- GitHub Actions `rewrite-ci` run URL：本 PR 的 CI 还在跑
- [ ] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [x] `npm run typecheck`（以 `npx tsc -b packages/kernel packages/daemon` 运行，exit 0）
- [ ] `npm test`
- [x] `npm run harness:check-import-boundaries`（经 `run-manifest-gates --changed origin/main`）
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts`（经 `run-manifest-gates --changed origin/main`）
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- 三条挂起注入测试，各带阴性对照（同一测试，生产文件撤回到 base）：
  - ci pull（integration，一个永不返回的 PATH gh 桩）：1.2 秒通过；撤回后并发的 `task-create` 6 秒后仍在等，测试失败。
  - 凭据查询（integration，一个永不返回的 vault 命令）：1.2 秒通过；撤回后 5.6 秒失败。
  - worker 推送（fast，真 git、真 bare remote、永不返回的 pre-push hook、300 ms 上限）：0.8 秒通过；撤回后推送一直不结束。
- 另做了一次库外实验，用完整 repo cell 和 task-bound runtime：pre-push hook 挂起时，修复前并发 `task-create` 75 秒后仍在排队；修复后 60.1 秒 applied（outcome 仍为 `succeeded`，并记录了推送失败）。它要 60 秒以上墙钟，所以没有入库。
- shard 6 失败（测试修复前）：原始 job 日志显示 `doc-sync-slice-a-artifacts-upgrades.test.ts:302` 期望 `applied`，实际 `no_changes`。在 Ubuntu VM 上整个 shard 通过（10 核和 4 核）；在 2 核上与 600 MB outbox 测试并发跑，22 次失败 2 次。修复后该文件在 VM 上通过。
- 触碰面测试全绿：`runtime-worker-push`、`agent-runtime-credential-port`、`ci-observatory-read`、`agent-runtime-instance-registry`、`json-rpc-protocol`、`artifact-entity-action.integration`（含 F2/F6 的 URL 测试）、`runtime-worker-github-credentials.integration`。`run-manifest-gates --changed origin/main`、`check-file-complexity`、`production-delta` 通过。

## 审查证据

- worker（Claude Opus）写了改动、测试和阴性对照。主控读了生产 diff，并确认 ci ingest 从未使用它现在不再收到的授权决定（旧函数只从 binding 读 `actor` 和 `source`）。
- Reviewer subagent：未使用
- 人工审查：待进行
- 阻塞发现：无

## 残余风险

- 挂住的 gh 现在只挂住它自己这一次 pull 请求，没有超时；其他写入照常进行。
- gh 读取现在发生在准入和授权之前，与 URL entity import 相同。本该被拒绝的调用方仍会先触发 gh。
- 一次 runtime 退出最多占队约 60 秒（GitHub 凭据查询另有最多 10 秒）。合法但很慢的推送会被记为超时，分支不会发布。
- macOS 上 10 秒内来不及输入 keychain 解锁密码的人会拿到 `runtime_credential_unavailable`，需要先解锁再重试。
- 没有跑 Windows：ci 队列测试在 win32 上带具名能力理由跳过。

## 关联材料

- Task: task_31a5ff133c117a556eec3cc803
- Fact：F-D634C4D1、F-F83E363E、F-96EA589B

---

## PR Gate Checklist / PR 门禁清单

- [x] Branch is based on latest `origin/main`. / 分支基于最新 `origin/main`。
- [x] PR body uses this full template structure. / PR 描述使用本模板完整结构。
- [x] PR body uses two complete language blocks: `# English` first, then `# 中文`. / PR 正文使用两块完整正文：`# English` 在上，`# 中文` 在下。
- [x] PR body passes `tools/check-pr-body-bilingual.mjs`. / PR 正文通过 `tools/check-pr-body-bilingual.mjs`。
- [x] If the PR touches a manifest-derived protected surface, Governance Declaration is filled with ADR/decision/task evidence or break-glass fields. / 若 PR 触碰 manifest 派生的 protected surface，Governance Declaration 已填写 ADR/decision/task 依据或 break-glass 字段。
- [x] No private harness files are included. / 不包含私有 harness 文件。
- [x] No ignored local agent entry files are included. / 不包含被忽略的本地 agent 入口文件。
- [x] No absolute local filesystem paths are included in this public PR body. / 本公开 PR 描述不包含本机绝对路径。
- [x] Public diff is limited to the stated task scope. / 公开 diff 限于声明的任务范围。
- [x] Private planning/evidence updates are recorded when applicable. / 适用时已记录私有计划 / 证据更新。
- [x] Version and publish impact are stated. / 已说明版本与发布影响。
- [x] Local verification commands are recorded honestly. / 已如实记录本地验证命令。
- [ ] CI results are linked or explained. / CI 结果已链接或说明。
- [x] Review evidence is recorded. / 已记录审查证据。
- [x] Open P0/P1/P2 findings are closed, deferred with owner, or explicitly blocked. / open P0/P1/P2 findings 已关闭、带 owner 延后，或明确阻塞。
- [x] Merge method and post-merge branch cleanup plan are clear. / 合并方式和合并后分支清理计划清楚。
- [x] No admin bypass is planned unless explicitly approved and recorded. / 除非明确批准并记录，否则不计划 admin bypass。
