### PR TITLE
chore(release): govern the cli and daemon npm package set

### DIFF
--- a/docs-release/release-posture.md
+++ b/docs-release/release-posture.md
@@ -140,27 +140,48 @@ This proves the renderer bundle compiles. The release build additionally runs
 
 ### GUI distribution and update boundary
 
-Harness Anything GUI 0.0.1 retains a manual, unsigned macOS arm64 packaging
-candidate, but `ha gui` from the source installation is the only supported
-launch entry. Direct DMG application launch, signing, notarization, other
-operating systems, and update feeds are future release tasks. Auto-update
-requires a later implementation packet with signing, an update feed, rollback,
-and security tests.
+The GUI is an Electron installer product, not a public npm startup package.
+`@harness-anything/gui` remains a private build workspace; its distributable
+artifacts are platform installers produced by electron-builder. Harness Anything
+GUI 0.0.1 retains a manual, unsigned macOS arm64 packaging candidate, but `ha
+gui` from the source installation is the only supported launch entry. Direct
+DMG application launch, signing, notarization, other operating systems, and
+update feeds are future release tasks. Auto-update requires a later
+implementation packet with signing, an update feed, rollback, and security
+tests.
 
 ### Runtime release boundary
 
 Current release boundaries are intentionally conservative:
 
-- The root product, GUI, and publishable `@harness-anything/cli` use version
-  `0.0.1`; the CLI is limited to npm publish dry-run in this task.
-- Internal workspace packages remain private and at version `0.0.0`.
+- The approved public npm set is `@harness-anything/cli` and
+  `@harness-anything/daemon`, both under the `@harness-anything` organization
+  owned by `lizeyu990625`. The daemon package is not public-ready until its
+  independent executable and package metadata land.
+- `@harness-anything/daemon` owns the resident server, service process, runtime
+  worker host, and the `harness-anything-daemon` bin. The CLI owns the `ha daemon
+  start --service` control UX and autostart orchestration, which must resolve and
+  spawn that installed daemon executable instead of hosting the daemon itself.
+- The root product, CLI, daemon release candidate, and Electron GUI use one
+  lockstep version. The current candidate is `0.0.1`; internal workspace
+  libraries remain private at `0.0.0`.
+- `@harness-anything/gui`, kernel, application, and adapter workspaces are not in
+  the approved npm publish set and remain private.
+- Every client must complete `protocol.hello` with the daemon's exact protocol
+  major and minor version before any other command. A mismatched edge CLI or GUI
+  is rejected with `incompatible_protocol_version`; an edge must not replace or
+  autostart over the center daemon to resolve a mismatch.
 - No real npm package release is claimed.
 - signed installers, notarized builds, auto-update, release feeds, and published
   artifacts are not shipped.
-- Desktop and daemon distribution policy is governed by this page.
 
 Future release tasks must extend the executable runtime/release readiness
-contract instead of relying on prose-only release notes.
+contract instead of relying on prose-only release notes. Before any real
+publication they must make the selected package public-ready, run package policy,
+runtime readiness, supply-chain checks, and package-specific pack/install smoke,
+then attach successful `npm publish --dry-run` evidence. Electron releases also
+require clean-install artifact validation plus the signing, notarization, and
+update requirements above.
 
 ## Supply chain and license gate
 
@@ -193,14 +214,16 @@ components.
 
 ### npm publish dry-run
 
-The only npm publish preflight command allowed in this phase is:
+The allowed npm publish preflight commands are:
 
 ```bash
 npm publish --dry-run --workspace @harness-anything/cli --access public
+npm publish --dry-run --workspace @harness-anything/daemon --access public
 ```
 
-This command is dry-run only. It may build and inspect the CLI package artifact,
-but it must not be replaced by a real `npm publish` command in this task phase.
+The daemon command becomes runnable only after its independent bin and public
+package metadata land. These commands are dry-run only; neither may be replaced
+by a real `npm publish` command in this task phase.
 
 ### OSV readiness
 

--- a/tools/check-package-policy.mjs
+++ b/tools/check-package-policy.mjs
@@ -11,6 +11,29 @@ const expectedPackages = new Map([
   ["packages/adapters/local/package.json", "@harness-anything/adapter-local"],
   ["packages/adapters/multica/package.json", "@harness-anything/adapter-multica"],
 ]);
