### PR TITLE
fix: reap test process groups when the host exits

### DIFF
--- a/tools/run-node-tests-process-group.test.mjs
+++ b/tools/run-node-tests-process-group.test.mjs
@@ -1,0 +1,97 @@
+// harness-test-tier: fast
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { once } from "node:events";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import test from "node:test";
+
+const repoRoot = resolve(import.meta.dirname, "..");
+
+test(
+  "runner reaps descendants when the test host dies before its output pipes close",
+  {
+    skip: process.platform === "win32" ? "requires POSIX process groups and SIGKILL semantics" : false,
+  },
+  async () => {
+    const root = mkdtempSync(join(tmpdir(), "ha-runner-host-exit-"));
+    const preload = join(root, "host.mjs");
+    writeFileSync(
+      preload,
+      `
+import childProcess from 'node:child_process';
+import { syncBuiltinESMExports } from 'node:module';
+const spawn = childProcess.spawn;
+childProcess.spawn = (command, args, options) => {
+  if (!args.includes('--test')) return spawn(command, args, options);
+  return spawn(command, ['-e', ${JSON.stringify(`
+  const { spawn } = require('node:child_process');
+  const child = spawn(process.execPath, ['-e',
+    "process.on('SIGTERM', () => {}); console.log('DESCENDANT_READY'); setInterval(() => {}, 1000);"
+  ], { stdio: ['ignore', 'inherit', 'inherit'], env: { ...process.env, NODE_OPTIONS: '' } });
+  console.log('HOST_PID=' + process.pid);
+  child.unref();
+  setInterval(() => {}, 1000);
+`)}], options);
+};
+syncBuiltinESMExports();
+`,
+    );
+    const env = { ...process.env, NODE_OPTIONS: `--import=${pathToFileURL(preload).href}` };
+    delete env.NODE_TEST_CONTEXT;
+    const runner = spawn(
+      process.execPath,
+      ["tools/run-node-tests.mjs", "--file", "tools/test-fixtures/runner-watchdog/open-handle.test.mjs"],
+      {
+        cwd: repoRoot,
+        env,
+        stdio: ["ignore", "pipe", "pipe"],
+      },
+    );
+    const closed = once(runner, "close");
+    let hostPid;
+    let output = "";
+    let deadline;
+    try {
+      await new Promise((resolveReady, reject) => {
+        deadline = setTimeout(() => reject(new Error(`host did not start: ${output}`)), 10_000);
+        runner.stdout.on("data", (chunk) => {
+          output += chunk;
+          const match = /HOST_PID=(\d+)/u.exec(output);
+          if (match) hostPid = Number(match[1]);
+          if (hostPid && output.includes("DESCENDANT_READY")) resolveReady();
+        });
+        runner.stderr.on("data", (chunk) => {
+          output += chunk;
+        });
+      });
+      clearTimeout(deadline);
+      process.kill(hostPid, "SIGKILL");
+      const result = await Promise.race([
+        closed,
+        new Promise((_, reject) => {
+          deadline = setTimeout(
+            () => reject(new Error(`runner waited for inherited pipes after host death: ${output}`)),
+            5_000,
+          );
+        }),
+      ]);
+      assert.deepEqual(result, [1, null], output);
+      assert.throws(() => process.kill(-hostPid, 0), { code: "ESRCH" });
+    } finally {
+      clearTimeout(deadline);
+      if (hostPid) {
+        try {
+          process.kill(-hostPid, "SIGKILL");
+        } catch (error) {
+          assert.equal(error.code, "ESRCH");
+        }
+      }
+      runner.kill("SIGKILL");
+      await closed;
+      rmSync(root, { recursive: true, force: true });
+    }
+  },
+);

--- a/tools/run-node-tests.mjs
+++ b/tools/run-node-tests.mjs
@@ -223,6 +223,11 @@ const exitCode = await new Promise((resolveRun) => {
     console.error(error.message);
     finish(1);
   });
