### PR TITLE
fix: count executing derived roots toward the task WIP limit

### DIFF
--- a/packages/daemon/src/repo-cell-completion.ts
+++ b/packages/daemon/src/repo-cell-completion.ts
@@ -138,6 +138,11 @@ export function taskShowFromProjection(
             status: task.status,
             taskClass: task.taskClass,
             packageDisposition: task.packageDisposition ?? "active",
+            hasOwnExecution:
+              read.snapshot.lease !== null ||
+              read.snapshot.executions.some(
+                (execution) => execution.state === "active" || execution.state === "submitted",
+              ),
             hasCloseoutEvidence: hasCloseoutEvidence(read.snapshot.executions),
             directChildCount,
           },

--- a/packages/daemon/src/repo-cell-task-query.ts
+++ b/packages/daemon/src/repo-cell-task-query.ts
@@ -146,6 +146,7 @@ export function listTasks(cell: TaskQueryCell, action: RepoTaskAction, binding: 
                     taskClass: row.taskClass,
                     packageDisposition: row.packageDisposition,
                     hasCloseoutEvidence: false,
+                    hasOwnExecution: false,
                     directChildCount,
                   },
                   rootSetting.threshold,
@@ -244,6 +245,9 @@ export function wipSnapshotEntries(cell: TaskQueryCell, activatingTaskId: string
     taskClass: row.snapshot.task?.taskClass ?? "standard",
     packageDisposition: requiredPackageDisposition(row.taskId, row.snapshot.task?.packageDisposition),
     hasCloseoutEvidence: hasCloseoutEvidence(row.snapshot.executions),
+    hasOwnExecution:
+      row.snapshot.lease !== null ||
+      row.snapshot.executions.some((execution) => execution.state === "active" || execution.state === "submitted"),
     directChildCount: childCounts[row.taskId] ?? 0,
   }));
 }

--- a/packages/daemon/test/task-wip.integration.test.ts
+++ b/packages/daemon/test/task-wip.integration.test.ts
@@ -254,15 +254,6 @@ test("a standard task becomes a visible structure-derived root without rewriting
       for (let index = 0; index < count; index++)
         await createReadyTask(cell, rootDir, `${parentTaskId}_CHILD_${index}`, `Child ${index}`, { parentTaskId });
     assert.deepEqual(resolveTaskRootThreshold(rootDir), { threshold: 3, label: TASK_ROOT_THRESHOLD_SETTING });
-    assert.equal(
-      (await cell.run({ kind: "task-start", taskId: "task_ROOT_2", executionId: "exe_root_2" }, binding)).outcome,
-      "applied",
-    );
-    assert.equal(
-      (await cell.run({ kind: "task-start", taskId: "task_ROOT_3", executionId: "exe_root_3" }, binding)).outcome,
-      "applied",
-      "3 children derives root and does not consume the existing slot",
-    );
     const shown = evidence(await cell.run({ kind: "task-show", taskId: "task_ROOT_3" }, binding));
     assert.equal(
       (shown.task as { readonly taskClass: string }).taskClass,
@@ -270,6 +261,22 @@ test("a standard task becomes a visible structure-derived root without rewriting
       "derived root never writes taskClass",
     );
     assert.deepEqual(shown.rootAssessment, { isRoot: true, reason: "derived", directChildCount: 3, threshold: 3 });
+    assert.equal(
+      (await cell.run({ kind: "task-start", taskId: "task_ROOT_2", executionId: "exe_root_2" }, binding)).outcome,
+      "applied",
+    );
+    const three = await cell.run({ kind: "task-start", taskId: "task_ROOT_3", executionId: "exe_root_3" }, binding);
+    assert.equal(
+      three.outcome,
+      "op_rejected",
+      "a container with three children occupies the worktable once it executes",
+    );
+    assert.equal(three.code, "task_wip_limit_reached");
+    assert.deepEqual(
+      evidence(await cell.run({ kind: "task-show", taskId: "task_ROOT_3" }, binding)).rootAssessment,
+      { isRoot: true, reason: "derived", directChildCount: 3, threshold: 3 },
+      "the rejected start leaves the pure container a derived root",
+    );
     process.env[TASK_ROOT_THRESHOLD_ENV] = "5";
     await cell.close();
     cell = await open();

--- a/packages/kernel/src/domain/task-wip-policy.ts
+++ b/packages/kernel/src/domain/task-wip-policy.ts
@@ -31,6 +31,8 @@ export interface TaskWipSnapshotEntryV1 {
    * adding parallel work, so it never enters the WIP count.
    */
   readonly hasCloseoutEvidence: boolean;
+  /** Whether this task has an active/submitted execution or an active lease. */
+  readonly hasOwnExecution: boolean;
   /** Number of direct children in the existing task projection. */
   readonly directChildCount: number;
 }
@@ -54,7 +56,8 @@ export function deriveTaskRoot(
   if (entry.taskClass === "milestone" || entry.taskClass === "long_running") {
     return { isRoot: true, reason: "declared", directChildCount, threshold };
   }
-  if (directChildCount >= threshold) return { isRoot: true, reason: "derived", directChildCount, threshold };
+  if (directChildCount >= threshold && !entry.hasOwnExecution)
+    return { isRoot: true, reason: "derived", directChildCount, threshold };
   return { isRoot: false, reason: "none", directChildCount, threshold };
 }
 
@@ -131,7 +134,7 @@ export function admitTaskExecutionWip(input: TaskWipAdmissionInput): TaskWipAdmi
       `${formatWipComposition(input.tasks, rootThreshold)} ` +
       `Before starting ${input.activatingTaskId}, close one existing task. Suggested: ${suggestions}. ` +
       `Next: complete, cancel (\`ha task transition <task-id> cancelled --force --reason <reason>\`), or archive one of those tasks, then retry \`ha task start ${input.activatingTaskId}\`. ` +
-      "Planned tasks stay in the idea backlog and are never counted or removed.",
+      "Derived root exemption applies only to pure containers. Planned tasks stay in the idea backlog and are never counted or removed.",
   };
 }
 

