### PR TITLE
feat(kernel,cli): roll restore drill shadows by a retention setting

### DIFF
--- a/packages/cli/src/cli-offline-storage.ts
+++ b/packages/cli/src/cli-offline-storage.ts
@@ -1,5 +1,4 @@
 import path from "node:path";
-import { existsSync, readFileSync } from "node:fs";
 // dec_4944EEC7EE3618CEFDD210DC6B/CH1 requires this named offline-maintenance edge
 // instead of the kernel public barrel; G30 pins its exact transitive runtime closure.
 // eslint-disable-next-line no-restricted-imports
@@ -7,11 +6,10 @@ import {
   createLedgerBackup,
   drillLedgerBackup,
   readOfflineLedgerEvents,
+  restoreDrillRetentionFor,
   resolveActiveGeneration,
   runGenerationTwoConversion,
 } from "../../kernel/src/store/ledger-backup.ts";
-import { INITIAL_SETTINGS_V1, readSettingsFacet } from "../../kernel/src/domain/settings.ts";
-import { resolveHarnessLayout } from "../../kernel/src/layout/index.ts";
 
 import { generationMigrationCommand, firstCliCommandIndex } from "./cli/thin-command-help.ts";
 import { readFlags } from "./cli/thin-command-flags.ts";
@@ -69,12 +67,7 @@ export function runOfflineStorageCommand(argv: readonly string[], emit: Emit): n
     if (argv[0] === "restore" && argv[1] === "--drill") {
       const backupDir = positional(argv, 2, "restore --drill requires a backup directory"),
         shadowParent = option(argv, "--shadow-parent") ?? path.join(rootInput, ".harness", "restore-drills"),
-        authoredRoot = resolveHarnessLayout(rootInput).authoredRoot,
-        settingsPath = path.join(authoredRoot, "harness.yaml"),
-        settings = existsSync(settingsPath)
-          ? readSettingsFacet(readFileSync(settingsPath, "utf8"))
-          : INITIAL_SETTINGS_V1,
-        result = drillLedgerBackup({ backupDir, shadowParent, retention: settings.restoreDrillRetention });
+        result = drillLedgerBackup({ backupDir, shadowParent, retention: restoreDrillRetentionFor(rootInput) });
       emit({ ok: true, schema: "ledger-restore-drill-receipt/v1", exitCode: 0, ...result }, json);
       return 0;
     }

--- a/packages/cli/src/cli-offline-storage.ts
+++ b/packages/cli/src/cli-offline-storage.ts
@@ -1,4 +1,5 @@
 import path from "node:path";
+import { existsSync, readFileSync } from "node:fs";
 // dec_4944EEC7EE3618CEFDD210DC6B/CH1 requires this named offline-maintenance edge
 // instead of the kernel public barrel; G30 pins its exact transitive runtime closure.
 // eslint-disable-next-line no-restricted-imports
@@ -9,6 +10,8 @@ import {
   resolveActiveGeneration,
   runGenerationTwoConversion,
 } from "../../kernel/src/store/ledger-backup.ts";
+import { INITIAL_SETTINGS_V1, readSettingsFacet } from "../../kernel/src/domain/settings.ts";
+import { resolveHarnessLayout } from "../../kernel/src/layout/index.ts";
 
 import { generationMigrationCommand, firstCliCommandIndex } from "./cli/thin-command-help.ts";
 import { readFlags } from "./cli/thin-command-flags.ts";
@@ -66,7 +69,12 @@ export function runOfflineStorageCommand(argv: readonly string[], emit: Emit): n
     if (argv[0] === "restore" && argv[1] === "--drill") {
       const backupDir = positional(argv, 2, "restore --drill requires a backup directory"),
         shadowParent = option(argv, "--shadow-parent") ?? path.join(rootInput, ".harness", "restore-drills"),
-        result = drillLedgerBackup({ backupDir, shadowParent });
+        authoredRoot = resolveHarnessLayout(rootInput).authoredRoot,
+        settingsPath = path.join(authoredRoot, "harness.yaml"),
+        settings = existsSync(settingsPath)
+          ? readSettingsFacet(readFileSync(settingsPath, "utf8"))
+          : INITIAL_SETTINGS_V1,
+        result = drillLedgerBackup({ backupDir, shadowParent, retention: settings.restoreDrillRetention });
       emit({ ok: true, schema: "ledger-restore-drill-receipt/v1", exitCode: 0, ...result }, json);
       return 0;
     }

