### PR TITLE
feat: configure the CI witness workflows per repository

### DIFF
--- a/packages/daemon/src/ci-observation-actions.ts
+++ b/packages/daemon/src/ci-observation-actions.ts
@@ -13,7 +13,7 @@ import {
 import type { RepoCellBinding, RepoTaskAction } from "./repo-cell-types.ts";
 import { runProcessTextAsync } from "./process-port.ts";
 import { localGitObjectRefStore, resolveHarnessLayout } from "../../kernel/src/index.ts";
-import type { RepoCellActionContext } from "./repo-cell-action-context.ts";
+import type { RepoCellActionContext, RepoCellOperationalContext } from "./repo-cell-action-context.ts";
 
 type CiRunArtifactGate =
   | CiRunObservationEventV3["payload"]["gates"][number]
@@ -37,17 +37,22 @@ type FetchedCiRun = {
   readonly summary: CiRunSummary;
   readonly artifacts: readonly CiRunArtifact[];
 };
-type CiObservationFetch = { readonly requestedRuns: number; readonly runs: readonly FetchedCiRun[] };
+type CiObservationFetch = {
+  readonly requestedRuns: number;
+  readonly workflows: readonly string[];
+  readonly runs: readonly FetchedCiRun[];
+};
 
 // Every gh call finishes before the pull enters the repository write queue: GitHub can stall
 // without bound, and the queue waits only on the event appends in ingestCiObservations.
 export async function fetchCiObservations(
-  cell: Pick<RepoCellActionContext, "rootDir" | "cellCodedError">,
+  cell: Pick<RepoCellOperationalContext, "rootDir" | "cellCodedError" | "settings">,
   action: RepoTaskAction,
   runGh: RunGh = (command, args, options) => runProcessTextAsync(command, args, options.cwd),
 ): Promise<CiObservationFetch> {
   const limit = Number(action.limit ?? 20),
-    namedRuns = Array.isArray(action.runs) ? action.runs.map(Number) : null;
+    namedRuns = Array.isArray(action.runs) ? action.runs.map(Number) : null,
+    workflows = cell.settings.read().ci.workflows;
   if (!Number.isSafeInteger(limit) || limit < 1 || limit > 100)
     throw cell.cellCodedError("invalid_command", "CI observation pull limit must be 1..100.");
   if (namedRuns && action.limit !== undefined)
@@ -61,7 +66,7 @@ export async function fetchCiObservations(
       selectCiObservationRuns(
         (
           await Promise.all(
-            ["rewrite-ci.yml", "rebuild-gates.yml"].map(
+            workflows.map(
               async (workflow) =>
                 JSON.parse(
                   await runGh(
@@ -70,7 +75,7 @@ export async function fetchCiObservations(
                       "run",
                       "list",
                       "--workflow",
-                      workflow,
+                      `${workflow}.yml`,
                       "--limit",
                       String(limit),
                       "--json",
@@ -163,7 +168,7 @@ export async function fetchCiObservations(
           });
       }
     }
-    return { requestedRuns: namedRuns?.length ?? limit, runs: fetched };
+    return { requestedRuns: namedRuns?.length ?? limit, workflows, runs: fetched };
   } finally {
     rmSync(temporaryRoot, { recursive: true, force: true });
   }
@@ -212,14 +217,14 @@ export function ingestCiObservations(
                     headSha: summary.headSha,
                     conclusion: "success",
                   }
-                : summary.workflowName === "rewrite-ci" &&
+                : fetched.workflows.includes(summary.workflowName) &&
                     summary.headBranch === "main" &&
                     artifact.run.branch === "main" &&
                     artifact.run.sha === summary.headSha &&
                     artifact.run.runId === `${databaseId}.${summary.attempt}`
                   ? {
                       source: "github-actions",
-                      workflow: "rewrite-ci",
+                      workflow: summary.workflowName,
                       runId: String(databaseId),
                       attempt: summary.attempt,
                       headSha: summary.headSha,

--- a/packages/daemon/test/ci-observatory-read.test.ts
+++ b/packages/daemon/test/ci-observatory-read.test.ts
@@ -9,6 +9,9 @@ import { fetchCiObservations, ingestCiObservations, selectCiObservationRuns } fr
 import type { CiRunObservationEventV3 } from "../../kernel/src/index.ts";
 
 const actor = { principal: { personId: "person-observatory" }, executor: null } as const;
+const ciSettings = (workflows: readonly string[] = ["rewrite-ci", "rebuild-gates"]) => ({
+  read: () => ({ ci: { workflows } }),
+});
 
 // The daemon runs the gh reads before the write queue and the appends inside it; these cases run both halves back to back.
 async function pullAndIngestCiObservations(
@@ -269,6 +272,7 @@ test("CI observation pull writes canonical events once per run and job", async (
   let revision = 0;
   const cell = {
     rootDir,
+    settings: ciSettings(),
     now: () => "2026-08-27T04:00:00.000Z",
     cellCodedError: (_code: string, message: string) => new Error(message),
     store: {
@@ -367,7 +371,10 @@ test("CI observation pull writes canonical events once per run and job", async (
       headSha: "sha-101",
       conclusion: "success",
     });
-    assert.equal(observed.find((event) => event.payload.run.runId === "102.1")?.payload.verification, null);
+    assert.equal(
+      observed.find((event) => event.payload.run.runId === "102.1")?.payload.verification?.workflow,
+      "rebuild-gates",
+    );
     assert.ok([...events.values()].every((observed) => observed.schema === "ci-run-observation/v3"));
     assert.deepEqual(
       [...events.values()].map((observed) => observed.payload.gates),
@@ -384,7 +391,11 @@ test("CI observation pull writes canonical events once per run and job", async (
 test("CI observation pull synthesizes a ledger-publication run only for private ledger commits", async () => {
   const rootDir = mkdtempSync(path.join(process.cwd(), ".tmp-ci-observation-ledger-"));
   const ledgerRoot = path.join(rootDir, "harness");
-  const cell = { rootDir, cellCodedError: (_code: string, message: string) => new Error(message) };
+  const cell = {
+    rootDir,
+    settings: ciSettings(),
+    cellCodedError: (_code: string, message: string) => new Error(message),
+  };
   const noRuns = ((_command: string, args: readonly string[]) => (args[1] === "list" ? "[]" : "")) as never;
   try {
     git(rootDir, "init", "-q", "-b", "main");
@@ -423,6 +434,7 @@ test("CI observation pull imports named main runs without listing recent runs", 
     calls: string[] = [];
   const cell = {
     rootDir,
+    settings: ciSettings(["ci"]),
     now: () => "2026-09-10T00:00:00.000Z",
     cellCodedError: (_code: string, message: string) => new Error(message),
     store: {
@@ -439,9 +451,9 @@ test("CI observation pull imports named main runs without listing recent runs", 
     calls.push(`${args[1]}:${args[2]}`);
     if (args[1] === "view")
       return JSON.stringify({
-        workflowName: "rewrite-ci",
+        workflowName: args[2] === "700" ? "ci" : "rewrite-ci",
         headSha: `sha-${args[2]}`,
-        headBranch: args[2] === "700" ? "main" : "codex/feature",
+        headBranch: args[2] === "701" ? "codex/feature" : "main",
         status: "completed",
         conclusion: "success",
         attempt: 1,
@@ -478,6 +490,7 @@ test("CI observation pull imports named main runs without listing recent runs", 
     assert.deepEqual(calls, ["view:700", "download:700"]);
     assert.equal(events.length, 1);
     assert.equal(events[0]?.payload.verification?.headSha, "sha-700");
+    assert.equal(events[0]?.payload.verification?.workflow, "ci");
     assert.equal(JSON.parse(receipt.evidence).requestedRuns, 1);
     await assert.rejects(
       pullAndIngestCiObservations(
@@ -489,6 +502,14 @@ test("CI observation pull imports named main runs without listing recent runs", 
       /CI run 701 is completed on codex\/feature; only completed main runs can be imported\./u,
     );
     assert.equal(events.length, 1);
+    const unconfigured = await pullAndIngestCiObservations(
+      cell as never,
+      { kind: "ci-observe-pull", runs: ["702"] },
+      { actor, source: "local" },
+      runGh,
+    );
+    assert.equal(JSON.parse(unconfigured.evidence).imported, 1);
+    assert.equal(events[1]?.payload.verification, null);
     await assert.rejects(
       pullAndIngestCiObservations(
         cell as never,
@@ -525,7 +546,7 @@ test("CI completion verdict comes from the completed matching workflow run, not 
     },
     {
       name: "other workflow",
-      workflow: "rebuild-gates",
+      workflow: "other-ci",
       status: "completed",
       conclusion: "success",
       attempt: 1,
@@ -566,6 +587,7 @@ test("CI completion verdict comes from the completed matching workflow run, not 
     let downloads = 0;
     const cell = {
       rootDir,
+      settings: ciSettings(),
       now: () => "2026-09-09T00:00:00.000Z",
       cellCodedError: (_code: string, message: string) => new Error(message),
       store: {

--- a/packages/daemon/test/json-rpc-protocol.test.ts
+++ b/packages/daemon/test/json-rpc-protocol.test.ts
@@ -1671,6 +1671,7 @@ async function publishCiObservation(
   try {
     const cell = {
       rootDir,
+      settings: { read: () => ({ ci: { workflows: ["rewrite-ci", "rebuild-gates"] } }) },
       store,
       projection,
       now: () => "2026-09-09T00:00:00.000Z",
@@ -1681,7 +1682,7 @@ async function publishCiObservation(
         return JSON.stringify([{ databaseId, headBranch: "main", createdAt: "2026-09-09T00:00:00.000Z" }]);
       if (args[1] === "view")
         return JSON.stringify({
-          workflowName: verified ? "rewrite-ci" : "rebuild-gates",
+          workflowName: verified ? "rewrite-ci" : "other-ci",
           headSha: commitSha,
           headBranch: "main",
           status: "completed",

--- a/packages/daemon/test/repo-cell-settings.integration.test.ts
+++ b/packages/daemon/test/repo-cell-settings.integration.test.ts
@@ -27,9 +27,14 @@ test("settings writes reject catalog-inconsistent vertical, preset, and profile 
       before = readFileSync(configPath, "utf8");
     const read = await cell.run({ kind: "settings-read" }, binding);
     assert.equal(read.outcome, "applied", JSON.stringify(read));
-    const catalogSettings = (read as typeof read & { readonly settings?: { readonly locale?: string } }).settings,
+    const catalogSettings = (
+        read as typeof read & {
+          readonly settings?: { readonly locale?: string; readonly ci?: { readonly workflows: readonly string[] } };
+        }
+      ).settings,
       initialRevision = read.revision!;
     assert.equal(catalogSettings?.locale, "en-US");
+    assert.deepEqual(catalogSettings?.ci?.workflows, ["ci"]);
     for (const selection of [
       { defaultVertical: "software/coding", defaultPreset: "standard-task", defaultProfile: "prose" },
       { defaultVertical: "other/vertical", defaultPreset: "standard-task", defaultProfile: "baseline" },
@@ -180,6 +185,8 @@ function initRepo(root: string): void {
       "    bytes: 8388608",
       "    milliseconds: 2000",
       "  locale: en-US",
+      "  ci:",
+      "    workflows: [ci]",
       "  scaffolds:",
       "    task: governance/task-scaffold.json",
       "    repository: governance/repository-scaffold.json",

--- a/packages/gui/test/service-bridge.test.ts
+++ b/packages/gui/test/service-bridge.test.ts
@@ -292,6 +292,7 @@ test("GUI client reaches every shipped read through a real resident daemon", asy
         repository: "governance/repository-scaffold.json",
       },
       walFlush: { adaptive: true, events: 256, bytes: 8_388_608, milliseconds: 3_600_000 },
+      ci: { workflows: ["rewrite-ci"] },
     });
     const settingsUpdated = parseDaemonGuiActionResponse(
       "repo.settings.update",

--- a/packages/kernel/src/domain/ci-run-observation-event.ts
+++ b/packages/kernel/src/domain/ci-run-observation-event.ts
@@ -50,7 +50,7 @@ export type CiRunObservationGateV2 = {
 
 export type CiWorkflowVerification = {
   readonly source: "github-actions" | "write-coordinator";
-  readonly workflow: "rewrite-ci" | "ledger-publication";
+  readonly workflow: string;
   readonly runId: string;
   readonly attempt: number;
   readonly headSha: string;
@@ -168,7 +168,7 @@ function validVerification(value: unknown, run: unknown): boolean {
     isRecord(run) &&
     hasContractFields(value, ["source", "workflow", "runId", "attempt", "headSha", "conclusion"], false) &&
     value.source === "github-actions" &&
-    value.workflow === "rewrite-ci" &&
+    nonEmpty(value.workflow) &&
     typeof value.runId === "string" &&
     /^[1-9][0-9]*$/u.test(value.runId) &&
     Number.isSafeInteger(value.attempt) &&

--- a/packages/kernel/src/domain/settings-action-contract.ts
+++ b/packages/kernel/src/domain/settings-action-contract.ts
@@ -214,6 +214,7 @@ export function compileSettingsUpdate(input: EntityActionCompileInput): Settings
         bytes: updatedPositiveInteger(input.action, "walFlushBytes", current.walFlush.bytes),
         milliseconds: updatedPositiveInteger(input.action, "walFlushMilliseconds", current.walFlush.milliseconds),
       },
+      ci: current.ci,
       restoreDrillRetention: updatedPositiveInteger(
         input.action,
         "restoreDrillRetention",

--- a/packages/kernel/src/domain/settings-event.ts
+++ b/packages/kernel/src/domain/settings-event.ts
@@ -154,6 +154,7 @@ function validSettingsSnapshot(value: unknown, allowUnknownFields: boolean): boo
               milliseconds: value.walFlush.milliseconds,
             }
           : (value.walFlush ?? DEFAULT_WAL_FLUSH_SETTINGS),
+      ci: value.ci ?? INITIAL_SETTINGS_V1.ci,
       restoreDrillRetention: value.restoreDrillRetention ?? DEFAULT_RESTORE_DRILL_RETENTION,
     },
     current = validateRepositorySettings(normalized).length === 0;
@@ -172,6 +173,7 @@ function validSettingsSnapshot(value: unknown, allowUnknownFields: boolean): boo
           "reviewReturnBudget",
           "scaffolds",
           "walFlush",
+          "ci",
           "restoreDrillRetention",
         ].includes(field),
       )

--- a/packages/kernel/src/domain/settings.ts
+++ b/packages/kernel/src/domain/settings.ts
@@ -9,7 +9,7 @@ export type SettingsLocale = (typeof settingsLocales)[number];
 export const reviewIndependenceLevels = ["execution", "principal"] as const;
 export type ReviewIndependence = (typeof reviewIndependenceLevels)[number];
 export const DEFAULT_RESTORE_DRILL_RETENTION = 3;
-export const DEFAULT_CI_WORKFLOWS = Object.freeze(["rewrite-ci", "rebuild-gates"] as const);
+export const DEFAULT_CI_WORKFLOWS = Object.freeze(["rewrite-ci"] as const);
 
 export interface WalFlushSettingsV1 {
   readonly adaptive: boolean;

--- a/packages/kernel/src/domain/settings.ts
+++ b/packages/kernel/src/domain/settings.ts
@@ -9,6 +9,7 @@ export type SettingsLocale = (typeof settingsLocales)[number];
 export const reviewIndependenceLevels = ["execution", "principal"] as const;
 export type ReviewIndependence = (typeof reviewIndependenceLevels)[number];
 export const DEFAULT_RESTORE_DRILL_RETENTION = 3;
+export const DEFAULT_CI_WORKFLOWS = Object.freeze(["rewrite-ci", "rebuild-gates"] as const);
 
 export interface WalFlushSettingsV1 {
   readonly adaptive: boolean;
@@ -37,6 +38,7 @@ export const SETTINGS_FIELD_OWNERSHIP = Object.freeze({
   locale: "local",
   scaffolds: "repository",
   walFlush: "repository",
+  ci: "repository",
   restoreDrillRetention: "repository",
 } as const);
 
@@ -62,6 +64,7 @@ export interface RepositorySettingsV1 {
     readonly repository: string;
   };
   readonly walFlush: WalFlushSettingsV1;
+  readonly ci: { readonly workflows: readonly string[] };
   readonly restoreDrillRetention: number;
 }
 
@@ -84,6 +87,7 @@ export interface SettingsV1 {
     readonly repository: string;
   };
   readonly walFlush: WalFlushSettingsV1;
+  readonly ci: { readonly workflows: readonly string[] };
   readonly restoreDrillRetention: number;
 }
 
@@ -113,6 +117,7 @@ export const INITIAL_SETTINGS_V1: SettingsV1 = Object.freeze({
     repository: "governance/repository-scaffold.json",
   }),
   walFlush: DEFAULT_WAL_FLUSH_SETTINGS,
+  ci: Object.freeze({ workflows: DEFAULT_CI_WORKFLOWS }),
   restoreDrillRetention: DEFAULT_RESTORE_DRILL_RETENTION,
 });
 
@@ -170,6 +175,7 @@ export const SETTINGS_V1_SCHEMA: EntityDocumentJsonSchema<SettingsV1> = {
       additionalProperties: false,
     },
     walFlush: walFlushSchema(),
+    ci: ciSettingsSchema(),
     restoreDrillRetention: ownedSchema("restoreDrillRetention", { type: "integer", minimum: 1 }),
   },
   required: [
@@ -227,6 +233,7 @@ export const SETTINGS_REPOSITORY_V1_SCHEMA: EntityDocumentJsonSchema<RepositoryS
       additionalProperties: false,
     },
     walFlush: walFlushSchema(),
+    ci: ciSettingsSchema(),
     restoreDrillRetention: ownedSchema("restoreDrillRetention", { type: "integer", minimum: 1 }),
   },
   required: ["schema", "settingsId", "defaultVertical", "defaultPreset", "defaultProfile", "scaffolds", "walFlush"],
@@ -248,6 +255,7 @@ export function repositorySettings(settings: SettingsV1 | RepositorySettingsV1):
     reviewReturnBudget: settings.reviewReturnBudget ?? INITIAL_SETTINGS_V1.reviewReturnBudget,
     scaffolds: { task: settings.scaffolds.task, repository: settings.scaffolds.repository },
     walFlush: settings.walFlush ?? DEFAULT_WAL_FLUSH_SETTINGS,
+    ci: settings.ci ?? INITIAL_SETTINGS_V1.ci,
     restoreDrillRetention: settings.restoreDrillRetention ?? DEFAULT_RESTORE_DRILL_RETENTION,
   };
 }
@@ -283,6 +291,7 @@ export function readSettingsFacet(body: string): SettingsV1 {
       repository: settingBlockValue(body, "scaffolds", "repository") ?? INITIAL_SETTINGS_V1.scaffolds.repository,
     },
     walFlush: readWalFlushSettings(body),
+    ci: readCiSettings(body),
     restoreDrillRetention: readRestoreDrillRetention(body),
   };
   const errors = validateSettingsV1(settings);
@@ -372,6 +381,43 @@ function walFlushSchema() {
     required: ["adaptive", "events", "bytes", "milliseconds"],
     additionalProperties: false,
   };
+}
+
+function ciSettingsSchema() {
+  return {
+    ...ownedSchema("ci", {}),
+    type: "object" as const,
+    properties: {
+      workflows: ownedSchema("ci", {
+        type: "array" as const,
+        items: { type: "string" as const, pattern: settingValuePattern, minLength: 1 },
+        minItems: 1,
+        uniqueItems: true,
+      }),
+    },
+    required: ["workflows"],
+    additionalProperties: false,
+  };
+}
+
+function readCiSettings(body: string): SettingsV1["ci"] {
+  const section = /^  ci:[^\S\r\n]*(?:\r?\n)((?:    [^\r\n]*(?:\r?\n|$))*)/mu.exec(body)?.[1];
+  if (section === undefined) return INITIAL_SETTINGS_V1.ci;
+  const raw = settingBlockValue(body, "ci", "workflows");
+  if (raw === undefined) throw new Error("settings.ci.workflows must be a non-empty inline array of workflow names");
+  if (!raw.startsWith("[") || !raw.endsWith("]"))
+    throw new Error("settings.ci.workflows must be a non-empty inline array of workflow names");
+  const workflows = raw
+    .slice(1, -1)
+    .split(",")
+    .map((workflow) => workflow.trim());
+  if (
+    workflows.length === 0 ||
+    workflows.some((workflow) => !new RegExp(settingValuePattern, "u").test(workflow) || /\.ya?ml$/u.test(workflow)) ||
+    new Set(workflows).size !== workflows.length
+  )
+    throw new Error("settings.ci.workflows must contain unique workflow names without .yml");
+  return { workflows };
 }
 
 function readWalFlushSettings(body: string): WalFlushSettingsV1 {

--- a/packages/kernel/src/schemas/registry.ts
+++ b/packages/kernel/src/schemas/registry.ts
@@ -84,6 +84,11 @@ export const HarnessConfigSchema = Schema.Struct({
           wipLimit: Schema.optional(TaskWipLimitSchema),
         }),
       ),
+      ci: Schema.optional(
+        Schema.Struct({
+          workflows: Schema.Array(ConfigIdentifierSchema).pipe(Schema.minItems(1)),
+        }),
+      ),
       identity: Schema.optional(
         Schema.Struct({
           personId: ConfigIdentifierSchema,

--- a/packages/kernel/test/layout/harness-settings.test.ts
+++ b/packages/kernel/test/layout/harness-settings.test.ts
@@ -37,8 +37,8 @@ test("a key absent from the block reads as absent", () => {
   assert.equal(settingBlockValue(body, "absentBlock", "wipLimit"), undefined);
 });
 
-test("CI workflows default to the established pair and accept configured workflow basenames", () => {
-  assert.deepEqual(readSettingsFacet(body).ci.workflows, ["rewrite-ci", "rebuild-gates"]);
+test("CI workflows default to rewrite-ci and accept configured workflow basenames", () => {
+  assert.deepEqual(readSettingsFacet(body).ci.workflows, ["rewrite-ci"]);
   assert.deepEqual(readSettingsFacet(`${body}\n  ci:\n    workflows: [ci]\n`).ci.workflows, ["ci"]);
 });
 

--- a/packages/kernel/test/layout/harness-settings.test.ts
+++ b/packages/kernel/test/layout/harness-settings.test.ts
@@ -2,6 +2,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { setting, settingBlockValue } from "../../src/layout/index.ts";
+import { readSettingsFacet } from "../../src/index.ts";
 
 const body = [
   "schema: harness-anything/v1",
@@ -12,7 +13,7 @@ const body = [
   "    wipLimit: 50  # bigger team, raised deliberately",
   "  scaffolds:",
   "    task: governance/task-scaffold.json",
-  ""
+  "",
 ].join("\n");
 
 test("an annotated setting keeps its authored value instead of falling back", () => {
@@ -34,4 +35,16 @@ test("a key absent from the block reads as absent", () => {
   assert.equal(setting(body, "defaultProfile"), undefined);
   assert.equal(settingBlockValue(body, "tasks", "missing"), undefined);
   assert.equal(settingBlockValue(body, "absentBlock", "wipLimit"), undefined);
+});
+
+test("CI workflows default to the established pair and accept configured workflow basenames", () => {
+  assert.deepEqual(readSettingsFacet(body).ci.workflows, ["rewrite-ci", "rebuild-gates"]);
+  assert.deepEqual(readSettingsFacet(`${body}\n  ci:\n    workflows: [ci]\n`).ci.workflows, ["ci"]);
+});
+
+test("CI workflows fail closed on empty, duplicate, extension-bearing, or block arrays", () => {
+  for (const workflows of ["[]", "[ci, ci]", "[ci.yml]", "", "\n      - ci"]) {
+    const configured = `${body}\n  ci:\n    workflows: ${workflows}\n`;
+    assert.throws(() => readSettingsFacet(configured), /settings\.ci\.workflows/u);
+  }
 });


### PR DESCRIPTION
# English

## Summary

task_217ab535a5067d9d98d6e5fde3, slice 1 (泽宇 2026-09-12: the completion witness must not hard-wire this repository's GitHub workflow names; a downstream user of Harness Anything, ai4s with a plain `ci.yml`, gets 404/service_rejected from `ha ci observe pull` and can never complete a code task). The workflow names were literals in `fetchCiObservations` (`["rewrite-ci.yml", "rebuild-gates.yml"]`) and the verification branch counted only `workflowName === "rewrite-ci"`. They now come from one repository setting, `settings.ci.workflows` in `harness.yaml` (basenames, no `.yml`), read by both the listing and the verification branch, so whatever a repository declares as its CI is what `ha ci observe pull` lists and what `task complete --ci` accepts. The default is `["rewrite-ci"]`: the worker's first cut defaulted to the old pair, but with the verification branch now keyed on the same list a rebuild-gates-only success would have become an accepted completion witness, which loosens the gate; rebuild-gates has no production consumer of its observations (`grep -rn rebuild-gates packages/*/src` finds only the default constant) and task_9a1058d0 folds it into rewrite-ci anyway. Kernel's `CiWorkflowVerification.workflow` widens from the two-literal union to a non-empty string.

## Architectural Justification

-

## What Changed

- `packages/kernel/src/domain/settings.ts`: `ci.workflows` facet (non-empty inline array of workflow basenames, fail-closed on empty, duplicates, `.yml` suffixes, block lists); `DEFAULT_CI_WORKFLOWS = ["rewrite-ci"]`; settings event/contract/schema carry the field.
- `packages/daemon/src/ci-observation-actions.ts`: listing and `--run` import iterate the configured workflows; the verification branch accepts any configured workflow name and records it.
- `packages/kernel/src/domain/ci-run-observation-event.ts`: workflow is a non-empty string.
- Tests: `harness-settings.test.ts`, `ci-observatory-read.test.ts`, `repo-cell-settings.integration.test.ts`, `json-rpc-protocol.test.ts` (settings stub).

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: +70/-11.

## Machine-Readable Declarations

- None.

## Task And Scope

- Harness task: task_217ab535a5067d9d98d6e5fde3 (slice 1 of completion witness by task type), parent task_4455977a529becac425737d812
- Branch: `codex/ci-workflows-setting`
- Public scope: CI observation source configuration and verification keying
- Private planning/evidence updated: yes (`artifacts/report.md`, fact F-DE45E09A)
- Out of scope: slice 2 (ledger-publication default for docs/design tasks by preset); `--workflow` CLI flag

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no (workflow files unchanged; the setting only names which workflows are observed)
- Protected surface scope: not applicable
- Authority: not applicable
- Machine-check boundary: not applicable
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `b1a124616`
- Branch merge-base with `origin/main`: `b1a124616`
- Last `git fetch origin` time: 2026-09-12 UTC
- Sync method: rebase onto origin/main
- Public diff command: `git diff origin/main...codex/ci-workflows-setting`
- Private evidence commit/path: task_217ab535a5067d9d98d6e5fde3 `artifacts/report.md`
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [x] `npm run typecheck` (`npx tsc -b packages/kernel packages/daemon`, CEO)
- [ ] `npm run check`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts` (via `run-manifest-gates --changed origin/main`, CEO)
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- CEO after rebase and default change: `harness-settings.test.ts` + `ci-observatory-read.test.ts` + `repo-cell-settings.integration.test.ts` 17/17. Worker (isolated Ubuntu): targeted 22/22, `json-rpc-protocol` 51/51, settings integration 1/1.

## Review Evidence

- CEO ground-truth: read the production diff; changed the default from the old pair to `["rewrite-ci"]` because the verification branch now keys on the same list (see Summary); no other consumer of rebuild-gates observations exists.
- Reviewer subagent: pending (closeout review after merge)
- Human review: pending
- Blocking findings: none open

## Residual Risk

- rebuild-gates runs are no longer pulled into the observatory by default until task_9a1058d0 merges the workflows; a repository can list it explicitly in `settings.ci.workflows` if it wants both, accepting that either then verifies.
- The ai4s live run (34608614686 on `ci.yml`) is verified only after deploy: `ha ci observe pull --run 34608614686` then `task complete --ci`.

## References

- Task: task_217ab535a5067d9d98d6e5fde3; task_9a1058d0 (merge rebuild-gates into rewrite-ci)

---

# 中文

## 概要

task_217ab535a5067d9d98d6e5fde3 切片 1（泽宇 2026-09-12：completion witness 不该写死本仓的 GitHub workflow 名；下游使用者 ai4s 只有一个普通 `ci.yml`，`ha ci observe pull` 报 404/service_rejected，代码任务永远收不了口）。workflow 名原来是 `fetchCiObservations` 里的字面量（`["rewrite-ci.yml", "rebuild-gates.yml"]`），校验分支只认 `workflowName === "rewrite-ci"`。现在统一来自 `harness.yaml` 的 `settings.ci.workflows`（basename，不带 `.yml`），列表与校验分支读同一份，仓库声明什么 CI，`ha ci observe pull` 就列什么、`task complete --ci` 就认什么。缺省是 `["rewrite-ci"]`：worker 第一版缺省沿用旧的一对，但校验分支现在按同一列表判定，rebuild-gates 单独绿就会成为被接受的完成见证，等于削门；rebuild-gates 的观察没有任何生产消费者（`grep -rn rebuild-gates packages/*/src` 只剩缺省常量），且 task_9a1058d0 本来就要把它并入 rewrite-ci。kernel 的 `CiWorkflowVerification.workflow` 由两字面量联合放宽为非空字符串。

## 架构辩护

-

## 改动内容

- `packages/kernel/src/domain/settings.ts`：`ci.workflows` facet（非空内联数组、basename；空、重复、`.yml` 后缀、block list 一律 fail-closed）；`DEFAULT_CI_WORKFLOWS = ["rewrite-ci"]`；settings event/contract/schema 带该字段。
- `packages/daemon/src/ci-observation-actions.ts`：列表与 `--run` 导入遍历配置的 workflows；校验分支接受任一配置的 workflow 名并记录。
- `packages/kernel/src/domain/ci-run-observation-event.ts`：workflow 为非空字符串。
- 测试：`harness-settings.test.ts`、`ci-observatory-read.test.ts`、`repo-cell-settings.integration.test.ts`、`json-rpc-protocol.test.ts`（settings 桩）。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 删除的门或 fixture：none
- 生产净行数：+70/-11。

## 机器可读声明

- 无。

## 任务与范围

- Harness 任务：task_217ab535a5067d9d98d6e5fde3（completion witness 按任务类型，切片 1），父任务 task_4455977a529becac425737d812
- 分支：`codex/ci-workflows-setting`
- 公开范围：CI 观察来源配置与校验键
- 私有计划/证据已更新：是（`artifacts/report.md`，fact F-DE45E09A）
- 范围外：切片 2（docs/设计类按 preset 缺省 ledger-publication）；`--workflow` CLI 参数

## 版本影响

- 版本：不变
- 发布影响：不发布

## 治理声明

- 触碰受保护面：否（workflow 文件不变；设置只声明观察哪些 workflow）
- 受保护面范围：不适用
- 授权：不适用
- 机器检查边界：不适用
- Break-glass：否
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- 基线 `origin/main` SHA：`b1a124616`
- 分支与 `origin/main` 的 merge-base：`b1a124616`
- 最近一次 `git fetch origin`：2026-09-12 UTC
- 同步方式：rebase 到 origin/main
- 公开 diff 命令：`git diff origin/main...codex/ci-workflows-setting`
- 私有证据路径：task_217ab535a5067d9d98d6e5fde3 的 `artifacts/report.md`
- 评审证据路径：本 PR 的评审证据节
- GitHub Actions `rewrite-ci` run URL：本 PR 待跑
- CEO rebase 并改缺省后：`harness-settings.test.ts` + `ci-observatory-read.test.ts` + `repo-cell-settings.integration.test.ts` 17/17；`npx tsc -b packages/kernel packages/daemon` 通过；`run-manifest-gates --changed origin/main` 通过。worker 隔离 Ubuntu：定向 22/22、`json-rpc-protocol` 51/51、settings 集成 1/1。

## 评审证据

- CEO 事实核对：读过生产 diff；把缺省从旧的一对改为 `["rewrite-ci"]`，理由见概要；rebuild-gates 观察没有其它消费者。
- 评审子代理：待定（合入后派收口评审）
- 人工评审：待定
- 阻塞发现：无

## 残余风险

- 在 task_9a1058d0 合并 workflow 之前，rebuild-gates 的 run 缺省不再进观察台；仓库可在 `settings.ci.workflows` 显式列出，但要接受两者任一都可作见证。
- ai4s 的真实 run（`ci.yml` 上的 34608614686）要部署后才能验：`ha ci observe pull --run 34608614686` 再 `task complete --ci`。

## 参考

- 任务：task_217ab535a5067d9d98d6e5fde3；task_9a1058d0（rebuild-gates 并入 rewrite-ci）
