### PR TITLE
feat: page task list by default (50 rows) and hint the next cursor

### DIFF
--- a/packages/daemon/src/protocol/daemon-protocol-commands-task-surface.ts
+++ b/packages/daemon/src/protocol/daemon-protocol-commands-task-surface.ts
@@ -238,7 +238,9 @@ export const taskSurfaceProtocolCommands = Object.freeze([
     id: "task-list",
     phase: "W3",
     path: ["task", "list"],
-    summary: "List Task projection rows or a recursive parent subtree with canonical filters.",
+    summary:
+      "List Task projection rows (default 50; use --cursor for more) or a recursive parent subtree " +
+      "with canonical filters.",
     method: "repo.task.read",
     inputs: [
       cliInput(

--- a/packages/daemon/src/repo-cell-task-query.ts
+++ b/packages/daemon/src/repo-cell-task-query.ts
@@ -20,6 +20,8 @@ import { requiredPackageDisposition, type TaskQueryReadModel } from "./task-quer
 import { resolveTaskRootThreshold, resolveTaskWipLimit } from "./task-wip-settings.ts";
 import { selectTaskIndex } from "./task-index-query.ts";
 
+export const DEFAULT_TASK_LIST_LIMIT = 50;
+
 export interface TaskQueryCell {
   readonly input: { readonly repoId: string };
   readonly rootDir: string;
@@ -72,12 +74,13 @@ export function listTasks(cell: TaskQueryCell, action: RepoTaskAction, binding: 
       ...(query.updatedBefore ? { updatedBefore: query.updatedBefore } : {}),
     },
     flat = depth === undefined,
+    effectiveLimit = flat && query.limit === undefined ? DEFAULT_TASK_LIST_LIMIT : query.limit,
     read = cell.projection.readTaskIndex(
       flat
         ? {
             ...filters,
             ...(typeof action.parentTaskId === "string" ? { parentTaskId: action.parentTaskId } : {}),
-            ...(query.limit === undefined ? {} : { limit: query.limit }),
+            ...(effectiveLimit === undefined ? {} : { limit: effectiveLimit }),
             ...(query.cursor === undefined ? {} : { cursor: query.cursor }),
             activePackagesOnly: true,
           }

--- a/packages/daemon/src/task-index-query.ts
+++ b/packages/daemon/src/task-index-query.ts
@@ -115,13 +115,15 @@ export function renderTaskIndexPayload(payload: unknown): string | null {
               ].join("\t"),
             )
             .join("\n"),
-    page = record.page && typeof record.page === "object" ? `  page=${JSON.stringify(record.page)}` : "";
+    pageRecord = record.page && typeof record.page === "object" ? (record.page as Record<string, unknown>) : null,
+    page = pageRecord ? `  page=${JSON.stringify(pageRecord)}` : "",
+    nextPage = typeof pageRecord?.nextCursor === "string" ? `\nmore: use --cursor ${pageRecord.nextCursor}` : "";
   return [
     `${record.mode === "tree" ? "tree" : "rows"}:`,
     body || "(none)",
     `count=${String(record.count ?? rows.length)}  status=${String(record.status ?? "unknown")}  ` +
       `watermark=${String(record.watermark ?? "unknown")}  ` +
-      `sourceRevision=${String(record.sourceRevision ?? "unknown")}${page}`,
+      `sourceRevision=${String(record.sourceRevision ?? "unknown")}${page}${nextPage}`,
   ].join("\n");
 }
 

--- a/packages/daemon/test/task-index-query.test.ts
+++ b/packages/daemon/test/task-index-query.test.ts
@@ -83,6 +83,20 @@ test("filtered task index pagination is keyset-equivalent", () => {
   assert.equal(second.page?.nextCursor, null);
 });
 
+test("task index text output explains how to continue a paged result", () => {
+  const rendered = renderTaskIndexPayload({
+    schema: "task-list/v2",
+    mode: "flat",
+    rows: [],
+    count: 50,
+    page: { limit: 50, cursor: null, nextCursor: "next-page" },
+    status: "ready",
+    watermark: 1,
+    sourceRevision: 1,
+  });
+  assert.match(rendered ?? "", /more: use --cursor next-page/u);
+});
+
 test("a 200-node projection iterable is consumed once and all-depth expansion stays iterative", () => {
   const rows = Array.from({ length: 200 }, (_, index) =>
     row(

--- a/packages/daemon/test/task-list-default-page.integration.test.ts
+++ b/packages/daemon/test/task-list-default-page.integration.test.ts
@@ -1,0 +1,41 @@
+// harness-test-tier: integration
+import assert from "node:assert/strict";
+import test from "node:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { canonicalRoot, workspaceId } from "../src/protocol/daemon-protocol.contract.ts";
+import { openBootstrappedRepoCell as openRepoCell } from "./repo-settings.fixture.ts";
+import { actor, evidence, initRepo } from "./task-surface.fixtures.ts";
+
+test("task list defaults to 50 rows and exposes a continuation cursor", async () => {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-task-list-default-page-"));
+  let cell: Awaited<ReturnType<typeof openRepoCell>> | undefined;
+  try {
+    initRepo(rootDir);
+    cell = await openRepoCell({
+      repoId: workspaceId("task-list-default-page"),
+      rootDir: canonicalRoot(rootDir),
+      ownerId: "task-list-default-page",
+      now: () => "2026-08-15T03:00:00.000Z",
+    });
+    const binding = { actor, source: "local" as const };
+    for (let index = 0; index < 51; index += 1)
+      assert.equal(
+        (
+          await cell.run(
+            { kind: "task-create", taskId: `task_${String(index).padStart(2, "0")}`, title: `Task ${index}` },
+            binding,
+          )
+        ).outcome,
+        "applied",
+      );
+    const listed = evidence(await cell.run({ kind: "task-list" }, binding));
+    assert.equal(listed.rows.length, 50);
+    assert.equal(listed.page.limit, 50);
+    assert.equal(typeof listed.page.nextCursor, "string");
+  } finally {
+    await cell?.close();
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
# English

## Summary

`ha task list` without `--limit` asked the daemon for every task (`readTaskIndex({})`), an O(tasks) read: E7 measured kernel 2.7 → 26.0 ms and CLI p95 5.4× from 10k to 100k events, and the round-5 bench measured p50 1.6 s for the unparameterized list at 10k tasks against 11–15 ms for the narrow paths. The repository owner ruled on 2026-09-11 that the list pages by default.

The daemon now applies a default limit of 50 to flat `task-list` reads that carry no `limit`; explicit limits and cursors are unchanged, and the text renderer prints `more: use --cursor <next>` when a page continues. This is fix-plan batch 8. Behaviour change: scripts that relied on the bare command returning everything must page or pass `--limit`.

## Architectural Justification

-

## What Changed

- `repo-cell-task-query.ts`: `DEFAULT_TASK_LIST_LIMIT = 50` applied when a flat query has no `limit`; tree (`--depth`) reads, explicit limits and cursors untouched.
- `task-index-query.ts`: text output appends `more: use --cursor …` when `page.nextCursor` is present.
- `daemon-protocol-commands-task-surface.ts`: `task list` summary states the default and the cursor.
- Audited unbounded call sites: `repo-cell.ts:124` (`readTaskIndex()` attach-time structural probe) stays unbounded on purpose; GUI `repo.tasks.list` already pages with explicit size 500 and cursors, so no GUI change.
- Tests: `task-index-query.test.ts` (renderer hint), new `task-list-default-page.integration.test.ts` (51-task fixture → 50 rows + continuation cursor).

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: +11/-3.

## Machine-Readable Declarations

- CLI contract: `task list` help summary text changed (default 50, `--cursor`).

## Task And Scope

- Harness task: task_2b4e3b038c5e10bb94f210415b (fix-plan batch 8; E7 G5), parent task_2b8f79fa4412cb726a26f9bfc7
- Branch: `codex/task-list-default-page`
- Public scope: daemon default page size for flat task lists, CLI hint
- Private planning/evidence updated: yes (task plan with the owner ruling, `artifacts/report.md`)
- Out of scope: `selectTaskIndex` internals (G6 attribution, task_2c5cdc09); batch hydration

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: not applicable
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `6bcfbbac5`
- Branch merge-base with `origin/main`: `6bcfbbac5`
- Last `git fetch origin` time: 2026-09-11 UTC
- Sync method: branched from origin/main
- Public diff command: `git diff origin/main...codex/task-list-default-page`
- Private evidence commit/path: task_2b4e3b038c5e10bb94f210415b `artifacts/report.md`
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [ ] `npm run typecheck`
- [ ] `npm run check`
- [ ] `npm test`
- [x] `npm run harness:check-import-boundaries` (via `run-manifest-gates --changed origin/main`)
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts` (via `run-manifest-gates --changed origin/main`)
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Fast: `task-index-query.test.ts` + `thin-command.test.ts` 23 passed; isolated integration: `task-surface-pages-facts.integration.test.ts` 2 passed, `task-list-default-page.integration.test.ts` 1 passed (worker).

## Review Evidence

- CEO ground-truth: read the diff; the default is applied in the daemon (not only the CLI), tree reads are excluded, and the only remaining unbounded `readTaskIndex()` is the attach-time probe.
- Reviewer subagent: not used
- Human review: pending
- Blocking findings: none open

## Residual Risk

- Callers that parsed the bare list as complete now see 50 rows; the text hint and JSON `page.nextCursor` are the signal.

## References

- Task: task_2b4e3b038c5e10bb94f210415b; measurement task_9c03d77ef810c7e03787c38752 (#2463); fix-plan task_6eba9c5d3a55735920aa4856f3 batch 8

---

# 中文

## 概要

`ha task list` 不带 `--limit` 时向 daemon 要全部任务（`readTaskIndex({})`），是 O(tasks) 的读：E7 测得 kernel 2.7 → 26.0 ms、CLI p95 5.4×（10k → 100k 事件），round-5 台架在 10k 任务下无参列表 p50 1.6 s，而窄路径 11–15 ms。仓库所有者 2026-09-11 裁决改为默认分页。

daemon 现在对不带 `limit` 的平铺 `task-list` 读施加默认 50；显式 limit 与游标不变；文本渲染在有下一页时打印 `more: use --cursor <next>`。对应 fix-plan 批 8。行为变化：依赖裸命令返回全量的脚本需要翻页或传 `--limit`。

## 架构辩护

-

## 改动内容

- `repo-cell-task-query.ts`：平铺查询无 `limit` 时用 `DEFAULT_TASK_LIST_LIMIT = 50`；树形（`--depth`）读、显式 limit 与游标不动。
- `task-index-query.ts`：文本输出在 `page.nextCursor` 存在时追加 `more: use --cursor …`。
- `daemon-protocol-commands-task-surface.ts`：`task list` 摘要写明默认 50 与游标。
- 无界调用点核对：`repo-cell.ts:124`（attach 时的结构探测）有意保持无界；GUI `repo.tasks.list` 已带页大小 500 与游标，无需改。
- 测试：`task-index-query.test.ts`（渲染提示）、新增 `task-list-default-page.integration.test.ts`（51 任务夹具 → 50 行 + 续页游标）。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 删除的门或 fixture：none
- 生产净行数：+11/-3。

## 机器可读声明

- CLI 契约：`task list` 帮助摘要文本变化（默认 50、`--cursor`）。

## 任务与范围

- Harness 任务：task_2b4e3b038c5e10bb94f210415b（fix-plan 批 8；E7 G5），父任务 task_2b8f79fa4412cb726a26f9bfc7
- 分支：`codex/task-list-default-page`
- 公开范围：daemon 平铺任务列表默认页大小、CLI 提示
- 私有计划/证据已更新：是（含所有者裁决的任务计划、`artifacts/report.md`）
- 范围外：`selectTaskIndex` 内部（G6 归因，task_2c5cdc09）；批量水合

## 版本影响

- 版本：不变
- 发布影响：不发布

## 治理声明

- 触碰受保护面：否
- 受保护面范围：不适用
- 授权：不适用
- 机器检查边界：本 PR 只断言声明存在；是否属实、是否充分由评审判断。
- Break-glass：否
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- 基线 `origin/main` SHA：`6bcfbbac5`
- 分支与 `origin/main` 的 merge-base：`6bcfbbac5`
- 最近一次 `git fetch origin`：2026-09-11 UTC
- 同步方式：从 origin/main 开分支
- 公开 diff 命令：`git diff origin/main...codex/task-list-default-page`
- 私有证据路径：task_2b4e3b038c5e10bb94f210415b 的 `artifacts/report.md`
- 评审证据路径：本 PR 的评审证据节
- GitHub Actions `rewrite-ci` run URL：本 PR 待跑
- fast：`task-index-query.test.ts` + `thin-command.test.ts` 23 通过；隔离 integration：`task-surface-pages-facts` 2 通过、`task-list-default-page` 1 通过（worker）。

## 评审证据

- CEO 事实核对：读过 diff；默认值在 daemon 施加（不只 CLI），树形读排除，唯一剩下的无界 `readTaskIndex()` 是 attach 探测。
- 评审子代理：未用
- 人工评审：待定
- 阻塞发现：无

## 残余风险

- 把裸列表当全量解析的调用方现在只看到 50 行；文本提示与 JSON `page.nextCursor` 是信号。

## 参考

- 任务：task_2b4e3b038c5e10bb94f210415b；测量任务 task_9c03d77ef810c7e03787c38752（#2463）；fix-plan task_6eba9c5d3a55735920aa4856f3 批 8