--- a/packages/cli/test/offline-storage.integration.test.ts
+++ b/packages/cli/test/offline-storage.integration.test.ts
@@ -1,7 +1,7 @@
 // harness-test-tier: integration
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, readdirSync, rmSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -48,6 +48,48 @@ test("offline CLI runs backup, restore drill and event tail without daemon dispa
       [true, true, true],
     );
     assert.equal((receipts[2]?.events as readonly unknown[]).length, 1);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+    rmSync(backupDir, { recursive: true, force: true });
+  }
+});
+
+test("offline restore drill reads retention from harness.yaml and defaults to three", () => {
+  const root = mkdtempSync(path.join(os.tmpdir(), "ha-cli-offline-retention-")),
+    backupDir = path.join(os.tmpdir(), `ha-cli-retention-backup-${process.pid}-${Date.now()}`),
+    shadowParent = path.join(root, "drills"),
+    { parent } = flatLedgerFixture(root, 1),
+    receipts: Record<string, unknown>[] = [],
+    emit = (receipt: Record<string, unknown>): void => {
+      receipts.push(receipt);
+    };
+  try {
+    execFileSync("git", ["update-ref", "refs/ha/canonical", parent], { cwd: root });
+    assert.equal(runOfflineStorageCommand(["backup", backupDir, "--root", root, "--json"], emit), 0);
+    writeFileSync(path.join(root, "harness", "harness.yaml"), "settings:\n  restoreDrillRetention: 1\n");
+    for (let index = 0; index < 2; index += 1)
+      assert.equal(
+        runOfflineStorageCommand(
+          ["restore", "--drill", backupDir, "--root", root, "--shadow-parent", shadowParent, "--json"],
+          emit,
+        ),
+        0,
+      );
+    const configured = receipts.at(-1)!;
+    assert.equal((configured.removedShadowRoots as readonly string[]).length, 1);
+
+    writeFileSync(path.join(root, "harness", "harness.yaml"), "settings:\n");
+    for (let index = 0; index < 4; index += 1)
+      assert.equal(
+        runOfflineStorageCommand(
+          ["restore", "--drill", backupDir, "--root", root, "--shadow-parent", shadowParent, "--json"],
+          emit,
+        ),
+        0,
+      );
+    const defaulted = receipts.at(-1)!;
+    assert.equal((defaulted.removedShadowRoots as readonly string[]).length, 1);
+    assert.equal(readdirSync(shadowParent).filter((entry) => entry.startsWith("restore-drill-")).length, 3);
   } finally {
     rmSync(root, { recursive: true, force: true });
     rmSync(backupDir, { recursive: true, force: true });

--- a/packages/gui/test/service-bridge.test.ts
+++ b/packages/gui/test/service-bridge.test.ts
@@ -285,6 +285,7 @@ test("GUI client reaches every shipped read through a real resident daemon", asy
       defaultProfile: "baseline",
       reviewIndependence: "execution",
       reviewReturnBudget: 3,
+      restoreDrillRetention: 3,
       locale: "en-US",
       scaffolds: {
         task: "governance/task-scaffold.json",

--- a/packages/kernel/src/domain/settings-action-contract.ts
+++ b/packages/kernel/src/domain/settings-action-contract.ts
@@ -13,6 +13,7 @@ import { compileSettingsChangedEvent, type SettingsEventBundle } from "./setting
 import {
   SETTINGS_ID,
   repositorySettings,
+  DEFAULT_RESTORE_DRILL_RETENTION,
   reviewIndependenceLevels,
   settingsLocales,
   validateRepositorySettings,
@@ -47,6 +48,7 @@ const repositoryFieldNames = Object.freeze([
   "walFlushEvents",
   "walFlushBytes",
   "walFlushMilliseconds",
+  "restoreDrillRetention",
 ] as const);
 
 const input = (fields: readonly EntityActionInputField[]): EntityActionInputContract =>
@@ -132,6 +134,7 @@ export function createSettingsActionCatalog(
           field("walFlushEvents", "number"),
           field("walFlushBytes", "number"),
           field("walFlushMilliseconds", "number"),
+          field("restoreDrillRetention", "number"),
           field("expectedVersion", "number"),
           field("idempotencyKey"),
         ]),
@@ -211,6 +214,11 @@ export function compileSettingsUpdate(input: EntityActionCompileInput): Settings
         bytes: updatedPositiveInteger(input.action, "walFlushBytes", current.walFlush.bytes),
         milliseconds: updatedPositiveInteger(input.action, "walFlushMilliseconds", current.walFlush.milliseconds),
       },
+      restoreDrillRetention: updatedPositiveInteger(
+        input.action,
+        "restoreDrillRetention",
+        current.restoreDrillRetention ?? DEFAULT_RESTORE_DRILL_RETENTION,
+      ),
     },
     errors = validateRepositorySettings(candidate);
   if (errors.length) rejectSettings("invalid_command", errors.join("; "));

--- a/packages/kernel/src/domain/settings-event.ts
+++ b/packages/kernel/src/domain/settings-event.ts
@@ -2,6 +2,7 @@ import { sha256Text, stableStringify } from "../integrity/stable-hash.ts";
 import { eventObjectTarget } from "../layout/ledger-object-layout.ts";
 import {
   DEFAULT_WAL_FLUSH_SETTINGS,
+  DEFAULT_RESTORE_DRILL_RETENTION,
   INITIAL_SETTINGS_V1,
   SETTINGS_ID,
   readSettingsFacet,
@@ -153,6 +154,7 @@ function validSettingsSnapshot(value: unknown, allowUnknownFields: boolean): boo
               milliseconds: value.walFlush.milliseconds,
             }
           : (value.walFlush ?? DEFAULT_WAL_FLUSH_SETTINGS),
+      restoreDrillRetention: value.restoreDrillRetention ?? DEFAULT_RESTORE_DRILL_RETENTION,
     },
     current = validateRepositorySettings(normalized).length === 0;
   if (!current) return false;
@@ -170,6 +172,7 @@ function validSettingsSnapshot(value: unknown, allowUnknownFields: boolean): boo
           "reviewReturnBudget",
           "scaffolds",
           "walFlush",
+          "restoreDrillRetention",
         ].includes(field),
       )
     );

