### PR TITLE
perf: pin the ledger split index off

### DIFF
--- a/packages/kernel/src/store/local-version-control-system.ts
+++ b/packages/kernel/src/store/local-version-control-system.ts
@@ -66,10 +66,14 @@ export function configureLedgerMaintenance(repoRoot: string): LedgerMaintenanceR
   pin("maintenance.autoDetach", "true");
   pin("gc.autoDetach", "true");
   pin("core.autocrlf", "false");
-  // WAL commits use fast-import and touch-path update-index. A split index keeps
-  // the latter proportional to that cut, while the untracked cache prevents the
-  // authored settlement probe from re-statting the full active tree.
-  pin("core.splitIndex", "true");
+  // WAL commits use fast-import and touch-path update-index. A split index is
+  // pinned off: every index read re-inserts the not-yet-shared entries into the
+  // sorted array (O(k x N), up to 20% of the index before Git rewrites it), which
+  // made a 1M-event ledger's update-index cost 0.42 s per write instead of 3 ms.
+  // Git converts an existing split index back on its next index write. The
+  // untracked cache still keeps the authored settlement probe from re-statting
+  // the full active tree.
+  pin("core.splitIndex", "false");
   pin("core.untrackedCache", "true");
   const geometric = version !== null && atLeastGitVersion(version.parts, geometricMaintenanceFloor);
   if (geometric) pin("maintenance.strategy", "geometric");

