### PR TITLE
fix(gui): dynamically derive agent runtime kinds in AgentCard

### DIFF
--- a/packages/gui/src/renderer/components/runtime/AgentCard.tsx
+++ b/packages/gui/src/renderer/components/runtime/AgentCard.tsx
@@ -9,6 +9,7 @@ import type {
   SquadEntityAvailableRow,
 } from "../../agent-entity-client.ts";
 import { t } from "../../i18n/index.tsx";
+import { RUNTIME_KIND_IDS } from "../../runtime-provider-planes.ts";
 import { EntityRefLink } from "../EntityRefLink.tsx";
 import { ViewInGraphButton } from "../ViewInGraphButton.tsx";
 import {
@@ -380,9 +381,7 @@ export function AgentCard({
               onChange={(runtimeType) => patch({ runtimeType })}
               options={[
                 { value: "any", label: t("agentRuntime.anyRuntime") },
-                { value: "claude", label: "claude" },
-                { value: "codex", label: "codex" },
-                { value: "agy", label: "agy" },
+                ...RUNTIME_KIND_IDS.map((kindId) => ({ value: kindId, label: kindId })),
               ]}
             />
             <Hint>{t("agentRuntime.compatibleCount", { count: compatible.length })}</Hint>

--- a/packages/gui/src/renderer/i18n/locales/en-US/agentRuntime.json
+++ b/packages/gui/src/renderer/i18n/locales/en-US/agentRuntime.json
@@ -118,7 +118,7 @@
   "agentRuntime.dispatchWithPrompt": "Dispatch with this",
   "agentRuntime.runtimeConstraint": "Runtime constraint",
   "agentRuntime.runtimeConstraintDesc": "Declares a type, never an instance — the instance is chosen at dispatch",
-  "agentRuntime.runtimeConstraintNote": "An agent declaration binds no concrete runtime instance. The same role can run on claude, codex, or agy.",
+  "agentRuntime.runtimeConstraintNote": "An agent declaration binds no concrete runtime instance. The same role can run on claude, codex, agy, or zcode.",
   "agentRuntime.anyRuntime": "any",
   "agentRuntime.expand": "Expand",
   "agentRuntime.collapse": "Collapse",

--- a/packages/gui/src/renderer/i18n/locales/zh-CN/agentRuntime.json
+++ b/packages/gui/src/renderer/i18n/locales/zh-CN/agentRuntime.json
@@ -118,7 +118,7 @@
   "agentRuntime.dispatchWithPrompt": "用这条派活",
   "agentRuntime.runtimeConstraint": "Runtime 约束",
   "agentRuntime.runtimeConstraintDesc": "只声明类型,不绑定实例 —— 派活时再分配",
-  "agentRuntime.runtimeConstraintNote": "Agent 定义不绑定具体 Runtime 实例。同一个角色可以跑在 claude、codex 或 agy 上。",
+  "agentRuntime.runtimeConstraintNote": "Agent 定义不绑定具体 Runtime 实例。同一个角色可以跑在 claude、codex、agy 或 zcode 上。",
   "agentRuntime.anyRuntime": "任意兼容",
   "agentRuntime.expand": "展开",
   "agentRuntime.collapse": "收起",

--- a/packages/gui/test/agent-runtime-renderer.vitest.ts
+++ b/packages/gui/test/agent-runtime-renderer.vitest.ts
@@ -611,6 +611,7 @@ describe("agent runtime renderer", () => {
       "Lead the squad. Decide before dispatch.",
       "commander",
       "claude",
+      "zcode",
       "review",
       "triage",
       "daily-plan",


### PR DESCRIPTION
# English

## Summary

Derive agent runtime kind radio options dynamically from `RUNTIME_KIND_IDS` in `AgentCard.tsx` instead of hardcoding `'any' | 'claude' | 'codex' | 'agy'`. This allows any newly registered runtime kind (such as `zcode`) to be rendered and selected in the AgentCard runtime constraint section. Also updates i18n notes and renderer vitest suite.

## Architectural Justification

-

## What Changed

- `packages/gui/src/renderer/components/runtime/AgentCard.tsx`: Replaced hardcoded `options` array with dynamic mapping over `RUNTIME_KIND_IDS`.
- `packages/gui/src/renderer/i18n/locales/en-US/agentRuntime.json`: Updated `runtimeConstraintNote` to state that agent definitions apply to all configured runtime kinds including zcode.
- `packages/gui/src/renderer/i18n/locales/zh-CN/agentRuntime.json`: Updated Chinese `runtimeConstraintNote` localization.
- `packages/gui/test/agent-runtime-renderer.vitest.ts`: Added test assertion proving `zcode` option is properly rendered in AgentCard.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: see the computed production-delta job summary.

## Machine-Readable Declarations

## Task And Scope

- Harness task: task_gui_agent_runtime_kinds
- Branch: codex/gui-agent-runtime-kinds
- Public scope: GUI AgentCard runtime selection options
- Private planning/evidence updated: not applicable
- Out of scope: Backend runtime instance execution or provider credentials

## Version Impact

- Version: no version change because internal GUI component enhancement
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: not applicable
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: 8f437e6c5
- Branch merge-base with `origin/main`: 8f437e6c5
- Last `git fetch origin` time: 2026-09-11 UTC
- Sync method: rebase
- Public diff command: `git diff origin/main...codex/gui-agent-runtime-kinds`
- Private evidence commit/path: not applicable
- Reviewer evidence path: not applicable
- GitHub Actions `rewrite-ci` run URL: N/A
- [x] `git diff --check`
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run test:gui -w @harness-anything/gui` (89 passed, 989 tests passed)
- [x] G33 production-delta: pass (+3/-3, net 0)

## Review Evidence

- Self-review: Verified dynamic mapping over `RUNTIME_KIND_IDS`, typecheck, lint, and all vitest unit tests pass.
- Reviewer subagent: not applicable
- Human review: pending maintainer review
- Blocking findings: none

## Residual Risk

- Low risk: `RUNTIME_KIND_IDS` is a constant array of known runtime kinds from kernel domain; expanding it adds options without breaking existing agent definitions.

## References

- Task: task_gui_agent_runtime_kinds
- Evidence: local test run
- Review: pending

---

# 中文

## 概要

将 `AgentCard.tsx` 中的 Agent Runtime 约束单选框选项由原本硬编码的 `['any', 'claude', 'codex', 'agy']` 改造为通过 `RUNTIME_KIND_IDS` 动态推导映射。这使得新注册的运行时类型（例如 `zcode`）能够自动在 AgentCard 中展示和被选择，并同步更新了中英双语国际化文案与组件单元测试。

## 架构辩护

-

## 改动内容

- `packages/gui/src/renderer/components/runtime/AgentCard.tsx`：引入 `RUNTIME_KIND_IDS`，将单选框选项列表由硬编码字符串数组改造为动态映射。
- `packages/gui/src/renderer/i18n/locales/en-US/agentRuntime.json`：更新英文 `runtimeConstraintNote` 文案，补充新运行时支持说明。
- `packages/gui/src/renderer/i18n/locales/zh-CN/agentRuntime.json`：更新中文 `runtimeConstraintNote` 文案。
- `packages/gui/test/agent-runtime-renderer.vitest.ts`：增加测试断言，验证单选框中正确渲染出 `zcode` 选项。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 同 commit 删除的门 / fixture：none
- 生产净行数：见 computed production-delta 计算结果。

## 机读声明说明

- 本 PR 不涉及依赖变动或事件样本迁移，无未注释机读声明。

## 任务与范围

- Harness 任务：task_gui_agent_runtime_kinds
- 分支：`codex/gui-agent-runtime-kinds`
- 公开范围：GUI AgentCard 运行时选项动态渲染
- 私有计划 / 证据是否已更新：not applicable
- 范围外：后端运行时实例配置与凭据存储

## 版本影响

- 版本：不改版本，原因是纯前端组件选项动态映射优化
- 发布影响：不发布

## 治理声明

- 是否触碰 protected surface：no
- protected surface 范围：不适用
- 依据：不适用
- 机器检查边界：本 PR 只声明该段存在；声明是否真实、充分，由 reviewer 判断。
- Break-glass：no
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- `origin/main` 基准 SHA：`8f437e6c5`
- 当前分支与 `origin/main` 的 merge-base：`8f437e6c5`
- 最近一次 `git fetch origin` 时间：2026-09-11 UTC
- 同步方式：rebase
- 公开 diff 命令：`git diff origin/main...codex/gui-agent-runtime-kinds`
- 私有证据 commit/path：不适用
- Reviewer 证据路径：不适用
- GitHub Actions `rewrite-ci` run URL：待 CI 触发
- [x] `git diff --check`
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run test:gui -w @harness-anything/gui`（89 个文件，989 个测试全部通过）
- [x] G33 production-delta 验证通过（+3/-3，净增 0）

## 审查证据

- 自查：已核对代码逻辑，`RUNTIME_KIND_IDS` 动态映射完整覆盖已知类型，测试全绿。
- Reviewer subagent：不适用
- 人工审查：待 maintainer 审查
- 阻塞发现：无

## 残余风险

- 低风险：`RUNTIME_KIND_IDS` 是 Kernel 领域层导出的稳定常量数组，动态推导不会破坏现有 Agent 声明。

## 关联材料

- 任务：task_gui_agent_runtime_kinds
- 证据：本地测试与构建记录
- 审查：待审查

---

## PR Gate Checklist / PR 门禁清单

- [x] Branch is based on latest `origin/main`. / 分支基于最新 `origin/main`。
- [x] PR body uses this full template structure. / PR 描述使用本模板完整结构。
- [x] PR body uses two complete language blocks: `# English` first, then `# 中文`. / PR 正文使用两块完整正文：`# English` 在上，`# 中文` 在下。
- [x] PR body passes `tools/check-pr-body-bilingual.mjs`. / PR 正文通过 `tools/check-pr-body-bilingual.mjs`。
- [x] If the PR touches a manifest-derived protected surface, Governance Declaration is filled with ADR/decision/task evidence or break-glass fields. / 若 PR 触碰 manifest 派生的 protected surface，Governance Declaration 已填写 ADR/decision/task 依据或 break-glass 字段。
- [x] No private harness files are included. / 不包含私有 harness 文件。
- [x] No ignored local agent entry files are included. / 不包含被忽略的本地 agent 入口文件。
- [x] No absolute local filesystem paths are included in this public PR body. / 本公开 PR 描述不包含本机绝对路径。
- [x] Public diff is limited to the stated task scope. / 公开 diff 限于声明的任务范围。
- [x] Private planning/evidence updates are recorded when applicable. / 适用时已记录私有计划 / 证据更新。
- [x] Version and publish impact are stated. / 已说明版本与发布影响。
- [x] Local verification commands are recorded honestly. / 已如实记录本地验证命令。
- [ ] CI results are linked or explained. / CI 结果已链接或说明。
- [x] Review evidence is recorded. / 已记录审查证据。
- [x] Open P0/P1/P2 findings are closed, deferred with owner, or explicitly blocked. / open P0/P1/P2 findings 已关闭、带 owner 延后，或明确阻塞。
- [x] Merge method and post-merge branch cleanup plan are clear. / 合并方式和合并后分支清理计划清楚。
- [x] No admin bypass is planned unless explicitly approved and recorded. / 除非明确批准并记录，否则不计划 admin bypass。
