### PR TITLE
fix: require G1 cost evidence for write-path pull requests

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -108,6 +108,23 @@ Dependency-Change: none
 - [ ] GitHub Actions `rewrite-ci` passed
 - Not run: [command and reason]
 
+## Per-Write Cost
+
+<!-- Required for changes to write/persist/projection/ledger paths under packages/**/src.
+Run the G1 probe on the base and head with the same environment. Repeat these five rows
+for each measured operation; replace placeholders with actual non-negative integer counts.
+The lint checks table completeness, not measurement truth or performance budgets.
+G1 command: node tools/gates/cost-budget.mjs (compare its 200/2000 measured counts).
+-->
+
+| Operation   | Metric        | Before (200) | Before (2000) | After (200) | After (2000) |
+| ----------- | ------------- | ------------ | ------------- | ----------- | ------------ |
+| <operation> | sqlRowsRead   |              |               |             |              |
+| <operation> | sha256Calls   |              |               |             |              |
+| <operation> | sha256Bytes   |              |               |             |              |
+| <operation> | gitProcesses  |              |               |             |              |
+| <operation> | fileReadBytes |              |               |             |              |
+
 ## Review Evidence
 
 - Self-review:
@@ -206,6 +223,12 @@ Dependency-Change: none
 - [ ] `npm run harness:smoke-cli-package`
 - [ ] GitHub Actions `rewrite-ci` passed
 - 未运行：[命令和原因]
+
+## 单次写入成本
+
+<!-- 涉及 packages/**/src 内 write/persist/projection/ledger 路径时，在英文 Per-Write Cost 节填写 G1 表。
+同一环境分别运行 base/head 的 node tools/gates/cost-budget.mjs；每个实测操作填写五项指标在 200/2000 规模的前后计数。
+lint 只验证表格完整性，测量真实性仍需审查，性能预算仍由 G1 门判定。 -->
 
 ## 审查证据
 

--- a/tools/check-pr-body-bilingual.mjs
+++ b/tools/check-pr-body-bilingual.mjs
@@ -3,6 +3,7 @@ import { readFileSync } from "node:fs";
 import process from "node:process";
 import { agentProtocolCommands } from "../packages/daemon/src/protocol/daemon-protocol-commands-agent.ts";
 import { clientLocalCommands } from "../packages/cli/src/cli/thin-command-help.ts";
+import { G1_MARGINS, G1_SCALES } from "./gates/cost-budget.mjs";
 import { computeProductionDelta } from "./gates/production-delta.mjs";
 import { changedFiles, repoRoot } from "./gates/git.mjs";
 
