### PR TITLE
perf: batch task projection hydration

### DIFF
--- a/packages/daemon/src/repo-cell-open.ts
+++ b/packages/daemon/src/repo-cell-open.ts
@@ -367,7 +367,7 @@ export async function openRepoWriterCell(
           );
         // Opening a reader generation is also a structural probe: a watermark can be current
         // while a persisted snapshot row is corrupt.
-        projection.list();
+        projection.readTaskIndex({ limit: 1 });
         state = "attached";
         lastError = null;
         causeClass = null;
@@ -386,7 +386,7 @@ export async function openRepoWriterCell(
           }
           recoveryUncertain = true;
         } else if (!adoptedIndeterminate) {
-          // The adopted candidate's post-catch-up structural probe (projection.list()) failed:
+          // The adopted candidate's post-catch-up structural probe failed:
           // a stronger signal than the plain indeterminate recovery.status above.
           recoveryUncertain = true;
         }

--- a/packages/daemon/src/repo-cell.ts
+++ b/packages/daemon/src/repo-cell.ts
@@ -121,7 +121,7 @@ export async function initializeRepoCell(context: RepoCellCoreInput): Promise<Re
       projection.catchUp?.();
       // Opening a reader generation is also a structural probe: a watermark can
       // be current while a persisted snapshot row is corrupt.
