### PR TITLE
perf: index task_relation by task_id and key decision search rows by the decision rowid

### DIFF
--- a/packages/kernel/src/projection/decision-projection-reducer.ts
+++ b/packages/kernel/src/projection/decision-projection-reducer.ts
@@ -199,6 +199,7 @@ function refreshDecisionFts(db: DatabaseSync, decisionId: string): void {
     body = readDecisionBody(db, decisionId)?.body ?? "";
   db.prepare("DELETE FROM decision_fts WHERE rowid=?").run(row.rowid);
   db.prepare(
-    "INSERT INTO decision_fts(rowid, decision_id, title, question, option_text, claim_text, body) VALUES (?, ?, ?, ?, ?, ?, ?)",
+    "INSERT INTO decision_fts(rowid, decision_id, title, question, option_text, claim_text, body) " +
+      "VALUES (?, ?, ?, ?, ?, ?, ?)",
   ).run(row.rowid, decisionId, row.title, row.question, options, claims, body);
 }

--- a/packages/kernel/src/projection/decision-projection-reducer.ts
+++ b/packages/kernel/src/projection/decision-projection-reducer.ts
@@ -180,8 +180,10 @@ export function refreshDecisionDocumentSearch(db: DatabaseSync, document: Docume
 }
 
 function refreshDecisionFts(db: DatabaseSync, decisionId: string): void {
-  const row = db.prepare("SELECT title,question FROM decision WHERE decision_id=?").get(decisionId) as
-    | { readonly title: string; readonly question: string }
+  // decision_id is UNINDEXED in the fts5 table, so the search row is keyed by the decision rowid
+  // (stable: decision rows are inserted once and only updated) instead of deleted by a column scan.
+  const row = db.prepare("SELECT rowid, title, question FROM decision WHERE decision_id=?").get(decisionId) as
+    | { readonly rowid: number; readonly title: string; readonly question: string }
     | undefined;
   if (!row) return;
   const options = queryRows<{ readonly text: string }>(
@@ -195,13 +197,8 @@ function refreshDecisionFts(db: DatabaseSync, decisionId: string): void {
       .map((c) => c.text)
       .join(" "),
     body = readDecisionBody(db, decisionId)?.body ?? "";
-  db.prepare("DELETE FROM decision_fts WHERE decision_id=?").run(decisionId);
-  db.prepare("INSERT INTO decision_fts VALUES (?, ?, ?, ?, ?, ?)").run(
-    decisionId,
-    row.title,
-    row.question,
-    options,
-    claims,
-    body,
-  );
+  db.prepare("DELETE FROM decision_fts WHERE rowid=?").run(row.rowid);
+  db.prepare(
+    "INSERT INTO decision_fts(rowid, decision_id, title, question, option_text, claim_text, body) VALUES (?, ?, ?, ?, ?, ?, ?)",
+  ).run(row.rowid, decisionId, row.title, row.question, options, claims, body);
 }

--- a/packages/kernel/src/projection/projection-schema.ts
+++ b/packages/kernel/src/projection/projection-schema.ts
@@ -1,3 +1,4 @@
-// Version 19 scopes task-owned Entity rows by owner so equal local Execution/Review ids
-// replay independently. A mismatch discards and replays the rebuildable cache.
-export const taskProjectionSchemaVersion = 19;
+// Version 20 indexes task_relation by task_id and keys decision_fts rows by the decision rowid,
+// so a Task or Decision event no longer scans those tables. A mismatch discards and replays the
+// rebuildable cache.
+export const taskProjectionSchemaVersion = 20;

--- a/packages/kernel/src/projection/task-query-projection.ts
+++ b/packages/kernel/src/projection/task-query-projection.ts
@@ -309,6 +309,7 @@ export function createTaskRelationProjectionTable(db: DatabaseSync): void {
     CREATE INDEX IF NOT EXISTS task_relation_target ON task_relation(target_ref, state, relation_id);
     CREATE INDEX IF NOT EXISTS task_relation_type ON task_relation(relation_type, state, relation_id);
     CREATE INDEX IF NOT EXISTS task_relation_updated ON task_relation(updated_at DESC, relation_id ASC);
+    CREATE INDEX IF NOT EXISTS task_relation_task ON task_relation(task_id, relation_id);
   `);
 }
 

--- a/packages/kernel/test/store/decision-fts-refresh.test.ts
+++ b/packages/kernel/test/store/decision-fts-refresh.test.ts
@@ -1,0 +1,48 @@
+// harness-test-tier: fast
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { DocumentState } from "../../src/domain/doc-sync-types.ts";
+import { compileDecisionWrite } from "../../src/index.ts";
+import { reduceDecisionEvent } from "../../src/projection/decision-event-projection.ts";
+import { refreshDecisionDocumentSearch } from "../../src/projection/decision-projection-reducer.ts";
+import { decisionProjectionDatabase, proposal } from "./relation-graph-projection.fixtures.ts";
+
+test("decision search rows are keyed by the decision rowid and refresh in place", () => {
+  const db = decisionProjectionDatabase();
+  try {
+    for (const [revision, decisionId] of [
+      [1, "dec_FIRST"],
+      [2, "dec_SECOND"],
+    ] as const) {
+      const event = proposal(revision, decisionId);
+      reduceDecisionEvent(
+        db,
+        compileDecisionWrite({ event, currentDecision: null, currentRelations: [], currentDocument: null }).event,
+      );
+    }
+    const document: DocumentState = {
+      path: "decisions/decision-dec_SECOND/decision.md" as DocumentState["path"],
+      blobSha256: "0".repeat(64),
+      body: "",
+      size: 0 as DocumentState["size"],
+      mediaType: "text/markdown",
+      policyId: "decision",
+      workspaceRevision: 3,
+    };
+    for (let round = 0; round < 3; round += 1) refreshDecisionDocumentSearch(db, document);
+    // Each refresh deletes by rowid and re-inserts under the decision's own rowid, so the search
+    // row never moves to a fresh fts rowid and is addressed without scanning decision_id.
+    const searchRows = (
+      db.prepare("SELECT rowid, decision_id AS decisionId FROM decision_fts ORDER BY rowid").all() as readonly {
+        readonly rowid: number;
+        readonly decisionId: string;
+      }[]
+    ).map(({ rowid, decisionId }) => ({ rowid, decisionId }));
+    assert.deepEqual(searchRows, [
+      { rowid: 1, decisionId: "dec_FIRST" },
+      { rowid: 2, decisionId: "dec_SECOND" },
+    ]);
+  } finally {
+    db.close();
+  }
+});

--- a/packages/kernel/test/store/projection-query-shape.test.ts
+++ b/packages/kernel/test/store/projection-query-shape.test.ts
@@ -568,6 +568,18 @@ test("decision collection read uses one statement and indexed owner lookups", (c
   }
 });
 
+test("task relation refresh deletes through the task index instead of scanning the table", () => {
+  const db = new DatabaseSync(":memory:");
+  try {
+    createTaskRelationProjectionTable(db);
+    const plan = queryPlan(db, { sql: "DELETE FROM task_relation WHERE task_id = ?", args: ["task_a"] });
+    assert.match(plan, /SEARCH task_relation USING (?:COVERING )?INDEX task_relation_task/u);
+    assert.doesNotMatch(plan, /SCAN task_relation(?:\s|$)/u);
+  } finally {
+    db.close();
+  }
+});
+
 function queryPlan(db: DatabaseSync, read: { readonly sql: string; readonly args: readonly unknown[] }): string {
   return (
     db.prepare(`EXPLAIN QUERY PLAN ${read.sql}`).all(...read.args) as unknown as readonly { readonly detail: string }[]

--- a/packages/kernel/test/store/schedule-projection.test.ts
+++ b/packages/kernel/test/store/schedule-projection.test.ts
@@ -18,7 +18,7 @@ const actor = { principal: { personId: "person-schedule" }, executor: null } as 
 test("Schedule definition and run view share one canonical stream and rebuild exactly", async () => {
   await withTempStoreAsync(async (rootDir) => {
     initRepo(rootDir);
-    assert.equal(taskProjectionSchemaVersion, 19);
+    assert.equal(taskProjectionSchemaVersion, 20);
     const eventStore = makeTaskEventStore({ repoId: "schedule-projection", rootDir }),
       projection = makeTaskProjection({ rootDir, eventStore }),
       schedule = baseSchedule(),


### PR DESCRIPTION
# English

## Summary

Every Task event refreshes the task-local relation index with `DELETE FROM task_relation WHERE task_id = ?`, and `task_relation` had indexes on source, target, type and updated_at but not on `task_id`, so the statement was a full table scan. In the E7 scale measurement (task_9c03d77ef810c7e03787c38752) this one statement was 37.3 s of a 73.8 s 100k-event cold rebuild; rebuild time grew 19× for 10× events and the 1M tier could not finish inside its budget. The same shape existed for Decision events: `decision_fts` is an fts5 table with `decision_id UNINDEXED`, so `DELETE FROM decision_fts WHERE decision_id = ?` scanned the virtual table on every refresh.

This PR adds the missing index and keys the decision search row by the decision's rowid (decision rows are inserted once and only updated, so the rowid is stable). Both statements become O(rows of this task/decision) instead of O(all rows). The projection schema version moves 19 → 20 so an existing rebuildable cache is discarded and replayed once; without that, old `decision_fts` rows would keep their auto-assigned rowids and the rowid-keyed refresh would duplicate them.

## Architectural Justification

-

## What Changed

- `task-query-projection.ts`: `CREATE INDEX task_relation_task ON task_relation(task_id, relation_id)`.
- `decision-projection-reducer.ts` `refreshDecisionFts`: reads the decision rowid with the title/question it already fetched; deletes and inserts `decision_fts` by that rowid.
- `projection-schema.ts`: `taskProjectionSchemaVersion` 19 → 20.
- Tests: `projection-query-shape.test.ts` asserts the delete plan is `SEARCH task_relation USING INDEX task_relation_task` (never `SCAN`); new `decision-fts-refresh.test.ts` proposes two decisions, refreshes the second three times and asserts the search rows are exactly `[{rowid 1, dec_FIRST}, {rowid 2, dec_SECOND}]`; `schedule-projection.test.ts` pins version 20.

## Per-Write Cost

- Task event: statement count unchanged (1 DELETE + 1 INSERT…SELECT per refresh); the DELETE plan changes from `SCAN task_relation` to `SEARCH task_relation USING INDEX task_relation_task`. One more index is maintained on `task_relation` insert (rows per task, not per ledger).
- Decision event: statement count unchanged; the fts5 delete addresses one rowid instead of scanning the `decision_id` column.
- One-time: the first open after deploy replays the rebuildable projection (schema 19 → 20).

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: +13/-14 (net -1), from `node tools/gates/production-delta.mjs --base origin/main`.

## Machine-Readable Declarations

- Rebuildable projection schema version 20 (cache-only; no canonical event change).

## Task And Scope

- Harness task: task_5656dffbe7c9a1c1b1f0c62bd3 (E7 follow-up G1 + G10), parent task_2b8f79fa4412cb726a26f9bfc7
- Branch: `codex/perf-task-relation-index`
- Public scope: two projection statements and the schema version
- Private planning/evidence updated: yes (task plan; fact F-B8463D22)
- Out of scope: the other E7 growth items (task_58df7cff, task_de9675a5, task_2c5cdc09); the Ubuntu 1M re-run, which the CEO performs after deploy with the merged fixture (#2463)

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: not applicable
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `b5bc37f23`
- Branch merge-base with `origin/main`: `b5bc37f23`
- Last `git fetch origin` time: 2026-09-11 UTC
- Sync method: rebased onto origin/main
- Public diff command: `git diff origin/main...codex/perf-task-relation-index`
- Private evidence commit/path: task_5656dffbe7c9a1c1b1f0c62bd3 task package
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [ ] `npm run typecheck`
- [ ] `npm run check`
- [ ] `npm test`
- [x] `npm run harness:check-import-boundaries` (via `run-manifest-gates --changed origin/main`)
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts` (via `run-manifest-gates --changed origin/main`)
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Kernel: `projection-query-shape.test.ts` 12/12, `decision-fts-refresh.test.ts` 1/1, `schedule-projection.test.ts` + `fact-fts-performance.test.ts` + `projection-cache-continuity.test.ts` + decision reducer tests 9/9.
- Negative control: the first version of the fts test used one decision and passed on both old and new code (auto rowid 1 = decision rowid 1); it was tightened to two decisions so the old delete-by-column path yields `[{1, dec_FIRST}, {3, dec_SECOND}]` and fails.
- Gates: `run-manifest-gates --changed origin/main`, `line-density`, `production-delta` pass.

## Review Evidence

- CEO ground-truth: `EXPLAIN QUERY PLAN` before (`SCAN task_relation`) and after (`SEARCH … USING INDEX task_relation_task`) on the fixture database; decision rows are only ever inserted once (`INSERT INTO decision VALUES` on propose, `UPDATE` afterwards), so the rowid key is stable.
- Reviewer subagent: not used
- Human review: pending
- Blocking findings: none open

## Residual Risk

- The one-time projection replay on the canonical ledger (70k events) runs on the first daemon start after deploy; on the 100k fixture the pre-fix rebuild took 79 s, so expect roughly a minute of projection catch-up.
- The 1M-tier improvement is extrapolated from the profile share (37.3 s / 73.8 s at 100k) until the Ubuntu re-run is done.

## References

- Task: task_5656dffbe7c9a1c1b1f0c62bd3; measurement task_9c03d77ef810c7e03787c38752 (#2463)

---

# 中文

## 概要

每个 Task 事件都用 `DELETE FROM task_relation WHERE task_id = ?` 刷新任务本地关系索引，而 `task_relation` 只有 source、target、type、updated_at 四个索引，没有 `task_id`，这条语句是全表扫描。E7 规模测量（task_9c03d77ef810c7e03787c38752）里，100k 事件冷重建 73.8 s 中这一条语句占 37.3 s；事件 10 倍、重建耗时 19 倍，1M 档跑不进预算。Decision 事件同形：`decision_fts` 是 `decision_id UNINDEXED` 的 fts5 表，`DELETE FROM decision_fts WHERE decision_id = ?` 每次刷新都扫虚表。

本 PR 补上索引，并把 decision 搜索行按 decision 的 rowid 定位（decision 行只插入一次、之后只 UPDATE，rowid 稳定）。两条语句从 O(全表) 变为 O(本 task/decision 的行数)。投影 schema 版本 19 → 20，让已有的可重建缓存丢弃并重放一次；不升版本的话旧 `decision_fts` 行还是自动 rowid，按 rowid 刷新会造成重复。

## 架构辩护

-

## 改动内容

- `task-query-projection.ts`：`CREATE INDEX task_relation_task ON task_relation(task_id, relation_id)`。
- `decision-projection-reducer.ts` 的 `refreshDecisionFts`：在本来就要读的 title/question 那条 SELECT 里一起读 rowid；按 rowid 删除与插入 `decision_fts`。
- `projection-schema.ts`：`taskProjectionSchemaVersion` 19 → 20。
- 测试：`projection-query-shape.test.ts` 断言删除计划为 `SEARCH task_relation USING INDEX task_relation_task`（不得 `SCAN`）；新增 `decision-fts-refresh.test.ts` 提出两个 decision、对第二个刷新三次，断言搜索行恰为 `[{rowid 1, dec_FIRST}, {rowid 2, dec_SECOND}]`；`schedule-projection.test.ts` 钉住版本 20。

## 每次写入成本

- Task 事件：语句数不变（每次刷新 1 条 DELETE + 1 条 INSERT…SELECT）；DELETE 计划从 `SCAN task_relation` 变为 `SEARCH task_relation USING INDEX task_relation_task`。`task_relation` 插入时多维护一个索引（按 task 行数计，不按台账计）。
- Decision 事件：语句数不变；fts5 删除按一个 rowid 定位，不再扫 `decision_id` 列。
- 一次性：部署后首次打开会重放可重建投影（schema 19 → 20）。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 删除的门或 fixture：none
- 生产净行数：+13/-14（净 -1），来自 `node tools/gates/production-delta.mjs --base origin/main`。

## 机器可读声明

- 可重建投影 schema 版本 20（仅缓存；canonical 事件不变）。

## 任务与范围

- Harness 任务：task_5656dffbe7c9a1c1b1f0c62bd3（E7 后续 G1 + G10），父任务 task_2b8f79fa4412cb726a26f9bfc7
- 分支：`codex/perf-task-relation-index`
- 公开范围：两条投影语句与 schema 版本
- 私有计划/证据已更新：是（任务计划；fact F-B8463D22）
- 范围外：E7 其它增长项（task_58df7cff、task_de9675a5、task_2c5cdc09）；Ubuntu 1M 重跑由 CEO 在部署后用已合入的夹具（#2463）执行

## 版本影响

- 版本：不变
- 发布影响：不发布

## 治理声明

- 触碰受保护面：否
- 受保护面范围：不适用
- 授权：不适用
- 机器检查边界：本 PR 只断言声明存在；是否属实、是否充分由评审判断。
- Break-glass：否
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- 基线 `origin/main` SHA：`b5bc37f23`
- 分支与 `origin/main` 的 merge-base：`b5bc37f23`
- 最近一次 `git fetch origin`：2026-09-11 UTC
- 同步方式：rebase 到 origin/main
- 公开 diff 命令：`git diff origin/main...codex/perf-task-relation-index`
- 私有证据路径：task_5656dffbe7c9a1c1b1f0c62bd3 任务包
- 评审证据路径：本 PR 的评审证据节
- GitHub Actions `rewrite-ci` run URL：本 PR 待跑
- kernel：`projection-query-shape.test.ts` 12/12、`decision-fts-refresh.test.ts` 1/1、`schedule-projection.test.ts` + `fact-fts-performance.test.ts` + `projection-cache-continuity.test.ts` + decision reducer 测试 9/9。
- 阴性对照：fts 测试第一版只用一个 decision，新旧代码都过（自动 rowid 1 = decision rowid 1）；收紧为两个 decision 后，旧的按列删除路径得到 `[{1, dec_FIRST}, {3, dec_SECOND}]` 而失败。
- 门：`run-manifest-gates --changed origin/main`、`line-density`、`production-delta` 通过。

## 评审证据

- CEO 事实核对：在夹具库上 `EXPLAIN QUERY PLAN` 改前（`SCAN task_relation`）与改后（`SEARCH … USING INDEX task_relation_task`）；decision 行只在 propose 时 `INSERT INTO decision VALUES` 一次、之后全是 `UPDATE`，所以 rowid 键稳定。
- 评审子代理：未用
- 人工评审：待定
- 阻塞发现：无

## 残余风险

- 部署后 daemon 首次启动会对 canonical 台账（7 万事件）做一次投影重放；100k 夹具上修前重建 79 s，预计约一分钟的投影追赶。
- 1M 档的改善在 Ubuntu 重跑前只是按 profile 占比（100k 时 37.3 s / 73.8 s）外推。

## 参考

- 任务：task_5656dffbe7c9a1c1b1f0c62bd3；测量任务 task_9c03d77ef810c7e03787c38752（#2463）
