### PR TITLE
test: verify CLI retirement of runtime artifacts

### DIFF
--- a/packages/daemon/test/runtime-spawn-ingress.integration.test.ts
+++ b/packages/daemon/test/runtime-spawn-ingress.integration.test.ts
@@ -1,7 +1,7 @@
 // harness-test-tier: integration
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -1177,7 +1177,7 @@ test("daemon ingress preserves executor-scoped task-bound runtime spawn", async 
     );
     await t.test(
       "the task-bound runtime keeps writes scoped and submits only its own execution after projection reopen",
-      async () => {
+      async (runtimeTest) => {
         const taskId = "task-runtime-artifact",
           executionId = "exec-runtime-artifact",
           otherTaskId = "task-runtime-artifact-other",
@@ -1253,6 +1253,68 @@ test("daemon ingress preserves executor-scoped task-bound runtime spawn", async 
         const synced = await host.run(repoId, { kind: "doc-submit", paths: [syncedPath], executor: worker }, auth);
         assert.equal(synced.outcome, "applied", JSON.stringify(synced));
         assert.match(String(synced.summary), new RegExp(`applied:[\\s\\S]*${syncedPath}`, "u"));
+
+        await runtimeTest.test(
+          "doc retire removes a runtime-produced artifact through the repository writer",
+          async () => {
+            const reason = "runtime evidence superseded",
+              action = { kind: "doc-retire", path: syncedPath, reason } as const,
+              waitForPublication = (opId: string) =>
+                host.run(
+                  repoId,
+                  {
+                    kind: "receipt-show",
+                    opId,
+                    waitFor: ["git_verified", "worktree_visible"],
+                    timeoutMs: 5000,
+                  },
+                  auth,
+                );
+            const submitted = await waitForPublication(synced.opId);
+            assert.equal(submitted.wait?.state, "satisfied", JSON.stringify(submitted));
+            assert.equal(readFileSync(syncedTarget, "utf8"), "# Runtime doc sync artifact\n");
+            const denied = await host.run(repoId, { ...action, executor: worker }, auth);
+            assert.equal(denied.outcome, "op_rejected", JSON.stringify(denied));
+            assert.equal(denied.code, "lease_conflict", JSON.stringify(denied));
+            assert.equal(readFileSync(syncedTarget, "utf8"), "# Runtime doc sync artifact\n");
+            const cliRetirement = await spawnCli(
+              ["--root", workerRoot, "--json", "doc", "retire", "--path", syncedPath, "--reason", reason],
+              {
+                ...process.env,
+                HARNESS_DAEMON_USER_ROOT: userRoot,
+                HARNESS_DAEMON_ID: "runtime-spawn-ingress",
+                HARNESS_DAEMON_ENDPOINT: endpoint,
+                HARNESS_ACTOR: undefined,
+                HARNESS_DAEMON_RELAY: undefined,
+              },
+            );
+            assert.equal(cliRetirement.status, 0, JSON.stringify(cliRetirement));
+            const retired = JSON.parse(cliRetirement.stdout) as { outcome: string; opId: string };
+            assert.equal(retired.outcome, "applied", JSON.stringify(retired));
+            const settled = await waitForPublication(retired.opId);
+            assert.equal(settled.wait?.state, "satisfied", JSON.stringify(settled));
+            const event = makeTaskEventReader({ repoId, rootDir: root }).readEvent(retired.opId);
+            assert.equal(event?.schema, "doc-event/v1");
+            if (event?.schema === "doc-event/v1") {
+              assert.equal(event.payload.retirementReason, reason);
+              assert.equal(event.payload.changes.length, 1);
+              assert.equal(event.payload.changes[0]?.path, syncedPath);
+              assert.equal(event.payload.changes[0]?.candidate, null);
+            }
+            assert.equal(
+              (await host.run(repoId, { kind: "doc-show", path: syncedPath }, auth)).code,
+              "document_not_found",
+            );
+            assert.equal(existsSync(syncedTarget), false, "the writer must remove the file without manual unlink");
+            assert.equal(
+              execFileSync("git", ["ls-tree", "--name-only", "HEAD", `harness/${syncedPath}`], {
+                cwd: root,
+                encoding: "utf8",
+              }).trim(),
+              "",
+            );
+          },
+        );
 
         const crossTask = await host.run(
           repoId,


### PR DESCRIPTION
# English

## Summary

The task's premise ("artifact deletion has no write road") turned out to be false at the fetched base. Round 2 verified, with a real CLI subprocess, that a repository operator can retire a runtime-produced task artifact through the existing `ha doc retire` write path: the audit event records reason/single-target/candidate:null, the projection query afterward returns `document_not_found`, the file is gone from disk, and Git HEAD no longer contains it. What is actually blocked is narrower than the title claimed: a runtime actor cannot retire its own artifact (self-retirement is rejected), and a Git-only document with no canonical descriptor cannot be retired at all (`document_not_found` on the retire call itself, verified against one real sample: `entities/architecture-decision-records/ADR-0028c961d58d3332.json`). No code changed — this PR adds one integration regression test proving the existing write road behaves this way, plus a read-only inventory of Git-vs-projection drift (68 unclaimed legacy candidates identified but none deleted).

## Architectural Justification

-

## What Changed

- `packages/daemon/test/runtime-spawn-ingress.integration.test.ts` (+64/-2): extends the existing runtime-artifact-submission test to (a) assert self-retirement by the runtime actor is rejected, then (b) actually retire the same artifact via a real CLI subprocess run as a repository operator with a dedicated isolated socket (exit 0), and assert the audit event shape, `document_not_found` on projection re-query, absence from disk, and absence from Git HEAD — a positive control (repo-writer retirement succeeds) paired with the existing negative control (runtime self-retirement fails) on the same artifact. No production file was touched; no new write path, permission, or claim-fence relaxation was introduced.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: +0/-0 production; tests +64/-2.

## Machine-Readable Declarations

- None.

## Task And Scope

- Harness task: task_3b58c4540ede0890bdc24909a3 (parent task_3b29776ee22b600c88a895ad97)
- Branch: `codex/artifact-deletion-road`
- Public scope: Test-only, one existing integration test file. No `packages/*/src`, `tools/`, `scripts/`, `.github`, `docs-release`, or `harness/context` production path changed. This does not fix, extend, or narrow the existing retirement permission boundary — it only adds regression coverage for the boundary as it already exists.
- Private planning/evidence updated: yes (`artifacts/report.md`)
- Out of scope: Only one of the 68 Git-only legacy candidate documents was verified end-to-end via real CLI (`ADR-0028c961d58d3332.json`, confirmed `document_not_found`/canonical-does-not-exist on the retire attempt, file still present in Git HEAD, nothing deleted); the other 67 are unverified beyond the read-only Git-vs-projection diff — whether they are still externally referenced, or originated from old WAL contamination, is explicitly called unverified. Fleet/multi-node concurrent retirement, retiring an artifact through the shared default daemon (as opposed to an isolated Ubuntu test daemon), and Windows/macOS parity are all unverified. Full typecheck via the commit hook did not run (`node_modules/.bin/tsc` missing locally).

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: not applicable
- Machine-check boundary: not applicable
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `554be6d94`
- Branch merge-base with `origin/main`: `554be6d94`
- Last `git fetch origin` time: 2026-09-12 UTC
- Sync method: branched from origin/main
- Public diff command: `git diff origin/main...codex/artifact-deletion-road`
- Private evidence commit/path: task_3b58c4540ede0890bdc24909a3 `artifacts/report.md`
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [x] `npm run typecheck` (worker, `tsc -b`)
- [ ] `npm run check`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts` (via `run-manifest-gates --changed origin/main`)
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- `node tools/dispatch-isolated-test.mjs --file packages/daemon/test/runtime-spawn-ingress.integration.test.ts` on isolated Ubuntu: 19/19 pass, 0 fail, 0 skipped. A second isolated run of `packages/daemon/test/doc-sync-slice-a.test.ts` (verifying unrelated task-package files stay untracked during the same commit flush): 12/12 pass. `npx eslint` on the changed test file exit 0. `node tools/gates/line-density.mjs --base origin/main` exit 0 (G36 pass). `node tools/run-manifest-gates.mjs --changed origin/main` exit 0 (1 changed path, lint + test-tier-manifest across 585 files). `git diff --check` exit 0; `git status --short` empty. Canonical `node harness/governance/walls/run-walls.mjs` exit 0 (pass=12 red=0). The worker's report is explicit this is not a red/green production fix — the underlying behavior already existed; what's new is the regression evidence and the positive/negative control pairing.

## Review Evidence

- CEO ground-truth: read the worker report and the diff stat; commit authorship and scope checked.
- Reviewer subagent: closeout review after merge (one-path closeout)
- Human review: pending
- Blocking findings: none open

## Residual Risk

- The task title implies a bug ("has no write road"); the actual finding is closer to "the write road exists and is correctly scoped, do not widen it." The worker explicitly recommends the CEO keep the current audit/permission boundary as-is and separately review the value of the 68 unclaimed candidates rather than removing `deletion_forbidden` or importing-then-retiring as a workaround to clean up Git-only debt. The main risk is scope creep in the other direction: someone reading only the task title might expect a fix landed here, when in fact zero production lines changed and the only actionable finding (68 orphaned Git-only entities) is explicitly left to a future, separately-authorized cleanup — not touched, not deleted, not even fully enumerated with per-file CLI verification.

## References

- Task: task_3b58c4540ede0890bdc24909a3

---

# 中文

## 概要

任务的前提（"artifact deletion has no write road"，制品删除没有写路）在本次核验的基线上并不成立。Round 2 用真实 CLI 子进程核实：仓库操作者可以经由既有的 `ha doc retire` 写路退休一个 runtime 产出的任务制品——审计事件记录了 reason、单一目标、candidate:null，随后投影查询返回 `document_not_found`，磁盘上文件消失，Git HEAD 也不再包含它。真正被拒绝的范围比标题暗示的更窄：runtime actor 不能退休自己产出的制品（自退被拒），而一份没有 canonical descriptor 的纯 Git 历史文档完全无法被退休（对退休调用本身就返回 `document_not_found`，已用一个真实样本核实：`entities/architecture-decision-records/ADR-0028c961d58d3332.json`）。本次没有改动任何代码——只新增了一个集成回归测试证明既有写路的这一行为，外加一份只读的 Git-投影漂移盘点（发现 68 个无人认领的历史候选，均未删除）。

## 架构辩护

-

## 改动内容

- `packages/daemon/test/runtime-spawn-ingress.integration.test.ts`（+64/-2）：在既有的 runtime 制品提交测试基础上扩展，(a) 断言 runtime actor 自退被拒，然后 (b) 用真实 CLI 子进程、以仓库操作者身份、专属隔离 socket 实际退休同一制品（退出 0），并断言审计事件形状、投影重新查询返回 `document_not_found`、磁盘上不存在、Git HEAD 中不存在——在同一制品上做出阳性对照（repo-writer 退休成功）与既有阴性对照（runtime 自退失败）的配对。未改动任何生产文件；未引入新写路、权限或 claim-fence 放宽。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 删除的门或 fixture：none
- 生产净行数：+0/-0 production; tests +64/-2。

## 机器可读声明

- 无。

## 任务与范围

- Harness 任务：task_3b58c4540ede0890bdc24909a3（父 task_3b29776ee22b600c88a895ad97）
- 分支：`codex/artifact-deletion-road`
- 公开范围：仅测试，一个既有集成测试文件。未改动任何 `packages/*/src`、`tools/`、`scripts/`、`.github`、`docs-release` 或 `harness/context` 生产路径。这不是对既有退休权限边界的修复、扩展或收窄——只是为该边界现状新增回归覆盖。
- 私有计划/证据已更新：是（`artifacts/report.md`）
- 范围外：68 个纯 Git 历史候选文档中，只有一个经真实 CLI 端到端核实（`ADR-0028c961d58d3332.json`，确认退休尝试返回 `document_not_found`/canonical 不存在，文件仍在 Git HEAD 中，未删除任何东西）；其余 67 个只做了只读的 Git-投影差集比对，未逐一核实——它们是否仍被外部引用、是否源自旧 WAL 污染，均明确标为 unverified。舰队/多节点并发退休、在共享 default daemon（而非隔离的 Ubuntu 测试 daemon）上退休制品，以及 Windows/macOS 一致性，均 unverified。提交钩子里的完整 typecheck 未运行（本地缺 `node_modules/.bin/tsc`）。

## 版本影响

- 版本：不变
- 发布影响：不发布

## 治理声明

- 触碰受保护面：否
- 受保护面范围：不适用
- 授权：不适用
- 机器检查边界：不适用
- Break-glass：否
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- 基线 `origin/main` SHA：`554be6d94`
- 分支与 `origin/main` 的 merge-base：`554be6d94`
- 最近一次 `git fetch origin`：2026-09-12 UTC
- 同步方式：从 origin/main 开分支
- 公开 diff 命令：`git diff origin/main...codex/artifact-deletion-road`
- 私有证据路径：task_3b58c4540ede0890bdc24909a3 的 `artifacts/report.md`
- 评审证据路径：本 PR 的评审证据节
- GitHub Actions `rewrite-ci` run URL：本 PR 待跑
- `node tools/dispatch-isolated-test.mjs --file packages/daemon/test/runtime-spawn-ingress.integration.test.ts` 在隔离 Ubuntu 上：19/19 通过，0 失败，0 跳过。另在同一次提交刷新中对 `packages/daemon/test/doc-sync-slice-a.test.ts`（验证无关任务包文件保持 untracked）做了第二次隔离运行：12/12 通过。对改动的测试文件 `npx eslint` 退出 0。`node tools/gates/line-density.mjs --base origin/main` 退出 0（G36 通过）。`node tools/run-manifest-gates.mjs --changed origin/main` 退出 0（1 个改动路径，lint + test-tier-manifest，覆盖 585 个文件）。`git diff --check` 退出 0；`git status --short` 为空。Canonical `node harness/governance/walls/run-walls.mjs` 退出 0（pass=12 red=0）。worker 报告明确说明这不是一次生产修复的红绿证据——底层行为本就存在；新增的是回归证据和阳性/阴性对照的配对。

## 评审证据

- CEO 事实核对：读过 worker 报告与 diff 统计；核过提交人与范围。
- 评审子代理：合入后走一条路收口评审
- 人工评审：待定
- 阻塞发现：无

## 残余风险

- 任务标题暗示存在一个 bug（"没有写路"）；实际结论更接近"写路存在，且范围划得对，不要放宽它"。worker 明确建议 CEO 保持现有审计/权限边界不变，另行评估那 68 个无人认领候选的实际价值，而不是通过去掉 `deletion_forbidden` 或"先导入再退休"这类旁路来清理 Git-only 历史债务。主要风险在另一个方向：只看任务标题的人可能以为这里落地了一次修复，但实际上零生产行改动，唯一可行动的发现（68 个孤立的纯 Git 实体）被明确留给未来另行授权的清理工作——本轮未触碰、未删除，甚至没有逐文件用 CLI 完整核实。

## 参考

- 任务：task_3b58c4540ede0890bdc24909a3