+const publicReadyPackages = new Map([
+  [
+    "packages/cli/package.json",
+    {
+      version: "0.0.1",
+      repositoryDirectory: "packages/cli",
+      bins: new Map([
+        ["harness-anything", "dist/cli/src/index.js"],
+        ["ha", "dist/cli/src/index.js"],
+      ]),
+      required: true,
+    },
+  ],
+  [
+    "packages/daemon/package.json",
+    {
+      version: "0.0.1",
+      repositoryDirectory: "packages/daemon",
+      bins: new Map([["harness-anything-daemon", "dist/index.js"]]),
+      required: false,
+    },
+  ],
+]);
 
 const violations = [];
 
@@ -37,19 +60,21 @@ for (const [relativePath, expectedName] of expectedPackages.entries()) {
   const packageJson = readJson(relativePath);
   if (packageJson.name !== expectedName)
     record(`${relativePath} expected name ${expectedName}, got ${packageJson.name}`);
-  if (relativePath === "packages/cli/package.json") {
-    if (packageJson.private === true)
-      record(`${relativePath} must be public-ready for the CLI-only npm publish dry-run preflight`);
-    if (packageJson.version !== "0.0.1")
-      record(`${relativePath} must use version 0.0.1 for the npm publish dry-run preflight`);
+  const publicContract = publicReadyPackages.get(relativePath);
+  if (publicContract && (publicContract.required || packageJson.private !== true)) {
+    if (packageJson.private === true) record(`${relativePath} must be public-ready for npm publish dry-run preflight`);
+    if (packageJson.version !== publicContract.version)
+      record(`${relativePath} must use version ${publicContract.version} for npm publish dry-run preflight`);
     if (packageJson.publishConfig?.access !== "public")
-      record(`${relativePath} must define publishConfig.access public for the scoped CLI package`);
-    if (packageJson.repository?.directory !== "packages/cli")
-      record(`${relativePath} must declare repository.directory packages/cli`);
+      record(`${relativePath} must define publishConfig.access public for the scoped npm package`);
+    if (packageJson.repository?.directory !== publicContract.repositoryDirectory)
+      record(`${relativePath} must declare repository.directory ${publicContract.repositoryDirectory}`);
     if (packageJson.engines?.node !== ">=24") record(`${relativePath} must declare Node >=24 runtime support`);
+    for (const [name, target] of publicContract.bins)
+      if (packageJson.bin?.[name] !== target) record(`${relativePath} must declare bin ${name} as ${target}`);
   } else {
     if (packageJson.private !== true)
-      record(`${relativePath} must stay private until npm ownership is explicitly confirmed`);
+      record(`${relativePath} is not in the approved npm publish set and must stay private`);
     const expectedVersion = relativePath === "packages/gui/package.json" ? "0.0.1" : "0.0.0";
     if (packageJson.version !== expectedVersion) record(`${relativePath} must use version ${expectedVersion}`);
     if (packageJson.publishConfig)

--- a/tools/check-package-policy.test.mjs
+++ b/tools/check-package-policy.test.mjs
@@ -1,0 +1,132 @@
+// harness-test-tier: integration
+import assert from "node:assert/strict";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import test from "node:test";
+
+const scriptPath = path.resolve(import.meta.dirname, "check-package-policy.mjs");
+
+test("package policy accepts the approved CLI and daemon npm publish set", async () => {
+  await withFixtureRepo((root) => {
+    writeValidFixture(root);
+    makeDaemonPublicReady(root);
+
+    const result = runCheck(root);
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, /Package policy check passed/u);
+  });
+});
+
+test("package policy rejects GUI as an npm package", async () => {
+  await withFixtureRepo((root) => {
+    writeValidFixture(root);
+    writeJson(root, "packages/gui/package.json", {
+      name: "@harness-anything/gui",
+      version: "0.0.1",
+      publishConfig: { access: "public" },
+    });
+
+    const result = runCheck(root);
+
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /not in the approved npm publish set/u);
+  });
+});
+
+test("package policy rejects a public daemon without its independent bin", async () => {
+  await withFixtureRepo((root) => {
+    writeValidFixture(root);
+    makeDaemonPublicReady(root);
+    const daemon = JSON.parse(readFileSync(path.join(root, "packages/daemon/package.json"), "utf8"));
+    delete daemon.bin;
+    writeJson(root, "packages/daemon/package.json", daemon);
+
+    const result = runCheck(root);
+
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /must declare bin harness-anything-daemon/u);
+  });
+});
+
+test("package policy rejects an internal library made public", async () => {
+  await withFixtureRepo((root) => {
+    writeValidFixture(root);
+    writeJson(root, "packages/kernel/package.json", {
+      name: "@harness-anything/kernel",
+      version: "0.0.0",
+    });
+
+    const result = runCheck(root);
+
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /not in the approved npm publish set/u);
+  });
+});
+
+function runCheck(root) {
+  return spawnSync(process.execPath, [scriptPath], { cwd: root, encoding: "utf8" });
+}
+
+async function withFixtureRepo(fn) {
+  const root = await mkdtemp(path.join(tmpdir(), "ha-package-policy-"));
+  try {
+    await fn(root);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+}
+
+function writeValidFixture(root) {
+  writeJson(root, "package.json", {
+    name: "harness-anything",
+    version: "0.0.1",
+    private: true,
+    workspaces: ["packages/*", "packages/adapters/*"],
+  });
+  const packages = new Map([
+    ["packages/kernel/package.json", "@harness-anything/kernel"],
+    ["packages/application/package.json", "@harness-anything/application"],
+    ["packages/daemon/package.json", "@harness-anything/daemon"],
+    ["packages/gui/package.json", "@harness-anything/gui"],
+    ["packages/adapters/local/package.json", "@harness-anything/adapter-local"],
+    ["packages/adapters/multica/package.json", "@harness-anything/adapter-multica"],
+  ]);
+  for (const [packagePath, name] of packages)
+    writeJson(root, packagePath, {
+      name,
+      version: packagePath === "packages/gui/package.json" ? "0.0.1" : "0.0.0",
+      private: true,
+    });
+  writeJson(root, "packages/cli/package.json", {
+    name: "@harness-anything/cli",
+    version: "0.0.1",
+    publishConfig: { access: "public" },
+    repository: { directory: "packages/cli" },
+    engines: { node: ">=24" },
+    bin: {
+      "harness-anything": "dist/cli/src/index.js",
+      ha: "dist/cli/src/index.js",
+    },
+  });
+}
+
+function makeDaemonPublicReady(root) {
+  writeJson(root, "packages/daemon/package.json", {
+    name: "@harness-anything/daemon",
+    version: "0.0.1",
+    publishConfig: { access: "public" },
+    repository: { directory: "packages/daemon" },
+    engines: { node: ">=24" },
+    bin: { "harness-anything-daemon": "dist/index.js" },
+  });
+}
+
+function writeJson(root, relativePath, value) {
+  const absolute = path.join(root, relativePath);
+  mkdirSync(path.dirname(absolute), { recursive: true });
+  writeFileSync(absolute, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+}


### PR DESCRIPTION
# English

## Summary

Release governance for the CLI/daemon/GUI product set (task_774495a5ee90e93ea146b8b7c9; decision dec_4061D4157B1FEF9925E38F2358, proposed with four evidenced claims, awaiting an independent arbiter). The repository owner ruled "governance first, then split" for the CLI surface plan (task_5bab54e6e88a9d40e8b241a411, C3 task_32df25c474582985e7595eabdf). This PR encodes the ruling where the release boundary is machine-checked: `tools/check-package-policy.mjs` replaces the hard-coded CLI-only branch with a public-ready package table covering `@harness-anything/cli` (required public-ready, bins `ha` and `harness-anything`) and `@harness-anything/daemon` (allowed public-ready once it is no longer private, bin `harness-anything-daemon`), and every other workspace must stay private and outside the publish set. `docs-release/release-posture.md` states the same contract: the approved npm set is CLI + daemon under the `@harness-anything` org (owner `lizeyu990625`), GUI ships as Electron installers only, versions are lockstep (candidate `0.0.1`, internal libraries `0.0.0`), and every connection must complete `protocol.hello` with an exact major/minor match or be rejected with `incompatible_protocol_version`. No real `npm publish`, tag, signing or installer publication is authorized by this PR. The private standard `harness/governance/standards/ci-cd-standard.md` was updated in the same sense (ledger commit 5644952b1e).

## Architectural Justification

- One table replaces a special-cased `if` for one package; the daemon row is the only new fact and it becomes required only when the daemon package stops being private, so the gate stays green today and starts enforcing the moment the split lands.

## What Changed

- `tools/check-package-policy.mjs`: `publicReadyPackages` table (version, repository.directory, bins, required); non-listed packages must stay private.
- `tools/check-package-policy.test.mjs` (new, +132): fixtures for CLI required, daemon optional-then-required, non-listed package must stay private.
- `docs-release/release-posture.md`: GUI distribution boundary, runtime release boundary, dry-run commands for both candidates.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: +34/-9 (tools; `packages/*/src` +0/-0). Tests +132.

## Machine-Readable Declarations

- None.

## Task And Scope

- Harness task: task_774495a5ee90e93ea146b8b7c9 (release governance, precondition of C3 task_32df25c474582985e7595eabdf)
- Branch: `codex/release-gov`
- Public scope: package-policy gate + release posture document
- Private planning/evidence updated: yes (`artifacts/report.md`, `artifacts/decision-body.md`, `artifacts/decision-packet.json`, five facts F-402C65FF/F-2CC4CC71/F-39FE2816/F-0FD2825C/F-C3E8F847)
- Out of scope: the daemon package split itself (C3), any real publish, GUI signing/notarization

## Version Impact

- Version: no version change
- Publish impact: no publish (dry-run policy only)

## Governance Declaration

- Protected surface touched: yes — `tools/check-package-policy.mjs` (release gate referenced by `tools/gate-manifest.json`)
- Protected surface scope: the CLI-only special case becomes a two-row public-ready table; the daemon row is not required until the package is public; every other package remains locked private at `0.0.0` (GUI `0.0.1`)
- Authority: repository owner ruling on 2026-09-12 for the CLI surface plan ("governance first, then split"), recorded in task_774495a5ee90e93ea146b8b7c9; decision dec_4061D4157B1FEF9925E38F2358 proposed (in_effect transition requires an arbiter other than the proposer and is pending)
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: task_32df25c474582985e7595eabdf (C3) derives from the decision

## Verification

- Base `origin/main` SHA: `31465b34f`
- Branch merge-base with `origin/main`: `31465b34f`
- Last `git fetch origin` time: 2026-09-12 UTC
- Sync method: branched from origin/main
- Public diff command: `git diff origin/main...codex/release-gov`
- Private evidence commit/path: task_774495a5ee90e93ea146b8b7c9 `artifacts/report.md`
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [ ] `npm run typecheck`
- [ ] `npm run check`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [x] `npm run harness:check-package-policy` (worker)
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Worker: isolated Ubuntu run of `tools/check-package-policy.test.mjs` 4/4; changed manifest gates, lint, gate tests 198/198 passed.

## Review Evidence

- CEO ground-truth: read the gate diff, the posture diff and the decision body; proposed the decision and related its four claims to the five recorded facts; committed the private standard through the repository prose channel.
- Reviewer subagent: pending (closeout review after merge)
- Human review: pending — the decision's in_effect transition is the owner's or an independent arbiter's call
- Blocking findings: none open

## Residual Risk

- The daemon row is dormant until `packages/daemon/package.json` drops `private`; a split PR that forgets the bin or repository.directory will be caught then, not now.

## References

- Task: task_774495a5ee90e93ea146b8b7c9; decision dec_4061D4157B1FEF9925E38F2358; CLI surface plan task_5bab54e6e88a9d40e8b241a411

---

# 中文

## 概要

CLI/daemon/GUI 产品集的发布治理（task_774495a5ee90e93ea146b8b7c9；决策 dec_4061D4157B1FEF9925E38F2358 已提案、四条 claim 均有事实边、待独立仲裁人生效）。仓库所有者对 CLI 面计划（task_5bab54e6e88a9d40e8b241a411，C3 为 task_32df25c474582985e7595eabdf）裁决「先治理再拆」。本 PR 把裁决落在发布边界的机器检查处：`tools/check-package-policy.mjs` 用一张 public-ready 包表替换写死的 CLI-only 分支，覆盖 `@harness-anything/cli`（必须 public-ready，bin `ha` 与 `harness-anything`）和 `@harness-anything/daemon`（去掉 private 后才要求 public-ready，bin `harness-anything-daemon`），其余 workspace 一律保持 private、不进发布集。`docs-release/release-posture.md` 陈述同一契约：批准的 npm 集合是 CLI + daemon，归 `@harness-anything` org（owner `lizeyu990625`），GUI 只出 Electron 安装产物，版本 lockstep（候选 `0.0.1`，内部库 `0.0.0`），每条连接必须先完成 `protocol.hello` 且 major/minor 精确匹配，否则以 `incompatible_protocol_version` 拒绝。本 PR 不授权任何真实 `npm publish`、tag、签名或安装包发布。私有标准 `harness/governance/standards/ci-cd-standard.md` 已同义更新（台账提交 5644952b1e）。

## 架构辩护

- 一张表替换单包特判的 `if`；daemon 行是唯一新增事实，且只在 daemon 包不再 private 时才生效，所以门今天照样绿、拆包落地那一刻开始执法。

## 改动内容

- `tools/check-package-policy.mjs`：`publicReadyPackages` 表（version、repository.directory、bins、required）；表外包必须保持 private。
- `tools/check-package-policy.test.mjs`（新增，+132）：CLI 必须 public-ready、daemon 先可选后必须、表外包必须 private 三组 fixture。
- `docs-release/release-posture.md`：GUI 分发边界、runtime 发布边界、两个候选包的 dry-run 命令。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 删除的门或 fixture：none
- 生产净行数：+34/-9（tools；`packages/*/src` +0/-0）。测试 +132。

## 机器可读声明

- 无。

## 任务与范围

- Harness 任务：task_774495a5ee90e93ea146b8b7c9（发布治理，C3 task_32df25c474582985e7595eabdf 的前置）
- 分支：`codex/release-gov`
- 公开范围：package-policy 门 + 发布姿态文档
- 私有计划/证据已更新：是（`artifacts/report.md`、`artifacts/decision-body.md`、`artifacts/decision-packet.json`，五条事实 F-402C65FF/F-2CC4CC71/F-39FE2816/F-0FD2825C/F-C3E8F847）
- 范围外：daemon 拆包本身（C3）、任何真实发布、GUI 签名/公证

## 版本影响

- 版本：不变
- 发布影响：不发布（仅 dry-run 政策）

## 治理声明

- 触碰受保护面：是——`tools/check-package-policy.mjs`（`tools/gate-manifest.json` 引用的发布门）
- 受保护面范围：CLI-only 特判变为两行 public-ready 表；daemon 行在包公开前不生效；其余包仍锁 private、`0.0.0`（GUI `0.0.1`）
- 授权：仓库所有者 2026-09-12 对 CLI 面计划的裁决（「先治理再拆」），记录在 task_774495a5ee90e93ea146b8b7c9；决策 dec_4061D4157B1FEF9925E38F2358 已提案（in_effect 需提案人以外的仲裁人，待办）
- 机器检查边界：本 PR 只断言声明存在；是否属实、是否充分由评审判断。
- Break-glass：否
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：task_32df25c474582985e7595eabdf（C3）由该决策派生

## 验证

- 基线 `origin/main` SHA：`31465b34f`
- 分支与 `origin/main` 的 merge-base：`31465b34f`
- 最近一次 `git fetch origin`：2026-09-12 UTC
- 同步方式：从 origin/main 开分支
- 公开 diff 命令：`git diff origin/main...codex/release-gov`
- 私有证据路径：task_774495a5ee90e93ea146b8b7c9 的 `artifacts/report.md`
- 评审证据路径：本 PR 的评审证据节
- GitHub Actions `rewrite-ci` run URL：本 PR 待跑
- worker：`tools/check-package-policy.test.mjs` 在隔离 Ubuntu 4/4；changed manifest gates、lint、gate tests 198/198 通过。

## 评审证据

- CEO 事实核对：读过门 diff、姿态文档 diff 与决策正文；提案决策并把四条 claim 关联到五条已记录事实；经 repository prose channel 提交私有标准。
- 评审子代理：待定（合入后派收口评审）
- 人工评审：待定——决策的 in_effect 由所有者或独立仲裁人裁定
- 阻塞发现：无

## 残余风险

- daemon 行在 `packages/daemon/package.json` 去掉 `private` 前是休眠的；拆包 PR 若漏了 bin 或 repository.directory，会在那时而不是现在被拦。

## 参考

- 任务：task_774495a5ee90e93ea146b8b7c9；决策 dec_4061D4157B1FEF9925E38F2358；CLI 面计划 task_5bab54e6e88a9d40e8b241a411
