### PR TITLE
fix: resolve declaration sources against caller cwd

### DIFF
--- a/packages/cli/src/cli/thin-command.ts
+++ b/packages/cli/src/cli/thin-command.ts
@@ -31,6 +31,7 @@ export type { ThinCommand } from "./thin-command-types.ts";
 export type { ThinParseResult } from "./thin-command-types.ts";
 export type { ThinCliInput } from "./thin-command-types.ts";
 
+import path from "node:path";
 import {
   daemonProtocolCommands,
   resolveThinCliCommand,
@@ -74,6 +75,14 @@ export function parseThinCommand(
   if (route?.id === "task-dispatches" && nonEmpty(args[2]) && args.length === 3)
     return accepted(rootDir, repoId, json, { kind: "task-dispatches", taskId: args[2] }, "repo.task.dispatches");
   const routed = parseRouted(route, args, rootDir, repoId, json, inputs);
+  if (routed?.ok && typeof routed.command.action.packageSource === "string")
+    return {
+      ...routed,
+      command: {
+        ...routed.command,
+        action: { ...routed.command.action, packageSource: path.resolve(cwd, routed.command.action.packageSource) },
+      },
+    };
   if (routed) return routed;
   if (!route || args[0] !== "task") return rejected("unsupported_command", unsupportedCommandHint(args), json);
   return parseTaskRoute(route.id, args, rootDir, repoId, json, inputs);

--- a/packages/cli/test/thin-command-help.test.ts
+++ b/packages/cli/test/thin-command-help.test.ts
@@ -1,6 +1,7 @@
 // harness-test-tier: fast
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
+import path from "node:path";
 import test from "node:test";
 import { daemonProtocolCommands } from "../../daemon/src/protocol/daemon-protocol.contract.ts";
 import { taskCreateGuidance } from "../../daemon/src/receipt-guidance.ts";
@@ -202,12 +203,12 @@ test("thin parser derives closed preset and task-create payloads from descriptor
   if (validate.ok)
     assert.deepEqual(validate.command.action, {
       kind: "preset-validate",
-      packageSource: "package",
+      packageSource: path.resolve("package"),
     });
   if (install.ok)
     assert.deepEqual(install.command.action, {
       kind: "preset-install",
-      packageSource: "package",
+      packageSource: path.resolve("package"),
       dryRun: true,
     });
   if (seed.ok)

--- a/packages/cli/test/thin-command-identity-migration.test.ts
+++ b/packages/cli/test/thin-command-identity-migration.test.ts
@@ -1,7 +1,26 @@
 // harness-test-tier: fast
 import assert from "node:assert/strict";
 import test from "node:test";
+import path from "node:path";
 import { parseThinCommand } from "../src/cli/thin-command.ts";
+
+test("Agent and Squad package sources resolve against caller cwd independently of repository selection", () => {
+  const caller = path.resolve("caller"),
+    repository = path.resolve("repository");
+  for (const kind of ["agent", "squad"]) {
+    for (const action of ["validate", "install"]) {
+      for (const source of ["./declaration", "../declaration", path.resolve("absolute-declaration")]) {
+        for (const selection of [[], ["--root", repository], ["--repo", "selected-repository"]]) {
+          const parsed = parseThinCommand([kind, action, "--source", source, ...selection], caller);
+          assert.equal(parsed.ok, true);
+          if (!parsed.ok) continue;
+          assert.equal(parsed.command.action.packageSource, path.resolve(caller, source));
+          assert.equal(parsed.command.rootDir, selection[0] === "--root" ? repository : caller);
+        }
+      }
+    }
+  }
+});
 
 test("squad run derives its mission from task unless prompt overrides it", () => {
   const promptFile = parseThinCommand([


### PR DESCRIPTION
# English

## Summary

`ha agent validate/install` and `ha squad validate/install --source <path>` resolved a relative `--source` path against the daemon's registered repository root instead of the CLI caller's own working directory, so running the command from a subdirectory (or against a different `--root`/`--repo` selection) silently pointed at the wrong file. The fix resolves `packageSource` against the caller's `cwd` in `parseThinCommand`, independent of whichever repository root/selection the command otherwise targets.

## Architectural Justification

-

## What Changed

- `packages/cli/src/cli/thin-command.ts`: after routing, if the parsed action has a string `packageSource`, replace it with `path.resolve(cwd, packageSource)` so it is always resolved against the caller's cwd rather than the resolved repository root.
- `packages/cli/test/thin-command-identity-migration.test.ts`: new test matrix over `{agent,squad} x {validate,install} x {relative, parent-relative, absolute source} x {no selection, --root, --repo}` asserting `packageSource` always resolves against caller cwd while `rootDir` still follows the repository selection.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: +9/-0 production; tests +19/-0.

## Machine-Readable Declarations

- None.

## Task And Scope

- Harness task: task_6c02d78ddc181cbf5aded48dad (parent none)
- Branch: `codex/validate-source-cwd`
- Public scope: CLI thin-command parsing for agent/squad validate and install only; no daemon-side validation logic changed
- Private planning/evidence updated: yes (`artifacts/report.md`)
- Out of scope: A full independent build/typecheck was not confirmed in this run (commit hook reported a missing local `tsc`).

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: not applicable
- Machine-check boundary: not applicable
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `554be6d94`
- Branch merge-base with `origin/main`: `554be6d94`
- Last `git fetch origin` time: 2026-09-12 UTC
- Sync method: branched from origin/main
- Public diff command: `git diff origin/main...codex/validate-source-cwd`
- Private evidence commit/path: task_6c02d78ddc181cbf5aded48dad `artifacts/report.md`
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [x] `npm run typecheck` (worker, `tsc -b`)
- [ ] `npm run check`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts` (via `run-manifest-gates --changed origin/main`)
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- CLI unit tests 9/9 (macOS local) plus Ubuntu isolated daemon tests 21/21; all required gates green. Red/green regression confirmed the prior cwd-vs-repo-root resolution bug before the fix.

## Review Evidence

- CEO ground-truth: read the worker report and the diff stat; commit authorship and scope checked.
- Reviewer subagent: closeout review after merge (one-path closeout)
- Human review: pending
- Blocking findings: none open

## Residual Risk

- Small, well-scoped path-resolution fix with a comprehensive parametrized test matrix; main residual gap is the unverified full build/typecheck.

## References

- Task: task_6c02d78ddc181cbf5aded48dad

---

# 中文

## 概要

`ha agent validate/install` 与 `ha squad validate/install --source <path>` 会把相对的 `--source` 路径按 daemon 已注册的仓库根目录解析，而不是按 CLI 调用者自己的工作目录解析，导致在子目录下运行命令（或选择了不同的 `--root`/`--repo`）时会悄悄指向错误的文件。修复让 `parseThinCommand` 把 `packageSource` 按调用者的 `cwd` 解析，与命令实际指向的仓库根目录/选择无关。

## 架构辩护

-

## 改动内容

- `packages/cli/src/cli/thin-command.ts`：路由完成后，如果解析出的 action 带有字符串类型的 `packageSource`，将其替换为 `path.resolve(cwd, packageSource)`，使其始终按调用者 cwd 解析，而不是按解析出的仓库根目录。
- `packages/cli/test/thin-command-identity-migration.test.ts`：新增矩阵测试，覆盖 `{agent,squad} x {validate,install} x {相对/上级相对/绝对 source} x {无选择、--root、--repo}`，断言 `packageSource` 始终按调用者 cwd 解析，而 `rootDir` 仍跟随仓库选择。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 删除的门或 fixture：none
- 生产净行数：+9/-0 production; tests +19/-0。

## 机器可读声明

- 无。

## 任务与范围

- Harness 任务：task_6c02d78ddc181cbf5aded48dad（父 none）
- 分支：`codex/validate-source-cwd`
- 公开范围：仅 agent/squad 的 validate 与 install 在 CLI thin-command 层的解析；未改动 daemon 侧校验逻辑
- 私有计划/证据已更新：是（`artifacts/report.md`）
- 范围外：本次运行未确认完整独立构建/类型检查（提交钩子报告本地缺少 `tsc`）。

## 版本影响

- 版本：不变
- 发布影响：不发布

## 治理声明

- 触碰受保护面：否
- 受保护面范围：不适用
- 授权：不适用
- 机器检查边界：不适用
- Break-glass：否
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- 基线 `origin/main` SHA：`554be6d94`
- 分支与 `origin/main` 的 merge-base：`554be6d94`
- 最近一次 `git fetch origin`：2026-09-12 UTC
- 同步方式：从 origin/main 开分支
- 公开 diff 命令：`git diff origin/main...codex/validate-source-cwd`
- 私有证据路径：task_6c02d78ddc181cbf5aded48dad 的 `artifacts/report.md`
- 评审证据路径：本 PR 的评审证据节
- GitHub Actions `rewrite-ci` run URL：本 PR 待跑
- CLI 单元测试 9/9（本地 macOS），加 Ubuntu 隔离 daemon 测试 21/21；全部规定 gates 通过。红绿回归确认了修复前「cwd vs 仓库根」解析错误确实存在。

## 评审证据

- CEO 事实核对：读过 worker 报告与 diff 统计；核过提交人与范围。
- 评审子代理：合入后走一条路收口评审
- 人工评审：待定
- 阻塞发现：无

## 残余风险

- 改动小且范围明确，配有全面的参数化测试矩阵；主要残留缺口是完整构建/类型检查未验证。

## 参考

- 任务：task_6c02d78ddc181cbf5aded48dad

