### PR TITLE
perf(kernel): narrow task list timestamp reads

### DIFF
--- a/packages/kernel/src/projection/rebuildable-task-projection-reads.ts
+++ b/packages/kernel/src/projection/rebuildable-task-projection-reads.ts
@@ -30,9 +30,8 @@ const UNPARAMETERIZED_LIST_SQL = [
   "COALESCE(task_generation.generation, 'v1') AS generation,",
   "task_snapshot.workspace_revision AS workspace_revision,",
   `${taskCreatedAtSql("task_snapshot.task_id")} AS created_at,`,
-  "event_index.event_json AS event_json FROM task_snapshot",
+  "task_snapshot.updated_at AS updated_at FROM task_snapshot",
   "LEFT JOIN task_package USING(task_id) LEFT JOIN task_generation USING(task_id)",
-  "JOIN event_index ON event_index.workspace_revision = task_snapshot.workspace_revision",
   "ORDER BY task_snapshot.task_id",
 ].join(" ");
 
@@ -66,7 +65,7 @@ export function listProjection(
           readonly generation: "v0" | "v1";
           readonly workspace_revision: number;
           readonly created_at: string | null;
-          readonly event_json: string;
+          readonly updated_at: string;
         }>(
           prepareQuery(db, UNPARAMETERIZED_LIST_SQL, (sql) =>
             /* @gate-identity check-bypass-write-boundary/bypass-write-012 */ db.prepare(sql),
@@ -85,7 +84,7 @@ export function listProjection(
           generation: row.generation,
           workspaceRevision: row.workspace_revision,
           createdAt: row.created_at,
-          updatedAt: (JSON.parse(row.event_json) as { readonly occurredAt: string }).occurredAt,
+          updatedAt: row.updated_at,
           snapshot: snapshots.get(row.task_id)!,
         })),
         watermark: cut.watermark,


### PR DESCRIPTION
# English

## Summary

Round 2 first disproved the mission's own premise: `taskList`'s dominant cost is the wide read hydrating 10,000 task snapshots plus dependency/relation/status/decision projections, not the F11 relation-write BFS cycle checker the fix-plan named (F11 is a write-path checker, never called during this read). Round 3 then implemented a narrow, low-risk fix found during that investigation: `rebuildable-task-projection-reads.ts`'s unparameterized task-list query already had the authoritative `task_snapshot.updated_at` scalar available, but was joining the full `event_index` table and `JSON.parse`-ing every event row solely to extract `occurredAt`. The fix selects `task_snapshot.updated_at` directly and drops the join and per-row parse, with row count, ordering, cut semantics, and response shape all unchanged (proven by identical output digest before/after).

## Architectural Justification

-

## What Changed

- `packages/kernel/src/projection/rebuildable-task-projection-reads.ts` (lines ~28-35, ~62-88): removes the full `event_index` JOIN and per-row `JSON.parse(event_json)` used only to read `occurredAt`; reads the existing `task_snapshot.updated_at` scalar instead and threads it through without re-decoding. Net +3/-4 (4 production lines deleted, 3 added, net -1). No new files, no test changes in this final slice (existing byte-for-byte digest equivalence coverage already exercises the changed path).

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: +3/-4 production; tests +0/-0.

## Machine-Readable Declarations

- None.

## Task And Scope

