### PR TITLE
refactor(cli,application): remove dead exports and modules (perf wave 1, batch 1③)

### DIFF
--- a/packages/application/src/node-errors.ts
+++ b/packages/application/src/node-errors.ts
@@ -1,3 +1,0 @@
-export function isNodeErrorCode(error: unknown, code: string): boolean {
-  return typeof error === "object" && error !== null && "code" in error && error.code === code;
-}

--- a/packages/application/src/record.ts
+++ b/packages/application/src/record.ts
@@ -1,3 +1,0 @@
-export function isRecord(value: unknown): value is Record<string, unknown> {
-  return value !== null && typeof value === "object" && !Array.isArray(value);
-}

--- a/packages/cli/src/cli-offline-storage.ts
+++ b/packages/cli/src/cli-offline-storage.ts
@@ -15,15 +15,6 @@ import { readFlags } from "./cli/thin-command-flags.ts";
 
 type Emit = (receipt: Record<string, unknown>, json: boolean) => void;
 
-export function isOfflineStorageCommand(argv: readonly string[]): boolean {
-  return (
-    argv[0] === "backup" ||
-    argv[0] === "restore" ||
-    argv[0] === "events" ||
-    (argv[0] === "migrate" && argv[1] === "ledger")
-  );
-}
-
 export function runOfflineStorageCommand(argv: readonly string[], emit: Emit): number {
   const json = argv.includes("--json"),
     rootInput = option(argv, "--root") ?? process.cwd();

--- a/packages/cli/src/cli/task-action-help.ts
+++ b/packages/cli/src/cli/task-action-help.ts
@@ -12,10 +12,6 @@ export function preferTaskActionHelp(row: TaskActionHelpRow): TaskActionHelpRow 
   return byCommand.get(commandKey(row.usage)) ?? row;
 }
 
