### PR TITLE
test: add the opt-in Entity V2 scale stress fixture (10k/100k/1M events)

### DIFF
--- a/tools/stress/entity-v2-scale.fixture.mjs
+++ b/tools/stress/entity-v2-scale.fixture.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { spawn, spawnSync, execFileSync } from "node:child_process";
+import { spawnSync, execFileSync } from "node:child_process";
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir, loadavg, availableParallelism, cpus, totalmem, freemem } from "node:os";
 import path from "node:path";
@@ -67,7 +67,7 @@ export function fixture(seed, daemonId = "entity-v2-scale") {
       env: { ...env, ...(actor ? { HARNESS_ACTOR: actor } : {}) },
       encoding: "utf8",
       timeout: timeoutMs,
-      maxBuffer: 32 * 1024 * 1024,
+      maxBuffer: 256 * 1024 * 1024,
       ...(input === undefined ? {} : { input: JSON.stringify(input) }),
     });
     let receipt = null;
@@ -97,58 +97,6 @@ export function fixture(seed, daemonId = "entity-v2-scale") {
     }
     return receipt;
   };
-  /** Arm A, concurrent: N independent CLI processes issued at once against one daemon. */
-  const concurrentCli = async (metric, argvList, { actor, timeoutMs = 180_000 } = {}) => {
-    const batchStarted = performance.now();
-    const results = await Promise.all(
-      argvList.map(
-        (args, client) =>
-          new Promise((resolve) => {
-            const started = performance.now();
-            const child = spawn(process.execPath, [cli, "--root", root, "--json", ...args], {
-              env: { ...env, ...(actor ? { HARNESS_ACTOR: actor } : {}) },
-            });
-            let stdout = "",
-              stderr = "";
-            const timer = setTimeout(() => child.kill("SIGKILL"), timeoutMs);
-            child.stdout.on("data", (chunk) => (stdout += chunk));
-            child.stderr.on("data", (chunk) => (stderr += chunk.toString().slice(0, 2048)));
-            child.on("close", (code, signal) => {
-              clearTimeout(timer);
-              let receipt = null;
-              try {
-                receipt = JSON.parse(stdout);
-              } catch {
-                /* Parse failures are evidence too. */
-              }
-              resolve({
-                seed,
-                metric,
-                arm: "cli-process-concurrent",
-                client,
-                args,
-                wallMs: performance.now() - started,
-                exit: code,
-                signal,
-                receipt,
-                stdout,
-                stderr: stderr.slice(0, 2048),
-              });
-            });
-          }),
-      ),
-    );
-    for (const row of results) record(row);
-    const batchMs = performance.now() - batchStarted;
-    frame("concurrent-batch", {
-      seed,
-      metric,
-      clients: argvList.length,
-      batchMs,
-      succeeded: results.filter(({ exit, receipt }) => exit === 0 && receipt?.ok).length,
-    });
-    return { results, batchMs };
-  };
   const check = (name, operation) => {
     try {
       operation();
@@ -174,30 +122,33 @@ export function fixture(seed, daemonId = "entity-v2-scale") {
     });
     return published;
   };
+  /** Stop this fixture's daemon and wait until its process is gone, so the ledger has no live writer. */
+  const stopDaemon = async (metric) => {
+    const stopped = invoke(metric, ["daemon", "stop"], { requireSuccess: false });
+    if (!Number.isSafeInteger(stopped?.pid)) return stopped;
+    const commandLine = `/proc/${stopped.pid}/cmdline`,
+      deadline = Date.now() + 10_000;
+    while (existsSync(commandLine) && Date.now() < deadline) {
+      let command;
+      try {
+        command = readFileSync(commandLine, "utf8");
+      } catch (error) {
+        if (error.code === "ENOENT") break;
+        throw error;
+      }
+      if (!command.includes(userRoot)) break;
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    }
+    return stopped;
+  };
   const close = async () => {
     try {
-      const stopped = invoke("cleanup.daemon-stop", ["daemon", "stop"], { requireSuccess: false });
-      if (Number.isSafeInteger(stopped?.pid)) {
-        const commandLine = `/proc/${stopped.pid}/cmdline`,
-          deadline = Date.now() + 10_000;
-        while (existsSync(commandLine)) {
-          let command;
-          try {
-            command = readFileSync(commandLine, "utf8");
-          } catch (error) {
-            if (error.code === "ENOENT") break;
-            throw error;
-          }
-          if (!command.includes(userRoot)) break;
-          if (Date.now() >= deadline) break;
-          await new Promise((resolve) => setTimeout(resolve, 25));
-        }
-      }
+      await stopDaemon("cleanup.daemon-stop");
     } finally {
       rmSync(parent, { recursive: true, force: true, maxRetries: 5 });
     }
   };
-  return { seed, parent, root, userRoot, env, rows, checks, invoke, concurrentCli, check, publish, close };
+  return { seed, parent, root, userRoot, env, rows, checks, invoke, check, publish, stopDaemon, close };
 }
 
 export function resourceSnapshot(root, label) {
@@ -224,9 +175,14 @@ export function resourceSnapshot(root, label) {
       "-lc",
       "ps -eo pid,pcpu,rss,etime,args | grep -F 'daemon' | grep -v grep | head -20",
     ]),
-    diskKb: command(["du", "-sk", root]),
+    diskBytes: directoryBytes(root),
     filesystem: command(["df", "-T", root]),
   };
+}
+
+export function directoryBytes(target) {
+  const output = spawnSync("du", ["-sb", target], { encoding: "utf8" }).stdout?.trim();
+  return output ? Number(output.split(/\s+/u)[0]) : null;
 }
 
 /** Exact-byte oracle across the canonical blob, the materialized worktree and authored Git. */

--- a/tools/stress/entity-v2-scale.fixture.mjs
+++ b/tools/stress/entity-v2-scale.fixture.mjs
@@ -1,0 +1,279 @@
+import assert from "node:assert/strict";
+import { spawn, spawnSync, execFileSync } from "node:child_process";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir, loadavg, availableParallelism, cpus, totalmem, freemem } from "node:os";
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { cli, git } from "../../packages/cli/test/daemon-multi-repo-lifecycle-cli.fixtures.ts";
+import { percentile } from "../measure-cli-command-timing.mjs";
+
+export const frame = (type, value) =>
+  console.log(`ENTITY_V2_SCALE\t${JSON.stringify({ type, at: Date.now(), ...value })}`);
+
+export const workloadConfigPath = path.resolve(import.meta.dirname, "entity-v2-scale.workload.json");
+
+export function readWorkloadConfig() {
+  return JSON.parse(readFileSync(workloadConfigPath, "utf8"));
+}
+
+/** Deterministic bytes for one entity; the same seed always rebuilds the same buffer. */
+export function syntheticBinary(seed, size) {
+  const buffer = Buffer.alloc(size);
+  let state = seed >>> 0 || 1;
+  for (let offset = 0; offset < size; offset++) {
+    state = (Math.imul(state, 1664525) + 1013904223) >>> 0;
+    buffer[offset] = state & 255;
+  }
+  return buffer;
+}
+
+export function fixture(seed, daemonId = "entity-v2-scale") {
+  const parent = mkdtempSync(path.join(tmpdir(), "ha-entity-v2-scale-"));
+  const root = path.join(parent, "repo"),
+    userRoot = path.join(parent, "user");
+  mkdirSync(root);
+  writeFileSync(path.join(root, "README.md"), "# V2 scale fixture\n");
+  git(root, "init", "--quiet");
+  git(root, "add", "README.md");
+  git(root, "commit", "--quiet", "-m", "fixture");
+  const env = { ...process.env };
+  for (const key of Object.keys(env)) {
+    if (key.startsWith("HARNESS_") || key.startsWith("HA_CLI_TIMING")) delete env[key];
+  }
+  Object.assign(env, {
+    HARNESS_DAEMON_USER_ROOT: userRoot,
+    HARNESS_DAEMON_ID: daemonId,
+    HARNESS_GIT_AUTHOR_NAME: "V2 Scale Fixture",
+    HARNESS_GIT_AUTHOR_EMAIL: "v2-scale@example.test",
+    GIT_CONFIG_GLOBAL: "/dev/null",
+  });
+  const rows = [],
+    checks = [];
+  const record = (row) => {
+    rows.push(row);
+    if (row.frame !== false) frame("command", { ...row, stdout: row.stdout?.slice(0, 4096) });
+    return row;
+  };
+  /** Arm A: one real `ha` child process per operation, the full CLI chain a user pays for. */
+  const invoke = (
+    metric,
+    args,
+    { actor, input, requireSuccess = true, frameRow = true, timeoutMs = 120_000, offline = false } = {},
+  ) => {
+    const started = performance.now();
+    // Offline storage commands (backup, restore, events, migrate ledger) are recognised by argv[0].
+    const argv = offline ? [...args, "--root", root, "--json"] : ["--root", root, "--json", ...args];
+    const result = spawnSync(process.execPath, [cli, ...argv], {
+      env: { ...env, ...(actor ? { HARNESS_ACTOR: actor } : {}) },
+      encoding: "utf8",
+      timeout: timeoutMs,
+      maxBuffer: 32 * 1024 * 1024,
+      ...(input === undefined ? {} : { input: JSON.stringify(input) }),
+    });
+    let receipt = null;
+    try {
+      receipt = JSON.parse(result.stdout);
+    } catch {
+      /* Parse failures are evidence too. */
+    }
+    const row = {
+      seed,
+      metric,
+      arm: "cli-process",
+      args: argv,
+      wallMs: performance.now() - started,
+      exit: result.status,
+      signal: result.signal,
+      error: result.error?.message ?? null,
+      receipt,
+      stdout: result.stdout,
+      stderr: result.stderr?.slice(0, 2048),
+      frame: frameRow,
+    };
+    record(row);
+    if (requireSuccess) {
+      assert.equal(result.status, 0, `${metric}: ${result.stdout}\n${result.stderr}`);
+      assert.equal(receipt?.ok, true, `${metric}: ${result.stdout}`);
+    }
+    return receipt;
+  };
+  /** Arm A, concurrent: N independent CLI processes issued at once against one daemon. */
+  const concurrentCli = async (metric, argvList, { actor, timeoutMs = 180_000 } = {}) => {
+    const batchStarted = performance.now();
+    const results = await Promise.all(
+      argvList.map(
+        (args, client) =>
+          new Promise((resolve) => {
+            const started = performance.now();
+            const child = spawn(process.execPath, [cli, "--root", root, "--json", ...args], {
+              env: { ...env, ...(actor ? { HARNESS_ACTOR: actor } : {}) },
+            });
+            let stdout = "",
+              stderr = "";
+            const timer = setTimeout(() => child.kill("SIGKILL"), timeoutMs);
+            child.stdout.on("data", (chunk) => (stdout += chunk));
+            child.stderr.on("data", (chunk) => (stderr += chunk.toString().slice(0, 2048)));
+            child.on("close", (code, signal) => {
+              clearTimeout(timer);
+              let receipt = null;
+              try {
+                receipt = JSON.parse(stdout);
+              } catch {
+                /* Parse failures are evidence too. */
+              }
+              resolve({
+                seed,
+                metric,
+                arm: "cli-process-concurrent",
+                client,
+                args,
+                wallMs: performance.now() - started,
+                exit: code,
+                signal,
+                receipt,
+                stdout,
+                stderr: stderr.slice(0, 2048),
+              });
+            });
+          }),
+      ),
+    );
+    for (const row of results) record(row);
+    const batchMs = performance.now() - batchStarted;
+    frame("concurrent-batch", {
+      seed,
+      metric,
+      clients: argvList.length,
+      batchMs,
+      succeeded: results.filter(({ exit, receipt }) => exit === 0 && receipt?.ok).length,
+    });
+    return { results, batchMs };
+  };
+  const check = (name, operation) => {
+    try {
+      operation();
+      checks.push({ name, passed: true });
+    } catch (error) {
+      checks.push({ name, passed: false, error: error.message });
+      frame("check", { seed, ...checks.at(-1) });
+      throw error;
+    }
+    frame("check", { seed, ...checks.at(-1) });
+  };
+  const publish = (receipt, metric, actor) => {
+    assert.equal(receipt.status, "accepted_durable", JSON.stringify(receipt));
+    const published = invoke(
+      `${metric}.publication`,
+      ["receipt", "show", receipt.opId, "--wait", "git_verified,worktree_visible", "--timeout-ms", "15000"],
+      { actor },
+    );
+    check(`${metric}.publication-facets`, () => {
+      assert.equal(published.wait?.state, "satisfied", JSON.stringify(published));
+      assert.equal(published.git?.state, "verified");
+      assert.equal(published.worktree?.state, "verified");
+    });
+    return published;
+  };
+  const close = async () => {
+    try {
+      const stopped = invoke("cleanup.daemon-stop", ["daemon", "stop"], { requireSuccess: false });
+      if (Number.isSafeInteger(stopped?.pid)) {
+        const commandLine = `/proc/${stopped.pid}/cmdline`,
+          deadline = Date.now() + 10_000;
+        while (existsSync(commandLine)) {
+          let command;
+          try {
+            command = readFileSync(commandLine, "utf8");
+          } catch (error) {
+            if (error.code === "ENOENT") break;
+            throw error;
+          }
+          if (!command.includes(userRoot)) break;
+          if (Date.now() >= deadline) break;
+          await new Promise((resolve) => setTimeout(resolve, 25));
+        }
+      }
+    } finally {
+      rmSync(parent, { recursive: true, force: true, maxRetries: 5 });
+    }
+  };
+  return { seed, parent, root, userRoot, env, rows, checks, invoke, concurrentCli, check, publish, close };
+}
+
+export function resourceSnapshot(root, label) {
+  const command = (args) =>
+    spawnSync(args[0], args.slice(1), { encoding: "utf8", maxBuffer: 8 * 1024 * 1024 }).stdout?.trim() ?? null;
+  const sqlite = new DatabaseSync(":memory:");
+  const sqliteVersion = sqlite.prepare("select sqlite_version() as version").get().version;
+  sqlite.close();
+  return {
+    label,
+    at: new Date().toISOString(),
+    node: process.version,
+    sqlite: sqliteVersion,
+    platform: process.platform,
+    arch: process.arch,
+    parallelism: availableParallelism(),
+    cpuModel: cpus()[0]?.model ?? null,
+    totalMemBytes: totalmem(),
+    freeMemBytes: freemem(),
+    load: loadavg(),
+    selfRssBytes: process.memoryUsage().rss,
+    daemonProcesses: command([
+      "bash",
+      "-lc",
+      "ps -eo pid,pcpu,rss,etime,args | grep -F 'daemon' | grep -v grep | head -20",
+    ]),
+    diskKb: command(["du", "-sk", root]),
+    filesystem: command(["df", "-T", root]),
+  };
+}
+
+/** Exact-byte oracle across the canonical blob, the materialized worktree and authored Git. */
+export function assertBytes(root, relativePath, expected, receipt, reader) {
+  const event = reader.readEvent(receipt.opId);
+  const claims =
+    event?.payload?.changes?.map(({ path: claimPath, candidate }) => ({ path: claimPath, ...candidate })) ??
+    event?.payload?.initialDocumentClaims ??
+    [];
+  const owned = event?.payload?.ownedContent;
+  const binding = owned?.bindings?.find(({ path: claimPath }) => claimPath === relativePath);
+  const claim = claims.find(({ path: claimPath }) => claimPath === relativePath);
+  const digest = binding?.contentSha256 ?? claim?.sha256;
+  assert.ok(digest, `No accepted content claim for ${relativePath} in ${event?.schema}`);
+  assert.deepEqual(Buffer.from(reader.readContentBlob(digest)), expected);
+  assert.deepEqual(readFileSync(path.join(root, "harness", relativePath)), expected);
+  assert.deepEqual(
+    execFileSync("git", ["-C", path.join(root, "harness"), "show", `HEAD:${relativePath}`], {
+      maxBuffer: 128 * 1024 * 1024,
+    }),
+    expected,
+  );
+}
+
+export function summarize(rows, filter = () => true) {
+  const selected = rows.filter(filter);
+  return Object.fromEntries(
+    [...new Set(selected.map(({ metric }) => metric))].map((metric) => {
+      const scoped = selected.filter((row) => row.metric === metric),
+        values = scoped.map(({ wallMs }) => wallMs);
+      return [
+        metric,
+        {
+          arm: scoped[0]?.arm ?? null,
+          samples: scoped.length,
+          success: scoped.filter(({ exit, receipt, ok }) =>
+            exit === undefined ? ok === true : exit === 0 && receipt?.ok,
+          ).length,
+          durableReceipts: scoped.filter(({ receipt }) => receipt?.status === "accepted_durable").length,
+          p50: percentile(values, 0.5),
+          p95: percentile(values, 0.95),
+          p99: percentile(values, 0.99),
+          min: Math.min(...values),
+          max: Math.max(...values),
+          totalMs: values.reduce((sum, value) => sum + value, 0),
+        },
+      ];
+    }),
+  );
+}

