### PR TITLE
test: add an opt-in profile switch to the V2 scale fixture

### DIFF
--- a/tools/stress/entity-v2-scale.fixture.mjs
+++ b/tools/stress/entity-v2-scale.fixture.mjs
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { spawnSync, execFileSync } from "node:child_process";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { appendFileSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { Session } from "node:inspector/promises";
 import { tmpdir, loadavg, availableParallelism, cpus, totalmem, freemem } from "node:os";
 import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
@@ -27,7 +28,49 @@ export function syntheticBinary(seed, size) {
   return buffer;
 }
 
-export function fixture(seed, daemonId = "entity-v2-scale") {
+/**
+ * Opt-in profile switch (`profileDir` in the workload): the measured daemon runs under `--cpu-prof`, so each of its
+ * threads writes a .cpuprofile on exit, and resolves `git` through a shim that logs every invocation. `timeline`
+ * interleaves those git lines with a start/end mark per operation on the monotonic clock the profiles use.
+ */
+export function profiling(profileDir) {
+  if (!profileDir) return null;
+  const bin = path.join(profileDir, "bin"),
+    cpu = path.join(profileDir, "cpu"),
+    timeline = path.join(profileDir, "timeline.log"),
+    realGit = execFileSync("sh", ["-c", "command -v git"], { encoding: "utf8" }).trim(),
+    session = new Session();
+  mkdirSync(bin, { recursive: true });
+  mkdirSync(cpu, { recursive: true });
+  writeFileSync(
+    path.join(bin, "git"),
+    `#!/bin/sh\nprintf 'git %s\\n' "$*" >> '${timeline}'\nexec '${realGit}' "$@"\n`,
+    {
+      mode: 0o755,
+    },
+  );
+  return {
+    daemonEnv: {
+      NODE_OPTIONS: `--cpu-prof --cpu-prof-dir=${cpu} --cpu-prof-interval=100`,
+      PATH: `${bin}:${process.env.PATH}`,
+    },
+    mark: (edge, metric) => appendFileSync(timeline, `mark ${edge} ${metric} ${process.hrtime.bigint() / 1000n}\n`),
+    /** The test process itself (generation and the resident arm's client side), sampled through the inspector. */
+    startProcess: async () => {
+      session.connect();
+      await session.post("Profiler.enable");
+      await session.post("Profiler.setSamplingInterval", { interval: 100 });
+      await session.post("Profiler.start");
+    },
+    stopProcess: async () => {
+      const { profile } = await session.post("Profiler.stop");
+      writeFileSync(path.join(cpu, "test-process.cpuprofile"), JSON.stringify(profile));
+      session.disconnect();
+    },
+  };
+}
+
+export function fixture(seed, daemonId = "entity-v2-scale", profile = null) {
   const parent = mkdtempSync(path.join(tmpdir(), "ha-entity-v2-scale-"));
   const root = path.join(parent, "repo"),
     userRoot = path.join(parent, "user");
@@ -58,18 +101,20 @@ export function fixture(seed, daemonId = "entity-v2-scale") {
   const invoke = (
     metric,
     args,
-    { actor, input, requireSuccess = true, frameRow = true, timeoutMs = 120_000, offline = false } = {},
+    { actor, input, requireSuccess = true, frameRow = true, timeoutMs = 120_000, offline = false, extraEnv = {} } = {},
   ) => {
+    profile?.mark("start", metric);
     const started = performance.now();
     // Offline storage commands (backup, restore, events, migrate ledger) are recognised by argv[0].
     const argv = offline ? [...args, "--root", root, "--json"] : ["--root", root, "--json", ...args];
     const result = spawnSync(process.execPath, [cli, ...argv], {
-      env: { ...env, ...(actor ? { HARNESS_ACTOR: actor } : {}) },
+      env: { ...env, ...extraEnv, ...(actor ? { HARNESS_ACTOR: actor } : {}) },
       encoding: "utf8",
       timeout: timeoutMs,
       maxBuffer: 256 * 1024 * 1024,
       ...(input === undefined ? {} : { input: JSON.stringify(input) }),
     });
+    profile?.mark("end", metric);
     let receipt = null;
     try {
       receipt = JSON.parse(result.stdout);

--- a/tools/stress/entity-v2-scale.integration.test.mjs
+++ b/tools/stress/entity-v2-scale.integration.test.mjs
@@ -14,6 +14,7 @@ import {
   directoryBytes,
   fixture,
   frame,
+  profiling,
   readWorkloadConfig,
   resourceSnapshot,
   summarize,
@@ -76,7 +77,8 @@ test(`V2 scale tier: ${config.targetEvents} generated events`, { skip, timeout: 
     if (remainingMs() < neededMs)
       throw new Error(`stage budget: ${Math.round(remainingMs())} ms left before ${phase}, needs ${neededMs} ms`);
   };
-  const f = fixture(config.seed);
+  const profile = profiling(config.profileDir);
+  const f = fixture(config.seed, undefined, profile);
   const failures = [],
     tier = { targetEvents: config.targetEvents };
   let reader = null,
@@ -121,6 +123,7 @@ test(`V2 scale tier: ${config.targetEvents} generated events`, { skip, timeout: 
       };
     process.stdout.write = capture(chunks, write);
     process.stderr.write = capture(errorChunks, writeError);
+    profile?.mark("start", `in-process.${metric}`);
     const commandStarted = performance.now();
     let status = null,
       thrown = null;
@@ -129,6 +132,7 @@ test(`V2 scale tier: ${config.targetEvents} generated events`, { skip, timeout: 
     } catch (error) {
       thrown = error;
     } finally {
+      profile?.mark("end", `in-process.${metric}`);
       process.stdout.write = write;
       process.stderr.write = writeError;
       for (const key of Object.keys(process.env)) if (!(key in previous)) delete process.env[key];
@@ -208,6 +212,8 @@ test(`V2 scale tier: ${config.targetEvents} generated events`, { skip, timeout: 
     await f.stopDaemon("generation.daemon-stop");
     hotFollower = follower("hot", f.root, config.repoId);
     coldFollower = follower("cold", f.root, config.repoId, path.join(f.parent, "cold-follower.sqlite"));
+    await profile?.startProcess();
+    profile?.mark("start", "generation");
     const generated = await generateEventStream({
       rootDir: f.root,
       repoId: config.repoId,
@@ -217,6 +223,7 @@ test(`V2 scale tier: ${config.targetEvents} generated events`, { skip, timeout: 
       drainEvery: config.drainEvery,
       onProgress: (progress) => frame("generation-progress", progress),
     });
+    profile?.mark("end", "generation");
     frame("generation", generated);
     const hotCatchUp = await hotFollower.finish(generated.headRevision, false, remainingMs());
     tier.generation = { ...generated, samples: undefined, hotCatchUp };
@@ -234,7 +241,10 @@ test(`V2 scale tier: ${config.targetEvents} generated events`, { skip, timeout: 
     const { samples } = generated;
     generatedSamples = samples;
     requireBudget("daemon attach and measurement", config.measureBudgetMs);
-    f.invoke("attach.daemon-start", ["daemon", "start", "--service"], { timeoutMs: 600_000 });
+    f.invoke("attach.daemon-start", ["daemon", "start", "--service"], {
+      timeoutMs: 600_000,
+      extraEnv: profile?.daemonEnv,
+    });
     f.invoke("attach.first-read", ["task", "list", "--limit", "1"], { timeoutMs: 600_000 });
     const firstWrite = guard("write.first-after-restart", () => importProbe("write.entity-import.first", 0));
     guard("write.first-publication", () => f.publish(firstWrite.receipt, "write.entity-import.first"));
@@ -276,6 +286,7 @@ test(`V2 scale tier: ${config.targetEvents} generated events`, { skip, timeout: 
         await inProcess(`${metric}.warm-up`, argv(0));
         for (let sample = 0; sample < config.readSamples; sample++) await inProcess(metric, argv(sample));
       });
+    await profile?.stopProcess();
 
     // Content exactness and a concurrency negative control, at scale.
     guard("content.exact-bytes", () =>

--- a/tools/stress/entity-v2-scale.workload.json
+++ b/tools/stress/entity-v2-scale.workload.json
@@ -9,5 +9,6 @@
   "writeSamples": 20,
   "binaryBytes": 4096,
   "measureBudgetMs": 300000,
-  "stageBudgetMs": 870000
+  "stageBudgetMs": 870000,
+  "profileDir": null
 }


### PR DESCRIPTION
# English

## Summary

The G6–G8 attribution round (task_2c5cdc09) needed CPU profiles of the measured daemon and a git-invocation timeline to split the 10k→100k growth into its causes. The stress fixture had no way to produce either, so the worker added an opt-in profile switch: when the workload sets `profileDir`, the daemon under test runs with `--cpu-prof`, git resolves through a shim that logs every invocation, and the test marks the start and end of every measured operation on the same monotonic clock. With `profileDir: null` (the committed default) nothing changes.

The measurements themselves live in the task package (report and three facts F-1CB4C60C, F-DACE2FDA, F-045F88C3). Headline: the three candidates named in the mission were all rejected by data; the real causes are `readTaskChildCounts` scanning `task_snapshot` (G6, 90–100 % of the daemon-side growth), fast-import rewriting the flat `facts/` tree on every publish (G7), and the per-process entity fold replaying all events on first write after restart (G8).

## Architectural Justification

-

## What Changed

- `tools/stress/entity-v2-scale.fixture.mjs`: `profiling(profileDir)` (cpu-prof env for the daemon, git shim, timeline marks, inspector sampling of the test process); `fixture()` takes the profile and `invoke()` accepts `extraEnv`.
- `tools/stress/entity-v2-scale.integration.test.mjs`: marks around generation and every in-process measurement; passes the profile env to `daemon start`.
- `tools/stress/entity-v2-scale.workload.json`: `profileDir: null`.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: +49/-4 as counted by the production-delta gate (it counts the fixture); `packages/*` +0/-0.

## Machine-Readable Declarations

- None.

## Task And Scope

- Harness task: task_2c5cdc0935e44e612367e7f2ce (G6–G8 attribution), parent task_2b8f79fa4412cb726a26f9bfc7
- Branch: `codex/perf-daemon-attribution`
- Public scope: `tools/stress` fixture instrumentation only
- Private planning/evidence updated: yes (task report, facts, `artifacts/tools/`, `artifacts/evidence/`)
- Out of scope: the G6/G7/G8 fixes (G6 gets its own kernel projection task; G7/G8 await a layout ruling)

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: not applicable
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `6bcfbbac5`
- Branch merge-base with `origin/main`: `6bcfbbac5`
- Last `git fetch origin` time: 2026-09-11 UTC
- Sync method: branched from origin/main
- Public diff command: `git diff origin/main...codex/perf-daemon-attribution`
- Private evidence commit/path: task_2c5cdc0935e44e612367e7f2ce `artifacts/report.md`, `artifacts/evidence/`
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [ ] `npm run typecheck`
- [ ] `npm run check`
- [ ] `npm test`
- [x] `npm run harness:check-import-boundaries` (via `run-manifest-gates --changed origin/main`)
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts` (via `run-manifest-gates --changed origin/main`)
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Worker ran the stress protocol on the Ubuntu VM through `dispatch-isolated-test`: 10k and 100k tiers, with and without profiling, all exit 0; one run with the committed `enabled:false` skips as designed.

## Review Evidence

- CEO ground-truth: read the full diff; the switch is null-guarded at every call site and the git shim only prepends to PATH inside the profiled daemon's environment.
- Reviewer subagent: not used
- Human review: pending
- Blocking findings: none open

## Residual Risk

- The git shim depends on `sh` and `command -v git`; it is only reached when `profileDir` is set.

## References

- Task: task_2c5cdc0935e44e612367e7f2ce; fixture #2463; measurement task_9c03d77ef810c7e03787c38752

---

# 中文

## 概要

G6–G8 归因轮（task_2c5cdc09）需要被测 daemon 的 CPU profile 和 git 调用时间线，才能把 10k→100k 的增长拆到具体原因。压测夹具此前两样都产不出来，worker 加了 opt-in 的 profile 开关：workload 设 `profileDir` 时，被测 daemon 带 `--cpu-prof` 启动、git 经记录每次调用的 shim 解析、测试对每个被测操作在同一单调时钟上打起止标记。`profileDir: null`（提交的默认值）时行为不变。

测量结果在任务包（报告与三条 fact F-1CB4C60C、F-DACE2FDA、F-045F88C3）。结论：mission 点名的三个候选都被数据否定；真实原因是 `readTaskChildCounts` 全表扫 `task_snapshot`（G6，占 daemon 侧增量 90–100%）、fast-import 每次发布重写平铺 `facts/` 树（G7）、进程内实体 fold 重启后首次写要重放全部事件（G8）。

## 架构辩护

-

## 改动内容

- `tools/stress/entity-v2-scale.fixture.mjs`：`profiling(profileDir)`（daemon 的 cpu-prof 环境、git shim、时间线标记、测试进程 inspector 采样）；`fixture()` 接收 profile，`invoke()` 接受 `extraEnv`。
- `tools/stress/entity-v2-scale.integration.test.mjs`：生成阶段与每个进程内测量前后打标记；把 profile 环境传给 `daemon start`。
- `tools/stress/entity-v2-scale.workload.json`：`profileDir: null`。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 删除的门或 fixture：none
- 生产净行数：production-delta 门计 +49/-4（它把夹具算作生产面）；`packages/*` +0/-0。

## 机器可读声明

- 无。

## 任务与范围

- Harness 任务：task_2c5cdc0935e44e612367e7f2ce（G6–G8 归因），父任务 task_2b8f79fa4412cb726a26f9bfc7
- 分支：`codex/perf-daemon-attribution`
- 公开范围：仅 `tools/stress` 夹具插桩
- 私有计划/证据已更新：是（任务报告、facts、`artifacts/tools/`、`artifacts/evidence/`）
- 范围外：G6/G7/G8 的修复（G6 另立 kernel 投影任务；G7/G8 待布局裁决）

## 版本影响

- 版本：不变
- 发布影响：不发布

## 治理声明

- 触碰受保护面：否
- 受保护面范围：不适用
- 授权：不适用
- 机器检查边界：本 PR 只断言声明存在；是否属实、是否充分由评审判断。
- Break-glass：否
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- 基线 `origin/main` SHA：`6bcfbbac5`
- 分支与 `origin/main` 的 merge-base：`6bcfbbac5`
- 最近一次 `git fetch origin`：2026-09-11 UTC
- 同步方式：从 origin/main 开分支
- 公开 diff 命令：`git diff origin/main...codex/perf-daemon-attribution`
- 私有证据路径：task_2c5cdc0935e44e612367e7f2ce 的 `artifacts/report.md`、`artifacts/evidence/`
- 评审证据路径：本 PR 的评审证据节
- GitHub Actions `rewrite-ci` run URL：本 PR 待跑
- worker 经 `dispatch-isolated-test` 在 Ubuntu VM 跑压测协议：10k 与 100k 两档、带与不带 profile，全部 exit 0；按提交的 `enabled:false` 跑一次按设计 skip。

## 评审证据

- CEO 事实核对：读过完整 diff；开关在每个调用点都有 null 守卫，git shim 只在被 profile 的 daemon 环境里前置到 PATH。
- 评审子代理：未用
- 人工评审：待定
- 阻塞发现：无

## 残余风险

- git shim 依赖 `sh` 与 `command -v git`；只有设了 `profileDir` 才会走到。

## 参考

- 任务：task_2c5cdc0935e44e612367e7f2ce；夹具 #2463；测量任务 task_9c03d77ef810c7e03787c38752
