### PR TITLE
perf(preset): collapse duplicate asset reads, decodes, and hashes per command

### DIFF
--- a/packages/preset/src/preset-bootstrap.ts
+++ b/packages/preset/src/preset-bootstrap.ts
@@ -63,6 +63,7 @@ export interface CompiledTaskDocument {
   readonly relativePath: string;
   readonly path: string;
   readonly body: string;
+  readonly contentSha256: string;
   readonly mediaType: "application/json" | "text/markdown" | "text/plain" | OpaqueTextualMediaType;
   readonly owner: TaskDocumentOwner;
   readonly requiredAnchors: readonly string[];
@@ -126,18 +127,20 @@ export function compileTaskPackage(input: CompileTaskPackageInput): CompiledTask
       surfaces: [...(input.surfaces ?? [])],
       fromLegacyId: input.fromLegacyId ?? null,
     },
-    prose = resolved.documents.map(
-      (document): CompiledTaskDocument => ({
+    prose = resolved.documents.map((document): CompiledTaskDocument => {
+      const body = document.body.replaceAll("{{title}}", input.title);
+      return {
         slot: document.slot,
         relativePath: document.path,
         path: `${packagePath}/${document.path}`,
-        body: document.body.replaceAll("{{title}}", input.title),
+        body,
+        contentSha256: sha256Text(body),
         mediaType: document.mediaType,
         owner: document.owner,
         requiredAnchors: document.requiredAnchors,
         templateRef: document.templateRef,
-      }),
-    ),
+      };
+    }),
     bySlot = new Map(prose.map((document) => [document.slot, document]));
   const createAction = getExecutableEntityAction("task-create");
   if (!createAction) throw bootstrapFailure("invalid_scaffold", "task.create descriptor is missing.");
@@ -153,6 +156,7 @@ export function compileTaskPackage(input: CompileTaskPackageInput): CompiledTask
       relativePath: `artifacts/scripts/${script.name}`,
       path: `${packagePath}/artifacts/scripts/${script.name}`,
       body: script.body,
+      contentSha256: sha256Text(script.body),
       mediaType: classifyTextualArtifactPath(`artifacts/scripts/${script.name}`)?.mediaType ?? "text/plain",
       owner: "machine",
       requiredAnchors: [],
@@ -241,6 +245,7 @@ export function compileTaskPackage(input: CompileTaskPackageInput): CompiledTask
       relativePath,
       path: `${packagePath}/${relativePath}`,
       body,
+      contentSha256: sha256Text(body),
       mediaType: relativePath.endsWith(".json") ? "application/json" : "text/markdown",
       owner: "machine",
       requiredAnchors: [],
