### PR TITLE
test: keep the default watchdog for unbounded stress files under CI

### DIFF
--- a/tools/run-node-tests.mjs
+++ b/tools/run-node-tests.mjs
@@ -110,8 +110,14 @@ const defaultFileTimeoutMs = positiveIntegerOrDefault(
   process.env.HARNESS_TEST_FILE_TIMEOUT_MS,
   DEFAULT_TEST_FILE_TIMEOUT_MS,
 );
+// An unbounded marker only counts in a dispatched stress run; every GitHub CI job keeps the default
+// watchdog for it (repository owner ruling of 2026-09-11: the exemption never enters per-PR CI).
+const unboundedAllowed = !process.env.CI;
 const selectedFileTimeouts = new Map(
-  selection.files.map((file) => [file, testFileTimeouts[file] ?? defaultFileTimeoutMs]),
+  selection.files.map((file) => {
+    const marked = testFileTimeouts[file];
+    return [file, marked === undefined || (marked === "none" && !unboundedAllowed) ? defaultFileTimeoutMs : marked];
+  }),
 );
 const finiteTimeouts = [...selectedFileTimeouts.values()].filter((timeout) => timeout !== "none");
 const fileTimeoutMs = finiteTimeouts.length > 0 ? Math.min(...finiteTimeouts) : defaultFileTimeoutMs;

--- a/tools/run-node-tests.test.mjs
+++ b/tools/run-node-tests.test.mjs
@@ -131,6 +131,35 @@ test("runner watchdog fails and names a file whose process keeps an open handle"
   );
 });
 
