### PR TITLE
perf: reuse resolved layouts in migration and dispatch reads

### DIFF
--- a/packages/daemon/src/dispatch-stream.ts
+++ b/packages/daemon/src/dispatch-stream.ts
@@ -248,7 +248,7 @@ export function readDispatchLiveIndex(rootDir: string, taskIds: readonly string[
 }
 
 export function rebuildDispatchLiveIndex(rootDir: string, taskIds: readonly string[]): DispatchLiveIndex {
-  const root = dispatchStreamRoot(rootDir),
+  const root = dispatchStreamRoot(resolveHarnessLayout(rootDir)),
     selected = new Set(taskIds);
   const entries = new Map<string, DispatchLiveIndexEntry>();
   if (existsSync(root) && statSync(root).isDirectory()) {
@@ -352,7 +352,7 @@ export function readDispatchStreamSummary(rootDir: string, dispatchId: string): 
 }
 
 export function readDispatchStreamHeaders(rootDir: string): readonly DispatchStreamHeader[] {
-  const root = dispatchStreamRoot(rootDir);
+  const root = dispatchStreamRoot(resolveHarnessLayout(rootDir));
   const stat = statSync(root, { throwIfNoEntry: false });
   if (!stat?.isDirectory()) {
     headerCache.delete(root);
@@ -452,8 +452,9 @@ export function readRuntimeWorkerChunk(target: string, offset: number, limit = 1
 }
 
 export function dispatchStreamRef(rootDir: string, dispatchId: string): string {
+  const layout = resolveHarnessLayout(rootDir);
   const relative = path
-    .relative(resolveHarnessLayout(rootDir).rootDir, dispatchStreamPath(rootDir, dispatchId))
+    .relative(layout.rootDir, dispatchStreamPathForLayout(layout, dispatchId))
     .split(path.sep)
     .join("/");
   return `file:${relative}`;
@@ -475,15 +476,19 @@ export function scrubProviderValue(value: unknown): unknown {
 }
 
 export function dispatchStreamPath(rootDir: string, dispatchId: string): string {
+  return dispatchStreamPathForLayout(resolveHarnessLayout(rootDir), dispatchId);
+}
+function dispatchStreamPathForLayout(layout: ReturnType<typeof resolveHarnessLayout>, dispatchId: string): string {
   if (!/^dispatch_[a-f0-9]{24}$/u.test(dispatchId)) throw new Error("dispatch id is invalid");
-  return path.join(dispatchStreamRoot(rootDir), `${dispatchId}.jsonl`);
+  return path.join(dispatchStreamRoot(layout), `${dispatchId}.jsonl`);
 }
 export function dispatchLiveIndexPath(rootDir: string, taskId: string): string {
-  const shard = `task-${Buffer.from(taskId).toString("base64url")}.json`;
-  return path.join(dispatchStreamRoot(rootDir), "live-index", shard);
+  const layout = resolveHarnessLayout(rootDir),
+    shard = `task-${Buffer.from(taskId).toString("base64url")}.json`;
+  return path.join(dispatchStreamRoot(layout), "live-index", shard);
 }
-function dispatchStreamRoot(rootDir: string): string {
-  return path.join(resolveHarnessLayout(rootDir).localRoot, "runtime", "dispatches");
+function dispatchStreamRoot(layout: ReturnType<typeof resolveHarnessLayout>): string {
+  return path.join(layout.localRoot, "runtime", "dispatches");
 }
 
 function dispatchLiveIndex(entries: readonly DispatchLiveIndexEntry[]): DispatchLiveIndex {

--- a/packages/daemon/src/migration-import-oracle-rebuild.ts
+++ b/packages/daemon/src/migration-import-oracle-rebuild.ts
@@ -275,7 +275,7 @@ function overlayAuthoredOracle(
     entityKeys = new Set(base.entityKeys),
     firstTaskEvents = earliestTaskEvents(inspection.events);
   for (const entry of taskRead.entries) {
-    const row = taskEntryToRow(sourceRoot, entry),
+    const row = taskEntryToRow(layout, entry),
       occurredAt =
         timestamp(readScalar(entry.frontmatter, "  bindingCreatedAt")) ??
         timestamp(readScalar(entry.frontmatter, "bindingCreatedAt")) ??

--- a/packages/daemon/src/migration-import-tasks.ts
+++ b/packages/daemon/src/migration-import-tasks.ts
@@ -23,7 +23,7 @@ import type { MigrationImportContext } from "./migration-import-run.ts";
 export function addTask(context: MigrationImportContext, entry: TaskSourceEntry): void {
   let row;
   try {
-    row = taskEntryToRow(context.sourceRoot, entry);
+    row = taskEntryToRow(context.sourceLayout, entry);
     validateTaskIdSyntax(row.taskId);
   } catch (error) {
     const reason = context.message(error);
@@ -249,7 +249,7 @@ export function addOracleTask(context: MigrationImportContext, source: Projectio
           : []),
       ].join("\n"),
     },
-    row = taskEntryToRow(context.sourceRoot, syntheticEntry),
+    row = taskEntryToRow(context.sourceLayout, syntheticEntry),
     body = context.taskDocument(
       task,
       source.taskId,

--- a/packages/daemon/test/migration-import.fixtures.ts
+++ b/packages/daemon/test/migration-import.fixtures.ts
@@ -8,6 +8,7 @@ import {
   readLegacyMigrationSource,
   readMarkdownSource,
   readScalar,
+  resolveHarnessLayout,
   sha256Text,
   taskEntryToRow,
 } from "../../kernel/src/index.ts";
@@ -317,7 +318,8 @@ export function snapshot(root: string): readonly string[] {
 export function buildProjectionOracle(root: string): void {
   const localRoot = path.join(root, ".harness/cache"),
     databasePath = path.join(localRoot, "task.sqlite"),
-    taskRead = readMarkdownSource(root),
+    layout = resolveHarnessLayout(root),
+    taskRead = readMarkdownSource(layout),
     cold = readLegacyMigrationSource(root);
   mkdirSync(localRoot, { recursive: true });
   rmSync(databasePath, { force: true });
@@ -339,7 +341,7 @@ export function buildProjectionOracle(root: string): void {
     for (const statement of statements) database.exec(statement);
     let revision = 0;
     for (const entry of taskRead.entries) {
-      const row = taskEntryToRow(root, entry),
+      const row = taskEntryToRow(layout, entry),
         title = row.title || markdownH1(entry.body) || row.taskId,
         occurredAt =
           readScalar(entry.frontmatter, "  bindingCreatedAt") ||

--- a/packages/kernel/src/projection/sqlite-task-source.ts
+++ b/packages/kernel/src/projection/sqlite-task-source.ts
@@ -7,7 +7,7 @@ import { isDomainStatus } from "../domain/lifecycle-status.ts";
 import { taskBoardColumnOf } from "../domain/task-board-projection.ts";
 import { isPackageDisposition } from "../domain/package-disposition.ts";
 import { sha256Text } from "../integrity/stable-hash.ts";
-import type { HarnessLayoutInput } from "../layout/index.ts";
+import type { HarnessLayout, HarnessLayoutInput } from "../layout/index.ts";
 import { resolveHarnessLayout } from "../layout/index.ts";
 import { readFrontmatter, readNestedScalar, readScalar } from "../markdown/frontmatter.ts";
 import type {
@@ -102,11 +102,11 @@ export interface TaskProjectionSourceHashInput {
 }
 
 export function taskEntryToRow(
-  rootInput: HarnessLayoutInput,
+  layout: HarnessLayout,
   entry: TaskSourceEntry,
   fieldExtensions: ReadonlyArray<TaskFieldExtensionProjection> = [],
 ): TaskProjectionRow {
-  const rootDir = resolveHarnessLayout(rootInput).rootDir;
+  const rootDir = layout.rootDir;
   const rawStatus = readScalar(entry.frontmatter, "  status") || "unknown";
   const canonicalStatus = isDomainStatus(rawStatus) ? rawStatus : "unknown";
   const rawDisposition = readScalar(entry.frontmatter, "packageDisposition") || "active";


### PR DESCRIPTION
# English

## Summary

fix-plan tail G7 (batch 6B layout remainder): `taskEntryToRow` in `sqlite-task-source.ts` takes the resolved layout as a parameter; `migration-import-tasks.ts` and `migration-import-oracle-rebuild.ts` resolve it once per import loop and pass it down, and the two `dispatch-stream.ts` call sites do the same, removing the per-row layout resolution.

## Architectural Justification

-

## What Changed

- `packages/daemon/src/sqlite-task-source.ts`, `migration-import-tasks.ts`, `migration-import-oracle-rebuild.ts`, `dispatch-stream.ts`: layout resolved once and passed down.
- One test fixture updated.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: +19/-14 (net +5).

## Machine-Readable Declarations

- None.

## Task And Scope

- Harness task: task_8b4517d15128729f2b75c03c3e (parent task_6eba9c5d3a55735920aa4856f3)
- Branch: `codex/perf-g7`
- Public scope: daemon migration import and dispatch stream read paths
- Private planning/evidence updated: yes (`artifacts/report.md`)
- Out of scope: none

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: not applicable
- Machine-check boundary: not applicable
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `466caf36a`
- Branch merge-base with `origin/main`: `466caf36a`
- Last `git fetch origin` time: 2026-09-12 UTC
- Sync method: branched from origin/main
- Public diff command: `git diff origin/main...codex/perf-g7`
- Private evidence commit/path: task_8b4517d15128729f2b75c03c3e `artifacts/report.md`
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [x] `npm run typecheck` (worker, `tsc -b`)
- [ ] `npm run check`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts` (via `run-manifest-gates --changed origin/main`)
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Fast 19/19; isolated Ubuntu migration 7/7, dispatch 2/2; `run-manifest-gates --changed` 6/6, line-density: exit 0.

## Review Evidence

- CEO ground-truth: read the worker report and the diff stat; commit authorship and scope checked.
- Reviewer subagent: closeout review after merge (one-path closeout)
- Human review: pending
- Blocking findings: none open

## Residual Risk

- None beyond the parameter threading itself.

## References

- Task: task_8b4517d15128729f2b75c03c3e

---

# 中文

## 概要

fix-plan 尾巴 G7（批6B layout 残余）：`sqlite-task-source.ts` 的 `taskEntryToRow` 接收已解析的 layout 参数；`migration-import-tasks.ts` 与 `migration-import-oracle-rebuild.ts` 每个导入循环只 resolve 一次下传，`dispatch-stream.ts` 两个调用点同样处理，去掉逐行 resolve。

## 架构辩护

-

## 改动内容

- `packages/daemon/src/sqlite-task-source.ts`、`migration-import-tasks.ts`、`migration-import-oracle-rebuild.ts`、`dispatch-stream.ts`：layout 只解析一次下传。
- 一个测试 fixture 更新。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 删除的门或 fixture：none
- 生产净行数：+19/-14 (net +5)。

## 机器可读声明

- 无。

## 任务与范围

- Harness 任务：task_8b4517d15128729f2b75c03c3e（父 task_6eba9c5d3a55735920aa4856f3）
- 分支：`codex/perf-g7`
- 公开范围：daemon migration import 与 dispatch stream 读路
- 私有计划/证据已更新：是（`artifacts/report.md`）
- 范围外：无

## 版本影响

- 版本：不变
- 发布影响：不发布

## 治理声明

- 触碰受保护面：否
- 受保护面范围：不适用
- 授权：不适用
- 机器检查边界：不适用
- Break-glass：否
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- 基线 `origin/main` SHA：`466caf36a`
- 分支与 `origin/main` 的 merge-base：`466caf36a`
- 最近一次 `git fetch origin`：2026-09-12 UTC
- 同步方式：从 origin/main 开分支
- 公开 diff 命令：`git diff origin/main...codex/perf-g7`
- 私有证据路径：task_8b4517d15128729f2b75c03c3e 的 `artifacts/report.md`
- 评审证据路径：本 PR 的评审证据节
- GitHub Actions `rewrite-ci` run URL：本 PR 待跑
- Fast 19/19；Ubuntu 隔离 migration 7/7、dispatch 2/2；`run-manifest-gates --changed` 6/6、line-density 退出码 0。

## 评审证据

- CEO 事实核对：读过 worker 报告与 diff 统计；核过提交人与范围。
- 评审子代理：合入后走一条路收口评审
- 人工评审：待定
- 阻塞发现：无

## 残余风险

- 除参数下传本身外无。

## 参考

- 任务：task_8b4517d15128729f2b75c03c3e

