### PR TITLE
test(daemon): cover runtime redispatch hotloop regression

### DIFF
--- a/packages/daemon/test/runtime-spawn-ingress.integration.test.ts
+++ b/packages/daemon/test/runtime-spawn-ingress.integration.test.ts
@@ -9,6 +9,8 @@ import { localUserDaemonEndpoint } from "../src/client/local-daemon-target.ts";
 import { openDaemonHost } from "../src/daemon-host.ts";
 import { createJsonRpcProtocolServer } from "../src/protocol/json-rpc-server.ts";
 import { createUnixSocketTransportServer } from "../src/transport/unix-socket.ts";
+import { cellCodedError } from "../src/repo-cell-errors.ts";
+import { projectedTaskIds } from "../src/repo-cell-receipts.ts";
 import { writeProviderExecutable } from "./fixtures/runtime-stub.ts";
 import { registerBootstrappedDaemonRepo as registerDaemonRepo } from "./repo-settings.fixture.ts";
 import { createRealizedTaskPlanFixture, realizeTaskPlanFixture } from "../../../tools/fixtures/task-plan.mjs";
@@ -407,20 +409,41 @@ test("daemon ingress preserves executor-scoped task-bound runtime spawn", async 
         kind: "agent",
         id: `runtime-session:${receipt.runtimeSessionId}`,
       });
+      assert.equal(
+        makeTaskEventReader({ repoId, rootDir: root })
+          .read()
+          .events.some(
+            (event) =>
+              event.type === "runtime_dispatch_requested" &&
+              event.payload.runtimeSessionId === receipt.runtimeSessionId &&
+              event.payload.dispatchId === receipt.dispatchId,
+          ),
+        true,
+        "the first dispatch must be durably recorded before the redispatch attempt",
+      );
       const launchesAfterFirst = launchCount,
-        concurrent = await rpc(host, auth, "repo.agentRuntime.spawn", {
-          repo: { repoId },
-          payload: {
-            runtimeInstanceId: ingressDefinition.instanceId,
-            cwd: { scope: "repo-root" },
-            prompt: "A second dispatcher must not share the execution lease.",
-            taskId,
-            idempotencyKey: "dispatcher-handoff-concurrent",
-          },
-        });
+        [concurrent, unrelated] = await Promise.all([
+          rpc(host, auth, "repo.agentRuntime.spawn", {
+            repo: { repoId },
+            payload: {
+              runtimeInstanceId: ingressDefinition.instanceId,
+              cwd: { scope: "repo-root" },
+              prompt: "A second dispatcher must not share the execution lease.",
+              taskId,
+              idempotencyKey: "dispatcher-handoff-concurrent",
+            },
+          }),
+          Promise.race([
+            createReadyTask("task-runtime-dispatcher-unrelated", "Dispatcher unrelated write"),
+            new Promise<never>((_resolve, reject) => {
+              setTimeout(() => reject(new Error("unrelated write was not accepted within 5000ms")), 5_000);
+            }),
+          ]),
+        ]);
       assert.equal(concurrent.outcome, "op_rejected", JSON.stringify(concurrent));
       assert.equal(concurrent.code, "runtime_task_lease_required", JSON.stringify(concurrent));
       assert.equal(launchCount, launchesAfterFirst, "the rejected dispatch must not launch a provider");
