### PR TITLE
perf: cache dispatch headers and runtime instance snapshots

### DIFF
--- a/packages/daemon/src/agent-runtime-instance-store.ts
+++ b/packages/daemon/src/agent-runtime-instance-store.ts
@@ -70,6 +70,7 @@ export function openRuntimeInstanceStore(input: {
     target = path.join(input.userRoot, "runtime-instances.json"),
     instancesRoot = path.join(input.userRoot, "runtime-instances"),
     readiness = new Map<string, RuntimeAuthReadiness>();
+  let cachedInstances: readonly RuntimeInstanceConfig[] | null = null;
   function create(
     candidate: RuntimeInstanceConfig | LegacyRuntimeInstanceConfig | FlatRuntimeInstanceConfig,
   ): RuntimeInstanceConfig {
@@ -237,7 +238,7 @@ export function openRuntimeInstanceStore(input: {
       effort = selectRuntimeEffort(config, request.effort),
       fast = selectRuntimeFast(config, request.fast),
       permissionMode = runtimePermissionMode(request.permissionMode ?? config.permissionMode, config.kindId),
-      witnessed = await refreshInstallations(),
+      witnessed = input.discover(),
       installation = witnessed.find(
         (entry) => entry.installationId === config.installationId && entry.kindId === config.kindId,
       );
@@ -300,10 +301,7 @@ export function openRuntimeInstanceStore(input: {
     } else if (config.kindId === "zcode") {
       const home = env.HOME ?? env.USERPROFILE;
       if (!home)
-        throw runtimeInstanceError(
-          "invalid_runtime_launch",
-          "ZCode launch environment has no home directory.",
-        );
+        throw runtimeInstanceError("invalid_runtime_launch", "ZCode launch environment has no home directory.");
       writeZcodeConfig(path.join(home, ".zcode", "cli", "config.json"), config, secret);
     } else env.ANTHROPIC_API_KEY = secret;
     rememberAuthReadiness(config.instanceId, available());
@@ -606,7 +604,14 @@ export function openRuntimeInstanceStore(input: {
     return input.refreshDiscovery ? input.refreshDiscovery() : input.discover();
   }
   function read(witnessed?: readonly RuntimeInstallationWitness[]): RuntimeInstanceConfig[] {
-    if (!existsSync(target)) return [];
+    if (cachedInstances) {
+      if (existsSync(target)) chmodSync(target, 0o600);
+      return [...cachedInstances];
+    }
+    if (!existsSync(target)) {
+      cachedInstances = [];
+      return [];
+    }
     chmodSync(target, 0o600);
     const value: unknown = JSON.parse(readFileSync(target, "utf8"));
     if (
@@ -624,7 +629,8 @@ export function openRuntimeInstanceStore(input: {
       installationMigrated = migrated.some((entry, index) => entry !== normalized[index]),
       instances = migrated.sort((a, b) => a.instanceId.localeCompare(b.instanceId));
     if (value.instances.some(needsRuntimeInstanceNormalization) || installationMigrated) persist(instances);
-    return instances;
+    cachedInstances = instances;
+    return [...instances];
   }
   function persist(instances: readonly RuntimeInstanceConfig[]): void {
     mkdirSync(input.userRoot, { recursive: true, mode: 0o700 });
@@ -645,6 +651,7 @@ export function openRuntimeInstanceStore(input: {
       throw error;
     }
     chmodSync(target, 0o600);
+    cachedInstances = [...instances].sort((left, right) => left.instanceId.localeCompare(right.instanceId));
   }
   function ensureStateRoot(config: RuntimeInstanceConfig): void {
     const root = path.join(instancesRoot, config.instanceId),

--- a/packages/daemon/src/agent-runtime-instance-store.ts
+++ b/packages/daemon/src/agent-runtime-instance-store.ts
@@ -238,7 +238,7 @@ export function openRuntimeInstanceStore(input: {
       effort = selectRuntimeEffort(config, request.effort),
       fast = selectRuntimeFast(config, request.fast),
       permissionMode = runtimePermissionMode(request.permissionMode ?? config.permissionMode, config.kindId),
-      witnessed = input.discover(),
+      witnessed = await refreshInstallations(),
       installation = witnessed.find(
         (entry) => entry.installationId === config.installationId && entry.kindId === config.kindId,
       );

--- a/packages/daemon/src/dispatch-stream.ts
+++ b/packages/daemon/src/dispatch-stream.ts
@@ -147,7 +147,13 @@ type SummaryCacheEntry = {
   readonly value: DispatchStreamSummary | null;
 };
 
+type HeaderCacheEntry = {
+  readonly mtimeMs: number;
+  readonly values: readonly DispatchStreamHeader[];
+};
+
 const summaryCache = new Map<string, SummaryCacheEntry>();
+const headerCache = new Map<string, HeaderCacheEntry>();
 const summaryHeadBytes = 16 * 1024;
 const summaryTailBytes = 128 * 1024;
 const dispatchStreamReadLimitBytes = 200 * 1024 * 1024;
@@ -279,7 +285,11 @@ export function removeDispatchLiveIndexEntries(rootDir: string, removals: readon
 
 export function readDispatchStreamHeader(rootDir: string, dispatchId: string): DispatchStreamHeader | null {
   const target = dispatchStreamPath(rootDir, dispatchId);
-  if (!existsSync(target) || !statSync(target).isFile()) return null;
+  const stat = statSync(target, { throwIfNoEntry: false });
+  return stat?.isFile() ? readDispatchStreamHeaderAt(target, dispatchId) : null;
+}
+
+function readDispatchStreamHeaderAt(target: string, dispatchId: string): DispatchStreamHeader | null {
   const descriptor = openSync(target, fsConstants.O_RDONLY),
     chunks: Buffer[] = [];
   try {
@@ -305,14 +315,14 @@ export function readDispatchStreamHeader(rootDir: string, dispatchId: string): D
  */
 export function readDispatchStreamSummary(rootDir: string, dispatchId: string): DispatchStreamSummary | null {
   const target = dispatchStreamPath(rootDir, dispatchId);
-  if (!existsSync(target) || !statSync(target).isFile()) {
+  const stat = statSync(target, { throwIfNoEntry: false });
+  if (!stat?.isFile()) {
     summaryCache.delete(target);
     return null;
   }
-  const stat = statSync(target),
-    cached = summaryCache.get(target);
+  const cached = summaryCache.get(target);
   if (cached?.mtimeMs === stat.mtimeMs && cached.size === stat.size) return cached.value;
-  const header = readDispatchStreamHeader(rootDir, dispatchId);
+  const header = readDispatchStreamHeaderAt(target, dispatchId);
   if (!header) {
     summaryCache.set(target, { mtimeMs: stat.mtimeMs, size: stat.size, value: null });
     return null;
@@ -343,11 +353,19 @@ export function readDispatchStreamSummary(rootDir: string, dispatchId: string): 
 
 export function readDispatchStreamHeaders(rootDir: string): readonly DispatchStreamHeader[] {
   const root = dispatchStreamRoot(rootDir);
-  if (!existsSync(root) || !statSync(root).isDirectory()) return [];
-  return readdirSync(root)
+  const stat = statSync(root, { throwIfNoEntry: false });
+  if (!stat?.isDirectory()) {
+    headerCache.delete(root);
+    return [];
+  }
+  const cached = headerCache.get(root);
+  if (cached?.mtimeMs === stat.mtimeMs) return cached.values;
+  const values = readdirSync(root)
     .filter((name) => /^dispatch_[a-f0-9]{24}\.jsonl$/u.test(name))
     .map((name) => readDispatchStreamHeader(rootDir, name.slice(0, -6)))
     .filter((header): header is DispatchStreamHeader => header !== null);
+  headerCache.set(root, { mtimeMs: stat.mtimeMs, values });
+  return values;
 }
 
 export function readDispatchStreamSummaries(rootDir: string): readonly DispatchStreamSummary[] {


### PR DESCRIPTION
# English

## Summary

fix-plan batches 11 and 12 (task_59e3ef9519e97932ae9f2deda6, parent task_6eba9c5d3a55735920aa4856f3 / task_2b8f79fa4412cb726a26f9bfc7), the part that fits inside the daemon dispatch/runtime surface without new mechanisms. Batch 11: `readDispatchStreamHeaders` reuses the parsed header set while the dispatch directory's mtime is unchanged (N directory enumerations and header reads per call → 1 on first use, 0 after), and the header/summary point reads collapse `existsSync + statSync (+ a second stat via the public header API)` into one `statSync(..., { throwIfNoEntry: false })`. Batch 12: the runtime instance store keeps the parsed instance configuration for the daemon lifetime with the write side updating it (per-call read/parse/sort → once), `prepareLaunch` keeps calling `refreshInstallations()` before a launch: the first cut skipped it and the isolated `read-stopgap-performance` "runtime discovery write load" case went red on the branch while green on main, so Round 2 restored it in 582d011db (+1/-1) and the case is 3/3 green again on Ubuntu before and after the rebase. Findings deliberately left for later batches, with the reason recorded per row in the task report: the 10 ms durable-output poll (needs a cursor contract), the per-append fd retention (the writer has no close lifecycle), attempt-chain explicit request (needs a CLI payload change, CLI is out of surface), keyed batch reads on the projection (needs a kernel API), and tmux async (would Promise-ify the TerminalHost interface). Production +38/-13 in three commits.

## Architectural Justification

-

## What Changed

- `packages/daemon/src/dispatch-stream.ts`: mtime-keyed header snapshot; single metadata probe for header and summary reads.
- `packages/daemon/src/agent-runtime-instance-store.ts`: instance configuration snapshot for the store lifetime, persisted-on-write; `prepareLaunch` still refreshes installations before launch (Round 2 restore, 582d011db).
- Tests: `dispatch-stream.test.ts` 15/15; `agent-runtime-instance-registry.test.ts` + `agent-runtime-instance-environment.test.ts` 55/55 (the first run's 54/55 proved the cache hit still has to run the chmod permission repair; fixed before commit).

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: +38/-13 (`packages/*/src`, tests excluded).
- Replaced in place: exists+stat double probe; summary→header second stat; per-launch PATH discovery; per-call instance file parse.

## Machine-Readable Declarations

- Production-Delta: +38/-13

## Task And Scope

- Harness task: task_59e3ef9519e97932ae9f2deda6, parent task_6eba9c5d3a55735920aa4856f3
- Branch: `codex/perf-w-e`
- Public scope: daemon dispatch stream reads, runtime instance store
- Private planning/evidence updated: yes (`artifacts/report.md`)
- Out of scope (recorded): durable-output poll cursor, append fd lifecycle, attemptChain explicit request, projection keyed batch API, tmux async

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: not applicable
- Machine-check boundary: not applicable
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `31465b34f`
- Branch merge-base with `origin/main`: `31465b34f`
- Last `git fetch origin` time: 2026-09-13 UTC
- Sync method: branched from origin/main
- Public diff command: `git diff origin/main...codex/perf-w-e`
- Private evidence commit/path: task_59e3ef9519e97932ae9f2deda6 `artifacts/report.md`
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [x] `npm run typecheck` (worker and CEO)
- [ ] `npm run check`
- [ ] `npm test`
- [x] `npm run harness:check-import-boundaries` (via `run-manifest-gates --changed origin/main`, worker and CEO)
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts` (via `run-manifest-gates --changed origin/main`)
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- CEO: check-fallback-boundaries 283/8/51 on the branch (no new entries).

## Review Evidence

- CEO ground-truth: read the per-finding table; the "already landed in #2509" rows were not redone, and each unmodified row names the mechanism it would have needed.
- Reviewer subagent: closeout review after merge
- Human review: pending
- Blocking findings: none open

## Residual Risk

- Directory mtime granularity: a header added within the same mtime tick as the last snapshot is picked up on the next mtime change; dispatch creation always writes a new file, so the next call after any later write sees it.
- Instance snapshot is process-local; external edits to the instance file while the daemon runs are not observed until restart (the persisted write path updates the snapshot).

## References

- Tasks: task_59e3ef9519e97932ae9f2deda6; fix-plan batches 11/12; fix-plan-status-0912.md items 8–9

---

# 中文

## 概要

fix-plan 批 11 与批 12（task_59e3ef9519e97932ae9f2deda6，父 task_6eba9c5d3a55735920aa4856f3 / task_2b8f79fa4412cb726a26f9bfc7）中不需要新机制、能落在 daemon dispatch/runtime 面内的部分。批 11：`readDispatchStreamHeaders` 在 dispatch 目录 mtime 不变时复用已解析的 header 集合（每次调用 N 次目录枚举与头读 → 首次 1 次、之后 0 次）；header/summary 点读把 `existsSync + statSync（+ 经公共 header API 的第二次 stat）` 收成一次 `statSync(..., { throwIfNoEntry: false })`。批 12：runtime instance store 在 daemon 生命周期内保留已解析的 instance 配置、写侧同步更新（每次调用 read/parse/sort → 一次）；`prepareLaunch` 启动前仍调用 `refreshInstallations()`：第一刀跳过了它，隔离环境的 `read-stopgap-performance`「runtime discovery write load」用例在分支上红、在 main 上绿，第二轮 582d011db（+1/-1）恢复后，rebase 前后在 Ubuntu 各 3/3 绿。有意留给后续批次、报告逐行写明原因的 finding：10 ms durable-output 轮询（需要 cursor 契约）、每次 append 的 fd 驻留（writer 没有 close 生命周期）、attemptChain 显式请求（要改 CLI payload，CLI 在本任务禁区）、projection keyed batch 读（要加 kernel API）、tmux 异步（要把 TerminalHost 接口整体 Promise 化）。生产 +38/-13，两个提交。

## 架构辩护

-

## 改动内容

- `packages/daemon/src/dispatch-stream.ts`：mtime 键 header 快照；header 与 summary 读只做一次元数据探针。
- `packages/daemon/src/agent-runtime-instance-store.ts`：store 生命周期内的 instance 配置快照、写时更新；`prepareLaunch` 启动前仍调用 `refreshInstallations()`（第二轮恢复，582d011db）。
- 测试：`dispatch-stream.test.ts` 15/15；`agent-runtime-instance-registry.test.ts` + `agent-runtime-instance-environment.test.ts` 55/55（首跑 54/55 证明缓存命中仍须执行 chmod 权限自修复，提交前已修）。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 删除的门或 fixture：none
- 生产净行数：+38/-13（`packages/*/src` 不含测试）。
- 原地替换：exists+stat 双探针；summary→header 二次 stat；每 launch 的 PATH 发现；每次调用的 instance 文件解析。

## 机器可读声明

- Production-Delta: +38/-13

## 任务与范围

- Harness 任务：task_59e3ef9519e97932ae9f2deda6，父任务 task_6eba9c5d3a55735920aa4856f3
- 分支：`codex/perf-w-e`
- 公开范围：daemon dispatch 流读面、runtime instance store
- 私有计划/证据已更新：是（`artifacts/report.md`）
- 范围外（已记录）：durable-output 轮询 cursor、append fd 生命周期、attemptChain 显式请求、projection keyed batch API、tmux 异步

## 版本影响

- 版本：不变
- 发布影响：不发布

## 治理声明

- 触碰受保护面：否
- 受保护面范围：不适用
- 授权：不适用
- 机器检查边界：不适用
- Break-glass：否
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- 基线 `origin/main` SHA：`31465b34f`
- 分支与 `origin/main` 的 merge-base：`31465b34f`
- 最近一次 `git fetch origin`：2026-09-13 UTC
- 同步方式：从 origin/main 开分支
- 公开 diff 命令：`git diff origin/main...codex/perf-w-e`
- 私有证据路径：task_59e3ef9519e97932ae9f2deda6 的 `artifacts/report.md`
- 评审证据路径：本 PR 的评审证据节
- GitHub Actions `rewrite-ci` run URL：本 PR 待跑
- worker：定向 fast 15/15、contract 55/55；tsc 0；changed gates 绿。CEO：分支上 check-fallback-boundaries 283/8/51（无新增条目）。

## 评审证据

- CEO 事实核对：逐 finding 表已读；#2509 已落地的行没有重做，每条未改行都写明了它需要的机制。
- 评审子代理：合入后派收口评审
- 人工评审：待定
- 阻塞发现：无

## 残余风险

- 目录 mtime 粒度：与上次快照同一 tick 内新增的 header 在下一次 mtime 变化时被看到；dispatch 创建总是写新文件，之后任何一次写都会让下一次调用看到它。
- instance 快照是进程内的；daemon 运行期间外部改动 instance 文件要到重启才被观察到（写路径会更新快照）。

## 参考

- 任务：task_59e3ef9519e97932ae9f2deda6；fix-plan 批 11/12；fix-plan-status-0912.md 第 8–9 项