--- a/packages/kernel/src/domain/settings.ts
+++ b/packages/kernel/src/domain/settings.ts
@@ -8,6 +8,7 @@ export const settingsLocales = ["en-US", "zh-CN"] as const;
 export type SettingsLocale = (typeof settingsLocales)[number];
 export const reviewIndependenceLevels = ["execution", "principal"] as const;
 export type ReviewIndependence = (typeof reviewIndependenceLevels)[number];
+export const DEFAULT_RESTORE_DRILL_RETENTION = 3;
 
 export interface WalFlushSettingsV1 {
   readonly adaptive: boolean;
@@ -36,6 +37,7 @@ export const SETTINGS_FIELD_OWNERSHIP = Object.freeze({
   locale: "local",
   scaffolds: "repository",
   walFlush: "repository",
+  restoreDrillRetention: "repository",
 } as const);
 
 type SettingsOwnedField = keyof typeof SETTINGS_FIELD_OWNERSHIP;
@@ -60,6 +62,7 @@ export interface RepositorySettingsV1 {
     readonly repository: string;
   };
   readonly walFlush: WalFlushSettingsV1;
+  readonly restoreDrillRetention: number;
 }
 
 export interface LocalSettingsV1 {
@@ -81,6 +84,7 @@ export interface SettingsV1 {
     readonly repository: string;
   };
   readonly walFlush: WalFlushSettingsV1;
+  readonly restoreDrillRetention: number;
 }
 
 export const SETTINGS_LOCAL_V1_SCHEMA: EntityDocumentJsonSchema<LocalSettingsV1> = {
@@ -109,6 +113,7 @@ export const INITIAL_SETTINGS_V1: SettingsV1 = Object.freeze({
     repository: "governance/repository-scaffold.json",
   }),
   walFlush: DEFAULT_WAL_FLUSH_SETTINGS,
+  restoreDrillRetention: DEFAULT_RESTORE_DRILL_RETENTION,
 });
 
 const settingValuePattern = "^[A-Za-z0-9][A-Za-z0-9/_.@-]*$";
@@ -165,6 +170,7 @@ export const SETTINGS_V1_SCHEMA: EntityDocumentJsonSchema<SettingsV1> = {
       additionalProperties: false,
     },
     walFlush: walFlushSchema(),
+    restoreDrillRetention: ownedSchema("restoreDrillRetention", { type: "integer", minimum: 1 }),
   },
   required: [
     "schema",
@@ -221,6 +227,7 @@ export const SETTINGS_REPOSITORY_V1_SCHEMA: EntityDocumentJsonSchema<RepositoryS
       additionalProperties: false,
     },
     walFlush: walFlushSchema(),
