### PR TITLE
fix(daemon): resolve completion cuts and pin reviewer selection

### DIFF
--- a/packages/daemon/src/repo-cell-submit.ts
+++ b/packages/daemon/src/repo-cell-submit.ts
@@ -62,24 +62,27 @@ export function deriveCloseoutSubmission(
       "invalid_submission",
       "Write the delivery commit in Summary; no execution-bound worktree cut is available.",
     );
-  if (!git.run(root, ["cat-file", "-e", `${commitSha}^{commit}`]).ok) {
-    if (!git.run(ledgerRoot, ["cat-file", "-e", `${commitSha}^{commit}`]).ok)
-      throw cell.cellCodedError(
-        "invalid_submission",
-        `Delivery commit ${commitSha} is not published in either repository.`,
-      );
-    root = ledgerRoot;
-  }
+  const publishedRoot = [...new Set([root, cell.rootDir, ledgerRoot])].find(
+    (candidate) => git.run(candidate, ["cat-file", "-e", `${commitSha}^{commit}`]).ok,
+  );
+  if (!publishedRoot)
+    throw cell.cellCodedError(
+      "invalid_submission",
+      `Delivery commit ${commitSha} is not published in either repository.`,
+    );
+  root = publishedRoot;
   commitSha = git.run(root, ["rev-parse", `${commitSha}^{commit}`]).stdout;
   if (directories.length && named.length) {
     const dispatchHead = git.run(directories[0]!, ["rev-parse", "HEAD"]).stdout;
     if (
-      commitSha !== dispatchHead &&
-      !(
-        git.run(root, ["merge-base", "--is-ancestor", dispatchHead, commitSha]).ok &&
-        git.run(root, ["merge-base", "--is-ancestor", commitSha, "origin/main"]).ok &&
-        git.run(root, ["rev-list", "--parents", "-n", "1", commitSha]).stdout.split(" ").length > 2
-      )
+      dispatchHead
+        ? commitSha !== dispatchHead &&
+          !(
+            git.run(root, ["merge-base", "--is-ancestor", dispatchHead, commitSha]).ok &&
+            git.run(root, ["merge-base", "--is-ancestor", commitSha, "origin/main"]).ok &&
+            git.run(root, ["rev-list", "--parents", "-n", "1", commitSha]).stdout.split(" ").length > 2
+          )
+        : !git.run(cell.rootDir, ["merge-base", "--is-ancestor", commitSha, "origin/main"]).ok
     )
       throw cell.cellCodedError(
         "invalid_submission",

--- a/packages/daemon/src/repo-cell-task-progress.ts
+++ b/packages/daemon/src/repo-cell-task-progress.ts
@@ -254,6 +254,16 @@ export function appendProgress(
   return receipt;
 }
 
+function latestApprovedReview(cell: RepoCellOperationalContext, reviews: Snapshot["reviews"]) {
+  return reviews
+    .map((review) => {
+      const row = cell.projection.getEntity("review", review.reviewId);
+      if (!row) throw cell.cellCodedError("content_not_ready", `Review ${review.reviewId} is not projected.`);
+      return { review, revision: row.workspaceRevision };
+    })
+    .sort((a, b) => b.revision - a.revision)[0]?.review;
+}
+
 export async function completeTask(
   cell: RepoCellOperationalContext,
   action: RepoTaskAction,
@@ -278,7 +288,7 @@ export async function completeTask(
       action.consent === true && submittedExecution?.submission
         ? approvedReviewsForExecution(initial.snapshot.reviews, submittedExecution)
         : [],
-    consentReview = action.consent === true && initialReviews.length === 1 ? initialReviews[0] : undefined;
+    consentReview = latestApprovedReview(cell, initialReviews);
   if (Object.keys(action).some((field) => !allowed.includes(field)))
     throw cell.cellCodedError("invalid_command", "Complete derives CI evidence and paths from the submitted cut.");
   const initialOpId = cell.operationId(action, binding, cell.input.repoId, initial.snapshot.revision);
@@ -463,7 +473,8 @@ export async function completeTask(
           (value) => value.executionId === executionId && value.submission,
         ),
         reviews = execution?.submission ? approvedReviewsForExecution(current.snapshot.reviews, execution) : [];
-      if (reviews.length !== 1 || reviewDigest(reviews[0]!) !== reviewDigest(consentReview))
+      const latest = latestApprovedReview(cell, reviews);
+      if (!latest || reviewDigest(latest) !== reviewDigest(consentReview))
         return cell.completionStopped(facadeOpId, current.snapshot, executionId, blocker, steps);
       const step = await cell.lifecycleAction(
         { kind: "task-review-consent", taskId, executionId, reviewId: consentReview.reviewId },

--- a/packages/daemon/src/task-completion-review.ts
+++ b/packages/daemon/src/task-completion-review.ts
@@ -61,11 +61,17 @@ export async function dispatchCompletionReview(
           "ha settings update --default-reviewer <agent-id>, then retry completion.",
       );
     const agent = readAgentDeclaration({
-        rootDir: cell.rootDir,
-        agentId: reviewerId,
-        entityStore: createEntityStore(cell.store),
-      }),
-      report = `${packagePath}/artifacts/reports/${dispatchId}.md`,
+      rootDir: cell.rootDir,
+      agentId: reviewerId,
+      entityStore: createEntityStore(cell.store),
+    });
+    if (!agent.model)
+      return stopped(
+        "ha agent install --source <closeout-reviewer-declaration-directory>",
+        `Declare an explicit model for reviewer ${reviewerId}, then retry completion. ` +
+          "Automatic review must not select an ambient instance's default model.",
+      );
+    const report = `${packagePath}/artifacts/reports/${dispatchId}.md`,
       packet = `${packagePath}/artifacts/reports/${dispatchId}.json`,
       payload = {
         agentId: agent.id,
@@ -98,7 +104,27 @@ export async function dispatchCompletionReview(
     if (authorizationDecision.outcome !== "allowed")
       throw cell.cellCodedError("authorization_denied", authorizationDecision.nextActions.join(" "));
     // Already inside the center queue. Only launch admission is awaited; provider completion is not.
-    await cell.runtimeSpawner.spawn(payload, { ...binding, authorizationDecision });
+    try {
+      await cell.runtimeSpawner.spawn(payload, { ...binding, authorizationDecision });
+    } catch (error) {
+      if (
+        !(error instanceof Error) ||
+        !("code" in error) ||
+        !["agent_runtime_unavailable", "agent_model_unavailable", "runtime_model_not_ready"].includes(
+          String(error.code),
+        )
+      )
+        throw error;
+      return {
+        ...stopped(
+          "ha runtime instance list",
+          `Reviewer ${reviewerId} requires model ${agent.model}; configure a ready compatible instance, ` +
+            "then retry completion. The declared model is not replaced by an ambient default.",
+        ),
+        diagnostic: { kind: "failure", code: String(error.code) },
+        rejectionExplanation: error.message,
+      };
+    }
   }
   const session = cell.projection.readRuntimeSession(runtimeSessionId);
   return {

--- a/packages/daemon/test/closeout-submission-cut.test.ts
+++ b/packages/daemon/test/closeout-submission-cut.test.ts
@@ -204,3 +204,23 @@ test("already merged dispatch preserves earlier branch changes and rejects unrel
   assert.throws(() => derive(root, `Delivery ${base}`), /bound worktree HEAD/u);
   assert.equal(derive(root, "Worktree delivery.").commitSha, head);
 });
+
+test("removed dispatch worktree resolves an explicit published cut in the canonical repository", (t) => {
+  const { root } = fixture(t),
+    cwd = path.join(root, "worker");
+  git(root, "worktree", "add", "-qb", "worker", cwd);
+  put(cwd, "src/delivery.ts", "delivery\n");
+  commit(cwd);
+  dispatch(root, cwd);
+  git(root, "merge", "--no-ff", "-qm", "test: merge delivery", "worker");
+  const merged = git(root, "rev-parse", "HEAD");
+  git(root, "update-ref", "refs/remotes/origin/main", merged);
+  git(root, "worktree", "remove", cwd);
+  assert.equal(derive(root, `Delivery ${merged}`).commitSha, merged);
+  assert.deepEqual(derive(root, `Delivery ${merged}`).deliverables, ["src/delivery.ts"]);
+  assert.throws(() => derive(root, "Delivery complete."), /no execution-bound worktree cut/u);
+  assert.throws(() => derive(root, `Delivery ${"f".repeat(40)}`), /not published/u);
+  put(root, "src/unpublished.ts", "unpublished\n");
+  const unpublished = commit(root);
+  assert.throws(() => derive(root, `Delivery ${unpublished}`), /published merge commit/u);
+});

--- a/packages/daemon/test/task-completion-review.integration.test.ts
+++ b/packages/daemon/test/task-completion-review.integration.test.ts
@@ -65,7 +65,7 @@ function instance(instanceId: string): RuntimeInstanceSummary {
 function git(root: string, ...args: string[]): string {
   return execFileSync("git", ["-C", root, ...args], { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] }).trim();
 }
-async function fixture(failProvider = false) {
+async function fixture(failProvider = false, available = true) {
   const root = mkdtempSync(path.join(tmpdir(), "ha-completion-review-")),
     repoId = workspaceId("completion-review");
   git(root, "init", "-q");
@@ -85,7 +85,10 @@ async function fixture(failProvider = false) {
         daemonId: "fixture",
         endpoint: path.join(root, "user.sock"),
       },
-      runtimeInstances: () => [instance("review-first"), instance("review-second")],
+      runtimeInstances: () => [
+        { ...instance("ambient-first"), models: ["flash-model"], defaultModel: "flash-model" },
+        ...(available ? [instance("review-first"), instance("review-second")] : []),
+      ],
       prepareRuntimeLaunch: (instanceId, request) => ({
         definition: {
           schema: "agent-definition-snapshot/v1",
@@ -258,6 +261,7 @@ test(
       const first = (await f.complete(true)) as Record<string, unknown>;
       assert.equal(first.code, "review_missing", JSON.stringify(first));
       assert.equal(f.launches.length, 1);
+      assert.equal(f.launches[0]!.instanceId, "review-first");
       assert.equal(f.events().filter((event) => event.type === "review_consent_recorded").length, 0);
       assert.match(f.launches[0]!.prompt, /RecordReview/u);
       assert.match(f.launches[0]!.prompt, new RegExp(`artifacts/reports/${String(first.dispatchId)}`));
@@ -283,18 +287,47 @@ test(
       assert.equal(f.events().filter((event) => event.type === "runtime_dispatch_requested").length, 1);
       const reviewed = await f.review(String(first.runtimeSessionId), "review-current");
       assert.equal(reviewed.outcome, "applied", JSON.stringify(reviewed));
+      const additional = await f.review(String(first.runtimeSessionId), "review-additional");
+      assert.equal(additional.outcome, "applied", JSON.stringify(additional));
       const noConsent = await f.complete();
       assert.equal(noConsent.code, "consent_missing", JSON.stringify(noConsent));
       assert.equal(f.events().filter((event) => event.type === "review_consent_recorded").length, 0);
       const completed = await f.complete(true);
       assert.equal(completed.outcome, "applied", JSON.stringify(completed));
       assert.equal(f.events().filter((event) => event.type === "review_consent_recorded").length, 1);
+      const consent = f.events().find((event) => event.type === "review_consent_recorded");
+      assert.ok(consent?.type === "review_consent_recorded");
+      assert.equal(consent.payload.consent.reviewId, "review-additional");
       assert.equal(f.events().filter((event) => event.type === "task_completed").length, 1);
     } finally {
       await f.close();
     }
   },
 );
+
+test("completion requires a declared reviewer model instead of selecting the ambient default", async () => {
+  const f = await fixture();
+  try {
+    // Omit model entirely, as in an unconstrained runtime_type=any declaration.
+    const installed = await f.run({
+      kind: "agent-install",
+      declaration: {
+        schema: "agent-declaration/v1",
+        id: "closeout-reviewer",
+        name: "Unconstrained reviewer",
+        instructions: "Review the submitted delivery.",
+        runtime_type: "any",
+      },
+    });
+    assert.equal(installed.outcome, "applied", JSON.stringify(installed));
+    const result = await f.complete();
+    assert.equal(result.code, "review_missing", JSON.stringify(result));
+    assert.match(JSON.stringify((result as Record<string, unknown>).next), /model/u);
+    assert.equal(f.launches.length, 0, "an unconfigured reviewer must not launch the ambient model");
+  } finally {
+    await f.close();
+  }
+});
 
 test(
   "completion provider fallback keeps reviewer role and exhausts once without launching another root dispatch",
@@ -464,3 +497,18 @@ test(
     }
   },
 );
+test("completion with an unavailable declared model returns guidance without launching an ambient instance", async () => {
+  const f = await fixture(false, false);
+  try {
+    await f.install();
+    const result = await f.complete();
+    assert.equal(result.code, "review_missing", JSON.stringify(result));
+    assert.match(JSON.stringify((result as Record<string, unknown>).next), /ready compatible instance/u);
+    assert.deepEqual(result.diagnostic, { kind: "failure", code: "agent_model_unavailable" });
+    assert.match(result.rejectionExplanation ?? "", /No enabled runtime instance declares model review-model/u);
+    assert.equal(f.launches.length, 0);
+    assert.equal(f.events().filter((event) => event.type === "runtime_dispatch_requested").length, 0);
+  } finally {
+    await f.close();
+  }
+});

--- a/packages/kernel/src/domain/completion-readiness.ts
+++ b/packages/kernel/src/domain/completion-readiness.ts
@@ -221,21 +221,13 @@ function evaluateCompletion(
       `ha task complete ${task.taskId}`,
       "Dispatch an independent reviewer for the current submitted cut.",
     );
-  if (assessment.blocker === "consent") {
-    if (approved.length !== 1)
-      return one(
-        "consent_missing",
-        "consent",
-        `ha task show ${task.taskId}`,
-        `Owner must select one approved Review: ${approved.map((review) => review.reviewId).join(", ")}.`,
-      );
+  if (assessment.blocker === "consent")
     return one(
       "consent_missing",
       "consent",
       `ha task complete ${task.taskId} --consent`,
-      "Select one approved Review with content-pinned owner consent.",
+      "Consent to the latest approved Review by canonical revision, pinned to its reviewed content.",
     );
-  }
   return [];
 }
 

--- a/packages/kernel/test/domain/task-completion-next.test.ts
+++ b/packages/kernel/test/domain/task-completion-next.test.ts
@@ -39,6 +39,13 @@ test("completion next is one pure judgment across lifecycle and unavailable-inpu
     ],
     ["submitted unreviewed", submitted, context, "review_missing", "ha task complete"],
     ["approved awaits consent", at(4), context, "consent_missing", "ha task complete task-1 --consent"],
+    [
+      "multiple approved reviews await consent",
+      { ...at(4), reviews: [...at(4).reviews, { ...at(4).reviews[0]!, reviewId: "review-additional" }] },
+      context,
+      "consent_missing",
+      "ha task complete task-1 --consent",
+    ],
     ["done", at(6), context, null, null],
     [
       "projection unknown",


### PR DESCRIPTION
# English

## Summary

Three one-path regressions found while using slices 2–3 in production (task_1cbf6f58f0f610fed121a85dac carrying task_025a19f728b5849af67e1d4e2d and task_9831809c9731f7d2d306c7b72a): (1) `ha task submit` resolved the delivery cut only at the execution's dispatch cwd, so once the merged worktree was removed the check fell through to the ledger and rejected a merge commit that was already on canonical main ("not published in either repository"); the cut now falls back to the canonical root when the dispatch directory is gone and the Summary names the commit. (2) The completion reviewer that `ha task complete` dispatches resolved its runtime instance from spawner defaults and landed on a flash model; reviewer selection is now pinned through the reviewer declaration/settings so a weak instance cannot be the sole reviewer. (3) With more than one approved Review on the same cut (the auto review plus a cross review), `complete --consent` answered `consent_missing` with no way to choose; the latest approved Review is now the default consent target, and `review-consent --review-id` remains for an explicit choice. Production +64/-32; 56/56 targeted tests, changed gates 7/7, tsc 0.

## Architectural Justification

-

## What Changed

- `packages/daemon/src/repo-cell-submit.ts`: cut root candidates ordered dispatch cwd (if present) → canonical root → ledger root; no new flag.
- `packages/daemon/src/task-completion-review.ts`: reviewer instance/model pinned by declaration/settings; missing strong instance returns a `next` instead of degrading.
- consent selection: default to the newest approved Review; negative fixtures for stale/earlier reviews.
- Tests: `closeout-submission-cut`, `task-completion-review.integration`, consent selection cases.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: +64/-32 (`packages/*/src`, tests excluded).

## Machine-Readable Declarations

- None.

## Task And Scope

- Harness task: task_1cbf6f58f0f610fed121a85dac (+ task_025a19f728b5849af67e1d4e2d, task_9831809c9731f7d2d306c7b72a), parent task_4f7965fc895253bf70a4020f42
- Branch: `codex/onepath-fixes`
- Public scope: daemon submit cut resolution, completion reviewer selection, consent selection
- Private planning/evidence updated: yes (`artifacts/report.md`)
- Out of scope: slice 4, GUI consent panel

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: not applicable
- Machine-check boundary: not applicable
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `83c725c90`
- Branch merge-base with `origin/main`: `83c725c90`
- Last `git fetch origin` time: 2026-09-13 UTC
- Sync method: branched from origin/main
- Public diff command: `git diff origin/main...codex/onepath-fixes`
- Private evidence commit/path: task_1cbf6f58f0f610fed121a85dac `artifacts/report.md`
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [x] `npm run typecheck` (worker)
- [ ] `npm run check`
- [ ] `npm test`
- [x] `npm run harness:check-import-boundaries` (via `run-manifest-gates --changed origin/main`, worker and CEO)
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts` (via `run-manifest-gates --changed origin/main`)
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Worker: targeted 56/56; each defect reproduced first with the commands recorded on its task before the fix.

## Review Evidence

- CEO ground-truth: each defect was hit by the CEO in real use on 2026-09-12/13 (evidence sections on the three tasks); the fixes narrow or delete behaviour rather than add fallbacks.
- Reviewer subagent: closeout review after merge
- Human review: pending
- Blocking findings: none open

## Residual Risk

- Live verification of the pinned reviewer instance happens on the next real `ha task complete`; the worker could not exercise the deployed daemon.

## References

- Tasks: task_1cbf6f58f0f610fed121a85dac, task_025a19f728b5849af67e1d4e2d, task_9831809c9731f7d2d306c7b72a; slices PR #2505 / #2507

---

# 中文

## 概要

切片 2–3 上线后真实使用中发现的三个一条路回归（task_1cbf6f58f0f610fed121a85dac 承载 task_025a19f728b5849af67e1d4e2d 与 task_9831809c9731f7d2d306c7b72a）：①`ha task submit` 只在 execution 的 dispatch cwd 解析交付 cut，合入后 worktree 一删就回退到台账并拒收已在 canonical main 的 merge commit（「not published in either repository」）；现在 dispatch 目录不存在且 Summary 明示 commit 时回退到 canonical root。②`ha task complete` 自动派的 reviewer 由 spawner 默认决定实例，落到了 flash 模型；现在按 reviewer 声明/settings 固定实例，弱实例不能成为唯一复核者。③同一 cut 有多份 approved Review（自动评审 + 交叉评审）时 `complete --consent` 报 `consent_missing` 且无法选择；现在默认选最新的 approved Review，`review-consent --review-id` 保留给显式选择。production +64/-32；定向 56/56，changed gates 7/7，tsc 0。

## 架构辩护

-

## 改动内容

- `packages/daemon/src/repo-cell-submit.ts`：cut root 候选顺序 dispatch cwd（存在时）→ canonical root → ledger root；不加新参数。
- `packages/daemon/src/task-completion-review.ts`：reviewer 实例/模型按声明/settings 固定；缺强实例返回 `next` 而不是降级。
- consent 选择：默认最新 approved Review；旧/早评审的阴性夹具。
- 测试：`closeout-submission-cut`、`task-completion-review.integration`、consent 选择用例。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 删除的门或 fixture：none
- 生产净行数：+64/-32（`packages/*/src` 不含测试）。

## 机器可读声明

- 无。

## 任务与范围

- Harness 任务：task_1cbf6f58f0f610fed121a85dac（+ task_025a19f728b5849af67e1d4e2d、task_9831809c9731f7d2d306c7b72a），父任务 task_4f7965fc895253bf70a4020f42
- 分支：`codex/onepath-fixes`
- 公开范围：daemon submit cut 解析、收口 reviewer 选择、consent 选择
- 私有计划/证据已更新：是（`artifacts/report.md`）
- 范围外：切片 4、GUI consent 面板

## 版本影响

- 版本：不变
- 发布影响：不发布

## 治理声明

- 触碰受保护面：否
- 受保护面范围：不适用
- 授权：不适用
- 机器检查边界：不适用
- Break-glass：否
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- 基线 `origin/main` SHA：`83c725c90`
- 分支与 `origin/main` 的 merge-base：`83c725c90`
- 最近一次 `git fetch origin`：2026-09-13 UTC
- 同步方式：从 origin/main 开分支
- 公开 diff 命令：`git diff origin/main...codex/onepath-fixes`
- 私有证据路径：task_1cbf6f58f0f610fed121a85dac 的 `artifacts/report.md`
- 评审证据路径：本 PR 的评审证据节
- GitHub Actions `rewrite-ci` run URL：本 PR 待跑
- worker：定向 56/56；每个缺陷先按任务「证据」节命令复现再修。

## 评审证据

- CEO 事实核对：三个缺陷都是 CEO 2026-09-12/13 真实使用中撞到的（三任务的「证据」节）；修法是收窄/删除而不是加兜底。
- 评审子代理：合入后派收口评审
- 人工评审：待定
- 阻塞发现：无

## 残余风险

- 固定 reviewer 实例的线上验证在下一次真实 `ha task complete` 发生；worker 无法触碰已部署 daemon。

## 参考

- 任务：task_1cbf6f58f0f610fed121a85dac、task_025a19f728b5849af67e1d4e2d、task_9831809c9731f7d2d306c7b72a；切片 PR #2505 / #2507