+  child.once("exit", () => {
+    if (watchdog !== null) clearInterval(watchdog);
+    // Descendants can keep the host's pipes open, so close cannot initiate cleanup.
+    if (process.platform !== "win32" && timedOutFiles.length === 0) termination = terminateProcessTree(child);
+  });
   child.once("close", (code, signal) => {
     if (signal !== null && timedOutFiles.length === 0) console.error(`node --test terminated by signal ${signal}`);
     finish(timedOutFiles.length > 0 || signal !== null ? 1 : (code ?? 1));
@@ -307,7 +312,7 @@ async function terminateProcessTree(child) {
     if (child.exitCode === null) child.kill("SIGKILL");
     return;
   }
-  signalProcessGroup(child.pid, "SIGTERM");
+  if (!signalProcessGroup(child.pid, "SIGTERM")) return;
   await new Promise((resolveDelay) => setTimeout(resolveDelay, PROCESS_TREE_KILL_GRACE_MS));
   signalProcessGroup(child.pid, "SIGKILL");
 }
@@ -315,8 +320,10 @@ async function terminateProcessTree(child) {
 function signalProcessGroup(pid, signal) {
   try {
     process.kill(-pid, signal);
+    return true;
   } catch (error) {
     if (error?.code !== "ESRCH") throw error;
+    return false;
   }
 }
 


### PR DESCRIPTION
# English

## Summary

`tools/run-node-tests.mjs` only started killing a runaway test process tree on the child's `close` event, but a descendant process that inherits the host's stdout/stderr pipes and keeps them open (e.g. after the host itself is killed) prevents `close` from ever firing, so the process group was never reaped. The fix moves process-tree termination to start on the earlier `exit` event instead, and makes `signalProcessGroup` report whether the target process group still existed so `terminateProcessTree` doesn't send a pointless follow-up `SIGKILL` after an `ESRCH`.

## Architectural Justification

-

## What Changed

- `tools/run-node-tests.mjs`: `child.once("exit", ...)` now clears the watchdog and starts `terminateProcessTree` (previously only wired to `close`); `signalProcessGroup` returns a boolean so `terminateProcessTree` skips the follow-up `SIGKILL` once the group is already gone.
- `tools/run-node-tests-process-group.test.mjs` (new): spawns a host process via a `child_process.spawn` interception that detaches an unref'd descendant holding the inherited stdio pipes, `SIGKILL`s the host, and asserts the runner still exits (not hangs) and that the whole process group is gone.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: +8/-1 production; tests +97/-0.

## Machine-Readable Declarations

- None.

## Task And Scope

- Harness task: task_01KY2BMY5FBDP5GXBXMJ8RTN6M (parent none)
- Branch: `codex/runner-process-group`
- Public scope: test-runner process cleanup only (`tools/run-node-tests.mjs`); no product/runtime code changed
- Private planning/evidence updated: yes (`artifacts/report.md`)
- Out of scope: Windows behavior and the scenario where the outer runner process itself is `SIGKILL`ed are both explicitly unverified (the new test is skipped on `win32`).

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: yes — `tools/run-node-tests.mjs` (shared test runner used by every gate lane)
- Protected surface scope: process-group cleanup now starts on host `exit` instead of `close`; test selection, tiers and exit codes are unchanged
- Authority: task task_01KY2BMY5FBDP5GXBXMJ8RTN6M (CEO-authorized fix in the perf/governance line, 2026-09-12); no gate is skipped, weakened, or retimed
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `554be6d94`
- Branch merge-base with `origin/main`: `554be6d94`
- Last `git fetch origin` time: 2026-09-12 UTC
- Sync method: branched from origin/main
- Public diff command: `git diff origin/main...codex/runner-process-group`
- Private evidence commit/path: task_01KY2BMY5FBDP5GXBXMJ8RTN6M `artifacts/report.md`
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [x] `npm run typecheck` (worker, `tsc -b`)
- [ ] `npm run check`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts` (via `run-manifest-gates --changed origin/main`)
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- macOS 25/25, Ubuntu 1/1 (the new process-group regression test); all required gates green. Pre-fix reproduction confirmed the runner hung waiting on inherited pipes after the host died.

## Review Evidence

- CEO ground-truth: read the worker report and the diff stat; commit authorship and scope checked.
- Reviewer subagent: closeout review after merge (one-path closeout)
- Human review: pending
- Blocking findings: none open

## Residual Risk

- This changes the test runner's own cleanup trigger (`exit` vs `close`), which every test invocation across the repo depends on; low functional risk since it only makes cleanup start earlier/more reliably, but worth a broad `check:local`-style smoke run by the CEO given how central this file is to every test run, rather than relying solely on the new targeted test.

## References

- Task: task_01KY2BMY5FBDP5GXBXMJ8RTN6M

---

# 中文

## 概要

`tools/run-node-tests.mjs` 只在子进程 `close` 事件上才开始清理失控的测试进程树，但如果某个子孙进程继承了宿主的 stdout/stderr 管道并一直持有它们（例如宿主本身被杀死之后），`close` 就永远不会触发，进程组也就永远不会被收割。修复把进程树终止的起点改到更早的 `exit` 事件；并让 `signalProcessGroup` 返回目标进程组是否仍然存在，这样 `terminateProcessTree` 就不会在收到 `ESRCH` 后还多发一次没意义的 `SIGKILL`。

## 架构辩护

-

## 改动内容

- `tools/run-node-tests.mjs`：`child.once("exit", ...)` 现在会清理 watchdog 并启动 `terminateProcessTree`（此前只挂在 `close` 上）；`signalProcessGroup` 返回布尔值，进程组已经消失时 `terminateProcessTree` 跳过多余的 `SIGKILL`。
- `tools/run-node-tests-process-group.test.mjs`（新增）：通过拦截 `child_process.spawn` 让宿主进程 fork 出一个持有继承 stdio 管道、已 unref 的子孙进程，然后 `SIGKILL` 宿主，断言 runner 仍会退出（而不是挂起）且整个进程组已消失。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 删除的门或 fixture：none
- 生产净行数：+8/-1 production; tests +97/-0。

## 机器可读声明

- 无。

## 任务与范围

- Harness 任务：task_01KY2BMY5FBDP5GXBXMJ8RTN6M（父 none）
- 分支：`codex/runner-process-group`
- 公开范围：仅测试运行器自身的进程清理逻辑（`tools/run-node-tests.mjs`）；未改动任何产品/运行时代码
- 私有计划/证据已更新：是（`artifacts/report.md`）
- 范围外：Windows 下的行为以及「外层 runner 进程本身被 SIGKILL」这一场景均明确 unverified（新测试在 `win32` 上跳过）。

## 版本影响

- 版本：不变
- 发布影响：不发布

## 治理声明

- 触碰受保护面：是——`tools/run-node-tests.mjs`（所有门车道共用的测试 runner）
- 受保护面范围：进程组清理改为在宿主 `exit` 而非 `close` 时启动；测试选择、tier 与退出码不变
- 授权：任务 task_01KY2BMY5FBDP5GXBXMJ8RTN6M（CEO 2026-09-12 在性能/治理线授权的修复）；没有跳过、削弱或调超时任何门
- 机器检查边界：本 PR 只断言声明存在；是否属实与充分由评审判断
- Break-glass：否
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- 基线 `origin/main` SHA：`554be6d94`
- 分支与 `origin/main` 的 merge-base：`554be6d94`
- 最近一次 `git fetch origin`：2026-09-12 UTC
- 同步方式：从 origin/main 开分支
- 公开 diff 命令：`git diff origin/main...codex/runner-process-group`
- 私有证据路径：task_01KY2BMY5FBDP5GXBXMJ8RTN6M 的 `artifacts/report.md`
- 评审证据路径：本 PR 的评审证据节
- GitHub Actions `rewrite-ci` run URL：本 PR 待跑
- macOS 25/25，Ubuntu 1/1（新增的进程组回归测试）；全部规定 gates 通过。修前复现确认宿主死亡后 runner 会挂起等待继承的管道。

## 评审证据

- CEO 事实核对：读过 worker 报告与 diff 统计；核过提交人与范围。
- 评审子代理：合入后走一条路收口评审
- 人工评审：待定
- 阻塞发现：无

## 残余风险

- 这改变了测试运行器自身的清理触发点（`exit` 而非 `close`），仓库里每一次测试调用都依赖这个文件；功能风险较低，因为只是让清理更早/更可靠地开始，但鉴于这个文件对每次测试运行都很核心，建议 CEO 做一次更广的 `check:local` 式冒烟跑，而不只依赖新增的这一个定向测试。

## 参考

- 任务：task_01KY2BMY5FBDP5GXBXMJ8RTN6M


