### PR TITLE
fix: reject evidence relations from non-claim decision anchors

### DIFF
--- a/packages/daemon/src/entity-action-relation.ts
+++ b/packages/daemon/src/entity-action-relation.ts
@@ -1,6 +1,7 @@
 import {
   deriveRelationId,
   isRelationEvent,
+  parseEntityRef,
   relationEventWritePlan,
   relationStrengthForType,
   type AuthorizationDecision,
@@ -57,6 +58,19 @@ export function executeRelationAction(input: {
   if (action.kind === "relation-relate") {
     if (source?.currentVersion === null) reject("entity_not_found", `Relation source ${sourceRef} does not exist.`);
     if (target?.currentVersion === null) reject("entity_not_found", `Relation target ${targetRef} does not exist.`);
+    if (!replay && action.relationType === "evidenced-by") {
+      const ref = parseEntityRef(sourceRef!),
+        claims = ref?.kind === "decision" ? input.projection.readDecision(ref.id).decision?.claims : undefined;
+      if (claims && !claims.some((claim) => claim.id === ref?.anchor))
+        reject(
+          "relation_source_anchor_invalid",
+          `evidenced-by requires a declared claim source; ${sourceRef} is not a claim. ` +
+            `Use --source-ref ${
+              claims.map((claim) => `decision/${ref!.id}/${claim.id}`).join(" or ") ||
+              `decision/${ref!.id}/<claim-id> (declare a claim first)`
+            }.`,
+        );
+    }
   }
   const draft = replay
       ? null

--- a/packages/daemon/test/decision-surface.test.ts
+++ b/packages/daemon/test/decision-surface.test.ts
@@ -434,6 +434,76 @@ test("decision transition accepts repeated matching proposal fulfillments and dr
   }
 });
 
+test("Evidence relations reject non-claim sources before writing and identify the missing accept edge", async () => {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-decision-evidence-anchor-"));
+  initRepo(rootDir);
+  const repoId = workspaceId("decision-evidence-anchor"),
+    cell = await openRepoCell({ repoId, rootDir: canonicalRoot(rootDir), ownerId: "evidence-anchor-test" });
+  try {
+    const proposed = await cell.run(
+      {
+        ...proposal("Evidence anchor admission"),
+        body: "# Evidence admission\n\nMeasured observations justify the selected approach.",
+      },
+      proposer,
+    );
+    assert.equal(proposed.outcome, "applied", JSON.stringify(proposed));
+    const decisionId = receiptJson(proposed).decisionId as string;
+    const fact = await cell.run(
+      {
+        kind: "fact-record",
+        factId: "F-12345678",
+        statement: "Observed evidence",
+        evidenceSource: "test:evidence-anchor",
+        confidence: "high",
+        memoryClass: "semantic",
+      },
+      proposer,
+    );
+    assert.equal(fact.outcome, "applied", JSON.stringify(fact));
+    const before = makeTaskEventReader({ repoId, rootDir }).readHead()?.revision;
+    for (const anchor of ["CH1", "RJ1", ""]) {
+      const related = await cell.run(
+        {
+          kind: "relation-relate",
+          sourceRef: `decision/${decisionId}${anchor ? `/${anchor}` : ""}`,
+          targetRef: "fact/F-12345678",
+          relationType: "evidenced-by",
+          rationale: "Evidence must originate at a declared claim.",
+          expectedVersion: 0,
+        },
+        proposer,
+      );
+      assert.equal(related.outcome, "op_rejected", JSON.stringify(related));
+      assert.equal(related.code, "relation_source_anchor_invalid", JSON.stringify(related));
+      assert.match(JSON.stringify(related), /C1/);
+      assert.equal(makeTaskEventReader({ repoId, rootDir }).readHead()?.revision, before);
+    }
+    const accepted = await cell.run(
+      { kind: "decision-accept", decisionId, rationale: "Attempt without evidence", judgmentOnlyRationale: null },
+      arbiter,
+    );
+    assert.equal(accepted.code, "invalid_transition", JSON.stringify(accepted));
+    assert.match(JSON.stringify(accepted), /evidenced-by/);
+    assert.match(JSON.stringify(accepted), new RegExp(`decision/${decisionId}/C1`));
+    const related = await cell.run(
+      {
+        kind: "relation-relate",
+        sourceRef: `decision/${decisionId}/C1`,
+        targetRef: "fact/F-12345678",
+        relationType: "evidenced-by",
+        rationale: "Measured claim evidence.",
+        expectedVersion: 0,
+      },
+      proposer,
+    );
+    assert.equal(related.outcome, "applied", JSON.stringify(related));
+  } finally {
+    await cell.close();
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});
+
 function proposal(title: string) {
   return {
     kind: "decision-propose",

--- a/packages/kernel/src/domain/decision-event-document.ts
+++ b/packages/kernel/src/domain/decision-event-document.ts
@@ -456,7 +456,9 @@ function assertDecisionEvidenceFloor(
   if (!evidence)
     invalidDecision(
       "decision accept has two valid routes: (1) run ha decision claim fulfill <id> --id <claim-id> " +
-        "--mode evidenced and add an active claim-to-evidence relation; or (2) retry with " +
+        "--mode evidenced and add an active claim-to-evidence relation " +
+        `(for example ${[...claims].join(" or ") || `decision/${event.decisionId}/<claim-id>`} ` +
+        "--evidenced-by--> fact/<fact-id>; chosen CH anchors do not count); or (2) retry with " +
         "--judgment-only <rationale>.",
     );
 }


### PR DESCRIPTION
# English

## Summary

`ha relation relate --type evidenced-by` accepted any decision anchor as its source — including a chosen option (`CH<n>`) or even the bare decision ref — when the standing ledger discipline (dec_60AF05D4F52CEFE347F2208791) requires evidence to anchor to a declared claim (`C<n>`) specifically. A prior regression confirmed this: writing `evidenced-by` from `decision/<id>/CH1` returned `applied` instead of being rejected. The fix rejects any non-replay `evidenced-by` relate whose source isn't one of the decision's declared claim ids, naming the available claim refs in the rejection, and `decision-accept`'s existing evidence-floor error message now also names a concrete claim ref instead of only describing the two acceptance routes abstractly.

## Architectural Justification

-

## What Changed

- `packages/daemon/src/entity-action-relation.ts`: `relation-relate` with `relationType === "evidenced-by"` now parses the source ref and, for a decision source, rejects with `relation_source_anchor_invalid` unless the anchor matches one of the decision's declared claim ids, listing the valid `decision/<id>/<claim-id>` refs in the message.
- `packages/kernel/src/domain/decision-event-document.ts`: `assertDecisionEvidenceFloor`'s rejection message now names an actual claim ref example instead of only the abstract two-route explanation, and explicitly notes chosen (`CH`) anchors don't count.
- `packages/daemon/test/decision-surface.test.ts`: new test proves `CH1`, `RJ1`, and a bare decision ref are all rejected pre-write (ledger revision unchanged) for `evidenced-by`, that `decision-accept` without evidence still fails with `invalid_transition` naming the `C1` claim ref, and that relating from the correct `C1` claim succeeds.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: +17/-1 production; tests +70/-0.

## Machine-Readable Declarations

- None.

## Task And Scope

- Harness task: task_756027ddee8ddbff5150906ee5 (parent none)
- Branch: `codex/evidenced-by-anchor`
- Public scope: daemon decision/relation entity-action validation only; no schema or protocol shape change, no change to already-accepted decisions
- Private planning/evidence updated: yes (`artifacts/report.md`)
- Out of scope: Independent typecheck is unverified in this run (commit hook reported a missing local `tsc`); no new governance decision was required for this fix per the report.

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: not applicable
- Machine-check boundary: not applicable
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `554be6d94`
- Branch merge-base with `origin/main`: `554be6d94`
- Last `git fetch origin` time: 2026-09-12 UTC
- Sync method: branched from origin/main
- Public diff command: `git diff origin/main...codex/evidenced-by-anchor`
- Private evidence commit/path: task_756027ddee8ddbff5150906ee5 `artifacts/report.md`
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [x] `npm run typecheck` (worker, `tsc -b`)
- [ ] `npm run check`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts` (via `run-manifest-gates --changed origin/main`)
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Ubuntu isolated: `decision-surface.test.ts` 4/4 and `fact-event-service-decision-lifecycle.test.ts` 3/3 (7/7 total, matching the report's headline number); ESLint, line-density, and manifest gates all green. Pre-fix reproduction on baseline `c61349de9` confirmed 3 pass / 1 fail (the bad `CH1`-sourced write returned `applied`).

## Review Evidence

- CEO ground-truth: read the worker report and the diff stat; commit authorship and scope checked.
- Reviewer subagent: closeout review after merge (one-path closeout)
- Human review: pending
- Blocking findings: none open

## Residual Risk

- Directly implements the standing decision/relation anchor discipline from AGENTS.md (Fact->Decision->Task->Fact loop, claim vs. chosen-option anchors); low risk, additive validation only, no existing accepted relations are touched.

## References

- Task: task_756027ddee8ddbff5150906ee5

---

# 中文

## 概要

`ha relation relate --type evidenced-by` 此前接受任何决策锚点作为来源——包括一个 chosen 选项（`CH<n>`）甚至裸的决策引用——而常设台账纪律（dec_60AF05D4F52CEFE347F2208791）要求证据必须专门锚定到一个已声明的 claim（`C<n>`）。此前的回归已证实这个问题：从 `decision/<id>/CH1` 写 `evidenced-by` 返回的是 `applied` 而不是被拒绝。修复让任何非重放的 `evidenced-by` relate，只要来源不是该决策已声明的某个 claim id，就直接拒绝，并在拒绝信息里点名可用的 claim 引用；`decision-accept` 原有的证据下限错误信息现在也会点名一个具体的 claim 引用，而不只是抽象描述两条接受路径。

## 架构辩护

-

## 改动内容

- `packages/daemon/src/entity-action-relation.ts`：`relationType === "evidenced-by"` 的 `relation-relate` 现在会解析来源引用，若来源是决策且锚点不是该决策已声明的某个 claim id，就以 `relation_source_anchor_invalid` 拒绝，并在信息里列出合法的 `decision/<id>/<claim-id>` 引用。
- `packages/kernel/src/domain/decision-event-document.ts`：`assertDecisionEvidenceFloor` 的拒绝信息现在会点名一个真实的 claim 引用示例，而不只是抽象的两条路径说明，并明确指出 chosen（`CH`）锚点不算数。
- `packages/daemon/test/decision-surface.test.ts`：新增测试证明 `CH1`、`RJ1` 及裸决策引用在写入前均被拒绝（台账 revision 不变）；`decision-accept` 在无证据时仍以 `invalid_transition` 失败并点名 `C1` claim 引用；从正确的 `C1` claim 关联则成功。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 删除的门或 fixture：none
- 生产净行数：+17/-1 production; tests +70/-0。

## 机器可读声明

- 无。

## 任务与范围

- Harness 任务：task_756027ddee8ddbff5150906ee5（父 none）
- 分支：`codex/evidenced-by-anchor`
- 公开范围：仅 daemon 决策/关系 entity-action 校验；未改动 schema 或协议形状，也不影响已被接受的历史决策
- 私有计划/证据已更新：是（`artifacts/report.md`）
- 范围外：本次运行未验证独立类型检查（提交钩子报告本地缺少 `tsc`）；据报告本次修复无需新增治理决策。

## 版本影响

- 版本：不变
- 发布影响：不发布

## 治理声明

- 触碰受保护面：否
- 受保护面范围：不适用
- 授权：不适用
- 机器检查边界：不适用
- Break-glass：否
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- 基线 `origin/main` SHA：`554be6d94`
- 分支与 `origin/main` 的 merge-base：`554be6d94`
- 最近一次 `git fetch origin`：2026-09-12 UTC
- 同步方式：从 origin/main 开分支
- 公开 diff 命令：`git diff origin/main...codex/evidenced-by-anchor`
- 私有证据路径：task_756027ddee8ddbff5150906ee5 的 `artifacts/report.md`
- 评审证据路径：本 PR 的评审证据节
- GitHub Actions `rewrite-ci` run URL：本 PR 待跑
- Ubuntu 隔离：`decision-surface.test.ts` 4/4 与 `fact-event-service-decision-lifecycle.test.ts` 3/3（合计 7/7，与报告的头条数字一致）；ESLint、line-density、manifest gates 全绿。基线 `c61349de9` 上的修前复现确认 3 通过/1 失败（错误的 `CH1` 来源写入返回了 `applied`）。

## 评审证据

- CEO 事实核对：读过 worker 报告与 diff 统计；核过提交人与范围。
- 评审子代理：合入后走一条路收口评审
- 人工评审：待定
- 阻塞发现：无

## 残余风险

- 直接落实了 AGENTS.md 中常设的决策/关系锚点纪律（Fact→Decision→Task→Fact 回环，claim 与 chosen 选项锚点的区别）；风险低，纯增量校验，不影响任何已被接受的历史关系。

## 参考

- 任务：task_756027ddee8ddbff5150906ee5

