### PR TITLE
fix: derive eslint exclusions from gitignore

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,4 +1,6 @@
 import js from "@eslint/js";
+import { includeIgnoreFile } from "eslint/config";
+import { fileURLToPath } from "node:url";
 import tseslint from "typescript-eslint";
 import { kernelImportBoundaryKnownDebt } from "./tools/kernel-import-boundary-known-debt.mjs";
 import { portPhysicalIoBoundaryKnownDebt } from "./tools/port-physical-io-boundary-known-debt.mjs";
@@ -214,30 +216,10 @@ const kernelImportKnownDebtOverrides = Object.values(
 }));
 
 export default tseslint.config(
+  includeIgnoreFile(fileURLToPath(new URL(".gitignore", import.meta.url)), { gitignoreResolution: true }),
   {
-    ignores: [
-      ".git/",
-      ".b5-baseline/",
-      ".agents/",
-      ".claude/",
-      ".codex/",
-      ".gstack/",
-      ".harness/",
-      ".harness-private/",
-      ".harness-old-generation-*/",
-      ".worktrees/",
-      "coverage/",
-      "dist/",
-      "docs/",
-      "harness/",
-      "harness-old-generation-*/",
-      "node_modules/",
-      "packages/gui/build-resources/",
-      "packages/gui/.runtime-cache/",
-      "packages/**/dist/",
-      "packages/**/dist-electron/",
-      "tmp/",
-    ],
+    // Lint-only exclusions; all Git exclusions come from .gitignore above.
+    ignores: [".b5-baseline/", "packages/gui/build-resources/", "packages/**/dist-electron/"],
   },
   js.configs.recommended,
   ...tseslint.configs.recommended,

--- a/tools/gates/test/eslint-ignore-gitignore-sync.test.mjs
+++ b/tools/gates/test/eslint-ignore-gitignore-sync.test.mjs
@@ -3,23 +3,13 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { readFileSync } from "node:fs";
+import { copyFileSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { ESLint } from "eslint";
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
 
-// `.gitignore` and the ESLint `ignores` list are two hand-maintained answers to the same
-// question: which trees under this repository are not source. They drifted once already —
-// `harness-old-generation-*/` was ignored by git and still linted, which put 15,066 errors
-// into `npm run lint` and made the root `check:local` step permanently red on any machine
-// that had that archive checked out. This test states the one-directional invariant that
-// closes the drift: whatever git refuses to track at the top level, ESLint must refuse to lint.
-//
-// The check runs through `isPathIgnored` rather than comparing the two pattern lists, because
-// the same tree can be spelled differently in each file (`.harness*/` in git, `.harness/` plus
-// `.harness-private/` in ESLint) without any drift existing. Only root-anchored directory
-// patterns are covered: those are the ones that name a whole top-level tree, and they are the
-// class that drifted.
+// Check real ESLint behavior against the root trees declared by Git. The isolated
+// fixture below also verifies that newly added patterns work without a config edit.
 
 function rootAnchoredIgnoredDirectories() {
   const body = readFileSync(path.join(repoRoot, ".gitignore"), "utf8");
@@ -52,7 +42,7 @@ test("every root-anchored directory ignored by git is also ignored by ESLint", a
   assert.deepEqual(
     linted,
     [],
-    `git ignores these top-level trees but ESLint would still lint them; add each to the ignores list in eslint.config.mjs:\n  ${linted.join("\n  ")}`
+    `git ignores these top-level trees but ESLint would still lint them:\n  ${linted.join("\n  ")}`,
   );
 });
 
@@ -65,4 +55,52 @@ test("the probe is capable of failing: real source is not ignored", async () => 
 test("probePathFor substitutes globs so the probe is a concrete path", () => {
   assert.equal(probePathFor("harness-old-generation-*"), "harness-old-generation-probe/probe.ts");
   assert.equal(probePathFor("docs"), "docs/probe.ts");
+});
+
+test("new gitignore rules take effect without editing ESLint configuration", async (t) => {
+  const fixture = mkdtempSync(path.join(repoRoot, ".eslint-ignore-test-"));
+  t.after(() => rmSync(fixture, { recursive: true, force: true }));
+  copyFileSync(path.join(repoRoot, "eslint.config.mjs"), path.join(fixture, "eslint.config.mjs"));
+  symlinkSync(path.join(repoRoot, "tools"), path.join(fixture, "tools"), "junction");
+  writeFileSync(
+    path.join(fixture, ".gitignore"),
+    [
+      "# Newly added local trees and files",
+      "/new-local-tree/",
+      "generated-cache/",
+      "*.generated.js",
+      "!keep.generated.js",
+      "",
+    ].join("\r\n"),
+  );
+
+  const eslint = new ESLint({
+    cwd: fixture,
+    overrideConfig: { languageOptions: { parserOptions: { tsconfigRootDir: fixture } } },
+  });
+  for (const filePath of [
+    "new-local-tree/probe.js",
+    "packages/example/generated-cache/probe.js",
+    "packages/example/output.generated.js",
+  ]) {
+    assert.equal(await eslint.isPathIgnored(filePath), true, filePath);
+  }
+  for (const filePath of ["nested/new-local-tree/probe.js", "keep.generated.js", "src/probe.js"]) {
+    assert.equal(await eslint.isPathIgnored(filePath), false, filePath);
+  }
+  const [ignored] = await eslint.lintText("const = ;", { filePath: "new-local-tree/probe.js" });
+  assert.equal(ignored.errorCount, 0);
+  const [source] = await eslint.lintText("debugger;", { filePath: "src/probe.js" });
+  assert.ok(
+    source.messages.some(({ ruleId }) => ruleId === "no-debugger"),
+    JSON.stringify(source),
+  );
+});
+
+test("unanchored gitignored trees are ignored below source packages", async () => {
+  const eslint = new ESLint({ cwd: repoRoot });
+  for (const directory of ["dist", "coverage", "tmp", ".harness-local", ".playwright-mcp"]) {
+    const probe = `packages/example/${directory}/probe.js`;
+    assert.equal(await eslint.isPathIgnored(probe), true, probe);
+  }
 });


### PR DESCRIPTION
# English

## Summary

`.gitignore` and ESLint's hand-maintained `ignores` list were two independently maintained answers to the same question (which top-level trees are not source), and they had already drifted once: `harness-old-generation-*/` was git-ignored but still linted, producing 15,066 lint errors and a permanently red `check:local` on any machine with that archive checked out. The fix replaces the 21-entry hand-written `ignores` array with `includeIgnoreFile(...gitignore..., { gitignoreResolution: true })`, keeping only three lint-only exclusions (`.b5-baseline/`, GUI build resources, `dist-electron/`) that are not meant to be git-ignored.

## Architectural Justification

-

## What Changed

- `eslint.config.mjs`: replaced the 21-entry hand-maintained `ignores` list with `includeIgnoreFile()` reading `.gitignore` directly, retaining only 3 lint-only-specific exclusions.
- `tools/gates/test/eslint-ignore-gitignore-sync.test.mjs`: rewrote the drift-detection comment/tests to check real ESLint behavior against Git-declared roots, and added new fixture-based tests proving new `.gitignore` rules take effect without any `eslint.config.mjs` edit (including glob negation and CRLF line endings), plus a test that unanchored gitignored trees (`dist`, `coverage`, `tmp`, etc.) are ignored under nested packages.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: +5/-23 production; tests +52/-14.

## Machine-Readable Declarations

- None.

## Task And Scope

- Harness task: task_387c702411fe097881ffbf1a02 (parent none)
- Branch: `codex/eslint-ignore-derived`
- Public scope: root ESLint configuration and its own drift-detection test only; no product source file changed
- Private planning/evidence updated: yes (`artifacts/report.md`)
- Out of scope: Cross-platform (Linux, Windows) and remote-CI lint behavior with the new gitignore-derived ignore list is unverified — only local macOS execution was performed, and the fixture's directory-junction technique is untested off macOS.

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: yes — `eslint.config.mjs` (repository lint configuration)
- Protected surface scope: the hand-maintained `ignores` list is replaced by entries derived from `.gitignore`; the set of linted source trees is unchanged and a sync test guards drift
- Authority: task task_387c702411fe097881ffbf1a02 (CEO-authorized fix in the perf/governance line, 2026-09-12); no gate is skipped, weakened, or retimed
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `554be6d94`
- Branch merge-base with `origin/main`: `554be6d94`
- Last `git fetch origin` time: 2026-09-12 UTC
- Sync method: branched from origin/main
- Public diff command: `git diff origin/main...codex/eslint-ignore-derived`
- Private evidence commit/path: task_387c702411fe097881ffbf1a02 `artifacts/report.md`
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [x] `npm run typecheck` (worker, `tsc -b`)
- [ ] `npm run check`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts` (via `run-manifest-gates --changed origin/main`)
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- macOS local only (explicitly the only entry point this task plan allowed): before the fix, 2 of the drift-detection/fixture tests failed; after, `tools/gates/test/eslint-ignore-gitignore-sync.test.mjs` passed 5/5. Lint, line-density, and manifest gates all green locally. Linux/Windows/remote CI are explicitly called out as unverified in the worker's own report.

## Review Evidence

- CEO ground-truth: read the worker report and the diff stat; commit authorship and scope checked.
- Reviewer subagent: closeout review after merge (one-path closeout)
- Human review: pending
- Blocking findings: none open

## Residual Risk

- This changes what the root ESLint config actually lints across the whole repository (every top-level tree named in `.gitignore` is now excluded, not just the previously hand-picked list) — even though it does not touch a `tools/check-*.mjs` gate file or CI workflow directly, a CEO should sanity-check `npm run lint` once broadly before merging, since a wrong `.gitignore` pattern would now silently widen or narrow lint coverage repo-wide instead of requiring a separate `eslint.config.mjs` edit.

## References

- Task: task_387c702411fe097881ffbf1a02

---

# 中文

## 概要

`.gitignore` 和 ESLint 手写的 `ignores` 列表是对同一个问题（哪些顶层目录不是源码）各自维护的两份答案，并且已经出现过一次真实漂移：`harness-old-generation-*/` 被 git 忽略但仍被 lint，产生 15,066 条 lint 错误，让任何检出过该 archive 的机器上 `check:local` 永久变红。修复把 21 项手写的 `ignores` 数组换成 `includeIgnoreFile(...gitignore..., { gitignoreResolution: true })`，只保留三条不该被 git 忽略、但要被 lint 忽略的专属排除项（`.b5-baseline/`、GUI 构建资源、`dist-electron/`）。

## 架构辩护

-

## 改动内容

- `eslint.config.mjs`：把 21 项手写的 `ignores` 列表换成直接读 `.gitignore` 的 `includeIgnoreFile()`，只保留 3 条 lint 专属排除项。
- `tools/gates/test/eslint-ignore-gitignore-sync.test.mjs`：重写漂移检测注释/测试为核对真实 ESLint 行为与 Git 声明根的一致性，新增基于 fixture 的测试证明新增 `.gitignore` 规则无需改 `eslint.config.mjs` 即生效（含 glob 取反和 CRLF 换行），并新增测试验证未锚定的 gitignore 目录（`dist`、`coverage`、`tmp` 等）在嵌套包内同样被忽略。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 删除的门或 fixture：none
- 生产净行数：+5/-23 production; tests +52/-14。

## 机器可读声明

- 无。

## 任务与范围

- Harness 任务：task_387c702411fe097881ffbf1a02（父 none）
- 分支：`codex/eslint-ignore-derived`
- 公开范围：仅根 ESLint 配置及其自身的漂移检测测试；未改动任何产品源码文件
- 私有计划/证据已更新：是（`artifacts/report.md`）
- 范围外：改用 gitignore 派生忽略列表后，跨平台（Linux、Windows）及远端 CI 下的 lint 行为为 unverified——只跑了本地 macOS，且 fixture 用的目录 junction 技术在 macOS 之外未经测试。

## 版本影响

- 版本：不变
- 发布影响：不发布

## 治理声明

- 触碰受保护面：是——`eslint.config.mjs`（仓库 lint 配置）
- 受保护面范围：手工维护的 `ignores` 列表改为从 `.gitignore` 派生；被 lint 的源码树集合不变，并有同步测试防漂移
- 授权：任务 task_387c702411fe097881ffbf1a02（CEO 2026-09-12 在性能/治理线授权的修复）；没有跳过、削弱或调超时任何门
- 机器检查边界：本 PR 只断言声明存在；是否属实与充分由评审判断
- Break-glass：否
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- 基线 `origin/main` SHA：`554be6d94`
- 分支与 `origin/main` 的 merge-base：`554be6d94`
- 最近一次 `git fetch origin`：2026-09-12 UTC
- 同步方式：从 origin/main 开分支
- 公开 diff 命令：`git diff origin/main...codex/eslint-ignore-derived`
- 私有证据路径：task_387c702411fe097881ffbf1a02 的 `artifacts/report.md`
- 评审证据路径：本 PR 的评审证据节
- GitHub Actions `rewrite-ci` run URL：本 PR 待跑
- 仅本地 macOS（本任务计划明确允许的唯一入口）：修前漂移检测/fixture 测试有 2 项失败；修后 `tools/gates/test/eslint-ignore-gitignore-sync.test.mjs` 5/5 通过。lint、line-density、manifest gates 本地全绿。worker 自己的报告明确点名 Linux/Windows/远端 CI 为 unverified。

## 评审证据

- CEO 事实核对：读过 worker 报告与 diff 统计；核过提交人与范围。
- 评审子代理：合入后走一条路收口评审
- 人工评审：待定
- 阻塞发现：无

## 残余风险

- 这改变了根 ESLint 配置在整个仓库实际 lint 的范围（现在 `.gitignore` 里点名的每个顶层目录都会被排除，不再只是之前手选的列表）——虽然没有直接碰 `tools/check-*.mjs` 门文件或 CI workflow，但因为错误的 `.gitignore` 规则如今会悄悄扩大或缩小全仓 lint 覆盖面（而不需要另外改 `eslint.config.mjs`），CEO 合并前应该整体跑一次 `npm run lint` 做 sanity check。

## 参考

- 任务：task_387c702411fe097881ffbf1a02


