### PR TITLE
fix: bind test daemon cleanup to fixture lifetime

### DIFF
--- a/packages/cli/test/daemon-autostart-cleanup.integration.test.ts
+++ b/packages/cli/test/daemon-autostart-cleanup.integration.test.ts
@@ -1,0 +1,59 @@
+// harness-test-tier: integration
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { daemonProcessAlive } from "../../daemon/src/daemon-singleton.ts";
+import { stop, waitForProcessExit } from "./daemon-autostart-cli.fixture.ts";
+
+test("autostart fixture stops its daemon even when the owning test throws", async () => {
+  const parent = mkdtempSync(path.join(tmpdir(), "ha-autostart-cleanup-")),
+    witness = path.join(parent, "witness.json"),
+    childTest = path.join(parent, "failure.test.mjs"),
+    fixtureModule = new URL("./daemon-autostart-cli.fixture.ts", import.meta.url).href;
+  writeFileSync(
+    childTest,
+    `import test from "node:test";
+import { writeFileSync } from "node:fs";
+import { setup, run, readDaemonPid } from ${JSON.stringify(fixtureModule)};
+test("intentional failure after daemon launch", () => {
+  const fixture = setup();
+  run(fixture.root, fixture.userRoot, ["daemon", "start", "--service"]);
+  writeFileSync(${JSON.stringify(witness)}, JSON.stringify({ ...fixture, pid: readDaemonPid(fixture.userRoot, "default") }));
+  throw new Error("intentional fixture-owner failure");
+});
+`,
+  );
+  let fixture: { parent: string; root: string; userRoot: string; pid: number } | undefined;
+  try {
+    const env = { ...process.env };
+    delete env.NODE_TEST_CONTEXT;
+    const child = spawnSync(process.execPath, ["--test", childTest], { encoding: "utf8", env, timeout: 30_000 });
+    assert.equal(
+      existsSync(witness),
+      true,
+      `${child.stderr}
+${child.stdout}`,
+    );
+    fixture = JSON.parse(readFileSync(witness, "utf8"));
+    assert.ok(fixture);
+    assert.equal(
+      child.status,
+      1,
+      `${child.stderr}
+${child.stdout}`,
+    );
+    assert.match(child.stdout, /intentional fixture-owner failure/u);
+    assert.equal(daemonProcessAlive(fixture.pid), false, `fixture daemon ${fixture.pid} outlived its failed test`);
+    assert.equal(existsSync(fixture.parent), false, "fixture removal must follow daemon exit");
+  } finally {
+    if (fixture) {
+      stop(fixture.root, fixture.userRoot);
+      await waitForProcessExit(fixture.pid);
+      rmSync(fixture.parent, { recursive: true, force: true });
+    }
+    rmSync(parent, { recursive: true, force: true });
+  }
+});

