### PR TITLE
fix: ask the object store whether a ledger commit exists before synthesizing a ledger observation

### DIFF
--- a/packages/daemon/src/ci-observation-actions.ts
+++ b/packages/daemon/src/ci-observation-actions.ts
@@ -131,8 +131,9 @@ export async function fetchCiObservations(
         const branch = localGitObjectRefStore.currentBranch(authoredRoot),
           sha = branch ? localGitObjectRefStore.resolveCommit(authoredRoot, `refs/heads/${branch}`) : null;
         // A ledger commit that is also in the public repository belongs to the
-        // GitHub observation path; synthesize only for private-ledger commits.
-        if (branch && sha && !localGitObjectRefStore.resolveCommit(cell.rootDir, sha))
+        // GitHub observation path; synthesize only for private-ledger commits. `git rev-parse`
+        // echoes any 40-hex string back, so existence must be asked with `cat-file -e`.
+        if (branch && sha && !localGitObjectRefStore.hasCommit(cell.rootDir, sha))
           fetched.push({
             databaseId: 0,
             summary: {

--- a/packages/daemon/test/ci-observatory-read.test.ts
+++ b/packages/daemon/test/ci-observatory-read.test.ts
@@ -1,4 +1,5 @@
 // harness-test-tier: contract
+import { execFileSync } from "node:child_process";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import test from "node:test";
@@ -379,6 +380,42 @@ test("CI observation pull writes canonical events once per run and job", async (
     rmSync(rootDir, { recursive: true, force: true });
   }
 });
+
+test("CI observation pull synthesizes a ledger-publication run only for private ledger commits", async () => {
+  const rootDir = mkdtempSync(path.join(process.cwd(), ".tmp-ci-observation-ledger-"));
+  const ledgerRoot = path.join(rootDir, "harness");
+  const cell = { rootDir, cellCodedError: (_code: string, message: string) => new Error(message) };
+  const noRuns = ((_command: string, args: readonly string[]) => (args[1] === "list" ? "[]" : "")) as never;
+  try {
+    git(rootDir, "init", "-q", "-b", "main");
+    writeFileSync(path.join(rootDir, "README.md"), "public\n");
+    git(rootDir, "add", "README.md");
+    git(rootDir, "commit", "-q", "-m", "public");
+    mkdirSync(ledgerRoot);
+    git(ledgerRoot, "init", "-q", "-b", "main");
+    writeFileSync(path.join(ledgerRoot, "harness.yaml"), "ledger: true\n");
+    git(ledgerRoot, "add", "harness.yaml");
+    git(ledgerRoot, "commit", "-q", "-m", "ledger");
+    const ledgerHead = git(ledgerRoot, "rev-parse", "HEAD");
+    const privateOnly = await fetchCiObservations(cell, { kind: "ci-observe-pull", limit: 20 }, noRuns);
+    assert.deepEqual(
+      privateOnly.runs.map((run) => [run.summary.workflowName, run.summary.headSha, run.artifacts[0]?.run.runId]),
+      [["ledger-publication", ledgerHead, `ledger-${ledgerHead}`]],
+    );
+    // Once the public repository holds the same commit, GitHub owns the observation.
+    git(rootDir, "fetch", "-q", ledgerRoot, "HEAD");
+    const published = await fetchCiObservations(cell, { kind: "ci-observe-pull", limit: 20 }, noRuns);
+    assert.deepEqual(published.runs, []);
+  } finally {
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});
+
+function git(rootDir: string, ...args: readonly string[]): string {
+  return execFileSync("git", ["-C", rootDir, "-c", "user.name=test", "-c", "user.email=test@example.com", ...args], {
+    encoding: "utf8",
+  }).trim();
+}
 
 test("CI observation pull imports named main runs without listing recent runs", async () => {
   const rootDir = mkdtempSync(path.join(process.cwd(), ".tmp-ci-observation-named-")),

--- a/packages/kernel/src/store/local-version-control-system.ts
+++ b/packages/kernel/src/store/local-version-control-system.ts
@@ -286,6 +286,16 @@ export const localGitObjectRefStore = Object.freeze({
     return Number.isNaN(timestamp.valueOf()) ? null : timestamp.toISOString();
   },
   resolveCommit: (repoRoot: string, revision: string) => runGit(repoRoot, "rev-parse", revision).trim(),
+  // `rev-parse` echoes a well-formed sha whether or not the object exists; this asks the object store.
+  hasCommit: (repoRoot: string, sha: string): boolean => {
+    try {
+      runGit(repoRoot, "cat-file", "-e", `${sha}^{commit}`);
+      return true;
+    } catch (error) {
+      consumeKnownError(error);
+      return false;
+    }
+  },
   currentBranch: (repoRoot: string): string | null => {
     try {
       const dotGit = path.join(repoRoot, ".git"),

--- a/tools/gate-allowlists/check-fallback-boundaries.json
+++ b/tools/gate-allowlists/check-fallback-boundaries.json
@@ -257,6 +257,7 @@
       "packages/kernel/src/store/local-version-control-system.ts#<module>",
       "packages/kernel/src/store/local-version-control-system.ts#currentBranch",
       "packages/kernel/src/store/local-version-control-system.ts#gitTopLevel",
+      "packages/kernel/src/store/local-version-control-system.ts#hasCommit",
       "packages/kernel/src/store/local-version-control-system.ts#isAncestor",
       "packages/kernel/src/store/local-version-control-system.ts#isDirectory",
       "packages/kernel/src/store/local-version-control-system.ts#processMayBeAlive",


### PR DESCRIPTION
# English

## Summary

`ci observe pull` (#2462) was supposed to synthesize a `ledger-publication` observation whenever the private ledger HEAD is not a public-repository commit. Live acceptance on 6bcfbbac5 showed it never did: the check used `git rev-parse <sha>`, which echoes any 40-hex string back whether or not the object exists, so "present in public repo" was always true and the five in_review tasks that deliver into the ledger still cannot pass the `ci` completion gate.

This PR asks the object store for existence with `git cat-file -e <sha>^{commit}` (`localGitObjectRefStore.hasCommit`) and adds a test with real temp git repositories that covers both sides: a ledger-only commit yields exactly one synthesized run; the same commit fetched into the public repository yields none. The test fails against the previous check.

## Architectural Justification

-

## What Changed

- `packages/kernel/src/store/local-version-control-system.ts`: `hasCommit(repoRoot, sha)` via `cat-file -e`.
- `packages/daemon/src/ci-observation-actions.ts`: synthesis condition uses `hasCommit` instead of `resolveCommit`.
- `packages/daemon/test/ci-observatory-read.test.ts`: `synthesizes a ledger-publication run only for private ledger commits`.
- `tools/gate-allowlists/check-fallback-boundaries.json`: `#hasCommit` entry.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: +13/-2 in `packages/*`.

## Machine-Readable Declarations

- None.

## Task And Scope

- Harness task: task_b616bd7d4e21b282855cca9270 (live-acceptance defect of #2462), parent task_2b8f79fa4412cb726a26f9bfc7
- Branch: `codex/ledger-observation-exists`
- Public scope: CI observation pull, local git object store port
- Private planning/evidence updated: yes (closeout acceptance section after deploy)
- Out of scope: the `ci` gate semantics themselves (unchanged from #2462)

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: yes — `tools/gate-allowlists/check-fallback-boundaries.json` gains one entry (`packages/kernel/src/store/local-version-control-system.ts#hasCommit`)
- Protected surface scope: allowlists the non-zero exit of `git cat-file -e` being read as "absent"; no gate logic changes
- Authority: task_b616bd7d4e21b282855cca9270 (user ruling of 2026-09-11 that ledger-delivered tasks must pass the `ci` gate against the ledger repository)
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `6bcfbbac5`
- Branch merge-base with `origin/main`: `6bcfbbac5`
- Last `git fetch origin` time: 2026-09-11 UTC
- Sync method: branched from origin/main
- Public diff command: `git diff origin/main...codex/ledger-observation-exists`
- Private evidence commit/path: task_b616bd7d4e21b282855cca9270 `closeout.md`, `artifacts/acceptance/`
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [ ] `npm run typecheck`
- [ ] `npm run check`
- [ ] `npm test`
- [x] `npm run harness:check-import-boundaries` (via `run-manifest-gates --changed origin/main`)
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts` (via `run-manifest-gates --changed origin/main`)
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- `ci-observatory-read.test.ts` 10/10; the new test fails 1/10 with the previous `resolveCommit` check (negative control run before commit).
- Live defect evidence: on the canonical checkout `git rev-parse 0bec9a1f…` exits 0 and `git cat-file -e 0bec9a1f…^{commit}` exits 1 for the ledger HEAD; the ledger copy holds no `ci_run_observed` event with `ledger-publication` verification.

## Review Evidence

- CEO ground-truth: found the defect during live acceptance of #2462, reproduced with the two git commands above, wrote the fix and test directly.
- Reviewer subagent: not used (14-line production diff)
- Human review: pending
- Blocking findings: none open

## Residual Risk

- `cat-file -e` runs once per pull on the public checkout; cost is one git process.

## References

- Task: task_b616bd7d4e21b282855cca9270; origin #2462

---

# 中文

## 概要

`ci observe pull`（#2462）本应在私有台账 HEAD 不是公开仓提交时合成一条 `ledger-publication` 观察。在 6bcfbbac5 上做现场验收发现它从未合成：判断用的是 `git rev-parse <sha>`，而 rev-parse 对任意 40 位十六进制串都原样回显、不管对象存不存在，于是「公开仓已有」恒为真，五个交付进台账的 in_review 任务依旧过不了 `ci` 完成门。

本 PR 改用 `git cat-file -e <sha>^{commit}`（`localGitObjectRefStore.hasCommit`）问对象库，并用真实临时 git 仓加一条双向测试：只在台账里的提交恰好合成一条运行；同一提交 fetch 进公开仓后不再合成。该测试在旧判断下失败。

## 架构辩护

-

## 改动内容

- `packages/kernel/src/store/local-version-control-system.ts`：`hasCommit(repoRoot, sha)`，走 `cat-file -e`。
- `packages/daemon/src/ci-observation-actions.ts`：合成条件由 `resolveCommit` 换成 `hasCommit`。
- `packages/daemon/test/ci-observatory-read.test.ts`：`synthesizes a ledger-publication run only for private ledger commits`。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 删除的门或 fixture：none
- 生产净行数：`packages/*` +13/-2。

## 机器可读声明

- 无。

## 任务与范围

- Harness 任务：task_b616bd7d4e21b282855cca9270（#2462 的现场验收缺陷），父任务 task_2b8f79fa4412cb726a26f9bfc7
- 分支：`codex/ledger-observation-exists`
- 公开范围：CI 观察拉取、本地 git 对象库端口
- 私有计划/证据已更新：是（部署后补 closeout 验收节）
- 范围外：`ci` 门语义本身（与 #2462 一致）

## 版本影响

- 版本：不变
- 发布影响：不发布

## 治理声明

- 触碰受保护面：是——`tools/gate-allowlists/check-fallback-boundaries.json` 新增一条（`packages/kernel/src/store/local-version-control-system.ts#hasCommit`）
- 受保护面范围：登记「`git cat-file -e` 非零退出读作不存在」；门逻辑不变
- 授权：task_b616bd7d4e21b282855cca9270（用户 2026-09-11 裁决：交付进台账的任务按台账仓过 `ci` 门）
- 机器检查边界：本 PR 只断言声明存在；是否属实、是否充分由评审判断。
- Break-glass：否
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- 基线 `origin/main` SHA：`6bcfbbac5`
- 分支与 `origin/main` 的 merge-base：`6bcfbbac5`
- 最近一次 `git fetch origin`：2026-09-11 UTC
- 同步方式：从 origin/main 开分支
- 公开 diff 命令：`git diff origin/main...codex/ledger-observation-exists`
- 私有证据路径：task_b616bd7d4e21b282855cca9270 的 `closeout.md`、`artifacts/acceptance/`
- 评审证据路径：本 PR 的评审证据节
- GitHub Actions `rewrite-ci` run URL：本 PR 待跑
- `ci-observatory-read.test.ts` 10/10；新测试在旧 `resolveCommit` 判断下 1/10 失败（提交前做过阴性对照）。
- 现场缺陷证据：canonical checkout 上对台账 HEAD `git rev-parse 0bec9a1f…` 返回 0、`git cat-file -e 0bec9a1f…^{commit}` 返回 1；台账副本里没有任何带 `ledger-publication` 校验的 `ci_run_observed` 事件。

## 评审证据

- CEO 事实核对：在 #2462 现场验收中发现，用上述两条 git 命令复现，直接写修复与测试。
- 评审子代理：未用（生产 diff 14 行）
- 人工评审：待定
- 阻塞发现：无

## 残余风险

- 每次拉取在公开 checkout 上多跑一次 `cat-file -e`；代价一个 git 进程。

## 参考

- 任务：task_b616bd7d4e21b282855cca9270；源头 #2462
