### PR TITLE
perf: reuse validated event bytes and narrow blob reads

### DIFF
--- a/packages/application/src/task-lifecycle-service.ts
+++ b/packages/application/src/task-lifecycle-service.ts
@@ -387,10 +387,11 @@ function planned<A>(plan: FrozenWritePlan, target: WriteTarget, write: () => A):
   return write();
 }
 export function assertWriteTargetDeclared(plan: FrozenWritePlan, target: WriteTarget): void {
+  const targetJson = json(target);
   if (
     !Object.isFrozen(plan) ||
     !Object.isFrozen(plan.targets) ||
-    !plan.targets.some((candidate) => json(candidate) === json(target))
+    !plan.targets.some((candidate) => json(candidate) === targetJson)
   )
     throw new TaskLifecycleOperationConflict(`undeclared_write_target: ${json(target)}`);
 }

--- a/packages/daemon/src/artifact-entity-action.ts
+++ b/packages/daemon/src/artifact-entity-action.ts
@@ -911,7 +911,9 @@ function artifactReplayReceipt(
 }
 
 function titleFromContent(content: Uint8Array, relative: string): string {
-  const decoded = new TextDecoder("utf-8").decode(content),
+  const decoded = new TextDecoder("utf-8").decode(content.subarray(0, 16 * 1024), {
+      stream: content.byteLength > 16 * 1024,
+    }),
     heading = /^#\s+(.+)$/mu.exec(decoded)?.[1]?.trim();
   return heading || path.basename(relative, path.extname(relative));
 }