--- a/packages/cli/test/daemon-autostart-cli-scenario-1.test.ts
+++ b/packages/cli/test/daemon-autostart-cli-scenario-1.test.ts
@@ -53,161 +53,149 @@ test("resident daemon autostart strips the worker callback relay marker", () => 
 
 test("stopping a cold daemon leaves the user root untouched", () => {
   const fixture = setup();
-  try {
-    const stopped = spawnSync(process.execPath, [cli, "--root", fixture.root, "--json", "daemon", "stop"], {
-      encoding: "utf8",
-      env: cliEnv(fixture.root, fixture.userRoot),
-    });
-    assert.notEqual(stopped.status, 0, `${stopped.stderr}\n${stopped.stdout}`);
-    const receipt = JSON.parse(stopped.stdout) as { error?: { code?: string } };
-    assert.equal(receipt.error?.code, "daemon_unavailable");
-    assert.equal(existsSync(fixture.userRoot), false, "a cold stop must not create daemon state");
-  } finally {
-    rmSync(fixture.parent, { recursive: true, force: true });
-  }
+
+  const stopped = spawnSync(process.execPath, [cli, "--root", fixture.root, "--json", "daemon", "stop"], {
+    encoding: "utf8",
+    env: cliEnv(fixture.root, fixture.userRoot),
+  });
+  assert.notEqual(stopped.status, 0, `${stopped.stderr}\n${stopped.stdout}`);
+  const receipt = JSON.parse(stopped.stdout) as { error?: { code?: string } };
+  assert.equal(receipt.error?.code, "daemon_unavailable");
+  assert.equal(existsSync(fixture.userRoot), false, "a cold stop must not create daemon state");
 });
 
 test("operator stop blocks autostart until explicit start while process death remains recoverable", async (context) => {
   const fixture = setup();
-  try {
-    assert.equal(run(fixture.root, fixture.userRoot, ["daemon", "start", "--service"]).ok, true);
-    register(fixture.root, fixture.userRoot, "autostart");
-    const status = run(fixture.root, fixture.userRoot, ["daemon", "status"]);
-    assert.equal(status.entry, "source");
-    const sourceCommit = (status.build as { readonly commit?: unknown }).commit;
-    const gitCommitResult = spawnSync("git", ["rev-parse", "--verify", "HEAD"], {
-      cwd: path.resolve("."),
-      encoding: "utf8",
-    });
-    const expectedSourceCommit = gitCommitResult.status === 0 ? gitCommitResult.stdout.trim() : null;
-    if (expectedSourceCommit !== null) {
-      assert.match(expectedSourceCommit, /^[0-9a-f]{40}$/u);
-      assert.equal(sourceCommit, expectedSourceCommit);
-      assert.match(String(status.summary), /entry=source commit=[0-9a-f]{40}/u);
-    } else assert.equal(sourceCommit, null, "an isolated source archive has no Git identity to report");
-    assert.deepEqual(status.target, {
-      endpoint: localUserDaemonEndpoint(fixture.userRoot, "default"),
-      daemonId: "default",
-      userRoot: fixture.userRoot,
-      repoId: "autostart",
-      canonicalRoot: realpathSync.native(fixture.root),
-    });
-    for (const value of Object.values(status.target as Record<string, unknown>))
-      assert.match(String(status.summary), new RegExp(escapeRegExp(String(value)), "u"));
-    assert.equal(
-      run(fixture.root, fixture.userRoot, ["task", "create", "--id", "task-autostart", "--admin", "--title", "Auto"])
-        .outcome,
-      "applied",
-    );
-    const previousPid = readDaemonPid(fixture.userRoot, "default");
-    assert.ok(previousPid);
-    // The autostart seam probes first: a live daemon is reused, never respawned.
-    assert.equal(run(fixture.root, fixture.userRoot, ["task", "list"]).outcome, "applied");
-    assert.equal(
-      readDaemonPid(fixture.userRoot, "default"),
-      previousPid,
-      "a reachable daemon must not be replaced by a second spawn",
-    );
-    assert.equal(run(fixture.root, fixture.userRoot, ["daemon", "stop"]).ok, true);
-    assert.equal(readDaemonPid(fixture.userRoot, "default"), null);
-    assert.equal(
-      existsSync(localUserDaemonEndpoint(fixture.userRoot, "default")),
-      false,
-      "stop receipt settles only after pid and socket are gone",
-    );
-    const lifecycle = readDaemonLifecycleRecords(fixture.userRoot, "default");
-    const processStart = lifecycle.find((record) => record.event === "process_start");
-    assert.equal(processStart?.entry, "source");
-    assert.equal(processStart?.commit, expectedSourceCommit);
-    assert.equal(
-      lifecycle.some((record) => record.event === "socket_bound"),
-      true,
-    );
-    assert.equal(
-      lifecycle.some((record) => record.event === "process_exit" && record.outcome === "stop_requested"),
-      true,
-    );
-    const stoppedStatusRun = spawnSync(process.execPath, [cli, "--root", fixture.root, "--json", "daemon", "status"], {
-      encoding: "utf8",
-      env: cliEnv(fixture.root, fixture.userRoot),
-    });
-    // Unavailable answers exit non-zero: the first-run lane polls this exit code to see the daemon gone.
-    assert.notEqual(stoppedStatusRun.status, 0, `${stoppedStatusRun.stderr}\n${stoppedStatusRun.stdout}`);
-    const stoppedStatus = JSON.parse(stoppedStatusRun.stdout) as Record<string, unknown>;
-    assert.match(String(stoppedStatus.summary), /not running \(stopped by operator at \d{4}-\d{2}-\d{2}T/u);
-    const worktree = path.join(fixture.root, ".worktrees", "task-list-feature");
-    git(fixture.root, "worktree", "add", "--quiet", "--detach", worktree);
-    const refused = spawnSync(process.execPath, [cli, "--root", worktree, "--json", "task", "list"], {
-      encoding: "utf8",
-      env: cliEnv(worktree, fixture.userRoot),
-    });
-    assert.notEqual(refused.status, 0, `${refused.stderr}\n${refused.stdout}`);
-    const refusal = JSON.parse(refused.stdout) as { error?: { code?: string } };
-    assert.equal(refusal.error?.code, "daemon_stopped_by_operator");
-    assert.equal(readDaemonPid(fixture.userRoot, "default"), null, "the refused worktree must not claim the daemon");
 
-    const blocked = spawnSync(process.execPath, [cli, "--root", fixture.root, "--json", "task", "list"], {
-      encoding: "utf8",
-      env: cliEnv(fixture.root, fixture.userRoot),
-    });
-    assert.notEqual(blocked.status, 0, `${blocked.stderr}\n${blocked.stdout}`);
-    const blockedReceipt = JSON.parse(blocked.stdout) as {
-      error?: { code?: string };
-      diagnostic?: { expectation?: string };
-    };
-    assert.equal(blockedReceipt.error?.code, "daemon_stopped_by_operator");
-    assert.match(String(blockedReceipt.diagnostic?.expectation), /ha daemon start --service/u);
-    assert.equal(readDaemonPid(fixture.userRoot, "default"), null, "operator stop must suppress autostart");
+  assert.equal(run(fixture.root, fixture.userRoot, ["daemon", "start", "--service"]).ok, true);
+  register(fixture.root, fixture.userRoot, "autostart");
+  const status = run(fixture.root, fixture.userRoot, ["daemon", "status"]);
+  assert.equal(status.entry, "source");
+  const sourceCommit = (status.build as { readonly commit?: unknown }).commit;
+  const gitCommitResult = spawnSync("git", ["rev-parse", "--verify", "HEAD"], {
+    cwd: path.resolve("."),
+    encoding: "utf8",
+  });
+  const expectedSourceCommit = gitCommitResult.status === 0 ? gitCommitResult.stdout.trim() : null;
+  if (expectedSourceCommit !== null) {
+    assert.match(expectedSourceCommit, /^[0-9a-f]{40}$/u);
+    assert.equal(sourceCommit, expectedSourceCommit);
+    assert.match(String(status.summary), /entry=source commit=[0-9a-f]{40}/u);
+  } else assert.equal(sourceCommit, null, "an isolated source archive has no Git identity to report");
+  assert.deepEqual(status.target, {
+    endpoint: localUserDaemonEndpoint(fixture.userRoot, "default"),
+    daemonId: "default",
+    userRoot: fixture.userRoot,
+    repoId: "autostart",
+    canonicalRoot: realpathSync.native(fixture.root),
+  });
+  for (const value of Object.values(status.target as Record<string, unknown>))
+    assert.match(String(status.summary), new RegExp(escapeRegExp(String(value)), "u"));
+  assert.equal(
+    run(fixture.root, fixture.userRoot, ["task", "create", "--id", "task-autostart", "--admin", "--title", "Auto"])
+      .outcome,
+    "applied",
+  );
+  const previousPid = readDaemonPid(fixture.userRoot, "default");
+  assert.ok(previousPid);
+  // The autostart seam probes first: a live daemon is reused, never respawned.
+  assert.equal(run(fixture.root, fixture.userRoot, ["task", "list"]).outcome, "applied");
+  assert.equal(
+    readDaemonPid(fixture.userRoot, "default"),
+    previousPid,
+    "a reachable daemon must not be replaced by a second spawn",
+  );
+  assert.equal(run(fixture.root, fixture.userRoot, ["daemon", "stop"]).ok, true);
+  assert.equal(readDaemonPid(fixture.userRoot, "default"), null);
+  assert.equal(
+    existsSync(localUserDaemonEndpoint(fixture.userRoot, "default")),
+    false,
+    "stop receipt settles only after pid and socket are gone",
+  );
+  const lifecycle = readDaemonLifecycleRecords(fixture.userRoot, "default");
+  const processStart = lifecycle.find((record) => record.event === "process_start");
+  assert.equal(processStart?.entry, "source");
+  assert.equal(processStart?.commit, expectedSourceCommit);
+  assert.equal(
+    lifecycle.some((record) => record.event === "socket_bound"),
+    true,
+  );
+  assert.equal(
+    lifecycle.some((record) => record.event === "process_exit" && record.outcome === "stop_requested"),
+    true,
+  );
+  const stoppedStatusRun = spawnSync(process.execPath, [cli, "--root", fixture.root, "--json", "daemon", "status"], {
+    encoding: "utf8",
+    env: cliEnv(fixture.root, fixture.userRoot),
+  });
+  // Unavailable answers exit non-zero: the first-run lane polls this exit code to see the daemon gone.
+  assert.notEqual(stoppedStatusRun.status, 0, `${stoppedStatusRun.stderr}\n${stoppedStatusRun.stdout}`);
+  const stoppedStatus = JSON.parse(stoppedStatusRun.stdout) as Record<string, unknown>;
+  assert.match(String(stoppedStatus.summary), /not running \(stopped by operator at \d{4}-\d{2}-\d{2}T/u);
+  const worktree = path.join(fixture.root, ".worktrees", "task-list-feature");
+  git(fixture.root, "worktree", "add", "--quiet", "--detach", worktree);
+  const refused = spawnSync(process.execPath, [cli, "--root", worktree, "--json", "task", "list"], {
+    encoding: "utf8",
+    env: cliEnv(worktree, fixture.userRoot),
+  });
+  assert.notEqual(refused.status, 0, `${refused.stderr}\n${refused.stdout}`);
+  const refusal = JSON.parse(refused.stdout) as { error?: { code?: string } };
+  assert.equal(refusal.error?.code, "daemon_stopped_by_operator");
+  assert.equal(readDaemonPid(fixture.userRoot, "default"), null, "the refused worktree must not claim the daemon");
 
-    assert.equal(run(fixture.root, fixture.userRoot, ["daemon", "start", "--service"]).ok, true);
-    const result = spawnSync(process.execPath, [cli, "--root", fixture.root, "--json", "task", "list"], {
-      encoding: "utf8",
-      env: cliEnv(fixture.root, fixture.userRoot),
-    });
-    assert.equal(result.status, 0, `${result.stderr}\n${result.stdout}`);
-    const receipt = JSON.parse(result.stdout) as { ok: boolean; outcome?: string };
-    assert.equal(receipt.ok, true, JSON.stringify(receipt));
-    assert.equal(receipt.outcome, "applied");
-    const restartedPid = readDaemonPid(fixture.userRoot, "default");
-    assert.ok(restartedPid, "explicit start must leave a resident daemon pid file");
-    assert.notEqual(restartedPid, previousPid);
-    const connected = spawnSync(process.execPath, [cli, "--root", worktree, "--json", "task", "list"], {
-      encoding: "utf8",
-      env: cliEnv(worktree, fixture.userRoot),
-    });
-    assert.equal(connected.status, 0, `${connected.stderr}\n${connected.stdout}`);
-    assert.equal(
-      readDaemonPid(fixture.userRoot, "default"),
-      restartedPid,
-      "the worktree must reuse the resident daemon",
+  const blocked = spawnSync(process.execPath, [cli, "--root", fixture.root, "--json", "task", "list"], {
+    encoding: "utf8",
+    env: cliEnv(fixture.root, fixture.userRoot),
+  });
+  assert.notEqual(blocked.status, 0, `${blocked.stderr}\n${blocked.stdout}`);
+  const blockedReceipt = JSON.parse(blocked.stdout) as {
+    error?: { code?: string };
+    diagnostic?: { expectation?: string };
+  };
+  assert.equal(blockedReceipt.error?.code, "daemon_stopped_by_operator");
+  assert.match(String(blockedReceipt.diagnostic?.expectation), /ha daemon start --service/u);
+  assert.equal(readDaemonPid(fixture.userRoot, "default"), null, "operator stop must suppress autostart");
+
+  assert.equal(run(fixture.root, fixture.userRoot, ["daemon", "start", "--service"]).ok, true);
+  const result = spawnSync(process.execPath, [cli, "--root", fixture.root, "--json", "task", "list"], {
+    encoding: "utf8",
+    env: cliEnv(fixture.root, fixture.userRoot),
+  });
+  assert.equal(result.status, 0, `${result.stderr}\n${result.stdout}`);
+  const receipt = JSON.parse(result.stdout) as { ok: boolean; outcome?: string };
+  assert.equal(receipt.ok, true, JSON.stringify(receipt));
+  assert.equal(receipt.outcome, "applied");
+  const restartedPid = readDaemonPid(fixture.userRoot, "default");
+  assert.ok(restartedPid, "explicit start must leave a resident daemon pid file");
+  assert.notEqual(restartedPid, previousPid);
+  const connected = spawnSync(process.execPath, [cli, "--root", worktree, "--json", "task", "list"], {
+    encoding: "utf8",
+    env: cliEnv(worktree, fixture.userRoot),
+  });
+  assert.equal(connected.status, 0, `${connected.stderr}\n${connected.stdout}`);
+  assert.equal(readDaemonPid(fixture.userRoot, "default"), restartedPid, "the worktree must reuse the resident daemon");
+  context.diagnostic(
+    `stop refusal=${blockedReceipt.error?.code}; explicit-start pid=${restartedPid}; worktree existing-daemon task-list=ok`,
+  );
+  const restartedLifecycle = readDaemonLifecycleRecords(fixture.userRoot, "default"),
+    generationStart = restartedLifecycle.findLastIndex((record) => record.event === "process_start"),
+    bound = restartedLifecycle.findIndex((record, index) => index > generationStart && record.event === "socket_bound"),
+    attach = restartedLifecycle.findIndex(
+      (record, index) => index > generationStart && record.event === "repo_attach_started",
     );
-    context.diagnostic(
-      `stop refusal=${blockedReceipt.error?.code}; explicit-start pid=${restartedPid}; worktree existing-daemon task-list=ok`,
-    );
-    const restartedLifecycle = readDaemonLifecycleRecords(fixture.userRoot, "default"),
-      generationStart = restartedLifecycle.findLastIndex((record) => record.event === "process_start"),
-      bound = restartedLifecycle.findIndex(
-        (record, index) => index > generationStart && record.event === "socket_bound",
-      ),
-      attach = restartedLifecycle.findIndex(
-        (record, index) => index > generationStart && record.event === "repo_attach_started",
-      );
-    assert.ok(
-      generationStart >= 0 && bound > generationStart && attach > bound,
-      "the resident socket must bind before the cold registry starts attaching",
-    );
-    process.kill(restartedPid, "SIGKILL");
-    await waitForProcessExit(restartedPid);
-    const recovered = run(fixture.root, fixture.userRoot, ["task", "list"]);
-    assert.equal(recovered.outcome, "applied");
-    const recoveredPid = readDaemonPid(fixture.userRoot, "default");
-    assert.ok(recoveredPid, "process death without daemon stop must remain autostartable");
-    assert.notEqual(recoveredPid, restartedPid);
-    context.diagnostic(`SIGKILL negative control autostart pid=${recoveredPid}`);
-    assert.equal(run(fixture.root, fixture.userRoot, ["daemon", "stop"]).ok, true);
-  } finally {
-    rmSync(fixture.parent, { recursive: true, force: true });
-  }
+  assert.ok(
+    generationStart >= 0 && bound > generationStart && attach > bound,
+    "the resident socket must bind before the cold registry starts attaching",
+  );
+  process.kill(restartedPid, "SIGKILL");
+  await waitForProcessExit(restartedPid);
+  const recovered = run(fixture.root, fixture.userRoot, ["task", "list"]);
+  assert.equal(recovered.outcome, "applied");
+  const recoveredPid = readDaemonPid(fixture.userRoot, "default");
+  assert.ok(recoveredPid, "process death without daemon stop must remain autostartable");
+  assert.notEqual(recoveredPid, restartedPid);
+  context.diagnostic(`SIGKILL negative control autostart pid=${recoveredPid}`);
+  assert.equal(run(fixture.root, fixture.userRoot, ["daemon", "stop"]).ok, true);
 });
 
 test("task-bound runtime identity cannot autostart the shared daemon", (context) => {
@@ -234,45 +222,41 @@ test("task-bound runtime identity cannot autostart the shared daemon", (context)
       HARNESS_DAEMON_REPO_ID: repoId,
       HARNESS_TASK_BOUND: "1",
     };
-  try {
-    seedSettingsEvent({ rootDir: fixture.root, repoId });
-    registerDaemonRepo({
-      canonicalRoot: fixture.root,
-      repoId,
-      userRoot: fixture.userRoot,
-      createConvenienceLinks: false,
-    });
-    const denied = spawnSync(process.execPath, [cli, "--root", fixture.root, "--json", "task", "list"], {
-      encoding: "utf8",
-      env: workerEnv,
-    });
-    assert.notEqual(denied.status, 0, `${denied.stderr}\n${denied.stdout}`);
-    const refusal = JSON.parse(denied.stdout) as { readonly error?: { readonly code?: string } };
-    assert.equal(refusal.error?.code, "daemon_start_runtime_forbidden");
-    assert.equal(readDaemonPid(fixture.userRoot, "default"), null, "a runtime caller must not claim the daemon slot");
 
-    const explicitStart = spawnSync(
-      process.execPath,
-      [cli, "--root", fixture.root, "--json", "daemon", "start", "--service"],
-      { encoding: "utf8", env: workerEnv },
-    );
-    assert.notEqual(explicitStart.status, 0);
-    assert.equal(
-      (JSON.parse(explicitStart.stdout) as { readonly error?: { readonly code?: string } }).error?.code,
-      "daemon_start_runtime_forbidden",
-    );
-    assert.equal(run(fixture.root, fixture.userRoot, ["daemon", "start", "--service"]).ok, true);
-    const available = spawnSync(process.execPath, [cli, "--root", fixture.root, "--json", "task", "list"], {
-      encoding: "utf8",
-      env: workerEnv,
-    });
-    assert.equal(available.status, 0, `${available.stderr}\n${available.stdout}`);
-    assert.equal((JSON.parse(available.stdout) as { readonly outcome?: string }).outcome, "applied");
-    context.diagnostic(`task-bound refusal=${refusal.error?.code}; existing daemon request=applied`);
-  } finally {
-    stop(fixture.root, fixture.userRoot);
-    rmSync(fixture.parent, { recursive: true, force: true });
-  }
+  seedSettingsEvent({ rootDir: fixture.root, repoId });
+  registerDaemonRepo({
+    canonicalRoot: fixture.root,
+    repoId,
+    userRoot: fixture.userRoot,
+    createConvenienceLinks: false,
+  });
+  const denied = spawnSync(process.execPath, [cli, "--root", fixture.root, "--json", "task", "list"], {
+    encoding: "utf8",
+    env: workerEnv,
+  });
+  assert.notEqual(denied.status, 0, `${denied.stderr}\n${denied.stdout}`);
+  const refusal = JSON.parse(denied.stdout) as { readonly error?: { readonly code?: string } };
+  assert.equal(refusal.error?.code, "daemon_start_runtime_forbidden");
+  assert.equal(readDaemonPid(fixture.userRoot, "default"), null, "a runtime caller must not claim the daemon slot");
+
+  const explicitStart = spawnSync(
+    process.execPath,
+    [cli, "--root", fixture.root, "--json", "daemon", "start", "--service"],
+    { encoding: "utf8", env: workerEnv },
+  );
+  assert.notEqual(explicitStart.status, 0);
+  assert.equal(
+    (JSON.parse(explicitStart.stdout) as { readonly error?: { readonly code?: string } }).error?.code,
+    "daemon_start_runtime_forbidden",
+  );
+  assert.equal(run(fixture.root, fixture.userRoot, ["daemon", "start", "--service"]).ok, true);
+  const available = spawnSync(process.execPath, [cli, "--root", fixture.root, "--json", "task", "list"], {
+    encoding: "utf8",
+    env: workerEnv,
+  });
+  assert.equal(available.status, 0, `${available.stderr}\n${available.stdout}`);
+  assert.equal((JSON.parse(available.stdout) as { readonly outcome?: string }).outcome, "applied");
+  context.diagnostic(`task-bound refusal=${refusal.error?.code}; existing daemon request=applied`);
 });
 
 test("repo bootstrap reaches an injected daemon endpoint across an isolated runtime temp directory", () => {
@@ -314,8 +298,6 @@ test("repo bootstrap reaches an injected daemon endpoint across an isolated runt
     assert.equal(receipt.ok, true);
     assert.equal(receipt.repoId, "runtime-bootstrap");
   } finally {
-    stop(fixture.root, fixture.userRoot);
-    rmSync(fixture.parent, { recursive: true, force: true });
     if (previousTemp === undefined) delete process.env.TMPDIR;
     else process.env.TMPDIR = previousTemp;
   }
@@ -449,8 +431,6 @@ test("a blocked vertical script keeps handshakes, snapshots, and same-repo write
     client?.close();
     readClient?.close();
     queuedClient?.close();
-    stop(fixture.root, fixture.userRoot);
-    rmSync(fixture.parent, { recursive: true, force: true });
   }
 });
 
@@ -547,7 +527,5 @@ test("runtime stream attach stays live before, during, and after a blocked verti
     rmSync(blocker, { force: true });
     await scriptRequest?.catch(() => undefined);
     client?.close();
-    stop(fixture.root, fixture.userRoot);
-    rmSync(fixture.parent, { recursive: true, force: true });
   }
 });

--- a/packages/cli/test/daemon-autostart-cli-scenario-2.test.ts
+++ b/packages/cli/test/daemon-autostart-cli-scenario-2.test.ts
@@ -36,7 +36,6 @@ const {
   waitForProcessExit,
   delay,
   processAlive,
-  stop,
   statusOf,
   seedLegacyTask,
   spawnCli,
@@ -137,103 +136,92 @@ test("disconnecting a blocked vertical script client terminates its child after 
     rmSync(blocker, { force: true });
     await queuedWrite?.catch(() => undefined);
     queuedClient?.close();
-    stop(fixture.root, fixture.userRoot);
-    rmSync(fixture.parent, { recursive: true, force: true });
   }
 });
 
 test("receipt show diagnoses a missing daemon without starting one", () => {
   const fixture = setup();
-  try {
-    seedSettingsEvent({ rootDir: fixture.root, repoId: "diagnostic" });
-    registerDaemonRepo({
-      canonicalRoot: fixture.root,
-      repoId: "diagnostic",
-      userRoot: fixture.userRoot,
-      createConvenienceLinks: false,
-    });
-    const result = spawnSync(
-      process.execPath,
-      [cli, "--root", fixture.root, "--json", "receipt", "show", "op-missing"],
-      { encoding: "utf8", env: cliEnv(fixture.root, fixture.userRoot) },
-    );
-    assert.notEqual(result.status, 0);
-    const receipt = JSON.parse(result.stdout) as { error: { code: string } };
-    assert.equal(receipt.error.code, "daemon_unavailable");
-    assert.equal(readDaemonPid(fixture.userRoot, "default"), null, "a diagnostic read must not autostart the daemon");
-  } finally {
-    stop(fixture.root, fixture.userRoot);
-    rmSync(fixture.parent, { recursive: true, force: true });
-  }
+
+  seedSettingsEvent({ rootDir: fixture.root, repoId: "diagnostic" });
+  registerDaemonRepo({
+    canonicalRoot: fixture.root,
+    repoId: "diagnostic",
+    userRoot: fixture.userRoot,
+    createConvenienceLinks: false,
+  });
+  const result = spawnSync(process.execPath, [cli, "--root", fixture.root, "--json", "receipt", "show", "op-missing"], {
+    encoding: "utf8",
+    env: cliEnv(fixture.root, fixture.userRoot),
+  });
+  assert.notEqual(result.status, 0);
+  const receipt = JSON.parse(result.stdout) as { error: { code: string } };
+  assert.equal(receipt.error.code, "daemon_unavailable");
+  assert.equal(readDaemonPid(fixture.userRoot, "default"), null, "a diagnostic read must not autostart the daemon");
 });
 
 test("receipt show waits for independent SQLite, projection, Git, and worktree facets", () => {
   const fixture = setup(),
     repoId = "receipt-wait";
-  try {
-    assert.equal(run(fixture.root, fixture.userRoot, ["daemon", "start", "--service"]).ok, true);
-    assert.equal(
-      run(fixture.root, fixture.userRoot, [
-        "init",
-        "--repo-id",
-        repoId,
-        "--person-id",
-        "owner",
-        "--display-name",
-        "Owner",
-      ]).ok,
-      true,
+
+  assert.equal(run(fixture.root, fixture.userRoot, ["daemon", "start", "--service"]).ok, true);
+  assert.equal(
+    run(fixture.root, fixture.userRoot, [
+      "init",
+      "--repo-id",
+      repoId,
+      "--person-id",
+      "owner",
+      "--display-name",
+      "Owner",
+    ]).ok,
+    true,
+  );
+  const accepted = run(fixture.root, fixture.userRoot, [
+    "task",
+    "create",
+    "--id",
+    "task-receipt-wait",
+    "--admin",
+    "--title",
+    "Receipt wait",
+  ]);
+  assert.equal(accepted.status, "accepted_durable", JSON.stringify(accepted));
+  assertValidWriteReceipt(accepted);
+
+  const settled = run(fixture.root, fixture.userRoot, [
+    "receipt",
+    "show",
+    String(accepted.opId),
+    "--wait",
+    "accepted_durable,projection_visible,git_verified,worktree_visible",
+    "--timeout-ms",
+    "5000",
+  ]);
+  assert.equal(settled.status, "accepted_durable", JSON.stringify(settled));
+  assert.deepEqual(settled.wait, { state: "satisfied", unsatisfied: [] });
+  assert.equal((settled.git as { readonly state?: unknown }).state, "verified");
+  assert.equal((settled.worktree as { readonly state?: unknown }).state, "verified");
+
+  for (const args of [
+    ["receipt", "show", String(accepted.opId), "--wait", "git_visible"],
+    ["receipt", "show", String(accepted.opId), "--timeout-ms", "60001"],
+  ] as const) {
+    const rejected = spawnSync(process.execPath, [cli, "--root", fixture.root, "--json", ...args], {
+      encoding: "utf8",
+      env: cliEnv(fixture.root, fixture.userRoot),
+    });
+    assert.notEqual(rejected.status, 0);
+    const body = JSON.parse(rejected.stdout) as {
+      readonly code?: string;
+      readonly error?: { readonly code?: string };
+    };
+    assert.ok(
+      body.code === "unsupported_wait_condition" ||
+        body.code === "invalid_field" ||
+        body.error?.code === "unsupported_wait_condition" ||
+        body.error?.code === "invalid_field",
+      rejected.stdout,
     );
-    const accepted = run(fixture.root, fixture.userRoot, [
-      "task",
-      "create",
-      "--id",
-      "task-receipt-wait",
-      "--admin",
-      "--title",
-      "Receipt wait",
-    ]);
-    assert.equal(accepted.status, "accepted_durable", JSON.stringify(accepted));
-    assertValidWriteReceipt(accepted);
-
-    const settled = run(fixture.root, fixture.userRoot, [
-      "receipt",
-      "show",
-      String(accepted.opId),
-      "--wait",
-      "accepted_durable,projection_visible,git_verified,worktree_visible",
-      "--timeout-ms",
-      "5000",
-    ]);
-    assert.equal(settled.status, "accepted_durable", JSON.stringify(settled));
-    assert.deepEqual(settled.wait, { state: "satisfied", unsatisfied: [] });
-    assert.equal((settled.git as { readonly state?: unknown }).state, "verified");
-    assert.equal((settled.worktree as { readonly state?: unknown }).state, "verified");
-
-    for (const args of [
-      ["receipt", "show", String(accepted.opId), "--wait", "git_visible"],
-      ["receipt", "show", String(accepted.opId), "--timeout-ms", "60001"],
-    ] as const) {
-      const rejected = spawnSync(process.execPath, [cli, "--root", fixture.root, "--json", ...args], {
-        encoding: "utf8",
-        env: cliEnv(fixture.root, fixture.userRoot),
-      });
-      assert.notEqual(rejected.status, 0);
-      const body = JSON.parse(rejected.stdout) as {
-        readonly code?: string;
-        readonly error?: { readonly code?: string };
-      };
-      assert.ok(
-        body.code === "unsupported_wait_condition" ||
-          body.code === "invalid_field" ||
-          body.error?.code === "unsupported_wait_condition" ||
-          body.error?.code === "invalid_field",
-        rejected.stdout,
-      );
-    }
-  } finally {
-    stop(fixture.root, fixture.userRoot);
-    rmSync(fixture.parent, { recursive: true, force: true });
   }
 });
 
@@ -310,7 +298,6 @@ test("CLI reports lifecycle attach progress and waits through a slow warming rep
     assert.match(result.stderr, /daemon is starting; waited \d+s \(repo 2\/5: slow-warming\)/u);
   } finally {
     await new Promise<void>((resolve) => server.close(() => resolve()));
-    rmSync(fixture.parent, { recursive: true, force: true });
   }
 });
 
@@ -319,248 +306,228 @@ test("semantic sources and agent execution cross the daemon before transport-bou
     taskId = "task-executor-axis",
     executionId = "exec-executor-axis",
     reviewId = "review-executor-axis";
-  try {
-    assert.equal(run(fixture.root, fixture.userRoot, ["daemon", "start", "--service"]).ok, true);
-    register(fixture.root, fixture.userRoot, "executor-axis");
-    const created = run(fixture.root, fixture.userRoot, [
-      "task",
-      "create",
-      "--id",
-      taskId,
-      "--admin",
-      "--title",
-      "Executor Axis",
-      "--preset",
-      "docs-task",
-    ]);
-    assert.equal(created.outcome, "applied", JSON.stringify(created));
-    assert.equal(
-      run(fixture.root, fixture.userRoot, [
-        "fact",
-        "record",
-        "--task",
-        taskId,
-        "--statement",
-        "The executor and review actor axes remain distinct across the daemon.",
-        "--source",
-        "test:executor-axis",
-      ]).outcome,
-      "applied",
-    );
-    const packagePath = String(created.packagePath),
-      closeoutPath = `${packagePath}/closeout.md`;
-    const planPath = `${packagePath}/task_plan.md`;
-    writeFileSync(path.join(fixture.root, "harness", planPath), realizedTaskPlan("Executor Axis"));
-    assert.equal(
-      run(fixture.root, fixture.userRoot, ["doc", "sync", "--submit", "--path", planPath]).outcome,
-      "applied",
-    );
 
-    assert.equal(
-      run(fixture.root, fixture.userRoot, ["task", "start", taskId, "--execution-id", executionId], "agent:claude-code")
-        .outcome,
-      "applied",
-    );
-    writeFileSync(
-      path.join(fixture.root, "harness", closeoutPath),
-      "# Closeout\n\n## Summary\n\nExecutor attribution restored.\n\n## Verification\n\nEnd-to-end daemon flow.\n\n## Residual Risk\n\nNone.\n\n## Same Mechanism Elsewhere\n\nNot applicable to this fixture.\n",
-      "utf8",
-    );
-    writeFileSync(
-      path.join(fixture.root, "harness", packagePath, "artifacts", "executor-axis.txt"),
-      "Executor and review actor axes remain distinct.\n",
-    );
-    const closeoutSync = run(
+  assert.equal(run(fixture.root, fixture.userRoot, ["daemon", "start", "--service"]).ok, true);
+  register(fixture.root, fixture.userRoot, "executor-axis");
+  const created = run(fixture.root, fixture.userRoot, [
+    "task",
+    "create",
+    "--id",
+    taskId,
+    "--admin",
+    "--title",
+    "Executor Axis",
+    "--preset",
+    "docs-task",
+  ]);
+  assert.equal(created.outcome, "applied", JSON.stringify(created));
+  assert.equal(
+    run(fixture.root, fixture.userRoot, [
+      "fact",
+      "record",
+      "--task",
+      taskId,
+      "--statement",
+      "The executor and review actor axes remain distinct across the daemon.",
+      "--source",
+      "test:executor-axis",
+    ]).outcome,
+    "applied",
+  );
+  const packagePath = String(created.packagePath),
+    closeoutPath = `${packagePath}/closeout.md`;
+  const planPath = `${packagePath}/task_plan.md`;
+  writeFileSync(path.join(fixture.root, "harness", planPath), realizedTaskPlan("Executor Axis"));
+  assert.equal(run(fixture.root, fixture.userRoot, ["doc", "sync", "--submit", "--path", planPath]).outcome, "applied");
+
+  assert.equal(
+    run(fixture.root, fixture.userRoot, ["task", "start", taskId, "--execution-id", executionId], "agent:claude-code")
+      .outcome,
+    "applied",
+  );
+  writeFileSync(
+    path.join(fixture.root, "harness", closeoutPath),
+    "# Closeout\n\n## Summary\n\nExecutor attribution restored.\n\n## Verification\n\nEnd-to-end daemon flow.\n\n## Residual Risk\n\nNone.\n\n## Same Mechanism Elsewhere\n\nNot applicable to this fixture.\n",
+    "utf8",
+  );
+  writeFileSync(
+    path.join(fixture.root, "harness", packagePath, "artifacts", "executor-axis.txt"),
+    "Executor and review actor axes remain distinct.\n",
+  );
+  const closeoutSync = run(
+    fixture.root,
+    fixture.userRoot,
+    ["doc", "sync", "--submit", "--task", taskId],
+    "agent:claude-code",
+  );
+  assert.equal(closeoutSync.outcome, "applied");
+  published(fixture.root, fixture.userRoot, closeoutSync);
+  assert.equal(
+    run(fixture.root, fixture.userRoot, ["task", "submit", taskId, "--execution-id", executionId], "agent:claude-code")
+      .outcome,
+    "applied",
+  );
+  assert.equal(
+    run(
       fixture.root,
       fixture.userRoot,
-      ["doc", "sync", "--submit", "--task", taskId],
+      ["task", "code-doc", "reconcile", taskId, "--path", `${packagePath}/artifacts/executor-axis.txt`],
       "agent:claude-code",
-    );
-    assert.equal(closeoutSync.outcome, "applied");
-    published(fixture.root, fixture.userRoot, closeoutSync);
-    assert.equal(
-      run(
-        fixture.root,
-        fixture.userRoot,
-        ["task", "submit", taskId, "--execution-id", executionId],
-        "agent:claude-code",
-      ).outcome,
-      "applied",
-    );
-    assert.equal(
-      run(
-        fixture.root,
-        fixture.userRoot,
-        ["task", "code-doc", "reconcile", taskId, "--path", `${packagePath}/artifacts/executor-axis.txt`],
-        "agent:claude-code",
-      ).outcome,
-      "applied",
-    );
+    ).outcome,
+    "applied",
+  );
 
-    writeFileSync(
-      path.join(fixture.root, "review.json"),
-      JSON.stringify({
-        verdict: "approved",
-        reason: "Human review accepted the agent execution.",
-        evidenceChecked: ["end-to-end daemon flow"],
-      }),
-    );
-    const reviewed = run(fixture.root, fixture.userRoot, [
+  writeFileSync(
+    path.join(fixture.root, "review.json"),
+    JSON.stringify({
+      verdict: "approved",
+      reason: "Human review accepted the agent execution.",
+      evidenceChecked: ["end-to-end daemon flow"],
+    }),
+  );
+  const reviewed = run(fixture.root, fixture.userRoot, [
+    "task",
+    "review-execution",
+    taskId,
+    "--execution-id",
+    executionId,
+    "--review-id",
+    reviewId,
+    "--from-file",
+    "review.json",
+  ]);
+  assert.equal(reviewed.outcome, "applied", JSON.stringify(reviewed));
+  assert.equal(
+    run(fixture.root, fixture.userRoot, [
       "task",
-      "review-execution",
+      "review-consent",
       taskId,
       "--execution-id",
       executionId,
       "--review-id",
       reviewId,
-      "--from-file",
-      "review.json",
-    ]);
-    assert.equal(reviewed.outcome, "applied", JSON.stringify(reviewed));
-    assert.equal(
-      run(fixture.root, fixture.userRoot, [
-        "task",
-        "review-consent",
-        taskId,
-        "--execution-id",
-        executionId,
-        "--review-id",
-        reviewId,
-      ]).outcome,
-      "applied",
-    );
-    assert.equal(run(fixture.root, fixture.userRoot, ["task", "complete", taskId]).outcome, "applied");
+    ]).outcome,
+    "applied",
+  );
+  assert.equal(run(fixture.root, fixture.userRoot, ["task", "complete", taskId]).outcome, "applied");
 
-    const shown = run(fixture.root, fixture.userRoot, ["task", "show", taskId]),
-      snapshot = JSON.parse(String(shown.evidence)) as {
-        task: { status: string; createdBy: unknown };
-        executions: { actor: unknown }[];
-        reviews: { actor: unknown }[];
-      };
-    assert.equal(snapshot.task.status, "done");
-    assert.deepEqual(snapshot.task.createdBy, { principal: { personId: "owner" }, executor: null });
-    assert.deepEqual(snapshot.executions[0]?.actor, {
-      principal: { personId: "owner" },
-      executor: { kind: "agent", id: "claude-code" },
-    });
-    assert.deepEqual(snapshot.reviews[0]?.actor, { principal: { personId: "owner" }, executor: null });
-    assert.equal(
-      run(
-        fixture.root,
-        fixture.userRoot,
-        ["task", "create", "--id", "task-source", "--admin", "--title", "Source"],
-        "agent:codex",
-      ).outcome,
-      "applied",
-    );
-    const sourceTask = JSON.parse(
-      String(run(fixture.root, fixture.userRoot, ["task", "show", "task-source"]).evidence),
-    ) as { task: { createdBy: unknown } };
-    assert.deepEqual(sourceTask.task.createdBy, {
-      principal: { personId: "owner" },
-      executor: { kind: "agent", id: "codex" },
-    });
-    writeFileSync(path.join(fixture.root, "artifact.md"), "# Artifact\n", "utf8");
-    assert.equal(
-      run(fixture.root, fixture.userRoot, [
-        "task",
-        "artifact",
-        "add",
-        "task-source",
-        "--source",
-        "artifact.md",
-        "--destination",
-        "proof.md",
-      ]).outcome,
-      "applied",
-    );
-    assert.equal(
-      run(fixture.root, fixture.userRoot, ["relation", "list", "--source", "task/task-source"]).outcome,
-      "applied",
-    );
-  } finally {
-    stop(fixture.root, fixture.userRoot);
-    rmSync(fixture.parent, { recursive: true, force: true });
-  }
+  const shown = run(fixture.root, fixture.userRoot, ["task", "show", taskId]),
+    snapshot = JSON.parse(String(shown.evidence)) as {
+      task: { status: string; createdBy: unknown };
+      executions: { actor: unknown }[];
+      reviews: { actor: unknown }[];
+    };
+  assert.equal(snapshot.task.status, "done");
+  assert.deepEqual(snapshot.task.createdBy, { principal: { personId: "owner" }, executor: null });
+  assert.deepEqual(snapshot.executions[0]?.actor, {
+    principal: { personId: "owner" },
+    executor: { kind: "agent", id: "claude-code" },
+  });
+  assert.deepEqual(snapshot.reviews[0]?.actor, { principal: { personId: "owner" }, executor: null });
+  assert.equal(
+    run(
+      fixture.root,
+      fixture.userRoot,
+      ["task", "create", "--id", "task-source", "--admin", "--title", "Source"],
+      "agent:codex",
+    ).outcome,
+    "applied",
+  );
+  const sourceTask = JSON.parse(
+    String(run(fixture.root, fixture.userRoot, ["task", "show", "task-source"]).evidence),
+  ) as { task: { createdBy: unknown } };
+  assert.deepEqual(sourceTask.task.createdBy, {
+    principal: { personId: "owner" },
+    executor: { kind: "agent", id: "codex" },
+  });
+  writeFileSync(path.join(fixture.root, "artifact.md"), "# Artifact\n", "utf8");
+  assert.equal(
+    run(fixture.root, fixture.userRoot, [
+      "task",
+      "artifact",
+      "add",
+      "task-source",
+      "--source",
+      "artifact.md",
+      "--destination",
+      "proof.md",
+    ]).outcome,
+    "applied",
+  );
+  assert.equal(
+    run(fixture.root, fixture.userRoot, ["relation", "list", "--source", "task/task-source"]).outcome,
+    "applied",
+  );
 });
 
 test("cancelled task reinstates to planned through the CLI and daemon", () => {
   const fixture = setup(),
     taskId = "task-reinstate";
-  try {
-    assert.equal(run(fixture.root, fixture.userRoot, ["daemon", "start", "--service"]).ok, true);
-    register(fixture.root, fixture.userRoot, "reinstate");
-    assert.equal(
-      run(fixture.root, fixture.userRoot, ["task", "create", "--id", taskId, "--admin", "--title", "Reinstate"])
-        .outcome,
-      "applied",
-    );
-    assert.equal(
-      run(fixture.root, fixture.userRoot, [
-        "task",
-        "transition",
-        taskId,
-        "cancelled",
-        "--force",
-        "--reason",
-        "Erroneous batch cleanup",
-      ]).outcome,
-      "applied",
-    );
-    assert.equal(statusOf(fixture.root, fixture.userRoot, taskId), "cancelled");
 
-    // A reinstate without the auditable reason is refused by the CLI before it can reach the daemon.
-    const bare = spawnSync(
-      process.execPath,
-      [cli, "--root", fixture.root, "--json", "task", "transition", taskId, "planned"],
-      { encoding: "utf8", env: cliEnv(fixture.root, fixture.userRoot) },
-    );
-    assert.equal(bare.status, 2, `${bare.stderr}\n${bare.stdout}`);
-    const bareReceipt = JSON.parse(bare.stdout) as { ok: boolean; error?: { code: string } };
-    assert.equal(bareReceipt.ok, false);
-    assert.equal(bareReceipt.error?.code, "missing_field");
-
-    const reinstated = run(fixture.root, fixture.userRoot, [
+  assert.equal(run(fixture.root, fixture.userRoot, ["daemon", "start", "--service"]).ok, true);
+  register(fixture.root, fixture.userRoot, "reinstate");
+  assert.equal(
+    run(fixture.root, fixture.userRoot, ["task", "create", "--id", taskId, "--admin", "--title", "Reinstate"]).outcome,
+    "applied",
+  );
+  assert.equal(
+    run(fixture.root, fixture.userRoot, [
       "task",
       "transition",
       taskId,
-      "planned",
+      "cancelled",
+      "--force",
       "--reason",
-      "Owner adjudicated rollback of the batch cancellation",
-    ]);
-    assert.equal(reinstated.outcome, "applied", JSON.stringify(reinstated));
-    assert.equal(statusOf(fixture.root, fixture.userRoot, taskId), "planned");
-  } finally {
-    stop(fixture.root, fixture.userRoot);
-    rmSync(fixture.parent, { recursive: true, force: true });
-  }
+      "Erroneous batch cleanup",
+    ]).outcome,
+    "applied",
+  );
+  assert.equal(statusOf(fixture.root, fixture.userRoot, taskId), "cancelled");
+
+  // A reinstate without the auditable reason is refused by the CLI before it can reach the daemon.
+  const bare = spawnSync(
+    process.execPath,
+    [cli, "--root", fixture.root, "--json", "task", "transition", taskId, "planned"],
+    { encoding: "utf8", env: cliEnv(fixture.root, fixture.userRoot) },
+  );
+  assert.equal(bare.status, 2, `${bare.stderr}\n${bare.stdout}`);
+  const bareReceipt = JSON.parse(bare.stdout) as { ok: boolean; error?: { code: string } };
+  assert.equal(bareReceipt.ok, false);
+  assert.equal(bareReceipt.error?.code, "missing_field");
+
+  const reinstated = run(fixture.root, fixture.userRoot, [
+    "task",
+    "transition",
+    taskId,
+    "planned",
+    "--reason",
+    "Owner adjudicated rollback of the batch cancellation",
+  ]);
+  assert.equal(reinstated.outcome, "applied", JSON.stringify(reinstated));
+  assert.equal(statusOf(fixture.root, fixture.userRoot, taskId), "planned");
 });
 
 test("dry-run contract migration prints each manual task once", async () => {
   const fixture = setup(),
     repoId = "contract-receipt",
     taskId = "task_legacy_l1";
-  try {
-    await seedLegacyTask(fixture.root, fixture.userRoot, repoId, taskId);
-    assert.equal(run(fixture.root, fixture.userRoot, ["daemon", "start", "--service"]).ok, true);
-    registerSeeded(fixture.root, fixture.userRoot, repoId);
-    const result = spawnSync(
-      process.execPath,
-      [cli, "--root", fixture.root, "task", "contract", "migrate", "--dry-run", "--task", taskId],
-      { encoding: "utf8", env: cliEnv(fixture.root, fixture.userRoot) },
-    );
-    assert.equal(result.status, 0, `${result.stderr}\n${result.stdout}`);
-    assert.equal((result.stdout.match(new RegExp(taskId, "gu")) ?? []).length, 1, result.stdout);
-    const receipt = run(fixture.root, fixture.userRoot, ["task", "contract", "migrate", "--dry-run", "--task", taskId]);
-    const evidence = JSON.parse(String(receipt.evidence)) as {
-      report: readonly { taskId: string; status: string; reason: string }[];
-      manual: readonly { taskId: string; status: string; reason: string }[];
-    };
-    assert.deepEqual(evidence.manual, [evidence.report[0]], "JSON keeps the manual subset for machine consumers");
-  } finally {
-    stop(fixture.root, fixture.userRoot);
-    rmSync(fixture.parent, { recursive: true, force: true });
-  }
+
+  await seedLegacyTask(fixture.root, fixture.userRoot, repoId, taskId);
+  assert.equal(run(fixture.root, fixture.userRoot, ["daemon", "start", "--service"]).ok, true);
+  registerSeeded(fixture.root, fixture.userRoot, repoId);
+  const result = spawnSync(
+    process.execPath,
+    [cli, "--root", fixture.root, "task", "contract", "migrate", "--dry-run", "--task", taskId],
+    { encoding: "utf8", env: cliEnv(fixture.root, fixture.userRoot) },
+  );
+  assert.equal(result.status, 0, `${result.stderr}\n${result.stdout}`);
+  assert.equal((result.stdout.match(new RegExp(taskId, "gu")) ?? []).length, 1, result.stdout);
+  const receipt = run(fixture.root, fixture.userRoot, ["task", "contract", "migrate", "--dry-run", "--task", taskId]);
+  const evidence = JSON.parse(String(receipt.evidence)) as {
+    report: readonly { taskId: string; status: string; reason: string }[];
+    manual: readonly { taskId: string; status: string; reason: string }[];
+  };
+  assert.deepEqual(evidence.manual, [evidence.report[0]], "JSON keeps the manual subset for machine consumers");
 });
 
 test(
@@ -595,7 +562,6 @@ test(
       );
     } finally {
       chmodSync(fixture.userRoot, 0o755);
-      rmSync(fixture.parent, { recursive: true, force: true });
     }
   },
 );