--- a/packages/kernel/src/domain/task-wip-policy.ts
+++ b/packages/kernel/src/domain/task-wip-policy.ts
@@ -134,7 +134,8 @@ export function admitTaskExecutionWip(input: TaskWipAdmissionInput): TaskWipAdmi
       `${formatWipComposition(input.tasks, rootThreshold)} ` +
       `Before starting ${input.activatingTaskId}, close one existing task. Suggested: ${suggestions}. ` +
       `Next: complete, cancel (\`ha task transition <task-id> cancelled --force --reason <reason>\`), or archive one of those tasks, then retry \`ha task start ${input.activatingTaskId}\`. ` +
-      "Derived root exemption applies only to pure containers. Planned tasks stay in the idea backlog and are never counted or removed.",
+      "Derived root exemption applies only to pure containers. " +
+      "Planned tasks stay in the idea backlog and are never counted or removed.",
   };
 }
 

--- a/packages/kernel/src/domain/task-wip-policy.ts
+++ b/packages/kernel/src/domain/task-wip-policy.ts
@@ -145,9 +145,10 @@ export function enteringExecutionWip(
   nextStatus: DomainStatus,
   rootThreshold = DEFAULT_TASK_ROOT_THRESHOLD,
 ): boolean {
-  return (
-    !isExecutionWipTask(current, rootThreshold) && isExecutionWipTask({ ...current, status: nextStatus }, rootThreshold)
-  );
+  // Entering active takes the worktable: task-start creates the execution and reserve
+  // takes the lease, so a container stops being a pure container at that moment.
+  const next = { ...current, status: nextStatus, hasOwnExecution: current.hasOwnExecution || nextStatus === "active" };
+  return !isExecutionWipTask(current, rootThreshold) && isExecutionWipTask(next, rootThreshold);
 }
 
 function formatWipComposition(tasks: readonly TaskWipSnapshotEntryV1[], rootThreshold: number): string {

--- a/packages/kernel/test/domain/task-wip-policy.test.ts
+++ b/packages/kernel/test/domain/task-wip-policy.test.ts
@@ -4,7 +4,7 @@ import test from "node:test";
 import { DEFAULT_TASK_WIP_LIMIT, admitTaskExecutionWip, parseTaskWipLimit } from "../../src/index.ts";
 import { enteringExecutionWip, hasCloseoutEvidence, isExecutionWipTask, type TaskWipSnapshotEntryV1 } from "../../src/domain/task-wip-policy.ts";
 
-const entry = (overrides: Partial<TaskWipSnapshotEntryV1> = {}): TaskWipSnapshotEntryV1 => ({ taskId: "task_X", title: "X", status: "active", taskClass: "standard", packageDisposition: "active", hasCloseoutEvidence: false, directChildCount: 0, ...overrides });
+const entry = (overrides: Partial<TaskWipSnapshotEntryV1> = {}): TaskWipSnapshotEntryV1 => ({ taskId: "task_X", title: "X", status: "active", taskClass: "standard", packageDisposition: "active", hasCloseoutEvidence: false, hasOwnExecution: false, directChildCount: 0, ...overrides });
 
 test("the default limit is 30 and the count admits work below it", () => {
   assert.equal(DEFAULT_TASK_WIP_LIMIT, 30);
@@ -25,6 +25,7 @@ test("an exactly full worktable rejects a new activation with the counting crite
   assert.match(admission.message, /TASK_WIP_LIMIT_REACHED: Execution worktable is full \(30\/30; settings\.tasks\.wipLimit=30\)/u);
   assert.match(admission.message, /Suggested: task_BLOCKED "Blocked" \(blocked\)/u);
   assert.match(admission.message, /ha task start task_NEW/u);
+  assert.match(admission.message, /Derived root exemption applies only to pure containers/u);
 });
 
 test("only occupying statuses on active standard packages count; ideas, containers, and dispositions never do", () => {
@@ -55,6 +56,12 @@ test("structure-derived roots do not occupy WIP, preserve the declared taskClass
   assert.equal(isExecutionWipTask(entry({ directChildCount: 2 })), true, "2 direct children remains a leaf at the default threshold");
   assert.equal(isExecutionWipTask(entry({ directChildCount: 4 }), 5), true, "4 direct children remains a leaf when threshold is raised to 5");
   assert.equal(isExecutionWipTask(entry({ directChildCount: 5 }), 5), false, "5 direct children reaches the configured threshold");
+});
+
+test("derived root exemption applies only to pure containers", () => {
+  assert.equal(isExecutionWipTask(entry({ directChildCount: 4, hasOwnExecution: true })), true);
+  assert.equal(isExecutionWipTask(entry({ directChildCount: 4, hasOwnExecution: false })), false);
+  assert.equal(isExecutionWipTask(entry({ directChildCount: 4, taskClass: "milestone", hasOwnExecution: true })), false);
 });
 
 test("entering the worktable is the only gated move; re-entering an occupied slot adds nothing", () => {


### PR DESCRIPTION
# English

## Summary

WIP gate loophole (task_9951403ae22d2db367e754dc08, ruling by the repository owner 2026-09-12). The execution WIP limit exempts "roots"; a *derived* root was any task with ≥3 direct children, so an ordinary working task escaped the limit by spawning sub-tasks (two such tasks today: task_7873609b, task_8a17b780, each with its own dispatch and execution). A derived root is now exempt only when it is a pure container: no active/submitted execution and no lease of its own. Declared milestones/long-running tasks are unchanged. `task_wip_limit_reached` says so. The GUI "active 33" the owner saw was a different measure (all active-status tasks); the gate's own count was 24/30 and becomes 26/30 with this rule.

## Architectural Justification

-

## What Changed

- `packages/kernel/src/domain/task-wip-policy.ts`: `hasOwnExecution` on the snapshot entry; `deriveTaskRoot` exempts derived roots only when it is false.
- `packages/daemon/src/repo-cell-task-query.ts`, `repo-cell-completion.ts`: populate the flag from lease/execution state (the second call site was missed by the worker and added by the CEO).
- `packages/kernel/test/domain/task-wip-policy.test.ts`: executing-with-children counts, container-with-children exempt, milestone exempt.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: +18/-5 (G33 pass).

## Machine-Readable Declarations

- None.

## Task And Scope

- Harness task: task_9951403ae22d2db367e754dc08, parent task_dfbe44e31bd5811ba720c1b1c7
- Branch: `codex/wip-derived-root`
- Public scope: WIP root derivation rule
- Private planning/evidence updated: yes (`artifacts/report.md`, fact F-73E27222)
- Out of scope: GUI display of the gate count (task_dbbc1760), the limit value itself (unchanged, 30)

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: not applicable
- Machine-check boundary: not applicable
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `161f4d684`
- Branch merge-base with `origin/main`: `161f4d684`
- Last `git fetch origin` time: 2026-09-12 UTC
- Sync method: rebase onto origin/main
- Public diff command: `git diff origin/main...codex/wip-derived-root`
- Private evidence commit/path: task_9951403ae22d2db367e754dc08 `artifacts/report.md`
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [x] `npm run typecheck` (`npx tsc -b packages/kernel packages/daemon`, CEO)
- [ ] `npm run check`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts` (via `run-manifest-gates --changed origin/main`)
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [x] GitHub Actions `rewrite-ci` passed — pending
- `task-wip-policy.test.ts` + `task-action-catalog-executor.test.ts` 19/19 (CEO); worker: isolated daemon integration 6/6.

## Review Evidence

- CEO ground-truth: reproduced the gate count on canonical (24 counted, 10 roots, 2 of them executing) before the ruling; typecheck caught a second call site the worker missed.
- Reviewer subagent: pending (closeout review after merge)
- Human review: pending
- Blocking findings: none open

## Residual Risk

- Tasks that are roots today by the derived rule and are executing will start counting after deploy; if the count crosses 30, new `task start` is refused until something closes — that is the intended effect.

## References

- Task: task_9951403ae22d2db367e754dc08

---

# 中文

## 概要

WIP 门漏洞（task_9951403ae22d2db367e754dc08，泽宇 2026-09-12 裁定）。执行 WIP 上限豁免「root」；*派生* root 是任何直接子任务 ≥3 的任务，于是普通工作任务只要拆几个子任务就逃出上限（今天有两个：task_7873609b、task_8a17b780，各自有 dispatch 与 execution）。现在派生 root 只在纯容器时豁免：自己没有 active/submitted 的 execution，也没有 lease。声明的 milestone/long_running 不变。`task_wip_limit_reached` 的消息说明这一点。泽宇在 GUI 看到的「进行中 33」是另一口径（所有 active 状态），门自己的计数是 24/30，本规则后变 26/30。

## 架构辩护

-

## 改动内容

- `packages/kernel/src/domain/task-wip-policy.ts`：快照条目加 `hasOwnExecution`；`deriveTaskRoot` 只在它为 false 时豁免派生 root。
- `packages/daemon/src/repo-cell-task-query.ts`、`repo-cell-completion.ts`：从 lease/execution 状态填该标记（第二个调用点 worker 漏了，CEO 补上）。
- `packages/kernel/test/domain/task-wip-policy.test.ts`：有子任务且在执行 → 计入；纯容器 → 豁免；milestone → 豁免。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 删除的门或 fixture：none
- 生产净行数：+18/-5（G33 通过）。

## 机器可读声明

- 无。

## 任务与范围

- Harness 任务：task_9951403ae22d2db367e754dc08，父任务 task_dfbe44e31bd5811ba720c1b1c7
- 分支：`codex/wip-derived-root`
- 公开范围：WIP root 派生规则
- 私有计划/证据已更新：是（`artifacts/report.md`，fact F-73E27222）
- 范围外：门计数的 GUI 显示（task_dbbc1760）、上限值本身（不变，30）

## 版本影响

- 版本：不变
- 发布影响：不发布

## 治理声明

- 触碰受保护面：否
- 受保护面范围：不适用
- 授权：不适用
- 机器检查边界：不适用
- Break-glass：否
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- 基线 `origin/main` SHA：`161f4d684`
- 分支与 `origin/main` 的 merge-base：`161f4d684`
- 最近一次 `git fetch origin`：2026-09-12 UTC
- 同步方式：rebase 到 origin/main
- 公开 diff 命令：`git diff origin/main...codex/wip-derived-root`
- 私有证据路径：task_9951403ae22d2db367e754dc08 的 `artifacts/report.md`
- 评审证据路径：本 PR 的评审证据节
- GitHub Actions `rewrite-ci` run URL：本 PR 待跑
- `task-wip-policy.test.ts` + `task-action-catalog-executor.test.ts` 19/19（CEO）；worker：隔离 daemon 集成 6/6。

## 评审证据

- CEO 事实核对：裁决前在 canonical 复算了门计数（24 计入、10 root、其中 2 个在执行）；typecheck 抓到 worker 漏掉的第二个调用点。
- 评审子代理：待定（合入后派收口评审）
- 人工评审：待定
- 阻塞发现：无

## 残余风险

- 今天按派生规则算 root 且在执行的任务，部署后开始计入；若超过 30，新的 `task start` 会被拒到有任务收口为止——这正是预期效果。

## 参考

- 任务：task_9951403ae22d2db367e754dc08