--- a/packages/kernel/test/store/ledger-maintenance.test.ts
+++ b/packages/kernel/test/store/ledger-maintenance.test.ts
@@ -56,7 +56,7 @@ test("ledger maintenance pins automatic housekeeping out of the write path", () 
 
     assert.equal(git(repoRoot, "config", "--get", "maintenance.autoDetach"), "true");
     assert.equal(git(repoRoot, "config", "--get", "gc.autoDetach"), "true");
-    assert.equal(git(repoRoot, "config", "--get", "core.splitIndex"), "true");
+    assert.equal(git(repoRoot, "config", "--get", "core.splitIndex"), "false");
     assert.equal(git(repoRoot, "config", "--get", "core.untrackedCache"), "true");
     assert.ok(receipt.applied.includes("maintenance.autoDetach=true"));
     assert.equal(receipt.gitVersion !== null, true);


### PR DESCRIPTION
# English

## Summary

1M write-growth attribution (task_44033752ec174b8a035fd31965, findings F-D684BCFF/F-B54F0E75: import 55 → 581 ms and closeout 2 s from 100k to 1M). The measured cause is one ledger Git setting, not Git itself: `configureLedgerMaintenance` pinned `core.splitIndex=true`, and every index read re-inserts the not-yet-shared entries into the sorted index (O(k×N), up to 20% of the index before Git rewrites it). At 1M the per-write `update-index` cost 0.42 s (2.7 ms at 100k). This PR pins it to `false`. Counterfactual 1M run on the same VM: import p50 581 → 234 ms, reckon 454 → 109 ms, task closeout 1.96 → 0.47 s, doc sync 3.9 → 2.6 s. Existing ledgers need no migration: Git converts a split index back on its next index write (verified offline).

## Architectural Justification

-

## What Changed

- `packages/kernel/src/store/local-version-control-system.ts`: `pin("core.splitIndex", "false")` with the measured reason in the comment.
- `packages/kernel/test/store/ledger-maintenance.test.ts`: assertion follows.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: +5/-4 (comment lines), G33 pass.

## Machine-Readable Declarations

- None.

## Task And Scope

- Harness task: task_44033752ec174b8a035fd31965 (attribution, opus), parent task_2b8f79fa4412cb726a26f9bfc7 (perf rescue)
- Branch: `codex/perf-split-index`
- Public scope: ledger Git maintenance pins
- Private planning/evidence updated: yes (task_44033752 `artifacts/report.md` §0–§2)
- Out of scope: F2 (`captureGitBaseline` per-file `ls-tree` pathspec calls, 6.6 s per drain and 130 s materialize at 1M) — separate task; G7 ledger sharding — not needed after this fix (2M projected ≈ 0.45/0.2 s per write)

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: not applicable
- Machine-check boundary: not applicable
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `cb30abb06`
- Branch merge-base with `origin/main`: `cb30abb06`
- Last `git fetch origin` time: 2026-09-11 UTC
- Sync method: branched from origin/main
- Public diff command: `git diff origin/main...codex/perf-split-index`
- Private evidence commit/path: task_44033752ec174b8a035fd31965 `artifacts/report.md`
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [x] `npm run typecheck` (`npx tsc -b packages/kernel`)
- [ ] `npm run check`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [x] GitHub Actions `rewrite-ci` passed — pending
- `packages/kernel/test/store/ledger-maintenance.test.ts` 6/6.

## Review Evidence

- CEO ground-truth: the attribution report's counterfactual table and the git source reasoning (split-index merge on read) were read; the one-line change is exactly the report's F1.
- Reviewer subagent: pending (closeout review after merge)
- Human review: pending
- Blocking findings: none open

## Residual Risk

- The counterfactual is one unprofiled 1M run (n=1) on the Ubuntu VM; the three-tier table gets re-measured after merge. The 1M profile run itself was 1.4–1.8× slower machine-wide, so only its per-phase shares were used, not its absolute numbers.

## References

- Task: task_44033752ec174b8a035fd31965; report §0–§2, §5 F1

---

# 中文

## 概要

1M 写入增长归因（task_44033752ec174b8a035fd31965，发现 F-D684BCFF/F-B54F0E75：100k→1M import 55 → 581 ms、closeout 2 s）。实测原因是账本的一个 Git 配置而不是 Git 本身：`configureLedgerMaintenance` 把 `core.splitIndex` 钉成 `true`，git 每读一次 index 都要把尚未并回 shared index 的条目逐条插回有序数组（O(k×N)，k 涨到 20% 才重写）。1M 下每次写的 `update-index` 要 0.42 s（100k 只要 2.7 ms）。本 PR 改钉为 `false`。同一 VM 的反事实 1M 跑：import p50 581 → 234 ms，reckon 454 → 109 ms，task closeout 1.96 → 0.47 s，doc sync 3.9 → 2.6 s。已有账本无需迁移：git 在下一次写 index 时自动转回普通 index（离线验证过）。

## 架构辩护

-

## 改动内容

- `packages/kernel/src/store/local-version-control-system.ts`：`pin("core.splitIndex", "false")`，注释写明实测原因。
- `packages/kernel/test/store/ledger-maintenance.test.ts`：断言跟随。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 删除的门或 fixture：none
- 生产净行数：+5/-4（注释行），G33 通过。

## 机器可读声明

- 无。

## 任务与范围

- Harness 任务：task_44033752ec174b8a035fd31965（归因，opus），父任务 task_2b8f79fa4412cb726a26f9bfc7
- 分支：`codex/perf-split-index`
- 公开范围：账本 Git 维护钉扎
- 私有计划/证据已更新：是（task_44033752 `artifacts/report.md` §0–§2）
- 范围外：F2（`captureGitBaseline` 逐文件带 pathspec 的 `ls-tree`，1M 下每个 drain 6.6 s、materialize 130 s）另立任务；G7 账本分片——本修复后不需要（推算 2M 单次写约 0.45/0.2 s）

## 版本影响

- 版本：不变
- 发布影响：不发布

## 治理声明

- 触碰受保护面：否
- 受保护面范围：不适用
- 授权：不适用
- 机器检查边界：不适用
- Break-glass：否
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- 基线 `origin/main` SHA：`cb30abb06`
- 分支与 `origin/main` 的 merge-base：`cb30abb06`
- 最近一次 `git fetch origin`：2026-09-11 UTC
- 同步方式：从 origin/main 开分支
- 公开 diff 命令：`git diff origin/main...codex/perf-split-index`
- 私有证据路径：task_44033752ec174b8a035fd31965 的 `artifacts/report.md`
- 评审证据路径：本 PR 的评审证据节
- GitHub Actions `rewrite-ci` run URL：本 PR 待跑
- `ledger-maintenance.test.ts` 6/6。

## 评审证据

- CEO 事实核对：读过归因报告的反事实表与 git 源码推理（split index 读时合并）；这一行改动就是报告的 F1。
- 评审子代理：待定（合入后派收口评审）
- 人工评审：待定
- 阻塞发现：无

## 残余风险

- 反事实是 Ubuntu VM 上一次无插桩 1M 跑（n=1）；合入后重测三档表。1M 那次 profile 跑整机慢 1.4–1.8 倍，所以只用了它的分项占比，不用绝对数。

## 参考

- 任务：task_44033752ec174b8a035fd31965；报告 §0–§2、§5 F1
