### PR TITLE
chore(gates): validate completion guidance commands against the CLI directory

### DIFF
--- a/packages/daemon/test/rejection-next-actions.integration.test.ts
+++ b/packages/daemon/test/rejection-next-actions.integration.test.ts
@@ -259,7 +259,7 @@ test("executor declaration and completion context refusals name projection rebui
     assert.equal(metadata.code, "projection_unknown", JSON.stringify(metadata));
     assert.deepEqual((metadata as Record<string, unknown>).next, [
       {
-        action: "ha projection rebuild",
+        action: "ha daemon projection rebuild",
         reason: "Rebuild the unavailable canonical task projection before retrying completion.",
         authority: "person-owner",
         readCut: { revision: submittedRevision, iteration: 0, executionId },

--- a/packages/kernel/src/domain/completion-readiness.ts
+++ b/packages/kernel/src/domain/completion-readiness.ts
@@ -91,7 +91,7 @@ function evaluateCompletion(
     return one(
       "projection_unknown",
       "projection",
-      "ha projection rebuild",
+      "ha daemon projection rebuild",
       "Rebuild the unavailable canonical task projection before retrying completion.",
     );
   if (context.authorization === "denied")

--- a/packages/kernel/test/domain/task-completion-next.test.ts
+++ b/packages/kernel/test/domain/task-completion-next.test.ts
@@ -52,7 +52,7 @@ test("completion next is one pure judgment across lifecycle and unavailable-inpu
       ready,
       { ...context, projectionStatus: "pending" as const },
       "projection_unknown",
-      "ha projection rebuild",
+      "ha daemon projection rebuild",
     ],
     [
       "multiple executions",

--- a/tools/check-cli-help-contract.mjs
+++ b/tools/check-cli-help-contract.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 
@@ -8,6 +8,7 @@ const contractPath = "packages/preset/src/preset-command-contract.ts";
 const renderPath = "packages/cli/src/cli/thin-command.ts";
 const entrypointPath = "packages/cli/src/index.ts";
 const toolContractPath = "tools/tool-command-contract.mjs";
+const guidanceSourcePaths = ["packages/kernel/src/domain/completion-readiness.ts"];
 const unknownOptionProbe = "--policy-conformance-probe";
 let loadSequence = 0;
 
@@ -15,24 +16,47 @@ export async function findCliHelpContractViolations(rootDir = process.cwd(), opt
   const source = readFileSync(path.join(rootDir, commandPath), "utf8");
   const render = readFileSync(path.join(rootDir, renderPath), "utf8");
   const entrypoint = readFileSync(path.join(rootDir, entrypointPath), "utf8");
-  const loaded = await loadCommands(rootDir), commands = options.commands ?? loaded.commands, violations = [];
+  const loaded = await loadCommands(rootDir),
+    commands = options.commands ?? loaded.commands,
+    violations = [];
   const minimumCommands = options.minimumCommands ?? 13;
-  if (commands.length < minimumCommands) violations.push(`thin command directory contains ${commands.length} commands (< ${minimumCommands}); refusing a vacuous help surface`);
+  if (commands.length < minimumCommands)
+    violations.push(
+      `thin command directory contains ${commands.length} commands (< ${minimumCommands}); refusing a vacuous help surface`,
+    );
   const usages = commands.map(({ usage }) => usage);
-  for (const duplicate of new Set(usages.filter((usage, index) => usages.indexOf(usage) !== index))) violations.push(`duplicate CLI usage: ${duplicate}`);
+  for (const duplicate of new Set(usages.filter((usage, index) => usages.indexOf(usage) !== index)))
+    violations.push(`duplicate CLI usage: ${duplicate}`);
   for (const command of commands) {
     if (!command.usage.startsWith("ha ")) violations.push(`usage must start with ha: ${command.usage}`);
     if (!command.summary.trim()) violations.push(`command ${command.usage} is missing summary`);
-    const routeFlags = new Set(command.path.filter((token) => token.startsWith("--"))), parserFlags = new Set(command.inputs.map(({ name }) => name)), usageFlags = flags(command.usage), help = typeof command.help === "string" ? command.help : `${command.usage}\n${command.summary}`;
-    for (const flag of usageFlags) if (!routeFlags.has(flag) && !parserFlags.has(flag)) violations.push(`command ${command.usage} documents unsupported option ${flag}`);
-    for (const flag of parserFlags) if (!usageFlags.includes(flag)) violations.push(`command ${command.usage} omits declared option ${flag}`);
-    for (const input of command.inputs) checkInputHelp(command, input, help, violations, loaded.regexLength, loaded.parameterRelationHint);
+    const routeFlags = new Set(command.path.filter((token) => token.startsWith("--"))),
+      parserFlags = new Set(command.inputs.map(({ name }) => name)),
+      usageFlags = flags(command.usage),
+      help = typeof command.help === "string" ? command.help : `${command.usage}\n${command.summary}`;
+    for (const flag of usageFlags)
+      if (!routeFlags.has(flag) && !parserFlags.has(flag))
+        violations.push(`command ${command.usage} documents unsupported option ${flag}`);
+    for (const flag of parserFlags)
+      if (!usageFlags.includes(flag)) violations.push(`command ${command.usage} omits declared option ${flag}`);
+    for (const input of command.inputs)
+      checkInputHelp(command, input, help, violations, loaded.regexLength, loaded.parameterRelationHint);
   }
   checkCliUnknownOptionHints(rootDir, commands, loaded.parseThinCommand, violations);
   checkToolUnknownOptionHints(loaded.toolCommands, loaded.parseToolOptions, violations);
-  if (!/argv\.length\s*===\s*0\s*\|\|\s*argv\.includes\("--help"\)/u.test(entrypoint) || !entrypoint.includes("renderThinHelp()")) violations.push("CLI entrypoint must render the derived thin command directory for empty argv and --help");
-  if (!/thinCliCommands\.map\(\(\{\s*usage,\s*summary,\s*help\s*\}\)/u.test(render) || !/help\s*\?\s*`\\n\$\{help\}`/u.test(render)) violations.push("help output must derive input details from the command contract");
-  if (/CliResult\/v1|command-registry/u.test(`${source}\n${entrypoint}`)) violations.push("thin help must not depend on the retired CLI registry or CliResult/v1");
+  checkGuidanceCommandLiterals(rootDir, commands, violations);
+  if (
+    !/argv\.length\s*===\s*0\s*\|\|\s*argv\.includes\("--help"\)/u.test(entrypoint) ||
+    !entrypoint.includes("renderThinHelp()")
+  )
+    violations.push("CLI entrypoint must render the derived thin command directory for empty argv and --help");
+  if (
+    !/thinCliCommands\.map\(\(\{\s*usage,\s*summary,\s*help\s*\}\)/u.test(render) ||
+    !/help\s*\?\s*`\\n\$\{help\}`/u.test(render)
+  )
+    violations.push("help output must derive input details from the command contract");
+  if (/CliResult\/v1|command-registry/u.test(`${source}\n${entrypoint}`))
+    violations.push("thin help must not depend on the retired CLI registry or CliResult/v1");
   return violations;
 }
 
@@ -42,58 +66,193 @@ export async function findCliHelpContractViolations(rootDir = process.cwd(), opt
 function checkCliUnknownOptionHints(rootDir, commands, parseThinCommand, violations) {
   for (const command of commands) {
     const result = parseThinCommand([...probeCliPath(command), unknownOptionProbe], rootDir, [command]);
-    const sharedRejection = result.ok === false && (result.code === "unknown_field" || command.path[0] === "task" && result.code === "unsupported_command");
+    const sharedRejection =
+      result.ok === false &&
+      (result.code === "unknown_field" || (command.path[0] === "task" && result.code === "unsupported_command"));
     if (!sharedRejection) continue;
     const expected = `ha ${command.path.join(" ")} --help`;
-    if (!actionableUnknownOptionHint(result.nextAction, expected, command.inputs.map(({ name }) => name))) violations.push(`command ${command.usage} [unknown-option-hint]: rejection must name ${expected} or the accepted option set`);
+    if (
+      !actionableUnknownOptionHint(
+        result.nextAction,
+        expected,
+        command.inputs.map(({ name }) => name),
+      )
+    )
+      violations.push(
+        `command ${command.usage} [unknown-option-hint]: rejection must name ${expected} or the accepted option set`,
+      );
   }
 }
 
 function checkToolUnknownOptionHints(commands, parseToolOptions, violations) {
   for (const command of commands) {
     let message = "";
-    try { parseToolOptions(command, [unknownOptionProbe]); }
-    catch (error) { message = error instanceof Error ? error.message : String(error); }
+    try {
+      parseToolOptions(command, [unknownOptionProbe]);
+    } catch (error) {
+      message = error instanceof Error ? error.message : String(error);
+    }
     const expected = `node ${command.entry} --help`;
-    if (!message || !actionableUnknownOptionHint(message, expected, command.options.map(({ name }) => name))) violations.push(`tool ${command.id} [unknown-option-hint]: rejection must name ${expected} or the accepted option set`);
+    if (
+      !message ||
+      !actionableUnknownOptionHint(
+        message,
+        expected,
+        command.options.map(({ name }) => name),
+      )
+    )
+      violations.push(
+        `tool ${command.id} [unknown-option-hint]: rejection must name ${expected} or the accepted option set`,
+      );
   }
+}
+
+// Hand-written next-step guidance keeps its own copy of CLI command surfaces. The check stays
+// mechanical, mirroring the boundary above: every "ha …" literal in a guidance source must resolve
+// to a command in the thin CLI directory (longest path prefix), and every --flag it passes must be
+// declared on that command. Wording and semantics stay outside this boundary. Sources absent from
+// the fixture tree are skipped so contract tests opt in by writing the file.
+function checkGuidanceCommandLiterals(rootDir, commands, violations) {
+  for (const relativePath of guidanceSourcePaths) {
+    const absolutePath = path.join(rootDir, relativePath);
+    if (!existsSync(absolutePath)) continue;
+    const source = readFileSync(absolutePath, "utf8");
+    for (const match of source.matchAll(/(["`])ha (?:(?!\1).)*\1/gu)) {
+      const literal = match[0].slice(1, -1),
+        tokens = literal.split(/\s+/u).slice(1);
+      const command = longestGuidanceCommand(commands, tokens);
+      if (!command) {
+        violations.push(`${relativePath} [guidance-command]: "${literal}" names no command in the thin CLI directory`);
+        continue;
+      }
+      const declared = new Set([...command.path, ...command.inputs.map(({ name }) => name)]);
+      for (const token of tokens.slice(command.path.length))
+        if (token.startsWith("--") && !declared.has(token))
+          violations.push(
+            `${relativePath} [guidance-command]: "${literal}" passes undeclared option ${token} to ${command.usage}`,
+          );
+    }
+  }
+}
+
+function longestGuidanceCommand(commands, tokens) {
+  let best = null;
+  for (const command of commands) {
+    if (command.path.length === 0 || !command.path.every((word, index) => tokens[index] === word)) continue;
+    if (best === null || command.path.length > best.path.length) best = command;
+  }
+  return best;
 }
 
 function actionableUnknownOptionHint(message, exactHelp, optionNames) {
   if (message.includes(exactHelp)) return true;
-  return optionNames.length === 0 ? /\btakes no options\b/iu.test(message) : optionNames.every((name) => message.includes(name));
+  return optionNames.length === 0
+    ? /\btakes no options\b/iu.test(message)
+    : optionNames.every((name) => message.includes(name));
 }
 
 function probeCliPath(command) {
   const positionalRegex = typeof command.positionalRegex === "string" ? new RegExp(command.positionalRegex, "u") : null;
-  const positionalSample = positionalRegex ? ["sample", "vertical:sample:sample", "preset:sample/check"].find((value) => positionalRegex.test(value)) ?? "sample" : "sample";
-  return command.syntaxPath.flatMap((token) => token.startsWith("[") ? [] : [token.replaceAll(/<([^>]+)>/gu, (_match, choices) => choices.includes("|") ? choices.split("|")[0] : positionalSample)]);
+  const positionalSample = positionalRegex
+    ? (["sample", "vertical:sample:sample", "preset:sample/check"].find((value) => positionalRegex.test(value)) ??
+      "sample")
+    : "sample";
+  return command.syntaxPath.flatMap((token) =>
+    token.startsWith("[")
+      ? []
+      : [
+          token.replaceAll(/<([^>]+)>/gu, (_match, choices) =>
+            choices.includes("|") ? choices.split("|")[0] : positionalSample,
+          ),
+        ],
+  );
 }
 
 function checkInputHelp(command, input, help, violations, regexLength, parameterRelationHint) {
   const prefix = `command ${command.usage} input ${input.name}`;
-  if (input.required && !/\brequired\b/u.test(helpForInput(help, input))) violations.push(`${prefix} [parameter-relations]: required input is not visible in help`);
+  if (input.required && !/\brequired\b/u.test(helpForInput(help, input)))
+    violations.push(`${prefix} [parameter-relations]: required input is not visible in help`);
   if (Array.isArray(input.jsonFields)) {
-    for (const field of input.jsonFields) if (!helpForInput(help, input).includes(field)) violations.push(`${prefix} [json-fields]: help omits required JSON field ${field}`);
-  } else if (input.name === "--from-file" || input.name === "--json-input") violations.push(`${prefix} [json-fields]: structured JSON input must declare required fields in the input contract`);
-  if (Array.isArray(input.enum)) for (const value of input.enum) if (!helpForInput(help, input).includes(value)) violations.push(`${prefix} [enum-values]: help omits enum value ${value}`);
-  const explicitBounds = input.minLength !== undefined || input.maxLength !== undefined, bounds = explicitBounds ? [input.minLength ?? 0, input.maxLength ?? "∞"] : regexLength(input.regex);
-  if (input.regex && !explicitBounds && bounds && regexLength(`x${input.regex}`)) violations.push(`${prefix} [constraints]: regex-derived length must be constrained by the entire input`);
-  if (bounds && (!helpForInput(help, input).includes(`length: ${bounds[0]}..${bounds[1]}`) || !/\b(?:characters?|bytes?)\b/iu.test(helpForInput(help, input)))) violations.push(`${prefix} [constraints]: bounded length must be visible with a character/byte unit`);
+    for (const field of input.jsonFields)
+      if (!helpForInput(help, input).includes(field))
+        violations.push(`${prefix} [json-fields]: help omits required JSON field ${field}`);
+  } else if (input.name === "--from-file" || input.name === "--json-input")
+    violations.push(
+      `${prefix} [json-fields]: structured JSON input must declare required fields in the input contract`,
+    );
+  if (Array.isArray(input.enum))
+    for (const value of input.enum)
+      if (!helpForInput(help, input).includes(value))
+        violations.push(`${prefix} [enum-values]: help omits enum value ${value}`);
+  const explicitBounds = input.minLength !== undefined || input.maxLength !== undefined,
+    bounds = explicitBounds ? [input.minLength ?? 0, input.maxLength ?? "∞"] : regexLength(input.regex);
+  if (input.regex && !explicitBounds && bounds && regexLength(`x${input.regex}`))
+    violations.push(`${prefix} [constraints]: regex-derived length must be constrained by the entire input`);
+  if (
+    bounds &&
+    (!helpForInput(help, input).includes(`length: ${bounds[0]}..${bounds[1]}`) ||
+      !/\b(?:characters?|bytes?)\b/iu.test(helpForInput(help, input)))
+  )
+    violations.push(`${prefix} [constraints]: bounded length must be visible with a character/byte unit`);
   if (input.minItems !== undefined || input.maxItems !== undefined) {
     const count = `count: ${input.minItems ?? 0}..${input.maxItems ?? "∞"}`;
-    if (!helpForInput(help, input).includes(count) || !/\bitems?\b/iu.test(helpForInput(help, input))) violations.push(`${prefix} [constraints]: item count must be visible with an item unit`);
+    if (!helpForInput(help, input).includes(count) || !/\bitems?\b/iu.test(helpForInput(help, input)))
+      violations.push(`${prefix} [constraints]: item count must be visible with an item unit`);
   }
-  if (input.unique && !/\bunique\b/iu.test(helpForInput(help, input))) violations.push(`${prefix} [constraints]: uniqueness must be visible in help`);
-  for (const relation of [...(input.requires ?? []), ...(input.requiresAny ?? []), ...(input.conflictsWith ?? [])]) if (!helpForInput(help, input).includes(relation)) violations.push(`${prefix} [parameter-relations]: help omits relation ${relation}`);
-  if (parameterRelationHint(input.error.nextAction) && !helpForInput(help, input).includes(input.error.nextAction)) violations.push(`${prefix} [parameter-relations]: help omits declared relationship hint`);
-  if (input.format && !helpForInput(help, input).includes(input.format)) violations.push(`${prefix} [structured-format]: help omits format ${input.format}`);
-  if (input.regex && !input.format && !helpForInput(help, input).includes(input.regex) && !helpForInput(help, input).includes(input.error.nextAction)) violations.push(`${prefix} [structured-format]: help omits declared input format`);
-  if (/(?:\bcannot\b|\bnot allowed\b|\bnot permitted\b|\bforbidden\b|\bprohibited\b)/iu.test(input.error.nextAction) && !/(?:--[a-z0-9-]+|\bha\s+[a-z][a-z0-9-]*(?:\s+[a-z][a-z0-9-]*)?\b)/iu.test(input.error.nextAction)) violations.push(`${prefix} [actionable-hint]: negative hint must name a command or flag for the next step`);
+  if (input.unique && !/\bunique\b/iu.test(helpForInput(help, input)))
+    violations.push(`${prefix} [constraints]: uniqueness must be visible in help`);
+  for (const relation of [...(input.requires ?? []), ...(input.requiresAny ?? []), ...(input.conflictsWith ?? [])])
+    if (!helpForInput(help, input).includes(relation))
+      violations.push(`${prefix} [parameter-relations]: help omits relation ${relation}`);
+  if (parameterRelationHint(input.error.nextAction) && !helpForInput(help, input).includes(input.error.nextAction))
+    violations.push(`${prefix} [parameter-relations]: help omits declared relationship hint`);
+  if (input.format && !helpForInput(help, input).includes(input.format))
+    violations.push(`${prefix} [structured-format]: help omits format ${input.format}`);
+  if (
+    input.regex &&
+    !input.format &&
+    !helpForInput(help, input).includes(input.regex) &&
+    !helpForInput(help, input).includes(input.error.nextAction)
+  )
+    violations.push(`${prefix} [structured-format]: help omits declared input format`);
+  if (
+    /(?:\bcannot\b|\bnot allowed\b|\bnot permitted\b|\bforbidden\b|\bprohibited\b)/iu.test(input.error.nextAction) &&
+    !/(?:--[a-z0-9-]+|\bha\s+[a-z][a-z0-9-]*(?:\s+[a-z][a-z0-9-]*)?\b)/iu.test(input.error.nextAction)
+  )
+    violations.push(`${prefix} [actionable-hint]: negative hint must name a command or flag for the next step`);
 }
 
-function helpForInput(help, input) { return help.split(/\r?\n/u).filter((line) => line.includes(input.name)).join("\n"); }
-async function loadCommands(rootDir) { const query = `?cli-help=${loadSequence += 1}`, [module, contract, parser, tools] = await Promise.all([import(`${pathToFileURL(path.join(rootDir, commandPath)).href}${query}`), import(`${pathToFileURL(path.join(rootDir, contractPath)).href}${query}`), import(`${pathToFileURL(path.join(rootDir, renderPath)).href}${query}`), import(`${pathToFileURL(path.join(rootDir, toolContractPath)).href}${query}`)]); return { commands: module.daemonProtocolCommands ?? module.thinCliCommands, regexLength: contract.regexLength, parameterRelationHint: contract.parameterRelationHint, parseThinCommand: parser.parseThinCommand, toolCommands: tools.supportedToolCommands, parseToolOptions: tools.parseToolOptions }; }
-function flags(source) { return [...new Set([...source.matchAll(/--[a-z0-9-]+/gu)].map((match) => match[0]))]; }
-async function main() { const violations = await findCliHelpContractViolations(); if (violations.length === 0) return; console.error("CLI help contract gate failed:"); for (const violation of violations) console.error(`- ${violation}`); process.exitCode = 1; }
+function helpForInput(help, input) {
+  return help
+    .split(/\r?\n/u)
+    .filter((line) => line.includes(input.name))
+    .join("\n");
+}
+async function loadCommands(rootDir) {
+  const query = `?cli-help=${(loadSequence += 1)}`,
+    [module, contract, parser, tools] = await Promise.all([
+      import(`${pathToFileURL(path.join(rootDir, commandPath)).href}${query}`),
+      import(`${pathToFileURL(path.join(rootDir, contractPath)).href}${query}`),
+      import(`${pathToFileURL(path.join(rootDir, renderPath)).href}${query}`),
+      import(`${pathToFileURL(path.join(rootDir, toolContractPath)).href}${query}`),
+    ]);
+  return {
+    commands: module.daemonProtocolCommands ?? module.thinCliCommands,
+    regexLength: contract.regexLength,
+    parameterRelationHint: contract.parameterRelationHint,
+    parseThinCommand: parser.parseThinCommand,
+    toolCommands: tools.supportedToolCommands,
+    parseToolOptions: tools.parseToolOptions,
+  };
+}
+function flags(source) {
+  return [...new Set([...source.matchAll(/--[a-z0-9-]+/gu)].map((match) => match[0]))];
+}
+async function main() {
+  const violations = await findCliHelpContractViolations();
+  if (violations.length === 0) return;
+  console.error("CLI help contract gate failed:");
+  for (const violation of violations) console.error(`- ${violation}`);
+  process.exitCode = 1;
+}
 if (path.resolve(process.argv[1] ?? "") === new URL(import.meta.url).pathname) await main();

--- a/tools/check-cli-help-contract.test.mjs
+++ b/tools/check-cli-help-contract.test.mjs
@@ -6,92 +6,360 @@ import path from "node:path";
 import test from "node:test";
 import { findCliHelpContractViolations } from "./check-cli-help-contract.mjs";
 
-test("thin help contract accepts a derived current command directory", () => withFixture(async ({ rootDir }) => {
-  assert.deepEqual(await findCliHelpContractViolations(rootDir, { minimumCommands: 1 }), []);
-}));
+test("thin help contract accepts a derived current command directory", () =>
+  withFixture(async ({ rootDir }) => {
+    assert.deepEqual(await findCliHelpContractViolations(rootDir, { minimumCommands: 1 }), []);
+  }));
 
-test("thin help contract rejects an old shared unknown-option hint", () => withFixture(async ({ rootDir, renderPath }) => {
-  writeFileSync(renderPath, thinCommandSource(false));
-  assert.match((await findCliHelpContractViolations(rootDir, { minimumCommands: 1 })).join("\n"), /\[unknown-option-hint\].*ha task show --help/u);
-}));
+test("thin help contract rejects an old shared unknown-option hint", () =>
+  withFixture(async ({ rootDir, renderPath }) => {
+    writeFileSync(renderPath, thinCommandSource(false));
+    assert.match(
+      (await findCliHelpContractViolations(rootDir, { minimumCommands: 1 })).join("\n"),
+      /\[unknown-option-hint\].*ha task show --help/u,
+    );
+  }));
 
-test("thin help contract rejects an old tool unknown-option hint", () => withFixture(async ({ rootDir, toolPath }) => {
-  writeFileSync(toolPath, toolCommandSource(false));
-  assert.match((await findCliHelpContractViolations(rootDir, { minimumCommands: 1 })).join("\n"), /tool fixture-tool \[unknown-option-hint\].*node tools\/fixture\.mjs --help/u);
-}));
+test("thin help contract rejects an old tool unknown-option hint", () =>
+  withFixture(async ({ rootDir, toolPath }) => {
+    writeFileSync(toolPath, toolCommandSource(false));
+    assert.match(
+      (await findCliHelpContractViolations(rootDir, { minimumCommands: 1 })).join("\n"),
+      /tool fixture-tool \[unknown-option-hint\].*node tools\/fixture\.mjs --help/u,
+    );
+  }));
 
-test("thin help contract derives route flags from command paths", () => withFixture(async ({ rootDir, commandPath }) => {
-  writeFileSync(commandPath, commandSource("ha doc sync --dry-run", "Preview documents.", ["doc", "sync", "--dry-run"]));
-  assert.deepEqual(await findCliHelpContractViolations(rootDir, { minimumCommands: 1 }), []);
-  writeFileSync(commandPath, commandSource("ha doc sync --dry-run", "Preview documents.", ["doc", "sync"]));
-  assert.match((await findCliHelpContractViolations(rootDir, { minimumCommands: 1 })).join("\n"), /documents unsupported option --dry-run/u);
-}));
+test("thin help contract derives route flags from command paths", () =>
+  withFixture(async ({ rootDir, commandPath }) => {
+    writeFileSync(
+      commandPath,
+      commandSource("ha doc sync --dry-run", "Preview documents.", ["doc", "sync", "--dry-run"]),
+    );
+    assert.deepEqual(await findCliHelpContractViolations(rootDir, { minimumCommands: 1 }), []);
+    writeFileSync(commandPath, commandSource("ha doc sync --dry-run", "Preview documents.", ["doc", "sync"]));
+    assert.match(
+      (await findCliHelpContractViolations(rootDir, { minimumCommands: 1 })).join("\n"),
+      /documents unsupported option --dry-run/u,
+    );
+  }));
 
-test("thin help contract rejects options missing from structured inputs", () => withFixture(async ({ rootDir, commandPath }) => {
-  writeFileSync(commandPath, commandSource("ha task show <id> --ghost", "Show a task."));
-  assert.match((await findCliHelpContractViolations(rootDir, { minimumCommands: 1 })).join("\n"), /documents unsupported option --ghost/u);
-}));
+test("thin help contract rejects options missing from structured inputs", () =>
+  withFixture(async ({ rootDir, commandPath }) => {
+    writeFileSync(commandPath, commandSource("ha task show <id> --ghost", "Show a task."));
+    assert.match(
+      (await findCliHelpContractViolations(rootDir, { minimumCommands: 1 })).join("\n"),
+      /documents unsupported option --ghost/u,
+    );
+  }));
 
-test("thin help contract rejects vacuous and duplicate directories", () => withFixture(async ({ rootDir, commandPath }) => {
-  writeFileSync(commandPath, commandModule([{ path: ["daemon", "status"], usage: "ha daemon status", summary: "Status.", inputs: [] }, { path: ["daemon", "status"], usage: "ha daemon status", summary: "Again.", inputs: [] }]));
-  const violations = await findCliHelpContractViolations(rootDir, { minimumCommands: 3 });
-  assert.match(violations.join("\n"), /vacuous/u); assert.match(violations.join("\n"), /duplicate CLI usage/u);
-}));
+test("thin help contract rejects vacuous and duplicate directories", () =>
+  withFixture(async ({ rootDir, commandPath }) => {
+    writeFileSync(
+      commandPath,
+      commandModule([
+        { path: ["daemon", "status"], usage: "ha daemon status", summary: "Status.", inputs: [] },
+        { path: ["daemon", "status"], usage: "ha daemon status", summary: "Again.", inputs: [] },
+      ]),
+    );
+    const violations = await findCliHelpContractViolations(rootDir, { minimumCommands: 3 });
+    assert.match(violations.join("\n"), /vacuous/u);
+    assert.match(violations.join("\n"), /duplicate CLI usage/u);
+  }));
 
-test("thin help contract rejects entrypoints that do not render the directory", () => withFixture(async ({ rootDir, entryPath }) => {
-  writeFileSync(entryPath, "export function main() { return 0; }\n");
-  assert.match((await findCliHelpContractViolations(rootDir, { minimumCommands: 1 })).join("\n"), /empty argv and --help/u);
-}));
+test("thin help contract rejects entrypoints that do not render the directory", () =>
+  withFixture(async ({ rootDir, entryPath }) => {
+    writeFileSync(entryPath, "export function main() { return 0; }\n");
+    assert.match(
+      (await findCliHelpContractViolations(rootDir, { minimumCommands: 1 })).join("\n"),
+      /empty argv and --help/u,
+    );
+  }));
 
-test("thin help contract requires every structured JSON packet to list its required fields", () => withFixture(async ({ rootDir, commandPath }) => {
-  const input = { name: "--from-file", kind: "single", required: true, jsonFields: ["alpha", "beta"], error: { code: "invalid_field", nextAction: "Use --from-file <packet.json>." } };
-  writeFileSync(commandPath, commandSource("ha task submit <task-id> --from-file <from-file>", "Submit.", ["task", "submit", "<task-id>"], [input], "    --from-file — required; JSON required fields: alpha"));
-  const violations = await findCliHelpContractViolations(rootDir, { minimumCommands: 1 });
-  assert.match(violations.join("\n"), /\[json-fields\].*beta/u);
-}));
+test("thin help contract requires every structured JSON packet to list its required fields", () =>
+  withFixture(async ({ rootDir, commandPath }) => {
+    const input = {
+      name: "--from-file",
+      kind: "single",
+      required: true,
+      jsonFields: ["alpha", "beta"],
+      error: { code: "invalid_field", nextAction: "Use --from-file <packet.json>." },
+    };
+    writeFileSync(
+      commandPath,
+      commandSource(
+        "ha task submit <task-id> --from-file <from-file>",
+        "Submit.",
+        ["task", "submit", "<task-id>"],
+        [input],
+        "    --from-file — required; JSON required fields: alpha",
+      ),
+    );
+    const violations = await findCliHelpContractViolations(rootDir, { minimumCommands: 1 });
+    assert.match(violations.join("\n"), /\[json-fields\].*beta/u);
+  }));
 
-test("thin help contract requires enum values to be projected into help", () => withFixture(async ({ rootDir, commandPath }) => {
-  const input = { name: "--mode", kind: "single", required: false, enum: ["alpha", "beta"], error: { code: "invalid_field", nextAction: "Use --mode." } };
-  writeFileSync(commandPath, commandSource("ha demo inspect --mode <mode>", "Inspect.", ["demo", "inspect"], [input], "    --mode — optional; values: alpha"));
-  assert.match((await findCliHelpContractViolations(rootDir, { minimumCommands: 1 })).join("\n"), /\[enum-values\].*beta/u);
-}));
+test("thin help contract requires enum values to be projected into help", () =>
+  withFixture(async ({ rootDir, commandPath }) => {
+    const input = {
+      name: "--mode",
+      kind: "single",
+      required: false,
+      enum: ["alpha", "beta"],
+      error: { code: "invalid_field", nextAction: "Use --mode." },
+    };
+    writeFileSync(
+      commandPath,
+      commandSource(
+        "ha demo inspect --mode <mode>",
+        "Inspect.",
+        ["demo", "inspect"],
+        [input],
+        "    --mode — optional; values: alpha",
+      ),
+    );
+    assert.match(
+      (await findCliHelpContractViolations(rootDir, { minimumCommands: 1 })).join("\n"),
+      /\[enum-values\].*beta/u,
+    );
+  }));
 
-test("thin help contract requires bounded constraints and units to be visible", () => withFixture(async ({ rootDir, commandPath }) => {
-  const input = { name: "--rationale", kind: "single", required: true, minLength: 1, maxLength: 199, lengthUnit: "characters", error: { code: "invalid_field", nextAction: "Provide a rationale." } };
-  writeFileSync(commandPath, commandSource("ha decision accept <id> --rationale <rationale>", "Accept.", ["decision", "accept", "<id>"], [input], "    --rationale — required"));
-  assert.match((await findCliHelpContractViolations(rootDir, { minimumCommands: 1 })).join("\n"), /\[constraints\].*bounded length/u);
-}));
+test("thin help contract requires bounded constraints and units to be visible", () =>
+  withFixture(async ({ rootDir, commandPath }) => {
+    const input = {
+      name: "--rationale",
+      kind: "single",
+      required: true,
+      minLength: 1,
+      maxLength: 199,
+      lengthUnit: "characters",
+      error: { code: "invalid_field", nextAction: "Provide a rationale." },
+    };
+    writeFileSync(
+      commandPath,
+      commandSource(
+        "ha decision accept <id> --rationale <rationale>",
+        "Accept.",
+        ["decision", "accept", "<id>"],
+        [input],
+        "    --rationale — required",
+      ),
+    );
+    assert.match(
+      (await findCliHelpContractViolations(rootDir, { minimumCommands: 1 })).join("\n"),
+      /\[constraints\].*bounded length/u,
+    );
+  }));
 
-test("thin help contract requires parameter relations to be visible", () => withFixture(async ({ rootDir, commandPath }) => {
-  const input = { name: "--judgment-only", kind: "single", required: false, requires: ["--rationale"], requiresAny: ["claim-to-evidence relation", "--judgment-only"], conflictsWith: ["--evidence"], error: { code: "invalid_field", nextAction: "Use --judgment-only with rationale." } };
-  writeFileSync(commandPath, commandSource("ha decision accept <id> --judgment-only <judgment-only>", "Accept.", ["decision", "accept", "<id>"], [input], "    --judgment-only — optional"));
-  assert.match((await findCliHelpContractViolations(rootDir, { minimumCommands: 1 })).join("\n"), /\[parameter-relations\].*--rationale/u);
-}));
+test("thin help contract requires parameter relations to be visible", () =>
+  withFixture(async ({ rootDir, commandPath }) => {
+    const input = {
+      name: "--judgment-only",
+      kind: "single",
+      required: false,
+      requires: ["--rationale"],
+      requiresAny: ["claim-to-evidence relation", "--judgment-only"],
+      conflictsWith: ["--evidence"],
+      error: { code: "invalid_field", nextAction: "Use --judgment-only with rationale." },
+    };
+    writeFileSync(
+      commandPath,
+      commandSource(
+        "ha decision accept <id> --judgment-only <judgment-only>",
+        "Accept.",
+        ["decision", "accept", "<id>"],
+        [input],
+        "    --judgment-only — optional",
+      ),
+    );
+    assert.match(
+      (await findCliHelpContractViolations(rootDir, { minimumCommands: 1 })).join("\n"),
+      /\[parameter-relations\].*--rationale/u,
+    );
+  }));
 
-test("thin help contract requires structured string formats to be visible", () => withFixture(async ({ rootDir, commandPath }) => {
-  const input = { name: "--evidence", kind: "repeated", required: false, format: "<type>:<path>:<summary>", error: { code: "invalid_field", nextAction: "Use the evidence format." } };
-  writeFileSync(commandPath, commandSource("ha task progress --evidence <evidence>...", "Append.", ["task", "progress"], [input], "    --evidence — repeatable"));
-  assert.match((await findCliHelpContractViolations(rootDir, { minimumCommands: 1 })).join("\n"), /\[structured-format\].*<type>:<path>:<summary>/u);
-}));
+test("thin help contract requires structured string formats to be visible", () =>
+  withFixture(async ({ rootDir, commandPath }) => {
+    const input = {
+      name: "--evidence",
+      kind: "repeated",
+      required: false,
+      format: "<type>:<path>:<summary>",
+      error: { code: "invalid_field", nextAction: "Use the evidence format." },
+    };
+    writeFileSync(
+      commandPath,
+      commandSource(
+        "ha task progress --evidence <evidence>...",
+        "Append.",
+        ["task", "progress"],
+        [input],
+        "    --evidence — repeatable",
+      ),
+    );
+    assert.match(
+      (await findCliHelpContractViolations(rootDir, { minimumCommands: 1 })).join("\n"),
+      /\[structured-format\].*<type>:<path>:<summary>/u,
+    );
+  }));
 
-test("thin help contract rejects negative hints without an executable next step", () => withFixture(async ({ rootDir, commandPath }) => {
-  const input = { name: "--proposal", kind: "single", required: false, error: { code: "invalid_field", nextAction: "This operation is not permitted." } };
-  writeFileSync(commandPath, commandSource("ha decision accept <id> --proposal <proposal>", "Accept.", ["decision", "accept", "<id>"], [input], "    --proposal — optional; This operation is not permitted."));
-  assert.match((await findCliHelpContractViolations(rootDir, { minimumCommands: 1 })).join("\n"), /\[actionable-hint\]/u);
-}));
+test("thin help contract rejects negative hints without an executable next step", () =>
+  withFixture(async ({ rootDir, commandPath }) => {
+    const input = {
+      name: "--proposal",
+      kind: "single",
+      required: false,
+      error: { code: "invalid_field", nextAction: "This operation is not permitted." },
+    };
+    writeFileSync(
+      commandPath,
+      commandSource(
+        "ha decision accept <id> --proposal <proposal>",
+        "Accept.",
+        ["decision", "accept", "<id>"],
+        [input],
+        "    --proposal — optional; This operation is not permitted.",
+      ),
+    );
+    assert.match(
+      (await findCliHelpContractViolations(rootDir, { minimumCommands: 1 })).join("\n"),
+      /\[actionable-hint\]/u,
+    );
+  }));
 
-test("thin help contract accepts a complete projection of input constraints", () => withFixture(async ({ rootDir, commandPath }) => {
-  const input = { name: "--judgment-only", kind: "single", required: true, enum: ["reviewed"], minLength: 1, maxLength: 199, lengthUnit: "characters", format: "<rationale>", requires: ["--rationale"], requiresAny: ["claim-to-evidence relation", "--judgment-only"], conflictsWith: ["--evidence"], error: { code: "invalid_field", nextAction: "Use --judgment-only <rationale>." } };
-  const help = "    --judgment-only — required; values: reviewed; length: 1..199 characters; format: <rationale>; requires: --rationale; requires one of: claim-to-evidence relation, --judgment-only; mutually exclusive with: --evidence; next: Use --judgment-only <rationale>.";
-  writeFileSync(commandPath, commandSource("ha decision accept <id> --judgment-only <reviewed>", "Accept.", ["decision", "accept", "<id>"], [input], help));
-  assert.deepEqual(await findCliHelpContractViolations(rootDir, { minimumCommands: 1 }), []);
-}));
+test("thin help contract accepts a complete projection of input constraints", () =>
+  withFixture(async ({ rootDir, commandPath }) => {
+    const input = {
+      name: "--judgment-only",
+      kind: "single",
+      required: true,
+      enum: ["reviewed"],
+      minLength: 1,
+      maxLength: 199,
+      lengthUnit: "characters",
+      format: "<rationale>",
+      requires: ["--rationale"],
+      requiresAny: ["claim-to-evidence relation", "--judgment-only"],
+      conflictsWith: ["--evidence"],
+      error: { code: "invalid_field", nextAction: "Use --judgment-only <rationale>." },
+    };
+    const help =
+      "    --judgment-only — required; values: reviewed; length: 1..199 characters; format: <rationale>; requires: --rationale; requires one of: claim-to-evidence relation, --judgment-only; mutually exclusive with: --evidence; next: Use --judgment-only <rationale>.";
+    writeFileSync(
+      commandPath,
+      commandSource(
+        "ha decision accept <id> --judgment-only <reviewed>",
+        "Accept.",
+        ["decision", "accept", "<id>"],
+        [input],
+        help,
+      ),
+    );
+    assert.deepEqual(await findCliHelpContractViolations(rootDir, { minimumCommands: 1 }), []);
+  }));
 
-async function withFixture(run) { const rootDir = mkdtempSync(path.join(tmpdir(), "thin-help-"));
-  try { const commandPath = write(rootDir, "packages/daemon/src/protocol/daemon-protocol.contract.ts", commandSource("ha task show <id>", "Show a task.")); write(rootDir, "packages/preset/src/preset-command-contract.ts", "export const regexLength = () => undefined; export const parameterRelationHint = () => false;\n"); const renderPath = write(rootDir, "packages/cli/src/cli/thin-command.ts", thinCommandSource(true)), toolPath = write(rootDir, "tools/tool-command-contract.mjs", toolCommandSource(true)); const entryPath = write(rootDir, "packages/cli/src/index.ts", `if (argv.length === 0 || argv.includes("--help")) renderThinHelp();\n`); await run({ rootDir, commandPath, entryPath, renderPath, toolPath });
-  } finally { rmSync(rootDir, { recursive: true, force: true }); } }
-function commandSource(usage, summary, commandPath = ["task", "show"], inputs = [], help) { return commandModule([{ path: commandPath, usage, summary, inputs, ...(help === undefined ? {} : { help }) }]); }
-function commandModule(commands) { const projected = commands.map((command) => ({ ...command, syntaxPath: command.path, help: command.help ?? command.inputs.map((input) => `    ${input.name} — ${input.required ? "required" : "optional"}; ${input.enum ? `values: ${input.enum.join(", ")}; ` : ""}${input.error?.nextAction ?? ""}`).join("\\n") })); return `export const daemonProtocolCommands = Object.freeze(${JSON.stringify(projected)});\nexport const thinCliCommands = daemonProtocolCommands.map(({usage, summary, help}) => ({usage, summary, help}));\n`; }
-function thinCommandSource(actionable) { return `export function renderThinHelp() { return [...thinCliCommands.map(({ usage, summary, help }) => \`  \${usage}\\n    \${summary}\${help ? \`\\n\${help}\` : ""}\`)]; }\nexport function parseThinCommand(_argv, _cwd, commands) { const command = commands[0]; return { ok: false, code: "unknown_field", nextAction: ${actionable ? "`Unknown option --policy-conformance-probe. Run ha ${command.path.join(\" \")} --help.`" : '"Unknown option --policy-conformance-probe."'}, json: false }; }\n`; }
-function toolCommandSource(actionable) { return `export const supportedToolCommands = [{ id: "fixture-tool", entry: "tools/fixture.mjs", options: [{ name: "--value" }] }];\nexport function parseToolOptions(descriptor) { throw new Error(${actionable ? "`unknown option\\nRun node ${descriptor.entry} --help.`" : '"unknown option"'}); }\n`; }
-function write(rootDir, relative, body) { const file = path.join(rootDir, relative); mkdirSync(path.dirname(file), { recursive: true }); writeFileSync(file, body); return file; }
+test("thin help contract accepts guidance literals that resolve to directory commands", () =>
+  withFixture(async ({ rootDir, commandPath }) => {
+    writeFileSync(
+      commandPath,
+      commandSource(
+        "ha task show <id> --dry-run",
+        "Show a task.",
+        ["task", "show"],
+        [
+          {
+            name: "--dry-run",
+            kind: "single",
+            required: false,
+            error: { code: "invalid_field", nextAction: "Run again with --dry-run." },
+          },
+        ],
+      ),
+    );
+    write(
+      rootDir,
+      "packages/kernel/src/domain/completion-readiness.ts",
+      guidanceSource(['"ha task show t-1"', "`ha task show ${id} --dry-run`"]),
+    );
+    assert.deepEqual(await findCliHelpContractViolations(rootDir, { minimumCommands: 1 }), []);
+  }));
+
+test("thin help contract rejects guidance literals naming unknown commands", () =>
+  withFixture(async ({ rootDir }) => {
+    write(rootDir, "packages/kernel/src/domain/completion-readiness.ts", guidanceSource(['"ha projection rebuild"']));
+    assert.match(
+      (await findCliHelpContractViolations(rootDir, { minimumCommands: 1 })).join("\n"),
+      /\[guidance-command\].*ha projection rebuild.*names no command/u,
+    );
+  }));
+
+test("thin help contract rejects guidance literals passing undeclared options", () =>
+  withFixture(async ({ rootDir }) => {
+    write(
+      rootDir,
+      "packages/kernel/src/domain/completion-readiness.ts",
+      guidanceSource(['"ha task show t-1 --ghost"']),
+    );
+    assert.match(
+      (await findCliHelpContractViolations(rootDir, { minimumCommands: 1 })).join("\n"),
+      /\[guidance-command\].*--ghost.*undeclared option/u,
+    );
+  }));
+
+function guidanceSource(literals) {
+  return `const nextActions = [\n  ${literals.join(",\n  ")},\n];\n`;
+}
+async function withFixture(run) {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "thin-help-"));
+  try {
+    const commandPath = write(
+      rootDir,
+      "packages/daemon/src/protocol/daemon-protocol.contract.ts",
+      commandSource("ha task show <id>", "Show a task."),
+    );
+    write(
+      rootDir,
+      "packages/preset/src/preset-command-contract.ts",
+      "export const regexLength = () => undefined; export const parameterRelationHint = () => false;\n",
+    );
+    const renderPath = write(rootDir, "packages/cli/src/cli/thin-command.ts", thinCommandSource(true)),
+      toolPath = write(rootDir, "tools/tool-command-contract.mjs", toolCommandSource(true));
+    const entryPath = write(
+      rootDir,
+      "packages/cli/src/index.ts",
+      `if (argv.length === 0 || argv.includes("--help")) renderThinHelp();\n`,
+    );
+    await run({ rootDir, commandPath, entryPath, renderPath, toolPath });
+  } finally {
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+}
+function commandSource(usage, summary, commandPath = ["task", "show"], inputs = [], help) {
+  return commandModule([{ path: commandPath, usage, summary, inputs, ...(help === undefined ? {} : { help }) }]);
+}
+function commandModule(commands) {
+  const projected = commands.map((command) => ({
+    ...command,
+    syntaxPath: command.path,
+    help:
+      command.help ??
+      command.inputs
+        .map(
+          (input) =>
+            `    ${input.name} — ${input.required ? "required" : "optional"}; ${input.enum ? `values: ${input.enum.join(", ")}; ` : ""}${input.error?.nextAction ?? ""}`,
+        )
+        .join("\\n"),
+  }));
+  return `export const daemonProtocolCommands = Object.freeze(${JSON.stringify(projected)});\nexport const thinCliCommands = daemonProtocolCommands.map(({usage, summary, help}) => ({usage, summary, help}));\n`;
+}
+function thinCommandSource(actionable) {
+  return `export function renderThinHelp() { return [...thinCliCommands.map(({ usage, summary, help }) => \`  \${usage}\\n    \${summary}\${help ? \`\\n\${help}\` : ""}\`)]; }\nexport function parseThinCommand(_argv, _cwd, commands) { const command = commands[0]; return { ok: false, code: "unknown_field", nextAction: ${actionable ? '`Unknown option --policy-conformance-probe. Run ha ${command.path.join(" ")} --help.`' : '"Unknown option --policy-conformance-probe."'}, json: false }; }\n`;
+}
+function toolCommandSource(actionable) {
+  return `export const supportedToolCommands = [{ id: "fixture-tool", entry: "tools/fixture.mjs", options: [{ name: "--value" }] }];\nexport function parseToolOptions(descriptor) { throw new Error(${actionable ? "`unknown option\\nRun node ${descriptor.entry} --help.`" : '"unknown option"'}); }\n`;
+}
+function write(rootDir, relative, body) {
+  const file = path.join(rootDir, relative);
+  mkdirSync(path.dirname(file), { recursive: true });
+  writeFileSync(file, body);
+  return file;
+}


### PR DESCRIPTION
# English

## Summary

The kernel completion ladder (completion-readiness.ts) keeps hand-written next-step commands with no single source of truth against the CLI surface. Its projection_unknown branch told agents to run `ha projection rebuild` — a command that does not exist in the thin CLI directory (the real command is `ha daemon projection rebuild`) — and two tests pinned the wrong literal. This PR fixes the live drift and extends `check-cli-help-contract` so the whole class of drift fails CI instead of landing on agents at runtime.

## Architectural Justification

- (Not required: computed production churn is ~4 lines across kernel sources; the bulk of the diff is gate tooling plus bringing the two touched gate files into the prettier conformance configured in 383ea6521 — both files failed `prettier --check` before this PR and pass after.)

## What Changed

- `packages/kernel/src/domain/completion-readiness.ts`: `"ha projection rebuild"` → `"ha daemon projection rebuild"` (the only drift among the file's 12 `ha …` literals; the other 11 resolve cleanly).
- `tools/check-cli-help-contract.mjs`: new mechanical check — every `ha …` string literal (double-quoted or template) in the guidance source is resolved by longest path-prefix against the thin CLI directory; unknown commands and undeclared `--flags` are violations. The boundary stays mechanical (existence + flag declarations); wording stays outside, mirroring the gate's existing boundary note.
- Tests updated/pinned: `task-completion-next.test.ts`, `rejection-next-actions.integration.test.ts`; `check-cli-help-contract.test.mjs` gains three cases (accepts resolving literals incl. template placeholders and declared flags; rejects unknown command; rejects undeclared option).

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: see the computed production-delta job summary.

## Machine-Readable Declarations

Dependency-Change: none

## Task And Scope

- Harness task: task_66fc2ee125649b19e2909ea426 (guidance-command-gate)
- Branch: `codex/guidance-command-gate`
- Public scope: one kernel guidance line, one gate tool, three test files
- Private planning/evidence updated: yes (task_plan, facts F-F0B7A9BB / F-AC8FC866)
- Out of scope: deriving guidance text from the action catalog (receipt-side single-source refactor, deliberately deferred)

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: yes — `tools/check-cli-help-contract.mjs` is a contract-tier gate; this PR extends its check scope (new guidance-command check).
- Protected surface scope: purely additive checks; no existing violation rule, allowlist, or required-check mapping changed.
- Authority: repository owner authorization in session (2026-09-12), recorded in task_66fc2ee125649b19e2909ea426 and the perf-scan task ledger.
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `4850da1fc`
- Branch merge-base with `origin/main`: `4850da1fc`
- Last `git fetch origin` time: 2026-09-12 UTC
- Sync method: branched from fresh origin/main in an isolated worktree
- Public diff command: `git diff origin/main...codex/guidance-command-gate`
- Private evidence commit/path: task_66fc2ee125649b19e2909ea426 facts F-F0B7A9BB / F-AC8FC866
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: this PR's checks
- [ ] `npm ci`
- [x] `git diff --check`
- [x] `npm run typecheck` (`tsc -b --pretty false`, clean exit in worktree)
- [ ] `npm run check`
- [ ] `npm test`
- [x] `node tools/check-cli-help-contract.mjs` (exit 0 on fixed tree; positive control below)
- [x] `node --test tools/check-cli-help-contract.test.mjs` (17/17)
- [x] `node --test packages/kernel/test/domain/task-completion-next.test.ts` (3/3)
- [x] `node --test packages/daemon/test/rejection-next-actions.integration.test.ts` (9/9)

## Review Evidence

- Positive control (drift really existed): before the one-line kernel fix, the extended gate reported exactly one violation — `"ha projection rebuild" names no command` — and the other 11 guidance literals passed; after the fix the gate exits 0. This is the ground-truth for "the check fires".
- Drift audit: all 12 `ha …` literals in completion-readiness.ts were matched by longest path-prefix against `daemonProtocolCommands`; flags (`--submit --task`, `--statement --source`, `--consent`, `--execution-id`, `--dry-run` forms) were checked against each command's declared inputs.

## Residual Risk

- The gate covers the completion ladder only; other hand-written `ha …` literals elsewhere (if any appear later) join by adding one line to `guidanceSourcePaths`. Wording/semantics of guidance remain outside the mechanical boundary.
- The prettier rewrap of the two touched gate files inflates the diff; logical change is ~90 lines.

## References

- Task task_66fc2ee125649b19e2909ea426 (one-path guidance gate); drift first surfaced in task_6eba9c5d3a55735920aa4856f3 research line (2026-09-12).

---

# 中文

## 概要

kernel 完成判决梯（completion-readiness.ts）手写下一步命令，与 CLI 面没有单一真源。其 projection_unknown 分支让 agent 跑 `ha projection rebuild`——thin CLI 目录里不存在这条命令（真实命令是 `ha daemon projection rebuild`），且两个测试把错误字面量钉死了。本 PR 修掉这个活漂移，并扩展 `check-cli-help-contract`，使这一类漂移在 CI 拦下，而不是运行时落到 agent 头上。

## 架构辩护

- （不需要：kernel 生产面净变化约 4 行；diff 大头是门工具，外加把两个被触碰的门文件带入 383ea6521 配置的 prettier 合规——这两个文件在本 PR 前过不了 `prettier --check`，现在通过。）

## 改动内容

- `packages/kernel/src/domain/completion-readiness.ts`：`"ha projection rebuild"` → `"ha daemon projection rebuild"`（该文件 12 个 `ha …` 字面量中的唯一漂移，其余 11 个全部可解析）。
- `tools/check-cli-help-contract.mjs`：新增机械检查——guidance 源中每个 `ha …` 字符串字面量（双引号或模板串）按最长路径前缀对 thin CLI 目录解析；未知命令与未声明的 `--flag` 记 violation。边界保持机械（存在性 + 旗标声明）；文案语义仍在线外，顺延门既有的边界注释。
- 测试更新/钉值：`task-completion-next.test.ts`、`rejection-next-actions.integration.test.ts`；`check-cli-help-contract.test.mjs` 新增三用例（接受可解析字面量，含模板占位与已声明旗标；拒绝未知命令；拒绝未声明旗标）。

## 门收割 / Gate Harvest

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: 见 production-delta 作业汇总。

## 机器可读声明

（本节声明仅在上文英文块中每项一次。）

## 任务与范围

- Harness 任务：task_66fc2ee125649b19e2909ea426（guidance-command-gate）
- 分支：`codex/guidance-command-gate`
- 公开面：kernel 一行指引、一个门工具、三个测试文件
- 私有台账：task_plan 与 facts F-F0B7A9BB / F-AC8FC866 已更新
- 范围外：指引文本从 action catalog 派生（receipt 侧单一真源化改造，刻意延后）

## 版本影响

- 版本：无变化
- 发布影响：无发布

## 治理声明

- 触碰保护面：是——`tools/check-cli-help-contract.mjs` 属 contract-tier 门，本 PR 扩展其检查范围（新增 guidance-command 检查）。
- 保护面范围：纯增量检查；未改任何既有 violation 规则、allowlist 或 required-check 映射。
- 授权：仓库所有者会话授权（2026-09-12），记录于 task_66fc2ee125649b19e2909ea426 与性能扫描任务台账。
- 机器检查边界：本 PR 只断言声明存在；内容真假与是否充分由评审裁定。
- 破窗：无
- 破窗理由：不适用
- 破窗范围：不适用
- 后续治理任务：不适用

## 验证

- 基准 `origin/main` SHA：`4850da1fc`
- 分支与 `origin/main` 的 merge-base：`4850da1fc`
- 最近 `git fetch origin`：2026-09-12 UTC
- 同步方式：隔离 worktree 自新 origin/main 切出
- 公开 diff 命令：`git diff origin/main...codex/guidance-command-gate`
- 私有证据：task_66fc2ee125649b19e2909ea426 facts F-F0B7A9BB / F-AC8FC866
- 评审证据：本 PR Review Evidence 节
- GitHub Actions `rewrite-ci`：本 PR checks
- [ ] `npm ci`
- [x] `git diff --check`
- [x] `npm run typecheck`（worktree 内 `tsc -b --pretty false` 干净退出）
- [ ] `npm run check`
- [ ] `npm test`
- [x] `node tools/check-cli-help-contract.mjs`（修复树 exit 0；阳性对照见下）
- [x] `node --test tools/check-cli-help-contract.test.mjs`（17/17）
- [x] `node --test packages/kernel/test/domain/task-completion-next.test.ts`（3/3）
- [x] `node --test packages/daemon/test/rejection-next-actions.integration.test.ts`（9/9）

## 评审证据

- 阳性对照（漂移真实存在）：单行 kernel 修复前，扩展后的门恰好报一条 violation——`"ha projection rebuild" names no command`——其余 11 条指引字面量全过；修复后门 exit=0。这是「检查器会出声」的地面真值。
- 漂移审计：completion-readiness.ts 全部 12 个 `ha …` 字面量按最长路径前缀对 `daemonProtocolCommands` 匹配；旗标（`--submit --task`、`--statement --source`、`--consent`、`--execution-id`、`--dry-run` 形态）逐一对各命令声明输入核验。

## 残余风险

- 门只覆盖完成判决梯；后续其它手写 `ha …` 字面量出现时，向 `guidanceSourcePaths` 加一行即可纳入。指引文案语义仍在机械边界之外。
- 两个门文件的 prettier 重排放大了 diff；逻辑变更约 90 行。

## 参考

- 任务 task_66fc2ee125649b19e2909ea426（一条路指引门）；漂移最早发现于 task_6eba9c5d3a55735920aa4856f3 研究线（2026-09-12）。