--- a/packages/cli/test/daemon-autostart-cli.fixture.ts
+++ b/packages/cli/test/daemon-autostart-cli.fixture.ts
@@ -1,5 +1,6 @@
 // harness-test-tier: integration
 import assert from "node:assert/strict";
+import { ownDaemonFixture } from "./daemon-cleanup.fixture.ts";
 
 import { execFileSync, spawn, spawnSync } from "node:child_process";
 
@@ -91,8 +92,10 @@ function cliEnv(root: string, userRoot: string, actor?: string): NodeJS.ProcessE
 
 function setup(): { parent: string; root: string; userRoot: string } {
   const parent = mkdtempSync(path.join(tmpdir(), "ha-autostart-")),
-    root = setupRepository(parent, "repo"),
+    root = path.join(parent, "repo"),
     userRoot = path.join(parent, "user");
+  ownDaemonFixture({ parent, userRoot, daemonId: "default", env: cliEnv(root, userRoot) });
+  setupRepository(parent, "repo");
   return { parent, root, userRoot };
 }
 

--- a/packages/cli/test/daemon-cleanup.fixture.ts
+++ b/packages/cli/test/daemon-cleanup.fixture.ts
@@ -1,0 +1,43 @@
+// harness-test-tier: integration
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { rmSync } from "node:fs";
+import path from "node:path";
+import { after } from "node:test";
+import { daemonProcessAlive, readDaemonPid } from "../../daemon/src/daemon-singleton.ts";
+
+/** Register ownership before launching: test failures must not skip daemon teardown. */
+export function ownDaemonFixture(input: {
+  readonly parent: string;
+  readonly userRoot: string;
+  readonly daemonId: string;
+  readonly env: NodeJS.ProcessEnv;
+}): void {
+  after(async () => {
+    const pid = readDaemonPid(input.userRoot, input.daemonId);
+    if (pid !== null) {
+      const stopped = spawnSync(
+        process.execPath,
+        [
+          path.resolve("packages/cli/src/index.ts"),
+          "daemon",
+          "stop",
+          "--user-root",
+          input.userRoot,
+          "--daemon-id",
+          input.daemonId,
+          "--json",
+        ],
+        { encoding: "utf8", env: input.env, timeout: 10_000 },
+      );
+      assert.equal(stopped.status, 0, `${stopped.stderr}\n${stopped.stdout}`);
+      // A successful stop can still be draining. Keep its files until the process has exited.
+      const deadline = Date.now() + 10_000;
+      while (daemonProcessAlive(pid)) {
+        assert.ok(Date.now() < deadline, `fixture daemon ${pid} did not exit; preserving ${input.parent}`);
+        await new Promise((resolve) => setTimeout(resolve, 10));
+      }
+    }
+    rmSync(input.parent, { recursive: true, force: true });
+  });
+}

