### PR TITLE
fix: expose admissible relation triples in rejection receipts

### DIFF
--- a/packages/cli/src/cli/guidance-plane.ts
+++ b/packages/cli/src/cli/guidance-plane.ts
@@ -215,7 +215,14 @@ export function humanError(receipt: Record<string, unknown>): { readonly code: s
 }
 
 function renderDiagnostic(diagnostic: Record<string, unknown>): string | null {
-  if (diagnostic.kind === "validation") return renderTemplate("failure", "validation", diagnostic);
+  if (diagnostic.kind === "validation") {
+    const hint = renderTemplate("failure", "validation", diagnostic);
+    if (!Array.isArray(diagnostic.allowedTriples)) return hint;
+    const rows = diagnostic.allowedTriples.map((row: { sourceKind: string; type: string; targetKind: string }) =>
+      [row.sourceKind, row.type, row.targetKind].join("\t"),
+    );
+    return [hint, "source kind\ttype\ttarget kind", ...(rows.length ? rows : ["(none)"])].join("\n");
+  }
   if (diagnostic.kind === "workspace-boundary") return renderTemplate("failure", "workspace-boundary", diagnostic);
   if (diagnostic.kind === "missing-sections") return renderTemplate("failure", "missing-sections", diagnostic);
   if (diagnostic.kind === "materialization-failed")

--- a/packages/cli/test/guidance-plane.test.ts
+++ b/packages/cli/test/guidance-plane.test.ts
@@ -5,7 +5,7 @@ import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { readWorkspaceText } from "../../daemon/src/workspace-text-port.ts";
-import { taskCreateGuidance } from "../../daemon/src/receipt-guidance.ts";
+import { diagnosticForError, taskCreateGuidance } from "../../daemon/src/receipt-guidance.ts";
 import { humanError, renderReceiptGuidance } from "../src/cli/guidance-plane.ts";
 import { renderCliReceipt } from "../src/cli/receipt-render-registry.ts";
 
@@ -274,4 +274,31 @@ test("task show renders lifecycle status before the secondary graph cursor", () 
   });
   assert.equal(rendered.stream, "stdout");
   assert.deepEqual(rendered.text.split("\n").slice(0, 2), ["status: done", "graph cursor: review"]);
+});
+
+test("relation rejection renders structured triples and preserves them through diagnostic validation", () => {
+  const diagnostic = {
+    kind: "validation",
+    entity: "relation",
+    field: "source-ref/type/target-ref",
+    actual: "fact --derives--> decision",
+    expectation: "Choose a declared triple for source kind fact",
+    allowedTriples: [{ sourceKind: "fact", type: "supersedes-fact", targetKind: "fact" }],
+  };
+  assert.deepEqual(diagnosticForError({ diagnostic }), diagnostic);
+  const { allowedTriples: _triples, ...plainDiagnostic } = diagnostic;
+  assert.deepEqual(diagnosticForError({ diagnostic: plainDiagnostic }), plainDiagnostic);
+  const rendered = renderCliReceipt({ ok: false, code: "relation_triple_undeclared", diagnostic });
+  assert.equal(rendered.stream, "stderr");
+  assert.match(rendered.text, /source kind\ttype\ttarget kind\nfact\tsupersedes-fact\tfact/u);
+  assert.doesNotMatch(rendered.text, /ha relation triples/u);
+  assert.match(renderCliReceipt({ ok: false, diagnostic: { ...diagnostic, allowedTriples: [] } }).text, /\n\(none\)$/u);
+  for (const allowedTriples of [
+    null,
+    {},
+    [{ sourceKind: "fact", type: "relates" }],
+    [{ sourceKind: "fact", type: "relates", targetKind: "fact", extra: true }],
+  ]) {
+    assert.equal(diagnosticForError({ diagnostic: { ...diagnostic, allowedTriples } }), undefined);
+  }
 });

