### PR TITLE
docs: remove stale graph hint and Chinese star history

### DIFF
--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -209,7 +209,3 @@ Harness Anything 用三个长期存在的原语承载 agent 工作：
 ## License
 
 [AGPL-3.0-or-later](./LICENSE)。Harness Anything 保持开源，包括有人把它作为服务提供时。
-
-## Star 趋势
-
-[![GitHub Star 增长趋势图](https://api.star-history.com/svg?repos=FairladyZ625/harness-anything&type=Date)](https://star-history.com/#FairladyZ625/harness-anything&Date)

--- a/packages/gui/src/renderer/components/GraphFilterPanel.tsx
+++ b/packages/gui/src/renderer/components/GraphFilterPanel.tsx
@@ -296,9 +296,6 @@ export function GraphFilterPanel({
                 </button>
               );
             })}
-            <div className="mt-0.5 ui-micro leading-snug text-text-faint">
-              {t("components.graphFilterPanel.assocRelatesTurnedOffByDefaultReduce")}
-            </div>
           </div>
         </div>
 

--- a/packages/gui/src/renderer/i18n/locales/en-US/components.json
+++ b/packages/gui/src/renderer/i18n/locales/en-US/components.json
@@ -145,7 +145,6 @@
   "components.taskPreviewDrawer.notProjected": "not projected",
   "components.factInspector.contradictsValue": "contradicts {value}",
   "components.factInspector.replacedByValue": "replaced by {value}",
-  "components.graphFilterPanel.assocRelatesTurnedOffByDefaultReduce": "Assoc off by default — click to enable.",
   "components.graphFilterPanel.collapseFilterPanel": "Collapse filter panel",
   "components.graphFilterPanel.decisionState": "Decision state",
   "components.graphFilterPanel.density": "Density",

--- a/packages/gui/src/renderer/i18n/locales/zh-CN/components.json
+++ b/packages/gui/src/renderer/i18n/locales/zh-CN/components.json
@@ -145,7 +145,6 @@
   "components.taskPreviewDrawer.notProjected": "未投影",
   "components.factInspector.contradictsValue": "矛盾于 {value}",
   "components.factInspector.replacedByValue": "已被 {value} 取代",
-  "components.graphFilterPanel.assocRelatesTurnedOffByDefaultReduce": "默认关 assoc(relates),减少噪音;点开切换。",
   "components.graphFilterPanel.collapseFilterPanel": "收起筛选面板",
   "components.graphFilterPanel.decisionState": "Decision 状态",
   "components.graphFilterPanel.density": "信息密度",


### PR DESCRIPTION
# English

## Summary

The `assoc` (relates) axis in the relation-graph filter panel already defaults to on (the sole default is declared once, in `relationVisual.ts`, and consumed by `GraphView.tsx`/`EgoNeighborhood.tsx`) — but the panel still rendered a stale hint claiming it was "off by default" in both locales, and the Chinese README still carried a GitHub star-history trend image that the English README had already dropped. Both were leftover copy from a superseded state, not a behavior change: this task deletes the stale hint node and its two locale strings, and deletes the stray Star-history section from `README.zh-CN.md`.

## Architectural Justification

-

## What Changed

- `packages/gui/src/renderer/components/GraphFilterPanel.tsx`: removed the `<div>` rendering `t("components.graphFilterPanel.assocRelatesTurnedOffByDefaultReduce")` under the assoc/relates axis toggles.
- `packages/gui/src/renderer/i18n/locales/en-US/components.json` and `.../zh-CN/components.json`: removed the now-unreferenced `components.graphFilterPanel.assocRelatesTurnedOffByDefaultReduce` key from both locale files (kept in parity — same key removed from each).
- `README.zh-CN.md`: removed the trailing `## Star 趋势` section and its `star-history.com` badge/link, matching the already-trend-image-free English `README.md`.
- No test files were added or modified; existing `i18n-locale-parity.vitest.ts` and `graph-view.vitest.ts` were re-run as verification, not changed.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: +0/-9 production (GUI copy +0/-5, README +0/-4); no test file changes.

## Machine-Readable Declarations

- None.

## Task And Scope

