### PR TITLE
fix: preserve tracked sources and Git identity in isolated tests

### DIFF
--- a/tools/dispatch-isolated-test.mjs
+++ b/tools/dispatch-isolated-test.mjs
@@ -2,7 +2,8 @@
 
 import { randomUUID } from "node:crypto";
 import { execFileSync, spawn } from "node:child_process";
-import { lstatSync } from "node:fs";
+import { cpSync, mkdirSync, mkdtempSync, readdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 import {
@@ -23,22 +24,6 @@ const dispatchCommand = Object.freeze({
     ),
   ),
 });
-export const sourceRootAllowlist = Object.freeze([
-  ".github",
-  ".gitignore",
-  "README.md",
-  "docs-release",
-  "eslint.config.mjs",
-  "prettier.config.mjs",
-  "package-lock.json",
-  "package.json",
-  "packages",
-  "scripts",
-  "skills",
-  "tools",
-  "tsconfig.json",
-]);
-
 export function parseDispatchArgs(argv) {
   const parsed = parseToolOptions(dispatchCommand, argv);
   if (parsed.help) return { help: true };
@@ -84,19 +69,39 @@ export function sourceRsyncArgs(sourceRoot, destination) {
   return ["-a", "--delete", "--from0", "--files-from=-", `${sourceRoot}/`, destination];
 }
 
-export function sourceFileList(
-  sourceRoot = repoRoot,
-  allowedRoots = sourceRootAllowlist,
-  candidates = gitWorktreeFiles(sourceRoot),
-) {
-  const allowed = new Set(allowedRoots);
-  return candidates
-    .filter(
-      (entry) =>
-        entry !== "" && !path.isAbsolute(entry) && entry.split("/")[0] !== ".." && allowed.has(entry.split("/")[0]),
-    )
-    .filter((entry) => pathExists(path.join(sourceRoot, entry)))
+export function sourceFileList(sourceRoot = repoRoot) {
+  return execFileSync("git", ["-C", sourceRoot, "ls-files", "--cached", "-z"])
+    .toString("utf8")
+    .split("\0")
+    .filter(Boolean)
     .sort();
+}
+
+export function prepareSource(sourceRoot, snapshotRoot) {
+  const files = sourceFileList(sourceRoot);
+  // Two generations support both source identity (HEAD) and the clean-tree shard baseline (HEAD^).
+  execFileSync("git", [
+    "clone",
+    "--quiet",
+    "--no-checkout",
+    "--depth",
+    "2",
+    "--template=",
+    pathToFileURL(sourceRoot).href,
+    snapshotRoot,
+  ]);
+  execFileSync("git", ["-C", snapshotRoot, "remote", "remove", "origin"]);
+  rmSync(path.join(snapshotRoot, ".git", "logs"), { recursive: true, force: true });
+  execFileSync("git", ["-C", snapshotRoot, "reset", "--mixed", "HEAD"], { stdio: "ignore" });
+  for (const file of files) {
+    const target = path.join(snapshotRoot, file);
+    mkdirSync(path.dirname(target), { recursive: true });
+    cpSync(path.join(sourceRoot, file), target, { verbatimSymlinks: true });
+  }
+  const metadata = readdirSync(path.join(snapshotRoot, ".git"), { recursive: true, withFileTypes: true })
+    .filter((entry) => !entry.isDirectory())
+    .map((entry) => path.relative(snapshotRoot, path.join(entry.parentPath, entry.name)).split(path.sep).join("/"));
+  return [...files, ...metadata].sort();
 }
 
 export function posixTestScript(workspaceRoot, stateRoot, options) {
@@ -143,26 +148,36 @@ export async function main(argv = process.argv.slice(2)) {
   console.log(
     `[test-isolation] target=${options.target} selection=${options.tier ? `tier:${options.tier}` : `file:${options.file}`} run=${runId}`,
   );
-  const exitCode =
-    options.target === "ubuntu"
-      ? await runUbuntu(options, runId)
-      : options.target === "docker"
-        ? await runDocker(options, runId)
-        : await runWindows(options, runId);
+  const snapshotRoot = mkdtempSync(path.join(tmpdir(), `${runId}-`));
+  let exitCode;
+  try {
+    const files = prepareSource(repoRoot, snapshotRoot);
+    exitCode =
+      options.target === "ubuntu"
+        ? await runUbuntu(options, runId, snapshotRoot, files)
+        : options.target === "docker"
+          ? await runDocker(options, runId, snapshotRoot, files)
+          : await runWindows(options, runId, snapshotRoot, files);
+  } finally {
+    rmSync(snapshotRoot, { recursive: true, force: true });
+  }
   console.log(`[test-isolation] target=${options.target} exit=${exitCode} duration_ms=${Date.now() - startedAt}`);
   return exitCode;
 }
 
-async function runUbuntu(options, runId) {
+async function runUbuntu(options, runId, snapshotRoot, files) {
   const workspaceRoot = `/tmp/${runId}`;
   const stateRoot = `${workspaceRoot}/.test-isolation-state`;
-  const files = sourceFileList();
   let exitCode = 1;
   try {
     console.log(`[test-isolation] sync=rsync destination=ubuntu:${workspaceRoot}`);
     if (
       (await run("ssh", ["ubuntu", `mkdir -p -- ${shellQuote(workspaceRoot)}`])) === 0 &&
-      (await runWithInput("rsync", sourceRsyncArgs(repoRoot, `ubuntu:${workspaceRoot}/`), encodeFileList(files))) === 0
+      (await runWithInput(
+        "rsync",
+        sourceRsyncArgs(snapshotRoot, `ubuntu:${workspaceRoot}/`),
+        encodeFileList(files),
+      )) === 0
     ) {
       exitCode = await run("ssh", ["ubuntu", posixTestScript(workspaceRoot, stateRoot, options)]);
     }
@@ -173,7 +188,7 @@ async function runUbuntu(options, runId) {
   return exitCode;
 }
 
-async function runDocker(options, runId) {
+async function runDocker(options, runId, snapshotRoot, files) {
   const container = runId;
   const workspaceRoot = "/workspace";
   const stateRoot = `/tmp/${runId}`;
@@ -196,7 +211,7 @@ async function runDocker(options, runId) {
     ) {
       created = true;
       console.log(`[test-isolation] sync=tar destination=docker:${container}:${workspaceRoot}`);
-      if ((await copyArchive(["docker", "cp", "-", `${container}:${workspaceRoot}`])) === 0)
+      if ((await copyArchive(["docker", "cp", "-", `${container}:${workspaceRoot}`], snapshotRoot, files)) === 0)
         exitCode = await run("docker", ["start", "-a", container]);
     }
   } finally {
@@ -208,7 +223,7 @@ async function runDocker(options, runId) {
   return exitCode;
 }
 
-async function runWindows(options, runId) {
+async function runWindows(options, runId, snapshotRoot, files) {
   let workspaceRoot;
   let exitCode = 1;
   try {
@@ -223,7 +238,9 @@ async function runWindows(options, runId) {
     if (workspaceRoot) {
       console.log(`[test-isolation] sync=tar destination=windows:${workspaceRoot}`);
       const extractScript = `$ProgressPreference = 'SilentlyContinue'\ntar -xf - -C ${powerShellLiteral(workspaceRoot)}`;
-      if ((await copyArchive(["ssh", "windows-vm", ...powerShellArgs(extractScript).slice(1)])) === 0) {
+      if (
+        (await copyArchive(["ssh", "windows-vm", ...powerShellArgs(extractScript).slice(1)], snapshotRoot, files)) === 0
+      ) {
         exitCode = await run(
           "ssh",
           powerShellArgs(powerShellTestScript(workspaceRoot, `${workspaceRoot}\\.test-isolation-state`, options)),
@@ -254,9 +271,9 @@ function powerShellArgs(script) {
   ];
 }
 
-async function copyArchive(destinationArgs) {
-  const input = encodeFileList(sourceFileList());
-  const archive = spawn("tar", sourceArchiveArgs(), {
+async function copyArchive(destinationArgs, snapshotRoot, files) {
+  const input = encodeFileList(files);
+  const archive = spawn("tar", sourceArchiveArgs(process.platform, snapshotRoot), {
     stdio: ["pipe", "pipe", "pipe"],
     env: { ...process.env, COPYFILE_DISABLE: "1" },
   });
@@ -316,23 +333,6 @@ function formatCommand(command, args) {
   const encodedAt = args.indexOf("-EncodedCommand");
   const visible = encodedAt === -1 ? args : [...args.slice(0, encodedAt + 1), "<encoded>"];
   return [command, ...visible].map(shellQuote).join(" ");
-}
-
-function gitWorktreeFiles(sourceRoot) {
-  return execFileSync("git", ["-C", sourceRoot, "ls-files", "--cached", "--others", "--exclude-standard", "-z"])
-    .toString("utf8")
-    .split("\0")
-    .filter(Boolean);
-}
-
-function pathExists(target) {
-  try {
-    lstatSync(target);
-    return true;
-  } catch (error) {
-    if (error?.code === "ENOENT") return false;
-    throw error;
-  }
 }
 
 function encodeFileList(files) {

--- a/tools/dispatch-isolated-test.test.mjs
+++ b/tools/dispatch-isolated-test.test.mjs
@@ -1,7 +1,7 @@
 // harness-test-tier: fast
 import assert from "node:assert/strict";
 import { execFileSync, spawnSync } from "node:child_process";
-import { existsSync, mkdirSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -11,7 +11,7 @@ import {
   powerShellTestScript,
   sourceArchiveArgs,
   sourceFileList,
-  sourceRootAllowlist,
+  prepareSource,
   sourceRsyncArgs,
   testRunnerArgs,
 } from "./dispatch-isolated-test.mjs";
@@ -100,24 +100,6 @@ test("GUI routing preserves native tests and accepts registered TSX", () => {
   ]);
 });
 
-test("source root allowlist contains only current test inputs", () => {
-  assert.deepEqual(sourceRootAllowlist, [
-    ".github",
-    ".gitignore",
-    "README.md",
-    "docs-release",
-    "eslint.config.mjs",
-    "prettier.config.mjs",
-    "package-lock.json",
-    "package.json",
-    "packages",
-    "scripts",
-    "skills",
-    "tools",
-    "tsconfig.json",
-  ]);
-});
-
 test("macOS source archives omit extended attributes while other hosts keep portable tar arguments", () => {
   assert.deepEqual(sourceArchiveArgs("darwin").slice(0, 2), ["--no-xattrs", "-cf"]);
   assert.equal(sourceArchiveArgs("linux").includes("--no-xattrs"), false);
@@ -136,62 +118,57 @@ test("source archives consume a structural NUL file list without exclusion patte
   });
 });
 
-test("source file discovery keeps worktree changes but drops ignored output and unknown roots", () => {
+test("source discovery includes every tracked root and excludes untracked and ignored files", () => {
   withFixture(({ source }) => {
-    execFileSync("git", ["-C", source, "init", "--quiet"]);
-    writeFileSync(path.join(source, ".gitignore"), "dist/\n");
-    write(source, "packages/tracked.ts");
+    seedRepository(source);
     write(source, "packages/untracked.ts");
-    write(source, "prettier.config.mjs");
-    write(source, "packages/gui/dist/ignored.js");
-    write(source, "future-private/untracked.txt");
-    execFileSync("git", ["-C", source, "add", ".gitignore", "packages/tracked.ts"]);
+    write(source, "dist/ignored.js");
     assert.deepEqual(sourceFileList(source), [
       ".gitignore",
-      "packages/tracked.ts",
-      "packages/untracked.ts",
+      "future-root/space name.txt",
       "prettier.config.mjs",
+      "tools/kept.txt",
     ]);
   });
 });
 
-test("tar copies the complete allowlist and rejects every other repository root", () => {
-  withFixture(({ source, destination }) => {
-    seedCompletePolicyFixture(source);
-    extractArchive(source, destination, sourceRootAllowlist);
-    assert.deepEqual(rootEntries(destination), ["packages", "tools"]);
-    console.log(`[archive-implementation] ${toolVersion("tar")}`);
-  });
-});
-
-test("tar file lists preserve a nested harness directory", () => {
-  withFixture(({ source, destination }) => {
-    write(source, "harness/root.txt");
-    write(source, "tmp/benchmarks/codex-hostnet-patch/harness/nested.txt");
-    extractArchive(source, destination, ["tmp"]);
-    assert.equal(existsSync(path.join(destination, "harness")), false);
-    assert.equal(existsSync(path.join(destination, "tmp/benchmarks/codex-hostnet-patch/harness/nested.txt")), true);
-  });
-});
-
-test("rsync copies the complete allowlist and rejects every other repository root", { skip: rsyncSkip }, () => {
-  withFixture(({ source, destination }) => {
-    seedCompletePolicyFixture(source);
-    syncWithRsync(source, destination, sourceRootAllowlist);
-    assert.deepEqual(rootEntries(destination), ["packages", "tools"]);
-    console.log(`[rsync-implementation] ${toolVersion("rsync")}`);
-  });
-});
-
-test("rsync file lists preserve a nested harness directory", { skip: rsyncSkip }, () => {
-  withFixture(({ source, destination }) => {
-    write(source, "harness/root.txt");
-    write(source, "tmp/benchmarks/codex-hostnet-patch/harness/nested.txt");
-    syncWithRsync(source, destination, ["tmp"]);
-    assert.equal(existsSync(path.join(destination, "harness")), false);
-    assert.equal(existsSync(path.join(destination, "tmp/benchmarks/codex-hostnet-patch/harness/nested.txt")), true);
-  });
-});
+for (const transport of ["tar", "rsync"]) {
+  test(
+    `${transport} preserves tracked content and independent Git identity from a linked worktree`,
+    { skip: transport === "rsync" ? rsyncSkip : false },
+    () => {
+      withFixture(({ source, destination }) => {
+        seedRepository(source);
+        const worktree = path.join(source, "linked");
+        execFileSync("git", ["-C", source, "worktree", "add", "--quiet", "--detach", worktree]);
+        writeFileSync(path.join(worktree, "tools/kept.txt"), "dirty tracked content\n");
+        write(worktree, "private/untracked.txt");
+        const snapshot = path.join(source, "snapshot");
+        const files = prepareSource(worktree, snapshot);
+        assert.deepEqual(
+          files.filter((file) => !file.startsWith(".git/")),
+          sourceFileList(worktree),
+        );
+        const head = gitText(worktree, ["rev-parse", "HEAD"]);
+        const parent = gitText(worktree, ["rev-parse", "HEAD^"]);
+        if (transport === "tar") extractArchive(snapshot, destination, files);
+        else syncWithRsync(snapshot, destination, files);
+        rmSync(source, { recursive: true, force: true });
+        assert.equal(gitText(destination, ["rev-parse", "HEAD"]), head);
+        assert.equal(gitText(destination, ["rev-parse", "HEAD^"]), parent);
+        assert.equal(gitText(destination, ["show", "HEAD:tools/kept.txt"]), "tools/kept.txt");
+        assert.equal(gitText(destination, ["show", "HEAD^:tools/kept.txt"]), "tools/kept.txt");
+        assert.match(gitText(destination, ["status", "--porcelain"]), /M tools\/kept.txt/u);
+        assert.equal(readFileSync(path.join(destination, "tools/kept.txt"), "utf8"), "dirty tracked content\n");
+        assert.equal(readFileSync(path.join(destination, "prettier.config.mjs"), "utf8"), "prettier.config.mjs\n");
+        assert.equal(existsSync(path.join(destination, "future-root/space name.txt")), true);
+        assert.equal(existsSync(path.join(destination, "private")), false);
+        assert.equal(gitText(destination, ["remote"]), "");
+        console.log(`[${transport}-implementation] ${toolVersion(transport)}`);
+      });
+    },
+  );
+}
 
 test("remote scripts preflight before executing tests with a dedicated root and id", () => {
   const options = { tier: "integration", file: undefined };
@@ -235,24 +212,22 @@ function write(root, relativePath) {
   writeFileSync(target, `${relativePath}\n`);
 }
 
-function seedCompletePolicyFixture(root) {
-  for (const entry of [
-    "harness",
-    ".harness",
-    ".harness-private",
-    ".worktrees",
-    "tmp",
-    ".harness-old-generation-20260818",
-    "harness-old-generation-20260818",
-    "future-private",
-  ])
-    write(root, `${entry}/excluded.txt`);
-  write(root, "packages/kept.txt");
-  write(root, "tools/kept.txt");
+function seedRepository(root) {
+  execFileSync("git", ["init", "--quiet", root]);
+  execFileSync("git", ["-C", root, "config", "user.name", "Dispatch Test"]);
+  execFileSync("git", ["-C", root, "config", "user.email", "dispatch@example.invalid"]);
+  writeFileSync(path.join(root, ".gitignore"), "dist/\n");
+  for (const file of ["tools/kept.txt", "prettier.config.mjs", "future-root/space name.txt"]) write(root, file);
+  execFileSync("git", ["-C", root, "add", "."]);
+  execFileSync("git", ["-C", root, "commit", "--quiet", "-m", "test: seed sources"]);
+  execFileSync("git", ["-C", root, "commit", "--quiet", "--allow-empty", "-m", "test: second generation"]);
 }
 
-function extractArchive(source, destination, allowedRoots) {
-  const files = sourceFileList(source, allowedRoots, fixtureFiles(source));
+function gitText(root, args) {
+  return execFileSync("git", ["-C", root, ...args], { encoding: "utf8" }).trim();
+}
+
+function extractArchive(source, destination, files) {
   const archive = spawnSync("tar", sourceArchiveArgs(process.platform, source), {
     input: encodeFileList(files),
     maxBuffer: 10 * 1024 * 1024,
@@ -262,8 +237,7 @@ function extractArchive(source, destination, allowedRoots) {
   assert.equal(extracted.status, 0, extracted.stderr.toString());
 }
 
-function syncWithRsync(source, destination, allowedRoots) {
-  const files = sourceFileList(source, allowedRoots, fixtureFiles(source));
+function syncWithRsync(source, destination, files) {
   const result = spawnSync("rsync", sourceRsyncArgs(source, `${destination}/`), {
     input: encodeFileList(files),
     encoding: "utf8",
@@ -271,22 +245,8 @@ function syncWithRsync(source, destination, allowedRoots) {
   assert.equal(result.status, 0, result.stderr);
 }
 
-function fixtureFiles(root, directory = root) {
-  const files = [];
-  for (const entry of readdirSync(directory, { withFileTypes: true })) {
-    const target = path.join(directory, entry.name);
-    if (entry.isDirectory()) files.push(...fixtureFiles(root, target));
-    else files.push(path.relative(root, target).split(path.sep).join("/"));
-  }
-  return files;
-}
-
 function encodeFileList(files) {
   return Buffer.from(files.length === 0 ? "" : `${files.join("\0")}\0`);
-}
-
-function rootEntries(root) {
-  return readdirSync(root).sort((left, right) => left.localeCompare(right));
 }
 
 function toolVersion(command) {


### PR DESCRIPTION
# English

## Summary

`tools/dispatch-isolated-test.mjs` synced the source tree to the Ubuntu VM without `.git` and while filtering nine tracked files, so three fast-tier checks failed before their logic ran while the same commit was green on GitHub. The sync set is now the full `git ls-files` set (2,486 files, zero omissions) plus standalone Git identity metadata that resolves HEAD/HEAD^; the formatter carries a regression assertion.

## Architectural Justification

-

## What Changed

- `tools/dispatch-isolated-test.mjs` and its tests: tracked-set sync and Git identity.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: tools change; tests 12/12.

## Machine-Readable Declarations

- None.

## Task And Scope

- Harness task: task_0666ce08485fcdf3a4608550de (parent task_4f7965fc895253bf70a4020f42)
- Branch: `codex/isolated-rsync`
- Public scope: isolated test dispatcher inputs
- Private planning/evidence updated: yes (`artifacts/report.md`)
- Out of scope: none

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: not applicable
- Machine-check boundary: not applicable
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `466caf36a`
- Branch merge-base with `origin/main`: `466caf36a`
- Last `git fetch origin` time: 2026-09-12 UTC
- Sync method: branched from origin/main
- Public diff command: `git diff origin/main...codex/isolated-rsync`
- Private evidence commit/path: task_0666ce08485fcdf3a4608550de `artifacts/report.md`
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [x] `npm run typecheck` (worker, `tsc -b`)
- [ ] `npm run check`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts` (via `run-manifest-gates --changed origin/main`)
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- VM fast tier at the same commit 688/688; targeted 12/12; eslint, line-density, manifest gates pass.

## Review Evidence

- CEO ground-truth: read the worker report and the diff stat; commit authorship and scope checked.
- Reviewer subagent: closeout review after merge (one-path closeout)
- Human review: pending
- Blocking findings: none open

## Residual Risk

- Same-commit GitHub CI for this branch is the authority; the VM run is the worker's evidence.

## References

- Task: task_0666ce08485fcdf3a4608550de

---

# 中文

## 概要

`tools/dispatch-isolated-test.mjs` 往 Ubuntu VM 同步源树时不带 `.git`、且过滤掉九个已跟踪文件，fast tier 有三项在测试逻辑前就失败而同 commit 在 GitHub 绿。同步集合改为 `git ls-files` 全集（2,486 个文件零遗漏）加能解析 HEAD/HEAD^ 的独立 Git 元数据；formatter 带防回归断言。

## 架构辩护

-

## 改动内容

- `tools/dispatch-isolated-test.mjs` 及其测试：tracked 集合同步与 Git 身份。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 删除的门或 fixture：none
- 生产净行数：tools change; tests 12/12。

## 机器可读声明

- 无。

## 任务与范围

- Harness 任务：task_0666ce08485fcdf3a4608550de（父 task_4f7965fc895253bf70a4020f42）
- 分支：`codex/isolated-rsync`
- 公开范围：隔离派测器输入
- 私有计划/证据已更新：是（`artifacts/report.md`）
- 范围外：无

## 版本影响

- 版本：不变
- 发布影响：不发布

## 治理声明

- 触碰受保护面：否
- 受保护面范围：不适用
- 授权：不适用
- 机器检查边界：不适用
- Break-glass：否
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- 基线 `origin/main` SHA：`466caf36a`
- 分支与 `origin/main` 的 merge-base：`466caf36a`
- 最近一次 `git fetch origin`：2026-09-12 UTC
- 同步方式：从 origin/main 开分支
- 公开 diff 命令：`git diff origin/main...codex/isolated-rsync`
- 私有证据路径：task_0666ce08485fcdf3a4608550de 的 `artifacts/report.md`
- 评审证据路径：本 PR 的评审证据节
- GitHub Actions `rewrite-ci` run URL：本 PR 待跑
- VM 同 commit fast tier 688/688；定向 12/12；eslint、line-density、manifest gates 通过。

## 评审证据

- CEO 事实核对：读过 worker 报告与 diff 统计；核过提交人与范围。
- 评审子代理：合入后走一条路收口评审
- 人工评审：待定
- 阻塞发现：无

## 残余风险

- 本分支同 commit 的 GitHub CI 为权威；VM 运行是 worker 证据。

## 参考

- 任务：task_0666ce08485fcdf3a4608550de