--- a/packages/cli/test/squad-resident-leader-scenario-1.integration.test.ts
+++ b/packages/cli/test/squad-resident-leader-scenario-1.integration.test.ts
@@ -1,5 +1,6 @@
 // harness-test-tier: integration
 import test from "node:test";
+import { ownDaemonFixture } from "./daemon-cleanup.fixture.ts";
 import * as shared from "./squad-resident-leader.fixture.ts";
 
 const {
@@ -55,179 +56,176 @@ test("each worker outcome calls back into a new leader turn and a failed worker 
     HARNESS_DAEMON_ID: "squad-resident-test",
     HARNESS_ACTOR: "agent:squad-resident-test",
   });
-  try {
-    run(root, env, ["daemon", "start", "--service"]);
-    run(root, env, ["init", "--repo-id", "squad-resident", "--person-id", "owner", "--display-name", "Owner"]);
-    for (const id of ["fable", "terra", "luna"]) {
-      const source = path.join(parent, id);
-      writeIdentity(source, id, id === "fable" ? "Fable" : id === "terra" ? "Terra" : "Luna");
-      run(root, env, ["agent", "install", "--source", source]);
-    }
-    const squadSource = path.join(parent, "core-squad");
-    mkdirSync(squadSource, { recursive: true });
-    writeFileSync(
-      path.join(squadSource, "squad.json"),
-      JSON.stringify({
-        schema: "squad-declaration/v1",
-        id: "core-squad",
-        name: "Core Squad",
-        leader: "fable",
-        workers: ["terra", "luna"],
-        leaderTurnBudget: 8,
-        roster: "terra -> backend\nluna -> frontend\nsynthesis -> artifacts/reports/{squadRunId}.md",
-      }),
-    );
-    run(root, env, ["squad", "install", "--source", squadSource]);
-    run(root, env, [
-      "runtime",
-      "instance",
+  ownDaemonFixture({ parent, userRoot, daemonId: String(env.HARNESS_DAEMON_ID), env });
+
+  run(root, env, ["daemon", "start", "--service"]);
+  run(root, env, ["init", "--repo-id", "squad-resident", "--person-id", "owner", "--display-name", "Owner"]);
+  for (const id of ["fable", "terra", "luna"]) {
+    const source = path.join(parent, id);
+    writeIdentity(source, id, id === "fable" ? "Fable" : id === "terra" ? "Terra" : "Luna");
+    run(root, env, ["agent", "install", "--source", source]);
+  }
+  const squadSource = path.join(parent, "core-squad");
+  mkdirSync(squadSource, { recursive: true });
+  writeFileSync(
+    path.join(squadSource, "squad.json"),
+    JSON.stringify({
+      schema: "squad-declaration/v1",
+      id: "core-squad",
+      name: "Core Squad",
+      leader: "fable",
+      workers: ["terra", "luna"],
+      leaderTurnBudget: 8,
+      roster: "terra -> backend\nluna -> frontend\nsynthesis -> artifacts/reports/{squadRunId}.md",
+    }),
+  );
+  run(root, env, ["squad", "install", "--source", squadSource]);
+  run(root, env, [
+    "runtime",
+    "instance",
+    "create",
+    "--id",
+    "resident-worker",
+    "--name",
+    "Resident Worker",
+    "--kind",
+    "codex",
+    "--provider",
+    "openai",
+    "--model",
+    "runtime-test-model",
+    "--auth",
+    "subscription",
+  ]);
+  const residentTask = run(root, env, [
+      "task",
       "create",
       "--id",
+      "resident-task",
+      "--admin",
+      "--title",
+      "Resident Squad",
+    ]),
+    residentPackage = String(residentTask.packagePath);
+  published(root, env, residentTask);
+  writeFileSync(path.join(root, "harness", residentPackage, "task_plan.md"), realizedPlan("Resident Squad"));
+  run(root, env, ["doc", "sync", "--submit", "--path", `${residentPackage}/task_plan.md`]);
+  mkdirSync(path.join(root, "squadwork"));
+
+  const runArgs = [
+      "squad",
+      "run",
+      "core-squad",
+      "--detach",
+      "--instance",
       "resident-worker",
-      "--name",
-      "Resident Worker",
-      "--kind",
-      "codex",
-      "--provider",
-      "openai",
-      "--model",
-      "runtime-test-model",
-      "--auth",
-      "subscription",
-    ]);
-    const residentTask = run(root, env, [
-        "task",
-        "create",
-        "--id",
-        "resident-task",
-        "--admin",
-        "--title",
-        "Resident Squad",
-      ]),
-      residentPackage = String(residentTask.packagePath);
-    published(root, env, residentTask);
-    writeFileSync(path.join(root, "harness", residentPackage, "task_plan.md"), realizedPlan("Resident Squad"));
-    run(root, env, ["doc", "sync", "--submit", "--path", `${residentPackage}/task_plan.md`]);
-    mkdirSync(path.join(root, "squadwork"));
+      "--cwd",
+      "squadwork",
+      "--task",
+      "resident-task",
+    ] as const,
+    started = run(root, env, runArgs);
+  assert.equal(started.ok, true, JSON.stringify(started));
+  assert.equal(started.outcome, "completed", JSON.stringify(started));
+  assert.equal(started.schema, "squad-control-result/v1", JSON.stringify(started));
+  assert.equal(started.phase, "leader_running", JSON.stringify(started));
+  for (const field of ["opId", "acceptance", "proof", "status"]) assert.equal(Object.hasOwn(started, field), false);
+  assert.match(String(started.squadRunId), /^squad_[a-f0-9]{24}$/u);
+  const duplicate = runMaybe(root, env, runArgs);
+  assert.equal(duplicate.status, 1, JSON.stringify(duplicate));
+  assert.equal(duplicate.receipt.code, "squad_run_active", JSON.stringify(duplicate));
+  for (const field of ["opId", "acceptance", "proof", "status"])
+    assert.equal(Object.hasOwn(duplicate.receipt, field), false);
+  assert.ok(
+    (duplicate.receipt.nextActions as unknown[]).some((next) => String(next).includes(String(started.squadRunId))),
+    JSON.stringify(duplicate),
+  );
 
-    const runArgs = [
-        "squad",
-        "run",
-        "core-squad",
-        "--detach",
-        "--instance",
-        "resident-worker",
-        "--cwd",
-        "squadwork",
-        "--task",
-        "resident-task",
-      ] as const,
-      started = run(root, env, runArgs);
-    assert.equal(started.ok, true, JSON.stringify(started));
-    assert.equal(started.outcome, "completed", JSON.stringify(started));
-    assert.equal(started.schema, "squad-control-result/v1", JSON.stringify(started));
-    assert.equal(started.phase, "leader_running", JSON.stringify(started));
-    for (const field of ["opId", "acceptance", "proof", "status"]) assert.equal(Object.hasOwn(started, field), false);
-    assert.match(String(started.squadRunId), /^squad_[a-f0-9]{24}$/u);
-    const duplicate = runMaybe(root, env, runArgs);
-    assert.equal(duplicate.status, 1, JSON.stringify(duplicate));
-    assert.equal(duplicate.receipt.code, "squad_run_active", JSON.stringify(duplicate));
-    for (const field of ["opId", "acceptance", "proof", "status"])
-      assert.equal(Object.hasOwn(duplicate.receipt, field), false);
-    assert.ok(
-      (duplicate.receipt.nextActions as unknown[]).some((next) => String(next).includes(String(started.squadRunId))),
-      JSON.stringify(duplicate),
+  const current = pollSquadStatus(root, env, String(started.squadRunId));
+  assert.equal(current.status, "converged", JSON.stringify(current));
+  assert.equal(current.workerCallbackCount, 3, JSON.stringify(current));
+  assert.equal(Array.isArray(current.leaders), true);
+  const leaderRuntimeSessionIds = current.leaderRuntimeSessionIds as string[];
+  assert.equal(leaderRuntimeSessionIds.length, 4, JSON.stringify(current));
+  assert.equal(new Set(leaderRuntimeSessionIds).size, 4);
+
+  const workers = current.workers as Array<Record<string, unknown>>;
+  assert.equal(workers.length, 3, JSON.stringify(current));
+  assert.equal(workers.filter((worker) => worker.agentId === "terra").length, 2, JSON.stringify(current));
+  assert.equal(
+    workers.some((worker) => worker.agentId === "terra" && worker.status === "failed"),
+    true,
+    JSON.stringify(current),
+  );
+  assert.equal(
+    workers.every(
+      (worker) =>
+        typeof worker.reportPath === "string" &&
+        typeof worker.resultRef === "string" &&
+        typeof worker.exitCode === "number",
+    ),
+    true,
+    JSON.stringify(current),
+  );
+
+  const calls = readFileSync(providerLog, "utf8")
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line) as Record<string, unknown>),
+    callbackLeaders = calls.filter(
+      (call) =>
+        call.kind === "leader-callback" && Array.isArray(call.args) && (call.args as unknown[]).includes("resume"),
     );
