### PR TITLE
fix: report projection cache discard reasons

### DIFF
--- a/packages/kernel/src/projection/rebuildable-task-projection-database.ts
+++ b/packages/kernel/src/projection/rebuildable-task-projection-database.ts
@@ -148,11 +148,25 @@ export function withQueryOnlyDatabaseSession<A>(
     db.close();
   }
 }
-export function discardDatabase(projectionPath: string, eventStore: EventStreamPort): void {
+export function discardDatabase(
+  projectionPath: string,
+  eventStore: EventStreamPort,
+  reason: "schema_mismatch" | "explicit_rebuild",
+): void {
   if (!localRuntimeStateFileSystem.exists(projectionPath)) return;
   const coverage = readProjectionCoverage(projectionPath, eventStore.readHead);
   assertEventStreamContinuity(eventStore, coverage);
   closeProjectionHandlesAt(canonicalProjectionPath(projectionPath));
+  console.error(
+    JSON.stringify({
+      event: "projection_discard_started",
+      reason,
+      projectionPath,
+      ...coverage,
+      supportedSchemaVersion: taskProjectionSchemaVersion,
+      eventStreamHead: eventStore.readHead()?.revision ?? null,
+    }),
+  );
   localRuntimeStateFileSystem.remove(projectionPath);
 }
 // close() shares discard()'s invariant: callers close a projection so they can remove its file, and
@@ -287,6 +301,7 @@ function readProjectionCoverage(
   projectionPath: string,
   readHead: EventStreamPort["readHead"],
 ): {
+  readonly schemaVersion: number | null;
   readonly watermark: number;
   readonly scannedRevision: number;
 } {
@@ -296,7 +311,11 @@ function readProjectionCoverage(
       "SELECT watermark, scanned_revision FROM projection_meta WHERE singleton = 1",
     )[0];
     if (row === undefined) throw new Error(`projection cache metadata is unavailable at ${projectionPath}`);
-    return { watermark: Number(row.watermark), scannedRevision: Number(row.scanned_revision) };
+    return {
+      schemaVersion: projectionSchemaVersion(db),
+      watermark: Number(row.watermark),
+      scannedRevision: Number(row.scanned_revision),
+    };
   });
 }
 

