### PR TITLE
feat(kernel,daemon): review return budget as a repository setting

### DIFF
--- a/packages/application/test/execution-approval-idempotency.test.ts
+++ b/packages/application/test/execution-approval-idempotency.test.ts
@@ -37,6 +37,7 @@ test("approval retry reuses Review identity and ignores transport-only metadata"
       actorBinding: reviewer,
       capability: "execution-review@v1" as const,
       capabilityRef: "cap-ae",
+      returnBudget: 3,
     };
     const first = await harness.service.execute(command, proof);
     const second = await harness.service.execute({ ...command, transport: { attempt: 2 } }, proof);
@@ -78,7 +79,12 @@ test("idempotent retry rejects source, workspace, expectedRevision, digest drift
       workspaceRevision: 4,
       occurredAt: "2026-08-11T00:04:00.000Z",
     };
-    const proof = { actorBinding: reviewer, capability: "execution-review@v1" as const, capabilityRef: "cap-drift" };
+    const proof = {
+      actorBinding: reviewer,
+      capability: "execution-review@v1" as const,
+      capabilityRef: "cap-drift",
+      returnBudget: 3,
+    };
     await harness.service.execute(command, proof);
     const drifts = [
       { source: "remote_direct" as const },

--- a/packages/application/test/task-lifecycle-test-harness.ts
+++ b/packages/application/test/task-lifecycle-test-harness.ts
@@ -42,7 +42,6 @@ export const replayGraph = {
       kind: "return",
     },
   ] as const,
-  maxIterations: 1 as const,
 };
 
 export function lifecycleHarness() {
@@ -263,6 +262,7 @@ export function lifecycleHarness() {
           actorBinding: reviewer,
           capability: "execution-review@v1",
           capabilityRef: `cap-${opId}`,
+          returnBudget: 3,
         },
       );
     },

--- a/packages/daemon/src/protocol/daemon-protocol-commands.ts
+++ b/packages/daemon/src/protocol/daemon-protocol-commands.ts
@@ -70,6 +70,7 @@ const settingsWriteTopology = {
             enum: ["execution", "principal"],
           },
         ),
