### PR TITLE
fix: reject unattended zcode dispatches that need an interactive permission client

### DIFF
--- a/packages/daemon/src/runtime-spawner.ts
+++ b/packages/daemon/src/runtime-spawner.ts
@@ -430,6 +430,14 @@ export function makeRuntimeSpawner(input: RuntimeSpawnerInput) {
       installation = prepared.installation,
       declaredKindId = runtimeKindForId(definition.kindId).kindId,
       launchedPermissionMode = runtimePermissionMode(effectivePermissionMode, declaredKindId);
+    if (declaredKindId === "zcode" && launchedPermissionMode !== "bypass")
+      throw runtimeSpawnError(
+        "zcode_unattended_permission_mode_unsupported",
+        [
+          "ZCode edit and plan modes require an interactive permission client and cannot run unattended. ",
+          "Use --permission-mode bypass, or use --agent glm-worker (which declares bypass).",
+        ].join(""),
+      );
     if (agent && !runtimeTypeMatchesKind(agent.runtime_type, declaredKindId))
       throw runtimeSpawnError(
         "agent_runtime_type_mismatch",

--- a/packages/daemon/test/runtime-spawn.integration.test.ts
+++ b/packages/daemon/test/runtime-spawn.integration.test.ts
@@ -107,6 +107,118 @@ test("runtime spawn maps the GUI Claude kind to a canonical claude-compatible in
   }
 });
 