--- a/packages/kernel/src/projection/rebuildable-task-projection-factory.ts
+++ b/packages/kernel/src/projection/rebuildable-task-projection-factory.ts
@@ -83,7 +83,7 @@ export function makeTaskProjection(options: {
     } catch (error) {
       if (error instanceof ProjectionSchemaMismatchError && error.observed < taskProjectionSchemaVersion) {
         consumeKnownError(error);
-        discardDatabase(projectionPath, options.eventStore);
+        discardDatabase(projectionPath, options.eventStore, "schema_mismatch");
       } else if (error instanceof ProjectionIdentityMismatchError) consumeKnownError(error);
       else throw error;
     }

--- a/packages/kernel/src/projection/rebuildable-task-projection-reads.ts
+++ b/packages/kernel/src/projection/rebuildable-task-projection-reads.ts
@@ -200,7 +200,7 @@ export function rebuildProjection(
   // Rebuild is a schema repair boundary as well as a data replay. Deleting the disposable
   // database ensures CREATE TABLE materializes current DDL instead of retaining any table
   // whose shape changed while its version metadata was stale or incorrect.
-  discardDatabase(projectionPath, eventStore);
+  discardDatabase(projectionPath, eventStore, "explicit_rebuild");
   let transactions = 0,
     reducedItems = 0,
     maxBatchItems = 0;

--- a/packages/kernel/test/store/projection-cache-continuity.test.ts
+++ b/packages/kernel/test/store/projection-cache-continuity.test.ts
@@ -14,6 +14,7 @@ import { initRepo } from "./task-event-store.fixtures.ts";
 import { withTempStoreAsync } from "./helpers.ts";
 
 test("a real SQLite event gap blocks schema rebuild and preserves the cache bytes", async (t) => {
+  const logged = t.mock.method(console, "error", () => undefined);
   await withTempStoreAsync(async (rootDir) => {
     initRepo(rootDir);
     const writer = makeTaskEventStore({ repoId: "cache-continuity", rootDir }),
@@ -69,6 +70,7 @@ test("a real SQLite event gap blocks schema rebuild and preserves the cache byte
     assert.deepEqual(readFileSync(projection.path), retained);
     assert.throws(() => makeTaskProjection({ rootDir, eventStore }), rejectsGap);
     assert.deepEqual(readFileSync(projection.path), retained);
+    assert.equal(logged.mock.callCount(), 0, "a refused discard must not report that deletion started");
     t.diagnostic(
       JSON.stringify({
         case: "sqlite-event-gap",

--- a/packages/kernel/test/store/projection-ddl-rebuild.test.ts
+++ b/packages/kernel/test/store/projection-ddl-rebuild.test.ts
@@ -1,7 +1,7 @@
 // harness-test-tier: integration
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { mkdirSync } from "node:fs";
+import { existsSync, mkdirSync } from "node:fs";
 import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
 import test from "node:test";
@@ -15,12 +15,27 @@ import { withTempStoreAsync } from "./helpers.ts";
 
 const previousProjectionSchemaVersion = 13;
 
-test("a projection schema bump discards pre-first-class Fact DDL before replay", async () => {
+test("a projection schema bump discards pre-first-class Fact DDL before replay", async (t) => {
   await withTempStoreAsync(async (rootDir) => {
     const { projectionPath, eventStore } = tasklessFactLedger(rootDir, "automatic-ddl-rebuild", "F-ABE050B5");
     writeLegacyFactProjection(projectionPath, previousProjectionSchemaVersion);
+    const logged = t.mock.method(console, "error", (line: string) => {
+      assert.equal(existsSync(projectionPath), true, "report the old cache before removing it");
+      return JSON.parse(line);
+    });
 
     const projection = makeTaskProjection({ rootDir, eventStore });
+    assert.equal(logged.mock.callCount(), 1);
+    assert.deepEqual(logged.mock.calls[0]!.result, {
+      event: "projection_discard_started",
+      reason: "schema_mismatch",
+      projectionPath,
+      schemaVersion: previousProjectionSchemaVersion,
+      supportedSchemaVersion: taskProjectionSchemaVersion,
+      watermark: 0,
+      scannedRevision: 0,
+      eventStreamHead: 1,
+    });
     projection.catchUp();
     assert.equal(projection.searchFacts({ query: "standalone" }).facts[0]?.factId, "F-ABE050B5");
     projection.close();
@@ -28,15 +43,37 @@ test("a projection schema bump discards pre-first-class Fact DDL before replay",
   });
 });
 
-test("explicit projection rebuild replaces stale DDL even when its version claims to be current", async () => {
+test("explicit projection rebuild replaces stale DDL even when its version claims to be current", async (t) => {
   await withTempStoreAsync(async (rootDir) => {
     const { projectionPath, eventStore } = tasklessFactLedger(rootDir, "explicit-ddl-rebuild", "F-C01DB01D");
     writeLegacyFactProjection(projectionPath, taskProjectionSchemaVersion);
 
     const projection = makeTaskProjection({ rootDir, eventStore });
+    const logged = t.mock.method(console, "error", (line: string) => {
+      assert.equal(existsSync(projectionPath), true, "report the old cache before removing it");
+      return JSON.parse(line);
+    });
     const rebuilt = projection.rebuild();
+    assert.equal(logged.mock.callCount(), 1);
+    assert.deepEqual(logged.mock.calls[0]!.result, {
+      event: "projection_discard_started",
+      reason: "explicit_rebuild",
+      projectionPath,
+      schemaVersion: taskProjectionSchemaVersion,
+      supportedSchemaVersion: taskProjectionSchemaVersion,
+      watermark: 0,
+      scannedRevision: 0,
+      eventStreamHead: 1,
+    });
     assert.equal(rebuilt.watermark, 1);
     assert.equal(projection.searchFacts({ query: "standalone" }).facts[0]?.factId, "F-C01DB01D");
+    projection.rebuild();
+    assert.equal(logged.mock.callCount(), 2);
+    assert.deepEqual(logged.mock.calls[1]!.result, {
+      ...logged.mock.calls[0]!.result,
+      watermark: 1,
+      scannedRevision: 1,
+    });
     projection.close();
     assertCurrentFactSchema(projectionPath);
   });


### PR DESCRIPTION
# English

## Summary

`discardDatabase()` deletes a projection's SQLite cache file before a schema-mismatch or explicit rebuild replay, but did so silently — there was no record of why a projection file disappeared, which matters for diagnosing an incident where a cache was unexpectedly gone. The premise task's identity-mismatch branch was already handled by prior work; this branch closes the remaining schema-upgrade and explicit-rebuild gap by logging a structured `projection_discard_started` event (reason, path, prior schema version, coverage watermark, event-stream head) to stderr immediately before the file is removed.

## Architectural Justification

-

## What Changed

- `packages/kernel/src/projection/rebuildable-task-projection-database.ts`: `discardDatabase()` takes a required `reason: "schema_mismatch" | "explicit_rebuild"` and logs a structured JSON event to `console.error` before deleting the projection file; `readProjectionCoverage()` now also returns `schemaVersion`.
- `rebuildable-task-projection-factory.ts`, `-reads.ts`: pass the specific reason at each of the two call sites.
- `projection-cache-continuity.test.ts`: asserts a refused discard (event-stream gap) logs nothing.
- `projection-ddl-rebuild.test.ts`: asserts the exact logged event shape for both the schema-mismatch and explicit-rebuild paths, including a second explicit rebuild logging updated watermark/scannedRevision.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: +23/-4 production; tests +42/-3.

## Machine-Readable Declarations

- None.

## Task And Scope

- Harness task: task_1947c67e88fb124ecf0860c1f7 (parent none)
- Branch: `codex/projection-drop-reason`
- Public scope: kernel projection discard/rebuild diagnostics only; no schema version change, no behavior change to when a discard happens
- Private planning/evidence updated: yes (`artifacts/report.md`)
- Out of scope: Root-causing any specific past incident from this new log line, and whether it gets durably persisted anywhere beyond stderr, are both unverified — this only adds the diagnostic emission point.

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: not applicable
- Machine-check boundary: not applicable
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `554be6d94`
- Branch merge-base with `origin/main`: `554be6d94`
- Last `git fetch origin` time: 2026-09-12 UTC
- Sync method: branched from origin/main
- Public diff command: `git diff origin/main...codex/projection-drop-reason`
- Private evidence commit/path: task_1947c67e88fb124ecf0860c1f7 `artifacts/report.md`
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [x] `npm run typecheck` (worker, `tsc -b`)
- [ ] `npm run check`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts` (via `run-manifest-gates --changed origin/main`)
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Ubuntu isolated run: 9/9 final; ESLint, typecheck, line-density, and 7 manifest gates all green (run locally on macOS for the non-integration steps). Red reproduction confirmed the missing-log gap before the fix.

## Review Evidence

- CEO ground-truth: read the worker report and the diff stat; commit authorship and scope checked.
- Reviewer subagent: closeout review after merge (one-path closeout)
- Human review: pending
- Blocking findings: none open

## Residual Risk

- Overlaps file-for-file with the `perf-g4` branch: both edit `rebuildable-task-projection-database.ts` and `projection-ddl-rebuild.test.ts`. If both are merged, expect a manual conflict resolution (perf-g4 changes `discardDatabase`'s surrounding code for STORED columns; this branch changes its signature and logging) — recommend rebasing one onto the other before merge rather than merging both independently.

## References

- Task: task_1947c67e88fb124ecf0860c1f7

---

# 中文

## 概要

`discardDatabase()` 在 schema 不匹配或显式 rebuild 重放前会删掉投影的 SQLite 缓存文件，但过程是静默的——没有任何记录说明一个投影文件为什么消失，这在排查「缓存意外消失」的事故时是个问题。前置任务的 identity-mismatch 分支已由之前的工作处理；本分支补上剩余的 schema 升级与显式 rebuild 缺口，在删除文件之前把结构化的 `projection_discard_started` 事件（reason、路径、旧 schema 版本、覆盖水位、事件流 head）打到 stderr。

## 架构辩护

-

## 改动内容

- `packages/kernel/src/projection/rebuildable-task-projection-database.ts`：`discardDatabase()` 增加必传的 `reason: "schema_mismatch" | "explicit_rebuild"`，删除投影文件前向 `console.error` 记录结构化 JSON 事件；`readProjectionCoverage()` 现在也返回 `schemaVersion`。
- `rebuildable-task-projection-factory.ts`、`-reads.ts`：在两个调用点分别传入具体 reason。
- `projection-cache-continuity.test.ts`：断言被拒绝的丢弃（事件流有缺口）不会打任何日志。
- `projection-ddl-rebuild.test.ts`：断言 schema-mismatch 与 explicit-rebuild 两条路径记录的日志事件的确切形状，包括第二次显式 rebuild 记录更新后的 watermark/scannedRevision。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 删除的门或 fixture：none
- 生产净行数：+23/-4 production; tests +42/-3。

## 机器可读声明

- 无。

## 任务与范围

- Harness 任务：task_1947c67e88fb124ecf0860c1f7（父 none）
- 分支：`codex/projection-drop-reason`
- 公开范围：仅内核投影丢弃/重建的诊断日志；不改变 schema 版本，也不改变丢弃发生的时机
- 私有计划/证据已更新：是（`artifacts/report.md`）
- 范围外：用这条新日志定位任何具体历史事故的根因，以及它是否会在 stderr 之外被持久保存，均为 unverified——本次只新增了诊断打点。

## 版本影响

- 版本：不变
- 发布影响：不发布

## 治理声明

- 触碰受保护面：否
- 受保护面范围：不适用
- 授权：不适用
- 机器检查边界：不适用
- Break-glass：否
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- 基线 `origin/main` SHA：`554be6d94`
- 分支与 `origin/main` 的 merge-base：`554be6d94`
- 最近一次 `git fetch origin`：2026-09-12 UTC
- 同步方式：从 origin/main 开分支
- 公开 diff 命令：`git diff origin/main...codex/projection-drop-reason`
- 私有证据路径：task_1947c67e88fb124ecf0860c1f7 的 `artifacts/report.md`
- 评审证据路径：本 PR 的评审证据节
- GitHub Actions `rewrite-ci` run URL：本 PR 待跑
- Ubuntu 隔离测试：最终 9/9；ESLint、typecheck、line-density、7 项 manifest gates 全绿（非 integration 步骤本地 macOS 跑）。修前红测复现了缺失日志的缺口。

## 评审证据

- CEO 事实核对：读过 worker 报告与 diff 统计；核过提交人与范围。
- 评审子代理：合入后走一条路收口评审
- 人工评审：待定
- 阻塞发现：无

## 残余风险

- 与 `perf-g4` 分支存在逐文件重叠：两者都改了 `rebuildable-task-projection-database.ts` 和 `projection-ddl-rebuild.test.ts`。若两者都合入，预计需要手工解决冲突（perf-g4 为 STORED 列改动了 `discardDatabase` 周围代码；本分支改了它的签名和日志）——建议合并前先把其中一个 rebase 到另一个上，而不是各自独立合并。

## 参考

- 任务：task_1947c67e88fb124ecf0860c1f7