--- a/packages/daemon/test/artifact-relation-endpoint.integration.test.ts
+++ b/packages/daemon/test/artifact-relation-endpoint.integration.test.ts
@@ -104,6 +104,13 @@ test("A vertical artifact entity is a relation endpoint for its declared triple 
     assert.equal(undeclared.outcome, "op_rejected", JSON.stringify(undeclared));
     assert.equal(undeclared.code, "relation_triple_undeclared", JSON.stringify(undeclared));
 
+    assert.deepEqual(JSON.parse(JSON.stringify(undeclared)).diagnostic.allowedTriples, [
+      { sourceKind: kind, type: "relates", targetKind: "decision" },
+    ]);
+    assert.equal(reversed.diagnostic?.kind, "validation");
+    assert.equal("allowedTriples" in (reversed.diagnostic ?? {}), false);
+    assert.equal("allowedTriples" in (invalidTarget.diagnostic ?? {}), false);
+
     await cell.close();
     cell = undefined;
     const relationId = deriveRelationId({

--- a/packages/kernel/src/domain/receipt-domain-registry.ts
+++ b/packages/kernel/src/domain/receipt-domain-registry.ts
@@ -29,6 +29,11 @@ export type ReceiptDiagnostic =
       readonly field: string;
       readonly actual: string;
       readonly expectation: string;
+      readonly allowedTriples?: readonly {
+        readonly sourceKind: string;
+        readonly type: string;
+        readonly targetKind: string;
+      }[];
     }
   | {
       readonly kind: "workspace-boundary";
@@ -399,7 +404,22 @@ export function isReceiptDiagnostic(value: unknown): value is ReceiptDiagnostic 
   if (!isReceiptDomainRecord(value) || !isNonEmptyString(value.kind)) return false;
   if (value.kind === "validation")
     return (
-      exact(value, ["kind", "entity", "field", "actual", "expectation"]) &&
+      exact(value, [
+        "kind",
+        "entity",
+        "field",
+        "actual",
+        "expectation",
+        ...("allowedTriples" in value ? ["allowedTriples"] : []),
+      ]) &&
+      (!("allowedTriples" in value) ||
+        (Array.isArray(value.allowedTriples) &&
+          value.allowedTriples.every(
+            (row) =>
+              isReceiptDomainRecord(row) &&
+              exact(row, ["sourceKind", "type", "targetKind"]) &&
+              [row.sourceKind, row.type, row.targetKind].every(isNonEmptyString),
+          ))) &&
       [value.entity, value.field, value.actual, value.expectation].every((field) => typeof field === "string")
     );
   if (value.kind === "workspace-boundary")

--- a/packages/kernel/src/domain/relation-event.ts
+++ b/packages/kernel/src/domain/relation-event.ts
@@ -14,11 +14,7 @@ import {
 } from "./entity-relation.ts";
 import type { EntityVersion } from "./entity-freshness.ts";
 import { parseEntityRef } from "./entity-ref.ts";
-import {
-  canonicalRelationDirections,
-  declaredRelationTriples,
-  type CanonicalRelationDirection,
-} from "./relation-direction.ts";
+import { canonicalRelationDirections, type CanonicalRelationDirection } from "./relation-direction.ts";
 import type { DecisionEventV1 } from "./decision-event.ts";
 import { factRef, type FactEventV1 } from "./fact-event.ts";
 import type { MigrationImportEventV1 } from "./migration-import-event.ts";
@@ -530,13 +526,8 @@ export function assertRelationAdmission(
     "relation_triple_undeclared",
     record,
     kinds,
-    `Declared triples for source kind ${kinds.source}: ` +
-      declaredRelationTriples({ sourceKind: kinds.source })
-        .map(({ type, targetKind }) => `${type} -> ${targetKind}`)
-        .join(", ") +
-      ". Run ha relation triples --source-kind " +
-      `${kinds.source} to inspect the canonical registry. ` +
-      "evidenced-by is directed decision/claim -> fact.",
+    `Choose a declared triple for source kind ${kinds.source}`,
+    writable.filter(({ sourceKind }) => sourceKind === kinds.source),
   );
 }
 
@@ -545,6 +536,7 @@ function relationAdmissionError(
   record: Pick<EntityRelationRecord, "type">,
   kinds: { readonly source: string; readonly target: string },
   expectation: string,
+  allowedTriples?: readonly CanonicalRelationDirection[],
 ): never {
   throw Object.assign(
     new Error(
@@ -559,6 +551,15 @@ function relationAdmissionError(
         field: "source-ref/type/target-ref",
         actual: `${kinds.source} --${record.type}--> ${kinds.target}`,
         expectation,
+        ...(allowedTriples
+          ? {
+              allowedTriples: allowedTriples.map(({ sourceKind, type, targetKind }) => ({
+                sourceKind,
+                type,
+                targetKind,
+              })),
+            }
+          : {}),
       },
     },
   );

--- a/packages/kernel/test/contracts/relation-entity.test.ts
+++ b/packages/kernel/test/contracts/relation-entity.test.ts
@@ -124,11 +124,15 @@ test("undeclared relation triples name the available triples for their source ki
         occurredAt: "2026-09-04T00:00:00.000Z",
         workspaceRevision: 1,
       }),
-    (error: unknown) =>
-      (error as { readonly code?: string }).code === "relation_triple_undeclared" &&
-      /Declared triples for source kind fact: supersedes-fact -> fact, relates -> relation/u.test(
-        String((error as { readonly diagnostic?: { readonly expectation?: unknown } }).diagnostic?.expectation),
-      ),
+    (error: unknown) => {
+      const rejected = error as { code: string; diagnostic: { allowedTriples: unknown } };
+      assert.equal(rejected.code, "relation_triple_undeclared");
+      assert.deepEqual(rejected.diagnostic.allowedTriples, [
+        { sourceKind: "fact", type: "supersedes-fact", targetKind: "fact" },
+        { sourceKind: "fact", type: "relates", targetKind: "relation" },
+      ]);
+      return true;
+    },
   );
 });
 

