### PR TITLE
fix(daemon): classify blank provider turns as faults

### DIFF
--- a/packages/daemon/src/runtime-provider-fault.ts
+++ b/packages/daemon/src/runtime-provider-fault.ts
@@ -84,6 +84,14 @@ export function classifyRuntimeExit(
     return classified("worker_stop", `Worker process stopped before settlement: ${active.lossReason}`);
   if (exitCode === null)
     return classified("provider_fault", "Provider process disconnected before completing the attempt.");
+  if (
+    exitCode === 0 &&
+    active.providerOutcome === "succeeded" &&
+    !active.toolCallObserved &&
+    !active.nonEmptyAgentOutputObserved &&
+    active.providerUsageEmpty
+  )
+    return classified("provider_fault", "Provider completed a turn but produced no output.");
   if (attemptFailed && !active.toolCallObserved) {
     const reason = active.errorOverflowed
       ? `Provider exited with code ${String(exitCode)} before any tool call; stderr exceeded the diagnostic limit.`
@@ -124,6 +132,8 @@ export function observeProviderFault(active: ActiveRuntime, frame: ProviderFrame
     active.toolCallObserved = true;
     active.providerFault = null;
   }
+  if (frame.finalText?.trim()) active.nonEmptyAgentOutputObserved = true;
+  if (frame.providerUsageEmpty !== undefined) active.providerUsageEmpty = frame.providerUsageEmpty;
   if (frame.providerFault) active.providerFault = frame.providerFault;
 }
 

--- a/packages/daemon/src/runtime-spawn-active.ts
+++ b/packages/daemon/src/runtime-spawn-active.ts
@@ -25,6 +25,8 @@ type ActiveRuntimeBase = Omit<
   | "descendantsAlive"
   | "worktreeDirty"
   | "toolCallObserved"
+  | "nonEmptyAgentOutputObserved"
+  | "providerUsageEmpty"
   | "providerFault"
   | "fallbackAttempt"
 > & { readonly providerSessionId?: string | null; readonly fallbackAttempt?: ActiveRuntime["fallbackAttempt"] };
@@ -55,6 +57,8 @@ export function createActiveRuntime(base: ActiveRuntimeBase): ActiveRuntime {
     descendantsAlive: false,
     worktreeDirty: false,
     toolCallObserved: false,
+    nonEmptyAgentOutputObserved: false,
+    providerUsageEmpty: false,
     providerFault: null,
   };
 }

--- a/packages/daemon/src/runtime-spawn-provider-frames.ts
+++ b/packages/daemon/src/runtime-spawn-provider-frames.ts
@@ -140,7 +140,11 @@ export function parseCodexFrame(value: Record<string, unknown>, providerSessionI
       };
     return {};
   }
