### PR TITLE
fix: settle stale runtime sessions on cancel

### DIFF
--- a/packages/daemon/src/runtime-spawn-adoption.ts
+++ b/packages/daemon/src/runtime-spawn-adoption.ts
@@ -114,35 +114,26 @@ export async function adoptRuntimes(context: RuntimeSpawnerContext): Promise<voi
         active.binding,
       );
     }
-    if (fullStream) attachActiveRuntime(context, active);
     const processState = stream.process;
-    if (processState && !processState.exited && !runtimePidIsAlive(processState.pid)) {
-      const timer = setTimeout(() => {
-        const current =
-          readDispatchStream(context.input.rootDir, active.dispatchId) ??
-          readDispatchStreamSummary(context.input.rootDir, active.dispatchId);
-        if (!current?.process?.exited && context.processes.get(active.runtimeSessionId) === active) {
-          const reason = `runtime process ${String(processState.pid)} is no longer alive after daemon restart`;
-          active.lossReason = reason;
-          active.lossExitCode = current?.process?.exitCode ?? null;
-          active.lossSignal = current?.process?.signal ?? null;
-          removeRuntimeCallbackRelay(context.input.rootDir, active.dispatchId);
-          appendRuntimeWorkerRecord(context.input.rootDir, active.dispatchId, {
-            kind: "process_lost",
-            occurredAt: context.input.now(),
-            reason,
-            exitCode: active.lossExitCode,
-            signal: active.lossSignal,
-          });
-          // No process_exit orders this settlement after the drain's last line. Settle from the stream.
-          context.input.schedule(async () => {
-            await consumeDurableOutput(context, active);
-            await context.publishExit(active, active.lossExitCode);
-          }, active.binding);
-        }
-      }, 50);
-      timer.unref();
+    if (processState.exited || !runtimePidIsAlive(processState.pid)) {
+      const reason = `runtime process ${String(processState.pid)} is no longer alive after daemon restart`;
+      active.lossReason = processState.exited ? null : reason;
+      active.lossExitCode = processState.exitCode ?? null;
+      active.lossSignal = processState.signal ?? null;
+      removeRuntimeCallbackRelay(context.input.rootDir, active.dispatchId);
+      if (!processState.exited)
+        appendRuntimeWorkerRecord(context.input.rootDir, active.dispatchId, {
+          kind: "process_lost",
+          occurredAt: context.input.now(),
+          reason,
+          exitCode: active.lossExitCode,
+          signal: active.lossSignal,
+        });
+      await consumeDurableOutput(context, active);
+      await context.publishExit(active, active.lossExitCode);
+      continue;
     }
+    if (fullStream) attachActiveRuntime(context, active);
   }
 }
 

--- a/packages/daemon/src/runtime-spawn-control.ts
+++ b/packages/daemon/src/runtime-spawn-control.ts
@@ -2,6 +2,7 @@ import { createHash } from "node:crypto";
 import { unknownFieldViolation, type JsonObject } from "./protocol/json-rpc-types.ts";
 import { requiredRuntimeSpawnText, runtimeSpawnError } from "./runtime-spawn-errors.ts";
 import { consumeDurableOutput } from "./runtime-spawn-provider-stream.ts";
+import { adoptRuntimes } from "./runtime-spawn-adoption.ts";
 import type { RuntimeBinding } from "./runtime-spawn-types.ts";
 import type { RuntimeSpawnerContext } from "./runtime-spawn-context.ts";
 
@@ -18,8 +19,9 @@ export async function cancelRuntime(
     throw runtimeSpawnError("invalid_runtime_cancel", `Runtime cancel payload contains an ${unknownField}`);
   const runtimeSessionId = requiredRuntimeSpawnText(payload.runtimeSessionId, "runtimeSessionId"),
     hash = createHash("sha256").update(`${context.input.repoId}\0${runtimeSessionId}`).digest("hex"),
-    opId = `runtime-cancel-${hash.slice(0, 32)}`,
-    active = context.processes.get(runtimeSessionId);
+    opId = `runtime-cancel-${hash.slice(0, 32)}`;
+  if (!context.processes.has(runtimeSessionId)) await adoptRuntimes(context);
+  const active = context.processes.get(runtimeSessionId);
   if (active) {
     active.cancelBinding = binding;
     active.cancelOpId = opId;

--- a/packages/daemon/test/dispatch-stream.test.ts
+++ b/packages/daemon/test/dispatch-stream.test.ts
@@ -410,6 +410,57 @@ test("fleet adoption does not probe a dispatch owned by another node", async () 
   }
 });
 
