### PR TITLE
fix(kernel): drop --execution-id from nonstandard gate-witness guidance

### DIFF
--- a/packages/application/test/task-lifecycle-transition-service.test.ts
+++ b/packages/application/test/task-lifecycle-transition-service.test.ts
@@ -68,6 +68,7 @@ test("completion blocker matrix returns one canonical next for every substantive
       ["consent_missing", reviewed.snapshot, ready],
       ["ci_missing", withGates(["ci"]), ready],
       ["code_doc_missing", withGates(["code-doc-reconciliation"]), ready],
+      ["gate_witness_missing", withGates(["lint"]), ready],
       ["decision_lineage_missing", orphanMilestone, ready],
       ["lease_held", { ...consented.snapshot, lease: started.snapshot.lease }, ready],
       [
@@ -102,6 +103,10 @@ test("completion blocker matrix returns one canonical next for every substantive
       closeoutMissingSections: [{ section: "Residual Risk", reason: "scaffold" }],
     })[0]!;
     assert.match(templateSection.next.reason, /section Residual Risk is scaffold/);
+    // A nonstandard gate has no ordinary selector-bearing command; the guidance names the checker, not --execution-id.
+    const witness = completionBlockers(withGates(["lint"]), "execution-1", ready)[0]!;
+    assert.equal(witness.next.action.includes("--execution-id"), false);
+    assert.match(witness.next.action, /canonical lint checker/);
     // The lineage blocker names the missing edge with the exact command that writes it.
     const lineage = completionBlockers(orphanMilestone, "execution-1", ready)[0]!;
     assert.equal(

--- a/packages/kernel/src/domain/completion-readiness.ts
+++ b/packages/kernel/src/domain/completion-readiness.ts
@@ -181,7 +181,9 @@ function evaluateCompletion(
       : one(
           gate.gateId === "ci" ? "ci_missing" : "gate_witness_missing",
           gate.gateId,
-          gate.gateId === "ci" ? "ha ci observe pull" : `ha task complete ${task.taskId} --execution-id ${executionId}`,
+          gate.gateId === "ci"
+            ? "ha ci observe pull"
+            : `Run the canonical ${gate.gateId} checker so it publishes a passing witness for execution ${executionId}.`,
           `Publish a passing canonical ${gate.gateId} checker witness for this execution cut.`,
         );
   if (lineageOrphan(task, snapshot.decisionRelations ?? []))

--- a/packages/kernel/src/domain/completion-readiness.ts
+++ b/packages/kernel/src/domain/completion-readiness.ts
@@ -183,7 +183,7 @@ function evaluateCompletion(
           gate.gateId,
           gate.gateId === "ci"
             ? "ha ci observe pull"
-            : `Run the canonical ${gate.gateId} checker so it publishes a passing witness for execution ${executionId}.`,
+            : `Run the canonical ${gate.gateId} checker to witness execution ${executionId}.`,
           `Publish a passing canonical ${gate.gateId} checker witness for this execution cut.`,
         );
   if (lineageOrphan(task, snapshot.decisionRelations ?? []))


### PR DESCRIPTION
# English

## Summary

One-path closeout, slice 4c (task_7ccb8f35ea42c3d5c00dbb45f5, follow-up to #2521 after independent closeout review): `completionBlockers` still emitted `ha task complete <taskId> --execution-id <executionId>` as the next command for any missing completion gate other than `ci` / `code-doc-reconciliation`. Gate IDs are arbitrary strings (task and preset contracts), so that branch is reachable, and the guidance contradicted the documented rule that `--execution-id` only repairs an ambiguous current-execution selection. There is no ordinary CLI command that publishes a witness for a nonstandard gate; the guidance now names the canonical checker for that gate and the execution it must witness, with no selector.

## Architectural Justification

-

## What Changed

- `packages/kernel/src/domain/completion-readiness.ts`: `gate_witness_missing` next action no longer carries `--execution-id`.
- `packages/application/test/task-lifecycle-transition-service.test.ts`: table row for a nonstandard gate (`lint`) plus an assertion that the guidance names the checker and carries no selector.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: +3/-1 (`packages/kernel`); tests +5.

## Machine-Readable Declarations

- None.

## Task And Scope

- Harness task: task_7ccb8f35ea42c3d5c00dbb45f5 (one-path closeout slice 4), root task_4f7965fc895253bf70a4020f42
- Branch: `codex/onepath-4c`
- Public scope: one blocker guidance string and its test
- Private planning/evidence updated: yes (closeout.md amended)
- Out of scope: the `executor_missing` recovery command (`declare-executor --execution-id`), which is a repair path by design

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: not applicable
- Machine-check boundary: not applicable
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `4850da1fc`
- Branch merge-base with `origin/main`: `4850da1fc`
- Last `git fetch origin` time: 2026-09-12 UTC
- Sync method: branched from origin/main
- Public diff command: `git diff origin/main...codex/onepath-4c`
- Private evidence commit/path: task_7ccb8f35ea42c3d5c00dbb45f5 `closeout.md`
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [x] `npm run typecheck` (kernel project `tsc --noEmit`)
- [ ] `npm run check`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- `task-lifecycle-transition-service.test.ts` 14/14; `task-action-catalog-executor.test.ts` 8/8; `rejection-next-actions.integration.test.ts` 9/9; eslint clean on both files.

## Review Evidence

- CEO ground-truth: independent closeout reviewer (dispatch_9757b8ee) named the site; read the branch and the gate-witness compile path (`completion-gate-publication.ts`) to confirm no generic publish command exists.
- Reviewer subagent: closeout review resubmitted after merge
- Human review: pending
- Blocking findings: none open

## Residual Risk

- None beyond the guidance wording itself.

## References

- Task: task_7ccb8f35ea42c3d5c00dbb45f5; prior slices #2503/#2510/#2521

---

# 中文

## 概要

一条路收口切片 4c（task_7ccb8f35ea42c3d5c00dbb45f5，#2521 经独立收口评审后的补丁）：`completionBlockers` 对 `ci` / `code-doc-reconciliation` 之外的任何缺失完成门，仍把 `ha task complete <taskId> --execution-id <executionId>` 当作下一步命令。门 id 是任意字符串（task 与 preset 契约），该分支可达，指引与「`--execution-id` 只用于修复当前执行歧义」的规则矛盾。非标准门没有普通 CLI 命令能发布见证；现在指引点名该门的 canonical checker 与它要见证的执行，不带选择器。

## 架构辩护

-

## 改动内容

- `packages/kernel/src/domain/completion-readiness.ts`：`gate_witness_missing` 的下一步不再带 `--execution-id`。
- `packages/application/test/task-lifecycle-transition-service.test.ts`：加一行非标准门（`lint`）用例，并断言指引点名 checker 且无选择器。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 删除的门或 fixture：none
- 生产净行数：+3/-1（`packages/kernel`）；测试 +5。

## 机器可读声明

- 无。

## 任务与范围

- Harness 任务：task_7ccb8f35ea42c3d5c00dbb45f5（一条路收口切片 4），根 task_4f7965fc895253bf70a4020f42
- 分支：`codex/onepath-4c`
- 公开范围：一条 blocker 指引字符串及其测试
- 私有计划/证据已更新：是（closeout.md 已修订）
- 范围外：`executor_missing` 的恢复命令（`declare-executor --execution-id`），它本就是修复路径

## 版本影响

- 版本：不变
- 发布影响：不发布

## 治理声明

- 触碰受保护面：否
- 受保护面范围：不适用
- 授权：不适用
- 机器检查边界：不适用
- Break-glass：否
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- 基线 `origin/main` SHA：`4850da1fc`
- 分支与 `origin/main` 的 merge-base：`4850da1fc`
- 最近一次 `git fetch origin`：2026-09-12 UTC
- 同步方式：从 origin/main 开分支
- 公开 diff 命令：`git diff origin/main...codex/onepath-4c`
- 私有证据路径：task_7ccb8f35ea42c3d5c00dbb45f5 的 `closeout.md`
- 评审证据路径：本 PR 的评审证据节
- GitHub Actions `rewrite-ci` run URL：本 PR 待跑
- `task-lifecycle-transition-service.test.ts` 14/14；`task-action-catalog-executor.test.ts` 8/8；`rejection-next-actions.integration.test.ts` 9/9；两文件 eslint 通过。

## 评审证据

- CEO 事实核对：独立收口评审（dispatch_9757b8ee）点名该处；读过分支与门见证编译路径（`completion-gate-publication.ts`），确认不存在通用发布命令。
- 评审子代理：合入后重新提交收口评审
- 人工评审：待定
- 阻塞发现：无

## 残余风险

- 除措辞本身外无。

## 参考

- 任务：task_7ccb8f35ea42c3d5c00dbb45f5；前序切片 #2503/#2510/#2521