- Harness task: task_259285bf6e5472341857ae95c3 (parent none)
- Branch: `codex/assoc-axis-default`
- Public scope: GUI relation-graph filter panel copy and its two i18n locale files, plus one README section; no default-value, behavior, or write-path change of any kind
- Private planning/evidence updated: yes (`artifacts/report.md`)
- Out of scope: No GUI screenshot/Electron-window visual verification, no live shared-daemon or CI run; only source-level rg scans, a before/after staleness assertion script, and targeted vitest runs are claimed as evidence.

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: not applicable
- Machine-check boundary: not applicable
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `554be6d94`
- Branch merge-base with `origin/main`: `554be6d94`
- Last `git fetch origin` time: 2026-09-12 UTC
- Sync method: branched from origin/main
- Public diff command: `git diff origin/main...codex/assoc-axis-default`
- Private evidence commit/path: task_259285bf6e5472341857ae95c3 `artifacts/report.md`
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [x] `npm run typecheck` (worker, `tsc -b`)
- [ ] `npm run check`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts` (via `run-manifest-gates --changed origin/main`)
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Before/after `rg` scans for `star-history`, `assocRelatesTurnedOffByDefaultReduce`, and the old hint text across `README.md`, `README.zh-CN.md`, and `packages/gui/src/renderer`: all four matches present before, zero after. A dedicated before/after Node assertion script (embedded in the report) confirmed all four target files were stale before and clean after. Ubuntu isolated: `i18n-locale-parity.vitest.ts` 4/4 and `graph-view.vitest.ts` 4/4 (8 tests total). ESLint, line-density, and manifest gates all exit 0. Governance walls 12 pass / 0 red / 4 info.

## Review Evidence

- CEO ground-truth: read the worker report and the diff stat; commit authorship and scope checked.
- Reviewer subagent: closeout review after merge (one-path closeout)
- Human review: pending
- Blocking findings: none open

## Residual Risk

- Very low risk, pure copy/asset deletion with no source-of-truth default touched (`relationVisual.ts`'s default declaration and its two consumers were read but not modified) and no new link, file, or persisted content added; README's License section and remaining links are untouched.

## References

- Task: task_259285bf6e5472341857ae95c3

---

# 中文

## 概要

关系图筛选面板里的 `assoc`（relates）轴默认值早已是开启（唯一的默认值声明在 `relationVisual.ts` 一处，由 `GraphView.tsx`/`EgoNeighborhood.tsx` 消费）——但面板里两种语言仍渲染着一条声称“默认关闭”的过期提示，中文 README 也还留着英文版早已删掉的 GitHub star 趋势图。两处都只是遗留自已被覆盖状态的文案，不是行为变更：本任务删除该过期提示节点及其两条 locale 字符串，并删除 `README.zh-CN.md` 里多余的 Star 趋势区块。

## 架构辩护

-

## 改动内容

- `packages/gui/src/renderer/components/GraphFilterPanel.tsx`：删除 assoc/relates 轴开关下方渲染 `t("components.graphFilterPanel.assocRelatesTurnedOffByDefaultReduce")` 的 `<div>`。
- `packages/gui/src/renderer/i18n/locales/en-US/components.json` 与 `.../zh-CN/components.json`：从两个 locale 文件中都删除已无引用的 `components.graphFilterPanel.assocRelatesTurnedOffByDefaultReduce` key（双语同步删除，保持一致）。
- `README.zh-CN.md`：删除结尾的 `## Star 趋势` 区块及其 star-history.com 徽章/链接，与已经没有趋势图的英文 `README.md` 对齐。
- 未新增或修改任何测试文件；既有 `i18n-locale-parity.vitest.ts` 与 `graph-view.vitest.ts` 只是被重跑作为验证，未被改动。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 删除的门或 fixture：none
- 生产净行数：+0/-9 production (GUI copy +0/-5, README +0/-4); no test file changes。

## 机器可读声明

- 无。

## 任务与范围

- Harness 任务：task_259285bf6e5472341857ae95c3（父 none）
- 分支：`codex/assoc-axis-default`
- 公开范围：仅涉及 GUI 关系图筛选面板文案及其两个 i18n locale 文件，以及一处 README 区块；不涉及任何默认值、行为或写路径变更
- 私有计划/证据已更新：是（`artifacts/report.md`）
- 范围外：本次未做 GUI 截图/Electron 窗口视觉验证，未跑真实共享 daemon 或 CI；只以源码级 rg 扫描、一份修前/修后过期性断言脚本与定向 vitest 作为证据。

## 版本影响

- 版本：不变
- 发布影响：不发布

## 治理声明

- 触碰受保护面：否
- 受保护面范围：不适用
- 授权：不适用
- 机器检查边界：不适用
- Break-glass：否
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- 基线 `origin/main` SHA：`554be6d94`
- 分支与 `origin/main` 的 merge-base：`554be6d94`
- 最近一次 `git fetch origin`：2026-09-12 UTC
- 同步方式：从 origin/main 开分支
- 公开 diff 命令：`git diff origin/main...codex/assoc-axis-default`
- 私有证据路径：task_259285bf6e5472341857ae95c3 的 `artifacts/report.md`
- 评审证据路径：本 PR 的评审证据节
- GitHub Actions `rewrite-ci` run URL：本 PR 待跑
- 对 `README.md`、`README.zh-CN.md`、`packages/gui/src/renderer` 中 `star-history`、`assocRelatesTurnedOffByDefaultReduce` 及旧提示文本的修前/修后 `rg` 扫描：修前四处全部命中，修后零命中。报告内嵌的一份修前/修后 Node 断言脚本确认四个目标文件修前均过期、修后均干净。Ubuntu 隔离：`i18n-locale-parity.vitest.ts` 4/4、`graph-view.vitest.ts` 4/4（合计 8 项）。ESLint、line-density、manifest gates 均 exit 0。治理墙 12 pass / 0 red / 4 info。

## 评审证据

- CEO 事实核对：读过 worker 报告与 diff 统计；核过提交人与范围。
- 评审子代理：合入后走一条路收口评审
- 人工评审：待定
- 阻塞发现：无

## 残余风险

- 风险极低，纯文案/资源删除，未触碰任何权威默认值（`relationVisual.ts` 的默认值声明及其两个消费点只读未改），未新增任何链接、文件或持久化内容；README 的 License 小节及其余链接保持原样。

## 参考

- 任务：task_259285bf6e5472341857ae95c3