+test("runtime cancel settles a live projection whose recorded process already exited", async () => {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-runtime-cancel-exited-"));
+  try {
+    const dispatchId = "dispatch_cccccccccccccccccccccccc",
+      runtimeSessionId = "runtime_cccccccccccccccccccccccc",
+      binding = { actor: { principal: { personId: "operator" }, executor: null }, source: "local" as const };
+    openDispatchStream(rootDir, {
+      dispatchId,
+      taskId: null,
+      executionId: null,
+      runtimeSessionId,
+      instanceId: "instance-1",
+      startedAt: "2026-09-08T00:00:00.000Z",
+      dispatchOpId: "dispatch-op-exited",
+      kindId: "codex",
+      permissionMode: null,
+      binding,
+      cwd: rootDir,
+      prompt: "settle exited runtime",
+      model: "gpt-5.6-sol",
+      reasoningEffort: null,
+      fast: false,
+    });
+    appendRuntimeWorkerRecord(rootDir, dispatchId, { kind: "process_started", pid: 2_147_483_647 });
+    appendRuntimeWorkerRecord(rootDir, dispatchId, { kind: "process_exit", exitCode: 1, signal: null });
+    const settled: string[] = [],
+      context = {
+        input: { rootDir, repoId: "cancel-exited", now: () => "2026-09-11T00:00:00.000Z" },
+        requiredRuntimeProjection: () => ({
+          readRuntimeSessions: () => [
+            { runtimeSessionId, instanceId: "instance-1", providerSessionId: null, liveness: "live", outcome: null },
+          ],
+        }),
+        processes: new Map(),
+        reconcileFallback: () => undefined,
+        restoreDurableOutputRecords: () => undefined,
+        consumeLine: async () => undefined,
+        publishExit: async (active: { runtimeSessionId: string }) => {
+          settled.push(active.runtimeSessionId);
+          context.processes.delete(active.runtimeSessionId);
+        },
+        controlReceipt: () => ({ ok: true, detail: "already-exited" }),
+      };
+    const receipt = await cancelRuntime(context as never, { runtimeSessionId }, binding);
+    assert.equal(receipt.detail, "already-exited");
+    assert.deepEqual(settled, [runtimeSessionId]);
+  } finally {
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});
+
 test("the dispatch fuse drops unbounded output but preserves terminal records", () => {
   const rootDir = mkdtempSync(path.join(tmpdir(), "ha-dispatch-write-fuse-"));
   const warning = console.warn,

--- a/tools/gate-allowlists/check-poll-spin-boundary.json
+++ b/tools/gate-allowlists/check-poll-spin-boundary.json
@@ -64,12 +64,6 @@
         "reason": "Existing polling or synchronous bridge at the CH3 baseline."
       },
       {
-        "key": "packages/daemon/src/runtime-spawn-adoption.ts#adoptRuntimes#short-timer",
-        "event": "baseline-2026-09-10: no awaitable completion event is exposed by the current API",
-        "ref": "dec_EF5F3820E81FB8A5266F1F3342",
-        "reason": "Existing polling or synchronous bridge at the CH3 baseline."
-      },
-      {
         "key": "packages/daemon/src/runtime-spawn-process.ts#awaitRuntimeProcessExit#await-in-loop",
         "event": "baseline-2026-09-10: no awaitable completion event is exposed by the current API",
         "ref": "dec_EF5F3820E81FB8A5266F1F3342",


### PR DESCRIPTION
# English

## Summary

Four `test-codex-sol` runtime sessions dispatched three days ago still showed `liveness: live` with no outcome although no worker process existed; `ha runtime cancel` answered `already-exited` and left the projection untouched, so the sessions could not be stopped from the CLI or the GUI. The cause is in `cancelRuntime`: when the daemon holds no in-memory process for the session it returned a no-op receipt without publishing any exit. These sessions were left behind by a daemon restart that never adopted them.

Cancel now runs the existing adoption pass when the session is not in memory, and adoption settles a runtime whose recorded process has exited or whose pid is dead synchronously through the existing `publishExit` path (the 50 ms deferred timer is deleted). A regression test cancels a session whose projection is live but whose process is gone and asserts the terminal outcome. No age-based sweeper was added: startup adoption already settles every dead pid it can see, and a timer would be a second settlement mechanism for the same state.

## Architectural Justification

-

## What Changed

- `packages/daemon/src/runtime-spawn-control.ts`: `cancelRuntime` adopts before looking up the active process.
- `packages/daemon/src/runtime-spawn-adoption.ts`: exited or dead-pid runtimes settle synchronously via `publishExit`; deferred timer removed.
- `packages/daemon/test/dispatch-stream.test.ts`: cancel of a live-projection / dead-process session reaches a terminal outcome.
- `tools/gate-allowlists/check-poll-spin-boundary.json`: stale entry for the deleted timer removed (the `crlf-checkout` job's poll-spin gate flagged it on the first push).

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: poll-spin allowlist entry `runtime-spawn-adoption.ts#adoptRuntimes#short-timer` (the timer it excused is deleted)
- Production net lines: +22/-29 in `packages/*` (net -7).

## Machine-Readable Declarations

- None.

## Task And Scope

- Harness task: task_e30d0748a7c1277f69dbf1b05b (supersedes task_8806a3309251608df38f65c72e), parent task_2b8f79fa4412cb726a26f9bfc7
- Branch: `codex/runtime-stale-settle`
- Public scope: daemon runtime cancel and adoption
- Private planning/evidence updated: yes (task plan, `artifacts/report.md`)
- Out of scope: sessions with no dispatch stream at all (cannot be settled safely; reported), any max-age policy for still-running workers

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: yes — `tools/gate-allowlists/check-poll-spin-boundary.json` loses one entry
- Protected surface scope: retires the allowlist entry for a timer this PR deletes; the gate itself is unchanged and passes
- Authority: task_e30d0748a7c1277f69dbf1b05b (repository owner request of 2026-09-11 to make stale runtime sessions stoppable)
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `3311ede22`
- Branch merge-base with `origin/main`: `3311ede22`
- Last `git fetch origin` time: 2026-09-11 UTC
- Sync method: branched from origin/main
- Public diff command: `git diff origin/main...codex/runtime-stale-settle`
- Private evidence commit/path: task_e30d0748a7c1277f69dbf1b05b `artifacts/report.md`
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [x] `npm run typecheck` (`npx tsc -b packages/daemon/tsconfig.json`, worker)
- [ ] `npm run check`
- [ ] `npm test`
- [x] `npm run harness:check-import-boundaries` (via `run-manifest-gates --changed origin/main`, 6/6)
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts` (via `run-manifest-gates --changed origin/main`)
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- `node --test packages/daemon/test/dispatch-stream.test.ts` 14/14 (worker and CEO).

## Review Evidence

- CEO ground-truth: reproduced the defect on the canonical daemon (`ps` shows no process, `cancel` answers already-exited, status stays live); read the diff: adoption path reused, timer deleted, no new event kinds.
- Reviewer subagent: pending (closeout review after merge)
- Human review: pending
- Blocking findings: none open

## Residual Risk

- A session whose dispatch stream is missing entirely still cannot be settled; none of the four field cases is of that kind.
- Live acceptance on the four field sessions happens after deploy (they read `unknown` since the last restart).

## References

- Task: task_e30d0748a7c1277f69dbf1b05b

---

# 中文

## 概要

四个 3 天前派出的 `test-codex-sol` 会话一直显示 `liveness: live`、无结果，但 worker 进程早已不在；`ha runtime cancel` 回 `already-exited` 却不动投影，CLI 与 GUI 都停不掉它们。原因在 `cancelRuntime`：daemon 内存里没有该会话的进程时直接回空回执，不发布任何退出事件。这些会话是某次 daemon 重启没收养它们留下的。

现在 cancel 在内存里找不到会话时先跑一遍既有的收养流程；收养对「记录已退出或 pid 已死」的 runtime 同步走既有 `publishExit` 结算（删掉了 50 ms 延迟定时器）。回归测试：投影 live、进程不在的会话 cancel 后到达终态。没有加按时长的清扫：启动收养已经无条件结算所有能看见的死 pid，再加定时器就是同一状态的第二套结算机制。

## 架构辩护

-

## 改动内容

- `packages/daemon/src/runtime-spawn-control.ts`：`cancelRuntime` 查 active 进程前先收养。
- `packages/daemon/src/runtime-spawn-adoption.ts`：已退出或 pid 已死的 runtime 同步经 `publishExit` 结算；删延迟定时器。
- `packages/daemon/test/dispatch-stream.test.ts`：live 投影 / 进程已死会话的 cancel 到终态。
- `tools/gate-allowlists/check-poll-spin-boundary.json`：删掉已删定时器的过期条目（第一次 push 时 `crlf-checkout` job 的 poll-spin 门报 stale）。

## 门收割 / Gate Harvest

- 删除的生产路径：none（收养里的 50 ms 延迟定时器被同步结算取代，属同一路径收窄）
- 删除的门或 fixture：poll-spin allowlist 条目 `runtime-spawn-adoption.ts#adoptRuntimes#short-timer`（它豁免的定时器已删）
- 生产净行数：`packages/*` +22/-29（净 -7）。

## 机器可读声明

- 无。

## 任务与范围

- Harness 任务：task_e30d0748a7c1277f69dbf1b05b（取代 task_8806a3309251608df38f65c72e），父任务 task_2b8f79fa4412cb726a26f9bfc7
- 分支：`codex/runtime-stale-settle`
- 公开范围：daemon runtime cancel 与收养
- 私有计划/证据已更新：是（任务计划、`artifacts/report.md`）
- 范围外：完全没有 dispatch stream 的会话（无法安全结算，已报告）；对仍在跑的 worker 的最长时长策略

## 版本影响

- 版本：不变
- 发布影响：不发布

## 治理声明

- 触碰受保护面：是——`tools/gate-allowlists/check-poll-spin-boundary.json` 少一条
- 受保护面范围：退役本 PR 删掉的定时器对应的 allowlist 条目；门本身不变且通过
- 授权：task_e30d0748a7c1277f69dbf1b05b（仓库所有者 2026-09-11 要求僵尸会话可停）
- 机器检查边界：本 PR 只断言声明存在；是否属实、是否充分由评审判断。
- Break-glass：否
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- 基线 `origin/main` SHA：`3311ede22`
- 分支与 `origin/main` 的 merge-base：`3311ede22`
- 最近一次 `git fetch origin`：2026-09-11 UTC
- 同步方式：从 origin/main 开分支
- 公开 diff 命令：`git diff origin/main...codex/runtime-stale-settle`
- 私有证据路径：task_e30d0748a7c1277f69dbf1b05b 的 `artifacts/report.md`
- 评审证据路径：本 PR 的评审证据节
- GitHub Actions `rewrite-ci` run URL：本 PR 待跑
- `node --test packages/daemon/test/dispatch-stream.test.ts` 14/14（worker 与 CEO）。

## 评审证据

- CEO 事实核对：在 canonical daemon 上复现（`ps` 无进程、`cancel` 回 already-exited、状态仍 live）；读过 diff：复用收养路径、删定时器、无新事件类型。
- 评审子代理：待定（合入后派收口评审）
- 人工评审：待定
- 阻塞发现：无

## 残余风险

- 完全没有 dispatch stream 的会话仍无法结算；现场四条不属此类。
- 现场四条会话的验收在部署后做（上次重启后它们显示 `unknown`）。

## 参考

- 任务：task_e30d0748a7c1277f69dbf1b05b
