### PR TITLE
perf: reuse daemon JSON-RPC clients in wait paths

### DIFF
--- a/packages/cli/src/cli-runtime-wait.ts
+++ b/packages/cli/src/cli-runtime-wait.ts
@@ -8,6 +8,7 @@ import {
   runCommandThroughDaemon,
   streamRuntimeThroughDaemon,
 } from "./daemon/client.ts";
+import { openDaemonStatusReader } from "./daemon/status-reader.ts";
 
 type DaemonGone = { readonly kind: "daemon-gone"; readonly cause: string };
 type RuntimeStreamSignal = "terminal" | "lost";
@@ -215,62 +216,73 @@ export async function waitForTaskDispatches(command: ThinCommand, taskId: string
     method: "repo.task.dispatches",
     action: { kind: "task-dispatches", taskId },
   };
-  let current: JsonObject | undefined;
-  for (;;) {
-    const next = await readDaemonSubscription(() =>
-      runCommandThroughDaemon(readCommand, () => undefined, { autostart: false }),
-    );
-    if (isDaemonGone(next)) {
-      const dispatches = Array.isArray(current?.dispatches) ? current.dispatches : [],
-        rows = `${dispatches.length} row${dispatches.length === 1 ? "" : "s"}`;
-      return daemonGoneReceipt(
-        "runtime-status",
-        next.cause,
-        rows,
-        { taskId, lastKnownDispatches: dispatches },
-        `runtime-status task ${taskId}`,
+  let current: JsonObject | undefined, statusReader: Awaited<ReturnType<typeof openDaemonStatusReader>> | undefined;
+  try {
+    for (;;) {
+      const next = await readDaemonSubscription(
+        async () => {
+          statusReader ??= await openDaemonStatusReader(readCommand, "repo.task.dispatches", { taskId });
+          return statusReader.read();
+        },
+        () => {
+          statusReader?.close();
+          statusReader = undefined;
+        },
       );
+      if (isDaemonGone(next)) {
+        const dispatches = Array.isArray(current?.dispatches) ? current.dispatches : [],
+          rows = `${dispatches.length} row${dispatches.length === 1 ? "" : "s"}`;
+        return daemonGoneReceipt(
+          "runtime-status",
+          next.cause,
+          rows,
+          { taskId, lastKnownDispatches: dispatches },
+          `runtime-status task ${taskId}`,
+        );
+      }
+      current = next;
+      if (current.ok !== true) return current;
+      if (current.status !== "pending" && taskDispatchesSettled(current)) break;
+      await new Promise((resolve) => setTimeout(resolve, 250));
     }
-    current = next;
-    if (current.ok !== true) return current;
-    if (current.status !== "pending" && taskDispatchesSettled(current)) break;
-    await new Promise((resolve) => setTimeout(resolve, 250));
-  }
-  const dispatches: readonly unknown[] = Array.isArray(current.dispatches) ? current.dispatches : [],
-    finalDispatches = dispatches.filter(
-      (row: unknown) => (row as Record<string, unknown>).fallbackState !== "dispatched",
-    ),
-    noDispatches = finalDispatches.length === 0,
-    cancelled = finalDispatches.some((row: unknown) => (row as Record<string, unknown>).status === "cancelled"),
-    lost = finalDispatches.some((row: unknown) => {
-      const status = row && typeof row === "object" ? (row as Record<string, unknown>).status : undefined;
-      return status === "lost";
-    }),
-    failed = finalDispatches.some((row: unknown) => {
-      const status = row && typeof row === "object" ? (row as Record<string, unknown>).status : undefined;
-      return status === "failed";
-    }),
-    outcome = noDispatches
-      ? "unknown"
-      : lost || finalDispatches.some((row: unknown) => (row as Record<string, unknown>).status === "unknown")
+    const dispatches: readonly unknown[] = Array.isArray(current.dispatches) ? current.dispatches : [],
+      finalDispatches = dispatches.filter(
+        (row: unknown) => (row as Record<string, unknown>).fallbackState !== "dispatched",
+      ),
+      noDispatches = finalDispatches.length === 0,
+      cancelled = finalDispatches.some((row: unknown) => (row as Record<string, unknown>).status === "cancelled"),
+      lost = finalDispatches.some((row: unknown) => {
+        const status = row && typeof row === "object" ? (row as Record<string, unknown>).status : undefined;
+        return status === "lost";
+      }),
+      failed = finalDispatches.some((row: unknown) => {
+        const status = row && typeof row === "object" ? (row as Record<string, unknown>).status : undefined;
+        return status === "failed";
+      }),
+      outcome = noDispatches
         ? "unknown"
-        : failed
-          ? "failed"
-          : cancelled
-            ? "cancelled"
-            : "succeeded";
-  return {
-    ...current,
-    command: "runtime-status",
-    taskId,
-    outcome,
-    summary: [
-      `runtime-status task ${taskId}:`,
-      `${dispatches.length} dispatch${dispatches.length === 1 ? "" : "es"}`,
+        : lost || finalDispatches.some((row: unknown) => (row as Record<string, unknown>).status === "unknown")
+          ? "unknown"
+          : failed
+            ? "failed"
+            : cancelled
+              ? "cancelled"
+              : "succeeded";
+    return {
+      ...current,
+      command: "runtime-status",
+      taskId,
       outcome,
-    ].join(" "),
-    exitCode: outcome === "succeeded" ? 0 : 1,
-  };
+      summary: [
+        `runtime-status task ${taskId}:`,
+        `${dispatches.length} dispatch${dispatches.length === 1 ? "" : "es"}`,
+        outcome,
+      ].join(" "),
+      exitCode: outcome === "succeeded" ? 0 : 1,
+    };
+  } finally {
+    statusReader?.close();
+  }
 }
 
 export async function waitForSquadRun(command: ThinCommand, squadRunId: string): Promise<JsonObject> {

--- a/packages/cli/src/daemon/client.ts
+++ b/packages/cli/src/daemon/client.ts
@@ -22,6 +22,7 @@ import type { DaemonLaunchSpec } from "../../../daemon/src/client/daemon-autosta
 import { cliErrorMessage } from "../cli-error.ts";
 import type { ThinCommand } from "../cli/thin-command.ts";
 import { fleetEdgeRegistration, fleetScheduleRoute } from "./fleet-command-route.ts";
+import { openDaemonStatusReader } from "./status-reader.ts";
 import { withAutostart } from "./with-autostart.ts";
 import { assertCanonicalCliEntry, cliEntryNotCanonicalCode } from "./cli-entry-guard.ts";
 export {
@@ -248,56 +249,71 @@ export async function runCommandThroughDaemon(
     target.socketPath,
     daemonAutostartOptions(command, autostart, env, target.userRoot, target.daemonId),
   );
-  result = await settleRepoWarming(result, request, target.userRoot, target.daemonId);
+  result = await settleRepoWarming(
+    result,
+    () =>
+      openLocalDaemonReader(target, command.method, {
+        repo: { repoId: target.repoId },
+        ...(daemonMethodAcceptsPayload(command.method) ? { payload: requestPayload as JsonObject } : {}),
+      }),
+    target.userRoot,
+    target.daemonId,
+  );
   if (command.action.kind !== "preset-run-start") return result;
-  let observed = 0;
-  for (;;) {
-    const phases = Array.isArray(result.phases)
-      ? result.phases.filter((phase): phase is string => typeof phase === "string")
-      : [];
-    for (const phase of phases.slice(observed))
-      onPhase({
-        ...result,
-        ok: !["op_rejected", "failed", "outcome_unknown"].includes(phase),
-        command: "preset-run-start",
-        summary: `preset-run-start: ${phase}`,
-      });
-    observed = phases.length;
-    if (["applied", "op_rejected", "failed", "outcome_unknown"].includes(String(result.outcome))) {
-      const ok = result.outcome === "applied";
-      return {
-        ...result,
-        ok,
-        command: "preset-run-start",
-        summary: `preset-run-start: ${String(result.phase)}`,
-        ...(!ok
-          ? {
-              error: {
-                code: result.code ?? "preset_run_failed",
-              },
-            }
-          : {}),
-      };
+  let observed = 0,
+    statusReader: Awaited<ReturnType<typeof openLocalDaemonReader>> | undefined;
+  try {
+    for (;;) {
+      const phases = Array.isArray(result.phases)
+        ? result.phases.filter((phase): phase is string => typeof phase === "string")
+        : [];
+      for (const phase of phases.slice(observed))
+        onPhase({
+          ...result,
+          ok: !["op_rejected", "failed", "outcome_unknown"].includes(phase),
+          command: "preset-run-start",
+          summary: `preset-run-start: ${phase}`,
+        });
+      observed = phases.length;
+      if (["applied", "op_rejected", "failed", "outcome_unknown"].includes(String(result.outcome))) {
+        const ok = result.outcome === "applied";
+        return {
+          ...result,
+          ok,
+          command: "preset-run-start",
+          summary: `preset-run-start: ${String(result.phase)}`,
+          ...(!ok
+            ? {
+                error: {
+                  code: result.code ?? "preset_run_failed",
+                },
+              }
+            : {}),
+        };
+      }
+      await new Promise((resolve) => setTimeout(resolve, 250));
+      try {
+        statusReader ??= await openLocalDaemonReader(target, "repo.preset.run.status", {
+          repo: { repoId: target.repoId },
+          payload: { runId: result.runId },
+        });
+        result = await statusReader.read();
+      } catch (error) {
+        consumeKnownError(error);
+        statusReader?.close();
+        statusReader = undefined;
+        result = {
+          ...result,
+          outcome: "outcome_unknown",
+          phase: "outcome_unknown",
+          phases: [...phases, "outcome_unknown"],
+          code: "daemon_disconnect",
+          nextAction: "Reconnect and inspect status; do not automatically retry.",
+        };
+      }
     }
-    await new Promise((resolve) => setTimeout(resolve, 250));
-    try {
-      result = await requestLocalDaemonJsonRpcForTarget(
-        target,
-        "repo.preset.run.status",
-        { repo: { repoId: target.repoId }, payload: { runId: result.runId } },
-        75,
-      );
-    } catch (error) {
-      consumeKnownError(error);
-      result = {
-        ...result,
-        outcome: "outcome_unknown",
-        phase: "outcome_unknown",
-        phases: [...phases, "outcome_unknown"],
-        code: "daemon_disconnect",
-        nextAction: "Reconnect and inspect status; do not automatically retry.",
-      };
-    }
+  } finally {
+    statusReader?.close();
   }
 }
 
@@ -335,7 +351,6 @@ function daemonRequestPayload(command: ThinCommand, env: NodeJS.ProcessEnv): Rea
       ? { ...payload, executor }
       : payload;
 }
-
 function materializeScheduleMission(command: ThinCommand): ThinCommand {
   if (
     !["schedule-create", "schedule-update"].includes(command.action.kind) ||
@@ -353,7 +368,7 @@ function materializeScheduleMission(command: ThinCommand): ThinCommand {
 }
 async function settleRepoWarming(
   initial: JsonObject,
-  request: () => Promise<JsonObject>,
+  openReader: () => ReturnType<typeof openLocalDaemonReader>,
   userRoot: string,
   daemonId: string,
 ): Promise<JsonObject> {
@@ -363,20 +378,26 @@ async function settleRepoWarming(
     startedAt = Date.now(),
     deadline = startedAt + 60_000;
   let result = initial,
+    reader: Awaited<ReturnType<typeof openLocalDaemonReader>> | undefined,
     reported = "";
-  while (isRepoWarming(result) && Date.now() < deadline) {
-    const progress = readDaemonStartProgress(launch, Date.now() - startedAt);
-    if (progress) {
-      const key = `${progress.fingerprint}:${Math.floor((Date.now() - startedAt) / 1_000)}`;
-      if (key !== reported) {
-        reported = key;
-        process.stderr.write(`${progress.message}\n`);
+  try {
+    while (isRepoWarming(result) && Date.now() < deadline) {
+      const progress = readDaemonStartProgress(launch, Date.now() - startedAt);
+      if (progress) {
+        const key = `${progress.fingerprint}:${Math.floor((Date.now() - startedAt) / 1_000)}`;
+        if (key !== reported) {
+          reported = key;
+          process.stderr.write(`${progress.message}\n`);
+        }
       }
+      await new Promise((resolve) => setTimeout(resolve, 250));
+      reader ??= await openReader();
+      result = await reader.read();
     }
-    await new Promise((resolve) => setTimeout(resolve, 250));
-    result = await request();
+    return result;
+  } finally {
+    reader?.close();
   }
-  return result;
 }
 function isRepoWarming(result: JsonObject): boolean {
   const error =
@@ -417,26 +438,24 @@ export async function openRuntimeStatusReader(
       read: () => runCommandThroughDaemon(fleetCommand, () => undefined, { autostart: false }),
       close: () => undefined,
     };
-  const daemonTarget = await resolveLocalDaemonTarget({ rootDir: command.rootDir, repoIdOverride: command.repoId }),
-    { connectSocket, JsonRpcLineClient } = await import("../../../daemon/src/client/local-json-rpc-client.ts"),
-    { currentDaemonProtocolVersion } = await import("../../../daemon/src/protocol/version.ts"),
-    socket = await connectSocket(daemonTarget.socketPath, 2_000),
-    client = new JsonRpcLineClient(socket, socket);
-  try {
-    await client.request("protocol.hello", { protocolVersion: currentDaemonProtocolVersion }, 30_000);
-  } catch (error) {
-    socket.destroy();
-    throw error;
-  }
-  return {
-    read: () =>
-      client.request(
-        "repo.agentRuntime.sessions.read",
-        { repo: { repoId: daemonTarget.repoId }, payload: waitTarget ?? { runtimeSessionId } },
-        30_000,
-      ),
-    close: () => client.close(),
-  };
+  return openDaemonStatusReader(fleetCommand, "repo.agentRuntime.sessions.read", waitTarget ?? { runtimeSessionId });
+}
+async function openLocalDaemonReader(
+  target: { readonly socketPath: string; readonly sessionEnvironment?: DaemonSessionEnvironment },
+  method: string,
+  params: JsonObject,
+  connectTimeoutMs = 75,
+  responseTimeoutMs?: number,
+): Promise<{ readonly read: () => Promise<JsonObject>; readonly close: () => void }> {
+  const { openDaemonJsonRpcReaderAt } = await import("../../../daemon/src/client/local-json-rpc-client.ts");
+  return openDaemonJsonRpcReaderAt(
+    target.socketPath,
+    method,
+    params,
+    connectTimeoutMs,
+    responseTimeoutMs,
+    target.sessionEnvironment,
+  );
 }
 // The sign-in relay stays lazy for the same reason the autostart seam does: the thin dist static
 // import graph stays entry/parser/transport-only, and the tty bridge only loads for an
@@ -658,7 +677,6 @@ function interactiveSessionEnvironment(env: NodeJS.ProcessEnv): DaemonSessionEnv
     ...(harnessActor ? { HARNESS_ACTOR: harnessActor } : {}),
   };
 }
-
 function interactiveAgentActor(env: NodeJS.ProcessEnv): string | null {
   const explicit = env.HARNESS_ACTOR?.trim();
   if (explicit) return explicit;
@@ -671,7 +689,6 @@ function interactiveAgentActor(env: NodeJS.ProcessEnv): string | null {
   const codex = thread ?? session;
   return codex ? `agent:codex-session:${codex}` : null;
 }
-
 export function consumeKnownError(error: unknown): void {
   void error;
 }

--- a/packages/cli/src/daemon/status-reader.ts
+++ b/packages/cli/src/daemon/status-reader.ts
@@ -1,0 +1,19 @@
+import type { JsonObject } from "../../../daemon/src/protocol/json-rpc-types.ts";
+import { resolveLocalDaemonTarget } from "../../../daemon/src/client/local-daemon-target.ts";
+import type { ThinCommand } from "../cli/thin-command.ts";
+
+export async function openDaemonStatusReader(
+  command: ThinCommand,
+  method: string,
+  payload: JsonObject,
+): Promise<{ readonly read: () => Promise<JsonObject>; readonly close: () => void }> {
+  const target = await resolveLocalDaemonTarget({ rootDir: command.rootDir, repoIdOverride: command.repoId }),
+    { openDaemonJsonRpcReaderAt } = await import("../../../daemon/src/client/local-json-rpc-client.ts");
+  return openDaemonJsonRpcReaderAt(
+    target.socketPath,
+    method,
+    { repo: { repoId: target.repoId }, payload },
+    2_000,
+    30_000,
+  );
+}

--- a/packages/cli/test/daemon-autostart-cli.test.ts
+++ b/packages/cli/test/daemon-autostart-cli.test.ts
@@ -776,7 +776,8 @@ test("CLI reports lifecycle attach progress and waits through a slow warming rep
   lifecycle.record({ event: "process_start", endpoint: socketPath });
   lifecycle.record({ event: "socket_bound", endpoint: socketPath });
   lifecycle.record({ event: "repo_attach_started", repoId, attachIndex: 2, attachTotal: 5 });
-  let requests = 0;
+  let requests = 0,
+    helloRequests = 0;
   const server = createServer((socket) => {
     let buffered = "";
     socket.on("data", (chunk) => {
@@ -787,8 +788,9 @@ test("CLI reports lifecycle attach progress and waits through a slow warming rep
         const line = buffered.slice(0, newline);
         buffered = buffered.slice(newline + 1);
         const request = JSON.parse(line) as { id: number; method: string };
-        requests += request.method === "protocol.hello" ? 0 : 1;
-        if (requests === 2)
+        if (request.method === "protocol.hello") helloRequests += 1;
+        else requests += 1;
+        if (requests === 3)
           lifecycle.record({
             event: "repo_attach_completed",
             repoId,
@@ -799,7 +801,7 @@ test("CLI reports lifecycle attach progress and waits through a slow warming rep
         const result =
           request.method === "protocol.hello"
             ? { protocolVersion: { major: 1, minor: 0 } }
-            : requests >= 2
+            : requests >= 3
               ? {
                   schema: "command-receipt/v2",
                   ok: true,
@@ -827,7 +829,8 @@ test("CLI reports lifecycle attach progress and waits through a slow warming rep
     const result = await spawnCli(fixture.root, fixture.userRoot, ["task", "list"]);
     assert.equal(result.status, 0, `${result.stderr}\n${result.stdout}`);
     assert.equal((JSON.parse(result.stdout) as { outcome: string }).outcome, "applied");
-    assert.ok(requests >= 2, "the original command must retry after the warming receipt");
+    assert.equal(requests, 3, "the original command must poll twice after the warming receipt");
+    assert.equal(helloRequests, 2, "the warming polls must share one JSON-RPC connection");
     assert.match(result.stderr, /daemon is starting; waited \d+s \(repo 2\/5: slow-warming\)/u);
   } finally {
     await new Promise<void>((resolve) => server.close(() => resolve()));

--- a/packages/cli/test/runtime-wait-reconnect.integration.test.ts
+++ b/packages/cli/test/runtime-wait-reconnect.integration.test.ts
@@ -407,6 +407,7 @@ test("task dispatch wait classifies an ENOENT reconnect as daemon_gone and retai
     }
     assert.equal(request.method, "repo.task.dispatches");
     reply(socket, request.id, { ok: true, status: "ready", dispatches: [dispatch] });
+    socket.end();
     socket.once("close", fixture.die);
   };
   const invocation = runWait(fixture, ["runtime", "status", "--task", taskId, "--wait", "--no-stream"]);

--- a/packages/cli/test/runtime-wait-reconnect.integration.test.ts
+++ b/packages/cli/test/runtime-wait-reconnect.integration.test.ts
@@ -423,6 +423,43 @@ test("task dispatch wait classifies an ENOENT reconnect as daemon_gone and retai
   }
 });
 
+test("task dispatch wait reuses one hello connection across polling ticks", async () => {
+  const fixture = await openFixtureDaemon("task-persistent-reader"),
+    taskId = "task-runtime-wait";
+  let helloRequests = 0,
+    statusReads = 0;
+  fixture.onRequest = (socket, request) => {
+    if (request.method === "protocol.hello") {
+      helloRequests += 1;
+      reply(socket, request.id, { ok: true });
+      return;
+    }
+    assert.equal(request.method, "repo.task.dispatches");
+    statusReads += 1;
+    reply(socket, request.id, {
+      ok: true,
+      status: "ready",
+      dispatches: [
+        {
+          dispatchId: "dispatch-runtime-wait",
+          status: statusReads === 3 ? "succeeded" : "running",
+          fallbackState: null,
+        },
+      ],
+    });
+  };
+  const invocation = runWait(fixture, ["runtime", "status", "--task", taskId, "--wait", "--no-stream"]);
+  try {
+    const result = await invocation.result(2_000);
+    assert.equal(result.code, 0, result.stderr);
+    assert.equal(statusReads, 3);
+    assert.equal(helloRequests, 1, "all polling ticks must share the initial JSON-RPC connection");
+  } finally {
+    invocation.stop();
+    await fixture.close();
+  }
+});
+
 interface FixtureDaemon {
   readonly root: string;
   readonly userRoot: string;

--- a/packages/daemon/src/client/local-json-rpc-client.ts
+++ b/packages/daemon/src/client/local-json-rpc-client.ts
@@ -96,6 +96,44 @@ export async function requestDaemonJsonRpcAt(
   );
 }
 
+export async function openDaemonJsonRpcClientAt(
+  socketPath: string,
+  timeoutMs = 75,
+  responseTimeoutMs?: number,
+  sessionEnvironment?: DaemonSessionEnvironment,
+): Promise<JsonRpcLineClient> {
+  const socket = await connectSocket(socketPath, timeoutMs),
+    client = new JsonRpcLineClient(socket, socket);
+  try {
+    await client.request(
+      "protocol.hello",
+      {
+        protocolVersion: currentDaemonProtocolVersion,
+        ...(sessionEnvironment && Object.keys(sessionEnvironment).length > 0
+          ? { sessionEnvironment: sessionEnvironment as JsonObject }
+          : {}),
+      },
+      responseTimeoutMs,
+    );
+    return client;
+  } catch (error) {
+    client.close();
+    throw error;
+  }
+}
+
+export async function openDaemonJsonRpcReaderAt(
+  socketPath: string,
+  method: string,
+  params: JsonObject,
+  timeoutMs = 75,
+  responseTimeoutMs?: number,
+  sessionEnvironment?: DaemonSessionEnvironment,
+): Promise<{ readonly read: () => Promise<JsonObject>; readonly close: () => void }> {
+  const client = await openDaemonJsonRpcClientAt(socketPath, timeoutMs, responseTimeoutMs, sessionEnvironment);
+  return { read: () => client.request(method, params, responseTimeoutMs), close: () => client.close() };
+}
+
 // One line reader per client, not per request. A readline interface attaches its own data/end/error
 // listeners to the input, so a fresh interface per request stacked one listener set per request on a
 // reused connection and nothing detached them: the read loop abandoned its iterator at the matching

--- a/packages/daemon/src/client/terminal-relay.ts
+++ b/packages/daemon/src/client/terminal-relay.ts
@@ -1,7 +1,7 @@
 import process from "node:process";
 import { consumeKnownError } from "../../../kernel/src/index.ts";
 import type { JsonObject } from "../protocol/json-rpc-types.ts";
-import { requestLocalDaemonJsonRpcForTarget } from "./local-json-rpc-client.ts";
+import { openDaemonJsonRpcClientAt, type JsonRpcLineClient } from "./local-json-rpc-client.ts";
 import { streamDaemonFacetAt } from "./local-json-rpc-stream.ts";
 
 // Interactive runtime sign-in runs on a daemon-owned PTY, never in this process, so the person
@@ -21,14 +21,20 @@ export async function relayDaemonTerminal(input: {
   readonly rows?: () => number;
 }): Promise<number> {
   const stdin = input.stdin ?? process.stdin,
-    call = (method: string, payload: JsonObject, responseTimeoutMs?: number) =>
-      requestLocalDaemonJsonRpcForTarget(
-        { socketPath: input.socketPath },
-        method,
-        Object.keys(payload).length ? { repo: { repoId: input.repoId }, payload } : { repo: { repoId: input.repoId } },
-        75,
-        responseTimeoutMs,
-      );
+    params = (payload: JsonObject): JsonObject =>
+      Object.keys(payload).length ? { repo: { repoId: input.repoId }, payload } : { repo: { repoId: input.repoId } };
+  let client: Promise<JsonRpcLineClient> | undefined;
+  const call = async (method: string, payload: JsonObject, responseTimeoutMs?: number): Promise<JsonObject> => {
+    client ??= openDaemonJsonRpcClientAt(input.socketPath, 75, responseTimeoutMs);
+    const active = await client;
+    try {
+      return await active.request(method, params(payload), responseTimeoutMs);
+    } catch (error) {
+      active.close();
+      client = undefined;
+      throw error;
+    }
+  };
   let clientSeq = 0,
     queue: Promise<unknown> = Promise.resolve(),
     settled = false,
@@ -62,6 +68,7 @@ export async function relayDaemonTerminal(input: {
     stdin.setRawMode?.(false);
     process.stdout.off("resize", onResize);
     detach();
+    void client?.then((active) => active.close());
     resolveExit?.(code);
   };
   const finishFromFrame = async () => {

--- a/packages/daemon/test/terminal-relay.integration.test.ts
+++ b/packages/daemon/test/terminal-relay.integration.test.ts
@@ -1,0 +1,107 @@
+// harness-test-tier: integration
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import net from "node:net";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { PassThrough } from "node:stream";
+import test from "node:test";
+import { relayDaemonTerminal } from "../src/client/terminal-relay.ts";
+
+test("terminal relay shares one control connection for resize, input, and exit lookup", async () => {
+  const parent = mkdtempSync(path.join(tmpdir(), "ha-terminal-relay-")),
+    socketPath = path.join(parent, "daemon.sock"),
+    stdin = new PassThrough() as PassThrough & { setRawMode: (mode: boolean) => void };
+  let connections = 0,
+    hellos = 0,
+    streamSocket: net.Socket | undefined,
+    inputSeen!: () => void;
+  const input = new Promise<void>((resolve) => {
+      inputSeen = resolve;
+    }),
+    server = net.createServer((socket) => {
+      connections += 1;
+      let buffered = "";
+      socket.on("data", (chunk) => {
+        buffered += String(chunk);
+        for (;;) {
+          const newline = buffered.indexOf("\n");
+          if (newline < 0) break;
+          const request = JSON.parse(buffered.slice(0, newline)) as { id: number; method: string };
+          buffered = buffered.slice(newline + 1);
+          if (request.method === "protocol.hello") {
+            hellos += 1;
+            reply(socket, request.id, { ok: true });
+          } else if (request.method === "repo.terminal.attach") {
+            streamSocket = socket;
+            reply(socket, request.id, {
+              schema: "terminal-attach/v1",
+              ok: true,
+              sessionId: "session-1",
+              attachmentId: "attachment-1",
+              daemonGeneration: 1,
+              status: "attached",
+              replayFromSeq: 1,
+              outputSeq: 0,
+            });
+          } else if (request.method === "repo.terminal.input") {
+            reply(socket, request.id, { ok: true });
+            inputSeen();
+          } else if (request.method === "repo.terminal.sessions.list")
+            reply(socket, request.id, { sessions: [{ sessionId: "session-1", exitCode: 0 }] });
+          else reply(socket, request.id, { ok: true });
+        }
+      });
+    });
+  stdin.setRawMode = () => undefined;
+  try {
+    await new Promise<void>((resolve, reject) => {
+      server.once("error", reject);
+      server.listen(socketPath, resolve);
+    });
+    const relay = relayDaemonTerminal({
+      socketPath,
+      repoId: "repo-1",
+      sessionId: "session-1",
+      write: () => undefined,
+      stdin,
+    });
+    await waitFor(() => streamSocket !== undefined);
+    stdin.write("x");
+    await input;
+    streamSocket!.write(
+      `${JSON.stringify({
+        jsonrpc: "2.0",
+        method: "repo.terminal.attach.frame",
+        params: {
+          schema: "terminal-attach-event/v1",
+          sessionId: "session-1",
+          seq: 1,
+          kind: "exit",
+          utf8: "",
+          droppedThrough: null,
+          occurredAt: "2026-09-12T00:00:00.000Z",
+        },
+      })}\n`,
+    );
+    assert.equal(await relay, 0);
+    assert.equal(connections, 2, "the stream and all control calls must use one socket each");
+    assert.equal(hellos, 2, "the relay must send one hello for its stream and one for its control connection");
+  } finally {
+    stdin.destroy();
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+    rmSync(parent, { recursive: true, force: true });
+  }
+});
+
+function reply(socket: net.Socket, id: number, result: Record<string, unknown>): void {
+  socket.write(`${JSON.stringify({ jsonrpc: "2.0", id, result })}\n`);
+}
+
+async function waitFor(condition: () => boolean): Promise<void> {
+  for (const deadline = Date.now() + 2_000; Date.now() < deadline; ) {
+    if (condition()) return;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  throw new Error("terminal relay did not attach");
+}


### PR DESCRIPTION
# English

## Summary

fix-plan batch 19 (task_e5e58cea9b4ce8b8c538023beb, parent task_6eba9c5d3a55735920aa4856f3 / task_2b8f79fa4412cb726a26f9bfc7): connection reuse family. `local-json-rpc-client.ts` gains a reusable, already-hello'd `JsonRpcLineClient` and reader openers (the `openRuntimeStatusReader` shape generalised); terminal-relay reuses one control client for resize, input, and exit-session lookup and closes it on a failed control request so the next call reconnects; the CLI reuses a reader while repo warming and preset-run status polling continue; `cli-runtime-wait.ts` reuses the task-dispatch reader across polling ticks and resets it through the existing reconnect handling. Connection/hello counts asserted by the targeted tests: terminal relay 4 → 2 connections for stream + resize + input + exit lookup; task-dispatch wait 3 → 1 hello across three polling reads; repo warming 3 → 2 hellos. Runtime-session waits already used `openRuntimeStatusReader` and were not changed. `status-reader.ts` is a new focused module so `client.ts` stays under the CLI source-file size gate. Production +236/-143 (net +93): the persistent reader/client lifecycle replaces per-tick socket construction.

## Architectural Justification

- One reusable client lifecycle (open once, reuse, close-on-failure-then-reconnect) replaces three copies of open-per-request; the added lines are that lifecycle plus its reconnect reset, with no pool, heartbeat, or retry layer. Net production is positive because the per-request path was one line at each site while the shared lifecycle has to own close and reset explicitly.

## What Changed

- `packages/daemon/src/client/local-json-rpc-client.ts`: reusable `JsonRpcLineClient` and reader openers.
- `packages/daemon/src/client/terminal-relay.ts`: one control client per relay; close-on-failure.
- `packages/cli/src/daemon/client.ts`, new `packages/cli/src/daemon/status-reader.ts`: reader reuse for warming and preset-run status polling.
- `packages/cli/src/cli-runtime-wait.ts`: reader reuse across ticks with reset via existing reconnect handling.
- Tests: connection/hello count coverage in `packages/cli/test/*` and `packages/daemon/test/terminal-relay.integration.test.ts`.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: +236/-143 (`packages/*/src`, tests excluded).
- Replaced in place: per-tick terminal control and task-dispatch socket construction (52 changed-line deletions).

## Machine-Readable Declarations

- Production-Delta: +236/-143

## Task And Scope

- Harness task: task_e5e58cea9b4ce8b8c538023beb, parent task_6eba9c5d3a55735920aa4856f3
- Branch: `codex/perf-w-d`
- Public scope: daemon local JSON-RPC client and terminal relay, CLI daemon client and wait paths
- Private planning/evidence updated: yes (`artifacts/report.md`)
- Out of scope: preset-run direct count test (reader lifecycle shared with `runCommandThroughDaemon`, count unverified), runtime-session waits (already reused)

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: not applicable
- Machine-check boundary: not applicable
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `31465b34f`
- Branch merge-base with `origin/main`: `31465b34f`
- Last `git fetch origin` time: 2026-09-13 UTC
- Sync method: branched from origin/main
- Public diff command: `git diff origin/main...codex/perf-w-d`
- Private evidence commit/path: task_e5e58cea9b4ce8b8c538023beb `artifacts/report.md`
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [x] `npm run typecheck` (worker and CEO)
- [ ] `npm run check`
- [ ] `npm test`
- [x] `npm run harness:check-import-boundaries` (via `run-manifest-gates --changed origin/main`, worker and CEO)
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts` (via `run-manifest-gates --changed origin/main`)
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Worker: `terminal-relay.integration.test.ts` on the isolated Ubuntu runner 1/1; `runtime-wait-reconnect.integration.test.ts` and `daemon-autostart-cli.test.ts` assert the hello counts; lint --quiet 0. CEO: fallback-boundaries 283/8/51 and write-road registry pass on the branch.

## Review Evidence

- CEO ground-truth: the three call sites use the same lifecycle shape; the close-on-failure path is the only new branch and is exercised by the terminal-relay test.
- Reviewer subagent: closeout review after merge
- Human review: pending
- Blocking findings: none open

## Residual Risk

- A reused reader that silently stalls (no error, no data) is reset by the existing reconnect handling only when a tick times out; this matches the previous per-tick behaviour.
- Preset-run status polling count is asserted only via the shared lifecycle, not a dedicated test.

## References

- Tasks: task_e5e58cea9b4ce8b8c538023beb; fix-plan batch 19; fix-plan-status-0912.md item 7

---

# 中文

## 概要

fix-plan 批 19（task_e5e58cea9b4ce8b8c538023beb，父 task_6eba9c5d3a55735920aa4856f3 / task_2b8f79fa4412cb726a26f9bfc7）：连接复用家族。`local-json-rpc-client.ts` 增加可复用、已完成 hello 的 `JsonRpcLineClient` 与 reader opener（把 `openRuntimeStatusReader` 的形状通用化）；terminal-relay 用一个 control client 承担 resize、input、exit-session 查询，control 请求失败即关闭以便下次重连；CLI 在 repo warming 与 preset-run 状态轮询期间复用一个 reader；`cli-runtime-wait.ts` 跨轮询 tick 复用 task-dispatch reader，经既有 reconnect 处理重置。定向测试断言的连接/hello 次数：terminal relay 的 stream+resize+input+exit 查询 4 → 2 连接；task-dispatch wait 三次轮询 3 → 1 hello；repo warming 3 → 2 hello。runtime-session 等待本就用 `openRuntimeStatusReader`，未改。`status-reader.ts` 是新拆的小模块，让 `client.ts` 留在 CLI 源文件大小门内。生产 +236/-143（净 +93）：持久 reader/client 生命周期替换每 tick 建连。

## 架构辩护

- 一套可复用的客户端生命周期（开一次、复用、失败即关再重连）替换三份每请求建连；新增行就是这套生命周期与其重连重置，没有连接池、心跳或重试层。生产净增为正是因为每请求路径在各位点只有一行，而共享生命周期必须显式拥有 close 与 reset。

## 改动内容

- `packages/daemon/src/client/local-json-rpc-client.ts`：可复用 `JsonRpcLineClient` 与 reader opener。
- `packages/daemon/src/client/terminal-relay.ts`：每 relay 一个 control client；失败即关。
- `packages/cli/src/daemon/client.ts`、新增 `packages/cli/src/daemon/status-reader.ts`：warming 与 preset-run 状态轮询的 reader 复用。
- `packages/cli/src/cli-runtime-wait.ts`：跨 tick 复用 reader，经既有 reconnect 重置。
- 测试：`packages/cli/test/*` 与 `packages/daemon/test/terminal-relay.integration.test.ts` 的连接/hello 计数覆盖。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 删除的门或 fixture：none
- 生产净行数：+236/-143（`packages/*/src` 不含测试）。
- 原地替换：每 tick 的 terminal control 与 task-dispatch socket 建连（52 行删除）。

## 机器可读声明

- Production-Delta: +236/-143

## 任务与范围

- Harness 任务：task_e5e58cea9b4ce8b8c538023beb，父任务 task_6eba9c5d3a55735920aa4856f3
- 分支：`codex/perf-w-d`
- 公开范围：daemon 本地 JSON-RPC client 与 terminal relay、CLI daemon client 与 wait 路径
- 私有计划/证据已更新：是（`artifacts/report.md`）
- 范围外：preset-run 的独立计数测试（与 `runCommandThroughDaemon` 共用生命周期，计数 unverified）、runtime-session 等待（已复用）

## 版本影响

- 版本：不变
- 发布影响：不发布

## 治理声明

- 触碰受保护面：否
- 受保护面范围：不适用
- 授权：不适用
- 机器检查边界：不适用
- Break-glass：否
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- 基线 `origin/main` SHA：`31465b34f`
- 分支与 `origin/main` 的 merge-base：`31465b34f`
- 最近一次 `git fetch origin`：2026-09-13 UTC
- 同步方式：从 origin/main 开分支
- 公开 diff 命令：`git diff origin/main...codex/perf-w-d`
- 私有证据路径：task_e5e58cea9b4ce8b8c538023beb 的 `artifacts/report.md`
- 评审证据路径：本 PR 的评审证据节
- GitHub Actions `rewrite-ci` run URL：本 PR 待跑
- worker：隔离 Ubuntu 上 `terminal-relay.integration.test.ts` 1/1；`runtime-wait-reconnect.integration.test.ts` 与 `daemon-autostart-cli.test.ts` 断言 hello 次数；lint --quiet 0。CEO：分支上 fallback-boundaries 283/8/51、write-road registry 通过。

## 评审证据

- CEO 事实核对：三个位点用同一生命周期形状；失败即关是唯一新分支，由 terminal-relay 测试覆盖。
- 评审子代理：合入后派收口评审
- 人工评审：待定
- 阻塞发现：无

## 残余风险

- 复用的 reader 若静默卡住（无错也无数据），只在 tick 超时时由既有 reconnect 处理重置；与此前每 tick 行为一致。
- preset-run 状态轮询的计数只经共享生命周期断言，没有独立测试。

## 参考

- 任务：task_e5e58cea9b4ce8b8c538023beb；fix-plan 批 19；fix-plan-status-0912.md 第 7 项
