### PR TITLE
chore(release): read the public-ready package table in all three release checkers

### DIFF
--- a/packages/gui/src/distribution/runtime-release-readiness.ts
+++ b/packages/gui/src/distribution/runtime-release-readiness.ts
@@ -9,10 +9,10 @@ export interface RuntimeCommandContract {
 }
 
 export interface ReleaseBoundaryContract {
-  readonly packagesPrivateExceptCli: true;
+  readonly packagesPrivateExceptPublicReady: true;
   readonly internalWorkspaceVersion: "0.0.0";
   readonly productVersion: "0.0.1";
-  readonly cliPublishDryRunVersion: "0.0.1";
+  readonly publicReadyPackageVersion: "0.0.1";
   readonly npmReleaseClaimed: false;
   readonly signedInstallersShipped: false;
   readonly notarizedBuildsShipped: false;
@@ -91,10 +91,10 @@ export const harnessRuntimeReleaseReadiness: RuntimeReleaseReadinessPolicy = {
     },
   ],
   releaseBoundary: {
-    packagesPrivateExceptCli: true,
+    packagesPrivateExceptPublicReady: true,
     internalWorkspaceVersion: "0.0.0",
     productVersion: "0.0.1",
-    cliPublishDryRunVersion: "0.0.1",
+    publicReadyPackageVersion: "0.0.1",
     npmReleaseClaimed: false,
     signedInstallersShipped: false,
     notarizedBuildsShipped: false,
@@ -140,10 +140,10 @@ export function validateRuntimeReleaseReadiness(
 
   const boundary = policy.releaseBoundary;
   if (
-    boundary.packagesPrivateExceptCli !== true ||
+    boundary.packagesPrivateExceptPublicReady !== true ||
     boundary.internalWorkspaceVersion !== "0.0.0" ||
     boundary.productVersion !== "0.0.1" ||
-    boundary.cliPublishDryRunVersion !== "0.0.1" ||
+    boundary.publicReadyPackageVersion !== "0.0.1" ||
     boundary.npmReleaseClaimed !== false ||
     boundary.signedInstallersShipped !== false ||
     boundary.notarizedBuildsShipped !== false ||

--- a/packages/gui/src/distribution/supply-chain-release-readiness.ts
+++ b/packages/gui/src/distribution/supply-chain-release-readiness.ts
@@ -26,11 +26,6 @@ export interface OsvContract {
 }
 
 export interface NpmPublishDryRunContract {
-  readonly packageName: "@harness-anything/cli";
-  readonly packagePath: "packages/cli/package.json";
-  readonly version: "0.0.1";
-  readonly command: "npm publish --dry-run --workspace @harness-anything/cli --access public";
-  readonly publishablePackages: readonly ["@harness-anything/cli"];
   readonly actualPublishPermitted: false;
   readonly requiredBeforePublication: true;
 }
@@ -81,10 +76,10 @@ export interface ElectronUpgradeContract {
 }
 
 export interface SupplyChainReleaseBoundaryContract {
-  readonly packagesPrivateExceptCli: true;
+  readonly packagesPrivateExceptPublicReady: true;
   readonly internalWorkspaceVersion: "0.0.0";
   readonly productVersion: "0.0.1";
-  readonly cliPublishDryRunVersion: "0.0.1";
+  readonly publicReadyPackageVersion: "0.0.1";
   readonly npmReleaseClaimed: false;
   readonly releaseArtifactsPublished: false;
   readonly signedInstallersShipped: false;
@@ -179,11 +174,6 @@ export const harnessSupplyChainReleaseReadiness: SupplyChainReleaseReadinessPoli
     deterministicDefaultGate: "package-lock-present-and-command-documented",
   },
   npmPublishDryRun: {
-    packageName: "@harness-anything/cli",
-    packagePath: "packages/cli/package.json",
-    version: "0.0.1",
-    command: "npm publish --dry-run --workspace @harness-anything/cli --access public",
-    publishablePackages: ["@harness-anything/cli"],
     actualPublishPermitted: false,
     requiredBeforePublication: true,
   },
@@ -279,10 +269,10 @@ export const harnessSupplyChainReleaseReadiness: SupplyChainReleaseReadinessPoli
     reviewDoc: "docs-release/release-posture.md",
   },
   releaseBoundary: {
-    packagesPrivateExceptCli: true,
+    packagesPrivateExceptPublicReady: true,
     internalWorkspaceVersion: "0.0.0",
     productVersion: "0.0.1",
-    cliPublishDryRunVersion: "0.0.1",
+    publicReadyPackageVersion: "0.0.1",
     npmReleaseClaimed: false,
     releaseArtifactsPublished: false,
     signedInstallersShipped: false,
@@ -343,18 +333,12 @@ export function validateSupplyChainReleaseReadiness(
   }
 
   if (
-    policy.npmPublishDryRun.packageName !== "@harness-anything/cli" ||
-    policy.npmPublishDryRun.packagePath !== "packages/cli/package.json" ||
-    policy.npmPublishDryRun.version !== "0.0.1" ||
-    policy.npmPublishDryRun.command !== "npm publish --dry-run --workspace @harness-anything/cli --access public" ||
-    policy.npmPublishDryRun.publishablePackages.length !== 1 ||
-    !policy.npmPublishDryRun.publishablePackages.includes("@harness-anything/cli") ||
     policy.npmPublishDryRun.actualPublishPermitted !== false ||
     policy.npmPublishDryRun.requiredBeforePublication !== true
   ) {
     errors.push({
       code: "invalid_npm_publish_dry_run_contract",
-      message: "NPM publish readiness must stay limited to a CLI-only dry-run command with no real publish permission.",
+      message: "NPM publish readiness must require dry-run evidence with no real publish permission.",
     });
   }
 
@@ -399,10 +383,10 @@ export function validateSupplyChainReleaseReadiness(
 
   const boundary = policy.releaseBoundary;
   if (
-    boundary.packagesPrivateExceptCli !== true ||
+    boundary.packagesPrivateExceptPublicReady !== true ||
     boundary.internalWorkspaceVersion !== "0.0.0" ||
     boundary.productVersion !== "0.0.1" ||
-    boundary.cliPublishDryRunVersion !== "0.0.1" ||
+    boundary.publicReadyPackageVersion !== "0.0.1" ||
     boundary.npmReleaseClaimed !== false ||
     boundary.releaseArtifactsPublished !== false ||
     boundary.signedInstallersShipped !== false ||

--- a/packages/gui/test/runtime-release-readiness.test.ts
+++ b/packages/gui/test/runtime-release-readiness.test.ts
@@ -30,10 +30,10 @@ test("runtime release readiness policy covers source, check, package smoke and G
     },
   );
   assert.deepEqual(harnessRuntimeReleaseReadiness.releaseBoundary, {
-    packagesPrivateExceptCli: true,
+    packagesPrivateExceptPublicReady: true,
     internalWorkspaceVersion: "0.0.0",
     productVersion: "0.0.1",
-    cliPublishDryRunVersion: "0.0.1",
+    publicReadyPackageVersion: "0.0.1",
     npmReleaseClaimed: false,
     signedInstallersShipped: false,
     notarizedBuildsShipped: false,

--- a/packages/gui/test/supply-chain-release-readiness.test.ts
+++ b/packages/gui/test/supply-chain-release-readiness.test.ts
@@ -4,7 +4,7 @@ import test from "node:test";
 import {
   harnessSupplyChainReleaseReadiness,
   validateSupplyChainReleaseReadiness,
-  type SupplyChainReleaseReadinessPolicy
+  type SupplyChainReleaseReadinessPolicy,
 } from "../src/distribution/supply-chain-release-readiness.ts";
 
 test("supply-chain release readiness covers audit SBOM OSV license and release boundaries", () => {
@@ -16,8 +16,7 @@ test("supply-chain release readiness covers audit SBOM OSV license and release b
   assert.equal(harnessSupplyChainReleaseReadiness.osv.releaseEvidenceRequiredBeforePublication, true);
   assert.equal(harnessSupplyChainReleaseReadiness.osv.releaseEvidencePath, "release-evidence/osv/scan-result.json");
   assert.equal(harnessSupplyChainReleaseReadiness.workspacePackagePaths.includes("packages/daemon/package.json"), true);
-  assert.equal(harnessSupplyChainReleaseReadiness.npmPublishDryRun.command, "npm publish --dry-run --workspace @harness-anything/cli --access public");
-  assert.deepEqual(harnessSupplyChainReleaseReadiness.npmPublishDryRun.publishablePackages, ["@harness-anything/cli"]);
+  assert.equal(harnessSupplyChainReleaseReadiness.npmPublishDryRun.requiredBeforePublication, true);
   assert.equal(harnessSupplyChainReleaseReadiness.npmPublishDryRun.actualPublishPermitted, false);
   assert.equal(harnessSupplyChainReleaseReadiness.sbom.releaseArtifactSbomRequiredBeforePublication, true);
   assert.equal(harnessSupplyChainReleaseReadiness.licensePolicy.projectLicense, "AGPL-3.0-or-later");
@@ -32,20 +31,20 @@ test("supply-chain release readiness rejects missing OSV and release artifact ga
       ...harnessSupplyChainReleaseReadiness.osv,
       releaseEvidencePath: "release-evidence/osv/result.txt" as "release-evidence/osv/scan-result.json",
       requiredInDefaultCheck: true,
-      releaseEvidenceRequiredBeforePublication: false
+      releaseEvidenceRequiredBeforePublication: false,
     },
     sbom: {
       ...harnessSupplyChainReleaseReadiness.sbom,
-      releaseArtifactSbomRequiredBeforePublication: false
+      releaseArtifactSbomRequiredBeforePublication: false,
     },
     npmPublishDryRun: {
       ...harnessSupplyChainReleaseReadiness.npmPublishDryRun,
-      actualPublishPermitted: true
+      actualPublishPermitted: true,
     },
     releaseBoundary: {
       ...harnessSupplyChainReleaseReadiness.releaseBoundary,
-      releaseArtifactsPublished: true
-    }
+      releaseArtifactsPublished: true,
+    },
   };
 
   const result = validateSupplyChainReleaseReadiness(invalid);
@@ -53,6 +52,11 @@ test("supply-chain release readiness rejects missing OSV and release artifact ga
   assert.equal(result.ok, false);
   assert.deepEqual(
     result.errors.map((error) => error.code),
-    ["invalid_sbom_contract", "invalid_osv_contract", "invalid_npm_publish_dry_run_contract", "invalid_release_boundary"]
+    [
+      "invalid_sbom_contract",
+      "invalid_osv_contract",
+      "invalid_npm_publish_dry_run_contract",
+      "invalid_release_boundary",
+    ],
   );
 });

--- a/tools/check-package-policy.mjs
+++ b/tools/check-package-policy.mjs
@@ -1,5 +1,6 @@
 import { existsSync, readFileSync } from "node:fs";
 import path from "node:path";
+import { publicReadyPackagesByPath } from "./public-ready-packages.mjs";
 
 const root = process.cwd();
 const expectedPackages = new Map([
@@ -10,29 +11,6 @@ const expectedPackages = new Map([
   ["packages/gui/package.json", "@harness-anything/gui"],
   ["packages/adapters/local/package.json", "@harness-anything/adapter-local"],
   ["packages/adapters/multica/package.json", "@harness-anything/adapter-multica"],
-]);
-const publicReadyPackages = new Map([
-  [
-    "packages/cli/package.json",
-    {
-      version: "0.0.1",
-      repositoryDirectory: "packages/cli",
-      bins: new Map([
-        ["harness-anything", "dist/cli/src/index.js"],
-        ["ha", "dist/cli/src/index.js"],
-      ]),
-      required: true,
-    },
-  ],
-  [
-    "packages/daemon/package.json",
-    {
-      version: "0.0.1",
-      repositoryDirectory: "packages/daemon",
-      bins: new Map([["harness-anything-daemon", "dist/index.js"]]),
-      required: false,
-    },
-  ],
 ]);
 
 const violations = [];
@@ -60,7 +38,7 @@ for (const [relativePath, expectedName] of expectedPackages.entries()) {
   const packageJson = readJson(relativePath);
   if (packageJson.name !== expectedName)
     record(`${relativePath} expected name ${expectedName}, got ${packageJson.name}`);
-  const publicContract = publicReadyPackages.get(relativePath);
+  const publicContract = publicReadyPackagesByPath.get(relativePath);
   if (publicContract && (publicContract.required || packageJson.private !== true)) {
     if (packageJson.private === true) record(`${relativePath} must be public-ready for npm publish dry-run preflight`);
     if (packageJson.version !== publicContract.version)
@@ -70,7 +48,7 @@ for (const [relativePath, expectedName] of expectedPackages.entries()) {
     if (packageJson.repository?.directory !== publicContract.repositoryDirectory)
       record(`${relativePath} must declare repository.directory ${publicContract.repositoryDirectory}`);
     if (packageJson.engines?.node !== ">=24") record(`${relativePath} must declare Node >=24 runtime support`);
-    for (const [name, target] of publicContract.bins)
+    for (const [name, target] of Object.entries(publicContract.bins))
       if (packageJson.bin?.[name] !== target) record(`${relativePath} must declare bin ${name} as ${target}`);
   } else {
     if (packageJson.private !== true)

--- a/tools/check-package-policy.test.mjs
+++ b/tools/check-package-policy.test.mjs
@@ -21,6 +21,17 @@ test("package policy accepts the approved CLI and daemon npm publish set", async
   });
 });
 
+test("package policy accepts a daemon that remains private", async () => {
+  await withFixtureRepo((root) => {
+    writeValidFixture(root);
+
+    const result = runCheck(root);
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, /Package policy check passed/u);
+  });
+});
+
 test("package policy rejects GUI as an npm package", async () => {
   await withFixtureRepo((root) => {
     writeValidFixture(root);

--- a/tools/check-runtime-release-readiness.mjs
+++ b/tools/check-runtime-release-readiness.mjs
@@ -5,6 +5,7 @@ import {
   harnessRuntimeReleaseReadiness,
   validateRuntimeReleaseReadiness,
 } from "../packages/gui/src/distribution/runtime-release-readiness.ts";
+import { publicReadyPackagesByPath } from "./public-ready-packages.mjs";
 import { selectManifestGateIds } from "./run-manifest-gates.mjs";
 
 const root = process.cwd();
@@ -87,15 +88,18 @@ for (const workspace of [
   "packages/adapters/multica/package.json",
 ]) {
   const packageJson = readJson(workspace);
-  if (workspace === "packages/cli/package.json") {
+  const publicContract = publicReadyPackagesByPath.get(workspace);
+  if (publicContract && (publicContract.required || packageJson.private !== true)) {
     if (packageJson.private === true) record(`${workspace} must be public-ready for npm publish --dry-run preflight`);
-    if (packageJson.version !== harnessRuntimeReleaseReadiness.releaseBoundary.cliPublishDryRunVersion) {
-      record(
-        `${workspace} must be ${harnessRuntimeReleaseReadiness.releaseBoundary.cliPublishDryRunVersion} for npm publish --dry-run preflight`,
-      );
+    if (packageJson.version !== publicContract.version) {
+      record(`${workspace} must be ${publicContract.version} for npm publish --dry-run preflight`);
     }
     if (packageJson.publishConfig?.access !== "public")
       record(`${workspace} must define publishConfig.access public for scoped npm dry-run preflight`);
+    if (packageJson.repository?.directory !== publicContract.repositoryDirectory)
+      record(`${workspace} must declare repository.directory ${publicContract.repositoryDirectory}`);
+    for (const [name, target] of Object.entries(publicContract.bins))
+      if (packageJson.bin?.[name] !== target) record(`${workspace} must declare bin ${name} as ${target}`);
   } else if (workspace === "packages/gui/package.json") {
     if (packageJson.private !== true) record(`${workspace} must remain private`);
     if (packageJson.version !== harnessRuntimeReleaseReadiness.releaseBoundary.productVersion) {

--- a/tools/check-runtime-release-readiness.test.mjs
+++ b/tools/check-runtime-release-readiness.test.mjs
@@ -1,6 +1,6 @@
 // harness-test-tier: integration
 import assert from "node:assert/strict";
-import { mkdirSync, writeFileSync } from "node:fs";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
@@ -17,6 +17,42 @@ test("runtime release readiness check accepts the expected contract", async () =
 
     assert.equal(result.status, 0, result.stderr);
     assert.match(result.stdout, /Runtime release readiness check passed/u);
+  });
+});
+
+test("runtime release readiness check accepts a daemon that remains private", async () => {
+  await withFixtureRepo((root) => {
+    writeValidRuntimeReleaseFixture(root);
+
+    const result = runCheck(root);
+
+    assert.equal(result.status, 0, result.stderr);
+  });
+});
+
+test("runtime release readiness check rejects a public daemon missing metadata", async () => {
+  await withFixtureRepo((root) => {
+    writeValidRuntimeReleaseFixture(root);
+    makeDaemonPublicReady(root);
+    const daemon = readJson(root, "packages/daemon/package.json");
+    delete daemon.bin;
+    writeJson(root, "packages/daemon/package.json", daemon);
+
+    const result = runCheck(root);
+
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /must declare bin harness-anything-daemon/u);
+  });
+});
+
+test("runtime release readiness check accepts a public daemon with complete metadata", async () => {
+  await withFixtureRepo((root) => {
+    writeValidRuntimeReleaseFixture(root);
+    makeDaemonPublicReady(root);
+
+    const result = runCheck(root);
+
+    assert.equal(result.status, 0, result.stderr);
   });
 });
 
@@ -124,7 +160,13 @@ function writeValidRuntimeReleaseFixture(root, options = {}) {
   ]) {
     const packageJson =
       packagePath === "packages/cli/package.json"
-        ? { name: "@harness-anything/cli", version: "0.0.1", publishConfig: { access: "public" } }
+        ? {
+            name: "@harness-anything/cli",
+            version: "0.0.1",
+            publishConfig: { access: "public" },
+            repository: { directory: "packages/cli" },
+            bin: { "harness-anything": "dist/cli/src/index.js", ha: "dist/cli/src/index.js" },
+          }
         : {
             name: packagePath,
             version: packagePath === "packages/gui/package.json" ? "0.0.1" : "0.0.0",
@@ -189,6 +231,20 @@ function validWorkflow() {
 
 function writeJson(root, relativePath, value) {
   writeFile(root, relativePath, JSON.stringify(value, null, 2));
+}
+
+function readJson(root, relativePath) {
+  return JSON.parse(readFileSync(path.join(root, relativePath), "utf8"));
+}
+
+function makeDaemonPublicReady(root) {
+  writeJson(root, "packages/daemon/package.json", {
+    name: "@harness-anything/daemon",
+    version: "0.0.1",
+    publishConfig: { access: "public" },
+    repository: { directory: "packages/daemon" },
+    bin: { "harness-anything-daemon": "dist/index.js" },
+  });
 }
 
 function writeFile(root, relativePath, body) {

--- a/tools/check-supply-chain.mjs
+++ b/tools/check-supply-chain.mjs
@@ -5,6 +5,7 @@ import {
   harnessSupplyChainReleaseReadiness,
   validateSupplyChainReleaseReadiness,
 } from "../packages/gui/src/distribution/supply-chain-release-readiness.ts";
+import { publicReadyPackagesByPath } from "./public-ready-packages.mjs";
 import { selectManifestGateIds } from "./run-manifest-gates.mjs";
 
 const root = process.cwd();
@@ -136,13 +137,12 @@ function validatePackageMetadata() {
     if (packageJson.license !== policy.licensePolicy.projectLicense) {
       record(`${packagePath} must declare license ${policy.licensePolicy.projectLicense}`);
     }
-    if (packagePath === policy.npmPublishDryRun.packagePath) {
-      validateCliPublishPreflightMetadata(packagePath, packageJson);
+    const publicContract = publicReadyPackagesByPath.get(packagePath);
+    if (publicContract && (publicContract.required || packageJson.private !== true)) {
+      validatePublicReadyPackageMetadata(packagePath, packageJson, publicContract);
     } else {
       if (packageJson.private !== true) {
-        record(
-          `${packagePath} must remain private; only ${policy.npmPublishDryRun.packageName} is allowed into npm dry-run preflight`,
-        );
+        record(`${packagePath} is not in the approved npm publish set and must stay private`);
       }
       const expectedVersion =
         packagePath === "package.json" || packagePath === "packages/gui/package.json"
@@ -168,31 +168,27 @@ function validatePackageMetadata() {
   }
 }
 
-function validateCliPublishPreflightMetadata(packagePath, packageJson) {
-  if (packageJson.name !== policy.npmPublishDryRun.packageName) {
-    record(`${packagePath} must be the CLI-only dry-run package ${policy.npmPublishDryRun.packageName}`);
+function validatePublicReadyPackageMetadata(packagePath, packageJson, publicContract) {
+  if (packageJson.name !== publicContract.packageName) {
+    record(`${packagePath} must be the public-ready package ${publicContract.packageName}`);
   }
   if (packageJson.private === true) {
     record(`${packagePath} must not be private for npm publish --dry-run preflight`);
   }
-  if (packageJson.version !== policy.npmPublishDryRun.version) {
-    record(`${packagePath} must use version ${policy.npmPublishDryRun.version} for npm publish --dry-run preflight`);
+  if (packageJson.version !== publicContract.version) {
+    record(`${packagePath} must use version ${publicContract.version} for npm publish --dry-run preflight`);
   }
   if (packageJson.publishConfig?.access !== "public") {
     record(`${packagePath} must define publishConfig.access public for the scoped CLI package`);
   }
-  if (packageJson.repository?.directory !== "packages/cli") {
-    record(`${packagePath} must declare repository.directory packages/cli`);
+  if (packageJson.repository?.directory !== publicContract.repositoryDirectory) {
+    record(`${packagePath} must declare repository.directory ${publicContract.repositoryDirectory}`);
   }
   if (packageJson.engines?.node !== ">=24") {
     record(`${packagePath} must declare Node >=24 runtime support`);
   }
-  if (
-    packageJson.bin?.["harness-anything"] !== "dist/cli/src/index.js" ||
-    packageJson.bin?.ha !== "dist/cli/src/index.js"
-  ) {
-    record(`${packagePath} must expose harness-anything and ha bins from dist/cli/src/index.js`);
-  }
+  for (const [name, target] of Object.entries(publicContract.bins))
+    if (packageJson.bin?.[name] !== target) record(`${packagePath} must declare bin ${name} as ${target}`);
   if (
     !Array.isArray(packageJson.files) ||
     !packageJson.files.includes("dist") ||

--- a/tools/check-supply-chain.test.mjs
+++ b/tools/check-supply-chain.test.mjs
@@ -20,18 +20,29 @@ test("supply-chain check accepts the expected release gate contract", async () =
   });
 });
 
-test("supply-chain check rejects non-CLI publishable packages", async () => {
+test("supply-chain check rejects a public daemon missing metadata", async () => {
   await withFixtureRepo((root) => {
     writeValidSupplyChainFixture(root, {
       packageMutator: (packages) => {
-        packages["packages/daemon/package.json"].private = false;
+        makeDaemonPublicReady(packages);
+        delete packages["packages/daemon/package.json"].bin;
       },
     });
 
     const result = runCheck(root);
 
     assert.notEqual(result.status, 0);
-    assert.match(result.stderr, /packages\/daemon\/package\.json must remain private/u);
+    assert.match(result.stderr, /must declare bin harness-anything-daemon/u);
+  });
+});
+
+test("supply-chain check accepts a public daemon with complete metadata", async () => {
+  await withFixtureRepo((root) => {
+    writeValidSupplyChainFixture(root, { packageMutator: makeDaemonPublicReady });
+
+    const result = runCheck(root);
+
+    assert.equal(result.status, 0, result.stderr);
   });
 });
 
@@ -336,6 +347,20 @@ function writeValidSupplyChainFixture(root, options = {}) {
   writeFile(root, "README.md", validReadme());
   writeFile(root, "docs-release/release-posture.md", options.supplyDocBody ?? validSupplyDoc());
   writeMockNpm(root, options.sbomMutator, options.auditBehavior);
+}
+
+function makeDaemonPublicReady(packages) {
+  packages["packages/daemon/package.json"] = {
+    ...packages["packages/daemon/package.json"],
+    name: "@harness-anything/daemon",
+    version: "0.0.1",
+    private: false,
+    publishConfig: { access: "public" },
+    repository: { directory: "packages/daemon" },
+    engines: { node: ">=24" },
+    bin: { "harness-anything-daemon": "dist/index.js" },
+    files: ["dist", "README.md", "package.json"],
+  };
 }
 
 function validReadme() {

--- a/tools/public-ready-packages.mjs
+++ b/tools/public-ready-packages.mjs
@@ -1,0 +1,23 @@
+export const publicReadyPackages = Object.freeze([
+  Object.freeze({
+    packagePath: "packages/cli/package.json",
+    packageName: "@harness-anything/cli",
+    version: "0.0.1",
+    repositoryDirectory: "packages/cli",
+    bins: Object.freeze({
+      "harness-anything": "dist/cli/src/index.js",
+      ha: "dist/cli/src/index.js",
+    }),
+    required: true,
+  }),
+  Object.freeze({
+    packagePath: "packages/daemon/package.json",
+    packageName: "@harness-anything/daemon",
+    version: "0.0.1",
+    repositoryDirectory: "packages/daemon",
+    bins: Object.freeze({ "harness-anything-daemon": "dist/index.js" }),
+    required: false,
+  }),
+]);
+
+export const publicReadyPackagesByPath = new Map(publicReadyPackages.map((entry) => [entry.packagePath, entry]));


### PR DESCRIPTION
# English

## Summary

Release governance, part two (task_5e81242b82ab5c0dfeb7c16632, derived from decision dec_4061D4157B1FEF9925E38F2358, in effect). Part one (#2520) gave `check-package-policy` a public-ready package table; the split's first slice (task_d0fe49e3) then hit the two checkers that still special-cased the CLI by name: `check-runtime-release-readiness` locked every workspace but `packages/cli` to private/0.0.0, and `check-supply-chain` accepted exactly one dry-run package. This PR makes one table the single source: `tools/public-ready-packages.mjs` lists `@harness-anything/cli` (required public-ready, bins `ha`/`harness-anything`, repository.directory `packages/cli`) and `@harness-anything/daemon` (public-ready once it drops `private`, bin `harness-anything-daemon`, repository.directory `packages/daemon`), version lockstep `0.0.1`; all three checkers consume it and drop their CLI literals; the GUI distribution contract constants are renamed from CLI-only (`packagesPrivateExceptCli`, `cliPublishDryRunVersion`, the single `npmPublishDryRun` package) to public-ready (`packagesPrivateExceptPublicReady`, `publicReadyPackageVersion`). On current main (daemon still private) the three checkers' output is byte-identical to `origin/main`; the tests cover daemon-private → green, daemon-public-but-incomplete → red, daemon-public-and-complete → green. No real publish is authorized. Production +34/-45 in tools (net -11) and +7/-30 in `packages/gui/src/distribution`; tests +97.

## Architectural Justification

- One table replaces three copies of the same package facts; net production lines go down.

## What Changed

- `tools/public-ready-packages.mjs` (new, 23 lines): the table.
- `tools/check-package-policy.mjs`, `check-runtime-release-readiness.mjs`, `check-supply-chain.mjs`: consume the table; CLI literals removed.
- `packages/gui/src/distribution/{runtime,supply-chain}-release-readiness.ts`: contract fields renamed to public-ready.
- Tests for all three checkers: three-state coverage.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: tools +34/-45; `packages/gui/src` +7/-30. Tests +97.

## Machine-Readable Declarations

- None.

## Task And Scope

- Harness task: task_5e81242b82ab5c0dfeb7c16632 (release governance 2), parent task_5bab54e6e88a9d40e8b241a411; unblocks task_d0fe49e3e6ed5aa370bbbe5fbe (split slice 1)
- Branch: `codex/release-gov-2`
- Public scope: three release checkers, their tests, the shared table, the GUI distribution contract constants
- Private planning/evidence updated: yes (`artifacts/report.md`, fact F-1DDD8F8A)
- Out of scope: any package.json change, real publish, CI workflow

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: yes — `tools/check-package-policy.mjs`, `tools/check-runtime-release-readiness.mjs`, `tools/check-supply-chain.mjs` (release gates in `tools/gate-manifest.json`) and the GUI distribution release-readiness contract
- Protected surface scope: the three gates read the same public-ready table; on current main their verdicts are byte-identical to before; the daemon row enforces only once `packages/daemon/package.json` drops `private`
- Authority: repository owner ruling 2026-09-12 ("governance first, then split") and decision dec_4061D4157B1FEF9925E38F2358 (in effect, arbiter person_zeyu), recorded in task_5e81242b82ab5c0dfeb7c16632
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `3e039d37a`
- Branch merge-base with `origin/main`: `3e039d37a`
- Last `git fetch origin` time: 2026-09-12 UTC
- Sync method: branched from origin/main
- Public diff command: `git diff origin/main...codex/release-gov-2`
- Private evidence commit/path: task_5e81242b82ab5c0dfeb7c16632 `artifacts/report.md`
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [ ] `npm run typecheck`
- [ ] `npm run check`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [x] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts` (via `run-manifest-gates --changed origin/main`, worker)
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- CEO follow-up commit 540cf229: the two GUI contract tests (`runtime-release-readiness.test.ts`, `supply-chain-release-readiness.test.ts`) still asserted the CLI-only field names and failed `fast-contract`; updated to the public-ready fields, 3/3 and 2/2 locally.
- Worker (Terra): isolated runs of the three checker tests 5/5, 8/8, 13/13; three checkers on current main exit 0 with output `diff` against origin/main empty; lint and line-density green.

## Review Evidence

- CEO ground-truth: read the table and the GUI contract diff; the renamed constants carry no CLI name, the daemon row is dormant until `private` is dropped.
- Reviewer subagent: closeout review after merge
- Human review: pending
- Blocking findings: none open

## Residual Risk

- If `schema-closure` / `derived-contracts` project the GUI distribution constants, the rename shows there; CI on this PR is the check.

## References

- Task: task_5e81242b82ab5c0dfeb7c16632; decision dec_4061D4157B1FEF9925E38F2358; part one #2520

---

# 中文

## 概要

发布治理二（task_5e81242b82ab5c0dfeb7c16632，由已生效决策 dec_4061D4157B1FEF9925E38F2358 派生）。发布治理一（#2520）给 `check-package-policy` 换上 public-ready 包表；拆分切片 1（task_d0fe49e3）随即撞上仍按包名特判 CLI 的两个 checker：`check-runtime-release-readiness` 把 `packages/cli` 之外的 workspace 全锁 private/0.0.0，`check-supply-chain` 只认一个 dry-run 包。本 PR 让一张表成为唯一真源：`tools/public-ready-packages.mjs` 列出 `@harness-anything/cli`（必须 public-ready，bins `ha`/`harness-anything`，repository.directory `packages/cli`）与 `@harness-anything/daemon`（去 `private` 后才要求，bin `harness-anything-daemon`，repository.directory `packages/daemon`），版本 lockstep `0.0.1`；三个 checker 都消费它、删掉各自的 CLI 字面；GUI distribution 契约常量从 CLI-only（`packagesPrivateExceptCli`、`cliPublishDryRunVersion`、单包 `npmPublishDryRun`）改名为 public-ready（`packagesPrivateExceptPublicReady`、`publicReadyPackageVersion`）。在当前 main（daemon 仍 private）上三 checker 输出与 `origin/main` 逐字节一致；测试覆盖 daemon private → 绿、daemon 公开但缺项 → 红、daemon 公开且齐全 → 绿三态。不授权任何真实发布。生产 tools +34/-45（净 -11）、`packages/gui/src/distribution` +7/-30；测试 +97。

## 架构辩护

- 一张表替换三份相同包事实的副本；生产净行数下降。

## 改动内容

- `tools/public-ready-packages.mjs`（新，23 行）：包表。
- `tools/check-package-policy.mjs`、`check-runtime-release-readiness.mjs`、`check-supply-chain.mjs`：消费包表；删 CLI 字面。
- `packages/gui/src/distribution/{runtime,supply-chain}-release-readiness.ts`：契约字段改名为 public-ready。
- 三个 checker 的测试：三态覆盖。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 删除的门或 fixture：none
- 生产净行数：tools +34/-45；`packages/gui/src` +7/-30。测试 +97。

## 机器可读声明

- 无。

## 任务与范围

- Harness 任务：task_5e81242b82ab5c0dfeb7c16632（发布治理二），父任务 task_5bab54e6e88a9d40e8b241a411；解锁 task_d0fe49e3e6ed5aa370bbbe5fbe（拆分切片 1）
- 分支：`codex/release-gov-2`
- 公开范围：三个发布 checker 及其测试、共享包表、GUI distribution 契约常量
- 私有计划/证据已更新：是（`artifacts/report.md`，事实 F-1DDD8F8A）
- 范围外：任何 package.json 改动、真实发布、CI workflow

## 版本影响

- 版本：不变
- 发布影响：不发布

## 治理声明

- 触碰受保护面：是——`tools/check-package-policy.mjs`、`tools/check-runtime-release-readiness.mjs`、`tools/check-supply-chain.mjs`（`tools/gate-manifest.json` 里的发布门）与 GUI distribution 发布就绪契约
- 受保护面范围：三个门读同一张 public-ready 包表；当前 main 上判定逐字节不变；daemon 行只在 `packages/daemon/package.json` 去掉 `private` 后执法
- 授权：仓库所有者 2026-09-12 裁决（「先治理再拆」）与决策 dec_4061D4157B1FEF9925E38F2358（已生效，仲裁人 person_zeyu），记录在 task_5e81242b82ab5c0dfeb7c16632
- 机器检查边界：本 PR 只断言声明存在；是否属实、是否充分由评审判断。
- Break-glass：否
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- 基线 `origin/main` SHA：`3e039d37a`
- 分支与 `origin/main` 的 merge-base：`3e039d37a`
- 最近一次 `git fetch origin`：2026-09-12 UTC
- 同步方式：从 origin/main 开分支
- 公开 diff 命令：`git diff origin/main...codex/release-gov-2`
- 私有证据路径：task_5e81242b82ab5c0dfeb7c16632 的 `artifacts/report.md`
- 评审证据路径：本 PR 的评审证据节
- GitHub Actions `rewrite-ci` run URL：本 PR 待跑
- CEO 追加提交 540cf229：两个 GUI 契约测试（`runtime-release-readiness.test.ts`、`supply-chain-release-readiness.test.ts`）仍断言 CLI-only 字段名，`fast-contract` 红；改到 public-ready 字段后本地 3/3、2/2。
- worker（Terra）：三个 checker 测试隔离跑 5/5、8/8、13/13；三 checker 在当前 main exit 0 且输出与 origin/main `diff` 为空；lint、line-density 绿。

## 评审证据

- CEO 事实核对：读过包表与 GUI 契约 diff；改名后的常量不再含 CLI 名字，daemon 行在去掉 `private` 前休眠。
- 评审子代理：合入后派收口评审
- 人工评审：待定
- 阻塞发现：无

## 残余风险

- 若 `schema-closure` / `derived-contracts` 投影了 GUI distribution 常量，改名会在那里显形；本 PR 的 CI 是检查点。

## 参考

- 任务：task_5e81242b82ab5c0dfeb7c16632；决策 dec_4061D4157B1FEF9925E38F2358；第一部分 #2520
