### PR TITLE
perf: bound triadic facets and filter fact refs before paging

### DIFF
--- a/packages/daemon/src/protocol/daemon-protocol-gui-types.ts
+++ b/packages/daemon/src/protocol/daemon-protocol-gui-types.ts
@@ -510,10 +510,12 @@ export interface DaemonRelationQueryPayload {
   readonly cursor?: string;
 }
 
-export type DaemonRelationGraphFacet = "edges" | "facts" | "coverageRows" | "factAnchors" | "runtimeEdges";
+export type DaemonRelationGraphFacet = "edges" | "facts" | "coverageRows" | "runtimeEdges";
 
 export interface DaemonRelationEdgeFacetPayload {
   readonly facet: "edges";
+  readonly limit?: number;
+  readonly cursor?: string;
   readonly relationType?: string;
   readonly state?: string;
   readonly direction?: "directed" | "undirected";
@@ -521,7 +523,8 @@ export interface DaemonRelationEdgeFacetPayload {
 
 export type DaemonRelationGraphFacetPayload =
   | DaemonRelationEdgeFacetPayload
-  | { readonly facet: Exclude<DaemonRelationGraphFacet, "edges"> };
+  | { readonly facet: "facts"; readonly limit?: number; readonly cursor?: string }
+  | { readonly facet: "coverageRows" | "runtimeEdges" };
 
 export interface DaemonFactSummaryRow {
   readonly anchor: string;
@@ -567,18 +570,16 @@ export type DaemonRelationGraphFacetResult =
   | ({ readonly ok: true; readonly facet: "edges" } & EventProjectionCut &
       Omit<EmptyRelationFacetRows, "edges"> & {
         readonly edges: DaemonRelationGraphProjection["edges"];
+        readonly page: ProjectionPage;
       })
   | ({ readonly ok: true; readonly facet: "coverageRows" } & EventProjectionCut &
       Omit<EmptyRelationFacetRows, "coverageRows"> & {
         readonly coverageRows: readonly ServedCoverageRow[];
       })
-  | ({ readonly ok: true; readonly facet: "factAnchors" } & EventProjectionCut &
-      Omit<EmptyRelationFacetRows, "factAnchors"> & {
-        readonly factAnchors: DaemonRelationGraphProjection["factAnchors"];
-      })
   | ({ readonly ok: true; readonly facet: "facts" } & EventProjectionCut &
       Omit<EmptyRelationFacetRows, "facts" | "domainTypes"> & {
         readonly facts: readonly DaemonFactSummaryRow[];
+        readonly page: ProjectionPage;
         readonly domainTypes: ReturnType<TaskProjection["listFactDomainTypes"]>["domainTypes"];
       })
   | ({ readonly ok: true; readonly facet: "runtimeEdges" } & Omit<EmptyRelationFacetRows, "edges"> & {

--- a/packages/daemon/src/protocol/daemon-protocol-rpc-validation.ts
+++ b/packages/daemon/src/protocol/daemon-protocol-rpc-validation.ts
@@ -197,14 +197,17 @@ export function validateDaemonQueryPayload(
 
 function validateRelationFacetPayload(value: JsonObject): string[] {
   const facet = value.facet,
-    edgeFields = ["facet", "relationType", "state", "direction"],
-    allowed = facet === "edges" ? edgeFields : ["facet"];
-  if (!["edges", "facts", "coverageRows", "factAnchors", "runtimeEdges"].includes(String(facet)))
+    edgeFields = ["facet", "relationType", "state", "direction", "limit", "cursor"],
+    allowed = facet === "edges" ? edgeFields : facet === "facts" ? ["facet", "limit", "cursor"] : ["facet"];
+  if (!["edges", "facts", "coverageRows", "runtimeEdges"].includes(String(facet)))
     return ["repo.triadic.relationGraph.payload.facet is invalid"];
   const unknown = unknownFieldViolation(value, allowed);
   if (unknown) return [`repo.triadic.relationGraph.payload contains an ${unknown}`];
-  if (facet !== "edges") return [];
-  const errors: string[] = [];
+  const errors = validateDaemonQueryPayload("repo.triadic.relationGraph", {
+    ...(value.limit === undefined ? {} : { limit: value.limit }),
+    ...(value.cursor === undefined ? {} : { cursor: value.cursor }),
+  });
+  if (facet !== "edges") return errors;
   if (value.relationType !== undefined && !nonEmpty(value.relationType))
     errors.push("repo.triadic.relationGraph.payload.relationType is invalid");
   if (value.state !== undefined && !statusWord(relationStateWords, value.state))

--- a/packages/daemon/src/protocol/daemon-protocol-schema-ids.ts
+++ b/packages/daemon/src/protocol/daemon-protocol-schema-ids.ts
@@ -270,7 +270,7 @@ export const daemonTaskQueryPayloadShape = shape({
 export const daemonRelationQueryPayloadShape = shape({
   entity: "string?",
   hops: "json?",
-  facet: optionalEnum(["edges", "facts", "coverageRows", "factAnchors", "runtimeEdges"]),
+  facet: optionalEnum(["edges", "facts", "coverageRows", "runtimeEdges"]),
   relationType: "string?",
   state: "string?",
   direction: optionalEnum(["directed", "undirected"]),

--- a/packages/daemon/src/protocol/daemon-protocol-validate-projections.ts
+++ b/packages/daemon/src/protocol/daemon-protocol-validate-projections.ts
@@ -145,12 +145,13 @@ export function validateDaemonRelationGraph(value: unknown): readonly string[] {
     );
   if (requiredShapeError) return [requiredShapeError];
   if (!isJsonObject(value)) return [];
-  const full = value.facet === undefined,
+  const pagedFacet = value.facet === "edges" || value.facet === "facts",
+    full = value.facet === undefined,
     canonicalCut = full || value.facet !== "runtimeEdges",
     topFields = [
       ...DAEMON_RELATION_GRAPH_SCHEMA.required,
       ...(canonicalCut ? DAEMON_RELATION_GRAPH_SCHEMA.canonicalCut : []),
-      ...(full && value.page !== undefined ? ["page"] : []),
+      ...(pagedFacet || (full && value.page !== undefined) ? ["page"] : []),
       ...(full ? [] : ["facet"]),
     ];
   const shapeError = recordShapeError(entityId, value, topFields, [
@@ -169,7 +170,12 @@ export function validateDaemonRelationGraph(value: unknown): readonly string[] {
     ["watermark", value.watermark, !canonicalCut || integer(value.watermark), "must be an integer"],
     ["sourceRevision", value.sourceRevision, !canonicalCut || integer(value.sourceRevision), "must be an integer"],
     ["warnings", value.warnings, warningArray(value.warnings), "must contain valid warnings"],
-    ["page", value.page, !full || value.page === undefined || queryPageRow(value.page), "must be a valid query page"],
+    [
+      "page",
+      value.page,
+      pagedFacet ? queryPageRow(value.page) : !full || value.page === undefined || queryPageRow(value.page),
+      "must be a valid query page",
+    ],
     ["edges", value.edges, Array.isArray(value.edges), "must be an array"],
     ["coverageRows", value.coverageRows, Array.isArray(value.coverageRows), "must be an array"],
     ["factAnchors", value.factAnchors, Array.isArray(value.factAnchors), "must be an array"],
@@ -203,14 +209,14 @@ export function validateDaemonRelationGraph(value: unknown): readonly string[] {
     }
     return [];
   }
-  if (!["edges", "facts", "coverageRows", "factAnchors", "runtimeEdges"].includes(String(value.facet)))
+  if (!["edges", "facts", "coverageRows", "runtimeEdges"].includes(String(value.facet)))
     return [validationError(entityId, "facet", value.facet, "must name a supported relation-graph facet")];
   // `runtimeEdges` 与 `edges` 同为边切面:选中的数组是 edges,其余必须为空。
   const edgesFacet = value.facet === "edges" || value.facet === "runtimeEdges";
   const populatedUnselected = [
     ["edges", value.edges, edgesFacet],
     ["coverageRows", value.coverageRows, value.facet === "coverageRows"],
-    ["factAnchors", value.factAnchors, value.facet === "factAnchors"],
+    ["factAnchors", value.factAnchors, false],
     ["facts", value.facts, value.facet === "facts"],
   ] as const;
   const unexpected = populatedUnselected.find(([, rows, selected]) => !selected && rows.length !== 0);
@@ -220,9 +226,7 @@ export function validateDaemonRelationGraph(value: unknown): readonly string[] {
     ? (["edges", value.edges, relationEdgeInvalid] as const)
     : value.facet === "coverageRows"
       ? (["coverageRows", value.coverageRows, coverageRowInvalid] as const)
-      : value.facet === "factAnchors"
-        ? (["factAnchors", value.factAnchors, factAnchorInvalid] as const)
-        : (["facts", value.facts, factSummaryInvalid] as const);
+      : (["facts", value.facts, factSummaryInvalid] as const);
   const invalidIndex = selected[1].findIndex(selected[2]);
   if (invalidIndex >= 0)
     return [

--- a/packages/daemon/src/repo-cell-api.ts
+++ b/packages/daemon/src/repo-cell-api.ts
@@ -852,9 +852,13 @@ export function createRepoCellApi(context: RepoCellApiContext): RepoCell & RepoC
     ) {
       const facet = payload.facet;
       if (
-        !["edges", "facts", "coverageRows", "factAnchors", "runtimeEdges"].includes(String(facet)) ||
+        !["edges", "facts", "coverageRows", "runtimeEdges"].includes(String(facet)) ||
         Object.keys(payload).some((field) =>
-          facet === "edges" ? !["facet", "relationType", "state", "direction"].includes(field) : field !== "facet",
+          facet === "edges"
+            ? !["facet", "relationType", "state", "direction", "limit", "cursor"].includes(field)
+            : facet === "facts"
+              ? !["facet", "limit", "cursor"].includes(field)
+              : field !== "facet",
         ) ||
         (payload.relationType !== undefined && (typeof payload.relationType !== "string" || !payload.relationType)) ||
         (payload.state !== undefined &&
@@ -863,6 +867,7 @@ export function createRepoCellApi(context: RepoCellApiContext): RepoCell & RepoC
           !relationDirections.includes(String(payload.direction) as (typeof relationDirections)[number]))
       )
         throw context.cellCodedError("invalid_command", "Relation graph facet selectors are invalid.");
+      queryPayloadFacets(payload, "repo.triadic.relationGraph");
       return queryRead().relationGraphFacet(payload as DaemonRelationGraphFacetPayload);
     }
     const common = queryPayloadFacets(payload, "repo.triadic.relationGraph");

--- a/packages/daemon/src/task-query-read.ts
+++ b/packages/daemon/src/task-query-read.ts
@@ -96,28 +96,33 @@ export function makeTaskQueryReadModel(input: {
     }
     if (query.facet === "edges") {
       const read = projection.readRelationQuery({
+          ...(query.direction === undefined ? {} : { direction: query.direction }),
+          limit: query.limit ?? 500,
+          ...(query.cursor === undefined ? {} : { cursor: query.cursor }),
           ...(query.relationType === undefined ? {} : { relationType: query.relationType }),
           ...(query.state === undefined ? {} : { state: query.state }),
         }),
-        edges =
-          query.direction === undefined
-            ? read.rows.map(withRelationCurrent)
-            : read.rows.filter(({ direction }) => direction === query.direction).map(withRelationCurrent);
+        edges = read.rows.map(withRelationCurrent);
       return {
         ok: true,
         facet: "edges",
         ...emptyRows,
         edges,
+        page: read.page!,
         warnings: relationFacetWarnings(read.status),
         ...projectionCut(read),
       };
     }
     if (query.facet === "facts") {
-      const read = projection.searchFacts({}),
+      const read = projection.searchFacts({
+          limit: query.limit ?? 500,
+          ...(query.cursor === undefined ? {} : { cursor: query.cursor }),
+        }),
         domainTypes = projection.listFactDomainTypes();
       return {
         ok: true,
         facet: "facts",
+        page: read.page!,
         ...emptyRows,
         facts: read.facts.map((row) => ({
           anchor: row.ref,
@@ -132,17 +137,6 @@ export function makeTaskQueryReadModel(input: {
         })),
         domainTypes: domainTypes.domainTypes,
         warnings: relationFacetWarnings(read.status === "ready" ? domainTypes.status : read.status),
-        ...projectionCut(read),
-      };
-    }
-    if (query.facet === "factAnchors") {
-      const read = projection.readFactAnchors();
-      return {
-        ok: true,
-        facet: "factAnchors",
-        ...emptyRows,
-        factAnchors: read.rows,
-        warnings: relationFacetWarnings(read.status),
         ...projectionCut(read),
       };
     }

--- a/packages/daemon/test/json-rpc-protocol.test.ts
+++ b/packages/daemon/test/json-rpc-protocol.test.ts
@@ -178,16 +178,17 @@ test("relation graph contract accepts the materialized ledger row schema and rej
   assertValidationDiagnostic(validateDaemonRelationGraph({ ...payload, facts: [{ ...payload.facts[0], invalidated: "superseded_fact" }] }), /F-REAL/u, "facts[0]");
   const empty = { edges: [], coverageRows: [], factAnchors: [], facts: [] };
   const facets = [
-    { ok: true, ...cut, facet: "edges", ...empty, edges: payload.edges, warnings: [] },
-    { ok: true, ...cut, facet: "facts", ...empty, facts: [{ anchor: "fact/F-REAL", text: "Real observation.", category: "lesson", taskId: "task_REAL" }], warnings: [] },
+    { ok: true, ...cut, facet: "edges", page: { limit: 500, cursor: null, nextCursor: null }, ...empty, edges: payload.edges, warnings: [] },
+    { ok: true, ...cut, facet: "facts", page: { limit: 500, cursor: null, nextCursor: null }, ...empty, facts: [{ anchor: "fact/F-REAL", text: "Real observation.", category: "lesson", taskId: "task_REAL" }], warnings: [] },
     { ok: true, ...cut, facet: "coverageRows", ...empty, coverageRows: payload.coverageRows, warnings: [] },
-    { ok: true, ...cut, facet: "factAnchors", ...empty, factAnchors: payload.factAnchors, warnings: [] },
   ];
   for (const facet of facets) assert.deepEqual(validateDaemonRelationGraph(facet), [], String(facet.facet));
+  assert.ok(validateDaemonRelationGraph({ ...facets[0], page: undefined }).length > 0);
+  assert.ok(validateDaemonRelationGraph({ ...facets[1], page: { limit: 0, cursor: null, nextCursor: null } }).length > 0);
   // Every facet echoes the fact-type vocabulary (empty outside `facts`); it is declared, not required.
   for (const facet of facets) assert.deepEqual(validateDaemonRelationGraph({ ...facet, domainTypes: [] }), [], `${facet.facet}+domainTypes`);
   assert.deepEqual(validateDaemonRelationGraph({ ...payload, domainTypes: ["lesson"] }), []);
-  assertValidationDiagnostic(validateDaemonRelationGraph({ ...facets[0], facet: "unknown" }), /relation-graph:unknown/u, "facet");
+  assertValidationDiagnostic(validateDaemonRelationGraph({ ...facets[2], facet: "unknown" }), /relation-graph:unknown/u, "facet");
   assertValidationDiagnostic(validateDaemonRelationGraph({ ...facets[1], extra: true }), /relation-graph:facts/u, "extra");
   assertValidationDiagnostic(validateDaemonRelationGraph({ ...facets[2], facts: facets[1]!.facts }), /relation-graph:coverageRows/u, "facts");
   assertValidationDiagnostic(validateDaemonRelationGraph({ ...facets[1], facts: [{ ...facets[1]!.facts[0], category: "semantic" }] }), /F-REAL/u, "facts[0]");
@@ -210,8 +211,15 @@ test("wide GUI read contracts accept only their explicit narrow and page facets"
   assert.equal(graph({ updatedAfter: "later", updatedBefore: "earlier" }).ok, false);
   assert.equal(task({ unexpected: true }).ok, false);
   assert.equal(graph({ facet: "edges", relationType: "derives", state: "active", direction: "directed" }).ok, true);
-  for (const facet of ["facts", "coverageRows", "factAnchors"]) assert.equal(graph({ facet }).ok, true, facet);
+  for (const facet of ["facts", "coverageRows"]) assert.equal(graph({ facet }).ok, true, facet);
   assert.equal(graph({ facet: "unknown" }).ok, false);
+  assert.equal(graph({ facet: "factAnchors" }).ok, false);
+  for (const facet of ["edges", "facts"]) {
+    assert.equal(graph({ facet, limit: 500, cursor: "next" }).ok, true);
+    for (const limit of [0, 501, 1.5, "5"]) assert.equal(graph({ facet, limit }).ok, false);
+    assert.equal(graph({ facet, cursor: "" }).ok, false);
+  }
+  assert.equal(graph({ facet: "coverageRows", limit: 5 }).ok, false);
   assert.equal(graph({ facet: "facts", relationType: "derives" }).ok, false);
   assert.equal(graph({ relationType: "derives" }).ok, false);
   assert.equal(decisions({ projection: "summary" }).ok, true);

--- a/packages/daemon/test/task-query-read.test.ts
+++ b/packages/daemon/test/task-query-read.test.ts
@@ -114,7 +114,7 @@ test("relation filters, facets, and pages select one event-backed edge universe"
       { relationType: "derives", limit: undefined, cursor: undefined },
       { relationType: undefined, limit: 1, cursor: undefined },
       { relationType: undefined, limit: 1, cursor: "page-2" },
-      { relationType: undefined, limit: undefined, cursor: undefined },
+      { relationType: undefined, limit: 500, cursor: undefined },
     ],
   );
 });

--- a/packages/daemon/test/task-surface-pages-facts.integration.test.ts
+++ b/packages/daemon/test/task-surface-pages-facts.integration.test.ts
@@ -346,8 +346,7 @@ test("wide task reads keep byte-identical unparameterized results and serve narr
         direction: "directed",
       }),
       factsFacet = await cell.read("repo.triadic.relationGraph", { facet: "facts" }),
-      coverageFacet = await cell.read("repo.triadic.relationGraph", { facet: "coverageRows" }),
-      anchorsFacet = await cell.read("repo.triadic.relationGraph", { facet: "factAnchors" });
+      coverageFacet = await cell.read("repo.triadic.relationGraph", { facet: "coverageRows" });
     assert.deepEqual(
       edgeFacet.edges.map(({ relationType, state, direction }) => ({ relationType, state, direction })),
       [{ relationType: "derives", state: "active", direction: "directed" }],
@@ -367,8 +366,9 @@ test("wide task reads keep byte-identical unparameterized results and serve narr
     assert.deepEqual([factsFacet.edges, factsFacet.coverageRows, factsFacet.factAnchors], [[], [], []]);
     assert.equal(coverageFacet.facet, "coverageRows");
     assert.deepEqual([coverageFacet.edges, coverageFacet.factAnchors, coverageFacet.facts], [[], [], []]);
-    assert.equal(anchorsFacet.factAnchors.length, 1);
-    assert.deepEqual([anchorsFacet.edges, anchorsFacet.coverageRows, anchorsFacet.facts], [[], [], []]);
+    assert.equal(edgeFacet.page?.limit, 500);
+    assert.equal(factsFacet.page?.limit, 500);
+    await assert.rejects(cell.read("repo.triadic.relationGraph", { facet: "factAnchors" } as never), /facet|invalid/u);
     const decisionSummary = await cell.read("repo.decisions.list", { projection: "summary" }),
       decisionFull = await cell.read("repo.decisions.list", { projection: "full" });
     assert.equal(decisionSummary.projection, "summary");

--- a/packages/gui/src/renderer/App.tsx
+++ b/packages/gui/src/renderer/App.tsx
@@ -731,6 +731,18 @@ function AppShell() {
             </div>
           </div>
         </main>
+        {edgeSurfaceMounted &&
+        !triadicQuery.graphAvailable &&
+        (activeEdges.hasNextPage || activeEdges.relationState === "error") ? (
+          <aside className="fixed bottom-4 left-4 z-50 rounded border border-border bg-bg p-3" role="status">
+            <span>{activeEdges.relationState === "error" ? "关系读取失败。" : "当前关系尚未全部加载。"}</span>
+            {activeEdges.hasNextPage ? (
+              <button disabled={activeEdges.isFetching} onClick={() => void activeEdges.fetchNextPage()}>
+                加载更多关系
+              </button>
+            ) : null}
+          </aside>
+        ) : null}
         <TaskPreviewDrawer
           task={previewTask}
           tasks={projectTasks}
@@ -743,6 +755,10 @@ function AppShell() {
         <CommandPalette
           open={paletteOpen}
           entries={paletteEntries}
+          factsIncomplete={paletteFacts.hasNextPage}
+          factsLoading={paletteFacts.isFetching}
+          factsError={paletteFacts.isError}
+          onLoadFacts={() => void paletteFacts.fetchNextPage()}
           onSelect={navigateToEntity}
           onClose={() => setPaletteOpen(false)}
         />

--- a/packages/gui/src/renderer/api-client.ts
+++ b/packages/gui/src/renderer/api-client.ts
@@ -97,12 +97,16 @@ export interface RelationPageQuery {
 }
 /** `repo.triadic.relationGraph` facet read: one row array, every other array empty. */
 export interface RelationEdgeFacetQuery {
+  readonly limit?: number;
+  readonly cursor?: string;
   readonly facet: "edges";
   readonly relationType?: string;
   readonly state?: RelationState;
   readonly direction?: RelationDirection;
 }
 export interface RelationFactFacetQuery {
+  readonly limit?: number;
+  readonly cursor?: string;
   readonly facet: "facts";
 }
 /** `repo.triadic.relationGraph {facet:"runtimeEdges"}`:运行时平面(agent→task)派发边。 */
@@ -149,6 +153,7 @@ export interface RelationFactSummaryRow {
   readonly taskId?: string;
 }
 export interface RelationFactFacetSuccess {
+  readonly page: QueryPage;
   readonly ok: true;
   readonly facet: "facts";
   readonly facts: ReadonlyArray<RelationFactSummaryRow>;
@@ -834,6 +839,7 @@ function readRelationFactFacetResult(value: unknown): RelationFactFacetSuccess {
     result.facet !== "facts" ||
     !Array.isArray(result.facts) ||
     !result.facts.every(isRelationFactSummaryRow) ||
+    !isQueryPage(result.page) ||
     !Array.isArray(result.domainTypes) ||
     !result.domainTypes.every(isFactDomainTypeSummaryRow)
   ) {
@@ -842,6 +848,7 @@ function readRelationFactFacetResult(value: unknown): RelationFactFacetSuccess {
   return {
     ok: true,
     facet: "facts",
+    page: result.page,
     facts: result.facts,
     domainTypes: result.domainTypes,
     warnings: Array.isArray(result.warnings) ? result.warnings : [],

--- a/packages/gui/src/renderer/components/CommandPalette.tsx
+++ b/packages/gui/src/renderer/components/CommandPalette.tsx
@@ -7,8 +7,7 @@ import { entityKindAxisVar } from "../graph/kindVisuals.ts";
  *
  * 纯前端派生:从 tasks/decisions/facts 建索引,typeahead 过滤,Enter 跳转。
  * 不消费任何写 IPC;只触发导航(onSelect ref)。
- * 完整渲染匹配结果,不分批(2026-08-25 泽宇裁决:性能顾虑用按需渲染解决,不转嫁给用户
- * 点击):每条带 content-visibility:auto,离屏条目的布局与绘制由渲染器跳过。
+ * 渲染已加载页的匹配结果;事实仍有后续页时显示搜索范围与续页入口。
  */
 export interface PaletteEntry {
   ref: string;
@@ -56,7 +55,15 @@ export function CommandPalette({
   entries,
   onSelect,
   onClose,
+  factsIncomplete,
+  factsLoading,
+  factsError,
+  onLoadFacts,
 }: {
+  factsIncomplete?: boolean;
+  factsLoading?: boolean;
+  factsError?: boolean;
+  onLoadFacts?: () => void;
   open: boolean;
   entries: ReadonlyArray<PaletteEntry>;
   onSelect: (ref: string) => void;
@@ -163,6 +170,14 @@ export function CommandPalette({
               </button>
             ))
           )}
+        </div>
+        <div role="status">
+          {factsError ? "事实读取失败。" : factsLoading ? "正在加载事实…" : null}
+          {factsIncomplete ? (
+            <button disabled={factsLoading} onClick={onLoadFacts}>
+              搜索仅含已加载事实，加载更多事实
+            </button>
+          ) : null}
         </div>
       </div>
     </div>

--- a/packages/gui/src/renderer/components/entityDoc/FactVocabularySections.tsx
+++ b/packages/gui/src/renderer/components/entityDoc/FactVocabularySections.tsx
@@ -55,7 +55,10 @@ export function FactFacetLive({ stats }: { readonly stats: ReturnType<typeof use
       {stats.state === "error" && <p className="ui-meta text-status-blocked">事实切面读取失败。</p>}
       {stats.state === "ready" && (
         <div className="flex flex-wrap items-center gap-2 ui-meta">
-          <span className="font-mono text-text">{stats.total} 条 fact</span>
+          <span className="font-mono text-text">
+            {stats.hasNextPage ? "已加载 " : ""}
+            {stats.total} 条 fact
+          </span>
           {stats.byCategory.map((entry) => (
             <span
               key={entry.category}
@@ -65,6 +68,11 @@ export function FactFacetLive({ stats }: { readonly stats: ReturnType<typeof use
             </span>
           ))}
         </div>
+      )}
+      {stats.hasNextPage && (
+        <button disabled={stats.isFetching} onClick={() => stats.fetchNextPage()}>
+          统计仅含已加载事实，加载更多事实
+        </button>
       )}
       {stats.state === "ready" && (
         <p className="mt-2 ui-micro leading-relaxed text-text-faint">

--- a/packages/gui/src/renderer/entities-data.ts
+++ b/packages/gui/src/renderer/entities-data.ts
@@ -5,7 +5,7 @@ import { agentEntityClient } from "./agent-entity-client.ts";
 import { schedulesClient } from "./schedules-client.ts";
 import { catalogQueryKeys } from "./catalog-data.ts";
 import { workspaceSummaryQuery } from "./workspace-summary-data.ts";
-import { triadicQueryKeys } from "./triadic-data.ts";
+import { usePaletteFactsQuery } from "./triadic-data.ts";
 import type { RelationFactSummaryRow } from "./api-client.ts";
 
 /**
@@ -75,6 +75,9 @@ function countOf(value: number): number {
 export interface FactFacetStats {
   readonly state: "ready" | "pending" | "error";
   readonly total: number | null;
+  readonly hasNextPage: boolean;
+  readonly isFetching: boolean;
+  readonly fetchNextPage: () => unknown;
   /** memoryClass 在读面上的折叠:semantic→lesson、procedural→progress、episodic→finding。 */
   readonly byCategory: ReadonlyArray<{ readonly category: RelationFactSummaryRow["category"]; readonly count: number }>;
   readonly domainTypes: ReadonlyArray<{
@@ -83,29 +86,21 @@ export interface FactFacetStats {
   }>;
 }
 
-/**
- * Fact 详情的实况切面:与 ⌘K 面板同一条 facts 切面读(同一 queryKey,共享缓存
- * 与失效)。只在 Fact 实体详情打开时启用——这是本面唯一的大读(约 1 MB 量级),
- * 不为目录页的计数去拉它。
- */
+/** Fact 详情与 ⌘K 共用分页缓存;统计只覆盖已加载页,由视图显式续页。 */
 export function useFactFacetStats(repoId: string, enabled: boolean): FactFacetStats {
-  const query = useQuery({
-    queryKey: triadicQueryKeys.facts(repoId),
-    queryFn: () => harnessClient.getRelationFacts({ repoId, facet: "facts" }),
-    enabled,
-    staleTime: 10_000,
-  });
-  return useMemo(() => {
-    if (query.isError) return { state: "error", total: null, byCategory: [], domainTypes: [] };
-    if (query.data === undefined) return { state: "pending", total: null, byCategory: [], domainTypes: [] };
-    const facts = query.data.facts,
-      counts = new Map<RelationFactSummaryRow["category"], number>();
-    for (const fact of facts) counts.set(fact.category, (counts.get(fact.category) ?? 0) + 1);
-    return {
-      state: "ready",
-      total: facts.length,
-      byCategory: [...counts.entries()].sort((a, b) => b[1] - a[1]).map(([category, count]) => ({ category, count })),
-      domainTypes: query.data.domainTypes,
-    };
-  }, [query.data, query.isError]);
+  const query = usePaletteFactsQuery(repoId, enabled);
+  const byCategory = useMemo(() => {
+    const counts = new Map<RelationFactSummaryRow["category"], number>();
+    for (const fact of query.facts) counts.set(fact.category, (counts.get(fact.category) ?? 0) + 1);
+    return [...counts.entries()].sort((a, b) => b[1] - a[1]).map(([category, count]) => ({ category, count }));
+  }, [query.facts]);
+  return {
+    state: query.isError ? "error" : query.isPending ? "pending" : "ready",
+    total: query.isError || query.isPending ? null : query.facts.length,
+    byCategory,
+    domainTypes: query.domainTypes,
+    hasNextPage: query.hasNextPage,
+    isFetching: query.isFetching,
+    fetchNextPage: query.fetchNextPage,
+  };
 }

--- a/packages/gui/src/renderer/triadic-data.ts
+++ b/packages/gui/src/renderer/triadic-data.ts
@@ -1,5 +1,5 @@
 import { useMemo } from "react";
-import { useQuery } from "@tanstack/react-query";
+import { useInfiniteQuery, useQuery } from "@tanstack/react-query";
 import type { DecisionProjectionRow, RelationCoverageRow, ServedRelationEdgeRow } from "../api/renderer-dto.ts";
 import { harnessClient } from "./api-client.ts";
 import type { DecisionListSuccess, RelationFactSummaryRow, RelationGraphSuccess } from "./api-client.ts";
@@ -33,42 +33,36 @@ export const triadicQueryKeys = {
   decisionSummary: (repoId: string) => ["triadic", repoId, "decisions", "summary"] as const,
 };
 
-export interface RelationReadState {
-  readonly relations: RelationEdge[];
-  readonly relationState: "ready" | "loading" | "error";
-  readonly relationWarnings: ReadonlyArray<{
-    readonly severity?: string;
-    readonly code?: string;
-    readonly message?: string;
-  }>;
-}
-
-function relationReadState(
-  query: { readonly data?: RelationGraphSuccess; readonly isPending: boolean; readonly isError: boolean },
-  enabled: boolean,
-): RelationReadState {
-  return {
-    relations: adaptRelationRows(query.data?.edges ?? []),
-    relationState: query.isError ? "error" : enabled && query.isPending ? "loading" : "ready",
-    relationWarnings: query.data?.warnings ?? [],
-  };
-}
-
 /**
  * 预览抽屉 / 任务详情 / 会话页自己的读面:全部 active 边(含 task↔task 与
  * decision↔decision 的 `relates`/`supersedes`/`depends-on`)。这些界面渲染的是边本身,
- * 不是完整投影,所以读边切面(~2.8 MB)而不是 4.96 MB 的完整图。`enabled` 由挂载方
- * 决定;完整图已在缓存里时调用方应传 `false`,避免同一批边读两遍。
+ * 不是完整投影,所以按页读边切面。`enabled` 由挂载方决定;
+ * 完整图已在缓存里时调用方应传 `false`,避免同一批边读两遍。
  */
-export function useActiveEdgesQuery(repoId: string | null, enabled: boolean): RelationReadState {
-  const query = useQuery({
+export function useActiveEdgesQuery(repoId: string | null, enabled: boolean) {
+  const query = useInfiniteQuery({
     queryKey: triadicQueryKeys.activeEdges(repoId ?? "unselected"),
-    queryFn: () => harnessClient.getRelationGraph({ repoId: repoId!, facet: "edges", state: "active" }),
+    initialPageParam: undefined as string | undefined,
+    queryFn: ({ pageParam }) =>
+      harnessClient.getRelationGraph({
+        repoId: repoId!,
+        facet: "edges",
+        state: "active",
+        limit: 500,
+        ...(pageParam === undefined ? {} : { cursor: pageParam }),
+      }),
+    getNextPageParam: (last) => last.page!.nextCursor ?? undefined,
     enabled: repoId !== null && enabled,
     staleTime: 10_000,
   });
   const active = repoId !== null && enabled;
-  return useMemo(() => relationReadState(query, active), [query.data, query.isPending, query.isError, active]);
+  return {
+    relations: useMemo(() => adaptRelationRows(query.data?.pages.flatMap((page) => page.edges) ?? []), [query.data]),
+    relationState: query.isError ? "error" : active && query.isPending ? "loading" : "ready",
+    hasNextPage: query.hasNextPage,
+    isFetching: query.isFetching,
+    fetchNextPage: query.fetchNextPage,
+  };
 }
 
 /** 根级常驻读面:决策摘要投影(decisionId/title/state/appliesTo),157,246 B 量级。 */
@@ -88,18 +82,35 @@ export function useDecisionSummaryQuery(repoId: string | null, options: { readon
 }
 
 /**
- * ⌘K 面板自己的读面:事实切面(989,858 B 量级)。面板没打开就不读——这不是缓存或
- * 降频,是"没有挂载的视图就不请求"。
+ * ⌘K 面板打开时读取首个事实页;后续页由面板显式加载。
  */
 export function usePaletteFactsQuery(repoId: string | null, enabled: boolean) {
-  const query = useQuery({
+  const query = useInfiniteQuery({
     queryKey: triadicQueryKeys.facts(repoId ?? "unselected"),
-    queryFn: () => harnessClient.getRelationFacts({ repoId: repoId!, facet: "facts" }),
+    initialPageParam: undefined as string | undefined,
+    queryFn: ({ pageParam }) =>
+      harnessClient.getRelationFacts({
+        repoId: repoId!,
+        facet: "facts",
+        limit: 500,
+        ...(pageParam === undefined ? {} : { cursor: pageParam }),
+      }),
+    getNextPageParam: (last) => last.page.nextCursor ?? undefined,
     enabled: repoId !== null && enabled,
     staleTime: 10_000,
   });
-  const facts = useMemo<ReadonlyArray<RelationFactSummaryRow>>(() => query.data?.facts ?? [], [query.data]);
-  return { facts, isPending: repoId !== null && enabled && query.isPending, isError: query.isError };
+  const facts = useMemo<ReadonlyArray<RelationFactSummaryRow>>(
+    () => query.data?.pages.flatMap((page) => page.facts) ?? [],
+    [query.data],
+  );
+  return {
+    facts,
+    isPending: repoId !== null && enabled && query.isPending,
+    isError: query.isError,
+    hasNextPage: query.hasNextPage,
+    isFetching: query.isFetching,
+    fetchNextPage: query.fetchNextPage,
+  };
 }
 
 /**
@@ -212,7 +223,7 @@ export function useTriadicProjectionQuery(
   const isLoading = (graphEnabled && graph.isLoading) || (decisionsEnabled && decisions.isLoading);
   const isError = (graphEnabled && graph.isError) || (decisionsEnabled && decisions.isError);
   /** 缓存里是否已有完整图(含之前挂载时读到的):有就不再读边切面。 */
-  const graphAvailable = graph.data !== undefined;
+  const graphAvailable = graph.data !== undefined && graph.data.page?.nextCursor == null;
   /** 挂载方需要它而它还没到位(禁用且无缓存时为 false,不冒充加载态)。 */
   const isPending = (graphEnabled && graph.isPending) || (decisionsEnabled && decisions.isPending);
 

--- a/packages/gui/src/renderer/triadic-data.ts
+++ b/packages/gui/src/renderer/triadic-data.ts
@@ -105,6 +105,7 @@ export function usePaletteFactsQuery(repoId: string | null, enabled: boolean) {
   );
   return {
     facts,
+    domainTypes: query.data?.pages[0]?.domainTypes ?? [],
     isPending: repoId !== null && enabled && query.isPending,
     isError: query.isError,
     hasNextPage: query.hasNextPage,

--- a/packages/gui/test/entities-view.fixtures.ts
+++ b/packages/gui/test/entities-view.fixtures.ts
@@ -274,6 +274,7 @@ export function stubBridge(
         return {
           ok: true,
           facet: "facts",
+          page: { limit: 500, cursor: null, nextCursor: null },
           edges: [],
           coverageRows: [],
           factAnchors: [],
@@ -443,6 +444,7 @@ export function stubCrudBridge(
       getRelationGraph: vi.fn(async () => ({
         ok: true,
         facet: "facts",
+        page: { limit: 500, cursor: null, nextCursor: null },
         edges: [],
         coverageRows: [],
         factAnchors: [],

--- a/packages/gui/test/triadic-graph-paging.vitest.ts
+++ b/packages/gui/test/triadic-graph-paging.vitest.ts
@@ -1,5 +1,6 @@
 // harness-test-tier: fast
-import { describe, expect, it } from "vitest";
+// @vitest-environment happy-dom
+import { describe, expect, it, vi } from "vitest";
 import type { RelationGraphSuccess } from "../src/renderer/api-client.ts";
 import { readRelationGraphPage } from "../src/renderer/triadic-data.ts";
 
@@ -58,4 +59,76 @@ describe("关系图按界限读取", () => {
     expect(reads).toBe(1);
     expect(graph.edges.map((row) => row.relationId)).toEqual(["r1"]);
   });
+});
+
+import { act, createElement } from "react";
+import { createRoot } from "react-dom/client";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { useActiveEdgesQuery, usePaletteFactsQuery } from "../src/renderer/triadic-data.ts";
+import { harnessClient } from "../src/renderer/api-client.ts";
+
+it("facet hooks fetch one page on mount and retain rows through explicit continuation and failure", async () => {
+  globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+  const facts = vi.spyOn(harnessClient, "getRelationFacts").mockImplementation(async (payload) => ({
+    ok: true,
+    facet: "facts",
+    facts: [{ anchor: payload.cursor ? "fact/second" : "fact/first", text: "fact", category: "finding" }],
+    domainTypes: [],
+    warnings: [],
+    page: { limit: 500, cursor: payload.cursor ?? null, nextCursor: payload.cursor ? null : "facts-next" },
+  }));
+  const edges = vi
+    .spyOn(harnessClient, "getRelationGraph")
+    .mockImplementation(async (payload) => page({}, payload.cursor ? null : "edges-next"));
+  let current: { facts: ReturnType<typeof usePaletteFactsQuery>; edges: ReturnType<typeof useActiveEdgesQuery> };
+  function Probe() {
+    current = { facts: usePaletteFactsQuery("repo", true), edges: useActiveEdgesQuery("repo", true) };
+    return null;
+  }
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const host = document.createElement("div"),
+    root = createRoot(host);
+  const settle = async () => {
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    });
+  };
+  try {
+    await act(async () => {
+      root.render(createElement(QueryClientProvider, { client }, createElement(Probe)));
+    });
+    await settle();
+    expect(facts).toHaveBeenCalledTimes(1);
+    expect(edges).toHaveBeenCalledTimes(1);
+    expect(facts.mock.calls[0][0]).toEqual({ repoId: "repo", facet: "facts", limit: 500 });
+    expect(current!.facts.hasNextPage).toBe(true);
+    expect(current!.edges.hasNextPage).toBe(true);
+    facts.mockRejectedValueOnce(new Error("page unavailable"));
+    await act(async () => {
+      await current!.facts.fetchNextPage();
+    });
+    await settle();
+    expect(current!.facts.isError).toBe(true);
+    expect(current!.facts.facts.map((row) => row.anchor)).toEqual(["fact/first"]);
+    expect(current!.facts.hasNextPage).toBe(true);
+    await act(async () => {
+      await current!.facts.fetchNextPage();
+      await current!.edges.fetchNextPage();
+    });
+    await settle();
+    expect(facts.mock.calls.at(-1)![0].cursor).toBe("facts-next");
+    expect(edges.mock.calls.at(-1)![0]).toMatchObject({
+      facet: "edges",
+      state: "active",
+      limit: 500,
+      cursor: "edges-next",
+    });
+    expect(current!.facts.facts.map((row) => row.anchor)).toEqual(["fact/first", "fact/second"]);
+    expect(current!.facts.hasNextPage).toBe(false);
+    expect(current!.edges.hasNextPage).toBe(false);
+  } finally {
+    await act(async () => root.unmount());
+    client.clear();
+    vi.restoreAllMocks();
+  }
 });

--- a/packages/gui/test/triadic-graph-paging.vitest.ts
+++ b/packages/gui/test/triadic-graph-paging.vitest.ts
@@ -65,6 +65,8 @@ import { act, createElement } from "react";
 import { createRoot } from "react-dom/client";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { useActiveEdgesQuery, usePaletteFactsQuery } from "../src/renderer/triadic-data.ts";
+import { useFactFacetStats } from "../src/renderer/entities-data.ts";
+import { FactFacetLive, FactTypeVocabulary } from "../src/renderer/components/entityDoc/FactVocabularySections.tsx";
 import { harnessClient } from "../src/renderer/api-client.ts";
 
 it("facet hooks fetch one page on mount and retain rows through explicit continuation and failure", async () => {
@@ -73,7 +75,7 @@ it("facet hooks fetch one page on mount and retain rows through explicit continu
     ok: true,
     facet: "facts",
     facts: [{ anchor: payload.cursor ? "fact/second" : "fact/first", text: "fact", category: "finding" }],
-    domainTypes: [],
+    domainTypes: [{ domainType: "architecture", registeredByFactId: "F-AAAABBBB", workspaceRevision: 1 }],
     warnings: [],
     page: { limit: 500, cursor: payload.cursor ?? null, nextCursor: payload.cursor ? null : "facts-next" },
   }));
@@ -82,8 +84,14 @@ it("facet hooks fetch one page on mount and retain rows through explicit continu
     .mockImplementation(async (payload) => page({}, payload.cursor ? null : "edges-next"));
   let current: { facts: ReturnType<typeof usePaletteFactsQuery>; edges: ReturnType<typeof useActiveEdgesQuery> };
   function Probe() {
+    const stats = useFactFacetStats("repo", true);
     current = { facts: usePaletteFactsQuery("repo", true), edges: useActiveEdgesQuery("repo", true) };
-    return null;
+    return createElement(
+      "div",
+      null,
+      createElement(FactFacetLive, { stats }),
+      createElement(FactTypeVocabulary, { stats }),
+    );
   }
   const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   const host = document.createElement("div"),
@@ -103,6 +111,10 @@ it("facet hooks fetch one page on mount and retain rows through explicit continu
     expect(facts.mock.calls[0][0]).toEqual({ repoId: "repo", facet: "facts", limit: 500 });
     expect(current!.facts.hasNextPage).toBe(true);
     expect(current!.edges.hasNextPage).toBe(true);
+    expect(host.textContent).toContain("已加载 1 条 fact");
+    expect(host.textContent).toContain("统计仅含已加载事实");
+    expect(host.textContent).toContain("architecture");
+    expect(host.textContent).toContain("fact/F-AAAABBBB");
     facts.mockRejectedValueOnce(new Error("page unavailable"));
     await act(async () => {
       await current!.facts.fetchNextPage();
@@ -112,7 +124,7 @@ it("facet hooks fetch one page on mount and retain rows through explicit continu
     expect(current!.facts.facts.map((row) => row.anchor)).toEqual(["fact/first"]);
     expect(current!.facts.hasNextPage).toBe(true);
     await act(async () => {
-      await current!.facts.fetchNextPage();
+      host.querySelector("button")!.click();
       await current!.edges.fetchNextPage();
     });
     await settle();
@@ -126,6 +138,10 @@ it("facet hooks fetch one page on mount and retain rows through explicit continu
     expect(current!.facts.facts.map((row) => row.anchor)).toEqual(["fact/first", "fact/second"]);
     expect(current!.facts.hasNextPage).toBe(false);
     expect(current!.edges.hasNextPage).toBe(false);
+    expect(host.textContent).toContain("2 条 fact");
+    expect(host.textContent).toContain("finding · 2");
+    expect(host.textContent).not.toContain("统计仅含已加载事实");
+    expect(host.querySelector("button")).toBeNull();
   } finally {
     await act(async () => root.unmount());
     client.clear();

--- a/packages/gui/test/triadic-read-scoping.vitest.ts
+++ b/packages/gui/test/triadic-read-scoping.vitest.ts
@@ -100,7 +100,12 @@ const EMPTY_GRAPH_FACET = {
 type RecordedCall = { readonly method: string; readonly payload: Record<string, unknown> | null };
 
 function emptyRelationFacet(facet: string) {
-  return { ...EMPTY_GRAPH_FACET, facet };
+  return {
+    ...EMPTY_GRAPH_FACET,
+    facet,
+    domainTypes: [],
+    ...(facet === "edges" || facet === "facts" ? { page: { limit: 500, cursor: null, nextCursor: null } } : {}),
+  };
 }
 
 /** 直接以某个视图启动(等价于「会话停在这个页面」),避免先经过总览。 */

--- a/packages/kernel/src/projection/fact-event-projection.ts
+++ b/packages/kernel/src/projection/fact-event-projection.ts
@@ -307,8 +307,6 @@ export function searchFactRowsPage(
 ): { readonly rows: readonly FactProjectionRow[]; readonly page?: FactSearchPage } {
   const where: string[] = [],
     values: Array<string> = [];
-  // A ref list above SQLite's parameter budget filters in memory after the decode instead of in SQL.
-  const memoryRefs = filters.refs !== undefined && filters.refs.length > 900 ? new Set(filters.refs) : null;
   if (filters.query?.trim()) {
     where.push("fact.rowid IN (SELECT rowid FROM fact_fts WHERE fact_fts MATCH ?)");
     values.push(ftsQuery(filters.query));
@@ -317,12 +315,9 @@ export function searchFactRowsPage(
     where.push("fact.task_id = ?");
     values.push(filters.taskId);
   }
-  if (filters.refs !== undefined && memoryRefs === null) {
-    if (filters.refs.length === 0) where.push("0");
-    else {
-      where.push(`fact.ref IN (${filters.refs.map(() => "?").join(",")})`);
-      values.push(...filters.refs);
-    }
+  if (filters.refs !== undefined) {
+    where.push("fact.ref IN (SELECT value FROM json_each(?))");
+    values.push(JSON.stringify(filters.refs));
   }
   if (filters.confidence) {
     where.push("fact.confidence = ?");
@@ -357,8 +352,7 @@ export function searchFactRowsPage(
   if (pageLimit !== null) values.push(String(pageLimit + 1));
   const records = queryRows<FactRecord>(db, sql, ...values);
   const visible = pageLimit === null ? records : records.slice(0, pageLimit),
-    decoded = decodeFactRows(db, visible);
-  const rows = memoryRefs === null ? decoded : decoded.filter((row) => memoryRefs.has(row.ref));
+    rows = decodeFactRows(db, visible);
   if (pageLimit === null) return { rows };
   const hasMore = records.length > pageLimit,
     last = rows.at(-1);
@@ -388,21 +382,23 @@ export function readFactGraphRows(db: DatabaseSync): {
 
 export function readFactAnchorRows(db: DatabaseSync, refs?: readonly string[]): readonly FactAnchorRow[] {
   if (refs !== undefined && refs.length === 0) return [];
-  const scoped = refs !== undefined && refs.length <= 900;
-  const where = scoped ? ` WHERE ref IN (${refs.map(() => "?").join(",")})` : "";
-  const memoryRefs = refs !== undefined && !scoped ? new Set(refs) : null;
+  const where = refs === undefined ? "" : " WHERE ref IN (SELECT value FROM json_each(?))";
   const rows = queryRows<{
     readonly ref: string;
     readonly task_id: string | null;
     readonly fact_id: string;
     readonly op_id: string;
-  }>(db, `SELECT ref, task_id, fact_id, op_id FROM fact${where} ORDER BY ref`, ...(scoped ? refs : [])).map((row) => ({
+  }>(
+    db,
+    `SELECT ref, task_id, fact_id, op_id FROM fact${where} ORDER BY ref`,
+    ...(refs === undefined ? [] : [JSON.stringify(refs)]),
+  ).map((row) => ({
     factRef: row.ref,
     ...(row.task_id ? { taskId: row.task_id } : {}),
     factId: row.fact_id,
     sourcePath: `event:${row.op_id}`,
   }));
-  return memoryRefs === null ? rows : rows.filter((row) => memoryRefs.has(row.factRef));
+  return rows;
 }
 function checkedFactPageLimit(value: number): number {
   if (!Number.isSafeInteger(value) || value < 1 || value > 500)

--- a/packages/kernel/src/projection/task-query-projection.ts
+++ b/packages/kernel/src/projection/task-query-projection.ts
@@ -39,6 +39,7 @@ export interface TaskProjectionListQuery {
   readonly activePackagesOnly?: boolean;
 }
 export interface TaskRelationQuery {
+  readonly direction?: EntityRelationRecord["direction"];
   readonly entity?: string;
   readonly source?: string;
   readonly target?: string;
@@ -715,6 +716,10 @@ export function readTaskRelationPage(
   if (query.state !== undefined) {
     where.push(`${residual}state = ?`);
     values.push(query.state);
+  }
+  if (query.direction !== undefined) {
+    where.push("direction = ?");
+    values.push(query.direction);
   }
   if (query.ownerRef !== undefined) {
     where.push("owner_ref = ?");

--- a/packages/kernel/test/store/fact-ref-paging.test.ts
+++ b/packages/kernel/test/store/fact-ref-paging.test.ts
@@ -1,0 +1,129 @@
+// harness-test-tier: fast
+import assert from "node:assert/strict";
+import { DatabaseSync } from "node:sqlite";
+import test from "node:test";
+import {
+  createFactProjectionTables,
+  readFactAnchorRows,
+  searchFactRowsPage,
+} from "../../src/projection/fact-event-projection.ts";
+import { createRelationGraphProjectionTables } from "../../src/projection/relation-graph-projection.ts";
+import { createTaskRelationProjectionTable, readTaskRelationPage } from "../../src/projection/task-query-projection.ts";
+
+test("large ref sets filter before limit, preserve order, and never decode unrelated facts", () => {
+  const db = new DatabaseSync(":memory:");
+  try {
+    createFactProjectionTables(db);
+    createRelationGraphProjectionTables(db);
+    const insert = db.prepare(
+      "INSERT INTO fact(task_id,fact_id,ref,statement,evidence_source,observed_at,confidence,memory_class,op_id,workspace_revision,row_json) VALUES(NULL,?,?,?,'fixture',?,'high','semantic',?,1,?)",
+    );
+    for (let i = 0; i < 1200; i++) {
+      const factId = `F-${String(i).padStart(8, "0")}`,
+        ref = `fact/${factId}`,
+        observedAt = "2026-09-12T00:00:00.000Z";
+      // Unselected records are intentionally undecodable: a full-decode fallback must fail.
+      const row =
+        i < 1000
+          ? "invalid unrelated JSON"
+          : JSON.stringify({
+              schema: "fact-row/v1",
+              ref,
+              factId,
+              statement: ref,
+              observedAt,
+              memoryClass: "semantic",
+              confidence: "high",
+            });
+      insert.run(factId, ref, ref, observedAt, `op-${i}`, row);
+    }
+    const refs = [
+      ...Array.from({ length: 1000 }, (_, i) => `fact/missing-${i}`),
+      ...Array.from({ length: 200 }, (_, i) => `fact/F-${String(i + 1000).padStart(8, "0")}`),
+    ];
+    refs.push(refs.at(-1)!);
+    const collected: string[] = [];
+    let cursor: string | undefined;
+    do {
+      const result = searchFactRowsPage(db, { refs, limit: 73, ...(cursor ? { cursor } : {}) });
+      collected.push(...result.rows.map((row) => row.ref));
+      cursor = result.page!.nextCursor ?? undefined;
+    } while (cursor);
+    assert.deepEqual(collected, refs.slice(1000, 1200));
+    assert.deepEqual(
+      readFactAnchorRows(db, refs).map((row) => row.factRef),
+      collected,
+    );
+    assert.deepEqual(searchFactRowsPage(db, { refs: [], limit: 5 }).rows, []);
+    assert.deepEqual(readFactAnchorRows(db, []), []);
+    assert.equal(searchFactRowsPage(db, { refs, limit: 73, confidence: "low" }).rows.length, 0);
+  } finally {
+    db.close();
+  }
+});
+
+test("direction filtering precedes pagination in both relation sources", () => {
+  const db = new DatabaseSync(":memory:");
+  try {
+    createRelationGraphProjectionTables(db);
+    createTaskRelationProjectionTable(db);
+    db.exec("CREATE TABLE event_index(workspace_revision INTEGER, event_json TEXT)");
+    const edge = db.prepare("INSERT INTO relation_edge VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)"),
+      taskEdge = db.prepare("INSERT INTO task_relation VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)");
+    for (let i = 0; i < 6; i++) {
+      const relationId = `rel-${i}`;
+      if (i % 2 === 0) {
+        taskEdge.run(
+          relationId,
+          "a",
+          "task/a",
+          "task/b",
+          "relates",
+          i < 3 ? "undirected" : "directed",
+          "weak",
+          "declared",
+          "active",
+          "fixture",
+          "task/a",
+          "fixture",
+          i,
+          i,
+          "",
+        );
+        continue;
+      }
+      edge.run(
+        relationId,
+        "task/a",
+        "task/b",
+        "relates",
+        "active",
+        null,
+        "task/a",
+        i,
+        JSON.stringify({
+          relationId,
+          direction: i < 3 ? "undirected" : "directed",
+          strength: "weak",
+          origin: "declared",
+          rationale: "fixture",
+          sourcePath: "fixture",
+          recordIndex: i,
+        }),
+      );
+    }
+    const first = readTaskRelationPage(db, { direction: "directed", limit: 2 });
+    assert.deepEqual(
+      first.rows.map((row) => row.relationId),
+      ["rel-3", "rel-4"],
+    );
+    const second = readTaskRelationPage(db, { direction: "directed", limit: 2, cursor: first.page!.nextCursor! });
+    assert.deepEqual(
+      second.rows.map((row) => row.relationId),
+      ["rel-5"],
+    );
+    assert.equal(second.page!.nextCursor, null);
+  } finally {
+    db.close();
+  }
+});


### PR DESCRIPTION
# English

## Summary

fix-plan tail G3 (batch 20, R4-dormant-F1/F2/F5/F6): triadic facets are bounded and paged instead of returning unbounded edge/fact lists; fact refs are filtered before paging (F6 in kernel); the facet input contract gains the bound and the response carries paging so the GUI (`triadic-data.ts`, useActiveEdgesQuery / ⌘K facts) pages rather than misreading a truncated list as complete. Round-5 edges first page p50 204.13 ms → 13.02 ms; concatenated pages are byte-equal to the pre-change full result.

## Architectural Justification

A facet that can return the whole ledger is a full-history read on every GUI refresh. Bounding the input and paging the response is the only way to keep the read proportional to what the viewer sees; the old unbounded shape is removed rather than kept as a default.

## What Changed

- `packages/daemon/src/repo-cell-api.ts` facet whitelist and handlers, `task-query-read.ts`, `fact-event-projection.ts` (F6), protocol shape for facet input/paging.
- `packages/gui/src/renderer/triadic-data.ts` and vitest: paged consumption.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: production net +57 (bounded facets and paged responses replace unbounded lists).

## Machine-Readable Declarations

- None.

## Task And Scope

- Harness task: task_0a523d10b6bf8f68b11a718cb2 (parent task_6eba9c5d3a55735920aa4856f3)
- Branch: `codex/perf-g3`
- Public scope: triadic facet protocol and GUI consumer
- Private planning/evidence updated: yes (`artifacts/report.md`)
- Out of scope: Electron visual acceptance (CEO after merge)

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: not applicable
- Machine-check boundary: not applicable
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `466caf36a`
- Branch merge-base with `origin/main`: `466caf36a`
- Last `git fetch origin` time: 2026-09-12 UTC
- Sync method: branched from origin/main
- Public diff command: `git diff origin/main...codex/perf-g3`
- Private evidence commit/path: task_0a523d10b6bf8f68b11a718cb2 `artifacts/report.md`
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [x] `npm run typecheck` (worker, `tsc -b`)
- [ ] `npm run check`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts` (via `run-manifest-gates --changed origin/main`)
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Targeted 85 tests, 7 changed gates pass; round-5 recipe edges first page p50 204.13 → 13.02 ms; page concatenation byte-equal to the old full result.

## Review Evidence

- CEO ground-truth: read the worker report and the diff stat; commit authorship and scope checked.
- Reviewer subagent: closeout review after merge (one-path closeout)
- Human review: pending
- Blocking findings: none open

## Residual Risk

- First-page digest changes because of paging; the fixture digest anchor is re-baselined in the report.

## References

- Task: task_0a523d10b6bf8f68b11a718cb2

---

# 中文

## 概要

fix-plan 尾巴 G3（批20，R4-dormant-F1/F2/F5/F6）：triadic facet 有界并分页，不再返回无界的 edge/fact 列表；fact refs 在分页前过滤（F6 在 kernel）；facet 输入契约加上界、响应带分页，GUI（`triadic-data.ts` 的 useActiveEdgesQuery / ⌘K facts）改为分页消费，不会把截断当完整。round-5 edges 首页 p50 204.13 ms → 13.02 ms；分页拼接与修前全量逐字节相等。

## 架构辩护

能返回整本台账的 facet 就是 GUI 每次刷新一次全历史读。输入有界、响应分页是让读与所见成比例的唯一办法；旧的无界形状删除，不留作默认。

## 改动内容

- `packages/daemon/src/repo-cell-api.ts` facet 白名单与 handler、`task-query-read.ts`、`fact-event-projection.ts`（F6）、facet 输入/分页的协议 shape。
- `packages/gui/src/renderer/triadic-data.ts` 与 vitest：分页消费。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 删除的门或 fixture：none
- 生产净行数：production net +57 (bounded facets and paged responses replace unbounded lists)。

## 机器可读声明

- 无。

## 任务与范围

- Harness 任务：task_0a523d10b6bf8f68b11a718cb2（父 task_6eba9c5d3a55735920aa4856f3）
- 分支：`codex/perf-g3`
- 公开范围：triadic facet 协议与 GUI 消费面
- 私有计划/证据已更新：是（`artifacts/report.md`）
- 范围外：Electron 视觉验收（合入后 CEO 做）

## 版本影响

- 版本：不变
- 发布影响：不发布

## 治理声明

- 触碰受保护面：否
- 受保护面范围：不适用
- 授权：不适用
- 机器检查边界：不适用
- Break-glass：否
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- 基线 `origin/main` SHA：`466caf36a`
- 分支与 `origin/main` 的 merge-base：`466caf36a`
- 最近一次 `git fetch origin`：2026-09-12 UTC
- 同步方式：从 origin/main 开分支
- 公开 diff 命令：`git diff origin/main...codex/perf-g3`
- 私有证据路径：task_0a523d10b6bf8f68b11a718cb2 的 `artifacts/report.md`
- 评审证据路径：本 PR 的评审证据节
- GitHub Actions `rewrite-ci` run URL：本 PR 待跑
- 定向 85 项、7 个 changed gates 通过；round-5 配方 edges 首页 p50 204.13 → 13.02 ms；分页拼接与旧全量逐字节相等。

## 评审证据

- CEO 事实核对：读过 worker 报告与 diff 统计；核过提交人与范围。
- 评审子代理：合入后走一条路收口评审
- 人工评审：待定
- 阻塞发现：无

## 残余风险

- 首页 digest 因分页改变；fixture digest 锚在报告里重新基线。

## 参考

- 任务：task_0a523d10b6bf8f68b11a718cb2

