### PR TITLE
feat: support artifact delivery and explicit task preset migration

### DIFF
--- a/packages/cli/src/cli/thin-command-task-admin.ts
+++ b/packages/cli/src/cli/thin-command-task-admin.ts
@@ -1,16 +1,6 @@
 import type { SafePath } from "../../../daemon/src/protocol/daemon-protocol.contract.ts";
-import {
-  accepted,
-  nonEmpty,
-  optionalFlags,
-  readFlags,
-  rejectInput,
-  rejected,
-} from "./thin-command-flags.ts";
-import type {
-  ThinCliInputDirectory,
-  ThinParseResult,
-} from "./thin-command-types.ts";
+import { accepted, nonEmpty, optionalFlags, readFlags, rejectInput, rejected } from "./thin-command-flags.ts";
+import type { ThinCliInputDirectory, ThinParseResult } from "./thin-command-types.ts";
 
 export function parseContractMigrate(
   args: readonly string[],
@@ -23,12 +13,12 @@ export function parseContractMigrate(
   if (!f.ok) return rejected(f.code, f.nextAction, json);
   const dryRun = f.booleans.has("--dry-run"),
     apply = f.booleans.has("--apply");
-  if (dryRun === apply)
-    return rejectInput(inputs, "task-contract-migrate", "--dry-run", json);
+  if (dryRun === apply) return rejectInput(inputs, "task-contract-migrate", "--dry-run", json);
   return accepted(rootDir, repoId, json, {
     kind: "task-contract-migrate",
     mode: dryRun ? "dry-run" : "apply",
     ...(f.one.get("--task") ? { taskId: f.one.get("--task") } : {}),
+    ...(f.one.get("--to-preset") ? { toPresetId: f.one.get("--to-preset") } : {}),
   });
 }
 
@@ -45,26 +35,15 @@ export function parseTaskDelete(
     hard = f.one.get("--hard"),
     reason = f.one.get("--reason"),
     confirm = f.one.get("--confirm");
-  if (
-    Boolean(soft) === Boolean(hard) ||
-    (soft && !reason) ||
-    (hard && confirm !== hard)
-  )
-    return rejectInput(
-      inputs,
-      "task-delete",
-      soft && !reason ? "--reason" : hard ? "--confirm" : "--soft",
-      json,
-    );
+  if (Boolean(soft) === Boolean(hard) || (soft && !reason) || (hard && confirm !== hard))
+    return rejectInput(inputs, "task-delete", soft && !reason ? "--reason" : hard ? "--confirm" : "--soft", json);
   return accepted(rootDir, repoId, json, {
     kind: "task-delete",
     taskId: soft ?? hard,
     mode: soft ? "soft" : "hard",
     ...(reason ? { reason } : {}),
     ...(confirm ? { confirm } : {}),
-    ...(f.one.get("--deleted-by")
-      ? { deletedBy: f.one.get("--deleted-by") }
-      : {}),
+    ...(f.one.get("--deleted-by") ? { deletedBy: f.one.get("--deleted-by") } : {}),
   });
 }
 
@@ -85,11 +64,7 @@ export function parseTaskArchive(
     return rejectInput(inputs, "task-archive", "--ids", json);
   return accepted(rootDir, repoId, json, {
     kind: "task-archive",
-    ...(taskId
-      ? { taskId }
-      : ids
-        ? { taskIds: ids.split(",").filter(nonEmpty) }
-        : { filter }),
+    ...(taskId ? { taskId } : ids ? { taskIds: ids.split(",").filter(nonEmpty) } : { filter }),
     reason: f.one.get("--reason"),
     ...optionalFlags(f.one, [
       ["--before", "before"],

--- a/packages/cli/test/cli-lifecycle-user-journey-stress-scenario-1.integration.test.ts
+++ b/packages/cli/test/cli-lifecycle-user-journey-stress-scenario-1.integration.test.ts
@@ -156,9 +156,10 @@ test("CLI changes-requested recovery releases and re-enters a new execution", as
     await expectApplied(fixture, ["task", "start", taskId, "--execution-id", firstExecutionId], workerEnvironment);
     await expectApplied(fixture, ["doc", "sync", "--submit", "--task", taskId], workerEnvironment);
     writeFileSync(path.join(packageRoot, "artifacts", "recovery.txt"), "Changes-requested recovery execution.\n");
+    const artifactSync = await expectApplied(fixture, ["doc", "sync", "--submit", "--task", taskId], workerEnvironment);
     writeFileSync(
       closeoutPath,
-      "# Closeout\n\n## Summary\n\nFirst execution needs another iteration.\n\n" +
+      `# Closeout\n\n## Summary\n\nFirst execution needs another iteration: artifact:${packagePath}/artifacts/recovery.txt@${artifactSync.revision}\n\n` +
         "## Verification\n\nChanges-requested recovery exercised.\n\n" +
         "## Residual Risk\n\n已知缺口：review requested another iteration\n\n" +
         "## Same Mechanism Elsewhere\n\nRecovery lifecycle.\n",
@@ -193,7 +194,7 @@ test("CLI changes-requested recovery releases and re-enters a new execution", as
     await expectApplied(fixture, ["task", "start", taskId, "--execution-id", secondExecutionId], workerEnvironment);
     writeFileSync(
       closeoutPath,
-      "# Closeout\n\n## Summary\n\nSecond execution addresses the requested verification note.\n\n" +
+      `# Closeout\n\n## Summary\n\nSecond execution addresses the verification note: artifact:${packagePath}/artifacts/recovery.txt@${artifactSync.revision}\n\n` +
         "## Verification\n\nRequested verification note addressed.\n\n" +
         "## Residual Risk\n\nNone.\n\n## Same Mechanism Elsewhere\n\nRecovery lifecycle.\n",
     );

--- a/packages/cli/test/cli-lifecycle-user-journey-stress.fixture.ts
+++ b/packages/cli/test/cli-lifecycle-user-journey-stress.fixture.ts
@@ -131,9 +131,10 @@ async function runChain(
     ],
     workerEnvironment,
   );
+  const artifactSync = await expectApplied(fixture, ["doc", "sync", "--submit", "--task", taskId], workerEnvironment);
   writeFileSync(
     closeoutPath,
-    "# Closeout\n\n## Summary\n\nSynthetic chain complete.\n\n" +
+    `# Closeout\n\n## Summary\n\nSynthetic chain complete: artifact:${packagePath}/artifacts/chain.txt@${artifactSync.revision}\n\n` +
       "## Verification\n\nCLI stress path.\n\n## Residual Risk\n\nNone.\n\n" +
       "## Same Mechanism Elsewhere\n\nNo production behavior changed.\n",
   );

--- a/packages/cli/test/daemon-autostart-cli-scenario-2.test.ts
+++ b/packages/cli/test/daemon-autostart-cli-scenario-2.test.ts
@@ -346,11 +346,6 @@ test("semantic sources and agent execution cross the daemon before transport-bou
     "applied",
   );
   writeFileSync(
-    path.join(fixture.root, "harness", closeoutPath),
-    "# Closeout\n\n## Summary\n\nExecutor attribution restored.\n\n## Verification\n\nEnd-to-end daemon flow.\n\n## Residual Risk\n\nNone.\n\n## Same Mechanism Elsewhere\n\nNot applicable to this fixture.\n",
-    "utf8",
-  );
-  writeFileSync(
     path.join(fixture.root, "harness", packagePath, "artifacts", "executor-axis.txt"),
     "Executor and review actor axes remain distinct.\n",
   );
@@ -362,6 +357,12 @@ test("semantic sources and agent execution cross the daemon before transport-bou
   );
   assert.equal(closeoutSync.outcome, "applied");
   published(fixture.root, fixture.userRoot, closeoutSync);
+  writeFileSync(
+    path.join(fixture.root, "harness", closeoutPath),
+    `# Closeout\n\n## Summary\n\nExecutor attribution restored: artifact:${packagePath}/artifacts/executor-axis.txt@${closeoutSync.revision}\n\n` +
+      "## Verification\n\nEnd-to-end daemon flow.\n\n## Residual Risk\n\nNone.\n\n" +
+      "## Same Mechanism Elsewhere\n\nNot applicable to this fixture.\n",
+  );
   assert.equal(
     run(fixture.root, fixture.userRoot, ["task", "submit", taskId, "--execution-id", executionId], "agent:claude-code")
       .outcome,

--- a/packages/cli/test/daemon-autostart-cli-scenario-2.test.ts
+++ b/packages/cli/test/daemon-autostart-cli-scenario-2.test.ts
@@ -4,6 +4,7 @@ import * as shared from "./daemon-autostart-cli.fixture.ts";
 
 const {
   assert,
+  git,
   spawnSync,
   chmodSync,
   existsSync,
@@ -357,9 +358,13 @@ test("semantic sources and agent execution cross the daemon before transport-bou
   );
   assert.equal(closeoutSync.outcome, "applied");
   published(fixture.root, fixture.userRoot, closeoutSync);
+  writeFileSync(path.join(fixture.root, "executor-axis.mjs"), "export const executorAxis = true;\n");
+  git(fixture.root, "add", "executor-axis.mjs");
+  git(fixture.root, "commit", "--quiet", "-m", "executor axis implementation");
+  const deliveryCommit = git(fixture.root, "rev-parse", "HEAD");
   writeFileSync(
     path.join(fixture.root, "harness", closeoutPath),
-    `# Closeout\n\n## Summary\n\nExecutor attribution restored: artifact:${packagePath}/artifacts/executor-axis.txt@${closeoutSync.revision}\n\n` +
+    `# Closeout\n\n## Summary\n\nExecutor attribution restored at ${deliveryCommit}.\n\n` +
       "## Verification\n\nEnd-to-end daemon flow.\n\n## Residual Risk\n\nNone.\n\n" +
       "## Same Mechanism Elsewhere\n\nNot applicable to this fixture.\n",
   );
@@ -372,7 +377,7 @@ test("semantic sources and agent execution cross the daemon before transport-bou
     run(
       fixture.root,
       fixture.userRoot,
-      ["task", "code-doc", "reconcile", taskId, "--path", `${packagePath}/artifacts/executor-axis.txt`],
+      ["task", "code-doc", "reconcile", taskId, "--path", "executor-axis.mjs"],
       "agent:claude-code",
     ).outcome,
     "applied",

--- a/packages/cli/test/release-cli-acceptance-scenario-1.integration.test.ts
+++ b/packages/cli/test/release-cli-acceptance-scenario-1.integration.test.ts
@@ -226,6 +226,12 @@ test("release acceptance: changes_requested rework keeps both same-named reports
       "verified",
     );
     const firstCommit = git(root, "rev-parse", "HEAD");
+    writeCloseout(
+      root,
+      packagePath,
+      `First round: artifact:${reportLogical}@${firstPublication.revision}`,
+      "已知缺口：The report needs a second execution.",
+    );
     run(root, userRoot, ["task", "submit", taskId, "--execution-id", firstExecutionId], worker);
     const firstSubmission = reader
       .read()
@@ -288,6 +294,7 @@ test("release acceptance: changes_requested rework keeps both same-named reports
       assert.equal(firstEvent.payload.executionId, firstExecutionId);
       assert.equal(secondEvent.payload.executionId, secondExecutionId);
     }
+    writeCloseout(root, packagePath, `Second round: artifact:${reportLogical}@${secondPublication.revision}`);
     run(root, userRoot, ["task", "submit", taskId, "--execution-id", secondExecutionId], worker);
     const secondSubmission = reader
       .read()

--- a/packages/cli/test/thin-command-routing.test.ts
+++ b/packages/cli/test/thin-command-routing.test.ts
@@ -440,3 +440,26 @@ test("task transition leaves lifecycle eligibility to the kernel", () => {
     true,
   );
 });
+
+test("task contract migration carries an explicit target preset through the thin CLI", () => {
+  for (const mode of ["--apply", "--dry-run"]) {
+    const parsed = parseThinCommand([
+      "task",
+      "contract",
+      "migrate",
+      "--task",
+      "task_example",
+      "--to-preset",
+      "docs-task",
+      mode,
+    ]);
+    assert.equal(parsed.ok, true);
+    if (parsed.ok)
+      assert.deepEqual(parsed.command.action, {
+        kind: "task-contract-migrate",
+        taskId: "task_example",
+        toPresetId: "docs-task",
+        mode: mode === "--apply" ? "apply" : "dry-run",
+      });
+  }
+});

--- a/packages/daemon/src/protocol/daemon-protocol-commands-task-surface.ts
+++ b/packages/daemon/src/protocol/daemon-protocol-commands-task-surface.ts
@@ -91,9 +91,12 @@ export const taskSurfaceProtocolCommands = Object.freeze([
     id: "task-contract-migrate",
     phase: "W3",
     path: ["task", "contract", "migrate"],
-    summary: "Plan or apply deterministic Task contract backfills; ambiguous Tasks remain manual.",
+    summary: "Backfill Task contracts, or explicitly migrate one inactive Task to an existing preset.",
     method: "repo.task.run",
     inputs: [
+      cliInput("--to-preset", "single", false, {
+        code: "invalid_field",
+      }),
       cliInput("--dry-run", "boolean", false, {
         code: "invalid_field",
       }),

--- a/packages/daemon/src/protocol/daemon-protocol-gui-types.ts
+++ b/packages/daemon/src/protocol/daemon-protocol-gui-types.ts
@@ -657,15 +657,7 @@ export interface ExecutionEvidenceProjection {
   }[];
 }
 
-export interface GuiSubmissionV1 {
-  readonly completionClaim: string;
-  readonly deliverables: readonly string[];
-  readonly outputs: readonly string[];
-  readonly verificationNotes: readonly string[];
-  readonly knownGaps: readonly string[];
-  readonly residualRisks: readonly string[];
-  readonly commitSha: string;
-}
+export type GuiSubmissionV1 = import("../../../kernel/src/index.ts").SubmissionV1;
 
 /** One projected document under a task package (paths relative to the package root, e.g. artifacts/report.md). */
 export interface TaskDocumentListEntryRow {

--- a/packages/daemon/src/protocol/daemon-protocol-validate-entities.ts
+++ b/packages/daemon/src/protocol/daemon-protocol-validate-entities.ts
@@ -143,6 +143,22 @@ export function sessionProvenance(value: unknown): boolean {
   );
 }
 
+function validArtifactDelivery(value: unknown): boolean {
+  return (
+    Array.isArray(value) &&
+    value.length > 0 &&
+    value.every(
+      (anchor) =>
+        exactRecord(anchor, ["path", "revision", "blobSha256"]) &&
+        nonEmpty(anchor.path) &&
+        Number.isSafeInteger(anchor.revision) &&
+        Number(anchor.revision) > 0 &&
+        typeof anchor.blobSha256 === "string" &&
+        /^[0-9a-f]{64}$/u.test(anchor.blobSha256),
+    )
+  );
+}
+
 export function validateGuiSubmission(value: unknown): readonly string[] {
   const fields = [
       "completionClaim",
@@ -152,6 +168,7 @@ export function validateGuiSubmission(value: unknown): readonly string[] {
       "knownGaps",
       "residualRisks",
       "commitSha",
+      ...(isJsonObject(value) && value.commitSha === null ? ["artifacts"] : []),
     ],
     entityId = validationEntityId(value, ["commitSha"], "submission:<unknown>"),
     shapeError = recordShapeError(entityId, value, fields);
@@ -163,8 +180,10 @@ export function validateGuiSubmission(value: unknown): readonly string[] {
   for (const field of ["deliverables", "outputs", "verificationNotes", "knownGaps", "residualRisks"] as const)
     if (!stringArray(value[field]))
       errors.push(validationError(entityId, field, value[field], "must be an array of non-empty strings"));
-  if (!sha(value.commitSha))
-    errors.push(validationError(entityId, "commitSha", value.commitSha, "must be a native 40-character commit SHA"));
+  if (value.commitSha === null ? !validArtifactDelivery(value.artifacts) : !sha(value.commitSha))
+    errors.push(
+      validationError(entityId, "commitSha", value.commitSha, "must identify a commit or accepted artifact revisions"),
+    );
   return errors;
 }
 
@@ -349,7 +368,7 @@ export function review(value: unknown): boolean {
     statusWord(reviewVerdictWords, value.verdict) &&
     actor(value.actor) &&
     stringArray(value.evidenceChecked) &&
-    sha(value.commitSha) &&
+    (value.commitSha === null ? digest(value.submissionDigest) : sha(value.commitSha)) &&
     iteration(value.iteration) &&
     digest(value.contentDigest) &&
     (value.submissionDigest === undefined || digest(value.submissionDigest))

--- a/packages/daemon/src/protocol/daemon-protocol-validate-task.ts
+++ b/packages/daemon/src/protocol/daemon-protocol-validate-task.ts
@@ -478,7 +478,7 @@ function snapshotFailurePaths(value: unknown, availability: unknown): readonly s
         !exactRecord(edge, ["edgeId", "from", "to", "on", "actorRole", "reason", "commitSha", "iteration"]) ||
         !nonEmpty(edge.edgeId) ||
         !nonEmpty(edge.reason) ||
-        !sha(edge.commitSha) ||
+        (edge.commitSha !== null && !sha(edge.commitSha)) ||
         !iteration(edge.iteration),
     )
   )

--- a/packages/daemon/src/repo-cell-command.ts
+++ b/packages/daemon/src/repo-cell-command.ts
@@ -222,15 +222,19 @@ export function buildCommand(
     if (!canonicalCodeDocPaths(action.paths, true))
       throw cellCodedError("invalid_command", "Pass explicit canonical completion.codeDocPaths to code-doc reconcile.");
     const witness = submittedExecutionWitness(action, snapshot, taskId, ["kind", "taskId", "paths"], action.paths);
+    if (witness.commitSha === null)
+      throw cellCodedError("invalid_proof", "Code/doc reconciliation requires a code delivery.");
     return normalizeTaskLifecycleCommand(bound, {
       type: "ReconcileCodeDoc",
       taskId,
       ...witness,
+      commitSha: witness.commitSha,
       witnessId: `code-doc-${createHash("sha256").update(JSON.stringify(witness)).digest("hex").slice(0, 16)}`,
     });
   }
   if (action.kind === "task-code-doc-repoint") {
     const witness = submittedExecutionWitness(action, snapshot, taskId, CODE_DOC_REPOINT_FIELDS, []);
+    if (witness.commitSha === null) throw cellCodedError("invalid_proof", "Code/doc repoint requires a code delivery.");
     return normalizeTaskLifecycleCommand(bound, {
       type: "RepointCodeDoc",
       taskId,

--- a/packages/daemon/src/repo-cell-completion.ts
+++ b/packages/daemon/src/repo-cell-completion.ts
@@ -29,7 +29,7 @@ export function publishCiWitness(
   const execution = snapshot.executions.find(
     (value) => value.executionId === executionId && value.iteration === snapshot.task?.iteration,
   );
-  if (!execution?.submission)
+  if (!execution?.submission?.commitSha)
     throw cell.cellCodedError("invalid_transition", "CI witness requires a submitted execution.");
   const judgment: CompletionEvidenceJudgment = judgeCompletionEvidence(evidence, { execution, gateId: "ci" });
   if (!judgment.accepted)

--- a/packages/daemon/src/repo-cell-execution-selection.ts
+++ b/packages/daemon/src/repo-cell-execution-selection.ts
@@ -54,7 +54,7 @@ export function reviewExecutionSelection(
   taskId: string,
 ): {
   readonly executionId: string;
-  readonly commitSha: string;
+  readonly commitSha: string | null;
   readonly iteration: number;
   readonly submissionDigest: `sha256:${string}`;
 } {

--- a/packages/daemon/src/repo-cell-submit.ts
+++ b/packages/daemon/src/repo-cell-submit.ts
@@ -4,8 +4,6 @@ import {
   heldLeaseForExecutionActor,
   isSameExecution,
   isTaskEvent,
-  resolveLedgerGitLayout,
-  ledgerGitPath,
   submissionFromCloseout,
   submissionDigest,
   type SubmissionV1,
@@ -14,15 +12,16 @@ import {
 import type { RepoCellOperationalContext } from "./repo-cell-action-context.ts";
 import type { RepoCellBinding, RepoTaskAction, Snapshot } from "./repo-cell-types.ts";
 import { assertCurrentSubmittedExecution } from "./repo-cell-execution-selection.ts";
+import { artifactAnchors, readSubmissionArtifact } from "./submission-artifacts.ts";
 import { readDispatchStreamHeaders } from "./dispatch-stream.ts";
 import { runDocAction } from "./doc-sync-actions.ts";
 import { makeGitReadinessSource, runProcessText } from "./process-port.ts";
 import { readTaskTransitionDocument } from "./transition-document-access.ts";
 import { prepareSubmissionEvidence } from "./repo-cell-task-progress.ts";
 
-/** The cut comes from the execution's dispatch or an explicit commit in its closeout. */
+/** Summary explicitly selects a public commit or center-accepted artifact revisions. */
 export function deriveCloseoutSubmission(
-  cell: Pick<RepoCellOperationalContext, "rootDir" | "projection" | "cellCodedError">,
+  cell: Pick<RepoCellOperationalContext, "rootDir" | "projection" | "store" | "cellCodedError">,
   taskId: string,
   executionId: string,
   snapshot: Snapshot,
@@ -34,35 +33,41 @@ export function deriveCloseoutSubmission(
       slot: "task.closeout",
       bodyOverrides,
     }),
-    existing = snapshot.executions.find((execution) => execution.executionId === executionId)?.submission,
     // Parse/validate before reading any Git cut. No risk or verification line is filtered.
     prose = submissionFromCloseout(document.body, { commitSha: "0".repeat(40), deliverables: [], outputs: [] }),
-    named = [...new Set(prose.completionClaim.match(/\b[0-9a-f]{40}\b/gu) ?? [])],
-    dispatches = readDispatchStreamHeaders(cell.rootDir).filter(
-      (dispatch) => dispatch.taskId === taskId && dispatch.executionId === executionId && dispatch.cwd,
-    ),
-    directories = [...new Set(dispatches.map((dispatch) => dispatch.cwd!))],
-    git = makeGitReadinessSource(),
-    ledgerLayout = resolveLedgerGitLayout(cell.rootDir),
-    ledgerRoot = ledgerLayout.rootDir,
-    privateDelivery = !(snapshot.task?.completionGateIds ?? []).some(
-      (gate) => gate === "ci" || gate === "code-doc-reconciliation",
-    );
-  if (named.length > 1 || directories.length > 1)
-    throw cell.cellCodedError("invalid_submission", "Summary must identify one delivery commit for this execution.");
-  let root = directories[0] ?? cell.rootDir,
-    commitSha =
-      named[0] ?? existing?.commitSha ?? (directories.length ? git.run(root, ["rev-parse", "HEAD"]).stdout : "");
-  if (!commitSha && privateDelivery) {
-    root = ledgerRoot;
-    commitSha = git.run(root, ["rev-parse", "HEAD"]).stdout;
-  }
-  if (!commitSha)
+    anchors = artifactAnchors(prose.completionClaim),
+    named = [...new Set(prose.completionClaim.replace(/artifact:[^\s`<>]+/gu, "").match(/\b[0-9a-f]{40}\b/gu) ?? [])];
+  if (
+    (named.length === 1) === anchors.length > 0 ||
+    named.length > 1 ||
+    (prose.completionClaim.match(/artifact:/gu) ?? []).length !== anchors.length
+  )
     throw cell.cellCodedError(
       "invalid_submission",
-      "Write the delivery commit in Summary; no execution-bound worktree cut is available.",
+      "Summary must explicitly name one commit or artifact:path@revision anchors.",
     );
-  const publishedRoot = [...new Set([root, cell.rootDir, ledgerRoot])].find(
+  if (anchors.length) {
+    const artifacts = anchors.map(
+      ({ path, revision }) => readSubmissionArtifact(cell, document.packagePath, path, revision).anchor,
+    );
+    if (new Set(artifacts.map((anchor) => anchor.path)).size !== artifacts.length)
+      throw cell.cellCodedError("invalid_submission", "Summary must name each artifact path once.");
+    return { ...prose, commitSha: null, artifacts, deliverables: artifacts.map((anchor) => anchor.path), outputs: [] };
+  }
+  const dispatches = readDispatchStreamHeaders(cell.rootDir).filter(
+      (dispatch) =>
+        dispatch.taskId === taskId &&
+        dispatch.executionId === executionId &&
+        dispatch.role !== "reviewer" &&
+        dispatch.cwd,
+    ),
+    directories = [...new Set(dispatches.map((dispatch) => dispatch.cwd!))],
+    git = makeGitReadinessSource();
+  if (directories.length > 1)
+    throw cell.cellCodedError("invalid_submission", "Execution has more than one delivery worktree.");
+  let root = directories[0] ?? cell.rootDir,
+    commitSha = named[0]!;
+  const publishedRoot = [...new Set([root, cell.rootDir])].find(
     (candidate) => git.run(candidate, ["cat-file", "-e", `${commitSha}^{commit}`]).ok,
   );
   if (!publishedRoot)
@@ -89,49 +94,11 @@ export function deriveCloseoutSubmission(
         "Summary commit must be the bound worktree HEAD or its published merge commit.",
       );
   }
-  if (
-    root === ledgerRoot &&
-    (privateDelivery || !git.run(cell.rootDir, ["cat-file", "-e", `${commitSha}^{commit}`]).ok)
-  ) {
-    const artifacts = git.run(root, [
-      "ls-tree",
-      "-r",
-      "--name-only",
-      commitSha,
-      "--",
-      ledgerGitPath(ledgerLayout, `${document.packagePath}/artifacts/`),
-    ]);
-    if (!artifacts.ok || !artifacts.stdout)
-      throw cell.cellCodedError(
-        "invalid_submission",
-        "Publish this task's artifacts before submitting the private delivery.",
-      );
-    return { ...prose, commitSha, deliverables: artifacts.stdout.split("\n"), outputs: [] };
-  }
   const mergeBase = git.run(root, ["merge-base", "origin/main", commitSha]);
-  let base =
+  const base =
     mergeBase.ok && mergeBase.stdout !== commitSha
       ? mergeBase.stdout
       : git.run(root, ["rev-parse", `${commitSha}^1`]).stdout;
-  // A worktree branch can already be merged. Compare against its merge base,
-  // not just its final commit's parent, or earlier branch deliveries disappear.
-  if (directories.length && !named.length && mergeBase.stdout === commitSha) {
-    const merges = git.run(root, ["rev-list", "--ancestry-path", "--merges", "--reverse", `${commitSha}..origin/main`]);
-    const containing = merges.stdout
-      .split("\n")
-      .filter(Boolean)
-      .find(
-        (merge) =>
-          git.run(root, ["merge-base", "--is-ancestor", commitSha, `${merge}^2`]).ok &&
-          !git.run(root, ["merge-base", "--is-ancestor", commitSha, `${merge}^1`]).ok,
-      );
-    if (!containing)
-      throw cell.cellCodedError(
-        "invalid_submission",
-        "Name the delivery commit in Summary; the bound branch has no distinct cut against origin/main.",
-      );
-    base = git.run(root, ["merge-base", commitSha, `${containing}^1`]).stdout;
-  }
   if (!base) throw cell.cellCodedError("invalid_submission", "Delivery commit has no verifiable comparison cut.");
   const deliverables = runProcessText(
       "git",
@@ -145,8 +112,9 @@ export function deriveCloseoutSubmission(
       .filter(Boolean);
   if (!deliverables.length && !removed.length)
     throw cell.cellCodedError("invalid_submission", "Delivery cut contains no changed paths.");
+  const { artifacts: _artifacts, ...codeProse } = prose;
   return {
-    ...prose,
+    ...codeProse,
     commitSha,
     deliverables,
     outputs: removed.map((target) => `Deleted-Production-Paths: ${target}`),

--- a/packages/daemon/src/repo-cell-task-maintenance.ts
+++ b/packages/daemon/src/repo-cell-task-maintenance.ts
@@ -2,10 +2,12 @@ import { createHash } from "node:crypto";
 import {
   createEntityStore,
   isMigrationImportEvent,
+  isTerminalStatus,
   requireEntityStoreKindContract,
   type TaskProjectionListQuery,
   type WriteReceiptDraft as WriteReceipt,
 } from "../../kernel/src/index.ts";
+import { compileRepoPresetSnapshotUpgrade } from "../../preset/src/index.ts";
 import {
   compileRestatedTaskContract,
   restateTaskContractBody,
@@ -200,6 +202,7 @@ export function migrateTaskContracts(
   action: RepoTaskAction,
   binding: RepoCellBinding,
 ): WriteReceipt {
+  if (action.toPresetId !== undefined) return migrateTaskPreset(cell, action, binding);
   const migratedTaskIds = new Set(
       cell.store
         .read()
@@ -361,6 +364,63 @@ export function migrateTaskContracts(
     cell.store.readHead()?.revision ?? 0,
     steps.length > 0,
   );
+}
+
+function migrateTaskPreset(
+  cell: RepoCellOperationalContext,
+  action: RepoTaskAction,
+  binding: RepoCellBinding,
+): WriteReceipt {
+  const taskId = cell.requiredCellText(action.taskId, "taskId"),
+    toPresetId = cell.requiredCellText(action.toPresetId, "toPresetId"),
+    current = cell.projection.read(taskId),
+    task = current.snapshot.task;
+  if (!cell.projectionReady(current) || !task || !current.packagePath)
+    throw cell.cellCodedError("task_not_found", `Task ${taskId} is not ready for contract migration.`);
+  if (current.snapshot.lease)
+    throw cell.cellCodedError("active_lease", `Run ha task release ${taskId} before contract migration.`);
+  if (isTerminalStatus(task.status))
+    throw cell.cellCodedError("terminal_task", "Contract migration requires a non-terminal task.");
+  if (action.mode !== "apply" && action.mode !== "dry-run")
+    throw cell.cellCodedError("invalid_command", "Choose --dry-run or --apply for contract migration.");
+  const contract = cell.projection.readDocument(`${current.packagePath}/task-contract.json`);
+  if (!cell.projectionReady(contract) || !contract.document)
+    throw cell.cellCodedError("content_not_ready", `Task ${taskId} contract is not ready for migration.`);
+  const revision = cell.store.readHead()?.revision ?? 0,
+    opId = cell.operationId(action, binding, cell.input.repoId, current.snapshot.revision),
+    compiled = compileRepoPresetSnapshotUpgrade({
+      rootDir: cell.rootDir,
+      settings: cell.settings.read(),
+      task,
+      taskContractBody: contract.document.body,
+      toPresetId,
+      actor: binding.actor,
+      source: binding.source,
+      workspaceRevision: revision + 1,
+      eventId: `event-${createHash("sha256").update(opId).digest("hex")}`,
+      opId,
+      occurredAt: cell.now(),
+    }),
+    report = {
+      taskId,
+      actor: binding.actor,
+      occurredAt: compiled.event.occurredAt,
+      from: { presetId: task.metadata?.presetId, digest: task.presetSnapshotDigest, gates: task.completionGateIds },
+      to: {
+        presetId: toPresetId,
+        digest: compiled.snapshot.digest,
+        gates: compiled.snapshot.profile.completionGateIds,
+      },
+    };
+  if (action.mode === "dry-run")
+    return cell.previewResult(opId, { report, applied: false }, revision, "task-contract-migrate");
+  const appended = cell.store.append(compiled),
+    publication = cell.publicPublication(appended);
+  cell.projection.apply(compiled.event, compiled.plan);
+  return {
+    ...cell.readResult(opId, { report, applied: true, migrated: [taskId] }, appended.revision, true),
+    proof: cell.receiptProof(compiled.event, publication),
+  };
 }
 
 function requirePrepared(value: WriteReceipt | PreparedTaskSurfaceWrite): PreparedTaskSurfaceWrite {

--- a/packages/daemon/src/repo-cell-task-progress.ts
+++ b/packages/daemon/src/repo-cell-task-progress.ts
@@ -55,7 +55,7 @@ export function readLatestCiEvidence(
   cell: RepoCellOperationalContext,
   execution: Snapshot["executions"][number] | undefined,
 ): CompletionEvidenceV1 | null {
-  if (!execution?.submission) return null;
+  if (!execution?.submission?.commitSha) return null;
   const observations = cell.projection.readCiRunObservations(2000);
   if (!cell.projectionReady(observations))
     throw cell.cellCodedError("content_not_ready", "CI observation projection is not ready.");
@@ -354,7 +354,8 @@ export async function completeTask(
     ),
   );
   const codeDoc =
-    initial.snapshot.task?.completionGateIds.includes("code-doc-reconciliation") && submittedExecution?.submission
+    initial.snapshot.task?.completionGateIds.includes("code-doc-reconciliation") &&
+    submittedExecution?.submission?.commitSha
       ? verifyCodeDocCommitPaths({ rootDir: cell.rootDir, commitSha: submittedExecution.submission.commitSha, paths })
       : null;
   const remaining = completionPreparationBlockers(initial.snapshot, executionId, {

--- a/packages/daemon/src/submission-artifacts.ts
+++ b/packages/daemon/src/submission-artifacts.ts
@@ -1,0 +1,49 @@
+import { isUtf8 } from "node:buffer";
+import {
+  isDocEvent,
+  normalizeRelativeDocumentPath,
+  sha256Bytes,
+  type ArtifactDelivery,
+} from "../../kernel/src/index.ts";
+import type { RepoCellOperationalContext } from "./repo-cell-action-context.ts";
+
+/** Resolve only center-accepted bytes; current workspace files are never evidence for a historical cut. */
+export function readSubmissionArtifact(
+  cell: Pick<RepoCellOperationalContext, "store" | "cellCodedError">,
+  packagePath: string,
+  path: string,
+  revision: number,
+  expectedBlob?: string,
+): { readonly anchor: ArtifactDelivery; readonly body: string; readonly acceptance: string } {
+  const invalid = (reason: string): never => {
+    throw cell.cellCodedError("invalid_submission", `Artifact ${path}@${revision}: ${reason}`);
+  };
+  let normalized: string;
+  try {
+    normalized = normalizeRelativeDocumentPath(path);
+  } catch (cause) {
+    throw Object.assign(new Error(`Artifact path is invalid: ${path}`, { cause }), { code: "invalid_submission" });
+  }
+  if (normalized !== path || !path.startsWith(`${packagePath}/artifacts/`))
+    return invalid("path must belong to this task's artifacts");
+  if (!Number.isSafeInteger(revision) || revision < 1) invalid("revision must be a positive safe integer");
+  const event = cell.store.readBatch(String(revision - 1), 1).events[0];
+  if (!event || event.workspaceRevision !== revision || !isDocEvent(event))
+    return invalid("revision is not a document acceptance");
+  const change = event.payload.changes.find((candidate) => candidate.path === path);
+  if (!change?.candidate) return invalid("revision did not accept this path");
+  const blobSha256 = change.candidate.sha256,
+    bytes = cell.store.readContentBlob(blobSha256);
+  if (!bytes || sha256Bytes(bytes) !== blobSha256 || (expectedBlob !== undefined && expectedBlob !== blobSha256))
+    return invalid("accepted content is unavailable or does not match its frozen identity");
+  if (!isUtf8(bytes)) return invalid("review delivery must be UTF-8 text");
+  const body = new TextDecoder().decode(bytes);
+  return { anchor: { path, revision, blobSha256 }, body, acceptance: event.opId };
+}
+
+export function artifactAnchors(summary: string): readonly { readonly path: string; readonly revision: number }[] {
+  return [...summary.matchAll(/artifact:([^\s`<>]+)@([1-9][0-9]*)(?=$|[\s`<>])/gu)].map((match) => ({
+    path: match[1]!,
+    revision: Number(match[2]),
+  }));
+}

--- a/packages/daemon/src/task-completion-review.ts
+++ b/packages/daemon/src/task-completion-review.ts
@@ -6,6 +6,7 @@ import {
   type ExecutionV1,
   type WriteReceiptDraft,
 } from "../../kernel/src/index.ts";
+import { readSubmissionArtifact } from "./submission-artifacts.ts";
 import { isRuntimeEvent } from "./runtime-spawn-errors.ts";
 import { readAgentDeclaration } from "./agent-entities.ts";
 import { authorizeRepoCellAction } from "./repo-cell-authorization.ts";
@@ -82,7 +83,16 @@ export async function dispatchCompletionReview(
         prompt: [
           `Independently review task ${taskId}, execution ${execution.executionId}, iteration ${execution.iteration}.`,
           `The exact submission digest is ${submissionDigest(execution.submission!)}; ` +
-            `commit ${execution.submission!.commitSha}.`,
+            `delivery ${JSON.stringify(execution.submission!)}.`,
+          ...(execution.submission!.commitSha === null
+            ? execution.submission!.artifacts.map((anchor) =>
+                JSON.stringify(
+                  readSubmissionArtifact(cell, packagePath, anchor.path, anchor.revision, anchor.blobSha256),
+                ),
+              )
+            : []),
+          "For artifact delivery, review the center-accepted frozen contents above against the contract; " +
+            "do not substitute local files or require Git ancestry. Honor every gate declared by the task.",
           "Read the task plan, closeout, and submitted delivery yourself. " +
             "Record approved or changes_requested through RecordReview; never infer approval from provider success.",
           `Write this execution's review report to harness/${report} and review input to harness/${packet}. ` +

--- a/packages/daemon/test/closeout-submission-cut.test.ts
+++ b/packages/daemon/test/closeout-submission-cut.test.ts
@@ -78,6 +78,7 @@ function derive(rootDir: string, summary: string, missingPath?: string) {
     {
       rootDir,
       projection,
+      store: {} as Parameters<typeof deriveCloseoutSubmission>[0]["store"],
       cellCodedError: (code: string, message: string) => Object.assign(new Error(message), { code }),
     },
     "task-1",
@@ -129,12 +130,13 @@ test("rename cut anchors the surviving target path", (t) => {
   assert.deepEqual(packet.outputs, []);
 });
 
-test("bound dispatch supplies HEAD without an explicit Summary SHA", (t) => {
+test("bound dispatch cannot substitute HEAD for an explicit Summary anchor", (t) => {
   const { root } = fixture(t);
   put(root, "src/live.ts", "export const liveValue = 3;\n");
   const sha = commit(root);
   dispatch(root, root);
-  assert.equal(derive(root, "Completed the live path.").commitSha, sha);
+  assert.throws(() => derive(root, "Completed the live path."), { code: "invalid_submission" });
+  assert.equal(derive(root, `Delivered ${sha}`).commitSha, sha);
 });
 
 test("missing dispatch requires an explicit Summary cut and rejects ambiguous commits", (t) => {
@@ -146,15 +148,11 @@ test("missing dispatch requires an explicit Summary cut and rejects ambiguous co
   assert.throws(() => derive(root, `Delivered ${"f".repeat(40)}.`), { code: "invalid_submission" });
 });
 
-test("private ledger cut selects only this task's committed artifacts", (t) => {
+test("a private Git commit cannot substitute for an artifact acceptance revision", (t) => {
   const { root, ledger } = fixture(t);
   put(ledger, `${packagePath}/artifacts/report.md`, "Evidence.\n");
-  put(ledger, "tasks/task-2/artifacts/report.md", "Other evidence.\n");
-  const sha = commit(ledger),
-    packet = derive(root, `Delivered ${sha}.`);
-  assert.equal(packet.commitSha, sha);
-  assert.deepEqual(packet.deliverables, [`${packagePath}/artifacts/report.md`]);
-  assert.deepEqual(packet.outputs, []);
+  const sha = commit(ledger);
+  assert.throws(() => derive(root, `Delivered ${sha}.`), { code: "invalid_submission" });
 });
 
 test("missing ledger artifact paths and missing projected documents fail closed", (t) => {
@@ -166,15 +164,6 @@ test("missing ledger artifact paths and missing projected documents fail closed"
     assert.throws(() => derive(root, `Delivered ${sha}.`, missing), { code: "content_not_ready" });
   dispatch(root, path.join(root, "missing-worktree"));
   assert.throws(() => derive(root, "Completed the live path."), { code: "invalid_submission" });
-});
-
-test("ledger artifact cut respects an authored subdirectory prefix", (t) => {
-  const { root, ledger } = fixture(t);
-  put(ledger, "harness.yaml", "schema: harness-anything/v1\nlayout:\n  authoredRoot: harness/authored\n");
-  put(ledger, `authored/${packagePath}/artifacts/report.md`, "Evidence.\n");
-  const sha = commit(ledger),
-    packet = derive(root, `Delivered ${sha}.`);
-  assert.deepEqual(packet.deliverables, [`authored/${packagePath}/artifacts/report.md`]);
 });
 
 test("shared public and authored Git root keeps a code delivery on its public cut", (t) => {
@@ -192,17 +181,17 @@ test("already merged dispatch preserves earlier branch changes and rejects unrel
   put(root, "src/first.ts", "first\n");
   commit(root);
   put(root, "src/second.ts", "second\n");
-  const head = commit(root);
+  commit(root);
   git(root, "checkout", "-q", "main");
   git(root, "merge", "--no-ff", "-qm", "test: merge delivery", "worker");
   const merged = git(root, "rev-parse", "HEAD");
   git(root, "update-ref", "refs/remotes/origin/main", merged);
   git(root, "checkout", "-q", "worker");
   dispatch(root, root);
-  assert.deepEqual(derive(root, "Worktree delivery.").deliverables, ["src/first.ts", "src/second.ts"]);
+  assert.deepEqual(derive(root, `Delivery ${merged}`).deliverables, ["src/first.ts", "src/second.ts"]);
   assert.equal(derive(root, `Delivery ${merged}`).commitSha, merged);
   assert.throws(() => derive(root, `Delivery ${base}`), /bound worktree HEAD/u);
-  assert.equal(derive(root, "Worktree delivery.").commitSha, head);
+  assert.throws(() => derive(root, "Worktree delivery."), { code: "invalid_submission" });
 });
 
 test("removed dispatch worktree resolves an explicit published cut in the canonical repository", (t) => {
@@ -218,7 +207,7 @@ test("removed dispatch worktree resolves an explicit published cut in the canoni
   git(root, "worktree", "remove", cwd);
   assert.equal(derive(root, `Delivery ${merged}`).commitSha, merged);
   assert.deepEqual(derive(root, `Delivery ${merged}`).deliverables, ["src/delivery.ts"]);
-  assert.throws(() => derive(root, "Delivery complete."), /no execution-bound worktree cut/u);
+  assert.throws(() => derive(root, "Delivery complete."), /explicitly name/u);
   assert.throws(() => derive(root, `Delivery ${"f".repeat(40)}`), /not published/u);
   put(root, "src/unpublished.ts", "unpublished\n");
   const unpublished = commit(root);

--- a/packages/daemon/test/closeout-submit-holder.integration.test.ts
+++ b/packages/daemon/test/closeout-submit-holder.integration.test.ts
@@ -51,13 +51,19 @@ test("closeout submit preserves holder authority and resumes one cut after a dis
     await waitForFixturePublication(cell, started.opId, holder);
     const closeoutPath = path.join(ledger, packagePath, "closeout.md"),
       artifacts = path.join(ledger, packagePath, "artifacts"),
-      completeBody =
+      completeBodyTemplate =
         "## Summary\nDelivered the private report.\n" +
         "## Verification\n- Targeted test passed.\n- Real publication observed.\n" +
         "## Residual Risk\n- 已知缺口：pending external audit.\n- Accepted risk: manual review.\n" +
         "## Same Mechanism Elsewhere\n- Sibling known gap remains unverified.\n";
     mkdirSync(artifacts, { recursive: true });
     writeFileSync(path.join(artifacts, "report.md"), "# Evidence\n\nHolder-bound receipt under test.\n");
+    const artifactReceipt = await cell.run({ kind: "doc-submit", taskId }, holder);
+    assert.equal(artifactReceipt.outcome, "applied", JSON.stringify(artifactReceipt));
+    const completeBody = completeBodyTemplate.replace(
+      "Delivered the private report.",
+      `Delivered the private report. artifact:${packagePath}/artifacts/report.md@${artifactReceipt.revision}`,
+    );
     writeFileSync(closeoutPath, completeBody.replace(/## Verification\n[\s\S]*?(?=## Residual Risk)/u, ""));
     const submit = async () => {
       let receipt = await cell.run({ kind: "task-submit", taskId, executionId }, holder);

--- a/packages/daemon/test/doc-sync-artifact-opaque.test.ts
+++ b/packages/daemon/test/doc-sync-artifact-opaque.test.ts
@@ -585,7 +585,9 @@ async function reachGreenInReview(
   await waitForFixturePublication(cell, artifactSync.opId, binding);
   writeFileSync(
     path.join(rootDir, "harness", `${packagePath}/closeout.md`),
-    "# Closeout\n\n## Summary\n\nDone.\n\n## Verification\n\nVerified.\n\n## Residual Risk\n\nNone.\n\n## Same Mechanism Elsewhere\n\nNot applicable to this fixture.\n",
+    `# Closeout\n\n## Summary\n\nDelivered artifact:${artifactPath}@${artifactSync.revision}\n\n` +
+      "## Verification\n\nVerified.\n\n## Residual Risk\n\nNone.\n\n" +
+      "## Same Mechanism Elsewhere\n\nNot applicable to this fixture.\n",
   );
   assert.equal(
     (await cell.run({ kind: "doc-submit", paths: [`${packagePath}/closeout.md`] }, binding)).outcome,

--- a/packages/daemon/test/fact-retirement-completion.contract.test.ts
+++ b/packages/daemon/test/fact-retirement-completion.contract.test.ts
@@ -71,6 +71,9 @@ test("task complete rejects an undeclared upstream Fact and persists a still-hol
         binding,
       )) as unknown as Record<string, unknown>;
     assert.equal(completed.outcome, "applied", JSON.stringify(completed));
+    assert.equal(completed.status, "accepted_durable", JSON.stringify(completed));
+    const acceptance = completed.acceptance as { readonly memberOpIds: readonly string[] };
+    assert.ok(acceptance.memberOpIds.includes(String(completed.opId)));
     completionReader = makeTaskEventReader({ repoId, rootDir });
     const event = completionReader.readEvent(String(completed.opId));
     assert.equal(event?.type, "task_completed");
@@ -238,7 +241,7 @@ async function reachGreenInReview(
   await waitForFixturePublication(cell, artifactSync.opId, binding);
   writeFileSync(
     path.join(rootDir, "harness", closeoutPath),
-    "# Closeout\n\n## Summary\n\nDone.\n\n## Verification\n\nVerified.\n\n## Residual Risk\n\nNone.\n\n## Same Mechanism Elsewhere\n\nNo sibling mechanism in this fixture.\n",
+    `# Closeout\n\n## Summary\n\nDone: artifact:${artifactPath}@${artifactSync.revision}\n\n## Verification\n\nVerified.\n\n## Residual Risk\n\nNone.\n\n## Same Mechanism Elsewhere\n\nNo sibling mechanism in this fixture.\n`,
   );
   assert.equal((await cell.run({ kind: "doc-submit", paths: [closeoutPath] }, binding)).outcome, "applied");
   const submitted = await cell.run({ kind: "task-submit", taskId, executionId }, binding);

--- a/packages/daemon/test/gui-submission-validation.test.ts
+++ b/packages/daemon/test/gui-submission-validation.test.ts
@@ -24,7 +24,7 @@ test("#1546: a wrong-shape field is named with its expected shape, not a generic
   ]);
   const wrongCommitSha = validateGuiSubmission({ ...valid, commitSha: "not-a-sha" });
   assert.deepEqual(wrongCommitSha, [
-    "entity='not-a-sha' field=commitSha must be a native 40-character commit SHA; actual='not-a-sha'",
+    "entity='not-a-sha' field=commitSha must identify a commit or accepted artifact revisions; actual='not-a-sha'",
   ]);
   const emptyClaim = validateGuiSubmission({ ...valid, completionClaim: "" });
   assert.deepEqual(emptyClaim, [
@@ -36,7 +36,7 @@ test("#1546: multiple simultaneously wrong fields are all named, not just the fi
   const issues = validateGuiSubmission({ ...valid, deliverables: [1], commitSha: "bad" });
   assert.deepEqual(issues, [
     "entity='bad' field=deliverables must be an array of non-empty strings; actual=[ 1 ]",
-    "entity='bad' field=commitSha must be a native 40-character commit SHA; actual='bad'",
+    "entity='bad' field=commitSha must identify a commit or accepted artifact revisions; actual='bad'",
   ]);
 });
 

--- a/packages/daemon/test/milestone-lineage.integration.test.ts
+++ b/packages/daemon/test/milestone-lineage.integration.test.ts
@@ -88,7 +88,9 @@ async function reachGreenInReview(
   await waitForFixturePublication(cell, artifactSync.opId, binding);
   writeFileSync(
     path.join(rootDir, "harness", closeoutPath),
-    "# Closeout\n\n## Summary\n\nDone.\n\n## Verification\n\nVerified.\n\n## Residual Risk\n\nNone.\n\n## Same Mechanism Elsewhere\n\nNot applicable to this fixture.\n",
+    `# Closeout\n\n## Summary\n\nDelivered artifact:${artifactPath}@${artifactSync.revision}\n\n` +
+      "## Verification\n\nVerified.\n\n## Residual Risk\n\nNone.\n\n" +
+      "## Same Mechanism Elsewhere\n\nNot applicable to this fixture.\n",
   );
   assert.equal((await cell.run({ kind: "doc-submit", paths: [closeoutPath] }, binding)).outcome, "applied");
   const submitted = await cell.run({ kind: "task-submit", taskId, executionId }, binding);

--- a/packages/daemon/test/review-independence-diagnostics.integration.test.ts
+++ b/packages/daemon/test/review-independence-diagnostics.integration.test.ts
@@ -837,7 +837,7 @@ test("review binding permits independent runtimes but still rejects the executio
     const closeoutPath = `${String((created as Record<string, unknown>).packagePath)}/closeout.md`;
     writeFileSync(
       path.join(rootDir, "harness", closeoutPath),
-      "# Closeout\n\n## Summary\n\nRuntime implementation complete.\n\n" +
+      `# Closeout\n\n## Summary\n\nRuntime implementation complete at ${git(rootDir, "rev-parse", "HEAD")}.\n\n` +
         "## Verification\n\nIntegration chain verified.\n\n## Residual Risk\n\nNone.\n\n" +
         "## Same Mechanism Elsewhere\n\nThe runtime ingress path is the shared mechanism.\n",
     );

--- a/packages/daemon/test/review-independence-diagnostics.integration.test.ts
+++ b/packages/daemon/test/review-independence-diagnostics.integration.test.ts
@@ -696,6 +696,8 @@ test("review binding permits independent runtimes but still rejects the executio
   let cell: Awaited<ReturnType<typeof openRepoCell>> | undefined;
   try {
     initRepo(rootDir);
+    const workerRoot = path.join(rootDir, ".worktrees", "implementer");
+    git(rootDir, "worktree", "add", "--quiet", "--detach", workerRoot);
     const processes: { exit: ((code: number | null) => void) | null }[] = [];
     let providerSequence = 0;
     cell = await openRepoCell({
@@ -779,7 +781,7 @@ test("review binding permits independent runtimes but still rejects the executio
     const original = await cell.spawnRuntime(
       {
         runtimeInstanceId: "review-runtime",
-        cwd: { scope: "repo-root" },
+        cwd: { scope: "repo-relative", path: ".worktrees/implementer" },
         prompt: "Implement the task.",
         taskId,
         idempotencyKey: "original-runtime",
@@ -809,7 +811,7 @@ test("review binding permits independent runtimes but still rejects the executio
     const resumed = await cell.spawnRuntime(
       {
         runtimeInstanceId: "review-runtime",
-        cwd: { scope: "repo-root" },
+        cwd: { scope: "repo-relative", path: ".worktrees/implementer" },
         prompt: "Resume the task.",
         taskId,
         providerSessionId: "provider-1",
@@ -824,9 +826,9 @@ test("review binding permits independent runtimes but still rejects the executio
         event.type === "runtime_session_task_bound" && event.payload.runtimeSessionId === resumed.runtimeSessionId,
     );
 
-    writeFileSync(path.join(rootDir, "README.md"), "# Runtime closeout chain\n");
-    git(rootDir, "add", "README.md");
-    git(rootDir, "commit", "--quiet", "-m", "runtime implementation");
+    writeFileSync(path.join(workerRoot, "README.md"), "# Runtime closeout chain\n");
+    git(workerRoot, "add", "README.md");
+    git(workerRoot, "commit", "--quiet", "-m", "runtime implementation");
     const resumedImplementer = {
       actor: {
         principal,
@@ -837,7 +839,7 @@ test("review binding permits independent runtimes but still rejects the executio
     const closeoutPath = `${String((created as Record<string, unknown>).packagePath)}/closeout.md`;
     writeFileSync(
       path.join(rootDir, "harness", closeoutPath),
-      `# Closeout\n\n## Summary\n\nRuntime implementation complete at ${git(rootDir, "rev-parse", "HEAD")}.\n\n` +
+      `# Closeout\n\n## Summary\n\nRuntime implementation complete at ${git(workerRoot, "rev-parse", "HEAD")}.\n\n` +
         "## Verification\n\nIntegration chain verified.\n\n## Residual Risk\n\nNone.\n\n" +
         "## Same Mechanism Elsewhere\n\nThe runtime ingress path is the shared mechanism.\n",
     );

--- a/packages/daemon/test/submission-artifacts.test.ts
+++ b/packages/daemon/test/submission-artifacts.test.ts
@@ -1,0 +1,127 @@
+// harness-test-tier: fast
+import assert from "node:assert/strict";
+import test from "node:test";
+import { sha256Bytes, submissionDigest } from "../../kernel/src/index.ts";
+import { validateGuiSubmission } from "../src/protocol/daemon-protocol-validate-entities.ts";
+import { artifactAnchors, readSubmissionArtifact } from "../src/submission-artifacts.ts";
+import { deriveCloseoutSubmission } from "../src/repo-cell-submit.ts";
+
+const packagePath = "tasks/task-artifact",
+  path = `${packagePath}/artifacts/report.md`;
+function fixture() {
+  const bytes = Buffer.from("Frozen evidence.\n"),
+    blobSha256 = sha256Bytes(bytes);
+  const event = {
+    schema: "doc-event/v1",
+    workspaceRevision: 7,
+    opId: "accepted-7",
+    payload: { changes: [{ path, candidate: { sha256: blobSha256 } }] },
+  };
+  const store = {
+    readBatch: (cursor: string) => ({
+      events:
+        Number(cursor) === 6
+          ? [event]
+          : Number(cursor) === 7
+            ? [
+                {
+                  ...event,
+                  workspaceRevision: 8,
+                  opId: "accepted-8",
+                  payload: { changes: [{ path: `${path}.other`, candidate: { sha256: blobSha256 } }] },
+                },
+              ]
+            : [],
+    }),
+    readContentBlob: () => bytes,
+  };
+  const cell = {
+    store,
+    cellCodedError: (code: string, message: string) => Object.assign(new Error(message), { code }),
+  } as unknown as Parameters<typeof readSubmissionArtifact>[0];
+  return { cell, store, bytes, blobSha256 };
+}
+function derive(summary: string) {
+  const { cell } = fixture();
+  const body = `## Summary\n${summary}\n## Verification\nRead evidence.\n## Residual Risk\nNone identified.\n## Same Mechanism Elsewhere\nChecked sibling.\n`;
+  const projection = {
+    read: () => ({ watermark: 7, sourceRevision: 7, snapshot: { task: {} }, packagePath }),
+    readDocument: (target: string) => ({
+      watermark: 7,
+      sourceRevision: 7,
+      document: {
+        body: target.endsWith("task-contract.json")
+          ? JSON.stringify({ documents: [{ slot: "task.closeout", path: "closeout.md" }] })
+          : body,
+      },
+    }),
+  } as unknown as Parameters<typeof deriveCloseoutSubmission>[0]["projection"];
+  return deriveCloseoutSubmission(
+    { ...cell, rootDir: "/nonexistent", projection },
+    "task-artifact",
+    "execution",
+    {} as Parameters<typeof deriveCloseoutSubmission>[3],
+  );
+}
+
+test("artifact submission pins accepted bytes and both validators accept the same union", () => {
+  const submitted = derive(`artifact:${path}@7`);
+  const multiple = derive(`artifact:${path}@7 artifact:${path}.other@8`);
+  assert.equal(multiple.artifacts?.length, 2);
+  assert.deepEqual(multiple.deliverables, [path, `${path}.other`]);
+  assert.equal(submitted.commitSha, null);
+  assert.deepEqual(submitted.deliverables, [path]);
+  assert.deepEqual(validateGuiSubmission(submitted), []);
+  const changed = { ...submitted, artifacts: [{ ...submitted.artifacts![0]!, revision: 8 }] };
+  assert.notEqual(submissionDigest(submitted), submissionDigest(changed));
+  for (const invalid of [
+    { ...submitted, commitSha: "a".repeat(40) },
+    { ...submitted, artifacts: [] },
+    { ...submitted, artifacts: [{ path, revision: 0, blobSha256: "a".repeat(64) }] },
+  ]) {
+    assert.ok(validateGuiSubmission(invalid).length);
+  }
+});
+
+test("Summary requires exactly one delivery kind and complete unique artifact anchors", () => {
+  for (const summary of [
+    "no anchor",
+    `${"a".repeat(40)} artifact:${path}@7`,
+    `artifact:${path}@7 artifact:${path}@7`,
+    `artifact:${path}@7.2`,
+    `artifact:${path}@7oops`,
+    `artifact:${path}@0`,
+    `artifact:${path}@-1`,
+  ])
+    assert.throws(() => derive(summary), { code: "invalid_submission" });
+  assert.deepEqual(artifactAnchors(`artifact:${path}@7 artifact:${path}.other@9`), [
+    { path, revision: 7 },
+    { path: `${path}.other`, revision: 9 },
+  ]);
+});
+
+test("only this task's accepted revision and portable artifact path resolve", () => {
+  const { cell } = fixture();
+  assert.equal(readSubmissionArtifact(cell, packagePath, path, 7).body, "Frozen evidence.\n");
+  for (const target of [
+    "tasks/other/artifacts/report.md",
+    `${packagePath}/artifacts/../closeout.md`,
+    `/${path}`,
+    `${packagePath}/closeout.md`,
+    `${packagePath}/artifacts/missing.md`,
+    path.replaceAll("/", "\\"),
+  ])
+    assert.throws(() => readSubmissionArtifact(cell, packagePath, target, 7), { code: "invalid_submission" });
+  for (const revision of [0, 6, 8, Number.MAX_SAFE_INTEGER + 1])
+    assert.throws(() => readSubmissionArtifact(cell, packagePath, path, revision), { code: "invalid_submission" });
+});
+
+test("missing or changed frozen content cannot be replaced by latest workspace content", () => {
+  const { cell, store } = fixture();
+  assert.equal(readSubmissionArtifact(cell, packagePath, path, 7).acceptance, "accepted-7");
+  assert.throws(() => readSubmissionArtifact(cell, packagePath, path, 7, "f".repeat(64)), {
+    code: "invalid_submission",
+  });
+  store.readContentBlob = () => Buffer.from("latest content");
+  assert.throws(() => readSubmissionArtifact(cell, packagePath, path, 7), { code: "invalid_submission" });
+});

--- a/packages/daemon/test/task-completion-review.integration.test.ts
+++ b/packages/daemon/test/task-completion-review.integration.test.ts
@@ -65,12 +65,14 @@ function instance(instanceId: string): RuntimeInstanceSummary {
 function git(root: string, ...args: string[]): string {
   return execFileSync("git", ["-C", root, ...args], { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] }).trim();
 }
-async function fixture(failProvider = false, available = true) {
+async function fixture(failProvider = false, available = true, artifactDelivery = false) {
   const root = mkdtempSync(path.join(tmpdir(), "ha-completion-review-")),
     repoId = workspaceId("completion-review");
   git(root, "init", "-q");
   git(root, "config", "user.name", "Completion Review Test");
   git(root, "config", "user.email", "review@example.invalid");
+  git(root, "commit", "--allow-empty", "-qm", "test: base");
+  git(root, "update-ref", "refs/remotes/origin/main", git(root, "rev-parse", "HEAD"));
   writeFileSync(path.join(root, "README.md"), "# Reviewed delivery\n");
   git(root, "add", "README.md");
   git(root, "commit", "-qm", "docs: fixture delivery");
@@ -163,9 +165,18 @@ async function fixture(failProvider = false, available = true) {
     ).outcome,
     "applied",
   );
+  let delivery = git(root, "rev-parse", "HEAD");
+  if (artifactDelivery) {
+    const report = `${packagePath}/artifacts/delivery.md`;
+    mkdirSync(path.dirname(path.join(root, "harness", report)), { recursive: true });
+    writeFileSync(path.join(root, "harness", report), "Frozen artifact evidence.\n");
+    const accepted = await run({ kind: "doc-submit", taskId });
+    assert.equal(accepted.outcome, "applied", JSON.stringify(accepted));
+    delivery = `artifact:${report}@${accepted.revision}`;
+  }
   writeFileSync(
     path.join(root, "harness", packagePath, "closeout.md"),
-    "# Closeout\n\n## Summary\n\nReviewed delivery.\n\n## Verification\n\nREADME bytes checked.\n\n" +
+    `# Closeout\n\n## Summary\n\nReviewed delivery ${delivery}\n\n## Verification\n\nREADME bytes checked.\n\n` +
       "## Residual Risk\n\nNone.\n\n## Same Mechanism Elsewhere\n\nReview dispatch retry.\n",
   );
   assert.equal((await run({ kind: "task-submit", taskId, executionId })).outcome, "applied");
@@ -205,7 +216,10 @@ async function fixture(failProvider = false, available = true) {
         .at(-1);
       assert.ok(submitted?.type === "execution_submitted" && submitted.payload.execution.submission);
       const reviewedCommit = submitted.payload.execution.submission.commitSha;
-      assert.equal(git(root, "show", `${reviewedCommit}:README.md`), "# Reviewed delivery");
+      if (artifactDelivery) {
+        assert.equal(reviewedCommit, null);
+        assert.match(launches.at(-1)!.prompt, /Frozen artifact evidence/u);
+      } else assert.equal(git(root, "show", `${reviewedCommit}:README.md`), "# Reviewed delivery");
       assert.match(
         readFileSync(path.join(root, "harness", packagePath, "closeout.md"), "utf8"),
         /README bytes checked/u,
@@ -216,8 +230,12 @@ async function fixture(failProvider = false, available = true) {
         path.join(root, "harness", packet),
         JSON.stringify({
           verdict: "approved",
-          reason: "Independently inspected committed README and submitted closeout.",
-          evidenceChecked: [`${reviewedCommit}:README.md`, "closeout.md"],
+          reason: artifactDelivery
+            ? "Inspected center-accepted artifact contents and submitted closeout."
+            : "Independently inspected committed README and submitted closeout.",
+          evidenceChecked: artifactDelivery
+            ? submitted.payload.execution.submission.artifacts!.map((anchor) => `${anchor.path}@${anchor.revision}`)
+            : [`${reviewedCommit}:README.md`, "closeout.md"],
         }),
       );
       return cell.run(
@@ -476,7 +494,7 @@ test(
       const closeoutPath = path.join(f.root, "harness", f.packagePath, "closeout.md");
       writeFileSync(
         closeoutPath,
-        readFileSync(closeoutPath, "utf8").replace("Reviewed delivery.", "Amended reviewed delivery."),
+        readFileSync(closeoutPath, "utf8").replace("Reviewed delivery ", "Amended reviewed delivery "),
       );
       let amended = await f.run({ kind: "task-submit", taskId, executionId, amend: true });
       for (let attempt = 0; amended.outcome === "pending" && attempt < 4; attempt += 1) {
@@ -512,3 +530,41 @@ test("completion with an unavailable declared model returns guidance without lau
     await f.close();
   }
 });
+
+test(
+  "artifact delivery reaches the same independent review and completion after reopening",
+  { timeout: 20_000 },
+  async () => {
+    const f = await fixture(false, true, true);
+    try {
+      await f.install();
+      await f.reopen();
+      const artifactPath = path.join(f.root, "harness", f.packagePath, "artifacts/delivery.md");
+      writeFileSync(artifactPath, "Latest replacement must not be reviewed.\n");
+      const republished = await f.run({ kind: "doc-submit", taskId });
+      if (republished.outcome === "pending") await waitForFixturePublication(f.cell(), republished.opId, owner);
+      else assert.equal(republished.outcome, "applied", JSON.stringify(republished));
+      const dispatched = await f.complete();
+      assert.equal(dispatched.code, "review_missing", JSON.stringify(dispatched));
+      assert.equal(f.launches.length, 1);
+      assert.match(f.launches[0]!.prompt, /Frozen artifact evidence/u);
+      assert.doesNotMatch(f.launches[0]!.prompt, /Latest replacement must not be reviewed/u);
+      const session = String((dispatched as unknown as Record<string, unknown>).runtimeSessionId);
+      const reviewed = await f.review(session, "artifact-reviewed");
+      if (reviewed.outcome === "pending") await waitForFixturePublication(f.cell(), reviewed.opId, owner);
+      else assert.equal(reviewed.outcome, "applied", JSON.stringify(reviewed));
+      const complete = await f.complete(true);
+      assert.equal(complete.outcome, "applied", JSON.stringify(complete));
+      const final = f
+        .events()
+        .filter((event) => event.type === "task_completed")
+        .at(-1);
+      assert.equal(final?.payload.task.status, "done");
+      await f.reopen();
+      const shown = await f.run({ kind: "task-show", taskId });
+      assert.equal(JSON.parse(String(shown.evidence)).task.status, "done");
+    } finally {
+      await f.close();
+    }
+  },
+);

--- a/packages/daemon/test/task-preset-migration.integration.test.ts
+++ b/packages/daemon/test/task-preset-migration.integration.test.ts
@@ -1,0 +1,124 @@
+// harness-test-tier: integration
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { realizeTaskPlanFixture } from "../../../tools/fixtures/task-plan.mjs";
+import { makeTaskEventReader, makeTaskProjection, canStartExecution } from "../../kernel/src/index.ts";
+import { canonicalRoot, workspaceId } from "../src/protocol/daemon-protocol.contract.ts";
+import { actor, initRepo } from "./migration-import.fixtures.ts";
+import { openBootstrappedRepoCell as openRepoCell } from "./repo-settings.fixture.ts";
+
+test("explicit preset migration atomically freezes contract, gates and auditable snapshots", async () => {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-preset-migration-")),
+    repoId = workspaceId("preset-migration"),
+    binding = { actor, source: "local" as const },
+    taskId = "task_preset_migration",
+    action = { kind: "task-contract-migrate" as const, taskId, toPresetId: "docs-task", mode: "apply" },
+    now = "2026-09-12T01:00:00.000Z";
+  let cell: Awaited<ReturnType<typeof openRepoCell>> | undefined;
+  try {
+    initRepo(rootDir);
+    cell = await openRepoCell({ repoId, rootDir: canonicalRoot(rootDir), ownerId: "migration", now: () => now });
+    const created = await cell.run({ kind: "task-create", taskId, title: "Preset migration" }, binding);
+    assert.equal(created.outcome, "applied", JSON.stringify(created));
+    const reader = makeTaskEventReader({ repoId, rootDir }),
+      before = reader.read(),
+      original = before.events.find((event) => event.schema === "task-bootstrap-event/v1")!;
+    assert.equal(original.schema, "task-bootstrap-event/v1");
+    if (original.schema !== "task-bootstrap-event/v1") throw new Error("missing bootstrap");
+    assert.deepEqual(original.payload.task.completionGateIds, ["ci", "code-doc-reconciliation"]);
+    const preview = await cell.run({ ...action, mode: "dry-run" }, binding);
+    assert.equal(preview.outcome, "pending", JSON.stringify(preview));
+    assert.equal(reader.read().revision, before.revision);
+    assert.match(preview.evidence!, /"applied":false/u);
+    const unknown = await cell.run({ ...action, toPresetId: "not-installed" }, binding);
+    assert.equal(unknown.outcome, "op_rejected", JSON.stringify(unknown));
+    assert.equal(reader.read().revision, before.revision);
+    const applied = await cell.run(action, binding);
+    assert.equal(applied.status, "accepted_durable", JSON.stringify(applied));
+    const event = reader.readEvent(applied.opId)!;
+    assert.equal(event.schema, "preset-snapshot-upgrade-event/v1");
+    if (event.schema !== "preset-snapshot-upgrade-event/v1") throw new Error("missing migration event");
+    assert.deepEqual(event.actor, actor);
+    assert.equal(event.occurredAt, now);
+    assert.equal(event.payload.previousDigest, original.payload.task.presetSnapshotDigest);
+    assert.equal(event.payload.task.metadata?.presetId, "docs-task");
+    assert.deepEqual(event.payload.task.completionGateIds, []);
+    assert.equal(event.payload.task.iteration, original.payload.task.iteration + 1);
+    assert.equal(reader.read().revision, before.revision + 1);
+    const projection = makeTaskProjection({ rootDir, eventStore: reader });
+    const projected = projection.read(taskId),
+      contract = JSON.parse(projection.readDocument(`${projected.packagePath}/task-contract.json`).document!.body);
+    assert.equal(projection.readPresetSnapshot(event.payload.previousDigest).snapshot?.identity.id, "standard-task");
+    assert.equal(
+      projection.readPresetSnapshot(event.payload.presetSnapshotClaim.digest).snapshot?.identity.id,
+      "docs-task",
+    );
+    assert.equal(contract.presetId, "docs-task");
+    assert.equal(contract.metadata.presetId, "docs-task");
+    assert.deepEqual(contract.completionGates, []);
+    assert.equal(contract.presetSnapshotDigest, event.payload.presetSnapshotClaim.digest);
+    assert.equal(contract.packagePath, projected.packagePath);
+    assert.equal(
+      canStartExecution(
+        {
+          ...projected.snapshot,
+          task: { ...event.payload.task, status: "in_review", currentNode: "review" },
+        },
+        "execution_after_migration",
+      ),
+      true,
+    );
+    const rebuilt = makeTaskProjection({
+      rootDir,
+      eventStore: reader,
+      projectionPath: path.join(rootDir, ".harness/migration-replay.sqlite"),
+    });
+    rebuilt.rebuild();
+    assert.deepEqual(rebuilt.read(taskId).snapshot.task, projected.snapshot.task);
+    assert.deepEqual(
+      rebuilt.readPresetSnapshot(event.payload.presetSnapshotClaim.digest).snapshot,
+      projection.readPresetSnapshot(event.payload.presetSnapshotClaim.digest).snapshot,
+    );
+    rebuilt.close();
+    projection.close();
+    await reader.drain();
+    const wait = await cell.run(
+      {
+        kind: "receipt-show",
+        opId: applied.opId,
+        waitFor: ["accepted_durable", "projection_visible", "git_verified", "worktree_visible"],
+        timeoutMs: 5000,
+      },
+      binding,
+    );
+    assert.equal(wait.wait?.state, "satisfied", JSON.stringify(wait));
+    await realizeTaskPlanFixture(rootDir, String(created.packagePath), (planPath) =>
+      cell!.run({ kind: "doc-submit", paths: [planPath] }, binding),
+    );
+    const started = await cell.run({ kind: "task-start", taskId, executionId: "execution_migrated" }, binding);
+    assert.equal(started.outcome, "applied", JSON.stringify(started));
+    const leased = await cell.run({ ...action, toPresetId: "standard-task" }, binding);
+    assert.equal(leased.code, "active_lease", JSON.stringify(leased));
+    const released = await cell.run({ kind: "task-release", taskId }, binding);
+    assert.equal(released.outcome, "applied", JSON.stringify(released));
+    const cancelled = await cell.run(
+      {
+        kind: "task-transition",
+        taskId,
+        status: "cancelled",
+        force: true,
+        reason: "Migration terminal guard",
+      },
+      binding,
+    );
+    assert.equal(cancelled.outcome, "applied", JSON.stringify(cancelled));
+    const terminal = await cell.run({ ...action, toPresetId: "standard-task" }, binding);
+    assert.equal(terminal.code, "terminal_task", JSON.stringify(terminal));
+  } finally {
+    await cell?.close();
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});

--- a/packages/gui/test/service-bridge.test.ts
+++ b/packages/gui/test/service-bridge.test.ts
@@ -679,7 +679,7 @@ test("GUI client reaches every shipped read through a real resident daemon", asy
     assert.match(String(artifactCut.commitSha), /^[0-9a-f]{40}$/u);
     writeFileSync(
       path.join(fixture.rootDir, "harness", String(fixture.packagePath), "closeout.md"),
-      `# Closeout\n\n## Summary\n\nGUI bridge evidence delivered in ${artifactCut.commitSha}.\n\n## Verification\n\nResident daemon reads and typed progress passed.\n\n## Residual Risk\n\n已知缺口: Electron E2E unverified.\nManual desktop verification pending.\n\n## Same Mechanism Elsewhere\n\nCLI and GUI share canonical task submission.\n`,
+      `# Closeout\n\n## Summary\n\nGUI bridge evidence delivered as artifact:${artifactPath}@${artifactReceipt.revision}\n\n## Verification\n\nResident daemon reads and typed progress passed.\n\n## Residual Risk\n\n已知缺口: Electron E2E unverified.\nManual desktop verification pending.\n\n## Same Mechanism Elsewhere\n\nCLI and GUI share canonical task submission.\n`,
     );
     const submitted = parseDaemonGuiActionResponse(
       "repo.task.submit",

--- a/packages/kernel/src/domain/closeout-readiness.ts
+++ b/packages/kernel/src/domain/closeout-readiness.ts
@@ -135,7 +135,7 @@ export function gateResults(
   snapshot: CloseoutSnapshot,
   availability?: CloseoutProjectionAvailability,
   executionId?: string,
-  commitSha?: string,
+  commitSha?: string | null,
   iteration?: number,
 ): readonly CloseoutGateResult[] {
   return (snapshot.task?.completionGateIds ?? []).map((gateId) => {

--- a/packages/kernel/src/domain/completion-evidence.ts
+++ b/packages/kernel/src/domain/completion-evidence.ts
@@ -45,7 +45,9 @@ export function completionEvidenceBasis(execution: ExecutionV1): CompletionEvide
     executionId: execution.executionId,
     iteration: execution.iteration,
     submissionDigest: submissionDigest(execution.submission),
-    codeCommit: execution.submission.commitSha,
+    ...(execution.submission.commitSha === null
+      ? { ledgerCut: Math.max(...execution.submission.artifacts.map((anchor) => anchor.revision)) }
+      : { codeCommit: execution.submission.commitSha }),
   };
 }
 

--- a/packages/kernel/src/domain/entity-document-schemas.ts
+++ b/packages/kernel/src/domain/entity-document-schemas.ts
@@ -116,7 +116,7 @@ export const reviewSchema: EntityDocumentJsonSchema = {
     capabilityRef: { type: "string", minLength: 1 },
     reason: { type: "string", minLength: 1 },
     evidenceChecked: { type: "array", items: { type: "string", minLength: 1 } },
-    commitSha: { type: "string", pattern: "^[0-9a-f]{40}$" },
+    commitSha: { type: "string", pattern: "^[0-9a-f]{40}$", "x-nullable": true },
     iteration: { type: "integer" },
     contentDigest: { type: "string", pattern: "^sha256:[0-9a-f]{64}$" },
     submissionDigest: { type: "string", pattern: "^sha256:[0-9a-f]{64}$" },

--- a/packages/kernel/src/domain/execution.ts
+++ b/packages/kernel/src/domain/execution.ts
@@ -13,15 +13,22 @@ export type LeasePhase = (typeof leasePhases)[number];
 
 export const executionV1States = ["active", "submitted", "changes_requested", "accepted"] as const;
 export type ExecutionV1State = (typeof executionV1States)[number];
-export interface SubmissionV1 {
+export interface ArtifactDelivery {
+  readonly path: string;
+  readonly revision: number;
+  readonly blobSha256: string;
+}
+export type SubmissionDelivery =
+  | { readonly commitSha: string; readonly artifacts?: never }
+  | { readonly commitSha: null; readonly artifacts: readonly ArtifactDelivery[] };
+export type SubmissionV1 = SubmissionDelivery & {
   readonly completionClaim: string;
   readonly deliverables: readonly string[];
   readonly outputs: readonly string[];
   readonly verificationNotes: readonly string[];
   readonly knownGaps: readonly string[];
   readonly residualRisks: readonly string[];
-  readonly commitSha: string;
-}
+};
 export const SUBMISSION_V1_SCHEMA = Object.freeze({
   id: "Submission/v1",
   required: Object.freeze([
@@ -145,21 +152,39 @@ export function isNativeCommitSha(value: unknown): value is string {
 function stringArray(value: unknown): boolean {
   return Array.isArray(value) && value.every(isNonEmptyString);
 }
+export function validSubmissionDelivery(value: Record<string, unknown>): boolean {
+  if (value.commitSha !== null) return isNativeCommitSha(value.commitSha) && value.artifacts === undefined;
+  return (
+    Array.isArray(value.artifacts) &&
+    value.artifacts.length > 0 &&
+    value.artifacts.every(
+      (anchor) =>
+        isRecord(anchor) &&
+        hasOnlyFields(anchor, ["path", "revision", "blobSha256"]) &&
+        isNonEmptyString(anchor.path) &&
+        Number.isSafeInteger(anchor.revision) &&
+        Number(anchor.revision) > 0 &&
+        typeof anchor.blobSha256 === "string" &&
+        /^[0-9a-f]{64}$/u.test(anchor.blobSha256),
+    )
+  );
+}
 export function validateSubmissionV1(value: unknown, allowUnknownFields = false): readonly ContractValidationIssue[] {
   if (
     !isRecord(value) ||
-    !(allowUnknownFields ? hasRequiredFields : hasOnlyFields)(value, SUBMISSION_V1_SCHEMA.required) ||
+    !(allowUnknownFields ? hasRequiredFields : hasOnlyFields)(value, [
+      ...SUBMISSION_V1_SCHEMA.required,
+      ...(value.commitSha === null ? ["artifacts"] : []),
+    ]) ||
     !isNonEmptyString(value.completionClaim) ||
     !stringArray(value.deliverables) ||
     !stringArray(value.outputs) ||
     !stringArray(value.verificationNotes) ||
     !stringArray(value.knownGaps) ||
     !stringArray(value.residualRisks) ||
-    !isNativeCommitSha(value.commitSha)
+    !validSubmissionDelivery(value)
   ) {
-    return [
-      { code: "invalid_submission", message: "Submission must be complete and use a native 40-character commit SHA" },
-    ];
+    return [{ code: "invalid_submission", message: "Submission must name a commit or accepted artifact revisions" }];
   }
   return [];
 }

--- a/packages/kernel/src/domain/review.ts
+++ b/packages/kernel/src/domain/review.ts
@@ -19,7 +19,7 @@ export interface ReviewV1 {
   readonly capabilityRef: string;
   readonly reason: string;
   readonly evidenceChecked: readonly string[];
-  readonly commitSha: string;
+  readonly commitSha: string | null;
   readonly iteration: number;
   readonly contentDigest: `sha256:${string}`;
   readonly submissionDigest: SubmissionDigest;
@@ -101,7 +101,7 @@ export function validateReviewV1(value: unknown, allowUnknownFields = false): re
   if (
     !Array.isArray(value.evidenceChecked) ||
     value.evidenceChecked.some((item) => !isNonEmptyString(item)) ||
-    !isNativeCommitSha(value.commitSha) ||
+    (value.commitSha === null ? !digest(value.submissionDigest) : !isNativeCommitSha(value.commitSha)) ||
     !Number.isSafeInteger(value.iteration) ||
     Number(value.iteration) < 0 ||
     !digest(value.contentDigest) ||

--- a/packages/kernel/src/domain/task-graph.ts
+++ b/packages/kernel/src/domain/task-graph.ts
@@ -29,7 +29,7 @@ export interface TaskEdgeTaken {
   readonly on: GraphEdgeTrigger;
   readonly actorRole: GraphActorRole;
   readonly reason: string;
-  readonly commitSha: string;
+  readonly commitSha: string | null;
   readonly iteration: number;
 }
 export interface GraphValidationIssue {

--- a/packages/kernel/src/domain/task-lifecycle-contract-internal-types.ts
+++ b/packages/kernel/src/domain/task-lifecycle-contract-internal-types.ts
@@ -72,7 +72,7 @@ export interface RecordReviewIntent extends Intent<"RecordReview"> {
   readonly noDispatchReason?: string;
   readonly noIndependentReview?: boolean;
   readonly noIndependentReviewReason?: string;
-  readonly commitSha: string;
+  readonly commitSha: string | null;
   readonly iteration: number;
   readonly contentDigest: `sha256:${string}`;
   readonly submissionDigest: `sha256:${string}`;

--- a/packages/kernel/src/domain/task-lifecycle-contract-support.ts
+++ b/packages/kernel/src/domain/task-lifecycle-contract-support.ts
@@ -106,7 +106,7 @@ export function takeEdge(
   task: TaskV2,
   trigger: TaskEdgeTaken["on"],
   reason: string,
-  commitSha: string,
+  commitSha: string | null,
   iteration: number,
 ): TaskEdgeTaken {
   const edge = task.graph.edges.find((value) => value.on === trigger);
@@ -129,6 +129,8 @@ export function canonicalGateReceipts(
   snapshot: TaskLifecycleSnapshot,
   current: ExecutionV1,
 ): CompleteTaskProof["gateReceipts"] {
+  if (!current.submission?.commitSha) return [];
+  const commitSha = current.submission.commitSha;
   const passed = new Set(
     gateResults(snapshot, undefined, current.executionId, current.submission?.commitSha, current.iteration)
       .filter(({ status }) => status === "passed")
@@ -165,7 +167,7 @@ export function canonicalGateReceipts(
             receiptRef,
             result: "pass" as const,
             executionId: current.executionId,
-            commitSha: current.submission!.commitSha,
+            commitSha,
             iteration: current.iteration,
           },
         ]

--- a/packages/kernel/src/domain/task-lifecycle-event.ts
+++ b/packages/kernel/src/domain/task-lifecycle-event.ts
@@ -565,7 +565,7 @@ function validateEdge(value: unknown, allowUnknownFields: boolean): readonly Con
     !["implementation", "review"].includes(String(value.to)) ||
     !["submitted", "changes_requested"].includes(String(value.on)) ||
     !["executor", "reviewer"].includes(String(value.actorRole)) ||
-    !isNativeCommitSha(value.commitSha) ||
+    (value.commitSha !== null && !isNativeCommitSha(value.commitSha)) ||
     !Number.isSafeInteger(value.iteration) ||
     (value.iteration as number) < 0
     ? [

--- a/packages/kernel/src/domain/task-lifecycle-publication.ts
+++ b/packages/kernel/src/domain/task-lifecycle-publication.ts
@@ -382,7 +382,10 @@ function renderExecution(value: ExecutionV1, snapshot: TaskLifecycleSnapshot): s
     `- Claimed: ${value.claimedAt}\n`,
     `- Submitted: ${value.submittedAt ?? "pending"}\n`,
     `- Closed: ${value.closedAt ?? "open"}\n`,
-    `- Commit: ${packet?.commitSha ?? "pending"}\n`,
+    `- Commit: ${packet ? (packet.commitSha ?? "none (artifact delivery)") : "pending"}\n`,
+    ...(packet?.commitSha === null
+      ? packet.artifacts.map((anchor) => `- Artifact: ${anchor.path}@${anchor.revision} (${anchor.blobSha256})\n`)
+      : []),
     `- Completion claim: ${packet?.completionClaim ?? "pending"}\n`,
     `- Reviews: ${
       reviews.length

--- a/packages/kernel/src/domain/transition-document-readiness.ts
+++ b/packages/kernel/src/domain/transition-document-readiness.ts
@@ -178,7 +178,7 @@ export function assertTransitionDocumentReady(kind: TransitionDocumentKind, body
 /** Preserve authored evidence verbatim; the execution cut supplies every repository-derived field. */
 export function submissionFromCloseout(
   body: string,
-  cut: Pick<SubmissionV1, "commitSha" | "deliverables" | "outputs">,
+  cut: import("./execution.ts").SubmissionDelivery & Pick<SubmissionV1, "deliverables" | "outputs">,
 ): SubmissionV1 {
   assertTransitionDocumentReady("task.closeout", body);
   const sections = markdownSections(body),
@@ -188,9 +188,7 @@ export function submissionFromCloseout(
     verificationNotes: [sections.get("verification")!],
     knownGaps: risks,
     residualRisks: risks,
-    commitSha: cut.commitSha,
-    deliverables: cut.deliverables,
-    outputs: cut.outputs,
+    ...cut,
   };
 }
 

--- a/packages/kernel/src/index.ts
+++ b/packages/kernel/src/index.ts
@@ -198,6 +198,7 @@ export type {
   MigrationImportEventV1,
 } from "./domain/migration-import-event.ts";
 export type {
+  ArtifactDelivery,
   ArchivedExecutionV0,
   ExecutionV1,
   LeaseV1,

--- a/packages/kernel/src/projection/rebuildable-task-projection-event-application.ts
+++ b/packages/kernel/src/projection/rebuildable-task-projection-event-application.ts
@@ -470,15 +470,26 @@ export function applyEvent(
       contractBytes.byteLength !== event.payload.taskContractClaim.size
     )
       throw new Error(`preset snapshot upgrade basis mismatch for ${event.taskId}`);
-    const changed = {
-        completionGateIds: event.payload.task.completionGateIds,
-        presetSnapshotDigest: event.payload.task.presetSnapshotDigest,
+    const snapshot = JSON.parse(new TextDecoder("utf-8", { fatal: true }).decode(snapshotBytes)),
+      changedPreset = current.task.metadata?.presetId !== snapshot.identity.id,
+      changed = {
+        completionGateIds: snapshot.profile.completionGateIds,
+        presetSnapshotDigest: snapshot.digest,
+        ...(changedPreset && current.task.metadata
+          ? {
+              metadata: {
+                ...currentTaskForWrite(current.task).metadata,
+                presetId: snapshot.identity.id,
+                profileId: snapshot.profile.id,
+              },
+              iteration: current.task.iteration + 1,
+            }
+          : {}),
       },
       currentShape = { ...currentTaskForWrite(current.task), ...changed };
     if (canonicalJson(currentShape) !== canonicalJson(currentTaskForWrite(event.payload.task)))
       throw new Error(`preset snapshot upgrade changed immutable task fields for ${event.taskId}`);
-    const snapshot = JSON.parse(new TextDecoder("utf-8", { fatal: true }).decode(snapshotBytes)),
-      contractBody = new TextDecoder("utf-8", { fatal: true }).decode(contractBytes),
+    const contractBody = new TextDecoder("utf-8", { fatal: true }).decode(contractBytes),
       contract = event.payload.taskContractClaim,
       document: DocumentState = {
         path: contract.path as DocumentState["path"],

--- a/packages/kernel/test/domain/completion-evidence.test.ts
+++ b/packages/kernel/test/domain/completion-evidence.test.ts
@@ -86,3 +86,29 @@ test("a receipt with an unsupported provenance source cannot become a verified f
   assert.equal(judgment.accepted, false);
   assert.match(judgment.reason ?? "", /provenance source/u);
 });
+
+test("artifact evidence binds ledger revisions and never passes code gates", async () => {
+  const { gateResults } = await import("../../src/domain/closeout-readiness.ts");
+  const { validateSubmissionV1 } = await import("../../src/domain/execution.ts");
+  const artifactExecution: ExecutionV1 = {
+    ...execution,
+    submission: {
+      ...execution.submission,
+      commitSha: null,
+      artifacts: [{ path: "tasks/t/artifacts/report.md", revision: 7, blobSha256: "a".repeat(64) }],
+    },
+  };
+  assert.deepEqual(validateSubmissionV1(artifactExecution.submission), []);
+  assert.ok(validateSubmissionV1({ ...artifactExecution.submission, commitSha: "a".repeat(40) }).length);
+  const basis = completionEvidenceBasis(artifactExecution);
+  assert.equal(basis.codeCommit, undefined);
+  assert.equal(basis.ledgerCut, 7);
+  const snapshot = {
+    task: { completionGateIds: ["ci", "code-doc-reconciliation"] },
+    gateWitnesses: [],
+    codeDocWitnesses: [],
+  } as unknown as Parameters<typeof gateResults>[0];
+  const results = gateResults(snapshot, undefined, artifactExecution.executionId, null, 0);
+  assert.equal(results.length, 2);
+  assert.ok(results.every((gate) => gate.status !== "passed"));
+});

--- a/packages/preset/src/preset-bootstrap.ts
+++ b/packages/preset/src/preset-bootstrap.ts
@@ -82,6 +82,7 @@ export interface CompiledTaskBootstrap extends CompiledTaskPackage {
   readonly blobs: readonly TaskBootstrapBlob[];
 }
 export interface CompilePresetSnapshotUpgradeInput extends PresetResolverOptions {
+  readonly toPresetId?: string;
   readonly task: TaskBootstrapEventV1["payload"]["task"];
   readonly taskContractBody: string;
   readonly actor: ActorIdentity;
@@ -346,17 +347,19 @@ export function compilePresetSnapshotUpgrade(input: CompilePresetSnapshotUpgrade
     documents.some((item) => !item || typeof item !== "object" || typeof (item as { path?: unknown }).path !== "string")
   )
     throw bootstrapFailure("invalid_task_contract", "Task contract metadata does not match the canonical task.");
-  const compiled = compileTaskPackage({
-    ...input,
-    taskId: input.task.taskId,
-    title,
-    taskClass: input.task.taskClass,
-    presetId,
-    verticalId,
-    profileId,
-    locale,
-    slug: input.task.metadata?.slug,
-  });
+  const currentTask = currentTaskForWrite(input.task),
+    compiled = compileTaskPackage({
+      ...input,
+      taskId: input.task.taskId,
+      title,
+      taskClass: input.task.taskClass,
+      slug: input.task.metadata?.slug,
+      moduleKey: input.task.metadata?.moduleKey ?? undefined,
+      verticalId,
+      profileId: input.toPresetId && input.toPresetId !== presetId ? undefined : profileId,
+      locale,
+      presetId: input.toPresetId ?? presetId,
+    });
   // A preset may retire a document slot (afa7f26fc retired the fact ledger document once facts became
   // entities); the retired file stays on disk as committed prose. Only a slot the package does not have yet
   // would need materialization, so only additions are rejected.
@@ -377,7 +380,24 @@ export function compilePresetSnapshotUpgrade(input: CompilePresetSnapshotUpgrade
       size: Buffer.byteLength(snapshotBody),
       mediaType: "application/json" as const,
     },
-    contractDocument = compiled.documents.find(({ relativePath }) => relativePath === "task-contract.json")!,
+    compiledContract = compiled.documents.find(({ relativePath }) => relativePath === "task-contract.json")!,
+    contractBody = `${JSON.stringify(
+      {
+        ...JSON.parse(compiledContract.body),
+        packagePath: contract.packagePath,
+        metadata: currentTask.metadata
+          ? { ...currentTask.metadata, presetId: input.toPresetId ?? presetId, profileId: compiled.metadata.profileId }
+          : null,
+      },
+      null,
+      2,
+    )}\n`,
+    contractDocument = {
+      ...compiledContract,
+      path: `${contract.packagePath}/task-contract.json`,
+      body: contractBody,
+      contentSha256: sha256Text(contractBody),
+    },
     taskContractClaim = {
       path: contractDocument.path,
       sha256: contractDocument.contentSha256,
@@ -399,7 +419,17 @@ export function compilePresetSnapshotUpgrade(input: CompilePresetSnapshotUpgrade
       payload: {
         previousDigest: previousDigest as `sha256:${string}`,
         task: {
-          ...currentTaskForWrite(input.task),
+          ...currentTask,
+          ...(input.toPresetId && input.toPresetId !== presetId ? { iteration: input.task.iteration + 1 } : {}),
+          ...(input.toPresetId && currentTask.metadata
+            ? {
+                metadata: {
+                  ...currentTask.metadata,
+                  presetId: input.toPresetId,
+                  profileId: compiled.metadata.profileId,
+                },
+              }
+            : {}),
           completionGateIds: compiled.snapshot.profile.completionGateIds,
           presetSnapshotDigest: compiled.snapshot.digest,
         },

--- a/tools/smoke-cli-package.mjs
+++ b/tools/smoke-cli-package.mjs
@@ -217,9 +217,19 @@ export function runCliPackageSmoke(root = process.cwd()) {
       path.join(taskDir, "artifacts", "smoke.md"),
       "# Packaged CLI smoke\n\nBootstrap, task creation and execution start returned successful receipts.\n",
     );
+    const artifactPath = `${String(created.packagePath)}/artifacts/smoke.md`;
+    const artifactSync = expectOk(
+      runJson(
+        binPath,
+        ["--root", projectDir, "--json", "doc", "sync", "--submit", "--task", "task-smoke"],
+        projectDir,
+        env(userRoot, home),
+      ),
+      "smoke artifact submit",
+    );
     writeFileSync(
       path.join(taskDir, "closeout.md"),
-      "# Closeout\n\n## Summary\n\nThe packaged CLI bootstrapped a workspace and started its smoke task.\n\n" +
+      `# Closeout\n\n## Summary\n\nThe packaged CLI delivered artifact:${artifactPath}@${artifactSync.revision}\n\n` +
         "## Verification\n\nBoth installed CLI aliases expose help; init, task create and task start returned successful receipts.\n\n" +
         "## Residual Risk\n\nDaemon restart behavior is checked after submission.\n\n" +
         "## Same Mechanism Elsewhere\n\nThe installed ha alias uses the same lifecycle entry point.\n",

--- a/tools/stress/entity-cli-calibration.integration.test.mjs
+++ b/tools/stress/entity-cli-calibration.integration.test.mjs
@@ -140,17 +140,18 @@ function taskChain(f, reader, index) {
   const reportBody = Buffer.from(`# Calibration ${f.seed}/${index}\n\n${"durable bytes\n".repeat(32)}`);
   mkdirSync(path.dirname(path.join(f.root, "harness", reportPath)), { recursive: true });
   writeFileSync(path.join(f.root, "harness", reportPath), reportBody);
-  writeFileSync(
-    path.join(f.root, "harness", packagePath, "closeout.md"),
-    "# Closeout\n\n## Summary\n\nReport delivered.\n\n## Verification\n\nExact bytes checked.\n\n" +
-      "## Residual Risk\n\nPilot only.\n\n## Same Mechanism Elsewhere\n\nTask report ownership.\n",
-  );
   f.invoke("doc.status", ["doc", "status", "--task", taskId], { actor });
   const report = f.invoke("task.report.acceptance", ["doc", "sync", "--submit", "--task", taskId], {
     actor,
   });
   f.publish(report, "task.report", actor);
   f.check("task.report.same-cut-bytes", () => assertBytes(f.root, reportPath, reportBody, report, reader));
+  writeFileSync(
+    path.join(f.root, "harness", packagePath, "closeout.md"),
+    `# Closeout\n\n## Summary\n\nReport delivered: artifact:${reportPath}@${report.revision}\n\n` +
+      "## Verification\n\nExact bytes checked.\n\n## Residual Risk\n\nPilot only.\n\n" +
+      "## Same Mechanism Elsewhere\n\nTask report ownership.\n",
+  );
   f.invoke("task.submit", ["task", "submit", taskId], { actor });
   const reviewed = f.invoke(
     "task.review",


### PR DESCRIPTION
# English

## Summary

One-path closeout for artifact-only tasks: `ha task submit` accepts an artifact delivery (task-package path@revision anchors with center acceptance) as the alternative to a commit delivery, and an explicit preset migration (`standard-task` → `docs-task`) exists for already-created tasks whose deliverable is a report, reusing the existing snapshot event rather than a second write road. Reviewer verification is dispatched by delivery type (commit: ancestry/diff/CI; artifact: each path@revision's acceptance, ownership, immutable content). Real objects task_997414da and task_53b96aa4 are the first users (end-to-end on canonical after merge).

## Architectural Justification

Audit/research tasks had no honest way through submit→complete because the only recognized delivery was a public commit; the alternative was a forced transition that bypasses review. Adding a second delivery type inside the same submit/complete/reviewer chain keeps one path; a separate audit-only command would have been a second path.

## What Changed

- daemon submit delivery recognition (commit or artifact), preset migration action, reviewer input by delivery type; kernel contract updates; CLI flags; tests.
- `harness/agents/closeout-reviewer.json` instruction change is described in the report for the CEO to apply in the private ledger.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: production +, tests 49 targeted.

## Machine-Readable Declarations

- None.

## Task And Scope

- Harness task: task_6564b62f10b0bf3bc5994ed2c9 (parent task_4f7965fc895253bf70a4020f42)
- Branch: `codex/audit-closeout`
- Public scope: task submit/complete delivery types and preset migration
- Private planning/evidence updated: yes (`artifacts/report.md`)
- Out of scope: private reviewer declaration update and canonical deployment (CEO)

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: yes — `tools/smoke-cli-package.mjs` (package-policy smoke fixture): the fixture now submits its smoke artifact through `doc sync --submit` and cites it in the closeout Summary, because this PR makes closeout require an explicit delivery anchor
- Protected surface scope: fixture data only; the smoke's assertions (help, init, task create/start, restart) are unchanged and no check is skipped or weakened
- Authority: CEO ruling 2026-09-12 in task_6564b62f10b0bf3bc5994ed2c9 (Round 3 proposal `artifacts/round3-smoke-proposal.patch.txt` applied by CEO as be305af12)
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `466caf36a`
- Branch merge-base with `origin/main`: `466caf36a`
- Last `git fetch origin` time: 2026-09-12 UTC
- Sync method: branched from origin/main
- Public diff command: `git diff origin/main...codex/audit-closeout`
- Private evidence commit/path: task_6564b62f10b0bf3bc5994ed2c9 `artifacts/report.md`
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [x] `npm run typecheck` (worker, `tsc -b`)
- [ ] `npm run check`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts` (via `run-manifest-gates --changed origin/main`)
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- 49 targeted tests; typecheck, line-density, changed gates pass. End-to-end on the two real tasks with a model reviewer verdict is unverified until deployed.

## Review Evidence

- CEO ground-truth: read the worker report and the diff stat; commit authorship and scope checked.
- Reviewer subagent: closeout review after merge (one-path closeout)
- Human review: pending
- Blocking findings: none open

## Residual Risk

- Until the canonical daemon runs this build, the two real objects cannot be closed; their closure is the usage proof.

## References

- Task: task_6564b62f10b0bf3bc5994ed2c9

---

# 中文

## 概要

审计类任务的一条路收口：`ha task submit` 接受 artifact 交付（任务包 path@revision 锚 + center acceptance）作为提交交付之外的另一种交付；已创建任务若交付物是报告，可显式迁移 preset（`standard-task` → `docs-task`），复用既有 snapshot 事件而不是第二条写路。reviewer 按交付类型核验（commit：祖先/diff/CI；artifact：每个 path@revision 的 acceptance、归属、不可变内容）。真实对象 task_997414da 与 task_53b96aa4 是首两个使用者（合入部署后在 canonical 上端到端）。

## 架构辩护

审计/调研任务此前走不进 submit→complete，因为唯一被承认的交付是公开提交；替代只有绕过评审的强制转换。在同一条 submit/complete/reviewer 链里加第二种交付类型仍是一条路；单独的审计命令会是第二条路。

## 改动内容

- daemon submit 交付识别（commit 或 artifact）、preset 迁移动作、按交付类型的 reviewer 输入；kernel 契约；CLI 旗标；测试。
- `harness/agents/closeout-reviewer.json` 指令改法写在报告里，由 CEO 在私有台账落地。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 删除的门或 fixture：none
- 生产净行数：production +, tests 49 targeted。

## 机器可读声明

- 无。

## 任务与范围

- Harness 任务：task_6564b62f10b0bf3bc5994ed2c9（父 task_4f7965fc895253bf70a4020f42）
- 分支：`codex/audit-closeout`
- 公开范围：task submit/complete 交付类型与 preset 迁移
- 私有计划/证据已更新：是（`artifacts/report.md`）
- 范围外：私有 reviewer 声明更新与 canonical 部署（CEO）

## 版本影响

- 版本：不变
- 发布影响：不发布

## 治理声明

- 触碰受保护面：是——`tools/smoke-cli-package.mjs`（package-policy smoke fixture）：fixture 现在通过 `doc sync --submit` 提交 smoke 工件并在 closeout Summary 引用它，因为本 PR 让 closeout 必须带显式交付锚
- 受保护面范围：仅 fixture 数据；smoke 的断言（help、init、task create/start、重启）不变，没有跳过或削弱任何检查
- 授权：CEO 2026-09-12 在 task_6564b62f10b0bf3bc5994ed2c9 的裁决（Round 3 提案 `artifacts/round3-smoke-proposal.patch.txt`，由 CEO 以 be305af12 应用）
- 机器检查边界：本 PR 只断言声明存在；是否属实与充分由评审判断
- Break-glass：否
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- 基线 `origin/main` SHA：`466caf36a`
- 分支与 `origin/main` 的 merge-base：`466caf36a`
- 最近一次 `git fetch origin`：2026-09-12 UTC
- 同步方式：从 origin/main 开分支
- 公开 diff 命令：`git diff origin/main...codex/audit-closeout`
- 私有证据路径：task_6564b62f10b0bf3bc5994ed2c9 的 `artifacts/report.md`
- 评审证据路径：本 PR 的评审证据节
- GitHub Actions `rewrite-ci` run URL：本 PR 待跑
- 49 项定向测试；typecheck、line-density、changed gates 通过。两个真实任务带模型 verdict 的端到端在部署前未验证。

## 评审证据

- CEO 事实核对：读过 worker 报告与 diff 统计；核过提交人与范围。
- 评审子代理：合入后走一条路收口评审
- 人工评审：待定
- 阻塞发现：无

## 残余风险

- canonical daemon 跑上这个构建之前两个真实对象收不了口；它们的收口就是使用证明。

## 参考

- 任务：task_6564b62f10b0bf3bc5994ed2c9