--- a/packages/kernel/test/domain/relation-direction.test.ts
+++ b/packages/kernel/test/domain/relation-direction.test.ts
@@ -1,6 +1,7 @@
 // harness-test-tier: fast
 import assert from "node:assert/strict";
 import test from "node:test";
+import { assertRelationAdmission } from "../../src/domain/relation-event.ts";
 import { isAllowedRelationKindTriple, relationTypes } from "../../src/domain/entity-relation.ts";
 import {
   canonicalRelationDirections,
@@ -132,4 +133,31 @@ test("Relation is a first-class endpoint without changing existing verb meanings
   }
   assert.equal(isAllowedRelationKindTriple("relation", "depends-on", "task"), false);
   assert.equal(isAllowedRelationKindTriple("fact", "supersedes-fact", "relation"), false);
+});
+
+test("undeclared admission lists only writable rows from the supplied registry", () => {
+  const record = { source: "task/task-source", target: "fact/F-target", type: "derives" } as const;
+  for (const directions of [canonicalRelationDirections, []]) {
+    assert.throws(
+      () => assertRelationAdmission(record, directions),
+      (error: unknown) => {
+        const rejected = error as { code: string; diagnostic: { allowedTriples: unknown } };
+        assert.equal(rejected.code, "relation_triple_undeclared");
+        assert.deepEqual(
+          rejected.diagnostic.allowedTriples,
+          directions.length
+            ? [
+                { sourceKind: "task", type: "implements", targetKind: "decision" },
+                { sourceKind: "task", type: "depends-on", targetKind: "task" },
+                { sourceKind: "task", type: "relates", targetKind: "task" },
+                { sourceKind: "task", type: "produces", targetKind: "fact" },
+                { sourceKind: "task", type: "evidences", targetKind: "fact" },
+                { sourceKind: "task", type: "relates", targetKind: "relation" },
+              ]
+            : [],
+        );
+        return true;
+      },
+    );
+  }
 });


### PR DESCRIPTION
# English

## Summary

When `ha relation relate` rejected an undeclared (sourceKind, type, targetKind) triple with `relation_triple_undeclared`, the diagnostic only carried a free-text expectation string and told the caller to separately run `ha relation triples --source-kind <kind>` to discover what was actually legal. The admission check already had the writable-triple registry in hand when it rejected; it just wasn't projecting it into the receipt. The fix has `assertRelationAdmission` filter the registry rows for the offending source kind and attach them as a structured `diagnostic.allowedTriples: { sourceKind, type, targetKind }[]` field, and the CLI's validation renderer prints those rows as a tab-separated table (or `(none)` when the registry has nothing writable for that kind) directly under the existing hint text — no extra round trip needed.

## Architectural Justification

-

## What Changed

- `packages/kernel/src/domain/relation-event.ts`: `assertRelationAdmission`'s undeclared-triple error now passes the runtime registry's writable rows for the offending source kind into `relationAdmissionError`, which projects them onto the diagnostic as `allowedTriples`; the old free-text `declaredRelationTriples(...).map(...).join(...)` sentence (with its "Run ha relation triples" instruction and the fixed evidenced-by aside) is gone, replaced by a short `Choose a declared triple for source kind <kind>` expectation.
- `packages/kernel/src/domain/receipt-domain-registry.ts`: the `validation` diagnostic's `ReceiptDiagnostic` type and its `isReceiptDiagnostic` exact-field validator now admit an optional `allowedTriples` array, validating each row is `{ sourceKind, type, targetKind }` of non-empty strings with no extra fields.
- `packages/cli/src/cli/guidance-plane.ts`: `renderDiagnostic` for a `validation` diagnostic now appends a `source kind\ttype\ttarget kind` header and one tab-separated row per allowed triple (or `(none)`) under the existing rendered hint, when `allowedTriples` is present and is an array.
- Tests: `packages/kernel/test/domain/relation-direction.test.ts` adds a regression proving `assertRelationAdmission` lists only writable rows for the rejected source kind (and `[]` against an empty registry); `packages/kernel/test/contracts/relation-entity.test.ts` and `packages/daemon/test/artifact-relation-endpoint.integration.test.ts` assert the structured field survives the full admission/serialization path for both built-in and vertical (artifact) source kinds and that reversed-direction/invalid-target diagnostics carry no such field; `packages/cli/test/guidance-plane.test.ts` covers the CLI table rendering, the empty-list case, and diagnostic-shape validation (rejecting malformed `allowedTriples`).

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: +42/-14 production; tests +72/-6.

