### PR TITLE
perf(kernel,daemon): read decision coverage for the decisions asked about

### DIFF
--- a/packages/application/src/decision-service.ts
+++ b/packages/application/src/decision-service.ts
@@ -19,7 +19,7 @@ export function makeDecisionService(options: {
   readonly eventStore: Pick<CanonicalEventStore, "append" | "readEvent">;
   readonly projection: Pick<
     TaskProjection,
-    "admitDecision" | "apply" | "readDecision" | "listDecisions" | "readDecisionGraph"
+    "admitDecision" | "apply" | "readDecision" | "listDecisions" | "readDecisionCoverage"
   >;
 }) {
   const record = (
@@ -77,8 +77,8 @@ export function makeDecisionService(options: {
       if (!read.decision) throw new FactServiceError("entity_not_found", `Decision ${selector} does not exist.`);
       return { ...read, decision: read.decision };
     },
-    graph = () => {
-      const read = options.projection.readDecisionGraph();
+    coverage = (decisionId: string) => {
+      const read = options.projection.readDecisionCoverage([decisionId]);
       if (read.status !== "ready")
         throw new FactServiceError(
           "content_not_ready",
@@ -86,5 +86,5 @@ export function makeDecisionService(options: {
         );
       return read;
     };
-  return Object.freeze({ record, show, list, graph });
+  return Object.freeze({ record, show, list, coverage });
 }

--- a/packages/application/test/fact-event-service-decision-read-model.test.ts
+++ b/packages/application/test/fact-event-service-decision-read-model.test.ts
@@ -208,10 +208,15 @@ test("Decision coverage replays all fulfillment modes, refutation, and exact tas
     claim("dec_EVIDENCED", "evidenced");
     relate("dec_EVIDENCED", "decision/dec_EVIDENCED/C1", "fact/F-ABCDEFGH", "evidenced-by");
     relate("dec_EVIDENCED", "decision/dec_EVIDENCED/C1", "fact/F-BCDEFGHJ", "refuted-by");
-    const graph = decisionService.graph();
-    assert.equal(graph.status, "ready");
-    assert.equal(graph.watermark, revision - 1);
-    const byDecision = new Map(graph.coverageRows.map((row) => [row.decisionRef, row]));
+    const reads = ["dec_STANDING", "dec_DELIVERED", "dec_EVIDENCED"].map((decisionId) =>
+      decisionService.coverage(decisionId),
+    );
+    for (const read of reads) {
+      assert.equal(read.status, "ready");
+      assert.equal(read.watermark, revision - 1);
+      assert.equal(read.coverageRows.length, 1, "each read returns only the requested decision's claim");
+    }
+    const byDecision = new Map(reads.flatMap((read) => read.coverageRows).map((row) => [row.decisionRef, row]));
     assert.equal(byDecision.get("decision/dec_STANDING")?.status, "covered");
     assert.equal(byDecision.get("decision/dec_STANDING")?.fulfillment, "standing_policy");
     assert.equal(
@@ -223,7 +228,7 @@ test("Decision coverage replays all fulfillment modes, refutation, and exact tas
     assert.equal(byDecision.get("decision/dec_EVIDENCED")?.status, "uncovered");
     assert.deepEqual(byDecision.get("decision/dec_EVIDENCED")?.refutingFactRefs, ["fact/F-BCDEFGHJ"]);
     assert.equal(
-      graph.coverageRows.every((row) => row.basisRevision === graph.watermark),
+      reads.every((read) => read.coverageRows.every((row) => row.basisRevision === read.watermark)),
       true,
     );
   } finally {

--- a/packages/daemon/src/decision-surface-actions.ts
+++ b/packages/daemon/src/decision-surface-actions.ts
@@ -142,12 +142,15 @@ export function validateDecisionPackages(
 ) {
   const selection = typeof action.decisionId === "string" ? service.show(action.decisionId) : service.list({}),
     decisions = "decision" in selection ? [selection.decision] : selection.decisions,
-    graph = projection.readDecisionGraph(),
-    rows = decisions.map((decision) => validateOne(decision, projection, graph.edges));
+    // Only a decision's own edges enter its digest: one decision reads its own, the full check reads all.
+    relations = projection.readRelationQuery(
+      "decision" in selection ? { ownerRef: `decision/${selection.decision.decisionId}` } : {},
+    ),
+    rows = decisions.map((decision) => validateOne(decision, projection, relations.rows));
   return {
     status: selection.status,
-    watermark: Math.min(selection.watermark, graph.watermark),
-    sourceRevision: Math.max(selection.sourceRevision, graph.sourceRevision),
+    watermark: Math.min(selection.watermark, relations.watermark),
+    sourceRevision: Math.max(selection.sourceRevision, relations.sourceRevision),
     rows,
     report: {
       schema: "decision-validation-report/v1",
@@ -163,7 +166,7 @@ export function validateDecisionPackages(
 function validateOne(
   decision: DecisionProjectionRow,
   projection: TaskProjection,
-  edges: ReturnType<TaskProjection["readDecisionGraph"]>["edges"],
+  edges: ReturnType<TaskProjection["readRelationQuery"]>["rows"],
 ) {
   const errors: string[] = [],
     warnings: string[] = [],

--- a/packages/daemon/src/entity-action-catalog-executor.ts
+++ b/packages/daemon/src/entity-action-catalog-executor.ts
@@ -665,13 +665,8 @@ function decisionCoverage(action: Readonly<Record<string, unknown>>, service: Re
   const decisionId = requiredCommandText(action.decisionId, "decisionId"),
     taskId = requiredCommandText(action.taskId, "taskId");
   service.show(decisionId);
-  const graph = service.graph();
-  return {
-    decisionId,
-    taskId,
-    basisRevision: graph.watermark,
-    rows: graph.coverageRows.filter((row) => row.decisionRef === `decision/${decisionId}`),
-  };
+  const coverage = service.coverage(decisionId);
+  return { decisionId, taskId, basisRevision: coverage.watermark, rows: coverage.coverageRows };
 }
 
 function decisionAuthorization(

--- a/packages/daemon/src/task-query-read.ts
+++ b/packages/daemon/src/task-query-read.ts
@@ -410,7 +410,9 @@ export function makeTaskQueryReadModel(input: {
       facts = projection.searchFacts({ refs: factRefs }),
       factAnchors = projection.readFactAnchors(factRefs),
       decisionRefs = [...refs].filter((ref) => ref.startsWith("decision/")),
-      decisions = projection.readDecisionGraph(),
+      decisions = projection.readDecisionCoverage([
+        ...new Set(decisionRefs.flatMap((ref) => /^decision\/([^/]+)/u.exec(ref)?.[1] ?? [])),
+      ]),
       cut = requireSameProjectionCut(label, [page, facts, factAnchors, decisions]),
       coverageRows = decisions.coverageRows.filter((row) =>
         decisionRefs.some((ref) => row.decisionRef === ref || row.claimRef === ref),

--- a/packages/daemon/test/fixtures/g1-write-cost-scaling.ts
+++ b/packages/daemon/test/fixtures/g1-write-cost-scaling.ts
@@ -59,6 +59,7 @@ export const G1_WRITE_OPERATIONS = Object.freeze([
   "decision-propose",
   "decision-reject",
   "relation-relate",
+  "decision-reckon",
   "receipt-show",
 ]);
 export const G1_READ_OPERATIONS = Object.freeze(["task-list", "task-show", "agenda", "runtime-overview"]);
@@ -586,6 +587,9 @@ export async function measureWriteCostScaling(eventCount: number): Promise<G1Sca
           rationale: "G1 measured relation for the cost-scaling gate.",
           expectedVersion: 0,
         }),
+      );
+      await each("decision-reckon", measure, (subject) =>
+        run({ kind: "decision-reckon", decisionId: subject.decisionId, taskId: subject.taskId }),
       );
       await each("receipt-show", measure, (subject) => run({ kind: "receipt-show", opId: subject.createOpId }));
     } finally {

--- a/packages/daemon/test/task-query-read.test.ts
+++ b/packages/daemon/test/task-query-read.test.ts
@@ -320,6 +320,7 @@ function projectionStub(
       return { ...cut, rows: query.limit === undefined ? rows : rows.slice(0, query.limit), ...page };
     },
     readDecisionGraph: () => ({ ...decisionCut, decisions: [], edges: [], coverageRows: [] }),
+    readDecisionCoverage: () => ({ ...decisionCut, coverageRows: [] }),
     readFactGraph: () => ({ ...cut, facts: [], edges: [], factAnchors: [] }),
     searchFacts: () => ({ ...cut, facts: [] }),
     readFactAnchors: () => ({ ...cut, rows: [] }),

--- a/packages/kernel/src/projection/decision-event-projection.ts
+++ b/packages/kernel/src/projection/decision-event-projection.ts
@@ -21,3 +21,4 @@ export {
   readDecisionRows,
 } from "./decision-projection-reads.ts";
 export { readDecisionDocumentState } from "./decision-projection-documents.ts";
+export { decisionCoverage } from "./decision-projection-coverage.ts";

--- a/packages/kernel/src/projection/decision-projection-coverage.ts
+++ b/packages/kernel/src/projection/decision-projection-coverage.ts
@@ -3,6 +3,7 @@ import { coverageOf } from "../domain/decision-coverage.ts";
 import type { DecisionFulfillmentMode } from "../domain/decision-event.ts";
 import type { DecisionCoverageRow, DecisionRelationEdgeRow } from "./decision-projection-model.ts";
 import { queryRow, queryRows } from "./rebuildable-task-projection-sql.ts";
+import { readRelationProjectionRows } from "./relation-entity-projection.ts";
 export function decisionCoverage(
   db: DatabaseSync,
   edges: readonly DecisionRelationEdgeRow[],
@@ -37,7 +38,8 @@ export function decisionCoverage(
   const claimsByDecision = new Map<string, typeof claims>();
   for (const claim of claims)
     claimsByDecision.set(claim.decision_id, [...(claimsByDecision.get(claim.decision_id) ?? []), claim]);
-  const livenessEdges = edges.filter((edge) => edge.relationType === "supersedes-fact");
+  // supersedes-fact edges start at the newer Fact, so the caller's decision-owned edges never hold them.
+  const livenessEdges = readRelationProjectionRows(db).filter((edge) => edge.relationType === "supersedes-fact");
   return coverageOf(
     decisions.map((decision) => {
       const ref = `decision/${decision.decision_id}`;

--- a/packages/kernel/src/projection/decision-projection-coverage.ts
+++ b/packages/kernel/src/projection/decision-projection-coverage.ts
@@ -1,14 +1,28 @@
 import type { DatabaseSync } from "node:sqlite";
 import { coverageOf } from "../domain/decision-coverage.ts";
 import type { DecisionFulfillmentMode } from "../domain/decision-event.ts";
-import type { DecisionCoverageRow, DecisionRelationEdgeRow } from "./decision-projection-model.ts";
+import type { DecisionCoverageRow } from "./decision-projection-model.ts";
 import { queryRow, queryRows } from "./rebuildable-task-projection-sql.ts";
-import { readRelationProjectionRows } from "./relation-entity-projection.ts";
-export function decisionCoverage(
-  db: DatabaseSync,
-  edges: readonly DecisionRelationEdgeRow[],
-): readonly DecisionCoverageRow[] {
-  const basisRevision = Number(
+import { relationProjectionRowsAtCut } from "./relation-entity-projection.ts";
+
+// The active edges coverageOf can consult for the requested decisions: those leaving each decision
+// root (refuted-by, derives), and those leaving every decision anchor that a load-bearing claim
+// reaches through active edges into other decision anchors (the evidence walk). Unary + keeps the
+// state filter off its own index, which holds every active edge in the repository.
+const COVERAGE_EDGES_SQL = [
+  "WITH RECURSIVE requested(decision_id) AS (SELECT value FROM json_each(?)),",
+  "reach(ref) AS (SELECT 'decision/' || decision_id || '/' || claim_id FROM decision_claim",
+  "WHERE decision_id IN (SELECT decision_id FROM requested) AND load_bearing = 1",
+  "UNION SELECT edge.target_ref FROM reach JOIN relation_edge AS edge",
+  "ON edge.source_ref = reach.ref AND +edge.state = 'active' WHERE substr(edge.target_ref, 1, 9) = 'decision/')",
+  "SELECT row_json FROM relation_edge WHERE +state = 'active' AND source_ref IN",
+  "(SELECT ref FROM reach UNION SELECT 'decision/' || decision_id FROM requested) ORDER BY relation_id",
+].join(" ");
+
+/** Coverage of the requested decisions, computed from only the rows coverageOf consults for them. */
+export function decisionCoverage(db: DatabaseSync, decisionIds: readonly string[]): readonly DecisionCoverageRow[] {
+  const requested = JSON.stringify(decisionIds),
+    basisRevision = Number(
       queryRow<{ readonly watermark: number }>(db, "SELECT watermark FROM projection_meta WHERE singleton=1")!
         .watermark,
     ),
@@ -17,14 +31,46 @@ export function decisionCoverage(
       readonly state: string;
       readonly decision_class: string;
       readonly applies_json: string;
-    }>(db, "SELECT decision_id,state,decision_class,applies_json FROM decision ORDER BY decision_id"),
+    }>(
+      db,
+      "SELECT decision_id,state,decision_class,applies_json FROM decision " +
+        "WHERE decision_id IN (SELECT value FROM json_each(?)) ORDER BY decision_id",
+      requested,
+    ),
     claims = queryRows<{
       readonly decision_id: string;
       readonly claim_id: string;
       readonly load_bearing: number;
       readonly fulfillment: DecisionFulfillmentMode | null;
-    }>(db, "SELECT decision_id,claim_id,load_bearing,fulfillment FROM decision_claim ORDER BY decision_id,claim_id"),
-    facts = queryRows<{ readonly ref: string }>(db, "SELECT ref FROM fact ORDER BY ref"),
+    }>(
+      db,
+      "SELECT decision_id,claim_id,load_bearing,fulfillment FROM decision_claim " +
+        "WHERE decision_id IN (SELECT value FROM json_each(?)) ORDER BY decision_id,claim_id",
+      requested,
+    ),
+    edges = relationProjectionRowsAtCut(
+      db,
+      queryRows<{ readonly row_json: string }>(db, COVERAGE_EDGES_SQL, requested),
+    ),
+    targets = (kind: "fact/" | "task/") => [
+      ...new Set(edges.flatMap(({ targetRef }) => (targetRef.startsWith(kind) ? [targetRef] : []))),
+    ],
+    factRefs = JSON.stringify(targets("fact/")),
+    facts = queryRows<{ readonly ref: string }>(
+      db,
+      "SELECT ref FROM fact WHERE ref IN (SELECT value FROM json_each(?)) ORDER BY ref",
+      factRefs,
+    ),
+    // A superseded Fact no longer covers; its supersedes-fact edge starts at the newer Fact.
+    livenessEdges = relationProjectionRowsAtCut(
+      db,
+      queryRows<{ readonly row_json: string }>(
+        db,
+        "SELECT row_json FROM relation_edge WHERE target_ref IN (SELECT value FROM json_each(?)) " +
+          "AND +relation_type = 'supersedes-fact' AND +state = 'active' ORDER BY relation_id",
+        factRefs,
+      ),
+    ),
     hasTasks = Boolean(queryRow(db, "SELECT 1 FROM sqlite_master WHERE type='table' AND name='task_snapshot'")),
     tasks = hasTasks
       ? queryRows<{
@@ -32,14 +78,14 @@ export function decisionCoverage(
           readonly status: string;
         }>(
           db,
-          "SELECT task_id,json_extract(snapshot_json,'$.task.status') AS status FROM task_snapshot ORDER BY task_id",
+          "SELECT task_id,json_extract(snapshot_json,'$.task.status') AS status FROM task_snapshot " +
+            "WHERE task_id IN (SELECT value FROM json_each(?)) ORDER BY task_id",
+          JSON.stringify(targets("task/").map((ref) => ref.slice("task/".length))),
         )
       : [];
   const claimsByDecision = new Map<string, typeof claims>();
   for (const claim of claims)
     claimsByDecision.set(claim.decision_id, [...(claimsByDecision.get(claim.decision_id) ?? []), claim]);
-  // supersedes-fact edges start at the newer Fact, so the caller's decision-owned edges never hold them.
-  const livenessEdges = readRelationProjectionRows(db).filter((edge) => edge.relationType === "supersedes-fact");
   return coverageOf(
     decisions.map((decision) => {
       const ref = `decision/${decision.decision_id}`;

--- a/packages/kernel/src/projection/decision-projection-reads.ts
+++ b/packages/kernel/src/projection/decision-projection-reads.ts
@@ -360,7 +360,14 @@ export function readDecisionGraphRows(db: DatabaseSync): {
       anchorRefs: anchors.get(r.decision_id) ?? [`decision/${r.decision_id}`],
       sourcePath: `event:decision/${r.decision_id}`,
     }));
-  return { edges, decisionAnchors, coverageRows: decisionCoverage(db, edges) };
+  return {
+    edges,
+    decisionAnchors,
+    coverageRows: decisionCoverage(
+      db,
+      decisionAnchors.map(({ decisionId }) => decisionId),
+    ),
+  };
 }
 
 export function decisionAnchorIndex(db: DatabaseSync): ReadonlyMap<string, readonly string[]> {

--- a/packages/kernel/src/projection/projection-reads.ts
+++ b/packages/kernel/src/projection/projection-reads.ts
@@ -215,3 +215,9 @@ export interface DecisionGraphProjectionRead {
   readonly watermark: number;
   readonly sourceRevision: number;
 }
+export interface DecisionCoverageProjectionRead {
+  readonly status: "ready" | "pending";
+  readonly coverageRows: ReturnType<typeof readDecisionGraphRows>["coverageRows"];
+  readonly watermark: number;
+  readonly sourceRevision: number;
+}

--- a/packages/kernel/src/projection/rebuildable-task-projection-factory.ts
+++ b/packages/kernel/src/projection/rebuildable-task-projection-factory.ts
@@ -238,6 +238,7 @@ export function makeTaskProjectionReader(options: {
       listDecisions: knowledgeQueries.listDecisions,
       listDecisionAgendaPage: knowledgeQueries.listDecisionAgendaPage,
       readDecisionGraph: knowledgeQueries.readDecisionGraph,
+      readDecisionCoverage: knowledgeQueries.readDecisionCoverage,
       readLeaseIntervals: runtimeQueries.readLeaseIntervals,
       currentLease: runtimeQueries.currentLease,
       currentLeaseForExecution: runtimeQueries.currentLeaseForExecution,

--- a/packages/kernel/src/projection/rebuildable-task-projection-knowledge-queries.ts
+++ b/packages/kernel/src/projection/rebuildable-task-projection-knowledge-queries.ts
@@ -1,6 +1,7 @@
 // @write-boundary-exemption rebuildable-projection
 import {
   assertDecisionAdmission,
+  decisionCoverage,
   listDecisionAgendaRowsPage,
   listDecisionRowsPage,
   readDecisionGraphRows,
@@ -43,6 +44,7 @@ export function knowledgeQueryApi(
   | "listDecisions"
   | "listDecisionAgendaPage"
   | "readDecisionGraph"
+  | "readDecisionCoverage"
 > {
   const { eventStore, limit, projectionPath, readHead } = context;
   return {
@@ -172,6 +174,16 @@ export function knowledgeQueryApi(
         return {
           status: cut.status,
           ...readDecisionGraphRows(db),
+          watermark: cut.watermark,
+          sourceRevision: cut.sourceRevision,
+        };
+      }),
+    readDecisionCoverage: (decisionIds) =>
+      withDatabase(projectionPath, readHead, (db) => {
+        const cut = readProjectionCut(db, readHead);
+        return {
+          status: cut.status,
+          coverageRows: decisionCoverage(db, decisionIds),
           watermark: cut.watermark,
           sourceRevision: cut.sourceRevision,
         };

--- a/packages/kernel/src/projection/relation-entity-projection.ts
+++ b/packages/kernel/src/projection/relation-entity-projection.ts
@@ -205,15 +205,24 @@ export function readRelationProjectionRows(
   db: DatabaseSync,
   targetRef?: string,
 ): readonly VersionedRelationProjectionRow[] {
-  const rows = (
+  return relationProjectionRowsAtCut(
+    db,
     targetRef === undefined
       ? queryRows<{ readonly row_json: string }>(db, "SELECT row_json FROM relation_edge ORDER BY relation_id")
       : queryRows<{ readonly row_json: string }>(
           db,
           "SELECT row_json FROM relation_edge WHERE target_ref = ? ORDER BY relation_id",
           targetRef,
-        )
-  )
+        ),
+  );
+}
+
+/** Projection rows for selected relation_edge `row_json` values, each judged fresh or stale at this cut. */
+export function relationProjectionRowsAtCut(
+  db: DatabaseSync,
+  selected: readonly { readonly row_json: string }[],
+): readonly VersionedRelationProjectionRow[] {
+  const rows = selected
     .map((row) => JSON.parse(row.row_json) as Partial<VersionedRelationProjectionRow>)
     .filter(
       (row): row is VersionedRelationProjectionRow =>

--- a/packages/kernel/src/projection/task-projection-port.ts
+++ b/packages/kernel/src/projection/task-projection-port.ts
@@ -10,6 +10,7 @@ import type { DecisionListFilters, DecisionPageQuery } from "./decision-event-pr
 import type { FactSearchFilters } from "./fact-event-projection.ts";
 import type {
   DecisionAgendaProjectionPageRead,
+  DecisionCoverageProjectionRead,
   DecisionGraphProjectionRead,
   DecisionProjectionListRead,
   DecisionProjectionRead,
@@ -152,6 +153,7 @@ export interface TaskProjection {
   readonly listDecisions: (filters: DecisionListFilters) => DecisionProjectionListRead;
   readonly listDecisionAgendaPage: (query: DecisionPageQuery) => DecisionAgendaProjectionPageRead;
   readonly readDecisionGraph: () => DecisionGraphProjectionRead;
+  readonly readDecisionCoverage: (decisionIds: readonly string[]) => DecisionCoverageProjectionRead;
   readonly readLeaseIntervals: (taskId: string) => readonly LeaseInterval[];
   readonly currentLease: (taskId: string, now?: string) => LeaseV1 | null;
   readonly currentLeaseForExecution: (executionId: string, now?: string) => LeaseV1 | null;

--- a/packages/kernel/test/store/decision-coverage-read.test.ts
+++ b/packages/kernel/test/store/decision-coverage-read.test.ts
@@ -2,18 +2,24 @@
 import assert from "node:assert/strict";
 import { DatabaseSync } from "node:sqlite";
 import test from "node:test";
+import { coverageOf } from "../../src/domain/decision-coverage.ts";
 import {
   createDecisionProjectionTables,
+  decisionCoverage,
   readDecisionGraphRows,
 } from "../../src/projection/decision-event-projection.ts";
 import { createFactProjectionTables } from "../../src/projection/fact-event-projection.ts";
+import { readRelationProjectionRows } from "../../src/projection/relation-entity-projection.ts";
 import { createRelationGraphProjectionTables } from "../../src/projection/relation-graph-projection.ts";
 
 // A projection holding only the tables decision coverage reads, written row by row so each test
-// states exactly which decisions, claims, facts, tasks and edges exist.
+// states exactly which decisions, claims, facts, tasks and edges exist. Every statement is recorded
+// with the rows it returned, the same count G1's sqlRowsRead takes.
 function ledger() {
   const db = new DatabaseSync(":memory:"),
-    versions = new Map<string, number>();
+    versions = new Map<string, number>(),
+    reads: { readonly sql: string; readonly args: readonly unknown[]; rows: number }[] = [],
+    prepare = db.prepare.bind(db);
   createRelationGraphProjectionTables(db);
   createFactProjectionTables(db);
   createDecisionProjectionTables(db);
@@ -23,6 +29,18 @@ function ledger() {
       "CREATE TABLE task_snapshot (task_id TEXT PRIMARY KEY, workspace_revision INTEGER NOT NULL, " +
       "snapshot_json TEXT NOT NULL, status TEXT)",
   );
+  db.prepare = ((sql: string) => {
+    const statement = prepare(sql);
+    for (const method of ["all", "get"] as const) {
+      const original = statement[method].bind(statement);
+      statement[method] = ((...args: readonly unknown[]) => {
+        const result = original(...args);
+        reads.push({ sql, args, rows: Array.isArray(result) ? result.length : result === undefined ? 0 : 1 });
+        return result;
+      }) as (typeof statement)[typeof method];
+    }
+    return statement;
+  }) as typeof db.prepare;
   let revision = 1;
   const next = (ref: string) => {
     revision += 1;
@@ -32,6 +50,7 @@ function ledger() {
   };
   return {
     db,
+    reads,
     decision(
       decisionId: string,
       claims: readonly { readonly id: string; readonly fulfillment: string | null; readonly loadBearing?: boolean }[],
@@ -70,6 +89,10 @@ function ledger() {
           "'2026-09-11T00:00:00.000Z', 'high', 'semantic', ?, ?, '{}')",
       ).run(factId, ref, `op-${factId}`, version);
     },
+    /** A later Fact version the edges recorded earlier have not observed. */
+    restate(factId: string) {
+      db.prepare("UPDATE fact SET workspace_revision=? WHERE fact_id=?").run(next(`fact/${factId}`), factId);
+    },
     task(taskId: string, status: string) {
       const version = next(`task/${taskId}`);
       db.prepare("INSERT INTO task_snapshot VALUES (?, ?, ?, ?)").run(
@@ -80,9 +103,9 @@ function ledger() {
       );
     },
     edge(relationId: string, source: string, target: string, type: string, state = "active") {
-      const version = next(`relation/${relationId}`),
-        observed = versions.get(target) ?? null,
-        owner = source.startsWith("decision/") ? source.split("/").slice(0, 2).join("/") : source;
+      const entity = (ref: string) => (ref.startsWith("decision/") ? ref.split("/").slice(0, 2).join("/") : ref),
+        version = next(`relation/${relationId}`),
+        observed = versions.get(entity(target)) ?? null;
       db.prepare("INSERT INTO relation_edge VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)").run(
         relationId,
         source,
@@ -90,7 +113,7 @@ function ledger() {
         type,
         state,
         observed,
-        owner,
+        entity(source),
         version,
         JSON.stringify({
           schema: "relation-projection/v1",
@@ -115,6 +138,134 @@ function ledger() {
   };
 }
 
+type Ledger = ReturnType<typeof ledger>;
+
+// dec_TARGET exercises every branch of coverageOf; dec_PEER, dec_ROOTED and dec_REFUTED sit on its
+// walks, dec_STANDING covers by policy.
+function coverageScenario(fixture: Ledger): void {
+  for (const factId of [
+    "F-LIVE0001",
+    "F-PEER0001",
+    "F-ROOT0001",
+    "F-OLD00001",
+    "F-NEW00001",
+    "F-REFUTE01",
+    "F-REFOLD01",
+    "F-REFNEW01",
+    "F-STALE001",
+    "F-RETIRED1",
+  ])
+    fixture.fact(factId);
+  fixture.task("task-done", "done");
+  fixture.task("task-open", "active");
+  fixture.decision("dec_TARGET", [
+    { id: "C1", fulfillment: "evidenced" },
+    { id: "C2", fulfillment: "evidenced" },
+    { id: "C3", fulfillment: "evidenced" },
+    { id: "C4", fulfillment: "delivered" },
+    { id: "C5", fulfillment: "evidenced" },
+    { id: "C6", fulfillment: "evidenced" },
+    { id: "C7", fulfillment: "evidenced" },
+    { id: "C8", fulfillment: "evidenced" },
+    { id: "C9", fulfillment: "evidenced" },
+    { id: "C10", fulfillment: "evidenced", loadBearing: false },
+    { id: "C11", fulfillment: null },
+  ]);
+  fixture.decision("dec_PEER", [{ id: "C1", fulfillment: "evidenced" }]);
+  fixture.decision("dec_ROOTED", [], { state: "proposed" });
+  fixture.decision("dec_REFUTED", [{ id: "C1", fulfillment: "evidenced" }]);
+  fixture.decision("dec_STANDING", [{ id: "C1", fulfillment: "standing_policy" }], {
+    decisionClass: "standing_policy",
+  });
+  const t = "decision/dec_TARGET";
+  fixture.edge("rel_t1_live", `${t}/C1`, "fact/F-LIVE0001", "evidenced-by");
+  // Two hops into another decision's claim, which walks back into this one: the walk must stop.
+  fixture.edge("rel_t2_peer", `${t}/C2`, "decision/dec_PEER/C1", "refines");
+  fixture.edge("rel_peer_back", "decision/dec_PEER/C1", `${t}/C2`, "relates");
+  fixture.edge("rel_peer_fact", "decision/dec_PEER/C1", "fact/F-PEER0001", "evidenced-by");
+  fixture.edge("rel_t3_old", `${t}/C3`, "fact/F-OLD00001", "evidenced-by");
+  fixture.edge("rel_supersede", "fact/F-NEW00001", "fact/F-OLD00001", "supersedes-fact");
+  fixture.edge("rel_root_done", t, "task/task-done", "derives");
+  fixture.edge("rel_t4_open", `${t}/C4`, "task/task-open", "derives");
+  // A claim reaching another decision's root reads the edges that root carries.
+  fixture.edge("rel_t5_rooted", `${t}/C5`, "decision/dec_ROOTED", "narrows");
+  fixture.edge("rel_rooted_fact", "decision/dec_ROOTED", "fact/F-ROOT0001", "evidenced-by");
+  fixture.edge("rel_t6_live", `${t}/C6`, "fact/F-LIVE0001", "evidenced-by");
+  fixture.edge("rel_t6_refute", `${t}/C6`, "fact/F-REFUTE01", "refuted-by");
+  fixture.edge("rel_t7_stale", `${t}/C7`, "fact/F-STALE001", "evidenced-by");
+  fixture.restate("F-STALE001");
+  fixture.edge("rel_t8_retired", `${t}/C8`, "fact/F-RETIRED1", "evidenced-by", "retired");
+  // A refuter that was itself superseded no longer refutes.
+  fixture.edge("rel_t9_live", `${t}/C9`, "fact/F-LIVE0001", "evidenced-by");
+  fixture.edge("rel_t9_refute", `${t}/C9`, "fact/F-REFOLD01", "refuted-by");
+  fixture.edge("rel_refute_supersede", "fact/F-REFNEW01", "fact/F-REFOLD01", "supersedes-fact");
+  fixture.edge("rel_t10_live", `${t}/C10`, "fact/F-LIVE0001", "evidenced-by");
+  // A root refuter refutes every claim of its decision.
+  fixture.edge("rel_refuted_live", "decision/dec_REFUTED/C1", "fact/F-LIVE0001", "evidenced-by");
+  fixture.edge("rel_refuted_root", "decision/dec_REFUTED", "fact/F-REFUTE01", "refuted-by");
+}
+
+// `count` decisions with the same shape as the scenario but no edge into it: each claim is evidenced
+// by its own Fact, chained to the previous decision's claim, and its root derives its own Task.
+function unrelated(fixture: Ledger, count: number): void {
+  for (let index = 0; index < count; index += 1) {
+    const id = String(index).padStart(5, "0"),
+      root = `decision/dec_NOISE${id}`;
+    fixture.fact(`F-N${id}A`);
+    fixture.fact(`F-N${id}B`);
+    fixture.task(`task-noise-${id}`, index % 2 === 0 ? "done" : "active");
+    fixture.decision(`dec_NOISE${id}`, [{ id: "C1", fulfillment: index % 2 === 0 ? "evidenced" : "delivered" }]);
+    fixture.edge(`rel_noise_${id}_fact`, `${root}/C1`, `fact/F-N${id}A`, "evidenced-by");
+    fixture.edge(`rel_noise_${id}_task`, root, `task/task-noise-${id}`, "derives");
+    fixture.edge(`rel_noise_${id}_supersede`, `fact/F-N${id}B`, `fact/F-N${id}A`, "supersedes-fact");
+    if (index > 0)
+      fixture.edge(
+        `rel_noise_${id}_chain`,
+        `${root}/C1`,
+        `decision/dec_NOISE${String(index - 1).padStart(5, "0")}/C1`,
+        "refines",
+      );
+  }
+}
+
+// coverageOf fed every row the projection holds. Coverage read for any set of decisions must equal
+// these rows for those decisions: reading less may not change a verdict, a path or an order.
+function coverageOfEveryRow(db: DatabaseSync) {
+  const decisions = db
+      .prepare("SELECT decision_id, state, decision_class, applies_json FROM decision ORDER BY decision_id")
+      .all() as { decision_id: string; state: string; decision_class: string; applies_json: string }[],
+    claims = db
+      .prepare(
+        "SELECT decision_id, claim_id, load_bearing, fulfillment FROM decision_claim ORDER BY decision_id, claim_id",
+      )
+      .all() as { decision_id: string; claim_id: string; load_bearing: number; fulfillment: "evidenced" | null }[],
+    facts = db.prepare("SELECT ref FROM fact").all() as { ref: string }[],
+    tasks = db.prepare("SELECT task_id, status FROM task_snapshot").all() as { task_id: string; status: string }[],
+    basisRevision = (db.prepare("SELECT watermark FROM projection_meta").get() as { watermark: number }).watermark;
+  return coverageOf(
+    decisions.map((decision) => ({
+      ref: `decision/${decision.decision_id}`,
+      state: decision.state,
+      decisionClass: decision.decision_class,
+      appliesTo: JSON.parse(decision.applies_json) as { modules: string[]; productLines: string[] },
+      claims: claims
+        .filter((claim) => claim.decision_id === decision.decision_id)
+        .map((claim) => ({
+          ref: `decision/${decision.decision_id}/${claim.claim_id}`,
+          loadBearing: claim.load_bearing === 1,
+          fulfillment: claim.fulfillment,
+        })),
+    })),
+    facts,
+    tasks.map((task) => ({ ref: `task/${task.task_id}`, status: task.status })),
+    readRelationProjectionRows(db),
+  ).map((row) => ({
+    ...row,
+    fulfillment: row.fulfillment === "standing-policy" ? "standing_policy" : row.fulfillment,
+    basisRevision,
+  }));
+}
+
 test("a claim evidenced only by a superseded Fact is not covered", () => {
   const fixture = ledger();
   try {
@@ -136,3 +287,104 @@ test("a claim evidenced only by a superseded Fact is not covered", () => {
     fixture.db.close();
   }
 });
+
+test("each decision's coverage equals coverageOf over every projected row", () => {
+  const fixture = ledger();
+  try {
+    coverageScenario(fixture);
+    unrelated(fixture, 5);
+    const everyRow = coverageOfEveryRow(fixture.db),
+      decisionIds = (
+        fixture.db.prepare("SELECT decision_id FROM decision ORDER BY decision_id").all() as { decision_id: string }[]
+      ).map(({ decision_id }) => decision_id);
+    for (const decisionId of decisionIds)
+      assert.deepEqual(
+        decisionCoverage(fixture.db, [decisionId]),
+        everyRow.filter((row) => row.decisionRef === `decision/${decisionId}`),
+        decisionId,
+      );
+    assert.deepEqual(readDecisionGraphRows(fixture.db).coverageRows, everyRow);
+
+    // The scenario reaches every verdict the judgment can give, so the equality above is not vacuous.
+    const target = new Map(
+      decisionCoverage(fixture.db, ["dec_TARGET"]).map((row) => [row.claimRef.split("/").at(-1), row]),
+    );
+    assert.deepEqual([...target.keys()], ["C1", "C11", "C2", "C3", "C4", "C5", "C6", "C7", "C8", "C9"]);
+    assert.deepEqual(Object.fromEntries([...target].map(([claim, row]) => [claim, row.status])), {
+      C1: "covered",
+      C11: "uncovered",
+      C2: "covered",
+      C3: "uncovered",
+      C4: "covered",
+      C5: "covered",
+      C6: "uncovered",
+      C7: "uncovered",
+      C8: "uncovered",
+      C9: "covered",
+    });
+    assert.deepEqual(target.get("C2")?.relationPath, ["rel_t2_peer", "rel_peer_fact"]);
+    assert.deepEqual(target.get("C4")?.relationPath, ["rel_root_done"]);
+    assert.equal(target.get("C5")?.coveringFactRef, "fact/F-ROOT0001");
+    assert.deepEqual(target.get("C6")?.refutingFactRefs, ["fact/F-REFUTE01"]);
+    assert.deepEqual(target.get("C9")?.refutingFactRefs, []);
+    assert.equal(decisionCoverage(fixture.db, ["dec_REFUTED"])[0]?.status, "uncovered");
+    assert.equal(decisionCoverage(fixture.db, ["dec_STANDING"])[0]?.fulfillment, "standing_policy");
+    assert.equal(decisionCoverage(fixture.db, ["dec_STANDING"])[0]?.status, "covered");
+    assert.deepEqual(decisionCoverage(fixture.db, ["dec_MISSING"]), []);
+  } finally {
+    fixture.db.close();
+  }
+});
+
+test("one decision's coverage reads the same rows however many unrelated decisions, facts, tasks and edges exist", (context) => {
+  const measure = (noise: number) => {
+    const fixture = ledger();
+    try {
+      coverageScenario(fixture);
+      unrelated(fixture, noise);
+      fixture.reads.length = 0;
+      const rows = decisionCoverage(fixture.db, ["dec_TARGET"]),
+        reads = [...fixture.reads];
+      return {
+        rows,
+        statements: reads.length,
+        rowsRead: reads.reduce((sum, read) => sum + read.rows, 0),
+        plans: reads.map((read) => queryPlan(fixture.db, read)),
+      };
+    } finally {
+      fixture.db.close();
+    }
+  };
+  const small = measure(200),
+    large = measure(2_000);
+  context.diagnostic(`200 unrelated decisions: ${small.statements} statements, ${small.rowsRead} rows read`);
+  context.diagnostic(`2000 unrelated decisions: ${large.statements} statements, ${large.rowsRead} rows read`);
+  assert.deepEqual(
+    large.rows,
+    small.rows.map((row) => ({ ...row, basisRevision: large.rows[0]!.basisRevision })),
+  );
+  assert.equal(large.statements, small.statements);
+  assert.equal(large.rowsRead, small.rowsRead, "the coverage read grew with rows that are not this decision's");
+  // Row counts cannot see rows SQLite visits and filters out, so every table read must be searched by
+  // an identity or an edge endpoint. A search on state or relation type alone visits every such edge.
+  for (const plan of large.plans) {
+    context.diagnostic(plan.replaceAll("\n", " | "));
+    for (const [, scanned] of plan.matchAll(/SCAN (\S+)/gu))
+      assert.ok(["json_each", "reach", "requested", "sqlite_master"].includes(scanned!), plan);
+    for (const [, constraint] of plan.matchAll(/SEARCH \S+ USING (?:COVERING )?INDEX \S+ \((\w+)/gu))
+      assert.ok(
+        ["rowid", "decision_id", "source_ref", "target_ref", "ref", "task_id", "fact_id", "relation_id"].includes(
+          constraint!,
+        ),
+        plan,
+      );
+  }
+});
+
+function queryPlan(db: DatabaseSync, read: { readonly sql: string; readonly args: readonly unknown[] }): string {
+  return (
+    db.prepare(`EXPLAIN QUERY PLAN ${read.sql}`).all(...read.args) as unknown as readonly { readonly detail: string }[]
+  )
+    .map(({ detail }) => detail)
+    .join("\n");
+}

--- a/packages/kernel/test/store/decision-coverage-read.test.ts
+++ b/packages/kernel/test/store/decision-coverage-read.test.ts
@@ -1,0 +1,138 @@
+// harness-test-tier: fast
+import assert from "node:assert/strict";
+import { DatabaseSync } from "node:sqlite";
+import test from "node:test";
+import {
+  createDecisionProjectionTables,
+  readDecisionGraphRows,
+} from "../../src/projection/decision-event-projection.ts";
+import { createFactProjectionTables } from "../../src/projection/fact-event-projection.ts";
+import { createRelationGraphProjectionTables } from "../../src/projection/relation-graph-projection.ts";
+
+// A projection holding only the tables decision coverage reads, written row by row so each test
+// states exactly which decisions, claims, facts, tasks and edges exist.
+function ledger() {
+  const db = new DatabaseSync(":memory:"),
+    versions = new Map<string, number>();
+  createRelationGraphProjectionTables(db);
+  createFactProjectionTables(db);
+  createDecisionProjectionTables(db);
+  db.exec(
+    "CREATE TABLE projection_meta (singleton INTEGER PRIMARY KEY CHECK(singleton=1), watermark INTEGER NOT NULL); " +
+      "INSERT INTO projection_meta VALUES (1, 1); " +
+      "CREATE TABLE task_snapshot (task_id TEXT PRIMARY KEY, workspace_revision INTEGER NOT NULL, " +
+      "snapshot_json TEXT NOT NULL, status TEXT)",
+  );
+  let revision = 1;
+  const next = (ref: string) => {
+    revision += 1;
+    versions.set(ref, revision);
+    db.prepare("UPDATE projection_meta SET watermark=?").run(revision);
+    return revision;
+  };
+  return {
+    db,
+    decision(
+      decisionId: string,
+      claims: readonly { readonly id: string; readonly fulfillment: string | null; readonly loadBearing?: boolean }[],
+      options: { readonly state?: string; readonly decisionClass?: string } = {},
+    ) {
+      const version = next(`decision/${decisionId}`);
+      db.prepare(
+        "INSERT INTO decision(decision_id,state,title,question,risk_tier,urgency,vertical,preset,decision_class," +
+          "applies_json,proposer_json,arbiter_json,proposed_at,decided_at,workspace_revision) " +
+          "VALUES (?, ?, 'title', 'question', 'high', 'medium', 'coverage', 'default', ?, ?, ?, NULL, " +
+          "'2026-09-11T00:00:00.000Z', NULL, ?)",
+      ).run(
+        decisionId,
+        options.state ?? "in_effect",
+        options.decisionClass ?? "ordinary",
+        JSON.stringify({ modules: ["kernel"], productLines: [] }),
+        JSON.stringify({ principal: { personId: "coverage" }, executor: null }),
+        version,
+      );
+      for (const [position, claim] of claims.entries())
+        db.prepare("INSERT INTO decision_claim VALUES (?, ?, ?, 'claim', ?, ?, ?, NULL)").run(
+          decisionId,
+          claim.id,
+          position,
+          claim.loadBearing === false ? 0 : 1,
+          claim.fulfillment,
+          version,
+        );
+    },
+    fact(factId: string) {
+      const ref = `fact/${factId}`,
+        version = next(ref);
+      db.prepare(
+        "INSERT INTO fact(task_id, fact_id, ref, statement, evidence_source, observed_at, confidence, memory_class, " +
+          "op_id, workspace_revision, row_json) VALUES ('task-coverage', ?, ?, 'observation', 'coverage fixture', " +
+          "'2026-09-11T00:00:00.000Z', 'high', 'semantic', ?, ?, '{}')",
+      ).run(factId, ref, `op-${factId}`, version);
+    },
+    task(taskId: string, status: string) {
+      const version = next(`task/${taskId}`);
+      db.prepare("INSERT INTO task_snapshot VALUES (?, ?, ?, ?)").run(
+        taskId,
+        version,
+        JSON.stringify({ task: { taskId, status } }),
+        status,
+      );
+    },
+    edge(relationId: string, source: string, target: string, type: string, state = "active") {
+      const version = next(`relation/${relationId}`),
+        observed = versions.get(target) ?? null,
+        owner = source.startsWith("decision/") ? source.split("/").slice(0, 2).join("/") : source;
+      db.prepare("INSERT INTO relation_edge VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)").run(
+        relationId,
+        source,
+        target,
+        type,
+        state,
+        observed,
+        owner,
+        version,
+        JSON.stringify({
+          schema: "relation-projection/v1",
+          entity: {
+            kind: "relation",
+            id: relationId,
+            revision: version,
+            source,
+            target,
+            type,
+            direction: "directed",
+            strength: "strong",
+            origin: "declared",
+            state,
+            rationale: "coverage fixture",
+            targetObservedVersion: observed,
+          },
+          sourcePath: `event:op-${relationId}`,
+        }),
+      );
+    },
+  };
+}
+
+test("a claim evidenced only by a superseded Fact is not covered", () => {
+  const fixture = ledger();
+  try {
+    fixture.fact("F-OLD00001");
+    fixture.fact("F-NEW00001");
+    fixture.decision("dec_LIVENESS", [{ id: "C1", fulfillment: "evidenced" }]);
+    fixture.edge("rel_evidence", "decision/dec_LIVENESS/C1", "fact/F-OLD00001", "evidenced-by");
+    const covered = readDecisionGraphRows(fixture.db).coverageRows;
+    assert.equal(covered[0]?.status, "covered");
+    assert.equal(covered[0]?.coveringFactRef, "fact/F-OLD00001");
+
+    // `ha fact record --supersedes` writes the edge on the newer Fact, so the Fact owns it.
+    fixture.edge("rel_supersede", "fact/F-NEW00001", "fact/F-OLD00001", "supersedes-fact");
+    const [row] = readDecisionGraphRows(fixture.db).coverageRows;
+    assert.equal(row?.status, "uncovered", JSON.stringify(row));
+    assert.equal(row?.coveringFactRef, undefined);
+    assert.deepEqual(row?.relationPath, []);
+  } finally {
+    fixture.db.close();
+  }
+});

--- a/tools/gates/cost-budget.json
+++ b/tools/gates/cost-budget.json
@@ -72,6 +72,13 @@
         "gitProcesses": 6,
         "fileReadBytes": 495
       },
+      "decision-reckon": {
+        "sqlRowsRead": 219,
+        "sha256Calls": 29,
+        "sha256Bytes": 8548,
+        "gitProcesses": 6,
+        "fileReadBytes": 1237
+      },
       "receipt-show": {
         "sqlRowsRead": 38,
         "sha256Calls": 6,
@@ -164,6 +171,13 @@
         "sha256Bytes": 5905,
         "gitProcesses": 6,
         "fileReadBytes": 495
+      },
+      "decision-reckon": {
+        "sqlRowsRead": 219,
+        "sha256Calls": 29,
+        "sha256Bytes": 8548,
+        "gitProcesses": 6,
+        "fileReadBytes": 1237
       },
       "receipt-show": {
         "sqlRowsRead": 38,


### PR DESCRIPTION
# English

## Summary

`reckon`, the relation graph page and `decision validate` each read the whole decision graph (every claim, every decision-owned edge, every fact and task those edges point at) and then filtered down to the one decision that was asked about. On the canonical projection that is 27,025 rows per read, and it grows with the repository.

This PR adds `readDecisionCoverage(decisionIds)`: a read that resolves only the rows the asked-about decisions need (a recursive walk from their load-bearing claims over active edges, then the facts, tasks and supersedes-fact edges those edges point at) and hands them to the same `coverageOf`. The whole-graph read now passes every decision id through the same input, so there is one read path and no fallback.

It also fixes a regression that landed with e193a8d2f: the coverage read took its liveness edges from the decision-owned edge list, but a `supersedes-fact` edge starts at the newer Fact and never appears there, so superseded Facts still counted as evidence. On the canonical ledger this flips six claims from covered to uncovered (listed in the task report); each one's only covering Fact is the target of an active supersedes-fact edge.

## Architectural Justification

-

## What Changed

- `decision-projection-coverage.ts`: `decisionCoverage(db, decisionIds)` reads claims, reachable active edges, facts, tasks and supersedes-fact edges by id or edge endpoint (unary `+` on type and state keeps SQLite on the endpoint indexes). The liveness read is restored.
- `TaskProjection.readDecisionCoverage` port, wired through the knowledge queries and the read-only reader session. `DecisionService.graph()` deleted; reckon calls `coverage(id)`.
- Relation graph page (`task-query-read.ts`) reads coverage only for the decisions referenced on the page. `decision validate` reads its owner edges through `readRelationQuery({ ownerRef })` instead of the whole graph.
- `relationProjectionRowsAtCut` extracted from `readRelationProjectionRows` and reused.
- New fast test `decision-coverage-read.test.ts`: the superseded-Fact regression; a plan assertion that every table access searches by id or endpoint; a 200 vs 2,000 unrelated-decision scale check (101 rows read at both).
- G1 fixture gains a `decision-reckon` probe; `tools/gates/cost-budget.json` gains the matching `decision-reckon` baseline and budget entry (219 rows). Existing entries untouched.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Deleted code (no whole file): the four whole-table coverage reads, reckon's in-memory filter, `DecisionService.graph()`, and the private `readDecisionGraph()` copies in validate and the relation page.
- Production net lines: +118/-32 (net +86), from `node tools/gates/production-delta.mjs --base origin/main`.

## Machine-Readable Declarations

- `tools/gates/cost-budget.json`: new `decision-reckon` entry under `writeCostScaling.baseline` and `budgets`, baseline equal to budget. No dependency change, no event migration.

## Task And Scope

- Harness task: task_5c22671ab8bb95ec563d6d6a23 (successor of task_644341526c2540f75649959928)
- Branch: `codex/decision-coverage-single`
- Public scope: decision coverage read for a set of decisions; liveness regression fix; callers switched
- Private planning/evidence updated: yes (task report with 23 evidence files, three facts including F-E25F264B, closeout)
- Out of scope: the `owner_ref` column has no index on either table (schema change); `delivered` still ignores derives edges that start at `CH<n>`

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: yes — `tools/gates/cost-budget.json` (new `decision-reckon` entry) and the G1 fixture `packages/daemon/test/fixtures/g1-write-cost-scaling.ts` (new probe)
- Protected surface scope: additive only; no existing baseline, budget or exemption changed
- Authority: task_5c22671ab8bb95ec563d6d6a23 task_plan "CI/Gate Authority Stop Condition" authorises adding the reckon probe; the repository owner authorised governance fixes for this rescue line on 2026-09-11
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `8f437e6c5`
- Branch merge-base with `origin/main`: `8f437e6c5`
- Last `git fetch origin` time: 2026-09-11 UTC
- Sync method: rebased onto origin/main
- Public diff command: `git diff origin/main...codex/decision-coverage-single`
- Private evidence commit/path: task_5c22671ab8bb95ec563d6d6a23 `artifacts/report.md` and `artifacts/evidence/`
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [x] `npm run typecheck` (tsc, no errors)
- [ ] `npm test`
- [x] `npm run harness:check-import-boundaries` (via `run-manifest-gates --changed origin/main`)
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts` (via `run-manifest-gates --changed origin/main`)
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Regression: the new superseded-Fact test is red on main `daef48217` and green here.
- Scale, two tiers with a negative control (production withdrawn to the whole-graph read): G1 reckon probe 200 → 2,000 events: 219 → 219 rows (withdrawn: 481 → 2,209, gate red). Kernel test 200 → 2,000 unrelated decisions: 101 → 101 rows (withdrawn: 3,943 → 38,143, test fails).
- Plan assertion negative control: removing the unary `+` makes SQLite pick `relation_edge_state_page (state=?)` and the assertion fails.
- Equivalence on a read-only copy of the canonical projection (831 decisions, 10,617 edges): coverage rows identical for 831/831 decisions (1,056 rows), owner edges for validate 831/831, all 22 relation-graph pages 22/22. Against main, only the six liveness claims differ. Old read: 27,025 rows per call; new: median 48, max 103 rows per decision.
- Tests: 71/71 fast and contract locally; 14 integration files on isolated Ubuntu all exit 0 (json-rpc-protocol 51/51, decision-surface, G1 fixture, CLI reckon).
- Gates: `run-manifest-gates --changed origin/main`, `cost-budget`, tsc, eslint, `line-density`, `file-complexity`, `production-delta`, `test-selection` pass. CEO re-ran `decision-coverage-read.test.ts` on the branch head: 3/3.

## Review Evidence

- CEO ground-truth: read the e193a8d2f diff and confirmed that decision-owned edges cannot contain a supersedes-fact edge (it starts at the newer Fact), so the regression is real and the fix is the right layer.
- Independent closeout review: after merge, through the task's closeout review.
- Reviewer subagent: not used
- Human review: pending
- Blocking findings: none open

## Residual Risk

- The `decision-reckon` budget numbers were measured on macOS; if Linux CI reads different byte counts the cost-budget gate goes red and the entry needs the CI numbers.
- Six decisions on the canonical ledger change from covered to uncovered once this deploys; they were covered only by superseded Facts.
- `decision validate` reads edges by `owner_ref`, which has no index (same as `compileDraft` after F5).

## References

- Task: task_5c22671ab8bb95ec563d6d6a23; predecessor task_644341526c2540f75649959928
- PR #2451 (F5 endpoint index choice), e193a8d2f (regression origin)

---

# 中文

## 概要

`reckon`、relation graph 页和 `decision validate` 都先读整张 decision 图（全部 claim、全部 decision 拥有的边、这些边指向的全部 fact 和 task），再过滤出被问到的那一个 decision。在 canonical 投影上每次读 27,025 行，并随仓库增长。

本 PR 新增 `readDecisionCoverage(decisionIds)`：只读被问到的 decision 需要的行（从它们的 load-bearing claim 出发，递归求出 active 边，再按 id 读这些边指向的 fact、task，以及取代这些 fact 的 supersedes-fact 边），交给同一个 `coverageOf`。全量读取改为传入全部 decision id，只剩一条读路径，没有回退。

同时修掉 e193a8d2f 带入的回归：覆盖读取从「decision 拥有的边」里取 liveness 边，但 `supersedes-fact` 边从较新的 Fact 出发，永远不在那个列表里，所以被取代的 Fact 仍被当作有效证据。在 canonical 台账上这会让 6 条 claim 从 covered 变为 uncovered（名单在任务报告里）；每条的唯一覆盖 Fact 都是一条 active supersedes-fact 边的目标。

## 架构辩护

-

## 改动内容

- `decision-projection-coverage.ts`：`decisionCoverage(db, decisionIds)` 按 id 或边端点读 claim、可达 active 边、fact、task 与 supersedes-fact 边（type 与 state 上的一元 `+` 让 SQLite 留在端点索引上）。恢复 liveness 读取。
- 端口 `TaskProjection.readDecisionCoverage`，接到 knowledge queries 与只读 reader session。删除 `DecisionService.graph()`，reckon 改调 `coverage(id)`。
- relation graph 页（`task-query-read.ts`）只读页内引用到的 decision 的覆盖。`decision validate` 改用 `readRelationQuery({ ownerRef })` 读 owner 边，不再读整图。
- 从 `readRelationProjectionRows` 抽出 `relationProjectionRowsAtCut` 复用。
- 新 fast 测试 `decision-coverage-read.test.ts`：被取代 Fact 的回归；每张表都按 id 或端点查找的计划断言；200 对 2,000 个无关 decision 的规模对照（两档都读 101 行）。
- G1 夹具新增 `decision-reckon` 探针；`tools/gates/cost-budget.json` 新增对应的 `decision-reckon` 基线与预算条目（219 行）。已有条目未动。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 删除的门或 fixture：none
- 删除的代码（非整文件）：四张全表覆盖读取、reckon 的内存过滤、`DecisionService.graph()`、validate 与 relation 页各自的 `readDecisionGraph()`。
- 生产净行数：+118/-32（净 +86），来自 `node tools/gates/production-delta.mjs --base origin/main`。

## 机器可读声明

- `tools/gates/cost-budget.json`：`writeCostScaling.baseline` 与 `budgets` 新增 `decision-reckon`，基线等于预算。无依赖变化、无事件迁移。

## 任务与范围

- Harness 任务：task_5c22671ab8bb95ec563d6d6a23（task_644341526c2540f75649959928 的后继）
- 分支：`codex/decision-coverage-single`
- 公开范围：按 decision 集合读覆盖；liveness 回归修复；调用方切换
- 私有计划/证据已更新：是（任务报告与 23 个证据文件、三条 fact 含 F-E25F264B、closeout）
- 范围外：`owner_ref` 两张表都没有索引（需改 schema）；`delivered` 仍不认从 `CH<n>` 出发的 derives 边

## 版本影响

- 版本：不变
- 发布影响：不发布

## 治理声明

- 触碰受保护面：是——`tools/gates/cost-budget.json`（新增 `decision-reckon` 条目）与 G1 夹具 `packages/daemon/test/fixtures/g1-write-cost-scaling.ts`（新增探针）
- 受保护面范围：纯新增；已有基线、预算与豁免均未改
- 授权：task_5c22671ab8bb95ec563d6d6a23 的 task_plan「CI/Gate Authority Stop Condition」授权新增 reckon 探针；仓库所有者 2026-09-11 授权本救援线的治理修复
- 机器检查边界：本 PR 只断言声明存在；是否属实、是否充分由评审判断。
- Break-glass：否
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- 基线 `origin/main` SHA：`8f437e6c5`
- 分支与 `origin/main` 的 merge-base：`8f437e6c5`
- 最近一次 `git fetch origin`：2026-09-11 UTC
- 同步方式：rebase 到 origin/main
- 公开 diff 命令：`git diff origin/main...codex/decision-coverage-single`
- 私有证据路径：task_5c22671ab8bb95ec563d6d6a23 的 `artifacts/report.md` 与 `artifacts/evidence/`
- 评审证据路径：本 PR 的评审证据节
- GitHub Actions `rewrite-ci` run URL：本 PR 待跑
- 回归：新的被取代 Fact 测试在 main `daef48217` 上红、本分支绿。
- 规模，两档带阴性对照（生产撤回为整图读）：G1 reckon 探针 200 → 2,000 事件：219 → 219 行（撤回后 481 → 2,209，门报红）。内核测试 200 → 2,000 个无关 decision：101 → 101 行（撤回后 3,943 → 38,143，测试失败）。
- 计划断言阴性对照：去掉一元 `+` 后 SQLite 选 `relation_edge_state_page (state=?)`，断言失败。
- 等价验证（canonical 投影只读副本，831 个 decision、10,617 条边）：覆盖行 831/831 一致（1,056 行），validate 的 owner 边 831/831，relation graph 全部 22 页 22/22。与 main 相比只在 6 条 liveness claim 上不同。旧读取每次 27,025 行；新读取每个 decision 中位 48 行、最多 103 行。
- 测试：本机 fast/contract 71/71；隔离 Ubuntu 上 14 个 integration 文件全部 exit 0（json-rpc-protocol 51/51、decision-surface、G1 夹具、CLI reckon）。
- 门：`run-manifest-gates --changed origin/main`、`cost-budget`、tsc、eslint、`line-density`、`file-complexity`、`production-delta`、`test-selection` 通过。CEO 在分支头上复跑 `decision-coverage-read.test.ts`：3/3。

## 评审证据

- CEO 事实核对：读 e193a8d2f 的 diff，确认 decision 拥有的边不可能包含 supersedes-fact 边（它从较新的 Fact 出发），回归属实，修在正确的层。
- 独立收口评审：合入后经任务的 closeout review。
- 评审子代理：未用
- 人工评审：待定
- 阻塞发现：无

## 残余风险

- `decision-reckon` 的预算数值在 macOS 上测得；Linux CI 若读出不同字节数，cost-budget 门会红，需要改为 CI 的数值。
- 部署后 canonical 台账上有 6 个 decision 从 covered 变为 uncovered；它们只被已取代的 Fact 覆盖。
- `decision validate` 按 `owner_ref` 读边，这一列没有索引（与 F5 之后的 `compileDraft` 相同）。

## 参考

- 任务：task_5c22671ab8bb95ec563d6d6a23；前任务 task_644341526c2540f75649959928
- PR #2451（F5 端点索引选择）、e193a8d2f（回归来源）

