### PR TITLE
fix: derive local integration checks from changed paths

### DIFF
--- a/tools/run-local-check.mjs
+++ b/tools/run-local-check.mjs
@@ -16,7 +16,8 @@
  *     fall back to `nice -n 10`; if neither is available, run bare.
  *   - Tiers: default "fast" (fresh-main line-budget, typecheck, lint,
  *     test:fast, test:contract, boundaries checkers, package-policy, and rebuild contract gates).
- *     `--full` appends test:integration test:gui, and test:gui:e2e. First
+ *     Changed paths derive integration through G25; integration runs in isolation.
+ *     `--full` additionally forces integration, test:gui, and test:gui:e2e. First
  *     failing step stops the run with a non-zero exit and a clear report of
  *     which step failed.
  *
@@ -27,10 +28,14 @@
  */
 
 import { spawnSync } from "node:child_process";
-import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { availableParallelism } from "node:os";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
+
+import { git } from "./gates/git.mjs";
+import { selectTests } from "./gates/test-selection.mjs";
+import { parseTestTierMarker } from "./test-tier-manifest.mjs";
 
 const repoRoot = path.resolve(import.meta.dirname, "..");
 const LOCK_DIR = "/tmp/harness-local-check.lock";
@@ -124,8 +129,41 @@ export function parseLocalCheckArgs(args) {
   return options;
 }
 