+    restoreDrillRetention: ownedSchema("restoreDrillRetention", { type: "integer", minimum: 1 }),
   },
   required: ["schema", "settingsId", "defaultVertical", "defaultPreset", "defaultProfile", "scaffolds", "walFlush"],
   additionalProperties: false,
@@ -241,6 +248,7 @@ export function repositorySettings(settings: SettingsV1 | RepositorySettingsV1):
     reviewReturnBudget: settings.reviewReturnBudget ?? INITIAL_SETTINGS_V1.reviewReturnBudget,
     scaffolds: { task: settings.scaffolds.task, repository: settings.scaffolds.repository },
     walFlush: settings.walFlush ?? DEFAULT_WAL_FLUSH_SETTINGS,
+    restoreDrillRetention: settings.restoreDrillRetention ?? DEFAULT_RESTORE_DRILL_RETENTION,
   };
 }
 
@@ -275,6 +283,7 @@ export function readSettingsFacet(body: string): SettingsV1 {
       repository: settingBlockValue(body, "scaffolds", "repository") ?? INITIAL_SETTINGS_V1.scaffolds.repository,
     },
     walFlush: readWalFlushSettings(body),
+    restoreDrillRetention: readRestoreDrillRetention(body),
   };
   const errors = validateSettingsV1(settings);
   if (errors.length) throw new Error(errors.join("; "));
@@ -330,6 +339,13 @@ export function writeRepositorySettingsFacet(body: string, settings: RepositoryS
     INITIAL_SETTINGS_V1.scaffolds.task,
   );
   next = writeWalFlushFacet(next, repository.walFlush);
