### PR TITLE
feat: list declared relation triples in the error hint and a read-only query

### DIFF
--- a/packages/cli/src/cli/thin-command-router.ts
+++ b/packages/cli/src/cli/thin-command-router.ts
@@ -269,7 +269,8 @@ function parseRelationRouted(
   json: boolean,
   inputs: ThinCliInputDirectory,
 ): ThinParseResult | undefined {
-  if (route.id === "relation-list") return parseProjected(route.id, args.slice(2), rootDir, repoId, json, inputs);
+  if (route.id === "relation-list" || route.id === "relation-triples")
+    return parseProjected(route.id, args.slice(2), rootDir, repoId, json, inputs);
   if (route.id === "relation-relate")
     return normalizeRelationRelateFailure(
       parseProjected(

--- a/packages/cli/test/thin-command-preset-fact-decision.test.ts
+++ b/packages/cli/test/thin-command-preset-fact-decision.test.ts
@@ -122,11 +122,13 @@ test("Relation commands replace hosted Task and Decision relation ingress", () =
       "--rationale",
       "Reviewed the new target version.",
     ]),
-    suspect = parseThinCommand(["relation", "list", "--freshness", "suspect"]);
+    suspect = parseThinCommand(["relation", "list", "--freshness", "suspect"]),
+    triples = parseThinCommand(["relation", "triples", "--source-kind", "decision", "--target-kind", "fact"]);
   assert.equal(relate.ok, true);
   assert.equal(unrelate.ok, true);
   assert.equal(reconfirm.ok, true);
   assert.equal(suspect.ok, true);
+  assert.equal(triples.ok, true);
   if (relate.ok)
     assert.deepEqual(relate.command.action, {
       kind: "relation-relate",
@@ -153,6 +155,12 @@ test("Relation commands replace hosted Task and Decision relation ingress", () =
       rationale: "Reviewed the new target version.",
     });
   if (suspect.ok) assert.deepEqual(suspect.command.action, { kind: "relation-list", freshness: "suspect" });
+  if (triples.ok)
+    assert.deepEqual(triples.command.action, {
+      kind: "relation-triples",
+      sourceKind: "decision",
+      targetKind: "fact",
+    });
   assert.equal(parseThinCommand(["relation", "list", "--freshness", "unknown"]).ok, false);
   assert.equal(
     parseThinCommand([

--- a/packages/cli/test/thin-command.test.ts
+++ b/packages/cli/test/thin-command.test.ts
@@ -339,7 +339,7 @@ test("capabilities is an exact-set projection of the command contract", () => {
       "preset-validate",
     ],
     receipt: ["receipt-show"],
-    relation: ["relation-list", "relation-reconfirm", "relation-relate", "relation-unrelate"],
+    relation: ["relation-list", "relation-reconfirm", "relation-relate", "relation-triples", "relation-unrelate"],
     runtime: [
       "runtime-batch",
       "runtime-cancel",

--- a/packages/daemon/src/protocol/daemon-protocol-commands-task-surface.ts
+++ b/packages/daemon/src/protocol/daemon-protocol-commands-task-surface.ts
@@ -320,6 +320,17 @@ export const taskSurfaceProtocolCommands = Object.freeze([
     ],
   }),
   defineRepoReadCommand({
+    id: "relation-triples",
+    phase: "Governed-Entity-W1-D",
+    path: ["relation", "triples"],
+    summary: "List writable canonical relation triples, optionally filtered by endpoint kind.",
+    method: "repo.task.read",
+    inputs: [
+      cliInput("--source-kind", "single", false, { code: "invalid_field" }),
+      cliInput("--target-kind", "single", false, { code: "invalid_field" }),
+    ],
+  }),
+  defineRepoReadCommand({
     id: "relation-list",
     phase: "Governed-Entity-W1-D",
     path: ["relation", "list"],

--- a/packages/daemon/src/repo-cell-action-dispatch.ts
+++ b/packages/daemon/src/repo-cell-action-dispatch.ts
@@ -3,6 +3,7 @@ import {
   compileExecutionExecutorDeclaration,
   compileTaskLifecycleWrite,
   createEntityStore,
+  declaredRelationTriples,
   executionExecutorDeclarationCandidates,
   getExecutableEntityAction,
   lifecycleDocumentPaths,
@@ -104,6 +105,19 @@ export async function executeAction(
   if (action.kind === "task-show") return cell.showTask(String(action.taskId ?? ""));
   if (action.kind === "task-list") return cell.listTasks(action, binding);
   if (action.kind === "relation-list") return cell.listRelations(action, binding);
+  if (action.kind === "relation-triples") {
+    const revision = cell.store.readHead()?.revision ?? 0,
+      rows = declaredRelationTriples({
+        ...(typeof action.sourceKind === "string" ? { sourceKind: action.sourceKind } : {}),
+        ...(typeof action.targetKind === "string" ? { targetKind: action.targetKind } : {}),
+      });
+    return cell.readResult(
+      cell.operationId(action, binding, cell.input.repoId, revision),
+      { rows, count: rows.length },
+      revision,
+      null,
+    );
+  }
   if (action.kind === "task-read-set") return cell.taskReadSet(action, binding);
   if (action.kind === "task-review") return cell.reviewTask(action, binding);
   if (action.kind === "distill-candidate") {

--- a/packages/daemon/test/relation-action.integration.test.ts
+++ b/packages/daemon/test/relation-action.integration.test.ts
@@ -4,7 +4,7 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
-import { deriveRelationId, makeTaskEventReader } from "../../kernel/src/index.ts";
+import { declaredRelationTriples, deriveRelationId, makeTaskEventReader } from "../../kernel/src/index.ts";
 import { canonicalRoot, workspaceId } from "../src/protocol/daemon-protocol.contract.ts";
 import { withRoleBinding } from "./role-binding.fixtures.ts";
 import { openBootstrappedRepoCell as openRepoCell } from "./repo-settings.fixture.ts";
@@ -30,6 +30,30 @@ const binding = withRoleBinding(
     },
     "repo-write",
   );
+
+test("Relation triples read projects the canonical registry with endpoint filters", async () => {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-relation-triples-"));
+  initRepo(rootDir);
+  const repoId = workspaceId("relation-triples"),
+    cell = await openRepoCell({ repoId, rootDir: canonicalRoot(rootDir), ownerId: "relation-triples-test" });
+  try {
+    for (const sourceKind of ["fact", "decision", "task", "relation"]) {
+      const receipt = await cell.run({ kind: "relation-triples", sourceKind }, binding),
+        payload = JSON.parse(String(receipt.evidence)) as { readonly rows: unknown; readonly count: number };
+      assert.equal(receipt.outcome, "applied", JSON.stringify(receipt));
+      assert.deepEqual(payload.rows, declaredRelationTriples({ sourceKind }));
+      assert.equal(payload.count, declaredRelationTriples({ sourceKind }).length);
+    }
+    const filtered = await cell.run({ kind: "relation-triples", sourceKind: "decision", targetKind: "fact" }, binding);
+    assert.deepEqual(
+      (JSON.parse(String(filtered.evidence)) as { readonly rows: unknown }).rows,
+      declaredRelationTriples({ sourceKind: "decision", targetKind: "fact" }),
+    );
+  } finally {
+    await cell.close();
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});
 
 test("Relation actions serialize aggregate revisions and reject cycles and stale writers", async () => {
   const rootDir = mkdtempSync(path.join(tmpdir(), "ha-relation-action-"));

--- a/packages/kernel/src/domain/index.ts
+++ b/packages/kernel/src/domain/index.ts
@@ -196,7 +196,7 @@ export {
   pinnedArtifactKindContract,
 } from "./vertical-contract.ts";
 export type { CompiledArtifactKindContract, CompiledVerticalContract } from "./vertical-contract.ts";
-export { composeCanonicalRelationDirections } from "./relation-direction.ts";
+export { composeCanonicalRelationDirections, declaredRelationTriples } from "./relation-direction.ts";
 export type { CanonicalRelationDirection } from "./relation-direction.ts";
 export type {
   EntityActionCriterionFailure,

--- a/packages/kernel/src/domain/relation-direction.ts
+++ b/packages/kernel/src/domain/relation-direction.ts
@@ -238,6 +238,21 @@ export const canonicalRelationDirections: readonly CanonicalRelationDirection[] 
 ];
 
 /**
+ * The writable triples exposed to clients. This projects the canonical registry
+ * directly, so discovery and admission cannot acquire separate allowlists.
+ */
+export function declaredRelationTriples(
+  filters: Partial<Pick<CanonicalRelationDirection, "sourceKind" | "targetKind">> = {},
+): readonly CanonicalRelationDirection[] {
+  return canonicalRelationDirections.filter(
+    (row) =>
+      row.registration !== "derived" &&
+      (filters.sourceKind === undefined || row.sourceKind === filters.sourceKind) &&
+      (filters.targetKind === undefined || row.targetKind === filters.targetKind),
+  );
+}
+
+/**
  * Build the one runtime registry consumed by relation admission. Kernel rows stay
  * authoritative and governed rows can only add new, already-compiled cells.
  */

--- a/packages/kernel/src/domain/relation-event.ts
+++ b/packages/kernel/src/domain/relation-event.ts
@@ -14,7 +14,11 @@ import {
 } from "./entity-relation.ts";
 import type { EntityVersion } from "./entity-freshness.ts";
 import { parseEntityRef } from "./entity-ref.ts";
-import { canonicalRelationDirections, type CanonicalRelationDirection } from "./relation-direction.ts";
+import {
+  canonicalRelationDirections,
+  declaredRelationTriples,
+  type CanonicalRelationDirection,
+} from "./relation-direction.ts";
 import type { DecisionEventV1 } from "./decision-event.ts";
 import { factRef, type FactEventV1 } from "./fact-event.ts";
 import type { MigrationImportEventV1 } from "./migration-import-event.ts";
@@ -518,7 +522,13 @@ export function assertRelationAdmission(
     "relation_triple_undeclared",
     record,
     kinds,
-    "Choose a declared source --type--> target triple from ha relation relate --help",
+    `Declared triples for source kind ${kinds.source}: ` +
+      declaredRelationTriples({ sourceKind: kinds.source })
+        .map(({ type, targetKind }) => `${type} -> ${targetKind}`)
+        .join(", ") +
+      ". Run ha relation triples --source-kind " +
+      `${kinds.source} to inspect the canonical registry. ` +
+      "evidenced-by is directed decision/claim -> fact.",
   );
 }
 

--- a/packages/kernel/test/contracts/relation-entity.test.ts
+++ b/packages/kernel/test/contracts/relation-entity.test.ts
@@ -104,6 +104,34 @@ test("Relation admission distinguishes reversed direction from an invalid target
   );
 });
 
+test("undeclared relation triples name the available triples for their source kind", () => {
+  assert.throws(
+    () =>
+      compileRelationCreatedEvent({
+        record: {
+          ...eventRecord(record("fact/F-RELATION_SOURCE", "decision/dec_RELATION_TARGET"), 1),
+          relation_id: deriveRelationId({
+            source: "fact/F-RELATION_SOURCE",
+            target: "decision/dec_RELATION_TARGET",
+            type: "derives",
+            direction: "directed",
+          }),
+          type: "derives",
+        },
+        actor,
+        source,
+        opId: "relation-undeclared-hint",
+        occurredAt: "2026-09-04T00:00:00.000Z",
+        workspaceRevision: 1,
+      }),
+    (error: unknown) =>
+      (error as { readonly code?: string }).code === "relation_triple_undeclared" &&
+      /Declared triples for source kind fact: supersedes-fact -> fact, relates -> relation/u.test(
+        String((error as { readonly diagnostic?: { readonly expectation?: unknown } }).diagnostic?.expectation),
+      ),
+  );
+});
+
 test("native Relation history reduces and projects one versioned aggregate row", () => {
   const relation = record(),
     created = compileRelationCreatedEvent({

--- a/packages/kernel/test/domain/relation-direction.test.ts
+++ b/packages/kernel/test/domain/relation-direction.test.ts
@@ -4,6 +4,7 @@ import test from "node:test";
 import { isAllowedRelationKindTriple, relationTypes } from "../../src/domain/entity-relation.ts";
 import {
   canonicalRelationDirections,
+  declaredRelationTriples,
   incomingRelations,
   type CanonicalRelationDirection,
 } from "../../src/domain/relation-direction.ts";
@@ -35,6 +36,20 @@ test("the canonical direction registry is the allowlist: every triple agrees, ce
       }
     }
   }
+});
+
+test("declared relation triples project the canonical registry without derived rows", () => {
+  for (const sourceKind of ["fact", "decision", "task", "relation"]) {
+    assert.deepEqual(
+      declaredRelationTriples({ sourceKind }),
+      canonicalRelationDirections.filter((row) => row.registration !== "derived" && row.sourceKind === sourceKind),
+      `${sourceKind} discovery must be a direct projection of the registry`,
+    );
+  }
+  assert.equal(
+    declaredRelationTriples().some(({ registration }) => registration === "derived"),
+    false,
+  );
 });
 
 test("every reversed-direction pair keeps exactly one canonical writable side", () => {


### PR DESCRIPTION
# English

## Summary

ai4s user feedback (task_7048036fd65b7da01e2fa6a07d, parent task_4455977a529becac425737d812; `HARNESS-UX-FEEDBACK.md` items 1–6 and root cause 2): `relation_triple_undeclared` only said "wrong" and pointed at `--help`, which lists relation *types*, not the declared (source, type, target) triples, so writers guessed the direction three times per edge. The error now lists the legal `type -> target kind` triples for the source kind, and a read-only `ha relation triples [--source-kind] [--target-kind]` projects the canonical direction registry directly (no second copy).

## Architectural Justification

-

## What Changed

- `packages/kernel/src/domain/relation-direction.ts`: triples query over the canonical registry; `relation-event.ts`: hint lists legal triples.
- `packages/daemon/src/repo-cell-action-dispatch.ts`: `relation-triples` read action; CLI `ha relation triples`.
- Tests: `relation-direction.test.ts`, `relation-entity.test.ts`, `relation-action.integration.test.ts`.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: +45/-7 (G33 pass).

## Machine-Readable Declarations

- None.

## Task And Scope

- Harness task: task_7048036fd65b7da01e2fa6a07d, parent task_4455977a529becac425737d812
- Branch: `codex/ux-relation-triples`
- Public scope: relation error hint + one read-only query
- Private planning/evidence updated: yes (`artifacts/report.md`)
- Out of scope: entity-kind relation declarations needing a decision (feedback item 3; current state documented in the report, RBAC unchanged)

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: not applicable
- Machine-check boundary: not applicable
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `161f4d684`
- Branch merge-base with `origin/main`: `161f4d684`
- Last `git fetch origin` time: 2026-09-12 UTC
- Sync method: rebase onto origin/main
- Public diff command: `git diff origin/main...codex/ux-relation-triples`
- Private evidence commit/path: task_7048036fd65b7da01e2fa6a07d `artifacts/report.md`
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [x] `npm run typecheck` (`npx tsc -b` kernel/daemon/cli, CEO)
- [ ] `npm run check`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts` (via `run-manifest-gates --changed origin/main`)
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [x] GitHub Actions `rewrite-ci` passed — pending
- Touched tests 48/48 (CEO after rebase); worker: isolated integration 3/3.

## Review Evidence

- CEO ground-truth: diff stat and gates re-run after rebase; the query reads the same registry the validator uses.
- Reviewer subagent: pending (closeout review after merge)
- Human review: pending
- Blocking findings: none open

## Residual Risk

- The `report` source kind named in the feedback is not registered in this checkout, so the hint covers fact/decision/task/relation kinds only.

## References

- Task: task_7048036fd65b7da01e2fa6a07d; feedback items 1–6

---

# 中文

## 概要

ai4s 使用者反馈（task_7048036fd65b7da01e2fa6a07d，父任务 task_4455977a529becac425737d812；`HARNESS-UX-FEEDBACK.md` 第 1–6 条与根因 2）：`relation_triple_undeclared` 只说你错了并指向 `--help`，而 `--help` 列的是 relation *类型*不是已声明的 (source, type, target) 三元组，写关系的人每条边要猜三次方向。现在错误直接列出该 source kind 的合法 `type -> target kind` 三元组，并新增只读命令 `ha relation triples [--source-kind] [--target-kind]`，直接投影 canonical direction 表（不另存一份）。

## 架构辩护

-

## 改动内容

- `packages/kernel/src/domain/relation-direction.ts`：对 canonical 表的三元组查询；`relation-event.ts`：hint 列合法三元组。
- `packages/daemon/src/repo-cell-action-dispatch.ts`：`relation-triples` 只读 action；CLI `ha relation triples`。
- 测试：`relation-direction.test.ts`、`relation-entity.test.ts`、`relation-action.integration.test.ts`。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 删除的门或 fixture：none
- 生产净行数：+45/-7（G33 通过）。

## 机器可读声明

- 无。

## 任务与范围

- Harness 任务：task_7048036fd65b7da01e2fa6a07d，父任务 task_4455977a529becac425737d812
- 分支：`codex/ux-relation-triples`
- 公开范围：关系错误提示 + 一个只读查询
- 私有计划/证据已更新：是（`artifacts/report.md`）
- 范围外：entity-kind 关系声明需要 decision 的鸡生蛋（反馈第 3 条；现状写在报告里，RBAC 不动）

## 版本影响

- 版本：不变
- 发布影响：不发布

## 治理声明

- 触碰受保护面：否
- 受保护面范围：不适用
- 授权：不适用
- 机器检查边界：不适用
- Break-glass：否
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- 基线 `origin/main` SHA：`161f4d684`
- 分支与 `origin/main` 的 merge-base：`161f4d684`
- 最近一次 `git fetch origin`：2026-09-12 UTC
- 同步方式：rebase 到 origin/main
- 公开 diff 命令：`git diff origin/main...codex/ux-relation-triples`
- 私有证据路径：task_7048036fd65b7da01e2fa6a07d 的 `artifacts/report.md`
- 评审证据路径：本 PR 的评审证据节
- GitHub Actions `rewrite-ci` run URL：本 PR 待跑
- 触碰测试 48/48（CEO rebase 后）；worker：隔离集成 3/3。

## 评审证据

- CEO 事实核对：rebase 后复跑 diff stat 与 gates；查询读的是校验器用的同一张表。
- 评审子代理：待定（合入后派收口评审）
- 人工评审：待定
- 阻塞发现：无

## 残余风险

- 反馈里提到的 `report` source kind 在本 checkout 未注册，hint 只覆盖 fact/decision/task/relation。

## 参考

- 任务：task_7048036fd65b7da01e2fa6a07d；反馈第 1–6 条
