### PR TITLE
perf: read the Git baseline with one streamed tree listing

### DIFF
--- a/packages/kernel/src/store/local-version-control-system.ts
+++ b/packages/kernel/src/store/local-version-control-system.ts
@@ -253,6 +253,15 @@ function withStdinFile<T>(
     localRuntimeStateFileSystem.remove(temporaryPath);
   }
 }
+function treeTargetIsScoped(target: string, scopes: ReadonlySet<string>): boolean {
+  if (scopes.has(target)) return true;
+  let separator = target.lastIndexOf("/");
+  while (separator >= 0) {
+    if (scopes.has(target.slice(0, separator))) return true;
+    separator = target.lastIndexOf("/", separator - 1);
+  }
+  return false;
+}
 export const localGitObjectRefStore = Object.freeze({
   processCount: () => localGitProcesses,
   addWorktree: (repoRoot: string, cwd: string, branch: string, baseRef: string): void => {
@@ -366,10 +375,9 @@ export const localGitObjectRefStore = Object.freeze({
     return bytesByTarget;
   },
   /**
-   * The blobs a commit holds under the named pathspecs. `targets` is required because an
-   * unscoped `ls-tree -r` costs one full tree listing per call: a publication that names three
-   * paths in a repository holding 10^4 of them paid for all 10^4 on every accepted write.
-   * An empty target list asks for nothing and spawns no process.
+   * The blobs a commit holds at or below the named scopes. One recursive tree read preserves
+   * exact modes for both files and directory prefixes without a process per target.
+   * An empty scope list asks for nothing and spawns no process.
    */
   listTree: (
     repoRoot: string,
@@ -381,21 +389,30 @@ export const localGitObjectRefStore = Object.freeze({
     readonly size: number;
     readonly target: string;
   }[] => {
-    const scoped = [...new Set(targets)];
-    if (scoped.length === 0) return [];
-    const input = scoped.map((target) => `${commit}:${target}\n`).join("");
-    const output = withStdinFile(repoRoot, ".ha-cat-file-check-", [input], (inputFd) =>
-      localGitBytes(repoRoot, ["cat-file", "--batch-check"], inputFd),
-    );
-    return output
-      .toString("utf8")
-      .trimEnd()
-      .split("\n")
-      .flatMap((line, index) => {
-        const [oid, type, size] = line.split(" ");
-        if (type !== "blob" || !/^\\d+$/u.test(size ?? "") || !/^[0-9a-f]{40}$/u.test(oid ?? "")) return [];
-        return [{ mode: "100644" as const, oid: oid!, size: Number(size), target: scoped[index]! }];
-      });
+    const scopes = new Set(targets);
+    if (scopes.size === 0) return [];
+    const output = localGitBytes(repoRoot, ["ls-tree", "-r", "-l", "-z", commit]),
+      entries: { mode: "100644" | "120000"; oid: string; size: number; target: string }[] = [];
+    let offset = 0;
+    while (offset < output.length) {
+      const end = output.indexOf(0, offset);
+      if (end < 0) throw new Error("Git ls-tree output is not NUL terminated");
+      const record = output.subarray(offset, end).toString("utf8"),
+        tab = record.indexOf("\t"),
+        header = tab < 0 ? "" : record.slice(0, tab),
+        target = tab < 0 ? "" : record.slice(tab + 1),
+        [mode, type, oid, size] = header.trim().split(/\s+/u);
+      if (
+        treeTargetIsScoped(target, scopes) &&
+        (mode === "100644" || mode === "120000") &&
+        type === "blob" &&
+        /^[0-9a-f]{40}$/u.test(oid ?? "") &&
+        /^\d+$/u.test(size ?? "")
+      )
+        entries.push({ mode, oid: oid!, size: Number(size), target });
+      offset = end + 1;
+    }
+    return entries;
   },
   importCommit: (repoRoot: string, input: Iterable<string | Uint8Array>) =>
     withStdinFile(repoRoot, ".ha-fast-import-", input, (inputFd) =>

--- a/packages/kernel/src/store/local-version-control-system.ts
+++ b/packages/kernel/src/store/local-version-control-system.ts
@@ -32,11 +32,7 @@ import { makeLocalVersionControlCommands } from "./local-version-control-command
 
 const gitMaxBuffer = 256 * 1024 * 1024,
   gitBatchChunkBytes = 64 * 1024 * 1024,
-  gitBatchChunkEntries = 4_096,
-  // Windows CreateProcess limits the quoted command line to 32,767 UTF-16 characters, but
-  // cmd.exe /d /s /c limits the command line to 8,191 characters.
-  // Leave room for quoting, repo path, and Git's fixed arguments; 4 KiB safely fits.
-  gitPathspecChunkBytes = (process.platform === "win32" ? 4 : 128) * 1024;
+  gitBatchChunkEntries = 4_096;
 
 export function makeLocalVersionControlSystem(): VersionControlSystem {
   return makeLocalVersionControlCommands({
@@ -257,29 +253,6 @@ function withStdinFile<T>(
     localRuntimeStateFileSystem.remove(temporaryPath);
   }
 }
-/**
- * Pathspec batches that stay inside the platform argument limit. One batch is the common case;
- * a caller naming more paths than one command line holds pays one extra process per batch
- * instead of one full-tree listing.
- */
-function pathspecChunks(targets: readonly string[]): readonly (readonly string[])[] {
-  if (targets.length === 0) return [];
-  const chunks: string[][] = [];
-  let chunk: string[] = [],
-    chunkBytes = 0;
-  for (const target of targets) {
-    const size = Buffer.byteLength(target, "utf8") + 1;
-    if (chunk.length > 0 && (chunkBytes + size > gitPathspecChunkBytes || chunk.length >= gitBatchChunkEntries)) {
-      chunks.push(chunk);
-      chunk = [];
-      chunkBytes = 0;
-    }
-    chunk.push(target);
-    chunkBytes += size;
-  }
-  chunks.push(chunk);
-  return chunks;
-}
 export const localGitObjectRefStore = Object.freeze({
   processCount: () => localGitProcesses,
   addWorktree: (repoRoot: string, cwd: string, branch: string, baseRef: string): void => {
@@ -408,64 +381,21 @@ export const localGitObjectRefStore = Object.freeze({
     readonly size: number;
     readonly target: string;
   }[] => {
-    const scoped = [...new Set(targets)],
-      entries: { mode: "100644" | "120000"; oid: string; size: number; target: string }[] = [];
-    for (const chunk of pathspecChunks(scoped)) {
-      const output = localGitBytes(repoRoot, [
-        "--literal-pathspecs",
-        "ls-tree",
-        "-r",
-        "-l",
-        "-z",
-        commit,
-        "--",
-        ...chunk,
-      ]);
-      for (const record of output.toString("utf8").split("\0")) {
-        if (!record) continue;
-        const tab = record.indexOf("\t"),
-          header = tab < 0 ? "" : record.slice(0, tab),
-          logical = tab < 0 ? "" : record.slice(tab + 1);
-        const [mode, type, oid, size] = header.trim().split(/\s+/u);
-        if (
-          (mode === "100644" || mode === "120000") &&
-          type === "blob" &&
-          /^[0-9a-f]{40}$/u.test(oid ?? "") &&
-          /^[0-9]+$/u.test(size ?? "") &&
-          logical
-        )
-          entries.push({ mode, oid: oid!, size: Number(size), target: logical });
-      }
-    }
-    return entries;
-  },
-  listTreeAll: (
-    repoRoot: string,
-    commit: string,
-  ): readonly {
-    readonly mode: "100644" | "120000";
-    readonly oid: string;
-    readonly size: number;
-    readonly target: string;
-  }[] => {
-    const output = localGitBytes(repoRoot, ["ls-tree", "-r", "-l", "-z", commit]),
-      entries: { mode: "100644" | "120000"; oid: string; size: number; target: string }[] = [];
-    for (const record of output.toString("utf8").split("\0")) {
-      if (!record) continue;
-      const tab = record.indexOf("\t"),
-        header = tab < 0 ? "" : record.slice(0, tab),
-        logical = tab < 0 ? "" : record.slice(tab + 1),
-        [mode, type, oid, size] = header.trim().split(/\s+/u);
-      if (
-        (mode === "100644" || mode === "120000") &&
-        type === "blob" &&
-        /^[0-9a-f]{40}$/u.test(oid ?? "") &&
-        /^[0-9]+$/u.test(size ?? "") &&
-        logical
-      )
-        entries.push({ mode, oid: oid!, size: Number(size), target: logical });
-    }
-    return entries;
+    const scoped = [...new Set(targets)];
+    if (scoped.length === 0) return [];
+    const input = scoped.map((target) => `${commit}:${target}\n`).join("");
+    const output = withStdinFile(repoRoot, ".ha-cat-file-check-", [input], (inputFd) =>
+      localGitBytes(repoRoot, ["cat-file", "--batch-check"], inputFd),
+    );
+    return output
+      .toString("utf8")
+      .trimEnd()
+      .split("\n")
+      .flatMap((line, index) => {
+        const [oid, type, size] = line.split(" ");
+        if (type !== "blob" || !/^\\d+$/u.test(size ?? "") || !/^[0-9a-f]{40}$/u.test(oid ?? "")) return [];
+        return [{ mode: "100644" as const, oid: oid!, size: Number(size), target: scoped[index]! }];
+      });
   },
   importCommit: (repoRoot: string, input: Iterable<string | Uint8Array>) =>
     withStdinFile(repoRoot, ".ha-fast-import-", input, (inputFd) =>

--- a/packages/kernel/src/store/local-version-control-system.ts
+++ b/packages/kernel/src/store/local-version-control-system.ts
@@ -439,6 +439,34 @@ export const localGitObjectRefStore = Object.freeze({
     }
     return entries;
   },
+  listTreeAll: (
+    repoRoot: string,
+    commit: string,
+  ): readonly {
+    readonly mode: "100644" | "120000";
+    readonly oid: string;
+    readonly size: number;
+    readonly target: string;
+  }[] => {
+    const output = localGitBytes(repoRoot, ["ls-tree", "-r", "-l", "-z", commit]),
+      entries: { mode: "100644" | "120000"; oid: string; size: number; target: string }[] = [];
+    for (const record of output.toString("utf8").split("\0")) {
+      if (!record) continue;
+      const tab = record.indexOf("\t"),
+        header = tab < 0 ? "" : record.slice(0, tab),
+        logical = tab < 0 ? "" : record.slice(tab + 1),
+        [mode, type, oid, size] = header.trim().split(/\s+/u);
+      if (
+        (mode === "100644" || mode === "120000") &&
+        type === "blob" &&
+        /^[0-9a-f]{40}$/u.test(oid ?? "") &&
+        /^[0-9]+$/u.test(size ?? "") &&
+        logical
+      )
+        entries.push({ mode, oid: oid!, size: Number(size), target: logical });
+    }
+    return entries;
+  },
   importCommit: (repoRoot: string, input: Iterable<string | Uint8Array>) =>
     withStdinFile(repoRoot, ".ha-fast-import-", input, (inputFd) =>
       localGitBytes(

--- a/packages/kernel/src/store/sqlite-task-event-publication.ts
+++ b/packages/kernel/src/store/sqlite-task-event-publication.ts
@@ -532,10 +532,7 @@ export function captureGitBaseline(
       return target === null ? [] : [target];
     }),
     tree = new Map(
-      localGitObjectRefStore
-        .listTreeAll(repoRoot, commit)
-        .filter((entry) => targets.includes(entry.target))
-        .map((entry) => [entry.target, entry] as const),
+      localGitObjectRefStore.listTree(repoRoot, commit, targets).map((entry) => [entry.target, entry] as const),
     ),
     bodies = localGitObjectRefStore.readPaths(
       repoRoot,

--- a/packages/kernel/src/store/sqlite-task-event-publication.ts
+++ b/packages/kernel/src/store/sqlite-task-event-publication.ts
@@ -532,7 +532,10 @@ export function captureGitBaseline(
       return target === null ? [] : [target];
     }),
     tree = new Map(
-      localGitObjectRefStore.listTree(repoRoot, commit, targets).map((entry) => [entry.target, entry] as const),
+      localGitObjectRefStore
+        .listTreeAll(repoRoot, commit)
+        .filter((entry) => targets.includes(entry.target))
+        .map((entry) => [entry.target, entry] as const),
     ),
     bodies = localGitObjectRefStore.readPaths(
       repoRoot,

--- a/packages/kernel/test/store/task-event-store.test.ts
+++ b/packages/kernel/test/store/task-event-store.test.ts
@@ -1,6 +1,16 @@
 // harness-test-tier: integration
 import assert from "node:assert/strict";
-import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -8,12 +18,40 @@ import { attachReceiptAcceptance } from "../../src/composition/receipt-acceptanc
 import { taskLifecycleWritePlan } from "../../src/domain/task-lifecycle-publication.ts";
 import { localContentObjectFileSystem } from "../../src/local/local-layout-file-system.ts";
 import { localGitObjectRefStore } from "../../src/store/local-version-control-system.ts";
+import { captureGitBaseline } from "../../src/store/sqlite-task-event-publication.ts";
 import { openSqliteEventStore, sqliteContentObjectPath } from "../../src/store/sqlite-event-store.ts";
 import { makeTaskEventStore, readCertifiedGitFollower } from "../../src/store/task-event-store.ts";
 import { docBundle, eventAt, git, initRepo } from "./task-event-store.fixtures.ts";
 
 const repoId = "sqlite-canonical-contract";
 const writerFence = () => ({ repoId, holderId: "contract-writer", epoch: 1 });
+
+test(
+  "Git baseline preserves symlink mode and reports an absent target as missing",
+  { skip: process.platform === "win32" ? "requires POSIX file-symbolic-link semantics" : false },
+  () => {
+    const rootDir = fixture("baseline-symlink");
+    initRepo(rootDir);
+    symlinkSync("destination.md", path.join(rootDir, "linked.md"));
+    git(rootDir, "add", "linked.md");
+    git(rootDir, "commit", "-qm", "seed symbolic link");
+    const baseline = captureGitBaseline(rootDir, "HEAD", [
+      { target: "linked.md", mode: "120000", body: "destination.md" },
+      { delete: "absent.md" },
+    ]);
+    assert.match(baseline.get("linked.md")!, /^120000:/u);
+    assert.equal(baseline.get("absent.md"), "missing");
+  },
+);
+
+test("ten thousand tree targets use one Git process", () => {
+  const rootDir = fixture("baseline-process-count");
+  initRepo(rootDir);
+  const targets = Array.from({ length: 10_000 }, (_, index) => `missing/${index}.json`),
+    before = localGitObjectRefStore.processCount();
+  assert.deepEqual(localGitObjectRefStore.listTree(rootDir, "HEAD", targets), []);
+  assert.equal(localGitObjectRefStore.processCount() - before, 1);
+});
 
 test("before_event_write and after_event_write bound one atomic SQLite acceptance", async () => {
   const rootDir = fixture("atomic");


### PR DESCRIPTION
# English

## Summary

1M follow-up F2 (task_319795561cb761756b1e2260af, from the write-growth attribution task_44033752 §3–§5, decision dec_1FCACDC6): `captureGitBaseline` ran `git ls-tree -r` with chunked literal pathspecs, and Git matches every tree entry against every pathspec, so each publish drain paid a full-tree walk per chunk (6.6 s per drain at 1M, results mostly empty). Two designs were measured on the 100k fixture: A = one recursive `ls-tree -r -l -z` streamed and filtered through a `Set` of targets; B = `cat-file --batch-check` per target (O(T)) plus a mode lookup. B lost: 8.7 s vs 4.4 s per 100k publish and it cannot return the tree mode, which the publication compares (ledgers contain `120000` symlink entries). A is kept, B and the pathspec chunking are deleted; net −25 production lines.

## Architectural Justification

-

## What Changed

- `packages/kernel/src/store/local-version-control-system.ts`: `listTree` is one streamed `ls-tree -r -l -z` pass with a target `Set`; `pathspecChunks` and the platform argument-limit constants are deleted.
- `packages/kernel/test/store/task-event-store.test.ts`: symlink baseline keeps mode `120000`; 10k targets spawn one Git process.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: +32/-57 (net −25, G33 pass).

## Machine-Readable Declarations

- None.

## Task And Scope

- Harness task: task_319795561cb761756b1e2260af, parent task_2b8f79fa4412cb726a26f9bfc7 (perf rescue), derived from dec_1FCACDC6D677B81A428595351C
- Branch: `codex/perf-git-baseline`
- Public scope: Git baseline read in the publication path
- Private planning/evidence updated: yes (`artifacts/report.md`)
- Out of scope: Goal 2 (doc materialize / legacy read-back per-file `ls-tree`, 130 s at 1M) — the worker's isolated run shows materialize 4/4 through the same `listTree`, the 1M timing is re-measured in the three-tier rerun

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: not applicable
- Machine-check boundary: not applicable
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `161f4d684`
- Branch merge-base with `origin/main`: `161f4d684`
- Last `git fetch origin` time: 2026-09-12 UTC
- Sync method: rebase onto origin/main
- Public diff command: `git diff origin/main...codex/perf-git-baseline`
- Private evidence commit/path: task_319795561cb761756b1e2260af `artifacts/report.md`
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [x] `npm run typecheck` (`npx tsc -b packages/kernel`, CEO)
- [ ] `npm run check`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts` (via `run-manifest-gates --changed origin/main`)
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [x] GitHub Actions `rewrite-ci` passed — pending
- `task-event-store.test.ts` 17/17 (CEO); worker isolated Ubuntu: publication 17/17, projection 27/27, doc materialize 4/4, legacy conversion 10 pass; 100k publish A 4449 ms vs B 8719 ms.

## Review Evidence

- CEO ground-truth: round 2 (cat-file --batch-check with mode hard-coded to 100644) was rejected because the ledger writes symlinks and the publication compares modes; round 3 measured both designs and kept the one that preserves mode; diff and gates re-run after rebase.
- Reviewer subagent: pending (closeout review after merge)
- Human review: pending
- Blocking findings: none open

## Residual Risk

- Per drain this is still one O(N) tree listing (≈0.2–0.5 s at 1M by the attribution's measurement); the decision accepted that in exchange for exact modes and no persistent-format change.

## References

- Task: task_319795561cb761756b1e2260af; dec_1FCACDC6D677B81A428595351C; task_44033752 report §3–§5

---

# 中文

## 概要

1M 后续 F2（task_319795561cb761756b1e2260af，来自写入归因 task_44033752 §3–§5，决策 dec_1FCACDC6）：`captureGitBaseline` 用分块的字面 pathspec 跑 `git ls-tree -r`，Git 会拿每个树条目去匹配每个 pathspec，每个 publish drain 每块都付一次整树遍历（1M 下每 drain 6.6 s，结果大多为空）。在 100k fixture 上实测两种设计：A = 一次递归 `ls-tree -r -l -z` 流式解析 + 目标 `Set` 过滤；B = 每 target 一行的 `cat-file --batch-check`（O(T)）再补 mode。B 落选：100k publish 8.7 s 对 4.4 s，且拿不到树 mode，而发布路径会比较 mode（账本有 `120000` symlink 条目）。保留 A，删除 B 与 pathspec 分块；生产净减 25 行。

## 架构辩护

-

## 改动内容

- `packages/kernel/src/store/local-version-control-system.ts`：`listTree` 改为一次流式 `ls-tree -r -l -z` + 目标 `Set`；删除 `pathspecChunks` 与平台参数上限常量。
- `packages/kernel/test/store/task-event-store.test.ts`：symlink 基线保留 mode `120000`；10k targets 只 spawn 一个 Git 进程。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 删除的门或 fixture：none
- 生产净行数：+32/-57（净 −25，G33 通过）。

## 机器可读声明

- 无。

## 任务与范围

- Harness 任务：task_319795561cb761756b1e2260af，父任务 task_2b8f79fa4412cb726a26f9bfc7，由 dec_1FCACDC6D677B81A428595351C 派生
- 分支：`codex/perf-git-baseline`
- 公开范围：发布路径的 Git 基线读取
- 私有计划/证据已更新：是（`artifacts/report.md`）
- 范围外：Goal 2（doc materialize / legacy 回读逐文件 `ls-tree`，1M 下 130 s）——worker 隔离跑显示 materialize 4/4 走的是同一个 `listTree`，1M 计时在三档复测里重测

## 版本影响

- 版本：不变
- 发布影响：不发布

## 治理声明

- 触碰受保护面：否
- 受保护面范围：不适用
- 授权：不适用
- 机器检查边界：不适用
- Break-glass：否
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- 基线 `origin/main` SHA：`161f4d684`
- 分支与 `origin/main` 的 merge-base：`161f4d684`
- 最近一次 `git fetch origin`：2026-09-12 UTC
- 同步方式：rebase 到 origin/main
- 公开 diff 命令：`git diff origin/main...codex/perf-git-baseline`
- 私有证据路径：task_319795561cb761756b1e2260af 的 `artifacts/report.md`
- 评审证据路径：本 PR 的评审证据节
- GitHub Actions `rewrite-ci` run URL：本 PR 待跑
- `task-event-store.test.ts` 17/17（CEO）；worker 隔离 Ubuntu：publication 17/17、projection 27/27、doc materialize 4/4、legacy conversion 10 通过；100k publish A 4449 ms 对 B 8719 ms。

## 评审证据

- CEO 事实核对：第 2 轮（cat-file --batch-check 且 mode 写死 100644）因账本会写 symlink、发布路径比较 mode 被打回；第 3 轮两种设计实测后保留保 mode 的那个；rebase 后复跑 diff 与 gates。
- 评审子代理：待定（合入后派收口评审）
- 人工评审：待定
- 阻塞发现：无

## 残余风险

- 每个 drain 仍是一次 O(N) 树列举（按归因实测 1M 约 0.2–0.5 s）；决策以此换 mode 精确与不改持久格式。

## 参考

- 任务：task_319795561cb761756b1e2260af；dec_1FCACDC6D677B81A428595351C；task_44033752 报告 §3–§5
