### PR TITLE
fix(kernel): cap Windows git pathspec batch size to stay within cmd.exe 8191 limit

### DIFF
--- a/packages/kernel/src/store/local-version-control-system.ts
+++ b/packages/kernel/src/store/local-version-control-system.ts
@@ -33,9 +33,10 @@ import { makeLocalVersionControlCommands } from "./local-version-control-command
 const gitMaxBuffer = 256 * 1024 * 1024,
   gitBatchChunkBytes = 64 * 1024 * 1024,
   gitBatchChunkEntries = 4_096,
-  // Windows CreateProcess limits the quoted command line to 32,767 UTF-16 characters.
-  // Leave room for quoting and Git's fixed arguments; POSIX keeps the measured batch size.
-  gitPathspecChunkBytes = (process.platform === "win32" ? 8 : 128) * 1024;
+  // Windows CreateProcess limits the quoted command line to 32,767 UTF-16 characters, but
+  // cmd.exe /d /s /c limits the command line to 8,191 characters.
+  // Leave room for quoting, repo path, and Git's fixed arguments; 4 KiB safely fits.
+  gitPathspecChunkBytes = (process.platform === "win32" ? 4 : 128) * 1024;
 
 export function makeLocalVersionControlSystem(): VersionControlSystem {
   return makeLocalVersionControlCommands({


### PR DESCRIPTION
# English

## Summary

Cap Windows `gitPathspecChunkBytes` to 4 KiB instead of 8 KiB in `local-version-control-system.ts`. On Windows, git subcommands invoked via `cmd.exe /d /s /c` or standard shell wrappers hit the 8,191-character command line length limit. A chunk size of 8 KiB (8,192 bytes) exceeds this threshold when batching large lists of paths, resulting in `git --literal-pathspecs failed: 命令行太长。` errors during ledger/store replay. Lowering the batch chunk limit to 4 KiB safely keeps invocations within the boundary while preserving high batching efficiency.

## Architectural Justification

-

## What Changed

- `packages/kernel/src/store/local-version-control-system.ts`: Changed the Windows branch for `gitPathspecChunkBytes` from `8 * 1024` to `4 * 1024` (4,096 bytes), leaving ample budget for git executable path, flags, and quoting within the 8,191-character limit.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: see the computed production-delta job summary.

## Machine-Readable Declarations

## Task And Scope

- Harness task: task_windows_git_pathspec_batch_limit
- Branch: codex/windows-git-pathspec-batch-limit
- Public scope: Windows git pathspec batch chunk size in kernel VCS store
- Private planning/evidence updated: not applicable
- Out of scope: POSIX platform pathspec sizing (retains 128 KiB)

## Version Impact

- Version: no version change because internal kernel storage performance/compatibility bugfix
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: not applicable
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: 8f437e6c5
- Branch merge-base with `origin/main`: 8f437e6c5
- Last `git fetch origin` time: 2026-09-11 UTC
- Sync method: rebase
- Public diff command: `git diff origin/main...codex/windows-git-pathspec-batch-limit`
- Private evidence commit/path: not applicable
- Reviewer evidence path: not applicable
- GitHub Actions `rewrite-ci` run URL: N/A
- [x] `git diff --check`
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] Verified Windows git tree listing and materialization across 1,295 WAL events in `ha-target`
- [x] G33 production-delta: pass (+4/-3, net +1)

## Review Evidence

- Self-review: Confirmed Windows cmd.exe 8,191 character limit and tested with multi-thousand event repository replay.
- Reviewer subagent: not applicable
- Human review: pending maintainer review
- Blocking findings: none

## Residual Risk

- None. Lowering the batch chunk limit only increases the number of batches for extremely large file lists, with negligible wall-clock overhead, while completely eliminating the command line length crash.

## References

- Task: task_windows_git_pathspec_batch_limit
- Evidence: local test run and successful ledger materialization
- Review: pending

---

# 中文

## 概要

将 `local-version-control-system.ts` 中 Windows 平台的 `gitPathspecChunkBytes` 上限从 8 KiB 下调为 4 KiB。在 Windows 操作系统中，经由 `cmd.exe /d /s /c` 或标准 Shell 包装层派发的 Git 子进程受限于 8,191 字符的命令行长度硬顶。当分批大小设为 8 KiB（8,192 字节）且遇到包含海量路径的变更事件回放时，命令行直接超出上限并抛出 `git --literal-pathspecs failed: 命令行太长。` 致命错误。将 Windows 分块上限设为 4 KiB 能够在保持批量高效处理的同时彻底规避超长溢出。

## 架构辩护

-

## 改动内容

- `packages/kernel/src/store/local-version-control-system.ts`：将 Windows 分支的 `gitPathspecChunkBytes` 从 `8 * 1024` 调整为 `4 * 1024`（4,096 字节），为命令参数、路径和引号留出充足的安全余量。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 同 commit 删除的门 / fixture：none
- 生产净行数：见 computed production-delta 计算结果。

## 机读声明说明

- 本 PR 不涉及依赖变动或事件样本迁移，无未注释机读声明。

## 任务与范围

- Harness 任务：task_windows_git_pathspec_batch_limit
- 分支：`codex/windows-git-pathspec-batch-limit`
- 公开范围：Kernel VCS store 的 Windows git pathspec 分批大小
- 私有计划 / 证据是否已更新：not applicable
- 范围外：POSIX 平台 pathspec 分批大小（继续保留 128 KiB）

## 版本影响

- 版本：不改版本，原因是内部 Kernel 存储兼容性修复
- 发布影响：不发布

## 治理声明

- 是否触碰 protected surface：no
- protected surface 范围：不适用
- 依据：不适用
- 机器检查边界：本 PR 只声明该段存在；声明是否真实、充分，由 reviewer 判断。
- Break-glass：no
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- `origin/main` 基准 SHA：`8f437e6c5`
- 当前分支与 `origin/main` 的 merge-base：`8f437e6c5`
- 最近一次 `git fetch origin` 时间：2026-09-11 UTC
- 同步方式：rebase
- 公开 diff 命令：`git diff origin/main...codex/windows-git-pathspec-batch-limit`
- 私有证据 commit/path：不适用
- Reviewer 证据路径：不适用
- GitHub Actions `rewrite-ci` run URL：待 CI 触发
- [x] `git diff --check`
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] 在拥有 1,295 条历史 WAL 事件的 `ha-target` 仓库上实测物化，未再出现命令行超长报错，物化状态恢复为 `state: "ok"`
- [x] G33 production-delta 验证通过（+4/-3，净增 +1）

## 审查证据

- 自查：已核对 Windows CreateProcess 与 cmd.exe 命令行限制规范，经多千级事件仓库实测无误。
- Reviewer subagent：不适用
- 人工审查：待 maintainer 审查
- 阻塞发现：无

## 残余风险

- 无：下调批次大小仅在极端海量路径时略微增加批次数，耗时差异微秒级，但彻底消除了进程崩溃风险。

## 关联材料

- 任务：task_windows_git_pathspec_batch_limit
- 证据：本地事件物化与回归测试记录
- 审查：待审查

---

## PR Gate Checklist / PR 门禁清单

- [x] Branch is based on latest `origin/main`. / 分支基于最新 `origin/main`。
- [x] PR body uses this full template structure. / PR 描述使用本模板完整结构。
- [x] PR body uses two complete language blocks: `# English` first, then `# 中文`. / PR 正文使用两块完整正文：`# English` 在上，`# 中文` 在下。
- [x] PR body passes `tools/check-pr-body-bilingual.mjs`. / PR 正文通过 `tools/check-pr-body-bilingual.mjs`。
- [x] If the PR touches a manifest-derived protected surface, Governance Declaration is filled with ADR/decision/task evidence or break-glass fields. / 若 PR 触碰 manifest 派生的 protected surface，Governance Declaration 已填写 ADR/decision/task 依据或 break-glass 字段。
- [x] No private harness files are included. / 不包含私有 harness 文件。
- [x] No ignored local agent entry files are included. / 不包含被忽略的本地 agent 入口文件。
- [x] No absolute local filesystem paths are included in this public PR body. / 本公开 PR 描述不包含本机绝对路径。
- [x] Public diff is limited to the stated task scope. / 公开 diff 限于声明的任务范围。
- [x] Private planning/evidence updates are recorded when applicable. / 适用时已记录私有计划 / 证据更新。
- [x] Version and publish impact are stated. / 已说明版本与发布影响。
- [x] Local verification commands are recorded honestly. / 已如实记录本地验证命令。
- [ ] CI results are linked or explained. / CI 结果已链接或说明。
- [x] Review evidence is recorded. / 已记录审查证据。
- [x] Open P0/P1/P2 findings are closed, deferred with owner, or explicitly blocked. / open P0/P1/P2 findings 已关闭、带 owner 延后，或明确阻塞。
- [x] Merge method and post-merge branch cleanup plan are clear. / 合并方式和合并后分支清理计划清楚。
- [x] No admin bypass is planned unless explicitly approved and recorded. / 除非明确批准并记录，否则不计划 admin bypass。
