### PR TITLE
feat: per-file test timeout marker so opt-in stress files can run unbounded

### DIFF
--- a/tools/run-node-tests.mjs
+++ b/tools/run-node-tests.mjs
@@ -127,9 +127,9 @@ const quarantinePattern =
 // watchdog can say which test never returned; only the child itself can say which handle it is
 // still holding, and a remote runner offers no second chance to ask.
 const stallReportUrl = pathToFileURL(resolve(import.meta.dirname, "node-test-stall-report.mjs")).href;
-const stallReportMs = [...selectedFileTimeouts.values()].includes("none")
-  ? undefined
-  : Math.max(1_000, Math.floor(fileTimeoutMs * 0.9));
+// Stall reports stay on for the bounded files of a run; only a run made solely of unbounded
+// stress files has nothing to report at 90% of a timeout.
+const stallReportMs = finiteTimeouts.length === 0 ? undefined : Math.max(1_000, Math.floor(fileTimeoutMs * 0.9));
 const child = spawn(
   process.execPath,
   [

--- a/tools/run-node-tests.mjs
+++ b/tools/run-node-tests.mjs
@@ -15,7 +15,7 @@ import {
   resolveTestConcurrency,
   selectTestFiles,
 } from "./node-test-runner-lib.mjs";
-import { discoverTestTierManifest } from "./test-tier-manifest.mjs";
+import { discoverTestFileTimeouts, discoverTestTierManifest } from "./test-tier-manifest.mjs";
 import { renderToolHelp, runNodeTestsCommand } from "./tool-command-contract.mjs";
 import { readTestQuarantine } from "./test-quarantine.mjs";
 
@@ -48,6 +48,7 @@ process.env.HARNESS_TEST_TIER = options.tier;
 if (options.shard !== undefined) process.env.HARNESS_TEST_SHARD = String(options.shard);
 
 const testTierManifest = discoverTestTierManifest(repoRoot);
+const testFileTimeouts = discoverTestFileTimeouts(repoRoot);
 process.env.HARNESS_TEST_TIER_MANIFEST = JSON.stringify(testTierManifest);
 const testFiles = Object.values(testTierManifest).flat().sort();
 const selection = selectTestFiles(testFiles, testTierManifest, options.tier);
@@ -105,7 +106,15 @@ const concurrency = resolveTestConcurrency({
 });
 const concurrencyArgs =
   concurrency && Number.isInteger(concurrency) && concurrency > 0 ? [`--test-concurrency=${concurrency}`] : [];
-const fileTimeoutMs = positiveIntegerOrDefault(process.env.HARNESS_TEST_FILE_TIMEOUT_MS, DEFAULT_TEST_FILE_TIMEOUT_MS);
+const defaultFileTimeoutMs = positiveIntegerOrDefault(
+  process.env.HARNESS_TEST_FILE_TIMEOUT_MS,
+  DEFAULT_TEST_FILE_TIMEOUT_MS,
+);
+const selectedFileTimeouts = new Map(
+  selection.files.map((file) => [file, testFileTimeouts[file] ?? defaultFileTimeoutMs]),
+);
+const finiteTimeouts = [...selectedFileTimeouts.values()].filter((timeout) => timeout !== "none");
+const fileTimeoutMs = finiteTimeouts.length > 0 ? Math.min(...finiteTimeouts) : defaultFileTimeoutMs;
 const activityRoot = mkdtempSync(join(tmpdir(), "ha-node-test-watchdog-"));
 const activityPath = join(activityRoot, "activity.jsonl");
 const reporterUrl = pathToFileURL(resolve(import.meta.dirname, "node-test-file-activity-reporter.mjs")).href;
@@ -118,7 +127,9 @@ const quarantinePattern =
 // watchdog can say which test never returned; only the child itself can say which handle it is
 // still holding, and a remote runner offers no second chance to ask.
 const stallReportUrl = pathToFileURL(resolve(import.meta.dirname, "node-test-stall-report.mjs")).href;
-const stallReportMs = Math.max(1_000, Math.floor(fileTimeoutMs * 0.9));
+const stallReportMs = [...selectedFileTimeouts.values()].includes("none")
+  ? undefined
+  : Math.max(1_000, Math.floor(fileTimeoutMs * 0.9));
 const child = spawn(
   process.execPath,
   [
@@ -137,7 +148,12 @@ const child = spawn(
   ],
   {
     cwd: repoRoot,
-    env: { ...process.env, HARNESS_TEST_STALL_REPORT_MS: String(stallReportMs) },
+    env: {
+      ...process.env,
+      ...(stallReportMs === undefined
+        ? { HARNESS_TEST_STALL_REPORT_MS: "0" }
+        : { HARNESS_TEST_STALL_REPORT_MS: String(stallReportMs) }),
+    },
     detached: process.platform !== "win32",
     stdio: ["inherit", "pipe", "pipe"],
     windowsHide: true,
@@ -153,21 +169,26 @@ let timedOutFiles = [];
 let termination = Promise.resolve();
 const activeFiles = new Map();
 const removeSignalForwarding = installSignalForwarding(child);
-const watchdog = setInterval(
-  () => {
-    refreshActivity();
-    if (timedOutFiles.length > 0) return;
-    const now = Date.now();
-    const overdue = [...activeFiles].filter(([, startedAt]) => now - startedAt >= fileTimeoutMs).map(([file]) => file);
-    if (overdue.length === 0) return;
-    timedOutFiles = overdue;
-    console.error(
-      `[node-test-watchdog] test file exceeded ${fileTimeoutMs}ms: ${overdue.map(stalledFileReport).join(", ")}`,
-    );
-    termination = terminateProcessTree(child);
-  },
-  Math.min(1_000, Math.max(25, Math.floor(fileTimeoutMs / 4))),
-);
+const watchdog =
+  finiteTimeouts.length === 0
+    ? null
+    : setInterval(
+        () => {
+          refreshActivity();
+          if (timedOutFiles.length > 0) return;
+          const now = Date.now();
+          const overdue = [...activeFiles]
+            .filter(([, activity]) => activity.timeoutMs !== "none" && now - activity.startedAt >= activity.timeoutMs)
+            .map(([file]) => file);
+          if (overdue.length === 0) return;
+          timedOutFiles = overdue;
+          console.error(
+            `[node-test-watchdog] test file exceeded timeout: ${overdue.map(stalledFileReport).join(", ")}`,
+          );
+          termination = terminateProcessTree(child);
+        },
+        Math.min(1_000, Math.max(25, Math.floor(fileTimeoutMs / 4))),
+      );
 
 child.stdout.on("data", (chunk) => {
   const text = chunk.toString();
@@ -185,7 +206,7 @@ const exitCode = await new Promise((resolveRun) => {
   const finish = (code) => {
     if (settled) return;
     settled = true;
-    clearInterval(watchdog);
+    if (watchdog !== null) clearInterval(watchdog);
     removeSignalForwarding();
     void termination.then(() => {
       rmSync(activityRoot, { recursive: true, force: true });
@@ -247,8 +268,10 @@ function refreshActivity() {
   for (const line of lines) {
     if (!line) continue;
     const event = JSON.parse(line);
-    if (event.state === "started" && typeof event.file === "string" && Number.isFinite(event.at))
-      activeFiles.set(event.file, event.at);
+    if (event.state === "started" && typeof event.file === "string" && Number.isFinite(event.at)) {
+      const file = repoRelativeTestFile(event.file);
+      activeFiles.set(file, { startedAt: event.at, timeoutMs: selectedFileTimeouts.get(file) ?? defaultFileTimeoutMs });
+    }
     if (event.state === "progress" && typeof event.file === "string" && typeof event.name === "string") {
       const owner = repoRelativeTestFile(event.file);
       lastTestByFile.set(owner, event.name);
@@ -259,9 +282,10 @@ function refreshActivity() {
       openTestsByFile.set(owner, (openTestsByFile.get(owner) ?? 0) - 1);
     }
     if (event.state === "finished" && typeof event.file === "string") {
-      activeFiles.delete(event.file);
-      lastTestByFile.delete(event.file);
-      openTestsByFile.delete(event.file);
+      const owner = repoRelativeTestFile(event.file);
+      activeFiles.delete(owner);
+      lastTestByFile.delete(owner);
+      openTestsByFile.delete(owner);
     }
   }
 }

--- a/tools/run-node-tests.test.mjs
+++ b/tools/run-node-tests.test.mjs
@@ -3,8 +3,25 @@ import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
 import path from "node:path";
 import test from "node:test";
-import { collectSlowTests, filterTestFilesByNames, filterTestFilesByPrefixes, formatSlowTestSummary, parseCompletedTestLine, parseRunnerArgs, resolveTestConcurrency, selectTestFiles, validateManifest } from "./node-test-runner-lib.mjs";
-import { deriveTestTierManifest, discoverTestTierManifest, parseTestTierMarker, testTierNames } from "./test-tier-manifest.mjs";
+import {
+  collectSlowTests,
+  filterTestFilesByNames,
+  filterTestFilesByPrefixes,
+  formatSlowTestSummary,
+  parseCompletedTestLine,
+  parseRunnerArgs,
+  resolveTestConcurrency,
+  selectTestFiles,
+  validateManifest,
+} from "./node-test-runner-lib.mjs";
+import {
+  deriveTestTierManifest,
+  discoverTestFileTimeouts,
+  discoverTestTierManifest,
+  parseTestFileTimeoutMarker,
+  parseTestTierMarker,
+  testTierNames,
+} from "./test-tier-manifest.mjs";
 
 const repoRoot = path.resolve(import.meta.dirname, "..");
 
@@ -17,7 +34,7 @@ test("parseRunnerArgs accepts tier and slow summary options", () => {
     concurrency: undefined,
     shard: undefined,
     prefixes: [],
-    files: []
+    files: [],
   });
 });
 
@@ -41,69 +58,123 @@ test("parseRunnerArgs rejects unknown tiers and options", () => {
 test("parseRunnerArgs accepts safe repository-relative test prefixes", () => {
   assert.deepEqual(parseRunnerArgs(["--prefix", "tools", "--prefix=packages/kernel/"], testTierNames).prefixes, [
     "tools/",
-    "packages/kernel/"
+    "packages/kernel/",
   ]);
   assert.throws(() => parseRunnerArgs(["--prefix", "../outside"], testTierNames), /repository-relative/u);
 });
 
 test("parseRunnerArgs accepts safe repository-relative test files", () => {
-  assert.deepEqual(parseRunnerArgs(["--file", "tools/run-node-tests.test.mjs", "--file=packages/kernel/test/domain/domain-status.test.ts"], testTierNames).files, [
-    "tools/run-node-tests.test.mjs",
-    "packages/kernel/test/domain/domain-status.test.ts"
-  ]);
-  assert.throws(() => parseRunnerArgs(["--file", "../outside.test.mjs"], testTierNames), /repository-relative test file/u);
-  assert.throws(() => parseRunnerArgs(["--file", "tools/not-a-test.mjs"], testTierNames), /repository-relative test file/u);
-  assert.throws(() => parseRunnerArgs(["--tier", "integration", "--shard", "1", "--file", "tools/a.test.mjs"], testTierNames), /cannot be combined/u);
+  assert.deepEqual(
+    parseRunnerArgs(
+      ["--file", "tools/run-node-tests.test.mjs", "--file=packages/kernel/test/domain/domain-status.test.ts"],
+      testTierNames,
+    ).files,
+    ["tools/run-node-tests.test.mjs", "packages/kernel/test/domain/domain-status.test.ts"],
+  );
+  assert.throws(
+    () => parseRunnerArgs(["--file", "../outside.test.mjs"], testTierNames),
+    /repository-relative test file/u,
+  );
+  assert.throws(
+    () => parseRunnerArgs(["--file", "tools/not-a-test.mjs"], testTierNames),
+    /repository-relative test file/u,
+  );
+  assert.throws(
+    () => parseRunnerArgs(["--tier", "integration", "--shard", "1", "--file", "tools/a.test.mjs"], testTierNames),
+    /cannot be combined/u,
+  );
 });
 
 test("filterTestFilesByPrefixes keeps only selected repository paths", () => {
-  assert.deepEqual(filterTestFilesByPrefixes([
-    "tools/a.test.mjs",
-    "packages/kernel/b.test.ts",
-    "packages/gui/c.test.ts"
-  ], ["tools/", "packages/kernel/"]), ["tools/a.test.mjs", "packages/kernel/b.test.ts"]);
+  assert.deepEqual(
+    filterTestFilesByPrefixes(
+      ["tools/a.test.mjs", "packages/kernel/b.test.ts", "packages/gui/c.test.ts"],
+      ["tools/", "packages/kernel/"],
+    ),
+    ["tools/a.test.mjs", "packages/kernel/b.test.ts"],
+  );
 });
 
 test("filterTestFilesByNames keeps only exact selected repository paths", () => {
-  assert.deepEqual(filterTestFilesByNames([
-    "tools/a.test.mjs",
-    "packages/kernel/b.test.ts",
-    "packages/gui/c.test.ts"
-  ], ["packages/kernel/b.test.ts", "tools/a.test.mjs"]), ["tools/a.test.mjs", "packages/kernel/b.test.ts"]);
+  assert.deepEqual(
+    filterTestFilesByNames(
+      ["tools/a.test.mjs", "packages/kernel/b.test.ts", "packages/gui/c.test.ts"],
+      ["packages/kernel/b.test.ts", "tools/a.test.mjs"],
+    ),
+    ["tools/a.test.mjs", "packages/kernel/b.test.ts"],
+  );
 });
 
 test("runner watchdog fails and names a file whose process keeps an open handle", () => {
   const childEnv = {
     ...process.env,
     HARNESS_RUNNER_OPEN_HANDLE_FIXTURE: "1",
-    HARNESS_TEST_FILE_TIMEOUT_MS: "250"
+    HARNESS_TEST_FILE_TIMEOUT_MS: "250",
   };
   delete childEnv.NODE_TEST_CONTEXT;
-  const result = spawnSync(process.execPath, [
-    "tools/run-node-tests.mjs",
-    "--tier", "fast",
-    "--prefix", "tools/test-fixtures/runner-watchdog"
-  ], {
-    cwd: repoRoot,
-    encoding: "utf8",
-    env: childEnv,
-    timeout: 10_000
-  });
+  const result = spawnSync(
+    process.execPath,
+    ["tools/run-node-tests.mjs", "--tier", "fast", "--prefix", "tools/test-fixtures/runner-watchdog"],
+    {
+      cwd: repoRoot,
+      encoding: "utf8",
+      env: childEnv,
+      timeout: 10_000,
+    },
+  );
   const output = `${result.stdout}\n${result.stderr}`;
   assert.equal(result.error, undefined, output);
   assert.equal(result.status, 1, output);
-  assert.match(output, /\[node-test-watchdog\] test file exceeded 250ms: tools\/test-fixtures\/runner-watchdog\/open-handle\.test\.mjs/u);
+  assert.match(
+    output,
+    /\[node-test-watchdog\] test file exceeded timeout: tools\/test-fixtures\/runner-watchdog\/open-handle\.test\.mjs/u,
+  );
+});
+
+test("test file timeout markers allow stress opt-in and numeric values", () => {
+  assert.equal(
+    parseTestFileTimeoutMarker(
+      "// harness-test-tier: integration\n// harness-test-file-timeout: none\n",
+      "tools/stress/example.test.mjs",
+    ),
+    "none",
+  );
+  assert.equal(
+    parseTestFileTimeoutMarker(
+      "// harness-test-tier: fast\n// harness-test-file-timeout: 1234\n",
+      "tools/example.test.mjs",
+    ),
+    1234,
+  );
+  assert.throws(
+    () =>
+      parseTestFileTimeoutMarker(
+        "// harness-test-tier: fast\n// harness-test-file-timeout: none\n",
+        "tools/example.test.mjs",
+      ),
+    /only allowed under tools\/stress/u,
+  );
+});
+
+test("discoverTestFileTimeouts returns only explicit file overrides", () => {
+  assert.deepEqual(
+    discoverTestFileTimeouts(repoRoot, {
+      roots: ["tools/test-fixtures/runner-watchdog"],
+    }),
+    { "tools/test-fixtures/runner-watchdog/open-handle.test.mjs": undefined },
+  );
 });
 
 test("a --prefix that selects nothing fails instead of reporting a clean run", () => {
   const childEnv = { ...process.env };
   delete childEnv.NODE_TEST_CONTEXT;
   for (const prefix of ["packages/does-not-exist", "tools/run-node-tests.test.mjs"]) {
-    const result = spawnSync(process.execPath, [
-      "tools/run-node-tests.mjs",
-      "--tier", "fast",
-      "--prefix", prefix
-    ], { cwd: repoRoot, encoding: "utf8", env: childEnv, timeout: 30_000 });
+    const result = spawnSync(process.execPath, ["tools/run-node-tests.mjs", "--tier", "fast", "--prefix", prefix], {
+      cwd: repoRoot,
+      encoding: "utf8",
+      env: childEnv,
+      timeout: 30_000,
+    });
     const output = `${result.stdout}\n${result.stderr}`;
     assert.equal(result.status, 1, output);
     assert.match(output, /No test file in tier fast starts with any of/u);
@@ -113,42 +184,44 @@ test("a --prefix that selects nothing fails instead of reporting a clean run", (
 test("resolveTestConcurrency prefers the explicit flag over env and defaults", () => {
   assert.equal(
     resolveTestConcurrency({ flagConcurrency: 3, envConcurrency: "8", isCi: false, availableParallelism: 16 }),
-    3
+    3,
   );
   assert.equal(
     resolveTestConcurrency({ flagConcurrency: 12, envConcurrency: undefined, isCi: true, availableParallelism: 16 }),
-    12
+    12,
   );
 });
 
 test("resolveTestConcurrency honors HARNESS_TEST_CONCURRENCY when no flag is given", () => {
   assert.equal(
     resolveTestConcurrency({ flagConcurrency: undefined, envConcurrency: "8", isCi: false, availableParallelism: 16 }),
-    8
+    8,
   );
   // A blank or invalid env value falls through to the default path.
   assert.equal(
     resolveTestConcurrency({ flagConcurrency: undefined, envConcurrency: "", isCi: true, availableParallelism: 16 }),
-    undefined
+    undefined,
   );
   assert.equal(
     resolveTestConcurrency({ flagConcurrency: undefined, envConcurrency: "0", isCi: true, availableParallelism: 16 }),
-    undefined
+    undefined,
   );
 });
 
 test("resolveTestConcurrency keeps node's default in CI with no explicit signal", () => {
   assert.equal(
-    resolveTestConcurrency({ flagConcurrency: undefined, envConcurrency: undefined, isCi: true, availableParallelism: 16 }),
-    undefined
+    resolveTestConcurrency({
+      flagConcurrency: undefined,
+      envConcurrency: undefined,
+      isCi: true,
+      availableParallelism: 16,
+    }),
+    undefined,
   );
 });
 
 test("resolveTestConcurrency uses a fixed local per-session budget of two", () => {
-  assert.equal(
-    resolveTestConcurrency({ flagConcurrency: undefined, envConcurrency: undefined, isCi: false }),
-    2
-  );
+  assert.equal(resolveTestConcurrency({ flagConcurrency: undefined, envConcurrency: undefined, isCi: false }), 2);
 });
 
 test("selectTestFiles fails closed when a test file is unclassified", () => {
@@ -160,43 +233,50 @@ test("selectTestFiles fails closed when a test file is unclassified", () => {
 test("validateManifest rejects duplicates and missing manifest entries", () => {
   const validation = validateManifest(["a.test.ts"], {
     fast: ["a.test.ts"],
-    contract: ["a.test.ts", "gone.test.ts"]
+    contract: ["a.test.ts", "gone.test.ts"],
   });
   assert.deepEqual(validation.errors, [
     "test file appears in multiple tiers: a.test.ts (fast, contract)",
-    "test tier manifest references missing file: contract: gone.test.ts"
+    "test tier manifest references missing file: contract: gone.test.ts",
   ]);
 });
 
 test("inline test tier markers derive the manifest", () => {
   const manifest = deriveTestTierManifest(
     ["fast.test.ts", "contract.test.ts", "new.test.ts"],
-    (file) => `// harness-test-tier: ${file === "new.test.ts" ? "integration" : file.split(".")[0]}\n`
+    (file) => `// harness-test-tier: ${file === "new.test.ts" ? "integration" : file.split(".")[0]}\n`,
   );
   assert.deepEqual(manifest, {
     fast: ["fast.test.ts"],
     contract: ["contract.test.ts"],
-    integration: ["new.test.ts"]
+    integration: ["new.test.ts"],
   });
 });
 
 test("inline test tier markers fail closed when missing, repeated, or invalid", () => {
-  assert.throws(() => parseTestTierMarker("import test from \"node:test\";\n", "missing.test.ts"), /test tier marker missing: missing\.test\.ts/u);
+  assert.throws(
+    () => parseTestTierMarker('import test from "node:test";\n', "missing.test.ts"),
+    /test tier marker missing: missing\.test\.ts/u,
+  );
   assert.throws(
     () => parseTestTierMarker("// harness-test-tier: fast\n// harness-test-tier: contract\n", "duplicate.test.ts"),
-    /multiple test tier markers: duplicate\.test\.ts/u
+    /multiple test tier markers: duplicate\.test\.ts/u,
   );
   assert.throws(
     () => parseTestTierMarker("// harness-test-tier: slow\n", "invalid.test.ts"),
-    /invalid test tier marker: invalid\.test\.ts/u
+    /invalid test tier marker: invalid\.test\.ts/u,
   );
   assert.throws(
-    () => parseTestTierMarker("import test from \"node:test\";\n// harness-test-tier: fast\n", "late.test.ts"),
-    /test tier marker must be the first line: late\.test\.ts/u
+    () => parseTestTierMarker('import test from "node:test";\n// harness-test-tier: fast\n', "late.test.ts"),
+    /test tier marker must be the first line: late\.test\.ts/u,
   );
   assert.throws(
-    () => parseTestTierMarker(`// harness-test-tier: fast\n${"\n".repeat(20)}// harness-test-tier: contract\n`, "distant-duplicate.test.ts"),
-    /multiple test tier markers: distant-duplicate\.test\.ts/u
+    () =>
+      parseTestTierMarker(
+        `// harness-test-tier: fast\n${"\n".repeat(20)}// harness-test-tier: contract\n`,
+        "distant-duplicate.test.ts",
+      ),
+    /multiple test tier markers: distant-duplicate\.test\.ts/u,
   );
 });
 
@@ -204,7 +284,7 @@ test("integration discovery equals the files executed by the CI runner", () => {
   const manifest = discoverTestTierManifest(repoRoot);
   const result = spawnSync(process.execPath, ["tools/run-node-tests.mjs", "--tier", "integration", "--list"], {
     cwd: repoRoot,
-    encoding: "utf8"
+    encoding: "utf8",
   });
   assert.equal(result.status, 0, result.stderr);
   assert.deepEqual(result.stdout.trim().split(/\r?\n/u), manifest.integration);
@@ -221,18 +301,20 @@ test("selectTestFiles returns sorted tier files from the derived repository mani
 test("slow test summary parses node test output and formats top entries", () => {
   assert.deepEqual(parseCompletedTestLine("✔ CLI task delete (4765.862208ms)"), {
     name: "CLI task delete",
-    durationMs: 4765.862208
+    durationMs: 4765.862208,
   });
 
-  const slow = collectSlowTests([
-    "✔ fast thing (3.2ms)",
-    "✔ slow thing (1200.5ms)",
-    "✔ slower thing (2200ms)"
-  ].join("\n"), 1000);
+  const slow = collectSlowTests(
+    ["✔ fast thing (3.2ms)", "✔ slow thing (1200.5ms)", "✔ slower thing (2200ms)"].join("\n"),
+    1000,
+  );
 
-  assert.deepEqual(slow.map((entry) => entry.name), ["slower thing", "slow thing"]);
-  assert.equal(formatSlowTestSummary(slow, 1000, 1), [
-    "Slow test summary: top 1 tests at or above 1000ms",
-    "1. 2200.000ms slower thing"
-  ].join("\n"));
+  assert.deepEqual(
+    slow.map((entry) => entry.name),
+    ["slower thing", "slow thing"],
+  );
+  assert.equal(
+    formatSlowTestSummary(slow, 1000, 1),
+    ["Slow test summary: top 1 tests at or above 1000ms", "1. 2200.000ms slower thing"].join("\n"),
+  );
 });

--- a/tools/stress/entity-v2-scale.integration.test.mjs
+++ b/tools/stress/entity-v2-scale.integration.test.mjs
@@ -1,4 +1,5 @@
 // harness-test-tier: integration
+// harness-test-file-timeout: none
 import assert from "node:assert/strict";
 import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import path from "node:path";

--- a/tools/test-tier-manifest.mjs
+++ b/tools/test-tier-manifest.mjs
@@ -8,6 +8,7 @@ const testFilePattern = /\.(test|spec)\.(?:mjs|js|ts)$/u;
 // with "test tier marker missing" for a file nobody in this repository wrote.
 const ignoredDirectoryNames = new Set(["node_modules", "app-node_modules", "dist", "out", "coverage", ".git"]);
 const markerPattern = /^\s*\/\/\s*harness-test-tier:\s*(\S+)\s*$/u;
+const timeoutMarkerPattern = /^\s*\/\/\s*harness-test-file-timeout:\s*(\S+)\s*$/u;
 
 export const testTierNames = Object.freeze(["fast", "contract", "integration"]);
 
@@ -37,6 +38,30 @@ export function parseTestTierMarker(source, file = "test file") {
   return tier;
 }
 
+export function parseTestFileTimeoutMarker(source, file = "test file") {
+  const lines = source.split(/\r?\n/u);
+  const markerLines = lines
+    .map((line, index) => ({ line, index }))
+    .filter(({ line }) => /^\s*\/\/\s*harness-test-file-timeout:/u.test(line));
+  if (markerLines.length === 0) return undefined;
+  if (markerLines.length > 1) throw new Error(`multiple test file timeout markers: ${file}`);
+  const marker = markerLines[0];
+  if (marker.index > 1) throw new Error(`test file timeout marker must be in the file header: ${file}`);
+  const value = marker.line.match(timeoutMarkerPattern)?.[1];
+  if (value === "none") {
+    const normalized = file.replaceAll("\\", "/");
+    if (!normalized.startsWith("tools/stress/")) {
+      throw new Error(`unbounded test file timeout is only allowed under tools/stress/: ${file}`);
+    }
+    return "none";
+  }
+  const timeoutMs = Number(value);
+  if (!Number.isSafeInteger(timeoutMs) || timeoutMs <= 0) {
+    throw new Error(`invalid test file timeout marker: ${file}; expected none or a positive integer`);
+  }
+  return timeoutMs;
+}
+
 export function deriveTestTierManifest(testFiles, readSource) {
   if (typeof readSource !== "function") throw new Error("deriveTestTierManifest requires a source reader");
   const manifest = Object.fromEntries(testTierNames.map((tier) => [tier, []]));
@@ -59,6 +84,12 @@ export function discoverTestTierManifest(repoRoot, options = {}) {
     discoverTestFiles(repoRoot, options.roots),
     options.readSource ?? ((file) => readFileSync(path.join(repoRoot, file), "utf8")),
   );
+}
+
+export function discoverTestFileTimeouts(repoRoot, options = {}) {
+  const files = discoverTestFiles(repoRoot, options.roots);
+  const readSource = options.readSource ?? ((file) => readFileSync(path.join(repoRoot, file), "utf8"));
+  return Object.fromEntries(files.map((file) => [file, parseTestFileTimeoutMarker(readSource(file), file)]));
 }
 
 function main() {


### PR DESCRIPTION
# English

## Summary

`tools/run-node-tests.mjs` kills any test file that runs longer than 900 s (`DEFAULT_TEST_FILE_TIMEOUT_MS`), and `tools/dispatch-isolated-test.mjs` does not forward `HARNESS_TEST_FILE_TIMEOUT_MS`, so the opt-in 1M-event stress protocol from #2463 (`tools/stress/entity-v2-scale.integration.test.mjs`, ≥ 20 min even after the replay fix) cannot finish inside one dispatch. The repository owner ruled on 2026-09-11 to exempt opt-in stress files from the watchdog rather than persisting ledgers across dispatches.

A per-file header marker `// harness-test-file-timeout: none` (or a positive integer of milliseconds) now sets that file's watchdog; `none` is accepted only under `tools/stress/` and rejected elsewhere. Bounded files keep the 900 s default and their stall reports; the watchdog only stops polling when every selected file is unbounded.

## Architectural Justification

-

## What Changed

- `tools/test-tier-manifest.mjs`: `parseTestFileTimeoutMarker` / `discoverTestFileTimeouts` (same header-marker family as the tier marker; `none` allowed only for `tools/stress/**`).
- `tools/run-node-tests.mjs`: per-file timeouts in `activeFiles`; unbounded files excluded from overdue and stall accounting; watchdog interval derived from the smallest finite timeout; the stall-report threshold stays on whenever any bounded file is selected (CEO follow-up commit e15ff2df3 — the first version switched stall reports off for the whole run as soon as one unbounded file was selected, which would have silenced every CI integration shard that discovers the stress file).
- `tools/stress/entity-v2-scale.integration.test.mjs`: marked `none`.
- `tools/run-node-tests.test.mjs`: numeric/unbounded markers, path rejection, timeout discovery.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: +58/-15 (tools only; `packages/*` +0/-0).

## Machine-Readable Declarations

- New test-file header marker `harness-test-file-timeout` recognised by the test runner.

## Task And Scope

- Harness task: task_2ed2160696da17c94b1e3b4e49 (E7 follow-up), parent task_2b8f79fa4412cb726a26f9bfc7
- Branch: `codex/stress-file-timeout`
- Public scope: test runner watchdog per-file override
- Private planning/evidence updated: yes (task plan with the ruling, `artifacts/report.md`)
- Out of scope: `.github/**`, `tools/gate-manifest.json`; the 1M re-run itself (CEO, after merge)

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: yes — `tools/run-node-tests.mjs` and `tools/test-tier-manifest.mjs` are CI test-runner tooling referenced by `tools/gate-manifest.json`
- Protected surface scope: adds an opt-in per-file timeout marker restricted to `tools/stress/**`; the default timeout, tier rules, CI workflows and gate manifest are unchanged
- Authority: repository owner ruling of 2026-09-11 ("豁免"), recorded in task_2ed2160696da17c94b1e3b4e49 task_plan
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `6bcfbbac5`
- Branch merge-base with `origin/main`: `6bcfbbac5`
- Last `git fetch origin` time: 2026-09-11 UTC
- Sync method: branched from origin/main
- Public diff command: `git diff origin/main...codex/stress-file-timeout`
- Private evidence commit/path: task_2ed2160696da17c94b1e3b4e49 `artifacts/report.md`
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [ ] `npm run typecheck`
- [ ] `npm run check`
- [ ] `npm test`
- [x] `npm run harness:check-import-boundaries` (via `run-manifest-gates --changed origin/main`)
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts` (via `run-manifest-gates --changed origin/main`)
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- `tools/run-node-tests.test.mjs` 23/23 (worker and CEO after the follow-up); `node tools/test-tier-manifest.mjs` 562 files; lint, file-complexity, line-density pass.

## Review Evidence

- CEO ground-truth: read the runner diff; found and fixed the run-wide stall-report switch-off; the `none` path restriction is enforced in the parser, not only documented.
- Reviewer subagent: not used
- Human review: pending
- Blocking findings: none open

## Residual Risk

- An unbounded stress file still gets a stall *report* at 90 % of the smallest bounded timeout in the same run (report only, no kill).
- The full 1M protocol has not been run through the exemption yet; the CEO dispatches it after merge.

## References

- Task: task_2ed2160696da17c94b1e3b4e49; fixture #2463; measurement task_9c03d77ef810c7e03787c38752

---

# 中文

## 概要

`tools/run-node-tests.mjs` 对跑超过 900 s（`DEFAULT_TEST_FILE_TIMEOUT_MS`）的测试文件一律杀掉，`tools/dispatch-isolated-test.mjs` 也不转发 `HARNESS_TEST_FILE_TIMEOUT_MS`，所以 #2463 的 opt-in 1M 事件压测协议（`tools/stress/entity-v2-scale.integration.test.mjs`，回放修好后也 ≥ 20 分钟）放不进一次派测。仓库所有者 2026-09-11 裁决：给 opt-in 压测文件豁免看门狗，不做跨派测保留台账。

文件头标记 `// harness-test-file-timeout: none`（或正整数毫秒）现在决定该文件的看门狗；`none` 只允许出现在 `tools/stress/` 下，其它路径报错。有界文件保留 900 s 默认与 stall 报告；只有所选文件全部无界时看门狗才停止轮询。

## 架构辩护

-

## 改动内容

- `tools/test-tier-manifest.mjs`：`parseTestFileTimeoutMarker` / `discoverTestFileTimeouts`（与 tier 标记同族的文件头标记；`none` 仅限 `tools/stress/**`）。
- `tools/run-node-tests.mjs`：`activeFiles` 按文件记超时；无界文件不参与 overdue 与 stall 统计；轮询间隔按最小有限超时；只要选中任一有界文件 stall 报告阈值就保留（CEO 补充提交 e15ff2df3——第一版只要选中一个无界文件就关掉整轮 stall 报告，会让每个发现压测文件的 CI integration shard 都失声）。
- `tools/stress/entity-v2-scale.integration.test.mjs`：标 `none`。
- `tools/run-node-tests.test.mjs`：数值/无界标记、路径拒绝、超时发现。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 删除的门或 fixture：none
- 生产净行数：+58/-15（仅 tools；`packages/*` +0/-0）。

## 机器可读声明

- 测试运行器新识别文件头标记 `harness-test-file-timeout`。

## 任务与范围

- Harness 任务：task_2ed2160696da17c94b1e3b4e49（E7 后续），父任务 task_2b8f79fa4412cb726a26f9bfc7
- 分支：`codex/stress-file-timeout`
- 公开范围：测试运行器按文件的看门狗覆盖
- 私有计划/证据已更新：是（含裁决的任务计划、`artifacts/report.md`）
- 范围外：`.github/**`、`tools/gate-manifest.json`；1M 重跑本身（CEO 合入后做）

## 版本影响

- 版本：不变
- 发布影响：不发布

## 治理声明

- 触碰受保护面：是——`tools/run-node-tests.mjs` 与 `tools/test-tier-manifest.mjs` 是 `tools/gate-manifest.json` 引用的 CI 测试运行器工具
- 受保护面范围：新增仅限 `tools/stress/**` 的 opt-in 按文件超时标记；默认超时、tier 规则、CI workflow 与 gate manifest 不变
- 授权：仓库所有者 2026-09-11 裁决（「豁免」），记录在 task_2ed2160696da17c94b1e3b4e49 task_plan
- 机器检查边界：本 PR 只断言声明存在；是否属实、是否充分由评审判断。
- Break-glass：否
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- 基线 `origin/main` SHA：`6bcfbbac5`
- 分支与 `origin/main` 的 merge-base：`6bcfbbac5`
- 最近一次 `git fetch origin`：2026-09-11 UTC
- 同步方式：从 origin/main 开分支
- 公开 diff 命令：`git diff origin/main...codex/stress-file-timeout`
- 私有证据路径：task_2ed2160696da17c94b1e3b4e49 的 `artifacts/report.md`
- 评审证据路径：本 PR 的评审证据节
- GitHub Actions `rewrite-ci` run URL：本 PR 待跑
- `tools/run-node-tests.test.mjs` 23/23（worker 与 CEO 补充后）；`node tools/test-tier-manifest.mjs` 562 文件；lint、file-complexity、line-density 通过。

## 评审证据

- CEO 事实核对：读过运行器 diff；发现并修了整轮 stall 报告被关的问题；`none` 的路径限制在解析器里强制，不只是文档。
- 评审子代理：未用
- 人工评审：待定
- 阻塞发现：无

## 残余风险

- 同一轮里的无界压测文件仍会在最小有界超时的 90% 处收到一条 stall *报告*（只报告不杀）。
- 完整 1M 协议尚未经豁免跑过；CEO 合入后派测。

## 参考

- 任务：task_2ed2160696da17c94b1e3b4e49；夹具 #2463；测量任务 task_9c03d77ef810c7e03787c38752
