### PR TITLE
perf: read fact liveness edges through the relation target index

### DIFF
--- a/packages/kernel/src/projection/fact-event-projection.ts
+++ b/packages/kernel/src/projection/fact-event-projection.ts
@@ -237,17 +237,29 @@ function livenessRelations(
   targetRefs?: readonly string[],
 ): readonly { readonly targetRef: string; readonly relationType: string; readonly state: string }[] {
   if (targetRefs !== undefined && targetRefs.length === 0) return [];
+  const select =
+    "SELECT relation_edge.target_ref AS targetRef, relation_edge.relation_type AS relationType, relation_edge.state";
+  if (targetRefs === undefined)
+    return queryRows<{
+      readonly targetRef: string;
+      readonly relationType: string;
+      readonly state: string;
+    }>(
+      db,
+      select + " FROM relation_edge WHERE state = 'active' AND relation_type = 'supersedes-fact' ORDER BY relation_id",
+    );
   return queryRows<{
     readonly targetRef: string;
     readonly relationType: string;
     readonly state: string;
   }>(
     db,
-    "SELECT target_ref AS targetRef, relation_type AS relationType, state FROM relation_edge " +
-      "WHERE state = 'active' AND relation_type = 'supersedes-fact' " +
-      "AND (? IS NULL OR target_ref IN (SELECT value FROM json_each(?))) ORDER BY relation_id",
-    targetRefs === undefined ? null : JSON.stringify(targetRefs),
-    targetRefs === undefined ? null : JSON.stringify(targetRefs),
+    "WITH requested_targets AS (SELECT value AS target_ref FROM json_each(?)) " +
+      select +
+      " FROM requested_targets CROSS JOIN relation_edge INDEXED BY relation_edge_target " +
+      "WHERE relation_edge.target_ref = requested_targets.target_ref AND state = 'active' " +
+      "AND relation_type = 'supersedes-fact' ORDER BY relation_id",
+    JSON.stringify(targetRefs),
   );
 }
 function decodeFactRows(db: DatabaseSync, records: readonly FactRecord[]): readonly FactProjectionRow[] {

--- a/packages/kernel/test/store/fact-fts-performance.test.ts
+++ b/packages/kernel/test/store/fact-fts-performance.test.ts
@@ -160,3 +160,72 @@ test("10k Decision FTS searches stay indexed after refresh with p95 below 10ms",
     db.close();
   }
 });
+
+test("fact liveness lookup stays stable as unrelated active edges grow", (context) => {
+  const measure = (edgeCount: number): number => {
+    const db = new DatabaseSync(":memory:");
+    try {
+      createRelationGraphProjectionTables(db);
+      createFactProjectionTables(db);
+      db.prepare(
+        "INSERT INTO fact(task_id, fact_id, ref, statement, evidence_source, observed_at, confidence, memory_class, op_id, workspace_revision, row_json) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+      ).run(
+        "task-0",
+        "F-00000000",
+        "fact/F-00000000",
+        "liveness target",
+        "performance fixture",
+        "2026-08-13T00:00:00.000Z",
+        "high",
+        "semantic",
+        "op-0",
+        1,
+        JSON.stringify({
+          schema: "fact-row/v1",
+          ref: "fact/F-00000000",
+          taskId: "task-0",
+          factId: "F-00000000",
+          statement: "liveness target",
+          evidenceSource: "performance fixture",
+          observedAt: "2026-08-13T00:00:00.000Z",
+          confidence: "high",
+          memoryClass: "semantic",
+          memoryTags: [],
+          provenance: [],
+          actor: { principal: { personId: "performance" }, executor: null },
+          source: "local",
+          occurredAt: "2026-08-13T00:00:00.000Z",
+          workspaceRevision: 1,
+        }),
+      );
+      const insert = db.prepare("INSERT INTO relation_edge VALUES (?, ?, ?, ?, 'active', NULL, ?, ?, ?)");
+      db.exec("BEGIN");
+      for (let index = 0; index < edgeCount; index += 1)
+        insert.run(
+          `rel-${index}`,
+          `fact/source-${index}`,
+          `fact/other-${index}`,
+          "evidenced-by",
+          "fact/source",
+          index + 1,
+          "{}",
+        );
+      db.exec("COMMIT");
+      searchFactRows(db, { refs: ["fact/F-00000000"] });
+      const samples: number[] = [];
+      for (let index = 0; index < 20; index += 1) {
+        const startedAt = performance.now();
+        searchFactRows(db, { refs: ["fact/F-00000000"] });
+        samples.push(performance.now() - startedAt);
+      }
+      samples.sort((left, right) => left - right);
+      return samples[Math.ceil(samples.length * 0.95) - 1]!;
+    } finally {
+      db.close();
+    }
+  };
+  const p95_10k = measure(10_000),
+    p95_100k = measure(100_000);
+  context.diagnostic(`fact liveness p95: 10k=${p95_10k.toFixed(3)}ms 100k=${p95_100k.toFixed(3)}ms`);
+  assert.ok(p95_100k <= p95_10k * 2 + 1, "liveness cost grew with unrelated active edges");
+});

