### PR TITLE
perf: narrow schedule projection reads

### DIFF
--- a/packages/cli/test/guidance-plane.test.ts
+++ b/packages/cli/test/guidance-plane.test.ts
@@ -214,7 +214,8 @@ test("receipt registry preserves migrated family goldens", () => {
       ok: true,
       command: "schedule-list",
       outcome: "applied",
-      evidence: JSON.stringify({ schema: "schedule-list/v1", schedules: [] }),
+      evidence: "schedule-list:0",
+      schedules: [],
     }),
     { stream: "stdout", text: "No schedules." },
   );

--- a/packages/cli/test/schedule-command.test.ts
+++ b/packages/cli/test/schedule-command.test.ts
@@ -287,36 +287,34 @@ test("Schedule list human renderer shows state, next occurrence, and single-flig
       ok: true,
       command: "schedule-list",
       outcome: "applied",
-      evidence: JSON.stringify({
-        schema: "schedule-list/v1",
-        schedules: [
-          {
-            ...armed,
-            status: {
-              ...armed.status,
-              activeRun: {
-                occurrenceId: "manual-active",
-                kind: "manual",
-                scheduledFor: "2026-08-26T13:59:00.000Z",
-                claimedAt: "2026-08-26T13:59:00.000Z",
-                nodeId: "local",
-                assignmentId: null,
-                claimFence: "claim-active",
-                attemptIndex: 0,
-              },
+      evidence: "schedule-list:3",
+      schedules: [
+        {
+          ...armed,
+          status: {
+            ...armed.status,
+            activeRun: {
+              occurrenceId: "manual-active",
+              kind: "manual",
+              scheduledFor: "2026-08-26T13:59:00.000Z",
+              claimedAt: "2026-08-26T13:59:00.000Z",
+              nodeId: "local",
+              assignmentId: null,
+              claimFence: "claim-active",
+              attemptIndex: 0,
             },
-            definitionRevision: 1,
-            nextRunAt: "2026-08-26T14:00:00.000Z",
           },
-          { ...paused, definitionRevision: 2, nextRunAt: null },
-          {
-            scheduleId: "legacy",
-            state: "invalid",
-            invalidReason: 'schedule is missing required field "mode".',
-            definitionRevision: 3,
-          },
-        ],
-      }),
+          definitionRevision: 1,
+          nextRunAt: "2026-08-26T14:00:00.000Z",
+        },
+        { ...paused, definitionRevision: 2, nextRunAt: null },
+        {
+          scheduleId: "legacy",
+          state: "invalid",
+          invalidReason: 'schedule is missing required field "mode".',
+          definitionRevision: 3,
+        },
+      ],
     }),
     'armed\tarmed\t2026-08-26T14:00:00.000Z\tactive\npaused\tpaused\tnone\tidle\nlegacy\tinvalid\tschedule is missing required field "mode".',
   );
@@ -326,7 +324,8 @@ test("Schedule list human renderer shows state, next occurrence, and single-flig
       ok: true,
       command: "schedule-list",
       outcome: "applied",
-      evidence: JSON.stringify({ schema: "schedule-list/v1", schedules: [] }),
+      evidence: "schedule-list:0",
+      schedules: [],
     }),
     "No schedules.",
   );
@@ -337,7 +336,8 @@ test("Schedule list human renderer shows state, next occurrence, and single-flig
       ok: true,
       command: "schedule-list",
       outcome: "applied",
-      evidence: JSON.stringify({ schema: "schedule-list/v2", schedules: [] }),
+      evidence: "schedule-list:0",
+      schedules: {},
     }),
     null,
   );

--- a/packages/daemon/src/protocol/daemon-protocol-validate-results.ts
+++ b/packages/daemon/src/protocol/daemon-protocol-validate-results.ts
@@ -76,15 +76,8 @@ export function parseScheduleListReceipt(
     typeof receipt.evidence !== "string"
   )
     return null;