## Machine-Readable Declarations

- None.

## Task And Scope

- Harness task: task_7048036fd65b7da01e2fa6a07d (parent task_4455977a529becac425737d812)
- Branch: `codex/relation-triple-discoverable`
- Public scope: kernel relation admission rejection path and its receipt-diagnostic contract, plus the CLI's existing validation-diagnostic renderer; additive optional field only, no change to writable-triple semantics, no protocol/schema shape change for existing consumers that ignore the new field
- Private planning/evidence updated: yes (`artifacts/report.md`)
- Out of scope: GUI relation-graph rendering of this diagnostic, live shared-daemon rollout, Windows, full `check:local`, and GitHub CI were not exercised in this run; only targeted Ubuntu-isolated and local node test runs plus static gates are claimed as evidence.

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: not applicable
- Machine-check boundary: not applicable
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `554be6d94`
- Branch merge-base with `origin/main`: `554be6d94`
- Last `git fetch origin` time: 2026-09-12 UTC
- Sync method: branched from origin/main
- Public diff command: `git diff origin/main...codex/relation-triple-discoverable`
- Private evidence commit/path: task_7048036fd65b7da01e2fa6a07d `artifacts/report.md`
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [x] `npm run typecheck` (worker, `tsc -b`)
- [ ] `npm run check`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts` (via `run-manifest-gates --changed origin/main`)
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Local: `relation-direction.test.ts` 10/10 (new regression plus existing coverage) and `guidance-plane.test.ts` 8/8; `npx tsc -b packages/cli` clean; `line-density` and `run-manifest-gates.mjs --changed origin/main` (including ESLint) both exit 0. Ubuntu isolated (`dispatch-isolated-test.mjs`): `relation-entity.test.ts` 8/8 and `artifact-relation-endpoint.integration.test.ts` 1/1. An intermediate build that made `allowedTriples` a required field broke the reversed-direction diagnostic and was caught by the isolated daemon run before the final commit.

## Review Evidence

- CEO ground-truth: read the worker report and the diff stat; commit authorship and scope checked.
- Reviewer subagent: closeout review after merge (one-path closeout)
- Human review: pending
- Blocking findings: none open

## Residual Risk

- Low risk, additive diagnostic field only — existing consumers that don't read `allowedTriples` are unaffected, and no already-admitted relation is touched. Out-of-scope finding from this task's own report: a separate discovery query, `packages/daemon/src/repo-cell-action-dispatch.ts:111` (backing `ha relation triples`), still calls the built-in-only `declaredRelationTriples` rather than the composed runtime registry used here, so it can still omit vertical-kind rows; that code path was left unchanged and its live-daemon behavior is unverified. Recommended follow-up (not done here): thread the same runtime registry into that query.

## References

- Task: task_7048036fd65b7da01e2fa6a07d

---

# 中文

## 概要

此前 `ha relation relate` 因 (sourceKind, type, targetKind) 三元组未声明而被 `relation_triple_undeclared` 拒绝时，诊断信息只带一段自由文本说明，还要求调用方另外跑 `ha relation triples --source-kind <kind>` 才能查到真正合法的三元组。其实 admission 校验在拒绝时手上已经有可写三元组注册表，只是没有把它投影进回执。修复让 `assertRelationAdmission` 按被拒来源 kind 过滤注册表行，附加为结构化的 `diagnostic.allowedTriples: { sourceKind, type, targetKind }[]` 字段；CLI 的校验渲染器把这些行渲染成制表符分隔的表格（该 kind 没有可写行时显示 `(none)`），直接接在既有提示文字下面，不需要再多跑一次命令。

## 架构辩护

-

## 改动内容

- `packages/kernel/src/domain/relation-event.ts`：`assertRelationAdmission` 的三元组未声明错误现在把运行时注册表里该来源 kind 的可写行传给 `relationAdmissionError`，后者把它们投影为诊断的 `allowedTriples`；原来那段自由文本（`declaredRelationTriples(...).map(...).join(...)`，附带 “Run ha relation triples” 指引和固定的 evidenced-by 备注）被删除，改为一句简短的 `Choose a declared triple for source kind <kind>`。
- `packages/kernel/src/domain/receipt-domain-registry.ts`：`validation` 诊断的 `ReceiptDiagnostic` 类型与其 `isReceiptDiagnostic` 精确字段校验器现在接受可选的 `allowedTriples` 数组，校验每一行都是不含多余字段、字段均为非空字符串的 `{ sourceKind, type, targetKind }`。
- `packages/cli/src/cli/guidance-plane.ts`：`renderDiagnostic` 在 `validation` 诊断存在数组类型的 `allowedTriples` 时，会在既有提示文字下追加 `source kind\ttype\ttarget kind` 表头和逐行制表符分隔的三元组（为空时显示 `(none)`）。
- 测试：`packages/kernel/test/domain/relation-direction.test.ts` 新增回归，证明 `assertRelationAdmission` 只列出被拒来源 kind 的可写行（空注册表时为 `[]`）；`packages/kernel/test/contracts/relation-entity.test.ts` 与 `packages/daemon/test/artifact-relation-endpoint.integration.test.ts` 断言该结构化字段在内建与 vertical（artifact）来源 kind 下都能完整经过 admission/序列化，且方向相反/目标非法的诊断不带该字段；`packages/cli/test/guidance-plane.test.ts` 覆盖 CLI 表格渲染、空列表情形与诊断形状校验（拒绝畸形 `allowedTriples`）。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 删除的门或 fixture：none
- 生产净行数：+42/-14 production; tests +72/-6。

## 机器可读声明

- 无。

## 任务与范围

- Harness 任务：task_7048036fd65b7da01e2fa6a07d（父 task_4455977a529becac425737d812）
- 分支：`codex/relation-triple-discoverable`
- 公开范围：仅涉及 kernel 关系 admission 拒绝路径及其回执诊断契约，以及 CLI 既有的校验诊断渲染器；纯增量可选字段，不改变可写三元组的语义，对忽略新字段的既有消费方也不构成协议/schema 形状变化
- 私有计划/证据已更新：是（`artifacts/report.md`）
- 范围外：本次运行未验证 GUI 关系图对该诊断的渲染、真实共享 daemon 上线、Windows、完整 check:local 与 GitHub CI；只以定向的 Ubuntu 隔离测试、本地 node 测试与静态门作为证据。

## 版本影响

- 版本：不变
- 发布影响：不发布

## 治理声明

- 触碰受保护面：否
- 受保护面范围：不适用
- 授权：不适用
- 机器检查边界：不适用
- Break-glass：否
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- 基线 `origin/main` SHA：`554be6d94`
- 分支与 `origin/main` 的 merge-base：`554be6d94`
- 最近一次 `git fetch origin`：2026-09-12 UTC
- 同步方式：从 origin/main 开分支
- 公开 diff 命令：`git diff origin/main...codex/relation-triple-discoverable`
- 私有证据路径：task_7048036fd65b7da01e2fa6a07d 的 `artifacts/report.md`
- 评审证据路径：本 PR 的评审证据节
- GitHub Actions `rewrite-ci` run URL：本 PR 待跑
- 本地：`relation-direction.test.ts` 10/10（新增回归加既有覆盖）与 `guidance-plane.test.ts` 8/8；`npx tsc -b packages/cli` 无输出；`line-density` 与 `run-manifest-gates.mjs --changed origin/main`（含 ESLint）均 exit 0。Ubuntu 隔离（`dispatch-isolated-test.mjs`）：`relation-entity.test.ts` 8/8、`artifact-relation-endpoint.integration.test.ts` 1/1。中间一版把 `allowedTriples` 做成必填字段，导致方向相反诊断被破坏，在最终提交前已被隔离 daemon 测试跑出。

## 评审证据

- CEO 事实核对：读过 worker 报告与 diff 统计；核过提交人与范围。
- 评审子代理：合入后走一条路收口评审
- 人工评审：待定
- 阻塞发现：无

## 残余风险

- 风险低，纯增量诊断字段——不读 `allowedTriples` 的既有消费方不受影响，也不触碰任何已被接受的关系。本任务自身报告点出的范围外发现：一条独立的发现型查询 `packages/daemon/src/repo-cell-action-dispatch.ts:111`（支撑 `ha relation triples`）仍调用只含内建表的 `declaredRelationTriples`，而不是这里用到的组合运行时注册表，因此仍可能漏掉 vertical kind 的行；该路径本次未改动，其真实 daemon 行为未经验证。建议的后续工作（本次未做）：把同一份运行时注册表接入那条查询。

## 参考

- 任务：task_7048036fd65b7da01e2fa6a07d

