### PR TITLE
fix: settle missing runtime sessions on cancel

### DIFF
--- a/packages/daemon/src/runtime-spawn-control.ts
+++ b/packages/daemon/src/runtime-spawn-control.ts
@@ -35,6 +35,40 @@ export async function cancelRuntime(
     await context.publishExit(active, null);
     return context.controlReceipt(opId, runtimeSessionId);
   }
+  const session = context.input.remote
+    ? (await context.input.remote.readRuntimeSessions()).find((value) => value.runtimeSessionId === runtimeSessionId)
+    : context.requiredRuntimeProjection(context.input).readRuntimeSession(runtimeSessionId);
+  if (session && session.liveness !== "exited" && session.outcome === null) {
+    const terminalBinding = {
+      ...binding,
+      actor: {
+        principal: binding.actor.principal,
+        executor: { kind: "agent" as const, id: `runtime-session:${runtimeSessionId}` },
+      },
+    };
+    await context.publishRuntimeEvent("runtime_session_cancelled", { runtimeSessionId }, `${opId}-cancelled`, binding);
+    await context.publishRuntimeEvent(
+      "runtime_session_exited",
+      { runtimeSessionId },
+      `${opId}-exited`,
+      terminalBinding,
+    );
+    await context.publishRuntimeEvent(
+      "runtime_session_outcome_observed",
+      {
+        runtimeSessionId,
+        outcome: "cancelled",
+        exitCode: null,
+        resultRef: `artifact:runtime-result/sha256/${createHash("sha256").update(runtimeSessionId).digest("hex")}`,
+        result: null,
+        reasonCode: "runtime_process_missing",
+      },
+      `${opId}-outcome`,
+      terminalBinding,
+      "Runtime session cancelled after its worker process was no longer available.",
+    );
+    return context.controlReceipt(opId, runtimeSessionId, "cancelled");
+  }
   return context.controlReceipt(opId, runtimeSessionId, "already-exited");
 }
 

--- a/packages/daemon/src/runtime-spawn-control.ts
+++ b/packages/daemon/src/runtime-spawn-control.ts
@@ -3,6 +3,7 @@ import { unknownFieldViolation, type JsonObject } from "./protocol/json-rpc-type
 import { requiredRuntimeSpawnText, runtimeSpawnError } from "./runtime-spawn-errors.ts";
 import { consumeDurableOutput } from "./runtime-spawn-provider-stream.ts";
 import { adoptRuntimes } from "./runtime-spawn-adoption.ts";
+import { readDispatchStreamHeaders } from "./dispatch-stream.ts";
 import type { RuntimeBinding } from "./runtime-spawn-types.ts";
 import type { RuntimeSpawnerContext } from "./runtime-spawn-context.ts";
 
@@ -35,9 +36,17 @@ export async function cancelRuntime(
     await context.publishExit(active, null);
     return context.controlReceipt(opId, runtimeSessionId);
   }