@@ -260,7 +265,7 @@ export function compileTaskBootstrap(input: CompileTaskBootstrapInput): Compiled
     },
     initialDocumentClaims = compiled.documents.map((document) => ({
       path: document.path,
-      sha256: sha256Text(document.body),
+      sha256: document.contentSha256,
       size: Buffer.byteLength(document.body),
       mediaType: document.mediaType,
       owner: document.owner,
@@ -375,7 +380,7 @@ export function compilePresetSnapshotUpgrade(input: CompilePresetSnapshotUpgrade
     contractDocument = compiled.documents.find(({ relativePath }) => relativePath === "task-contract.json")!,
     taskContractClaim = {
       path: contractDocument.path,
-      sha256: sha256Text(contractDocument.body),
+      sha256: contractDocument.contentSha256,
       size: Buffer.byteLength(contractDocument.body),
       mediaType: "application/json" as const,
       owner: "machine" as const,
@@ -426,7 +431,7 @@ function descriptor(document: CompiledTaskDocument) {
     materializeAs: document.relativePath,
     requiredAnchors: document.requiredAnchors,
     templateRef: document.templateRef,
-    contentSha256: sha256Text(document.body),
+    contentSha256: document.contentSha256,
   };
 }
 function descriptorStub(slot: string, path: string, owner: TaskDocumentOwner) {

--- a/packages/preset/src/preset-extension-model.ts
+++ b/packages/preset/src/preset-extension-model.ts
@@ -257,7 +257,8 @@ export function validateVerticalDefinition(vertical: VerticalDefinition): Extens
 }
 
 export function planTemplateMaterialization(request: MaterializationRequest): MaterializationResult {
-  const catalogValidation = validateTemplateCatalog(request.catalog, { resolveBody: request.resolveBody });
+  const resolveBody = memoizeBodyResolver(request.resolveBody);
+  const catalogValidation = validateTemplateCatalog(request.catalog, { resolveBody });
   const issues: ExtensionValidationIssue[] = [...catalogValidation.issues];
   const documents: MaterializedTemplatePlan[] = [];
 
@@ -295,7 +296,7 @@ export function planTemplateMaterialization(request: MaterializationRequest): Ma
     }
     const documentIndex = request.catalog.documents.indexOf(document);
     const localeIndex = document.locales.indexOf(selected);
-    const body = request.resolveBody?.({ document, locale: selected, documentIndex, localeIndex });
+    const body = resolveBody?.({ document, locale: selected, documentIndex, localeIndex });
     if (body === undefined) {
       issues.push(
         extensionIssue(
@@ -320,6 +321,16 @@ export function planTemplateMaterialization(request: MaterializationRequest): Ma
   }
 
   return { ok: issues.length === 0, documents, issues };
+}
+
+function memoizeBodyResolver(resolver: TemplateBodyResolver | undefined): TemplateBodyResolver | undefined {
+  if (!resolver) return undefined;
+  const cache = new Map<string, string | undefined>();
+  return (input) => {
+    const cacheKey = `${input.documentIndex}\0${input.localeIndex}`;
+    if (!cache.has(cacheKey)) cache.set(cacheKey, resolver(input));
+    return cache.get(cacheKey);
+  };
 }
 
 function formatTemplateRef(id: string, version: string): string {

--- a/packages/preset/src/preset-installation.ts
+++ b/packages/preset/src/preset-installation.ts
@@ -1,5 +1,6 @@
 import { decodePresetPackageV3, parsePresetJson } from "./preset-package.ts";
 import { defaultBundled, isPresetResolutionRecord, presetFailure } from "./preset-resolver-common.ts";
+import type { DecodedPresetPackageV3 } from "./preset-resolver-types.ts";
 import { consumeKnownError } from "./preset.contract.ts";
 import { randomUUID } from "node:crypto";
 import {
@@ -28,14 +29,16 @@ export function seedPresetPackages(input: {
           .map((entry) => path.join(root, entry.name))
           .sort()
       : [];
-  sources.forEach(decodePresetPackageV3);
-  const packages = sources.map((source) =>
-    installPresetPackage({
-      source,
-      userRoot: input.userRoot,
-      dryRun: input.dryRun,
-    }),
-  );
+  const packages = sources
+    .map((source) => decodePresetPackageV3(source))
+    .map((decoded) =>
+      installPresetPackage({
+        source: decoded.root,
+        userRoot: input.userRoot,
+        dryRun: input.dryRun,
+        decoded,
+      }),
+    );
   return {
     schema: "preset-seed-report/v1" as const,
     mode: input.dryRun ? ("dry-run" as const) : ("apply" as const),
@@ -49,8 +52,9 @@ export function installPresetPackage(input: {
   readonly userRoot: string;
   readonly dryRun?: boolean;
   readonly killpoint?: (point: "after-object" | "after-pointer") => void;
+  readonly decoded?: DecodedPresetPackageV3;
 }) {
-  const decoded = decodePresetPackageV3(input.source),
+  const decoded = input.decoded ?? decodePresetPackageV3(input.source),
     userRoot = path.resolve(input.userRoot),
     objects = path.join(userRoot, "preset-objects"),
     active = path.join(userRoot, "active"),

--- a/packages/preset/src/preset-materialization.ts
+++ b/packages/preset/src/preset-materialization.ts
@@ -123,7 +123,8 @@ export function safeTemplatePath(root: string, value: string, ref: string): stri
 }
 
 export function requiredRegularFile(target: string, code: string): string {
-  if (!existsSync(target) || !lstatSync(target).isFile() || lstatSync(target).isSymbolicLink())
+  const stat = existsSync(target) ? lstatSync(target) : undefined;
+  if (!stat?.isFile() || stat.isSymbolicLink())
     throw presetFailure(code, `Required regular file ${target} is unavailable.`);
   return readFileSync(target, "utf8");
 }

--- a/packages/preset/src/preset-package.ts
+++ b/packages/preset/src/preset-package.ts
@@ -16,8 +16,9 @@ export function decodePackage(
   root: string,
   requireLocalCatalog = false,
   trustedDigest?: string,
+  scannedFiles?: Map<string, string>,
 ): DecodedPresetPackageV3 {
-  const files = scan(root),
+  const files = scannedFiles ?? scan(root),
     manifestBody = file(files, "preset.json", "missing_manifest"),
     presetBody = file(files, "PRESET.md", "missing_preset_document"),
     manifest = parsePresetManifestV3(parsePresetJson(manifestBody, "invalid_manifest")),
@@ -47,6 +48,7 @@ export function decodePackage(
     manifest,
     document,
     root,
+    files,
     packageDigest,
     manifestSha256: resolverContentHash(canonicalPresetBytes(manifest)),
   } as DecodedPresetPackageV3;
@@ -70,25 +72,22 @@ export function scan(root: string): Map<string, string> {
   return files;
 }
 
-export function presetPackageScripts(root: string): readonly PresetPackageScript[] {
-  const directory = path.join(root, "scripts");
-  if (!existsSync(directory)) return [];
-  if (!lstatSync(directory).isDirectory() || lstatSync(directory).isSymbolicLink())
-    throw presetFailure("invalid_preset_scripts", `Preset package ${root} ships scripts as a non-directory node.`);
-  return readdirSync(directory, { withFileTypes: true })
-    .sort((left, right) => left.name.localeCompare(right.name))
-    .map((entry) => {
-      if (entry.isSymbolicLink() || !entry.isFile())
-        throw presetFailure(
-          "invalid_preset_scripts",
-          `Preset scripts entry scripts/${entry.name} is not a regular file; ` +
-            "subdirectories and other node kinds are not materialized.",
-        );
-      return {
-        name: entry.name,
-        body: readFileSync(path.join(directory, entry.name), "utf8"),
-      };
-    });
+export function presetPackageScripts(files: Map<string, string>): readonly PresetPackageScript[] {
+  const scripts: PresetPackageScript[] = [];
+  for (const [name, body] of [...files].sort(([left], [right]) => left.localeCompare(right))) {
+    if (name === "scripts")
+      throw presetFailure("invalid_preset_scripts", `Preset package ships scripts as a non-directory node.`);
+    if (!name.startsWith("scripts/")) continue;
+    const entry = name.split("/")[1]!;
+    if (name.slice("scripts/".length) !== entry)
+      throw presetFailure(
+        "invalid_preset_scripts",
+        `Preset scripts entry scripts/${entry} is not a regular file; ` +
+          "subdirectories and other node kinds are not materialized.",
+      );
+    scripts.push({ name: entry, body });
+  }
+  return scripts;
 }
 
 export function parseDocument(body: string): PresetDocumentV1 {

--- a/packages/preset/src/preset-process-service.ts
+++ b/packages/preset/src/preset-process-service.ts
@@ -106,6 +106,7 @@ export function createPresetProcessService(options: PresetProcessServiceOptions)
     maxResultBytes = options.maxResultBytes ?? resultLimit;
   ensureTree(rootDir, runRoot, witnessRoot, stagingRoot);
   const witnesses = new Map<string, Witness>(),
+    runIdByKey = new Map<string, string>(),
     children = new Map<string, TrackedChild>();
   let closed = false;
   for (const name of readdirSync(witnessRoot).filter((entry) => entry.endsWith(".json"))) {
@@ -123,6 +124,7 @@ export function createPresetProcessService(options: PresetProcessServiceOptions)
             nextAction: "Inspect authored state before deciding whether to start with a new idempotency key.",
           }),
     );
+    if (!runIdByKey.has(loaded.idempotencyKey)) runIdByKey.set(loaded.idempotencyKey, loaded.runId);
   }
   const status = (runId: string): PresetRunReceiptV1 => {
     const witness = witnesses.get(runId);
@@ -138,7 +140,8 @@ export function createPresetProcessService(options: PresetProcessServiceOptions)
       return rejection("run_invalid", "invalid_idempotency_key", "idempotencyKey is required.");
     const requestDigest = digest(input),
       runId = `run_${digest(input.idempotencyKey).slice(7, 33)}`,
-      prior = [...witnesses.values()].find((item) => item.idempotencyKey === input.idempotencyKey);
+      priorRunId = runIdByKey.get(input.idempotencyKey),
+      prior = priorRunId === undefined ? undefined : witnesses.get(priorRunId);
     if (prior)
       return prior.requestDigest === requestDigest
         ? receipt(prior)
@@ -219,6 +222,7 @@ export function createPresetProcessService(options: PresetProcessServiceOptions)
 
   function save(witness: Witness): Witness {
     witnesses.set(witness.runId, witness);
+    runIdByKey.set(witness.idempotencyKey, witness.runId);
     const target = path.join(witnessRoot, `${witness.runId}.json`),
       temporary = path.join(witnessRoot, `.${witness.runId}-${randomUUID()}.tmp`);
     try {

--- a/packages/preset/src/preset-resolver-types.ts
+++ b/packages/preset/src/preset-resolver-types.ts
@@ -15,6 +15,7 @@ export interface DecodedPresetPackageV3 {
   readonly manifest: PresetManifestV3;
   readonly document: PresetDocumentV1;
   readonly root: string;
+  readonly files: Map<string, string>;
   readonly packageDigest: string;
   readonly manifestSha256: string;
   readonly [decodedPackageBrand]: true;
@@ -78,6 +79,7 @@ export interface OwnedEntrypoint {
   readonly definition: ManifestEntrypoint;
   readonly root: string;
   readonly packageDigest: string;
+  readonly files: Map<string, string>;
 }
 
 export interface PresetPackageScript {

--- a/packages/preset/src/preset-runtime.ts
+++ b/packages/preset/src/preset-runtime.ts
@@ -1,13 +1,8 @@
 import { assertCanonicalVertical, loadCanonicalAssets, packageCatalog } from "./preset-assets.ts";
 import { effectiveCatalog } from "./preset-catalog.ts";
 import { listCatalog } from "./preset-discovery.ts";
-import {
-  catalogAnchors,
-  materializeSelections,
-  requiredRegularFile,
-  taskOverlayPath,
-} from "./preset-materialization.ts";
-import { presetPackageScripts } from "./preset-package.ts";
+import { catalogAnchors, materializeSelections, taskOverlayPath } from "./preset-materialization.ts";
+import { file, presetPackageScripts } from "./preset-package.ts";
 import {
   asFailure,
   compareVersion,
@@ -35,7 +30,6 @@ import type {
   ResolvePresetRequestV1,
 } from "./preset.contract.ts";
 import { mergeScaffoldOverlay } from "./scaffold-overlay.ts";
-import { existsSync, lstatSync } from "node:fs";
 import path from "node:path";
 
 export function createRuntime(options: PresetResolverOptions): {
@@ -141,6 +135,7 @@ export function createRuntime(options: PresetResolverOptions): {
       }
     }
     const documents = materializeSelections([...selections.values()], normalizeLocale(request.locale)),
+      documentHashes = documents.map((item) => resolverContentHash(item.body)),
       catalogDigests = [
         ...new Set([...selections.values()].flatMap((item) => (item.source ? [item.source.sha256] : []))),
       ].sort(),
@@ -156,6 +151,7 @@ export function createRuntime(options: PresetResolverOptions): {
               definition,
               root: item.decoded!.root,
               packageDigest: item.decoded!.packageDigest,
+              files: item.decoded!.files,
             },
           ]),
         ),
@@ -165,12 +161,7 @@ export function createRuntime(options: PresetResolverOptions): {
       throw presetFailure("entrypoint_not_found", `Entrypoint ${request.entrypoint ?? "<missing>"} is not declared.`);
     for (const [name, owned] of Object.entries(entrypoints)) {
       const command = path.resolve(owned.root, owned.definition.command);
-      if (
-        !isWithinPresetAssetRoot(owned.root, command) ||
-        !existsSync(command) ||
-        !lstatSync(command).isFile() ||
-        lstatSync(command).isSymbolicLink()
-      )
+      if (!isWithinPresetAssetRoot(owned.root, command) || !owned.files.has(owned.definition.command))
         throw presetFailure("missing_script", `Entrypoint ${name} command is missing or unsafe.`);
       const missing = [...owned.definition.requires, ...owned.definition.produces, ...owned.definition.sideEffects]
         .filter((capability) => {
@@ -187,14 +178,14 @@ export function createRuntime(options: PresetResolverOptions): {
     }
     const resolvedSelectionDigest = `sha256:${resolverContentHash(
         canonicalPresetBytes(
-          documents.map((item) => ({
+          documents.map((item, index) => ({
             slot: item.selection.slot,
             path: item.selection.materializeAs,
             templateRef: item.selection.templateRef,
             locale: item.locale,
             owner: item.owner,
             requiredAnchors: item.requiredAnchors,
-            sha256: resolverContentHash(item.body),
+            sha256: documentHashes[index]!,
           })),
         ),
       )}` as const,
@@ -221,7 +212,7 @@ export function createRuntime(options: PresetResolverOptions): {
           overlayDigest: overlay.digest,
           resolvedSelectionDigest,
         },
-        templates: documents.map((item) => ({
+        templates: documents.map((item, index) => ({
           slot: item.selection.slot,
           path: item.selection.materializeAs,
           templateRef: item.selection.templateRef,
@@ -229,14 +220,14 @@ export function createRuntime(options: PresetResolverOptions): {
           owner: item.owner,
           requiredAnchors: item.requiredAnchors,
           content: {
-            sha256: resolverContentHash(item.body),
+            sha256: documentHashes[index]!,
             size: Buffer.byteLength(item.body),
             mediaType: item.mediaType,
           },
         })),
         entrypoints: Object.fromEntries(
-          Object.entries(entrypoints).map(([name, { definition: item, root }]) => {
-            const commandBody = requiredRegularFile(path.resolve(root, item.command), "missing_script");
+          Object.entries(entrypoints).map(([name, { definition: item, files }]) => {
+            const commandBody = file(files, item.command, "missing_script");
             return [
               name,
               {
@@ -277,7 +268,7 @@ export function createRuntime(options: PresetResolverOptions): {
         requiredAnchors: item.requiredAnchors,
         templateRef: item.selection.templateRef,
       })),
-      scripts: request.purpose === "task-create" ? presetPackageScripts(leaf.root) : [],
+      scripts: request.purpose === "task-create" ? presetPackageScripts(leaf.files) : [],
       ...(requiredTaskClass ? { requiredTaskClass } : {}),
       packageRoot: executablePackage.root,
       packageDigest: executablePackage.packageDigest,

--- a/packages/preset/src/preset-system.ts
+++ b/packages/preset/src/preset-system.ts
@@ -26,8 +26,10 @@ import {
   uninstallPresetPackage,
   validateVerticalSource,
   validatePresetPackage,
+  type InternalPresetResolution,
   type RepositoryScaffoldPlan,
 } from "./preset-resolver.ts";
+import { asFailure } from "./preset-resolver-common.ts";
 
 type TaskWorkKind = NonNullable<Parameters<typeof compileTaskPackage>[0]["workKind"]>;
 type PriorityTier = NonNullable<Parameters<typeof compileTaskPackage>[0]["riskTier"]>;
@@ -98,27 +100,31 @@ export async function runPresetAction(input: {
       ...(profileId ? { profileId } : {}),
       locale: optionalActionText(action.locale) ?? defaults.locale,
       purpose: "inspect" as const,
-    },
-    result = await resolver.resolve(request);
-  if (!result.ok) throw presetActionError(result.error.code, result.error.hint);
+    };
+  let resolved: InternalPresetResolution;
+  try {
+    resolved = runtime.resolveInternal(request);
+  } catch (error) {
+    const known = asFailure(error);
+    throw presetActionError(known.code, known.message);
+  }
   if (action.kind === "preset-check") {
     const actual = optionalActionText(action.snapshotDigest);
-    return actual && actual !== result.snapshot.digest
+    return actual && actual !== resolved.snapshot.digest
       ? {
           valid: false,
           code: "snapshot_mismatch",
           actualDigest: actual,
-          expectedDigest: result.snapshot.digest,
+          expectedDigest: resolved.snapshot.digest,
           nextAction: "Run ha preset upgrade <task-id>.",
         }
-      : { valid: true, digest: result.snapshot.digest };
+      : { valid: true, digest: resolved.snapshot.digest };
   }
-  const inspected = runtime.resolveInternal(request);
   return {
-    manifest: inspected.manifest,
-    snapshot: inspected.snapshot,
-    entrypoints: Object.keys(inspected.snapshot.entrypoints).sort(),
-    documents: inspected.documents,
+    manifest: resolved.manifest,
+    snapshot: resolved.snapshot,
+    entrypoints: Object.keys(resolved.snapshot.entrypoints).sort(),
+    documents: resolved.documents,
   };
 }
 export function compileRepoTaskBootstrap(input: {

--- a/packages/preset/src/preset-validation.ts
+++ b/packages/preset/src/preset-validation.ts
@@ -1,5 +1,5 @@
 import { loadCanonicalAssets } from "./preset-assets.ts";
-import { decodePresetPackageV3, parsePresetJson, presetDocumentValue, scan } from "./preset-package.ts";
+import { decodePackage, parsePresetJson, presetDocumentValue, scan } from "./preset-package.ts";
 import { asFailure, defaultAssets, isPresetResolutionRecord, presetFailure } from "./preset-resolver-common.ts";
 import type { PresetFailure } from "./preset-resolver-types.ts";
 import { consumeKnownError, validatePresetDocumentV1, validatePresetManifestV3 } from "./preset.contract.ts";
@@ -57,7 +57,7 @@ export function validatePresetPackage(input: { readonly source: string }) {
       issues,
     };
   try {
-    const decoded = decodePresetPackageV3(source);
+    const decoded = decodePackage(source, true, undefined, files);
     return {
       schema: "preset-validate-report/v1" as const,
       valid: true,

--- a/packages/preset/src/scaffold-overlay.ts
+++ b/packages/preset/src/scaffold-overlay.ts
@@ -130,7 +130,8 @@ function anchors(template: ProjectTemplate, required: readonly string[], slot: s
       throw scaffoldFailure("required_anchor", `Template for ${slot} is missing required anchor ${anchor}.`);
 }
 function requiredFile(target: string, code: string): string {
-  if (!existsSync(target) || !lstatSync(target).isFile() || lstatSync(target).isSymbolicLink())
+  const stat = existsSync(target) ? lstatSync(target) : undefined;
+  if (!stat?.isFile() || stat.isSymbolicLink())
     throw scaffoldFailure(code, `Required regular file ${target} is unavailable.`);
   return readFileSync(target, "utf8");
 }


### PR DESCRIPTION
# English

## Summary

fix-plan batch 16 (task_22afba1bdf036393fd66fbcb58, parent task_6eba9c5d3a55735920aa4856f3 / task_2b8f79fa4412cb726a26f9bfc7): the preset "multi-pass read" family. One preset asset was read, decoded or hashed several times inside one command; each finding now reads or computes once and threads the result. R1-07-F2 `preset inspect`/`check` resolve once instead of twice; R1-07-F3 document hashes computed once and reused by digest and templates; R1-07-F7 witness idempotency key looked up by Map instead of a linear scan; R2-07-F3 template bodies read during validation are reused by selection; R2-07-F4 (ruling §5.7) the seed pre-check decode is passed into `installPresetPackage` so the second full scan+hash is gone while the third, post-copy defensive decode stays; R2-07-F5 validate reuses the decode scan; R2-07-F7 `contentSha256` computed once at construction; R2-07-F8 the decode scan travels with the package (`files`), so entry-command existence, body reads and `scripts/` enumeration derive from the table instead of re-reading disk. Measured per command (fs/crypto hook counter, before vs after, digests identical): `preset inspect` template reads 171 → 110 and `lstatSync` 403 → 154; task-create compile `lstatSync` 287 → 154; seed of 13 packages source reads 120 → 60 (post-copy verification reads 60 kept); validate 4 → 2; script-run 4 → 3. Production +100/-76 in `packages/preset/src` (11 files); the net +24 is parameter threading (`scannedFiles`, `files`, `documentHashes`).

## Architectural Justification

- No new module or cache layer: the already-produced scan/decode result is passed along instead of being recomputed; the one intentional defensive decode (§5.7) is kept and named.

## What Changed

- `packages/preset/src/preset-package.ts`: `presetPackageScripts` derives from the scanned file map; `decodePackage` accepts an existing scan.
- `preset-runtime.ts`, `preset-system.ts`, `preset-validation.ts`, `preset-installation.ts`, `preset-bootstrap.ts`, `preset-extension-model.ts`, `preset-process-service.ts`, `preset-materialization.ts`, `preset-resolver-types.ts`, `scaffold-overlay.ts`: single-pass resolve/hash/decode, results threaded.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: +100/-76 (`packages/*/src`, tests excluded).

## Machine-Readable Declarations

- Production-Delta: +100/-76

## Task And Scope

- Harness task: task_22afba1bdf036393fd66fbcb58 (batch 16), parent task_6eba9c5d3a55735920aa4856f3
- Branch: `codex/perf-w-g`
- Public scope: `packages/preset/src` only
- Private planning/evidence updated: yes (`artifacts/report.md`, fact F-AC39EB13)
- Out of scope: the third defensive decode (§5.7 keeps it), round-5 hot paths (batch 16 is low-frequency command surface)

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: not applicable
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `3a574f24f`
- Branch merge-base with `origin/main`: `3a574f24f`
- Last `git fetch origin` time: 2026-09-12 UTC
- Sync method: branched from origin/main
- Public diff command: `git diff origin/main...codex/perf-w-g`
- Private evidence commit/path: task_22afba1bdf036393fd66fbcb58 `artifacts/report.md`
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [x] `npm run typecheck` (worker)
- [ ] `npm run check`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts` (via `run-manifest-gates --changed origin/main`, worker)
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Worker (GLM, isolated dispatch): preset suite 13 files / 83 tests and daemon consumer 3 files / 21 tests green; line-density, lint, file-complexity, canonical-event-compat green.

## Review Evidence

- CEO ground-truth: read the per-file diff; the `scripts/` enumeration and entry-command existence now derive from the decode scan, hashes are computed once and indexed, the third decode in installation is still present.
- Reviewer subagent: closeout review after merge
- Human review: pending
- Blocking findings: none open

## Residual Risk

- Entry-command existence is checked against the decode scan instead of a fresh `lstat`, so a file deleted between decode and resolve inside one command is caught by the retained post-copy decode / `commandSha256` check rather than the entry stat.
- An empty nested directory under `scripts/` is no longer rejected fail-closed (git does not track empty directories; theoretical).

## References

- Task: task_22afba1bdf036393fd66fbcb58; fix-plan batch 16; ruling §5.7 in fix-plan-status-0912.md

---

# 中文

## 概要

fix-plan 批 16（task_22afba1bdf036393fd66fbcb58，父 task_6eba9c5d3a55735920aa4856f3 / task_2b8f79fa4412cb726a26f9bfc7）：preset「多遍读」家族。同一 preset 资产在一次命令内被多次读取、解码或哈希；每条 finding 改为只读/只算一次并把结果下传。R1-07-F2 `preset inspect`/`check` 解析一次而非两次；R1-07-F3 文档哈希算一次，digest 与 templates 复用；R1-07-F7 witness 幂等键改 Map 定位而非线性扫描；R2-07-F3 验证阶段读过的模板正文供 selection 复用；R2-07-F4（§5.7 裁决）seed 预检的 decode 结果下传 `installPresetPackage`，砍掉第二次全量 scan+hash，拷贝后的第三次防御 decode 保留；R2-07-F5 validate 复用 decode 扫描；R2-07-F7 `contentSha256` 构造时算一次；R2-07-F8 decode 扫描随包携带（`files`），入口命令存在性、正文读取与 `scripts/` 枚举全部查表派生，不再重读盘。逐命令实测（fs/crypto hook 计数，修前 vs 修后，digest 一致）：`preset inspect` 模板读 171 → 110、`lstatSync` 403 → 154；task-create 编译 `lstatSync` 287 → 154；13 包 seed 源包读 120 → 60（拷贝后校验读 60 保留）；validate 4 → 2；script-run 4 → 3。生产 +100/-76（`packages/preset/src` 11 文件）；净 +24 是参数下传（`scannedFiles`、`files`、`documentHashes`）。

## 架构辩护

- 不新增模块或缓存层：把已产出的 scan/decode 结果传下去而不是重算；唯一有意保留的防御 decode（§5.7）点名保留。

## 改动内容

- `packages/preset/src/preset-package.ts`：`presetPackageScripts` 从扫描文件表派生；`decodePackage` 接受既有扫描。
- `preset-runtime.ts`、`preset-system.ts`、`preset-validation.ts`、`preset-installation.ts`、`preset-bootstrap.ts`、`preset-extension-model.ts`、`preset-process-service.ts`、`preset-materialization.ts`、`preset-resolver-types.ts`、`scaffold-overlay.ts`：单遍 resolve/hash/decode，结果下传。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 删除的门或 fixture：none
- 生产净行数：+100/-76（`packages/*/src` 不含测试）。

## 机器可读声明

- Production-Delta: +100/-76

## 任务与范围

- Harness 任务：task_22afba1bdf036393fd66fbcb58（批 16），父任务 task_6eba9c5d3a55735920aa4856f3
- 分支：`codex/perf-w-g`
- 公开范围：仅 `packages/preset/src`
- 私有计划/证据已更新：是（`artifacts/report.md`，事实 F-AC39EB13）
- 范围外：第三次防御 decode（§5.7 保留）、round-5 热路径（批 16 是低频命令面）

## 版本影响

- 版本：不变
- 发布影响：不发布

## 治理声明

- 触碰受保护面：否
- 受保护面范围：不适用
- 授权：不适用
- 机器检查边界：本 PR 只断言声明存在；是否属实、是否充分由评审判断。
- Break-glass：否
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- 基线 `origin/main` SHA：`3a574f24f`
- 分支与 `origin/main` 的 merge-base：`3a574f24f`
- 最近一次 `git fetch origin`：2026-09-12 UTC
- 同步方式：从 origin/main 开分支
- 公开 diff 命令：`git diff origin/main...codex/perf-w-g`
- 私有证据路径：task_22afba1bdf036393fd66fbcb58 的 `artifacts/report.md`
- 评审证据路径：本 PR 的评审证据节
- GitHub Actions `rewrite-ci` run URL：本 PR 待跑
- worker（GLM，隔离派测）：preset 全套 13 文件 / 83 用例与 daemon 消费面 3 文件 / 21 用例绿；line-density、lint、file-complexity、canonical-event-compat 绿。

## 评审证据

- CEO 事实核对：逐文件读过 diff；`scripts/` 枚举与入口命令存在性改为从 decode 扫描派生，哈希算一次并按下标索引，安装里的第三次 decode 仍在。
- 评审子代理：合入后派收口评审
- 人工评审：待定
- 阻塞发现：无

## 残余风险

- 入口命令存在性改查 decode 扫描而非现场 `lstat`，同一命令内 decode 之后被删的文件由保留的拷贝后 decode / `commandSha256` 复核兜住，而不是入口 stat。
- `scripts/` 下空嵌套目录不再 fail-closed 拒绝（git 不跟踪空目录，理论性）。

## 参考

- 任务：task_22afba1bdf036393fd66fbcb58；fix-plan 批 16；fix-plan-status-0912.md §5.7 裁决
