### PR TITLE
perf: prepare projection statements once per connection and index relation_edge by owner

### DIFF
--- a/packages/kernel/src/projection/decision-projection-admission.ts
+++ b/packages/kernel/src/projection/decision-projection-admission.ts
@@ -11,6 +11,7 @@ import { consumeKnownError } from "../error-consumption.ts";
 import { stableStringify } from "../integrity/stable-hash.ts";
 import { readDecisionDocumentState } from "./decision-projection-documents.ts";
 import { FactProjectionError } from "./fact-event-projection.ts";
+import { prepareQuery } from "./rebuildable-task-projection-sql.ts";
 
 export function assertDecisionAdmission(db: DatabaseSync, event: DecisionEventV1): void {
   const row = decisionState(db, event.decisionId);
@@ -93,17 +94,19 @@ export function assertDecisionAdmission(db: DatabaseSync, event: DecisionEventV1
   if (event.type === "decision_claim_declared") {
     if (!decisionClaimsOpen(row.state)) fail("invalid_transition", "Claims require proposed or in_effect state.");
     if (
-      db
-        .prepare("SELECT 1 FROM decision_claim WHERE decision_id=? AND claim_id=?")
-        .get(event.decisionId, event.payload.claimId)
+      prepareQuery(db, "SELECT 1 FROM decision_claim WHERE decision_id=? AND claim_id=?").get(
+        event.decisionId,
+        event.payload.claimId,
+      )
     )
       fail("invalid_transition", `Claim ${event.payload.claimId} already exists.`);
     return;
   }
   if (event.type === "decision_claim_fulfillment_declared") {
-    const claim = db
-      .prepare("SELECT fulfillment FROM decision_claim WHERE decision_id=? AND claim_id=?")
-      .get(event.decisionId, event.payload.claimId) as { readonly fulfillment: string | null } | undefined;
+    const claim = prepareQuery(db, "SELECT fulfillment FROM decision_claim WHERE decision_id=? AND claim_id=?").get(
+      event.decisionId,
+      event.payload.claimId,
+    ) as { readonly fulfillment: string | null } | undefined;
     if (!claim) fail("anchor_not_found", `Claim ${event.payload.claimId} does not exist.`);
     if (claim.fulfillment) fail("invalid_transition", `Claim ${event.payload.claimId} already has a fulfillment.`);
     return;
@@ -165,7 +168,7 @@ export function decisionState(
   db: DatabaseSync,
   id: string,
 ): { readonly state: DecisionState; readonly proposer_json: string } | undefined {
-  return db.prepare("SELECT state,proposer_json FROM decision WHERE decision_id=?").get(id) as
+  return prepareQuery(db, "SELECT state,proposer_json FROM decision WHERE decision_id=?").get(id) as
     | { readonly state: DecisionState; readonly proposer_json: string }
     | undefined;
 }

--- a/packages/kernel/src/projection/decision-projection-coverage.ts
+++ b/packages/kernel/src/projection/decision-projection-coverage.ts
@@ -2,7 +2,7 @@ import type { DatabaseSync } from "node:sqlite";
 import { coverageOf } from "../domain/decision-coverage.ts";
 import type { DecisionFulfillmentMode } from "../domain/decision-event.ts";
 import type { DecisionCoverageRow } from "./decision-projection-model.ts";
-import { queryRow, queryRows } from "./rebuildable-task-projection-sql.ts";
+import { projectionTables, queryRow, queryRows } from "./rebuildable-task-projection-sql.ts";
 import { relationProjectionRowsAtCut } from "./relation-entity-projection.ts";
 
 // The active edges coverageOf can consult for the requested decisions: those leaving each decision
@@ -71,8 +71,7 @@ export function decisionCoverage(db: DatabaseSync, decisionIds: readonly string[
         factRefs,
       ),
     ),
-    hasTasks = Boolean(queryRow(db, "SELECT 1 FROM sqlite_master WHERE type='table' AND name='task_snapshot'")),
-    tasks = hasTasks
+    tasks = projectionTables(db).has("task_snapshot")
       ? queryRows<{
           readonly task_id: string;
           readonly status: string;

--- a/packages/kernel/src/projection/decision-projection-documents.ts
+++ b/packages/kernel/src/projection/decision-projection-documents.ts
@@ -3,11 +3,11 @@ import { decisionDocumentProse, type DecisionDocumentState } from "../domain/dec
 import type { DocumentState } from "../domain/doc-sync.contract.ts";
 import type { DecisionBodyRow, DecisionRelationEdgeRow } from "./decision-projection-model.ts";
 import { readDecisionRow } from "./decision-projection-reads.ts";
-import { queryRows } from "./rebuildable-task-projection-sql.ts";
+import { prepareQuery, queryRows } from "./rebuildable-task-projection-sql.ts";
 
 export function readDecisionBody(db: DatabaseSync, decisionId: string): DecisionBodyRow | null {
   const path = `decisions/decision-${decisionId}/decision.md`,
-    row = db.prepare("SELECT value_json FROM document WHERE path=?").get(path) as
+    row = prepareQuery(db, "SELECT value_json FROM document WHERE path=?").get(path) as
       | { readonly value_json: string }
       | undefined;
   return row ? decisionBodyFromDocument(decisionId, row.value_json) : null;

--- a/packages/kernel/src/projection/decision-projection-reducer.ts
+++ b/packages/kernel/src/projection/decision-projection-reducer.ts
@@ -4,14 +4,14 @@ import type { DocumentState } from "../domain/doc-sync.contract.ts";
 import { assertDecisionAdmission, decisionState, fail } from "./decision-projection-admission.ts";
 import { readDecisionBody } from "./decision-projection-documents.ts";
 import { applyEmbeddedRelationProjectionEvents } from "./relation-entity-projection.ts";
-import { queryRows } from "./rebuildable-task-projection-sql.ts";
+import { prepareQuery, queryRows } from "./rebuildable-task-projection-sql.ts";
 
 export function reduceDecisionEvent(db: DatabaseSync, event: DecisionEventV1): void {
   assertDecisionAdmission(db, event);
   const revision = event.workspaceRevision;
   if (event.type === "decision_proposed") {
     const p = event.payload;
-    db.prepare("INSERT INTO decision VALUES (?, 'proposed', ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, ?, NULL, ?, ?)").run(
+    prepareQuery(db, "INSERT INTO decision VALUES (?, 'proposed', ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, ?, NULL, ?, ?)").run(
       event.decisionId,
       p.title,
       p.question,
@@ -26,12 +26,12 @@ export function reduceDecisionEvent(db: DatabaseSync, event: DecisionEventV1): v
       JSON.stringify(p.provenance ?? []),
       revision,
     );
-    const insert = db.prepare("INSERT INTO decision_option VALUES (?, ?, ?, ?, ?, ?, ?)");
+    const insert = prepareQuery(db, "INSERT INTO decision_option VALUES (?, ?, ?, ?, ?, ?, ?)");
     for (const [position, option] of p.chosen.entries())
       insert.run(event.decisionId, "chosen", option.id, position, option.text, option.rationale ?? null, revision);
     for (const [position, option] of p.rejected.entries())
       insert.run(event.decisionId, "rejected", option.id, position, option.text, option.whyNot, revision);
-    const claim = db.prepare("INSERT INTO decision_claim VALUES (?, ?, ?, ?, ?, ?, ?, ?)");
+    const claim = prepareQuery(db, "INSERT INTO decision_claim VALUES (?, ?, ?, ?, ?, ?, ?, ?)");
     for (const [position, entry] of p.claims.entries()) {
       const fulfillment = p.fulfillments.find((candidate) => candidate.claimId === entry.id)?.mode ?? null;
       claim.run(
@@ -49,13 +49,14 @@ export function reduceDecisionEvent(db: DatabaseSync, event: DecisionEventV1): v
     refreshDecisionFts(db, event.decisionId);
     return;
   }
-  db.prepare("UPDATE decision SET workspace_revision=? WHERE decision_id=?").run(revision, event.decisionId);
+  prepareQuery(db, "UPDATE decision SET workspace_revision=? WHERE decision_id=?").run(revision, event.decisionId);
   if (event.type === "decision_accepted" || event.type === "decision_rejected" || event.type === "decision_deferred") {
     const state = event.type === "decision_accepted" ? "in_effect" : event.type.slice("decision_".length);
-    db.prepare(
+    prepareQuery(
+      db,
       "UPDATE decision SET state=?, arbiter_json=?, decided_at=?, workspace_revision=? WHERE decision_id=?",
     ).run(state, JSON.stringify(event.actor), event.occurredAt, revision, event.decisionId);
-    db.prepare("INSERT INTO decision_judgment_consent VALUES (?, ?, ?, ?)").run(
+    prepareQuery(db, "INSERT INTO decision_judgment_consent VALUES (?, ?, ?, ?)").run(
       event.payload.judgmentConsent.consentId,
       event.decisionId,
       revision,
@@ -63,9 +64,12 @@ export function reduceDecisionEvent(db: DatabaseSync, event: DecisionEventV1): v
     );
     if (event.type === "decision_accepted") {
       if (event.payload.standingPolicy)
-        db.prepare("UPDATE decision SET decision_class='standing_policy' WHERE decision_id=?").run(event.decisionId);
+        prepareQuery(db, "UPDATE decision SET decision_class='standing_policy' WHERE decision_id=?").run(
+          event.decisionId,
+        );
       for (const fulfillment of event.payload.fulfillments ?? [])
-        db.prepare(
+        prepareQuery(
+          db,
           "UPDATE decision_claim SET fulfillment=?, fulfilled_revision=? WHERE decision_id=? AND claim_id=?",
         ).run(fulfillment.mode, revision, event.decisionId, fulfillment.claimId);
     }
@@ -75,7 +79,7 @@ export function reduceDecisionEvent(db: DatabaseSync, event: DecisionEventV1): v
   }
   if (event.type === "decision_superseded" || event.type === "decision_retired") {
     const state = event.type === "decision_superseded" ? "superseded" : "outcome_retired";
-    db.prepare("UPDATE decision SET state=?, decided_at=?, workspace_revision=? WHERE decision_id=?").run(
+    prepareQuery(db, "UPDATE decision SET state=?, decided_at=?, workspace_revision=? WHERE decision_id=?").run(
       state,
       event.occurredAt,
       revision,
@@ -87,19 +91,19 @@ export function reduceDecisionEvent(db: DatabaseSync, event: DecisionEventV1): v
   }
   if (event.type === "decision_amended") {
     const next = event.payload.next;
-    db.prepare("UPDATE decision SET title=?, decision_class=? WHERE decision_id=?").run(
+    prepareQuery(db, "UPDATE decision SET title=?, decision_class=? WHERE decision_id=?").run(
       next.title,
       next.decisionClass,
       event.decisionId,
     );
-    db.prepare("DELETE FROM decision_option WHERE decision_id=?").run(event.decisionId);
-    const option = db.prepare("INSERT INTO decision_option VALUES (?, ?, ?, ?, ?, ?, ?)");
+    prepareQuery(db, "DELETE FROM decision_option WHERE decision_id=?").run(event.decisionId);
+    const option = prepareQuery(db, "INSERT INTO decision_option VALUES (?, ?, ?, ?, ?, ?, ?)");
     for (const [position, value] of next.chosen.entries())
       option.run(event.decisionId, "chosen", value.id, position, value.text, value.rationale ?? null, revision);
     for (const [position, value] of next.rejected.entries())
       option.run(event.decisionId, "rejected", value.id, position, value.text, value.whyNot, revision);
-    db.prepare("DELETE FROM decision_claim WHERE decision_id=?").run(event.decisionId);
-    const claim = db.prepare("INSERT INTO decision_claim VALUES (?, ?, ?, ?, ?, ?, ?, ?)");
+    prepareQuery(db, "DELETE FROM decision_claim WHERE decision_id=?").run(event.decisionId);
+    const claim = prepareQuery(db, "INSERT INTO decision_claim VALUES (?, ?, ?, ?, ?, ?, ?, ?)");
     for (const [position, value] of next.claims.entries())
       claim.run(
         event.decisionId,
@@ -111,7 +115,7 @@ export function reduceDecisionEvent(db: DatabaseSync, event: DecisionEventV1): v
         revision,
         value.fulfillment ? revision : null,
       );
-    db.prepare("INSERT INTO decision_amendment VALUES (?, ?, ?, ?)").run(
+    prepareQuery(db, "INSERT INTO decision_amendment VALUES (?, ?, ?, ?)").run(
       event.payload.amendment.amendmentId,
       event.decisionId,
       revision,
@@ -126,7 +130,8 @@ export function reduceDecisionEvent(db: DatabaseSync, event: DecisionEventV1): v
     return;
   }
   if (event.type === "decision_claim_declared") {
-    db.prepare(
+    prepareQuery(
+      db,
       [
         "INSERT INTO decision_claim VALUES (?, ?,",
         "(SELECT COALESCE(MAX(position), -1) + 1 FROM decision_claim WHERE decision_id=?),",
@@ -144,12 +149,10 @@ export function reduceDecisionEvent(db: DatabaseSync, event: DecisionEventV1): v
     return;
   }
   if (event.type === "decision_claim_fulfillment_declared") {
-    db.prepare("UPDATE decision_claim SET fulfillment=?, fulfilled_revision=? WHERE decision_id=? AND claim_id=?").run(
-      event.payload.mode,
-      revision,
-      event.decisionId,
-      event.payload.claimId,
-    );
+    prepareQuery(
+      db,
+      "UPDATE decision_claim SET fulfillment=?, fulfilled_revision=? WHERE decision_id=? AND claim_id=?",
+    ).run(event.payload.mode, revision, event.decisionId, event.payload.claimId);
     return;
   }
   if (
@@ -166,7 +169,7 @@ export function reduceDecisionEvent(db: DatabaseSync, event: DecisionEventV1): v
 function insertDecisionPin(db: DatabaseSync, event: DecisionEventV1): void {
   if (!("contentPin" in event.payload) || event.payload.contentPin === undefined) return;
   const pin = event.payload.contentPin;
-  db.prepare("INSERT INTO decision_content_pin VALUES (?, ?, ?, ?)").run(
+  prepareQuery(db, "INSERT INTO decision_content_pin VALUES (?, ?, ?, ?)").run(
     pin.pinId,
     event.decisionId,
     event.workspaceRevision,
@@ -182,7 +185,7 @@ export function refreshDecisionDocumentSearch(db: DatabaseSync, document: Docume
 function refreshDecisionFts(db: DatabaseSync, decisionId: string): void {
   // decision_id is UNINDEXED in the fts5 table, so the search row is keyed by the decision rowid
   // (stable: decision rows are inserted once and only updated) instead of deleted by a column scan.
-  const row = db.prepare("SELECT rowid, title, question FROM decision WHERE decision_id=?").get(decisionId) as
+  const row = prepareQuery(db, "SELECT rowid, title, question FROM decision WHERE decision_id=?").get(decisionId) as
     | { readonly rowid: number; readonly title: string; readonly question: string }
     | undefined;
   if (!row) return;
@@ -197,8 +200,9 @@ function refreshDecisionFts(db: DatabaseSync, decisionId: string): void {
       .map((c) => c.text)
       .join(" "),
     body = readDecisionBody(db, decisionId)?.body ?? "";
-  db.prepare("DELETE FROM decision_fts WHERE rowid=?").run(row.rowid);
-  db.prepare(
+  prepareQuery(db, "DELETE FROM decision_fts WHERE rowid=?").run(row.rowid);
+  prepareQuery(
+    db,
     "INSERT INTO decision_fts(rowid, decision_id, title, question, option_text, claim_text, body) " +
       "VALUES (?, ?, ?, ?, ?, ?, ?)",
   ).run(row.rowid, decisionId, row.title, row.question, options, claims, body);

--- a/packages/kernel/src/projection/entity-freshness-projection.ts
+++ b/packages/kernel/src/projection/entity-freshness-projection.ts
@@ -1,6 +1,7 @@
 import type { DatabaseSync } from "node:sqlite";
 import { parseEntityRef } from "../domain/entity-ref.ts";
 import type { EntityFreshness, EntityVersionWitness } from "../domain/entity-freshness.ts";
+import { prepareQuery, projectionTables } from "./rebuildable-task-projection-sql.ts";
 
 export function readEntityVersionWitness(db: DatabaseSync, entityRef: string): EntityVersionWitness {
   return readEntityVersionWitnesses(db, [entityRef]).get(entityRef)!;
@@ -13,12 +14,7 @@ export function readEntityVersionWitnesses(
   const uniqueRefs = [...new Set(entityRefs)],
     witnesses = new Map<string, EntityVersionWitness>();
   if (uniqueRefs.length === 0) return witnesses;
-  const tables = new Set(
-    db
-      .prepare("SELECT name FROM sqlite_master WHERE type='table'")
-      .all()
-      .map((row) => String((row as { readonly name: unknown }).name)),
-  );
+  const tables = projectionTables(db);
   const requests = uniqueRefs.map((entityRef) => {
       const parsed = parseEntityRef(entityRef);
       return {
@@ -51,9 +47,9 @@ export function readEntityVersionWitnesses(
       .filter(({ table }) => tables.has(table))
       .map(({ kind }) => `${kind}_version.workspace_revision`),
     coreVersion = coreVersions.length > 1 ? `COALESCE(${coreVersions.join(", ")})` : (coreVersions[0] ?? "NULL"),
-    rows = db
-      .prepare(
-        `WITH requested AS (
+    rows = prepareQuery(
+      db,
+      `WITH requested AS (
           SELECT CAST(key AS INTEGER) AS position,
             json_extract(value, '$.ref') AS ref,
             json_extract(value, '$.kind') AS kind,
@@ -65,8 +61,7 @@ export function readEntityVersionWitnesses(
                WHEN ${coreVersion} IS NOT NULL THEN 'current' ELSE 'unknown' END AS freshness,
           CASE WHEN ${projectedPresent} THEN ${projectedVersion} ELSE ${coreVersion} END AS current_version
         FROM requested ${joins.join(" ")} ORDER BY requested.position`,
-      )
-      .all(JSON.stringify(requests)) as unknown as readonly {
+    ).all(JSON.stringify(requests)) as unknown as readonly {
       readonly ref: string;
       readonly freshness: EntityFreshness;
       readonly current_version: string | number | null;

--- a/packages/kernel/src/projection/fact-event-projection.ts
+++ b/packages/kernel/src/projection/fact-event-projection.ts
@@ -12,7 +12,7 @@ import type { FactAnchorRow } from "./relation-graph-projection.ts";
 import { factInvalidated, factLiveness } from "../domain/fact-liveness.ts";
 import { ftsQuery } from "./fts-query.ts";
 import { applyEmbeddedRelationProjectionEvents } from "./relation-entity-projection.ts";
-import { queryRows, type ProjectionSqlRow } from "./rebuildable-task-projection-sql.ts";
+import { prepareQuery, queryRows, type ProjectionSqlRow } from "./rebuildable-task-projection-sql.ts";
 
 export interface FactProjectionRow {
   readonly schema: "fact-row/v1";
@@ -110,13 +110,13 @@ export function createFactProjectionTables(db: DatabaseSync): void {
 
 export function assertFactAdmission(db: DatabaseSync, event: FactEventV1): void {
   const ownRef = factRef(event.factId);
-  const existing = db.prepare("SELECT 1 FROM fact WHERE fact_id = ?").get(event.factId);
+  const existing = prepareQuery(db, "SELECT 1 FROM fact WHERE fact_id = ?").get(event.factId);
   if (event.type === "fact_reclassified" && !existing)
     throw new FactProjectionError("entity_not_found", `Fact ${ownRef} does not exist.`);
   if (event.type === "fact_recorded" && existing)
     throw new FactProjectionError("invalid_transition", `Fact ${ownRef} already exists.`);
   if (event.type === "fact_reclassified") {
-    const record = db.prepare("SELECT row_json FROM fact WHERE fact_id = ?").get(event.factId) as
+    const record = prepareQuery(db, "SELECT row_json FROM fact WHERE fact_id = ?").get(event.factId) as
       | { readonly row_json: string }
       | undefined;
     const row = record ? (JSON.parse(record.row_json) as FactProjectionRow) : null;
@@ -133,18 +133,18 @@ export function assertFactAdmission(db: DatabaseSync, event: FactEventV1): void 
       throw new FactProjectionError("invalid_transition", `Fact ${ownRef} reclassification changed observation data.`);
   }
   if (event.payload.registersDomainType) {
-    if (db.prepare("SELECT 1 FROM fact_domain_type WHERE domain_type = ?").get(event.payload.registersDomainType))
+    if (prepareQuery(db, "SELECT 1 FROM fact_domain_type WHERE domain_type = ?").get(event.payload.registersDomainType))
       throw new FactProjectionError(
         "invalid_transition",
         `Fact domain type ${event.payload.registersDomainType} is already registered.`,
       );
   }
   for (const domainType of event.payload.domainTypes ?? [])
-    if (!db.prepare("SELECT 1 FROM fact_domain_type WHERE domain_type = ?").get(domainType))
+    if (!prepareQuery(db, "SELECT 1 FROM fact_domain_type WHERE domain_type = ?").get(domainType))
       throw new FactProjectionError("fact_type_unregistered", `Fact domain type ${domainType} is not registered.`);
   const supersedes = event.payload.supersedes;
   if (!supersedes) return;
-  const target = db.prepare("SELECT ref FROM fact WHERE ref = ?").get(supersedes.factRef) as
+  const target = prepareQuery(db, "SELECT ref FROM fact WHERE ref = ?").get(supersedes.factRef) as
     | { readonly ref: string }
     | undefined;
   if (target && factLiveness(target, livenessRelations(db, [target.ref])) === "superseded_fact")
@@ -157,17 +157,18 @@ export function assertFactAdmission(db: DatabaseSync, event: FactEventV1): void 
 export function reduceFactEvent(db: DatabaseSync, event: FactEventV1): void {
   assertFactAdmission(db, event);
   if (event.type === "fact_reclassified") {
-    const record = db.prepare("SELECT row_json FROM fact WHERE fact_id = ?").get(event.factId) as
+    const record = prepareQuery(db, "SELECT row_json FROM fact WHERE fact_id = ?").get(event.factId) as
       | { readonly row_json: string }
       | undefined;
     if (!record) throw new FactProjectionError("entity_not_found", `Fact fact/${event.factId} does not exist.`);
     const row = JSON.parse(record.row_json) as FactProjectionRow;
-    db.prepare("UPDATE fact SET workspace_revision = ?, row_json = ? WHERE fact_id = ?").run(
+    prepareQuery(db, "UPDATE fact SET workspace_revision = ?, row_json = ? WHERE fact_id = ?").run(
       event.workspaceRevision,
       JSON.stringify({ ...row, domainTypes: event.payload.domainTypes, workspaceRevision: event.workspaceRevision }),
       event.factId,
     );
-    db.prepare(
+    prepareQuery(
+      db,
       "INSERT INTO fact_reclassification" +
         "(op_id, fact_id, domain_types_json, rationale, workspace_revision) VALUES (?, ?, ?, ?, ?)",
     ).run(
@@ -198,7 +199,8 @@ export function reduceFactEvent(db: DatabaseSync, event: FactEventV1): void {
     occurredAt: event.occurredAt,
     workspaceRevision: event.workspaceRevision,
   };
-  db.prepare(
+  prepareQuery(
+    db,
     "INSERT INTO fact(task_id, fact_id, ref, statement, evidence_source, observed_at, confidence, memory_class, op_id, workspace_revision, row_json) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
   ).run(
     event.taskId ?? null,
@@ -214,10 +216,11 @@ export function reduceFactEvent(db: DatabaseSync, event: FactEventV1): void {
     JSON.stringify(row),
   );
   if (event.payload.registersDomainType)
-    db.prepare(
+    prepareQuery(
+      db,
       "INSERT INTO fact_domain_type(domain_type, registered_by_fact_id, workspace_revision) VALUES (?, ?, ?)",
     ).run(event.payload.registersDomainType, event.factId, event.workspaceRevision);
-  db.prepare("INSERT INTO fact_fts(fact_id, statement, evidence_source) VALUES (?, ?, ?)").run(
+  prepareQuery(db, "INSERT INTO fact_fts(fact_id, statement, evidence_source) VALUES (?, ?, ?)").run(
     event.factId,
     row.statement,
     row.evidenceSource,
@@ -280,7 +283,7 @@ function listFactRows(db: DatabaseSync, where: string, values: readonly string[]
   );
 }
 export function readFactRow(db: DatabaseSync, factId: string): FactProjectionRow | null {
-  const record = db.prepare(`${factRowSelect} WHERE fact_id = ?`).get(factId) as FactRecord | undefined;
+  const record = prepareQuery(db, `${factRowSelect} WHERE fact_id = ?`).get(factId) as FactRecord | undefined;
   return record ? (decodeFactRows(db, [record])[0] ?? null) : null;
 }
 

--- a/packages/kernel/src/projection/rebuildable-task-projection-catch-up.ts
+++ b/packages/kernel/src/projection/rebuildable-task-projection-catch-up.ts
@@ -8,12 +8,17 @@ import {
 import type { EventContentPrefetch, EventStreamPort } from "./rebuildable-task-projection-types.ts";
 import type { ProjectionApplyReceipt } from "./projection-reads.ts";
 import { applyEvent } from "./rebuildable-task-projection-event-application.ts";
-import { queryRows, runSql, transaction, watermark } from "./rebuildable-task-projection-sql.ts";
+import { prepareQuery, queryRows, runSql, transaction, watermark } from "./rebuildable-task-projection-sql.ts";
 export type { ProjectionPage, TaskProjectionListQuery, TaskRelationQuery } from "./task-query-projection.ts";
 export type { TaskProjection } from "./task-projection-port.ts";
 
 // Incremental source scanning, deferred-event staging, and batch replay.
 const batchContentPrefetchers = new WeakMap<EventStreamPort, EventContentPrefetch>();
+const SCAN_STATE_SQL = "SELECT scan_cursor, scanned_revision FROM projection_meta WHERE singleton = 1",
+  NEXT_DEFERRED_EVENT_SQL = [
+    "SELECT event_json FROM event_source WHERE workspace_revision = ?",
+    "OR (? = 1 AND workspace_revision > ?) ORDER BY workspace_revision LIMIT 1",
+  ].join(" ");
 export function reduceBatch(
   db: DatabaseSync,
   events: readonly CanonicalEventV1[],
@@ -24,12 +29,9 @@ export function reduceBatch(
   return transaction(db, () => {
     for (const event of events) stageEvent(db, event);
     const reducedItems = drainDeferred(db, limit, readBlob, true);
-    const state =
-      /* @gate-identity check-bypass-write-boundary/bypass-write-001 */
-      db.prepare("SELECT scan_cursor, scanned_revision FROM projection_meta WHERE singleton = 1").get() as {
-        readonly scan_cursor: string | null;
-        readonly scanned_revision: number;
-      };
+    const state = prepareQuery(db, SCAN_STATE_SQL, (sql) =>
+      /* @gate-identity check-bypass-write-boundary/bypass-write-001 */ db.prepare(sql),
+    ).get() as { readonly scan_cursor: string | null; readonly scanned_revision: number };
     const last = events.at(-1);
     if (
       last !== undefined &&
@@ -61,19 +63,16 @@ export function catchUpRound(
 } {
   const head = eventStore.readHead();
   const sourceRevision = head?.revision ?? 0;
-  const state =
-    /* @gate-identity check-bypass-write-boundary/bypass-write-002 */
-    db.prepare("SELECT scan_cursor, scanned_revision FROM projection_meta WHERE singleton = 1").get() as {
-      readonly scan_cursor: string | null;
-      readonly scanned_revision: number;
-    };
+  const state = prepareQuery(db, SCAN_STATE_SQL, (sql) =>
+    /* @gate-identity check-bypass-write-boundary/bypass-write-002 */ db.prepare(sql),
+  ).get() as { readonly scan_cursor: string | null; readonly scanned_revision: number };
   const shouldScan = state.scan_cursor !== null || state.scanned_revision < sourceRevision;
   const batch = shouldScan ? eventStore.readBatch(state.scan_cursor, limit) : null;
   if (batch?.prefetchContent !== undefined) batchContentPrefetchers.set(eventStore, batch.prefetchContent);
   const hasDeferred =
-    /* @gate-identity check-bypass-write-boundary/bypass-write-003 */
-    db.prepare("SELECT 1 AS present FROM event_source WHERE workspace_revision > ? LIMIT 1").get(watermark(db)) !==
-    undefined;
+    prepareQuery(db, "SELECT 1 AS present FROM event_source WHERE workspace_revision > ? LIMIT 1", (sql) =>
+      /* @gate-identity check-bypass-write-boundary/bypass-write-003 */ db.prepare(sql),
+    ).get(watermark(db)) !== undefined;
   if (batch === null && !hasDeferred)
     return {
       sourceRevision,
@@ -152,20 +151,18 @@ function readyDeferredEvents(
 
 function stageEvent(db: DatabaseSync, event: CanonicalEventV1): void {
   const eventJson = serializePersistedCanonicalEvent(event).trimEnd();
-  const applied =
-    /* @gate-identity check-bypass-write-boundary/bypass-write-004 */
-    db.prepare("SELECT event_json FROM event_index WHERE op_id = ?").get(event.opId) as
-      | { readonly event_json: string }
-      | undefined;
+  const applied = prepareQuery(db, "SELECT event_json FROM event_index WHERE op_id = ?", (sql) =>
+    /* @gate-identity check-bypass-write-boundary/bypass-write-004 */ db.prepare(sql),
+  ).get(event.opId) as { readonly event_json: string } | undefined;
   if (applied !== undefined) {
     if (applied.event_json !== eventJson) throw new Error(`projection opId ${event.opId} names different bytes`);
     return;
   }
-  const staged =
-    /* @gate-identity check-bypass-write-boundary/bypass-write-005 */
-    db
-      .prepare("SELECT event_json FROM event_source WHERE op_id = ? OR workspace_revision = ?")
-      .get(event.opId, event.workspaceRevision) as { readonly event_json: string } | undefined;
+  const staged = prepareQuery(
+    db,
+    "SELECT event_json FROM event_source WHERE op_id = ? OR workspace_revision = ?",
+    (sql) => /* @gate-identity check-bypass-write-boundary/bypass-write-005 */ db.prepare(sql),
+  ).get(event.opId, event.workspaceRevision) as { readonly event_json: string } | undefined;
   if (staged !== undefined) {
     if (staged.event_json !== eventJson)
       throw new Error(`projection revision or opId ${event.opId} names different bytes`);
@@ -189,16 +186,9 @@ function drainDeferred(
   let next = watermark(db),
     reduced = 0;
   while (reduced < limit) {
-    const row =
-      /* @gate-identity check-bypass-write-boundary/bypass-write-006 */
-      db
-        .prepare(
-          [
-            "SELECT event_json FROM event_source WHERE workspace_revision = ?",
-            "OR (? = 1 AND workspace_revision > ?) ORDER BY workspace_revision LIMIT 1",
-          ].join(" "),
-        )
-        .get(next + 1, allowRevisionGaps ? 1 : 0, next) as { readonly event_json: string } | undefined;
+    const row = prepareQuery(db, NEXT_DEFERRED_EVENT_SQL, (sql) =>
+      /* @gate-identity check-bypass-write-boundary/bypass-write-006 */ db.prepare(sql),
+    ).get(next + 1, allowRevisionGaps ? 1 : 0, next) as { readonly event_json: string } | undefined;
     if (row === undefined) break;
     const event = JSON.parse(row.event_json) as CanonicalEventV1;
     applyEvent(db, normalizePersistedCanonicalEvent(event), row.event_json, readBlob);

--- a/packages/kernel/src/projection/rebuildable-task-projection-database.ts
+++ b/packages/kernel/src/projection/rebuildable-task-projection-database.ts
@@ -9,7 +9,7 @@ import { createRelationGraphProjectionTables } from "./relation-graph-projection
 import { taskProjectionSchemaVersion } from "./projection-schema.ts";
 import { createTaskRelationProjectionTable } from "./task-query-projection.ts";
 import type { EventStreamPort } from "./rebuildable-task-projection-types.ts";
-import { queryRows, runSql } from "./rebuildable-task-projection-sql.ts";
+import { prepareQuery, queryRows, runSql } from "./rebuildable-task-projection-sql.ts";
 export type { ProjectionPage, TaskProjectionListQuery, TaskRelationQuery } from "./task-query-projection.ts";
 export type { TaskProjection } from "./task-projection-port.ts";
 
@@ -224,12 +224,11 @@ function projectionDatabaseOwner(
       if (db !== null && fingerprint !== projectionFileFingerprint(projectionPath)) close();
       if (db === null) initialize();
     }
+    // initialize() verified the schema version of this file identity; only a replaced file
+    // (a changed fingerprint) can carry another one, and that reopens and verifies again.
     useDepth += 1;
     let succeeded = false;
     try {
-      const observed = projectionSchemaVersion(db!);
-      if (observed !== null && observed > taskProjectionSchemaVersion)
-        throw new ProjectionSchemaMismatchError(observed, projectionPath);
       assertLedgerIdentity(db!, readHead());
       const value = operation(db!);
       succeeded = true;
@@ -267,13 +266,11 @@ function projectionFileFingerprint(projectionPath: string): string | null {
 // which has scanned or applied beyond the current source cut may be the only readable copy of those
 // revisions, so opening must retain it and fail closed.
 function assertLedgerIdentity(db: DatabaseSync, head: ReturnType<EventStreamPort["readHead"]>): void {
-  const row =
-    /* @gate-identity check-bypass-write-boundary/bypass-write-010 */
-    db.prepare("SELECT watermark, scanned_revision, head_digest FROM projection_meta WHERE singleton = 1").get() as {
-      readonly watermark: number;
-      readonly scanned_revision: number;
-      readonly head_digest: string | null;
-    };
+  const row = prepareQuery(
+    db,
+    "SELECT watermark, scanned_revision, head_digest FROM projection_meta WHERE singleton = 1",
+    (sql) => /* @gate-identity check-bypass-write-boundary/bypass-write-010 */ db.prepare(sql),
+  ).get() as { readonly watermark: number; readonly scanned_revision: number; readonly head_digest: string | null };
   const sourceRevision = head?.revision ?? 0;
   if (Number(row.watermark) > sourceRevision || Number(row.scanned_revision) > sourceRevision)
     throw new ProjectionEventStreamIncompleteError(

--- a/packages/kernel/src/projection/rebuildable-task-projection-event-application.ts
+++ b/packages/kernel/src/projection/rebuildable-task-projection-event-application.ts
@@ -51,7 +51,7 @@ import {
   readSnapshot,
   refreshRuntimeSessionAssociations,
 } from "./rebuildable-task-projection-runtime.ts";
-import { canonicalJson, runSql } from "./rebuildable-task-projection-sql.ts";
+import { canonicalJson, prepareQuery, runSql } from "./rebuildable-task-projection-sql.ts";
 import { applyEmbeddedRelationProjectionEvents, applyRelationProjectionEvent } from "./relation-entity-projection.ts";
 export type { ProjectionPage, TaskProjectionListQuery, TaskRelationQuery } from "./task-query-projection.ts";
 export type { TaskProjection } from "./task-projection-port.ts";
@@ -400,11 +400,9 @@ export function applyEvent(
       eventJson,
     );
     for (const change of event.payload.changes) {
-      const previous =
-          /* @gate-identity check-bypass-write-boundary/bypass-write-011 */
-          db.prepare("SELECT value_json FROM document WHERE path = ?").get(change.path) as
-            | { readonly value_json: string }
-            | undefined,
+      const previous = prepareQuery(db, "SELECT value_json FROM document WHERE path = ?", (sql) =>
+          /* @gate-identity check-bypass-write-boundary/bypass-write-011 */ db.prepare(sql),
+        ).get(change.path) as { readonly value_json: string } | undefined,
         base = previous ? (JSON.parse(previous.value_json) as DocumentState) : null;
       if (change.candidate === null) {
         if (

--- a/packages/kernel/src/projection/rebuildable-task-projection-reads.ts
+++ b/packages/kernel/src/projection/rebuildable-task-projection-reads.ts
@@ -15,6 +15,7 @@ import { discardDatabase, withDatabase } from "./rebuildable-task-projection-dat
 import { catchUpRound } from "./rebuildable-task-projection-catch-up.ts";
 import { markRuntimeSessionsUnknown, readSnapshot } from "./rebuildable-task-projection-runtime.ts";
 import {
+  prepareQuery,
   queryPreparedRows,
   readProjectionCut,
   readStateDigest,
@@ -23,6 +24,17 @@ import {
 } from "./rebuildable-task-projection-sql.ts";
 export type { ProjectionPage, TaskProjectionListQuery, TaskRelationQuery } from "./task-query-projection.ts";
 export type { TaskProjection } from "./task-projection-port.ts";
+
+const UNPARAMETERIZED_LIST_SQL = [
+  "SELECT task_snapshot.task_id AS task_id, task_package.package_path AS package_path,",
+  "COALESCE(task_generation.generation, 'v1') AS generation,",
+  "task_snapshot.workspace_revision AS workspace_revision,",
+  `${taskCreatedAtSql("task_snapshot.task_id")} AS created_at,`,
+  "event_index.event_json AS event_json FROM task_snapshot",
+  "LEFT JOIN task_package USING(task_id) LEFT JOIN task_generation USING(task_id)",
+  "JOIN event_index ON event_index.workspace_revision = task_snapshot.workspace_revision",
+  "ORDER BY task_snapshot.task_id",
+].join(" ");
 
 // Cache-backed task, document, preset, and rebuild reads.
 export function listProjection(
@@ -56,18 +68,8 @@ export function listProjection(
         readonly created_at: string | null;
         readonly event_json: string;
       }>(
-        /* @gate-identity check-bypass-write-boundary/bypass-write-012 */
-        db.prepare(
-          [
-            "SELECT task_snapshot.task_id AS task_id, task_package.package_path AS package_path,",
-            "COALESCE(task_generation.generation, 'v1') AS generation,",
-            "task_snapshot.workspace_revision AS workspace_revision,",
-            `${taskCreatedAtSql("task_snapshot.task_id")} AS created_at,`,
-            "event_index.event_json AS event_json FROM task_snapshot",
-            "LEFT JOIN task_package USING(task_id) LEFT JOIN task_generation USING(task_id)",
-            "JOIN event_index ON event_index.workspace_revision = task_snapshot.workspace_revision",
-            "ORDER BY task_snapshot.task_id",
-          ].join(" "),
+        prepareQuery(db, UNPARAMETERIZED_LIST_SQL, (sql) =>
+          /* @gate-identity check-bypass-write-boundary/bypass-write-012 */ db.prepare(sql),
         ),
       );
       return {
@@ -115,11 +117,9 @@ export function readDocument(
 ): DocumentProjectionRead {
   return withDatabase(projectionPath, readHead, (db) => {
     const cut = readProjectionCut(db, readHead),
-      row =
-        /* @gate-identity check-bypass-write-boundary/bypass-write-013 */
-        db.prepare("SELECT value_json FROM document WHERE path = ?").get(documentPath) as
-          | { readonly value_json: string }
-          | undefined;
+      row = prepareQuery(db, "SELECT value_json FROM document WHERE path = ?", (sql) =>
+        /* @gate-identity check-bypass-write-boundary/bypass-write-013 */ db.prepare(sql),
+      ).get(documentPath) as { readonly value_json: string } | undefined;
     return {
       status: cut.status,
       document: row ? (JSON.parse(row.value_json) as DocumentState) : null,
@@ -137,11 +137,9 @@ export function readPresetSnapshot(
 ): PresetSnapshotProjectionRead {
   return withDatabase(projectionPath, readHead, (db) => {
     const cut = readProjectionCut(db, readHead),
-      row =
-        /* @gate-identity check-bypass-write-boundary/bypass-write-014 */
-        db.prepare("SELECT value_json FROM preset_snapshot WHERE digest = ?").get(digest) as
-          | { readonly value_json: string }
-          | undefined;
+      row = prepareQuery(db, "SELECT value_json FROM preset_snapshot WHERE digest = ?", (sql) =>
+        /* @gate-identity check-bypass-write-boundary/bypass-write-014 */ db.prepare(sql),
+      ).get(digest) as { readonly value_json: string } | undefined;
     return {
       status: cut.status,
       snapshot: row ? JSON.parse(row.value_json) : null,
@@ -166,11 +164,10 @@ export function readProjection(
       status: cut.status,
       snapshot: readSnapshot(db, taskId, now()),
       packagePath:
-        /* @gate-identity check-bypass-write-boundary/bypass-write-015 */
         (
-          db.prepare("SELECT package_path FROM task_package WHERE task_id = ?").get(taskId) as
-            | { readonly package_path: string }
-            | undefined
+          prepareQuery(db, "SELECT package_path FROM task_package WHERE task_id = ?", (sql) =>
+            /* @gate-identity check-bypass-write-boundary/bypass-write-015 */ db.prepare(sql),
+          ).get(taskId) as { readonly package_path: string } | undefined
         )?.package_path ?? null,
       watermark: cut.watermark,
       sourceRevision: cut.sourceRevision,

--- a/packages/kernel/src/projection/rebuildable-task-projection-runtime-api.ts
+++ b/packages/kernel/src/projection/rebuildable-task-projection-runtime-api.ts
@@ -23,7 +23,7 @@ import {
   squadRunProjectionReady,
   upsertSquadRun,
 } from "./rebuildable-task-projection-squad-runs.ts";
-import { transaction } from "./rebuildable-task-projection-sql.ts";
+import { prepareQuery, transaction } from "./rebuildable-task-projection-sql.ts";
 export type { ProjectionPage, TaskProjectionListQuery, TaskRelationQuery } from "./task-query-projection.ts";
 export type { TaskProjection } from "./task-projection-port.ts";
 
@@ -78,11 +78,11 @@ export function runtimeLeaseApi(
       withDatabase(projectionPath, readHead, (db) => effectiveLease(db, taskId, at ?? now())),
     currentLeaseForExecution: (executionId, at) =>
       withDatabase(projectionPath, readHead, (db: DatabaseSync) => {
-        const row =
-          /* @gate-identity check-bypass-write-boundary/bypass-write-016 */
-          db
-            .prepare("SELECT task_id FROM lease_cas WHERE json_extract(lease_json, '$.executionId') = ?")
-            .get(executionId) as { readonly task_id: string } | undefined;
+        const row = prepareQuery(
+          db,
+          "SELECT task_id FROM lease_cas WHERE json_extract(lease_json, '$.executionId') = ?",
+          (sql) => /* @gate-identity check-bypass-write-boundary/bypass-write-016 */ db.prepare(sql),
+        ).get(executionId) as { readonly task_id: string } | undefined;
         return row ? effectiveLease(db, row.task_id, at ?? now()) : null;
       }),
     reserveLease: (lease, now) =>

--- a/packages/kernel/src/projection/rebuildable-task-projection-runtime.ts
+++ b/packages/kernel/src/projection/rebuildable-task-projection-runtime.ts
@@ -14,7 +14,13 @@ import {
   type RuntimeSession,
 } from "../domain/agent-runtime.ts";
 import { validateTaskV2 } from "../domain/task.ts";
-import { canonicalJson, queryPreparedRows, queryRows, runSql } from "./rebuildable-task-projection-sql.ts";
+import {
+  canonicalJson,
+  prepareQuery,
+  queryPreparedRows,
+  queryRows,
+  runSql,
+} from "./rebuildable-task-projection-sql.ts";
 import type { LeaseInterval } from "./projection-reads.ts";
 import type { RuntimeSessionPageQuery, RuntimeSessionPageRead } from "./task-projection-port.ts";
 import { readRelationProjectionRows } from "./relation-entity-projection.ts";
@@ -30,6 +36,7 @@ const INSERT_LEASE_INTERVAL_SQL = [
   "holder_json, previous_holder_json, lease_expires_at, reason)",
   "VALUES (?, ?, ?, NULL, ?, ?, ?, ?)",
 ].join(" ");
+const UPDATE_LEASE_SQL = "UPDATE lease_cas SET lease_json = ? WHERE task_id = ?";
 const UPDATE_LEASE_EXPIRY_SQL = [
   "UPDATE lease_interval SET lease_expires_at = ?",
   "WHERE task_id = ? AND execution_id = ? AND released_revision IS NULL",
@@ -51,15 +58,15 @@ export function replayClaim(
 ): void {
   const lease = checkedLease(event.payload.lease);
   const reserving = { ...lease, phase: "reserving" as const };
-  /* @gate-identity check-bypass-write-boundary/bypass-write-017 */
-  db.prepare(UPSERT_LEASE_SQL).run(event.taskId, canonicalJson(reserving));
-  /* @gate-identity check-bypass-write-boundary/bypass-write-018 */
-  db.prepare("UPDATE lease_cas SET lease_json = ? WHERE task_id = ?").run(
-    canonicalJson({ ...lease, phase: "held" }),
-    event.taskId,
-  );
-  /* @gate-identity check-bypass-write-boundary/bypass-write-019 */
-  db.prepare(INSERT_LEASE_INTERVAL_SQL).run(
+  prepareQuery(db, UPSERT_LEASE_SQL, (sql) =>
+    /* @gate-identity check-bypass-write-boundary/bypass-write-017 */ db.prepare(sql),
+  ).run(event.taskId, canonicalJson(reserving));
+  prepareQuery(db, UPDATE_LEASE_SQL, (sql) =>
+    /* @gate-identity check-bypass-write-boundary/bypass-write-018 */ db.prepare(sql),
+  ).run(canonicalJson({ ...lease, phase: "held" }), event.taskId);
+  prepareQuery(db, INSERT_LEASE_INTERVAL_SQL, (sql) =>
+    /* @gate-identity check-bypass-write-boundary/bypass-write-019 */ db.prepare(sql),
+  ).run(
     event.taskId,
     lease.executionId,
     event.workspaceRevision,
@@ -82,17 +89,20 @@ export function replayRenew(db: DatabaseSync, event: Extract<TaskEventV1, { read
     current.version + 1 === renewed.version;
   if (!matchesPrevious && canonicalJson(current) !== canonicalJson(renewed))
     throw new Error(`stale lease renewal event for task ${event.taskId}`);
-  /* @gate-identity check-bypass-write-boundary/bypass-write-020 */
-  db.prepare(UPSERT_LEASE_SQL).run(event.taskId, canonicalJson(renewed));
-  /* @gate-identity check-bypass-write-boundary/bypass-write-021 */
-  db.prepare(UPDATE_LEASE_EXPIRY_SQL).run(renewed.expiresAt, event.taskId, renewed.executionId);
+  prepareQuery(db, UPSERT_LEASE_SQL, (sql) =>
+    /* @gate-identity check-bypass-write-boundary/bypass-write-020 */ db.prepare(sql),
+  ).run(event.taskId, canonicalJson(renewed));
+  prepareQuery(db, UPDATE_LEASE_EXPIRY_SQL, (sql) =>
+    /* @gate-identity check-bypass-write-boundary/bypass-write-021 */ db.prepare(sql),
+  ).run(renewed.expiresAt, event.taskId, renewed.executionId);
 }
 
 export function replayRelease(db: DatabaseSync, taskId: string, executionId: string, revision: number): void {
   const lease = storedLease(db, taskId);
   if (lease !== null && lease.executionId === executionId)
-    /* @gate-identity check-bypass-write-boundary/bypass-write-022 */
-    db.prepare("UPDATE lease_cas SET lease_json = ? WHERE task_id = ?").run(
+    prepareQuery(db, UPDATE_LEASE_SQL, (sql) =>
+      /* @gate-identity check-bypass-write-boundary/bypass-write-022 */ db.prepare(sql),
+    ).run(
       canonicalJson({
         ...lease,
         phase: "released",
@@ -100,16 +110,15 @@ export function replayRelease(db: DatabaseSync, taskId: string, executionId: str
       }),
       taskId,
     );
-  /* @gate-identity check-bypass-write-boundary/bypass-write-023 */
-  db.prepare(UPDATE_LEASE_RELEASE_SQL).run(revision, taskId, executionId);
+  prepareQuery(db, UPDATE_LEASE_RELEASE_SQL, (sql) =>
+    /* @gate-identity check-bypass-write-boundary/bypass-write-023 */ db.prepare(sql),
+  ).run(revision, taskId, executionId);
 }
 
 export function readSnapshot(db: DatabaseSync, taskId: string, now?: string): TaskLifecycleSnapshot {
-  const row =
-    /* @gate-identity check-bypass-write-boundary/bypass-write-024 */
-    db.prepare("SELECT snapshot_json FROM task_snapshot WHERE task_id = ?").get(taskId) as
-      | { readonly snapshot_json: string }
-      | undefined;
+  const row = prepareQuery(db, "SELECT snapshot_json FROM task_snapshot WHERE task_id = ?", (sql) =>
+    /* @gate-identity check-bypass-write-boundary/bypass-write-024 */ db.prepare(sql),
+  ).get(taskId) as { readonly snapshot_json: string } | undefined;
   if (row === undefined) return emptyTaskLifecycleSnapshot();
   let snapshot: TaskLifecycleSnapshot;
   try {
@@ -157,8 +166,9 @@ export function readSnapshot(db: DatabaseSync, taskId: string, now?: string): Ta
 
 export function readIntervals(db: DatabaseSync, taskId: string): readonly LeaseInterval[] {
   const rows = queryPreparedRows(
-    /* @gate-identity check-bypass-write-boundary/bypass-write-025 */
-    db.prepare("SELECT * FROM lease_interval WHERE task_id = ? ORDER BY acquired_revision"),
+    prepareQuery(db, "SELECT * FROM lease_interval WHERE task_id = ? ORDER BY acquired_revision", (sql) =>
+      /* @gate-identity check-bypass-write-boundary/bypass-write-025 */ db.prepare(sql),
+    ),
     taskId,
   );
   return rows.map((row) => ({
@@ -179,9 +189,9 @@ export function reserve(db: DatabaseSync, lease: LeaseV1, now: string): LeaseV1 
   const current = effectiveLease(db, lease.taskId, now);
   if (current !== null && current.phase !== "orphaned" && current.phase !== "released")
     throw new Error(`lease conflict for task ${lease.taskId}`);
-  const count =
-    /* @gate-identity check-bypass-write-boundary/bypass-write-026 */
-    db.prepare(COUNT_ACTIVE_LEASES_SQL).get(now) as { readonly count: number };
+  const count = prepareQuery(db, COUNT_ACTIVE_LEASES_SQL, (sql) =>
+    /* @gate-identity check-bypass-write-boundary/bypass-write-026 */ db.prepare(sql),
+  ).get(now) as { readonly count: number };
   if (count.count >= TASK_LEASE_BROKER_CONTRACT.capacity)
     throw new Error(
       `lease capacity ${TASK_LEASE_BROKER_CONTRACT.capacity} exhausted; wait for a lease to be released or expire`,
@@ -189,8 +199,9 @@ export function reserve(db: DatabaseSync, lease: LeaseV1, now: string): LeaseV1 
   const expectedVersion = current === null ? 0 : current.version + 1;
   if (lease.phase !== "reserving" || lease.version !== expectedVersion)
     throw new Error(`stale lease reservation for task ${lease.taskId}`);
-  /* @gate-identity check-bypass-write-boundary/bypass-write-027 */
-  db.prepare(UPSERT_LEASE_SQL).run(lease.taskId, canonicalJson(lease));
+  prepareQuery(db, UPSERT_LEASE_SQL, (sql) =>
+    /* @gate-identity check-bypass-write-boundary/bypass-write-027 */ db.prepare(sql),
+  ).run(lease.taskId, canonicalJson(lease));
   return lease;
 }
 
@@ -220,7 +231,7 @@ export function changeLease(
     expiresAt,
     version: current.version + 1,
   });
-  runSql(db, "UPDATE lease_cas SET lease_json = ? WHERE task_id = ?", canonicalJson(next), next.taskId);
+  runSql(db, UPDATE_LEASE_SQL, canonicalJson(next), next.taskId);
   return next;
 }
 

--- a/packages/kernel/src/projection/rebuildable-task-projection-sql.ts
+++ b/packages/kernel/src/projection/rebuildable-task-projection-sql.ts
@@ -35,11 +35,9 @@ const stateDigestTables = [
 ] as const;
 
 export function watermark(db: DatabaseSync): number {
-  const row =
-    /* @gate-identity check-bypass-write-boundary/bypass-write-031 */
-    db.prepare("SELECT watermark FROM projection_meta WHERE singleton = 1").get() as {
-      readonly watermark: number;
-    };
+  const row = prepareQuery(db, "SELECT watermark FROM projection_meta WHERE singleton = 1", (sql) =>
+    /* @gate-identity check-bypass-write-boundary/bypass-write-031 */ db.prepare(sql),
+  ).get() as { readonly watermark: number };
   return Number(row.watermark);
 }
 
@@ -130,10 +128,38 @@ export function queryTransaction<A>(db: DatabaseSync, run: () => A): A {
 }
 type SqlValue = string | number | bigint | Uint8Array | null;
 export function runSql(db: DatabaseSync, sql: string, ...values: readonly SqlValue[]): number | bigint {
-  return /* @gate-identity check-bypass-write-boundary/bypass-write-035 */ db.prepare(sql).run(...values).changes;
+  return prepareQuery(db, sql, (text) =>
+    /* @gate-identity check-bypass-write-boundary/bypass-write-035 */ db.prepare(text),
+  ).run(...values).changes;
 }
-export function prepareQuery(db: DatabaseSync, sql: string) {
-  return /* @gate-identity check-bypass-write-boundary/bypass-write-036 */ db.prepare(sql);
+// Statements are keyed by connection object and SQL text. Closing a connection finalizes its
+// statements and a reopen constructs a new object, so a finalized statement is never reused.
+const connectionStatements = new WeakMap<DatabaseSync, Map<string, StatementSync>>();
+/** The connection's statement for `sql`, prepared on first use. Call sites that carry their own
+ * write-boundary identity pass the `prepare` that performs it. */
+export function prepareQuery(
+  db: DatabaseSync,
+  sql: string,
+  prepare = (text: string) => /* @gate-identity check-bypass-write-boundary/bypass-write-036 */ db.prepare(text),
+): StatementSync {
+  let statements = connectionStatements.get(db);
+  if (statements === undefined) connectionStatements.set(db, (statements = new Map()));
+  let statement = statements.get(sql);
+  if (statement === undefined) statements.set(sql, (statement = prepare(sql)));
+  return statement;
+}
+/** Table names read once per connection: every table is created while a connection initializes. */
+const connectionTables = new WeakMap<DatabaseSync, ReadonlySet<string>>();
+export function projectionTables(db: DatabaseSync): ReadonlySet<string> {
+  let tables = connectionTables.get(db);
+  if (tables === undefined)
+    connectionTables.set(
+      db,
+      (tables = new Set(
+        queryRows(db, "SELECT name FROM sqlite_master WHERE type='table'").map(({ name }) => String(name)),
+      )),
+    );
+  return tables;
 }
 export type ProjectionSqlRow = Readonly<Record<string, SQLOutputValue>>;
 export function queryRow<Row extends ProjectionSqlRow = ProjectionSqlRow>(

--- a/packages/kernel/src/projection/rebuildable-task-projection-task-queries.ts
+++ b/packages/kernel/src/projection/rebuildable-task-projection-task-queries.ts
@@ -21,6 +21,7 @@ import { withDatabase } from "./rebuildable-task-projection-database.ts";
 import { catchUpRound } from "./rebuildable-task-projection-catch-up.ts";
 import { readDocument, readPresetSnapshot } from "./rebuildable-task-projection-reads.ts";
 import {
+  prepareQuery,
   readProjectionCut,
   watermark,
   queryTransaction,
@@ -85,6 +86,7 @@ const REPLICA_DOCUMENTS_SQL = [
   "json_extract(value_json, '$.mediaType') AS media_type",
   "FROM document ORDER BY path",
 ].join(" ");
+const EVENT_BY_OP_SQL = "SELECT event_json FROM event_index WHERE op_id = ?";
 const TASK_FOR_DOCUMENT_SQL = [
   "SELECT task_id FROM task_package WHERE ? = package_path",
   "OR substr(?, 1, length(package_path) + 1) = package_path || '/'",
@@ -225,11 +227,9 @@ export function taskQueryApi(
       }),
     readOperation: (opId) =>
       withDatabase(projectionPath, readHead, (db) => {
-        const row =
-          /* @gate-identity check-bypass-write-boundary/bypass-write-037 */
-          db.prepare("SELECT event_json FROM event_index WHERE op_id = ?").get(opId) as
-            | { readonly event_json: string }
-            | undefined;
+        const row = prepareQuery(db, EVENT_BY_OP_SQL, (sql) =>
+          /* @gate-identity check-bypass-write-boundary/bypass-write-037 */ db.prepare(sql),
+        ).get(opId) as { readonly event_json: string } | undefined;
         return row === undefined ? null : { event: JSON.parse(row.event_json), watermark: watermark(db) };
       }),
     readRelationEdge: (relationId) =>
@@ -238,11 +238,9 @@ export function taskQueryApi(
       withDatabase(projectionPath, readHead, (db) => readEntityVersionWitness(db, entityRef)),
     readTaskOperation: (opId) =>
       withDatabase(projectionPath, readHead, (db) => {
-        const row =
-          /* @gate-identity check-bypass-write-boundary/bypass-write-038 */
-          db.prepare("SELECT event_json FROM event_index WHERE op_id = ?").get(opId) as
-            | { readonly event_json: string }
-            | undefined;
+        const row = prepareQuery(db, EVENT_BY_OP_SQL, (sql) =>
+          /* @gate-identity check-bypass-write-boundary/bypass-write-038 */ db.prepare(sql),
+        ).get(opId) as { readonly event_json: string } | undefined;
         if (!row) return null;
         const event = JSON.parse(row.event_json);
         return isTaskEvent(event) ? { event, watermark: watermark(db) } : null;
@@ -349,11 +347,10 @@ export function taskQueryApi(
         projectionPath,
         readHead,
         (db) =>
-          /* @gate-identity check-bypass-write-boundary/bypass-write-039 */
           (
-            db.prepare(TASK_FOR_DOCUMENT_SQL).get(documentPath, documentPath) as
-              | { readonly task_id: string }
-              | undefined
+            prepareQuery(db, TASK_FOR_DOCUMENT_SQL, (sql) =>
+              /* @gate-identity check-bypass-write-boundary/bypass-write-039 */ db.prepare(sql),
+            ).get(documentPath, documentPath) as { readonly task_id: string } | undefined
           )?.task_id ?? null,
       ),
     readPresetSnapshot: (digest) => readPresetSnapshot(projectionPath, readHead, eventStore, digest, limit),

--- a/packages/kernel/src/projection/relation-entity-projection.ts
+++ b/packages/kernel/src/projection/relation-entity-projection.ts
@@ -17,7 +17,7 @@ import {
 } from "../domain/relation-event.ts";
 import type { MigrationImportEventV1 } from "../domain/migration-import-event.ts";
 import type { RelationGraphEdgeRow } from "./relation-graph-projection.ts";
-import { canonicalJson, queryRow, queryRows, runSql } from "./rebuildable-task-projection-sql.ts";
+import { canonicalJson, projectionTables, queryRow, queryRows, runSql } from "./rebuildable-task-projection-sql.ts";
 import { refreshTaskRelationProjection } from "./task-query-projection.ts";
 import { readEntityVersionWitness, readEntityVersionWitnesses } from "./entity-freshness-projection.ts";
 import { relationFreshnessAtCut, type EntityVersionWitness } from "../domain/entity-freshness.ts";
@@ -65,11 +65,7 @@ export function applyRelationProjectionEvent(
     canonicalJson(row),
   );
   const taskId = row.sourceRef.match(/^task\/([^/]+)$/u)?.[1];
-  const taskRelationReady = queryRow(
-    db,
-    "SELECT 1 AS present FROM sqlite_master WHERE type='table' AND name='task_relation'",
-  );
-  if (taskId && taskRelationReady)
+  if (taskId && projectionTables(db).has("task_relation"))
     refreshTaskRelationProjection(db, taskId, null, row.workspaceRevision, entity.updatedAt);
   return row;
 }

--- a/packages/kernel/src/projection/relation-graph-projection.ts
+++ b/packages/kernel/src/projection/relation-graph-projection.ts
@@ -81,6 +81,7 @@ export function createRelationGraphProjectionTables(db: DatabaseSync): void {
     CREATE INDEX IF NOT EXISTS relation_edge_state_page ON relation_edge(state, relation_id);
     CREATE INDEX IF NOT EXISTS relation_edge_target_observation
       ON relation_edge(target_ref, target_observed_version, relation_id);
+    CREATE INDEX IF NOT EXISTS relation_edge_owner ON relation_edge(owner_ref, relation_id);
   `);
 }
 

--- a/packages/kernel/src/projection/task-query-projection.ts
+++ b/packages/kernel/src/projection/task-query-projection.ts
@@ -7,7 +7,7 @@ import type { EntityRelationRecord, RelationType } from "../domain/entity-relati
 import type { EntityVersion, EntityVersionWitness, RelationFreshness } from "../domain/entity-freshness.ts";
 import { validateTaskV2, type ReplayTaskStatus, type TaskV2 } from "../domain/task.ts";
 import type { TaskIndexProjectionRow } from "./projection-reads.ts";
-import { queryRows, type ProjectionSqlRow } from "./rebuildable-task-projection-sql.ts";
+import { prepareQuery, queryRows, type ProjectionSqlRow } from "./rebuildable-task-projection-sql.ts";
 import { readEntityVersionWitnesses } from "./entity-freshness-projection.ts";
 import { relationFreshnessAtCut } from "../domain/entity-freshness.ts";
 
@@ -322,8 +322,9 @@ export function refreshTaskRelationProjection(
   updatedAt: string,
   _packagePath?: string | null,
 ): void {
-  db.prepare("DELETE FROM task_relation WHERE task_id = ?").run(taskId);
-  db.prepare(
+  prepareQuery(db, "DELETE FROM task_relation WHERE task_id = ?").run(taskId);
+  prepareQuery(
+    db,
     [
       "INSERT INTO task_relation(relation_id, task_id, source_ref, target_ref, relation_type, direction, strength, origin, state, rationale, owner_ref, source_path, record_index, workspace_revision, updated_at)",
       "SELECT relation_id, ?, source_ref, target_ref, relation_type,",

--- a/packages/kernel/test/store/projection-ddl-rebuild.test.ts
+++ b/packages/kernel/test/store/projection-ddl-rebuild.test.ts
@@ -40,6 +40,35 @@ test("explicit projection rebuild replaces stale DDL even when its version claim
   });
 });
 
+// A pure index needs no replay: every owner runs CREATE INDEX IF NOT EXISTS when it opens, so a
+// current-version cache written before the index existed gains it in place.
+test("an owner adds the relation owner index to a current-version cache in place", async () => {
+  await withTempStoreAsync(async (rootDir) => {
+    const { projectionPath, eventStore } = tasklessFactLedger(rootDir, "owner-index", "F-0A1B2C3D");
+    const projection = makeTaskProjection({ rootDir, eventStore });
+    projection.catchUp();
+    projection.close();
+    const indexed = (db: DatabaseSync) =>
+      db.prepare("SELECT 1 FROM sqlite_master WHERE type='index' AND name='relation_edge_owner'").get() !== undefined;
+    const stale = new DatabaseSync(projectionPath);
+    try {
+      stale.exec("DROP INDEX relation_edge_owner");
+      assert.equal(indexed(stale), false);
+    } finally {
+      stale.close();
+    }
+    const reopened = makeTaskProjection({ rootDir, eventStore });
+    assert.equal(reopened.searchFacts({ query: "standalone" }).facts[0]?.factId, "F-0A1B2C3D");
+    reopened.close();
+    const current = new DatabaseSync(projectionPath, { readOnly: true });
+    try {
+      assert.equal(indexed(current), true);
+    } finally {
+      current.close();
+    }
+  });
+});
+
 function tasklessFactLedger(rootDir: string, repoId: string, factId: string) {
   initRepo(rootDir);
   const eventStore = makeTaskEventStore({ repoId, rootDir }),

--- a/packages/kernel/test/store/projection-identity-binding.test.ts
+++ b/packages/kernel/test/store/projection-identity-binding.test.ts
@@ -2,6 +2,7 @@
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
 import { readFileSync } from "node:fs";
+import { StatementSync, type SQLInputValue } from "node:sqlite";
 import test from "node:test";
 import { makeTaskProjection } from "../../src/projection/rebuildable-task-projection.ts";
 import { makeTaskEventStore, type CanonicalEventStore } from "../../src/store/task-event-store.ts";
@@ -11,6 +12,7 @@ import { sha256Text } from "../../src/integrity/stable-hash.ts";
 import { compileFactWrite, type FactEventDraftV1 } from "../../src/domain/fact-event.ts";
 import { lifecycleFixture } from "./task-lifecycle-fixture.ts";
 import { withTempStoreAsync } from "./helpers.ts";
+import { memoryEventStore } from "./task-owned-entity-projection.fixtures.ts";
 
 // Two ledgers at the same revision with different content is exactly the shape a genesis replay
 // produces: the whole ledger is rewritten while the head revision stays put. A projection cache
@@ -118,6 +120,37 @@ test("a cache ahead of a replacement source history is retained and rejected", a
       );
       assert.deepEqual(readFileSync(projectionA.path), retained);
     });
+  });
+});
+
+// A file identity carries one schema version, so the owner verifies it when a connection opens.
+// The ledger identity follows the live source head and is still verified on every operation.
+test("the owner verifies the schema per connection and the ledger identity per operation", async () => {
+  await withTempStoreAsync(async (rootDir) => {
+    const projection = makeTaskProjection({
+      rootDir,
+      eventStore: memoryEventStore(lifecycleFixture().events.slice(0, 2)),
+    });
+    projection.catchUp();
+    const executed: string[] = [],
+      { get, all } = StatementSync.prototype;
+    StatementSync.prototype.get = function (this: StatementSync, ...values: SQLInputValue[]) {
+      executed.push(this.sourceSQL);
+      return get.apply(this, values);
+    };
+    StatementSync.prototype.all = function (this: StatementSync, ...values: SQLInputValue[]) {
+      executed.push(this.sourceSQL);
+      return all.apply(this, values);
+    };
+    try {
+      for (let read = 0; read < 3; read += 1) assert.equal(projection.readDocument("missing.md").document, null);
+    } finally {
+      StatementSync.prototype.get = get;
+      StatementSync.prototype.all = all;
+      projection.close();
+    }
+    assert.equal(executed.filter((sql) => sql.includes("table_info(projection_meta)")).length, 0);
+    assert.equal(executed.filter((sql) => sql.includes("head_digest FROM projection_meta")).length, 3);
   });
 });
 

--- a/packages/kernel/test/store/projection-query-shape.test.ts
+++ b/packages/kernel/test/store/projection-query-shape.test.ts
@@ -16,6 +16,8 @@ import {
   searchFactRows,
   type FactProjectionRow,
 } from "../../src/projection/fact-event-projection.ts";
+import { readEntityVersionWitnesses } from "../../src/projection/entity-freshness-projection.ts";
+import { prepareQuery, queryRow, runSql } from "../../src/projection/rebuildable-task-projection-sql.ts";
 import { createRelationGraphProjectionTables } from "../../src/projection/relation-graph-projection.ts";
 import {
   createTaskRelationProjectionTable,
@@ -77,12 +79,15 @@ function countingDatabase(): {
   readonly db: DatabaseSync;
   readonly executions: () => number;
   readonly reads: () => readonly { readonly sql: string; readonly args: readonly unknown[] }[];
+  readonly prepared: () => readonly string[];
 } {
   const db = new DatabaseSync(":memory:"),
     prepare = db.prepare.bind(db);
   let executions = 0;
-  const reads: { sql: string; args: readonly unknown[] }[] = [];
+  const reads: { sql: string; args: readonly unknown[] }[] = [],
+    prepared: string[] = [];
   db.prepare = ((sql: string) => {
+    prepared.push(sql);
     const statement = prepare(sql);
     for (const method of ["all", "get"] as const) {
       const original = statement[method].bind(statement);
@@ -94,7 +99,7 @@ function countingDatabase(): {
     }
     return statement;
   }) as typeof db.prepare;
-  return { db, executions: () => executions, reads: () => reads };
+  return { db, executions: () => executions, reads: () => reads, prepared: () => prepared };
 }
 
 function seed(db: DatabaseSync, decisions: number, facts: number): void {
@@ -540,8 +545,9 @@ test("task context collection reads stay indexed, bounded, and constant in state
       derives.map(({ relationId }) => relationId),
       ["rel_decision_a"],
     );
+    // The first read on this connection also resolves its table set; the second reuses it.
     assert.equal(afterClosure - before, 3);
-    assert.equal(afterTargets - afterClosure, 3);
+    assert.equal(afterTargets - afterClosure, 2);
     assert.throws(() => readTaskDependencyClosureRows(db, ["task/a"], 1), /depth limit/u);
     const closureRead = counted.reads().find(({ sql }) => sql.includes("WITH RECURSIVE dependency_walk"))!,
       targetRead = counted.reads().find(({ sql }) => sql.includes("requested_targets"))!;
@@ -642,6 +648,43 @@ test("decision collection read uses one statement and indexed owner lookups", (c
     );
   } finally {
     db.close();
+  }
+});
+
+test("a projection connection prepares each statement once and reads its table set once", () => {
+  const counted = countingDatabase(),
+    { db } = counted;
+  try {
+    seed(db, 2, 2);
+    const before = counted.prepared().length,
+      refs = ["fact/F-00000000", "decision/dec_SHAPE_00000", "task/task-missing"];
+    for (let round = 1; round <= 3; round += 1) {
+      assert.equal(readEntityVersionWitnesses(db, refs).get("fact/F-00000000")?.currentVersion, 1);
+      runSql(db, "UPDATE projection_meta SET watermark = ? WHERE singleton = 1", round);
+      assert.equal(queryRow(db, "SELECT watermark FROM projection_meta WHERE singleton = 1")?.watermark, round);
+    }
+    const prepared = counted.prepared().slice(before);
+    assert.equal(prepared.length, 4, prepared.join("\n"));
+    assert.equal(new Set(prepared).size, prepared.length);
+    assert.equal(counted.reads().filter(({ sql }) => sql.includes("sqlite_master")).length, 1);
+  } finally {
+    db.close();
+  }
+});
+
+test("prepared statements belong to the connection that prepared them", () => {
+  const first = new DatabaseSync(":memory:"),
+    statement = prepareQuery(first, "SELECT 1 AS one");
+  assert.equal(prepareQuery(first, "SELECT 1 AS one"), statement);
+  first.close();
+  const second = new DatabaseSync(":memory:");
+  try {
+    const reopened = prepareQuery(second, "SELECT 1 AS one");
+    assert.notEqual(reopened, statement);
+    assert.deepEqual({ ...reopened.get() }, { one: 1 });
+    assert.throws(() => statement.get(), /finalized/u);
+  } finally {
+    second.close();
   }
 });
 

--- a/packages/kernel/test/store/projection-query-shape.test.ts
+++ b/packages/kernel/test/store/projection-query-shape.test.ts
@@ -688,6 +688,21 @@ test("prepared statements belong to the connection that prepared them", () => {
   }
 });
 
+test("a Decision's own relation edges are read through the owner index", () => {
+  const db = new DatabaseSync(":memory:");
+  try {
+    createRelationGraphProjectionTables(db);
+    const plan = queryPlan(db, {
+      sql: "SELECT row_json FROM relation_edge WHERE owner_ref=? ORDER BY relation_id",
+      args: ["decision/dec_A"],
+    });
+    assert.match(plan, /SEARCH relation_edge USING INDEX relation_edge_owner \(owner_ref=\?\)/u);
+    assert.doesNotMatch(plan, /SCAN relation_edge|USE TEMP B-TREE/u);
+  } finally {
+    db.close();
+  }
+});
+
 test("task relation refresh deletes through the task index instead of scanning the table", () => {
   const db = new DatabaseSync(":memory:");
   try {


### PR DESCRIPTION
# English

## Summary

Round-5 profiling of the 10k-task ledger (task_6eba9c5d `artifacts/round-5/01-baseline-pass2.md`) put 46 % of sampled CPU in `queryPreparedRows` and 11.5 % in the witness `sqlite_master` introspection. This PR is fix-plan batch 2 on the projection side (task_d928fcf6). The worker found the mission's premise partly wrong: `queryPreparedRows` only calls `statement.all()`, so its cost is SQL execution, and the largest single item is `readDecisionDocumentState` scanning `relation_edge` by `owner_ref` without an index (12,633 rows per Decision event at 10k, 12.5–16 ms each). Prepare hoisting alone did not move that function (25,975 ms → 26,295 ms), so the index is a separate second commit.

Measured on the same recipe before and after (base `3e319b43a`): cold catch-up 38,599 ms → 5,682 ms; `taskList` p50 1,604 ms → 834 ms; `taskStatusNarrow` / `taskWindowNarrow` / `taskPageFirst` p50 13.96 / 11.47 / 11.77 ms → 8.08 / 5.57 / 5.53 ms; `queryPreparedRows` + witness self-time share 65.5 % → 36.1 %. The parameterless digest is unchanged (`00e9a513…`, same as the task_f63743c3 baseline).

## Architectural Justification

Production churn is +228/-210 (net +18) because every projection SQL call site moves from an inline `db.prepare(...)` into a per-connection statement cache keyed by connection and SQL text; the cache lives and dies with the connection, so no new lifecycle, layer or port is introduced. Call sites carrying bypass-write gate identities stay in place and are only wrapped in the cache callback, which keeps the write-boundary gate count (33 `db.prepare` sites in the projection files) unchanged. The index commit adds one `CREATE INDEX IF NOT EXISTS` executed when the owner opens the connection; schema version stays 20 so existing caches get the index in place instead of forcing a rebuild, and an integration test pins that.

## What Changed

- `3ac390439` prepare projection statements once per connection: statement cache across catch-up, fact, decision, lease and read paths; witness, relation refresh and decision coverage query `sqlite_master` once per connection; `use()` no longer re-reads the schema version per operation (three statements fewer).
- `b75f0f94c` index `relation_edge(owner_ref, relation_id)`; created on owner open with `IF NOT EXISTS`; schema version unchanged.
- Tests: `projection-query-shape.test.ts` (plan assertions for the index and cached shapes), `projection-ddl-rebuild.test.ts`, `projection-identity-binding.test.ts`.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: +228/-210 in `packages/*` (net +18).

## Machine-Readable Declarations

- None.

## Task And Scope

- Harness task: task_d928fcf6af63311e70cd0db865 (fix-plan batch 2, projection side), parent task_2b8f79fa4412cb726a26f9bfc7
- Branch: `codex/perf-batch2-projection`
- Public scope: `packages/kernel/src/store` projection files only
- Private planning/evidence updated: yes (`artifacts/report.md`, `closeout.md`, facts F-7E061BB5, F-C4CFF349, F-29201B13)
- Out of scope: `sqlite-event-store.ts` append-loop prepare (batch 3, same work unit later); `doc-sync-canonical-events.ts` (R4-validation-F8, deferred to batch 3); query-only connection residency (see Residual Risk)

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: not applicable
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `3a8833a87`
- Branch merge-base with `origin/main`: `3a8833a87`
- Last `git fetch origin` time: 2026-09-11 UTC
- Sync method: rebased onto origin/main
- Public diff command: `git diff origin/main...codex/perf-batch2-projection`
- Private evidence commit/path: task_d928fcf6af63311e70cd0db865 `artifacts/report.md`
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [ ] `npm run typecheck`
- [ ] `npm run check`
- [ ] `npm test`
- [x] `npm run harness:check-import-boundaries` (via `run-manifest-gates --changed origin/main`)
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts` (via `run-manifest-gates --changed origin/main`)
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Worker: fast 29/29, contract 109/109; 23 integration files via `dispatch-isolated-test` on Ubuntu, 145 tests 0 failures, before and after rebase; negative controls: removing the cache fails 3 shape tests, removing the index fails the plan test.
- CEO after rebase onto `3a8833a87`: the three touched test files 25/25; `run-manifest-gates --changed origin/main` passed.

## Review Evidence

- CEO ground-truth: read the worker report and both commits; accepted the two-commit split and the three deferrals below; the numbers above are the worker's measurements from the round-5 recipe, not re-measured by the CEO.
- Reviewer subagent: pending (closeout review dispatched after merge)
- Human review: pending
- Blocking findings: none open

## Residual Risk

- The statement cache grows with the number of distinct SQL texts a connection sees; today the dynamic SQL is a fixed set of filter combinations, and only a comment guards against interpolating values into SQL on the resident writer connection.
- Table-set caching assumes tables are created during connection initialisation; production does, unit fixtures must create tables before reading.
- Query-only connection residency (≈250 µs per read) was deliberately not done: the writer runs on a worker thread and cannot close host-thread connections when it discards the cache, and discard removes only the main file, not `-wal`/`-shm`; residency without a cross-thread close would risk corruption (and EPERM on Windows).
- `use()` still checks ledger identity per operation (≈0.03 %), on purpose, so a replaced or rolled-back ledger is detected while a connection lives.

## References

- Task: task_d928fcf6af63311e70cd0db865; fix-plan task_6eba9c5d3a55735920aa4856f3 `artifacts/fix-plan.md` batch 2; round-5 baseline `artifacts/round-5/01-baseline-pass2.md`

---

# 中文

## 概要

round-5 对 10k 任务台账的火焰图（task_6eba9c5d `artifacts/round-5/01-baseline-pass2.md`）显示 `queryPreparedRows` 占采样 CPU 46 %、witness 的 `sqlite_master` 内省占 11.5 %。本 PR 是 fix-plan 批 2 的投影侧（task_d928fcf6）。worker 发现任务前提有一半不成立：`queryPreparedRows` 只调 `statement.all()`，耗时是 SQL 执行本身，最大单项是 `readDecisionDocumentState` 按 `owner_ref` 查 `relation_edge` 没有索引（10k 档每个 Decision 事件扫 12,633 行，每次 12.5–16 ms）。只做 prepare 上提这个函数反而 25,975 ms → 26,295 ms，所以索引单独做成第二个提交。

同一配方前后实测（base `3e319b43a`）：冷追赶 38,599 ms → 5,682 ms；`taskList` p50 1,604 ms → 834 ms；`taskStatusNarrow` / `taskWindowNarrow` / `taskPageFirst` p50 13.96 / 11.47 / 11.77 ms → 8.08 / 5.57 / 5.53 ms；`queryPreparedRows` + witness 自耗时占比 65.5 % → 36.1 %。无参 digest 不变（`00e9a513…`，与 task_f63743c3 基线一致）。

## 架构辩护

生产 churn +228/-210（净 +18）来自把投影层每个 SQL 调用点从内联 `db.prepare(...)` 挪进按「连接 + SQL 文本」键的语句缓存；缓存随连接生灭，没有新增生命周期、分层或端口。带写边界门标识的调用点原地保留，只包进缓存回调，写边界门要求的投影文件 `db.prepare` 数（33 处）不变。索引提交只加一条 owner 打开连接时执行的 `CREATE INDEX IF NOT EXISTS`；schema 版本保持 20，已有缓存原地补索引而不是强制重建，有集成测试固化。

## 改动内容

- `3ac390439` 语句按连接驻留：覆盖 catch-up、fact、decision、lease 与读路径；witness、relation 刷新、decision coverage 每连接只查一次 `sqlite_master`；`use()` 不再每次操作重读 schema 版本（少 3 条语句）。
- `b75f0f94c` 给 `relation_edge(owner_ref, relation_id)` 加索引；owner 打开时 `IF NOT EXISTS` 创建；schema 版本不变。
- 测试：`projection-query-shape.test.ts`（索引与缓存形状的计划断言）、`projection-ddl-rebuild.test.ts`、`projection-identity-binding.test.ts`。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 删除的门或 fixture：none
- 生产净行数：`packages/*` +228/-210（净 +18）。

## 机器可读声明

- 无。

## 任务与范围

- Harness 任务：task_d928fcf6af63311e70cd0db865（fix-plan 批 2 投影侧），父任务 task_2b8f79fa4412cb726a26f9bfc7
- 分支：`codex/perf-batch2-projection`
- 公开范围：仅 `packages/kernel/src/store` 投影文件
- 私有计划/证据已更新：是（`artifacts/report.md`、`closeout.md`、fact F-7E061BB5、F-C4CFF349、F-29201B13）
- 范围外：`sqlite-event-store.ts` 的 append 循环 prepare（批 3，后续同一工单）；`doc-sync-canonical-events.ts`（R4-validation-F8，并入批 3）；query-only 连接驻留（见残余风险）

## 版本影响

- 版本：不变
- 发布影响：不发布

## 治理声明

- 触碰受保护面：否
- 受保护面范围：不适用
- 授权：不适用
- 机器检查边界：本 PR 只断言声明存在；是否属实、是否充分由评审判断。
- Break-glass：否
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- 基线 `origin/main` SHA：`3a8833a87`
- 分支与 `origin/main` 的 merge-base：`3a8833a87`
- 最近一次 `git fetch origin`：2026-09-11 UTC
- 同步方式：rebase 到 origin/main
- 公开 diff 命令：`git diff origin/main...codex/perf-batch2-projection`
- 私有证据路径：task_d928fcf6af63311e70cd0db865 的 `artifacts/report.md`
- 评审证据路径：本 PR 的评审证据节
- GitHub Actions `rewrite-ci` run URL：本 PR 待跑
- worker：fast 29/29、contract 109/109；23 个 integration 文件经 `dispatch-isolated-test` 在 Ubuntu 上跑，rebase 前后各一遍 145 个测试 0 失败；阴性对照：去掉缓存 3 个 shape 测试失败，删掉索引计划测试失败。
- CEO rebase 到 `3a8833a87` 后：三个被触碰的测试文件 25/25；`run-manifest-gates --changed origin/main` 通过。

## 评审证据

- CEO 事实核对：读过 worker 报告与两个提交；接受两提交拆分与下列三项推迟；上面的数字是 worker 按 round-5 配方的实测，CEO 未复测。
- 评审子代理：待定（合入后派收口评审）
- 人工评审：待定
- 阻塞发现：无

## 残余风险

- 语句缓存大小等于该连接见过的不同 SQL 文本数；当前动态 SQL 只有固定几种过滤组合，常驻写者连接上禁止把值拼进 SQL 目前只靠注释约束。
- 表集合按连接缓存，前提是建表发生在连接初始化阶段；生产路径满足，单测夹具必须先建表再读。
- query-only 连接驻留（每次读约省 250 µs）有意没做：写者在 worker 线程，discard 缓存时关不到宿主线程连接，且 discard 只删主文件不删 `-wal`/`-shm`；没有跨线程关闭机制就驻留可能损坏库（Windows 上还会 EPERM）。
- `use()` 仍每次操作检查 ledger identity（约 0.03 %），有意保留，以便连接存活期间发现台账被替换或回退。

## 参考

- 任务：task_d928fcf6af63311e70cd0db865；fix-plan task_6eba9c5d3a55735920aa4856f3 `artifacts/fix-plan.md` 批 2；round-5 基线 `artifacts/round-5/01-baseline-pass2.md`
