### PR TITLE
perf(daemon): narrow the agenda, archive, explain, artifacts and CI observatory reads

### DIFF
--- a/packages/daemon/src/artifacts-gui-read.ts
+++ b/packages/daemon/src/artifacts-gui-read.ts
@@ -80,14 +80,24 @@ interface ArtifactFileRow {
   readonly mtimeMs: number;
 }
 
-/** 一棵 artifacts/ 子树下的产物文件;符号链接一律不跟(产物只认真实文件)。 */
-function walkArtifactTree(artifactsRoot: string, packageDir: string): readonly ArtifactFileRow[] {
-  const rows: ArtifactFileRow[] = [];
+/** 一棵 artifacts/ 子树下的产物文件;符号链接一律不跟(产物只认真实文件)。
+ * kind 下推进 walk:三种 kind 都计数(计数只需 Dirent 与扩展名分类,零额外
+ * syscall),但只有请求的 kind 才 stat 取 size/mtime——非请求 kind 的文件
+ * 不再付每文件 2 次 stat 的代价。遍历规模上限按分类文件总数计,与收窄前
+ * 一致。 */
+function walkArtifactTree(
+  artifactsRoot: string,
+  packageDir: string,
+  wanted: ArtifactGuiKind,
+  counts: { [K in ArtifactGuiKind]: number },
+): readonly ArtifactFileRow[] {
+  const rows: ArtifactFileRow[] = [],
+    classifiedTotal = () => counts.html + counts.md + counts.raw;
   if (statLinkSync(artifactsRoot)?.isSymbolicLink() === true || statFileSync(artifactsRoot)?.isDirectory() !== true)
     return rows;
   const queue: (readonly [string, string])[] = [[artifactsRoot, "artifacts"]];
   let visited = 0;
-  while (queue.length > 0 && rows.length < artifactWalkMaxFiles && visited < artifactWalkMaxVisits) {
+  while (queue.length > 0 && classifiedTotal() < artifactWalkMaxFiles && visited < artifactWalkMaxVisits) {
     const [directory, prefix] = queue.shift()!;
     let entries: readonly import("node:fs").Dirent[];
     try {
@@ -106,7 +116,10 @@ function walkArtifactTree(artifactsRoot: string, packageDir: string): readonly A
         continue;
       }
       const classified = artifactKindOf(packageDir, relative, entry.name);
-      if (classified === null || !entry.isFile() || statLinkSync(target)?.isSymbolicLink() === true) continue;
+      if (classified === null || !entry.isFile() || entry.isSymbolicLink()) continue;
+      counts[classified.kind] += 1;
+      if (classifiedTotal() >= artifactWalkMaxFiles) break;
+      if (classified.kind !== wanted) continue;
       const stat = statFileSync(target);
       if (stat === null || !stat.isFile()) continue;
       rows.push({ packageDir, relative, ...classified, sizeBytes: stat.size, mtimeMs: stat.mtimeMs });
@@ -117,21 +130,25 @@ function walkArtifactTree(artifactsRoot: string, packageDir: string): readonly A
 
 /** 全部 task 包的 artifacts 文件:只进各包的 artifacts/ 子树,包内其它目录不扫,
  * 因此非 artifacts/ 的 html 永远不会出现在时间线里。 */
-function walkAllTaskArtifacts(tasksRoot: string): readonly ArtifactFileRow[] {
+function walkAllTaskArtifacts(
+  tasksRoot: string,
+  wanted: ArtifactGuiKind,
+): { readonly rows: readonly ArtifactFileRow[]; readonly counts: { [K in ArtifactGuiKind]: number } } {
   let entries: readonly import("node:fs").Dirent[];
   try {
     entries = readdirSync(tasksRoot, { withFileTypes: true });
   } catch (error) {
     consumeKnownError(error);
-    return [];
+    return { rows: [], counts: { html: 0, md: 0, raw: 0 } };
   }
-  const rows: ArtifactFileRow[] = [];
+  const rows: ArtifactFileRow[] = [],
+    counts = { html: 0, md: 0, raw: 0 };
   for (const entry of entries) {
     if (!entry.isDirectory() || entry.name.startsWith(".")) continue;
-    rows.push(...walkArtifactTree(path.join(tasksRoot, entry.name, "artifacts"), entry.name));
-    if (rows.length >= artifactWalkMaxFiles) break;
+    rows.push(...walkArtifactTree(path.join(tasksRoot, entry.name, "artifacts"), entry.name, wanted, counts));
+    if (counts.html + counts.md + counts.raw >= artifactWalkMaxFiles) break;
   }
-  return rows;
+  return { rows, counts };
 }
 
 /** 投影批量 join:packagePath → {taskId, title}。标题列取自 readTaskRuntimeBatch 的
@@ -173,19 +190,15 @@ export function readArtifactsGui(
 ): ArtifactsListResult {
   const kind: ArtifactGuiKind = payload.kind === "md" || payload.kind === "raw" ? payload.kind : "html",
     cut = context.projection.readTaskStatuses(),
-    files = walkAllTaskArtifacts(resolveHarnessLayout(context.rootDir).tasksRoot),
-    counts = {
-      html: files.filter((row) => row.kind === "html").length,
-      md: files.filter((row) => row.kind === "md").length,
-      raw: files.filter((row) => row.kind === "raw").length,
-    },
+    walk = walkAllTaskArtifacts(resolveHarnessLayout(context.rootDir).tasksRoot, kind),
+    files = walk.rows,
+    counts = walk.counts,
     tasksByPackage = taskIndexByPackage(
       context.projection,
       cut.rows.map(({ taskId }) => taskId),
     ),
     eventTimes = new Map<number, string>(),
     artifacts: readonly ArtifactGuiRowDto[] = files
-      .filter((row) => row.kind === kind)
       .map((row) => {
         const packagePath = `tasks/${row.packageDir}`,
           task = tasksByPackage.get(packagePath) ?? null,

--- a/packages/daemon/src/ci-observatory-read.ts
+++ b/packages/daemon/src/ci-observatory-read.ts
@@ -75,6 +75,8 @@ export function readCiObservatory(input: {
     throw new Error("CI observatory window must be 1..100");
   const read = input.projection.readCiRunObservations(Math.max(window * 20, 100)),
     events = selectRunWindow(read.events.filter(mainBranch), window),
+    // One derivation per event, reused by the run rows and the flake rows.
+    finalOutcomes = events.map((event) => ({ event, outcomes: finalTestOutcomes(event) })),
     quarantine = new Map(readQuarantine(input.rootDir).map((entry) => [entry.test, entry])),
     now = Date.parse(input.now ?? new Date().toISOString());
   return {
@@ -82,15 +84,15 @@ export function readCiObservatory(input: {
     ok: true,
     status: read.status,
     window,
-    flakes: flakeRows(events, quarantine, now),
+    flakes: flakeRows(finalOutcomes, quarantine, now),
     shardDurations: shardRows(events),
     gateTrends: gateRows(events),
     l0MedianMs: percentile(l0Wallclocks(events), 0.5),
-    runs: events.map((event) => ({
+    runs: finalOutcomes.map(({ event, outcomes }) => ({
       ...event.payload.run,
       occurredAt: event.occurredAt,
       pass:
-        finalTestOutcomes(event).every((entry) => !outcomeIs(entry, "failed")) &&
+        outcomes.every((entry) => !outcomeIs(entry, "failed")) &&
         event.payload.gates.every((entry) => entry.result === "pass"),
       testCount: event.payload.tests.length,
       gateCount: event.payload.gates.length,
@@ -140,13 +142,16 @@ function l0Wallclocks(events: readonly CiRunObservationEventV3[]): readonly numb
 }
 
 function flakeRows(
-  events: readonly CiRunObservationEventV3[],
+  observations: readonly {
+    readonly event: CiRunObservationEventV3;
+    readonly outcomes: readonly CiRunObservationEventV3["payload"]["tests"][number][];
+  }[],
   quarantine: ReadonlyMap<string, QuarantineEntry>,
   now: number,
 ): CiObservatoryRead["flakes"] {
   const rows = new Map<string, { file: string; durations: number[]; attempts: number; flakes: number }>();
-  for (const event of events)
-    for (const observation of finalTestOutcomes(event)) {
+  for (const { outcomes } of observations)
+    for (const observation of outcomes) {
       if (outcomeIs(observation, "skipped")) continue;
       const key = observation.name,
         row = rows.get(key) ?? { file: observation.file, durations: [], attempts: 0, flakes: 0 };
@@ -158,15 +163,16 @@ function flakeRows(
   return [...rows]
     .map(([test, row]) => {
       const entry = quarantine.get(test),
-        quarantinedAt = entry?.quarantinedAt ?? null;
+        quarantinedAt = entry?.quarantinedAt ?? null,
+        sortedDurations = [...row.durations].sort((left, right) => left - right);
       return {
         test,
         file: row.file,
         attempts: row.attempts,
         flakes: row.flakes,
         flakeRate: row.attempts === 0 ? 0 : row.flakes / row.attempts,
-        p50Ms: percentile(row.durations, 0.5) ?? 0,
-        p95Ms: percentile(row.durations, 0.95) ?? 0,
+        p50Ms: percentileOfSorted(sortedDurations, 0.5) ?? 0,
+        p95Ms: percentileOfSorted(sortedDurations, 0.95) ?? 0,
         quarantined: entry !== undefined,
         ownerTask: entry?.ownerTask ?? null,
         quarantinedAt,
@@ -201,29 +207,47 @@ function shardRows(events: readonly CiRunObservationEventV3[]): CiObservatoryRea
 }
 
 function gateRows(events: readonly CiRunObservationEventV3[]): CiObservatoryRead["gateTrends"] {
-  const trends = new Map<string, CiObservatoryRead["gateTrends"][number]>();
+  const trends = new Map<
+    string,
+    {
+      readonly gate: string;
+      readonly metric: string;
+      readonly points: {
+        runId: string;
+        occurredAt: string;
+        value: number;
+        pass: boolean;
+      }[];
+    }
+  >();
   for (const event of [...events].reverse())
     for (const gate of event.payload.gates)
       for (const [metric, value] of Object.entries(gate.metrics)) {
         const key = `${gate.gate}\u0000${metric}`,
           current = trends.get(key) ?? { gate: gate.gate, metric, points: [] };
-        trends.set(key, {
-          ...current,
-          points: [
-            ...current.points,
-            { runId: event.payload.run.runId, occurredAt: event.occurredAt, value, pass: gate.result === "pass" },
-          ],
+        current.points.push({
+          runId: event.payload.run.runId,
+          occurredAt: event.occurredAt,
+          value,
+          pass: gate.result === "pass",
         });
+        trends.set(key, current);
       }
   return [...trends.values()].sort(
     (left, right) => left.gate.localeCompare(right.gate) || left.metric.localeCompare(right.metric),
   );
 }
 
-function percentile(values: readonly number[], ratio: number): number | null {
-  if (values.length === 0) return null;
-  const sorted = [...values].sort((left, right) => left - right);
+function percentileOfSorted(sorted: readonly number[], ratio: number): number | null {
+  if (sorted.length === 0) return null;
   return sorted[Math.min(sorted.length - 1, Math.ceil(sorted.length * ratio) - 1)]!;
+}
+
+function percentile(values: readonly number[], ratio: number): number | null {
+  return percentileOfSorted(
+    [...values].sort((left, right) => left - right),
+    ratio,
+  );
 }
 
 function readQuarantine(rootDir: string): readonly QuarantineEntry[] {

--- a/packages/daemon/src/repo-cell-task-maintenance.ts
+++ b/packages/daemon/src/repo-cell-task-maintenance.ts
@@ -3,6 +3,7 @@ import {
   createEntityStore,
   isMigrationImportEvent,
   requireEntityStoreKindContract,
+  type TaskProjectionListQuery,
   type WriteReceiptDraft as WriteReceipt,
 } from "../../kernel/src/index.ts";
 import {
@@ -31,27 +32,7 @@ export function archiveTasks(
   binding: RepoCellBinding,
 ): WriteReceipt {
   const selected = [
-    ...new Set(
-      Array.isArray(action.taskIds)
-        ? cell.cellStringList(action.taskIds)
-        : cell
-            .queryRead()
-            .guiTasks()
-            .rows.filter((row) => {
-              const state = /^state:(.+)$/u.exec(String(action.filter ?? ""))?.[1],
-                before = typeof action.before === "string" ? Date.parse(action.before) : Number.NaN;
-              if (action.before && Number.isNaN(before))
-                throw cell.cellCodedError(
-                  "invalid_command",
-                  "Use an ISO-compatible --before date, then retry task archive.",
-                );
-              return (
-                (!state || row.snapshot.task?.status === state) &&
-                (!action.before || Date.parse(row.updatedAt) < before)
-              );
-            })
-            .map((row) => row.taskId),
-    ),
+    ...new Set(Array.isArray(action.taskIds) ? cell.cellStringList(action.taskIds) : archiveCandidateIds(cell, action)),
   ];
   if (!selected.length)
     throw cell.cellCodedError(
@@ -177,6 +158,22 @@ export function supersedeWithNewTask(
     replacementTaskId: preparedCreate.fields.taskId,
     steps: [created, replaced],
   } as WriteReceipt;
+}
+
+/** Selection candidates for a filter/before archive: the narrow task index
+ * scan with the status filter pushed down, so bulk archive no longer pays for
+ * the wide guiTasks assembly (graph reads, blocking, placement, evidence) only
+ * to discard it. The before bound stays a JS comparison because it compares
+ * parsed instants, not raw timestamp strings. */
+function archiveCandidateIds(cell: RepoCellOperationalContext, action: RepoTaskAction): readonly string[] {
+  const state = /^state:(.+)$/u.exec(String(action.filter ?? ""))?.[1],
+    before = typeof action.before === "string" ? Date.parse(action.before) : Number.NaN;
+  if (action.before && Number.isNaN(before))
+    throw cell.cellCodedError("invalid_command", "Use an ISO-compatible --before date, then retry task archive.");
+  return cell.projection
+    .readTaskIndex(state === undefined ? {} : { status: state as TaskProjectionListQuery["status"] })
+    .rows.filter((row) => !action.before || Date.parse(row.updatedAt) < before)
+    .map(({ taskId }) => taskId);
 }
 
 function taskValidationContext(

--- a/packages/daemon/src/task-action-explanation-read.ts
+++ b/packages/daemon/src/task-action-explanation-read.ts
@@ -64,8 +64,8 @@ export function readTaskActionExplanation(
       repositoryId: dependencies.rootDir,
     });
 
-  const stream = dependencies.store.read(),
-    cut = `canonical:${stream.revision}`,
+  const headRevision = dependencies.store.readHead()?.revision ?? 0,
+    cut = `canonical:${headRevision}`,
     evaluatedAt = dependencies.now(),
     authorize = ({
       action,
@@ -86,7 +86,7 @@ export function readTaskActionExplanation(
         },
         binding,
         actionId: `explain:${evaluatedAtCut}:${target}:${action.id}`,
-        revision: stream.revision,
+        revision: headRevision,
         now: evaluatedAt,
         targetOverride: target,
       });
@@ -94,12 +94,12 @@ export function readTaskActionExplanation(
     taskService = makeTaskActionExplanationService({
       actor: binding.actor,
       authorize: ({ action, target, evaluatedAtCut }) =>
-        explainAuthorization(action, target, evaluatedAtCut, "task", binding, stream.revision, evaluatedAt),
+        explainAuthorization(action, target, evaluatedAtCut, "task", binding, headRevision, evaluatedAt),
     }),
     squadService = makeSquadActionExplanationService({
       actor: binding.actor,
       authorize: ({ action, target, evaluatedAtCut }) =>
-        explainAuthorization(action, target, evaluatedAtCut, "squad", binding, stream.revision, evaluatedAt),
+        explainAuthorization(action, target, evaluatedAtCut, "squad", binding, headRevision, evaluatedAt),
     }),
     personService = makePersonActionExplanationService({ actor: binding.actor, authorize }),
     parsed = request.refs.map((ref) => ({ ref, parsed: parseEntityRef(ref) })),
@@ -107,25 +107,26 @@ export function readTaskActionExplanation(
       ({ parsed: entity }) =>
         entity !== null && !entity.externalHarness && (entity.kind === "task" || entity.kind === "squad"),
     ),
-    projection = supported.length ? dependencies.projection.list() : null,
+    cutRead = supported.length ? dependencies.projection.readCut() : null,
     projectionReady =
-      projection !== null &&
-      projection.status === "ready" &&
-      projection.watermark === stream.revision &&
-      projection.sourceRevision === stream.revision,
-    taskRows = new Map(projection?.rows.map((row) => [row.taskId, row]) ?? []),
-    effectiveLeaseByTask = new Map(
-      projection?.rows.map((row) => {
-        const lease = dependencies.projection.currentLease(row.taskId, evaluatedAt);
-        return [row.taskId, lease?.phase === "released" ? null : lease] as const;
-      }) ?? [],
-    ),
+      cutRead !== null &&
+      cutRead.status === "ready" &&
+      cutRead.watermark === headRevision &&
+      cutRead.sourceRevision === headRevision,
     installedAgentIds = new Set(
-      projectionReady ? dependencies.projection.listEntities("agent").map(({ id }) => id) : [],
+      parsed.some(({ parsed: entity }) => entity?.kind === "squad" && !entity.externalHarness) && projectionReady
+        ? dependencies.projection.listEntities("agent").map(({ id }) => id)
+        : [],
     ),
-    witnessByRevision = new Map(stream.events.map((event) => [event.workspaceRevision, event])),
+    /** Same-cut witness for one entity revision: an indexed event page of one,
+     * not a Map over the whole ledger. */
+    witnessAt = (revision: number) => {
+      if (!Number.isSafeInteger(revision) || revision < 1) return undefined;
+      const [event] = dependencies.projection.readCanonicalEvents(revision - 1, 1).events;
+      return event !== undefined && event.workspaceRevision === revision ? event : undefined;
+    },
     personCut = parsed.some(({ parsed: entity }) => entity?.kind === "person" && !entity.externalHarness)
-      ? personRosterAtCut(dependencies.rootDir, stream.events, stream.revision, binding, evaluatedAt)
+      ? personRosterAtCut(dependencies.rootDir, dependencies.store.read().events, headRevision, binding, evaluatedAt)
       : null,
     cache = new Map<string, EntityActionExplanationSubjectV1>(),
     subjects = parsed.map(({ ref, parsed: entity }) => {
@@ -198,14 +199,17 @@ export function readTaskActionExplanation(
           [`Retry after the ${entity.kind === "task" ? "Task" : "Squad"} projection reaches the canonical cut.`],
         );
       else if (entity.kind === "task") {
-        const row = taskRows.get(entity.id),
-          event = row ? witnessByRevision.get(row.workspaceRevision) : undefined,
-          task = row?.snapshot.task;
+        // Point reads: the task exists check, its snapshot, and the witness at
+        // its own revision — no full task list, no per-task lease sweep, no Map
+        // over every canonical event.
+        const row = dependencies.projection.readTaskExists(entity.id) ? dependencies.projection.read(entity.id) : null,
+          task = row?.snapshot.task,
+          event = row ? witnessAt(row.snapshot.revision) : undefined;
         if (!row)
           subject = failure("task", entity.raw as EntityRef, "entity_not_found", `Task ${entity.id} was not found.`, [
             "Run ha task list and choose an existing Task ref.",
           ]);
-        else if (!event || !task || row.snapshot.revision !== row.workspaceRevision)
+        else if (!event || !task)
           subject = failure(
             "task",
             entity.raw as EntityRef,
@@ -214,11 +218,12 @@ export function readTaskActionExplanation(
             ["Retry after the Task projection and canonical ledger witness agree."],
           );
         else {
-          const snapshot = { ...row.snapshot, lease: effectiveLeaseByTask.get(entity.id) ?? null },
+          const lease = dependencies.projection.currentLease(entity.id, evaluatedAt),
+            snapshot = { ...row.snapshot, lease: lease?.phase === "released" ? null : lease },
             entityWitness = projectBaseEntityAtCut<BaseEntity<"task">>(requireEntityTypeContract("task"), {
               kind: "task",
               id: entity.id,
-              workspaceRevision: row.workspaceRevision,
+              workspaceRevision: row.snapshot.revision,
               occurredAt: event.occurredAt,
               actor: event.actor,
               source: event.source,
@@ -229,7 +234,7 @@ export function readTaskActionExplanation(
         }
       } else {
         const row = dependencies.projection.getEntity("squad", entity.id),
-          event = row ? witnessByRevision.get(row.workspaceRevision) : undefined;
+          event = row ? witnessAt(row.workspaceRevision) : undefined;
         if (!row)
           subject = failure("squad", entity.raw as EntityRef, "entity_not_found", `Squad ${entity.id} was not found.`, [
             "Run ha squad list and choose an existing Squad ref.",

--- a/packages/daemon/src/task-query-read.ts
+++ b/packages/daemon/src/task-query-read.ts
@@ -17,6 +17,7 @@ import {
   resolveHarnessLayout,
   type FreshnessReason,
   type FreshnessReasonInput,
+  type ProjectionPage,
   type ProjectedExecution,
   type RelationGraphEdgeRow,
   type TaskProjection,
@@ -158,21 +159,52 @@ export function makeTaskQueryReadModel(input: {
       ...projectionCut(read),
     };
   }
-  function guiTasks(query: TaskProjectionListQuery = {}): DaemonTaskSnapshotListResult {
-    const lifecycle = projection.list(query),
-      taskRefs = lifecycle.rows.map(({ taskId }) => `task/${taskId}`),
+  /**
+   * Blocking judgments for one lifecycle page: the graph reads (dependency
+   * closure plus derives edges plus the statuses of every task those edges
+   * touch) and the kernel blocking verdict over them. The wide guiTasks
+   * assembly and the narrow agenda page read share this one implementation, so
+   * agenda no longer pays for placement, decision scopes, or execution
+   * evidence projection it never serves.
+   */
+  function readBlockingAssessments(taskIds: readonly string[]) {
+    const taskRefs = taskIds.map((taskId) => `task/${taskId}`),
       dependencies = projection.readTaskDependencyClosure(taskRefs),
       derives = projection.readTaskRelationsByTargets(taskRefs, "derives"),
       edges = [...dependencies.rows, ...derives.rows],
       relatedTaskIds = [
         ...new Set([
-          ...lifecycle.rows.map(({ taskId }) => taskId),
+          ...taskIds,
           ...dependencies.rows.flatMap(({ sourceRef, targetRef }) =>
             [sourceRef, targetRef].flatMap((ref) => /^task\/([^/]+)$/u.exec(ref)?.[1] ?? []),
           ),
         ]),
       ],
       taskStatuses = projection.readTaskStatuses(relatedTaskIds),
+      hardWarnings = [...relationFacetWarnings(dependencies.status), ...relationFacetWarnings(derives.status)]
+        .filter(({ severity }) => severity === "hard-fail")
+        .map(({ message }) => message),
+      blockingTasks = taskStatuses.rows.flatMap((row) =>
+        row.status === null ? [] : [{ taskId: row.taskId, status: row.status }],
+      );
+    return {
+      dependencies,
+      derives,
+      taskStatuses,
+      edges,
+      blockingByTaskId: new Map(
+        blocking(blockingTasks, edges, {
+          state: hardWarnings.length ? "error" : "ready",
+          hardFailWarnings: hardWarnings,
+        }).map((row) => [row.taskId, row]),
+      ),
+    };
+  }
+  function guiTasks(query: TaskProjectionListQuery = {}): DaemonTaskSnapshotListResult {
+    const lifecycle = projection.list(query),
+      { dependencies, derives, taskStatuses, blockingByTaskId } = readBlockingAssessments(
+        lifecycle.rows.map(({ taskId }) => taskId),
+      ),
       decisionIds = [
         ...new Set(derives.rows.flatMap(({ sourceRef }) => /^decision\/([^/]+)/u.exec(sourceRef)?.[1] ?? [])),
       ],
@@ -184,21 +216,10 @@ export function makeTaskQueryReadModel(input: {
         taskStatuses,
         decisionRead,
       ]),
-      graphWarnings = [...relationFacetWarnings(dependencies.status), ...relationFacetWarnings(derives.status)],
-      hardWarnings = graphWarnings.filter(({ severity }) => severity === "hard-fail").map(({ message }) => message),
-      activeDerives = new Map<string, typeof edges>();
+      activeDerives = new Map<string, typeof derives.rows>();
     for (const edge of derives.rows)
       if (edge.state === "active" && edge.direction === "directed" && edge.relationType === "derives")
         activeDerives.set(edge.targetRef, [...(activeDerives.get(edge.targetRef) ?? []), edge]);
-    const blockingTasks = taskStatuses.rows.flatMap((row) =>
-      row.status === null ? [] : [{ taskId: row.taskId, status: row.status }],
-    );
-    const blockingRows = new Map(
-      blocking(blockingTasks, edges, {
-        state: hardWarnings.length ? "error" : "ready",
-        hardFailWarnings: hardWarnings,
-      }).map((row) => [row.taskId, row]),
-    );
     const decisions = new Map(decisionRead.decisions.map((row) => [row.decisionId, row]));
     const result: Omit<DaemonTaskSnapshotListResult, "invalidRows"> = {
       ok: true,
@@ -246,7 +267,7 @@ export function makeTaskQueryReadModel(input: {
             codeDocWitnesses: "known" as const,
             gateWitnesses: "known" as const,
           },
-          blockingAssessment = blockingRows.get(row.taskId) ?? {
+          blockingAssessment = blockingByTaskId.get(row.taskId) ?? {
             taskId: row.taskId,
             state: "unknown" as const,
             label: "unresolved" as const,
@@ -287,18 +308,46 @@ export function makeTaskQueryReadModel(input: {
     };
     return { ...result, ...isolateDaemonTaskSnapshotRows(result.rows) };
   }
+  /**
+   * Narrow agenda page read: the lifecycle page plus only the blocking
+   * judgment each row needs. Deliberately skips everything the wide guiTasks
+   * assembly builds and the agenda never serves (placement scopes and their
+   * decision read, execution evidence ids, board/visibility/closeout) — the
+   * agenda consumes snapshots and blocking assessments directly.
+   */
+  function readAgendaTaskPage(
+    status: "active" | "blocked" | "planned" | "in_review",
+    sourceLimit: number,
+    pageCursor: string | undefined,
+  ): AgendaSourcePage {
+    const lifecycle = projection.list({
+        status,
+        limit: sourceLimit,
+        pinnedFirst: true,
+        ...(pageCursor ? { cursor: pageCursor } : {}),
+      }),
+      graph = readBlockingAssessments(lifecycle.rows.map(({ taskId }) => taskId));
+    return {
+      page: lifecycle.page ?? null,
+      rows: lifecycle.rows.map((row) => ({
+        ...row,
+        blockingAssessment: graph.blockingByTaskId.get(row.taskId) ?? {
+          taskId: row.taskId,
+          state: "unknown" as const,
+          label: "unresolved" as const,
+          blockers: [],
+          warnings: ["task snapshot missing from blocking judgment"],
+        },
+      })),
+      warnings: lifecycle.warnings,
+      reads: [lifecycle, graph.dependencies, graph.derives, graph.taskStatuses],
+    };
+  }
   function agenda(query: { readonly limit?: number; readonly cursor?: string } = {}): DaemonAgendaResult {
     const sourceLimit = query.limit ?? 100,
       cursor = query.cursor === undefined ? null : decodeAgendaCursor(query.cursor),
       readTaskPage = (status: "active" | "blocked" | "planned" | "in_review", key: AgendaCursorKey) =>
-        cursor?.[key] === null
-          ? null
-          : guiTasks({
-              status,
-              limit: sourceLimit,
-              pinnedFirst: true,
-              ...(cursor?.[key] ? { cursor: cursor[key]! } : {}),
-            }),
+        cursor?.[key] === null ? null : readAgendaTaskPage(status, sourceLimit, cursor?.[key] ?? undefined),
       active = readTaskPage("active", "active"),
       blocked = readTaskPage("blocked", "blocked"),
       planned = readTaskPage("planned", "planned"),
@@ -311,9 +360,13 @@ export function makeTaskQueryReadModel(input: {
               limit: sourceLimit,
               ...(cursor?.decisions ? { cursor: cursor.decisions } : {}),
             }),
-      reads = [active, blocked, planned, inReview, decisions].filter(
-        (read): read is NonNullable<typeof read> => read !== null,
-      ),
+      reads = [
+        ...(active?.reads ?? []),
+        ...(blocked?.reads ?? []),
+        ...(planned?.reads ?? []),
+        ...(inReview?.reads ?? []),
+        ...(decisions === null ? [] : [decisions]),
+      ],
       inFlight = (active?.rows ?? [])
         .filter((row) => row.snapshot.lease !== null || row.snapshot.executions.some(({ state }) => state === "active"))
         .map(agendaTaskRow)
@@ -585,10 +638,18 @@ function projectExecutionEvidence(
     })),
   };
 }
-type AgendaSourceRead = DaemonTaskSnapshotListResult["rows"][number];
+type AgendaSourceRow = ReturnType<TaskProjection["list"]>["rows"][number] & {
+  readonly blockingAssessment: DaemonTaskSnapshotListResult["rows"][number]["blockingAssessment"];
+};
+type AgendaSourcePage = {
+  readonly page: ProjectionPage | null;
+  readonly rows: readonly AgendaSourceRow[];
+  readonly warnings: ReturnType<TaskProjection["list"]>["warnings"];
+  readonly reads: readonly ProjectionCut[];
+};
 type AgendaCursorKey = "active" | "blocked" | "planned" | "inReview";
 type AgendaCursor = Readonly<Record<AgendaCursorKey | "decisions", string | null>>;
-function agendaTaskRow(row: AgendaSourceRead): AgendaTaskRow {
+function agendaTaskRow(row: AgendaSourceRow): AgendaTaskRow {
   const task = row.snapshot.task!;
   return {
     taskId: row.taskId,

--- a/packages/daemon/test/task-archive-selection.contract.test.ts
+++ b/packages/daemon/test/task-archive-selection.contract.test.ts
@@ -1,0 +1,59 @@
+// harness-test-tier: contract
+import assert from "node:assert/strict";
+import test from "node:test";
+import { archiveTasks } from "../src/repo-cell-task-maintenance.ts";
+import type { RepoTaskAction } from "../src/repo-cell-types.ts";
+
+const binding = { actor: { principal: { personId: "person-owner" }, executor: null }, source: "local" } as const,
+  cellCodedError = (code: string, message: string) => Object.assign(new Error(message), { code }),
+  /** Minimal cell for the selection phase only: `read` throws with the task id
+   * so the selected ids surface through the error, and any attempt to run the
+   * wide query-read assembly would miss the method entirely. */
+  selectionCell = (indexQueries: unknown[], rows: readonly { taskId: string; updatedAt: string }[]) => ({
+    cellCodedError,
+    projection: {
+      readTaskIndex: (query: unknown = {}) => {
+        indexQueries.push(query);
+        return { rows };
+      },
+      read: (taskId: string) => {
+        throw new Error(`SURFACE-READ:${taskId}`);
+      },
+    },
+  }),
+  archive = (cell: ReturnType<typeof selectionCell>, action: Partial<RepoTaskAction>) =>
+    archiveTasks(
+      cell as never,
+      { kind: "task-archive", reason: "Retire", ...action } as RepoTaskAction,
+      binding as never,
+    );
+
+test("archive selection pushes the status filter into one task index scan", () => {
+  const indexQueries: unknown[] = [],
+    cell = selectionCell(indexQueries, [
+      { taskId: "task_recent", updatedAt: "2026-09-10T00:00:00.000Z" },
+      { taskId: "task_old", updatedAt: "2026-08-01T00:00:00.000Z" },
+    ]);
+
+  assert.throws(
+    () => archive(cell, { filter: "state:done", before: "2026-09-01T00:00:00.000Z" }),
+    /SURFACE-READ:task_old/u,
+  );
+  assert.deepEqual(indexQueries, [{ status: "done" }]);
+});
+
+test("archive selection scans unfiltered when no state filter is given", () => {
+  const indexQueries: unknown[] = [],
+    cell = selectionCell(indexQueries, [{ taskId: "task_any", updatedAt: "2026-08-01T00:00:00.000Z" }]);
+
+  assert.throws(() => archive(cell, {}), /SURFACE-READ:task_any/u);
+  assert.deepEqual(indexQueries, [{}]);
+});
+
+test("archive selection keeps rejecting non-ISO before bounds", () => {
+  const indexQueries: unknown[] = [],
+    cell = selectionCell(indexQueries, []);
+
+  assert.throws(() => archive(cell, { filter: "state:done", before: "not-a-date" }), /ISO-compatible/u);
+  assert.deepEqual(indexQueries, []);
+});

--- a/packages/daemon/test/task-query-read.test.ts
+++ b/packages/daemon/test/task-query-read.test.ts
@@ -199,7 +199,31 @@ test("a surface fails closed instead of stitching mismatched projection cuts", (
     /relation graph neighborhood spans multiple event projection cuts/u,
   );
   assert.throws(() => read.guiTasks(), /task control surface spans multiple event projection cuts/u);
-  assert.throws(() => read.agenda(), /task control surface spans multiple event projection cuts/u);
+  assert.throws(() => read.agenda(), /review queue spans multiple event projection cuts/u);
+});
+
+test("agenda reads one narrow lifecycle page per status and no wide-assembly reads", () => {
+  const listCalls: TaskProjectionListQuery[] = [],
+    decisionCalls: string[][] = [],
+    projection = projectionStub({
+      taskRows: [protocolTaskRow("task_event", [], { status: "active" })],
+      listCalls,
+      decisionCalls,
+    });
+
+  const result = queryRead(process.cwd(), projection).agenda();
+
+  assert.deepEqual(listCalls, [
+    { status: "active", limit: 100, pinnedFirst: true },
+    { status: "blocked", limit: 100, pinnedFirst: true },
+    { status: "planned", limit: 100, pinnedFirst: true },
+    { status: "in_review", limit: 100, pinnedFirst: true },
+  ]);
+  assert.deepEqual(decisionCalls, []);
+  assert.deepEqual(
+    result.waitingOnOthers.map(({ taskId }) => taskId),
+    ["task_event"],
+  );
 });
 
 test("task reads fail closed when event truth has no packageDisposition", () => {
@@ -289,6 +313,7 @@ function projectionStub(
     readonly edges?: TaskRelationProjectionRead["rows"];
     readonly calls?: TaskRelationQuery[];
     readonly taskRows?: readonly unknown[];
+    readonly listCalls?: TaskProjectionListQuery[];
     readonly dependencyCalls?: string[][];
     readonly targetCalls?: { targetRefs: readonly string[]; relationType: string }[];
     readonly statusCalls?: string[][];
@@ -301,16 +326,19 @@ function projectionStub(
     edges = options.edges ?? [eventEdge],
     taskRows = options.taskRows ?? [];
   return {
-    list: (query: TaskProjectionListQuery = {}) => ({
-      ...cut,
-      rows: query.status
-        ? taskRows.filter((row) => (row as ReturnType<typeof protocolTaskRow>).snapshot.task.status === query.status)
-        : taskRows,
-      warnings: [],
-      ...(query.limit === undefined
-        ? {}
-        : { page: { limit: query.limit, cursor: query.cursor ?? null, nextCursor: null } }),
-    }),
+    list: (query: TaskProjectionListQuery = {}) => {
+      options.listCalls?.push(query);
+      return {
+        ...cut,
+        rows: query.status
+          ? taskRows.filter((row) => (row as ReturnType<typeof protocolTaskRow>).snapshot.task.status === query.status)
+          : taskRows,
+        warnings: [],
+        ...(query.limit === undefined
+          ? {}
+          : { page: { limit: query.limit, cursor: query.cursor ?? null, nextCursor: null } }),
+      };
+    },
     read: () => ({ ...cut, packagePath: null }),
     readTaskChildCounts: () => options.childCounts ?? {},
     readTaskRelations: () => ({ ...cut, rows: edges }),

--- a/tools/gate-allowlists/check-fallback-boundaries.json
+++ b/tools/gate-allowlists/check-fallback-boundaries.json
@@ -314,6 +314,12 @@
         "reason": "Existing request-path historical scan pending a bounded-read deletion task."
       },
       {
+        "file": "packages/daemon/src/task-action-explanation-read.ts",
+        "function": "readTaskActionExplanation",
+        "task": "task_212cde7d9f5f916bee17bf2c63",
+        "reason": "Person-ref explanation still reads the whole ledger to build the roster at cut (no narrow people read yet); the task/decision refs on this path became point reads in batch 9. Pending a people point-read in batch 17 / G4."
+      },
+      {
         "file": "packages/gui/src/renderer/components/taskDetail/TaskDetailSections.tsx",
         "function": "queryFn",
         "task": "task_403e958e3fefd3496820e8843d",


### PR DESCRIPTION
# English

## Summary

fix-plan batch 9, daemon read-surface scatter (task_212cde7d9f5f916bee17bf2c63, group G1 of the W-H tail audit task_997414da4f72d57e8dfad7097c; parent task_6eba9c5d3a55735920aa4856f3 / task_2b8f79fa4412cb726a26f9bfc7). Six of seven findings land, one is skipped by checkpoint. Agenda (R2-01-F3/F7): the blocking judgment is extracted into one `readBlockingAssessments` shared by the wide `guiTasks` assembly and a new narrow `readAgendaTaskPage`, so the agenda no longer pays for placement scopes, decision reads, per-output evidence ids or board/visibility/closeout it never serves (four wide assemblies per request → narrow lifecycle pages). Task archive (R2-01-F5): the status filter is pushed into the task-index scan instead of reading every gui task and filtering in JS. Explain (R1-03-F2): entity-action explanation becomes a point-read path (head/cut plus four point reads per ref) instead of the whole ledger, the full task list and a witness map of every event. Artifacts (R1-03-F7): kind counting uses the directory entry and extension only and stats just the requested kind. CI observatory (R2-03-F4): quadratic point copies and double derivations removed. Evidence ids (R2-03-F8): the agenda's four sha256 passes disappear with the narrow read. Skipped: lease-release point lookup (R1-01-F1) needs a sibling query in the projection port (a new mechanism in the G4 file set), with the replacement routed to batch 17/G4 in the report. Production +215/-115 in 7 daemon files: the net is positive because the wide assembly stays in service for its other callers and the narrow paths sit beside it; the two findings that would have netted deletions were the skipped one and a caching variant the worker rejected on the no-new-mechanism rule.

## Architectural Justification

- One shared blocking-judgment helper replaces the agenda's use of the wide assembly; no cache, no flag, no second projection. The remaining growth is narrow read paths next to an assembly that other callers still need.

## What Changed

- `packages/daemon/src/task-query-read.ts`: `readBlockingAssessments`, `readAgendaTaskPage`; `guiTasks` uses the shared helper.
- `packages/daemon/src/repo-cell-task-maintenance.ts`: archive status filter pushed into the index scan.
- `packages/daemon/src/task-action-explanation-read.ts`: point-read explain.
- `packages/daemon/src/artifacts-gui-read.ts`: kind counts without statting non-served files.
- `packages/daemon/src/ci-observatory-read.ts`: linear point expansion, single derivations.
- Tests: `task-archive-selection.contract.test.ts` (new), `task-query-read.test.ts`.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: +215/-115 (`packages/*/src`, tests excluded); `tools/gate-allowlists/check-fallback-boundaries.json` +6 (one `fullHistoryScans` entry).

## Machine-Readable Declarations

- Production-Delta: +215/-115

## Task And Scope

- Harness task: task_212cde7d9f5f916bee17bf2c63 (G1), parent task_6eba9c5d3a55735920aa4856f3
- Branch: `codex/perf-g1`
- Public scope: six daemon read files + two tests
- Private planning/evidence updated: yes (`artifacts/report.md`, fact F-8AB9BD7B)
- Out of scope: lease-release point lookup (batch 17 / G4), `rebuildable-task-projection-*`, fleet

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: yes — `tools/gate-allowlists/check-fallback-boundaries.json` (fallback-boundaries ratchet)
- Protected surface scope: one `fullHistoryScans` entry added for `task-action-explanation-read.ts#readTaskActionExplanation`: the person-ref path still reads the whole ledger (as on main, where the same read was written in a shape the gate does not match); the entry names the pending deletion task. No other entry changes; gate semantics unchanged.
- Authority: repository owner authorization for governance fixes in the perf rescue line (2026-09-10/11), recorded in task_212cde7d9f5f916bee17bf2c63
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `3e039d37a`
- Branch merge-base with `origin/main`: `3e039d37a`
- Last `git fetch origin` time: 2026-09-12 UTC
- Sync method: rebased onto origin/main by the worker
- Public diff command: `git diff origin/main...codex/perf-g1`
- Private evidence commit/path: task_212cde7d9f5f916bee17bf2c63 `artifacts/report.md`
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [x] `npm run typecheck` (worker)
- [ ] `npm run check`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts` (via `run-manifest-gates --changed origin/main`, worker)
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Worker (GLM): eight touched integration files each dispatched to the isolated Ubuntu runner, all exit 0; new assertions have a negative control (production change reverted → 5 assertions red, restored → green); fast tier 684 pass; line-density, file-complexity, canonical-event-compat, eslint green.

## Review Evidence

- CEO ground-truth: the boundaries job red was the ratchet keying the surviving person-roster whole-ledger read under the new function; listed with rationale rather than reshaping the call to dodge the gate. Read the agenda commit; the narrow page and the wide assembly share one blocking helper, nothing is cached across polls; the skipped finding and its routing are recorded in the report.
- Reviewer subagent: closeout review after merge
- Human review: pending
- Blocking findings: none open

## Residual Risk

- Explain still reads the whole ledger for person refs (no narrow API; cold path), noted in the report.
- The wide `guiTasks` assembly remains for its other callers; the agenda's savings do not reduce those callers' cost.

## References

- Task: task_212cde7d9f5f916bee17bf2c63; W-H tail audit task_997414da4f72d57e8dfad7097c §G1; fix-plan batch 9

---

# 中文

## 概要

fix-plan 批 9 daemon 读面散点（task_212cde7d9f5f916bee17bf2c63，W-H 尾巴核对 task_997414da4f72d57e8dfad7097c 的 G1 组；父 task_6eba9c5d3a55735920aa4856f3 / task_2b8f79fa4412cb726a26f9bfc7）。七条 finding 落地六条、按 checkpoint 跳过一条。agenda（R2-01-F3/F7）：阻塞判定抽成一个 `readBlockingAssessments`，宽装配 `guiTasks` 与新的窄读 `readAgendaTaskPage` 共用，agenda 不再为它从不返回的 placement scope、decision 读、逐 output evidenceId、board/visibility/closeout 付费（每请求四次宽装配 → 窄的 lifecycle 分页）。task-archive（R2-01-F5）：状态过滤下推进 task-index 扫描，不再读全部 gui task 再在 JS 里过滤。explain（R1-03-F2）：实体动作解释改为点读路径（head/cut 加每 ref 四个点读），不再整本账本 + 全任务列表 + 全事件 witness map。artifacts（R1-03-F7）：kind 计数只看目录项与扩展名，只对请求的 kind 做 stat。CI observatory（R2-03-F4）：去掉 O(P²) 的点复制与重复推导。evidenceId（R2-03-F8）：agenda 的四遍 sha256 随窄读消失。跳过：lease 释放点查（R1-01-F1）需要在投影 port 加兄弟查询（G4 文件集里的新机制），替代方案在报告里排入批 17/G4。生产 +215/-115（7 个 daemon 文件）：净增为正是因为宽装配仍在为其他调用方服务，窄路径立在它旁边；本可净删的两条分别是被跳过的那条与 worker 按「不加机制」纪律否决的缓存变体。

## 架构辩护

- 一个共享的阻塞判定 helper 替换 agenda 对宽装配的使用；不加缓存、不加 flag、不加第二份投影。剩余增量是立在其他调用方仍需的装配旁边的窄读路径。

## 改动内容

- `packages/daemon/src/task-query-read.ts`：`readBlockingAssessments`、`readAgendaTaskPage`；`guiTasks` 改用共享 helper。
- `packages/daemon/src/repo-cell-task-maintenance.ts`：archive 状态过滤下推进索引扫描。
- `packages/daemon/src/task-action-explanation-read.ts`：点读 explain。
- `packages/daemon/src/artifacts-gui-read.ts`：不 stat 非请求 kind 的 kind 计数。
- `packages/daemon/src/ci-observatory-read.ts`：线性点展开、单次推导。
- 测试：`task-archive-selection.contract.test.ts`（新）、`task-query-read.test.ts`。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 删除的门或 fixture：none
- 生产净行数：+215/-115（`packages/*/src` 不含测试）；`tools/gate-allowlists/check-fallback-boundaries.json` +6（一条 `fullHistoryScans` 条目）。

## 机器可读声明

- Production-Delta: +215/-115

## 任务与范围

- Harness 任务：task_212cde7d9f5f916bee17bf2c63（G1），父任务 task_6eba9c5d3a55735920aa4856f3
- 分支：`codex/perf-g1`
- 公开范围：六个 daemon 读文件 + 两个测试
- 私有计划/证据已更新：是（`artifacts/report.md`，事实 F-8AB9BD7B）
- 范围外：lease 释放点查（批 17 / G4）、`rebuildable-task-projection-*`、fleet

## 版本影响

- 版本：不变
- 发布影响：不发布

## 治理声明

- 触碰受保护面：是——`tools/gate-allowlists/check-fallback-boundaries.json`（fallback-boundaries ratchet）
- 受保护面范围：为 `task-action-explanation-read.ts#readTaskActionExplanation` 加一条 `fullHistoryScans` 条目：person ref 路径仍整本读账本（main 上同一读法，只是写法没被门匹配到），条目写明待删除任务。无其他条目改动；门语义不变。
- 授权：仓库所有者对性能抢救线治理修复的授权（2026-09-10/11），记录在 task_212cde7d9f5f916bee17bf2c63
- 机器检查边界：本 PR 只断言声明存在；是否属实、是否充分由评审判断。
- Break-glass：否
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- 基线 `origin/main` SHA：`3e039d37a`
- 分支与 `origin/main` 的 merge-base：`3e039d37a`
- 最近一次 `git fetch origin`：2026-09-12 UTC
- 同步方式：worker rebase 到 origin/main
- 公开 diff 命令：`git diff origin/main...codex/perf-g1`
- 私有证据路径：task_212cde7d9f5f916bee17bf2c63 的 `artifacts/report.md`
- 评审证据路径：本 PR 的评审证据节
- GitHub Actions `rewrite-ci` run URL：本 PR 待跑
- worker（GLM）：八个触碰面 integration 文件逐一隔离 Ubuntu 派测全部 exit 0；新增断言有阴性对照（回退生产改动 → 5 项断言红，恢复 → 绿）；fast 层 684 通过；line-density、file-complexity、canonical-event-compat、eslint 绿。

## 评审证据

- CEO 事实核对：boundaries job 红是 ratchet 把仍存在的 person roster 整本读按新函数计键；登记条目并写明理由，不改写调用形状绕门。读过 agenda 提交；窄分页与宽装配共用一个阻塞 helper，跨 poll 无缓存；跳过项与其去向记录在报告。
- 评审子代理：合入后派收口评审
- 人工评审：待定
- 阻塞发现：无

## 残余风险

- explain 对 person ref 仍整本读（无窄 API；冷路径），报告已注明。
- 宽装配 `guiTasks` 为其他调用方保留；agenda 的节省不减少那些调用方的开销。

## 参考

- 任务：task_212cde7d9f5f916bee17bf2c63；W-H 尾巴核对 task_997414da4f72d57e8dfad7097c §G1；fix-plan 批 9
