### PR TITLE
refactor: retire legacy task creation input

### DIFF
--- a/packages/cli/src/cli/thin-command-task-create.ts
+++ b/packages/cli/src/cli/thin-command-task-create.ts
@@ -14,14 +14,13 @@ export function parseTaskCreate(
   if (!f.ok) return rejected(f.code, f.nextAction, json);
   const title = f.one.get("--title"),
     id = f.one.get("--id"),
-    fromLegacy = f.one.get("--from-legacy"),
     modes = ["migration", "import", "admin"].filter((mode) => f.booleans.has(`--${mode}`)),
     structured = [f.one.get("--from-file"), f.one.get("--json-input")].filter(Boolean),
     moduleNames = ["--register-module", "--module-title", "--module-prefix", "--module-scope"],
     moduleFields = moduleNames.map((name) => f.one.get(name)),
     moduleCount = moduleFields.filter(Boolean).length;
   if (
-    (!title && !structured.length && !fromLegacy) ||
+    (!title && !structured.length) ||
     (id && modes.length !== 1) ||
     (!id && modes.length > 0) ||
     structured.length > 1 ||
@@ -31,7 +30,7 @@ export function parseTaskCreate(
     return rejectInput(
       inputs,
       route.id,
-      !title && !structured.length && !fromLegacy
+      !title && !structured.length
         ? "--title"
         : id || modes.length
           ? "--id"

--- a/packages/cli/src/daemon/client.ts
+++ b/packages/cli/src/daemon/client.ts
@@ -550,7 +550,6 @@ export async function fleetTaskRoute(
     commandType: _commandType,
     fromFile,
     jsonInput,
-    fromLegacyId,
     ...action
   } = command.action as Record<string, unknown> & {
     executor?: unknown;
@@ -559,13 +558,12 @@ export async function fleetTaskRoute(
     commandType?: unknown;
     fromFile?: unknown;
     jsonInput?: unknown;
-    fromLegacyId?: unknown;
   };
-  // Migration/import/admin creation and legacy conversion are intentionally
+  // Migration/import/admin creation is intentionally
   // outside the remote-edge surface. Falling through produces the existing,
   // explicit repo_mode_read_only receipt instead of silently dropping their
   // authority-bearing fields on the fleet route.
-  if (actionKind === "task-create" && (createMode !== undefined || fromLegacyId !== undefined)) return null;
+  if (actionKind === "task-create" && createMode !== undefined) return null;
   const payload: Record<string, unknown> = {
     host: config.host,
     port: config.port,
@@ -603,7 +601,7 @@ export async function fleetTaskRoute(
     if (actionKind === "task-create" || ("path" in descriptor && descriptor.path[0] === "schedule")) {
       const fields = packet as Record<string, unknown>;
       const unsupported = Object.keys(fields).filter((field) =>
-        ["fromFile", "jsonInput", "kind", "createMode", "fromLegacyId"].includes(field),
+        ["fromFile", "jsonInput", "kind", "createMode"].includes(field),
       );
       if (unsupported.length)
         throw Object.assign(new Error(`--from-file cannot carry ${unsupported.join(", ")} over the fleet channel.`), {

--- a/packages/cli/test/thin-command-identity-migration.test.ts
+++ b/packages/cli/test/thin-command-identity-migration.test.ts
@@ -346,3 +346,9 @@ test("thin parser rejects retired caller-supplied gate receipts", () => {
     json: false,
   });
 });
+
+test("task create rejects the retired legacy flag and still accepts a title", () => {
+  assert.equal(parseThinCommand(["task", "create", "--from-legacy", "legacy-1"]).ok, false);
+  assert.equal(parseThinCommand(["task", "create", "--title", "New task", "--from-legacy", "legacy-1"]).ok, false);
+  assert.equal(parseThinCommand(["task", "create", "--title", "New task"]).ok, true);
+});

--- a/packages/daemon/src/repo-cell-action-parse.ts
+++ b/packages/daemon/src/repo-cell-action-parse.ts
@@ -1,14 +1,11 @@
-import { realpathSync } from "node:fs";
-import path from "node:path";
 import {
   decisionProposalJsonFields,
   decisionProposalRequiredJsonFields,
   taskCreateJsonFields,
 } from "../../preset/src/index.ts";
 import { consumeKnownError, type SettingsV1 } from "../../kernel/src/index.ts";
-import { cellCodedError, cellErrorCode } from "./repo-cell-errors.ts";
+import { cellCodedError } from "./repo-cell-errors.ts";
 import { packetRecord, readPacketSource, workspaceText } from "./repo-cell-packets.ts";
-import { requiredCellText } from "./repo-cell-settlement.ts";
 import type { RepoTaskAction } from "./repo-cell-types.ts";
 
 export const decisionProposalFields = decisionProposalJsonFields;
@@ -66,24 +63,16 @@ export function resolvePacketAction(
 
 export function taskCreateAction(rootDir: string, action: RepoTaskAction): RepoTaskAction {
   const fromFile = typeof action.fromFile === "string",
-    jsonInput = typeof action.jsonInput === "string",
-    fromLegacy = typeof action.fromLegacyId === "string";
-  if (fromLegacy) {
-    if (fromFile || jsonInput)
-      throw cellCodedError(
-        "invalid_command",
-        "Use --from-legacy by itself, with only optional --title, --slug, or --dry-run overrides.",
-      );
-    const allowed = ["kind", "fromLegacyId", "title", "slug", "dryRun"],
-      invalid = Object.keys(action).filter((field) => !allowed.includes(field));
-    if (invalid.length)
-      throw cellCodedError("invalid_command", `Remove ${invalid.join(", ")} from --from-legacy task creation.`);
-    return legacyTaskCreateAction(rootDir, action);
-  }
+    jsonInput = typeof action.jsonInput === "string";
+  const unsupported = Object.keys(action).filter(
+    (field) => !["kind", "fromFile", "jsonInput", "dryRun", ...taskCreateFields].includes(field),
+  );
+  if (unsupported.length)
+    throw cellCodedError("invalid_command", `Remove unsupported task create fields: ${unsupported.join(", ")}.`);
   if (!fromFile && !jsonInput) return action;
   if (fromFile === jsonInput)
     throw cellCodedError("invalid_command", "Choose exactly one structured task source: --from-file or --json-input.");
-  const resolved = resolvePacketAction(rootDir, action, {
+  return resolvePacketAction(rootDir, action, {
     required: [],
     allowed: taskCreateFields,
     invalid: (message) => cellCodedError("invalid_command", message),
@@ -98,56 +87,6 @@ export function taskCreateAction(rootDir: string, action: RepoTaskAction): RepoT
       return { kind: "task-create", ...packet, ...direct };
     },
   });
-  return typeof resolved.fromLegacyId === "string" ? taskCreateAction(rootDir, resolved) : resolved;
-}
-
-export function legacyTaskCreateAction(rootDir: string, action: RepoTaskAction): RepoTaskAction {
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(workspaceText(rootDir, "harness/legacy/index.json", "legacy index"));
-  } catch (error) {
-    if (cellErrorCode(error) === "invalid_command")
-      throw cellCodedError(
-        "legacy_index_missing",
-        "Create a valid harness/legacy/index.json with ha legacy index, then retry --from-legacy.",
-      );
-    throw error;
-  }
-  const entries =
-      parsed && typeof parsed === "object" && !Array.isArray(parsed)
-        ? (parsed as Record<string, unknown>).entries
-        : null,
-    legacyId = requiredCellText(action.fromLegacyId, "fromLegacyId"),
-    entry = Array.isArray(entries)
-      ? (entries.find(
-          (value) => value && typeof value === "object" && (value as Record<string, unknown>).id === legacyId,
-        ) as Record<string, unknown> | undefined)
-      : undefined;
-  if (!entry)
-    throw cellCodedError(
-      "legacy_entry_not_found",
-      `Add legacy entry ${legacyId} to harness/legacy/index.json, then retry --from-legacy.`,
-    );
-  const storedPath = requiredCellText(entry.storedPath, "legacy storedPath");
-  try {
-    const root = realpathSync(rootDir),
-      stored = realpathSync(path.resolve(root, storedPath));
-    if (stored !== root && !stored.startsWith(`${root}${path.sep}`)) throw new Error("outside");
-  } catch {
-    throw cellCodedError(
-      "legacy_source_missing",
-      `Restore ${storedPath} inside the workspace, then retry --from-legacy ${legacyId}.`,
-    );
-  }
-  return {
-    ...action,
-    title:
-      typeof action.title === "string"
-        ? action.title
-        : typeof entry.title === "string" && entry.title
-          ? entry.title
-          : legacyId,
-  };
 }
 
 export function decisionProposalAction(

--- a/packages/daemon/test/json-rpc-protocol.test.ts
+++ b/packages/daemon/test/json-rpc-protocol.test.ts
@@ -345,8 +345,7 @@ test("RepoCell serializes identical lifecycle intents into one accepted SQLite o
     initRepo(rootDir);
     cell = await openRepoCell({ repoId: workspaceId("alpha"), rootDir: canonicalRoot(rootDir), ownerId: "daemon-test" });
     const baselineRevision = makeTaskEventReader({ repoId: "alpha", rootDir }).read().revision;
-    const action = { kind: "task-create", verb: "create", commandType: "CreateReplayTask", taskId: "task-alpha",
-      title: "Alpha task" } as const;
+    const action = { kind: "task-create", taskId: "task-alpha", title: "Alpha task" } as const;
 
     const [left, right] = await Promise.all([
       cell.run(action, repoWriteBinding),

--- a/packages/daemon/test/task-create-input.test.ts
+++ b/packages/daemon/test/task-create-input.test.ts
@@ -1,0 +1,25 @@
+// harness-test-tier: fast
+import assert from "node:assert/strict";
+import test from "node:test";
+import { taskCreateAction } from "../src/repo-cell-action-parse.ts";
+
+test("task creation rejects retired legacy inputs through direct and structured sources", () => {
+  for (const fields of [{ fromLegacyId: "legacy-1" }, { title: "New task", fromLegacyId: "legacy-1" }]) {
+    for (const action of [fields, { jsonInput: JSON.stringify(fields) }])
+      assert.throws(
+        () => taskCreateAction("/unused", { kind: "task-create", ...action }),
+        /unsupported task create fields: fromLegacyId/u,
+      );
+  }
+});
+
+test("ordinary task creation retains direct overrides of structured fields", () => {
+  assert.deepEqual(
+    taskCreateAction("/unused", {
+      kind: "task-create",
+      title: "Override",
+      jsonInput: JSON.stringify({ title: "Packet", slug: "packet" }),
+    }),
+    { kind: "task-create", title: "Override", slug: "packet" },
+  );
+});

--- a/packages/daemon/test/task-surface-reads-leases.integration.test.ts
+++ b/packages/daemon/test/task-surface-reads-leases.integration.test.ts
@@ -1,6 +1,6 @@
 // harness-test-tier: integration
 import assert from "node:assert/strict";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -91,25 +91,6 @@ test("task read surfaces, dry-runs, idempotency, structured input, and supersede
       ).outcome,
       "applied",
     );
-    mkdirSync(path.join(rootDir, "harness/legacy/source"), { recursive: true });
-    writeFileSync(path.join(rootDir, "harness/legacy/source/old.md"), "# Legacy\n");
-    writeFileSync(
-      path.join(rootDir, "harness/legacy/index.json"),
-      JSON.stringify({
-        entries: [
-          {
-            id: "legacy-1",
-            title: "Legacy Rebuilt",
-            storedPath: "harness/legacy/source/old.md",
-          },
-        ],
-      }),
-    );
-    const legacy = (await cell.run({ kind: "task-create", fromLegacyId: "legacy-1" }, binding)) as Record<
-      string,
-      unknown
-    >;
-    assert.equal(legacy.outcome, "applied", JSON.stringify(legacy));
     const eventCount = makeTaskEventReader({
       repoId: "task-read-surface",
       rootDir,

--- a/packages/kernel/src/domain/task-action-contract.ts
+++ b/packages/kernel/src/domain/task-action-contract.ts
@@ -134,7 +134,6 @@ const createPacketFields = Object.freeze([
   field("surfaces", "string-array"),
   field("taskClass", "string", false, taskClasses),
   field("locale", "string", false, settingsLocales),
-  field("fromLegacyId"),
   field("createMode", "string", false, ["migration", "import", "admin"]),
 ]);
 const packet = (schemaRef: string, fields: readonly EntityActionInputField[]) => Object.freeze({ schemaRef, fields });
@@ -194,7 +193,6 @@ const createInput = input([
   cli("taskClass", "string", false, "--task-class", "single", { enum: taskClasses }),
   cli("dryRun", "boolean", false, "--dry-run", "boolean"),
   cli("locale", "string", false, "--locale", "single", { enum: settingsLocales }),
-  cli("fromLegacyId", "string", false, "--from-legacy"),
   cli("migration", "boolean", false, "--migration", "boolean"),
   cli("import", "boolean", false, "--import", "boolean"),
   cli("admin", "boolean", false, "--admin", "boolean"),

--- a/packages/preset/src/preset-bootstrap.ts
+++ b/packages/preset/src/preset-bootstrap.ts
@@ -48,7 +48,6 @@ export interface CompileTaskPackageInput extends PresetResolverOptions {
   readonly registerModule?: TaskModuleRegistration;
   readonly slug?: string;
   readonly surfaces?: readonly string[];
-  readonly fromLegacyId?: string;
 }
 export interface CompileTaskBootstrapInput extends CompileTaskPackageInput {
   readonly actor: ActorIdentity;
@@ -126,7 +125,7 @@ export function compileTaskPackage(input: CompileTaskPackageInput): CompiledTask
       moduleKey: input.moduleKey ?? input.registerModule?.key ?? null,
       slug,
       surfaces: [...(input.surfaces ?? [])],
-      fromLegacyId: input.fromLegacyId ?? null,
+      fromLegacyId: null,
     },
     prose = resolved.documents.map((document): CompiledTaskDocument => {
       const body = document.body.replaceAll("{{title}}", input.title);

--- a/packages/preset/src/preset-system.ts
+++ b/packages/preset/src/preset-system.ts
@@ -269,7 +269,6 @@ function taskPackageFields(
   | "registerModule"
   | "slug"
   | "surfaces"
-  | "fromLegacyId"
 > {
   const register =
     action.registerModule && typeof action.registerModule === "object" && !Array.isArray(action.registerModule)
@@ -296,7 +295,6 @@ function taskPackageFields(
       : {}),
     ...(optionalActionText(action.slug) ? { slug: optionalActionText(action.slug)! } : {}),
     ...(Array.isArray(action.surfaces) ? { surfaces: action.surfaces.map((value) => required(value, "surface")) } : {}),
-    ...(optionalActionText(action.fromLegacyId) ? { fromLegacyId: optionalActionText(action.fromLegacyId)! } : {}),
   };
 }
 function oneOf<const T extends readonly string[]>(value: unknown, allowed: T): T[number] | undefined {

--- a/packages/preset/src/task-action-projection.generated.ts
+++ b/packages/preset/src/task-action-projection.generated.ts
@@ -148,7 +148,6 @@ export const taskActionDescriptorProjection = {
                 "surfaces",
                 "taskClass",
                 "locale",
-                "fromLegacyId",
                 "createMode",
               ],
               jsonEnums: {
@@ -189,7 +188,6 @@ export const taskActionDescriptorProjection = {
                 "surfaces",
                 "taskClass",
                 "locale",
-                "fromLegacyId",
                 "createMode",
               ],
               jsonEnums: {
@@ -282,12 +280,6 @@ export const taskActionDescriptorProjection = {
             required: false,
             enum: ["en-US", "zh-CN"],
             cli: { name: "--locale", kind: "single", error: "invalid_field" },
-          },
-          {
-            field: "fromLegacyId",
-            type: "string",
-            required: false,
-            cli: { name: "--from-legacy", kind: "single", error: "invalid_field" },
           },
           {
             field: "migration",


### PR DESCRIPTION
# English

## Summary

`ha task create --from-legacy <id>` was a second task-creation implementation living alongside the normal `--title`/`--from-file`/`--json-input` paths: the CLI parser exempted it from requiring a title, the fleet-route client carried a dedicated `fromLegacyId` field, and `packages/daemon/src/repo-cell-action-parse.ts` read `harness/legacy/index.json`, resolved a `storedPath` inside the workspace, and synthesized a task title from a legacy entry. This round retires the whole path: the CLI flag, its parser exemption, the fleet-route field, the kernel action-contract field/CLI declaration (and its generated projection), the preset compile/bootstrap pass-through, and the entire `legacyTaskCreateAction` function in the daemon are all deleted. `task create` now only accepts `--title`, `--from-file`, or `--json-input`, and any leftover `fromLegacyId` in a structured payload is rejected as an unsupported field.

## Architectural Justification

-

## What Changed

- `packages/cli/src/cli/thin-command-task-create.ts`: removed the `--from-legacy` read and its title-requirement exemption; a bare `task create` with neither `--title` nor a structured source is now rejected the same way regardless of `--from-legacy`.
- `packages/cli/src/daemon/client.ts`: removed `fromLegacyId` from `fleetTaskRoute`'s destructuring, its fleet-routing bypass condition, and its list of fields disallowed alongside `--from-file`.
- `packages/daemon/src/repo-cell-action-parse.ts`: `taskCreateAction` no longer branches on `fromLegacy`; it now rejects any field not in the allowed `task-create` set up front, and the entire `legacyTaskCreateAction` function (legacy-index JSON parsing, `storedPath` workspace-boundary resolution via `realpathSync`, and title synthesis) is deleted along with its now-unused imports (`realpathSync`, `path`, `cellErrorCode`, `requiredCellText`).
- `packages/kernel/src/domain/task-action-contract.ts`: removed the `fromLegacyId` packet field and its `--from-legacy` CLI declaration from `createPacketFields`/`createInput`.
- `packages/preset/src/task-action-projection.generated.ts`: regenerated via `node tools/generate-task-action-protocol.mjs` to drop the now-absent `fromLegacyId` field from both JSON and CLI projections.
- `packages/preset/src/preset-bootstrap.ts` and `packages/preset/src/preset-system.ts`: removed the `fromLegacyId` input/pass-through; `compileTaskPackage` now always writes `fromLegacyId: null` into task metadata (the historical replay field is kept, not repurposed as a new compatibility path).
- Tests: `packages/daemon/test/task-create-input.test.ts` (new) asserts direct and JSON-input `fromLegacyId` fields are rejected as unsupported while ordinary direct-override-of-structured-fields behavior is retained; `packages/daemon/test/task-surface-reads-leases.integration.test.ts` drops its legacy-index fixture and successful `--from-legacy` creation scenario; `packages/cli/test/thin-command-identity-migration.test.ts` adds a regression that `--from-legacy` is rejected and a bare `--title` still works.

## Gate Harvest / 门收割

Deleted-Production-Paths: --from-legacy (CLI flag/input), packages/daemon/src/repo-cell-action-parse.ts (legacyTaskCreateAction function and legacy-index/storedPath resolution), packages/cli/src/cli/thin-command-task-create.ts (--from-legacy parser exemption), packages/cli/src/daemon/client.ts (fromLegacyId fleet-route field), packages/kernel/src/domain/task-action-contract.ts (fromLegacyId packet field + --from-legacy CLI declaration), packages/preset/src/task-action-projection.generated.ts (fromLegacyId projection, regenerated), packages/preset/src/preset-bootstrap.ts (fromLegacyId compile input), packages/preset/src/preset-system.ts (fromLegacyId pass-through)
Deleted-Gates-Fixtures: `packages/daemon/test/task-surface-reads-leases.integration.test.ts` legacy fixture (harness/legacy/index.json + source/old.md and the `fromLegacyId: "legacy-1"` task-create case) removed with the retired input
- Production net lines: +14/-91 production, net -77; tests +32/-20.

## Machine-Readable Declarations

- None.

## Task And Scope

- Harness task: task_237b139bb0b710cf047303c6ed (parent none)
- Branch: `codex/retire-from-legacy`
- Public scope: CLI task-create parsing, daemon repo-cell task-create input handling, kernel task-action contract/CLI declaration, and the generated preset projection that mirrors it, plus preset compile-time pass-through; no change to already-persisted task event metadata shape (the `fromLegacyId` history field is retained, just always null going forward) and no GUI change
- Private planning/evidence updated: yes (`artifacts/report.md`)
- Out of scope: This task did not touch the GUI, so it produced zero change to the GUI's i18n key set. As a side investigation it ran a repo-wide static i18n reference scan (285 GUI production TS/TSX files, 1563 keys per locale) and found 59 candidate keys in `components.json`/etc. with no static string-literal or matched dynamic-template reference (30 more match a dynamic template conservatively and were excluded); it deliberately did NOT delete any of those 59 i18n dictionary entries here, since static-candidate status doesn't prove runtime unreachability and this task's scope was CLI/daemon input handling, not GUI cleanup — see risk for the caveat.

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: not applicable
- Machine-check boundary: not applicable
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `554be6d94`
- Branch merge-base with `origin/main`: `554be6d94`
- Last `git fetch origin` time: 2026-09-12 UTC
- Sync method: branched from origin/main
- Public diff command: `git diff origin/main...codex/retire-from-legacy`
- Private evidence commit/path: task_237b139bb0b710cf047303c6ed `artifacts/report.md`
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [x] `npm run typecheck` (worker, `tsc -b`)
- [ ] `npm run check`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts` (via `run-manifest-gates --changed origin/main`)
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Red-before-fix: pre-fix `task-create-input.test.ts` failed (1/2) hitting the old `legacyTaskCreateAction` error path instead of the new unsupported-field rejection. Final directed run: daemon input tests 2, RepoCell create/read/idempotency/lease integration 4, CLI parser 9, fleet-routing 1, generated-projection tests 2 — 18 passed total. `line-density` and manifest gates (including ESLint) both exit 0. Governance walls (`run-walls.mjs`) 12 pass / 0 red / 4 info. The isolated Ubuntu VM was unreachable this run (SSH permission denied) so the contract-allowed local runner was used instead. Full `check:local`, GitHub CI, and independent `tsc` build were not run (commit hook reported a missing local `tsc` binary) and are unverified.

## Review Evidence

- CEO ground-truth: read the worker report and the diff stat; commit authorship and scope checked.
- Reviewer subagent: closeout review after merge (one-path closeout)
- Human review: pending
- Blocking findings: none open

## Residual Risk

- Low risk, pure deletion of a redundant, less-validated creation path with no already-accepted event replaced (historical `fromLegacyId` metadata is preserved, just always null on new tasks). Residual risk / follow-up: the i18n static-reference scan run alongside this task left 59 unreferenced-candidate GUI dictionary keys undeleted — they are unverified as truly dead (dynamic key construction, external callers, or runtime-unreachable-but-still-referenced components could all explain a false candidate), and no causal link was established between this CLI-only change and GUI key liveness; deleting those 59 keys is explicitly deferred to a separate GUI-scoped review, not done in this task.

## References

- Task: task_237b139bb0b710cf047303c6ed

---

# 中文

## 概要

`ha task create --from-legacy <id>` 此前是与正常 `--title`/`--from-file`/`--json-input` 路径并存的第二套任务创建实现：CLI parser 对它豁免了 title 必填，fleet-route client 带专用 `fromLegacyId` 字段，`packages/daemon/src/repo-cell-action-parse.ts` 会读取 `harness/legacy/index.json`、在工作区内解析 `storedPath`，并从 legacy 条目合成任务标题。本轮把整条路径退役：CLI flag、其 parser 豁免、fleet-route 字段、kernel action-contract 字段/CLI 声明（及其生成投影）、preset 编译期透传，以及 daemon 里整个 `legacyTaskCreateAction` 函数全部删除。`task create` 现在只接受 `--title`、`--from-file` 或 `--json-input`，结构化 payload 里残留的 `fromLegacyId` 会被当作不支持字段直接拒绝。

## 架构辩护

-

## 改动内容

- `packages/cli/src/cli/thin-command-task-create.ts`：删除 `--from-legacy` 读取及其 title 必填豁免；不带 `--title` 也不带结构化来源的裸 `task create`，现在无论有没有 `--from-legacy` 都同样被拒绝。
- `packages/cli/src/daemon/client.ts`：从 `fleetTaskRoute` 的解构、fleet 路由旁路条件、以及与 `--from-file` 互斥的字段清单中都删除了 `fromLegacyId`。
- `packages/daemon/src/repo-cell-action-parse.ts`：`taskCreateAction` 不再按 `fromLegacy` 分支，而是先对不在允许 `task-create` 字段集合内的字段整体拒绝；整个 `legacyTaskCreateAction` 函数（legacy 索引 JSON 解析、经 `realpathSync` 的 `storedPath` 工作区边界解析、标题合成）连同其此后未用的 imports（`realpathSync`、`path`、`cellErrorCode`、`requiredCellText`）一并删除。
- `packages/kernel/src/domain/task-action-contract.ts`：从 `createPacketFields`/`createInput` 中删除 `fromLegacyId` 包字段及其 `--from-legacy` CLI 声明。
- `packages/preset/src/task-action-projection.generated.ts`：用 `node tools/generate-task-action-protocol.mjs` 重新生成，JSON 与 CLI 投影中都不再出现 `fromLegacyId`。
- `packages/preset/src/preset-bootstrap.ts` 与 `packages/preset/src/preset-system.ts`：删除 `fromLegacyId` 的入参与透传；`compileTaskPackage` 现在始终把 `fromLegacyId: null` 写入任务 metadata（历史回放字段保留，不被挪用为新的兼容路径）。
- 测试：新增 `packages/daemon/test/task-create-input.test.ts`，断言直接字段与 JSON-input 里的 `fromLegacyId` 都被当作不支持字段拒绝，同时保留普通的“直接字段覆盖结构化字段”行为；`packages/daemon/test/task-surface-reads-leases.integration.test.ts` 删掉了 legacy 索引 fixture 与成功的 `--from-legacy` 创建场景；`packages/cli/test/thin-command-identity-migration.test.ts` 新增回归，证明 `--from-legacy` 被拒绝而裸 `--title` 仍可用。

## 门收割 / Gate Harvest

- 删除的生产路径：--from-legacy (CLI flag/input), packages/daemon/src/repo-cell-action-parse.ts (legacyTaskCreateAction function and legacy-index/storedPath resolution), packages/cli/src/cli/thin-command-task-create.ts (--from-legacy parser exemption), packages/cli/src/daemon/client.ts (fromLegacyId fleet-route field), packages/kernel/src/domain/task-action-contract.ts (fromLegacyId packet field + --from-legacy CLI declaration), packages/preset/src/task-action-projection.generated.ts (fromLegacyId projection, regenerated), packages/preset/src/preset-bootstrap.ts (fromLegacyId compile input), packages/preset/src/preset-system.ts (fromLegacyId pass-through)
- 删除的门或 fixture：`packages/daemon/test/task-surface-reads-leases.integration.test.ts` 的 legacy fixture（harness/legacy/index.json + source/old.md 与 `fromLegacyId: "legacy-1"` 的 task-create 用例）随退役输入一并删除
- 生产净行数：+14/-91 production, net -77; tests +32/-20。

## 机器可读声明

- 无。

## 任务与范围

- Harness 任务：task_237b139bb0b710cf047303c6ed（父 none）
- 分支：`codex/retire-from-legacy`
- 公开范围：CLI task-create 解析、daemon repo-cell task-create 输入处理、kernel task-action 契约/CLI 声明及其镜像的生成投影，以及 preset 编译期透传；不改变已落盘任务事件 metadata 的形状（`fromLegacyId` 历史字段保留，此后恒为 null），不涉及 GUI
- 私有计划/证据已更新：是（`artifacts/report.md`）
- 范围外：本任务未改动 GUI，因此对 GUI 的 i18n key 集合造成的变化为零。作为附带调查，它跑了一次全仓静态 i18n 引用扫描（285 个 GUI production TS/TSX 文件，双语各 1563 个 key），发现 `components.json` 等文件里有 59 个既无静态字符串字面量引用、也未匹配到动态模板的候选 key（另有 30 个保守匹配到动态模板而被排除）；本任务刻意没有删除这 59 个候选 i18n 词典项，因为静态候选状态不能证明运行时不可达，且本任务范围是 CLI/daemon 输入处理而非 GUI 清理——详见风险说明。

## 版本影响

- 版本：不变
- 发布影响：不发布

## 治理声明

- 触碰受保护面：否
- 受保护面范围：不适用
- 授权：不适用
- 机器检查边界：不适用
- Break-glass：否
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- 基线 `origin/main` SHA：`554be6d94`
- 分支与 `origin/main` 的 merge-base：`554be6d94`
- 最近一次 `git fetch origin`：2026-09-12 UTC
- 同步方式：从 origin/main 开分支
- 公开 diff 命令：`git diff origin/main...codex/retire-from-legacy`
- 私有证据路径：task_237b139bb0b710cf047303c6ed 的 `artifacts/report.md`
- 评审证据路径：本 PR 的评审证据节
- GitHub Actions `rewrite-ci` run URL：本 PR 待跑
- 修前红：`task-create-input.test.ts` 修前跑 1/2 失败，命中的是旧 `legacyTaskCreateAction` 错误路径而非新的不支持字段拒绝。最终定向测试：daemon 输入测试 2、RepoCell 创建/读取/幂等/lease 集成 4、CLI parser 9、fleet 路由 1、生成投影测试 2，合计 18 全部通过。`line-density` 与 manifest gates（含 ESLint）均 exit 0。治理墙（`run-walls.mjs`）12 pass / 0 red / 4 info。隔离 Ubuntu VM 本次不可达（SSH 权限被拒），改用合同允许的本地 runner。完整 `check:local`、GitHub CI 及独立 `tsc` 构建未跑（提交钩子报告本地缺少 `tsc` 二进制），均未验证。

## 评审证据

- CEO 事实核对：读过 worker 报告与 diff 统计；核过提交人与范围。
- 评审子代理：合入后走一条路收口评审
- 人工评审：待定
- 阻塞发现：无

## 残余风险

- 风险低，纯粹删除一条冗余且校验更弱的创建路径，不替换任何已被接受的历史事件（`fromLegacyId` 历史 metadata 保留，新任务上恒为 null）。残留风险/后续事项：本任务附带跑的 i18n 静态引用扫描留下了 59 个未被引用的候选 GUI 词典 key 未删除——它们是否真的死亡未经验证（动态拼接 key、外部调用方，或运行时不可达但仍被引用的组件都可能造成假候选），且本次这项纯 CLI 改动与 GUI key 存活性之间没有建立因果联系；删除这 59 个 key 被明确留给一次独立的 GUI 范围评审，本任务未做。

## 参考

- 任务：task_237b139bb0b710cf047303c6ed

