### PR TITLE
test: drain ledger git publication before fixture-side commits

### DIFF
--- a/packages/cli/test/release-cli-acceptance-scenario-1.integration.test.ts
+++ b/packages/cli/test/release-cli-acceptance-scenario-1.integration.test.ts
@@ -79,7 +79,10 @@ test("release acceptance: attributed lifecycle chain create→start→fact→sub
     const reportFile = path.join(root, "harness", packagePath, "artifacts", "implementation.md");
     mkdirSync(path.dirname(reportFile), { recursive: true });
     writeFileSync(reportFile, "# Release acceptance\n\nThe public probe is the code-doc verification target.\n");
-    run(root, userRoot, ["doc", "sync", "--submit", "--task", taskId], worker);
+    // The probe below commits repo Git directly, so the daemon must finish publishing this cut first;
+    // otherwise the two HEAD writers race and git dies with `cannot lock ref 'HEAD'`.
+    const probePublication = run(root, userRoot, ["doc", "sync", "--submit", "--task", taskId], worker);
+    settle(root, userRoot, String(probePublication.opId), worker);
 
     // A real repository deliverable, committed by the fixture, so code-doc reconcile has a true path.
     mkdirSync(path.join(root, "scripts"), { recursive: true });

--- a/packages/cli/test/release-cli-acceptance-scenario-2.integration.test.ts
+++ b/packages/cli/test/release-cli-acceptance-scenario-2.integration.test.ts
@@ -71,6 +71,8 @@ test("release acceptance: a fresh custom Artifact kind runs its file/folder life
     writeFileSync(path.join(absoluteSource, "README.md"), readmeBytes);
     writeFileSync(path.join(absoluteSource, "data.json"), dataBytes);
     writeFileSync(path.join(absoluteSource, "blobs", "binary.bin"), binaryBytes);
+    // Same HEAD-race guard as scenario 1: drain the daemon's ledger publication before committing.
+    settle(root, userRoot, String(upserted.opId));
     git(root, "add", sourcePath);
     git(root, "commit", "--quiet", "-m", "custom kind source");
 

--- a/packages/daemon/test/json-rpc-protocol.test.ts
+++ b/packages/daemon/test/json-rpc-protocol.test.ts
@@ -380,7 +380,13 @@ test("GUI and CLI submit derive the same canonical event from closeout", async (
     roots.forEach(initDeterministicRepo);
     for (const [index, rootDir] of roots.entries()) cells.push(await openRepoCell({ repoId: workspaceId("submit-ab"), rootDir: canonicalRoot(rootDir), ownerId: `submit-ab-${index}`, now }));
     for (const [index, cell] of cells.entries()) { const created = await cell.run({ kind: "task-create", taskId, title: "Submit A B" }, binding); assert.equal(created.outcome, "applied"); const visible = await waitForAcceptedReceipt(cell, created, binding); assert.equal(visible.wait?.state, "satisfied", JSON.stringify(visible)); await realizeTaskPlanFixture(roots[index]!, String((created as Record<string, unknown>).packagePath), (planPath) => cell.run({ kind: "doc-submit", paths: [planPath] }, binding)); assert.equal((await cell.run({ kind: "task-start", taskId, executionId }, binding)).outcome, "applied"); }
-    roots.forEach((rootDir) => writeCloseout(rootDir, "tasks/task-submit-ab-submit-a-b", "Typed GUI submit is equivalent."));
+    for (const [index, rootDir] of roots.entries())
+      await writeCloseout(
+        () => cells[index]!.settlePendingMaterialization("closeout git commit"),
+        rootDir,
+        "tasks/task-submit-ab-submit-a-b",
+        "Typed GUI submit is equivalent.",
+      );
     assert.equal((await cells[0]!.run({ kind: "task-submit", taskId, executionId }, binding)).outcome, "applied");
     const server = createJsonRpcProtocolServer({ host: { remoteProxy: { route: () => false }, run: async (_repoId: string, action: Record<string, unknown>) => cells[1]!.run(action as { readonly kind: string }, binding) } as never, build: { commit: null }, authContext: {} as never, emit: async () => undefined }); await server.handle({ jsonrpc: "2.0", id: 1, method: "protocol.hello", params: { protocolVersion: currentDaemonProtocolVersion } }); const response = await server.handle({ jsonrpc: "2.0", id: 2, method: "repo.task.submit", params: { repo: { repoId: "submit-ab" }, payload: { taskId, executionId } } }); assert.ok(response && !Array.isArray(response) && "result" in response, JSON.stringify(response)); assert.equal((response as { result: { outcome: string } }).result.outcome, "applied", JSON.stringify(response)); server.close();
     const events = roots.map((rootDir) => makeTaskEventReader({ repoId: "submit-ab", rootDir }).read().events.find((event) => event.type === "execution_submitted"));
@@ -414,7 +420,12 @@ test("lifecycle commands publish typed events, machine files, rebuildable L2, an
     assert.equal(invalidSubmit.outcome, "op_rejected");
     assert.equal(makeTaskEventReader({ repoId: "lifecycle-files", rootDir }).readHead()?.revision, Number(beforeInvalidSubmit) + 1);
     assert.equal(makeTaskEventReader({ repoId: "lifecycle-files", rootDir }).read().events.some((event) => event.type === "execution_submitted"), false);
-    const commitSha = writeCloseout(rootDir, packagePath, "Lifecycle output is ready.");
+    const commitSha = await writeCloseout(
+      () => cell!.settlePendingMaterialization("closeout git commit"),
+      rootDir,
+      packagePath,
+      "Lifecycle output is ready.",
+    );
     const submitted = await cell.run({ kind: "task-submit", taskId, executionId }, binding) as unknown as Record<string, unknown>; await assertCut(submitted, "execution_submitted", [indexPath, executionPath]); assert.deepEqual(submitted.transition, { from: "active/implementation", to: "in_review/review" }); assert.match(readFileSync(path.join(rootDir, "harness", executionPath), "utf8"), /State: submitted[\s\S]*Lifecycle output is ready/u);
     writeFileSync(path.join(rootDir, "review.json"), JSON.stringify({ verdict: "approved", reason: "Independent review passed.", evidenceChecked: ["tests"] })); const reviewBinding = withRoleBinding({ actor: { principal: { personId: "person-reviewer" }, executor: { kind: "agent" as const, id: "arbiter" } }, source: "local" as const }, "arbiter");
     const reviewed = await cell.run({ kind: "task-review-execution", taskId, executionId, reviewId: "review-life", fromFile: "review.json" }, reviewBinding) as unknown as Record<string, unknown>; await assertCut(reviewed, "review_recorded", [indexPath, executionPath, reviewPath]); assert.equal(reviewed.reviewId, "review-life"); assert.match(readFileSync(path.join(rootDir, "harness", reviewPath), "utf8"), /Verdict: approved[\s\S]*Consent: pending/u);
@@ -573,7 +584,13 @@ test("milestone-closeout uses the normal completion facade, review, and gates ex
 
     await cell.run({ kind: "task-progress-append", taskId, text: "implementation complete", evidence: [] }, binding); await cell.run({ kind: "fact-record", taskId, statement: "Completion uses canonical witnesses.", evidenceSource: "test:completion", confidence: "high", memoryClass: "semantic", memoryTags: [] }, binding);
     const closeoutPath = `${packagePath}/closeout.md`, artifactPath = `${packagePath}/artifacts/evidence.md`; writeFileSync(path.join(rootDir, "harness", closeoutPath), "# Closeout\n\n## Summary\n\nComplete.\n\n## Verification\n\nAll checks passed.\n\n## Residual Risk\n\nNone.\n\n## Same Mechanism Elsewhere\n\nNot applicable to this fixture.\n"); writeFileSync(path.join(rootDir, "harness", artifactPath), "# Evidence\n\nCanonical flow.\n");
-    const commitSha = writeCloseout(rootDir, packagePath, "All required outputs are complete.", "All checks passed.");
+    const commitSha = await writeCloseout(
+      () => cell!.settlePendingMaterialization("closeout git commit"),
+      rootDir,
+      packagePath,
+      "All required outputs are complete.",
+      "All checks passed.",
+    );
     assert.equal((await cell.run({ kind: "task-submit", taskId, executionId }, binding)).outcome, "applied");
     const missingCi = await cell.run({ kind: "task-complete", taskId, executionId }, binding) as unknown as Record<string, unknown>; assert.deepEqual({ outcome: missingCi.outcome, code: missingCi.code, steps: missingCi.steps }, { outcome: "op_rejected", code: "ci_missing", steps: [] }); await publishCiObservation("completion-facade", rootDir, executionId, commitSha, "run-completion-facade");
     const beforeReviewBlock = store().read().revision,
@@ -1186,7 +1203,12 @@ test("Policy rejects a principal without a durable-action RoleBinding", async ()
     assert.equal(deniedReview.outcome, "op_rejected"); assert.equal(deniedReview.code, "authorization_denied");
     const deniedAdmin = await rpc(host, auth(ids.reader), "daemon.repo.register", { rootDir: second, repoId: "second" });
     assert.equal(deniedAdmin.outcome, "op_rejected"); assert.equal(deniedAdmin.code, "authorization_denied");
-    writeCloseout(root, String((created as Record<string, unknown>).packagePath), "Role-bound delivery complete.");
+    await writeCloseout(
+      () => host.run("rbac", { kind: "doc-materialize" }, auth(ids.writer)),
+      root,
+      String((created as Record<string, unknown>).packagePath),
+      "Role-bound delivery complete.",
+    );
     assert.equal((await host.run("rbac", { kind: "task-submit", taskId: "task-rbac", executionId }, auth(ids.writer))).outcome, "applied");
     writeFileSync(path.join(root, "review.json"), JSON.stringify({ verdict: "approved", reason: "checked", evidenceChecked: [] }));
     const review = await host.run("rbac", { kind: "task-review-execution", taskId: "task-rbac", executionId, reviewId: "review-rbac", fromFile: "review.json" }, auth(ids.arbiter)); assert.equal(review.outcome, "applied", JSON.stringify(review));
@@ -1354,7 +1376,16 @@ test("task complete accepts a verified main run on a commit that contains the su
   }
 });
 
-function writeCloseout(rootDir: string, packagePath: string, summary: string, verification = "Verified."): string {
+async function writeCloseout(
+  drain: () => Promise<unknown>,
+  rootDir: string,
+  packagePath: string,
+  summary: string,
+  verification = "Verified.",
+): Promise<string> {
+  // The cell publishes ledger cuts to the same repo Git; drain its writer queue before this fixture
+  // commit, or the two HEAD writers race and git dies with `cannot lock ref 'HEAD'`.
+  await drain();
   writeFileSync(path.join(rootDir, "README.md"), "# Verified delivery\n");
   git(rootDir, "add", "README.md");
   execFileSync("git", ["-C", rootDir, "commit", "--quiet", "-m", "test: verified delivery"], {
@@ -1446,7 +1477,12 @@ async function prepareReadyCompletion(
     .toLocaleLowerCase("en-US")
     .replace(/[^a-z0-9]+/gu, "-")
     .replace(/^-|-$/gu, "")}`;
-  const commitSha = writeCloseout(rootDir, packagePath, "Ready.");
+  const commitSha = await writeCloseout(
+    () => cell.settlePendingMaterialization("closeout git commit"),
+    rootDir,
+    packagePath,
+    "Ready.",
+  );
   const submitted = await cell.run({ kind: "task-submit", taskId, executionId }, binding);
   assert.equal(submitted.outcome, "applied", JSON.stringify(submitted));
   assert.equal((await waitForAcceptedReceipt(cell, submitted, binding)).wait?.state, "satisfied");


### PR DESCRIPTION
# English

## Summary

Three CI flakes in one family (json-rpc-protocol on #2519, release-acceptance on #2526, submit-ab-structured on #2525/#2530): a test fixture ran its own `git commit` on the temporary ledger while the daemon's background Git publication was advancing HEAD, so git refused with `cannot lock ref 'HEAD': is at X but expected Y`. The fixtures now settle the daemon's write queue (`settle()` for `git_verified,worktree_visible` / `settlePendingMaterialization` / `doc-materialize`) before any fixture-side commit; `writeCloseout` in json-rpc-protocol takes a required drain argument wired at all five call sites. No production change.

## Architectural Justification

-

## What Changed

- `packages/cli/test/release-cli-acceptance-scenario-1.integration.test.ts`, `scenario-2`: settle before fixture commit.
- `packages/daemon/test/json-rpc-protocol.test.ts`: `writeCloseout` drains ledger publication first.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: +0/-0 production; tests +48/-7.

## Machine-Readable Declarations

- None.

## Task And Scope

- Harness task: task_1dd31ab1ce17d51f5a2a0fe982 (parent task_2b8f79fa4412cb726a26f9bfc7)
- Branch: `codex/reflock-flake`
- Public scope: test fixtures only
- Private planning/evidence updated: yes (`artifacts/report.md`)
- Out of scope: none

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: not applicable
- Machine-check boundary: not applicable
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `466caf36a`
- Branch merge-base with `origin/main`: `466caf36a`
- Last `git fetch origin` time: 2026-09-12 UTC
- Sync method: branched from origin/main
- Public diff command: `git diff origin/main...codex/reflock-flake`
- Private evidence commit/path: task_1dd31ab1ce17d51f5a2a0fe982 `artifacts/report.md`
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [x] `npm run typecheck` (worker, `tsc -b`)
- [ ] `npm run check`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts` (via `run-manifest-gates --changed origin/main`)
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Targeted files green after the change (GLM report); the race reproduced before the change.

## Review Evidence

- CEO ground-truth: read the worker report and the diff stat; commit authorship and scope checked.
- Reviewer subagent: closeout review after merge (one-path closeout)
- Human review: pending
- Blocking findings: none open

## Residual Risk

- Other fixtures that commit on a live ledger may exist; the report's grep lists the three found.

## References

- Task: task_1dd31ab1ce17d51f5a2a0fe982

---

# 中文

## 概要

同族三次 CI flake（#2519 的 json-rpc-protocol、#2526 的 release-acceptance、#2525/#2530 的 submit-ab-structured）：测试 fixture 在临时台账上自己 `git commit`，而 daemon 后台 Git 发布正在推进 HEAD，git 拒绝 `cannot lock ref 'HEAD': is at X but expected Y`。fixture 现在先等 daemon 写队列排空（`settle()` 等 `git_verified,worktree_visible` / `settlePendingMaterialization` / `doc-materialize`）再做 fixture 侧提交；json-rpc-protocol 的 `writeCloseout` 增加必传 drain 参数，五个调用点全部接上。无生产改动。

## 架构辩护

-

## 改动内容

- `packages/cli/test/release-cli-acceptance-scenario-1.integration.test.ts`、`scenario-2`：fixture 提交前 settle。
- `packages/daemon/test/json-rpc-protocol.test.ts`：`writeCloseout` 先排空台账发布。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 删除的门或 fixture：none
- 生产净行数：+0/-0 production; tests +48/-7。

## 机器可读声明

- 无。

## 任务与范围

- Harness 任务：task_1dd31ab1ce17d51f5a2a0fe982（父 task_2b8f79fa4412cb726a26f9bfc7）
- 分支：`codex/reflock-flake`
- 公开范围：仅测试 fixture
- 私有计划/证据已更新：是（`artifacts/report.md`）
- 范围外：无

## 版本影响

- 版本：不变
- 发布影响：不发布

## 治理声明

- 触碰受保护面：否
- 受保护面范围：不适用
- 授权：不适用
- 机器检查边界：不适用
- Break-glass：否
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- 基线 `origin/main` SHA：`466caf36a`
- 分支与 `origin/main` 的 merge-base：`466caf36a`
- 最近一次 `git fetch origin`：2026-09-12 UTC
- 同步方式：从 origin/main 开分支
- 公开 diff 命令：`git diff origin/main...codex/reflock-flake`
- 私有证据路径：task_1dd31ab1ce17d51f5a2a0fe982 的 `artifacts/report.md`
- 评审证据路径：本 PR 的评审证据节
- GitHub Actions `rewrite-ci` run URL：本 PR 待跑
- 改后定向文件全绿（GLM 报告）；改前竞态可复现。

## 评审证据

- CEO 事实核对：读过 worker 报告与 diff 统计；核过提交人与范围。
- 评审子代理：合入后走一条路收口评审
- 人工评审：待定
- 阻塞发现：无

## 残余风险

- 可能还有别的 fixture 在活台账上提交；报告的 grep 列出了找到的三处。

## 参考

- 任务：task_1dd31ab1ce17d51f5a2a0fe982