-export function projectedTaskActionHelpRows(): readonly TaskActionHelpRow[] {
-  return taskActionHelpRows;
-}
-
 function commandKey(usage: string): string {
   return usage.split(/ (?=<|\[)/u, 1)[0]!;
 }

--- a/packages/cli/src/daemon/client.ts
+++ b/packages/cli/src/daemon/client.ts
@@ -24,7 +24,6 @@ import type { ThinCommand } from "../cli/thin-command.ts";
 import { fleetEdgeRegistration, fleetScheduleRoute } from "./fleet-command-route.ts";
 import { withAutostart } from "./with-autostart.ts";
 import { assertCanonicalCliEntry, cliEntryNotCanonicalCode } from "./cli-entry-guard.ts";
-export { fleetScheduleRoute } from "./fleet-command-route.ts";
 export {
   daemonIdFromEnv,
   daemonUserRoot,

--- a/packages/cli/test/explain-three-door-consistency.test.ts
+++ b/packages/cli/test/explain-three-door-consistency.test.ts
@@ -10,7 +10,7 @@ import {
   requireEntityTypeContract,
   type BaseEntity,
 } from "../../kernel/src/index.ts";
-import { projectedTaskActionHelpRows } from "../src/cli/task-action-help.ts";
+import { taskActionHelpRows } from "../../daemon/src/protocol/daemon-protocol-commands-task.ts";
 
 test("help, object explain, and rejected ActionResult preserve one Task Action row", async () => {
   const harness = lifecycleHarness();
@@ -47,7 +47,7 @@ test("help, object explain, and rejected ActionResult preserve one Task Action r
       }).object({ entity, snapshot, evaluatedAtCut: cut }),
       row = explanation.subjects[0]?.actions.find(({ action }) => action.id === "start"),
       contract = getExecutableEntityAction("task-start"),
-      help = projectedTaskActionHelpRows().find(({ usage }) => usage.startsWith("ha task start "));
+      help = taskActionHelpRows.find(({ usage }) => usage.startsWith("ha task start "));
     assert.ok(row);
     assert.ok(contract);
     assert.ok(help);

--- a/packages/cli/test/offline-storage.integration.test.ts
+++ b/packages/cli/test/offline-storage.integration.test.ts
@@ -5,15 +5,8 @@ import { mkdtempSync, rmSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
-import { isOfflineStorageCommand, runOfflineStorageCommand } from "../src/cli-offline-storage.ts";
+import { runOfflineStorageCommand } from "../src/cli-offline-storage.ts";
 import { flatLedgerFixture } from "../../kernel/test/store/task-event-store.fixtures.ts";
-
-test("offline storage routing is limited to backup, restore and events", () => {
-  assert.equal(isOfflineStorageCommand(["backup"]), true);
-  assert.equal(isOfflineStorageCommand(["restore"]), true);
-  assert.equal(isOfflineStorageCommand(["events"]), true);
-  assert.equal(isOfflineStorageCommand(["task", "show"]), false);
-});
 
 test("offline storage reports malformed invocations without daemon dispatch", () => {
   const receipts: Record<string, unknown>[] = [],

--- a/packages/cli/test/task-action-help.test.ts
+++ b/packages/cli/test/task-action-help.test.ts
@@ -2,13 +2,15 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { makeTaskActionExplanationService } from "../../application/src/task-action-explanation-service.ts";
-import { generatedTaskActionProtocolDeclarations } from "../../daemon/src/protocol/daemon-protocol-commands-task.ts";
+import {
+  generatedTaskActionProtocolDeclarations,
+  taskActionHelpRows,
+} from "../../daemon/src/protocol/daemon-protocol-commands-task.ts";
 import { renderEntityActionExplanation } from "../src/cli/entity-action-explain-render.ts";
-import { projectedTaskActionHelpRows } from "../src/cli/task-action-help.ts";
 import { renderThinHelp } from "../src/cli/thin-command.ts";
 
 test("Task lifecycle help is projected from the generated Action declarations", () => {
-  const rows = projectedTaskActionHelpRows();
+  const rows = taskActionHelpRows;
   assert.deepEqual(
     rows.map(({ summary }) => summary),
     generatedTaskActionProtocolDeclarations.map(({ explain }) => explain),
@@ -29,7 +31,7 @@ test("Task lifecycle help is projected from the generated Action declarations", 
 
 test("Task help replaces every descriptor-backed lifecycle row", () => {
   const help = renderThinHelp([], "task");
-  for (const row of projectedTaskActionHelpRows()) {
+  for (const row of taskActionHelpRows) {
     assert.match(help, new RegExp(row.summary.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&"), "u"));
     assert.match(help, new RegExp(row.usage.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&"), "u"));
   }


### PR DESCRIPTION
# English

## Summary

Wave 1 of the performance/redundancy cleanup (fix-plan batch 1③): delete CLI and application code that has no production or tooling caller. Every deletion was preceded by a whole-repository search that includes `tools/` and `.github/` (the two false positives in the scan were tooling consumers that an earlier search had missed).

## Architectural Justification

-

## What Changed

- `packages/cli/src/cli-offline-storage.ts`: `isOfflineStorageCommand` deleted (no caller); the routing test that only exercised it is removed.
- `packages/cli/src/cli/task-action-help.ts`: `projectedTaskActionHelpRows` deleted; tests read the canonical `taskActionHelpRows`.
- `packages/cli/src/daemon/client.ts`: the `fleetScheduleRoute` barrel re-export deleted; the internal call stays.
- `packages/application/src/record.ts` and `packages/application/src/node-errors.ts` deleted (whole files, no importer).

## Gate Harvest / 门收割

Deleted-Production-Paths: packages/application/src/record.ts, packages/application/src/node-errors.ts
Deleted-Gates-Fixtures: packages/cli/test/offline-storage.integration.test.ts (the `isOfflineStorageCommand` routing case, deleted with its subject)
- Production net lines: +0/-20 (net -20), from `node tools/gates/production-delta.mjs --base origin/main`.

## Machine-Readable Declarations

- None.

## Task And Scope

- Harness task: task_aac08fc2fda61b90a1e039f551 (parent task_6eba9c5d3a55735920aa4856f3)
- Branch: `codex/perf-w1-cli-dead`
- Public scope: dead code in cli and application
- Private planning/evidence updated: yes (task plan, report with per-symbol grep evidence)
- Out of scope: `thinCliLocalErrorCodes` (consumed by `tools/check-cli-error-codes.mjs`, kept)

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: not applicable
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `3b3fb6e0f`
- Branch merge-base with `origin/main`: `3b3fb6e0f`
- Last `git fetch origin` time: 2026-09-11 UTC
- Sync method: rebased onto origin/main
- Public diff command: `git diff origin/main...codex/perf-w1-cli-dead`
- Private evidence commit/path: task_aac08fc2fda61b90a1e039f551 `artifacts/report.md`
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [x] `npm run typecheck` (`tsc -b packages/application packages/cli`)
- [ ] `npm test`
- [x] `npm run harness:check-import-boundaries` (via `run-manifest-gates --changed origin/main`)
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts` (via `run-manifest-gates --changed origin/main`)
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- `task-action-help.test.ts`, `explain-three-door-consistency.test.ts`: 4/4; `offline-storage.integration.test.ts` on isolated Ubuntu: 2/2.
- CEO re-ran the whole-repository search for the four deleted symbols/files on the rebased branch (excluding dist, node_modules, harness/): no matches.

## Review Evidence

- CEO ground-truth: grep repeated on the rebased head; production-delta and line-density gates pass on the rebased head.
- Reviewer subagent: not used
- Human review: pending
- Blocking findings: none open

## Residual Risk

- None identified; the deleted code had no caller in source, tests or tooling.

## References

- Task: task_aac08fc2fda61b90a1e039f551; fix-plan batch 1③ in task_6eba9c5d3a55735920aa4856f3

---

# 中文

## 概要

性能/冗余清理 Wave 1（fix-plan 批 1③）：删除 CLI 与 application 包里没有生产或工具调用方的代码。每个删除前都做了包含 `tools/` 与 `.github/` 的全仓搜索（扫描里的两条误报正是此前漏查工具消费方造成的）。

## 架构辩护

-

## 改动内容

- `packages/cli/src/cli-offline-storage.ts`：删除无调用方的 `isOfflineStorageCommand`，只测它的路由测试一并删除。
- `packages/cli/src/cli/task-action-help.ts`：删除 `projectedTaskActionHelpRows`，测试改读 canonical 的 `taskActionHelpRows`。
- `packages/cli/src/daemon/client.ts`：删除 `fleetScheduleRoute` 的 barrel 再导出，内部调用保留。
- 整文件删除 `packages/application/src/record.ts` 与 `node-errors.ts`（无 importer）。

## 门收割 / Gate Harvest

- 删除的生产路径：packages/application/src/record.ts、packages/application/src/node-errors.ts
- 删除的门或 fixture：packages/cli/test/offline-storage.integration.test.ts（`isOfflineStorageCommand` 的路由用例，随其主体删除）
- 生产净行数：+0/-20（净 -20），来自 `node tools/gates/production-delta.mjs --base origin/main`。

## 机器可读声明

- 无。

## 任务与范围

- Harness 任务：task_aac08fc2fda61b90a1e039f551（父任务 task_6eba9c5d3a55735920aa4856f3）
- 分支：`codex/perf-w1-cli-dead`
- 公开范围：cli 与 application 的死代码
- 私有计划/证据已更新：是（任务计划、逐符号 grep 证据的报告）
- 范围外：`thinCliLocalErrorCodes`（被 `tools/check-cli-error-codes.mjs` 消费，保留）

## 版本影响

- 版本：不变
- 发布影响：不发布

## 治理声明

- 触碰受保护面：否
- 受保护面范围：不适用
- 授权：不适用
- 机器检查边界：本 PR 只断言声明存在；是否属实、是否充分由评审判断。
- Break-glass：否
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- 基线 `origin/main` SHA：`3b3fb6e0f`
- 分支与 `origin/main` 的 merge-base：`3b3fb6e0f`
- 最近一次 `git fetch origin`：2026-09-11 UTC
- 同步方式：rebase 到 origin/main
- 公开 diff 命令：`git diff origin/main...codex/perf-w1-cli-dead`
- 私有证据路径：task_aac08fc2fda61b90a1e039f551 的 `artifacts/report.md`
- 评审证据路径：本 PR 的评审证据节
- GitHub Actions `rewrite-ci` run URL：本 PR 待跑
- `task-action-help.test.ts`、`explain-three-door-consistency.test.ts`：4/4；隔离 Ubuntu 上 `offline-storage.integration.test.ts`：2/2。
- CEO 在 rebase 后的分支头上重跑四个符号/文件的全仓搜索（排除 dist、node_modules、harness/）：无匹配。

## 评审证据

- CEO 事实核对：rebase 后重跑 grep；production-delta 与 line-density 门在 rebase 后的分支头上通过。
- 评审子代理：未用
- 人工评审：待定
- 阻塞发现：无

## 残余风险

- 未发现；被删代码在源码、测试与工具里都没有调用方。

## 参考

- 任务：task_aac08fc2fda61b90a1e039f551；task_6eba9c5d3a55735920aa4856f3 的 fix-plan 批 1③