+test("runtime spawn rejects unattended zcode modes that require a permission client", async () => {
+  const root = mkdtempSync(path.join(tmpdir(), "ha-runtime-spawn-zcode-permission-"));
+  let launchCount = 0;
+  try {
+    git(root, "init", "-q");
+    git(root, "config", "user.name", "Spawn Test");
+    git(root, "config", "user.email", "spawn@example.invalid");
+    git(root, "commit", "--allow-empty", "-qm", "base");
+    const zcodeDefinition: AgentDefinitionSnapshot = {
+        ...definition,
+        instanceId: "zcode-review",
+        installationId: "installation-zcode",
+        kindId: "zcode",
+        providerId: "zai",
+        model: "glm-5",
+        reasoningEffort: null,
+        baseUrl: null,
+      },
+      zcodeInstallation: RuntimeInstallationWitness = {
+        installationId: zcodeDefinition.installationId,
+        kindId: zcodeDefinition.kindId,
+        executablePath: "/opt/witnessed/zcode",
+        version: "0.16.5",
+        observedAt: "2026-09-12T00:00:00.000Z",
+      },
+      instance = {
+        schemaVersion: 2 as const,
+        instanceId: zcodeDefinition.instanceId,
+        name: "ZCode Review",
+        installationId: zcodeDefinition.installationId,
+        providerId: zcodeDefinition.providerId,
+        models: [zcodeDefinition.model],
+        defaultModel: zcodeDefinition.model,
+        enabled: true,
+        permissionMode: "bypass" as const,
+        authMode: "subscription" as const,
+        authState: "authenticated" as const,
+        authReadiness: { status: "ready" as const, code: null, hint: null },
+        isolationState: "enforced" as const,
+        configuration: {},
+        kindId: "zcode",
+      },
+      cell = await openRepoCell({
+        repoId: workspaceId("runtime-spawn-zcode-permission"),
+        rootDir: canonicalRoot(root),
+        ownerId: "spawn-test",
+        runtimeInstances: () => [instance],
+        prepareRuntimeLaunch: (_instanceId, request) => ({
+          definition: zcodeDefinition,
+          installation: zcodeInstallation,
+          executablePath: zcodeInstallation.executablePath,
+          args: ["--mode", request.permissionMode === "bypass" ? "yolo" : "edit"],
+          env: {},
+          cwd: request.cwd,
+          prompt: request.prompt,
+        }),
+        runtimeLaunch: () => {
+          launchCount += 1;
+          return {
+            pid: 125,
+            onOutput: () => undefined,
+            onErrorOutput: () => undefined,
+            onExit: () => undefined,
+            terminate: () => undefined,
+          };
+        },
+      }),
+      binding = {
+        actor: { principal: { personId: "person-spawn" }, executor: null },
+        source: "local" as const,
+      };
+    try {
+      await assert.rejects(
+        cell.spawnRuntime(
+          {
+            runtimeInstanceId: instance.instanceId,
+            cwd: { scope: "repo-root" },
+            prompt: "Review the repository",
+            permissionMode: "workspace-write",
+            taskId: null,
+            idempotencyKey: "spawn-zcode-edit",
+          },
+          binding,
+        ),
+        (error: unknown) =>
+          error instanceof Error &&
+          "code" in error &&
+          error.code === "zcode_unattended_permission_mode_unsupported" &&
+          /interactive permission client.*--permission-mode bypass.*--agent glm-worker/su.test(error.message),
+      );
+      assert.equal(launchCount, 0);
+      const bypass = await cell.spawnRuntime(
+        {
+          runtimeInstanceId: instance.instanceId,
+          cwd: { scope: "repo-root" },
+          prompt: "Review the repository",
+          permissionMode: "bypass",
+          taskId: null,
+          idempotencyKey: "spawn-zcode-yolo",
+        },
+        binding,
+      );
+      assert.equal(bypass.outcome, "applied");
+      assert.equal(launchCount, 1);
+    } finally {
+      await cell.close();
+    }
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test("runtime spawn resolves command model, Agent model, then instance default without silent fallback", async () => {
   const parent = mkdtempSync(path.join(tmpdir(), "ha-runtime-agent-model-")),
     root = path.join(parent, "repo"),


### PR DESCRIPTION
# English

## Summary

task_b8257b73d40d8de994306b9da5 (from the ai4s user report, 2026-09-12): a zcode (GLM) dispatch with `--permission-mode workspace-write` or `read-only` maps to zcode `--mode edit`/`plan`, which need an interactive permission client; unattended (`--detach`) the worker's Bash tool rejects every call with "No permission client configured for Bash" before any shell runs, so even `ha --version` never executes (two rounds of probes, dispatch_d47239c8 vs dispatch_a39e441e). Only `bypass` (`--mode yolo`) works headless, and `--agent glm-worker` declares bypass. This PR rejects the dispatch up front, at the one place where the resolved permission mode meets the runtime kind, with a self-describing error that names both fixes, instead of spawning a worker that is guaranteed to fail.

## Architectural Justification

-

## What Changed

- `packages/daemon/src/runtime-spawner.ts`: after `runtimePermissionMode(effectivePermissionMode, declaredKindId)` resolves, a zcode launch with any mode other than `bypass` throws `zcode_unattended_permission_mode_unsupported` before `runtimeLaunch`; the message says edit/plan need an interactive permission client and points to `--permission-mode bypass` or `--agent glm-worker`.
- `packages/daemon/test/runtime-spawn.integration.test.ts`: zcode + workspace-write and read-only are rejected with that code and message; zcode + bypass still launches.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: +8/-0. The `edit`/`plan` entries in the zcode inventory mapping stay because `permissionArgs` is the provider catalogue's three-mode contract shared by all kinds and `prepareLaunch` is tested on its own; dispatch can no longer reach them.

## Machine-Readable Declarations

- None.

## Task And Scope

- Harness task: task_b8257b73d40d8de994306b9da5, parent task_4455977a529becac425737d812 (ai4s UX feedback)
- Branch: `codex/zcode-permission`
- Public scope: runtime dispatch admission for the zcode kind
- Private planning/evidence updated: yes (`artifacts/report.md`, rounds 1–3, fact F-B63103D4)
- Out of scope: giving zcode a headless permission client (not a harness-side capability); agent catalogue changes

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: not applicable
- Machine-check boundary: not applicable
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `b1a124616`
- Branch merge-base with `origin/main`: `b1a124616`
- Last `git fetch origin` time: 2026-09-12 UTC
- Sync method: rebase onto origin/main
- Public diff command: `git diff origin/main...codex/zcode-permission`
- Private evidence commit/path: task_b8257b73d40d8de994306b9da5 `artifacts/report.md`
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [x] `npm run typecheck` (`npx tsc -b packages/daemon`, CEO)
- [ ] `npm run check`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts` (via `run-manifest-gates --changed origin/main`, CEO)
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- `runtime-spawn.integration.test.ts` 6/6 (CEO after rebase; worker isolated Ubuntu 6/6).

## Review Evidence

- CEO ground-truth: read the 8-line production diff; the check sits after mode resolution so `--agent` and bare dispatches share one judgement; both remedies appear in the message; round 1–2 probes (accepted_durable via glm-worker, tool-level rejection via bare workspace-write) are in the task report.
- Reviewer subagent: pending (closeout review after merge)
- Human review: pending
- Blocking findings: none open

## Residual Risk

- If zcode later ships a headless permission client, this admission check is the one line to delete.

## References

- Task: task_b8257b73d40d8de994306b9da5; HARNESS-UX-FEEDBACK.md (ai4s)

---

# 中文

## 概要

task_b8257b73d40d8de994306b9da5（来自 ai4s 使用者报告，2026-09-12）：zcode（GLM）派工带 `--permission-mode workspace-write` 或 `read-only` 会映射到 zcode 的 `--mode edit`/`plan`，这两种模式需要交互式 permission client；无人值守（`--detach`）下 worker 的 Bash 工具在起任何 shell 之前就以 "No permission client configured for Bash" 拒绝，连 `ha --version` 都不执行（两轮探针，dispatch_d47239c8 对 dispatch_a39e441e）。只有 `bypass`（`--mode yolo`）能 headless 跑，而 `--agent glm-worker` 声明的就是 bypass。本 PR 在解析后的权限模式与运行时类型汇合的唯一一处派前拒绝，错误自描述并给出两条修法，不再起一个必然失败的 worker。

## 架构辩护

-

## 改动内容

- `packages/daemon/src/runtime-spawner.ts`：`runtimePermissionMode(effectivePermissionMode, declaredKindId)` 解析后，zcode 且模式不是 `bypass` 的启动在 `runtimeLaunch` 之前抛 `zcode_unattended_permission_mode_unsupported`；消息说明 edit/plan 需要交互式 permission client，并指向 `--permission-mode bypass` 或 `--agent glm-worker`。
- `packages/daemon/test/runtime-spawn.integration.test.ts`：zcode + workspace-write 与 read-only 以该码与消息拒绝；zcode + bypass 照常启动。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 删除的门或 fixture：none
- 生产净行数：+8/-0。zcode inventory 映射里的 `edit`/`plan` 条目保留：`permissionArgs` 是所有运行时共用的三模式 provider 目录契约，`prepareLaunch` 有独立测试；派工已不可能到达它们。

## 机器可读声明

- 无。

## 任务与范围

- Harness 任务：task_b8257b73d40d8de994306b9da5，父任务 task_4455977a529becac425737d812（ai4s UX 反馈）
- 分支：`codex/zcode-permission`
- 公开范围：zcode 类型的运行时派工受理
- 私有计划/证据已更新：是（`artifacts/report.md` 第 1–3 轮，fact F-B63103D4）
- 范围外：给 zcode 配 headless permission client（非 harness 侧能力）；agent 目录改动

## 版本影响

- 版本：不变
- 发布影响：不发布

## 治理声明

- 触碰受保护面：否
- 受保护面范围：不适用
- 授权：不适用
- 机器检查边界：不适用
- Break-glass：否
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- 基线 `origin/main` SHA：`b1a124616`
- 分支与 `origin/main` 的 merge-base：`b1a124616`
- 最近一次 `git fetch origin`：2026-09-12 UTC
- 同步方式：rebase 到 origin/main
- 公开 diff 命令：`git diff origin/main...codex/zcode-permission`
- 私有证据路径：task_b8257b73d40d8de994306b9da5 的 `artifacts/report.md`
- 评审证据路径：本 PR 的评审证据节
- GitHub Actions `rewrite-ci` run URL：本 PR 待跑
- `runtime-spawn.integration.test.ts` 6/6（CEO rebase 后；worker 隔离 Ubuntu 6/6）；`npx tsc -b packages/daemon` 通过；`run-manifest-gates --changed origin/main` 通过。

## 评审证据

- CEO 事实核对：读过 8 行生产 diff；判定放在模式解析之后，`--agent` 派与裸派共用一处；消息含两条修法；第 1–2 轮探针（glm-worker 下 accepted_durable、裸 workspace-write 下工具层拒绝）在任务报告里。
- 评审子代理：待定（合入后派收口评审）
- 人工评审：待定
- 阻塞发现：无

## 残余风险

- 若 zcode 日后提供 headless permission client，删掉这一处受理检查即可。

## 参考

- 任务：task_b8257b73d40d8de994306b9da5；HARNESS-UX-FEEDBACK.md（ai4s）