--- a/tools/stress/entity-v2-scale.generator.mjs
+++ b/tools/stress/entity-v2-scale.generator.mjs
@@ -1,0 +1,306 @@
+import { createHash } from "node:crypto";
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import {
+  applyTransition,
+  compileDecisionWrite,
+  compileFactWrite,
+  deriveRelationId,
+  makeTaskEventStore,
+  normalizeTaskLifecycleCommand,
+  openSqliteEventStore,
+  relationEventWritePlan,
+  sessionProvenance,
+  taskLifecycleWritePlan,
+  unavailableSessionIdentity,
+} from "../../packages/kernel/src/index.ts";
+import { compileRelationCreatedEvent } from "../../packages/kernel/src/domain/relation-event.ts";
+import { emptyTaskLifecycleSnapshot } from "../../packages/kernel/src/domain/task-lifecycle-contract-support.ts";
+import { compileTaskBootstrap } from "../../packages/preset/src/preset-bootstrap.ts";
+
+/**
+ * The declared V2 scale workset. Domain entities keep the production ledger's ratio per event
+ * (canonical ledger, revision 70,353: 2,368 Tasks, 3,373 Facts, 833 Decisions, so about 30 events
+ * per Task). The rest of each Task's 30 events is lifecycle activity on that Task: real
+ * block/unblock transitions compiled by the kernel lifecycle reducer, standing in for the
+ * execution, runtime and document activity production records per Task.
+ */
+export const declaredWorkset = Object.freeze({
+  schema: "entity-v2-scale-workset/v1",
+  eventsPerTask: 30,
+  factsPerTask: 1.5,
+  relationsPerTask: 1,
+  decisionEveryTasks: 3,
+  dependencyForestWidth: 8,
+  presetId: "standard-task",
+  verticalId: "software/coding",
+});
+
+const hex = (text) => createHash("sha256").update(text).digest("hex");
+const crockford = "0123456789ABCDEFGHJKMNPQRSTVWXYZ";
+const factIdFor = (seed, index) => {
+  const digest = createHash("sha256").update(`${seed}:fact:${index}`).digest();
+  return `F-${Array.from(digest.subarray(0, 8), (byte) => crockford[byte & 31]).join("")}`;
+};
+const spread = (items, count) =>
+  Array.from(
+    { length: Math.min(count, items.length) },
+    (_value, position) => items[Math.floor((position * items.length) / Math.min(count, items.length))],
+  );
+const at = (revision) => new Date(Date.UTC(2026, 0, 1) + revision * 1_000).toISOString();
+
+/**
+ * Append a deterministic event stream to a generation-2 ledger in this process, through the same
+ * `makeTaskEventStore().append` the daemon uses, without the daemon write queue. Each Task unit is
+ * one command; the Git follower drains every `drainEvery` events so publication stays bounded.
+ * The daemon of the repository must be stopped: the generator takes the next writer epoch.
+ */
+export async function generateEventStream({
+  rootDir,
+  repoId,
+  seed,
+  targetEvents,
+  userRoot,
+  personId = "owner",
+  drainEvery = 16_384,
+  onProgress = () => undefined,
+}) {
+  const probe = openSqliteEventStore({ repoId, rootInput: rootDir, readOnly: true }),
+    baseRevision = probe.revision(),
+    objectRoot = path.join(path.dirname(probe.databasePath), "objects", "sha256"),
+    fence = { repoId, holderId: "entity-v2-scale-generator", epoch: (probe.writerFence()?.epoch ?? 0) + 1 };
+  probe.close();
+  const store = makeTaskEventStore({ repoId, rootDir, writerFence: () => fence }),
+    actor = { principal: { personId }, executor: { kind: "agent", id: "entity-v2-scale-generator" } },
+    source = "local",
+    provenance = (occurredAt) => [sessionProvenance(unavailableSessionIdentity("human"), occurredAt)],
+    tasks = [],
+    decisions = [],
+    counts = { tasks: 0, facts: 0, relations: 0, decisions: 0, transitions: 0, commands: 0, blobs: 0 },
+    phaseMs = { compile: 0, stage: 0, append: 0, publish: 0 },
+    started = performance.now(),
+    timed = async (phase, operation) => {
+      const phaseStarted = performance.now();
+      try {
+        return await operation();
+      } finally {
+        phaseMs[phase] += performance.now() - phaseStarted;
+      }
+    };
+  let revision = baseRevision,
+    sinceDrain = 0;
+
+  while (revision - baseRevision < targetEvents) {
+    const unitStarted = performance.now(),
+      index = tasks.length,
+      budget = targetEvents - (revision - baseRevision),
+      members = [],
+      next = () => ({
+        workspaceRevision: revision + members.length + 1,
+        occurredAt: at(revision + members.length + 1),
+      }),
+      push = (event, plan, blobs = []) => {
+        members.push({ event, plan, blobs });
+        counts.blobs += blobs.length;
+      },
+      pushRelation = (identity, rationale, targetObservedVersion) => {
+        const relationAt = next(),
+          event = compileRelationCreatedEvent({
+            record: {
+              relation_id: deriveRelationId(identity),
+              ...identity,
+              origin: "declared",
+              state: "active",
+              rationale,
+              targetObservedVersion,
+            },
+            actor,
+            source,
+            opId: `op-${seed}-${relationAt.workspaceRevision}`,
+            ...relationAt,
+          });
+        push(event, relationEventWritePlan(event));
+        counts.relations += 1;
+      };
+
+    const taskId = `task_${hex(`${seed}:task:${index}`).slice(0, 26)}`,
+      bootstrapAt = next(),
+      bootstrap = compileTaskBootstrap({
+        taskId,
+        title: `Scale workload ${index}`,
+        presetId: declaredWorkset.presetId,
+        verticalId: declaredWorkset.verticalId,
+        locale: "en-US",
+        workKind: ["feat", "fix", "refactor", "docs", "test", "chore"][index % 6],
+        riskTier: ["low", "medium", "high"][index % 3],
+        urgency: ["low", "medium", "high"][(index + 1) % 3],
+        userRoot,
+        actor,
+        source,
+        eventId: `event-${seed}-${bootstrapAt.workspaceRevision}`,
+        opId: `op-${seed}-${bootstrapAt.workspaceRevision}`,
+        ...bootstrapAt,
+      });
+    push(bootstrap.event, bootstrap.plan, bootstrap.blobs);
+    let snapshot = { ...emptyTaskLifecycleSnapshot(bootstrapAt.workspaceRevision), task: bootstrap.event.payload.task };
+    tasks.push({ taskId, version: bootstrapAt.workspaceRevision });
+    counts.tasks += 1;
+
+    for (let fact = 0; fact < (index % 2 === 0 ? 1 : 2) && members.length < budget; fact++) {
+      const factAt = next(),
+        factId = factIdFor(seed, counts.facts),
+        compiled = compileFactWrite({
+          event: {
+            schema: "fact-event/v1",
+            eventId: `event-${seed}-${factAt.workspaceRevision}`,
+            opId: `op-${seed}-${factAt.workspaceRevision}`,
+            taskId,
+            factId,
+            type: "fact_recorded",
+            actor,
+            source,
+            ...factAt,
+            payload: {
+              statement: `Scale observation token${counts.facts} on workload ${index} stays index friendly`,
+              evidenceSource: `test:entity-v2-scale/${index}`,
+              observedAt: factAt.occurredAt,
+              confidence: ["low", "medium", "high"][counts.facts % 3],
+              memoryClass: ["semantic", "episodic", "procedural"][counts.facts % 3],
+              memoryTags: ["pattern"],
+              provenance: provenance(factAt.occurredAt),
+            },
+          },
+        });
+      push(compiled.event, compiled.plan, compiled.blobs);
+      counts.facts += 1;
+    }
+
+    if (index > 0 && members.length < budget) {
+      // A forest of depth two: each anchor depends on the first Task, the rest on their anchor.
+      const offset = index % declaredWorkset.dependencyForestWidth,
+        anchor = tasks[offset === 0 ? 0 : index - offset],
+        identity = {
+          source: `task/${taskId}`,
+          target: `task/${anchor.taskId}`,
+          type: "depends-on",
+          direction: "directed",
+        };
+      pushRelation(identity, `Workload ${index} builds on workload anchor`, anchor.version);
+    }
+
+    if (index % declaredWorkset.decisionEveryTasks === 0 && members.length + 1 < budget) {
+      const decisionAt = next(),
+        decisionId = `dec_${hex(`${seed}:decision:${counts.decisions}`).slice(0, 26).toUpperCase()}`,
+        compiled = compileDecisionWrite({
+          event: {
+            schema: "decision-event/v1",
+            eventId: `event-${seed}-${decisionAt.workspaceRevision}`,
+            opId: `op-${seed}-${decisionAt.workspaceRevision}`,
+            decisionId,
+            type: "decision_proposed",
+            actor,
+            source,
+            ...decisionAt,
+            payload: {
+              title: `Scale decision ${counts.decisions}`,
+              question: `How should workload ${index} be handled?`,
+              riskTier: "medium",
+              urgency: "low",
+              vertical: declaredWorkset.verticalId,
+              preset: "decision-conformance",
+              appliesTo: { modules: [], productLines: [] },
+              decisionClass: "ordinary",
+              chosen: [{ id: "CH1", text: `Proceed with option one for workload ${index}` }],
+              rejected: [{ id: "RJ1", text: "Do nothing", whyNot: "The workload requires handling" }],
+              body: `\n# Scale decision ${counts.decisions}\n\nRationale for the synthetic decision record.\n`,
+              claims: [{ id: "C1", text: `Workload ${index} stays index friendly`, loadBearing: true }],
+              fulfillments: [],
+              relations: [],
+              provenance: provenance(decisionAt.occurredAt),
+            },
+          },
+          currentDecision: null,
+          currentRelations: [],
+          currentDocument: null,
+        });
+      push(compiled.event, compiled.plan, compiled.blobs);
+      decisions.push({ decisionId, taskId });
+      counts.decisions += 1;
+      const identity = {
+        source: `decision/${decisionId}/C1`,
+        target: `task/${taskId}`,
+        type: "derives",
+        direction: "directed",
+      };
+      pushRelation(identity, `Decision ${decisionId} derives workload ${index}`, tasks.at(-1).version);
+    }
+
+    // Lifecycle activity closes the unit at the declared density: block, unblock and return-to-planned
+    // cycles, then a cancel (and a reinstate) for the remainder, so no Task is left occupying WIP.
+    const activity = Math.min(budget, declaredWorkset.eventsPerTask) - members.length,
+      statuses = [
+        ...Array.from({ length: Math.floor(activity / 3) }, () => ["blocked", "active", "planned"]).flat(),
+        ...[[], ["cancelled"], ["cancelled", "planned"]][activity % 3],
+      ];
+    for (const status of statuses) {
+      const transitionAt = next(),
+        command = {
+          ...normalizeTaskLifecycleCommand(
+            { workspaceId: repoId, actor, source, expectedRevision: snapshot.revision },
+            { type: "TransitionTask", taskId, status, reason: `Scale activity ${transitionAt.workspaceRevision}` },
+          ),
+          eventId: `event-${seed}-${transitionAt.workspaceRevision}`,
+          ...transitionAt,
+        },
+        result = applyTransition(snapshot, command, {});
+      push(result.event, taskLifecycleWritePlan(result.event));
+      snapshot = result.snapshot;
+      counts.transitions += 1;
+    }
+    tasks.at(-1).version = snapshot.revision;
+
+    phaseMs.compile += performance.now() - unitStarted;
+    // Content objects land byte-identical to the store's own layout without a per-object fsync;
+    // append then finds each present and skips it. Everything else is the production append.
+    await timed("stage", () => {
+      for (const { blobs } of members)
+        for (const blob of blobs) {
+          const target = path.join(objectRoot, blob.sha256.slice(0, 2), blob.sha256.slice(2));
+          if (existsSync(target)) continue;
+          mkdirSync(path.dirname(target), { recursive: true });
+          writeFileSync(target, blob.body);
+        }
+    });
+    const [last, ...rest] = members.reverse();
+    await timed("append", () => store.append({ ...last, preceding: rest.reverse() }));
+    counts.commands += 1;
+    revision += members.length;
+    sinceDrain += members.length;
+    if (sinceDrain >= drainEvery) {
+      sinceDrain = 0;
+      await timed("publish", () => store.settlePendingMaterialization());
+      onProgress({ revision, generated: revision - baseRevision, elapsedMs: performance.now() - started });
+    }
+  }
+  await timed("publish", () => store.settlePendingMaterialization());
+  const follower = store.followerStatus(),
+    head = store.readHead();
+  await store.drain();
+  return {
+    workset: declaredWorkset,
+    baseRevision,
+    headRevision: head?.revision ?? 0,
+    generatedEvents: (head?.revision ?? 0) - baseRevision,
+    counts,
+    phaseMs,
+    fence,
+    follower: { git: follower.git.status, worktree: follower.worktree.status, cut: follower.git.cut?.revision ?? null },
+    elapsedMs: performance.now() - started,
+    samples: {
+      taskIds: spread(tasks, 20).map(({ taskId }) => taskId),
+      decisions: spread(decisions, 40),
+      anchorTaskId: tasks[0].taskId,
+      factToken: `token${Math.max(0, counts.facts - 1)}`,
+    },
+  };
+}

