### PR TITLE
feat(daemon): expose squad attempt runtime metrics

### DIFF
--- a/packages/cli/src/cli/receipt-render-registry.ts
+++ b/packages/cli/src/cli/receipt-render-registry.ts
@@ -33,6 +33,7 @@ const commandRenderers = new Map<string, ReceiptRenderer>([
   ["schedule-show", renderScheduleReceipt],
   ["schedule-runs", renderScheduleReceipt],
   ["squad-list", renderSquadListReceipt],
+  ["squad-status", renderSquadStatusReceipt],
 ]);
 
 const preOutcomeCommandRenderers = new Map<string, ReceiptRenderer>([["runtime-batch", renderRuntimeBatchReceipt]]);
@@ -142,6 +143,26 @@ function renderSquadListReceipt(receipt: Record<string, unknown>): string {
   if (!parsed || parsed.schema !== "squad-list/v1" || !Array.isArray(parsed.squads))
     return renderSuccessfulReceipt(receipt);
   return parsed.squads.length === 0 ? "No squads." : parsed.squads.map(squadListColumns).join("\n");
+}
+
+function renderSquadStatusReceipt(receipt: Record<string, unknown>): string {
+  const leaders = Array.isArray(receipt.leaders) ? receipt.leaders : [],
+    workers = Array.isArray(receipt.workers) ? receipt.workers : [];
+  return [
+    String(receipt.summary ?? "squad-status"),
+    ...leaders.map((turn, index) => squadAttemptLine("leader", index + 1, turn)),
+    ...workers.map((attempt, index) => squadAttemptLine("worker", index + 1, attempt)),
+  ].join("\n");
+}
+
+function squadAttemptLine(kind: string, index: number, value: unknown): string {
+  if (!isRecord(value)) throw new TypeError(`Squad ${kind} metrics are invalid.`);
+  const usage = isRecord(value.tokenUsage) ? value.tokenUsage : {};
+  return (
+    `${kind} ${String(value.turnId ?? value.attemptId ?? index)}: status=${String(value.status ?? "unknown")}` +
+    ` tokens=${String(usage.input ?? 0)}in/${String(usage.output ?? 0)}out` +
+    ` tools=${String(value.toolCallCount ?? 0)} compacted=${String(value.compacted ?? false)}`
+  );
 }
 
 function parseEvidence(receipt: Record<string, unknown>): Record<string, unknown> | null {

--- a/packages/cli/test/squad-status-render.test.ts
+++ b/packages/cli/test/squad-status-render.test.ts
@@ -1,0 +1,39 @@
+// harness-test-tier: fast
+import assert from "node:assert/strict";
+import test from "node:test";
+import { renderCliReceipt } from "../src/cli/receipt-render-registry.ts";
+
+test("Squad status renders token, tool-call, and compaction metrics for each attempt", () => {
+  const rendered = renderCliReceipt({
+    ok: true,
+    command: "squad-status",
+    summary: "squad-run core-squad: converged",
+    leaders: [
+      {
+        turnId: "leader-1",
+        status: "succeeded",
+        tokenUsage: { input: 120, output: 30 },
+        toolCallCount: 4,
+        compacted: true,
+      },
+    ],
+    workers: [
+      {
+        attemptId: "worker-1",
+        status: "succeeded",
+        tokenUsage: { input: 80, output: 20 },
+        toolCallCount: 2,
+        compacted: false,
+      },
+    ],
+  });
+
+  assert.deepEqual(rendered, {
+    stream: "stdout",
+    text: [
+      "squad-run core-squad: converged",
+      "leader leader-1: status=succeeded tokens=120in/30out tools=4 compacted=true",
+      "worker worker-1: status=succeeded tokens=80in/20out tools=2 compacted=false",
+    ].join("\n"),
+  });
+});

--- a/packages/daemon/src/squad-coordinator.ts
+++ b/packages/daemon/src/squad-coordinator.ts
@@ -885,10 +885,14 @@ export function makeSquadCoordinator(input: {
       revision: state.revision,
       currentLeaderRuntimeSessionId: state.currentLeaderRuntimeSessionId,
       leaderRuntimeSessionIds: state.leaderTurns.map((turn) => turn.runtimeSessionId),
-      leaders: state.leaderTurns.map((turn) => ({ ...byDispatchId.get(turn.dispatchId), ...turn })),
+      leaders: state.leaderTurns.map((turn) => {
+        const row = byDispatchId.get(turn.dispatchId);
+        return { ...row, ...turn, ...attemptMetrics(row) };
+      }),
       workers: state.workerAttempts.map((attempt) => ({
         ...(attempt.dispatchId ? byDispatchId.get(attempt.dispatchId) : undefined),
         ...attempt,
+        ...attemptMetrics(attempt.dispatchId ? byDispatchId.get(attempt.dispatchId) : undefined),
       })),
       workerCallbackCount: state.observedWorkerRuntimeSessionIds.length,
       pendingLeaderCallbackCount: state.pendingLeaderTriggers.length + state.workerWaits.length,
@@ -933,6 +937,7 @@ export function makeSquadCoordinator(input: {
             status: row?.status ?? null,
             startedAt: row?.startedAt ?? null,
             endedAt: row?.endedAt ?? null,
+            ...attemptMetrics(row),
           };
         }),
         workerAttempts: state.workerAttempts.map((attempt) => {
@@ -948,6 +953,7 @@ export function makeSquadCoordinator(input: {
             status: row?.status ?? null,
             startedAt: row?.startedAt ?? null,
             endedAt: row?.endedAt ?? null,
+            ...attemptMetrics(row),
           };
         }),
       },
@@ -989,6 +995,17 @@ export function makeSquadCoordinator(input: {
     if (terminal(state) || state.currentLeaderRuntimeSessionId === null) return state.phase;
     const leader = input.projection().readRuntimeSession(state.currentLeaderRuntimeSessionId);
     return leader && runtimeSessionSemanticState(leader) === "cancelled" ? "cancelled" : state.phase;
+  }
+
+  function attemptMetrics(row: TaskDispatchRow | undefined) {
+    return {
+      tokenUsage: {
+        input: row?.metrics?.inputTokens ?? 0,
+        output: row?.metrics?.outputTokens ?? 0,
+      },
+      toolCallCount: row?.metrics?.toolCallCount ?? 0,
+      compacted: row?.metrics?.compacted ?? false,
+    };
   }
 
   return { start, status, cancel, list, read, observeOutcome, reconcile };

--- a/packages/daemon/src/squad-run-contract.ts
+++ b/packages/daemon/src/squad-run-contract.ts
@@ -46,6 +46,11 @@ export type SquadRunDecisionDto =
   | { readonly kind: "converged" }
   | { readonly kind: "plan"; readonly dispatchCount: number };
 export type SquadRunTurnStatus = "running" | "succeeded" | "failed" | "unknown" | "cancelled" | "lost";
+export interface SquadRunAttemptMetricsDto {
+  readonly tokenUsage: { readonly input: number; readonly output: number };
+  readonly toolCallCount: number;
+  readonly compacted: boolean;
+}
 export interface SquadRunLeaderTurnDto {
   readonly turnId: string;
   readonly trigger: SquadRunTriggerDto;
@@ -57,6 +62,9 @@ export interface SquadRunLeaderTurnDto {
   readonly status: SquadRunTurnStatus | null;
   readonly startedAt: string | null;
   readonly endedAt: string | null;
+  readonly tokenUsage: SquadRunAttemptMetricsDto["tokenUsage"];
+  readonly toolCallCount: number;
+  readonly compacted: boolean;
 }
 export interface SquadRunWorkerAttemptDto {
   readonly attemptId: string;
@@ -74,6 +82,9 @@ export interface SquadRunWorkerAttemptDto {
   readonly status: SquadRunTurnStatus | null;
   readonly startedAt: string | null;
   readonly endedAt: string | null;
+  readonly tokenUsage: SquadRunAttemptMetricsDto["tokenUsage"];
+  readonly toolCallCount: number;
+  readonly compacted: boolean;
 }
 /** `ha squad status` 的 statusDto 对 GUI 开放的编排流转扇出树(leaderTurnId 是
  * 父子边,turn.resultText 是该轮 receipt 原文):全部来自 SquadState、既有派工
@@ -193,6 +204,9 @@ function validSquadRunLeaderTurn(value: unknown): value is SquadRunLeaderTurnDto
       "status",
       "startedAt",
       "endedAt",
+      "tokenUsage",
+      "toolCallCount",
+      "compacted",
     ]) &&
     [value.turnId, value.dispatchId, value.runtimeSessionId].every(squadRunText) &&
     (value.resultText === null || squadRunText(value.resultText)) &&
@@ -200,7 +214,8 @@ function validSquadRunLeaderTurn(value: unknown): value is SquadRunLeaderTurnDto
     (value.decision === null || validSquadRunDecision(value.decision)) &&
     (value.status === null || turnStatuses.includes(value.status as SquadRunTurnStatus)) &&
     (value.startedAt === null || squadRunIso(value.startedAt)) &&
-    (value.endedAt === null || squadRunIso(value.endedAt))
+    (value.endedAt === null || squadRunIso(value.endedAt)) &&
+    validSquadRunAttemptMetrics(value)
   );
 }
 
@@ -219,6 +234,9 @@ function validSquadRunWorkerAttempt(value: unknown): value is SquadRunWorkerAtte
         "status",
         "startedAt",
         "endedAt",
+        "tokenUsage",
+        "toolCallCount",
+        "compacted",
       ],
       ["worktree"],
     ) &&
@@ -234,7 +252,19 @@ function validSquadRunWorkerAttempt(value: unknown): value is SquadRunWorkerAtte
     (value.rejection === null || squadRunText(value.rejection)) &&
     (value.status === null || turnStatuses.includes(value.status as SquadRunTurnStatus)) &&
     (value.startedAt === null || squadRunIso(value.startedAt)) &&
-    (value.endedAt === null || squadRunIso(value.endedAt))
+    (value.endedAt === null || squadRunIso(value.endedAt)) &&
+    validSquadRunAttemptMetrics(value)
+  );
+}
+
+function validSquadRunAttemptMetrics(value: Readonly<Record<string, unknown>>): boolean {
+  return (
+    squadRunRecord(value.tokenUsage) &&
+    exactSquadRunFields(value.tokenUsage, ["input", "output"]) &&
+    squadRunCount(value.tokenUsage.input) &&
+    squadRunCount(value.tokenUsage.output) &&
+    squadRunCount(value.toolCallCount) &&
+    typeof value.compacted === "boolean"
   );
 }
 
@@ -340,7 +370,10 @@ function squadRunSafeKeys(value: unknown): boolean {
   if (Array.isArray(value)) return value.every(squadRunSafeKeys);
   if (!squadRunRecord(value)) return true;
   for (const [key, nested] of Object.entries(value)) {
-    if (/(?:credential|password|secret|authorization|api[-_]?key|token|transcript|stdout|stderr)/iu.test(key))
+    if (
+      key !== "tokenUsage" &&
+      /(?:credential|password|secret|authorization|api[-_]?key|token|transcript|stdout|stderr)/iu.test(key)
+    )
       return false;
     if (!squadRunSafeKeys(nested)) return false;
   }

--- a/packages/daemon/test/squad-run-detail-read.test.ts
+++ b/packages/daemon/test/squad-run-detail-read.test.ts
@@ -67,6 +67,16 @@ function seedRunningSquadRun(rootDir: string, squadRunId: string): void {
       error: null,
     },
   });
+  appendRuntimeWorkerRecord(rootDir, "dispatch_00000000000000000000a1b2", {
+    kind: "runtime_metrics",
+    inputTokens: 120,
+    cacheReadTokens: 20,
+    outputTokens: 30,
+    totalTokens: 150,
+    toolCallCount: 4,
+    compacted: true,
+    raw: { input_tokens: 120, output_tokens: 30 },
+  });
 }
 
 /** leader 派工的归档结算行:outcome/resultRef 是 receipt 原文的既有时实来源。 */
@@ -211,6 +221,19 @@ test("a settled leader turn carries its receipt verbatim and its dispatches link
     assert.equal(detail.run.workerAttempts[0]?.leaderTurnId, "leader-1");
     assert.equal(detail.run.workerAttempts[0]?.workerId, "sol");
     assert.equal(detail.run.workerAttempts[0]?.runtimeSessionId, "runtime-worker-1");
+    assert.deepEqual(detail.run.leaderTurns[0]?.tokenUsage, { input: 120, output: 30 });
+    assert.equal(detail.run.leaderTurns[0]?.toolCallCount, 4);
+    assert.equal(detail.run.leaderTurns[0]?.compacted, true);
+    assert.deepEqual(detail.run.workerAttempts[0]?.tokenUsage, { input: 0, output: 0 });
+    assert.equal(detail.run.workerAttempts[0]?.toolCallCount, 0);
+    assert.equal(detail.run.workerAttempts[0]?.compacted, false);
+    const status = squad.status("squad_0123456789abcdef01234567"),
+      leader = (status.leaders as Array<Record<string, unknown>>)[0],
+      worker = (status.workers as Array<Record<string, unknown>>)[0];
+    assert.deepEqual(leader?.tokenUsage, { input: 120, output: 30 });
+    assert.equal(leader?.toolCallCount, 4);
+    assert.equal(leader?.compacted, true);
+    assert.deepEqual(worker?.tokenUsage, { input: 0, output: 0 });
     assert.deepEqual(validateSquadRunRead(detail), []);
   } finally {
     rmSync(rootDir, { recursive: true, force: true });

--- a/packages/daemon/test/squad-run-reads.contract.test.ts
+++ b/packages/daemon/test/squad-run-reads.contract.test.ts
@@ -52,6 +52,9 @@ const detail = {
         status: "succeeded" as const,
         startedAt: "2026-08-26T00:00:00.000Z",
         endedAt: "2026-08-26T00:05:00.000Z",
+        tokenUsage: { input: 120, output: 30 },
+        toolCallCount: 4,
+        compacted: true,
       },
       {
         turnId: "leader-2",
@@ -63,6 +66,9 @@ const detail = {
         status: null,
         startedAt: null,
         endedAt: null,
+        tokenUsage: { input: 0, output: 0 },
+        toolCallCount: 0,
+        compacted: false,
       },
       {
         turnId: "leader-3",
@@ -78,6 +84,9 @@ const detail = {
         status: "running" as const,
         startedAt: "2026-08-26T00:10:00.000Z",
         endedAt: null,
+        tokenUsage: { input: 0, output: 0 },
+        toolCallCount: 0,
+        compacted: false,
       },
       {
         turnId: "leader-4",
@@ -93,6 +102,9 @@ const detail = {
         status: "running" as const,
         startedAt: "2026-08-26T00:11:00.000Z",
         endedAt: null,
+        tokenUsage: { input: 0, output: 0 },
+        toolCallCount: 0,
+        compacted: false,
       },
     ],
     workerAttempts: [
@@ -106,6 +118,9 @@ const detail = {
         status: "succeeded" as const,
         startedAt: "2026-08-26T00:06:00.000Z",
         endedAt: "2026-08-26T00:09:00.000Z",
+        tokenUsage: { input: 80, output: 20 },
+        toolCallCount: 2,
+        compacted: false,
       },
       {
         attemptId: "worker-2",
@@ -117,6 +132,9 @@ const detail = {
         status: null,
         startedAt: null,
         endedAt: null,
+        tokenUsage: { input: 0, output: 0 },
+        toolCallCount: 0,
+        compacted: false,
       },
     ],
   },
@@ -255,6 +273,9 @@ test("squad run read accepts legacy worker attempts without a worktree", () => {
       status: null,
       startedAt: null,
       endedAt: null,
+      tokenUsage: { input: 0, output: 0 },
+      toolCallCount: 0,
+      compacted: false,
     },
   ];
   assert.deepEqual(validateSquadRunRead(legacy), []);


### PR DESCRIPTION
# English

## Summary

Observability-Eval P1.2 (task_114c7c07061e3d01695eed72ca, parent task_e7c14849c6803ed749a86870f2): squad run status and detail reads now project the per-attempt runtime metrics that P1.1 (PR #2492) records at settlement. Every leader turn and worker attempt carries `tokenUsage { input, output }`, `toolCallCount` and `compacted`, read from `TaskDispatchRow.metrics` through the existing dispatch-row join; rows settled before P1.1 render `0`/`false`. `ha squad status` human output prints one line per attempt with status, tokens, tool calls and compaction; the JSON shape keeps the established `leaders`/`workers` keys. The redaction filter no longer strips the `tokenUsage` key just because it contains the substring "token".

## Architectural Justification

-

## What Changed

- `packages/daemon/src/squad-run-contract.ts`: `SquadRunAttemptMetricsDto`; leader-turn and worker-attempt DTOs require the three metrics fields; validators enforce non-negative integer counts and a boolean `compacted`; `tokenUsage` exempted from the secret-key redaction regex.
- `packages/daemon/src/squad-coordinator.ts`: `attemptMetrics(row)` fills the fields from `TaskDispatchRow.metrics` in `statusDto` and `detailDto`; missing metrics default to zero/false.
- `packages/cli/src/cli/receipt-render-registry.ts`: `squad-status` receipt renderer prints per-attempt metric lines.
- Tests: `squad-run-detail-read.test.ts`, `squad-status-render.test.ts` (new), `squad-run-reads.contract.test.ts` wire fixture.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: +75/-4 (`packages/*/src`, tests excluded).

## Machine-Readable Declarations

- None.

## Task And Scope

- Harness task: task_114c7c07061e3d01695eed72ca (P1.2), parent task_e7c14849c6803ed749a86870f2
- Branch: `codex/obs-p1-2`
- Public scope: squad run DTO + coordinator projection + CLI receipt rendering
- Private planning/evidence updated: yes (`artifacts/report.md`, fact F-03C57804)
- Out of scope: GUI rendering of the metrics, aggregate totals per run, context-health thresholds (P1.3+)

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: not applicable
- Machine-check boundary: not applicable
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `229b36489`
- Branch merge-base with `origin/main`: `229b36489`
- Last `git fetch origin` time: 2026-09-12 UTC
- Sync method: branched from origin/main
- Public diff command: `git diff origin/main...codex/obs-p1-2`
- Private evidence commit/path: task_114c7c07061e3d01695eed72ca `artifacts/report.md`
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [x] `npm run typecheck` (worker, before commit and after rebase)
- [ ] `npm run check`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Worker: `node --test packages/daemon/test/squad-run-detail-read.test.ts packages/cli/test/squad-status-render.test.ts` 3/3; `squad-run-reads.contract.test.ts` 5/5 on the Ubuntu isolated runner; lint, line-density, file-complexity (squad-coordinator.ts 1075 lines), status-vocabulary, production-delta gates pass; `test:fast` 695/697 with the two failures being environment fixtures (Unix socket `EINVAL`, unrelated to this diff).

## Review Evidence

- CEO ground-truth: read the full diff; the `tokenUsage` redaction exemption is the minimal fix for a regex false positive on the substring "token".
- Reviewer subagent: pending (closeout review after merge)
- Human review: pending
- Blocking findings: none open

## Residual Risk

- Rows settled before P1.1 render `0`/`false`, which is indistinguishable from a measured zero at this DTO layer.
- A live `ha squad status --json` against a freshly settled provider attempt was not run by the worker (daemon state outside the isolated path); projection and renderer are covered by direct tests.

## References

- Task: task_114c7c07061e3d01695eed72ca; P1.1 PR #2492

---

# 中文

## 概要

Observability-Eval P1.2（task_114c7c07061e3d01695eed72ca，父任务 task_e7c14849c6803ed749a86870f2）：squad run 的 status/detail 读面现在投影 P1.1（PR #2492）结算时记录的 attempt 级运行指标。每个 leader turn 与 worker attempt 带 `tokenUsage { input, output }`、`toolCallCount`、`compacted`，经既有 dispatch-row join 从 `TaskDispatchRow.metrics` 读出；P1.1 之前结算的行降级为 `0`/`false`。`ha squad status` 人读输出每个 attempt 一行（状态、token、工具调用、是否压缩）；JSON 形状保留既有 `leaders`/`workers` 键。脱敏过滤不再因为 `tokenUsage` 含子串 "token" 而把它剥掉。

## 架构辩护

-

## 改动内容

- `packages/daemon/src/squad-run-contract.ts`：`SquadRunAttemptMetricsDto`；leader turn / worker attempt DTO 必带三个指标字段；校验器要求非负整数与布尔 `compacted`；`tokenUsage` 从密钥脱敏正则豁免。
- `packages/daemon/src/squad-coordinator.ts`：`attemptMetrics(row)` 在 `statusDto`/`detailDto` 里从 `TaskDispatchRow.metrics` 填字段；缺指标默认零/false。
- `packages/cli/src/cli/receipt-render-registry.ts`：`squad-status` 回执渲染逐 attempt 打印指标行。
- 测试：`squad-run-detail-read.test.ts`、`squad-status-render.test.ts`（新）、`squad-run-reads.contract.test.ts` wire fixture。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 删除的门或 fixture：none
- 生产净行数：+75/-4（`packages/*/src`，不含测试）。

## 机器可读声明

- 无。

## 任务与范围

- Harness 任务：task_114c7c07061e3d01695eed72ca（P1.2），父任务 task_e7c14849c6803ed749a86870f2
- 分支：`codex/obs-p1-2`
- 公开范围：squad run DTO + coordinator 投影 + CLI 回执渲染
- 私有计划/证据已更新：是（`artifacts/report.md`，fact F-03C57804）
- 范围外：GUI 渲染指标、每次 run 的聚合总量、上下文健康度阈值（P1.3+）

## 版本影响

- 版本：不变
- 发布影响：不发布

## 治理声明

- 触碰受保护面：否
- 受保护面范围：不适用
- 授权：不适用
- 机器检查边界：不适用
- Break-glass：否
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- 基线 `origin/main` SHA：`229b36489`
- 分支与 `origin/main` 的 merge-base：`229b36489`
- 最近一次 `git fetch origin`：2026-09-12 UTC
- 同步方式：从 origin/main 开分支
- 公开 diff 命令：`git diff origin/main...codex/obs-p1-2`
- 私有证据路径：task_114c7c07061e3d01695eed72ca 的 `artifacts/report.md`
- 评审证据路径：本 PR 的评审证据节
- GitHub Actions `rewrite-ci` run URL：本 PR 待跑
- worker：定向 3/3；contract 5/5（Ubuntu 隔离）；lint、line-density、file-complexity（squad-coordinator.ts 1075 行）、status-vocabulary、production-delta 门通过；`test:fast` 695/697，两个失败为环境 fixture（Unix socket `EINVAL`），与本 diff 无关。

## 评审证据

- CEO 事实核对：读过完整 diff；`tokenUsage` 脱敏豁免是对正则子串 "token" 误命中的最小修法。
- 评审子代理：待定（合入后派收口评审）
- 人工评审：待定
- 阻塞发现：无

## 残余风险

- P1.1 之前结算的行显示 `0`/`false`，在 DTO 层与实测为零不可区分。
- worker 未对新结算的真实 provider attempt 跑 `ha squad status --json`（会触碰隔离路径之外的 daemon 状态）；投影与渲染由直接测试覆盖。

## 参考

- 任务：task_114c7c07061e3d01695eed72ca；P1.1 PR #2492
