### PR TITLE
fix: clarify packet roots and decision next steps

### DIFF
--- a/packages/cli/src/cli/receipt-render-registry.ts
+++ b/packages/cli/src/cli/receipt-render-registry.ts
@@ -24,6 +24,7 @@ const schemaRenderers = new Map<string, ReceiptRenderer>([
 const commandRenderers = new Map<string, ReceiptRenderer>([
   ["task-create", renderTaskCreate],
   ["task-show", renderTaskShow],
+  ["decision-propose", renderDecisionPropose],
   ["preset-list", renderPresetListReceipt],
   ["migrate-import", renderSuccessfulReceipt],
   ["task-contract-migrate", renderSuccessfulReceipt],
@@ -102,6 +103,14 @@ function renderTaskShow(receipt: Record<string, unknown>): string {
   const payload = parseEvidence(receipt);
   if (!payload || !isRecord(payload.task)) return renderSuccessfulReceipt(receipt);
   return [`status: ${String(payload.task.status)}`, `graph cursor: ${String(payload.task.currentNode)}`].join("\n");
+}
+
+function renderDecisionPropose(receipt: Record<string, unknown>): string {
+  const payload = parseEvidence(receipt),
+    summary = renderSuccessfulReceipt(receipt);
+  return typeof payload?.decisionId === "string"
+    ? `${summary}\nnext: ha explain decision/${payload.decisionId}`
+    : summary;
 }
 
 function renderPresetListReceipt(receipt: Record<string, unknown>): string {

--- a/packages/cli/test/guidance-plane.test.ts
+++ b/packages/cli/test/guidance-plane.test.ts
@@ -1,9 +1,52 @@
 // harness-test-tier: fast
 import assert from "node:assert/strict";
 import test from "node:test";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { readWorkspaceText } from "../../daemon/src/workspace-text-port.ts";
 import { taskCreateGuidance } from "../../daemon/src/receipt-guidance.ts";
 import { humanError, renderReceiptGuidance } from "../src/cli/guidance-plane.ts";
 import { renderCliReceipt } from "../src/cli/receipt-render-registry.ts";
+
+test("missing workspace packets identify the root used for relative paths", () => {
+  const root = mkdtempSync(path.join(tmpdir(), "ha-packet-root-"));
+  try {
+    mkdirSync(path.join(root, "harness"));
+    writeFileSync(path.join(root, "harness/input.json"), "{}");
+    assert.equal(readWorkspaceText(root, "harness/input.json", "fromFile"), "{}");
+    assert.equal(readWorkspaceText(root, path.join(root, "harness/input.json"), "fromFile"), "{}");
+    assert.throws(
+      () => readWorkspaceText(root, "input.json", "fromFile"),
+      (error: Error) => {
+        const hint = humanError({ code: "invalid_command", rejectionExplanation: error.message }).hint;
+        assert.ok(hint.includes(root), hint);
+        assert.match(hint, /relative paths are resolved from this root/u);
+        return true;
+      },
+    );
+    writeFileSync(path.join(root, "invalid.json"), Buffer.from([0xff]));
+    assert.throws(() => readWorkspaceText(root, "invalid.json", "fromFile"), /readable UTF-8/u);
+    assert.throws(() => readWorkspaceText(root, "../outside.json", "fromFile"), /outside the workspace boundary/u);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("successful Decision proposals point to the canonical action explanation", () => {
+  const receipt = {
+    ok: true,
+    command: "decision-propose",
+    summary: "Decision proposed",
+    evidence: JSON.stringify({ decisionId: "dec_example", state: "proposed" }),
+  };
+  assert.deepEqual(renderCliReceipt(receipt), {
+    stream: "stdout",
+    text: "Decision proposed\nnext: ha explain decision/dec_example",
+  });
+  assert.equal(renderCliReceipt({ ...receipt, ok: false, code: "invalid_command" }).stream, "stderr");
+  assert.equal(renderCliReceipt({ ...receipt, command: "decision-show" }).text, "Decision proposed");
+});
 
 test("guidance plane renders all seven descriptor-derived task-create messages exactly", () => {
   const values = {

--- a/packages/daemon/src/workspace-text-port.ts
+++ b/packages/daemon/src/workspace-text-port.ts
@@ -11,14 +11,13 @@ export function readWorkspaceText(rootDir: string, requested: string, field: str
     candidate = realpathSync(requestedPath);
     if (candidate !== root && !candidate.startsWith(`${root}${path.sep}`)) throw boundaryError(field, root);
     bytes = readFileSync(candidate);
+    return new TextDecoder("utf-8", { fatal: true }).decode(bytes);
   } catch (error) {
     if (isBoundaryError(error)) throw error;
-    throw portError(`${field} must be a readable UTF-8 file.`);
-  }
-  try {
-    return new TextDecoder("utf-8", { fatal: true }).decode(bytes);
-  } catch {
-    throw portError(`${field} must be a readable UTF-8 file.`);
+    throw portError(
+      `${field} must name a readable UTF-8 file inside workspace root ${rootDir}; ` +
+        "relative paths are resolved from this root.",
+    );
   }
 }
 


### PR DESCRIPTION
# English

## Summary

Two separate CLI guidance gaps. First, when `readWorkspaceText` (used by `--from-file`) failed to find a packet like `harness/input.json`, its error message only said the file must be readable UTF-8, without saying what root the relative path was resolved against — a user seeing `harness/input.json` fail had no way to tell it needed to be `input.json` instead. Second, a successful `ha decision propose` printed only a bare success summary with no pointer to the next command. The fix folds the missing-file and invalid-UTF-8 error paths into one handler that names the workspace root, and adds a `decision-propose` renderer that appends `next: ha explain decision/<id>`.

## Architectural Justification

-

## What Changed

- `packages/daemon/src/workspace-text-port.ts`: merged the duplicate generic error handlers into one that reports the workspace root and states relative paths resolve against it.
- `packages/cli/src/cli/receipt-render-registry.ts`: new `renderDecisionPropose` appends `next: ha explain decision/<id>` to a successful proposal's summary.
- `packages/cli/test/guidance-plane.test.ts`: new tests for the root-hint error message and the decision-propose next-command text.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: +14/-6 production; tests +43/-0.

## Machine-Readable Declarations

- None.

## Task And Scope

- Harness task: task_382f825d9432cd9535d243b690 (parent task_5b051225f10ebe9505e73e5b43)
- Branch: `codex/packet-root-hint`
- Public scope: CLI/daemon guidance text only (error hints and success next-steps); no change to accepted inputs, validation rules, or protocol shape
- Private planning/evidence updated: yes (`artifacts/report.md`)
- Out of scope: Cross-platform (Linux/Windows) and remote-CI behavior of the fixture's directory-junction technique is unverified; only macOS local execution was performed as the task plan explicitly allowed.

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: not applicable
- Machine-check boundary: not applicable
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `554be6d94`
- Branch merge-base with `origin/main`: `554be6d94`
- Last `git fetch origin` time: 2026-09-12 UTC
- Sync method: branched from origin/main
- Public diff command: `git diff origin/main...codex/packet-root-hint`
- Private evidence commit/path: task_382f825d9432cd9535d243b690 `artifacts/report.md`
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [x] `npm run typecheck` (worker, `tsc -b`)
- [ ] `npm run check`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts` (via `run-manifest-gates --changed origin/main`)
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- macOS local: `node tools/run-node-tests.mjs --file packages/cli/test/guidance-plane.test.ts` went from 7 passed / 2 failed (red) to 9/9 (green); targeted eslint clean; line-density G36 pass; changed-path manifest gates 6/6 pass (584 discovered test files); governance walls 12 pass / 0 red. No Ubuntu isolated run was performed for this branch.

## Review Evidence

- CEO ground-truth: read the worker report and the diff stat; commit authorship and scope checked.
- Reviewer subagent: closeout review after merge (one-path closeout)
- Human review: pending
- Blocking findings: none open

## Residual Risk

- Low risk, additive guidance text only; the worker notes the underlying generic workspace-text reader also serves non-Decision inputs, so this presentation change reaches slightly beyond the Decision workflow it was written for (still just error/next-step text, not behavior).

## References

- Task: task_382f825d9432cd9535d243b690

---

# 中文

## 概要

两处独立的 CLI 引导缺口。其一，`readWorkspaceText`（服务于 `--from-file`）在找不到像 `harness/input.json` 这样的 packet 时，错误信息只说文件必须是可读 UTF-8，没说相对路径是相对哪个根解析的——用户看到 `harness/input.json` 失败后无法判断该写成 `input.json`。其二，`ha decision propose` 成功后只打印一句干巴巴的成功摘要，没有提示下一步命令。修复把「文件缺失」和「UTF-8 非法」两条错误路径合并成一个会点名 workspace 根目录的处理器，并新增 `decision-propose` 渲染器，在成功摘要后追加 `next: ha explain decision/<id>`。

## 架构辩护

-

## 改动内容

- `packages/daemon/src/workspace-text-port.ts`：把重复的两个通用错误处理器合并成一个，报出 workspace 根目录并说明相对路径以此为基准解析。
- `packages/cli/src/cli/receipt-render-registry.ts`：新增 `renderDecisionPropose`，在成功提案摘要后追加 `next: ha explain decision/<id>`。
- `packages/cli/test/guidance-plane.test.ts`：新增测试覆盖根提示错误信息和 decision-propose 的下一步命令文本。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 删除的门或 fixture：none
- 生产净行数：+14/-6 production; tests +43/-0。

## 机器可读声明

- 无。

## 任务与范围

- Harness 任务：task_382f825d9432cd9535d243b690（父 task_5b051225f10ebe9505e73e5b43）
- 分支：`codex/packet-root-hint`
- 公开范围：仅 CLI/daemon 引导文本（错误提示与成功后的下一步提示）；未改变接受的输入、校验规则或协议形状
- 私有计划/证据已更新：是（`artifacts/report.md`）
- 范围外：fixture 使用的目录 junction 技术在跨平台（Linux/Windows）与远端 CI 下的表现为 unverified；本次按 task_plan 明确允许，只跑了本地 macOS。

## 版本影响

- 版本：不变
- 发布影响：不发布

## 治理声明

- 触碰受保护面：否
- 受保护面范围：不适用
- 授权：不适用
- 机器检查边界：不适用
- Break-glass：否
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- 基线 `origin/main` SHA：`554be6d94`
- 分支与 `origin/main` 的 merge-base：`554be6d94`
- 最近一次 `git fetch origin`：2026-09-12 UTC
- 同步方式：从 origin/main 开分支
- 公开 diff 命令：`git diff origin/main...codex/packet-root-hint`
- 私有证据路径：task_382f825d9432cd9535d243b690 的 `artifacts/report.md`
- 评审证据路径：本 PR 的评审证据节
- GitHub Actions `rewrite-ci` run URL：本 PR 待跑
- 本地 macOS：`node tools/run-node-tests.mjs --file packages/cli/test/guidance-plane.test.ts` 从 7 通过/2 失败（红）改到 9/9（绿）；定向 eslint 无问题；line-density G36 通过；改动面 manifest gates 6/6 通过（584 份发现的测试文件）；治理 walls 12 通过/0 red。本分支未跑 Ubuntu 隔离测试。

## 评审证据

- CEO 事实核对：读过 worker 报告与 diff 统计；核过提交人与范围。
- 评审子代理：合入后走一条路收口评审
- 人工评审：待定
- 阻塞发现：无

## 残余风险

- 风险较低，纯增量引导文本；worker 指出底层通用 workspace 文本读取器同时服务非 Decision 输入，因此这次展示层改动的影响面略微超出它本来针对的 Decision 流程（但仍只是错误/下一步文本，不涉及行为）。

## 参考

- 任务：task_382f825d9432cd9535d243b690

