### PR TITLE
feat: publish daemon host entry and replace CLI hosting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9598,6 +9598,7 @@
         "@effect/platform": "0.96.2",
         "@effect/sql": "0.51.1",
         "@effect/sql-sqlite-node": "0.52.0",
+        "@harness-anything/daemon": "0.0.1",
         "cron-parser": "5.10.0",
         "effect": "3.21.4",
         "node-pty": "1.1.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9612,12 +9612,22 @@
     },
     "packages/daemon": {
       "name": "@harness-anything/daemon",
-      "version": "0.0.0",
+      "version": "0.0.1",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
-        "@harness-anything/adapter-local": "0.0.0",
-        "@harness-anything/adapter-multica": "0.0.0",
+        "@effect/experimental": "0.60.0",
+        "@effect/platform": "0.96.2",
+        "@effect/sql": "0.51.1",
+        "@effect/sql-sqlite-node": "0.52.0",
+        "cron-parser": "5.10.0",
+        "effect": "3.21.4",
         "node-pty": "1.1.0"
+      },
+      "bin": {
+        "harness-anything-daemon": "dist/index.js"
+      },
+      "engines": {
+        "node": ">=24"
       }
     },
     "packages/gui": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -40,6 +40,7 @@
     "@effect/platform": "0.96.2",
     "@effect/sql": "0.51.1",
     "@effect/sql-sqlite-node": "0.52.0",
+    "@harness-anything/daemon": "0.0.1",
     "cron-parser": "5.10.0",
     "effect": "3.21.4",
     "node-pty": "1.1.0"