+  const acceptedAtLaunch = calls.find((call) => call.kind === "leader-initial")?.acceptedAtLaunch as {
+    opId: string;
+    runtimeSessionId: string;
+  };
+  assert.match(acceptedAtLaunch.opId, /^runtime-spawn-/u);
+  assert.equal(acceptedAtLaunch.runtimeSessionId, started.leaderRuntimeSessionId);
+  assert.equal(callbackLeaders.length, 3, JSON.stringify(calls));
+  assert.equal(
+    calls.every((call) => String(call.cwd).endsWith(`${path.sep}squadwork`)),
+    true,
+    JSON.stringify(calls),
+  );
+  assert.match(String(calls.find((call) => call.kind === "leader-initial")?.prompt), /Your task package is/u);
 
-    const current = pollSquadStatus(root, env, String(started.squadRunId));
-    assert.equal(current.status, "converged", JSON.stringify(current));
-    assert.equal(current.workerCallbackCount, 3, JSON.stringify(current));
-    assert.equal(Array.isArray(current.leaders), true);
-    const leaderRuntimeSessionIds = current.leaderRuntimeSessionIds as string[];
-    assert.equal(leaderRuntimeSessionIds.length, 4, JSON.stringify(current));
-    assert.equal(new Set(leaderRuntimeSessionIds).size, 4);
-
-    const workers = current.workers as Array<Record<string, unknown>>;
-    assert.equal(workers.length, 3, JSON.stringify(current));
-    assert.equal(workers.filter((worker) => worker.agentId === "terra").length, 2, JSON.stringify(current));
-    assert.equal(
-      workers.some((worker) => worker.agentId === "terra" && worker.status === "failed"),
-      true,
-      JSON.stringify(current),
-    );
-    assert.equal(
-      workers.every(
-        (worker) =>
-          typeof worker.reportPath === "string" &&
-          typeof worker.resultRef === "string" &&
-          typeof worker.exitCode === "number",
-      ),
-      true,
-      JSON.stringify(current),
-    );
-
-    const calls = readFileSync(providerLog, "utf8")
-        .trim()
-        .split("\n")
-        .map((line) => JSON.parse(line) as Record<string, unknown>),
-      callbackLeaders = calls.filter(
-        (call) =>
-          call.kind === "leader-callback" && Array.isArray(call.args) && (call.args as unknown[]).includes("resume"),
+  run(root, env, ["daemon", "stop"]);
+  const synthesisBody = "# Squad synthesis\n\nWorker receipts verified.\n",
+    synthesisPath = `${residentPackage}/artifacts/reports/${String(started.squadRunId)}.md`,
+    synthesisEvent = makeTaskEventStore({ repoId: "squad-resident", rootDir: root })
+      .read()
+      .events.findLast(
+        (event) =>
+          event.schema === "doc-event/v1" && event.payload.changes.some((change) => change.path === synthesisPath),
       );
-    const acceptedAtLaunch = calls.find((call) => call.kind === "leader-initial")?.acceptedAtLaunch as {
-      opId: string;
-      runtimeSessionId: string;
-    };
-    assert.match(acceptedAtLaunch.opId, /^runtime-spawn-/u);
-    assert.equal(acceptedAtLaunch.runtimeSessionId, started.leaderRuntimeSessionId);
-    assert.equal(callbackLeaders.length, 3, JSON.stringify(calls));
-    assert.equal(
-      calls.every((call) => String(call.cwd).endsWith(`${path.sep}squadwork`)),
-      true,
-      JSON.stringify(calls),
-    );
-    assert.match(String(calls.find((call) => call.kind === "leader-initial")?.prompt), /Your task package is/u);
-
-    run(root, env, ["daemon", "stop"]);
-    const synthesisBody = "# Squad synthesis\n\nWorker receipts verified.\n",
-      synthesisPath = `${residentPackage}/artifacts/reports/${String(started.squadRunId)}.md`,
-      synthesisEvent = makeTaskEventStore({ repoId: "squad-resident", rootDir: root })
-        .read()
-        .events.findLast(
-          (event) =>
-            event.schema === "doc-event/v1" && event.payload.changes.some((change) => change.path === synthesisPath),
-        );
-    assert.equal(readFileSync(path.join(root, "harness", synthesisPath), "utf8"), synthesisBody);
-    assert.equal(synthesisEvent?.schema, "doc-event/v1");
-    assert.equal(synthesisEvent?.actor.executor?.id, `runtime-session:${leaderRuntimeSessionIds.at(-1)}`);
-    rmSync(path.join(root, ".harness", "cache", "task.sqlite"), { force: true });
-    run(root, env, ["daemon", "start", "--service"]);
-    const afterRestart = run(root, env, ["squad", "status", String(started.squadRunId)]);
-    assert.equal(afterRestart.status, "converged", JSON.stringify(afterRestart));
-    assert.equal(afterRestart.workerCallbackCount, 3);
-    process.stdout.write(
-      `squad-event-flow ${JSON.stringify({
-        squadRunId: current.squadRunId,
-        status: current.status,
-        workerCallbackCount: current.workerCallbackCount,
-        leaderRuntimeSessionIds,
-        workers: workers.map((worker) => ({
-          attemptId: worker.attemptId,
-          agentId: worker.agentId,
-          dispatchId: worker.dispatchId,
-          runtimeSessionId: worker.runtimeSessionId,
-          status: worker.status,
-          exitCode: worker.exitCode,
-          resultRef: worker.resultRef,
-          reportPath: worker.reportPath,
-        })),
-        afterRestart: afterRestart.status,
-      })}\n`,
-    );
-  } finally {
-    runMaybe(root, env, ["daemon", "stop"]);
-    rmSync(parent, { recursive: true, force: true });
-  }
+  assert.equal(readFileSync(path.join(root, "harness", synthesisPath), "utf8"), synthesisBody);
+  assert.equal(synthesisEvent?.schema, "doc-event/v1");
+  assert.equal(synthesisEvent?.actor.executor?.id, `runtime-session:${leaderRuntimeSessionIds.at(-1)}`);
+  rmSync(path.join(root, ".harness", "cache", "task.sqlite"), { force: true });
+  run(root, env, ["daemon", "start", "--service"]);
+  const afterRestart = run(root, env, ["squad", "status", String(started.squadRunId)]);
+  assert.equal(afterRestart.status, "converged", JSON.stringify(afterRestart));
+  assert.equal(afterRestart.workerCallbackCount, 3);
+  process.stdout.write(
+    `squad-event-flow ${JSON.stringify({
+      squadRunId: current.squadRunId,
+      status: current.status,
+      workerCallbackCount: current.workerCallbackCount,
+      leaderRuntimeSessionIds,
+      workers: workers.map((worker) => ({
+        attemptId: worker.attemptId,
+        agentId: worker.agentId,
+        dispatchId: worker.dispatchId,
+        runtimeSessionId: worker.runtimeSessionId,
+        status: worker.status,
+        exitCode: worker.exitCode,
+        resultRef: worker.resultRef,
+        reportPath: worker.reportPath,
+      })),
+      afterRestart: afterRestart.status,
+    })}\n`,
+  );
 });
 
 test("a Claude leader dispatches Codex workers by each worker declaration and reports a missing kind", () => {
@@ -261,193 +259,190 @@ test("a Claude leader dispatches Codex workers by each worker declaration and re
     HARNESS_DAEMON_ID: "squad-mixed-runtime-test",
     HARNESS_ACTOR: "agent:squad-mixed-runtime-test",
   });
-  try {
-    run(root, env, ["daemon", "start", "--service"]);
-    run(root, env, ["init", "--repo-id", "squad-mixed-runtime", "--person-id", "owner", "--display-name", "Owner"]);
-    for (const [id, name, runtimeType, model] of [
-      ["mixed-leader", "Mixed Leader", "claude", "fable"],
-      ["mixed-reconcile", "Mixed Reconcile", "codex", "gpt-5.6-terra"],
-      ["mixed-discrimination", "Mixed Discrimination", "codex", "gpt-5.6-sol"],
-      ["mixed-errorexit", "Mixed Error Exit", "codex", "gpt-5.6-terra"],
-      ["mixed-missing", "Mixed Missing", "agy", "agy-model"],
-    ] as const) {
-      const source = path.join(parent, id);
-      writeIdentity(source, id, name, runtimeType, model);
-      run(root, env, ["agent", "install", "--source", source]);
-    }
-    for (const [id, workers] of [
-      ["mixed-positive", ["mixed-reconcile", "mixed-discrimination", "mixed-errorexit"]],
-      ["mixed-negative", ["mixed-missing"]],
-    ] as const) {
-      const source = path.join(parent, id);
-      mkdirSync(source, { recursive: true });
-      writeFileSync(
-        path.join(source, "squad.json"),
-        JSON.stringify({
-          schema: "squad-declaration/v1",
-          id,
-          name: id,
-          leader: "mixed-leader",
-          workers,
-          leaderTurnBudget: 4,
-          roster: `${workers.join(" -> ")}\nsynthesis -> artifacts/reports/{squadRunId}.md`,
-        }),
-      );
-      run(root, env, ["squad", "install", "--source", source]);
-    }
-    run(root, env, [
-      "runtime",
-      "instance",
-      "create",
-      "--id",
-      "claude-lee",
-      "--name",
-      "Claude Leader",
-      "--kind",
-      "claude",
-      "--provider",
-      "anthropic",
-      "--model",
-      "fable",
-      "--auth",
-      "subscription",
-    ]);
-    run(root, env, [
-      "runtime",
-      "instance",
-      "create",
-      "--id",
-      "test-codex-sol",
-      "--name",
-      "Codex Workers",
-      "--kind",
-      "codex",
-      "--provider",
-      "openai",
-      "--model",
-      "gpt-5.6-terra",
-      "--model",
-      "gpt-5.6-sol",
-      "--auth",
-      "subscription",
-    ]);
-    for (const [taskId, title] of [
-      ["mixed-positive-task", "Mixed positive"],
-      ["mixed-negative-task", "Mixed negative"],
-    ] as const) {
-      const created = run(root, env, ["task", "create", "--id", taskId, "--admin", "--title", title]),
-        packagePath = String(created.packagePath);
-      published(root, env, created);
-      writeFileSync(path.join(root, "harness", packagePath, "task_plan.md"), realizedPlan(title));
-      run(root, env, ["doc", "sync", "--submit", "--path", `${packagePath}/task_plan.md`]);
-    }
+  ownDaemonFixture({ parent, userRoot, daemonId: String(env.HARNESS_DAEMON_ID), env });
 
-    const positive = run(root, env, [
-        "squad",
-        "run",
-        "mixed-positive",
-        "--detach",
-        "--instance",
-        "claude-lee",
-        "--model",
-        "fable",
-        "--task",
-        "mixed-positive-task",
-        "--cwd",
-        ".",
-        "--prompt",
-        "positive mixed mission",
-      ]),
-      positiveStatus = pollSquadUntil(
-        root,
-        env,
-        String(positive.squadRunId),
-        (status) => status.status === "workers_running" && (status.workers as unknown[] | undefined)?.length === 3,
-      ),
-      positiveWorkers = positiveStatus.workers as Array<Record<string, unknown>>;
-    assert.deepEqual(
-      positiveWorkers.map(({ workerId, instanceId, provider, rejection }) => ({
-        workerId,
-        instanceId,
-        model: (provider as Record<string, unknown>).model,
-        rejection,
-      })),
-      [
-        { workerId: "mixed-reconcile", instanceId: "test-codex-sol", model: "gpt-5.6-terra", rejection: null },
-        {
-          workerId: "mixed-discrimination",
-          instanceId: "test-codex-sol",
-          model: "gpt-5.6-sol",
-          rejection: null,
-        },
-        { workerId: "mixed-errorexit", instanceId: "test-codex-sol", model: "gpt-5.6-terra", rejection: null },
-      ],
-      JSON.stringify(positiveStatus),
-    );
-    assert.equal((positiveStatus.leaders as Array<Record<string, unknown>>)[0]?.instanceId, "claude-lee");
-    assert.equal(
-      ((positiveStatus.leaders as Array<Record<string, unknown>>)[0]?.provider as Record<string, unknown>).model,
-      "fable",
-    );
-    const positiveCancellation = run(root, env, ["squad", "cancel", String(positive.squadRunId)]);
-    assert.equal(positiveCancellation.outcome, "completed");
-    for (const field of ["opId", "acceptance", "proof", "status"])
-      assert.equal(Object.hasOwn(positiveCancellation, field), false);
-
-    const negative = run(root, env, [
-        "squad",
-        "run",
-        "mixed-negative",
-        "--detach",
-        "--instance",
-        "claude-lee",
-        "--model",
-        "fable",
-        "--task",
-        "mixed-negative-task",
-        "--cwd",
-        ".",
-        "--prompt",
-        "negative mixed mission",
-      ]),
-      negativeStatus = pollSquadUntil(root, env, String(negative.squadRunId), (status) => {
-        const workers = status.workers as Array<Record<string, unknown>> | undefined;
-        return (status.leaders as unknown[] | undefined)?.length === 2 && workers?.[0]?.rejection !== null;
-      }),
-      rejection = String((negativeStatus.workers as Array<Record<string, unknown>>)[0]?.rejection),
-      leaderCalls = readFileSync(leaderLog, "utf8")
-        .trim()
-        .split("\n")
-        .map((line) => JSON.parse(line) as Record<string, unknown>),
-      callback = leaderCalls.find(
-        (call) => call.kind === "callback" && String(call.prompt).includes(String(negative.squadRunId)),
-      );
-    assert.equal(rejection, "Agent mixed-missing requires agy, but no enabled agy instance is available on this node.");
-    assert.deepEqual((negativeStatus.leaders as Array<Record<string, unknown>>)[1]?.trigger, {
-      kind: "worker_rejected",
-      attemptId: "worker-1",
-    });
-    assert.match(String(callback?.prompt), /worker_rejected/u);
-    assert.match(String(callback?.prompt), /no enabled agy instance is available on this node/u);
-    const negativeCancellation = run(root, env, ["squad", "cancel", String(negative.squadRunId)]);
-    assert.equal(negativeCancellation.outcome, "completed");
-    for (const field of ["opId", "acceptance", "proof", "status"])
-      assert.equal(Object.hasOwn(negativeCancellation, field), false);
-    process.stdout.write(
-      `squad-mixed-runtime-flow ${JSON.stringify({
-        positive: { squadRunId: positive.squadRunId, status: positiveStatus.status, workers: positiveWorkers },
-        negative: {
-          squadRunId: negative.squadRunId,
-          status: negativeStatus.status,
-          rejection,
-          trigger: (negativeStatus.leaders as Array<Record<string, unknown>>)[1]?.trigger,
-        },
-      })}\n`,
-    );
-  } finally {
-    runMaybe(root, env, ["daemon", "stop"]);
-    rmSync(parent, { recursive: true, force: true });
+  run(root, env, ["daemon", "start", "--service"]);
+  run(root, env, ["init", "--repo-id", "squad-mixed-runtime", "--person-id", "owner", "--display-name", "Owner"]);
+  for (const [id, name, runtimeType, model] of [
+    ["mixed-leader", "Mixed Leader", "claude", "fable"],
+    ["mixed-reconcile", "Mixed Reconcile", "codex", "gpt-5.6-terra"],
+    ["mixed-discrimination", "Mixed Discrimination", "codex", "gpt-5.6-sol"],
+    ["mixed-errorexit", "Mixed Error Exit", "codex", "gpt-5.6-terra"],
+    ["mixed-missing", "Mixed Missing", "agy", "agy-model"],
+  ] as const) {
+    const source = path.join(parent, id);
+    writeIdentity(source, id, name, runtimeType, model);
+    run(root, env, ["agent", "install", "--source", source]);
   }
+  for (const [id, workers] of [
+    ["mixed-positive", ["mixed-reconcile", "mixed-discrimination", "mixed-errorexit"]],
+    ["mixed-negative", ["mixed-missing"]],
+  ] as const) {
+    const source = path.join(parent, id);
+    mkdirSync(source, { recursive: true });
+    writeFileSync(
+      path.join(source, "squad.json"),
+      JSON.stringify({
+        schema: "squad-declaration/v1",
+        id,
+        name: id,
+        leader: "mixed-leader",
+        workers,
+        leaderTurnBudget: 4,
+        roster: `${workers.join(" -> ")}\nsynthesis -> artifacts/reports/{squadRunId}.md`,
+      }),
+    );
+    run(root, env, ["squad", "install", "--source", source]);
+  }
+  run(root, env, [
+    "runtime",
+    "instance",
+    "create",
+    "--id",
+    "claude-lee",
+    "--name",
+    "Claude Leader",
+    "--kind",
+    "claude",
+    "--provider",
+    "anthropic",
+    "--model",
+    "fable",
+    "--auth",
+    "subscription",
+  ]);
+  run(root, env, [
+    "runtime",
+    "instance",
+    "create",
+    "--id",
+    "test-codex-sol",
+    "--name",
+    "Codex Workers",
+    "--kind",
+    "codex",
+    "--provider",
+    "openai",
+    "--model",
+    "gpt-5.6-terra",
+    "--model",
+    "gpt-5.6-sol",
+    "--auth",
+    "subscription",
+  ]);
+  for (const [taskId, title] of [
+    ["mixed-positive-task", "Mixed positive"],
+    ["mixed-negative-task", "Mixed negative"],
+  ] as const) {
+    const created = run(root, env, ["task", "create", "--id", taskId, "--admin", "--title", title]),
+      packagePath = String(created.packagePath);
+    published(root, env, created);
+    writeFileSync(path.join(root, "harness", packagePath, "task_plan.md"), realizedPlan(title));
+    run(root, env, ["doc", "sync", "--submit", "--path", `${packagePath}/task_plan.md`]);
+  }
+
+  const positive = run(root, env, [
+      "squad",
+      "run",
+      "mixed-positive",
+      "--detach",
+      "--instance",
+      "claude-lee",
+      "--model",
+      "fable",
+      "--task",
+      "mixed-positive-task",
+      "--cwd",
+      ".",
+      "--prompt",
+      "positive mixed mission",
+    ]),
+    positiveStatus = pollSquadUntil(
+      root,
+      env,
+      String(positive.squadRunId),
+      (status) => status.status === "workers_running" && (status.workers as unknown[] | undefined)?.length === 3,
+    ),
+    positiveWorkers = positiveStatus.workers as Array<Record<string, unknown>>;
+  assert.deepEqual(
+    positiveWorkers.map(({ workerId, instanceId, provider, rejection }) => ({
+      workerId,
+      instanceId,
+      model: (provider as Record<string, unknown>).model,
+      rejection,
+    })),
+    [
+      { workerId: "mixed-reconcile", instanceId: "test-codex-sol", model: "gpt-5.6-terra", rejection: null },
+      {
+        workerId: "mixed-discrimination",
+        instanceId: "test-codex-sol",
+        model: "gpt-5.6-sol",
+        rejection: null,
+      },
+      { workerId: "mixed-errorexit", instanceId: "test-codex-sol", model: "gpt-5.6-terra", rejection: null },
+    ],
+    JSON.stringify(positiveStatus),
+  );
+  assert.equal((positiveStatus.leaders as Array<Record<string, unknown>>)[0]?.instanceId, "claude-lee");
+  assert.equal(
+    ((positiveStatus.leaders as Array<Record<string, unknown>>)[0]?.provider as Record<string, unknown>).model,
+    "fable",
+  );
+  const positiveCancellation = run(root, env, ["squad", "cancel", String(positive.squadRunId)]);
+  assert.equal(positiveCancellation.outcome, "completed");
+  for (const field of ["opId", "acceptance", "proof", "status"])
+    assert.equal(Object.hasOwn(positiveCancellation, field), false);
+
+  const negative = run(root, env, [
+      "squad",
+      "run",
+      "mixed-negative",
+      "--detach",
+      "--instance",
+      "claude-lee",
+      "--model",
+      "fable",
+      "--task",
+      "mixed-negative-task",
+      "--cwd",
+      ".",
+      "--prompt",
+      "negative mixed mission",
+    ]),
+    negativeStatus = pollSquadUntil(root, env, String(negative.squadRunId), (status) => {
+      const workers = status.workers as Array<Record<string, unknown>> | undefined;
+      return (status.leaders as unknown[] | undefined)?.length === 2 && workers?.[0]?.rejection !== null;
+    }),
+    rejection = String((negativeStatus.workers as Array<Record<string, unknown>>)[0]?.rejection),
+    leaderCalls = readFileSync(leaderLog, "utf8")
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line) as Record<string, unknown>),
+    callback = leaderCalls.find(
+      (call) => call.kind === "callback" && String(call.prompt).includes(String(negative.squadRunId)),
+    );
+  assert.equal(rejection, "Agent mixed-missing requires agy, but no enabled agy instance is available on this node.");
+  assert.deepEqual((negativeStatus.leaders as Array<Record<string, unknown>>)[1]?.trigger, {
+    kind: "worker_rejected",
+    attemptId: "worker-1",
+  });
+  assert.match(String(callback?.prompt), /worker_rejected/u);
+  assert.match(String(callback?.prompt), /no enabled agy instance is available on this node/u);
+  const negativeCancellation = run(root, env, ["squad", "cancel", String(negative.squadRunId)]);
+  assert.equal(negativeCancellation.outcome, "completed");
+  for (const field of ["opId", "acceptance", "proof", "status"])
+    assert.equal(Object.hasOwn(negativeCancellation, field), false);
+  process.stdout.write(
+    `squad-mixed-runtime-flow ${JSON.stringify({
+      positive: { squadRunId: positive.squadRunId, status: positiveStatus.status, workers: positiveWorkers },
+      negative: {
+        squadRunId: negative.squadRunId,
+        status: negativeStatus.status,
+        rejection,
+        trigger: (negativeStatus.leaders as Array<Record<string, unknown>>)[1]?.trigger,
+      },
+    })}\n`,
+  );
 });
 
 test(
@@ -480,121 +475,110 @@ test(
       HARNESS_DAEMON_ID: "squad-api-key-test",
       HARNESS_ACTOR: "agent:squad-api-key-test",
     });