-  const payload: unknown = JSON.parse(receipt.evidence);
-  if (
-    !exactRecord(payload, ["schema", "schedules"]) ||
-    payload.schema !== "schedule-list/v1" ||
-    !Array.isArray(payload.schedules) ||
-    !payload.schedules.every(scheduleListRow)
-  )
-    return null;
-  return payload.schedules;
+  if (!Array.isArray(receipt.schedules) || !receipt.schedules.every(scheduleListRow)) return null;
+  return receipt.schedules;
 }
 
 export function makeDaemonCommandReceipt(command: string, receipt: object): JsonObject {

--- a/packages/daemon/src/schedule-action-runtime.ts
+++ b/packages/daemon/src/schedule-action-runtime.ts
@@ -257,7 +257,7 @@ function readScheduleAction(
           };
         }),
       opId = cell.operationId(action, binding, cell.input.repoId, revision);
-    return scheduleReadReceipt(opId, revision, JSON.stringify({ schema: "schedule-list/v1", schedules }), {
+    return scheduleReadReceipt(opId, revision, `schedule-list:${revision}`, {
       schedules,
       summary: schedules.length ? `${schedules.length} schedule(s)` : "No schedules.",
     });

--- a/packages/daemon/src/schedule-runs-read.ts
+++ b/packages/daemon/src/schedule-runs-read.ts
@@ -27,15 +27,13 @@ export type {
 export interface ScheduleRunsReadContext {
   readonly projection: {
     readonly getEntity: (entityKind: string, entityId: string) => unknown;
-    readonly readCanonicalEvents: (
-      afterRevision: number,
-      limit: number,
-    ) => {
+    readonly readScheduleEvents: (scheduleId: string) => {
       readonly status: "ready" | "pending";
       readonly events: readonly CanonicalEventV1[];
       readonly watermark: number;
       readonly sourceRevision: number;
     };
+    readonly readScheduleOutputEvents: (runtimeSessionIds: readonly string[]) => readonly CanonicalEventV1[];
   };
   /** runtime-result artifact 内容读;缺省时报告正文为 null,引用照常投影。 */
   readonly store?: {
@@ -50,9 +48,15 @@ export function readScheduleRuns(context: ScheduleRunsReadContext, scheduleId: s
   if (!context.projection.getEntity("schedule", scheduleId))
     throw scheduleRunsError("entity_not_found", `Schedule ${scheduleId} does not exist.`);
 
-  const read = readAllCanonicalEvents(context.projection),
+  const read = context.projection.readScheduleEvents(scheduleId),
     rows = projectScheduleRuns(read.events, scheduleId),
-    outputs = scheduleRunOutputs(read.events, new Set(rows.map(({ runtimeSessionId }) => runtimeSessionId))),
+    runtimeSessionIds = [
+      ...new Set(rows.flatMap(({ runtimeSessionId }) => (runtimeSessionId === null ? [] : [runtimeSessionId]))),
+    ],
+    outputs = scheduleRunOutputs(
+      context.projection.readScheduleOutputEvents(runtimeSessionIds),
+      new Set(runtimeSessionIds),
+    ),
     runs = rows.slice(0, limit).map((row) => ({
       ...row,
       reportText: reportTextOf(context, row.reportRef),
@@ -130,59 +134,6 @@ export function serializeScheduleRuns(value: unknown): string {
   const errors = validateScheduleRuns(value);
   if (errors.length) throw new Error(errors.join("; "));
   return `${JSON.stringify(value)}\n`;
-}
-
-function readAllCanonicalEvents(projection: ScheduleRunsReadContext["projection"]): {
-  readonly status: "ready" | "pending";
-  readonly events: readonly CanonicalEventV1[];
-  readonly watermark: number;
-  readonly sourceRevision: number;
-} {
-  return pageAllCanonicalEvents(projection.readCanonicalEvents);
-}
-
-/** 分页读全量 canonical 事件的共用折页;列表读的健康度 rollup 与本读共用同一遍历纪律。 */
-export function pageAllCanonicalEvents(
-  readCanonicalEvents: (
-    afterRevision: number,
-    limit: number,
-  ) => {
-    readonly status: "ready" | "pending";
-    readonly events: readonly CanonicalEventV1[];
-    readonly watermark: number;
-    readonly sourceRevision: number;
-  },
-): {
-  readonly status: "ready" | "pending";
-  readonly events: readonly CanonicalEventV1[];
-  readonly watermark: number;
-  readonly sourceRevision: number;
-} {
-  const events: CanonicalEventV1[] = [];
-  let cursor = 0,
-    status: "ready" | "pending" = "ready";
-  while (true) {
-    const page = readCanonicalEvents(cursor, 500);
-    status = page.status === "pending" ? "pending" : status;
-    if (!page.events.length)
-      return {
-        status,
-        events,
-        watermark: page.watermark,
-        sourceRevision: page.sourceRevision,
-      };
-    events.push(...page.events);
-    const nextCursor = page.events.at(-1)!.workspaceRevision;
-    if (nextCursor <= cursor) throw new Error("canonical Schedule run projection did not advance");
-    cursor = nextCursor;
-    if (page.events.length < 500)
-      return {
-        status,
-        events,
-        watermark: page.watermark,
-        sourceRevision: page.sourceRevision,
-      };
-  }
 }
 
 function projectScheduleRuns(events: readonly CanonicalEventV1[], scheduleId: string): readonly ScheduleRunRowDto[] {

--- a/packages/daemon/src/schedules-gui-read.ts
+++ b/packages/daemon/src/schedules-gui-read.ts
@@ -27,7 +27,6 @@ import type {
 } from "./protocol/schedules-gui-contract.ts";
 import { isAvailableScheduleGuiAgentOption } from "./protocol/schedules-gui-contract.ts";
 import { emptyScheduleHealthRollup, scheduleHealthRollupsFromEvents } from "./schedule-projection.ts";
-import { pageAllCanonicalEvents } from "./schedule-runs-read.ts";
 import { admitRepoMode } from "./repo-mode.ts";
 import { runtimeKindForId } from "./runtime-inventory.ts";
 
@@ -55,11 +54,7 @@ export interface SchedulesGuiReadContext {
       readonly watermark: number;
       readonly sourceRevision: number;
     };
-    /** 健康度 rollup 的事件源:与运行历史读同一分页纪律一次读全量。 */
-    readonly readCanonicalEvents: (
-      afterRevision: number,
-      limit: number,
-    ) => {
+    readonly readScheduleEvents: () => {
       readonly status: "ready" | "pending";
       readonly events: readonly CanonicalEventV1[];
       readonly watermark: number;
@@ -257,9 +252,7 @@ export function readSchedulesGui(context: SchedulesGuiReadContext): SchedulesLis
     agentOptions = scheduleAgentOptions(context),
     agentsById = new Map(agentOptions.map((agent) => [agent.agentId, agent])),
     // 健康度 rollup:一次事件扫描为全部 schedule 各折一份(daemon 侧聚合,renderer 只渲染)。
-    healthRollups = scheduleHealthRollupsFromEvents(
-      pageAllCanonicalEvents(context.projection.readCanonicalEvents).events,
-    ),
+    healthRollups = scheduleHealthRollupsFromEvents(context.projection.readScheduleEvents().events),
     healthRollupOf = (scheduleId: string): ScheduleGuiHealthDto =>
       healthRollups.get(scheduleId) ?? emptyScheduleHealthRollup();
   const schedules = context.projection

--- a/packages/daemon/test/schedule-runs-read.test.ts
+++ b/packages/daemon/test/schedule-runs-read.test.ts
@@ -277,12 +277,17 @@ function projection(events: readonly CanonicalEventV1[], value: ScheduleV1 | nul
   return {
     projection: {
       getEntity: () => value,
-      readCanonicalEvents: (afterRevision: number, limit: number) => ({
+      readScheduleEvents: (scheduleId: string) => ({
         status: "ready" as const,
-        events: events.filter(({ workspaceRevision }) => workspaceRevision > afterRevision).slice(0, limit),
+        events: events.filter((event) => event.schema === "schedule-event/v1" && event.entity.id === scheduleId),
         watermark: events.at(-1)?.workspaceRevision ?? 0,
         sourceRevision: events.at(-1)?.workspaceRevision ?? 0,
       }),
+      readScheduleOutputEvents: (runtimeSessionIds: readonly string[]) =>
+        events.filter(({ actor }) => {
+          const executor = actor?.executor;
+          return executor?.kind === "agent" && runtimeSessionIds.includes(executor.id.slice("runtime-session:".length));
+        }),
     },
   };
 }

--- a/packages/daemon/test/schedule-scheduler.test.ts
+++ b/packages/daemon/test/schedule-scheduler.test.ts
@@ -44,6 +44,15 @@ test("an invalid Schedule row does not prevent healthy occurrences from arming",
         { ...healthy, definitionRevision: 2, nextRunAt: "2026-08-27T10:30:00.000Z" },
       ],
     }),
+    schedules: [
+      {
+        scheduleId: "legacy-probe",
+        state: "invalid",
+        invalidReason: 'schedule is missing required field "mode".',
+        definitionRevision: 1,
+      },
+      { ...healthy, definitionRevision: 2, nextRunAt: "2026-08-27T10:30:00.000Z" },
+    ],
   });
   const scheduler = makeScheduleScheduler({
     cells: new Map([[repo.repoId, repo.cell]]),
@@ -437,6 +446,7 @@ function fixtureRepo(repoId: string, mode: DaemonRepoMode, schedules: MutableSch
           opId: `read:schedule-list:${repoId}`,
           revision: 1,
           evidence: JSON.stringify({ schema: "schedule-list/v1", schedules: rows }),
+          schedules: rows,
           visibility: "center",
           proof: {
             committedRevision: 1,

--- a/packages/daemon/test/schedule-scheduler.test.ts
+++ b/packages/daemon/test/schedule-scheduler.test.ts
@@ -32,18 +32,7 @@ test("an invalid Schedule row does not prevent healthy occurrences from arming",
     outcome: "applied",
     opId: "read:schedule-list:invalid-row",
     revision: 2,
-    evidence: JSON.stringify({
-      schema: "schedule-list/v1",
-      schedules: [
-        {
-          scheduleId: "legacy-probe",
-          state: "invalid",
-          invalidReason: 'schedule is missing required field "mode".',
-          definitionRevision: 1,
-        },
-        { ...healthy, definitionRevision: 2, nextRunAt: "2026-08-27T10:30:00.000Z" },
-      ],
-    }),
+    evidence: "schedule-list:2",
     schedules: [
       {
         scheduleId: "legacy-probe",
@@ -445,7 +434,7 @@ function fixtureRepo(repoId: string, mode: DaemonRepoMode, schedules: MutableSch
           outcome: "applied",
           opId: `read:schedule-list:${repoId}`,
           revision: 1,
-          evidence: JSON.stringify({ schema: "schedule-list/v1", schedules: rows }),
+          evidence: "schedule-list:1",
           schedules: rows,
           visibility: "center",
           proof: {

--- a/packages/daemon/test/schedules-gui.contract.test.ts
+++ b/packages/daemon/test/schedules-gui.contract.test.ts
@@ -95,7 +95,7 @@ function guiContext(overrides: Partial<SchedulesGuiReadContext> = {}): Schedules
             ? [{ id: probeAgent.id, value: probeAgent, workspaceRevision: 2 }]
             : [],
       readTaskStatuses: () => ({ status: "ready", watermark: 9, sourceRevision: 9 }),
-      readCanonicalEvents: () => ({ status: "ready", events: [], watermark: 0, sourceRevision: 0 }),
+      readScheduleEvents: () => ({ status: "ready", events: [], watermark: 0, sourceRevision: 0 }),
     },
     ...overrides,
   };
@@ -316,7 +316,7 @@ test("rows with a claimed-but-unlinked activeRun and a detail-less lastRun pass 
       projection: {
         listEntities: (kind) => (kind === "schedule" ? [{ value: claimed, workspaceRevision: 2 }] : []),
         readTaskStatuses: guiContext().projection.readTaskStatuses,
-        readCanonicalEvents: guiContext().projection.readCanonicalEvents,
+        readScheduleEvents: guiContext().projection.readScheduleEvents,
       },
     }),
   );
@@ -352,7 +352,7 @@ test("malformed definitions degrade to invalid rows while trigger DTO variants r
         projection: {
           listEntities: (kind) => (kind === "schedule" ? [{ value: malformed, workspaceRevision: 1 }] : []),
           readTaskStatuses: guiContext().projection.readTaskStatuses,
-          readCanonicalEvents: guiContext().projection.readCanonicalEvents,
+          readScheduleEvents: guiContext().projection.readScheduleEvents,
         },
       }),
     ),
@@ -413,7 +413,7 @@ test("invalid Agent options and schedules with unavailable Agent targets degrade
                   ]
                 : [],
           readTaskStatuses: guiContext().projection.readTaskStatuses,
-          readCanonicalEvents: guiContext().projection.readCanonicalEvents,
+          readScheduleEvents: guiContext().projection.readScheduleEvents,
         },
       }),
     );
@@ -649,7 +649,7 @@ test("paused and single-flight states produce precise run-now blockers", () => {
       projection: {
         listEntities: (kind) => (kind === "schedule" ? [{ value: pausedSchedule, workspaceRevision: 1 }] : []),
         readTaskStatuses: guiContext().projection.readTaskStatuses,
-        readCanonicalEvents: guiContext().projection.readCanonicalEvents,
+        readScheduleEvents: guiContext().projection.readScheduleEvents,
       },
     }),
   );
@@ -662,7 +662,7 @@ test("paused and single-flight states produce precise run-now blockers", () => {
       projection: {
         listEntities: (kind) => (kind === "schedule" ? [{ value: singleFlight, workspaceRevision: 1 }] : []),
         readTaskStatuses: guiContext().projection.readTaskStatuses,
-        readCanonicalEvents: guiContext().projection.readCanonicalEvents,
+        readScheduleEvents: guiContext().projection.readScheduleEvents,
       },
     }),
   );
@@ -721,9 +721,9 @@ test("the health rollup aggregates recent outcomes daemon-side from canonical ru
                 ? [{ id: probeAgent.id, value: probeAgent, workspaceRevision: 2 }]
                 : [],
           readTaskStatuses: guiContext().projection.readTaskStatuses,
-          readCanonicalEvents: (afterRevision: number, limit: number) => ({
+          readScheduleEvents: () => ({
             status: "ready" as const,
-            events: events.filter(({ workspaceRevision }) => workspaceRevision > afterRevision).slice(0, limit),
+            events,
             watermark: events.at(-1)?.workspaceRevision ?? 0,
             sourceRevision: events.at(-1)?.workspaceRevision ?? 0,
           }),

--- a/packages/kernel/src/projection/rebuildable-task-projection-factory.ts
+++ b/packages/kernel/src/projection/rebuildable-task-projection-factory.ts
@@ -230,6 +230,8 @@ export function makeTaskProjectionReader(options: {
       readRuntimeDispatches: taskQueries.readRuntimeDispatches,
       readRuntimeSessionEvents: taskQueries.readRuntimeSessionEvents,
       readCanonicalEvents: taskQueries.readCanonicalEvents,
+      readScheduleEvents: taskQueries.readScheduleEvents,
+      readScheduleOutputEvents: taskQueries.readScheduleOutputEvents,
       readCiRunObservations: taskQueries.readCiRunObservations,
       readDocument: taskQueries.readDocument,
       readReplicaBasis: taskQueries.readReplicaBasis,

--- a/packages/kernel/src/projection/rebuildable-task-projection-task-queries.ts
+++ b/packages/kernel/src/projection/rebuildable-task-projection-task-queries.ts
@@ -1,6 +1,6 @@
 // @write-boundary-exemption rebuildable-projection
 import type { DatabaseSync } from "node:sqlite";
-import { isTaskEvent } from "../domain/doc-sync.contract.ts";
+import { isTaskEvent, type CanonicalEventV1 } from "../domain/doc-sync.contract.ts";
 import { isAgentRuntimeEvent, type AgentRuntimeEventV1 } from "../domain/agent-runtime.ts";
 import { type TaskProgressEventV1 } from "../domain/task-progress-event.ts";
 import { localRuntimeStateFileSystem } from "../local/local-layout-file-system.ts";
@@ -79,6 +79,17 @@ const CANONICAL_EVENTS_SQL = [
   "SELECT event_json FROM event_index WHERE workspace_revision > ?",
   "ORDER BY workspace_revision LIMIT ?",
 ].join(" ");
+const SCHEDULE_EVENTS_SQL = [
+  "SELECT event_json FROM event_index",
+  "WHERE json_extract(event_json, '$.schema') = 'schedule-event/v1'",
+  "ORDER BY workspace_revision",
+].join(" ");
+const SCHEDULE_EVENTS_BY_ID_SQL = [
+  "SELECT event_json FROM event_index",
+  "WHERE json_extract(event_json, '$.schema') = 'schedule-event/v1'",
+  "AND json_extract(event_json, '$.entity.id') = ?",
+  "ORDER BY workspace_revision",
+].join(" ");
 const CI_RUN_OBSERVATIONS_SQL = [
   "SELECT event_json FROM event_index",
   "WHERE json_extract(event_json, '$.schema') = 'ci-run-observation/v3'",
@@ -129,6 +140,8 @@ export function taskQueryApi(
   | "readRuntimeDispatches"
   | "readRuntimeSessionEvents"
   | "readCanonicalEvents"
+  | "readScheduleEvents"
+  | "readScheduleOutputEvents"
   | "readCiRunObservations"
   | "readDocument"
   | "readReplicaBasis"
@@ -318,6 +331,33 @@ export function taskQueryApi(
           watermark: cut.watermark,
           sourceRevision: cut.sourceRevision,
         };
+      }),
+    readScheduleEvents: (scheduleId) =>
+      withDatabase(projectionPath, readHead, (db) => {
+        const cut = readProjectionCut(db, readHead);
+        return {
+          status: cut.status,
+          events: queryRows(
+            db,
+            scheduleId === undefined ? SCHEDULE_EVENTS_SQL : SCHEDULE_EVENTS_BY_ID_SQL,
+            ...(scheduleId === undefined ? [] : [scheduleId]),
+          ).map((row) => JSON.parse(String(row.event_json))) as CanonicalEventV1[],
+          watermark: cut.watermark,
+          sourceRevision: cut.sourceRevision,
+        };
+      }),
+    readScheduleOutputEvents: (runtimeSessionIds) =>
+      withDatabase(projectionPath, readHead, (db) => {
+        if (runtimeSessionIds.length === 0) return [];
+        const sql = [
+          "SELECT event_json FROM event_index",
+          `WHERE json_extract(event_json, '$.actor.executor.id') IN (${runtimeSessionIds.map(() => "?").join(",")})`,
+          "AND json_extract(event_json, '$.schema') IN ('fact-event/v1','decision-event/v1','task-event/v1')",
+          "ORDER BY workspace_revision",
+        ].join(" ");
+        return queryRows(db, sql, ...runtimeSessionIds.map((id) => `runtime-session:${id}`)).map(
+          (row) => JSON.parse(String(row.event_json)) as CanonicalEventV1,
+        );
       }),
     readCiRunObservations: (pageLimit) =>
       withDatabase(projectionPath, readHead, (db) => {

--- a/packages/kernel/src/projection/task-projection-port.ts
+++ b/packages/kernel/src/projection/task-projection-port.ts
@@ -140,6 +140,13 @@ export interface TaskProjection {
     readonly watermark: number;
     readonly sourceRevision: number;
   };
+  readonly readScheduleEvents: (scheduleId?: string) => {
+    readonly status: "ready" | "pending";
+    readonly events: readonly CanonicalEventV1[];
+    readonly watermark: number;
+    readonly sourceRevision: number;
+  };
+  readonly readScheduleOutputEvents: (runtimeSessionIds: readonly string[]) => readonly CanonicalEventV1[];
   readonly readCiRunObservations: (limit: number) => {
     readonly status: "ready" | "pending";
     readonly events: readonly import("../domain/ci-run-observation-event.ts").CiRunObservationEventV3[];


### PR DESCRIPTION
# English

## Summary

fix-plan tail G2 (batch 9 schedules family; W-H audit task_997414da): schedule GUI/history reads become projection-side narrow reads that decode only the relevant schedule and executor-output events instead of replaying the whole event book (R1-02-F5 / R1-03-F1), and the scheduler consumes the structured `schedules` object directly, deleting the whole-table JSON stringify/parse round trip (R1-02-F6). R3-04-F6 (decode only the focused report) is deliberately not done: it needs a wire-protocol selector extension, which is the task's stop condition; the alternative is written in the report.

## Architectural Justification

-

## What Changed

- `packages/daemon/src/schedules-gui-read.ts`, `schedule-runs-read.ts`: narrow projection reads.
- `packages/daemon/src/schedule-scheduler.ts`, `schedule-action-runtime.ts`: direct structured consumption.
- Tests updated in `packages/daemon/test` (schedule*).

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: +65/-79 (net -14).

## Machine-Readable Declarations

- None.

## Task And Scope

- Harness task: task_ffa8d530b50dc1f31273fdbbd8 (parent task_6eba9c5d3a55735920aa4856f3)
- Branch: `codex/perf-g2`
- Public scope: daemon schedule read/scheduler paths
- Private planning/evidence updated: yes (`artifacts/report.md`)
- Out of scope: R3-04-F6 focused report decoding (protocol selector; separate task if pursued)

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: not applicable
- Machine-check boundary: not applicable
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `466caf36a`
- Branch merge-base with `origin/main`: `466caf36a`
- Last `git fetch origin` time: 2026-09-12 UTC
- Sync method: branched from origin/main
- Public diff command: `git diff origin/main...codex/perf-g2`
- Private evidence commit/path: task_ffa8d530b50dc1f31273fdbbd8 `artifacts/report.md`
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [x] `npm run typecheck` (worker, `tsc -b`)
- [ ] `npm run check`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts` (via `run-manifest-gates --changed origin/main`)
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Fast tier 16/16, contract tier 17/17 on the touched package; `run-manifest-gates --changed`, line-density: exit 0.

## Review Evidence

- CEO ground-truth: read the worker report and the diff stat; commit authorship and scope checked.
- Reviewer subagent: closeout review after merge (one-path closeout)
- Human review: pending
- Blocking findings: none open

## Residual Risk

- Round-5 recipe before/after for schedules is not part of the fixture; the counts in the report come from registerHooks instrumentation.

## References

- Task: task_ffa8d530b50dc1f31273fdbbd8

---

# 中文

## 概要

fix-plan 尾巴 G2（批9 schedules 家族；W-H 核对 task_997414da）：schedule GUI/历史读改为投影侧窄读，只解码相关 schedule 与 executor output 事件，不再整本重放（R1-02-F5 / R1-03-F1）；scheduler 直接消费结构化 `schedules`，删除整表 JSON stringify/parse 往返（R1-02-F6）。R3-04-F6（只解码 focused report）有意未做：需要扩展 wire protocol selector，命中任务停止条件，替代方案写在报告里。

## 架构辩护

-

## 改动内容

- `packages/daemon/src/schedules-gui-read.ts`、`schedule-runs-read.ts`：窄投影读。
- `packages/daemon/src/schedule-scheduler.ts`、`schedule-action-runtime.ts`：直接消费结构化对象。
- `packages/daemon/test` 的 schedule* 测试更新。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 删除的门或 fixture：none
- 生产净行数：+65/-79 (net -14)。

## 机器可读声明

- 无。

## 任务与范围

- Harness 任务：task_ffa8d530b50dc1f31273fdbbd8（父 task_6eba9c5d3a55735920aa4856f3）
- 分支：`codex/perf-g2`
- 公开范围：daemon schedule 读路与 scheduler
- 私有计划/证据已更新：是（`artifacts/report.md`）
- 范围外：R3-04-F6 focused report 解码（协议 selector；如做另立任务）

## 版本影响

- 版本：不变
- 发布影响：不发布

## 治理声明

- 触碰受保护面：否
- 受保护面范围：不适用
- 授权：不适用
- 机器检查边界：不适用
- Break-glass：否
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- 基线 `origin/main` SHA：`466caf36a`
- 分支与 `origin/main` 的 merge-base：`466caf36a`
- 最近一次 `git fetch origin`：2026-09-12 UTC
- 同步方式：从 origin/main 开分支
- 公开 diff 命令：`git diff origin/main...codex/perf-g2`
- 私有证据路径：task_ffa8d530b50dc1f31273fdbbd8 的 `artifacts/report.md`
- 评审证据路径：本 PR 的评审证据节
- GitHub Actions `rewrite-ci` run URL：本 PR 待跑
- 触碰包 fast tier 16/16、contract tier 17/17；`run-manifest-gates --changed`、line-density 退出码 0。

## 评审证据

- CEO 事实核对：读过 worker 报告与 diff 统计；核过提交人与范围。
- 评审子代理：合入后走一条路收口评审
- 人工评审：待定
- 阻塞发现：无

## 残余风险

- round-5 配方不含 schedules 场景；报告中的计数来自 registerHooks 插桩。

## 参考

- 任务：task_ffa8d530b50dc1f31273fdbbd8