+        positiveSettingInput("--review-return-budget"),
         cliInput(
           "--locale",
           "single",

--- a/packages/daemon/src/protocol/daemon-protocol-gui-actions.ts
+++ b/packages/daemon/src/protocol/daemon-protocol-gui-actions.ts
@@ -195,6 +195,7 @@ export const daemonGuiActionMethods = Object.freeze([
       defaultPreset: "string?",
       defaultProfile: "string?",
       reviewIndependence: "string?",
+      reviewReturnBudget: "number?",
       locale: "string?",
       taskScaffold: "string?",
       repositoryScaffold: "string?",

--- a/packages/daemon/src/protocol/daemon-protocol-rpc-validation.ts
+++ b/packages/daemon/src/protocol/daemon-protocol-rpc-validation.ts
@@ -284,7 +284,8 @@ export function validateGuiActionPayload(method: DaemonGuiActionMethod, value: u
   if (method === "repo.task.submit") errors.push(...validateGuiSubmission(value.submission));
   if (method === "repo.settings.update") {
     const settingFields = (
-        "defaultVertical defaultPreset defaultProfile reviewIndependence locale taskScaffold repositoryScaffold " +
+        "defaultVertical defaultPreset defaultProfile reviewIndependence reviewReturnBudget locale taskScaffold " +
+        "repositoryScaffold " +
         "walFlushAdaptive walFlushEvents walFlushBytes walFlushMilliseconds"
       ).split(" "),
       changed = settingFields.filter((field) => value[field] !== undefined),
@@ -298,6 +299,8 @@ export function validateGuiActionPayload(method: DaemonGuiActionMethod, value: u
       [value.walFlushEvents, value.walFlushBytes, value.walFlushMilliseconds].some(
         (item) => item !== undefined && (!Number.isSafeInteger(item) || Number(item) < 1),
       ) ||
+      (value.reviewReturnBudget !== undefined &&
+        (!Number.isSafeInteger(value.reviewReturnBudget) || Number(value.reviewReturnBudget) < 1)) ||
       (value.locale !== undefined && !["en-US", "zh-CN"].includes(String(value.locale))) ||
       (value.reviewIndependence !== undefined && !["execution", "principal"].includes(String(value.reviewIndependence)))
     )

--- a/packages/daemon/src/protocol/daemon-protocol-validate-entities.ts
+++ b/packages/daemon/src/protocol/daemon-protocol-validate-entities.ts
@@ -32,7 +32,7 @@ export const stringArray = (value: unknown): value is readonly string[] =>
 
 export const sha = (value: unknown): boolean => typeof value === "string" && /^[0-9a-f]{40}$/u.test(value),
   digest = (value: unknown): boolean => typeof value === "string" && /^sha256:[0-9a-f]{64}$/u.test(value),
-  iteration = (value: unknown): boolean => value === 0 || value === 1;
+  iteration = (value: unknown): boolean => Number.isSafeInteger(value) && Number(value) >= 0;
 
 export const statusWord = (vocabulary: readonly string[], value: unknown): boolean =>
   vocabulary.includes(String(value));

--- a/packages/daemon/src/repo-cell-execution-selection.ts
+++ b/packages/daemon/src/repo-cell-execution-selection.ts
@@ -58,7 +58,7 @@ export function reviewExecutionSelection(
 ): {
   readonly executionId: string;
   readonly commitSha: string;
-  readonly iteration: 0 | 1;
+  readonly iteration: number;
   readonly submissionDigest: `sha256:${string}`;
 } {
   const requestedExecutionId = explicitExecutionId(action),

--- a/packages/daemon/src/repo-cell-proof.ts
+++ b/packages/daemon/src/repo-cell-proof.ts
@@ -222,6 +222,7 @@ export async function proofFor(
       actorBinding: command.actor,
       capability: "execution-review@v1",
       capabilityRef: authorizationDecision.policyRef,
+      returnBudget: settings.reviewReturnBudget,
       authorizationDecision,
     };
   }

--- a/packages/gui/src/renderer/model/types.ts
+++ b/packages/gui/src/renderer/model/types.ts
@@ -95,7 +95,7 @@ interface TaskRowFields {
   profile?: string;
   createdBy?: string;
   currentNode?: "implementation" | "review";
-  iteration?: 0 | 1;
+  iteration?: number;
   activeExecutionId?: string;
   leaseExpiresAt?: string;
   /**

--- a/packages/gui/test/service-bridge.test.ts
+++ b/packages/gui/test/service-bridge.test.ts
@@ -284,6 +284,7 @@ test("GUI client reaches every shipped read through a real resident daemon", asy
       defaultPreset: "standard-task",
       defaultProfile: "baseline",
       reviewIndependence: "execution",
+      reviewReturnBudget: 3,
       locale: "en-US",
       scaffolds: {
         task: "governance/task-scaffold.json",

--- a/packages/kernel/src/domain/code-doc-witness.ts
+++ b/packages/kernel/src/domain/code-doc-witness.ts
@@ -10,7 +10,7 @@ export interface CodeDocWitnessV1 {
   readonly taskId: string;
   readonly executionId: string;
   readonly commitSha: string;
-  readonly iteration: 0 | 1;
+  readonly iteration: number;
   readonly paths: readonly string[];
   readonly actor: ActorAxes;
   readonly source: WriteSource;
@@ -23,7 +23,7 @@ export interface CodeDocRepointV1 {
   readonly taskId: string;
   readonly executionId: string;
   readonly commitSha: string;
-  readonly iteration: 0 | 1;
+  readonly iteration: number;
   readonly paths: readonly string[];
   readonly disposition: "repointed" | "known-invalid";
   readonly reason: string;
@@ -56,7 +56,8 @@ export function validateCodeDocWitnessV1(
   return value.schema === "code-doc-witness/v1" &&
     [value.witnessId, value.taskId, value.executionId, value.reconciledAt].every(isNonEmptyString) &&
     isNativeCommitSha(value.commitSha) &&
-    (value.iteration === 0 || value.iteration === 1) &&
+    Number.isSafeInteger(value.iteration) &&
+    Number(value.iteration) >= 0 &&
     canonical &&
     validateActorAxes(value.actor, allowUnknownFields).length === 0 &&
     validateWriteSource(value.source, allowUnknownFields).length === 0
@@ -95,7 +96,8 @@ export function validateCodeDocRepointV1(
       isNonEmptyString,
     ) &&
     isNativeCommitSha(value.commitSha) &&
-    (value.iteration === 0 || value.iteration === 1) &&
+    Number.isSafeInteger(value.iteration) &&
+    Number(value.iteration) >= 0 &&
     (value.disposition === "repointed" || value.disposition === "known-invalid") &&
     paths &&
     validateActorAxes(value.actor, allowUnknownFields).length === 0 &&

--- a/packages/kernel/src/domain/completion-evidence.ts
+++ b/packages/kernel/src/domain/completion-evidence.ts
@@ -5,7 +5,7 @@ export type CompletionEvidenceResult = (typeof completionEvidenceResults)[number
 
 export interface CompletionEvidenceBasis {
   readonly executionId: string;
-  readonly iteration: 0 | 1;
+  readonly iteration: number;
   readonly submissionDigest: `sha256:${string}`;
   readonly codeCommit?: string;
   readonly ledgerCut?: number;

--- a/packages/kernel/src/domain/completion-gate-publication.ts
+++ b/packages/kernel/src/domain/completion-gate-publication.ts
@@ -55,7 +55,7 @@ export function compileCompletionGateWitness(input: {
       taskId: input.taskId,
       executionId: input.executionId,
       commitSha: input.commitSha,
-      iteration: input.iteration as 0 | 1,
+      iteration: input.iteration,
       actor: input.actor,
       source: input.source,
       verifiedAt: input.occurredAt,

--- a/packages/kernel/src/domain/completion-gate-witness.ts
+++ b/packages/kernel/src/domain/completion-gate-witness.ts
@@ -16,7 +16,7 @@ export interface CompletionGateWitnessV1 {
   readonly taskId: string;
   readonly executionId: string;
   readonly commitSha: string;
-  readonly iteration: 0 | 1;
+  readonly iteration: number;
   readonly actor: ActorAxes;
   readonly source: WriteSource;
   readonly verifiedAt: string;
@@ -62,13 +62,15 @@ export function validateCompletionGateWitnessV1(
     ].every(isNonEmptyString) ||
     !["pass", "fail", "advisory", "not_run"].includes(record.result as string) ||
     !isNativeCommitSha(record.commitSha) ||
-    (record.iteration !== 0 && record.iteration !== 1) ||
+    !Number.isSafeInteger(record.iteration) ||
+    Number(record.iteration) < 0 ||
     validateActorAxes(record.actor, allowUnknownFields).length ||
     validateWriteSource(record.source, allowUnknownFields).length ||
     (record.observed !== undefined && typeof record.observed !== "boolean") ||
     (record.basis !== undefined &&
       (!isNonEmptyString(record.basis.executionId) ||
-        (record.basis.iteration !== 0 && record.basis.iteration !== 1) ||
+        !Number.isSafeInteger(record.basis.iteration) ||
+        Number(record.basis.iteration) < 0 ||
         !/^sha256:[0-9a-f]{64}$/u.test(record.basis.submissionDigest) ||
         (record.basis.codeCommit !== undefined && !isNativeCommitSha(record.basis.codeCommit)) ||
         (record.basis.ledgerCut !== undefined &&

--- a/packages/kernel/src/domain/execution.ts
+++ b/packages/kernel/src/domain/execution.ts
@@ -53,7 +53,7 @@ export interface ExecutionV1 {
   readonly executionId: string;
   readonly taskId: string;
   readonly nodeId: TaskNodeId;
-  readonly iteration: 0 | 1;
+  readonly iteration: number;
   readonly state: ExecutionV1State;
   readonly actor: ActorAxes;
   readonly claimedAt: string;
@@ -75,7 +75,7 @@ export interface ArchivedExecutionV0 {
   readonly executionId: string;
   readonly taskId: string;
   readonly nodeId: "implementation";
-  readonly iteration: 0 | 1;
+  readonly iteration: number;
   readonly state: ExecutionState;
   readonly actor: ActorAxes;
   readonly claimedAt: string;
@@ -174,8 +174,8 @@ export function validateExecutionV1(value: unknown, allowUnknownFields = false):
     issues.push({ code: "invalid_schema", message: "Execution must use execution/v1" });
   if (!isNonEmptyString(value.executionId) || !isNonEmptyString(value.taskId) || value.nodeId !== "implementation")
     issues.push({ code: "invalid_execution", message: "execution identity is invalid" });
-  if (value.iteration !== 0 && value.iteration !== 1)
-    issues.push({ code: "invalid_iteration", message: "execution iteration must be 0 or 1" });
+  if (!Number.isSafeInteger(value.iteration) || Number(value.iteration) < 0)
+    issues.push({ code: "invalid_iteration", message: "execution iteration must be a non-negative integer" });
   if (!(executionV1States as readonly unknown[]).includes(value.state))
     issues.push({ code: "invalid_execution", message: "invalid execution state" });
   if (
@@ -219,7 +219,8 @@ export function validateArchivedExecutionV0(
     !isNonEmptyString(value.executionId) ||
     !isNonEmptyString(value.taskId) ||
     value.nodeId !== "implementation" ||
-    (value.iteration !== 0 && value.iteration !== 1) ||
+    !Number.isSafeInteger(value.iteration) ||
+    Number(value.iteration) < 0 ||
     !(executionStates as readonly unknown[]).includes(value.state) ||
     validateActorAxes(value.actor, allowUnknownFields).length ||
     !timestamp(value.claimedAt) ||

--- a/packages/kernel/src/domain/review.ts
+++ b/packages/kernel/src/domain/review.ts
@@ -20,7 +20,7 @@ export interface ReviewV1 {
   readonly reason: string;
   readonly evidenceChecked: readonly string[];
   readonly commitSha: string;
-  readonly iteration: 0 | 1;
+  readonly iteration: number;
   readonly contentDigest: `sha256:${string}`;
   readonly submissionDigest: SubmissionDigest;
   readonly reviewedAt: string;
@@ -102,7 +102,8 @@ export function validateReviewV1(value: unknown, allowUnknownFields = false): re
     !Array.isArray(value.evidenceChecked) ||
     value.evidenceChecked.some((item) => !isNonEmptyString(item)) ||
     !isNativeCommitSha(value.commitSha) ||
-    (value.iteration !== 0 && value.iteration !== 1) ||
+    !Number.isSafeInteger(value.iteration) ||
+    Number(value.iteration) < 0 ||
     !digest(value.contentDigest) ||
     (value.submissionDigest !== undefined && !digest(value.submissionDigest))
   )

--- a/packages/kernel/src/domain/settings-action-contract.ts
+++ b/packages/kernel/src/domain/settings-action-contract.ts
@@ -40,6 +40,7 @@ const repositoryFieldNames = Object.freeze([
   "defaultPreset",
   "defaultProfile",
   "reviewIndependence",
+  "reviewReturnBudget",
   "taskScaffold",
   "repositoryScaffold",
   "walFlushAdaptive",
@@ -123,6 +124,7 @@ export function createSettingsActionCatalog(
           field("defaultPreset"),
           field("defaultProfile"),
           field("reviewIndependence", "string", false, reviewIndependenceLevels),
+          field("reviewReturnBudget", "number"),
           field("locale", "string", false, settingsLocales),
           field("taskScaffold"),
           field("repositoryScaffold"),
@@ -198,6 +200,7 @@ export function compileSettingsUpdate(input: EntityActionCompileInput): Settings
       defaultPreset: updatedText(input.action, "defaultPreset", current.defaultPreset),
       defaultProfile: updatedText(input.action, "defaultProfile", current.defaultProfile),
       reviewIndependence: updatedReviewIndependence(input.action.reviewIndependence, current.reviewIndependence),
+      reviewReturnBudget: updatedPositiveInteger(input.action, "reviewReturnBudget", current.reviewReturnBudget),
       scaffolds: {
         task: updatedText(input.action, "taskScaffold", current.scaffolds.task),
         repository: updatedText(input.action, "repositoryScaffold", current.scaffolds.repository),

--- a/packages/kernel/src/domain/settings-event.ts
+++ b/packages/kernel/src/domain/settings-event.ts
@@ -2,6 +2,7 @@ import { sha256Text, stableStringify } from "../integrity/stable-hash.ts";
 import { eventObjectTarget } from "../layout/ledger-object-layout.ts";
 import {
   DEFAULT_WAL_FLUSH_SETTINGS,
+  INITIAL_SETTINGS_V1,
   SETTINGS_ID,
   readSettingsFacet,
   repositorySettings,
@@ -138,6 +139,7 @@ function validSettingsSnapshot(value: unknown, allowUnknownFields: boolean): boo
       defaultPreset: value.defaultPreset,
       defaultProfile: value.defaultProfile,
       reviewIndependence: value.reviewIndependence ?? "execution",
+      reviewReturnBudget: value.reviewReturnBudget ?? INITIAL_SETTINGS_V1.reviewReturnBudget,
       scaffolds: {
         task: value.scaffolds.task,
         repository: value.scaffolds.repository,
@@ -165,6 +167,7 @@ function validSettingsSnapshot(value: unknown, allowUnknownFields: boolean): boo
           "defaultPreset",
           "defaultProfile",
           "reviewIndependence",
+          "reviewReturnBudget",
           "scaffolds",
           "walFlush",
         ].includes(field),

--- a/packages/kernel/src/domain/settings.ts
+++ b/packages/kernel/src/domain/settings.ts
@@ -32,6 +32,7 @@ export const SETTINGS_FIELD_OWNERSHIP = Object.freeze({
   defaultPreset: "repository",
   defaultProfile: "repository",
   reviewIndependence: "repository",
+  reviewReturnBudget: "repository",
   locale: "local",
   scaffolds: "repository",
   walFlush: "repository",
@@ -53,6 +54,7 @@ export interface RepositorySettingsV1 {
   readonly defaultPreset: string;
   readonly defaultProfile: string;
   readonly reviewIndependence: ReviewIndependence;
+  readonly reviewReturnBudget: number;
   readonly scaffolds: {
     readonly task: string;
     readonly repository: string;
@@ -72,6 +74,7 @@ export interface SettingsV1 {
   readonly defaultPreset: string;
   readonly defaultProfile: string;
   readonly reviewIndependence: ReviewIndependence;
+  readonly reviewReturnBudget: number;
   readonly locale: SettingsLocale;
   readonly scaffolds: {
     readonly task: string;
@@ -99,6 +102,7 @@ export const INITIAL_SETTINGS_V1: SettingsV1 = Object.freeze({
   defaultPreset: "standard-task",
   defaultProfile: "baseline",
   reviewIndependence: "execution",
+  reviewReturnBudget: 3,
   locale: "en-US",
   scaffolds: Object.freeze({
     task: "governance/task-scaffold.json",
@@ -138,6 +142,7 @@ export const SETTINGS_V1_SCHEMA: EntityDocumentJsonSchema<SettingsV1> = {
       type: "string",
       enum: reviewIndependenceLevels,
     }),
+    reviewReturnBudget: ownedSchema("reviewReturnBudget", { type: "integer", minimum: 1 }),
     locale: ownedSchema("locale", { type: "string", enum: settingsLocales }),
     scaffolds: {
       ...ownedSchema("scaffolds", {}),
@@ -199,6 +204,7 @@ export const SETTINGS_REPOSITORY_V1_SCHEMA: EntityDocumentJsonSchema<RepositoryS
       type: "string",
       enum: reviewIndependenceLevels,
     }),
+    reviewReturnBudget: ownedSchema("reviewReturnBudget", { type: "integer", minimum: 1 }),
     scaffolds: {
       ...ownedSchema("scaffolds", {}),
       type: "object",
@@ -232,6 +238,7 @@ export function repositorySettings(settings: SettingsV1 | RepositorySettingsV1):
     defaultPreset: settings.defaultPreset,
     defaultProfile: settings.defaultProfile,
     reviewIndependence: settings.reviewIndependence ?? INITIAL_SETTINGS_V1.reviewIndependence,
+    reviewReturnBudget: settings.reviewReturnBudget ?? INITIAL_SETTINGS_V1.reviewReturnBudget,
     scaffolds: { task: settings.scaffolds.task, repository: settings.scaffolds.repository },
     walFlush: settings.walFlush ?? DEFAULT_WAL_FLUSH_SETTINGS,
   };
@@ -261,6 +268,7 @@ export function readSettingsFacet(body: string): SettingsV1 {
     defaultProfile: setting(body, "defaultProfile") ?? INITIAL_SETTINGS_V1.defaultProfile,
     reviewIndependence: (setting(body, "reviewIndependence") ??
       INITIAL_SETTINGS_V1.reviewIndependence) as ReviewIndependence,
+    reviewReturnBudget: Number(setting(body, "reviewReturnBudget") ?? INITIAL_SETTINGS_V1.reviewReturnBudget),
     locale: (setting(body, "locale") ?? INITIAL_SETTINGS_V1.locale) as SettingsLocale,
     scaffolds: {
       task: settingBlockValue(body, "scaffolds", "task") ?? INITIAL_SETTINGS_V1.scaffolds.task,
@@ -306,6 +314,13 @@ export function writeRepositorySettingsFacet(body: string, settings: RepositoryS
     "reviewIndependence",
     repository.reviewIndependence,
     INITIAL_SETTINGS_V1.reviewIndependence,
+  );
+  next = replaceOptionalDefaultedScalar(
+    next,
+    "  ",
+    "reviewReturnBudget",
+    String(repository.reviewReturnBudget),
+    String(INITIAL_SETTINGS_V1.reviewReturnBudget),
   );
   next = replaceDefaultedBlockScalar(
     next,

--- a/packages/kernel/src/domain/task-graph.ts
+++ b/packages/kernel/src/domain/task-graph.ts
@@ -21,7 +21,6 @@ export interface TaskGraphV1 {
     { readonly id: "review"; readonly kind: "review" },
   ];
   readonly edges: readonly GraphEdgeDefinition[];
-  readonly maxIterations: 1;
 }
 export interface TaskEdgeTaken {
   readonly edgeId: string;
@@ -67,13 +66,11 @@ export const REPLAY_TASK_GRAPH: TaskGraphV1 = Object.freeze({
       kind: "return",
     }),
   ]),
-  maxIterations: 1,
 });
 export const TASK_GRAPH_V1_SCHEMA = Object.freeze({
   id: "TaskGraph/v1",
   template: "replay/v1",
   nodes: taskNodeIds,
-  maxIterations: 1,
 });
 export const TASK_EDGE_TAKEN_SCHEMA = Object.freeze({
   id: "TaskEdgeTaken/v1",
@@ -83,9 +80,8 @@ export function validateTaskGraph(value: unknown, allowUnknownFields = false): r
   const hasFields = allowUnknownFields ? hasRequiredFields : hasOnlyFields;
   if (
     !isRecord(value) ||
-    !hasFields(value, ["template", "nodes", "edges", "maxIterations"]) ||
+    !hasFields(value, ["template", "nodes", "edges"]) ||
     value.template !== "replay/v1" ||
-    value.maxIterations !== 1 ||
     !Array.isArray(value.nodes) ||
     !Array.isArray(value.edges)
   )

--- a/packages/kernel/src/domain/task-graph.ts
+++ b/packages/kernel/src/domain/task-graph.ts
@@ -76,8 +76,11 @@ export const TASK_EDGE_TAKEN_SCHEMA = Object.freeze({
   id: "TaskEdgeTaken/v1",
   required: Object.freeze(["edgeId", "from", "to", "on", "actorRole", "reason", "commitSha", "iteration"]),
 });
-export function validateTaskGraph(value: unknown, allowUnknownFields = false): readonly GraphValidationIssue[] {
+export function validateTaskGraph(input: unknown, allowUnknownFields = false): readonly GraphValidationIssue[] {
   const hasFields = allowUnknownFields ? hasRequiredFields : hasOnlyFields;
+  // Graphs written before the return budget moved to Settings carry `maxIterations: 1`. The field is
+  // read-only history: replay ignores it and no new graph writes it.
+  const value = isRecord(input) && "maxIterations" in input ? withoutLegacyMaxIterations(input) : input;
   if (
     !isRecord(value) ||
     !hasFields(value, ["template", "nodes", "edges"]) ||
@@ -133,4 +136,9 @@ function sameEdge(value: unknown, expected: GraphEdgeDefinition): boolean {
 }
 function graphIssue(code: GraphValidationIssue["code"], message: string): GraphValidationIssue {
   return { code, message };
+}
+
+function withoutLegacyMaxIterations(graph: Record<string, unknown>): Record<string, unknown> {
+  const { maxIterations: _legacy, ...rest } = graph;
+  return rest;
 }

--- a/packages/kernel/src/domain/task-lifecycle-contract-internal-types.ts
+++ b/packages/kernel/src/domain/task-lifecycle-contract-internal-types.ts
@@ -164,6 +164,7 @@ export interface ReviewProof {
   readonly actorBinding: ActorAxes;
   readonly capability: "execution-review@v1";
   readonly capabilityRef: string;
+  readonly returnBudget: number;
 }
 export interface ReviewConsentProof {
   readonly actorBinding: ActorAxes;

--- a/packages/kernel/src/domain/task-lifecycle-event.ts
+++ b/packages/kernel/src/domain/task-lifecycle-event.ts
@@ -566,9 +566,8 @@ function validateEdge(value: unknown, allowUnknownFields: boolean): readonly Con
     !["submitted", "changes_requested"].includes(String(value.on)) ||
     !["executor", "reviewer"].includes(String(value.actorRole)) ||
     !isNativeCommitSha(value.commitSha) ||
-    !Number.isInteger(value.iteration) ||
-    (value.iteration as number) < 0 ||
-    (value.iteration as number) > 1
+    !Number.isSafeInteger(value.iteration) ||
+    (value.iteration as number) < 0
     ? [
         {
           code: "invalid_edge_evidence",

--- a/packages/kernel/src/domain/task-lifecycle-review-transitions.ts
+++ b/packages/kernel/src/domain/task-lifecycle-review-transitions.ts
@@ -76,14 +76,11 @@ function reviewIssues(
     issues.push(
       lifecycleContractIssue("invalid_proof", "transport-bound execution review proof and content digest are required"),
     );
-  if (
-    command.verdict === "changes_requested" &&
-    (snapshot.task?.iteration ?? 0) >= (snapshot.task?.graph.maxIterations ?? 0)
-  )
+  if (command.verdict === "changes_requested" && (snapshot.task?.iteration ?? 0) >= (proof.returnBudget ?? 0))
     issues.push(
       lifecycleContractIssue(
         "manual_intervention_required",
-        "return budget exhausted; escalate for manual intervention",
+        "return budget exhausted; use `ha task submit --amend` to update the current submitted execution before requesting review again",
       ),
     );
   return issues;
@@ -109,7 +106,7 @@ function reviewFrom(command: RecordReviewCommand, proof: ReviewProof): ReviewV1 
     reason: command.reason,
     evidenceChecked: [...command.evidenceChecked, ...qualificationEvidence],
     commitSha: command.commitSha,
-    iteration: command.iteration as 0 | 1,
+    iteration: command.iteration,
     contentDigest: command.contentDigest,
     submissionDigest: command.submissionDigest,
     reviewedAt: command.occurredAt,
@@ -145,7 +142,7 @@ export const review: Transition = {
         ...(snapshot.task as TaskV2),
         status: "active",
         currentNode: "implementation",
-        iteration: 1,
+        iteration: (snapshot.task?.iteration ?? 0) + 1,
       },
       edge = takeEdge(
         snapshot.task as TaskV2,
@@ -293,7 +290,7 @@ export const reconcile: Transition = {
         taskId: command.taskId,
         executionId: command.executionId,
         commitSha: command.commitSha,
-        iteration: command.iteration as 0 | 1,
+        iteration: command.iteration,
         paths: [...new Set(command.paths)].sort(),
         actor: command.actor,
         source: command.source,

--- a/packages/kernel/src/domain/task-lifecycle-review-transitions.ts
+++ b/packages/kernel/src/domain/task-lifecycle-review-transitions.ts
@@ -76,11 +76,13 @@ function reviewIssues(
     issues.push(
       lifecycleContractIssue("invalid_proof", "transport-bound execution review proof and content digest are required"),
     );
-  if (command.verdict === "changes_requested" && (snapshot.task?.iteration ?? 0) >= (proof.returnBudget ?? 0))
+  const iteration = snapshot.task?.iteration ?? 0;
+  if (command.verdict === "changes_requested" && iteration >= (proof.returnBudget ?? 0))
     issues.push(
       lifecycleContractIssue(
         "manual_intervention_required",
-        "return budget exhausted; use `ha task submit --amend` to update the current submitted execution before requesting review again",
+        "return budget exhausted; use `ha task submit --amend` to update the current submitted execution " +
+          "before requesting review again",
       ),
     );
   return issues;

--- a/packages/kernel/src/domain/task.ts
+++ b/packages/kernel/src/domain/task.ts
@@ -64,7 +64,7 @@ export interface TaskV2 extends BaseEntityPinState {
   readonly status: ReplayTaskStatus;
   readonly graph: TaskGraphV1;
   readonly currentNode: TaskNodeId;
-  readonly iteration: 0 | 1;
+  readonly iteration: number;
   readonly createdBy: ActorAxes;
   readonly completionGateIds: readonly string[];
   readonly presetSnapshotDigest: `sha256:${string}` | null;
@@ -119,8 +119,8 @@ export function validateTaskV2(value: unknown, allowUnknownFields = false): read
     issues.push({ code: "invalid_task", message: "invalid Task status" });
   if (!(taskNodeIdsForValidation as readonly unknown[]).includes(value.currentNode))
     issues.push({ code: "invalid_task", message: "invalid current node" });
-  if (value.iteration !== 0 && value.iteration !== 1)
-    issues.push({ code: "invalid_iteration", message: "iteration must be 0 or 1" });
+  if (!Number.isSafeInteger(value.iteration) || Number(value.iteration) < 0)
+    issues.push({ code: "invalid_iteration", message: "iteration must be a non-negative integer" });
   if (!Array.isArray(value.completionGateIds) || value.completionGateIds.some((id) => !isNonEmptyString(id)))
     issues.push({ code: "invalid_task", message: "completion gate ids must be strings" });
   if (

--- a/packages/kernel/test/contracts/task-lifecycle-replay.test.ts
+++ b/packages/kernel/test/contracts/task-lifecycle-replay.test.ts
@@ -10,6 +10,7 @@ import {
 } from "../../src/index.ts";
 import { lifecycleFixture, implementer } from "../store/task-lifecycle-fixture.ts";
 import { closeoutReadiness } from "../../src/domain/closeout-readiness.ts";
+import { validateTaskGraph } from "../../src/domain/task-graph.ts";
 import {
   applyTransition,
   normalizeTaskLifecycleCommand,
@@ -178,4 +179,9 @@ test("accepted history still rejects missing approval and mismatched gate bindin
     { ...snapshot, gateWitnesses: snapshot.gateWitnesses.map((w) => ({ ...w, executionId: "other-execution" })) },
   ])
     assert.throws(() => reduceTaskEvent(invalid, completed), /accepted task and execution state/);
+});
+
+test("a graph stored with the retired maxIterations field still validates strictly", () => {
+  assert.deepEqual(validateTaskGraph({ ...REPLAY_TASK_GRAPH, maxIterations: 1 }), []);
+  assert.equal(validateTaskGraph({ ...REPLAY_TASK_GRAPH, maxIterationz: 1 }).length, 1);
 });

--- a/packages/kernel/test/store/task-lifecycle-fixture.ts
+++ b/packages/kernel/test/store/task-lifecycle-fixture.ts
@@ -118,6 +118,7 @@ export function lifecycleFixture(
     actorBinding: reviewer,
     capability: "execution-review@v1",
     capabilityRef: "cap-review",
+    returnBudget: 3,
   });
   const review = snapshot.reviews[0]!;
   run(
@@ -217,6 +218,7 @@ export function twoRoundLifecycleEvents(
     actorBinding: reviewer,
     capability: "execution-review@v1",
     capabilityRef: "cap-review",
+    returnBudget: 3,
   });
   run(
     command(implementer, 5, {

--- a/tools/gates/test/task-lifecycle-transitions.test.mjs
+++ b/tools/gates/test/task-lifecycle-transitions.test.mjs
@@ -134,7 +134,12 @@ function review(
   );
 }
 function reviewProof(actor = reviewer) {
-  return { actorBinding: actor, capability: "execution-review@v1", capabilityRef: "capability:review" };
+  return {
+    actorBinding: actor,
+    capability: "execution-review@v1",
+    capabilityRef: "capability:review",
+    returnBudget: 3,
+  };
 }
 function consent(revision, recorded, actor = owner) {
   return command(
@@ -560,7 +565,7 @@ test("G34 replay preserves reject to new execution to approved consent to comple
           iteration: 1,
           reviewId: "review-second-reject",
         }),
-        reviewProof(),
+        { ...reviewProof(), returnBudget: 1 },
       ),
     (error) => error instanceof TaskLifecycleContractError && error.code === "manual_intervention_required",
   );


### PR DESCRIPTION
# English

## Summary

replay/v1 allowed exactly one review return: `maxIterations: 1` was a literal in the task graph, `iteration` was typed `0 | 1`, and a second `changes_requested` was rejected with `manual_intervention_required` and no way forward. On 2026-09-11 two tasks (B6, R3) hit this and their last-round review verdicts never reached the ledger. The repository owner ruled: relax the limit and make it a setting.

The return budget is now a repository Setting, `reviewReturnBudget` (default 3, minimum 1), read at review time and carried on the review proof. The task graph no longer stores a limit; `iteration` is a plain non-negative integer everywhere. When the budget is exhausted the rejection tells the executor to `ha task submit --amend` and request review again.

## Architectural Justification

-

## What Changed

- `settings.ts`, `settings-event.ts`, `settings-action-contract.ts`: `reviewReturnBudget` on the Settings entity, its event snapshot and the CLI/RPC update surface; harness.yaml facet read/write.
- `task-graph.ts`: `maxIterations` removed from `TaskGraphV1`, `REPLAY_TASK_GRAPH` and the schema. Graphs stored before this change carry `maxIterations: 1` (9,522 events on the canonical ledger); strict validation drops that field before the shape check and nothing writes it.
- `task-lifecycle-review-transitions.ts`: the changes_requested budget check reads `proof.returnBudget`; the exhausted message names `submit --amend`.
- `repo-cell-proof.ts`: the daemon fills `returnBudget` from Settings when it builds the review proof.
- `iteration` typed `number` in Task, Execution, Review, CodeDocWitness, CompletionEvidence and the edge validator (`Number.isSafeInteger`, `>= 0`).
- Tests: a contract test that a legacy graph with `maxIterations` still validates strictly (and an unknown field still does not); review proof fixtures in kernel and application carry `returnBudget: 3`.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Deleted code (no whole file): the `maxIterations` literal, its schema entry and the `value.maxIterations !== 1` replay check; the `0 | 1` iteration types.
- Production net lines: +74/-40 (net +34), from `node tools/gates/production-delta.mjs --base origin/main`.

## Machine-Readable Declarations

- Settings event snapshot gains `reviewReturnBudget`; older snapshots without the field read as the default (3). No event version change.

## Task And Scope

- Harness task: task_95311ea722963206360fa9e3c6
- Branch: `codex/review-return-budget`
- Public scope: review return budget as a Setting; task graph and iteration types
- Private planning/evidence updated: yes (CEO ruling in task_plan, dispatch report)
- Out of scope: recording a last-round changes_requested without a return edge (option B, not chosen)

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no (lifecycle contract, not CI/gate)
- Protected surface scope: not applicable
- Authority: repository owner ruling of 2026-09-11 recorded in task_95311ea722963206360fa9e3c6 task_plan
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `076933148`
- Branch merge-base with `origin/main`: `076933148`
- Last `git fetch origin` time: 2026-09-11 UTC
- Sync method: rebased onto origin/main
- Public diff command: `git diff origin/main...codex/review-return-budget`
- Private evidence commit/path: task_95311ea722963206360fa9e3c6 `artifacts/reports/`
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [x] `npm run typecheck` (`tsc -b packages/kernel packages/daemon packages/application`, no errors)
- [ ] `npm test`
- [x] `npm run harness:check-import-boundaries` (via `run-manifest-gates --changed origin/main`)
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts` (via `run-manifest-gates --changed origin/main`)
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Lifecycle tests on the branch head: application `task-lifecycle-transition-service`, `execution-approval-idempotency`; kernel `task-lifecycle-replay`, `task-bootstrap-event`, `task-action-contract`, `projection-cache-continuity`, `task-projection`, `task-snapshot-normalization`, `projection-identity-binding`: 61/61.
- Legacy-graph check: `validateTaskGraph({ ...REPLAY_TASK_GRAPH, maxIterations: 1 })` returns no issues; with an unknown field it still returns one.
- Negative control: before the second commit, the same lifecycle tests failed 10+ with `invalid_graph_shape` (fixtures still carried `maxIterations`) and 2 with `manual_intervention_required` (proof had no budget).

## Review Evidence

- CEO ground-truth: the worker's first commit claimed legacy-field compatibility but had none; strict `validateTaskGraph` rejected any stored graph with `maxIterations`, which the canonical ledger has 9,522 of. The second commit adds the drop and the fixtures. The worker's targeted run was 3 tests; the CEO ran the 61 above.
- Reviewer subagent: not used
- Human review: pending
- Blocking findings: none open

## Residual Risk

- `reviewReturnBudget` is read at review time, so lowering it below a task's current iteration makes the next changes_requested on that task fail with the amend hint; that is the intended behaviour of a budget.
- GUI settings surface shows the new field only if it renders Settings generically; not checked in this PR.

## References

- Task: task_95311ea722963206360fa9e3c6
- a18f97caf (the one-return design this replaces)

---

# 中文

## 概要

replay/v1 只允许退回一次：`maxIterations: 1` 写死在任务图里，`iteration` 类型是 `0 | 1`，第二次 `changes_requested` 会被 `manual_intervention_required` 拒绝且没有出路。2026-09-11 两个任务（B6、R3）撞上它，最后一轮评审结论进不了台账。仓库所有者裁定：放宽，做成设置项。

退回预算现在是仓库 Settings 的 `reviewReturnBudget`（默认 3，最小 1），评审时读取并随 review proof 传入。任务图不再存上限；`iteration` 在所有地方都是普通非负整数。预算耗尽时的拒绝信息告诉执行者 `ha task submit --amend` 后再请求评审。

## 架构辩护

-

## 改动内容

- `settings.ts`、`settings-event.ts`、`settings-action-contract.ts`：Settings 实体、事件快照与 CLI/RPC 更新面新增 `reviewReturnBudget`；harness.yaml facet 读写。
- `task-graph.ts`：从 `TaskGraphV1`、`REPLAY_TASK_GRAPH` 与 schema 删除 `maxIterations`。此前存下的图带 `maxIterations: 1`（canonical 台账有 9,522 条事件）；严格校验先丢掉这个字段再查形状，没有任何地方再写它。
- `task-lifecycle-review-transitions.ts`：changes_requested 的预算判断读 `proof.returnBudget`；耗尽信息点名 `submit --amend`。
- `repo-cell-proof.ts`：daemon 构造 review proof 时从 Settings 填 `returnBudget`。
- Task、Execution、Review、CodeDocWitness、CompletionEvidence 与边校验器里 `iteration` 改为 `number`（`Number.isSafeInteger`、`>= 0`）。
- 测试：契约测试断言带 `maxIterations` 的旧图仍能严格通过（未知字段仍不通过）；kernel 与 application 的 review proof fixture 带 `returnBudget: 3`。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 删除的门或 fixture：none
- 删除的代码（非整文件）：`maxIterations` 字面量、其 schema 条目与 `value.maxIterations !== 1` 的 replay 检查；`0 | 1` 的 iteration 类型。
- 生产净行数：+74/-40（净 +34），来自 `node tools/gates/production-delta.mjs --base origin/main`。

## 机器可读声明

- Settings 事件快照新增 `reviewReturnBudget`；旧快照缺该字段时按默认值 3 读。无事件版本变化。

## 任务与范围

- Harness 任务：task_95311ea722963206360fa9e3c6
- 分支：`codex/review-return-budget`
- 公开范围：退回预算作为 Setting；任务图与 iteration 类型
- 私有计划/证据已更新：是（task_plan 的 CEO 裁决、派工报告）
- 范围外：不带退回边登记最后一轮 changes_requested（选项 B，未选）

## 版本影响

- 版本：不变
- 发布影响：不发布

## 治理声明

- 触碰受保护面：否（生命周期契约，不是 CI/gate）
- 受保护面范围：不适用
- 授权：仓库所有者 2026-09-11 的裁决，记录在 task_95311ea722963206360fa9e3c6 的 task_plan
- 机器检查边界：本 PR 只断言声明存在；是否属实、是否充分由评审判断。
- Break-glass：否
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- 基线 `origin/main` SHA：`076933148`
- 分支与 `origin/main` 的 merge-base：`076933148`
- 最近一次 `git fetch origin`：2026-09-11 UTC
- 同步方式：rebase 到 origin/main
- 公开 diff 命令：`git diff origin/main...codex/review-return-budget`
- 私有证据路径：task_95311ea722963206360fa9e3c6 的 `artifacts/reports/`
- 评审证据路径：本 PR 的评审证据节
- GitHub Actions `rewrite-ci` run URL：本 PR 待跑
- 分支头上的生命周期测试：application `task-lifecycle-transition-service`、`execution-approval-idempotency`；kernel `task-lifecycle-replay`、`task-bootstrap-event`、`task-action-contract`、`projection-cache-continuity`、`task-projection`、`task-snapshot-normalization`、`projection-identity-binding`：61/61。
- 旧图检查：`validateTaskGraph({ ...REPLAY_TASK_GRAPH, maxIterations: 1 })` 无 issue；带未知字段仍报一条。
- 阴性对照：第二个提交之前，同一批生命周期测试 10+ 个因 `invalid_graph_shape` 失败（fixture 仍带 `maxIterations`），2 个因 `manual_intervention_required` 失败（proof 没有预算）。

## 评审证据

- CEO 事实核对：worker 第一个提交声称有旧字段兼容，实际没有——严格的 `validateTaskGraph` 会拒绝任何带 `maxIterations` 的已存图，而 canonical 台账有 9,522 条。第二个提交补了丢字段与 fixture。worker 的定向运行只有 3 个测试；CEO 跑了上面的 61 个。
- 评审子代理：未用
- 人工评审：待定
- 阻塞发现：无

## 残余风险

- `reviewReturnBudget` 在评审时读取，把它调到低于某任务当前 iteration 会让该任务下一次 changes_requested 以 amend 提示失败；这是预算的本意。
- GUI 设置面只有在泛化渲染 Settings 时才会显示新字段；本 PR 未检查。

## 参考

- 任务：task_95311ea722963206360fa9e3c6
- a18f97caf（被本 PR 取代的「只退回一次」设计）
