### PR TITLE
fix: keep request log sinks open instead of open/append/close per line

### DIFF
--- a/packages/daemon/src/request-log.ts
+++ b/packages/daemon/src/request-log.ts
@@ -1,4 +1,4 @@
-import { appendFile, mkdir, rename, rm, stat } from "node:fs/promises";
+import { mkdir, open, rename, rm, type FileHandle } from "node:fs/promises";
 import path from "node:path";
 import { consumeKnownError, resolveHarnessLayout } from "../../kernel/src/index.ts";
 // Classification lives here rather than at the dispatch point: the schema registry names the
@@ -67,6 +67,7 @@ export interface DaemonRequestLogOptions {
   readonly keptFiles?: number;
   readonly now?: () => Date;
   readonly onFailure?: (error: unknown) => void;
+  readonly openFile?: typeof open;
 }
 
 export function daemonRequestLogPath(rootDir: string): string {
@@ -77,9 +78,11 @@ export function openDaemonRequestLog(options: DaemonRequestLogOptions): DaemonRe
   const maxBytes = options.maxBytes ?? defaultMaxBytes;
   const keptFiles = options.keptFiles ?? defaultKeptFiles;
   const now = options.now ?? (() => new Date());
+  const openFile = options.openFile ?? open;
   // resolveHarnessLayout walks the filesystem for harness.yaml; hold the resolved path per repo so
   // that cost is paid once instead of on every request.
   const logPaths = new Map<string, string>();
+  const sinks = new Map<string, { handle: FileHandle; bytes: number }>();
   let reportedFailure = false;
   let chain: Promise<void> = Promise.resolve();
 
@@ -89,20 +92,56 @@ export function openDaemonRequestLog(options: DaemonRequestLogOptions): DaemonRe
       if (!logPath) return;
       chain = chain.then(() => writeRequestLogLine(logPath, `${JSON.stringify(buildRecord(entry, now()))}\n`));
     },
-    settle: () => chain,
+    settle: async () => {
+      let tail: Promise<void>;
+      do {
+        tail = chain;
+        await tail;
+      } while (tail !== chain);
+      chain = chain.then(async () => {
+        for (const [logPath, sink] of sinks) {
+          await closeSink(logPath, sink);
+        }
+      });
+      await chain;
+    },
   };
 
   async function writeRequestLogLine(logPath: string, line: string): Promise<void> {
     try {
-      await mkdir(path.dirname(logPath), { recursive: true });
-      if ((await fileSize(logPath)) >= maxBytes) await rotate(logPath, keptFiles);
-      await appendFile(logPath, line, "utf8");
+      let sink = sinks.get(logPath);
+      if (!sink) sink = await openSink(logPath);
+      if (sink.bytes + Buffer.byteLength(line) > maxBytes) {
+        await closeSink(logPath, sink);
+        await rotate(logPath, keptFiles);
+        sink = await openSink(logPath);
+      }
+      sink.bytes += (await sink.handle.write(line, null, "utf8")).bytesWritten;
     } catch (error) {
       consumeKnownError(error);
+      const sink = sinks.get(logPath);
+      if (sink) await closeSink(logPath, sink);
       if (!reportedFailure) {
         reportedFailure = true;
         (options.onFailure ?? defaultFailureReporter)(error);
       }
+    }
+  }
+
+  async function openSink(logPath: string): Promise<{ handle: FileHandle; bytes: number }> {
+    await mkdir(path.dirname(logPath), { recursive: true });
+    const handle = await openFile(logPath, "a");
+    const sink = { handle, bytes: (await handle.stat()).size };
+    sinks.set(logPath, sink);
+    return sink;
+  }
+
+  async function closeSink(logPath: string, sink: { handle: FileHandle; bytes: number }): Promise<void> {
+    if (sinks.get(logPath) === sink) sinks.delete(logPath);
+    try {
+      await sink.handle.close();
+    } catch (error) {
+      consumeKnownError(error);
     }
   }
 
@@ -169,15 +208,6 @@ async function rotate(logPath: string, keptFiles: number): Promise<void> {
     }
   }
   await rename(logPath, `${logPath}.1`);