+  next = replaceOptionalDefaultedScalar(
+    next,
+    "  ",
+    "restoreDrillRetention",
+    String(repository.restoreDrillRetention),
+    String(DEFAULT_RESTORE_DRILL_RETENTION),
+  );
   next = replaceDefaultedBlockScalar(
     next,
     "scaffolds",
@@ -375,6 +391,15 @@ function readWalFlushSettings(body: string): WalFlushSettingsV1 {
     bytes: readPositive("bytes"),
     milliseconds: readPositive("milliseconds"),
   };
+}
+
+function readRestoreDrillRetention(body: string): number {
+  const raw = setting(body, "restoreDrillRetention");
+  if (raw === undefined) return DEFAULT_RESTORE_DRILL_RETENTION;
+  const value = Number(raw);
+  if (!Number.isSafeInteger(value) || value < 1)
+    throw new Error("settings.restoreDrillRetention must be a positive integer");
+  return value;
 }
 
 function writeWalFlushFacet(body: string, settings: WalFlushSettingsV1): string {

--- a/packages/kernel/src/local/local-layout-file-system.ts
+++ b/packages/kernel/src/local/local-layout-file-system.ts
@@ -43,6 +43,7 @@ export const localLedgerBackupFileSystem = {
   readLink: readlinkSync,
   stat: statSync,
   write: writeFileSync,
+  remove: (inputPath: string) => rmSync(inputPath, { recursive: true, force: true }),
 } as const;
 
 export const localEventFileSystem = {

--- a/packages/kernel/src/local/local-layout-file-system.ts
+++ b/packages/kernel/src/local/local-layout-file-system.ts
@@ -43,7 +43,9 @@ export const localLedgerBackupFileSystem = {
   readLink: readlinkSync,
   stat: statSync,
   write: writeFileSync,
-  remove: (inputPath: string) => rmSync(inputPath, { recursive: true, force: true }),
+  remove: (inputPath: string) =>
+    /* @gate-identity check-bypass-write-boundary/bypass-write-135 */
+    rmSync(inputPath, { recursive: true, force: true }),
 } as const;
 
 export const localEventFileSystem = {

--- a/packages/kernel/src/store/ledger-backup.ts
+++ b/packages/kernel/src/store/ledger-backup.ts
@@ -83,9 +83,12 @@ export function drillLedgerBackup(input: {
   readonly backupDir: string;
   readonly shadowParent: string;
   readonly destinationRoot?: string;
+  readonly retention?: number;
 }): {
   readonly shadowRoot: string;
   readonly manifest: LedgerBackupManifestV1;
+  readonly removedShadowRoots: readonly string[];
+  readonly warnings: readonly string[];
 } {
   const backupDir = path.resolve(input.backupDir),
     manifest = readManifest(backupDir),
@@ -101,7 +104,24 @@ export function drillLedgerBackup(input: {
   verifyManifest(shadowRoot, manifest);
   for (const database of manifest.files.filter(({ method }) => method === "vacuum-into"))
     inspectSqlite(path.join(shadowRoot, database.path));
-  return { shadowRoot, manifest };
+  const removedShadowRoots: string[] = [],
+    warnings: string[] = [],
+    retention = input.retention ?? 3,
+    candidates = fileSystem
+      .readDirectory(path.resolve(input.shadowParent))
+      .filter((name) => name.startsWith("restore-drill-"))
+      .map((name) => path.join(path.resolve(input.shadowParent), name))
+      .filter((candidate) => fileSystem.lstat(candidate).isDirectory())
+      .sort((left, right) => fileSystem.stat(left).mtimeMs - fileSystem.stat(right).mtimeMs);
+  for (const candidate of candidates.slice(0, Math.max(0, candidates.length - retention))) {
+    try {
+      fileSystem.remove(candidate);
+      removedShadowRoots.push(candidate);
+    } catch (error) {
+      warnings.push(`could not remove ${candidate}: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+  return { shadowRoot, manifest, removedShadowRoots, warnings };
 }
 
 export function readOfflineLedgerEvents(input: {

--- a/packages/kernel/src/store/ledger-backup.ts
+++ b/packages/kernel/src/store/ledger-backup.ts
@@ -2,6 +2,8 @@ import { randomUUID } from "node:crypto";
 import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
 import { parseCanonicalEvent } from "../domain/doc-sync-canonical-events.ts";
+import { DEFAULT_RESTORE_DRILL_RETENTION, readSettingsFacet } from "../domain/settings.ts";
+import { consumeKnownError } from "../error-consumption.ts";
 import { sha256Bytes } from "../integrity/stable-hash.ts";
 import { resolveHarnessLayout, type HarnessLayoutInput } from "../layout/index.ts";
 import { localLedgerBackupFileSystem as fileSystem } from "../local/local-layout-file-system.ts";
@@ -106,7 +108,7 @@ export function drillLedgerBackup(input: {
     inspectSqlite(path.join(shadowRoot, database.path));
   const removedShadowRoots: string[] = [],
     warnings: string[] = [],
-    retention = input.retention ?? 3,
+    retention = input.retention ?? DEFAULT_RESTORE_DRILL_RETENTION,
     candidates = fileSystem
       .readDirectory(path.resolve(input.shadowParent))
       .filter((name) => name.startsWith("restore-drill-"))
@@ -118,10 +120,18 @@ export function drillLedgerBackup(input: {
       fileSystem.remove(candidate);
       removedShadowRoots.push(candidate);
     } catch (error) {
+      consumeKnownError(error);
       warnings.push(`could not remove ${candidate}: ${error instanceof Error ? error.message : String(error)}`);
     }
   }
   return { shadowRoot, manifest, removedShadowRoots, warnings };
+}
+
+/** The drill runs offline, so the retention setting is read from the authored harness.yaml facet. */
+export function restoreDrillRetentionFor(rootInput: HarnessLayoutInput): number {
+  const settingsPath = path.join(resolveHarnessLayout(rootInput).authoredRoot, "harness.yaml");
+  if (!fileSystem.exists(settingsPath)) return DEFAULT_RESTORE_DRILL_RETENTION;
+  return readSettingsFacet(fileSystem.read(settingsPath, "utf8")).restoreDrillRetention;
 }
 
 export function readOfflineLedgerEvents(input: {

--- a/packages/kernel/test/store/ledger-backup.integration.test.ts
+++ b/packages/kernel/test/store/ledger-backup.integration.test.ts
@@ -1,7 +1,18 @@
 // harness-test-tier: integration
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { lstatSync, mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, symlinkSync, writeFileSync } from "node:fs";
+import {
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  statSync,
+  symlinkSync,
+  utimesSync,
+  writeFileSync,
+} from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -177,6 +188,46 @@ test("VACUUM backup survives source deletion and rejects wrong generation metada
     rmSync(backupDir, { recursive: true, force: true });
   }
 });
+
+test("restore drill rolls shadows by retention, preserves unrelated directories and reports removals", () => {
+  const root = fixture("retention"),
+    backupDir = path.join(os.tmpdir(), `ha-backup-retention-${process.pid}-${Date.now()}`),
+    shadowParent = path.join(root, "shadow"),
+    unrelated = path.join(shadowParent, "keep-me");
+  try {
+    const manifest = createLedgerBackup({ rootInput: root, backupDir });
+    mkdirSync(unrelated, { recursive: true });
+    const drilled = [];
+    for (let index = 0; index < 4; index += 1) {
+      const result = drillLedgerBackup({ backupDir, shadowParent, retention: 2 });
+      utimesSync(result.shadowRoot, new Date(1_000 + index * 1_000), new Date(1_000 + index * 1_000));
+      drilled.push(result);
+    }
+    const retained = drilled.slice(-2).map(({ shadowRoot }) => shadowRoot);
+    assert.equal(lstatSync(unrelated).isDirectory(), true);
+    assert.deepEqual(
+      readdirDirectories(shadowParent).filter((entry) => entry.startsWith("restore-drill-")),
+      retained.map((entry) => path.basename(entry)),
+    );
+    assert.equal(drilled.at(-1)?.manifest.tag, manifest.tag);
+    assert.deepEqual(drilled[2]?.removedShadowRoots, [drilled[0]?.shadowRoot]);
+    assert.deepEqual(drilled[3]?.removedShadowRoots, [drilled[1]?.shadowRoot]);
+
+    const single = drillLedgerBackup({ backupDir, shadowParent, retention: 1 });
+    assert.deepEqual(
+      readdirDirectories(shadowParent).filter((entry) => entry.startsWith("restore-drill-")),
+      [path.basename(single.shadowRoot)],
+    );
+    assert.equal(single.removedShadowRoots.length, 2);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+    rmSync(backupDir, { recursive: true, force: true });
+  }
+});
+
+function readdirDirectories(parent: string): string[] {
+  return readdirSync(parent).filter((entry) => lstatSync(path.join(parent, entry)).isDirectory());
+}
 
 function fixture(name: string): string {
   const root = mkdtempSync(path.join(os.tmpdir(), `ha-ledger-backup-${name}-`)),

--- a/tools/gate-allowlists/check-bypass-write-boundary.json
+++ b/tools/gate-allowlists/check-bypass-write-boundary.json
@@ -640,6 +640,12 @@
         "api": "rmdirSync",
         "ref": "dec_78A329289D1AA69527529DA92C",
         "reason": "The canonical materializer retires only accepted owned directory paths with non-recursive removal; unowned and non-empty directories remain."
+      },
+      {
+        "value": "bypass-write-135",
+        "api": "rmSync",
+        "ref": "task_f16581aa37aadc9e00699729d7",
+        "reason": "Ledger backup drill rolls its own restore-drill shadow copies beyond the configured retention under the ledger's restore-drills parent."
       }
     ],
     "exemptHumanOrBootstrap": [],

--- a/tools/gate-allowlists/check-fallback-boundaries.json
+++ b/tools/gate-allowlists/check-fallback-boundaries.json
@@ -251,6 +251,7 @@
       "packages/kernel/src/schemas/task-closeout-packet.ts#validatePortablePath",
       "packages/kernel/src/store/generation-two-conversion.ts#historicalContentClaims",
       "packages/kernel/src/store/generation-two-conversion.ts#planConversion",
+      "packages/kernel/src/store/ledger-backup.ts#drillLedgerBackup",
       "packages/kernel/src/store/local-version-control-commands.ts#currentBranch",
       "packages/kernel/src/store/local-version-control-commands.ts#originHeadBranch",
       "packages/kernel/src/store/local-version-control-system.ts#<module>",


### PR DESCRIPTION
# English

## Summary

`ha restore --drill <backup>` leaves a full ledger copy under `<root>/.harness/restore-drills/restore-drill-*` on every run and nothing ever removes them, so a scheduled drill accumulates copies without bound. The repository owner ruled on 2026-09-11: keep the copies (they exist for a human to inspect), but roll them, with the number kept as a setting.

This PR adds `restoreDrillRetention` to the repository Settings (default 3, minimum 1) and makes `drillLedgerBackup` delete the oldest `restore-drill-*` directories beyond that count after the new copy has been verified. The receipt lists what was removed; a removal that fails is reported as a warning and does not fail the drill. The drill is an offline command, so the setting is read from the authored `harness.yaml` facet.

## Architectural Justification

-

## What Changed

- `settings.ts`, `settings-event.ts`, `settings-action-contract.ts`: `restoreDrillRetention` (integer ≥ 1, default `DEFAULT_RESTORE_DRILL_RETENTION` = 3) on the entity, its event snapshot, the harness.yaml facet and `ha settings update`.
- `ledger-backup.ts`: `drillLedgerBackup` takes `retention`; after `verifyManifest` and the SQLite inspection it sorts `restore-drill-*` directories in the shadow parent by mtime and removes the oldest beyond the retention, returning `removedShadowRoots` and `warnings`. `restoreDrillRetentionFor(rootInput)` reads the setting from the authored facet (default when the file is absent).
- `local-layout-file-system.ts`: `remove` on the backup file-system port.
- `cli-offline-storage.ts`: `restore --drill` passes `restoreDrillRetentionFor(rootInput)`; the receipt carries the two new fields.
- Tests: kernel `ledger-backup.integration.test.ts` — retention+2 drills leave exactly `retention` copies with the newest kept, retention 1 keeps one, an unrelated directory in the same parent survives, the receipt lists removals; CLI `offline-storage.integration.test.ts` — `restoreDrillRetention: 1` in harness.yaml yields a non-empty `removedShadowRoots`, absence uses the default.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: +70/-2 (net +68), from `node tools/gates/production-delta.mjs --base origin/main`.

## Machine-Readable Declarations

- Settings event snapshot gains `restoreDrillRetention`; older snapshots without it read as the default. No event version change.

## Task And Scope

- Harness task: task_f16581aa37aadc9e00699729d7
- Branch: `codex/restore-drill-settings`
- Public scope: restore drill shadow retention
- Private planning/evidence updated: yes (task plan, dispatch reports, CEO negative-control output)
- Out of scope: a separate cleanup command, a dry-run flag, backup format

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: yes — `tools/gate-allowlists/check-fallback-boundaries.json` (lists `ledger-backup.ts#drillLedgerBackup`, whose caught removal error is consumed via `consumeKnownError`) and `tools/gate-allowlists/check-bypass-write-boundary.json` (the backup file-system port's `remove` uses `rmSync` under the ledger's own restore-drill parent)
- Protected surface scope: allowlist entries only; no gate logic, threshold or required check changes
- Authority: task_f16581aa37aadc9e00699729d7 (owner ruling of 2026-09-11: keep restore-drill copies but roll them, retention as a setting)
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `3b3fb6e0f`
- Branch merge-base with `origin/main`: `3b3fb6e0f`
- Last `git fetch origin` time: 2026-09-11 UTC
- Sync method: rebased onto origin/main
- Public diff command: `git diff origin/main...codex/restore-drill-settings`
- Private evidence commit/path: task_f16581aa37aadc9e00699729d7 `artifacts/reports/`
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [x] `npm run typecheck` (`tsc -b packages/kernel packages/cli`)
- [ ] `npm run check`
- [ ] `npm test`
- [x] `npm run harness:check-import-boundaries` (via `run-manifest-gates --changed origin/main`)
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts` (via `run-manifest-gates --changed origin/main`)
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- `ledger-backup.integration.test.ts` + `offline-storage.integration.test.ts`: 9/9 locally.
- Negative control (CEO): with the removal loop deleted from `drillLedgerBackup`, "restore drill rolls shadows by retention, preserves unrelated directories and reports removals" fails (4 pass / 1 fail); restored, 9/9.
- Gates: `run-manifest-gates --changed origin/main` (lint, duplicate definitions, import boundaries, implementation contracts, …), `line-density`, `production-delta` pass.

## Review Evidence

- CEO ground-truth: read the retention diff; the CLI reads the setting through a kernel helper instead of deep kernel imports (lint `no-restricted-imports`); the caught removal error is consumed explicitly (`no-swallowed-failure`).
- Reviewer subagent: not used
- Human review: pending
- Blocking findings: none open

## Residual Risk

- Ordering is by directory mtime; a copy whose mtime was altered by hand could be kept or removed out of order.
- The just-created copy is always the newest and is never a removal candidate under retention ≥ 1.

## References

- Task: task_f16581aa37aadc9e00699729d7

---

# 中文

## 概要

`ha restore --drill <backup>` 每次演练都在 `<root>/.harness/restore-drills/restore-drill-*` 下留一份完整台账副本，没有任何东西删它们，定时演练会无限累积。仓库所有者 2026-09-11 裁定：副本保留（给人检查用），但滚动删除，份数做成设置项。

本 PR 在仓库 Settings 上新增 `restoreDrillRetention`（默认 3，最小 1），`drillLedgerBackup` 在新副本校验通过后删除同目录下超出份数的最旧 `restore-drill-*` 目录；回执列出删了哪些，删除失败记为警告、不让演练失败。演练是离线命令，所以设置从 authored `harness.yaml` facet 读。

## 架构辩护

-

## 改动内容

- `settings.ts`、`settings-event.ts`、`settings-action-contract.ts`：实体、事件快照、harness.yaml facet 与 `ha settings update` 新增 `restoreDrillRetention`（整数 ≥ 1，默认 `DEFAULT_RESTORE_DRILL_RETENTION` = 3）。
- `ledger-backup.ts`：`drillLedgerBackup` 接收 `retention`；在 `verifyManifest` 与 SQLite 检查之后按 mtime 排序同目录的 `restore-drill-*`，删除超出份数的最旧目录，返回 `removedShadowRoots` 与 `warnings`。`restoreDrillRetentionFor(rootInput)` 从 authored facet 读设置（文件不存在时用默认值）。
- `local-layout-file-system.ts`：备份文件系统端口新增 `remove`。
- `cli-offline-storage.ts`：`restore --drill` 传入 `restoreDrillRetentionFor(rootInput)`；回执带两个新字段。
- 测试：kernel `ledger-backup.integration.test.ts`——连续 drill retention+2 次后恰好剩 retention 份且最新的都在、retention 1 只剩一份、同目录无关目录保留、回执列出删除；CLI `offline-storage.integration.test.ts`——harness.yaml 写 `restoreDrillRetention: 1` 后 `removedShadowRoots` 非空、缺省按默认值。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 删除的门或 fixture：none
- 生产净行数：+70/-2（净 +68），来自 `node tools/gates/production-delta.mjs --base origin/main`。

## 机器可读声明

- Settings 事件快照新增 `restoreDrillRetention`；旧快照缺该字段时按默认值读。无事件版本变化。

## 任务与范围

- Harness 任务：task_f16581aa37aadc9e00699729d7
- 分支：`codex/restore-drill-settings`
- 公开范围：restore drill 影子副本保留份数
- 私有计划/证据已更新：是（任务计划、派工报告、CEO 阴性对照输出）
- 范围外：单独的清理命令、dry-run 标志、备份格式

## 版本影响

- 版本：不变
- 发布影响：不发布

## 治理声明

- 触碰受保护面：是——`tools/gate-allowlists/check-fallback-boundaries.json`（登记 `ledger-backup.ts#drillLedgerBackup`，其捕获的删除错误经 `consumeKnownError` 消费）与 `tools/gate-allowlists/check-bypass-write-boundary.json`（备份文件系统端口的 `remove` 在台账自己的 restore-drill 父目录下用 `rmSync`）
- 受保护面范围：仅 allowlist 条目；不改门逻辑、阈值或 required check
- 授权：task_f16581aa37aadc9e00699729d7（所有者 2026-09-11 裁决：restore-drill 副本保留但滚动删除、份数做成设置项）
- 机器检查边界：本 PR 只断言声明存在；是否属实、是否充分由评审判断。
- Break-glass：否
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- 基线 `origin/main` SHA：`3b3fb6e0f`
- 分支与 `origin/main` 的 merge-base：`3b3fb6e0f`
- 最近一次 `git fetch origin`：2026-09-11 UTC
- 同步方式：rebase 到 origin/main
- 公开 diff 命令：`git diff origin/main...codex/restore-drill-settings`
- 私有证据路径：task_f16581aa37aadc9e00699729d7 的 `artifacts/reports/`
- 评审证据路径：本 PR 的评审证据节
- GitHub Actions `rewrite-ci` run URL：本 PR 待跑
- `ledger-backup.integration.test.ts` + `offline-storage.integration.test.ts`：本机 9/9。
- 阴性对照（CEO）：删掉 `drillLedgerBackup` 的删除循环后，「restore drill rolls shadows by retention, preserves unrelated directories and reports removals」失败（4 过 1 败）；还原后 9/9。
- 门：`run-manifest-gates --changed origin/main`（lint、duplicate definitions、import boundaries、implementation contracts 等）、`line-density`、`production-delta` 通过。

## 评审证据

- CEO 事实核对：读过保留逻辑的 diff；CLI 经 kernel 助手读设置而非深层 import（lint `no-restricted-imports`）；捕获的删除错误显式消费（`no-swallowed-failure`）。
- 评审子代理：未用
- 人工评审：待定
- 阻塞发现：无

## 残余风险

- 按目录 mtime 排序；被手工改过 mtime 的副本可能保留或删除顺序异常。
- 刚创建的副本永远最新，retention ≥ 1 时不会成为删除候选。

## 参考

- 任务：task_f16581aa37aadc9e00699729d7