-    try {
-      const stored = spawnSync(credentialTool, ["store", "squad-key"], {
-        encoding: "utf8",
-        env,
-        input: "squad-secret",
-      });
-      assert.equal(stored.status, 0, stored.stderr);
-      run(root, env, ["daemon", "start", "--service"]);
-      run(root, env, ["init", "--repo-id", "squad-api-key", "--person-id", "owner", "--display-name", "Owner"]);
-      for (const id of ["fable", "terra", "luna"]) {
-        const source = path.join(parent, id);
-        writeIdentity(source, id, id === "fable" ? "Fable" : id === "terra" ? "Terra" : "Luna");
-        run(root, env, ["agent", "install", "--source", source]);
-      }
-      const squadSource = path.join(parent, "core-squad");
-      mkdirSync(squadSource, { recursive: true });
-      writeFileSync(
-        path.join(squadSource, "squad.json"),
-        JSON.stringify({
-          schema: "squad-declaration/v1",
-          id: "core-squad",
-          name: "Core Squad",
-          leader: "fable",
-          workers: ["terra", "luna"],
-          leaderTurnBudget: 8,
-          roster: "terra -> backend\nluna -> frontend\nsynthesis -> artifacts/reports/{squadRunId}.md",
-        }),
-      );
-      run(root, env, ["squad", "install", "--source", squadSource]);
-      run(root, env, [
-        "runtime",
-        "instance",
-        "create",
-        "--id",
-        "squad-api",
-        "--name",
-        "Squad API",
-        "--kind",
-        "codex",
-        "--provider",
-        "codex_local_access",
-        "--model",
-        "runtime-test-model",
-        "--base-url",
-        "http://127.0.0.1:1/v1",
-        "--wire-api",
-        "responses",
-        "--requires-openai-auth",
-        "--auth",
-        "api-key",
-        "--credential-ref",
-        "credential:v1:squad-key",
-      ]);
-      const apiTask = run(root, env, [
-        "task",
-        "create",
-        "--id",
-        "squad-api-task",
-        "--admin",
-        "--title",
-        "Squad API run",
-      ]);
-      const placeholderPlan = runMaybe(root, env, [
-        "squad",
-        "run",
-        "core-squad",
-        "--detach",
-        "--instance",
-        "squad-api",
-        "--cwd",
-        ".",
-        "--task",
-        "squad-api-task",
-        "--prompt",
-        "ship without lease",
-      ]);
-      assert.equal(placeholderPlan.status, 1, JSON.stringify(placeholderPlan));
-      assert.equal(placeholderPlan.receipt.code, "plan_placeholder");
-      const apiPackage = String(apiTask.packagePath);
-      writeFileSync(path.join(root, "harness", apiPackage, "task_plan.md"), realizedPlan("Squad API run"));
-      run(root, env, ["doc", "sync", "--submit", "--path", `${apiPackage}/task_plan.md`]);
-      const started = run(root, env, [
-        "squad",
-        "run",
-        "core-squad",
-        "--detach",
-        "--instance",
-        "squad-api",
-        "--cwd",
-        ".",
-        "--task",
-        "squad-api-task",
-      ]);
-      assert.equal(started.ok, true, JSON.stringify(started));
-      assert.equal(started.outcome, "completed", JSON.stringify(started));
-      assert.equal(started.schema, "squad-control-result/v1", JSON.stringify(started));
-      assert.equal(started.phase, "leader_running", JSON.stringify(started));
-      for (const field of ["opId", "acceptance", "proof", "status"]) assert.equal(Object.hasOwn(started, field), false);
-      const current = pollSquadStatus(root, env, String(started.squadRunId));
-      assert.equal(current.status, "converged", JSON.stringify(current));
-      const workers = current.workers as Array<Record<string, unknown>>;
-      assert.deepEqual(
-        workers.map((worker) => worker.workerId),
-        ["terra", "luna"],
-      );
-      assert.equal(
-        workers.every((worker) => worker.status === "succeeded" && worker.exitCode === 0),
-        true,
-      );
-      const configPath = path.join(userRoot, "runtime-instances", "squad-api", "home", ".codex", "config.toml");
-      assert.match(readFileSync(configPath, "utf8"), /experimental_bearer_token = "squad-secret"/u);
-      process.stdout.write(`squad-api-key-flow ${JSON.stringify({ squadRunId: current.squadRunId, workers })}\n`);
-    } finally {
-      runMaybe(root, env, ["daemon", "stop"]);
-      rmSync(parent, { recursive: true, force: true });
+    ownDaemonFixture({ parent, userRoot, daemonId: String(env.HARNESS_DAEMON_ID), env });
+
+    const stored = spawnSync(credentialTool, ["store", "squad-key"], {
+      encoding: "utf8",
+      env,
+      input: "squad-secret",
+    });
+    assert.equal(stored.status, 0, stored.stderr);
+    run(root, env, ["daemon", "start", "--service"]);
+    run(root, env, ["init", "--repo-id", "squad-api-key", "--person-id", "owner", "--display-name", "Owner"]);
+    for (const id of ["fable", "terra", "luna"]) {
+      const source = path.join(parent, id);
+      writeIdentity(source, id, id === "fable" ? "Fable" : id === "terra" ? "Terra" : "Luna");
+      run(root, env, ["agent", "install", "--source", source]);
     }
+    const squadSource = path.join(parent, "core-squad");
+    mkdirSync(squadSource, { recursive: true });
+    writeFileSync(
+      path.join(squadSource, "squad.json"),
+      JSON.stringify({
+        schema: "squad-declaration/v1",
+        id: "core-squad",
+        name: "Core Squad",
+        leader: "fable",
+        workers: ["terra", "luna"],
+        leaderTurnBudget: 8,
+        roster: "terra -> backend\nluna -> frontend\nsynthesis -> artifacts/reports/{squadRunId}.md",
+      }),
+    );
+    run(root, env, ["squad", "install", "--source", squadSource]);
+    run(root, env, [
+      "runtime",
+      "instance",
+      "create",
+      "--id",
+      "squad-api",
+      "--name",
+      "Squad API",
+      "--kind",
+      "codex",
+      "--provider",
+      "codex_local_access",
+      "--model",
+      "runtime-test-model",
+      "--base-url",
+      "http://127.0.0.1:1/v1",
+      "--wire-api",
+      "responses",
+      "--requires-openai-auth",
+      "--auth",
+      "api-key",
+      "--credential-ref",
+      "credential:v1:squad-key",
+    ]);
+    const apiTask = run(root, env, ["task", "create", "--id", "squad-api-task", "--admin", "--title", "Squad API run"]);
+    const placeholderPlan = runMaybe(root, env, [
+      "squad",
+      "run",
+      "core-squad",
+      "--detach",
+      "--instance",
+      "squad-api",
+      "--cwd",
+      ".",
+      "--task",
+      "squad-api-task",
+      "--prompt",
+      "ship without lease",
+    ]);
+    assert.equal(placeholderPlan.status, 1, JSON.stringify(placeholderPlan));
+    assert.equal(placeholderPlan.receipt.code, "plan_placeholder");
+    const apiPackage = String(apiTask.packagePath);
+    writeFileSync(path.join(root, "harness", apiPackage, "task_plan.md"), realizedPlan("Squad API run"));
+    run(root, env, ["doc", "sync", "--submit", "--path", `${apiPackage}/task_plan.md`]);
+    const started = run(root, env, [
+      "squad",
+      "run",
+      "core-squad",
+      "--detach",
+      "--instance",
+      "squad-api",
+      "--cwd",
+      ".",
+      "--task",
+      "squad-api-task",
+    ]);
+    assert.equal(started.ok, true, JSON.stringify(started));
+    assert.equal(started.outcome, "completed", JSON.stringify(started));
+    assert.equal(started.schema, "squad-control-result/v1", JSON.stringify(started));
+    assert.equal(started.phase, "leader_running", JSON.stringify(started));
+    for (const field of ["opId", "acceptance", "proof", "status"]) assert.equal(Object.hasOwn(started, field), false);
+    const current = pollSquadStatus(root, env, String(started.squadRunId));
+    assert.equal(current.status, "converged", JSON.stringify(current));
+    const workers = current.workers as Array<Record<string, unknown>>;
+    assert.deepEqual(
+      workers.map((worker) => worker.workerId),
+      ["terra", "luna"],
+    );
+    assert.equal(
+      workers.every((worker) => worker.status === "succeeded" && worker.exitCode === 0),
+      true,
+    );
+    const configPath = path.join(userRoot, "runtime-instances", "squad-api", "home", ".codex", "config.toml");
+    assert.match(readFileSync(configPath, "utf8"), /experimental_bearer_token = "squad-secret"/u);
+    process.stdout.write(`squad-api-key-flow ${JSON.stringify({ squadRunId: current.squadRunId, workers })}\n`);
   },
 );