-}
-
-async function fileSize(filePath: string): Promise<number> {
-  try {
-    return (await stat(filePath)).size;
-  } catch (error) {
-    if (isMissingFile(error)) return 0;
-    throw error;
-  }
 }
 
 function isMissingFile(error: unknown): boolean {

--- a/packages/daemon/test/request-log.test.ts
+++ b/packages/daemon/test/request-log.test.ts
@@ -1,6 +1,7 @@
 // harness-test-tier: fast
 import assert from "node:assert/strict";
 import { mkdirSync, mkdtempSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
+import { open as openFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -220,6 +221,35 @@ test("rotation holds the log to a bounded number of files", async () => {
   // The newest record survives rotation; the oldest is the one that was dropped.
   const live = readRecords(rootDir);
   assert.equal(live.at(-1)?.opId, "op_399");
+});
+
+test("a repository sink keeps one descriptor for many records and closes it on settle", async () => {
+  const rootDir = tempRoot();
+  const counts = { open: 0, write: 0, close: 0 };
+  const log = openDaemonRequestLog({
+    resolveRootDir: () => rootDir,
+    openFile: async (...args) => {
+      counts.open += 1;
+      const handle = await openFile(...args);
+      const write = handle.write.bind(handle),
+        close = handle.close.bind(handle);
+      handle.write = async (...writeArgs) => {
+        counts.write += 1;
+        return write(...writeArgs);
+      };
+      handle.close = async (...closeArgs) => {
+        counts.close += 1;
+        return close(...closeArgs);
+      };
+      return handle;
+    },
+  });
+  for (let index = 0; index < 100; index += 1) log.record(entry({ opId: `op_${index}` }));
+  await log.settle();
+
+  assert.equal(counts.open, 1);
+  assert.equal(counts.write, 100);
+  assert.equal(counts.close, 1);
 });
 
 test("each repository's requests land in that repository's own log, and a record after settle is still written", async () => {

--- a/tools/gate-allowlists/check-fallback-boundaries.json
+++ b/tools/gate-allowlists/check-fallback-boundaries.json
@@ -145,6 +145,7 @@
       "packages/daemon/src/repo-writer-worker.ts#handleControl",
       "packages/daemon/src/repo-writer-worker.ts#handleRequest",
       "packages/daemon/src/repo-writer-worker.ts#startRepoWriterWorker",
+      "packages/daemon/src/request-log.ts#closeSink",
       "packages/daemon/src/request-log.ts#commandClassOrNull",
       "packages/daemon/src/request-log.ts#rotate",
       "packages/daemon/src/request-log.ts#writeRequestLogLine",


### PR DESCRIPTION
# English

## Summary

The daemon request log wrote every record with `mkdir` + `stat` + `appendFile` — an open/write/close per line, on each of its two sinks (perf scan R3-03-F1). The fix-plan asked whether to merge or drop a sink; the repository owner ruled on 2026-09-11 to keep both sinks and change the writer shape to the persistent file descriptor that `conn-log.ts` already uses.

Each sink now holds an open `FileHandle`, tracks its size in memory for the existing size-based rotation (close → rotate → reopen), and `settle()` drains the write chain and closes every sink; the daemon already calls `settle()` on stop. JSONL format, paths, rotation policy and kept generations are unchanged.

## Architectural Justification

-

## What Changed

- `request-log.ts`: `sinks: Map<path, {handle, bytes}>`; `openSink`/`closeSink`; write failure closes the sink so the next line reopens; `openFile` injectable for tests; `fileSize` removed.
- `request-log.test.ts`: syscall counting — 100 records: before open 100 / write 100 / close 100, after open 1 / write 100 / close 1; rotation still produces `requests.jsonl`, `.1`, `.2`.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: +44/-14 (net +30), from `node tools/gates/production-delta.mjs --base origin/main`.

## Machine-Readable Declarations

- None.

## Task And Scope

- Harness task: task_8242719f8b61d87dd95ac06d1a (fix-plan batch 13, §5 item 4), parent task_2b8f79fa4412cb726a26f9bfc7
- Branch: `codex/request-log-writer`
- Public scope: request-log writer shape
- Private planning/evidence updated: yes (task plan with the ruling, `artifacts/report.md`)
- Out of scope: dispatch-stream append (same shape, separate task); lifecycle-log

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: yes — `tools/gate-allowlists/check-fallback-boundaries.json` gains one entry (`packages/daemon/src/request-log.ts#closeSink`)
- Protected surface scope: allowlists the close-error swallow in the new persistent-sink close path; no gate logic changes
- Authority: task_8242719f8b61d87dd95ac06d1a (fix-plan batch 13, §5 item 4 ruling of 2026-09-11)
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `6bcfbbac5`
- Branch merge-base with `origin/main`: `6bcfbbac5`
- Last `git fetch origin` time: 2026-09-11 UTC
- Sync method: branched from origin/main
- Public diff command: `git diff origin/main...codex/request-log-writer`
- Private evidence commit/path: task_8242719f8b61d87dd95ac06d1a `artifacts/report.md`
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [x] `npm run typecheck`
- [ ] `npm run check`
- [ ] `npm test`
- [x] `npm run harness:check-import-boundaries` (via `run-manifest-gates --changed origin/main`)
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts` (via `run-manifest-gates --changed origin/main`)
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- `request-log.test.ts` 11/11 (worker); the counting assertion is the negative control (the old writer yields open = records).

## Review Evidence

- CEO ground-truth: read the diff; rotation closes before rename and reopens after; a write error closes the sink and reports once; `settle()` closes all handles.
- Reviewer subagent: not used
- Human review: pending
- Blocking findings: none open

## Residual Risk

- A sink's byte counter starts from `stat` at open; an external truncation between rotations is not observed until the next open (same as before for the size check).

## References

- Task: task_8242719f8b61d87dd95ac06d1a; fix-plan task_6eba9c5d3a55735920aa4856f3 batch 13

---

# 中文

## 概要

daemon 的 request log 每条记录都 `mkdir` + `stat` + `appendFile`——每行一次 open/write/close，两个 sink 各来一遍（perf 扫描 R3-03-F1）。fix-plan 问合并还是删一个 sink；仓库所有者 2026-09-11 裁决：保留两个 sink，写手改成 `conn-log.ts` 已有的持 fd 形状。

每个 sink 现在持有一个打开的 `FileHandle`，用内存字节计数做既有的按大小轮转（关闭 → 轮转 → 重开）；`settle()` 排空写链并关闭所有 sink，daemon 停止时已调用 `settle()`。JSONL 格式、路径、轮转策略与保留代数不变。

## 架构辩护

-

## 改动内容

- `request-log.ts`：`sinks: Map<path, {handle, bytes}>`；`openSink`/`closeSink`；写失败关闭 sink，下一行重开；`openFile` 可注入；删除 `fileSize`。
- `request-log.test.ts`：syscall 计数——100 条记录：改前 open 100 / write 100 / close 100，改后 open 1 / write 100 / close 1；轮转仍产出 `requests.jsonl`、`.1`、`.2`。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 删除的门或 fixture：none
- 生产净行数：+44/-14（净 +30），来自 `node tools/gates/production-delta.mjs --base origin/main`。

## 机器可读声明

- 无。

## 任务与范围

- Harness 任务：task_8242719f8b61d87dd95ac06d1a（fix-plan 批 13，§5 第 4 项），父任务 task_2b8f79fa4412cb726a26f9bfc7
- 分支：`codex/request-log-writer`
- 公开范围：request-log 写手形状
- 私有计划/证据已更新：是（含裁决的任务计划、`artifacts/report.md`）
- 范围外：dispatch-stream append（同形，另立）；lifecycle-log

## 版本影响

- 版本：不变
- 发布影响：不发布

## 治理声明

- 触碰受保护面：是——`tools/gate-allowlists/check-fallback-boundaries.json` 新增一条（`packages/daemon/src/request-log.ts#closeSink`）
- 受保护面范围：为新的持久 sink 关闭路径登记关闭错误吞没；门逻辑不变
- 授权：task_8242719f8b61d87dd95ac06d1a（fix-plan 批 13，§5 第 4 项 2026-09-11 裁决）
- 机器检查边界：本 PR 只断言声明存在；是否属实、是否充分由评审判断。
- Break-glass：否
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- 基线 `origin/main` SHA：`6bcfbbac5`
- 分支与 `origin/main` 的 merge-base：`6bcfbbac5`
- 最近一次 `git fetch origin`：2026-09-11 UTC
- 同步方式：从 origin/main 开分支
- 公开 diff 命令：`git diff origin/main...codex/request-log-writer`
- 私有证据路径：task_8242719f8b61d87dd95ac06d1a 的 `artifacts/report.md`
- 评审证据路径：本 PR 的评审证据节
- GitHub Actions `rewrite-ci` run URL：本 PR 待跑
- `request-log.test.ts` 11/11（worker）；计数断言即阴性对照（旧写手 open = 记录数）。

## 评审证据

- CEO 事实核对：读过 diff；轮转先关再 rename 再重开；写错误关闭 sink 并只报告一次；`settle()` 关闭全部句柄。
- 评审子代理：未用
- 人工评审：待定
- 阻塞发现：无

## 残余风险

- sink 的字节计数从打开时的 `stat` 起算；轮转之间的外部截断要到下次打开才被观察到（与之前的大小检查相同）。

## 参考

- 任务：task_8242719f8b61d87dd95ac06d1a；fix-plan task_6eba9c5d3a55735920aa4856f3 批 13
