### PR TITLE
perf(kernel): keep relation reads with a fixed endpoint on the endpoint indexes

### DIFF
--- a/packages/daemon/test/artifact-relation-endpoint.integration.test.ts
+++ b/packages/daemon/test/artifact-relation-endpoint.integration.test.ts
@@ -116,7 +116,7 @@ test("A vertical artifact entity is a relation endpoint for its declared triple 
       rebuilt = makeTaskProjection({ rootDir, eventStore: rebuildStore, now: () => "2026-09-04T00:01:00.000Z" });
     try {
       rebuilt.rebuild();
-      const edge = rebuilt.readRelationTruth().edges.find((row) => row.relationId === relationId);
+      const edge = rebuilt.readRelationEdge(relationId);
       assert.equal(edge?.sourceRef, entityRef, "the artifact edge must survive a cold rebuild");
       assert.equal(edge?.state, "active");
     } finally {

--- a/packages/daemon/test/relation-action.integration.test.ts
+++ b/packages/daemon/test/relation-action.integration.test.ts
@@ -258,7 +258,7 @@ test("Relation actions serialize aggregate revisions and reject cycles and stale
   }
 });
 
-test("a depends-on cycle through several hops is rejected and converging paths are not a cycle", async () => {
+test("a depends-on cycle at the end of a long chain is rejected, and converging paths or a deep acyclic walk are not cycles", async () => {
   const rootDir = mkdtempSync(path.join(tmpdir(), "ha-relation-cycle-"));
   initRepo(rootDir);
   const cell = await openRepoCell({
@@ -279,23 +279,27 @@ test("a depends-on cycle through several hops is rejected and converging paths a
       binding,
     );
   try {
-    for (const name of ["a", "b", "c", "d"])
+    const chain = Array.from({ length: 12 }, (_, index) => `c${index + 1}`);
+    for (const name of ["a", "b", "c", "d", ...chain, "x"])
       assert.equal(
         (await cell.run({ kind: "task-create", taskId: `task_cycle_${name}`, title: name }, binding)).outcome,
         "applied",
       );
-    // a -> b -> c, and a -> d -> c: two paths converge on c.
+    // a -> b -> c, and a -> d -> c: two paths converge on c, which then runs c -> c1 -> ... -> c12.
     for (const [source, target] of [
       ["a", "b"],
       ["b", "c"],
       ["a", "d"],
       ["d", "c"],
+      ...["c", ...chain.slice(0, -1)].map((name, index) => [name, chain[index]!]),
     ])
-      assert.equal((await dependsOn(source, target)).outcome, "applied", `${source} -> ${target}`);
+      assert.equal((await dependsOn(source!, target!)).outcome, "applied", `${source} -> ${target}`);
     // d -> b closes no loop: b cannot reach d.
     assert.equal((await dependsOn("d", "b")).outcome, "applied");
-    // c -> a closes a loop through either path.
-    const cycle = await dependsOn("c", "a");
+    // x -> a closes no loop: the walk from a covers the whole 16-task graph and never meets x.
+    assert.equal((await dependsOn("x", "a")).outcome, "applied");
+    // c12 -> a closes a 15-hop loop through either path.
+    const cycle = await dependsOn("c12", "a");
     assert.equal(cycle.outcome, "op_rejected", JSON.stringify(cycle));
     assert.equal(cycle.code, "relation_cycle");
   } finally {

--- a/packages/kernel/src/projection/rebuildable-task-projection-factory.ts
+++ b/packages/kernel/src/projection/rebuildable-task-projection-factory.ts
@@ -214,7 +214,6 @@ export function makeTaskProjectionReader(options: {
       readTaskRuntimeBatch: taskQueries.readTaskRuntimeBatch,
       readRelationQuery: taskQueries.readRelationQuery,
       readOperation: taskQueries.readOperation,
-      readRelationTruth: taskQueries.readRelationTruth,
       readRelationEdge: taskQueries.readRelationEdge,
       readEntityVersionWitness: taskQueries.readEntityVersionWitness,
       readTaskOperation: taskQueries.readTaskOperation,

--- a/packages/kernel/src/projection/rebuildable-task-projection-task-queries.ts
+++ b/packages/kernel/src/projection/rebuildable-task-projection-task-queries.ts
@@ -4,8 +4,6 @@ import { isTaskEvent } from "../domain/doc-sync.contract.ts";
 import { isAgentRuntimeEvent, type AgentRuntimeEventV1 } from "../domain/agent-runtime.ts";
 import { type TaskProgressEventV1 } from "../domain/task-progress-event.ts";
 import { localRuntimeStateFileSystem } from "../local/local-layout-file-system.ts";
-import { readDecisionGraphRows } from "./decision-event-projection.ts";
-import { readFactGraphRows } from "./fact-event-projection.ts";
 import {
   readTaskDependencyClosureRows,
   readTaskRelationNeighborhoodRows,
@@ -30,7 +28,7 @@ import {
   queryRows,
 } from "./rebuildable-task-projection-sql.ts";
 import { readWorkspaceSummaryRows } from "./workspace-summary-projection.ts";
-import { readRelationProjectionRow, readRelationProjectionRows } from "./relation-entity-projection.ts";
+import { readRelationProjectionRow } from "./relation-entity-projection.ts";
 import { readEntityVersionWitness } from "./entity-freshness-projection.ts";
 export type {
   ProjectionPage,
@@ -109,7 +107,6 @@ export function taskQueryApi(
   | "readTaskRuntimeBatch"
   | "readRelationQuery"
   | "readOperation"
-  | "readRelationTruth"
   | "readRelationEdge"
   | "readEntityVersionWitness"
   | "readTaskOperation"
@@ -234,21 +231,6 @@ export function taskQueryApi(
             | { readonly event_json: string }
             | undefined;
         return row === undefined ? null : { event: JSON.parse(row.event_json), watermark: watermark(db) };
-      }),
-    readRelationTruth: () =>
-      withDatabase(projectionPath, readHead, (db) => {
-        const facts = readFactGraphRows(db),
-          decisions = readDecisionGraphRows(db),
-          edges = readRelationProjectionRows(db);
-        return {
-          factAnchors: facts.factAnchors,
-          decisionAnchors: decisions.decisionAnchors,
-          edges,
-          coverageRows: decisions.coverageRows.map((row) => ({
-            ...row,
-            fulfillment: row.fulfillment === "standing_policy" ? ("standing-policy" as const) : row.fulfillment,
-          })),
-        };
       }),
     readRelationEdge: (relationId) =>
       withDatabase(projectionPath, readHead, (db) => readRelationProjectionRow(db, relationId)),

--- a/packages/kernel/src/projection/task-projection-port.ts
+++ b/packages/kernel/src/projection/task-projection-port.ts
@@ -33,7 +33,6 @@ import type {
   TaskRuntimeBatchRead,
   WorkspaceSummaryProjectionRead,
 } from "./projection-reads.ts";
-import type { EventBackedRelationTruth } from "./relation-graph-projection.ts";
 import type { VersionedRelationProjectionRow } from "./relation-entity-projection.ts";
 import type { EntityFreshness, EntityVersion, EntityVersionWitness } from "../domain/entity-freshness.ts";
 import type { ProjectionPage, TaskProjectionListQuery, TaskRelationQuery } from "./task-query-projection.ts";
@@ -103,7 +102,6 @@ export interface TaskProjection {
   readonly readTaskRuntimeBatch: (query: TaskRuntimeBatchQuery) => TaskRuntimeBatchRead;
   readonly readRelationQuery: (query?: TaskRelationQuery) => TaskRelationProjectionRead;
   readonly readOperation: (opId: string) => { readonly event: CanonicalEventV1; readonly watermark: number } | null;
-  readonly readRelationTruth: () => EventBackedRelationTruth;
   readonly readRelationEdge: (relationId: string) => VersionedRelationProjectionRow | null;
   readonly readEntityVersionWitness: (entityRef: string) => EntityVersionWitness;
   readonly readDecisionDocumentState?: (decisionId: string) => DecisionDocumentState | null;

--- a/packages/kernel/src/projection/task-query-projection.ts
+++ b/packages/kernel/src/projection/task-query-projection.ts
@@ -660,7 +660,11 @@ export function readTaskRelationPage(
     "WHERE event_index.workspace_revision = relation_edge.workspace_revision) AS updated_at",
     "FROM relation_edge",
   ].join(" ");
-  const where: string[] = [],
+  // With an endpoint fixed, its source or target index finds that endpoint's few edges. Unary +
+  // keeps the type and state filters from steering SQLite to their own indexes instead, which
+  // visit every edge of that type or state in the repository.
+  const residual = query.entity !== undefined || query.source !== undefined || query.target !== undefined ? "+" : "",
+    where: string[] = [],
     values: (string | number)[] = [];
   if (query.entity !== undefined) {
     where.push("(source_ref = ? OR target_ref = ?)");
@@ -675,11 +679,11 @@ export function readTaskRelationPage(
     values.push(query.target);
   }
   if (query.relationType !== undefined) {
-    where.push("relation_type = ?");
+    where.push(`${residual}relation_type = ?`);
     values.push(query.relationType);
   }
   if (query.state !== undefined) {
-    where.push("state = ?");
+    where.push(`${residual}state = ?`);
     values.push(query.state);
   }
   if (query.ownerRef !== undefined) {

--- a/packages/kernel/test/store/agent-runtime.test.ts
+++ b/packages/kernel/test/store/agent-runtime.test.ts
@@ -140,11 +140,7 @@ test("runtime events use the canonical envelope, head, store, and the shared pro
       semanticState: "succeeded",
     });
     const executionRelation = runtimeTaskExecutionRelation("runtime-session-claude", "task-runtime");
-    assert.equal(
-      projection.readRelationTruth().edges.filter(({ relationId }) => relationId === executionRelation.relation_id)
-        .length,
-      1,
-    );
+    assert.equal(projection.readRelationEdge(executionRelation.relation_id)?.relationId, executionRelation.relation_id);
     assert.deepEqual(
       projection.readRuntimeSessionsForTask("task-runtime").map((value) => value.runtimeSessionId),
       ["runtime-session-claude"],

--- a/packages/kernel/test/store/projection-identity-binding.test.ts
+++ b/packages/kernel/test/store/projection-identity-binding.test.ts
@@ -70,28 +70,23 @@ test("projection cache identity mismatch is explicit and rebuild remains availab
   });
 });
 
-test("event relation truth cannot cross a same-revision ledger identity", async () => {
+test("the fact graph cannot cross a same-revision ledger identity", async () => {
   await withTempStoreAsync(async (rootA) => {
     await withTempStoreAsync(async (rootB) => {
       const storeA = seedFactLedger(rootA),
         storeB = seedLedger(rootB, "relation-empty", "# Notes\n\nEmpty ledger.\n"),
         projectionA = makeTaskProjection({ rootDir: rootA, eventStore: storeA });
       projectionA.rebuild();
-      projectionA.readFactGraph();
       assert.deepEqual(
-        projectionA.readRelationTruth().factAnchors.map(({ factRef }) => factRef),
+        projectionA.readFactGraph().factAnchors.map(({ factRef }) => factRef),
         ["fact/F-12345678"],
       );
       projectionA.close();
       const projectionB = makeTaskProjection({ rootDir: rootB, eventStore: storeB, projectionPath: projectionA.path });
-      assert.throws(() => projectionB.readRelationTruth(), /projection cache ledger identity mismatch/iu);
+      assert.throws(() => projectionB.readFactGraph(), /projection cache ledger identity mismatch/iu);
       projectionB.rebuild();
-      assert.deepEqual(projectionB.readRelationTruth(), {
-        factAnchors: [],
-        decisionAnchors: [],
-        edges: [],
-        coverageRows: [],
-      });
+      const rebuilt = projectionB.readFactGraph();
+      assert.deepEqual([rebuilt.factAnchors, rebuilt.edges, rebuilt.facts], [[], [], []]);
     });
   });
 });

--- a/packages/kernel/test/store/task-query-projection.test.ts
+++ b/packages/kernel/test/store/task-query-projection.test.ts
@@ -12,7 +12,12 @@ import {
 } from "../../src/projection/fact-event-projection.ts";
 import { deriveRelationId, type EntityRelationRecord } from "../../src/domain/entity-relation.ts";
 import { createRelationGraphProjectionTables } from "../../src/projection/relation-graph-projection.ts";
-import { readTaskRelationNeighborhoodRows } from "../../src/projection/task-query-projection.ts";
+import {
+  createTaskRelationProjectionTable,
+  readTaskRelationNeighborhoodRows,
+  readTaskRelationPage,
+  type TaskRelationQuery,
+} from "../../src/projection/task-query-projection.ts";
 import { REPLAY_TASK_GRAPH } from "../../src/domain/task-graph.ts";
 import type { CanonicalEventV1 } from "../../src/domain/doc-sync.contract.ts";
 import type { TaskEventV1 } from "../../src/domain/task-lifecycle.contract.ts";
@@ -700,4 +705,98 @@ test("fact search liveness reads only supersedes edges, however many facts and e
   } finally {
     db.close();
   }
+});
+
+test("a relation read with a fixed endpoint searches only that endpoint's edges, however many other edges exist", () => {
+  // Both tables hold a 60-hop depends-on chain plus unrelated depends-on and relates edges. A read that
+  // lets the type or state index drive visits every edge of that type or state on each call; the cycle
+  // check on relation relate makes one such call per hop, and entity import makes one per write.
+  const queries: readonly TaskRelationQuery[] = [
+    { source: "task/chain-30", relationType: "depends-on", state: "active" },
+    { target: "task/chain-30", state: "active" },
+    { entity: "task/chain-30", state: "active" },
+  ];
+  const shapes = [200, 5000].map((unrelated) => {
+    const db = new DatabaseSync(":memory:");
+    try {
+      createRelationGraphProjectionTables(db);
+      createTaskRelationProjectionTable(db);
+      db.exec(
+        "CREATE TABLE IF NOT EXISTS event_index (op_id TEXT PRIMARY KEY, workspace_revision INTEGER NOT NULL UNIQUE, task_id TEXT, event_json TEXT NOT NULL)",
+      );
+      const edge = db.prepare("INSERT INTO relation_edge VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)"),
+        mirror = db.prepare("INSERT INTO task_relation VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)");
+      let revision = 0;
+      const add = (source: string, target: string, type: string) => {
+        revision += 1;
+        const id = `rel-${String(revision).padStart(8, "0")}`;
+        edge.run(id, source, target, type, "active", null, source, revision, JSON.stringify({ relationId: id }));
+        mirror.run(
+          id,
+          source.slice(5),
+          source,
+          target,
+          type,
+          "directed",
+          "hard",
+          "authored",
+          "active",
+          "",
+          source,
+          "",
+          0,
+          revision,
+          "",
+        );
+      };
+      db.exec("BEGIN");
+      for (let hop = 0; hop < 60; hop += 1) add(`task/chain-${hop}`, `task/chain-${hop + 1}`, "depends-on");
+      for (let index = 0; index < unrelated; index += 1) {
+        add(`task/other-${index}`, `task/other-${index + 1}`, "depends-on");
+        add(`task/other-${index}`, "task/hub", "relates");
+      }
+      db.exec("COMMIT");
+      const original = db.prepare,
+        statements: string[] = [];
+      db.prepare = ((sql: string) => {
+        statements.push(sql);
+        return original.call(db, sql);
+      }) as typeof db.prepare;
+      return queries.map((query) => {
+        statements.length = 0;
+        const rows = readTaskRelationPage(db, query).rows.map((row) => `${row.sourceRef}>${row.targetRef}`),
+          sql = statements.find((statement) => statement.includes("UNION ALL"))!,
+          values = [query.entity, query.entity, query.source, query.target, query.relationType, query.state].filter(
+            (value) => value !== undefined,
+          ),
+          plan = (original.call(db, `EXPLAIN QUERY PLAN ${sql}`).all(...values) as { detail: string }[])
+            .map(({ detail }) => detail)
+            .filter(
+              (detail) => /\b(task_relation|relation_edge)\b/u.test(detail) && !/\(relation_id=\?\)/u.test(detail),
+            );
+        return { rows, plan };
+      });
+    } finally {
+      db.close();
+    }
+  });
+  for (const [index, query] of queries.entries()) {
+    const [small, large] = [shapes[0]![index]!, shapes[1]![index]!];
+    assert.deepEqual(large.rows, small.rows, JSON.stringify(query));
+    assert.ok(small.plan.length >= 2, `${JSON.stringify(query)} plan: ${small.plan.join("; ")}`);
+    for (const detail of [...small.plan, ...large.plan])
+      assert.match(
+        detail,
+        /^SEARCH \w+ USING (?:COVERING )?INDEX \w+ \((?:source_ref|target_ref)=\?\)$/u,
+        JSON.stringify(query),
+      );
+  }
+  assert.deepEqual(
+    shapes[1]!.map(({ rows }) => rows),
+    [
+      ["task/chain-30>task/chain-31"],
+      ["task/chain-29>task/chain-30"],
+      ["task/chain-29>task/chain-30", "task/chain-30>task/chain-31"],
+    ],
+  );
 });


### PR DESCRIPTION
# English

## Summary

PR #2447 moved the depends-on cycle check and the entity import relation count onto `readRelationQuery` with a fixed endpoint. An independent review found that SQLite still did not search by that endpoint:

- Cycle check, `{ source, relationType: "depends-on", state: "active" }`: the task_relation arm chose `task_relation_type (relation_type=? AND state=?)`. Every hop visited every active depends-on edge in the repository, so one relate cost (nodes walked) × (all depends-on edges).
- Import count, `{ entity, state: "active" }`: the relation_edge arm chose `relation_edge_state_page (state=?)` and visited every active edge.

Now, when a source, target or entity filter is present, the query builder writes the type and state filters with unary `+`. SQLite then can only choose the source and target indexes on both arms, and applies type and state to the few rows they return. Queries with no endpoint are unchanged.

This PR also deletes `readRelationTruth`, which read the whole fact graph, decision graph and relation table and has no production caller left.

## Architectural Justification

-

## What Changed

- `task-query-projection.ts` `readTaskRelationPage`: `+relation_type = ?` and `+state = ?` when an endpoint is fixed.
- `readRelationTruth` removed from `TaskProjection`, the factory and the task queries. Three tests now read the same rows through `readRelationEdge` and `readFactGraph`.
- `task-query-projection.test.ts`: a new test builds a 60-hop chain with 200 and with 5,000 unrelated depends-on and relates edges, and checks that every table access in the three endpoint queries searches by `source_ref` or `target_ref`, and that the rows are the same at both scales.
- `relation-action.integration.test.ts`: the cycle test now closes a 15-hop loop, and also accepts an edge whose check walks the whole 16-task graph without finding a cycle.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Deleted code (no whole file): `TaskProjection.readRelationTruth` and its implementation.
- Production net lines: +8/-25 (net -17), from `node tools/gates/production-delta.mjs --base origin/main`.

## Machine-Readable Declarations

- No dependency change or event migration; no machine-readable declarations.

## Task And Scope

- Harness task: task_644341526c2540f75649959928
- Branch: `codex/f5-hop-index`
- Public scope: index choice of relation reads with a fixed endpoint; removal of `readRelationTruth`
- Private planning/evidence updated: yes (task report, review response, CEO scope ruling in task_plan)
- Out of scope: `reckon`'s whole-graph coverage read, moved to task_5c22671ab8bb95ec563d6d6a23 by a scope ruling; the decision `ownerRef` read, which has no index on either table (schema change)

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: not applicable
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `8a0213695`
- Branch merge-base with `origin/main`: `8a0213695`
- Last `git fetch origin` time: 2026-09-11 UTC
- Sync method: branched from origin/main
- Public diff command: `git diff origin/main...codex/f5-hop-index`
- Private evidence commit/path: task_644341526c2540f75649959928 task package report
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [x] `npm run typecheck` (as `npx tsc -b packages/kernel packages/daemon packages/application`, no errors)
- [ ] `npm test`
- [x] `npm run harness:check-import-boundaries` (via `run-manifest-gates --changed origin/main`)
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts` (via `run-manifest-gates --changed origin/main`)
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Negative control: with `task-query-projection.ts` from main, the new plan test fails on `SEARCH task_relation USING INDEX task_relation_type (relation_type=? AND state=?)`.
- Scale, with the real `readTaskRelationPage` on in-memory tables built by the real schema functions (main → this branch):
  - Full cycle-check walk over a chain of 1,000 / 2,000 / 5,000: 152 / 416 / 1,957 ms → 92 / 177 / 461 ms. Main grows with the square of chain length, this branch linearly.
  - A 100-hop walk with 0 / 10,000 / 100,000 unrelated depends-on edges: 11.6 / 67.6 / 722 ms → 10.6 / 9.5 / 8.4 ms.
  - Import count with 1,000 / 10,000 / 100,000 edges: 0.183 / 0.933 / 8.391 ms → 0.112 / 0.123 / 0.117 ms per read.
- Real data (read-only copy of the canonical projection): the entity query takes 12.5 ms → 3.7 ms for the most-connected target and returns the same 488 rows; the hop query now searches `task_relation_source` and `relation_edge_source`.
- Tests: `task-query-projection` 10/10, `agent-runtime` 10/10, `projection-identity-binding` 3/3, `task-projection` 27/27, `task-read-set` 8/8, `task-query-read` 9/9, `fact-retirement-completion` 2/2, cli `thin-command` 19/19. On Ubuntu through `dispatch-isolated-test`: `relation-action.integration` 2/2, `artifact-relation-endpoint` 1/1, `task-read-set.integration` 1/1, `task-surface` 4/4, `task-surface-pages-facts` 2/2, `task-surface-reads-leases` 4/4.
- Gates: `run-manifest-gates --changed origin/main`, `check-file-complexity`, `check-fallback-boundaries`, `line-density`, `production-delta` and G1 `cost-budget` pass.

## Review Evidence

- The independent closeout review of PR #2447 (changes requested) found the index choice and the missing scale evidence. This PR answers both; the same reviewer re-reviews the task after merge.
- Reviewer subagent: not used
- Human review: pending
- Blocking findings: none open

## Residual Risk

- Unary `+` is a planner hint written into the SQL. A future index that includes `relation_type` or `state` after the endpoint would not be used for those columns when an endpoint is fixed; the endpoint alone already narrows to a handful of rows.
- The decision `ownerRef` read still scans both tables inside SQLite (no index on `owner_ref`).

## References

- Task: task_644341526c2540f75649959928; follow-up task_5c22671ab8bb95ec563d6d6a23
- PR #2447

---

# 中文

## 概要

PR #2447 把 depends-on 环检测和 entity import 的关系计数改成了固定端点的 `readRelationQuery`。独立评审发现 SQLite 仍然没有按端点查找：

- 环检测 `{ source, relationType: "depends-on", state: "active" }`：task_relation 臂选了 `task_relation_type (relation_type=? AND state=?)`。每一跳都访问仓库里全部 active 的 depends-on 边，所以一次 relate 的代价是（走过的节点数）×（全部 depends-on 边数）。
- 导入计数 `{ entity, state: "active" }`：relation_edge 臂选了 `relation_edge_state_page (state=?)`，访问全部 active 边。

现在，查询带 source、target 或 entity 过滤时，构造器给 type 和 state 过滤加一元 `+`。SQLite 在两臂上都只能选 source 和 target 索引，再在它们找到的少数行上按 type 和 state 过滤。不带端点的查询不变。

本 PR 同时删除 `readRelationTruth`：它读出整个 fact 图、decision 图和关系表，已经没有生产调用方。

## 架构辩护

-

## 改动内容

- `task-query-projection.ts` 的 `readTaskRelationPage`：固定端点时写成 `+relation_type = ?` 与 `+state = ?`。
- 从 `TaskProjection`、工厂和 task queries 中删除 `readRelationTruth`。三个测试改为经 `readRelationEdge` 与 `readFactGraph` 读同样的行。
- `task-query-projection.test.ts`：新测试构造一条 60 跳的链，分别加 200 条和 5,000 条无关的 depends-on 与 relates 边，检查三种端点查询对两张表的每次访问都按 `source_ref` 或 `target_ref` 查找，且两档规模下返回的行相同。
- `relation-action.integration.test.ts`：环检测测试现在会闭合一个 15 跳的环；另有一条边的检查会走完整个 16 个任务的图、找不到环，应被接受。

## 门收割 / Gate Harvest

- 删除的生产路径：none（没有删除整个文件）
- 删除的门或 fixture：none
- 删除的代码：`TaskProjection.readRelationTruth` 及其实现。
- 生产净行数：+8/-25（net -17），由 `node tools/gates/production-delta.mjs --base origin/main` 计算。

## 机读声明说明

- 本 PR 不涉及依赖变化和事件迁移，没有机读声明。

## 任务与范围

- Harness 任务：task_644341526c2540f75649959928
- 分支：`codex/f5-hop-index`
- 公开范围：固定端点的关系读取的索引选择；删除 `readRelationTruth`
- 私有计划 / 证据是否已更新：yes（任务报告、评审回应、task_plan 中的 CEO 范围裁决）
- 范围外：`reckon` 的全图覆盖读取，按范围裁决移交 task_5c22671ab8bb95ec563d6d6a23；decision 的 `ownerRef` 读取，两张表上都没有该列的索引（需要改 schema）

## 版本影响

- 版本：不改版本
- 发布影响：不发布

## 治理声明

- 是否触碰 protected surface：no
- protected surface 范围：不适用
- 依据：不适用
- 机器检查边界：本 PR 只声明该段存在；声明是否真实、充分，由 reviewer 判断。
- Break-glass：no
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- `origin/main` 基准 SHA：`8a0213695`
- 当前分支与 `origin/main` 的 merge-base：`8a0213695`
- 最近一次 `git fetch origin` 时间：2026-09-11 UTC
- 同步方式：从 origin/main 开分支
- 公开 diff 命令：`git diff origin/main...codex/f5-hop-index`
- 私有证据 commit/path：task_644341526c2540f75649959928 任务包报告
- Reviewer 证据路径：见本 PR 的「审查证据」一节
- GitHub Actions `rewrite-ci` run URL：本 PR 的 CI 还在跑
- [ ] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [x] `npm run typecheck`（以 `npx tsc -b packages/kernel packages/daemon packages/application` 运行，无错误）
- [ ] `npm test`
- [x] `npm run harness:check-import-boundaries`（经 `run-manifest-gates --changed origin/main`）
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts`（经 `run-manifest-gates --changed origin/main`）
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- 阴性对照：换回 main 的 `task-query-projection.ts`，新的计划测试在 `SEARCH task_relation USING INDEX task_relation_type (relation_type=? AND state=?)` 处失败。
- 规模对照：用真实的 `readTaskRelationPage`，在由真实 schema 函数建出的内存表上测（main → 本分支）：
  - 链长 1,000 / 2,000 / 5,000 的完整环检测遍历：152 / 416 / 1,957 ms → 92 / 177 / 461 ms。main 随链长平方增长，本分支线性增长。
  - 100 跳遍历，另有 0 / 10,000 / 100,000 条无关 depends-on 边：11.6 / 67.6 / 722 ms → 10.6 / 9.5 / 8.4 ms。
  - 1,000 / 10,000 / 100,000 条边时的导入计数：每次 0.183 / 0.933 / 8.391 ms → 0.112 / 0.123 / 0.117 ms。
- 真实数据（canonical projection 的只读副本）：对连接最多的 target，entity 查询 12.5 ms → 3.7 ms，返回同样的 488 行；hop 查询现在走 `task_relation_source` 与 `relation_edge_source`。
- 测试：`task-query-projection` 10/10、`agent-runtime` 10/10、`projection-identity-binding` 3/3、`task-projection` 27/27、`task-read-set` 8/8、`task-query-read` 9/9、`fact-retirement-completion` 2/2、cli `thin-command` 19/19。经 `dispatch-isolated-test` 在 Ubuntu 上：`relation-action.integration` 2/2、`artifact-relation-endpoint` 1/1、`task-read-set.integration` 1/1、`task-surface` 4/4、`task-surface-pages-facts` 2/2、`task-surface-reads-leases` 4/4。
- 门：`run-manifest-gates --changed origin/main`、`check-file-complexity`、`check-fallback-boundaries`、`line-density`、`production-delta` 与 G1 `cost-budget` 通过。

## 审查证据

- PR #2447 的独立收口评审（changes requested）指出了索引选择问题和规模证据缺失。本 PR 回应这两条；合并后由同一评审者复审该任务。
- Reviewer subagent：未使用
- 人工审查：待进行
- 阻塞发现：无未处理项

## 残余风险

- 一元 `+` 是写进 SQL 的规划器提示。以后如果新建一个在端点列之后包含 `relation_type` 或 `state` 的索引，固定端点时这两列不会用上该索引；只按端点已经能收窄到少数几行。
- decision 的 `ownerRef` 读取仍在 SQLite 内扫描两张表（`owner_ref` 没有索引）。

## 关联材料

- Task: task_644341526c2540f75649959928；后继 task_5c22671ab8bb95ec563d6d6a23
- PR #2447

---

## PR Gate Checklist / PR 门禁清单

- [x] Branch is based on latest `origin/main`. / 分支基于最新 `origin/main`。
- [x] PR body uses this full template structure. / PR 描述使用本模板完整结构。
- [x] PR body uses two complete language blocks: `# English` first, then `# 中文`. / PR 正文使用两块完整正文：`# English` 在上，`# 中文` 在下。
- [x] PR body passes `tools/check-pr-body-bilingual.mjs`. / PR 正文通过 `tools/check-pr-body-bilingual.mjs`。
- [x] If the PR touches a manifest-derived protected surface, Governance Declaration is filled with ADR/decision/task evidence or break-glass fields. / 若 PR 触碰 manifest 派生的 protected surface，Governance Declaration 已填写 ADR/decision/task 依据或 break-glass 字段。
- [x] No private harness files are included. / 不包含私有 harness 文件。
- [x] No ignored local agent entry files are included. / 不包含被忽略的本地 agent 入口文件。
- [x] No absolute local filesystem paths are included in this public PR body. / 本公开 PR 描述不包含本机绝对路径。
- [x] Public diff is limited to the stated task scope. / 公开 diff 限于声明的任务范围。
- [x] Private planning/evidence updates are recorded when applicable. / 适用时已记录私有计划 / 证据更新。
- [x] Version and publish impact are stated. / 已说明版本与发布影响。
- [x] Local verification commands are recorded honestly. / 已如实记录本地验证命令。
- [ ] CI results are linked or explained. / CI 结果已链接或说明。
- [x] Review evidence is recorded. / 已记录审查证据。
- [x] Open P0/P1/P2 findings are closed, deferred with owner, or explicitly blocked. / open P0/P1/P2 findings 已关闭、带 owner 延后，或明确阻塞。
- [x] Merge method and post-merge branch cleanup plan are clear. / 合并方式和合并后分支清理计划清楚。
- [x] No admin bypass is planned unless explicitly approved and recorded. / 除非明确批准并记录，否则不计划 admin bypass。
