### PR TITLE
fix(gui): surface decision read failures instead of empty lists

### DIFF
--- a/packages/gui/src/renderer/App.tsx
+++ b/packages/gui/src/renderer/App.tsx
@@ -214,6 +214,11 @@ function AppShell() {
     previewTask !== null || selected !== null || overviewDecisionPreviewId !== null || view === "sessions";
   const activeEdges = useActiveEdgesQuery(activeRepoId, edgeSurfaceMounted && !triadicQuery.graphAvailable);
 
+  const decisionReadError = fullProjectionMounted
+    ? triadicQuery.decisionError
+    : view === "overview"
+      ? decisionSummary.error
+      : null;
   const decisions = triadicQuery.decisions;
   const facts = triadicQuery.facts;
   const coverageRows = triadicQuery.coverageRows;
@@ -442,6 +447,8 @@ function AppShell() {
                   }}
                   onFocusGraph={focusEntityInGraph}
                 />
+              ) : decisionReadError ? (
+                <WorkspaceSummaryPending error={decisionReadError} />
               ) : view === "home" ? (
                 <HomeView
                   repos={systemQuery.data?.repos ?? []}

--- a/packages/gui/src/renderer/api-client-decisions.ts
+++ b/packages/gui/src/renderer/api-client-decisions.ts
@@ -1,0 +1,184 @@
+import type { DecisionProjectionRow, GuiActionResult, ProjectionWarning } from "../api/renderer-dto.ts";
+import { readGuiActionResult } from "./command-receipt.ts";
+import { daemonBridgeError } from "./daemon-startup.ts";
+import { isRendererRecord } from "./result-validation.ts";
+
+export interface DecisionListSuccess {
+  readonly ok: true;
+  readonly decisions: ReadonlyArray<DecisionProjectionRow>;
+  readonly warnings: ReadonlyArray<ProjectionWarning>;
+}
+
+/**
+ * `repo.decisions.list {projection:"summary"}` row: the fields the overview's decision
+ * stream renders and sorts. It deliberately excludes claims, consents, and body; opening
+ * a row reads that one complete decision separately.
+ */
+export interface DecisionSummaryRow {
+  readonly decisionId: string;
+  readonly title: string;
+  readonly state: DecisionProjectionRow["state"];
+  readonly riskTier: DecisionProjectionRow["riskTier"];
+  readonly urgency: DecisionProjectionRow["urgency"];
+  readonly proposedAt: DecisionProjectionRow["proposedAt"];
+}
+
+export interface DecisionSummaryListSuccess {
+  readonly ok: true;
+  readonly projection: "summary";
+  readonly decisions: ReadonlyArray<DecisionSummaryRow>;
+  readonly warnings: ReadonlyArray<ProjectionWarning>;
+}
+
+export interface DecisionControlListSuccess {
+  readonly status: "ready" | "pending";
+  readonly decisionIds: ReadonlyArray<string>;
+  readonly opId: string;
+  readonly hint?: string;
+}
+
+export interface DecisionShowSuccess {
+  readonly status: "ready" | "pending";
+  readonly decision: DecisionProjectionRow;
+  readonly hint: string | null;
+}
+
+export interface DecisionProposalInput {
+  readonly title: string;
+  readonly question: string;
+  readonly riskTier: "low" | "medium" | "high";
+  readonly urgency: "low" | "medium" | "high";
+  readonly vertical: string;
+  readonly preset: string;
+  readonly decisionClass: "ordinary" | "standing_policy";
+  readonly appliesTo: { readonly modules: readonly string[]; readonly productLines: readonly string[] };
+  readonly chosen: ReadonlyArray<{ readonly id: string; readonly text: string; readonly rationale?: string }>;
+  readonly rejected: ReadonlyArray<{ readonly id: string; readonly text: string; readonly whyNot: string }>;
+  readonly body: string;
+  readonly claims: ReadonlyArray<{ readonly id: string; readonly text: string; readonly loadBearing: boolean }>;
+  readonly fulfillments: ReadonlyArray<{
+    readonly claimId: string;
+    readonly mode: "evidenced" | "delivered" | "standing_policy";
+  }>;
+}
+
+function decisionReadError(value: unknown): Error {
+  const error = daemonBridgeError(
+    value,
+    "GUI/daemon decision response shape mismatch; reload the GUI with the matching daemon build.",
+  );
+  return new Error(`Decision read failed [${error.code ?? "daemon_decision_result_invalid"}]: ${error.message}`);
+}
+
+export function readDecisionListResult(value: unknown): DecisionListSuccess {
+  const result = value as Partial<DecisionListSuccess>;
+  if (
+    !result ||
+    result.ok !== true ||
+    !Array.isArray(result.decisions) ||
+    !result.decisions.every(isDecisionProjectionRow)
+  ) {
+    throw decisionReadError(value);
+  }
+  return {
+    ok: true,
+    decisions: result.decisions,
+    warnings: Array.isArray(result.warnings) ? result.warnings : [],
+  };
+}
+
+/** Summary rows are a different wire shape than `decision-row/v1`; never filter them
+ *  through `isDecisionProjectionRow`, which would silently drop every row. */
+export function readDecisionSummaryListResult(value: unknown): DecisionSummaryListSuccess {
+  const result = value as Partial<DecisionSummaryListSuccess>;
+  const rows = result?.decisions;
+  if (
+    !result ||
+    result.ok !== true ||
+    result.projection !== "summary" ||
+    !Array.isArray(rows) ||
+    !rows.every(isDecisionSummaryRow)
+  ) {
+    throw decisionReadError(value);
+  }
+  return {
+    ok: true,
+    projection: "summary",
+    decisions: rows,
+    warnings: Array.isArray(result.warnings) ? result.warnings : [],
+  };
+}
+
+function isDecisionSummaryRow(value: unknown): value is DecisionSummaryRow {
+  if (!isRendererRecord(value)) return false;
+  return (
+    typeof value.decisionId === "string" &&
+    typeof value.title === "string" &&
+    typeof value.state === "string" &&
+    (value.riskTier === "low" || value.riskTier === "medium" || value.riskTier === "high") &&
+    (value.urgency === "low" || value.urgency === "medium" || value.urgency === "high") &&
+    typeof value.proposedAt === "string"
+  );
+}
+
+export function readDecisionControlList(value: unknown): DecisionControlListSuccess {
+  const receipt = readGuiActionResult(value) as GuiActionResult & {
+    readonly evidence?: string;
+    readonly nextAction?: string;
+    readonly error?: { readonly code?: string; readonly hint?: string };
+  };
+  if (receipt.outcome === "op_rejected" || receipt.outcome === "indeterminate")
+    throw new Error(
+      `${receipt.error?.code ?? receipt.outcome}: ${
+        receipt.error?.hint ?? receipt.nextAction ?? "Decision list failed."
+      }`,
+    );
+  try {
+    const evidence = JSON.parse(receipt.evidence ?? "") as { readonly status?: unknown; readonly decisions?: unknown };
+    if ((evidence.status !== "ready" && evidence.status !== "pending") || !Array.isArray(evidence.decisions))
+      throw new Error();
+    const decisionIds = evidence.decisions.flatMap((item) =>
+      isRendererRecord(item) && typeof item.decisionId === "string" ? [item.decisionId] : [],
+    );
+    return {
+      status: evidence.status,
+      decisionIds,
+      opId: receipt.opId,
+      ...(receipt.nextAction ? { hint: receipt.nextAction } : {}),
+    };
+  } catch {
+    throw new Error("Decision list receipt evidence is invalid.");
+  }
+}
+
+export function readDecisionShowResult(value: unknown): DecisionShowSuccess {
+  const receipt = readGuiActionResult(value) as GuiActionResult & {
+    readonly evidence?: string;
+    readonly nextAction?: string;
+    readonly error?: { readonly code?: string; readonly hint?: string };
+  };
+  if (receipt.outcome === "op_rejected" || receipt.outcome === "indeterminate") {
+    const detail = receipt.error?.hint ?? receipt.nextAction ?? "Decision show failed.";
+    throw new Error(`${receipt.error?.code ?? receipt.outcome}: ${detail}`);
+  }
+  try {
+    const evidence = JSON.parse(receipt.evidence ?? "") as { readonly status?: unknown; readonly decision?: unknown };
+    if ((evidence.status !== "ready" && evidence.status !== "pending") || !isDecisionProjectionRow(evidence.decision))
+      throw new Error();
+    return { status: evidence.status, decision: evidence.decision, hint: receipt.nextAction ?? null };
+  } catch {
+    throw new Error("Decision show receipt evidence is invalid.");
+  }
+}
+
+function isDecisionProjectionRow(value: unknown): value is DecisionProjectionRow {
+  return (
+    isRendererRecord(value) &&
+    value.schema === "decision-row/v1" &&
+    typeof value.decisionId === "string" &&
+    typeof value.title === "string" &&
+    typeof value.state === "string" &&
+    Number.isInteger(value.workspaceRevision) &&
+    Array.isArray(value.claims)
+  );
+}

--- a/packages/gui/src/renderer/api-client.ts
+++ b/packages/gui/src/renderer/api-client.ts
@@ -4,7 +4,6 @@ import type {
   AgendaTaskRow,
   AgendaAwaitingRow,
   ContractVersion,
-  DecisionProjectionRow,
   FactAnchorRow,
   RelationFactRow,
   GuiActionResult,
@@ -36,6 +35,25 @@ import { isSettingsSuccess } from "./settings-payload.ts";
 import { invoke } from "./api-client-invoke.ts";
 import { readGuiActionResult } from "./command-receipt.ts";
 import { daemonBridgeError } from "./daemon-startup.ts";
+import {
+  readDecisionControlList,
+  readDecisionListResult,
+  readDecisionShowResult,
+  readDecisionSummaryListResult,
+  type DecisionControlListSuccess,
+  type DecisionListSuccess,
+  type DecisionProposalInput,
+  type DecisionShowSuccess,
+  type DecisionSummaryListSuccess,
+} from "./api-client-decisions.ts";
+export type {
+  DecisionControlListSuccess,
+  DecisionListSuccess,
+  DecisionProposalInput,
+  DecisionShowSuccess,
+  DecisionSummaryListSuccess,
+  DecisionSummaryRow,
+} from "./api-client-decisions.ts";
 
 export interface TaskListSuccess {
   readonly ok: true;
@@ -119,32 +137,6 @@ export type RelationQueryFacets =
   | RelationFactFacetQuery
   | RelationRuntimeEdgeFacetQuery;
 
-export interface DecisionListSuccess {
-  readonly ok: true;
-  readonly decisions: ReadonlyArray<DecisionProjectionRow>;
-  readonly warnings: ReadonlyArray<ProjectionWarning>;
-}
-
-/**
- * `repo.decisions.list {projection:"summary"}` row: the fields the overview's decision
- * stream renders and sorts. It deliberately excludes claims, consents, and body; opening
- * a row reads that one complete decision separately.
- */
-export interface DecisionSummaryRow {
-  readonly decisionId: string;
-  readonly title: string;
-  readonly state: DecisionProjectionRow["state"];
-  readonly riskTier: DecisionProjectionRow["riskTier"];
-  readonly urgency: DecisionProjectionRow["urgency"];
-  readonly proposedAt: DecisionProjectionRow["proposedAt"];
-}
-export interface DecisionSummaryListSuccess {
-  readonly ok: true;
-  readonly projection: "summary";
-  readonly decisions: ReadonlyArray<DecisionSummaryRow>;
-  readonly warnings: ReadonlyArray<ProjectionWarning>;
-}
-
 /** `repo.triadic.relationGraph {facet:"facts"}` row: the palette's fact vocabulary. */
 export interface RelationFactSummaryRow {
   readonly anchor: string;
@@ -175,19 +167,6 @@ export type SettingsUpdateInput = RepoScope &
     walFlushBytes: number;
     walFlushMilliseconds: number;
   }> & { readonly idempotencyKey: string };
-
-export interface DecisionControlListSuccess {
-  readonly status: "ready" | "pending";
-  readonly decisionIds: ReadonlyArray<string>;
-  readonly opId: string;
-  readonly hint?: string;
-}
-
-export interface DecisionShowSuccess {
-  readonly status: "ready" | "pending";
-  readonly decision: DecisionProjectionRow;
-  readonly hint: string | null;
-}
 
 export interface RepoScope {
   readonly repoId: string;
@@ -347,25 +326,6 @@ export interface CatalogRereadReceipt {
   readonly repoId: string;
   readonly observedAt: string;
   readonly error: BridgeError | null;
-}
-
-export interface DecisionProposalInput {
-  readonly title: string;
-  readonly question: string;
-  readonly riskTier: "low" | "medium" | "high";
-  readonly urgency: "low" | "medium" | "high";
-  readonly vertical: string;
-  readonly preset: string;
-  readonly decisionClass: "ordinary" | "standing_policy";
-  readonly appliesTo: { readonly modules: readonly string[]; readonly productLines: readonly string[] };
-  readonly chosen: ReadonlyArray<{ readonly id: string; readonly text: string; readonly rationale?: string }>;
-  readonly rejected: ReadonlyArray<{ readonly id: string; readonly text: string; readonly whyNot: string }>;
-  readonly body: string;
-  readonly claims: ReadonlyArray<{ readonly id: string; readonly text: string; readonly loadBearing: boolean }>;
-  readonly fulfillments: ReadonlyArray<{
-    readonly claimId: string;
-    readonly mode: "evidenced" | "delivered" | "standing_policy";
-  }>;
 }
 
 export const harnessClient = {
@@ -785,65 +745,6 @@ function isQueryPage(value: unknown): value is QueryPage {
   );
 }
 
-function decisionReadError(value: unknown): Error {
-  const error = daemonBridgeError(
-    value,
-    "GUI/daemon decision response shape mismatch; reload the GUI with the matching daemon build.",
-  );
-  return new Error(`Decision read failed [${error.code ?? "daemon_decision_result_invalid"}]: ${error.message}`);
-}
-
-function readDecisionListResult(value: unknown): DecisionListSuccess {
-  const result = value as Partial<DecisionListSuccess>;
-  if (
-    !result ||
-    result.ok !== true ||
-    !Array.isArray(result.decisions) ||
-    !result.decisions.every(isDecisionProjectionRow)
-  ) {
-    throw decisionReadError(value);
-  }
-  return {
-    ok: true,
-    decisions: result.decisions,
-    warnings: Array.isArray(result.warnings) ? result.warnings : [],
-  };
-}
-
-/** Summary rows are a different wire shape than `decision-row/v1`; never filter them
- *  through `isDecisionProjectionRow`, which would silently drop every row. */
-function readDecisionSummaryListResult(value: unknown): DecisionSummaryListSuccess {
-  const result = value as Partial<DecisionSummaryListSuccess>;
-  const rows = result?.decisions;
-  if (
-    !result ||
-    result.ok !== true ||
-    result.projection !== "summary" ||
-    !Array.isArray(rows) ||
-    !rows.every(isDecisionSummaryRow)
-  ) {
-    throw decisionReadError(value);
-  }
-  return {
-    ok: true,
-    projection: "summary",
-    decisions: rows,
-    warnings: Array.isArray(result.warnings) ? result.warnings : [],
-  };
-}
-
-function isDecisionSummaryRow(value: unknown): value is DecisionSummaryRow {
-  if (!isRendererRecord(value)) return false;
-  return (
-    typeof value.decisionId === "string" &&
-    typeof value.title === "string" &&
-    typeof value.state === "string" &&
-    (value.riskTier === "low" || value.riskTier === "medium" || value.riskTier === "high") &&
-    (value.urgency === "low" || value.urgency === "medium" || value.urgency === "high") &&
-    typeof value.proposedAt === "string"
-  );
-}
-
 function readRelationFactFacetResult(value: unknown): RelationFactFacetSuccess {
   const result = value as Partial<RelationFactFacetSuccess>;
   if (
@@ -876,54 +777,6 @@ function isRelationFactSummaryRow(value: unknown): value is RelationFactSummaryR
     (value.category === "lesson" || value.category === "finding" || value.category === "progress") &&
     (value.taskId === undefined || typeof value.taskId === "string")
   );
-}
-
-function readDecisionControlList(value: unknown): DecisionControlListSuccess {
-  const receipt = readGuiActionResult(value) as GuiActionResult & {
-    readonly evidence?: string;
-    readonly nextAction?: string;
-    readonly error?: { readonly code?: string; readonly hint?: string };
-  };
-  if (receipt.outcome === "op_rejected" || receipt.outcome === "indeterminate")
-    throw new Error(
-      `${receipt.error?.code ?? receipt.outcome}: ${receipt.error?.hint ?? receipt.nextAction ?? "Decision list failed."}`,
-    );
-  try {
-    const evidence = JSON.parse(receipt.evidence ?? "") as { readonly status?: unknown; readonly decisions?: unknown };
-    if ((evidence.status !== "ready" && evidence.status !== "pending") || !Array.isArray(evidence.decisions))
-      throw new Error();
-    const decisionIds = evidence.decisions.flatMap((item) =>
-      isRendererRecord(item) && typeof item.decisionId === "string" ? [item.decisionId] : [],
-    );
-    return {
-      status: evidence.status,
-      decisionIds,
-      opId: receipt.opId,
-      ...(receipt.nextAction ? { hint: receipt.nextAction } : {}),
-    };
-  } catch {
-    throw new Error("Decision list receipt evidence is invalid.");
-  }
-}
-
-function readDecisionShowResult(value: unknown): DecisionShowSuccess {
-  const receipt = readGuiActionResult(value) as GuiActionResult & {
-    readonly evidence?: string;
-    readonly nextAction?: string;
-    readonly error?: { readonly code?: string; readonly hint?: string };
-  };
-  if (receipt.outcome === "op_rejected" || receipt.outcome === "indeterminate") {
-    const detail = receipt.error?.hint ?? receipt.nextAction ?? "Decision show failed.";
-    throw new Error(`${receipt.error?.code ?? receipt.outcome}: ${detail}`);
-  }
-  try {
-    const evidence = JSON.parse(receipt.evidence ?? "") as { readonly status?: unknown; readonly decision?: unknown };
-    if ((evidence.status !== "ready" && evidence.status !== "pending") || !isDecisionProjectionRow(evidence.decision))
-      throw new Error();
-    return { status: evidence.status, decision: evidence.decision, hint: receipt.nextAction ?? null };
-  } catch {
-    throw new Error("Decision show receipt evidence is invalid.");
-  }
 }
 
 function readSystemStatus(value: unknown): SystemStatusSuccess {
@@ -1062,18 +915,6 @@ function isTaskSnapshotInvalidRow(value: unknown): value is TaskSnapshotInvalidR
     typeof value.taskId === "string" &&
     typeof value.field === "string" &&
     typeof value.message === "string"
-  );
-}
-
-function isDecisionProjectionRow(value: unknown): value is DecisionProjectionRow {
-  return (
-    isRendererRecord(value) &&
-    value.schema === "decision-row/v1" &&
-    typeof value.decisionId === "string" &&
-    typeof value.title === "string" &&
-    typeof value.state === "string" &&
-    Number.isInteger(value.workspaceRevision) &&
-    Array.isArray(value.claims)
   );
 }
 

--- a/packages/gui/src/renderer/api-client.ts
+++ b/packages/gui/src/renderer/api-client.ts
@@ -785,14 +785,27 @@ function isQueryPage(value: unknown): value is QueryPage {
   );
 }
 
+function decisionReadError(value: unknown): Error {
+  const error = daemonBridgeError(
+    value,
+    "GUI/daemon decision response shape mismatch; reload the GUI with the matching daemon build.",
+  );
+  return new Error(`Decision read failed [${error.code ?? "daemon_decision_result_invalid"}]: ${error.message}`);
+}
+
 function readDecisionListResult(value: unknown): DecisionListSuccess {
   const result = value as Partial<DecisionListSuccess>;
-  if (!result || result.ok !== true || !Array.isArray(result.decisions)) {
-    throw new Error(localErrorHint(value, "Decision list bridge returned an invalid result."));
+  if (
+    !result ||
+    result.ok !== true ||
+    !Array.isArray(result.decisions) ||
+    !result.decisions.every(isDecisionProjectionRow)
+  ) {
+    throw decisionReadError(value);
   }
   return {
     ok: true,
-    decisions: result.decisions.filter(isDecisionProjectionRow),
+    decisions: result.decisions,
     warnings: Array.isArray(result.warnings) ? result.warnings : [],
   };
 }
@@ -809,7 +822,7 @@ function readDecisionSummaryListResult(value: unknown): DecisionSummaryListSucce
     !Array.isArray(rows) ||
     !rows.every(isDecisionSummaryRow)
   ) {
-    throw new Error(localErrorHint(value, "Decision summary bridge returned an invalid result."));
+    throw decisionReadError(value);
   }
   return {
     ok: true,

--- a/packages/gui/src/renderer/triadic-data.ts
+++ b/packages/gui/src/renderer/triadic-data.ts
@@ -78,6 +78,7 @@ export function useDecisionSummaryQuery(repoId: string | null, options: { readon
     decisions: query.data?.decisions ?? [],
     isPending: enabled && query.isPending,
     isError: query.isError,
+    error: query.error,
   };
 }
 
@@ -233,6 +234,7 @@ export function useTriadicProjectionQuery(
       isLoading,
       isPending,
       isError,
+      decisionError: decisionsEnabled ? decisions.error : null,
       graphAvailable,
       relationPageNextCursor: graph.data?.page?.nextCursor ?? null,
       relationState: graph.isError
@@ -248,6 +250,8 @@ export function useTriadicProjectionQuery(
       isPending,
       isError,
       graphAvailable,
+      decisionsEnabled,
+      decisions.error,
       graph.isError,
       graph.isPending,
       graphEnabled,

--- a/packages/gui/test/triadic-read-scoping.vitest.ts
+++ b/packages/gui/test/triadic-read-scoping.vitest.ts
@@ -135,7 +135,7 @@ function startOnView(view: string) {
  * 挂 App,从 `options.view` 起步。`getTasks` 决定台账 cut:每次返回的 watermark/
  * sourceRevision 变化都会触发 `invalidateLedgerDependents`,这正是被测的失效面。
  */
-async function mountApp(options: { readonly view: string }): Promise<{
+async function mountApp(options: { readonly view: string; readonly decisionResult?: unknown }): Promise<{
   readonly calls: () => readonly RecordedCall[];
   readonly container: HTMLElement;
   readonly navigate: (label: string) => Promise<void>;
@@ -229,6 +229,7 @@ async function mountApp(options: { readonly view: string }): Promise<{
     },
     getDecisions: async (payload) => {
       calls.push({ method: "getDecisions", payload: payload ?? null });
+      if (options.decisionResult !== undefined) return options.decisionResult;
       return payload?.projection === "summary"
         ? { ok: true, projection: "summary", decisions: [], warnings: [] }
         : { ok: true, decisions: [], warnings: [] };
@@ -316,6 +317,28 @@ afterEach(() => {
 const relationGraphCalls = (calls: readonly RecordedCall[]) =>
   calls.filter(({ method }) => method === "getRelationGraph");
 const decisionCalls = (calls: readonly RecordedCall[]) => calls.filter(({ method }) => method === "getDecisions");
+
+describe("决策读失败不能冒充空台账", () => {
+  it.each(["overview", "decisionPool", "graph"])("%s 显示拒绝码与原因", async (view) => {
+    const { container } = await mountApp({
+      view,
+      decisionResult: { ok: false, error: { code: "unknown_field", hint: "Rejected projection selector" } },
+    });
+    expect(container.textContent).toContain("unknown_field");
+    expect(container.textContent).toContain("Rejected projection selector");
+    expect(container.textContent).not.toContain("该状态下暂无决策");
+  });
+
+  it.each(["overview", "decisionPool", "graph"])("%s 明示不匹配的决策响应形状", async (view) => {
+    const { container } = await mountApp({
+      view,
+      decisionResult: { ok: true, projection: "summary", decisions: [{ decisionId: "dec_probe" }], warnings: [] },
+    });
+    expect(container.textContent).toContain("daemon_decision_result_invalid");
+    expect(container.textContent).toContain("GUI/daemon");
+    expect(container.textContent).not.toContain("该状态下暂无决策");
+  });
+});
 
 describe("三元读取按挂载域分层", () => {
   it("总览只读决策摘要与 ha agenda,决策抽屉关闭时不读图或完整决策", async () => {


### PR DESCRIPTION
# English

## Summary

The GUI Overview, Decision Pool, and Relationship Graph views rendered a failed decision read as an empty list, indistinguishable from an actually-empty state. Root cause: `useDecisionSummaryQuery`/`useTriadicProjectionQuery` defaulted query data to `[]` and never surfaced `isError`, and the full-row reader silently filtered out malformed rows into a successful empty result instead of rejecting them. The fix threads the query error through to a new `decisionReadError` selector that renders before the decision views, and `readDecisionListResult`/`readDecisionSummaryListResult` now throw a labeled error (`daemon_decision_result_invalid` or the daemon's own code/hint) instead of silently dropping bad rows.

## Architectural Justification

The fix reuses the existing page-level error component and the query library's own error field; no new state machine, retry, or fallback path was added, matching the minimal change needed to stop masking a real error as an empty state.

## What Changed

- `packages/gui/src/renderer/App.tsx`: compute `decisionReadError` and render it ahead of the decision-bearing views.
- `packages/gui/src/renderer/api-client.ts`: `readDecisionListResult`/`readDecisionSummaryListResult` throw a labeled decision-read error instead of filtering rows into a false-empty success.
- `packages/gui/src/renderer/triadic-data.ts`: `useDecisionSummaryQuery`/`useTriadicProjectionQuery` expose `error`/`decisionError` instead of only booleans.
- `packages/gui/test/triadic-read-scoping.vitest.ts`: six new cases assert rejected/malformed decision reads surface their code and hint on overview, decisionPool, and graph, and never render the empty-state copy.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: +28/-4 production; tests +24/-1.

## Machine-Readable Declarations

- None.

## Task And Scope

- Harness task: task_f8014a5fe34a6ac9112411215b (parent task_4f7965fc895253bf70a4020f42)
- Branch: `codex/gui-decisions`
- Public scope: GUI renderer only (4 files: App.tsx, api-client.ts, triadic-data.ts, and their vitest suite)
- Private planning/evidence updated: yes (`artifacts/report.md`)
- Out of scope: The original reported Electron-window symptom (a specific running build showing an empty decision view) is not reproduced or root-caused here; current daemon and source both return 836 decisions in every probe this worker ran. CEO three-page acceptance against a freshly restarted Electron build is still pending.

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: not applicable
- Machine-check boundary: not applicable
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `554be6d94`
- Branch merge-base with `origin/main`: `554be6d94`
- Last `git fetch origin` time: 2026-09-12 UTC
- Sync method: branched from origin/main
- Public diff command: `git diff origin/main...codex/gui-decisions`
- Private evidence commit/path: task_f8014a5fe34a6ac9112411215b `artifacts/report.md`
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [x] `npm run typecheck` (worker, `tsc -b`)
- [ ] `npm run check`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts` (via `run-manifest-gates --changed origin/main`)
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- macOS local only: `npx vitest run test/triadic-read-scoping.vitest.ts` went from 6 failing / 8 passing (red) to 14/14, then 22/22 once decision-state-vocabulary and triadic-decision-queue were included; `tsc -b packages/gui/tsconfig.renderer.json`, targeted eslint, line-density, and changed-path manifest gates all passed. No Ubuntu isolated run and no live-Electron/IPC observation were performed (report calls that unverified); full check:local was not run.

## Review Evidence

- CEO ground-truth: read the worker report and the diff stat; commit authorship and scope checked.
- Reviewer subagent: closeout review after merge (one-path closeout)
- Human review: pending
- Blocking findings: none open

## Residual Risk

- This closes a specific silent-failure class (empty list masking a read error) but does not confirm or rule out the original Electron symptom's cause; the worker explicitly disagrees with the CEO's hypothesis that two named daemon commits differ in accepted request shape (a diff of the relevant protocol/renderer files between them was empty). CEO must reopen Electron and check all three decision surfaces before treating this as resolved.

## References

- Task: task_f8014a5fe34a6ac9112411215b

---

# 中文

## 概要

GUI 的总览、决策池、关系图三个视图会把「决策读取失败」渲染成和「台账本来就是空」完全一样的空列表。根因是 `useDecisionSummaryQuery`/`useTriadicProjectionQuery` 把查询数据默认成 `[]` 且从不上抛 `isError`，而完整行读取器会把格式错误的行静默过滤掉，返回一个「成功的空结果」而不是拒绝它。修复把查询错误一路传到新增的 `decisionReadError` 选择器并在决策视图之前渲染；`readDecisionListResult`/`readDecisionSummaryListResult` 现在会抛出带标签的错误（`daemon_decision_result_invalid` 或 daemon 自身的 code/hint），不再悄悄丢行。

## 架构辩护

修复复用了已有的页面级错误组件和查询库自带的 error 字段，没有新增状态机、重试或兜底路径，是阻止「真实错误被伪装成空态」所需的最小改动。

## 改动内容

- `packages/gui/src/renderer/App.tsx`：计算 `decisionReadError` 并在决策视图之前渲染。
- `packages/gui/src/renderer/api-client.ts`：`readDecisionListResult`/`readDecisionSummaryListResult` 改为抛出带标签的决策读取错误，不再把坏行过滤成假空成功。
- `packages/gui/src/renderer/triadic-data.ts`：`useDecisionSummaryQuery`/`useTriadicProjectionQuery` 暴露 `error`/`decisionError` 而不只是布尔值。
- `packages/gui/test/triadic-read-scoping.vitest.ts`：新增六个用例，验证总览/决策池/图三个视图在拒绝或格式错误的决策读取下会显示 code 与 hint，绝不显示空态文案。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 删除的门或 fixture：none
- 生产净行数：+28/-4 production; tests +24/-1。

## 机器可读声明

- 无。

## 任务与范围

- Harness 任务：task_f8014a5fe34a6ac9112411215b（父 task_4f7965fc895253bf70a4020f42）
- 分支：`codex/gui-decisions`
- 公开范围：仅 GUI 渲染层（4 个文件：App.tsx、api-client.ts、triadic-data.ts 及其 vitest 套件）
- 私有计划/证据已更新：是（`artifacts/report.md`）
- 范围外：原始报告的 Electron 窗口症状（某个正在运行的构建显示空决策视图）本次未复现也未定位根因；本次所有探测中当前 daemon 与当前源码都返回 836 条决策。CEO 需要重开 Electron 做三页亲验，仍待完成。

## 版本影响

- 版本：不变
- 发布影响：不发布

## 治理声明

- 触碰受保护面：否
- 受保护面范围：不适用
- 授权：不适用
- 机器检查边界：不适用
- Break-glass：否
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- 基线 `origin/main` SHA：`554be6d94`
- 分支与 `origin/main` 的 merge-base：`554be6d94`
- 最近一次 `git fetch origin`：2026-09-12 UTC
- 同步方式：从 origin/main 开分支
- 公开 diff 命令：`git diff origin/main...codex/gui-decisions`
- 私有证据路径：task_f8014a5fe34a6ac9112411215b 的 `artifacts/report.md`
- 评审证据路径：本 PR 的评审证据节
- GitHub Actions `rewrite-ci` run URL：本 PR 待跑
- 仅本地 macOS：`npx vitest run test/triadic-read-scoping.vitest.ts` 从 6 例失败/8 例通过（红）改到 14/14，纳入 decision-state-vocabulary 与 triadic-decision-queue 后为 22/22；`tsc -b packages/gui/tsconfig.renderer.json`、定向 eslint、line-density、改动面 manifest gates 全部通过。未跑 Ubuntu 隔离测试，未做真实 Electron/IPC 观测（报告标记为 unverified）；未跑完整 check:local。

## 评审证据

- CEO 事实核对：读过 worker 报告与 diff 统计；核过提交人与范围。
- 评审子代理：合入后走一条路收口评审
- 人工评审：待定
- 阻塞发现：无

## 残余风险

- 本次只关闭了「空列表冒充读取失败」这一类静默失败，不证明也不排除原始 Electron 症状的根因；worker 明确不同意 CEO 关于两个指定 daemon commit 接受的请求形状不同的假设（对两者相关协议/渲染文件做 diff 为空）。CEO 需重开 Electron 核对三个决策视图后才能视为解决。

## 参考

- 任务：task_f8014a5fe34a6ac9112411215b

