### PR TITLE
fix(scale): align the B5 harness with current projection contracts and record the 10k baseline

### DIFF
--- a/tools/scale/b5-real.mjs
+++ b/tools/scale/b5-real.mjs
@@ -175,6 +175,7 @@ async function measureB5RealSingle(options) {
       taskId,
       title,
       taskClass: "standard",
+      packageDisposition: "active",
       status: "planned",
       graph: kernel.REPLAY_TASK_GRAPH,
       currentNode: "implementation",
@@ -423,12 +424,7 @@ async function measureB5RealSingle(options) {
     if (!(error instanceof Error) || !/catch-up limit/u.test(error.message)) throw error;
     projection = makeTaskProjection({ rootDir, eventStore, catchUpLimit: 64 });
   }
-  // Drive the catch-up with the cheap progress probe: each round drains a bounded
-  // batch, and a full list() per round would itself be an O(rounds x rows) scan.
-  let reads = 0;
-  while (projection.readProgress(taskIds[0]).status !== "ready" && reads < events.length / 64 + 16) reads += 1;
-  if (projection.readProgress(taskIds[0]).status !== "ready")
-    throw new Error(`cold catch-up did not reach ready after ${events.length} events`);
+  const catchUp = projection.catchUp();
   const catchUpMs = performance.now() - projectionStarted,
     buildMs = performance.now() - buildStarted;
 
@@ -448,7 +444,7 @@ async function measureB5RealSingle(options) {
   const windowStart = new Date(Date.UTC(2026, 0, 10)).toISOString();
 
   const unparamTask = () => readModel.guiTasks();
-  const unparamGraph = () => readModel.relationGraph();
+  const unparamGraph = () => readModel.relationGraphFacet({ facet: "edges" });
   const factRead = (action) => {
     if (!catalogActions) return projection.searchFacts(action);
     const receipt = catalogActions.run(
@@ -546,7 +542,7 @@ async function measureB5RealSingle(options) {
       buildMs: Number(buildMs.toFixed(1)),
       ledgerBuildMs: Number(ledgerBuiltMs.toFixed(1)),
       catchUpMs: Number(catchUpMs.toFixed(1)),
-      catchUpReads: reads,
+      catchUpReads: catchUp.metrics.sqliteTransactions,
       narrowSupported,
     },
     sentinel,

--- a/tools/scale/measure.mjs
+++ b/tools/scale/measure.mjs
@@ -12,7 +12,17 @@
  * explicit.
  */
 
-import { existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync, openSync, closeSync, fsyncSync, unlinkSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  writeFileSync,
+  openSync,
+  closeSync,
+  fsyncSync,
+  unlinkSync,
+} from "node:fs";
 import { join, resolve, relative } from "node:path";
 import { availableParallelism, cpus, freemem, loadavg, totalmem } from "node:os";
 import { spawnSync } from "node:child_process";
@@ -20,10 +30,23 @@ import { performance } from "node:perf_hooks";
 import { measureB5Real } from "./b5-real.mjs";
 
 function parseArgs(argv) {
-  const result = { fixtures: [], rounds: 2, jsonOut: null, markdownOut: null, reportFile: null, hotSamples: 100, sections: new Set(["b2", "b3", "b5", "b6"]) };
+  const result = {
+    fixtures: [],
+    rounds: 2,
+    jsonOut: null,
+    markdownOut: null,
+    reportFile: null,
+    hotSamples: 100,
+    sections: new Set(["b2", "b3", "b5", "b6"]),
+  };
   for (let i = 0; i < argv.length; i += 1) {
     const key = argv[i];
-    if (key === "--help" || key === "-h") { console.log("Usage: node tools/scale/measure.mjs --fixtures PATH[,PATH] [--rounds 2] [--json-out PATH] [--markdown-out PATH] [--report-file PATH]"); process.exit(0); }
+    if (key === "--help" || key === "-h") {
+      console.log(
+        "Usage: node tools/scale/measure.mjs --fixtures PATH[,PATH] [--rounds 2] [--json-out PATH] [--markdown-out PATH] [--report-file PATH]",
+      );
+      process.exit(0);
+    }
     const value = argv[++i];
     if (key === "--fixtures" || key === "--fixture") result.fixtures.push(...value.split(",").filter(Boolean));
     else if (key === "--rounds") result.rounds = Number(value);
@@ -60,11 +83,36 @@ function percentile(values, p) {
   return sorted[index];
 }
 
-function stats(values) { return { count: values.length, minMs: percentile(values, 0), p50Ms: percentile(values, 50), p95Ms: percentile(values, 95), maxMs: percentile(values, 100), meanMs: values.length ? values.reduce((a, b) => a + b, 0) / values.length : null }; }
-function elapsed(start) { return Number((performance.now() - start).toFixed(3)); }
-function rssMb() { return Number((process.memoryUsage().rss / 1024 / 1024).toFixed(2)); }
-function loadSnapshot() { const loads = loadavg(); return { load1: Number(loads[0].toFixed(2)), load5: Number(loads[1].toFixed(2)), cpuCount: cpus().length, parallelism: availableParallelism(), freeMemoryMb: Number((freemem() / 1024 / 1024).toFixed(1)), totalMemoryMb: Number((totalmem() / 1024 / 1024).toFixed(1)) }; }
-function sleepTick() { return new Promise((resolvePromise) => setImmediate(resolvePromise)); }
+function stats(values) {
+  return {
+    count: values.length,
+    minMs: percentile(values, 0),
+    p50Ms: percentile(values, 50),
+    p95Ms: percentile(values, 95),
+    maxMs: percentile(values, 100),
+    meanMs: values.length ? values.reduce((a, b) => a + b, 0) / values.length : null,
+  };
+}
+function elapsed(start) {
+  return Number((performance.now() - start).toFixed(3));
+}
+function rssMb() {
+  return Number((process.memoryUsage().rss / 1024 / 1024).toFixed(2));
+}
+function loadSnapshot() {
+  const loads = loadavg();
+  return {
+    load1: Number(loads[0].toFixed(2)),
+    load5: Number(loads[1].toFixed(2)),
+    cpuCount: cpus().length,
+    parallelism: availableParallelism(),
+    freeMemoryMb: Number((freemem() / 1024 / 1024).toFixed(1)),
+    totalMemoryMb: Number((totalmem() / 1024 / 1024).toFixed(1)),
+  };
+}
+function sleepTick() {
+  return new Promise((resolvePromise) => setImmediate(resolvePromise));
+}
 
 function metadata(fixture) {
   const path = join(fixture, "fixture-metadata.json");
@@ -81,15 +129,30 @@ async function rebuild(fixture, files) {
   for (let index = 0; index < events.length; index += 1) {
     const event = JSON.parse(readFileSync(events[index], "utf8"));
     const current = tasks.get(event.taskId) ?? { taskId: event.taskId, events: 0, lastType: null };
-    current.events += 1; current.lastType = event.type; tasks.set(event.taskId, current);
-    if (event.payload?.relation) relations.push({ source: event.payload.relation, target: event.taskId, type: event.type });
-    if (index % 2000 === 0) { peak = Math.max(peak, rssMb()); await sleepTick(); }
+    current.events += 1;
+    current.lastType = event.type;
+    tasks.set(event.taskId, current);
+    if (event.payload?.relation)
+      relations.push({ source: event.payload.relation, target: event.taskId, type: event.type });
+    if (index % 2000 === 0) {
+      peak = Math.max(peak, rssMb());
+      await sleepTick();
+    }
   }
   peak = Math.max(peak, rssMb());
-  return { wallClockMs: elapsed(start), peakRssMb: peak, eventsReplayed: events.length, taskRows: tasks.size, relationRows: relations.length, rssDeltaMb: Number((peak - rssMb()).toFixed(2)) };
+  return {
+    wallClockMs: elapsed(start),
+    peakRssMb: peak,
+    eventsReplayed: events.length,
+    taskRows: tasks.size,
+    relationRows: relations.length,
+    rssDeltaMb: Number((peak - rssMb()).toFixed(2)),
+  };
 }
 
-function eventPaths(fixture, files) { return files.filter((path) => path.includes(`${join("harness", "events")}/`) && path.endsWith(".json")); }
+function eventPaths(fixture, files) {
+  return files.filter((path) => path.includes(`${join("harness", "events")}/`) && path.endsWith(".json"));
+}
 
 function hotWrite(fixture, paths, samples) {
   const git = spawnSync("git", ["-C", fixture, "init", "--quiet"], { encoding: "utf8" });
@@ -104,14 +167,25 @@ function hotWrite(fixture, paths, samples) {
     const start = performance.now();
     const fd = openSync(hotPath, "w");
     writeFileSync(fd, payload);
-    fsyncSync(fd); closeSync(fd);
+    fsyncSync(fd);
+    closeSync(fd);
     const result = spawnSync("git", ["-C", fixture, "hash-object", "--stdin"], { input: payload, encoding: "utf8" });
     subprocesses += 1;
     if (result.status !== 0) throw new Error(`git hash-object failed: ${result.stderr}`);
     latencies.push(elapsed(start));
   }
-  try { unlinkSync(hotPath); } catch { /* fixture cleanup is best effort */ }
-  return { samples, gitSubprocesses: subprocesses, gitSubprocessesPerEvent: subprocesses / samples, hotWriteLatencyMs: stats(latencies), instrument: "one git hash-object subprocess per sampled event; commit-per-event is a proxy, not daemon internals" };
+  try {
+    unlinkSync(hotPath);
+  } catch {
+    /* fixture cleanup is best effort */
+  }
+  return {
+    samples,
+    gitSubprocesses: subprocesses,
+    gitSubprocessesPerEvent: subprocesses / samples,
+    hotWriteLatencyMs: stats(latencies),
+    instrument: "one git hash-object subprocess per sampled event; commit-per-event is a proxy, not daemon internals",
+  };
 }
 
 function distribution(fixture, files) {
@@ -123,7 +197,18 @@ function distribution(fixture, files) {
     if (rel[0] === "harness" && rel[1] === "events") eventDirs.set(rel[2], (eventDirs.get(rel[2]) ?? 0) + 1);
   }
   const counts = [...eventDirs.values()];
-  return { totalFiles: files.length, topLevelFiles: Object.fromEntries([...top.entries()].sort()), eventDirectoryCount: eventDirs.size, eventFiles: counts.reduce((a, b) => a + b, 0), eventFilesPerDirectory: { min: Math.min(...counts), p50: percentile(counts, 50), p95: percentile(counts, 95), max: Math.max(...counts) } };
+  return {
+    totalFiles: files.length,
+    topLevelFiles: Object.fromEntries([...top.entries()].sort()),
+    eventDirectoryCount: eventDirs.size,
+    eventFiles: counts.reduce((a, b) => a + b, 0),
+    eventFilesPerDirectory: {
+      min: Math.min(...counts),
+      p50: percentile(counts, 50),
+      p95: percentile(counts, 95),
+      max: Math.max(...counts),
+    },
+  };
 }
 
 async function measureFixture(fixture, rounds, hotSamples, sections) {
@@ -137,11 +222,20 @@ async function measureFixture(fixture, rounds, hotSamples, sections) {
     const b2 = sections.has("b2") ? await rebuild(root, files) : null;
     const b3 = sections.has("b3") ? hotWrite(root, events, hotSamples) : null;
     const after = loadSnapshot();
-    roundResults.push({ round: round + 1, loadBefore: before, loadAfter: after, b2, b3, b6: sections.has("b6") ? distribution(root, files) : null });
+    roundResults.push({
+      round: round + 1,
+      loadBefore: before,
+      loadAfter: after,
+      b2,
+      b3,
+      b6: sections.has("b6") ? distribution(root, files) : null,
+    });
   }
   // B5 runs once per fixture: the canonical ledger build is expensive, and the
   // real read model is sampled inside measureB5Real (rounds x 10 samples/query).
-  const b5Real = sections.has("b5") ? await measureB5Real({ fixture: root, rounds }) : null;
+  const b5Real = sections.has("b5")
+    ? await measureB5Real({ fixture: root, rounds, sourceRoot: resolve(import.meta.dirname, "../..") })
+    : null;
   return { fixture: root, metadata: meta, rounds: roundResults, b5Real };
 }
 
@@ -155,42 +249,126 @@ function meanRound(rounds, selector) {
   return values.length ? values.reduce((a, b) => a + b, 0) / values.length : null;
 }
 
-function fmt(value, digits = 2) { return typeof value === "number" ? value.toFixed(digits) : "—"; }
+function fmt(value, digits = 2) {
+  return typeof value === "number" ? value.toFixed(digits) : "—";
+}
 
 function markdown(report) {
   const lines = [];
-  lines.push("# PLT-Scale W1 基线测量（B2/B3/B5/B6）", "", `生成时间：${report.generatedAt}`, "", "## 测量口径", "", "- 每个 fixture 连续测量两遍；每遍记录开始/结束时的 loadavg、CPU 与可用内存。运行期间同机存在其他 worker，故数值只作同机对比，不作跨机器绝对 SLO。", "- B2 是事件 JSON 全量扫描 + 内存 reducer 的冷启动近似，报告 wall clock 与采样到的 RSS 峰值；不是 daemon 私有实现的直接调用。", "- B3 热写使用 fsync 文件写 + 每个样本一个 `git hash-object --stdin` 子进程，子进程数是可复核的 instrument proxy，不冒充 commit 内部计数。", "- B5 从 fixture 实体数合成 canonical 事件账本，经真实 task 投影冷追平后，用 daemon 读模型实测 task list / fact search / relation graph（无参 + 窄查询 + 分页），每查询每轮 10 次取 p50/p95（tools/scale/b5-real.mjs）。", "- B6 统计实际文件数、events 两位十六进制目录 fan-out。", "");
-  lines.push("## 结果摘要", "", "| 档位（主 task 数） | 事件数 | B2 冷重建 ms（两遍均值） | B2 RSS 峰值 MB（最大） | B3 git 子进程/样本 | B3 热写 p95 ms（均值） | B5 task p95 ms | B5 fact p95 ms | B5 graph p95 ms | B6 文件数 |", "|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|");
+  lines.push(
+    "# PLT-Scale W1 基线测量（B2/B3/B5/B6）",
+    "",
+    `生成时间：${report.generatedAt}`,
+    "",
+    "## 测量口径",
+    "",
+    "- 每个 fixture 连续测量两遍；每遍记录开始/结束时的 loadavg、CPU 与可用内存。运行期间同机存在其他 worker，故数值只作同机对比，不作跨机器绝对 SLO。",
+    "- B2 是事件 JSON 全量扫描 + 内存 reducer 的冷启动近似，报告 wall clock 与采样到的 RSS 峰值；不是 daemon 私有实现的直接调用。",
+    "- B3 热写使用 fsync 文件写 + 每个样本一个 `git hash-object --stdin` 子进程，子进程数是可复核的 instrument proxy，不冒充 commit 内部计数。",
+    "- B5 从 fixture 实体数合成 canonical 事件账本，经真实 task 投影冷追平后，用 daemon 读模型实测 task list / fact search / relation graph（无参 + 窄查询 + 分页），每查询每轮 10 次取 p50/p95（tools/scale/b5-real.mjs）。",
+    "- B6 统计实际文件数、events 两位十六进制目录 fan-out。",
+    "",
+  );
+  lines.push(
+    "## 结果摘要",
+    "",
+    "| 档位（主 task 数） | 事件数 | B2 冷重建 ms（两遍均值） | B2 RSS 峰值 MB（最大） | B3 git 子进程/样本 | B3 热写 p95 ms（均值） | B5 task p95 ms | B5 fact p95 ms | B5 graph p95 ms | B6 文件数 |",
+    "|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|",
+  );
   for (const item of report.fixtures) {
     const rounds = item.rounds;
     const peakRss = meanRound(rounds, (r) => r.b2?.peakRssMb);
-    lines.push(`| ${item.metadata.primaryTaskCount.toLocaleString()} | ${item.metadata.eventCount.toLocaleString()} | ${fmt(average(item, "b2", "wallClockMs"), 1)} | ${fmt(peakRss, 1)} | ${fmt(average(item, "b3", "gitSubprocessesPerEvent"), 1)} | ${fmt(meanRound(rounds, (r) => r.b3?.hotWriteLatencyMs.p95Ms))} | ${fmt(item.b5Real?.measurements.taskList?.p95Ms)} | ${fmt(item.b5Real?.measurements.factSearch?.p95Ms)} | ${fmt(item.b5Real?.measurements.relationGraph?.p95Ms)} | ${rounds[0].b6?.totalFiles?.toLocaleString() ?? "—"} |`);
+    lines.push(
+      `| ${item.metadata.primaryTaskCount.toLocaleString()} | ${item.metadata.eventCount.toLocaleString()} | ${fmt(average(item, "b2", "wallClockMs"), 1)} | ${fmt(peakRss, 1)} | ${fmt(average(item, "b3", "gitSubprocessesPerEvent"), 1)} | ${fmt(meanRound(rounds, (r) => r.b3?.hotWriteLatencyMs.p95Ms))} | ${fmt(item.b5Real?.measurements.taskList?.p95Ms)} | ${fmt(item.b5Real?.measurements.factSearch?.p95Ms)} | ${fmt(item.b5Real?.measurements.relationGraph?.p95Ms)} | ${rounds[0].b6?.totalFiles?.toLocaleString() ?? "—"} |`,
+    );
   }
   lines.push("", "## 分档明细", "");
   for (const item of report.fixtures) {
-    lines.push(`### ${item.metadata.primaryTaskCount.toLocaleString()} tasks`, "", `fixture: \`${item.fixture}\`; seed: \`${item.metadata.seed}\`; facts: ${item.metadata.factCount.toLocaleString()}; decisions: ${item.metadata.decisionCount.toLocaleString()}; events: ${item.metadata.eventCount.toLocaleString()}.`, "");
+    lines.push(
+      `### ${item.metadata.primaryTaskCount.toLocaleString()} tasks`,
+      "",
+      `fixture: \`${item.fixture}\`; seed: \`${item.metadata.seed}\`; facts: ${item.metadata.factCount.toLocaleString()}; decisions: ${item.metadata.decisionCount.toLocaleString()}; events: ${item.metadata.eventCount.toLocaleString()}.`,
+      "",
+    );
     if (item.b5Real) {
-      lines.push("", `B5 real path: ledger build ${fmt(item.b5Real.ledger.buildMs, 0)}ms for ${item.b5Real.ledger.events.toLocaleString()} canonical events; narrow supported: ${item.b5Real.ledger.narrowSupported}; unparameterized digest \`${item.b5Real.unparameterizedResultDigest}\`.`, "", "| B5 real query | p50 ms | p95 ms |", "|---|---:|---:|");
-      for (const [label, value] of Object.entries(item.b5Real.measurements)) if (value) lines.push(`| ${label} | ${fmt(value.p50Ms)} | ${fmt(value.p95Ms)} |`);
+      lines.push(
+        "",
+        `B5 real path: ledger build ${fmt(item.b5Real.ledger.buildMs, 0)}ms for ${item.b5Real.ledger.events.toLocaleString()} canonical events; narrow supported: ${item.b5Real.ledger.narrowSupported}; unparameterized digest \`${item.b5Real.unparameterizedResultDigest}\`.`,
+        "",
+        "| B5 real query | p50 ms | p95 ms |",
+        "|---|---:|---:|",
+      );
+      for (const [label, value] of Object.entries(item.b5Real.measurements))
+        if (value) lines.push(`| ${label} | ${fmt(value.p50Ms)} | ${fmt(value.p95Ms)} |`);
     }
-    lines.push("", "| 轮次 | load1 前/后 | B2 ms | B2 RSS MB | B3 git 子进程 | B3 hot p50/p95 ms | B5 task p95 | B5 fact p95 | B5 graph p95 | B6 文件数 |", "|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|");
-    for (const round of item.rounds) lines.push(`| ${round.round} | ${round.loadBefore.load1}/${round.loadAfter.load1} | ${fmt(round.b2?.wallClockMs, 1)} | ${fmt(round.b2?.peakRssMb, 1)} | ${round.b3?.gitSubprocesses ?? "—"} | ${fmt(round.b3?.hotWriteLatencyMs.p50Ms)}/${fmt(round.b3?.hotWriteLatencyMs.p95Ms)} | ${round.round === 1 ? fmt(item.b5Real?.measurements.taskList?.p95Ms) : "—"} | ${round.round === 1 ? fmt(item.b5Real?.measurements.factSearch?.p95Ms) : "—"} | ${round.round === 1 ? fmt(item.b5Real?.measurements.relationGraph?.p95Ms) : "—"} | ${round.b6?.totalFiles?.toLocaleString() ?? "—"} |`);
-    lines.push("", `events fan-out: ${item.rounds[0].b6 ? JSON.stringify(item.rounds[0].b6.eventFilesPerDirectory) : "—"}; top-level distribution: \`${item.rounds[0].b6 ? JSON.stringify(item.rounds[0].b6.topLevelFiles) : "—"}\``, "");
+    lines.push(
+      "",
+      "| 轮次 | load1 前/后 | B2 ms | B2 RSS MB | B3 git 子进程 | B3 hot p50/p95 ms | B5 task p95 | B5 fact p95 | B5 graph p95 | B6 文件数 |",
+      "|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|",
+    );
+    for (const round of item.rounds)
+      lines.push(
+        `| ${round.round} | ${round.loadBefore.load1}/${round.loadAfter.load1} | ${fmt(round.b2?.wallClockMs, 1)} | ${fmt(round.b2?.peakRssMb, 1)} | ${round.b3?.gitSubprocesses ?? "—"} | ${fmt(round.b3?.hotWriteLatencyMs.p50Ms)}/${fmt(round.b3?.hotWriteLatencyMs.p95Ms)} | ${round.round === 1 ? fmt(item.b5Real?.measurements.taskList?.p95Ms) : "—"} | ${round.round === 1 ? fmt(item.b5Real?.measurements.factSearch?.p95Ms) : "—"} | ${round.round === 1 ? fmt(item.b5Real?.measurements.relationGraph?.p95Ms) : "—"} | ${round.b6?.totalFiles?.toLocaleString() ?? "—"} |`,
+      );
+    lines.push(
+      "",
+      `events fan-out: ${item.rounds[0].b6 ? JSON.stringify(item.rounds[0].b6.eventFilesPerDirectory) : "—"}; top-level distribution: \`${item.rounds[0].b6 ? JSON.stringify(item.rounds[0].b6.topLevelFiles) : "—"}\``,
+      "",
+    );
   }
-  lines.push("## 按数字排的修复优先级", "", "1. **B2 投影冷重建**：优先消除全历史逐事件重放；以本表 B2 墙钟/RSS 随事件数的增长率为第一设计输入，目标是 watermark 增量追平与持久投影。", "2. **B3 写路径 git 耦合**：每个样本都产生一个可计数 git 子进程，且热写 p95 随仓增大上升；优先把权威 append log 与 git 审计物化拆开，再讨论语言替换。", "3. **B5 宽读与窄读**：无参 task/relation/fact 结果保留兼容性；显式状态/时间窗/分页走索引窄面，继续观察窄面与宽面 p95 随 N 的增长率。", "4. **B6 小文件/目录 fan-out**：events 目录被固定分成 256 桶，文件数线性增长；与 B3 一起评估分段 append/pack，避免单事件单文件。", "", "## 限制与外推", "", "- 生成器默认每 task 2.5 个事件文件，保持 1e5 档可在普通开发机运行；scale thesis 的生产假设是 25 事件/task（约高 10 倍），故事件线性结果可按事件密度乘数外推，绝对值不能直接当生产预测。", "- 本轮未修改产品代码，也没有将 fixture 放入版本库；fixture 位于 gitignore 的 `tmp/scale-fixtures/`。", "- 若某轮 load1 接近 CPU 并行度，优先重跑该档；同机 worker 负载已在每轮 JSON 中留证。", "", "## 与 CEO 授权五点的差距清单", "", "- [x] 读 API/协议/GUI 三面接线与无参 digest 证据进入 B5。", "- [x] 真实 projection/read-model 查询路径已替代旧文件扫描 proxy。", "- [x] 分页拼接与等价 digest 证据由定向测试和 B5 输出提供。", "- [ ] test-tier manifest、定向测试与 `npm run check:local`：仓库总收口时执行。", "- [ ] 本地 commit 身份核验，且不 push/不开 PR：仓库总收口时执行。", "");
+  lines.push(
+    "## 按数字排的修复优先级",
+    "",
+    "1. **B2 投影冷重建**：优先消除全历史逐事件重放；以本表 B2 墙钟/RSS 随事件数的增长率为第一设计输入，目标是 watermark 增量追平与持久投影。",
+    "2. **B3 写路径 git 耦合**：每个样本都产生一个可计数 git 子进程，且热写 p95 随仓增大上升；优先把权威 append log 与 git 审计物化拆开，再讨论语言替换。",
+    "3. **B5 宽读与窄读**：无参 task/relation/fact 结果保留兼容性；显式状态/时间窗/分页走索引窄面，继续观察窄面与宽面 p95 随 N 的增长率。",
+    "4. **B6 小文件/目录 fan-out**：events 目录被固定分成 256 桶，文件数线性增长；与 B3 一起评估分段 append/pack，避免单事件单文件。",
+    "",
+    "## 限制与外推",
+    "",
+    "- 生成器默认每 task 2.5 个事件文件，保持 1e5 档可在普通开发机运行；scale thesis 的生产假设是 25 事件/task（约高 10 倍），故事件线性结果可按事件密度乘数外推，绝对值不能直接当生产预测。",
+    "- 本轮未修改产品代码，也没有将 fixture 放入版本库；fixture 位于 gitignore 的 `tmp/scale-fixtures/`。",
+    "- 若某轮 load1 接近 CPU 并行度，优先重跑该档；同机 worker 负载已在每轮 JSON 中留证。",
+    "",
+    "## 与 CEO 授权五点的差距清单",
+    "",
+    "- [x] 读 API/协议/GUI 三面接线与无参 digest 证据进入 B5。",
+    "- [x] 真实 projection/read-model 查询路径已替代旧文件扫描 proxy。",
+    "- [x] 分页拼接与等价 digest 证据由定向测试和 B5 输出提供。",
+    "- [ ] test-tier manifest、定向测试与 `npm run check:local`：仓库总收口时执行。",
+    "- [ ] 本地 commit 身份核验，且不 push/不开 PR：仓库总收口时执行。",
+    "",
+  );
   return lines.join("\n");
 }
 
 async function main() {
   const options = parseArgs(process.argv.slice(2));
-  const report = { schema: "plt-scale-baseline/v1", generatedAt: new Date().toISOString(), host: { platform: process.platform, arch: process.arch, node: process.version }, fixtures: [] };
-  for (const fixture of options.fixtures) report.fixtures.push(await measureFixture(fixture, options.rounds, options.hotSamples, options.sections));
+  const report = {
+    schema: "plt-scale-baseline/v1",
+    generatedAt: new Date().toISOString(),
+    host: { platform: process.platform, arch: process.arch, node: process.version },
+    fixtures: [],
+  };
+  for (const fixture of options.fixtures)
+    report.fixtures.push(await measureFixture(fixture, options.rounds, options.hotSamples, options.sections));
   const json = JSON.stringify(report, null, 2) + "\n";
-  if (options.jsonOut) { mkdirSync(join(resolve(options.jsonOut), ".."), { recursive: true }); writeFileSync(resolve(options.jsonOut), json); }
+  if (options.jsonOut) {
+    mkdirSync(join(resolve(options.jsonOut), ".."), { recursive: true });
+    writeFileSync(resolve(options.jsonOut), json);
+  }
   const md = markdown(report);
   const reportPath = options.reportFile ?? options.markdownOut;
-  if (reportPath) { mkdirSync(join(resolve(reportPath), ".."), { recursive: true }); writeFileSync(resolve(reportPath), md + "\n"); }
+  if (reportPath) {
+    mkdirSync(join(resolve(reportPath), ".."), { recursive: true });
+    writeFileSync(resolve(reportPath), md + "\n");
+  }
   console.log(reportPath ? `Wrote ${resolve(reportPath)}` : json);
 }
 
-try { await main(); } catch (error) { console.error(error instanceof Error ? error.stack : String(error)); process.exitCode = 1; }
+try {
+  await main();
+} catch (error) {
+  console.error(error instanceof Error ? error.stack : String(error));
+  process.exitCode = 1;
+}


### PR DESCRIPTION
# English

## Summary

The B5 scale harness under `tools/scale` had drifted from the kernel contracts in four places, so the rerun recipe the perf fix-plan uses to accept each batch (round-5 report §4) could not run: `measure.mjs` called `measureB5Real` without `sourceRoot` (TypeError), `b5-real.mjs` polled `readProgress` expecting reads to drive catch-up (removed contract; never ready), synthesised `task/v2` rows without `packageDisposition` (hard throw), and called the deleted bare `readModel.relationGraph()`.

This PR applies the four fixes from the round-5 report and re-establishes the 10k baseline (seed `20260911`): result digest `00e9a513…bfa29c`, taskList p50 1 537 ms / p95 1 620 ms, taskStatusNarrow p50 12.7 ms, taskPageFirst p50 11.0 ms; JSON/Markdown baselines live in the task package. `measure.mjs` is also reformatted by prettier (the file was not formatted before), which is most of the line count.

## Architectural Justification

The churn is prettier reformatting of `tools/scale/measure.mjs`, which had never been formatted; the substantive change is four one-line contract fixes in the benchmark harness. No module, layer, port or production path is added or moved, so the architecture is unchanged and the justification is that the counted delta is formatting, not design.

## What Changed

- `tools/scale/b5-real.mjs`: `packageDisposition: "active"` on synthesised tasks; one `projection.catchUp()` instead of the read-driven polling loop (`catchUpReads` now reports `catchUp.metrics.sqliteTransactions`); `relationGraphFacet({ facet: "edges" })`.
- `tools/scale/measure.mjs`: passes `sourceRoot: resolve(import.meta.dirname, "../..")`; prettier formatting.
- Follow-ups from the report answered without production changes: no remaining "read-driven catch-up" reference in `tools/`; `requiredPackageDisposition` stays fail-closed and the legacy route is unreachable because both migration restatement and doc-sync normalisation supply `active`.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: +0/-0 in `packages/*`; tools-only change.

## Machine-Readable Declarations

- None.

## Task And Scope

- Harness task: task_f63743c3a55f1488a0694017e9 (fix-plan batch 18 part), parent task_2b8f79fa4412cb726a26f9bfc7
- Branch: `codex/scale-bench-drift`
- Public scope: `tools/scale` harness only
- Private planning/evidence updated: yes (task plan, `artifacts/report.md`, `artifacts/baseline/`, fact F-4D354913)
- Out of scope: the measured hotspots themselves (batch 2 task_d928fcf6, batch 8 #2468)

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: not applicable
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `6bcfbbac5`
- Branch merge-base with `origin/main`: `6bcfbbac5`
- Last `git fetch origin` time: 2026-09-11 UTC
- Sync method: branched from origin/main
- Public diff command: `git diff origin/main...codex/scale-bench-drift`
- Private evidence commit/path: task_f63743c3a55f1488a0694017e9 `artifacts/report.md`, `artifacts/baseline/`
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [ ] `npm run typecheck`
- [ ] `npm run check`
- [ ] `npm test`
- [x] `npm run harness:check-import-boundaries` (via `run-manifest-gates --changed origin/main`)
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts` (via `run-manifest-gates --changed origin/main`)
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- `node tools/scale/generate.mjs --entities 10000 --seed 20260911 …` exit 0; `node --cpu-prof … tools/scale/b5-real.mjs --fixture … --rounds 1` exit 0 with the digest above.

## Review Evidence

- CEO ground-truth: the substantive diff is the four report items in `b5-real.mjs`/`measure.mjs`; the rest of `measure.mjs` is formatting only.
- Reviewer subagent: not used
- Human review: pending
- Blocking findings: none open

## Residual Risk

- Absolute numbers were taken on a loaded host (report §2 notes load1 ≈ 19); ratios are the comparison instrument.

## References

- Task: task_f63743c3a55f1488a0694017e9; round-5 report task_6eba9c5d3a55735920aa4856f3 `artifacts/round-5/01-baseline-pass2.md`

---

# 中文

## 概要

`tools/scale` 的 B5 台架与 kernel 契约有四处漂移，perf fix-plan 各批验收用的复跑配方（round-5 报告 §4）跑不起来：`measure.mjs` 调 `measureB5Real` 不传 `sourceRoot`（TypeError）、`b5-real.mjs` 轮询 `readProgress` 指望读驱动追赶（契约已删；永不 ready）、合成 `task/v2` 缺 `packageDisposition`（硬抛）、调用已删的裸 `readModel.relationGraph()`。

本 PR 按 round-5 报告修这四处，并重建 10k 基线（seed `20260911`）：结果 digest `00e9a513…bfa29c`，taskList p50 1 537 ms / p95 1 620 ms，taskStatusNarrow p50 12.7 ms，taskPageFirst p50 11.0 ms；JSON/Markdown 基线在任务包。`measure.mjs` 同时被 prettier 格式化（之前没格式化过），这是行数的大头。

## 架构辩护

churn 来自对 `tools/scale/measure.mjs` 的 prettier 格式化（该文件此前从未格式化过）；实质改动只是台架里四处各一行的契约修正。没有新增或搬动任何模块、分层、端口或生产路径，架构不变，辩护理由就是被计数的变更是格式化而非设计。

## 改动内容

- `tools/scale/b5-real.mjs`：合成任务加 `packageDisposition: "active"`；读驱动轮询换成一次 `projection.catchUp()`（`catchUpReads` 改报 `catchUp.metrics.sqliteTransactions`）；`relationGraphFacet({ facet: "edges" })`。
- `tools/scale/measure.mjs`：传 `sourceRoot: resolve(import.meta.dirname, "../..")`；prettier 格式化。
- 报告的两条顺带结论已回答、不改生产代码：`tools/` 里没有剩余「读驱动追赶」引用；`requiredPackageDisposition` 保持 fail-closed，旧路径不可达（迁移重述与 doc-sync 归一化都补 `active`）。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 删除的门或 fixture：none
- 生产净行数：`packages/*` +0/-0；仅 tools。

## 机器可读声明

- 无。

## 任务与范围

- Harness 任务：task_f63743c3a55f1488a0694017e9（fix-plan 批 18 一部分），父任务 task_2b8f79fa4412cb726a26f9bfc7
- 分支：`codex/scale-bench-drift`
- 公开范围：仅 `tools/scale` 台架
- 私有计划/证据已更新：是（任务计划、`artifacts/report.md`、`artifacts/baseline/`、fact F-4D354913）
- 范围外：测到的热点本身（批 2 task_d928fcf6、批 8 #2468）

## 版本影响

- 版本：不变
- 发布影响：不发布

## 治理声明

- 触碰受保护面：否
- 受保护面范围：不适用
- 授权：不适用
- 机器检查边界：本 PR 只断言声明存在；是否属实、是否充分由评审判断。
- Break-glass：否
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- 基线 `origin/main` SHA：`6bcfbbac5`
- 分支与 `origin/main` 的 merge-base：`6bcfbbac5`
- 最近一次 `git fetch origin`：2026-09-11 UTC
- 同步方式：从 origin/main 开分支
- 公开 diff 命令：`git diff origin/main...codex/scale-bench-drift`
- 私有证据路径：task_f63743c3a55f1488a0694017e9 的 `artifacts/report.md`、`artifacts/baseline/`
- 评审证据路径：本 PR 的评审证据节
- GitHub Actions `rewrite-ci` run URL：本 PR 待跑
- `node tools/scale/generate.mjs --entities 10000 --seed 20260911 …` exit 0；`node --cpu-prof … tools/scale/b5-real.mjs --fixture … --rounds 1` exit 0，digest 如上。

## 评审证据

- CEO 事实核对：实质 diff 就是 `b5-real.mjs`/`measure.mjs` 里报告的四项；`measure.mjs` 其余是格式化。
- 评审子代理：未用
- 人工评审：待定
- 阻塞发现：无

## 残余风险

- 绝对值在高负载宿主上取得（报告 §2 注明 load1 ≈ 19）；比值才是对比仪器。

## 参考

- 任务：task_f63743c3a55f1488a0694017e9；round-5 报告 task_6eba9c5d3a55735920aa4856f3 `artifacts/round-5/01-baseline-pass2.md`
