### PR TITLE
test(daemon): share clock in orphan lease projection

### DIFF
--- a/packages/daemon/test/runtime-spawn-lifecycle.integration.test.ts
+++ b/packages/daemon/test/runtime-spawn-lifecycle.integration.test.ts
@@ -1650,6 +1650,7 @@ test("dispatch reclaims an orphaned task lease instead of requiring a manual rel
       const projection = makeTaskProjection({
         rootDir: root,
         eventStore: makeTaskEventReader({ repoId: "runtime-orphan-lease", rootDir: root }),
+        now: () => clock,
       });
       try {
         const snapshot = projection.read(taskId).snapshot;


### PR DESCRIPTION
# English

## Summary

Test determinism fix (task_62b2d9a9422e715a0dd82ae1fd, parent task_8f0bdfa8f340b078aed05df7e3). `runtime-spawn-lifecycle.integration.test.ts` "dispatch reclaims an orphaned task lease instead of requiring a manual release" drove the repo cell and the reclaim write path with a fixture clock (`2026-09-11T00:01:01Z`) but built its final independent `makeTaskProjection` without `now`, so that projection judged the reclaimed lease against the host's real wall clock and reported `orphaned` once real time was more than the 60 s TTL past the fixture instant. That made the test red on the isolated Ubuntu runner at origin/main and twice on PR #2510's shard 2. The projection now shares the fixture clock; one added line, no production change. Isolated run: 7/8 → 8/8.

## Architectural Justification

-

## What Changed

- `packages/daemon/test/runtime-spawn-lifecycle.integration.test.ts`: pass `now: () => clock` to the final `makeTaskProjection`.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: +0/-0 (`packages/*/src`, tests excluded).

## Machine-Readable Declarations

- None.

## Task And Scope

- Harness task: task_62b2d9a9422e715a0dd82ae1fd, parent task_8f0bdfa8f340b078aed05df7e3
- Branch: `codex/orphan-lease-flake`
- Public scope: one daemon integration test
- Private planning/evidence updated: yes (`artifacts/report.md`)
- Out of scope: lease TTL semantics, other flakes in task_8f0bdfa8

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: not applicable
- Machine-check boundary: not applicable
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `96ecbf402`
- Branch merge-base with `origin/main`: `96ecbf402`
- Last `git fetch origin` time: 2026-09-13 UTC
- Sync method: branched from origin/main
- Public diff command: `git diff origin/main...codex/orphan-lease-flake`
- Private evidence commit/path: task_62b2d9a9422e715a0dd82ae1fd `artifacts/report.md`
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [x] `npm run typecheck` (worker)
- [ ] `npm run check`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Worker: `node tools/dispatch-isolated-test.mjs --file packages/daemon/test/runtime-spawn-lifecycle.integration.test.ts` red before (7/8, actual orphaned / expected held) and green after (8/8) on the isolated Ubuntu runner.

## Review Evidence

- CEO ground-truth: the CEO reproduced the failure on origin/main in isolation before dispatch and predicted this clock split; the fix is exactly that one line.
- Reviewer subagent: not required for a one-line test fix
- Human review: pending
- Blocking findings: none open

## Residual Risk

- None beyond the test itself.

## References

- Tasks: task_62b2d9a9422e715a0dd82ae1fd, task_8f0bdfa8f340b078aed05df7e3; blocks PR #2510

---

# 中文

## 概要

测试确定性修复（task_62b2d9a9422e715a0dd82ae1fd，父 task_8f0bdfa8f340b078aed05df7e3）。`runtime-spawn-lifecycle.integration.test.ts` 的「dispatch reclaims an orphaned task lease instead of requiring a manual release」用 fixture 时钟（`2026-09-11T00:01:01Z`）驱动 repo cell 与 reclaim 写路径，但最后独立构造的 `makeTaskProjection` 没传 `now`，于是该投影拿宿主真实墙钟判定被回收的 lease，真实时间超过 fixture 时刻 60 s TTL 后就报 `orphaned`。这使它在 origin/main 的隔离 Ubuntu 环境红、在 PR #2510 分片 2 两次红。现在投影共用 fixture 时钟；加一行，生产代码不变。隔离运行 7/8 → 8/8。

## 架构辩护

-

## 改动内容

- `packages/daemon/test/runtime-spawn-lifecycle.integration.test.ts`：给最后的 `makeTaskProjection` 传 `now: () => clock`。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 删除的门或 fixture：none
- 生产净行数：+0/-0（`packages/*/src` 不含测试）。

## 机器可读声明

- 无。

## 任务与范围

- Harness 任务：task_62b2d9a9422e715a0dd82ae1fd，父任务 task_8f0bdfa8f340b078aed05df7e3
- 分支：`codex/orphan-lease-flake`
- 公开范围：一个 daemon 集成测试
- 私有计划/证据已更新：是（`artifacts/report.md`）
- 范围外：lease TTL 语义、task_8f0bdfa8 里的其他 flake

## 版本影响

- 版本：不变
- 发布影响：不发布

## 治理声明

- 触碰受保护面：否
- 受保护面范围：不适用
- 授权：不适用
- 机器检查边界：不适用
- Break-glass：否
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- 基线 `origin/main` SHA：`96ecbf402`
- 分支与 `origin/main` 的 merge-base：`96ecbf402`
- 最近一次 `git fetch origin`：2026-09-13 UTC
- 同步方式：从 origin/main 开分支
- 公开 diff 命令：`git diff origin/main...codex/orphan-lease-flake`
- 私有证据路径：task_62b2d9a9422e715a0dd82ae1fd 的 `artifacts/report.md`
- 评审证据路径：本 PR 的评审证据节
- GitHub Actions `rewrite-ci` run URL：本 PR 待跑
- worker：`node tools/dispatch-isolated-test.mjs --file packages/daemon/test/runtime-spawn-lifecycle.integration.test.ts` 修前红（7/8，actual orphaned / expected held）、修后绿（8/8）。

## 评审证据

- CEO 事实核对：派工前 CEO 已在 origin/main 隔离复现并预判了时钟分裂；修复正是那一行。
- 评审子代理：一行测试修复不需要
- 人工评审：待定
- 阻塞发现：无

## 残余风险

- 除该测试本身外无。

## 参考

- 任务：task_62b2d9a9422e715a0dd82ae1fd、task_8f0bdfa8f340b078aed05df7e3；解锁 PR #2510
