### PR TITLE
fix: ignore cancelled and skipped CI evidence

### DIFF
--- a/packages/daemon/src/repo-cell-task-progress.ts
+++ b/packages/daemon/src/repo-cell-task-progress.ts
@@ -60,46 +60,52 @@ export function readLatestCiEvidence(
   if (!cell.projectionReady(observations))
     throw cell.cellCodedError("content_not_ready", "CI observation projection is not ready.");
   // Projection order is newest canonical observation first. Never skip a related red or
-  // unverified observation to find an older green observation.
+  // unverified observation to find an older green observation; verified cancelled/skipped runs give no verdict.
   const submitted = execution.submission.commitSha,
     publicCut = localGitObjectRefStore.hasCommit(cell.rootDir, submitted),
-    root = publicCut ? cell.rootDir : resolveHarnessLayout(cell.rootDir).authoredRoot,
-    event = observations.events.find((candidate) => relatedCiObservation(root, candidate, submitted));
-  if (!event) return null;
-  const verification = event.payload.verification;
-  if (
-    !localGitObjectRefStore.hasCommit(root, submitted) ||
-    !verification ||
-    (publicCut
-      ? verification.source !== "github-actions" ||
-        verification.workflow !== "rewrite-ci" ||
-        event.payload.run.branch !== "main"
-      : verification.source !== "write-coordinator" || verification.workflow !== "ledger-publication")
-  )
-    throw cell.cellCodedError(
-      "invalid_proof",
-      publicCut
-        ? "Public delivery requires a verified rewrite-ci GitHub main run."
-        : "Private delivery requires a verified ledger-publication observation for its authored cut.",
-    );
-  const result: CompletionEvidenceResult = verification.conclusion === "success" ? "pass" : "fail";
-  if (!completionEvidenceResults.includes(result)) return null;
-  const basis: CompletionEvidenceBasis = { ...completionEvidenceBasis(execution), ledgerCut: event.workspaceRevision },
-    provenance: CompletionEvidenceProvenance = {
-      source: "runner",
-      runId: event.payload.run.runId,
-      rawResult: `event:${event.opId}`,
+    root = publicCut ? cell.rootDir : resolveHarnessLayout(cell.rootDir).authoredRoot;
+  for (const event of observations.events) {
+    if (!relatedCiObservation(root, event, submitted)) continue;
+    const verification = event.payload.verification;
+    if (
+      !localGitObjectRefStore.hasCommit(root, submitted) ||
+      !verification ||
+      (publicCut
+        ? verification.source !== "github-actions" ||
+          verification.workflow !== "rewrite-ci" ||
+          event.payload.run.branch !== "main"
+        : verification.source !== "write-coordinator" || verification.workflow !== "ledger-publication")
+    )
+      throw cell.cellCodedError(
+        "invalid_proof",
+        publicCut
+          ? "Public delivery requires a verified rewrite-ci GitHub main run."
+          : "Private delivery requires a verified ledger-publication observation for its authored cut.",
+      );
+    if (verification.conclusion === "cancelled" || verification.conclusion === "skipped") continue;
+    const result: CompletionEvidenceResult = verification.conclusion === "success" ? "pass" : "fail";
+    if (!completionEvidenceResults.includes(result)) return null;
+    const basis: CompletionEvidenceBasis = {
+        ...completionEvidenceBasis(execution),
+        ledgerCut: event.workspaceRevision,
+      },
+      provenance: CompletionEvidenceProvenance = {
+        source: "runner",
+        runId: event.payload.run.runId,
+        rawResult: `event:${event.opId}`,
+      };
+    return {
+      schema: "completion-evidence/v1",
+      evidenceId: `ci-${event.opId}`,
+      checkerId: "ci",
+      gateId: "ci",
+      result,
+      observed: true,
+      basis,
+      provenance,
     };
-  return {
-    schema: "completion-evidence/v1",
-    evidenceId: `ci-${event.opId}`,
-    checkerId: "ci",
-    gateId: "ci",
-    result,
-    observed: true,
-    basis,
-    provenance,
-  };
+  }
+  return null;
 }
 
 /** Attach only existing evidence to the submitted cut; document sync belongs to its original holder. */

--- a/packages/daemon/test/repo-cell-task-progress-evidence.test.ts
+++ b/packages/daemon/test/repo-cell-task-progress-evidence.test.ts
@@ -140,6 +140,13 @@ test("automatic CI evidence selects exact and descendant main runs, excluding un
     const descendant = git(root, "rev-parse", "HEAD");
     assert.equal(readLatestCiEvidence(fixture(root, current, [observation(submitted)]).cell, current)?.result, "pass");
     assert.equal(readLatestCiEvidence(fixture(root, current, [observation(descendant)]).cell, current)?.result, "pass");
+    assert.equal(
+      readLatestCiEvidence(
+        fixture(root, current, [observation(descendant, 2, "cancelled"), observation(submitted)]).cell,
+        current,
+      )?.result,
+      "pass",
+    );
     assert.equal(readLatestCiEvidence(fixture(root, current, [observation("f".repeat(40))]).cell, current), null);
     assert.throws(
       () =>
@@ -182,6 +189,37 @@ test("unverified latest observation rejects and latest real red never falls back
   await assert.rejects(prepareSubmissionEvidence(red.cell, "task", "execution", binding), { code: "invalid_proof" });
   assert.deepEqual(red.calls, []);
 });
+
+for (const conclusion of ["cancelled", "skipped"]) {
+  test(`${conclusion} latest observation falls back to older success`, () => {
+    const current = execution(publicSha),
+      prepared = fixture(publicRoot, current, [observation(publicSha, 2, conclusion), observation(publicSha)]),
+      evidence = readLatestCiEvidence(prepared.cell, current);
+    assert.equal(evidence?.result, "pass");
+    assert.equal(evidence?.provenance.rawResult, "event:op-1");
+  });
+
+  test(`${conclusion} observation without older evidence returns null`, () => {
+    const current = execution(publicSha);
+    assert.equal(
+      readLatestCiEvidence(fixture(publicRoot, current, [observation(publicSha, 2, conclusion)]).cell, current),
+      null,
+    );
+  });
+}
+
+for (const conclusion of ["failure", "timed_out"]) {
+  test(`cancelled latest observation preserves older ${conclusion} over success`, () => {
+    const current = execution(publicSha),
+      prepared = fixture(publicRoot, current, [
+        observation(publicSha, 3, "cancelled"),
+        observation(publicSha, 2, conclusion),
+        observation(publicSha),
+      ]);
+    assert.equal(readLatestCiEvidence(prepared.cell, current)?.result, "fail");
+    assert.equal(readLatestCiEvidence(prepared.cell, current)?.provenance.rawResult, "event:op-2");
+  });
+}
 
 test("private ledger ancestor observation supports its cut and pending publication provides no witness", async () => {
   const root = mkdtempSync(path.join(tmpdir(), "ha-ledger-evidence-"));


### PR DESCRIPTION
# English

## Summary

`readLatestCiEvidence` treated any newest related main run whose conclusion was not `success` as a failed CI witness, so a run cancelled by GitHub's main concurrency (superseded by a newer push) blocked `ha task complete` with `invalid_proof` for an already-merged, already-green cut (live sample task_212cde7d). Now `cancelled` and `skipped` observations are skipped to the next related observation; `failure`/`timed_out` still fail. Reason propagation to the CLI hint belongs to task_dcbfdb78 (peer).

## Architectural Justification

-

## What Changed

- `packages/daemon/src/repo-cell-task-progress.ts`: skip cancelled/skipped conclusions.
- Regression tests: [cancelled, success] → pass; [failure, success] → fail; [cancelled] → unobserved.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: small production change in readLatestCiEvidence plus regression tests (14/14).

## Machine-Readable Declarations

- None.

## Task And Scope

- Harness task: task_2ca4250be25c3c69f9f2135d5a (parent task_4f7965fc895253bf70a4020f42)
- Branch: `codex/ci-cancel`
- Public scope: daemon CI evidence selection
- Private planning/evidence updated: yes (`artifacts/report.md`)
- Out of scope: CLI receipt reason propagation (task_dcbfdb78)

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: not applicable
- Machine-check boundary: not applicable
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `466caf36a`
- Branch merge-base with `origin/main`: `466caf36a`
- Last `git fetch origin` time: 2026-09-12 UTC
- Sync method: branched from origin/main
- Public diff command: `git diff origin/main...codex/ci-cancel`
- Private evidence commit/path: task_2ca4250be25c3c69f9f2135d5a `artifacts/report.md`
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [x] `npm run typecheck` (worker, `tsc -b`)
- [ ] `npm run check`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts` (via `run-manifest-gates --changed origin/main`)
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Ubuntu targeted 14/14 (4 failing before the fix); eslint, line-density, 6 changed gates pass.

## Review Evidence

- CEO ground-truth: read the worker report and the diff stat; commit authorship and scope checked.
- Reviewer subagent: closeout review after merge (one-path closeout)
- Human review: pending
- Blocking findings: none open

## Residual Risk

- Full typecheck unverified by the worker (post-commit hook lacked tsc); CI is the authority.

## References

- Task: task_2ca4250be25c3c69f9f2135d5a

---

# 中文

## 概要

`readLatestCiEvidence` 把最新相关 main run 里任何非 `success` 的结论都当失败见证，于是被 GitHub main 并发取消（被更新 push 取代）的 run 让已合入、已有绿证据的 cut 在 `ha task complete` 撞 `invalid_proof`（活样本 task_212cde7d）。现在 `cancelled`/`skipped` 观察跳到下一条相关观察；`failure`/`timed_out` 仍判失败。原因传到 CLI hint 归 task_dcbfdb78（peer）。

## 架构辩护

-

## 改动内容

- `packages/daemon/src/repo-cell-task-progress.ts`：跳过 cancelled/skipped。
- 回归测试：[cancelled, success] → pass；[failure, success] → fail；[cancelled] → 未观察。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 删除的门或 fixture：none
- 生产净行数：small production change in readLatestCiEvidence plus regression tests (14/14)。

## 机器可读声明

- 无。

## 任务与范围

- Harness 任务：task_2ca4250be25c3c69f9f2135d5a（父 task_4f7965fc895253bf70a4020f42）
- 分支：`codex/ci-cancel`
- 公开范围：daemon CI 证据选择
- 私有计划/证据已更新：是（`artifacts/report.md`）
- 范围外：CLI 回执原因传播（task_dcbfdb78）

## 版本影响

- 版本：不变
- 发布影响：不发布

## 治理声明

- 触碰受保护面：否
- 受保护面范围：不适用
- 授权：不适用
- 机器检查边界：不适用
- Break-glass：否
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- 基线 `origin/main` SHA：`466caf36a`
- 分支与 `origin/main` 的 merge-base：`466caf36a`
- 最近一次 `git fetch origin`：2026-09-12 UTC
- 同步方式：从 origin/main 开分支
- 公开 diff 命令：`git diff origin/main...codex/ci-cancel`
- 私有证据路径：task_2ca4250be25c3c69f9f2135d5a 的 `artifacts/report.md`
- 评审证据路径：本 PR 的评审证据节
- GitHub Actions `rewrite-ci` run URL：本 PR 待跑
- Ubuntu 定向 14/14（修前 4 失败）；eslint、line-density、6 个 changed gates 通过。

## 评审证据

- CEO 事实核对：读过 worker 报告与 diff 统计；核过提交人与范围。
- 评审子代理：合入后走一条路收口评审
- 人工评审：待定
- 阻塞发现：无

## 残余风险

- worker 未跑完整 typecheck（post-commit 钩子缺 tsc）；以 CI 为准。

## 参考

- 任务：task_2ca4250be25c3c69f9f2135d5a

