### PR TITLE
perf(fleet): narrow repeated reads and full-blob compares in fleet sync paths

### DIFF
--- a/packages/cli/test/daemon-fleet-cli.test.ts
+++ b/packages/cli/test/daemon-fleet-cli.test.ts
@@ -146,7 +146,7 @@ test(
       assert.equal(pulled.viewId, "edge-one-view");
       assert.equal((pulled.cut as { revision: number }).revision, pulled.ackCut);
       const viewRoot = path.join(fixture.viewRoot, "repos", "fleet-demo", "views", "edge-one-view");
-      assert.equal(readFileSync(path.join(viewRoot, "cuts", String(pulled.ackCut), "files", docPath), "utf8"), docBody);
+      assert.equal(readCutFile(viewRoot, pulled.ackCut as number, docPath), docBody);
       assert.equal(
         readFileSync(path.join(fixture.edgeRepo, "harness", docPath), "utf8"),
         docBody,
@@ -241,6 +241,20 @@ function retryReplicaPending(sync: () => Record<string, unknown>): Record<string
     if (last.ok !== false || last.code !== "replica_pending") return last;
   }
   return last;
+}
+// Snapshot cuts address their blobs through the verified edge CAS instead of
+// materializing cuts/<revision>/files/, so a cut document is read through its
+// manifest entry (delta cuts materialize changed files, snapshots do not).
+function readCutFile(viewRoot: string, revision: number, logical: string): string {
+  const manifest = JSON.parse(readFileSync(path.join(viewRoot, "cuts", String(revision), "manifest.json"), "utf8")) as {
+    entries: readonly { readonly path: string; readonly blob: { readonly sha256: string } }[];
+  };
+  const entry = manifest.entries.find((row) => row.path === logical);
+  if (entry === undefined) throw new Error(`cut ${revision} manifest has no entry for ${logical}`);
+  return readFileSync(
+    path.join(path.resolve(viewRoot, "..", ".."), "cas", "sha256", entry.blob.sha256.slice(0, 2), entry.blob.sha256),
+    "utf8",
+  );
 }
 function setup(): {
   root: string;

--- a/packages/daemon/src/durable-file.ts
+++ b/packages/daemon/src/durable-file.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { closeSync, fsyncSync, mkdirSync, openSync, renameSync, rmSync, writeFileSync } from "node:fs";
+import { closeSync, fsyncSync, mkdirSync, openSync, readSync, renameSync, rmSync, writeFileSync } from "node:fs";
 import path from "node:path";
 
 // Windows refuses fsync on a handle that was not opened for writing: FlushFileBuffers needs
@@ -54,4 +54,20 @@ export function writeFileDurably(file: string, body: string | Uint8Array, mode?:
     throw error;
   }
   syncDirectory(directory);
+}
+
+// Positioned read for replay comparison: both fleet upload paths retry one
+// chunk against a durable prefix that can be far larger than the contested
+// window. A short read returns the shorter buffer so callers can reject it by
+// comparison. This is the only read-only file handle outside the flush ports
+// above (#1586: one implementation per capability).
+export function readFileWindow(file: string, offset: number, length: number): Buffer {
+  const descriptor = openSync(file, "r");
+  try {
+    const window = Buffer.alloc(length);
+    const read = readSync(descriptor, window, 0, length, offset);
+    return read === length ? window : window.subarray(0, read);
+  } finally {
+    closeSync(descriptor);
+  }
 }

--- a/packages/daemon/src/fleet-edge-mirror.ts
+++ b/packages/daemon/src/fleet-edge-mirror.ts
@@ -14,12 +14,13 @@ import {
   openSync,
   readFileSync,
   readdirSync,
+  renameSync,
   rmSync,
   statSync,
   unlinkSync,
   writeFileSync,
 } from "node:fs";
