### PR TITLE
fix: guide agent and squad installation after init

### DIFF
--- a/packages/cli/test/daemon-multi-repo-lifecycle-cli-init-bootstrap.test.ts
+++ b/packages/cli/test/daemon-multi-repo-lifecycle-cli-init-bootstrap.test.ts
@@ -67,6 +67,11 @@ test("REQ-CTX-01..10 empty init publishes the canonical scaffold, authority pari
     assert.deepEqual(initialized.updated, []);
     assert.deepEqual(initialized.preserved, []);
     assert.deepEqual(initialized.drifted, []);
+    for (const kind of ["agent", "squad"]) {
+      const catalog = JSON.parse(String(run(fixture.repo, fixture.userRoot, [kind, "list"]).evidence));
+      assert.deepEqual(catalog[`${kind}s`], []);
+      assert.match(String(initialized.next), new RegExp(`${kind} install --source`));
+    }
     const plan = initialized.plan as {
       digest: string;
       baseScaffoldDigest: string;
@@ -258,6 +263,8 @@ test("REQ-CTX-01..10 empty init publishes the canonical scaffold, authority pari
       /drifted: \[\]\ncommit: none\nnext: ha daemon repo register --repo-id fresh --root/u,
     );
     assert.match(textReceipt.stdout, /daemon status/u);
+    assert.match(textReceipt.stdout, /agent install --source/u);
+    assert.match(textReceipt.stdout, /squad install --source/u);
     assert.equal(
       run(fixture.repo, fixture.userRoot, ["task", "create", "--id", "task-first", "--admin", "--title", "First task"])
         .outcome,

--- a/packages/daemon/src/repo-bootstrap.ts
+++ b/packages/daemon/src/repo-bootstrap.ts
@@ -499,7 +499,13 @@ function jsonStringEnd(body: string, start: number): number {
   throw repoBootstrapError("invalid_package_json", "package.json string is incomplete.");
 }
 function initNext(rootDir: string, repoId: string, orphaned: boolean, maintenanceDegraded: string | null): string {
-  return `ha daemon repo register --repo-id ${repoId} --root ${JSON.stringify(rootDir)}; ha --root ${JSON.stringify(rootDir)} daemon status${orphaned ? " # Resolve orphaned scaffold documents through an explicit governance task; init will not delete or migrate them." : ""}${maintenanceDegraded ? ` # ${maintenanceDegraded}` : ""}`;
+  return [
+    `ha daemon repo register --repo-id ${repoId} --root ${JSON.stringify(rootDir)}; ha --root ${JSON.stringify(rootDir)} daemon status${orphaned ? " # Resolve orphaned scaffold documents through an explicit governance task; init will not delete or migrate them." : ""}${maintenanceDegraded ? ` # ${maintenanceDegraded}` : ""}`,
+    "Init does not install agents or squads. To populate an empty catalog:",
+    "Install Agent packages first, then a Squad package referencing those agents.",
+    `ha --root ${JSON.stringify(rootDir)} agent install --source <directory-containing-agent.json>`,
+    `ha --root ${JSON.stringify(rootDir)} squad install --source <directory-containing-squad.json>`,
+  ].join("\n");
 }
 function withTopLevelName(body: string, name: string): string {
   const match = /^name:[ \t]*(.*?)[ \t]*(\r?)$/mu.exec(body);


### PR DESCRIPTION
# English

## Summary

After `ha daemon repo register`/`init`, a freshly bootstrapped repository has an empty Agent and Squad catalog, but `init`'s `next` guidance only suggested `daemon status` — leaving a new operator with no roster and no hint that Agent packages must be installed before Squad packages (Squad definitions reference Agents). The fix appends explicit `agent install --source <...>` / `squad install --source <...>` guidance lines, in that order, to the bootstrap receipt's `next` field.

## Architectural Justification

-

## What Changed

- `packages/daemon/src/repo-bootstrap.ts`: `initNext()` now appends two guidance lines ("Install Agent packages first, then a Squad package referencing those agents", followed by the two install commands) after the existing register/status guidance.
- `packages/cli/test/daemon-multi-repo-lifecycle-cli-init-bootstrap.test.ts`: asserts both the JSON `next` field and the text receipt mention `agent install --source` and `squad install --source`, and that a fresh init's `agent list`/`squad list` catalogs are empty.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: +7/-1 production; tests +7/-0.

## Machine-Readable Declarations

- None.

## Task And Scope

- Harness task: task_5a83184e37cd8b9652be101804 (parent task_5b051225f10ebe9505e73e5b43)
- Branch: `codex/init-empty-catalog`
- Public scope: daemon repo-bootstrap `next` guidance text only; no change to what init actually creates
- Private planning/evidence updated: yes (`artifacts/report.md`)
- Out of scope: Full CI and independent typecheck were not run in this session (commit hook reported a missing local `tsc`); this is purely an onboarding-message change and does not alter catalog state itself.

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: not applicable
- Machine-check boundary: not applicable
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `554be6d94`
- Branch merge-base with `origin/main`: `554be6d94`
- Last `git fetch origin` time: 2026-09-12 UTC
- Sync method: branched from origin/main
- Public diff command: `git diff origin/main...codex/init-empty-catalog`
- Private evidence commit/path: task_5a83184e37cd8b9652be101804 `artifacts/report.md`
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [x] `npm run typecheck` (worker, `tsc -b`)
- [ ] `npm run check`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts` (via `run-manifest-gates --changed origin/main`)
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Ubuntu isolated test 5/5; ESLint, line-density, and six manifest gates all green.

## Review Evidence

- CEO ground-truth: read the worker report and the diff stat; commit authorship and scope checked.
- Reviewer subagent: closeout review after merge (one-path closeout)
- Human review: pending
- Blocking findings: none open

## Residual Risk

- Very low risk — additive guidance text appended to an existing `next` field, no change to command parsing or catalog behavior.

## References

- Task: task_5a83184e37cd8b9652be101804

---

# 中文

## 概要

`ha daemon repo register`/`init` 之后，新引导的仓库 Agent 和 Squad 目录都是空的，但 `init` 的 `next` 引导只建议了 `daemon status`——新操作者既没有花名册，也不知道必须先装 Agent 包再装 Squad 包（Squad 定义引用 Agent）。修复在 bootstrap 回执的 `next` 字段里追加明确的 `agent install --source <...>` / `squad install --source <...>` 引导行，并保证先 Agent 后 Squad 的顺序。

## 架构辩护

-

## 改动内容

- `packages/daemon/src/repo-bootstrap.ts`：`initNext()` 现在在已有的 register/status 引导之后，追加两行引导（「先装 Agent 包，再装引用这些 Agent 的 Squad 包」，紧跟两条安装命令）。
- `packages/cli/test/daemon-multi-repo-lifecycle-cli-init-bootstrap.test.ts`：断言 JSON 的 `next` 字段与文本回执都提到 `agent install --source` 与 `squad install --source`，且新 init 后 `agent list`/`squad list` 目录为空。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 删除的门或 fixture：none
- 生产净行数：+7/-1 production; tests +7/-0。

## 机器可读声明

- 无。

## 任务与范围

- Harness 任务：task_5a83184e37cd8b9652be101804（父 task_5b051225f10ebe9505e73e5b43）
- 分支：`codex/init-empty-catalog`
- 公开范围：仅 daemon repo-bootstrap 的 `next` 引导文本；不改变 init 实际创建的内容
- 私有计划/证据已更新：是（`artifacts/report.md`）
- 范围外：本次未跑完整 CI 与独立类型检查（提交钩子报告本地缺少 `tsc`）；这纯粹是一条引导文案改动，不改变目录本身的状态。

## 版本影响

- 版本：不变
- 发布影响：不发布

## 治理声明

- 触碰受保护面：否
- 受保护面范围：不适用
- 授权：不适用
- 机器检查边界：不适用
- Break-glass：否
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- 基线 `origin/main` SHA：`554be6d94`
- 分支与 `origin/main` 的 merge-base：`554be6d94`
- 最近一次 `git fetch origin`：2026-09-12 UTC
- 同步方式：从 origin/main 开分支
- 公开 diff 命令：`git diff origin/main...codex/init-empty-catalog`
- 私有证据路径：task_5a83184e37cd8b9652be101804 的 `artifacts/report.md`
- 评审证据路径：本 PR 的评审证据节
- GitHub Actions `rewrite-ci` run URL：本 PR 待跑
- Ubuntu 隔离测试 5/5；ESLint、line-density、六项 manifest gates 全绿。

## 评审证据

- CEO 事实核对：读过 worker 报告与 diff 统计；核过提交人与范围。
- 评审子代理：合入后走一条路收口评审
- 人工评审：待定
- 阻塞发现：无

## 残余风险

- 风险很低——只是在已有的 `next` 字段上追加引导文本，不改变命令解析或目录行为。

## 参考

- 任务：task_5a83184e37cd8b9652be101804

