### PR TITLE
test: normalize checkout line endings in isolated-test snapshot assertion

### DIFF
--- a/tools/dispatch-isolated-test.test.mjs
+++ b/tools/dispatch-isolated-test.test.mjs
@@ -160,7 +160,10 @@ for (const transport of ["tar", "rsync"]) {
         assert.equal(gitText(destination, ["show", "HEAD^:tools/kept.txt"]), "tools/kept.txt");
         assert.match(gitText(destination, ["status", "--porcelain"]), /M tools\/kept.txt/u);
         assert.equal(readFileSync(path.join(destination, "tools/kept.txt"), "utf8"), "dirty tracked content\n");
-        assert.equal(readFileSync(path.join(destination, "prettier.config.mjs"), "utf8"), "prettier.config.mjs\n");
+        assert.equal(
+          readFileSync(path.join(destination, "prettier.config.mjs"), "utf8").replace(/\r\n/gu, "\n"),
+          "prettier.config.mjs\n",
+        );
         assert.equal(existsSync(path.join(destination, "future-root/space name.txt")), true);
         assert.equal(existsSync(path.join(destination, "private")), false);
         assert.equal(gitText(destination, ["remote"]), "");


### PR DESCRIPTION
# English

## Summary

The main run for eba5faac8 failed only in the crlf-checkout lane: two cases in the isolated-test snapshot suite compare the checked-out `prettier.config.mjs` against `prettier.config.mjs\n`, but that lane checks out with `core.autocrlf true`, so the tracked file reads back as `\r\n`. The line ending of a tracked file after checkout is a platform setting, not a snapshot defect, so the assertion normalizes `\r\n` to `\n` before comparing. No behavior change in the snapshot tools.

## Architectural Justification

Smallest correct change: the expectation was wrong for one lane, so only the expectation is adjusted.

## What Changed

- `tools/dispatch-isolated-test.test.mjs`: normalize CRLF in the prettier.config.mjs content assertion (both tar and rsync cases).

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: +0/-0 production; tests +4/-1.

## Machine-Readable Declarations

- None.

## Task And Scope

- Harness task: task_064bb6d463a44aa6d698f55e8a (parent task_3733384e8940956916a5339810)
- Branch: `codex/crlf-prettier`
- Public scope: one test assertion
- Private planning/evidence updated: yes (`artifacts/report.md`)
- Out of scope: the snapshot transport itself (prepareSource/extractArchive/rsync) is untouched

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: not applicable
- Machine-check boundary: not applicable
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `554be6d94`
- Branch merge-base with `origin/main`: `554be6d94`
- Last `git fetch origin` time: 2026-09-12 UTC
- Sync method: branched from origin/main
- Public diff command: `git diff origin/main...codex/crlf-prettier`
- Private evidence commit/path: task_064bb6d463a44aa6d698f55e8a `artifacts/report.md`
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [x] `npm run typecheck` (worker, `tsc -b`)
- [ ] `npm run check`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts` (via `run-manifest-gates --changed origin/main`)
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- `node --test tools/dispatch-isolated-test.test.mjs` 12/12 locally on macOS; the crlf-checkout lane on this PR is the authority.

## Review Evidence

- CEO ground-truth: read the worker report and the diff stat; commit authorship and scope checked.
- Reviewer subagent: closeout review after merge (one-path closeout)
- Human review: pending
- Blocking findings: none open

## Residual Risk

- Other assertions on tracked-file content in this suite could hit the same lane later; only the one that failed is normalized.

## References

- Task: task_064bb6d463a44aa6d698f55e8a

---

# 中文

## 概要

eba5faac8 的 main 运行只在 crlf-checkout 车道红：隔离测试快照套件里两例把检出的 `prettier.config.mjs` 与 `prettier.config.mjs\n` 做严格比较，而该车道用 `core.autocrlf true` 检出，tracked 文件读回来是 `\r\n`。tracked 文件检出后的换行由平台配置决定，不是快照缺陷，所以断言前把 `\r\n` 归一化为 `\n`。快照工具行为不变。

## 架构辩护

最小正确改法：只有一条车道的期望值错了，所以只改期望值。

## 改动内容

- `tools/dispatch-isolated-test.test.mjs`：prettier.config.mjs 内容断言前归一化 CRLF（tar 与 rsync 两例）。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 删除的门或 fixture：none
- 生产净行数：+0/-0 production; tests +4/-1。

## 机器可读声明

- 无。

## 任务与范围

- Harness 任务：task_064bb6d463a44aa6d698f55e8a（父 task_3733384e8940956916a5339810）
- 分支：`codex/crlf-prettier`
- 公开范围：一处测试断言
- 私有计划/证据已更新：是（`artifacts/report.md`）
- 范围外：快照传输本身（prepareSource/extractArchive/rsync）不动

## 版本影响

- 版本：不变
- 发布影响：不发布

## 治理声明

- 触碰受保护面：否
- 受保护面范围：不适用
- 授权：不适用
- 机器检查边界：不适用
- Break-glass：否
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- 基线 `origin/main` SHA：`554be6d94`
- 分支与 `origin/main` 的 merge-base：`554be6d94`
- 最近一次 `git fetch origin`：2026-09-12 UTC
- 同步方式：从 origin/main 开分支
- 公开 diff 命令：`git diff origin/main...codex/crlf-prettier`
- 私有证据路径：task_064bb6d463a44aa6d698f55e8a 的 `artifacts/report.md`
- 评审证据路径：本 PR 的评审证据节
- GitHub Actions `rewrite-ci` run URL：本 PR 待跑
- macOS 本地 `node --test tools/dispatch-isolated-test.test.mjs` 12/12；本 PR 的 crlf-checkout 车道为权威。

## 评审证据

- CEO 事实核对：读过 worker 报告与 diff 统计；核过提交人与范围。
- 评审子代理：合入后走一条路收口评审
- 人工评审：待定
- 阻塞发现：无

## 残余风险

- 本套件里其他对 tracked 文件内容的断言以后也可能撞同一车道；本次只归一化红掉的那一处。

## 参考

- 任务：task_064bb6d463a44aa6d698f55e8a