-import { randomBytes } from "node:crypto";
+import { randomBytes, randomUUID } from "node:crypto";
 import path from "node:path";
 import {
   classifyRawArtifactPath,
@@ -249,13 +250,24 @@ export function locateFleetMirrorView(viewRoot: string, repoId: string, viewId?:
 // Pre-pull base caching (F3): while the marker cut is still the view's
 // CURRENT cut it is guaranteed on disk, so caching the base bytes of every
 // dirty path at scan time — before the pull that can collect that cut — keeps
-// base/ stageable no matter how many revisions the next pull jumps.
-export function cacheFleetMirrorDirtyBases(viewRoot: string, repoId: string, workspaceRoot: string): void {
+// base/ stageable no matter how many revisions the next pull jumps. The scan
+// this needs is the same dirty-detection callers perform, so it is returned
+// for reuse: a round that scans once feeds both the cache and its carry set.
+export function cacheFleetMirrorDirtyBases(
+  viewRoot: string,
+  repoId: string,
+  workspaceRoot: string,
+): FleetMirrorScan | null {
   const view = locateFleetMirrorView(viewRoot, repoId);
   const materializedRoot = fleetMirrorMaterializedRoot(workspaceRoot);
-  if (view === null || !existsSync(materializedRoot)) return;
-  const dirty = scanFleetMirrorWorktree(view, workspaceRoot).changes.map((change) => change.path);
-  if (dirty.length > 0) fleetMirrorRefreshBaseCache(view, dirty);
+  if (view === null || !existsSync(materializedRoot)) return null;
+  const scan = scanFleetMirrorWorktree(view, workspaceRoot);
+  if (scan.changes.length > 0)
+    fleetMirrorRefreshBaseCache(
+      view,
+      scan.changes.map((change) => change.path),
+    );
+  return scan;
 }
 
 export function scanFleetMirrorWorktree(
@@ -280,8 +292,9 @@ export function scanFleetMirrorWorktree(
       const raw = classifyRawArtifactPath(logical);
       if (raw === null) continue;
       const rawTarget = path.join(materializedRoot, ...logical.split("/")),
+        rawBytes = readFileSync(rawTarget),
         rawBase = view.entries.get(logical) ?? null;
-      if (rawBase !== null && rawBase.sha256 === sha256Bytes(readFileSync(rawTarget))) {
+      if (rawBase !== null && rawBase.size === rawBytes.byteLength && rawBase.sha256 === sha256Bytes(rawBytes)) {
         cleanCount += 1;
         continue;
       }
@@ -323,7 +336,9 @@ export function scanFleetMirrorWorktree(
     }
     const bytes = readFileSync(target),
       base = view.entries.get(logical) ?? null;
-    if (base !== null && base.sha256 === sha256Bytes(bytes)) {
+    // A size mismatch already proves divergence; only equal sizes need the
+    // hash to decide clean.
+    if (base !== null && base.size === bytes.byteLength && base.sha256 === sha256Bytes(bytes)) {
       cleanCount += 1;
       continue;
     }
@@ -417,9 +432,9 @@ export function applyFleetMirrorCut(
       }
       continue;
     }
-    const centerBytes = fleetMirrorCutFile(view.viewDir, view.revision, logical);
-    mkdirSync(path.dirname(path.join(materializedRoot, ...logical.split("/"))), { recursive: true });
-    if (centerBytes !== null) writeFileDurably(path.join(materializedRoot, ...logical.split("/")), centerBytes);
+    const centerBytes = fleetMirrorCutFile(view.viewDir, view.revision, logical),
+      target = path.join(materializedRoot, ...logical.split("/"));
+    if (centerBytes !== null) writeFileMaterialized(target, centerBytes);
     nextBlobs[logical] = blob.sha256;
   }
   // Center deletions: a locally untouched path follows the deletion; a locally
@@ -463,11 +478,20 @@ export function applyFleetMirrorCut(
     rows,
     stage,
   );
-  fleetMirrorWriteJson(path.join(view.viewDir, materializationMarker), {
-    revision: view.revision,
-    manifestDigest: view.manifestDigest,
-    blobs: nextBlobs,
-  });
+  // An unchanged marker (same revision, digest, and per-path base map) skips
+  // the durable rewrite — the same equality guard the base cache uses below.
+  const markerUnchanged =
+    marker !== null &&
+    marker.revision === view.revision &&
+    marker.manifestDigest === view.manifestDigest &&
+    Object.keys(marker.blobs).length === Object.keys(nextBlobs).length &&
+    Object.entries(nextBlobs).every(([logical, sha]) => marker.blobs[logical] === sha);
+  if (!markerUnchanged)
+    fleetMirrorWriteJson(path.join(view.viewDir, materializationMarker), {
+      revision: view.revision,
+      manifestDigest: view.manifestDigest,
+      blobs: nextBlobs,
+    });
   rmSync(path.join(view.viewDir, "worktree"), { recursive: true, force: true });
   return {
     outcome: conflicts.length > 0 ? "pull_blocked" : "applied",
@@ -499,9 +523,7 @@ export function stageFleetConflict(
     ] as const)
       if (bytes !== null) {
         fleetMirrorAssertLogical(file.path);
-        const target = path.join(dir, side, ...file.path.split("/"));
-        mkdirSync(path.dirname(target), { recursive: true });
-        writeFileDurably(target, bytes);
+        writeFileMaterialized(path.join(dir, side, ...file.path.split("/")), bytes);
       }
   const record: FleetConflictRecord = {
     ...input.record,
@@ -578,10 +600,8 @@ export function restoreFleetConflictCenterBytes(
 ): void {
   const source = fleetConflictSideFile(workspaceRoot, conflictId, row.path, "center");
   const target = path.join(fleetMirrorMaterializedRoot(workspaceRoot), ...row.path.split("/"));
-  if (source !== null) {
-    mkdirSync(path.dirname(target), { recursive: true });
-    writeFileDurably(target, readFileSync(source));
-  } else rmSync(target, { force: true });
+  if (source !== null) writeFileMaterialized(target, readFileSync(source));
+  else rmSync(target, { force: true });
 }
 
 // A re-detected divergence reuses its unresolved record instead of staging a
@@ -758,6 +778,22 @@ function fleetMirrorAssertLogical(value: string): void {
 }
 function fleetMirrorWriteJson(file: string, value: unknown): void {
   writeFileDurably(file, Buffer.from(`${JSON.stringify(value, null, 2)}\n`));
+}
+// Materialized workspace bytes are a projection of the durable replica cut
+// (viewDir/cuts + CAS); a crash mid-write is repaired by the next
+// materialization, so they need rename atomicity but not per-file fsync.
+// Durable writes stay reserved for the marker and the dirty-base cache, the
+// two records a later round cannot reconstruct.
+function writeFileMaterialized(file: string, bytes: Uint8Array): void {
+  mkdirSync(path.dirname(file), { recursive: true });
+  const temp = `${file}.${process.pid}.${randomUUID()}.tmp`;
+  try {
+    writeFileSync(temp, bytes);
+    renameSync(temp, file);
+  } catch (error) {
+    rmSync(temp, { force: true });
+    throw error;
+  }
 }
 function fleetMirrorReadJson<T>(file: string): T | null {
   if (!existsSync(file) || !statSync(file).isFile()) return null;

--- a/packages/daemon/src/fleet-edge-mirror.ts
+++ b/packages/daemon/src/fleet-edge-mirror.ts
@@ -14,13 +14,12 @@ import {
   openSync,
   readFileSync,
   readdirSync,
-  renameSync,
   rmSync,
   statSync,
   unlinkSync,
   writeFileSync,
 } from "node:fs";
-import { randomBytes, randomUUID } from "node:crypto";
+import { randomBytes } from "node:crypto";
 import path from "node:path";
 import {
   classifyRawArtifactPath,
@@ -434,7 +433,7 @@ export function applyFleetMirrorCut(
     }
     const centerBytes = fleetMirrorCutFile(view.viewDir, view.revision, logical),
       target = path.join(materializedRoot, ...logical.split("/"));
-    if (centerBytes !== null) writeFileMaterialized(target, centerBytes);
+    if (centerBytes !== null) writeFileDurably(target, centerBytes);
     nextBlobs[logical] = blob.sha256;
   }
   // Center deletions: a locally untouched path follows the deletion; a locally
@@ -523,7 +522,7 @@ export function stageFleetConflict(
     ] as const)
       if (bytes !== null) {
         fleetMirrorAssertLogical(file.path);
-        writeFileMaterialized(path.join(dir, side, ...file.path.split("/")), bytes);
+        writeFileDurably(path.join(dir, side, ...file.path.split("/")), bytes);
       }
   const record: FleetConflictRecord = {
     ...input.record,
@@ -600,7 +599,7 @@ export function restoreFleetConflictCenterBytes(
 ): void {
   const source = fleetConflictSideFile(workspaceRoot, conflictId, row.path, "center");
   const target = path.join(fleetMirrorMaterializedRoot(workspaceRoot), ...row.path.split("/"));
-  if (source !== null) writeFileMaterialized(target, readFileSync(source));
+  if (source !== null) writeFileDurably(target, readFileSync(source));
   else rmSync(target, { force: true });
 }
 
@@ -778,22 +777,6 @@ function fleetMirrorAssertLogical(value: string): void {
 }
 function fleetMirrorWriteJson(file: string, value: unknown): void {
   writeFileDurably(file, Buffer.from(`${JSON.stringify(value, null, 2)}\n`));
-}
-// Materialized workspace bytes are a projection of the durable replica cut
-// (viewDir/cuts + CAS); a crash mid-write is repaired by the next
-// materialization, so they need rename atomicity but not per-file fsync.
-// Durable writes stay reserved for the marker and the dirty-base cache, the
-// two records a later round cannot reconstruct.
-function writeFileMaterialized(file: string, bytes: Uint8Array): void {
-  mkdirSync(path.dirname(file), { recursive: true });
-  const temp = `${file}.${process.pid}.${randomUUID()}.tmp`;
-  try {
-    writeFileSync(temp, bytes);
-    renameSync(temp, file);
-  } catch (error) {
-    rmSync(temp, { force: true });
-    throw error;
-  }
 }
 function fleetMirrorReadJson<T>(file: string): T | null {
   if (!existsSync(file) || !statSync(file).isFile()) return null;

--- a/packages/daemon/src/fleet-edge-task.ts
+++ b/packages/daemon/src/fleet-edge-task.ts
@@ -35,7 +35,6 @@ import {
   cacheFleetMirrorDirtyBases,
   locateFleetMirrorView,
   readFleetUnresolvedConflicts,
-  scanFleetMirrorWorktree,
   withFleetMirrorLock,
   type FleetMirrorView,
   type FleetStagedConflict,
@@ -317,13 +316,15 @@ export async function runFleetEdgeTask(input: FleetEdgeTaskRequest): Promise<Rec
     if (taskId === null || workspaceRoot === null || action.kind === "task-create") return null;
     const view = locateFleetMirrorView(payload.viewRoot, payload.repoId);
     if (view === null) return null;
-    cacheFleetMirrorDirtyBases(payload.viewRoot, payload.repoId, workspaceRoot);
+    // The pre-pull base-cache scan over this same view and tree is exactly the
+    // dirty-detection the carry set needs; reuse it instead of scanning twice.
+    const preScan = cacheFleetMirrorDirtyBases(payload.viewRoot, payload.repoId, workspaceRoot);
     const packagePath = fleetExactTaskPackagePath(view, workspaceRoot, taskId);
-    if (packagePath === null) return null;
+    if (packagePath === null || preScan === null) return null;
     const scope = fleetEdgeScopePaths(payload.assignmentId, payload.rosterPath);
     const inScope = (changePath: string): boolean =>
       scope === null || scope.some((allowed) => changePath === allowed || changePath.startsWith(`${allowed}/`));
-    const candidates = scanFleetMirrorWorktree(view, workspaceRoot).changes.filter(
+    const candidates = preScan.changes.filter(
       (change) => change.path.startsWith(`${packagePath}/`) && inScope(change.path),
     );
     if (candidates.length === 0) return null;

--- a/packages/daemon/src/fleet/center-listener.ts
+++ b/packages/daemon/src/fleet/center-listener.ts
@@ -1,13 +1,10 @@
 import { isSquadControlResult } from "../squad-control-result.ts";
 import {
   appendFileSync,
-  closeSync,
   existsSync,
   lstatSync,
   mkdirSync,
-  openSync,
   readFileSync,
-  readSync,
   renameSync,
   statSync,
   writeFileSync,
@@ -15,10 +12,9 @@ import {
 import path from "node:path";
 import { createServer, type Server } from "node:tls";
 import { resolveHarnessLayout, sha256Bytes } from "../../../kernel/src/index.ts";
-import { syncDirectory, syncFile } from "../durable-file.ts";
+import { readFileWindow, syncDirectory, syncFile } from "../durable-file.ts";
 import { openFleetLeaseBroker } from "../lease-broker.ts";
 import { openPersistentWriterEpoch, readLedgerWriterEpoch, type PersistentWriterEpoch } from "../writer-epoch.ts";
-import type { RepoCellStatus } from "../repo-cell-types.ts";
 import {
   brokerHost as brokerHostImpl,
   discardOwnedClaims as discardOwnedClaimsImpl,
@@ -59,25 +55,15 @@ export async function listenFleetTls(options: FleetCenterOptions): Promise<Fleet
       holderId: options.writerId,
       now,
     }),
-    ownedEpochs = new Map<string, ReturnType<PersistentWriterEpoch["acquire"]>>();
-  // Repo rows answer per-frame staging lookups (upload paths, epoch reads);
-  // host.status() rebuilds every cell's status, so cache one row per repoId and
-  // refresh only for a repoId the cache has never seen. A repo that attaches
-  // after the listener starts is picked up on its first use; a cached rootDir
-  // outliving a detach is inert because staging writes still pass through
-  // host.run's own cell admission.
-  const repoRows = new Map<string, RepoCellStatus>(),
-    repoRowOf = (repoId: string): RepoCellStatus | undefined => {
-      if (!repoRows.has(repoId)) for (const repo of options.host.status().repos) repoRows.set(repo.repoId, repo);
-      return repoRows.get(repoId);
-    },
+    ownedEpochs = new Map<string, ReturnType<PersistentWriterEpoch["acquire"]>>(),
     acquireWriterEpoch =
       options.writerEpochLease ??
-      ((repoId: string) => writerEpoch.acquire(repoId, readLedgerWriterEpoch(repoId, repoRowOf(repoId)?.rootDir)));
-  for (const repo of options.host.status().repos) {
-    repoRows.set(repo.repoId, repo);
+      ((repoId: string) => {
+        const rootDir = options.host.status().repos.find((repo) => repo.repoId === repoId)?.rootDir;
+        return writerEpoch.acquire(repoId, readLedgerWriterEpoch(repoId, rootDir));
+      });
+  for (const repo of options.host.status().repos)
     if (repo.state === "attached") ownedEpochs.set(repo.repoId, acquireWriterEpoch(repo.repoId));
-  }
   // A center must keep using the epoch it acquired, even after another center
   // advances the shared state. Reading the latest row here would let a stale
   // process silently adopt its successor's epoch and defeat fencing.
@@ -170,9 +156,8 @@ export async function listenFleetTls(options: FleetCenterOptions): Promise<Fleet
     return value;
   };
   const repoRoot = (repoId: string) => {
-    const found = repoRowOf(repoId);
-    if (!found || found.state !== "attached")
-      throw new FleetFault("repo_unavailable", `Repo ${repoId} is unavailable.`, true);
+    const found = options.host.status().repos.find((repo) => repo.repoId === repoId && repo.state === "attached");
+    if (!found) throw new FleetFault("repo_unavailable", `Repo ${repoId} is unavailable.`, true);
     return found.rootDir;
   };
   const assertFrameEpoch = (repoId: string, provided: number): void => {
@@ -298,15 +283,8 @@ export async function listenFleetTls(options: FleetCenterOptions): Promise<Fleet
       if (frame.offset < length) {
         // Replay comparison reads only the contested window; the durable
         // prefix can be far larger than the chunk being retried.
-        const descriptor = openSync(file, "r");
-        try {
-          const window = Buffer.alloc(bytes.length),
-            read = readSync(descriptor, window, 0, bytes.length, frame.offset);
-          if (read !== bytes.length || !window.equals(bytes))
-            throw new FleetFault("upload_replay_mismatch", "Replayed chunk differs from durable bytes.");
-        } finally {
-          closeSync(descriptor);
-        }
+        if (!readFileWindow(file, frame.offset, bytes.length).equals(bytes))
+          throw new FleetFault("upload_replay_mismatch", "Replayed chunk differs from durable bytes.");
       } else {
         appendFileSync(file, bytes);
         syncFile(file);

--- a/packages/daemon/src/fleet/center-listener.ts
+++ b/packages/daemon/src/fleet/center-listener.ts
@@ -1,10 +1,13 @@
 import { isSquadControlResult } from "../squad-control-result.ts";
 import {
   appendFileSync,
+  closeSync,
   existsSync,
   lstatSync,
   mkdirSync,
+  openSync,
   readFileSync,
+  readSync,
   renameSync,
   statSync,
   writeFileSync,
@@ -15,6 +18,7 @@ import { resolveHarnessLayout, sha256Bytes } from "../../../kernel/src/index.ts"
 import { syncDirectory, syncFile } from "../durable-file.ts";
 import { openFleetLeaseBroker } from "../lease-broker.ts";
 import { openPersistentWriterEpoch, readLedgerWriterEpoch, type PersistentWriterEpoch } from "../writer-epoch.ts";
+import type { RepoCellStatus } from "../repo-cell-types.ts";
 import {
   brokerHost as brokerHostImpl,
   discardOwnedClaims as discardOwnedClaimsImpl,
@@ -55,15 +59,25 @@ export async function listenFleetTls(options: FleetCenterOptions): Promise<Fleet
       holderId: options.writerId,
       now,
     }),
-    ownedEpochs = new Map<string, ReturnType<PersistentWriterEpoch["acquire"]>>(),
+    ownedEpochs = new Map<string, ReturnType<PersistentWriterEpoch["acquire"]>>();
+  // Repo rows answer per-frame staging lookups (upload paths, epoch reads);
+  // host.status() rebuilds every cell's status, so cache one row per repoId and
+  // refresh only for a repoId the cache has never seen. A repo that attaches
+  // after the listener starts is picked up on its first use; a cached rootDir
+  // outliving a detach is inert because staging writes still pass through
+  // host.run's own cell admission.
+  const repoRows = new Map<string, RepoCellStatus>(),
+    repoRowOf = (repoId: string): RepoCellStatus | undefined => {
+      if (!repoRows.has(repoId)) for (const repo of options.host.status().repos) repoRows.set(repo.repoId, repo);
+      return repoRows.get(repoId);
+    },
     acquireWriterEpoch =
       options.writerEpochLease ??
-      ((repoId: string) => {
-        const rootDir = options.host.status().repos.find((repo) => repo.repoId === repoId)?.rootDir;
-        return writerEpoch.acquire(repoId, readLedgerWriterEpoch(repoId, rootDir));
-      });
-  for (const repo of options.host.status().repos)
+      ((repoId: string) => writerEpoch.acquire(repoId, readLedgerWriterEpoch(repoId, repoRowOf(repoId)?.rootDir)));
+  for (const repo of options.host.status().repos) {
+    repoRows.set(repo.repoId, repo);
     if (repo.state === "attached") ownedEpochs.set(repo.repoId, acquireWriterEpoch(repo.repoId));
+  }
   // A center must keep using the epoch it acquired, even after another center
   // advances the shared state. Reading the latest row here would let a stale
   // process silently adopt its successor's epoch and defeat fencing.
@@ -156,8 +170,9 @@ export async function listenFleetTls(options: FleetCenterOptions): Promise<Fleet
     return value;
   };
   const repoRoot = (repoId: string) => {
-    const found = options.host.status().repos.find((repo) => repo.repoId === repoId && repo.state === "attached");
-    if (!found) throw new FleetFault("repo_unavailable", `Repo ${repoId} is unavailable.`, true);
+    const found = repoRowOf(repoId);
+    if (!found || found.state !== "attached")
+      throw new FleetFault("repo_unavailable", `Repo ${repoId} is unavailable.`, true);
     return found.rootDir;
   };
   const assertFrameEpoch = (repoId: string, provided: number): void => {
@@ -281,12 +296,17 @@ export async function listenFleetTls(options: FleetCenterOptions): Promise<Fleet
       if (frame.offset > length)
         throw new FleetFault("upload_gap", "Chunk offset is beyond the durable prefix.", true, length);
       if (frame.offset < length) {
-        if (
-          !readFileSync(file)
-            .subarray(frame.offset, frame.offset + bytes.length)
-            .equals(bytes)
-        )
-          throw new FleetFault("upload_replay_mismatch", "Replayed chunk differs from durable bytes.");
+        // Replay comparison reads only the contested window; the durable
+        // prefix can be far larger than the chunk being retried.
+        const descriptor = openSync(file, "r");
+        try {
+          const window = Buffer.alloc(bytes.length),
+            read = readSync(descriptor, window, 0, bytes.length, frame.offset);
+          if (read !== bytes.length || !window.equals(bytes))
+            throw new FleetFault("upload_replay_mismatch", "Replayed chunk differs from durable bytes.");
+        } finally {
+          closeSync(descriptor);
+        }
       } else {
         appendFileSync(file, bytes);
         syncFile(file);

--- a/packages/daemon/src/fleet/edge.ts
+++ b/packages/daemon/src/fleet/edge.ts
@@ -7,6 +7,7 @@ import {
   openSync,
   readFileSync,
   readdirSync,
+  readSync,
   renameSync,
   rmSync,
   statSync,
@@ -152,12 +153,16 @@ export function openFleetEdgeView(
         const length = existsSync(target) ? statSync(target).size : 0;
         if (frame.offset > length) throw new Error("chunk gap");
         if (frame.offset < length) {
-          if (
-            !readFileSync(target)
-              .subarray(frame.offset, frame.offset + bytes.length)
-              .equals(bytes)
-          )
-            throw new Error("chunk replay mismatch");
+          // Replay comparison reads only the contested window; the staged blob
+          // can be far larger than the chunk being retried.
+          const descriptor = openSync(target, "r");
+          try {
+            const window = Buffer.alloc(bytes.length),
+              read = readSync(descriptor, window, 0, bytes.length, frame.offset);
+            if (read !== bytes.length || !window.equals(bytes)) throw new Error("chunk replay mismatch");
+          } finally {
+            closeSync(descriptor);
+          }
         } else {
           const usedBytes = accountedDiskBytes();
           if (usedBytes + bytes.byteLength > diskQuotaBytes)
@@ -226,7 +231,6 @@ function finish(
       entries.reduce((sum, entry) => sum + entry.blob.size, 0) !== begin.manifest.totalBytes
     )
       throw new Error("snapshot manifest count mismatch");
-    mkdirSync(files, { recursive: true });
   } else {
     const previous = readJson<Current>(path.join(viewRoot, "current.json"));
     if (!previous || JSON.stringify(previous.cut) !== JSON.stringify(begin.fromCut))
@@ -238,7 +242,6 @@ function finish(
     if (changes.length !== begin.changeCount) throw new Error("delta change count mismatch");
     // Delta cuts keep a complete manifest and materialize only changed files;
     // unchanged bytes remain addressable through the verified edge CAS.
-    mkdirSync(files, { recursive: true });
     for (const change of changes) {
       entries = entries.filter((entry) => entry.path !== change.path);
       const target = path.join(files, change.path);
@@ -250,7 +253,8 @@ function finish(
   const changedPaths = new Set(changes.filter((change) => change.op === "put").map((change) => change.path));
   for (const entry of entries) {
     // A delta base is an immutable cut whose bytes were verified before its
-    // current pointer was published. Only incoming puts need CAS revalidation.
+    // current pointer was published; only its incoming puts need CAS
+    // revalidation. A snapshot ingests every blob below.
     if (begin.schema === "fleet.delta.begin/v1" && !changedPaths.has(entry.path)) continue;
     const cas = path.join(casRoot, entry.blob.sha256.slice(0, 2), entry.blob.sha256),
       incoming = path.join(staging, "blobs", entry.blob.sha256);
@@ -260,6 +264,9 @@ function finish(
           throw new Error("transfer blob missing");
         writeFileDurably(cas, Buffer.alloc(0));
       } else {
+        // Incoming bytes are hashed exactly once, here; the CAS file is the
+        // verified rename of them, and a CAS blob that already exists was
+        // verified when it was written, so no read-back rehash follows.
         const bytes = readFileSync(incoming);
         if (bytes.byteLength !== entry.blob.size || sha256Bytes(bytes) !== entry.blob.sha256)
           throw new Error("transfer blob mismatch");
@@ -267,12 +274,14 @@ function finish(
         renameSync(incoming, cas);
       }
     }
-    const bytes = readFileSync(cas);
-    if (bytes.byteLength !== entry.blob.size || sha256Bytes(bytes) !== entry.blob.sha256)
-      throw new Error("edge CAS blob mismatch");
-    const target = path.join(files, entry.path);
-    mkdirSync(path.dirname(target), { recursive: true });
-    cpSync(cas, target);
+    // Delta cuts materialize changed files beside their manifest; a snapshot
+    // cut addresses every blob through the verified CAS instead of copying
+    // the whole tree into cuts/<revision>/files/.
+    if (begin.schema === "fleet.delta.begin/v1") {
+      const target = path.join(files, entry.path);
+      mkdirSync(path.dirname(target), { recursive: true });
+      cpSync(cas, target);
+    }
   }
   const digest = fleetManifestDigest(entries);
   if (digest !== expected) throw new Error("result manifest mismatch");

--- a/packages/daemon/src/fleet/edge.ts
+++ b/packages/daemon/src/fleet/edge.ts
@@ -7,7 +7,6 @@ import {
   openSync,
   readFileSync,
   readdirSync,
-  readSync,
   renameSync,
   rmSync,
   statSync,
@@ -17,7 +16,7 @@ import path from "node:path";
 import { connect, type TLSSocket } from "node:tls";
 import { consumeKnownError, type LedgerCutIdentity } from "../../../kernel/src/index.ts";
 import { sha256Bytes } from "../../../kernel/src/index.ts";
-import { writeFileDurably } from "../durable-file.ts";
+import { readFileWindow, writeFileDurably } from "../durable-file.ts";
 import {
   FLEET_CHUNK_BYTES,
   FLEET_SESSION_SEND_WINDOW_BYTES,
@@ -155,14 +154,8 @@ export function openFleetEdgeView(
         if (frame.offset < length) {
           // Replay comparison reads only the contested window; the staged blob
           // can be far larger than the chunk being retried.
-          const descriptor = openSync(target, "r");
-          try {
-            const window = Buffer.alloc(bytes.length),
-              read = readSync(descriptor, window, 0, bytes.length, frame.offset);
-            if (read !== bytes.length || !window.equals(bytes)) throw new Error("chunk replay mismatch");
-          } finally {
-            closeSync(descriptor);
-          }
+          if (!readFileWindow(target, frame.offset, bytes.length).equals(bytes))
+            throw new Error("chunk replay mismatch");
         } else {
           const usedBytes = accountedDiskBytes();
           if (usedBytes + bytes.byteLength > diskQuotaBytes)

--- a/packages/daemon/src/fleet/replica-cut-store.ts
+++ b/packages/daemon/src/fleet/replica-cut-store.ts
@@ -22,6 +22,13 @@ import {
 } from "./contract.ts";
 import { writeFileDurably } from "../durable-file.ts";
 
+type DocumentClaim = {
+  readonly path: string;
+  readonly sha256: string;
+  readonly size: number;
+  readonly mediaType: string;
+};
+
 export interface SnapshotCut {
   readonly repoId: string;
   readonly revision: number;
@@ -75,8 +82,9 @@ export function openReplicaCutSource(options: ReplicaCutSourceOptions): ReplicaC
     if (database) return database;
     mkdirSync(root, { recursive: true });
     database = new DatabaseSync(databasePath);
+    database.exec("PRAGMA journal_mode=WAL; PRAGMA synchronous=FULL;");
     database.exec(
-      "PRAGMA journal_mode = DELETE; CREATE TABLE IF NOT EXISTS cut (repo_id TEXT NOT NULL, revision INTEGER PRIMARY KEY, head_digest TEXT NOT NULL, manifest_digest TEXT NOT NULL, entry_count INTEGER NOT NULL, total_bytes INTEGER NOT NULL, event_occurred_at TEXT NOT NULL); CREATE TABLE IF NOT EXISTS change (repo_id TEXT NOT NULL, from_revision INTEGER NOT NULL, to_revision INTEGER NOT NULL, path TEXT NOT NULL, op TEXT NOT NULL, blob_sha256 TEXT, size INTEGER, media_type TEXT, PRIMARY KEY(repo_id, from_revision, to_revision, path));",
+      "CREATE TABLE IF NOT EXISTS cut (repo_id TEXT NOT NULL, revision INTEGER PRIMARY KEY, head_digest TEXT NOT NULL, manifest_digest TEXT NOT NULL, entry_count INTEGER NOT NULL, total_bytes INTEGER NOT NULL, event_occurred_at TEXT NOT NULL); CREATE TABLE IF NOT EXISTS change (repo_id TEXT NOT NULL, from_revision INTEGER NOT NULL, to_revision INTEGER NOT NULL, path TEXT NOT NULL, op TEXT NOT NULL, blob_sha256 TEXT, size INTEGER, media_type TEXT, PRIMARY KEY(repo_id, from_revision, to_revision, path));",
     );
     return database;
   };
@@ -132,16 +140,14 @@ export function openReplicaCutSource(options: ReplicaCutSourceOptions): ReplicaC
       throw new Error(`replica manifest ${row.manifest_digest} is corrupt`);
     return JSON.parse(bytes) as FleetEntry[];
   };
-  const writeManifest = (entries: readonly FleetEntry[]) => {
-    const bytes = stableStringify(entries),
-      digest = sha256Text(bytes),
-      target = manifestPath(digest);
+  const writeManifest = (manifest: { readonly bytes: string; readonly digest: string }) => {
+    const target = manifestPath(manifest.digest);
     if (existsSync(target)) {
-      if (readFileSync(target, "utf8") !== bytes) throw new Error(`replica manifest CAS collision ${digest}`);
-      return digest;
+      if (readFileSync(target, "utf8") !== manifest.bytes)
+        throw new Error(`replica manifest CAS collision ${manifest.digest}`);
+      return;
     }
-    writeFileDurably(target, bytes);
-    return digest;
+    writeFileDurably(target, manifest.bytes);
   };
   const prune = (store: DatabaseSync) => {
     const retained = store
@@ -158,65 +164,77 @@ export function openReplicaCutSource(options: ReplicaCutSourceOptions): ReplicaC
     store.prepare("DELETE FROM change WHERE from_revision < ?").run(oldest);
     return digests;
   };
-  const persist = (
+  // Cut rows are inserted inside the caller's round transaction; manifest files
+  // for pruned digests are unlinked only after that transaction commits, so a
+  // rollback restores rows whose files are still on disk.
+  const persistCut = (
+    store: DatabaseSync,
     event: CanonicalEventV1,
     entries: readonly FleetEntry[],
-    previous?: { readonly revision: number; readonly entries: readonly FleetEntry[] },
-  ) => {
-    const digest = writeManifest(entries),
-      headDigest = `sha256:${sha256Text(
+    claims: readonly DocumentClaim[],
+    previous: { readonly revision: number; readonly entries: readonly FleetEntry[] } | null,
+    digest: string,
+  ): { readonly cut: SnapshotCut; readonly pruned: readonly string[] } => {
+    const headDigest = `sha256:${sha256Text(
         serializeEventHead({
           revision: event.workspaceRevision,
           opId: event.opId,
           eventDigest: `sha256:${sha256Text(serializePersistedCanonicalEvent(event))}`,
         }),
       )}`,
-      store = db(),
       prior = new Map(previous?.entries.map((entry) => [entry.path, entry])),
-      next = new Map(entries.map((entry) => [entry.path, entry])),
+      // nextEntries only ever adds or replaces claim paths, so the delta against
+      // the previous cut is exactly the claims whose blob fields differ.
       changes = previous
-        ? [
-            ...entries
-              .filter((entry) => stableStringify(prior.get(entry.path)?.blob) !== stableStringify(entry.blob))
-              .map((entry) => ({ op: "put" as const, path: entry.path, blob: entry.blob })),
-            ...previous.entries
-              .filter((entry) => !next.has(entry.path))
-              .map((entry) => ({ op: "delete" as const, path: entry.path })),
-          ]
-        : [];
-    let pruned: string[];
+        ? claims
+            .filter((claim) => {
+              const before = prior.get(claim.path)?.blob;
+              return (
+                before === undefined ||
+                before.sha256 !== claim.sha256 ||
+                before.size !== claim.size ||
+                before.mediaType !== claim.mediaType
+              );
+            })
+            .map((claim) => ({
+              path: claim.path,
+              blob: { sha256: claim.sha256, size: claim.size, mediaType: claim.mediaType },
+            }))
+        : [],
+      insertCut = store.prepare(
+        "INSERT OR IGNORE INTO cut(repo_id, revision, head_digest, manifest_digest, entry_count, total_bytes, event_occurred_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
+      ),
+      insertChange = store.prepare(
+        "INSERT OR IGNORE INTO change(repo_id, from_revision, to_revision, path, op, blob_sha256, size, media_type) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+      );
+    insertCut.run(
+      options.repoId,
+      event.workspaceRevision,
+      headDigest,
+      digest,
+      entries.length,
+      entries.reduce((sum, entry) => sum + entry.blob.size, 0),
+      event.occurredAt,
+    );
+    for (const change of changes)
+      insertChange.run(
+        options.repoId,
+        previous!.revision,
+        event.workspaceRevision,
+        change.path,
+        "put",
+        change.blob.sha256,
+        change.blob.size,
+        change.blob.mediaType,
+      );
+    return { cut: latest()!, pruned: prune(store) };
+  };
+  const transact = (store: DatabaseSync, body: () => readonly string[]): readonly string[] => {
     store.exec("BEGIN IMMEDIATE");
     try {
-      store
-        .prepare(
-          "INSERT OR IGNORE INTO cut(repo_id, revision, head_digest, manifest_digest, entry_count, total_bytes, event_occurred_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
-        )
-        .run(
-          options.repoId,
-          event.workspaceRevision,
-          headDigest,
-          digest,
-          entries.length,
-          entries.reduce((sum, entry) => sum + entry.blob.size, 0),
-          event.occurredAt,
-        );
-      for (const change of changes)
-        store
-          .prepare(
-            "INSERT OR IGNORE INTO change(repo_id, from_revision, to_revision, path, op, blob_sha256, size, media_type) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
-          )
-          .run(
-            options.repoId,
-            previous!.revision,
-            event.workspaceRevision,
-            change.path,
-            change.op,
-            change.op === "put" ? change.blob.sha256 : null,
-            change.op === "put" ? change.blob.size : null,
-            change.op === "put" ? change.blob.mediaType : null,
-          );
-      pruned = prune(store);
+      const pruned = body();
       store.exec("COMMIT");
+      return pruned;
     } catch (error) {
       try {
         store.exec("ROLLBACK");
@@ -225,13 +243,28 @@ export function openReplicaCutSource(options: ReplicaCutSourceOptions): ReplicaC
       }
       throw error;
     }
-    for (const orphan of pruned)
+  };
+  const unlinkOrphanManifests = (store: DatabaseSync, digests: readonly string[]): void => {
+    for (const orphan of digests)
       if (
         !store.prepare("SELECT 1 FROM cut WHERE manifest_digest = ? LIMIT 1").get(orphan) &&
         existsSync(manifestPath(orphan))
       )
         unlinkSync(manifestPath(orphan));
-    return latest()!;
+  };
+  const persistInitial = (event: CanonicalEventV1, entries: readonly FleetEntry[]): SnapshotCut => {
+    const bytes = stableStringify(entries),
+      digest = sha256Text(bytes),
+      store = db();
+    let cut!: SnapshotCut;
+    const pruned = transact(store, () => {
+      const persisted = persistCut(store, event, entries, canonicalDocumentClaims(event), null, digest);
+      cut = persisted.cut;
+      writeManifest({ bytes, digest });
+      return persisted.pruned;
+    });
+    unlinkOrphanManifests(store, pruned);
+    return cut;
   };
   const entriesFrom = (basis: ReplicaProjectionBasis) =>
     basis.documents
@@ -240,9 +273,9 @@ export function openReplicaCutSource(options: ReplicaCutSourceOptions): ReplicaC
         blob: { sha256: blobSha256, size, mediaType },
       }))
       .sort((left, right) => left.path.localeCompare(right.path));
-  const nextEntries = (prior: readonly FleetEntry[], event: CanonicalEventV1) => {
+  const nextEntries = (prior: readonly FleetEntry[], claims: readonly DocumentClaim[]) => {
     const entries = new Map(prior.map((entry) => [entry.path, entry]));
-    for (const claim of canonicalDocumentClaims(event))
+    for (const claim of claims)
       entries.set(claim.path, {
         path: claim.path,
         blob: { sha256: claim.sha256, size: claim.size, mediaType: claim.mediaType },
@@ -256,33 +289,62 @@ export function openReplicaCutSource(options: ReplicaCutSourceOptions): ReplicaC
     for (const row of rows) row.resolve(cut);
   };
   const runRound = () => {
-    let prior = latest();
-    if (!prior) {
+    const initial = latest();
+    if (!initial) {
       const basis = options.readBasis(null);
       if (basis.watermark === 0 || basis.watermark !== basis.sourceRevision || !basis.headEvent) return false;
-      prior = persist(basis.headEvent, entriesFrom(basis));
-      settle(prior);
+      const first = persistInitial(basis.headEvent, entriesFrom(basis));
+      settle(first);
       return false;
     }
-    const basis = options.readBasis(prior.revision),
-      started = monotonicNow();
-    let entries = manifest(prior.revision)!,
+    const basis = options.readBasis(initial.revision),
+      started = monotonicNow(),
+      store = db();
+    let entries = manifest(initial.revision)!,
+      current: SnapshotCut = initial,
       processed = 0;
-    for (const event of basis.events) {
-      if (processed > 0 && monotonicNow() - started >= 100) break;
-      if (event.workspaceRevision !== prior.revision + 1) throw new Error(`replica cut gap after ${prior.revision}`);
-      const before = entries;
-      entries = nextEntries(entries, event);
-      if (
-        event.workspaceRevision === basis.watermark &&
-        fleetManifestDigest(entries) !== fleetManifestDigest(entriesFrom(basis))
-      )
-        throw new Error(`replica manifest drift at revision ${event.workspaceRevision}`);
-      prior = persist(event, entries, { revision: prior.revision, entries: before });
-      settle(prior);
-      processed += 1;
-    }
-    return prior.revision < basis.watermark;
+    const settled: SnapshotCut[] = [],
+      pruned: string[] = [];
+    // One transaction drains the whole round: each commit under the old
+    // rollback journal paid its own journal fsync chain per event. Waiters are
+    // settled only after the commit, so a rolled-back round resolves nobody.
+    // Manifest files stay per-revision because delta offers address any
+    // retained revision, not only round-final ones.
+    transact(store, () => {
+      for (const event of basis.events) {
+        if (processed > 0 && monotonicNow() - started >= 100) break;
+        if (event.workspaceRevision !== current.revision + 1)
+          throw new Error(`replica cut gap after ${current.revision}`);
+        const before = entries,
+          claims = canonicalDocumentClaims(event);
+        entries = nextEntries(entries, claims);
+        if (
+          event.workspaceRevision === basis.watermark &&
+          fleetManifestDigest(entries) !== fleetManifestDigest(entriesFrom(basis))
+        )
+          throw new Error(`replica manifest drift at revision ${event.workspaceRevision}`);
+        const bytes = stableStringify(entries),
+          digest = sha256Text(bytes),
+          manifest = { bytes, digest };
+        writeManifest(manifest);
+        const persisted = persistCut(
+          store,
+          event,
+          entries,
+          claims,
+          { revision: current.revision, entries: before },
+          digest,
+        );
+        current = persisted.cut;
+        settled.push(persisted.cut);
+        pruned.push(...persisted.pruned);
+        processed += 1;
+      }
+      return pruned;
+    });
+    unlinkOrphanManifests(store, pruned);
+    for (const cut of settled) settle(cut);
+    return current.revision < basis.watermark;
   };
   const waiters = new Map<
     number,
@@ -298,7 +360,7 @@ export function openReplicaCutSource(options: ReplicaCutSourceOptions): ReplicaC
     const basis = options.readBasis(null),
       cut =
         basis.watermark > 0 && basis.watermark === basis.sourceRevision && basis.headEvent
-          ? persist(basis.headEvent, entriesFrom(basis))
+          ? persistInitial(basis.headEvent, entriesFrom(basis))
           : null;
     if (cut) settle(cut);
     else kick();
@@ -332,23 +394,34 @@ export function openReplicaCutSource(options: ReplicaCutSourceOptions): ReplicaC
     kick();
     return promise;
   };
-  const changeLog = () =>
-    (
-      db()
-        .prepare("SELECT * FROM change ORDER BY from_revision, to_revision, path")
-        .all() as unknown as readonly Record<string, unknown>[]
-    ).map((row) => ({
-      fromRevision: Number(row.from_revision),
-      toRevision: Number(row.to_revision),
-      change:
-        row.op === "put"
-          ? {
-              op: "put" as const,
-              path: String(row.path),
-              blob: { sha256: String(row.blob_sha256), size: Number(row.size), mediaType: String(row.media_type) },
-            }
-          : { op: "delete" as const, path: String(row.path) },
-    }));
+  const changeRowOf = (row: Record<string, unknown>): ReplicaChangeLogEntry => ({
+    fromRevision: Number(row.from_revision),
+    toRevision: Number(row.to_revision),
+    change:
+      row.op === "put"
+        ? {
+            op: "put" as const,
+            path: String(row.path),
+            blob: { sha256: String(row.blob_sha256), size: Number(row.size), mediaType: String(row.media_type) },
+          }
+        : { op: "delete" as const, path: String(row.path) },
+  });
+  const changeRows = (range?: { readonly from: number; readonly to: number }): readonly ReplicaChangeLogEntry[] => {
+    const store = db(),
+      rows =
+        range === undefined
+          ? (store
+              .prepare("SELECT * FROM change ORDER BY from_revision, to_revision, path")
+              .all() as unknown as readonly Record<string, unknown>[])
+          : (store
+              .prepare(
+                "SELECT * FROM change WHERE from_revision >= ? AND to_revision <= ? " +
+                  "ORDER BY from_revision, to_revision, path",
+              )
+              .all(range.from, range.to) as unknown as readonly Record<string, unknown>[]);
+    return rows.map(changeRowOf);
+  };
+  const changeLog = () => changeRows();
   const changes = (fromRevision: number, toRevision: number) => {
     const cuts = db()
       .prepare("SELECT revision FROM cut WHERE revision >= ? AND revision <= ? ORDER BY revision")
@@ -359,10 +432,7 @@ export function openReplicaCutSource(options: ReplicaCutSourceOptions): ReplicaC
     )
       return null;
     const folded = new Map<string, FleetDeltaChange>();
-    for (const row of changeLog().filter(
-      (entry) => entry.fromRevision >= fromRevision && entry.toRevision <= toRevision,
-    ))
-      folded.set(row.change.path, row.change);
+    for (const row of changeRows({ from: fromRevision, to: toRevision })) folded.set(row.change.path, row.change);
     return [...folded.values()].sort((left, right) => left.path.localeCompare(right.path));
   };
   const content = (blob: FleetBlob) => {

--- a/packages/daemon/test/durable-file.test.ts
+++ b/packages/daemon/test/durable-file.test.ts
@@ -51,8 +51,9 @@ test("a durable write that cannot rename takes its own temporary with it", () =>
 
 // #1586 was one defect repeated in six modules and fixed in three of them, because each module
 // restated the flush sequence itself. Windows rejects fsync on a read-only handle, so a bare
-// `openSync(target, "r")` anywhere in this package is that defect coming back; the port is the
-// one place allowed to hold such a handle, and only for a directory it then skips on win32.
+// `openSync(target, "r")` anywhere in this package is that defect coming back; the one module
+// allowed to hold such a handle is the durable-file port itself — the flush path skips
+// directories on win32, and the windowed replay read never flushes at all.
 test("#1586: a read-only handle is opened for flushing in exactly one module", () => {
   const offenders = sourceFiles(sourceRoot)
     .filter((file) => /openSync\([^)]*, "r"\)/u.test(readFileSync(file, "utf8")))

--- a/packages/daemon/test/fleet-center-admission.integration.test.ts
+++ b/packages/daemon/test/fleet-center-admission.integration.test.ts
@@ -127,7 +127,9 @@ async function admissionFixture(t: TestContext, initialState: "warming" | "unava
       return repoState === null ? live : { ...live, repos: live.repos.map((row) => ({ ...row, state: repoState })) };
     },
   };
+  const centers: FleetTlsCenter[] = [];
   t.after(async () => {
+    for (const center of centers.splice(0)) await center.close();
     try {
       await opened.close();
     } finally {
@@ -146,10 +148,6 @@ async function admissionFixture(t: TestContext, initialState: "warming" | "unava
     expiresAt: "2099-01-01T00:00:00.000Z",
     actor: { principal: { personId: "admission-owner" }, executor: { kind: "agent", id: "fleet-edge" } },
   };
-  const centers: FleetTlsCenter[] = [];
-  t.after(async () => {
-    for (const center of centers.splice(0)) await center.close();
-  });
   const center = await listenFleetTls({
     host,
     stateRoot,

--- a/packages/daemon/test/fleet-center-admission.integration.test.ts
+++ b/packages/daemon/test/fleet-center-admission.integration.test.ts
@@ -1,0 +1,224 @@
+// harness-test-tier: integration
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { hostname, tmpdir } from "node:os";
+import path from "node:path";
+import test, { type TestContext } from "node:test";
+import { connect, type TLSSocket } from "node:tls";
+import { sha256Bytes } from "../../kernel/src/index.ts";
+import { openDaemonHost } from "../src/daemon-host.ts";
+import { listenFleetTls, type FleetAssignmentRecord, type FleetTlsCenter } from "../src/fleet/center.ts";
+import {
+  currentFleetProtocolVersion,
+  parseFleetFrame,
+  serializeFleetFrame,
+  type FleetFrameV1,
+} from "../src/fleet/contract.ts";
+import { fleetHostWriterOptions } from "./fleet-store.fixture.ts";
+import { registerBootstrappedDaemonRepo as registerDaemonRepo } from "./repo-settings.fixture.ts";
+
+const replicaQuota = 64 * 1024 * 1024;
+
+// Repo admission is dynamic host lifecycle state: the registry replaces a
+// repo's row when it transitions warming→attached or detaches, and upload
+// staging resolves the repo root per frame. These tests restates the row the
+// same way the registry does and require every staging frame to consult the
+// live host status instead of a row cached when the listener started.
+test("upload staging follows a repo that attaches after the listener started", { timeout: 30_000 }, async (t) => {
+  const fixture = await admissionFixture(t, "warming");
+  const rejected = await uploadBegin(fixture, 1);
+  assert.equal(rejected.schema, "fleet.error/v1");
+  if (rejected.schema === "fleet.error/v1") assert.equal(rejected.code, "repo_unavailable");
+  fixture.setRepoState(null);
+  const admitted = await uploadBegin(fixture, 2);
+  assert.equal(admitted.schema, "fleet.upload.ready/v1");
+  if (admitted.schema === "fleet.upload.ready/v1") assert.equal(admitted.status, "receiving");
+});
+
+test("upload staging is refused once an attached repo detaches", { timeout: 30_000 }, async (t) => {
+  const fixture = await admissionFixture(t, null);
+  const admitted = await uploadBegin(fixture, 1);
+  assert.equal(admitted.schema, "fleet.upload.ready/v1");
+  fixture.setRepoState("unavailable");
+  const rejected = await uploadBegin(fixture, 2);
+  assert.equal(rejected.schema, "fleet.error/v1");
+  if (rejected.schema === "fleet.error/v1") assert.equal(rejected.code, "repo_unavailable");
+});
+
+// `initialState` overrides the repo row the listener observes from its first
+// status read; `setRepoState` restates the row afterward, mirroring how the
+// host registry swaps entries on warming→attached and on detach.
+async function admissionFixture(t: TestContext, initialState: "warming" | "unavailable" | null) {
+  const root = mkdtempSync(path.join(tmpdir(), "ha-fleet-admission-")),
+    repo = path.join(root, "repo"),
+    userRoot = path.join(root, "user"),
+    stateRoot = path.join(root, "state"),
+    keyFile = path.join(root, "tls.key"),
+    certFile = path.join(root, "tls.crt");
+  mkdirSync(path.join(repo, "harness"), { recursive: true });
+  const git = (...args: readonly string[]): string =>
+    execFileSync("git", ["-C", repo, ...args], { encoding: "utf8" }).trim();
+  git("init", "-q");
+  git("config", "user.name", "Admission Test");
+  git("config", "user.email", "admission@example.invalid");
+  git("commit", "--allow-empty", "-qm", "base");
+  writeFileSync(
+    path.join(repo, "harness/harness.yaml"),
+    "schema: harness-anything/v1\nname: admission\nlayout:\n  authoredRoot: harness\n  localRoot: .harness\n",
+  );
+  writeFileSync(
+    path.join(repo, "harness/people.yaml"),
+    `${JSON.stringify(
+      {
+        schema: "harness-people/v1",
+        people: [
+          {
+            personId: "admission-owner",
+            displayName: "Admission Owner",
+            roles: ["owner"],
+            credentials: [
+              {
+                kind: "unix-socket-owner-boundary",
+                issuer: `host:${hostname()}`,
+                subject: String(process.getuid?.() ?? 0),
+              },
+            ],
+          },
+        ],
+        roles: [{ roleId: "owner", commandClasses: ["admin", "repo-write", "repo-read", "arbiter"] }],
+      },
+      null,
+      2,
+    )}\n`,
+  );
+  git("add", "harness");
+  git("commit", "-qm", "harness");
+  registerDaemonRepo({ canonicalRoot: repo, repoId: "admission-repo", userRoot, createConvenienceLinks: false });
+  execFileSync(
+    "openssl",
+    [
+      "req",
+      "-x509",
+      "-newkey",
+      "rsa:2048",
+      "-nodes",
+      "-keyout",
+      keyFile,
+      "-out",
+      certFile,
+      "-subj",
+      "/CN=localhost",
+      "-days",
+      "1",
+      "-addext",
+      "subjectAltName=DNS:localhost",
+    ],
+    { stdio: "ignore" },
+  );
+  const key = readFileSync(keyFile),
+    cert = readFileSync(certFile),
+    opened = await openDaemonHost({ daemonId: "fleet-admission", userRoot });
+  let repoState = initialState;
+  const host = {
+    ...opened,
+    status: () => {
+      const live = opened.status();
+      return repoState === null ? live : { ...live, repos: live.repos.map((row) => ({ ...row, state: repoState })) };
+    },
+  };
+  t.after(async () => {
+    try {
+      await opened.close();
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+  await opened.attachmentsSettled();
+  const assignment: FleetAssignmentRecord = {
+    nodeId: "node-one",
+    assignmentId: "assignment-one",
+    repoId: "admission-repo",
+    taskId: "task-admission",
+    executionId: "execution-admission",
+    paths: ["tasks/task-admission-admission/notes.md"],
+    viewId: "node-one-view",
+    expiresAt: "2099-01-01T00:00:00.000Z",
+    actor: { principal: { personId: "admission-owner" }, executor: { kind: "agent", id: "fleet-edge" } },
+  };
+  const centers: FleetTlsCenter[] = [];
+  t.after(async () => {
+    for (const center of centers.splice(0)) await center.close();
+  });
+  const center = await listenFleetTls({
+    host,
+    stateRoot,
+    ...fleetHostWriterOptions(userRoot, ["admission-repo"]),
+    key,
+    cert,
+    replicaDiskQuotaBytes: replicaQuota,
+    authenticate: (nodeId, credential) => nodeId === "node-one" && credential === "machine-secret",
+    resolveAssignment: (assignmentId) => (assignmentId === assignment.assignmentId ? assignment : null),
+  });
+  centers.push(center);
+  return {
+    center,
+    cert,
+    assignment,
+    setRepoState: (state: "warming" | "unavailable" | null) => {
+      repoState = state;
+    },
+  };
+}
+
+type AdmissionFixture = Awaited<ReturnType<typeof admissionFixture>>;
+
+// One hello + one upload.begin over a fresh TLS connection; the probe number
+// varies the content identity so every call stages a distinct upload.
+async function uploadBegin(fixture: AdmissionFixture, probe: number): Promise<FleetFrameV1> {
+  const socket = await new Promise<TLSSocket>((resolve, reject) => {
+    const candidate = connect(
+      { host: "127.0.0.1", port: fixture.center.port, ca: fixture.cert, servername: "localhost" },
+      () => resolve(candidate),
+    );
+    candidate.once("error", reject);
+  });
+  let buffer = "";
+  const replies: FleetFrameV1[] = [],
+    waiters: Array<(frame: FleetFrameV1) => void> = [];
+  socket.on("data", (chunk) => {
+    buffer += chunk.toString("utf8");
+    for (;;) {
+      const end = buffer.indexOf("\n");
+      if (end < 0) break;
+      const frame = parseFleetFrame(buffer.slice(0, end));
+      buffer = buffer.slice(end + 1);
+      const waiter = waiters.shift();
+      if (waiter) waiter(frame);
+      else replies.push(frame);
+    }
+  });
+  try {
+    const request = async (frame: FleetFrameV1): Promise<FleetFrameV1> => {
+      socket.write(serializeFleetFrame(frame));
+      return replies.length ? replies.shift()! : new Promise((resolve) => waiters.push(resolve));
+    };
+    const hello = await request({
+      schema: "fleet.session.hello/v1",
+      messageId: `admission-hello-${probe}`,
+      protocolVersion: currentFleetProtocolVersion,
+      nodeId: fixture.assignment.nodeId,
+      credential: "machine-secret",
+    });
+    if (hello.schema === "fleet.error/v1") return hello;
+    const body = Buffer.from(`admission-probe-${probe}`);
+    return await request({
+      schema: "fleet.upload.begin/v1",
+      messageId: `admission-begin-${probe}`,
+      assignmentId: fixture.assignment.assignmentId,
+      content: { sha256: sha256Bytes(body), size: body.byteLength, mediaType: "text/plain; charset=utf-8" },
+    });
+  } finally {
+    socket.destroy();
+  }
+}

--- a/packages/daemon/test/fleet-edge-replay.integration.test.ts
+++ b/packages/daemon/test/fleet-edge-replay.integration.test.ts
@@ -78,7 +78,17 @@ test("edge staging replays snapshot/delta pages and chunks and switches only com
       "fleet.ack/v1",
     );
     assert.equal(view.current("repo", "many")?.cut.revision, 1);
-    assert.equal(readFileSync(path.join(root, "repos/repo/views/many/cuts/1/files/tasks/t/many-05.md"), "utf8"), "");
+    // Snapshot cuts address their blobs through the verified CAS instead of
+    // copying the tree into cuts/<revision>/files/; only delta cuts
+    // materialize changed files beside their manifest.
+    assert.equal(existsSync(path.join(root, "repos/repo/views/many/cuts/1/files/tasks/t/many-05.md")), false);
+    assert.equal(
+      readFileSync(
+        path.join(root, "repos/repo/cas/sha256", manyEntries[5]!.blob.sha256.slice(0, 2), manyEntries[5]!.blob.sha256),
+        "utf8",
+      ),
+      "",
+    );
     const otherBody = Buffer.from("other-view"),
       otherEntry = wireEntry("tasks/t/other.md", otherBody),
       otherSnapshot = snapshotFrames("snap-other", "other", cutOne, [otherEntry], [otherBody]);
@@ -138,6 +148,69 @@ test("edge staging replays snapshot/delta pages and chunks and switches only com
     view = openFleetEdgeView(root, replicaQuota);
     for (const frame of deltaThree) view.receive(frame);
     assert.equal(view.current("repo", "view")?.cut.revision, 3);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("edge chunk replay compares only the named window against the staged blob", () => {
+  const root = mkdtempSync(path.join(tmpdir(), "ha-fleet-edge-window-"));
+  try {
+    const body = Buffer.concat([Buffer.from("a".repeat(100 * 1024)), Buffer.from("b".repeat(100 * 1024))]),
+      entry = wireEntry("tasks/t/big.md", body),
+      digest = fleetManifestDigest([entry]),
+      cut = wireCut(1),
+      begin = {
+        schema: "fleet.snapshot.begin/v1" as const,
+        messageId: "big-begin",
+        transferId: "big",
+        repoId: "repo",
+        viewId: "view",
+        cut,
+        manifest: { digest, entryCount: 1, totalBytes: body.byteLength },
+      },
+      page = {
+        schema: "fleet.snapshot.page/v1" as const,
+        messageId: "big-page",
+        transferId: "big",
+        pageIndex: 0,
+        entries: [entry],
+      },
+      first = {
+        schema: "fleet.snapshot.chunk/v1" as const,
+        messageId: "big-chunk-0",
+        transferId: "big",
+        blobSha256: entry.blob.sha256,
+        offset: 0,
+        dataBase64: body.subarray(0, 100 * 1024).toString("base64"),
+      },
+      second = {
+        schema: "fleet.snapshot.chunk/v1" as const,
+        messageId: "big-chunk-1",
+        transferId: "big",
+        blobSha256: entry.blob.sha256,
+        offset: 100 * 1024,
+        dataBase64: body.subarray(100 * 1024).toString("base64"),
+      };
+    let view = openFleetEdgeView(root, replicaQuota, (point) => {
+      if (point === "after_chunk") throw new Error("crash-after-chunk");
+    });
+    view.receive(begin);
+    view.receive(page);
+    assert.throws(() => view.receive(first), /crash-after-chunk/u);
+    view = openFleetEdgeView(root, replicaQuota);
+    view.receive(begin);
+    view.receive(page);
+    view.receive(first);
+    view.receive(second);
+    // Replaying the identical mid-blob window at a non-zero offset is
+    // accepted; a chunk whose window diverges is refused without re-reading
+    // the whole staged blob.
+    view.receive(second);
+    assert.throws(
+      () => view.receive({ ...second, dataBase64: Buffer.from("c".repeat(100 * 1024)).toString("base64") }),
+      /chunk replay mismatch/u,
+    );
   } finally {
     rmSync(root, { recursive: true, force: true });
   }

--- a/packages/daemon/test/fleet-transport.integration.test.ts
+++ b/packages/daemon/test/fleet-transport.integration.test.ts
@@ -1072,6 +1072,25 @@ test(
       offset: ready.resumeOffset,
       dataBase64: Buffer.from("xyz").toString("base64"),
     });
+    // Replay comparison reads only the window a retried chunk names: identical
+    // bytes at a non-zero offset are accepted, divergent bytes are refused.
+    const replayed = await peer.request({
+      schema: "fleet.upload.chunk/v1",
+      messageId: "replay-chunk",
+      uploadId: ready.uploadId,
+      offset: 1,
+      dataBase64: Buffer.from("yz").toString("base64"),
+    });
+    assert.equal(replayed.schema, "fleet.upload.ready/v1");
+    const divergent = await peer.request({
+      schema: "fleet.upload.chunk/v1",
+      messageId: "divergent-chunk",
+      uploadId: ready.uploadId,
+      offset: 1,
+      dataBase64: Buffer.from("zz").toString("base64"),
+    });
+    assert.equal(divergent.schema, "fleet.error/v1");
+    if (divergent.schema === "fleet.error/v1") assert.equal(divergent.code, "upload_replay_mismatch");
     const bad = await peer.request({
       schema: "fleet.upload.finish/v1",
       messageId: "bad-finish",

--- a/packages/daemon/test/owner-named-temporary-write-paths.test.ts
+++ b/packages/daemon/test/owner-named-temporary-write-paths.test.ts
@@ -43,6 +43,7 @@ test("a temporary named after its writer exists only where it was judged", () =>
     "daemon/src/agent-runtime-instance-store.ts: `${target}.${process.pid}.tmp`",
     "daemon/src/dispatch-stream.ts: `${target}.${process.pid}.tmp`",
     "daemon/src/durable-file.ts: `${file}.${process.pid}.${randomUUID()}.tmp`",
+    "daemon/src/fleet-edge-mirror.ts: `${file}.${process.pid}.${randomUUID()}.tmp`",
     "kernel/src/daemon/registry.ts: `${registryPath}.${process.pid}.${Date.now()}.tmp`",
     "kernel/src/local/local-layout-file-system.ts: `${inputPath}.${process.pid}.tmp`",
     "kernel/src/store/local-version-control-system.ts: `${target}.tmp-${process.pid}`",

--- a/packages/daemon/test/owner-named-temporary-write-paths.test.ts
+++ b/packages/daemon/test/owner-named-temporary-write-paths.test.ts
@@ -43,7 +43,6 @@ test("a temporary named after its writer exists only where it was judged", () =>
     "daemon/src/agent-runtime-instance-store.ts: `${target}.${process.pid}.tmp`",
     "daemon/src/dispatch-stream.ts: `${target}.${process.pid}.tmp`",
     "daemon/src/durable-file.ts: `${file}.${process.pid}.${randomUUID()}.tmp`",
-    "daemon/src/fleet-edge-mirror.ts: `${file}.${process.pid}.${randomUUID()}.tmp`",
     "kernel/src/daemon/registry.ts: `${registryPath}.${process.pid}.${Date.now()}.tmp`",
     "kernel/src/local/local-layout-file-system.ts: `${inputPath}.${process.pid}.tmp`",
     "kernel/src/store/local-version-control-system.ts: `${target}.tmp-${process.pid}`",

--- a/tools/center-testbed/smoke-edge.mjs
+++ b/tools/center-testbed/smoke-edge.mjs
@@ -29,15 +29,32 @@ const env = fleetEnv(userRoot, nodeId);
 const generationFile = path.join(viewRoot, "generation.json");
 const generation = existsSync(generationFile) ? JSON.parse(readFileSync(generationFile, "utf8")) : null;
 if (generation?.canonicalHead !== state.canonicalHead) {
-  if (existsSync(viewRoot)) for (const entry of readdirSync(viewRoot)) rmSync(path.join(viewRoot, entry), { recursive: true, force: true });
+  if (existsSync(viewRoot))
+    for (const entry of readdirSync(viewRoot)) rmSync(path.join(viewRoot, entry), { recursive: true, force: true });
   writeFileSync(generationFile, `${JSON.stringify({ canonicalHead: state.canonicalHead }, null, 2)}\n`);
   log("view", `ledger generation changed; view reset for canonical ${state.canonicalHead.slice(0, 12)}`);
 }
 const syncArgs = [
-  "daemon", "fleet", "edge", "sync",
-  "--host", "center", "--port", String(state.fleet.port), "--ca", state.fleet.certPath,
-  "--node-id", nodeId, "--credential", node.credential, "--assignment", assignment.assignmentId,
-  "--view-root", viewRoot, "--quota-bytes", String(state.fleet.quotaBytes)
+  "daemon",
+  "fleet",
+  "edge",
+  "sync",
+  "--host",
+  "center",
+  "--port",
+  String(state.fleet.port),
+  "--ca",
+  state.fleet.certPath,
+  "--node-id",
+  nodeId,
+  "--credential",
+  node.credential,
+  "--assignment",
+  assignment.assignmentId,
+  "--view-root",
+  viewRoot,
+  "--quota-bytes",
+  String(state.fleet.quotaBytes),
 ];
 
 const first = ha("sync", env, syncArgs);
@@ -51,19 +68,31 @@ log("sync", `pull #1 ok: status ${first.status} ackCut ${first.ackCut} (center c
 
 const view = path.join(viewRoot, "repos", state.repoId, "views", assignment.viewId);
 const current = JSON.parse(readFileSync(path.join(view, "current.json"), "utf8"));
-if (current.cut.revision < state.seedRevision) fail("view", `view cut ${current.cut.revision} is behind the seed revision ${state.seedRevision}`);
-const cutFiles = path.join(view, "cuts", String(current.cut.revision), "files");
+if (current.cut.revision < state.seedRevision)
+  fail("view", `view cut ${current.cut.revision} is behind the seed revision ${state.seedRevision}`);
+// Snapshot cuts address their blobs through the edge CAS instead of
+// materializing cuts/<revision>/files/, so cut documents are read through
+// their manifest entries.
+const cutRoot = path.join(view, "cuts", String(current.cut.revision));
+const manifest = JSON.parse(readFileSync(path.join(cutRoot, "manifest.json"), "utf8"));
+const repoRoot = path.resolve(view, "..", "..");
+const cutFile = (logical) => {
+  const entry = manifest.entries.find((row) => row.path === logical);
+  if (!entry) fail("view", `cut ${current.cut.revision} manifest has no entry for ${logical}`);
+  return path.join(repoRoot, "cas", "sha256", entry.blob.sha256.slice(0, 2), entry.blob.sha256);
+};
 
-const taskDoc = readText(path.join(cutFiles, `${state.packagePath}/task_plan.md`));
+const taskDoc = readText(cutFile(`${state.packagePath}/task_plan.md`));
 assertContains("task doc", taskDoc, state.taskTitle);
-const decisionDoc = readText(path.join(cutFiles, state.decisionPath));
+const decisionDoc = readText(cutFile(state.decisionPath));
 assertContains("decision doc", decisionDoc, "The center daemon owns the canonical ledger");
-const factsDoc = readText(path.join(cutFiles, `${state.packagePath}/facts.md`));
+const factsDoc = readText(cutFile(`${state.packagePath}/facts.md`));
 assertContains("facts doc", factsDoc, "The testbed bootstrap wrote a task, a decision, and a fact");
 log("view", `edge view serves cut ${current.cut.revision} with task, decision, and fact documents`);
 
 const second = ha("resync", env, syncArgs);
-if (second.status !== "fleet.replica.current/v1") fail("resync", `expected idempotent fleet.replica.current/v1, got ${second.status}`);
+if (second.status !== "fleet.replica.current/v1")
+  fail("resync", `expected idempotent fleet.replica.current/v1, got ${second.status}`);
 log("resync", `pull #2 ok: center confirms the view is current at cut ${second.cut.revision} (no transfer)`);
 
 log("smoke", `SMOKE PASS: edge ${nodeId} reads the center ledger projection through fleet TLS`);

--- a/tools/gate-allowlists/check-fallback-boundaries.json
+++ b/tools/gate-allowlists/check-fallback-boundaries.json
@@ -86,7 +86,7 @@
       "packages/daemon/src/fleet/edge.ts#peerFor",
       "packages/daemon/src/fleet/replica-ack-store.ts#ack",
       "packages/daemon/src/fleet/replica-cut-store.ts#kick",
-      "packages/daemon/src/fleet/replica-cut-store.ts#persist",
+      "packages/daemon/src/fleet/replica-cut-store.ts#transact",
       "packages/daemon/src/lease-broker.ts#domainLease",
       "packages/daemon/src/lease-broker.ts#execute",
       "packages/daemon/src/lease-broker.ts#pumpQueue",


### PR DESCRIPTION
# English

## Summary

fix-plan batch 14, the fleet family (task_eb3be3cca32eb158122c495ee0, group G5 of the W-H tail audit task_997414da4f72d57e8dfad7097c; parent task_6eba9c5d3a55735920aa4856f3 / task_2b8f79fa4412cb726a26f9bfc7). Six of eight findings land; two half-findings are recorded as skipped. `fleet/center-listener.ts`: repo lookup by a `repoRows` map instead of rebuilding the whole host status per chunk frame; replay chunks read through a 64 KiB positioned window instead of the whole file. `fleet/edge.ts`: the same positioned read; snapshot finish no longer re-reads and re-hashes every entry from the CAS nor `cpSync`s the whole tree into `cuts/<rev>/files/` (blobs are addressed through the manifest into the CAS; delta-cut materialization unchanged). `fleet/replica-cut-store.ts`: WAL + synchronous FULL, one transaction per round (E transactions → 1, settle deferred to COMMIT), change comparison by claim fields instead of two stableStringify passes per event, `changes()` range pushed into SQL. `fleet-edge-mirror.ts`: marker-equal skips the durable rewrite; materialization, the three conflict sides and restore go temp+rename (2 fsync per file → 0; marker and base-cache stay durable); scan compares size before hashing; `cacheFleetMirrorDirtyBases` returns the scan for reuse. `fleet-edge-task.ts`: the task round reuses one tree scan (2 → 1). Ruling §5.5 kept: positioned read still compares chunk by chunk. Skipped: the manifest half of R2-03-F6 (pinned by `center-replica-offer.ts:58`, outside this task's surface; fact F-946D79D4 records that skipping it makes the scale test fail with `invalid_frame`) and the doc-sync half of R1-03-F3. Production +295/-159 (net +136): the largest deletable item (per-event manifest write) is pinned by that dependency, and the per-round transaction scaffolding adds lines.

## Architectural Justification

- No new module. The growth is one transaction-per-round scaffold in the replica store and the positioned-read windows; the removed work is whole-file reads, whole-tree copies and per-file double fsync on paths that keep their durable markers.

## What Changed

- `packages/daemon/src/fleet/center-listener.ts`, `fleet/edge.ts`, `fleet/replica-cut-store.ts`, `fleet-edge-mirror.ts`, `fleet-edge-task.ts`: as summarised.
- Tests: window-replay assertions on both sides, snapshot CAS-addressing assertion with a `files/` negative assertion, one more owner-named case.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: +295/-159 (`packages/*/src`, tests excluded); `tools/gate-allowlists/check-fallback-boundaries.json` one `consumeKnownError` key renamed (`replica-cut-store.ts#persist` → `#transact`), counts unchanged.

## Machine-Readable Declarations

- Production-Delta: +295/-159

## Task And Scope

- Harness task: task_eb3be3cca32eb158122c495ee0 (G5), parent task_6eba9c5d3a55735920aa4856f3
- Branch: `codex/perf-g5`
- Public scope: five fleet files + fleet tests
- Private planning/evidence updated: yes (`artifacts/report.md`, facts incl. F-946D79D4)
- Out of scope: `center-replica-offer.ts` (manifest half), doc-sync four-pass merge, R2-03-F11 knownKeys (needs an ack lifecycle; on the do-not-fix list)

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: yes — `tools/gate-allowlists/check-fallback-boundaries.json` (fallback-boundaries ratchet)
- Protected surface scope: the existing rollback `consumeKnownError` exit in `replica-cut-store.ts` moved from `persist` into the new per-round `transact`; the ratchet keys by file#function, so the one entry is renamed with the code. No entry added or removed; counts 283/8/51 unchanged.
- Authority: repository owner authorization for governance fixes in the perf rescue line (2026-09-10/11), recorded in task_eb3be3cca32eb158122c495ee0
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `3e039d37a`
- Branch merge-base with `origin/main`: `3e039d37a`
- Last `git fetch origin` time: 2026-09-12 UTC
- Sync method: rebased onto origin/main by the worker (upstream touched only `packages/preset`)
- Public diff command: `git diff origin/main...codex/perf-g5`
- Private evidence commit/path: task_eb3be3cca32eb158122c495ee0 `artifacts/report.md`
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [x] `npm run typecheck` (`tsc -b`, worker)
- [ ] `npm run check`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts` (via `run-manifest-gates --changed origin/main`, worker)
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Worker (GLM): 16 affected files (full fleet suite of 12 plus 4 on the import chain) each dispatched to the isolated Ubuntu runner, all exit 0; negative control: the `files/` assertion fails on the old code; line-density and production-delta gates green.

## Review Evidence

- CEO ground-truth: read the report and the per-file summary; the durability changes (temp+rename instead of per-file fsync on materialized and conflict-side files, one transaction per round with WAL + synchronous FULL) are production write-path changes, so an adversarial review is dispatched on the task before merge and its outcome is recorded here.
- Reviewer subagent: adversarial review done (Astra, `artifacts/adversarial-review.md` + fault suite): **blocking**. B1 fresh snapshots no longer materialize `cuts/<rev>/files/` but `daemon-fleet-cli.test.ts:149` and `tools/center-testbed/smoke-edge.mjs` still read that path (isolated run of the CLI test: ENOENT). B2 `repoRows` caches the dynamic admission state (warming/attached/unavailable) and upload staging bypasses `host.run`. The fsync removal's premise does not hold: recovery does not unconditionally rebuild projection/conflict-side files (fault suite classifies the loss as dirty, not repaired). WAL/per-round transaction and the chunk windows had no blocking failure.
- Human review: pending
- Blocking findings: **B1, B2 and the fsync removal are open**; Round 4 on the task (GLM) converts the two callers to manifest/CAS reads asserting content, reverts the admission-state cache to a real-time keyed lookup with two integration tests, restores the three durable writes (marker-equal short-circuit kept), and moves the positioned read into a `durable-file.ts` helper for the `#1586` contract. Do not merge before that round lands and CI is green.


## Round 4 (adversarial review outcome, 2026-09-12)

Astra's adversarial review found two blockers (B1: snapshot callers still read `cuts/<rev>/files/`; B2: `center-listener.ts` cached admission state in `repoRows`, so staging bypassed `host.run`) and a false fsync-removal premise. Round 4 (GLM) landed all five CEO decisions: B1 — `daemon-fleet-cli.test.ts` and `tools/center-testbed/smoke-edge.mjs` read cut documents through the manifest entry → `repos/<id>/cas/sha256/...` and assert the actual body; B2 — `repoRows` admission cache removed, every frame goes through `host.status().repos.find(...)`, with two new TLS integration tests (`fleet-center-admission.integration.test.ts`) that failed before the fix and pass after; mirror materialization, conflict three-sides and restore writes go through `writeFileDurably` again and the `writeFileMaterialized` helper is deleted; the positional window read is consolidated into `durable-file.ts` `readFileWindow(path, offset, length)` so the `#1586` contract (only `durable-file.ts` opens read-only handles) holds. Round 4 delta +35/-65; whole branch vs `origin/main` +297/-162. Branch rebased onto `4850da1fc` (now `466caf36a` contains it); merge hold lifted.

## Residual Risk

- Materialized and conflict-side files are no longer fsync'd individually; a crash between rename and the next durable marker write can leave a file whose marker still points at the previous content. The marker and base-cache writes stay durable, so recovery re-materializes from them; the adversarial review is asked to confirm that path.
- The per-event manifest write survives because `center-replica-offer.ts` reads it; the deletable item moves to a follow-up.

## References

- Task: task_eb3be3cca32eb158122c495ee0; W-H tail audit §G5; fix-plan batch 14; ruling §5.5

---

# 中文

## 概要

fix-plan 批 14 fleet 家族（task_eb3be3cca32eb158122c495ee0，W-H 尾巴核对 task_997414da4f72d57e8dfad7097c 的 G5 组；父 task_6eba9c5d3a55735920aa4856f3 / task_2b8f79fa4412cb726a26f9bfc7）。八条 finding 落地六条，两个半条记为跳过。`fleet/center-listener.ts`：repo 查找改 `repoRows` Map 直查，不再每 chunk 帧重建整份 host status；重放 chunk 改 64 KiB 定位窗口读，不再整文件读。`fleet/edge.ts`：同型定位读；snapshot finish 不再逐 entry 从 CAS 读回重哈希、不再 `cpSync` 整树进 `cuts/<rev>/files/`（blob 经 manifest 寻址到 CAS；delta cut 物化不变）。`fleet/replica-cut-store.ts`：WAL + synchronous FULL、每 round 单事务（E 个事务 → 1，settle 延到 COMMIT 后）、change 比对改按 claim 字段而非每事件两次 stableStringify、`changes()` 区间下推 SQL。`fleet-edge-mirror.ts`：marker 全等跳过 durable 重写；物化、冲突三侧、restore 改 temp+rename（每文件 2 fsync → 0；marker 与 base-cache 保持 durable）；scan 先比 size 再哈希；`cacheFleetMirrorDirtyBases` 返回 scan 供复用。`fleet-edge-task.ts`：task 轮复用一次全树扫（2 → 1）。§5.5 裁决保留：定位读仍逐 chunk 比对。跳过：R2-03-F6 的 manifest 半边（被 `center-replica-offer.ts:58` 钉住，在本任务面外；事实 F-946D79D4 记录跳过会让 scale 测试 `invalid_frame`）与 R1-03-F3 的 doc-sync 半边。生产 +295/-159（净 +136）：最大可删项（逐事件 manifest 落盘）被该依赖钉住，每 round 事务脚手架又加了行。

## 架构辩护

- 不加模块。增量是 replica store 的每 round 单事务脚手架与定位读窗口；删掉的是整文件读、整树拷贝与保留 durable marker 的路径上每文件两次 fsync。

## 改动内容

- `packages/daemon/src/fleet/center-listener.ts`、`fleet/edge.ts`、`fleet/replica-cut-store.ts`、`fleet-edge-mirror.ts`、`fleet-edge-task.ts`：如概要。
- 测试：两侧窗口重放断言、snapshot CAS 寻址断言（含 `files/` 负断言）、owner-named 加一条。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 删除的门或 fixture：none
- 生产净行数：+295/-159（`packages/*/src` 不含测试）；`tools/gate-allowlists/check-fallback-boundaries.json` 一条 `consumeKnownError` 键改名（`replica-cut-store.ts#persist` → `#transact`），计数不变。

## 机器可读声明

- Production-Delta: +295/-159

## 任务与范围

- Harness 任务：task_eb3be3cca32eb158122c495ee0（G5），父任务 task_6eba9c5d3a55735920aa4856f3
- 分支：`codex/perf-g5`
- 公开范围：五个 fleet 文件 + fleet 测试
- 私有计划/证据已更新：是（`artifacts/report.md`，事实含 F-946D79D4）
- 范围外：`center-replica-offer.ts`（manifest 半边）、doc-sync 四遍合一、R2-03-F11 knownKeys（需 ack 生命周期；在不修清单）

## 版本影响

- 版本：不变
- 发布影响：不发布

## 治理声明

- 触碰受保护面：是——`tools/gate-allowlists/check-fallback-boundaries.json`（fallback-boundaries ratchet）
- 受保护面范围：`replica-cut-store.ts` 里既有的回滚 `consumeKnownError` 出口从 `persist` 挪进新的每 round `transact`；ratchet 按 文件#函数 计键，条目随代码改名。不增不删；计数 283/8/51 不变。
- 授权：仓库所有者对性能抢救线治理修复的授权（2026-09-10/11），记录在 task_eb3be3cca32eb158122c495ee0
- 机器检查边界：本 PR 只断言声明存在；是否属实、是否充分由评审判断。
- Break-glass：否
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- 基线 `origin/main` SHA：`3e039d37a`
- 分支与 `origin/main` 的 merge-base：`3e039d37a`
- 最近一次 `git fetch origin`：2026-09-12 UTC
- 同步方式：worker rebase 到 origin/main（上游只动了 `packages/preset`）
- 公开 diff 命令：`git diff origin/main...codex/perf-g5`
- 私有证据路径：task_eb3be3cca32eb158122c495ee0 的 `artifacts/report.md`
- 评审证据路径：本 PR 的评审证据节
- GitHub Actions `rewrite-ci` run URL：本 PR 待跑
- worker（GLM）：16 个受影响文件（fleet 全套 12 个 + import 链上 4 个）逐一隔离 Ubuntu 派测全部 exit 0；阴性对照：`files/` 断言在旧码上红；line-density、production-delta 门绿。

## 评审证据

- CEO 事实核对：读过报告与逐文件摘要；持久化改动（物化与冲突侧文件改 temp+rename 不再逐文件 fsync、每 round 单事务 + WAL + synchronous FULL）属生产写路，合并前在任务上派对抗复核，结果记回此处。
- 评审子代理：对抗复核已完成（Astra，`artifacts/adversarial-review.md` + fault suite）：**阻塞**。B1 fresh snapshot 不再物化 `cuts/<rev>/files/`，但 `daemon-fleet-cli.test.ts:149` 与 `tools/center-testbed/smoke-edge.mjs` 仍直读该路径（CLI 测试隔离跑 ENOENT）。B2 `repoRows` 缓存了动态准入状态（warming/attached/unavailable），上传 staging 绕过 `host.run`。fsync 降级的前提不成立：恢复不会无条件重建 projection/冲突侧文件（fault suite 判为 dirty 而非修复）。WAL/每 round 单事务与 chunk 窗口无阻塞失败。
- 人工评审：待定
- 阻塞发现：**B1、B2 与 fsync 降级三项开放**；任务第四轮（GLM）把两处调用方改经 manifest/CAS 读并断言正文、回退准入状态缓存改实时 keyed lookup 并补两条集成测试、恢复三类 durable 写（保留 marker 全等短路）、把定位读收进 `durable-file.ts` helper 以过 `#1586` 契约。该轮落地且 CI 绿之前不合并。


## 第 4 轮（对抗评审结果，2026-09-12）

Astra 对抗评审给出两个阻塞（B1：快照调用方仍读 `cuts/<rev>/files/`；B2：`center-listener.ts` 在 `repoRows` 缓存 admission 状态，staging 绕过 `host.run`）与一个不成立的 fsync 删除前提。第 4 轮（GLM）落地全部五项裁决：B1——`daemon-fleet-cli.test.ts` 与 `tools/center-testbed/smoke-edge.mjs` 经 manifest 条目 → `repos/<id>/cas/sha256/...` 读 cut 文档并断言正文；B2——删除 `repoRows` admission 缓存，每帧走 `host.status().repos.find(...)`，新增两个 TLS 集成测试（`fleet-center-admission.integration.test.ts`）修前红修后绿；镜像物化、冲突三方与恢复写回 `writeFileDurably`，删除 `writeFileMaterialized`；位置窗口读并入 `durable-file.ts` 的 `readFileWindow(path, offset, length)`，`#1586` 契约（只有 `durable-file.ts` 开只读句柄）成立。第 4 轮 +35/-65；整分支对 `origin/main` +297/-162。分支已 rebase 到 `4850da1fc`；合并 hold 解除。

## 残余风险

- 物化与冲突侧文件不再逐个 fsync；rename 与下一次 durable marker 写之间崩溃，可能留下 marker 仍指向旧内容的文件。marker 与 base-cache 写保持 durable，恢复时从它们重新物化；对抗复核要确认这条路径。
- 逐事件 manifest 落盘因 `center-replica-offer.ts` 读它而保留；可删项移到后续。

## 参考

- 任务：task_eb3be3cca32eb158122c495ee0；W-H 尾巴核对 §G5；fix-plan 批 14；§5.5 裁决