-export function buildSteps(full) {
-  return full ? [...FAST_STEPS, ...FULL_EXTRA_STEPS] : [...FAST_STEPS];
+export function localChangedPaths(root = repoRoot) {
+  const base = git(root, ["merge-base", "origin/main", "HEAD"]).trim();
+  return [
+    ...new Set(
+      [
+        ...git(root, ["diff", "--name-only", "-z", base, "--"]).split("\0"),
+        ...git(root, ["ls-files", "--others", "--exclude-standard", "-z"]).split("\0"),
+      ].filter(Boolean),
+    ),
+  ];
+}
+
+export function buildSteps(
+  full,
+  changedPaths = [],
+  readSource = (file) => {
+    const absolute = path.join(repoRoot, file);
+    return existsSync(absolute) ? readFileSync(absolute, "utf8") : null;
+  },
+) {
+  if (full) return [...FAST_STEPS, ...FULL_EXTRA_STEPS];
+  const selection = selectTests(changedPaths, {
+    readTestTier(file) {
+      if (!/\.(?:test|spec)\.(?:mjs|js|ts|tsx)$/u.test(file)) return null;
+      const source = readSource(file);
+      return source === null ? null : parseTestTierMarker(source, file);
+    },
+  });
+  if (!selection.ok) throw new Error(selection.errors.join("\n"));
+  return [
+    ...FAST_STEPS,
+    ...FULL_EXTRA_STEPS.filter(
+      ([, script]) => script === "test:integration" && selection.required.includes("integration"),
+    ),
+  ];
 }
 
 /**
@@ -226,7 +264,12 @@ function sleep(ms) {
 }
 
 function runStep(label, scriptName, qosPrefix) {
-  const argv = [...qosPrefix, "npm", "run", scriptName];
+  const argv = [
+    ...qosPrefix,
+    ...(scriptName === "test:integration"
+      ? [process.execPath, "tools/dispatch-isolated-test.mjs", "--tier", "integration"]
+      : ["npm", "run", scriptName]),
+  ];
   const [command, ...rest] = argv;
   console.log(`\n▶ ${label}  (${argv.join(" ")})`);
   const started = Date.now();
@@ -264,6 +307,10 @@ async function main(argv) {
     hasNice: binaryExists("nice"),
   });
 
+  const steps = buildSteps(options.full, localChangedPaths());
+  const integrationSelected = steps.some(([, script]) => script === "test:integration");
+  const tierLabel = options.full ? "full" : integrationSelected ? "fast + integration" : "fast";
+
   let release;
   try {
     release = await acquireLock({ wait: options.wait, pollMs: options.pollMs });
@@ -276,11 +323,10 @@ async function main(argv) {
     throw error;
   }
 
-  const steps = buildSteps(options.full);
   const cores = availableParallelism();
   const qosLabel = qosPrefix.length ? qosPrefix.join(" ") : "none";
   console.log(
-    `Local check (${options.full ? "full" : "fast"} tier): ${steps.length} steps, ` +
+    `Local check (${tierLabel} tier): ${steps.length} steps, ` +
       `QoS wrapper: ${qosLabel}, cores: ${cores}. ` +
       `Cloud CI enforces the required checks on pull requests.`,
   );
@@ -300,10 +346,10 @@ async function main(argv) {
   }
 
   const totalS = ((Date.now() - totalStart) / 1000).toFixed(1);
-  console.log(`\nLocal check passed (${options.full ? "full" : "fast"} tier) in ${totalS}s.`);
+  console.log(`\nLocal check passed (${tierLabel} tier) in ${totalS}s.`);
   if (!options.full) {
     console.log(
-      "Note: this tier did not run test:integration or test:gui. Cloud CI runs the integration shards on every " +
+      `Note: integration ${integrationSelected ? "ran in isolation" : "was not selected by changed paths"}; GUI tests did not run. Cloud CI runs integration on every ` +
         "pull request; the GUI job runs only when the pull request touches packages/gui or the root " +
         "package/tsconfig manifests. Run `npm run check:local -- --full` to cover both here.",
     );

--- a/tools/run-local-check.test.mjs
+++ b/tools/run-local-check.test.mjs
@@ -1,8 +1,17 @@
 // harness-test-tier: fast
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import test from "node:test";
-import { buildSteps, parseLocalCheckArgs, excludedBoundaryGateIds, selectQosPrefix } from "./run-local-check.mjs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { execFileSync } from "node:child_process";
+import {
+  buildSteps,
+  localChangedPaths,
+  parseLocalCheckArgs,
+  excludedBoundaryGateIds,
+  selectQosPrefix,
+} from "./run-local-check.mjs";
 
 test("parseLocalCheckArgs defaults to the waiting fast tier", () => {
   assert.deepEqual(parseLocalCheckArgs([]), { full: false, wait: true, pollMs: 2000 });
@@ -20,7 +29,7 @@ test("parseLocalCheckArgs rejects unknown options", () => {
   assert.throws(() => parseLocalCheckArgs(["--bogus"]), /unknown run-local-check option/u);
 });
 
-test("buildSteps appends integration and gui lanes only in the full tier", () => {
+test("buildSteps keeps unchanged work fast and forces all extra lanes with full", () => {
   const fastScripts = buildSteps(false).map(([, script]) => script);
   const fullScripts = buildSteps(true).map(([, script]) => script);
 
@@ -85,4 +94,57 @@ test("selectQosPrefix falls back to nice off darwin or without taskpolicy", () =
 
 test("selectQosPrefix runs bare when no QoS tool is available", () => {
   assert.deepEqual(selectQosPrefix({ platform: "linux", hasTaskpolicy: false, hasNice: false }), []);
+});
+
+for (const file of [
+  "packages/cli/src/index.ts",
+  "packages/kernel/src/store/task-store.ts",
+  "packages/daemon/src/runtime.ts",
+]) {
+  test(`default local steps include integration for ${file}`, () => {
+    assert.ok(buildSteps(false, [file]).some(([, script]) => script === "test:integration"));
+  });
+}
+
+test("changed test selection reads its marker, regardless of its filename", () => {
+  const file = "tools/custom.test.mjs";
+  const readSource = () => "// harness-test-tier: integration\n";
+  assert.ok(buildSteps(false, [file], readSource).some(([, script]) => script === "test:integration"));
+  assert.ok(!buildSteps(false, [file], () => "// harness-test-tier: fast\n").some(([, s]) => s === "test:integration"));
+  assert.equal(buildSteps(true, [file], readSource).filter(([, s]) => s === "test:integration").length, 1);
+  assert.ok(!buildSteps(false, ["README.md"]).some(([, s]) => s === "test:integration"));
+});
+
+test("local changed paths include committed, staged, unstaged, deleted and untracked files", (t) => {
+  const root = mkdtempSync(path.join(tmpdir(), "local-changes-"));
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  const git = (...args) => execFileSync("git", args, { cwd: root, encoding: "utf8", stdio: "pipe" });
+  const write = (file, text) => writeFileSync(path.join(root, file), text);
+  git("init");
+  git("config", "user.name", "Test");
+  git("config", "user.email", "test@example.com");
+  for (const file of ["committed", "staged", "unstaged", "deleted"]) write(file, "base");
+  git("add", ".");
+  git("commit", "-m", "test: base");
+  git("update-ref", "refs/remotes/origin/main", "HEAD");
+  write("committed", "changed");
+  git("add", "committed");
+  git("commit", "-m", "test: branch change");
+  write("staged", "changed");
+  git("add", "staged");
+  write("unstaged", "changed");
+  rmSync(path.join(root, "deleted"));
+  write("untracked", "changed");
+  assert.deepEqual(localChangedPaths(root).sort(), ["committed", "deleted", "staged", "unstaged", "untracked"]);
+});
+
+test("deleted tests select integration and malformed markers cannot silently omit it", () => {
+  assert.ok(buildSteps(false, ["tools/deleted.test.mjs"], () => null).some(([, s]) => s === "test:integration"));
+  assert.throws(() => buildSteps(false, ["tools/broken.test.mjs"], () => ""), /test tier marker missing/u);
+});
+
+test("test helpers and data fixtures select all tiers without requiring test markers", () => {
+  for (const file of ["packages/cli/test/helpers.ts", "packages/kernel/test/fixtures/input.json"]) {
+    assert.ok(buildSteps(false, [file], () => "{}").some(([, s]) => s === "test:integration"));
+  }
 });


### PR DESCRIPTION
# English

## Summary

`npm run check:local`'s default (fast) tier always skipped `test:integration` and printed a blanket "integration did not run" note, even when the changed files actually required integration coverage per the existing G25 change-based test-selection gate — so a worker relying on the default local check could stop with fast-tier-only evidence on a change that needed integration. The fix makes the default tier compute `git diff`/untracked changed paths, run them through the existing `selectTests`/`parseTestTierMarker` machinery (G25), and — if integration is required — run it through the mandatory isolated dispatcher (`tools/dispatch-isolated-test.mjs --tier integration`) rather than bare `npm run test:integration`; the summary line now says whether integration ran or was legitimately not selected.

## Architectural Justification

-

## What Changed

- `tools/run-local-check.mjs`: new `localChangedPaths()` (merge-base diff + untracked files); `buildSteps()` now takes changed paths and a source reader, derives required tiers via `selectTests`/`parseTestTierMarker`, and adds `test:integration` to the fast tier when required; `runStep()` routes `test:integration` through the isolated dispatcher instead of `npm run test:integration`; summary/note text reports the actual selected tier.
- `tools/run-local-check.test.mjs`: rewrote the fast/full-tier test, added coverage for per-path tier selection, marker-driven selection independent of filename, deleted/malformed-marker handling, non-test fixture files always selecting all tiers, and a real temporary git repo exercising `localChangedPaths()` across committed/staged/unstaged/deleted/untracked files.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: +55/-9 production; tests +65/-3.

## Machine-Readable Declarations

- None.

## Task And Scope

- Harness task: task_01KZK47QSWARNN5WG8XG443TY0 (parent task_01KZGA4PPBB46DE75FY7NSXS20)
- Branch: `codex/stop-point-tier`
- Public scope: local developer check-runner (`tools/run-local-check.mjs`) only; does not change the CI workflow files or the manifest-gate definitions it reuses
- Private planning/evidence updated: yes (`artifacts/report.md`)
- Out of scope: Full remote-CI parity and dispatching a real full integration suite end-to-end through this path were not run in this session (report calls that unverified); only targeted/local execution was performed.

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: not applicable
- Machine-check boundary: not applicable
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `554be6d94`
- Branch merge-base with `origin/main`: `554be6d94`
- Last `git fetch origin` time: 2026-09-12 UTC
- Sync method: branched from origin/main
- Public diff command: `git diff origin/main...codex/stop-point-tier`
- Private evidence commit/path: task_01KZK47QSWARNN5WG8XG443TY0 `artifacts/report.md`
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [x] `npm run typecheck` (worker, `tsc -b`)
- [ ] `npm run check`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts` (via `run-manifest-gates --changed origin/main`)
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- 15/15 tests green, run locally (macOS, fast tier) via the repo's own runner — this branch modifies the local check runner itself, so its regression tests are not isolated/Ubuntu-dispatched. Red reproduction: 8/12 passing before the fix. Targeted eslint, line-density, and the changed-path manifest gate (584 discovered test files) all passed.

## Review Evidence

- CEO ground-truth: read the worker report and the diff stat; commit authorship and scope checked.
- Reviewer subagent: closeout review after merge (one-path closeout)
- Human review: pending
- Blocking findings: none open

## Residual Risk

- This is developer tooling (not a CI workflow or `tools/check-*.mjs` gate file) but it changes what a worker's default local check actually exercises before declaring a stop point — worth the CEO spot-checking one real changed-file scenario end-to-end (does it actually invoke the isolated dispatcher and not just claim to) before treating this as the new default.

## References

- Task: task_01KZK47QSWARNN5WG8XG443TY0

---

# 中文

## 概要

`npm run check:local` 的默认（fast）档位一直无条件跳过 `test:integration`，并打印一句笼统的「未跑 integration」提示，即便改动的文件按现有的 G25 改动面测试选择门实际上需要 integration 覆盖——于是依赖默认本地检查的 worker 可能在明明需要 integration 的改动上，只凭 fast 档证据就停手。修复让默认档位先算出 `git diff`/未跟踪的改动路径，过一遍现有的 `selectTests`/`parseTestTierMarker` 机制（G25），如果需要 integration，就走强制的隔离派发器（`tools/dispatch-isolated-test.mjs --tier integration`）而不是裸 `npm run test:integration`；摘要行现在会明说 integration 到底跑了还是合理地未被选中。

## 架构辩护

-

## 改动内容

- `tools/run-local-check.mjs`：新增 `localChangedPaths()`（merge-base diff + 未跟踪文件）；`buildSteps()` 现在接收改动路径和一个源码读取器，经 `selectTests`/`parseTestTierMarker` 推导所需档位，需要时把 `test:integration` 加进 fast 档；`runStep()` 把 `test:integration` 路由到隔离派发器而不是 `npm run test:integration`；摘要/提示文本改为报告实际选中的档位。
- `tools/run-local-check.test.mjs`：重写 fast/full 档测试，新增按路径选档、按标记选档（与文件名无关）、删除/畸形标记处理、非测试 fixture 文件总是选中全部档位的覆盖，以及一个真实临时 git 仓库测试 `localChangedPaths()` 在已提交/暂存/未暂存/已删除/未跟踪文件下的表现。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 删除的门或 fixture：none
- 生产净行数：+55/-9 production; tests +65/-3。

## 机器可读声明

- 无。

## 任务与范围

- Harness 任务：task_01KZK47QSWARNN5WG8XG443TY0（父 task_01KZGA4PPBB46DE75FY7NSXS20）
- 分支：`codex/stop-point-tier`
- 公开范围：仅本地开发者检查运行器（`tools/run-local-check.mjs`）；未改动 CI workflow 文件，也未改动它复用的 manifest-gate 定义本身
- 私有计划/证据已更新：是（`artifacts/report.md`）
- 范围外：本次未跑完整远端 CI 对等验证，也没有真的端到端跑通一整套 integration 套件走这条新路径（报告标为 unverified）；只做了定向/本地执行。

## 版本影响

- 版本：不变
- 发布影响：不发布

## 治理声明

- 触碰受保护面：否
- 受保护面范围：不适用
- 授权：不适用
- 机器检查边界：不适用
- Break-glass：否
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- 基线 `origin/main` SHA：`554be6d94`
- 分支与 `origin/main` 的 merge-base：`554be6d94`
- 最近一次 `git fetch origin`：2026-09-12 UTC
- 同步方式：从 origin/main 开分支
- 公开 diff 命令：`git diff origin/main...codex/stop-point-tier`
- 私有证据路径：task_01KZK47QSWARNN5WG8XG443TY0 的 `artifacts/report.md`
- 评审证据路径：本 PR 的评审证据节
- GitHub Actions `rewrite-ci` run URL：本 PR 待跑
- 15/15 测试通过，本地（macOS，fast 档）经仓库自身运行器跑——本分支改动的正是本地检查运行器自身，因此其回归测试不走隔离/Ubuntu 派发。红测复现：修前 12 项中 8 项通过。定向 eslint、line-density、改动面 manifest gate（584 份发现的测试文件）均通过。

## 评审证据

- CEO 事实核对：读过 worker 报告与 diff 统计；核过提交人与范围。
- 评审子代理：合入后走一条路收口评审
- 人工评审：待定
- 阻塞发现：无

## 残余风险

- 这是开发者工具（不是 CI workflow 或 `tools/check-*.mjs` 门文件），但它改变了 worker 在宣布停止点之前默认本地检查实际执行的内容——建议 CEO 在把它当作新默认行为之前，端到端抽查一个真实改动文件场景（确认它真的调用了隔离派发器，而不只是嘴上说说）。

## 参考

- 任务：task_01KZK47QSWARNN5WG8XG443TY0

