### PR TITLE
fix: derive daemon sockets from a short per-user directory

### DIFF
--- a/packages/cli/test/migration-multi-source-cli.integration.test.ts
+++ b/packages/cli/test/migration-multi-source-cli.integration.test.ts
@@ -200,10 +200,7 @@ function environment(root: string, userRoot: string): NodeJS.ProcessEnv {
     TMPDIR: process.platform === "win32" ? base.TMPDIR : "/tmp",
     GIT_CONFIG_GLOBAL: "/dev/null",
     HARNESS_DAEMON_USER_ROOT: userRoot,
-    HARNESS_DAEMON_ENDPOINT:
-      process.platform === "win32"
-        ? localUserDaemonEndpoint(userRoot)
-        : path.join("/tmp/harness-anything", path.basename(localUserDaemonEndpoint(userRoot))),
+    HARNESS_DAEMON_ENDPOINT: localUserDaemonEndpoint(userRoot),
   };
 }
 function stop(userRoot: string, root: string): void {

--- a/packages/cli/test/runtime-cli.setup.fixture.ts
+++ b/packages/cli/test/runtime-cli.setup.fixture.ts
@@ -45,10 +45,7 @@ export function createRuntimeFixture(context: TestContext) {
     HARNESS_NOTIFY_TEST_SECRET: "must-not-reach-notifier",
     HARNESS_DAEMON_USER_ROOT: userRoot,
     HARNESS_DAEMON_ID: daemonId,
-    HARNESS_DAEMON_ENDPOINT:
-      process.platform === "win32"
-        ? localUserDaemonEndpoint(userRoot, daemonId)
-        : path.join("/tmp/harness-anything", path.basename(localUserDaemonEndpoint(userRoot, daemonId))),
+    HARNESS_DAEMON_ENDPOINT: localUserDaemonEndpoint(userRoot, daemonId),
     HARNESS_ACTOR: "agent:runtime-cli-test",
   };
   context.after(() => {

--- a/packages/cli/test/sqlite-ledger-reconcile.integration.test.ts
+++ b/packages/cli/test/sqlite-ledger-reconcile.integration.test.ts
@@ -270,10 +270,7 @@ function environment(root: string, userRoot: string): NodeJS.ProcessEnv {
     HOME: path.join(root, ".home"),
     GIT_CONFIG_GLOBAL: "/dev/null",
     HARNESS_DAEMON_USER_ROOT: userRoot,
-    HARNESS_DAEMON_ENDPOINT:
-      process.platform === "win32"
-        ? localUserDaemonEndpoint(userRoot)
-        : path.join("/tmp/harness-anything", path.basename(localUserDaemonEndpoint(userRoot))),
+    HARNESS_DAEMON_ENDPOINT: localUserDaemonEndpoint(userRoot),
   };
 }
 

--- a/packages/daemon/src/client/local-daemon-target.ts
+++ b/packages/daemon/src/client/local-daemon-target.ts
@@ -32,9 +32,7 @@ export function localUserDaemonEndpoint(
   platform: NodeJS.Platform = process.platform,
 ): EndpointIdentity {
   const id = `u-${localDaemonTargetHash(`${path.resolve(userRoot)}\0${daemonId}`)}`;
-  return endpointIdentity(
-    platform === "win32" ? `\\\\.\\pipe\\harness-anything-${safeDaemonId(id)}` : unixEndpoint(id),
-  );
+  return endpointIdentity(platform === "win32" ? `\\\\.\\pipe\\harness-anything-${id}` : defaultUnixSocketPath(id));
 }
 export function daemonUserRoot(env: NodeJS.ProcessEnv = process.env): string {
   return path.resolve(env.HARNESS_DAEMON_USER_ROOT || path.join(os.homedir(), ".harness"));
@@ -63,8 +61,8 @@ export function resolveLocalDaemonEndpoint(input: {
     return expected;
   }
   const endpoint = endpointIdentity(injected);
-  // An enforced runtime changes TMPDIR, so a matching POSIX socket may live in a different
-  // directory. Its basename still carries the hash of the sealed (userRoot, daemonId) pair.
+  // An explicitly injected POSIX socket may live in a different directory. Its basename
+  // carries the hash of the sealed (userRoot, daemonId) pair.
   const accepted =
     env.HARNESS_DAEMON_RELAY === "1"
       ? input.canonicalRoot !== undefined && isWorkspaceRelayEndpoint(endpoint, input.canonicalRoot)
@@ -156,13 +154,6 @@ export async function readRegisteredRepos(
 function localDaemonTargetHash(value: string): string {
   return createHash("sha256").update(value).digest("hex").slice(0, 16);
 }
-function safeDaemonId(value: string): string {
-  return value.replace(/[^A-Za-z0-9_.-]/gu, "-");
-}
-function unixEndpoint(id: string): string {
-  return path.join(os.tmpdir(), "harness-anything", `daemon-${process.getuid?.() ?? 0}-${safeDaemonId(id)}.sock`);
-}
-
 function isWorkspaceRelayEndpoint(endpoint: string, rootDir: string): boolean {
   const root = path.resolve(rootDir),
     relative = path.relative(root, path.resolve(endpoint)),
@@ -175,4 +166,13 @@ function isWorkspaceRelayEndpoint(endpoint: string, rootDir: string): boolean {
     if (info?.isSymbolicLink()) return false;
   }
   return true;
+}
+
+export function defaultUnixSocketPath(daemonId: string, uid = process.getuid?.() ?? 0): string {
+  // TMPDIR can exceed the Unix socket path limit and differ between clients and the daemon.
+  return path.join(
+    "/tmp",
+    `harness-anything-${uid}`,
+    `daemon-${uid}-${daemonId.replace(/[^A-Za-z0-9_.-]/gu, "-")}.sock`,
+  );
 }

--- a/packages/daemon/src/transport/unix-socket.ts
+++ b/packages/daemon/src/transport/unix-socket.ts
@@ -2,8 +2,9 @@
 import { randomUUID } from "node:crypto";
 import { mkdirSync, rmSync, chmodSync, statSync } from "node:fs";
 import net from "node:net";
-import os from "node:os";
 import path from "node:path";
+import { defaultUnixSocketPath } from "../client/local-daemon-target.ts";
+export { defaultUnixSocketPath } from "../client/local-daemon-target.ts";
 import type { DaemonAuthenticationContext } from "./auth-context.ts";
 import { serveJsonRpcStream, type DaemonTransportConnection } from "./json-rpc-stream.ts";
 import type { JsonRpcProtocolServer } from "../protocol/json-rpc-server.ts";
@@ -26,10 +27,6 @@ export interface UnixSocketTransportServer {
   readonly endpoint: string;
   readonly start: () => Promise<void>;
   readonly stop: () => Promise<void>;
-}
-
-export function defaultUnixSocketPath(daemonId: string, uid = process.getuid?.() ?? 0): string {
-  return path.join(os.tmpdir(), "harness-anything", `daemon-${uid}-${safeUnixSocketEndpointId(daemonId)}.sock`);
 }
 
 export function createUnixSocketTransportServer(options: UnixSocketTransportOptions): UnixSocketTransportServer {
@@ -110,8 +107,4 @@ export function createUnixSocketTransportServer(options: UnixSocketTransportOpti
       if (process.platform !== "win32") rmSync(endpoint, { force: true });
     },
   };
-}
-
-function safeUnixSocketEndpointId(value: string): string {
-  return value.replace(/[^A-Za-z0-9_.-]/gu, "-");
 }

--- a/packages/daemon/test/unix-socket-path.test.ts
+++ b/packages/daemon/test/unix-socket-path.test.ts
@@ -1,0 +1,53 @@
+// harness-test-tier: integration
+import assert from "node:assert/strict";
+import { randomUUID } from "node:crypto";
+import { once } from "node:events";
+import { mkdirSync, statSync } from "node:fs";
+import net from "node:net";
+import path from "node:path";
+import test from "node:test";
+import { localUserDaemonEndpoint } from "../src/client/local-daemon-target.ts";
+import { defaultUnixSocketPath } from "../src/transport/unix-socket.ts";
+
+test(
+  "Unix daemon endpoints connect independently of long process TMPDIR values",
+  {
+    skip: process.platform === "win32" ? "requires POSIX Unix-domain sockets" : false,
+    timeout: 5000,
+  },
+  async () => {
+    const original = process.env.TMPDIR;
+    const id = randomUUID();
+    const userRoot = `/tmp/${id}`;
+    let endpoints: string[];
+    try {
+      process.env.TMPDIR = `/tmp/${"packaged-app-temp-".repeat(12)}`;
+      endpoints = [localUserDaemonEndpoint(userRoot, id), defaultUnixSocketPath(id)];
+      process.env.TMPDIR = "/tmp/another-runtime";
+      assert.deepEqual([localUserDaemonEndpoint(userRoot, id), defaultUnixSocketPath(id)], endpoints);
+      assert.notEqual(localUserDaemonEndpoint(`${userRoot}-other`, id), endpoints[0]);
+      assert.notEqual(localUserDaemonEndpoint(userRoot, `${id}-other`), endpoints[0]);
+      assert.notEqual(defaultUnixSocketPath(id, 1001), defaultUnixSocketPath(id, 1002));
+    } finally {
+      if (original === undefined) delete process.env.TMPDIR;
+      else process.env.TMPDIR = original;
+    }
+    for (const endpoint of endpoints) {
+      assert.ok(Buffer.byteLength(endpoint) < 104, endpoint);
+      mkdirSync(path.dirname(endpoint), { recursive: true, mode: 0o700 });
+      assert.equal(statSync(path.dirname(endpoint)).uid, process.getuid!());
+      const server = net.createServer((socket) => socket.end("connected"));
+      let client: net.Socket | undefined;
+      try {
+        server.listen(endpoint);
+        await once(server, "listening");
+        client = net.createConnection(endpoint);
+        const [data] = await once(client, "data");
+        assert.equal(data.toString(), "connected");
+      } finally {
+        client?.destroy();
+        await new Promise<void>((resolve) => server.close(() => resolve()));
+      }
+    }
+  },
+);


### PR DESCRIPTION
# English

## Summary

The packaged macOS app's daemon Unix socket path was built from `os.tmpdir()`, which under an app sandbox/packaged runtime can be a long per-process directory; combined with the `harness-anything/daemon-<uid>-<hash>.sock` suffix this could exceed the ~104-byte `sun_path` limit and fail to bind with `EINVAL`. Reproduced at 241 bytes; the fix hardcodes the socket directory to `/tmp/harness-anything-<uid>/` (not `os.tmpdir()`), cutting the path to 60 bytes, and consolidates the previously duplicated `defaultUnixSocketPath`/`safeDaemonId` helpers into one shared implementation in `local-daemon-target.ts` (re-exported from `unix-socket.ts` for compatibility).

## Architectural Justification

-

## What Changed

- `packages/daemon/src/client/local-daemon-target.ts`: `defaultUnixSocketPath()` now builds the socket path under `/tmp/harness-anything-<uid>/` instead of `os.tmpdir()`; `localUserDaemonEndpoint`/`unixEndpoint` use it; duplicate `safeDaemonId` sanitizer removed.
- `packages/daemon/src/transport/unix-socket.ts`: its own copy of `defaultUnixSocketPath`/`safeUnixSocketEndpointId` deleted; re-exports the shared implementation from `local-daemon-target.ts`.
- `packages/daemon/test/unix-socket-path.test.ts` (new): proves the endpoint/socket path stays under the 104-byte `sun_path` limit and is stable across `TMPDIR` changes, and that two different daemon ids/uids produce different paths, by actually binding and connecting a socket.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: +14/-21 production; tests +53/-0.

## Machine-Readable Declarations

- None.

## Task And Scope

- Harness task: task_265b60d8ab1da917e18e3011f5 (parent task_9e3eea2efd1fa156ecceaa1303)
- Branch: `codex/socket-path-limit`
- Public scope: daemon Unix socket path resolution only; no protocol, transport framing, or public CLI-facing behavior changed
- Private planning/evidence updated: yes (`artifacts/report.md`)
- Out of scope: A DMG-packaged end-to-end smoke test, Windows named-pipe behavior, and a full `tsc` build are all unverified in this run.

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: not applicable
- Machine-check boundary: not applicable
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `554be6d94`
- Branch merge-base with `origin/main`: `554be6d94`
- Last `git fetch origin` time: 2026-09-12 UTC
- Sync method: branched from origin/main
- Public diff command: `git diff origin/main...codex/socket-path-limit`
- Private evidence commit/path: task_265b60d8ab1da917e18e3011f5 `artifacts/report.md`
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [x] `npm run typecheck` (worker, `tsc -b`)
- [ ] `npm run check`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts` (via `run-manifest-gates --changed origin/main`)
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- macOS 20/20, Ubuntu 1/1 (the new binding/connection test); ESLint and all required gates passed. The `EINVAL` reproduction (241-byte path) and the fixed 60-byte path were both actually measured, not just asserted.

## Review Evidence

- CEO ground-truth: read the worker report and the diff stat; commit authorship and scope checked.
- Reviewer subagent: closeout review after merge (one-path closeout)
- Human review: pending
- Blocking findings: none open

## Residual Risk

- The socket directory is now hardcoded to `/tmp/harness-anything-<uid>/` regardless of `TMPDIR`, which is the intended fix for the packaged-app path-length bug but is a real behavior change for any environment relying on a custom `TMPDIR` for the daemon socket (e.g. a sandboxed or restricted `/tmp`); worth a deliberate sanity check on the actual packaged macOS build before merge, since only the isolated unit/integration test was run, not a DMG smoke test.

## References

- Task: task_265b60d8ab1da917e18e3011f5

---

# 中文

## 概要

打包后 macOS app 的 daemon Unix socket 路径由 `os.tmpdir()` 拼出，而在 app 沙箱/打包运行时下这可能是一个很长的按进程目录；加上 `harness-anything/daemon-<uid>-<hash>.sock` 后缀，总长可能超过 `sun_path` 约 104 字节的限制，绑定时报 `EINVAL`。已复现出 241 字节的路径；修复把 socket 目录硬编码为 `/tmp/harness-anything-<uid>/`（不再用 `os.tmpdir()`），把路径缩到 60 字节，并把此前重复的 `defaultUnixSocketPath`/`safeDaemonId` 两份实现合并为 `local-daemon-target.ts` 里的一份共享实现（`unix-socket.ts` 里改为重导出以保持兼容）。

## 架构辩护

-

## 改动内容

- `packages/daemon/src/client/local-daemon-target.ts`：`defaultUnixSocketPath()` 改为在 `/tmp/harness-anything-<uid>/` 下构造路径而非 `os.tmpdir()`；`localUserDaemonEndpoint`/`unixEndpoint` 使用它；删除重复的 `safeDaemonId` 清理函数。
- `packages/daemon/src/transport/unix-socket.ts`：删除自身那份 `defaultUnixSocketPath`/`safeUnixSocketEndpointId`，改为重导出 `local-daemon-target.ts` 的共享实现。
- `packages/daemon/test/unix-socket-path.test.ts`（新增）：通过实际绑定并连接一个 socket，证明端点/socket 路径始终低于 104 字节的 `sun_path` 限制，且在 `TMPDIR` 变化下保持稳定，不同 daemon id/uid 产生不同路径。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 删除的门或 fixture：none
- 生产净行数：+14/-21 production; tests +53/-0。

## 机器可读声明

- 无。

## 任务与范围

- Harness 任务：task_265b60d8ab1da917e18e3011f5（父 task_9e3eea2efd1fa156ecceaa1303）
- 分支：`codex/socket-path-limit`
- 公开范围：仅 daemon Unix socket 路径解析；未改动协议、传输帧格式或任何面向公开 CLI 的行为
- 私有计划/证据已更新：是（`artifacts/report.md`）
- 范围外：本次运行未验证：DMG 打包后的端到端 smoke 测试、Windows 命名管道行为、完整 `tsc` 构建。

## 版本影响

- 版本：不变
- 发布影响：不发布

## 治理声明

- 触碰受保护面：否
- 受保护面范围：不适用
- 授权：不适用
- 机器检查边界：不适用
- Break-glass：否
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- 基线 `origin/main` SHA：`554be6d94`
- 分支与 `origin/main` 的 merge-base：`554be6d94`
- 最近一次 `git fetch origin`：2026-09-12 UTC
- 同步方式：从 origin/main 开分支
- 公开 diff 命令：`git diff origin/main...codex/socket-path-limit`
- 私有证据路径：task_265b60d8ab1da917e18e3011f5 的 `artifacts/report.md`
- 评审证据路径：本 PR 的评审证据节
- GitHub Actions `rewrite-ci` run URL：本 PR 待跑
- macOS 20/20，Ubuntu 1/1（新增的绑定/连接测试）；ESLint 及全部规定 gates 通过。`EINVAL` 复现（241 字节路径）与修复后 60 字节路径均为实测，非仅断言。

## 评审证据

- CEO 事实核对：读过 worker 报告与 diff 统计；核过提交人与范围。
- 评审子代理：合入后走一条路收口评审
- 人工评审：待定
- 阻塞发现：无

## 残余风险

- socket 目录现在无论 `TMPDIR` 为何都硬编码为 `/tmp/harness-anything-<uid>/`，这正是针对打包应用路径过长 bug 的预期修复，但对任何依赖自定义 `TMPDIR` 承载 daemon socket 的环境（例如受限 `/tmp` 的沙箱）都是真实行为变化；建议合并前在实际打包的 macOS 构建上专门 sanity check 一次，因为本次只跑了隔离单元/集成测试，没跑 DMG smoke 测试。

## 参考

- 任务：task_265b60d8ab1da917e18e3011f5