--- a/packages/daemon/test/registry-wal-restart.repro.mjs
+++ b/packages/daemon/test/registry-wal-restart.repro.mjs
@@ -30,38 +30,43 @@ export async function reproduceRegistrySqliteRestart(arm, options = {}) {
     createConvenienceLinks: false,
   });
   downgradeRegistryToV1(userRoot);
-  startDaemon(fixture);
-  await waitForAttached(fixture);
-  const taskReceipt = runCli(fixture, ["task", "create", "--title", `Daemon SQLite ${arm}`]),
-    taskId = String(taskReceipt.taskId),
-    factReceipt = runCli(fixture, [
-      "fact",
-      "record",
-      taskId,
-      "--statement",
-      `Daemon WAL ${arm} fact`,
-      "--source",
-      `test:registry-wal-${arm}`,
-      "--confidence",
-      "high",
-    ]),
-    before = observeBefore(fixture, taskReceipt, factReceipt);
-  assert.equal(taskReceipt.status, "accepted_durable", JSON.stringify(taskReceipt));
-  assert.equal(factReceipt.status, "accepted_durable", JSON.stringify(factReceipt));
-  assert.ok(before.canonicalEventHead >= 2, JSON.stringify(before));
-  if (arm === "graceful-stop") runCli(fixture, ["daemon", "stop"]);
-  else killDaemon(fixture);
-  await waitForStopped(fixture);
-  startDaemon(fixture);
-  await waitForAttached(fixture);
-  const task = runCli(fixture, ["task", "show", taskId]),
-    fact = runCli(fixture, ["fact", "show", "--id", String(factReceipt.factId)]),
-    after = observeAfter(fixture, taskId, String(factReceipt.factId), String(taskReceipt.packagePath), task, fact);
-  await waitForPublication(fixture, factReceipt.opId);
-  after.taskPackageExists = packageExists(fixture.rootDir, String(taskReceipt.packagePath));
-  runCli(fixture, ["daemon", "stop"]);
-  await waitForStopped(fixture);
-  return { arm, fixtureRoot, before, after };
+  try {
+    startDaemon(fixture);
+    await waitForAttached(fixture);
+    const taskReceipt = runCli(fixture, ["task", "create", "--title", `Daemon SQLite ${arm}`]),
+      taskId = String(taskReceipt.taskId),
+      factReceipt = runCli(fixture, [
+        "fact",
+        "record",
+        taskId,
+        "--statement",
+        `Daemon WAL ${arm} fact`,
+        "--source",
+        `test:registry-wal-${arm}`,
+        "--confidence",
+        "high",
+      ]),
+      before = observeBefore(fixture, taskReceipt, factReceipt);
+    assert.equal(taskReceipt.status, "accepted_durable", JSON.stringify(taskReceipt));
+    assert.equal(factReceipt.status, "accepted_durable", JSON.stringify(factReceipt));
+    assert.ok(before.canonicalEventHead >= 2, JSON.stringify(before));
+    if (arm === "graceful-stop") runCli(fixture, ["daemon", "stop"]);
+    else killDaemon(fixture);
+    await waitForStopped(fixture);
+    startDaemon(fixture);
+    await waitForAttached(fixture);
+    const task = runCli(fixture, ["task", "show", taskId]),
+      fact = runCli(fixture, ["fact", "show", "--id", String(factReceipt.factId)]),
+      after = observeAfter(fixture, taskId, String(factReceipt.factId), String(taskReceipt.packagePath), task, fact);
+    await waitForPublication(fixture, factReceipt.opId);
+    after.taskPackageExists = packageExists(fixture.rootDir, String(taskReceipt.packagePath));
+    return { arm, fixtureRoot, before, after };
+  } finally {
+    if (readDaemonPid(userRoot, daemonId) !== null) {
+      runCli(fixture, ["daemon", "stop"]);
+      await waitForStopped(fixture);
+    }
+  }
 }
 
 function observeBefore(fixture, taskReceipt, factReceipt) {


### PR DESCRIPTION
# English

## Summary

Test daemons no longer outlive their fixtures: teardown on the failure path waits for the daemon to actually exit before deleting the fixture root, binding cleanup to fixture lifetime. Parent-death self-exit was rejected because resident daemons must survive their launcher by design. Zero residual daemons after the touched suites.

## Architectural Justification

-

## What Changed

- test fixtures/helpers that start daemons: teardown waits for exit on the failure path.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: +0/-0 production; tests only.

## Machine-Readable Declarations

- None.

## Task And Scope

- Harness task: task_0ab80cfb17c9fbae5321fd1136 (parent task_4f7965fc895253bf70a4020f42)
- Branch: `codex/orphan-daemons`
- Public scope: test fixture teardown
- Private planning/evidence updated: yes (`artifacts/report.md`)
- Out of scope: killing the historical orphan processes on the developer machine (CEO decides)

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: not applicable
- Machine-check boundary: not applicable
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `466caf36a`
- Branch merge-base with `origin/main`: `466caf36a`
- Last `git fetch origin` time: 2026-09-12 UTC
- Sync method: branched from origin/main
- Public diff command: `git diff origin/main...codex/orphan-daemons`
- Private evidence commit/path: task_0ab80cfb17c9fbae5321fd1136 `artifacts/report.md`
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [x] `npm run typecheck` (worker, `tsc -b`)
- [ ] `npm run check`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts` (via `run-manifest-gates --changed origin/main`)
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Ubuntu 18 files and Docker squad 3 pass; residual `daemon serve` processes after the run: 0. Two Ubuntu squad convergence failures per round remain unexplained (reported).

## Review Evidence

- CEO ground-truth: read the worker report and the diff stat; commit authorship and scope checked.
- Reviewer subagent: closeout review after merge (one-path closeout)
- Human review: pending
- Blocking findings: none open

## Residual Risk

- Two Ubuntu squad convergence failures are not understood yet; they predate this change.

## References

- Task: task_0ab80cfb17c9fbae5321fd1136

---

# 中文

## 概要

测试起的 daemon 不再活过 fixture：失败路径的 teardown 等 daemon 真正退出后再删 fixture 根目录，把清理绑定到 fixture 生命周期。否掉了父进程死亡自退——常驻 daemon 按设计要活过启动器。触碰的套件跑完残留 daemon 为 0。

## 架构辩护

-

## 改动内容

- 起 daemon 的测试 fixture/helper：失败路径 teardown 等退出。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 删除的门或 fixture：none
- 生产净行数：+0/-0 production; tests only。

## 机器可读声明

- 无。

## 任务与范围

- Harness 任务：task_0ab80cfb17c9fbae5321fd1136（父 task_4f7965fc895253bf70a4020f42）
- 分支：`codex/orphan-daemons`
- 公开范围：测试 fixture teardown
- 私有计划/证据已更新：是（`artifacts/report.md`）
- 范围外：本机历史孤儿进程的清理（CEO 定）

## 版本影响

- 版本：不变
- 发布影响：不发布

## 治理声明

- 触碰受保护面：否
- 受保护面范围：不适用
- 授权：不适用
- 机器检查边界：不适用
- Break-glass：否
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- 基线 `origin/main` SHA：`466caf36a`
- 分支与 `origin/main` 的 merge-base：`466caf36a`
- 最近一次 `git fetch origin`：2026-09-12 UTC
- 同步方式：从 origin/main 开分支
- 公开 diff 命令：`git diff origin/main...codex/orphan-daemons`
- 私有证据路径：task_0ab80cfb17c9fbae5321fd1136 的 `artifacts/report.md`
- 评审证据路径：本 PR 的评审证据节
- GitHub Actions `rewrite-ci` run URL：本 PR 待跑
- Ubuntu 18 个文件与 Docker squad 3 项通过；跑后残留 `daemon serve` 进程 0。Ubuntu squad 每轮 2 项收敛失败原因未明（已报告）。

## 评审证据

- CEO 事实核对：读过 worker 报告与 diff 统计；核过提交人与范围。
- 评审子代理：合入后走一条路收口评审
- 人工评审：待定
- 阻塞发现：无

## 残余风险

- Ubuntu squad 的两项收敛失败尚未理解；早于本改动。

## 参考

- 任务：task_0ab80cfb17c9fbae5321fd1136