-      projection.readTaskIndex();
+      projection.readTaskIndex({ limit: 1 });
     } catch (error) {
       consumeKnownError(error);
       recovery = {

--- a/packages/daemon/src/squad-action-runtime.ts
+++ b/packages/daemon/src/squad-action-runtime.ts
@@ -1,4 +1,5 @@
 import {
+  createEntityStore,
   parseAgentDeclarationV1,
   parseSquadDeclarationV1,
   type SquadDeclarationV1,
@@ -20,6 +21,7 @@ export function makeSquadActionRuntime(cell: RepoCellRuntimeContext): EntityActi
       const report = validateAgentEntityAction({
         rootDir: cell.rootDir,
         action,
+        entityStore: createEntityStore(cell.store),
         runtimeInstances: cell.input.runtimeInstances?.(),
       });
       return cell.readResult(opId, report as object, revision, null);

--- a/packages/kernel/src/projection/rebuildable-task-projection-reads.ts
+++ b/packages/kernel/src/projection/rebuildable-task-projection-reads.ts
@@ -13,7 +13,7 @@ import type {
 } from "./projection-reads.ts";
 import { discardDatabase, withDatabase } from "./rebuildable-task-projection-database.ts";
 import { catchUpRound } from "./rebuildable-task-projection-catch-up.ts";
-import { markRuntimeSessionsUnknown, readSnapshot } from "./rebuildable-task-projection-runtime.ts";
+import { markRuntimeSessionsUnknown, readSnapshot, readSnapshots } from "./rebuildable-task-projection-runtime.ts";
 import {
   prepareQuery,
   queryPreparedRows,
@@ -61,17 +61,22 @@ export function listProjection(
       query.pinnedFirst !== true
     ) {
       const rows = queryPreparedRows<{
-        readonly task_id: string;
-        readonly package_path: string | null;
-        readonly generation: "v0" | "v1";
-        readonly workspace_revision: number;
-        readonly created_at: string | null;
-        readonly event_json: string;
-      }>(
-        prepareQuery(db, UNPARAMETERIZED_LIST_SQL, (sql) =>
-          /* @gate-identity check-bypass-write-boundary/bypass-write-012 */ db.prepare(sql),
+          readonly task_id: string;
+          readonly package_path: string | null;
+          readonly generation: "v0" | "v1";
+          readonly workspace_revision: number;
+          readonly created_at: string | null;
+          readonly event_json: string;
+        }>(
+          prepareQuery(db, UNPARAMETERIZED_LIST_SQL, (sql) =>
+            /* @gate-identity check-bypass-write-boundary/bypass-write-012 */ db.prepare(sql),
+          ),
         ),
-      );
+        snapshots = readSnapshots(
+          db,
+          rows.map((row) => row.task_id),
+          at,
+        );
       return {
         status: cut.status,
         rows: rows.map((row) => ({
@@ -81,14 +86,19 @@ export function listProjection(
           workspaceRevision: row.workspace_revision,
           createdAt: row.created_at,
           updatedAt: (JSON.parse(row.event_json) as { readonly occurredAt: string }).occurredAt,
-          snapshot: readSnapshot(db, row.task_id, at),
+          snapshot: snapshots.get(row.task_id)!,
         })),
         watermark: cut.watermark,
         sourceRevision: cut.sourceRevision,
         warnings: !existed && cut.sourceRevision > 0 ? ["projection_missing"] : [],
       };
     }
-    const page = listTaskRowsNarrow(db, query);
+    const page = listTaskRowsNarrow(db, query),
+      snapshots = readSnapshots(
+        db,
+        page.rows.map((row) => row.task_id),
+        at,
+      );
     return {
       status: cut.status,
       rows: page.rows.map((row) => ({
@@ -98,7 +108,7 @@ export function listProjection(
         workspaceRevision: row.workspace_revision,
         createdAt: row.created_at,
         updatedAt: row.updated_at,
-        snapshot: readSnapshot(db, row.task_id, at),
+        snapshot: snapshots.get(row.task_id)!,
       })),
       watermark: cut.watermark,
       sourceRevision: cut.sourceRevision,

--- a/packages/kernel/src/projection/rebuildable-task-projection-runtime.ts
+++ b/packages/kernel/src/projection/rebuildable-task-projection-runtime.ts
@@ -23,7 +23,7 @@ import {
 } from "./rebuildable-task-projection-sql.ts";
 import type { LeaseInterval } from "./projection-reads.ts";
 import type { RuntimeSessionPageQuery, RuntimeSessionPageRead } from "./task-projection-port.ts";
-import { readRelationProjectionRows } from "./relation-entity-projection.ts";
+import { readRelationProjectionRows, readRelationProjectionRowsForTargets } from "./relation-entity-projection.ts";
 export type { ProjectionPage, TaskProjectionListQuery, TaskRelationQuery } from "./task-query-projection.ts";
 export type { TaskProjection } from "./task-projection-port.ts";
 
@@ -116,52 +116,122 @@ export function replayRelease(db: DatabaseSync, taskId: string, executionId: str
 }
 
 export function readSnapshot(db: DatabaseSync, taskId: string, now?: string): TaskLifecycleSnapshot {
-  const row = prepareQuery(db, "SELECT snapshot_json FROM task_snapshot WHERE task_id = ?", (sql) =>
-    /* @gate-identity check-bypass-write-boundary/bypass-write-024 */ db.prepare(sql),
-  ).get(taskId) as { readonly snapshot_json: string } | undefined;
-  if (row === undefined) return emptyTaskLifecycleSnapshot();
-  let snapshot: TaskLifecycleSnapshot;
-  try {
-    snapshot = JSON.parse(row.snapshot_json) as TaskLifecycleSnapshot;
-  } catch {
-    throw new Error(`projection snapshot mismatch for task ${taskId}`);
+  return readSnapshots(db, [taskId], now).get(taskId) ?? emptyTaskLifecycleSnapshot();
+}
+
+export function readSnapshots(
+  db: DatabaseSync,
+  taskIds: readonly string[],
+  now?: string,
+): ReadonlyMap<string, TaskLifecycleSnapshot> {
+  if (taskIds.length === 0) return new Map();
+  const requested = JSON.stringify(taskIds),
+    snapshotRows = queryPreparedRows<{ readonly task_id: string; readonly snapshot_json: string }>(
+      prepareQuery(
+        db,
+        "SELECT task_id, snapshot_json FROM task_snapshot WHERE task_id IN (SELECT value FROM json_each(?))",
+        (sql) => /* @gate-identity check-bypass-write-boundary/bypass-write-024 */ db.prepare(sql),
+      ),
+      requested,
+    ),
+    snapshots = new Map<string, TaskLifecycleSnapshot>();
+  for (const row of snapshotRows) {
+    let snapshot: TaskLifecycleSnapshot;
+    try {
+      snapshot = JSON.parse(row.snapshot_json) as TaskLifecycleSnapshot;
+    } catch {
+      throw new Error(`projection snapshot mismatch for task ${row.task_id}`);
+    }
+    if (snapshot.task !== null && validateTaskV2(snapshot.task, true).length)
+      throw new Error(`projection snapshot mismatch for task ${row.task_id}`);
+    snapshots.set(row.task_id, snapshot);
   }
-  if (snapshot.task !== null && validateTaskV2(snapshot.task, true).length)
-    throw new Error(`projection snapshot mismatch for task ${taskId}`);
-  const executions = queryRows(
+  const grouped = <Value>(rows: readonly { readonly task_id: string; readonly value_json: string }[]) => {
+    const values = new Map<string, Value[]>();
+    for (const row of rows) {
+      const groupedValues = values.get(row.task_id) ?? [];
+      groupedValues.push(JSON.parse(row.value_json) as Value);
+      values.set(row.task_id, groupedValues);
+    }
+    return values;
+  };
+  const executions = grouped<TaskLifecycleSnapshot["executions"][number]>(
+      queryRows(
+        db,
+        [
+          "SELECT task_id, value_json FROM entity_projection WHERE entity_kind = 'execution'",
+          "AND task_id IN (SELECT value FROM json_each(?))",
+          "ORDER BY task_id, json_extract(value_json, '$.iteration'),",
+          "json_extract(value_json, '$.claimedAt'), entity_id",
+        ].join(" "),
+        requested,
+      ) as readonly { readonly task_id: string; readonly value_json: string }[],
+    ),
+    reviews = grouped<TaskLifecycleSnapshot["reviews"][number]>(
+      queryRows(
+        db,
+        [
+          "SELECT task_id, value_json FROM entity_projection WHERE entity_kind = 'review'",
+          "AND task_id IN (SELECT value FROM json_each(?)) ORDER BY task_id, entity_id",
+        ].join(" "),
+        requested,
+      ) as readonly { readonly task_id: string; readonly value_json: string }[],
+    ),
+    leases = new Map(
+      queryRows<{ readonly task_id: string; readonly lease_json: string }>(
+        db,
+        "SELECT task_id, lease_json FROM lease_cas WHERE task_id IN (SELECT value FROM json_each(?))",
+        requested,
+      ).map((row) => [row.task_id, checkedLease(JSON.parse(row.lease_json) as LeaseV1)]),
+    ),
+    relationRows = readRelationProjectionRowsForTargets(
       db,
-      [
-        "SELECT value_json FROM entity_projection WHERE entity_kind = 'execution' AND task_id = ?",
-        "ORDER BY json_extract(value_json, '$.iteration'), json_extract(value_json, '$.claimedAt'), entity_id",
-      ].join(" "),
-      taskId,
-    ).map((value) => JSON.parse(String(value.value_json)) as TaskLifecycleSnapshot["executions"][number]),
-    reviews = queryRows(
-      db,
-      "SELECT value_json FROM entity_projection WHERE entity_kind = 'review' AND task_id = ? ORDER BY entity_id",
-      taskId,
-    ).map((value) => JSON.parse(String(value.value_json)) as TaskLifecycleSnapshot["reviews"][number]);
-  const lease = now === undefined ? storedLease(db, taskId) : effectiveLease(db, taskId, now);
-  // The stored snapshot is pure task-aggregate state; the decision relations this task is a
-  // target of are stamped at read time as-of the applied cut, the same join the live lease uses.
-  const decisionRelations = readRelationProjectionRows(db, `task/${taskId}`).map(
-    ({ relationId, sourceRef, targetRef, relationType, state, strength, freshness }) => ({
-      relationId,
-      sourceRef,
-      targetRef,
-      relationType,
-      state,
-      strength,
-      freshness,
+      taskIds.map((taskId) => `task/${taskId}`),
+    ),
+    relations = new Map<string, ReturnType<typeof lifecycleRelation>[]>();
+  for (const row of relationRows) {
+    const values = relations.get(row.targetRef) ?? [];
+    values.push(lifecycleRelation(row));
+    relations.set(row.targetRef, values);
+  }
+  return new Map(
+    taskIds.flatMap((taskId) => {
+      const snapshot = snapshots.get(taskId);
+      if (!snapshot) return [];
+      const stored = leases.get(taskId) ?? null,
+        lease = now === undefined ? stored : effectiveLeaseValue(stored, now);
+      return [
+        [
+          taskId,
+          {
+            ...snapshot,
+            executions: executions.get(taskId) ?? [],
+            reviews: reviews.get(taskId) ?? [],
+            lease: lease?.phase === "released" ? null : lease,
+            decisionRelations: relations.get(`task/${taskId}`) ?? [],
+          },
+        ] as const,
+      ];
     }),
   );
-  return {
-    ...snapshot,
-    executions,
-    reviews,
-    lease: lease?.phase === "released" ? null : lease,
-    decisionRelations,
-  };
+}
+
+function lifecycleRelation({
+  relationId,
+  sourceRef,
+  targetRef,
+  relationType,
+  state,
+  strength,
+  freshness,
+}: ReturnType<typeof readRelationProjectionRows>[number]) {
+  return { relationId, sourceRef, targetRef, relationType, state, strength, freshness };
+}
+
+function effectiveLeaseValue(current: LeaseV1 | null, now: string): LeaseV1 | null {
+  if (current === null || current.phase === "released") return current;
+  if (current.expiresAt > now) return current;
+  return current.phase === "reserving" ? null : checkedLease({ ...current, phase: "orphaned" });
 }
 
 export function readIntervals(db: DatabaseSync, taskId: string): readonly LeaseInterval[] {
@@ -338,7 +408,15 @@ export function refreshRuntimeSessionAssociations(db: DatabaseSync, session: Run
     );
 }
 export function markRuntimeSessionsUnknown(db: DatabaseSync): number {
-  const rows = queryRows(db, "SELECT runtime_session_id, value_json FROM runtime_session");
+  const rows = queryRows(
+    db,
+    [
+      "SELECT runtime_session_id, value_json FROM runtime_session",
+      "WHERE json_extract(value_json, '$.liveness') NOT IN ('exited', 'unknown')",
+      "OR (json_extract(value_json, '$.liveness') = 'unknown'",
+      "AND json_extract(value_json, '$.attachable') <> 0)",
+    ].join(" "),
+  );
   let changed = 0;
   for (const row of rows) {
     const current = JSON.parse(String(row.value_json)) as RuntimeSession,

--- a/packages/kernel/src/projection/relation-entity-projection.ts
+++ b/packages/kernel/src/projection/relation-entity-projection.ts
@@ -213,6 +213,24 @@ export function readRelationProjectionRows(
   );
 }
 
+export function readRelationProjectionRowsForTargets(
+  db: DatabaseSync,
+  targetRefs: readonly string[],
+): readonly VersionedRelationProjectionRow[] {
+  if (targetRefs.length === 0) return [];
+  return relationProjectionRowsAtCut(
+    db,
+    queryRows<{ readonly row_json: string }>(
+      db,
+      [
+        "SELECT row_json FROM relation_edge",
+        "WHERE target_ref IN (SELECT value FROM json_each(?)) ORDER BY target_ref, relation_id",
+      ].join(" "),
+      JSON.stringify(targetRefs),
+    ),
+  );
+}
+
 /** Projection rows for selected relation_edge `row_json` values, each judged fresh or stale at this cut. */
 export function relationProjectionRowsAtCut(
   db: DatabaseSync,


### PR DESCRIPTION
# English

## Summary

fix-plan batch 8 second half (task_91bcef9ca1d4f5078d38a3e066, parent task_6eba9c5d3a55735920aa4856f3 / task_2b8f79fa4412cb726a26f9bfc7). The task projection's list reads hydrated every row with its own `readSnapshot` call (executions, reviews, leases, inbound decision relations: an N+1 per task). `readSnapshots` now hydrates a page with fixed batch reads and both full and paged lists assemble from that one result; the single-row read delegates to it. The two structural probes on cell open and latch recovery read one task-index row instead of hydrating the whole list, runtime-session startup invalidation selects only rows that actually need a transition, and Squad validation reuses the cell's entity store instead of opening a cold event-fold source. On the round-5 fixture (10,000 tasks, seed 20260911) the unparameterized task-list p50 goes 864.8 ms → 712.6 ms with byte-identical results; the remainder is serialisation of the deliberately unbounded 28.4 MB compatibility response, while the served CLI path stays capped at 50 rows. Digest check: the result digest moved from f11e8959 to 00e9a513 between the round-5 baseline and today's main only because `task.graph.maxIterations` was retired (7e21d60ed, 4b73e498a); graph, fact-search, and facts-all digests are identical and no row changed, so 00e9a513 is the new anchor. Production +169/-61.

## Architectural Justification

- The added lines are one batch assembler and one multi-target relation query replacing per-row hydration; the read path is the same projection with the same result shape, no cache, flag, or second implementation. Net production is positive because the fix replaces N single-row reads with a page-level assembler rather than deleting a path.

## What Changed

- `packages/kernel/src/projection/rebuildable-task-projection-runtime.ts`: `readSnapshots` batch hydration; selective runtime-session invalidation query.
- `packages/kernel/src/projection/relation-entity-projection.ts`: multi-target inbound relation read.
- `packages/kernel/src/projection/rebuildable-task-projection-reads.ts`: full and paged lists assemble from one batch.
- `packages/daemon/src/repo-cell.ts`, `repo-cell-open.ts`: probes use `readTaskIndex({ limit: 1 })`.
- `packages/daemon/src/squad-action-runtime.ts`: Squad validation passes the cell-backed entity store.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
- Per-row hydration, the two unbounded probes, and the cold Squad validation source are replaced in place, not removed as paths.
Deleted-Gates-Fixtures: none
- Production net lines: +169/-61 (`packages/*/src`, tests excluded).

## Machine-Readable Declarations

- Production-Delta: +169/-61

## Task And Scope

- Harness task: task_91bcef9ca1d4f5078d38a3e066, parent task_6eba9c5d3a55735920aa4856f3
- Branch: `codex/perf-w-a`
- Public scope: kernel task projection reads, daemon cell probes, squad validation
- Private planning/evidence updated: yes (`artifacts/report.md`)
- Out of scope: control-receipt retention (R2-03-F11, contract-bound), per-request read-model construction (R2-01-F4, already session-scoped), batch 4 schema changes

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: not applicable
- Machine-check boundary: not applicable
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `96ecbf402`
- Branch merge-base with `origin/main`: `96ecbf402`
- Last `git fetch origin` time: 2026-09-13 UTC
- Sync method: branched from origin/main
- Public diff command: `git diff origin/main...codex/perf-w-a`
- Private evidence commit/path: task_91bcef9ca1d4f5078d38a3e066 `artifacts/report.md`
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [x] `npm run typecheck` (worker, `tsc -b`)
- [ ] `npm run check`
- [x] `npm test` (worker: fast tier 716/718, the two reds are the long-tmp-path Unix socket fixture and the missing `lint-staged` formatter fixture; contract tier 1083/1084 → the one red was fixed in the delivered commit and re-run green)
- [x] `npm run harness:check-import-boundaries` (via `run-manifest-gates --changed origin/main`, worker 6/6 and CEO)
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts` (via `run-manifest-gates --changed origin/main`)
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Round-5 recipe before/after on the regenerated fixture: task-list p50 864.804 ms → 712.557 ms; full digest 00e9a513 and all four component digests identical before and after.

## Review Evidence

- CEO ground-truth: the only production caller of `readTaskIndex` without a limit is `repo-cell-task-query.ts`, which already applies `DEFAULT_TASK_LIST_LIMIT = 50` to flat lists; the bench's unparameterized read is the deliberate wide compatibility path, so the residual 712 ms is not a served-path regression. Digest cause verified against the two commits named in the report.
- Reviewer subagent: closeout review after merge
- Human review: pending
- Blocking findings: none open

## Residual Risk

- Batch hydration holds the parsed page and its grouped entities at once; memory for the wide path is unchanged in magnitude.
- The bench's wide path remains unbounded by contract; bounding it is a separate decision, not a perf fix.

## References

- Tasks: task_91bcef9ca1d4f5078d38a3e066; fix-plan batch 8; fix-plan-status-0912.md items 1–2

---

# 中文

## 概要

fix-plan 批 8 后半（task_91bcef9ca1d4f5078d38a3e066，父 task_6eba9c5d3a55735920aa4856f3 / task_2b8f79fa4412cb726a26f9bfc7）。任务投影的列表读对每一行各调一次 `readSnapshot` 水合（executions、reviews、leases、入向 decision 关系：每任务一次 N+1）。现在 `readSnapshots` 用固定批量读水合一页，全量与分页列表都从这一份结果组装，单行读委托给它。cell 打开与 latch 恢复的两处结构探针改读一行 task-index 而不是水合整表，runtime-session 启动失效只选真正需要转换的行，Squad 校验复用 cell 的 entity store 而不是冷开 event-fold 源。round-5 fixture（10,000 任务，seed 20260911）上无参任务列表 p50 864.8 ms → 712.6 ms，结果逐字节一致；余下是有意不设上限的 28.4 MB 兼容响应的序列化，而 CLI 服务路径仍固定 50 行。digest 核对：round-5 基线到今日 main 的结果 digest 从 f11e8959 变为 00e9a513，唯一原因是 `task.graph.maxIterations` 字段退役（7e21d60ed、4b73e498a）；graph、fact-search、facts-all 三个 digest 完全一致、无行变化，故 00e9a513 为新锚。生产 +169/-61。

## 架构辩护

- 新增行是一个批量组装器与一个多目标关系查询，替代逐行水合；读路径仍是同一投影、同一结果形状，没有缓存、flag 或第二实现。生产净增为正是因为修法是用页级组装器替换 N 次单行读，而不是删除路径。

## 改动内容

- `packages/kernel/src/projection/rebuildable-task-projection-runtime.ts`：`readSnapshots` 批量水合；runtime-session 失效查询收窄。
- `packages/kernel/src/projection/relation-entity-projection.ts`：多目标入向关系读。
- `packages/kernel/src/projection/rebuildable-task-projection-reads.ts`：全量与分页列表从一批结果组装。
- `packages/daemon/src/repo-cell.ts`、`repo-cell-open.ts`：探针用 `readTaskIndex({ limit: 1 })`。
- `packages/daemon/src/squad-action-runtime.ts`：Squad 校验传入 cell 的 entity store。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 逐行水合、两处无界探针、Squad 校验冷源都是原地替换，不是删除路径。
- 删除的门或 fixture：none
- 生产净行数：+169/-61（`packages/*/src` 不含测试）。

## 机器可读声明

- Production-Delta: +169/-61

## 任务与范围

- Harness 任务：task_91bcef9ca1d4f5078d38a3e066，父任务 task_6eba9c5d3a55735920aa4856f3
- 分支：`codex/perf-w-a`
- 公开范围：kernel 任务投影读、daemon cell 探针、squad 校验
- 私有计划/证据已更新：是（`artifacts/report.md`）
- 范围外：control receipt 保留（R2-03-F11，契约约束）、每请求读模型构造（R2-01-F4，已 session 作用域）、批 4 schema 改动

## 版本影响

- 版本：不变
- 发布影响：不发布

## 治理声明

- 触碰受保护面：否
- 受保护面范围：不适用
- 授权：不适用
- 机器检查边界：不适用
- Break-glass：否
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- 基线 `origin/main` SHA：`96ecbf402`
- 分支与 `origin/main` 的 merge-base：`96ecbf402`
- 最近一次 `git fetch origin`：2026-09-13 UTC
- 同步方式：从 origin/main 开分支
- 公开 diff 命令：`git diff origin/main...codex/perf-w-a`
- 私有证据路径：task_91bcef9ca1d4f5078d38a3e066 的 `artifacts/report.md`
- 评审证据路径：本 PR 的评审证据节
- GitHub Actions `rewrite-ci` run URL：本 PR 待跑
- worker：fast 整层 716/718（两红是长临时路径 Unix socket fixture 与缺 `lint-staged` 的格式化 fixture）；contract 整层 1083/1084，唯一红已在交付提交里修正并复跑绿；`tsc -b` 0；changed gates 6/6。round-5 配方修前/修后：task-list p50 864.804 ms → 712.557 ms，完整 digest 00e9a513 与四个分项 digest 前后一致。

## 评审证据

- CEO 事实核对：无 limit 调用 `readTaskIndex` 的唯一生产调用方是 `repo-cell-task-query.ts`，它对平铺列表已套 `DEFAULT_TASK_LIST_LIMIT = 50`；台架的无参读是有意保留的宽兼容路径，余下 712 ms 不是服务路径回归。digest 成因对照报告点名的两个提交核过。
- 评审子代理：合入后派收口评审
- 人工评审：待定
- 阻塞发现：无

## 残余风险

- 批量水合同时持有解析后的页与分组实体；宽路径内存量级不变。
- 台架宽路径按契约仍无上限；给它加上限是独立裁决，不是性能修复。

## 参考

- 任务：task_91bcef9ca1d4f5078d38a3e066；fix-plan 批 8；fix-plan-status-0912.md 第 1–2 项