@@ -224,11 +225,72 @@ export function checkArchitectureJustification({
   return { ok: issues.length === 0, required, known: true, added, deleted, churn, net, issues };
 }
 
+export function checkPerWriteCost(body, files = []) {
+  const required = files.some((file) =>
+    /^packages\/(?:[^/]+\/)+src\/.*(?:write|persist|projection|ledger)/u.test(file),
+  );
+  if (!required) return { ok: true, required, issues: [] };
+  const visible = body.replace(/<!--[\s\S]*?-->/gu, "").replace(/^\s*(`{3,}|~{3,}).*\n[\s\S]*?^\s*\1\s*$/gmu, ""),
+    section = sectionContent(visible, /^## Per-Write Cost\s*$/mu) ?? "",
+    rows = section
+      .split(/\r?\n/u)
+      .filter((line) => /^\s*\|.*\|\s*$/u.test(line))
+      .map((line) =>
+        line
+          .trim()
+          .slice(1, -1)
+          .split("|")
+          .map((cell) => cell.trim()),
+      ),
+    headers = [
+      "Operation",
+      "Metric",
+      ...["Before", "After"].flatMap((phase) =>
+        [G1_SCALES.small, G1_SCALES.large].map((scale) => `${phase} (${scale})`),
+      ),
+    ],
+    metrics = Object.keys(G1_MARGINS),
+    operations = new Map();
+  const validRows =
+    rows.length >= metrics.length + 2 &&
+    rows[0].join("|") === headers.join("|") &&
+    rows[1].length === headers.length &&
+    rows[1].every((cell) => /^:?-{3,}:?$/u.test(cell)) &&
+    rows.slice(2).every(([operation, metric, ...counts]) => {
+      if (
+        !/^[a-z]+(?:-[a-z]+)+$/u.test(operation ?? "") ||
+        !metrics.includes(metric) ||
+        counts.length !== 4 ||
+        !counts.every((count) => /^\d+$/u.test(count) && Number.isSafeInteger(Number(count)))
+      )
+        return false;
+      const seen = operations.get(operation) ?? new Set();
+      if (seen.has(metric)) return false;
+      seen.add(metric);
+      operations.set(operation, seen);
+      return true;
+    });
+  const ok = validRows && [...operations.values()].every((seen) => seen.size === metrics.length);
+  return {
+    ok,
+    required,
+    issues: ok
+      ? []
+      : [
+          "Write-path changes require `## Per-Write Cost` with a G1 count table: " +
+            headers.join(" | ") +
+            ". Include all five G1 metrics per operation and non-negative integer counts; see the PR template.",
+          "写路径变更必须填写 Per-Write Cost 节：每个操作包含 G1 五项指标，以及 200/2000 规模的修改前后整数计数。",
+        ],
+  };
+}
+
 export function checkPrBodyBilingual(body, thresholds = defaultThresholds, context = {}) {
   const blocks = splitPrBodyLanguageBlocks(body);
   const englishCounts = countBilingualSignals(blocks.englishBlock);
   const chineseCounts = countBilingualSignals(blocks.chineseBlock);
-  const issues = [...blocks.issues];
+  const perWriteCost = checkPerWriteCost(blocks.englishBlock, context.files);
+  const issues = [...blocks.issues, ...perWriteCost.issues];
   const gateHarvest = checkGateHarvestDeclarations(blocks.englishBlock);
   issues.push(...gateHarvest.issues);
   const eventMigration = checkEventMigrationDeclaration(blocks.englishBlock, context.eventMigration);
@@ -268,6 +330,7 @@ export function checkPrBodyBilingual(body, thresholds = defaultThresholds, conte
       chineseIndex: blocks.chineseIndex,
     },
     gateHarvest,
+    perWriteCost,
     eventMigration,
     architectureJustification,
     issues,
@@ -292,6 +355,7 @@ function readBodyFromArgs(argv) {
           "",
           "Requires a top-level `# English` block before a top-level `# 中文` block.",
           "The English block must contain at least 20 Latin words; the Chinese block must contain at least 20 CJK characters.",
+          "Write/persist/projection/ledger paths under packages/**/src require a completed Per-Write Cost G1 table (see the PR template).",
           "When Deleted-Production-Paths names a path, Deleted-Gates-Fixtures is required.",
           "When the computed production delta exceeds 200 churn lines or +300 net production lines, both language blocks must contain a completed architectural justification section.",
           "When an accepted canonical-event sample changes, Event-Migration must name an existing ha migrate command or explain why no migration is required.",
@@ -317,7 +381,7 @@ if (import.meta.url === `file://${process.argv[1]}`) {
       head = process.env.PR_HEAD_SHA,
       files = base && head ? changedFiles(repoRoot(), base, head) : [],
       productionDelta = base && head ? computeProductionDelta({ rootDir: repoRoot(), base }) : undefined,
-      result = checkPrBodyBilingual(body, defaultThresholds, { eventMigration: { files }, productionDelta });
+      result = checkPrBodyBilingual(body, defaultThresholds, { files, eventMigration: { files }, productionDelta });
     if (result.ok) {
       process.stdout.write(
         [

--- a/tools/check-pr-body-bilingual.test.mjs
+++ b/tools/check-pr-body-bilingual.test.mjs
@@ -1,6 +1,12 @@
 // harness-test-tier: contract
 import assert from "node:assert/strict";
 import test from "node:test";
+import { execFileSync, spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { removeTemporaryDirectory } from "./temporary-directory-cleanup.mjs";
 import {
   architectureJustificationThresholds,
   checkArchitectureJustification,
@@ -306,4 +312,80 @@ test("signal counter counts CJK characters and Latin words independently", () =>
     cjkChars: 4,
     latinWords: 3,
   });
+});
+
+const g1Table = [
+  "## Per-Write Cost",
+  "| Operation | Metric | Before (200) | Before (2000) | After (200) | After (2000) |",
+  "| --- | --- | --- | --- | --- | --- |",
+  ...["sqlRowsRead", "sha256Calls", "sha256Bytes", "gitProcesses", "fileReadBytes"].map(
+    (metric) => `| task-create | ${metric} | 0 | 0 | 0 | 0 |`,
+  ),
+].join("\n");
+
+function checkWriteBody(evidence = "", files = ["packages/kernel/src/store/write-journal-coordinator.ts"]) {
+  return checkPrBodyBilingual(twoBlockBody({ english: `${validEnglish}\n${evidence}` }), undefined, { files });
+}
+
+test("write path changes require a complete G1 before/after count table", () => {
+  for (const file of [
+    "packages/kernel/src/store/write-journal-coordinator.ts",
+    "packages/kernel/src/store/persist.ts",
+    "packages/kernel/src/projection/task.ts",
+    "packages/adapters/local/src/ledger.ts",
+  ]) {
+    assert.equal(checkWriteBody("", [file]).ok, false, file);
+    assert.equal(checkWriteBody(g1Table, [file]).ok, true, file);
+  }
+  assert.equal(checkWriteBody("", ["docs-release/write.md", "packages/kernel/test/ledger.test.ts"]).ok, true);
+});
+
+test("G1 evidence rejects headings, placeholders, partial metrics, and hidden tables", () => {
+  for (const table of [
+    "## Per-Write Cost\nG1: passed",
+    g1Table.replace("| 0 |", "| TBD |"),
+    g1Table.replace("| 0 |", "| -1 |"),
+    g1Table.replace("| 0 |", "| 1.5 |"),
+    g1Table.replace(/^.*fileReadBytes.*$/mu, ""),
+    g1Table.replace("Before (2000)", "Before"),
+    `<!--\n${g1Table}\n-->`,
+    `\`\`\`markdown\n${g1Table}\n\`\`\``,
+    g1Table.replace("## Per-Write Cost", "## Verification"),
+    g1Table.replace("| task-create | fileReadBytes", "| doc-submit | fileReadBytes"),
+  ])
+    assert.equal(checkWriteBody(table).ok, false, table);
+});
+
+test("PR lint CLI derives write changes from PR base/head and rejects missing evidence", (t) => {
+  const root = mkdtempSync(path.join(tmpdir(), "pr-write-cost-"));
+  t.after(() => removeTemporaryDirectory(root));
+  const git = (...args) => execFileSync("git", args, { cwd: root, encoding: "utf8" }).trim();
+  git("init", "-q");
+  git("config", "user.name", "Fixture");
+  git("config", "user.email", "fixture@example.invalid");
+  git("commit", "--allow-empty", "-qm", "base");
+  const base = git("rev-parse", "HEAD");
+  mkdirSync(path.join(root, "packages/kernel/src"), { recursive: true });
+  writeFileSync(path.join(root, "packages/kernel/src/write.ts"), "export const count = 1;\n");
+  git("add", ".");
+  git("commit", "-qm", "write path");
+  const head = git("rev-parse", "HEAD");
+  for (const evidence of ["", g1Table]) {
+    const result = spawnSync(
+      process.execPath,
+      [fileURLToPath(new URL("./check-pr-body-bilingual.mjs", import.meta.url)), "--env", "PR_BODY"],
+      {
+        cwd: root,
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          PR_BASE_SHA: base,
+          PR_HEAD_SHA: head,
+          PR_BODY: twoBlockBody({ english: `${validEnglish}\n${evidence}` }),
+        },
+      },
+    );
+    assert.equal(result.status, evidence ? 0 : 1, result.stderr);
+    if (!evidence) assert.match(result.stderr, /Write-path changes require/u);
+  }
 });


### PR DESCRIPTION
# English

## Summary

The PR-body bilingual lint (`tools/check-pr-body-bilingual.mjs`) already knew how to check for an Event-Migration section, but had no requirement tied to write-path changes even though `tools/gates/cost-budget.mjs` already defines G1 per-write cost scales and margins. So a PR that changed a `packages/**/src` write/persist/projection/ledger path could merge without ever reporting its per-write cost impact. This tightens the lint: when the changed paths (matched by keyword against `write`, `persist`, `projection`, or `ledger` under `packages/**/src`) include such a path, the PR body must contain an English `## Per-Write Cost` table where every reported operation has all five G1 metrics with non-negative integer before/after counts at 200 and 2000 events; missing, partial, commented-out, or fenced-code tables are all rejected. The `.github/pull_request_template.md` was updated to carry this table format so authors see the required shape before they hit the failure. This is a filename/keyword heuristic reusing the existing G1_MARGINS/G1_SCALES constants (no new metric or scale authority), not semantic call-graph analysis — a write implementation that doesn't match those keywords is outside this rule's reach.

## Architectural Justification

-

## What Changed

- `tools/check-pr-body-bilingual.mjs` (+66/-2): adds the write-path path-matcher and the five-metric table-shape validator (implementation at line ~228), composes it into the existing lint entry point (~292), and wires it to the real Git diff paths already computed by the CLI (~384). Reuses existing `G1_MARGINS`/`G1_SCALES` constants rather than introducing a second source of truth for the metrics.
- `tools/check-pr-body-bilingual.test.mjs` (+82/-0, new negative/positive fixtures at lines ~330, ~343, ~359): covers missing table, heading-only (no rows), and complete-table acceptance/rejection, plus real-CLI-argument coverage.
- `.github/pull_request_template.md` (+23/-0): adds the `## Per-Write Cost` table skeleton and format guidance so contributors see the required shape before the gate rejects a bare PR body.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: +89/-2 production; tests +82/-0.

## Machine-Readable Declarations

- None.

## Task And Scope

- Harness task: task_559a818b48478f255b3c720a0c (parent task_2b8f79fa4412cb726a26f9bfc7)
- Branch: `codex/per-write-cost-lint`
- Public scope: `tools/check-pr-body-bilingual.mjs` (an existing required PR-body lint, wired into `.github/workflows/pr-body.yml` and the `pr-body-lint` manifest job/branch-protection context per the worker's declaration check) and its passive delivery vehicle `.github/pull_request_template.md`. No new script, gate-manifest entry, workflow, runtime writer, queue, or claim-fence change; this is a read-only lint over PR body text and diff paths, so it introduces no additional writer or competing artifact owner.
- Private planning/evidence updated: yes (`artifacts/report.md`)
- Out of scope: The table only checks presence, shape, and non-negative-integer counts — it does not check measurement truth, does not verify every affected write operation is represented, and does not check operation names against the actual probe catalog (G1 cost-budget remains the sole measurement/budget authority). Full `check:local`, live GitHub CI, and actual G1 runtime measurements are unverified/not run — this task changed no product write path. Full typecheck via the commit hook did not run (`node_modules/.bin/tsc` missing locally; no CLI source/asset changes triggered a build, so the skip is by design not a failure).

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: yes — `tools/check-pr-body-bilingual.mjs` (required `pr-body-lint`, wired into `.github/workflows/pr-body.yml` and branch protection) and `.github/pull_request_template.md`
- Protected surface scope: a PR whose changed paths under `packages/**/src` match write/persist/projection/ledger keywords must now carry an English `## Per-Write Cost` table with all five G1 metrics and non-negative integer before/after counts at 200/2000 events for every reported operation; missing/partial/commented/fenced tables are rejected; this is presence/shape enforcement only, not a new measurement authority (G1_MARGINS/G1_SCALES are reused unchanged)
- Authority: CEO ruling 2026-09-12 recorded in task_559a818b48478f255b3c720a0c task_plan (Round 2), approved by repository owner
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `554be6d94`
- Branch merge-base with `origin/main`: `554be6d94`
- Last `git fetch origin` time: 2026-09-12 UTC
- Sync method: branched from origin/main
- Public diff command: `git diff origin/main...codex/per-write-cost-lint`
- Private evidence commit/path: task_559a818b48478f255b3c720a0c `artifacts/report.md`
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [x] `npm run typecheck` (worker, `tsc -b`)
- [ ] `npm run check`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts` (via `run-manifest-gates --changed origin/main`)
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Red before fix: `node tools/dispatch-isolated-test.mjs --file tools/check-pr-body-bilingual.test.mjs` exit 1, 20/22 pass — missing-table and heading-only-evidence cases both incorrectly returned true (accepted) instead of false. Green after fix: same command on isolated Ubuntu, 23/23 pass, no skips; real Git base/head CLI invocation rejects an absent table and accepts a complete one. `npx eslint` on both changed files exit 0. `node tools/gates/line-density.mjs --base origin/main` exit 0 (G36 pass). `node tools/run-manifest-gates.mjs --changed origin/main` exit 0 (3 changed paths, lint + test-tier-manifest across 585 files). `git diff --check origin/main` exit 0. Canonical `node harness/governance/walls/run-walls.mjs` exit 0 (pass=12 red=0). The lint was also run against this PR's own evidence draft (`PR_BASE_SHA=... PR_HEAD_SHA=... node tools/check-pr-body-bilingual.mjs --file <evidence.md>`) exit 0 — that draft explicitly states its own Per-Write Cost section is not applicable since it changed no matched write path.

## Review Evidence

- CEO ground-truth: read the worker report and the diff stat; commit authorship and scope checked.
- Reviewer subagent: closeout review after merge (one-path closeout)
- Human review: pending
- Blocking findings: none open

## Residual Risk

- The report's own `computeProductionDelta` helper reports "+66/-2 production (tooling), no unclassified paths" — deliberately excluding `.github/pull_request_template.md`'s +23/-0 from "production" because the repo's `isProductionPath`/`classifyModule` policy in `tools/gates/module-policy.mjs` explicitly excludes `.github/**` from the production surface. That is a narrower definition than this review's own production-path list (which counts `.github` as production), so the two accounting methods disagree by 23 lines on a change that is itself governance process. The matcher is a keyword heuristic against literal path segments (`write`, `persist`, `projection`, `ledger`); a real write-path change that happens not to use one of those words in its path is invisible to this new requirement and will not be asked for a cost table at all.

## References

- Task: task_559a818b48478f255b3c720a0c

---

# 中文

## 概要

PR 正文双语 lint（`tools/check-pr-body-bilingual.mjs`）此前已经会检查 Event-Migration 节，但没有与写路径改动挂钩的要求——尽管 `tools/gates/cost-budget.mjs` 早已定义了 G1 每写成本的量级与容差。于是一个改动了 `packages/**/src` 写/持久化/投影/ledger 路径的 PR，完全可以在从不报告其每写成本影响的情况下合入。本次收紧该 lint：当改动路径（按 `write`、`persist`、`projection`、`ledger` 关键词匹配 `packages/**/src` 下路径）命中时，PR 正文必须包含一份英文 `## Per-Write Cost` 表，每个报告的操作都要有全部五项 G1 指标，且在 200、2000 事件规模下的前后计数为非负整数；缺失、部分、被注释掉或写在代码块里的表格一律拒绝。`.github/pull_request_template.md` 同步更新，带上该表格格式，让作者在触发失败前就看到要求的形状。这是复用既有 `G1_MARGINS`/`G1_SCALES` 常量的文件名/关键词启发式匹配（不是语义调用图分析），不匹配这些关键词的真实写实现不在此规则覆盖范围内。

## 架构辩护

-

## 改动内容

- `tools/check-pr-body-bilingual.mjs`（+66/-2）：新增写路径匹配器与五指标表格形状校验器（实现约在 228 行），接入既有 lint 入口（约 292 行），并接上 CLI 已计算好的真实 Git diff 路径（约 384 行）。复用既有 `G1_MARGINS`/`G1_SCALES` 常量，未新建第二套指标权威。
- `tools/check-pr-body-bilingual.test.mjs`（+82/-0，新增正负例约在 330、343、359 行）：覆盖缺表、只有标题无行、完整表格的接受/拒绝，以及真实 CLI 参数覆盖。
- `.github/pull_request_template.md`（+23/-0）：新增 `## Per-Write Cost` 表格骨架与格式说明，让贡献者在被门拒绝前先看到要求的形状。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 删除的门或 fixture：none
- 生产净行数：+89/-2 production; tests +82/-0。

## 机器可读声明

- 无。

## 任务与范围

- Harness 任务：task_559a818b48478f255b3c720a0c（父 task_2b8f79fa4412cb726a26f9bfc7）
- 分支：`codex/per-write-cost-lint`
- 公开范围：`tools/check-pr-body-bilingual.mjs`（既有必需 PR 正文 lint，按 worker 的声明检查接入 `.github/workflows/pr-body.yml` 及 `pr-body-lint` manifest job/分支保护 context）及其被动交付载体 `.github/pull_request_template.md`。未新增脚本、gate-manifest 条目、workflow、运行时写者、队列或 claim-fence；这是对 PR 正文文本和 diff 路径的只读 lint，不引入新的写者或竞争 artifact owner。
- 私有计划/证据已更新：是（`artifacts/report.md`）
- 范围外：该表格只检查是否存在、形状是否正确、计数是否为非负整数——不检查测量真实性，不验证每个受影响的写操作是否都已出现，也不核对操作名称与真实探针目录（G1 cost-budget 仍是唯一的测量/预算权威）。完整 `check:local`、真实 GitHub CI 与实际 G1 运行时测量均 unverified/未跑——本任务未改动任何产品写路径。提交钩子里的完整 typecheck 未运行（本地缺 `node_modules/.bin/tsc`；因无 CLI 源码/资源改动而按设计跳过构建，不是失败）。

## 版本影响

- 版本：不变
- 发布影响：不发布

## 治理声明

- 触碰受保护面：是——`tools/check-pr-body-bilingual.mjs`（必需的 `pr-body-lint`，接入 `.github/workflows/pr-body.yml` 及分支保护）与 `.github/pull_request_template.md`
- 受保护面范围：改动路径命中 `packages/**/src` 下 write/persist/projection/ledger 关键词的 PR，现在必须携带一份英文 `## Per-Write Cost` 表，每个报告的操作都要有全部五项 G1 指标、且在 200/2000 事件规模下前后计数为非负整数；缺失/部分/注释/代码块中的表格一律拒绝；这只是存在性/形状层面的强制，不是新的测量权威（`G1_MARGINS`/`G1_SCALES` 原样复用）
- 授权：CEO 于 2026-09-12 在 task_559a818b48478f255b3c720a0c 的 task_plan（Round 2）中记录的裁决，已由仓库所有者批准
- 机器检查边界：本 PR 只断言该声明存在；是否属实、是否充分由评审者判断
- Break-glass：否
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- 基线 `origin/main` SHA：`554be6d94`
- 分支与 `origin/main` 的 merge-base：`554be6d94`
- 最近一次 `git fetch origin`：2026-09-12 UTC
- 同步方式：从 origin/main 开分支
- 公开 diff 命令：`git diff origin/main...codex/per-write-cost-lint`
- 私有证据路径：task_559a818b48478f255b3c720a0c 的 `artifacts/report.md`
- 评审证据路径：本 PR 的评审证据节
- GitHub Actions `rewrite-ci` run URL：本 PR 待跑
- 修前红：`node tools/dispatch-isolated-test.mjs --file tools/check-pr-body-bilingual.test.mjs` 退出 1，22 项中 20 通过——缺表和只有标题无证据两个用例都被误判为 true（通过）而非预期的 false。修后绿：同命令在隔离 Ubuntu 上 23/23 全通过，无跳过；真实 Git base/head CLI 调用能拒绝缺表、接受完整表格。对两个改动文件 `npx eslint` 退出 0。`node tools/gates/line-density.mjs --base origin/main` 退出 0（G36 通过）。`node tools/run-manifest-gates.mjs --changed origin/main` 退出 0（3 个改动路径，lint + test-tier-manifest，覆盖 585 个文件）。`git diff --check origin/main` 退出 0。Canonical `node harness/governance/walls/run-walls.mjs` 退出 0（pass=12 red=0）。该 lint 还被用于核验本 PR 自己的证据草稿（`PR_BASE_SHA=... PR_HEAD_SHA=... node tools/check-pr-body-bilingual.mjs --file <evidence.md>`）退出 0——该草稿明确写出自己未命中匹配写路径，故 Per-Write Cost 节为不适用。

## 评审证据

- CEO 事实核对：读过 worker 报告与 diff 统计；核过提交人与范围。
- 评审子代理：合入后走一条路收口评审
- 人工评审：待定
- 阻塞发现：无

## 残余风险

- 报告自带的 `computeProductionDelta` 工具报的是"+66/-2 production（tooling），无未分类路径"——刻意把 `.github/pull_request_template.md` 的 +23/-0 排除在"production"之外，因为仓库 `tools/gates/module-policy.mjs` 里的 `isProductionPath`/`classifyModule` 策略明确把 `.github/**` 排除在生产面之外。这比本次审阅任务给定的生产路径定义（把 `.github` 算作 production）更窄，两种核算方法在一次本身就是治理流程改动的 PR 上相差 23 行。匹配器是对字面路径片段（`write`、`persist`、`projection`、`ledger`）的关键词启发式；一个真实的写路径改动只要路径里恰好没用到这些词，就对这条新规则不可见，完全不会被要求提供成本表。

## 参考

- 任务：task_559a818b48478f255b3c720a0c