--- a/packages/daemon/src/distill-actions.ts
+++ b/packages/daemon/src/distill-actions.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { readFileSync, realpathSync, statSync } from "node:fs";
+import { closeSync, openSync, readSync, readFileSync, realpathSync, statSync } from "node:fs";
 import path from "node:path";
 import {
   resolveHarnessLayout,
@@ -323,14 +323,28 @@ function isProjectionCut(value: unknown): value is ProjectionCut {
   );
 }
 function suggestedClaimFromWorkspaceFile(rootDir: string, relativePath: string): string {
-  return truncateClaim(readFileSync(path.join(rootDir, relativePath), "utf8"));
+  const fd = openSync(path.join(rootDir, relativePath), "r"),
+    buffer = Buffer.allocUnsafe(8192),
+    decoder = new TextDecoder("utf-8");
+  let text = "";
+  try {
+    for (;;) {
+      const length = readSync(fd, buffer),
+        done = length === 0;
+      text += decoder.decode(buffer.subarray(0, length), { stream: !done });
+      const first = /\S/u.exec(text);
+      if (first) {
+        text = text.slice(first.index);
+        if (done || text.includes("\n") || text.trimEnd().length > 240) return truncateClaim(text);
+      } else text = "";
+      if (done) return truncateClaim(text);
+    }
+  } finally {
+    closeSync(fd);
+  }
 }
 function truncateClaim(input: string): string {
-  const line =
-    input
-      .split(/\r?\n/u)
-      .map((entry) => entry.trim())
-      .find(Boolean) ?? "Distill candidate requires an explicit promotion claim.";
+  const line = /[^\n]*\S[^\n]*/u.exec(input)?.[0]?.trim() ?? "Distill candidate requires an explicit promotion claim.";
   return line.length > 240 ? `${line.slice(0, 237)}...` : line;
 }
 function nonEmptyString(value: unknown): value is string {

--- a/packages/daemon/src/distill-actions.ts
+++ b/packages/daemon/src/distill-actions.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { closeSync, openSync, readSync, readFileSync, realpathSync, statSync } from "node:fs";
+import { readFileSync, realpathSync, statSync } from "node:fs";
 import path from "node:path";
 import {
   resolveHarnessLayout,
@@ -323,25 +323,7 @@ function isProjectionCut(value: unknown): value is ProjectionCut {
   );
 }
 function suggestedClaimFromWorkspaceFile(rootDir: string, relativePath: string): string {
-  const fd = openSync(path.join(rootDir, relativePath), "r"),
-    buffer = Buffer.allocUnsafe(8192),
-    decoder = new TextDecoder("utf-8");
-  let text = "";
-  try {
-    for (;;) {
-      const length = readSync(fd, buffer),
-        done = length === 0;
-      text += decoder.decode(buffer.subarray(0, length), { stream: !done });
-      const first = /\S/u.exec(text);
-      if (first) {
-        text = text.slice(first.index);
-        if (done || text.includes("\n") || text.trimEnd().length > 240) return truncateClaim(text);
-      } else text = "";
-      if (done) return truncateClaim(text);
-    }
-  } finally {
-    closeSync(fd);
-  }
+  return truncateClaim(readFileSync(path.join(rootDir, relativePath), "utf8"));
 }
 function truncateClaim(input: string): string {
   const line = /[^\n]*\S[^\n]*/u.exec(input)?.[0]?.trim() ?? "Distill candidate requires an explicit promotion claim.";

--- a/packages/daemon/src/entity-action-catalog-executor.ts
+++ b/packages/daemon/src/entity-action-catalog-executor.ts
@@ -630,6 +630,7 @@ function matchingReplayBundle(
     const claim = existing.payload.factsDocumentClaim,
       bytes = store.readContentBlob(claim.sha256);
     if (!bytes) reject("content_not_ready", `Facts content for ${existing.taskId} is unavailable.`);
+    const body = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
     return {
       event: existing,
       plan: factWritePlan(existing),
@@ -638,11 +639,11 @@ function matchingReplayBundle(
           sha256: claim.sha256,
           size: claim.size,
           mediaType: claim.mediaType,
-          body: new TextDecoder("utf-8", { fatal: true }).decode(bytes),
+          body,
         },
       ],
       path: claim.path,
-      body: new TextDecoder("utf-8", { fatal: true }).decode(bytes),
+      body,
     };
   }
   if (existing?.schema === "decision-event/v1" && !writesFact) {

--- a/packages/daemon/src/entity-content-read.ts
+++ b/packages/daemon/src/entity-content-read.ts
@@ -97,16 +97,18 @@ export function readEntityContent(input: {
     mediaOf = new Map(ownedContent.content.map(({ sha256, mediaType }) => [sha256, mediaType] as const)),
     file = bindings.find(({ path: bound }) => bound === manifestPath);
   if (file) {
-    const bytes = input.source.readContentBlob(file.contentSha256),
+    const size = sizeOf.get(file.contentSha256),
+      maxBytes = input.maxBytes ?? ENTITY_CONTENT_READ_MAX_BYTES,
       base = {
         ...contentResult("file", entityRef, relative, repositoryPath),
-        sizeBytes: sizeOf.get(file.contentSha256) ?? bytes?.byteLength ?? null,
+        sizeBytes: size ?? null,
         mediaType: mediaOf.get(file.contentSha256) ?? null,
       };
-    // An accepted object that storage cannot produce is a storage failure, not an absent file: say so rather
-    // than inventing an empty one.
+    if (size !== undefined && size > maxBytes) return { ...base, outcome: "too-large" };
+    const bytes = input.source.readContentBlob(file.contentSha256);
     if (!bytes) return { ...base, outcome: "missing", sizeBytes: null, mediaType: null };
-    if (bytes.byteLength > (input.maxBytes ?? ENTITY_CONTENT_READ_MAX_BYTES)) return { ...base, outcome: "too-large" };
+    base.sizeBytes = size ?? bytes.byteLength;
+    if (bytes.byteLength > maxBytes) return { ...base, outcome: "too-large" };
     const text = decodeUtf8(bytes);
     return text === null || text.includes(NUL) ? { ...base, outcome: "binary" } : { ...base, content: text };
   }

--- a/packages/daemon/test/artifact-entity-action.integration.test.ts
+++ b/packages/daemon/test/artifact-entity-action.integration.test.ts
@@ -7,11 +7,90 @@ import { createServer } from "node:http";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
-import { deriveArtifactContentVersion, makeTaskEventReader, makeTaskProjection } from "../../kernel/src/index.ts";
+import {
+  entityContentPath,
+  requireEntityStoreKindContract,
+  deriveArtifactContentVersion,
+  makeTaskEventReader,
+  makeTaskProjection,
+} from "../../kernel/src/index.ts";
 import { canonicalRoot, workspaceId } from "../src/protocol/daemon-protocol.contract.ts";
 import { withRoleBinding } from "./role-binding.fixtures.ts";
 import { openBootstrappedRepoCell as openRepoCell, waitForFixturePublication } from "./repo-settings.fixture.ts";
 import { initRepo } from "./task-surface.fixtures.ts";
+
+import { readEntityContent } from "../src/entity-content-read.ts";
+import { prepareDistillCandidate } from "../src/distill-actions.ts";
+
+test("owned-content size admission avoids reading oversized objects", () => {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-content-size-")),
+    contract = requireEntityStoreKindContract("agent"),
+    sha256 = "a".repeat(64),
+    ownedContent = {
+      schema: "entity-owned-content/v1",
+      ownerRef: "agent/terra",
+      schemaId: contract.schema.$id,
+      schemaVersion: 1,
+      content: [{ sha256, byteLength: 100, mediaType: "text/markdown" }],
+      bindings: [
+        { path: entityContentPath(contract, "terra", "large.md"), contentSha256: sha256, policyId: "test/v1" },
+      ],
+      directories: [],
+      retirements: [],
+      directoryRetirements: [],
+    } as const;
+  let reads = 0;
+  try {
+    const source = {
+      entityKind: "agent",
+      contract,
+      entityId: "terra",
+      ownedContent,
+      readContentBlob: () => {
+        reads += 1;
+        return Buffer.from("small");
+      },
+    };
+    assert.equal(readEntityContent({ rootDir, source, requestedPath: "large.md", maxBytes: 99 }).outcome, "too-large");
+    assert.equal(reads, 0);
+    assert.equal(readEntityContent({ rootDir, source, requestedPath: "large.md", maxBytes: 100 }).content, "small");
+    assert.equal(reads, 1);
+  } finally {
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});
+
+test("distill claim streaming preserves first nonblank lines across UTF-8 chunk boundaries", () => {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-distill-prefix-"));
+  try {
+    for (const text of [
+      "\n \r\n中文 claim\n" + "tail".repeat(10000),
+      " ".repeat(8191) + "中文 boundary\nsecond",
+      "x".repeat(300) + "\n",
+      " \r\n".repeat(10000),
+    ]) {
+      writeFileSync(path.join(rootDir, "input.md"), text);
+      const result = prepareDistillCandidate({
+        rootDir,
+        action: { taskId: "task-one", inputPath: "input.md" },
+        opId: "op-one",
+        revision: 1,
+        now: () => "2026-09-12T00:00:00.000Z",
+        readEntity: () => {
+          throw new Error("workspace file must not read an entity");
+        },
+      });
+      const first =
+        text
+          .split(/\r?\n/u)
+          .map((line) => line.trim())
+          .find(Boolean) ?? "Distill candidate requires an explicit promotion claim.";
+      assert.equal(JSON.parse(result.body).suggestedClaim, first.length > 240 ? `${first.slice(0, 237)}...` : first);
+    }
+  } finally {
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});
 
 const kind = "entity-kind/KND-1f5c0a7e9b3d4c6a8e2f0b1d3c5a7e94",
   researchKind = "entity-kind/KND-3b7e2c9a1d5f6e8c0a4b2d3f5e7c9a16",

--- a/packages/kernel/src/domain/doc-sync-canonical-events.ts
+++ b/packages/kernel/src/domain/doc-sync-canonical-events.ts
@@ -143,7 +143,7 @@ export function serializeCanonicalEvent(event: CanonicalEventV1): string {
   const entry = canonicalEventSchemas.find((candidate) => candidate.schema === event.schema);
   const errors = entry?.validate(event) ?? ["canonical event schema is unknown"];
   if (errors.length) throw new Error(errors.join("; "));
-  return canonicalEventBytes(event);
+  return serializeCanonicalEventUnchecked(event);
 }
 
 export function serializePersistedCanonicalEvent(event: PersistedCanonicalEventV1): string {
@@ -151,7 +151,7 @@ export function serializePersistedCanonicalEvent(event: PersistedCanonicalEventV
     entry = canonicalEventSchemas.find((candidate) => candidate.schema === normalized.schema),
     errors = entry?.validate(normalized) ?? ["canonical event schema is unknown"];
   if (errors.length) throw new Error(errors.join("; "));
-  return canonicalEventBytes(event);
+  return serializeCanonicalEventUnchecked(event);
 }
 
 export function parseCanonicalEvent(body: string): CanonicalEventV1 {
@@ -166,7 +166,7 @@ export function parseCanonicalEvent(body: string): CanonicalEventV1 {
     entry = canonicalEventSchemas.find((candidate) => candidate.schema === normalized.schema),
     errors = entry?.validate(normalized) ?? ["canonical event schema is unknown"];
   if (errors.length) throw new Error(errors.join("; "));
-  if (canonicalEventBytes(value as unknown as CanonicalEventV1) !== body)
+  if (serializeCanonicalEventUnchecked(value as unknown as CanonicalEventV1) !== body)
     throw new Error("canonical event bytes are not canonical");
   return value as unknown as CanonicalEventV1;
 }
@@ -194,7 +194,8 @@ function normalizePersistedValue(value: unknown, field = ""): unknown {
     : normalized;
 }
 
-function canonicalEventBytes(event: PersistedCanonicalEventV1): string {
+/** Encode already validated current or historical events without changing their persisted bytes. */
+export function serializeCanonicalEventUnchecked(event: PersistedCanonicalEventV1): string {
   return `${JSON.stringify(canonicalizeWriteValue(event))}\n`;
 }
 

--- a/packages/kernel/src/domain/doc-sync-writer.ts
+++ b/packages/kernel/src/domain/doc-sync-writer.ts
@@ -29,6 +29,7 @@ import { isTaskBoundRuntimeWriter, runtimeSessionIdFromActor } from "./task-boun
 import {
   freezeDeclaredWritePlan,
   isFrozenWritePlan,
+  sameWriteTargets,
   isRecord,
   normalizeContentAddressedInputs,
   type FrozenWritePlan,
@@ -379,13 +380,13 @@ export function assertDocSyncWritePlan(
   event: DocEventV1,
   plan: FrozenWritePlan<"DocSyncSubmit"> | undefined,
 ): asserts plan is FrozenWritePlan<"DocSyncSubmit"> {
-  const expected = docSyncWritePlan(event),
-    shape = (candidate: FrozenWritePlan<"DocSyncSubmit">) =>
-      stableStringify({
-        commandType: candidate.commandType,
-        targets: candidate.targets.map(stableStringify).sort(),
-      });
-  if (plan === undefined || !isFrozenWritePlan(plan) || shape(plan) !== shape(expected))
+  const expected = docSyncWritePlan(event);
+  if (
+    plan === undefined ||
+    !isFrozenWritePlan(plan) ||
+    plan.commandType !== expected.commandType ||
+    !sameWriteTargets(plan.targets, expected.targets)
+  )
     throw new DocSyncContractError("doc write plan must exactly declare event, head, projection, and content targets");
 }
 

--- a/packages/kernel/src/domain/doc-sync.contract.ts
+++ b/packages/kernel/src/domain/doc-sync.contract.ts
@@ -18,6 +18,7 @@ export {
   parseCanonicalEvent,
   serializeCanonicalEvent,
   serializePersistedCanonicalEvent,
+  serializeCanonicalEventUnchecked,
   validateCurrentCanonicalEvent,
 } from "./doc-sync-canonical-events.ts";
 export {

--- a/packages/kernel/src/domain/entity-action-explanation.ts
+++ b/packages/kernel/src/domain/entity-action-explanation.ts
@@ -249,7 +249,17 @@ function validateAction(
   if (
     canonicalAction &&
     Array.isArray(value.criteria) &&
-    JSON.stringify(value.criteria.map(staticCriterion)) !== JSON.stringify(canonicalAction.criteria)
+    (value.criteria.length !== canonicalAction.criteria.length ||
+      value.criteria.some((criterion, index) => {
+        const expected = canonicalAction.criteria[index];
+        return (
+          !explanationRecord(criterion) ||
+          !expected ||
+          criterion.ref !== expected.ref ||
+          criterion.failureCode !== expected.failureCode ||
+          criterion.explain !== expected.explain
+        );
+      }))
   )
     errors.push("criteria must preserve the canonical Action contract identity and order");
   if (
@@ -359,10 +369,6 @@ function explanationCatalog(kind: string) {
     pattern: "^[A-Z][A-Z0-9]{0,15}-[a-f0-9]{16}$",
     refTemplate: `${kind}/{id}`,
   });
-}
-
-function staticCriterion(value: unknown): unknown {
-  return explanationRecord(value) ? { ref: value.ref, failureCode: value.failureCode, explain: value.explain } : value;
 }
 
 function validateCriterion(value: unknown): readonly string[] {

--- a/packages/kernel/src/domain/entity-event-compile.ts
+++ b/packages/kernel/src/domain/entity-event-compile.ts
@@ -27,7 +27,7 @@ import {
   type EntityUpdatedEventV1,
   type EntityUpsertEventV1,
 } from "./entity-event.ts";
-import { parseEntityJsonSchema, serializeEntityJsonSchema } from "./entity-json-schema.ts";
+import { parseEntityJsonSchema, serializeEntityJsonSchemaUnchecked } from "./entity-json-schema.ts";
 import {
   entityDocumentPath,
   requireEntityStoreKindContract,
@@ -305,7 +305,7 @@ export function compileEntityDeleted(
 }
 
 function declarationContent(contract: EntityStoreKindContract, entityId: string, entity: unknown) {
-  const body = serializeEntityJsonSchema(contract.schema, entity, `${contract.kind} declaration`),
+  const body = serializeEntityJsonSchemaUnchecked(entity),
     claim: EntityDeclarationClaim = {
       path: normalizeRelativeDocumentPath(entityDocumentPath(contract, entityId)),
       sha256: sha256Text(body),

--- a/packages/kernel/src/domain/entity-event.ts
+++ b/packages/kernel/src/domain/entity-event.ts
@@ -39,6 +39,7 @@ import {
   hasOnlyFields,
   hasRequiredFields,
   isFrozenWritePlan,
+  sameWriteTargets,
   isRecord,
   validateEventEnvelopeIdentity,
   type ActorIdentity,
@@ -776,9 +777,12 @@ export function declarationWritePlan<Command extends "EntityUpsert" | "EntityCon
 }
 
 function assertExactWritePlan(plan: FrozenWritePlan | undefined, expected: FrozenWritePlan): void {
-  const shape = (value: FrozenWritePlan) =>
-    stableStringify({ commandType: value.commandType, targets: value.targets.map(stableStringify).sort() });
-  if (plan === undefined || !isFrozenWritePlan(plan) || shape(plan) !== shape(expected))
+  if (
+    plan === undefined ||
+    !isFrozenWritePlan(plan) ||
+    plan.commandType !== expected.commandType ||
+    !sameWriteTargets(plan.targets, expected.targets)
+  )
     throw new Error("entity write plan must exactly declare its event, declaration, projection, and content targets");
 }
 

--- a/packages/kernel/src/domain/entity-json-schema.ts
+++ b/packages/kernel/src/domain/entity-json-schema.ts
@@ -83,7 +83,12 @@ export function serializeEntityJsonSchema<T>(
   value: unknown,
   label?: string,
 ): string {
-  return `${JSON.stringify(parseEntityJsonSchema(schema, value, label), null, 2)}\n`;
+  return serializeEntityJsonSchemaUnchecked(parseEntityJsonSchema(schema, value, label));
+}
+
+/** The caller has already decoded the value against its declaration schema. */
+export function serializeEntityJsonSchemaUnchecked(value: unknown): string {
+  return `${JSON.stringify(value, null, 2)}\n`;
 }
 
 export function explainEntityJsonSchema(schema: EntityDocumentJsonSchema): readonly EntitySchemaFieldExplanation[] {

--- a/packages/kernel/src/domain/entity-relation.ts
+++ b/packages/kernel/src/domain/entity-relation.ts
@@ -235,7 +235,7 @@ export function isAllowedRelationRecord(
 
 export function assertGovernedRelationRecord(
   record: EntityRelationRecord,
-  witness: GovernedRelationRegistryWitness,
+  witness: unknown,
   allowUnknownFields = false,
 ): void {
   assertGovernedRelationRegistryWitness(witness, allowUnknownFields);

--- a/packages/kernel/src/domain/migration-import-event.ts
+++ b/packages/kernel/src/domain/migration-import-event.ts
@@ -1,6 +1,5 @@
 import {
   assertGovernedRelationRecord,
-  assertGovernedRelationRegistryWitness,
   deriveRelationId,
   relationDirections,
   relationOrigins,
@@ -416,7 +415,6 @@ function validRelationEntity(value: Readonly<Record<string, unknown>>, allowUnkn
   if (!valid) return false;
   if (value.registry === undefined) return true;
   try {
-    assertGovernedRelationRegistryWitness(value.registry, allowUnknownFields);
     assertGovernedRelationRecord(relation as unknown as EntityRelationRecord, value.registry, allowUnknownFields);
     return true;
   } catch {

--- a/packages/kernel/src/domain/people-event.ts
+++ b/packages/kernel/src/domain/people-event.ts
@@ -4,7 +4,7 @@ import {
   applyPeopleRosterAction,
   parsePeopleRosterDocument,
   PEOPLE_ROSTER_PATH,
-  serializePeopleRosterDocument,
+  normalizePeopleRoster,
   type AppliedPeopleRosterAction,
   type PeopleRosterAction,
   type PeopleRosterDocumentV1,
@@ -123,7 +123,8 @@ export function compilePeopleRosterActionEvent(input: {
         baseDocumentSha256: input.currentBody === null ? null : sha256Text(input.currentBody),
       },
     };
-  const errors = validateCurrentPeopleEvent(event);
+  // applyPeopleRosterAction has validated the new roster; only the ingress envelope remains unchecked.
+  const errors = validateEventEnvelopeIdentity(event);
   if (errors.length) throw new Error(errors.join("; "));
   return {
     ...applied,
@@ -192,7 +193,7 @@ const peopleActions: readonly PeopleRosterAction["kind"][] = Object.freeze([
 function validRoster(value: unknown, allowUnknownFields: boolean): value is PeopleRosterDocumentV1 {
   try {
     const roster = value as PeopleRosterDocumentV1;
-    const normalized = parsePeopleRosterDocument(serializePeopleRosterDocument(roster));
+    const normalized = normalizePeopleRoster(roster);
     return allowUnknownFields || stableStringify(normalized) === stableStringify(roster);
   } catch {
     return false;

--- a/packages/kernel/src/domain/people-roster.ts
+++ b/packages/kernel/src/domain/people-roster.ts
@@ -150,22 +150,26 @@ export function parsePeopleRosterDocument(body: string): PeopleRosterDocumentV1 
   };
 }
 
-export function serializePeopleRosterDocument(roster: PeopleRosterDocumentV1): string {
-  const bindings = roster.bindings ?? [];
-  const delegatedExecutionTokens = roster.delegatedExecutionTokens ?? [];
+export function normalizePeopleRoster(roster: PeopleRosterDocumentV1): PeopleRosterDocumentV1 {
+  const bindings = roster.bindings ?? [],
+    delegatedExecutionTokens = roster.delegatedExecutionTokens ?? [];
   validatePeopleRoster(roster.people, roster.roles, bindings, delegatedExecutionTokens);
+  return {
+    schema: PEOPLE_ROSTER_SCHEMA,
+    people: roster.people.map(orderedPerson),
+    roles: roster.roles.map(({ roleId, commandClasses }) => ({ roleId, commandClasses: [...commandClasses] })),
+    bindings: bindings.map(orderedBinding),
+    delegatedExecutionTokens: delegatedExecutionTokens.map(orderedDelegatedExecutionToken),
+  } as unknown as PeopleRosterDocumentV1;
+}
+
+export function serializePeopleRosterDocument(roster: PeopleRosterDocumentV1): string {
+  const { bindings, delegatedExecutionTokens, ...value } = normalizePeopleRoster(roster);
   return `${JSON.stringify(
     {
-      schema: PEOPLE_ROSTER_SCHEMA,
-      people: roster.people.map(orderedPerson),
-      roles: roster.roles.map(({ roleId, commandClasses }) => ({
-        roleId,
-        commandClasses: [...commandClasses],
-      })),
-      ...(bindings.length ? { bindings: bindings.map(orderedBinding) } : {}),
-      ...(delegatedExecutionTokens.length
-        ? { delegatedExecutionTokens: delegatedExecutionTokens.map(orderedDelegatedExecutionToken) }
-        : {}),
+      ...value,
+      ...(bindings.length ? { bindings } : {}),
+      ...(delegatedExecutionTokens.length ? { delegatedExecutionTokens } : {}),
     },
     null,
     2,
@@ -191,9 +195,9 @@ export function applyPeopleRosterAction(
     if (!merged.ok) throw new PeopleRosterContractError(merged.reason);
     next = parsePeopleRosterDocument(merged.body);
   }
+  const body = serializePeopleRosterDocument(next);
   assertPeopleRosterActionInvariants(current, next, action);
-  const body = serializePeopleRosterDocument(next),
-    changed = currentBody === null || body !== currentBody,
+  const changed = currentBody === null || body !== currentBody,
     targetPersonId =
       action.kind === "people-add"
         ? action.person.personId
@@ -226,7 +230,6 @@ function addPerson(
   if (roster.people.length > 0 && person.roles.includes("owner"))
     throw new PeopleRosterContractError("the owner role is reserved for the bootstrap creator");
   const roles = withRolePolicy(roster.roles, rolePolicy);
-  validatePeopleRoster([...roster.people, person], roles, roster.bindings, roster.delegatedExecutionTokens);
   return {
     schema: PEOPLE_ROSTER_SCHEMA,
     people: [...roster.people, person],
@@ -253,7 +256,6 @@ function setPersonRole(
     people = roster.people.map((person) =>
       person.personId === personId ? { ...person, roles: [rolePolicy.roleId] } : person,
     );
-  validatePeopleRoster(people, roles, roster.bindings, roster.delegatedExecutionTokens);
   return {
     schema: PEOPLE_ROSTER_SCHEMA,
     people,
@@ -278,7 +280,6 @@ function bindActorRole(roster: PeopleRosterDocumentV1, value: RoleBinding): Peop
       existing < 0
         ? [...roster.bindings, binding]
         : roster.bindings.map((candidate, index) => (index === existing ? binding : candidate));
-  validatePeopleRoster(roster.people, roster.roles, bindings, roster.delegatedExecutionTokens);
   return { ...roster, bindings };
 }
 
@@ -302,7 +303,6 @@ function issueDelegatedExecutionToken(
     throw new PeopleRosterContractError(`DelegatedExecutionToken ${token.tokenId} already exists`);
   }
   const delegatedExecutionTokens = [...roster.delegatedExecutionTokens, token];
-  validatePeopleRoster(roster.people, roster.roles, roster.bindings, delegatedExecutionTokens);
   return { ...roster, delegatedExecutionTokens };
 }
 
@@ -323,7 +323,6 @@ function revokeDelegatedExecutionToken(
     delegatedExecutionTokens = roster.delegatedExecutionTokens.map((token) =>
       token.tokenId === tokenId ? revoked : token,
     );
-  validatePeopleRoster(roster.people, roster.roles, roster.bindings, delegatedExecutionTokens);
   return { ...roster, delegatedExecutionTokens };
 }
 

--- a/packages/kernel/src/domain/relation-event.ts
+++ b/packages/kernel/src/domain/relation-event.ts
@@ -295,6 +295,10 @@ export function compileRelationCreatedEvent(input: {
 }): RelationCreated {
   assertRelationEventRecord(input.record);
   assertRelationAdmission(input.record, input.directions);
+  return relationCreatedEvent(input);
+}
+
+function relationCreatedEvent(input: Parameters<typeof compileRelationCreatedEvent>[0]): RelationCreated {
   return {
     schema: "relation-event/v1",
     eventId: `event-${input.opId}`,
@@ -350,7 +354,14 @@ export function compileRelationRetiredEvent(input: {
   readonly occurredAt: string;
   readonly workspaceRevision: number;
 }): RelationRetired {
-  const event: RelationRetired = {
+  const event = relationRetiredEvent(input);
+  const issues = validateCurrentRelationEvent(event);
+  if (issues.length) throw new Error(issues.join("; "));
+  return event;
+}
+
+function relationRetiredEvent(input: Parameters<typeof compileRelationRetiredEvent>[0]): RelationRetired {
+  return {
     schema: "relation-event/v1",
     eventId: `event-${input.opId}`,
     workspaceRevision: input.workspaceRevision,
@@ -362,9 +373,6 @@ export function compileRelationRetiredEvent(input: {
     occurredAt: input.occurredAt,
     payload: { reason: input.reason },
   };
-  const issues = validateCurrentRelationEvent(event);
-  if (issues.length) throw new Error(issues.join("; "));
-  return event;
 }
 
 /** Historical Decision and Fact envelopes embedded relation mutations before
@@ -380,7 +388,7 @@ export function embeddedRelationEventsForReplay(
   if (event.type === "decision_related") return [replayCreatedEvent(event, event.payload.relation)];
   if (event.type === "decision_relation_retired")
     return [
-      compileRelationRetiredEvent({
+      relationRetiredEvent({
         relationId: event.payload.relationId,
         reason: event.payload.reason,
         actor: event.actor,
@@ -392,7 +400,7 @@ export function embeddedRelationEventsForReplay(
     ];
   if (event.type !== "decision_relation_replaced") return [];
   return [
-    compileRelationRetiredEvent({
+    relationRetiredEvent({
       relationId: event.payload.relationId,
       reason: event.payload.reason,
       actor: event.actor,
@@ -473,7 +481,7 @@ function replayCreatedEvent(
   event: DecisionEventV1 | FactEventV1 | TaskEventV1,
   record: EntityRelationRecord,
 ): RelationEventV1 {
-  return compileRelationCreatedEvent({
+  return relationCreatedEvent({
     record: eventRecord(record),
     actor: event.actor,
     source: event.source,

--- a/packages/kernel/src/domain/task-lifecycle-publication.ts
+++ b/packages/kernel/src/domain/task-lifecycle-publication.ts
@@ -10,6 +10,7 @@ import type { TaskLifecycleSnapshot } from "./task-lifecycle.contract.ts";
 import {
   freezeDeclaredWritePlan,
   isFrozenWritePlan,
+  sameWriteTargets,
   type FrozenWritePlan,
   type WriteTarget,
 } from "./write-chain.contract.ts";
@@ -204,12 +205,13 @@ export function taskLifecycleWritePlan(event: TaskEventV1): FrozenWritePlan {
   return freezeDeclaredWritePlan({ commandType: event.type, targets }, [event.type]);
 }
 export function assertTaskLifecycleWritePlan(event: TaskEventV1, plan: FrozenWritePlan | undefined): void {
-  const shape = (value: FrozenWritePlan) =>
-    stableStringify({
-      commandType: value.commandType,
-      targets: value.targets.map(stableStringify).sort(),
-    });
-  if (!plan || !isFrozenWritePlan(plan) || shape(plan) !== shape(taskLifecycleWritePlan(event)))
+  const expected = taskLifecycleWritePlan(event);
+  if (
+    !plan ||
+    !isFrozenWritePlan(plan) ||
+    plan.commandType !== expected.commandType ||
+    !sameWriteTargets(plan.targets, expected.targets)
+  )
     throw new Error(
       "lifecycle write plan must exactly declare event, authored documents, blobs, lease, and projections",
     );

--- a/packages/kernel/src/domain/vertical-declaration.ts
+++ b/packages/kernel/src/domain/vertical-declaration.ts
@@ -11,6 +11,7 @@ import {
   freezeDeclaredWritePlan,
   hasContractFields,
   isFrozenWritePlan,
+  sameWriteTargets,
   isRecord,
   validateEventEnvelopeIdentity,
   type ActorIdentity,
@@ -498,10 +499,13 @@ export function assertVerticalDeclarationEventInputs(
     readonly body: string;
   }[],
 ): void {
-  const expected = verticalDeclarationWritePlan(event),
-    shape = (candidate: FrozenWritePlan) =>
-      stableStringify({ commandType: candidate.commandType, targets: candidate.targets.map(stableStringify).sort() });
-  if (!plan || !isFrozenWritePlan(plan) || shape(plan) !== shape(expected))
+  const expected = verticalDeclarationWritePlan(event);
+  if (
+    !plan ||
+    !isFrozenWritePlan(plan) ||
+    plan.commandType !== expected.commandType ||
+    !sameWriteTargets(plan.targets, expected.targets)
+  )
     throw new Error("vertical declaration write plan is not exact");
   const claim = event.payload.declarationDocumentClaim,
     blob = blobs.find((candidate) => candidate.sha256 === claim.sha256);

--- a/packages/kernel/src/domain/write-chain.contract.ts
+++ b/packages/kernel/src/domain/write-chain.contract.ts
@@ -1,4 +1,4 @@
-import { stablePayloadHash, stableStringify } from "../integrity/stable-hash.ts";
+import { stablePayloadHash } from "../integrity/stable-hash.ts";
 import { validateActorIdentity, type ActorIdentity } from "./actor-identity.ts";
 import { isNonEmptyString } from "./contract-validation.ts";
 import { validateWriteReceipt, type WriteReceipt, type WriteReceiptDraft } from "./receipt-domain-registry.ts";
@@ -243,12 +243,14 @@ function actorIdentityShape(value: unknown): readonly unknown[] | null {
   if (validateActorIdentity(value, true).length || !isRecord(value) || !isRecord(value.principal)) return null;
   return [
     value.principal.personId,
-    value.executor === null ? null : isRecord(value.executor) ? [value.executor.kind, value.executor.id] : null,
+    value.executor === null ? null : (value.executor as Record<string, unknown>).kind,
+    value.executor === null ? null : (value.executor as Record<string, unknown>).id,
   ];
 }
 export function sameActorIdentity(left: unknown, right: unknown): boolean {
-  const shape = actorIdentityShape(left);
-  return shape !== null && stableStringify(shape) === stableStringify(actorIdentityShape(right));
+  const shape = actorIdentityShape(left),
+    other = actorIdentityShape(right);
+  return shape !== null && other !== null && shape.every((field, index) => field === other[index]);
 }
 function writeSourceShape(value: unknown): unknown {
   if (validateWriteSource(value, true).length) return null;
@@ -258,8 +260,14 @@ function writeSourceShape(value: unknown): unknown {
     : [value.kind, value.sessionId, value.path, value.fingerprint];
 }
 export function sameWriteSource(left: unknown, right: unknown): boolean {
-  const shape = writeSourceShape(left);
-  return shape !== null && stableStringify(shape) === stableStringify(writeSourceShape(right));
+  const shape = writeSourceShape(left),
+    other = writeSourceShape(right);
+  return (
+    shape !== null &&
+    (Array.isArray(shape)
+      ? Array.isArray(other) && shape.length === other.length && shape.every((field, index) => field === other[index])
+      : shape === other)
+  );
 }
 
 export function createWriteReceipt<R extends WriteReceipt>(receipt: R): Readonly<R> {
@@ -407,6 +415,30 @@ function normalizeWriteTargets(targets: readonly WriteTarget[]): readonly WriteT
   });
 }
 
+/** Write targets are flat scalar records; compare their fields without serializing them. */
+export function sameWriteTarget(left: WriteTarget, right: WriteTarget): boolean {
+  const a = left as unknown as Record<string, unknown>,
+    b = right as unknown as Record<string, unknown>;
+  const keys = Object.keys(a).filter((key) => a[key] !== undefined);
+  return (
+    keys.length === Object.keys(b).filter((key) => b[key] !== undefined).length &&
+    keys.every((key) => a[key] === b[key])
+  );
+}
+
+export function sameWriteTargets(left: readonly WriteTarget[], right: readonly WriteTarget[]): boolean {
+  if (left.length !== right.length) return false;
+  const remaining = new Map(right.map((target) => [targetKey(target), target]));
+  if (remaining.size !== right.length) return false;
+  return left.every((target) => {
+    const key = targetKey(target),
+      candidate = remaining.get(key);
+    if (candidate === undefined || !sameWriteTarget(target, candidate)) return false;
+    remaining.delete(key);
+    return true;
+  });
+}
+
 export function normalizeContentAddressedInputs<T extends ContentAddressedInput>(inputs: readonly T[]): readonly T[] {
   const bySha256 = new Map<string, T>();
   for (const input of inputs) {
@@ -489,16 +521,11 @@ export function freezeDeclaredWritePlan<C extends string>(
   plan: WritePlan<C>,
   commandTypes: readonly string[],
 ): FrozenWritePlan<C> {
-  const logicalTargets = normalizeWriteTargets(plan.targets);
-  const resolvedPlan = { commandType: plan.commandType, targets: logicalTargets };
-  const errors = [
-    ...validateDeclaredWritePlan(plan, commandTypes),
-    ...validateDeclaredWritePlan(resolvedPlan, commandTypes),
-  ];
+  const errors = validateDeclaredWritePlan(plan, commandTypes);
   if (errors.length > 0) throw new WriteChainContractError("invalid_write_plan", errors.join("; "));
   return Object.freeze({
-    commandType: resolvedPlan.commandType,
-    targets: Object.freeze(resolvedPlan.targets.map((target) => Object.freeze({ ...target }))),
+    commandType: plan.commandType,
+    targets: Object.freeze(normalizeWriteTargets(plan.targets).map((target) => Object.freeze({ ...target }))),
   }) as FrozenWritePlan<C>;
 }
 
@@ -551,10 +578,11 @@ export function validateNormalizedCommandEnvelope<A extends ActorIdentity>(
   const errors: string[] = [];
   if (envelope.schema !== "normalized-command/v1" || envelope.workspaceId !== input.workspaceId)
     errors.push("normalized command schema or workspace is invalid");
-  if (JSON.stringify(canonicalizeWriteValue(envelope.actor)) !== JSON.stringify(canonicalizeWriteValue(input.actor)))
+  if (validateActorIdentity(envelope.actor).length > 0 || !sameActorIdentity(envelope.actor, input.actor))
     errors.push("normalized command actor is invalid");
   if (
-    JSON.stringify(canonicalizeWriteValue(envelope.source)) !== JSON.stringify(canonicalizeWriteValue(input.source)) ||
+    validateWriteSource(envelope.source).length > 0 ||
+    !sameWriteSource(envelope.source, input.source) ||
     envelope.expectedRevision !== input.expectedRevision
   )
     errors.push("normalized command source or expected revision is invalid");

--- a/packages/kernel/src/projection/rebuildable-task-projection-factory.ts
+++ b/packages/kernel/src/projection/rebuildable-task-projection-factory.ts
@@ -1,7 +1,35 @@
 // @write-boundary-exemption rebuildable-projection
 import path from "node:path";
 import { consumeKnownError } from "../error-consumption.ts";
+import {
+  assertDocSyncWritePlan,
+  isDecisionEvent,
+  isDocEvent,
+  isFactEvent,
+  isMigrationImportEvent,
+  isTaskEvent,
+} from "../domain/doc-sync.contract.ts";
+import { isFrozenWritePlan, sameWriteTargets, type FrozenWritePlan } from "../domain/write-chain.contract.ts";
+import { assertMigrationImportWritePlan } from "../domain/migration-import-event.ts";
+import {
+  assertLedgerLayoutMigrationWritePlan,
+  isLedgerLayoutMigrationEvent,
+} from "../domain/ledger-layout-migration-event.ts";
 import { localRuntimeStateFileSystem } from "../local/local-layout-file-system.ts";
+import { assertEntityUpsertWritePlan, isEntityEvent } from "../domain/entity-event.ts";
+import { assertScheduleEventWritePlan, isScheduleEvent } from "../domain/schedule-event.ts";
+import { assertSettingsEventWritePlan, isSettingsEvent } from "../domain/settings-event.ts";
+import { isVerticalDeclarationEvent, verticalDeclarationWritePlan } from "../domain/vertical-declaration.ts";
+import { assertPeopleEventWritePlan, isPeopleEvent } from "../domain/people-event.ts";
+import { assertTaskBootstrapWritePlan, isTaskBootstrapEvent } from "../domain/task-bootstrap-event.ts";
+import { assertTaskProgressWritePlan, isTaskProgressEvent } from "../domain/task-progress-event.ts";
+import {
+  assertPresetSnapshotUpgradeWritePlan,
+  isPresetSnapshotUpgradeEvent,
+} from "../domain/preset-snapshot-upgrade-event.ts";
+import { assertDecisionWritePlan } from "../domain/decision-event.ts";
+import { assertFactWritePlan } from "../domain/fact-event.ts";
+import { assertTaskLifecycleWritePlan } from "../domain/task-lifecycle-publication.ts";
 import type { TaskProjection, TaskProjectionQueries, TaskProjectionReader } from "./task-projection-port.ts";
 import type { EventStreamPort, ProjectionContext } from "./rebuildable-task-projection-types.ts";
 import {
@@ -73,7 +101,35 @@ export function makeTaskProjection(options: {
   return {
     path: projectionPath,
     close: closeProjection,
-    apply: (event) => {
+    apply: (event, plan) => {
+      if (isDocEvent(event)) assertDocSyncWritePlan(event, plan as FrozenWritePlan<"DocSyncSubmit">);
+      if (isEntityEvent(event)) assertEntityUpsertWritePlan(event, plan as FrozenWritePlan<"EntityUpsert">);
+      if (isScheduleEvent(event)) assertScheduleEventWritePlan(event, plan);
+      if (isSettingsEvent(event)) assertSettingsEventWritePlan(event, plan);
+      if (isVerticalDeclarationEvent(event)) {
+        const expected = verticalDeclarationWritePlan(event);
+        if (
+          plan === undefined ||
+          !isFrozenWritePlan(plan) ||
+          plan.commandType !== expected.commandType ||
+          !sameWriteTargets(plan.targets, expected.targets)
+        )
+          throw new Error("vertical declaration write plan does not match the event");
+      }
+      if (isPeopleEvent(event)) assertPeopleEventWritePlan(event, plan);
+      if (
+        isTaskEvent(event) &&
+        ((event.payload.documentClaims?.length ?? 0) > 0 || (event.payload.carriedDocumentClaims?.length ?? 0) > 0)
+      )
+        assertTaskLifecycleWritePlan(event, plan);
+      if (isTaskBootstrapEvent(event)) assertTaskBootstrapWritePlan(event, plan as FrozenWritePlan<"TaskBootstrap">);
+      if (isPresetSnapshotUpgradeEvent(event))
+        assertPresetSnapshotUpgradeWritePlan(event, plan as FrozenWritePlan<"PresetSnapshotUpgrade">);
+      if (isTaskProgressEvent(event)) assertTaskProgressWritePlan(event, plan);
+      if (isFactEvent(event)) assertFactWritePlan(event, plan);
+      if (isDecisionEvent(event)) assertDecisionWritePlan(event, plan);
+      if (isMigrationImportEvent(event)) assertMigrationImportWritePlan(event, plan);
+      if (isLedgerLayoutMigrationEvent(event)) assertLedgerLayoutMigrationWritePlan(event, plan);
       return withDatabase(projectionPath, readHead, (db) =>
         reduceBatch(db, [event], limit, options.eventStore.readContentBlob, options.eventStore.readHead()),
       );

--- a/packages/kernel/src/projection/rebuildable-task-projection-factory.ts
+++ b/packages/kernel/src/projection/rebuildable-task-projection-factory.ts
@@ -1,35 +1,7 @@
 // @write-boundary-exemption rebuildable-projection
 import path from "node:path";
 import { consumeKnownError } from "../error-consumption.ts";
-import {
-  assertDocSyncWritePlan,
-  isDecisionEvent,
-  isDocEvent,
-  isFactEvent,
-  isMigrationImportEvent,
-  isTaskEvent,
-} from "../domain/doc-sync.contract.ts";
-import type { FrozenWritePlan } from "../domain/write-chain.contract.ts";
-import { assertMigrationImportWritePlan } from "../domain/migration-import-event.ts";
-import {
-  assertLedgerLayoutMigrationWritePlan,
-  isLedgerLayoutMigrationEvent,
-} from "../domain/ledger-layout-migration-event.ts";
 import { localRuntimeStateFileSystem } from "../local/local-layout-file-system.ts";
-import { assertEntityUpsertWritePlan, isEntityEvent } from "../domain/entity-event.ts";
-import { assertScheduleEventWritePlan, isScheduleEvent } from "../domain/schedule-event.ts";
-import { assertSettingsEventWritePlan, isSettingsEvent } from "../domain/settings-event.ts";
-import { isVerticalDeclarationEvent, verticalDeclarationWritePlan } from "../domain/vertical-declaration.ts";
-import { assertPeopleEventWritePlan, isPeopleEvent } from "../domain/people-event.ts";
-import { assertTaskBootstrapWritePlan, isTaskBootstrapEvent } from "../domain/task-bootstrap-event.ts";
-import { assertTaskProgressWritePlan, isTaskProgressEvent } from "../domain/task-progress-event.ts";
-import {
-  assertPresetSnapshotUpgradeWritePlan,
-  isPresetSnapshotUpgradeEvent,
-} from "../domain/preset-snapshot-upgrade-event.ts";
-import { assertDecisionWritePlan } from "../domain/decision-event.ts";
-import { assertFactWritePlan } from "../domain/fact-event.ts";
-import { assertTaskLifecycleWritePlan } from "../domain/task-lifecycle-publication.ts";
 import type { TaskProjection, TaskProjectionQueries, TaskProjectionReader } from "./task-projection-port.ts";
 import type { EventStreamPort, ProjectionContext } from "./rebuildable-task-projection-types.ts";
 import {
@@ -101,30 +73,7 @@ export function makeTaskProjection(options: {
   return {
     path: projectionPath,
     close: closeProjection,
-    apply: (event, plan) => {
-      if (isDocEvent(event)) assertDocSyncWritePlan(event, plan as FrozenWritePlan<"DocSyncSubmit">);
-      if (isEntityEvent(event)) assertEntityUpsertWritePlan(event, plan as FrozenWritePlan<"EntityUpsert">);
-      if (isScheduleEvent(event)) assertScheduleEventWritePlan(event, plan);
-      if (isSettingsEvent(event)) assertSettingsEventWritePlan(event, plan);
-      if (
-        isVerticalDeclarationEvent(event) &&
-        JSON.stringify(plan) !== JSON.stringify(verticalDeclarationWritePlan(event))
-      )
-        throw new Error("vertical declaration write plan does not match the event");
-      if (isPeopleEvent(event)) assertPeopleEventWritePlan(event, plan);
-      if (
-        isTaskEvent(event) &&
-        ((event.payload.documentClaims?.length ?? 0) > 0 || (event.payload.carriedDocumentClaims?.length ?? 0) > 0)
-      )
-        assertTaskLifecycleWritePlan(event, plan);
-      if (isTaskBootstrapEvent(event)) assertTaskBootstrapWritePlan(event, plan as FrozenWritePlan<"TaskBootstrap">);
-      if (isPresetSnapshotUpgradeEvent(event))
-        assertPresetSnapshotUpgradeWritePlan(event, plan as FrozenWritePlan<"PresetSnapshotUpgrade">);
-      if (isTaskProgressEvent(event)) assertTaskProgressWritePlan(event, plan);
-      if (isFactEvent(event)) assertFactWritePlan(event, plan);
-      if (isDecisionEvent(event)) assertDecisionWritePlan(event, plan);
-      if (isMigrationImportEvent(event)) assertMigrationImportWritePlan(event, plan);
-      if (isLedgerLayoutMigrationEvent(event)) assertLedgerLayoutMigrationWritePlan(event, plan);
+    apply: (event) => {
       return withDatabase(projectionPath, readHead, (db) =>
         reduceBatch(db, [event], limit, options.eventStore.readContentBlob, options.eventStore.readHead()),
       );

--- a/packages/kernel/src/store/entity-store.ts
+++ b/packages/kernel/src/store/entity-store.ts
@@ -1,3 +1,4 @@
+import { deepFreeze } from "../domain/artifact-entity.ts";
 import type { HarnessLayoutInput } from "../layout/index.ts";
 import { compileEntityUpsert, type EntityUpsertBundle } from "../domain/entity-event-compile.ts";
 import {
@@ -30,13 +31,18 @@ type EntityEventSource = Pick<CanonicalEventStore, "readBatch" | "readContentBlo
 
 const entityEventCaches = new WeakMap<
   EntityEventSource,
-  { cursor: string | null; latestByKind: Map<string, Map<string, StoredEntityEventV1>> }
+  {
+    cursor: string | null;
+    latestByKind: Map<string, Map<string, StoredEntityEventV1>>;
+    records: Map<string, { event: StoredEntityEventV1; contract: EntityStoreKindContract; record: StoredEntity }>;
+  }
 >();
 
 function entityEventCache(source: EntityEventSource): Map<string, Map<string, StoredEntityEventV1>> {
   const cache = entityEventCaches.get(source) ?? {
     cursor: null,
     latestByKind: new Map<string, Map<string, StoredEntityEventV1>>(),
+    records: new Map(),
   };
   entityEventCaches.set(source, cache);
   for (;;) {
@@ -45,6 +51,13 @@ function entityEventCache(source: EntityEventSource): Map<string, Map<string, St
       if (!isEntityEvent(event)) continue;
       const latest = cache.latestByKind.get(event.payload.entityKind) ?? new Map<string, StoredEntityEventV1>();
       cache.latestByKind.set(event.payload.entityKind, latest);
+      const previous = latest.get(event.payload.entityId);
+      if (
+        previous &&
+        isEntityDeclarationEvent(previous) &&
+        (isEntityDeclarationEvent(event) || event.type === "entity_deleted")
+      )
+        cache.records.delete(previous.payload.declarationDocumentClaim.sha256);
       if (isEntityDeclarationEvent(event)) latest.set(event.payload.entityId, event);
       else if (event.type === "entity_deleted") latest.delete(event.payload.entityId);
     }
@@ -118,7 +131,10 @@ function entityEventRecord(
 ): StoredEntity {
   if (!isEntityDeclarationEvent(event)) throw new Error("entity target-missing event has no declaration document");
   const claim = event.payload.declarationDocumentClaim,
-    bytes = source.readContentBlob(claim.sha256);
+    cache = entityEventCaches.get(source)!.records,
+    cached = cache.get(claim.sha256);
+  if (cached?.event === event && cached.contract === contract) return cached.record;
+  const bytes = source.readContentBlob(claim.sha256);
   if (!bytes || bytes.byteLength !== claim.size)
     throw new Error(`entity declaration blob ${claim.sha256} is unavailable`);
   let body: string;
@@ -140,12 +156,14 @@ function entityEventRecord(
   if (contractErrors.length) throw new Error(contractErrors.join("; "));
   if (entity.id !== event.payload.entityId)
     throw new Error(`entity declaration blob ${claim.sha256} identity mismatch`);
-  return {
+  const record = deepFreeze({
     kind: contract.kind,
     id: event.payload.entityId,
     value: entity.value,
     documentPath: claim.path,
     documentSha256: claim.sha256,
     workspaceRevision: event.workspaceRevision,
-  };
+  });
+  cache.set(claim.sha256, { event, contract, record });
+  return record;
 }

--- a/packages/kernel/src/store/ledger-backup.ts
+++ b/packages/kernel/src/store/ledger-backup.ts
@@ -151,12 +151,11 @@ export function readOfflineLedgerEvents(input: {
   const sinceMs = input.sinceTime === undefined ? null : Date.parse(input.sinceTime);
   if (sinceMs !== null && !Number.isFinite(sinceMs)) throw new Error("--since time must be an ISO timestamp");
   return events.filter((value) => {
-    const event = value as { readonly workspaceRevision: number; readonly occurredAt?: string },
-      body = JSON.stringify(value);
+    const event = value as { readonly workspaceRevision: number; readonly occurredAt?: string };
     return (
       (input.sinceRevision === undefined || event.workspaceRevision > input.sinceRevision) &&
       (sinceMs === null || Date.parse(event.occurredAt ?? "") >= sinceMs) &&
-      (input.grep === undefined || body.includes(input.grep))
+      (input.grep === undefined || JSON.stringify(value).includes(input.grep))
     );
   });
 }

--- a/packages/kernel/src/store/legacy-generation-conversion.ts
+++ b/packages/kernel/src/store/legacy-generation-conversion.ts
@@ -1,6 +1,9 @@
 import { createHash } from "node:crypto";
 import path from "node:path";
-import { serializePersistedCanonicalEvent } from "../domain/doc-sync-canonical-events.ts";
+import {
+  serializeCanonicalEventUnchecked,
+  serializePersistedCanonicalEvent,
+} from "../domain/doc-sync-canonical-events.ts";
 import { validateCurrentCanonicalEvent } from "../domain/doc-sync-canonical-events.ts";
 import type { CanonicalEventV1 } from "../domain/doc-sync-types.ts";
 import { sha256Bytes, sha256Text, stableStringify } from "../integrity/stable-hash.ts";
@@ -175,21 +178,20 @@ export function convertLegacyGeneration(input: {
           body: generatedBlob?.body ?? new TextDecoder("utf-8", { fatal: true }).decode(bytes),
         };
       });
-      const eventJson = serializePersistedCanonicalEvent(event);
-      store.appendCommand({
+      store.appendValidatedBundle({
         fence,
-        intent: {
+        intent: ([eventJson]) => ({
           opId: event.opId,
-          intentDigest: `sha256:${sha256Text(eventJson)}`,
+          intentDigest: `sha256:${sha256Text(eventJson!)}`,
           summary: event.type,
-        },
+        }),
         events: [event],
         blobs,
       });
     }
     const stored = store.eventRows();
     for (const [index, event] of plan.events.entries())
-      if (stored[index]?.eventJson !== serializePersistedCanonicalEvent(event))
+      if (stored[index]?.eventJson !== serializeCanonicalEventUnchecked(event))
         throw new TaskEventStoreError("invalid_store", `converted event differs at revision ${index + 1}`);
     publishConvertedGeneration({ rootInput: input.rootDir, repoId: snapshot.repoId, store });
     return {
@@ -245,7 +247,7 @@ export function preflightConvertedGenerationActivation(input: {
       rows.length < plan.events.length ||
       rows
         .slice(0, plan.events.length)
-        .some((row, index) => row.eventJson !== serializePersistedCanonicalEvent(plan.events[index]!))
+        .some((row, index) => row.eventJson !== serializeCanonicalEventUnchecked(plan.events[index]!))
     )
       throw new TaskEventStoreError("invalid_store", "generation conversion is incomplete");
     const events = rows.map(
@@ -290,7 +292,6 @@ export function preflightConvertedGenerationActivation(input: {
 function validatedConversionPlan(snapshot: ImmutableLegacySnapshotV2, rootDir: string, snapshotPath: string) {
   const plan = planLegacyGenerationConversion({ rootDir, store: snapshotStore(snapshot, snapshotPath) });
   for (const event of plan.events) {
-    serializePersistedCanonicalEvent(event);
     const issues = validateCurrentCanonicalEvent(event);
     if (issues.length > 0)
       throw new TaskEventStoreError(

--- a/packages/kernel/src/store/local-version-control-system.ts
+++ b/packages/kernel/src/store/local-version-control-system.ts
@@ -648,7 +648,9 @@ function readNode(target: string): {
     const bytes = mode === "120000" ? readlinkSync(target, { encoding: "buffer" }) : readFileSync(target);
     return {
       mode,
-      body: bytes.toString("utf8"),
+      get body() {
+        return bytes.toString("utf8");
+      },
       bytes,
       sha256: hashVcsBytes("sha256", bytes),
       size: bytes.byteLength,

--- a/packages/kernel/src/store/sqlite-event-store.ts
+++ b/packages/kernel/src/store/sqlite-event-store.ts
@@ -796,9 +796,7 @@ function objectPath(objectRoot: string, sha256: string): string {
 
 function readContentObject(objectRoot: string, sha256: string): Uint8Array | null {
   const target = objectPath(objectRoot, sha256);
-  return localContentObjectFileSystem.exists(target)
-    ? Buffer.from(localContentObjectFileSystem.readBytes(target))
-    : null;
+  return localContentObjectFileSystem.exists(target) ? localContentObjectFileSystem.readBytes(target) : null;
 }
 
 function listContentObjectDigests(objectRoot: string): readonly string[] {

--- a/packages/kernel/src/store/sqlite-event-store.ts
+++ b/packages/kernel/src/store/sqlite-event-store.ts
@@ -1,6 +1,10 @@
 import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
-import { serializePersistedCanonicalEvent, type CanonicalEventV1 } from "../domain/doc-sync.contract.ts";
+import {
+  serializeCanonicalEventUnchecked,
+  serializePersistedCanonicalEvent,
+  type CanonicalEventV1,
+} from "../domain/doc-sync.contract.ts";
 import { sha256Text, stableStringify } from "../integrity/stable-hash.ts";
 import { resolveHarnessLayout, type HarnessLayoutInput } from "../layout/index.ts";
 import { localRuntimeStateFileSystem } from "../local/local-layout-file-system.ts";
@@ -110,6 +114,14 @@ export interface SqliteEventStore {
       readonly recordedAt: string;
       readonly eventRecordedAt: readonly string[];
     };
+  }) => SqliteCommandOutcome;
+  /** Internal admission seam: the caller has validated the canonical bundle before invoking this. */
+  readonly appendValidatedBundle: (input: {
+    readonly intent?: (eventBytes: readonly string[]) => SqliteCommandIntent;
+    readonly fence: SqliteWriterFence;
+    readonly events: readonly CanonicalEventV1[];
+    readonly blobs: readonly CanonicalContentBlob[];
+    readonly beforeOutcome?: () => void;
   }) => SqliteCommandOutcome;
   readonly outcome: (opId: string) => SqliteCommandOutcome | null;
   readonly readCommandOutcome: (opId: string) => SqliteCommandOutcome | null;
@@ -450,7 +462,10 @@ export function openSqliteEventStore(options: {
     });
 
   const outcome = (opId: string): SqliteCommandOutcome | null => readOutcome(db, query, opId);
-  const appendCommand: SqliteEventStore["appendCommand"] = (input) => {
+  const appendCommand = (
+    input: Parameters<SqliteEventStore["appendCommand"]>[0],
+    eventBytes = input.events.map(serializePersistedCanonicalEvent),
+  ): SqliteCommandOutcome => {
     if ((options.conversionSourceGeneration !== undefined) !== (input.historicalRecord !== undefined))
       throw new TaskEventStoreError("invalid_write_plan", "historical timestamps require an offline conversion writer");
     if (
@@ -492,7 +507,7 @@ export function openSqliteEventStore(options: {
             "revision_conflict",
             `workspace revision ${event.workspaceRevision} must equal ` + `allocated revision ${revision}`,
           );
-        const eventJson = serializePersistedCanonicalEvent(event),
+        const eventJson = eventBytes[offset]!,
           digest = `sha256:${sha256Text(eventJson)}`;
         insertEvent.run(
           revision,
@@ -552,6 +567,22 @@ export function openSqliteEventStore(options: {
       return writer ? { repoId, ...writer } : null;
     },
     appendCommand,
+    appendValidatedBundle: ({ events, intent, ...input }) => {
+      const eventBytes = events.map(serializeCanonicalEventUnchecked),
+        terminal = events.at(-1)!;
+      return appendCommand(
+        {
+          ...input,
+          events,
+          intent: intent?.(eventBytes) ?? {
+            opId: terminal.opId,
+            intentDigest: `sha256:${sha256Text(JSON.stringify(eventBytes))}`,
+            summary: terminal.type,
+          },
+        },
+        eventBytes,
+      );
+    },
     outcome,
     readCommandOutcome: (opId) => readCommandOutcome(db, query, opId),
     outcomes: () => readOutcomes(db, query),

--- a/packages/kernel/src/store/sqlite-event-store.ts
+++ b/packages/kernel/src/store/sqlite-event-store.ts
@@ -395,6 +395,11 @@ export function openSqliteEventStore(options: {
       .get()!.version,
   );
 
+  const insertEvent = /* @gate-identity check-bypass-write-boundary/bypass-write-120 */ db.prepare(
+    "INSERT INTO event(revision, op_id, event_json, digest, occurred_at, recorded_at) " +
+      "VALUES (?, ?, ?, ?, ?, COALESCE(?, strftime('%Y-%m-%dT%H:%M:%fZ','now')))",
+  );
+
   const transaction = <A>(run: () => A): A => {
     /* @gate-identity check-bypass-write-boundary/bypass-write-125 */ db.exec("BEGIN IMMEDIATE");
     try {
@@ -489,10 +494,7 @@ export function openSqliteEventStore(options: {
           );
         const eventJson = serializePersistedCanonicalEvent(event),
           digest = `sha256:${sha256Text(eventJson)}`;
-        /* @gate-identity check-bypass-write-boundary/bypass-write-120 */ db.prepare(
-          "INSERT INTO event(revision, op_id, event_json, digest, occurred_at, recorded_at) " +
-            "VALUES (?, ?, ?, ?, ?, COALESCE(?, strftime('%Y-%m-%dT%H:%M:%fZ','now')))",
-        ).run(
+        insertEvent.run(
           revision,
           event.opId,
           eventJson,

--- a/packages/kernel/src/store/sqlite-task-event-publication.ts
+++ b/packages/kernel/src/store/sqlite-task-event-publication.ts
@@ -326,7 +326,15 @@ export function readEventsThrough(
   sqlite: ReturnType<typeof openSqliteEventStore>,
   revision: number,
 ): readonly CanonicalEventV1[] {
-  return readPendingEvents(sqlite, 0).filter((event) => event.workspaceRevision <= revision);
+  const events: CanonicalEventV1[] = [];
+  let cursor = 0;
+  while (cursor < revision) {
+    const page = sqlite.eventsAfter(cursor, Math.min(1024, revision - cursor));
+    if (!page.length) break;
+    events.push(...page);
+    cursor = page.at(-1)!.workspaceRevision;
+  }
+  return events;
 }
 
 export function readPendingEvents(
@@ -428,19 +436,20 @@ export function settleWorktree(
       )
     )
       conflicts.push(target);
-  for (const file of writes)
+  for (const file of writes) {
+    const digest = publicationDigest(file.body);
     if (
       !settleVisibleChange(
         repoRoot,
         file.target,
-        `${file.mode}:${publicationDigest(file.body)}:${Buffer.byteLength(file.body)}`,
+        `${file.mode}:${digest}:${Buffer.byteLength(file.body)}`,
         baseline,
         killpoint,
         (hooks) => {
           if (preserve.has(file.target)) {
             hooks.beforeRename();
             const node = localGitWorktreeSettlement.readNode(`${repoRoot}/${file.target}`);
-            if (node && node.sha256 !== publicationDigest(file.body))
+            if (node && node.sha256 !== digest)
               localGitWorktreeSettlement.preserveVisibleConflict(
                 repoRoot,
                 `${repoRoot}/${file.target}`,
@@ -453,6 +462,7 @@ export function settleWorktree(
       )
     )
       conflicts.push(file.target);
+  }
   return conflicts;
 }
 

--- a/packages/kernel/src/store/sqlite-task-event-store.ts
+++ b/packages/kernel/src/store/sqlite-task-event-store.ts
@@ -1,10 +1,5 @@
 import { type EventHead, type LedgerCutIdentity } from "../domain/write-chain.contract.ts";
-import {
-  isTaskEvent,
-  ledgerCommitSha,
-  serializePersistedCanonicalEvent,
-  type CanonicalEventV1,
-} from "../domain/doc-sync.contract.ts";
+import { isTaskEvent, ledgerCommitSha, type CanonicalEventV1 } from "../domain/doc-sync.contract.ts";
 import { sha256Text } from "../integrity/stable-hash.ts";
 import { resolveHarnessLayout, type HarnessLayoutInput } from "../layout/index.ts";
 import { consumeKnownError } from "../error-consumption.ts";
@@ -140,13 +135,8 @@ export function makeSqliteTaskEventStore(options: SqliteTaskEventStoreOptions): 
     }
     const fence = options.writerFence?.() ?? { repoId: options.repoId, holderId: "direct-store", epoch: 1 },
       accept = () =>
-        sqlite.appendCommand({
+        sqlite.appendValidatedBundle({
           fence: { repoId: fence.repoId, holder: fence.holderId, epoch: fence.epoch },
-          intent: {
-            opId: bundle.event.opId,
-            intentDigest: `sha256:${sha256Text(JSON.stringify(appended.map(serializePersistedCanonicalEvent)))}`,
-            summary: bundle.event.type,
-          },
           events: appended,
           blobs,
           beforeOutcome: () => options.killpoint?.("after_event_write"),

--- a/packages/kernel/src/store/task-event-store-claims-layout.ts
+++ b/packages/kernel/src/store/task-event-store-claims-layout.ts
@@ -23,8 +23,6 @@ import { migrationImportClaims, migrationImportContentClaims } from "../domain/m
 import { isTaskBootstrapEvent, taskBootstrapClaims } from "../domain/task-bootstrap-event.ts";
 import { isTaskProgressEvent } from "../domain/task-progress-event.ts";
 import { isSnapshotUpgradeEvent, snapshotUpgradeClaims } from "../domain/task-snapshot-upgrade-store-seam.ts";
-import { type WriteTarget } from "../domain/write-chain.contract.ts";
-import { stableStringify } from "../integrity/stable-hash.ts";
 
 // Canonical document claim extraction plus flat-to-sharded layout auditing.
 export function canonicalDocumentClaims(event: PersistedCanonicalEventV1): readonly {
@@ -169,7 +167,4 @@ export function contentClaims(event: CanonicalEventV1): readonly {
                       ? runtimeEventContentClaims(event)
                       : [];
   return [...new Map(claims.map((claim) => [claim.sha256, claim])).values()];
-}
-export function targetShape(targets: readonly WriteTarget[]): string {
-  return stableStringify(targets.map(stableStringify).sort());
 }

--- a/packages/kernel/src/store/task-event-store-replacement-authorization.ts
+++ b/packages/kernel/src/store/task-event-store-replacement-authorization.ts
@@ -1,6 +1,6 @@
 import { isDecisionEvent, isMigrationImportEvent, type CanonicalEventV1 } from "../domain/doc-sync.contract.ts";
 import { isPeopleEvent } from "../domain/people-event.ts";
-import { parsePeopleRosterDocument, serializePeopleRosterDocument } from "../domain/people-roster.ts";
+import { serializePeopleRosterDocument } from "../domain/people-roster.ts";
 import { isSettingsEvent } from "../domain/settings-event.ts";
 import { writeRepositorySettingsFacet } from "../domain/settings.ts";
 import { localGitWorktreeSettlement } from "./local-version-control-system.ts";
@@ -131,11 +131,7 @@ function authorize(
       candidate = blobs.find((blob) => blob.sha256 === event.payload.peopleDocumentClaim.sha256)?.body;
     if ((base?.sha256 ?? null) !== event.payload.baseDocumentSha256)
       throw new TaskEventStoreError("revision_conflict", "people.yaml changed before the People write committed");
-    if (
-      typeof candidate !== "string" ||
-      candidate !== serializePeopleRosterDocument(event.payload.roster) ||
-      serializePeopleRosterDocument(parsePeopleRosterDocument(candidate)) !== candidate
-    )
+    if (typeof candidate !== "string" || candidate !== serializePeopleRosterDocument(event.payload.roster))
       throw new TaskEventStoreError("invalid_write_plan", "People may replace only the canonical people roster");
     return;
   }

--- a/packages/kernel/src/store/task-event-store-replacement-authorization.ts
+++ b/packages/kernel/src/store/task-event-store-replacement-authorization.ts
@@ -72,19 +72,25 @@ export function assertAuthorizedReplacements(
       const node = localGitWorktreeSettlement.readNode(`${authoredRoot}/${target}`);
       return node && { ...node, nodeKind: node.mode === "120000" ? "symbolic-link" : "file" };
     },
-    current = (target: string): DocumentNode | null => {
+    current = (target: string): DocumentHead | null => {
       if (pending.has(target)) return pending.get(target)!;
       const head = heads.get(target);
       if (head === "retired") return null;
       // Only a never-claimed bootstrap document can take its baseline from authored bytes.
       if (head === undefined) return local(target);
-      const bytes = store.readContentObject(head.sha256);
-      if (bytes === null) throw new TaskEventStoreError("invalid_store", `Missing content for ${target}`);
-      return { ...head, body: bytes };
+      return head;
     };
   for (const member of members) {
     if (store.event(member.event.opId)) continue; // SQLite still verifies the replay's exact intent digest.
-    authorize(member, current, local);
+    authorize(member, current, local, (target) => {
+      if (pending.has(target)) return pending.get(target)?.body ?? null;
+      const head = heads.get(target);
+      if (head === "retired") return null;
+      if (head === undefined) return local(target)?.body ?? null;
+      const bytes = store.readContentObject(head.sha256);
+      if (bytes === null) throw new TaskEventStoreError("invalid_store", `Missing content for ${target}`);
+      return bytes;
+    });
     for (const claim of canonicalDocumentClaims(member.event)) {
       const blob = member.blobs.find((candidate) => candidate.sha256 === claim.sha256);
       if (!blob) throw new TaskEventStoreError("invalid_write_plan", `Missing candidate for ${claim.path}`);
@@ -100,8 +106,9 @@ export function assertAuthorizedReplacements(
 
 function authorize(
   member: CanonicalWriteBundle,
-  current: (target: string) => DocumentNode | null,
+  current: (target: string) => DocumentHead | null,
   local: (target: string) => DocumentNode | null,
+  readBody: (target: string) => string | Uint8Array | null,
 ): void {
   const { event, blobs } = member;
   if (isDecisionEvent(event)) {
@@ -114,10 +121,10 @@ function authorize(
     const base = current(event.payload.harnessDocumentClaim.path);
     if (base === null || base.sha256 !== event.payload.baseDocumentSha256)
       throw new TaskEventStoreError("revision_conflict", "harness.yaml changed before the Settings write committed");
+    const body = readBody(event.payload.harnessDocumentClaim.path);
+    if (body === null) throw new TaskEventStoreError("invalid_store", "Missing settings base content");
     const baseBody =
-        typeof base.body === "string"
-          ? base.body
-          : new TextDecoder("utf-8", { fatal: true, ignoreBOM: true }).decode(base.body),
+        typeof body === "string" ? body : new TextDecoder("utf-8", { fatal: true, ignoreBOM: true }).decode(body),
       candidate = blobs.find((blob) => blob.sha256 === event.payload.harnessDocumentClaim.sha256)?.body;
     if (typeof candidate !== "string" || candidate !== writeRepositorySettingsFacet(baseBody, event.payload.settings))
       throw new TaskEventStoreError(
@@ -150,7 +157,7 @@ function authorize(
   ) {
     const entity = event.payload.entity,
       expected = entity.destinationPreimage!,
-      same = (node: DocumentNode | null) =>
+      same = (node: DocumentHead | null) =>
         node !== null &&
         node.nodeKind === expected.nodeKind &&
         node.sha256 === expected.sha256 &&

--- a/packages/kernel/src/store/task-event-store-validation.ts
+++ b/packages/kernel/src/store/task-event-store-validation.ts
@@ -32,16 +32,18 @@ import { assertPeopleEventInputs, isPeopleEvent } from "../domain/people-event.t
 import { assertSnapshotUpgradeInputs, isSnapshotUpgradeEvent } from "../domain/task-snapshot-upgrade-store-seam.ts";
 import {
   isFrozenWritePlan,
+  sameWriteTarget,
+  sameWriteTargets,
   normalizeContentAddressedInputs,
   WriteChainContractError,
   type FrozenWritePlan,
   type WriteTarget,
 } from "../domain/write-chain.contract.ts";
-import { sha256Bytes, stableStringify } from "../integrity/stable-hash.ts";
+import { sha256Bytes } from "../integrity/stable-hash.ts";
 import { assertPublishableOpId, eventObjectTarget } from "../layout/ledger-object-layout.ts";
 import type { CanonicalContentBlob, CanonicalEventWriteBundle } from "./task-event-store-types.ts";
 import { TaskEventStoreError } from "./task-event-store-types.ts";
-import { canonicalDocumentClaims, contentClaims, targetShape } from "./task-event-store-claims-layout.ts";
+import { canonicalDocumentClaims, contentClaims } from "./task-event-store-claims-layout.ts";
 
 // Bundle, plan, content-input, and prepared-publication validation.
 export function assertBundle(bundle: CanonicalEventWriteBundle): void {
@@ -189,12 +191,9 @@ export function assertBundle(bundle: CanonicalEventWriteBundle): void {
       },
     ],
     claims = contentClaims(event);
-  if (
-    required.some((target) => !plan.targets.some((candidate) => stableStringify(candidate) === stableStringify(target)))
-  )
+  if (required.some((target) => !plan.targets.some((candidate) => sameWriteTarget(candidate, target))))
     throw new TaskEventStoreError("invalid_write_plan", "canonical write bundle must declare its event and head");
-  assertContentInputs(claims, blobs, "canonical bundle");
-  const normalizedClaims = normalizeContentAddressedInputs(claims),
+  const normalizedClaims = assertContentInputs(claims, blobs, "canonical bundle"),
     declaredAuthored = plan.targets.filter((target) => target.kind === "authored_file"),
     expectedAuthored: WriteTarget[] = canonicalDocumentClaims(event).map((claim) => ({
       kind: "authored_file",
@@ -205,16 +204,16 @@ export function assertBundle(bundle: CanonicalEventWriteBundle): void {
       mediaType: claim.mediaType,
     }));
   if (
-    targetShape(declaredAuthored) !== targetShape(expectedAuthored) ||
-    targetShape(plan.targets.filter((target) => target.kind === "content_blob")) !==
-      targetShape(
-        normalizedClaims.map((claim) => ({
-          kind: "content_blob",
-          sha256: claim.sha256,
-          size: claim.size,
-          mediaType: claim.mediaType,
-        })),
-      )
+    !sameWriteTargets(declaredAuthored, expectedAuthored) ||
+    !sameWriteTargets(
+      plan.targets.filter((target) => target.kind === "content_blob"),
+      normalizedClaims.map((claim) => ({
+        kind: "content_blob",
+        sha256: claim.sha256,
+        size: claim.size,
+        mediaType: claim.mediaType,
+      })),
+    )
   )
     throw new TaskEventStoreError("invalid_write_plan", "canonical write bundle claims and plan differ");
 }
@@ -259,7 +258,7 @@ export function assertContentInputs(
     readonly body: string | Uint8Array;
   }[],
   label: string,
-): void {
+): typeof claims {
   let normalizedClaims: readonly (typeof claims)[number][];
   let normalizedBlobs: readonly (typeof blobs)[number][];
   try {
@@ -290,4 +289,5 @@ export function assertContentInputs(
       "invalid_write_plan",
       `${label} content inputs must exactly match the frozen write plan`,
     );
+  return normalizedClaims;
 }

--- a/packages/kernel/test/contracts/entity-store.test.ts
+++ b/packages/kernel/test/contracts/entity-store.test.ts
@@ -299,6 +299,35 @@ test("EntityStore hot reads consume only events appended since the cached cursor
   }
 });
 
+test("EntityStore reuses accepted records while new content and revisions replace the cache", () => {
+  const body = `${JSON.stringify(agent, null, 2)}\n`,
+    first = storedAgentEvent(agent, body, 1),
+    events = [first],
+    blobs = new Map([[first.payload.declarationDocumentClaim.sha256, Buffer.from(body)]]),
+    source = entitySource(events, blobs);
+  let reads = 0;
+  const store = createEntityStore({
+    ...source,
+    readContentBlob: (sha256) => {
+      reads += 1;
+      return source.readContentBlob(sha256);
+    },
+  });
+  assert.equal(store.get("agent", "terra")?.workspaceRevision, 1);
+  assert.equal(store.list("agent").length, 1);
+  assert.equal(reads, 1);
+  events.push(storedAgentEvent(agent, body, 2));
+  assert.equal(store.get("agent", "terra")?.workspaceRevision, 2);
+  const changed = { ...agent, name: "Updated Terra" },
+    changedBody = `${JSON.stringify(changed, null, 2)}\n`,
+    next = storedAgentEvent(changed, changedBody, 3);
+  blobs.set(next.payload.declarationDocumentClaim.sha256, Buffer.from(changedBody));
+  events.push(next);
+  assert.equal(store.get<typeof agent>("agent", "terra")?.value.name, "Updated Terra");
+  assert.equal(store.list("agent")[0]?.workspaceRevision, 3);
+  assert.equal(reads, 3);
+});
+
 test("entity_upsert receipt detail is closed and registered", () => {
   const receipt = {
     ...committedAcceptance("op-agent-terra-1", 1),

--- a/packages/kernel/test/contracts/entity-store.test.ts
+++ b/packages/kernel/test/contracts/entity-store.test.ts
@@ -9,7 +9,7 @@ import { explainEntityKind } from "../../src/domain/entity-kind-registry.ts";
 import { type EntityEventV1 } from "../../src/domain/entity-event.ts";
 import { assertContentInputs } from "../../src/store/task-event-store-validation.ts";
 import type { EntityUpsertBundle } from "../../src/domain/entity-event-compile.ts";
-import { validateWriteReceipt } from "../../src/domain/write-chain.contract.ts";
+import { sameWriteTargets, validateWriteReceipt } from "../../src/domain/write-chain.contract.ts";
 import { createEntityOwnedContent, MAX_ENTITY_CONTENT_OBJECT_BYTES } from "../../src/domain/entity-owned-content.ts";
 
 const actor = { principal: { personId: "person-entity-store" }, executor: null } as const;
@@ -402,4 +402,21 @@ test("an owned content object is described up to the maximum object size and ref
     () => createEntityOwnedContent(binding(MAX_ENTITY_CONTENT_OBJECT_BYTES + 1, "3")),
     /content object reference is invalid/u,
   );
+});
+
+test("write-target comparison is order independent, rejects duplicates, and reads fields linearly", () => {
+  let reads = 0;
+  const count = 2000,
+    targets = Array.from({ length: count }, (_, index) => ({
+      kind: "event_file" as const,
+      get path() {
+        reads += 1;
+        return `harness/events/op-${index}.json`;
+      },
+      operation: "create" as const,
+    }));
+  assert.equal(sameWriteTargets([...targets].reverse(), targets), true);
+  assert.ok(reads <= count * 8, `comparison read ${reads} paths for ${count} targets`);
+  assert.equal(sameWriteTargets([targets[0]!, targets[0]!], targets.slice(0, 2)), false);
+  assert.equal(sameWriteTargets(targets.slice(0, 2), [targets[0]!, targets[0]!]), false);
 });

--- a/packages/kernel/test/store/task-projection.test.ts
+++ b/packages/kernel/test/store/task-projection.test.ts
@@ -13,6 +13,7 @@ import {
   type CanonicalWriteBundle,
 } from "../../src/store/task-event-store.ts";
 import { localGitObjectRefStore } from "../../src/store/local-version-control-system.ts";
+import { freezeDeclaredWritePlan } from "../../src/domain/write-chain.contract.ts";
 import { taskLifecycleWritePlan } from "../../src/domain/task-lifecycle-publication.ts";
 import { compileEntityUpsert } from "../../src/domain/entity-event-compile.ts";
 import type { TaskEventV1 } from "../../src/domain/task-lifecycle.contract.ts";
@@ -84,6 +85,20 @@ test("task/doc reducers share one SQLite transaction and L2 rebuild restores exa
       blobs: [{ sha256: hash, size: Buffer.byteLength(body), mediaType: "text/markdown", body }],
     });
     assert.throws(() => projection.apply(event), /write plan/iu);
+    for (const invalidPlan of [
+      { ...plan, targets: plan.targets.filter((target) => target.kind !== "content_blob") },
+      {
+        ...plan,
+        targets: [
+          ...plan.targets,
+          { kind: "content_blob" as const, sha256: "f".repeat(64), size: 1, mediaType: "text/plain" },
+        ],
+      },
+      { ...plan, commandType: "TaskCreate" as const },
+    ]) {
+      const frozen = freezeDeclaredWritePlan(invalidPlan, [invalidPlan.commandType]);
+      assert.throws(() => projection.apply(event, frozen), /write plan/iu);
+    }
     assert.deepEqual(projection.apply(event, plan).metrics, { sqliteTransactions: 1, reducedItems: 1 });
     const first = projection.readDocument("context/notes.md");
     assert.equal(first.status, "ready");


### PR DESCRIPTION
# English

## Summary

fix-plan batches 2-store, 3, and 5 on the `sqlite-event-store` serial chain (task_768272d54aadd7e7b654552f55, parent task_6eba9c5d3a55735920aa4856f3 / task_2b8f79fa4412cb726a26f9bfc7), three commits. Batch 2-store: the event INSERT is prepared once per connection instead of inside the per-event loop (#2479 had only hoisted the projection statements). Batch 3: one validated byte string per event now feeds both the command intent digest and the row (`appendValidatedBundle`), the canonical serializer gains an unchecked entry for already-validated bundles and conversion plans, replay of relation events reuses the unchecked constructors instead of re-entering write compilation, plan assertion in the projection factory is removed in favour of a target-keyed member match, and JSON-stringify equality comparisons become field comparisons (actor/source, criteria, claims, write targets). Per §5.2 the `applyTransition` validation and the store's public-boundary input assertions stay. Batch 5: `Buffer.from` around blob reads is deleted at the source, `current()` returns only the document head, title and claim extraction decode a bounded window, entity-content reads check the manifest size first, the duplicate fact decode is hoisted, and the entity store caches accepted records by sha. Evidence: a real-store determinism script in the task package (production imports only, 500 commands / 1,000 events / 1,000 blobs through `makeSqliteTaskEventStore.append`) shows byte-identical `event_json`, per-row sha, intent digests and blobs before and after, `integrity_check ok`, append p50 23.00 → 19.86 ms (-13.65%); the round-5 B5 recipe keeps the full digest 00e9a513 and all four component digests, task-list p50 878 → 712 ms (after the batch-8 merge), catch-up 5.72 → 6.01 s (single-run noise, not claimed either way). Production +297/-183 (net +114): the additions are the unchecked entry points, field comparators, bounded readers and the record cache; no flag, fallback, or compatibility path. Two follow-up commits after the first CI run: the claim-extraction chunked fd read was reverted to `readFileSync` because the write-road registry gate treats `openSync` as an undeclared sink (0117b9f90), and the exact write-plan validation at `projection.apply` was restored because the projection is an independent boundary that also consumes catch-up and replay events (034fe9dba; `task-projection.test.ts` 27/27).

## Architectural Justification

- The chain replaces "serialize → parse → revalidate" loops with one validated byte string reused across intent and storage, and replaces whole-object JSON equality with named field comparators; each new function is the single entry that a previously duplicated path now shares, and the deleted paths (second serialisations, re-compilation on replay, factory plan rebuild, blob copies) are listed in Gate Harvest. Net production is positive because the validated/unchecked split adds explicit entry points while the public validation boundary is kept by ruling §5.2.

## What Changed

- `packages/kernel/src/store/sqlite-event-store.ts`, `sqlite-task-event-store.ts`, `sqlite-task-event-publication.ts`: per-connection insert statement, `appendValidatedBundle`, one digest per write, bounded `readEventsThrough`, `Buffer.from` removal.
- `packages/kernel/src/domain/doc-sync-canonical-events.ts`, `entity-json-schema.ts`, `entity-event-compile.ts`, `relation-event.ts`, `write-chain.contract.ts`, `entity-action-explanation.ts`, `people-*.ts`: unchecked serializer/encoder entries for validated inputs, replay constructors, field comparators, single roster validation.
- `packages/kernel/src/projection/rebuildable-task-projection-factory.ts`: plan re-assertion removed; target-keyed member match.
- `packages/kernel/src/store/legacy-generation-conversion.ts`, `ledger-backup.ts`, `local-version-control-system.ts`: no unused serialisation, grep-only stringify, lazy body decode.
- `packages/application/src/task-lifecycle-service.ts`: target JSON hoisted out of the loop.
- `packages/daemon/src/artifact-entity-action.ts`, `distill-actions.ts`, `entity-content-read.ts`, `entity-action-catalog-executor.ts`, `replacement-authorization.ts`, `entity-store.ts`: bounded decode windows, size-first checks, head-only `current()`, sha-keyed record cache.
- Tests: +127/-2 across store, domain, and daemon suites.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Replaced in place (no file or gate removed): per-event INSERT prepare; second serialisation of appended events for the intent digest; serialize→parse→revalidate on relation replay and conversion plans; projection factory plan rebuild/compare; duplicate publication digest; unused conversion-plan serializer output; `Buffer.from` blob copy; whole-body decode for title/claim extraction.
- Production net lines: +297/-183 (`packages/*/src`, tests excluded).

## Machine-Readable Declarations

- Production-Delta: +297/-183

## Task And Scope

- Harness task: task_768272d54aadd7e7b654552f55, parent task_6eba9c5d3a55735920aa4856f3
- Branch: `codex/perf-w-b`
- Public scope: kernel store/domain/projection factory, application lifecycle target check, daemon blob readers
- Private planning/evidence updated: yes (`artifacts/report.md`, `artifacts/round3/*`, `artifacts/store-append-bench/*`)
- Out of scope (handed to later batches): projection catch-up checked serialize (`rebuildable-task-projection-catch-up.ts:153,193`), schemas double `deriveRelationId` (`entity-relations.ts:45,51`), batch 17 conversion transactions, batch 13/4 remainders in the same store file

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: not applicable
- Machine-check boundary: not applicable
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `3a574f24f`
- Branch merge-base with `origin/main`: `31465b34f`
- Last `git fetch origin` time: 2026-09-13 UTC
- Sync method: merged origin/main into the branch after the worker's rebase onto ac6dbdd18
- Public diff command: `git diff origin/main...codex/perf-w-b`
- Private evidence commit/path: task_768272d54aadd7e7b654552f55 `artifacts/report.md`, `artifacts/round3/linear-integrity.txt`, `artifacts/round3/source-comparison.txt`
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [x] `npm run typecheck` (worker and CEO, `tsc -b`)
- [ ] `npm run check`
- [x] `npm test` (worker: fast tier 717/718, the one red re-run green in isolation; contract tier once)
- [x] `npm run harness:check-import-boundaries` (via `run-manifest-gates --changed origin/main`, worker and CEO)
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts` (via `run-manifest-gates --changed origin/main`)
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- CEO on the merged head: changed gates pass, check-fallback-boundaries 283/8/51 (no new entries), production-delta pass.

## Review Evidence

- CEO ground-truth: read the finding-by-finding table against the §5.2 ruling (validation kept at the public boundary; only duplicated validation on already-validated bytes removed); store determinism evidence is byte-level (`byteComparison: equal`, `integrity_check ok`) and the B5 digest is unchanged. The worker stopped twice with contract challenges that were both accepted (batch 2 store remainder, execution surface, evidence recipe) before implementing.
- Reviewer subagent: closeout review after merge; because this touches the write-authority chain, a second cross review by a different instance will be requested before consent.
- Human review: pending
- Blocking findings: none open

## Residual Risk

- Net production is positive; if the closeout reviewer finds an unchecked entry that a not-yet-validated caller can reach, that is a blocking finding.
- Catch-up time moved +4% in a single run on a loaded host; not claimed as a regression or an improvement.

## References

- Tasks: task_768272d54aadd7e7b654552f55; fix-plan batches 2/3/5; fix-plan-status-0912.md items 3 and 6

---

# 中文

## 概要

`sqlite-event-store` 串行链上的 fix-plan 批 2-store、批 3、批 5（task_768272d54aadd7e7b654552f55，父 task_6eba9c5d3a55735920aa4856f3 / task_2b8f79fa4412cb726a26f9bfc7），三个提交。批 2-store：事件 INSERT 每连接 prepare 一次，不再在每事件循环内（#2479 只上提了 projection 的语句）。批 3：每个事件只生成一份已验证字节，同时供命令 intent digest 与入库行（`appendValidatedBundle`）；canonical serializer 增加给已验证 bundle 与转换计划用的 unchecked 入口；relation 事件 replay 复用 unchecked 构造器而不是重入写编译；projection factory 的 plan 重建/比较删除，改为按 target 键的成员匹配；JSON stringify 等值比较改为字段比较（actor/source、criteria、claims、write targets）。按 §5.2，`applyTransition` 校验与 store 公共边界的输入断言保留。批 5：blob 读的 `Buffer.from` 从源头删除，`current()` 只返文档头，标题/claim 提取只解码有界窗口，entity-content 读先判 manifest size，fact 双解码提 const，entity store 按 sha 缓存已接受记录。证据：任务包内只导入生产源码的真实 store 确定性脚本（500 命令 / 1,000 事件 / 1,000 blob 经 `makeSqliteTaskEventStore.append`）修前修后 `event_json`、每行 sha、intent digest、blob 逐字节相等，`integrity_check ok`，append p50 23.00 → 19.86 ms（-13.65%）；round-5 B5 配方完整 digest 00e9a513 与四个分项 digest 不变，task-list p50 878 → 712 ms（批 8 合入后），catch-up 5.72 → 6.01 s（单次噪声，不作任何方向的断言）。生产 +297/-183（净 +114）：新增是 unchecked 入口、字段比较器、有界读取与记录缓存；没有 flag、兜底或兼容路径。首轮 CI 后两个补充提交：claim 提取的 fd 分块读回退为 `readFileSync`（write-road 门把 `openSync` 视为未声明 sink，0117b9f90）；恢复 `projection.apply` 的精确 write plan 校验，因为投影是独立边界、也消费 catch-up 与 replay 事件（034fe9dba；`task-projection.test.ts` 27/27）。

## 架构辩护

- 该链把「serialize → parse → revalidate」环替换为一份已验证字节在 intent 与入库间复用，把整对象 JSON 等值替换为具名字段比较器；每个新函数都是先前重复路径共用的唯一入口，被删路径（第二次序列化、replay 重编译、factory plan 重建、blob 拷贝）列在门收割。生产净增为正是因为 validated/unchecked 拆分增加了显式入口，而公共校验边界按 §5.2 裁决保留。

## 改动内容

- `packages/kernel/src/store/sqlite-event-store.ts`、`sqlite-task-event-store.ts`、`sqlite-task-event-publication.ts`：每连接 insert 语句、`appendValidatedBundle`、每次写一次 digest、有界 `readEventsThrough`、删 `Buffer.from`。
- `packages/kernel/src/domain/doc-sync-canonical-events.ts`、`entity-json-schema.ts`、`entity-event-compile.ts`、`relation-event.ts`、`write-chain.contract.ts`、`entity-action-explanation.ts`、`people-*.ts`：已验证输入的 unchecked serializer/encoder 入口、replay 构造器、字段比较器、roster 单次验证。
- `packages/kernel/src/projection/rebuildable-task-projection-factory.ts`：删 plan 重断言；target 键成员匹配。
- `packages/kernel/src/store/legacy-generation-conversion.ts`、`ledger-backup.ts`、`local-version-control-system.ts`：删无消费的序列化、只在 grep 时 stringify、正文延迟解码。
- `packages/application/src/task-lifecycle-service.ts`：target JSON 提出循环。
- `packages/daemon/src/artifact-entity-action.ts`、`distill-actions.ts`、`entity-content-read.ts`、`entity-action-catalog-executor.ts`、`replacement-authorization.ts`、`entity-store.ts`：有界解码窗口、size 先判、head-only `current()`、按 sha 的记录缓存。
- 测试：store/domain/daemon 套件 +127/-2。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 删除的门或 fixture：none
- 原地替换（未删除文件或门）：每事件 INSERT prepare；为 intent digest 的第二次事件序列化；relation replay 与转换计划的 serialize→parse→revalidate；projection factory 的 plan 重建/比较；重复的 publication digest；转换计划无消费的 serializer 输出；`Buffer.from` blob 拷贝；标题/claim 提取的整文解码。
- 生产净行数：+297/-183（`packages/*/src` 不含测试）。

## 机器可读声明

- Production-Delta: +297/-183

## 任务与范围

- Harness 任务：task_768272d54aadd7e7b654552f55，父任务 task_6eba9c5d3a55735920aa4856f3
- 分支：`codex/perf-w-b`
- 公开范围：kernel store/domain/projection factory、application lifecycle target 检查、daemon blob 读面
- 私有计划/证据已更新：是（`artifacts/report.md`、`artifacts/round3/*`、`artifacts/store-append-bench/*`）
- 范围外（交后续批次）：projection catch-up 的 checked serialize（`rebuildable-task-projection-catch-up.ts:153,193`）、schemas 双 `deriveRelationId`（`entity-relations.ts:45,51`）、批 17 转换事务、同一 store 文件的批 13/4 剩余

## 版本影响

- 版本：不变
- 发布影响：不发布

## 治理声明

- 触碰受保护面：否
- 受保护面范围：不适用
- 授权：不适用
- 机器检查边界：不适用
- Break-glass：否
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- 基线 `origin/main` SHA：`3a574f24f`
- 分支与 `origin/main` 的 merge-base：`31465b34f`
- 最近一次 `git fetch origin`：2026-09-13 UTC
- 同步方式：worker rebase 到 ac6dbdd18 后由 CEO 将 origin/main 并入分支
- 公开 diff 命令：`git diff origin/main...codex/perf-w-b`
- 私有证据路径：task_768272d54aadd7e7b654552f55 的 `artifacts/report.md`、`artifacts/round3/linear-integrity.txt`、`artifacts/round3/source-comparison.txt`
- 评审证据路径：本 PR 的评审证据节
- GitHub Actions `rewrite-ci` run URL：本 PR 待跑
- worker：fast 整层 717/718（唯一红项隔离重跑 1/1 绿）；contract 整层一次；`tsc -b` 0；changed gates 绿。CEO 在并入 main 后的头上：changed gates 绿，check-fallback-boundaries 283/8/51（无新增条目），production-delta 通过。

## 评审证据

- CEO 事实核对：逐 finding 表对照 §5.2 裁决（公共边界校验保留，只删已验证字节上的重复校验）；store 确定性证据是字节级（`byteComparison: equal`、`integrity_check ok`），B5 digest 不变。worker 两次带契约异议停手（批 2 store 剩余、执行面、证据口径），均被采纳后才实现。
- 评审子代理：合入后派收口评审；因触碰写权威链，consent 前再请另一实例交叉评审。
- 人工评审：待定
- 阻塞发现：无

## 残余风险

- 生产净增为正；若收口评审发现某个 unchecked 入口可被尚未验证的调用方触达，属阻塞发现。
- catch-up 单次在高负载宿主上 +4%，不作回归或改进断言。

## 参考

- 任务：task_768272d54aadd7e7b654552f55；fix-plan 批 2/3/5；fix-plan-status-0912.md 第 3、6 项
