### PR TITLE
perf: index task identity checks on task create

### DIFF
--- a/packages/daemon/src/repo-cell-task-create.ts
+++ b/packages/daemon/src/repo-cell-task-create.ts
@@ -150,11 +150,9 @@ export function prepareTaskCreateAt(
   }
   const idempotent =
     !dryRun && typeof canonicalAction.idempotencyKey === "string"
-      ? cell.projection
-          .list()
-          .rows.find((row) => row.snapshot.task?.metadata?.idempotencyKey === canonicalAction.idempotencyKey)
-      : undefined;
-  if (idempotent?.snapshot.task) {
+      ? cell.projection.readTaskByIdempotencyKey(canonicalAction.idempotencyKey)
+      : null;
+  if (idempotent) {
     const current = cell.projection.read(idempotent.taskId);
     return {
       ...cell.readResult(
@@ -168,15 +166,14 @@ export function prepareTaskCreateAt(
         true,
       ),
       taskId: idempotent.taskId,
-      taskStatus: idempotent.snapshot.task.status,
-      packagePath: current.packagePath,
+      taskStatus: idempotent.status as TaskCreateReceipt["taskStatus"],
+      packagePath: idempotent.packagePath,
       summary: `reused task ${idempotent.taskId} for the supplied idempotency key`,
     } as WriteReceipt;
   }
-  const taskId = cell.createTaskId(canonicalAction, binding, cell.input.repoId),
-    taskIds = cell.projectedTaskIds();
-  if (taskIds.has(taskId)) return cell.rejected(opId, "task_exists");
-  if (typeof canonicalAction.parentTaskId === "string" && !taskIds.has(canonicalAction.parentTaskId))
+  const taskId = cell.createTaskId(canonicalAction, binding, cell.input.repoId);
+  if (cell.projection.readTaskExists(taskId)) return cell.rejected(opId, "task_exists");
+  if (typeof canonicalAction.parentTaskId === "string" && !cell.projection.readTaskExists(canonicalAction.parentTaskId))
     return cell.rejected(opId, "parent_not_found");
   const currentRevision = cell.store.readHead()?.revision ?? 0,
     workspaceRevision = assigned?.workspaceRevision ?? currentRevision + 1,
@@ -256,7 +253,7 @@ export function prepareTaskCreateAt(
 
 export function applyPreparedTaskCreate(cell: RepoCellOperationalContext, prepared: PreparedTaskCreate): void {
   cell.projection.apply(prepared.compiled.event, prepared.compiled.plan);
-  cell.projectedTaskIds().add(prepared.fields.taskId);
+  cell.knownTaskIds?.add(prepared.fields.taskId);
 }
 
 export function preparedTaskCreateReceipt(

--- a/packages/kernel/src/projection/rebuildable-task-projection-factory.ts
+++ b/packages/kernel/src/projection/rebuildable-task-projection-factory.ts
@@ -211,6 +211,8 @@ export function makeTaskProjectionReader(options: {
       readTaskDependencyClosure: taskQueries.readTaskDependencyClosure,
       readTaskRelationsByTargets: taskQueries.readTaskRelationsByTargets,
       readTaskStatuses: taskQueries.readTaskStatuses,
+      readTaskExists: taskQueries.readTaskExists,
+      readTaskByIdempotencyKey: taskQueries.readTaskByIdempotencyKey,
       readTaskRuntimeBatch: taskQueries.readTaskRuntimeBatch,
       readRelationQuery: taskQueries.readRelationQuery,
       readOperation: taskQueries.readOperation,

--- a/packages/kernel/src/projection/rebuildable-task-projection-task-queries.ts
+++ b/packages/kernel/src/projection/rebuildable-task-projection-task-queries.ts
@@ -14,6 +14,8 @@ import {
   readTaskRelationsByTargets,
   readTaskRuntimeBatchPage,
   readTaskStatusRows,
+  readTaskExists,
+  readTaskByIdempotencyKey,
 } from "./task-query-projection.ts";
 import type { TaskProjection } from "./task-projection-port.ts";
 import type { ProjectionContext } from "./rebuildable-task-projection-types.ts";
@@ -106,6 +108,8 @@ export function taskQueryApi(
   | "readTaskDependencyClosure"
   | "readTaskRelationsByTargets"
   | "readTaskStatuses"
+  | "readTaskExists"
+  | "readTaskByIdempotencyKey"
   | "readTaskRuntimeBatch"
   | "readRelationQuery"
   | "readOperation"
@@ -202,6 +206,9 @@ export function taskQueryApi(
           sourceRevision: cut.sourceRevision,
         };
       }),
+    readTaskExists: (taskId) => withDatabase(projectionPath, readHead, (db) => readTaskExists(db, taskId)),
+    readTaskByIdempotencyKey: (idempotencyKey) =>
+      withDatabase(projectionPath, readHead, (db) => readTaskByIdempotencyKey(db, idempotencyKey)),
     readTaskRuntimeBatch: (query) =>
       withDatabase(projectionPath, readHead, (db) => {
         const cut = readProjectionCut(db, readHead),

--- a/packages/kernel/src/projection/task-projection-port.ts
+++ b/packages/kernel/src/projection/task-projection-port.ts
@@ -100,6 +100,12 @@ export interface TaskProjection {
     readonly watermark: number;
     readonly sourceRevision: number;
   };
+  readonly readTaskExists: (taskId: string) => boolean;
+  readonly readTaskByIdempotencyKey: (idempotencyKey: string) => {
+    readonly taskId: string;
+    readonly status: string;
+    readonly packagePath: string | null;
+  } | null;
   readonly readTaskRuntimeBatch: (query: TaskRuntimeBatchQuery) => TaskRuntimeBatchRead;
   readonly readRelationQuery: (query?: TaskRelationQuery) => TaskRelationProjectionRead;
   readonly readOperation: (opId: string) => { readonly event: CanonicalEventV1; readonly watermark: number } | null;

--- a/packages/kernel/src/projection/task-query-projection.ts
+++ b/packages/kernel/src/projection/task-query-projection.ts
@@ -576,6 +576,34 @@ export function readTaskStatusRows(
   ).map((row) => ({ taskId: row.task_id, status: row.status }));
 }
 
+/** Indexed existence check used by task creation and parent validation.
+ * The task_snapshot primary key keeps this lookup bounded. */
+export function readTaskExists(db: DatabaseSync, taskId: string): boolean {
+  const query = "SELECT task_id FROM task_snapshot WHERE task_id = ? LIMIT 1";
+  return queryRows<{ readonly task_id: string }>(db, query, taskId).length > 0;
+}
+
+/** Find a task by its idempotency key without materializing the task index. */
+export function readTaskByIdempotencyKey(
+  db: DatabaseSync,
+  idempotencyKey: string,
+): { readonly taskId: string; readonly status: string; readonly packagePath: string | null } | null {
+  const row = queryRows<{
+    readonly task_id: string;
+    readonly status: string;
+    readonly package_path: string | null;
+  }>(
+    db,
+    [
+      "SELECT task_snapshot.task_id, task_snapshot.status, task_package.package_path FROM task_snapshot",
+      "LEFT JOIN task_package USING(task_id)",
+      "WHERE json_extract(task_snapshot.snapshot_json, '$.task.metadata.idempotencyKey') = ? LIMIT 1",
+    ].join(" "),
+    idempotencyKey,
+  )[0];
+  return row ? { taskId: row.task_id, status: row.status, packagePath: row.package_path } : null;
+}
+
 /** Indexed narrow page over the task snapshot table; order matches the unparameterized list (task id asc). */
 export function listTaskRowsNarrow(
   db: DatabaseSync,


### PR DESCRIPTION
# English

## Summary

1M follow-up (task_755495b74e28390ad2a72ae7af, from the 1M rerun finding F-80a574ca: first `task create` took 4.4 s at 1M because `repo-cell-receipts.ts` materialized every task snapshot to check the generated id, the parent id and the idempotency key). `task create` now asks the projection two indexed questions: `readTaskExists(taskId)` (primary-key lookup on `task_snapshot`) and `readTaskByIdempotencyKey(key)` (single SQL query joined with `task_package`). The full task-id set is no longer built on the create path; the existing cache is only touched if some other path already built it.

## Architectural Justification

-

## What Changed

- `packages/kernel/src/projection/task-query-projection.ts`: `readTaskExists`, `readTaskByIdempotencyKey`.
- `packages/kernel/src/projection/task-projection-port.ts`, `rebuildable-task-projection-task-queries.ts`, `rebuildable-task-projection-factory.ts`: expose the two reads on `TaskProjection`.
- `packages/daemon/src/repo-cell-task-create.ts`: create/parent/idempotency checks use the indexed reads instead of `projection.list()` + `projectedTaskIds()`.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: +52/-12 (churn 64, `production-delta` G33 pass).

## Machine-Readable Declarations

- None.

## Task And Scope

- Harness task: task_755495b74e28390ad2a72ae7af, parent task_2b8f79fa4412cb726a26f9bfc7 (perf rescue)
- Branch: `codex/perf-task-create-index`
- Public scope: task create identity checks
- Private planning/evidence updated: yes (`artifacts/report.md`, fact F-DD771A1C)
- Out of scope: other O(N) reads on the create path (task_44033752 attribution in flight)

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: not applicable
- Machine-check boundary: not applicable
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `1a19fd348`
- Branch merge-base with `origin/main`: `1a19fd348` (rebased)
- Last `git fetch origin` time: 2026-09-11 UTC
- Sync method: rebase onto origin/main
- Public diff command: `git diff origin/main...codex/perf-task-create-index`
- Private evidence commit/path: task_755495b74e28390ad2a72ae7af `artifacts/report.md`
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [x] `npm run typecheck` (`npx tsc -b packages/kernel packages/daemon`, CEO after rebase)
- [ ] `npm run check`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [x] GitHub Actions `rewrite-ci` passed — pending
- `packages/daemon/test/repo-cell-latch-recovery.test.ts` 7/7 (CEO after rebase); worker: daemon fast tier 251/251, lint, typecheck, line-density.

## Review Evidence

- CEO ground-truth: read the diff; both new reads are single indexed/targeted queries; the idempotent reuse receipt now takes status/packagePath from the targeted row (previously from the materialized snapshot).
- Reviewer subagent: pending (closeout review after merge)
- Human review: pending
- Blocking findings: none open

## Residual Risk

- `readTaskByIdempotencyKey` filters with `json_extract` over `snapshot_json` (no expression index), so an idempotency-key create is still a single SQL scan of `task_snapshot` rather than a materialization; only creates that pass an idempotency key pay it. No 10k/100k timing was measured in this PR (worker run); the 1M three-tier rerun covers it.

## References

- Task: task_755495b74e28390ad2a72ae7af; finding F-80a574ca

---

# 中文

## 概要

1M 复测后续（task_755495b74e28390ad2a72ae7af，来自 F-80a574ca：1M 台账上第一次 `task create` 要 4.4 s，因为 `repo-cell-receipts.ts` 把全部 task 快照物化出来查生成 id、父 id 和幂等键）。现在 `task create` 只问投影两个带索引的问题：`readTaskExists(taskId)`（`task_snapshot` 主键查询）和 `readTaskByIdempotencyKey(key)`（一条 SQL 联 `task_package`）。创建路径不再构造全量 task id 集合；已有缓存只在别的路径已经建好时才被追加。

## 架构辩护

-

## 改动内容

- `packages/kernel/src/projection/task-query-projection.ts`：新增 `readTaskExists`、`readTaskByIdempotencyKey`。
- `task-projection-port.ts`、`rebuildable-task-projection-task-queries.ts`、`rebuildable-task-projection-factory.ts`：在 `TaskProjection` 上暴露这两个读。
- `packages/daemon/src/repo-cell-task-create.ts`：创建/父任务/幂等检查改用索引读，不再 `projection.list()` + `projectedTaskIds()`。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 删除的门或 fixture：none
- 生产净行数：+52/-12（churn 64，G33 通过）。

## 机器可读声明

- 无。

## 任务与范围

- Harness 任务：task_755495b74e28390ad2a72ae7af，父任务 task_2b8f79fa4412cb726a26f9bfc7
- 分支：`codex/perf-task-create-index`
- 公开范围：task create 身份检查
- 私有计划/证据已更新：是（`artifacts/report.md`，fact F-DD771A1C）
- 范围外：创建路径上其他 O(N) 读（task_44033752 归因在飞）

## 版本影响

- 版本：不变
- 发布影响：不发布

## 治理声明

- 触碰受保护面：否
- 受保护面范围：不适用
- 授权：不适用
- 机器检查边界：不适用
- Break-glass：否
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- 基线 `origin/main` SHA：`1a19fd348`
- 分支与 `origin/main` 的 merge-base：`1a19fd348`（已 rebase）
- 最近一次 `git fetch origin`：2026-09-11 UTC
- 同步方式：rebase 到 origin/main
- 公开 diff 命令：`git diff origin/main...codex/perf-task-create-index`
- 私有证据路径：task_755495b74e28390ad2a72ae7af 的 `artifacts/report.md`
- 评审证据路径：本 PR 的评审证据节
- GitHub Actions `rewrite-ci` run URL：本 PR 待跑
- `repo-cell-latch-recovery.test.ts` 7/7（CEO rebase 后）；worker：daemon fast tier 251/251、lint、typecheck、line-density 通过。

## 评审证据

- CEO 事实核对：读过 diff；两个新读都是单条索引/定向查询；幂等复用回执的 status/packagePath 改从定向行取（原来取自物化快照）。
- 评审子代理：待定（合入后派收口评审）
- 人工评审：待定
- 阻塞发现：无

## 残余风险

- `readTaskByIdempotencyKey` 用 `json_extract` 过滤 `snapshot_json`（无表达式索引），带幂等键的创建仍是一次 SQL 扫表而非物化；只有传幂等键的创建才付这笔账。本 PR 没测 10k/100k 计时（worker 轮次），由 1M 三档复测覆盖。

## 参考

- 任务：task_755495b74e28390ad2a72ae7af；发现 F-80a574ca
