### PR TITLE
fix(daemon): spawn the squad leader with the same permission mode as its workers

### DIFF
--- a/packages/daemon/src/squad-coordinator.ts
+++ b/packages/daemon/src/squad-coordinator.ts
@@ -650,7 +650,7 @@ export function makeSquadCoordinator(input: {
           runtimeInstanceId: state.runtimeInstanceId,
           agentId: state.leaderAgentId,
           squadId: state.squadId,
-          permissionMode: state.permissionMode ?? "read-only",
+          ...(state.permissionMode ? { permissionMode: state.permissionMode } : {}),
           prompt,
           cwd: cwdPayload(input.rootDir, state.cwd),
           taskId: state.taskId,


### PR DESCRIPTION
# English

## Summary

Commander line task_aee7bf3633cd8ea2ecd3be4f4c Goal 2 follow-up ("permission mode consistent with workers"): `spawnLeader` in `squad-coordinator.ts` defaulted the leader turn to `read-only` whenever the squad run carried no explicit permission mode, while `spawnWorker` only forwards the run's mode when set and otherwise lets the runtime instance default apply. The leader now uses the same conditional spread, so leader and workers resolve to the same effective mode (explicit run mode, else the instance's configured mode). Read-only runs are unchanged: an explicit `read-only` is still forwarded and still skips worker worktrees.

## Architectural Justification

-

## What Changed

- `packages/daemon/src/squad-coordinator.ts`: leader spawn payload uses `...(state.permissionMode ? { permissionMode } : {})` instead of `state.permissionMode ?? "read-only"`.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: +1/-1.

## Machine-Readable Declarations

- None.

## Task And Scope

- Harness task: task_aee7bf3633cd8ea2ecd3be4f4c (Commander/squad contract rework), Goal 2
- Branch: `codex/squad-leader-permission`
- Public scope: one spawn payload field in the squad coordinator
- Private planning/evidence updated: yes (task_plan.md rounds)
- Out of scope: Commander handbook / agent declaration contract dedup (Goal 1), real-line acceptance run (Goal 4)

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: not applicable
- Machine-check boundary: not applicable
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `387485e98`
- Branch merge-base with `origin/main`: `387485e98`
- Last `git fetch origin` time: 2026-09-12 UTC
- Sync method: branched from origin/main
- Public diff command: `git diff origin/main...codex/squad-leader-permission`
- Private evidence commit/path: task_aee7bf3633cd8ea2ecd3be4f4c `task_plan.md`
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [ ] `npm run typecheck`
- [ ] `npm run check`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- `node --test packages/daemon/test/squad-coordinator*.test.ts packages/daemon/test/squad-run*.test.ts packages/cli/test/squad-*.test.ts`: 43 tests, 42 pass, 0 fail (1 skipped); `run-manifest-gates --changed origin/main`: no red gate.

## Review Evidence

- CEO ground-truth: read both spawn sites; no existing test pinned the leader's read-only fallback.
- Reviewer subagent: not dispatched (one-line fix, CI is the authority)
- Human review: pending
- Blocking findings: none open

## Residual Risk

- No new test pins the leader/worker parity; a squad run without an explicit mode on an instance configured `read-only` behaves exactly as before, one configured `bypass` now gives the leader `bypass` too, which is the intended parity.

## References

- Task: task_aee7bf3633cd8ea2ecd3be4f4c; PR #2501 (Goal 2 first half)

---

# 中文

## 概要

Commander 线 task_aee7bf3633cd8ea2ecd3be4f4c Goal 2 补尾（「permission-mode 与 worker 一致」）：`squad-coordinator.ts` 的 `spawnLeader` 在 squad run 没有显式权限模式时把 leader 回落成 `read-only`，而 `spawnWorker` 只在有显式模式时透传、否则用 runtime instance 的默认。现在 leader 用同一个条件展开，leader 与 worker 解析到同一有效模式（显式 run 模式，否则实例配置）。只读 run 不变：显式 `read-only` 仍透传、仍跳过 worker worktree。

## 架构辩护

-

## 改动内容

- `packages/daemon/src/squad-coordinator.ts`：leader spawn payload 由 `state.permissionMode ?? "read-only"` 改为 `...(state.permissionMode ? { permissionMode } : {})`。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 删除的门或 fixture：none
- 生产净行数：+1/-1。

## 机器可读声明

- 无。

## 任务与范围

- Harness 任务：task_aee7bf3633cd8ea2ecd3be4f4c（Commander/squad 契约返工），Goal 2
- 分支：`codex/squad-leader-permission`
- 公开范围：squad coordinator 一个 spawn payload 字段
- 私有计划/证据已更新：是（task_plan.md 各轮）
- 范围外：Commander 手册/agent 声明契约去重（Goal 1）、真实线验收 run（Goal 4）

## 版本影响

- 版本：不变
- 发布影响：不发布

## 治理声明

- 触碰受保护面：否
- 受保护面范围：不适用
- 授权：不适用
- 机器检查边界：不适用
- Break-glass：否
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- 基线 `origin/main` SHA：`387485e98`
- 分支与 `origin/main` 的 merge-base：`387485e98`
- 最近一次 `git fetch origin`：2026-09-12 UTC
- 同步方式：从 origin/main 开分支
- 公开 diff 命令：`git diff origin/main...codex/squad-leader-permission`
- 私有证据路径：task_aee7bf3633cd8ea2ecd3be4f4c 的 `task_plan.md`
- 评审证据路径：本 PR 的评审证据节
- GitHub Actions `rewrite-ci` run URL：本 PR 待跑
- squad 定向测试 43（42 pass、0 fail、1 skip）；`run-manifest-gates --changed origin/main` 无红门。

## 评审证据

- CEO 事实核对：读过两个 spawn 点；没有既有测试钉住 leader 的 read-only 回落。
- 评审子代理：未派（一行修复，CI 为权威）
- 人工评审：待定
- 阻塞发现：无

## 残余风险

- 没有新测试钉住 leader/worker 一致性；实例配置 `read-only` 时行为与之前完全相同，实例配置 `bypass` 时 leader 也拿到 `bypass`，这正是目标。

## 参考

- 任务：task_aee7bf3633cd8ea2ecd3be4f4c；PR #2501（Goal 2 前半）