- Harness task: task_21a2c02de7d6b5e35954cff57f (parent task_6eba9c5d3a55735920aa4856f3)
- Branch: `codex/perf-g8`
- Public scope: `packages/kernel/src/projection` (kernel read-side projection only) — architecture route component.daemon → component.kernel, ARCH-013/ARCH-014. Read-only narrowing; the worker's report states it adds no writer, fleet claimant, shared artifact, cache, fallback, or compatibility path, and does not touch the BFS write path (F11) or any protected/currently-owned surface.
- Private planning/evidence updated: yes (`artifacts/report.md`)
- Out of scope: Linux/Windows production-daemon-socket latency and full `check:local`/integration-tier/CI/GUI-rendering impact are unverified — correctness was verified on isolated Ubuntu with a worker-local synthetic fixture, not the shared default daemon. The remaining wide-list costs identified during profiling (snapshot hydration for the other stages, dependency closure, decision/relation reads, per-row validation, and result assembly — measured at roughly 85ms, 63ms, 11ms, 83ms and 147ms respectively out of a ~660ms taskList) are unchanged and explicitly out of scope for this slice. A repository-wide search for the same "decode a full payload for one already-projected scalar" pattern found no other qualifying site to fix.

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: not applicable
- Machine-check boundary: not applicable
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `554be6d94`
- Branch merge-base with `origin/main`: `554be6d94`
- Last `git fetch origin` time: 2026-09-12 UTC
- Sync method: branched from origin/main
- Public diff command: `git diff origin/main...codex/perf-g8`
- Private evidence commit/path: task_21a2c02de7d6b5e35954cff57f `artifacts/report.md`
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [x] `npm run typecheck` (worker, `tsc -b`)
- [ ] `npm run check`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts` (via `run-manifest-gates --changed origin/main`)
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- `node tools/dispatch-isolated-test.mjs --file packages/kernel/test/store/task-query-projection.test.ts` on isolated Ubuntu: 10/10 pass. `npx eslint` on the changed file exit 0. `node tools/gates/line-density.mjs --base origin/main` exit 0 (G36 pass). `node tools/run-manifest-gates.mjs --changed origin/main` exit 0 (6 selected commands: lint, CLI structure, import boundaries, kernel dead exports, duplicate definitions, implementation contracts). `PR_BODY="Production-Delta: +3/-4" node tools/gates/production-delta.mjs --base origin/main` exit 0 (G33 pass). `git diff --check` exit 0. Performance: paired before/after runs of the same worker-local B5 recipe (`tools/scale/b5-real.mjs --entities 10000 --seed 20260911 --rounds 1`, 10,000 tasks/4,500 facts/4,800 decisions/30,613 events) with a method-timing wrapper toggling only this candidate — `projection.list` p50 improved 328.32ms -> 274.19ms (54.13ms, 16.5%), full instrumented `taskList` p50 658.93/718.93ms -> 659.85ms (~59ms, 8.2%; the two figures are not additive since they are overlapping inclusive stage medians). Both sides returned exactly 10,000 rows, 28,430,343 bytes, and identical task digest `47dcbe889f46a37dbaad05d54783c384fa72e6b1b9be93d992669c68693c7729`, confirming the optimization changed no output.

## Review Evidence

- CEO ground-truth: read the worker report and the diff stat; commit authorship and scope checked.
- Reviewer subagent: closeout review after merge (one-path closeout)
- Human review: pending
- Blocking findings: none open

## Residual Risk

- Low risk in isolation (a 3/-4-line scalar-column read replacing a redundant join+decode, with byte-identical output proven by digest match), but the improvement is modest relative to the fix-plan's original framing: the task was filed against an 865ms taskList figure attributed to an F11 BFS cost that Round 2 proved does not run on this path at all, and the actual measured gain here is ~54-59ms (about 8% of total taskList time) against a noisy uninstrumented wall-clock baseline the worker explicitly discounted as unreliable under host contention (694.54ms->721.17ms went the wrong direction on that unindexed metric). Anyone expecting this PR to resolve the original 865ms complaint should be told it does not — it fixes a real, verified, but comparatively small redundant-decode cost found along the way, and the actual dominant costs (snapshot/relation/decision hydration and validation) remain untouched by design pending a separate CEO-authorized scope decision.

## References

- Task: task_21a2c02de7d6b5e35954cff57f

---

# 中文

## 概要

Round 2 先证伪了任务本身的前提：`taskList` 的主要开销来自宽读——水合 10,000 个任务快照，加上依赖/关系/状态/决策投影——而不是 fix-plan 点名的 F11 relation-write BFS 环检测器（F11 是写路径检查器，在这条读路径中根本不会被调用）。Round 3 随后实现了那次调查中发现的一处窄、低风险修复：`rebuildable-task-projection-reads.ts` 的无参数任务列表查询本已有权威的 `task_snapshot.updated_at` 标量可用，却仍在联表整张 `event_index` 并对每一行事件做 `JSON.parse`，只为取出 `occurredAt`。修复改为直接读取既有的 `task_snapshot.updated_at` 标量，去掉了联表和逐行解析，行数、顺序、cut 语义和响应形状全部不变（通过前后完全一致的输出 digest 证明）。

## 架构辩护

-

## 改动内容

- `packages/kernel/src/projection/rebuildable-task-projection-reads.ts`（约 28-35、62-88 行）：删除只为读 `occurredAt` 而做的完整 `event_index` JOIN 和逐行 `JSON.parse(event_json)`；改为直接读取既有的 `task_snapshot.updated_at` 标量并原样传递，不再重新解码。净改动 +3/-4（删除 4 行生产代码，新增 3 行，净 -1）。本轮未新增文件，也未改动测试（既有的逐字节 digest 等价性覆盖已经在锻炼这条改动路径）。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 删除的门或 fixture：none
- 生产净行数：+3/-4 production; tests +0/-0。

## 机器可读声明

- 无。

## 任务与范围

- Harness 任务：task_21a2c02de7d6b5e35954cff57f（父 task_6eba9c5d3a55735920aa4856f3）
- 分支：`codex/perf-g8`
- 公开范围：仅 `packages/kernel/src/projection`（kernel 读侧投影）——架构路由 component.daemon → component.kernel，ARCH-013/ARCH-014。纯只读收窄；worker 报告说明未新增写者、舰队认领者、共享制品、缓存、兜底或兼容路径，也没有触碰 BFS 写路径（F11）或任何受保护/现有归属面。
- 私有计划/证据已更新：是（`artifacts/report.md`）
- 范围外：Linux/Windows 生产 daemon socket 延迟，以及完整 `check:local`/integration 层/CI/GUI 渲染影响均 unverified——正确性核验用的是隔离 Ubuntu 上的 worker 本地合成 fixture，不是共享 default daemon。剖析过程中发现的其余宽读开销（其他阶段的快照水合、依赖闭包、决策/关系读取、逐行校验和结果组装——在约 660ms 的 taskList 中分别测得约 85ms、63ms、11ms、83ms 和 147ms）本轮未改动，明确列为该切片范围外。对同类"为一个已投影的标量而解码完整 payload"模式的全仓搜索，未发现其他符合条件、需要修的位置。

## 版本影响

- 版本：不变
- 发布影响：不发布

## 治理声明

- 触碰受保护面：否
- 受保护面范围：不适用
- 授权：不适用
- 机器检查边界：不适用
- Break-glass：否
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- 基线 `origin/main` SHA：`554be6d94`
- 分支与 `origin/main` 的 merge-base：`554be6d94`
- 最近一次 `git fetch origin`：2026-09-12 UTC
- 同步方式：从 origin/main 开分支
- 公开 diff 命令：`git diff origin/main...codex/perf-g8`
- 私有证据路径：task_21a2c02de7d6b5e35954cff57f 的 `artifacts/report.md`
- 评审证据路径：本 PR 的评审证据节
- GitHub Actions `rewrite-ci` run URL：本 PR 待跑
- `node tools/dispatch-isolated-test.mjs --file packages/kernel/test/store/task-query-projection.test.ts` 在隔离 Ubuntu 上：10/10 通过。对改动文件 `npx eslint` 退出 0。`node tools/gates/line-density.mjs --base origin/main` 退出 0（G36 通过）。`node tools/run-manifest-gates.mjs --changed origin/main` 退出 0（选中 6 项命令：lint、CLI 结构、import 边界、kernel 死导出、重复定义、implementation contracts）。`PR_BODY="Production-Delta: +3/-4" node tools/gates/production-delta.mjs --base origin/main` 退出 0（G33 通过）。`git diff --check` 退出 0。性能：用同一套 worker 本地 B5 配方（`tools/scale/b5-real.mjs --entities 10000 --seed 20260911 --rounds 1`，10,000 任务/4,500 事实/4,800 决策/30,613 事件）做修前/修后配对运行，方法计时包装只切换本次候选改动——`projection.list` p50 从 328.32ms 改善到 274.19ms（改善 54.13ms，16.5%），完整插桩 `taskList` p50 从 718.93ms 改善到 659.85ms（约 59ms，8.2%；两个数字不可相加，因为是重叠的包含式阶段中位数）。修前修后均返回恰好 10,000 行、28,430,343 字节，且任务 digest 完全一致：`47dcbe889f46a37dbaad05d54783c384fa72e6b1b9be93d992669c68693c7729`，证明本次优化未改变任何输出。

## 评审证据

- CEO 事实核对：读过 worker 报告与 diff 统计；核过提交人与范围。
- 评审子代理：合入后走一条路收口评审
- 人工评审：待定
- 阻塞发现：无

## 残余风险

- 单看本身风险很低（一处 3/-4 行的标量列读取替换掉冗余的联表+解码，digest 一致证明输出逐字节相同），但相对 fix-plan 最初的叙事，这次改善幅度有限：任务立项时引用的是 865ms 的 taskList 数字，并把它归因于 Round 2 已证明在这条路径上根本不会运行的 F11 BFS 开销，而本次实测的真实收益约为 54-59ms（约占 taskList 总耗时的 8%），对照组还是一个 worker 明确指出在宿主机争用下不可靠的、有噪声的未插桩墙钟基线（该未插桩指标反而从 694.54ms 变差到 721.17ms）。如果有人期待这个 PR 解决最初 865ms 的投诉，应当被告知它没有解决——它修的是调查过程中发现的一处真实、已核验、但相对较小的冗余解码开销，真正占大头的开销（快照/关系/决策水合与校验）按设计保持未动，等待另一次 CEO 授权的范围裁决。

## 参考

- 任务：task_21a2c02de7d6b5e35954cff57f