--- a/packages/cli/src/daemon/autostart.ts
+++ b/packages/cli/src/daemon/autostart.ts
@@ -13,6 +13,7 @@ export async function ensureCliDaemonRunning(input: {
   readonly daemonId?: string;
   readonly socketPath?: string;
   readonly launchEntry?: string;
+  readonly mode?: "serve" | "--service";
   readonly onProgress?: (progress: DaemonStartProgress) => void;
 }): Promise<DaemonAutostartResult> {
   const { ensureLocalDaemonRunning, runtimeDaemonStartRefusal } = await import(
@@ -25,7 +26,7 @@ export async function ensureCliDaemonRunning(input: {
   return ensureLocalDaemonRunning({
     socketPath: input.socketPath ?? localUserDaemonEndpoint(userRoot, daemonId),
     invokingRoot: input.invokingRoot,
-    launch: () => cliDaemonServeLaunch(userRoot, daemonId, process.execPath, input.launchEntry),
+    launch: () => cliDaemonServeLaunch(userRoot, daemonId, process.execPath, input.launchEntry, input.mode),
     ...(input.onProgress ? { onProgress: input.onProgress } : {}),
   });
 }

--- a/packages/cli/src/daemon/client.ts
+++ b/packages/cli/src/daemon/client.ts
@@ -1,6 +1,6 @@
-import { realpathSync, readFileSync } from "node:fs";
+import { readFileSync } from "node:fs";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
+import { createRequire } from "node:module";
 import type { JsonObject } from "../../../daemon/src/protocol/json-rpc-types.ts";
 import {
   canonicalRoot,
@@ -54,21 +54,25 @@ const daemonRuntimeScopedEnvironmentKeys = [
   "HARNESS_DAEMON_USER_ROOT",
 ] as const;
 export function daemonServeEntry(): string {
-  return realpathSync(
-    fileURLToPath(new URL(import.meta.url.endsWith(".js") ? "../index.js" : "../index.ts", import.meta.url)),
-  );
+  const manifestPath = createRequire(import.meta.url).resolve("@harness-anything/daemon/package.json");
+  const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
+  const bin = manifest.bin?.["harness-anything-daemon"];
+  if (manifest.version !== "0.0.1" || typeof bin !== "string")
+    throw new Error("The installed daemon must provide the 0.0.1 harness-anything-daemon bin.");
+  return path.resolve(path.dirname(manifestPath), bin);
 }
 export function cliDaemonServeLaunch(
   userRoot: string,
   daemonId: string,
   execPath = process.execPath,
   entry = daemonServeEntry(),
+  mode: "serve" | "--service" = "serve",
 ): DaemonLaunchSpec {
   const env = { ...process.env };
   for (const key of daemonRuntimeScopedEnvironmentKeys) delete env[key];
   return {
     command: execPath,
-    args: [entry, "daemon", "serve", "--user-root", userRoot, "--daemon-id", daemonId],
+    args: [entry, mode, "--user-root", userRoot, "--daemon-id", daemonId],
     env,
   };
 }

--- a/packages/cli/src/daemon/control.ts
+++ b/packages/cli/src/daemon/control.ts
@@ -15,7 +15,7 @@ import {
   runtimeDaemonStartRefusal,
   writeDaemonStoppedMarker,
 } from "../../../daemon/src/client/daemon-autostart.ts";
-import { readDaemonPid, startDaemon } from "../../../daemon/src/runtime.ts";
+import { readDaemonPid } from "../../../daemon/src/runtime.ts";
 import {
   daemonProcessAlive,
   daemonSocketProbe,
@@ -75,12 +75,6 @@ export async function runDaemonControl(argv: readonly string[], renderReceipt: R
       if (result !== undefined) return result;
     }
     if (command === "connection") return runDaemonConnectionControl(argv, subcommand, userRoot, daemonId, finish);
-    if (command === "serve") {
-      const refusal = runtimeDaemonStartRefusal();
-      if (refusal) return finish(daemonFailure("daemon-serve", "daemon_start_runtime_forbidden", refusal.hint), 1);
-      clearDaemonStoppedMarker(userRoot, daemonId);
-      return serve(userRoot, daemonId, finish);
-    }
     if (command === "start") return startDaemonService(argv, userRoot, daemonId, invokingRoot, finish);
     if (command === "status") {
       const assessed = assessDaemonStatus(await status(userRoot, daemonId, argv));
@@ -147,6 +141,7 @@ async function startDaemonService(
   }
   if (running?.ok === true) return finish(running, 0);
   const started = await ensureCliDaemonRunning({
+    mode: "--service",
     invokingRoot,
     userRoot,
     daemonId,
@@ -240,60 +235,6 @@ async function fleetControl(
       1,
     );
   }
-}
-async function serve(userRoot: string, daemonId: string, finish: ControlFinisher): Promise<number> {
-  // The signal latch registers before startup: a TERM that lands during the
-  // startup replay parks here and drains at the next yield instead of being
-  // swallowed by synchronous work. stop() is idempotent, so a second signal
-  // cannot cut the drain short.
-  let daemon: Awaited<ReturnType<typeof startDaemon>>,
-    stopping: Promise<void> | null = null,
-    parked: (() => void) | undefined;
-  const idle = new Promise<void>((resolve) => {
-    parked = resolve;
-  });
-  const requestStop = () => {
-    parked?.();
-    stopping ??= (async () => {
-      if (daemon && "stop" in daemon) await daemon.stop();
-    })();
-  };
-  process.once("SIGTERM", requestStop);
-  process.once("SIGINT", requestStop);
-  try {
-    daemon = await startDaemon({
-      userRoot,
-      daemonId,
-      shutdownRequested: () => stopping !== null,
-      requestShutdown: requestStop,
-    });
-    if (!("stop" in daemon)) return finish(deferredServeReceipt(daemon, userRoot), 0);
-    if (stopping === null) {
-      await idle;
-      await stopping;
-    } else await daemon.stop();
-    return 0;
-  } finally {
-    process.removeListener("SIGTERM", requestStop);
-    process.removeListener("SIGINT", requestStop);
-  }
-}
-function deferredServeReceipt(
-  incumbent: { readonly pid: number | null; readonly endpoint: string; readonly witness: string },
-  userRoot: string,
-): Record<string, unknown> {
-  const witness =
-    incumbent.witness === "unix-socket"
-      ? `a daemon is already accepting connections at ${incumbent.endpoint}`
-      : `daemon pid ${incumbent.pid} already holds the singleton lock for --user-root ${userRoot}`;
-  return {
-    ok: true,
-    command: "daemon-serve",
-    outcome: "deferred",
-    incumbent: { pid: incumbent.pid, endpoint: incumbent.endpoint },
-    summary: `daemon serve deferred: ${witness}; this process did not bind the socket or take any workspace writer lock.`,
-    nextAction: "Use the resident daemon (ha daemon status) or stop it first (ha daemon stop).",
-  };
 }
 async function status(
   userRoot: string,

--- a/packages/cli/test/daemon-autostart-cli-scenario-1.test.ts
+++ b/packages/cli/test/daemon-autostart-cli-scenario-1.test.ts
@@ -70,18 +70,18 @@ test("operator stop blocks autostart until explicit start while process death re
   assert.equal(run(fixture.root, fixture.userRoot, ["daemon", "start", "--service"]).ok, true);
   register(fixture.root, fixture.userRoot, "autostart");
   const status = run(fixture.root, fixture.userRoot, ["daemon", "status"]);
-  assert.equal(status.entry, "source");
-  const sourceCommit = (status.build as { readonly commit?: unknown }).commit;
+  assert.equal(status.entry, "dist");
+  const buildCommit = (status.build as { readonly commit?: unknown }).commit;
   const gitCommitResult = spawnSync("git", ["rev-parse", "--verify", "HEAD"], {
     cwd: path.resolve("."),
     encoding: "utf8",
   });
-  const expectedSourceCommit = gitCommitResult.status === 0 ? gitCommitResult.stdout.trim() : null;
-  if (expectedSourceCommit !== null) {
-    assert.match(expectedSourceCommit, /^[0-9a-f]{40}$/u);
-    assert.equal(sourceCommit, expectedSourceCommit);
-    assert.match(String(status.summary), /entry=source commit=[0-9a-f]{40}/u);
-  } else assert.equal(sourceCommit, null, "an isolated source archive has no Git identity to report");
+  const expectedBuildCommit = gitCommitResult.status === 0 ? gitCommitResult.stdout.trim() : null;
+  if (expectedBuildCommit !== null) {
+    assert.match(expectedBuildCommit, /^[0-9a-f]{40}$/u);
+    assert.equal(buildCommit, expectedBuildCommit);
+    assert.match(String(status.summary), /entry=dist commit=[0-9a-f]{40}/u);
+  } else assert.equal(buildCommit, null, "an isolated source archive has no Git identity to report");
   assert.deepEqual(status.target, {
     endpoint: localUserDaemonEndpoint(fixture.userRoot, "default"),
     daemonId: "default",
@@ -114,8 +114,8 @@ test("operator stop blocks autostart until explicit start while process death re
   );
   const lifecycle = readDaemonLifecycleRecords(fixture.userRoot, "default");
   const processStart = lifecycle.find((record) => record.event === "process_start");
-  assert.equal(processStart?.entry, "source");
-  assert.equal(processStart?.commit, expectedSourceCommit);
+  assert.equal(processStart?.entry, "dist");
+  assert.equal(processStart?.commit, expectedBuildCommit);
   assert.equal(
     lifecycle.some((record) => record.event === "socket_bound"),
     true,

--- a/packages/cli/test/daemon-bin-launch.test.ts
+++ b/packages/cli/test/daemon-bin-launch.test.ts
@@ -1,0 +1,22 @@
+// harness-test-tier: fast
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import path from "node:path";
+import test from "node:test";
+import { cliDaemonServeLaunch, daemonServeEntry } from "../src/daemon/client.ts";
+
+test("CLI resident modes resolve the installed daemon manifest and launch its absolute bin", () => {
+  const manifestPath = createRequire(import.meta.url).resolve("@harness-anything/daemon/package.json");
+  const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
+  const entry = path.resolve(path.dirname(manifestPath), manifest.bin["harness-anything-daemon"]);
+  assert.equal(manifest.version, "0.0.1");
+  assert.equal(daemonServeEntry(), entry);
+  for (const mode of ["serve", "--service"] as const) {
+    const launch = cliDaemonServeLaunch("/daemon-user", "blue", process.execPath, undefined, mode);
+    assert.equal(launch.command, process.execPath);
+    assert.deepEqual(launch.args, [entry, mode, "--user-root", "/daemon-user", "--daemon-id", "blue"]);
+    assert.equal(launch.env.HARNESS_ACTOR, undefined);
+    assert.equal(launch.env.HARNESS_DAEMON_RELAY, undefined);
+  }
+});

--- a/packages/cli/test/daemon-singleton-cli.test.ts
+++ b/packages/cli/test/daemon-singleton-cli.test.ts
@@ -12,6 +12,8 @@ import { daemonPidPath, readDaemonPid } from "../../daemon/src/runtime.ts";
 import { buildProjectionOracle } from "../../daemon/test/migration-import.fixtures.ts";
 import { seedSettingsEvent } from "../../daemon/test/repo-settings.fixture.ts";
 
+import { daemonServeEntry } from "../src/daemon/client.ts";
+
 const cli = path.resolve("packages/cli/src/index.ts");
 
 // #1565: on Windows nothing delivers SIGTERM -- process.kill terminates unconditionally and the
@@ -162,7 +164,7 @@ const serveOutput = new WeakMap<ChildProcess, string>();
 function spawnServe(userRoot: string): ChildProcess {
   const child = spawn(
     process.execPath,
-    [cli, "daemon", "serve", "--user-root", userRoot, "--daemon-id", "default", "--json"],
+    [daemonServeEntry(), "serve", "--user-root", userRoot, "--daemon-id", "default", "--json"],
     { env: cliEnv(userRoot, userRoot) },
   );
   serveOutput.set(child, "");

--- a/packages/cli/test/daemon-stop-drain-window.test.ts
+++ b/packages/cli/test/daemon-stop-drain-window.test.ts
@@ -101,7 +101,7 @@ interface Fixture {
 function launchSpec(userRoot: string, daemonId: string): DaemonLaunchSpec {
   return {
     command: process.execPath,
-    args: ["index.ts", "daemon", "serve", "--user-root", userRoot, "--daemon-id", daemonId],
+    args: ["index.ts", "serve", "--user-root", userRoot, "--daemon-id", daemonId],
     env: {},
   };
 }

--- a/packages/cli/test/executor-null-live-daemon.integration.test.ts
+++ b/packages/cli/test/executor-null-live-daemon.integration.test.ts
@@ -5,6 +5,7 @@ import { accessSync, constants, existsSync, mkdirSync, mkdtempSync, rmSync, writ
 import { hostname, tmpdir } from "node:os";
 import path from "node:path";
 import test, { before, after } from "node:test";
+import { daemonServeEntry } from "../src/daemon/client.ts";
 import { localUserDaemonEndpoint } from "../../daemon/src/client/local-daemon-target.ts";
 import { readDaemonPid } from "../../daemon/src/runtime.ts";
 import { seedSettingsEvent } from "../../daemon/test/repo-settings.fixture.ts";
@@ -37,7 +38,7 @@ type TaskSnapshot = {
   readonly reviews: readonly { readonly verdict: string }[];
 };
 
-test("a live source daemon refuses to declare an executor for a reviewed execution that was never dispatched", async (context) => {
+test("a live installed-bin daemon refuses to declare an executor for a reviewed execution that was never dispatched", async (context) => {
   const parent = mkdtempSync(path.join(privateTemporaryRoot(), "executor-null-live.")),
     root = path.join(parent, "repo"),
     userRoot = path.join(parent, "edge-user-root"),
@@ -49,7 +50,7 @@ test("a live source daemon refuses to declare an executor for a reviewed executi
   initialize(root);
   seedSettingsEvent({ rootDir: root, repoId: "executor-null-live" });
   try {
-    daemon = spawnSourceDaemon(root, userRoot, daemonId);
+    daemon = spawnBinDaemon(root, userRoot, daemonId);
     const status = waitForDaemon(root, userRoot, daemonId),
       daemonPid = readDaemonPid(userRoot, daemonId);
     assert.equal(status.ok, true, JSON.stringify(status));
@@ -121,7 +122,7 @@ test("a live source daemon refuses to declare an executor for a reviewed executi
       JSON.stringify({
         verdict: "approved",
         reason: "Independent agent review passed.",
-        evidenceChecked: ["live source daemon route"],
+        evidenceChecked: ["live installed-bin daemon route"],
       }),
     );
     const reviewed = run(
@@ -243,12 +244,16 @@ roles:
   git(root, "commit", "--quiet", "-m", "fixture");
 }
 
-function spawnSourceDaemon(root: string, userRoot: string, daemonId: string): ChildProcess {
-  return spawn(process.execPath, [cli, "daemon", "serve", "--user-root", userRoot, "--daemon-id", daemonId, "--json"], {
-    cwd: root,
-    env: environment(root, userRoot, daemonId),
-    stdio: ["ignore", "pipe", "pipe"],
-  });
+function spawnBinDaemon(root: string, userRoot: string, daemonId: string): ChildProcess {
+  return spawn(
+    process.execPath,
+    [daemonServeEntry(), "serve", "--user-root", userRoot, "--daemon-id", daemonId, "--json"],
+    {
+      cwd: root,
+      env: environment(root, userRoot, daemonId),
+      stdio: ["ignore", "pipe", "pipe"],
+    },
+  );
 }
 
 function waitForDaemon(root: string, userRoot: string, daemonId: string): Record<string, unknown> {

--- a/packages/daemon/README.md
+++ b/packages/daemon/README.md
@@ -1,0 +1,21 @@
+# Harness Anything daemon
+
+The resident service and runtime worker host for Harness Anything. Requires Node 24 or newer and uses the same release version as the CLI.
+
+```sh
+harness-anything-daemon serve --user-root /path/to/daemon-state --daemon-id default
+harness-anything-daemon --service --user-root /path/to/daemon-state --daemon-id default
+```
+
+Both modes run the resident process in the foreground; `ha daemon start --service` handles detached startup and readiness. Clients must complete an exact protocol major/minor `protocol.hello` before sending requests. A second process for the same user root and daemon ID defers to the singleton owner. SIGTERM, SIGINT, and `daemon.stop` drain the resident service.
+
+`--runtime-worker-host` is the internal stdin-manifest entry used by daemon dispatch. It persists provider output and process exit records and runs independently of the resident daemon so a restarted daemon can adopt its pid. It is not an RPC server.
+
+Build and verify the package from a source checkout:
+
+```sh
+npm run build -w @harness-anything/daemon
+node tools/dispatch-isolated-test.mjs --target ubuntu --file packages/daemon/test/daemon-package.integration.test.mjs
+```
+
+The smoke packs the workspace, installs it into a temporary consumer, exercises both resident modes with hello and singleton checks, and verifies the worker's persisted output. No npm publication is performed.

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -1,15 +1,47 @@
 {
   "name": "@harness-anything/daemon",
-  "version": "0.0.0",
-  "private": true,
+  "version": "0.0.1",
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "exports": {
-    ".": "./src/index.ts"
+    ".": "./dist/daemon/src/index.js",
+    "./package.json": "./package.json"
   },
   "dependencies": {
-    "@harness-anything/adapter-local": "0.0.0",
-    "@harness-anything/adapter-multica": "0.0.0",
+    "@effect/experimental": "0.60.0",
+    "@effect/platform": "0.96.2",
+    "@effect/sql": "0.51.1",
+    "@effect/sql-sqlite-node": "0.52.0",
+    "cron-parser": "5.10.0",
+    "effect": "3.21.4",
     "node-pty": "1.1.0"
-  }
+  },
+  "homepage": "https://github.com/FairladyZ625/harness-anything#readme",
+  "bugs": {
+    "url": "https://github.com/FairladyZ625/harness-anything/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/FairladyZ625/harness-anything.git",
+    "directory": "packages/daemon"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "engines": {
+    "node": ">=24"
+  },
+  "description": "Resident daemon and runtime worker host for Harness Anything.",
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json && node scripts/copy-assets.mjs",
+    "prepare": "npm run build"
+  },
+  "bin": {
+    "harness-anything-daemon": "dist/index.js"
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "package.json"
+  ]
 }

--- a/packages/daemon/scripts/copy-assets.mjs
+++ b/packages/daemon/scripts/copy-assets.mjs
@@ -1,0 +1,11 @@
+import { randomUUID } from "node:crypto";
+import { cpSync, writeFileSync, chmodSync, rmSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+const dist = new URL("../dist/", import.meta.url);
+rmSync(new URL("preset/assets/", dist), { recursive: true, force: true });
+cpSync(new URL("../../preset/assets/", import.meta.url), new URL("preset/assets/", dist), { recursive: true });
+writeFileSync(new URL("build-id.txt", dist), `${randomUUID()}\n`);
+const entry = new URL("index.js", dist);
+writeFileSync(entry, '#!/usr/bin/env node\nimport "./daemon/src/bin.js";\n');
+chmodSync(fileURLToPath(entry), 0o755);

--- a/packages/daemon/scripts/smoke-package.mjs
+++ b/packages/daemon/scripts/smoke-package.mjs
@@ -1,0 +1,135 @@
+import assert from "node:assert/strict";
+import { spawn, spawnSync } from "node:child_process";
+import { once } from "node:events";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+const repository = path.resolve(import.meta.dirname, "../../..");
+const parent = mkdtempSync(path.join(tmpdir(), "ha-daemon-package-"));
+const consumer = path.join(parent, "consumer");
+const env = Object.fromEntries(Object.entries(process.env).filter(([key]) => !key.startsWith("HARNESS_")));
+const npm = process.platform === "win32" ? "npm.cmd" : "npm";
+function run(command, args, cwd = repository) {
+  console.log(JSON.stringify({ command, args, cwd }));
+  const result = spawnSync(command, args, { cwd, env, encoding: "utf8", timeout: 180_000 });
+  process.stdout.write(result.stdout ?? "");
+  process.stderr.write(result.stderr ?? "");
+  console.log(`exit=${result.status}`);
+  assert.equal(result.status, 0, result.error?.message ?? result.stderr);
+  return result.stdout;
+}
+try {
+  mkdirSync(consumer);
+  writeFileSync(path.join(consumer, "package.json"), '{"private":true,"type":"module"}\n');
+  run(npm, ["pack", "-w", "@harness-anything/daemon", "--pack-destination", parent]);
+  run(npm, ["install", "--no-audit", "--no-fund", path.join(parent, "harness-anything-daemon-0.0.1.tgz")], consumer);
+  const installed = path.join(consumer, "node_modules/@harness-anything/daemon");
+  const manifest = JSON.parse(readFileSync(path.join(installed, "package.json"), "utf8"));
+  const entry = path.join(installed, manifest.bin["harness-anything-daemon"]);
+  const load = (file) => import(pathToFileURL(path.join(installed, "dist/daemon/src", file)).href);
+  const { localUserDaemonEndpoint } = await load("client/local-daemon-target.js");
+  const { openDaemonJsonRpcClientAt } = await load("client/local-json-rpc-client.js");
+  const { currentDaemonProtocolVersion } = await load("protocol/version.js");
+  const { dispatchStreamPath } = await load("dispatch-stream.js");
+  for (const mode of ["serve", "--service"]) {
+    const userRoot = path.join(parent, mode.replaceAll("-", ""));
+    const args = [entry, mode, "--user-root", userRoot, "--daemon-id", "smoke"];
+    console.log(JSON.stringify({ command: process.execPath, args, cwd: consumer }));
+    const child = spawn(process.execPath, args, { cwd: consumer, env, stdio: ["ignore", "pipe", "pipe"] });
+    const exited = once(child, "exit");
+    let output = "";
+    child.stdout.on("data", (data) => {
+      output += data;
+    });
+    child.stderr.on("data", (data) => {
+      output += data;
+    });
+    let client;
+    try {
+      for (const deadline = Date.now() + 30_000; Date.now() < deadline && !client; ) {
+        assert.equal(child.exitCode, null, output);
+        try {
+          client = await openDaemonJsonRpcClientAt(localUserDaemonEndpoint(userRoot, "smoke"), 100, 1_000);
+        } catch {
+          await new Promise((resolve) => setTimeout(resolve, 50));
+        }
+      }
+      assert.ok(client, output);
+      const hello = await client.request("protocol.hello", { protocolVersion: currentDaemonProtocolVersion }, 2_000);
+      assert.equal(hello.ok, true);
+      console.log(JSON.stringify({ mode, hello: hello.ok, protocolVersion: hello.protocolVersion }));
+      const deferred = run(process.execPath, args, consumer);
+      assert.equal(JSON.parse(deferred).outcome, "deferred");
+      const stopped = await client.request("daemon.stop", {}, 5_000);
+      assert.equal(stopped.ok, true);
+      client.close();
+      const result = await Promise.race([
+        exited,
+        new Promise((_, reject) => {
+          const timer = setTimeout(() => reject(new Error("daemon did not stop")), 10_000);
+          timer.unref();
+        }),
+      ]);
+      assert.equal(result[0], 0, output);
+      console.log(`${mode} exit=0; hello=true; singleton deferred; cooperative stop=true`);
+    } finally {
+      client?.close();
+      if (child.exitCode === null && child.signalCode === null) child.kill("SIGKILL");
+      await exited;
+    }
+  }
+  const rootDir = path.join(parent, "worker");
+  const dispatchId = "dispatch_0123456789abcdef01234567";
+  const stream = dispatchStreamPath(rootDir, dispatchId);
+  mkdirSync(path.dirname(stream), { recursive: true });
+  writeFileSync(stream, "");
+  const args = [entry, "--runtime-worker-host"];
+  console.log(JSON.stringify({ command: process.execPath, args, cwd: consumer }));
+  const worker = spawn(process.execPath, args, { cwd: consumer, env, detached: true, stdio: ["pipe", "pipe", "pipe"] });
+  const exited = once(worker, "exit");
+  let errors = "";
+  worker.stderr.on("data", (data) => {
+    errors += data;
+  });
+  worker.stdin.end(
+    JSON.stringify({
+      rootDir,
+      dispatchId,
+      executablePath: process.execPath,
+      args: [
+        "-e",
+        'let prompt=""; process.stdin.on("data", chunk => prompt += chunk); process.stdin.on("end", () => console.log(JSON.stringify({hello:prompt})));',
+      ],
+      cwd: consumer,
+      env,
+      prompt: "package-worker-smoke",
+      windowsVerbatimArguments: false,
+    }),
+  );
+  try {
+    const result = await Promise.race([
+      exited,
+      new Promise((_, reject) => {
+        const timer = setTimeout(() => reject(new Error("worker did not exit")), 30_000);
+        timer.unref();
+      }),
+    ]);
+    assert.equal(result[0], 0, errors);
+    const records = readFileSync(stream, "utf8").trim().split("\n").map(JSON.parse);
+    assert.ok(
+      records.some((record) => record.kind === "provider_event" && record.event.hello === "package-worker-smoke"),
+    );
+    assert.ok(records.some((record) => record.kind === "process_exit" && record.exitCode === 0));
+    console.log(
+      "--runtime-worker-host exit=0; provider hello=true; persisted process_exit=0; protocol.hello=N/A (stdio worker)",
+    );
+  } finally {
+    if (worker.exitCode === null && worker.signalCode === null) worker.kill("SIGKILL");
+    await exited;
+  }
+  console.log(`Daemon package smoke passed; pack/install directory: ${parent}`);
+} finally {
+  rmSync(parent, { recursive: true, force: true });
+}

--- a/packages/daemon/scripts/smoke-package.mjs
+++ b/packages/daemon/scripts/smoke-package.mjs
@@ -24,7 +24,29 @@ try {
   mkdirSync(consumer);
   writeFileSync(path.join(consumer, "package.json"), '{"private":true,"type":"module"}\n');
   run(npm, ["pack", "-w", "@harness-anything/daemon", "--pack-destination", parent]);
-  run(npm, ["install", "--no-audit", "--no-fund", path.join(parent, "harness-anything-daemon-0.0.1.tgz")], consumer);
+  run(npm, ["pack", "-w", "@harness-anything/cli", "--pack-destination", parent]);
+  run(
+    npm,
+    [
+      "install",
+      "--no-audit",
+      "--no-fund",
+      path.join(parent, "harness-anything-daemon-0.0.1.tgz"),
+      path.join(parent, "harness-anything-cli-0.0.1.tgz"),
+    ],
+    consumer,
+  );
+  const cli = path.join(consumer, "node_modules/@harness-anything/cli/dist/cli/src/index.js");
+  const cliArgs = ["--user-root", path.join(parent, "cli-user"), "--daemon-id", "cli-smoke", "--json"];
+  run(process.execPath, [cli, "daemon", "start", "--service", ...cliArgs], consumer);
+  try {
+    const status = JSON.parse(run(process.execPath, [cli, "daemon", "status", ...cliArgs], consumer));
+    assert.equal(status.ok, true);
+    assert.equal(status.entry, "dist");
+    console.log("installed CLI status exit=0; daemon start --service and protocol hello=true");
+  } finally {
+    run(process.execPath, [cli, "daemon", "stop", ...cliArgs], consumer);
+  }
   const installed = path.join(consumer, "node_modules/@harness-anything/daemon");
   const manifest = JSON.parse(readFileSync(path.join(installed, "package.json"), "utf8"));
   const entry = path.join(installed, manifest.bin["harness-anything-daemon"]);

--- a/packages/daemon/src/bin.ts
+++ b/packages/daemon/src/bin.ts
@@ -1,0 +1,101 @@
+#!/usr/bin/env node
+import path from "node:path";
+import { consumeKnownError } from "../../kernel/src/index.ts";
+
+async function main(argv: readonly string[]): Promise<number> {
+  if (argv[0] === "--runtime-worker-host") {
+    const { runRuntimeWorkerHost } = await import("./runtime-worker-host.ts");
+    await runRuntimeWorkerHost();
+    return 0;
+  }
+  if (!(argv[0] === "serve" || argv[0] === "--service")) {
+    process.stderr.write("Usage: harness-anything-daemon serve|--service [--user-root <path>] [--daemon-id <id>]\n");
+    return 2;
+  }
+  const option = (name: string): string | undefined => {
+    const at = argv.indexOf(name);
+    if (at < 0) return undefined;
+    const value = argv[at + 1];
+    if (!value || value.startsWith("--")) throw new Error(`Missing value for ${name}`);
+    return value;
+  };
+  const { daemonUserRoot, daemonIdFromEnv } = await import("./client/local-daemon-target.ts");
+  const { clearDaemonStoppedMarker, runtimeDaemonStartRefusal } = await import("./client/daemon-autostart.ts");
+  const userRoot = path.resolve(option("--user-root") ?? daemonUserRoot());
+  const daemonId = option("--daemon-id") ?? daemonIdFromEnv();
+  const refusal = runtimeDaemonStartRefusal();
+  if (refusal) throw new Error(refusal.hint);
+  clearDaemonStoppedMarker(userRoot, daemonId);
+  return runResidentDaemon(userRoot, daemonId, (receipt, code) => {
+    console.log(JSON.stringify(receipt));
+    return code;
+  });
+}
+
+async function runResidentDaemon(
+  userRoot: string,
+  daemonId: string,
+  finish: (receipt: Record<string, unknown>, exitCode: number) => number,
+): Promise<number> {
+  const { startDaemon } = await import("./runtime.ts");
+  // The signal latch registers before startup: a TERM that lands during the
+  // startup replay parks here and drains at the next yield instead of being
+  // swallowed by synchronous work. stop() is idempotent, so a second signal
+  // cannot cut the drain short.
+  let daemon: Awaited<ReturnType<typeof startDaemon>>,
+    stopping: Promise<void> | null = null,
+    parked: (() => void) | undefined;
+  const idle = new Promise<void>((resolve) => {
+    parked = resolve;
+  });
+  const requestStop = () => {
+    parked?.();
+    stopping ??= (async () => {
+      if (daemon && "stop" in daemon) await daemon.stop();
+    })();
+  };
+  process.once("SIGTERM", requestStop);
+  process.once("SIGINT", requestStop);
+  try {
+    daemon = await startDaemon({
+      userRoot,
+      daemonId,
+      shutdownRequested: () => stopping !== null,
+      requestShutdown: requestStop,
+    });
+    if (!("stop" in daemon)) return finish(deferredServeReceipt(daemon, userRoot), 0);
+    if (stopping === null) {
+      await idle;
+      await stopping;
+    } else await daemon.stop();
+    return 0;
+  } finally {
+    process.removeListener("SIGTERM", requestStop);
+    process.removeListener("SIGINT", requestStop);
+  }
+}
+function deferredServeReceipt(
+  incumbent: { readonly pid: number | null; readonly endpoint: string; readonly witness: string },
+  userRoot: string,
+): Record<string, unknown> {
+  const witness =
+    incumbent.witness === "unix-socket"
+      ? `a daemon is already accepting connections at ${incumbent.endpoint}`
+      : `daemon pid ${incumbent.pid} already holds the singleton lock for --user-root ${userRoot}`;
+  return {
+    ok: true,
+    command: "daemon-serve",
+    outcome: "deferred",
+    incumbent: { pid: incumbent.pid, endpoint: incumbent.endpoint },
+    summary: `daemon serve deferred: ${witness}; this process did not bind the socket or take any workspace writer lock.`,
+    nextAction: "Use the resident daemon (ha daemon status) or stop it first (ha daemon stop).",
+  };
+}
+
+try {
+  process.exitCode = await main(process.argv.slice(2));
+} catch (error) {
+  process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+  process.exitCode = 1;
+  consumeKnownError(error);
+}

--- a/packages/daemon/src/bin.ts
+++ b/packages/daemon/src/bin.ts
@@ -87,7 +87,8 @@ function deferredServeReceipt(
     command: "daemon-serve",
     outcome: "deferred",
     incumbent: { pid: incumbent.pid, endpoint: incumbent.endpoint },
-    summary: `daemon serve deferred: ${witness}; this process did not bind the socket or take any workspace writer lock.`,
+    summary:
+      `daemon serve deferred: ${witness}; ` + "this process did not bind the socket or take any workspace writer lock.",
     nextAction: "Use the resident daemon (ha daemon status) or stop it first (ha daemon stop).",
   };
 }

--- a/packages/daemon/src/client/daemon-autostart.ts
+++ b/packages/daemon/src/client/daemon-autostart.ts
@@ -327,13 +327,16 @@ function classifySpawnFailure(
   return { code: "daemon_start_failed", hint: `Starting the daemon failed: ${detail}. Command: ${command}.` };
 }
 function daemonLaunchTarget(launch: DaemonLaunchSpec): { readonly userRoot: string; readonly daemonId: string } | null {
-  const daemon = launch.args.indexOf("daemon"),
-    serve = daemon < 0 ? -1 : launch.args.indexOf("serve", daemon + 1),
+  const serve = 1,
     rootAt = launch.args.indexOf("--user-root", serve + 1),
     idAt = launch.args.indexOf("--daemon-id", serve + 1),
     userRoot = launch.args[rootAt + 1],
     daemonId = launch.args[idAt + 1];
-  return daemon >= 0 && serve === daemon + 1 && rootAt >= 0 && idAt >= 0 && userRoot && daemonId
+  return (launch.args[serve] === "serve" || launch.args[serve] === "--service") &&
+    rootAt > serve &&
+    idAt > serve &&
+    userRoot &&
+    daemonId
     ? { userRoot: path.resolve(userRoot), daemonId }
     : null;
 }

--- a/packages/daemon/src/runtime-spawn-process.ts
+++ b/packages/daemon/src/runtime-spawn-process.ts
@@ -441,7 +441,7 @@ export function launchNative(
   },
 ): RuntimeProcess {
   const command = nativeCommand(input);
-  const workerHost = import.meta.url.endsWith(".js") ? "./runtime-worker-host.js" : "./runtime-worker-host.ts";
+  const workerHost = import.meta.url.endsWith(".js") ? "./bin.js" : "./bin.ts";
   const entry = fileURLToPath(new URL(workerHost, import.meta.url));
   const child = spawn(process.execPath, [entry, "--runtime-worker-host"], {
     detached: true,

--- a/packages/daemon/src/runtime-worker-host.ts
+++ b/packages/daemon/src/runtime-worker-host.ts
@@ -16,7 +16,7 @@ type RuntimeWorkerManifest = {
   readonly callbackRelay?: RuntimeCallbackRelay;
 };
 
-async function runRuntimeWorkerHost(): Promise<void> {
+export async function runRuntimeWorkerHost(): Promise<void> {
   const manifest = parseManifest(await readStandardInput());
   const stream = dispatchStreamPath(manifest.rootDir, manifest.dispatchId);
   const append = (value: Readonly<Record<string, unknown>>): void =>
@@ -129,11 +129,4 @@ function parseManifest(value: string): RuntimeWorkerManifest {
 }
 function isRuntimeWorkerRecord(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === "object" && !Array.isArray(value);
-}
-
-if (process.argv[2] === "--runtime-worker-host") {
-  void runRuntimeWorkerHost().catch((error: unknown) => {
-    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
-    process.exitCode = 1;
-  });
 }

--- a/packages/daemon/test/daemon-autostart.test.ts
+++ b/packages/daemon/test/daemon-autostart.test.ts
@@ -26,7 +26,7 @@ function coded(code: string): Error & { code: string } {
 }
 const launch = (): DaemonLaunchSpec => ({
   command: "node",
-  args: ["index.ts", "daemon", "serve", "--user-root", "/tmp/ha-user", "--daemon-id", "default"],
+  args: ["index.ts", "serve", "--user-root", "/tmp/ha-user", "--daemon-id", "default"],
   env: {},
 });
 
@@ -89,7 +89,7 @@ test("a worktree is refused before spawn while the registered canonical checkout
       invokingRoot: worktree,
       launch: () => ({
         command: "node",
-        args: ["index.ts", "daemon", "serve", "--user-root", userRoot, "--daemon-id", "default"],
+        args: ["index.ts", "serve", "--user-root", userRoot, "--daemon-id", "default"],
         env: {},
       }),
       probe: async () => false,
@@ -129,7 +129,7 @@ test("concurrent callers share one autostart flight and wait for the same socket
     reachable = false;
   const sharedLaunch = (): DaemonLaunchSpec => ({
     command: "node",
-    args: ["index.ts", "daemon", "serve", "--user-root", userRoot, "--daemon-id", "default"],
+    args: ["index.ts", "serve", "--user-root", userRoot, "--daemon-id", "default"],
     env: {},
   });
   try {
@@ -165,7 +165,7 @@ test("a GUI/CLI peer that already owns the daemon singleton is awaited, not resp
   let spawns = 0;
   const sharedLaunch = (): DaemonLaunchSpec => ({
     command: "node",
-    args: ["index.ts", "daemon", "serve", "--user-root", userRoot, "--daemon-id", "default"],
+    args: ["index.ts", "serve", "--user-root", userRoot, "--daemon-id", "default"],
     env: {},
   });
   try {
@@ -217,7 +217,7 @@ test("a live process with lifecycle attach progress reports starting instead of 
     progress: string[] = [],
     spec = (): DaemonLaunchSpec => ({
       command: "node",
-      args: ["index.ts", "daemon", "serve", "--user-root", userRoot, "--daemon-id", "progress"],
+      args: ["index.ts", "serve", "--user-root", userRoot, "--daemon-id", "progress"],
       env: {},
     });
   try {
@@ -335,7 +335,7 @@ test("daemon launch output path is the stdio sink, not the structured lifecycle 
   assert.equal(
     daemonLaunchOutputPath({
       command: "node",
-      args: ["index.js", "daemon", "serve", "--user-root", userRoot, "--daemon-id", "blue"],
+      args: ["index.js", "--service", "--user-root", userRoot, "--daemon-id", "blue"],
       env: {},
     }),
     daemonStdioLogPath(userRoot, "blue"),
@@ -349,7 +349,7 @@ test("start progress stages report the last repository, attach timeouts, prunes,
     const log = openDaemonLifecycleLog({ userRoot, daemonId: "stages" }),
       spec = (): DaemonLaunchSpec => ({
         command: "node",
-        args: ["index.ts", "daemon", "serve", "--user-root", userRoot, "--daemon-id", "stages"],
+        args: ["index.ts", "serve", "--user-root", userRoot, "--daemon-id", "stages"],
         env: {},
       });
     log.record({ event: "process_start" });

--- a/packages/daemon/test/daemon-build-drain.integration.test.ts
+++ b/packages/daemon/test/daemon-build-drain.integration.test.ts
@@ -349,7 +349,7 @@ function runningDaemon(started: Awaited<ReturnType<typeof startDaemon>>): Runnin
 function launchSpec(userRoot: string, daemonId: string): DaemonLaunchSpec {
   return {
     command: process.execPath,
-    args: ["index.ts", "daemon", "serve", "--user-root", userRoot, "--daemon-id", daemonId],
+    args: ["index.js", "serve", "--user-root", userRoot, "--daemon-id", daemonId],
     env: {},
   };
 }

--- a/packages/daemon/test/daemon-package.integration.test.mjs
+++ b/packages/daemon/test/daemon-package.integration.test.mjs
@@ -1,0 +1,6 @@
+// harness-test-tier: integration
+import test from "node:test";
+
+test("installed daemon package serves, owns its singleton, stops, and hosts a runtime worker", async () => {
+  await import("../scripts/smoke-package.mjs");
+});

--- a/packages/daemon/tsconfig.build.json
+++ b/packages/daemon/tsconfig.build.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "composite": false,
+    "declaration": false,
+    "emitDeclarationOnly": false,
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "target": "ES2024",
+    "strict": true,
+    "skipLibCheck": true,
+    "allowImportingTsExtensions": true,
+    "rewriteRelativeImportExtensions": true,
+    "erasableSyntaxOnly": true,
+    "rootDir": "..",
+    "outDir": "dist"
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/tools/gate-allowlists/check-fallback-boundaries.json
+++ b/tools/gate-allowlists/check-fallback-boundaries.json
@@ -37,6 +37,7 @@
       "packages/daemon/src/agent-runtime-launch-config.ts#providerSubscriptionReadiness",
       "packages/daemon/src/artifacts-gui-read.ts#walkAllTaskArtifacts",
       "packages/daemon/src/artifacts-gui-read.ts#walkArtifactTree",
+      "packages/daemon/src/bin.ts#<module>",
       "packages/daemon/src/build-identity.ts#resolveStamp",
       "packages/daemon/src/ci-observation-actions.ts#fetchCiObservations",
       "packages/daemon/src/client/local-json-rpc-client.ts#onLine",

--- a/tools/smoke-cli-package.mjs
+++ b/tools/smoke-cli-package.mjs
@@ -8,6 +8,7 @@ import { realizedTaskPlan } from "./fixtures/task-plan.mjs";
 
 export function runCliPackageSmoke(root = process.cwd()) {
   buildCliPackageArtifact(root);
+  execNpmFileSync(["run", "build", "--workspace", "@harness-anything/daemon"], { cwd: root, stdio: "inherit" });
   const tempRoot = mkdtempSync(path.join(tmpdir(), "ha-cli-pack-")),
     packDir = path.join(tempRoot, "pack"),
     consumerDir = path.join(tempRoot, "consumer");
@@ -23,16 +24,20 @@ export function runCliPackageSmoke(root = process.cwd()) {
     mkdirSync(consumerDir, { recursive: true });
     mkdirSync(projectDir);
     mkdirSync(home);
-    const packed = JSON.parse(
-      execNpmFileSync(["pack", "--workspace", "@harness-anything/cli", "--pack-destination", packDir, "--json"], {
-        cwd: root,
-        encoding: "utf8",
-        env: { ...process.env, NPM_CONFIG_IGNORE_SCRIPTS: "true" },
-      }),
-    )[0];
-    const tarball = path.join(packDir, packed?.filename ?? "");
-    if (!packed?.filename || !existsSync(tarball)) throw new Error("npm pack did not produce the CLI tarball");
-    execNpmFileSync(["install", "--prefix", consumerDir, "--no-audit", "--no-fund", tarball], {
+    const tarballs = ["@harness-anything/cli", "@harness-anything/daemon"].map((workspace) => {
+      const packed = JSON.parse(
+        execNpmFileSync(["pack", "--workspace", workspace, "--pack-destination", packDir, "--json"], {
+          cwd: root,
+          encoding: "utf8",
+          env: { ...process.env, NPM_CONFIG_IGNORE_SCRIPTS: "true" },
+        }),
+      )[0];
+      const tarball = path.join(packDir, packed?.filename ?? "");
+      if (!packed?.filename || !existsSync(tarball))
+        throw new Error(`npm pack did not produce the ${workspace} tarball`);
+      return tarball;
+    });
+    execNpmFileSync(["install", "--prefix", consumerDir, "--no-audit", "--no-fund", ...tarballs], {
       cwd: root,
       stdio: "inherit",
     });
@@ -336,7 +341,7 @@ export function assertUnstartableDaemonFailedClosed(result, harnessExists) {
   if (result.receipt?.ok !== false) throw new Error(`unstartable-daemon receipt must report ok=false: ${detail}`);
   const code = result.receipt?.error?.code;
   if (code !== "daemon_bind_timeout" && code !== "daemon_spawn_permission")
-    throw new Error(`unexpected unstartable-daemon code: ${String(code)}`);
+    throw new Error(`unexpected unstartable-daemon code: ${String(code)}; ${detail}`);
   if (harnessExists) throw new Error(`unstartable-daemon created harness before failing: ${detail}`);
 }
 function runJson(command, args, cwd, environment) {


### PR DESCRIPTION
# English

## Summary

Three-package split, slice 1 (design task_32df25c4, boundary decision dec_8FF9DEDD, refines release contract dec_4061D415): `@harness-anything/daemon` becomes the publishable host. `packages/daemon/package.json` drops `private`, gains public metadata (publishConfig public, repository.directory, engines node >=24, bin `harness-anything-daemon` → `dist/index.js`, version 0.0.1 lockstep) and its own build config; the new `src/bin.ts` is the only interpreter for `serve`, `--service` and `--runtime-worker-host`. The CLI's production hosting branch is deleted (`control.ts` serve/deferral, `client.ts` `[entry, "daemon", "serve", …]`); the CLI launch spec resolves the installed daemon bin through createRequire → package.json → bin with version check and starts it with `process.execPath`; `daemon-autostart.ts` and the worker-host spawn use the same bin. Offline maintenance stays in the CLI until slice 5 (ruling recorded in the task plan, Round 5). `rg 'daemon serve|runtime-worker-host' packages/cli/src` now returns nothing.

## Architectural Justification

The daemon package owns every load-bearing process (serve, service, worker host); the CLI is a client that spawns the installed daemon bin and keeps no host interpreter. One interpreter for host modes lives in `bin.ts`; the CLI-side copy is deleted in the same change. Net production lines are positive because the bin entry, build config and launch resolution are new files while the deleted CLI branches were smaller.

## What Changed

- `packages/daemon/package.json`, `tsconfig.build.json`, `scripts/copy-assets.mjs`, `scripts/smoke-package.mjs`, `README.md`: publishable package, build, pack/install smoke.
- `packages/daemon/src/bin.ts` (new): host mode dispatch.
- `packages/daemon/src/runtime-spawn-process.ts`, `runtime-worker-host.ts`: worker host launched through the bin; argv interpreter removed from the module.
- `packages/daemon/src/client/daemon-autostart.ts`: `[entry, mode, …]` launch.
- `packages/cli/src/daemon/{client,control,autostart}.ts`: host branches deleted; launch spec resolves the installed bin.
- Tests: `daemon-bin-launch.test.ts` (new), `daemon-package.integration.test.mjs`, autostart/singleton/drain tests updated.

## Gate Harvest / 门收割

Deleted-Production-Paths: packages/cli/src/daemon/control.ts serve/deferral host branch; packages/cli/src/daemon/client.ts `[entry, "daemon", "serve", …]` launch spec; packages/daemon/src/runtime-worker-host.ts argv interpreter
Deleted-Gates-Fixtures: CLI `daemon serve` launch fixture `[cli, "daemon", "serve", …]` in packages/cli/test/daemon-singleton-cli.test.ts and packages/cli/test/daemon-stop-drain-window.test.ts (replaced by `daemonServeEntry()`; the installed-bin launch is covered by the new packages/cli/test/daemon-bin-launch.test.ts)
- Production net lines: +123/-80 production (net +43); tests/scripts/README +262/-15.

## Machine-Readable Declarations

Dependency-Change: packages/daemon/package.json declares its external runtime dependencies directly (@effect/experimental 0.60.0, @effect/platform 0.96.2, @effect/sql 0.51.1, @effect/sql-sqlite-node 0.52.0, cron-parser 5.10.0, effect 3.21.4) and drops the workspace-internal @harness-anything/adapter-local and adapter-multica entries because those packages are compiled into the daemon build; package-lock.json updated with `npm install --package-lock-only`, no new third-party package enters the tree.

## Task And Scope

- Harness task: task_d0fe49e3e6ed5aa370bbbe5fbe (parent task_32df25c474582985e7595eabdf)
- Branch: `codex/split-1`
- Public scope: daemon package metadata/build/bin entry and the CLI launch spec
- Private planning/evidence updated: yes (`artifacts/report.md`)
- Out of scope: slices 2–5 (client/protocol SDK, dependency cut, GUI, CLI offline facade + `check-cli-structure` retirement task_8f9184c7); real `npm publish` (not authorized)

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: yes — `packages/daemon/package.json` (packages/*/package.json); `tools/gate-allowlists/check-fallback-boundaries.json` (one consumeKnownError entry `packages/daemon/src/bin.ts#<module>`: the bin's top-level catch is the host process exit, moved from the deleted CLI serve branch)
- Protected surface scope: daemon package drops `private` and declares public metadata, bin and build; the public-ready package table (`tools/public-ready-packages.mjs`, #2524) already lists this package, and `check-package-policy`, `check-runtime-release-readiness`, `check-supply-chain` exit 0 on the branch
- Authority: repository owner ruling 2026-09-12 ("A 吧 治理然后拆": release governance then split), release contract dec_4061D4157B1FEF9925E38F2358 (in_effect) and boundary decision dec_8FF9DEDD562CE7B2AB37A4C776, recorded in task_d0fe49e3e6ed5aa370bbbe5fbe
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: task_8f9184c7a402583aefeba8adbe (check-cli-structure offline closure, before slice 5)

## Verification

- Base `origin/main` SHA: `466caf36a`
- Branch merge-base with `origin/main`: `466caf36a`
- Last `git fetch origin` time: 2026-09-12 UTC
- Sync method: branched from origin/main
- Public diff command: `git diff origin/main...codex/split-1`
- Private evidence commit/path: task_d0fe49e3e6ed5aa370bbbe5fbe `artifacts/report.md`
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [x] `npm run typecheck` (worker, `tsc -b`)
- [ ] `npm run check`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts` (via `run-manifest-gates --changed origin/main`)
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Isolated Ubuntu `daemon-package.integration.test.mjs`: pack → install → serve / --service / --runtime-worker-host smoke, hello 1.0, deferred second instance, stop; six targeted files 28/28; `npm run build -w @harness-anything/daemon`, typecheck, three release checkers, publish dry-run, `run-manifest-gates --changed` 6/6: exit 0.

## Review Evidence

- CEO ground-truth: read the worker report and the diff stat; ruled Rounds 5/6 (offline stays for slice 5; autostart caller belongs to this slice) and checked `rg` shows no host entry left in packages/cli/src.
- Reviewer subagent: closeout review after merge (one-path closeout)
- Human review: pending
- Blocking findings: none open

## Residual Risk

- Full CI matrix and Windows lane unverified by the worker (PR CI is the authority); daemon restart adoption (`adoptRuntimes`) with the bin-launched worker host is exercised only by existing tests.

## References

- Task: task_d0fe49e3e6ed5aa370bbbe5fbe

---

# 中文

## 概要

三包拆分切片 1（设计 task_32df25c4，边界决策 dec_8FF9DEDD，refines 发布契约 dec_4061D415）：`@harness-anything/daemon` 成为可发布宿主。`packages/daemon/package.json` 去 `private`、加 public metadata（publishConfig public、repository.directory、engines node >=24、bin `harness-anything-daemon` → `dist/index.js`、版本 0.0.1 lockstep）与独立 build 配置；新 `src/bin.ts` 是 `serve`、`--service`、`--runtime-worker-host` 的唯一解释器。CLI 的生产宿主分支删除（`control.ts` serve/deferral、`client.ts` 的 `[entry, "daemon", "serve", …]`）；CLI launch spec 经 createRequire → package.json → bin 解析已安装 daemon bin（带版本校验），用 `process.execPath` 启动；`daemon-autostart.ts` 与 worker-host spawn 用同一个 bin。offline 维护留在 CLI 到切片 5（裁决记录在任务 plan Round 5）。`rg 'daemon serve|runtime-worker-host' packages/cli/src` 现为零命中。

## 架构辩护

daemon 包拥有全部承重进程（serve、service、worker host）；CLI 是客户端，只 spawn 已安装的 daemon bin，不保留宿主解释器。宿主 mode 只有 `bin.ts` 一份解释器，CLI 侧副本同变更删除。生产净行数为正是因为 bin 入口、build 配置与 launch 解析是新文件，而删掉的 CLI 分支更小。

## 改动内容

- `packages/daemon/package.json`、`tsconfig.build.json`、`scripts/copy-assets.mjs`、`scripts/smoke-package.mjs`、`README.md`：可发布包、构建、pack/install smoke。
- `packages/daemon/src/bin.ts`（新）：宿主 mode 分派。
- `packages/daemon/src/runtime-spawn-process.ts`、`runtime-worker-host.ts`：worker host 经 bin 启动；模块内 argv 解释器删除。
- `packages/daemon/src/client/daemon-autostart.ts`：`[entry, mode, …]` 启动。
- `packages/cli/src/daemon/{client,control,autostart}.ts`：删宿主分支；launch spec 解析已安装 bin。
- 测试：`daemon-bin-launch.test.ts`（新）、`daemon-package.integration.test.mjs`、autostart/singleton/drain 测试更新。

## 门收割 / Gate Harvest

- 删除的生产路径：packages/cli/src/daemon/control.ts serve/deferral host branch; packages/cli/src/daemon/client.ts `[entry, "daemon", "serve", …]` launch spec; packages/daemon/src/runtime-worker-host.ts argv interpreter
- 删除的门或 fixture：packages/cli/test/daemon-singleton-cli.test.ts 与 packages/cli/test/daemon-stop-drain-window.test.ts 里的 CLI `daemon serve` 启动 fixture `[cli, "daemon", "serve", …]`（改为 `daemonServeEntry()`；已安装 bin 的启动由新 packages/cli/test/daemon-bin-launch.test.ts 覆盖）
- 生产净行数：+123/-80 production (net +43); tests/scripts/README +262/-15。

## 机器可读声明

- 无。

## 任务与范围

- Harness 任务：task_d0fe49e3e6ed5aa370bbbe5fbe（父 task_32df25c474582985e7595eabdf）
- 分支：`codex/split-1`
- 公开范围：daemon 包 metadata/构建/bin 入口与 CLI launch spec
- 私有计划/证据已更新：是（`artifacts/report.md`）
- 范围外：切片 2–5（client/protocol SDK、依赖切断、GUI、CLI offline facade 与 `check-cli-structure` 退役 task_8f9184c7）；真实 `npm publish`（未授权）

## 版本影响

- 版本：不变
- 发布影响：不发布

## 治理声明

- 触碰受保护面：是——`packages/daemon/package.json`（packages/*/package.json）；`tools/gate-allowlists/check-fallback-boundaries.json`（新增一条 consumeKnownError 条目 `packages/daemon/src/bin.ts#<module>`：bin 顶层 catch 是宿主进程出口，从删掉的 CLI serve 分支移过来）
- 受保护面范围：daemon 包去 `private`、声明公开 metadata、bin 与构建；public-ready 包表（`tools/public-ready-packages.mjs`，#2524）已列出该包，`check-package-policy`、`check-runtime-release-readiness`、`check-supply-chain` 在分支上退出码 0
- 授权：仓库所有者 2026-09-12 裁定「A 吧 治理然后拆」、发布契约 dec_4061D4157B1FEF9925E38F2358（in_effect）与边界决策 dec_8FF9DEDD562CE7B2AB37A4C776，记录在 task_d0fe49e3e6ed5aa370bbbe5fbe
- 机器检查边界：本 PR 只断言声明存在；是否属实、是否充分由评审判断。
- Break-glass：否
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：task_8f9184c7a402583aefeba8adbe（check-cli-structure offline 闭包，切片 5 前置）

## 验证

- 基线 `origin/main` SHA：`466caf36a`
- 分支与 `origin/main` 的 merge-base：`466caf36a`
- 最近一次 `git fetch origin`：2026-09-12 UTC
- 同步方式：从 origin/main 开分支
- 公开 diff 命令：`git diff origin/main...codex/split-1`
- 私有证据路径：task_d0fe49e3e6ed5aa370bbbe5fbe 的 `artifacts/report.md`
- 评审证据路径：本 PR 的评审证据节
- GitHub Actions `rewrite-ci` run URL：本 PR 待跑
- Ubuntu 隔离 `daemon-package.integration.test.mjs`：pack → install → serve / --service / --runtime-worker-host smoke，hello 1.0、第二实例 deferred、stop；六个定向文件 28/28；`npm run build -w @harness-anything/daemon`、typecheck、三个发布 checker、publish dry-run、`run-manifest-gates --changed` 6/6 均退出码 0。

## 评审证据

- CEO 事实核对：读过 worker 报告与 diff 统计；裁决过 Round 5/6（offline 留切片 5；autostart 调用方属本片），核过 `rg` 在 packages/cli/src 已无宿主入口。
- 评审子代理：合入后走一条路收口评审
- 人工评审：待定
- 阻塞发现：无

## 残余风险

- worker 未跑完整 CI 矩阵与 Windows lane（以本 PR 的 CI 为准）；bin 启动的 worker host 在 daemon 重启收养（`adoptRuntimes`）下只被既有测试覆盖。

## 参考

- 任务：task_d0fe49e3e6ed5aa370bbbe5fbe

