### PR TITLE
fix(daemon): preserve squad attempt and runtime metrics identity

### DIFF
--- a/packages/daemon/src/dispatch-stream.ts
+++ b/packages/daemon/src/dispatch-stream.ts
@@ -332,8 +332,13 @@ export function readDispatchStreamSummary(rootDir: string, dispatchId: string): 
     }
   }
   const value = summarizeDispatch(header, records, stat.mtimeMs);
-  summaryCache.set(target, { mtimeMs: stat.mtimeMs, size: stat.size, value });
-  return value;
+  if (value.runtimeMetrics === null) {
+    const runtimeMetrics = readLatestRecordOfKind(target, "runtime_metrics");
+    if (runtimeMetrics && isRuntimeMetrics(runtimeMetrics)) records.push(runtimeMetrics);
+  }
+  const valueWithRecoveredMetrics = summarizeDispatch(header, records, stat.mtimeMs);
+  summaryCache.set(target, { mtimeMs: stat.mtimeMs, size: stat.size, value: valueWithRecoveredMetrics });
+  return valueWithRecoveredMetrics;
 }
 
 export function readDispatchStreamHeaders(rootDir: string): readonly DispatchStreamHeader[] {
@@ -704,6 +709,31 @@ function completeLines(text: string, offset: number, size: number): readonly { o
 function lineKind(value: string): string | null {
   const match = /"kind"\s*:\s*"([^"\\]+)"/u.exec(value);
   return match?.[1] ?? null;
+}
+function readLatestRecordOfKind(target: string, kind: string): Record<string, unknown> | null {
+  const descriptor = openSync(target, fsConstants.O_RDONLY),
+    size = fstatSync(descriptor).size,
+    marker = Buffer.from(`"kind":"${kind}"`),
+    chunkSize = 64 * 1024;
+  try {
+    for (let end = size; end > 0; ) {
+      const start = Math.max(0, end - chunkSize),
+        length = end - start,
+        bytes = Buffer.alloc(length),
+        read = readSync(descriptor, bytes, 0, length, start),
+        markerOffset = bytes.subarray(0, read).lastIndexOf(marker);
+      if (markerOffset !== -1) {
+        const lineStart = bytes.lastIndexOf(10, markerOffset) + 1,
+          lineEnd = bytes.indexOf(10, markerOffset);
+        if (lineEnd !== -1) return parseRecord(bytes.subarray(lineStart, lineEnd).toString("utf8"));
+      }
+      if (start === 0) break;
+      end = start + marker.length - 1;
+    }
+  } finally {
+    closeSync(descriptor);
+  }
+  return null;
 }
 function parseRecord(value: string | undefined): Record<string, unknown> | null {
   if (!value) return null;

--- a/packages/daemon/src/runtime-spawn-provider-stream.ts
+++ b/packages/daemon/src/runtime-spawn-provider-stream.ts
@@ -1,4 +1,6 @@
 import { setTimeout as delay } from "node:timers/promises";
+import { globSync, readFileSync } from "node:fs";
+import path from "node:path";
 import type { SessionIdentity } from "../../kernel/src/index.ts";
 import { consumeKnownError } from "../../kernel/src/index.ts";
 import { readDispatchStream, scrubProviderValue } from "./dispatch-stream.ts";
@@ -69,6 +71,7 @@ export async function consumeProviderChunk(
   active.buffer = flush ? "" : trailing;
   for (const line of lines) if (line.trim()) await context.consumeLine(active, line, persisted);
   if (flush && trailing.trim()) await context.consumeLine(active, trailing, persisted);
+  if (flush) observeCodexSessionMetrics(context, active);
 }
 
 export async function consumeProviderLine(
@@ -162,6 +165,55 @@ function observeRuntimeMetrics(active: ActiveRuntime, value: unknown): void {
 
 function numberValue(value: unknown): number | null {
   return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function observeCodexSessionMetrics(context: RuntimeSpawnerContext, active: ActiveRuntime): void {
+  if (
+    active.kindId !== "codex" ||
+    !active.providerUsageEmpty ||
+    active.providerSessionId === null ||
+    !/^[a-z0-9-]+$/iu.test(active.providerSessionId)
+  )
+    return;
+  const userRoot = context.input.runtimeDaemonRoute?.userRoot;
+  if (!userRoot) return;
+  const sessionsRoot = path.join(userRoot, "runtime-instances", active.instanceId, "home", ".codex", "sessions"),
+    matches = globSync(`**/rollout-*-${active.providerSessionId}.jsonl`, { cwd: sessionsRoot });
+  if (matches.length !== 1) return;
+  let lines: string[];
+  try {
+    lines = readFileSync(path.join(sessionsRoot, matches[0]!), "utf8").split(/\r?\n/u);
+  } catch (error) {
+    consumeKnownError(error);
+    return;
+  }
+  for (let index = lines.length - 1; index >= 0; index -= 1) {
+    try {
+      const record: unknown = JSON.parse(lines[index]!);
+      if (!record || typeof record !== "object" || Array.isArray(record)) continue;
+      const payload = (record as Record<string, unknown>).payload;
+      if (!payload || typeof payload !== "object" || Array.isArray(payload)) continue;
+      const info = (payload as Record<string, unknown>).info;
+      if ((payload as Record<string, unknown>).type !== "token_count" || !providerRecord(info)) continue;
+      const usage = providerRecord(info.last_token_usage) ? info.last_token_usage : null;
+      if (!usage) continue;
+      const input = numberValue(usage.input_tokens),
+        cached = numberValue(usage.cached_input_tokens),
+        output = numberValue(usage.output_tokens);
+      if (input === null || cached === null || output === null) return;
+      active.inputTokens = input;
+      active.cacheReadTokens = cached;
+      active.outputTokens = output;
+      active.rawUsage = { ...usage };
+      return;
+    } catch (error) {
+      consumeKnownError(error);
+    }
+  }
+}
+
+function providerRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
 }
 
 export async function consumeDurableOutput(

--- a/packages/daemon/src/runtime-spawn-provider-stream.ts
+++ b/packages/daemon/src/runtime-spawn-provider-stream.ts
@@ -180,35 +180,25 @@ function observeCodexSessionMetrics(context: RuntimeSpawnerContext, active: Acti
   const sessionsRoot = path.join(userRoot, "runtime-instances", active.instanceId, "home", ".codex", "sessions"),
     matches = globSync(`**/rollout-*-${active.providerSessionId}.jsonl`, { cwd: sessionsRoot });
   if (matches.length !== 1) return;
-  let lines: string[];
-  try {
-    lines = readFileSync(path.join(sessionsRoot, matches[0]!), "utf8").split(/\r?\n/u);
-  } catch (error) {
-    consumeKnownError(error);
-    return;
-  }
+  const lines = readFileSync(path.join(sessionsRoot, matches[0]!), "utf8").split(/\r?\n/u);
   for (let index = lines.length - 1; index >= 0; index -= 1) {
-    try {
-      const record: unknown = JSON.parse(lines[index]!);
-      if (!record || typeof record !== "object" || Array.isArray(record)) continue;
-      const payload = (record as Record<string, unknown>).payload;
-      if (!payload || typeof payload !== "object" || Array.isArray(payload)) continue;
-      const info = (payload as Record<string, unknown>).info;
-      if ((payload as Record<string, unknown>).type !== "token_count" || !providerRecord(info)) continue;
-      const usage = providerRecord(info.last_token_usage) ? info.last_token_usage : null;
-      if (!usage) continue;
-      const input = numberValue(usage.input_tokens),
-        cached = numberValue(usage.cached_input_tokens),
-        output = numberValue(usage.output_tokens);
-      if (input === null || cached === null || output === null) return;
-      active.inputTokens = input;
-      active.cacheReadTokens = cached;
-      active.outputTokens = output;
-      active.rawUsage = { ...usage };
-      return;
-    } catch (error) {
-      consumeKnownError(error);
-    }
+    const line = lines[index]!;
+    if (!line.includes('"token_count"')) continue;
+    const record: unknown = JSON.parse(line);
+    if (!providerRecord(record) || !providerRecord(record.payload)) continue;
+    const { payload } = record;
+    if (payload.type !== "token_count" || !providerRecord(payload.info)) continue;
+    const usage = providerRecord(payload.info.last_token_usage) ? payload.info.last_token_usage : null;
+    if (!usage) continue;
+    const input = numberValue(usage.input_tokens),
+      cached = numberValue(usage.cached_input_tokens),
+      output = numberValue(usage.output_tokens);
+    if (input === null || cached === null || output === null) return;
+    active.inputTokens = input;
+    active.cacheReadTokens = cached;
+    active.outputTokens = output;
+    active.rawUsage = { ...usage };
+    return;
   }
 }
 

--- a/packages/daemon/src/squad-coordinator.ts
+++ b/packages/daemon/src/squad-coordinator.ts
@@ -540,7 +540,9 @@ export function makeSquadCoordinator(input: {
               baseSha: localGitObjectRefStore.headCommit(state.cwd),
             });
       worktree =
-        dispatchState.permissionMode === "read-only" ? null : prepareWorkerWorktree(dispatchState, plan.workerId);
+        dispatchState.permissionMode === "read-only"
+          ? null
+          : prepareWorkerWorktree(dispatchState, plan.workerId, attemptId);
       await input.reacquireTaskLease(dispatchState.taskId, dispatchState.binding);
       const receipt = await input.runtimeSpawner().spawn(
           {

--- a/packages/daemon/src/squad-worker-checkout.ts
+++ b/packages/daemon/src/squad-worker-checkout.ts
@@ -23,9 +23,10 @@ export function cwdPayload(rootDir: string, cwd: string): JsonObject {
 export function prepareWorkerWorktree(
   state: { readonly squadRunId: string; readonly cwd: string; readonly baseSha: string | null },
   workerId: string,
+  attemptId: string,
 ): WorkerCheckout | null {
   if (state.baseSha === null) return null;
-  const slug = `squad-${state.squadRunId.slice("squad_".length)}-${workerId}`,
+  const slug = `squad-${state.squadRunId.slice("squad_".length)}-${workerId}-${attemptId}`,
     branch = `codex/${slug}`,
     cwd = path.join(state.cwd, ".worktrees", slug);
   localGitObjectRefStore.addWorktree(state.cwd, cwd, branch, state.baseSha);

--- a/packages/daemon/test/dispatch-read.test.ts
+++ b/packages/daemon/test/dispatch-read.test.ts
@@ -117,6 +117,10 @@ test("runtime metrics project to task dispatch rows and remain optional for lega
       instanceId: "instance-1",
       startedAt: "2026-08-23T00:00:00.000Z",
     });
+    writer.appendProviderEvent(
+      { type: "item.completed", item: { text: "x".repeat(32 * 1024) } },
+      "2026-08-23T00:00:30.000Z",
+    );
     writer.appendRuntimeMetrics?.(
       {
         inputTokens: 110,
@@ -139,6 +143,18 @@ test("runtime metrics project to task dispatch rows and remain optional for lega
       toolCallCount: 10,
       compacted: true,
     });
+
+    for (let index = 0; index < 40; index += 1)
+      appendRuntimeWorkerRecord(rootDir, dispatchId, {
+        kind: "squad_run_state",
+        state: { phase: "workers_running", report: "x".repeat(4096), index },
+      });
+    const restartedRow = readTaskDispatches({
+      rootDir,
+      projection: projectionFor(session("exited", "succeeded")),
+      taskId,
+    }).dispatches[0];
+    assert.deepEqual(restartedRow?.metrics, row?.metrics);
 
     const legacyRoot = mkdtempSync(path.join(tmpdir(), "ha-dispatch-read-legacy-"));
     try {

--- a/packages/daemon/test/runtime-spawn-provider-stream.test.ts
+++ b/packages/daemon/test/runtime-spawn-provider-stream.test.ts
@@ -1,8 +1,11 @@
 // harness-test-tier: fast
 import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
 import test from "node:test";
 import { createActiveRuntime } from "../src/runtime-spawn-active.ts";
-import { consumeProviderLine } from "../src/runtime-spawn-provider-stream.ts";
+import { consumeProviderChunk, consumeProviderLine } from "../src/runtime-spawn-provider-stream.ts";
 
 function active() {
   return createActiveRuntime({
@@ -96,4 +99,57 @@ test("Claude stream normalizes message usage including cache creation and preser
     cache_creation_input_tokens: 10,
     output_tokens: 25,
   });
+});
+
+test("Codex empty turn usage is replaced by the matching session turn token count", async () => {
+  const userRoot = mkdtempSync(path.join(tmpdir(), "ha-codex-session-metrics-")),
+    runtime = active(),
+    providerSessionId = "01a091cd-17a9-71d1-9f46-b924018345e4",
+    sessions = path.join(
+      userRoot,
+      "runtime-instances",
+      runtime.instanceId,
+      "home",
+      ".codex",
+      "sessions",
+      "2026",
+      "09",
+      "12",
+    );
+  try {
+    mkdirSync(sessions, { recursive: true });
+    writeFileSync(
+      path.join(sessions, `rollout-2026-09-12T02-48-52-${providerSessionId}.jsonl`),
+      `${JSON.stringify({
+        type: "event_msg",
+        payload: {
+          type: "token_count",
+          info: {
+            total_token_usage: { input_tokens: 181354, cached_input_tokens: 170624, output_tokens: 2449 },
+            last_token_usage: { input_tokens: 62284, cached_input_tokens: 60672, output_tokens: 2046 },
+          },
+        },
+      })}\n`,
+    );
+    runtime.providerSessionId = providerSessionId;
+    runtime.providerUsageEmpty = true;
+    await consumeProviderLine(context(), runtime, JSON.stringify({ type: "turn.completed", usage: {} }));
+    await consumeProviderChunk(
+      { ...context(), input: { ...context().input, runtimeDaemonRoute: { userRoot } } } as never,
+      runtime,
+      "",
+      true,
+    );
+    assert.deepEqual(
+      {
+        inputTokens: runtime.inputTokens,
+        cacheReadTokens: runtime.cacheReadTokens,
+        outputTokens: runtime.outputTokens,
+      },
+      { inputTokens: 62284, cacheReadTokens: 60672, outputTokens: 2046 },
+    );
+    assert.deepEqual(runtime.rawUsage, { input_tokens: 62284, cached_input_tokens: 60672, output_tokens: 2046 });
+  } finally {
+    rmSync(userRoot, { recursive: true, force: true });
+  }
 });

--- a/packages/daemon/test/squad-worker-checkout.test.ts
+++ b/packages/daemon/test/squad-worker-checkout.test.ts
@@ -1,0 +1,35 @@
+// harness-test-tier: fast
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { prepareWorkerWorktree } from "../src/squad-worker-checkout.ts";
+
+test("the same squad worker receives a distinct checkout for each attempt", () => {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-squad-worker-checkout-"));
+  try {
+    execFileSync("git", ["init", "--initial-branch=main"], { cwd: rootDir });
+    writeFileSync(path.join(rootDir, "baseline.txt"), "baseline\n");
+    execFileSync("git", ["add", "baseline.txt"], { cwd: rootDir });
+    execFileSync(
+      "git",
+      ["-c", "user.name=Fixture", "-c", "user.email=fixture@example.com", "commit", "-m", "baseline"],
+      {
+        cwd: rootDir,
+      },
+    );
+    const baseSha = execFileSync("git", ["rev-parse", "HEAD"], { cwd: rootDir, encoding: "utf8" }).trim(),
+      state = { squadRunId: "squad_0123456789abcdef01234567", cwd: rootDir, baseSha },
+      first = prepareWorkerWorktree(state, "worker-3", "worker-1"),
+      second = prepareWorkerWorktree(state, "worker-3", "worker-2");
+
+    assert.notEqual(first?.cwd, second?.cwd);
+    assert.notEqual(first?.branch, second?.branch);
+    assert.equal(first?.baseSha, baseSha);
+    assert.equal(second?.baseSha, baseSha);
+  } finally {
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
# English

## Summary

Two frictions from the first real Commander squad run (task_554e096151ece42ee78b91c534 carrying task_040e277d617fbc8b84deec83a7). (1) `prepareWorkerWorktree` named the worker branch/worktree by worker id, so re-dispatching the same worker inside one squad run failed at `git worktree add` ("Preparing worktree (new branch …)") and the attempt never started; each attempt now gets its own branch/worktree. (2) The Codex CLI provider emits `turn.completed` with an empty `usage` object, so P1.1 recorded zero tokens for every Codex attempt; when the stream carries no usage the settlement now reads `last_token_usage` from the exactly matching Codex session JSONL. The dispatch read also keeps `runtime_metrics` for historical rows across a daemon restart instead of returning null. Production +89/-4.

## Architectural Justification

-

## What Changed

- `packages/daemon/src/squad-worker-checkout.ts`, `squad-coordinator.ts`: per-attempt worktree/branch identity.
- `packages/daemon/src/runtime-spawn-provider-stream.ts`: Codex usage fallback from the session JSONL (`last_token_usage`) when the stream usage is empty.
- `packages/daemon/src/dispatch-stream.ts`: metrics record read back for historical rows.
- Tests: `squad-worker-checkout.test.ts` (new), `runtime-spawn-provider-stream.test.ts`, `dispatch-read.test.ts`.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: +89/-4 (`packages/*/src`, tests excluded).

## Machine-Readable Declarations

- None.

## Task And Scope

- Harness task: task_554e096151ece42ee78b91c534 (+ task_040e277d617fbc8b84deec83a7), parents task_aee7bf3633cd8ea2ecd3be4f4c / task_e7c14849c6803ed749a86870f2
- Branch: `codex/squad-dispatch-fixes`
- Public scope: daemon squad worker checkout, provider stream metrics, dispatch stream read
- Private planning/evidence updated: yes (`artifacts/report.md`)
- Out of scope: P1.3 context-health thresholds, GUI metrics rendering

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: not applicable
- Machine-check boundary: not applicable
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `83c725c90`
- Branch merge-base with `origin/main`: `83c725c90`
- Last `git fetch origin` time: 2026-09-13 UTC
- Sync method: branched from origin/main
- Public diff command: `git diff origin/main...codex/squad-dispatch-fixes`
- Private evidence commit/path: task_554e096151ece42ee78b91c534 `artifacts/report.md`
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [x] `npm run typecheck` (worker)
- [ ] `npm run check`
- [ ] `npm test`
- [x] `npm run harness:check-import-boundaries` (via `run-manifest-gates --changed origin/main`, worker and CEO)
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts` (via `run-manifest-gates --changed origin/main`)
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Worker: targeted squad/provider-stream/dispatch-read tests green; the same-worker second attempt and the empty-usage `turn.completed` sample are covered by new cases.

## Review Evidence

- CEO ground-truth: both frictions were observed on squad_c489ecb761104639992a7b10 (worker-3 rejection "git worktree failed: Preparing worktree (new branch …)"; leader dispatch jsonl `turn.completed` with `usage: {}` and zero metrics).
- Reviewer subagent: closeout review after merge
- Human review: pending
- Blocking findings: none open

## Residual Risk

- Session-JSONL fallback depends on the Codex CLI keeping `last_token_usage` in its session log; if that shape changes the metrics fall back to zero again (visible, not silent).

## References

- Tasks: task_554e096151ece42ee78b91c534, task_040e277d617fbc8b84deec83a7; squad run squad_c489ecb761104639992a7b10; P1.1 PR #2492, P1.2 PR #2503

---

# 中文

## 概要

第一次真实 Commander squad run 暴露的两处摩擦（task_554e096151ece42ee78b91c534 承载 task_040e277d617fbc8b84deec83a7）。①`prepareWorkerWorktree` 按 worker id 命名分支/worktree，同一 squad run 内二次派同一 worker 在 `git worktree add` 处失败（「Preparing worktree (new branch …)」）、attempt 未启动；现在每个 attempt 独立分支/worktree。②Codex CLI provider 的 `turn.completed` 事件 `usage` 为空对象，P1.1 对每个 Codex attempt 都记 0 token；现在流里无 usage 时结算从精确匹配的 Codex session JSONL 读 `last_token_usage`。dispatch 读面在 daemon 重启后也保留历史行的 `runtime_metrics` 而不是返回 null。production +89/-4。

## 架构辩护

-

## 改动内容

- `packages/daemon/src/squad-worker-checkout.ts`、`squad-coordinator.ts`：按 attempt 的 worktree/分支身份。
- `packages/daemon/src/runtime-spawn-provider-stream.ts`：流 usage 为空时从 session JSONL（`last_token_usage`）回填。
- `packages/daemon/src/dispatch-stream.ts`：历史行回读 metrics 记录。
- 测试：`squad-worker-checkout.test.ts`（新）、`runtime-spawn-provider-stream.test.ts`、`dispatch-read.test.ts`。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 删除的门或 fixture：none
- 生产净行数：+89/-4（`packages/*/src` 不含测试）。

## 机器可读声明

- 无。

## 任务与范围

- Harness 任务：task_554e096151ece42ee78b91c534（+ task_040e277d617fbc8b84deec83a7），父任务 task_aee7bf3633cd8ea2ecd3be4f4c / task_e7c14849c6803ed749a86870f2
- 分支：`codex/squad-dispatch-fixes`
- 公开范围：daemon squad worker checkout、provider 流指标、dispatch 流读面
- 私有计划/证据已更新：是（`artifacts/report.md`）
- 范围外：P1.3 上下文健康度阈值、GUI 指标渲染

## 版本影响

- 版本：不变
- 发布影响：不发布

## 治理声明

- 触碰受保护面：否
- 受保护面范围：不适用
- 授权：不适用
- 机器检查边界：不适用
- Break-glass：否
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- 基线 `origin/main` SHA：`83c725c90`
- 分支与 `origin/main` 的 merge-base：`83c725c90`
- 最近一次 `git fetch origin`：2026-09-13 UTC
- 同步方式：从 origin/main 开分支
- 公开 diff 命令：`git diff origin/main...codex/squad-dispatch-fixes`
- 私有证据路径：task_554e096151ece42ee78b91c534 的 `artifacts/report.md`
- 评审证据路径：本 PR 的评审证据节
- GitHub Actions `rewrite-ci` run URL：本 PR 待跑
- worker：squad/provider-stream/dispatch-read 定向测试绿；同 worker 第二次 attempt 与空 usage 的 `turn.completed` 样本有新用例覆盖。

## 评审证据

- CEO 事实核对：两处摩擦均在 squad_c489ecb761104639992a7b10 上观察到（worker-3 拒绝原文「git worktree failed: Preparing worktree (new branch …)」；leader dispatch jsonl `turn.completed` 的 `usage: {}` 与零指标）。
- 评审子代理：合入后派收口评审
- 人工评审：待定
- 阻塞发现：无

## 残余风险

- session JSONL 回填依赖 Codex CLI 保持 `last_token_usage` 字段；形状变了指标会再次归零（可见，不静默）。

## 参考

- 任务：task_554e096151ece42ee78b91c534、task_040e277d617fbc8b84deec83a7；squad run squad_c489ecb761104639992a7b10；P1.1 PR #2492、P1.2 PR #2503