--- a/tools/stress/entity-v2-scale.integration.test.mjs
+++ b/tools/stress/entity-v2-scale.integration.test.mjs
@@ -3,12 +3,14 @@ import assert from "node:assert/strict";
 import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import test from "node:test";
-import { makeTaskEventReader } from "../../packages/kernel/src/index.ts";
+import { Worker } from "node:worker_threads";
+import { makeTaskEventReader, makeTaskProjection } from "../../packages/kernel/src/index.ts";
 import { main as cliMain } from "../../packages/cli/src/index.ts";
 import { git } from "../../packages/cli/test/daemon-multi-repo-lifecycle-cli.fixtures.ts";
 import { realizedTaskPlan } from "../fixtures/task-plan.mjs";
 import {
   assertBytes,
+  directoryBytes,
   fixture,
   frame,
   readWorkloadConfig,
@@ -16,6 +18,7 @@ import {
   summarize,
   syntheticBinary,
 } from "./entity-v2-scale.fixture.mjs";
+import { generateEventStream } from "./entity-v2-scale.generator.mjs";
 
 const kind = "entity-kind/KND-3b7e2c9a1d5f6e8c0a4b2d3f5e7c9a16";
 const config = readWorkloadConfig();
@@ -27,13 +30,57 @@ const skip =
       ? false
       : "workload disabled: tools/stress/entity-v2-scale.workload.json enabled=false";
 
-test("bounded V2 scale: real CLI Task lifecycle and Entity content at a declared workset", { skip }, async () => {
+/**
+ * A projection follower on its own thread. `finish` names the final revision and whether to digest, and gives
+ * up at `withinMs`: the follower is stopped and the error names how far replay got.
+ */
+function follower(label, rootDir, repoId, projectionPath) {
+  const worker = new Worker(new URL("./entity-v2-scale.projection-worker.mjs", import.meta.url), {
+    workerData: { rootDir, repoId, projectionPath },
+  });
+  let reached = null;
+  const settled = new Promise((resolve) => {
+    worker.on("message", ({ progress, ...message }) => {
+      if (!progress) return resolve(message);
+      reached = message;
+      frame("follower-progress", { label, ...message });
+    });
+    worker.once("error", (error) => resolve({ ok: false, error: error.message }));
+    worker.once("exit", (code) => resolve({ ok: false, error: `${label} follower exited ${code} before reporting` }));
+  });
+  return {
+    finish: async (revision, digest, withinMs) => {
+      worker.postMessage({ revision, digest });
+      let timer;
+      const expired = new Promise((resolve) => {
+        const error = () => `stage budget: ${label} follower reached ${JSON.stringify(reached)} of ${revision}`;
+        timer = setTimeout(() => resolve({ ok: false, error: error() }), Math.max(0, withinMs));
+      });
+      const result = await Promise.race([settled, expired]);
+      clearTimeout(timer);
+      if (result.ok) return result;
+      await worker.terminate();
+      throw new Error(result.error);
+    },
+    stop: () => worker.terminate(),
+  };
+}
+
+test(`V2 scale tier: ${config.targetEvents} generated events`, { skip, timeout: config.stageBudgetMs }, async () => {
   const started = performance.now();
   const elapsed = () => performance.now() - started;
+  // Phases stop cleanly before the dispatcher's per-file watchdog, keeping room to report and clean up.
+  const remainingMs = () => config.stageBudgetMs - 45_000 - elapsed();
+  const requireBudget = (phase, neededMs) => {
+    if (remainingMs() < neededMs)
+      throw new Error(`stage budget: ${Math.round(remainingMs())} ms left before ${phase}, needs ${neededMs} ms`);
+  };
   const f = fixture(config.seed);
   const failures = [],
-    capacity = {};
-  let reader = null;
+    tier = { targetEvents: config.targetEvents };
+  let reader = null,
+    hotFollower = null,
+    coldFollower = null;
   const guard = (name, operation) => {
     try {
       return operation();
@@ -61,11 +108,11 @@ test("bounded V2 scale: real CLI Task lifecycle and Entity content at a declared
       errorChunks = [],
       write = process.stdout.write.bind(process.stdout),
       writeError = process.stderr.write.bind(process.stderr),
-      // The node:test reporter writes its own binary protocol to these streams; only the CLI's
-      // console.log receipt arrives as a string, so string chunks are the receipt channel and
-      // everything else is passed straight through to the real stream.
+      // The node:test reporter writes its own binary protocol to these streams and follower frames can
+      // land mid-command; only the CLI's console.log receipt is captured, everything else passes through.
       capture = (sink, passthrough) => (chunk, encoding, callback) => {
-        if (typeof chunk !== "string") return passthrough(chunk, encoding, callback);
+        if (typeof chunk !== "string" || chunk.startsWith("ENTITY_V2_SCALE\t"))
+          return passthrough(chunk, encoding, callback);
         sink.push(chunk);
         if (typeof encoding === "function") encoding();
         else if (typeof callback === "function") callback();
@@ -106,337 +153,210 @@ test("bounded V2 scale: real CLI Task lifecycle and Entity content at a declared
       ...(status === 0 && receipt?.ok === true ? {} : { stdout: stdout.slice(0, 2000), stderr: stderr.slice(0, 2000) }),
     };
     f.rows.push(row);
+    if (!row.ok) {
+      const { receipt: rejected, ...rest } = row;
+      failures.push({ phase: metric, error: JSON.stringify({ ...rest, code: rejected?.code ?? null }).slice(0, 2000) });
+      frame("failure", failures.at(-1));
+    }
     return row;
   };
-
+  const probeInput = (sample) => {
+    const locator = `inputs/probe/${sample}`,
+      directory = path.join(f.root, locator),
+      text = Buffer.from(`# Probe ${sample}\n`),
+      binary = syntheticBinary(90_000 + sample, config.binaryBytes);
+    mkdirSync(directory, { recursive: true });
+    writeFileSync(path.join(directory, "README.md"), text);
+    writeFileSync(path.join(directory, "sample.bin"), binary);
+    return {
+      argv: ["entity", "import", "--kind", kind, "--locator", locator, "--expected-version", "0"],
+      text,
+      binary,
+    };
+  };
+  const importProbe = (metric, sample) => {
+    const { argv, text, binary } = probeInput(sample),
+      receipt = f.invoke(metric, argv, { frameRow: false });
+    return { receipt, id: evidence(receipt).preview.entityId, text, binary };
+  };
+  let generatedSamples = null;
+  const reckonArgs = (sample) => {
+    const { decisionId, taskId } = generatedSamples.decisions[sample % generatedSamples.decisions.length];
+    return ["decision", "reckon", decisionId, "--task", taskId];
+  };
   try {
     frame("protocol", {
       config,
-      cache: "source CLI; no OS page cache eviction; cold reads are daemon-restart cold, not disk cold",
+      cache: "no OS page cache eviction; the daemon starts onto a projection its follower kept current",
       interpretation:
-        "arm cli-process includes Node startup and module load per operation; arm in-process-reused-modules does not. The two arms are never compared as a speedup.",
+        "arm cli-process includes Node startup and module load per operation; arm in-process-reused-modules " +
+        "does not. The two arms are never compared as a speedup.",
       resources: resourceSnapshot(f.parent, "before"),
     });
 
     f.invoke("setup.init", ["init", "--repo-id", config.repoId, "--person-id", "owner", "--display-name", "Owner"]);
     reader = makeTaskEventReader({ rootDir: f.root, repoId: config.repoId });
-
-    // V2 entry: the production reader, the production writer receipts and a real backup must agree.
-    const backupDir = path.join(f.parent, "entry-backup");
-    const backup = f.invoke("v2.backup", ["backup", backupDir], { offline: true });
+    const entryBackup = f.invoke("v2.backup", ["backup", path.join(f.parent, "entry-backup")], { offline: true });
     f.check("v2.generation-two-before-workload", () => {
       assert.equal(reader.ledgerMetadata().generation, 2, "reader generation");
-      assert.equal(backup.manifest?.sqlite?.generation, 2, JSON.stringify(backup.manifest));
-    });
-    frame("v2-entry", {
-      readerGeneration: reader.ledgerMetadata().generation,
-      backupManifest: backup.manifest,
-      initialRevision: reader.readHead().revision,
+      assert.equal(entryBackup.manifest?.sqlite?.generation, 2, JSON.stringify(entryBackup.manifest));
     });
 
-    // One full real Task document lifecycle on the empty repository.
-    guard("task-lifecycle.empty", () => taskLifecycle(f, reader, "empty"));
+    // Generation writes the ledger directly, so the daemon is stopped. One follower keeps the daemon's own
+    // projection current while events land; a second builds an independent projection from empty.
+    await f.stopDaemon("generation.daemon-stop");
+    hotFollower = follower("hot", f.root, config.repoId);
+    coldFollower = follower("cold", f.root, config.repoId, path.join(f.parent, "cold-follower.sqlite"));
+    const generated = await generateEventStream({
+      rootDir: f.root,
+      repoId: config.repoId,
+      seed: config.seed,
+      targetEvents: config.targetEvents,
+      userRoot: f.userRoot,
+      drainEvery: config.drainEvery,
+      onProgress: (progress) => frame("generation-progress", progress),
+    });
+    frame("generation", generated);
+    const hotCatchUp = await hotFollower.finish(generated.headRevision, false, remainingMs());
+    tier.generation = { ...generated, samples: undefined, hotCatchUp };
+    frame("hot-catch-up", hotCatchUp);
+    f.check("generation.exact-count-and-follower-verified", () => {
+      assert.equal(generated.generatedEvents, config.targetEvents);
+      assert.equal(generated.follower.git, "verified");
+      assert.equal(generated.follower.worktree, "verified");
+      assert.equal(generated.follower.cut, generated.headRevision);
+      assert.equal(hotCatchUp.watermark, generated.headRevision);
+    });
+    frame("resources-after-generation", resourceSnapshot(f.parent, "after-generation"));
 
-    // Population to the declared workset, plus periodic exact-byte verification.
-    const inputRoot = path.join(f.root, "inputs", "scale");
-    mkdirSync(inputRoot, { recursive: true });
-    const verified = [];
-    const populateStarted = performance.now();
-    let imported = 0,
-      populationStop = "target-reached";
-    for (let index = 0; index < config.targetEntities; index++) {
-      if (performance.now() - populateStarted > config.populateBudgetMs) {
-        populationStop = "populate-budget-exhausted";
-        break;
-      }
-      const locator = `inputs/scale/${index}`,
-        directory = path.join(f.root, locator);
-      mkdirSync(directory, { recursive: true });
-      const text = Buffer.from(`# Scale ${config.seed}/${index}\n${"canonical content\n".repeat(8)}`),
-        binary = syntheticBinary(config.seed + index, config.binaryBytes);
-      writeFileSync(path.join(directory, "README.md"), text);
-      writeFileSync(path.join(directory, "sample.bin"), binary);
-      const row = await inProcess("entity.import.populate", [
-        "entity",
-        "import",
-        "--kind",
-        kind,
-        "--locator",
-        locator,
-        "--expected-version",
-        "0",
-        "--no-wait",
-      ]);
-      if (!row.ok) {
-        failures.push({
-          phase: `populate-${index}`,
-          error: JSON.stringify({ exit: row.exit, thrown: row.error, stdout: row.stdout, stderr: row.stderr }).slice(
-            0,
-            2000,
-          ),
-        });
-        frame("failure", failures.at(-1));
-        populationStop = "import-rejected";
-        break;
-      }
-      imported += 1;
-      if (
-        verified.length < config.contentSamples &&
-        index % Math.max(1, Math.floor(config.targetEntities / config.contentSamples)) === 0
-      ) {
-        verified.push({ index, id: evidence(row.receipt).preview.entityId, receipt: row.receipt, text, binary });
-      }
-      if (index % 100 === 0)
-        frame("populate-progress", {
-          index,
-          imported,
-          elapsedMs: elapsed(),
-          populateMs: performance.now() - populateStarted,
-        });
-    }
-    const populateMs = performance.now() - populateStarted;
-    capacity.population = {
-      requested: config.targetEntities,
-      imported,
-      stop: populationStop,
-      populateMs,
-      opsPerSecond: imported / (populateMs / 1000),
-      arm: "in-process-reused-modules",
-    };
-    frame("capacity", capacity.population);
-
-    const afterPopulation = reader.readHead().revision;
-    frame("cut-after-population", { revision: afterPopulation, entities: imported });
-
-    // Exact-byte oracle on the sampled entities, plus the negative control that proves the oracle bites.
-    for (const sample of verified) {
-      const contentRoot = `entities/research/${sample.id}`;
-      guard(`content.bytes-${sample.index}`, () =>
-        f.check(`content.exact-bytes-${sample.index}`, () => {
-          assertBytes(f.root, `${contentRoot}/README.md`, sample.text, sample.receipt, reader);
-          assertBytes(f.root, `${contentRoot}/sample.bin`, sample.binary, sample.receipt, reader);
-        }),
-      );
-    }
-    if (verified.length > 0)
-      guard("content.negative-control", () =>
-        f.check("content.oracle-rejects-wrong-bytes", () =>
-          assert.throws(() =>
-            assertBytes(
-              f.root,
-              `entities/research/${verified[0].id}/sample.bin`,
-              Buffer.from("dropped bytes"),
-              verified[0].receipt,
-              reader,
-            ),
-          ),
-        ),
-      );
-
-    // Latency probes at the populated scale, full CLI chain.
-    guard("probe.cli-import", () => {
-      for (let sample = 0; sample < config.cliProbeSamples; sample++) {
-        const locator = `inputs/probe/${sample}`,
-          directory = path.join(f.root, locator);
-        mkdirSync(directory, { recursive: true });
-        writeFileSync(path.join(directory, "README.md"), Buffer.from(`# Probe ${sample}\n`));
-        writeFileSync(path.join(directory, "sample.bin"), syntheticBinary(90_000 + sample, config.binaryBytes));
-        f.invoke(
-          "probe.entity.import",
-          ["entity", "import", "--kind", kind, "--locator", locator, "--expected-version", "0", "--no-wait"],
-          { frameRow: false },
-        );
+    // The daemon attaches to the current projection; its first write pays any whole-ledger follower work.
+    const { samples } = generated;
+    generatedSamples = samples;
+    requireBudget("daemon attach and measurement", config.measureBudgetMs);
+    f.invoke("attach.daemon-start", ["daemon", "start", "--service"], { timeoutMs: 600_000 });
+    f.invoke("attach.first-read", ["task", "list", "--limit", "1"], { timeoutMs: 600_000 });
+    const firstWrite = guard("write.first-after-restart", () => importProbe("write.entity-import.first", 0));
+    guard("write.first-publication", () => f.publish(firstWrite.receipt, "write.entity-import.first"));
+    guard("write.entity-import", () => {
+      for (let sample = 1; sample <= config.writeSamples; sample++) importProbe("write.entity-import", sample);
+    });
+    guard("write.decision-reckon", () => {
+      for (let sample = 0; sample < config.writeSamples; sample++)
+        f.invoke("write.decision-reckon", reckonArgs(sample), { frameRow: false });
+    });
+    // The resident arm writes other entities and reckons other decisions, so no write repeats one above.
+    await guardAsync("write.in-process", async () => {
+      for (let sample = 0; sample < config.writeSamples; sample++) {
+        await inProcess("write.entity-import", probeInput(1_000 + sample).argv);
+        await inProcess("write.decision-reckon", reckonArgs(config.writeSamples + sample));
       }
     });
-    const probeReceipt = f.rows.findLast((row) => row.metric === "probe.entity.import")?.receipt;
-    const probeId = probeReceipt ? evidence(probeReceipt).preview.entityId : null;
-    guard("probe.publication", () => f.publish(probeReceipt, "probe.entity.import"));
 
-    guard("probe.cli-get-warm", () => {
-      for (let sample = 0; sample < config.cliProbeSamples; sample++)
-        f.invoke("probe.entity.get.warm", ["entity", "get", kind, "--id", probeId], { frameRow: false });
-    });
-    guard("probe.cli-list-warm", () =>
-      f.invoke("probe.entity.list.warm", ["entity", "list", kind], { frameRow: false }),
-    );
-
-    // Update and its concurrency negative control at scale.
-    guard("probe.update", () => {
-      const current = f.invoke("probe.entity.get.before-update", ["entity", "get", kind, "--id", probeId], {
-        frameRow: false,
+    // Hot reads, both arms, one untimed warm-up each.
+    const hub = `task/${samples.anchorTaskId}`,
+      leaf = `task/${samples.taskIds.at(-1)}`,
+      reads = [
+        ["read.task-show", (sample) => ["task", "show", samples.taskIds[sample % samples.taskIds.length]]],
+        ["read.task-list", () => ["task", "list"]],
+        ["read.task-list.page", () => ["task", "list", "--limit", "50"]],
+        ["read.relation-list.page", () => ["relation", "list", "--limit", "50"]],
+        ["read.relation-list.hub", () => ["relation", "list", "--entity", hub, "--limit", "50"]],
+        ["read.relation-list.leaf", () => ["relation", "list", "--entity", leaf, "--limit", "50"]],
+        ["read.fact-search.selective", () => ["fact", "search", samples.factToken, "--limit", "20"]],
+        ["read.fact-search.broad", () => ["fact", "search", "observation", "--limit", "20"]],
+      ];
+    for (const [metric, argv] of reads)
+      guard(metric, () => {
+        f.invoke(`${metric}.warm-up`, argv(0), { frameRow: false });
+        for (let sample = 0; sample < config.readSamples; sample++) f.invoke(metric, argv(sample), { frameRow: false });
       });
-      const updated = f.invoke("probe.entity.update", [
-        "entity",
-        "update",
-        kind,
-        "--id",
-        probeId,
-        "--title",
-        "Updated at scale",
-        "--expected-version",
-        String(current.revision),
-        "--no-wait",
-      ]);
-      f.publish(updated, "probe.entity.update");
-      const warm = f.invoke("probe.entity.get.after-update", ["entity", "get", kind, "--id", probeId]);
-      f.check("probe.updated-title-visible", () => assert.equal(evidence(warm).entity.value.title, "Updated at scale"));
-      const stale = f.invoke(
-        "probe.entity.update.stale-negative",
-        [
-          "entity",
-          "update",
-          kind,
-          "--id",
-          probeId,
-          "--title",
-          "Stale must fail",
-          "--expected-version",
-          String(current.revision),
-        ],
-        { requireSuccess: false },
-      );
-      f.check("probe.stale-update-rejected", () => {
+    for (const [metric, argv] of reads)
+      await guardAsync(`${metric}.in-process`, async () => {
+        await inProcess(`${metric}.warm-up`, argv(0));
+        for (let sample = 0; sample < config.readSamples; sample++) await inProcess(metric, argv(sample));
+      });
+
+    // Content exactness and a concurrency negative control, at scale.
+    guard("content.exact-bytes", () =>
+      f.check("content.exact-bytes", () => {
+        const root = `entities/research/${firstWrite.id}`;
+        assertBytes(f.root, `${root}/README.md`, firstWrite.text, firstWrite.receipt, reader);
+        assertBytes(f.root, `${root}/sample.bin`, firstWrite.binary, firstWrite.receipt, reader);
+        assert.throws(() =>
+          assertBytes(f.root, `${root}/sample.bin`, Buffer.from("dropped"), firstWrite.receipt, reader),
+        );
+      }),
+    );
+    guard("content.stale-update", () => {
+      const current = f.invoke("probe.entity.get", ["entity", "get", kind, "--id", firstWrite.id]);
+      const update = (title) => [
+        ...["entity", "update", kind, "--id", firstWrite.id, "--title", title],
+        ...["--expected-version", String(evidence(current).entity.workspaceRevision)],
+      ];
+      f.invoke("write.entity-update", update("Updated at scale"));
+      const stale = f.invoke("write.entity-update.stale", update("Stale must fail"), { requireSuccess: false });
+      f.check("content.stale-update-rejected", () => {
         assert.equal(stale.ok, false);
         assert.equal(stale.code, "revision_conflict");
       });
     });
 
-    // Concurrent clients, each an independent CLI process against the one daemon.
-    await guardAsync("probe.concurrent-reads", async () => {
-      const rounds = config.concurrentRounds ?? 1,
-        batches = [];
-      let succeeded = 0;
-      for (let round = 0; round < rounds; round++) {
-        const { batchMs, results } = await f.concurrentCli(
-          "probe.entity.get.concurrent",
-          Array.from({ length: config.clients }, () => ["entity", "get", kind, "--id", probeId]),
-        );
-        batches.push(batchMs);
-        succeeded += results.filter((row) => row.exit === 0 && row.receipt?.ok).length;
-      }
-      capacity.concurrentReads = {
-        clients: config.clients,
-        rounds,
-        batchMs: batches,
-        succeeded,
-        readsPerSecond: succeeded / (batches.reduce((sum, value) => sum + value, 0) / 1000),
-      };
-      frame("capacity", { concurrentReads: capacity.concurrentReads });
-    });
-    await guardAsync("probe.concurrent-writes", async () => {
-      const rounds = config.concurrentRounds ?? 1,
-        batches = [],
-        opIds = new Set(),
-        rejections = [];
-      let accepted = 0;
-      for (let round = 0; round < rounds; round++) {
-        for (let client = 0; client < config.clients; client++) {
-          const directory = path.join(f.root, "inputs", "concurrent", `${round}-${client}`);
-          mkdirSync(directory, { recursive: true });
-          writeFileSync(path.join(directory, "README.md"), Buffer.from(`# Concurrent ${round}/${client}\n`));
-          writeFileSync(
-            path.join(directory, "sample.bin"),
-            syntheticBinary(70_000 + round * 100 + client, config.binaryBytes),
-          );
-        }
-        const { batchMs, results } = await f.concurrentCli(
-          "probe.entity.import.concurrent",
-          Array.from({ length: config.clients }, (_unused, client) => [
-            "entity",
-            "import",
-            "--kind",
-            kind,
-            "--locator",
-            `inputs/concurrent/${round}-${client}`,
-            "--expected-version",
-            "0",
-            "--no-wait",
-          ]),
-        );
-        batches.push(batchMs);
-        for (const row of results) {
-          if (row.exit === 0 && row.receipt?.ok) {
-            accepted += 1;
-            opIds.add(row.receipt.opId);
-          } else if (row.receipt?.ok === false) rejections.push(row.receipt.code);
-        }
-      }
-      capacity.concurrentWrites = {
-        clients: config.clients,
-        rounds,
-        batchMs: batches,
-        accepted,
-        distinctOpIds: opIds.size,
-        rejections,
-        writesPerSecond: accepted / (batches.reduce((sum, value) => sum + value, 0) / 1000),
-      };
-      frame("capacity", { concurrentWrites: capacity.concurrentWrites });
-    });
-
-    // Cold read: stop the daemon, then time the first read that has to reopen the ledger.
-    guard("probe.cold-read", () => {
-      f.invoke("cold.daemon-stop", ["daemon", "stop"], { requireSuccess: false });
-      f.invoke("cold.daemon-start", ["daemon", "start", "--service"], { timeoutMs: 120_000 });
-      f.invoke("cold.entity.list", ["entity", "list", kind], { timeoutMs: 300_000 });
-      f.invoke("cold.entity.get", ["entity", "get", kind, "--id", probeId]);
-      for (let sample = 0; sample < config.cliProbeSamples; sample++)
-        f.invoke("hot.entity.list", ["entity", "list", kind], { frameRow: false });
-    });
-
-    // Large content, bounded by the remaining budget.
-    guard("probe.large-content", () => {
-      const locator = "inputs/large/0",
-        directory = path.join(f.root, locator),
-        large = syntheticBinary(4242, config.largeBytes);
-      mkdirSync(directory, { recursive: true });
-      writeFileSync(path.join(directory, "large.bin"), large);
-      const receipt = f.invoke("probe.entity.import.large", [
-        "entity",
-        "import",
-        "--kind",
-        kind,
-        "--locator",
-        locator,
-        "--expected-version",
-        "0",
-        "--no-wait",
-      ]);
-      const id = evidence(receipt).preview.entityId;
-      f.publish(receipt, "probe.entity.import.large");
-      f.check("large.exact-bytes", () =>
-        assertBytes(f.root, `entities/research/${id}/large.bin`, large, receipt, reader),
-      );
-      capacity.largeContent = { bytes: config.largeBytes, id };
-    });
-
-    // Recovery: delete materialized content and rebuild it from the canonical ledger.
-    guard("probe.recovery", () => {
-      const sample = verified[0];
-      assert.ok(sample, "recovery needs at least one byte-verified sample");
-      const contentRoot = `entities/research/${sample.id}`,
-        before = reader.readHead().revision;
-      rmSync(path.join(f.root, "harness", contentRoot), { recursive: true });
-      f.invoke("recovery.materialize", ["doc", "materialize"], { timeoutMs: 600_000 });
-      f.check("recovery.no-new-events-and-exact-bytes", () => {
-        assert.equal(reader.readHead().revision, before);
-        assert.deepEqual(readFileSync(path.join(f.root, "harness", contentRoot, "README.md")), sample.text);
-        assert.deepEqual(readFileSync(path.join(f.root, "harness", contentRoot, "sample.bin")), sample.binary);
-      });
-      capacity.recovery = { revision: before, restored: contentRoot };
-    });
-
-    // A second full Task lifecycle, now against the populated ledger.
+    // One full Task document lifecycle through the real CLI against the scaled ledger.
     guard("task-lifecycle.at-scale", () => taskLifecycle(f, reader, "at-scale"));
 
-    const finalBackupDir = path.join(f.parent, "final-backup");
-    const finalBackup = guard("v2.final-backup", () =>
-      f.invoke("v2.backup.final", ["backup", finalBackupDir], { offline: true }),
+    // Backup size and restore drill on the scaled ledger.
+    const backupDir = path.join(f.parent, "scale-backup");
+    const backup = guard("backup", () =>
+      f.invoke("backup", ["backup", backupDir], { offline: true, timeoutMs: 600_000 }),
     );
-    frame("v2-exit", {
-      readerGeneration: reader.ledgerMetadata().generation,
-      backupManifest: finalBackup?.manifest ?? null,
-      finalRevision: reader.readHead().revision,
+    tier.backup = { bytes: directoryBytes(backupDir), files: backup?.manifest?.files?.length ?? null };
+    guard("restore-drill", () => {
+      const drill = f.invoke(
+        "restore-drill",
+        ["restore", "--drill", backupDir, "--shadow-parent", path.join(f.parent, "drills")],
+        { offline: true, timeoutMs: 600_000 },
+      );
+      tier.restoreDrill = { shadowBytes: directoryBytes(drill.shadowRoot) };
+      rmSync(path.join(f.parent, "drills"), { recursive: true, force: true });
     });
+    rmSync(backupDir, { recursive: true, force: true });
+    frame("backup", tier);
+
+    // Strict rebuild: the daemon's hot projection must equal one built from empty, at the same cut.
+    await f.stopDaemon("strict.daemon-stop");
+    const finalRevision = reader.readHead().revision,
+      cold = await coldFollower.finish(finalRevision, true, remainingMs()),
+      hotStarted = performance.now(),
+      hot = makeTaskProjection({ rootDir: f.root, eventStore: reader }),
+      hotDigest = hot.readStateDigest(),
+      hotCut = hot.readCut();
+    hot.close();
+    tier.strict = {
+      finalRevision,
+      cold,
+      hot: { stateDigest: hotDigest, cut: hotCut, digestMs: performance.now() - hotStarted },
+    };
+    f.check("strict.hot-projection-equals-cold", () => {
+      assert.equal(cold.watermark, finalRevision);
+      assert.ok(hotDigest, "hot projection is at the source cut");
+      assert.equal(hotDigest, cold.stateDigest);
+    });
+    // A sequential rebuild from empty with nothing else running, when the stage budget still allows it.
+    const rebuildBudgetMs = remainingMs();
+    if (rebuildBudgetMs > cold.busyMs * 1.5) {
+      const rebuildStarted = performance.now(),
+        rebuilt = makeTaskProjection({
+          rootDir: f.root,
+          eventStore: reader,
+          projectionPath: path.join(f.parent, "cold-rebuild.sqlite"),
+        }),
+        receipt = rebuilt.rebuild();
+      rebuilt.close();
+      tier.rebuild = { ...receipt, elapsedMs: performance.now() - rebuildStarted };
+      f.check("strict.sequential-rebuild-equals-hot", () => assert.equal(receipt.stateDigest, hotDigest));
+    } else tier.rebuild = { skipped: "stage budget", remainingMs: rebuildBudgetMs, followerBusyMs: cold.busyMs };
+    frame("strict", tier.strict);
+    frame("rebuild", tier.rebuild);
     frame("resources-after", resourceSnapshot(f.parent, "after"));
   } catch (error) {
     failures.push({ phase: "run", error: error.message });
@@ -445,13 +365,20 @@ test("bounded V2 scale: real CLI Task lifecycle and Entity content at a declared
     frame("summary", {
       config,
       elapsedMs: elapsed(),
-      capacity,
+      tier,
       cliMetrics: summarize(f.rows, (row) => row.arm !== "in-process-reused-modules"),
       inProcessMetrics: summarize(f.rows, (row) => row.arm === "in-process-reused-modules"),
+      samples: Object.fromEntries(
+        [...new Set(f.rows.map(({ arm, metric }) => `${arm}|${metric}`))].map((key) => [
+          key,
+          f.rows.filter(({ arm, metric }) => `${arm}|${metric}` === key).map(({ wallMs }) => Math.round(wallMs)),
+        ]),
+      ),
       checks: f.checks,
       failures,
       verdict: failures.length ? "FAILURES_PRESENT" : "MEASURED",
     });
+    await Promise.all([hotFollower?.stop(), coldFollower?.stop()]);
     await reader?.drain();
     await f.close();
   }
@@ -471,7 +398,6 @@ function taskLifecycle(f, reader, label) {
     `V2 scale ${label}`,
     "--preset",
     "docs-task",
-    "--no-wait",
   ]);
   f.publish(created, `task.create.${label}`);
   const packagePath = created.packagePath,
@@ -480,7 +406,7 @@ function taskLifecycle(f, reader, label) {
     assertBytes(f.root, planPath, readFileSync(path.join(f.root, "harness", planPath)), created, reader),
   );
   writeFileSync(path.join(f.root, "harness", planPath), realizedTaskPlan(`V2 scale ${label}`));
-  const prose = f.invoke(`task.prose.${label}`, ["doc", "sync", "--submit", "--path", planPath, "--no-wait"]);
+  const prose = f.invoke(`task.prose.${label}`, ["doc", "sync", "--submit", "--path", planPath]);
   f.publish(prose, `task.prose.${label}`);
   f.invoke(`task.fact.${label}`, [
     "fact",
@@ -502,8 +428,7 @@ function taskLifecycle(f, reader, label) {
     "# Closeout\n\n## Summary\n\nReport delivered.\n\n## Verification\n\nExact bytes checked.\n\n" +
       "## Residual Risk\n\nBounded measurement.\n\n## Same Mechanism Elsewhere\n\nTask report ownership.\n",
   );
-  f.invoke(`doc.status.${label}`, ["doc", "status", "--task", taskId], { actor });
-  const report = f.invoke(`task.report.${label}`, ["doc", "sync", "--submit", "--task", taskId, "--no-wait"], {
+  const report = f.invoke(`task.report.${label}`, ["doc", "sync", "--submit", "--task", taskId], {
     actor,
   });
   f.publish(report, `task.report.${label}`, actor);

--- a/tools/stress/entity-v2-scale.integration.test.mjs
+++ b/tools/stress/entity-v2-scale.integration.test.mjs
@@ -1,0 +1,537 @@
+// harness-test-tier: integration
+import assert from "node:assert/strict";
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import { makeTaskEventReader } from "../../packages/kernel/src/index.ts";
+import { main as cliMain } from "../../packages/cli/src/index.ts";
+import { git } from "../../packages/cli/test/daemon-multi-repo-lifecycle-cli.fixtures.ts";
+import { realizedTaskPlan } from "../fixtures/task-plan.mjs";
+import {
+  assertBytes,
+  fixture,
+  frame,
+  readWorkloadConfig,
+  resourceSnapshot,
+  summarize,
+  syntheticBinary,
+} from "./entity-v2-scale.fixture.mjs";
+
+const kind = "entity-kind/KND-3b7e2c9a1d5f6e8c0a4b2d3f5e7c9a16";
+const config = readWorkloadConfig();
+const evidence = (receipt) => JSON.parse(receipt.evidence);
+const skip =
+  process.platform !== "linux"
+    ? "requires the isolated Linux measurement target"
+    : config.enabled === true
+      ? false
+      : "workload disabled: tools/stress/entity-v2-scale.workload.json enabled=false";
+
+test("bounded V2 scale: real CLI Task lifecycle and Entity content at a declared workset", { skip }, async () => {
+  const started = performance.now();
+  const elapsed = () => performance.now() - started;
+  const f = fixture(config.seed);
+  const failures = [],
+    capacity = {};
+  let reader = null;
+  const guard = (name, operation) => {
+    try {
+      return operation();
+    } catch (error) {
+      failures.push({ phase: name, error: error.message });
+      frame("failure", failures.at(-1));
+      return null;
+    }
+  };
+  const guardAsync = async (name, operation) => {
+    try {
+      return await operation();
+    } catch (error) {
+      failures.push({ phase: name, error: error.message });
+      frame("failure", failures.at(-1));
+      return null;
+    }
+  };
+
+  // Arm B: one resident Node process reusing loaded CLI modules and a fresh socket per request.
+  const inProcess = async (metric, args) => {
+    const previous = { ...process.env };
+    Object.assign(process.env, f.env);
+    const chunks = [],
+      errorChunks = [],
+      write = process.stdout.write.bind(process.stdout),
+      writeError = process.stderr.write.bind(process.stderr),
+      // The node:test reporter writes its own binary protocol to these streams; only the CLI's
+      // console.log receipt arrives as a string, so string chunks are the receipt channel and
+      // everything else is passed straight through to the real stream.
+      capture = (sink, passthrough) => (chunk, encoding, callback) => {
+        if (typeof chunk !== "string") return passthrough(chunk, encoding, callback);
+        sink.push(chunk);
+        if (typeof encoding === "function") encoding();
+        else if (typeof callback === "function") callback();
+        return true;
+      };
+    process.stdout.write = capture(chunks, write);
+    process.stderr.write = capture(errorChunks, writeError);
+    const commandStarted = performance.now();
+    let status = null,
+      thrown = null;
+    try {
+      status = await cliMain(["--root", f.root, "--json", ...args]);
+    } catch (error) {
+      thrown = error;
+    } finally {
+      process.stdout.write = write;
+      process.stderr.write = writeError;
+      for (const key of Object.keys(process.env)) if (!(key in previous)) delete process.env[key];
+      Object.assign(process.env, previous);
+    }
+    const stdout = chunks.join(""),
+      stderr = errorChunks.join("");
+    let receipt = null;
+    try {
+      receipt = JSON.parse(stdout);
+    } catch {
+      /* Parse failures are evidence too. */
+    }
+    const row = {
+      seed: config.seed,
+      metric,
+      arm: "in-process-reused-modules",
+      wallMs: performance.now() - commandStarted,
+      exit: status,
+      ok: status === 0 && receipt?.ok === true,
+      receipt,
+      error: thrown?.message ?? null,
+      ...(status === 0 && receipt?.ok === true ? {} : { stdout: stdout.slice(0, 2000), stderr: stderr.slice(0, 2000) }),
+    };
+    f.rows.push(row);
+    return row;
+  };
+
+  try {
+    frame("protocol", {
+      config,
+      cache: "source CLI; no OS page cache eviction; cold reads are daemon-restart cold, not disk cold",
+      interpretation:
+        "arm cli-process includes Node startup and module load per operation; arm in-process-reused-modules does not. The two arms are never compared as a speedup.",
+      resources: resourceSnapshot(f.parent, "before"),
+    });
+
+    f.invoke("setup.init", ["init", "--repo-id", config.repoId, "--person-id", "owner", "--display-name", "Owner"]);
+    reader = makeTaskEventReader({ rootDir: f.root, repoId: config.repoId });
+
+    // V2 entry: the production reader, the production writer receipts and a real backup must agree.
+    const backupDir = path.join(f.parent, "entry-backup");
+    const backup = f.invoke("v2.backup", ["backup", backupDir], { offline: true });
+    f.check("v2.generation-two-before-workload", () => {
+      assert.equal(reader.ledgerMetadata().generation, 2, "reader generation");
+      assert.equal(backup.manifest?.sqlite?.generation, 2, JSON.stringify(backup.manifest));
+    });
+    frame("v2-entry", {
+      readerGeneration: reader.ledgerMetadata().generation,
+      backupManifest: backup.manifest,
+      initialRevision: reader.readHead().revision,
+    });
+
+    // One full real Task document lifecycle on the empty repository.
+    guard("task-lifecycle.empty", () => taskLifecycle(f, reader, "empty"));
+
+    // Population to the declared workset, plus periodic exact-byte verification.
+    const inputRoot = path.join(f.root, "inputs", "scale");
+    mkdirSync(inputRoot, { recursive: true });
+    const verified = [];
+    const populateStarted = performance.now();
+    let imported = 0,
+      populationStop = "target-reached";
+    for (let index = 0; index < config.targetEntities; index++) {
+      if (performance.now() - populateStarted > config.populateBudgetMs) {
+        populationStop = "populate-budget-exhausted";
+        break;
+      }
+      const locator = `inputs/scale/${index}`,
+        directory = path.join(f.root, locator);
+      mkdirSync(directory, { recursive: true });
+      const text = Buffer.from(`# Scale ${config.seed}/${index}\n${"canonical content\n".repeat(8)}`),
+        binary = syntheticBinary(config.seed + index, config.binaryBytes);
+      writeFileSync(path.join(directory, "README.md"), text);
+      writeFileSync(path.join(directory, "sample.bin"), binary);
+      const row = await inProcess("entity.import.populate", [
+        "entity",
+        "import",
+        "--kind",
+        kind,
+        "--locator",
+        locator,
+        "--expected-version",
+        "0",
+        "--no-wait",
+      ]);
+      if (!row.ok) {
+        failures.push({
+          phase: `populate-${index}`,
+          error: JSON.stringify({ exit: row.exit, thrown: row.error, stdout: row.stdout, stderr: row.stderr }).slice(
+            0,
+            2000,
+          ),
+        });
+        frame("failure", failures.at(-1));
+        populationStop = "import-rejected";
+        break;
+      }
+      imported += 1;
+      if (
+        verified.length < config.contentSamples &&
+        index % Math.max(1, Math.floor(config.targetEntities / config.contentSamples)) === 0
+      ) {
+        verified.push({ index, id: evidence(row.receipt).preview.entityId, receipt: row.receipt, text, binary });
+      }
+      if (index % 100 === 0)
+        frame("populate-progress", {
+          index,
+          imported,
+          elapsedMs: elapsed(),
+          populateMs: performance.now() - populateStarted,
+        });
+    }
+    const populateMs = performance.now() - populateStarted;
+    capacity.population = {
+      requested: config.targetEntities,
+      imported,
+      stop: populationStop,
+      populateMs,
+      opsPerSecond: imported / (populateMs / 1000),
+      arm: "in-process-reused-modules",
+    };
+    frame("capacity", capacity.population);
+
+    const afterPopulation = reader.readHead().revision;
+    frame("cut-after-population", { revision: afterPopulation, entities: imported });
+
+    // Exact-byte oracle on the sampled entities, plus the negative control that proves the oracle bites.
+    for (const sample of verified) {
+      const contentRoot = `entities/research/${sample.id}`;
+      guard(`content.bytes-${sample.index}`, () =>
+        f.check(`content.exact-bytes-${sample.index}`, () => {
+          assertBytes(f.root, `${contentRoot}/README.md`, sample.text, sample.receipt, reader);
+          assertBytes(f.root, `${contentRoot}/sample.bin`, sample.binary, sample.receipt, reader);
+        }),
+      );
+    }
+    if (verified.length > 0)
+      guard("content.negative-control", () =>
+        f.check("content.oracle-rejects-wrong-bytes", () =>
+          assert.throws(() =>
+            assertBytes(
+              f.root,
+              `entities/research/${verified[0].id}/sample.bin`,
+              Buffer.from("dropped bytes"),
+              verified[0].receipt,
+              reader,
+            ),
+          ),
+        ),
+      );
+
+    // Latency probes at the populated scale, full CLI chain.
+    guard("probe.cli-import", () => {
+      for (let sample = 0; sample < config.cliProbeSamples; sample++) {
+        const locator = `inputs/probe/${sample}`,
+          directory = path.join(f.root, locator);
+        mkdirSync(directory, { recursive: true });
+        writeFileSync(path.join(directory, "README.md"), Buffer.from(`# Probe ${sample}\n`));
+        writeFileSync(path.join(directory, "sample.bin"), syntheticBinary(90_000 + sample, config.binaryBytes));
+        f.invoke(
+          "probe.entity.import",
+          ["entity", "import", "--kind", kind, "--locator", locator, "--expected-version", "0", "--no-wait"],
+          { frameRow: false },
+        );
+      }
+    });
+    const probeReceipt = f.rows.findLast((row) => row.metric === "probe.entity.import")?.receipt;
+    const probeId = probeReceipt ? evidence(probeReceipt).preview.entityId : null;
+    guard("probe.publication", () => f.publish(probeReceipt, "probe.entity.import"));
+
+    guard("probe.cli-get-warm", () => {
+      for (let sample = 0; sample < config.cliProbeSamples; sample++)
+        f.invoke("probe.entity.get.warm", ["entity", "get", kind, "--id", probeId], { frameRow: false });
+    });
+    guard("probe.cli-list-warm", () =>
+      f.invoke("probe.entity.list.warm", ["entity", "list", kind], { frameRow: false }),
+    );
+
+    // Update and its concurrency negative control at scale.
+    guard("probe.update", () => {
+      const current = f.invoke("probe.entity.get.before-update", ["entity", "get", kind, "--id", probeId], {
+        frameRow: false,
+      });
+      const updated = f.invoke("probe.entity.update", [
+        "entity",
+        "update",
+        kind,
+        "--id",
+        probeId,
+        "--title",
+        "Updated at scale",
+        "--expected-version",
+        String(current.revision),
+        "--no-wait",
+      ]);
+      f.publish(updated, "probe.entity.update");
+      const warm = f.invoke("probe.entity.get.after-update", ["entity", "get", kind, "--id", probeId]);
+      f.check("probe.updated-title-visible", () => assert.equal(evidence(warm).entity.value.title, "Updated at scale"));
+      const stale = f.invoke(
+        "probe.entity.update.stale-negative",
+        [
+          "entity",
+          "update",
+          kind,
+          "--id",
+          probeId,
+          "--title",
+          "Stale must fail",
+          "--expected-version",
+          String(current.revision),
+        ],
+        { requireSuccess: false },
+      );
+      f.check("probe.stale-update-rejected", () => {
+        assert.equal(stale.ok, false);
+        assert.equal(stale.code, "revision_conflict");
+      });
+    });
+
+    // Concurrent clients, each an independent CLI process against the one daemon.
+    await guardAsync("probe.concurrent-reads", async () => {
+      const rounds = config.concurrentRounds ?? 1,
+        batches = [];
+      let succeeded = 0;
+      for (let round = 0; round < rounds; round++) {
+        const { batchMs, results } = await f.concurrentCli(
+          "probe.entity.get.concurrent",
+          Array.from({ length: config.clients }, () => ["entity", "get", kind, "--id", probeId]),
+        );
+        batches.push(batchMs);
+        succeeded += results.filter((row) => row.exit === 0 && row.receipt?.ok).length;
+      }
+      capacity.concurrentReads = {
+        clients: config.clients,
+        rounds,
+        batchMs: batches,
+        succeeded,
+        readsPerSecond: succeeded / (batches.reduce((sum, value) => sum + value, 0) / 1000),
+      };
+      frame("capacity", { concurrentReads: capacity.concurrentReads });
+    });
+    await guardAsync("probe.concurrent-writes", async () => {
+      const rounds = config.concurrentRounds ?? 1,
+        batches = [],
+        opIds = new Set(),
+        rejections = [];
+      let accepted = 0;
+      for (let round = 0; round < rounds; round++) {
+        for (let client = 0; client < config.clients; client++) {
+          const directory = path.join(f.root, "inputs", "concurrent", `${round}-${client}`);
+          mkdirSync(directory, { recursive: true });
+          writeFileSync(path.join(directory, "README.md"), Buffer.from(`# Concurrent ${round}/${client}\n`));
+          writeFileSync(
+            path.join(directory, "sample.bin"),
+            syntheticBinary(70_000 + round * 100 + client, config.binaryBytes),
+          );
+        }
+        const { batchMs, results } = await f.concurrentCli(
+          "probe.entity.import.concurrent",
+          Array.from({ length: config.clients }, (_unused, client) => [
+            "entity",
+            "import",
+            "--kind",
+            kind,
+            "--locator",
+            `inputs/concurrent/${round}-${client}`,
+            "--expected-version",
+            "0",
+            "--no-wait",
+          ]),
+        );
+        batches.push(batchMs);
+        for (const row of results) {
+          if (row.exit === 0 && row.receipt?.ok) {
+            accepted += 1;
+            opIds.add(row.receipt.opId);
+          } else if (row.receipt?.ok === false) rejections.push(row.receipt.code);
+        }
+      }
+      capacity.concurrentWrites = {
+        clients: config.clients,
+        rounds,
+        batchMs: batches,
+        accepted,
+        distinctOpIds: opIds.size,
+        rejections,
+        writesPerSecond: accepted / (batches.reduce((sum, value) => sum + value, 0) / 1000),
+      };
+      frame("capacity", { concurrentWrites: capacity.concurrentWrites });
+    });
+
+    // Cold read: stop the daemon, then time the first read that has to reopen the ledger.
+    guard("probe.cold-read", () => {
+      f.invoke("cold.daemon-stop", ["daemon", "stop"], { requireSuccess: false });
+      f.invoke("cold.daemon-start", ["daemon", "start", "--service"], { timeoutMs: 120_000 });
+      f.invoke("cold.entity.list", ["entity", "list", kind], { timeoutMs: 300_000 });
+      f.invoke("cold.entity.get", ["entity", "get", kind, "--id", probeId]);
+      for (let sample = 0; sample < config.cliProbeSamples; sample++)
+        f.invoke("hot.entity.list", ["entity", "list", kind], { frameRow: false });
+    });
+
+    // Large content, bounded by the remaining budget.
+    guard("probe.large-content", () => {
+      const locator = "inputs/large/0",
+        directory = path.join(f.root, locator),
+        large = syntheticBinary(4242, config.largeBytes);
+      mkdirSync(directory, { recursive: true });
+      writeFileSync(path.join(directory, "large.bin"), large);
+      const receipt = f.invoke("probe.entity.import.large", [
+        "entity",
+        "import",
+        "--kind",
+        kind,
+        "--locator",
+        locator,
+        "--expected-version",
+        "0",
+        "--no-wait",
+      ]);
+      const id = evidence(receipt).preview.entityId;
+      f.publish(receipt, "probe.entity.import.large");
+      f.check("large.exact-bytes", () =>
+        assertBytes(f.root, `entities/research/${id}/large.bin`, large, receipt, reader),
+      );
+      capacity.largeContent = { bytes: config.largeBytes, id };
+    });
+
+    // Recovery: delete materialized content and rebuild it from the canonical ledger.
+    guard("probe.recovery", () => {
+      const sample = verified[0];
+      assert.ok(sample, "recovery needs at least one byte-verified sample");
+      const contentRoot = `entities/research/${sample.id}`,
+        before = reader.readHead().revision;
+      rmSync(path.join(f.root, "harness", contentRoot), { recursive: true });
+      f.invoke("recovery.materialize", ["doc", "materialize"], { timeoutMs: 600_000 });
+      f.check("recovery.no-new-events-and-exact-bytes", () => {
+        assert.equal(reader.readHead().revision, before);
+        assert.deepEqual(readFileSync(path.join(f.root, "harness", contentRoot, "README.md")), sample.text);
+        assert.deepEqual(readFileSync(path.join(f.root, "harness", contentRoot, "sample.bin")), sample.binary);
+      });
+      capacity.recovery = { revision: before, restored: contentRoot };
+    });
+
+    // A second full Task lifecycle, now against the populated ledger.
+    guard("task-lifecycle.at-scale", () => taskLifecycle(f, reader, "at-scale"));
+
+    const finalBackupDir = path.join(f.parent, "final-backup");
+    const finalBackup = guard("v2.final-backup", () =>
+      f.invoke("v2.backup.final", ["backup", finalBackupDir], { offline: true }),
+    );
+    frame("v2-exit", {
+      readerGeneration: reader.ledgerMetadata().generation,
+      backupManifest: finalBackup?.manifest ?? null,
+      finalRevision: reader.readHead().revision,
+    });
+    frame("resources-after", resourceSnapshot(f.parent, "after"));
+  } catch (error) {
+    failures.push({ phase: "run", error: error.message });
+    frame("failure", failures.at(-1));
+  } finally {
+    frame("summary", {
+      config,
+      elapsedMs: elapsed(),
+      capacity,
+      cliMetrics: summarize(f.rows, (row) => row.arm !== "in-process-reused-modules"),
+      inProcessMetrics: summarize(f.rows, (row) => row.arm === "in-process-reused-modules"),
+      checks: f.checks,
+      failures,
+      verdict: failures.length ? "FAILURES_PRESENT" : "MEASURED",
+    });
+    await reader?.drain();
+    await f.close();
+  }
+  assert.deepEqual(failures, [], "every measured failure is retained in the frames above");
+});
+
+function taskLifecycle(f, reader, label) {
+  const taskId = `task-v2-scale-${label}`,
+    actor = "agent:v2-scale-worker";
+  const created = f.invoke(`task.create.${label}`, [
+    "task",
+    "create",
+    "--id",
+    taskId,
+    "--admin",
+    "--title",
+    `V2 scale ${label}`,
+    "--preset",
+    "docs-task",
+    "--no-wait",
+  ]);
+  f.publish(created, `task.create.${label}`);
+  const packagePath = created.packagePath,
+    planPath = `${packagePath}/task_plan.md`;
+  f.check(`task.${label}.initial-content`, () =>
+    assertBytes(f.root, planPath, readFileSync(path.join(f.root, "harness", planPath)), created, reader),
+  );
+  writeFileSync(path.join(f.root, "harness", planPath), realizedTaskPlan(`V2 scale ${label}`));
+  const prose = f.invoke(`task.prose.${label}`, ["doc", "sync", "--submit", "--path", planPath, "--no-wait"]);
+  f.publish(prose, `task.prose.${label}`);
+  f.invoke(`task.fact.${label}`, [
+    "fact",
+    "record",
+    "--task",
+    taskId,
+    "--statement",
+    `V2 scale ${label} plan bytes verified.`,
+    "--source",
+    "test:entity-v2-scale",
+  ]);
+  f.invoke(`task.start.${label}`, ["task", "start", taskId, "--execution-id", `execution-${label}`], { actor });
+  const reportPath = `${packagePath}/artifacts/report.md`;
+  const reportBody = Buffer.from(`# V2 scale ${label}\n\n${"durable bytes\n".repeat(32)}`);
+  mkdirSync(path.dirname(path.join(f.root, "harness", reportPath)), { recursive: true });
+  writeFileSync(path.join(f.root, "harness", reportPath), reportBody);
+  writeFileSync(
+    path.join(f.root, "harness", packagePath, "closeout.md"),
+    "# Closeout\n\n## Summary\n\nReport delivered.\n\n## Verification\n\nExact bytes checked.\n\n" +
+      "## Residual Risk\n\nBounded measurement.\n\n## Same Mechanism Elsewhere\n\nTask report ownership.\n",
+  );
+  f.invoke(`doc.status.${label}`, ["doc", "status", "--task", taskId], { actor });
+  const report = f.invoke(`task.report.${label}`, ["doc", "sync", "--submit", "--task", taskId, "--no-wait"], {
+    actor,
+  });
+  f.publish(report, `task.report.${label}`, actor);
+  f.check(`task.${label}.report-same-cut-bytes`, () => assertBytes(f.root, reportPath, reportBody, report, reader));
+  const submission = {
+    completionClaim: "Bounded scale report is complete.",
+    deliverables: [reportPath],
+    outputs: ["scale report"],
+    verificationNotes: ["canonical blob, Git and worktree bytes checked"],
+    knownGaps: [],
+    residualRisks: [],
+    commitSha: git(f.root, "rev-parse", "HEAD"),
+  };
+  writeFileSync(path.join(f.root, `submission-${label}.json`), JSON.stringify(submission));
+  f.invoke(`task.submit.${label}`, ["task", "submit", taskId, "--from-file", `submission-${label}.json`], { actor });
+  const closeout = f.invoke(`task.closeout.${label}`, ["task", "closeout", taskId, "--json-input", "@-"], {
+    input: {
+      review: { verdict: "approved", reason: "Fixture bytes checked.", evidenceChecked: [reportPath] },
+      consent: { approved: true },
+      completion: { ci: "not_applicable", codeDocPaths: [] },
+    },
+  });
+  f.check(`task.${label}.real-stages`, () =>
+    assert.deepEqual(
+      closeout.steps.map(({ stage }) => stage),
+      ["review-execution", "review-consent", "complete"],
+    ),
+  );
+  const shown = f.invoke(`task.show.${label}`, ["task", "show", taskId]);
+  f.check(`task.${label}.done`, () => assert.equal(evidence(shown).task.status, "done"));
+}

--- a/tools/stress/entity-v2-scale.projection-worker.mjs
+++ b/tools/stress/entity-v2-scale.projection-worker.mjs
@@ -1,0 +1,57 @@
+import { parentPort, workerData } from "node:worker_threads";
+import { makeTaskEventReader, makeTaskProjection } from "../../packages/kernel/src/index.ts";
+
+// Follows a ledger that another thread is appending to, the way a running daemon keeps its projection
+// current. The parent posts { revision, digest } once that revision is final; the follower stops there.
+const { rootDir, repoId, projectionPath } = workerData;
+const reader = makeTaskEventReader({ rootDir, repoId }),
+  started = performance.now();
+let reported = { watermark: 0, at: started };
+const projection = makeTaskProjection({
+  rootDir,
+  eventStore: reader,
+  ...(projectionPath ? { projectionPath } : {}),
+  // Reports every few catch-up rounds, so a run cut short still shows how far replay got.
+  onProgress: ({ watermark: reached }) => {
+    if (reached - reported.watermark < 16_384 && performance.now() - reported.at < 10_000) return;
+    reported = { watermark: reached, at: performance.now() };
+    parentPort.postMessage({ progress: true, watermark: reached, elapsedMs: reported.at - started });
+  },
+});
+let target = null,
+  busyMs = 0,
+  rounds = 0,
+  watermark = 0;
+parentPort.on("message", (message) => {
+  target = message;
+});
+let report;
+try {
+  for (;;) {
+    const roundStarted = performance.now();
+    watermark = projection.catchUp().watermark;
+    busyMs += performance.now() - roundStarted;
+    rounds += 1;
+    if (target !== null && watermark >= target.revision) break;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  const digestStarted = performance.now(),
+    stateDigest = target.digest ? projection.readStateDigest() : null;
+  report = {
+    ok: true,
+    watermark,
+    busyMs,
+    elapsedMs: performance.now() - started,
+    rounds,
+    stateDigest,
+    digestMs: performance.now() - digestStarted,
+  };
+} catch (error) {
+  report = { ok: false, error: error instanceof Error ? error.message : String(error), watermark };
+} finally {
+  projection.close();
+  await reader.drain();
+}
+// Report only once the projection is closed, so the parent may hand the file to the daemon.
+parentPort.postMessage({ progress: false, ...report });
+parentPort.close();

--- a/tools/stress/entity-v2-scale.workload.json
+++ b/tools/stress/entity-v2-scale.workload.json
@@ -1,0 +1,16 @@
+{
+  "enabled": false,
+  "note": "Bounded V2 scale measurement. Left disabled so the integration tier stays cheap; an operator enables it for one dispatched measurement run.",
+  "seed": 1103,
+  "repoId": "v2-scale",
+  "targetEntities": 1000,
+  "clients": 8,
+  "cliProbeSamples": 30,
+  "contentSamples": 5,
+  "binaryBytes": 4096,
+  "largeBytes": 1048576,
+  "populateBudgetMs": 300000,
+  "stageBudgetMs": 1140000,
+  "stage": "disabled",
+  "concurrentRounds": 5
+}

--- a/tools/stress/entity-v2-scale.workload.json
+++ b/tools/stress/entity-v2-scale.workload.json
@@ -1,16 +1,13 @@
 {
   "enabled": false,
-  "note": "Bounded V2 scale measurement. Left disabled so the integration tier stays cheap; an operator enables it for one dispatched measurement run.",
+  "note": "Opt-in scale tier: an operator enables it and sets targetEvents for one dispatched run.",
   "seed": 1103,
   "repoId": "v2-scale",
-  "targetEntities": 1000,
-  "clients": 8,
-  "cliProbeSamples": 30,
-  "contentSamples": 5,
+  "targetEvents": 10000,
+  "drainEvery": 65536,
+  "readSamples": 20,
+  "writeSamples": 20,
   "binaryBytes": 4096,
-  "largeBytes": 1048576,
-  "populateBudgetMs": 300000,
-  "stageBudgetMs": 1140000,
-  "stage": "disabled",
-  "concurrentRounds": 5
+  "measureBudgetMs": 300000,
+  "stageBudgetMs": 870000
 }


### PR DESCRIPTION
# English

## Summary

Task E7 (Entity V2 scale baseline on Ubuntu) needed a way to measure the ledger at 10k, 100k and 1M events without depending on the canonical repository. This PR adds that measurement fixture under `tools/stress/` as an opt-in stress test (`entity-v2-scale.workload.json` ships with `enabled: false`; CI never runs it). It generates a V2 ledger in-process (compile → stage → append → publish), replays the projection in a worker, and records read/write latencies, backup and restore-drill timings, and hot-vs-cold projection consistency.

The fixture already produced the numbers behind the E7 handoff: at 10k → 100k events, nine read/write latencies grow beyond noise; cold rebuild goes 4.2 s → 79.4 s (19× for 10× events); the 1M ledger generates in 381.6 s but the projection replay only reaches 357,058 / 1,000,002 within the 870 s budget. The root cause (`DELETE FROM task_relation WHERE task_id = ?` with no `task_id` index → `SCAN task_relation`) is fixed separately in task_5656dffbe7c9a1c1b1f0c62bd3; this fixture is the acceptance tool for that fix and for the 1M re-run.

## Architectural Justification

- The +598 lines are measurement tooling under `tools/stress`, not product code: `packages/*` is +0/-0. They exist because the scale question ("does write/read cost grow with the ledger?") could not be answered by any existing fixture — the previous scale tests stop at 5k entities and depend on the canonical repository. An in-process generator plus a budgeted replay worker is the smallest shape that produces a 1M-event ledger deterministically and stops honestly when the projection cannot keep up; a smaller fixture would have hidden exactly the quadratic replay this one exposed. It is opt-in so CI cost does not change.

## What Changed

- `tools/stress/entity-v2-scale.generator.mjs` (new): in-process V2 ledger generator up to 1M events, four phases with progress frames.
- `tools/stress/entity-v2-scale.projection-worker.mjs` (new): projection replay in a worker thread with a stage budget, so a replay that cannot finish stops at the budget and reports the reached cut instead of hanging.
- `tools/stress/entity-v2-scale.fixture.mjs`: resident-process and one-CLI-process-per-operation measurements, backup/restore-drill timings, strict hot-vs-cold projection comparison, structured `.log.txt` output.
- `tools/stress/entity-v2-scale.integration.test.mjs`: the 14-check protocol (MEASURED / budget-stop outcomes), `enabled` gated by the workload file.
- `tools/stress/entity-v2-scale.workload.json`: 10k / 100k / 1M tiers, `enabled: false`.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: +598/-0 (net +598), from `node tools/gates/production-delta.mjs --base origin/main`; all 598 lines are `tools/stress` tooling, `packages/*` is +0/-0.

## Machine-Readable Declarations

- None (no event schema, CLI contract or settings change).

## Task And Scope

- Harness task: task_9c03d77ef810c7e03787c38752
- Branch: `codex/release-v2-performance`
- Public scope: opt-in V2 scale stress fixture under `tools/stress`
- Private planning/evidence updated: yes (task plan with CEO ruling 二, `artifacts/report.md`, `closeout.md`, raw logs under `artifacts/raw/v2-million-*`, facts F-5F90E439, F-F820B09F, F-D20C192E, F-4B8D63F6)
- Out of scope: the fixes for the growth items (G1–G10 in the report, tasks task_5656dffb / task_58df7cff / task_de9675a5 / task_2c5cdc09); the 900 s single-file watchdog in `tools/run-node-tests.mjs` that still bounds a full 1M run

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: not applicable
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `b5bc37f23`
- Branch merge-base with `origin/main`: `b5bc37f23`
- Last `git fetch origin` time: 2026-09-11 UTC
- Sync method: rebased onto origin/main
- Public diff command: `git diff origin/main...codex/release-v2-performance`
- Private evidence commit/path: task_9c03d77ef810c7e03787c38752 `artifacts/report.md`, `artifacts/raw/`
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [ ] `npm run typecheck`
- [ ] `npm run check`
- [ ] `npm test`
- [x] `npm run harness:check-import-boundaries` (via `run-manifest-gates --changed origin/main`)
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts` (via `run-manifest-gates --changed origin/main`)
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Isolated Ubuntu runs via `node tools/dispatch-isolated-test.mjs --target ubuntu`: 10k exit 0 MEASURED 14/14; 100k exit 0 MEASURED 14/14; 1M exit 1 by design at the stage budget with no leftover daemon; 10k re-runs on main 3b3fb6e0f and b5bc37f23 both 14/14 with strict hot/cold consistency.
- Gates on the branch head: `run-manifest-gates --changed origin/main` (test tier manifest 561 files), `line-density`, `production-delta` pass (CEO re-run).

## Review Evidence

- CEO ground-truth: read the handoff and report; the fixture is opt-in (`enabled: false`), no production package is touched, and the measured growth items map to concrete statements (verified for G1/G2/G4/G10, candidates only for G6–G8).
- Reviewer subagent: not used
- Human review: pending
- Blocking findings: none open

## Residual Risk

- The generator writes blobs without per-object fsync, so generation timings are slightly optimistic; measurement phases are unaffected.
- A full 1M run still needs either a watchdog exemption for opt-in stress files or ledger persistence across dispatches (CEO ruling pending); until then the 1M tier stops at the budget by design.

## References

- Task: task_9c03d77ef810c7e03787c38752
- Follow-ups: task_5656dffbe7c9a1c1b1f0c62bd3 (G1+G10), task_58df7cffa03b4a1b369b9d95d2 (G2+G3), task_de9675a5e6e7f6075bb02c23c6 (G4), task_2c5cdc0935e44e612367e7f2ce (G6–G8)

---

# 中文

## 概要

E7（Entity V2 在 Ubuntu 上的规模基线）需要一个不依赖 canonical 仓库、能在 10k / 100k / 1M 事件档测量台账的工具。本 PR 把这个测量夹具加到 `tools/stress/`，作为手动开启的压测（`entity-v2-scale.workload.json` 提交时 `enabled: false`，CI 不跑）。它在进程内生成 V2 台账（compile → stage → append → publish），在 worker 线程里回放投影，记录读写延迟、backup 与 restore-drill 时长、hot 与冷投影一致性。

E7 交接里的数字就来自它：10k → 100k 事件，9 项读写延迟超出噪声；冷重建 4.2 s → 79.4 s（事件 10 倍、耗时 19 倍）；1M 台账 381.6 s 生成完，投影回放在 870 s 预算内只到 357,058 / 1,000,002。根因（`DELETE FROM task_relation WHERE task_id = ?` 无 `task_id` 索引 → `SCAN task_relation`）由 task_5656dffbe7c9a1c1b1f0c62bd3 另行修复；本夹具是那项修复与 1M 重跑的验收工具。

## 架构辩护

- +598 行全是 `tools/stress` 下的测量工具，不是产品代码：`packages/*` 为 +0/-0。它们存在是因为「读写成本是否随台账规模增长」这个问题没有任何现成夹具能回答——既有规模测试止步于 5k 实体且依赖 canonical 仓。进程内生成器 + 带预算的回放 worker 是能确定性产出 1M 事件台账、并在投影跟不上时诚实停下的最小形状；更小的夹具恰恰会藏起这次暴露的二次回放。手动开启，CI 成本不变。

## 改动内容

- `tools/stress/entity-v2-scale.generator.mjs`（新增）：进程内 V2 台账生成器，最多 1M 事件，四阶段带进度帧。
- `tools/stress/entity-v2-scale.projection-worker.mjs`（新增）：worker 线程里带阶段预算的投影回放，跑不完时在预算处停止并报告到达的 cut，不挂死。
- `tools/stress/entity-v2-scale.fixture.mjs`：常驻进程与每次起一个 CLI 进程两种测量、backup/restore-drill 时长、hot 与冷投影严格比对、结构化 `.log.txt` 输出。
- `tools/stress/entity-v2-scale.integration.test.mjs`：14 项检查协议（MEASURED / 预算停止两种结果），由 workload 文件的 `enabled` 门控。
- `tools/stress/entity-v2-scale.workload.json`：10k / 100k / 1M 三档，`enabled: false`。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 删除的门或 fixture：none
- 生产净行数：+598/-0（净 +598），来自 `node tools/gates/production-delta.mjs --base origin/main`；598 行全在 `tools/stress`，`packages/*` 为 +0/-0。

## 机器可读声明

- 无（不改事件 schema、CLI 契约或设置）。

## 任务与范围

- Harness 任务：task_9c03d77ef810c7e03787c38752
- 分支：`codex/release-v2-performance`
- 公开范围：`tools/stress` 下手动开启的 V2 规模压测夹具
- 私有计划/证据已更新：是（含 CEO 裁决二的任务计划、`artifacts/report.md`、`closeout.md`、`artifacts/raw/v2-million-*` 原始日志、fact F-5F90E439、F-F820B09F、F-D20C192E、F-4B8D63F6）
- 范围外：各增长项的修复（报告 G1–G10，任务 task_5656dffb / task_58df7cff / task_de9675a5 / task_2c5cdc09）；`tools/run-node-tests.mjs` 的 900 s 单文件看门狗仍限制 1M 完整跑

## 版本影响

- 版本：不变
- 发布影响：不发布

## 治理声明

- 触碰受保护面：否
- 受保护面范围：不适用
- 授权：不适用
- 机器检查边界：本 PR 只断言声明存在；是否属实、是否充分由评审判断。
- Break-glass：否
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- 基线 `origin/main` SHA：`b5bc37f23`
- 分支与 `origin/main` 的 merge-base：`b5bc37f23`
- 最近一次 `git fetch origin`：2026-09-11 UTC
- 同步方式：rebase 到 origin/main
- 公开 diff 命令：`git diff origin/main...codex/release-v2-performance`
- 私有证据路径：task_9c03d77ef810c7e03787c38752 的 `artifacts/report.md`、`artifacts/raw/`
- 评审证据路径：本 PR 的评审证据节
- GitHub Actions `rewrite-ci` run URL：本 PR 待跑
- 隔离 Ubuntu 派测（`node tools/dispatch-isolated-test.mjs --target ubuntu`）：10k exit 0 MEASURED 14/14；100k exit 0 MEASURED 14/14；1M 按设计在阶段预算处 exit 1、无残留 daemon；10k 在 main 3b3fb6e0f 与 b5bc37f23 上复跑均 14/14、hot/冷严格一致。
- 分支头门：`run-manifest-gates --changed origin/main`（test tier manifest 561 文件）、`line-density`、`production-delta` 通过（CEO 复跑）。

## 评审证据

- CEO 事实核对：读过交接与报告；夹具为手动开启（`enabled: false`），不碰生产包；测得的增长项对应到具体语句（G1/G2/G4/G10 已验证，G6–G8 只有候选）。
- 评审子代理：未用
- 人工评审：待定
- 阻塞发现：无

## 残余风险

- 生成器写 blob 不逐个 fsync，生成耗时略偏乐观；测量阶段不受影响。
- 完整 1M 跑仍需二选一：给手动开启的压测文件豁免看门狗，或让派测跨次保留台账（待 CEO 裁决）；在此之前 1M 档按设计停在预算处。

## 参考

- 任务：task_9c03d77ef810c7e03787c38752
- 后续：task_5656dffbe7c9a1c1b1f0c62bd3（G1+G10）、task_58df7cffa03b4a1b369b9d95d2（G2+G3）、task_de9675a5e6e7f6075bb02c23c6（G4）、task_2c5cdc0935e44e612367e7f2ce（G6–G8）
