### PR TITLE
perf: index hot projection reads and narrow document admission

### DIFF
--- a/packages/daemon/src/runtime-session-action-runtime.ts
+++ b/packages/daemon/src/runtime-session-action-runtime.ts
@@ -11,9 +11,7 @@ import type { RepoCellBinding, RuntimeIngressAction } from "./repo-cell-types.ts
 export function runtimeSessionActionPreparer(projection: () => TaskProjection): EntityActionCatalogPreparer {
   return (contract, action, binding) => {
     const runtimeSessionId = requiredRuntimeActionText(action.runtimeSessionId, "runtimeSessionId"),
-      dispatch = projection()
-        .readRuntimeDispatches()
-        .find((event) => event.payload.runtimeSessionId === runtimeSessionId),
+      dispatch = projection().readRuntimeDispatch(runtimeSessionId),
       dispatchSource = dispatch?.source,
       ingressSource = binding.source,
       localOwner = dispatchSource === "local" && ingressSource === "local";

--- a/packages/daemon/test/dispatch-stream.test.ts
+++ b/packages/daemon/test/dispatch-stream.test.ts
@@ -635,9 +635,10 @@ test("portable runtime binding retains the assignment scope required by the exis
     prepare = runtimeSessionActionPreparer(
       () =>
         ({
-          readRuntimeDispatches: () => [
-            { source, payload: { runtimeSessionId: "runtime-1", dispatchId: "dispatch-1" } },
-          ],
+          readRuntimeDispatch: () => ({
+            source,
+            payload: { runtimeSessionId: "runtime-1", dispatchId: "dispatch-1" },
+          }),
         }) as never,
     ),
     contract = getExecutableEntityAction("runtime_session_task_bound");

--- a/packages/kernel/src/projection/projection-schema.ts
+++ b/packages/kernel/src/projection/projection-schema.ts
@@ -1,4 +1,4 @@
 // Version 20 indexes task_relation by task_id and keys decision_fts rows by the decision rowid,
 // so a Task or Decision event no longer scans those tables. A mismatch discards and replays the
 // rebuildable cache.
-export const taskProjectionSchemaVersion = 21;
+export const taskProjectionSchemaVersion = 22;

--- a/packages/kernel/src/projection/rebuildable-task-projection-database.ts
+++ b/packages/kernel/src/projection/rebuildable-task-projection-database.ts
@@ -400,6 +400,14 @@ function createTables(db: DatabaseSync): void {
     ) WHERE
       json_extract(event_json, '$.schema') = 'agent-runtime-event/v1'
       AND json_extract(event_json, '$.type') = 'runtime_dispatch_requested';
+    CREATE INDEX IF NOT EXISTS event_index_runtime_dispatches ON event_index(workspace_revision)
+      WHERE json_extract(event_json, '$.schema') = 'agent-runtime-event/v1'
+        AND json_extract(event_json, '$.type') = 'runtime_dispatch_requested';
+    CREATE INDEX IF NOT EXISTS event_index_runtime_session ON event_index(
+      json_extract(event_json, '$.payload.runtimeSessionId'), workspace_revision
+    ) WHERE json_extract(event_json, '$.schema') = 'agent-runtime-event/v1';
+    CREATE INDEX IF NOT EXISTS event_index_ci_observations ON event_index(workspace_revision)
+      WHERE json_extract(event_json, '$.schema') = 'ci-run-observation/v3';
     CREATE TABLE IF NOT EXISTS document (
       path TEXT PRIMARY KEY,
       workspace_revision INTEGER NOT NULL,
@@ -441,6 +449,9 @@ function createTables(db: DatabaseSync): void {
       status TEXT,
       pinned INTEGER NOT NULL GENERATED ALWAYS AS (
         json_extract(snapshot_json, '$.task.pinned')
+      ) STORED,
+      package_disposition TEXT NOT NULL GENERATED ALWAYS AS (
+        COALESCE(json_extract(snapshot_json, '$.task.packageDisposition'), 'active')
       ) STORED,
       updated_at TEXT NOT NULL DEFAULT ''
     );
@@ -489,7 +500,11 @@ function createTables(db: DatabaseSync): void {
       value_json TEXT NOT NULL,
       PRIMARY KEY(task_id, edge_id, iteration)
     );
-    CREATE TABLE IF NOT EXISTS lease_cas (task_id TEXT PRIMARY KEY, lease_json TEXT NOT NULL);
+    CREATE TABLE IF NOT EXISTS lease_cas (
+      task_id TEXT PRIMARY KEY, lease_json TEXT NOT NULL,
+      execution_id TEXT GENERATED ALWAYS AS (json_extract(lease_json, '$.executionId')) STORED
+    );
+    CREATE INDEX IF NOT EXISTS lease_cas_execution ON lease_cas(execution_id);
     CREATE TABLE IF NOT EXISTS lease_interval (
       task_id TEXT NOT NULL,
       execution_id TEXT NOT NULL,

--- a/packages/kernel/src/projection/rebuildable-task-projection-event-application.ts
+++ b/packages/kernel/src/projection/rebuildable-task-projection-event-application.ts
@@ -56,6 +56,11 @@ import { applyEmbeddedRelationProjectionEvents, applyRelationProjectionEvent } f
 export type { ProjectionPage, TaskProjectionListQuery, TaskRelationQuery } from "./task-query-projection.ts";
 export type { TaskProjection } from "./task-projection-port.ts";
 
+const DOCUMENT_BASE_SQL = [
+  "SELECT json_extract(value_json, '$.blobSha256') AS blobSha256,",
+  "json_extract(value_json, '$.size') AS size, json_extract(value_json, '$.mediaType') AS mediaType,",
+  "json_extract(value_json, '$.policyId') AS policyId FROM document WHERE path = ?",
+].join(" ");
 const UPSERT_DOCUMENT_SQL = [
   "INSERT INTO document(path, workspace_revision, value_json) VALUES (?, ?, ?)",
   "ON CONFLICT(path) DO UPDATE SET workspace_revision=excluded.workspace_revision,",
@@ -400,14 +405,13 @@ export function applyEvent(
       eventJson,
     );
     for (const change of event.payload.changes) {
-      const previous = prepareQuery(db, "SELECT value_json FROM document WHERE path = ?", (sql) =>
-          /* @gate-identity check-bypass-write-boundary/bypass-write-011 */ db.prepare(sql),
-        ).get(change.path) as { readonly value_json: string } | undefined,
-        base = previous ? (JSON.parse(previous.value_json) as DocumentState) : null;
+      const base = prepareQuery(db, DOCUMENT_BASE_SQL, (sql) =>
+        /* @gate-identity check-bypass-write-boundary/bypass-write-011 */ db.prepare(sql),
+      ).get(change.path) as Pick<DocumentState, "blobSha256" | "size" | "mediaType" | "policyId"> | undefined;
       if (change.candidate === null) {
         if (
           event.payload.retirementReason === undefined ||
-          (base !== null && change.baseBlobSha256 !== base.blobSha256)
+          (base !== undefined && change.baseBlobSha256 !== base.blobSha256)
         )
           throw new Error(`document retirement mismatch for ${change.path}`);
         runSql(db, "DELETE FROM document WHERE path = ?", change.path);
@@ -415,7 +419,7 @@ export function applyEvent(
       }
       if (change.baseBlobSha256 !== (base?.blobSha256 ?? null)) {
         if (
-          base !== null &&
+          base !== undefined &&
           change.candidate.sha256 === base.blobSha256 &&
           change.candidate.size === base.size &&
           change.candidate.mediaType === base.mediaType &&

--- a/packages/kernel/src/projection/rebuildable-task-projection-runtime-api.ts
+++ b/packages/kernel/src/projection/rebuildable-task-projection-runtime-api.ts
@@ -78,10 +78,8 @@ export function runtimeLeaseApi(
       withDatabase(projectionPath, readHead, (db) => effectiveLease(db, taskId, at ?? now())),
     currentLeaseForExecution: (executionId, at) =>
       withDatabase(projectionPath, readHead, (db: DatabaseSync) => {
-        const row = prepareQuery(
-          db,
-          "SELECT task_id FROM lease_cas WHERE json_extract(lease_json, '$.executionId') = ?",
-          (sql) => /* @gate-identity check-bypass-write-boundary/bypass-write-016 */ db.prepare(sql),
+        const row = prepareQuery(db, "SELECT task_id FROM lease_cas WHERE execution_id = ?", (sql) =>
+          /* @gate-identity check-bypass-write-boundary/bypass-write-016 */ db.prepare(sql),
         ).get(executionId) as { readonly task_id: string } | undefined;
         return row ? effectiveLease(db, row.task_id, at ?? now()) : null;
       }),

--- a/packages/kernel/src/projection/rebuildable-task-projection-task-queries.ts
+++ b/packages/kernel/src/projection/rebuildable-task-projection-task-queries.ts
@@ -55,14 +55,17 @@ const TASK_COMPLETION_SQL = [
   "AND json_extract(event_json, '$.payload.execution.executionId') = ?",
   "ORDER BY workspace_revision DESC LIMIT 1",
 ].join(" ");
-const RUNTIME_DISPATCH_SQL = [
+const RUNTIME_DISPATCH_SESSION_SQL = [
   "SELECT event_json FROM event_index",
   "WHERE json_extract(event_json, '$.schema') = 'agent-runtime-event/v1'",
   "AND json_extract(event_json, '$.type') = 'runtime_dispatch_requested'",
   "AND json_extract(event_json, '$.payload.runtimeSessionId') = ?",
-  "AND json_extract(event_json, '$.payload.definitionSnapshotRef') = ?",
   "ORDER BY workspace_revision LIMIT 1",
 ].join(" ");
+const RUNTIME_DISPATCH_SQL = RUNTIME_DISPATCH_SESSION_SQL.replace(
+  "ORDER BY",
+  "AND json_extract(event_json, '$.payload.definitionSnapshotRef') = ? ORDER BY",
+);
 const RUNTIME_DISPATCHES_SQL = [
   "SELECT event_json FROM event_index",
   "WHERE json_extract(event_json, '$.schema') = 'agent-runtime-event/v1'",
@@ -290,7 +293,10 @@ export function taskQueryApi(
       }),
     readRuntimeDispatch: (runtimeSessionIdValue, definitionSnapshotRef) =>
       withDatabase(projectionPath, readHead, (db) => {
-        const row = queryRow(db, RUNTIME_DISPATCH_SQL, runtimeSessionIdValue, definitionSnapshotRef);
+        const row =
+          definitionSnapshotRef === undefined
+            ? queryRow(db, RUNTIME_DISPATCH_SESSION_SQL, runtimeSessionIdValue)
+            : queryRow(db, RUNTIME_DISPATCH_SQL, runtimeSessionIdValue, definitionSnapshotRef);
         if (!row) return null;
         const event = JSON.parse(String(row.event_json));
         return isAgentRuntimeEvent(event) && event.type === "runtime_dispatch_requested" ? event : null;

--- a/packages/kernel/src/projection/rebuildable-task-projection-write-model.ts
+++ b/packages/kernel/src/projection/rebuildable-task-projection-write-model.ts
@@ -17,6 +17,7 @@ import { readRuntimeSession, readSnapshot, storedLease } from "./rebuildable-tas
 export type { ProjectionPage, TaskProjectionListQuery, TaskRelationQuery } from "./task-query-projection.ts";
 export type { TaskProjection } from "./task-projection-port.ts";
 
+const DOCUMENT_BASE_SQL = "SELECT json_extract(value_json, '$.blobSha256') AS blob_sha256 FROM document WHERE path = ?";
 const UPSERT_DOCUMENT_SQL = [
   "INSERT INTO document(path, workspace_revision, value_json) VALUES (?, ?, ?)",
   "ON CONFLICT(path) DO UPDATE SET workspace_revision=excluded.workspace_revision,",
@@ -35,8 +36,7 @@ export function projectProgress(
     lease = storedLease(db, taskId),
     packagePath = queryRows(db, "SELECT package_path FROM task_package WHERE task_id = ?", taskId)[0]?.package_path,
     claim = event.payload.resultDocumentClaim,
-    previous = queryRows(db, "SELECT value_json FROM document WHERE path = ?", claim.path)[0],
-    base = previous ? (JSON.parse(String(previous.value_json)) as DocumentState) : null,
+    base = queryRows(db, DOCUMENT_BASE_SQL, claim.path)[0],
     bytes = readBlob(claim.sha256),
     runtimeSessionIdValue = event.payload.runtimeSessionId,
     runtime = runtimeSessionIdValue ? readRuntimeSession(db, runtimeSessionIdValue) : null;
@@ -61,7 +61,7 @@ export function projectProgress(
     (!directHolder && !runtimeWorker)
   )
     throw new Error(`progress event lease mismatch for task ${taskId}`);
-  if (event.payload.baseDocumentSha256 !== (base?.blobSha256 ?? null) || !bytes || bytes.byteLength !== claim.size)
+  if (event.payload.baseDocumentSha256 !== (base?.blob_sha256 ?? null) || !bytes || bytes.byteLength !== claim.size)
     throw new Error(`progress document base or blob mismatch for task ${taskId}`);
   const body = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
   const document: DocumentState = {
@@ -91,8 +91,7 @@ export function projectProgress(
   );
   runSql(db, UPSERT_DOCUMENT_SQL, claim.path, event.workspaceRevision, canonicalJson(document));
   for (const change of event.payload.carriedDocumentClaims ?? []) {
-    const previous = queryRows(db, "SELECT value_json FROM document WHERE path = ?", change.path)[0],
-      carriedBase = previous ? (JSON.parse(String(previous.value_json)) as DocumentState) : null,
+    const carriedBase = queryRows(db, DOCUMENT_BASE_SQL, change.path)[0],
       carriedBytes = readBlob(change.candidate.sha256);
     if (!carriedBytes || carriedBytes.byteLength !== change.candidate.size)
       throw new Error(`carried document blob ${change.candidate.sha256} is unavailable`);
@@ -102,7 +101,7 @@ export function projectProgress(
     } catch {
       throw new Error(`carried document blob ${change.candidate.sha256} is not UTF-8`);
     }
-    if (change.baseBlobSha256 !== (carriedBase?.blobSha256 ?? null))
+    if (change.baseBlobSha256 !== (carriedBase?.blob_sha256 ?? null))
       throw new Error(`carried document proof mismatch for ${change.path}`);
     const carriedDocument: DocumentState = {
       path: change.path as DocumentState["path"],
@@ -157,12 +156,11 @@ export function projectDecision(
   readBlob: EventStreamPort["readContentBlob"],
 ): void {
   const claim = event.payload.decisionDocumentClaim,
-    previousRow = queryRows(db, "SELECT value_json FROM document WHERE path = ?", claim.path)[0],
-    previous = previousRow ? (JSON.parse(String(previousRow.value_json)) as DocumentState) : null,
+    previous = queryRows(db, DOCUMENT_BASE_SQL, claim.path)[0],
     bytes = readBlob(claim.sha256);
   if (
     claim.path !== `decisions/decision-${event.decisionId}/decision.md` ||
-    event.payload.baseDocumentSha256 !== (previous?.blobSha256 ?? null) ||
+    event.payload.baseDocumentSha256 !== (previous?.blob_sha256 ?? null) ||
     !bytes ||
     bytes.byteLength !== claim.size
   )

--- a/packages/kernel/src/projection/task-projection-port.ts
+++ b/packages/kernel/src/projection/task-projection-port.ts
@@ -120,7 +120,7 @@ export interface TaskProjection {
   readonly readTaskCompletion: (taskId: string, executionId: string) => TaskEventV1 | null;
   readonly readRuntimeDispatch: (
     runtimeSessionIdValue: string,
-    definitionSnapshotRef: string,
+    definitionSnapshotRef?: string,
   ) => Extract<AgentRuntimeEventV1, { readonly type: "runtime_dispatch_requested" }> | null;
   readonly readRuntimeDispatches: () => readonly Extract<
     AgentRuntimeEventV1,

--- a/packages/kernel/src/projection/task-query-projection.ts
+++ b/packages/kernel/src/projection/task-query-projection.ts
@@ -102,7 +102,7 @@ export function readTaskChildCounts(
       db,
       [
         `SELECT ${parent} AS parent_task_id, COUNT(*) AS child_count FROM task_snapshot`,
-        "WHERE COALESCE(json_extract(snapshot_json, '$.task.packageDisposition'), 'active') = 'active'",
+        "WHERE package_disposition = 'active'",
         `AND ${parent} IN (SELECT value FROM json_each(?)) GROUP BY parent_task_id`,
       ].join(" "),
       JSON.stringify(parentTaskIds),

--- a/packages/kernel/src/projection/workspace-summary-projection.ts
+++ b/packages/kernel/src/projection/workspace-summary-projection.ts
@@ -18,11 +18,7 @@ interface TaskCensusRow {
 export function readWorkspaceSummaryRows(db: DatabaseSync): WorkspaceSummary {
   const taskRows = queryRows<TaskCensusRow & ProjectionSqlRow>(
     db,
-    [
-      "SELECT task_id, status,",
-      "COALESCE(json_extract(snapshot_json, '$.task.packageDisposition'), 'active') AS package_disposition",
-      "FROM task_snapshot ORDER BY task_id",
-    ].join(" "),
+    "SELECT task_id, status, package_disposition FROM task_snapshot ORDER BY task_id",
   );
   const dependencyRows: Array<ReturnType<typeof readTaskRelationPage>["rows"][number]> = [];
   let relationCursor: string | undefined;

--- a/packages/kernel/src/store/sqlite-event-store.ts
+++ b/packages/kernel/src/store/sqlite-event-store.ts
@@ -670,6 +670,7 @@ function createSchema(db: DatabaseSync, repoId: string, generation: number): voi
         OR (status='rejected' AND rejection_code IS NOT NULL)
       )
     ) STRICT;
+    CREATE INDEX IF NOT EXISTS command_outcome_revision ON command_outcome(last_revision, first_revision);
     CREATE TABLE IF NOT EXISTS writer_lease (
       repo_id TEXT PRIMARY KEY, holder TEXT NOT NULL, epoch INTEGER NOT NULL CHECK(epoch>0)
     ) STRICT;

--- a/packages/kernel/test/store/agent-runtime.test.ts
+++ b/packages/kernel/test/store/agent-runtime.test.ts
@@ -101,6 +101,8 @@ test("runtime events use the canonical envelope, head, store, and the shared pro
     const session = projection.readRuntimeSession("runtime-session-claude");
     assert.equal(session?.providerSessionId, "provider-session-claude");
     const dispatch = projection.readRuntimeDispatch("runtime-session-claude", session!.definitionSnapshotRef);
+    assert.deepEqual(projection.readRuntimeDispatch("runtime-session-claude"), dispatch);
+    assert.equal(projection.readRuntimeDispatch("missing"), null);
     assert.equal(dispatch?.type, "runtime_dispatch_requested");
     assert.equal(dispatch?.payload.runtimeSessionId, session?.runtimeSessionId);
     assert.equal(

--- a/packages/kernel/test/store/projection-ddl-rebuild.test.ts
+++ b/packages/kernel/test/store/projection-ddl-rebuild.test.ts
@@ -79,6 +79,77 @@ test("explicit projection rebuild replaces stale DDL even when its version claim
   });
 });
 
+test("previous projection DDL is replaced on reopen and hot reads use their indexes", async () => {
+  await withTempStoreAsync(async (rootDir) => {
+    const { projectionPath, eventStore } = tasklessFactLedger(rootDir, "hot-index-rebuild", "F-0123ABCD");
+    const original = makeTaskProjection({ rootDir, eventStore });
+    original.catchUp();
+    original.close();
+    const stale = new DatabaseSync(projectionPath);
+    stale.exec(`DROP INDEX lease_cas_execution;
+      ALTER TABLE lease_cas DROP COLUMN execution_id;
+      ALTER TABLE task_snapshot DROP COLUMN package_disposition;
+      UPDATE projection_meta SET schema_version = ${taskProjectionSchemaVersion - 1}`);
+    stale.close();
+    const projection = makeTaskProjection({ rootDir, eventStore });
+    projection.catchUp();
+    assert.equal(projection.searchFacts({ query: "standalone" }).facts[0]?.factId, "F-0123ABCD");
+    const statements: string[] = [],
+      prepare = DatabaseSync.prototype.prepare;
+    DatabaseSync.prototype.prepare = function (sql: string) {
+      statements.push(sql);
+      return prepare.call(this, sql);
+    };
+    try {
+      assert.equal(projection.currentLeaseForExecution("missing"), null);
+      assert.equal(projection.readRuntimeDispatch("missing"), null);
+      assert.deepEqual(projection.readRuntimeDispatches(), []);
+      assert.deepEqual(projection.readRuntimeSessionEvents("missing", 0, 10), []);
+      projection.readCiRunObservations(10);
+    } finally {
+      DatabaseSync.prototype.prepare = prepare;
+      projection.close();
+    }
+    const db = new DatabaseSync(projectionPath);
+    try {
+      for (const [part, args, expected] of [
+        ["FROM lease_cas WHERE execution_id", ["missing"], "lease_cas_execution"],
+        ["runtime_dispatch_requested' AND json_extract", ["missing"], "event_index_runtime_session"],
+        ["runtime_dispatch_requested' ORDER BY", [], "event_index_runtime_dispatches"],
+        ["WHERE workspace_revision > ? AND json_extract", [0, "missing", 10], "event_index_runtime_session"],
+        ["ci-run-observation/v3", [10], "event_index_ci_observations"],
+      ] as const) {
+        const sql = statements.find((statement) => statement.includes(part));
+        assert.ok(sql, part);
+        const plan = db
+          .prepare(`EXPLAIN QUERY PLAN ${sql}`)
+          .all(...args)
+          .map((row) => String(row.detail))
+          .join("\n");
+        assert.ok(plan.includes(expected), plan);
+        assert.doesNotMatch(plan, /USE TEMP B-TREE|SCAN event_index(?:\n|$)|SCAN lease_cas(?:\n|$)/u);
+      }
+      db.prepare("INSERT INTO lease_cas(task_id, lease_json) VALUES (?, ?)").run(
+        "task-fixture",
+        JSON.stringify({ executionId: "first" }),
+      );
+      db.prepare("UPDATE lease_cas SET lease_json = ? WHERE task_id = ?").run(
+        JSON.stringify({ executionId: "second" }),
+        "task-fixture",
+      );
+      assert.equal(db.prepare("SELECT execution_id FROM lease_cas").get()?.execution_id, "second");
+      db.prepare("INSERT INTO task_snapshot(task_id, workspace_revision, snapshot_json) VALUES (?, ?, ?)").run(
+        "task-fixture",
+        1,
+        JSON.stringify({ task: { packageDisposition: "archived", pinned: false } }),
+      );
+      assert.equal(db.prepare("SELECT package_disposition FROM task_snapshot").get()?.package_disposition, "archived");
+    } finally {
+      db.close();
+    }
+  });
+});
+
 // A pure index needs no replay: every owner runs CREATE INDEX IF NOT EXISTS when it opens, so a
 // current-version cache written before the index existed gains it in place.
 test("an owner adds the relation owner index to a current-version cache in place", async () => {

--- a/packages/kernel/test/store/projection-query-shape.test.ts
+++ b/packages/kernel/test/store/projection-query-shape.test.ts
@@ -721,6 +721,7 @@ test("task child counts search the parent expression index instead of scanning t
     db.exec(`
       CREATE TABLE task_snapshot (task_id TEXT PRIMARY KEY, workspace_revision INTEGER NOT NULL, snapshot_json TEXT NOT NULL,
         status TEXT, updated_at TEXT NOT NULL DEFAULT '');
+      ALTER TABLE task_snapshot ADD COLUMN package_disposition TEXT GENERATED ALWAYS AS (COALESCE(json_extract(snapshot_json, '$.task.packageDisposition'), 'active')) STORED;
       CREATE INDEX task_snapshot_parent ON task_snapshot(json_extract(snapshot_json, '$.task.metadata.parentTaskId'));
     `);
     const insert = db.prepare("INSERT INTO task_snapshot(task_id, workspace_revision, snapshot_json) VALUES (?, ?, ?)");
@@ -734,7 +735,7 @@ test("task child counts search the parent expression index instead of scanning t
     const parent = "json_extract(snapshot_json, '$.task.metadata.parentTaskId')",
       sql =
         `SELECT ${parent} AS parent_task_id, COUNT(*) AS child_count FROM task_snapshot ` +
-        "WHERE COALESCE(json_extract(snapshot_json, '$.task.packageDisposition'), 'active') = 'active' " +
+        "WHERE package_disposition = 'active' " +
         `AND ${parent} IN (SELECT value FROM json_each(?)) GROUP BY parent_task_id`,
       plan = queryPlan(db, { sql, args: [JSON.stringify(["task_00000"])] });
     assert.match(plan, /SEARCH task_snapshot USING INDEX task_snapshot_parent/u);

--- a/packages/kernel/test/store/schedule-projection.test.ts
+++ b/packages/kernel/test/store/schedule-projection.test.ts
@@ -18,7 +18,7 @@ const actor = { principal: { personId: "person-schedule" }, executor: null } as 
 test("Schedule definition and run view share one canonical stream and rebuild exactly", async () => {
   await withTempStoreAsync(async (rootDir) => {
     initRepo(rootDir);
-    assert.equal(taskProjectionSchemaVersion, 21);
+    assert.equal(taskProjectionSchemaVersion, 22);
     const eventStore = makeTaskEventStore({ repoId: "schedule-projection", rootDir }),
       projection = makeTaskProjection({ rootDir, eventStore }),
       schedule = baseSchedule(),

--- a/packages/kernel/test/store/sqlite-event-store.integration.test.ts
+++ b/packages/kernel/test/store/sqlite-event-store.integration.test.ts
@@ -710,7 +710,8 @@ test("event, writer takeover, ledger head, and outcome roll back atomically", ()
 });
 
 test("one canonical bundle appends preceding events and its terminal event in one command", () => {
-  const store = openSqliteEventStore({ repoId, databasePath: scratch("bundle") }),
+  const databasePath = scratch("bundle"),
+    store = openSqliteEventStore({ repoId, databasePath }),
     events = [eventAt(1), eventAt(2), eventAt(3)],
     eventBytes = events.map(serializePersistedCanonicalEvent),
     outcome = store.appendCommand({
@@ -728,6 +729,22 @@ test("one canonical bundle appends preceding events and its terminal event in on
       { firstRevision: 1, lastRevision: 3 },
     );
     assert.deepEqual(store.events(), events);
+    assert.deepEqual(store.readCommandOutcome(events[0]!.opId), outcome);
+    assert.deepEqual(store.readCommandOutcome(events[1]!.opId), outcome);
+    const db = new DatabaseSync(databasePath, { readOnly: true });
+    try {
+      const plan = db
+        .prepare(
+          "EXPLAIN QUERY PLAN SELECT op_id FROM command_outcome WHERE first_revision<=? AND last_revision>=? ORDER BY last_revision LIMIT 1",
+        )
+        .all(2, 2)
+        .map((row) => String(row.detail))
+        .join("\n");
+      assert.match(plan, /SEARCH command_outcome USING INDEX command_outcome_revision/u);
+      assert.doesNotMatch(plan, /USE TEMP B-TREE/u);
+    } finally {
+      db.close();
+    }
   } finally {
     store.close();
   }


### PR DESCRIPTION
# English

## Summary

Six tail-diff performance findings (R2-04-F2/F3/F5/F7/F9, R2-02-F4) against the kernel task projection: several hot queries lacked indexes or derived columns for keys they filtered on, and JS-side code was decoding whole JSON documents just to read a few fields. The fix adds STORED generated columns and partial indexes for `executionId`, dispatch/session/CI revision lookups, `packageDisposition`, and an outcome-member revision range, replaces four full `DocumentState` JSON decodes with narrow hash/size/mediaType/policyId reads, and replaces a `find()` over all runtime dispatches with a single indexed lookup; projection schema version moved 21->22.

## Architectural Justification

Adds only STORED generated columns and partial indexes on existing tables plus a narrower single-row read, deleting the wide JSON-decode/full-scan paths they replace, rather than introducing a cache, denormalized copy, or new write authority.

## What Changed

- `packages/kernel/src/projection/rebuildable-task-projection-database.ts`: new STORED columns (`execution_id`, `package_disposition`) and partial indexes; schema bump plumbing.
- `packages/kernel/src/projection/rebuildable-task-projection-event-application.ts`, `-write-model.ts`: write the new derived columns instead of leaving values only inside JSON blobs.
- `packages/kernel/src/projection/rebuildable-task-projection-runtime-api.ts`, `-task-queries.ts`: query the new indexed columns instead of scanning/decoding JSON.
- `packages/kernel/src/projection/task-query-projection.ts`, `workspace-summary-projection.ts`, `task-projection-port.ts`: consume `packageDisposition`/narrower reads through the port.
- `packages/kernel/src/store/sqlite-event-store.ts`: `command_outcome(last_revision, first_revision)` index for member range lookups.
- `packages/daemon/src/runtime-session-action-runtime.ts`: single-row `readRuntimeDispatch(runtimeSessionId)` replaces `readRuntimeDispatches().find()`.
- Kernel test files (`agent-runtime.test.ts`, `projection-ddl-rebuild.test.ts`, `projection-query-shape.test.ts`, `sqlite-event-store.integration.test.ts`): regression coverage for the new indexes/columns and a schema-version DDL-rebuild round trip.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: +50/-34 production; tests +93/-2.

## Machine-Readable Declarations

- None.

## Task And Scope

- Harness task: task_5c7d17c63a45ab70b37603f00a (parent task_6eba9c5d3a55735920aa4856f3)
- Branch: `codex/perf-g4`
- Public scope: kernel projection/store internals (schema v21->22) plus one daemon runtime-dispatch read path; no daemon protocol/public export shape changed
- Private planning/evidence updated: yes (`artifacts/report.md`)
- Out of scope: Overall end-to-end performance improvement is not claimed. Restarting the shared production daemon against this schema version, and any migration behavior beyond an isolated projection reopen, are unverified.

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: not applicable
- Machine-check boundary: not applicable
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `554be6d94`
- Branch merge-base with `origin/main`: `554be6d94`
- Last `git fetch origin` time: 2026-09-12 UTC
- Sync method: branched from origin/main
- Public diff command: `git diff origin/main...codex/perf-g4`
- Private evidence commit/path: task_5c7d17c63a45ab70b37603f00a `artifacts/report.md`
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [x] `npm run typecheck` (worker, `tsc -b`)
- [ ] `npm run check`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts` (via `run-manifest-gates --changed origin/main`)
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- 92 targeted tests green in total: kernel unit tests ran locally on macOS (e.g. `projection-query-shape.test.ts` 18/18); the integration files went through `node tools/dispatch-isolated-test.mjs --target ubuntu` (7 files, all exit 0) per the standing test-isolation policy. `tsc -b packages/kernel packages/daemon`, line-density, and the 7-command changed-path manifest gate all passed locally. All commands and outputs are attached per-file in the task's `artifacts/` evidence.

## Review Evidence

- CEO ground-truth: read the worker report and the diff stat; commit authorship and scope checked.
- Reviewer subagent: closeout review after merge (one-path closeout)
- Human review: pending
- Blocking findings: none open

## Residual Risk

- The round-5 cold-rebuild benchmark got worse, not better: cold catch-up went from 5,922.2ms to 6,846.4ms on the final commit (+15.7%), while most hot-query p95s held steady or improved slightly (taskList p95 715->773ms is also up). The worker states overall performance is unverified and explicitly asks the CEO to weigh hot-read gains against this cold-rebuild regression before accepting. Also overlaps file-for-file with the `projection-drop-reason` branch (`rebuildable-task-projection-database.ts` and `projection-ddl-rebuild.test.ts` are touched by both) — expect a merge conflict if both land.

## References

- Task: task_5c7d17c63a45ab70b37603f00a

---

# 中文

## 概要

针对内核任务投影的六项尾差性能发现（R2-04-F2/F3/F5/F7/F9、R2-02-F4）：多处热路径查询缺少按过滤键建的索引或派生列，且 JS 侧为了读几个字段把整份 JSON 文档解码出来。修复为 `executionId`、dispatch/session/CI revision 查询、`packageDisposition`、outcome member revision 区间分别新增 STORED 生成列和局部索引；把四处整份 `DocumentState` JSON 解码换成只取 hash/size/mediaType/policyId；把对全部 runtime dispatch 的 `find()` 换成单行索引查询；投影 schema 版本从 21 升到 22。

## 架构辩护

只在既有表上加 STORED 生成列和局部索引，外加一次更窄的单行读取，并删除被替代的整份 JSON 解码/全表扫描路径，没有引入缓存、反规范化副本或新的写权威。

## 改动内容

- `packages/kernel/src/projection/rebuildable-task-projection-database.ts`：新增 STORED 列（`execution_id`、`package_disposition`）和局部索引；schema 版本升级管道。
- `rebuildable-task-projection-event-application.ts`、`-write-model.ts`：写入新派生列，不再只留在 JSON blob 里。
- `rebuildable-task-projection-runtime-api.ts`、`-task-queries.ts`：改为查询新索引列而不是扫描/解码 JSON。
- `task-query-projection.ts`、`workspace-summary-projection.ts`、`task-projection-port.ts`：经端口消费 `packageDisposition`/更窄的读取。
- `packages/kernel/src/store/sqlite-event-store.ts`：新增 `command_outcome(last_revision, first_revision)` 索引用于 member 区间回查。
- `packages/daemon/src/runtime-session-action-runtime.ts`：单行 `readRuntimeDispatch(runtimeSessionId)` 取代 `readRuntimeDispatches().find()`。
- 内核测试文件（`agent-runtime.test.ts`、`projection-ddl-rebuild.test.ts`、`projection-query-shape.test.ts`、`sqlite-event-store.integration.test.ts`）：覆盖新索引/列及 schema 版本 DDL 重建回归。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 删除的门或 fixture：none
- 生产净行数：+50/-34 production; tests +93/-2。

## 机器可读声明

- 无。

## 任务与范围

- Harness 任务：task_5c7d17c63a45ab70b37603f00a（父 task_6eba9c5d3a55735920aa4856f3）
- 分支：`codex/perf-g4`
- 公开范围：仅内核投影/存储内部实现（schema v21->22）及一处 daemon runtime-dispatch 读路径；未改动 daemon 协议或公共导出形状
- 私有计划/证据已更新：是（`artifacts/report.md`）
- 范围外：不宣称整体端到端性能提升。共享生产 daemon 按此 schema 版本重启，以及超出隔离投影重开范围的任何迁移行为，均为 unverified。

## 版本影响

- 版本：不变
- 发布影响：不发布

## 治理声明

- 触碰受保护面：否
- 受保护面范围：不适用
- 授权：不适用
- 机器检查边界：不适用
- Break-glass：否
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- 基线 `origin/main` SHA：`554be6d94`
- 分支与 `origin/main` 的 merge-base：`554be6d94`
- 最近一次 `git fetch origin`：2026-09-12 UTC
- 同步方式：从 origin/main 开分支
- 公开 diff 命令：`git diff origin/main...codex/perf-g4`
- 私有证据路径：task_5c7d17c63a45ab70b37603f00a 的 `artifacts/report.md`
- 评审证据路径：本 PR 的评审证据节
- GitHub Actions `rewrite-ci` run URL：本 PR 待跑
- 共 92 项定向测试通过：内核单元测试本地 macOS 跑（如 `projection-query-shape.test.ts` 18/18）；integration 文件按现行隔离测试纪律走 `node tools/dispatch-isolated-test.mjs --target ubuntu`（7 个文件全部 exit 0）。`tsc -b packages/kernel packages/daemon`、line-density、7 项改动面 manifest gates 均本地通过。所有命令与输出按文件附在任务 `artifacts/` 证据中。

## 评审证据

- CEO 事实核对：读过 worker 报告与 diff 统计；核过提交人与范围。
- 评审子代理：合入后走一条路收口评审
- 人工评审：待定
- 阻塞发现：无

## 残余风险

- round-5 冷重建基准不升反降：最终提交冷 catch-up 从 5,922.2ms 变为 6,846.4ms（+15.7%），而多数热查询 p95 基本持平或略有改善（taskList p95 也从 715 升到 773ms）。worker 明确标注整体性能 unverified，并要求 CEO 在接受前权衡热读收益与冷重建成本。另外本分支与 `projection-drop-reason` 分支存在逐文件重叠（`rebuildable-task-projection-database.ts` 与 `projection-ddl-rebuild.test.ts` 两者都改了）——若两者都合入，预期会冲突。

## 参考

- 任务：task_5c7d17c63a45ab70b37603f00a