-  if (value.type === "turn.completed") return { outcome: "succeeded" };
+  if (value.type === "turn.completed")
+    return {
+      outcome: "succeeded",
+      providerUsageEmpty: !isPlainRecord(value.usage) || Object.keys(value.usage).length === 0,
+    };
   if (value.type === "turn.failed") {
     const failureText = isPlainRecord(value.error) ? JSON.stringify(value.error) : undefined;
     return {

--- a/packages/daemon/src/runtime-spawn-types.ts
+++ b/packages/daemon/src/runtime-spawn-types.ts
@@ -179,6 +179,8 @@ export type ActiveRuntime = {
   descendantsAlive: boolean;
   worktreeDirty: boolean;
   toolCallObserved: boolean;
+  nonEmptyAgentOutputObserved: boolean;
+  providerUsageEmpty: boolean;
   providerFault: RuntimeProviderFault | null;
 };
 
@@ -192,6 +194,7 @@ export type ProviderFrame = {
   readonly planObserved?: boolean;
   readonly planIncomplete?: boolean;
   readonly toolCallObserved?: boolean;
+  readonly providerUsageEmpty?: boolean;
   readonly providerFault?: RuntimeProviderFault;
 };
 

--- a/packages/daemon/test/runtime-provider-fault.test.ts
+++ b/packages/daemon/test/runtime-provider-fault.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import type { ActiveRuntime } from "../src/runtime-spawn-types.ts";
 import { classifyRuntimeExit, observeProviderFault, providerFaultFromFrame } from "../src/runtime-provider-fault.ts";
+import { parseCodexFrame } from "../src/runtime-spawn-provider-frames.ts";
 
 test("structured provider errors classify rate limits, server faults, quota, model, and auth failures", () => {
   const rateLimit = providerFaultFromFrame("codex", {
@@ -163,6 +164,39 @@ test("attempt-bound classification falls back only before tools or for recognize
   assert.equal(classifyRuntimeExit(recovered, 1).classification, "gate_red");
 });
 
+test("blank successful Codex turns classify as provider faults", () => {
+  const runtime = active({ providerOutcome: null });
+  for (const frame of [
+    { type: "thread.started", thread_id: "provider-session" },
+    { type: "turn.started" },
+    { type: "item.completed", item: { id: "item_0", type: "agent_message", text: " " } },
+    { type: "turn.completed", usage: {} },
+  ]) {
+    const parsed = parseCodexFrame(frame, "provider-session");
+    if (parsed.finalText !== undefined) runtime.finalText = parsed.finalText;
+    if (parsed.outcome) runtime.providerOutcome = parsed.outcome;
+    observeProviderFault(runtime, parsed);
+  }
+  const result = classifyRuntimeExit(runtime, 0);
+  assert.equal(result.outcome, "succeeded");
+  assert.equal(result.classification, "provider_fault");
+  assert.equal(result.reason, "Provider completed a turn but produced no output.");
+});
+
+test("non-blank successful Codex turns remain worker stops", () => {
+  const runtime = active({ providerOutcome: null });
+  for (const frame of [
+    { type: "item.completed", item: { id: "item_0", type: "agent_message", text: "done" } },
+    { type: "turn.completed", usage: {} },
+  ]) {
+    const parsed = parseCodexFrame(frame, "provider-session");
+    if (parsed.finalText !== undefined) runtime.finalText = parsed.finalText;
+    if (parsed.outcome) runtime.providerOutcome = parsed.outcome;
+    observeProviderFault(runtime, parsed);
+  }
+  assert.equal(classifyRuntimeExit(runtime, 0).classification, "worker_stop");
+});
+
 test("observed provider fault takes precedence over a later runtime loss", () => {
   const result = classifyRuntimeExit(
     active({
@@ -196,6 +230,8 @@ function active(overrides: Partial<ActiveRuntime>): ActiveRuntime {
     errorOverflowed: false,
     errorBuffer: "",
     toolCallObserved: false,
+    nonEmptyAgentOutputObserved: false,
+    providerUsageEmpty: false,
     providerOutcome: null,
     failureText: null,
     permissionMode: "read-only",


### PR DESCRIPTION
# English

## Summary

A Codex turn that completes with a single whitespace-only `agent_message`, an empty `usage`, no tool call and exit 0 was settled as `worker_stop` / `succeeded` with a one-byte result artifact (dispatch_ae06e0764279f0bd936f2274, 2026-09-11 02:50). Nothing downstream noticed; the CEO found it by reading the task package. Such a turn is a provider-side failure (upstream filter or empty reply) and must be classified as `provider_fault` so the existing fallback chain can act on it.

## Architectural Justification

-

## What Changed

- `runtime-spawn-provider-frames.ts`: the Codex `turn.completed` frame reports `providerUsageEmpty` (usage missing or `{}`).
- `runtime-spawn-types.ts` / `runtime-spawn-active.ts`: `ActiveRuntime` gains `nonEmptyAgentOutputObserved` and `providerUsageEmpty`, both default false.
- `runtime-provider-fault.ts`: `observeProviderFault` sets the two observations; `classifyRuntimeExit` classifies exit 0 + provider succeeded + no tool call + no non-blank agent text + empty usage as `provider_fault` ("Provider completed a turn but produced no output."). Any non-blank text keeps `worker_stop`. Other providers never set `providerUsageEmpty`, so they are unaffected.
- `runtime-provider-fault.test.ts`: the recorded blank event sequence classifies as `provider_fault`; the same sequence with a non-blank message stays `worker_stop` (negative control).

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: +22/-1 (net +21), from `node tools/gates/production-delta.mjs --base origin/main`; tests +36/-0.

## Machine-Readable Declarations

- None.

## Task And Scope

- Harness task: task_56295761e7a5099639992d5325
- Branch: `codex/runtime-blank-turn`
- Public scope: attempt classification of blank provider turns
- Private planning/evidence updated: yes (task plan, report, fact F-50C5FCCD)
- Out of scope: fallback policy; retry counts

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: not applicable
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `076933148`
- Branch merge-base with `origin/main`: `076933148`
- Last `git fetch origin` time: 2026-09-11 UTC
- Sync method: branched from origin/main
- Public diff command: `git diff origin/main...codex/runtime-blank-turn`
- Private evidence commit/path: task_56295761e7a5099639992d5325 `artifacts/report.md`
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [x] `npm run typecheck`
- [ ] `npm test`
- [x] `npm run harness:check-import-boundaries` (via `run-manifest-gates --changed origin/main`)
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts` (via `run-manifest-gates --changed origin/main`)
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- `node --test packages/daemon/test/runtime-provider-fault.test.ts`: 9/9, including the recorded blank sequence and the non-blank negative control.

## Review Evidence

- CEO read the diff: the new branch sits before the generic `worker_stop` default and after every existing fault branch; the observation bits are set only from provider frames.
- Reviewer subagent: not used
- Human review: pending
- Blocking findings: none open

## Residual Risk

- Only Codex frames report `providerUsageEmpty`; a blank turn from another provider still settles as `worker_stop` until its frame parser reports usage.

## References

- Task: task_56295761e7a5099639992d5325
- Event sample: `.harness/runtime/dispatches/dispatch_ae06e0764279f0bd936f2274.jsonl`

---

# 中文

## 概要

一次 Codex 回合只产出一条全空白的 `agent_message`、`usage` 为空、没有 tool call、exit 0，被结算成 `worker_stop` / `succeeded`，result artifact 只有 1 字节（dispatch_ae06e0764279f0bd936f2274，2026-09-11 02:50）。下游没有任何告警，CEO 是读任务包才发现的。这种回合是 provider 侧失败（上游过滤或空回复），必须判为 `provider_fault`，让既有 fallback 链能处理。

## 架构辩护

-

## 改动内容

- `runtime-spawn-provider-frames.ts`：Codex 的 `turn.completed` 帧报告 `providerUsageEmpty`（usage 缺失或为 `{}`）。
- `runtime-spawn-types.ts` / `runtime-spawn-active.ts`：`ActiveRuntime` 新增 `nonEmptyAgentOutputObserved` 与 `providerUsageEmpty`，默认 false。
- `runtime-provider-fault.ts`：`observeProviderFault` 置这两个观察位；`classifyRuntimeExit` 把「exit 0 + provider 成功 + 无 tool call + 无非空白文本 + usage 为空」判为 `provider_fault`（"Provider completed a turn but produced no output."）。有非空白文本仍是 `worker_stop`。其它 provider 不会置 `providerUsageEmpty`，不受影响。
- `runtime-provider-fault.test.ts`：录下来的空白事件序列判为 `provider_fault`；同一序列换成非空白消息仍是 `worker_stop`（阴性对照）。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 删除的门或 fixture：none
- 生产净行数：+22/-1（净 +21），来自 `node tools/gates/production-delta.mjs --base origin/main`；测试 +36/-0。

## 机器可读声明

- 无。

## 任务与范围

- Harness 任务：task_56295761e7a5099639992d5325
- 分支：`codex/runtime-blank-turn`
- 公开范围：空白 provider 回合的结算分类
- 私有计划/证据已更新：是（任务计划、报告、fact F-50C5FCCD）
- 范围外：fallback 策略；重试计数

## 版本影响

- 版本：不变
- 发布影响：不发布

## 治理声明

- 触碰受保护面：否
- 受保护面范围：不适用
- 授权：不适用
- 机器检查边界：本 PR 只断言声明存在；是否属实、是否充分由评审判断。
- Break-glass：否
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- 基线 `origin/main` SHA：`076933148`
- 分支与 `origin/main` 的 merge-base：`076933148`
- 最近一次 `git fetch origin`：2026-09-11 UTC
- 同步方式：从 origin/main 分出
- 公开 diff 命令：`git diff origin/main...codex/runtime-blank-turn`
- 私有证据路径：task_56295761e7a5099639992d5325 的 `artifacts/report.md`
- 评审证据路径：本 PR 的评审证据节
- GitHub Actions `rewrite-ci` run URL：本 PR 待跑
- `node --test packages/daemon/test/runtime-provider-fault.test.ts`：9/9，含录下的空白序列与非空白阴性对照。

## 评审证据

- CEO 读过 diff：新分支位于通用 `worker_stop` 默认分支之前、所有既有 fault 分支之后；观察位只由 provider 帧置位。
- 评审子代理：未用
- 人工评审：待定
- 阻塞发现：无

## 残余风险

- 只有 Codex 帧报告 `providerUsageEmpty`；其它 provider 的空白回合在其帧解析器报告 usage 之前仍会结算成 `worker_stop`。

## 参考

- 任务：task_56295761e7a5099639992d5325
- 事件样本：`.harness/runtime/dispatches/dispatch_ae06e0764279f0bd936f2274.jsonl`
