### PR TITLE
perf: parallelize CI observation collection

### DIFF
--- a/packages/daemon/src/ci-observation-actions.ts
+++ b/packages/daemon/src/ci-observation-actions.ts
@@ -89,47 +89,57 @@ export async function fetchCiObservations(
         ).flat(),
         limit,
       );
-    const fetched: FetchedCiRun[] = [];
-    for (const run of runs) {
-      const summary = JSON.parse(
-        await runGh(
-          "gh",
-          [
-            "run",
-            "view",
-            String(run.databaseId),
-            "--json",
-            "workflowName,headSha,headBranch,status,conclusion,attempt",
-          ],
-          { cwd: cell.rootDir },
-        ),
-      ) as CiRunSummary;
-      const { status: runLifecycleState } = summary;
-      // Publish immutable observations only for main runs that have a final conclusion.
-      if (summary.headBranch !== "main" || runLifecycleState !== "completed") {
-        if (namedRuns)
-          throw cell.cellCodedError(
-            "invalid_command",
-            `CI run ${run.databaseId} is ${runLifecycleState} on ${summary.headBranch}; ` +
-              "only completed main runs can be imported.",
-          );
-        continue;
-      }
-      const runRoot = path.join(temporaryRoot, String(run.databaseId));
-      try {
-        await runGh(
-          "gh",
-          ["run", "download", String(run.databaseId), "--pattern", "ci-observation-*", "--dir", runRoot],
-          {
-            cwd: cell.rootDir,
-          },
-        );
-      } catch (error) {
-        consumeKnownError(error);
-        continue;
-      }
-      fetched.push({ databaseId: run.databaseId, summary, artifacts: readArtifacts(runRoot) });
-    }
+    const fetchResults = await Promise.all(
+      runs.map(async (run): Promise<{ fetched: FetchedCiRun | null } | { failure: unknown }> => {
+        try {
+          const summary = JSON.parse(
+            await runGh(
+              "gh",
+              [
+                "run",
+                "view",
+                String(run.databaseId),
+                "--json",
+                "workflowName,headSha,headBranch,status,conclusion,attempt",
+              ],
+              { cwd: cell.rootDir },
+            ),
+          ) as CiRunSummary;
+          const { status: runLifecycleState } = summary;
+          // Publish immutable observations only for main runs that have a final conclusion.
+          if (summary.headBranch !== "main" || runLifecycleState !== "completed") {
+            if (namedRuns)
+              throw cell.cellCodedError(
+                "invalid_command",
+                `CI run ${run.databaseId} is ${runLifecycleState} on ${summary.headBranch}; ` +
+                  "only completed main runs can be imported.",
+              );
+            return { fetched: null };
+          }
+          const runRoot = path.join(temporaryRoot, String(run.databaseId));
+          try {
+            await runGh(
+              "gh",
+              ["run", "download", String(run.databaseId), "--pattern", "ci-observation-*", "--dir", runRoot],
+              {
+                cwd: cell.rootDir,
+              },
+            );
+          } catch (error) {
+            consumeKnownError(error);
+            return { fetched: null };
+          }
+          return { fetched: { databaseId: run.databaseId, summary, artifacts: readArtifacts(runRoot) } };
+        } catch (failure) {
+          return { failure };
+        }
+      }),
+    );
+    const failedFetch = fetchResults.find((result) => "failure" in result);
+    if (failedFetch && "failure" in failedFetch) throw failedFetch.failure;
+    const fetched = fetchResults.flatMap((result) =>
+      "fetched" in result && result.fetched !== null ? [result.fetched] : [],
+    );
     if (!namedRuns) {
       const authoredRoot = resolveHarnessLayout(cell.rootDir).authoredRoot;
       if (existsSync(authoredRoot)) {

--- a/packages/daemon/test/ci-observatory-read.test.ts
+++ b/packages/daemon/test/ci-observatory-read.test.ts
@@ -388,6 +388,65 @@ test("CI observation pull writes canonical events once per run and job", async (
   }
 });
 
+test("CI observation pull collects selected GitHub runs concurrently in selection order", async () => {
+  const rootDir = mkdtempSync(path.join(process.cwd(), ".tmp-ci-observation-concurrent-"));
+  const viewResolvers = new Map<string, () => void>();
+  const viewStarts: string[] = [];
+  const runGh = (async (_command: string, args: readonly string[]) => {
+    const runId = String(args[2]);
+    if (args[1] === "view") {
+      viewStarts.push(runId);
+      await new Promise<void>((resolve) => viewResolvers.set(runId, resolve));
+      return JSON.stringify({
+        workflowName: "rewrite-ci",
+        headSha: `sha-${runId}`,
+        headBranch: "main",
+        status: "completed",
+        conclusion: "success",
+        attempt: 1,
+      });
+    }
+    const outputDir = String(args[args.indexOf("--dir") + 1]);
+    mkdirSync(outputDir, { recursive: true });
+    writeFileSync(
+      path.join(outputDir, "observation.json"),
+      JSON.stringify({
+        schema: "ci-run-artifact/v1",
+        run: {
+          runId: `${runId}.1`,
+          sha: `sha-${runId}`,
+          branch: "main",
+          prNumber: null,
+          job: `job-${runId}`,
+          wallclockMs: 20,
+          runner: "ubuntu",
+        },
+        tests: [],
+        gates: [],
+      }),
+    );
+    return "";
+  }) as never;
+  try {
+    const fetching = fetchCiObservations(
+      { rootDir, settings: ciSettings(), cellCodedError: (_code: string, message: string) => new Error(message) },
+      { kind: "ci-observe-pull", runs: [102, 101] },
+      runGh,
+    );
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    assert.deepEqual(viewStarts, ["102", "101"]);
+    viewResolvers.get("102")?.();
+    viewResolvers.get("101")?.();
+    const result = await fetching;
+    assert.deepEqual(
+      result.runs.map((run) => run.databaseId),
+      [102, 101],
+    );
+  } finally {
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});
+
 test("CI observation pull synthesizes a ledger-publication run only for private ledger commits", async () => {
   const rootDir = mkdtempSync(path.join(process.cwd(), ".tmp-ci-observation-ledger-"));
   const ledgerRoot = path.join(rootDir, "harness");


### PR DESCRIPTION
# English

## Summary

fix-plan tail G6 (batch 18 remainder): R2-09a-F1 FULL — GitHub CI run collection in `ci-observation-actions.ts` runs the per-run `gh` calls in parallel while keeping input order and the original failure semantics. R3-06-F1 (merge boundary-gate walk/parse) is falsified: only one syntax-boundary consumer exists, so there is no cross-gate duplicate traversal to merge; evidence in the report.

## Architectural Justification

-

## What Changed

- `packages/daemon/src/ci-observation-actions.ts`: parallel collection.
- `packages/daemon/test/ci-observatory*.test.ts`: ordering and failure-semantics assertions.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: +51/-41 (net +10).

## Machine-Readable Declarations

- None.

## Task And Scope

- Harness task: task_cd0b7bb83bdc4e5a8abbf60881 (parent task_6eba9c5d3a55735920aa4856f3)
- Branch: `codex/perf-g6`
- Public scope: daemon CI observation collection
- Private planning/evidence updated: yes (`artifacts/report.md`)
- Out of scope: boundary gate family (no change warranted)

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: not applicable
- Machine-check boundary: not applicable
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `466caf36a`
- Branch merge-base with `origin/main`: `466caf36a`
- Last `git fetch origin` time: 2026-09-12 UTC
- Sync method: branched from origin/main
- Public diff command: `git diff origin/main...codex/perf-g6`
- Private evidence commit/path: task_cd0b7bb83bdc4e5a8abbf60881 `artifacts/report.md`
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [x] `npm run typecheck` (worker, `tsc -b`)
- [ ] `npm run check`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts` (via `run-manifest-gates --changed origin/main`)
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Isolated Ubuntu: CI observatory 11/11, syntax boundaries 3/3; typecheck, eslint, line-density, test-selection, `run-manifest-gates --changed`: exit 0.

## Review Evidence

- CEO ground-truth: read the worker report and the diff stat; commit authorship and scope checked.
- Reviewer subagent: closeout review after merge (one-path closeout)
- Human review: pending
- Blocking findings: none open

## Residual Risk

- Parallel `gh` calls raise burst rate against the GitHub API; the count per pull is bounded by `--limit` (max 100).

## References

- Task: task_cd0b7bb83bdc4e5a8abbf60881

---

# 中文

## 概要

fix-plan 尾巴 G6（批18 残余）：R2-09a-F1 FULL——`ci-observation-actions.ts` 的 GitHub CI run 收集改为并行调用 `gh`，保持输入顺序与原失败语义。R3-06-F1（合并 boundary 门的 walk/parse）证伪：只有一个 syntax-boundary 消费者，不存在跨门重复遍历可合并；证据在报告里。

## 架构辩护

-

## 改动内容

- `packages/daemon/src/ci-observation-actions.ts`：并行收集。
- `packages/daemon/test/ci-observatory*.test.ts`：顺序与失败语义断言。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 删除的门或 fixture：none
- 生产净行数：+51/-41 (net +10)。

## 机器可读声明

- 无。

## 任务与范围

- Harness 任务：task_cd0b7bb83bdc4e5a8abbf60881（父 task_6eba9c5d3a55735920aa4856f3）
- 分支：`codex/perf-g6`
- 公开范围：daemon CI 观察收集
- 私有计划/证据已更新：是（`artifacts/report.md`）
- 范围外：boundary 门家族（无需改动）

## 版本影响

- 版本：不变
- 发布影响：不发布

## 治理声明

- 触碰受保护面：否
- 受保护面范围：不适用
- 授权：不适用
- 机器检查边界：不适用
- Break-glass：否
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- 基线 `origin/main` SHA：`466caf36a`
- 分支与 `origin/main` 的 merge-base：`466caf36a`
- 最近一次 `git fetch origin`：2026-09-12 UTC
- 同步方式：从 origin/main 开分支
- 公开 diff 命令：`git diff origin/main...codex/perf-g6`
- 私有证据路径：task_cd0b7bb83bdc4e5a8abbf60881 的 `artifacts/report.md`
- 评审证据路径：本 PR 的评审证据节
- GitHub Actions `rewrite-ci` run URL：本 PR 待跑
- Ubuntu 隔离：CI observatory 11/11、syntax boundaries 3/3；typecheck、eslint、line-density、test-selection、`run-manifest-gates --changed` 退出码 0。

## 评审证据

- CEO 事实核对：读过 worker 报告与 diff 统计；核过提交人与范围。
- 评审子代理：合入后走一条路收口评审
- 人工评审：待定
- 阻塞发现：无

## 残余风险

- 并行 `gh` 提高对 GitHub API 的瞬时速率；每次 pull 的数量受 `--limit`（最多 100）约束。

## 参考

- 任务：task_cd0b7bb83bdc4e5a8abbf60881

