### PR TITLE
perf: index the task snapshot parent expression for child counts

### DIFF
--- a/packages/kernel/src/projection/projection-schema.ts
+++ b/packages/kernel/src/projection/projection-schema.ts
@@ -1,4 +1,4 @@
 // Version 20 indexes task_relation by task_id and keys decision_fts rows by the decision rowid,
 // so a Task or Decision event no longer scans those tables. A mismatch discards and replays the
 // rebuildable cache.
-export const taskProjectionSchemaVersion = 20;
+export const taskProjectionSchemaVersion = 21;

--- a/packages/kernel/src/projection/rebuildable-task-projection-database.ts
+++ b/packages/kernel/src/projection/rebuildable-task-projection-database.ts
@@ -425,6 +425,8 @@ function createTables(db: DatabaseSync): void {
     CREATE INDEX IF NOT EXISTS task_snapshot_updated_task ON task_snapshot(updated_at DESC, task_id ASC);
     CREATE INDEX IF NOT EXISTS task_snapshot_revision_task ON task_snapshot(workspace_revision, task_id ASC);
     CREATE INDEX IF NOT EXISTS task_snapshot_agenda_status_pin ON task_snapshot(status, pinned DESC, task_id ASC);
+    CREATE INDEX IF NOT EXISTS task_snapshot_parent
+      ON task_snapshot(json_extract(snapshot_json, '$.task.metadata.parentTaskId'));
     CREATE TABLE IF NOT EXISTS task_package (task_id TEXT PRIMARY KEY, package_path TEXT NOT NULL UNIQUE);
     CREATE TABLE IF NOT EXISTS task_generation (
       task_id TEXT PRIMARY KEY,

--- a/packages/kernel/test/store/projection-query-shape.test.ts
+++ b/packages/kernel/test/store/projection-query-shape.test.ts
@@ -20,6 +20,7 @@ import { createRelationGraphProjectionTables } from "../../src/projection/relati
 import {
   createTaskRelationProjectionTable,
   listTaskRowsNarrow,
+  readTaskChildCounts,
   readTaskDependencyClosureRows,
   readTaskIndexRows,
   readTaskRelationPage,
@@ -651,6 +652,36 @@ test("task relation refresh deletes through the task index instead of scanning t
     const plan = queryPlan(db, { sql: "DELETE FROM task_relation WHERE task_id = ?", args: ["task_a"] });
     assert.match(plan, /SEARCH task_relation USING (?:COVERING )?INDEX task_relation_task/u);
     assert.doesNotMatch(plan, /SCAN task_relation(?:\s|$)/u);
+  } finally {
+    db.close();
+  }
+});
+
+test("task child counts search the parent expression index instead of scanning task_snapshot", () => {
+  const db = new DatabaseSync(":memory:");
+  try {
+    db.exec(`
+      CREATE TABLE task_snapshot (task_id TEXT PRIMARY KEY, workspace_revision INTEGER NOT NULL, snapshot_json TEXT NOT NULL,
+        status TEXT, updated_at TEXT NOT NULL DEFAULT '');
+      CREATE INDEX task_snapshot_parent ON task_snapshot(json_extract(snapshot_json, '$.task.metadata.parentTaskId'));
+    `);
+    const insert = db.prepare("INSERT INTO task_snapshot(task_id, workspace_revision, snapshot_json) VALUES (?, ?, ?)");
+    for (let index = 0; index < 200; index += 1)
+      insert.run(
+        `task_${String(index).padStart(5, "0")}`,
+        index + 1,
+        JSON.stringify({ task: { metadata: { parentTaskId: index % 3 === 0 ? "task_00000" : "task_00001" } } }),
+      );
+    // Mirrors the statement readTaskChildCounts issues; the expression must match the index expression verbatim.
+    const parent = "json_extract(snapshot_json, '$.task.metadata.parentTaskId')",
+      sql =
+        `SELECT ${parent} AS parent_task_id, COUNT(*) AS child_count FROM task_snapshot ` +
+        "WHERE COALESCE(json_extract(snapshot_json, '$.task.packageDisposition'), 'active') = 'active' " +
+        `AND ${parent} IN (SELECT value FROM json_each(?)) GROUP BY parent_task_id`,
+      plan = queryPlan(db, { sql, args: [JSON.stringify(["task_00000"])] });
+    assert.match(plan, /SEARCH task_snapshot USING INDEX task_snapshot_parent/u);
+    assert.doesNotMatch(plan, /SCAN task_snapshot(?:\s|$)/u);
+    assert.deepEqual(readTaskChildCounts(db, ["task_00000", "task_00001"]), { task_00000: 67, task_00001: 133 });
   } finally {
     db.close();
   }

--- a/packages/kernel/test/store/schedule-projection.test.ts
+++ b/packages/kernel/test/store/schedule-projection.test.ts
@@ -18,7 +18,7 @@ const actor = { principal: { personId: "person-schedule" }, executor: null } as 
 test("Schedule definition and run view share one canonical stream and rebuild exactly", async () => {
   await withTempStoreAsync(async (rootDir) => {
     initRepo(rootDir);
-    assert.equal(taskProjectionSchemaVersion, 20);
+    assert.equal(taskProjectionSchemaVersion, 21);
     const eventStore = makeTaskEventStore({ repoId: "schedule-projection", rootDir }),
       projection = makeTaskProjection({ rootDir, eventStore }),
       schedule = baseSchedule(),


### PR DESCRIPTION
# English

## Summary

The G6–G8 attribution (task_2c5cdc09, fact F-1CB4C60C) measured that 90–100 % of the daemon-side growth of `task show` and `task list --limit 50` from 10k to 100k tasks (2.2→10.2 ms per request) comes from `readTaskChildCounts`: it scans the whole `task_snapshot` table and `json_extract`s the parent task id from every row (`SCAN task_snapshot`), because no index covers that expression. The result feeds the public payload, so the daemon cannot skip it.

This PR adds an expression index `task_snapshot_parent` on `json_extract(snapshot_json, '$.task.metadata.parentTaskId')` and bumps the task projection schema to 21 so existing projections rebuild with it. The query is unchanged; SQLite picks the index because the expression matches verbatim. A query-plan test asserts `SEARCH task_snapshot USING INDEX task_snapshot_parent` and the counts; without the index the same statement plans as `SCAN task_snapshot` (checked before the change).

## Architectural Justification

-

## What Changed

- `packages/kernel/src/projection/rebuildable-task-projection-database.ts`: `CREATE INDEX IF NOT EXISTS task_snapshot_parent ON task_snapshot(json_extract(snapshot_json, '$.task.metadata.parentTaskId'))`.
- `packages/kernel/src/projection/projection-schema.ts`: `taskProjectionSchemaVersion` 20 → 21.
- `packages/kernel/test/store/projection-query-shape.test.ts`: plan + count assertion for the child-count statement.
- `packages/kernel/test/store/schedule-projection.test.ts`: version assertion 21.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: +3/-1 in `packages/*`.

## Machine-Readable Declarations

- Task projection schema version 21 (projection rebuild on first open).

## Task And Scope

- Harness task: task_9ebd44f89260c693a9713f2b9f (E7 G6), parent task_2b8f79fa4412cb726a26f9bfc7
- Branch: `codex/task-child-counts-index`
- Public scope: kernel task projection DDL and schema version
- Private planning/evidence updated: yes (task plan)
- Out of scope: G7 (ledger git layout) and G8 (entity fold replay), which await a ruling

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: not applicable
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `93cce19ff`
- Branch merge-base with `origin/main`: `93cce19ff`
- Last `git fetch origin` time: 2026-09-11 UTC
- Sync method: branched from origin/main
- Public diff command: `git diff origin/main...codex/task-child-counts-index`
- Private evidence commit/path: task_9ebd44f89260c693a9713f2b9f `task_plan.md`; measurement task_2c5cdc0935e44e612367e7f2ce `artifacts/report.md`
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [ ] `npm run typecheck`
- [ ] `npm run check`
- [ ] `npm test`
- [x] `npm run harness:check-import-boundaries` (via `run-manifest-gates --changed origin/main`)
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts` (via `run-manifest-gates --changed origin/main`)
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- `projection-query-shape.test.ts` + `schedule-projection.test.ts` 16/16; every kernel test referencing the schema version green; negative control: the statement plans as `SCAN task_snapshot` on a table without the index.

## Review Evidence

- CEO ground-truth: wrote the change directly from the attribution report; verified plan with and without the index.
- Reviewer subagent: not used (4-line production diff)
- Human review: pending
- Blocking findings: none open

## Residual Risk

- Every existing projection rebuilds once on first open after deploy (schema 20 → 21); the 100k timing after the index is not re-measured here and belongs to the E7 rerun.

## References

- Task: task_9ebd44f89260c693a9713f2b9f; attribution task_2c5cdc0935e44e612367e7f2ce (fact F-1CB4C60C); earlier projection index PR #2464

---

# 中文

## 概要

G6–G8 归因（task_2c5cdc09，fact F-1CB4C60C）测得 `task show` 与 `task list --limit 50` 从 10k 到 100k 任务的 daemon 侧增长（每请求 2.2→10.2 ms）90–100% 来自 `readTaskChildCounts`：它全表扫 `task_snapshot`、逐行 `json_extract` 父任务 id（`SCAN task_snapshot`），因为没有索引覆盖该表达式；结果进对外 payload，daemon 跳不掉。

本 PR 给 `json_extract(snapshot_json, '$.task.metadata.parentTaskId')` 加表达式索引 `task_snapshot_parent`，并把任务投影 schema 升到 21，让既有投影重建带上它。查询不变；表达式逐字一致，SQLite 自动选用该索引。查询计划测试断言 `SEARCH task_snapshot USING INDEX task_snapshot_parent` 与计数；无索引时同一语句是 `SCAN task_snapshot`（改前验证）。

## 架构辩护

-

## 改动内容

- `packages/kernel/src/projection/rebuildable-task-projection-database.ts`：`CREATE INDEX IF NOT EXISTS task_snapshot_parent ON task_snapshot(json_extract(snapshot_json, '$.task.metadata.parentTaskId'))`。
- `packages/kernel/src/projection/projection-schema.ts`：`taskProjectionSchemaVersion` 20 → 21。
- `packages/kernel/test/store/projection-query-shape.test.ts`：子任务计数语句的计划与计数断言。
- `packages/kernel/test/store/schedule-projection.test.ts`：版本断言改 21。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 删除的门或 fixture：none
- 生产净行数：`packages/*` +3/-1。

## 机器可读声明

- 任务投影 schema 版本 21（首次打开时重建投影）。

## 任务与范围

- Harness 任务：task_9ebd44f89260c693a9713f2b9f（E7 G6），父任务 task_2b8f79fa4412cb726a26f9bfc7
- 分支：`codex/task-child-counts-index`
- 公开范围：kernel 任务投影 DDL 与 schema 版本
- 私有计划/证据已更新：是（任务计划）
- 范围外：G7（台账 git 布局）与 G8（实体 fold 重放），待裁决

## 版本影响

- 版本：不变
- 发布影响：不发布

## 治理声明

- 触碰受保护面：否
- 受保护面范围：不适用
- 授权：不适用
- 机器检查边界：本 PR 只断言声明存在；是否属实、是否充分由评审判断。
- Break-glass：否
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- 基线 `origin/main` SHA：`93cce19ff`
- 分支与 `origin/main` 的 merge-base：`93cce19ff`
- 最近一次 `git fetch origin`：2026-09-11 UTC
- 同步方式：从 origin/main 开分支
- 公开 diff 命令：`git diff origin/main...codex/task-child-counts-index`
- 私有证据路径：task_9ebd44f89260c693a9713f2b9f 的 `task_plan.md`；测量任务 task_2c5cdc0935e44e612367e7f2ce 的 `artifacts/report.md`
- 评审证据路径：本 PR 的评审证据节
- GitHub Actions `rewrite-ci` run URL：本 PR 待跑
- `projection-query-shape.test.ts` + `schedule-projection.test.ts` 16/16；引用 schema 版本的 kernel 测试全绿；阴性对照：无索引的表上同一语句计划为 `SCAN task_snapshot`。

## 评审证据

- CEO 事实核对：按归因报告直接写改动；分别验证了有/无索引的计划。
- 评审子代理：未用（生产 diff 4 行）
- 人工评审：待定
- 阻塞发现：无

## 残余风险

- 部署后每个既有投影首次打开重建一次（schema 20 → 21）；加索引后的 100k 计时本 PR 不复测，归 E7 重跑。

## 参考

- 任务：task_9ebd44f89260c693a9713f2b9f；归因任务 task_2c5cdc0935e44e612367e7f2ce（fact F-1CB4C60C）；前一投影索引 PR #2464
