### PR TITLE
perf(gui): bound relation graph refresh reads and surface truncation

### DIFF
--- a/packages/gui/src/renderer/App.tsx
+++ b/packages/gui/src/renderer/App.tsx
@@ -510,6 +510,7 @@ function AppShell() {
                   onFocusEntityChange={focusEntityInWorkspace}
                   recentRefs={recentRefs}
                   entries={paletteEntries}
+                  relationPageNextCursor={triadicQuery.relationPageNextCursor}
                   onOpenPalette={() => setPaletteOpen(true)}
                 />
               ) : view === "decisionDetail" ? (

--- a/packages/gui/src/renderer/components/EntityWorkspace.tsx
+++ b/packages/gui/src/renderer/components/EntityWorkspace.tsx
@@ -48,6 +48,7 @@ export interface EntityWorkspaceProps {
   entityKinds?: readonly EntityTypeOption[];
   /** 声明实体行(vertical kind),透传给 GraphView。 */
   governedEntities?: ReadonlyArray<GovernedEntityRow>;
+  relationPageNextCursor?: string | null;
 }
 
 const FOCUS_REF_DECISION = /^decision\//u;
@@ -72,6 +73,7 @@ export function EntityWorkspace({
   onOpenPalette,
   entityKinds,
   governedEntities,
+  relationPageNextCursor,
 }: EntityWorkspaceProps) {
   // lineage 仅 decision 有谱系。
   const canShowLineage = focusedEntityRef ? FOCUS_REF_DECISION.test(focusedEntityRef) : false;
@@ -139,6 +141,7 @@ export function EntityWorkspace({
             focusRef={focusedEntityRef}
             viewMode={viewMode}
             onViewModeChange={setViewMode}
+            relationPageNextCursor={relationPageNextCursor}
             recentRefs={recentRefs}
             entries={entries}
             onOpenPalette={onOpenPalette}

--- a/packages/gui/src/renderer/triadic-data.ts
+++ b/packages/gui/src/renderer/triadic-data.ts
@@ -171,7 +171,7 @@ export function useRuntimePlaneQuery(repoId: string | null, options: { readonly 
  * Read one bounded relation-graph page. The daemon page contract carries a cursor for
  * explicit follow-up reads, but the GUI must not drain a 10k+ ledger on every refresh.
  */
-export async function readWholeRelationGraph(
+export async function readRelationGraphPage(
   read: (payload: { readonly limit: number; readonly cursor?: string }) => Promise<RelationGraphSuccess>,
 ): Promise<RelationGraphSuccess> {
   return read({ limit: 500 });
@@ -191,7 +191,7 @@ export function useTriadicProjectionQuery(
   const decisionsEnabled = enabled && options.decisionsEnabled !== false;
   const graph = useQuery({
     queryKey: triadicQueryKeys.graph(repoId ?? "unselected"),
-    queryFn: () => readWholeRelationGraph((payload) => harnessClient.getRelationGraph({ repoId: repoId!, ...payload })),
+    queryFn: () => readRelationGraphPage((payload) => harnessClient.getRelationGraph({ repoId: repoId!, ...payload })),
     enabled: graphEnabled,
     staleTime: 10_000,
   });
@@ -222,6 +222,7 @@ export function useTriadicProjectionQuery(
       isPending,
       isError,
       graphAvailable,
+      relationPageNextCursor: graph.data?.page?.nextCursor ?? null,
       relationState: graph.isError
         ? ("error" as const)
         : graphEnabled && graph.isPending

--- a/packages/gui/src/renderer/triadic-data.ts
+++ b/packages/gui/src/renderer/triadic-data.ts
@@ -168,34 +168,13 @@ export function useRuntimePlaneQuery(repoId: string | null, options: { readonly 
 }
 
 /**
- * 完整图。daemon 的无参 `repo.triadic.relationGraph` 只给一页(上限 500 条边),而且
- * facts / factAnchors / coverageRows 只随该页边的端点返回;领地与聚光灯渲染的是整张图,
- * 500 条之外的 decision/fact 节点会整个消失。所以按 `nextCursor` 翻到底再合并,
- * 各类行按各自主键去重;各页可能落在不同 cut 上,cut 字段以末页为准。
+ * Read one bounded relation-graph page. The daemon page contract carries a cursor for
+ * explicit follow-up reads, but the GUI must not drain a 10k+ ledger on every refresh.
  */
 export async function readWholeRelationGraph(
   read: (payload: { readonly limit: number; readonly cursor?: string }) => Promise<RelationGraphSuccess>,
 ): Promise<RelationGraphSuccess> {
-  const edges = new Map<string, ServedRelationEdgeRow>(),
-    coverageRows = new Map<string, RelationCoverageRow>(),
-    factAnchors = new Map<string, RelationGraphSuccess["factAnchors"][number]>(),
-    facts = new Map<string, RelationGraphSuccess["facts"][number]>();
-  let cursor: string | undefined, page: RelationGraphSuccess;
-  do {
-    page = await read(cursor === undefined ? { limit: 500 } : { limit: 500, cursor });
-    for (const row of page.edges) edges.set(row.relationId, row);
-    for (const row of page.coverageRows) coverageRows.set(`${row.decisionRef}\u0000${row.claimRef}`, row);
-    for (const row of page.factAnchors) factAnchors.set(row.factRef, row);
-    for (const row of page.facts) facts.set(row.ref, row);
-    cursor = page.page?.nextCursor ?? undefined;
-  } while (cursor !== undefined);
-  return {
-    ...page,
-    edges: [...edges.values()],
-    coverageRows: [...coverageRows.values()],
-    factAnchors: [...factAnchors.values()],
-    facts: [...facts.values()],
-  };
+  return read({ limit: 500 });
 }
 
 /**

--- a/packages/gui/src/renderer/views/GraphView.tsx
+++ b/packages/gui/src/renderer/views/GraphView.tsx
@@ -78,6 +78,7 @@ export interface GraphViewProps {
   focusRef: string | null;
   viewMode: ViewMode;
   onViewModeChange: (mode: ViewMode) => void;
+  relationPageNextCursor?: string | null;
 }
 
 /**
@@ -118,6 +119,7 @@ function GraphViewInner({
   focusRef,
   viewMode,
   onViewModeChange,
+  relationPageNextCursor = null,
   recentRefs = [],
   entries = [],
   onOpenPalette = () => {},
@@ -456,6 +458,11 @@ function GraphViewInner({
           >
             重点外 {territory.deferredCount}
             {focusSelection ? ` · 重点 ${focusSelection.seedCount} task` : ""}
+          </span>
+        )}
+        {relationPageNextCursor !== null && (
+          <span data-testid="triadic-graph-truncated" className="ui-micro text-stale">
+            仅显示前 500 条边，台账更大；使用重点模式或筛选查看其余
           </span>
         )}
         {territory && territory.unprojectedCount > 0 && (

--- a/packages/gui/test/triadic-graph-paging.vitest.ts
+++ b/packages/gui/test/triadic-graph-paging.vitest.ts
@@ -1,7 +1,7 @@
 // harness-test-tier: fast
 import { describe, expect, it } from "vitest";
 import type { RelationGraphSuccess } from "../src/renderer/api-client.ts";
-import { readWholeRelationGraph } from "../src/renderer/triadic-data.ts";
+import { readRelationGraphPage } from "../src/renderer/triadic-data.ts";
 
 type Edge = RelationGraphSuccess["edges"][number];
 type Fact = RelationGraphSuccess["facts"][number];
@@ -39,17 +39,18 @@ describe("关系图按界限读取", () => {
       },
       "cursor-2",
     );
-    const graph = await readWholeRelationGraph(async (payload) => {
+    const graph = await readRelationGraphPage(async (payload) => {
       calls.push(payload);
       return first;
     });
     expect(calls).toEqual([{ limit: 500 }]);
     expect(graph).toEqual(first);
+    expect(graph.page?.nextCursor).toBe("cursor-2");
   });
 
   it("没有分页信息的回答只读一次", async () => {
     let reads = 0;
-    const graph = await readWholeRelationGraph(async () => {
+    const graph = await readRelationGraphPage(async () => {
       reads += 1;
       const { page: _page, ...single } = page({ edges: [edge("r1")] }, null);
       return single;

--- a/packages/gui/test/triadic-graph-paging.vitest.ts
+++ b/packages/gui/test/triadic-graph-paging.vitest.ts
@@ -27,40 +27,24 @@ const page = (
   page: { limit: 500, cursor, nextCursor },
 });
 
-describe("完整关系图按 nextCursor 翻页合并", () => {
-  it("翻到 nextCursor 为空为止,四类行按主键去重", async () => {
+describe("关系图按界限读取", () => {
+  it("只读取首个有界页,保留 nextCursor 供显式后续读取", async () => {
     const calls: unknown[] = [];
-    const pages = [
-      page(
-        {
-          edges: [edge("r1"), edge("r2")],
-          facts: [fact("fact/F-1")],
-          factAnchors: [anchor("fact/F-1")],
-          coverageRows: [coverage("decision/d1", "decision/d1/C1")],
-        },
-        "cursor-2",
-      ),
-      page(
-        {
-          edges: [edge("r2"), edge("r3")],
-          facts: [fact("fact/F-1"), fact("fact/F-2")],
-          factAnchors: [anchor("fact/F-2")],
-          coverageRows: [coverage("decision/d1", "decision/d1/C1"), coverage("decision/d1", "decision/d1/C2")],
-        },
-        null,
-        "cursor-2",
-      ),
-    ];
+    const first = page(
+      {
+        edges: [edge("r1"), edge("r2")],
+        facts: [fact("fact/F-1")],
+        factAnchors: [anchor("fact/F-1")],
+        coverageRows: [coverage("decision/d1", "decision/d1/C1")],
+      },
+      "cursor-2",
+    );
     const graph = await readWholeRelationGraph(async (payload) => {
       calls.push(payload);
-      return pages[calls.length - 1]!;
+      return first;
     });
-    expect(calls).toEqual([{ limit: 500 }, { limit: 500, cursor: "cursor-2" }]);
-    expect(graph.edges.map((row) => row.relationId)).toEqual(["r1", "r2", "r3"]);
-    expect(graph.facts.map((row) => row.ref)).toEqual(["fact/F-1", "fact/F-2"]);
-    expect(graph.factAnchors.map((row) => row.factRef)).toEqual(["fact/F-1", "fact/F-2"]);
-    expect(graph.coverageRows.map((row) => row.claimRef)).toEqual(["decision/d1/C1", "decision/d1/C2"]);
-    expect(graph.page).toEqual({ limit: 500, cursor: "cursor-2", nextCursor: null });
+    expect(calls).toEqual([{ limit: 500 }]);
+    expect(graph).toEqual(first);
   });
 
   it("没有分页信息的回答只读一次", async () => {


### PR DESCRIPTION
# English

## Summary

1M follow-up for the GUI (task_e7c27348236f75dedc412b1c96, finding F-64494f53): the relation-graph refresh in `triadic-data.ts` drained every 500-edge page of `repo.triadic.relationGraph` on each refresh, so the graph view's IPC cost grew with the ledger. The reader is now `readRelationGraphPage`: one bounded 500-edge page per refresh, `page.nextCursor` passed through to `GraphView`, and a visible truncation note when a cursor remains ("仅显示前 500 条边…"), so a large ledger is bounded and honest instead of silently partial. The overview page already reads decisions through the existing `projection:"summary"` facet, so no daemon change was needed.

## Architectural Justification

-

## What Changed

- `packages/gui/src/renderer/triadic-data.ts`: `readWholeRelationGraph` → `readRelationGraphPage` (single page, no cursor draining); exposes `relationPageNextCursor`.
- `packages/gui/src/renderer/views/*` / `GraphView`: thread `relationPageNextCursor`; render `data-testid="triadic-graph-truncated"` note when non-null.
- `packages/gui/test/triadic-graph-paging.vitest.ts`: asserts one bounded page and cursor preservation.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: +17/-26 (churn 43, net −9, `production-delta` G33 pass).

## Machine-Readable Declarations

- None.

## Task And Scope

- Harness task: task_e7c27348236f75dedc412b1c96, parent task_2b8f79fa4412cb726a26f9bfc7 (perf rescue)
- Branch: `codex/gui-overview-graph-narrow`
- Public scope: GUI relation-graph read path and truncation note
- Private planning/evidence updated: yes (`artifacts/report.md`, fact F-6FB9A65C)
- Out of scope: incremental cut-delta refresh, a "load more" control (follow-up if users ask)

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: not applicable
- Machine-check boundary: not applicable
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `59e562cea`
- Branch merge-base with `origin/main`: `59e562cea` (rebased)
- Last `git fetch origin` time: 2026-09-11 UTC
- Sync method: rebase onto origin/main
- Public diff command: `git diff origin/main...codex/gui-overview-graph-narrow`
- Private evidence commit/path: task_e7c27348236f75dedc412b1c96 `artifacts/report.md`
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [x] `npm run typecheck` (`npx tsc -b packages/gui`, CEO after rebase)
- [ ] `npm run check`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [x] GitHub Actions `rewrite-ci` passed — pending
- `npm run test:gui -w @harness-anything/gui -- triadic-graph-paging.vitest.ts` 2/2 (CEO after rebase).

## Review Evidence

- CEO ground-truth: round 1 shipped the bounded read without the note the task contract required ("明确上限并提示"); round 2 added the rename and the note; diff read by the CEO.
- Reviewer subagent: pending (closeout review after merge)
- Human review: pending
- Blocking findings: none open

## Residual Risk

- No component-level test renders the truncation note (only the reader test); the note is a single conditional span. No 10k/100k IPC timing pair was measured; the structural change is N pages → 1 page per refresh.

## References

- Task: task_e7c27348236f75dedc412b1c96; finding F-64494f53

---

# 中文

## 概要

GUI 的 1M 后续（task_e7c27348236f75dedc412b1c96，发现 F-64494f53）：`triadic-data.ts` 的关系图刷新每次都把 `repo.triadic.relationGraph` 的 500 条边分页翻到底，图页的 IPC 成本随台账增长。现在读函数是 `readRelationGraphPage`：每次刷新只读一页 500 条边，`page.nextCursor` 透传到 `GraphView`，有剩余游标时显示截断提示（「仅显示前 500 条边…」），大台账上有界且诚实，不再静默残缺。总览页已经通过现有 `projection:"summary"` facet 读决策摘要，不需要改 daemon。

## 架构辩护

-

## 改动内容

- `packages/gui/src/renderer/triadic-data.ts`：`readWholeRelationGraph` → `readRelationGraphPage`（单页，不翻游标）；暴露 `relationPageNextCursor`。
- `packages/gui/src/renderer/views/*` / `GraphView`：透传 `relationPageNextCursor`；非空时渲染 `data-testid="triadic-graph-truncated"` 提示。
- `packages/gui/test/triadic-graph-paging.vitest.ts`：断言只读一页且保留游标。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 删除的门或 fixture：none
- 生产净行数：+17/-26（churn 43，净 −9，G33 通过）。

## 机器可读声明

- 无。

## 任务与范围

- Harness 任务：task_e7c27348236f75dedc412b1c96，父任务 task_2b8f79fa4412cb726a26f9bfc7
- 分支：`codex/gui-overview-graph-narrow`
- 公开范围：GUI 关系图读路径与截断提示
- 私有计划/证据已更新：是（`artifacts/report.md`，fact F-6FB9A65C）
- 范围外：按 cut 增量刷新、「加载更多」控件（用户提出再做）

## 版本影响

- 版本：不变
- 发布影响：不发布

## 治理声明

- 触碰受保护面：否
- 受保护面范围：不适用
- 授权：不适用
- 机器检查边界：不适用
- Break-glass：否
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- 基线 `origin/main` SHA：`59e562cea`
- 分支与 `origin/main` 的 merge-base：`59e562cea`（已 rebase）
- 最近一次 `git fetch origin`：2026-09-11 UTC
- 同步方式：rebase 到 origin/main
- 公开 diff 命令：`git diff origin/main...codex/gui-overview-graph-narrow`
- 私有证据路径：task_e7c27348236f75dedc412b1c96 的 `artifacts/report.md`
- 评审证据路径：本 PR 的评审证据节
- GitHub Actions `rewrite-ci` run URL：本 PR 待跑
- `npm run test:gui -w @harness-anything/gui -- triadic-graph-paging.vitest.ts` 2/2（CEO rebase 后）。

## 评审证据

- CEO 事实核对：第 1 轮只交了有界读、没有契约要求的「明确上限并提示」；第 2 轮补了改名与提示；diff 由 CEO 读过。
- 评审子代理：待定（合入后派收口评审）
- 人工评审：待定
- 阻塞发现：无

## 残余风险

- 没有组件级测试渲染截断提示（只有读函数测试）；提示是一个条件 span。没测 10k/100k IPC 计时对；结构变化是每次刷新 N 页 → 1 页。

## 参考

- 任务：task_e7c27348236f75dedc412b1c96；发现 F-64494f53
