### PR TITLE
test: settle the request log before the observe-tail test ends

### DIFF
--- a/packages/daemon/test/observe-tail.integration.test.mjs
+++ b/packages/daemon/test/observe-tail.integration.test.mjs
@@ -51,6 +51,9 @@ test("observe.tail exposes the 3x3 mode matrix and advances only when the source
       opId: null,
       durationMs: 2,
     });
+    // The request log keeps its file handle open between writes since #2470; settle before the
+    // test ends so no handle is left for garbage collection to close.
+    await requestLog.settle();
     const connLog = openDaemonConnLog({
       userRoot,
       daemonId,


### PR DESCRIPTION
# English

## Summary

`full-check (26)` on main f450d416d (run 34574761071) failed in `packages/daemon/test/observe-tail.integration.test.mjs`: "A FileHandle object was closed during garbage collection … requests.jsonl". Since #2470 the daemon request log keeps its file handle open between writes and closes it in `settle()`; the daemon runtime settles it at teardown, but this test recorded one entry directly through `openDaemonRequestLog` and never settled, so the handle outlived the test. The test now awaits `requestLog.settle()` right after recording, which is what the per-write `appendFile` used to do implicitly. Test-only change; no production lines.

## Architectural Justification

-

## What Changed

- `packages/daemon/test/observe-tail.integration.test.mjs`: `await requestLog.settle()` after `record(...)`.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: +0/-0.

## Machine-Readable Declarations

- None.

## Task And Scope

- Harness task: task_8242719f8b61d87dd95ac06d1a (request-log writer shape; this is its main-red follow-up), parent task_2b8f79fa4412cb726a26f9bfc7
- Branch: `codex/observe-tail-settle`
- Public scope: one daemon integration test
- Private planning/evidence updated: yes (closeout residual risk)
- Out of scope: `request-log.ts` itself (the runtime already settles at teardown; `request-log.test.ts` settles in every case)

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: not applicable
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `213086894`
- Branch merge-base with `origin/main`: `213086894`
- Last `git fetch origin` time: 2026-09-11 UTC
- Sync method: branched from origin/main
- Public diff command: `git diff origin/main...codex/observe-tail-settle`
- Private evidence commit/path: task_8242719f8b61d87dd95ac06d1a `closeout.md`
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [ ] `npm run typecheck`
- [ ] `npm run check`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- `node --test packages/daemon/test/observe-tail.integration.test.mjs` 5/5 with no FileHandle warning.

## Review Evidence

- CEO ground-truth: read the failing log, `request-log.ts` `settle()`, and `runtime.ts` teardown (line 105 settles in production); the other test file using the request log settles in every case.
- Reviewer subagent: not used
- Human review: pending
- Blocking findings: none open

## Residual Risk

- None beyond the test.

## References

- Task: task_8242719f8b61d87dd95ac06d1a; origin #2470; failing run 34574761071

---

# 中文

## 概要

main f450d416d 的 `full-check (26)`（run 34574761071）在 `packages/daemon/test/observe-tail.integration.test.mjs` 失败：「A FileHandle object was closed during garbage collection … requests.jsonl」。#2470 之后 daemon 请求日志在两次写之间保持文件句柄打开、在 `settle()` 里关闭；daemon runtime 在 teardown 时会 settle，但这个测试直接用 `openDaemonRequestLog` 记了一条、从未 settle，句柄活过了测试。现在记录后立刻 `await requestLog.settle()`，等价于旧的按写 `appendFile` 隐式关闭。仅测试改动，无生产行。

## 架构辩护

-

## 改动内容

- `packages/daemon/test/observe-tail.integration.test.mjs`：`record(...)` 之后 `await requestLog.settle()`。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 删除的门或 fixture：none
- 生产净行数：+0/-0。

## 机器可读声明

- 无。

## 任务与范围

- Harness 任务：task_8242719f8b61d87dd95ac06d1a（request-log 写手形状；本 PR 是它的 main 红后续），父任务 task_2b8f79fa4412cb726a26f9bfc7
- 分支：`codex/observe-tail-settle`
- 公开范围：一个 daemon 集成测试
- 私有计划/证据已更新：是（closeout 残余风险）
- 范围外：`request-log.ts` 本身（runtime teardown 已 settle；`request-log.test.ts` 每个用例都 settle）

## 版本影响

- 版本：不变
- 发布影响：不发布

## 治理声明

- 触碰受保护面：否
- 受保护面范围：不适用
- 授权：不适用
- 机器检查边界：本 PR 只断言声明存在；是否属实、是否充分由评审判断。
- Break-glass：否
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- 基线 `origin/main` SHA：`213086894`
- 分支与 `origin/main` 的 merge-base：`213086894`
- 最近一次 `git fetch origin`：2026-09-11 UTC
- 同步方式：从 origin/main 开分支
- 公开 diff 命令：`git diff origin/main...codex/observe-tail-settle`
- 私有证据路径：task_8242719f8b61d87dd95ac06d1a 的 `closeout.md`
- 评审证据路径：本 PR 的评审证据节
- GitHub Actions `rewrite-ci` run URL：本 PR 待跑
- `node --test packages/daemon/test/observe-tail.integration.test.mjs` 5/5，无 FileHandle 警告。

## 评审证据

- CEO 事实核对：读过失败日志、`request-log.ts` 的 `settle()` 与 `runtime.ts` teardown（第 105 行在生产里 settle）；另一处用请求日志的测试文件每个用例都 settle。
- 评审子代理：未用
- 人工评审：待定
- 阻塞发现：无

## 残余风险

- 测试之外无。

## 参考

- 任务：task_8242719f8b61d87dd95ac06d1a；源头 #2470；失败 run 34574761071
