### PR TITLE
test: compare retained restore drill shadows independent of readdir order

### DIFF
--- a/packages/kernel/test/store/ledger-backup.integration.test.ts
+++ b/packages/kernel/test/store/ledger-backup.integration.test.ts
@@ -205,9 +205,12 @@ test("restore drill rolls shadows by retention, preserves unrelated directories 
     }
     const retained = drilled.slice(-2).map(({ shadowRoot }) => shadowRoot);
     assert.equal(lstatSync(unrelated).isDirectory(), true);
+    // readdir order is not creation order for mkdtemp names, so compare the sets.
     assert.deepEqual(
-      readdirDirectories(shadowParent).filter((entry) => entry.startsWith("restore-drill-")),
-      retained.map((entry) => path.basename(entry)),
+      readdirDirectories(shadowParent)
+        .filter((entry) => entry.startsWith("restore-drill-"))
+        .sort(),
+      retained.map((entry) => path.basename(entry)).sort(),
     );
     assert.equal(drilled.at(-1)?.manifest.tag, manifest.tag);
     assert.deepEqual(drilled[2]?.removedShadowRoots, [drilled[0]?.shadowRoot]);


### PR DESCRIPTION
# English

## Summary

The restore-drill retention test from #2460 compared the surviving `restore-drill-*` directories in `readdir` order against creation order. `mkdtemp` names are random, so `readdir` order is not creation order and the test fails roughly one run in three (reproduced locally 1/3 and on PR #2464's integration-shard (5)). The implementation is correct; the assertion now compares both sides sorted.

## Architectural Justification

-

## What Changed

- `packages/kernel/test/store/ledger-backup.integration.test.ts`: sort both sides of the retained-shadows comparison.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: +0/-0.

## Machine-Readable Declarations

- None.

## Task And Scope

- Harness task: task_f16581aa37aadc9e00699729d7 (follow-up to #2460)
- Branch: `codex/restore-drill-test-order`
- Public scope: one test assertion
- Private planning/evidence updated: noted in the task closeout
- Out of scope: everything else

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: not applicable
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `f8753176d`
- Branch merge-base with `origin/main`: `f8753176d`
- Last `git fetch origin` time: 2026-09-11 UTC
- Sync method: branched from origin/main
- Public diff command: `git diff origin/main...codex/restore-drill-test-order`
- Private evidence commit/path: task_f16581aa37aadc9e00699729d7
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [ ] `npm run typecheck`
- [ ] `npm run check`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- `ledger-backup.integration.test.ts` 6/6 consecutive runs green after the change; before it, 1 failure in 3 runs with `actual: ['restore-drill-OHOXL3','restore-drill-t0LlnL']` vs `expected` in the opposite order.

## Review Evidence

- CEO ground-truth: the failing assertion diff shows the same two names in different order; no directory was wrongly kept or removed.
- Reviewer subagent: not used
- Human review: pending
- Blocking findings: none open

## Residual Risk

- None beyond the test.

## References

- #2460, #2464 (shard 5 failure)

---

# 中文

## 概要

#2460 的 restore-drill 保留测试把存活的 `restore-drill-*` 目录按 `readdir` 顺序与创建顺序比较。`mkdtemp` 名字是随机的，`readdir` 顺序不等于创建顺序，测试约三次里失败一次（本机 1/3 复现，PR #2464 的 integration-shard (5) 也红了）。实现是对的；断言改为两边排序后比较。

## 架构辩护

-

## 改动内容

- `packages/kernel/test/store/ledger-backup.integration.test.ts`：保留副本比较两边都排序。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 删除的门或 fixture：none
- 生产净行数：+0/-0。

## 机器可读声明

- 无。

## 任务与范围

- Harness 任务：task_f16581aa37aadc9e00699729d7（#2460 的后续）
- 分支：`codex/restore-drill-test-order`
- 公开范围：一条测试断言
- 私有计划/证据已更新：记入任务 closeout
- 范围外：其它一切

## 版本影响

- 版本：不变
- 发布影响：不发布

## 治理声明

- 触碰受保护面：否
- 受保护面范围：不适用
- 授权：不适用
- 机器检查边界：本 PR 只断言声明存在；是否属实、是否充分由评审判断。
- Break-glass：否
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- 基线 `origin/main` SHA：`f8753176d`
- 分支与 `origin/main` 的 merge-base：`f8753176d`
- 最近一次 `git fetch origin`：2026-09-11 UTC
- 同步方式：从 origin/main 开分支
- 公开 diff 命令：`git diff origin/main...codex/restore-drill-test-order`
- 私有证据路径：task_f16581aa37aadc9e00699729d7
- 评审证据路径：本 PR 的评审证据节
- GitHub Actions `rewrite-ci` run URL：本 PR 待跑
- `ledger-backup.integration.test.ts` 改后连续 6 次绿；改前 3 次里 1 次失败，`actual` 与 `expected` 是同两个名字的不同顺序。

## 评审证据

- CEO 事实核对：失败断言的 diff 是同两个名字顺序不同；没有目录被错留或错删。
- 评审子代理：未用
- 人工评审：待定
- 阻塞发现：无

## 残余风险

- 除测试外无。

## 参考

- #2460、#2464（shard 5 失败）