-  const session = context.input.remote
-    ? (await context.input.remote.readRuntimeSessions()).find((value) => value.runtimeSessionId === runtimeSessionId)
-    : context.requiredRuntimeProjection(context.input).readRuntimeSession(runtimeSessionId);
+  // A session with a dispatch record belongs to adoption above; only a session the projection
+  // knows without any dispatch record is settled from the projection alone.
+  const recorded = readDispatchStreamHeaders(context.input.rootDir).some(
+      (header) => header.runtimeSessionId === runtimeSessionId,
+    ),
+    session = recorded
+      ? undefined
+      : (context.input.remote
+          ? await context.input.remote.readRuntimeSessions()
+          : context.requiredRuntimeProjection(context.input).readRuntimeSessions()
+        ).find((value) => value.runtimeSessionId === runtimeSessionId);
   if (session && session.liveness !== "exited" && session.outcome === null) {
     const terminalBinding = {
       ...binding,


### PR DESCRIPTION
# English

## Summary

#2481 made `ha runtime cancel` settle sessions whose dispatch record shows a dead process. Live acceptance on 60d6a6ab2 showed the four field sessions (three days old, still "running" in the GUI) are a different kind: they exist in the runtime projection but have no dispatch record at all, so adoption has nothing to settle and cancel still answered `already-exited`.

Cancel now handles that case too: when the daemon holds no process for the session and the projection still shows it un-exited with no outcome, it publishes the existing `runtime_session_cancelled`, `runtime_session_exited` and `runtime_session_outcome_observed` events (outcome `cancelled`, reason code `runtime_process_missing`) and returns `cancelled`. No new event kinds; the terminal binding's executor is the session itself, as for normal exits.

## Architectural Justification

-

## What Changed

- `packages/daemon/src/runtime-spawn-control.ts`: the no-active-process branch reads the session from the projection (or the remote read for edge mode) and settles it before falling back to `already-exited`.
- `packages/daemon/test/runtime-spawn-lifecycle.integration.test.ts`: cancel of a projected session without a dispatch record reaches `cancelled`.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: +34/-0 in `packages/*`.

## Machine-Readable Declarations

- None.

## Task And Scope

- Harness task: task_e30d0748a7c1277f69dbf1b05b (round 2), parent task_2b8f79fa4412cb726a26f9bfc7
- Branch: `codex/runtime-stale-settle-2`
- Public scope: daemon runtime cancel
- Private planning/evidence updated: yes (task plan round 2, fact F-C71AC5E8)
- Out of scope: startup reconciliation of sessions without dispatch records (cancel is the user-facing path; a follow-up if such sessions keep appearing)

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: not applicable
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `60d6a6ab2`
- Branch merge-base with `origin/main`: `60d6a6ab2`
- Last `git fetch origin` time: 2026-09-11 UTC
- Sync method: branched from origin/main
- Public diff command: `git diff origin/main...codex/runtime-stale-settle-2`
- Private evidence commit/path: task_e30d0748a7c1277f69dbf1b05b `artifacts/report.md`
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [ ] `npm run typecheck`
- [ ] `npm run check`
- [ ] `npm test`
- [x] `npm run harness:check-import-boundaries` (via `run-manifest-gates --changed origin/main`, CEO)
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts` (via `run-manifest-gates --changed origin/main`)
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- `runtime-spawn-lifecycle.integration.test.ts` 8/8 (worker and CEO).
- Live acceptance on the four field sessions happens after deploy (recorded in the task package).

## Review Evidence

- CEO ground-truth: reproduced on the deployed 60d6a6ab2 daemon (`cancel` → already-exited, status stays unknown/-); read the diff: existing event kinds only, projection read guarded by liveness/outcome.
- Reviewer subagent: pending (closeout review after merge)
- Human review: pending
- Blocking findings: none open

## Residual Risk

- A session that was never projected at all cannot be cancelled by id; none of the field cases is of that kind.

## References

- Task: task_e30d0748a7c1277f69dbf1b05b; first part #2481

---

# 中文

## 概要

#2481 让 `ha runtime cancel` 能结算「dispatch 记录里进程已死」的会话。在 60d6a6ab2 上现场验收发现现场那 4 条（挂了 3 天、GUI 仍显示运行中）是另一类：投影里有会话，但完全没有 dispatch 记录，收养无从结算，cancel 仍回 `already-exited`。

现在 cancel 也处理这一类：daemon 没有该会话的进程、投影里它仍未退出且无结果时，发布既有的 `runtime_session_cancelled`、`runtime_session_exited`、`runtime_session_outcome_observed` 三个事件（outcome `cancelled`，原因码 `runtime_process_missing`），回 `cancelled`。不新造事件类型；终态绑定的 executor 是会话自身，与正常退出一致。

## 架构辩护

-

## 改动内容

- `packages/daemon/src/runtime-spawn-control.ts`：无 active 进程分支先从投影（edge 模式走 remote 读）读会话并结算，再回落到 `already-exited`。
- `packages/daemon/test/runtime-spawn-lifecycle.integration.test.ts`：无 dispatch 记录的投影会话 cancel 后到 `cancelled`。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 删除的门或 fixture：none
- 生产净行数：`packages/*` +34/-0。

## 机器可读声明

- 无。

## 任务与范围

- Harness 任务：task_e30d0748a7c1277f69dbf1b05b（第二轮），父任务 task_2b8f79fa4412cb726a26f9bfc7
- 分支：`codex/runtime-stale-settle-2`
- 公开范围：daemon runtime cancel
- 私有计划/证据已更新：是（任务计划 Round 2、fact F-C71AC5E8）
- 范围外：无 dispatch 记录会话的启动对账（cancel 是用户面路径；若此类会话持续出现再立后续）

## 版本影响

- 版本：不变
- 发布影响：不发布

## 治理声明

- 触碰受保护面：否
- 受保护面范围：不适用
- 授权：不适用
- 机器检查边界：本 PR 只断言声明存在；是否属实、是否充分由评审判断。
- Break-glass：否
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- 基线 `origin/main` SHA：`60d6a6ab2`
- 分支与 `origin/main` 的 merge-base：`60d6a6ab2`
- 最近一次 `git fetch origin`：2026-09-11 UTC
- 同步方式：从 origin/main 开分支
- 公开 diff 命令：`git diff origin/main...codex/runtime-stale-settle-2`
- 私有证据路径：task_e30d0748a7c1277f69dbf1b05b 的 `artifacts/report.md`
- 评审证据路径：本 PR 的评审证据节
- GitHub Actions `rewrite-ci` run URL：本 PR 待跑
- `runtime-spawn-lifecycle.integration.test.ts` 8/8（worker 与 CEO）。
- 现场 4 条会话的验收在部署后做（记入任务包）。

## 评审证据

- CEO 事实核对：在已部署的 60d6a6ab2 daemon 上复现（`cancel` → already-exited，状态仍 unknown/-）；读过 diff：只用既有事件类型，投影读以 liveness/outcome 把守。
- 评审子代理：待定（合入后派收口评审）
- 人工评审：待定
- 阻塞发现：无

## 残余风险

- 从未进过投影的会话无法按 id 取消；现场四条不属此类。

## 参考

- 任务：task_e30d0748a7c1277f69dbf1b05b；第一部分 #2481