+function runUnboundedFixture(extraEnv) {
+  const childEnv = {
+    ...process.env,
+    HARNESS_RUNNER_UNBOUNDED_FIXTURE: "1",
+    HARNESS_TEST_FILE_TIMEOUT_MS: "250",
+  };
+  delete childEnv.NODE_TEST_CONTEXT;
+  delete childEnv.CI;
+  Object.assign(childEnv, extraEnv);
+  const result = spawnSync(
+    process.execPath,
+    ["tools/run-node-tests.mjs", "--tier", "fast", "--file", "tools/stress/runner-unbounded-fixture.test.mjs"],
+    { cwd: repoRoot, encoding: "utf8", env: childEnv, timeout: 20_000 },
+  );
+  return { result, output: `${result.stdout}\n${result.stderr}` };
+}
+
+test("an unbounded stress marker is honoured outside CI and ignored under CI", () => {
+  const local = runUnboundedFixture({});
+  assert.equal(local.result.status, 0, local.output);
+  assert.doesNotMatch(local.output, /test file exceeded timeout/u);
+  const ci = runUnboundedFixture({ CI: "true" });
+  assert.equal(ci.result.status, 1, ci.output);
+  assert.match(
+    ci.output,
+    /\[node-test-watchdog\] test file exceeded timeout: tools\/stress\/runner-unbounded-fixture\.test\.mjs/u,
+  );
+});
+
 test("test file timeout markers allow stress opt-in and numeric values", () => {
   assert.equal(
     parseTestFileTimeoutMarker(

--- a/tools/stress/runner-unbounded-fixture.test.mjs
+++ b/tools/stress/runner-unbounded-fixture.test.mjs
@@ -1,0 +1,10 @@
+// harness-test-tier: fast
+// harness-test-file-timeout: none
+import test from "node:test";
+
+// Exercised by tools/run-node-tests.test.mjs: outside CI the unbounded marker lets this file outlive a tiny
+// default timeout; under CI=1 the runner keeps the default watchdog and kills it.
+test("runner unbounded fixture", async () => {
+  if (process.env.HARNESS_RUNNER_UNBOUNDED_FIXTURE !== "1") return;
+  await new Promise((resolve) => setTimeout(resolve, 600));
+});


### PR DESCRIPTION
# English

## Summary

#2472 let an opt-in stress file under `tools/stress/` carry `// harness-test-file-timeout: none` so the 1M-event protocol can outlive the 900 s per-file watchdog of `tools/run-node-tests.mjs`. The repository owner ruled on 2026-09-11 that this exemption is for dispatched stress runs only and must never reach per-PR CI, where one unbounded file could hold the merge surface for hours.

The runner now ignores the `none` marker whenever the `CI` environment variable is set (GitHub Actions always sets `CI=true`) and applies the default file timeout to that file; outside CI the marker keeps working. A minimal fixture under `tools/stress/` and a runner test pin both sides: locally the fixture outlives a 250 ms default without being killed, under `CI=true` the watchdog kills it and names the file.

## Architectural Justification

-

## What Changed

- `tools/run-node-tests.mjs`: `unboundedAllowed = !process.env.CI`; a `none` marker resolves to the default timeout when it is false.
- `tools/stress/runner-unbounded-fixture.test.mjs`: fast-tier fixture that sleeps 600 ms only when `HARNESS_RUNNER_UNBOUNDED_FIXTURE=1`.
- `tools/run-node-tests.test.mjs`: `an unbounded stress marker is honoured outside CI and ignored under CI`.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: +46/-1 (tools only; `packages/*` +0/-0).

## Machine-Readable Declarations

- None.

## Task And Scope

- Harness task: task_7662808014e79d4abe3852e0fe, parent task_2b8f79fa4412cb726a26f9bfc7; follow-up of task_2ed2160696da17c94b1e3b4e49 (#2472)
- Branch: `codex/ci-bounded-stress`
- Public scope: test runner watchdog only
- Private planning/evidence updated: yes (task plan)
- Out of scope: `.github/**`, `tools/gate-manifest.json`, `tools/test-tier-manifest.mjs`

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: yes — `tools/run-node-tests.mjs` is CI test-runner tooling referenced by `tools/gate-manifest.json`
- Protected surface scope: narrows the #2472 exemption so it is inert under CI; default timeout, tier rules, workflows and gate manifest unchanged
- Authority: repository owner ruling of 2026-09-11 (the 900 s exemption may be used for dispatched tests but must not enter per-PR CI), recorded in task_7662808014e79d4abe3852e0fe task_plan
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `64b8a63cc`
- Branch merge-base with `origin/main`: `64b8a63cc`
- Last `git fetch origin` time: 2026-09-11 UTC
- Sync method: branched from origin/main
- Public diff command: `git diff origin/main...codex/ci-bounded-stress`
- Private evidence commit/path: task_7662808014e79d4abe3852e0fe `task_plan.md`
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [ ] `npm run typecheck`
- [ ] `npm run check`
- [ ] `npm test`
- [x] `npm run harness:check-import-boundaries` (via `run-manifest-gates --changed origin/main`)
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts` (via `run-manifest-gates --changed origin/main`)
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- `node --test tools/run-node-tests.test.mjs` 24/24; `node tools/test-tier-manifest.mjs` 564 files.

## Review Evidence

- CEO ground-truth: implemented directly from the ruling; the new test spawns the real runner for both environments.
- Reviewer subagent: not used
- Human review: pending
- Blocking findings: none open

## Residual Risk

- The switch keys on the conventional `CI` variable; a self-hosted runner that unsets it would honour the marker again.

## References

- Task: task_7662808014e79d4abe3852e0fe; origin #2472

---

# 中文

## 概要

#2472 让 `tools/stress/` 下的 opt-in 压测文件带 `// harness-test-file-timeout: none`，使 1M 事件协议能超过 `tools/run-node-tests.mjs` 的 900 s 单文件看门狗。仓库所有者 2026-09-11 裁决：这个豁免只用于派测，绝不能进入每次 PR 的 CI——一个无界文件就能把合并面卡住几个小时。

runner 现在只要 `CI` 环境变量存在（GitHub Actions 恒设 `CI=true`）就忽略 `none` 标记、对该文件施加默认超时；CI 之外标记照常生效。`tools/stress/` 下一个最小夹具加一条 runner 测试锁住两侧：本地夹具超过 250 ms 默认值也不被杀，`CI=true` 下看门狗把它杀掉并点名文件。

## 架构辩护

-

## 改动内容

- `tools/run-node-tests.mjs`：`unboundedAllowed = !process.env.CI`；为假时 `none` 标记按默认超时处理。
- `tools/stress/runner-unbounded-fixture.test.mjs`：fast tier 夹具，仅在 `HARNESS_RUNNER_UNBOUNDED_FIXTURE=1` 时睡 600 ms。
- `tools/run-node-tests.test.mjs`：`an unbounded stress marker is honoured outside CI and ignored under CI`。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 删除的门或 fixture：none
- 生产净行数：+46/-1（仅 tools；`packages/*` +0/-0）。

## 机器可读声明

- 无。

## 任务与范围

- Harness 任务：task_7662808014e79d4abe3852e0fe，父任务 task_2b8f79fa4412cb726a26f9bfc7；task_2ed2160696da17c94b1e3b4e49（#2472）的后续
- 分支：`codex/ci-bounded-stress`
- 公开范围：仅测试运行器看门狗
- 私有计划/证据已更新：是（任务计划）
- 范围外：`.github/**`、`tools/gate-manifest.json`、`tools/test-tier-manifest.mjs`

## 版本影响

- 版本：不变
- 发布影响：不发布

## 治理声明

- 触碰受保护面：是——`tools/run-node-tests.mjs` 是 `tools/gate-manifest.json` 引用的 CI 测试运行器工具
- 受保护面范围：把 #2472 的豁免收窄为 CI 下不生效；默认超时、tier 规则、workflow 与 gate manifest 不变
- 授权：仓库所有者 2026-09-11 裁决（900 s 豁免可用于派测，不得进入每次 PR 的 CI），记录在 task_7662808014e79d4abe3852e0fe 的 task_plan
- 机器检查边界：本 PR 只断言声明存在；是否属实、是否充分由评审判断。
- Break-glass：否
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- 基线 `origin/main` SHA：`64b8a63cc`
- 分支与 `origin/main` 的 merge-base：`64b8a63cc`
- 最近一次 `git fetch origin`：2026-09-11 UTC
- 同步方式：从 origin/main 开分支
- 公开 diff 命令：`git diff origin/main...codex/ci-bounded-stress`
- 私有证据路径：task_7662808014e79d4abe3852e0fe 的 `task_plan.md`
- 评审证据路径：本 PR 的评审证据节
- GitHub Actions `rewrite-ci` run URL：本 PR 待跑
- `node --test tools/run-node-tests.test.mjs` 24/24；`node tools/test-tier-manifest.mjs` 564 文件。

## 评审证据

- CEO 事实核对：按裁决直接实现；新测试在两种环境下都真实拉起 runner。
- 评审子代理：未用
- 人工评审：待定
- 阻塞发现：无

## 残余风险

- 开关依赖惯例变量 `CI`；自托管 runner 若取消它，标记会重新生效。

## 参考

- 任务：task_7662808014e79d4abe3852e0fe；源头 #2472
