### PR TITLE
fix: retire the task closeout guidance and the execution selector from normal completion

### DIFF
--- a/packages/cli/test/cli-lifecycle-user-journey-stress.fixture.ts
+++ b/packages/cli/test/cli-lifecycle-user-journey-stress.fixture.ts
@@ -158,11 +158,7 @@ async function runChain(
     ],
     reviewerEnvironment,
   );
-  await expectApplied(
-    fixture,
-    ["task", "complete", taskId, "--execution-id", executionId, "--consent"],
-    workerEnvironment,
-  );
+  await expectApplied(fixture, ["task", "complete", taskId, "--consent"], workerEnvironment);
   const final = await expectApplied(fixture, ["task", "show", taskId], workerEnvironment),
     finalEvidence = JSON.parse(String(final.evidence)) as { readonly task?: { readonly status?: string } };
   assert.equal(finalEvidence.task?.status, "done");

--- a/packages/cli/test/daemon-autostart-cli-scenario-2.test.ts
+++ b/packages/cli/test/daemon-autostart-cli-scenario-2.test.ts
@@ -429,10 +429,7 @@ test("semantic sources and agent execution cross the daemon before transport-bou
       ]).outcome,
       "applied",
     );
-    assert.equal(
-      run(fixture.root, fixture.userRoot, ["task", "complete", taskId, "--execution-id", executionId]).outcome,
-      "applied",
-    );
+    assert.equal(run(fixture.root, fixture.userRoot, ["task", "complete", taskId]).outcome, "applied");
 
     const shown = run(fixture.root, fixture.userRoot, ["task", "show", taskId]),
       snapshot = JSON.parse(String(shown.evidence)) as {

--- a/packages/cli/test/release-cli-acceptance-scenario-1.integration.test.ts
+++ b/packages/cli/test/release-cli-acceptance-scenario-1.integration.test.ts
@@ -128,7 +128,7 @@ test("release acceptance: attributed lifecycle chain create→start→fact→sub
       ["task", "review-consent", taskId, "--execution-id", executionId, "--review-id", "review-release-acc-approved"],
       worker,
     );
-    const completed = run(root, userRoot, ["task", "complete", taskId, "--execution-id", executionId], worker);
+    const completed = run(root, userRoot, ["task", "complete", taskId], worker);
     assert.equal(completed.outcome, "applied", JSON.stringify(completed));
     const shown = run(root, userRoot, ["task", "show", taskId]),
       evidence = JSON.parse(String(shown.evidence)) as {

--- a/packages/daemon/src/repo-cell-packets.ts
+++ b/packages/daemon/src/repo-cell-packets.ts
@@ -227,11 +227,9 @@ export function lifecycleReceipt(
                     ].join("")
                 : !selected
                   ? `ha task complete ${event.taskId} --consent`
-                  : missingGate === "ci"
-                    ? `ha task complete ${event.taskId} --execution-id ${executionId}`
-                    : missingGate === "code-doc-reconciliation"
-                      ? `ha task closeout ${event.taskId} --from-file <packet.json>`
-                      : `ha task complete ${event.taskId} --execution-id ${executionId}`,
+                  : missingGate === "code-doc-reconciliation"
+                    ? `ha task code-doc reconcile ${event.taskId} --path <repo-relative-path>...`
+                    : `ha task complete ${event.taskId}`,
     next = nextCommand
       ? [
           {

--- a/packages/kernel/src/domain/task-lifecycle-publication.ts
+++ b/packages/kernel/src/domain/task-lifecycle-publication.ts
@@ -293,15 +293,13 @@ function renderIndex(event: TaskEventV1, snapshot: TaskLifecycleSnapshot, path: 
           ? `Run \`ha task complete ${task.taskId}\`.`
           : task.status === "in_review" && !selected
             ? [`Run \`ha task complete ${task.taskId} --consent\`.`].join("")
-            : missingGate === "ci"
-              ? `Run \`ha task complete ${task.taskId} --execution-id <id>\`.`
-              : missingGate === "code-doc-reconciliation"
-                ? `Run \`ha task closeout ${task.taskId} --from-file <packet.json>\`.`
-                : task.status === "done"
-                  ? "Task complete."
-                  : task.status === "cancelled"
-                    ? "Task cancelled; create follow-up work with `ha task supersede`."
-                    : `Run \`ha task complete ${task.taskId} --execution-id <id>\`.`,
+            : missingGate === "code-doc-reconciliation"
+              ? `Run \`ha task code-doc reconcile ${task.taskId} --path <repo-relative-path>...\`.`
+              : task.status === "done"
+                ? "Task complete."
+                : task.status === "cancelled"
+                  ? "Task cancelled; create follow-up work with `ha task supersede`."
+                  : `Run \`ha task complete ${task.taskId}\`.`,
     gates = task.completionGateIds.length
       ? task.completionGateIds.map((gateId) => `- ${gateId}: ${gateStatus(gateId) ? "pass" : "blocked"}`).join("\n")
       : "- none",


### PR DESCRIPTION
# English

## Summary

One-path closeout slice 4b (task_7ccb8f35ea42c3d5c00dbb45f5, root task_4f7965fc895253bf70a4020f42, ruling dec_13FF6AEF3598AF34DC8F4A0558). The closeout review of slice 4 (main 3da872ded) found that two generated-guidance sites still taught the retired paths: the kernel completion guidance in `task-lifecycle-publication.ts` and the daemon closeout packet in `repo-cell-packets.ts` both told the user to run `ha task closeout <id> --from-file <packet.json>` when code-doc reconciliation was missing, and both named `ha task complete <id> --execution-id <id>` as the ordinary completion command. Missing reconciliation now points at `ha task code-doc reconcile <id> --path <repo-relative-path>...`, ordinary completion is `ha task complete <id>` (the `ci` branch collapsed into the default because both produced the same command), and the three single-execution CLI tests stop passing `--execution-id`; the two multi-execution cases (user-journey stress, release acceptance second execution) keep the selector, which is what it is for. Production +10/-14.

## Architectural Justification

- Deletion only: two guidance strings and one redundant branch removed; no new path.

## What Changed

- `packages/kernel/src/domain/task-lifecycle-publication.ts`: guidance strings; `missingGate === "ci"` branch removed.
- `packages/daemon/src/repo-cell-packets.ts`: next-command strings.
- `packages/cli/test/{cli-lifecycle-user-journey-stress.fixture,daemon-autostart-cli-scenario-2,release-cli-acceptance-scenario-1.integration}.test.ts`: ordinary completion without the selector.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Removed strings only (the generated `ha task closeout` guidance in two files); no module or gate deleted.
- Production net lines: +10/-14 (`packages/*/src`, tests excluded).

## Machine-Readable Declarations

- Production-Delta: +10/-14

## Task And Scope

- Harness task: task_7ccb8f35ea42c3d5c00dbb45f5 (slice 4, Round 2 / 4b), root task_4f7965fc895253bf70a4020f42
- Branch: `codex/onepath-4b`
- Public scope: two guidance sites + three test call sites
- Private planning/evidence updated: yes (task plan Round 2)
- Out of scope: CLI parser changes, review/consent commands

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: not applicable
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `95f13903a`
- Branch merge-base with `origin/main`: `95f13903a`
- Last `git fetch origin` time: 2026-09-12 UTC
- Sync method: branched from origin/main
- Public diff command: `git diff origin/main...codex/onepath-4b`
- Private evidence commit/path: task_7ccb8f35ea42c3d5c00dbb45f5 `task_plan.md` Round 2
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [x] `npm run typecheck` (`npx tsc -b`)
- [ ] `npm run check`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts` (via `run-manifest-gates --changed origin/main`, 7 commands passed)
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Local: `task-completion-next.test.ts` 3/3, `review-consent-digest-fixture.test.ts` 1/1, `fleet-transport.contract.test.ts` 2/2, `hitrate-task-lifecycle.integration.test.ts` 1/1. Isolated Ubuntu: `daemon-autostart-cli-scenario-2.test.ts` 8/8, `cli-lifecycle-user-journey-stress-scenario-1.integration.test.ts` 6/6, `release-cli-acceptance-scenario-1.integration.test.ts` exit 0.

## Review Evidence

- CEO ground-truth: `rg "task closeout" packages/*/src` now returns only prose in `repo-cell-task-progress.ts` (the noun, not the command); `rg -- '"complete", taskId, "--execution-id"' packages/cli/test` returns only the two second-execution cases.
- Reviewer subagent: closeout review after merge (slice 4 Round 2)
- Human review: pending
- Blocking findings: none open

## Residual Risk

- A task whose current execution is ambiguous still needs `--execution-id`; the guidance no longer mentions it, which matches the ruling that it is a repair selector, not the normal path.

## References

- Task: task_7ccb8f35ea42c3d5c00dbb45f5; slice 4 PR #2510; ruling dec_13FF6AEF3598AF34DC8F4A0558

---

# 中文

## 概要

一条路收口切片 4b（task_7ccb8f35ea42c3d5c00dbb45f5，根任务 task_4f7965fc895253bf70a4020f42，裁决 dec_13FF6AEF3598AF34DC8F4A0558）。切片 4（main 3da872ded）的收口评审发现两处生成式指引仍在教已退役的路径：`task-lifecycle-publication.ts` 的 kernel 完成指引与 `repo-cell-packets.ts` 的 daemon closeout packet 在缺 code-doc reconciliation 时都让用户跑 `ha task closeout <id> --from-file <packet.json>`，并都把 `ha task complete <id> --execution-id <id>` 当普通完成命令。现在缺 reconciliation 指向 `ha task code-doc reconcile <id> --path <repo-relative-path>...`，普通完成是 `ha task complete <id>`（`ci` 分支与默认分支产出相同命令，已合并），三处单 execution 的 CLI 测试不再传 `--execution-id`；两处多 execution 用例（user-journey stress、release acceptance 的第二个 execution）保留选择器，那正是它的用途。生产 +10/-14。

## 架构辩护

- 纯删除：去掉两条指引字符串与一个冗余分支；不新增路径。

## 改动内容

- `packages/kernel/src/domain/task-lifecycle-publication.ts`：指引字符串；删 `missingGate === "ci"` 分支。
- `packages/daemon/src/repo-cell-packets.ts`：next-command 字符串。
- `packages/cli/test/{cli-lifecycle-user-journey-stress.fixture,daemon-autostart-cli-scenario-2,release-cli-acceptance-scenario-1.integration}.test.ts`：普通完成不带选择器。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 删除的门或 fixture：none
- 只删字符串（两个文件里生成的 `ha task closeout` 指引）；不删模块或门。
- 生产净行数：+10/-14（`packages/*/src` 不含测试）。

## 机器可读声明

- Production-Delta: +10/-14

## 任务与范围

- Harness 任务：task_7ccb8f35ea42c3d5c00dbb45f5（切片 4 第二轮 / 4b），根任务 task_4f7965fc895253bf70a4020f42
- 分支：`codex/onepath-4b`
- 公开范围：两处指引 + 三处测试调用点
- 私有计划/证据已更新：是（task plan 第二轮）
- 范围外：CLI 解析器改动、review/consent 命令

## 版本影响

- 版本：不变
- 发布影响：不发布

## 治理声明

- 触碰受保护面：否
- 受保护面范围：不适用
- 授权：不适用
- 机器检查边界：本 PR 只断言声明存在；是否属实、是否充分由评审判断。
- Break-glass：否
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- 基线 `origin/main` SHA：`95f13903a`
- 分支与 `origin/main` 的 merge-base：`95f13903a`
- 最近一次 `git fetch origin`：2026-09-12 UTC
- 同步方式：从 origin/main 开分支
- 公开 diff 命令：`git diff origin/main...codex/onepath-4b`
- 私有证据路径：task_7ccb8f35ea42c3d5c00dbb45f5 的 `task_plan.md` 第二轮
- 评审证据路径：本 PR 的评审证据节
- GitHub Actions `rewrite-ci` run URL：本 PR 待跑
- 本地：`task-completion-next.test.ts` 3/3、`review-consent-digest-fixture.test.ts` 1/1、`fleet-transport.contract.test.ts` 2/2、`hitrate-task-lifecycle.integration.test.ts` 1/1。隔离 Ubuntu：`daemon-autostart-cli-scenario-2.test.ts` 8/8、`cli-lifecycle-user-journey-stress-scenario-1.integration.test.ts` 6/6、`release-cli-acceptance-scenario-1.integration.test.ts` exit 0。

## 评审证据

- CEO 事实核对：`rg "task closeout" packages/*/src` 只剩 `repo-cell-task-progress.ts` 里的名词用法（不是命令）；`rg -- '"complete", taskId, "--execution-id"' packages/cli/test` 只剩两处第二个 execution 的用例。
- 评审子代理：合入后派收口评审（切片 4 第二轮）
- 人工评审：待定
- 阻塞发现：无

## 残余风险

- 当前 execution 有歧义的任务仍需 `--execution-id`；指引不再提它，与「它是修复选择器、不是正常路径」的裁决一致。

## 参考

- 任务：task_7ccb8f35ea42c3d5c00dbb45f5；切片 4 PR #2510；裁决 dec_13FF6AEF3598AF34DC8F4A0558
