### PR TITLE
fix: accept explanatory suffixes in task plan headings

### DIFF
--- a/packages/kernel/src/domain/transition-document-readiness.ts
+++ b/packages/kernel/src/domain/transition-document-readiness.ts
@@ -195,7 +195,7 @@ export function submissionFromCloseout(
 }
 
 function missingMarkdownSections(body: string, contract: MarkdownDocumentContract): TransitionDocumentMissingSection[] {
-  const sections = markdownSections(body),
+  const sections = markdownSections(body, contract === taskPlan ? contract.requiredSections : []),
     untouchedScaffold = contract.requiredSections.every((heading) => {
       const content = sections.get(normalizeHeading(heading));
       return (
@@ -248,8 +248,9 @@ function meaningfulMarkdown(body: string): boolean {
 }
 
 /** Shared section reader: fenced examples are content, and repeated sections retain every occurrence. */
-export function markdownSections(body: string): ReadonlyMap<string, string> {
+export function markdownSections(body: string, headingPrefixes: readonly string[] = []): ReadonlyMap<string, string> {
   const sections = new Map<string, string>();
+  const prefixes = headingPrefixes.map(normalizeHeading);
   let heading: string | null = null;
   let content: string[] = [];
   let fence: { marker: string; length: number } | null = null;
@@ -277,6 +278,11 @@ export function markdownSections(body: string): ReadonlyMap<string, string> {
     if (match) {
       retain();
       heading = normalizeHeading(match[1]!);
+      const authoredHeading = heading;
+      heading =
+        prefixes.find(
+          (prefix) => authoredHeading.startsWith(prefix) && /^[ \t]*[(—–-]/u.test(authoredHeading.slice(prefix.length)),
+        ) ?? heading;
       content = [];
     } else content.push(line);
   }

--- a/packages/kernel/test/transition-document-readiness.test.ts
+++ b/packages/kernel/test/transition-document-readiness.test.ts
@@ -104,6 +104,59 @@ test("task plan rejects pure scaffolds but accepts a retained scaffold sentence 
   assert.equal(assessTransitionDocument("task.plan", realizedPlan()).ready, true);
 });
 
+test("task plan accepts explanatory suffixes on every required heading", () => {
+  for (const suffix of [" (context)", "（说明）", " - details", " – details", "—说明"]) {
+    const body = planHeadings.map((heading) => `## ${heading}${suffix}\n\nImplemented ${heading}.`).join("\n\n");
+    assert.deepEqual(assessTransitionDocument("task.plan", body).missingSections, [], suffix);
+  }
+});
+
+test("task plan suffixes preserve empty and scaffold detection", () => {
+  for (const suffix of [" (context)", "（说明）", " — details"]) {
+    const body = realizedPlan().replace("## Required Reading", `## Required Reading${suffix}`);
+    assert.deepEqual(
+      assessTransitionDocument("task.plan", body.replace("Implemented Required Reading.", "")).missingSections,
+      [{ section: "Required Reading", reason: "empty" }],
+    );
+    const scaffold = "List concrete code, document, and contract paths in reading order";
+    assert.deepEqual(
+      assessTransitionDocument("task.plan", body.replace("Implemented Required Reading.", scaffold)).missingSections,
+      [{ section: "Required Reading", reason: "scaffold", retainedScaffold: scaffold.slice(0, 60) }],
+    );
+  }
+  const template = readFileSync(
+    new URL("../../preset/assets/software-coding/templates/task.plan/en-US.md", import.meta.url),
+    "utf8",
+  ).replace(/^(## .+)$/gmu, "$1 (details)");
+  assert.deepEqual(
+    assessTransitionDocument("task.plan", template).missingSections.map(({ section, reason }) => ({ section, reason })),
+    planHeadings.map((section) => ({ section, reason: "scaffold" })),
+  );
+});
+
+test("task plan suffix matching respects heading boundaries and fenced examples", () => {
+  for (const heading of ["Required ReadingList", "Required Reading Optional", "Required Reading: optional"]) {
+    assert.deepEqual(
+      assessTransitionDocument("task.plan", realizedPlan().replace("## Required Reading", `## ${heading}`))
+        .missingSections,
+      [{ section: "Required Reading", reason: "empty" }],
+    );
+  }
+  const body = realizedPlan().replace("## Required Reading\n\nImplemented Required Reading.", "");
+  assert.deepEqual(
+    assessTransitionDocument("task.plan", body + "\n```md\n## Required Reading (example)\nRead file.\n```")
+      .missingSections,
+    [{ section: "Required Reading", reason: "empty" }],
+  );
+  assert.equal(
+    assessTransitionDocument(
+      "task.plan",
+      body + "\n## Required Reading (first)\nRead file.\n## Required Reading—second\n",
+    ).ready,
+    true,
+  );
+});
+
 test("closeout uses the same required-section and scaffold rules", () => {
   const template = readFileSync(
     new URL("../../preset/assets/software-coding/templates/task.closeout/zh-CN.md", import.meta.url),


### PR DESCRIPTION
# English

## Summary

`task.plan`'s required-section readiness check matched headings by exact normalized text, so an author writing `## Required Reading (context)` or `## Required Reading — details` instead of the bare canonical `## Required Reading` had that heading's content silently dropped into no section, and the checker reported it as `missing: empty` even though the section was fully written. The fix teaches the shared `markdownSections` reader an optional list of canonical heading prefixes: for `task.plan` only, a parsed heading that starts with one of the 14 required-section names followed by a parenthetical or dash-introduced suffix (ASCII/full-width parens, hyphen, en dash, or em dash) is folded onto the canonical heading key before section content is collected; anything else (a run-on word, a colon suffix, a fenced-code example heading) is left unmatched, so empty/scaffold detection and `closeout`'s existing exact-match contract are both unchanged.

## Architectural Justification

-

## What Changed

- `packages/kernel/src/domain/transition-document-readiness.ts`: `markdownSections` gained an optional `headingPrefixes: readonly string[]` parameter (default `[]`); when a heading matches one of those normalized prefixes followed by `/^[ \t]*[(—–-]/`, it is remapped to the prefix before being stored, so the section keyed under the canonical heading receives that content. `missingMarkdownSections` now passes `contract.requiredSections` as the prefix list only when `contract === taskPlan`; `closeout` and any other contract get `[]`, preserving today's exact-match behavior for them.
- `packages/kernel/test/transition-document-readiness.test.ts`: three new tests cover (1) all 14 required headings accepting five suffix styles (ASCII/full-width parens, hyphen, en dash, em dash) with content correctly attributed; (2) suffixed headings still triggering `empty` and `scaffold` detection identically to unsuffixed ones, including against the real `task.plan` template with every heading suffixed; (3) negative boundary cases — a run-on word (`Required ReadingList`), a bare-word suffix without a parenthetical/dash separator, and a colon suffix are all rejected as non-matches (still reported `empty`), a fenced-code-block heading is not treated as a real section, and two differently-suffixed occurrences of the same canonical heading still merge as repeats.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: +8/-2 production; tests +53/-0.

## Machine-Readable Declarations

- None.

## Task And Scope

- Harness task: task_82ebb9a77f8cb14abce70e8344 (parent none)
- Branch: `codex/placeholder-heading-suffix`
- Public scope: kernel `task.plan` readiness checker only (`transition-document-readiness.ts`'s shared section reader); `task.closeout`'s heading-matching contract is unchanged and covered by its own existing exact-match test
- Private planning/evidence updated: yes (`artifacts/report.md`)
- Out of scope: Independent CLI build/typecheck via the commit hook did not run (local `tsc` binary missing under `node_modules/.bin`); a separate direct `npx tsc -p packages/kernel/tsconfig.json --noEmit` was run instead and passed. Full CI, Windows, a live daemon restart, and an end-to-end `runtime.run` exercise of this check were not performed and are unverified.

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: yes — `packages/kernel/src/domain/transition-document-readiness.ts` (the `task.plan` required-section placeholder/readiness checker)
- Protected surface scope: headings may now carry a parenthetical or dash-introduced explanatory suffix after the canonical name; empty-section detection, scaffold/placeholder-text detection, and `task.closeout`'s separate exact-match heading contract are all unchanged and covered by regression tests
- Authority: CEO ruling 2026-09-12 recorded in task_82ebb9a77f8cb14abce70e8344 task_plan (Round 2), approved by repository owner; principle "the framework must not create friction for agents" (AGENTS.md)
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `554be6d94`
- Branch merge-base with `origin/main`: `554be6d94`
- Last `git fetch origin` time: 2026-09-12 UTC
- Sync method: branched from origin/main
- Public diff command: `git diff origin/main...codex/placeholder-heading-suffix`
- Private evidence commit/path: task_82ebb9a77f8cb14abce70e8344 `artifacts/report.md`
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [x] `npm run typecheck` (worker, `tsc -b`)
- [ ] `npm run check`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts` (via `run-manifest-gates --changed origin/main`)
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Red before fix: targeted isolated run on the pre-fix HEAD, 9/12 passing, 3 failing (every suffixed-heading case treated as missing/empty). Green after fix: same file, 12/12 passing under the Ubuntu hermetic isolated runner. `npx tsc -p packages/kernel/tsconfig.json --noEmit` clean. `run-manifest-gates.mjs --changed origin/main` (2 changed paths, 7 commands, including ESLint) and `line-density` gate both exit 0. `git diff --check origin/main` and `git status --short` both clean.

## Review Evidence

- CEO ground-truth: read the worker report and the diff stat; commit authorship and scope checked.
- Reviewer subagent: closeout review after merge (one-path closeout)
- Human review: pending
- Blocking findings: none open

## Residual Risk

- This changes gate semantics of a governance-relevant checker (which task-plan sections count as filled), so it is called out explicitly below rather than folded into an ordinary low-risk note; see Governance Declaration.

## References

- Task: task_82ebb9a77f8cb14abce70e8344

---

# 中文

## 概要

`task.plan` 的必填标题就绪检测此前按规范化后的精确文本匹配标题，因此作者若写成 `## Required Reading (context)` 或 `## Required Reading — details` 而不是纯粹的规范标题 `## Required Reading`，该标题下的内容会被静默归入“无节”，检查器则报 `missing: empty`，即便该节内容其实写得完整。修复给共享的 `markdownSections` reader 增加一个可选的规范标题前缀列表：仅对 `task.plan`，若解析到的标题以 14 个必填节名称之一开头、后接括号或破折号引出的说明后缀（半角/全角括号、连字符、en dash、em dash），就在收集节内容前把它归并到规范标题键上；其余情况（连写单词、冒号后缀、fenced 代码示例标题）一律不匹配，因此空节/scaffold 检测以及 `closeout` 既有的精确匹配契约都不受影响。

## 架构辩护

-

## 改动内容

- `packages/kernel/src/domain/transition-document-readiness.ts`：`markdownSections` 新增可选参数 `headingPrefixes: readonly string[]`（默认 `[]`）；当某个标题匹配其中一个规范化前缀、且后接 `/^[ \t]*[(—–-]/`，就在存入前把它归并到该前缀，使规范标题下的节收到这段内容。`missingMarkdownSections` 现在只在 `contract === taskPlan` 时把 `contract.requiredSections` 作为前缀列表传入；`closeout` 及其他契约都传 `[]`，保持它们原有的精确匹配行为不变。
- `packages/kernel/test/transition-document-readiness.test.ts`：新增三项测试，覆盖 (1) 全部 14 个必填标题接受五种后缀写法（半角/全角括号、连字符、en dash、em dash）且内容归属正确；(2) 带后缀的标题依旧能触发 `empty` 与 `scaffold` 检测，与不带后缀时完全一致，包括对真实 `task.plan` 模板全部标题加后缀后的整体断言；(3) 边界负例——连写单词（`Required ReadingList`）、无括号/破折号分隔的裸词后缀、冒号后缀均不匹配（仍报 `empty`），fenced 代码块内的标题不被当作真实节，同一规范标题的两个不同后缀写法仍按重复节合并。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 删除的门或 fixture：none
- 生产净行数：+8/-2 production; tests +53/-0。

## 机器可读声明

- 无。

## 任务与范围

- Harness 任务：task_82ebb9a77f8cb14abce70e8344（父 none）
- 分支：`codex/placeholder-heading-suffix`
- 公开范围：仅涉及 kernel 的 `task.plan` 就绪检查器（`transition-document-readiness.ts` 的共享节读取器）；`task.closeout` 的标题匹配契约未变，由其既有的精确匹配测试覆盖
- 私有计划/证据已更新：是（`artifacts/report.md`）
- 范围外：提交钩子自带的独立 CLI 构建/typecheck 本次未跑（`node_modules/.bin` 下本地缺少 `tsc` 二进制）；改为单独直接跑 `npx tsc -p packages/kernel/tsconfig.json --noEmit` 并通过。完整 CI、Windows、真实 daemon 重启及对该检查的端到端 `runtime.run` 演练均未执行，未经验证。

## 版本影响

- 版本：不变
- 发布影响：不发布

## 治理声明

- 触碰受保护面：是——`packages/kernel/src/domain/transition-document-readiness.ts`（`task.plan` 必填节占位符/就绪检查器）
- 受保护面范围：标题现在可以在规范名称后携带括号或破折号引出的说明后缀；空节检测、scaffold/占位文本检测，以及 `task.closeout` 另一套精确匹配标题契约均未改变，均有回归测试覆盖
- 授权：CEO 于 2026-09-12 在 task_82ebb9a77f8cb14abce70e8344 的 task_plan（Round 2）中记录的裁决，已由仓库所有者批准；依据原则“框架不得给 agent 造成不必要的摩擦”（AGENTS.md）
- 机器检查边界：本 PR 只断言该声明存在；是否属实、是否充分由评审者判断
- Break-glass：否
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- 基线 `origin/main` SHA：`554be6d94`
- 分支与 `origin/main` 的 merge-base：`554be6d94`
- 最近一次 `git fetch origin`：2026-09-12 UTC
- 同步方式：从 origin/main 开分支
- 公开 diff 命令：`git diff origin/main...codex/placeholder-heading-suffix`
- 私有证据路径：task_82ebb9a77f8cb14abce70e8344 的 `artifacts/report.md`
- 评审证据路径：本 PR 的评审证据节
- GitHub Actions `rewrite-ci` run URL：本 PR 待跑
- 修前红：在修前 HEAD 上的定向隔离测试，12 项中 9 通过 3 失败（所有带后缀标题的用例都被判定为缺失/空）。修后绿：同一文件在 Ubuntu hermetic 隔离 runner 下 12/12 全部通过。`npx tsc -p packages/kernel/tsconfig.json --noEmit` 无输出。`run-manifest-gates.mjs --changed origin/main`（2 个改动路径、7 项命令，含 ESLint）与 `line-density` 门均 exit 0。`git diff --check origin/main` 与 `git status --short` 均干净。

## 评审证据

- CEO 事实核对：读过 worker 报告与 diff 统计；核过提交人与范围。
- 评审子代理：合入后走一条路收口评审
- 人工评审：待定
- 阻塞发现：无

## 残余风险

- 本次改动改变了一个治理相关检查器的门语义（哪些 task-plan 节算作已填写），因此在此单独点名说明，而不是折叠进普通低风险备注；详见治理声明。

## 参考

- 任务：task_82ebb9a77f8cb14abce70e8344