+      assert.equal(unrelated, undefined);
       const projection = makeTaskProjection({
         rootDir: root,
         eventStore: makeTaskEventReader({ repoId, rootDir: root }),
@@ -441,6 +464,21 @@ test("daemon ingress preserves executor-scoped task-bound runtime spawn", async 
       } finally {
         projection.close();
       }
+    });
+    await t.test("a lagging task identity projection rejects without scanning canonical batches", () => {
+      const cell = {
+        knownTaskIds: null,
+        projection: {
+          list: () => ({ watermark: 2, sourceRevision: 3, rows: [{ taskId: "task-projected" }] }),
+        },
+        cellCodedError,
+      };
+      assert.throws(
+        () => projectedTaskIds(cell),
+        (error: Error & { readonly code?: string }) =>
+          error.code === "content_not_ready" && /watermark 2, source revision 3/u.test(error.message),
+      );
+      assert.equal(cell.knownTaskIds, null);
     });
     await t.test("a worker cannot replace its relay with the private daemon endpoint", async () => {
       const scratchUserRoot = path.join(parent, "isolated-user");


### PR DESCRIPTION
# English

## Summary

Test-only. The runtime redispatch hotloop (a second `repo.agentRuntime.spawn` on a task whose first dispatch is already durably recorded) was fixed on main by a8389b200; this PR locks the behaviour with a regression test so it cannot silently return.

The ingress test now proves, in one scenario, that the first dispatch is durably recorded before the redispatch is attempted, that the redispatch is rejected with the typed `runtime_task_lease_required` and launches no provider, and that an unrelated task write queued concurrently is still accepted within 5 s (the hotloop used to starve it). A second subtest locks the `projectedTaskIds` contract: when the task identity projection lags the source revision, ingress rejects with `content_not_ready` without scanning canonical batches and leaves `knownTaskIds` unset.

## Architectural Justification

-

## What Changed

- `packages/daemon/test/runtime-spawn-ingress.integration.test.ts`: the redispatch scenario asserts the durable `runtime_dispatch_requested` event first, races the redispatch against an unrelated `task-create`, and adds the lagging-projection subtest.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: +0/-0; test +48/-10.

## Machine-Readable Declarations

- None.

## Task And Scope

- Harness task: task_5a330de641ae85cb7cb45374bf
- Branch: `codex/runtime-hotloop-regression`
- Public scope: regression coverage for the redispatch hotloop and the lagging-projection rejection
- Private planning/evidence updated: yes (premise update in task_plan, fact F-4637262B, dispatch report)
- Out of scope: production changes; none were needed

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: not applicable
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `8f437e6c5`
- Branch merge-base with `origin/main`: `8f437e6c5`
- Last `git fetch origin` time: 2026-09-11 UTC
- Sync method: branched from origin/main
- Public diff command: `git diff origin/main...codex/runtime-hotloop-regression`
- Private evidence commit/path: task_5a330de641ae85cb7cb45374bf `artifacts/reports/dispatch_c038d1ff8bc506ec2cb29f48.md`
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [x] `npm run harness:check-import-boundaries` (via `run-manifest-gates --changed origin/main`)
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts` (via `run-manifest-gates --changed origin/main`)
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Isolated Ubuntu (`tools/dispatch-isolated-test.mjs`): `runtime-spawn-ingress.integration` 18/18, `rejection-next-actions.integration` 9/9.
- Negative control: with `projectedTaskIds` restored to its a8389b200^ form, the ingress suite fails at the new lagging-identity assertion (`Missing expected exception`); restored, green again.

## Review Evidence

- CEO read the diff: test-only, the assertions match the fixed behaviour on main.
- Reviewer subagent: not used
- Human review: pending
- Blocking findings: none open

## Residual Risk

- The unrelated-write race uses a 5 s ceiling; on a very slow runner it could fail for speed rather than starvation.

## References

- Task: task_5a330de641ae85cb7cb45374bf
- a8389b200 (the production fix this test locks)

---

# 中文

## 概要

只改测试。runtime 重复派工热循环（对已经持久记录了第一次派工的任务再发一次 `repo.agentRuntime.spawn`）已由 main 上的 a8389b200 修掉；本 PR 用回归测试锁住这个行为，防止它悄悄回来。

ingress 测试现在在一个场景里证明：重复派工之前第一次派工已经持久记录；重复派工被拒且带 typed `runtime_task_lease_required`、不启动 provider；同时排队的无关任务写入在 5 秒内仍被接受（热循环以前会饿死它）。第二个子测试锁住 `projectedTaskIds` 的契约：任务身份投影落后于源 revision 时，ingress 以 `content_not_ready` 拒绝、不扫描 canonical batch、`knownTaskIds` 保持未设置。

## 架构辩护

-

## 改动内容

- `packages/daemon/test/runtime-spawn-ingress.integration.test.ts`：重复派工场景先断言持久的 `runtime_dispatch_requested` 事件，把重复派工与无关的 `task-create` 并发竞速，并新增投影落后的子测试。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 删除的门或 fixture：none
- 生产净行数：+0/-0；测试 +48/-10。

## 机器可读声明

- 无。

## 任务与范围

- Harness 任务：task_5a330de641ae85cb7cb45374bf
- 分支：`codex/runtime-hotloop-regression`
- 公开范围：重复派工热循环与投影落后拒绝的回归覆盖
- 私有计划/证据已更新：是（task_plan 前提更新、fact F-4637262B、派工报告）
- 范围外：生产改动；本任务不需要

## 版本影响

- 版本：不变
- 发布影响：不发布

## 治理声明

- 触碰受保护面：否
- 受保护面范围：不适用
- 授权：不适用
- 机器检查边界：本 PR 只断言声明存在；是否属实、是否充分由评审判断。
- Break-glass：否
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- 基线 `origin/main` SHA：`8f437e6c5`
- 分支与 `origin/main` 的 merge-base：`8f437e6c5`
- 最近一次 `git fetch origin`：2026-09-11 UTC
- 同步方式：从 origin/main 分出
- 公开 diff 命令：`git diff origin/main...codex/runtime-hotloop-regression`
- 私有证据路径：task_5a330de641ae85cb7cb45374bf 的 `artifacts/reports/dispatch_c038d1ff8bc506ec2cb29f48.md`
- 评审证据路径：本 PR 的评审证据节
- GitHub Actions `rewrite-ci` run URL：本 PR 待跑
- 隔离 Ubuntu（`tools/dispatch-isolated-test.mjs`）：`runtime-spawn-ingress.integration` 18/18，`rejection-next-actions.integration` 9/9。
- 阴性对照：把 `projectedTaskIds` 恢复到 a8389b200^ 的形态，ingress 套件在新的投影落后断言处失败（`Missing expected exception`）；恢复后再次全绿。

## 评审证据

- CEO 读过 diff：只改测试，断言与 main 上已修的行为一致。
- 评审子代理：未用
- 人工评审：待定
- 阻塞发现：无

## 残余风险

- 无关写入的竞速用 5 秒上限；在极慢的 runner 上可能因速度而非饿死失败。

## 参考

- 任务：task_5a330de641ae85cb7cb45374bf
- a8389b200（本测试锁住的生产修复）