--- a/packages/kernel/test/store/projection-query-shape.test.ts
+++ b/packages/kernel/test/store/projection-query-shape.test.ts
@@ -240,6 +240,30 @@ for (const [label, read] of [
   });
 }
 
+test("fact liveness target reads use the target-leading relation index", () => {
+  const counted = countingDatabase(),
+    { db } = counted;
+  try {
+    seed(db, 1, 1);
+    db.prepare("INSERT INTO relation_edge VALUES (?, ?, ?, 'supersedes-fact', 'active', NULL, ?, ?, ?)").run(
+      "rel_supersedes",
+      "fact/F-00000001",
+      "fact/F-00000000",
+      "fact/F-00000000",
+      99,
+      JSON.stringify({}),
+    );
+    searchFactRows(db, { refs: ["fact/F-00000000"] });
+    const read = counted.reads().find(({ sql }) => sql.includes("requested_targets"));
+    assert.ok(read, "expected target-scoped liveness query");
+    const plan = queryPlan(db, read!);
+    assert.match(plan, /SEARCH relation_edge USING INDEX relation_edge_target/u);
+    assert.doesNotMatch(plan, /relation_edge_state_page \(state=\?\)/u);
+  } finally {
+    db.close();
+  }
+});
+
 test("decision list reads every match without paging parameters and a constant number of statements per page", (context) => {
   const counted = countingDatabase(),
     { db } = counted;


### PR DESCRIPTION
# English

## Summary

`livenessRelations` in `fact-event-projection.ts` decides whether a Fact is still live by reading its incoming `supersedes-fact` edges. The target-scoped form was written as `(? IS NULL OR target_ref IN (SELECT value FROM json_each(?)))`, which SQLite planned as `SEARCH relation_edge USING INDEX relation_edge_state_page (state=?)` plus a bloom filter — a scan of every active edge per read. The E7 scale measurement (task_9c03d77ef810c7e03787c38752, G2/G3) shows kernel `searchFacts` going 0.29 → 12.45 ms and the daemon's relation enrichment (`relationGraphFromRead` → `searchFacts({refs})`) 0.61 → 11.87 ms from 10k to 100k events, while the `supersedes-fact` edge count was 0.

This PR splits the read into two statements: the unscoped read keeps its state-first query; the target-scoped read joins the requested refs against `relation_edge INDEXED BY relation_edge_target`, so its cost follows the number of requested facts, not the number of active edges.

## Architectural Justification

-

## What Changed

- `fact-event-projection.ts` `livenessRelations`: two explicit statements; the target branch is `WITH requested_targets AS (SELECT value FROM json_each(?)) … CROSS JOIN relation_edge INDEXED BY relation_edge_target WHERE relation_edge.target_ref = requested_targets.target_ref AND state = 'active' AND relation_type = 'supersedes-fact'`.
- `projection-query-shape.test.ts`: asserts the target branch plans `SEARCH relation_edge USING INDEX relation_edge_target`.
- `fact-fts-performance.test.ts`: with 10k and then 100k unrelated active edges, target-scoped liveness p95 stays flat (0.029 ms → 0.025 ms measured).

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: +17/-5 (net +12), from `node tools/gates/production-delta.mjs --base <merge-base>`.

## Machine-Readable Declarations

- None.

## Task And Scope

- Harness task: task_58df7cffa03b4a1b369b9d95d2 (E7 follow-up G2 + G3), parent task_2b8f79fa4412cb726a26f9bfc7
- Branch: `codex/perf-fact-liveness`
- Public scope: one kernel read statement and its tests
- Private planning/evidence updated: yes (task plan, `artifacts/report.md`, fact F-D4467AE5)
- Out of scope: the daemon enrichment call structure (unchanged; it now benefits through the same kernel path); the Ubuntu 100k re-run (CEO, after deploy)

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: not applicable
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `b5bc37f23`
- Branch merge-base with `origin/main`: `b5bc37f23`
- Last `git fetch origin` time: 2026-09-11 UTC
- Sync method: branched from origin/main
- Public diff command: `git diff origin/main...codex/perf-fact-liveness`
- Private evidence commit/path: task_58df7cffa03b4a1b369b9d95d2 `artifacts/report.md`
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [ ] `npm run typecheck`
- [ ] `npm run check`
- [ ] `npm test`
- [x] `npm run harness:check-import-boundaries` (via `run-manifest-gates --changed origin/main`)
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts` (via `run-manifest-gates --changed origin/main`)
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- `projection-query-shape.test.ts` + `fact-fts-performance.test.ts`: 15/15 (worker); the plan assertion is the negative control — restoring the `? IS NULL OR … IN json_each` form fails it.

## Review Evidence

- CEO ground-truth: read the diff; the unscoped branch is unchanged in semantics, the scoped branch keeps the same three predicates and ordering, and `INDEXED BY` pins the plan the test asserts.
- Reviewer subagent: not used
- Human review: pending
- Blocking findings: none open

## Residual Risk

- `INDEXED BY` makes the statement fail loudly if the index is ever renamed; that is intended (the plan assertion would fail first).
- The Ubuntu numbers from E7 are not yet re-measured with this change.

## References

- Task: task_58df7cffa03b4a1b369b9d95d2; measurement task_9c03d77ef810c7e03787c38752 (#2463); predecessor F8 task_3d544f598841881061d54556c8

---

# 中文

## 概要

`fact-event-projection.ts` 的 `livenessRelations` 靠读取一个 Fact 的入边 `supersedes-fact` 来判断它是否仍然有效。按目标过滤的写法是 `(? IS NULL OR target_ref IN (SELECT value FROM json_each(?)))`，SQLite 把它规划成 `SEARCH relation_edge USING INDEX relation_edge_state_page (state=?)` 加 bloom filter——每次读都扫全部 active 边。E7 规模测量（task_9c03d77ef810c7e03787c38752，G2/G3）里 kernel `searchFacts` 从 0.29 涨到 12.45 ms，daemon 的 relation 富化（`relationGraphFromRead` → `searchFacts({refs})`）从 0.61 涨到 11.87 ms（10k → 100k 事件），而 `supersedes-fact` 边实际是 0 条。

本 PR 把这次读拆成两条语句：不限目标的读保留按 state 的查询；限目标的读把请求的 ref 与 `relation_edge INDEXED BY relation_edge_target` 连接，成本随请求的 fact 数增长，不随 active 边总数增长。

## 架构辩护

-

## 改动内容

- `fact-event-projection.ts` 的 `livenessRelations`：两条显式语句；目标分支为 `WITH requested_targets AS (SELECT value FROM json_each(?)) … CROSS JOIN relation_edge INDEXED BY relation_edge_target WHERE relation_edge.target_ref = requested_targets.target_ref AND state = 'active' AND relation_type = 'supersedes-fact'`。
- `projection-query-shape.test.ts`：断言目标分支的计划为 `SEARCH relation_edge USING INDEX relation_edge_target`。
- `fact-fts-performance.test.ts`：先 10k 后 100k 条无关 active 边，限目标 liveness 的 p95 持平（实测 0.029 ms → 0.025 ms）。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 删除的门或 fixture：none
- 生产净行数：+17/-5（净 +12），来自 `node tools/gates/production-delta.mjs --base <merge-base>`。

## 机器可读声明

- 无。

## 任务与范围

- Harness 任务：task_58df7cffa03b4a1b369b9d95d2（E7 后续 G2 + G3），父任务 task_2b8f79fa4412cb726a26f9bfc7
- 分支：`codex/perf-fact-liveness`
- 公开范围：一条 kernel 读语句及其测试
- 私有计划/证据已更新：是（任务计划、`artifacts/report.md`、fact F-D4467AE5）
- 范围外：daemon 富化调用结构（不变；经同一 kernel 路径受益）；Ubuntu 100k 重跑（CEO 部署后做）

## 版本影响

- 版本：不变
- 发布影响：不发布

## 治理声明

- 触碰受保护面：否
- 受保护面范围：不适用
- 授权：不适用
- 机器检查边界：本 PR 只断言声明存在；是否属实、是否充分由评审判断。
- Break-glass：否
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- 基线 `origin/main` SHA：`b5bc37f23`
- 分支与 `origin/main` 的 merge-base：`b5bc37f23`
- 最近一次 `git fetch origin`：2026-09-11 UTC
- 同步方式：从 origin/main 开分支
- 公开 diff 命令：`git diff origin/main...codex/perf-fact-liveness`
- 私有证据路径：task_58df7cffa03b4a1b369b9d95d2 的 `artifacts/report.md`
- 评审证据路径：本 PR 的评审证据节
- GitHub Actions `rewrite-ci` run URL：本 PR 待跑
- `projection-query-shape.test.ts` + `fact-fts-performance.test.ts`：15/15（worker）；计划断言即阴性对照——还原 `? IS NULL OR … IN json_each` 写法它就失败。

## 评审证据

- CEO 事实核对：读过 diff；不限目标分支语义不变，限目标分支保留同样三个谓词与排序，`INDEXED BY` 钉住测试断言的计划。
- 评审子代理：未用
- 人工评审：待定
- 阻塞发现：无

## 残余风险

- `INDEXED BY` 在索引被改名时会让语句直接报错；这是有意的（计划断言会先失败）。
- E7 的 Ubuntu 数字尚未用本改动重测。

## 参考

- 任务：task_58df7cffa03b4a1b369b9d95d2；测量任务 task_9c03d77ef810c7e03787c38752（#2463）；前任务 F8 task_3d544f598841881061d54556c8
