### PR TITLE
feat: allocate squad worker worktrees

### DIFF
--- a/packages/daemon/src/squad-coordinator.ts
+++ b/packages/daemon/src/squad-coordinator.ts
@@ -118,7 +118,7 @@ export function makeSquadCoordinator(input: {
       runtimeInstanceId = requiredSquadText(action.runtimeInstanceId, "runtimeInstanceId"),
       cwd = resolveCwd(input.rootDir, action.cwd),
       squad = squadForRun(squadId),
-      baseSha = localGitObjectRefStore.resolveCommit(cwd, cwd === input.rootDir ? "origin/main" : "HEAD");
+      baseSha = localGitObjectRefStore.headCommit(cwd);
     let mission: string;
     await input.reacquireTaskLease(taskId, binding);
     try {
@@ -536,10 +536,7 @@ export function makeSquadCoordinator(input: {
         state.permissionMode === "read-only" || state.baseSha !== null
           ? state
           : revise(state, {
-              baseSha: localGitObjectRefStore.resolveCommit(
-                state.cwd,
-                state.cwd === input.rootDir ? "origin/main" : "HEAD",
-              ),
+              baseSha: localGitObjectRefStore.headCommit(state.cwd),
             });
       worktree =
         dispatchState.permissionMode === "read-only" ? null : prepareWorkerWorktree(dispatchState, plan.workerId);
@@ -1055,8 +1052,10 @@ function cwdPayload(rootDir: string, cwd: string): JsonObject {
   return relative ? { scope: "repo-relative", path: relative } : { scope: "repo-root" };
 }
 
+/** Writing workers get their own worktree when the run cwd is a Git work tree with a commit; a cwd without
+ * a Git baseline (a Git-less edge, or a repo before its first commit) keeps the shared cwd. */
 function prepareWorkerWorktree(state: SquadState, workerId: string) {
-  if (state.baseSha === null) throw new Error("Squad run baseline is unavailable.");
+  if (state.baseSha === null) return null;
   const slug = `squad-${state.squadRunId.slice("squad_".length)}-${workerId}`,
     branch = `codex/${slug}`,
     cwd = path.join(state.cwd, ".worktrees", slug);

--- a/packages/daemon/src/squad-coordinator.ts
+++ b/packages/daemon/src/squad-coordinator.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import {
   consumeKnownError,
   createEntityStore,
+  localGitObjectRefStore,
   latestRuntimeActivityAt,
   parseAgentDeclarationV1,
   parseSquadDeclarationV1,
@@ -58,6 +59,7 @@ type SquadState = {
   readonly taskId: string;
   readonly runtimeInstanceId: string;
   readonly cwd: string;
+  readonly baseSha: string;
   readonly mission: string;
   readonly model: string | null;
   readonly effort: string | null;
@@ -115,7 +117,8 @@ export function makeSquadCoordinator(input: {
     const squadId = requiredSquadText(action.squadId, "squadId"),
       runtimeInstanceId = requiredSquadText(action.runtimeInstanceId, "runtimeInstanceId"),
       cwd = resolveCwd(input.rootDir, action.cwd),
-      squad = squadForRun(squadId);
+      squad = squadForRun(squadId),
+      baseSha = localGitObjectRefStore.resolveCommit(cwd, cwd === input.rootDir ? "origin/main" : "HEAD");
     let mission: string;
     await input.reacquireTaskLease(taskId, binding);
     try {
@@ -139,6 +142,7 @@ export function makeSquadCoordinator(input: {
         taskId,
         runtimeInstanceId,
         cwd,
+        baseSha,
         mission,
         model: optionalText(action.model),
         effort: optionalText(action.effort),
@@ -526,14 +530,16 @@ export function makeSquadCoordinator(input: {
 
   async function spawnWorker(state: SquadState, plan: WorkerPlan, leaderTurnId: string): Promise<SquadState> {
     const attemptId = `worker-${state.workerAttempts.length + 1}`;
+    let worktree: WorkerAttempt["worktree"] = null;
     try {
+      worktree = state.permissionMode === "read-only" ? null : prepareWorkerWorktree(state, plan.workerId);
       await input.reacquireTaskLease(state.taskId, state.binding);
       const receipt = await input.runtimeSpawner().spawn(
           {
             agentId: state.leaderAgentId,
             targetAgentId: plan.workerId,
-            prompt: plan.prompt,
-            cwd: cwdPayload(input.rootDir, state.cwd),
+            prompt: workerPrompt(plan.prompt, worktree),
+            cwd: cwdPayload(input.rootDir, worktree?.cwd ?? state.cwd),
             taskId: state.taskId,
             ...(state.effort ? { effort: state.effort } : {}),
             ...(state.permissionMode ? { permissionMode: state.permissionMode } : {}),
@@ -552,6 +558,7 @@ export function makeSquadCoordinator(input: {
               leaderTurnId,
               dispatchId,
               runtimeSessionId,
+              worktree,
               rejection: null,
             },
           ],
@@ -569,6 +576,7 @@ export function makeSquadCoordinator(input: {
             leaderTurnId,
             dispatchId: null,
             runtimeSessionId: null,
+            worktree,
             rejection: errorText(error),
           },
         ],
@@ -923,6 +931,7 @@ export function makeSquadCoordinator(input: {
             leaderTurnId: attempt.leaderTurnId,
             dispatchId: attempt.dispatchId,
             runtimeSessionId: attempt.runtimeSessionId,
+            worktree: attempt.worktree ?? null,
             rejection: attempt.rejection,
             status: row?.status ?? null,
             startedAt: row?.startedAt ?? null,
@@ -978,6 +987,7 @@ function squadState(value: unknown): SquadState | null {
   const row = value as Partial<SquadState>;
   return row.schema === "squad-run/v1" &&
     typeof row.squadRunId === "string" &&
+    typeof row.baseSha === "string" &&
     validSquadRunId(row.squadRunId) &&
     typeof row.stateDispatchId === "string" &&
     Array.isArray(row.leaderTurns) &&
@@ -1033,6 +1043,28 @@ function resolveCwd(rootDir: string, value: unknown): string {
 function cwdPayload(rootDir: string, cwd: string): JsonObject {
   const relative = path.relative(rootDir, cwd);
   return relative ? { scope: "repo-relative", path: relative } : { scope: "repo-root" };
+}
+
+function prepareWorkerWorktree(state: SquadState, workerId: string) {
+  const slug = `squad-${state.squadRunId.slice("squad_".length)}-${workerId}`,
+    branch = `codex/${slug}`,
+    cwd = path.join(state.cwd, ".worktrees", slug);
+  localGitObjectRefStore.addWorktree(state.cwd, cwd, branch, state.baseSha);
+  return { cwd, branch, baseSha: state.baseSha };
+}
+
+function workerPrompt(
+  prompt: string,
+  worktree: { readonly cwd: string; readonly branch: string; readonly baseSha: string } | null,
+): string {
+  if (worktree === null) return prompt;
+  return [
+    prompt,
+    "# Squad worker checkout",
+    `Worker repository root: ${worktree.cwd}`,
+    `Worker branch: ${worktree.branch}`,
+    `Worker baseline: ${worktree.baseSha}`,
+  ].join("\n\n");
 }
 
 /** 派工台账行的已落盘时间事实:startedAt 恒有,endedAt 仅归档结算行有;无台账行的派工不贡献时间。 */

--- a/packages/daemon/src/squad-coordinator.ts
+++ b/packages/daemon/src/squad-coordinator.ts
@@ -59,7 +59,7 @@ type SquadState = {
   readonly taskId: string;
   readonly runtimeInstanceId: string;
   readonly cwd: string;
-  readonly baseSha: string;
+  readonly baseSha: string | null;
   readonly mission: string;
   readonly model: string | null;
   readonly effort: string | null;
@@ -532,24 +532,34 @@ export function makeSquadCoordinator(input: {
     const attemptId = `worker-${state.workerAttempts.length + 1}`;
     let worktree: WorkerAttempt["worktree"] = null;
     try {
-      worktree = state.permissionMode === "read-only" ? null : prepareWorkerWorktree(state, plan.workerId);
-      await input.reacquireTaskLease(state.taskId, state.binding);
+      const dispatchState =
+        state.permissionMode === "read-only" || state.baseSha !== null
+          ? state
+          : revise(state, {
+              baseSha: localGitObjectRefStore.resolveCommit(
+                state.cwd,
+                state.cwd === input.rootDir ? "origin/main" : "HEAD",
+              ),
+            });
+      worktree =
+        dispatchState.permissionMode === "read-only" ? null : prepareWorkerWorktree(dispatchState, plan.workerId);
+      await input.reacquireTaskLease(dispatchState.taskId, dispatchState.binding);
       const receipt = await input.runtimeSpawner().spawn(
           {
-            agentId: state.leaderAgentId,
+            agentId: dispatchState.leaderAgentId,
             targetAgentId: plan.workerId,
             prompt: workerPrompt(plan.prompt, worktree),
-            cwd: cwdPayload(input.rootDir, worktree?.cwd ?? state.cwd),
-            taskId: state.taskId,
-            ...(state.effort ? { effort: state.effort } : {}),
-            ...(state.permissionMode ? { permissionMode: state.permissionMode } : {}),
-            idempotencyKey: `${state.squadRunId}:${leaderTurnId}:${attemptId}`,
+            cwd: cwdPayload(input.rootDir, worktree?.cwd ?? dispatchState.cwd),
+            taskId: dispatchState.taskId,
+            ...(dispatchState.effort ? { effort: dispatchState.effort } : {}),
+            ...(dispatchState.permissionMode ? { permissionMode: dispatchState.permissionMode } : {}),
+            idempotencyKey: `${dispatchState.squadRunId}:${leaderTurnId}:${attemptId}`,
           },
           state.binding,
         ),
         dispatchId = requiredReceiptText(receipt, "dispatchId"),
         runtimeSessionId = requiredReceiptText(receipt, "runtimeSessionId"),
-        updated = revise(state, {
+        updated = revise(dispatchState, {
           workerAttempts: [
             ...state.workerAttempts,
             {
@@ -987,7 +997,7 @@ function squadState(value: unknown): SquadState | null {
   const row = value as Partial<SquadState>;
   return row.schema === "squad-run/v1" &&
     typeof row.squadRunId === "string" &&
-    typeof row.baseSha === "string" &&
+    (row.baseSha === undefined || row.baseSha === null || typeof row.baseSha === "string") &&
     validSquadRunId(row.squadRunId) &&
     typeof row.stateDispatchId === "string" &&
     Array.isArray(row.leaderTurns) &&
@@ -998,7 +1008,7 @@ function squadState(value: unknown): SquadState | null {
     Number.isSafeInteger(row.leaderTurnBudget) &&
     Number(row.leaderTurnBudget) >= 1 &&
     typeof row.revision === "number"
-    ? (value as SquadState)
+    ? ({ ...value, baseSha: row.baseSha ?? null } as SquadState)
     : null;
 }
 
@@ -1046,6 +1056,7 @@ function cwdPayload(rootDir: string, cwd: string): JsonObject {
 }
 
 function prepareWorkerWorktree(state: SquadState, workerId: string) {
+  if (state.baseSha === null) throw new Error("Squad run baseline is unavailable.");
   const slug = `squad-${state.squadRunId.slice("squad_".length)}-${workerId}`,
     branch = `codex/${slug}`,
     cwd = path.join(state.cwd, ".worktrees", slug);

--- a/packages/daemon/src/squad-leader-decision.ts
+++ b/packages/daemon/src/squad-leader-decision.ts
@@ -66,6 +66,11 @@ export type WorkerAttempt = {
   readonly leaderTurnId: string;
   readonly dispatchId: string | null;
   readonly runtimeSessionId: string | null;
+  readonly worktree: {
+    readonly cwd: string;
+    readonly branch: string;
+    readonly baseSha: string;
+  } | null;
   readonly rejection: string | null;
 };
 

--- a/packages/daemon/src/squad-run-contract.ts
+++ b/packages/daemon/src/squad-run-contract.ts
@@ -65,6 +65,11 @@ export interface SquadRunWorkerAttemptDto {
   readonly leaderTurnId: string;
   readonly dispatchId: string | null;
   readonly runtimeSessionId: string | null;
+  readonly worktree: {
+    readonly cwd: string;
+    readonly branch: string;
+    readonly baseSha: string;
+  } | null;
   readonly rejection: string | null;
   readonly status: SquadRunTurnStatus | null;
   readonly startedAt: string | null;
@@ -183,6 +188,7 @@ function validSquadRunLeaderTurn(value: unknown): value is SquadRunLeaderTurnDto
       "trigger",
       "dispatchId",
       "runtimeSessionId",
+      "worktree",
       "decision",
       "resultText",
       "status",
@@ -217,6 +223,10 @@ function validSquadRunWorkerAttempt(value: unknown): value is SquadRunWorkerAtte
     squadRunText(value.leaderTurnId) &&
     (value.dispatchId === null || squadRunText(value.dispatchId)) &&
     (value.runtimeSessionId === null || squadRunText(value.runtimeSessionId)) &&
+    (value.worktree === null ||
+      (squadRunRecord(value.worktree) &&
+        exactSquadRunFields(value.worktree, ["cwd", "branch", "baseSha"]) &&
+        [value.worktree.cwd, value.worktree.branch, value.worktree.baseSha].every(squadRunText))) &&
     (value.rejection === null || squadRunText(value.rejection)) &&
     (value.status === null || turnStatuses.includes(value.status as SquadRunTurnStatus)) &&
     (value.startedAt === null || squadRunIso(value.startedAt)) &&

--- a/packages/daemon/src/squad-run-contract.ts
+++ b/packages/daemon/src/squad-run-contract.ts
@@ -188,7 +188,6 @@ function validSquadRunLeaderTurn(value: unknown): value is SquadRunLeaderTurnDto
       "trigger",
       "dispatchId",
       "runtimeSessionId",
-      "worktree",
       "decision",
       "resultText",
       "status",
@@ -208,22 +207,27 @@ function validSquadRunLeaderTurn(value: unknown): value is SquadRunLeaderTurnDto
 function validSquadRunWorkerAttempt(value: unknown): value is SquadRunWorkerAttemptDto {
   return (
     squadRunRecord(value) &&
-    exactSquadRunFields(value, [
-      "attemptId",
-      "workerId",
-      "leaderTurnId",
-      "dispatchId",
-      "runtimeSessionId",
-      "rejection",
-      "status",
-      "startedAt",
-      "endedAt",
-    ]) &&
+    exactSquadRunFieldsOptional(
+      value,
+      [
+        "attemptId",
+        "workerId",
+        "leaderTurnId",
+        "dispatchId",
+        "runtimeSessionId",
+        "rejection",
+        "status",
+        "startedAt",
+        "endedAt",
+      ],
+      ["worktree"],
+    ) &&
     [value.attemptId, value.workerId].every(squadRunText) &&
     squadRunText(value.leaderTurnId) &&
     (value.dispatchId === null || squadRunText(value.dispatchId)) &&
     (value.runtimeSessionId === null || squadRunText(value.runtimeSessionId)) &&
-    (value.worktree === null ||
+    (value.worktree === undefined ||
+      value.worktree === null ||
       (squadRunRecord(value.worktree) &&
         exactSquadRunFields(value.worktree, ["cwd", "branch", "baseSha"]) &&
         [value.worktree.cwd, value.worktree.branch, value.worktree.baseSha].every(squadRunText))) &&
@@ -231,6 +235,17 @@ function validSquadRunWorkerAttempt(value: unknown): value is SquadRunWorkerAtte
     (value.status === null || turnStatuses.includes(value.status as SquadRunTurnStatus)) &&
     (value.startedAt === null || squadRunIso(value.startedAt)) &&
     (value.endedAt === null || squadRunIso(value.endedAt))
+  );
+}
+
+function exactSquadRunFieldsOptional(
+  value: Readonly<Record<string, unknown>>,
+  fields: readonly string[],
+  optionalFields: readonly string[],
+): boolean {
+  const allowed = [...fields, ...optionalFields];
+  return (
+    fields.every((field) => Object.hasOwn(value, field)) && Object.keys(value).every((field) => allowed.includes(field))
   );
 }
 

--- a/packages/daemon/test/squad-coordinator-recovery.test.ts
+++ b/packages/daemon/test/squad-coordinator-recovery.test.ts
@@ -63,6 +63,7 @@ function makeRecoveryFixture(
     readonly pendingLeaderTriggers?: readonly Readonly<Record<string, unknown>>[];
     readonly rejectWorkerOnce?: string;
     readonly observedWorkerRuntimeSessionIds?: readonly string[];
+    readonly permissionMode?: "bypass" | "workspace-write" | "read-only";
   },
 ): RecoveryFixture {
   const workers = options.workers ?? [],
@@ -113,6 +114,8 @@ function makeRecoveryFixture(
     mission: "Finish the milestone",
     model: null,
     effort: null,
+    permissionMode: options.permissionMode ?? "read-only",
+    baseSha: "1".repeat(40),
     leaderAgentId: "leader",
     roster: "leader -> sol, terra\nsynthesis -> artifacts/reports/{squadRunId}.md",
     workers: ["sol", "terra"],
@@ -135,6 +138,7 @@ function makeRecoveryFixture(
       workerId: worker.workerId,
       dispatchId: worker.dispatchId,
       runtimeSessionId: worker.runtimeSessionId,
+      worktree: null,
       rejection: null,
     })),
     observedWorkerRuntimeSessionIds: options.observedWorkerRuntimeSessionIds ?? [],

--- a/packages/daemon/test/squad-run-reads.contract.test.ts
+++ b/packages/daemon/test/squad-run-reads.contract.test.ts
@@ -240,3 +240,22 @@ test("squad run read validator locks the orchestration-flow wire shape", () => {
     [],
   );
 });
+
+test("squad run read accepts legacy worker attempts without a worktree", () => {
+  const legacy = structuredClone(detail) as Record<string, unknown>;
+  const run = legacy.run as Record<string, unknown>;
+  run.workerAttempts = [
+    {
+      attemptId: "worker-1",
+      workerId: "sol",
+      leaderTurnId: "leader-1",
+      dispatchId: null,
+      runtimeSessionId: null,
+      rejection: null,
+      status: null,
+      startedAt: null,
+      endedAt: null,
+    },
+  ];
+  assert.deepEqual(validateSquadRunRead(legacy), []);
+});

--- a/packages/kernel/src/store/local-version-control-system.ts
+++ b/packages/kernel/src/store/local-version-control-system.ts
@@ -289,6 +289,15 @@ export const localGitObjectRefStore = Object.freeze({
     return Number.isNaN(timestamp.valueOf()) ? null : timestamp.toISOString();
   },
   resolveCommit: (repoRoot: string, revision: string) => runGit(repoRoot, "rev-parse", revision).trim(),
+  // A directory that is not a Git work tree, or one without any commit yet, has no baseline to branch from.
+  headCommit: (repoRoot: string): string | null => {
+    try {
+      return runGit(repoRoot, "rev-parse", "--verify", "--quiet", "HEAD^{commit}").trim() || null;
+    } catch (error) {
+      consumeKnownError(error);
+      return null;
+    }
+  },
   // `rev-parse` echoes a well-formed sha whether or not the object exists; this asks the object store.
   hasCommit: (repoRoot: string, sha: string): boolean => {
     try {

--- a/packages/kernel/src/store/local-version-control-system.ts
+++ b/packages/kernel/src/store/local-version-control-system.ts
@@ -278,6 +278,9 @@ function pathspecChunks(targets: readonly string[]): readonly (readonly string[]
 }
 export const localGitObjectRefStore = Object.freeze({
   processCount: () => localGitProcesses,
+  addWorktree: (repoRoot: string, cwd: string, branch: string, baseRef: string): void => {
+    runGit(repoRoot, "worktree", "add", cwd, "-b", branch, baseRef);
+  },
   commitTimestamp: (repoRoot: string, commit: string): string | null => {
     const output = localGitBytes(repoRoot, ["cat-file", "commit", commit]).toString("utf8"),
       seconds = /^committer .+ ([0-9]+) [+-][0-9]{4}$/mu.exec(output)?.[1];

--- a/tools/gate-allowlists/check-fallback-boundaries.json
+++ b/tools/gate-allowlists/check-fallback-boundaries.json
@@ -259,6 +259,7 @@
       "packages/kernel/src/store/local-version-control-system.ts#currentBranch",
       "packages/kernel/src/store/local-version-control-system.ts#gitTopLevel",
       "packages/kernel/src/store/local-version-control-system.ts#hasCommit",
+      "packages/kernel/src/store/local-version-control-system.ts#headCommit",
       "packages/kernel/src/store/local-version-control-system.ts#isAncestor",
       "packages/kernel/src/store/local-version-control-system.ts#isDirectory",
       "packages/kernel/src/store/local-version-control-system.ts#processMayBeAlive",


### PR DESCRIPTION
# English

## Summary

The squad coordinator handed every worker the same `--cwd` (`squad-coordinator.ts`, no worktree allocation), so rosters that require one worktree per worker could not be honoured and write workers stopped on dirty trees (fact F-72CD0EA0, three cases). This is the structural gap the squad retrospective (task_7873609b) listed as blocking, and the repository owner ruled on 2026-09-11 that it be fixed.

The coordinator now resolves a baseline sha when a run starts (`origin/main` when the run cwd is the repository root, otherwise that cwd's `HEAD`) and, for every worker whose permission mode is not `read-only`, adds a git worktree `.worktrees/squad-<runId>-<workerId>` on branch `codex/squad-<runId>-<workerId>` at that baseline before dispatch; the worker's prompt gains a "Squad worker checkout" section naming its root, branch and baseline, and the attempt record stores the same triple. Read-only workers keep sharing the run cwd. Worktrees are not deleted by the coordinator; the CEO cleans them after merging.

## Architectural Justification

- Simplest alternative: keep dispatching every squad worker into the shared run cwd. Rejected because that is the defect this task fixes (F-… in task_faf4cc9a: two writing workers and the CEO checkout edit the same working tree).
- What the added lines buy: `prepareWorkerWorktree` (one git `worktree add` per writing worker from the run's HEAD baseline) and the `worktree`/`baseSha` fields on the attempt and run records, so a worker's cwd, branch and baseline are auditable from `ha squad status`. No new module, no new port; `localGitObjectRefStore.addWorktree`/`headCommit` are two thin git calls next to the existing `resolveCommit`/`hasCommit`.
- Deleted: nothing in this PR; the shared-cwd path stays only for read-only workers and for a cwd without a Git commit, which is the same code path as before, not a second implementation.

## What Changed

- `packages/daemon/src/squad-coordinator.ts`: `baseSha` on run state; `prepareWorkerWorktree` for write workers; worker prompt and cwd use the worktree.
- `packages/daemon/src/squad-run-contract.ts`, `squad-leader-decision.ts`: `worktree {cwd, branch, baseSha} | null` on worker attempts, validated.
- `packages/kernel/src/store/local-version-control-system.ts`: `addWorktree(repoRoot, cwd, branch, baseRef)`.
- `packages/daemon/test/squad-coordinator-recovery.test.ts`: attempts carry the worktree triple.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: +106/-22 (churn 128, `production-delta` G33 pass; four commits, last one drops the `origin/main` dependency).

## Machine-Readable Declarations

- `squad-run` record: worker attempts gain an optional `worktree` object (`cwd`, `branch`, `baseSha`) or `null`.

## Task And Scope

- Harness task: task_faf4cc9a3a51de2d118cdce143, parent task_7873609b3f504ce8fd26c3b30a
- Branch: `codex/squad-worker-worktree`
- Public scope: squad coordinator dispatch path and its record contract
- Private planning/evidence updated: yes (`artifacts/report.md`, fact F-F729CD14)
- Out of scope: worktree cleanup policy, leader contract rework (task_aee7bf36)

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: yes — `tools/gate-allowlists/check-fallback-boundaries.json` (one entry added: `local-version-control-system.ts#headCommit`, the non-throwing HEAD probe next to the already-listed `hasCommit`)
- Protected surface scope: ratchet moves 283 → 284 for one kernel git probe whose catch converts "no commit / not a work tree" into `null`; no gate semantics change
- Authority: repository owner authorization for the squad worktree fix (task_faf4cc9a3a51de2d118cdce143, 2026-09-11 ruling "阻塞性缺陷就去修复")
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `60d6a6ab2`
- Branch merge-base with `origin/main`: `60d6a6ab2`
- Last `git fetch origin` time: 2026-09-11 UTC
- Sync method: rebased onto origin/main
- Public diff command: `git diff origin/main...codex/squad-worker-worktree`
- Private evidence commit/path: task_faf4cc9a3a51de2d118cdce143 `artifacts/report.md`
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [x] `npm run typecheck` (`npx tsc -b packages/daemon/tsconfig.json`, CEO; kernel `--noEmit`, worker)
- [ ] `npm run check`
- [ ] `npm test`
- [x] `npm run harness:check-import-boundaries` (via `run-manifest-gates --changed origin/main`, CEO)
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts` (via `run-manifest-gates --changed origin/main`)
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- `squad-coordinator-recovery.test.ts` 15/15 (worker and CEO after rebase).

## Review Evidence

- CEO ground-truth: read the diff (baseline resolution, worktree creation only for write workers, prompt and record carry the triple); no real-git coordinator fixture was added, the worker says so.
- Reviewer subagent: pending (closeout review after merge)
- Human review: pending
- Blocking findings: none open

## Residual Risk

- No integration fixture runs the coordinator against a real git repository; cross-platform worktree behaviour is left to CI.
- Worktrees accumulate under `.worktrees/` until the CEO removes them.

## References

- Task: task_faf4cc9a3a51de2d118cdce143; retrospective task_7873609b3f504ce8fd26c3b30a

---

# 中文

## 概要

squad 协调器把同一个 `--cwd` 交给所有 worker（`squad-coordinator.ts`，没有 worktree 分配），roster 里「一个 worker 一个 worktree」兑现不了，写类 worker 因工作树不干净停手（fact F-72CD0EA0，三例）。这是小队复盘（task_7873609b）单列的阻塞性结构缺口，仓库所有者 2026-09-11 裁决去修。

协调器现在在 run 开始时解析基线 sha（run cwd 是仓库根时取 `origin/main`，否则取该 cwd 的 `HEAD`），对每个 permission mode 不是 `read-only` 的 worker，派出前在 `.worktrees/squad-<runId>-<workerId>` 以分支 `codex/squad-<runId>-<workerId>` 基于该基线建 worktree；worker 的 prompt 追加「Squad worker checkout」段写明根目录、分支与基线，attempt 记录存同一三元组。只读 worker 继续共用 run cwd。协调器不删 worktree，合并后由 CEO 清理。

## 架构辩护

- 最简替代：继续把每个 squad worker 派进共享的 run cwd。否决，因为这正是本任务修的缺陷（task_faf4cc9a：两个写 worker 和 CEO 的 checkout 改同一个工作树）。
- 新增行买到了什么：`prepareWorkerWorktree`（每个写 worker 从 run 的 HEAD 基线 `git worktree add` 一次）以及 attempt/run 记录上的 `worktree`/`baseSha` 字段，worker 的 cwd、分支、基线都能从 `ha squad status` 审计。没有新模块、没有新 port；`localGitObjectRefStore.addWorktree`/`headCommit` 是挨着现有 `resolveCommit`/`hasCommit` 的两个薄 git 调用。
- 删除：本 PR 无；共享 cwd 路径只留给只读 worker 和没有 Git 提交的 cwd，与原来是同一条代码路径，不是第二套实现。

## 改动内容

- `packages/daemon/src/squad-coordinator.ts`：run 状态带 `baseSha`；写类 worker 走 `prepareWorkerWorktree`；worker prompt 与 cwd 用 worktree。
- `packages/daemon/src/squad-run-contract.ts`、`squad-leader-decision.ts`：worker attempt 增加 `worktree {cwd, branch, baseSha} | null` 并校验。
- `packages/kernel/src/store/local-version-control-system.ts`：`addWorktree(repoRoot, cwd, branch, baseRef)`。
- `packages/daemon/test/squad-coordinator-recovery.test.ts`：attempt 带 worktree 三元组。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 删除的门或 fixture：none
- 生产净行数：+106/-22（churn 128，G33 通过；四个提交，最后一个去掉了对 `origin/main` 的依赖）。

## 机器可读声明

- `squad-run` 记录：worker attempt 新增可选 `worktree` 对象（`cwd`、`branch`、`baseSha`）或 `null`。

## 任务与范围

- Harness 任务：task_faf4cc9a3a51de2d118cdce143，父任务 task_7873609b3f504ce8fd26c3b30a
- 分支：`codex/squad-worker-worktree`
- 公开范围：squad 协调器派出路径与其记录契约
- 私有计划/证据已更新：是（`artifacts/report.md`、fact F-F729CD14）
- 范围外：worktree 清理策略、leader 契约返工（task_aee7bf36）

## 版本影响

- 版本：不变
- 发布影响：不发布

## 治理声明

- 触碰受保护面：是——`tools/gate-allowlists/check-fallback-boundaries.json`（新增一条：`local-version-control-system.ts#headCommit`，与已登记的 `hasCommit` 并列的不抛错 HEAD 探针）
- 受保护面范围：棘轮 283 → 284，只为一个 kernel git 探针，其 catch 把「无提交 / 非工作树」转成 `null`；门语义不变
- 授权：仓库所有者对 squad worktree 修复的授权（task_faf4cc9a3a51de2d118cdce143，2026-09-11 裁决「阻塞性缺陷就去修复」）
- 机器检查边界：本 PR 只断言声明存在；是否属实、是否充分由评审判断。
- Break-glass：否
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- 基线 `origin/main` SHA：`60d6a6ab2`
- 分支与 `origin/main` 的 merge-base：`60d6a6ab2`
- 最近一次 `git fetch origin`：2026-09-11 UTC
- 同步方式：rebase 到 origin/main
- 公开 diff 命令：`git diff origin/main...codex/squad-worker-worktree`
- 私有证据路径：task_faf4cc9a3a51de2d118cdce143 的 `artifacts/report.md`
- 评审证据路径：本 PR 的评审证据节
- GitHub Actions `rewrite-ci` run URL：本 PR 待跑
- `squad-coordinator-recovery.test.ts` 15/15（worker 与 CEO rebase 后）。

## 评审证据

- CEO 事实核对：读过 diff（基线解析、只给写类 worker 建 worktree、prompt 与记录带三元组）；没有加真实 git 的协调器夹具，worker 已如实说明。
- 评审子代理：待定（合入后派收口评审）
- 人工评审：待定
- 阻塞发现：无

## 残余风险

- 没有 integration 夹具让协调器跑在真实 git 仓上；跨平台 worktree 行为交给 CI。
- worktree 会在 `.worktrees/` 下累积，直到 CEO 清理。

## 参考

- 任务：task_faf4cc9a3a51de2d118cdce143；复盘 task_7873609b3f504ce8fd26c3b30a
