### PR TITLE
fix: throttle activity-only terminal registry persistence to once per 10 s

### DIFF
--- a/packages/daemon/src/terminal-host.ts
+++ b/packages/daemon/src/terminal-host.ts
@@ -32,7 +32,8 @@ import { terminalEnvironment } from "./terminal-environment.ts";
 const scrollbackLimit = 1024 * 1024,
   replayLimit = 256 * 1024,
   subscriberLimit = 256 * 1024,
-  ptyExitDrainMs = 5_000;
+  ptyExitDrainMs = 5_000,
+  activityPersistIntervalMs = 10_000;
 type Frame = JsonObject & {
   readonly schema: "terminal-attach-event/v1";
   readonly sessionId: string;
@@ -140,6 +141,7 @@ export function openTerminalHost(input: OpenTerminalHostInput): TerminalHost {
     input.registryFilePath ?? path.join(input.rootDir, ".harness", "generated", "terminal-sessions.json");
   const restored = loadTmuxSessionRegistry(registryFilePath);
   let registryTouched = restored.length > 0;
+  let lastPersistedAt: number | undefined;
   for (const stored of restored) {
     const session = restoreSession(stored);
     sessions.set(session.sessionId, session);
@@ -292,7 +294,7 @@ export function openTerminalHost(input: OpenTerminalHostInput): TerminalHost {
         ensureChannel(session).write(utf8);
         session.acceptedThrough = clientSeq;
         session.lastActivityAt = now();
-        persistSessions();
+        persistSessions({ activityOnly: true });
       }
       return writeTerminalInputAck({
         schema: "terminal-input-ack/v1",
@@ -314,7 +316,7 @@ export function openTerminalHost(input: OpenTerminalHostInput): TerminalHost {
         );
       ensureChannel(session).resize(dimension(payload.cols, "cols"), dimension(payload.rows, "rows"));
       session.lastActivityAt = now();
-      persistSessions();
+      persistSessions({ activityOnly: true });
       const resizeSeed = `${session.sessionId}:resize:${payload.cols}x${payload.rows}`;
       return control("applied", session.sessionId, "running", resizeSeed);
     },
@@ -543,7 +545,12 @@ export function openTerminalHost(input: OpenTerminalHostInput): TerminalHost {
       subscribers: new Map(),
     };
   }
-  function persistSessions(): void {
+  function persistSessions(options: { readonly activityOnly?: boolean } = {}): void {
+    const activityOnly = options.activityOnly === true;
+    if (activityOnly) {
+      const current = Date.parse(now());
+      if (lastPersistedAt !== undefined && current - lastPersistedAt < activityPersistIntervalMs) return;
+    }
     const durable = [...sessions.values()]
       .filter((session) => session.backend === "tmux" && session.status !== "exited")
       .map(
@@ -561,6 +568,7 @@ export function openTerminalHost(input: OpenTerminalHostInput): TerminalHost {
     if (!registryTouched && durable.length === 0) return;
     registryTouched = true;
     saveTmuxSessionRegistry(registryFilePath, durable);
+    lastPersistedAt = Date.parse(now());
   }
   function frame(session: Session, kind: Frame["kind"], utf8: string, droppedThrough: number | null): Frame {
     session.outputSeq += 1;

--- a/packages/daemon/test/terminal-host.integration.test.ts
+++ b/packages/daemon/test/terminal-host.integration.test.ts
@@ -525,6 +525,45 @@ test("a TMUX registry restores a live session and attach uses the existing names
   }
 });
 
+test("TMUX activity persistence is throttled while termination persists immediately", async () => {
+  const root = mkdtempSync(path.join(tmpdir(), "ha-terminal-activity-throttle-")),
+    live = new Set<string>(),
+    launches: RecordedLaunch[] = [],
+    registry = path.join(root, ".harness", "generated", "terminal-sessions.json");
+  let clock = Date.parse("2026-09-11T00:00:00.000Z");
+  try {
+    const host = openTerminalHost({
+      repoId: "repo-activity",
+      rootDir: root,
+      daemonGeneration: 16,
+      now: () => new Date(clock).toISOString(),
+      tmux: fakeTmuxController(live, []),
+      spawnPty: recordingPtySpawner(launches, live),
+    });
+    const spawned = host.spawn({
+      idempotencyKey: "activity-throttle",
+      backend: "tmux",
+      cwd: { scope: "repo-root" },
+      shellProfileId: "zsh",
+      name: "Activity",
+    });
+    const first = readFileSync(registry, "utf8");
+    const attachment = host.attach(spawned.sessionId!, 0);
+    for (let clientSeq = 1; clientSeq <= 100; clientSeq += 1)
+      host.input({ sessionId: spawned.sessionId!, clientSeq, utf8: "x" });
+    assert.equal(readFileSync(registry, "utf8"), first, "activity writes within 10 seconds must be coalesced");
+    clock += 10_000;
+    host.input({ sessionId: spawned.sessionId!, clientSeq: 101, utf8: "x" });
+    assert.notEqual(readFileSync(registry, "utf8"), first, "activity must persist at the 10 second boundary");
+    host.detach({ sessionId: spawned.sessionId!, attachmentId: attachment.initial.attachmentId as string });
+    host.terminate({ sessionId: spawned.sessionId!, confirmed: true });
+    assert.deepEqual(JSON.parse(readFileSync(registry, "utf8")).sessions, [], "termination must persist immediately");
+    await host.close();
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
 interface RecordedLaunch {
   readonly file: string;
   readonly args: readonly string[] | string;


### PR DESCRIPTION
# English

## Summary

`terminal-host.ts` persisted the whole tmux session registry (`writeFileDurably`: temp file + fsync + rename + directory fsync) on every accepted terminal `input` and every `resize`, although the only state those paths change is `lastActivityAt`. Typing costs two fsyncs per keystroke and a window drag produces a resize storm (perf scan R1-02-F3 + R3-03-F8). The fix-plan asked whether to delete those writes or throttle them; the repository owner ruled on 2026-09-11 for a 10 s throttle after checking the consumers of `lastActivityAt`.

Activity-only persistence is now throttled to one registry write per 10 s using the injected `now()` clock; spawn, terminate/exit, recovery cleanup and close still persist immediately. The consumer audit found no TTL or threshold reader of `lastActivityAt` (GUI list field, restore path, tunnel metadata only).

## Architectural Justification

-

## What Changed

- `terminal-host.ts`: `persistSessions({ activityOnly })`; activity-only calls return early when the last durable write is less than `activityPersistIntervalMs` (10 000 ms) old; `lastPersistedAt` updated after each write. No timer.
- `terminal-host.integration.test.ts`: injected clock; 100 inputs coalesce into one write, the 10 s boundary writes again, terminate writes immediately.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: +12/-4.

## Machine-Readable Declarations

- None (registry format unchanged).

## Task And Scope

- Harness task: task_4d088a4cf1fb64c48ccb514ce1 (fix-plan batch 13, §5 item 3), parent task_2b8f79fa4412cb726a26f9bfc7
- Branch: `codex/terminal-activity-throttle`
- Public scope: terminal registry persistence cadence
- Private planning/evidence updated: yes (task plan with the ruling, `artifacts/report.md` with the consumer audit)
- Out of scope: batching fsync elsewhere (batch 13 other items)

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: not applicable
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `6bcfbbac5`
- Branch merge-base with `origin/main`: `6bcfbbac5`
- Last `git fetch origin` time: 2026-09-11 UTC
- Sync method: branched from origin/main
- Public diff command: `git diff origin/main...codex/terminal-activity-throttle`
- Private evidence commit/path: task_4d088a4cf1fb64c48ccb514ce1 `artifacts/report.md`
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [ ] `npm run typecheck`
- [ ] `npm run check`
- [ ] `npm test`
- [x] `npm run harness:check-import-boundaries` (via `run-manifest-gates --changed origin/main`)
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts` (via `run-manifest-gates --changed origin/main`)
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Isolated: `terminal-host.integration.test.ts` 11 passed (worker). Before: up to 200 fsyncs per 100 inputs; after: at most 2 per 10 s interval for activity-only writes.

## Review Evidence

- CEO ground-truth: read the diff; the throttle only gates `activityOnly` calls and all collection-changing paths still call `persistSessions()` without the flag.
- Reviewer subagent: not used
- Human review: pending
- Blocking findings: none open

## Residual Risk

- After a daemon crash the restored `lastActivityAt` can be up to 10 s stale; no consumer compares it against a threshold.

## References

- Task: task_4d088a4cf1fb64c48ccb514ce1; fix-plan task_6eba9c5d3a55735920aa4856f3 batch 13

---

# 中文

## 概要

`terminal-host.ts` 在每次被接受的终端 `input` 与每次 `resize` 都整表持久化 tmux 会话注册表（`writeFileDurably`：临时文件 + fsync + rename + 目录 fsync），而这两条路径唯一变化的状态是 `lastActivityAt`。打字每键两次 fsync，拖窗口产生 resize 风暴（perf 扫描 R1-02-F3 + R3-03-F8）。fix-plan 问是删这两处写还是节流；仓库所有者 2026-09-11 裁决：核对 `lastActivityAt` 消费方后改 10 s 节流。

仅活动时间变化的持久化现在按注入的 `now()` 时钟节流为每 10 s 一次注册表写入；spawn、terminate/exit、恢复清理与 close 仍立即持久化。消费方核对没有发现任何按阈值比较 `lastActivityAt` 的读方（只有 GUI 列表字段、恢复路径、隧道元数据）。

## 架构辩护

-

## 改动内容

- `terminal-host.ts`：`persistSessions({ activityOnly })`；仅活动写在距上次落盘不足 `activityPersistIntervalMs`（10 000 ms）时直接返回；每次写后更新 `lastPersistedAt`。不引入定时器。
- `terminal-host.integration.test.ts`：注入时钟；100 次 input 合并为一次写，跨 10 s 边界再写，terminate 立即写。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 删除的门或 fixture：none
- 生产净行数：+12/-4。

## 机器可读声明

- 无（注册表格式不变）。

## 任务与范围

- Harness 任务：task_4d088a4cf1fb64c48ccb514ce1（fix-plan 批 13，§5 第 3 项），父任务 task_2b8f79fa4412cb726a26f9bfc7
- 分支：`codex/terminal-activity-throttle`
- 公开范围：终端注册表持久化节奏
- 私有计划/证据已更新：是（含裁决的任务计划、含消费方核对的 `artifacts/report.md`）
- 范围外：其它 fsync 批量化（批 13 其它项）

## 版本影响

- 版本：不变
- 发布影响：不发布

## 治理声明

- 触碰受保护面：否
- 受保护面范围：不适用
- 授权：不适用
- 机器检查边界：本 PR 只断言声明存在；是否属实、是否充分由评审判断。
- Break-glass：否
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- 基线 `origin/main` SHA：`6bcfbbac5`
- 分支与 `origin/main` 的 merge-base：`6bcfbbac5`
- 最近一次 `git fetch origin`：2026-09-11 UTC
- 同步方式：从 origin/main 开分支
- 公开 diff 命令：`git diff origin/main...codex/terminal-activity-throttle`
- 私有证据路径：task_4d088a4cf1fb64c48ccb514ce1 的 `artifacts/report.md`
- 评审证据路径：本 PR 的评审证据节
- GitHub Actions `rewrite-ci` run URL：本 PR 待跑
- 隔离：`terminal-host.integration.test.ts` 11 通过（worker）。改前 100 次 input 最多 200 次 fsync；改后仅活动写每 10 s 最多 2 次。

## 评审证据

- CEO 事实核对：读过 diff；节流只作用于 `activityOnly` 调用，所有集合变化路径仍不带该标志调用 `persistSessions()`。
- 评审子代理：未用
- 人工评审：待定
- 阻塞发现：无

## 残余风险

- daemon 崩溃后恢复的 `lastActivityAt` 最多落后 10 s；没有消费方拿它与阈值比较。

## 参考

- 任务：task_4d088a4cf1fb64c48ccb514ce1；fix-plan task_6eba9c5d3a55735920aa4856f3 批 13
