### PR TITLE
perf: deduplicate boundary CI checks

### DIFF
--- a/.github/workflows/rewrite-ci.yml
+++ b/.github/workflows/rewrite-ci.yml
@@ -302,7 +302,6 @@ jobs:
           node-version: 24
           cache: npm
       - run: npm ci
-      - run: npm run harness:check-fallback-boundaries
       - name: Run boundary gates
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/rewrite-ci.yml
+++ b/.github/workflows/rewrite-ci.yml
@@ -302,6 +302,7 @@ jobs:
           node-version: 24
           cache: npm
       - run: npm ci
+      - run: npm run harness:check-fallback-boundaries
       - name: Run boundary gates
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/tools/check-integration-test-shards.mjs
+++ b/tools/check-integration-test-shards.mjs
@@ -131,12 +131,9 @@ function previousIntegrationTestState(repoRoot, requestedRef) {
       stdio: ["ignore", "pipe", "ignore"],
     });
     const files = output.split(/\r?\n/u).filter((file) => /\.(?:test|spec)\.(?:mjs|js|ts)$/u.test(file));
-    const tiers = files.map((file) => {
-      const source = execFileSync("git", ["show", `${ref}:${file}`], {
-        cwd: repoRoot,
-        encoding: "utf8",
-        stdio: ["ignore", "pipe", "ignore"],
-      });
+    const sources = readGitSources(repoRoot, ref, files);
+    const tiers = sources.map((source, index) => {
+      const file = files[index];
       try {
         return parseTestTierMarker(source, file);
       } catch (error) {
@@ -156,6 +153,33 @@ function previousIntegrationTestState(repoRoot, requestedRef) {
   } catch {
     return { count: null, files: null, ref: null };
   }
+}
+
+function readGitSources(repoRoot, ref, files) {
+  const output = execFileSync("git", ["cat-file", "--batch"], {
+    cwd: repoRoot,
+    input: files.map((file) => `${ref}:${file}`).join("\n") + "\n",
+    maxBuffer: 16 * 1024 * 1024,
+    stdio: ["pipe", "pipe", "ignore"],
+  });
+  const sources = [];
+  let offset = 0;
+  for (const file of files) {
+    const headerEnd = output.indexOf(0x0a, offset);
+    if (headerEnd < 0) throw new Error(`missing Git object header for ${file}`);
+    const header = output.subarray(offset, headerEnd).toString("utf8");
+    const match = /^[0-9a-f]+\s+\w+\s+(\d+)$/u.exec(header);
+    if (!match) throw new Error(`unable to read Git object for ${file}: ${header}`);
+    const size = Number(match[1]);
+    const contentStart = headerEnd + 1;
+    const contentEnd = contentStart + size;
+    if (contentEnd >= output.length || output[contentEnd] !== 0x0a) {
+      throw new Error(`truncated Git object for ${file}`);
+    }
+    sources.push(output.subarray(contentStart, contentEnd).toString("utf8"));
+    offset = contentEnd + 1;
+  }
+  return sources;
 }
 
 function legacyIntegrationFiles(repoRoot, ref, files) {


### PR DESCRIPTION
# English

## Summary

fix-plan batch 18 (task_6eba9c5d `artifacts/fix-plan.md`, R3-06-F4): `check-integration-test-shards.mjs` spawned one `git show` per baseline test file. The per-file `git show` is replaced by one `git cat-file --batch` whose records are parsed by byte length and handed unchanged to `parseTestTierMarker`. Shard-gate output is byte-identical to `origin/main` at the same base and the local gate time drops from 16.13 s to 0.37 s. Two items of the batch are deliberately not done: R3-06-F2 (the direct `harness:check-fallback-boundaries` step in the `boundaries` job) must stay because `schema-closure` and `derived-contracts` require the job to project gate G40 as a literal command (the first push of this PR removed it and both gates went red); R3-06-F1 (narrowing `check-import-boundaries` source roots) would change coverage.

## Architectural Justification

-

## What Changed

- `tools/check-integration-test-shards.mjs`: baseline markers read through a single `git cat-file --batch` (maxBuffer 16 MiB for the ~1.1 MiB current object stream).

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: +30/-6 (tools only; `packages/*` +0/-0).

## Machine-Readable Declarations

- None.

## Task And Scope

- Harness task: task_9b2e8caca393b8e10ce15f71f4 (fix-plan batch 18), parent task_6eba9c5d3a55735920aa4856f3 / task_2b8f79fa4412cb726a26f9bfc7
- Branch: `codex/perf-ci-dedup`
- Public scope: one gate tool's git read path
- Private planning/evidence updated: yes (`artifacts/report.md`)
- Out of scope: merging `rebuild-gates.yml` into `rewrite-ci.yml` (task_9a1058d0), gate semantics

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: yes — `tools/check-integration-test-shards.mjs` (gate tooling referenced by `tools/gate-manifest.json`)
- Protected surface scope: only the git read path of the shard gate changes; the verdict per file is unchanged (byte-identical output at the same base); no workflow change
- Authority: repository owner authorization for governance fixes in the perf rescue line (2026-09-10/11) and fix-plan batch 18 (task_6eba9c5d), recorded in task_9b2e8caca393b8e10ce15f71f4
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `3311ede22`
- Branch merge-base with `origin/main`: `3311ede22`
- Last `git fetch origin` time: 2026-09-11 UTC
- Sync method: branched from origin/main
- Public diff command: `git diff origin/main...codex/perf-ci-dedup`
- Private evidence commit/path: task_9b2e8caca393b8e10ce15f71f4 `artifacts/report.md`
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [x] `npm run typecheck` (`npx tsc -b`, worker)
- [ ] `npm run check`
- [ ] `npm test`
- [x] `npm run harness:check-import-boundaries` (direct, worker)
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts` (via `run-manifest-gates --changed origin/main`)
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- `tools/check-integration-test-shards.test.mjs` 13/13; `check-import-boundaries.test.mjs` 26/26; `harness:check-fallback-boundaries` passed (283/9/53); shard gate `diff -u` against origin/main empty.

## Review Evidence

- CEO ground-truth: read the diff and the report; reverted the workflow step after schema-closure/derived-contracts showed the G40 projection contract.
- Reviewer subagent: pending (closeout review after merge)
- Human review: pending
- Blocking findings: none open

## Residual Risk

- A pre/post byte diff of the *direct* fallback gate across worktrees was not completed (baseline checkout could not resolve `typescript`); the surviving manifest-runner invocation is the authoritative one and passed.

## References

- Task: task_9b2e8caca393b8e10ce15f71f4; fix-plan batch 18

---

# 中文

## 概要

fix-plan 批 18（task_6eba9c5d `artifacts/fix-plan.md`，R3-06-F4）：`check-integration-test-shards.mjs` 对每个基线测试文件各起一次 `git show`。现在换成一次 `git cat-file --batch`，记录按字节长度解析后原样交给 `parseTestTierMarker`。分片门输出与同基线 `origin/main` 逐字节一致，本地耗时 16.13 s → 0.37 s。批 18 另两项有意不做：R3-06-F2（`boundaries` job 里直接调用 `harness:check-fallback-boundaries` 的步骤）必须保留，因为 `schema-closure` 与 `derived-contracts` 要求该 job 以字面命令投影门 G40（本 PR 第一次 push 删了它，两个门立刻红）；R3-06-F1（收窄 `check-import-boundaries` 源根）会改变覆盖面。

## 架构辩护

-

## 改动内容

- `tools/check-integration-test-shards.mjs`：基线标记经一次 `git cat-file --batch` 读取（maxBuffer 16 MiB，当前对象流约 1.1 MiB）。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 删除的门或 fixture：none
- 生产净行数：+30/-6（仅 tools；`packages/*` +0/-0）。

## 机器可读声明

- 无。

## 任务与范围

- Harness 任务：task_9b2e8caca393b8e10ce15f71f4（fix-plan 批 18），父任务 task_6eba9c5d3a55735920aa4856f3 / task_2b8f79fa4412cb726a26f9bfc7
- 分支：`codex/perf-ci-dedup`
- 公开范围：一个门工具的 git 读路径
- 私有计划/证据已更新：是（`artifacts/report.md`）
- 范围外：把 `rebuild-gates.yml` 并入 `rewrite-ci.yml`（task_9a1058d0）、门语义

## 版本影响

- 版本：不变
- 发布影响：不发布

## 治理声明

- 触碰受保护面：是——`tools/check-integration-test-shards.mjs`（`tools/gate-manifest.json` 引用的门工具）
- 受保护面范围：只改分片门的 git 读路径；每文件判定不变（同基线输出逐字节一致）；不改 workflow
- 授权：仓库所有者对性能抢救线治理修复的授权（2026-09-10/11）与 fix-plan 批 18（task_6eba9c5d），记录在 task_9b2e8caca393b8e10ce15f71f4
- 机器检查边界：本 PR 只断言声明存在；是否属实、是否充分由评审判断。
- Break-glass：否
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- 基线 `origin/main` SHA：`3311ede22`
- 分支与 `origin/main` 的 merge-base：`3311ede22`
- 最近一次 `git fetch origin`：2026-09-11 UTC
- 同步方式：从 origin/main 开分支
- 公开 diff 命令：`git diff origin/main...codex/perf-ci-dedup`
- 私有证据路径：task_9b2e8caca393b8e10ce15f71f4 的 `artifacts/report.md`
- 评审证据路径：本 PR 的评审证据节
- GitHub Actions `rewrite-ci` run URL：本 PR 待跑
- `tools/check-integration-test-shards.test.mjs` 13/13；`check-import-boundaries.test.mjs` 26/26；`harness:check-fallback-boundaries` 通过（283/9/53）；分片门与 origin/main `diff -u` 为空。

## 评审证据

- CEO 事实核对：读过 diff 与报告；schema-closure/derived-contracts 暴露 G40 投影契约后回退了 workflow 步骤。
- 评审子代理：待定（合入后派收口评审）
- 人工评审：待定
- 阻塞发现：无

## 残余风险

- *直接*调用的 fallback 门跨 worktree 前后逐字节 diff 没做完（基线 checkout 解析不到 `typescript`）；保留的 manifest runner 调用是权威的，已通过。

## 参考

- 任务：task_9b2e8caca393b8e10ce15f71f4；fix-plan 批 18
